### PR TITLE
Implement issues #14-17: PROXY protocol on TLS, OCSP auto-refresh, ACME automation, upstream mTLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,15 @@ Config file notes:
 | `TARDIGRADE_HTTP3_ENABLE_0RTT` | Allow 0-RTT handling in HTTP/3 foundation logic | `false` |
 | `TARDIGRADE_HTTP3_CONNECTION_MIGRATION` | Allow QUIC connection migration updates | `false` |
 | `TARDIGRADE_HTTP3_MAX_DATAGRAM_SIZE` | Target maximum QUIC datagram size | `1350` |
-| `TARDIGRADE_PROXY_PROTOCOL` | PROXY protocol mode for plaintext listeners | `off` |
+| `TARDIGRADE_PROXY_PROTOCOL` | PROXY protocol mode (`off`, `v1`, `v2`, `auto`) — supported on both plaintext and TLS listeners | `off` |
+| `TARDIGRADE_TLS_OCSP_AUTO_REFRESH` | Automatically fetch and refresh OCSP stapling response from the certificate's AIA OCSP URL | `false` |
+| `TARDIGRADE_TLS_OCSP_REFRESH_INTERVAL_MS` | How often (ms) the background OCSP refresh runs | `3600000` |
+| `TARDIGRADE_TLS_OCSP_REFRESH_TIMEOUT_MS` | HTTP timeout (ms) for OCSP responder requests | `10000` |
+| `TARDIGRADE_TLS_ACME_DIRECTORY_URL` | ACME directory URL for automated certificate issuance (e.g. Let's Encrypt) | empty |
+| `TARDIGRADE_TLS_ACME_DOMAINS` | Comma-separated list of domains to issue/renew via ACME | empty |
+| `TARDIGRADE_TLS_ACME_EMAIL` | Contact email sent to the ACME server during account registration | empty |
+| `TARDIGRADE_TLS_ACME_ACCOUNT_KEY_PATH` | Path for the ACME account EC private key (auto-generated if absent) | `acme_account.key` |
+| `TARDIGRADE_TLS_ACME_RENEW_DAYS_BEFORE_EXPIRY` | Renew certificate this many days before it expires | `30` |
 | `TARDIGRADE_VALIDATE_CONFIG_ONLY` | Validate config and exit without serving | empty |
 
 #### Trust, Upstreams, and Proxying
@@ -208,6 +216,11 @@ Config file notes:
 | `TARDIGRADE_PROXY_CACHE_MANAGER_INTERVAL_MS` | Cache maintenance interval | `30000` |
 | `TARDIGRADE_UPSTREAM_GUNZIP_ENABLED` | Gunzip upstream gzip responses before downstream negotiation | `true` |
 | `TARDIGRADE_MIRROR_RULES` | Semicolon-separated mirror dispatch rules | empty |
+| `TARDIGRADE_UPSTREAM_TLS_VERIFY` | Verify upstream TLS certificates | `true` |
+| `TARDIGRADE_UPSTREAM_TLS_CA_BUNDLE` | Path to PEM CA bundle for upstream certificate verification | empty (system default) |
+| `TARDIGRADE_UPSTREAM_TLS_SERVER_NAME` | Override SNI/hostname for upstream TLS handshake | empty |
+| `TARDIGRADE_UPSTREAM_TLS_CLIENT_CERT` | Path to PEM client certificate for mTLS upstream connections | empty |
+| `TARDIGRADE_UPSTREAM_TLS_CLIENT_KEY` | Path to PEM private key paired with `TARDIGRADE_UPSTREAM_TLS_CLIENT_CERT` | empty |
 
 #### Authentication and Access Control
 

--- a/src/edge_config.zig
+++ b/src/edge_config.zig
@@ -118,6 +118,9 @@ pub const EdgeConfig = struct {
     tls_session_tickets_enabled: bool,
     tls_ocsp_stapling_enabled: bool,
     tls_ocsp_response_path: []const u8,
+    tls_ocsp_auto_refresh: bool,
+    tls_ocsp_refresh_interval_ms: u64,
+    tls_ocsp_refresh_timeout_ms: u32,
     tls_client_ca_path: []const u8,
     tls_client_verify: bool,
     tls_client_verify_depth: u32,
@@ -126,7 +129,29 @@ pub const EdgeConfig = struct {
     tls_dynamic_reload_interval_ms: u64,
     tls_acme_enabled: bool,
     tls_acme_cert_dir: []const u8,
+    /// ACME directory URL (e.g. Let's Encrypt production or staging).
+    tls_acme_directory_url: []const u8,
+    /// Comma-separated list of domain names to obtain/renew certificates for.
+    tls_acme_domains: [][]const u8,
+    /// Contact email for ACME account registration.
+    tls_acme_email: []const u8,
+    /// Path to the PEM-encoded ECDSA P-256 account private key (created on first run).
+    tls_acme_account_key_path: []const u8,
+    /// Days before certificate expiry at which renewal is triggered.
+    tls_acme_renew_days_before_expiry: u32,
     http2_enabled: bool,
+    /// Verify TLS certificates presented by HTTPS upstream backends (default: true).
+    upstream_tls_verify: bool,
+    /// Path to a PEM CA bundle used to verify upstream TLS certificates.
+    /// When empty, the system default CA bundle is used.
+    upstream_tls_ca_bundle: []const u8,
+    /// Override the SNI hostname sent to upstream HTTPS backends.
+    /// When empty, the hostname from the upstream URL is used.
+    upstream_tls_server_name: []const u8,
+    /// Path to the PEM client certificate for upstream mTLS connections.
+    upstream_tls_client_cert: []const u8,
+    /// Path to the PEM client private key for upstream mTLS connections.
+    upstream_tls_client_key: []const u8,
     http3_enabled: bool,
     quic_port: u16,
     http3_enable_0rtt: bool,
@@ -371,6 +396,15 @@ pub const EdgeConfig = struct {
         }
         allocator.free(self.tls_sni_certs);
         allocator.free(self.tls_ocsp_response_path);
+        allocator.free(self.tls_acme_directory_url);
+        for (self.tls_acme_domains) |d| allocator.free(d);
+        allocator.free(self.tls_acme_domains);
+        allocator.free(self.tls_acme_email);
+        allocator.free(self.tls_acme_account_key_path);
+        allocator.free(self.upstream_tls_ca_bundle);
+        allocator.free(self.upstream_tls_server_name);
+        allocator.free(self.upstream_tls_client_cert);
+        allocator.free(self.upstream_tls_client_key);
         allocator.free(self.tls_client_ca_path);
         allocator.free(self.tls_crl_path);
         allocator.free(self.tls_acme_cert_dir);
@@ -549,6 +583,9 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
     const tls_ocsp_stapling_enabled = parseBoolEnv(allocator, "TARDIGRADE_TLS_OCSP_STAPLING", false);
     const tls_ocsp_response_path = envOrDefault(allocator, "TARDIGRADE_TLS_OCSP_RESPONSE_PATH", "") catch unreachable;
     errdefer allocator.free(tls_ocsp_response_path);
+    const tls_ocsp_auto_refresh = parseBoolEnv(allocator, "TARDIGRADE_TLS_OCSP_AUTO_REFRESH", false);
+    const tls_ocsp_refresh_interval_ms = parseIntEnv(u64, allocator, "TARDIGRADE_TLS_OCSP_REFRESH_INTERVAL_MS", 3_600_000);
+    const tls_ocsp_refresh_timeout_ms = parseIntEnv(u32, allocator, "TARDIGRADE_TLS_OCSP_REFRESH_TIMEOUT_MS", 10_000);
     const tls_client_ca_path = envOrDefault(allocator, "TARDIGRADE_TLS_CLIENT_CA_PATH", "") catch unreachable;
     errdefer allocator.free(tls_client_ca_path);
     const tls_client_verify = parseBoolEnv(allocator, "TARDIGRADE_TLS_CLIENT_VERIFY", false);
@@ -560,6 +597,29 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
     const tls_acme_enabled = parseBoolEnv(allocator, "TARDIGRADE_TLS_ACME_ENABLED", false);
     const tls_acme_cert_dir = envOrDefault(allocator, "TARDIGRADE_TLS_ACME_CERT_DIR", "") catch unreachable;
     errdefer allocator.free(tls_acme_cert_dir);
+    const tls_acme_directory_url = envOrDefault(allocator, "TARDIGRADE_TLS_ACME_DIRECTORY_URL", "https://acme-v02.api.letsencrypt.org/directory") catch unreachable;
+    errdefer allocator.free(tls_acme_directory_url);
+    const tls_acme_domains_raw = envOrDefault(allocator, "TARDIGRADE_TLS_ACME_DOMAINS", "") catch unreachable;
+    defer allocator.free(tls_acme_domains_raw);
+    const tls_acme_domains = try parseCsvValues(allocator, tls_acme_domains_raw);
+    errdefer {
+        for (tls_acme_domains) |d| allocator.free(d);
+        allocator.free(tls_acme_domains);
+    }
+    const tls_acme_email = envOrDefault(allocator, "TARDIGRADE_TLS_ACME_EMAIL", "") catch unreachable;
+    errdefer allocator.free(tls_acme_email);
+    const tls_acme_account_key_path = envOrDefault(allocator, "TARDIGRADE_TLS_ACME_ACCOUNT_KEY_PATH", "") catch unreachable;
+    errdefer allocator.free(tls_acme_account_key_path);
+    const tls_acme_renew_days_before_expiry = parseIntEnv(u32, allocator, "TARDIGRADE_TLS_ACME_RENEW_DAYS_BEFORE_EXPIRY", 30);
+    const upstream_tls_verify = parseBoolEnv(allocator, "TARDIGRADE_UPSTREAM_TLS_VERIFY", true);
+    const upstream_tls_ca_bundle = envOrDefault(allocator, "TARDIGRADE_UPSTREAM_TLS_CA_BUNDLE", "") catch unreachable;
+    errdefer allocator.free(upstream_tls_ca_bundle);
+    const upstream_tls_server_name = envOrDefault(allocator, "TARDIGRADE_UPSTREAM_TLS_SERVER_NAME", "") catch unreachable;
+    errdefer allocator.free(upstream_tls_server_name);
+    const upstream_tls_client_cert = envOrDefault(allocator, "TARDIGRADE_UPSTREAM_TLS_CLIENT_CERT", "") catch unreachable;
+    errdefer allocator.free(upstream_tls_client_cert);
+    const upstream_tls_client_key = envOrDefault(allocator, "TARDIGRADE_UPSTREAM_TLS_CLIENT_KEY", "") catch unreachable;
+    errdefer allocator.free(upstream_tls_client_key);
     const http2_enabled = parseBoolEnv(allocator, "TARDIGRADE_HTTP2_ENABLED", true);
     const http3_enabled = parseBoolEnv(allocator, "TARDIGRADE_HTTP3_ENABLED", false);
     const quic_port_str = envOrDefault(allocator, "TARDIGRADE_QUIC_PORT", "443") catch unreachable;
@@ -1126,6 +1186,9 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
         .tls_session_tickets_enabled = tls_session_tickets_enabled,
         .tls_ocsp_stapling_enabled = tls_ocsp_stapling_enabled,
         .tls_ocsp_response_path = tls_ocsp_response_path,
+        .tls_ocsp_auto_refresh = tls_ocsp_auto_refresh,
+        .tls_ocsp_refresh_interval_ms = tls_ocsp_refresh_interval_ms,
+        .tls_ocsp_refresh_timeout_ms = tls_ocsp_refresh_timeout_ms,
         .tls_client_ca_path = tls_client_ca_path,
         .tls_client_verify = tls_client_verify,
         .tls_client_verify_depth = tls_client_verify_depth,
@@ -1134,7 +1197,17 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
         .tls_dynamic_reload_interval_ms = tls_dynamic_reload_interval_ms,
         .tls_acme_enabled = tls_acme_enabled,
         .tls_acme_cert_dir = tls_acme_cert_dir,
+        .tls_acme_directory_url = tls_acme_directory_url,
+        .tls_acme_domains = tls_acme_domains,
+        .tls_acme_email = tls_acme_email,
+        .tls_acme_account_key_path = tls_acme_account_key_path,
+        .tls_acme_renew_days_before_expiry = tls_acme_renew_days_before_expiry,
         .http2_enabled = http2_enabled,
+        .upstream_tls_verify = upstream_tls_verify,
+        .upstream_tls_ca_bundle = upstream_tls_ca_bundle,
+        .upstream_tls_server_name = upstream_tls_server_name,
+        .upstream_tls_client_cert = upstream_tls_client_cert,
+        .upstream_tls_client_key = upstream_tls_client_key,
         .http3_enabled = http3_enabled,
         .quic_port = quic_port,
         .http3_enable_0rtt = http3_enable_0rtt,

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -276,6 +276,8 @@ const GatewayState = struct {
     compression_config: http.compression.CompressionConfig,
     circuit_breaker: http.circuit_breaker.CircuitBreaker,
     upstream_client: std.http.Client,
+    /// ACME HTTP-01 challenge token store (null when ACME automation is disabled).
+    acme_challenge_store: ?http.acme_client.ChallengeStore,
     event_hub: http.event_hub.EventHub,
     request_buffer_pool: http.buffer_pool.BufferPool,
     relay_buffer_pool: http.buffer_pool.BufferPool,
@@ -322,6 +324,7 @@ const GatewayState = struct {
         if (self.session_store) |*ss| ss.deinit();
         if (self.access_control) |*acl| acl.deinit();
         self.upstream_client.deinit();
+        if (self.acme_challenge_store) |*store| store.deinit();
         self.event_hub.deinit();
         self.request_buffer_pool.deinit();
         self.relay_buffer_pool.deinit();
@@ -2066,6 +2069,10 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
             .timeout_ms = cfg.cb_timeout_ms,
         }),
         .upstream_client = .{ .allocator = state_allocator },
+        .acme_challenge_store = if (cfg.tls_acme_enabled and cfg.tls_acme_domains.len > 0)
+            http.acme_client.ChallengeStore.init(state_allocator)
+        else
+            null,
         .event_hub = http.event_hub.EventHub.init(state_allocator, cfg.sse_max_events_per_topic),
         .request_buffer_pool = http.buffer_pool.BufferPool.init(state_allocator, MAX_REQUEST_SIZE, cfg.connection_pool_size),
         .relay_buffer_pool = http.buffer_pool.BufferPool.init(state_allocator, STREAM_RELAY_BUFFER_SIZE, cfg.connection_pool_size),
@@ -2124,6 +2131,32 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
     }) catch {};
     defer http.access_log.deinit();
 
+    // Configure upstream HTTP client TLS (custom CA bundle and skip-verify).
+    if (cfg.upstream_tls_ca_bundle.len > 0) {
+        const ca_file = std.fs.cwd().openFile(cfg.upstream_tls_ca_bundle, .{}) catch |err| blk: {
+            state.logger.warn(null, "upstream TLS CA bundle open failed ({s}): {}", .{ cfg.upstream_tls_ca_bundle, err });
+            break :blk null;
+        };
+        if (ca_file) |f| {
+            defer f.close();
+            state.upstream_client.ca_bundle.addCertsFromFile(state_allocator, f) catch |err| {
+                state.logger.warn(null, "upstream TLS CA bundle load failed: {}", .{err});
+            };
+            // Disable auto-rescan so our bundle takes precedence.
+            state.upstream_client.next_https_rescan_certs = false;
+        }
+    }
+    if (!cfg.upstream_tls_verify) {
+        // Clear CA bundle so the Zig TLS client performs no certificate verification.
+        state.upstream_client.ca_bundle.deinit(state_allocator);
+        state.upstream_client.ca_bundle = .{};
+        state.upstream_client.next_https_rescan_certs = false;
+        state.logger.warn(null, "upstream TLS certificate verification disabled", .{});
+    }
+    if (cfg.upstream_tls_client_cert.len > 0 or cfg.upstream_tls_server_name.len > 0) {
+        state.logger.info(null, "upstream mTLS client cert and/or SNI override configured; applies to OpenSSL-backed connections", .{});
+    }
+
     const address = try std.net.Address.parseIp(cfg.listen_host, cfg.listen_port);
     var server = try std.net.Address.listen(address, .{ .reuse_address = true });
     defer server.deinit();
@@ -2161,6 +2194,9 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
             .session_tickets_enabled = cfg.tls_session_tickets_enabled,
             .ocsp_stapling_enabled = cfg.tls_ocsp_stapling_enabled,
             .ocsp_response_path = cfg.tls_ocsp_response_path,
+            .ocsp_auto_refresh_enabled = cfg.tls_ocsp_auto_refresh,
+            .ocsp_refresh_interval_ms = cfg.tls_ocsp_refresh_interval_ms,
+            .ocsp_refresh_timeout_ms = cfg.tls_ocsp_refresh_timeout_ms,
             .client_ca_path = cfg.tls_client_ca_path,
             .client_verify = cfg.tls_client_verify,
             .client_verify_depth = cfg.tls_client_verify_depth,
@@ -2169,6 +2205,13 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
             .dynamic_reload_interval_ms = cfg.tls_dynamic_reload_interval_ms,
             .acme_enabled = cfg.tls_acme_enabled,
             .acme_cert_dir = cfg.tls_acme_cert_dir,
+            .acme_auto_issue = cfg.tls_acme_enabled and cfg.tls_acme_domains.len > 0,
+            .acme_directory_url = cfg.tls_acme_directory_url,
+            .acme_domains = cfg.tls_acme_domains,
+            .acme_email = cfg.tls_acme_email,
+            .acme_account_key_path = cfg.tls_acme_account_key_path,
+            .acme_renew_days_before_expiry = cfg.tls_acme_renew_days_before_expiry,
+            .acme_challenge_store = if (state.acme_challenge_store) |*s| s else null,
             .http2_enabled = cfg.http2_enabled,
         });
     }
@@ -2273,10 +2316,7 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
         if (cfg.access_log_syslog_udp.len > 0) cfg.access_log_syslog_udp else "off",
     });
     if (cfg.proxy_protocol_mode != .off) {
-        state.logger.info(null, "Proxy protocol enabled: {s}", .{@tagName(cfg.proxy_protocol_mode)});
-        if (edge_config.hasTlsFiles(cfg)) {
-            state.logger.warn(null, "proxy protocol parsing currently applies only to plaintext listeners", .{});
-        }
+        state.logger.info(null, "Proxy protocol enabled: {s} (plaintext and TLS listeners)", .{@tagName(cfg.proxy_protocol_mode)});
     }
     if (cfg.http3_enabled) {
         state.logger.info(null, "HTTP/3 foundation enabled: quic_port={d} 0rtt={} migration={} max_datagram={d}", .{
@@ -2867,6 +2907,22 @@ fn handleAcceptedClient(raw_ctx: *anyopaque, client_fd: std.posix.fd_t) void {
     };
 
     if (ctx.tls) |tls| {
+        // Parse PROXY protocol header from the raw TCP socket before SSL_accept.
+        // The PROXY header is plaintext even on TLS connections and must be consumed
+        // before OpenSSL sees the TLS ClientHello.
+        if (cfg.proxy_protocol_mode != .off and !session.proxy_protocol_checked) {
+            peekAndConsumeProxyHeaderFromRawFd(
+                client_fd,
+                cfg.proxy_protocol_mode,
+                &session.proxy_client_ip_buf,
+                &session.proxy_client_ip_len,
+            ) catch |err| {
+                ctx.state.logger.warn(null, "proxy protocol parse failed on TLS connection: {}", .{err});
+                std.posix.close(client_fd);
+                return;
+            };
+            session.proxy_protocol_checked = true;
+        }
         var tls_conn = tls.accept(client_fd) catch |err| {
             ctx.state.logger.warn(null, "tls handshake error: {}", .{err});
             std.posix.close(client_fd);
@@ -2982,6 +3038,54 @@ fn maybeConsumeProxyProtocolPreface(conn: anytype, mode: edge_config.ProxyProtoc
             },
         }
     }
+}
+
+/// Parse and consume a PROXY protocol header from a raw TCP socket fd before the TLS handshake.
+/// Uses MSG_PEEK so that unconsumed application bytes (TLS ClientHello) remain intact in the kernel
+/// receive buffer and OpenSSL can read them normally via SSL_set_fd / SSL_accept.
+fn peekAndConsumeProxyHeaderFromRawFd(
+    fd: std.posix.fd_t,
+    mode: edge_config.ProxyProtocolMode,
+    client_ip_buf: *[64]u8,
+    client_ip_len: *usize,
+) !void {
+    if (mode == .off) return;
+    const msg_peek: u32 = 2; // MSG_PEEK — peek without consuming
+    var peek_buf: [1024]u8 = undefined;
+    var peeked: usize = 0;
+    // Retry loop to handle blocking sockets that may not have all bytes immediately.
+    // In practice the PROXY header always arrives in the first TCP segment.
+    var attempts: u32 = 0;
+    while (attempts < 20) : (attempts += 1) {
+        const n = std.posix.recv(fd, &peek_buf, msg_peek) catch return error.ConnectionClosed;
+        if (n == 0) return error.ConnectionClosed;
+        if (n > peeked) peeked = n;
+        const outcome = parseProxyHeader(peek_buf[0..peeked], mode, client_ip_buf);
+        switch (outcome) {
+            .no_header => return,
+            .invalid => return error.InvalidProxyProtocolHeader,
+            .parsed => |parsed| {
+                client_ip_len.* = parsed.client_ip_len;
+                // Consume exactly `parsed.consumed` bytes from the socket so
+                // that OpenSSL's SSL_accept sees only the TLS ClientHello.
+                var consumed_total: usize = 0;
+                var discard: [1024]u8 = undefined;
+                while (consumed_total < parsed.consumed) {
+                    const to_read = @min(parsed.consumed - consumed_total, discard.len);
+                    const nr = std.posix.recv(fd, discard[0..to_read], 0) catch return error.ConnectionClosed;
+                    if (nr == 0) return error.ConnectionClosed;
+                    consumed_total += nr;
+                }
+                return;
+            },
+            .need_more => {
+                if (peeked >= peek_buf.len) return error.ProxyProtocolHeaderTooLarge;
+                // Wait briefly for more data to arrive in the kernel buffer.
+                std.time.sleep(500_000); // 0.5 ms
+            },
+        }
+    }
+    return error.ProxyProtocolHeaderTooLarge;
 }
 
 fn parseProxyHeader(buf: []const u8, mode: edge_config.ProxyProtocolMode, client_ip_buf: *[64]u8) ProxyHeaderOutcome {
@@ -3396,6 +3500,25 @@ fn handleConnection(conn: anytype, session: *ConnectionSession, cfg: *const edge
     else
         "unknown";
     const client_ip = http.request_context.extractClientIp(&request, connection_ip);
+
+    // --- ACME HTTP-01 challenge response (/.well-known/acme-challenge/<token>) ---
+    const acme_prefix = "/.well-known/acme-challenge/";
+    if (state.acme_challenge_store != null and
+        std.mem.startsWith(u8, request.uri.path, acme_prefix))
+    {
+        const token = request.uri.path[acme_prefix.len..];
+        if (state.acme_challenge_store.?.getCopy(allocator, token)) |key_auth| {
+            defer allocator.free(key_auth);
+            var acme_response = http.Response.init(allocator, .ok);
+            defer acme_response.deinit();
+            _ = acme_response.setBody(key_auth)
+                .setHeader("Content-Type", "application/octet-stream")
+                .setConnection(keep_alive);
+            try acme_response.write(writer);
+            return;
+        }
+    }
+
     var effective_cfg_storage = cfg.*;
     const effective_cfg = resolveRequestConfig(cfg, request.headers.get("host"), &effective_cfg_storage) orelse {
         try sendApiError(allocator, writer, .not_found, "invalid_request", "Not Found", correlation_id, keep_alive, state);
@@ -3854,19 +3977,35 @@ fn handleLocationProxyPass(
     const body = request.body orelse "";
     const upstream_url = try appendProxyQueryString(allocator, resolved.url, request.uri.query);
     defer allocator.free(upstream_url);
-    var upstream_response = try executeRawHttpProxyRequest(
-        allocator,
-        &state.upstream_client,
-        upstream_url,
-        resolved.unix_socket_path,
-        request.method.toString(),
-        &request.headers,
-        body,
-        correlation_id,
-        client_ip,
-        if (edge_config.hasTlsFiles(cfg)) "https" else "http",
-        request.headers.get("host"),
-    );
+    const use_mtls_path = cfg.upstream_tls_client_cert.len > 0 and
+        std.mem.startsWith(u8, upstream_url, "https://");
+    var upstream_response = if (use_mtls_path)
+        try executeUpstreamHttpsWithMtls(
+            allocator,
+            upstream_url,
+            request.method.toString(),
+            &request.headers,
+            body,
+            correlation_id,
+            client_ip,
+            if (edge_config.hasTlsFiles(cfg)) "https" else "http",
+            request.headers.get("host"),
+            cfg,
+        )
+    else
+        try executeRawHttpProxyRequest(
+            allocator,
+            &state.upstream_client,
+            upstream_url,
+            resolved.unix_socket_path,
+            request.method.toString(),
+            &request.headers,
+            body,
+            correlation_id,
+            client_ip,
+            if (edge_config.hasTlsFiles(cfg)) "https" else "http",
+            request.headers.get("host"),
+        );
     defer upstream_response.deinit(allocator);
     state.appendTranscript(
         upstreamScopeName(proxyScopeForPath(request.uri.path)),
@@ -4014,6 +4153,119 @@ fn appendSpecialUpstreamResponseHeader(
         .name = try allocator.dupe(u8, name),
         .value = try allocator.dupe(u8, raw),
     });
+}
+
+/// Execute an HTTPS upstream proxy request using OpenSSL directly, supporting
+/// custom CA bundles, SNI overrides, and mutual TLS client certificates.
+/// Used when `TARDIGRADE_UPSTREAM_TLS_CLIENT_CERT` is set.
+fn executeUpstreamHttpsWithMtls(
+    allocator: std.mem.Allocator,
+    url: []const u8,
+    method: []const u8,
+    request_headers: *const http.Headers,
+    body: []const u8,
+    correlation_id: []const u8,
+    client_ip: []const u8,
+    forwarded_proto: []const u8,
+    incoming_host: ?[]const u8,
+    cfg: *const edge_config.EdgeConfig,
+) !RawUpstreamResponse {
+    const uri = try std.Uri.parse(url);
+    const host = if (uri.host) |h| switch (h) {
+        .raw => |r| r,
+        .percent_encoded => |pe| pe,
+    } else return error.UnsupportedHttpMethod;
+    const port: u16 = if (uri.port) |p| p else 443;
+    const tcp_stream = try std.net.tcpConnectToHost(allocator, host, port);
+    defer tcp_stream.close();
+
+    var tls_conn = try http.tls_termination.UpstreamTlsConn.connect(tcp_stream.handle, host, .{
+        .skip_verify = !cfg.upstream_tls_verify,
+        .ca_bundle_path = cfg.upstream_tls_ca_bundle,
+        .sni_override = cfg.upstream_tls_server_name,
+        .client_cert_path = cfg.upstream_tls_client_cert,
+        .client_key_path = cfg.upstream_tls_client_key,
+    });
+    defer tls_conn.deinit();
+
+    // Build and send HTTP/1.1 request.
+    const path_raw = if (uri.path.len > 0) uri.path else "/";
+    const forwarded_for = try buildForwardedFor(allocator, request_headers.get("x-forwarded-for"), client_ip);
+    defer allocator.free(forwarded_for);
+
+    var req_buf = std.ArrayList(u8).init(allocator);
+    defer req_buf.deinit();
+    const req_writer = req_buf.writer();
+    try req_writer.print("{s} {s} HTTP/1.1\r\n", .{ method, path_raw });
+    try req_writer.print("Host: {s}\r\n", .{host});
+    try req_writer.print("Connection: close\r\n", .{});
+    if (body.len > 0) try req_writer.print("Content-Length: {d}\r\n", .{body.len});
+    try req_writer.print("{s}: {s}\r\n", .{ http.correlation.HEADER_NAME, correlation_id });
+    try req_writer.print("X-Forwarded-For: {s}\r\n", .{forwarded_for});
+    try req_writer.print("X-Real-IP: {s}\r\n", .{client_ip});
+    try req_writer.print("X-Forwarded-Proto: {s}\r\n", .{forwarded_proto});
+    if (incoming_host) |h| {
+        const trimmed = std.mem.trim(u8, h, " \t\r\n");
+        if (trimmed.len > 0) try req_writer.print("X-Forwarded-Host: {s}\r\n", .{trimmed});
+    }
+    var hdr_it = request_headers.iterator();
+    while (hdr_it.next()) |entry| {
+        if (shouldSkipUpstreamRequestHeader(entry.name)) continue;
+        try req_writer.print("{s}: {s}\r\n", .{ entry.name, entry.value });
+    }
+    try req_writer.writeAll("\r\n");
+    if (body.len > 0) try req_writer.writeAll(body);
+
+    try tls_conn.writeAll(req_buf.items);
+
+    // Read the raw HTTP response.
+    var resp_raw = std.ArrayList(u8).init(allocator);
+    defer resp_raw.deinit();
+    var read_buf: [8192]u8 = undefined;
+    while (true) {
+        const n = tls_conn.read(&read_buf) catch 0;
+        if (n == 0) break;
+        try resp_raw.appendSlice(read_buf[0..n]);
+        if (resp_raw.items.len > MAX_REQUEST_SIZE) break;
+    }
+
+    // Minimal HTTP/1.1 response parsing.
+    const raw = resp_raw.items;
+    const header_end = std.mem.indexOf(u8, raw, "\r\n\r\n") orelse return error.UnsupportedHttpMethod;
+    const headers_raw = raw[0..header_end];
+    const resp_body = raw[header_end + 4 ..];
+
+    const first_line_end = std.mem.indexOfScalar(u8, headers_raw, '\n') orelse return error.UnsupportedHttpMethod;
+    const first_line = std.mem.trimRight(u8, headers_raw[0..first_line_end], "\r");
+    var line_parts = std.mem.splitScalar(u8, first_line, ' ');
+    _ = line_parts.next(); // HTTP/1.1
+    const status_str = line_parts.next() orelse "200";
+    const status_code = std.fmt.parseInt(u16, status_str, 10) catch 200;
+    const reason = line_parts.rest();
+
+    var resp_headers = std.ArrayList(UpstreamHeader).init(allocator);
+    errdefer {
+        for (resp_headers.items) |*h| h.deinit(allocator);
+        resp_headers.deinit();
+    }
+    var hdr_lines = std.mem.splitSequence(u8, headers_raw[first_line_end + 1 ..], "\r\n");
+    while (hdr_lines.next()) |line| {
+        const colon = std.mem.indexOfScalar(u8, line, ':') orelse continue;
+        const hname = std.mem.trim(u8, line[0..colon], " \t");
+        const hval = std.mem.trim(u8, line[colon + 1 ..], " \t");
+        if (shouldSkipUpstreamResponseHeader(hname)) continue;
+        try resp_headers.append(.{
+            .name = try allocator.dupe(u8, hname),
+            .value = try allocator.dupe(u8, hval),
+        });
+    }
+
+    return .{
+        .status_code = status_code,
+        .reason = try allocator.dupe(u8, reason),
+        .headers = try resp_headers.toOwnedSlice(),
+        .body = try allocator.dupe(u8, resp_body),
+    };
 }
 
 const StaticErrorPageResult = union(enum) {
@@ -5725,19 +5977,35 @@ fn handleHttp3LocationProxyPass(
     const upstream_url = try appendProxyQueryString(allocator, resolved.url, request_query);
     defer allocator.free(upstream_url);
 
-    var upstream_response = try executeRawHttpProxyRequest(
-        allocator,
-        &ctx.state.upstream_client,
-        upstream_url,
-        resolved.unix_socket_path,
-        request.method,
-        &request.headers,
-        request.body,
-        correlation_id,
-        request.headers.get("x-real-ip") orelse "unknown",
-        if (edge_config.hasTlsFiles(ctx.cfg)) "https" else "http",
-        request.headers.get(":authority") orelse request.headers.get("host"),
-    );
+    const h3_use_mtls_path = ctx.cfg.upstream_tls_client_cert.len > 0 and
+        std.mem.startsWith(u8, upstream_url, "https://");
+    var upstream_response = if (h3_use_mtls_path)
+        try executeUpstreamHttpsWithMtls(
+            allocator,
+            upstream_url,
+            request.method,
+            &request.headers,
+            request.body,
+            correlation_id,
+            request.headers.get("x-real-ip") orelse "unknown",
+            if (edge_config.hasTlsFiles(ctx.cfg)) "https" else "http",
+            request.headers.get(":authority") orelse request.headers.get("host"),
+            ctx.cfg,
+        )
+    else
+        try executeRawHttpProxyRequest(
+            allocator,
+            &ctx.state.upstream_client,
+            upstream_url,
+            resolved.unix_socket_path,
+            request.method,
+            &request.headers,
+            request.body,
+            correlation_id,
+            request.headers.get("x-real-ip") orelse "unknown",
+            if (edge_config.hasTlsFiles(ctx.cfg)) "https" else "http",
+            request.headers.get(":authority") orelse request.headers.get("host"),
+        );
     defer upstream_response.deinit(allocator);
 
     _ = response

--- a/src/http.zig
+++ b/src/http.zig
@@ -44,6 +44,7 @@ pub const event_loop = @import("http/event_loop.zig");
 pub const worker_pool = @import("http/worker_pool.zig");
 pub const buffer_pool = @import("http/buffer_pool.zig");
 pub const tls_termination = @import("http/tls_termination.zig");
+pub const acme_client = @import("http/acme_client.zig");
 pub const hpack = @import("http/hpack.zig");
 pub const http2_frame = @import("http/http2_frame.zig");
 pub const ngtcp2_binding = @import("http/ngtcp2_binding.zig");

--- a/src/http/acme_client.zig
+++ b/src/http/acme_client.zig
@@ -1,0 +1,767 @@
+/// ACME (RFC 8555) client for automated TLS certificate issuance and renewal.
+///
+/// Supports:
+/// - ECDSA P-256 account and domain keys
+/// - HTTP-01 challenge fulfillment via ChallengeStore
+/// - Certificate renewal based on expiry horizon
+/// - Integration with the TLS terminator's cert directory
+const std = @import("std");
+
+const c = @cImport({
+    @cInclude("openssl/ec.h");
+    @cInclude("openssl/ecdsa.h");
+    @cInclude("openssl/obj_mac.h");
+    @cInclude("openssl/evp.h");
+    @cInclude("openssl/pem.h");
+    @cInclude("openssl/bio.h");
+    @cInclude("openssl/x509.h");
+    @cInclude("openssl/x509v3.h");
+    @cInclude("openssl/bn.h");
+    @cInclude("openssl/sha.h");
+    @cInclude("openssl/crypto.h");
+});
+
+pub const AcmeError = error{
+    OutOfMemory,
+    KeyGenFailed,
+    KeyLoadFailed,
+    KeySaveFailed,
+    JsonParseFailed,
+    NetworkError,
+    AcmeProtocolError,
+    ChallengeFailed,
+    CsrFailed,
+    CertDownloadFailed,
+    CertSaveFailed,
+    CertNotYetDue,
+};
+
+// ---------------------------------------------------------------------------
+// Challenge token store (HTTP-01)
+// ---------------------------------------------------------------------------
+
+/// Thread-safe store for HTTP-01 ACME challenge tokens.
+/// The edge gateway reads from this store to serve
+/// /.well-known/acme-challenge/<token> responses.
+pub const ChallengeStore = struct {
+    allocator: std.mem.Allocator,
+    mutex: std.Thread.Mutex = .{},
+    tokens: std.StringHashMap([]u8),
+
+    pub fn init(allocator: std.mem.Allocator) ChallengeStore {
+        return .{
+            .allocator = allocator,
+            .tokens = std.StringHashMap([]u8).init(allocator),
+        };
+    }
+
+    pub fn deinit(self: *ChallengeStore) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        var it = self.tokens.iterator();
+        while (it.next()) |entry| {
+            self.allocator.free(entry.key_ptr.*);
+            self.allocator.free(entry.value_ptr.*);
+        }
+        self.tokens.deinit();
+    }
+
+    pub fn put(self: *ChallengeStore, token: []const u8, key_auth: []const u8) !void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const owned_token = try self.allocator.dupe(u8, token);
+        errdefer self.allocator.free(owned_token);
+        const owned_auth = try self.allocator.dupe(u8, key_auth);
+        errdefer self.allocator.free(owned_auth);
+        const gop = try self.tokens.getOrPut(owned_token);
+        if (gop.found_existing) {
+            self.allocator.free(gop.key_ptr.*);
+            self.allocator.free(gop.value_ptr.*);
+            gop.key_ptr.* = owned_token;
+        }
+        gop.value_ptr.* = owned_auth;
+    }
+
+    /// Returns an owned copy of the key authorization for the token, or null.
+    /// Caller must free the returned slice.
+    pub fn getCopy(self: *ChallengeStore, allocator: std.mem.Allocator, token: []const u8) ?[]u8 {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const val = self.tokens.get(token) orelse return null;
+        return allocator.dupe(u8, val) catch null;
+    }
+
+    pub fn remove(self: *ChallengeStore, token: []const u8) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (self.tokens.fetchRemove(token)) |entry| {
+            self.allocator.free(entry.key);
+            self.allocator.free(entry.value);
+        }
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Base64url helpers
+// ---------------------------------------------------------------------------
+
+const b64url_enc = std.base64.url_safe_no_pad.Encoder;
+const b64url_dec = std.base64.url_safe_no_pad.Decoder;
+
+fn b64urlEncode(allocator: std.mem.Allocator, data: []const u8) ![]u8 {
+    const out = try allocator.alloc(u8, b64url_enc.calcSize(data.len));
+    return b64url_enc.encode(out, data);
+}
+
+// ---------------------------------------------------------------------------
+// EC P-256 key helpers
+// ---------------------------------------------------------------------------
+
+/// Load an EC P-256 private key from a PEM file, or generate a new one and
+/// persist it to the path.
+fn loadOrGenerateEcKey(allocator: std.mem.Allocator, path: []const u8) AcmeError!*c.EC_KEY {
+    // Try loading from file first.
+    const path_z = std.heap.c_allocator.dupeZ(u8, path) catch return error.OutOfMemory;
+    defer std.heap.c_allocator.free(path_z);
+
+    const loaded = loadEcKeyFromFile(path_z);
+    if (loaded) |key| return key;
+
+    // Generate a new P-256 key.
+    const key = c.EC_KEY_new_by_curve_name(c.NID_X9_62_prime256v1) orelse return error.KeyGenFailed;
+    errdefer c.EC_KEY_free(key);
+    if (c.EC_KEY_generate_key(key) != 1) return error.KeyGenFailed;
+
+    // Persist the key.
+    const bio = c.BIO_new_file(path_z.ptr, "w") orelse return error.KeySaveFailed;
+    defer _ = c.BIO_free(bio);
+    if (c.PEM_write_bio_ECPrivateKey(bio, key, null, null, 0, null, null) != 1) return error.KeySaveFailed;
+    _ = allocator; // used for path_z allocation above
+    return key;
+}
+
+fn loadEcKeyFromFile(path_z: [:0]const u8) ?*c.EC_KEY {
+    const bio = c.BIO_new_file(path_z.ptr, "r") orelse return null;
+    defer _ = c.BIO_free(bio);
+    return c.PEM_read_bio_ECPrivateKey(bio, null, null, null);
+}
+
+/// Extract the public key X and Y coordinates (32 bytes each, big-endian).
+fn ecKeyPublicCoords(key: *c.EC_KEY, x_out: *[32]u8, y_out: *[32]u8) AcmeError!void {
+    const group = c.EC_KEY_get0_group(key) orelse return error.KeyGenFailed;
+    const point = c.EC_KEY_get0_public_key(key) orelse return error.KeyGenFailed;
+    const ctx = c.BN_CTX_new() orelse return error.OutOfMemory;
+    defer c.BN_CTX_free(ctx);
+    const bx = c.BN_new() orelse return error.OutOfMemory;
+    defer c.BN_free(bx);
+    const by = c.BN_new() orelse return error.OutOfMemory;
+    defer c.BN_free(by);
+    if (c.EC_POINT_get_affine_coordinates_GFp(group, point, bx, by, ctx) != 1) return error.KeyGenFailed;
+    if (c.BN_bn2binpad(bx, x_out.ptr, 32) != 32) return error.KeyGenFailed;
+    if (c.BN_bn2binpad(by, y_out.ptr, 32) != 32) return error.KeyGenFailed;
+}
+
+/// Build the canonical JWK JSON for an EC P-256 public key (lexicographic key order,
+/// no whitespace — required for thumbprint computation).
+fn buildJwk(allocator: std.mem.Allocator, key: *c.EC_KEY) ![]u8 {
+    var x: [32]u8 = undefined;
+    var y: [32]u8 = undefined;
+    try ecKeyPublicCoords(key, &x, &y);
+    const xb64 = try b64urlEncode(allocator, &x);
+    defer allocator.free(xb64);
+    const yb64 = try b64urlEncode(allocator, &y);
+    defer allocator.free(yb64);
+    // RFC 7638: keys MUST be sorted lexicographically.
+    return std.fmt.allocPrint(allocator, "{{\"crv\":\"P-256\",\"kty\":\"EC\",\"x\":\"{s}\",\"y\":\"{s}\"}}", .{ xb64, yb64 });
+}
+
+/// Compute the JWK thumbprint: SHA-256(canonical_JWK) → base64url.
+fn jwkThumbprint(allocator: std.mem.Allocator, key: *c.EC_KEY) ![]u8 {
+    const jwk = try buildJwk(allocator, key);
+    defer allocator.free(jwk);
+    var digest: [32]u8 = undefined;
+    _ = c.EVP_Digest(jwk.ptr, jwk.len, &digest, null, c.EVP_sha256(), null);
+    return b64urlEncode(allocator, &digest);
+}
+
+// ---------------------------------------------------------------------------
+// JWS signing
+// ---------------------------------------------------------------------------
+
+/// Sign `data` with ECDSA P-256 and return the raw R||S bytes (64 bytes).
+fn ecdsaSignRaw(allocator: std.mem.Allocator, key: *c.EC_KEY, data: []const u8) ![]u8 {
+    var digest: [32]u8 = undefined;
+    _ = c.EVP_Digest(data.ptr, data.len, &digest, null, c.EVP_sha256(), null);
+
+    const sig: ?*c.ECDSA_SIG = c.ECDSA_do_sign(&digest, 32, key);
+    if (sig == null) return error.AcmeProtocolError;
+    defer c.ECDSA_SIG_free(sig);
+
+    var r_ptr: ?*const c.BIGNUM = null;
+    var s_ptr: ?*const c.BIGNUM = null;
+    c.ECDSA_SIG_get0(sig, &r_ptr, &s_ptr);
+    const r = r_ptr orelse return error.AcmeProtocolError;
+    const s = s_ptr orelse return error.AcmeProtocolError;
+
+    const out = try allocator.alloc(u8, 64);
+    if (c.BN_bn2binpad(r, out.ptr, 32) != 32) {
+        allocator.free(out);
+        return error.AcmeProtocolError;
+    }
+    if (c.BN_bn2binpad(s, out.ptr + 32, 32) != 32) {
+        allocator.free(out);
+        return error.AcmeProtocolError;
+    }
+    return out;
+}
+
+const JwsContext = struct {
+    /// Account key
+    key: *c.EC_KEY,
+    /// Account URL (empty = not yet registered, use `jwk` in header)
+    account_url: []const u8,
+    /// ACME replay nonce
+    nonce: []const u8,
+};
+
+/// Build a signed JWS flat JSON object for the given URL and payload.
+/// `payload` is the raw bytes to sign; pass empty slice for POST-as-GET.
+fn buildJws(allocator: std.mem.Allocator, jws_ctx: *const JwsContext, url: []const u8, payload: []const u8) ![]u8 {
+    // Protected header
+    const protected_json = blk: {
+        if (jws_ctx.account_url.len == 0) {
+            // New account: embed JWK
+            const jwk = try buildJwk(allocator, jws_ctx.key);
+            defer allocator.free(jwk);
+            break :blk try std.fmt.allocPrint(allocator, "{{\"alg\":\"ES256\",\"nonce\":\"{s}\",\"url\":\"{s}\",\"jwk\":{s}}}", .{ jws_ctx.nonce, url, jwk });
+        } else {
+            break :blk try std.fmt.allocPrint(allocator, "{{\"alg\":\"ES256\",\"nonce\":\"{s}\",\"url\":\"{s}\",\"kid\":\"{s}\"}}", .{ jws_ctx.nonce, url, jws_ctx.account_url });
+        }
+    };
+    defer allocator.free(protected_json);
+
+    const protected_b64 = try b64urlEncode(allocator, protected_json);
+    defer allocator.free(protected_b64);
+
+    const payload_b64 = if (payload.len == 0) try allocator.dupe(u8, "") else try b64urlEncode(allocator, payload);
+    defer allocator.free(payload_b64);
+
+    // Signing input: protected_b64 + "." + payload_b64
+    const signing_input = try std.fmt.allocPrint(allocator, "{s}.{s}", .{ protected_b64, payload_b64 });
+    defer allocator.free(signing_input);
+
+    const sig_raw = try ecdsaSignRaw(allocator, jws_ctx.key, signing_input);
+    defer allocator.free(sig_raw);
+    const sig_b64 = try b64urlEncode(allocator, sig_raw);
+    defer allocator.free(sig_b64);
+
+    return std.fmt.allocPrint(allocator, "{{\"protected\":\"{s}\",\"payload\":\"{s}\",\"signature\":\"{s}\"}}", .{ protected_b64, payload_b64, sig_b64 });
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+const AcmeResponse = struct {
+    allocator: std.mem.Allocator,
+    status: std.http.Status,
+    location: ?[]u8,
+    replay_nonce: ?[]u8,
+    body: []u8,
+
+    fn deinit(self: *AcmeResponse) void {
+        if (self.location) |l| self.allocator.free(l);
+        if (self.replay_nonce) |n| self.allocator.free(n);
+        self.allocator.free(self.body);
+    }
+};
+
+fn acmeRequest(
+    allocator: std.mem.Allocator,
+    client: *std.http.Client,
+    method: std.http.Method,
+    url: []const u8,
+    body_opt: ?[]const u8,
+) AcmeError!AcmeResponse {
+    const uri = std.Uri.parse(url) catch return error.NetworkError;
+    var server_header_buf: [8192]u8 = undefined;
+    const extra: []const std.http.Header = if (body_opt != null)
+        &.{.{ .name = "Content-Type", .value = "application/jose+json" }}
+    else
+        &.{};
+    var req = client.open(method, uri, .{
+        .server_header_buffer = &server_header_buf,
+        .extra_headers = extra,
+        .keep_alive = false,
+    }) catch return error.NetworkError;
+    defer req.deinit();
+    if (body_opt) |body| {
+        req.transfer_encoding = .{ .content_length = body.len };
+    }
+    req.send() catch return error.NetworkError;
+    if (body_opt) |body| req.writeAll(body) catch return error.NetworkError;
+    req.finish() catch return error.NetworkError;
+    req.wait() catch return error.NetworkError;
+
+    var body_list = std.ArrayList(u8).init(allocator);
+    errdefer body_list.deinit();
+    req.reader().readAllArrayList(&body_list, 512 * 1024) catch return error.NetworkError;
+
+    var location: ?[]u8 = null;
+    var replay_nonce: ?[]u8 = null;
+    var header_it = req.response.iterateHeaders();
+    while (header_it.next()) |h| {
+        if (std.ascii.eqlIgnoreCase(h.name, "location")) {
+            location = allocator.dupe(u8, h.value) catch null;
+        } else if (std.ascii.eqlIgnoreCase(h.name, "replay-nonce")) {
+            replay_nonce = allocator.dupe(u8, h.value) catch null;
+        }
+    }
+    return .{
+        .allocator = allocator,
+        .status = req.response.status,
+        .location = location,
+        .replay_nonce = replay_nonce,
+        .body = try body_list.toOwnedSlice(),
+    };
+}
+
+fn fetchNonce(allocator: std.mem.Allocator, client: *std.http.Client, new_nonce_url: []const u8) AcmeError![]u8 {
+    var resp = try acmeRequest(allocator, client, .HEAD, new_nonce_url, null);
+    defer resp.deinit();
+    const nonce = resp.replay_nonce orelse return error.AcmeProtocolError;
+    const owned = allocator.dupe(u8, nonce) catch return error.OutOfMemory;
+    resp.replay_nonce = null; // prevent double-free
+    return owned;
+}
+
+// ---------------------------------------------------------------------------
+// CSR generation
+// ---------------------------------------------------------------------------
+
+fn buildCsr(allocator: std.mem.Allocator, domains: []const []const u8, domain_key: *c.EC_KEY) ![]u8 {
+    if (domains.len == 0) return error.CsrFailed;
+
+    const pkey = c.EVP_PKEY_new() orelse return error.CsrFailed;
+    defer c.EVP_PKEY_free(pkey);
+    // EVP_PKEY_assign_EC_KEY increments the refcount of domain_key
+    if (c.EVP_PKEY_assign_EC_KEY(pkey, c.EC_KEY_dup(domain_key)) != 1) return error.CsrFailed;
+
+    const req = c.X509_REQ_new() orelse return error.CsrFailed;
+    defer c.X509_REQ_free(req);
+    if (c.X509_REQ_set_version(req, 0) != 1) return error.CsrFailed;
+    if (c.X509_REQ_set_pubkey(req, pkey) != 1) return error.CsrFailed;
+
+    // Set CN to the first domain
+    const name = c.X509_REQ_get_subject_name(req);
+    const cn_z = try std.heap.c_allocator.dupeZ(u8, domains[0]);
+    defer std.heap.c_allocator.free(cn_z);
+    if (c.X509_NAME_add_entry_by_txt(name, "CN", c.MBSTRING_UTF8, cn_z.ptr, -1, -1, 0) != 1) return error.CsrFailed;
+
+    // Build SANs extension
+    var san_buf = std.ArrayList(u8).init(allocator);
+    defer san_buf.deinit();
+    for (domains, 0..) |domain, i| {
+        if (i > 0) try san_buf.appendSlice(", ");
+        try san_buf.appendSlice("DNS:");
+        try san_buf.appendSlice(domain);
+    }
+    try san_buf.append(0); // null terminate for OpenSSL
+
+    const san_z: [:0]const u8 = san_buf.items[0 .. san_buf.items.len - 1 :0];
+    const san_ext = c.X509V3_EXT_conf_nid(null, null, c.NID_subject_alt_name, san_z.ptr) orelse return error.CsrFailed;
+    defer c.X509_EXTENSION_free(san_ext);
+
+    const exts = c.sk_X509_EXTENSION_new_null() orelse return error.CsrFailed;
+    defer c.sk_X509_EXTENSION_pop_free(exts, c.X509_EXTENSION_free);
+    if (c.sk_X509_EXTENSION_push(exts, san_ext) == 0) return error.CsrFailed;
+    if (c.X509_REQ_add_extensions(req, exts) != 1) return error.CsrFailed;
+
+    // Sign
+    if (c.X509_REQ_sign(req, pkey, c.EVP_sha256()) == 0) return error.CsrFailed;
+
+    // DER encode
+    var der_buf: ?[*]u8 = null;
+    const der_len = c.i2d_X509_REQ(req, &der_buf);
+    if (der_len <= 0 or der_buf == null) return error.CsrFailed;
+    defer std.c.free(der_buf);
+
+    return allocator.dupe(u8, der_buf.?[0..@intCast(der_len)]);
+}
+
+// ---------------------------------------------------------------------------
+// Certificate expiry check
+// ---------------------------------------------------------------------------
+
+/// Returns the number of days until the certificate at `cert_path` expires,
+/// or null if the file does not exist or cannot be parsed.
+pub fn daysUntilExpiry(cert_path: []const u8) ?i64 {
+    const path_z = std.heap.c_allocator.dupeZ(u8, cert_path) catch return null;
+    defer std.heap.c_allocator.free(path_z);
+    const bio = c.BIO_new_file(path_z.ptr, "r") orelse return null;
+    defer _ = c.BIO_free(bio);
+    const cert: ?*c.X509 = c.PEM_read_bio_X509(bio, null, null, null);
+    if (cert == null) return null;
+    defer c.X509_free(cert);
+
+    const not_after = c.X509_get0_notAfter(cert) orelse return null;
+    const diff = c.ASN1_TIME_diff(null, null, null, not_after);
+    // diff is days; negative means already expired
+    return @as(i64, diff);
+}
+
+// ---------------------------------------------------------------------------
+// ACME state machine
+// ---------------------------------------------------------------------------
+
+pub const AcmeOptions = struct {
+    allocator: std.mem.Allocator,
+    /// ACME directory URL (e.g. Let's Encrypt v2 production or staging).
+    directory_url: []const u8,
+    /// Domains to request a certificate for.
+    domains: []const []const u8,
+    /// Contact email for ACME account.
+    email: []const u8,
+    /// Path to persist/load the ECDSA account private key.
+    account_key_path: []const u8,
+    /// Directory where certificate (<domain>.crt) and key (<domain>.key) files are stored.
+    cert_dir: []const u8,
+    /// How many days before expiry to trigger renewal.
+    renew_days_before_expiry: u32,
+    /// HTTP-01 challenge token store shared with the edge gateway.
+    challenge_store: *ChallengeStore,
+    /// Maximum seconds to wait for ACME challenge validation.
+    challenge_timeout_s: u32 = 120,
+};
+
+/// Run one ACME cycle: check whether a certificate needs to be issued/renewed,
+/// and if so perform the full ACME flow.  Returns `error.CertNotYetDue` when
+/// the existing certificate has more than `renew_days_before_expiry` days left.
+pub fn runOnce(opts: AcmeOptions) AcmeError!void {
+    const allocator = opts.allocator;
+    if (opts.domains.len == 0) return error.AcmeProtocolError;
+
+    // Determine output paths based on first domain name.
+    const cert_path = std.fmt.allocPrint(allocator, "{s}/{s}.crt", .{ opts.cert_dir, opts.domains[0] }) catch return error.OutOfMemory;
+    defer allocator.free(cert_path);
+    const key_path = std.fmt.allocPrint(allocator, "{s}/{s}.key", .{ opts.cert_dir, opts.domains[0] }) catch return error.OutOfMemory;
+    defer allocator.free(key_path);
+
+    // Check if renewal is due.
+    if (daysUntilExpiry(cert_path)) |days| {
+        if (days > @as(i64, opts.renew_days_before_expiry)) return error.CertNotYetDue;
+    }
+
+    // Load or generate account key.
+    const account_key = try loadOrGenerateEcKey(allocator, opts.account_key_path);
+    defer c.EC_KEY_free(account_key);
+
+    // Generate a fresh domain key for this certificate.
+    const domain_key = c.EC_KEY_new_by_curve_name(c.NID_X9_62_prime256v1) orelse return error.KeyGenFailed;
+    defer c.EC_KEY_free(domain_key);
+    if (c.EC_KEY_generate_key(domain_key) != 1) return error.KeyGenFailed;
+
+    // HTTP client for ACME server communication.
+    var http_client = std.http.Client{ .allocator = allocator };
+    defer http_client.deinit();
+
+    // Step 1: Fetch ACME directory.
+    var dir_resp = acmeRequest(allocator, &http_client, .GET, opts.directory_url, null) catch return error.NetworkError;
+    defer dir_resp.deinit();
+    if (dir_resp.status != .ok) return error.AcmeProtocolError;
+
+    var dir_parsed = std.json.parseFromSlice(std.json.Value, allocator, dir_resp.body, .{ .ignore_unknown_fields = true }) catch return error.JsonParseFailed;
+    defer dir_parsed.deinit();
+    const dir_obj = dir_parsed.value.object;
+
+    const new_account_url = dir_obj.get("newAccount") orelse return error.AcmeProtocolError;
+    const new_order_url = dir_obj.get("newOrder") orelse return error.AcmeProtocolError;
+    const new_nonce_url = dir_obj.get("newNonce") orelse return error.AcmeProtocolError;
+    if (new_account_url != .string or new_order_url != .string or new_nonce_url != .string) return error.AcmeProtocolError;
+
+    // Step 2: Register / find account.
+    var nonce = try fetchNonce(allocator, &http_client, new_nonce_url.string);
+    defer allocator.free(nonce);
+
+    var jws_ctx = JwsContext{
+        .key = account_key,
+        .account_url = "",
+        .nonce = nonce,
+    };
+
+    const contact_json = std.fmt.allocPrint(allocator, "{{\"termsOfServiceAgreed\":true,\"contact\":[\"mailto:{s}\"]}}", .{opts.email}) catch return error.OutOfMemory;
+    defer allocator.free(contact_json);
+    const acct_jws = try buildJws(allocator, &jws_ctx, new_account_url.string, contact_json);
+    defer allocator.free(acct_jws);
+
+    var acct_resp = acmeRequest(allocator, &http_client, .POST, new_account_url.string, acct_jws) catch return error.NetworkError;
+    defer acct_resp.deinit();
+    if (@intFromEnum(acct_resp.status) < 200 or @intFromEnum(acct_resp.status) >= 300) return error.AcmeProtocolError;
+    const account_url = acct_resp.location orelse return error.AcmeProtocolError;
+    const owned_account_url = allocator.dupe(u8, account_url) catch return error.OutOfMemory;
+    defer allocator.free(owned_account_url);
+    jws_ctx.account_url = owned_account_url;
+    if (acct_resp.replay_nonce) |new_nonce| {
+        allocator.free(nonce);
+        nonce = allocator.dupe(u8, new_nonce) catch return error.OutOfMemory;
+        jws_ctx.nonce = nonce;
+    }
+
+    // Step 3: Create order.
+    var ids_buf = std.ArrayList(u8).init(allocator);
+    defer ids_buf.deinit();
+    try ids_buf.appendSlice("[");
+    for (opts.domains, 0..) |domain, i| {
+        if (i > 0) try ids_buf.appendSlice(",");
+        try ids_buf.writer().print("{{\"type\":\"dns\",\"value\":\"{s}\"}}", .{domain});
+    }
+    try ids_buf.appendSlice("]");
+    const order_payload = std.fmt.allocPrint(allocator, "{{\"identifiers\":{s}}}", .{ids_buf.items}) catch return error.OutOfMemory;
+    defer allocator.free(order_payload);
+
+    // Refresh nonce
+    allocator.free(nonce);
+    nonce = try fetchNonce(allocator, &http_client, new_nonce_url.string);
+    jws_ctx.nonce = nonce;
+
+    const order_jws = try buildJws(allocator, &jws_ctx, new_order_url.string, order_payload);
+    defer allocator.free(order_jws);
+
+    var order_resp = acmeRequest(allocator, &http_client, .POST, new_order_url.string, order_jws) catch return error.NetworkError;
+    defer order_resp.deinit();
+    if (@intFromEnum(order_resp.status) < 200 or @intFromEnum(order_resp.status) >= 300) return error.AcmeProtocolError;
+    const order_url = order_resp.location orelse return error.AcmeProtocolError;
+    const owned_order_url = allocator.dupe(u8, order_url) catch return error.OutOfMemory;
+    defer allocator.free(owned_order_url);
+    if (order_resp.replay_nonce) |new_nonce| {
+        allocator.free(nonce);
+        nonce = allocator.dupe(u8, new_nonce) catch return error.OutOfMemory;
+        jws_ctx.nonce = nonce;
+    }
+
+    var order_parsed = std.json.parseFromSlice(std.json.Value, allocator, order_resp.body, .{ .ignore_unknown_fields = true }) catch return error.JsonParseFailed;
+    defer order_parsed.deinit();
+    const order_obj = order_parsed.value.object;
+    const authz_urls_val = order_obj.get("authorizations") orelse return error.AcmeProtocolError;
+    if (authz_urls_val != .array) return error.AcmeProtocolError;
+    const finalize_val = order_obj.get("finalize") orelse return error.AcmeProtocolError;
+    if (finalize_val != .string) return error.AcmeProtocolError;
+    const finalize_url = finalize_val.string;
+
+    // Step 4: Fulfill HTTP-01 challenges for each authorization.
+    const thumbprint = try jwkThumbprint(allocator, account_key);
+    defer allocator.free(thumbprint);
+
+    for (authz_urls_val.array.items) |authz_url_val| {
+        if (authz_url_val != .string) return error.AcmeProtocolError;
+        const authz_url = authz_url_val.string;
+
+        // GET authorization (POST-as-GET with empty payload)
+        allocator.free(nonce);
+        nonce = try fetchNonce(allocator, &http_client, new_nonce_url.string);
+        jws_ctx.nonce = nonce;
+        const authz_jws = try buildJws(allocator, &jws_ctx, authz_url, "");
+        defer allocator.free(authz_jws);
+        var authz_resp = acmeRequest(allocator, &http_client, .POST, authz_url, authz_jws) catch return error.NetworkError;
+        defer authz_resp.deinit();
+        if (authz_resp.replay_nonce) |new_nonce| {
+            allocator.free(nonce);
+            nonce = allocator.dupe(u8, new_nonce) catch return error.OutOfMemory;
+            jws_ctx.nonce = nonce;
+        }
+
+        var authz_parsed = std.json.parseFromSlice(std.json.Value, allocator, authz_resp.body, .{ .ignore_unknown_fields = true }) catch return error.JsonParseFailed;
+        defer authz_parsed.deinit();
+        const authz_obj = authz_parsed.value.object;
+        const challenges_val = authz_obj.get("challenges") orelse return error.AcmeProtocolError;
+        if (challenges_val != .array) return error.AcmeProtocolError;
+
+        // Find the HTTP-01 challenge.
+        var challenge_token: ?[]const u8 = null;
+        var challenge_url: ?[]const u8 = null;
+        for (challenges_val.array.items) |ch_val| {
+            if (ch_val != .object) continue;
+            const ch = ch_val.object;
+            const type_val = ch.get("type") orelse continue;
+            if (type_val != .string or !std.mem.eql(u8, type_val.string, "http-01")) continue;
+            const token_val = ch.get("token") orelse continue;
+            const url_val = ch.get("url") orelse continue;
+            if (token_val == .string and url_val == .string) {
+                challenge_token = token_val.string;
+                challenge_url = url_val.string;
+                break;
+            }
+        }
+        if (challenge_token == null or challenge_url == null) return error.ChallengeFailed;
+
+        // key_auth = token + "." + thumbprint
+        const key_auth = std.fmt.allocPrint(allocator, "{s}.{s}", .{ challenge_token.?, thumbprint }) catch return error.OutOfMemory;
+        defer allocator.free(key_auth);
+
+        // Publish challenge token to the store so the gateway can serve it.
+        opts.challenge_store.put(challenge_token.?, key_auth) catch return error.OutOfMemory;
+        defer opts.challenge_store.remove(challenge_token.?);
+
+        // Notify ACME server that the challenge is ready.
+        allocator.free(nonce);
+        nonce = try fetchNonce(allocator, &http_client, new_nonce_url.string);
+        jws_ctx.nonce = nonce;
+        const ch_ready_jws = try buildJws(allocator, &jws_ctx, challenge_url.?, "{}");
+        defer allocator.free(ch_ready_jws);
+        var ch_ready_resp = acmeRequest(allocator, &http_client, .POST, challenge_url.?, ch_ready_jws) catch return error.NetworkError;
+        defer ch_ready_resp.deinit();
+        if (ch_ready_resp.replay_nonce) |new_nonce| {
+            allocator.free(nonce);
+            nonce = allocator.dupe(u8, new_nonce) catch return error.OutOfMemory;
+            jws_ctx.nonce = nonce;
+        }
+
+        // Poll the authorization until valid or timeout.
+        const deadline = std.time.milliTimestamp() + @as(i64, opts.challenge_timeout_s) * 1000;
+        while (true) {
+            std.time.sleep(2_000_000_000); // 2 seconds
+            allocator.free(nonce);
+            nonce = try fetchNonce(allocator, &http_client, new_nonce_url.string);
+            jws_ctx.nonce = nonce;
+            const poll_jws = try buildJws(allocator, &jws_ctx, authz_url, "");
+            defer allocator.free(poll_jws);
+            var poll_resp = acmeRequest(allocator, &http_client, .POST, authz_url, poll_jws) catch return error.NetworkError;
+            defer poll_resp.deinit();
+            if (poll_resp.replay_nonce) |new_nonce| {
+                allocator.free(nonce);
+                nonce = allocator.dupe(u8, new_nonce) catch return error.OutOfMemory;
+                jws_ctx.nonce = nonce;
+            }
+            var poll_parsed = std.json.parseFromSlice(std.json.Value, allocator, poll_resp.body, .{ .ignore_unknown_fields = true }) catch return error.JsonParseFailed;
+            defer poll_parsed.deinit();
+            const status_val = poll_parsed.value.object.get("status") orelse break;
+            if (status_val == .string) {
+                if (std.mem.eql(u8, status_val.string, "valid")) break;
+                if (std.mem.eql(u8, status_val.string, "invalid")) return error.ChallengeFailed;
+            }
+            if (std.time.milliTimestamp() > deadline) return error.ChallengeFailed;
+        }
+    }
+
+    // Step 5: Generate CSR for all domains.
+    const csr_der = try buildCsr(allocator, opts.domains, domain_key);
+    defer allocator.free(csr_der);
+    const csr_b64 = try b64urlEncode(allocator, csr_der);
+    defer allocator.free(csr_b64);
+
+    // Step 6: Finalize the order.
+    const finalize_payload = std.fmt.allocPrint(allocator, "{{\"csr\":\"{s}\"}}", .{csr_b64}) catch return error.OutOfMemory;
+    defer allocator.free(finalize_payload);
+    allocator.free(nonce);
+    nonce = try fetchNonce(allocator, &http_client, new_nonce_url.string);
+    jws_ctx.nonce = nonce;
+    const fin_jws = try buildJws(allocator, &jws_ctx, finalize_url, finalize_payload);
+    defer allocator.free(fin_jws);
+    var fin_resp = acmeRequest(allocator, &http_client, .POST, finalize_url, fin_jws) catch return error.NetworkError;
+    defer fin_resp.deinit();
+    if (@intFromEnum(fin_resp.status) < 200 or @intFromEnum(fin_resp.status) >= 300) return error.AcmeProtocolError;
+    if (fin_resp.replay_nonce) |new_nonce| {
+        allocator.free(nonce);
+        nonce = allocator.dupe(u8, new_nonce) catch return error.OutOfMemory;
+        jws_ctx.nonce = nonce;
+    }
+
+    // Poll the order until the certificate URL is available.
+    const order_deadline = std.time.milliTimestamp() + 120_000;
+    var cert_url: ?[]u8 = null;
+    defer if (cert_url) |u| allocator.free(u);
+    while (cert_url == null) {
+        std.time.sleep(2_000_000_000);
+        allocator.free(nonce);
+        nonce = try fetchNonce(allocator, &http_client, new_nonce_url.string);
+        jws_ctx.nonce = nonce;
+        const ord_poll_jws = try buildJws(allocator, &jws_ctx, owned_order_url, "");
+        defer allocator.free(ord_poll_jws);
+        var ord_poll_resp = acmeRequest(allocator, &http_client, .POST, owned_order_url, ord_poll_jws) catch return error.NetworkError;
+        defer ord_poll_resp.deinit();
+        if (ord_poll_resp.replay_nonce) |new_nonce| {
+            allocator.free(nonce);
+            nonce = allocator.dupe(u8, new_nonce) catch return error.OutOfMemory;
+            jws_ctx.nonce = nonce;
+        }
+        var ord_parsed = std.json.parseFromSlice(std.json.Value, allocator, ord_poll_resp.body, .{ .ignore_unknown_fields = true }) catch return error.JsonParseFailed;
+        defer ord_parsed.deinit();
+        const cert_url_val = ord_parsed.value.object.get("certificate");
+        if (cert_url_val != null and cert_url_val.? == .string) {
+            cert_url = allocator.dupe(u8, cert_url_val.?.string) catch return error.OutOfMemory;
+            break;
+        }
+        if (std.time.milliTimestamp() > order_deadline) return error.CertDownloadFailed;
+    }
+
+    // Step 7: Download the certificate chain.
+    allocator.free(nonce);
+    nonce = try fetchNonce(allocator, &http_client, new_nonce_url.string);
+    jws_ctx.nonce = nonce;
+    const dl_jws = try buildJws(allocator, &jws_ctx, cert_url.?, "");
+    defer allocator.free(dl_jws);
+    var dl_resp = acmeRequest(allocator, &http_client, .POST, cert_url.?, dl_jws) catch return error.NetworkError;
+    defer dl_resp.deinit();
+    if (dl_resp.status != .ok) return error.CertDownloadFailed;
+
+    // Step 8: Atomically save the certificate and private key to disk.
+    std.fs.cwd().makePath(opts.cert_dir) catch {};
+    const tmp_cert = std.fmt.allocPrint(allocator, "{s}.tmp", .{cert_path}) catch return error.OutOfMemory;
+    defer allocator.free(tmp_cert);
+    std.fs.cwd().writeFile(.{ .sub_path = tmp_cert, .data = dl_resp.body }) catch return error.CertSaveFailed;
+    std.fs.cwd().rename(tmp_cert, cert_path) catch return error.CertSaveFailed;
+
+    // Write domain private key in PEM.
+    const domain_bio = c.BIO_new(c.BIO_s_mem()) orelse return error.CertSaveFailed;
+    defer _ = c.BIO_free(domain_bio);
+    if (c.PEM_write_bio_ECPrivateKey(domain_bio, domain_key, null, null, 0, null, null) != 1) return error.CertSaveFailed;
+    var key_ptr: ?[*]u8 = null;
+    const key_len = c.BIO_get_mem_data(domain_bio, &key_ptr);
+    if (key_len <= 0 or key_ptr == null) return error.CertSaveFailed;
+    const tmp_key = std.fmt.allocPrint(allocator, "{s}.tmp", .{key_path}) catch return error.OutOfMemory;
+    defer allocator.free(tmp_key);
+    std.fs.cwd().writeFile(.{ .sub_path = tmp_key, .data = key_ptr.?[0..@intCast(key_len)] }) catch return error.CertSaveFailed;
+    std.fs.cwd().rename(tmp_key, key_path) catch return error.CertSaveFailed;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "ChallengeStore put/getCopy/remove" {
+    const allocator = std.testing.allocator;
+    var store = ChallengeStore.init(allocator);
+    defer store.deinit();
+
+    try store.put("abc123", "abc123.thumbprint");
+    const val = store.getCopy(allocator, "abc123").?;
+    defer allocator.free(val);
+    try std.testing.expectEqualStrings("abc123.thumbprint", val);
+
+    store.remove("abc123");
+    try std.testing.expect(store.getCopy(allocator, "abc123") == null);
+}
+
+test "b64urlEncode round-trip" {
+    const allocator = std.testing.allocator;
+    const data = "hello world";
+    const encoded = try b64urlEncode(allocator, data);
+    defer allocator.free(encoded);
+    const decoded_len = try b64url_dec.calcSizeForSlice(encoded);
+    const decoded = try allocator.alloc(u8, decoded_len);
+    defer allocator.free(decoded);
+    _ = try b64url_dec.decode(decoded, encoded);
+    try std.testing.expectEqualStrings(data, decoded);
+}
+
+test "EC P-256 key generation and JWK thumbprint" {
+    const allocator = std.testing.allocator;
+    const key = c.EC_KEY_new_by_curve_name(c.NID_X9_62_prime256v1) orelse return error.KeyGenFailed;
+    defer c.EC_KEY_free(key);
+    try std.testing.expect(c.EC_KEY_generate_key(key) == 1);
+
+    const tp = try jwkThumbprint(allocator, key);
+    defer allocator.free(tp);
+    // Thumbprint should be 43 bytes of base64url (32 bytes SHA-256 → 43 chars base64url-no-pad)
+    try std.testing.expectEqual(@as(usize, 43), tp.len);
+}

--- a/src/http/tls_termination.zig
+++ b/src/http/tls_termination.zig
@@ -1,13 +1,16 @@
 const std = @import("std");
+const acme_client = @import("acme_client.zig");
 
 const c = @cImport({
     @cInclude("openssl/ssl.h");
     @cInclude("openssl/err.h");
     @cInclude("openssl/x509_vfy.h");
     @cInclude("openssl/x509.h");
+    @cInclude("openssl/x509v3.h");
     @cInclude("openssl/pem.h");
     @cInclude("openssl/bio.h");
     @cInclude("openssl/crypto.h");
+    @cInclude("openssl/ocsp.h");
 });
 
 extern fn SSL_CTX_set_alpn_select_cb(
@@ -60,6 +63,15 @@ pub const TlsOptions = struct {
     session_tickets_enabled: bool = true,
     ocsp_stapling_enabled: bool = false,
     ocsp_response_path: []const u8 = "",
+    /// When true, Tardigrade fetches OCSP responses from the responder URL
+    /// embedded in the certificate's AIA extension instead of relying on a
+    /// static file.  The static-file path is used as a warm-start fallback on
+    /// the first boot if a pre-fetched file is present.
+    ocsp_auto_refresh_enabled: bool = false,
+    /// How often (ms) to re-fetch the OCSP response from the responder.
+    ocsp_refresh_interval_ms: u64 = 3_600_000,
+    /// Per-request timeout (ms) when contacting the OCSP responder.
+    ocsp_refresh_timeout_ms: u32 = 10_000,
     client_ca_path: []const u8 = "",
     client_verify: bool = false,
     client_verify_depth: u32 = 3,
@@ -68,6 +80,20 @@ pub const TlsOptions = struct {
     dynamic_reload_interval_ms: u64 = 5_000,
     acme_enabled: bool = false,
     acme_cert_dir: []const u8 = "",
+    /// When true, Tardigrade runs the ACME issuance/renewal workflow automatically.
+    acme_auto_issue: bool = false,
+    /// ACME directory URL (Let's Encrypt production or staging, or pebble for tests).
+    acme_directory_url: []const u8 = "https://acme-v02.api.letsencrypt.org/directory",
+    /// Comma-separated domain names to request a certificate for.
+    acme_domains: []const []const u8 = &.{},
+    /// Contact email for ACME account registration.
+    acme_email: []const u8 = "",
+    /// PEM file path for the persistent ECDSA account private key.
+    acme_account_key_path: []const u8 = "",
+    /// Days before certificate expiry to trigger renewal.
+    acme_renew_days_before_expiry: u32 = 30,
+    /// Pointer to the HTTP-01 challenge token store shared with the gateway.
+    acme_challenge_store: ?*@import("acme_client.zig").ChallengeStore = null,
     http2_enabled: bool = true,
 };
 
@@ -95,17 +121,33 @@ const State = struct {
     ocsp_response_path: []const u8,
     ocsp_response: ?[]u8 = null,
     ocsp_mtime: ?i128 = null,
+    ocsp_auto_refresh_enabled: bool,
+    ocsp_refresh_interval_ms: u64,
+    ocsp_refresh_timeout_ms: u32,
+    ocsp_next_auto_refresh_ms: u64 = 0,
+    /// OCSP responder URL extracted from the leaf certificate's AIA extension.
+    /// Empty when no AIA OCSP entry is present.
+    ocsp_responder_url: []u8 = &.{},
     client_ca_path: []const u8,
     crl_path: []const u8,
     crl_check: bool,
     acme_enabled: bool,
     acme_cert_dir: []const u8,
+    acme_auto_issue: bool,
+    acme_directory_url: []const u8,
+    acme_domains: []const []const u8,
+    acme_email: []const u8,
+    acme_account_key_path: []const u8,
+    acme_renew_days_before_expiry: u32,
+    acme_challenge_store: ?*acme_client.ChallengeStore,
+    acme_next_check_ms: u64 = 0,
     static_sni_specs: []SniCertSpec,
     sni_certs: std.ArrayList(ManagedSniCert),
     http2_enabled: bool,
 
     fn deinit(self: *State) void {
         if (self.ocsp_response) |resp| self.allocator.free(resp);
+        if (self.ocsp_responder_url.len > 0) self.allocator.free(self.ocsp_responder_url);
         self.allocator.free(self.static_sni_specs);
         for (self.sni_certs.items) |sc| {
             self.allocator.free(sc.host_lc);
@@ -143,11 +185,21 @@ pub const TlsTerminator = struct {
             .default_key_path = opts.key_path,
             .ocsp_enabled = opts.ocsp_stapling_enabled,
             .ocsp_response_path = opts.ocsp_response_path,
+            .ocsp_auto_refresh_enabled = opts.ocsp_auto_refresh_enabled,
+            .ocsp_refresh_interval_ms = opts.ocsp_refresh_interval_ms,
+            .ocsp_refresh_timeout_ms = opts.ocsp_refresh_timeout_ms,
             .client_ca_path = opts.client_ca_path,
             .crl_path = opts.crl_path,
             .crl_check = opts.crl_check,
             .acme_enabled = opts.acme_enabled,
             .acme_cert_dir = opts.acme_cert_dir,
+            .acme_auto_issue = opts.acme_auto_issue,
+            .acme_directory_url = opts.acme_directory_url,
+            .acme_domains = opts.acme_domains,
+            .acme_email = opts.acme_email,
+            .acme_account_key_path = opts.acme_account_key_path,
+            .acme_renew_days_before_expiry = opts.acme_renew_days_before_expiry,
+            .acme_challenge_store = opts.acme_challenge_store,
             .static_sni_specs = owned_sni_specs,
             .sni_certs = std.ArrayList(ManagedSniCert).init(allocator),
             .http2_enabled = opts.http2_enabled,
@@ -161,6 +213,12 @@ pub const TlsTerminator = struct {
         try configureClientVerification(ctx, opts.client_ca_path, opts.client_verify, opts.client_verify_depth);
         if (opts.crl_check and opts.crl_path.len > 0) try configureCrl(ctx, opts.crl_path);
         if (opts.ocsp_stapling_enabled and opts.ocsp_response_path.len > 0) try loadOcspResponse(st);
+        // Extract OCSP responder URL from the leaf certificate so auto-refresh knows where to go.
+        if (opts.ocsp_auto_refresh_enabled) {
+            if (extractOcspResponderUrl(allocator, ctx)) |url| {
+                st.ocsp_responder_url = url;
+            }
+        }
         try rebuildSniCertificates(st);
         if (st.sni_certs.items.len > 0) {
             _ = c.SSL_CTX_callback_ctrl(
@@ -209,6 +267,37 @@ pub const TlsTerminator = struct {
             if (ocsp_mtime != self.state.ocsp_mtime) {
                 _ = loadOcspResponse(self.state) catch {};
             }
+        }
+
+        if (self.state.ocsp_auto_refresh_enabled and self.state.ocsp_responder_url.len > 0) {
+            if (self.state.ocsp_next_auto_refresh_ms == 0 or now_ms >= self.state.ocsp_next_auto_refresh_ms) {
+                _ = fetchAndStoreOcspResponse(self.state, self.ctx) catch {};
+                self.state.ocsp_next_auto_refresh_ms = now_ms + self.state.ocsp_refresh_interval_ms;
+            }
+        }
+
+        // Trigger ACME renewal if enabled and the check interval has elapsed.
+        if (self.state.acme_auto_issue and
+            self.state.acme_challenge_store != null and
+            self.state.acme_domains.len > 0 and
+            (self.state.acme_next_check_ms == 0 or now_ms >= self.state.acme_next_check_ms))
+        {
+            self.state.acme_next_check_ms = now_ms + 3_600_000; // recheck every hour
+            acme_client.runOnce(.{
+                .allocator = self.state.allocator,
+                .directory_url = self.state.acme_directory_url,
+                .domains = self.state.acme_domains,
+                .email = self.state.acme_email,
+                .account_key_path = self.state.acme_account_key_path,
+                .cert_dir = self.state.acme_cert_dir,
+                .renew_days_before_expiry = self.state.acme_renew_days_before_expiry,
+                .challenge_store = self.state.acme_challenge_store.?,
+            }) catch |err| switch (err) {
+                // Not yet due is expected and silent.
+                error.CertNotYetDue => {},
+                else => {},
+            };
+            // After a successful issuance, rebuild the SNI cert list to pick up the new cert.
         }
 
         _ = rebuildSniCertificates(self.state) catch {};
@@ -345,6 +434,123 @@ fn configureCrl(ctx: *c.SSL_CTX, crl_path: []const u8) TlsError!void {
     if (c.X509_STORE_set_flags(store, c.X509_V_FLAG_CRL_CHECK | c.X509_V_FLAG_CRL_CHECK_ALL) != 1) return error.CrlLoadFailed;
 }
 
+/// Extract the first OCSP responder URL from the leaf certificate's Authority
+/// Information Access (AIA) extension.  Returns an allocated slice owned by the
+/// caller, or null if no OCSP entry is found.
+fn extractOcspResponderUrl(allocator: std.mem.Allocator, ctx: *c.SSL_CTX) ?[]u8 {
+    const cert: ?*c.X509 = c.SSL_CTX_get0_certificate(ctx);
+    const raw_cert = cert orelse return null;
+
+    const aia_raw: ?*anyopaque = c.X509_get_ext_d2i(raw_cert, c.NID_info_access, null, null);
+    const aia: *c.AUTHORITY_INFO_ACCESS = @ptrCast(aia_raw orelse return null);
+    defer c.AUTHORITY_INFO_ACCESS_free(aia);
+
+    const count: c_int = c.sk_ACCESS_DESCRIPTION_num(aia);
+    var i: c_int = 0;
+    while (i < count) : (i += 1) {
+        const ad: ?*c.ACCESS_DESCRIPTION = c.sk_ACCESS_DESCRIPTION_value(aia, i);
+        const desc = ad orelse continue;
+        // OID for id-ad-ocsp
+        if (c.OBJ_obj2nid(desc.method) != c.NID_ad_OCSP) continue;
+        if (desc.location.*.type != c.GEN_URI) continue;
+        const uri = desc.location.*.d.uniformResourceIdentifier;
+        const url_bytes = uri.*.data[0..@intCast(uri.*.length)];
+        return allocator.dupe(u8, url_bytes) catch null;
+    }
+    return null;
+}
+
+/// Build a minimal DER-encoded OCSP request for the leaf certificate and POST
+/// it to the responder URL.  On success the raw DER response bytes (suitable
+/// for SSL_set_tlsext_status_ocsp_resp) are written into st.ocsp_response.
+/// Failures are non-fatal; the last-known-good response is preserved.
+fn fetchAndStoreOcspResponse(st: *State, ctx: *c.SSL_CTX) TlsError!void {
+    const cert: ?*c.X509 = c.SSL_CTX_get0_certificate(ctx);
+    const leaf = cert orelse return error.OcspLoadFailed;
+
+    // Build OCSP request for the leaf cert.  We need the issuer cert to
+    // compute the cert ID; retrieve it from the extra chain if available.
+    const chain_stack: ?*c.struct_stack_st_X509 = blk: {
+        var chain_ptr: ?*c.struct_stack_st_X509 = null;
+        _ = c.SSL_CTX_get0_extra_chain_certs(ctx, &chain_ptr);
+        break :blk chain_ptr;
+    };
+    const issuer: ?*c.X509 = if (chain_stack != null and c.sk_X509_num(chain_stack) > 0)
+        c.sk_X509_value(chain_stack, 0)
+    else
+        null;
+
+    const cert_id: ?*c.OCSP_CERTID = if (issuer != null)
+        c.OCSP_cert_to_id(null, leaf, issuer)
+    else
+        null;
+    if (cert_id == null) return error.OcspLoadFailed;
+    defer c.OCSP_CERTID_free(cert_id);
+
+    const req: ?*c.OCSP_REQUEST = c.OCSP_REQUEST_new();
+    if (req == null) return error.OcspLoadFailed;
+    defer c.OCSP_REQUEST_free(req);
+
+    if (c.OCSP_request_add0_id(req, cert_id) == null) return error.OcspLoadFailed;
+    _ = c.OCSP_request_add1_nonce(req, null, -1);
+
+    // DER-encode the request.
+    var req_buf: ?[*]u8 = null;
+    const req_len = c.i2d_OCSP_REQUEST(req, &req_buf);
+    if (req_len <= 0 or req_buf == null) return error.OcspLoadFailed;
+    defer std.c.free(req_buf);
+    const req_bytes = req_buf.?[0..@intCast(req_len)];
+
+    // HTTP POST to responder URL using std.http.Client.
+    var client = std.http.Client{ .allocator = st.allocator };
+    defer client.deinit();
+
+    const uri = std.Uri.parse(st.ocsp_responder_url) catch return error.OcspLoadFailed;
+    var server_header_buf: [4096]u8 = undefined;
+    var ocsp_req = client.open(.POST, uri, .{
+        .server_header_buffer = &server_header_buf,
+        .extra_headers = &.{
+            .{ .name = "Content-Type", .value = "application/ocsp-request" },
+        },
+        .keep_alive = false,
+    }) catch return error.OcspLoadFailed;
+    defer ocsp_req.deinit();
+    ocsp_req.transfer_encoding = .{ .content_length = req_bytes.len };
+    ocsp_req.send() catch return error.OcspLoadFailed;
+    ocsp_req.writeAll(req_bytes) catch return error.OcspLoadFailed;
+    ocsp_req.finish() catch return error.OcspLoadFailed;
+    ocsp_req.wait() catch return error.OcspLoadFailed;
+    if (ocsp_req.response.status != .ok) return error.OcspLoadFailed;
+
+    var resp_body = std.ArrayList(u8).init(st.allocator);
+    defer resp_body.deinit();
+    ocsp_req.reader().readAllArrayList(&resp_body, 64 * 1024) catch return error.OcspLoadFailed;
+
+    // Parse and validate the OCSP response structure minimally.
+    const body = resp_body.items;
+    var body_ptr: [*c]const u8 = body.ptr;
+    const ocsp_resp: ?*c.OCSP_RESPONSE = c.d2i_OCSP_RESPONSE(null, &body_ptr, @intCast(body.len));
+    if (ocsp_resp == null) return error.OcspLoadFailed;
+    defer c.OCSP_RESPONSE_free(ocsp_resp);
+
+    if (c.OCSP_response_status(ocsp_resp) != c.OCSP_RESPONSE_STATUS_SUCCESSFUL) return error.OcspLoadFailed;
+
+    // Re-encode to DER (ensures clean bytes for stapling).
+    var der_buf: ?[*]u8 = null;
+    const der_len = c.i2d_OCSP_RESPONSE(ocsp_resp, &der_buf);
+    if (der_len <= 0 or der_buf == null) return error.OcspLoadFailed;
+    defer std.c.free(der_buf);
+
+    const new_response = st.allocator.dupe(u8, der_buf.?[0..@intCast(der_len)]) catch return error.OcspLoadFailed;
+    if (st.ocsp_response) |old| st.allocator.free(old);
+    st.ocsp_response = new_response;
+
+    // Persist to the static-file path so it survives restarts (best-effort).
+    if (st.ocsp_response_path.len > 0) {
+        std.fs.cwd().writeFile(.{ .sub_path = st.ocsp_response_path, .data = new_response }) catch {};
+    }
+}
+
 fn loadOcspResponse(st: *State) TlsError!void {
     if (st.ocsp_response) |old| st.allocator.free(old);
     st.ocsp_response = null;
@@ -436,6 +642,111 @@ fn fileMtime(path: []const u8) !i128 {
     const stat = try std.fs.cwd().statFile(path);
     return stat.mtime;
 }
+
+// ---------------------------------------------------------------------------
+// Upstream mTLS / custom-CA HTTPS transport (Issue #17)
+// ---------------------------------------------------------------------------
+
+pub const UpstreamTlsOptions = struct {
+    /// Skip server certificate verification (insecure; for testing only).
+    skip_verify: bool = false,
+    /// Path to PEM CA bundle for verifying the upstream server cert.
+    /// When empty, the OpenSSL default CA store is used.
+    ca_bundle_path: []const u8 = "",
+    /// Override the SNI hostname sent during the TLS ClientHello.
+    /// When empty, the connect hostname is used.
+    sni_override: []const u8 = "",
+    /// PEM path to the client certificate for mTLS (optional).
+    client_cert_path: []const u8 = "",
+    /// PEM path to the client private key for mTLS (optional).
+    client_key_path: []const u8 = "",
+};
+
+/// An OpenSSL-backed TLS client connection to a TCP stream.
+/// Used for upstream HTTPS connections that require mTLS or custom CA/SNI.
+pub const UpstreamTlsConn = struct {
+    ssl: *c.SSL,
+    ctx: *c.SSL_CTX,
+
+    pub fn connect(
+        fd: std.posix.fd_t,
+        host: []const u8,
+        opts: UpstreamTlsOptions,
+    ) TlsError!UpstreamTlsConn {
+        if (c.OPENSSL_init_ssl(0, null) != 1) return error.OpenSslInitFailed;
+        const method = c.TLS_client_method() orelse return error.ContextInitFailed;
+        const ctx = c.SSL_CTX_new(method) orelse return error.ContextInitFailed;
+        errdefer c.SSL_CTX_free(ctx);
+
+        if (opts.skip_verify) {
+            c.SSL_CTX_set_verify(ctx, c.SSL_VERIFY_NONE, null);
+        } else if (opts.ca_bundle_path.len > 0) {
+            const ca_z = try std.heap.c_allocator.dupeZ(u8, opts.ca_bundle_path);
+            defer std.heap.c_allocator.free(ca_z);
+            if (c.SSL_CTX_load_verify_locations(ctx, ca_z.ptr, null) != 1) return error.VerifyConfigFailed;
+            c.SSL_CTX_set_verify(ctx, c.SSL_VERIFY_PEER, null);
+        } else {
+            if (c.SSL_CTX_set_default_verify_paths(ctx) != 1) return error.VerifyConfigFailed;
+            c.SSL_CTX_set_verify(ctx, c.SSL_VERIFY_PEER, null);
+        }
+
+        if (opts.client_cert_path.len > 0) {
+            const cert_z = try std.heap.c_allocator.dupeZ(u8, opts.client_cert_path);
+            defer std.heap.c_allocator.free(cert_z);
+            if (c.SSL_CTX_use_certificate_file(ctx, cert_z.ptr, c.SSL_FILETYPE_PEM) != 1) return error.CertificateLoadFailed;
+        }
+        if (opts.client_key_path.len > 0) {
+            const key_z = try std.heap.c_allocator.dupeZ(u8, opts.client_key_path);
+            defer std.heap.c_allocator.free(key_z);
+            if (c.SSL_CTX_use_PrivateKey_file(ctx, key_z.ptr, c.SSL_FILETYPE_PEM) != 1) return error.PrivateKeyLoadFailed;
+            if (c.SSL_CTX_check_private_key(ctx) != 1) return error.CertificateKeyMismatch;
+        }
+
+        const ssl = c.SSL_new(ctx) orelse return error.ContextInitFailed;
+        errdefer c.SSL_free(ssl);
+
+        const sni_host = if (opts.sni_override.len > 0) opts.sni_override else host;
+        const sni_z = try std.heap.c_allocator.dupeZ(u8, sni_host);
+        defer std.heap.c_allocator.free(sni_z);
+        _ = c.SSL_set_tlsext_host_name(ssl, sni_z.ptr);
+
+        if (!opts.skip_verify) {
+            const verify_host_z = try std.heap.c_allocator.dupeZ(u8, sni_host);
+            defer std.heap.c_allocator.free(verify_host_z);
+            const param = c.SSL_get0_param(ssl);
+            _ = c.X509_VERIFY_PARAM_set_hostflags(param, c.X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+            if (c.X509_VERIFY_PARAM_set1_host(param, verify_host_z.ptr, 0) != 1) return error.VerifyConfigFailed;
+        }
+
+        if (c.SSL_set_fd(ssl, fd) != 1) return error.HandshakeFailed;
+        if (c.SSL_connect(ssl) != 1) return error.HandshakeFailed;
+
+        return .{ .ssl = ssl, .ctx = ctx };
+    }
+
+    pub fn deinit(self: *UpstreamTlsConn) void {
+        _ = c.SSL_shutdown(self.ssl);
+        c.SSL_free(self.ssl);
+        c.SSL_CTX_free(self.ctx);
+        self.* = undefined;
+    }
+
+    pub fn read(self: *UpstreamTlsConn, buf: []u8) TlsError!usize {
+        const rc = c.SSL_read(self.ssl, buf.ptr, @intCast(buf.len));
+        if (rc > 0) return @intCast(rc);
+        if (c.SSL_get_error(self.ssl, rc) == c.SSL_ERROR_ZERO_RETURN) return 0;
+        return error.TlsReadFailed;
+    }
+
+    pub fn writeAll(self: *UpstreamTlsConn, data: []const u8) TlsError!void {
+        var offset: usize = 0;
+        while (offset < data.len) {
+            const rc = c.SSL_write(self.ssl, data.ptr + offset, @intCast(data.len - offset));
+            if (rc <= 0) return error.TlsWriteFailed;
+            offset += @intCast(rc);
+        }
+    }
+};
 
 test "openssl init" {
     try std.testing.expect(c.OPENSSL_init_ssl(0, null) == 1);


### PR DESCRIPTION
Issue #14: PROXY protocol support for TLS listeners
- Parse PROXY protocol v1/v2 headers from raw socket using MSG_PEEK before
  SSL_accept, extracting real client IP for TLS connections
- Updated config description: mode applies to both plaintext and TLS listeners

Issue #15: Automated OCSP stapling refresh
- TlsTerminator can now periodically fetch the OCSP response directly from
  the URL in the certificate's AIA extension (no manual DER file required)
- New env vars: TARDIGRADE_TLS_OCSP_AUTO_REFRESH, TARDIGRADE_TLS_OCSP_REFRESH_INTERVAL_MS,
  TARDIGRADE_TLS_OCSP_REFRESH_TIMEOUT_MS

Issue #16: ACME certificate issuance and renewal
- New acme_client.zig: full RFC 8555 ACME client with ES256 JWS signing,
  HTTP-01 challenge fulfillment, CSR generation, and atomic cert write
- TlsTerminator maintenance loop triggers renewal when cert nears expiry
- New env vars: TARDIGRADE_TLS_ACME_DIRECTORY_URL, TARDIGRADE_TLS_ACME_DOMAINS,
  TARDIGRADE_TLS_ACME_EMAIL, TARDIGRADE_TLS_ACME_ACCOUNT_KEY_PATH,
  TARDIGRADE_TLS_ACME_RENEW_DAYS_BEFORE_EXPIRY

Issue #17: Upstream TLS verification and mTLS controls
- UpstreamTlsConn in tls_termination.zig: OpenSSL-backed client TLS connection
  supporting custom CA bundles, SNI overrides, and mutual TLS client certs
- executeUpstreamHttpsWithMtls() dispatched from handleLocationProxyPass and
  handleHttp3LocationProxyPass when client cert is configured
- New env vars: TARDIGRADE_UPSTREAM_TLS_VERIFY, TARDIGRADE_UPSTREAM_TLS_CA_BUNDLE,
  TARDIGRADE_UPSTREAM_TLS_SERVER_NAME, TARDIGRADE_UPSTREAM_TLS_CLIENT_CERT,
  TARDIGRADE_UPSTREAM_TLS_CLIENT_KEY

https://claude.ai/code/session_012VC2QQKQEKAEfBDvHog9g2