### PR TITLE
feat(quic): protect Initial packet payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable user-facing changes to Tardigrade are documented here.
 ## [Unreleased]
 
 ### Reliability
+- **Pure Zig QUIC Initial packet protection (#249)** — adds AES-128-GCM
+  sealing/opening helpers for QUIC v1 Initial payloads using the derived
+  packet-protection keys, with RFC 9001 client Initial sample coverage and
+  negative tests for wrong keys, truncated tags, and undersized output buffers.
 - **Pure Zig QUIC Initial key derivation (#249)** — derives RFC 9001 QUIC v1
   Initial client/server secrets and AES-128-GCM packet-protection/header-
   protection material from the client Initial DCID, installs read/write Initial

--- a/src/quic/tls_adapter.zig
+++ b/src/quic/tls_adapter.zig
@@ -35,6 +35,7 @@ pub const initial_secret_len = HkdfSha256.prk_length;
 pub const initial_key_len = Aes128Gcm.key_length;
 pub const initial_iv_len = Aes128Gcm.nonce_length;
 pub const header_protection_key_len = Aes128Gcm.key_length;
+pub const packet_protection_tag_len = Aes128Gcm.tag_length;
 
 pub const EncryptionLevel = enum(u2) {
     initial,
@@ -163,6 +164,52 @@ pub const InitialPacketProtectionKeys = struct {
             out[initial_iv_len - packet_number_bytes.len + index] ^= byte;
         }
         return out;
+    }
+
+    pub fn sealPayload(
+        self: *const InitialPacketProtectionKeys,
+        packet_number: u64,
+        header: []const u8,
+        plaintext: []const u8,
+        out: []u8,
+    ) error{OutputTooSmall}![]u8 {
+        if (out.len < plaintext.len + packet_protection_tag_len) return error.OutputTooSmall;
+
+        var tag: [packet_protection_tag_len]u8 = undefined;
+        Aes128Gcm.encrypt(
+            out[0..plaintext.len],
+            &tag,
+            plaintext,
+            header,
+            self.nonce(packet_number),
+            self.key,
+        );
+        @memcpy(out[plaintext.len..][0..packet_protection_tag_len], &tag);
+        return out[0 .. plaintext.len + packet_protection_tag_len];
+    }
+
+    pub fn openPayload(
+        self: *const InitialPacketProtectionKeys,
+        packet_number: u64,
+        header: []const u8,
+        protected_payload: []const u8,
+        out: []u8,
+    ) error{ ProtectedPayloadTooShort, OutputTooSmall, AuthenticationFailed }![]u8 {
+        if (protected_payload.len < packet_protection_tag_len) return error.ProtectedPayloadTooShort;
+        const ciphertext_len = protected_payload.len - packet_protection_tag_len;
+        if (out.len < ciphertext_len) return error.OutputTooSmall;
+
+        var tag: [packet_protection_tag_len]u8 = undefined;
+        @memcpy(&tag, protected_payload[ciphertext_len..][0..packet_protection_tag_len]);
+        Aes128Gcm.decrypt(
+            out[0..ciphertext_len],
+            protected_payload[0..ciphertext_len],
+            tag,
+            header,
+            self.nonce(packet_number),
+            self.key,
+        ) catch return error.AuthenticationFailed;
+        return out[0..ciphertext_len];
     }
 
     pub fn headerProtectionMask(self: *const InitialPacketProtectionKeys, sample: [16]u8) [5]u8 {
@@ -468,6 +515,12 @@ fn expectHex(comptime hex: []const u8, actual: []const u8) !void {
     try testing.expectEqualSlices(u8, &expected, actual);
 }
 
+fn hexBytes(comptime hex: []const u8) [hex.len / 2]u8 {
+    var bytes: [hex.len / 2]u8 = undefined;
+    _ = std.fmt.hexToBytes(&bytes, hex) catch unreachable;
+    return bytes;
+}
+
 test "encryption levels map to QUIC packet number spaces" {
     try testing.expectEqual(PacketNumberSpace.initial, EncryptionLevel.initial.packetNumberSpace());
     try testing.expectEqual(PacketNumberSpace.handshake, EncryptionLevel.handshake.packetNumberSpace());
@@ -501,6 +554,69 @@ test "Initial packet protection derives nonce and header protection mask" {
     var sample: [16]u8 = undefined;
     _ = try std.fmt.hexToBytes(&sample, "d1b1c98dd7689fb8ec11d242b123dc9b");
     try expectHex("437b9aec36", &secrets.client.headerProtectionMask(sample));
+}
+
+test "Initial packet protection seals RFC 9001 client Initial payload sample" {
+    var dcid: [8]u8 = undefined;
+    _ = try std.fmt.hexToBytes(&dcid, "8394c8f03e515708");
+    const secrets = try deriveInitialSecretsV1(&dcid);
+
+    var header: [22]u8 = undefined;
+    _ = try std.fmt.hexToBytes(&header, "c300000001088394c8f03e5157080000449e00000002");
+    const crypto_frame = hexBytes(
+        "060040f1010000ed0303ebf8fa56f129" ++
+            "39b9584a3896472ec40bb863cfd3e868" ++
+            "04fe3a47f06a2b69484c000004130113" ++
+            "02010000c000000010000e00000b6578" ++
+            "616d706c652e636f6dff01000100000a" ++
+            "00080006001d00170018001000070005" ++
+            "04616c706e0005000501000000000033" ++
+            "00260024001d00209370b2c9caa47fba" ++
+            "baf4559fedba753de171fa71f50f1ce1" ++
+            "5d43e994ec74d748002b000302030400" ++
+            "0d0010000e0403050306030203080408" ++
+            "050806002d00020101001c0002400100" ++
+            "3900320408ffffffffffffffff050480" ++
+            "00ffff07048000ffff08011001048000" ++
+            "75300901100f088394c8f03e51570806" ++
+            "048000ffff",
+    );
+    var plaintext = [_]u8{0} ** 1162;
+    @memcpy(plaintext[0..crypto_frame.len], &crypto_frame);
+
+    var protected_payload: [1178]u8 = undefined;
+    const sealed = try secrets.client.sealPayload(2, &header, &plaintext, &protected_payload);
+    try testing.expectEqual(@as(usize, plaintext.len + packet_protection_tag_len), sealed.len);
+    try expectHex("d1b1c98dd7689fb8ec11d242b123dc9b", sealed[0..16]);
+
+    var opened: [1162]u8 = undefined;
+    const unsealed = try secrets.client.openPayload(2, &header, sealed, &opened);
+    try testing.expectEqualSlices(u8, &plaintext, unsealed);
+}
+
+test "Initial packet protection rejects invalid inputs" {
+    var dcid: [8]u8 = undefined;
+    _ = try std.fmt.hexToBytes(&dcid, "8394c8f03e515708");
+    const secrets = try deriveInitialSecretsV1(&dcid);
+    const header = "test header";
+    const plaintext = "ping";
+
+    var too_small_seal: [plaintext.len + packet_protection_tag_len - 1]u8 = undefined;
+    try testing.expectError(error.OutputTooSmall, secrets.client.sealPayload(0, header, plaintext, &too_small_seal));
+
+    var protected_payload: [plaintext.len + packet_protection_tag_len]u8 = undefined;
+    const sealed = try secrets.client.sealPayload(0, header, plaintext, &protected_payload);
+
+    var too_small_open: [plaintext.len - 1]u8 = undefined;
+    try testing.expectError(error.OutputTooSmall, secrets.client.openPayload(0, header, sealed, &too_small_open));
+    try testing.expectError(error.ProtectedPayloadTooShort, secrets.client.openPayload(0, header, sealed[0 .. packet_protection_tag_len - 1], &too_small_open));
+
+    var opened: [plaintext.len]u8 = undefined;
+    try testing.expectError(error.AuthenticationFailed, secrets.server.openPayload(0, header, sealed, &opened));
+
+    var tampered = protected_payload;
+    tampered[0] ^= 0x01;
+    try testing.expectError(error.AuthenticationFailed, secrets.client.openPayload(0, header, &tampered, &opened));
 }
 
 test "Initial secrets reject invalid destination connection IDs" {

--- a/src/quic/tls_adapter.zig
+++ b/src/quic/tls_adapter.zig
@@ -36,6 +36,7 @@ pub const initial_key_len = Aes128Gcm.key_length;
 pub const initial_iv_len = Aes128Gcm.nonce_length;
 pub const header_protection_key_len = Aes128Gcm.key_length;
 pub const packet_protection_tag_len = Aes128Gcm.tag_length;
+pub const max_packet_number: u64 = (@as(u64, 1) << 62) - 1;
 
 pub const EncryptionLevel = enum(u2) {
     initial,
@@ -155,7 +156,7 @@ pub const InitialPacketProtectionKeys = struct {
     hp: [header_protection_key_len]u8,
 
     pub fn nonce(self: *const InitialPacketProtectionKeys, packet_number: u64) [initial_iv_len]u8 {
-        std.debug.assert(packet_number <= ((@as(u64, 1) << 62) - 1));
+        std.debug.assert(packet_number <= max_packet_number);
 
         var out = self.iv;
         var packet_number_bytes: [8]u8 = undefined;
@@ -172,8 +173,11 @@ pub const InitialPacketProtectionKeys = struct {
         header: []const u8,
         plaintext: []const u8,
         out: []u8,
-    ) error{OutputTooSmall}![]u8 {
-        if (out.len < plaintext.len + packet_protection_tag_len) return error.OutputTooSmall;
+    ) error{ InvalidPacketNumber, OutputTooSmall }![]u8 {
+        try validatePacketNumber(packet_number);
+        if (plaintext.len > std.math.maxInt(usize) - packet_protection_tag_len) return error.OutputTooSmall;
+        const required_len = plaintext.len + packet_protection_tag_len;
+        if (out.len < required_len) return error.OutputTooSmall;
 
         var tag: [packet_protection_tag_len]u8 = undefined;
         Aes128Gcm.encrypt(
@@ -185,7 +189,7 @@ pub const InitialPacketProtectionKeys = struct {
             self.key,
         );
         @memcpy(out[plaintext.len..][0..packet_protection_tag_len], &tag);
-        return out[0 .. plaintext.len + packet_protection_tag_len];
+        return out[0..required_len];
     }
 
     pub fn openPayload(
@@ -194,7 +198,8 @@ pub const InitialPacketProtectionKeys = struct {
         header: []const u8,
         protected_payload: []const u8,
         out: []u8,
-    ) error{ ProtectedPayloadTooShort, OutputTooSmall, AuthenticationFailed }![]u8 {
+    ) error{ InvalidPacketNumber, ProtectedPayloadTooShort, OutputTooSmall, AuthenticationFailed }![]u8 {
+        try validatePacketNumber(packet_number);
         if (protected_payload.len < packet_protection_tag_len) return error.ProtectedPayloadTooShort;
         const ciphertext_len = protected_payload.len - packet_protection_tag_len;
         if (out.len < ciphertext_len) return error.OutputTooSmall;
@@ -219,6 +224,10 @@ pub const InitialPacketProtectionKeys = struct {
         return block[0..5].*;
     }
 };
+
+fn validatePacketNumber(packet_number: u64) error{InvalidPacketNumber}!void {
+    if (packet_number > max_packet_number) return error.InvalidPacketNumber;
+}
 
 pub const InitialSecrets = struct {
     initial_secret: [initial_secret_len]u8,
@@ -587,7 +596,47 @@ test "Initial packet protection seals RFC 9001 client Initial payload sample" {
     var protected_payload: [1178]u8 = undefined;
     const sealed = try secrets.client.sealPayload(2, &header, &plaintext, &protected_payload);
     try testing.expectEqual(@as(usize, plaintext.len + packet_protection_tag_len), sealed.len);
-    try expectHex("d1b1c98dd7689fb8ec11d242b123dc9b", sealed[0..16]);
+    const expected_protected_payload = hexBytes(
+        "d1b1c98dd7689fb8ec11d242b123dc9b" ++
+            "d8bab936b47d92ec356c0bab7df5976d27cd449f63300099f399" ++
+            "1c260ec4c60d17b31f8429157bb35a1282a643a8d2262cad67500cadb8e7378c" ++
+            "8eb7539ec4d4905fed1bee1fc8aafba17c750e2c7ace01e6005f80fcb7df6212" ++
+            "30c83711b39343fa028cea7f7fb5ff89eac2308249a02252155e2347b63d58c5" ++
+            "457afd84d05dfffdb20392844ae812154682e9cf012f9021a6f0be17ddd0c208" ++
+            "4dce25ff9b06cde535d0f920a2db1bf362c23e596d11a4f5a6cf3948838a3aec" ++
+            "4e15daf8500a6ef69ec4e3feb6b1d98e610ac8b7ec3faf6ad760b7bad1db4ba3" ++
+            "485e8a94dc250ae3fdb41ed15fb6a8e5eba0fc3dd60bc8e30c5c4287e53805db" ++
+            "059ae0648db2f64264ed5e39be2e20d82df566da8dd5998ccabdae053060ae6c" ++
+            "7b4378e846d29f37ed7b4ea9ec5d82e7961b7f25a9323851f681d582363aa5f8" ++
+            "9937f5a67258bf63ad6f1a0b1d96dbd4faddfcefc5266ba6611722395c906556" ++
+            "be52afe3f565636ad1b17d508b73d8743eeb524be22b3dcbc2c7468d54119c74" ++
+            "68449a13d8e3b95811a198f3491de3e7fe942b330407abf82a4ed7c1b311663a" ++
+            "c69890f4157015853d91e923037c227a33cdd5ec281ca3f79c44546b9d90ca00" ++
+            "f064c99e3dd97911d39fe9c5d0b23a229a234cb36186c4819e8b9c5927726632" ++
+            "291d6a418211cc2962e20fe47feb3edf330f2c603a9d48c0fcb5699dbfe58964" ++
+            "25c5bac4aee82e57a85aaf4e2513e4f05796b07ba2ee47d80506f8d2c25e50fd" ++
+            "14de71e6c418559302f939b0e1abd576f279c4b2e0feb85c1f28ff18f58891ff" ++
+            "ef132eef2fa09346aee33c28eb130ff28f5b766953334113211996d20011a198" ++
+            "e3fc433f9f2541010ae17c1bf202580f6047472fb36857fe843b19f5984009dd" ++
+            "c324044e847a4f4a0ab34f719595de37252d6235365e9b84392b061085349d73" ++
+            "203a4a13e96f5432ec0fd4a1ee65accdd5e3904df54c1da510b0ff20dcc0c77f" ++
+            "cb2c0e0eb605cb0504db87632cf3d8b4dae6e705769d1de354270123cb11450e" ++
+            "fc60ac47683d7b8d0f811365565fd98c4c8eb936bcab8d069fc33bd801b03ade" ++
+            "a2e1fbc5aa463d08ca19896d2bf59a071b851e6c239052172f296bfb5e724047" ++
+            "90a2181014f3b94a4e97d117b438130368cc39dbb2d198065ae3986547926cd2" ++
+            "162f40a29f0c3c8745c0f50fba3852e566d44575c29d39a03f0cda721984b6f4" ++
+            "40591f355e12d439ff150aab7613499dbd49adabc8676eef023b15b65bfc5ca0" ++
+            "6948109f23f350db82123535eb8a7433bdabcb909271a6ecbcb58b936a88cd4e" ++
+            "8f2e6ff5800175f113253d8fa9ca8885c2f552e657dc603f252e1a8e308f76f0" ++
+            "be79e2fb8f5d5fbbe2e30ecadd220723c8c0aea8078cdfcb3868263ff8f09400" ++
+            "54da48781893a7e49ad5aff4af300cd804a6b6279ab3ff3afb64491c85194aab" ++
+            "760d58a606654f9f4400e8b38591356fbf6425aca26dc85244259ff2b19c41b9" ++
+            "f96f3ca9ec1dde434da7d2d392b905ddf3d1f9af93d1af5950bd493f5aa731b4" ++
+            "056df31bd267b6b90a079831aaf579be0a39013137aac6d404f518cfd4684064" ++
+            "7e78bfe706ca4cf5e9c5453e9f7cfd2b8b4c8d169a44e55c88d4a9a7f9474241" ++
+            "e221af44860018ab0856972e194cd934",
+    );
+    try testing.expectEqualSlices(u8, &expected_protected_payload, sealed);
 
     var opened: [1162]u8 = undefined;
     const unsealed = try secrets.client.openPayload(2, &header, sealed, &opened);
@@ -607,11 +656,14 @@ test "Initial packet protection rejects invalid inputs" {
     var protected_payload: [plaintext.len + packet_protection_tag_len]u8 = undefined;
     const sealed = try secrets.client.sealPayload(0, header, plaintext, &protected_payload);
 
+    try testing.expectError(error.InvalidPacketNumber, secrets.client.sealPayload(max_packet_number + 1, header, plaintext, &protected_payload));
+
     var too_small_open: [plaintext.len - 1]u8 = undefined;
     try testing.expectError(error.OutputTooSmall, secrets.client.openPayload(0, header, sealed, &too_small_open));
     try testing.expectError(error.ProtectedPayloadTooShort, secrets.client.openPayload(0, header, sealed[0 .. packet_protection_tag_len - 1], &too_small_open));
 
     var opened: [plaintext.len]u8 = undefined;
+    try testing.expectError(error.InvalidPacketNumber, secrets.client.openPayload(max_packet_number + 1, header, sealed, &opened));
     try testing.expectError(error.AuthenticationFailed, secrets.server.openPayload(0, header, sealed, &opened));
 
     var tampered = protected_payload;


### PR DESCRIPTION
## Summary

- add AES-128-GCM sealing/opening helpers for QUIC v1 Initial payloads
- keep packet-protection output sizing and tag splitting inside `InitialPacketProtectionKeys`
- cover the RFC 9001 client Initial sample and negative wrong-key/truncated-tag/output-buffer paths

Refs #249

## Tests

- `zig build test-quic --summary all --error-style verbose`
- `zig fmt --check build.zig src/ tests/`
- `git diff --check`
- `zig build test --summary all --error-style verbose`
- `zig build --summary all --error-style verbose`