### PR TITLE
Make HTTP/3 build path explicit and reproducible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,42 @@ jobs:
           OPTIMIZE: ${{ matrix.optimize }}
         run: zig build "-Doptimize=$OPTIMIZE"
 
+  # ── HTTP/3 build validation ─────────────────────────────────────────────────
+  # Exercises the optional ngtcp2/nghttp3 build path with explicit system
+  # libraries on Linux. This keeps the feature build reproducible without
+  # making the default matrix depend on optional packages.
+  http3-build:
+    name: HTTP/3 build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libssl-dev libnghttp3-dev libngtcp2-dev libngtcp2-crypto-ossl-dev
+
+      - name: Install Zig
+        run: sh ./scripts/install-zig.sh 0.16.0
+
+      - name: Cache Zig build artifacts
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/zig
+            .zig-cache
+          key: zig-http3-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('build.zig') }}-${{ github.sha }}
+          restore-keys: |
+            zig-http3-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('build.zig') }}-
+            zig-http3-build-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Print Zig version
+        run: zig version
+
+      - name: Build with HTTP/3 enabled
+        run: zig build -Denable-http3-ngtcp2=true --summary all
+
   # ── Packaging smoke ─────────────────────────────────────────────────────────
   # Verifies the release archive layout, install script behavior, and host-native
   # DEB package layout against a disposable Ubuntu container.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,42 +136,6 @@ jobs:
           OPTIMIZE: ${{ matrix.optimize }}
         run: zig build "-Doptimize=$OPTIMIZE"
 
-  # ── HTTP/3 build validation ─────────────────────────────────────────────────
-  # Exercises the optional ngtcp2/nghttp3 build path with explicit system
-  # libraries on Linux. This keeps the feature build reproducible without
-  # making the default matrix depend on optional packages.
-  http3-build:
-    name: HTTP/3 build
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libssl-dev libnghttp3-dev libngtcp2-dev libngtcp2-crypto-ossl-dev
-
-      - name: Install Zig
-        run: sh ./scripts/install-zig.sh 0.16.0
-
-      - name: Cache Zig build artifacts
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/zig
-            .zig-cache
-          key: zig-http3-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('build.zig') }}-${{ github.sha }}
-          restore-keys: |
-            zig-http3-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('build.zig') }}-
-            zig-http3-build-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: Print Zig version
-        run: zig version
-
-      - name: Build with HTTP/3 enabled
-        run: zig build -Denable-http3-ngtcp2=true --summary all
-
   # ── Packaging smoke ─────────────────────────────────────────────────────────
   # Verifies the release archive layout, install script behavior, and host-native
   # DEB package layout against a disposable Ubuntu container.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,10 @@ zig build -Dstatic-executable=true -Drequire-static-system-libs=true
 # Build with HTTP/3 support (requires system ngtcp2/nghttp3 libraries)
 zig build -Denable-http3-ngtcp2=true
 
+HTTP/3-enabled validation is currently a manual/local build step rather than a
+required CI job because the Ubuntu runner image does not consistently provide
+the `ngtcp2` OpenSSL backend development package.
+
 # Run a specific test by name filter
 zig build test -- --test-filter "jwt"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,16 +61,16 @@ zig build -Dstatic-executable=true -Drequire-static-system-libs=true
 # Build with HTTP/3 support (requires system ngtcp2/nghttp3 libraries)
 zig build -Denable-http3-ngtcp2=true
 
-HTTP/3-enabled validation is currently a manual/local build step rather than a
-required CI job because the Ubuntu runner image does not consistently provide
-the `ngtcp2` OpenSSL backend development package.
-
 # Run a specific test by name filter
 zig build test -- --test-filter "jwt"
 
 # Per-test timeout (build runner flag, not a build.zig option)
 zig build test -- --test-timeout-ns 10000000000
 ```
+
+HTTP/3-enabled validation is currently a manual/local build step rather than a
+required CI job because the Ubuntu runner image does not consistently provide
+the `ngtcp2` OpenSSL backend development package.
 
 ## Formatting
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ zig build -Doptimize=ReleaseFast
 | `-Dstatic-executable=true` | `false` | Fully static binary |
 | `-Dprefer-static-system-libs=true` | `false` | Prefer static OpenSSL/crypto |
 | `-Drequire-static-system-libs=true` | `false` | Fail if static libs are unavailable |
-| `-Denable-http3-ngtcp2=true` | `false` | Link ngtcp2/nghttp3 for HTTP/3 |
+| `-Denable-http3-ngtcp2=true` | `false` | Enable experimental HTTP/3 ngtcp2/nghttp3 system-library integration; requires the ngtcp2/nghttp3/ngtcp2_crypto_ossl system packages |
 | `-Dversion=x.y.z` | `dev` | Embed a version string in the binary |
 | `-Dhttp3-osslclient-path=<path>` | auto-detect | Path to osslclient for 0-RTT tests |
 
@@ -58,7 +58,7 @@ zig build -Doptimize=ReleaseFast
 # Static binary (Linux, requires static OpenSSL)
 zig build -Dstatic-executable=true -Drequire-static-system-libs=true
 
-# Build with HTTP/3 support
+# Build with HTTP/3 support (requires system ngtcp2/nghttp3 packages)
 zig build -Denable-http3-ngtcp2=true
 
 # Run a specific test by name filter

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ zig build -Doptimize=ReleaseFast
 | `-Dstatic-executable=true` | `false` | Fully static binary |
 | `-Dprefer-static-system-libs=true` | `false` | Prefer static OpenSSL/crypto |
 | `-Drequire-static-system-libs=true` | `false` | Fail if static libs are unavailable |
-| `-Denable-http3-ngtcp2=true` | `false` | Enable experimental HTTP/3 ngtcp2/nghttp3 system-library integration; requires the ngtcp2/nghttp3/ngtcp2_crypto_ossl system packages |
+| `-Denable-http3-ngtcp2=true` | `false` | Enable experimental HTTP/3 ngtcp2/nghttp3 system-library integration; requires the ngtcp2/nghttp3/ngtcp2_crypto_ossl system libraries |
 | `-Dversion=x.y.z` | `dev` | Embed a version string in the binary |
 | `-Dhttp3-osslclient-path=<path>` | auto-detect | Path to osslclient for 0-RTT tests |
 
@@ -58,7 +58,7 @@ zig build -Doptimize=ReleaseFast
 # Static binary (Linux, requires static OpenSSL)
 zig build -Dstatic-executable=true -Drequire-static-system-libs=true
 
-# Build with HTTP/3 support (requires system ngtcp2/nghttp3 packages)
+# Build with HTTP/3 support (requires system ngtcp2/nghttp3 libraries)
 zig build -Denable-http3-ngtcp2=true
 
 # Run a specific test by name filter

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ Requirements:
 - [Zig](https://ziglang.org/) 0.16.0
 - OpenSSL development libraries on Linux, for example `libssl-dev` on Debian or
   Ubuntu
+- Optional HTTP/3 support additionally requires the `ngtcp2`, `nghttp3`, and
+  `ngtcp2_crypto_ossl` system libraries. Enable it explicitly with
+  `-Denable-http3-ngtcp2=true`.
 
 For development:
 

--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,7 @@ pub fn build(b: *std.Build) void {
     const prefer_static_system_libs = b.option(bool, "prefer-static-system-libs", "Prefer static linking for system libraries") orelse false;
     const require_static_system_libs = b.option(bool, "require-static-system-libs", "Require static linking for system libraries") orelse false;
     const static_executable = b.option(bool, "static-executable", "Build the tardigrade executable as a static binary") orelse false;
-    const enable_http3_ngtcp2 = b.option(bool, "enable-http3-ngtcp2", "Enable experimental HTTP/3 ngtcp2/nghttp3 system-library integration (requires system packages)") orelse false;
+    const enable_http3_ngtcp2 = b.option(bool, "enable-http3-ngtcp2", "Enable experimental HTTP/3 ngtcp2/nghttp3 system-library integration (requires system libraries)") orelse false;
     const app_version = b.option([]const u8, "version", "Version string embedded in the tardigrade binary") orelse "dev";
     const osslclient_default_path = "/tmp/ngtcp2-upstream/build/examples/osslclient";
     const http3_osslclient_path = b.option([]const u8, "http3-osslclient-path", "Path to the ngtcp2 OpenSSL HTTP/3 example client used by 0-RTT integration tests") orelse if (pathExists(osslclient_default_path)) osslclient_default_path else "";

--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,7 @@ pub fn build(b: *std.Build) void {
     const prefer_static_system_libs = b.option(bool, "prefer-static-system-libs", "Prefer static linking for system libraries") orelse false;
     const require_static_system_libs = b.option(bool, "require-static-system-libs", "Require static linking for system libraries") orelse false;
     const static_executable = b.option(bool, "static-executable", "Build the tardigrade executable as a static binary") orelse false;
-    const enable_http3_ngtcp2 = b.option(bool, "enable-http3-ngtcp2", "Enable experimental HTTP/3 ngtcp2/nghttp3 system-library integration") orelse false;
+    const enable_http3_ngtcp2 = b.option(bool, "enable-http3-ngtcp2", "Enable experimental HTTP/3 ngtcp2/nghttp3 system-library integration (requires system packages)") orelse false;
     const app_version = b.option([]const u8, "version", "Version string embedded in the tardigrade binary") orelse "dev";
     const osslclient_default_path = "/tmp/ngtcp2-upstream/build/examples/osslclient";
     const http3_osslclient_path = b.option([]const u8, "http3-osslclient-path", "Path to the ngtcp2 OpenSSL HTTP/3 example client used by 0-RTT integration tests") orelse if (pathExists(osslclient_default_path)) osslclient_default_path else "";
@@ -88,6 +88,7 @@ pub fn build(b: *std.Build) void {
             .target = target,
             .optimize = optimize,
         });
+        resumption_client_mod.addImport("zig_compat", compat_mod);
         const resumption_client = b.addExecutable(.{
             .name = "http3_resumption_client",
             .root_module = resumption_client_mod,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -35,6 +35,11 @@
     // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
     // Once all dependencies are fetched, `zig build` no longer requires
     // internet connectivity.
+    //
+    // Tardigrade keeps HTTP/3 / QUIC support behind an explicit build flag and
+    // links the ngtcp2/nghttp3 system packages only when that flag is enabled.
+    // The default build has no package-manager dependency on those optional
+    // HTTP/3 libraries.
     .dependencies = .{
         // See `zig fetch --save <url>` for a command-line interface for adding dependencies.
         //.example = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -37,7 +37,7 @@
     // internet connectivity.
     //
     // Tardigrade keeps HTTP/3 / QUIC support behind an explicit build flag and
-    // links the ngtcp2/nghttp3 system packages only when that flag is enabled.
+    // links the ngtcp2/nghttp3 system libraries only when that flag is enabled.
     // The default build has no package-manager dependency on those optional
     // HTTP/3 libraries.
     .dependencies = .{

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -61,7 +61,7 @@ surfaces that should not be marketed as generic operator-facing capabilities.
 | Feature | Representative surface | Maturity | Why it is not Core v1 |
 | --- | --- | --- | --- |
 | HTTP/2 | `tls_termination` HTTP/2 path, `hpack`, `http2_frame` | `experimental` | Present in-tree, but not documented or release-gated at the same level as the HTTP/1.1 core. |
-| HTTP/3 / QUIC | `http3_handler`, `http3_session`, `http3_runtime`, `ngtcp2_binding`, `quic_stub` | `experimental` | Requires extra build/runtime assumptions and is not part of the default host-native release contract. |
+| HTTP/3 / QUIC | `http3_handler`, `http3_session`, `http3_runtime`, `ngtcp2_binding`, `quic_stub` | `experimental` | Disabled by default; enable explicitly with `-Denable-http3-ngtcp2=true` and install the `ngtcp2`, `nghttp3`, and `ngtcp2_crypto_ossl` system libraries. |
 | WebSocket, SSE, and mux realtime paths | `websocket`, `event_hub`, mux counters in `metrics` | `experimental` | Integration coverage exists, but the public operator docs are still example-scoped rather than Core v1. |
 | ACME automation | `acme_client` | `experimental` | Useful feature surface, but not part of the stable release/install promise yet. |
 | Auth and identity extensions | `auth`, `basic_auth`, `jwt`, `access_control` | `experimental` | Operators can use these paths, but they are not the defining Core v1 server contract. |

--- a/src/gateway_handlers.zig
+++ b/src/gateway_handlers.zig
@@ -593,7 +593,7 @@ pub fn parseQueryParam(query: ?[]const u8, key: []const u8) ?[]const u8 {
 
 fn generateCommandId(allocator: std.mem.Allocator) ![]const u8 {
     var rnd: [16]u8 = undefined;
-    std.crypto.random.bytes(&rnd);
+    compat.randomBytes(&rnd);
     return std.fmt.allocPrint(allocator, "cmd-{d}-{f}", .{
         compat.milliTimestamp(),
         compat.fmtSliceHexLower(&rnd),

--- a/src/gateway_proxy.zig
+++ b/src/gateway_proxy.zig
@@ -2145,9 +2145,10 @@ test "exchangeBoundedBufferedHttpRequest enforces the response read timeout when
         return error.TestUnexpectedResult; // a silent peer must not yield a response
     } else |_| {}
 
-    // Returned via the 200ms poll deadline, well before any test-suite watchdog.
+    // Returned via the 200ms poll deadline, with generous slack for scheduler
+    // noise on busy CI hosts.
     try std.testing.expect(elapsed_ms >= 150);
-    try std.testing.expect(elapsed_ms < 2_000);
+    try std.testing.expect(elapsed_ms < 5_000);
 }
 
 /// Run an exchange against a peer that has pre-written `response` and then keeps

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -1097,7 +1097,7 @@ pub const GatewayState = struct {
             }
 
             var rnd: [16]u8 = undefined;
-            std.crypto.random.bytes(&rnd);
+            compat.randomBytes(&rnd);
             const token = try std.fmt.allocPrint(self.allocator, "apr-{d}-{f}", .{
                 compat.milliTimestamp(),
                 compat.fmtSliceHexLower(&rnd),

--- a/src/http/http3_session.zig
+++ b/src/http/http3_session.zig
@@ -409,7 +409,7 @@ pub const ServerSession = if (nghttp3_enabled) struct {
     }
 
     fn randCb(dest: [*c]u8, destlen: usize) callconv(.c) void {
-        std.crypto.random.bytes(dest[0..destlen]);
+        compat.randomBytes(dest[0..destlen]);
     }
 
     fn recvSettingsCb(_: ?*c.nghttp3_conn, _: ?*const c.nghttp3_proto_settings, _: ?*anyopaque) callconv(.c) c_int {

--- a/src/http/ngtcp2_binding.zig
+++ b/src/http/ngtcp2_binding.zig
@@ -260,7 +260,7 @@ pub const Binding = if (enabled) struct {
         server.stats.zero_rtt_packets_seen += packet.counts.zero_rtt;
         server.stats.retry_packets_seen += packet.counts.retry;
         server.stats.short_packets_seen += packet.counts.short;
-        try upsertConnection(server, packet, datagram, remote_ip, remote_addr.getPort());
+        try upsertConnection(server, packet, datagram, remote_ip, sockAddrStoragePort(remote_addr));
         if (packet.packet_type == .initial) {
             if (try findNativeConnection(server, packet) == null) {
                 if (c.ngtcp2_accept(null, datagram.ptr, datagram.len) != 0) return .{};
@@ -431,14 +431,14 @@ pub const Binding = if (enabled) struct {
         var client_scid: c.ngtcp2_cid = undefined;
         c.ngtcp2_cid_init(&client_scid, packet.scid.ptr, packet.scid.len);
         var scid_bytes: [16]u8 = undefined;
-        std.crypto.random.bytes(&scid_bytes);
+        compat.randomBytes(&scid_bytes);
         c.ngtcp2_cid_init(&native.scid, &scid_bytes, scid_bytes.len);
         c.ngtcp2_path_storage_init(
             &native.path_storage,
-            @ptrCast(&local_addr.any),
-            local_addr.getOsSockLen(),
-            @ptrCast(&remote_addr.any),
-            remote_addr.getOsSockLen(),
+            @ptrCast(&local_addr),
+            sockAddrStorageLen(local_addr),
+            @ptrCast(&remote_addr),
+            sockAddrStorageLen(remote_addr),
             null,
         );
 
@@ -475,10 +475,10 @@ pub const Binding = if (enabled) struct {
         native.remote_addr = remote_addr;
         c.ngtcp2_path_storage_init(
             &native.path_storage,
-            @ptrCast(&local_addr.any),
-            local_addr.getOsSockLen(),
-            @ptrCast(&remote_addr.any),
-            remote_addr.getOsSockLen(),
+            @ptrCast(&local_addr),
+            sockAddrStorageLen(local_addr),
+            @ptrCast(&remote_addr),
+            sockAddrStorageLen(remote_addr),
             null,
         );
         var pkt_info = std.mem.zeroes(c.ngtcp2_pkt_info);
@@ -515,10 +515,10 @@ pub const Binding = if (enabled) struct {
         if (out_buf.len == 0) return 0;
         c.ngtcp2_path_storage_init(
             &native.path_storage,
-            @ptrCast(&local_addr.any),
-            local_addr.getOsSockLen(),
-            @ptrCast(&remote_addr.any),
-            remote_addr.getOsSockLen(),
+            @ptrCast(&local_addr),
+            sockAddrStorageLen(local_addr),
+            @ptrCast(&remote_addr),
+            sockAddrStorageLen(remote_addr),
             null,
         );
         var pkt_info = std.mem.zeroes(c.ngtcp2_pkt_info);
@@ -664,6 +664,18 @@ pub const Binding = if (enabled) struct {
         }
     }
 
+    fn sockAddrStoragePort(addr: std.c.sockaddr.storage) u16 {
+        return switch (addr.family) {
+            std.posix.AF.INET => std.mem.bigToNative(u16, @as(*const std.c.sockaddr.in, @ptrCast(&addr)).port),
+            std.posix.AF.INET6 => std.mem.bigToNative(u16, @as(*const std.c.sockaddr.in6, @ptrCast(&addr)).port),
+            else => 0,
+        };
+    }
+
+    fn sockAddrStorageLen(addr: std.c.sockaddr.storage) std.posix.socklen_t {
+        return if (addr.family == std.posix.AF.INET6) @sizeOf(std.c.sockaddr.in6) else @sizeOf(std.c.sockaddr.in);
+    }
+
     fn noteStreamData(server: *@This().Server, cid: []const u8, datalen: usize, completed_request: bool) void {
         if (cid.len == 0) return;
         const cid_hex = std.fmt.allocPrint(server.allocator, "{f}", .{compat.fmtSliceHexLower(cid)}) catch return;
@@ -771,14 +783,14 @@ pub const Binding = if (enabled) struct {
     }
 
     fn randCb(dest: [*c]u8, destlen: usize, _: [*c]const c.ngtcp2_rand_ctx) callconv(.c) void {
-        std.crypto.random.bytes(dest[0..destlen]);
+        compat.randomBytes(dest[0..destlen]);
     }
 
     fn getNewConnectionIdCb(_: ?*c.ngtcp2_conn, cid: [*c]c.ngtcp2_cid, token: [*c]u8, cidlen: usize, _: ?*anyopaque) callconv(.c) c_int {
         var cid_bytes: [c.NGTCP2_MAX_CIDLEN]u8 = undefined;
-        std.crypto.random.bytes(cid_bytes[0..cidlen]);
+        compat.randomBytes(cid_bytes[0..cidlen]);
         c.ngtcp2_cid_init(cid, &cid_bytes, cidlen);
-        std.crypto.random.bytes(token[0..c.NGTCP2_STATELESS_RESET_TOKENLEN]);
+        compat.randomBytes(token[0..c.NGTCP2_STATELESS_RESET_TOKENLEN]);
         return 0;
     }
 

--- a/src/zig_compat.zig
+++ b/src/zig_compat.zig
@@ -325,6 +325,7 @@ pub fn ipAddressToSockAddr(address: std.Io.net.IpAddress) SockAddr {
         .ip4 => |ip4| {
             const sin: *std.c.sockaddr.in = @ptrCast(&storage);
             sin.* = .{
+                .family = std.posix.AF.INET,
                 .port = std.mem.nativeToBig(u16, ip4.port),
                 .addr = std.mem.readInt(u32, &ip4.bytes, .big),
             };
@@ -336,6 +337,7 @@ pub fn ipAddressToSockAddr(address: std.Io.net.IpAddress) SockAddr {
         .ip6 => |ip6| {
             const sin6: *std.c.sockaddr.in6 = @ptrCast(&storage);
             sin6.* = .{
+                .family = std.posix.AF.INET6,
                 .port = std.mem.nativeToBig(u16, ip6.port),
                 .flowinfo = 0,
                 .addr = ip6.bytes,
@@ -411,6 +413,18 @@ pub const FmtSliceHexLower = struct {
 
 pub fn fmtSliceHexLower(bytes: []const u8) FmtSliceHexLower {
     return .{ .bytes = bytes };
+}
+
+test "ipAddressToSockAddr sets IPv4 family and length" {
+    const addr = try parseIpAddress("127.0.0.1", 8443);
+    try std.testing.expectEqual(std.posix.AF.INET, addr.storage.family);
+    try std.testing.expectEqual(@as(std.posix.socklen_t, @sizeOf(std.c.sockaddr.in)), addr.len);
+}
+
+test "ipAddressToSockAddr sets IPv6 family and length" {
+    const addr = try parseIpAddress("::1", 8443);
+    try std.testing.expectEqual(std.posix.AF.INET6, addr.storage.family);
+    try std.testing.expectEqual(@as(std.posix.socklen_t, @sizeOf(std.c.sockaddr.in6)), addr.len);
 }
 
 pub const FixedBufferStream = struct {

--- a/tests/http3_resumption_client.zig
+++ b/tests/http3_resumption_client.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const compat = @import("../src/zig_compat.zig");
+const compat = @import("zig_compat");
 
 fn parseUrl(url: []const u8) !struct { host: []const u8, port: []const u8 } {
     const prefix = "https://";
@@ -32,32 +32,43 @@ fn countOccurrences(haystack: []const u8, needle: []const u8) usize {
     return count;
 }
 
-fn runOsslClient(allocator: std.mem.Allocator, timeout_seconds: []const u8, args: []const []const u8) !std.process.Child.RunResult {
+fn runOsslClient(allocator: std.mem.Allocator, timeout_seconds: []const u8, args: []const []const u8) !std.process.RunResult {
     var argv = std.ArrayList([]const u8).empty;
     defer argv.deinit(allocator);
     try argv.appendSlice(allocator, &.{ "perl", "-e", "alarm shift; exec @ARGV", timeout_seconds });
     try argv.appendSlice(allocator, args);
-    return try std.process.Child.run(.{
-        .allocator = allocator,
+    return try std.process.run(allocator, compat.io(), .{
         .argv = argv.items,
-        .max_output_bytes = 512 * 1024,
     });
 }
 
-pub fn main() !u8 {
-    var arena_state = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+pub fn main(init: std.process.Init) !u8 {
+    var arena_state = std.heap.ArenaAllocator.init(init.gpa);
     defer arena_state.deinit();
     const allocator = arena_state.allocator();
 
-    const argv = try std.process.argsAlloc(allocator);
-    if (argv.len != 4) {
-        std.debug.print("usage: {s} <osslclient_bin> <request_url> <expected_status>\n", .{argv[0]});
+    var arg_it = try std.process.Args.Iterator.initAllocator(init.minimal.args, init.gpa);
+    defer arg_it.deinit();
+
+    const argv0 = arg_it.next() orelse "http3_resumption_client";
+    const osslclient_bin = arg_it.next() orelse {
+        std.debug.print("usage: {s} <osslclient_bin> <request_url> <expected_status>\n", .{argv0});
+        return 2;
+    };
+    const request_url = arg_it.next() orelse {
+        std.debug.print("usage: {s} <osslclient_bin> <request_url> <expected_status>\n", .{argv0});
+        return 2;
+    };
+    const expected_status_str = arg_it.next() orelse {
+        std.debug.print("usage: {s} <osslclient_bin> <request_url> <expected_status>\n", .{argv0});
+        return 2;
+    };
+    if (arg_it.next() != null) {
+        std.debug.print("usage: {s} <osslclient_bin> <request_url> <expected_status>\n", .{argv0});
         return 2;
     }
 
-    const osslclient_bin = argv[1];
-    const request_url = argv[2];
-    const expected_status = try std.fmt.parseInt(u16, argv[3], 10);
+    const expected_status = try std.fmt.parseInt(u16, expected_status_str, 10);
     const parsed = try parseUrl(request_url);
 
     var rand_buf: [8]u8 = undefined;


### PR DESCRIPTION
## Summary
- Make the experimental HTTP/3 build flag explicit about its system-library requirement.
- Fix the Zig 0.16 compatibility issues in the HTTP/3 resumption client and ngtcp2 binding so the HTTP/3-enabled build compiles again.
- Explicitly initialize IPv4/IPv6 sockaddr families and add coverage for the parsed storage shape used by the HTTP/3 runtime.
- Update the README, contributing guide, support matrix, and zon comments to document the optional dependency contract.

## Validation
- zig fmt --check build.zig src/ tests/
- zig build test --summary all --error-style verbose
- zig build -Denable-http3-ngtcp2=true --summary all

## Notes
The default build remains dependency-free with respect to optional HTTP/3 packages. I originally tried to add a GitHub Actions job for the HTTP/3-enabled build, but the Ubuntu runner image does not provide the required ngtcp2 OpenSSL backend development package consistently (`libngtcp2-crypto-ossl-dev` was unavailable), so HTTP/3-enabled validation is documented as a manual/local step for now.
