### PR TITLE
feat(quic): complete TLS 1.3 adapter and packet protection (#249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable user-facing changes to Tardigrade are documented here.
 ## [Unreleased]
 
 ### Reliability
+- **Pure Zig QUIC TLS adapter completion — header protection, key updates,
+  0-RTT guard (#249)** — finishes `QuicTlsAdapter`. Adds RFC 9001 §5.4 header
+  protection (`applyHeaderProtection` / `removeHeaderProtection`) with
+  packet-number reconstruction wired through `packet.decodePacketNumber` and
+  RFC 9001 Appendix A.2 sample coverage; RFC 9001 §6 key updates
+  (`deriveNextGenerationSecret`, `updateApplicationKeys`) that roll the 1-RTT
+  read/write secrets and flip the key-phase bit; peer transport parameters that
+  are only exposed after the handshake authenticates them; a
+  `config.zero_rtt_enabled` guard (default off) so the adapter refuses 0-RTT
+  keys unless an operator opts in; ALPN and certificate-validation accessors;
+  and an adapter-level `sealPacketPayload` / `openPacketPayload` seam with
+  `Metrics` counters that deterministically count AEAD deprotection failures.
+  Driving a concrete TLS 1.3 backend behind the seam is tracked in #296.
+- **Pure Zig QUIC Handshake and 1-RTT packet protection (#249)** — generalizes
+  packet protection beyond Initial. `PacketProtectionKeys` / `deriveAes128GcmKeys`
+  derive AES-128-GCM protection keys for any encryption level from a TLS traffic
+  secret, and `QuicTlsAdapter.protectionKeys(level, direction)` now serves
+  Initial, Handshake, and 1-RTT (returning null for missing or wrong-length
+  secrets), with per-level derivation, direction-selection, and seal/open
+  round-trip tests in `src/quic/tls_adapter.zig`.
 - **Pure Zig QUIC Initial packet protection (#249)** — adds AES-128-GCM
   sealing/opening helpers for QUIC v1 Initial payloads using the derived
   packet-protection keys, with RFC 9001 client Initial sample coverage and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ All notable user-facing changes to Tardigrade are documented here.
   protection (`applyHeaderProtection` / `removeHeaderProtection`) with
   packet-number reconstruction wired through `packet.decodePacketNumber` and
   RFC 9001 Appendix A.2 sample coverage; RFC 9001 §6 key updates
-  (`deriveNextGenerationSecret`, `updateApplicationKeys`) that roll the 1-RTT
-  read/write secrets and flip the key-phase bit; peer transport parameters that
-  are only exposed after the handshake authenticates them; a
+  (`deriveNextGenerationSecret`) with direction-independent phase tracking —
+  `updateApplicationWriteKeys` rolls the local send secret and outgoing phase
+  while `nextApplicationReadKeys` / `commitApplicationReadKeyUpdate` advance the
+  receive secret only once a peer key update authenticates; peer transport
+  parameters that are only exposed after the handshake authenticates them; a
   `config.zero_rtt_enabled` guard (default off) so the adapter refuses 0-RTT
   keys unless an operator opts in; ALPN and certificate-validation accessors;
   and an adapter-level `sealPacketPayload` / `openPacketPayload` seam with

--- a/src/quic/config.zig
+++ b/src/quic/config.zig
@@ -71,6 +71,9 @@ pub const Config = struct {
     initial_max_streams_uni: u64 = 16,
     retry_policy: RetryPolicy = .off,
     migration_policy: MigrationPolicy = .disabled,
+    /// 0-RTT is off unless an operator explicitly opts in, given its replay
+    /// exposure (RFC 9001 §9.2). The TLS adapter refuses 0-RTT keys while false.
+    zero_rtt_enabled: bool = false,
     observability: Observability = .{},
     qpack: QpackConfig = .{},
 
@@ -129,6 +132,7 @@ test "default QUIC config maps to conservative transport parameters" {
     try std.testing.expectEqual(@as(u64, 4), params.active_connection_id_limit);
     try std.testing.expectEqual(@as(u64, 1200), params.max_udp_payload_size);
     try std.testing.expect(params.disable_active_migration);
+    try std.testing.expect(!cfg.zero_rtt_enabled);
     try std.testing.expectEqual(QpackMode.static_only, cfg.qpack.mode);
 }
 

--- a/src/quic/tls_adapter.zig
+++ b/src/quic/tls_adapter.zig
@@ -483,9 +483,10 @@ pub const CryptoOutput = struct {
 
     pub fn append(self: *CryptoOutput, bytes: []const u8) error{CryptoBufferTooLarge}!void {
         if (bytes.len == 0) return;
-        if (self.end + bytes.len > max_crypto_buffer) {
+        // Overflow-safe: never form `self.end + bytes.len` at a packet boundary.
+        if (bytes.len > max_crypto_buffer - self.end) {
             self.compact();
-            if (self.end + bytes.len > max_crypto_buffer) return error.CryptoBufferTooLarge;
+            if (bytes.len > max_crypto_buffer - self.end) return error.CryptoBufferTooLarge;
         }
         @memcpy(self.buffer[self.end .. self.end + bytes.len], bytes);
         self.end += bytes.len;
@@ -538,8 +539,11 @@ pub const QuicTlsAdapter = struct {
     certificate_state: CertificateState = .not_checked,
     /// 0-RTT is disabled unless explicitly enabled via config (RFC 9001 §4.6).
     zero_rtt_enabled: bool = false,
-    /// Current 1-RTT key phase bit (RFC 9001 §6); toggled on each key update.
-    application_key_phase: u1 = 0,
+    /// 1-RTT key phase bits (RFC 9001 §6). Write and read advance independently:
+    /// write flips when this endpoint initiates a key update, read flips when a
+    /// peer key update is observed and authenticated.
+    application_write_key_phase: u1 = 0,
+    application_read_key_phase: u1 = 0,
     metrics: Metrics = .{},
 
     pub fn setLocalTransportParameters(self: *QuicTlsAdapter, params: config.TransportParameters) void {
@@ -672,23 +676,47 @@ pub const QuicTlsAdapter = struct {
         return plaintext;
     }
 
-    /// Current 1-RTT key phase bit (RFC 9001 §6).
-    pub fn applicationKeyPhase(self: *const QuicTlsAdapter) u1 {
-        return self.application_key_phase;
+    /// Key phase bit this endpoint sets on outgoing 1-RTT packets (RFC 9001 §6).
+    pub fn applicationWriteKeyPhase(self: *const QuicTlsAdapter) u1 {
+        return self.application_write_key_phase;
     }
 
-    /// Roll the 1-RTT read and write secrets to the next generation and flip the
-    /// key phase bit (RFC 9001 §6.1). Requires both application secrets to be
-    /// installed; the derived secrets replace them in place.
-    pub fn updateApplicationKeys(self: *QuicTlsAdapter) error{ApplicationSecretsMissing}!void {
-        const read_secret = self.applicationTrafficSecret(.read) orelse return error.ApplicationSecretsMissing;
+    /// Key phase bit this endpoint currently decrypts incoming 1-RTT packets
+    /// with (RFC 9001 §6). Read and write phases advance independently.
+    pub fn applicationReadKeyPhase(self: *const QuicTlsAdapter) u1 {
+        return self.application_read_key_phase;
+    }
+
+    /// Initiate a local key update: roll the 1-RTT *write* secret to the next
+    /// generation and flip the outgoing key phase bit (RFC 9001 §6.1). Read keys
+    /// are untouched — the peer's key phase rolls only when its updated packets
+    /// are observed. Requires the application write secret to be installed.
+    pub fn updateApplicationWriteKeys(self: *QuicTlsAdapter) error{ApplicationSecretsMissing}!void {
         const write_secret = self.applicationTrafficSecret(.write) orelse return error.ApplicationSecretsMissing;
-        const next_read = deriveNextGenerationSecret(read_secret);
         const next_write = deriveNextGenerationSecret(write_secret);
         // Secrets are exactly traffic_secret_len, so Secret.init cannot overflow.
-        self.installSecret(Secret.init(.application, .read, &next_read) catch unreachable);
         self.installSecret(Secret.init(.application, .write, &next_write) catch unreachable);
-        self.application_key_phase ^= 1;
+        self.application_write_key_phase ^= 1;
+    }
+
+    /// Next-generation 1-RTT *read* keys for trial-decrypting a peer packet that
+    /// carries the opposite key phase bit (RFC 9001 §6.3), without committing to
+    /// them. Returns null when no application read secret is installed. Commit
+    /// with `commitApplicationReadKeyUpdate` only after such a packet
+    /// authenticates.
+    pub fn nextApplicationReadKeys(self: *const QuicTlsAdapter) ?PacketProtectionKeys {
+        const read_secret = self.applicationTrafficSecret(.read) orelse return null;
+        return deriveAes128GcmKeys(deriveNextGenerationSecret(read_secret));
+    }
+
+    /// Commit the next-generation 1-RTT *read* secret after a peer key update
+    /// has been authenticated, flipping the incoming key phase bit (RFC 9001
+    /// §6.3). Write keys and the outgoing phase are untouched.
+    pub fn commitApplicationReadKeyUpdate(self: *QuicTlsAdapter) error{ApplicationSecretsMissing}!void {
+        const read_secret = self.applicationTrafficSecret(.read) orelse return error.ApplicationSecretsMissing;
+        const next_read = deriveNextGenerationSecret(read_secret);
+        self.installSecret(Secret.init(.application, .read, &next_read) catch unreachable);
+        self.application_read_key_phase ^= 1;
     }
 
     fn applicationTrafficSecret(self: *const QuicTlsAdapter, direction: Direction) ?[traffic_secret_len]u8 {
@@ -1023,32 +1051,65 @@ test "key update derives chained next-generation secrets" {
     try testing.expectEqualSlices(u8, &s1, &deriveNextGenerationSecret(s0));
 }
 
-test "adapter key update rolls 1-RTT secrets and flips the phase bit" {
+test "local key update rolls only write keys and outgoing phase" {
     var adapter = QuicTlsAdapter{};
-    try testing.expectError(error.ApplicationSecretsMissing, adapter.updateApplicationKeys());
+    try testing.expectError(error.ApplicationSecretsMissing, adapter.updateApplicationWriteKeys());
 
     const read_secret = hexBytes("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
     const write_secret = hexBytes("ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100");
     adapter.installSecret(try Secret.init(.application, .read, &read_secret));
     adapter.installSecret(try Secret.init(.application, .write, &write_secret));
 
-    try testing.expectEqual(@as(u1, 0), adapter.applicationKeyPhase());
-    const before = adapter.protectionKeys(.application, .write).?;
+    try testing.expectEqual(@as(u1, 0), adapter.applicationWriteKeyPhase());
+    try testing.expectEqual(@as(u1, 0), adapter.applicationReadKeyPhase());
+    const read_before = adapter.protectionKeys(.application, .read).?;
 
-    try adapter.updateApplicationKeys();
-    try testing.expectEqual(@as(u1, 1), adapter.applicationKeyPhase());
+    try adapter.updateApplicationWriteKeys();
 
-    const after = adapter.protectionKeys(.application, .write).?;
-    try testing.expect(!std.mem.eql(u8, &before.key, &after.key));
-    const expected = deriveAes128GcmKeys(deriveNextGenerationSecret(write_secret));
-    try testing.expectEqualSlices(u8, &expected.key, &after.key);
+    // Only the write side advanced: outgoing phase flipped, read side untouched.
+    try testing.expectEqual(@as(u1, 1), adapter.applicationWriteKeyPhase());
+    try testing.expectEqual(@as(u1, 0), adapter.applicationReadKeyPhase());
+    const expected_write = deriveAes128GcmKeys(deriveNextGenerationSecret(write_secret));
+    try testing.expectEqualSlices(u8, &expected_write.key, &adapter.protectionKeys(.application, .write).?.key);
+    // Read keys still decrypt the peer's current (old) key phase.
+    try testing.expectEqualSlices(u8, &read_before.key, &adapter.protectionKeys(.application, .read).?.key);
+}
 
-    // A second update flips the phase bit back and chains the secret again.
-    try adapter.updateApplicationKeys();
-    try testing.expectEqual(@as(u1, 0), adapter.applicationKeyPhase());
-    const twice = adapter.protectionKeys(.application, .write).?;
-    const expected_twice = deriveAes128GcmKeys(deriveNextGenerationSecret(deriveNextGenerationSecret(write_secret)));
-    try testing.expectEqualSlices(u8, &expected_twice.key, &twice.key);
+test "peer key update advances only read keys and incoming phase" {
+    var adapter = QuicTlsAdapter{};
+    const read_secret = hexBytes("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+    const write_secret = hexBytes("ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100");
+    adapter.installSecret(try Secret.init(.application, .read, &read_secret));
+    adapter.installSecret(try Secret.init(.application, .write, &write_secret));
+
+    const write_before = adapter.protectionKeys(.application, .write).?;
+
+    // Trial-decrypt keys for the next peer phase are derived without committing.
+    const next_read = adapter.nextApplicationReadKeys().?;
+    const expected_next_read = deriveAes128GcmKeys(deriveNextGenerationSecret(read_secret));
+    try testing.expectEqualSlices(u8, &expected_next_read.key, &next_read.key);
+    // Not yet committed: current read keys and phases are unchanged.
+    try testing.expectEqual(@as(u1, 0), adapter.applicationReadKeyPhase());
+    try testing.expectEqualSlices(u8, &deriveAes128GcmKeys(read_secret).key, &adapter.protectionKeys(.application, .read).?.key);
+
+    // After the peer packet authenticates, commit the read key update.
+    try adapter.commitApplicationReadKeyUpdate();
+    try testing.expectEqual(@as(u1, 1), adapter.applicationReadKeyPhase());
+    try testing.expectEqual(@as(u1, 0), adapter.applicationWriteKeyPhase());
+    try testing.expectEqualSlices(u8, &expected_next_read.key, &adapter.protectionKeys(.application, .read).?.key);
+    // Write keys and outgoing phase were not disturbed.
+    try testing.expectEqualSlices(u8, &write_before.key, &adapter.protectionKeys(.application, .write).?.key);
+
+    // Read updates chain from the now-current read secret.
+    const expected_second = deriveAes128GcmKeys(deriveNextGenerationSecret(deriveNextGenerationSecret(read_secret)));
+    try testing.expectEqualSlices(u8, &expected_second.key, &adapter.nextApplicationReadKeys().?.key);
+}
+
+test "key update helpers require the corresponding application secret" {
+    var adapter = QuicTlsAdapter{};
+    try testing.expectError(error.ApplicationSecretsMissing, adapter.updateApplicationWriteKeys());
+    try testing.expectError(error.ApplicationSecretsMissing, adapter.commitApplicationReadKeyUpdate());
+    try testing.expectEqual(@as(?PacketProtectionKeys, null), adapter.nextApplicationReadKeys());
 }
 
 test "adapter guards 0-RTT keys behind explicit config" {

--- a/src/quic/tls_adapter.zig
+++ b/src/quic/tls_adapter.zig
@@ -8,9 +8,10 @@
 //! library type escapes this module. Initial-secret derivation and key updates
 //! also live here.
 //!
-//! Status: foundation slice — adapter contract and CRYPTO reassembly are in
-//! place. Backend TLS driving, packet/header protection, and key updates land
-//! in later #249 slices.
+//! Status: foundation slice — adapter contract, CRYPTO reassembly, and AEAD
+//! packet protection for every encryption level (Initial, Handshake, 1-RTT) are
+//! in place for the TLS_AES_128_GCM_SHA256 suite. Backend TLS driving, further
+//! cipher suites, and key updates land in later #249 slices.
 
 const std = @import("std");
 const config = @import("config.zig");
@@ -31,9 +32,11 @@ pub const initial_salt_v1 = [_]u8{
     0x38, 0x76, 0x2c, 0xf7, 0xf5, 0x59, 0x34, 0xb3, 0x4d, 0x17,
     0x9a, 0xe6, 0xa4, 0xc8, 0x0c, 0xad, 0xcc, 0xbb, 0x7f, 0x0a,
 };
-pub const initial_secret_len = HkdfSha256.prk_length;
-pub const initial_key_len = Aes128Gcm.key_length;
-pub const initial_iv_len = Aes128Gcm.nonce_length;
+/// Length of a TLS-exported traffic secret for the SHA-256 based suite. QUIC
+/// uses the same length for Initial, Handshake, and 1-RTT secrets.
+pub const traffic_secret_len = HkdfSha256.prk_length;
+pub const aead_key_len = Aes128Gcm.key_length;
+pub const aead_iv_len = Aes128Gcm.nonce_length;
 pub const header_protection_key_len = Aes128Gcm.key_length;
 pub const packet_protection_tag_len = Aes128Gcm.tag_length;
 pub const max_packet_number: u64 = (@as(u64, 1) << 62) - 1;
@@ -147,28 +150,31 @@ pub const SecretStore = struct {
     }
 };
 
-// TODO(#249): Handshake and Application packet protection must be derived from
-// TLS-exported traffic secrets, not from QUIC v1 Initial salt/DCID material.
-pub const InitialPacketProtectionKeys = struct {
-    secret: [initial_secret_len]u8,
-    key: [initial_key_len]u8,
-    iv: [initial_iv_len]u8,
+/// AEAD packet-protection material for one encryption level and direction under
+/// the TLS_AES_128_GCM_SHA256 suite (RFC 9001 §5.1). Initial keys are derived
+/// from the QUIC v1 salt and client DCID; Handshake and 1-RTT keys are derived
+/// from the traffic secrets TLS exports at each level. The derivation is
+/// identical for every level, so the same type serves all of them.
+pub const PacketProtectionKeys = struct {
+    secret: [traffic_secret_len]u8,
+    key: [aead_key_len]u8,
+    iv: [aead_iv_len]u8,
     hp: [header_protection_key_len]u8,
 
-    pub fn nonce(self: *const InitialPacketProtectionKeys, packet_number: u64) [initial_iv_len]u8 {
+    pub fn nonce(self: *const PacketProtectionKeys, packet_number: u64) [aead_iv_len]u8 {
         std.debug.assert(packet_number <= max_packet_number);
 
         var out = self.iv;
         var packet_number_bytes: [8]u8 = undefined;
         std.mem.writeInt(u64, &packet_number_bytes, packet_number, .big);
         for (packet_number_bytes, 0..) |byte, index| {
-            out[initial_iv_len - packet_number_bytes.len + index] ^= byte;
+            out[aead_iv_len - packet_number_bytes.len + index] ^= byte;
         }
         return out;
     }
 
     pub fn sealPayload(
-        self: *const InitialPacketProtectionKeys,
+        self: *const PacketProtectionKeys,
         packet_number: u64,
         header: []const u8,
         plaintext: []const u8,
@@ -193,7 +199,7 @@ pub const InitialPacketProtectionKeys = struct {
     }
 
     pub fn openPayload(
-        self: *const InitialPacketProtectionKeys,
+        self: *const PacketProtectionKeys,
         packet_number: u64,
         header: []const u8,
         protected_payload: []const u8,
@@ -217,7 +223,7 @@ pub const InitialPacketProtectionKeys = struct {
         return out[0..ciphertext_len];
     }
 
-    pub fn headerProtectionMask(self: *const InitialPacketProtectionKeys, sample: [16]u8) [5]u8 {
+    pub fn headerProtectionMask(self: *const PacketProtectionKeys, sample: [16]u8) [5]u8 {
         const aes = Aes128.initEnc(self.hp);
         var block: [16]u8 = undefined;
         aes.encrypt(&block, &sample);
@@ -230,9 +236,9 @@ fn validatePacketNumber(packet_number: u64) error{InvalidPacketNumber}!void {
 }
 
 pub const InitialSecrets = struct {
-    initial_secret: [initial_secret_len]u8,
-    client: InitialPacketProtectionKeys,
-    server: InitialPacketProtectionKeys,
+    initial_secret: [traffic_secret_len]u8,
+    client: PacketProtectionKeys,
+    server: PacketProtectionKeys,
 };
 
 pub fn deriveInitialSecretsV1(client_initial_dcid: []const u8) error{InvalidConnectionId}!InitialSecrets {
@@ -241,20 +247,25 @@ pub fn deriveInitialSecretsV1(client_initial_dcid: []const u8) error{InvalidConn
     }
 
     const initial_secret = HkdfSha256.extract(&initial_salt_v1, client_initial_dcid);
-    const client_secret = tls.hkdfExpandLabel(HkdfSha256, initial_secret, "client in", "", initial_secret_len);
-    const server_secret = tls.hkdfExpandLabel(HkdfSha256, initial_secret, "server in", "", initial_secret_len);
+    const client_secret = tls.hkdfExpandLabel(HkdfSha256, initial_secret, "client in", "", traffic_secret_len);
+    const server_secret = tls.hkdfExpandLabel(HkdfSha256, initial_secret, "server in", "", traffic_secret_len);
     return .{
         .initial_secret = initial_secret,
-        .client = deriveInitialAes128GcmKeys(client_secret),
-        .server = deriveInitialAes128GcmKeys(server_secret),
+        .client = deriveAes128GcmKeys(client_secret),
+        .server = deriveAes128GcmKeys(server_secret),
     };
 }
 
-pub fn deriveInitialAes128GcmKeys(secret: [initial_secret_len]u8) InitialPacketProtectionKeys {
+/// Derive AEAD packet-protection keys for the TLS_AES_128_GCM_SHA256 suite from
+/// a traffic `secret`, per RFC 9001 §5.1. The `secret` is the Initial secret for
+/// Initial packets, or the TLS-exported Handshake / 1-RTT traffic secret for the
+/// respective levels; the "quic key" / "quic iv" / "quic hp" derivation is the
+/// same regardless of level.
+pub fn deriveAes128GcmKeys(secret: [traffic_secret_len]u8) PacketProtectionKeys {
     return .{
         .secret = secret,
-        .key = tls.hkdfExpandLabel(HkdfSha256, secret, "quic key", "", initial_key_len),
-        .iv = tls.hkdfExpandLabel(HkdfSha256, secret, "quic iv", "", initial_iv_len),
+        .key = tls.hkdfExpandLabel(HkdfSha256, secret, "quic key", "", aead_key_len),
+        .iv = tls.hkdfExpandLabel(HkdfSha256, secret, "quic iv", "", aead_iv_len),
         .hp = tls.hkdfExpandLabel(HkdfSha256, secret, "quic hp", "", header_protection_key_len),
     };
 }
@@ -501,10 +512,16 @@ pub const QuicTlsAdapter = struct {
         return secrets;
     }
 
-    pub fn initialProtectionKeys(self: *const QuicTlsAdapter, direction: Direction) ?InitialPacketProtectionKeys {
-        const installed_secret = self.secret(.initial, direction) orelse return null;
-        if (installed_secret.len != initial_secret_len) return null;
-        return deriveInitialAes128GcmKeys(installed_secret.bytes[0..initial_secret_len].*);
+    /// Derive AEAD packet-protection keys for `level` in `direction` from the
+    /// installed traffic secret. Works for Initial, Handshake, and 1-RTT
+    /// (`.application`) once the corresponding secret has been installed —
+    /// Initial via `installInitialSecrets`, later levels via `installSecret`
+    /// with the TLS-exported traffic secret. Returns null when no secret is
+    /// installed or its length does not match the SHA-256 suite.
+    pub fn protectionKeys(self: *const QuicTlsAdapter, level: EncryptionLevel, direction: Direction) ?PacketProtectionKeys {
+        const installed_secret = self.secret(level, direction) orelse return null;
+        if (installed_secret.len != traffic_secret_len) return null;
+        return deriveAes128GcmKeys(installed_secret.bytes[0..traffic_secret_len].*);
     }
 
     pub fn discardSecrets(self: *QuicTlsAdapter, level: EncryptionLevel) void {
@@ -691,15 +708,77 @@ test "adapter installs Initial secrets by endpoint perspective" {
     const client_secrets = try client.installInitialSecrets(.client, &dcid);
     try testing.expectEqualSlices(u8, &client_secrets.client.secret, client.secret(.initial, .write).?.slice());
     try testing.expectEqualSlices(u8, &client_secrets.server.secret, client.secret(.initial, .read).?.slice());
-    const client_write_keys = client.initialProtectionKeys(.write).?;
+    const client_write_keys = client.protectionKeys(.initial, .write).?;
     try testing.expectEqualSlices(u8, &client_secrets.client.key, &client_write_keys.key);
 
     var server = QuicTlsAdapter{};
     const server_secrets = try server.installInitialSecrets(.server, &dcid);
     try testing.expectEqualSlices(u8, &server_secrets.client.secret, server.secret(.initial, .read).?.slice());
     try testing.expectEqualSlices(u8, &server_secrets.server.secret, server.secret(.initial, .write).?.slice());
-    const server_write_keys = server.initialProtectionKeys(.write).?;
+    const server_write_keys = server.protectionKeys(.initial, .write).?;
     try testing.expectEqualSlices(u8, &server_secrets.server.hp, &server_write_keys.hp);
+}
+
+test "adapter derives Handshake and 1-RTT protection keys from installed traffic secrets" {
+    var adapter = QuicTlsAdapter{};
+
+    // No secret installed yet: every non-Initial level reports no keys.
+    try testing.expectEqual(@as(?PacketProtectionKeys, null), adapter.protectionKeys(.handshake, .write));
+    try testing.expectEqual(@as(?PacketProtectionKeys, null), adapter.protectionKeys(.application, .read));
+
+    var hs_secret: [traffic_secret_len]u8 = undefined;
+    for (&hs_secret, 0..) |*byte, i| byte.* = @intCast((i * 7 + 3) & 0xff);
+    var app_secret: [traffic_secret_len]u8 = undefined;
+    for (&app_secret, 0..) |*byte, i| byte.* = @intCast((i * 5 + 1) & 0xff);
+
+    adapter.installSecret(try Secret.init(.handshake, .write, &hs_secret));
+    adapter.installSecret(try Secret.init(.application, .read, &app_secret));
+
+    // The adapter path matches the standalone derivation for the same suite.
+    const hs_keys = adapter.protectionKeys(.handshake, .write).?;
+    const expected_hs = deriveAes128GcmKeys(hs_secret);
+    try testing.expectEqualSlices(u8, &expected_hs.key, &hs_keys.key);
+    try testing.expectEqualSlices(u8, &expected_hs.iv, &hs_keys.iv);
+    try testing.expectEqualSlices(u8, &expected_hs.hp, &hs_keys.hp);
+
+    const app_keys = adapter.protectionKeys(.application, .read).?;
+    try testing.expectEqualSlices(u8, &deriveAes128GcmKeys(app_secret).key, &app_keys.key);
+
+    // Direction is honored: the untouched direction stays empty.
+    try testing.expectEqual(@as(?PacketProtectionKeys, null), adapter.protectionKeys(.handshake, .read));
+    try testing.expectEqual(@as(?PacketProtectionKeys, null), adapter.protectionKeys(.application, .write));
+}
+
+test "packet protection round-trips at Handshake and 1-RTT levels" {
+    var adapter = QuicTlsAdapter{};
+    const secret = hexBytes("0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20");
+    adapter.installSecret(try Secret.init(.handshake, .write, &secret));
+    adapter.installSecret(try Secret.init(.application, .write, &secret));
+
+    const header = "\xe0\x00\x00\x00\x01";
+    const plaintext = "handshake and 1-rtt payloads use the same AEAD path";
+
+    for ([_]EncryptionLevel{ .handshake, .application }) |level| {
+        const keys = adapter.protectionKeys(level, .write).?;
+
+        var sealed: [128]u8 = undefined;
+        const protected = try keys.sealPayload(7, header, plaintext, &sealed);
+        try testing.expectEqual(plaintext.len + packet_protection_tag_len, protected.len);
+
+        var opened: [128]u8 = undefined;
+        const recovered = try keys.openPayload(7, header, protected, &opened);
+        try testing.expectEqualSlices(u8, plaintext, recovered);
+
+        // A different packet number changes the nonce and fails authentication.
+        try testing.expectError(error.AuthenticationFailed, keys.openPayload(8, header, protected, &opened));
+    }
+}
+
+test "protection keys reject a traffic secret of the wrong length" {
+    var adapter = QuicTlsAdapter{};
+    const short_secret = [_]u8{0xab} ** (traffic_secret_len - 1);
+    adapter.installSecret(try Secret.init(.application, .write, &short_secret));
+    try testing.expectEqual(@as(?PacketProtectionKeys, null), adapter.protectionKeys(.application, .write));
 }
 
 test "CRYPTO reassembly emits only contiguous bytes by encryption level" {

--- a/src/quic/tls_adapter.zig
+++ b/src/quic/tls_adapter.zig
@@ -8,13 +8,16 @@
 //! library type escapes this module. Initial-secret derivation and key updates
 //! also live here.
 //!
-//! Status: foundation slice — adapter contract, CRYPTO reassembly, and AEAD
-//! packet protection for every encryption level (Initial, Handshake, 1-RTT) are
-//! in place for the TLS_AES_128_GCM_SHA256 suite. Backend TLS driving, further
-//! cipher suites, and key updates land in later #249 slices.
+//! Status: the adapter contract, CRYPTO reassembly, AEAD packet protection and
+//! header protection for every encryption level (Initial, Handshake, 1-RTT),
+//! packet-number reconstruction wiring, key updates, authenticated transport
+//! parameters, ALPN/certificate reporting, and deprotection metrics are all in
+//! place for the TLS_AES_128_GCM_SHA256 suite. Driving a concrete TLS 1.3
+//! backend and adding further cipher suites remain follow-up work.
 
 const std = @import("std");
 const config = @import("config.zig");
+const packet = @import("packet.zig");
 
 const crypto = std.crypto;
 const tls = std.crypto.tls;
@@ -39,6 +42,10 @@ pub const aead_key_len = Aes128Gcm.key_length;
 pub const aead_iv_len = Aes128Gcm.nonce_length;
 pub const header_protection_key_len = Aes128Gcm.key_length;
 pub const packet_protection_tag_len = Aes128Gcm.tag_length;
+/// Ciphertext sample size for header protection (RFC 9001 §5.4.1: one AES block).
+pub const header_protection_sample_len = 16;
+/// Largest QUIC packet-number encoding (RFC 9000 §17.1: 1..4 bytes).
+pub const max_packet_number_length = 4;
 pub const max_packet_number: u64 = (@as(u64, 1) << 62) - 1;
 
 pub const EncryptionLevel = enum(u2) {
@@ -223,13 +230,68 @@ pub const PacketProtectionKeys = struct {
         return out[0..ciphertext_len];
     }
 
-    pub fn headerProtectionMask(self: *const PacketProtectionKeys, sample: [16]u8) [5]u8 {
+    pub fn headerProtectionMask(self: *const PacketProtectionKeys, sample: [header_protection_sample_len]u8) [5]u8 {
         const aes = Aes128.initEnc(self.hp);
-        var block: [16]u8 = undefined;
+        var block: [header_protection_sample_len]u8 = undefined;
         aes.encrypt(&block, &sample);
         return block[0..5].*;
     }
+
+    /// Apply QUIC header protection in place (RFC 9001 §5.4.1). `first_byte` is
+    /// the packet's first byte and `packet_number_field` the 1..4 encoded
+    /// packet-number bytes already written into the header; both are masked with
+    /// the value derived from `sample`. The long/short header form is read from
+    /// the (unprotected) high bit of `first_byte`.
+    pub fn applyHeaderProtection(
+        self: *const PacketProtectionKeys,
+        first_byte: *u8,
+        packet_number_field: []u8,
+        sample: [header_protection_sample_len]u8,
+    ) void {
+        std.debug.assert(packet_number_field.len >= 1 and packet_number_field.len <= max_packet_number_length);
+        const mask = self.headerProtectionMask(sample);
+        first_byte.* ^= mask[0] & firstByteMask(first_byte.*);
+        for (packet_number_field, 0..) |*byte, index| byte.* ^= mask[1 + index];
+    }
+
+    /// Result of removing header protection: the recovered packet-number length
+    /// (1..4) and the truncated packet number as sent on the wire. Feed
+    /// `truncated_packet_number` to `packet.decodePacketNumber` with the largest
+    /// processed packet number to reconstruct the full value.
+    pub const RemovedHeaderProtection = struct {
+        packet_number_length: usize,
+        truncated_packet_number: u64,
+    };
+
+    /// Remove QUIC header protection in place (RFC 9001 §5.4.1). `sampled_pn`
+    /// must hold the four bytes at the packet-number offset (the maximum-length
+    /// field, always present because the header-protection sample follows it);
+    /// only the recovered packet-number length is unmasked. The packet-number
+    /// length is not known until the first byte is unmasked, so it is returned.
+    pub fn removeHeaderProtection(
+        self: *const PacketProtectionKeys,
+        first_byte: *u8,
+        sampled_pn: *[max_packet_number_length]u8,
+        sample: [header_protection_sample_len]u8,
+    ) RemovedHeaderProtection {
+        const mask = self.headerProtectionMask(sample);
+        first_byte.* ^= mask[0] & firstByteMask(first_byte.*);
+        const packet_number_length: usize = @as(usize, first_byte.* & 0x03) + 1;
+        var truncated: u64 = 0;
+        var index: usize = 0;
+        while (index < packet_number_length) : (index += 1) {
+            sampled_pn[index] ^= mask[1 + index];
+            truncated = (truncated << 8) | sampled_pn[index];
+        }
+        return .{ .packet_number_length = packet_number_length, .truncated_packet_number = truncated };
+    }
 };
+
+/// Header-protection first-byte mask: 4 low bits for long headers (high bit
+/// set), 5 low bits for short headers (RFC 9001 §5.4.1).
+fn firstByteMask(first_byte: u8) u8 {
+    return if (first_byte & 0x80 != 0) 0x0f else 0x1f;
+}
 
 fn validatePacketNumber(packet_number: u64) error{InvalidPacketNumber}!void {
     if (packet_number > max_packet_number) return error.InvalidPacketNumber;
@@ -268,6 +330,13 @@ pub fn deriveAes128GcmKeys(secret: [traffic_secret_len]u8) PacketProtectionKeys 
         .iv = tls.hkdfExpandLabel(HkdfSha256, secret, "quic iv", "", aead_iv_len),
         .hp = tls.hkdfExpandLabel(HkdfSha256, secret, "quic hp", "", header_protection_key_len),
     };
+}
+
+/// Derive the next-generation application traffic secret for a key update
+/// (RFC 9001 §6.1): `secret_<n+1> = HKDF-Expand-Label(secret_<n>, "quic ku")`.
+/// Applies to the 1-RTT read and write secrets only.
+pub fn deriveNextGenerationSecret(secret: [traffic_secret_len]u8) [traffic_secret_len]u8 {
+    return tls.hkdfExpandLabel(HkdfSha256, secret, "quic ku", "", traffic_secret_len);
 }
 
 pub const ByteRange = struct {
@@ -450,21 +519,59 @@ pub const CryptoOutput = struct {
     }
 };
 
+/// Packet-protection counters exposed for observability (#255) and to satisfy
+/// the requirement that deprotection failures are reported deterministically.
+pub const Metrics = struct {
+    packets_protected: u64 = 0,
+    packets_deprotected: u64 = 0,
+    deprotection_failures: u64 = 0,
+};
+
 pub const QuicTlsAdapter = struct {
     local_transport_parameters: ?config.TransportParameters = null,
+    peer_transport_parameters: ?config.TransportParameters = null,
     peer_transport_parameters_authenticated: bool = false,
     reassembler: CryptoReassembler = .{},
     outbound: [4]CryptoOutput = .{ .{}, .{}, .{}, .{} },
     secrets: SecretStore = .{},
     alpn_h3: bool = false,
     certificate_state: CertificateState = .not_checked,
+    /// 0-RTT is disabled unless explicitly enabled via config (RFC 9001 §4.6).
+    zero_rtt_enabled: bool = false,
+    /// Current 1-RTT key phase bit (RFC 9001 §6); toggled on each key update.
+    application_key_phase: u1 = 0,
+    metrics: Metrics = .{},
 
     pub fn setLocalTransportParameters(self: *QuicTlsAdapter, params: config.TransportParameters) void {
         self.local_transport_parameters = params;
     }
 
+    /// Record the peer's transport parameters as received in the handshake.
+    /// They are not trusted until `authenticatePeerTransportParameters` marks
+    /// the handshake authenticated, so `peerTransportParameters` returns null
+    /// until then.
+    pub fn setPeerTransportParameters(self: *QuicTlsAdapter, params: config.TransportParameters) void {
+        self.peer_transport_parameters = params;
+        self.peer_transport_parameters_authenticated = false;
+    }
+
     pub fn authenticatePeerTransportParameters(self: *QuicTlsAdapter) void {
         self.peer_transport_parameters_authenticated = true;
+    }
+
+    /// The peer's transport parameters, but only once they have been
+    /// authenticated through the handshake. Returns null while unauthenticated,
+    /// so callers cannot act on unverified parameters.
+    pub fn peerTransportParameters(self: *const QuicTlsAdapter) ?config.TransportParameters {
+        if (!self.peer_transport_parameters_authenticated) return null;
+        return self.peer_transport_parameters;
+    }
+
+    /// Enable or disable 0-RTT. Off by default; callers wire this from
+    /// `config` after making the replay-safety product decision (out of scope
+    /// for #249).
+    pub fn setZeroRttEnabled(self: *QuicTlsAdapter, enabled: bool) void {
+        self.zero_rtt_enabled = enabled;
     }
 
     pub fn receiveCrypto(self: *QuicTlsAdapter, level: EncryptionLevel, offset: u64, data: []const u8) error{ CryptoBufferTooLarge, TooManyCryptoRanges, InvalidCryptoLevel }!void {
@@ -516,12 +623,78 @@ pub const QuicTlsAdapter = struct {
     /// installed traffic secret. Works for Initial, Handshake, and 1-RTT
     /// (`.application`) once the corresponding secret has been installed —
     /// Initial via `installInitialSecrets`, later levels via `installSecret`
-    /// with the TLS-exported traffic secret. Returns null when no secret is
-    /// installed or its length does not match the SHA-256 suite.
+    /// with the TLS-exported traffic secret. Returns null when 0-RTT is
+    /// requested but disabled, when no secret is installed, or when its length
+    /// does not match the SHA-256 suite.
     pub fn protectionKeys(self: *const QuicTlsAdapter, level: EncryptionLevel, direction: Direction) ?PacketProtectionKeys {
+        if (level == .zero_rtt and !self.zero_rtt_enabled) return null;
         const installed_secret = self.secret(level, direction) orelse return null;
         if (installed_secret.len != traffic_secret_len) return null;
         return deriveAes128GcmKeys(installed_secret.bytes[0..traffic_secret_len].*);
+    }
+
+    /// Seal `plaintext` for `level`/`direction` into `out`, tracking a protected
+    /// packet count. Returns error.KeysUnavailable when no usable secret is
+    /// installed for the level.
+    pub fn sealPacketPayload(
+        self: *QuicTlsAdapter,
+        level: EncryptionLevel,
+        direction: Direction,
+        packet_number: u64,
+        header: []const u8,
+        plaintext: []const u8,
+        out: []u8,
+    ) error{ KeysUnavailable, InvalidPacketNumber, OutputTooSmall }![]u8 {
+        const keys = self.protectionKeys(level, direction) orelse return error.KeysUnavailable;
+        const sealed = try keys.sealPayload(packet_number, header, plaintext, out);
+        self.metrics.packets_protected += 1;
+        return sealed;
+    }
+
+    /// Remove packet protection for `level`/`direction`, incrementing the
+    /// deprotection counters. Authentication failures are counted separately so
+    /// the connection layer can act on repeated forgery deterministically.
+    pub fn openPacketPayload(
+        self: *QuicTlsAdapter,
+        level: EncryptionLevel,
+        direction: Direction,
+        packet_number: u64,
+        header: []const u8,
+        protected_payload: []const u8,
+        out: []u8,
+    ) error{ KeysUnavailable, InvalidPacketNumber, ProtectedPayloadTooShort, OutputTooSmall, AuthenticationFailed }![]u8 {
+        const keys = self.protectionKeys(level, direction) orelse return error.KeysUnavailable;
+        const plaintext = keys.openPayload(packet_number, header, protected_payload, out) catch |err| {
+            if (err == error.AuthenticationFailed) self.metrics.deprotection_failures += 1;
+            return err;
+        };
+        self.metrics.packets_deprotected += 1;
+        return plaintext;
+    }
+
+    /// Current 1-RTT key phase bit (RFC 9001 §6).
+    pub fn applicationKeyPhase(self: *const QuicTlsAdapter) u1 {
+        return self.application_key_phase;
+    }
+
+    /// Roll the 1-RTT read and write secrets to the next generation and flip the
+    /// key phase bit (RFC 9001 §6.1). Requires both application secrets to be
+    /// installed; the derived secrets replace them in place.
+    pub fn updateApplicationKeys(self: *QuicTlsAdapter) error{ApplicationSecretsMissing}!void {
+        const read_secret = self.applicationTrafficSecret(.read) orelse return error.ApplicationSecretsMissing;
+        const write_secret = self.applicationTrafficSecret(.write) orelse return error.ApplicationSecretsMissing;
+        const next_read = deriveNextGenerationSecret(read_secret);
+        const next_write = deriveNextGenerationSecret(write_secret);
+        // Secrets are exactly traffic_secret_len, so Secret.init cannot overflow.
+        self.installSecret(Secret.init(.application, .read, &next_read) catch unreachable);
+        self.installSecret(Secret.init(.application, .write, &next_write) catch unreachable);
+        self.application_key_phase ^= 1;
+    }
+
+    fn applicationTrafficSecret(self: *const QuicTlsAdapter, direction: Direction) ?[traffic_secret_len]u8 {
+        const installed_secret = self.secret(.application, direction) orelse return null;
+        if (installed_secret.len != traffic_secret_len) return null;
+        return installed_secret.bytes[0..traffic_secret_len].*;
     }
 
     pub fn discardSecrets(self: *QuicTlsAdapter, level: EncryptionLevel) void {
@@ -530,6 +703,20 @@ pub const QuicTlsAdapter = struct {
 
     pub fn markAlpn(self: *QuicTlsAdapter, protocol: []const u8) void {
         self.alpn_h3 = std.mem.eql(u8, protocol, "h3");
+    }
+
+    /// Whether ALPN negotiated `h3` for the future HTTP/3 layer.
+    pub fn negotiatedH3(self: *const QuicTlsAdapter) bool {
+        return self.alpn_h3;
+    }
+
+    /// Report the peer certificate validation outcome from the TLS backend.
+    pub fn setCertificateState(self: *QuicTlsAdapter, state: CertificateState) void {
+        self.certificate_state = state;
+    }
+
+    pub fn certificateState(self: *const QuicTlsAdapter) CertificateState {
+        return self.certificate_state;
     }
 };
 
@@ -779,6 +966,159 @@ test "protection keys reject a traffic secret of the wrong length" {
     const short_secret = [_]u8{0xab} ** (traffic_secret_len - 1);
     adapter.installSecret(try Secret.init(.application, .write, &short_secret));
     try testing.expectEqual(@as(?PacketProtectionKeys, null), adapter.protectionKeys(.application, .write));
+}
+
+test "header protection matches the RFC 9001 client Initial sample" {
+    var dcid: [8]u8 = undefined;
+    _ = try std.fmt.hexToBytes(&dcid, "8394c8f03e515708");
+    const secrets = try deriveInitialSecretsV1(&dcid);
+    const sample = hexBytes("d1b1c98dd7689fb8ec11d242b123dc9b");
+
+    // Apply: unprotected long header 0xc3 + 4-byte packet number 2 protect to
+    // the wire bytes shown in RFC 9001 Appendix A.2.
+    var first_byte: u8 = 0xc3;
+    var pn_field = [_]u8{ 0x00, 0x00, 0x00, 0x02 };
+    secrets.client.applyHeaderProtection(&first_byte, &pn_field, sample);
+    try testing.expectEqual(@as(u8, 0xc0), first_byte);
+    try expectHex("7b9aec34", &pn_field);
+
+    // Remove: reverse the transformation and recover the packet-number length
+    // from the unmasked first byte.
+    var protected_first: u8 = 0xc0;
+    var sampled_pn = [_]u8{ 0x7b, 0x9a, 0xec, 0x34 };
+    const removed = secrets.client.removeHeaderProtection(&protected_first, &sampled_pn, sample);
+    try testing.expectEqual(@as(u8, 0xc3), protected_first);
+    try testing.expectEqual(@as(usize, 4), removed.packet_number_length);
+    try testing.expectEqual(@as(u64, 2), removed.truncated_packet_number);
+
+    // Packet-number reconstruction is wired through the packet layer.
+    const pn_bits: u6 = @intCast(removed.packet_number_length * 8);
+    try testing.expectEqual(@as(u64, 2), packet.decodePacketNumber(1, removed.truncated_packet_number, pn_bits));
+}
+
+test "header protection round-trips for short headers" {
+    const secret = hexBytes("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f");
+    const keys = deriveAes128GcmKeys(secret);
+    const sample = hexBytes("101112131415161718191a1b1c1d1e1f");
+
+    // Short header (high bit clear), 1-byte packet number, key phase bit set.
+    var first_byte: u8 = 0x50;
+    var pn_field = [_]u8{0x9c};
+    keys.applyHeaderProtection(&first_byte, &pn_field, sample);
+
+    var sampled_pn = [_]u8{ pn_field[0], 0x00, 0x00, 0x00 };
+    const removed = keys.removeHeaderProtection(&first_byte, &sampled_pn, sample);
+    try testing.expectEqual(@as(u8, 0x50), first_byte);
+    try testing.expectEqual(@as(usize, 1), removed.packet_number_length);
+    try testing.expectEqual(@as(u64, 0x9c), removed.truncated_packet_number);
+}
+
+test "key update derives chained next-generation secrets" {
+    const s0 = hexBytes("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f");
+    const s1 = deriveNextGenerationSecret(s0);
+    const s2 = deriveNextGenerationSecret(s1);
+    try testing.expect(!std.mem.eql(u8, &s0, &s1));
+    try testing.expect(!std.mem.eql(u8, &s1, &s2));
+    // Deterministic for a given input secret.
+    try testing.expectEqualSlices(u8, &s1, &deriveNextGenerationSecret(s0));
+}
+
+test "adapter key update rolls 1-RTT secrets and flips the phase bit" {
+    var adapter = QuicTlsAdapter{};
+    try testing.expectError(error.ApplicationSecretsMissing, adapter.updateApplicationKeys());
+
+    const read_secret = hexBytes("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+    const write_secret = hexBytes("ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100");
+    adapter.installSecret(try Secret.init(.application, .read, &read_secret));
+    adapter.installSecret(try Secret.init(.application, .write, &write_secret));
+
+    try testing.expectEqual(@as(u1, 0), adapter.applicationKeyPhase());
+    const before = adapter.protectionKeys(.application, .write).?;
+
+    try adapter.updateApplicationKeys();
+    try testing.expectEqual(@as(u1, 1), adapter.applicationKeyPhase());
+
+    const after = adapter.protectionKeys(.application, .write).?;
+    try testing.expect(!std.mem.eql(u8, &before.key, &after.key));
+    const expected = deriveAes128GcmKeys(deriveNextGenerationSecret(write_secret));
+    try testing.expectEqualSlices(u8, &expected.key, &after.key);
+
+    // A second update flips the phase bit back and chains the secret again.
+    try adapter.updateApplicationKeys();
+    try testing.expectEqual(@as(u1, 0), adapter.applicationKeyPhase());
+    const twice = adapter.protectionKeys(.application, .write).?;
+    const expected_twice = deriveAes128GcmKeys(deriveNextGenerationSecret(deriveNextGenerationSecret(write_secret)));
+    try testing.expectEqualSlices(u8, &expected_twice.key, &twice.key);
+}
+
+test "adapter guards 0-RTT keys behind explicit config" {
+    var adapter = QuicTlsAdapter{};
+    const secret = hexBytes("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f");
+    adapter.installSecret(try Secret.init(.zero_rtt, .write, &secret));
+
+    // Disabled by default: no 0-RTT keys even though a secret is installed.
+    try testing.expectEqual(@as(?PacketProtectionKeys, null), adapter.protectionKeys(.zero_rtt, .write));
+
+    adapter.setZeroRttEnabled(true);
+    try testing.expect(adapter.protectionKeys(.zero_rtt, .write) != null);
+}
+
+test "peer transport parameters require handshake authentication" {
+    var adapter = QuicTlsAdapter{};
+    try testing.expectEqual(@as(?config.TransportParameters, null), adapter.peerTransportParameters());
+
+    const params = try (config.Config{}).transportParameters();
+    adapter.setPeerTransportParameters(params);
+    // Still withheld until the handshake authenticates them.
+    try testing.expectEqual(@as(?config.TransportParameters, null), adapter.peerTransportParameters());
+
+    adapter.authenticatePeerTransportParameters();
+    const authenticated = adapter.peerTransportParameters() orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(params.max_idle_timeout_ms, authenticated.max_idle_timeout_ms);
+}
+
+test "adapter reports ALPN and certificate validation state" {
+    var adapter = QuicTlsAdapter{};
+    try testing.expect(!adapter.negotiatedH3());
+    adapter.markAlpn("h3");
+    try testing.expect(adapter.negotiatedH3());
+    adapter.markAlpn("h2");
+    try testing.expect(!adapter.negotiatedH3());
+
+    try testing.expectEqual(CertificateState.not_checked, adapter.certificateState());
+    adapter.setCertificateState(.valid);
+    try testing.expectEqual(CertificateState.valid, adapter.certificateState());
+}
+
+test "adapter packet protection tracks metrics and counts deprotection failures" {
+    var adapter = QuicTlsAdapter{};
+    var out: [64]u8 = undefined;
+
+    // No keys installed yet: deprotection is unavailable, not a failure.
+    try testing.expectError(error.KeysUnavailable, adapter.openPacketPayload(.application, .read, 0, "hdr", "0123456789abcdef", &out));
+    try testing.expectEqual(@as(u64, 0), adapter.metrics.deprotection_failures);
+
+    const secret = hexBytes("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f");
+    adapter.installSecret(try Secret.init(.application, .write, &secret));
+    adapter.installSecret(try Secret.init(.application, .read, &secret));
+
+    const header = "\x50\x00\x00\x00\x03";
+    const plaintext = "one-rtt payload through the adapter seam";
+    var sealed: [128]u8 = undefined;
+    const protected = try adapter.sealPacketPayload(.application, .write, 3, header, plaintext, &sealed);
+    try testing.expectEqual(@as(u64, 1), adapter.metrics.packets_protected);
+
+    var opened: [128]u8 = undefined;
+    const recovered = try adapter.openPacketPayload(.application, .read, 3, header, protected, &opened);
+    try testing.expectEqualSlices(u8, plaintext, recovered);
+    try testing.expectEqual(@as(u64, 1), adapter.metrics.packets_deprotected);
+
+    // A forged packet is rejected and counted deterministically.
+    var tampered: [128]u8 = undefined;
+    @memcpy(tampered[0..protected.len], protected);
+    tampered[0] ^= 0xff;
+    try testing.expectError(error.AuthenticationFailed, adapter.openPacketPayload(.application, .read, 3, header, tampered[0..protected.len], &opened));
+    try testing.expectEqual(@as(u64, 1), adapter.metrics.deprotection_failures);
 }
 
 test "CRYPTO reassembly emits only contiguous bytes by encryption level" {


### PR DESCRIPTION
## Summary
Implements the adapter and cryptographic packet-protection scope of **#249 — QUIC TLS 1.3 adapter, CRYPTO frames, packet protection, and key updates**. Builds on the existing CRYPTO reassembly and Initial-packet protection foundation.

> **Scope note:** this PR delivers the `QuicTlsAdapter` seam and its crypto. It does **not** drive a real TLS 1.3 handshake — the acceptance items that require a live handshake (parsing/authenticating peer transport parameters and actually negotiating ALPN) are provided here only as the adapter-side gate and are completed by #296. Hence **Part of #249**, not Closes.

**Packet protection for all levels**
- Generalizes QUIC packet protection beyond Initial. The `TLS_AES_128_GCM_SHA256` key schedule (`quic key`/`quic iv`/`quic hp`) is identical at every level, so `PacketProtectionKeys` (renamed from `InitialPacketProtectionKeys`) and `deriveAes128GcmKeys` now serve Initial, Handshake, and 1-RTT.
- `QuicTlsAdapter.protectionKeys(level, direction)` derives keys from the installed secret; Handshake/1-RTT secrets arrive via `installSecret`.

**Header protection & packet-number reconstruction (RFC 9001 §5.4)**
- `applyHeaderProtection` / `removeHeaderProtection` mask the first byte and packet-number field (long/short form read from the unprotected high bit). Removal returns the recovered packet-number length and truncated value, which feed the existing `packet.decodePacketNumber` for reconstruction. Verified against the RFC 9001 Appendix A.2 client Initial sample.

**Key updates (RFC 9001 §6) — direction-aware**
- `deriveNextGenerationSecret` (`quic ku`) with independent write/read phase tracking: `updateApplicationWriteKeys` rolls only the local send secret and outgoing key phase; `nextApplicationReadKeys` + `commitApplicationReadKeyUpdate` advance the receive secret and incoming phase only once a peer key update authenticates. One side can update keys while the other has not.

**Adapter boundary hardening**
- Peer transport parameters are stored on receipt but only returned once `authenticatePeerTransportParameters` marks the handshake authenticated (adapter-side gate; handshake-backed parsing/authentication lands in #296).
- 0-RTT guarded behind an explicit `config.zero_rtt_enabled` knob (default off); `protectionKeys` refuses 0-RTT keys while disabled.
- ALPN (`negotiatedH3`) and certificate-validation state accessors.
- Adapter-level `sealPacketPayload` / `openPacketPayload` seam with a `Metrics` struct; AEAD authentication failures are counted deterministically.
- `CryptoOutput.append` uses an overflow-safe capacity check, matching `CryptoStream.insert`.

No foreign/C TLS types cross the adapter seam.

## Test plan
- [x] `zig build test-quic` — all QUIC/HTTP-3 unit tests pass, including the new ones.
- [x] `zig build test` — full workspace suite passes.
- [x] `zig build` — full project compiles.
- [x] RFC 9001 vectors: Initial secrets/keys, Initial payload seal, and Appendix A.2 header-protection sample.
- [x] New coverage: per-level derivation & direction selection; Handshake/1-RTT seal↔open round-trips; short-header round-trip; direction-aware key-update invariants (local update touches only write keys/phase; peer update advances only read keys/phase after commit); 0-RTT guard on/off; transport-parameter authentication gating; ALPN/certificate reporting; deprotection metrics incl. forged-packet failure count.

## #249 acceptance criteria
- [x] QUIC/TLS boundary documented, no foreign/C types above the seam
- [x] CRYPTO frame reassembly handles out-of-order fragments
- [ ] Transport parameters authenticated **through the handshake path** — adapter-side authenticated-access gate only; handshake-backed parsing/authentication tracked in #296
- [x] Protected-packet test vectors pass where practical
- [x] Deprotection failures rejected deterministically with metrics
- [x] Key-update state transitions covered by tests (direction-aware)
- [ ] ALPN `h3` can be **negotiated** — adapter records/report only; live negotiation via the TLS handshake tracked in #296

Part of #249. Remaining handshake-dependent criteria are delivered by #296 (drive a concrete TLS 1.3 handshake behind `QuicTlsAdapter`); #249 can close once #296 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)