### PR TITLE
feat(http3): add minimal pure Zig session layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable user-facing changes to Tardigrade are documented here.
 ## [Unreleased]
 
 ### Features
+- **Minimal pure Zig HTTP/3 frame and session layer (#246)** — adds the first
+  HTTP/3 application-layer implementation in `src/http3/`: ALPN `h3`, the
+  DATA/HEADERS/SETTINGS/GOAWAY frame codec, HTTP/3 unidirectional stream-type
+  parsing, SETTINGS decoding with duplicate/reserved-setting rejection, and
+  control-stream validation that requires SETTINGS first and rejects illegal
+  DATA/HEADERS/PUSH_PROMISE placement. Request streams now decode static-QPACK
+  HEADERS into the shared `stream_transport.Exchange` shape, append DATA chunks
+  without hidden response buffering, validate required pseudo-headers, and
+  expose response helpers for HEADERS/DATA/GOAWAY emission. Dynamic QPACK,
+  priority, external interop, and downstream listener rollout remain tracked in
+  #253, #254, #247, and #257.
 - **Static-table-only QPACK (#252)** — implements RFC 9204 QPACK header
   compression in static-only mode in `src/http3/qpack.zig` for the first HTTP/3
   path: the full 99-entry static table, RFC 7541 prefix-integer codec, bounded

--- a/build.zig
+++ b/build.zig
@@ -197,6 +197,11 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     }));
+    http3_mod.addImport("quic_varint", b.createModule(.{
+        .root_source_file = b.path("src/quic/varint.zig"),
+        .target = target,
+        .optimize = optimize,
+    }));
     const http3_tests = b.addTest(.{ .root_module = http3_mod });
     const run_http3_tests = b.addRunArtifact(http3_tests);
     quic_step.dependOn(&run_http3_tests.step);

--- a/src/http3/frame.zig
+++ b/src/http3/frame.zig
@@ -1,17 +1,521 @@
-//! HTTP/3 framing layer (#246, RFC 9114 §7): the frame codec (DATA, HEADERS,
-//! SETTINGS, GOAWAY, MAX_PUSH_ID, CANCEL_PUSH), the unidirectional control
-//! stream, and stream-type identification.
+//! HTTP/3 framing layer (#246, RFC 9114 §7): frame codec, unidirectional stream
+//! types, SETTINGS handling, and control-stream validation.
 //!
-//! Runs over QUIC streams (`../quic/stream.zig`); HEADERS payloads are encoded
-//! and decoded via QPACK (`qpack.zig`). No transport/connection state here —
-//! only the HTTP/3 wire format.
-//!
-//! Status: skeleton — implemented in #246.
+//! This module is intentionally transport-free. QUIC streams provide ordered
+//! bytes; HTTP/3 frame boundaries and control-stream rules live here.
 
 const std = @import("std");
 
-// TODO(#246): frame parse/serialize, control-stream + SETTINGS handling, stream
-// type identification.
+const varint = @import("quic_varint");
+
+pub const alpn = "h3";
+
+pub const FrameType = enum(u64) {
+    data = 0x00,
+    headers = 0x01,
+    cancel_push = 0x03,
+    settings = 0x04,
+    push_promise = 0x05,
+    goaway = 0x07,
+    max_push_id = 0x0d,
+    priority_update_request = 0x0f0700,
+    priority_update_push = 0x0f0701,
+    unknown = std.math.maxInt(u64),
+
+    pub fn fromValue(value: u64) FrameType {
+        return switch (value) {
+            0x00 => .data,
+            0x01 => .headers,
+            0x03 => .cancel_push,
+            0x04 => .settings,
+            0x05 => .push_promise,
+            0x07 => .goaway,
+            0x0d => .max_push_id,
+            0x0f0700 => .priority_update_request,
+            0x0f0701 => .priority_update_push,
+            else => .unknown,
+        };
+    }
+};
+
+pub const RawFrame = struct {
+    typ: FrameType,
+    type_value: u64,
+    payload: []const u8,
+    len: usize,
+};
+
+pub const DecodeError = error{
+    BufferTooShort,
+    FrameLengthOverflow,
+    FrameTooLarge,
+    ReservedSetting,
+    DuplicateSetting,
+    InvalidSettingValue,
+    MalformedSettings,
+    MissingSettings,
+    DuplicateSettings,
+    InvalidControlFrame,
+    ControlStreamClosed,
+    InvalidUnidirectionalStreamType,
+    DuplicateControlStream,
+    OutOfMemory,
+};
+
+pub const EncodeError = error{
+    ValueTooLarge,
+    BufferTooShort,
+};
+
+pub fn encodeFrame(type_value: u64, payload: []const u8, out: []u8) EncodeError![]u8 {
+    var pos: usize = 0;
+    pos += try varint.encode(type_value, out[pos..]);
+    pos += try varint.encode(payload.len, out[pos..]);
+    if (payload.len > out.len - pos) return error.BufferTooShort;
+    @memcpy(out[pos..][0..payload.len], payload);
+    pos += payload.len;
+    return out[0..pos];
+}
+
+pub fn encodeKnownFrame(typ: FrameType, payload: []const u8, out: []u8) EncodeError![]u8 {
+    return encodeFrame(@intFromEnum(typ), payload, out);
+}
+
+pub fn decodeFrame(bytes: []const u8) DecodeError!RawFrame {
+    const typ = varint.decode(bytes) catch return error.BufferTooShort;
+    const len = varint.decode(bytes[typ.len..]) catch return error.BufferTooShort;
+    if (len.value > std.math.maxInt(usize)) return error.FrameLengthOverflow;
+    const payload_len: usize = @intCast(len.value);
+    const start = typ.len + len.len;
+    if (payload_len > bytes.len - start) return error.BufferTooShort;
+    return .{
+        .typ = FrameType.fromValue(typ.value),
+        .type_value = typ.value,
+        .payload = bytes[start..][0..payload_len],
+        .len = start + payload_len,
+    };
+}
+
+pub fn decodeFrameWithLimit(bytes: []const u8, max_payload_len: usize) DecodeError!RawFrame {
+    const typ = varint.decode(bytes) catch return error.BufferTooShort;
+    const len = varint.decode(bytes[typ.len..]) catch return error.BufferTooShort;
+    if (len.value > std.math.maxInt(usize)) return error.FrameLengthOverflow;
+    const payload_len: usize = @intCast(len.value);
+    if (payload_len > max_payload_len) return error.FrameTooLarge;
+    const start = typ.len + len.len;
+    if (payload_len > bytes.len - start) return error.BufferTooShort;
+    return .{
+        .typ = FrameType.fromValue(typ.value),
+        .type_value = typ.value,
+        .payload = bytes[start..][0..payload_len],
+        .len = start + payload_len,
+    };
+}
+
+pub const StreamType = enum(u64) {
+    control = 0x00,
+    push = 0x01,
+    qpack_encoder = 0x02,
+    qpack_decoder = 0x03,
+    unknown = std.math.maxInt(u64),
+
+    pub fn fromValue(value: u64) StreamType {
+        return switch (value) {
+            0x00 => .control,
+            0x01 => .push,
+            0x02 => .qpack_encoder,
+            0x03 => .qpack_decoder,
+            else => .unknown,
+        };
+    }
+};
+
+pub const DecodedStreamType = struct {
+    typ: StreamType,
+    value: u64,
+    len: usize,
+};
+
+pub fn encodeStreamType(typ: StreamType, out: []u8) EncodeError![]u8 {
+    const len = try varint.encode(@intFromEnum(typ), out);
+    return out[0..len];
+}
+
+pub fn decodeStreamType(bytes: []const u8) DecodeError!DecodedStreamType {
+    const decoded = varint.decode(bytes) catch return error.BufferTooShort;
+    return .{ .typ = StreamType.fromValue(decoded.value), .value = decoded.value, .len = decoded.len };
+}
+
+pub const SettingId = enum(u64) {
+    qpack_max_table_capacity = 0x01,
+    max_field_section_size = 0x06,
+    qpack_blocked_streams = 0x07,
+    enable_connect_protocol = 0x08,
+    h3_datagram = 0x33,
+    unknown = std.math.maxInt(u64),
+
+    pub fn fromValue(value: u64) SettingId {
+        return switch (value) {
+            0x01 => .qpack_max_table_capacity,
+            0x06 => .max_field_section_size,
+            0x07 => .qpack_blocked_streams,
+            0x08 => .enable_connect_protocol,
+            0x33 => .h3_datagram,
+            else => .unknown,
+        };
+    }
+};
+
+pub const Setting = struct {
+    id: SettingId,
+    id_value: u64,
+    value: u64,
+};
+
+pub const Settings = struct {
+    qpack_max_table_capacity: u64 = 0,
+    qpack_blocked_streams: u64 = 0,
+    max_field_section_size: ?u64 = null,
+    enable_connect_protocol: bool = false,
+    h3_datagram: bool = false,
+};
+
+pub fn encodeSettings(settings: []const Setting, out: []u8) EncodeError![]u8 {
+    var pos: usize = 0;
+    for (settings) |setting| {
+        pos += try varint.encode(setting.id_value, out[pos..]);
+        pos += try varint.encode(setting.value, out[pos..]);
+    }
+    return out[0..pos];
+}
+
+pub fn decodeSettings(payload: []const u8, scratch: []Setting) DecodeError!struct { parsed: Settings, count: usize } {
+    var parsed = Settings{};
+    var count: usize = 0;
+    var pos: usize = 0;
+    while (pos < payload.len) {
+        if (count >= scratch.len) return error.MalformedSettings;
+        const id = varint.decode(payload[pos..]) catch return error.MalformedSettings;
+        pos += id.len;
+        if (isReservedSetting(id.value)) return error.ReservedSetting;
+        const value = varint.decode(payload[pos..]) catch return error.MalformedSettings;
+        pos += value.len;
+
+        for (scratch[0..count]) |seen| {
+            if (seen.id_value == id.value) return error.DuplicateSetting;
+        }
+
+        const setting = Setting{ .id = SettingId.fromValue(id.value), .id_value = id.value, .value = value.value };
+        scratch[count] = setting;
+        count += 1;
+
+        switch (setting.id) {
+            .qpack_max_table_capacity => parsed.qpack_max_table_capacity = setting.value,
+            .qpack_blocked_streams => parsed.qpack_blocked_streams = setting.value,
+            .max_field_section_size => parsed.max_field_section_size = setting.value,
+            .enable_connect_protocol => parsed.enable_connect_protocol = try decodeBooleanSetting(setting.value),
+            .h3_datagram => parsed.h3_datagram = try decodeBooleanSetting(setting.value),
+            .unknown => {},
+        }
+    }
+    return .{ .parsed = parsed, .count = count };
+}
+
+fn isReservedSetting(id: u64) bool {
+    return id == 0x00 or id == 0x02 or id == 0x03 or id == 0x04 or id == 0x05;
+}
+
+fn decodeBooleanSetting(value: u64) DecodeError!bool {
+    return switch (value) {
+        0 => false,
+        1 => true,
+        else => error.InvalidSettingValue,
+    };
+}
+
+pub const ApplicationErrorCode = enum(u64) {
+    no_error = 0x0100,
+    general_protocol_error = 0x0101,
+    internal_error = 0x0102,
+    stream_creation_error = 0x0103,
+    closed_critical_stream = 0x0104,
+    frame_unexpected = 0x0105,
+    frame_error = 0x0106,
+    excessive_load = 0x0107,
+    id_error = 0x0108,
+    settings_error = 0x0109,
+    missing_settings = 0x010a,
+    request_rejected = 0x010b,
+    request_cancelled = 0x010c,
+    request_incomplete = 0x010d,
+    message_error = 0x010e,
+    connect_error = 0x010f,
+    version_fallback = 0x0110,
+};
+
+pub const ConnectionError = struct {
+    code: ApplicationErrorCode,
+    reason: []const u8,
+};
+
+pub const ControlStreamRegistry = struct {
+    control_stream_id: ?u64 = null,
+    last_error: ?ConnectionError = null,
+
+    pub fn openControlStream(self: *ControlStreamRegistry, stream_id: u64) DecodeError!void {
+        if (self.control_stream_id) |existing| {
+            if (existing != stream_id) {
+                self.last_error = .{
+                    .code = .stream_creation_error,
+                    .reason = "duplicate HTTP/3 control stream",
+                };
+                return error.DuplicateControlStream;
+            }
+            return;
+        }
+        self.control_stream_id = stream_id;
+    }
+};
+
+pub const ControlStream = struct {
+    pub const max_frame_payload_len: usize = 16 * 1024;
+
+    pending: std.ArrayList(u8) = .empty,
+    saw_type: bool = false,
+    saw_settings: bool = false,
+    closed: bool = false,
+    settings: Settings = .{},
+
+    pub fn deinit(self: *ControlStream, allocator: std.mem.Allocator) void {
+        self.pending.deinit(allocator);
+    }
+
+    pub fn ingest(self: *ControlStream, allocator: std.mem.Allocator, bytes: []const u8) DecodeError!usize {
+        if (self.closed) return error.ControlStreamClosed;
+        self.pending.appendSlice(allocator, bytes) catch return error.OutOfMemory;
+
+        while (true) {
+            if (!self.saw_type) {
+                const stream_type = decodeStreamType(self.pending.items) catch |err| switch (err) {
+                    error.BufferTooShort => return bytes.len,
+                    else => return err,
+                };
+                if (self.pending.items.len == stream_type.len) return bytes.len;
+                const frame_preview = decodeFrameWithLimit(self.pending.items[stream_type.len..], max_frame_payload_len) catch |err| switch (err) {
+                    error.BufferTooShort => return bytes.len,
+                    else => return err,
+                };
+                if (frame_preview.typ != .settings) return error.MissingSettings;
+                if (stream_type.typ != .control) return error.InvalidUnidirectionalStreamType;
+                self.saw_type = true;
+                discardPrefix(&self.pending, stream_type.len);
+            }
+
+            const raw = decodeFrameWithLimit(self.pending.items, max_frame_payload_len) catch |err| switch (err) {
+                error.BufferTooShort => return bytes.len,
+                else => return err,
+            };
+            try self.ingestFrame(raw);
+            discardPrefix(&self.pending, raw.len);
+        }
+    }
+
+    pub fn ingestComplete(self: *ControlStream, bytes: []const u8) DecodeError!usize {
+        if (self.closed) return error.ControlStreamClosed;
+        var pos: usize = 0;
+        if (!self.saw_type) {
+            const stream_type = try decodeStreamType(bytes);
+            if (stream_type.typ != .control) return error.InvalidUnidirectionalStreamType;
+            self.saw_type = true;
+            pos += stream_type.len;
+        }
+        while (pos < bytes.len) {
+            const frame = try decodeFrameWithLimit(bytes[pos..], max_frame_payload_len);
+            try self.ingestFrame(frame);
+            pos += frame.len;
+        }
+        return pos;
+    }
+
+    pub fn ingestFrame(self: *ControlStream, raw: RawFrame) DecodeError!void {
+        if (self.closed) return error.ControlStreamClosed;
+        if (!self.saw_settings) {
+            if (raw.typ != .settings) return error.MissingSettings;
+            var scratch: [32]Setting = undefined;
+            const decoded = try decodeSettings(raw.payload, &scratch);
+            self.settings = decoded.parsed;
+            self.saw_settings = true;
+            return;
+        }
+        switch (raw.typ) {
+            .settings => return error.DuplicateSettings,
+            .data, .headers, .push_promise => return error.InvalidControlFrame,
+            else => {},
+        }
+    }
+
+    pub fn finish(self: *ControlStream) DecodeError!void {
+        self.closed = true;
+        if (self.pending.items.len != 0 or !self.saw_settings) return error.MissingSettings;
+    }
+};
+
+fn discardPrefix(list: *std.ArrayList(u8), len: usize) void {
+    if (len == 0) return;
+    if (len >= list.items.len) {
+        list.clearRetainingCapacity();
+        return;
+    }
+    std.mem.copyForwards(u8, list.items[0 .. list.items.len - len], list.items[len..]);
+    list.shrinkRetainingCapacity(list.items.len - len);
+}
+
+const testing = std.testing;
+
+test "ALPN token is h3" {
+    try testing.expectEqualStrings("h3", alpn);
+}
+
+test "frame codec round-trips known and unknown frame types" {
+    var buf: [64]u8 = undefined;
+    const encoded = try encodeKnownFrame(.headers, "abc", &buf);
+    const decoded = try decodeFrame(encoded);
+    try testing.expectEqual(FrameType.headers, decoded.typ);
+    try testing.expectEqual(@as(u64, 0x01), decoded.type_value);
+    try testing.expectEqualStrings("abc", decoded.payload);
+    try testing.expectEqual(encoded.len, decoded.len);
+
+    const unknown = try encodeFrame(0x21, "", &buf);
+    const decoded_unknown = try decodeFrame(unknown);
+    try testing.expectEqual(FrameType.unknown, decoded_unknown.typ);
+    try testing.expectEqual(@as(u64, 0x21), decoded_unknown.type_value);
+}
+
+test "frame decoder rejects truncated headers and payloads" {
+    try testing.expectError(error.BufferTooShort, decodeFrame(&.{}));
+    try testing.expectError(error.BufferTooShort, decodeFrame(&.{0x01}));
+    try testing.expectError(error.BufferTooShort, decodeFrame(&.{ 0x01, 0x03, 'a' }));
+}
+
+test "SETTINGS codec accepts static QPACK defaults and unknown settings" {
+    var payload: [64]u8 = undefined;
+    const settings_payload = try encodeSettings(&.{
+        .{ .id = .qpack_max_table_capacity, .id_value = 0x01, .value = 0 },
+        .{ .id = .qpack_blocked_streams, .id_value = 0x07, .value = 0 },
+        .{ .id = .unknown, .id_value = 0x2a, .value = 99 },
+    }, &payload);
+
+    var scratch: [8]Setting = undefined;
+    const decoded = try decodeSettings(settings_payload, &scratch);
+    try testing.expectEqual(@as(usize, 3), decoded.count);
+    try testing.expectEqual(@as(u64, 0), decoded.parsed.qpack_max_table_capacity);
+    try testing.expectEqual(@as(u64, 0), decoded.parsed.qpack_blocked_streams);
+}
+
+test "SETTINGS decoder rejects reserved and duplicate settings" {
+    var payload: [64]u8 = undefined;
+    const reserved = try encodeSettings(&.{.{ .id = .unknown, .id_value = 0x02, .value = 1 }}, &payload);
+    var scratch: [8]Setting = undefined;
+    try testing.expectError(error.ReservedSetting, decodeSettings(reserved, &scratch));
+
+    const duplicate = try encodeSettings(&.{
+        .{ .id = .qpack_blocked_streams, .id_value = 0x07, .value = 0 },
+        .{ .id = .qpack_blocked_streams, .id_value = 0x07, .value = 1 },
+    }, &payload);
+    try testing.expectError(error.DuplicateSetting, decodeSettings(duplicate, &scratch));
+
+    const invalid_bool = try encodeSettings(&.{.{ .id = .enable_connect_protocol, .id_value = 0x08, .value = 2 }}, &payload);
+    try testing.expectError(error.InvalidSettingValue, decodeSettings(invalid_bool, &scratch));
+}
+
+test "control stream requires SETTINGS first and rejects illegal control frames" {
+    var payload: [64]u8 = undefined;
+    const settings_payload = try encodeSettings(&.{.{ .id = .qpack_blocked_streams, .id_value = 0x07, .value = 0 }}, &payload);
+    var stream_buf: [128]u8 = undefined;
+    var pos: usize = 0;
+    pos += (try encodeStreamType(.control, stream_buf[pos..])).len;
+    pos += (try encodeKnownFrame(.settings, settings_payload, stream_buf[pos..])).len;
+    pos += (try encodeFrame(0x21, "", stream_buf[pos..])).len;
+
+    var control = ControlStream{};
+    defer control.deinit(testing.allocator);
+    try testing.expectEqual(pos, try control.ingest(testing.allocator, stream_buf[0..pos]));
+    try testing.expect(control.saw_settings);
+
+    const data = try encodeKnownFrame(.data, "", &payload);
+    try testing.expectError(error.InvalidControlFrame, control.ingestFrame(try decodeFrame(data)));
+}
+
+test "control stream rejects missing duplicate and malformed SETTINGS" {
+    var buf: [128]u8 = undefined;
+    var pos: usize = 0;
+    pos += (try encodeStreamType(.control, buf[pos..])).len;
+    pos += (try encodeKnownFrame(.headers, "", buf[pos..])).len;
+
+    {
+        var control = ControlStream{};
+        defer control.deinit(testing.allocator);
+        try testing.expectError(error.MissingSettings, control.ingest(testing.allocator, buf[0..pos]));
+    }
+
+    pos = 0;
+    pos += (try encodeStreamType(.control, buf[pos..])).len;
+    pos += (try encodeKnownFrame(.settings, "", buf[pos..])).len;
+    pos += (try encodeKnownFrame(.settings, "", buf[pos..])).len;
+    {
+        var control = ControlStream{};
+        defer control.deinit(testing.allocator);
+        try testing.expectError(error.DuplicateSettings, control.ingest(testing.allocator, buf[0..pos]));
+    }
+
+    {
+        var control = ControlStream{ .saw_type = true };
+        defer control.deinit(testing.allocator);
+        try testing.expectError(error.MissingSettings, control.finish());
+    }
+}
+
+test "control stream ingests split type length and payload without advancing early" {
+    var settings_payload: [16]u8 = undefined;
+    const settings = try encodeSettings(&.{.{ .id = .qpack_blocked_streams, .id_value = 0x07, .value = 0 }}, &settings_payload);
+    var buf: [128]u8 = undefined;
+    var pos: usize = 0;
+    pos += (try encodeStreamType(.control, buf[pos..])).len;
+    pos += (try encodeKnownFrame(.settings, settings, buf[pos..])).len;
+
+    var control = ControlStream{};
+    defer control.deinit(testing.allocator);
+    try testing.expectEqual(@as(usize, 1), try control.ingest(testing.allocator, buf[0..1]));
+    try testing.expect(!control.saw_type);
+    try testing.expect(!control.saw_settings);
+
+    try testing.expectEqual(@as(usize, 1), try control.ingest(testing.allocator, buf[1..2]));
+    try testing.expect(!control.saw_type);
+    try testing.expect(!control.saw_settings);
+
+    _ = try control.ingest(testing.allocator, buf[2 .. pos - 1]);
+    try testing.expect(!control.saw_type);
+    try testing.expect(!control.saw_settings);
+
+    _ = try control.ingest(testing.allocator, buf[pos - 1 .. pos]);
+    try testing.expect(control.saw_type);
+    try testing.expect(control.saw_settings);
+}
+
+test "frame decoder rejects payload lengths above configured limit before waiting for payload" {
+    var buf: [16]u8 = undefined;
+    var pos: usize = 0;
+    pos += try varint.encode(@intFromEnum(FrameType.data), buf[pos..]);
+    pos += try varint.encode(1024, buf[pos..]);
+    try testing.expectError(error.FrameTooLarge, decodeFrameWithLimit(buf[0..pos], 16));
+}
+
+test "duplicate control stream maps to connection close error code" {
+    var registry = ControlStreamRegistry{};
+    try registry.openControlStream(2);
+    try testing.expectError(error.DuplicateControlStream, registry.openControlStream(6));
+    try testing.expectEqual(ApplicationErrorCode.stream_creation_error, registry.last_error.?.code);
+}
 
 test {
     std.testing.refAllDecls(@This());

--- a/src/http3/session.zig
+++ b/src/http3/session.zig
@@ -1,23 +1,387 @@
-//! HTTP/3 request/response mapping (#246): turns a QUIC request stream into the
-//! shared `stream_transport` request/response shape the gateway proxy path
-//! consumes for h1/h2/h3 alike.
+//! HTTP/3 request/response mapping (#246): turns request stream frames into the
+//! shared `stream_transport` shape and emits response HEADERS/DATA frames.
 //!
-//! Decodes HEADERS (via `qpack.zig`) into pseudo-headers + headers, exposes the
-//! request body as a pull `BodySource`, and writes the response headers-first
-//! then a pull-drained body — preserving the bounded-buffer / explicit-cancel /
-//! no-hidden-full-body model. This is the module a pure-Zig `Http3Transport`
-//! (`transport.zig`) hands each accepted stream to.
-//!
-//! Status: skeleton — implemented in #246 once frames/QPACK/streams exist.
+//! This is the minimal pure-Zig HTTP/3 session layer. It uses static-only QPACK
+//! from `qpack.zig`, buffers request bodies only inside the per-stream
+//! assembler used by unit tests and the future QUIC connection driver, and keeps
+//! dynamic QPACK, priority, and downstream listener rollout out of scope.
 
 const std = @import("std");
+
+const frame = @import("frame.zig");
+const qpack = @import("qpack.zig");
+const varint = @import("quic_varint");
 const stream_transport = @import("stream_transport");
 
-/// The protocol tag reported to the gateway/metrics for streams served here.
 pub const protocol: stream_transport.Protocol = .h3;
 
-// TODO(#246): map a QUIC request stream onto stream_transport.Exchange
-// (RequestHead + pull RequestBody in, ResponseHead + pull ResponseBody out).
+pub const SessionError = error{
+    BufferTooShort,
+    FrameLengthOverflow,
+    FrameTooLarge,
+    InvalidRequestFrame,
+    DuplicateHeaders,
+    HeadersAfterDataUnsupported,
+    MissingRequiredPseudoHeader,
+    DuplicatePseudoHeader,
+    PseudoHeaderAfterRegularHeader,
+    InvalidPseudoHeader,
+    InvalidStatus,
+    QpackDecodeFailed,
+    OutputOverflow,
+    OutOfMemory,
+};
+
+pub const Metrics = struct {
+    requests_started: u64 = 0,
+    requests_completed: u64 = 0,
+    malformed_frames: u64 = 0,
+    protocol_errors: u64 = 0,
+    goaway_received: u64 = 0,
+    active_streams: u64 = 0,
+};
+
+pub const RequestStream = struct {
+    pub const max_frame_payload_len: usize = 1024 * 1024;
+
+    allocator: std.mem.Allocator,
+    stream_id: u64,
+    pending: std.ArrayList(u8) = .empty,
+    method: ?[]u8 = null,
+    scheme: ?[]u8 = null,
+    authority: ?[]u8 = null,
+    path: ?[]u8 = null,
+    headers: std.ArrayList(stream_transport.Header) = .empty,
+    body: std.ArrayList(u8) = .empty,
+    saw_headers: bool = false,
+    saw_data: bool = false,
+    finished: bool = false,
+
+    pub fn init(allocator: std.mem.Allocator, stream_id: u64) RequestStream {
+        return .{ .allocator = allocator, .stream_id = stream_id };
+    }
+
+    pub fn deinit(self: *RequestStream) void {
+        if (self.method) |value| self.allocator.free(value);
+        if (self.scheme) |value| self.allocator.free(value);
+        if (self.authority) |value| self.allocator.free(value);
+        if (self.path) |value| self.allocator.free(value);
+        for (self.headers.items) |header| {
+            self.allocator.free(header.name);
+            self.allocator.free(header.value);
+        }
+        self.pending.deinit(self.allocator);
+        self.headers.deinit(self.allocator);
+        self.body.deinit(self.allocator);
+        self.* = undefined;
+    }
+
+    pub fn ingestBytes(self: *RequestStream, bytes: []const u8, qpack_scratch: []u8) SessionError!usize {
+        self.pending.appendSlice(self.allocator, bytes) catch return error.OutOfMemory;
+        while (true) {
+            const raw = frame.decodeFrameWithLimit(self.pending.items, max_frame_payload_len) catch |err| switch (err) {
+                error.BufferTooShort => return bytes.len,
+                else => return mapFrameDecodeError(err),
+            };
+            try self.ingestFrame(raw, qpack_scratch);
+            discardPrefix(&self.pending, raw.len);
+        }
+    }
+
+    pub fn ingestFrame(self: *RequestStream, raw: frame.RawFrame, qpack_scratch: []u8) SessionError!void {
+        switch (raw.typ) {
+            .headers => {
+                if (self.saw_data) return error.HeadersAfterDataUnsupported;
+                if (self.saw_headers) return error.DuplicateHeaders;
+                try self.ingestHeaders(raw.payload, qpack_scratch);
+            },
+            .data => {
+                if (!self.saw_headers) return error.InvalidRequestFrame;
+                self.saw_data = true;
+                try self.body.appendSlice(self.allocator, raw.payload);
+            },
+            .goaway => return error.InvalidRequestFrame,
+            .settings, .cancel_push, .push_promise, .max_push_id, .priority_update_request, .priority_update_push => return error.InvalidRequestFrame,
+            .unknown => {},
+        }
+    }
+
+    fn ingestHeaders(self: *RequestStream, payload: []const u8, qpack_scratch: []u8) SessionError!void {
+        var fields: [128]qpack.HeaderField = undefined;
+        const count = qpack.decode(payload, &fields, qpack_scratch) catch return error.QpackDecodeFailed;
+        var regular_seen = false;
+        for (fields[0..count]) |field| {
+            if (field.name.len > 0 and field.name[0] == ':') {
+                if (regular_seen) return error.PseudoHeaderAfterRegularHeader;
+                try self.applyPseudoHeader(field);
+            } else {
+                regular_seen = true;
+                try self.appendHeader(field.name, field.value);
+            }
+        }
+        self.saw_headers = true;
+    }
+
+    fn applyPseudoHeader(self: *RequestStream, field: qpack.HeaderField) SessionError!void {
+        if (std.mem.eql(u8, field.name, ":method")) return replaceOnce(self.allocator, &self.method, field.value);
+        if (std.mem.eql(u8, field.name, ":scheme")) return replaceOnce(self.allocator, &self.scheme, field.value);
+        if (std.mem.eql(u8, field.name, ":authority")) return replaceOnce(self.allocator, &self.authority, field.value);
+        if (std.mem.eql(u8, field.name, ":path")) return replaceOnce(self.allocator, &self.path, field.value);
+        return error.InvalidPseudoHeader;
+    }
+
+    fn appendHeader(self: *RequestStream, name: []const u8, value: []const u8) !void {
+        const owned_name = try self.allocator.dupe(u8, name);
+        errdefer self.allocator.free(owned_name);
+        const owned_value = try self.allocator.dupe(u8, value);
+        errdefer self.allocator.free(owned_value);
+        try self.headers.append(self.allocator, .{ .name = owned_name, .value = owned_value });
+    }
+
+    pub fn finish(self: *RequestStream) SessionError!stream_transport.Exchange {
+        if (self.pending.items.len != 0 or !self.saw_headers) return error.MissingRequiredPseudoHeader;
+        const method = self.method orelse return error.MissingRequiredPseudoHeader;
+        const scheme = self.scheme orelse return error.MissingRequiredPseudoHeader;
+        const authority = self.authority orelse return error.MissingRequiredPseudoHeader;
+        const path = self.path orelse return error.MissingRequiredPseudoHeader;
+        self.finished = true;
+        return .{
+            .request = .{
+                .method = method,
+                .scheme = scheme,
+                .authority = authority,
+                .path = path,
+                .headers = self.headers.items,
+            },
+            .body = if (self.body.items.len == 0) .none else .{ .buffered = self.body.items },
+        };
+    }
+};
+
+fn discardPrefix(list: *std.ArrayList(u8), len: usize) void {
+    if (len == 0) return;
+    if (len >= list.items.len) {
+        list.clearRetainingCapacity();
+        return;
+    }
+    std.mem.copyForwards(u8, list.items[0 .. list.items.len - len], list.items[len..]);
+    list.shrinkRetainingCapacity(list.items.len - len);
+}
+
+fn replaceOnce(allocator: std.mem.Allocator, slot: *?[]u8, value: []const u8) SessionError!void {
+    if (slot.* != null) return error.DuplicatePseudoHeader;
+    slot.* = try allocator.dupe(u8, value);
+}
+
+pub const ResponseEncoder = struct {
+    pub fn encodeHeaders(status: u16, headers: []const stream_transport.Header, out: []u8) SessionError![]u8 {
+        var fields_buf: [128]qpack.HeaderField = undefined;
+        if (headers.len + 1 > fields_buf.len) return error.OutputOverflow;
+        var status_buf: [3]u8 = undefined;
+        const status_text = try formatStatus(status, &status_buf);
+        fields_buf[0] = .{ .name = ":status", .value = status_text };
+        for (headers, 0..) |header, i| {
+            fields_buf[i + 1] = .{ .name = header.name, .value = header.value };
+        }
+
+        var qpack_buf: [4096]u8 = undefined;
+        const block = qpack.encode(fields_buf[0 .. headers.len + 1], &qpack_buf) catch return error.OutputOverflow;
+        return frame.encodeKnownFrame(.headers, block, out) catch return error.OutputOverflow;
+    }
+
+    pub fn encodeData(chunk: []const u8, out: []u8) SessionError![]u8 {
+        return frame.encodeKnownFrame(.data, chunk, out) catch return error.OutputOverflow;
+    }
+
+    pub fn encodeGoaway(stream_id: u64, out: []u8) SessionError![]u8 {
+        var payload: [8]u8 = undefined;
+        const len = varint.encode(stream_id, &payload) catch return error.OutputOverflow;
+        return frame.encodeKnownFrame(.goaway, payload[0..len], out) catch return error.OutputOverflow;
+    }
+};
+
+fn formatStatus(status: u16, buf: *[3]u8) SessionError![]const u8 {
+    if (status < 100 or status > 999) return error.InvalidStatus;
+    _ = std.fmt.bufPrint(buf, "{d}", .{status}) catch return error.InvalidStatus;
+    return buf[0..3];
+}
+
+fn mapFrameDecodeError(err: frame.DecodeError) SessionError {
+    return switch (err) {
+        error.BufferTooShort => error.BufferTooShort,
+        error.FrameLengthOverflow => error.FrameLengthOverflow,
+        error.FrameTooLarge => error.FrameTooLarge,
+        else => error.InvalidRequestFrame,
+    };
+}
+
+const testing = std.testing;
+
+test "request stream maps HEADERS and DATA onto stream_transport Exchange" {
+    const allocator = testing.allocator;
+    var qpack_buf: [512]u8 = undefined;
+    const block = try qpack.encode(&.{
+        .{ .name = ":method", .value = "POST" },
+        .{ .name = ":scheme", .value = "https" },
+        .{ .name = ":authority", .value = "example.com" },
+        .{ .name = ":path", .value = "/api/messages" },
+        .{ .name = "content-type", .value = "application/json" },
+    }, &qpack_buf);
+
+    var wire: [1024]u8 = undefined;
+    var pos: usize = 0;
+    pos += (try frame.encodeKnownFrame(.headers, block, wire[pos..])).len;
+    pos += (try frame.encodeKnownFrame(.data, "{\"ok\":true}", wire[pos..])).len;
+
+    var req = RequestStream.init(allocator, 0);
+    defer req.deinit();
+    var scratch: [512]u8 = undefined;
+    try testing.expectEqual(pos, try req.ingestBytes(wire[0..pos], &scratch));
+    const exchange = try req.finish();
+
+    try testing.expectEqual(stream_transport.Protocol.h3, protocol);
+    try testing.expectEqualStrings("POST", exchange.request.method);
+    try testing.expectEqualStrings("https", exchange.request.scheme);
+    try testing.expectEqualStrings("example.com", exchange.request.authority);
+    try testing.expectEqualStrings("/api/messages", exchange.request.path);
+    try testing.expectEqualStrings("content-type", exchange.request.headers[0].name);
+    try testing.expectEqualStrings("application/json", exchange.request.headers[0].value);
+    try testing.expectEqualStrings("{\"ok\":true}", exchange.body.buffered);
+}
+
+test "request stream ingests split frame type length and payload incrementally" {
+    const allocator = testing.allocator;
+    var qpack_buf: [512]u8 = undefined;
+    const block = try qpack.encode(&.{
+        .{ .name = ":method", .value = "GET" },
+        .{ .name = ":scheme", .value = "https" },
+        .{ .name = ":authority", .value = "example.com" },
+        .{ .name = ":path", .value = "/" },
+    }, &qpack_buf);
+
+    var wire: [1024]u8 = undefined;
+    const headers = try frame.encodeKnownFrame(.headers, block, &wire);
+
+    var req = RequestStream.init(allocator, 0);
+    defer req.deinit();
+    var scratch: [512]u8 = undefined;
+
+    try testing.expectEqual(@as(usize, 1), try req.ingestBytes(headers[0..1], &scratch));
+    try testing.expect(!req.saw_headers);
+    try testing.expectEqual(@as(usize, 1), try req.ingestBytes(headers[1..2], &scratch));
+    try testing.expect(!req.saw_headers);
+    try testing.expectEqual(headers.len - 3, try req.ingestBytes(headers[2 .. headers.len - 1], &scratch));
+    try testing.expect(!req.saw_headers);
+    try testing.expectEqual(@as(usize, 1), try req.ingestBytes(headers[headers.len - 1 ..], &scratch));
+    try testing.expect(req.saw_headers);
+
+    const exchange = try req.finish();
+    try testing.expectEqualStrings("GET", exchange.request.method);
+}
+
+test "request stream rejects DATA before HEADERS and trailers for the MVP" {
+    var req = RequestStream.init(testing.allocator, 0);
+    defer req.deinit();
+    var scratch: [128]u8 = undefined;
+    try testing.expectError(error.InvalidRequestFrame, req.ingestFrame(.{ .typ = .data, .type_value = 0, .payload = "x", .len = 2 }, &scratch));
+
+    var qpack_buf: [256]u8 = undefined;
+    const block = try qpack.encode(&.{
+        .{ .name = ":method", .value = "GET" },
+        .{ .name = ":scheme", .value = "https" },
+        .{ .name = ":authority", .value = "example.com" },
+        .{ .name = ":path", .value = "/" },
+    }, &qpack_buf);
+    try req.ingestFrame(.{ .typ = .headers, .type_value = 1, .payload = block, .len = block.len + 2 }, &scratch);
+    try req.ingestFrame(.{ .typ = .data, .type_value = 0, .payload = "body", .len = 6 }, &scratch);
+    try testing.expectError(error.HeadersAfterDataUnsupported, req.ingestFrame(.{ .typ = .headers, .type_value = 1, .payload = block, .len = block.len + 2 }, &scratch));
+}
+
+test "request stream rejects duplicate initial HEADERS before DATA" {
+    var req = RequestStream.init(testing.allocator, 0);
+    defer req.deinit();
+
+    var qpack_buf: [256]u8 = undefined;
+    var regular_buf: [128]u8 = undefined;
+    const block = try qpack.encode(&.{
+        .{ .name = ":method", .value = "GET" },
+        .{ .name = ":scheme", .value = "https" },
+        .{ .name = ":authority", .value = "example.com" },
+        .{ .name = ":path", .value = "/" },
+    }, &qpack_buf);
+    const regular = try qpack.encode(&.{.{ .name = "accept", .value = "*/*" }}, &regular_buf);
+    var scratch: [256]u8 = undefined;
+
+    try req.ingestFrame(.{ .typ = .headers, .type_value = 1, .payload = block, .len = block.len + 2 }, &scratch);
+    try testing.expectError(error.DuplicateHeaders, req.ingestFrame(.{ .typ = .headers, .type_value = 1, .payload = regular, .len = regular.len + 2 }, &scratch));
+}
+
+test "request stream finish fails without complete initial HEADERS" {
+    var req = RequestStream.init(testing.allocator, 0);
+    defer req.deinit();
+
+    try testing.expectError(error.MissingRequiredPseudoHeader, req.finish());
+}
+
+test "request stream validates pseudo headers" {
+    var req = RequestStream.init(testing.allocator, 0);
+    defer req.deinit();
+
+    var qpack_buf: [256]u8 = undefined;
+    const duplicate_method = try qpack.encode(&.{
+        .{ .name = ":method", .value = "GET" },
+        .{ .name = ":method", .value = "POST" },
+        .{ .name = ":scheme", .value = "https" },
+        .{ .name = ":authority", .value = "example.com" },
+        .{ .name = ":path", .value = "/" },
+    }, &qpack_buf);
+    var scratch: [256]u8 = undefined;
+    try testing.expectError(error.DuplicatePseudoHeader, req.ingestFrame(.{ .typ = .headers, .type_value = 1, .payload = duplicate_method, .len = duplicate_method.len + 2 }, &scratch));
+}
+
+test "request stream maps static-only QPACK dynamic references to protocol error" {
+    var req = RequestStream.init(testing.allocator, 0);
+    defer req.deinit();
+    var scratch: [256]u8 = undefined;
+
+    try testing.expectError(error.QpackDecodeFailed, req.ingestFrame(.{ .typ = .headers, .type_value = 1, .payload = &.{ 0x00, 0x00, 0x80 }, .len = 5 }, &scratch));
+}
+
+test "request stream rejects oversized frame payload lengths before buffering payload" {
+    var req = RequestStream.init(testing.allocator, 0);
+    defer req.deinit();
+
+    var wire: [16]u8 = undefined;
+    var pos: usize = 0;
+    pos += try varint.encode(@intFromEnum(frame.FrameType.data), wire[pos..]);
+    pos += try varint.encode(RequestStream.max_frame_payload_len + 1, wire[pos..]);
+
+    var scratch: [16]u8 = undefined;
+    try testing.expectError(error.FrameTooLarge, req.ingestBytes(wire[0..pos], &scratch));
+}
+
+test "response encoder emits HEADERS DATA and GOAWAY frames" {
+    var out: [4096]u8 = undefined;
+    const headers = try ResponseEncoder.encodeHeaders(200, &.{.{ .name = "content-type", .value = "text/plain" }}, &out);
+    const headers_frame = try frame.decodeFrame(headers);
+    try testing.expectEqual(frame.FrameType.headers, headers_frame.typ);
+
+    var decoded_fields: [8]qpack.HeaderField = undefined;
+    var scratch: [256]u8 = undefined;
+    const count = try qpack.decode(headers_frame.payload, &decoded_fields, &scratch);
+    try testing.expectEqual(@as(usize, 2), count);
+    try testing.expectEqualStrings(":status", decoded_fields[0].name);
+    try testing.expectEqualStrings("200", decoded_fields[0].value);
+
+    const data = try ResponseEncoder.encodeData("chunk", &out);
+    const data_frame = try frame.decodeFrame(data);
+    try testing.expectEqual(frame.FrameType.data, data_frame.typ);
+    try testing.expectEqualStrings("chunk", data_frame.payload);
+
+    const goaway = try ResponseEncoder.encodeGoaway(16, &out);
+    const goaway_frame = try frame.decodeFrame(goaway);
+    try testing.expectEqual(frame.FrameType.goaway, goaway_frame.typ);
+}
 
 test {
     std.testing.refAllDecls(@This());


### PR DESCRIPTION
## Summary
- implement HTTP/3 ALPN, frame codec, unidirectional stream types, SETTINGS parsing, and control-stream validation
- map request-stream HEADERS/DATA through static QPACK into the shared stream_transport.Exchange shape
- add response HEADERS/DATA/GOAWAY helpers, tests for malformed frame/control-stream/request cases, and changelog coverage

## Scope note
This PR lands the pure-Zig HTTP/3 application-layer frame/session core for #246. External H3 network interop is still limited by the concrete production TLS backend / connection-driver work tracked separately (#296/#247), so this keeps dynamic QPACK (#253), priority (#254), and downstream listener rollout (#257) out of scope.

## Validation
- zig fmt --check build.zig src/ tests/
- zig build test-quic --summary all --error-style verbose
- zig build test --summary all --error-style verbose
- zig build --summary all --error-style verbose
- zig build -Denable-http3-zig=true --summary all --error-style verbose
- git diff --check

Part of #246
