### PR TITLE
test(quic): add fuzz coverage for H3 parser surfaces

### DIFF
--- a/src/http3/frame.zig
+++ b/src/http3/frame.zig
@@ -517,6 +517,75 @@ test "duplicate control stream maps to connection close error code" {
     try testing.expectEqual(ApplicationErrorCode.stream_creation_error, registry.last_error.?.code);
 }
 
+test "fuzz: frame decoder never panics on arbitrary bytes" {
+    try testing.fuzz({}, fuzzDecodeFrame, .{ .corpus = &.{
+        "",
+        "\x01",
+        "\x01\x00",
+        "\x01\x03abc",
+        "\x04\x00",
+        "\x40\x21\x00",
+        "\x80\x0f\x07\x00\x00",
+    } });
+}
+
+fn fuzzDecodeFrame(_: void, smith: *testing.Smith) !void {
+    var buf: [512]u8 = undefined;
+    const len = smith.slice(&buf);
+    const raw = decodeFrame(buf[0..len]) catch return;
+    try testing.expect(raw.len <= len);
+    try testing.expect(raw.payload.len <= raw.len);
+    try testing.expectEqual(FrameType.fromValue(raw.type_value), raw.typ);
+
+    const limited = decodeFrameWithLimit(buf[0..len], raw.payload.len) catch |err| switch (err) {
+        error.FrameTooLarge => unreachable,
+        else => return,
+    };
+    try testing.expectEqual(raw.type_value, limited.type_value);
+    try testing.expectEqual(raw.len, limited.len);
+}
+
+test "fuzz: SETTINGS decoder never panics on arbitrary payloads" {
+    try testing.fuzz({}, fuzzDecodeSettings, .{ .corpus = &.{
+        "",
+        "\x01\x00",
+        "\x07\x00",
+        "\x08\x01",
+        "\x08\x02",
+        "\x02\x01",
+        "\x07\x00\x07\x01",
+    } });
+}
+
+fn fuzzDecodeSettings(_: void, smith: *testing.Smith) !void {
+    var buf: [256]u8 = undefined;
+    const len = smith.slice(&buf);
+    var scratch: [16]Setting = undefined;
+    const decoded = decodeSettings(buf[0..len], &scratch) catch return;
+    try testing.expect(decoded.count <= scratch.len);
+}
+
+test "fuzz: control stream ingestion never panics or leaks" {
+    try testing.fuzz({}, fuzzControlStreamIngest, .{ .corpus = &.{
+        "",
+        "\x00",
+        "\x00\x04\x00",
+        "\x00\x04\x02\x01\x00",
+        "\x00\x01\x00",
+        "\x02\x04\x00",
+    } });
+}
+
+fn fuzzControlStreamIngest(_: void, smith: *testing.Smith) !void {
+    const allocator = testing.allocator;
+    var buf: [512]u8 = undefined;
+    const len = smith.slice(&buf);
+    var stream = ControlStream{};
+    defer stream.deinit(allocator);
+    _ = stream.ingest(allocator, buf[0..len]) catch return;
+    stream.finish() catch {};
+}
+
 test {
     std.testing.refAllDecls(@This());
 }

--- a/src/http3/frame.zig
+++ b/src/http3/frame.zig
@@ -552,7 +552,9 @@ test "fuzz: SETTINGS decoder never panics on arbitrary payloads" {
         "\x07\x00",
         "\x08\x01",
         "\x08\x02",
+        "\x40\x08\x40\x01",
         "\x02\x01",
+        "\x40\x02\x40\x01",
         "\x07\x00\x07\x01",
     } });
 }
@@ -563,6 +565,36 @@ fn fuzzDecodeSettings(_: void, smith: *testing.Smith) !void {
     var scratch: [16]Setting = undefined;
     const decoded = decodeSettings(buf[0..len], &scratch) catch return;
     try testing.expect(decoded.count <= scratch.len);
+    try expectUniqueSettings(scratch[0..decoded.count]);
+    try expectCanonicalBooleanSettings(scratch[0..decoded.count]);
+
+    var reencoded_buf: [256]u8 = undefined;
+    const reencoded = encodeSettings(scratch[0..decoded.count], &reencoded_buf) catch return;
+    var roundtrip_scratch: [16]Setting = undefined;
+    const roundtrip = try decodeSettings(reencoded, &roundtrip_scratch);
+    try testing.expectEqual(decoded.count, roundtrip.count);
+    try testing.expectEqual(decoded.parsed.qpack_max_table_capacity, roundtrip.parsed.qpack_max_table_capacity);
+    try testing.expectEqual(decoded.parsed.qpack_blocked_streams, roundtrip.parsed.qpack_blocked_streams);
+    try testing.expectEqual(decoded.parsed.max_field_section_size, roundtrip.parsed.max_field_section_size);
+    try testing.expectEqual(decoded.parsed.enable_connect_protocol, roundtrip.parsed.enable_connect_protocol);
+    try testing.expectEqual(decoded.parsed.h3_datagram, roundtrip.parsed.h3_datagram);
+}
+
+fn expectUniqueSettings(settings: []const Setting) !void {
+    for (settings, 0..) |setting, index| {
+        for (settings[0..index]) |prior| {
+            try testing.expect(setting.id_value != prior.id_value);
+        }
+    }
+}
+
+fn expectCanonicalBooleanSettings(settings: []const Setting) !void {
+    for (settings) |setting| {
+        switch (setting.id) {
+            .enable_connect_protocol, .h3_datagram => try testing.expect(setting.value == 0 or setting.value == 1),
+            else => {},
+        }
+    }
 }
 
 test "fuzz: control stream ingestion never panics or leaks" {
@@ -571,6 +603,9 @@ test "fuzz: control stream ingestion never panics or leaks" {
         "\x00",
         "\x00\x04\x00",
         "\x00\x04\x02\x01\x00",
+        "\x00\x04\x04\x01\x00\x07\x00",
+        "\x00\x04\x02\x40\x07",
+        "\x00\x40\x04\x40\x00",
         "\x00\x01\x00",
         "\x02\x04\x00",
     } });
@@ -580,10 +615,70 @@ fn fuzzControlStreamIngest(_: void, smith: *testing.Smith) !void {
     const allocator = testing.allocator;
     var buf: [512]u8 = undefined;
     const len = smith.slice(&buf);
-    var stream = ControlStream{};
-    defer stream.deinit(allocator);
-    _ = stream.ingest(allocator, buf[0..len]) catch return;
-    stream.finish() catch {};
+
+    var whole = ControlStream{};
+    defer whole.deinit(allocator);
+    const whole_result = whole.ingest(allocator, buf[0..len]);
+    const whole_state = controlStreamState(&whole);
+
+    var fragmented = ControlStream{};
+    defer fragmented.deinit(allocator);
+    var pos: usize = 0;
+    var failed = false;
+    while (pos < len) {
+        const remaining = len - pos;
+        var chunk_len = @as(usize, smith.value(u8)) % remaining + 1;
+        if (smith.value(u1) == 1) chunk_len = 1;
+        const before = controlStreamState(&fragmented);
+        const result = fragmented.ingest(allocator, buf[pos..][0..chunk_len]);
+        if (result) |_| {
+            const after = controlStreamState(&fragmented);
+            try expectControlStateMonotonic(before, after);
+            pos += chunk_len;
+        } else |_| {
+            failed = true;
+            break;
+        }
+    }
+
+    if (whole_result) |_| {
+        try testing.expect(!failed);
+        try testing.expectEqual(whole_state.saw_type, fragmented.saw_type);
+        try testing.expectEqual(whole_state.saw_settings, fragmented.saw_settings);
+        try testing.expectEqual(whole_state.pending_len, fragmented.pending.items.len);
+        if (whole.saw_settings and whole.pending.items.len == 0) {
+            try whole.finish();
+            try fragmented.finish();
+            try testing.expect(whole.closed);
+            try testing.expect(fragmented.closed);
+        } else {
+            try testing.expectError(error.MissingSettings, whole.finish());
+        }
+    } else |_| {
+        if (!failed) {
+            try testing.expect(fragmented.saw_type == whole_state.saw_type or !fragmented.saw_type);
+            try testing.expect(fragmented.saw_settings == whole_state.saw_settings or !fragmented.saw_settings);
+        }
+    }
+}
+
+const ControlState = struct {
+    saw_type: bool,
+    saw_settings: bool,
+    pending_len: usize,
+};
+
+fn controlStreamState(stream: *const ControlStream) ControlState {
+    return .{
+        .saw_type = stream.saw_type,
+        .saw_settings = stream.saw_settings,
+        .pending_len = stream.pending.items.len,
+    };
+}
+
+fn expectControlStateMonotonic(before: ControlState, after: ControlState) !void {
+    if (before.saw_type) try testing.expect(after.saw_type);
+    if (before.saw_settings) try testing.expect(after.saw_settings);
 }
 
 test {

--- a/src/http3/qpack.zig
+++ b/src/http3/qpack.zig
@@ -1446,3 +1446,53 @@ test "dynamic table memory remains bounded under repeated inserts" {
     }
     try testing.expect(table.metrics.evictions > 0);
 }
+
+test "fuzz: QPACK static decoder never panics on arbitrary field sections" {
+    try testing.fuzz({}, fuzzQpackDecode, .{ .corpus = &.{
+        "",
+        "\x00",
+        "\x00\x00",
+        "\x00\x00\xd1",
+        "\x00\x00\x51\x0btardigrade",
+        "\x01\x00",
+        "\x00\x80",
+        "\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff",
+    } });
+}
+
+fn fuzzQpackDecode(_: void, smith: *testing.Smith) !void {
+    var buf: [512]u8 = undefined;
+    const len = smith.slice(&buf);
+    var fields: [16]HeaderField = undefined;
+    var scratch: [1024]u8 = undefined;
+    const count = decode(buf[0..len], &fields, &scratch) catch return;
+    try testing.expect(count <= fields.len);
+}
+
+test "fuzz: QPACK static-table selections round-trip through encoder" {
+    try testing.fuzz({}, fuzzQpackStaticRoundTrip, .{ .corpus = &.{
+        "\x00",
+        "\x01\x02\x03\x04",
+        "\x11\x17\x19\x1d",
+        "\xff\x00\x7f\x40",
+    } });
+}
+
+fn fuzzQpackStaticRoundTrip(_: void, smith: *testing.Smith) !void {
+    var fields: [4]HeaderField = undefined;
+    const count = @as(usize, smith.value(u2)) + 1;
+    for (fields[0..count]) |*field| {
+        field.* = static_table[smith.value(u8) % static_table_len];
+    }
+
+    var encoded: [512]u8 = undefined;
+    const block = try encode(fields[0..count], &encoded);
+    var decoded: [4]HeaderField = undefined;
+    var scratch: [512]u8 = undefined;
+    const decoded_count = try decode(block, &decoded, &scratch);
+    try testing.expectEqual(count, decoded_count);
+    for (fields[0..count], decoded[0..decoded_count]) |expected, actual| {
+        try testing.expectEqualStrings(expected.name, actual.name);
+        try testing.expectEqualStrings(expected.value, actual.value);
+    }
+}

--- a/src/quic/packet.zig
+++ b/src/quic/packet.zig
@@ -95,3 +95,27 @@ test "truncatePacketNumber keeps the low-order bytes" {
     try testing.expectEqual(@as(u32, 0xa82f9b32), truncatePacketNumber(0xa82f9b32, 4));
     try testing.expectEqual(@as(u32, 0x32), truncatePacketNumber(0xa82f9b32, 1));
 }
+
+test "fuzz: packet number truncation reconstructs recent sends" {
+    try testing.fuzz({}, fuzzPacketNumberRoundTrip, .{ .corpus = &.{
+        "\x00\x00\x00\x00\x00\x00",
+        "\x00\x00\x00\x01\x00\x01",
+        "\x00\x00\x7f\xff\x00\x01",
+        "\x00\x80\x00\x00\x00\x07",
+        "\xff\xff\xff\xff\xff\xff",
+    } });
+}
+
+fn fuzzPacketNumberRoundTrip(_: void, smith: *testing.Smith) !void {
+    const largest = @as(u64, smith.value(u32));
+    const delta = @as(u64, smith.value(u16)) + 1;
+    const full = largest + delta;
+    try testing.expect(full <= max_packet_number);
+
+    const len = packetNumberLength(full, largest);
+    try testing.expect(len >= 1 and len <= 4);
+    const truncated = truncatePacketNumber(full, len);
+    const bits: u6 = @as(u6, len) * 8;
+    try testing.expect(truncated < (@as(u64, 1) << bits));
+    try testing.expectEqual(full, decodePacketNumber(largest, truncated, bits));
+}

--- a/src/quic/varint.zig
+++ b/src/quic/varint.zig
@@ -122,3 +122,49 @@ test "malformed and boundary inputs" {
     try testing.expectError(error.BufferTooShort, encode(64, &small)); // needs 2 bytes
     try testing.expectError(error.ValueTooLarge, encode(max_value + 1, &small));
 }
+
+test "fuzz: varint decode and minimal re-encode never panic" {
+    try testing.fuzz({}, fuzzVarintDecode, .{ .corpus = &.{
+        "",
+        "\x25",
+        "\x40\x25",
+        "\x7b\xbd",
+        "\x9d\x7f\x3e\x7d",
+        "\xc2\x19\x7c\x5e\xff\x14\xe8\x8c",
+        "\xff\xff\xff\xff\xff\xff\xff\xff",
+    } });
+}
+
+fn fuzzVarintDecode(_: void, smith: *testing.Smith) !void {
+    var buf: [16]u8 = undefined;
+    const len = smith.slice(&buf);
+    const decoded = decode(buf[0..len]) catch return;
+    try testing.expect(decoded.len == 1 or decoded.len == 2 or decoded.len == 4 or decoded.len == 8);
+    try testing.expect(decoded.len <= len);
+    try testing.expect(decoded.value <= max_value);
+
+    var encoded: [8]u8 = undefined;
+    const encoded_len = try encode(decoded.value, &encoded);
+    try testing.expectEqual(try encodedLen(decoded.value), encoded_len);
+    const roundtrip = try decode(encoded[0..encoded_len]);
+    try testing.expectEqual(decoded.value, roundtrip.value);
+    try testing.expectEqual(encoded_len, roundtrip.len);
+}
+
+test "fuzz: varint encode round-trips arbitrary in-range values" {
+    try testing.fuzz({}, fuzzVarintEncodeRoundTrip, .{ .corpus = &.{
+        "\x00\x00\x00\x00\x00\x00\x00\x00",
+        "\x00\x00\x00\x00\x00\x00\x00\x3f",
+        "\x00\x00\x00\x00\x00\x00\x40\x00",
+        "\x3f\xff\xff\xff\xff\xff\xff\xff",
+    } });
+}
+
+fn fuzzVarintEncodeRoundTrip(_: void, smith: *testing.Smith) !void {
+    const value = smith.value(u64) & max_value;
+    var encoded: [8]u8 = undefined;
+    const encoded_len = try encode(value, &encoded);
+    const decoded = try decode(encoded[0..encoded_len]);
+    try testing.expectEqual(value, decoded.value);
+    try testing.expectEqual(encoded_len, decoded.len);
+}


### PR DESCRIPTION
## Summary

- Add `std.testing.fuzz` coverage for QUIC varint decode/minimal re-encode and in-range encode round trips.
- Add packet-number property coverage for truncate/reconstruct behavior over recent sends.
- Add HTTP/3 frame, SETTINGS, and control-stream ingestion fuzz coverage.
- Add QPACK static decoder arbitrary-input fuzz coverage plus static-table encode/decode round-trip properties.

Refs #247.

## Validation

- `zig build test-quic --summary all --error-style verbose`
- `zig fmt --check build.zig src/ tests/`
- `zig build test --summary all --error-style verbose`
