### PR TITLE
Implement HTTP/2 stream state machine, HPACK dynamic table, and flow control (#111)

### DIFF
--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -9,8 +9,6 @@ const STREAM_RELAY_BUFFER_SIZE: usize = 16 * 1024;
 const JSON_CONTENT_TYPE = "application/json";
 const HTTP2_PREFACE = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 const HTTP2_MAX_FRAME_SIZE: usize = 16 * 1024;
-const HTTP2_MAX_CONCURRENT_STREAMS: u32 = 100;
-const HTTP2_INITIAL_STREAM_RECV_WINDOW: u32 = 1024 * 1024;
 const WS_MUX_MAX_CHANNELS: usize = 32;
 /// Fallback approval TTL when no config value is provided (5 minutes).
 const APPROVAL_TIMEOUT_MS_DEFAULT: i64 = 300_000;
@@ -1540,14 +1538,19 @@ fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const
 
     const allocator = state.allocator;
 
-    // Advertise our SETTINGS: max concurrent streams and initial receive window per stream.
     try http.http2_frame.writeSettings(allocator, conn.writer(), &[_][2]u32{
-        .{ 0x3, HTTP2_MAX_CONCURRENT_STREAMS },
-        .{ 0x4, HTTP2_INITIAL_STREAM_RECV_WINDOW },
+        .{ 0x3, 100 }, // max concurrent streams
+        .{ 0x4, 1024 * 1024 }, // initial window size
     });
-
-    // pending: HTTP request data (headers, body) assembled per stream.
     var pending = std.AutoHashMap(u31, Http2PendingStream).init(allocator);
+    var stream_windows = std.AutoHashMap(u31, i32).init(allocator);
+    defer stream_windows.deinit();
+    var stream_priorities = std.AutoHashMap(u31, u8).init(allocator);
+    defer stream_priorities.deinit();
+    var ready_streams = std.array_list.Managed(u31).init(allocator);
+    defer ready_streams.deinit();
+    var next_server_stream_id: u31 = 2;
+    var conn_send_window: i32 = 65_535;
     defer {
         var it = pending.iterator();
         while (it.next()) |entry| {
@@ -1557,28 +1560,7 @@ fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const
         pending.deinit();
     }
 
-    // streams: RFC 7540 stream state and flow-control windows per stream.
-    var streams = std.AutoHashMap(u31, http.http2_stream.Stream).init(allocator);
-    defer streams.deinit();
-
-    // Stateful HPACK decoder — maintains dynamic table across HEADERS frames.
-    var decoder = http.hpack.Decoder.init();
-    defer decoder.deinit(allocator);
-
-    var ready_streams = std.array_list.Managed(u31).init(allocator);
-    defer ready_streams.deinit();
-
-    var next_server_stream_id: u31 = 2;
-    // Highest client-initiated stream ID seen; used in GOAWAY frames.
-    var last_client_stream_id: u31 = 0;
-    // Connection-level receive window (how much data the client may send us).
-    var conn_recv_window: i32 = 65_535;
-    // Connection-level send window (how much data we may send the client).
-    // Starts at the HTTP/2 default; increased by client WINDOW_UPDATE(stream=0).
-    var conn_send_window: i32 = 65_535;
-    var goaway_received = false;
-
-    while (!http.shutdown.isShutdownRequested() and !goaway_received) {
+    while (!http.shutdown.isShutdownRequested()) {
         var frame = http.http2_frame.readFrame(conn, allocator, HTTP2_MAX_FRAME_SIZE) catch |err| switch (err) {
             error.ConnectionClosed => return,
             else => return err,
@@ -1587,49 +1569,24 @@ fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const
 
         switch (frame.typ) {
             .settings => {
-                if ((frame.flags & http.http2_frame.Flags.ACK) == 0) {
-                    try http.http2_frame.writeSettingsAck(conn.writer());
-                }
+                if ((frame.flags & http.http2_frame.Flags.ACK) == 0) try http.http2_frame.writeSettingsAck(conn.writer());
             },
             .ping => {
-                if ((frame.flags & http.http2_frame.Flags.ACK) == 0) {
-                    try http.http2_frame.writePingAck(conn.writer(), frame.payload);
-                }
+                if ((frame.flags & http.http2_frame.Flags.ACK) == 0) try http.http2_frame.writePingAck(conn.writer(), frame.payload);
             },
             .headers => {
-                if (frame.stream_id == 0) {
-                    try http.http2_frame.writeGoaway(conn.writer(), last_client_stream_id, http.http2_stream.ErrorCode.protocol_error.value());
-                    return error.Http2ProtocolError;
-                }
-
-                // Enforce maximum concurrent streams to bound memory usage.
-                if (countOpenStreams(&streams) >= HTTP2_MAX_CONCURRENT_STREAMS) {
-                    try http.http2_frame.writeRstStream(conn.writer(), frame.stream_id, http.http2_stream.ErrorCode.refused_stream.value());
-                    continue;
-                }
-
-                last_client_stream_id = @max(last_client_stream_id, frame.stream_id);
-
+                if (frame.stream_id == 0) return error.InvalidHttp2StreamId;
                 var payload_offset: usize = 0;
-                var priority_weight: u8 = 16;
                 if ((frame.flags & http.http2_frame.Flags.PRIORITY) != 0) {
-                    if (frame.payload.len < 5) {
-                        try http.http2_frame.writeGoaway(conn.writer(), last_client_stream_id, http.http2_stream.ErrorCode.frame_size_error.value());
-                        return error.Http2ProtocolError;
-                    }
                     const pr = try http.http2_frame.parsePriority(frame.payload);
-                    priority_weight = pr.weight;
+                    try stream_priorities.put(frame.stream_id, pr.weight);
                     payload_offset = 5;
                 }
-
-                var decoded = decoder.decode(allocator, frame.payload[payload_offset..]) catch {
-                    try http.http2_frame.writeGoaway(conn.writer(), last_client_stream_id, http.http2_stream.ErrorCode.compression_error.value());
-                    return error.Http2CompressionError;
-                };
+                var decoded = try http.hpack.decode(allocator, frame.payload[payload_offset..]);
                 defer http.hpack.deinitDecoded(allocator, &decoded);
 
                 var ps = pending.get(frame.stream_id) orelse Http2PendingStream.init(allocator);
-                ps.priority_weight = priority_weight;
+                ps.priority_weight = stream_priorities.get(frame.stream_id) orelse ps.priority_weight;
                 for (decoded.headers) |h| {
                     if (std.mem.eql(u8, h.name, ":method")) {
                         if (ps.method) |m| allocator.free(m);
@@ -1642,136 +1599,77 @@ fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const
                     }
                 }
                 try pending.put(frame.stream_id, ps);
-
-                // Register stream state on first HEADERS for this stream.
-                if (!streams.contains(frame.stream_id)) {
-                    try streams.put(frame.stream_id, http.http2_stream.Stream.init(frame.stream_id, conn_send_window));
-                }
-                if (streams.getPtr(frame.stream_id)) |s| s.priority_weight = priority_weight;
+                _ = try stream_windows.getOrPutValue(frame.stream_id, 65_535);
 
                 if ((frame.flags & http.http2_frame.Flags.END_STREAM) != 0) {
-                    if (streams.getPtr(frame.stream_id)) |s| s.remoteEndStream() catch {}; // ignore: state already half-closed-remote from a prior frame
                     try ready_streams.append(frame.stream_id);
                 }
             },
             .data => {
-                if (frame.stream_id == 0) {
-                    try http.http2_frame.writeGoaway(conn.writer(), last_client_stream_id, http.http2_stream.ErrorCode.protocol_error.value());
-                    return error.Http2ProtocolError;
-                }
-
-                const stream_ptr = streams.getPtr(frame.stream_id);
-                if (stream_ptr == null or !stream_ptr.?.canReceive()) {
-                    // DATA on a closed or non-existent stream.
-                    try http.http2_frame.writeRstStream(conn.writer(), frame.stream_id, http.http2_stream.ErrorCode.stream_closed.value());
-                    continue;
-                }
-
-                // Enforce bounded request body size.
-                const ps_ptr = pending.getPtr(frame.stream_id);
-                if (ps_ptr == null) {
-                    try http.http2_frame.writeRstStream(conn.writer(), frame.stream_id, http.http2_stream.ErrorCode.stream_closed.value());
-                    continue;
-                }
-                if (ps_ptr.?.body.items.len + frame.payload.len > MAX_REQUEST_SIZE) {
-                    try http.http2_frame.writeRstStream(conn.writer(), frame.stream_id, http.http2_stream.ErrorCode.cancel.value());
-                    _ = streams.remove(frame.stream_id);
-                    if (pending.fetchRemove(frame.stream_id)) |removed| {
-                        var tmp = removed.value;
-                        tmp.deinit(allocator);
+                if (frame.stream_id == 0) return error.InvalidHttp2StreamId;
+                if (stream_windows.getPtr(frame.stream_id)) |sw| sw.* -= @intCast(frame.payload.len);
+                conn_send_window -= @intCast(frame.payload.len);
+                if (pending.getPtr(frame.stream_id)) |ps| {
+                    try ps.body.appendSlice(frame.payload);
+                    try http.http2_frame.writeWindowUpdate(conn.writer(), frame.stream_id, @intCast(frame.payload.len));
+                    try http.http2_frame.writeWindowUpdate(conn.writer(), 0, @intCast(frame.payload.len));
+                    if (stream_windows.getPtr(frame.stream_id)) |sw| sw.* += @intCast(frame.payload.len);
+                    conn_send_window += @intCast(frame.payload.len);
+                    if ((frame.flags & http.http2_frame.Flags.END_STREAM) != 0) {
+                        try ready_streams.append(frame.stream_id);
                     }
-                    continue;
-                }
-
-                // Debit receive windows.
-                conn_recv_window -= @intCast(frame.payload.len);
-                stream_ptr.?.recv_window -= @intCast(frame.payload.len);
-
-                try ps_ptr.?.body.appendSlice(frame.payload);
-
-                // Immediately replenish receive windows so the client can keep sending.
-                try http.http2_frame.writeWindowUpdate(conn.writer(), frame.stream_id, @intCast(frame.payload.len));
-                try http.http2_frame.writeWindowUpdate(conn.writer(), 0, @intCast(frame.payload.len));
-                conn_recv_window += @intCast(frame.payload.len);
-                stream_ptr.?.recv_window += @intCast(frame.payload.len);
-
-                if ((frame.flags & http.http2_frame.Flags.END_STREAM) != 0) {
-                    stream_ptr.?.remoteEndStream() catch {}; // ignore: duplicate END_STREAM on same stream is benign
-                    try ready_streams.append(frame.stream_id);
+                } else {
+                    try http.http2_frame.writeGoaway(conn.writer(), frame.stream_id, 1);
+                    return;
                 }
             },
             .priority => {
                 const pr = try http.http2_frame.parsePriority(frame.payload);
-                if (streams.getPtr(frame.stream_id)) |s| s.priority_weight = pr.weight;
+                try stream_priorities.put(frame.stream_id, pr.weight);
                 if (pending.getPtr(frame.stream_id)) |ps| ps.priority_weight = pr.weight;
             },
             .window_update => {
-                if (http.http2_frame.parseWindowUpdateIncrement(frame.payload)) |inc| {
-                    if (frame.stream_id == 0) {
-                        conn_send_window += @intCast(inc);
-                    } else {
-                        if (streams.getPtr(frame.stream_id)) |s| s.send_window += @intCast(inc);
-                    }
-                } else |_| {
-                    if (frame.stream_id == 0) {
-                        try http.http2_frame.writeGoaway(conn.writer(), last_client_stream_id, http.http2_stream.ErrorCode.protocol_error.value());
-                        return error.Http2ProtocolError;
-                    }
-                    try http.http2_frame.writeRstStream(conn.writer(), frame.stream_id, http.http2_stream.ErrorCode.protocol_error.value());
+                const inc = try http.http2_frame.parseWindowUpdateIncrement(frame.payload);
+                if (frame.stream_id == 0) {
+                    conn_send_window += @intCast(inc);
+                } else {
+                    const gop = try stream_windows.getOrPutValue(frame.stream_id, 65_535);
+                    gop.value_ptr.* += @intCast(inc);
                 }
             },
             .rst_stream => {
-                if (streams.getPtr(frame.stream_id)) |s| s.close();
-                _ = streams.remove(frame.stream_id);
                 if (pending.fetchRemove(frame.stream_id)) |removed| {
                     var tmp = removed.value;
                     tmp.deinit(allocator);
                 }
+                _ = stream_windows.remove(frame.stream_id);
+                _ = stream_priorities.remove(frame.stream_id);
             },
-            .goaway => {
-                goaway_received = true;
-            },
-            .continuation, .push_promise => {},
+            .continuation, .push_promise, .goaway => {},
         }
 
-        // Dispatch ready streams in priority order (highest weight first).
         while (ready_streams.items.len > 0) {
             var best_idx: usize = 0;
             var best_weight: u8 = 0;
             for (ready_streams.items, 0..) |sid, idx| {
-                const w = if (streams.get(sid)) |s| s.priority_weight else 16;
+                const w = stream_priorities.get(sid) orelse 16;
                 if (w >= best_weight) {
                     best_weight = w;
                     best_idx = idx;
                 }
             }
             const sid = ready_streams.swapRemove(best_idx);
-            const stream_send = if (streams.get(sid)) |s| s.send_window else conn_send_window;
             if (pending.getPtr(sid)) |ps| {
-                try respondHttp2Stream(conn.writer(), allocator, state, cfg, sid, ps, &next_server_stream_id, &conn_send_window, stream_send);
+                try respondHttp2Stream(conn.writer(), allocator, state, cfg, sid, ps, &next_server_stream_id);
             }
-            if (streams.getPtr(sid)) |s| s.localEndStream() catch {}; // ignore: stream may already be half-closed or closed
-            _ = streams.remove(sid);
             if (pending.fetchRemove(sid)) |removed| {
                 var tmp = removed.value;
                 tmp.deinit(allocator);
             }
+            _ = stream_windows.remove(sid);
+            _ = stream_priorities.remove(sid);
         }
     }
-
-    // Send GOAWAY on clean shutdown so the client knows the last processed stream.
-    http.http2_frame.writeGoaway(conn.writer(), last_client_stream_id, http.http2_stream.ErrorCode.no_error.value()) catch {}; // best-effort: connection is closing regardless
-}
-
-/// Count streams that are still open (remote can still send data).
-fn countOpenStreams(streams: *std.AutoHashMap(u31, http.http2_stream.Stream)) u32 {
-    var count: u32 = 0;
-    var it = streams.iterator();
-    while (it.next()) |entry| {
-        const state = entry.value_ptr.state;
-        if (state == .open or state == .half_closed_local) count += 1;
-    }
-    return count;
 }
 
 fn respondHttp2Stream(
@@ -1782,19 +1680,10 @@ fn respondHttp2Stream(
     stream_id: u31,
     ps: *const Http2PendingStream,
     next_server_stream_id: *u31,
-    conn_send_window: *i32,
-    stream_send_window: i32,
 ) !void {
     _ = next_server_stream_id;
     const method = ps.method orelse return error.InvalidHttp2Request;
     const path = ps.path orelse return error.InvalidHttp2Request;
-
-    var lifecycle = http.request_lifecycle.RequestLifecycle.init(
-        "h2",
-        cfg.request_total_timeout_ms,
-    );
-    if (lifecycle.checkDeadline(.headers_read)) return error.RequestTimeout;
-
     const correlation_id = try http.correlation.generate(allocator);
     defer allocator.free(correlation_id);
 
@@ -1837,22 +1726,13 @@ fn respondHttp2Stream(
         stream_id,
         header_block,
     );
-
-    // Respect flow-control windows: only send as much as both windows allow.
-    const effective_window: i32 = @min(conn_send_window.*, stream_send_window);
-    const send_len: usize = if (effective_window > 0)
-        @min(body.len, @as(usize, @intCast(effective_window)))
-    else
-        0;
-
     try http.http2_frame.writeFrame(
         writer,
         .data,
         http.http2_frame.Flags.END_STREAM,
         stream_id,
-        body[0..send_len],
+        body,
     );
-    conn_send_window.* -= @intCast(send_len);
 
     state.metricsRecord(status_code);
 }

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -9,6 +9,8 @@ const STREAM_RELAY_BUFFER_SIZE: usize = 16 * 1024;
 const JSON_CONTENT_TYPE = "application/json";
 const HTTP2_PREFACE = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 const HTTP2_MAX_FRAME_SIZE: usize = 16 * 1024;
+const HTTP2_MAX_CONCURRENT_STREAMS: u32 = 100;
+const HTTP2_INITIAL_STREAM_RECV_WINDOW: u32 = 1024 * 1024;
 const WS_MUX_MAX_CHANNELS: usize = 32;
 /// Fallback approval TTL when no config value is provided (5 minutes).
 const APPROVAL_TIMEOUT_MS_DEFAULT: i64 = 300_000;
@@ -1538,19 +1540,14 @@ fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const
 
     const allocator = state.allocator;
 
+    // Advertise our SETTINGS: max concurrent streams and initial receive window per stream.
     try http.http2_frame.writeSettings(allocator, conn.writer(), &[_][2]u32{
-        .{ 0x3, 100 }, // max concurrent streams
-        .{ 0x4, 1024 * 1024 }, // initial window size
+        .{ 0x3, HTTP2_MAX_CONCURRENT_STREAMS },
+        .{ 0x4, HTTP2_INITIAL_STREAM_RECV_WINDOW },
     });
+
+    // pending: HTTP request data (headers, body) assembled per stream.
     var pending = std.AutoHashMap(u31, Http2PendingStream).init(allocator);
-    var stream_windows = std.AutoHashMap(u31, i32).init(allocator);
-    defer stream_windows.deinit();
-    var stream_priorities = std.AutoHashMap(u31, u8).init(allocator);
-    defer stream_priorities.deinit();
-    var ready_streams = std.array_list.Managed(u31).init(allocator);
-    defer ready_streams.deinit();
-    var next_server_stream_id: u31 = 2;
-    var conn_send_window: i32 = 65_535;
     defer {
         var it = pending.iterator();
         while (it.next()) |entry| {
@@ -1560,7 +1557,28 @@ fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const
         pending.deinit();
     }
 
-    while (!http.shutdown.isShutdownRequested()) {
+    // streams: RFC 7540 stream state and flow-control windows per stream.
+    var streams = std.AutoHashMap(u31, http.http2_stream.Stream).init(allocator);
+    defer streams.deinit();
+
+    // Stateful HPACK decoder — maintains dynamic table across HEADERS frames.
+    var decoder = http.hpack.Decoder.init();
+    defer decoder.deinit(allocator);
+
+    var ready_streams = std.array_list.Managed(u31).init(allocator);
+    defer ready_streams.deinit();
+
+    var next_server_stream_id: u31 = 2;
+    // Highest client-initiated stream ID seen; used in GOAWAY frames.
+    var last_client_stream_id: u31 = 0;
+    // Connection-level receive window (how much data the client may send us).
+    var conn_recv_window: i32 = 65_535;
+    // Connection-level send window (how much data we may send the client).
+    // Starts at the HTTP/2 default; increased by client WINDOW_UPDATE(stream=0).
+    var conn_send_window: i32 = 65_535;
+    var goaway_received = false;
+
+    while (!http.shutdown.isShutdownRequested() and !goaway_received) {
         var frame = http.http2_frame.readFrame(conn, allocator, HTTP2_MAX_FRAME_SIZE) catch |err| switch (err) {
             error.ConnectionClosed => return,
             else => return err,
@@ -1569,24 +1587,49 @@ fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const
 
         switch (frame.typ) {
             .settings => {
-                if ((frame.flags & http.http2_frame.Flags.ACK) == 0) try http.http2_frame.writeSettingsAck(conn.writer());
+                if ((frame.flags & http.http2_frame.Flags.ACK) == 0) {
+                    try http.http2_frame.writeSettingsAck(conn.writer());
+                }
             },
             .ping => {
-                if ((frame.flags & http.http2_frame.Flags.ACK) == 0) try http.http2_frame.writePingAck(conn.writer(), frame.payload);
+                if ((frame.flags & http.http2_frame.Flags.ACK) == 0) {
+                    try http.http2_frame.writePingAck(conn.writer(), frame.payload);
+                }
             },
             .headers => {
-                if (frame.stream_id == 0) return error.InvalidHttp2StreamId;
+                if (frame.stream_id == 0) {
+                    try http.http2_frame.writeGoaway(conn.writer(), last_client_stream_id, http.http2_stream.ErrorCode.protocol_error.value());
+                    return error.Http2ProtocolError;
+                }
+
+                // Enforce maximum concurrent streams to bound memory usage.
+                if (countOpenStreams(&streams) >= HTTP2_MAX_CONCURRENT_STREAMS) {
+                    try http.http2_frame.writeRstStream(conn.writer(), frame.stream_id, http.http2_stream.ErrorCode.refused_stream.value());
+                    continue;
+                }
+
+                last_client_stream_id = @max(last_client_stream_id, frame.stream_id);
+
                 var payload_offset: usize = 0;
+                var priority_weight: u8 = 16;
                 if ((frame.flags & http.http2_frame.Flags.PRIORITY) != 0) {
+                    if (frame.payload.len < 5) {
+                        try http.http2_frame.writeGoaway(conn.writer(), last_client_stream_id, http.http2_stream.ErrorCode.frame_size_error.value());
+                        return error.Http2ProtocolError;
+                    }
                     const pr = try http.http2_frame.parsePriority(frame.payload);
-                    try stream_priorities.put(frame.stream_id, pr.weight);
+                    priority_weight = pr.weight;
                     payload_offset = 5;
                 }
-                var decoded = try http.hpack.decode(allocator, frame.payload[payload_offset..]);
+
+                var decoded = decoder.decode(allocator, frame.payload[payload_offset..]) catch {
+                    try http.http2_frame.writeGoaway(conn.writer(), last_client_stream_id, http.http2_stream.ErrorCode.compression_error.value());
+                    return error.Http2CompressionError;
+                };
                 defer http.hpack.deinitDecoded(allocator, &decoded);
 
                 var ps = pending.get(frame.stream_id) orelse Http2PendingStream.init(allocator);
-                ps.priority_weight = stream_priorities.get(frame.stream_id) orelse ps.priority_weight;
+                ps.priority_weight = priority_weight;
                 for (decoded.headers) |h| {
                     if (std.mem.eql(u8, h.name, ":method")) {
                         if (ps.method) |m| allocator.free(m);
@@ -1599,77 +1642,136 @@ fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const
                     }
                 }
                 try pending.put(frame.stream_id, ps);
-                _ = try stream_windows.getOrPutValue(frame.stream_id, 65_535);
+
+                // Register stream state on first HEADERS for this stream.
+                if (!streams.contains(frame.stream_id)) {
+                    try streams.put(frame.stream_id, http.http2_stream.Stream.init(frame.stream_id, conn_send_window));
+                }
+                if (streams.getPtr(frame.stream_id)) |s| s.priority_weight = priority_weight;
 
                 if ((frame.flags & http.http2_frame.Flags.END_STREAM) != 0) {
+                    if (streams.getPtr(frame.stream_id)) |s| s.remoteEndStream() catch {}; // ignore: state already half-closed-remote from a prior frame
                     try ready_streams.append(frame.stream_id);
                 }
             },
             .data => {
-                if (frame.stream_id == 0) return error.InvalidHttp2StreamId;
-                if (stream_windows.getPtr(frame.stream_id)) |sw| sw.* -= @intCast(frame.payload.len);
-                conn_send_window -= @intCast(frame.payload.len);
-                if (pending.getPtr(frame.stream_id)) |ps| {
-                    try ps.body.appendSlice(frame.payload);
-                    try http.http2_frame.writeWindowUpdate(conn.writer(), frame.stream_id, @intCast(frame.payload.len));
-                    try http.http2_frame.writeWindowUpdate(conn.writer(), 0, @intCast(frame.payload.len));
-                    if (stream_windows.getPtr(frame.stream_id)) |sw| sw.* += @intCast(frame.payload.len);
-                    conn_send_window += @intCast(frame.payload.len);
-                    if ((frame.flags & http.http2_frame.Flags.END_STREAM) != 0) {
-                        try ready_streams.append(frame.stream_id);
+                if (frame.stream_id == 0) {
+                    try http.http2_frame.writeGoaway(conn.writer(), last_client_stream_id, http.http2_stream.ErrorCode.protocol_error.value());
+                    return error.Http2ProtocolError;
+                }
+
+                const stream_ptr = streams.getPtr(frame.stream_id);
+                if (stream_ptr == null or !stream_ptr.?.canReceive()) {
+                    // DATA on a closed or non-existent stream.
+                    try http.http2_frame.writeRstStream(conn.writer(), frame.stream_id, http.http2_stream.ErrorCode.stream_closed.value());
+                    continue;
+                }
+
+                // Enforce bounded request body size.
+                const ps_ptr = pending.getPtr(frame.stream_id);
+                if (ps_ptr == null) {
+                    try http.http2_frame.writeRstStream(conn.writer(), frame.stream_id, http.http2_stream.ErrorCode.stream_closed.value());
+                    continue;
+                }
+                if (ps_ptr.?.body.items.len + frame.payload.len > MAX_REQUEST_SIZE) {
+                    try http.http2_frame.writeRstStream(conn.writer(), frame.stream_id, http.http2_stream.ErrorCode.cancel.value());
+                    _ = streams.remove(frame.stream_id);
+                    if (pending.fetchRemove(frame.stream_id)) |removed| {
+                        var tmp = removed.value;
+                        tmp.deinit(allocator);
                     }
-                } else {
-                    try http.http2_frame.writeGoaway(conn.writer(), frame.stream_id, 1);
-                    return;
+                    continue;
+                }
+
+                // Debit receive windows.
+                conn_recv_window -= @intCast(frame.payload.len);
+                stream_ptr.?.recv_window -= @intCast(frame.payload.len);
+
+                try ps_ptr.?.body.appendSlice(frame.payload);
+
+                // Immediately replenish receive windows so the client can keep sending.
+                try http.http2_frame.writeWindowUpdate(conn.writer(), frame.stream_id, @intCast(frame.payload.len));
+                try http.http2_frame.writeWindowUpdate(conn.writer(), 0, @intCast(frame.payload.len));
+                conn_recv_window += @intCast(frame.payload.len);
+                stream_ptr.?.recv_window += @intCast(frame.payload.len);
+
+                if ((frame.flags & http.http2_frame.Flags.END_STREAM) != 0) {
+                    stream_ptr.?.remoteEndStream() catch {}; // ignore: duplicate END_STREAM on same stream is benign
+                    try ready_streams.append(frame.stream_id);
                 }
             },
             .priority => {
                 const pr = try http.http2_frame.parsePriority(frame.payload);
-                try stream_priorities.put(frame.stream_id, pr.weight);
+                if (streams.getPtr(frame.stream_id)) |s| s.priority_weight = pr.weight;
                 if (pending.getPtr(frame.stream_id)) |ps| ps.priority_weight = pr.weight;
             },
             .window_update => {
-                const inc = try http.http2_frame.parseWindowUpdateIncrement(frame.payload);
-                if (frame.stream_id == 0) {
-                    conn_send_window += @intCast(inc);
-                } else {
-                    const gop = try stream_windows.getOrPutValue(frame.stream_id, 65_535);
-                    gop.value_ptr.* += @intCast(inc);
+                if (http.http2_frame.parseWindowUpdateIncrement(frame.payload)) |inc| {
+                    if (frame.stream_id == 0) {
+                        conn_send_window += @intCast(inc);
+                    } else {
+                        if (streams.getPtr(frame.stream_id)) |s| s.send_window += @intCast(inc);
+                    }
+                } else |_| {
+                    if (frame.stream_id == 0) {
+                        try http.http2_frame.writeGoaway(conn.writer(), last_client_stream_id, http.http2_stream.ErrorCode.protocol_error.value());
+                        return error.Http2ProtocolError;
+                    }
+                    try http.http2_frame.writeRstStream(conn.writer(), frame.stream_id, http.http2_stream.ErrorCode.protocol_error.value());
                 }
             },
             .rst_stream => {
+                if (streams.getPtr(frame.stream_id)) |s| s.close();
+                _ = streams.remove(frame.stream_id);
                 if (pending.fetchRemove(frame.stream_id)) |removed| {
                     var tmp = removed.value;
                     tmp.deinit(allocator);
                 }
-                _ = stream_windows.remove(frame.stream_id);
-                _ = stream_priorities.remove(frame.stream_id);
             },
-            .continuation, .push_promise, .goaway => {},
+            .goaway => {
+                goaway_received = true;
+            },
+            .continuation, .push_promise => {},
         }
 
+        // Dispatch ready streams in priority order (highest weight first).
         while (ready_streams.items.len > 0) {
             var best_idx: usize = 0;
             var best_weight: u8 = 0;
             for (ready_streams.items, 0..) |sid, idx| {
-                const w = stream_priorities.get(sid) orelse 16;
+                const w = if (streams.get(sid)) |s| s.priority_weight else 16;
                 if (w >= best_weight) {
                     best_weight = w;
                     best_idx = idx;
                 }
             }
             const sid = ready_streams.swapRemove(best_idx);
+            const stream_send = if (streams.get(sid)) |s| s.send_window else conn_send_window;
             if (pending.getPtr(sid)) |ps| {
-                try respondHttp2Stream(conn.writer(), allocator, state, cfg, sid, ps, &next_server_stream_id);
+                try respondHttp2Stream(conn.writer(), allocator, state, cfg, sid, ps, &next_server_stream_id, &conn_send_window, stream_send);
             }
+            if (streams.getPtr(sid)) |s| s.localEndStream() catch {}; // ignore: stream may already be half-closed or closed
+            _ = streams.remove(sid);
             if (pending.fetchRemove(sid)) |removed| {
                 var tmp = removed.value;
                 tmp.deinit(allocator);
             }
-            _ = stream_windows.remove(sid);
-            _ = stream_priorities.remove(sid);
         }
     }
+
+    // Send GOAWAY on clean shutdown so the client knows the last processed stream.
+    http.http2_frame.writeGoaway(conn.writer(), last_client_stream_id, http.http2_stream.ErrorCode.no_error.value()) catch {}; // best-effort: connection is closing regardless
+}
+
+/// Count streams that are still open (remote can still send data).
+fn countOpenStreams(streams: *const std.AutoHashMap(u31, http.http2_stream.Stream)) u32 {
+    var count: u32 = 0;
+    var it = streams.iterator();
+    while (it.next()) |entry| {
+        const state = entry.value_ptr.state;
+        if (state == .open or state == .half_closed_local) count += 1;
+    }
+    return count;
 }
 
 fn respondHttp2Stream(
@@ -1680,10 +1782,19 @@ fn respondHttp2Stream(
     stream_id: u31,
     ps: *const Http2PendingStream,
     next_server_stream_id: *u31,
+    conn_send_window: *i32,
+    stream_send_window: i32,
 ) !void {
     _ = next_server_stream_id;
     const method = ps.method orelse return error.InvalidHttp2Request;
     const path = ps.path orelse return error.InvalidHttp2Request;
+
+    var lifecycle = http.request_lifecycle.RequestLifecycle.init(
+        "h2",
+        cfg.request_total_timeout_ms,
+    );
+    if (lifecycle.checkDeadline(.headers_read)) return error.RequestTimeout;
+
     const correlation_id = try http.correlation.generate(allocator);
     defer allocator.free(correlation_id);
 
@@ -1726,13 +1837,22 @@ fn respondHttp2Stream(
         stream_id,
         header_block,
     );
+
+    // Respect flow-control windows: only send as much as both windows allow.
+    const effective_window: i32 = @min(conn_send_window.*, stream_send_window);
+    const send_len: usize = if (effective_window > 0)
+        @min(body.len, @as(usize, @intCast(effective_window)))
+    else
+        0;
+
     try http.http2_frame.writeFrame(
         writer,
         .data,
         http.http2_frame.Flags.END_STREAM,
         stream_id,
-        body,
+        body[0..send_len],
     );
+    conn_send_window.* -= @intCast(send_len);
 
     state.metricsRecord(status_code);
 }

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -1542,15 +1542,19 @@ fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const
         .{ 0x3, 100 }, // max concurrent streams
         .{ 0x4, 1024 * 1024 }, // initial window size
     });
+
+    var decoder = http.hpack.Decoder.init();
+    defer decoder.deinit(allocator);
+
     var pending = std.AutoHashMap(u31, Http2PendingStream).init(allocator);
-    var stream_windows = std.AutoHashMap(u31, i32).init(allocator);
-    defer stream_windows.deinit();
-    var stream_priorities = std.AutoHashMap(u31, u8).init(allocator);
-    defer stream_priorities.deinit();
+    var streams = std.AutoHashMap(u31, http.http2_stream.Stream).init(allocator);
+    defer streams.deinit();
     var ready_streams = std.array_list.Managed(u31).init(allocator);
     defer ready_streams.deinit();
     var next_server_stream_id: u31 = 2;
     var conn_send_window: i32 = 65_535;
+    var last_client_stream_id: u31 = 0;
+    var goaway_received = false;
     defer {
         var it = pending.iterator();
         while (it.next()) |entry| {
@@ -1560,7 +1564,7 @@ fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const
         pending.deinit();
     }
 
-    while (!http.shutdown.isShutdownRequested()) {
+    while (!http.shutdown.isShutdownRequested() and !goaway_received) {
         var frame = http.http2_frame.readFrame(conn, allocator, HTTP2_MAX_FRAME_SIZE) catch |err| switch (err) {
             error.ConnectionClosed => return,
             else => return err,
@@ -1576,17 +1580,23 @@ fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const
             },
             .headers => {
                 if (frame.stream_id == 0) return error.InvalidHttp2StreamId;
+                last_client_stream_id = @max(last_client_stream_id, frame.stream_id);
+                if (!streams.contains(frame.stream_id)) {
+                    try streams.put(frame.stream_id, http.http2_stream.Stream.init(frame.stream_id, 65_535));
+                }
                 var payload_offset: usize = 0;
                 if ((frame.flags & http.http2_frame.Flags.PRIORITY) != 0) {
                     const pr = try http.http2_frame.parsePriority(frame.payload);
-                    try stream_priorities.put(frame.stream_id, pr.weight);
+                    if (streams.getPtr(frame.stream_id)) |s| s.priority_weight = pr.weight;
                     payload_offset = 5;
                 }
-                var decoded = try http.hpack.decode(allocator, frame.payload[payload_offset..]);
+                var decoded = decoder.decode(allocator, frame.payload[payload_offset..]) catch {
+                    try http.http2_frame.writeGoaway(conn.writer(), last_client_stream_id, http.http2_stream.ErrorCode.compression_error.value());
+                    return error.Http2CompressionError;
+                };
                 defer http.hpack.deinitDecoded(allocator, &decoded);
-
                 var ps = pending.get(frame.stream_id) orelse Http2PendingStream.init(allocator);
-                ps.priority_weight = stream_priorities.get(frame.stream_id) orelse ps.priority_weight;
+                if (streams.get(frame.stream_id)) |s| ps.priority_weight = s.priority_weight;
                 for (decoded.headers) |h| {
                     if (std.mem.eql(u8, h.name, ":method")) {
                         if (ps.method) |m| allocator.free(m);
@@ -1599,23 +1609,23 @@ fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const
                     }
                 }
                 try pending.put(frame.stream_id, ps);
-                _ = try stream_windows.getOrPutValue(frame.stream_id, 65_535);
-
                 if ((frame.flags & http.http2_frame.Flags.END_STREAM) != 0) {
+                    if (streams.getPtr(frame.stream_id)) |s| s.remoteEndStream() catch {};
                     try ready_streams.append(frame.stream_id);
                 }
             },
             .data => {
                 if (frame.stream_id == 0) return error.InvalidHttp2StreamId;
-                if (stream_windows.getPtr(frame.stream_id)) |sw| sw.* -= @intCast(frame.payload.len);
+                if (streams.getPtr(frame.stream_id)) |s| s.send_window -= @intCast(frame.payload.len);
                 conn_send_window -= @intCast(frame.payload.len);
                 if (pending.getPtr(frame.stream_id)) |ps| {
                     try ps.body.appendSlice(frame.payload);
                     try http.http2_frame.writeWindowUpdate(conn.writer(), frame.stream_id, @intCast(frame.payload.len));
                     try http.http2_frame.writeWindowUpdate(conn.writer(), 0, @intCast(frame.payload.len));
-                    if (stream_windows.getPtr(frame.stream_id)) |sw| sw.* += @intCast(frame.payload.len);
+                    if (streams.getPtr(frame.stream_id)) |s| s.send_window += @intCast(frame.payload.len);
                     conn_send_window += @intCast(frame.payload.len);
                     if ((frame.flags & http.http2_frame.Flags.END_STREAM) != 0) {
+                        if (streams.getPtr(frame.stream_id)) |s| s.remoteEndStream() catch {};
                         try ready_streams.append(frame.stream_id);
                     }
                 } else {
@@ -1625,7 +1635,7 @@ fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const
             },
             .priority => {
                 const pr = try http.http2_frame.parsePriority(frame.payload);
-                try stream_priorities.put(frame.stream_id, pr.weight);
+                if (streams.getPtr(frame.stream_id)) |s| s.priority_weight = pr.weight;
                 if (pending.getPtr(frame.stream_id)) |ps| ps.priority_weight = pr.weight;
             },
             .window_update => {
@@ -1633,8 +1643,7 @@ fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const
                 if (frame.stream_id == 0) {
                     conn_send_window += @intCast(inc);
                 } else {
-                    const gop = try stream_windows.getOrPutValue(frame.stream_id, 65_535);
-                    gop.value_ptr.* += @intCast(inc);
+                    if (streams.getPtr(frame.stream_id)) |s| s.send_window += @intCast(inc);
                 }
             },
             .rst_stream => {
@@ -1642,34 +1651,46 @@ fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const
                     var tmp = removed.value;
                     tmp.deinit(allocator);
                 }
-                _ = stream_windows.remove(frame.stream_id);
-                _ = stream_priorities.remove(frame.stream_id);
+                _ = streams.remove(frame.stream_id);
             },
-            .continuation, .push_promise, .goaway => {},
+            .goaway => {
+                goaway_received = true;
+            },
+            .continuation, .push_promise => {},
         }
 
         while (ready_streams.items.len > 0) {
             var best_idx: usize = 0;
             var best_weight: u8 = 0;
             for (ready_streams.items, 0..) |sid, idx| {
-                const w = stream_priorities.get(sid) orelse 16;
+                const w = if (streams.get(sid)) |s| s.priority_weight else 16;
                 if (w >= best_weight) {
                     best_weight = w;
                     best_idx = idx;
                 }
             }
             const sid = ready_streams.swapRemove(best_idx);
+            const stream_send = if (streams.get(sid)) |s| s.send_window else conn_send_window;
             if (pending.getPtr(sid)) |ps| {
-                try respondHttp2Stream(conn.writer(), allocator, state, cfg, sid, ps, &next_server_stream_id);
+                try respondHttp2Stream(conn.writer(), allocator, state, cfg, sid, ps, &next_server_stream_id, &conn_send_window, stream_send);
             }
             if (pending.fetchRemove(sid)) |removed| {
                 var tmp = removed.value;
                 tmp.deinit(allocator);
             }
-            _ = stream_windows.remove(sid);
-            _ = stream_priorities.remove(sid);
+            _ = streams.remove(sid);
         }
     }
+}
+
+fn countOpenStreams(streams: *std.AutoHashMap(u31, http.http2_stream.Stream)) u32 {
+    var count: u32 = 0;
+    var it = streams.iterator();
+    while (it.next()) |entry| {
+        const st = entry.value_ptr.state;
+        if (st == .open or st == .half_closed_local) count += 1;
+    }
+    return count;
 }
 
 fn respondHttp2Stream(
@@ -1680,12 +1701,20 @@ fn respondHttp2Stream(
     stream_id: u31,
     ps: *const Http2PendingStream,
     next_server_stream_id: *u31,
+    conn_send_window: *i32,
+    stream_send_window: i32,
 ) !void {
     _ = next_server_stream_id;
     const method = ps.method orelse return error.InvalidHttp2Request;
     const path = ps.path orelse return error.InvalidHttp2Request;
     const correlation_id = try http.correlation.generate(allocator);
     defer allocator.free(correlation_id);
+
+    var lifecycle = http.request_lifecycle.RequestLifecycle.init(
+        correlation_id,
+        cfg.request_total_timeout_ms,
+    );
+    if (lifecycle.checkDeadline(.headers_read)) return error.RequestTimeout;
 
     var status_code: u16 = 404;
     var body: []const u8 = "{\"error\":\"Not Found\"}";
@@ -1695,7 +1724,6 @@ fn respondHttp2Stream(
 
     _ = method;
     _ = path;
-    _ = cfg;
 
     status_code = 404;
     body = "{\"error\":\"not_found\"}";
@@ -1726,13 +1754,14 @@ fn respondHttp2Stream(
         stream_id,
         header_block,
     );
-    try http.http2_frame.writeFrame(
-        writer,
-        .data,
-        http.http2_frame.Flags.END_STREAM,
-        stream_id,
-        body,
-    );
+
+    const effective_window: i32 = @min(conn_send_window.*, stream_send_window);
+    const send_len: usize = if (effective_window > 0)
+        @min(body.len, @as(usize, @intCast(effective_window)))
+    else
+        0;
+    try http.http2_frame.writeFrame(writer, .data, http.http2_frame.Flags.END_STREAM, stream_id, body[0..send_len]);
+    conn_send_window.* -= @intCast(send_len);
 
     state.metricsRecord(status_code);
 }

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -1764,7 +1764,7 @@ fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const
 }
 
 /// Count streams that are still open (remote can still send data).
-fn countOpenStreams(streams: *const std.AutoHashMap(u31, http.http2_stream.Stream)) u32 {
+fn countOpenStreams(streams: *std.AutoHashMap(u31, http.http2_stream.Stream)) u32 {
     var count: u32 = 0;
     var it = streams.iterator();
     while (it.next()) |entry| {

--- a/src/http.zig
+++ b/src/http.zig
@@ -49,6 +49,7 @@ pub const tls_termination = @import("http/tls_termination.zig");
 pub const acme_client = @import("http/acme_client.zig");
 pub const hpack = @import("http/hpack.zig");
 pub const http2_frame = @import("http/http2_frame.zig");
+pub const http2_stream = @import("http/http2_stream.zig");
 pub const ngtcp2_binding = @import("http/ngtcp2_binding.zig");
 pub const http3_handler = @import("http/http3_handler.zig");
 pub const http3_session = @import("http/http3_session.zig");

--- a/src/http/hpack.zig
+++ b/src/http/hpack.zig
@@ -14,6 +14,100 @@ const StaticEntry = struct {
     value: []const u8,
 };
 
+const DYNAMIC_TABLE_ENTRY_OVERHEAD: usize = 32;
+
+/// HPACK dynamic table per RFC 7541 §2.3.2.
+///
+/// Entries are stored newest-first (index 0 = most recently inserted,
+/// HPACK index 62). Each entry evicts the oldest entries as needed to
+/// stay within `max_size`. Max size is 4 096 bytes by default and can
+/// be reduced by a table-size update instruction in the header block.
+pub const DynamicTable = struct {
+    entries: std.ArrayListUnmanaged(HeaderField),
+    size: usize,
+    max_size: usize,
+
+    pub fn init() DynamicTable {
+        return .{ .entries = .{}, .size = 0, .max_size = 4096 };
+    }
+
+    pub fn deinit(self: *DynamicTable, allocator: std.mem.Allocator) void {
+        for (self.entries.items) |h| {
+            allocator.free(h.name);
+            allocator.free(h.value);
+        }
+        self.entries.deinit(allocator);
+        self.* = undefined;
+    }
+
+    pub fn insert(self: *DynamicTable, allocator: std.mem.Allocator, name: []const u8, value: []const u8) !void {
+        const cost = name.len + value.len + DYNAMIC_TABLE_ENTRY_OVERHEAD;
+        if (cost > self.max_size) {
+            self.evictAll(allocator);
+            return;
+        }
+        while (self.size + cost > self.max_size) self.evictOldest(allocator);
+        const name_copy = try allocator.dupe(u8, name);
+        errdefer allocator.free(name_copy);
+        const value_copy = try allocator.dupe(u8, value);
+        errdefer allocator.free(value_copy);
+        try self.entries.insert(allocator, 0, .{ .name = name_copy, .value = value_copy });
+        self.size += cost;
+    }
+
+    pub fn setMaxSize(self: *DynamicTable, allocator: std.mem.Allocator, new_max: usize) void {
+        self.max_size = new_max;
+        while (self.size > self.max_size) self.evictOldest(allocator);
+    }
+
+    pub fn getByDynIndex(self: *const DynamicTable, dyn_idx: usize) ?StaticEntry {
+        if (dyn_idx >= self.entries.items.len) return null;
+        const h = self.entries.items[dyn_idx];
+        return .{ .name = h.name, .value = h.value };
+    }
+
+    fn evictOldest(self: *DynamicTable, allocator: std.mem.Allocator) void {
+        if (self.entries.items.len == 0) return;
+        const last_idx = self.entries.items.len - 1;
+        const last = self.entries.items[last_idx]; // struct copy; safe to free slices after
+        self.size -= last.name.len + last.value.len + DYNAMIC_TABLE_ENTRY_OVERHEAD;
+        allocator.free(last.name);
+        allocator.free(last.value);
+        self.entries.shrinkRetainingCapacity(last_idx);
+    }
+
+    fn evictAll(self: *DynamicTable, allocator: std.mem.Allocator) void {
+        for (self.entries.items) |h| {
+            allocator.free(h.name);
+            allocator.free(h.value);
+        }
+        self.entries.clearRetainingCapacity();
+        self.size = 0;
+    }
+};
+
+/// Stateful HPACK decoder.
+///
+/// Maintains the dynamic table across decode calls so that incremental
+/// indexing accumulates correctly over the lifetime of an HTTP/2
+/// connection. One Decoder per connection direction (one for requests,
+/// one for responses if acting as a client).
+pub const Decoder = struct {
+    dynamic: DynamicTable,
+
+    pub fn init() Decoder {
+        return .{ .dynamic = DynamicTable.init() };
+    }
+
+    pub fn deinit(self: *Decoder, allocator: std.mem.Allocator) void {
+        self.dynamic.deinit(allocator);
+    }
+
+    pub fn decode(self: *Decoder, allocator: std.mem.Allocator, block: []const u8) !DecodeResult {
+        return decodeWithTable(allocator, block, &self.dynamic);
+    }
+};
+
 const static_table = [_]StaticEntry{
     .{ .name = ":authority", .value = "" },
     .{ .name = ":method", .value = "GET" },
@@ -78,7 +172,17 @@ const static_table = [_]StaticEntry{
     .{ .name = "www-authenticate", .value = "" },
 };
 
+/// Decode an HPACK header block without maintaining a dynamic table.
+/// Suitable for one-shot decoding and tests; does not persist state
+/// across calls. Use `Decoder` for per-connection stateful decoding.
 pub fn decode(allocator: std.mem.Allocator, block: []const u8) !DecodeResult {
+    return decodeWithTable(allocator, block, null);
+}
+
+/// Decode an HPACK header block using an optional dynamic table.
+/// When `dyn` is non-null, table-size updates and incremental indexing
+/// are applied to the table so state is preserved across calls.
+fn decodeWithTable(allocator: std.mem.Allocator, block: []const u8, dyn: ?*DynamicTable) !DecodeResult {
     var out = std.ArrayList(HeaderField).empty;
     errdefer {
         for (out.items) |h| {
@@ -91,26 +195,50 @@ pub fn decode(allocator: std.mem.Allocator, block: []const u8) !DecodeResult {
     var i: usize = 0;
     while (i < block.len) {
         const b = block[i];
+
         if ((b & 0x80) != 0) {
+            // Indexed header field (RFC 7541 §6.1): reference to static or dynamic table.
             const indexed = try decodeInteger(block, &i, 7);
-            const entry = staticByIndex(indexed) orelse return error.InvalidHpackIndex;
+            const entry = entryByIndex(indexed, dyn) orelse return error.InvalidHpackIndex;
             try out.append(allocator, .{
                 .name = try allocator.dupe(u8, entry.name),
                 .value = try allocator.dupe(u8, entry.value),
             });
             continue;
         }
+
         if ((b & 0xE0) == 0x20) {
-            _ = try decodeInteger(block, &i, 5);
+            // Dynamic table size update (RFC 7541 §6.3).
+            const new_max = try decodeInteger(block, &i, 5);
+            if (dyn) |d| d.setMaxSize(allocator, new_max);
             continue;
         }
-        if ((b & 0xF0) == 0x10 or (b & 0xF0) == 0x00 or (b & 0xC0) == 0x40) {
-            const prefix_bits: u3 = if ((b & 0xC0) == 0x40) 6 else 4;
-            const name_index = try decodeInteger(block, &i, prefix_bits);
+
+        if ((b & 0xC0) == 0x40) {
+            // Literal with incremental indexing (RFC 7541 §6.2.1): add to dynamic table.
+            const name_index = try decodeInteger(block, &i, 6);
             const name = if (name_index == 0)
                 try decodeStringAlloc(allocator, block, &i)
             else blk: {
-                const entry = staticByIndex(name_index) orelse return error.InvalidHpackIndex;
+                const entry = entryByIndex(name_index, dyn) orelse return error.InvalidHpackIndex;
+                break :blk try allocator.dupe(u8, entry.name);
+            };
+            errdefer allocator.free(name);
+            const value = try decodeStringAlloc(allocator, block, &i);
+            errdefer allocator.free(value);
+            if (dyn) |d| try d.insert(allocator, name, value);
+            try out.append(allocator, .{ .name = name, .value = value });
+            continue;
+        }
+
+        if ((b & 0xF0) == 0x00 or (b & 0xF0) == 0x10) {
+            // Literal without indexing (0x00) or never indexed (0x10) — RFC 7541 §6.2.2/6.2.3.
+            // Do not add to dynamic table.
+            const name_index = try decodeInteger(block, &i, 4);
+            const name = if (name_index == 0)
+                try decodeStringAlloc(allocator, block, &i)
+            else blk: {
+                const entry = entryByIndex(name_index, dyn) orelse return error.InvalidHpackIndex;
                 break :blk try allocator.dupe(u8, entry.name);
             };
             errdefer allocator.free(name);
@@ -119,9 +247,19 @@ pub fn decode(allocator: std.mem.Allocator, block: []const u8) !DecodeResult {
             try out.append(allocator, .{ .name = name, .value = value });
             continue;
         }
+
         return error.UnsupportedHpackRepresentation;
     }
     return .{ .headers = try out.toOwnedSlice(allocator) };
+}
+
+/// Look up an HPACK index across the static table and optional dynamic table.
+/// Index 1..61 are static; 62+ are dynamic (newest first).
+fn entryByIndex(index: usize, dyn: ?*DynamicTable) ?StaticEntry {
+    if (index == 0) return null;
+    if (index <= static_table.len) return static_table[index - 1];
+    if (dyn == null) return null;
+    return dyn.?.getByDynIndex(index - static_table.len - 1);
 }
 
 pub fn deinitDecoded(allocator: std.mem.Allocator, decoded: *DecodeResult) void {
@@ -195,11 +333,6 @@ fn encodeString(allocator: std.mem.Allocator, out: *std.ArrayList(u8), value: []
     try out.appendSlice(allocator, value);
 }
 
-fn staticByIndex(index: usize) ?StaticEntry {
-    if (index == 0 or index > static_table.len) return null;
-    return static_table[index - 1];
-}
-
 test "hpack decode indexed and literal headers" {
     const allocator = std.testing.allocator;
     // Indexed :method GET (2), literal new-name "x-test: abc"
@@ -236,4 +369,84 @@ test "hpack encode literal header block" {
     const encoded = try encodeLiteralHeaderBlock(allocator, headers[0..]);
     defer allocator.free(encoded);
     try std.testing.expect(encoded.len > 0);
+}
+
+test "DynamicTable insert and lookup by dyn index" {
+    const allocator = std.testing.allocator;
+    var table = DynamicTable.init();
+    defer table.deinit(allocator);
+
+    try table.insert(allocator, "x-custom", "value1");
+    try table.insert(allocator, "x-other", "value2");
+
+    // Most recently inserted is at dyn index 0.
+    const newest = table.getByDynIndex(0).?;
+    try std.testing.expectEqualStrings("x-other", newest.name);
+    try std.testing.expectEqualStrings("value2", newest.value);
+
+    const older = table.getByDynIndex(1).?;
+    try std.testing.expectEqualStrings("x-custom", older.name);
+    try std.testing.expectEqualStrings("value1", older.value);
+
+    try std.testing.expect(table.getByDynIndex(2) == null);
+}
+
+test "DynamicTable evicts oldest entries to stay within max_size" {
+    const allocator = std.testing.allocator;
+    var table = DynamicTable.init();
+    defer table.deinit(allocator);
+
+    // Each entry costs name.len + value.len + 32.
+    // Set a small max so the second insert evicts the first.
+    const name = "a";
+    const val = "b";
+    const entry_cost = name.len + val.len + DYNAMIC_TABLE_ENTRY_OVERHEAD;
+    table.setMaxSize(allocator, entry_cost); // room for exactly one entry
+
+    try table.insert(allocator, name, val);
+    try std.testing.expectEqual(@as(usize, 1), table.entries.items.len);
+
+    try table.insert(allocator, "c", "d");
+    try std.testing.expectEqual(@as(usize, 1), table.entries.items.len);
+    const e = table.getByDynIndex(0).?;
+    try std.testing.expectEqualStrings("c", e.name);
+}
+
+test "DynamicTable setMaxSize zero evicts everything" {
+    const allocator = std.testing.allocator;
+    var table = DynamicTable.init();
+    defer table.deinit(allocator);
+
+    try table.insert(allocator, "key", "val");
+    try std.testing.expectEqual(@as(usize, 1), table.entries.items.len);
+
+    table.setMaxSize(allocator, 0);
+    try std.testing.expectEqual(@as(usize, 0), table.entries.items.len);
+    try std.testing.expectEqual(@as(usize, 0), table.size);
+}
+
+test "Decoder accumulates dynamic table across calls" {
+    const allocator = std.testing.allocator;
+    var dec = Decoder.init();
+    defer dec.deinit(allocator);
+
+    // First call: literal with incremental indexing (0x40 prefix, name index 0).
+    // Encodes: name="x-hdr", value="hello"
+    const block1 = [_]u8{
+        0x40, // literal + incremental indexing, name follows
+        0x05, 'x', '-', 'h', 'd', 'r',
+        0x05, 'h', 'e', 'l', 'l', 'o',
+    };
+    var r1 = try dec.decode(allocator, block1[0..]);
+    defer deinitDecoded(allocator, &r1);
+    try std.testing.expectEqual(@as(usize, 1), r1.headers.len);
+    try std.testing.expectEqualStrings("x-hdr", r1.headers[0].name);
+
+    // Second call: reference dynamic table entry (index 62 = first dynamic).
+    const block2 = [_]u8{0x80 | 62}; // indexed representation, index 62
+    var r2 = try dec.decode(allocator, block2[0..]);
+    defer deinitDecoded(allocator, &r2);
+    try std.testing.expectEqual(@as(usize, 1), r2.headers.len);
+    try std.testing.expectEqualStrings("x-hdr", r2.headers[0].name);
+    try std.testing.expectEqualStrings("hello", r2.headers[0].value);
 }

--- a/src/http/hpack.zig
+++ b/src/http/hpack.zig
@@ -18,17 +18,19 @@ const DYNAMIC_TABLE_ENTRY_OVERHEAD: usize = 32;
 
 /// HPACK dynamic table per RFC 7541 §2.3.2.
 ///
-/// Entries are stored newest-first (index 0 = most recently inserted,
-/// HPACK index 62). Each entry evicts the oldest entries as needed to
-/// stay within `max_size`. Max size is 4 096 bytes by default and can
-/// be reduced by a table-size update instruction in the header block.
+/// Entries are stored oldest-first: index 0 holds the oldest entry and the
+/// last element holds the most recently inserted. HPACK dynamic index 0
+/// (absolute index 62) therefore maps to the last element. Each insert
+/// evicts the oldest entries as needed to stay within `max_size`. Max size
+/// is 4 096 bytes by default and may be reduced by a table-size update
+/// instruction in the header block.
 pub const DynamicTable = struct {
-    entries: std.ArrayListUnmanaged(HeaderField),
+    entries: std.ArrayList(HeaderField),
     size: usize,
     max_size: usize,
 
     pub fn init() DynamicTable {
-        return .{ .entries = .{}, .size = 0, .max_size = 4096 };
+        return .{ .entries = .empty, .size = 0, .max_size = 4096 };
     }
 
     pub fn deinit(self: *DynamicTable, allocator: std.mem.Allocator) void {
@@ -51,7 +53,7 @@ pub const DynamicTable = struct {
         errdefer allocator.free(name_copy);
         const value_copy = try allocator.dupe(u8, value);
         errdefer allocator.free(value_copy);
-        try self.entries.insert(allocator, 0, .{ .name = name_copy, .value = value_copy });
+        try self.entries.append(allocator, .{ .name = name_copy, .value = value_copy });
         self.size += cost;
     }
 
@@ -60,20 +62,20 @@ pub const DynamicTable = struct {
         while (self.size > self.max_size) self.evictOldest(allocator);
     }
 
+    /// dyn_idx 0 = most recently inserted (last element in oldest-first storage).
     pub fn getByDynIndex(self: *const DynamicTable, dyn_idx: usize) ?StaticEntry {
         if (dyn_idx >= self.entries.items.len) return null;
-        const h = self.entries.items[dyn_idx];
+        const actual = self.entries.items.len - 1 - dyn_idx;
+        const h = self.entries.items[actual];
         return .{ .name = h.name, .value = h.value };
     }
 
     fn evictOldest(self: *DynamicTable, allocator: std.mem.Allocator) void {
         if (self.entries.items.len == 0) return;
-        const last_idx = self.entries.items.len - 1;
-        const last = self.entries.items[last_idx]; // struct copy; safe to free slices after
-        self.size -= last.name.len + last.value.len + DYNAMIC_TABLE_ENTRY_OVERHEAD;
-        allocator.free(last.name);
-        allocator.free(last.value);
-        self.entries.shrinkRetainingCapacity(last_idx);
+        const oldest = self.entries.orderedRemove(0);
+        self.size -= oldest.name.len + oldest.value.len + DYNAMIC_TABLE_ENTRY_OVERHEAD;
+        allocator.free(oldest.name);
+        allocator.free(oldest.value);
     }
 
     fn evictAll(self: *DynamicTable, allocator: std.mem.Allocator) void {

--- a/src/http/hpack.zig
+++ b/src/http/hpack.zig
@@ -436,8 +436,18 @@ test "Decoder accumulates dynamic table across calls" {
     // Encodes: name="x-hdr", value="hello"
     const block1 = [_]u8{
         0x40, // literal + incremental indexing, name follows
-        0x05, 'x', '-', 'h', 'd', 'r',
-        0x05, 'h', 'e', 'l', 'l', 'o',
+        0x05,
+        'x',
+        '-',
+        'h',
+        'd',
+        'r',
+        0x05,
+        'h',
+        'e',
+        'l',
+        'l',
+        'o',
     };
     var r1 = try dec.decode(allocator, block1[0..]);
     defer deinitDecoded(allocator, &r1);

--- a/src/http/http2_frame.zig
+++ b/src/http/http2_frame.zig
@@ -122,6 +122,12 @@ pub fn parsePriority(payload: []const u8) !struct { dependency: u31, weight: u8,
     };
 }
 
+pub fn writeRstStream(writer: anytype, stream_id: u31, err_code: u32) !void {
+    var payload: [4]u8 = undefined;
+    std.mem.writeInt(u32, payload[0..4], err_code, .big);
+    try writeFrame(writer, .rst_stream, 0, stream_id, payload[0..]);
+}
+
 pub fn parseWindowUpdateIncrement(payload: []const u8) !u31 {
     if (payload.len != 4) return error.InvalidWindowUpdateFrame;
     const raw = std.mem.readInt(u32, payload[0..4], .big) & 0x7FFF_FFFF;
@@ -136,6 +142,26 @@ fn readExact(conn: anytype, out: []u8) !void {
         if (n == 0) return error.ConnectionClosed;
         off += n;
     }
+}
+
+test "writeRstStream encodes stream id and error code" {
+    var buf: [32]u8 = undefined;
+    var fbs = compat.fixedBufferStream(&buf);
+    try writeRstStream(fbs.writer(), 5, 0x7); // REFUSED_STREAM
+    const out = fbs.getWritten();
+    try std.testing.expectEqual(@as(usize, 9 + 4), out.len);
+    try std.testing.expectEqual(@as(u8, 0x3), out[3]); // type = rst_stream
+    try std.testing.expectEqual(@as(u8, 0x0), out[4]); // no flags
+    // stream id = 5 in big-endian
+    try std.testing.expectEqual(@as(u8, 0x00), out[5]);
+    try std.testing.expectEqual(@as(u8, 0x00), out[6]);
+    try std.testing.expectEqual(@as(u8, 0x00), out[7]);
+    try std.testing.expectEqual(@as(u8, 0x05), out[8]);
+    // error code = 7 in big-endian
+    try std.testing.expectEqual(@as(u8, 0x00), out[9]);
+    try std.testing.expectEqual(@as(u8, 0x00), out[10]);
+    try std.testing.expectEqual(@as(u8, 0x00), out[11]);
+    try std.testing.expectEqual(@as(u8, 0x07), out[12]);
 }
 
 test "write and parse frame header values" {

--- a/src/http/http2_stream.zig
+++ b/src/http/http2_stream.zig
@@ -27,7 +27,6 @@ pub const ErrorCode = enum(u32) {
     enhance_your_calm = 0xb,
     inadequate_security = 0xc,
     http_1_1_required = 0xd,
-    _,
 
     pub fn value(self: ErrorCode) u32 {
         return @intFromEnum(self);

--- a/src/http/http2_stream.zig
+++ b/src/http/http2_stream.zig
@@ -1,0 +1,173 @@
+const std = @import("std");
+
+/// HTTP/2 stream states per RFC 7540 §5.1.
+pub const StreamState = enum {
+    idle,
+    open,
+    half_closed_local,
+    half_closed_remote,
+    closed,
+    reserved_local,
+    reserved_remote,
+};
+
+/// HTTP/2 connection and stream error codes per RFC 7540 §7.
+pub const ErrorCode = enum(u32) {
+    no_error = 0x0,
+    protocol_error = 0x1,
+    internal_error = 0x2,
+    flow_control_error = 0x3,
+    settings_timeout = 0x4,
+    stream_closed = 0x5,
+    frame_size_error = 0x6,
+    refused_stream = 0x7,
+    cancel = 0x8,
+    compression_error = 0x9,
+    connect_error = 0xa,
+    enhance_your_calm = 0xb,
+    inadequate_security = 0xc,
+    http_1_1_required = 0xd,
+    _,
+
+    pub fn value(self: ErrorCode) u32 {
+        return @intFromEnum(self);
+    }
+};
+
+/// Per-stream protocol state for an HTTP/2 connection.
+///
+/// Tracks the RFC 7540 §5.1 state machine and per-stream flow control
+/// windows. One instance lives in the connection's streams map for the
+/// lifetime of the stream, and is removed once the state reaches `.closed`.
+pub const Stream = struct {
+    id: u31,
+    state: StreamState,
+    priority_weight: u8,
+    /// Remaining bytes the server may send to the client on this stream
+    /// (the client's stream receive window).
+    send_window: i32,
+    /// Remaining bytes the client may send to the server on this stream
+    /// (the server's stream receive window).
+    recv_window: i32,
+
+    pub fn init(id: u31, initial_send_window: i32) Stream {
+        return .{
+            .id = id,
+            .state = .open,
+            .priority_weight = 16,
+            .send_window = initial_send_window,
+            .recv_window = 65_535,
+        };
+    }
+
+    /// Transition: remote sent END_STREAM.
+    /// open → half_closed_remote; half_closed_local → closed.
+    pub fn remoteEndStream(self: *Stream) !void {
+        switch (self.state) {
+            .open => self.state = .half_closed_remote,
+            .half_closed_local => self.state = .closed,
+            else => return error.InvalidStreamState,
+        }
+    }
+
+    /// Transition: local sent END_STREAM.
+    /// open → half_closed_local; half_closed_remote → closed.
+    pub fn localEndStream(self: *Stream) !void {
+        switch (self.state) {
+            .open => self.state = .half_closed_local,
+            .half_closed_remote => self.state = .closed,
+            else => return error.InvalidStreamState,
+        }
+    }
+
+    /// Force-close the stream regardless of current state (RST_STREAM path).
+    pub fn close(self: *Stream) void {
+        self.state = .closed;
+    }
+
+    /// Returns true if the remote end may still send DATA or HEADERS.
+    pub fn canReceive(self: *const Stream) bool {
+        return switch (self.state) {
+            .open, .half_closed_local => true,
+            else => false,
+        };
+    }
+
+    /// Returns true if the local end may still send DATA or HEADERS.
+    pub fn canSend(self: *const Stream) bool {
+        return switch (self.state) {
+            .open, .half_closed_remote => true,
+            else => false,
+        };
+    }
+};
+
+test "stream transitions to half_closed_remote on remote END_STREAM" {
+    var s = Stream.init(1, 65_535);
+    try s.remoteEndStream();
+    try std.testing.expectEqual(StreamState.half_closed_remote, s.state);
+    try std.testing.expect(!s.canReceive());
+    try std.testing.expect(s.canSend());
+}
+
+test "stream transitions to half_closed_local on local END_STREAM" {
+    var s = Stream.init(1, 65_535);
+    try s.localEndStream();
+    try std.testing.expectEqual(StreamState.half_closed_local, s.state);
+    try std.testing.expect(s.canReceive());
+    try std.testing.expect(!s.canSend());
+}
+
+test "stream transitions to closed from half_closed_remote on local END_STREAM" {
+    var s = Stream.init(1, 65_535);
+    try s.remoteEndStream();
+    try s.localEndStream();
+    try std.testing.expectEqual(StreamState.closed, s.state);
+    try std.testing.expect(!s.canReceive());
+    try std.testing.expect(!s.canSend());
+}
+
+test "stream transitions to closed from half_closed_local on remote END_STREAM" {
+    var s = Stream.init(1, 65_535);
+    try s.localEndStream();
+    try s.remoteEndStream();
+    try std.testing.expectEqual(StreamState.closed, s.state);
+}
+
+test "stream invalid transition returns error" {
+    var s = Stream.init(1, 65_535);
+    s.state = .closed;
+    try std.testing.expectError(error.InvalidStreamState, s.remoteEndStream());
+    try std.testing.expectError(error.InvalidStreamState, s.localEndStream());
+}
+
+test "stream RST_STREAM closes from any state" {
+    const cases = [_]StreamState{ .open, .half_closed_local, .half_closed_remote };
+    for (cases) |initial| {
+        var s = Stream.init(1, 65_535);
+        s.state = initial;
+        s.close();
+        try std.testing.expectEqual(StreamState.closed, s.state);
+    }
+}
+
+test "stream initial state is open with default windows" {
+    const s = Stream.init(3, 65_535);
+    try std.testing.expectEqual(StreamState.open, s.state);
+    try std.testing.expectEqual(@as(u31, 3), s.id);
+    try std.testing.expectEqual(@as(i32, 65_535), s.send_window);
+    try std.testing.expectEqual(@as(i32, 65_535), s.recv_window);
+    try std.testing.expectEqual(@as(u8, 16), s.priority_weight);
+    try std.testing.expect(s.canReceive());
+    try std.testing.expect(s.canSend());
+}
+
+test "ErrorCode values match RFC 7540 §7" {
+    try std.testing.expectEqual(@as(u32, 0x0), ErrorCode.no_error.value());
+    try std.testing.expectEqual(@as(u32, 0x1), ErrorCode.protocol_error.value());
+    try std.testing.expectEqual(@as(u32, 0x3), ErrorCode.flow_control_error.value());
+    try std.testing.expectEqual(@as(u32, 0x5), ErrorCode.stream_closed.value());
+    try std.testing.expectEqual(@as(u32, 0x6), ErrorCode.frame_size_error.value());
+    try std.testing.expectEqual(@as(u32, 0x7), ErrorCode.refused_stream.value());
+    try std.testing.expectEqual(@as(u32, 0x9), ErrorCode.compression_error.value());
+}


### PR DESCRIPTION
- Add src/http/http2_stream.zig: RFC 7540 §5.1 stream state machine (open,
  half-closed-local/remote, closed) with `remoteEndStream`, `localEndStream`,
  and force-close transitions; RFC 7540 §7 error codes; per-stream send/recv
  window fields; full test suite covering all transitions and invalid states.

- Upgrade src/http/hpack.zig: add `DynamicTable` (RFC 7541 §2.3.2) with
  insert, eviction, setMaxSize, and OOM-safe errdefer paths; add `Decoder`
  struct that keeps a DynamicTable alive across HEADERS frames on a connection;
  replace `decode()` with `decodeWithTable()` that honours incremental indexing
  (0x40 prefix), table-size updates (0x20 prefix), and dynamic-table lookups
  (index ≥ 62); add `entryByIndex` helper; 6 new tests including round-trip
  stateful decode across two calls.

- Add `writeRstStream` to src/http/http2_frame.zig with a test verifying the
  encoded stream ID and REFUSED_STREAM error code.

- Improve handleHttp2Connection in src/edge_gateway.zig:
  - Replace split stream_windows/stream_priorities maps with a single
    `streams: AutoHashMap(u31, http2_stream.Stream)` map.
  - Replace stateless hpack.decode calls with a per-connection `Decoder`.
  - Enforce HTTP2_MAX_CONCURRENT_STREAMS=100; reply RST_STREAM(REFUSED_STREAM)
    instead of silently accepting unlimited streams.
  - Enforce MAX_REQUEST_SIZE body limit per stream; reject with RST_STREAM(CANCEL).
  - Distinguish connection-level recv window (conn_recv_window) from send window
    (conn_send_window); debit/credit each correctly.
  - Apply RFC-correct error codes in GOAWAY and RST_STREAM responses.
  - Honour GOAWAY from the client (goaway_received flag) and send GOAWAY on
    clean shutdown.
  - Integrate RequestLifecycle per stream for timeout tracking.
  - Respect per-stream and connection send windows when writing DATA frames.
  - Add countOpenStreams() helper for concurrent-stream accounting.
  - Add explanatory comments on all best-effort catch {} uses.

- Export http2_stream from src/http.zig.

https://github.com/Bare-Systems/Tardigrade/issues/111