### PR TITLE
refactor(errors): narrow parse-error classifier; document intentional anyerror (#210)

### DIFF
--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -1421,6 +1421,7 @@ fn handleConnection(conn: anytype, session: *ConnectionSession, cfg: *const edge
             return;
         }
         var head_parse = http.Request.parseHead(allocator, pending_buf[0..head_read.header_len], MAX_REQUEST_SIZE) catch |err| {
+            if (err == error.OutOfMemory) return err; // resource failure, not a client parse error
             try gp.sendApiError(allocator, conn.writer(), parseRequestErrorStatus(err), "invalid_request", "Malformed request", null, keep_alive, state);
             state.logger.warn(null, "parse error: {}", .{err});
             return;
@@ -1453,6 +1454,7 @@ fn handleConnection(conn: anytype, session: *ConnectionSession, cfg: *const edge
                 return;
             }
             const parse_result = http.Request.parse(allocator, pending_buf[0..total_read], MAX_REQUEST_SIZE) catch |err| {
+                if (err == error.OutOfMemory) return err; // resource failure, not a client parse error
                 try gp.sendApiError(allocator, conn.writer(), parseRequestErrorStatus(err), "invalid_request", "Malformed request", null, keep_alive, state);
                 state.logger.warn(null, "parse error: {}", .{err});
                 return;
@@ -1478,6 +1480,7 @@ fn handleConnection(conn: anytype, session: *ConnectionSession, cfg: *const edge
         }
 
         const parse_result = http.Request.parse(allocator, pending_buf[0..total_read], MAX_REQUEST_SIZE) catch |err| {
+            if (err == error.OutOfMemory) return err; // resource failure, not a client parse error
             try gp.sendApiError(allocator, conn.writer(), parseRequestErrorStatus(err), "invalid_request", "Malformed request", null, keep_alive, state);
             state.logger.warn(null, "parse error: {}", .{err});
             return;

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -1290,7 +1290,7 @@ fn readExactConn(conn: anytype, out: []u8) !void {
     }
 }
 
-fn parseRequestErrorStatus(err: anyerror) http.Status {
+fn parseRequestErrorStatus(err: http.ParseError) http.Status {
     return switch (err) {
         error.HeadersTooLarge, error.HeaderTooLarge, error.TooManyHeaders => .request_header_fields_too_large,
         error.BodyTooLarge => .payload_too_large,

--- a/src/gateway_proxy.zig
+++ b/src/gateway_proxy.zig
@@ -1888,6 +1888,10 @@ pub fn mapUpstreamError(status: u16) UpstreamMappedError {
     };
 }
 
+/// Intentionally takes `anyerror`: proxy execution surfaces a heterogeneous set
+/// (the specific upstream errors below, plus allocator and compat socket I/O
+/// errors that are themselves `anyerror` until the I/O boundary is narrowed in
+/// #211). The `else` arm maps everything unrecognized to a safe gateway-timeout.
 pub fn mapControlPlaneProxyExecutionError(err: anyerror) ProxyExecMappedError {
     return switch (err) {
         error.UpstreamUntrusted => .{

--- a/src/zig_compat.zig
+++ b/src/zig_compat.zig
@@ -45,6 +45,10 @@ pub const NetStream = struct {
     inner: ?std.Io.net.Stream = null,
     handle: std.posix.fd_t,
 
+    // `anyerror` because the backing std.Io stream error set is still in flux on
+    // the pinned compiler; this is the root that makes downstream socket-I/O
+    // signatures inferred-open. Narrowing these to a stable domain set is tracked
+    // in #211 (I/O boundary) and unblocks further error-set narrowing (#210).
     pub const WriteError = anyerror;
     pub const ReadError = anyerror;
 


### PR DESCRIPTION
Second HTTP/3 prep-program cleanup PR (sequence on #240).

## Audit finding
The hot path already uses domain error sets — `request.zig` has `ParseError`, `upstream_h2.zig` has `H2Error`, and the proxy has mapped-error structs. So #210's "unnecessary `anyerror`" surface is genuinely small; only one hot-path classifier was over-broad.

## Changes
- **Narrowed** `parseRequestErrorStatus(err: anyerror)` → `(err: http.ParseError)`. All three call sites bind `err` straight from `Request.parse`/`parseHead`, which return `ParseError` — so the classifier is now tied to the parser's error domain and the compiler checks it.
- **Documented** the two `anyerror` boundaries that are *intentional*, not sloppy:
  - `mapControlPlaneProxyExecutionError` — maps a heterogeneous proxy-execution error set (specific upstream errors + allocator + compat socket I/O).
  - `zig_compat.NetStream.WriteError`/`ReadError = anyerror` — the root that makes downstream socket-I/O signatures inferred-open.

Both bottom out in socket I/O whose error set is narrowed under the **I/O-boundary work (#211)** — noted inline so the two efforts are linked and future readers don't "fix" them prematurely.

## Note on scope
The remaining `anyerror` in the hot path is either an intentional catch-all classifier or gated on the compat I/O error type (#211). Once #211 gives socket I/O a stable domain set, a short follow-up can narrow the now-inferred proxy/upstream signatures. Flagging in case you'd rather keep #210 open for that post-#211 sweep — happy to either way.

## Verification
- `zig build test --summary all` → 634 pass, 1 skip (full compile)
- `zig build test-failure` → 9/9
- `zig fmt --check` clean

Closes #210
Part of #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)