### PR TITLE
refactor(proxy): drop dead re-exports, group by owner (#156)

### DIFF
--- a/src/gateway_proxy.zig
+++ b/src/gateway_proxy.zig
@@ -16,36 +16,35 @@ const gpres = @import("gateway_proxy_response.zig");
 const gpt = @import("gateway_proxy_target.zig");
 const gconn = @import("gateway_connection.zig");
 
-// Re-export the header-boundary API so existing callers that import from this
-// module continue to work without change.
-pub const MaybeOwnedBytes = gph.MaybeOwnedBytes;
+// Compatibility re-exports of the split-out proxy helper APIs (headers /
+// response / target modules) so existing callers that import this module keep
+// compiling. New code should import from the owning module directly
+// (`gph` / `gpres` / `gpt`); this shim shrinks as callers migrate (#156, #152).
+// Grouped by owning module so code search points at the true owner.
+//
+// -- gateway_proxy_headers.zig (gph)
 pub const buildForwardedFor = gph.buildForwardedFor;
 pub const isTrustedUpstream = gph.isTrustedUpstream;
 pub const appendTrustedUpstreamHeaders = gph.appendTrustedUpstreamHeaders;
 pub const appendRequestIdHeaders = gph.appendRequestIdHeaders;
 pub const writeRequestIdHeaders = gph.writeRequestIdHeaders;
 pub const setRequestIdHeaders = gph.setRequestIdHeaders;
+// -- gateway_proxy_response.zig (gpres)
 pub const applyResponseHeaders = gpres.applyResponseHeaders;
 pub const writeStreamedUpstreamResponse = gpres.writeStreamedUpstreamResponse;
-pub const writeStreamedUpstreamResponseHead = gpres.writeStreamedUpstreamResponseHead;
 pub const writeStreamedUpstreamResponseHeadFromHeaders = gpres.writeStreamedUpstreamResponseHeadFromHeaders;
 pub const writeBufferedUpstreamResponse = gpres.writeBufferedUpstreamResponse;
-pub const writeBufferedUpstreamResponseHead = gpres.writeBufferedUpstreamResponseHead;
 pub const computeHstsValue = gpres.computeHstsValue;
 pub const writeSecurityHeaders = gpres.writeSecurityHeaders;
-pub const writeSecurityHeadersFiltered = gpres.writeSecurityHeadersFiltered;
 pub const writeChunk = gpres.writeChunk;
 pub const buildApiErrorJson = gpres.buildApiErrorJson;
 pub const sendApiError = gpres.sendApiError;
 pub const upstreamReasonPhrase = gpres.upstreamReasonPhrase;
+// -- gateway_proxy_target.zig (gpt)
 pub const ResolvedProxyTarget = gpt.ResolvedProxyTarget;
-pub const isRedirectStatusCode = gpt.isRedirectStatusCode;
 pub const resolveProxyTarget = gpt.resolveProxyTarget;
 pub const appendProxyQueryString = gpt.appendProxyQueryString;
-pub const resolveRedirectTargetUrl = gpt.resolveRedirectTargetUrl;
 pub const unixSocketPathFromEndpoint = gpt.unixSocketPathFromEndpoint;
-pub const combineProxyTarget = gpt.combineProxyTarget;
-pub const parseUpstreamHost = gpt.parseUpstreamHost;
 const maxBufferedUpstreamResponseBytes = gs.maxBufferedUpstreamResponseBytes;
 const CancellationToken = http.cancellation.CancellationToken;
 


### PR DESCRIPTION
First of the HTTP/3 prep-program cleanup PRs (see the sequenced program on #240).

## What
`gateway_proxy.zig` re-exports the split-out `gph`/`gpres`/`gpt` helper APIs as `pub const X = mod.Y` so older callers can reach them via `gp.`. The audit for #156 found:
- **8 of those re-exports are dead** — no `gp.NAME` reference anywhere, no internal bare use, no test use. Removed.
- The remaining live re-exports are now **grouped by owning module** with a comment directing new code to import from `gph`/`gpres`/`gpt` directly (the shim shrinks as callers migrate; fuller de-aliasing rides with #152).
- `edge_gateway.zig`'s alias block was **already grouped and documented** — no change needed.
- A scan of the other alias-dense modules (`gateway_handlers`, `gateway_proxy_runtime`, `gateway_control_plane_proxy`, `gateway_shutdown`) found **no unused private aliases**.

Net: the "alias wall" was smaller than the issue implied; this removes the genuinely obsolete entries and makes code-search point at the true owner.

## Why it's safe
Pure compile-time symbol change — no runtime code is touched. The removed names were referenced nowhere, so the full build proves it.

## Verification
- `zig build test --summary all` → 634 pass, 1 skip (full compile of every module)
- `zig build test-failure` → 9/9
- `zig fmt --check` clean

Closes #156
Part of #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)