### PR TITLE
refactor(gateway): separate route matching from execution via RouteDecision (#201, PR 1)

### DIFF
--- a/src/gateway_handlers.zig
+++ b/src/gateway_handlers.zig
@@ -40,6 +40,63 @@ const handleStaticLocation = gstatic.handleStaticLocation;
 const maybeResolveStaticErrorPage = gstatic.maybeResolveStaticErrorPage;
 const serveTryFilesFallback = gstatic.serveTryFilesFallback;
 
+/// The route a request resolves to, decided independently of executing it.
+/// Kept exhaustive so a new route kind forces a decision at every dispatch site.
+pub const RouteDecision = union(enum) {
+    reload_status,
+    metrics,
+    location: http.location_router.MatchResult,
+    unmatched,
+};
+
+/// Pure route-matching precedence — no I/O, no mutation of `state`/`request`.
+/// Mirrors the order previously inlined at the top of `routeRequest`: the
+/// reload-status path, then the configured metrics path, then location blocks.
+/// (The transcript route still matches+executes inside `routeRequest`; folding
+/// it in here is a small follow-up.)
+pub fn resolveRoute(cfg: *const edge_config.EdgeConfig, request: *const http.Request) RouteDecision {
+    return resolveRouteFor(cfg.metrics_path, cfg.location_blocks, request.uri.path);
+}
+
+/// Pure core of route resolution, decoupled from `EdgeConfig`/`Request` so the
+/// precedence is directly unit-testable without constructing a full config.
+fn resolveRouteFor(
+    metrics_path: []const u8,
+    location_blocks: []const http.location_router.LocationBlock,
+    path: []const u8,
+) RouteDecision {
+    if (std.mem.eql(u8, path, "/tardigrade/reload/status")) return .reload_status;
+    if (metrics_path.len > 0 and std.mem.eql(u8, path, metrics_path)) return .metrics;
+    if (http.location_router.matchLocation(path, location_blocks)) |matched| {
+        return .{ .location = matched };
+    }
+    return .unmatched;
+}
+
+test "resolveRouteFor: reload-status and metrics precede location matching" {
+    const blocks = [_]http.location_router.LocationBlock{
+        .{ .match_type = .prefix, .pattern = "/", .priority = 0, .action = .{ .return_response = .{ .status = 200, .body = "" } } },
+    };
+    const Tag = std.meta.Tag(RouteDecision);
+    // reload-status wins over a configured metrics path and a catch-all location.
+    try std.testing.expectEqual(Tag.reload_status, std.meta.activeTag(resolveRouteFor("/metrics", &blocks, "/tardigrade/reload/status")));
+    // metrics path wins over a matching location.
+    try std.testing.expectEqual(Tag.metrics, std.meta.activeTag(resolveRouteFor("/metrics", &blocks, "/metrics")));
+    // an empty metrics_path disables the metrics route, falling to the location.
+    try std.testing.expectEqual(Tag.location, std.meta.activeTag(resolveRouteFor("", &blocks, "/metrics")));
+}
+
+test "resolveRouteFor: location match carries the block, else unmatched" {
+    const blocks = [_]http.location_router.LocationBlock{
+        .{ .match_type = .exact, .pattern = "/app", .priority = 1, .action = .{ .proxy_pass = "" } },
+    };
+    switch (resolveRouteFor("/status/metrics", &blocks, "/app")) {
+        .location => |m| try std.testing.expectEqualStrings("/app", m.block.pattern),
+        else => try std.testing.expect(false),
+    }
+    try std.testing.expectEqual(std.meta.Tag(RouteDecision).unmatched, std.meta.activeTag(resolveRouteFor("/status/metrics", &blocks, "/nope")));
+}
+
 pub fn routeRequest(
     conn: anytype,
     allocator: std.mem.Allocator,
@@ -58,121 +115,122 @@ pub fn routeRequest(
         return status;
     }
 
-    if (std.mem.eql(u8, request.uri.path, "/tardigrade/reload/status")) {
-        const status = try handleReloadStatusRoute(allocator, writer, state, correlation_id, keep_alive.*);
-        state.metricsRecord(status);
-        return status;
-    }
-
-    if (cfg.metrics_path.len > 0 and std.mem.eql(u8, request.uri.path, cfg.metrics_path)) {
-        const status = try handleMetricsRoute(allocator, writer, cfg, state, ctx, request, correlation_id, keep_alive.*);
-        state.metricsRecord(status);
-        return status;
-    }
-
-    if (http.location_router.matchLocation(request.uri.path, cfg.location_blocks)) |matched| {
-        if (matched.block.auth == .required and !ctx.authenticated and ctx.identity == null) {
-            var auth_res = try authorizeRequest(allocator, cfg, &request.headers);
-            defer auth_res.deinit(allocator);
-            if (auth_res.ok) {
-                if (auth_res.identity) |identity| {
-                    ctx.setAuthContext(identity, auth_res.user_id, auth_res.device_id, auth_res.scopes);
-                    auth_res.identity = null;
-                    auth_res.user_id = null;
-                    auth_res.device_id = null;
-                    auth_res.scopes = null;
-                }
-            } else if (http.session.fromHeaders(&request.headers)) |session_token| {
-                if (state.validateSessionIdentity(allocator, session_token)) |identity| {
-                    ctx.setIdentity(identity);
+    switch (resolveRoute(cfg, request)) {
+        .reload_status => {
+            const status = try handleReloadStatusRoute(allocator, writer, state, correlation_id, keep_alive.*);
+            state.metricsRecord(status);
+            return status;
+        },
+        .metrics => {
+            const status = try handleMetricsRoute(allocator, writer, cfg, state, ctx, request, correlation_id, keep_alive.*);
+            state.metricsRecord(status);
+            return status;
+        },
+        .unmatched => {},
+        .location => |matched| {
+            if (matched.block.auth == .required and !ctx.authenticated and ctx.identity == null) {
+                var auth_res = try authorizeRequest(allocator, cfg, &request.headers);
+                defer auth_res.deinit(allocator);
+                if (auth_res.ok) {
+                    if (auth_res.identity) |identity| {
+                        ctx.setAuthContext(identity, auth_res.user_id, auth_res.device_id, auth_res.scopes);
+                        auth_res.identity = null;
+                        auth_res.user_id = null;
+                        auth_res.device_id = null;
+                        auth_res.scopes = null;
+                    }
+                } else if (http.session.fromHeaders(&request.headers)) |session_token| {
+                    if (state.validateSessionIdentity(allocator, session_token)) |identity| {
+                        ctx.setIdentity(identity);
+                    } else {
+                        try sendApiError(allocator, writer, .unauthorized, "unauthorized", "Unauthorized", correlation_id, keep_alive.*, state);
+                        state.metricsRecord(401);
+                        state.metricsRecordErrorCode("unauthorized");
+                        return 401;
+                    }
+                } else if (cfg.auth_request_url.len > 0 and authorizeViaSubrequest(allocator, cfg, request, correlation_id, client_ip)) {
+                    ctx.authenticated = true;
                 } else {
-                    try sendApiError(allocator, writer, .unauthorized, "unauthorized", "Unauthorized", correlation_id, keep_alive.*, state);
-                    state.metricsRecord(401);
-                    state.metricsRecordErrorCode("unauthorized");
-                    return 401;
+                    const auth_status: http.Status = if (auth_res.failure_reason == .invalid) .forbidden else .unauthorized;
+                    const auth_code = if (auth_res.failure_reason == .invalid) "forbidden" else "unauthorized";
+                    const auth_message = if (auth_res.failure_reason == .invalid) "Forbidden" else "Unauthorized";
+                    const auth_status_code: u16 = @intFromEnum(auth_status);
+                    try sendApiError(allocator, writer, auth_status, auth_code, auth_message, correlation_id, keep_alive.*, state);
+                    state.metricsRecord(auth_status_code);
+                    state.metricsRecordErrorCode(auth_code);
+                    return auth_status_code;
                 }
-            } else if (cfg.auth_request_url.len > 0 and authorizeViaSubrequest(allocator, cfg, request, correlation_id, client_ip)) {
-                ctx.authenticated = true;
-            } else {
-                const auth_status: http.Status = if (auth_res.failure_reason == .invalid) .forbidden else .unauthorized;
-                const auth_code = if (auth_res.failure_reason == .invalid) "forbidden" else "unauthorized";
-                const auth_message = if (auth_res.failure_reason == .invalid) "Forbidden" else "Unauthorized";
-                const auth_status_code: u16 = @intFromEnum(auth_status);
-                try sendApiError(allocator, writer, auth_status, auth_code, auth_message, correlation_id, keep_alive.*, state);
-                state.metricsRecord(auth_status_code);
-                state.metricsRecordErrorCode(auth_code);
-                return auth_status_code;
             }
-        }
-        switch (matched.block.action) {
-            .proxy_pass => |target| {
-                return try handleLocationProxyPass(
-                    allocator,
-                    conn,
-                    writer,
-                    cfg,
-                    state,
-                    ctx,
-                    request,
-                    target,
-                    proxySuffixPathForLocation(request.uri.path, matched, cfg.location_blocks),
-                    correlation_id,
-                    keep_alive.*,
-                    client_ip,
-                    ctx.identity,
-                    ctx.user_id,
-                    ctx.device_id,
-                    ctx.scopes,
-                    request.headers.get("host"),
-                    matched.block.pattern,
-                    streaming_request_body,
-                );
-            },
-            .fastcgi_pass => |upstream| {
-                return try handleFastcgiRoute(allocator, writer, cfg, upstream, request, client_ip, correlation_id, keep_alive.*, state);
-            },
-            .return_response => |ret| {
-                // Static-return directives (non-redirect) only make semantic sense
-                // for GET and HEAD.  Accepting DELETE, PUT, or PATCH on a route like
-                // `return 200 ok` would silently succeed and mislead the client into
-                // believing a destructive operation completed (ASVS-14.5.1).
-                // Redirect responses (3xx) are method-agnostic and pass through.
-                const is_redirect = ret.status >= 300 and ret.status < 400;
-                if (!is_redirect and !(request.method == .GET or request.method == .HEAD)) {
-                    try sendApiError(allocator, writer, .method_not_allowed, "invalid_request", "Method Not Allowed", correlation_id, keep_alive.*, state);
-                    state.metricsRecord(405);
-                    return 405;
-                }
-                if (is_redirect and ret.body.len > 0) {
-                    var response = http.Response.redirect(allocator, ret.body, @enumFromInt(ret.status));
-                    defer response.deinit();
-                    _ = response.setConnection(keep_alive.*);
-                    setRequestIdHeaders(&response, correlation_id);
-                    ctx.response_bytes = 0;
-                    applyResponseHeaders(state, &response);
-                    try response.write(writer);
-                } else {
-                    var response = http.Response.init(allocator);
-                    defer response.deinit();
-                    _ = response.setStatus(@enumFromInt(ret.status))
-                        .setBody(ret.body)
-                        .setContentType("text/plain; charset=utf-8")
-                        .setConnection(keep_alive.*);
-                    setRequestIdHeaders(&response, correlation_id);
-                    ctx.response_bytes = ret.body.len;
-                    applyResponseHeaders(state, &response);
-                    try response.write(writer);
-                }
-                state.metricsRecord(ret.status);
-                return ret.status;
-            },
-            .rewrite => |rw| {
-                request.uri.path = rw.replacement;
-            },
-            .static_root => |root_cfg| {
-                if (try handleStaticLocation(allocator, conn, request, matched, root_cfg, correlation_id, keep_alive.*, state)) |status| return status;
-            },
-        }
+            switch (matched.block.action) {
+                .proxy_pass => |target| {
+                    return try handleLocationProxyPass(
+                        allocator,
+                        conn,
+                        writer,
+                        cfg,
+                        state,
+                        ctx,
+                        request,
+                        target,
+                        proxySuffixPathForLocation(request.uri.path, matched, cfg.location_blocks),
+                        correlation_id,
+                        keep_alive.*,
+                        client_ip,
+                        ctx.identity,
+                        ctx.user_id,
+                        ctx.device_id,
+                        ctx.scopes,
+                        request.headers.get("host"),
+                        matched.block.pattern,
+                        streaming_request_body,
+                    );
+                },
+                .fastcgi_pass => |upstream| {
+                    return try handleFastcgiRoute(allocator, writer, cfg, upstream, request, client_ip, correlation_id, keep_alive.*, state);
+                },
+                .return_response => |ret| {
+                    // Static-return directives (non-redirect) only make semantic sense
+                    // for GET and HEAD.  Accepting DELETE, PUT, or PATCH on a route like
+                    // `return 200 ok` would silently succeed and mislead the client into
+                    // believing a destructive operation completed (ASVS-14.5.1).
+                    // Redirect responses (3xx) are method-agnostic and pass through.
+                    const is_redirect = ret.status >= 300 and ret.status < 400;
+                    if (!is_redirect and !(request.method == .GET or request.method == .HEAD)) {
+                        try sendApiError(allocator, writer, .method_not_allowed, "invalid_request", "Method Not Allowed", correlation_id, keep_alive.*, state);
+                        state.metricsRecord(405);
+                        return 405;
+                    }
+                    if (is_redirect and ret.body.len > 0) {
+                        var response = http.Response.redirect(allocator, ret.body, @enumFromInt(ret.status));
+                        defer response.deinit();
+                        _ = response.setConnection(keep_alive.*);
+                        setRequestIdHeaders(&response, correlation_id);
+                        ctx.response_bytes = 0;
+                        applyResponseHeaders(state, &response);
+                        try response.write(writer);
+                    } else {
+                        var response = http.Response.init(allocator);
+                        defer response.deinit();
+                        _ = response.setStatus(@enumFromInt(ret.status))
+                            .setBody(ret.body)
+                            .setContentType("text/plain; charset=utf-8")
+                            .setConnection(keep_alive.*);
+                        setRequestIdHeaders(&response, correlation_id);
+                        ctx.response_bytes = ret.body.len;
+                        applyResponseHeaders(state, &response);
+                        try response.write(writer);
+                    }
+                    state.metricsRecord(ret.status);
+                    return ret.status;
+                },
+                .rewrite => |rw| {
+                    request.uri.path = rw.replacement;
+                },
+                .static_root => |root_cfg| {
+                    if (try handleStaticLocation(allocator, conn, request, matched, root_cfg, correlation_id, keep_alive.*, state)) |status| return status;
+                },
+            }
+        },
     }
 
     if (serveTryFilesFallback(allocator, conn, cfg, request, correlation_id, keep_alive.*, state)) |status| {

--- a/src/gateway_handlers.zig
+++ b/src/gateway_handlers.zig
@@ -49,18 +49,27 @@ pub const RouteDecision = union(enum) {
     unmatched,
 };
 
-/// Pure route-matching precedence — no I/O, no mutation of `state`/`request`.
-/// Mirrors the order previously inlined at the top of `routeRequest`: the
-/// reload-status path, then the configured metrics path, then location blocks.
-/// (The transcript route still matches+executes inside `routeRequest`; folding
-/// it in here is a small follow-up.)
+/// Resolve a request to its route. Convenience over `resolveRoutePath` for the
+/// h1 `http.Request`.
+///
+/// TODO(#201): the transcript route is intentionally NOT part of `RouteDecision`
+/// yet. `handleTranscriptRoute` returns null for a `/transcripts/…` path that is
+/// not a recognized transcript endpoint, letting it fall through to location
+/// matching / try_files; a `.transcript` decision variant would swallow that
+/// fall-through and change behavior. So it stays a pre-check in `routeRequest`
+/// until that matcher is split from its handler. Fold it in with the pre-route
+/// middleware stage (later #201 PR).
 pub fn resolveRoute(cfg: *const edge_config.EdgeConfig, request: *const http.Request) RouteDecision {
-    return resolveRouteFor(cfg.metrics_path, cfg.location_blocks, request.uri.path);
+    return resolveRoutePath(cfg.metrics_path, cfg.location_blocks, request.uri.path);
 }
 
-/// Pure core of route resolution, decoupled from `EdgeConfig`/`Request` so the
-/// precedence is directly unit-testable without constructing a full config.
-fn resolveRouteFor(
+/// Pure route-matching precedence — no I/O, no mutation of `state`/`request`.
+/// Decoupled from `EdgeConfig`/`Request` so h1, h3, and pure-Zig h3 can share
+/// the same precedence (h3 has `http3_session.StreamRequest`, not `http.Request`)
+/// and so it is directly unit-testable without constructing a full config.
+/// Mirrors the order previously inlined in `routeRequest`: reload-status path,
+/// then the configured metrics path, then location blocks.
+pub fn resolveRoutePath(
     metrics_path: []const u8,
     location_blocks: []const http.location_router.LocationBlock,
     path: []const u8,
@@ -73,28 +82,28 @@ fn resolveRouteFor(
     return .unmatched;
 }
 
-test "resolveRouteFor: reload-status and metrics precede location matching" {
+test "resolveRoutePath: reload-status and metrics precede location matching" {
     const blocks = [_]http.location_router.LocationBlock{
         .{ .match_type = .prefix, .pattern = "/", .priority = 0, .action = .{ .return_response = .{ .status = 200, .body = "" } } },
     };
     const Tag = std.meta.Tag(RouteDecision);
     // reload-status wins over a configured metrics path and a catch-all location.
-    try std.testing.expectEqual(Tag.reload_status, std.meta.activeTag(resolveRouteFor("/metrics", &blocks, "/tardigrade/reload/status")));
+    try std.testing.expectEqual(Tag.reload_status, std.meta.activeTag(resolveRoutePath("/metrics", &blocks, "/tardigrade/reload/status")));
     // metrics path wins over a matching location.
-    try std.testing.expectEqual(Tag.metrics, std.meta.activeTag(resolveRouteFor("/metrics", &blocks, "/metrics")));
+    try std.testing.expectEqual(Tag.metrics, std.meta.activeTag(resolveRoutePath("/metrics", &blocks, "/metrics")));
     // an empty metrics_path disables the metrics route, falling to the location.
-    try std.testing.expectEqual(Tag.location, std.meta.activeTag(resolveRouteFor("", &blocks, "/metrics")));
+    try std.testing.expectEqual(Tag.location, std.meta.activeTag(resolveRoutePath("", &blocks, "/metrics")));
 }
 
-test "resolveRouteFor: location match carries the block, else unmatched" {
+test "resolveRoutePath: location match carries the block, else unmatched" {
     const blocks = [_]http.location_router.LocationBlock{
         .{ .match_type = .exact, .pattern = "/app", .priority = 1, .action = .{ .proxy_pass = "" } },
     };
-    switch (resolveRouteFor("/status/metrics", &blocks, "/app")) {
+    switch (resolveRoutePath("/status/metrics", &blocks, "/app")) {
         .location => |m| try std.testing.expectEqualStrings("/app", m.block.pattern),
         else => try std.testing.expect(false),
     }
-    try std.testing.expectEqual(std.meta.Tag(RouteDecision).unmatched, std.meta.activeTag(resolveRouteFor("/status/metrics", &blocks, "/nope")));
+    try std.testing.expectEqual(std.meta.Tag(RouteDecision).unmatched, std.meta.activeTag(resolveRoutePath("/status/metrics", &blocks, "/nope")));
 }
 
 pub fn routeRequest(


### PR DESCRIPTION
First of the staged **#201** pipeline refactor (see the staging plan on #201 / #240). Behaviour-preserving, h1 only.

## What
`routeRequest` inlined its routing precedence (reload-status path → metrics path → `matchLocation`) and interleaved it with execution. This extracts a pure decision:

```zig
pub const RouteDecision = union(enum) { reload_status, metrics, location: MatchResult, unmatched };
pub fn resolveRoute(cfg, request) RouteDecision  // → resolveRouteFor(metrics_path, blocks, path)
```

`routeRequest` now `switch`es on `resolveRoute(...)`. The location body — auth + the action dispatch (proxy / fastcgi / return / rewrite / static) — is **unchanged**, and the outer switch preserves the exact fall-through to `serveTryFilesFallback` + 404 for the rewrite / static-miss / unmatched cases.

## Why
It's the "route matching separated from route execution" acceptance item, and `resolveRoute` is the seam **h3 will consume** in a later PR instead of re-implementing `matchLocation` in `handleHttp3Connection` — the core of converging the parallel h1/h3 dispatch.

## Testability
`resolveRoute` delegates to a pure `resolveRouteFor(metrics_path, blocks, path)` so precedence is unit-testable without constructing a full `EdgeConfig`. Adds the first independently-testable routing tests (reload/metrics precedence, empty-metrics disable, location match carries the block, unmatched).

## Notes
- The `RouteDecision` union is exhaustive, so a future route kind forces a decision at the dispatch site.
- The transcript route still matches+executes inside `routeRequest` (it interleaves match+execute); folding it into `resolveRoute` is a small follow-up, noted inline.
- Most of the diff is `zig fmt` reindenting the unchanged location body one level deeper.

## Verification
- `zig build test --summary all` → 647/648, 1 skip (+2 new routing tests)
- `zig build test-failure` → 9/9
- `zig build test-integration` → clean except the pre-existing `split upstream /ursa mount` flake (fails on `main` too)
- `zig fmt --check build.zig src/ tests/` clean

Part of #201, #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)