### PR TITLE
feat(http2): stream uploads over h2 upstreams (#301)

### DIFF
--- a/docs/UPSTREAM_POOLING.md
+++ b/docs/UPSTREAM_POOLING.md
@@ -85,9 +85,10 @@ structure from the h1 pool:
 
 The remaining HTTP/2 work is intentionally outside #145:
 
-- streaming request uploads over h2 are deferred until the actor has an
-  incremental DATA-send API for slow client bodies; fallback decisions are
-  counted in `tardigrade_upstream_h2_streaming_upload_fallback_total`;
+- streaming request uploads over h2 are tracked by #301 and use the actor's
+  incremental DATA-send API for slow client bodies; unexpected fallback
+  decisions remain counted in
+  `tardigrade_upstream_h2_streaming_upload_fallback_total`;
 - canonical Beelink benchmark capture remains a benchmark-operations task; the
   comparison harness is committed and ready to run.
 
@@ -225,10 +226,12 @@ The actor gains a streaming request mode next to the fully-buffered
   connection itself died.
 
 Streaming **uploads** (`full` mode with a request body relayed from the client)
-stay on the HTTP/1.1 path: the request-body sender currently buffers the body,
-and relaying a slow client upload over the shared connection needs an
-incremental DATA-send API on the actor. Deferred within #145: streaming
-uploads over h2.
+use `openStreaming()` plus incremental `writeStreamingRequestBody()` DATA
+writes before waiting for response headers. Each DATA write reserves h2
+connection and stream send window without holding `write_mutex`, then writes one
+frame under the write mutex, so slow/flow-controlled uploads backpressure the
+client relay without blocking unrelated streams or the reader's control-frame
+writes.
 
 ## Protocol-agnostic stream transport target (#241)
 

--- a/src/gateway_proxy.zig
+++ b/src/gateway_proxy.zig
@@ -635,6 +635,7 @@ fn streamViaH2Pool(
     method: []const u8,
     extra_headers: []const std.http.Header,
     buffered_body: []const u8,
+    streaming_body: ?StreamingRequestBody,
     read_buf: []u8,
     downstream_conn: anytype,
     downstream_writer: anytype,
@@ -669,7 +670,7 @@ fn streamViaH2Pool(
                 if (h1_pool) |p| p.recordProtocol(false);
                 const start_ms = http.event_loop.monotonicMs();
                 var wrote_downstream = false;
-                const res = try streamProxyOverTransport(allocator, tls_ptr, tls_ptr.fd, read_buf, uri, method, extra_headers, buffered_body, null, downstream_conn, downstream_writer, security, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, &wrote_downstream);
+                const res = try streamProxyOverTransport(allocator, tls_ptr, tls_ptr.fd, read_buf, uri, method, extra_headers, buffered_body, streaming_body, downstream_conn, downstream_writer, security, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, &wrote_downstream);
                 if (h1_pool) |p| p.recordRequestLatency(false, http.event_loop.monotonicMs() - start_ms);
                 return res.result;
             },
@@ -692,20 +693,76 @@ fn streamViaH2Pool(
                 }
 
                 const start_ms = http.event_loop.monotonicMs();
-                const stream = conn.requestStreaming(.{
+                const stream = conn.openStreaming(.{
                     .method = method,
                     .scheme = scheme,
                     .authority = authority,
                     .path = path_buf.written(),
                     .headers = extra_headers,
                     .body = buffered_body,
+                    .end_stream = streaming_body == null,
                 }) catch |err| {
                     // Nothing has reached the client yet: evict the dead
                     // connection so new requests do not pick it, and retry
                     // once on connection-level failures.
                     h2_pool.evict(key, conn);
                     h2_pool.release(conn);
-                    if (attempt == 0 and (err == error.Http2GoAway or err == error.Http2ConnectionClosed or err == error.Http2StreamReset)) {
+                    if (streaming_body == null and attempt == 0 and (err == error.Http2GoAway or err == error.Http2ConnectionClosed or err == error.Http2StreamReset)) {
+                        continue;
+                    }
+                    return err;
+                };
+
+                if (streaming_body) |sb| {
+                    var sent: usize = @min(sb.initial_bytes.len, sb.content_length);
+                    if (sent > 0) {
+                        conn.writeStreamingRequestBody(stream, sb.initial_bytes[0..sent], sent == sb.content_length) catch |err| {
+                            conn.finishStreaming(stream);
+                            if (!conn.healthy()) h2_pool.evict(key, conn);
+                            h2_pool.release(conn);
+                            return err;
+                        };
+                    }
+                    while (sent < sb.content_length) {
+                        if (cancelStopped(cancel_token)) {
+                            conn.finishStreaming(stream);
+                            h2_pool.release(conn);
+                            return error.RequestCancelled;
+                        }
+                        const want = @min(read_buf.len, sb.content_length - sent);
+                        const n = downstream_conn.read(read_buf[0..want]) catch {
+                            conn.finishStreaming(stream);
+                            h2_pool.release(conn);
+                            return error.ClientAborted;
+                        };
+                        if (n == 0) {
+                            conn.finishStreaming(stream);
+                            h2_pool.release(conn);
+                            return error.ClientAborted;
+                        }
+                        conn.writeStreamingRequestBody(stream, read_buf[0..n], sent + n == sb.content_length) catch |err| {
+                            conn.finishStreaming(stream);
+                            if (!conn.healthy()) h2_pool.evict(key, conn);
+                            h2_pool.release(conn);
+                            return err;
+                        };
+                        sent += n;
+                    }
+                    if (sb.content_length == 0) {
+                        conn.writeStreamingRequestBody(stream, "", true) catch |err| {
+                            conn.finishStreaming(stream);
+                            if (!conn.healthy()) h2_pool.evict(key, conn);
+                            h2_pool.release(conn);
+                            return err;
+                        };
+                    }
+                }
+
+                conn.waitStreamingResponseHead(stream) catch |err| {
+                    conn.finishStreaming(stream);
+                    if (!conn.healthy()) h2_pool.evict(key, conn);
+                    h2_pool.release(conn);
+                    if (streaming_body == null and attempt == 0 and (err == error.Http2GoAway or err == error.Http2ConnectionClosed or err == error.Http2StreamReset)) {
                         continue;
                     }
                     return err;
@@ -1653,12 +1710,11 @@ fn streamProxyOverTransport(
 /// is pooled (plain or TLS) and per-phase reads are `poll`-bounded, so the
 /// streaming path inherits the #196 timeout enforcement and #141 reuse.
 ///
-/// When `TARDIGRADE_UPSTREAM_PROTOCOL` offers h2 and the target is HTTPS, the
-/// response is multiplexed over the shared per-origin HTTP/2 connection
-/// (#145, Phase 4b PR 4) with bounded per-stream buffering — see
-/// `streamViaH2Pool`. Streaming request bodies (`full` mode uploads) stay on
-/// the HTTP/1.1 path: relaying a slow client upload over the shared h2
-/// connection is deferred.
+/// When `TARDIGRADE_UPSTREAM_PROTOCOL` offers h2 and the target is HTTPS, or
+/// when h2c prior knowledge is explicitly configured for plain HTTP, the
+/// exchange is multiplexed over the shared per-origin HTTP/2 connection. Full
+/// streaming uploads relay request DATA incrementally over the h2 stream; h1 is
+/// used only when h2 is not requested or TLS ALPN negotiates HTTP/1.1.
 pub fn executeStreamingHttpProxyRequest(
     allocator: std.mem.Allocator,
     cfg: *const edge_config.EdgeConfig,
@@ -1733,17 +1789,12 @@ pub fn executeStreamingHttpProxyRequest(
     const read_buf = try allocator.alloc(u8, @max(cfg.proxy_stream_buffer_size, 16 * 1024));
     defer allocator.free(read_buf);
 
-    // HTTP/2 upstream (#145 PR 4): multiplex the streaming response over the
-    // shared per-origin h2 connection when configured — via ALPN for HTTPS
-    // (h1 origins fall back inside) or prior-knowledge h2c for plain HTTP
-    // when explicitly opted in (#237). Streaming uploads stay on the h1 path
-    // below (`offer_h2` remains false there, so ALPN cannot negotiate a
-    // protocol we then would not speak).
+    // HTTP/2 upstream (#145/#301): multiplex the streaming exchange over the
+    // shared per-origin h2 connection when configured — via ALPN for HTTPS (h1
+    // origins fall back inside) or prior-knowledge h2c for plain HTTP when
+    // explicitly opted in (#237).
     const h2_requested_for_streaming = if (is_https) cfg.upstream_protocol.offersH2() else cfg.upstream_protocol.h2cPriorKnowledge();
-    if (streaming_body != null and h2_requested_for_streaming) {
-        if (pool) |p| p.recordH2StreamingUploadFallback();
-    }
-    const stream_h2 = streaming_body == null and h2_requested_for_streaming;
+    const stream_h2 = h2_requested_for_streaming;
     if (stream_h2) {
         if (h2_pool) |hp| {
             const h2_opts: ?http.tls_termination.UpstreamTlsOptions = if (is_https) blk: {
@@ -1751,7 +1802,10 @@ pub fn executeStreamingHttpProxyRequest(
                 o.offer_h2 = true;
                 break :blk o;
             } else null;
-            return streamViaH2Pool(allocator, hp, pool, host, port, h2_opts, uri, method, extra_headers.items, buffered_body, read_buf, downstream_conn, downstream_writer, security, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token);
+            return streamViaH2Pool(allocator, hp, pool, host, port, h2_opts, uri, method, extra_headers.items, buffered_body, streaming_body, read_buf, downstream_conn, downstream_writer, security, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token);
+        }
+        if (streaming_body != null) {
+            if (pool) |p| p.recordH2StreamingUploadFallback();
         }
     }
     // Everything below runs HTTP/1.1 (counted per request, not per attempt).

--- a/src/gateway_proxy.zig
+++ b/src/gateway_proxy.zig
@@ -700,7 +700,7 @@ fn streamViaH2Pool(
                     .path = path_buf.written(),
                     .headers = extra_headers,
                     .body = buffered_body,
-                    .end_stream = streaming_body == null,
+                    .body_mode = if (streaming_body == null) .complete else .streaming,
                 }) catch |err| {
                     // Nothing has reached the client yet: evict the dead
                     // connection so new requests do not pick it, and retry

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -1525,7 +1525,7 @@ pub const GatewayState = struct {
         try out.print("tardigrade_upstream_protocol_requests_total{{protocol=\"h2\"}} {d}\n", .{proto.h2});
 
         try out.appendSlice(
-            \\# HELP tardigrade_upstream_h2_streaming_upload_fallback_total Streaming upload requests that requested h2/h2c upstreams but fell back to h1 because incremental h2 request-body DATA is not implemented
+            \\# HELP tardigrade_upstream_h2_streaming_upload_fallback_total Streaming upload requests that requested h2/h2c upstreams but fell back to h1 because the h2 pool was unavailable
             \\# TYPE tardigrade_upstream_h2_streaming_upload_fallback_total counter
             \\
         );
@@ -3368,7 +3368,7 @@ test "served Prometheus metrics expose h2 streaming upload fallback counter" {
     const prom = try gs.metricsToPrometheus(std.testing.allocator);
     defer std.testing.allocator.free(prom);
 
-    try std.testing.expect(std.mem.find(u8, prom, "# HELP tardigrade_upstream_h2_streaming_upload_fallback_total Streaming upload requests that requested h2/h2c upstreams but fell back to h1 because incremental h2 request-body DATA is not implemented") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "# HELP tardigrade_upstream_h2_streaming_upload_fallback_total Streaming upload requests that requested h2/h2c upstreams but fell back to h1 because the h2 pool was unavailable") != null);
     try std.testing.expect(std.mem.find(u8, prom, "# TYPE tardigrade_upstream_h2_streaming_upload_fallback_total counter") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_upstream_h2_streaming_upload_fallback_total 1\n") != null);
 }

--- a/src/http/upstream_h2.zig
+++ b/src/http/upstream_h2.zig
@@ -81,10 +81,14 @@ pub const Request = struct {
     /// headers (and Host) are dropped before sending.
     headers: []const std.http.Header = &.{},
     body: []const u8 = "",
-    /// Whether this request's outbound body is complete after `body`.
-    /// Streaming uploads set this false, write more DATA incrementally, then
-    /// finish with a final DATA frame carrying END_STREAM.
-    end_stream: bool = true,
+    /// Whether `body` is the complete outbound request body or the first bytes
+    /// of a request body that will continue through streaming DATA writes.
+    body_mode: BodyMode = .complete,
+};
+
+pub const BodyMode = enum {
+    complete,
+    streaming,
 };
 
 pub const Response = struct {
@@ -716,9 +720,12 @@ pub fn H2Conn(comptime Transport: type) type {
                 return;
             }
             if (!end_stream) return;
+            try self.ensureStreamWritable(stream);
+            var write_result: anyerror!void = {};
             self.write_mutex.lock();
-            defer self.write_mutex.unlock();
-            try frame.writeFrame(self.transport, .data, frame.Flags.END_STREAM, stream.id, &[_]u8{});
+            write_result = frame.writeFrame(self.transport, .data, frame.Flags.END_STREAM, stream.id, &[_]u8{});
+            self.write_mutex.unlock();
+            if (write_result) |_| {} else |err| return self.markWriteFailure(err);
         }
 
         /// Copy the next chunk of a streaming response body into `out`,
@@ -845,20 +852,20 @@ pub fn H2Conn(comptime Transport: type) type {
             const block = try hpack.encodeLiteralHeaderBlock(self.allocator, fields.items);
             defer self.allocator.free(block);
 
-            const end_stream = req.end_stream and req.body.len == 0;
+            const request_body_complete = req.body_mode == .complete;
+            const end_stream = request_body_complete and req.body.len == 0;
             // HEADERS (+CONTINUATION) must be contiguous on the wire, so the
             // whole block goes out under one write_mutex hold. DATA frames may
             // interleave with other streams, so the body sender takes the lock
             // per frame — and, crucially, never holds it while waiting on
             // state_mutex for flow-control window (the reader needs write_mutex
             // for PING/SETTINGS acks; holding both would deadlock it).
-            {
-                self.write_mutex.lock();
-                defer self.write_mutex.unlock();
-                try self.writeHeaderBlockLocked(stream.id, block, end_stream);
-            }
+            self.write_mutex.lock();
+            const write_result = self.writeHeaderBlockLocked(stream.id, block, end_stream);
+            self.write_mutex.unlock();
+            if (write_result) |_| {} else |err| return self.markWriteFailure(err);
             stream.wire_opened = true;
-            if (req.body.len > 0) try self.sendBody(stream, req.body, req.end_stream);
+            if (req.body.len > 0) try self.sendBody(stream, req.body, request_body_complete);
         }
 
         /// Write a header block as HEADERS (+CONTINUATION) frames. Caller holds
@@ -895,13 +902,24 @@ pub fn H2Conn(comptime Transport: type) type {
                 const budget = try self.reserveSendWindow(stream, full_body.len - off);
                 const is_last = end_stream and (off + budget) == full_body.len;
                 const flags: u8 = if (is_last) frame.Flags.END_STREAM else 0;
-                {
-                    self.write_mutex.lock();
-                    defer self.write_mutex.unlock();
-                    try frame.writeFrame(self.transport, .data, flags, stream.id, full_body[off .. off + budget]);
-                }
+                self.write_mutex.lock();
+                const write_result = frame.writeFrame(self.transport, .data, flags, stream.id, full_body[off .. off + budget]);
+                self.write_mutex.unlock();
+                if (write_result) |_| {} else |err| return self.markWriteFailure(err);
                 off += budget;
             }
+        }
+
+        fn ensureStreamWritable(self: *Self, stream: *Stream) !void {
+            self.state_mutex.lock();
+            defer self.state_mutex.unlock();
+            if (self.conn_err) |e| return e;
+            if (stream.err) |e| return e;
+        }
+
+        fn markWriteFailure(self: *Self, err: anyerror) anyerror {
+            self.failConnection(err);
+            return err;
         }
 
         /// Reserve up to `want` bytes of send window (connection + stream),
@@ -1734,6 +1752,43 @@ const PlainTransport = struct {
     }
 };
 
+const FailingDataTransport = struct {
+    fd: std.posix.fd_t,
+    fail_next_data_payload: bool = false,
+
+    pub fn read(self: *FailingDataTransport, buf: []u8) !usize {
+        return std.posix.read(self.fd, buf) catch error.ReadFailed;
+    }
+
+    pub fn writeAll(self: *FailingDataTransport, data: []const u8) !void {
+        if (self.fail_next_data_payload) {
+            self.fail_next_data_payload = false;
+            return error.WriteFailed;
+        }
+        if (data.len == frame.HEADER_LEN and data[3] == @intFromEnum(frame.Type.data)) {
+            self.fail_next_data_payload = true;
+        }
+        var off: usize = 0;
+        while (off < data.len) {
+            const n = std.c.write(self.fd, data.ptr + off, data.len - off);
+            if (n < 0) {
+                if (std.posix.errno(n) == .INTR) continue;
+                return error.WriteFailed;
+            }
+            if (n == 0) return error.WriteFailed;
+            off += @intCast(n);
+        }
+    }
+
+    pub fn pending(_: *const FailingDataTransport) usize {
+        return 0;
+    }
+
+    pub fn close(self: *FailingDataTransport) void {
+        _ = std.c.close(self.fd);
+    }
+};
+
 fn makeSocketpair() ![2]std.posix.fd_t {
     var fds: [2]std.posix.fd_t = undefined;
     try testing.expect(std.c.socketpair(std.posix.AF.UNIX, std.posix.SOCK.STREAM, 0, &fds) == 0);
@@ -2561,7 +2616,7 @@ test "streaming request upload sends DATA incrementally and waits for flow-contr
         .scheme = "http",
         .authority = "upload.test",
         .path = "/upload",
-        .end_stream = false,
+        .body_mode = .streaming,
     });
 
     var writer_ctx = UploadWriterCtx{
@@ -2593,6 +2648,30 @@ test "streaming request upload sends DATA incrementally and waits for flow-contr
     try testing.expect(writer_ctx.ok);
     try testing.expect(blocked_observed.load(.acquire));
     try testing.expectEqualStrings("upload-ok", got.items);
+}
+
+test "streaming request upload DATA write failure poisons the h2 connection" {
+    const fds = try makeSocketpair();
+    defer _ = std.c.close(fds[1]);
+
+    var transport = FailingDataTransport{ .fd = fds[0] };
+    const conn = try H2Conn(*FailingDataTransport).init(testing.allocator, &transport, fds[0], 3000, null, null, null);
+
+    const stream = try conn.openStreaming(.{
+        .method = "POST",
+        .scheme = "http",
+        .authority = "upload.test",
+        .path = "/upload",
+        .body_mode = .streaming,
+    });
+
+    try testing.expectError(error.WriteFailed, conn.writeStreamingRequestBody(stream, "payload", true));
+    try testing.expect(!conn.healthy());
+
+    conn.finishStreaming(stream);
+    try testing.expectEqual(@as(u32, 0), conn.activeStreamCount());
+
+    conn.deinit();
 }
 
 test "h2 exchange round-trips a request and response over a socketpair" {

--- a/src/http/upstream_h2.zig
+++ b/src/http/upstream_h2.zig
@@ -81,6 +81,10 @@ pub const Request = struct {
     /// headers (and Host) are dropped before sending.
     headers: []const std.http.Header = &.{},
     body: []const u8 = "",
+    /// Whether this request's outbound body is complete after `body`.
+    /// Streaming uploads set this false, write more DATA incrementally, then
+    /// finish with a final DATA frame carrying END_STREAM.
+    end_stream: bool = true,
 };
 
 pub const Response = struct {
@@ -665,11 +669,27 @@ pub fn H2Conn(comptime Transport: type) type {
         /// downstream client backpressures its own stream while the connection
         /// window keeps other streams on the shared connection flowing.
         pub fn requestStreaming(self: *Self, req: Request) !*Stream {
+            const stream = try self.openStreaming(req);
+            errdefer self.finishStreaming(stream);
+            try self.waitStreamingResponseHead(stream);
+            return stream;
+        }
+
+        /// Start a streaming request and return immediately after the request
+        /// HEADERS and any initial `req.body` DATA have reached the wire. This
+        /// is the entry point for streaming uploads: the caller can then send
+        /// request-body DATA incrementally before waiting for response headers.
+        pub fn openStreaming(self: *Self, req: Request) !*Stream {
             const stream = try self.beginStream(true);
             errdefer self.finishStreaming(stream);
-
             try self.sendRequest(stream, req);
+            return stream;
+        }
 
+        /// Wait until response headers for an opened streaming request have
+        /// been decoded. Once this returns, `stream.status.?` and
+        /// `stream.headers.items` are stable for response-head relay.
+        pub fn waitStreamingResponseHead(self: *Self, stream: *Stream) !void {
             self.state_mutex.lock();
             stream.wait_deadline_ms = nowMs() + self.deadline_ms;
             while (!stream.headers_done and !stream.done and stream.err == null and self.conn_err == null) {
@@ -682,7 +702,23 @@ pub fn H2Conn(comptime Transport: type) type {
 
             if (stream_err) |e| return e;
             if (status == null) return error.Http2MissingStatus;
-            return stream;
+        }
+
+        /// Send one chunk of a streaming request body. `end_stream` marks the
+        /// final body chunk; when the final chunk is empty an empty DATA frame
+        /// carrying END_STREAM is sent. The method waits for connection and
+        /// stream send window with no write mutex held, preserving the actor's
+        /// lock-order invariant while backpressuring slow/flow-controlled
+        /// uploads.
+        pub fn writeStreamingRequestBody(self: *Self, stream: *Stream, chunk: []const u8, end_stream: bool) !void {
+            if (chunk.len > 0) {
+                try self.sendBody(stream, chunk, end_stream);
+                return;
+            }
+            if (!end_stream) return;
+            self.write_mutex.lock();
+            defer self.write_mutex.unlock();
+            try frame.writeFrame(self.transport, .data, frame.Flags.END_STREAM, stream.id, &[_]u8{});
         }
 
         /// Copy the next chunk of a streaming response body into `out`,
@@ -809,7 +845,7 @@ pub fn H2Conn(comptime Transport: type) type {
             const block = try hpack.encodeLiteralHeaderBlock(self.allocator, fields.items);
             defer self.allocator.free(block);
 
-            const end_stream = req.body.len == 0;
+            const end_stream = req.end_stream and req.body.len == 0;
             // HEADERS (+CONTINUATION) must be contiguous on the wire, so the
             // whole block goes out under one write_mutex hold. DATA frames may
             // interleave with other streams, so the body sender takes the lock
@@ -822,7 +858,7 @@ pub fn H2Conn(comptime Transport: type) type {
                 try self.writeHeaderBlockLocked(stream.id, block, end_stream);
             }
             stream.wire_opened = true;
-            if (req.body.len > 0) try self.sendBody(stream, req.body);
+            if (req.body.len > 0) try self.sendBody(stream, req.body, req.end_stream);
         }
 
         /// Write a header block as HEADERS (+CONTINUATION) frames. Caller holds
@@ -853,11 +889,11 @@ pub fn H2Conn(comptime Transport: type) type {
         /// window with no lock held, then takes the write mutex per frame so
         /// concurrent streams' DATA may interleave and the reader is never
         /// blocked on write_mutex behind a window wait.
-        fn sendBody(self: *Self, stream: *Stream, full_body: []const u8) !void {
+        fn sendBody(self: *Self, stream: *Stream, full_body: []const u8, end_stream: bool) !void {
             var off: usize = 0;
             while (off < full_body.len) {
                 const budget = try self.reserveSendWindow(stream, full_body.len - off);
-                const is_last = (off + budget) == full_body.len;
+                const is_last = end_stream and (off + budget) == full_body.len;
                 const flags: u8 = if (is_last) frame.Flags.END_STREAM else 0;
                 {
                     self.write_mutex.lock();
@@ -2442,6 +2478,121 @@ test "streaming and buffered requests multiplex together on one connection" {
     server.join();
     _ = std.c.close(fds[1]);
     try testing.expect(all_ok);
+}
+
+const UploadWriterCtx = struct {
+    conn: *H2Conn(*PlainTransport),
+    stream: *Stream,
+    body: []const u8,
+    done: *std.atomic.Value(bool),
+    ok: bool = false,
+};
+
+fn uploadWriterThread(ctx: *UploadWriterCtx) void {
+    ctx.conn.writeStreamingRequestBody(ctx.stream, ctx.body, true) catch return;
+    ctx.ok = true;
+    ctx.done.store(true, .release);
+}
+
+fn cannedStreamingUploadServer(peer_fd: std.posix.fd_t, writer_done: *std.atomic.Value(bool), blocked_observed: *std.atomic.Value(bool), expected_len: usize) void {
+    const a = std.heap.page_allocator;
+    var srv = PlainTransport{ .fd = peer_fd };
+    var preface: [PREFACE.len]u8 = undefined;
+    readExact(&srv, peer_fd, preface[0..], 2000) catch return;
+    frame.writeSettings(a, &srv, &[_][2]u32{}) catch return;
+
+    var req_stream: u31 = 0;
+    while (req_stream == 0) {
+        var fr = readFrameBounded(&srv, peer_fd, a, 2000) catch return;
+        if (fr.typ == .headers) req_stream = fr.stream_id;
+        frame.deinitFrame(a, &fr);
+    }
+
+    var received: usize = 0;
+    while (received < @as(usize, @intCast(PROTOCOL_DEFAULT_WINDOW))) {
+        var fr = readFrameBounded(&srv, peer_fd, a, 2000) catch return;
+        if (fr.typ == .data and fr.stream_id == req_stream) {
+            received += fr.payload.len;
+        }
+        frame.deinitFrame(a, &fr);
+    }
+
+    if (!writer_done.load(.acquire)) blocked_observed.store(true, .release);
+    const inc = windowIncrement(expected_len - received);
+    frame.writeFrame(&srv, .window_update, 0, 0, &inc) catch return;
+    frame.writeFrame(&srv, .window_update, 0, req_stream, &inc) catch return;
+
+    var saw_end = false;
+    while (!saw_end) {
+        var fr = readFrameBounded(&srv, peer_fd, a, 2000) catch return;
+        if (fr.typ == .data and fr.stream_id == req_stream) {
+            received += fr.payload.len;
+            saw_end = (fr.flags & frame.Flags.END_STREAM) != 0;
+        }
+        frame.deinitFrame(a, &fr);
+    }
+    if (received != expected_len) return;
+
+    const head = hpack.encodeLiteralHeaderBlock(a, &[_]hpack.HeaderField{
+        .{ .name = ":status", .value = "200" },
+        .{ .name = "x-uploaded-bytes", .value = "69631" },
+    }) catch return;
+    defer a.free(head);
+    frame.writeFrame(&srv, .headers, frame.Flags.END_HEADERS, req_stream, head) catch return;
+    frame.writeFrame(&srv, .data, frame.Flags.END_STREAM, req_stream, "upload-ok") catch return;
+}
+
+test "streaming request upload sends DATA incrementally and waits for flow-control window" {
+    const upload_len: usize = @as(usize, @intCast(PROTOCOL_DEFAULT_WINDOW)) + 4096;
+    const body = try testing.allocator.alloc(u8, upload_len);
+    defer testing.allocator.free(body);
+    @memset(body, 'u');
+
+    const fds = try makeSocketpair();
+    var writer_done = std.atomic.Value(bool).init(false);
+    var blocked_observed = std.atomic.Value(bool).init(false);
+    const server = try std.Thread.spawn(.{}, cannedStreamingUploadServer, .{ fds[1], &writer_done, &blocked_observed, upload_len });
+
+    var transport = PlainTransport{ .fd = fds[0] };
+    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 3000, null, null, null);
+
+    const stream = try conn.openStreaming(.{
+        .method = "POST",
+        .scheme = "http",
+        .authority = "upload.test",
+        .path = "/upload",
+        .end_stream = false,
+    });
+
+    var writer_ctx = UploadWriterCtx{
+        .conn = conn,
+        .stream = stream,
+        .body = body,
+        .done = &writer_done,
+    };
+    const writer = try std.Thread.spawn(.{}, uploadWriterThread, .{&writer_ctx});
+
+    try conn.waitStreamingResponseHead(stream);
+    try testing.expectEqual(@as(u16, 200), stream.status.?);
+
+    var got: std.ArrayList(u8) = .empty;
+    defer got.deinit(testing.allocator);
+    var buf: [32]u8 = undefined;
+    while (true) {
+        const n = try conn.readStreamingBody(stream, buf[0..]);
+        if (n == 0) break;
+        try got.appendSlice(testing.allocator, buf[0..n]);
+    }
+
+    conn.finishStreaming(stream);
+    writer.join();
+    conn.deinit();
+    server.join();
+    _ = std.c.close(fds[1]);
+
+    try testing.expect(writer_ctx.ok);
+    try testing.expect(blocked_observed.load(.acquire));
+    try testing.expectEqualStrings("upload-ok", got.items);
 }
 
 test "h2 exchange round-trips a request and response over a socketpair" {

--- a/src/http/upstream_pool.zig
+++ b/src/http/upstream_pool.zig
@@ -157,9 +157,8 @@ pub const UpstreamPool = struct {
     /// the hot proxy path need not take the pool mutex just to count.
     protocol_h1_requests: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
     protocol_h2_requests: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
-    /// Streaming uploads intentionally stay on h1 until h2 gains an
-    /// incremental request-body DATA API. Count those fallback decisions so the
-    /// deferred #145 work is visible to operators.
+    /// Count streaming uploads that requested h2/h2c but still had to use h1
+    /// because the h2 pool was unavailable for the exchange.
     h2_streaming_upload_fallbacks: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
 
     pub fn init(allocator: std.mem.Allocator, config: Config) UpstreamPool {


### PR DESCRIPTION
## Summary
- add an `openStreaming` / `waitStreamingResponseHead` split for h2 streams so uploads can send request DATA before waiting for response headers
- add incremental `writeStreamingRequestBody` DATA writes that reserve flow-control window without holding the write mutex
- route `TARDIGRADE_PROXY_STREAMING_MODE=full` h2/h2c upstreams through the h2 pool instead of falling back to h1 when the pool is available
- keep the fallback metric only for unexpected h2-pool-unavailable cases and update docs/help text

Closes #301.

## Validation
- `zig fmt build.zig src/ tests/ --check`
- `zig build test -- --test-filter "streaming request upload"`
- `zig build test --summary all --error-style verbose`
- `zig build test-integration -- --test-filter "proxy full streaming mode"`
