### PR TITLE
build: preflight optional HTTP/3 system deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,11 @@ Requirements:
 - [Zig](https://ziglang.org/) 0.16.0
 - OpenSSL development libraries on Linux, for example `libssl-dev` on Debian or
   Ubuntu
-- Optional HTTP/3 support additionally requires the `ngtcp2`, `nghttp3`, and
-  `ngtcp2_crypto_ossl` system libraries. Enable it explicitly with
-  `-Denable-http3-ngtcp2=true`.
+- Optional C-backed HTTP/3 support additionally requires the `ngtcp2`,
+  `nghttp3`, and `ngtcp2_crypto_ossl` system libraries. Enable it explicitly
+  with `-Denable-http3-ngtcp2=true`.
+- The experimental pure-Zig QUIC/HTTP-3 path is enabled with
+  `-Denable-http3-zig=true` and does not require those system libraries.
 
 For development:
 

--- a/build.zig
+++ b/build.zig
@@ -14,6 +14,9 @@ pub fn build(b: *std.Build) void {
     if (enable_http3_ngtcp2 and enable_http3_zig) {
         std.debug.panic("Enable at most one HTTP/3 backend: -Denable-http3-ngtcp2 (C libraries) or -Denable-http3-zig (pure Zig), not both.", .{});
     }
+    if (enable_http3_ngtcp2) {
+        requireHttp3Ngtcp2Dependencies(b, target.result.os.tag, target.result.cpu.arch, prefer_static_system_libs, require_static_system_libs);
+    }
     const app_version = b.option([]const u8, "version", "Version string embedded in the tardigrade binary") orelse "dev";
     const osslclient_default_path = "/tmp/ngtcp2-upstream/build/examples/osslclient";
     const http3_osslclient_path = b.option([]const u8, "http3-osslclient-path", "Path to the ngtcp2 OpenSSL HTTP/3 example client used by 0-RTT integration tests") orelse if (pathExists(osslclient_default_path)) osslclient_default_path else "";
@@ -200,6 +203,173 @@ fn pathExists(path: []const u8) bool {
     return true;
 }
 
+const SystemDependency = struct {
+    name: []const u8,
+    headers: []const []const u8,
+};
+
+const http3_ngtcp2_deps = [_]SystemDependency{
+    .{
+        .name = "ngtcp2",
+        .headers = &.{
+            "ngtcp2/ngtcp2.h",
+            "ngtcp2/ngtcp2_crypto.h",
+        },
+    },
+    .{
+        .name = "ngtcp2_crypto_ossl",
+        .headers = &.{
+            "ngtcp2/ngtcp2_crypto_ossl.h",
+        },
+    },
+    .{
+        .name = "nghttp3",
+        .headers = &.{
+            "nghttp3/nghttp3.h",
+        },
+    },
+};
+
+fn requireHttp3Ngtcp2Dependencies(
+    b: *std.Build,
+    os_tag: std.Target.Os.Tag,
+    arch: std.Target.Cpu.Arch,
+    prefer_static: bool,
+    require_static: bool,
+) void {
+    const include_dirs = systemIncludeSearchPaths(os_tag, arch);
+    const library_dirs = systemLibrarySearchPaths(os_tag, arch, prefer_static);
+    const library_extensions = libraryExtensions(os_tag, prefer_static, require_static);
+
+    for (http3_ngtcp2_deps) |dep| {
+        for (dep.headers) |header| {
+            if (!findRelativePath(b, include_dirs, header)) {
+                std.debug.panic(
+                    \\Missing optional HTTP/3 header '{s}' required by -Denable-http3-ngtcp2.
+                    \\Install the ngtcp2/nghttp3 OpenSSL backend development packages, then retry.
+                    \\Debian/Ubuntu packages when available: libngtcp2-dev libngtcp2-crypto-ossl-dev libnghttp3-dev.
+                    \\macOS Homebrew: brew install ngtcp2 nghttp3.
+                    \\For a no-system-library build, omit -Denable-http3-ngtcp2 or use -Denable-http3-zig.
+                    \\
+                , .{header});
+            }
+        }
+        if (!findSystemLibrary(b, library_dirs, dep.name, library_extensions)) {
+            std.debug.panic(
+                \\Missing optional HTTP/3 library 'lib{s}' required by -Denable-http3-ngtcp2.
+                \\Install the ngtcp2/nghttp3 OpenSSL backend development packages, then retry.
+                \\Debian/Ubuntu packages when available: libngtcp2-dev libngtcp2-crypto-ossl-dev libnghttp3-dev.
+                \\macOS Homebrew: brew install ngtcp2 nghttp3.
+                \\For a no-system-library build, omit -Denable-http3-ngtcp2 or use -Denable-http3-zig.
+                \\
+            , .{dep.name});
+        }
+    }
+}
+
+fn findRelativePath(b: *std.Build, dirs: []const []const u8, relative_path: []const u8) bool {
+    for (dirs) |dir| {
+        const candidate = std.fs.path.join(b.allocator, &.{ dir, relative_path }) catch @panic("out of memory");
+        defer b.allocator.free(candidate);
+        if (pathExists(candidate)) return true;
+    }
+    return false;
+}
+
+fn findSystemLibrary(
+    b: *std.Build,
+    dirs: []const []const u8,
+    name: []const u8,
+    extensions: []const []const u8,
+) bool {
+    for (extensions) |extension| {
+        const file_name = std.fmt.allocPrint(b.allocator, "lib{s}{s}", .{ name, extension }) catch @panic("out of memory");
+        defer b.allocator.free(file_name);
+        if (findRelativePath(b, dirs, file_name)) return true;
+    }
+    return false;
+}
+
+fn systemIncludeSearchPaths(os_tag: std.Target.Os.Tag, arch: std.Target.Cpu.Arch) []const []const u8 {
+    return switch (os_tag) {
+        .macos => &.{
+            "/opt/homebrew/include",
+            "/usr/local/include",
+            "/opt/homebrew/opt/openssl@3/include",
+            "/usr/local/opt/openssl@3/include",
+        },
+        .linux => switch (arch) {
+            .aarch64 => &.{
+                "/usr/local/include",
+                "/usr/include",
+                "/usr/include/aarch64-linux-gnu",
+            },
+            .x86_64 => &.{
+                "/usr/local/include",
+                "/usr/include",
+                "/usr/include/x86_64-linux-gnu",
+            },
+            else => &.{
+                "/usr/local/include",
+                "/usr/include",
+            },
+        },
+        else => &.{"/usr/include"},
+    };
+}
+
+fn systemLibrarySearchPaths(os_tag: std.Target.Os.Tag, arch: std.Target.Cpu.Arch, prefer_static: bool) []const []const u8 {
+    _ = prefer_static;
+    return switch (os_tag) {
+        .macos => &.{
+            "/opt/homebrew/lib",
+            "/usr/local/lib",
+            "/opt/homebrew/opt/openssl@3/lib",
+            "/usr/local/opt/openssl@3/lib",
+        },
+        .linux => switch (arch) {
+            .aarch64 => &.{
+                "/usr/local/lib",
+                "/usr/lib/aarch64-linux-gnu",
+                "/lib/aarch64-linux-gnu",
+                "/usr/lib",
+                "/lib",
+            },
+            .x86_64 => &.{
+                "/usr/local/lib",
+                "/usr/lib/x86_64-linux-gnu",
+                "/lib/x86_64-linux-gnu",
+                "/usr/lib",
+                "/lib",
+            },
+            else => &.{
+                "/usr/local/lib",
+                "/usr/lib",
+                "/lib",
+            },
+        },
+        else => &.{
+            "/usr/local/lib",
+            "/usr/lib",
+            "/lib",
+        },
+    };
+}
+
+fn libraryExtensions(os_tag: std.Target.Os.Tag, prefer_static: bool, require_static: bool) []const []const u8 {
+    if (require_static) return &.{".a"};
+    if (prefer_static) {
+        return switch (os_tag) {
+            .macos => &.{ ".a", ".dylib" },
+            else => &.{ ".a", ".so" },
+        };
+    }
+    return switch (os_tag) {
+        .macos => &.{ ".dylib", ".a" },
+        else => &.{ ".so", ".a" },
+    };
+}
+
 /// Link OpenSSL (required) and optional HTTP/3 libraries against a compile step.
 fn configureSsl(
     compile: *std.Build.Step.Compile,
@@ -241,12 +411,18 @@ fn configureSystemLibrarySearchPaths(
     // Always add Homebrew paths on macOS so OpenSSL (not in Apple's SDK) is found.
     if (target.os.tag == .macos) {
         compile.root_module.addSystemIncludePath(.{ .cwd_relative = "/opt/homebrew/include" });
+        if (pathExists("/usr/local/include")) compile.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/local/include" });
         compile.root_module.addSystemIncludePath(.{ .cwd_relative = "/opt/homebrew/opt/openssl@3/include" });
+        if (pathExists("/usr/local/opt/openssl@3/include")) compile.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/local/opt/openssl@3/include" });
         compile.root_module.addLibraryPath(.{ .cwd_relative = "/opt/homebrew/lib" });
+        if (pathExists("/usr/local/lib")) compile.root_module.addLibraryPath(.{ .cwd_relative = "/usr/local/lib" });
         compile.root_module.addLibraryPath(.{ .cwd_relative = "/opt/homebrew/opt/openssl@3/lib" });
+        if (pathExists("/usr/local/opt/openssl@3/lib")) compile.root_module.addLibraryPath(.{ .cwd_relative = "/usr/local/opt/openssl@3/lib" });
     }
     if (target.os.tag == .linux) {
+        if (pathExists("/usr/local/include")) compile.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/local/include" });
         compile.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/include" });
+        if (pathExists("/usr/local/lib")) compile.root_module.addLibraryPath(.{ .cwd_relative = "/usr/local/lib" });
         switch (target.cpu.arch) {
             .aarch64 => {
                 compile.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/include/aarch64-linux-gnu" });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -36,10 +36,11 @@
     // Once all dependencies are fetched, `zig build` no longer requires
     // internet connectivity.
     //
-    // Tardigrade keeps HTTP/3 / QUIC support behind an explicit build flag and
-    // links the ngtcp2/nghttp3 system libraries only when that flag is enabled.
-    // The default build has no package-manager dependency on those optional
-    // HTTP/3 libraries.
+    // Tardigrade keeps HTTP/3 / QUIC support behind explicit build flags. The
+    // C-backed path links ngtcp2/nghttp3 system libraries only when
+    // `-Denable-http3-ngtcp2` is enabled. The pure-Zig path uses
+    // `-Denable-http3-zig` and has no package-manager or system-library
+    // dependency on those optional HTTP/3 libraries.
     .dependencies = .{
         // See `zig fetch --save <url>` for a command-line interface for adding dependencies.
         //.example = .{

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -61,7 +61,7 @@ surfaces that should not be marketed as generic operator-facing capabilities.
 | Feature | Representative surface | Maturity | Why it is not Core v1 |
 | --- | --- | --- | --- |
 | HTTP/2 | `tls_termination` HTTP/2 path, `hpack`, `http2_frame` | `experimental` | Present in-tree, but not documented or release-gated at the same level as the HTTP/1.1 core. |
-| HTTP/3 / QUIC | `http3_handler`, `http3_session`, `http3_runtime`, `ngtcp2_binding`, `quic_stub` | `experimental` | Disabled by default; enable explicitly with `-Denable-http3-ngtcp2=true` and install the `ngtcp2`, `nghttp3`, and `ngtcp2_crypto_ossl` system libraries. |
+| HTTP/3 / QUIC | `http3_handler`, `http3_session`, `http3_runtime`, `ngtcp2_binding`, `quic_stub`, `quic`, `http3` | `experimental` | Disabled by default; enable the C-backed path explicitly with `-Denable-http3-ngtcp2=true` and install the `ngtcp2`, `nghttp3`, and `ngtcp2_crypto_ossl` system libraries, or enable the pure-Zig path with `-Denable-http3-zig=true` while it remains in development. |
 | WebSocket, SSE, and mux realtime paths | `websocket`, `event_hub`, mux counters in `metrics` | `experimental` | Integration coverage exists, but the public operator docs are still example-scoped rather than Core v1. |
 | ACME automation | `acme_client` | `experimental` | Useful feature surface, but not part of the stable release/install promise yet. |
 | Auth and identity extensions | `auth`, `basic_auth`, `jwt`, `access_control` | `experimental` | Operators can use these paths, but they are not the defining Core v1 server contract. |


### PR DESCRIPTION
Closes #208.

## Summary
- Add an explicit `-Denable-http3-ngtcp2` preflight for the required ngtcp2/nghttp3 headers and libraries before the build reaches generic compile/link failures.
- Preserve the default and pure-Zig HTTP/3 paths as no-system-library builds.
- Refresh README, `build.zig.zon`, and support matrix wording so the C-backed and pure-Zig HTTP/3 backends are described separately.

## Related review
- PR #287 already added the pure-Zig flag and `test-quic`; this PR fills the remaining issue-comment gap around actionable missing ngtcp2/nghttp3 failures.
- PR #288 already merged the #242 module/boundary scaffold. I did not pull #243+ QUIC implementation work into this branch because it is intentionally separate from #208 build hygiene.

## Validation
- `zig fmt --check build.zig src/ tests/`
- `zig build`
- `zig build -Denable-http3-zig=true`
- `zig build -Denable-http3-ngtcp2=true -Denable-http3-zig=true` fails with the existing mutually-exclusive backend message
- `zig build -Denable-http3-ngtcp2=true --summary all`
- `zig build test-quic`
- `zig build test --summary all --error-style verbose`
- `zig build -Dtarget=x86_64-linux -Denable-http3-ngtcp2=true` fails with the new actionable missing-header message on this macOS host
