### PR TITLE
feat(quic): varint + packet-number codec — QUIC packet layer foundation (#243)

### DIFF
--- a/src/quic/packet.zig
+++ b/src/quic/packet.zig
@@ -1,20 +1,84 @@
-//! QUIC packet layer (#243): varint codec, long/short packet headers, packet
-//! number encoding/reconstruction, and the frame codec.
+//! QUIC packet layer (#243): long/short packet headers, packet number
+//! encoding/reconstruction, and (later) the frame codec. The varint codec lives
+//! in `varint.zig`; packet/header protection (crypto) lives with the TLS
+//! adapter (#249). Long-header types: Initial, 0-RTT, Handshake, Retry; short
+//! header for the 1-RTT application space (RFC 9000 §17).
 //!
-//! Owns the wire format only — no connection state, no crypto (packet/header
-//! protection lives with the TLS adapter, #249). Long-header types: Initial,
-//! 0-RTT, Handshake, Retry; short header for the 1-RTT application space.
-//! Frame set starts with PADDING/PING/ACK/CRYPTO/CONNECTION_CLOSE and the
-//! STREAM/flow-control/CID/path frame skeletons (RFC 9000 §12, §17, §19).
-//!
-//! Status: skeleton — implemented in #243. Compiles and is covered by
-//! `zig build test-quic`; carries no behavior yet.
+//! Status: packet-number encoding/reconstruction implemented; header and frame
+//! codec land in follow-up commits of #243.
 
 const std = @import("std");
 
-// TODO(#243): varint encode/decode, packet header parse/serialize, packet
-// number reconstruction, and the initial frame codec set.
+/// Largest valid packet number (RFC 9000 §17.1: 2^62 - 1).
+pub const max_packet_number: u64 = (1 << 62) - 1;
 
-test {
-    std.testing.refAllDecls(@This());
+/// Minimal number of bytes (1..4) needed to encode `full_pn` such that a peer
+/// who has acknowledged up to `largest_acked` can reconstruct it. Pass null for
+/// `largest_acked` when no packet has been acknowledged yet. (RFC 9000 §A.2)
+pub fn packetNumberLength(full_pn: u64, largest_acked: ?u64) u3 {
+    const num_unacked: u64 = if (largest_acked) |acked| full_pn - acked else full_pn + 1;
+    // Need enough bits so the window (2 * num_unacked) is representable.
+    const min_bits: usize = @as(usize, 64) - @clz(num_unacked * 2);
+    const num_bytes = (min_bits + 7) / 8;
+    return @intCast(std.math.clamp(num_bytes, 1, 4));
+}
+
+/// The `pn_length` low-order bytes of `full_pn`, big-endian, as sent on the
+/// wire. `pn_length` is 1..4.
+pub fn truncatePacketNumber(full_pn: u64, pn_length: u3) u32 {
+    const bits: u6 = @as(u6, pn_length) * 8;
+    if (bits >= 32) return @truncate(full_pn);
+    const mask: u64 = (@as(u64, 1) << bits) - 1;
+    return @intCast(full_pn & mask);
+}
+
+/// Reconstruct the full packet number from a truncated one, given the largest
+/// packet number successfully processed in the same space and the number of
+/// bits that were sent. (RFC 9000 §A.3)
+pub fn decodePacketNumber(largest_pn: u64, truncated_pn: u64, pn_nbits: u6) u64 {
+    const expected_pn = largest_pn + 1;
+    const pn_win: u64 = @as(u64, 1) << pn_nbits;
+    const pn_hwin = pn_win / 2;
+    const pn_mask = pn_win - 1;
+    const candidate_pn = (expected_pn & ~pn_mask) | truncated_pn;
+    if (candidate_pn <= expected_pn -% pn_hwin and candidate_pn < max_packet_number + 1 - pn_win and expected_pn >= pn_hwin) {
+        return candidate_pn + pn_win;
+    }
+    if (candidate_pn > expected_pn + pn_hwin and candidate_pn >= pn_win) {
+        return candidate_pn - pn_win;
+    }
+    return candidate_pn;
+}
+
+const testing = std.testing;
+
+test "decodePacketNumber matches RFC 9000 A.3 example" {
+    try testing.expectEqual(@as(u64, 0xa82f9b32), decodePacketNumber(0xa82f30ea, 0x9b32, 16));
+}
+
+test "truncate then reconstruct round-trips across a window" {
+    // A peer at largest_pn reconstructs recent packet numbers exactly.
+    const largest: u64 = 0xa82f30ea;
+    var pn: u64 = largest + 1;
+    while (pn < largest + 500) : (pn += 7) {
+        const len = packetNumberLength(pn, largest);
+        const trunc = truncatePacketNumber(pn, len);
+        const nbits: u6 = @as(u6, len) * 8;
+        try testing.expectEqual(pn, decodePacketNumber(largest, trunc, nbits));
+    }
+}
+
+test "packetNumberLength grows with the unacked distance" {
+    // Small gaps fit in one byte; larger gaps need more.
+    try testing.expectEqual(@as(u3, 1), packetNumberLength(100, 99));
+    try testing.expectEqual(@as(u3, 1), packetNumberLength(0, null));
+    try testing.expect(packetNumberLength(0x1_0000, 0) >= 3);
+    try testing.expect(packetNumberLength(0xFFFF_FFFF, 0) == 4);
+}
+
+test "truncatePacketNumber keeps the low-order bytes" {
+    try testing.expectEqual(@as(u32, 0x9b32), truncatePacketNumber(0xa82f9b32, 2));
+    try testing.expectEqual(@as(u32, 0x2f9b32), truncatePacketNumber(0xa82f9b32, 3));
+    try testing.expectEqual(@as(u32, 0xa82f9b32), truncatePacketNumber(0xa82f9b32, 4));
+    try testing.expectEqual(@as(u32, 0x32), truncatePacketNumber(0xa82f9b32, 1));
 }

--- a/src/quic/packet.zig
+++ b/src/quic/packet.zig
@@ -16,6 +16,9 @@ pub const max_packet_number: u64 = (1 << 62) - 1;
 /// who has acknowledged up to `largest_acked` can reconstruct it. Pass null for
 /// `largest_acked` when no packet has been acknowledged yet. (RFC 9000 §A.2)
 pub fn packetNumberLength(full_pn: u64, largest_acked: ?u64) u3 {
+    std.debug.assert(full_pn <= max_packet_number);
+    // A packet being sent always has a higher number than anything acked.
+    if (largest_acked) |acked| std.debug.assert(acked < full_pn);
     const num_unacked: u64 = if (largest_acked) |acked| full_pn - acked else full_pn + 1;
     // Need enough bits so the window (2 * num_unacked) is representable.
     const min_bits: usize = @as(usize, 64) - @clz(num_unacked * 2);
@@ -26,6 +29,8 @@ pub fn packetNumberLength(full_pn: u64, largest_acked: ?u64) u3 {
 /// The `pn_length` low-order bytes of `full_pn`, big-endian, as sent on the
 /// wire. `pn_length` is 1..4.
 pub fn truncatePacketNumber(full_pn: u64, pn_length: u3) u32 {
+    std.debug.assert(full_pn <= max_packet_number);
+    std.debug.assert(pn_length >= 1 and pn_length <= 4);
     const bits: u6 = @as(u6, pn_length) * 8;
     if (bits >= 32) return @truncate(full_pn);
     const mask: u64 = (@as(u64, 1) << bits) - 1;
@@ -36,6 +41,10 @@ pub fn truncatePacketNumber(full_pn: u64, pn_length: u3) u32 {
 /// packet number successfully processed in the same space and the number of
 /// bits that were sent. (RFC 9000 §A.3)
 pub fn decodePacketNumber(largest_pn: u64, truncated_pn: u64, pn_nbits: u6) u64 {
+    std.debug.assert(largest_pn <= max_packet_number);
+    // Packet numbers are sent as 1..4 bytes.
+    std.debug.assert(pn_nbits == 8 or pn_nbits == 16 or pn_nbits == 24 or pn_nbits == 32);
+    std.debug.assert(truncated_pn < (@as(u64, 1) << pn_nbits));
     const expected_pn = largest_pn + 1;
     const pn_win: u64 = @as(u64, 1) << pn_nbits;
     const pn_hwin = pn_win / 2;
@@ -68,12 +77,16 @@ test "truncate then reconstruct round-trips across a window" {
     }
 }
 
-test "packetNumberLength grows with the unacked distance" {
-    // Small gaps fit in one byte; larger gaps need more.
+test "packetNumberLength at exact RFC threshold boundaries" {
     try testing.expectEqual(@as(u3, 1), packetNumberLength(100, 99));
     try testing.expectEqual(@as(u3, 1), packetNumberLength(0, null));
-    try testing.expect(packetNumberLength(0x1_0000, 0) >= 3);
-    try testing.expect(packetNumberLength(0xFFFF_FFFF, 0) == 4);
+    // Boundaries where the required length steps up (largest_acked = 0).
+    try testing.expectEqual(@as(u3, 1), packetNumberLength(127, 0));
+    try testing.expectEqual(@as(u3, 2), packetNumberLength(128, 0));
+    try testing.expectEqual(@as(u3, 2), packetNumberLength(32767, 0));
+    try testing.expectEqual(@as(u3, 3), packetNumberLength(32768, 0));
+    try testing.expectEqual(@as(u3, 3), packetNumberLength(8388607, 0));
+    try testing.expectEqual(@as(u3, 4), packetNumberLength(8388608, 0));
 }
 
 test "truncatePacketNumber keeps the low-order bytes" {

--- a/src/quic/root.zig
+++ b/src/quic/root.zig
@@ -3,6 +3,7 @@
 
 pub const config = @import("config.zig");
 pub const udp = @import("udp.zig");
+pub const varint = @import("varint.zig");
 pub const packet = @import("packet.zig");
 pub const connection = @import("connection.zig");
 pub const tls_adapter = @import("tls_adapter.zig");

--- a/src/quic/varint.zig
+++ b/src/quic/varint.zig
@@ -1,0 +1,124 @@
+//! QUIC variable-length integer codec (#243, RFC 9000 §16).
+//!
+//! The first two bits of the first byte encode the length (00→1, 01→2, 10→4,
+//! 11→8 bytes); the value is the remaining big-endian bits. Range is 0 ..
+//! 2^62-1. Decoding accepts non-minimal encodings (RFC 9000 §16); encoding
+//! always uses the minimal length.
+
+const std = @import("std");
+
+/// Largest value representable by a QUIC varint (2^62 - 1).
+pub const max_value: u64 = (1 << 62) - 1;
+
+pub const DecodeError = error{BufferTooShort};
+pub const EncodeError = error{ ValueTooLarge, BufferTooShort };
+
+pub const Decoded = struct {
+    value: u64,
+    /// Number of bytes consumed.
+    len: usize,
+};
+
+/// Number of bytes a varint occupies, read from its first byte's 2-bit prefix.
+pub fn decodedLen(first_byte: u8) usize {
+    return @as(usize, 1) << @intCast(first_byte >> 6);
+}
+
+/// Decode a varint from the front of `bytes`.
+pub fn decode(bytes: []const u8) DecodeError!Decoded {
+    if (bytes.len == 0) return error.BufferTooShort;
+    const len = decodedLen(bytes[0]);
+    if (bytes.len < len) return error.BufferTooShort;
+    var value: u64 = bytes[0] & 0x3f;
+    var i: usize = 1;
+    while (i < len) : (i += 1) {
+        value = (value << 8) | bytes[i];
+    }
+    return .{ .value = value, .len = len };
+}
+
+/// Minimal number of bytes needed to encode `value` (1, 2, 4, or 8).
+pub fn encodedLen(value: u64) EncodeError!usize {
+    if (value <= 0x3f) return 1;
+    if (value <= 0x3fff) return 2;
+    if (value <= 0x3fff_ffff) return 4;
+    if (value <= max_value) return 8;
+    return error.ValueTooLarge;
+}
+
+/// Encode `value` into the front of `buf` using the minimal length; returns the
+/// number of bytes written.
+pub fn encode(value: u64, buf: []u8) EncodeError!usize {
+    const len = try encodedLen(value);
+    if (buf.len < len) return error.BufferTooShort;
+    switch (len) {
+        1 => buf[0] = @intCast(value),
+        2 => {
+            std.mem.writeInt(u16, buf[0..2], @intCast(value), .big);
+            buf[0] |= 0x40;
+        },
+        4 => {
+            std.mem.writeInt(u32, buf[0..4], @intCast(value), .big);
+            buf[0] |= 0x80;
+        },
+        8 => {
+            std.mem.writeInt(u64, buf[0..8], value, .big);
+            buf[0] |= 0xc0;
+        },
+        else => unreachable,
+    }
+    return len;
+}
+
+const testing = std.testing;
+
+test "decode RFC 9000 Appendix A sample varints" {
+    const D = struct { bytes: []const u8, value: u64, len: usize };
+    const cases = [_]D{
+        .{ .bytes = &.{ 0xc2, 0x19, 0x7c, 0x5e, 0xff, 0x14, 0xe8, 0x8c }, .value = 151288809941952652, .len = 8 },
+        .{ .bytes = &.{ 0x9d, 0x7f, 0x3e, 0x7d }, .value = 494878333, .len = 4 },
+        .{ .bytes = &.{ 0x7b, 0xbd }, .value = 15293, .len = 2 },
+        .{ .bytes = &.{0x25}, .value = 37, .len = 1 },
+        // Non-minimal 2-byte encoding of 37 is still valid on decode.
+        .{ .bytes = &.{ 0x40, 0x25 }, .value = 37, .len = 2 },
+    };
+    for (cases) |c| {
+        const got = try decode(c.bytes);
+        try testing.expectEqual(c.value, got.value);
+        try testing.expectEqual(c.len, got.len);
+    }
+}
+
+test "encode uses the minimal length and round-trips" {
+    var buf: [8]u8 = undefined;
+    const values = [_]u64{ 0, 1, 37, 63, 64, 15293, 16383, 16384, 494878333, 0x3fff_ffff, 0x4000_0000, 151288809941952652, max_value };
+    for (values) |v| {
+        const n = try encode(v, &buf);
+        try testing.expectEqual(try encodedLen(v), n);
+        const got = try decode(buf[0..n]);
+        try testing.expectEqual(v, got.value);
+        try testing.expectEqual(n, got.len);
+    }
+}
+
+test "encodedLen boundaries" {
+    try testing.expectEqual(@as(usize, 1), try encodedLen(63));
+    try testing.expectEqual(@as(usize, 2), try encodedLen(64));
+    try testing.expectEqual(@as(usize, 2), try encodedLen(16383));
+    try testing.expectEqual(@as(usize, 4), try encodedLen(16384));
+    try testing.expectEqual(@as(usize, 4), try encodedLen(0x3fff_ffff));
+    try testing.expectEqual(@as(usize, 8), try encodedLen(0x4000_0000));
+    try testing.expectEqual(@as(usize, 8), try encodedLen(max_value));
+    try testing.expectError(error.ValueTooLarge, encodedLen(max_value + 1));
+}
+
+test "malformed and boundary inputs" {
+    try testing.expectError(error.BufferTooShort, decode(&.{}));
+    // 8-byte prefix but only one byte present.
+    try testing.expectError(error.BufferTooShort, decode(&.{0xc2}));
+    // 2-byte prefix, one byte present.
+    try testing.expectError(error.BufferTooShort, decode(&.{0x40}));
+    var small: [1]u8 = undefined;
+    try testing.expectError(error.BufferTooShort, encode(64, &small)); // needs 2 bytes
+    try testing.expectError(error.ValueTooLarge, encode(max_value + 1, &small));
+}


### PR DESCRIPTION
First PR of **#243** (pure-Zig QUIC packet layer). The two foundational wire primitives everything else — packet headers, frames, transport parameters — builds on. Pure Zig, libc-free, entirely test-vector-driven.

## What
**`src/quic/varint.zig` — RFC 9000 §16 variable-length integer codec**
- `decode` / `encode` / `encodedLen` / `decodedLen`, with `DecodeError`/`EncodeError`.
- Minimal-length encoding; non-minimal decode accepted (per spec).
- Tests: the four **RFC 9000 Appendix A** sample vectors, a non-minimal decode, round-trips across every length boundary, `encodedLen` boundaries, and malformed/short/too-large inputs.

**`src/quic/packet.zig` — RFC 9000 §17.1 + §A.2/§A.3 packet numbers**
- `packetNumberLength` (minimal 1..4 bytes vs unacked distance), `truncatePacketNumber` (wire bytes), `decodePacketNumber` (the §A.3 reconstruction algorithm).
- Tests: the **RFC §A.3 worked example** (`0xa82f30ea` / `0x9b32` / 16 → `0xa82f9b32`), truncate+reconstruct round-trips across a sliding window, length growth, and low-order-byte truncation.

## Scope
This is `Part of #243` — the codec foundation. Follow-up commits/PRs add long/short packet header parse+serialize (Initial/0-RTT/Handshake/Retry), the frame codec, version negotiation, and CID scaffolding (all non-goals in this slice per the issue: no crypto/protection, loss, or HTTP/3 framing).

## Verify
```
zig build test-quic   # 28/28 (incl. RFC 9000 App. A varint vectors + §A.3 PN example)
zig build             # default unchanged (pure-Zig path off by default)
```

Part of #243, #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)