### PR TITLE
test(security): regression coverage for default security headers (#175, PR A)

### DIFF
--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -4559,7 +4559,7 @@ test "security headers are emitted with safe defaults (#175)" {
     try std.testing.expectEqualStrings("nosniff", response.header("X-Content-Type-Options") orelse "");
     try std.testing.expectEqualStrings("default-src 'self'", response.header("Content-Security-Policy") orelse "");
     try std.testing.expectEqualStrings("strict-origin-when-cross-origin", response.header("Referrer-Policy") orelse "");
-    try assertContains(response.header("Permissions-Policy") orelse "", "camera=()");
+    try std.testing.expectEqualStrings("camera=(), microphone=(), geolocation=()", response.header("Permissions-Policy") orelse "");
     // X-XSS-Protection is intentionally "0" (disabled; CSP is the modern control).
     try std.testing.expectEqualStrings("0", response.header("X-XSS-Protection") orelse "");
     try std.testing.expectEqualStrings("same-origin", response.header("Cross-Origin-Opener-Policy") orelse "");
@@ -4587,9 +4587,15 @@ test "security headers can be disabled via config (#175)" {
     });
     defer response.deinit();
     try std.testing.expectEqual(@as(u16, 200), response.status_code);
+    // The full default set must be absent when disabled.
     try std.testing.expect(response.header("X-Frame-Options") == null);
+    try std.testing.expect(response.header("X-Content-Type-Options") == null);
     try std.testing.expect(response.header("Content-Security-Policy") == null);
     try std.testing.expect(response.header("Referrer-Policy") == null);
+    try std.testing.expect(response.header("Permissions-Policy") == null);
+    try std.testing.expect(response.header("X-XSS-Protection") == null);
+    try std.testing.expect(response.header("Cross-Origin-Opener-Policy") == null);
+    try std.testing.expect(response.header("Cross-Origin-Resource-Policy") == null);
 }
 
 test "location rewrite action falls through to try_files (#201)" {

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -4534,6 +4534,64 @@ test "top-level try_files serves index html and rejects encoded traversal" {
     try std.testing.expectEqual(@as(u16, 403), traversal_response.status_code);
 }
 
+test "security headers are emitted with safe defaults (#175)" {
+    // Locks in the production-safe security-header posture so a future change
+    // cannot silently weaken it. These are default-on and applied to every
+    // response (here a `return` terminal).
+    const allocator = std.testing.allocator;
+    const config_text =
+        \\location = /r {
+        \\    return 200 ok;
+        \\}
+    ;
+    var tardigrade = try TardigradeProcess.start(allocator, .{ .config_text = config_text });
+    defer tardigrade.stop();
+
+    var response = try sendRequest(allocator, tardigrade.port, .{
+        .method = "GET",
+        .path = "/r",
+        .body = null,
+        .headers = &.{},
+    });
+    defer response.deinit();
+    try std.testing.expectEqual(@as(u16, 200), response.status_code);
+    try std.testing.expectEqualStrings("DENY", response.header("X-Frame-Options") orelse "");
+    try std.testing.expectEqualStrings("nosniff", response.header("X-Content-Type-Options") orelse "");
+    try std.testing.expectEqualStrings("default-src 'self'", response.header("Content-Security-Policy") orelse "");
+    try std.testing.expectEqualStrings("strict-origin-when-cross-origin", response.header("Referrer-Policy") orelse "");
+    try assertContains(response.header("Permissions-Policy") orelse "", "camera=()");
+    // X-XSS-Protection is intentionally "0" (disabled; CSP is the modern control).
+    try std.testing.expectEqualStrings("0", response.header("X-XSS-Protection") orelse "");
+    try std.testing.expectEqualStrings("same-origin", response.header("Cross-Origin-Opener-Policy") orelse "");
+    try std.testing.expectEqualStrings("same-origin", response.header("Cross-Origin-Resource-Policy") orelse "");
+}
+
+test "security headers can be disabled via config (#175)" {
+    const allocator = std.testing.allocator;
+    const config_text =
+        \\location = /r {
+        \\    return 200 ok;
+        \\}
+    ;
+    var tardigrade = try TardigradeProcess.start(allocator, .{
+        .config_text = config_text,
+        .extra_env = &.{.{ .name = "TARDIGRADE_SECURITY_HEADERS", .value = "false" }},
+    });
+    defer tardigrade.stop();
+
+    var response = try sendRequest(allocator, tardigrade.port, .{
+        .method = "GET",
+        .path = "/r",
+        .body = null,
+        .headers = &.{},
+    });
+    defer response.deinit();
+    try std.testing.expectEqual(@as(u16, 200), response.status_code);
+    try std.testing.expect(response.header("X-Frame-Options") == null);
+    try std.testing.expect(response.header("Content-Security-Policy") == null);
+    try std.testing.expect(response.header("Referrer-Policy") == null);
+}
+
 test "location rewrite action falls through to try_files (#201)" {
     // Guards the routeRequest fall-through after a location `.rewrite` action:
     // the action mutates the path and does NOT return, so control must reach the


### PR DESCRIPTION
First PR of **#175** (see the audit on the issue). Test-only.

## Context
The audit found Tardigrade's TLS + security-header **defaults are already production-safe and well-validated** — the real gap is **regression coverage**: `tests/integration.zig` had **zero** assertions on security headers, so a future change could silently weaken the posture.

## What
Two integration tests over plain HTTP (a `return` terminal, which applies the same security headers as any response):
1. **Defaults present** — asserts every default header + value: `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Content-Security-Policy: default-src 'self'`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy` (camera/mic/geo denied), `X-XSS-Protection: 0` (intentionally disabled — CSP is the modern control), `Cross-Origin-Opener-Policy`/`Cross-Origin-Resource-Policy: same-origin`.
2. **Disable path** — `TARDIGRADE_SECURITY_HEADERS=false` suppresses them.

## Verification
- `zig build test-integration` → 59 pass / 4 skip / 1 fail (only the pre-existing `split upstream /ursa mount` flake; the two new tests pass)
- `zig fmt --check` clean
- No source changes.

## Next in #175
- **PR B** — HSTS emitted on HTTPS when enabled (reusing the #270 TLS scaffolding), and a TLS 1.1 client is rejected when min-version is 1.2.
- **PR C** — override behavior: an upstream that sets its own CSP/X-Frame is not double-set (`setHeaderIfAbsent`).

Part of #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)