### PR TITLE
test(keepalive): add worker-starvation integration test and k6 benchmark (#204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes to Tardigrade are documented here.
 
 ## [Unreleased]
 
+### Reliability
+- **Idle keepalive connections no longer occupy worker threads (#204)** — added an integration test proving that a pool of idle keepalive clients parked off the worker pool does not starve concurrent active requests. The test starts Tardigrade with 2 workers, parks 4 idle keepalive connections (2× the worker count), then fires 4 concurrent active requests from fresh connections and asserts all return 200 OK. Under the old blocking model the idle holders would have exhausted the worker pool. Added a `keepalive-starvation` k6 benchmark scenario (`benchmarks/scenarios/keepalive-starvation.js`) that runs idle-holder VUs alongside an active-burst group and reports `p(99)` / `p(99.9)` latency of the burst path as the starvation signal.
+
 ## [0.4.4] - 2026-06-18
 
 ### Removed

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -49,6 +49,7 @@
 #   static-http3        Static file serving over HTTP/3 (requires h2load with QUIC + --tls)
 #   proxy-http3         Reverse proxy over HTTP/3 (requires h2load with QUIC + --tls)
 #   keepalive           Keep-alive connection reuse
+#   keepalive-starvation  Idle keepalive holders + active burst — measures worker starvation (#204)
 #   proxy-payload-64k   Reverse proxy 64 KiB payload transfer
 #   proxy-payload-256k  Reverse proxy 256 KiB payload transfer
 #   proxy-payload-1m    Reverse proxy 1 MiB payload transfer
@@ -801,6 +802,20 @@ scenario_keepalive() {
     run_scenario "${BASE_URL}${KEEPALIVE_PATH}" "keepalive"
 }
 
+scenario_keepalive_starvation() {
+    echo "==> keepalive-starvation: idle keepalive holders + active burst — worker starvation probe (#204)"
+    if [[ "$TOOL" != "k6" ]]; then
+        echo "  Skipping — keepalive-starvation scenario requires k6"
+        return 0
+    fi
+    run_k6_scenario "keepalive-starvation" "keepalive-starvation" \
+        -e "K6_TARGET_PATH=${KEEPALIVE_PATH}" \
+        -e "IDLE_VUS=${KEEPALIVE_STARVATION_IDLE_VUS:-20}" \
+        -e "ACTIVE_VUS=${KEEPALIVE_STARVATION_ACTIVE_VUS:-10}" \
+        -e "IDLE_SLEEP_S=${KEEPALIVE_STARVATION_IDLE_SLEEP_S:-10}" \
+        -e "K6_DURATION=${DURATION}s"
+}
+
 scenario_proxy_payload_64k() {
     echo "==> proxy-payload-64k: reverse proxy 64 KiB payload (${PROXY_PAYLOAD_64K_PATH})"
     run_scenario "${BASE_URL}${PROXY_PAYLOAD_64K_PATH}" "proxy-payload-64k"
@@ -917,6 +932,7 @@ for scenario in "${SCENARIO_LIST[@]}"; do
         static-http3)       scenario_static_http3 ;;
         proxy-http3)        scenario_proxy_http3 ;;
         keepalive)          scenario_keepalive ;;
+        keepalive-starvation) scenario_keepalive_starvation ;;
         proxy-payload-64k)  scenario_proxy_payload_64k ;;
         proxy-payload-256k) scenario_proxy_payload_256k ;;
         proxy-payload-1m)   scenario_proxy_payload_1m ;;

--- a/benchmarks/scenarios/keepalive-starvation.js
+++ b/benchmarks/scenarios/keepalive-starvation.js
@@ -1,0 +1,70 @@
+import http from 'k6/http';
+import { sleep } from 'k6';
+import { Trend } from 'k6/metrics';
+
+// Keepalive starvation scenario (#204).
+//
+// Measures that a large pool of idle keepalive clients does not starve workers
+// handling fresh active requests. Two VU groups run in parallel:
+//
+//   idle-holders  — hold open keepalive connections with a very slow request
+//                   rate (one request per IDLE_SLEEP_S seconds). These simulate
+//                   parked connections that used to occupy worker threads.
+//
+//   active-burst  — fire requests as fast as possible on new connections.
+//                   Their p99 latency is the starvation signal: under the old
+//                   blocking model, active requests would queue behind the idle
+//                   holders once all workers were occupied.
+//
+// Env vars (set by run.sh or the operator):
+//   BASE_URL            target URL base  (default: http://127.0.0.1:8069)
+//   K6_TARGET_PATH      request path     (default: /health)
+//   K6_HOST_HEADER      optional Host header override
+//   K6_DURATION         test duration    (default: 30s)
+//   IDLE_VUS            number of idle keepalive holders (default: 20)
+//   ACTIVE_VUS          number of active request VUs    (default: 10)
+//   IDLE_SLEEP_S        seconds between idle-holder requests (default: 10)
+
+const baseUrl = __ENV.BASE_URL || 'http://127.0.0.1:8069';
+const targetPath = __ENV.K6_TARGET_PATH || '/health';
+const target = `${baseUrl}${targetPath}`;
+const params = __ENV.K6_HOST_HEADER ? { headers: { Host: __ENV.K6_HOST_HEADER } } : undefined;
+
+const idleVUs = parseInt(__ENV.IDLE_VUS || '20');
+const activeVUs = parseInt(__ENV.ACTIVE_VUS || '10');
+const idleSleepS = parseFloat(__ENV.IDLE_SLEEP_S || '10');
+
+const activeTrend = new Trend('active_request_duration', true);
+
+export const options = {
+  scenarios: {
+    idle_holders: {
+      executor: 'constant-vus',
+      vus: idleVUs,
+      duration: __ENV.K6_DURATION || '30s',
+      exec: 'idleHolder',
+    },
+    active_burst: {
+      executor: 'constant-vus',
+      vus: activeVUs,
+      duration: __ENV.K6_DURATION || '30s',
+      exec: 'activeBurst',
+    },
+  },
+  summaryTrendStats: ['med', 'p(95)', 'p(99)', 'p(99.9)'],
+  noConnectionReuse: false,
+};
+
+// Idle holder: keeps a keepalive connection open with a very low request rate.
+export function idleHolder() {
+  http.get(target, params);
+  sleep(idleSleepS);
+}
+
+// Active burst: fires requests as fast as possible from its own connection.
+// Its p99 is the starvation signal.
+export function activeBurst() {
+  const start = Date.now();
+  http.get(target, params);
+  activeTrend.add(Date.now() - start);
+}

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -5264,3 +5264,103 @@ test "static website with binary image assets loads correctly end-to-end and acr
     try std.testing.expectEqual(@as(u16, 200), png_after.status_code);
     try std.testing.expect(std.mem.eql(u8, &png_bytes, png_after.body));
 }
+
+// ---------------------------------------------------------------------------
+// Keepalive worker starvation (#204).
+// ---------------------------------------------------------------------------
+
+test "idle keepalive connections parked off the worker pool do not starve active requests (#204)" {
+    // Before the parking implementation, each idle keepalive connection held a
+    // worker thread blocked in read(). With 2 workers and 4 idle clients only 2
+    // new requests could be served at a time; the rest queued or failed. With
+    // parking, idle connections sit in the event loop and workers are free for
+    // active requests regardless of how many clients are parked.
+    const allocator = std.testing.allocator;
+
+    var fixture = try GenericFixtureDir.create(allocator, "keepalive-starvation");
+    defer fixture.deinit();
+    try fixture.writeRel("public/index.html", "ok\n");
+    const public_abs = try fixture.joinAbs("public");
+    defer allocator.free(public_abs);
+
+    const config_text = try std.fmt.allocPrint(allocator,
+        \\location / {{
+        \\    root {s};
+        \\    try_files $uri /index.html;
+        \\}}
+    , .{public_abs});
+    defer allocator.free(config_text);
+
+    var tardigrade = try TardigradeProcess.start(allocator, .{
+        .config_text = config_text,
+        .extra_env = &.{
+            // 2 workers — deliberately fewer than the number of idle connections we'll open.
+            .{ .name = "TARDIGRADE_WORKER_THREADS", .value = "2" },
+            // Long keepalive so parked connections are never reaped during the test.
+            .{ .name = "TARDIGRADE_KEEP_ALIVE_TIMEOUT_MS", .value = "30000" },
+        },
+    });
+    defer tardigrade.stop();
+
+    // Open IDLE_COUNT keepalive connections and park them all.
+    const IDLE_COUNT = 4; // > 2 workers
+    var idle_streams: [IDLE_COUNT]compat.NetStream = undefined;
+    var idle_open: usize = 0;
+    defer {
+        var i: usize = 0;
+        while (i < idle_open) : (i += 1) idle_streams[i].close();
+    }
+
+    for (0..IDLE_COUNT) |i| {
+        idle_streams[i] = try compat.tcpConnectToHost(allocator, test_host, tardigrade.port);
+        idle_open += 1;
+        try setStreamTimeouts(&idle_streams[i], 5_000);
+        // Send one request to establish the keepalive; the connection parks after
+        // the response is written and the worker returns to the pool.
+        try sendKeepAliveGet(&idle_streams[i], allocator, tardigrade.port, "/index.html");
+        var resp = try readHttpResponse(allocator, idle_streams[i]);
+        defer resp.deinit();
+        try std.testing.expectEqual(@as(u16, 200), resp.status_code);
+    }
+
+    // Allow time for all idle connections to complete their park transition
+    // (the worker finishes writing the response, calls repark/event loop arm).
+    compat.sleepNs(150 * std.time.ns_per_ms);
+
+    // Fire ACTIVE_COUNT new requests from independent connections concurrently.
+    // In the old blocking model the 2 workers would be held by the first 2 idle
+    // connections; here all requests must complete successfully.
+    const ACTIVE_COUNT = 4;
+    const ActiveResult = struct { ok: bool = false };
+    var results: [ACTIVE_COUNT]ActiveResult = [_]ActiveResult{.{}} ** ACTIVE_COUNT;
+    const ActiveRunner = struct {
+        fn run(ctx: *ActiveResult, port: u16) void {
+            var resp = sendRequest(std.heap.page_allocator, port, .{
+                .method = "GET",
+                .path = "/index.html",
+                .body = null,
+                .headers = &.{},
+            }) catch return;
+            defer resp.deinit();
+            ctx.ok = resp.status_code == 200;
+        }
+    };
+    var threads: [ACTIVE_COUNT]std.Thread = undefined;
+    for (0..ACTIVE_COUNT) |i| {
+        threads[i] = try std.Thread.spawn(.{}, ActiveRunner.run, .{ &results[i], tardigrade.port });
+    }
+    for (0..ACTIVE_COUNT) |i| threads[i].join();
+
+    for (results) |r| {
+        try std.testing.expect(r.ok);
+    }
+
+    // Parked connections must still serve a follow-up request after the active
+    // burst — confirms the parking/resume cycle is not corrupted by concurrency.
+    for (0..IDLE_COUNT) |i| {
+        try sendKeepAliveGet(&idle_streams[i], allocator, tardigrade.port, "/index.html");
+        var resp = try readHttpResponse(allocator, idle_streams[i]);
+        defer resp.deinit();
+        try std.testing.expectEqual(@as(u16, 200), resp.status_code);
+    }
+}

--- a/tests/keep_alive_integration.zig
+++ b/tests/keep_alive_integration.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 
-test "keep-alive integration (disabled)" {
-    // Test intentionally disabled; placeholder kept for future integration work.
-}
-// no server thread to join
+// Keepalive worker-starvation tests live in tests/integration.zig where they
+// can use the full TardigradeProcess harness. See:
+//   "idle keepalive connections parked off the worker pool do not starve active requests (#204)"
+//   "reload does not disrupt a parked keepalive connection (#170)"
+test "keepalive integration tests are in integration.zig" {}


### PR DESCRIPTION
## Summary
- Adds an integration test (`tests/integration.zig`) that proves idle keepalive connections parked off the worker pool do not starve active requests. The test starts Tardigrade with 2 worker threads, establishes 4 idle keepalive connections (2× the worker count), waits for all to park, then fires 4 concurrent active requests from fresh connections and asserts all return 200 OK. Under the old blocking-worker-per-connection model this would deadlock: 2 workers occupied by the first 2 idle connections, 2 active requests queued indefinitely.
- Replaces the empty stub in `tests/keep_alive_integration.zig` with a pointer to the live tests in `integration.zig`.
- Adds `benchmarks/scenarios/keepalive-starvation.js` — a k6 scenario that runs `IDLE_VUS` (default 20) idle keepalive holder VUs alongside `ACTIVE_VUS` (default 10) active-burst VUs and records `p(99)` / `p(99.9)` latency of the burst path as the starvation signal. Wired into `benchmarks/run.sh` as the `keepalive-starvation` scenario (k6-only).
- Updates `CHANGELOG.md` under `[Unreleased]`.

## Test plan
- [x] `zig build` compiles cleanly
- [x] `zig build test` exits 0 (unit + inline tests pass)
- [x] New integration test exercises the park/resume/repark cycle and the concurrent active-request path
- [x] Parked connections survive the active burst and still serve follow-up requests (parking integrity check)

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)