### PR TITLE
docs(io): define std.Io and posix boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ All notable user-facing changes to Tardigrade are documented here.
 - **CI perf smoke now guards upstream connection reuse (#141)** — `benchmarks/ci-smoke.sh` scrapes the gateway metrics endpoint after the proxy run and fails if fewer than 80% of upstream connections were reused (`reused / (reused + new)`). This catches a regression to per-request connections — the exact failure mode that motivated the pool (#196 dropped reuse to zero). The smoke fixture gains a `metrics_path`.
 
 ### Documentation
+- **I/O abstraction boundary documented (#211)** — `docs/CONCURRENCY.md` now
+  records the intended split between high-level `std.Io` / `zig_compat.zig`
+  usage for config, files, CLI, cache, session, transcript, and utility code,
+  and raw fd / `std.posix` ownership for listener, proxy, h2, FastCGI-style, and
+  HTTP/3/UDP socket paths. The note also links the existing follow-up issues for
+  the shared stream transport, QUIC replacement boundary, UDP endpoint model,
+  and HTTP/3 foundation epic so future refactors have one target architecture.
 - **Archived old HTTP server patterns research (#227)** — preserved the workspace-root `tardi-perf-maxxing.md` draft in a closed GitHub archive issue and removed the stale local research file. The active Tardigrade performance work remains tracked in the existing milestone-backed GitHub issues.
 
 ### Reliability

--- a/docs/CONCURRENCY.md
+++ b/docs/CONCURRENCY.md
@@ -21,6 +21,77 @@ The hot path for a single request therefore runs entirely on one worker thread â
 no async hand-offs, no continuation queues. Shared state is only touched at
 well-defined call sites (accept, route, upstream select, metrics emit, response).
 
+## I/O abstraction boundary
+
+Tardigrade uses two I/O layers deliberately. The layer is chosen by ownership of
+the fd and by whether the code is on the data-plane socket path, not by local
+convenience.
+
+### High-level / compatibility I/O
+
+Config parsing, config generation, static-file metadata, cache files, session
+and transcript stores, CLI file operations, subprocess spawning, clocks, random
+bytes, stdout/stderr writers, and other common utilities should go through
+`src/zig_compat.zig` or the `std.Io` APIs it wraps.
+
+`zig_compat.zig` is the compatibility boundary for the pinned Zig compiler. It
+absorbs `std.Io` churn and owns the few low-level escape hatches needed to keep
+the rest of the codebase small:
+
+- `compat.cwd()`, `compat.openFileAbsolute`, and `compat.createFileAbsolute`
+  wrap directory and file operations.
+- `compat.NetStream`, `compat.netStreamFromFd`, and the bounded connect helpers
+  keep the gateway's socket-facing transport shape stable.
+- `compat.Mutex`, `compat.Condition`, clocks, sleeps, env lookup, and writer
+  helpers keep high-level modules off raw OS APIs.
+
+New config, static-file, CLI, cache, session, transcript, ACME, and utility code
+should not call `std.posix`, `std.c`, or `std.os` directly unless it is adding a
+compatibility helper here first.
+
+### Low-level socket / fd I/O
+
+Listener, gateway socket, proxy transport, HTTP/2 transport, FastCGI-style
+protocol transport, and HTTP/3/UDP code own raw fds and may use `std.posix` /
+`std.c` directly for socket semantics that `std.Io` does not expose stably in
+Zig 0.16. This includes:
+
+- `accept`, `poll`, non-blocking toggles, `SO_*TIMEO`, `SO_REUSEADDR`,
+  `TCP_NODELAY`, `shutdown`, peer address extraction, and fd close behavior.
+- Bounded blocking upstream sockets where timeout behavior depends on
+  `SO_RCVTIMEO`, `SO_SNDTIMEO`, and `poll(2)`.
+- UDP datagram send/receive and address metadata for the current C-backed
+  HTTP/3 path and the future QUIC endpoint abstraction.
+
+The target API layer for gateway/listener/socket code is therefore raw fd
+ownership wrapped at protocol boundaries, not ad hoc high-level file/config
+helpers. Socket-specific helpers belong in `gateway_connection.zig`,
+`gateway_accept.zig`, `gateway_proxy.zig`, the h2 transport, the HTTP/3/UDP
+runtime, or `zig_compat.zig` when multiple protocols need the same behavior.
+
+### Static-file fast path
+
+Static-file selection, normalization, metadata, range calculation, and fallback
+body reads remain high-level `compat` / `std.Io` work. The plain HTTP file-backed
+send path is the intentional exception: `gateway_static_runtime.zig` may use
+Linux `sendfile(2)` behind an OS gate and falls back to a portable read/write
+loop elsewhere. TLS and compressed responses do not use that zero-copy path.
+
+### Follow-up work
+
+The remaining implementation work is already tracked:
+
+| Area | Issue |
+|---|---|
+| Shared h1/h2/h3 stream transport boundary | #241 |
+| Pure Zig QUIC and C-backend replacement boundary | #242 |
+| UDP endpoint and QUIC config model | #248 |
+| Pure Zig QUIC / HTTP/3 foundation epic | #240 |
+
+Do not start an `io_uring` or async-runtime rewrite from this boundary. Any new
+backend must be benchmark-justified and fit behind the same socket/protocol
+ownership rules.
+
 ---
 
 ## Lock inventory

--- a/docs/CONCURRENCY.md
+++ b/docs/CONCURRENCY.md
@@ -49,6 +49,12 @@ New config, static-file, CLI, cache, session, transcript, ACME, and utility code
 should not call `std.posix`, `std.c`, or `std.os` directly unless it is adding a
 compatibility helper here first.
 
+Known low-level exceptions outside the socket/protocol modules are intentional:
+`logger.zig` and `access_log.zig` may use raw stderr writes for last-resort
+logging, `access_log.zig` may own its syslog UDP socket, and
+`gateway_static_runtime.zig` may own the zero-copy `sendfile` / `socketpair`
+path described below.
+
 ### Low-level socket / fd I/O
 
 Listener, gateway socket, proxy transport, HTTP/2 transport, FastCGI-style

--- a/src/zig_compat.zig
+++ b/src/zig_compat.zig
@@ -1,3 +1,22 @@
+//! I/O compatibility boundary for Tardigrade (see #211 and docs/CONCURRENCY.md).
+//!
+//! This module is the seam between the gateway and the still-evolving Zig
+//! standard-library I/O (`std.Io`). High-level code — config, files, process,
+//! logging, static assets — goes through the helpers here rather than reaching
+//! into `std.Io`/`std.posix` directly, so a stdlib API churn is absorbed in one
+//! place and those modules stay free of raw syscalls. Add new shared I/O
+//! compatibility shims here before reaching into raw OS APIs from config,
+//! file, CLI, cache, session, transcript, ACME, or other utility modules.
+//!
+//! Hot socket paths (`gateway_connection.zig`, `gateway_proxy.zig`, the
+//! h2/UDP transports) deliberately use low-level `std.posix` for `poll`,
+//! `SO_*TIMEO`, `TCP_NODELAY`, and address handling; that is the sanctioned
+//! low-level layer. The only low-level calls outside those socket modules are
+//! deliberate: raw `stderr` writes in `logger.zig`/`access_log.zig`, the
+//! `access_log.zig` syslog UDP socket, and the `gateway_static_runtime.zig`
+//! zero-copy `sendfile`/`socketpair` path. New code should not add raw
+//! `std.posix` I/O to config/util modules.
+
 const std = @import("std");
 const builtin = @import("builtin");
 


### PR DESCRIPTION
## Summary
- document the intended high-level `std.Io` / `zig_compat.zig` layer for config, files, CLI, cache, session, transcript, ACME, and utility I/O
- document the sanctioned raw fd / `std.posix` layer for listener, proxy, h2, FastCGI-style, and HTTP/3/UDP socket paths
- point the boundary note at existing follow-up issues: #240, #241, #242, and #248
- add a short `zig_compat.zig` module note and changelog entry

Closes #211

## Validation
- `zig fmt --check build.zig src/ tests/`
- `zig build test --summary all --error-style verbose` (634/635 passed, 1 skipped)
