### PR TITLE
reliability: audit and standardize timeout policy across client and proxy paths (#171)

### DIFF
--- a/examples/bearclaw/tardigrade.env.example
+++ b/examples/bearclaw/tardigrade.env.example
@@ -38,8 +38,57 @@ TARDIGRADE_UPSTREAM_BASE_URL=http://127.0.0.1:8080
 TARDIGRADE_UPSTREAM_CHAT_BASE_URLS=http://127.0.0.1:8080
 TARDIGRADE_UPSTREAM_COMMANDS_BASE_URLS=http://127.0.0.1:8080
 
-# Proxy timeout: how long Tardigrade waits for a response from the upstream.
+# ── Downstream timeouts ───────────────────────────────────────────────────────
+
+# TLS handshake: maximum time to complete SSL_accept before closing the
+# connection. Protects against clients that open a connection but stall the
+# handshake. Default: 5000.
+#TARDIGRADE_TLS_HANDSHAKE_TIMEOUT_MS=5000
+
+# Header read: maximum time to receive complete request headers from a client.
+# Bounds slowloris and header-drip attacks. Default: 10000.
+#TARDIGRADE_HEADER_TIMEOUT_MS=10000
+
+# Body read: maximum time to receive a complete request body after headers.
+# Only relevant when the server buffers the body before proxying. Default: 30000.
+#TARDIGRADE_BODY_TIMEOUT_MS=30000
+
+# Downstream write: maximum time to flush a response chunk to the client.
+# Applied as SO_SNDTIMEO independently of read timeouts. Default: 30000.
+#TARDIGRADE_DOWNSTREAM_WRITE_TIMEOUT_MS=30000
+
+# Keep-alive idle: how long a parked keep-alive connection may sit idle between
+# requests before being reaped. Default: 5000.
+#TARDIGRADE_KEEP_ALIVE_TIMEOUT_MS=5000
+
+# Overall request deadline: wall-clock cap from first byte received to response
+# fully written. 0 = disabled. When set, must be >= upstream timeout budget.
+#TARDIGRADE_REQUEST_TOTAL_TIMEOUT_MS=0
+
+# Graceful shutdown drain: how long to wait for queued connections to finish
+# before force-closing them. Active (already-dispatched) handlers always finish
+# naturally; only unstarted queued connections are force-closed at deadline.
+#TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS=30000
+
+# ── Upstream timeouts ─────────────────────────────────────────────────────────
+
+# Per-attempt timeout: maximum wall time for a single upstream attempt
+# (connect + headers + body). Applies to Unix-socket upstreams. Default: 10000.
 TARDIGRADE_UPSTREAM_TIMEOUT_MS=30000
+
+# TCP connect timeout: maximum time to establish a TCP connection to an upstream.
+# Applies to Unix-socket upstreams; the TCP http.Client path does not yet
+# enforce this. Default: 5000.
+#TARDIGRADE_UPSTREAM_CONNECT_TIMEOUT_MS=5000
+
+# Response timeout: maximum time from request-send completion to first response
+# byte. Only enforced on Unix-socket upstreams. Default: 0 (falls back to
+# upstream_timeout_ms).
+#TARDIGRADE_UPSTREAM_RESPONSE_TIMEOUT_MS=0
+
+# Total timeout budget across all upstream retry attempts. 0 = disabled.
+# Should be >= upstream_timeout_ms * retry_attempts.
+#TARDIGRADE_UPSTREAM_TIMEOUT_BUDGET_MS=0
 
 # Passive health: mark a backend unhealthy after this many consecutive failures.
 TARDIGRADE_UPSTREAM_MAX_FAILS=3
@@ -48,6 +97,7 @@ TARDIGRADE_UPSTREAM_FAIL_TIMEOUT_MS=30000
 # Active health probe: Tardigrade probes this path every interval.
 TARDIGRADE_UPSTREAM_ACTIVE_PROBE_PATH=/health
 TARDIGRADE_UPSTREAM_ACTIVE_PROBE_INTERVAL_MS=10000
+# Per-probe timeout; applied to both Unix-socket and TCP probes. Default: 2000.
 TARDIGRADE_UPSTREAM_ACTIVE_PROBE_TIMEOUT_MS=5000
 
 # Legacy per-role upstream shortcuts (still respected when set).

--- a/src/edge_config.zig
+++ b/src/edge_config.zig
@@ -349,6 +349,14 @@ pub const EdgeConfig = struct {
     /// Caps all downstream work (auth, upstream calls, response streaming) for a single request.
     /// Set via TARDIGRADE_REQUEST_TOTAL_TIMEOUT_MS.
     request_total_timeout_ms: u32,
+    /// TLS handshake timeout in milliseconds (TARDIGRADE_TLS_HANDSHAKE_TIMEOUT_MS).
+    /// Applied as SO_RCVTIMEO before SSL_accept to bound slow or stalled clients.
+    /// 0 falls back to keep_alive_timeout_ms. Default: 5000.
+    tls_handshake_timeout_ms: u32,
+    /// Downstream write timeout in milliseconds (TARDIGRADE_DOWNSTREAM_WRITE_TIMEOUT_MS).
+    /// Applied as SO_SNDTIMEO during response writes; distinct from read timeouts.
+    /// 0 = no explicit write deadline. Default: 30000.
+    downstream_write_timeout_ms: u32,
     /// Maximum requests served per client connection (0 = unlimited).
     max_requests_per_connection: u32,
     /// Maximum idle connection sessions cached for reuse.
@@ -913,9 +921,9 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
     defer allocator.free(body_timeout_str);
     const body_timeout_ms = std.fmt.parseInt(u32, body_timeout_str, 10) catch 0;
 
-    const header_timeout_str = envOrDefault(allocator, "TARDIGRADE_HEADER_TIMEOUT_MS", "0") catch unreachable;
+    const header_timeout_str = envOrDefault(allocator, "TARDIGRADE_HEADER_TIMEOUT_MS", "10000") catch unreachable;
     defer allocator.free(header_timeout_str);
-    const header_timeout_ms = std.fmt.parseInt(u32, header_timeout_str, 10) catch 0;
+    const header_timeout_ms = std.fmt.parseInt(u32, header_timeout_str, 10) catch 10_000;
 
     // Basic auth
     const raw_basic_hashes = envOrDefault(allocator, "TARDIGRADE_BASIC_AUTH_HASHES", "") catch unreachable;
@@ -1085,6 +1093,8 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
     const keep_alive_timeout_ms = std.fmt.parseInt(u32, keep_alive_timeout_str, 10) catch 5000;
 
     const request_total_timeout_ms = parseIntEnv(u32, allocator, "TARDIGRADE_REQUEST_TOTAL_TIMEOUT_MS", 0);
+    const tls_handshake_timeout_ms = parseIntEnv(u32, allocator, "TARDIGRADE_TLS_HANDSHAKE_TIMEOUT_MS", 5_000);
+    const downstream_write_timeout_ms = parseIntEnv(u32, allocator, "TARDIGRADE_DOWNSTREAM_WRITE_TIMEOUT_MS", 30_000);
 
     const max_req_conn_str = envOrDefault(allocator, "TARDIGRADE_MAX_REQUESTS_PER_CONNECTION", "100") catch unreachable;
     defer allocator.free(max_req_conn_str);
@@ -1461,6 +1471,8 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
         .max_in_flight_requests = max_in_flight_requests,
         .keep_alive_timeout_ms = keep_alive_timeout_ms,
         .request_total_timeout_ms = request_total_timeout_ms,
+        .tls_handshake_timeout_ms = tls_handshake_timeout_ms,
+        .downstream_write_timeout_ms = downstream_write_timeout_ms,
         .max_requests_per_connection = max_requests_per_connection,
         .connection_pool_size = connection_pool_size,
         .max_connection_memory_bytes = max_connection_memory_bytes,
@@ -2480,6 +2492,25 @@ pub fn validate(cfg: *const EdgeConfig) !void {
         std.log.err("config validation failed: TARDIGRADE_PROXY_STREAM_BUFFER_SIZE must be between 1 and 1048576 bytes", .{});
         return error.InvalidConfigValue;
     };
+
+    // Timeout relationship sanity checks — warn only, these are not hard errors
+    // because operators may have intentional unusual configurations.
+    if (cfg.upstream_timeout_budget_ms > 0 and cfg.upstream_timeout_ms > 0 and
+        cfg.upstream_timeout_budget_ms < cfg.upstream_timeout_ms)
+    {
+        std.log.warn("config: TARDIGRADE_UPSTREAM_TIMEOUT_BUDGET_MS ({d}) is less than TARDIGRADE_UPSTREAM_TIMEOUT_MS ({d}); budget expires before a single attempt can complete", .{
+            cfg.upstream_timeout_budget_ms,
+            cfg.upstream_timeout_ms,
+        });
+    }
+    if (cfg.request_total_timeout_ms > 0 and cfg.upstream_timeout_budget_ms > 0 and
+        cfg.request_total_timeout_ms < cfg.upstream_timeout_budget_ms)
+    {
+        std.log.warn("config: TARDIGRADE_REQUEST_TOTAL_TIMEOUT_MS ({d}) is less than TARDIGRADE_UPSTREAM_TIMEOUT_BUDGET_MS ({d}); request deadline fires before upstream budget is exhausted", .{
+            cfg.request_total_timeout_ms,
+            cfg.upstream_timeout_budget_ms,
+        });
+    }
 }
 
 fn validateTlsCertKeyPair(cert_path: []const u8, key_path: []const u8) !void {

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -779,16 +779,6 @@ fn startNewConnection(ctx: *WorkerContext, client_fd: std.posix.fd_t) void {
     var cfg_lease = ctx.acquireConfig();
     defer cfg_lease.release();
     const cfg = cfg_lease.cfg;
-    const idle_timeout_ms = if (cfg.keep_alive_timeout_ms > 0)
-        cfg.keep_alive_timeout_ms
-    else
-        cfg.request_limits.header_timeout_ms;
-    if (idle_timeout_ms > 0) {
-        gconn.setSocketTimeoutMs(client_fd, idle_timeout_ms, idle_timeout_ms) catch |err| {
-            ctx.state.logger.warn(null, "failed to set client socket timeout: {}", .{err});
-        };
-    }
-
     gconn.setNonBlocking(client_fd, false) catch |err| {
         ctx.state.logger.warn(null, "failed to switch client fd to blocking mode: {}", .{err});
         return;
@@ -798,7 +788,25 @@ fn startNewConnection(ctx: *WorkerContext, client_fd: std.posix.fd_t) void {
         ctx.state.logger.warn(null, "failed to set TCP_NODELAY on client fd: {}", .{err});
     };
 
+    // Effective per-phase timeouts used throughout this connection's lifetime.
+    const header_timeout_ms = cfg.request_limits.effectiveHeaderTimeout();
+    const write_timeout_ms = if (cfg.downstream_write_timeout_ms > 0) cfg.downstream_write_timeout_ms else header_timeout_ms;
+
     if (ctx.tls) |tls| {
+        // Apply the TLS handshake timeout before PROXY protocol parsing and
+        // SSL_accept. Falls back to keep_alive_timeout_ms when not explicitly
+        // configured so the old behavior is preserved for operators that haven't
+        // set the new field.
+        const handshake_timeout_ms = if (cfg.tls_handshake_timeout_ms > 0)
+            cfg.tls_handshake_timeout_ms
+        else
+            cfg.keep_alive_timeout_ms;
+        if (handshake_timeout_ms > 0) {
+            gconn.setSocketTimeoutMs(client_fd, handshake_timeout_ms, handshake_timeout_ms) catch |err| {
+                ctx.state.logger.warn(null, "failed to set client handshake timeout: {}", .{err});
+            };
+        }
+
         // Parse PROXY protocol header from the raw TCP socket before SSL_accept.
         // The PROXY header is plaintext even on TLS connections and must be
         // consumed before OpenSSL sees the TLS ClientHello.
@@ -827,6 +835,14 @@ fn startNewConnection(ctx: *WorkerContext, client_fd: std.posix.fd_t) void {
         // teardown defer (or a failed park) frees it exactly once.
         tls_to_park = tls_conn;
 
+        // Handshake complete — switch to request-phase timeouts.
+        // SO_RCVTIMEO covers header/body reads; SO_SNDTIMEO covers response writes.
+        if (header_timeout_ms > 0 or write_timeout_ms > 0) {
+            gconn.setSocketTimeoutMs(client_fd, header_timeout_ms, write_timeout_ms) catch |err| {
+                ctx.state.logger.warn(null, "failed to set post-handshake socket timeout: {}", .{err});
+            };
+        }
+
         if (tls_conn.negotiatedProtocol() == .http2 and cfg.http2_enabled) {
             // HTTP/2 multiplexes many streams over one connection internally and
             // is not parked (out of scope for #138); the teardown defer closes it.
@@ -847,6 +863,13 @@ fn startNewConnection(ctx: *WorkerContext, client_fd: std.posix.fd_t) void {
             .close => return,
         };
     } else {
+        // Plaintext path: apply read and write timeouts immediately (no separate
+        // handshake phase).
+        if (header_timeout_ms > 0 or write_timeout_ms > 0) {
+            gconn.setSocketTimeoutMs(client_fd, header_timeout_ms, write_timeout_ms) catch |err| {
+                ctx.state.logger.warn(null, "failed to set client socket timeout: {}", .{err});
+            };
+        }
         const stream = compat.netStreamFromFd(client_fd);
         var served: u32 = 0;
         while (true) switch (serveOneRequest(ctx, stream, session, connection_ip, &served, true)) {

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -1337,6 +1337,18 @@ fn streamingRequestBodyFromHead(
     };
 }
 
+fn connRawFd(conn: anytype) ?std.posix.fd_t {
+    const T = @TypeOf(conn);
+    if (comptime std.meta.activeTag(@typeInfo(T)) == .pointer) {
+        const Child = std.meta.Child(T);
+        if (comptime @hasDecl(Child, "rawFd")) return conn.rawFd();
+        if (comptime @hasField(Child, "handle")) return conn.handle;
+    } else {
+        if (comptime @hasField(T, "handle")) return conn.handle;
+    }
+    return null;
+}
+
 fn handleConnection(conn: anytype, session: *ConnectionSession, cfg: *const edge_config.EdgeConfig, state: *GatewayState, keep_alive_out: *bool, connection_ip: []const u8, enable_proxy_protocol: bool) !void {
     var keep_alive = false;
     keep_alive_out.* = false;
@@ -1400,6 +1412,17 @@ fn handleConnection(conn: anytype, session: *ConnectionSession, cfg: *const edge
             session.pending_len = 0;
         } else {
             head_parse.request.deinit();
+            // Switch SO_RCVTIMEO from header phase to body read phase.
+            const body_timeout_ms = cfg.request_limits.effectiveBodyTimeout();
+            if (body_timeout_ms > 0) {
+                if (connRawFd(conn)) |fd| {
+                    const write_timeout_ms = if (cfg.downstream_write_timeout_ms > 0)
+                        cfg.downstream_write_timeout_ms
+                    else
+                        cfg.request_limits.effectiveHeaderTimeout();
+                    gconn.setSocketTimeoutMs(fd, body_timeout_ms, write_timeout_ms) catch {};
+                }
+            }
             const total_read = try gconn.readHttpRequest(conn, pending_buf, &session.pending_len);
             if (total_read == 0) return;
             if (cfg.max_connection_memory_bytes > 0 and total_read > cfg.max_connection_memory_bytes) {

--- a/src/gateway_control_plane_proxy.zig
+++ b/src/gateway_control_plane_proxy.zig
@@ -595,6 +595,11 @@ fn executeBoundedControlPlaneJsonProxyAttempt(
         };
     }
 
+    // NOTE: attempt_timeout_ms is passed to this function but cannot be applied
+    // here because state.upstream_client is a shared std.http.Client that does
+    // not expose per-request socket timeout control. TCP control-plane calls are
+    // unbounded by the timeout policy until this path is replaced with a bounded
+    // manual transport matching the Unix-socket path above.
     var req = try state.upstream_client.request(.POST, uri, .{
         .headers = .{ .content_type = .{ .override = "application/json" } },
         .extra_headers = extra_headers.items,

--- a/src/gateway_proxy.zig
+++ b/src/gateway_proxy.zig
@@ -14,6 +14,7 @@ const gs = @import("gateway_state.zig");
 const gph = @import("gateway_proxy_headers.zig");
 const gpres = @import("gateway_proxy_response.zig");
 const gpt = @import("gateway_proxy_target.zig");
+const gconn = @import("gateway_connection.zig");
 
 // Re-export the header-boundary API so existing callers that import from this
 // module continue to work without change.
@@ -471,6 +472,18 @@ pub fn executeBoundedBufferedHttpsMtlsRequest(
     const tcp_stream = try compat.tcpConnectToHost(allocator, host, port);
     defer tcp_stream.close();
 
+    // Apply upstream connect timeout to bound the TLS handshake. The TCP
+    // connect itself is blocking, so this timeout bounds the handshake stall
+    // rather than the TCP SYN. Falls back to upstream_timeout_ms when the
+    // connect-specific timeout is not set.
+    const effective_connect_timeout_ms = if (cfg.upstream_connect_timeout_ms > 0)
+        cfg.upstream_connect_timeout_ms
+    else
+        cfg.upstream_timeout_ms;
+    if (effective_connect_timeout_ms > 0) {
+        gconn.setSocketTimeoutMs(tcp_stream.handle, effective_connect_timeout_ms, effective_connect_timeout_ms) catch {};
+    }
+
     var tls_conn = try http.tls_termination.UpstreamTlsConn.connect(tcp_stream.handle, host, .{
         .skip_verify = !cfg.upstream_tls_verify,
         .ca_bundle_path = cfg.upstream_tls_ca_bundle,
@@ -519,6 +532,16 @@ pub fn executeBoundedBufferedHttpsMtlsRequest(
     }
     try req_writer.writeAll("\r\n");
     if (body.len > 0) try req_writer.writeAll(body);
+
+    // After the TLS handshake, switch to the per-attempt read/write timeout for
+    // request write and response read phases.
+    if (cfg.upstream_timeout_ms > 0) {
+        const resp_timeout_ms = if (cfg.upstream_response_timeout_ms > 0)
+            cfg.upstream_response_timeout_ms
+        else
+            cfg.upstream_timeout_ms;
+        gconn.setSocketTimeoutMs(tcp_stream.handle, resp_timeout_ms, cfg.upstream_timeout_ms) catch {};
+    }
 
     try tls_conn.writeAll(req_aw.written());
 

--- a/src/gateway_proxy.zig
+++ b/src/gateway_proxy.zig
@@ -312,8 +312,9 @@ pub fn executeBoundedBufferedHttpProxyRequest(
     attempt_timeout_ms: u32,
     connect_timeout_ms: u32,
     /// If > 0, caps the time from finished request-send to first response byte.
-    /// Only enforced on Unix socket upstreams; std.http.Client does not expose
-    /// per-phase socket timeout control.
+    /// Only enforced on Unix socket upstreams; the TCP path uses std.http.Client
+    /// which does not expose per-phase socket timeout control. attempt_timeout_ms
+    /// and connect_timeout_ms are likewise unenforced on the TCP path.
     response_timeout_ms: u32,
     cancel_token: ?*const CancellationToken,
 ) !BufferedUpstreamResponse {

--- a/src/gateway_shutdown.zig
+++ b/src/gateway_shutdown.zig
@@ -199,31 +199,28 @@ fn activeHealthProbeThread(task: *HealthProbeTask) void {
     defer cfg_lease.release();
     const cfg = cfg_lease.cfg;
 
-    var probe_client = std.http.Client{ .allocator = allocator, .io = compat.io() };
-    defer probe_client.deinit();
-
     if (cfg.upstream_base_urls.len > 0) {
         for (cfg.upstream_base_urls) |base_url| {
-            probeSingleUpstream(cfg, state, &probe_client, base_url);
+            probeSingleUpstream(cfg, state, base_url);
         }
         for (cfg.upstream_backup_base_urls) |base_url| {
-            probeSingleUpstream(cfg, state, &probe_client, base_url);
+            probeSingleUpstream(cfg, state, base_url);
         }
     } else {
-        probeSingleUpstream(cfg, state, &probe_client, cfg.upstream_base_url);
+        probeSingleUpstream(cfg, state, cfg.upstream_base_url);
     }
 
     for (cfg.upstream_chat_base_urls) |base_url| {
-        probeSingleUpstream(cfg, state, &probe_client, base_url);
+        probeSingleUpstream(cfg, state, base_url);
     }
     for (cfg.upstream_chat_backup_base_urls) |base_url| {
-        probeSingleUpstream(cfg, state, &probe_client, base_url);
+        probeSingleUpstream(cfg, state, base_url);
     }
     for (cfg.upstream_commands_base_urls) |base_url| {
-        probeSingleUpstream(cfg, state, &probe_client, base_url);
+        probeSingleUpstream(cfg, state, base_url);
     }
     for (cfg.upstream_commands_backup_base_urls) |base_url| {
-        probeSingleUpstream(cfg, state, &probe_client, base_url);
+        probeSingleUpstream(cfg, state, base_url);
     }
 
     // Also probe DNS-discovered upstreams when active health checks are enabled.
@@ -236,7 +233,7 @@ fn activeHealthProbeThread(task: *HealthProbeTask) void {
         for (state.dns_discovery.urls.items[0..n], 0..) |url, i| discovered_buf[i] = url;
         state.dns_discovery.mutex.unlock();
         for (discovered_buf[0..n]) |url| {
-            probeSingleUpstream(cfg, state, &probe_client, url);
+            probeSingleUpstream(cfg, state, url);
         }
     }
 
@@ -294,7 +291,7 @@ pub fn runProxyCacheMaintenance(cfg: *const edge_config.EdgeConfig, state: *Gate
     }
 }
 
-fn probeSingleUpstream(cfg: *const edge_config.EdgeConfig, state: *GatewayState, probe_client: *std.http.Client, base_url: []const u8) void {
+fn probeSingleUpstream(cfg: *const edge_config.EdgeConfig, state: *GatewayState, base_url: []const u8) void {
     const health_cfg = activeHealthConfig(cfg, base_url);
     const probe_base = if (unixSocketPathFromEndpoint(base_url) != null) "http://localhost" else base_url;
     const probe_url = http.health_checker.buildProbeUrl(state.allocator, probe_base, health_cfg.path) catch |err| {
@@ -320,34 +317,12 @@ fn probeSingleUpstream(cfg: *const edge_config.EdgeConfig, state: *GatewayState,
         return;
     }
 
-    var header_buf: [4 * 1024]u8 = undefined;
-    var req = probe_client.request(.GET, uri, .{
-        .keep_alive = false,
-    }) catch |err| {
-        state.logger.warn(null, "active health probe open failed for {s}: {}", .{ base_url, err });
+    const status_code = probeTcpHttpUpstream(state.allocator, uri, cfg.upstream_active_health_timeout_ms) catch |err| {
+        state.logger.warn(null, "active health probe tcp request failed for {s}: {}", .{ base_url, err });
         state.recordActiveProbeResult(cfg, base_url, false);
         return;
     };
-    defer req.deinit();
-
-    req.sendBodiless() catch |err| {
-        state.logger.warn(null, "active health probe send failed for {s}: {}", .{ base_url, err });
-        state.recordActiveProbeResult(cfg, base_url, false);
-        return;
-    };
-    var probe_resp = req.receiveHead(&header_buf) catch |err| {
-        state.logger.warn(null, "active health probe wait failed for {s}: {}", .{ base_url, err });
-        state.recordActiveProbeResult(cfg, base_url, false);
-        return;
-    };
-    _ = &probe_resp;
-
-    const status_code: u16 = @intFromEnum(probe_resp.head.status);
-    if (health_cfg.statusIsHealthy(status_code)) {
-        state.recordActiveProbeResult(cfg, base_url, true);
-    } else {
-        state.recordActiveProbeResult(cfg, base_url, false);
-    }
+    state.recordActiveProbeResult(cfg, base_url, health_cfg.statusIsHealthy(status_code));
 }
 
 fn probeUnixSocketUpstream(socket_path: []const u8, uri: std.Uri, timeout_ms: u32) !u16 {
@@ -371,6 +346,47 @@ fn probeUnixSocketUpstream(socket_path: []const u8, uri: std.Uri, timeout_ms: u3
     }
 
     try stream.print("GET {s} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n", .{request_target_buf.items});
+
+    var response_buf: [256]u8 = undefined;
+    var used: usize = 0;
+    while (used < response_buf.len) {
+        const n = try stream.read(response_buf[used..]);
+        if (n == 0) break;
+        used += n;
+        if (std.mem.find(u8, response_buf[0..used], "\r\n")) |line_end| {
+            var parts = std.mem.splitScalar(u8, response_buf[0..line_end], ' ');
+            _ = parts.next() orelse return error.InvalidHttpResponse;
+            const status_str = parts.next() orelse return error.InvalidHttpResponse;
+            return std.fmt.parseInt(u16, status_str, 10);
+        }
+    }
+
+    return error.InvalidHttpResponse;
+}
+
+/// Probe a TCP/HTTP upstream with a bounded timeout, mirroring
+/// probeUnixSocketUpstream but over a regular TCP connection. Uses a raw
+/// socket so we can apply SO_RCVTIMEO and SO_SNDTIMEO before the HTTP
+/// round-trip, preventing hung probes from blocking the health-check batch.
+fn probeTcpHttpUpstream(allocator: std.mem.Allocator, uri: std.Uri, timeout_ms: u32) !u16 {
+    const host = if (uri.host) |h| switch (h) {
+        .raw => |r| r,
+        .percent_encoded => |pe| pe,
+    } else return error.InvalidHttpResponse;
+    const port: u16 = if (uri.port) |p| p else 80;
+
+    var stream = try compat.tcpConnectToHost(allocator, host, port);
+    defer stream.close();
+
+    if (timeout_ms > 0) {
+        try setSocketTimeoutMs(stream.handle, timeout_ms, timeout_ms);
+    }
+
+    const path_raw = switch (uri.path) {
+        .raw => |path| if (path.len > 0) path else "/",
+        .percent_encoded => |path| if (path.len > 0) path else "/",
+    };
+    try stream.print("GET {s} HTTP/1.1\r\nHost: {s}\r\nConnection: close\r\n\r\n", .{ path_raw, host });
 
     var response_buf: [256]u8 = undefined;
     var used: usize = 0;

--- a/src/http/hpack.zig
+++ b/src/http/hpack.zig
@@ -465,10 +465,10 @@ test "Decoder accumulates dynamic table across calls" {
 
 test "fuzz: decode never panics on arbitrary HPACK header blocks" {
     try std.testing.fuzz({}, fuzzHpackDecode, .{ .corpus = &.{
-        "\x82",                                                         // indexed: :method GET (static index 2)
-        "\x82\x86\x84",                                                 // :method GET + :scheme http + :path /
-        "\x82\x86\x84\x41\x0f\x77\x77\x77\x2e\x65\x78\x61\x6d\x70"   // RFC 7541 §C.3.1 first request
-        ++ "\x6c\x65\x2e\x63\x6f\x6d",
+        "\x82", // indexed: :method GET (static index 2)
+        "\x82\x86\x84", // :method GET + :scheme http + :path /
+        "\x82\x86\x84\x41\x0f\x77\x77\x77\x2e\x65\x78\x61\x6d\x70" ++ // RFC 7541 §C.3.1 first request
+            "\x6c\x65\x2e\x63\x6f\x6d",
         "",
     } });
 }

--- a/src/http/hpack_huffman.zig
+++ b/src/http/hpack_huffman.zig
@@ -445,14 +445,16 @@ test "huffman rejects EOS in stream" {
 }
 
 test "fuzz: decodeAlloc never panics on arbitrary byte sequences" {
-    try std.testing.fuzz({}, fuzzHuffmanDecodeAlloc, .{ .corpus = &.{
-        // RFC 7541 Appendix C: Huffman-encoded "www.example.com"
-        "\xf1\xe3\xc2\xe5\xf2\x3a\x6b\xa0\xab\x90\xf4\xff",
-        // RFC 7541 Appendix C: Huffman-encoded "no-cache"
-        "\xa8\xeb\x10\x64\x9c\xbf",
-        "\xff\xff\xff\xff", // EOS pattern (invalid)
-        "",
-    } });
+    try std.testing.fuzz({}, fuzzHuffmanDecodeAlloc, .{
+        .corpus = &.{
+            // RFC 7541 Appendix C: Huffman-encoded "www.example.com"
+            "\xf1\xe3\xc2\xe5\xf2\x3a\x6b\xa0\xab\x90\xf4\xff",
+            // RFC 7541 Appendix C: Huffman-encoded "no-cache"
+            "\xa8\xeb\x10\x64\x9c\xbf",
+            "\xff\xff\xff\xff", // EOS pattern (invalid)
+            "",
+        },
+    });
 }
 
 fn fuzzHuffmanDecodeAlloc(_: void, smith: *std.testing.Smith) !void {

--- a/src/http/request_limits.zig
+++ b/src/http/request_limits.zig
@@ -55,6 +55,16 @@ pub const RequestLimits = struct {
     pub fn effectiveMaxHeadersTotalSize(self: RequestLimits) usize {
         return if (self.max_headers_total_size > 0) self.max_headers_total_size else default.max_headers_total_size;
     }
+
+    /// Effective header read timeout (returns default if 0).
+    pub fn effectiveHeaderTimeout(self: RequestLimits) u32 {
+        return if (self.header_timeout_ms > 0) self.header_timeout_ms else default.header_timeout_ms;
+    }
+
+    /// Effective body read timeout (returns default if 0).
+    pub fn effectiveBodyTimeout(self: RequestLimits) u32 {
+        return if (self.body_timeout_ms > 0) self.body_timeout_ms else default.body_timeout_ms;
+    }
 };
 
 /// Validation result with specific rejection reason.
@@ -309,4 +319,24 @@ test "rejectionMessage formats headers_total_too_large" {
     const msg = rejectionMessage(result, &buf);
     try std.testing.expect(std.mem.find(u8, msg, "65536") != null);
     try std.testing.expect(std.mem.find(u8, msg, "32768") != null);
+}
+
+test "effectiveHeaderTimeout returns configured value when nonzero" {
+    const limits = RequestLimits{ .max_body_size = 0, .max_uri_length = 0, .max_header_count = 0, .max_header_size = 0, .max_headers_total_size = 0, .body_timeout_ms = 0, .header_timeout_ms = 3000 };
+    try std.testing.expectEqual(@as(u32, 3000), limits.effectiveHeaderTimeout());
+}
+
+test "effectiveHeaderTimeout falls back to default when zero" {
+    const limits = RequestLimits{ .max_body_size = 0, .max_uri_length = 0, .max_header_count = 0, .max_header_size = 0, .max_headers_total_size = 0, .body_timeout_ms = 0, .header_timeout_ms = 0 };
+    try std.testing.expectEqual(RequestLimits.default.header_timeout_ms, limits.effectiveHeaderTimeout());
+}
+
+test "effectiveBodyTimeout returns configured value when nonzero" {
+    const limits = RequestLimits{ .max_body_size = 0, .max_uri_length = 0, .max_header_count = 0, .max_header_size = 0, .max_headers_total_size = 0, .body_timeout_ms = 5000, .header_timeout_ms = 0 };
+    try std.testing.expectEqual(@as(u32, 5000), limits.effectiveBodyTimeout());
+}
+
+test "effectiveBodyTimeout falls back to default when zero" {
+    const limits = RequestLimits{ .max_body_size = 0, .max_uri_length = 0, .max_header_count = 0, .max_header_size = 0, .max_headers_total_size = 0, .body_timeout_ms = 0, .header_timeout_ms = 0 };
+    try std.testing.expectEqual(RequestLimits.default.body_timeout_ms, limits.effectiveBodyTimeout());
 }

--- a/src/http/tls_termination.zig
+++ b/src/http/tls_termination.zig
@@ -353,6 +353,12 @@ pub const TlsConnection = struct {
         return if (n > 0) @intCast(n) else 0;
     }
 
+    /// Return the underlying TCP socket fd so callers can apply per-phase
+    /// socket timeouts (SO_RCVTIMEO/SO_SNDTIMEO) without going through OpenSSL.
+    pub fn rawFd(self: *const TlsConnection) std.posix.fd_t {
+        return @intCast(c.SSL_get_fd(self.ssl));
+    }
+
     pub const Writer = struct {
         conn: *TlsConnection,
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -449,6 +449,12 @@ fn writeConfigSummary(writer: anytype, resolved_config_path: ?[]const u8, cfg: *
         cfg.request_total_timeout_ms,
         cfg.shutdown_drain_timeout_ms,
     });
+    try writer.print("downstream_timeouts: tls_handshake_ms={d} header_ms={d} body_ms={d} write_ms={d}\n", .{
+        cfg.tls_handshake_timeout_ms,
+        cfg.request_limits.effectiveHeaderTimeout(),
+        cfg.request_limits.effectiveBodyTimeout(),
+        cfg.downstream_write_timeout_ms,
+    });
     try writer.print("upstream_timeouts: attempt_ms={d} connect_ms={d} response_ms={d} budget_ms={d}\n", .{
         cfg.upstream_timeout_ms,
         cfg.upstream_connect_timeout_ms,


### PR DESCRIPTION
Addresses the concrete gaps identified in the audit on issue #171:

**Phase 1 — Canonical timeout model**
- Add `tls_handshake_timeout_ms` (TARDIGRADE_TLS_HANDSHAKE_TIMEOUT_MS, default 5000ms) to
  EdgeConfig. Applied as SO_RCVTIMEO before SSL_accept to bound stalled handshakes.
- Add `downstream_write_timeout_ms` (TARDIGRADE_DOWNSTREAM_WRITE_TIMEOUT_MS, default 30000ms)
  to EdgeConfig. Applied as SO_SNDTIMEO during response writes, distinct from read timeouts.
- Fix TARDIGRADE_HEADER_TIMEOUT_MS env default: was loading as 0 (which caused the struct
  default of 10s to be silently bypassed). Now loads as 10000 to match RequestLimits.default.
- Add `effectiveHeaderTimeout()` and `effectiveBodyTimeout()` accessors to RequestLimits,
  following the existing effectiveMax* pattern.
- Add timeout relationship sanity warnings in validate(): warns when upstream_timeout_budget_ms
  is shorter than upstream_timeout_ms, and when request_total_timeout_ms is shorter than the
  upstream budget.

**Phase 2 — Downstream connection phase splitting**
- Replace the single `idle_timeout_ms` socket timeout (which incorrectly used keep_alive_timeout_ms
  for header read, body read, and response write) with distinct per-phase timeouts:
  - TLS path: apply tls_handshake_timeout_ms before PROXY protocol + SSL_accept, then switch
    to (header_timeout_ms, downstream_write_timeout_ms) after the handshake completes.
  - Plaintext path: apply (header_timeout_ms, downstream_write_timeout_ms) immediately.
- SO_RCVTIMEO and SO_SNDTIMEO are now set to independent values for the first time.

**Phase 3 — mTLS upstream path timeouts**
- executeBoundedBufferedHttpsMtlsRequest() previously ignored all upstream timeout inputs.
- Now applies upstream_connect_timeout_ms (falling back to upstream_timeout_ms) before the
  TLS handshake to bound stalled upstream TLS accepts.
- Applies (upstream_response_timeout_ms, upstream_timeout_ms) before writing the request and
  reading the response, so both directions are bounded.

**Phase 4 — Active health TCP probe timeout**
- TCP probes in probeSingleUpstream() used std.http.Client with no timeout, allowing a hung
  upstream to permanently block the health-check batch (health_probe_running stuck true).
- Replace with probeTcpHttpUpstream(): a manual TCP connect that applies SO_RCVTIMEO and
  SO_SNDTIMEO from upstream_active_health_timeout_ms before the probe round-trip, matching
  the existing probeUnixSocketUpstream() behavior for Unix socket upstreams.
- Remove now-unused std.http.Client creation from activeHealthProbeThread().

**Phase 6 — print-config output**
- Add downstream_timeouts line to print-config output showing all four new/corrected timeout
  values: tls_handshake, header read, body read, and write.

https://claude.ai/code/session_01DQ13NJmwBCatr6tzSdPumN