### PR TITLE
feat(quic): scaffold qlog/keylog observability seam for pure-Zig QUIC/H3 (#255)

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -238,3 +238,12 @@ A healthy reload increments `reload_attempts_total` and `reload_success_total`
 together; a rejected reload increments `reload_attempts_total` and
 `reload_failure_total` while the reload-status endpoint reports `ok: false` with
 the rejection reason.
+
+## QUIC / HTTP-3 (pure-Zig backend)
+
+The pure-Zig QUIC/H3 stack (#240) has its own transport-level observability
+seam — qlog event tracing, TLS key logging for local decryption, and planned
+Prometheus counters — designed in [`QUIC_QLOG.md`](QUIC_QLOG.md). Unlike the
+stable HTTP/1.1 contract above, these paths are **disabled by default** and are
+**sensitive/debug-only**: a key log decrypts the connection. They are for local
+debugging and the interop harness (#247), never a production default.

--- a/docs/QUIC_QLOG.md
+++ b/docs/QUIC_QLOG.md
@@ -20,8 +20,11 @@ layering, and the safety rules up front so those call-sites are mechanical.
 - Make handshake, loss/PTO, path validation/migration, stream reset,
   flow-control blocking, and QPACK head-of-line blocking **distinguishable**
   from a captured trace, not just from ad-hoc `std.log` lines.
-- Produce artifacts (`*.qlog`, `*.keys`) that the interop/failure harnesses
-  (#247) can save and that qvis / Wireshark can consume directly.
+- Provide the primitives (trace-header + event-line + keylog-line writers) so
+  that, once the composition root assembles them, the interop/failure harnesses
+  (#247) save `*.qlog` / `*.keys` artifacts that qvis / Wireshark consume
+  directly. This PR ships those writers and the merged-shape test; the root
+  wiring that emits real flows is follow-up.
 - Keep everything **off by default** and cheap when off.
 - Keep HTTP/3 out of `src/quic` (the #255 layering constraint).
 
@@ -129,9 +132,26 @@ Each record is one JSON-SEQ line:
 - Writers are **allocation-free**: they format into a caller-owned buffer
   (`writeJson(record, buf)`), matching the bounded-buffer style already used by
   the TLS handshake wire writer. A 512-byte buffer covers every event.
-- A qlog file is a trace header (emitted once by the root) followed by these
-  lines. The header (vantage point, `reference_time`, ODCID group id) is the
-  root's responsibility since only it spans both packages.
+- A qlog file is a trace header followed by these event lines.
+  `qlog.writeTraceHeader(header, buf)` serializes that header (qlog version,
+  vantage point, `reference_time`, and ODCID `group_id`) as the first JSON-SEQ
+  record. The header spans both packages — the `group_id` ties transport and
+  H3 events to one connection — so the **composition root** fills it in and
+  writes it once, then appends event records from both `quic` and `http3`. The
+  `tests/quic_h3_smoke.zig` harness exercises exactly this shape (header +
+  transport record + H3 record) so the merged-file contract is locked.
+
+### Sink error handling
+
+`Sink.emit` returns `void` so transport/H3 emission stays infallible on the hot
+path — a dropped debug record must never fail a connection, mirroring
+`recovery.EventSink`. The tradeoff: a concrete file sink cannot propagate
+serialization / disk-full / permission errors back through `emit`. The
+**contract for concrete sinks** is therefore to *retain the first write error
+and/or count dropped records* and expose that out-of-band, so a truncated trace
+is detectable rather than silently lost during interop. This is a requirement on
+the composition-root sink implementation, documented here before that wiring
+lands.
 
 ## Keylog
 

--- a/docs/QUIC_QLOG.md
+++ b/docs/QUIC_QLOG.md
@@ -1,0 +1,226 @@
+# QUIC/HTTP-3 Observability: qlog, keylog, metrics
+
+Design for the minimal qlog / keylog / metrics seam the pure-Zig QUIC and
+HTTP/3 stack (#240) needs **before** external interop and fuzzing (#247, #255).
+
+This document is the design of record. The scaffolding it describes lives in:
+
+- `src/quic/qlog.zig` — transport-vantage event model + JSON-SEQ serializer.
+- `src/http3/qlog.zig` — HTTP/3- and QPACK-vantage event model + serializer.
+- `src/quic/keylog.zig` — NSS `SSLKEYLOGFILE` label mapping + line writer.
+- `src/quic/config.zig` — `Observability { qlog_enabled, keylog_enabled }`.
+
+The intent is **design + small scaffold**, not a full observability
+implementation. Emission call-sites in the connection/packet/stream/path layers
+are added as those layers land; this seam fixes the event vocabulary, the
+layering, and the safety rules up front so those call-sites are mechanical.
+
+## Goals
+
+- Make handshake, loss/PTO, path validation/migration, stream reset,
+  flow-control blocking, and QPACK head-of-line blocking **distinguishable**
+  from a captured trace, not just from ad-hoc `std.log` lines.
+- Produce artifacts (`*.qlog`, `*.keys`) that the interop/failure harnesses
+  (#247) can save and that qvis / Wireshark can consume directly.
+- Keep everything **off by default** and cheap when off.
+- Keep HTTP/3 out of `src/quic` (the #255 layering constraint).
+
+## Non-goals (per the issue)
+
+- qvis UI integration, high-cardinality per-client metrics, always-on qlog.
+- A general logging framework; this is transport observability only.
+
+## Layering: where emission belongs
+
+`src/quic` and `src/http3` are **independent modules** — the build graph keeps
+them apart on purpose (see `build.zig`: the smoke harness stitches the two
+together "so neither package learns about the other"). The observability seam
+respects that boundary rather than punching through it.
+
+```
+                 composition root (gateway h3 listener / smoke harness)
+                 ┌───────────────────────────────────────────────────┐
+                 │  owns the *.qlog file + *.keys file writers        │
+                 │  installs one quic.qlog.Sink, one http3.qlog.Sink, │
+                 │  one quic.keylog.Sink; interleaves all three       │
+                 └───────────────▲───────────────▲───────────────▲────┘
+                                 │ Record        │ Record        │ Entry
+        transport events ────────┘        H3/QPACK events ┘   TLS secrets ┘
+        emitted by src/quic               emitted by src/http3   emitted by
+        (connection, packet,              (session, frame,       src/quic
+         recovery, path, stream)           qpack)                (tls_adapter)
+```
+
+Rules:
+
+1. **Transport-vantage events** (`connectivity`, `security`, `transport`,
+   `recovery` qlog categories) are defined in `src/quic/qlog.zig` and emitted
+   from the transport layers. `src/quic` imports no HTTP/3 type.
+2. **Application-vantage events** (`http`, `qpack` categories) are defined in
+   `src/http3/qlog.zig` and emitted from `src/http3`. `src/http3` imports no
+   transport type.
+3. Both packages emit through an **injected `Sink`** — an opaque context plus a
+   function pointer, exactly like the existing `recovery.EventSink`. A default
+   `Sink{}` is a no-op, so the seam costs nothing until a root wires it.
+4. The **concrete file writers** live at the composition root, which already
+   owns both packages. It timestamps and interleaves the streams into one
+   JSON-SEQ `.qlog` file, so a single trace still shows transport and H3 events
+   side by side without either package depending on the other.
+
+This is why there is no single shared "qlog writer" module: sharing one would
+force one package to import the other's event type. Two small symmetric writers
+with an identical line format (`0x1E` + JSON + `\n`, RFC 7464 JSON-SEQ) compose
+into one valid file at the root instead.
+
+### Relationship to existing hooks and metrics
+
+- `recovery.EventSink` / `recovery.Event` already exist for ACK/loss/PTO. The
+  connection layer bridges those into `qlog.Event.packet_lost` etc. rather than
+  duplicating loss logic — `recovery` stays qlog-agnostic.
+- Per-module counters already exist and remain the source for Prometheus:
+  `tls_adapter.Metrics` (protect/deprotect/deprotection-failure),
+  `path.Metrics` (challenges, migrations, amplification-blocked),
+  `stream.Metrics` (resets, stop-sending). qlog is the *event* view; these
+  counters are the *aggregate* view. The two are independent and both feed the
+  same operator story.
+
+## qlog event catalogue
+
+Names below are `category:event`. Transport events (`src/quic/qlog.zig`):
+
+| Requirement (#255)        | qlog event                          | Key data |
+|---------------------------|-------------------------------------|----------|
+| handshake                 | `connectivity:connection_started`   | odcid/scid/dcid lengths |
+|                           | `connectivity:handshake`            | `stage` (started → confirmed / failed) |
+|                           | `connectivity:connection_closed`    | `reason`, optional `error_code` |
+|                           | `security:key_updated`              | `key_phase` |
+| packet sent               | `transport:packet_sent`             | type, number, length, ack-eliciting |
+| packet received           | `transport:packet_received`         | type, number, length |
+| packet lost               | `recovery:packet_lost`              | type, number, bytes-in-flight, cwnd |
+| **deprotection failure**  | `transport:packet_dropped`          | `trigger:"payload_decrypt_error"` |
+| PATH_CHALLENGE/RESPONSE   | `transport:path_validation`         | `phase` (challenge/response sent/received, validated, failed) |
+| migration                 | `connectivity:connection_migrated`  | `kind` (nat_rebinding/active), `outcome` (accepted/blocked) |
+| stream reset              | `transport:stream_reset`            | `direction` (reset/stop-sending, sent/received), stream id, error code |
+| flow-control blocked      | `transport:data_blocked`            | `scope` (connection/stream), optional stream id, limit |
+
+Application events (`src/http3/qlog.zig`):
+
+| Requirement (#255)        | qlog event                          | Key data |
+|---------------------------|-------------------------------------|----------|
+| SETTINGS                  | `http:parameters_set`               | max field section size, QPACK table cap, blocked streams |
+| control stream / HEADERS / DATA / GOAWAY | `http:frame_created` / `http:frame_parsed` | frame type, stream id, length |
+| **QPACK blocked**         | `qpack:stream_state_updated`        | `state` (blocked/unblocked), stream id |
+
+`transport:packet_dropped` with `trigger:"payload_decrypt_error"` is the
+canonical qlog encoding of an AEAD deprotection failure, satisfying the #255
+requirement that deprotection failures are reported deterministically. It is
+distinct from a normal drop (`unknown_connection_id`, `key_unavailable`, …).
+
+### Serialization format
+
+Each record is one JSON-SEQ line:
+
+```
+0x1E {"time":<ms>.<us>,"name":"transport:packet_sent","data":{ … }}\n
+```
+
+- Time is milliseconds (qlog's default `time_units`) with microsecond
+  precision, derived from a monotonic `time_us`.
+- Writers are **allocation-free**: they format into a caller-owned buffer
+  (`writeJson(record, buf)`), matching the bounded-buffer style already used by
+  the TLS handshake wire writer. A 512-byte buffer covers every event.
+- A qlog file is a trace header (emitted once by the root) followed by these
+  lines. The header (vantage point, `reference_time`, ODCID group id) is the
+  root's responsibility since only it spans both packages.
+
+## Keylog
+
+`src/quic/keylog.zig` maps a `(perspective, direction, level)` triple from the
+TLS adapter to an NSS `SSLKEYLOGFILE` label and formats the line:
+
+```
+<LABEL> <client_random_hex> <secret_hex>\n
+```
+
+Labels: `CLIENT_EARLY_TRAFFIC_SECRET`, `{CLIENT,SERVER}_HANDSHAKE_TRAFFIC_SECRET`,
+`{CLIENT,SERVER}_TRAFFIC_SECRET_0`. **Initial secrets are never logged** — they
+are derivable from the client DCID on the wire, so logging them only widens the
+exposure without adding debugging value.
+
+Wiring point: `QuicTlsAdapter.installSecret` is the single choke point where
+every traffic secret is installed, so a keylog `Sink` is invoked there (guarded
+by `keylog_enabled`) before the secret is later wiped.
+
+### Sensitive / debug-only behaviour  ⚠️
+
+A key log **is** the plaintext. Anyone holding the `.keys` file plus a packet
+capture can decrypt the entire connection.
+
+- **Disabled by default.** `config.Observability.keylog_enabled` is `false`.
+  qlog is likewise `false` by default.
+- **Never in production.** These paths are for local debugging and the interop
+  harness only. Treat the key-log destination with the same care as the
+  private key: local filesystem, restrictive permissions, deleted after use.
+  Do not point it at shared storage, logs, or anything network-reachable.
+- **Not for third-party traffic.** Only key-log connections you own and are
+  authorized to decrypt.
+- The adapter otherwise wipes these secrets (`SecretStore.wipe`); the key log is
+  the only path by which they leave the process.
+- Artifacts the harness saves (`*.qlog`, `*.keys`) inherit this: store them with
+  the capture, scrub them from CI logs, and never attach them to public issues.
+
+## Configuration
+
+`config.Observability`:
+
+```zig
+qlog_enabled: bool = false,   // emit qlog events for local/debug runs
+keylog_enabled: bool = false, // emit TLS secrets for local decryption
+```
+
+Both default off and are intended to be reachable only through explicit
+debug/interop configuration, never a production default. The concrete
+destinations (qlog directory, keylog path) are supplied by the composition root
+that owns the writers, not by the transport config, keeping file I/O out of the
+transport core.
+
+## Metrics (Prometheus) — planned surface
+
+qlog answers "what happened on this one connection"; Prometheus answers "what is
+happening across all connections". The existing per-module `Metrics` counters
+are the source. The gateway `/status/metrics` endpoint (see
+`docs/OBSERVABILITY.md`) will export, when the pure-Zig backend is active:
+
+- `tardigrade_quic_connections_active` (gauge)
+- `tardigrade_quic_handshake_failures_total{stage}`
+- `tardigrade_quic_retry_total`, `tardigrade_quic_amplification_blocked_total`
+- `tardigrade_quic_pto_total`, `tardigrade_quic_packets_lost_total`
+- `tardigrade_quic_bytes_sent_total`, `tardigrade_quic_bytes_received_total`
+- `tardigrade_quic_stream_resets_total`
+- `tardigrade_quic_flow_control_blocked_total`
+- `tardigrade_quic_deprotection_failures_total`
+- `tardigrade_h3_qpack_blocked_streams` (gauge)
+- `tardigrade_h3_requests_total` and an h3 latency histogram
+
+Labels are kept low-cardinality (e.g. `stage`, not per-client) per the issue's
+non-goals. Wiring these into the gateway registry is follow-up work; the
+counters they read from already exist.
+
+## Testing strategy
+
+- **Unit** (in place): event category/name mapping and JSON-SEQ serialization
+  for representative transport events, QPACK blocking, and keylog line format,
+  in `src/quic/qlog.zig`, `src/http3/qlog.zig`, `src/quic/keylog.zig`.
+- **Integration** (follow-up, with the connection layer): drive a handshake and
+  assert a produced `.qlog` contains the expected event classes; snapshot
+  metrics on common error paths.
+- **Manual**: load a saved `.qlog` in qvis and a capture + `.keys` in Wireshark
+  once enough transport exists to produce real flows.
+
+## References
+
+- qlog main schema & QUIC/HTTP-3 event definitions (IETF drafts)
+- qvis tooling; QUIC Interop Runner artifact conventions
+- RFC 7464 (JSON Text Sequences), RFC 9000/9001/9002, RFC 9114/9204
+- NSS `SSLKEYLOGFILE` format
+- #240 pure-Zig QUIC/HTTP-3 foundation, #247 interop/fuzz/benchmark harness

--- a/docs/QUIC_TLS.md
+++ b/docs/QUIC_TLS.md
@@ -100,3 +100,8 @@ where appropriate, but its `Client` state machine cannot drive a QUIC handshake.
   cipher suites and signature algorithms, and web-PKI certificate-chain
   validation in the pure-Zig backend.
 - Interop, fuzz, and benchmark coverage against ngtcp2/nghttp3 and quiche (#247).
+- TLS key logging for local decryption (#255): `installSecret` is the single
+  choke point where every traffic secret is installed, so the debug-only keylog
+  `Sink` (`src/quic/keylog.zig`) is invoked there when `keylog_enabled`. Initial
+  secrets are intentionally never logged. See `docs/QUIC_QLOG.md` for the
+  sensitive/debug-only handling rules.

--- a/src/http3/qlog.zig
+++ b/src/http3/qlog.zig
@@ -95,6 +95,10 @@ pub const Record = struct {
 /// Injected emission seam — same shape as `quic.qlog.Sink`, so a composition
 /// root can hold one of each and route both into the same trace file. A default
 /// `.{}` is a no-op.
+///
+/// `emit_fn` returns `void`, so a concrete file sink cannot propagate write
+/// errors here. Same contract as the transport sink: retain the first error
+/// and/or count dropped records out-of-band so a truncated trace is detectable.
 pub const Sink = struct {
     context: ?*anyopaque = null,
     emit_fn: ?*const fn (?*anyopaque, Record) void = null,

--- a/src/http3/qlog.zig
+++ b/src/http3/qlog.zig
@@ -1,0 +1,216 @@
+//! HTTP/3- and QPACK-vantage qlog events (#255).
+//!
+//! The symmetric half of `src/quic/qlog.zig`. It exists here, in `src/http3`,
+//! because these events (`http:*`, `qpack:*`) describe the *application*
+//! mapping — SETTINGS, control-stream framing, HEADERS/DATA, GOAWAY, and QPACK
+//! head-of-line blocking — and must not leak into the transport package. Just
+//! like the transport side it emits through an injected `Sink`; the concrete
+//! qlog file writer lives at the composition root and interleaves this stream
+//! with the transport stream into one trace.
+//!
+//! Scope note: only the events needed before external interop are modelled
+//! here. `qpack_state_updated` (blocked/unblocked) is the load-bearing one for
+//! #255 — QPACK head-of-line blocking is otherwise invisible in application
+//! logs — with the frame/settings events included so a trace can attribute a
+//! stall to the right H3 exchange.
+
+const std = @import("std");
+
+/// qlog application-vantage categories owned by HTTP/3.
+pub const Category = enum {
+    http,
+    qpack,
+
+    pub fn label(self: Category) []const u8 {
+        return @tagName(self);
+    }
+};
+
+/// H3 frame types we surface in traces (RFC 9114 §7.2).
+pub const FrameType = enum {
+    data,
+    headers,
+    settings,
+    goaway,
+    push_promise,
+    cancel_push,
+    max_push_id,
+
+    pub fn label(self: FrameType) []const u8 {
+        return @tagName(self);
+    }
+};
+
+pub const Direction = enum { created, parsed };
+
+/// QPACK stream state (RFC 9204 §2.1.2): a request stream becomes `blocked`
+/// when it references a dynamic-table entry not yet acknowledged by the
+/// encoder stream, and `unblocked` once the required insert count arrives.
+pub const QpackState = enum { blocked, unblocked };
+
+pub const Event = union(enum) {
+    /// http:parameters_set (SETTINGS applied)
+    parameters_set: struct {
+        max_field_section_size: ?u64 = null,
+        qpack_max_table_capacity: ?u64 = null,
+        qpack_blocked_streams: ?u64 = null,
+    },
+    /// http:frame_created / http:frame_parsed
+    frame: struct {
+        direction: Direction,
+        frame_type: FrameType,
+        stream_id: u64,
+        length: usize = 0,
+    },
+    /// qpack:stream_state_updated (head-of-line blocking)
+    qpack_state_updated: struct {
+        state: QpackState,
+        stream_id: u64,
+    },
+
+    pub fn category(self: Event) Category {
+        return switch (self) {
+            .parameters_set, .frame => .http,
+            .qpack_state_updated => .qpack,
+        };
+    }
+
+    pub fn name(self: Event) []const u8 {
+        return switch (self) {
+            .parameters_set => "parameters_set",
+            .frame => |f| switch (f.direction) {
+                .created => "frame_created",
+                .parsed => "frame_parsed",
+            },
+            .qpack_state_updated => "stream_state_updated",
+        };
+    }
+};
+
+pub const Record = struct {
+    time_us: u64,
+    event: Event,
+};
+
+/// Injected emission seam — same shape as `quic.qlog.Sink`, so a composition
+/// root can hold one of each and route both into the same trace file. A default
+/// `.{}` is a no-op.
+pub const Sink = struct {
+    context: ?*anyopaque = null,
+    emit_fn: ?*const fn (?*anyopaque, Record) void = null,
+
+    pub fn emit(self: Sink, record: Record) void {
+        if (self.emit_fn) |f| f(self.context, record);
+    }
+
+    pub fn log(self: Sink, time_us: u64, event: Event) void {
+        self.emit(.{ .time_us = time_us, .event = event });
+    }
+};
+
+/// JSON-SEQ record separator (RFC 7464), identical framing to the transport
+/// side so both streams concatenate into one valid qlog JSON-SEQ file.
+pub const record_separator: u8 = 0x1e;
+
+const Buf = struct {
+    buf: []u8,
+    len: usize = 0,
+
+    fn add(self: *Buf, comptime fmt: []const u8, args: anytype) error{NoSpaceLeft}!void {
+        const written = try std.fmt.bufPrint(self.buf[self.len..], fmt, args);
+        self.len += written.len;
+    }
+
+    fn slice(self: *const Buf) []const u8 {
+        return self.buf[0..self.len];
+    }
+};
+
+fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
+    switch (event) {
+        .parameters_set => |d| {
+            try b.add("{{", .{});
+            var need_comma = false;
+            if (d.max_field_section_size) |v| {
+                try b.add("\"max_field_section_size\":{d}", .{v});
+                need_comma = true;
+            }
+            if (d.qpack_max_table_capacity) |v| {
+                if (need_comma) try b.add(",", .{});
+                try b.add("\"qpack_max_table_capacity\":{d}", .{v});
+                need_comma = true;
+            }
+            if (d.qpack_blocked_streams) |v| {
+                if (need_comma) try b.add(",", .{});
+                try b.add("\"qpack_blocked_streams\":{d}", .{v});
+            }
+            try b.add("}}", .{});
+        },
+        .frame => |d| try b.add(
+            "{{\"stream_id\":{d},\"frame\":{{\"frame_type\":\"{s}\"}},\"length\":{d}}}",
+            .{ d.stream_id, d.frame_type.label(), d.length },
+        ),
+        .qpack_state_updated => |d| try b.add(
+            "{{\"stream_id\":{d},\"state\":\"{s}\"}}",
+            .{ d.stream_id, @tagName(d.state) },
+        ),
+    }
+}
+
+/// Serialize one `Record` into `out` as a single qlog JSON-SEQ line. Same shape
+/// as `quic.qlog.writeJson` so a merged trace is uniform.
+pub fn writeJson(record: Record, out: []u8) error{NoSpaceLeft}![]const u8 {
+    var b = Buf{ .buf = out };
+    try b.add("{c}", .{record_separator});
+    try b.add(
+        "{{\"time\":{d}.{d:0>3},\"name\":\"{s}:{s}\",\"data\":",
+        .{ record.time_us / 1000, record.time_us % 1000, record.event.category().label(), record.event.name() },
+    );
+    try writeData(&b, record.event);
+    try b.add("}}\n", .{});
+    return b.slice();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+fn expectJson(record: Record, needle: []const u8) !void {
+    var buf: [512]u8 = undefined;
+    const line = try writeJson(record, &buf);
+    try testing.expect(line[0] == record_separator);
+    try testing.expect(line[line.len - 1] == '\n');
+    try testing.expect(std.mem.indexOf(u8, line, needle) != null);
+}
+
+test "qpack blocking is a qpack:stream_state_updated event" {
+    const ev = Event{ .qpack_state_updated = .{ .state = .blocked, .stream_id = 12 } };
+    try testing.expectEqual(Category.qpack, ev.category());
+    try expectJson(.{ .time_us = 42, .event = ev }, "\"name\":\"qpack:stream_state_updated\"");
+    try expectJson(.{ .time_us = 42, .event = ev }, "\"state\":\"blocked\"");
+}
+
+test "frame direction chooses frame_created vs frame_parsed" {
+    try expectJson(
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .frame_type = .headers, .stream_id = 0, .length = 20 } } },
+        "\"name\":\"http:frame_created\"",
+    );
+    try expectJson(
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .parsed, .frame_type = .goaway, .stream_id = 3 } } },
+        "\"name\":\"http:frame_parsed\"",
+    );
+}
+
+test "parameters_set only emits present settings" {
+    try expectJson(
+        .{ .time_us = 0, .event = .{ .parameters_set = .{ .qpack_blocked_streams = 16 } } },
+        "{\"qpack_blocked_streams\":16}",
+    );
+}
+
+test "default sink is a no-op" {
+    const sink = Sink{};
+    sink.log(1, .{ .qpack_state_updated = .{ .state = .unblocked, .stream_id = 0 } });
+}

--- a/src/http3/root.zig
+++ b/src/http3/root.zig
@@ -7,6 +7,7 @@ pub const transport = @import("transport.zig");
 pub const frame = @import("frame.zig");
 pub const qpack = @import("qpack.zig");
 pub const session = @import("session.zig");
+pub const qlog = @import("qlog.zig");
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/quic/config.zig
+++ b/src/quic/config.zig
@@ -46,6 +46,12 @@ pub const QpackMode = enum {
     dynamic,
 };
 
+/// qlog/keylog toggles for the pure-Zig QUIC/H3 stack (#255). Both default off
+/// and are sensitive/debug-only: qlog reveals connection internals and keylog
+/// reveals the TLS traffic secrets that decrypt the connection. See
+/// `docs/QUIC_QLOG.md` for the event model and safe-handling rules. The event
+/// seam lives in `src/quic/qlog.zig` (+ `keylog.zig`) and `src/http3/qlog.zig`;
+/// destinations are supplied by the composition root, not this config.
 pub const Observability = struct {
     qlog_enabled: bool = false,
     keylog_enabled: bool = false,

--- a/src/quic/keylog.zig
+++ b/src/quic/keylog.zig
@@ -1,0 +1,180 @@
+//! TLS key-log support for local QUIC decryption (#255).
+//!
+//! ## What this is
+//!
+//! Wireshark/qvis can only decrypt a captured QUIC flow if it is handed the
+//! TLS traffic secrets. The de-facto interchange format is NSS's
+//! `SSLKEYLOGFILE` — one line per secret:
+//!
+//!     <LABEL> <client_random_hex> <secret_hex>
+//!
+//! This module maps a `(perspective, direction, level)` triple from the TLS
+//! adapter onto the correct NSS label and formats that line. It does **not**
+//! open files or read `SSLKEYLOGFILE` itself: like `qlog.Sink`, secrets are
+//! handed to an injected `Sink` and the composition root decides where they go.
+//!
+//! ## Why this is sensitive / debug-only
+//!
+//! A key log is exactly the material needed to decrypt the connection. Emitting
+//! it defeats the confidentiality QUIC provides, so:
+//!
+//!   * it is gated behind `config.Observability.keylog_enabled`, which is
+//!     `false` by default;
+//!   * the adapter otherwise **wipes** these secrets (`SecretStore.wipe`), so a
+//!     key log is the *only* place they escape — treat the destination as
+//!     equivalent to the plaintext;
+//!   * Initial secrets are intentionally never logged: they are derivable from
+//!     the client DCID on the wire and add no debugging value while widening the
+//!     surface.
+//!
+//! Operator guidance lives in `docs/QUIC_QLOG.md`.
+
+const std = @import("std");
+const tls = @import("tls_adapter.zig");
+
+/// NSS key-log labels QUIC/TLS 1.3 uses (RFC 9001 keys are TLS 1.3 secrets).
+pub const Label = enum {
+    client_early_traffic_secret,
+    client_handshake_traffic_secret,
+    server_handshake_traffic_secret,
+    client_traffic_secret_0,
+    server_traffic_secret_0,
+
+    pub fn text(self: Label) []const u8 {
+        return switch (self) {
+            .client_early_traffic_secret => "CLIENT_EARLY_TRAFFIC_SECRET",
+            .client_handshake_traffic_secret => "CLIENT_HANDSHAKE_TRAFFIC_SECRET",
+            .server_handshake_traffic_secret => "SERVER_HANDSHAKE_TRAFFIC_SECRET",
+            .client_traffic_secret_0 => "CLIENT_TRAFFIC_SECRET_0",
+            .server_traffic_secret_0 => "SERVER_TRAFFIC_SECRET_0",
+        };
+    }
+};
+
+/// The classic `client_random` from the ClientHello ties every line in a key
+/// log to its connection. QUIC has no TLS record layer, but the TLS 1.3
+/// ClientHello still carries a 32-byte random that Wireshark keys on.
+pub const client_random_len = 32;
+
+/// Resolve which NSS label a freshly installed secret should be logged under,
+/// or null when it should not be logged at all (Initial keys, and the
+/// server-side "early" slot which does not exist).
+///
+/// `direction` is relative to this endpoint: `.write` is the secret this
+/// endpoint encrypts with, `.read` the peer's. NSS labels are phrased from the
+/// client/server point of view, so we fold `perspective` and `direction`
+/// together to decide whose secret it is.
+pub fn labelFor(
+    perspective: tls.Perspective,
+    direction: tls.Direction,
+    level: tls.EncryptionLevel,
+) ?Label {
+    const is_client_secret = switch (direction) {
+        .write => perspective == .client,
+        .read => perspective == .server,
+    };
+    return switch (level) {
+        .initial => null,
+        .zero_rtt => if (is_client_secret) .client_early_traffic_secret else null,
+        .handshake => if (is_client_secret) .client_handshake_traffic_secret else .server_handshake_traffic_secret,
+        .application => if (is_client_secret) .client_traffic_secret_0 else .server_traffic_secret_0,
+    };
+}
+
+/// One key-log entry: everything an NSS line needs, borrowing (not copying) the
+/// secret bytes. The `Sink` is expected to format-and-write synchronously.
+pub const Entry = struct {
+    label: Label,
+    client_random: []const u8,
+    secret: []const u8,
+};
+
+/// Injected write seam, mirroring `qlog.Sink`. Default `.{}` is a no-op, so
+/// key logging is off unless a composition root wires a destination.
+pub const Sink = struct {
+    context: ?*anyopaque = null,
+    emit_fn: ?*const fn (?*anyopaque, Entry) void = null,
+
+    pub fn emit(self: Sink, entry: Entry) void {
+        if (self.emit_fn) |f| f(self.context, entry);
+    }
+};
+
+/// Format one NSS `SSLKEYLOGFILE` line (including the trailing newline) into
+/// `out`. Returns the written slice, or `error.NoSpaceLeft` if `out` is too
+/// small — a 256-byte buffer covers a 32-byte random and a 48-byte secret.
+pub fn writeLine(entry: Entry, out: []u8) error{NoSpaceLeft}![]const u8 {
+    const label = entry.label.text();
+    const needed = label.len + 1 + entry.client_random.len * 2 + 1 + entry.secret.len * 2 + 1;
+    if (out.len < needed) return error.NoSpaceLeft;
+
+    var i: usize = 0;
+    @memcpy(out[i .. i + label.len], label);
+    i += label.len;
+    out[i] = ' ';
+    i += 1;
+    i += writeHex(entry.client_random, out[i..]);
+    out[i] = ' ';
+    i += 1;
+    i += writeHex(entry.secret, out[i..]);
+    out[i] = '\n';
+    i += 1;
+    return out[0..i];
+}
+
+fn writeHex(bytes: []const u8, out: []u8) usize {
+    const hex = "0123456789abcdef";
+    for (bytes, 0..) |b, idx| {
+        out[idx * 2] = hex[b >> 4];
+        out[idx * 2 + 1] = hex[b & 0x0f];
+    }
+    return bytes.len * 2;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+test "initial secrets are never logged" {
+    try testing.expectEqual(@as(?Label, null), labelFor(.client, .write, .initial));
+    try testing.expectEqual(@as(?Label, null), labelFor(.server, .read, .initial));
+}
+
+test "label folds perspective and direction into client/server secrets" {
+    // Client endpoint: its write secret is the client's, its read secret the server's.
+    try testing.expectEqual(Label.client_handshake_traffic_secret, labelFor(.client, .write, .handshake).?);
+    try testing.expectEqual(Label.server_handshake_traffic_secret, labelFor(.client, .read, .handshake).?);
+    // Server endpoint: mirror image.
+    try testing.expectEqual(Label.server_traffic_secret_0, labelFor(.server, .write, .application).?);
+    try testing.expectEqual(Label.client_traffic_secret_0, labelFor(.server, .read, .application).?);
+    // 0-RTT only exists for the client's early data.
+    try testing.expectEqual(Label.client_early_traffic_secret, labelFor(.client, .write, .zero_rtt).?);
+    try testing.expectEqual(@as(?Label, null), labelFor(.server, .write, .zero_rtt));
+}
+
+test "writeLine emits a well-formed NSS key-log line" {
+    const random = [_]u8{0xab} ** client_random_len;
+    const secret = [_]u8{ 0x00, 0x0f, 0xff };
+    var buf: [256]u8 = undefined;
+    const line = try writeLine(.{ .label = .client_traffic_secret_0, .client_random = &random, .secret = &secret }, &buf);
+    try testing.expect(std.mem.startsWith(u8, line, "CLIENT_TRAFFIC_SECRET_0 "));
+    try testing.expect(std.mem.endsWith(u8, line, " 000fff\n"));
+    // 32-byte random renders as 64 hex chars of 'ab'.
+    try testing.expect(std.mem.indexOf(u8, line, "ababab") != null);
+}
+
+test "writeLine reports NoSpaceLeft instead of overflowing" {
+    var buf: [8]u8 = undefined;
+    try testing.expectError(error.NoSpaceLeft, writeLine(.{
+        .label = .client_traffic_secret_0,
+        .client_random = &[_]u8{0} ** client_random_len,
+        .secret = &[_]u8{0} ** 48,
+    }, &buf));
+}
+
+test "default sink is a no-op" {
+    const sink = Sink{};
+    sink.emit(.{ .label = .client_traffic_secret_0, .client_random = &[_]u8{}, .secret = &[_]u8{} });
+}

--- a/src/quic/keylog.zig
+++ b/src/quic/keylog.zig
@@ -101,9 +101,18 @@ pub const Sink = struct {
 };
 
 /// Format one NSS `SSLKEYLOGFILE` line (including the trailing newline) into
-/// `out`. Returns the written slice, or `error.NoSpaceLeft` if `out` is too
-/// small — a 256-byte buffer covers a 32-byte random and a 48-byte secret.
-pub fn writeLine(entry: Entry, out: []u8) error{NoSpaceLeft}![]const u8 {
+/// `out`. Returns the written slice, or:
+///   * `error.InvalidClientRandom` unless `client_random` is exactly
+///     `client_random_len` bytes — Wireshark keys every line on the 32-byte
+///     ClientHello random, so a wrong-length value produces a line no tool can
+///     match. Rejecting it loudly beats emitting silent garbage.
+///   * `error.EmptySecret` if `secret` is empty (a keyless line is useless).
+///     Secret length is otherwise unconstrained, to admit future cipher suites.
+///   * `error.NoSpaceLeft` if `out` is too small — a 256-byte buffer covers a
+///     32-byte random and a 48-byte secret.
+pub fn writeLine(entry: Entry, out: []u8) error{ InvalidClientRandom, EmptySecret, NoSpaceLeft }![]const u8 {
+    if (entry.client_random.len != client_random_len) return error.InvalidClientRandom;
+    if (entry.secret.len == 0) return error.EmptySecret;
     const label = entry.label.text();
     const needed = label.len + 1 + entry.client_random.len * 2 + 1 + entry.secret.len * 2 + 1;
     if (out.len < needed) return error.NoSpaceLeft;
@@ -171,6 +180,25 @@ test "writeLine reports NoSpaceLeft instead of overflowing" {
         .label = .client_traffic_secret_0,
         .client_random = &[_]u8{0} ** client_random_len,
         .secret = &[_]u8{0} ** 48,
+    }, &buf));
+}
+
+test "writeLine rejects a wrong-length client random" {
+    var buf: [256]u8 = undefined;
+    // One byte short of the required 32.
+    try testing.expectError(error.InvalidClientRandom, writeLine(.{
+        .label = .client_traffic_secret_0,
+        .client_random = &[_]u8{0} ** (client_random_len - 1),
+        .secret = &[_]u8{0x11},
+    }, &buf));
+}
+
+test "writeLine rejects an empty secret" {
+    var buf: [256]u8 = undefined;
+    try testing.expectError(error.EmptySecret, writeLine(.{
+        .label = .client_traffic_secret_0,
+        .client_random = &[_]u8{0} ** client_random_len,
+        .secret = &[_]u8{},
     }, &buf));
 }
 

--- a/src/quic/qlog.zig
+++ b/src/quic/qlog.zig
@@ -1,0 +1,431 @@
+//! Transport-layer qlog event model and a minimal JSON-SEQ serializer (#255).
+//!
+//! This is the observability seam the pure-Zig QUIC transport emits through
+//! *before* external interop. It defines:
+//!
+//!   * `Event`     — a closed union of the transport events qvis/qlog tooling
+//!                   needs to explain handshake, loss, path, and flow-control
+//!                   behaviour (RFC 9000/9002 vantage points).
+//!   * `Record`    — an `Event` stamped with a monotonic time.
+//!   * `Sink`      — the injected emission seam, mirroring
+//!                   `recovery.EventSink`: an opaque context plus a function
+//!                   pointer. The transport calls `sink.emit(record)` and never
+//!                   learns what the sink does with it.
+//!   * `writeJson` — turns one `Record` into a single qlog JSON-SEQ line
+//!                   (RFC 7464: 0x1E record separator + JSON + '\n').
+//!
+//! ## Layering (the #255 "don't leak H3 into src/quic" decision)
+//!
+//! `src/quic` owns *only* transport-vantage events (qlog categories
+//! `connectivity`, `security`, `transport`, `recovery`). HTTP/3- and
+//! QPACK-vantage events live in `src/http3/qlog.zig` and are emitted from
+//! `src/http3`. Neither package imports the other — the same boundary the
+//! build graph already enforces (see build.zig: the smoke harness stitches the
+//! two together, "so neither package learns about the other").
+//!
+//! The *concrete* qlog file writer therefore lives at the composition root
+//! (the gateway h3 listener, or the `tests/quic_h3_smoke.zig` harness), which
+//! owns both packages. It installs one `quic.qlog.Sink` and one
+//! `http3.qlog.Sink`, and interleaves both event streams into a single qlog
+//! trace. This keeps `src/quic` free of any HTTP/3 type while still producing a
+//! unified trace file.
+//!
+//! ## Cost when disabled
+//!
+//! A default `Sink{}` has a null `emit_fn`; `emit` is a single null check and
+//! return. Callers should still guard expensive event construction behind
+//! `config.Observability.qlog_enabled` so the hot path pays nothing when qlog
+//! is off (the default, per the issue's "disabled by default" requirement).
+
+const std = @import("std");
+
+/// qlog top-level event categories this transport emits. Application (`http`,
+/// `qpack`) categories are intentionally absent: they belong to `src/http3`.
+pub const Category = enum {
+    connectivity,
+    security,
+    transport,
+    recovery,
+
+    pub fn label(self: Category) []const u8 {
+        return @tagName(self);
+    }
+};
+
+/// QUIC packet types (RFC 9000 §17), named as qlog expects them.
+pub const PacketType = enum {
+    initial,
+    zero_rtt,
+    handshake,
+    one_rtt,
+    retry,
+    version_negotiation,
+
+    pub fn label(self: PacketType) []const u8 {
+        return switch (self) {
+            .zero_rtt => "0RTT",
+            .one_rtt => "1RTT",
+            else => @tagName(self),
+        };
+    }
+};
+
+/// Coarse handshake milestones, enough to localize a stalled handshake to a
+/// key-installation / transport-parameter / confirmation stage.
+pub const HandshakeStage = enum {
+    started,
+    initial_keys_installed,
+    handshake_keys_installed,
+    application_keys_installed,
+    transport_parameters_authenticated,
+    confirmed,
+    failed,
+};
+
+/// Why a connection closed (drives `connectivity:connection_closed`).
+pub const CloseReason = enum {
+    idle_timeout,
+    application_close,
+    transport_error,
+    stateless_reset,
+    handshake_failure,
+};
+
+/// PATH_CHALLENGE / PATH_RESPONSE lifecycle phases (RFC 9000 §8.2).
+pub const PathEventKind = enum {
+    challenge_sent,
+    challenge_received,
+    response_sent,
+    response_received,
+    validated,
+    failed,
+};
+
+/// Connection-migration classification and policy outcome (RFC 9000 §9).
+pub const MigrationKind = enum { nat_rebinding, active };
+pub const MigrationOutcome = enum { accepted, blocked };
+
+/// RESET_STREAM / STOP_SENDING direction (RFC 9000 §19.4, §19.5).
+pub const StreamResetKind = enum {
+    reset_sent,
+    reset_received,
+    stop_sending_sent,
+    stop_sending_received,
+};
+
+/// DATA_BLOCKED vs. STREAM_DATA_BLOCKED (RFC 9000 §19.12, §19.13).
+pub const BlockedScope = enum { connection, stream };
+
+/// Why an inbound packet was dropped. `payload_decrypt_error` is the qlog
+/// canonical trigger for AEAD deprotection failure — the #255 requirement that
+/// deprotection failures are reported deterministically.
+pub const DropTrigger = enum {
+    payload_decrypt_error,
+    key_unavailable,
+    unknown_connection_id,
+    unexpected_packet,
+    header_parse_error,
+};
+
+/// The closed set of transport-vantage events. Data payloads are kept small and
+/// copy-free (scalars/enums only) so emitting is cheap and the union never
+/// borrows connection-owned buffers.
+pub const Event = union(enum) {
+    /// connectivity:connection_started
+    connection_started: struct {
+        odcid_len: u8 = 0,
+        scid_len: u8 = 0,
+        dcid_len: u8 = 0,
+    },
+    /// connectivity:connection_closed
+    connection_closed: struct {
+        reason: CloseReason,
+        error_code: ?u64 = null,
+    },
+    /// connectivity:handshake (progress milestone; not a base qlog name, kept
+    /// under connectivity as a Tardigrade extension for stage visibility)
+    handshake_progressed: struct {
+        stage: HandshakeStage,
+    },
+    /// security:key_updated (1-RTT key-phase flip, RFC 9001 §6)
+    key_updated: struct {
+        phase: u1,
+    },
+    /// transport:packet_sent
+    packet_sent: struct {
+        packet_type: PacketType,
+        packet_number: u64,
+        length: usize,
+        ack_eliciting: bool = false,
+    },
+    /// transport:packet_received
+    packet_received: struct {
+        packet_type: PacketType,
+        packet_number: u64,
+        length: usize,
+    },
+    /// recovery:packet_lost
+    packet_lost: struct {
+        packet_type: PacketType,
+        packet_number: ?u64 = null,
+        bytes_in_flight: usize = 0,
+        congestion_window: usize = 0,
+    },
+    /// transport:packet_dropped (deprotection failure and other drops)
+    packet_dropped: struct {
+        packet_type: ?PacketType = null,
+        trigger: DropTrigger,
+        length: usize = 0,
+    },
+    /// transport:path_validation (PATH_CHALLENGE / PATH_RESPONSE)
+    path_validation: struct {
+        kind: PathEventKind,
+        path_id: u8 = 0,
+    },
+    /// connectivity:connection_migrated
+    connection_migrated: struct {
+        kind: MigrationKind,
+        outcome: MigrationOutcome,
+    },
+    /// transport:stream_reset (RESET_STREAM / STOP_SENDING)
+    stream_reset: struct {
+        kind: StreamResetKind,
+        stream_id: u64,
+        error_code: u64 = 0,
+    },
+    /// transport:data_blocked (flow-control blocked)
+    data_blocked: struct {
+        scope: BlockedScope,
+        stream_id: ?u64 = null,
+        limit: u64 = 0,
+    },
+
+    pub fn category(self: Event) Category {
+        return switch (self) {
+            .connection_started,
+            .connection_closed,
+            .handshake_progressed,
+            .connection_migrated,
+            => .connectivity,
+            .key_updated => .security,
+            .packet_lost => .recovery,
+            .packet_sent,
+            .packet_received,
+            .packet_dropped,
+            .path_validation,
+            .stream_reset,
+            .data_blocked,
+            => .transport,
+        };
+    }
+
+    /// The qlog event name within the category (the part after the `:`).
+    pub fn name(self: Event) []const u8 {
+        return switch (self) {
+            .connection_started => "connection_started",
+            .connection_closed => "connection_closed",
+            .handshake_progressed => "handshake",
+            .key_updated => "key_updated",
+            .packet_sent => "packet_sent",
+            .packet_received => "packet_received",
+            .packet_lost => "packet_lost",
+            .packet_dropped => "packet_dropped",
+            .path_validation => "path_validation",
+            .connection_migrated => "connection_migrated",
+            .stream_reset => "stream_reset",
+            .data_blocked => "data_blocked",
+        };
+    }
+};
+
+/// An `Event` stamped with a monotonic microsecond time. qlog time is emitted
+/// in milliseconds (the qlog default `time_units`), derived from `time_us`.
+pub const Record = struct {
+    time_us: u64,
+    event: Event,
+};
+
+/// The injected emission seam. Mirrors `recovery.EventSink`: a default value
+/// (`.{}`) is a no-op, so wiring qlog is opt-in and free when absent.
+pub const Sink = struct {
+    context: ?*anyopaque = null,
+    emit_fn: ?*const fn (?*anyopaque, Record) void = null,
+
+    pub fn emit(self: Sink, record: Record) void {
+        if (self.emit_fn) |f| f(self.context, record);
+    }
+
+    /// Convenience: stamp an event and emit it in one call.
+    pub fn log(self: Sink, time_us: u64, event: Event) void {
+        self.emit(.{ .time_us = time_us, .event = event });
+    }
+};
+
+/// JSON-SEQ record separator (RFC 7464 §2.2): each qlog line is 0x1E + JSON.
+pub const record_separator: u8 = 0x1e;
+
+/// A bounded, allocation-free JSON accumulator over a caller-owned buffer, in
+/// the same spirit as the wire `Writer` in `tls_handshake.zig`.
+const Buf = struct {
+    buf: []u8,
+    len: usize = 0,
+
+    fn add(self: *Buf, comptime fmt: []const u8, args: anytype) error{NoSpaceLeft}!void {
+        const written = try std.fmt.bufPrint(self.buf[self.len..], fmt, args);
+        self.len += written.len;
+    }
+
+    fn slice(self: *const Buf) []const u8 {
+        return self.buf[0..self.len];
+    }
+};
+
+fn boolText(value: bool) []const u8 {
+    return if (value) "true" else "false";
+}
+
+fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
+    switch (event) {
+        .connection_started => |d| try b.add(
+            "{{\"odcid_length\":{d},\"scid_length\":{d},\"dcid_length\":{d}}}",
+            .{ d.odcid_len, d.scid_len, d.dcid_len },
+        ),
+        .connection_closed => |d| {
+            try b.add("{{\"reason\":\"{s}\"", .{@tagName(d.reason)});
+            if (d.error_code) |code| try b.add(",\"error_code\":{d}", .{code});
+            try b.add("}}", .{});
+        },
+        .handshake_progressed => |d| try b.add(
+            "{{\"stage\":\"{s}\"}}",
+            .{@tagName(d.stage)},
+        ),
+        .key_updated => |d| try b.add("{{\"key_phase\":{d}}}", .{d.phase}),
+        .packet_sent => |d| try b.add(
+            "{{\"packet_type\":\"{s}\",\"packet_number\":{d},\"length\":{d},\"ack_eliciting\":{s}}}",
+            .{ d.packet_type.label(), d.packet_number, d.length, boolText(d.ack_eliciting) },
+        ),
+        .packet_received => |d| try b.add(
+            "{{\"packet_type\":\"{s}\",\"packet_number\":{d},\"length\":{d}}}",
+            .{ d.packet_type.label(), d.packet_number, d.length },
+        ),
+        .packet_lost => |d| {
+            try b.add("{{\"packet_type\":\"{s}\"", .{d.packet_type.label()});
+            if (d.packet_number) |pn| try b.add(",\"packet_number\":{d}", .{pn});
+            try b.add(
+                ",\"bytes_in_flight\":{d},\"congestion_window\":{d}}}",
+                .{ d.bytes_in_flight, d.congestion_window },
+            );
+        },
+        .packet_dropped => |d| {
+            try b.add("{{\"trigger\":\"{s}\"", .{@tagName(d.trigger)});
+            if (d.packet_type) |pt| try b.add(",\"packet_type\":\"{s}\"", .{pt.label()});
+            try b.add(",\"length\":{d}}}", .{d.length});
+        },
+        .path_validation => |d| try b.add(
+            "{{\"phase\":\"{s}\",\"path_id\":{d}}}",
+            .{ @tagName(d.kind), d.path_id },
+        ),
+        .connection_migrated => |d| try b.add(
+            "{{\"kind\":\"{s}\",\"outcome\":\"{s}\"}}",
+            .{ @tagName(d.kind), @tagName(d.outcome) },
+        ),
+        .stream_reset => |d| try b.add(
+            "{{\"direction\":\"{s}\",\"stream_id\":{d},\"error_code\":{d}}}",
+            .{ @tagName(d.kind), d.stream_id, d.error_code },
+        ),
+        .data_blocked => |d| {
+            try b.add("{{\"scope\":\"{s}\"", .{@tagName(d.scope)});
+            if (d.stream_id) |sid| try b.add(",\"stream_id\":{d}", .{sid});
+            try b.add(",\"limit\":{d}}}", .{d.limit});
+        },
+    }
+}
+
+/// Serialize one `Record` into `out` as a single qlog JSON-SEQ line:
+///
+///     0x1E {"time":<ms>,"name":"<category>:<event>","data":{...}} \n
+///
+/// Returns the written slice. Errors only if `out` is too small; a 512-byte
+/// buffer is comfortably enough for every event above.
+pub fn writeJson(record: Record, out: []u8) error{NoSpaceLeft}![]const u8 {
+    var b = Buf{ .buf = out };
+    try b.add("{c}", .{record_separator});
+    // qlog default time unit is milliseconds; keep microsecond precision.
+    try b.add(
+        "{{\"time\":{d}.{d:0>3},\"name\":\"{s}:{s}\",\"data\":",
+        .{ record.time_us / 1000, record.time_us % 1000, record.event.category().label(), record.event.name() },
+    );
+    try writeData(&b, record.event);
+    try b.add("}}\n", .{});
+    return b.slice();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+fn expectJson(record: Record, needle: []const u8) !void {
+    var buf: [512]u8 = undefined;
+    const line = try writeJson(record, &buf);
+    try testing.expect(line[0] == record_separator);
+    try testing.expect(line[line.len - 1] == '\n');
+    try testing.expect(std.mem.indexOf(u8, line, needle) != null);
+}
+
+test "category and name mapping stays aligned with qlog vantage points" {
+    try testing.expectEqual(Category.transport, (Event{ .packet_sent = .{ .packet_type = .one_rtt, .packet_number = 0, .length = 0 } }).category());
+    try testing.expectEqual(Category.recovery, (Event{ .packet_lost = .{ .packet_type = .one_rtt } }).category());
+    try testing.expectEqual(Category.security, (Event{ .key_updated = .{ .phase = 1 } }).category());
+    try testing.expectEqual(Category.connectivity, (Event{ .connection_migrated = .{ .kind = .active, .outcome = .blocked } }).category());
+    try testing.expectEqualStrings("packet_dropped", (Event{ .packet_dropped = .{ .trigger = .payload_decrypt_error } }).name());
+}
+
+test "packet_sent serializes to a transport JSON-SEQ line" {
+    try expectJson(
+        .{ .time_us = 1_234_567, .event = .{ .packet_sent = .{ .packet_type = .initial, .packet_number = 7, .length = 1200, .ack_eliciting = true } } },
+        "\"name\":\"transport:packet_sent\"",
+    );
+    try expectJson(
+        .{ .time_us = 1_234_567, .event = .{ .packet_sent = .{ .packet_type = .one_rtt, .packet_number = 7, .length = 1200 } } },
+        "\"packet_type\":\"1RTT\"",
+    );
+}
+
+test "deprotection failure is a packet_dropped with payload_decrypt_error" {
+    try expectJson(
+        .{ .time_us = 0, .event = .{ .packet_dropped = .{ .packet_type = .one_rtt, .trigger = .payload_decrypt_error, .length = 42 } } },
+        "\"trigger\":\"payload_decrypt_error\"",
+    );
+}
+
+test "time is rendered in milliseconds with microsecond precision" {
+    var buf: [512]u8 = undefined;
+    const line = try writeJson(.{ .time_us = 1_002_003, .event = .{ .key_updated = .{ .phase = 1 } } }, &buf);
+    try testing.expect(std.mem.indexOf(u8, line, "\"time\":1002.003") != null);
+}
+
+test "path, migration, stream reset and flow-control events serialize" {
+    try expectJson(.{ .time_us = 5, .event = .{ .path_validation = .{ .kind = .response_received } } }, "\"phase\":\"response_received\"");
+    try expectJson(.{ .time_us = 5, .event = .{ .connection_migrated = .{ .kind = .nat_rebinding, .outcome = .accepted } } }, "connection_migrated");
+    try expectJson(.{ .time_us = 5, .event = .{ .stream_reset = .{ .kind = .reset_received, .stream_id = 4, .error_code = 9 } } }, "\"stream_id\":4");
+    try expectJson(.{ .time_us = 5, .event = .{ .data_blocked = .{ .scope = .stream, .stream_id = 8, .limit = 4096 } } }, "\"scope\":\"stream\"");
+}
+
+test "default sink is a no-op and log() stamps time" {
+    const Collector = struct {
+        var last: ?Record = null;
+        fn emit(_: ?*anyopaque, record: Record) void {
+            last = record;
+        }
+    };
+    const noop = Sink{};
+    noop.log(1, .{ .key_updated = .{ .phase = 0 } }); // must not crash
+
+    Collector.last = null;
+    const sink = Sink{ .emit_fn = Collector.emit };
+    sink.log(99, .{ .connection_closed = .{ .reason = .idle_timeout } });
+    try testing.expect(Collector.last != null);
+    try testing.expectEqual(@as(u64, 99), Collector.last.?.time_us);
+}

--- a/src/quic/qlog.zig
+++ b/src/quic/qlog.zig
@@ -247,6 +247,14 @@ pub const Record = struct {
 
 /// The injected emission seam. Mirrors `recovery.EventSink`: a default value
 /// (`.{}`) is a no-op, so wiring qlog is opt-in and free when absent.
+///
+/// `emit_fn` returns `void` so transport emission stays infallible on the hot
+/// path (a lost debug record must never fail a connection). The cost is that a
+/// concrete file sink cannot propagate serialization / disk-full / permission
+/// errors through this call. The **contract for concrete sinks** is therefore:
+/// retain the first write error (and/or count dropped records) and expose it
+/// out-of-band, so a truncated trace is detectable rather than silent. See
+/// `docs/QUIC_QLOG.md`.
 pub const Sink = struct {
     context: ?*anyopaque = null,
     emit_fn: ?*const fn (?*anyopaque, Record) void = null,
@@ -341,6 +349,36 @@ fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
     }
 }
 
+/// qlog vantage point: which endpoint recorded the trace (RFC 9000 roles).
+pub const VantagePoint = enum { client, server };
+
+/// The once-per-file qlog trace header. Only the composition root can fill this
+/// in: `group_id` (the original DCID, as lowercase hex, tying every event to
+/// one connection) and the `reference_time` baseline span both packages, so the
+/// root — not the transport — owns it. `title` and `group_id` must be JSON-safe
+/// (ASCII / hex); they are emitted verbatim without escaping.
+pub const TraceHeader = struct {
+    vantage_point: VantagePoint,
+    reference_time_us: u64 = 0,
+    group_id: []const u8 = "",
+    title: []const u8 = "tardigrade-quic",
+    qlog_version: []const u8 = "0.3",
+};
+
+/// Serialize the qlog file header as the first JSON-SEQ record. A composition
+/// root writes this once, then appends `writeJson` event records (from both
+/// `quic` and `http3`) to form a complete `.qlog` file qvis can consume.
+/// Returns the written slice; a 512-byte buffer is enough.
+pub fn writeTraceHeader(header: TraceHeader, out: []u8) error{NoSpaceLeft}![]const u8 {
+    var b = Buf{ .buf = out };
+    try b.add("{c}", .{record_separator});
+    try b.add(
+        "{{\"qlog_version\":\"{s}\",\"qlog_format\":\"JSON-SEQ\",\"title\":\"{s}\",\"trace\":{{\"vantage_point\":{{\"type\":\"{s}\"}},\"common_fields\":{{\"reference_time\":{d}.{d:0>3},\"group_id\":\"{s}\"}}}}}}\n",
+        .{ header.qlog_version, header.title, @tagName(header.vantage_point), header.reference_time_us / 1000, header.reference_time_us % 1000, header.group_id },
+    );
+    return b.slice();
+}
+
 /// Serialize one `Record` into `out` as a single qlog JSON-SEQ line:
 ///
 ///     0x1E {"time":<ms>,"name":"<category>:<event>","data":{...}} \n
@@ -411,6 +449,18 @@ test "path, migration, stream reset and flow-control events serialize" {
     try expectJson(.{ .time_us = 5, .event = .{ .connection_migrated = .{ .kind = .nat_rebinding, .outcome = .accepted } } }, "connection_migrated");
     try expectJson(.{ .time_us = 5, .event = .{ .stream_reset = .{ .kind = .reset_received, .stream_id = 4, .error_code = 9 } } }, "\"stream_id\":4");
     try expectJson(.{ .time_us = 5, .event = .{ .data_blocked = .{ .scope = .stream, .stream_id = 8, .limit = 4096 } } }, "\"scope\":\"stream\"");
+}
+
+test "trace header then event forms a two-record JSON-SEQ stream" {
+    var buf: [1024]u8 = undefined;
+    const header = try writeTraceHeader(.{ .vantage_point = .server, .reference_time_us = 1_000, .group_id = "0011deadbeef" }, &buf);
+    const event = try writeJson(.{ .time_us = 2_500, .event = .{ .packet_sent = .{ .packet_type = .initial, .packet_number = 0, .length = 1200 } } }, buf[header.len..]);
+    // Exactly two record separators, one per record.
+    try testing.expectEqual(@as(usize, 2), std.mem.count(u8, buf[0 .. header.len + event.len], &[_]u8{record_separator}));
+    try testing.expect(std.mem.indexOf(u8, header, "\"qlog_format\":\"JSON-SEQ\"") != null);
+    try testing.expect(std.mem.indexOf(u8, header, "\"vantage_point\":{\"type\":\"server\"}") != null);
+    try testing.expect(std.mem.indexOf(u8, header, "\"group_id\":\"0011deadbeef\"") != null);
+    try testing.expect(std.mem.indexOf(u8, event, "transport:packet_sent") != null);
 }
 
 test "default sink is a no-op and log() stamps time" {

--- a/src/quic/root.zig
+++ b/src/quic/root.zig
@@ -13,6 +13,8 @@ pub const recovery = @import("recovery.zig");
 pub const cid = @import("cid.zig");
 pub const path = @import("path.zig");
 pub const stream = @import("stream.zig");
+pub const qlog = @import("qlog.zig");
+pub const keylog = @import("keylog.zig");
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/tests/quic_h3_smoke.zig
+++ b/tests/quic_h3_smoke.zig
@@ -750,3 +750,43 @@ test "smoke harness fails truncated long-header packets deterministically" {
     try smoke.server.onDatagram(initial);
     try testing.expect(smoke.server.adapter.metrics.packets_deprotected == 1);
 }
+
+// The composition root owns the qlog file: it writes one trace header, then
+// interleaves transport records (src/quic) and HTTP/3 records (src/http3) into
+// a single JSON-SEQ stream. This test locks that intended file shape — the seam
+// #255 designs — without either package importing the other.
+test "qlog composition root interleaves transport and h3 records under one header" {
+    const qlog = quic.qlog;
+    const h3qlog = http3.qlog;
+
+    var file: [1024]u8 = undefined;
+    var len: usize = 0;
+
+    const header = try qlog.writeTraceHeader(.{
+        .vantage_point = .server,
+        .reference_time_us = 0,
+        .group_id = "0011223344556677",
+    }, file[len..]);
+    len += header.len;
+
+    const transport_rec = try qlog.writeJson(.{
+        .time_us = 1_000,
+        .event = .{ .packet_received = .{ .packet_type = .initial, .packet_number = 0, .length = 1200 } },
+    }, file[len..]);
+    len += transport_rec.len;
+
+    const h3_rec = try h3qlog.writeJson(.{
+        .time_us = 2_000,
+        .event = .{ .qpack_state_updated = .{ .state = .blocked, .stream_id = 0 } },
+    }, file[len..]);
+    len += h3_rec.len;
+
+    const stream = file[0..len];
+    // Three records: header + one transport + one h3, each JSON-SEQ delimited.
+    try testing.expectEqual(@as(usize, 3), std.mem.count(u8, stream, &[_]u8{qlog.record_separator}));
+    try testing.expect(std.mem.indexOf(u8, stream, "\"qlog_format\":\"JSON-SEQ\"") != null);
+    try testing.expect(std.mem.indexOf(u8, stream, "transport:packet_received") != null);
+    try testing.expect(std.mem.indexOf(u8, stream, "qpack:stream_state_updated") != null);
+    // Both writers frame identically, so the merged stream is uniform.
+    try testing.expectEqual(qlog.record_separator, h3qlog.record_separator);
+}


### PR DESCRIPTION
**What changed and why**

Design and scaffold the minimal qlog/keylog/metrics seam the pure-Zig QUIC/H3 stack needs before external interop (#247), without leaking HTTP/3 into `src/quic`. This is design + small scaffold, not a full observability implementation: it fixes the event vocabulary, the layering, and the safety rules so the later emission call-sites are mechanical.

- **`src/quic/qlog.zig`** — transport-vantage event model (handshake, packet sent/received/lost, `packet_dropped` with `payload_decrypt_error` for deprotection failure, path validation, migration, stream reset, flow-control blocked) + an injected no-op-by-default `Sink` + an allocation-free JSON-SEQ serializer, plus `writeTraceHeader` for the once-per-file qlog header.
- **`src/http3/qlog.zig`** — the symmetric HTTP/3- and QPACK-vantage half (`parameters_set`, `frame_created/parsed`, `qpack:stream_state_updated` for head-of-line blocking). Keeps H3/QPACK events out of the transport package.
- **`src/quic/keylog.zig`** — NSS `SSLKEYLOGFILE` label mapping + line writer; Initial secrets are never logged; validates the 32-byte client random and non-empty secret. Debug-only.
- **`docs/QUIC_QLOG.md`** — the layering decision, event catalogue, serialization format, sink error-handling contract, and sensitive/debug-only keylog handling. Cross-referenced from `OBSERVABILITY.md` / `QUIC_TLS.md`; `config.Observability` annotated.

Both packages emit through injected sinks, so the concrete qlog/keylog file writers live at the composition root that owns both packages — preserving the existing `src/quic` ↔ `src/http3` module boundary (the build graph keeps them independent). `tests/quic_h3_smoke.zig` (that root) locks the merged-file shape: one trace header + a transport record + an H3 record interleaved under uniform JSON-SEQ framing.

**Related issues**

Related to #255 (does **not** close it). This PR is the scaffold only. #255 additionally expects real emission call-sites, produced artifacts, transport Prometheus metrics, and integration validation — those remain open follow-ups (see the "planned metrics surface" and "testing strategy" sections in `docs/QUIC_QLOG.md`).

**Tests**

Unit tests added alongside the new modules:
- qlog: event category/name mapping, JSON-SEQ serialization for representative transport events (packet_sent/dropped, path/migration/reset/flow-control), ms-time precision, trace-header record, no-op default sink.
- http3 qlog: `qpack:stream_state_updated` blocking, frame direction → created/parsed, `parameters_set` field presence.
- keylog: label folding across perspective/direction/level, well-formed NSS line, `NoSpaceLeft`, and the new `InvalidClientRandom` / `EmptySecret` rejections.
- smoke harness: composition-root test that header + transport + H3 records form one uniform JSON-SEQ stream.

Verified locally with Zig 0.16.0: `zig fmt --check build.zig src/ tests/` clean; `zig build test --summary all` green (1051 passed, 1 pre-existing skip).

**Security impact**

Yes — this adds **keylog** (TLS traffic-secret logging) and qlog. Both are disabled by default (`config.Observability.qlog_enabled` / `keylog_enabled = false`) and documented as sensitive/debug-only: a key log decrypts the connection, so it is equivalent to plaintext and must never be enabled in production or pointed at shared/network-reachable storage. Initial secrets are intentionally never logged (derivable from the DCID on the wire). No default behavior changes; no wire, routing, auth, or header-parsing paths are touched. `docs/QUIC_QLOG.md` documents the handling rules.

**Performance impact**

None on any existing path. New code is additive and unreferenced by the running server until a composition root wires a sink. A default `Sink{}` is a single null-check; serialization is allocation-free into caller buffers.

**Checklist**
- [x] `zig fmt --check build.zig src/ tests/` passes
- [x] `zig build test --summary all` green
- [ ] `zig build test-integration` — N/A: additive scaffold, no protocol/proxy/TLS wire changes
- [x] New behavior covered by tests
- [ ] [docs/CODE_REVIEW_CHECKLIST.md](docs/CODE_REVIEW_CHECKLIST.md) completed
- [ ] README / CHANGELOG — N/A: no operator-visible behavior change (feature is disabled by default and not yet wired)
