### PR TITLE
feat(proxy): define shared stream transport contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,12 @@ All notable user-facing changes to Tardigrade are documented here.
   `src/http/stream_transport.zig` now defines the shared h1/h2/h3 proxy stream
   contract for request heads, buffered or streaming request bodies,
   headers-first responses, pull-based body drains, protocol metadata, and retry
-  boundaries. `docs/UPSTREAM_POOLING.md` maps the existing h1 buffered, h1
-  streaming, h2 buffered, and h2 streaming paths to that contract so future H3
-  work has a stable adapter target without a data-plane rewrite.
+  boundaries. The contract also names the stream error domain and carries
+  request/response finish reasons so adapters can distinguish clean drains from
+  downstream cancellation and upstream errors. `docs/UPSTREAM_POOLING.md` maps
+  the existing h1 buffered, h1 streaming, h2 buffered, and h2 streaming paths to
+  that contract so future H3 work has a stable adapter target without a
+  data-plane rewrite.
 - **I/O abstraction boundary documented (#211)** — `docs/CONCURRENCY.md` now
   records the intended split between high-level `std.Io` / `zig_compat.zig`
   usage for config, files, CLI, cache, session, transcript, and utility code,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ All notable user-facing changes to Tardigrade are documented here.
 - **CI perf smoke now guards upstream connection reuse (#141)** — `benchmarks/ci-smoke.sh` scrapes the gateway metrics endpoint after the proxy run and fails if fewer than 80% of upstream connections were reused (`reused / (reused + new)`). This catches a regression to per-request connections — the exact failure mode that motivated the pool (#196 dropped reuse to zero). The smoke fixture gains a `metrics_path`.
 
 ### Documentation
+- **Protocol-agnostic stream transport target defined (#241)** —
+  `src/http/stream_transport.zig` now defines the shared h1/h2/h3 proxy stream
+  contract for request heads, buffered or streaming request bodies,
+  headers-first responses, pull-based body drains, protocol metadata, and retry
+  boundaries. `docs/UPSTREAM_POOLING.md` maps the existing h1 buffered, h1
+  streaming, h2 buffered, and h2 streaming paths to that contract so future H3
+  work has a stable adapter target without a data-plane rewrite.
 - **I/O abstraction boundary documented (#211)** — `docs/CONCURRENCY.md` now
   records the intended split between high-level `std.Io` / `zig_compat.zig`
   usage for config, files, CLI, cache, session, transcript, and utility code,

--- a/docs/UPSTREAM_POOLING.md
+++ b/docs/UPSTREAM_POOLING.md
@@ -208,6 +208,38 @@ and relaying a slow client upload over the shared connection needs an
 incremental DATA-send API on the actor. Deferred within #145: streaming
 uploads over h2.
 
+## Protocol-agnostic stream transport target (#241)
+
+Future HTTP/3 work should plug into the existing proxy runtime through the
+shared contract in `src/http/stream_transport.zig` instead of creating a second
+parallel data plane. The contract models the pieces all upstream protocols must
+provide:
+
+- request head: method, scheme, authority, path, and request headers;
+- request body: none, buffered bytes, or a pull-based streaming source;
+- response head before body bytes: status, headers, and protocol metadata;
+- response body: pull-based drain plus explicit finish/cancel cleanup;
+- transport metadata: `h1` / `h2` / `h3`, connection reuse, and optional stream
+  id;
+- retry boundary: safe before delivery, maybe-safe after request send but before
+  downstream response bytes, and unsafe after response bytes have started
+  downstream.
+
+Current paths map to that contract without semantic loss:
+
+| Path | Current entry point | Contract mapping |
+|---|---|---|
+| h1 buffered | `executeBoundedBufferedHttpProxyRequest` / `exchangeBoundedBufferedHttpRequest` | `RequestBody.buffered`, materialized `ResponseHead` + bounded body; stale pooled close maps to `before_delivery` |
+| h1 streaming | `executeStreamingHttpProxyRequest` / `streamProxyOverTransport` | `RequestBody.buffered` or `RequestBody.streaming`; response head is written before pull-draining body; `wrote_downstream` maps to `response_started_downstream` |
+| h2 buffered | `upstream_h2.H2Conn.request` | `RequestBody.buffered`, `ResponseHead.meta.protocol = h2`, body materialized under the configured cap |
+| h2 streaming | `requestStreaming` / `readStreamingBody` / `finishStreaming` | headers-first `OpenedResponse`, pull body drain, explicit finish that RST_STREAMs abandoned streams |
+
+Retry policy stays in `gateway_proxy_runtime.zig`; transports expose only the
+delivery state needed to make the decision. A future h3 adapter should expose
+the same shape with `meta.protocol = h3` and a QUIC stream id, while keeping
+QUIC connection IDs, packet routing, and flow-control internals below this
+boundary.
+
 ### Cleartext h2c (#237)
 
 `TARDIGRADE_UPSTREAM_PROTOCOL=h2c` makes plain-HTTP (`http://`) upstreams speak

--- a/docs/UPSTREAM_POOLING.md
+++ b/docs/UPSTREAM_POOLING.md
@@ -216,9 +216,14 @@ parallel data plane. The contract models the pieces all upstream protocols must
 provide:
 
 - request head: method, scheme, authority, path, and request headers;
-- request body: none, buffered bytes, or a pull-based streaming source;
+- request body: none, buffered bytes, or a pull-based streaming source with an
+  explicit finish/cancel reason;
 - response head before body bytes: status, headers, and protocol metadata;
-- response body: pull-based drain plus explicit finish/cancel cleanup;
+- response body: pull-based drain plus explicit finish reason (`drained`,
+  `cancelled_downstream`, or `upstream_error`) so h2/h3 adapters can distinguish
+  clean EOF from downstream abort/reset behavior;
+- stream errors: a named `StreamError` set for timeouts, cancellation, resets,
+  closed connections, protocol errors, and allocation failure;
 - transport metadata: `h1` / `h2` / `h3`, connection reuse, and optional stream
   id;
 - retry boundary: safe before delivery, maybe-safe after request send but before
@@ -232,7 +237,7 @@ Current paths map to that contract without semantic loss:
 | h1 buffered | `executeBoundedBufferedHttpProxyRequest` / `exchangeBoundedBufferedHttpRequest` | `RequestBody.buffered`, materialized `ResponseHead` + bounded body; stale pooled close maps to `before_delivery` |
 | h1 streaming | `executeStreamingHttpProxyRequest` / `streamProxyOverTransport` | `RequestBody.buffered` or `RequestBody.streaming`; response head is written before pull-draining body; `wrote_downstream` maps to `response_started_downstream` |
 | h2 buffered | `upstream_h2.H2Conn.request` | `RequestBody.buffered`, `ResponseHead.meta.protocol = h2`, body materialized under the configured cap |
-| h2 streaming | `requestStreaming` / `readStreamingBody` / `finishStreaming` | headers-first `OpenedResponse`, pull body drain, explicit finish that RST_STREAMs abandoned streams |
+| h2 streaming | `requestStreaming` / `readStreamingBody` / `finishStreaming` | headers-first `OpenedResponse`, pull body drain, explicit finish reason that lets abandoned streams map to RST_STREAM |
 
 Retry policy stays in `gateway_proxy_runtime.zig`; transports expose only the
 delivery state needed to make the decision. A future h3 adapter should expose

--- a/src/http.zig
+++ b/src/http.zig
@@ -53,6 +53,7 @@ pub const hpack = @import("http/hpack.zig");
 pub const http2_frame = @import("http/http2_frame.zig");
 pub const http2_stream = @import("http/http2_stream.zig");
 pub const upstream_h2 = @import("http/upstream_h2.zig");
+pub const stream_transport = @import("http/stream_transport.zig");
 pub const ngtcp2_binding = @import("http/ngtcp2_binding.zig");
 pub const http3_handler = @import("http/http3_handler.zig");
 pub const http3_session = @import("http/http3_session.zig");

--- a/src/http/stream_transport.zig
+++ b/src/http/stream_transport.zig
@@ -1,0 +1,181 @@
+//! Protocol-agnostic upstream stream transport contract (#241).
+//!
+//! This is the target shape that the existing h1 buffered/streaming paths,
+//! `upstream_h2.H2Conn`, and future h3 transports map to. It is intentionally
+//! a small data contract first: no current proxy path is rewritten here.
+
+const std = @import("std");
+
+pub const Protocol = enum {
+    h1,
+    h2,
+    h3,
+};
+
+pub const TimeoutPhase = enum {
+    connect,
+    request_write,
+    response_head,
+    response_body,
+};
+
+pub const TransportMeta = struct {
+    protocol: Protocol,
+    reused_connection: bool = false,
+    stream_id: ?u64 = null,
+};
+
+pub const Header = struct {
+    name: []const u8,
+    value: []const u8,
+};
+
+pub const RequestHead = struct {
+    method: []const u8,
+    scheme: []const u8,
+    authority: []const u8,
+    path: []const u8,
+    headers: []const Header = &.{},
+};
+
+pub const BodySource = struct {
+    ctx: *anyopaque,
+    readFn: *const fn (*anyopaque, []u8) anyerror!usize,
+
+    pub fn read(self: BodySource, out: []u8) !usize {
+        return self.readFn(self.ctx, out);
+    }
+};
+
+pub const RequestBody = union(enum) {
+    none,
+    buffered: []const u8,
+    streaming: BodySource,
+};
+
+pub const ResponseHead = struct {
+    status: u16,
+    reason: []const u8 = "",
+    headers: []const Header = &.{},
+    meta: TransportMeta,
+};
+
+pub const ResponseBody = struct {
+    ctx: *anyopaque,
+    readFn: *const fn (*anyopaque, []u8) anyerror!usize,
+    finishFn: *const fn (*anyopaque) void,
+
+    pub fn read(self: ResponseBody, out: []u8) !usize {
+        return self.readFn(self.ctx, out);
+    }
+
+    pub fn finish(self: ResponseBody) void {
+        self.finishFn(self.ctx);
+    }
+};
+
+pub const DeliveryState = enum {
+    /// The request has not reached the origin. A retry on a fresh connection is
+    /// always safe and does not consume the normal attempt budget.
+    before_delivery,
+    /// The request may have reached the origin, but no response bytes were
+    /// written downstream. Retry only when the method and policy allow it.
+    sent_no_downstream_response,
+    /// Response headers or body bytes have been written downstream. Retrying
+    /// would duplicate or fabricate a response and is forbidden.
+    response_started_downstream,
+};
+
+pub const RetryBoundary = enum {
+    safe_before_delivery,
+    maybe_safe_before_response,
+    unsafe_after_downstream_started,
+};
+
+pub fn retryBoundary(state: DeliveryState) RetryBoundary {
+    return switch (state) {
+        .before_delivery => .safe_before_delivery,
+        .sent_no_downstream_response => .maybe_safe_before_response,
+        .response_started_downstream => .unsafe_after_downstream_started,
+    };
+}
+
+pub const Exchange = struct {
+    request: RequestHead,
+    body: RequestBody,
+    connect_timeout_ms: u32 = 0,
+    response_timeout_ms: u32 = 0,
+};
+
+pub const OpenedResponse = struct {
+    head: ResponseHead,
+    body: ResponseBody,
+    delivery_state: DeliveryState,
+};
+
+const SliceReader = struct {
+    data: []const u8,
+    off: usize = 0,
+    finished: bool = false,
+
+    fn read(ctx: *anyopaque, out: []u8) !usize {
+        const self: *SliceReader = @ptrCast(@alignCast(ctx));
+        const remaining = self.data[self.off..];
+        if (remaining.len == 0) return 0;
+        const n = @min(out.len, remaining.len);
+        @memcpy(out[0..n], remaining[0..n]);
+        self.off += n;
+        return n;
+    }
+
+    fn finish(ctx: *anyopaque) void {
+        const self: *SliceReader = @ptrCast(@alignCast(ctx));
+        self.finished = true;
+    }
+};
+
+test "BodySource drains a streaming request body" {
+    var reader = SliceReader{ .data = "request-body" };
+    const source = BodySource{ .ctx = &reader, .readFn = SliceReader.read };
+
+    var buf: [7]u8 = undefined;
+    const first = try source.read(&buf);
+    try std.testing.expectEqualSlices(u8, "request", buf[0..first]);
+    const second = try source.read(&buf);
+    try std.testing.expectEqualSlices(u8, "-body", buf[0..second]);
+    try std.testing.expectEqual(@as(usize, 0), try source.read(&buf));
+}
+
+test "ResponseBody exposes headers-first pull drain and explicit finish" {
+    var reader = SliceReader{ .data = "part1part2" };
+    const response = OpenedResponse{
+        .head = .{
+            .status = 200,
+            .reason = "OK",
+            .headers = &.{.{ .name = "content-type", .value = "text/plain" }},
+            .meta = .{ .protocol = .h2, .reused_connection = true, .stream_id = 5 },
+        },
+        .body = .{
+            .ctx = &reader,
+            .readFn = SliceReader.read,
+            .finishFn = SliceReader.finish,
+        },
+        .delivery_state = .sent_no_downstream_response,
+    };
+
+    try std.testing.expectEqual(@as(u16, 200), response.head.status);
+    try std.testing.expectEqual(Protocol.h2, response.head.meta.protocol);
+    try std.testing.expectEqual(@as(?u64, 5), response.head.meta.stream_id);
+
+    var buf: [5]u8 = undefined;
+    const n = try response.body.read(&buf);
+    try std.testing.expectEqualSlices(u8, "part1", buf[0..n]);
+    response.body.finish();
+    try std.testing.expect(reader.finished);
+}
+
+test "retryBoundary pins the shared retry policy states" {
+    try std.testing.expectEqual(RetryBoundary.safe_before_delivery, retryBoundary(.before_delivery));
+    try std.testing.expectEqual(RetryBoundary.maybe_safe_before_response, retryBoundary(.sent_no_downstream_response));
+    try std.testing.expectEqual(RetryBoundary.unsafe_after_downstream_started, retryBoundary(.response_started_downstream));
+}

--- a/src/http/stream_transport.zig
+++ b/src/http/stream_transport.zig
@@ -19,6 +19,28 @@ pub const TimeoutPhase = enum {
     response_body,
 };
 
+pub const StreamError = error{
+    Timeout,
+    Cancelled,
+    StreamReset,
+    ConnectionClosed,
+    UpstreamProtocolError,
+    OutOfMemory,
+};
+
+pub const RequestFinishReason = enum {
+    sent,
+    cancelled_downstream,
+    timeout,
+    upstream_error,
+};
+
+pub const ResponseFinishReason = enum {
+    drained,
+    cancelled_downstream,
+    upstream_error,
+};
+
 pub const TransportMeta = struct {
     protocol: Protocol,
     reused_connection: bool = false,
@@ -40,10 +62,15 @@ pub const RequestHead = struct {
 
 pub const BodySource = struct {
     ctx: *anyopaque,
-    readFn: *const fn (*anyopaque, []u8) anyerror!usize,
+    readFn: *const fn (*anyopaque, []u8) StreamError!usize,
+    finishFn: *const fn (*anyopaque, RequestFinishReason) void,
 
-    pub fn read(self: BodySource, out: []u8) !usize {
+    pub fn read(self: BodySource, out: []u8) StreamError!usize {
         return self.readFn(self.ctx, out);
+    }
+
+    pub fn finish(self: BodySource, reason: RequestFinishReason) void {
+        self.finishFn(self.ctx, reason);
     }
 };
 
@@ -62,15 +89,15 @@ pub const ResponseHead = struct {
 
 pub const ResponseBody = struct {
     ctx: *anyopaque,
-    readFn: *const fn (*anyopaque, []u8) anyerror!usize,
-    finishFn: *const fn (*anyopaque) void,
+    readFn: *const fn (*anyopaque, []u8) StreamError!usize,
+    finishFn: *const fn (*anyopaque, ResponseFinishReason) void,
 
-    pub fn read(self: ResponseBody, out: []u8) !usize {
+    pub fn read(self: ResponseBody, out: []u8) StreamError!usize {
         return self.readFn(self.ctx, out);
     }
 
-    pub fn finish(self: ResponseBody) void {
-        self.finishFn(self.ctx);
+    pub fn finish(self: ResponseBody, reason: ResponseFinishReason) void {
+        self.finishFn(self.ctx, reason);
     }
 };
 
@@ -116,9 +143,10 @@ pub const OpenedResponse = struct {
 const SliceReader = struct {
     data: []const u8,
     off: usize = 0,
-    finished: bool = false,
+    request_finish: ?RequestFinishReason = null,
+    response_finish: ?ResponseFinishReason = null,
 
-    fn read(ctx: *anyopaque, out: []u8) !usize {
+    fn read(ctx: *anyopaque, out: []u8) StreamError!usize {
         const self: *SliceReader = @ptrCast(@alignCast(ctx));
         const remaining = self.data[self.off..];
         if (remaining.len == 0) return 0;
@@ -128,15 +156,24 @@ const SliceReader = struct {
         return n;
     }
 
-    fn finish(ctx: *anyopaque) void {
+    fn finishRequest(ctx: *anyopaque, reason: RequestFinishReason) void {
         const self: *SliceReader = @ptrCast(@alignCast(ctx));
-        self.finished = true;
+        self.request_finish = reason;
+    }
+
+    fn finishResponse(ctx: *anyopaque, reason: ResponseFinishReason) void {
+        const self: *SliceReader = @ptrCast(@alignCast(ctx));
+        self.response_finish = reason;
     }
 };
 
-test "BodySource drains a streaming request body" {
+test "BodySource drains and finishes a streaming request body" {
     var reader = SliceReader{ .data = "request-body" };
-    const source = BodySource{ .ctx = &reader, .readFn = SliceReader.read };
+    const source = BodySource{
+        .ctx = &reader,
+        .readFn = SliceReader.read,
+        .finishFn = SliceReader.finishRequest,
+    };
 
     var buf: [7]u8 = undefined;
     const first = try source.read(&buf);
@@ -144,9 +181,11 @@ test "BodySource drains a streaming request body" {
     const second = try source.read(&buf);
     try std.testing.expectEqualSlices(u8, "-body", buf[0..second]);
     try std.testing.expectEqual(@as(usize, 0), try source.read(&buf));
+    source.finish(.sent);
+    try std.testing.expectEqual(RequestFinishReason.sent, reader.request_finish.?);
 }
 
-test "ResponseBody exposes headers-first pull drain and explicit finish" {
+test "ResponseBody exposes headers-first pull drain and reasoned finish" {
     var reader = SliceReader{ .data = "part1part2" };
     const response = OpenedResponse{
         .head = .{
@@ -158,7 +197,7 @@ test "ResponseBody exposes headers-first pull drain and explicit finish" {
         .body = .{
             .ctx = &reader,
             .readFn = SliceReader.read,
-            .finishFn = SliceReader.finish,
+            .finishFn = SliceReader.finishResponse,
         },
         .delivery_state = .sent_no_downstream_response,
     };
@@ -170,8 +209,8 @@ test "ResponseBody exposes headers-first pull drain and explicit finish" {
     var buf: [5]u8 = undefined;
     const n = try response.body.read(&buf);
     try std.testing.expectEqualSlices(u8, "part1", buf[0..n]);
-    response.body.finish();
-    try std.testing.expect(reader.finished);
+    response.body.finish(.cancelled_downstream);
+    try std.testing.expectEqual(ResponseFinishReason.cancelled_downstream, reader.response_finish.?);
 }
 
 test "retryBoundary pins the shared retry policy states" {


### PR DESCRIPTION
## Summary
- add `src/http/stream_transport.zig` as the shared h1/h2/h3 proxy stream contract
- model request heads, buffered or streaming request bodies, headers-first responses, pull-based response bodies, protocol metadata, timeout phases, and retry boundaries
- add fake-adapter unit tests for request streaming, response drain/finish, and retry boundary state mapping
- document how current h1 buffered, h1 streaming, h2 buffered, and h2 streaming paths map to the contract without semantic loss

Closes #241

## Validation
- `zig fmt --check build.zig src/ tests/`
- `zig build test --summary all --error-style verbose` (637/638 passed, 1 skipped)
- `git diff --check`
