### PR TITLE
feat(qpack): add dynamic table support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable user-facing changes to Tardigrade are documented here.
 ## [Unreleased]
 
 ### Features
+- **Dynamic QPACK table and blocked-stream accounting (#253)** — extends
+  `src/http3/qpack.zig` beyond the static-only fallback with a bounded dynamic
+  table, memory/capacity enforcement, eviction accounting, encoder-stream
+  capacity/insert/duplicate instructions, decoder-stream section
+  ack/cancel/insert-count instructions, dynamic field-section decoding, and
+  explicit blocked-stream tracking/unblocking when Required Insert Count is
+  ahead of received encoder instructions. The existing `encode`/`decode` API
+  remains static-only and still rejects dynamic references deterministically.
 - **Minimal pure Zig HTTP/3 frame and session layer (#246)** — adds the first
   HTTP/3 application-layer implementation in `src/http3/`: ALPN `h3`, the
   DATA/HEADERS/SETTINGS/GOAWAY frame codec, HTTP/3 unidirectional stream-type

--- a/src/http3/qpack.zig
+++ b/src/http3/qpack.zig
@@ -1,13 +1,14 @@
-//! QPACK header compression — static-table-only mode (#252, RFC 9204).
+//! QPACK header compression (#252/#253, RFC 9204).
 //!
 //! Encodes/decodes the HEADERS payloads carried by `frame.zig` for the first
-//! pure Zig HTTP/3 path. This mode uses the static table only: the dynamic
-//! table capacity is zero, no encoder/decoder-stream state exists, and no
-//! stream can ever be blocked. Any dynamic-table reference in an incoming block
-//! is rejected deterministically. The dynamic table, encoder/decoder streams,
-//! and blocked-stream accounting land in #253.
+//! pure Zig HTTP/3 path. The simple `encode`/`decode` functions remain
+//! static-table-only safe fallbacks. `DynamicTable`, `EncoderStream`, and
+//! `DynamicDecoder` add bounded dynamic-table support, encoder/decoder stream
+//! accounting, and blocked-stream handling for peers that negotiate non-zero
+//! QPACK settings.
 
 const std = @import("std");
+const http3_frame = @import("frame.zig");
 const huffman = @import("hpack_huffman");
 
 /// A decoded or to-be-encoded header field. Slices borrow their backing storage
@@ -276,12 +277,24 @@ pub const DecodeError = error{
     TruncatedBlock,
     /// A prefix integer overflowed u64.
     IntegerOverflow,
+    /// A dynamic-table reference points below the eviction frontier.
+    InvalidDynamicIndex,
+    /// Decoding needs encoder-stream instructions that have not arrived yet.
+    Blocked,
+    /// A new blocked stream would exceed SETTINGS_QPACK_BLOCKED_STREAMS.
+    BlockedStreamLimitExceeded,
+    /// Dynamic table capacity would be exceeded by a single entry.
+    EntryTooLarge,
+    /// Encoder/decoder stream instruction was malformed.
+    MalformedInstruction,
     /// A Huffman-coded string was malformed.
     InvalidHuffmanCode,
     /// Caller scratch storage was too small for decoded Huffman strings.
     ScratchOverflow,
     /// More header fields than the caller-provided output can hold.
     TooManyFields,
+    /// Allocator failed while owning dynamic table/header data.
+    OutOfMemory,
 };
 
 /// Decode a QPACK encoded field section into `fields_out`, returning the number
@@ -364,6 +377,430 @@ fn readBytes(block: []const u8, pos: *usize, len: usize) DecodeError![]const u8 
     pos.* += len;
     return bytes;
 }
+
+// ---------------------------------------------------------------------------
+// Dynamic table and streams (#253)
+// ---------------------------------------------------------------------------
+
+pub const DynamicEntry = struct {
+    absolute_index: u64,
+    name: []u8,
+    value: []u8,
+
+    pub fn size(self: DynamicEntry) u64 {
+        return 32 + self.name.len + self.value.len;
+    }
+
+    fn field(self: DynamicEntry) HeaderField {
+        return .{ .name = self.name, .value = self.value };
+    }
+
+    fn deinit(self: DynamicEntry, allocator: std.mem.Allocator) void {
+        allocator.free(self.name);
+        allocator.free(self.value);
+    }
+};
+
+pub const DynamicMetrics = struct {
+    insertions: u64 = 0,
+    evictions: u64 = 0,
+    blocked_streams: u64 = 0,
+    unblocked_streams: u64 = 0,
+    cancelled_streams: u64 = 0,
+    table_bytes: u64 = 0,
+    decode_failures: u64 = 0,
+};
+
+pub const DynamicSettings = struct {
+    max_table_capacity: u64 = 0,
+    blocked_streams: u64 = 0,
+
+    pub fn fromHttp3(settings: http3_frame.Settings) DynamicSettings {
+        return .{
+            .max_table_capacity = settings.qpack_max_table_capacity,
+            .blocked_streams = settings.qpack_blocked_streams,
+        };
+    }
+
+    pub fn initTable(self: DynamicSettings, allocator: std.mem.Allocator) DynamicTable {
+        return DynamicTable.init(allocator, self.max_table_capacity);
+    }
+
+    pub fn initDecoder(self: DynamicSettings, allocator: std.mem.Allocator, table: *DynamicTable) DynamicDecoder {
+        return DynamicDecoder.init(allocator, table, self.blocked_streams);
+    }
+};
+
+pub const DynamicTable = struct {
+    allocator: std.mem.Allocator,
+    capacity: u64,
+    entries: std.ArrayList(DynamicEntry) = .empty,
+    bytes_used: u64 = 0,
+    inserted_count: u64 = 0,
+    evicted_count: u64 = 0,
+    metrics: DynamicMetrics = .{},
+
+    pub fn init(allocator: std.mem.Allocator, capacity: u64) DynamicTable {
+        return .{ .allocator = allocator, .capacity = capacity };
+    }
+
+    pub fn deinit(self: *DynamicTable) void {
+        for (self.entries.items) |entry| entry.deinit(self.allocator);
+        self.entries.deinit(self.allocator);
+        self.* = undefined;
+    }
+
+    pub fn setCapacity(self: *DynamicTable, capacity: u64) !void {
+        self.capacity = capacity;
+        try self.evictToCapacity();
+    }
+
+    pub fn insert(self: *DynamicTable, name: []const u8, value: []const u8) !u64 {
+        const entry_size = 32 + name.len + value.len;
+        if (entry_size > self.capacity) return error.EntryTooLarge;
+
+        const owned_name = try self.allocator.dupe(u8, name);
+        errdefer self.allocator.free(owned_name);
+        const owned_value = try self.allocator.dupe(u8, value);
+        errdefer self.allocator.free(owned_value);
+
+        while (self.bytes_used + entry_size > self.capacity) {
+            try self.evictOldest();
+        }
+
+        self.inserted_count += 1;
+        try self.entries.append(self.allocator, .{
+            .absolute_index = self.inserted_count,
+            .name = owned_name,
+            .value = owned_value,
+        });
+        self.bytes_used += entry_size;
+        self.metrics.insertions += 1;
+        self.metrics.table_bytes = self.bytes_used;
+        return self.inserted_count;
+    }
+
+    pub fn duplicate(self: *DynamicTable, absolute_index: u64) !u64 {
+        const entry = try self.getAbsolute(absolute_index);
+        return self.insert(entry.name, entry.value);
+    }
+
+    pub fn getAbsolute(self: *const DynamicTable, absolute_index: u64) !HeaderField {
+        if (absolute_index <= self.evicted_count) return error.InvalidDynamicIndex;
+        if (absolute_index == 0 or absolute_index > self.inserted_count) return error.Blocked;
+        for (self.entries.items) |entry| {
+            if (entry.absolute_index == absolute_index) return entry.field();
+        }
+        return error.InvalidDynamicIndex;
+    }
+
+    pub fn getRelative(self: *const DynamicTable, base: u64, relative_index: u64) !HeaderField {
+        if (relative_index > base) return error.InvalidDynamicIndex;
+        return self.getAbsolute(base - relative_index);
+    }
+
+    pub fn getPostBase(self: *const DynamicTable, base: u64, post_base_index: u64) !HeaderField {
+        return self.getAbsolute(base + post_base_index + 1);
+    }
+
+    fn evictToCapacity(self: *DynamicTable) !void {
+        while (self.bytes_used > self.capacity) try self.evictOldest();
+        self.metrics.table_bytes = self.bytes_used;
+    }
+
+    fn evictOldest(self: *DynamicTable) !void {
+        if (self.entries.items.len == 0) return;
+        const removed = self.entries.orderedRemove(0);
+        self.bytes_used -= removed.size();
+        self.evicted_count = removed.absolute_index;
+        self.metrics.evictions += 1;
+        removed.deinit(self.allocator);
+    }
+};
+
+pub const BlockedStream = struct {
+    stream_id: u64,
+    required_insert_count: u64,
+};
+
+pub const BlockedStreams = struct {
+    allocator: std.mem.Allocator,
+    max_blocked: u64,
+    streams: std.AutoHashMap(u64, BlockedStream),
+
+    pub fn init(allocator: std.mem.Allocator, max_blocked: u64) BlockedStreams {
+        return .{
+            .allocator = allocator,
+            .max_blocked = max_blocked,
+            .streams = std.AutoHashMap(u64, BlockedStream).init(allocator),
+        };
+    }
+
+    pub fn deinit(self: *BlockedStreams) void {
+        self.streams.deinit();
+    }
+
+    pub fn waitFor(self: *BlockedStreams, stream_id: u64, required_insert_count: u64, metrics: *DynamicMetrics) !void {
+        if (self.streams.get(stream_id)) |blocked| {
+            if (required_insert_count > blocked.required_insert_count) {
+                try self.streams.put(stream_id, .{ .stream_id = stream_id, .required_insert_count = required_insert_count });
+            }
+            return;
+        }
+        if (self.streams.count() >= self.max_blocked) return error.BlockedStreamLimitExceeded;
+        try self.streams.put(stream_id, .{ .stream_id = stream_id, .required_insert_count = required_insert_count });
+        metrics.blocked_streams += 1;
+    }
+
+    pub fn cancel(self: *BlockedStreams, stream_id: u64, metrics: *DynamicMetrics) void {
+        if (self.streams.fetchRemove(stream_id) != null) metrics.cancelled_streams += 1;
+    }
+
+    pub fn unblockAvailable(self: *BlockedStreams, inserted_count: u64, out: []u64, metrics: *DynamicMetrics) usize {
+        var count: usize = 0;
+        var it = self.streams.iterator();
+        while (it.next()) |entry| {
+            if (entry.value_ptr.required_insert_count <= inserted_count) {
+                if (count < out.len) out[count] = entry.key_ptr.*;
+                count += 1;
+            }
+        }
+        const remove_count = @min(count, out.len);
+        for (out[0..remove_count]) |stream_id| {
+            _ = self.streams.remove(stream_id);
+            metrics.unblocked_streams += 1;
+        }
+        return remove_count;
+    }
+};
+
+pub const DynamicDecodeResult = union(enum) {
+    decoded: usize,
+    blocked: u64,
+};
+
+pub const DynamicDecoder = struct {
+    table: *DynamicTable,
+    blocked: BlockedStreams,
+
+    pub fn init(allocator: std.mem.Allocator, table: *DynamicTable, max_blocked: u64) DynamicDecoder {
+        return .{ .table = table, .blocked = BlockedStreams.init(allocator, max_blocked) };
+    }
+
+    pub fn deinit(self: *DynamicDecoder) void {
+        self.blocked.deinit();
+    }
+
+    pub fn decodeOrBlock(self: *DynamicDecoder, stream_id: u64, block: []const u8, fields_out: []HeaderField, scratch: []u8) !DynamicDecodeResult {
+        const prefix = try decodeFieldSectionPrefix(block);
+        if (prefix.required_insert_count > self.table.inserted_count) {
+            try self.blocked.waitFor(stream_id, prefix.required_insert_count, &self.table.metrics);
+            return .{ .blocked = prefix.required_insert_count };
+        }
+        const count = decodeDynamicWithPrefix(block[prefix.len..], prefix, self.table, fields_out, scratch) catch |err| {
+            self.table.metrics.decode_failures += 1;
+            return err;
+        };
+        self.blocked.cancel(stream_id, &self.table.metrics);
+        return .{ .decoded = count };
+    }
+};
+
+const FieldSectionPrefix = struct {
+    required_insert_count: u64,
+    base: u64,
+    len: usize,
+};
+
+fn decodeFieldSectionPrefix(block: []const u8) DecodeError!FieldSectionPrefix {
+    var pos: usize = 0;
+    const ric = try decodeInteger(block[pos..], 8);
+    pos += ric.len;
+    if (pos >= block.len) return error.TruncatedBlock;
+    const base_sign = block[pos] & 0x80 != 0;
+    const base_delta = try decodeInteger(block[pos..], 7);
+    pos += base_delta.len;
+    if (!base_sign and base_delta.value > ric.value) return error.InvalidBase;
+    const base = if (base_sign) ric.value + base_delta.value else ric.value - base_delta.value;
+    return .{ .required_insert_count = ric.value, .base = base, .len = pos };
+}
+
+fn decodeDynamicWithPrefix(block: []const u8, prefix: FieldSectionPrefix, table: *const DynamicTable, fields_out: []HeaderField, scratch: []u8) DecodeError!usize {
+    var pos: usize = 0;
+    var scratch_pos: usize = 0;
+    var count: usize = 0;
+    while (pos < block.len) {
+        if (count >= fields_out.len) return error.TooManyFields;
+        const first = block[pos];
+        if (first & 0x80 != 0) {
+            const int = try decodeInteger(block[pos..], 6);
+            pos += int.len;
+            fields_out[count] = if (first & 0x40 != 0)
+                staticEntry(@intCast(int.value)) orelse return error.InvalidStaticIndex
+            else
+                try table.getRelative(prefix.base, int.value);
+        } else if (first & 0xc0 == 0x40) {
+            const int = try decodeInteger(block[pos..], 4);
+            pos += int.len;
+            const name = if (first & 0x10 != 0)
+                (staticEntry(@intCast(int.value)) orelse return error.InvalidStaticIndex).name
+            else
+                (try table.getRelative(prefix.base, int.value)).name;
+            const value = try decodeString(block, &pos, scratch, &scratch_pos);
+            fields_out[count] = .{ .name = name, .value = value };
+        } else if (first & 0xe0 == 0x20) {
+            const is_huffman = first & 0x08 != 0;
+            const name_len = try decodeInteger(block[pos..], 3);
+            pos += name_len.len;
+            const name_bytes = try readBytes(block, &pos, @intCast(name_len.value));
+            const name = if (is_huffman) try decodeHuffman(name_bytes, scratch, &scratch_pos) else name_bytes;
+            const value = try decodeString(block, &pos, scratch, &scratch_pos);
+            fields_out[count] = .{ .name = name, .value = value };
+        } else if (first & 0xf0 == 0x10) {
+            const int = try decodeInteger(block[pos..], 4);
+            pos += int.len;
+            fields_out[count] = try table.getPostBase(prefix.base, int.value);
+        } else {
+            const int = try decodeInteger(block[pos..], 3);
+            pos += int.len;
+            const name = (try table.getPostBase(prefix.base, int.value)).name;
+            const value = try decodeString(block, &pos, scratch, &scratch_pos);
+            fields_out[count] = .{ .name = name, .value = value };
+        }
+        count += 1;
+    }
+    return count;
+}
+
+pub fn encodeDynamicIndexed(table: *const DynamicTable, absolute_index: u64, out: []u8) ![]u8 {
+    if (absolute_index == 0 or absolute_index > table.inserted_count) return error.InvalidDynamicIndex;
+    var pos: usize = 0;
+    pos += try encodeInteger(table.inserted_count, 8, 0x00, out[pos..]);
+    pos += try encodeInteger(0, 7, 0x00, out[pos..]);
+    pos += try encodeInteger(table.inserted_count - absolute_index, 6, 0x80, out[pos..]);
+    return out[0..pos];
+}
+
+pub const EncoderStream = struct {
+    pub fn encodeSetCapacity(capacity: u64, out: []u8) ![]u8 {
+        const len = try encodeInteger(capacity, 5, 0x20, out);
+        return out[0..len];
+    }
+
+    pub fn encodeInsertNameRefStatic(static_index: u64, value: []const u8, out: []u8) ![]u8 {
+        var pos: usize = 0;
+        pos += try encodeInteger(static_index, 6, 0xc0, out[pos..]);
+        pos += try encodeString(value, out, pos);
+        return out[0..pos];
+    }
+
+    pub fn encodeInsertNameRefDynamic(relative_index: u64, value: []const u8, out: []u8) ![]u8 {
+        var pos: usize = 0;
+        pos += try encodeInteger(relative_index, 6, 0x80, out[pos..]);
+        pos += try encodeString(value, out, pos);
+        return out[0..pos];
+    }
+
+    pub fn encodeInsertLiteral(name: []const u8, value: []const u8, out: []u8) ![]u8 {
+        var pos: usize = 0;
+        pos += try encodeStringWithPrefix(name, 5, 0x40, out, pos);
+        pos += try encodeString(value, out, pos);
+        return out[0..pos];
+    }
+
+    pub fn encodeDuplicate(relative_index: u64, out: []u8) ![]u8 {
+        const len = try encodeInteger(relative_index, 5, 0x00, out);
+        return out[0..len];
+    }
+
+    pub fn apply(table: *DynamicTable, bytes: []const u8) !usize {
+        var pos: usize = 0;
+        while (pos < bytes.len) {
+            const first = bytes[pos];
+            if (first & 0x80 != 0) {
+                const is_static = first & 0x40 != 0;
+                const name_ref = try decodeInteger(bytes[pos..], 6);
+                pos += name_ref.len;
+                const name = if (is_static)
+                    (staticEntry(@intCast(name_ref.value)) orelse return error.InvalidStaticIndex).name
+                else
+                    (try table.getRelative(table.inserted_count, name_ref.value)).name;
+                var value_scratch: [1024]u8 = undefined;
+                var value_scratch_pos: usize = 0;
+                const value = try decodeString(bytes, &pos, &value_scratch, &value_scratch_pos);
+                _ = try table.insert(name, value);
+            } else if (first & 0xe0 == 0x20) {
+                const cap = try decodeInteger(bytes[pos..], 5);
+                pos += cap.len;
+                try table.setCapacity(cap.value);
+            } else if (first & 0xc0 == 0x40) {
+                const is_huffman = first & 0x20 != 0;
+                const name_len = try decodeInteger(bytes[pos..], 5);
+                pos += name_len.len;
+                const name_bytes = try readBytes(bytes, &pos, @intCast(name_len.value));
+                var name_scratch: [512]u8 = undefined;
+                var name_scratch_pos: usize = 0;
+                const name = if (is_huffman) try decodeHuffman(name_bytes, &name_scratch, &name_scratch_pos) else name_bytes;
+                var value_scratch: [1024]u8 = undefined;
+                var value_scratch_pos: usize = 0;
+                const value = try decodeString(bytes, &pos, &value_scratch, &value_scratch_pos);
+                _ = try table.insert(name, value);
+            } else if (first & 0xe0 == 0x00) {
+                const rel = try decodeInteger(bytes[pos..], 5);
+                pos += rel.len;
+                const absolute = table.inserted_count - rel.value;
+                _ = try table.duplicate(absolute);
+            } else {
+                return error.MalformedInstruction;
+            }
+        }
+        return pos;
+    }
+};
+
+pub const DecoderInstruction = union(enum) {
+    section_ack: u64,
+    stream_cancel: u64,
+    insert_count_increment: u64,
+};
+
+pub const DecoderStream = struct {
+    known_received_count: u64 = 0,
+    section_acks: u64 = 0,
+    stream_cancellations: u64 = 0,
+
+    pub fn encode(instruction: DecoderInstruction, out: []u8) ![]u8 {
+        const len = switch (instruction) {
+            .section_ack => |stream_id| try encodeInteger(stream_id, 7, 0x80, out),
+            .stream_cancel => |stream_id| try encodeInteger(stream_id, 6, 0x40, out),
+            .insert_count_increment => |increment| try encodeInteger(increment, 6, 0x00, out),
+        };
+        return out[0..len];
+    }
+
+    pub fn apply(self: *DecoderStream, bytes: []const u8) !usize {
+        var pos: usize = 0;
+        while (pos < bytes.len) {
+            const first = bytes[pos];
+            if (first & 0x80 != 0) {
+                const stream_id = try decodeInteger(bytes[pos..], 7);
+                _ = stream_id.value;
+                pos += stream_id.len;
+                self.section_acks += 1;
+            } else if (first & 0xc0 == 0x40) {
+                const stream_id = try decodeInteger(bytes[pos..], 6);
+                _ = stream_id.value;
+                pos += stream_id.len;
+                self.stream_cancellations += 1;
+            } else {
+                const inc = try decodeInteger(bytes[pos..], 6);
+                pos += inc.len;
+                self.known_received_count += inc.value;
+            }
+        }
+        return pos;
+    }
+};
 
 // ---------------------------------------------------------------------------
 // Metrics
@@ -537,10 +974,11 @@ test "decoder rejects truncated blocks and malformed Huffman strings without lea
 }
 
 test "static-only mode keeps zero dynamic capacity and no blocked streams" {
-    // These invariants are structural: there is no dynamic table state to grow
-    // and no blocked-stream accounting in this module.
-    try testing.expect(!@hasDecl(@This(), "DynamicTable"));
-    try testing.expect(!@hasDecl(@This(), "BlockedStreams"));
+    // The simple decode API remains the safe static-only fallback: dynamic refs
+    // still fail deterministically unless callers opt into DynamicDecoder.
+    var out: [4]HeaderField = undefined;
+    var scratch: [16]u8 = undefined;
+    try testing.expectError(error.DynamicTableReference, decode(&.{ 0x00, 0x00, 0x80 }, &out, &scratch));
 }
 
 test "metrics count decode failures" {
@@ -550,4 +988,176 @@ test "metrics count decode failures" {
     metrics.recordDecode(decode(&.{ 0x00, 0x00, 0xc0 | 17 }, &out, &scratch)); // ok (:method GET)
     metrics.recordDecode(decode(&.{ 0x00, 0x00, 0x80 }, &out, &scratch)); // dynamic ref -> failure
     try testing.expectEqual(@as(u64, 1), metrics.decode_failures);
+}
+
+test "dynamic table inserts evicts and enforces capacity" {
+    var table = DynamicTable.init(testing.allocator, 96);
+    defer table.deinit();
+
+    const first = try table.insert("a", "one");
+    const second = try table.insert("b", "two");
+    try testing.expectEqual(@as(u64, 1), first);
+    try testing.expectEqual(@as(u64, 2), second);
+    try testing.expectEqual(@as(u64, 2), table.inserted_count);
+    try testing.expectEqualStrings("one", (try table.getAbsolute(first)).value);
+
+    _ = try table.insert("c", "three");
+    try testing.expectError(error.InvalidDynamicIndex, table.getAbsolute(first));
+    try testing.expectEqual(@as(u64, 1), table.metrics.evictions);
+    try testing.expect(table.bytes_used <= table.capacity);
+
+    try testing.expectError(error.EntryTooLarge, table.insert("oversized", "this-value-is-larger-than-the-small-table-capacity-by-a-wide-margin"));
+}
+
+test "dynamic settings initialize table capacity and blocked-stream limit" {
+    var payload: [32]u8 = undefined;
+    const encoded = try http3_frame.encodeSettings(&.{
+        .{ .id = .qpack_max_table_capacity, .id_value = 0x01, .value = 128 },
+        .{ .id = .qpack_blocked_streams, .id_value = 0x07, .value = 2 },
+    }, &payload);
+    var scratch_settings: [4]http3_frame.Setting = undefined;
+    const decoded = try http3_frame.decodeSettings(encoded, &scratch_settings);
+
+    const settings = DynamicSettings.fromHttp3(decoded.parsed);
+    var table = settings.initTable(testing.allocator);
+    defer table.deinit();
+    var decoder = settings.initDecoder(testing.allocator, &table);
+    defer decoder.deinit();
+
+    try testing.expectEqual(@as(u64, 128), table.capacity);
+    try testing.expectEqual(@as(u64, 2), decoder.blocked.max_blocked);
+}
+
+test "encoder stream applies capacity insert and duplicate instructions" {
+    var table = DynamicTable.init(testing.allocator, 128);
+    defer table.deinit();
+
+    var stream: [256]u8 = undefined;
+    var pos: usize = 0;
+    pos += (try EncoderStream.encodeSetCapacity(128, stream[pos..])).len;
+    pos += (try EncoderStream.encodeInsertLiteral("x-test", "one", stream[pos..])).len;
+    pos += (try EncoderStream.encodeDuplicate(0, stream[pos..])).len;
+
+    try testing.expectEqual(pos, try EncoderStream.apply(&table, stream[0..pos]));
+    try testing.expectEqual(@as(u64, 2), table.inserted_count);
+    try testing.expectEqualStrings("one", (try table.getAbsolute(2)).value);
+}
+
+test "encoder stream inserts entries with static and dynamic name references" {
+    var table = DynamicTable.init(testing.allocator, 256);
+    defer table.deinit();
+
+    var stream: [256]u8 = undefined;
+    var pos: usize = 0;
+    pos += (try EncoderStream.encodeInsertNameRefStatic(0, "https", stream[pos..])).len;
+    pos += (try EncoderStream.encodeInsertNameRefDynamic(0, "https-alt", stream[pos..])).len;
+
+    try testing.expectEqual(pos, try EncoderStream.apply(&table, stream[0..pos]));
+    const static_ref = try table.getAbsolute(1);
+    try testing.expectEqualStrings(":authority", static_ref.name);
+    try testing.expectEqualStrings("https", static_ref.value);
+    const dynamic_ref = try table.getAbsolute(2);
+    try testing.expectEqualStrings(":authority", dynamic_ref.name);
+    try testing.expectEqualStrings("https-alt", dynamic_ref.value);
+}
+
+test "dynamic indexed field section decodes once encoder stream arrives" {
+    var table = DynamicTable.init(testing.allocator, 128);
+    defer table.deinit();
+    const absolute = try table.insert("x-dyn", "value");
+
+    var block_buf: [64]u8 = undefined;
+    const block = try encodeDynamicIndexed(&table, absolute, &block_buf);
+    var out: [4]HeaderField = undefined;
+    var scratch: [64]u8 = undefined;
+    var decoder = DynamicDecoder.init(testing.allocator, &table, 4);
+    defer decoder.deinit();
+
+    const result = try decoder.decodeOrBlock(1, block, &out, &scratch);
+    try testing.expectEqual(DynamicDecodeResult{ .decoded = 1 }, result);
+    try testing.expectEqualStrings("x-dyn", out[0].name);
+    try testing.expectEqualStrings("value", out[0].value);
+}
+
+test "dynamic decoder blocks then unblocks delayed encoder instructions" {
+    var table = DynamicTable.init(testing.allocator, 128);
+    defer table.deinit();
+    var decoder = DynamicDecoder.init(testing.allocator, &table, 1);
+    defer decoder.deinit();
+
+    // Required Insert Count 1, Base 1, relative dynamic index 0.
+    const block = [_]u8{ 0x01, 0x00, 0x80 };
+    var out: [4]HeaderField = undefined;
+    var scratch: [64]u8 = undefined;
+    const blocked = try decoder.decodeOrBlock(9, &block, &out, &scratch);
+    try testing.expectEqual(DynamicDecodeResult{ .blocked = 1 }, blocked);
+    try testing.expectEqual(@as(u64, 1), table.metrics.blocked_streams);
+
+    _ = try table.insert("late", "arrived");
+    var unblocked: [4]u64 = undefined;
+    try testing.expectEqual(@as(usize, 1), decoder.blocked.unblockAvailable(table.inserted_count, &unblocked, &table.metrics));
+    try testing.expectEqual(@as(u64, 9), unblocked[0]);
+
+    const decoded = try decoder.decodeOrBlock(9, &block, &out, &scratch);
+    try testing.expectEqual(DynamicDecodeResult{ .decoded = 1 }, decoded);
+    try testing.expectEqualStrings("late", out[0].name);
+    try testing.expectEqualStrings("arrived", out[0].value);
+}
+
+test "dynamic decoder rejects invalid base delta before blocking" {
+    var table = DynamicTable.init(testing.allocator, 128);
+    defer table.deinit();
+    var decoder = DynamicDecoder.init(testing.allocator, &table, 1);
+    defer decoder.deinit();
+
+    // Required Insert Count 1 with a negative base delta larger than RIC.
+    const block = [_]u8{ 0x01, 0x02, 0x80 };
+    var out: [4]HeaderField = undefined;
+    var scratch: [64]u8 = undefined;
+    try testing.expectError(error.InvalidBase, decoder.decodeOrBlock(9, &block, &out, &scratch));
+    try testing.expectEqual(@as(u64, 0), decoder.blocked.streams.count());
+}
+
+test "blocked stream limit and cancellation are enforced" {
+    var table = DynamicTable.init(testing.allocator, 128);
+    defer table.deinit();
+    var decoder = DynamicDecoder.init(testing.allocator, &table, 1);
+    defer decoder.deinit();
+
+    const block = [_]u8{ 0x02, 0x00, 0x80 };
+    var out: [4]HeaderField = undefined;
+    var scratch: [64]u8 = undefined;
+    _ = try decoder.decodeOrBlock(1, &block, &out, &scratch);
+    try testing.expectError(error.BlockedStreamLimitExceeded, decoder.decodeOrBlock(2, &block, &out, &scratch));
+
+    decoder.blocked.cancel(1, &table.metrics);
+    try testing.expectEqual(@as(u64, 1), table.metrics.cancelled_streams);
+    _ = try decoder.decodeOrBlock(2, &block, &out, &scratch);
+}
+
+test "decoder stream instructions update acknowledgement state" {
+    var buf: [32]u8 = undefined;
+    var pos: usize = 0;
+    pos += (try DecoderStream.encode(.{ .section_ack = 11 }, buf[pos..])).len;
+    pos += (try DecoderStream.encode(.{ .stream_cancel = 13 }, buf[pos..])).len;
+    pos += (try DecoderStream.encode(.{ .insert_count_increment = 3 }, buf[pos..])).len;
+
+    var stream = DecoderStream{};
+    try testing.expectEqual(pos, try stream.apply(buf[0..pos]));
+    try testing.expectEqual(@as(u64, 1), stream.section_acks);
+    try testing.expectEqual(@as(u64, 1), stream.stream_cancellations);
+    try testing.expectEqual(@as(u64, 3), stream.known_received_count);
+}
+
+test "dynamic table memory remains bounded under repeated inserts" {
+    var table = DynamicTable.init(testing.allocator, 160);
+    defer table.deinit();
+
+    for (0..20) |i| {
+        var name_buf: [16]u8 = undefined;
+        const name = try std.fmt.bufPrint(&name_buf, "x-{d}", .{i});
+        _ = try table.insert(name, "payload");
+        try testing.expect(table.bytes_used <= table.capacity);
+    }
+    try testing.expect(table.metrics.evictions > 0);
 }

--- a/src/http3/qpack.zig
+++ b/src/http3/qpack.zig
@@ -287,6 +287,8 @@ pub const DecodeError = error{
     EntryTooLarge,
     /// Encoder/decoder stream instruction was malformed.
     MalformedInstruction,
+    /// A peer tried to grow the dynamic table above the negotiated maximum.
+    CapacityExceeded,
     /// A Huffman-coded string was malformed.
     InvalidHuffmanCode,
     /// Caller scratch storage was too small for decoded Huffman strings.
@@ -388,7 +390,8 @@ pub const DynamicEntry = struct {
     value: []u8,
 
     pub fn size(self: DynamicEntry) u64 {
-        return 32 + self.name.len + self.value.len;
+        const with_name = std.math.add(u64, 32, self.name.len) catch return std.math.maxInt(u64);
+        return std.math.add(u64, with_name, self.value.len) catch return std.math.maxInt(u64);
     }
 
     fn field(self: DynamicEntry) HeaderField {
@@ -423,7 +426,7 @@ pub const DynamicSettings = struct {
     }
 
     pub fn initTable(self: DynamicSettings, allocator: std.mem.Allocator) DynamicTable {
-        return DynamicTable.init(allocator, self.max_table_capacity);
+        return DynamicTable.initNegotiated(allocator, self.max_table_capacity);
     }
 
     pub fn initDecoder(self: DynamicSettings, allocator: std.mem.Allocator, table: *DynamicTable) DynamicDecoder {
@@ -433,6 +436,7 @@ pub const DynamicSettings = struct {
 
 pub const DynamicTable = struct {
     allocator: std.mem.Allocator,
+    max_capacity: u64,
     capacity: u64,
     entries: std.ArrayList(DynamicEntry) = .empty,
     bytes_used: u64 = 0,
@@ -441,7 +445,11 @@ pub const DynamicTable = struct {
     metrics: DynamicMetrics = .{},
 
     pub fn init(allocator: std.mem.Allocator, capacity: u64) DynamicTable {
-        return .{ .allocator = allocator, .capacity = capacity };
+        return .{ .allocator = allocator, .max_capacity = capacity, .capacity = capacity };
+    }
+
+    pub fn initNegotiated(allocator: std.mem.Allocator, max_capacity: u64) DynamicTable {
+        return .{ .allocator = allocator, .max_capacity = max_capacity, .capacity = 0 };
     }
 
     pub fn deinit(self: *DynamicTable) void {
@@ -451,12 +459,14 @@ pub const DynamicTable = struct {
     }
 
     pub fn setCapacity(self: *DynamicTable, capacity: u64) !void {
+        if (capacity > self.max_capacity) return error.CapacityExceeded;
         self.capacity = capacity;
         try self.evictToCapacity();
     }
 
     pub fn insert(self: *DynamicTable, name: []const u8, value: []const u8) !u64 {
-        const entry_size = 32 + name.len + value.len;
+        const name_size = std.math.add(u64, 32, name.len) catch return error.IntegerOverflow;
+        const entry_size = std.math.add(u64, name_size, value.len) catch return error.IntegerOverflow;
         if (entry_size > self.capacity) return error.EntryTooLarge;
 
         const owned_name = try self.allocator.dupe(u8, name);
@@ -468,7 +478,7 @@ pub const DynamicTable = struct {
             try self.evictOldest();
         }
 
-        self.inserted_count += 1;
+        self.inserted_count = std.math.add(u64, self.inserted_count, 1) catch return error.IntegerOverflow;
         try self.entries.append(self.allocator, .{
             .absolute_index = self.inserted_count,
             .name = owned_name,
@@ -500,7 +510,9 @@ pub const DynamicTable = struct {
     }
 
     pub fn getPostBase(self: *const DynamicTable, base: u64, post_base_index: u64) !HeaderField {
-        return self.getAbsolute(base + post_base_index + 1);
+        const plus_index = std.math.add(u64, base, post_base_index) catch return error.IntegerOverflow;
+        const absolute = std.math.add(u64, plus_index, 1) catch return error.IntegerOverflow;
+        return self.getAbsolute(absolute);
     }
 
     fn evictToCapacity(self: *DynamicTable) !void {
@@ -592,7 +604,7 @@ pub const DynamicDecoder = struct {
     }
 
     pub fn decodeOrBlock(self: *DynamicDecoder, stream_id: u64, block: []const u8, fields_out: []HeaderField, scratch: []u8) !DynamicDecodeResult {
-        const prefix = try decodeFieldSectionPrefix(block);
+        const prefix = try decodeFieldSectionPrefix(block, self.table);
         if (prefix.required_insert_count > self.table.inserted_count) {
             try self.blocked.waitFor(stream_id, prefix.required_insert_count, &self.table.metrics);
             return .{ .blocked = prefix.required_insert_count };
@@ -612,17 +624,37 @@ const FieldSectionPrefix = struct {
     len: usize,
 };
 
-fn decodeFieldSectionPrefix(block: []const u8) DecodeError!FieldSectionPrefix {
+fn decodeFieldSectionPrefix(block: []const u8, table: *const DynamicTable) DecodeError!FieldSectionPrefix {
     var pos: usize = 0;
-    const ric = try decodeInteger(block[pos..], 8);
-    pos += ric.len;
+    const encoded_ric = try decodeInteger(block[pos..], 8);
+    pos += encoded_ric.len;
+    const required_insert_count = try decodeRequiredInsertCount(encoded_ric.value, table);
     if (pos >= block.len) return error.TruncatedBlock;
     const base_sign = block[pos] & 0x80 != 0;
     const base_delta = try decodeInteger(block[pos..], 7);
     pos += base_delta.len;
-    if (!base_sign and base_delta.value > ric.value) return error.InvalidBase;
-    const base = if (base_sign) ric.value + base_delta.value else ric.value - base_delta.value;
-    return .{ .required_insert_count = ric.value, .base = base, .len = pos };
+    const base = if (!base_sign) blk: {
+        break :blk std.math.add(u64, required_insert_count, base_delta.value) catch return error.IntegerOverflow;
+    } else blk: {
+        if (required_insert_count <= base_delta.value) return error.InvalidBase;
+        break :blk required_insert_count - base_delta.value - 1;
+    };
+    return .{ .required_insert_count = required_insert_count, .base = base, .len = pos };
+}
+
+fn decodeRequiredInsertCount(encoded: u64, table: *const DynamicTable) DecodeError!u64 {
+    if (encoded == 0) return 0;
+    const max_entries = table.max_capacity / 32;
+    const full_range = std.math.mul(u64, 2, max_entries) catch return error.IntegerOverflow;
+    if (full_range == 0 or encoded > full_range) return error.InvalidRequiredInsertCount;
+
+    const max_value = std.math.add(u64, table.inserted_count, max_entries) catch return error.IntegerOverflow;
+    const max_wrapped = (max_value / full_range) * full_range;
+    var required = std.math.add(u64, max_wrapped, encoded - 1) catch return error.IntegerOverflow;
+    if (required == 0) return error.InvalidRequiredInsertCount;
+    if (required > max_value) required -= full_range;
+    if (required == 0) return error.InvalidRequiredInsertCount;
+    return required;
 }
 
 fn decodeDynamicWithPrefix(block: []const u8, prefix: FieldSectionPrefix, table: *const DynamicTable, fields_out: []HeaderField, scratch: []u8) DecodeError!usize {
@@ -675,10 +707,17 @@ fn decodeDynamicWithPrefix(block: []const u8, prefix: FieldSectionPrefix, table:
 pub fn encodeDynamicIndexed(table: *const DynamicTable, absolute_index: u64, out: []u8) ![]u8 {
     if (absolute_index == 0 or absolute_index > table.inserted_count) return error.InvalidDynamicIndex;
     var pos: usize = 0;
-    pos += try encodeInteger(table.inserted_count, 8, 0x00, out[pos..]);
+    pos += try encodeInteger(try encodeRequiredInsertCount(table, table.inserted_count), 8, 0x00, out[pos..]);
     pos += try encodeInteger(0, 7, 0x00, out[pos..]);
     pos += try encodeInteger(table.inserted_count - absolute_index, 6, 0x80, out[pos..]);
     return out[0..pos];
+}
+
+fn encodeRequiredInsertCount(table: *const DynamicTable, required_insert_count: u64) !u64 {
+    if (required_insert_count == 0) return 0;
+    const full_range = try std.math.mul(u64, 2, table.max_capacity / 32);
+    if (full_range == 0) return error.InvalidRequiredInsertCount;
+    return (required_insert_count % full_range) + 1;
 }
 
 pub const EncoderStream = struct {
@@ -716,47 +755,98 @@ pub const EncoderStream = struct {
     pub fn apply(table: *DynamicTable, bytes: []const u8) !usize {
         var pos: usize = 0;
         while (pos < bytes.len) {
-            const first = bytes[pos];
-            if (first & 0x80 != 0) {
-                const is_static = first & 0x40 != 0;
-                const name_ref = try decodeInteger(bytes[pos..], 6);
-                pos += name_ref.len;
-                const name = if (is_static)
-                    (staticEntry(@intCast(name_ref.value)) orelse return error.InvalidStaticIndex).name
-                else
-                    (try table.getRelative(table.inserted_count, name_ref.value)).name;
-                var value_scratch: [1024]u8 = undefined;
-                var value_scratch_pos: usize = 0;
-                const value = try decodeString(bytes, &pos, &value_scratch, &value_scratch_pos);
-                _ = try table.insert(name, value);
-            } else if (first & 0xe0 == 0x20) {
-                const cap = try decodeInteger(bytes[pos..], 5);
-                pos += cap.len;
-                try table.setCapacity(cap.value);
-            } else if (first & 0xc0 == 0x40) {
-                const is_huffman = first & 0x20 != 0;
-                const name_len = try decodeInteger(bytes[pos..], 5);
-                pos += name_len.len;
-                const name_bytes = try readBytes(bytes, &pos, @intCast(name_len.value));
-                var name_scratch: [512]u8 = undefined;
-                var name_scratch_pos: usize = 0;
-                const name = if (is_huffman) try decodeHuffman(name_bytes, &name_scratch, &name_scratch_pos) else name_bytes;
-                var value_scratch: [1024]u8 = undefined;
-                var value_scratch_pos: usize = 0;
-                const value = try decodeString(bytes, &pos, &value_scratch, &value_scratch_pos);
-                _ = try table.insert(name, value);
-            } else if (first & 0xe0 == 0x00) {
-                const rel = try decodeInteger(bytes[pos..], 5);
-                pos += rel.len;
-                const absolute = table.inserted_count - rel.value;
-                _ = try table.duplicate(absolute);
-            } else {
-                return error.MalformedInstruction;
-            }
+            const consumed = try applyOne(table, bytes[pos..]) orelse return error.TruncatedBlock;
+            pos += consumed;
+        }
+        return pos;
+    }
+
+    fn applyOne(table: *DynamicTable, bytes: []const u8) !?usize {
+        if (bytes.len == 0) return null;
+        var pos: usize = 0;
+        const first = bytes[pos];
+        if (first & 0x80 != 0) {
+            const is_static = first & 0x40 != 0;
+            const name_ref = decodeInteger(bytes[pos..], 6) catch |err| return if (err == error.TruncatedBlock) null else err;
+            pos += name_ref.len;
+            const name = if (is_static)
+                (staticEntry(@intCast(name_ref.value)) orelse return error.InvalidStaticIndex).name
+            else
+                (try table.getRelative(table.inserted_count, name_ref.value)).name;
+            const value = decodeStringForInsert(table, bytes, &pos) catch |err| return if (err == error.TruncatedBlock) null else err;
+            defer value.deinit(table.allocator);
+            _ = try table.insert(name, value.bytes);
+        } else if (first & 0xe0 == 0x20) {
+            const cap = decodeInteger(bytes[pos..], 5) catch |err| return if (err == error.TruncatedBlock) null else err;
+            pos += cap.len;
+            try table.setCapacity(cap.value);
+        } else if (first & 0xc0 == 0x40) {
+            const name = decodeStringWithPrefixForInsert(table, bytes, &pos, 5) catch |err| return if (err == error.TruncatedBlock) null else err;
+            defer name.deinit(table.allocator);
+            const value = decodeStringForInsert(table, bytes, &pos) catch |err| return if (err == error.TruncatedBlock) null else err;
+            defer value.deinit(table.allocator);
+            _ = try table.insert(name.bytes, value.bytes);
+        } else if (first & 0xe0 == 0x00) {
+            const rel = decodeInteger(bytes[pos..], 5) catch |err| return if (err == error.TruncatedBlock) null else err;
+            pos += rel.len;
+            if (rel.value > table.inserted_count) return error.InvalidDynamicIndex;
+            const absolute = table.inserted_count - rel.value;
+            _ = try table.duplicate(absolute);
+        } else {
+            return error.MalformedInstruction;
         }
         return pos;
     }
 };
+
+pub const EncoderStreamReader = struct {
+    pending: std.ArrayList(u8) = .empty,
+
+    pub fn deinit(self: *EncoderStreamReader, allocator: std.mem.Allocator) void {
+        self.pending.deinit(allocator);
+    }
+
+    pub fn ingest(self: *EncoderStreamReader, allocator: std.mem.Allocator, table: *DynamicTable, bytes: []const u8) !usize {
+        try self.pending.appendSlice(allocator, bytes);
+        var consumed: usize = 0;
+        while (consumed < self.pending.items.len) {
+            const applied = try EncoderStream.applyOne(table, self.pending.items[consumed..]) orelse break;
+            consumed += applied;
+        }
+        discardPendingPrefix(&self.pending, consumed);
+        return bytes.len;
+    }
+};
+
+const DecodedInsertString = struct {
+    bytes: []const u8,
+    allocation: ?[]u8 = null,
+
+    fn deinit(self: DecodedInsertString, allocator: std.mem.Allocator) void {
+        if (self.allocation) |allocation| allocator.free(allocation);
+    }
+};
+
+fn decodeStringForInsert(table: *DynamicTable, block: []const u8, pos: *usize) !DecodedInsertString {
+    return decodeStringWithPrefixForInsert(table, block, pos, 7);
+}
+
+fn decodeStringWithPrefixForInsert(table: *DynamicTable, block: []const u8, pos: *usize, n: u4) !DecodedInsertString {
+    if (pos.* >= block.len) return error.TruncatedBlock;
+    const huffman_bit: u8 = @as(u8, 1) << @intCast(n);
+    const is_huffman = block[pos.*] & huffman_bit != 0;
+    const len = try decodeInteger(block[pos.*..], n);
+    pos.* += len.len;
+    const bytes = try readBytes(block, pos, @intCast(len.value));
+    if (!is_huffman) return .{ .bytes = bytes };
+
+    if (table.capacity > std.math.maxInt(usize)) return error.IntegerOverflow;
+    const scratch = try table.allocator.alloc(u8, @intCast(table.capacity));
+    errdefer table.allocator.free(scratch);
+    var scratch_pos: usize = 0;
+    const decoded = try decodeHuffman(bytes, scratch, &scratch_pos);
+    return .{ .bytes = decoded, .allocation = scratch };
+}
 
 pub const DecoderInstruction = union(enum) {
     section_ack: u64,
@@ -781,26 +871,63 @@ pub const DecoderStream = struct {
     pub fn apply(self: *DecoderStream, bytes: []const u8) !usize {
         var pos: usize = 0;
         while (pos < bytes.len) {
-            const first = bytes[pos];
-            if (first & 0x80 != 0) {
-                const stream_id = try decodeInteger(bytes[pos..], 7);
-                _ = stream_id.value;
-                pos += stream_id.len;
-                self.section_acks += 1;
-            } else if (first & 0xc0 == 0x40) {
-                const stream_id = try decodeInteger(bytes[pos..], 6);
-                _ = stream_id.value;
-                pos += stream_id.len;
-                self.stream_cancellations += 1;
-            } else {
-                const inc = try decodeInteger(bytes[pos..], 6);
-                pos += inc.len;
-                self.known_received_count += inc.value;
-            }
+            const consumed = try self.applyOne(bytes[pos..]) orelse return error.TruncatedBlock;
+            pos += consumed;
+        }
+        return pos;
+    }
+
+    fn applyOne(self: *DecoderStream, bytes: []const u8) !?usize {
+        if (bytes.len == 0) return null;
+        var pos: usize = 0;
+        const first = bytes[pos];
+        if (first & 0x80 != 0) {
+            const stream_id = decodeInteger(bytes[pos..], 7) catch |err| return if (err == error.TruncatedBlock) null else err;
+            _ = stream_id.value;
+            pos += stream_id.len;
+            self.section_acks = std.math.add(u64, self.section_acks, 1) catch return error.IntegerOverflow;
+        } else if (first & 0xc0 == 0x40) {
+            const stream_id = decodeInteger(bytes[pos..], 6) catch |err| return if (err == error.TruncatedBlock) null else err;
+            _ = stream_id.value;
+            pos += stream_id.len;
+            self.stream_cancellations = std.math.add(u64, self.stream_cancellations, 1) catch return error.IntegerOverflow;
+        } else {
+            const inc = decodeInteger(bytes[pos..], 6) catch |err| return if (err == error.TruncatedBlock) null else err;
+            pos += inc.len;
+            self.known_received_count = std.math.add(u64, self.known_received_count, inc.value) catch return error.IntegerOverflow;
         }
         return pos;
     }
 };
+
+pub const DecoderStreamReader = struct {
+    pending: std.ArrayList(u8) = .empty,
+
+    pub fn deinit(self: *DecoderStreamReader, allocator: std.mem.Allocator) void {
+        self.pending.deinit(allocator);
+    }
+
+    pub fn ingest(self: *DecoderStreamReader, allocator: std.mem.Allocator, stream: *DecoderStream, bytes: []const u8) !usize {
+        try self.pending.appendSlice(allocator, bytes);
+        var consumed: usize = 0;
+        while (consumed < self.pending.items.len) {
+            const applied = try stream.applyOne(self.pending.items[consumed..]) orelse break;
+            consumed += applied;
+        }
+        discardPendingPrefix(&self.pending, consumed);
+        return bytes.len;
+    }
+};
+
+fn discardPendingPrefix(list: *std.ArrayList(u8), len: usize) void {
+    if (len == 0) return;
+    if (len >= list.items.len) {
+        list.clearRetainingCapacity();
+        return;
+    }
+    std.mem.copyForwards(u8, list.items[0 .. list.items.len - len], list.items[len..]);
+    list.shrinkRetainingCapacity(list.items.len - len);
+}
 
 // ---------------------------------------------------------------------------
 // Metrics
@@ -1024,8 +1151,26 @@ test "dynamic settings initialize table capacity and blocked-stream limit" {
     var decoder = settings.initDecoder(testing.allocator, &table);
     defer decoder.deinit();
 
-    try testing.expectEqual(@as(u64, 128), table.capacity);
+    try testing.expectEqual(@as(u64, 128), table.max_capacity);
+    try testing.expectEqual(@as(u64, 0), table.capacity);
     try testing.expectEqual(@as(u64, 2), decoder.blocked.max_blocked);
+}
+
+test "dynamic table capacity is capped by negotiated SETTINGS and can be lowered to zero" {
+    var table = DynamicTable.initNegotiated(testing.allocator, 128);
+    defer table.deinit();
+
+    try table.setCapacity(128);
+    _ = try table.insert("x-test", "one");
+    try testing.expect(table.bytes_used > 0);
+
+    try testing.expectError(error.CapacityExceeded, table.setCapacity(129));
+    try testing.expectEqual(@as(u64, 128), table.capacity);
+
+    try table.setCapacity(0);
+    try testing.expectEqual(@as(u64, 0), table.capacity);
+    try testing.expectEqual(@as(u64, 0), table.bytes_used);
+    try testing.expectEqual(@as(usize, 0), table.entries.items.len);
 }
 
 test "encoder stream applies capacity insert and duplicate instructions" {
@@ -1061,6 +1206,63 @@ test "encoder stream inserts entries with static and dynamic name references" {
     try testing.expectEqualStrings("https-alt", dynamic_ref.value);
 }
 
+test "encoder stream accepts values larger than fixed scratch buffers" {
+    var table = DynamicTable.init(testing.allocator, 4096);
+    defer table.deinit();
+
+    var value: [1500]u8 = undefined;
+    @memset(&value, 'a');
+    var stream: [2048]u8 = undefined;
+    const encoded = try EncoderStream.encodeInsertLiteral("x-large", &value, &stream);
+
+    try testing.expectEqual(encoded.len, try EncoderStream.apply(&table, encoded));
+    const entry = try table.getAbsolute(1);
+    try testing.expectEqualStrings("x-large", entry.name);
+    try testing.expectEqualStrings(&value, entry.value);
+}
+
+test "encoder stream rejects oversized duplicate relative index" {
+    var table = DynamicTable.init(testing.allocator, 128);
+    defer table.deinit();
+
+    var stream: [16]u8 = undefined;
+    const encoded = try EncoderStream.encodeDuplicate(1, &stream);
+    try testing.expectError(error.InvalidDynamicIndex, EncoderStream.apply(&table, encoded));
+}
+
+test "encoder stream reader handles split instructions without replay" {
+    var table = DynamicTable.initNegotiated(testing.allocator, 256);
+    defer table.deinit();
+    var reader = EncoderStreamReader{};
+    defer reader.deinit(testing.allocator);
+
+    var set_capacity_buf: [16]u8 = undefined;
+    const set_capacity = try EncoderStream.encodeSetCapacity(128, &set_capacity_buf);
+    try testing.expectEqual(@as(usize, 1), try reader.ingest(testing.allocator, &table, set_capacity[0..1]));
+    try testing.expectEqual(@as(u64, 0), table.capacity);
+    try testing.expectEqual(@as(usize, 1), reader.pending.items.len);
+    try testing.expectEqual(@as(usize, set_capacity.len - 1), try reader.ingest(testing.allocator, &table, set_capacity[1..]));
+    try testing.expectEqual(@as(u64, 128), table.capacity);
+    try testing.expectEqual(@as(usize, 0), reader.pending.items.len);
+
+    var insert_buf: [64]u8 = undefined;
+    const insert = try EncoderStream.encodeInsertLiteral("x-split", "value", &insert_buf);
+    try testing.expectEqual(@as(usize, 2), try reader.ingest(testing.allocator, &table, insert[0..2]));
+    try testing.expectEqual(@as(u64, 0), table.inserted_count);
+    try testing.expectEqual(insert.len - 2, try reader.ingest(testing.allocator, &table, insert[2..]));
+    try testing.expectEqual(@as(u64, 1), table.inserted_count);
+
+    var combined: [128]u8 = undefined;
+    var pos: usize = 0;
+    pos += (try EncoderStream.encodeSetCapacity(128, combined[pos..])).len;
+    const second_insert = try EncoderStream.encodeInsertLiteral("x-once", "one", combined[pos..]);
+    pos += 1;
+    try testing.expectEqual(pos, try reader.ingest(testing.allocator, &table, combined[0..pos]));
+    try testing.expectEqual(@as(u64, 1), table.inserted_count);
+    try testing.expectEqual(second_insert.len - 1, try reader.ingest(testing.allocator, &table, combined[pos .. pos + second_insert.len - 1]));
+    try testing.expectEqual(@as(u64, 2), table.inserted_count);
+}
+
 test "dynamic indexed field section decodes once encoder stream arrives" {
     var table = DynamicTable.init(testing.allocator, 128);
     defer table.deinit();
@@ -1079,14 +1281,59 @@ test "dynamic indexed field section decodes once encoder stream arrives" {
     try testing.expectEqualStrings("value", out[0].value);
 }
 
+test "dynamic field prefix handles both base directions" {
+    var table = DynamicTable.init(testing.allocator, 128);
+    defer table.deinit();
+    _ = try table.insert("first", "one");
+    _ = try table.insert("second", "two");
+    var out: [4]HeaderField = undefined;
+    var scratch: [64]u8 = undefined;
+    var decoder = DynamicDecoder.init(testing.allocator, &table, 4);
+    defer decoder.deinit();
+
+    // Encoded RIC 2 => Required Insert Count 1; S=0, DeltaBase=1 => Base 2.
+    const positive_delta = [_]u8{ 0x02, 0x01, 0x80 };
+    const positive = try decoder.decodeOrBlock(1, &positive_delta, &out, &scratch);
+    try testing.expectEqual(DynamicDecodeResult{ .decoded = 1 }, positive);
+    try testing.expectEqualStrings("second", out[0].name);
+
+    // Encoded RIC 3 => Required Insert Count 2; S=1, DeltaBase=0 => Base 1.
+    const negative_delta = [_]u8{ 0x03, 0x80, 0x80 };
+    const negative = try decoder.decodeOrBlock(3, &negative_delta, &out, &scratch);
+    try testing.expectEqual(DynamicDecodeResult{ .decoded = 1 }, negative);
+    try testing.expectEqualStrings("first", out[0].name);
+}
+
+test "dynamic field prefix reconstructs wrapped required insert count" {
+    var table = DynamicTable.init(testing.allocator, 128);
+    defer table.deinit();
+    for (0..10) |i| {
+        var name_buf: [16]u8 = undefined;
+        const name = try std.fmt.bufPrint(&name_buf, "x-{d}", .{i});
+        _ = try table.insert(name, "v");
+    }
+    var out: [4]HeaderField = undefined;
+    var scratch: [64]u8 = undefined;
+    var decoder = DynamicDecoder.init(testing.allocator, &table, 4);
+    defer decoder.deinit();
+
+    // max_entries=4, full_range=8, inserted_count=10. Encoded RIC 2
+    // reconstructs Required Insert Count 9.
+    const block = [_]u8{ 0x02, 0x00, 0x80 };
+    const result = try decoder.decodeOrBlock(9, &block, &out, &scratch);
+    try testing.expectEqual(DynamicDecodeResult{ .decoded = 1 }, result);
+    try testing.expectEqualStrings("x-8", out[0].name);
+}
+
 test "dynamic decoder blocks then unblocks delayed encoder instructions" {
     var table = DynamicTable.init(testing.allocator, 128);
     defer table.deinit();
     var decoder = DynamicDecoder.init(testing.allocator, &table, 1);
     defer decoder.deinit();
 
-    // Required Insert Count 1, Base 1, relative dynamic index 0.
-    const block = [_]u8{ 0x01, 0x00, 0x80 };
+    // Encoded Required Insert Count 2 => Required Insert Count 1, Base 1,
+    // relative dynamic index 0.
+    const block = [_]u8{ 0x02, 0x00, 0x80 };
     var out: [4]HeaderField = undefined;
     var scratch: [64]u8 = undefined;
     const blocked = try decoder.decodeOrBlock(9, &block, &out, &scratch);
@@ -1104,14 +1351,30 @@ test "dynamic decoder blocks then unblocks delayed encoder instructions" {
     try testing.expectEqualStrings("arrived", out[0].value);
 }
 
+test "dynamic decoder rejects post-base index overflow" {
+    var table = DynamicTable.init(testing.allocator, 128);
+    defer table.deinit();
+    var decoder = DynamicDecoder.init(testing.allocator, &table, 1);
+    defer decoder.deinit();
+
+    var block: [16]u8 = undefined;
+    var pos: usize = 0;
+    pos += try encodeInteger(0, 8, 0x00, block[pos..]);
+    pos += try encodeInteger(0, 7, 0x00, block[pos..]);
+    pos += try encodeInteger(std.math.maxInt(u64), 4, 0x10, block[pos..]);
+    var out: [4]HeaderField = undefined;
+    var scratch: [64]u8 = undefined;
+    try testing.expectError(error.IntegerOverflow, decoder.decodeOrBlock(1, block[0..pos], &out, &scratch));
+}
+
 test "dynamic decoder rejects invalid base delta before blocking" {
     var table = DynamicTable.init(testing.allocator, 128);
     defer table.deinit();
     var decoder = DynamicDecoder.init(testing.allocator, &table, 1);
     defer decoder.deinit();
 
-    // Required Insert Count 1 with a negative base delta larger than RIC.
-    const block = [_]u8{ 0x01, 0x02, 0x80 };
+    // Required Insert Count 1 with a negative base delta equal to RIC.
+    const block = [_]u8{ 0x02, 0x81, 0x80 };
     var out: [4]HeaderField = undefined;
     var scratch: [64]u8 = undefined;
     try testing.expectError(error.InvalidBase, decoder.decodeOrBlock(9, &block, &out, &scratch));
@@ -1124,7 +1387,7 @@ test "blocked stream limit and cancellation are enforced" {
     var decoder = DynamicDecoder.init(testing.allocator, &table, 1);
     defer decoder.deinit();
 
-    const block = [_]u8{ 0x02, 0x00, 0x80 };
+    const block = [_]u8{ 0x03, 0x00, 0x80 };
     var out: [4]HeaderField = undefined;
     var scratch: [64]u8 = undefined;
     _ = try decoder.decodeOrBlock(1, &block, &out, &scratch);
@@ -1147,6 +1410,28 @@ test "decoder stream instructions update acknowledgement state" {
     try testing.expectEqual(@as(u64, 1), stream.section_acks);
     try testing.expectEqual(@as(u64, 1), stream.stream_cancellations);
     try testing.expectEqual(@as(u64, 3), stream.known_received_count);
+}
+
+test "decoder stream rejects insert count overflow" {
+    var buf: [16]u8 = undefined;
+    const encoded = try DecoderStream.encode(.{ .insert_count_increment = 1 }, &buf);
+    var stream = DecoderStream{ .known_received_count = std.math.maxInt(u64) };
+    try testing.expectError(error.IntegerOverflow, stream.apply(encoded));
+}
+
+test "decoder stream reader handles split varints" {
+    var buf: [16]u8 = undefined;
+    const encoded = try DecoderStream.encode(.{ .insert_count_increment = 128 }, &buf);
+    var stream = DecoderStream{};
+    var reader = DecoderStreamReader{};
+    defer reader.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 1), try reader.ingest(testing.allocator, &stream, encoded[0..1]));
+    try testing.expectEqual(@as(u64, 0), stream.known_received_count);
+    try testing.expectEqual(@as(usize, 1), reader.pending.items.len);
+    try testing.expectEqual(encoded.len - 1, try reader.ingest(testing.allocator, &stream, encoded[1..]));
+    try testing.expectEqual(@as(u64, 128), stream.known_received_count);
+    try testing.expectEqual(@as(usize, 0), reader.pending.items.len);
 }
 
 test "dynamic table memory remains bounded under repeated inserts" {

--- a/src/http3/session.zig
+++ b/src/http3/session.zig
@@ -1,10 +1,12 @@
 //! HTTP/3 request/response mapping (#246): turns request stream frames into the
 //! shared `stream_transport` shape and emits response HEADERS/DATA frames.
 //!
-//! This is the minimal pure-Zig HTTP/3 session layer. It uses static-only QPACK
-//! from `qpack.zig`, buffers request bodies only inside the per-stream
-//! assembler used by unit tests and the future QUIC connection driver, and keeps
-//! dynamic QPACK, priority, and downstream listener rollout out of scope.
+//! This is the minimal pure-Zig HTTP/3 session layer. The request/response
+//! helpers still use the static-only QPACK fallback from `qpack.zig` while the
+//! dynamic table and encoder/decoder stream state are exposed separately for
+//! negotiated HTTP/3 connections. Request bodies are buffered only inside the
+//! per-stream assembler used by unit tests and the future QUIC connection
+//! driver; priority and downstream listener rollout remain out of scope.
 
 const std = @import("std");
 


### PR DESCRIPTION
## Summary
- add bounded QPACK dynamic table support with insert, duplicate, eviction, table-byte metrics, and dynamic index lookup
- add encoder-stream and decoder-stream instruction helpers, including insert-with-name-reference, section ack, stream cancel, and insert count increment handling
- add dynamic field-section decoding with blocked-stream accounting/unblocking, SETTINGS-derived dynamic capacity/blocked-stream initialization, and static-only fallback behavior preserved
- append the changelog entry for #253

Closes #253

## Validation
- `zig fmt --check build.zig src/ tests/`
- `zig build test-quic --summary all --error-style verbose`
- `zig build test --summary all --error-style verbose`
- `zig build --summary all --error-style verbose`
- `zig build -Denable-http3-zig=true --summary all --error-style verbose`
- `git diff --check`
