### PR TITLE
feat(quic): Retry, address validation, anti-amplification, stateless reset (#250)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable user-facing changes to Tardigrade are documented here.
 ## [Unreleased]
 
 ### Reliability
+- **Pure Zig QUIC Retry, address validation, and anti-amplification (#250)** —
+  adds the server safety mechanisms for unauthenticated UDP in `src/quic/path.zig`
+  and `src/quic/cid.zig`: an `AntiAmplification` ledger enforcing the RFC 9000
+  §8.1 3x send budget (saturating, so certificate/handshake bytes and
+  retransmissions cannot overflow it); `RetryTokens`, AEAD-sealed
+  address-validation tokens with timestamp/expiry, peer-address binding, a
+  rotating key ring, and tamper/unknown-key rejection; the RFC 9001 §5.8 Retry
+  integrity tag (`retryIntegrityTag` / `verifyRetryIntegrity`), verified against
+  the Appendix A.4 vector; stateless-reset token derivation and reset-packet
+  construction (`statelessResetToken`, `StatelessReset`) with loop-safe sizing
+  and eligibility; and a `Metrics` struct counting Retry packets sent, invalid
+  tokens, amplification-blocked sends, stateless resets, and unknown-CID packets.
 - **Pure Zig QUIC handshake driver (#296)** — adds `src/quic/tls_handshake.zig`,
   the backend-agnostic state machine that drives a TLS 1.3 handshake through the
   `QuicTlsAdapter` seam: it routes handshake bytes through per-level CRYPTO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ All notable user-facing changes to Tardigrade are documented here.
   adds the server safety mechanisms for unauthenticated UDP in `src/quic/path.zig`
   and `src/quic/cid.zig`: an `AntiAmplification` ledger enforcing the RFC 9000
   §8.1 3x send budget (saturating, so certificate/handshake bytes and
-  retransmissions cannot overflow it); `RetryTokens`, AEAD-sealed
-  address-validation tokens with timestamp/expiry, peer-address binding, a
-  rotating key ring, and tamper/unknown-key rejection; the RFC 9001 §5.8 Retry
+  retransmissions cannot overflow it); `RetryTokens`, versioned AEAD-sealed
+  Retry tokens binding the original destination connection ID, QUIC version,
+  and peer address (IPv6 scope id included) with timestamp/expiry, a
+  future-issued guard, a rotating key ring, and tamper/unknown-key rejection —
+  `validateRetry` returns the recovered ODCID/version for the connection layer;
+  the RFC 9001 §5.8 Retry
   integrity tag (`retryIntegrityTag` / `verifyRetryIntegrity`), verified against
   the Appendix A.4 vector; stateless-reset token derivation and reset-packet
   construction (`statelessResetToken`, `StatelessReset`) with loop-safe sizing

--- a/src/quic/cid.zig
+++ b/src/quic/cid.zig
@@ -6,13 +6,129 @@
 //! CONNECTION_ID frame handling and the active-CID limit from `config.zig` also
 //! live here. Deeper migration/path lifecycle is `path.zig`.
 //!
-//! Status: skeleton — basic generation/lookup scaffolding for #243, full
-//! lifecycle in #251.
+//! Status: stateless-reset token derivation and reset-packet emission land with
+//! #250; CID generation/lookup/retirement lifecycle in #251.
 
 const std = @import("std");
+const udp = @import("udp.zig");
 
-// TODO(#251): CID generation/lookup/retirement and stateless-reset tokens.
+const HmacSha256 = std.crypto.auth.hmac.sha2.HmacSha256;
+
+// TODO(#251): CID generation/lookup/retirement and the active-CID limit.
+
+// ---------------------------------------------------------------------------
+// Stateless reset (RFC 9000 §10.3)
+// ---------------------------------------------------------------------------
+
+pub const stateless_reset_token_len = 16;
+
+/// Derive a connection's stateless-reset token from its connection ID under a
+/// static server key (RFC 9000 §10.3.1). The token is the first 16 bytes of
+/// HMAC-SHA256(static_key, connection_id); it MUST be hard to guess, so the
+/// static key must be secret and stable across the connection's lifetime.
+pub fn statelessResetToken(static_key: [32]u8, connection_id: []const u8) [stateless_reset_token_len]u8 {
+    var mac: [HmacSha256.mac_length]u8 = undefined;
+    HmacSha256.create(&mac, connection_id, &static_key);
+    return mac[0..stateless_reset_token_len].*;
+}
+
+/// Emission rules and packet construction for stateless resets (RFC 9000 §10.3).
+pub const StatelessReset = struct {
+    /// Smallest reset we emit: >= 5 unpredictable bytes plus the 16-byte token,
+    /// so it is indistinguishable from a short-header packet (RFC 9000 §10.3).
+    pub const min_len = 5 + stateless_reset_token_len;
+
+    /// Whether a stateless reset may be sent in response to a packet of
+    /// `received_len` bytes. A reset must be at least `min_len` and strictly
+    /// smaller than the packet it answers, which both avoids an endless
+    /// reset↔reset loop between two endpoints and keeps a server from being an
+    /// amplifier. Packets too small to carry a reset get no response.
+    pub fn eligible(received_len: usize) bool {
+        return received_len > min_len;
+    }
+
+    /// Build a stateless reset into `out` responding to a packet of
+    /// `received_len` bytes. `unpredictable` supplies the leading random bytes
+    /// (its first byte's high bits are forced to `01` so the datagram looks like
+    /// a short-header packet); `token` is the connection's reset token. The
+    /// reset is sized one byte smaller than the triggering packet, clamped to
+    /// `out`. Returns the written slice.
+    pub fn build(
+        out: []u8,
+        received_len: usize,
+        unpredictable: []const u8,
+        token: [stateless_reset_token_len]u8,
+    ) error{ NotEligible, OutputTooSmall, NotEnoughEntropy }![]u8 {
+        if (!eligible(received_len)) return error.NotEligible;
+        // One byte smaller than the trigger, but no larger than the output buffer.
+        const reset_len = @min(received_len - 1, out.len);
+        if (reset_len < min_len) return error.OutputTooSmall;
+
+        const entropy_len = reset_len - stateless_reset_token_len;
+        if (unpredictable.len < entropy_len) return error.NotEnoughEntropy;
+
+        @memcpy(out[0..entropy_len], unpredictable[0..entropy_len]);
+        // Short header form: clear the long-header bit, set the fixed bit.
+        out[0] = (out[0] & 0x3f) | 0x40;
+        @memcpy(out[entropy_len..][0..stateless_reset_token_len], &token);
+        return out[0..reset_len];
+    }
+};
+
+const testing = std.testing;
+
+test "stateless reset token is a stable function of the connection ID" {
+    const key = [_]u8{0xab} ** 32;
+    const cid = [_]u8{ 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+
+    const token = statelessResetToken(key, &cid);
+    // Deterministic for a given key + CID.
+    try testing.expectEqualSlices(u8, &token, &statelessResetToken(key, &cid));
+
+    // A different CID or key yields a different token.
+    const other_cid = [_]u8{ 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x09 };
+    try testing.expect(!std.mem.eql(u8, &token, &statelessResetToken(key, &other_cid)));
+    const other_key = [_]u8{0xcd} ** 32;
+    try testing.expect(!std.mem.eql(u8, &token, &statelessResetToken(other_key, &cid)));
+}
+
+test "stateless reset is only emitted for packets large enough to answer safely" {
+    // Too small to carry a reset (min_len = 21): no response.
+    try testing.expect(!StatelessReset.eligible(StatelessReset.min_len));
+    try testing.expect(StatelessReset.eligible(StatelessReset.min_len + 1));
+
+    var out: [64]u8 = undefined;
+    const token = [_]u8{0x7e} ** stateless_reset_token_len;
+    const unpredictable = [_]u8{0xff} ** 64;
+
+    try testing.expectError(error.NotEligible, StatelessReset.build(&out, StatelessReset.min_len, &unpredictable, token));
+}
+
+test "stateless reset is shorter than the packet it answers and ends with the token" {
+    var out: [128]u8 = undefined;
+    const token = [_]u8{0x5c} ** stateless_reset_token_len;
+    const unpredictable = [_]u8{0xff} ** 128;
+
+    const reset = try StatelessReset.build(&out, 40, &unpredictable, token);
+    // One byte smaller than the trigger, avoiding a reset loop.
+    try testing.expectEqual(@as(usize, 39), reset.len);
+    // Looks like a short-header packet: high bits are 01.
+    try testing.expectEqual(@as(u8, 0x40), reset[0] & 0xc0);
+    // Trailing 16 bytes carry the reset token.
+    try testing.expectEqualSlices(u8, &token, reset[reset.len - stateless_reset_token_len ..]);
+}
+
+test "stateless reset clamps to the output buffer for large triggers" {
+    var out: [30]u8 = undefined;
+    const token = [_]u8{0x11} ** stateless_reset_token_len;
+    const unpredictable = [_]u8{0xa0} ** 30;
+
+    // Trigger is large, but the reset is bounded by the 30-byte output buffer.
+    const reset = try StatelessReset.build(&out, 1200, &unpredictable, token);
+    try testing.expectEqual(@as(usize, 30), reset.len);
+    try testing.expectEqualSlices(u8, &token, reset[reset.len - stateless_reset_token_len ..]);
+}
 
 test {
-    std.testing.refAllDecls(@This());
+    testing.refAllDecls(@This());
 }

--- a/src/quic/path.zig
+++ b/src/quic/path.zig
@@ -78,15 +78,29 @@ pub const token_nonce_len = Aes128Gcm.nonce_length;
 pub const token_tag_len = Aes128Gcm.tag_length;
 pub const max_token_keys = 8;
 
-/// Encoded plaintext is `issued_at(8) + family(1) + addr_len(1) + addr(4|16) + port(2)`.
-const token_min_plaintext_len = 8 + 1 + 1 + 4 + 2;
-const token_max_plaintext_len = 8 + 1 + 1 + 16 + 2;
+/// What a token authenticates. Retry tokens are bound to a specific connection
+/// attempt (original DCID + QUIC version); the enum leaves room for the future
+/// NEW_TOKEN address-validation flow (RFC 9000 §8.1.3) without a format break.
+pub const TokenKind = enum(u8) {
+    retry = 1,
+    address_validation = 2,
+};
+
+/// Fixed-size prefix of the token plaintext: `kind(1) + version(4) +
+/// issued_at(8) + odcid_len(1)`. The connection ID, address, and port follow.
+const token_header_len = 1 + 4 + 8 + 1;
+/// Variable address suffix: `family(1) + addr_len(1) + addr(4|16) +
+/// scope_id(4, IPv6 only) + port(2)`.
+const token_addr_min_len = 1 + 1 + 4 + 2; // IPv4
+const token_addr_max_len = 1 + 1 + 16 + 4 + 2; // IPv6, with scope id
+const token_min_plaintext_len = token_header_len + 0 + token_addr_min_len;
+const token_max_plaintext_len = token_header_len + udp.MaxConnectionIdLen + token_addr_max_len;
 
 /// Largest possible encoded token (`key_id + nonce + plaintext + tag`).
 pub const max_token_len = 1 + token_nonce_len + token_max_plaintext_len + token_tag_len;
 
 pub const TokenError = error{
-    /// Token is too short/long to be well-formed.
+    /// Token is too short/long or otherwise not well-formed.
     MalformedToken,
     /// Token names a key id the server does not hold (e.g. rotated out).
     UnknownTokenKey,
@@ -94,8 +108,11 @@ pub const TokenError = error{
     TokenAuthenticationFailed,
     /// Token authenticated but was issued to a different peer address.
     TokenAddressMismatch,
-    /// Token authenticated but is older than the configured lifetime.
+    /// Token authenticated but is expired or impossibly future-dated.
     TokenExpired,
+    /// Token authenticated but is not the expected kind (e.g. NEW_TOKEN where a
+    /// Retry token was required).
+    UnexpectedTokenKind,
 };
 
 /// A rotating ring of AEAD keys used to protect address-validation tokens.
@@ -121,27 +138,44 @@ pub const RetryTokenKeyRing = struct {
     }
 };
 
-/// Issues and verifies address-validation tokens. Tokens are AEAD-sealed with a
-/// key from the ring and bind the peer address plus an issue timestamp.
+/// Context recovered from a validated Retry token. The connection layer needs
+/// the original destination connection ID and QUIC version to validate the
+/// Retry flow and populate/verify the `original_destination_connection_id`
+/// transport parameter (RFC 9000 §7.3).
+pub const RetryContext = struct {
+    original_dcid: udp.ConnectionId,
+    quic_version: u32,
+};
+
+/// Issues and verifies Retry address-validation tokens. Tokens are AEAD-sealed
+/// with a key from the ring and bind the original destination connection ID,
+/// the QUIC version, the peer address, and an issue timestamp.
 pub const RetryTokens = struct {
     keys: RetryTokenKeyRing = .{},
     /// Maximum token age, in microseconds, before verification rejects it.
     lifetime_us: u64 = 10 * std.time.us_per_s,
+    /// Tolerance for a token whose issue time is slightly ahead of the
+    /// validator's clock. Tokens further in the future are rejected.
+    allowed_clock_skew_us: u64 = 0,
 
-    /// Seal a token for `address` stamped at `issued_at_us`. `nonce` must be
-    /// unique per token under the current key (the caller supplies it so the
-    /// module stays deterministic and free of ambient randomness).
-    pub fn issue(
+    /// Seal a Retry token binding `original_dcid` + `quic_version` + `address`,
+    /// stamped at `issued_at_us`. `nonce` must be unique per token under the
+    /// current key (the caller supplies it so the module stays deterministic and
+    /// free of ambient randomness).
+    pub fn issueRetry(
         self: *const RetryTokens,
+        original_dcid: []const u8,
+        quic_version: u32,
         address: udp.Address,
         issued_at_us: u64,
         nonce: [token_nonce_len]u8,
         out: []u8,
-    ) error{ OutputTooSmall, NoTokenKey }![]u8 {
+    ) error{ OutputTooSmall, NoTokenKey, ConnectionIdTooLong }![]u8 {
+        if (original_dcid.len > udp.MaxConnectionIdLen) return error.ConnectionIdTooLong;
         const key = self.keys.get(self.keys.current) orelse return error.NoTokenKey;
 
         var plaintext: [token_max_plaintext_len]u8 = undefined;
-        const plaintext_len = encodeTokenPlaintext(address, issued_at_us, &plaintext);
+        const plaintext_len = encodeTokenPlaintext(.retry, quic_version, original_dcid, address, issued_at_us, &plaintext);
         const total = 1 + token_nonce_len + plaintext_len + token_tag_len;
         if (out.len < total) return error.OutputTooSmall;
 
@@ -154,8 +188,10 @@ pub const RetryTokens = struct {
         return out[0..total];
     }
 
-    /// Verify a token was issued by this server to `address` and is unexpired.
-    pub fn validate(self: *const RetryTokens, token: []const u8, address: udp.Address, now_us: u64) TokenError!void {
+    /// Verify a Retry token was issued by this server to `address`, is a Retry
+    /// token, and is neither expired nor impossibly future-dated. Returns the
+    /// bound original DCID and QUIC version for the connection layer.
+    pub fn validateRetry(self: *const RetryTokens, token: []const u8, address: udp.Address, now_us: u64) TokenError!RetryContext {
         if (token.len < 1 + token_nonce_len + token_min_plaintext_len + token_tag_len) return error.MalformedToken;
         if (token.len > max_token_len) return error.MalformedToken;
         const plaintext_len = token.len - 1 - token_nonce_len - token_tag_len;
@@ -171,44 +207,113 @@ pub const RetryTokens = struct {
         Aes128Gcm.decrypt(plaintext[0..plaintext_len], cipher, tag, &.{}, nonce, key) catch return error.TokenAuthenticationFailed;
 
         const decoded = decodeTokenPlaintext(plaintext[0..plaintext_len]) catch return error.MalformedToken;
+        if (decoded.kind != .retry) return error.UnexpectedTokenKind;
         if (!addressEql(decoded.address, address)) return error.TokenAddressMismatch;
+        // Reject tokens dated further in the future than the allowed skew, so a
+        // backwards clock jump cannot make a stale token look freshly issued.
+        if (decoded.issued_at_us > now_us +| self.allowed_clock_skew_us) return error.TokenExpired;
         if ((now_us -| decoded.issued_at_us) > self.lifetime_us) return error.TokenExpired;
+        return .{ .original_dcid = decoded.original_dcid, .quic_version = decoded.quic_version };
     }
 };
 
-const DecodedToken = struct { issued_at_us: u64, address: udp.Address };
+const DecodedToken = struct {
+    kind: TokenKind,
+    quic_version: u32,
+    issued_at_us: u64,
+    original_dcid: udp.ConnectionId,
+    address: udp.Address,
+};
 
-fn encodeTokenPlaintext(address: udp.Address, issued_at_us: u64, out: *[token_max_plaintext_len]u8) usize {
-    std.mem.writeInt(u64, out[0..8], issued_at_us, .big);
-    out[8] = @intFromEnum(address.family);
+fn encodeTokenPlaintext(
+    kind: TokenKind,
+    quic_version: u32,
+    original_dcid: []const u8,
+    address: udp.Address,
+    issued_at_us: u64,
+    out: *[token_max_plaintext_len]u8,
+) usize {
+    var pos: usize = 0;
+    out[pos] = @intFromEnum(kind);
+    pos += 1;
+    std.mem.writeInt(u32, out[pos..][0..4], quic_version, .big);
+    pos += 4;
+    std.mem.writeInt(u64, out[pos..][0..8], issued_at_us, .big);
+    pos += 8;
+    out[pos] = @intCast(original_dcid.len);
+    pos += 1;
+    @memcpy(out[pos..][0..original_dcid.len], original_dcid);
+    pos += original_dcid.len;
+
+    out[pos] = @intFromEnum(address.family);
+    pos += 1;
     const addr = address.slice();
-    out[9] = @intCast(addr.len);
-    @memcpy(out[10..][0..addr.len], addr);
-    std.mem.writeInt(u16, out[10 + addr.len ..][0..2], address.port, .big);
-    return 10 + addr.len + 2;
+    out[pos] = @intCast(addr.len);
+    pos += 1;
+    @memcpy(out[pos..][0..addr.len], addr);
+    pos += addr.len;
+    // Encode scope_id for IPv6 so scoped (link-local) addresses round-trip.
+    if (address.family == .ip6) {
+        std.mem.writeInt(u32, out[pos..][0..4], address.scope_id, .big);
+        pos += 4;
+    }
+    std.mem.writeInt(u16, out[pos..][0..2], address.port, .big);
+    pos += 2;
+    return pos;
 }
 
 fn decodeTokenPlaintext(bytes: []const u8) error{MalformedToken}!DecodedToken {
-    if (bytes.len < 10) return error.MalformedToken;
-    const issued_at_us = std.mem.readInt(u64, bytes[0..8], .big);
-    const family = std.enums.fromInt(udp.AddressFamily, bytes[8]) orelse return error.MalformedToken;
-    const addr_len = bytes[9];
+    var pos: usize = 0;
+    if (bytes.len < token_header_len) return error.MalformedToken;
+    const kind = std.enums.fromInt(TokenKind, bytes[pos]) orelse return error.MalformedToken;
+    pos += 1;
+    const quic_version = std.mem.readInt(u32, bytes[pos..][0..4], .big);
+    pos += 4;
+    const issued_at_us = std.mem.readInt(u64, bytes[pos..][0..8], .big);
+    pos += 8;
+    const odcid_len = bytes[pos];
+    pos += 1;
+    if (odcid_len > udp.MaxConnectionIdLen) return error.MalformedToken;
+    if (bytes.len - pos < odcid_len) return error.MalformedToken;
+    var original_dcid = udp.ConnectionId{ .len = odcid_len };
+    @memcpy(original_dcid.bytes[0..odcid_len], bytes[pos..][0..odcid_len]);
+    pos += odcid_len;
+
+    if (bytes.len - pos < 2) return error.MalformedToken;
+    const family = std.enums.fromInt(udp.AddressFamily, bytes[pos]) orelse return error.MalformedToken;
+    pos += 1;
+    const addr_len = bytes[pos];
+    pos += 1;
     const expected_addr_len: usize = switch (family) {
         .ip4 => 4,
         .ip6 => 16,
     };
     if (addr_len != expected_addr_len) return error.MalformedToken;
-    if (bytes.len != 10 + expected_addr_len + 2) return error.MalformedToken;
-    const port = std.mem.readInt(u16, bytes[10 + expected_addr_len ..][0..2], .big);
-    var address = udp.Address{ .family = family, .port = port };
-    @memcpy(address.bytes[0..expected_addr_len], bytes[10..][0..expected_addr_len]);
-    return .{ .issued_at_us = issued_at_us, .address = address };
+    if (bytes.len - pos < expected_addr_len) return error.MalformedToken;
+    var address = udp.Address{ .family = family, .port = 0 };
+    @memcpy(address.bytes[0..expected_addr_len], bytes[pos..][0..expected_addr_len]);
+    pos += expected_addr_len;
+    if (family == .ip6) {
+        if (bytes.len - pos < 4) return error.MalformedToken;
+        address.scope_id = std.mem.readInt(u32, bytes[pos..][0..4], .big);
+        pos += 4;
+    }
+    if (bytes.len - pos != 2) return error.MalformedToken;
+    address.port = std.mem.readInt(u16, bytes[pos..][0..2], .big);
+
+    return .{
+        .kind = kind,
+        .quic_version = quic_version,
+        .issued_at_us = issued_at_us,
+        .original_dcid = original_dcid,
+        .address = address,
+    };
 }
 
 fn addressEql(a: udp.Address, b: udp.Address) bool {
     if (a.family != b.family or a.port != b.port) return false;
     if (!std.mem.eql(u8, a.slice(), b.slice())) return false;
-    // scope_id only distinguishes link-local IPv6 paths.
+    // scope_id distinguishes link-local IPv6 paths and now round-trips in tokens.
     return a.scope_id == b.scope_id;
 }
 
@@ -300,8 +405,8 @@ pub const Metrics = struct {
     }
 
     /// Fold a token-validation result into the counters (invalid tokens are
-    /// counted; a success is a no-op).
-    pub fn recordTokenValidation(self: *Metrics, result: TokenError!void) void {
+    /// counted; a success is a no-op). Accepts any `TokenError!T` result.
+    pub fn recordTokenValidation(self: *Metrics, result: anytype) void {
         if (result) |_| {} else |_| self.recordInvalidToken();
     }
 };
@@ -339,18 +444,37 @@ test "anti-amplification accounting saturates instead of overflowing" {
     try testing.expect(limiter.canSend(std.math.maxInt(u64)));
 }
 
-test "retry token round-trips and binds the peer address" {
+const test_odcid = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08 };
+const test_version: u32 = 0x0000_0001;
+
+test "retry token round-trips and recovers the original DCID and version" {
     var tokens = RetryTokens{ .lifetime_us = 10_000_000 };
     tokens.keys.install(0, [_]u8{0xa5} ** token_key_len);
 
     var buf: [max_token_len]u8 = undefined;
-    const token = try tokens.issue(loopbackV4(4433), 1_000_000, [_]u8{0x11} ** token_nonce_len, &buf);
+    const token = try tokens.issueRetry(&test_odcid, test_version, loopbackV4(4433), 1_000_000, [_]u8{0x11} ** token_nonce_len, &buf);
 
-    try tokens.validate(token, loopbackV4(4433), 1_500_000);
-    // A different port is a different path.
-    try testing.expectError(error.TokenAddressMismatch, tokens.validate(token, loopbackV4(4434), 1_500_000));
-    // A different host is a different path.
-    try testing.expectError(error.TokenAddressMismatch, tokens.validate(token, udp.Address.ip4(.{ 10, 0, 0, 1 }, 4433), 1_500_000));
+    const ctx = try tokens.validateRetry(token, loopbackV4(4433), 1_500_000);
+    try testing.expectEqualSlices(u8, &test_odcid, ctx.original_dcid.slice());
+    try testing.expectEqual(test_version, ctx.quic_version);
+
+    // A different port or host is a different path.
+    try testing.expectError(error.TokenAddressMismatch, tokens.validateRetry(token, loopbackV4(4434), 1_500_000));
+    try testing.expectError(error.TokenAddressMismatch, tokens.validateRetry(token, udp.Address.ip4(.{ 10, 0, 0, 1 }, 4433), 1_500_000));
+}
+
+test "retry token binds scoped IPv6 addresses including the scope id" {
+    var tokens = RetryTokens{ .lifetime_us = 10_000_000 };
+    tokens.keys.install(0, [_]u8{0xa5} ** token_key_len);
+
+    const scoped = udp.Address.ip6([_]u8{0xfe} ++ [_]u8{0x80} ++ [_]u8{0} ** 13 ++ [_]u8{0x01}, 4433, 7);
+    var buf: [max_token_len]u8 = undefined;
+    const token = try tokens.issueRetry(&test_odcid, test_version, scoped, 1_000_000, [_]u8{0x66} ** token_nonce_len, &buf);
+
+    // Same address including scope id validates; a different scope id does not.
+    _ = try tokens.validateRetry(token, scoped, 1_500_000);
+    const other_scope = udp.Address.ip6(scoped.bytes, 4433, 9);
+    try testing.expectError(error.TokenAddressMismatch, tokens.validateRetry(token, other_scope, 1_500_000));
 }
 
 test "retry token expires after its lifetime" {
@@ -358,10 +482,23 @@ test "retry token expires after its lifetime" {
     tokens.keys.install(1, [_]u8{0x5a} ** token_key_len);
 
     var buf: [max_token_len]u8 = undefined;
-    const token = try tokens.issue(loopbackV4(443), 2_000_000, [_]u8{0x22} ** token_nonce_len, &buf);
+    const token = try tokens.issueRetry(&test_odcid, test_version, loopbackV4(443), 2_000_000, [_]u8{0x22} ** token_nonce_len, &buf);
 
-    try tokens.validate(token, loopbackV4(443), 7_000_000); // exactly at the limit
-    try testing.expectError(error.TokenExpired, tokens.validate(token, loopbackV4(443), 7_000_001));
+    _ = try tokens.validateRetry(token, loopbackV4(443), 7_000_000); // exactly at the limit
+    try testing.expectError(error.TokenExpired, tokens.validateRetry(token, loopbackV4(443), 7_000_001));
+}
+
+test "retry token dated in the future is rejected" {
+    var tokens = RetryTokens{ .lifetime_us = 5_000_000, .allowed_clock_skew_us = 1_000 };
+    tokens.keys.install(0, [_]u8{0x7a} ** token_key_len);
+
+    var buf: [max_token_len]u8 = undefined;
+    const token = try tokens.issueRetry(&test_odcid, test_version, loopbackV4(443), 5_000_000, [_]u8{0x77} ** token_nonce_len, &buf);
+
+    // Within the allowed skew: accepted (age saturates to zero).
+    _ = try tokens.validateRetry(token, loopbackV4(443), 4_999_500);
+    // Further in the future than the skew: rejected instead of treated as fresh.
+    try testing.expectError(error.TokenExpired, tokens.validateRetry(token, loopbackV4(443), 4_000_000));
 }
 
 test "retry token rejects tampering and unknown keys" {
@@ -369,22 +506,22 @@ test "retry token rejects tampering and unknown keys" {
     tokens.keys.install(0, [_]u8{0x01} ** token_key_len);
 
     var buf: [max_token_len]u8 = undefined;
-    const token = try tokens.issue(loopbackV4(4433), 1_000_000, [_]u8{0x33} ** token_nonce_len, &buf);
+    const token = try tokens.issueRetry(&test_odcid, test_version, loopbackV4(4433), 1_000_000, [_]u8{0x33} ** token_nonce_len, &buf);
 
     // Flip a ciphertext byte: AEAD authentication must fail.
     var tampered: [max_token_len]u8 = undefined;
     @memcpy(tampered[0..token.len], token);
     tampered[1 + token_nonce_len] ^= 0x80;
-    try testing.expectError(error.TokenAuthenticationFailed, tokens.validate(tampered[0..token.len], loopbackV4(4433), 1_000_000));
+    try testing.expectError(error.TokenAuthenticationFailed, tokens.validateRetry(tampered[0..token.len], loopbackV4(4433), 1_000_000));
 
     // Name a key id the ring never held.
     var wrong_key: [max_token_len]u8 = undefined;
     @memcpy(wrong_key[0..token.len], token);
     wrong_key[0] = 7;
-    try testing.expectError(error.UnknownTokenKey, tokens.validate(wrong_key[0..token.len], loopbackV4(4433), 1_000_000));
+    try testing.expectError(error.UnknownTokenKey, tokens.validateRetry(wrong_key[0..token.len], loopbackV4(4433), 1_000_000));
 
     // Truncated token is malformed.
-    try testing.expectError(error.MalformedToken, tokens.validate(token[0..10], loopbackV4(4433), 1_000_000));
+    try testing.expectError(error.MalformedToken, tokens.validateRetry(token[0..10], loopbackV4(4433), 1_000_000));
 }
 
 test "retry token survives key rotation while a key is retained" {
@@ -392,15 +529,15 @@ test "retry token survives key rotation while a key is retained" {
     tokens.keys.install(0, [_]u8{0x01} ** token_key_len);
 
     var buf: [max_token_len]u8 = undefined;
-    const token = try tokens.issue(loopbackV4(4433), 1_000_000, [_]u8{0x44} ** token_nonce_len, &buf);
+    const token = try tokens.issueRetry(&test_odcid, test_version, loopbackV4(4433), 1_000_000, [_]u8{0x44} ** token_nonce_len, &buf);
 
     // Rotate to a new current key; the old key still validates prior tokens.
     tokens.keys.install(1, [_]u8{0x02} ** token_key_len);
-    try tokens.validate(token, loopbackV4(4433), 1_000_000);
+    _ = try tokens.validateRetry(token, loopbackV4(4433), 1_000_000);
 
     // Retiring the issuing key invalidates its tokens.
     tokens.keys.retire(0);
-    try testing.expectError(error.UnknownTokenKey, tokens.validate(token, loopbackV4(4433), 1_000_000));
+    try testing.expectError(error.UnknownTokenKey, tokens.validateRetry(token, loopbackV4(4433), 1_000_000));
 }
 
 test "retry integrity tag matches the RFC 9001 Appendix A.4 vector" {
@@ -433,12 +570,12 @@ test "metrics distinguish invalid tokens from normal retry usage" {
     var metrics = Metrics{};
 
     var buf: [max_token_len]u8 = undefined;
-    const token = try tokens.issue(loopbackV4(4433), 1_000_000, [_]u8{0x55} ** token_nonce_len, &buf);
+    const token = try tokens.issueRetry(&test_odcid, test_version, loopbackV4(4433), 1_000_000, [_]u8{0x55} ** token_nonce_len, &buf);
     metrics.recordRetrySent();
 
-    metrics.recordTokenValidation(tokens.validate(token, loopbackV4(4433), 1_500_000)); // valid
-    metrics.recordTokenValidation(tokens.validate(token, loopbackV4(4433), 9_000_000)); // expired
-    metrics.recordTokenValidation(tokens.validate(token, loopbackV4(9999), 1_500_000)); // wrong address
+    metrics.recordTokenValidation(tokens.validateRetry(token, loopbackV4(4433), 1_500_000)); // valid
+    metrics.recordTokenValidation(tokens.validateRetry(token, loopbackV4(4433), 9_000_000)); // expired
+    metrics.recordTokenValidation(tokens.validateRetry(token, loopbackV4(9999), 1_500_000)); // wrong address
 
     try testing.expectEqual(@as(u64, 1), metrics.retry_packets_sent);
     try testing.expectEqual(@as(u64, 2), metrics.invalid_tokens);

--- a/src/quic/path.zig
+++ b/src/quic/path.zig
@@ -1,18 +1,445 @@
-//! QUIC path management (#250, #251): Retry / address validation, the
-//! anti-amplification limit, PATH_CHALLENGE/PATH_RESPONSE path validation, NAT
-//! rebinding detection, and connection migration policy.
+//! QUIC server address-validation and anti-amplification (#250, RFC 9000 §8 &
+//! RFC 9001 §5.8): the safety mechanisms that let a server handle
+//! unauthenticated UDP before a peer's address is validated without becoming an
+//! amplification vector.
 //!
-//! Gates how many bytes `connection.zig` may send to an unvalidated peer
-//! address (anti-amplification), validates new paths before migrating, and
-//! implements the Retry-token issue/verify used for downstream address
-//! validation. Stateless reset detection pairs with `cid.zig`.
+//! - `AntiAmplification` enforces the 3x send budget per unvalidated path.
+//! - `RetryTokens` issues and verifies integrity-protected address-validation
+//!   tokens (timestamp/expiry, address binding, key rotation, tamper rejection).
+//! - `retryIntegrityTag` / `verifyRetryIntegrity` implement the RFC 9001 Retry
+//!   integrity tag. Stateless-reset tokens/packets live in `cid.zig`.
+//! - `Metrics` exposes the operator counters the issue requires.
 //!
-//! Status: skeleton — Retry/anti-amplification in #250, migration in #251.
+//! Packet framing and DCID parsing stay in `packet.zig` (#243); connection
+//! migration / path validation stay in #251; interop/fuzz in #247.
 
 const std = @import("std");
+const udp = @import("udp.zig");
 
-// TODO(#250/#251): Retry tokens, anti-amplification, path validation, migration.
+const Aes128Gcm = std.crypto.aead.aes_gcm.Aes128Gcm;
 
-test {
-    std.testing.refAllDecls(@This());
+// ---------------------------------------------------------------------------
+// Anti-amplification (RFC 9000 §8.1)
+// ---------------------------------------------------------------------------
+
+/// A server may send at most this multiple of the bytes it has received from an
+/// unvalidated peer address.
+pub const anti_amplification_factor = 3;
+
+/// Per-path ledger of bytes received from and sent to a peer whose address has
+/// not yet been validated. Once the address is validated the limit is lifted.
+/// The connection layer records every received datagram and every send (including
+/// handshake/certificate bytes and retransmissions) against this ledger.
+pub const AntiAmplification = struct {
+    received: u64 = 0,
+    sent: u64 = 0,
+    validated: bool = false,
+
+    pub fn recordReceived(self: *AntiAmplification, bytes: u64) void {
+        self.received +|= bytes;
+    }
+
+    pub fn recordSent(self: *AntiAmplification, bytes: u64) void {
+        self.sent +|= bytes;
+    }
+
+    /// Mark the peer address validated (a Retry/handshake token was verified or
+    /// the handshake completed). Lifts the send budget.
+    pub fn markValidated(self: *AntiAmplification) void {
+        self.validated = true;
+    }
+
+    /// Total bytes this side is currently permitted to have sent.
+    pub fn budget(self: *const AntiAmplification) u64 {
+        if (self.validated) return std.math.maxInt(u64);
+        return self.received *| anti_amplification_factor;
+    }
+
+    /// Bytes that may still be sent before the budget is exhausted.
+    pub fn remaining(self: *const AntiAmplification) u64 {
+        if (self.validated) return std.math.maxInt(u64);
+        return self.budget() -| self.sent;
+    }
+
+    /// Whether a datagram of `bytes` may be sent now without exceeding the
+    /// budget. A blocked send must be deferred, not dropped or spun on.
+    pub fn canSend(self: *const AntiAmplification, bytes: u64) bool {
+        if (self.validated) return true;
+        return (self.sent +| bytes) <= self.budget();
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Retry / address-validation tokens (RFC 9000 §8.1.1–§8.1.4)
+// ---------------------------------------------------------------------------
+
+pub const token_key_len = Aes128Gcm.key_length;
+pub const token_nonce_len = Aes128Gcm.nonce_length;
+pub const token_tag_len = Aes128Gcm.tag_length;
+pub const max_token_keys = 8;
+
+/// Encoded plaintext is `issued_at(8) + family(1) + addr_len(1) + addr(4|16) + port(2)`.
+const token_min_plaintext_len = 8 + 1 + 1 + 4 + 2;
+const token_max_plaintext_len = 8 + 1 + 1 + 16 + 2;
+
+/// Largest possible encoded token (`key_id + nonce + plaintext + tag`).
+pub const max_token_len = 1 + token_nonce_len + token_max_plaintext_len + token_tag_len;
+
+pub const TokenError = error{
+    /// Token is too short/long to be well-formed.
+    MalformedToken,
+    /// Token names a key id the server does not hold (e.g. rotated out).
+    UnknownTokenKey,
+    /// AEAD authentication failed — the token was forged or tampered with.
+    TokenAuthenticationFailed,
+    /// Token authenticated but was issued to a different peer address.
+    TokenAddressMismatch,
+    /// Token authenticated but is older than the configured lifetime.
+    TokenExpired,
+};
+
+/// A rotating ring of AEAD keys used to protect address-validation tokens.
+/// Installing a key makes it current; older keys remain valid for verification
+/// until explicitly retired, so tokens issued before a rotation still validate.
+pub const RetryTokenKeyRing = struct {
+    keys: [max_token_keys]?[token_key_len]u8 = .{null} ** max_token_keys,
+    current: u8 = 0,
+
+    pub fn install(self: *RetryTokenKeyRing, key_id: u8, key: [token_key_len]u8) void {
+        std.debug.assert(key_id < max_token_keys);
+        self.keys[key_id] = key;
+        self.current = key_id;
+    }
+
+    pub fn retire(self: *RetryTokenKeyRing, key_id: u8) void {
+        if (key_id < max_token_keys) self.keys[key_id] = null;
+    }
+
+    fn get(self: *const RetryTokenKeyRing, key_id: u8) ?[token_key_len]u8 {
+        if (key_id >= max_token_keys) return null;
+        return self.keys[key_id];
+    }
+};
+
+/// Issues and verifies address-validation tokens. Tokens are AEAD-sealed with a
+/// key from the ring and bind the peer address plus an issue timestamp.
+pub const RetryTokens = struct {
+    keys: RetryTokenKeyRing = .{},
+    /// Maximum token age, in microseconds, before verification rejects it.
+    lifetime_us: u64 = 10 * std.time.us_per_s,
+
+    /// Seal a token for `address` stamped at `issued_at_us`. `nonce` must be
+    /// unique per token under the current key (the caller supplies it so the
+    /// module stays deterministic and free of ambient randomness).
+    pub fn issue(
+        self: *const RetryTokens,
+        address: udp.Address,
+        issued_at_us: u64,
+        nonce: [token_nonce_len]u8,
+        out: []u8,
+    ) error{ OutputTooSmall, NoTokenKey }![]u8 {
+        const key = self.keys.get(self.keys.current) orelse return error.NoTokenKey;
+
+        var plaintext: [token_max_plaintext_len]u8 = undefined;
+        const plaintext_len = encodeTokenPlaintext(address, issued_at_us, &plaintext);
+        const total = 1 + token_nonce_len + plaintext_len + token_tag_len;
+        if (out.len < total) return error.OutputTooSmall;
+
+        out[0] = self.keys.current;
+        @memcpy(out[1..][0..token_nonce_len], &nonce);
+        const cipher = out[1 + token_nonce_len ..][0..plaintext_len];
+        var tag: [token_tag_len]u8 = undefined;
+        Aes128Gcm.encrypt(cipher, &tag, plaintext[0..plaintext_len], &.{}, nonce, key);
+        @memcpy(out[1 + token_nonce_len + plaintext_len ..][0..token_tag_len], &tag);
+        return out[0..total];
+    }
+
+    /// Verify a token was issued by this server to `address` and is unexpired.
+    pub fn validate(self: *const RetryTokens, token: []const u8, address: udp.Address, now_us: u64) TokenError!void {
+        if (token.len < 1 + token_nonce_len + token_min_plaintext_len + token_tag_len) return error.MalformedToken;
+        if (token.len > max_token_len) return error.MalformedToken;
+        const plaintext_len = token.len - 1 - token_nonce_len - token_tag_len;
+
+        const key = self.keys.get(token[0]) orelse return error.UnknownTokenKey;
+        var nonce: [token_nonce_len]u8 = undefined;
+        @memcpy(&nonce, token[1..][0..token_nonce_len]);
+        const cipher = token[1 + token_nonce_len ..][0..plaintext_len];
+        var tag: [token_tag_len]u8 = undefined;
+        @memcpy(&tag, token[1 + token_nonce_len + plaintext_len ..][0..token_tag_len]);
+
+        var plaintext: [token_max_plaintext_len]u8 = undefined;
+        Aes128Gcm.decrypt(plaintext[0..plaintext_len], cipher, tag, &.{}, nonce, key) catch return error.TokenAuthenticationFailed;
+
+        const decoded = decodeTokenPlaintext(plaintext[0..plaintext_len]) catch return error.MalformedToken;
+        if (!addressEql(decoded.address, address)) return error.TokenAddressMismatch;
+        if ((now_us -| decoded.issued_at_us) > self.lifetime_us) return error.TokenExpired;
+    }
+};
+
+const DecodedToken = struct { issued_at_us: u64, address: udp.Address };
+
+fn encodeTokenPlaintext(address: udp.Address, issued_at_us: u64, out: *[token_max_plaintext_len]u8) usize {
+    std.mem.writeInt(u64, out[0..8], issued_at_us, .big);
+    out[8] = @intFromEnum(address.family);
+    const addr = address.slice();
+    out[9] = @intCast(addr.len);
+    @memcpy(out[10..][0..addr.len], addr);
+    std.mem.writeInt(u16, out[10 + addr.len ..][0..2], address.port, .big);
+    return 10 + addr.len + 2;
+}
+
+fn decodeTokenPlaintext(bytes: []const u8) error{MalformedToken}!DecodedToken {
+    if (bytes.len < 10) return error.MalformedToken;
+    const issued_at_us = std.mem.readInt(u64, bytes[0..8], .big);
+    const family = std.enums.fromInt(udp.AddressFamily, bytes[8]) orelse return error.MalformedToken;
+    const addr_len = bytes[9];
+    const expected_addr_len: usize = switch (family) {
+        .ip4 => 4,
+        .ip6 => 16,
+    };
+    if (addr_len != expected_addr_len) return error.MalformedToken;
+    if (bytes.len != 10 + expected_addr_len + 2) return error.MalformedToken;
+    const port = std.mem.readInt(u16, bytes[10 + expected_addr_len ..][0..2], .big);
+    var address = udp.Address{ .family = family, .port = port };
+    @memcpy(address.bytes[0..expected_addr_len], bytes[10..][0..expected_addr_len]);
+    return .{ .issued_at_us = issued_at_us, .address = address };
+}
+
+fn addressEql(a: udp.Address, b: udp.Address) bool {
+    if (a.family != b.family or a.port != b.port) return false;
+    if (!std.mem.eql(u8, a.slice(), b.slice())) return false;
+    // scope_id only distinguishes link-local IPv6 paths.
+    return a.scope_id == b.scope_id;
+}
+
+// ---------------------------------------------------------------------------
+// Retry integrity tag (RFC 9001 §5.8)
+// ---------------------------------------------------------------------------
+
+/// QUIC v1 Retry integrity AEAD key (RFC 9001 §5.8).
+pub const retry_integrity_key_v1 = [16]u8{
+    0xbe, 0x0c, 0x69, 0x0b, 0x9f, 0x66, 0x57, 0x5a,
+    0x1d, 0x76, 0x6b, 0x54, 0xe3, 0x68, 0xc8, 0x4e,
+};
+/// QUIC v1 Retry integrity AEAD nonce (RFC 9001 §5.8).
+pub const retry_integrity_nonce_v1 = [12]u8{
+    0x46, 0x15, 0x99, 0xd3, 0x5d, 0x63, 0x2b, 0xf2,
+    0x23, 0x98, 0x25, 0xbb,
+};
+pub const retry_integrity_tag_len = 16;
+
+/// Largest Retry packet body (everything before the integrity tag) this module
+/// assembles a pseudo-packet for.
+pub const max_retry_body_len = 512;
+const max_retry_pseudo_len = 1 + udp.MaxConnectionIdLen + max_retry_body_len;
+
+/// Compute the Retry integrity tag over the Retry pseudo-packet
+/// (`ODCID length || ODCID || Retry packet without tag`), RFC 9001 §5.8.
+pub fn retryIntegrityTag(
+    original_dcid: []const u8,
+    retry_body: []const u8,
+) error{ ConnectionIdTooLong, RetryBodyTooLong }![retry_integrity_tag_len]u8 {
+    if (original_dcid.len > udp.MaxConnectionIdLen) return error.ConnectionIdTooLong;
+    if (retry_body.len > max_retry_body_len) return error.RetryBodyTooLong;
+
+    var pseudo: [max_retry_pseudo_len]u8 = undefined;
+    var len: usize = 0;
+    pseudo[len] = @intCast(original_dcid.len);
+    len += 1;
+    @memcpy(pseudo[len..][0..original_dcid.len], original_dcid);
+    len += original_dcid.len;
+    @memcpy(pseudo[len..][0..retry_body.len], retry_body);
+    len += retry_body.len;
+
+    var tag: [retry_integrity_tag_len]u8 = undefined;
+    Aes128Gcm.encrypt(&.{}, &tag, &.{}, pseudo[0..len], retry_integrity_nonce_v1, retry_integrity_key_v1);
+    return tag;
+}
+
+/// Verify a received Retry packet's trailing integrity tag against `original_dcid`.
+/// `retry_packet` includes the 16-byte tag. Returns false on tamper.
+pub fn verifyRetryIntegrity(original_dcid: []const u8, retry_packet: []const u8) bool {
+    if (retry_packet.len < retry_integrity_tag_len) return false;
+    const body = retry_packet[0 .. retry_packet.len - retry_integrity_tag_len];
+    const received_tag = retry_packet[retry_packet.len - retry_integrity_tag_len ..][0..retry_integrity_tag_len];
+    const expected = retryIntegrityTag(original_dcid, body) catch return false;
+    return std.crypto.timing_safe.eql([retry_integrity_tag_len]u8, expected, received_tag.*);
+}
+
+// ---------------------------------------------------------------------------
+// Operator metrics (issue #250)
+// ---------------------------------------------------------------------------
+
+/// Counters that let an operator distinguish normal Retry usage from invalid
+/// tokens, budget-blocked sends, and unknown-CID / stateless-reset traffic.
+pub const Metrics = struct {
+    retry_packets_sent: u64 = 0,
+    invalid_tokens: u64 = 0,
+    amplification_blocked_sends: u64 = 0,
+    stateless_resets_sent: u64 = 0,
+    unknown_connection_id_packets: u64 = 0,
+
+    pub fn recordRetrySent(self: *Metrics) void {
+        self.retry_packets_sent += 1;
+    }
+
+    pub fn recordInvalidToken(self: *Metrics) void {
+        self.invalid_tokens += 1;
+    }
+
+    pub fn recordAmplificationBlocked(self: *Metrics) void {
+        self.amplification_blocked_sends += 1;
+    }
+
+    pub fn recordStatelessReset(self: *Metrics) void {
+        self.stateless_resets_sent += 1;
+    }
+
+    pub fn recordUnknownConnectionId(self: *Metrics) void {
+        self.unknown_connection_id_packets += 1;
+    }
+
+    /// Fold a token-validation result into the counters (invalid tokens are
+    /// counted; a success is a no-op).
+    pub fn recordTokenValidation(self: *Metrics, result: TokenError!void) void {
+        if (result) |_| {} else |_| self.recordInvalidToken();
+    }
+};
+
+const testing = std.testing;
+
+fn loopbackV4(port: u16) udp.Address {
+    return udp.Address.ip4(.{ 127, 0, 0, 1 }, port);
+}
+
+test "anti-amplification caps sends at 3x received until validated" {
+    var limiter = AntiAmplification{};
+    limiter.recordReceived(1200);
+    try testing.expectEqual(@as(u64, 3600), limiter.budget());
+    try testing.expectEqual(@as(u64, 3600), limiter.remaining());
+
+    try testing.expect(limiter.canSend(3600));
+    try testing.expect(!limiter.canSend(3601));
+
+    limiter.recordSent(3000);
+    try testing.expectEqual(@as(u64, 600), limiter.remaining());
+    try testing.expect(limiter.canSend(600));
+    try testing.expect(!limiter.canSend(601));
+
+    // Validation lifts the budget entirely.
+    limiter.markValidated();
+    try testing.expect(limiter.canSend(std.math.maxInt(u64)));
+    try testing.expectEqual(@as(u64, std.math.maxInt(u64)), limiter.remaining());
+}
+
+test "anti-amplification accounting saturates instead of overflowing" {
+    var limiter = AntiAmplification{};
+    limiter.recordReceived(std.math.maxInt(u64));
+    try testing.expectEqual(@as(u64, std.math.maxInt(u64)), limiter.budget());
+    try testing.expect(limiter.canSend(std.math.maxInt(u64)));
+}
+
+test "retry token round-trips and binds the peer address" {
+    var tokens = RetryTokens{ .lifetime_us = 10_000_000 };
+    tokens.keys.install(0, [_]u8{0xa5} ** token_key_len);
+
+    var buf: [max_token_len]u8 = undefined;
+    const token = try tokens.issue(loopbackV4(4433), 1_000_000, [_]u8{0x11} ** token_nonce_len, &buf);
+
+    try tokens.validate(token, loopbackV4(4433), 1_500_000);
+    // A different port is a different path.
+    try testing.expectError(error.TokenAddressMismatch, tokens.validate(token, loopbackV4(4434), 1_500_000));
+    // A different host is a different path.
+    try testing.expectError(error.TokenAddressMismatch, tokens.validate(token, udp.Address.ip4(.{ 10, 0, 0, 1 }, 4433), 1_500_000));
+}
+
+test "retry token expires after its lifetime" {
+    var tokens = RetryTokens{ .lifetime_us = 5_000_000 };
+    tokens.keys.install(1, [_]u8{0x5a} ** token_key_len);
+
+    var buf: [max_token_len]u8 = undefined;
+    const token = try tokens.issue(loopbackV4(443), 2_000_000, [_]u8{0x22} ** token_nonce_len, &buf);
+
+    try tokens.validate(token, loopbackV4(443), 7_000_000); // exactly at the limit
+    try testing.expectError(error.TokenExpired, tokens.validate(token, loopbackV4(443), 7_000_001));
+}
+
+test "retry token rejects tampering and unknown keys" {
+    var tokens = RetryTokens{ .lifetime_us = 10_000_000 };
+    tokens.keys.install(0, [_]u8{0x01} ** token_key_len);
+
+    var buf: [max_token_len]u8 = undefined;
+    const token = try tokens.issue(loopbackV4(4433), 1_000_000, [_]u8{0x33} ** token_nonce_len, &buf);
+
+    // Flip a ciphertext byte: AEAD authentication must fail.
+    var tampered: [max_token_len]u8 = undefined;
+    @memcpy(tampered[0..token.len], token);
+    tampered[1 + token_nonce_len] ^= 0x80;
+    try testing.expectError(error.TokenAuthenticationFailed, tokens.validate(tampered[0..token.len], loopbackV4(4433), 1_000_000));
+
+    // Name a key id the ring never held.
+    var wrong_key: [max_token_len]u8 = undefined;
+    @memcpy(wrong_key[0..token.len], token);
+    wrong_key[0] = 7;
+    try testing.expectError(error.UnknownTokenKey, tokens.validate(wrong_key[0..token.len], loopbackV4(4433), 1_000_000));
+
+    // Truncated token is malformed.
+    try testing.expectError(error.MalformedToken, tokens.validate(token[0..10], loopbackV4(4433), 1_000_000));
+}
+
+test "retry token survives key rotation while a key is retained" {
+    var tokens = RetryTokens{ .lifetime_us = 10_000_000 };
+    tokens.keys.install(0, [_]u8{0x01} ** token_key_len);
+
+    var buf: [max_token_len]u8 = undefined;
+    const token = try tokens.issue(loopbackV4(4433), 1_000_000, [_]u8{0x44} ** token_nonce_len, &buf);
+
+    // Rotate to a new current key; the old key still validates prior tokens.
+    tokens.keys.install(1, [_]u8{0x02} ** token_key_len);
+    try tokens.validate(token, loopbackV4(4433), 1_000_000);
+
+    // Retiring the issuing key invalidates its tokens.
+    tokens.keys.retire(0);
+    try testing.expectError(error.UnknownTokenKey, tokens.validate(token, loopbackV4(4433), 1_000_000));
+}
+
+test "retry integrity tag matches the RFC 9001 Appendix A.4 vector" {
+    var odcid: [8]u8 = undefined;
+    _ = try std.fmt.hexToBytes(&odcid, "8394c8f03e515708");
+    var retry_body: [20]u8 = undefined;
+    _ = try std.fmt.hexToBytes(&retry_body, "ff000000010008f067a5502a4262b5746f6b656e");
+
+    const tag = try retryIntegrityTag(&odcid, &retry_body);
+    var expected: [16]u8 = undefined;
+    _ = try std.fmt.hexToBytes(&expected, "04a265ba2eff4d829058fb3f0f2496ba");
+    try testing.expectEqualSlices(u8, &expected, &tag);
+
+    // The full Retry packet (body + tag) verifies; a tampered tag does not.
+    var retry_packet: [36]u8 = undefined;
+    @memcpy(retry_packet[0..20], &retry_body);
+    @memcpy(retry_packet[20..], &tag);
+    try testing.expect(verifyRetryIntegrity(&odcid, &retry_packet));
+
+    retry_packet[35] ^= 0x01;
+    try testing.expect(!verifyRetryIntegrity(&odcid, &retry_packet));
+    // Wrong original DCID must also fail.
+    @memcpy(retry_packet[20..], &tag);
+    try testing.expect(!verifyRetryIntegrity("wrongdcid", &retry_packet));
+}
+
+test "metrics distinguish invalid tokens from normal retry usage" {
+    var tokens = RetryTokens{ .lifetime_us = 1_000_000 };
+    tokens.keys.install(0, [_]u8{0x09} ** token_key_len);
+    var metrics = Metrics{};
+
+    var buf: [max_token_len]u8 = undefined;
+    const token = try tokens.issue(loopbackV4(4433), 1_000_000, [_]u8{0x55} ** token_nonce_len, &buf);
+    metrics.recordRetrySent();
+
+    metrics.recordTokenValidation(tokens.validate(token, loopbackV4(4433), 1_500_000)); // valid
+    metrics.recordTokenValidation(tokens.validate(token, loopbackV4(4433), 9_000_000)); // expired
+    metrics.recordTokenValidation(tokens.validate(token, loopbackV4(9999), 1_500_000)); // wrong address
+
+    try testing.expectEqual(@as(u64, 1), metrics.retry_packets_sent);
+    try testing.expectEqual(@as(u64, 2), metrics.invalid_tokens);
 }


### PR DESCRIPTION
## Summary
Implements the QUIC server safety mechanisms for handling unauthenticated UDP before a peer's address is validated (`src/quic/path.zig`, `src/quic/cid.zig`). These are self-contained transport primitives; the connection layer wires them onto the receive/send path once the connection state machine lands (packet framing/DCID parsing stay in #243, migration in #251, interop in #247, per the review scope note).

### Anti-amplification (RFC 9000 §8.1)
- `AntiAmplification`: a per-path ledger of bytes received vs. sent that enforces the 3× budget until the address is validated. Saturating arithmetic (`+|`, `*|`) means certificate/handshake bytes and retransmissions can't overflow it; `canSend(bytes)` lets the connection layer **defer** a blocked send rather than drop or spin.

### Retry / address-validation tokens (RFC 9000 §8.1)
- `RetryTokens`: AEAD-sealed tokens binding the peer address + an issue timestamp, protected by a **rotating key ring** (old keys stay valid until retired). Verification returns typed errors: `MalformedToken`, `UnknownTokenKey`, `TokenAuthenticationFailed`, `TokenAddressMismatch`, `TokenExpired`. The nonce is caller-supplied so the module carries no ambient randomness and stays deterministic.

### Retry integrity (RFC 9001 §5.8)
- `retryIntegrityTag` / `verifyRetryIntegrity` over the Retry pseudo-packet, verified against the **RFC 9001 Appendix A.4 test vector**, with constant-time tag comparison.

### Stateless reset (RFC 9000 §10.3, `cid.zig`)
- `statelessResetToken`: 16-byte token = HMAC-SHA256(static_key, CID).
- `StatelessReset.build`: constructs a reset **one byte smaller than the triggering packet** (loop-safe), ≥ 21 bytes, short-header form (high bits `01`), and refuses packets too small to answer (`eligible`).

### Metrics
- `Metrics`: counters for Retry packets sent, invalid tokens, amplification-blocked sends, stateless resets sent, and unknown-CID packets, so an operator can distinguish invalid-token traffic from normal Retry usage.

## Test plan
- [x] `zig build test-quic` — all QUIC/H3 unit tests pass, including the new ones.
- [x] `zig build test` — full workspace suite passes.
- [x] `zig build` — full project compiles.
- New coverage: 3× budget enforcement + validation lift + saturation; token round-trip/address-binding, expiry boundary, tamper, unknown/retired key, key rotation; RFC 9001 A.4 Retry integrity vector + tamper + wrong-ODCID; stateless-reset token determinism, eligibility, loop-safe sizing, output-buffer clamping; metrics distinguishing invalid tokens from Retry usage.

## #250 acceptance criteria
- [x] Server never sends more than the anti-amplification limit before validation
- [x] Retry tokens are integrity-protected and reject tampering
- [x] Unknown connection IDs only trigger a stateless reset when legal (eligibility + loop-safe construction; no per-packet state)
- [x] Metrics distinguish invalid-token traffic from normal Retry usage
- [x] Unit tests cover token expiry/tamper, Retry validation, and anti-amplification send blocking

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)