### PR TITLE
ci: add RPM packaging smoke test to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,9 @@ jobs:
       - name: Smoke test DEB package
         run: ./scripts/test-deb-package.sh
 
+      - name: Smoke test RPM package
+        run: ./scripts/test-rpm-package.sh
+
   # ── Performance smoke ────────────────────────────────────────────────────────
   # Shared-runner loopback benchmark with conservative floors and a 30s default
   # run per scenario. This is not a release benchmark; it exists only to catch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes to Tardigrade are documented here.
 
 ## [Unreleased]
 
+### Fixed
+- **RPM smoke test mounts full Zig install directory** — the Rocky Linux container now mounts the host Zig install dir at `/opt/zig` (not just the binary) and installs `systemd-rpm-macros` so `zig build` and RPM spec systemd macros work in CI.
+
 ## [0.4.4] - 2026-06-18
 
 ### Removed

--- a/scripts/test-rpm-package.sh
+++ b/scripts/test-rpm-package.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Smoke-test the RPM package.
+#
+# Builds the RPM inside a Rocky Linux 9 container (where rpmbuild macros
+# and systemd-rpm-macros are defined) then installs and exercises it in
+# the same container.
+#
+# Usage: ./scripts/test-rpm-package.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+    echo "skipping RPM smoke test outside Linux" >&2
+    exit 0
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "skipping RPM smoke test because docker is unavailable" >&2
+    exit 0
+fi
+
+OUTPUT_DIR="${TMPDIR}/dist"
+mkdir -p "$OUTPUT_DIR"
+
+docker run --rm \
+    --volume "${REPO_ROOT}:/repo:ro" \
+    --volume "${OUTPUT_DIR}:/output" \
+    rockylinux:9 bash -euxc '
+        dnf install -y rpm-build openssl-libs
+
+        /repo/packaging/rpm/build.sh \
+            --version 0.0.0 \
+            --arch x86_64 \
+            --binary /repo/zig-out/bin/tardigrade \
+            --output /output
+
+        rpm_path=$(find /output -name "tardigrade-*.rpm" | head -1)
+        test -n "$rpm_path"
+        test -f "$rpm_path"
+
+        dnf install -y "$rpm_path"
+
+        test -x /usr/bin/tardigrade
+        /usr/bin/tardigrade version >/dev/null
+        test -f /etc/tardigrade/tardigrade.env
+        test -f /usr/lib/systemd/system/tardigrade.service
+        test -f /usr/share/licenses/tardigrade/LICENSE
+        test -d /var/log/tardigrade
+        test "$(stat -c "%a %U %G" /etc/tardigrade/tardigrade.env)" = "640 root tardigrade"
+        grep -F "EnvironmentFile=-/etc/tardigrade/tardigrade.env" /usr/lib/systemd/system/tardigrade.service
+        grep -F "ExecStart=/usr/bin/tardigrade run -c /etc/tardigrade/tardigrade.conf" /usr/lib/systemd/system/tardigrade.service
+
+        dnf remove -y tardigrade
+        test ! -e /usr/bin/tardigrade
+    '
+
+printf 'rpm smoke test passed\n'

--- a/scripts/test-rpm-package.sh
+++ b/scripts/test-rpm-package.sh
@@ -3,7 +3,7 @@
 #
 # Builds the binary from source inside a Rocky Linux 9 container so it links
 # against that platform's glibc (2.34), then builds the RPM and installs it.
-# The host Zig binary (statically linked) is mounted into the container.
+# The host Zig install directory is mounted into the container.
 #
 # Usage: ./scripts/test-rpm-package.sh
 
@@ -23,8 +23,8 @@ if ! command -v docker >/dev/null 2>&1; then
     exit 0
 fi
 
-# Locate the Zig binary to mount into the container. Zig's official release
-# binaries are statically linked and run on any Linux regardless of glibc.
+# Locate the Zig installation directory to mount into the container.
+# Zig's binary is statically linked, but it still needs its adjacent lib dir.
 ZIG_BIN="${ZIG_BIN:-$(command -v zig 2>/dev/null || true)}"
 if [[ -z "$ZIG_BIN" ]]; then
     ZIG_BIN="$(find "${REPO_ROOT}/.zig" -maxdepth 4 -name zig -type f 2>/dev/null | head -1 || true)"
@@ -34,15 +34,25 @@ if [[ -z "$ZIG_BIN" ]]; then
     exit 1
 fi
 
+ZIG_BIN="$(readlink -f "$ZIG_BIN")"
+ZIG_DIR="$(cd "$(dirname "$ZIG_BIN")" && pwd)"
+
+if [[ ! -x "${ZIG_DIR}/zig" || ! -d "${ZIG_DIR}/lib" ]]; then
+    echo "error: invalid Zig install directory: ${ZIG_DIR}" >&2
+    exit 1
+fi
+
 OUTPUT_DIR="${TMPDIR}/dist"
 mkdir -p "$OUTPUT_DIR"
 
 docker run --rm \
     --volume "${REPO_ROOT}:/repo:ro" \
     --volume "${OUTPUT_DIR}:/output" \
-    --volume "${ZIG_BIN}:/usr/local/bin/zig:ro" \
+    --volume "${ZIG_DIR}:/opt/zig:ro" \
     rockylinux:9 bash -euxc '
-        dnf install -y rpm-build openssl-devel openssl-libs
+        dnf install -y rpm-build openssl-devel openssl-libs systemd-rpm-macros
+
+        export PATH="/opt/zig:${PATH}"
 
         # Build from source inside this container so the binary links against
         # Rocky Linux 9'"'"'s glibc (2.34) rather than the CI runner'"'"'s.

--- a/scripts/test-rpm-package.sh
+++ b/scripts/test-rpm-package.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Smoke-test the RPM package.
 #
-# Builds the RPM inside a Rocky Linux 9 container (where rpmbuild macros
-# and systemd-rpm-macros are defined) then installs and exercises it in
-# the same container.
+# Builds the binary from source inside a Rocky Linux 9 container so it links
+# against that platform's glibc (2.34), then builds the RPM and installs it.
+# The host Zig binary (statically linked) is mounted into the container.
 #
 # Usage: ./scripts/test-rpm-package.sh
 
@@ -23,19 +23,37 @@ if ! command -v docker >/dev/null 2>&1; then
     exit 0
 fi
 
+# Locate the Zig binary to mount into the container. Zig's official release
+# binaries are statically linked and run on any Linux regardless of glibc.
+ZIG_BIN="${ZIG_BIN:-$(command -v zig 2>/dev/null || true)}"
+if [[ -z "$ZIG_BIN" ]]; then
+    ZIG_BIN="$(find "${REPO_ROOT}/.zig" -maxdepth 4 -name zig -type f 2>/dev/null | head -1 || true)"
+fi
+if [[ -z "$ZIG_BIN" ]]; then
+    echo "error: zig binary not found; set ZIG_BIN or run scripts/install-zig.sh first" >&2
+    exit 1
+fi
+
 OUTPUT_DIR="${TMPDIR}/dist"
 mkdir -p "$OUTPUT_DIR"
 
 docker run --rm \
     --volume "${REPO_ROOT}:/repo:ro" \
     --volume "${OUTPUT_DIR}:/output" \
+    --volume "${ZIG_BIN}:/usr/local/bin/zig:ro" \
     rockylinux:9 bash -euxc '
-        dnf install -y rpm-build openssl-libs
+        dnf install -y rpm-build openssl-devel openssl-libs
+
+        # Build from source inside this container so the binary links against
+        # Rocky Linux 9'"'"'s glibc (2.34) rather than the CI runner'"'"'s.
+        cp -a /repo /tmp/tardigrade
+        cd /tmp/tardigrade
+        zig build -Doptimize=ReleaseFast
 
         /repo/packaging/rpm/build.sh \
             --version 0.0.0 \
             --arch x86_64 \
-            --binary /repo/zig-out/bin/tardigrade \
+            --binary /tmp/tardigrade/zig-out/bin/tardigrade \
             --output /output
 
         rpm_path=$(find /output -name "tardigrade-*.rpm" | head -1)


### PR DESCRIPTION
RPM packaging scripts (packaging/rpm/build.sh, packaging/rpm/tardigrade.spec)
existed without any CI coverage, unlike DEB which has a full smoke test.
Add scripts/test-rpm-package.sh that builds and installs the RPM inside a
Rocky Linux 9 container (where systemd-rpm-macros are properly defined) and
verifies binary, service file, env config permissions, license, and log dir.
Wire it into the existing packaging-smoke CI job.

Closes the "Add RPM packaging" item in issue #114.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WK1efSeXQjRN2NZ3h2L3sd