### PR TITLE
build: HTTP/3 build reproducibility — pure-Zig flag, test-quic target, build matrix docs (#208)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,10 @@ zig build test-integration
 # exercises broken origins and clients (see "Failure-mode harness" below).
 zig build test-failure
 
+# Pure-Zig QUIC/HTTP-3 package unit tests (no system libraries). Also run under
+# `zig build test`.
+zig build test-quic
+
 # Release-mode build
 zig build -Doptimize=ReleaseFast
 ```
@@ -76,7 +80,8 @@ filter, e.g. `zig build test-integration -- --test-filter "failure: client abort
 | `-Dstatic-executable=true` | `false` | Fully static binary |
 | `-Dprefer-static-system-libs=true` | `false` | Prefer static OpenSSL/crypto |
 | `-Drequire-static-system-libs=true` | `false` | Fail if static libs are unavailable |
-| `-Denable-http3-ngtcp2=true` | `false` | Enable experimental HTTP/3 ngtcp2/nghttp3 system-library integration; requires the ngtcp2/nghttp3/ngtcp2_crypto_ossl system libraries |
+| `-Denable-http3-ngtcp2=true` | `false` | Enable experimental C-backed HTTP/3 via ngtcp2/nghttp3 system-library integration; requires the ngtcp2/nghttp3/ngtcp2_crypto_ossl system libraries |
+| `-Denable-http3-zig=true` | `false` | Enable the experimental pure-Zig QUIC/HTTP-3 path (no system libraries; in development). Mutually exclusive with `-Denable-http3-ngtcp2` |
 | `-Dversion=x.y.z` | `dev` | Embed a version string in the binary |
 | `-Dhttp3-osslclient-path=<path>` | auto-detect | Path to osslclient for 0-RTT tests |
 
@@ -102,9 +107,21 @@ zig build test -- --test-filter "jwt"
 zig build test -- --test-timeout-ns 10000000000
 ```
 
-HTTP/3-enabled validation is currently a manual/local build step rather than a
-required CI job because the Ubuntu runner image does not consistently provide
-the `ngtcp2` OpenSSL backend development package.
+### HTTP/3 backends
+
+The **default build ships no HTTP/3** and needs no HTTP/3 system libraries — a
+clean checkout builds consistently anywhere. Two mutually-exclusive backends can
+be opted into:
+
+- `-Denable-http3-ngtcp2` — the C-backed path; requires the ngtcp2/nghttp3
+  system libraries. Validation is a manual/local build step rather than a
+  required CI job because the Ubuntu runner image does not consistently provide
+  the `ngtcp2` OpenSSL backend development package.
+- `-Denable-http3-zig` — the pure-Zig QUIC/HTTP-3 path (#240); no system
+  libraries, in active development. Its package is unit-tested via
+  `zig build test-quic`.
+
+Enabling both fails the build with an actionable message.
 
 ## Formatting
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,9 @@ zig build test-integration
 # Failure-mode / chaos suite (broken origins, aborting clients, reloads)
 zig build test-failure
 
+# Pure-Zig QUIC/HTTP-3 package tests (no system libraries)
+zig build test-quic
+
 # Allocation budget report
 zig build bench-allocations
 ```

--- a/build.zig
+++ b/build.zig
@@ -7,12 +7,20 @@ pub fn build(b: *std.Build) void {
     const require_static_system_libs = b.option(bool, "require-static-system-libs", "Require static linking for system libraries") orelse false;
     const static_executable = b.option(bool, "static-executable", "Build the tardigrade executable as a static binary") orelse false;
     const enable_http3_ngtcp2 = b.option(bool, "enable-http3-ngtcp2", "Enable experimental HTTP/3 ngtcp2/nghttp3 system-library integration (requires system libraries)") orelse false;
+    // Pure-Zig QUIC/HTTP-3 path (#240). Off by default and in active development;
+    // needs no system libraries. Mutually exclusive with the ngtcp2 backend —
+    // both would provide HTTP/3.
+    const enable_http3_zig = b.option(bool, "enable-http3-zig", "Enable the experimental pure-Zig QUIC/HTTP-3 path (no system libraries; off by default, in development)") orelse false;
+    if (enable_http3_ngtcp2 and enable_http3_zig) {
+        std.debug.panic("Enable at most one HTTP/3 backend: -Denable-http3-ngtcp2 (C libraries) or -Denable-http3-zig (pure Zig), not both.", .{});
+    }
     const app_version = b.option([]const u8, "version", "Version string embedded in the tardigrade binary") orelse "dev";
     const osslclient_default_path = "/tmp/ngtcp2-upstream/build/examples/osslclient";
     const http3_osslclient_path = b.option([]const u8, "http3-osslclient-path", "Path to the ngtcp2 OpenSSL HTTP/3 example client used by 0-RTT integration tests") orelse if (pathExists(osslclient_default_path)) osslclient_default_path else "";
 
     const build_options = b.addOptions();
     build_options.addOption(bool, "enable_http3_ngtcp2", enable_http3_ngtcp2);
+    build_options.addOption(bool, "enable_http3_zig", enable_http3_zig);
     build_options.addOption([]const u8, "version", app_version);
     const compat_mod = b.createModule(.{
         .root_source_file = b.path("src/zig_compat.zig"),
@@ -156,6 +164,21 @@ pub fn build(b: *std.Build) void {
     const run_security_corpus_tests = b.addRunArtifact(security_corpus_tests);
     const security_corpus_step = b.step("test-security-corpus", "Run request parser corpus regression tests");
     security_corpus_step.dependOn(&run_security_corpus_tests.step);
+
+    // Pure-Zig QUIC/HTTP-3 package (#240): a first-class test target rather than
+    // only being compiled transitively through the exe. No system libraries.
+    const quic_mod = b.createModule(.{
+        .root_source_file = b.path("src/quic/root.zig"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    const quic_tests = b.addTest(.{ .root_module = quic_mod });
+    const run_quic_tests = b.addRunArtifact(quic_tests);
+    const quic_step = b.step("test-quic", "Run pure-Zig QUIC/HTTP-3 unit tests");
+    quic_step.dependOn(&run_quic_tests.step);
+    // Also exercise them under the default `zig build test`.
+    test_step.dependOn(&run_quic_tests.step);
 }
 
 fn pathExists(path: []const u8) bool {


### PR DESCRIPTION
Closes **#208** — the build-reproducibility prep before the pure-Zig QUIC/HTTP-3 work (#240).

## What
- **`-Denable-http3-zig`** (off by default, no system libraries) for the pure-Zig QUIC/HTTP-3 path, plumbed into `build_options` as `enable_http3_zig` so code can gate on it. **Mutually exclusive** with `-Denable-http3-ngtcp2` — enabling both fails the build with an actionable message.
- **`test-quic`** build step: `src/quic/` is now a first-class test target (was only compiled transitively through the exe) and also runs under `zig build test`.
- **Docs**: CONTRIBUTING build-options table + a new "HTTP/3 backends" section (default ships no HTTP/3 / needs no system libs; the two mutually-exclusive backends; enabling both fails). `test-quic` added to CONTRIBUTING + README command lists.

## Acceptance
- ✅ Clean checkout builds consistently with no hidden system deps (default = no HTTP/3).
- ✅ Clear enable/disable behavior — two explicit, mutually-exclusive flags.
- ✅ Missing/conflicting selection produces an actionable build error (the both-enabled guard). *Note:* a missing ngtcp2 lib under `-Denable-http3-ngtcp2` still surfaces as a linker error; it's documented as requiring those libraries. A preflight check could be a follow-up if wanted.
- ✅ Build docs updated.

## Verify
```
zig build                                   # default: no HTTP/3, no system deps
zig build test-quic                         # 7/7 pure-Zig QUIC config/UDP tests
zig build test                              # 662 pass (now incl. quic)
zig build -Denable-http3-zig=true           # builds (flag off-by-default, nothing gated yet)
zig build -Denable-http3-ngtcp2=true -Denable-http3-zig=true   # fails: "Enable at most one HTTP/3 backend…"
```

This is the first of the two remaining prep gates from the readiness review; **#242** (QUIC core boundary + isolate the ngtcp2 path behind a replaceable `Http3Transport` + module skeleton) is next, after which #243 (packet layer) can start.

Part of #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)