### PR TITLE
Extract protocol-neutral TLS core

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -40,6 +40,11 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    const tls_core_mod = b.createModule(.{
+        .root_source_file = b.path("src/tls/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
 
     const exe_mod = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
@@ -49,6 +54,7 @@ pub fn build(b: *std.Build) void {
     });
     exe_mod.addImport("build_options", build_options.createModule());
     exe_mod.addImport("quic_varint", quic_varint_mod);
+    exe_mod.addImport("tls_core", tls_core_mod);
 
     const exe = b.addExecutable(.{
         .name = "tardigrade",
@@ -81,6 +87,7 @@ pub fn build(b: *std.Build) void {
     });
     allocation_regression_mod.addImport("build_options", build_options.createModule());
     allocation_regression_mod.addImport("quic_varint", quic_varint_mod);
+    allocation_regression_mod.addImport("tls_core", tls_core_mod);
 
     const allocation_regression_tests = b.addTest(.{
         .root_module = allocation_regression_mod,
@@ -187,6 +194,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     quic_mod.addImport("quic_varint", quic_varint_mod);
+    quic_mod.addImport("tls_core", tls_core_mod);
     // varint.zig now lives in its own module, so its tests need their own run.
     const quic_varint_tests = b.addTest(.{ .root_module = quic_varint_mod });
     const run_quic_varint_tests = b.addRunArtifact(quic_varint_tests);

--- a/docs/QUIC_TLS.md
+++ b/docs/QUIC_TLS.md
@@ -1,4 +1,4 @@
-# QUIC TLS 1.3 backend strategy (#296)
+# QUIC TLS 1.3 backend strategy (#296, #329)
 
 This note records the decision for how Tardigrade's pure-Zig QUIC stack drives a
 TLS 1.3 handshake, and the staged migration behind the `QuicTlsAdapter` seam
@@ -15,9 +15,9 @@ material; the rest of `src/quic/` must never see a concrete TLS type.
 
 ## Decision
 
-**The QUIC handshake driver is backend-agnostic, and the production TLS engine
-is a pure-Zig TLS 1.3 implementation behind the runtime `TlsBackend`
-interface.**
+**The QUIC handshake driver is backend-agnostic, and reusable TLS 1.3 state now
+lives under a protocol-neutral `src/tls/` core while the QUIC adapter keeps
+CRYPTO-frame transport and packet-key installation.**
 
 1. `src/quic/tls_handshake.zig` implements the connection-facing handshake
    driver (`Handshake`) plus the backend interface (`TlsBackend`) and event
@@ -27,20 +27,27 @@ interface.**
    parameters, enforces ALPN `h3`, reports certificate state, and classifies
    failures into a typed `HandshakeError`.
 
-2. `src/quic/tls_backend.zig` is the concrete production backend: a TLS 1.3
-   engine operating in QUIC mode, built entirely on `std.crypto` primitives
-   (no external TLS library). It consumes and produces raw handshake messages
-   per encryption level — there is no record layer; QUIC packet protection
-   covers confidentiality — and exports traffic secrets, transport parameters,
-   ALPN, and certificate state through the `EventSink`. Its first profile is
+2. `src/tls/` is the protocol-neutral TLS 1.3 core. `state.zig` defines roles,
+   handshake states, and the explicit `quic` versus `record` transport modes;
+   `events.zig` defines transport-neutral handshake byte, traffic-secret,
+   certificate, ALPN, discard, and completion events; `key_schedule.zig` owns
+   the SHA-256 TLS 1.3 key schedule with no QUIC, HTTP, socket, or record-layer
+   imports; and `engine.zig` is the shared shell that can be instantiated for
+   record mode before records exist.
+
+3. `src/quic/tls_backend.zig` is the concrete production adapter from that core
+   to QUIC mode. It consumes and produces raw handshake messages per encryption
+   level — there is no record layer; QUIC packet protection covers
+   confidentiality — and exports traffic secrets, transport parameters, ALPN,
+   and certificate state through the `EventSink`. Its first profile is
    deliberately narrow with one interoperable code path per choice:
    TLS_AES_128_GCM_SHA256 (the adapter's suite), X25519 key exchange, Ed25519
    server certificates (parsed/verified via `std.crypto.Certificate`), and
-   pinned-certificate or explicit-insecure trust. The key schedule is validated
-   against the RFC 8448 trace. Entropy is caller-supplied, like the rest of
-   `src/quic/`.
+   pinned-certificate or explicit-insecure trust. The shared key schedule is
+   validated against the RFC 8448 trace. Entropy is caller-supplied, like the
+   rest of `src/quic/`.
 
-3. A deterministic in-memory `TestTlsBackend` in `tls_handshake.zig` exercises
+4. A deterministic in-memory `TestTlsBackend` in `tls_handshake.zig` exercises
    the driver end to end. It is a fixture, not a TLS implementation, and it is
    the regression seam that later packet-layer and interop work (#247) build
    on. `src/quic/testdata/` holds a deterministic self-signed Ed25519

--- a/src/quic/root.zig
+++ b/src/quic/root.zig
@@ -15,7 +15,7 @@ pub const path = @import("path.zig");
 pub const stream = @import("stream.zig");
 pub const qlog = @import("qlog.zig");
 pub const keylog = @import("keylog.zig");
-pub const tls_core = @import("../tls/root.zig");
+pub const tls_core = @import("tls_core");
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/quic/root.zig
+++ b/src/quic/root.zig
@@ -15,6 +15,7 @@ pub const path = @import("path.zig");
 pub const stream = @import("stream.zig");
 pub const qlog = @import("qlog.zig");
 pub const keylog = @import("keylog.zig");
+pub const tls_core = @import("../tls/root.zig");
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -22,12 +22,9 @@ const config = @import("config.zig");
 const varint = @import("quic_varint");
 const tls_adapter = @import("tls_adapter.zig");
 const tls_handshake = @import("tls_handshake.zig");
+const tls_key_schedule = @import("../tls/key_schedule.zig");
 
 const crypto = std.crypto;
-const tls = crypto.tls;
-const Sha256 = crypto.hash.sha2.Sha256;
-const HmacSha256 = crypto.auth.hmac.sha2.HmacSha256;
-const HkdfSha256 = crypto.kdf.hkdf.HkdfSha256;
 const X25519 = crypto.dh.X25519;
 const Ed25519 = crypto.sign.Ed25519;
 const Certificate = crypto.Certificate;
@@ -39,7 +36,7 @@ const EventSink = tls_handshake.EventSink;
 const TlsBackend = tls_handshake.TlsBackend;
 const Role = tls_handshake.Role;
 
-pub const hash_len = Sha256.digest_length;
+pub const hash_len = tls_key_schedule.hash_len;
 /// Largest handshake message body we accept (u24 wire limit is 16 MiB; a
 /// single-certificate Ed25519 flight is far below this).
 pub const max_message_len = 8 * 1024;
@@ -78,81 +75,10 @@ const hello_retry_request_random = [32]u8{
 };
 
 // ===========================================================================
-// TLS 1.3 key schedule (RFC 8446 §7.1), SHA-256 profile.
+// TLS 1.3 key schedule (protocol-neutral core).
 // ===========================================================================
 
-/// SHA-256 of the empty transcript, used by every "derived" key-schedule step.
-const empty_transcript_hash: [hash_len]u8 = blk: {
-    @setEvalBranchQuota(100_000);
-    var out: [hash_len]u8 = undefined;
-    Sha256.hash("", &out, .{});
-    break :blk out;
-};
-
-/// RFC 8446 §7.1 early-secret stage, folded to a compile-time constant: this
-/// profile defers PSK and 0-RTT, so the early secret is always
-/// HKDF-Extract(salt: "", IKM: 0^32) and its "derived" expansion is static.
-/// The RFC 8448 key-schedule test pins the values derived downstream of it.
-const derived_early_secret: [hash_len]u8 = blk: {
-    @setEvalBranchQuota(100_000);
-    const zeros = [_]u8{0} ** hash_len;
-    const early_secret = HkdfSha256.extract("", &zeros);
-    break :blk tls.hkdfExpandLabel(HkdfSha256, early_secret, "derived", &empty_transcript_hash, hash_len);
-};
-
-/// The key-schedule states this backend needs: handshake and application
-/// traffic secrets. Early (PSK/0-RTT) and resumption secrets are out of scope.
-pub const KeySchedule = struct {
-    handshake_secret: [hash_len]u8,
-    master_secret: [hash_len]u8,
-    client_handshake_traffic: [hash_len]u8,
-    server_handshake_traffic: [hash_len]u8,
-
-    /// Derive through the handshake stage from the ECDHE shared secret and the
-    /// transcript hash of ClientHello..ServerHello.
-    pub fn init(shared: [X25519.shared_length]u8, hello_transcript_hash: [hash_len]u8) KeySchedule {
-        const zeros = [_]u8{0} ** hash_len;
-        const handshake_secret = HkdfSha256.extract(&derived_early_secret, &shared);
-        const derived_handshake = tls.hkdfExpandLabel(HkdfSha256, handshake_secret, "derived", &empty_transcript_hash, hash_len);
-        const master_secret = HkdfSha256.extract(&derived_handshake, &zeros);
-        return .{
-            .handshake_secret = handshake_secret,
-            .master_secret = master_secret,
-            .client_handshake_traffic = tls.hkdfExpandLabel(HkdfSha256, handshake_secret, "c hs traffic", &hello_transcript_hash, hash_len),
-            .server_handshake_traffic = tls.hkdfExpandLabel(HkdfSha256, handshake_secret, "s hs traffic", &hello_transcript_hash, hash_len),
-        };
-    }
-
-    pub const ApplicationSecrets = struct {
-        client: [hash_len]u8,
-        server: [hash_len]u8,
-    };
-
-    /// Application traffic secrets from the transcript hash of
-    /// ClientHello..server Finished.
-    pub fn applicationSecrets(self: *const KeySchedule, finished_transcript_hash: [hash_len]u8) ApplicationSecrets {
-        return .{
-            .client = tls.hkdfExpandLabel(HkdfSha256, self.master_secret, "c ap traffic", &finished_transcript_hash, hash_len),
-            .server = tls.hkdfExpandLabel(HkdfSha256, self.master_secret, "s ap traffic", &finished_transcript_hash, hash_len),
-        };
-    }
-
-    pub fn finishedKey(traffic_secret: [hash_len]u8) [hash_len]u8 {
-        return tls.hkdfExpandLabel(HkdfSha256, traffic_secret, "finished", "", hash_len);
-    }
-
-    /// Finished verify_data (RFC 8446 §4.4.4) for the side owning
-    /// `traffic_secret`, over `transcript_hash`.
-    pub fn verifyData(traffic_secret: [hash_len]u8, transcript_hash: [hash_len]u8) [hash_len]u8 {
-        var mac: [HmacSha256.mac_length]u8 = undefined;
-        HmacSha256.create(&mac, &transcript_hash, &finishedKey(traffic_secret));
-        return mac;
-    }
-
-    fn wipe(self: *KeySchedule) void {
-        crypto.secureZero(u8, std.mem.asBytes(self));
-    }
-};
+pub const KeySchedule = tls_key_schedule.KeySchedule;
 
 // ===========================================================================
 // QUIC transport parameters codec (RFC 9000 §18).

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -22,7 +22,7 @@ const config = @import("config.zig");
 const varint = @import("quic_varint");
 const tls_adapter = @import("tls_adapter.zig");
 const tls_handshake = @import("tls_handshake.zig");
-const tls_key_schedule = @import("../tls/key_schedule.zig");
+const tls_key_schedule = @import("tls_core").key_schedule;
 
 const crypto = std.crypto;
 const X25519 = crypto.dh.X25519;
@@ -37,6 +37,7 @@ const TlsBackend = tls_handshake.TlsBackend;
 const Role = tls_handshake.Role;
 
 pub const hash_len = tls_key_schedule.hash_len;
+const TranscriptHash = tls_key_schedule.TranscriptHash;
 /// Largest handshake message body we accept (u24 wire limit is 16 MiB; a
 /// single-certificate Ed25519 flight is far below this).
 pub const max_message_len = 8 * 1024;
@@ -415,7 +416,7 @@ pub const Tls13Backend = struct {
 
     local_params: config.TransportParameters = undefined,
     key_pair: ?X25519.KeyPair = null,
-    transcript: Sha256 = Sha256.init(.{}),
+    transcript: TranscriptHash = TranscriptHash.init(.{}),
     schedule: ?KeySchedule = null,
     /// The client Finished verify_data the server expects (computed when its
     /// own flight is sent).

--- a/src/tls/engine.zig
+++ b/src/tls/engine.zig
@@ -1,0 +1,43 @@
+//! Protocol-neutral TLS 1.3 core shell shared by QUIC and future record mode.
+//!
+//! The current QUIC adapter still owns CRYPTO-frame transport and packet-key
+//! installation. This core exposes transport-neutral configuration/state so the
+//! TLS handshake and secret lifecycle can be exercised without importing QUIC,
+//! HTTP, socket, or record-layer types.
+
+const std = @import("std");
+pub const state = @import("state.zig");
+pub const events = @import("events.zig");
+pub const key_schedule = @import("key_schedule.zig");
+
+pub const EngineConfig = struct {
+    role: state.Role,
+    transport_mode: state.TransportMode,
+};
+
+pub const Engine = struct {
+    config: EngineConfig,
+    handshake_state: state.HandshakeState = .idle,
+
+    pub fn init(config: EngineConfig) Engine {
+        return .{ .config = config };
+    }
+
+    pub fn start(self: *Engine) void {
+        self.handshake_state = switch (self.config.role) {
+            .client => .client_hello,
+            .server => .idle,
+        };
+    }
+
+    pub fn canUseRecordLayer(self: *const Engine) bool {
+        return self.config.transport_mode == .record;
+    }
+};
+
+test "core engine can be instantiated for record mode without record framing" {
+    var engine = Engine.init(.{ .role = .server, .transport_mode = .record });
+    try std.testing.expect(engine.canUseRecordLayer());
+    engine.start();
+    try std.testing.expectEqual(state.HandshakeState.idle, engine.handshake_state);
+}

--- a/src/tls/events.zig
+++ b/src/tls/events.zig
@@ -1,0 +1,14 @@
+//! Protocol-neutral events emitted by the TLS 1.3 core.
+
+pub const EncryptionEpoch = enum { initial, handshake, application };
+pub const SecretDirection = enum { read, write };
+pub const CertificateState = enum { not_checked, valid, invalid };
+
+pub const Event = union(enum) {
+    handshake_bytes: struct { epoch: EncryptionEpoch, data: []const u8 },
+    traffic_secret: struct { epoch: EncryptionEpoch, direction: SecretDirection, data: []const u8 },
+    alpn: []const u8,
+    certificate: CertificateState,
+    discard_epoch: EncryptionEpoch,
+    handshake_complete,
+};

--- a/src/tls/key_schedule.zig
+++ b/src/tls/key_schedule.zig
@@ -13,6 +13,7 @@ const HmacSha256 = crypto.auth.hmac.sha2.HmacSha256;
 const HkdfSha256 = crypto.kdf.hkdf.HkdfSha256;
 const X25519 = crypto.dh.X25519;
 
+pub const TranscriptHash = Sha256;
 pub const hash_len = Sha256.digest_length;
 pub const shared_secret_len = X25519.shared_length;
 

--- a/src/tls/key_schedule.zig
+++ b/src/tls/key_schedule.zig
@@ -1,0 +1,83 @@
+//! Protocol-neutral TLS 1.3 SHA-256 key schedule.
+//!
+//! This module intentionally depends only on `std.crypto`: it has no QUIC,
+//! HTTP, socket, or record-layer types. QUIC and future TCP-record integrations
+//! both derive handshake/application traffic secrets through this shared core.
+
+const std = @import("std");
+
+const crypto = std.crypto;
+const tls = crypto.tls;
+const Sha256 = crypto.hash.sha2.Sha256;
+const HmacSha256 = crypto.auth.hmac.sha2.HmacSha256;
+const HkdfSha256 = crypto.kdf.hkdf.HkdfSha256;
+const X25519 = crypto.dh.X25519;
+
+pub const hash_len = Sha256.digest_length;
+pub const shared_secret_len = X25519.shared_length;
+
+const empty_transcript_hash: [hash_len]u8 = blk: {
+    @setEvalBranchQuota(100_000);
+    var out: [hash_len]u8 = undefined;
+    Sha256.hash("", &out, .{});
+    break :blk out;
+};
+
+const derived_early_secret: [hash_len]u8 = blk: {
+    @setEvalBranchQuota(100_000);
+    const zeros = [_]u8{0} ** hash_len;
+    const early_secret = HkdfSha256.extract("", &zeros);
+    break :blk tls.hkdfExpandLabel(HkdfSha256, early_secret, "derived", &empty_transcript_hash, hash_len);
+};
+
+pub const KeySchedule = struct {
+    handshake_secret: [hash_len]u8,
+    master_secret: [hash_len]u8,
+    client_handshake_traffic: [hash_len]u8,
+    server_handshake_traffic: [hash_len]u8,
+
+    pub fn init(shared: [shared_secret_len]u8, hello_transcript_hash: [hash_len]u8) KeySchedule {
+        const zeros = [_]u8{0} ** hash_len;
+        const handshake_secret = HkdfSha256.extract(&derived_early_secret, &shared);
+        const derived_handshake = tls.hkdfExpandLabel(HkdfSha256, handshake_secret, "derived", &empty_transcript_hash, hash_len);
+        const master_secret = HkdfSha256.extract(&derived_handshake, &zeros);
+        return .{
+            .handshake_secret = handshake_secret,
+            .master_secret = master_secret,
+            .client_handshake_traffic = tls.hkdfExpandLabel(HkdfSha256, handshake_secret, "c hs traffic", &hello_transcript_hash, hash_len),
+            .server_handshake_traffic = tls.hkdfExpandLabel(HkdfSha256, handshake_secret, "s hs traffic", &hello_transcript_hash, hash_len),
+        };
+    }
+
+    pub const ApplicationSecrets = struct { client: [hash_len]u8, server: [hash_len]u8 };
+
+    pub fn applicationSecrets(self: *const KeySchedule, finished_transcript_hash: [hash_len]u8) ApplicationSecrets {
+        return .{
+            .client = tls.hkdfExpandLabel(HkdfSha256, self.master_secret, "c ap traffic", &finished_transcript_hash, hash_len),
+            .server = tls.hkdfExpandLabel(HkdfSha256, self.master_secret, "s ap traffic", &finished_transcript_hash, hash_len),
+        };
+    }
+
+    pub fn finishedKey(traffic_secret: [hash_len]u8) [hash_len]u8 {
+        return tls.hkdfExpandLabel(HkdfSha256, traffic_secret, "finished", "", hash_len);
+    }
+
+    pub fn verifyData(traffic_secret: [hash_len]u8, transcript_hash: [hash_len]u8) [hash_len]u8 {
+        var mac: [HmacSha256.mac_length]u8 = undefined;
+        HmacSha256.create(&mac, &transcript_hash, &finishedKey(traffic_secret));
+        return mac;
+    }
+
+    pub fn wipe(self: *KeySchedule) void {
+        crypto.secureZero(u8, std.mem.asBytes(self));
+    }
+};
+
+test "record-mode users can instantiate the protocol-neutral key schedule" {
+    const shared = [_]u8{0x42} ** shared_secret_len;
+    const transcript = [_]u8{0x24} ** hash_len;
+    var schedule = KeySchedule.init(shared, transcript);
+    defer schedule.wipe();
+    const app = schedule.applicationSecrets(transcript);
+    try std.testing.expect(!std.mem.eql(u8, &app.client, &app.server));
+}

--- a/src/tls/root.zig
+++ b/src/tls/root.zig
@@ -1,0 +1,8 @@
+pub const engine = @import("engine.zig");
+pub const state = @import("state.zig");
+pub const events = @import("events.zig");
+pub const key_schedule = @import("key_schedule.zig");
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/tls/state.zig
+++ b/src/tls/state.zig
@@ -1,0 +1,22 @@
+//! Protocol-neutral TLS engine state vocabulary.
+
+pub const Role = enum { client, server };
+
+pub const TransportMode = enum {
+    /// TLS handshake messages are carried directly by a QUIC CRYPTO transport.
+    quic,
+    /// TLS owns record framing over a reliable byte stream; the record layer is
+    /// a future module and is deliberately not imported here.
+    record,
+};
+
+pub const HandshakeState = enum {
+    idle,
+    client_hello,
+    server_hello,
+    encrypted_extensions,
+    certificate,
+    certificate_verify,
+    finished,
+    complete,
+};


### PR DESCRIPTION
### Motivation

- Make TLS 1.3 state and key-schedule reusable across QUIC and a future record-mode by separating protocol-neutral pieces from QUIC-specific code.
- Reduce duplication by moving the SHA-256 TLS 1.3 key schedule out of the QUIC backend into a standalone core that depends only on `std.crypto`.
- Clarify ownership boundaries in the design docs so the QUIC adapter continues to own CRYPTO-frame transport and transport-parameter handling while reusable TLS state lives in a neutral core.

### Description

- Add a protocol-neutral TLS core under `src/tls/` including `state.zig`, `events.zig`, `key_schedule.zig`, `engine.zig`, and `root.zig` that declare roles, transport modes, event types, a key schedule, and a small engine shell.
- Extract the TLS 1.3 SHA-256 key schedule into `src/tls/key_schedule.zig` and add a lightweight record-mode instantiation test in that module.
- Rewire the QUIC TLS backend (`src/quic/tls_backend.zig`) to import and use `tls_key_schedule.KeySchedule` and remove the duplicated key-schedule implementation from that file.
- Export the TLS core through `src/quic/root.zig` (`pub const tls_core = @import("../tls/root.zig");`) and update `docs/QUIC_TLS.md` to describe the new `src/tls/` ownership boundary and the record-mode path.

### Testing

- Ran `git diff --check` to validate whitespace and simple issues, which completed successfully.
- Attempted to run the Zig unit tests with `zig build test-quic`, but the command could not be executed in this environment because `zig` is not installed (test run failed for that reason).
- New module-level `test` cases were added (in `src/tls/key_schedule.zig` and `src/tls/engine.zig`) and will run under a normal Zig-enabled CI or local developer environment via `zig build test-quic`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a516dfb487483279cea9d4f50747b56)