### PR TITLE
feat(quic): implement CID routing, path validation, and migration policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable user-facing changes to Tardigrade are documented here.
 ## [Unreleased]
 
 ### Features
+- **QUIC CID routing, path validation, and migration policy (#251)** — the
+  pure-Zig transport gains connection-ID lifecycle and path handling:
+  `cid.zig` adds caller-entropy CID generation, a DCID→connection
+  `CidRoutingTable` (routing independent of the UDP 4-tuple, with hit/miss
+  counters), a `LocalCidRegistry` for issued CIDs (NEW_CONNECTION_ID models
+  with derived stateless-reset tokens, RETIRE_CONNECTION_ID consumption,
+  peer active-CID-limit enforcement) and a `PeerCidPool` for received CIDs
+  (RFC 9000 §19.15 validation, retire_prior_to sweeps, queued retirements,
+  and fresh-CID claims for migration). `path.zig` adds a `PathManager` keyed
+  by the (local, remote) address tuple: PATH_CHALLENGE/PATH_RESPONSE
+  validation with deterministic expiry, NAT-rebinding vs. migration
+  classification, gating by the configurable migration policy
+  (disabled / NAT-rebinding-only / full), and metrics distinguishing
+  rebinding, migration, validation failure, blocked attempts, and unknown-CID
+  traffic. Real migrations (host change) reset RTT/congestion state via the
+  new `RecoveryController.resetForPathMigration` (RFC 9000 §9.4); port-only
+  rebindings keep it. Retired CIDs stop routing immediately, and a
+  10k-iteration churn test pins the routing table against leaks.
 - **Local pure-Zig H3 connection-driver smoke harness (#314)** — the first
   stitched end-to-end path for the pure-Zig QUIC stack under the #247
   validation umbrella: `tests/quic_h3_smoke.zig` drives a deterministic

--- a/src/quic/cid.zig
+++ b/src/quic/cid.zig
@@ -2,19 +2,352 @@
 //! lookup/routing, retirement, and stateless-reset token derivation.
 //!
 //! The UDP endpoint (`udp.zig`) demultiplexes incoming datagrams to a
-//! connection by destination CID via the lookup table owned here; NEW/RETIRE
-//! CONNECTION_ID frame handling and the active-CID limit from `config.zig` also
-//! live here. Deeper migration/path lifecycle is `path.zig`.
-//!
-//! Status: stateless-reset token derivation and reset-packet emission land with
-//! #250; CID generation/lookup/retirement lifecycle in #251.
+//! connection by destination CID via `CidRoutingTable`, so packets route to the
+//! right connection independent of the UDP 4-tuple. `LocalCidRegistry` owns the
+//! CIDs this endpoint issued (NEW_CONNECTION_ID emission, RETIRE_CONNECTION_ID
+//! consumption); `PeerCidPool` tracks the CIDs the peer issued to us
+//! (NEW_CONNECTION_ID consumption, retire_prior_to, and the fresh-CID pick a
+//! path migration needs per RFC 9000 §9.5). Frame structs are wire-free state
+//! models like `stream.zig`'s; the packet codec owns the byte encoding.
+//! Deeper migration/path lifecycle is `path.zig`.
 
 const std = @import("std");
 const udp = @import("udp.zig");
 
 const HmacSha256 = std.crypto.auth.hmac.sha2.HmacSha256;
 
-// TODO(#251): CID generation/lookup/retirement and the active-CID limit.
+pub const ConnectionId = udp.ConnectionId;
+
+/// Smallest CID this endpoint generates. RFC 9000 allows zero-length CIDs, but
+/// routing by DCID requires enough entropy to avoid collisions across
+/// connections; 4 bytes is the practical floor for a proxy-scale table.
+pub const min_generated_cid_len = 4;
+pub const max_generated_cid_len = udp.MaxConnectionIdLen;
+
+/// Copy caller-supplied entropy into a connection ID. Entropy always comes
+/// from the caller in `src/quic/` — no ambient RNG — so generation is
+/// deterministic in tests and auditable in production.
+pub fn generateCid(entropy: []const u8, len: u8) error{ InvalidCidLength, NotEnoughEntropy }!ConnectionId {
+    if (len < min_generated_cid_len or len > max_generated_cid_len) return error.InvalidCidLength;
+    if (entropy.len < len) return error.NotEnoughEntropy;
+    return ConnectionId.init(entropy[0..len]) catch unreachable;
+}
+
+// ---------------------------------------------------------------------------
+// Frame state models (RFC 9000 §19.15 / §19.16)
+// ---------------------------------------------------------------------------
+
+pub const NewConnectionIdFrame = struct {
+    sequence: u64,
+    retire_prior_to: u64,
+    cid: ConnectionId,
+    stateless_reset_token: [stateless_reset_token_len]u8,
+};
+
+pub const RetireConnectionIdFrame = struct {
+    sequence: u64,
+};
+
+/// Operator counters for CID lifecycle and routing (#251 acceptance: metrics
+/// must distinguish unknown-CID traffic and retirement activity).
+pub const Metrics = struct {
+    cids_issued: u64 = 0,
+    /// Our CIDs the peer retired via RETIRE_CONNECTION_ID.
+    local_cids_retired: u64 = 0,
+    /// Peer CIDs we retired (retire_prior_to sweeps or rotation).
+    peer_cids_retired: u64 = 0,
+    routing_hits: u64 = 0,
+    routing_misses: u64 = 0,
+};
+
+// ---------------------------------------------------------------------------
+// Routing table: destination CID -> connection handle
+// ---------------------------------------------------------------------------
+
+/// Maps every active locally-issued CID to an opaque connection handle so the
+/// UDP endpoint can demultiplex by DCID alone (RFC 9000 §5.2). One connection
+/// registers several CIDs; lookups never consult the peer address, which is
+/// what lets a connection survive NAT rebinding and migration.
+pub const CidRoutingTable = struct {
+    allocator: std.mem.Allocator,
+    routes: std.AutoHashMap(ConnectionId, u64),
+    metrics: Metrics = .{},
+
+    pub fn init(allocator: std.mem.Allocator) CidRoutingTable {
+        return .{ .allocator = allocator, .routes = std.AutoHashMap(ConnectionId, u64).init(allocator) };
+    }
+
+    pub fn deinit(self: *CidRoutingTable) void {
+        self.routes.deinit();
+    }
+
+    pub fn insert(self: *CidRoutingTable, cid: ConnectionId, connection: u64) !void {
+        try self.routes.put(cid, connection);
+    }
+
+    /// Route a packet's destination CID to its connection. A miss is counted:
+    /// unknown-CID traffic is the stateless-reset / drop path (#250).
+    pub fn lookup(self: *CidRoutingTable, dcid: []const u8) ?u64 {
+        const key = ConnectionId.init(dcid) catch {
+            self.metrics.routing_misses += 1;
+            return null;
+        };
+        if (self.routes.get(key)) |connection| {
+            self.metrics.routing_hits += 1;
+            return connection;
+        }
+        self.metrics.routing_misses += 1;
+        return null;
+    }
+
+    /// Remove a retired CID; retired CIDs must no longer route.
+    pub fn remove(self: *CidRoutingTable, cid: ConnectionId) void {
+        _ = self.routes.remove(cid);
+    }
+
+    pub fn count(self: *const CidRoutingTable) usize {
+        return self.routes.count();
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Locally issued CIDs (what the peer uses to reach us)
+// ---------------------------------------------------------------------------
+
+/// Most CIDs this endpoint keeps active at once, independent of the peer's
+/// advertised limit. Bounded storage, no allocation.
+pub const max_local_active_cids = 8;
+
+pub const LocalCidRegistry = struct {
+    pub const Entry = struct {
+        sequence: u64,
+        cid: ConnectionId,
+        stateless_reset_token: [stateless_reset_token_len]u8,
+    };
+
+    /// min(peer's active_connection_id_limit, local storage bound).
+    active_limit: u64,
+    /// Static secret for stateless-reset token derivation (RFC 9000 §10.3.1).
+    reset_token_key: [32]u8,
+    entries: [max_local_active_cids]?Entry = [_]?Entry{null} ** max_local_active_cids,
+    next_sequence: u64 = 0,
+    metrics: Metrics = .{},
+
+    pub fn init(peer_active_connection_id_limit: u64, reset_token_key: [32]u8) LocalCidRegistry {
+        return .{
+            .active_limit = @min(peer_active_connection_id_limit, max_local_active_cids),
+            .reset_token_key = reset_token_key,
+        };
+    }
+
+    /// Register the CID chosen during the handshake as sequence 0
+    /// (RFC 9000 §5.1.1). Call once, before any `issue`.
+    pub fn registerInitial(self: *LocalCidRegistry, cid: ConnectionId) error{CidLimitExceeded}!Entry {
+        std.debug.assert(self.next_sequence == 0);
+        return self.store(cid);
+    }
+
+    /// Issue a fresh CID from caller-supplied entropy and return the
+    /// NEW_CONNECTION_ID frame model to send. Fails when the peer's active
+    /// CID limit is reached (RFC 9000 §5.1.1: an endpoint MUST NOT provide
+    /// more CIDs than the peer's limit).
+    pub fn issue(self: *LocalCidRegistry, entropy: []const u8, cid_len: u8) !NewConnectionIdFrame {
+        const cid = try generateCid(entropy, cid_len);
+        const entry = try self.store(cid);
+        self.metrics.cids_issued += 1;
+        return .{
+            .sequence = entry.sequence,
+            .retire_prior_to = 0,
+            .cid = entry.cid,
+            .stateless_reset_token = entry.stateless_reset_token,
+        };
+    }
+
+    fn store(self: *LocalCidRegistry, cid: ConnectionId) error{CidLimitExceeded}!Entry {
+        if (self.activeCount() >= self.active_limit) return error.CidLimitExceeded;
+        const slot = for (&self.entries) |*entry| {
+            if (entry.* == null) break entry;
+        } else return error.CidLimitExceeded;
+        const entry = Entry{
+            .sequence = self.next_sequence,
+            .cid = cid,
+            .stateless_reset_token = statelessResetToken(self.reset_token_key, cid.slice()),
+        };
+        slot.* = entry;
+        self.next_sequence += 1;
+        return entry;
+    }
+
+    /// Apply a peer RETIRE_CONNECTION_ID. Returns the retired CID so the
+    /// caller removes it from the routing table, or null when the frame is a
+    /// permitted retransmit of an already-retired sequence. A sequence this
+    /// endpoint never issued is a protocol violation (RFC 9000 §19.16).
+    pub fn retire(self: *LocalCidRegistry, frame: RetireConnectionIdFrame) error{ProtocolViolation}!?ConnectionId {
+        if (frame.sequence >= self.next_sequence) return error.ProtocolViolation;
+        for (&self.entries) |*slot| {
+            const entry = &(slot.* orelse continue);
+            if (entry.sequence != frame.sequence) continue;
+            const cid = entry.cid;
+            slot.* = null;
+            self.metrics.local_cids_retired += 1;
+            return cid;
+        }
+        // Issued in the past and already retired: a permitted retransmit.
+        return null;
+    }
+
+    pub fn activeCount(self: *const LocalCidRegistry) usize {
+        var active: usize = 0;
+        for (self.entries) |entry| {
+            if (entry != null) active += 1;
+        }
+        return active;
+    }
+
+    pub fn get(self: *const LocalCidRegistry, sequence: u64) ?Entry {
+        for (self.entries) |entry| {
+            if (entry) |value| {
+                if (value.sequence == sequence) return value;
+            }
+        }
+        return null;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Peer-issued CIDs (what we use to reach the peer)
+// ---------------------------------------------------------------------------
+
+pub const max_peer_active_cids = 8;
+pub const max_pending_retires = 16;
+
+pub const PeerCidPool = struct {
+    pub const Entry = struct {
+        sequence: u64,
+        cid: ConnectionId,
+        stateless_reset_token: ?[stateless_reset_token_len]u8,
+        /// A CID already used on some path; migration wants a fresh one
+        /// (RFC 9000 §9.5, linkability).
+        used: bool = false,
+    };
+
+    /// The limit this endpoint advertised in active_connection_id_limit.
+    local_active_limit: u64,
+    entries: [max_peer_active_cids]?Entry = [_]?Entry{null} ** max_peer_active_cids,
+    /// Highest retire_prior_to the peer has requested.
+    retire_prior_to: u64 = 0,
+    /// RETIRE_CONNECTION_ID sequences queued to send back to the peer.
+    pending_retires: [max_pending_retires]u64 = undefined,
+    pending_retire_count: usize = 0,
+    metrics: Metrics = .{},
+
+    pub fn init(local_active_connection_id_limit: u64) PeerCidPool {
+        return .{ .local_active_limit = @min(local_active_connection_id_limit, max_peer_active_cids) };
+    }
+
+    /// Register the peer's handshake source CID as sequence 0. It carries no
+    /// stateless-reset token (RFC 9000 §10.3: the handshake CID's token comes
+    /// separately via the transport parameter).
+    pub fn registerInitial(self: *PeerCidPool, cid: ConnectionId) error{ CidLimitExceeded, ProtocolViolation }!void {
+        try self.storeValidated(.{
+            .sequence = 0,
+            .cid = cid,
+            .stateless_reset_token = null,
+            .used = true, // in use on the handshake path
+        });
+    }
+
+    /// Apply a peer NEW_CONNECTION_ID frame (RFC 9000 §19.15 / §5.1.1):
+    /// rejects malformed retire_prior_to, detects sequence reuse with
+    /// different contents, tolerates exact retransmits, retires sequences
+    /// below retire_prior_to (queueing RETIRE_CONNECTION_ID responses), and
+    /// enforces the advertised active-CID limit.
+    pub fn onNewConnectionId(self: *PeerCidPool, frame: NewConnectionIdFrame) error{ ProtocolViolation, CidLimitExceeded, RetireQueueFull }!void {
+        if (frame.retire_prior_to > frame.sequence) return error.ProtocolViolation;
+
+        // Same sequence must always carry the same CID and token.
+        for (self.entries) |existing| {
+            const entry = existing orelse continue;
+            const same_sequence = entry.sequence == frame.sequence;
+            const same_cid = std.mem.eql(u8, entry.cid.slice(), frame.cid.slice());
+            if (same_sequence and !same_cid) return error.ProtocolViolation;
+            if (!same_sequence and same_cid) return error.ProtocolViolation;
+            if (same_sequence) return; // exact retransmit
+        }
+
+        if (frame.retire_prior_to > self.retire_prior_to) {
+            self.retire_prior_to = frame.retire_prior_to;
+            try self.retireBelowThreshold();
+        }
+
+        // A sequence the peer already told us to retire: acknowledge with a
+        // RETIRE_CONNECTION_ID and never store it (RFC 9000 §5.1.2).
+        if (frame.sequence < self.retire_prior_to) {
+            try self.queueRetire(frame.sequence);
+            return;
+        }
+
+        try self.storeValidated(.{
+            .sequence = frame.sequence,
+            .cid = frame.cid,
+            .stateless_reset_token = frame.stateless_reset_token,
+        });
+    }
+
+    fn storeValidated(self: *PeerCidPool, entry: Entry) error{ CidLimitExceeded, ProtocolViolation }!void {
+        if (self.activeCount() >= self.local_active_limit) return error.CidLimitExceeded;
+        const slot = for (&self.entries) |*candidate| {
+            if (candidate.* == null) break candidate;
+        } else return error.CidLimitExceeded;
+        slot.* = entry;
+    }
+
+    fn retireBelowThreshold(self: *PeerCidPool) error{RetireQueueFull}!void {
+        for (&self.entries) |*slot| {
+            const entry = slot.* orelse continue;
+            if (entry.sequence >= self.retire_prior_to) continue;
+            try self.queueRetire(entry.sequence);
+            slot.* = null;
+            self.metrics.peer_cids_retired += 1;
+        }
+    }
+
+    fn queueRetire(self: *PeerCidPool, sequence: u64) error{RetireQueueFull}!void {
+        if (self.pending_retire_count == self.pending_retires.len) return error.RetireQueueFull;
+        self.pending_retires[self.pending_retire_count] = sequence;
+        self.pending_retire_count += 1;
+    }
+
+    /// Next RETIRE_CONNECTION_ID to send, or null when none is pending.
+    pub fn takePendingRetire(self: *PeerCidPool) ?RetireConnectionIdFrame {
+        if (self.pending_retire_count == 0) return null;
+        const sequence = self.pending_retires[0];
+        std.mem.copyForwards(u64, self.pending_retires[0 .. self.pending_retire_count - 1], self.pending_retires[1..self.pending_retire_count]);
+        self.pending_retire_count -= 1;
+        return .{ .sequence = sequence };
+    }
+
+    /// Claim a never-used peer CID for a new path (RFC 9000 §9.5: reusing a
+    /// CID across paths links them). Returns null when the pool has no fresh
+    /// CID — the caller must not migrate until the peer issues more.
+    pub fn claimForMigration(self: *PeerCidPool) ?Entry {
+        for (&self.entries) |*slot| {
+            const entry = &(slot.* orelse continue);
+            if (entry.used or entry.sequence < self.retire_prior_to) continue;
+            entry.used = true;
+            return entry.*;
+        }
+        return null;
+    }
+
+    pub fn activeCount(self: *const PeerCidPool) usize {
+        var active: usize = 0;
+        for (self.entries) |entry| {
+            if (entry != null) active += 1;
+        }
+        return active;
+    }
+};
 
 // ---------------------------------------------------------------------------
 // Stateless reset (RFC 9000 §10.3)
@@ -127,6 +460,165 @@ test "stateless reset clamps to the output buffer for large triggers" {
     const reset = try StatelessReset.build(&out, 1200, &unpredictable, token);
     try testing.expectEqual(@as(usize, 30), reset.len);
     try testing.expectEqualSlices(u8, &token, reset[reset.len - stateless_reset_token_len ..]);
+}
+
+test "generateCid copies caller entropy and enforces length bounds" {
+    const entropy = [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+    const cid = try generateCid(&entropy, 8);
+    try testing.expectEqualSlices(u8, entropy[0..8], cid.slice());
+
+    try testing.expectError(error.InvalidCidLength, generateCid(&entropy, 3));
+    try testing.expectError(error.InvalidCidLength, generateCid(&entropy, max_generated_cid_len + 1));
+    try testing.expectError(error.NotEnoughEntropy, generateCid(entropy[0..4], 8));
+}
+
+test "routing table routes by DCID independent of any address and counts misses" {
+    var table = CidRoutingTable.init(testing.allocator);
+    defer table.deinit();
+
+    const cid_a = try ConnectionId.init(&.{ 1, 1, 1, 1, 1, 1, 1, 1 });
+    const cid_b = try ConnectionId.init(&.{ 2, 2, 2, 2 });
+    try table.insert(cid_a, 7);
+    try table.insert(cid_b, 7); // several CIDs route to one connection
+    const cid_other = try ConnectionId.init(&.{ 3, 3, 3, 3 });
+    try table.insert(cid_other, 9);
+
+    try testing.expectEqual(@as(?u64, 7), table.lookup(cid_a.slice()));
+    try testing.expectEqual(@as(?u64, 7), table.lookup(cid_b.slice()));
+    try testing.expectEqual(@as(?u64, 9), table.lookup(cid_other.slice()));
+    try testing.expectEqual(@as(?u64, null), table.lookup(&.{ 9, 9, 9, 9 }));
+    try testing.expectEqual(@as(?u64, null), table.lookup(""));
+    try testing.expectEqual(@as(u64, 3), table.metrics.routing_hits);
+    try testing.expectEqual(@as(u64, 2), table.metrics.routing_misses);
+}
+
+test "retired local CIDs stop routing and unknown retire sequences are violations" {
+    var table = CidRoutingTable.init(testing.allocator);
+    defer table.deinit();
+    var registry = LocalCidRegistry.init(4, [_]u8{0xab} ** 32);
+
+    const initial = try ConnectionId.init(&.{ 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa });
+    const initial_entry = try registry.registerInitial(initial);
+    try table.insert(initial_entry.cid, 1);
+
+    var entropy = [_]u8{0x10} ** 8;
+    const issued = try registry.issue(&entropy, 8);
+    try table.insert(issued.cid, 1);
+    try testing.expectEqual(@as(u64, 1), issued.sequence);
+    try testing.expectEqual(@as(?u64, 1), table.lookup(issued.cid.slice()));
+
+    // Retire the issued CID: it must come out of the routing table.
+    const retired = (try registry.retire(.{ .sequence = issued.sequence })).?;
+    table.remove(retired);
+    try testing.expectEqual(@as(?u64, null), table.lookup(issued.cid.slice()));
+    try testing.expectEqual(@as(u64, 1), registry.metrics.local_cids_retired);
+
+    // A retransmitted RETIRE_CONNECTION_ID for the same sequence is a no-op.
+    try testing.expectEqual(@as(?ConnectionId, null), try registry.retire(.{ .sequence = issued.sequence }));
+    // A sequence never issued is a protocol violation (RFC 9000 §19.16).
+    try testing.expectError(error.ProtocolViolation, registry.retire(.{ .sequence = 99 }));
+}
+
+test "local registry enforces the peer's active CID limit and derives reset tokens" {
+    const key = [_]u8{0x77} ** 32;
+    var registry = LocalCidRegistry.init(2, key);
+    _ = try registry.registerInitial(try ConnectionId.init(&.{ 1, 2, 3, 4 }));
+
+    var entropy = [_]u8{0x20} ** 8;
+    const issued = try registry.issue(&entropy, 8);
+    // The frame's token matches the RFC 9000 §10.3.1 derivation for the CID.
+    try testing.expectEqualSlices(u8, &statelessResetToken(key, issued.cid.slice()), &issued.stateless_reset_token);
+
+    // Limit of 2 is reached: further issuance must fail until one retires.
+    var more_entropy = [_]u8{0x30} ** 8;
+    try testing.expectError(error.CidLimitExceeded, registry.issue(&more_entropy, 8));
+    _ = try registry.retire(.{ .sequence = issued.sequence });
+    _ = try registry.issue(&more_entropy, 8);
+    try testing.expectEqual(@as(usize, 2), registry.activeCount());
+}
+
+test "peer pool validates NEW_CONNECTION_ID and sweeps retire_prior_to" {
+    var pool = PeerCidPool.init(4);
+    try pool.registerInitial(try ConnectionId.init(&.{ 9, 9, 9, 9 }));
+
+    const cid_1 = try ConnectionId.init(&.{ 1, 1, 1, 1 });
+    const token_1 = [_]u8{0x01} ** stateless_reset_token_len;
+    try pool.onNewConnectionId(.{ .sequence = 1, .retire_prior_to = 0, .cid = cid_1, .stateless_reset_token = token_1 });
+    // Exact retransmit: tolerated.
+    try pool.onNewConnectionId(.{ .sequence = 1, .retire_prior_to = 0, .cid = cid_1, .stateless_reset_token = token_1 });
+    // Same sequence, different CID: protocol violation.
+    const cid_conflict = try ConnectionId.init(&.{ 2, 2, 2, 2 });
+    try testing.expectError(error.ProtocolViolation, pool.onNewConnectionId(.{ .sequence = 1, .retire_prior_to = 0, .cid = cid_conflict, .stateless_reset_token = token_1 }));
+    // Same CID, different sequence: also a violation (RFC 9000 §5.1.1).
+    try testing.expectError(error.ProtocolViolation, pool.onNewConnectionId(.{ .sequence = 2, .retire_prior_to = 0, .cid = cid_1, .stateless_reset_token = token_1 }));
+    // retire_prior_to beyond the sequence itself is malformed.
+    try testing.expectError(error.ProtocolViolation, pool.onNewConnectionId(.{ .sequence = 3, .retire_prior_to = 4, .cid = cid_conflict, .stateless_reset_token = token_1 }));
+
+    // A frame with retire_prior_to = 2 sweeps sequences 0 and 1 and queues
+    // RETIRE_CONNECTION_ID for each.
+    const cid_2 = try ConnectionId.init(&.{ 3, 3, 3, 3 });
+    try pool.onNewConnectionId(.{ .sequence = 2, .retire_prior_to = 2, .cid = cid_2, .stateless_reset_token = token_1 });
+    try testing.expectEqual(@as(u64, 2), pool.metrics.peer_cids_retired);
+    const first_retire = pool.takePendingRetire().?;
+    const second_retire = pool.takePendingRetire().?;
+    try testing.expect((first_retire.sequence == 0 and second_retire.sequence == 1) or
+        (first_retire.sequence == 1 and second_retire.sequence == 0));
+    try testing.expectEqual(@as(?RetireConnectionIdFrame, null), pool.takePendingRetire());
+
+    // A late frame below retire_prior_to is retired immediately, never stored.
+    const cid_late = try ConnectionId.init(&.{ 4, 4, 4, 4 });
+    try pool.onNewConnectionId(.{ .sequence = 0, .retire_prior_to = 0, .cid = cid_late, .stateless_reset_token = token_1 });
+    try testing.expectEqual(@as(u64, 0), pool.takePendingRetire().?.sequence);
+    try testing.expectEqual(@as(usize, 1), pool.activeCount());
+}
+
+test "peer pool enforces the advertised active CID limit" {
+    var pool = PeerCidPool.init(2);
+    try pool.registerInitial(try ConnectionId.init(&.{ 9, 9, 9, 9 }));
+    const token = [_]u8{0x0f} ** stateless_reset_token_len;
+    try pool.onNewConnectionId(.{ .sequence = 1, .retire_prior_to = 0, .cid = try ConnectionId.init(&.{ 1, 0, 0, 1 }), .stateless_reset_token = token });
+    try testing.expectError(error.CidLimitExceeded, pool.onNewConnectionId(.{ .sequence = 2, .retire_prior_to = 0, .cid = try ConnectionId.init(&.{ 2, 0, 0, 2 }), .stateless_reset_token = token }));
+}
+
+test "migration claims only fresh peer CIDs" {
+    var pool = PeerCidPool.init(4);
+    try pool.registerInitial(try ConnectionId.init(&.{ 9, 9, 9, 9 }));
+    // The handshake CID is in use; with nothing else the pool has no fresh CID.
+    try testing.expectEqual(@as(?PeerCidPool.Entry, null), pool.claimForMigration());
+
+    const token = [_]u8{0x0c} ** stateless_reset_token_len;
+    const fresh = try ConnectionId.init(&.{ 5, 5, 5, 5 });
+    try pool.onNewConnectionId(.{ .sequence = 1, .retire_prior_to = 0, .cid = fresh, .stateless_reset_token = token });
+    const claimed = pool.claimForMigration().?;
+    try testing.expectEqualSlices(u8, fresh.slice(), claimed.cid.slice());
+    // Claimed once: a second migration needs yet another CID.
+    try testing.expectEqual(@as(?PeerCidPool.Entry, null), pool.claimForMigration());
+}
+
+test "CID issue/retire churn does not leak routing table entries" {
+    var table = CidRoutingTable.init(testing.allocator);
+    defer table.deinit();
+    var registry = LocalCidRegistry.init(4, [_]u8{0x55} ** 32);
+    _ = try registry.registerInitial(try ConnectionId.init(&.{ 0, 0, 0, 0, 0, 0, 0, 1 }));
+
+    // Long-running rotation: issue a fresh CID and retire the previous one,
+    // thousands of times. Table and registry stay bounded throughout.
+    var previous_sequence: u64 = 0;
+    var iteration: u64 = 0;
+    while (iteration < 10_000) : (iteration += 1) {
+        var entropy: [8]u8 = undefined;
+        std.mem.writeInt(u64, &entropy, iteration + 1, .big);
+        const issued = try registry.issue(&entropy, 8);
+        try table.insert(issued.cid, 1);
+        if (try registry.retire(.{ .sequence = previous_sequence })) |retired| {
+            table.remove(retired);
+        }
+        previous_sequence = issued.sequence;
+        try testing.expect(registry.activeCount() <= 2);
+        try testing.expect(table.count() <= 2);
+    }
+    try testing.expectEqual(@as(u64, 10_000), registry.metrics.cids_issued);
+    try testing.expectEqual(@as(u64, 10_000), registry.metrics.local_cids_retired);
 }
 
 test {

--- a/src/quic/cid.zig
+++ b/src/quic/cid.zig
@@ -81,7 +81,16 @@ pub const CidRoutingTable = struct {
         self.routes.deinit();
     }
 
-    pub fn insert(self: *CidRoutingTable, cid: ConnectionId, connection: u64) !void {
+    /// Register a CID for a connection. Re-registering the same CID for the
+    /// same connection is idempotent; the same CID appearing for a *different*
+    /// connection is a deterministic error — silently stealing a route would
+    /// misdeliver protected packets and be brutal to debug (bad entropy,
+    /// duplicate issuance, or an integration bug).
+    pub fn insert(self: *CidRoutingTable, cid: ConnectionId, connection: u64) error{ CidCollision, OutOfMemory }!void {
+        if (self.routes.get(cid)) |existing| {
+            if (existing == connection) return;
+            return error.CidCollision;
+        }
         try self.routes.put(cid, connection);
     }
 
@@ -142,7 +151,7 @@ pub const LocalCidRegistry = struct {
 
     /// Register the CID chosen during the handshake as sequence 0
     /// (RFC 9000 §5.1.1). Call once, before any `issue`.
-    pub fn registerInitial(self: *LocalCidRegistry, cid: ConnectionId) error{CidLimitExceeded}!Entry {
+    pub fn registerInitial(self: *LocalCidRegistry, cid: ConnectionId) error{ CidLimitExceeded, DuplicateCid }!Entry {
         std.debug.assert(self.next_sequence == 0);
         return self.store(cid);
     }
@@ -163,8 +172,15 @@ pub const LocalCidRegistry = struct {
         };
     }
 
-    fn store(self: *LocalCidRegistry, cid: ConnectionId) error{CidLimitExceeded}!Entry {
+    fn store(self: *LocalCidRegistry, cid: ConnectionId) error{ CidLimitExceeded, DuplicateCid }!Entry {
         if (self.activeCount() >= self.active_limit) return error.CidLimitExceeded;
+        // Repeated caller entropy must not mint the same CID twice under
+        // different sequence numbers.
+        for (self.entries) |existing| {
+            if (existing) |entry| {
+                if (std.mem.eql(u8, entry.cid.slice(), cid.slice())) return error.DuplicateCid;
+            }
+        }
         const slot = for (&self.entries) |*entry| {
             if (entry.* == null) break entry;
         } else return error.CidLimitExceeded;
@@ -226,6 +242,9 @@ pub const PeerCidPool = struct {
         sequence: u64,
         cid: ConnectionId,
         stateless_reset_token: ?[stateless_reset_token_len]u8,
+        /// The retire_prior_to the frame that introduced this sequence
+        /// carried, kept to verify that a "retransmit" really is one.
+        announced_retire_prior_to: u64 = 0,
         /// A CID already used on some path; migration wants a fresh one
         /// (RFC 9000 §9.5, linkability).
         used: bool = false,
@@ -265,14 +284,23 @@ pub const PeerCidPool = struct {
     pub fn onNewConnectionId(self: *PeerCidPool, frame: NewConnectionIdFrame) error{ ProtocolViolation, CidLimitExceeded, RetireQueueFull }!void {
         if (frame.retire_prior_to > frame.sequence) return error.ProtocolViolation;
 
-        // Same sequence must always carry the same CID and token.
+        // A repeated sequence number must be an exact retransmit: same CID,
+        // same stateless reset token, and same retire_prior_to (RFC 9000
+        // §19.15 — reuse with different contents is a protocol violation).
         for (self.entries) |existing| {
             const entry = existing orelse continue;
             const same_sequence = entry.sequence == frame.sequence;
             const same_cid = std.mem.eql(u8, entry.cid.slice(), frame.cid.slice());
-            if (same_sequence and !same_cid) return error.ProtocolViolation;
             if (!same_sequence and same_cid) return error.ProtocolViolation;
-            if (same_sequence) return; // exact retransmit
+            if (!same_sequence) continue;
+            if (!same_cid) return error.ProtocolViolation;
+            const same_token = if (entry.stateless_reset_token) |token|
+                std.mem.eql(u8, &token, &frame.stateless_reset_token)
+            else
+                false;
+            if (!same_token) return error.ProtocolViolation;
+            if (entry.announced_retire_prior_to != frame.retire_prior_to) return error.ProtocolViolation;
+            return; // exact retransmit
         }
 
         if (frame.retire_prior_to > self.retire_prior_to) {
@@ -291,6 +319,7 @@ pub const PeerCidPool = struct {
             .sequence = frame.sequence,
             .cid = frame.cid,
             .stateless_reset_token = frame.stateless_reset_token,
+            .announced_retire_prior_to = frame.retire_prior_to,
         });
     }
 
@@ -580,6 +609,61 @@ test "peer pool enforces the advertised active CID limit" {
     try testing.expectError(error.CidLimitExceeded, pool.onNewConnectionId(.{ .sequence = 2, .retire_prior_to = 0, .cid = try ConnectionId.init(&.{ 2, 0, 0, 2 }), .stateless_reset_token = token }));
 }
 
+test "routing table rejects CID collisions across connections" {
+    var table = CidRoutingTable.init(testing.allocator);
+    defer table.deinit();
+    const cid = try ConnectionId.init(&.{ 6, 6, 6, 6 });
+    try table.insert(cid, 1);
+    // Re-registering for the same connection is idempotent.
+    try table.insert(cid, 1);
+    try testing.expectEqual(@as(usize, 1), table.count());
+    // The same CID must never silently route to a different connection.
+    try testing.expectError(error.CidCollision, table.insert(cid, 2));
+    try testing.expectEqual(@as(?u64, 1), table.lookup(cid.slice()));
+}
+
+test "local registry rejects duplicate CIDs from repeated entropy" {
+    var registry = LocalCidRegistry.init(4, [_]u8{0x42} ** 32);
+    _ = try registry.registerInitial(try ConnectionId.init(&.{ 1, 2, 3, 4, 5, 6, 7, 8 }));
+    var entropy = [_]u8{0x99} ** 8;
+    _ = try registry.issue(&entropy, 8);
+    // Same entropy again would mint the same CID under a new sequence.
+    try testing.expectError(error.DuplicateCid, registry.issue(&entropy, 8));
+    // And so would re-registering the handshake CID.
+    try testing.expectError(error.DuplicateCid, registry.issue(&[_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 }, 8));
+}
+
+test "NEW_CONNECTION_ID sequence reuse must be an exact retransmit" {
+    var pool = PeerCidPool.init(4);
+    const cid = try ConnectionId.init(&.{ 8, 8, 8, 8 });
+    const token = [_]u8{0x08} ** stateless_reset_token_len;
+    try pool.onNewConnectionId(.{ .sequence = 1, .retire_prior_to = 1, .cid = cid, .stateless_reset_token = token });
+
+    // Same sequence and CID with a different stateless reset token: violation.
+    const other_token = [_]u8{0x09} ** stateless_reset_token_len;
+    try testing.expectError(error.ProtocolViolation, pool.onNewConnectionId(.{ .sequence = 1, .retire_prior_to = 1, .cid = cid, .stateless_reset_token = other_token }));
+    // Same sequence, CID, and token but a different retire_prior_to: also not
+    // a retransmit of the same frame.
+    try testing.expectError(error.ProtocolViolation, pool.onNewConnectionId(.{ .sequence = 1, .retire_prior_to = 0, .cid = cid, .stateless_reset_token = token }));
+    // The true retransmit still passes.
+    try pool.onNewConnectionId(.{ .sequence = 1, .retire_prior_to = 1, .cid = cid, .stateless_reset_token = token });
+}
+
+test "a stale retire_prior_to below the current threshold is a clean no-op" {
+    var pool = PeerCidPool.init(8);
+    const token = [_]u8{0x0a} ** stateless_reset_token_len;
+    try pool.onNewConnectionId(.{ .sequence = 3, .retire_prior_to = 3, .cid = try ConnectionId.init(&.{ 3, 0, 0, 3 }), .stateless_reset_token = token });
+    try testing.expectEqual(@as(u64, 3), pool.retire_prior_to);
+    const retired_before = pool.metrics.peer_cids_retired;
+
+    // A late frame carrying a lower retire_prior_to sweeps nothing and queues
+    // nothing extra: the threshold never regresses.
+    try pool.onNewConnectionId(.{ .sequence = 4, .retire_prior_to = 1, .cid = try ConnectionId.init(&.{ 4, 0, 0, 4 }), .stateless_reset_token = token });
+    try testing.expectEqual(@as(u64, 3), pool.retire_prior_to);
+    try testing.expectEqual(retired_before, pool.metrics.peer_cids_retired);
+    try testing.expectEqual(@as(usize, 2), pool.activeCount());
+}
+
 test "migration claims only fresh peer CIDs" {
     var pool = PeerCidPool.init(4);
     try pool.registerInitial(try ConnectionId.init(&.{ 9, 9, 9, 9 }));
@@ -599,7 +683,7 @@ test "CID issue/retire churn does not leak routing table entries" {
     var table = CidRoutingTable.init(testing.allocator);
     defer table.deinit();
     var registry = LocalCidRegistry.init(4, [_]u8{0x55} ** 32);
-    _ = try registry.registerInitial(try ConnectionId.init(&.{ 0, 0, 0, 0, 0, 0, 0, 1 }));
+    _ = try registry.registerInitial(try ConnectionId.init(&.{ 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa }));
 
     // Long-running rotation: issue a fresh CID and retire the previous one,
     // thousands of times. Table and registry stay bounded throughout.

--- a/src/quic/path.zig
+++ b/src/quic/path.zig
@@ -392,7 +392,13 @@ pub const Metrics = struct {
     // rebinding, migration, validation failure, and blocked attempts.
     path_challenges_sent: u64 = 0,
     path_validations_succeeded: u64 = 0,
+    /// Validations that failed terminally: the challenge expired unanswered.
     path_validations_failed: u64 = 0,
+    /// PATH_RESPONSE frames that validated nothing — wrong payload, wrong
+    /// path, or no outstanding challenge. Kept separate from
+    /// `path_validations_failed` because the probe may still succeed; a spike
+    /// here without failures suggests reordering or off-path spoofing.
+    path_response_mismatches: u64 = 0,
     nat_rebindings: u64 = 0,
     migrations: u64 = 0,
     migrations_blocked: u64 = 0,
@@ -595,22 +601,33 @@ pub const PathManager = struct {
     /// Apply a PATH_RESPONSE received from `key`. On a match the path becomes
     /// validated and active, and the outcome says whether congestion/RTT
     /// state must reset. A response with no matching outstanding challenge —
-    /// wrong payload, wrong path, or expired — is ignored (null): responses
-    /// do not validate paths they were not sent on (RFC 9000 §8.2.3).
+    /// wrong payload, wrong path, or expired — is ignored (null) and counted
+    /// in `path_response_mismatches`: responses do not validate paths they
+    /// were not sent on (RFC 9000 §8.2.3), but the probe itself keeps waiting
+    /// (only expiry fails it terminally).
     pub fn onPathResponse(
         self: *PathManager,
         key: PathKey,
         data: [path_challenge_len]u8,
         now_us: u64,
     ) ?MigrationOutcome {
-        const index = self.find(key) orelse return null;
+        const index = self.find(key) orelse {
+            self.metrics.path_response_mismatches += 1;
+            return null;
+        };
         const path = &self.paths[index].?;
-        if (path.state != .validating) return null;
+        if (path.state != .validating) {
+            self.metrics.path_response_mismatches += 1;
+            return null;
+        }
         if (now_us > path.challenge_deadline_us) {
             self.failValidation(path);
             return null;
         }
-        if (!std.crypto.timing_safe.eql([path_challenge_len]u8, path.challenge, data)) return null;
+        if (!std.crypto.timing_safe.eql([path_challenge_len]u8, path.challenge, data)) {
+            self.metrics.path_response_mismatches += 1;
+            return null;
+        }
 
         path.state = .validated;
         path.anti_amplification.markValidated();
@@ -895,12 +912,21 @@ test "a real migration validates and requires congestion/RTT reset" {
     var controller = recovery.RecoveryController{};
     controller.rtt.update(50_000, 0);
     controller.congestion.congestion_window = 3;
-    controller.congestion.bytes_in_flight = 999;
+    const old_path_packet = recovery.SentPacket{
+        .space = .application,
+        .packet_number = 5,
+        .time_sent_us = 10,
+        .size = 999,
+    };
+    controller.congestion.onPacketSent(old_path_packet.size);
     controller.resetForPathMigration();
     try testing.expect(!controller.rtt.hasSample());
     try testing.expectEqual(recovery.CongestionController.initialWindow(recovery.max_datagram_size), controller.congestion.congestion_window);
-    // Packets in flight on the old path are still accounted for.
+    // Packets in flight on the old path stay in the single send ledger...
     try testing.expectEqual(@as(usize, 999), controller.congestion.bytes_in_flight);
+    // ...and drain through the normal ack path without corrupting accounting.
+    controller.congestion.onPacketAcked(old_path_packet);
+    try testing.expectEqual(@as(usize, 0), controller.congestion.bytes_in_flight);
 }
 
 test "a wrong PATH_RESPONSE payload does not validate the path" {
@@ -912,9 +938,14 @@ test "a wrong PATH_RESPONSE payload does not validate the path" {
     try testing.expectEqual(@as(?MigrationOutcome, null), manager.onPathResponse(rebound, wrong, 100));
     // A response on a different tuple does not validate the probed one either.
     try testing.expectEqual(@as(?MigrationOutcome, null), manager.onPathResponse(testKeyOtherHost(1), test_challenge, 100));
-    // Still probing; the active path is unchanged.
+    // Still probing; the active path is unchanged. Both bogus responses are
+    // counted as mismatches, not as terminal validation failures — the probe
+    // can still succeed.
     try testing.expect(manager.activePath().key.eql(testKey(50_000)));
     try testing.expectEqual(@as(u64, 0), manager.metrics.path_validations_succeeded);
+    try testing.expectEqual(@as(u64, 0), manager.metrics.path_validations_failed);
+    try testing.expectEqual(@as(u64, 2), manager.metrics.path_response_mismatches);
+    try testing.expect(manager.onPathResponse(rebound, test_challenge, 200) != null);
 }
 
 test "path validation fails deterministically when the challenge expires" {

--- a/src/quic/path.zig
+++ b/src/quic/path.zig
@@ -8,12 +8,17 @@
 //!   tokens (timestamp/expiry, address binding, key rotation, tamper rejection).
 //! - `retryIntegrityTag` / `verifyRetryIntegrity` implement the RFC 9001 Retry
 //!   integrity tag. Stateless-reset tokens/packets live in `cid.zig`.
-//! - `Metrics` exposes the operator counters the issue requires.
+//! - `PathManager` (#251) owns the per-connection path table keyed by the
+//!   (local, remote) address tuple: PATH_CHALLENGE/PATH_RESPONSE validation,
+//!   NAT-rebinding vs. migration classification, the configurable migration
+//!   policy from `config.zig`, and the RFC 9000 §9.4 congestion-reset rule.
+//! - `Metrics` exposes the operator counters #250/#251 require.
 //!
-//! Packet framing and DCID parsing stay in `packet.zig` (#243); connection
-//! migration / path validation stay in #251; interop/fuzz in #247.
+//! Packet framing and DCID parsing stay in `packet.zig` (#243); CID issuance
+//! and routing live in `cid.zig`; interop/fuzz in #247.
 
 const std = @import("std");
+const config = @import("config.zig");
 const udp = @import("udp.zig");
 
 const Aes128Gcm = std.crypto.aead.aes_gcm.Aes128Gcm;
@@ -383,6 +388,14 @@ pub const Metrics = struct {
     amplification_blocked_sends: u64 = 0,
     stateless_resets_sent: u64 = 0,
     unknown_connection_id_packets: u64 = 0,
+    // Path lifecycle (#251): the acceptance criteria require distinguishing
+    // rebinding, migration, validation failure, and blocked attempts.
+    path_challenges_sent: u64 = 0,
+    path_validations_succeeded: u64 = 0,
+    path_validations_failed: u64 = 0,
+    nat_rebindings: u64 = 0,
+    migrations: u64 = 0,
+    migrations_blocked: u64 = 0,
 
     pub fn recordRetrySent(self: *Metrics) void {
         self.retry_packets_sent += 1;
@@ -408,6 +421,253 @@ pub const Metrics = struct {
     /// counted; a success is a no-op). Accepts any `TokenError!T` result.
     pub fn recordTokenValidation(self: *Metrics, result: anytype) void {
         if (result) |_| {} else |_| self.recordInvalidToken();
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Path state, PATH_CHALLENGE / PATH_RESPONSE validation, and migration policy
+// (#251, RFC 9000 §8.2 / §9)
+// ---------------------------------------------------------------------------
+
+pub const path_challenge_len = 8;
+/// Most concurrently tracked paths per connection: the active path plus a
+/// small number of probes. A peer hopping addresses faster than probes
+/// resolve recycles the oldest failed/unvalidated slot.
+pub const max_paths = 4;
+/// How long a PATH_CHALLENGE may stay unanswered before the validation fails
+/// deterministically. Connection integration can override per RTT (3×PTO);
+/// the default keeps standalone use safe.
+pub const default_validation_timeout_us: u64 = 1_000_000;
+
+/// A network path keyed by the (local, remote) address tuple.
+pub const PathKey = struct {
+    local: udp.Address,
+    remote: udp.Address,
+
+    pub fn eql(self: PathKey, other: PathKey) bool {
+        return self.local.eql(other.local) and self.remote.eql(other.remote);
+    }
+};
+
+pub const PathState = enum {
+    /// Traffic seen, no validation started (policy denied or not yet probed).
+    unvalidated,
+    /// PATH_CHALLENGE outstanding.
+    validating,
+    /// PATH_RESPONSE echoed the challenge; the path is usable.
+    validated,
+    /// The challenge expired unanswered.
+    failed,
+};
+
+/// How a new remote tuple is classified against the active path.
+pub const AddressChange = enum {
+    /// Same host, different port: almost always a NAT rebinding (RFC 9308 §4.1).
+    nat_rebinding,
+    /// Different host: a real migration with likely-new path characteristics.
+    migration,
+};
+
+pub const Path = struct {
+    key: PathKey,
+    state: PathState = .unvalidated,
+    change: AddressChange,
+    challenge: [path_challenge_len]u8 = undefined,
+    challenge_deadline_us: u64 = 0,
+    anti_amplification: AntiAmplification = .{},
+};
+
+/// The action the connection takes for a datagram from a given tuple.
+pub const PathDecision = union(enum) {
+    /// Datagram arrived on the active path: nothing to do.
+    on_active_path,
+    /// A new/unvalidated tuple is being probed: send PATH_CHALLENGE with this
+    /// payload on that path (RFC 9000 §9.3: packets from the new address are
+    /// processed, but the path is validated before it becomes the active one).
+    probe: [path_challenge_len]u8,
+    /// Probe already in flight for this tuple; nothing new to send.
+    probing,
+    /// Migration policy forbids this address change: the caller drops state
+    /// changes for this tuple (packets themselves stay processed on the
+    /// active path per RFC 9000 §9.1 server behavior for disabled migration).
+    blocked,
+};
+
+/// Result of a successful path validation switch.
+pub const MigrationOutcome = struct {
+    change: AddressChange,
+    /// RFC 9000 §9.4 policy, documented here once: RTT and congestion state
+    /// reset (`recovery.RecoveryController.resetForPathMigration`) when the
+    /// peer's *host* changed — new path, unknown characteristics. A NAT
+    /// rebinding that only changed the port keeps the estimator, since the
+    /// underlying path is almost certainly the same.
+    reset_congestion: bool,
+};
+
+pub const PathManager = struct {
+    policy: config.MigrationPolicy,
+    validation_timeout_us: u64 = default_validation_timeout_us,
+    paths: [max_paths]?Path = [_]?Path{null} ** max_paths,
+    /// Index of the active (validated, in-use) path.
+    active: usize = 0,
+    metrics: Metrics = .{},
+
+    /// Start with the handshake path: it is validated by the handshake itself
+    /// (RFC 9000 §8.1).
+    pub fn init(policy: config.MigrationPolicy, handshake_path: PathKey) PathManager {
+        var manager = PathManager{ .policy = policy };
+        manager.paths[0] = .{
+            .key = handshake_path,
+            .state = .validated,
+            .change = .migration,
+        };
+        manager.paths[0].?.anti_amplification.markValidated();
+        return manager;
+    }
+
+    pub fn activePath(self: *const PathManager) *const Path {
+        return &self.paths[self.active].?;
+    }
+
+    /// Classify a datagram's tuple and drive path state. `challenge_entropy`
+    /// supplies the unpredictable PATH_CHALLENGE payload (RFC 9000 §8.2.1)
+    /// when a probe starts.
+    pub fn onDatagram(
+        self: *PathManager,
+        key: PathKey,
+        challenge_entropy: [path_challenge_len]u8,
+        now_us: u64,
+    ) PathDecision {
+        if (key.eql(self.paths[self.active].?.key)) return .on_active_path;
+
+        const change: AddressChange = if (key.remote.sameHost(self.paths[self.active].?.key.remote))
+            .nat_rebinding
+        else
+            .migration;
+
+        const allowed = switch (self.policy) {
+            .disabled => false,
+            .nat_rebinding_only => change == .nat_rebinding,
+            .full => true,
+        };
+        if (!allowed) {
+            self.metrics.migrations_blocked += 1;
+            return .blocked;
+        }
+
+        if (self.find(key)) |index| {
+            const path = &self.paths[index].?;
+            switch (path.state) {
+                .validating => return .probing,
+                // Fresh traffic on a previously failed/unvalidated tuple:
+                // start a new probe.
+                .failed, .unvalidated => {},
+                // A validated non-active path re-activates only through a new
+                // challenge round trip, keeping the switch deterministic.
+                .validated => {},
+            }
+            path.state = .validating;
+            path.change = change;
+            path.challenge = challenge_entropy;
+            path.challenge_deadline_us = now_us + self.validation_timeout_us;
+            self.metrics.path_challenges_sent += 1;
+            return .{ .probe = challenge_entropy };
+        }
+
+        const slot = self.claimSlot();
+        self.paths[slot] = .{
+            .key = key,
+            .state = .validating,
+            .change = change,
+            .challenge = challenge_entropy,
+            .challenge_deadline_us = now_us + self.validation_timeout_us,
+        };
+        self.metrics.path_challenges_sent += 1;
+        return .{ .probe = challenge_entropy };
+    }
+
+    /// PATH_CHALLENGE handling is stateless: echo the payload in a
+    /// PATH_RESPONSE on the same path (RFC 9000 §8.2.2).
+    pub fn onPathChallenge(data: [path_challenge_len]u8) [path_challenge_len]u8 {
+        return data;
+    }
+
+    /// Apply a PATH_RESPONSE received from `key`. On a match the path becomes
+    /// validated and active, and the outcome says whether congestion/RTT
+    /// state must reset. A response with no matching outstanding challenge —
+    /// wrong payload, wrong path, or expired — is ignored (null): responses
+    /// do not validate paths they were not sent on (RFC 9000 §8.2.3).
+    pub fn onPathResponse(
+        self: *PathManager,
+        key: PathKey,
+        data: [path_challenge_len]u8,
+        now_us: u64,
+    ) ?MigrationOutcome {
+        const index = self.find(key) orelse return null;
+        const path = &self.paths[index].?;
+        if (path.state != .validating) return null;
+        if (now_us > path.challenge_deadline_us) {
+            self.failValidation(path);
+            return null;
+        }
+        if (!std.crypto.timing_safe.eql([path_challenge_len]u8, path.challenge, data)) return null;
+
+        path.state = .validated;
+        path.anti_amplification.markValidated();
+        self.active = index;
+        self.metrics.path_validations_succeeded += 1;
+        switch (path.change) {
+            .nat_rebinding => self.metrics.nat_rebindings += 1,
+            .migration => self.metrics.migrations += 1,
+        }
+        return .{
+            .change = path.change,
+            .reset_congestion = path.change == .migration,
+        };
+    }
+
+    /// Fail every probe whose challenge deadline has passed. Returns how many
+    /// validations failed; callers run this off their timer wheel.
+    pub fn expireValidations(self: *PathManager, now_us: u64) usize {
+        var failed: usize = 0;
+        for (&self.paths) |*slot| {
+            const path = &(slot.* orelse continue);
+            if (path.state != .validating) continue;
+            if (now_us <= path.challenge_deadline_us) continue;
+            self.failValidation(path);
+            failed += 1;
+        }
+        return failed;
+    }
+
+    fn failValidation(self: *PathManager, path: *Path) void {
+        path.state = .failed;
+        self.metrics.path_validations_failed += 1;
+    }
+
+    fn find(self: *const PathManager, key: PathKey) ?usize {
+        for (self.paths, 0..) |slot, index| {
+            const path = slot orelse continue;
+            if (path.key.eql(key)) return index;
+        }
+        return null;
+    }
+
+    /// A free slot, or the oldest non-active failed/unvalidated slot when the
+    /// table is full — probe storms recycle probes, never the active path.
+    fn claimSlot(self: *PathManager) usize {
+        for (self.paths, 0..) |slot, index| {
+            if (slot == null) return index;
+        }
+        for (self.paths, 0..) |slot, index| {
+            if (index == self.active) continue;
+            if (slot.?.state == .failed or slot.?.state == .unvalidated) return index;
+        }
+        // All slots are live probes: recycle the first non-active one.
+        for (self.paths, 0..) |_, index| {
+            if (index != self.active) return index;
+        }
+        unreachable; // max_paths >= 2 guarantees a non-active slot
     }
 };
 
@@ -579,4 +839,143 @@ test "metrics distinguish invalid tokens from normal retry usage" {
 
     try testing.expectEqual(@as(u64, 1), metrics.retry_packets_sent);
     try testing.expectEqual(@as(u64, 2), metrics.invalid_tokens);
+}
+
+// ---------------------------------------------------------------------------
+// Path validation / migration tests (#251)
+// ---------------------------------------------------------------------------
+
+fn testKey(remote_port: u16) PathKey {
+    return .{ .local = loopbackV4(4433), .remote = udp.Address.ip4(.{ 192, 0, 2, 10 }, remote_port) };
+}
+
+fn testKeyOtherHost(remote_port: u16) PathKey {
+    return .{ .local = loopbackV4(4433), .remote = udp.Address.ip4(.{ 198, 51, 100, 7 }, remote_port) };
+}
+
+const test_challenge = [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 };
+
+test "datagrams on the active path require no action" {
+    var manager = PathManager.init(.full, testKey(50_000));
+    try testing.expectEqual(PathDecision.on_active_path, manager.onDatagram(testKey(50_000), test_challenge, 0));
+    try testing.expectEqual(PathState.validated, manager.activePath().state);
+}
+
+test "path validation succeeds deterministically and switches the active path" {
+    var manager = PathManager.init(.full, testKey(50_000));
+    const rebound = testKey(50_001); // same host, new port: NAT rebinding
+
+    const decision = manager.onDatagram(rebound, test_challenge, 1_000);
+    try testing.expectEqualSlices(u8, &test_challenge, &decision.probe);
+    try testing.expectEqual(@as(u64, 1), manager.metrics.path_challenges_sent);
+
+    // Peer echoes the challenge (PATH_RESPONSE semantics are a pure echo).
+    const echoed = PathManager.onPathChallenge(test_challenge);
+    const outcome = manager.onPathResponse(rebound, echoed, 2_000).?;
+    try testing.expectEqual(AddressChange.nat_rebinding, outcome.change);
+    // Port-only rebinding: same underlying path, keep congestion/RTT state.
+    try testing.expect(!outcome.reset_congestion);
+    try testing.expect(manager.activePath().key.eql(rebound));
+    try testing.expectEqual(@as(u64, 1), manager.metrics.nat_rebindings);
+    try testing.expectEqual(@as(u64, 1), manager.metrics.path_validations_succeeded);
+}
+
+test "a real migration validates and requires congestion/RTT reset" {
+    var manager = PathManager.init(.full, testKey(50_000));
+    const migrated = testKeyOtherHost(50_000); // new host: real migration
+
+    _ = manager.onDatagram(migrated, test_challenge, 0);
+    const outcome = manager.onPathResponse(migrated, test_challenge, 100).?;
+    try testing.expectEqual(AddressChange.migration, outcome.change);
+    try testing.expect(outcome.reset_congestion);
+    try testing.expectEqual(@as(u64, 1), manager.metrics.migrations);
+
+    // The documented reset actually reinitializes recovery state.
+    const recovery = @import("recovery.zig");
+    var controller = recovery.RecoveryController{};
+    controller.rtt.update(50_000, 0);
+    controller.congestion.congestion_window = 3;
+    controller.congestion.bytes_in_flight = 999;
+    controller.resetForPathMigration();
+    try testing.expect(!controller.rtt.hasSample());
+    try testing.expectEqual(recovery.CongestionController.initialWindow(recovery.max_datagram_size), controller.congestion.congestion_window);
+    // Packets in flight on the old path are still accounted for.
+    try testing.expectEqual(@as(usize, 999), controller.congestion.bytes_in_flight);
+}
+
+test "a wrong PATH_RESPONSE payload does not validate the path" {
+    var manager = PathManager.init(.full, testKey(50_000));
+    const rebound = testKey(50_001);
+    _ = manager.onDatagram(rebound, test_challenge, 0);
+
+    const wrong = [_]u8{0xff} ** path_challenge_len;
+    try testing.expectEqual(@as(?MigrationOutcome, null), manager.onPathResponse(rebound, wrong, 100));
+    // A response on a different tuple does not validate the probed one either.
+    try testing.expectEqual(@as(?MigrationOutcome, null), manager.onPathResponse(testKeyOtherHost(1), test_challenge, 100));
+    // Still probing; the active path is unchanged.
+    try testing.expect(manager.activePath().key.eql(testKey(50_000)));
+    try testing.expectEqual(@as(u64, 0), manager.metrics.path_validations_succeeded);
+}
+
+test "path validation fails deterministically when the challenge expires" {
+    var manager = PathManager.init(.full, testKey(50_000));
+    manager.validation_timeout_us = 1_000;
+    const rebound = testKey(50_001);
+    _ = manager.onDatagram(rebound, test_challenge, 0);
+
+    // Not yet expired: nothing fails.
+    try testing.expectEqual(@as(usize, 0), manager.expireValidations(1_000));
+    // Past the deadline: the probe fails and is counted.
+    try testing.expectEqual(@as(usize, 1), manager.expireValidations(1_001));
+    try testing.expectEqual(@as(u64, 1), manager.metrics.path_validations_failed);
+    // A late response for the failed probe is ignored.
+    try testing.expectEqual(@as(?MigrationOutcome, null), manager.onPathResponse(rebound, test_challenge, 1_002));
+    // New traffic from the tuple restarts a probe.
+    const retry = manager.onDatagram(rebound, test_challenge, 2_000);
+    try testing.expectEqualSlices(u8, &test_challenge, &retry.probe);
+}
+
+test "migration policy gates rebinding and migration separately" {
+    // disabled: even a port-only rebinding is blocked.
+    var disabled = PathManager.init(.disabled, testKey(50_000));
+    try testing.expectEqual(PathDecision.blocked, disabled.onDatagram(testKey(50_001), test_challenge, 0));
+    try testing.expectEqual(@as(u64, 1), disabled.metrics.migrations_blocked);
+
+    // nat_rebinding_only: port change probes, host change is blocked.
+    var rebind_only = PathManager.init(.nat_rebinding_only, testKey(50_000));
+    const probe = rebind_only.onDatagram(testKey(50_001), test_challenge, 0);
+    try testing.expectEqualSlices(u8, &test_challenge, &probe.probe);
+    try testing.expectEqual(PathDecision.blocked, rebind_only.onDatagram(testKeyOtherHost(50_000), test_challenge, 0));
+    try testing.expectEqual(@as(u64, 1), rebind_only.metrics.migrations_blocked);
+
+    // full: both probe.
+    var full = PathManager.init(.full, testKey(50_000));
+    const rebinding_probe = full.onDatagram(testKey(50_001), test_challenge, 0);
+    try testing.expectEqualSlices(u8, &test_challenge, &rebinding_probe.probe);
+    const migration_probe = full.onDatagram(testKeyOtherHost(50_000), test_challenge, 0);
+    try testing.expectEqualSlices(u8, &test_challenge, &migration_probe.probe);
+}
+
+test "duplicate datagrams on a probing path do not restart the challenge" {
+    var manager = PathManager.init(.full, testKey(50_000));
+    const rebound = testKey(50_001);
+    _ = manager.onDatagram(rebound, test_challenge, 0);
+    const again = manager.onDatagram(rebound, [_]u8{0xee} ** path_challenge_len, 10);
+    try testing.expectEqual(PathDecision.probing, again);
+    try testing.expectEqual(@as(u64, 1), manager.metrics.path_challenges_sent);
+    // The original challenge still validates.
+    try testing.expect(manager.onPathResponse(rebound, test_challenge, 20) != null);
+}
+
+test "probe storms recycle probe slots but never the active path" {
+    var manager = PathManager.init(.full, testKey(50_000));
+    // More new tuples than slots: the oldest probes are recycled.
+    var port: u16 = 50_001;
+    while (port < 50_001 + 2 * max_paths) : (port += 1) {
+        _ = manager.onDatagram(testKey(port), test_challenge, 0);
+    }
+    // The active path survived the storm and still routes.
+    try testing.expect(manager.activePath().key.eql(testKey(50_000)));
+    try testing.expectEqual(PathState.validated, manager.activePath().state);
+    try testing.expectEqual(PathDecision.on_active_path, manager.onDatagram(testKey(50_000), test_challenge, 0));
 }

--- a/src/quic/recovery.zig
+++ b/src/quic/recovery.zig
@@ -443,6 +443,14 @@ pub const RecoveryController = struct {
     /// and can still be acknowledged or declared lost. Skip this for a NAT
     /// rebinding that only changed the peer's port; `path.zig` documents the
     /// policy.
+    ///
+    /// `bytes_in_flight` deliberately carries over: this endpoint has one
+    /// send ledger, and old-path packets drain from it through the normal
+    /// ack/loss paths (zeroing it would double-count capacity now and
+    /// mis-decrement later). The cost is that a large old-path backlog can
+    /// briefly gate sends on the fresh window until it drains — true
+    /// per-path congestion isolation during concurrent validation needs
+    /// per-path controllers, which is multipath-adjacent work outside #251.
     pub fn resetForPathMigration(self: *RecoveryController) void {
         self.rtt = RttEstimator.init(self.rtt.max_ack_delay_us);
         self.congestion = .{ .bytes_in_flight = self.congestion.bytes_in_flight };

--- a/src/quic/recovery.zig
+++ b/src/quic/recovery.zig
@@ -435,6 +435,18 @@ pub const RecoveryController = struct {
         }
         return result;
     }
+
+    /// Reinitialize path-dependent state after migrating to a path with new
+    /// characteristics (RFC 9000 §9.4): the RTT estimate and congestion
+    /// controller reset to their initial values, while packet/ACK tracking
+    /// continues — packets in flight on the old path are still accounted for
+    /// and can still be acknowledged or declared lost. Skip this for a NAT
+    /// rebinding that only changed the peer's port; `path.zig` documents the
+    /// policy.
+    pub fn resetForPathMigration(self: *RecoveryController) void {
+        self.rtt = RttEstimator.init(self.rtt.max_ack_delay_us);
+        self.congestion = .{ .bytes_in_flight = self.congestion.bytes_in_flight };
+    }
 };
 
 fn spaceIndex(space: PacketNumberSpace) usize {

--- a/src/quic/udp.zig
+++ b/src/quic/udp.zig
@@ -41,6 +41,19 @@ pub const Address = struct {
             .ip6 => self.bytes[0..16],
         };
     }
+
+    pub fn eql(self: Address, other: Address) bool {
+        return self.sameHost(other) and self.port == other.port;
+    }
+
+    /// Same IP address (family, octets, scope) regardless of port. A NAT
+    /// rebinding usually changes only the port; a host change is a real
+    /// migration (RFC 9308 §4.1).
+    pub fn sameHost(self: Address, other: Address) bool {
+        if (self.family != other.family) return false;
+        if (self.scope_id != other.scope_id) return false;
+        return std.mem.eql(u8, self.slice(), other.slice());
+    }
 };
 
 pub const ReceivedDatagram = struct {


### PR DESCRIPTION
## Summary
- Implements connection-ID lifecycle and path handling for the pure-Zig QUIC transport (#251), following the repo's established patterns: bounded no-alloc state where possible, caller-supplied entropy everywhere, and wire-free frame state models like `stream.zig`'s (the packet codec owns byte encoding).
- **CID lifecycle** (`src/quic/cid.zig`, extending the #250 stateless-reset material):
  - `generateCid` — deterministic CID generation from caller entropy (4–20 bytes).
  - `CidRoutingTable` — DCID → connection-handle map so demultiplexing never consults the peer address; that's the property that lets connections survive rebinding/migration. Hits and misses are counted (unknown-CID traffic feeds the #250 stateless-reset/drop path).
  - `LocalCidRegistry` — CIDs we issued: `NEW_CONNECTION_ID` frame models carrying RFC 9000 §10.3.1-derived stateless-reset tokens, enforcement of the peer's `active_connection_id_limit`, and `RETIRE_CONNECTION_ID` consumption where never-issued sequences are protocol violations and retransmits are no-ops.
  - `PeerCidPool` — CIDs the peer issued: RFC 9000 §19.15 validation (sequence reuse with different contents, same CID under different sequences, `retire_prior_to > sequence` all rejected; exact retransmits tolerated), `retire_prior_to` sweeps with queued `RETIRE_CONNECTION_ID` responses, advertised-limit enforcement, and §9.5-compliant fresh-CID claims for migration (a used CID is never reused across paths).
- **Path handling** (`src/quic/path.zig`): `PathManager` keyed by the (local, remote) address tuple — `PATH_CHALLENGE`/`PATH_RESPONSE` validation with timing-safe echo comparison and deterministic expiry, NAT-rebinding (same host, new port) vs. real-migration (new host) classification per RFC 9308 §4.1, gating by `config.MigrationPolicy` (`disabled` / `nat_rebinding_only` / `full`), per-path anti-amplification ledgers, and probe-slot recycling that can never evict the active path under a probe storm.
- **Congestion/RTT reset** (`src/quic/recovery.zig`): `RecoveryController.resetForPathMigration` reinitializes the RTT estimator and congestion controller per RFC 9000 §9.4 while packet/ACK tracking (and bytes in flight) carries over. Documented policy: reset on host change, keep on port-only rebinding since the underlying path is almost certainly unchanged.
- `udp.Address` gains `eql`/`sameHost`; module headers and changelog updated.

## Acceptance criteria (#251)
- ✅ CID lookup routes packets to the correct connection independent of the UDP 4-tuple (multiple CIDs per connection covered)
- ✅ Retired CIDs no longer route (removed from the table the moment `retire` returns them)
- ✅ NAT rebinding tolerated when policy allows; blocked and counted when not
- ✅ Path validation succeeds/fails deterministically (echo match, wrong payload, wrong path, expiry — all pinned)
- ✅ Real migration resets RTT/congestion per the documented policy; rebinding preserves it
- ✅ Metrics distinguish NAT rebinding, migration, validation failure, blocked attempts, CID retirement (both directions), and unknown-CID routing misses

## Non-goals honored
No multipath, no load-balancer CID format, no eBPF/reuseport routing. Connection-layer wiring (feeding `PathManager` decisions from real datagrams, sending the queued frames) lands with the #247 driver integration.

## Test plan
- [x] `zig build test-quic` — 209 tests across four targets, all passing (16 new)
- [x] CID: generation bounds, routing hits/misses, retirement stops routing, unknown-sequence violation, retransmit no-ops, peer-limit enforcement, NEW_CONNECTION_ID conflict/malformed rejection, retire_prior_to sweep with queued responses, fresh-CID migration claims
- [x] Path: validation success switches the active path, wrong payload/path rejected, deterministic expiry with late-response rejection and re-probe, policy gating for all three modes, duplicate probe traffic doesn't restart challenges, probe storms never evict the active path
- [x] Migration reset: RTT sample cleared, congestion window reinitialized, bytes-in-flight preserved
- [x] Leak stress: 10,000 issue/retire rotations keep the routing table and registry bounded
- [x] `zig build test` full suite exits 0

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)