### PR TITLE
fix(test): keep expected log output off stderr during zig build test

### DIFF
--- a/src/http/access_log.zig
+++ b/src/http/access_log.zig
@@ -367,6 +367,13 @@ test "AccessLog format parse" {
 }
 
 test "AccessLogEntry log does not panic" {
+    // Swallow the emitted line: anything a test writes to the real stderr makes
+    // the zig build runner print the step with a red "failed command:" banner
+    // even though the step succeeds.
+    resetSinkForTest();
+    sink_override = swallowingSink;
+    defer resetSinkForTest();
+
     const entry = AccessLogEntry{
         .method = "GET",
         .path = "/status/metrics",
@@ -383,6 +390,7 @@ test "AccessLogEntry log does not panic" {
         .error_category = "-",
     };
     entry.log();
+    try std.testing.expectEqual(@as(u64, 0), droppedLines());
 }
 
 test "formatEntry json contains required fields" {
@@ -463,6 +471,10 @@ test "formatEntryInto reuses a scratch buffer and matches formatEntry" {
 
 fn rejectingSink(_: []const u8) usize {
     return 0; // simulate a sink that accepts nothing (slow/unavailable)
+}
+
+fn swallowingSink(bytes: []const u8) usize {
+    return bytes.len; // accept everything, write nowhere
 }
 
 test "buffered access log stays bounded and counts drops when the sink stalls" {

--- a/src/http/request_lifecycle.zig
+++ b/src/http/request_lifecycle.zig
@@ -108,6 +108,13 @@ test "RequestLifecycle: timeout in the future, not yet stopped" {
 }
 
 test "RequestLifecycle: checkDeadline on past deadline cancels once and returns true" {
+    // checkDeadline logs the timeout at warn level by design; keep the expected
+    // line off stderr, where the zig build runner would render the passing step
+    // with a red "failed command:" banner.
+    const previous_log_level = std.testing.log_level;
+    std.testing.log_level = .err;
+    defer std.testing.log_level = previous_log_level;
+
     var lc = RequestLifecycle.init("req-3", 0);
     // Manually force an already-elapsed deadline.
     lc.token.deadline_ms = 1; // epoch+1ms is always in the past


### PR DESCRIPTION
## Summary
- Every `zig build test` run printed an alarming red `failed command: ./.zig-cache/o/.../test ... --listen=-` banner even though the build **succeeded** (exit 0, 930/931 tests passing, 1 skipped). The suite was fine; the output was misleading enough that it was reported as a real failure.
- Root cause is not IPC corruption as first suspected (the access logger already writes to stderr, not stdout): the Zig 0.16 build runner unconditionally renders any step whose child produced stderr output through its error printer — "No matter the result, we want to display error/warning messages" (`compiler/build_runner.zig`) — and that printer ends with the red `failed command:` line even for passing steps.
- Two tests leaked one stderr line each:
  - `AccessLogEntry log does not panic` (`src/http/access_log.zig`) emitted a real JSON access-log line via the no-global-state `writeLine` fallback. It now routes through the module's existing `sink_override` test hook with a swallowing sink, and additionally asserts no bytes were dropped.
  - `RequestLifecycle: checkDeadline on past deadline cancels once and returns true` (`src/http/request_lifecycle.zig`) logs its expected timeout warning via `std.log.warn`. The test now scopes `std.testing.log_level = .err` (saved/restored) around the expected warning.

## Test plan
- [x] `zig build test` before: exit 0 but stderr shows the JSON access line, the timeout warning, and the red `failed command:` banner
- [x] `zig build test` after: exit 0 with **zero output** on stdout and stderr
- [x] `zig build test --summary all`: all steps succeed, 756+9+106+59 tests pass (1 skip), including both modified tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)