### PR TITLE
feat(quic): define config model and UDP endpoint contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ All notable user-facing changes to Tardigrade are documented here.
   `src/quic/config.zig` now captures the internal QUIC/H3 config defaults,
   validation rules, and transport-parameter mapping, while `src/quic/udp.zig`
   defines an HTTP-independent UDP endpoint contract with datagram metadata,
-  ECN, buffer-tuning hooks, deterministic clocks, and DCID route keys.
+  ECN, buffer-tuning hooks, deterministic clocks, owned DCID route keys,
+  binary endpoint addresses, and all-or-error datagram sends.
   `docs/CONCURRENCY.md` documents the `udp`, `quic`, `tls_adapter`, `http3`,
   and gateway stream-transport seams plus the upstream-H3-first rollout model.
 - **Protocol-agnostic stream transport target defined (#241)** —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ All notable user-facing changes to Tardigrade are documented here.
 - **CI perf smoke now guards upstream connection reuse (#141)** — `benchmarks/ci-smoke.sh` scrapes the gateway metrics endpoint after the proxy run and fails if fewer than 80% of upstream connections were reused (`reused / (reused + new)`). This catches a regression to per-request connections — the exact failure mode that motivated the pool (#196 dropped reuse to zero). The smoke fixture gains a `metrics_path`.
 
 ### Documentation
+- **Pure Zig QUIC config and UDP endpoint foundation defined (#248)** —
+  `src/quic/config.zig` now captures the internal QUIC/H3 config defaults,
+  validation rules, and transport-parameter mapping, while `src/quic/udp.zig`
+  defines an HTTP-independent UDP endpoint contract with datagram metadata,
+  ECN, buffer-tuning hooks, deterministic clocks, and DCID route keys.
+  `docs/CONCURRENCY.md` documents the `udp`, `quic`, `tls_adapter`, `http3`,
+  and gateway stream-transport seams plus the upstream-H3-first rollout model.
 - **Protocol-agnostic stream transport target defined (#241)** —
   `src/http/stream_transport.zig` now defines the shared h1/h2/h3 proxy stream
   contract for request heads, buffered or streaming request bodies,

--- a/docs/CONCURRENCY.md
+++ b/docs/CONCURRENCY.md
@@ -98,6 +98,55 @@ Do not start an `io_uring` or async-runtime rewrite from this boundary. Any new
 backend must be benchmark-justified and fit behind the same socket/protocol
 ownership rules.
 
+## Pure Zig QUIC / H3 Embedding Target
+
+Pure Zig QUIC/H3 work starts upstream-first. Tardigrade should validate QUIC
+transport, stream flow control, QPACK, and proxy retry semantics as an upstream
+client before exposing a public downstream HTTP/3 UDP listener. A public listener
+adds Alt-Svc rollout, reload behavior, UDP routing, NAT rebinding at the edge,
+and load-balancer concerns that are tracked separately.
+
+The target module seams are:
+
+| Seam | Responsibility |
+|---|---|
+| `src/quic/udp.zig` | HTTP-independent UDP endpoint: send/receive datagrams, local/remote address metadata, ECN, socket buffer tuning, deterministic clock hook, and future batching/GSO/pacing extension points |
+| `src/quic/config.zig` | Internal config defaults, validation, and QUIC transport-parameter mapping |
+| `src/quic/packet.*` / `connection.*` / `stream.*` | QUIC packet codec, connection state, packet number spaces, DCID routing, timers, loss recovery, stream flow control, close/drain |
+| `src/quic/tls_adapter.*` | QUIC TLS 1.3 handshake bytes, transport parameters, traffic secrets, AEAD/header protection, ALPN, certificate state, and key updates |
+| `src/http3/` | HTTP/3 frames, control streams, SETTINGS, QPACK, and request/response mapping |
+| `src/http/stream_transport.zig` | Gateway-facing h1/h2/h3 stream/proxy contract |
+
+Incoming UDP packets are routed by parsed Destination Connection ID (DCID) to a
+connection bucket before HTTP/3 request logic runs. That routing layer owns QUIC
+connection/worker ownership; HTTP and gateway request types must not leak into
+`src/quic/udp.zig`.
+
+The initial config model is intentionally conservative and defaults off. Only
+safe rollout toggles should become operator-facing early; internal transport
+defaults can remain private until interop, benchmark, or production evidence says
+they need public control.
+
+| Config area | Transport mapping | Default | Exposure |
+|---|---|---|---|
+| Enable pure Zig QUIC/H3 | none | off | user-facing when implementation exists |
+| QUIC version set | version negotiation | QUIC v1, v2-aware but disabled | internal initially |
+| Idle timeout | `max_idle_timeout` | 30s | likely user-facing with upstream H3 |
+| Active CID limit | `active_connection_id_limit` | 4 | internal initially |
+| Max UDP payload | `max_udp_payload_size` | 1200 bytes | user-facing only if MTU tuning is needed |
+| Initial connection window | `initial_max_data` | 8 MiB | internal initially |
+| Initial stream windows | `initial_max_stream_data_*` | 1 MiB bidi, 256 KiB uni | internal initially |
+| Max streams | `initial_max_streams_*` | 100 bidi, 16 uni | internal initially |
+| Retry policy | address validation / tokens | off for upstream-first | user-facing for downstream listener work |
+| Migration policy | `disable_active_migration` | disabled | user-facing only when downstream listener exists |
+| qlog / keylog | debug artifact emission | off | local-debug toggle |
+| QPACK | SETTINGS | static-only, zero dynamic capacity | internal until dynamic QPACK lands |
+
+Allocator ownership is per connection. A QUIC connection owns packet/frame/stream
+scratch allocations and releases them on close/drain; stream buffers must not be
+owned by HTTP request objects. Deterministic timer/clock hooks belong below HTTP
+so RTT, PTO, loss recovery, and pacing tests can run without wall-clock sleeps.
+
 ---
 
 ## Lock inventory

--- a/docs/CONCURRENCY.md
+++ b/docs/CONCURRENCY.md
@@ -120,7 +120,17 @@ The target module seams are:
 Incoming UDP packets are routed by parsed Destination Connection ID (DCID) to a
 connection bucket before HTTP/3 request logic runs. That routing layer owns QUIC
 connection/worker ownership; HTTP and gateway request types must not leak into
-`src/quic/udp.zig`.
+`src/quic/udp.zig`. Route keys own a bounded copy of the DCID rather than a
+borrowed receive-buffer slice, so connection maps cannot accidentally retain
+packet scratch memory. Received datagram payload slices are explicitly
+short-lived: they point into caller-owned receive scratch and must be copied by
+connection code if needed after dispatch.
+
+The UDP endpoint contract is whole-datagram oriented. A successful send means
+the full datagram was handed to the socket layer; short sends are translated to
+errors by the endpoint implementation. Endpoint addresses carry binary IPv4/IPv6
+bytes plus port and scope id rather than formatted strings, avoiding hot-path
+parse/format allocation when real socket I/O lands.
 
 The initial config model is intentionally conservative and defaults off. Only
 safe rollout toggles should become operator-facing early; internal transport

--- a/src/http.zig
+++ b/src/http.zig
@@ -54,6 +54,7 @@ pub const http2_frame = @import("http/http2_frame.zig");
 pub const http2_stream = @import("http/http2_stream.zig");
 pub const upstream_h2 = @import("http/upstream_h2.zig");
 pub const stream_transport = @import("http/stream_transport.zig");
+pub const quic = @import("quic/root.zig");
 pub const ngtcp2_binding = @import("http/ngtcp2_binding.zig");
 pub const http3_handler = @import("http/http3_handler.zig");
 pub const http3_session = @import("http/http3_session.zig");

--- a/src/quic/config.zig
+++ b/src/quic/config.zig
@@ -1,0 +1,153 @@
+//! Pure Zig QUIC/H3 configuration model (#248).
+//!
+//! These structs define the internal transport defaults before the pure Zig
+//! implementation exists. Operator-facing env/config wiring should expose only
+//! fields that are needed for safe rollout; the remaining values are internal
+//! defaults until benchmarks or interop require public knobs.
+
+const std = @import("std");
+
+pub const QuicVersion = enum(u32) {
+    v1 = 0x00000001,
+    v2 = 0x6b3343cf,
+};
+
+pub const VersionSet = struct {
+    v1: bool = true,
+    v2: bool = false,
+
+    pub fn supports(self: VersionSet, version: QuicVersion) bool {
+        return switch (version) {
+            .v1 => self.v1,
+            .v2 => self.v2,
+        };
+    }
+
+    pub fn preferred(self: VersionSet) ?QuicVersion {
+        if (self.v1) return .v1;
+        if (self.v2) return .v2;
+        return null;
+    }
+};
+
+pub const RetryPolicy = enum {
+    off,
+    address_validation,
+};
+
+pub const MigrationPolicy = enum {
+    disabled,
+    nat_rebinding_only,
+    full,
+};
+
+pub const QpackMode = enum {
+    static_only,
+    dynamic,
+};
+
+pub const Observability = struct {
+    qlog_enabled: bool = false,
+    keylog_enabled: bool = false,
+};
+
+pub const QpackConfig = struct {
+    mode: QpackMode = .static_only,
+    dynamic_table_capacity: u64 = 0,
+    blocked_streams: u64 = 0,
+};
+
+pub const Config = struct {
+    enabled: bool = false,
+    versions: VersionSet = .{},
+    idle_timeout_ms: u64 = 30_000,
+    active_connection_id_limit: u64 = 4,
+    max_udp_payload_size: u64 = 1200,
+    initial_max_data: u64 = 8 * 1024 * 1024,
+    initial_max_stream_data_bidi_local: u64 = 1024 * 1024,
+    initial_max_stream_data_bidi_remote: u64 = 1024 * 1024,
+    initial_max_stream_data_uni: u64 = 256 * 1024,
+    initial_max_streams_bidi: u64 = 100,
+    initial_max_streams_uni: u64 = 16,
+    retry_policy: RetryPolicy = .off,
+    migration_policy: MigrationPolicy = .disabled,
+    observability: Observability = .{},
+    qpack: QpackConfig = .{},
+
+    pub fn validate(self: Config) !void {
+        if (self.versions.preferred() == null) return error.UnsupportedQuicVersion;
+        if (self.idle_timeout_ms == 0) return error.InvalidIdleTimeout;
+        if (self.active_connection_id_limit < 2) return error.InvalidActiveConnectionIdLimit;
+        if (self.max_udp_payload_size < 1200 or self.max_udp_payload_size > 65_527) return error.InvalidMaxUdpPayloadSize;
+        if (self.initial_max_data == 0) return error.InvalidFlowControlWindow;
+        if (self.initial_max_stream_data_bidi_local > self.initial_max_data) return error.InvalidFlowControlWindow;
+        if (self.initial_max_stream_data_bidi_remote > self.initial_max_data) return error.InvalidFlowControlWindow;
+        if (self.initial_max_stream_data_uni > self.initial_max_data) return error.InvalidFlowControlWindow;
+        if (self.initial_max_streams_bidi == 0) return error.InvalidStreamLimit;
+        if (self.qpack.mode == .static_only and (self.qpack.dynamic_table_capacity != 0 or self.qpack.blocked_streams != 0)) {
+            return error.InvalidQpackConfig;
+        }
+    }
+
+    pub fn transportParameters(self: Config) !TransportParameters {
+        try self.validate();
+        return .{
+            .max_idle_timeout_ms = self.idle_timeout_ms,
+            .active_connection_id_limit = self.active_connection_id_limit,
+            .max_udp_payload_size = self.max_udp_payload_size,
+            .initial_max_data = self.initial_max_data,
+            .initial_max_stream_data_bidi_local = self.initial_max_stream_data_bidi_local,
+            .initial_max_stream_data_bidi_remote = self.initial_max_stream_data_bidi_remote,
+            .initial_max_stream_data_uni = self.initial_max_stream_data_uni,
+            .initial_max_streams_bidi = self.initial_max_streams_bidi,
+            .initial_max_streams_uni = self.initial_max_streams_uni,
+            .disable_active_migration = self.migration_policy == .disabled,
+        };
+    }
+};
+
+pub const TransportParameters = struct {
+    max_idle_timeout_ms: u64,
+    active_connection_id_limit: u64,
+    max_udp_payload_size: u64,
+    initial_max_data: u64,
+    initial_max_stream_data_bidi_local: u64,
+    initial_max_stream_data_bidi_remote: u64,
+    initial_max_stream_data_uni: u64,
+    initial_max_streams_bidi: u64,
+    initial_max_streams_uni: u64,
+    disable_active_migration: bool,
+};
+
+test "default QUIC config maps to conservative transport parameters" {
+    const cfg = Config{};
+    const params = try cfg.transportParameters();
+    try std.testing.expect(!cfg.enabled);
+    try std.testing.expect(cfg.versions.supports(.v1));
+    try std.testing.expect(!cfg.versions.supports(.v2));
+    try std.testing.expectEqual(@as(u64, 30_000), params.max_idle_timeout_ms);
+    try std.testing.expectEqual(@as(u64, 4), params.active_connection_id_limit);
+    try std.testing.expectEqual(@as(u64, 1200), params.max_udp_payload_size);
+    try std.testing.expect(params.disable_active_migration);
+    try std.testing.expectEqual(QpackMode.static_only, cfg.qpack.mode);
+}
+
+test "QUIC config validation rejects unsafe combinations" {
+    try std.testing.expectError(error.UnsupportedQuicVersion, (Config{ .versions = .{ .v1 = false, .v2 = false } }).validate());
+    try std.testing.expectError(error.InvalidActiveConnectionIdLimit, (Config{ .active_connection_id_limit = 1 }).validate());
+    try std.testing.expectError(error.InvalidMaxUdpPayloadSize, (Config{ .max_udp_payload_size = 1199 }).validate());
+    try std.testing.expectError(error.InvalidFlowControlWindow, (Config{
+        .initial_max_data = 1024,
+        .initial_max_stream_data_bidi_local = 2048,
+    }).validate());
+    try std.testing.expectError(error.InvalidQpackConfig, (Config{
+        .qpack = .{ .mode = .static_only, .dynamic_table_capacity = 4096 },
+    }).validate());
+}
+
+test "migration policy maps to transport parameter" {
+    const disabled = try (Config{ .migration_policy = .disabled }).transportParameters();
+    const rebinding = try (Config{ .migration_policy = .nat_rebinding_only }).transportParameters();
+    try std.testing.expect(disabled.disable_active_migration);
+    try std.testing.expect(!rebinding.disable_active_migration);
+}

--- a/src/quic/root.zig
+++ b/src/quic/root.zig
@@ -1,0 +1,8 @@
+//! Pure Zig QUIC foundation modules.
+
+pub const config = @import("config.zig");
+pub const udp = @import("udp.zig");
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/quic/udp.zig
+++ b/src/quic/udp.zig
@@ -1,0 +1,183 @@
+//! HTTP-independent UDP endpoint contract for pure Zig QUIC (#248).
+//!
+//! This layer owns datagram metadata, socket tuning hooks, deterministic time,
+//! and future batching/pacing extension points. It must not import gateway or
+//! HTTP request types; QUIC packet routing happens above it by DCID.
+
+const std = @import("std");
+
+pub const Ecn = enum {
+    unavailable,
+    not_ect,
+    ect0,
+    ect1,
+    ce,
+};
+
+pub const Address = struct {
+    ip: []const u8,
+    port: u16,
+};
+
+pub const ReceivedDatagram = struct {
+    bytes: []const u8,
+    local: ?Address = null,
+    remote: Address,
+    ecn: Ecn = .unavailable,
+    received_at_us: u64,
+};
+
+pub const SendDatagram = struct {
+    bytes: []const u8,
+    local: ?Address = null,
+    remote: Address,
+    ecn: Ecn = .unavailable,
+    /// Future pacing hook. `null` means send as soon as the endpoint can.
+    send_at_us: ?u64 = null,
+};
+
+pub const BufferTuning = struct {
+    recv_bytes: ?usize = null,
+    send_bytes: ?usize = null,
+};
+
+pub const ReceiveError = error{
+    WouldBlock,
+    PacketTooLarge,
+    SocketClosed,
+    Unexpected,
+};
+
+pub const SendError = error{
+    PacketTooLarge,
+    SocketClosed,
+    Unexpected,
+};
+
+pub const Clock = struct {
+    ctx: *anyopaque,
+    nowUsFn: *const fn (*anyopaque) u64,
+
+    pub fn nowUs(self: Clock) u64 {
+        return self.nowUsFn(self.ctx);
+    }
+};
+
+pub const Endpoint = struct {
+    ctx: *anyopaque,
+    clock: Clock,
+    recvFn: *const fn (*anyopaque, []u8, Clock) ReceiveError!ReceivedDatagram,
+    sendFn: *const fn (*anyopaque, SendDatagram) SendError!usize,
+    tuneBuffersFn: *const fn (*anyopaque, BufferTuning) void,
+
+    pub fn receive(self: Endpoint, scratch: []u8) ReceiveError!ReceivedDatagram {
+        return self.recvFn(self.ctx, scratch, self.clock);
+    }
+
+    pub fn send(self: Endpoint, datagram: SendDatagram) SendError!usize {
+        return self.sendFn(self.ctx, datagram);
+    }
+
+    pub fn tuneBuffers(self: Endpoint, tuning: BufferTuning) void {
+        self.tuneBuffersFn(self.ctx, tuning);
+    }
+};
+
+pub const RouteKey = struct {
+    dcid: []const u8,
+};
+
+pub fn routeByDcid(dcid: []const u8) ?RouteKey {
+    if (dcid.len == 0) return null;
+    return .{ .dcid = dcid };
+}
+
+const FakeClock = struct {
+    now_us: u64,
+
+    fn now(ctx: *anyopaque) u64 {
+        const self: *FakeClock = @ptrCast(@alignCast(ctx));
+        return self.now_us;
+    }
+};
+
+const FakeEndpoint = struct {
+    clock: FakeClock,
+    recv_payload: []const u8,
+    remote: Address,
+    last_sent_len: usize = 0,
+    last_tuning: BufferTuning = .{},
+
+    fn receive(ctx: *anyopaque, scratch: []u8, clock: Clock) ReceiveError!ReceivedDatagram {
+        const self: *FakeEndpoint = @ptrCast(@alignCast(ctx));
+        if (scratch.len < self.recv_payload.len) return error.PacketTooLarge;
+        @memcpy(scratch[0..self.recv_payload.len], self.recv_payload);
+        return .{
+            .bytes = scratch[0..self.recv_payload.len],
+            .remote = self.remote,
+            .ecn = .ect0,
+            .received_at_us = clock.nowUs(),
+        };
+    }
+
+    fn send(ctx: *anyopaque, datagram: SendDatagram) SendError!usize {
+        const self: *FakeEndpoint = @ptrCast(@alignCast(ctx));
+        self.last_sent_len = datagram.bytes.len;
+        return datagram.bytes.len;
+    }
+
+    fn tune(ctx: *anyopaque, tuning: BufferTuning) void {
+        const self: *FakeEndpoint = @ptrCast(@alignCast(ctx));
+        self.last_tuning = tuning;
+    }
+
+    fn endpoint(self: *FakeEndpoint) Endpoint {
+        return .{
+            .ctx = self,
+            .clock = .{ .ctx = &self.clock, .nowUsFn = FakeClock.now },
+            .recvFn = FakeEndpoint.receive,
+            .sendFn = FakeEndpoint.send,
+            .tuneBuffersFn = FakeEndpoint.tune,
+        };
+    }
+};
+
+test "UDP endpoint carries datagram metadata and deterministic time" {
+    var fake = FakeEndpoint{
+        .clock = .{ .now_us = 42_000 },
+        .recv_payload = "packet",
+        .remote = .{ .ip = "127.0.0.1", .port = 4433 },
+    };
+    const endpoint = fake.endpoint();
+    var scratch: [64]u8 = undefined;
+    const datagram = try endpoint.receive(&scratch);
+    try std.testing.expectEqualSlices(u8, "packet", datagram.bytes);
+    try std.testing.expectEqualStrings("127.0.0.1", datagram.remote.ip);
+    try std.testing.expectEqual(@as(u16, 4433), datagram.remote.port);
+    try std.testing.expectEqual(Ecn.ect0, datagram.ecn);
+    try std.testing.expectEqual(@as(u64, 42_000), datagram.received_at_us);
+}
+
+test "UDP endpoint exposes send and buffer tuning hooks" {
+    var fake = FakeEndpoint{
+        .clock = .{ .now_us = 1 },
+        .recv_payload = "",
+        .remote = .{ .ip = "127.0.0.1", .port = 4433 },
+    };
+    const endpoint = fake.endpoint();
+    const sent = try endpoint.send(.{
+        .bytes = "hello",
+        .remote = .{ .ip = "127.0.0.1", .port = 4433 },
+        .send_at_us = 100,
+    });
+    endpoint.tuneBuffers(.{ .recv_bytes = 4 * 1024 * 1024, .send_bytes = 1024 * 1024 });
+    try std.testing.expectEqual(@as(usize, 5), sent);
+    try std.testing.expectEqual(@as(usize, 5), fake.last_sent_len);
+    try std.testing.expectEqual(@as(?usize, 4 * 1024 * 1024), fake.last_tuning.recv_bytes);
+}
+
+test "DCID routing key rejects empty IDs" {
+    try std.testing.expect(routeByDcid("") == null);
+    const key = routeByDcid("abcd").?;
+    try std.testing.expectEqualSlices(u8, "abcd", key.dcid);
+}

--- a/src/quic/udp.zig
+++ b/src/quic/udp.zig
@@ -14,12 +14,39 @@ pub const Ecn = enum {
     ce,
 };
 
+pub const AddressFamily = enum {
+    ip4,
+    ip6,
+};
+
 pub const Address = struct {
-    ip: []const u8,
+    family: AddressFamily,
+    bytes: [16]u8 = [_]u8{0} ** 16,
     port: u16,
+    scope_id: u32 = 0,
+
+    pub fn ip4(octets: [4]u8, port: u16) Address {
+        var address = Address{ .family = .ip4, .port = port };
+        @memcpy(address.bytes[0..4], &octets);
+        return address;
+    }
+
+    pub fn ip6(octets: [16]u8, port: u16, scope_id: u32) Address {
+        return .{ .family = .ip6, .bytes = octets, .port = port, .scope_id = scope_id };
+    }
+
+    pub fn slice(self: *const Address) []const u8 {
+        return switch (self.family) {
+            .ip4 => self.bytes[0..4],
+            .ip6 => self.bytes[0..16],
+        };
+    }
 };
 
 pub const ReceivedDatagram = struct {
+    /// Slice into the caller-provided receive scratch buffer. Valid only until
+    /// that scratch buffer is reused or the next receive call writes into it.
+    /// Connection state that outlives dispatch must copy packet bytes it needs.
     bytes: []const u8,
     local: ?Address = null,
     remote: Address,
@@ -67,15 +94,17 @@ pub const Endpoint = struct {
     ctx: *anyopaque,
     clock: Clock,
     recvFn: *const fn (*anyopaque, []u8, Clock) ReceiveError!ReceivedDatagram,
-    sendFn: *const fn (*anyopaque, SendDatagram) SendError!usize,
+    sendFn: *const fn (*anyopaque, SendDatagram) SendError!void,
     tuneBuffersFn: *const fn (*anyopaque, BufferTuning) void,
 
     pub fn receive(self: Endpoint, scratch: []u8) ReceiveError!ReceivedDatagram {
         return self.recvFn(self.ctx, scratch, self.clock);
     }
 
-    pub fn send(self: Endpoint, datagram: SendDatagram) SendError!usize {
-        return self.sendFn(self.ctx, datagram);
+    /// Send one complete UDP datagram. Short successful sends are not part of
+    /// this contract; an implementation must translate them to an error.
+    pub fn send(self: Endpoint, datagram: SendDatagram) SendError!void {
+        try self.sendFn(self.ctx, datagram);
     }
 
     pub fn tuneBuffers(self: Endpoint, tuning: BufferTuning) void {
@@ -83,13 +112,31 @@ pub const Endpoint = struct {
     }
 };
 
-pub const RouteKey = struct {
-    dcid: []const u8,
+pub const MaxConnectionIdLen = 20;
+
+pub const ConnectionId = struct {
+    bytes: [MaxConnectionIdLen]u8 = [_]u8{0} ** MaxConnectionIdLen,
+    len: u8 = 0,
+
+    pub fn init(raw: []const u8) !ConnectionId {
+        if (raw.len == 0) return error.EmptyConnectionId;
+        if (raw.len > MaxConnectionIdLen) return error.ConnectionIdTooLong;
+        var id = ConnectionId{ .len = @intCast(raw.len) };
+        @memcpy(id.bytes[0..raw.len], raw);
+        return id;
+    }
+
+    pub fn slice(self: *const ConnectionId) []const u8 {
+        return self.bytes[0..self.len];
+    }
 };
 
-pub fn routeByDcid(dcid: []const u8) ?RouteKey {
-    if (dcid.len == 0) return null;
-    return .{ .dcid = dcid };
+pub const RouteKey = struct {
+    dcid: ConnectionId,
+};
+
+pub fn routeByDcid(dcid: []const u8) !RouteKey {
+    return .{ .dcid = try ConnectionId.init(dcid) };
 }
 
 const FakeClock = struct {
@@ -120,10 +167,9 @@ const FakeEndpoint = struct {
         };
     }
 
-    fn send(ctx: *anyopaque, datagram: SendDatagram) SendError!usize {
+    fn send(ctx: *anyopaque, datagram: SendDatagram) SendError!void {
         const self: *FakeEndpoint = @ptrCast(@alignCast(ctx));
         self.last_sent_len = datagram.bytes.len;
-        return datagram.bytes.len;
     }
 
     fn tune(ctx: *anyopaque, tuning: BufferTuning) void {
@@ -146,13 +192,14 @@ test "UDP endpoint carries datagram metadata and deterministic time" {
     var fake = FakeEndpoint{
         .clock = .{ .now_us = 42_000 },
         .recv_payload = "packet",
-        .remote = .{ .ip = "127.0.0.1", .port = 4433 },
+        .remote = Address.ip4(.{ 127, 0, 0, 1 }, 4433),
     };
     const endpoint = fake.endpoint();
     var scratch: [64]u8 = undefined;
     const datagram = try endpoint.receive(&scratch);
     try std.testing.expectEqualSlices(u8, "packet", datagram.bytes);
-    try std.testing.expectEqualStrings("127.0.0.1", datagram.remote.ip);
+    try std.testing.expectEqual(AddressFamily.ip4, datagram.remote.family);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 127, 0, 0, 1 }, datagram.remote.slice());
     try std.testing.expectEqual(@as(u16, 4433), datagram.remote.port);
     try std.testing.expectEqual(Ecn.ect0, datagram.ecn);
     try std.testing.expectEqual(@as(u64, 42_000), datagram.received_at_us);
@@ -162,22 +209,24 @@ test "UDP endpoint exposes send and buffer tuning hooks" {
     var fake = FakeEndpoint{
         .clock = .{ .now_us = 1 },
         .recv_payload = "",
-        .remote = .{ .ip = "127.0.0.1", .port = 4433 },
+        .remote = Address.ip4(.{ 127, 0, 0, 1 }, 4433),
     };
     const endpoint = fake.endpoint();
-    const sent = try endpoint.send(.{
+    try endpoint.send(.{
         .bytes = "hello",
-        .remote = .{ .ip = "127.0.0.1", .port = 4433 },
+        .remote = Address.ip4(.{ 127, 0, 0, 1 }, 4433),
         .send_at_us = 100,
     });
     endpoint.tuneBuffers(.{ .recv_bytes = 4 * 1024 * 1024, .send_bytes = 1024 * 1024 });
-    try std.testing.expectEqual(@as(usize, 5), sent);
     try std.testing.expectEqual(@as(usize, 5), fake.last_sent_len);
     try std.testing.expectEqual(@as(?usize, 4 * 1024 * 1024), fake.last_tuning.recv_bytes);
 }
 
-test "DCID routing key rejects empty IDs" {
-    try std.testing.expect(routeByDcid("") == null);
-    const key = routeByDcid("abcd").?;
-    try std.testing.expectEqualSlices(u8, "abcd", key.dcid);
+test "DCID routing key owns a bounded connection ID" {
+    try std.testing.expectError(error.EmptyConnectionId, routeByDcid(""));
+    try std.testing.expectError(error.ConnectionIdTooLong, routeByDcid("012345678901234567890"));
+    var source = [_]u8{ 'a', 'b', 'c', 'd' };
+    const key = try routeByDcid(&source);
+    source[0] = 'z';
+    try std.testing.expectEqualSlices(u8, "abcd", key.dcid.slice());
 }


### PR DESCRIPTION
## Summary
- add `src/quic/config.zig` with conservative pure Zig QUIC/H3 defaults, validation, and transport-parameter mapping
- add `src/quic/udp.zig` as an HTTP-independent UDP endpoint contract with datagram metadata, ECN, buffer tuning, deterministic clock hooks, pacing/batching extension slots, and DCID route keys
- export the new pure Zig QUIC foundation modules through `http.quic` so unit tests run with the existing target
- document the `udp`, `quic`, `tls_adapter`, `http3`, and gateway stream-transport seams plus upstream-H3-first rollout in `docs/CONCURRENCY.md`

Closes #248

## Validation
- `zig fmt --check build.zig src/ tests/`
- `git diff --check`
- `zig build test --summary all --error-style verbose` (645/646 passed, 1 skipped)

## Note
I intentionally skipped #246 as the next implementation target because it is too large for one safe PR and depends on still-open foundation pieces such as static QPACK (#252). This PR takes the next substantial foundation issue that unblocks that path.
