### PR TITLE
feat(quic): add TLS crypto reassembly foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable user-facing changes to Tardigrade are documented here.
 ## [Unreleased]
 
 ### Reliability
+- **Pure Zig QUIC TLS adapter foundation (#249)** — defines the internal
+  `QuicTlsAdapter` boundary for QUIC transport parameters, ALPN, certificate
+  state, per-level traffic secrets, and raw TLS handshake I/O without leaking
+  backend TLS types above `src/quic/tls_adapter.zig`. Adds deterministic CRYPTO
+  frame reassembly and outbound offset accounting per encryption level so
+  Initial, Handshake, 0-RTT, and 1-RTT data stay isolated before later packet
+  protection work.
 - **Pure Zig QUIC recovery foundation (#244)** — adds deterministic ACK-range
   tracking, RTT/PTO calculations, packet-threshold/time-threshold loss
   detection, bytes-in-flight accounting, NewReno recovery-period guards, and

--- a/src/quic/tls_adapter.zig
+++ b/src/quic/tls_adapter.zig
@@ -39,6 +39,13 @@ pub const EncryptionLevel = enum(u2) {
     }
 };
 
+fn cryptoStreamIndex(level: EncryptionLevel) error{InvalidCryptoLevel}!usize {
+    return switch (level) {
+        .initial, .handshake, .application => level.index(),
+        .zero_rtt => error.InvalidCryptoLevel,
+    };
+}
+
 pub const PacketNumberSpace = enum {
     initial,
     handshake,
@@ -87,21 +94,33 @@ pub const SecretStore = struct {
 
     pub fn install(self: *SecretStore, secret: Secret) void {
         switch (secret.direction) {
-            .read => self.read[secret.level.index()] = secret,
-            .write => self.write[secret.level.index()] = secret,
+            .read => installSlot(&self.read[secret.level.index()], secret),
+            .write => installSlot(&self.write[secret.level.index()], secret),
         }
     }
 
-    pub fn get(self: *const SecretStore, level: EncryptionLevel, direction: Direction) ?Secret {
+    pub fn get(self: *const SecretStore, level: EncryptionLevel, direction: Direction) ?*const Secret {
         return switch (direction) {
-            .read => self.read[level.index()],
-            .write => self.write[level.index()],
+            .read => if (self.read[level.index()]) |*secret| secret else null,
+            .write => if (self.write[level.index()]) |*secret| secret else null,
         };
     }
 
     pub fn discard(self: *SecretStore, level: EncryptionLevel) void {
+        if (self.read[level.index()]) |*secret| wipe(secret);
+        if (self.write[level.index()]) |*secret| wipe(secret);
         self.read[level.index()] = null;
         self.write[level.index()] = null;
+    }
+
+    fn installSlot(slot: *?Secret, secret: Secret) void {
+        if (slot.*) |*old_secret| wipe(old_secret);
+        slot.* = secret;
+    }
+
+    fn wipe(secret: *Secret) void {
+        @memset(secret.bytes[0..], 0);
+        secret.len = 0;
     }
 };
 
@@ -118,12 +137,22 @@ pub const CryptoStream = struct {
 
     pub fn insert(self: *CryptoStream, offset: u64, data: []const u8) error{ CryptoBufferTooLarge, TooManyCryptoRanges }!void {
         if (data.len == 0) return;
-        if (offset > max_crypto_buffer) return error.CryptoBufferTooLarge;
-        const end = offset + data.len;
-        if (end > max_crypto_buffer) return error.CryptoBufferTooLarge;
+        if (offset >= max_crypto_buffer) return error.CryptoBufferTooLarge;
+        const offset_usize: usize = @intCast(offset);
+        if (data.len > max_crypto_buffer - offset_usize) return error.CryptoBufferTooLarge;
 
-        @memcpy(self.buffer[@intCast(offset)..@intCast(end)], data);
-        try self.addRange(.{ .start = offset, .end = end });
+        var start = offset;
+        var bytes = data;
+        if (start + bytes.len <= self.consumed_offset) return;
+        if (start < self.consumed_offset) {
+            const skip: usize = @intCast(self.consumed_offset - start);
+            start = self.consumed_offset;
+            bytes = bytes[skip..];
+        }
+        const end = start + bytes.len;
+
+        try self.addRangeMerged(.{ .start = start, .end = end });
+        @memcpy(self.buffer[@intCast(start)..@intCast(end)], bytes);
     }
 
     pub fn contiguous(self: *const CryptoStream) []const u8 {
@@ -141,12 +170,38 @@ pub const CryptoStream = struct {
         return bytes;
     }
 
-    fn addRange(self: *CryptoStream, new_range: ByteRange) error{TooManyCryptoRanges}!void {
-        if (self.range_count == max_crypto_ranges) return error.TooManyCryptoRanges;
-        self.ranges[self.range_count] = new_range;
-        self.range_count += 1;
-        self.sortRanges();
-        self.mergeRanges();
+    fn addRangeMerged(self: *CryptoStream, new_range: ByteRange) error{TooManyCryptoRanges}!void {
+        var merged: [max_crypto_ranges]ByteRange = undefined;
+        var merged_count: usize = 0;
+        var pending = new_range;
+        var inserted = false;
+
+        var index: usize = 0;
+        while (index < self.range_count) : (index += 1) {
+            const current = self.ranges[index];
+            if (current.end < pending.start) {
+                try appendRange(&merged, &merged_count, current);
+            } else if (pending.end < current.start) {
+                if (!inserted) {
+                    try appendRange(&merged, &merged_count, pending);
+                    inserted = true;
+                }
+                try appendRange(&merged, &merged_count, current);
+            } else {
+                pending.start = @min(pending.start, current.start);
+                pending.end = @max(pending.end, current.end);
+            }
+        }
+        if (!inserted) try appendRange(&merged, &merged_count, pending);
+
+        @memcpy(self.ranges[0..merged_count], merged[0..merged_count]);
+        self.range_count = merged_count;
+    }
+
+    fn appendRange(ranges_out: *[max_crypto_ranges]ByteRange, count: *usize, range: ByteRange) error{TooManyCryptoRanges}!void {
+        if (count.* == max_crypto_ranges) return error.TooManyCryptoRanges;
+        ranges_out[count.*] = range;
+        count.* += 1;
     }
 
     fn contiguousEnd(self: *const CryptoStream) u64 {
@@ -173,49 +228,24 @@ pub const CryptoStream = struct {
         }
         self.range_count = out;
     }
-
-    fn sortRanges(self: *CryptoStream) void {
-        var i: usize = 1;
-        while (i < self.range_count) : (i += 1) {
-            const current = self.ranges[i];
-            var j = i;
-            while (j > 0 and self.ranges[j - 1].start > current.start) : (j -= 1) {
-                self.ranges[j] = self.ranges[j - 1];
-            }
-            self.ranges[j] = current;
-        }
-    }
-
-    fn mergeRanges(self: *CryptoStream) void {
-        if (self.range_count <= 1) return;
-        var out: usize = 0;
-        var index: usize = 1;
-        while (index < self.range_count) : (index += 1) {
-            const next = self.ranges[index];
-            if (next.start <= self.ranges[out].end) {
-                self.ranges[out].end = @max(self.ranges[out].end, next.end);
-            } else {
-                out += 1;
-                self.ranges[out] = next;
-            }
-        }
-        self.range_count = out + 1;
-    }
 };
 
 pub const CryptoReassembler = struct {
     streams: [4]CryptoStream = .{ .{}, .{}, .{}, .{} },
 
-    pub fn insert(self: *CryptoReassembler, level: EncryptionLevel, offset: u64, data: []const u8) error{ CryptoBufferTooLarge, TooManyCryptoRanges }!void {
-        try self.streams[level.index()].insert(offset, data);
+    pub fn insert(self: *CryptoReassembler, level: EncryptionLevel, offset: u64, data: []const u8) error{ CryptoBufferTooLarge, TooManyCryptoRanges, InvalidCryptoLevel }!void {
+        const index = try cryptoStreamIndex(level);
+        try self.streams[index].insert(offset, data);
     }
 
-    pub fn contiguous(self: *const CryptoReassembler, level: EncryptionLevel) []const u8 {
-        return self.streams[level.index()].contiguous();
+    pub fn contiguous(self: *const CryptoReassembler, level: EncryptionLevel) error{InvalidCryptoLevel}![]const u8 {
+        const index = try cryptoStreamIndex(level);
+        return self.streams[index].contiguous();
     }
 
-    pub fn consumeContiguous(self: *CryptoReassembler, level: EncryptionLevel) []const u8 {
-        return self.streams[level.index()].consumeContiguous();
+    pub fn consumeContiguous(self: *CryptoReassembler, level: EncryptionLevel) error{InvalidCryptoLevel}![]const u8 {
+        const index = try cryptoStreamIndex(level);
+        return self.streams[index].consumeContiguous();
     }
 };
 
@@ -291,23 +321,25 @@ pub const QuicTlsAdapter = struct {
         self.peer_transport_parameters_authenticated = true;
     }
 
-    pub fn receiveCrypto(self: *QuicTlsAdapter, level: EncryptionLevel, offset: u64, data: []const u8) error{ CryptoBufferTooLarge, TooManyCryptoRanges }!void {
+    pub fn receiveCrypto(self: *QuicTlsAdapter, level: EncryptionLevel, offset: u64, data: []const u8) error{ CryptoBufferTooLarge, TooManyCryptoRanges, InvalidCryptoLevel }!void {
         try self.reassembler.insert(level, offset, data);
     }
 
-    pub fn nextHandshakeInput(self: *QuicTlsAdapter, level: EncryptionLevel) ?HandshakeInput {
-        const bytes = self.reassembler.consumeContiguous(level);
+    pub fn nextHandshakeInput(self: *QuicTlsAdapter, level: EncryptionLevel) error{InvalidCryptoLevel}!?HandshakeInput {
+        const bytes = try self.reassembler.consumeContiguous(level);
         if (bytes.len == 0) return null;
         return .{ .level = level, .bytes = bytes };
     }
 
-    pub fn queueHandshakeOutput(self: *QuicTlsAdapter, level: EncryptionLevel, bytes: []const u8) error{CryptoBufferTooLarge}!void {
-        try self.outbound[level.index()].append(bytes);
+    pub fn queueHandshakeOutput(self: *QuicTlsAdapter, level: EncryptionLevel, bytes: []const u8) error{ CryptoBufferTooLarge, InvalidCryptoLevel }!void {
+        const index = try cryptoStreamIndex(level);
+        try self.outbound[index].append(bytes);
     }
 
-    pub fn nextHandshakeOutput(self: *QuicTlsAdapter, level: EncryptionLevel, max_bytes: usize) ?HandshakeOutput {
+    pub fn nextHandshakeOutput(self: *QuicTlsAdapter, level: EncryptionLevel, max_bytes: usize) error{InvalidCryptoLevel}!?HandshakeOutput {
+        const index = try cryptoStreamIndex(level);
         if (max_bytes == 0) return null;
-        const output = self.outbound[level.index()].take(max_bytes) orelse return null;
+        const output = self.outbound[index].take(max_bytes) orelse return null;
         return .{ .level = level, .offset = output.offset, .bytes = output.bytes };
     }
 
@@ -315,7 +347,7 @@ pub const QuicTlsAdapter = struct {
         self.secrets.install(installed_secret);
     }
 
-    pub fn secret(self: *const QuicTlsAdapter, level: EncryptionLevel, direction: Direction) ?Secret {
+    pub fn secret(self: *const QuicTlsAdapter, level: EncryptionLevel, direction: Direction) ?*const Secret {
         return self.secrets.get(level, direction);
     }
 
@@ -341,14 +373,14 @@ test "CRYPTO reassembly emits only contiguous bytes by encryption level" {
     var reassembler = CryptoReassembler{};
 
     try reassembler.insert(.initial, 6, "world");
-    try testing.expectEqual(@as(usize, 0), reassembler.contiguous(.initial).len);
+    try testing.expectEqual(@as(usize, 0), (try reassembler.contiguous(.initial)).len);
 
     try reassembler.insert(.handshake, 0, "other");
-    try testing.expectEqualStrings("other", reassembler.consumeContiguous(.handshake));
+    try testing.expectEqualStrings("other", try reassembler.consumeContiguous(.handshake));
 
     try reassembler.insert(.initial, 0, "hello ");
-    try testing.expectEqualStrings("hello world", reassembler.consumeContiguous(.initial));
-    try testing.expectEqual(@as(usize, 0), reassembler.consumeContiguous(.initial).len);
+    try testing.expectEqualStrings("hello world", try reassembler.consumeContiguous(.initial));
+    try testing.expectEqual(@as(usize, 0), (try reassembler.consumeContiguous(.initial)).len);
 }
 
 test "CRYPTO reassembly merges duplicate and overlapping fragments" {
@@ -374,6 +406,52 @@ test "CRYPTO reassembly preserves a gap after consumed bytes" {
     try testing.expectEqualStrings("defghi", stream.consumeContiguous());
 }
 
+test "CRYPTO insert merges a full range set without partial failure" {
+    var stream = CryptoStream{};
+    stream.range_count = max_crypto_ranges;
+    stream.ranges[0] = .{ .start = 0, .end = 2 };
+    stream.ranges[1] = .{ .start = 4, .end = 6 };
+    var index: usize = 2;
+    while (index < max_crypto_ranges) : (index += 1) {
+        const start: u64 = 10 + @as(u64, @intCast(index)) * 2;
+        stream.ranges[index] = .{ .start = start, .end = start + 1 };
+    }
+
+    try stream.insert(2, "cd");
+    try testing.expectEqual(@as(usize, max_crypto_ranges - 1), stream.range_count);
+    try testing.expectEqual(ByteRange{ .start = 0, .end = 6 }, stream.ranges[0]);
+    try testing.expectEqualStrings("cd", stream.buffer[2..4]);
+}
+
+test "CRYPTO insert does not mutate bytes when range insertion fails" {
+    var stream = CryptoStream{};
+    stream.range_count = max_crypto_ranges;
+    var index: usize = 0;
+    while (index < max_crypto_ranges) : (index += 1) {
+        const start: u64 = 10 + @as(u64, @intCast(index)) * 2;
+        stream.ranges[index] = .{ .start = start, .end = start + 1 };
+    }
+    stream.buffer[1] = 'x';
+
+    try testing.expectError(error.TooManyCryptoRanges, stream.insert(1, "y"));
+    try testing.expectEqual(@as(u8, 'x'), stream.buffer[1]);
+    try testing.expectEqual(@as(usize, max_crypto_ranges), stream.range_count);
+}
+
+test "CRYPTO insert ignores and trims consumed retransmits" {
+    var stream = CryptoStream{};
+    try stream.insert(0, "hello");
+    try testing.expectEqualStrings("hello", stream.consumeContiguous());
+    try testing.expectEqual(@as(u64, 5), stream.consumed_offset);
+
+    try stream.insert(0, "hello");
+    try testing.expectEqual(@as(usize, 0), stream.range_count);
+    try testing.expectEqual(@as(usize, 0), stream.contiguous().len);
+
+    try stream.insert(3, "lo world");
+    try testing.expectEqualStrings(" world", stream.consumeContiguous());
+}
+
 test "adapter tracks transport parameters ALPN secrets and handshake input" {
     var adapter = QuicTlsAdapter{};
     const params = try (config.Config{}).transportParameters();
@@ -385,19 +463,35 @@ test "adapter tracks transport parameters ALPN secrets and handshake input" {
 
     const read_secret = try Secret.init(.handshake, .read, "read-secret");
     adapter.installSecret(read_secret);
-    try testing.expectEqualStrings("read-secret", adapter.secret(.handshake, .read).?.slice());
+    const stored_read_secret = adapter.secret(.handshake, .read).?;
+    try testing.expectEqualStrings("read-secret", stored_read_secret.slice());
     adapter.discardSecrets(.handshake);
     try testing.expect(adapter.secret(.handshake, .read) == null);
 
     try adapter.receiveCrypto(.initial, 4, "lo");
     try adapter.receiveCrypto(.initial, 0, "hel");
-    const first_input = adapter.nextHandshakeInput(.initial).?;
+    const first_input = (try adapter.nextHandshakeInput(.initial)).?;
     try testing.expectEqual(EncryptionLevel.initial, first_input.level);
     try testing.expectEqualStrings("hel", first_input.bytes);
     try adapter.receiveCrypto(.initial, 3, "l");
-    const input = adapter.nextHandshakeInput(.initial).?;
+    const input = (try adapter.nextHandshakeInput(.initial)).?;
     try testing.expectEqual(EncryptionLevel.initial, input.level);
     try testing.expectEqualStrings("llo", input.bytes);
+}
+
+test "secret store returns pointers and wipes discarded secret bytes" {
+    var store = SecretStore{};
+    store.install(try Secret.init(.application, .write, "app-secret"));
+    const stored = store.get(.application, .write).?;
+    try testing.expectEqualStrings("app-secret", stored.slice());
+
+    var standalone = try Secret.init(.application, .write, "wipe-me");
+    SecretStore.wipe(&standalone);
+    try testing.expectEqual(@as(usize, 0), standalone.len);
+    for (standalone.bytes) |byte| try testing.expectEqual(@as(u8, 0), byte);
+
+    store.discard(.application);
+    try testing.expect(store.get(.application, .write) == null);
 }
 
 test "adapter queues outbound TLS handshake bytes as CRYPTO stream data" {
@@ -407,20 +501,31 @@ test "adapter queues outbound TLS handshake bytes as CRYPTO stream data" {
     try adapter.queueHandshakeOutput(.initial, " hello");
     try adapter.queueHandshakeOutput(.handshake, "server");
 
-    const first = adapter.nextHandshakeOutput(.initial, 6).?;
+    const first = (try adapter.nextHandshakeOutput(.initial, 6)).?;
     try testing.expectEqual(EncryptionLevel.initial, first.level);
     try testing.expectEqual(@as(u64, 0), first.offset);
     try testing.expectEqualStrings("client", first.bytes);
 
-    const second = adapter.nextHandshakeOutput(.initial, 32).?;
+    const second = (try adapter.nextHandshakeOutput(.initial, 32)).?;
     try testing.expectEqual(@as(u64, 6), second.offset);
     try testing.expectEqualStrings(" hello", second.bytes);
-    try testing.expect(adapter.nextHandshakeOutput(.initial, 1) == null);
+    try testing.expect((try adapter.nextHandshakeOutput(.initial, 1)) == null);
 
-    const handshake = adapter.nextHandshakeOutput(.handshake, 32).?;
+    const handshake = (try adapter.nextHandshakeOutput(.handshake, 32)).?;
     try testing.expectEqual(EncryptionLevel.handshake, handshake.level);
     try testing.expectEqual(@as(u64, 0), handshake.offset);
     try testing.expectEqualStrings("server", handshake.bytes);
+}
+
+test "0-RTT secrets are allowed but CRYPTO streams reject zero_rtt level" {
+    var adapter = QuicTlsAdapter{};
+    adapter.installSecret(try Secret.init(.zero_rtt, .read, "early-data-secret"));
+    try testing.expectEqualStrings("early-data-secret", adapter.secret(.zero_rtt, .read).?.slice());
+
+    try testing.expectError(error.InvalidCryptoLevel, adapter.receiveCrypto(.zero_rtt, 0, "bad"));
+    try testing.expectError(error.InvalidCryptoLevel, adapter.queueHandshakeOutput(.zero_rtt, "bad"));
+    try testing.expectError(error.InvalidCryptoLevel, adapter.nextHandshakeInput(.zero_rtt));
+    try testing.expectError(error.InvalidCryptoLevel, adapter.nextHandshakeOutput(.zero_rtt, 1));
 }
 
 test {

--- a/src/quic/tls_adapter.zig
+++ b/src/quic/tls_adapter.zig
@@ -8,12 +8,420 @@
 //! library type escapes this module. Initial-secret derivation and key updates
 //! also live here.
 //!
-//! Status: skeleton — implemented in #249.
+//! Status: foundation slice — adapter contract and CRYPTO reassembly are in
+//! place. Backend TLS driving, packet/header protection, and key updates land
+//! in later #249 slices.
 
 const std = @import("std");
+const config = @import("config.zig");
 
-// TODO(#249): CRYPTO reassembly, per-level secret installation, packet/header
-// protection key provision, and key updates.
+pub const max_crypto_buffer = 64 * 1024;
+pub const max_crypto_ranges = 32;
+pub const max_handshake_record = 16 * 1024;
+pub const max_secret_len = 64;
+
+pub const EncryptionLevel = enum(u2) {
+    initial,
+    zero_rtt,
+    handshake,
+    application,
+
+    pub fn index(self: EncryptionLevel) usize {
+        return @intFromEnum(self);
+    }
+
+    pub fn packetNumberSpace(self: EncryptionLevel) PacketNumberSpace {
+        return switch (self) {
+            .initial => .initial,
+            .handshake => .handshake,
+            .zero_rtt, .application => .application,
+        };
+    }
+};
+
+pub const PacketNumberSpace = enum {
+    initial,
+    handshake,
+    application,
+};
+
+pub const Direction = enum {
+    read,
+    write,
+};
+
+pub const CertificateState = enum {
+    not_checked,
+    valid,
+    invalid,
+};
+
+pub const KeyPhase = enum {
+    current,
+    next,
+};
+
+pub const Secret = struct {
+    level: EncryptionLevel,
+    direction: Direction,
+    phase: KeyPhase = .current,
+    bytes: [max_secret_len]u8 = [_]u8{0} ** max_secret_len,
+    len: usize = 0,
+
+    pub fn init(level: EncryptionLevel, direction: Direction, bytes: []const u8) error{SecretTooLarge}!Secret {
+        if (bytes.len > max_secret_len) return error.SecretTooLarge;
+        var secret = Secret{ .level = level, .direction = direction };
+        @memcpy(secret.bytes[0..bytes.len], bytes);
+        secret.len = bytes.len;
+        return secret;
+    }
+
+    pub fn slice(self: *const Secret) []const u8 {
+        return self.bytes[0..self.len];
+    }
+};
+
+pub const SecretStore = struct {
+    read: [4]?Secret = .{ null, null, null, null },
+    write: [4]?Secret = .{ null, null, null, null },
+
+    pub fn install(self: *SecretStore, secret: Secret) void {
+        switch (secret.direction) {
+            .read => self.read[secret.level.index()] = secret,
+            .write => self.write[secret.level.index()] = secret,
+        }
+    }
+
+    pub fn get(self: *const SecretStore, level: EncryptionLevel, direction: Direction) ?Secret {
+        return switch (direction) {
+            .read => self.read[level.index()],
+            .write => self.write[level.index()],
+        };
+    }
+
+    pub fn discard(self: *SecretStore, level: EncryptionLevel) void {
+        self.read[level.index()] = null;
+        self.write[level.index()] = null;
+    }
+};
+
+pub const ByteRange = struct {
+    start: u64,
+    end: u64,
+};
+
+pub const CryptoStream = struct {
+    buffer: [max_crypto_buffer]u8 = undefined,
+    ranges: [max_crypto_ranges]ByteRange = undefined,
+    range_count: usize = 0,
+    consumed_offset: u64 = 0,
+
+    pub fn insert(self: *CryptoStream, offset: u64, data: []const u8) error{ CryptoBufferTooLarge, TooManyCryptoRanges }!void {
+        if (data.len == 0) return;
+        if (offset > max_crypto_buffer) return error.CryptoBufferTooLarge;
+        const end = offset + data.len;
+        if (end > max_crypto_buffer) return error.CryptoBufferTooLarge;
+
+        @memcpy(self.buffer[@intCast(offset)..@intCast(end)], data);
+        try self.addRange(.{ .start = offset, .end = end });
+    }
+
+    pub fn contiguous(self: *const CryptoStream) []const u8 {
+        const end = self.contiguousEnd();
+        if (end <= self.consumed_offset) return &.{};
+        return self.buffer[@intCast(self.consumed_offset)..@intCast(end)];
+    }
+
+    pub fn consumeContiguous(self: *CryptoStream) []const u8 {
+        const end = self.contiguousEnd();
+        if (end <= self.consumed_offset) return &.{};
+        const bytes = self.buffer[@intCast(self.consumed_offset)..@intCast(end)];
+        self.consumed_offset = end;
+        self.dropConsumedRanges();
+        return bytes;
+    }
+
+    fn addRange(self: *CryptoStream, new_range: ByteRange) error{TooManyCryptoRanges}!void {
+        if (self.range_count == max_crypto_ranges) return error.TooManyCryptoRanges;
+        self.ranges[self.range_count] = new_range;
+        self.range_count += 1;
+        self.sortRanges();
+        self.mergeRanges();
+    }
+
+    fn contiguousEnd(self: *const CryptoStream) u64 {
+        var end = self.consumed_offset;
+        var index: usize = 0;
+        while (index < self.range_count) : (index += 1) {
+            const range = self.ranges[index];
+            if (range.end <= end) continue;
+            if (range.start > end) break;
+            end = range.end;
+        }
+        return end;
+    }
+
+    fn dropConsumedRanges(self: *CryptoStream) void {
+        var out: usize = 0;
+        var index: usize = 0;
+        while (index < self.range_count) : (index += 1) {
+            var range = self.ranges[index];
+            if (range.end <= self.consumed_offset) continue;
+            if (range.start < self.consumed_offset) range.start = self.consumed_offset;
+            self.ranges[out] = range;
+            out += 1;
+        }
+        self.range_count = out;
+    }
+
+    fn sortRanges(self: *CryptoStream) void {
+        var i: usize = 1;
+        while (i < self.range_count) : (i += 1) {
+            const current = self.ranges[i];
+            var j = i;
+            while (j > 0 and self.ranges[j - 1].start > current.start) : (j -= 1) {
+                self.ranges[j] = self.ranges[j - 1];
+            }
+            self.ranges[j] = current;
+        }
+    }
+
+    fn mergeRanges(self: *CryptoStream) void {
+        if (self.range_count <= 1) return;
+        var out: usize = 0;
+        var index: usize = 1;
+        while (index < self.range_count) : (index += 1) {
+            const next = self.ranges[index];
+            if (next.start <= self.ranges[out].end) {
+                self.ranges[out].end = @max(self.ranges[out].end, next.end);
+            } else {
+                out += 1;
+                self.ranges[out] = next;
+            }
+        }
+        self.range_count = out + 1;
+    }
+};
+
+pub const CryptoReassembler = struct {
+    streams: [4]CryptoStream = .{ .{}, .{}, .{}, .{} },
+
+    pub fn insert(self: *CryptoReassembler, level: EncryptionLevel, offset: u64, data: []const u8) error{ CryptoBufferTooLarge, TooManyCryptoRanges }!void {
+        try self.streams[level.index()].insert(offset, data);
+    }
+
+    pub fn contiguous(self: *const CryptoReassembler, level: EncryptionLevel) []const u8 {
+        return self.streams[level.index()].contiguous();
+    }
+
+    pub fn consumeContiguous(self: *CryptoReassembler, level: EncryptionLevel) []const u8 {
+        return self.streams[level.index()].consumeContiguous();
+    }
+};
+
+pub const HandshakeInput = struct {
+    level: EncryptionLevel,
+    bytes: []const u8,
+};
+
+pub const HandshakeOutput = struct {
+    level: EncryptionLevel,
+    offset: u64,
+    bytes: []const u8,
+};
+
+pub const CryptoOutput = struct {
+    buffer: [max_crypto_buffer]u8 = undefined,
+    start: usize = 0,
+    end: usize = 0,
+    next_offset: u64 = 0,
+
+    pub fn append(self: *CryptoOutput, bytes: []const u8) error{CryptoBufferTooLarge}!void {
+        if (bytes.len == 0) return;
+        if (self.end + bytes.len > max_crypto_buffer) {
+            self.compact();
+            if (self.end + bytes.len > max_crypto_buffer) return error.CryptoBufferTooLarge;
+        }
+        @memcpy(self.buffer[self.end .. self.end + bytes.len], bytes);
+        self.end += bytes.len;
+    }
+
+    pub fn pending(self: *const CryptoOutput) usize {
+        return self.end - self.start;
+    }
+
+    pub fn take(self: *CryptoOutput, max_bytes: usize) ?struct { offset: u64, bytes: []const u8 } {
+        const available = self.pending();
+        if (available == 0) return null;
+        const len = @min(available, max_bytes);
+        const offset = self.next_offset;
+        const bytes = self.buffer[self.start .. self.start + len];
+        self.start += len;
+        self.next_offset += len;
+        if (self.start == self.end) {
+            self.start = 0;
+            self.end = 0;
+        }
+        return .{ .offset = offset, .bytes = bytes };
+    }
+
+    fn compact(self: *CryptoOutput) void {
+        if (self.start == 0) return;
+        const available = self.pending();
+        if (available > 0) std.mem.copyForwards(u8, self.buffer[0..available], self.buffer[self.start..self.end]);
+        self.start = 0;
+        self.end = available;
+    }
+};
+
+pub const QuicTlsAdapter = struct {
+    local_transport_parameters: ?config.TransportParameters = null,
+    peer_transport_parameters_authenticated: bool = false,
+    reassembler: CryptoReassembler = .{},
+    outbound: [4]CryptoOutput = .{ .{}, .{}, .{}, .{} },
+    secrets: SecretStore = .{},
+    alpn_h3: bool = false,
+    certificate_state: CertificateState = .not_checked,
+
+    pub fn setLocalTransportParameters(self: *QuicTlsAdapter, params: config.TransportParameters) void {
+        self.local_transport_parameters = params;
+    }
+
+    pub fn authenticatePeerTransportParameters(self: *QuicTlsAdapter) void {
+        self.peer_transport_parameters_authenticated = true;
+    }
+
+    pub fn receiveCrypto(self: *QuicTlsAdapter, level: EncryptionLevel, offset: u64, data: []const u8) error{ CryptoBufferTooLarge, TooManyCryptoRanges }!void {
+        try self.reassembler.insert(level, offset, data);
+    }
+
+    pub fn nextHandshakeInput(self: *QuicTlsAdapter, level: EncryptionLevel) ?HandshakeInput {
+        const bytes = self.reassembler.consumeContiguous(level);
+        if (bytes.len == 0) return null;
+        return .{ .level = level, .bytes = bytes };
+    }
+
+    pub fn queueHandshakeOutput(self: *QuicTlsAdapter, level: EncryptionLevel, bytes: []const u8) error{CryptoBufferTooLarge}!void {
+        try self.outbound[level.index()].append(bytes);
+    }
+
+    pub fn nextHandshakeOutput(self: *QuicTlsAdapter, level: EncryptionLevel, max_bytes: usize) ?HandshakeOutput {
+        if (max_bytes == 0) return null;
+        const output = self.outbound[level.index()].take(max_bytes) orelse return null;
+        return .{ .level = level, .offset = output.offset, .bytes = output.bytes };
+    }
+
+    pub fn installSecret(self: *QuicTlsAdapter, installed_secret: Secret) void {
+        self.secrets.install(installed_secret);
+    }
+
+    pub fn secret(self: *const QuicTlsAdapter, level: EncryptionLevel, direction: Direction) ?Secret {
+        return self.secrets.get(level, direction);
+    }
+
+    pub fn discardSecrets(self: *QuicTlsAdapter, level: EncryptionLevel) void {
+        self.secrets.discard(level);
+    }
+
+    pub fn markAlpn(self: *QuicTlsAdapter, protocol: []const u8) void {
+        self.alpn_h3 = std.mem.eql(u8, protocol, "h3");
+    }
+};
+
+const testing = std.testing;
+
+test "encryption levels map to QUIC packet number spaces" {
+    try testing.expectEqual(PacketNumberSpace.initial, EncryptionLevel.initial.packetNumberSpace());
+    try testing.expectEqual(PacketNumberSpace.handshake, EncryptionLevel.handshake.packetNumberSpace());
+    try testing.expectEqual(PacketNumberSpace.application, EncryptionLevel.zero_rtt.packetNumberSpace());
+    try testing.expectEqual(PacketNumberSpace.application, EncryptionLevel.application.packetNumberSpace());
+}
+
+test "CRYPTO reassembly emits only contiguous bytes by encryption level" {
+    var reassembler = CryptoReassembler{};
+
+    try reassembler.insert(.initial, 6, "world");
+    try testing.expectEqual(@as(usize, 0), reassembler.contiguous(.initial).len);
+
+    try reassembler.insert(.handshake, 0, "other");
+    try testing.expectEqualStrings("other", reassembler.consumeContiguous(.handshake));
+
+    try reassembler.insert(.initial, 0, "hello ");
+    try testing.expectEqualStrings("hello world", reassembler.consumeContiguous(.initial));
+    try testing.expectEqual(@as(usize, 0), reassembler.consumeContiguous(.initial).len);
+}
+
+test "CRYPTO reassembly merges duplicate and overlapping fragments" {
+    var stream = CryptoStream{};
+    try stream.insert(0, "abcde");
+    try stream.insert(2, "cdef");
+    try stream.insert(6, "g");
+
+    try testing.expectEqual(@as(usize, 1), stream.range_count);
+    try testing.expectEqualStrings("abcdefg", stream.consumeContiguous());
+}
+
+test "CRYPTO reassembly preserves a gap after consumed bytes" {
+    var stream = CryptoStream{};
+    try stream.insert(0, "abc");
+    try stream.insert(6, "ghi");
+    try testing.expectEqualStrings("abc", stream.consumeContiguous());
+    try testing.expectEqual(@as(u64, 3), stream.consumed_offset);
+    try testing.expectEqual(@as(usize, 1), stream.range_count);
+    try testing.expectEqual(@as(usize, 0), stream.contiguous().len);
+
+    try stream.insert(3, "def");
+    try testing.expectEqualStrings("defghi", stream.consumeContiguous());
+}
+
+test "adapter tracks transport parameters ALPN secrets and handshake input" {
+    var adapter = QuicTlsAdapter{};
+    const params = try (config.Config{}).transportParameters();
+    adapter.setLocalTransportParameters(params);
+    try testing.expect(adapter.local_transport_parameters != null);
+
+    adapter.markAlpn("h3");
+    try testing.expect(adapter.alpn_h3);
+
+    const read_secret = try Secret.init(.handshake, .read, "read-secret");
+    adapter.installSecret(read_secret);
+    try testing.expectEqualStrings("read-secret", adapter.secret(.handshake, .read).?.slice());
+    adapter.discardSecrets(.handshake);
+    try testing.expect(adapter.secret(.handshake, .read) == null);
+
+    try adapter.receiveCrypto(.initial, 4, "lo");
+    try adapter.receiveCrypto(.initial, 0, "hel");
+    const first_input = adapter.nextHandshakeInput(.initial).?;
+    try testing.expectEqual(EncryptionLevel.initial, first_input.level);
+    try testing.expectEqualStrings("hel", first_input.bytes);
+    try adapter.receiveCrypto(.initial, 3, "l");
+    const input = adapter.nextHandshakeInput(.initial).?;
+    try testing.expectEqual(EncryptionLevel.initial, input.level);
+    try testing.expectEqualStrings("llo", input.bytes);
+}
+
+test "adapter queues outbound TLS handshake bytes as CRYPTO stream data" {
+    var adapter = QuicTlsAdapter{};
+
+    try adapter.queueHandshakeOutput(.initial, "client");
+    try adapter.queueHandshakeOutput(.initial, " hello");
+    try adapter.queueHandshakeOutput(.handshake, "server");
+
+    const first = adapter.nextHandshakeOutput(.initial, 6).?;
+    try testing.expectEqual(EncryptionLevel.initial, first.level);
+    try testing.expectEqual(@as(u64, 0), first.offset);
+    try testing.expectEqualStrings("client", first.bytes);
+
+    const second = adapter.nextHandshakeOutput(.initial, 32).?;
+    try testing.expectEqual(@as(u64, 6), second.offset);
+    try testing.expectEqualStrings(" hello", second.bytes);
+    try testing.expect(adapter.nextHandshakeOutput(.initial, 1) == null);
+
+    const handshake = adapter.nextHandshakeOutput(.handshake, 32).?;
+    try testing.expectEqual(EncryptionLevel.handshake, handshake.level);
+    try testing.expectEqual(@as(u64, 0), handshake.offset);
+    try testing.expectEqualStrings("server", handshake.bytes);
+}
 
 test {
     std.testing.refAllDecls(@This());


### PR DESCRIPTION
## Summary
- define the pure Zig `QuicTlsAdapter` boundary for transport parameters, ALPN, certificate state, per-level secrets, and TLS handshake byte I/O
- add deterministic CRYPTO stream reassembly per encryption level, including overlap/gap handling
- add outbound TLS handshake byte queues with CRYPTO stream offsets for later packet framing
- document the #249 foundation slice in the Unreleased changelog

Refs #249

## Validation
- `zig build test-quic --summary all --error-style verbose`
- `zig fmt --check build.zig src/ tests/`
- `git diff --check`
- `zig build test --summary all --error-style verbose`
- `zig build --summary all --error-style verbose`

## Deferred
- backend TLS driving
- packet/header protection test vectors
- key update transitions
- transport-parameter authentication parsing
