### PR TITLE
feat(http3): QUIC core + http3 module skeleton and Http3Transport boundary (#242)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -171,7 +171,6 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/quic/root.zig"),
         .target = target,
         .optimize = optimize,
-        .link_libc = true,
     });
     const quic_tests = b.addTest(.{ .root_module = quic_mod });
     const run_quic_tests = b.addRunArtifact(quic_tests);
@@ -184,7 +183,6 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/http3/root.zig"),
         .target = target,
         .optimize = optimize,
-        .link_libc = true,
     });
     http3_mod.addImport("stream_transport", b.createModule(.{
         .root_source_file = b.path("src/http/stream_transport.zig"),

--- a/build.zig
+++ b/build.zig
@@ -179,6 +179,22 @@ pub fn build(b: *std.Build) void {
     quic_step.dependOn(&run_quic_tests.step);
     // Also exercise them under the default `zig build test`.
     test_step.dependOn(&run_quic_tests.step);
+
+    const http3_mod = b.createModule(.{
+        .root_source_file = b.path("src/http3/root.zig"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    http3_mod.addImport("stream_transport", b.createModule(.{
+        .root_source_file = b.path("src/http/stream_transport.zig"),
+        .target = target,
+        .optimize = optimize,
+    }));
+    const http3_tests = b.addTest(.{ .root_module = http3_mod });
+    const run_http3_tests = b.addRunArtifact(http3_tests);
+    quic_step.dependOn(&run_http3_tests.step);
+    test_step.dependOn(&run_http3_tests.step);
 }
 
 fn pathExists(path: []const u8) bool {

--- a/src/http3/frame.zig
+++ b/src/http3/frame.zig
@@ -1,0 +1,18 @@
+//! HTTP/3 framing layer (#246, RFC 9114 §7): the frame codec (DATA, HEADERS,
+//! SETTINGS, GOAWAY, MAX_PUSH_ID, CANCEL_PUSH), the unidirectional control
+//! stream, and stream-type identification.
+//!
+//! Runs over QUIC streams (`../quic/stream.zig`); HEADERS payloads are encoded
+//! and decoded via QPACK (`qpack.zig`). No transport/connection state here —
+//! only the HTTP/3 wire format.
+//!
+//! Status: skeleton — implemented in #246.
+
+const std = @import("std");
+
+// TODO(#246): frame parse/serialize, control-stream + SETTINGS handling, stream
+// type identification.
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/http3/qpack.zig
+++ b/src/http3/qpack.zig
@@ -1,0 +1,19 @@
+//! QPACK header compression (#252 static-only first, then #253 dynamic table,
+//! RFC 9204): static table, Huffman coding, and later the dynamic table with
+//! encoder/decoder streams and blocked-stream accounting.
+//!
+//! Encodes/decodes the HEADERS payloads carried by `frame.zig`. The initial
+//! milestone is static-table-only (no dynamic insertions, `SETTINGS`
+//! capacity 0) to unblock #246; the dynamic table and blocked-stream limits
+//! from `../quic/config.zig` follow in #253.
+//!
+//! Status: skeleton — static mode #252, dynamic #253.
+
+const std = @import("std");
+
+// TODO(#252/#253): static table + Huffman, then dynamic table + encoder/decoder
+// streams + blocked-stream accounting.
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/http3/root.zig
+++ b/src/http3/root.zig
@@ -1,0 +1,13 @@
+//! Pure Zig HTTP/3 application layer (#240): frames, QPACK, request/response
+//! session mapping, and the backend-agnostic `Http3Transport` boundary. Sits
+//! above the QUIC transport core in `src/quic/` and maps each request onto the
+//! shared `stream_transport` contract used by h1/h2/h3.
+
+pub const transport = @import("transport.zig");
+pub const frame = @import("frame.zig");
+pub const qpack = @import("qpack.zig");
+pub const session = @import("session.zig");
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/http3/session.zig
+++ b/src/http3/session.zig
@@ -1,0 +1,24 @@
+//! HTTP/3 request/response mapping (#246): turns a QUIC request stream into the
+//! shared `stream_transport` request/response shape the gateway proxy path
+//! consumes for h1/h2/h3 alike.
+//!
+//! Decodes HEADERS (via `qpack.zig`) into pseudo-headers + headers, exposes the
+//! request body as a pull `BodySource`, and writes the response headers-first
+//! then a pull-drained body — preserving the bounded-buffer / explicit-cancel /
+//! no-hidden-full-body model. This is the module a pure-Zig `Http3Transport`
+//! (`transport.zig`) hands each accepted stream to.
+//!
+//! Status: skeleton — implemented in #246 once frames/QPACK/streams exist.
+
+const std = @import("std");
+const stream_transport = @import("stream_transport");
+
+/// The protocol tag reported to the gateway/metrics for streams served here.
+pub const protocol: stream_transport.Protocol = .h3;
+
+// TODO(#246): map a QUIC request stream onto stream_transport.Exchange
+// (RequestHead + pull RequestBody in, ResponseHead + pull ResponseBody out).
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/http3/transport.zig
+++ b/src/http3/transport.zig
@@ -50,3 +50,37 @@ pub const Http3Transport = struct {
 test {
     std.testing.refAllDecls(@This());
 }
+
+test "Http3Transport dispatches lifecycle through the vtable" {
+    const Fake = struct {
+        started: bool = false,
+        stopped: bool = false,
+        deinitialized: bool = false,
+
+        fn start(ctx: *anyopaque) anyerror!void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.started = true;
+        }
+        fn stop(ctx: *anyopaque) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.stopped = true;
+        }
+        fn deinit(ctx: *anyopaque) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.deinitialized = true;
+        }
+    };
+
+    var fake = Fake{};
+    const vt = Http3Transport.VTable{ .start = Fake.start, .stop = Fake.stop, .deinit = Fake.deinit };
+    const transport = Http3Transport{ .ptr = &fake, .vtable = &vt };
+    try transport.start();
+    transport.stop();
+    transport.deinit();
+    try std.testing.expect(fake.started and fake.stopped and fake.deinitialized);
+}
+
+test "Http3Transport.Exchange is the shared stream-transport Exchange" {
+    // Lock the boundary so #243/#246 build on the shared contract, not a copy.
+    try std.testing.expect(Exchange == stream_transport.Exchange);
+}

--- a/src/http3/transport.zig
+++ b/src/http3/transport.zig
@@ -1,0 +1,52 @@
+//! `Http3Transport` — the C-backend replacement boundary (#242).
+//!
+//! Both HTTP/3 backends implement this vtable, selected at build time:
+//!   * `-Denable-http3-ngtcp2` — the current ngtcp2/nghttp3 C-backed path.
+//!   * `-Denable-http3-zig`    — the pure-Zig `src/quic` + `src/http3` path.
+//!
+//! The boundary sits *at the transport*: above the QUIC/ngtcp2 machinery and
+//! below `http3_handler` / `handleHttp3Request`, so pseudo-header mapping,
+//! response encoding, and the gateway bridge are reused by both backends. No
+//! backend-specific type (ngtcp2 handle, `src/quic` connection) escapes this
+//! interface. The gateway itself drives h1/h2/h3 through the shared
+//! `stream_transport` contract; this seam is only the h3 listener lifecycle.
+//!
+//! Status: interface defined (#242). Retrofitting the existing ngtcp2 runtime
+//! onto this vtable, and implementing the pure-Zig backend, are tracked
+//! follow-ups (#246 and the QUIC implementation issues).
+
+const std = @import("std");
+const stream_transport = @import("stream_transport");
+
+/// The request/response shape an h3 backend maps each stream onto — shared with
+/// h1/h2 so the gateway proxy path stays protocol-agnostic.
+pub const Exchange = stream_transport.Exchange;
+
+/// Backend-agnostic HTTP/3 listener lifecycle.
+pub const Http3Transport = struct {
+    ptr: *anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        /// Serve on the already-bound UDP endpoint until `stop` is requested.
+        start: *const fn (ctx: *anyopaque) anyerror!void,
+        /// Request a graceful stop of the listener.
+        stop: *const fn (ctx: *anyopaque) void,
+        /// Release all resources.
+        deinit: *const fn (ctx: *anyopaque) void,
+    };
+
+    pub fn start(self: Http3Transport) anyerror!void {
+        return self.vtable.start(self.ptr);
+    }
+    pub fn stop(self: Http3Transport) void {
+        self.vtable.stop(self.ptr);
+    }
+    pub fn deinit(self: Http3Transport) void {
+        self.vtable.deinit(self.ptr);
+    }
+};
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/quic/cid.zig
+++ b/src/quic/cid.zig
@@ -1,0 +1,18 @@
+//! QUIC connection ID management (#251, RFC 9000 §5.1): CID generation,
+//! lookup/routing, retirement, and stateless-reset token derivation.
+//!
+//! The UDP endpoint (`udp.zig`) demultiplexes incoming datagrams to a
+//! connection by destination CID via the lookup table owned here; NEW/RETIRE
+//! CONNECTION_ID frame handling and the active-CID limit from `config.zig` also
+//! live here. Deeper migration/path lifecycle is `path.zig`.
+//!
+//! Status: skeleton — basic generation/lookup scaffolding for #243, full
+//! lifecycle in #251.
+
+const std = @import("std");
+
+// TODO(#251): CID generation/lookup/retirement and stateless-reset tokens.
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -1,0 +1,20 @@
+//! QUIC connection state machine (RFC 9000): packet number spaces (Initial,
+//! Handshake, Application), transport-parameter negotiation, and the
+//! connection close/draining lifecycle.
+//!
+//! Drives the packet layer (`packet.zig`) and the TLS adapter
+//! (`tls_adapter.zig`), owns per-space packet-number issuance and the ACK
+//! eliciting/acked bookkeeping handed to `recovery.zig`, and multiplexes
+//! `stream.zig` streams. Depends on `config.zig` for transport parameters and
+//! `udp.zig` for datagram I/O.
+//!
+//! Status: skeleton — implemented after #243 (packet) + #249 (crypto).
+
+const std = @import("std");
+
+// TODO: connection state machine, packet-number spaces, transport-parameter
+// application, and close/drain handling.
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/quic/packet.zig
+++ b/src/quic/packet.zig
@@ -1,0 +1,20 @@
+//! QUIC packet layer (#243): varint codec, long/short packet headers, packet
+//! number encoding/reconstruction, and the frame codec.
+//!
+//! Owns the wire format only — no connection state, no crypto (packet/header
+//! protection lives with the TLS adapter, #249). Long-header types: Initial,
+//! 0-RTT, Handshake, Retry; short header for the 1-RTT application space.
+//! Frame set starts with PADDING/PING/ACK/CRYPTO/CONNECTION_CLOSE and the
+//! STREAM/flow-control/CID/path frame skeletons (RFC 9000 §12, §17, §19).
+//!
+//! Status: skeleton — implemented in #243. Compiles and is covered by
+//! `zig build test-quic`; carries no behavior yet.
+
+const std = @import("std");
+
+// TODO(#243): varint encode/decode, packet header parse/serialize, packet
+// number reconstruction, and the initial frame codec set.
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/quic/path.zig
+++ b/src/quic/path.zig
@@ -1,0 +1,18 @@
+//! QUIC path management (#250, #251): Retry / address validation, the
+//! anti-amplification limit, PATH_CHALLENGE/PATH_RESPONSE path validation, NAT
+//! rebinding detection, and connection migration policy.
+//!
+//! Gates how many bytes `connection.zig` may send to an unvalidated peer
+//! address (anti-amplification), validates new paths before migrating, and
+//! implements the Retry-token issue/verify used for downstream address
+//! validation. Stateless reset detection pairs with `cid.zig`.
+//!
+//! Status: skeleton — Retry/anti-amplification in #250, migration in #251.
+
+const std = @import("std");
+
+// TODO(#250/#251): Retry tokens, anti-amplification, path validation, migration.
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/quic/recovery.zig
+++ b/src/quic/recovery.zig
@@ -1,0 +1,20 @@
+//! QUIC loss detection and congestion control (#244, RFC 9002): ACK manager,
+//! RTT estimator, loss detection, PTO, and a NewReno-baseline congestion
+//! controller with pacing hooks.
+//!
+//! Consumes ACK frames decoded by `packet.zig` and the sent-packet metadata
+//! recorded by `connection.zig`; drives retransmission and the send-allowance
+//! that gates `stream.zig` output. Deliberately starts on a correct RFC 9002 /
+//! NewReno baseline — BBR and aggressive optimizer work are explicitly deferred
+//! (see the #240 non-goals).
+//!
+//! Status: skeleton — implemented in #244.
+
+const std = @import("std");
+
+// TODO(#244): ACK range processing, RTT/PTO, loss detection, NewReno window +
+// pacing.
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/quic/root.zig
+++ b/src/quic/root.zig
@@ -1,7 +1,15 @@
-//! Pure Zig QUIC foundation modules.
+//! Pure Zig QUIC foundation modules (#240). Transport core only — no HTTP or
+//! gateway types. HTTP/3 application mapping lives in `src/http3/`.
 
 pub const config = @import("config.zig");
 pub const udp = @import("udp.zig");
+pub const packet = @import("packet.zig");
+pub const connection = @import("connection.zig");
+pub const tls_adapter = @import("tls_adapter.zig");
+pub const recovery = @import("recovery.zig");
+pub const cid = @import("cid.zig");
+pub const path = @import("path.zig");
+pub const stream = @import("stream.zig");
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/quic/stream.zig
+++ b/src/quic/stream.zig
@@ -1,0 +1,20 @@
+//! QUIC streams (#245, RFC 9000 §2–§4, §19.8–§19.13): per-stream send/receive
+//! state, stream- and connection-level flow control, RESET_STREAM /
+//! STOP_SENDING, and the backpressure integration that HTTP/3 relies on.
+//!
+//! Reassembles STREAM frames decoded by `packet.zig`, enforces the MAX_DATA /
+//! MAX_STREAM_DATA windows from `config.zig`, and exposes the bounded
+//! read/write surface that `../http3/session.zig` maps onto the shared
+//! `stream_transport` contract — mirroring the bounded-buffer, explicit-cancel,
+//! no-hidden-full-body model already used by the h1/h2 proxy paths.
+//!
+//! Status: skeleton — implemented in #245.
+
+const std = @import("std");
+
+// TODO(#245): stream state machines, flow control, resets, STOP_SENDING,
+// backpressure.
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/quic/tls_adapter.zig
+++ b/src/quic/tls_adapter.zig
@@ -1,0 +1,20 @@
+//! QUIC TLS 1.3 adapter (#249, RFC 9001): the boundary between the QUIC
+//! connection and the TLS handshake. Carries CRYPTO frame data in/out of the
+//! TLS state machine, installs read/write secrets per encryption level, and
+//! provides packet-protection and header-protection keys to `packet.zig`.
+//!
+//! This is the one seam that may temporarily wrap an external TLS 1.3
+//! implementation behind a no-leak interface (see the #242 design); no TLS
+//! library type escapes this module. Initial-secret derivation and key updates
+//! also live here.
+//!
+//! Status: skeleton — implemented in #249.
+
+const std = @import("std");
+
+// TODO(#249): CRYPTO reassembly, per-level secret installation, packet/header
+// protection key provision, and key updates.
+
+test {
+    std.testing.refAllDecls(@This());
+}


### PR DESCRIPTION
Closes **#242** — the QUIC-core boundary + module-layout checkpoint (design already captured in the issue comment). This is the last prep gate before #243 (packet layer) can start.

## What
Scaffolds the pure-Zig module layout from the design, all behind the off-by-default `-Denable-http3-zig` path and covered by `zig build test-quic` (now 19 tests). Every module is a compiling stub carrying a responsibility doc-comment (RFC + implementing issue), no behavior:

**`src/quic/` (transport core — no HTTP/gateway types):**
`packet.zig` (#243) · `connection.zig` · `tls_adapter.zig` (#249) · `recovery.zig` (#244) · `cid.zig` (#251) · `path.zig` (#250) · `stream.zig` (#245) — alongside the existing `config.zig`/`udp.zig` (#248).

**`src/http3/` (application layer):**
- **`transport.zig` — the `Http3Transport` vtable**, the C-backend replacement boundary: both backends (ngtcp2 today, pure-Zig later) implement it, selected by build flag; it sits above QUIC and below `http3_handler`, and no backend type escapes it. Exposes `Exchange` aliased from the shared `stream_transport` contract so h3 maps onto the same request/response shape as h1/h2.
- `frame.zig` (#246) · `qpack.zig` (#252/#253) · `session.zig` (maps a QUIC stream onto `stream_transport`, `protocol = .h3`).

## Scope note
This **defines** the boundary and **scaffolds** the layout. Retrofitting the existing ngtcp2 runtime onto the `Http3Transport` vtable is intentionally a follow-up (it's behind its own flag and riskier) — flagged in `transport.zig` and the commit. It isn't needed for #243 readiness, which this PR clears.

## Verify
```
zig build            # default: unchanged, no HTTP/3
zig build test-quic  # 19/19 (quic core + http3 packages)
zig build test       # unchanged suites + the new packages
```

## Readiness
With #241 (contract), #248 (config/UDP), #208 (flag/build), and this (skeleton + boundary), the foundation is in place — **#243 (packet/frame codec) can begin**. The remaining pre-impl validation is mapping one existing h1/h2 path onto `stream_transport` to prove the contract fits.

Part of #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)