### PR TITLE
feat(crypto): define stable cryptographic-provider boundary (#370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable user-facing changes to Tardigrade are documented here.
 ## [Unreleased]
 
 ### Features
+- **Stable cryptographic-provider boundary (#370, epic #327)** — a new
+  `src/crypto/` package defines the single narrow interface every TLS, QUIC,
+  and PKI module will consume cryptography through, so protocol code never
+  names a concrete primitive or a foreign TLS type. `provider.zig` is the
+  boundary: a runtime-dispatched `CryptoProvider` (`context` + `*const VTable`,
+  the same seam shape as the QUIC `TlsBackend`) covering HKDF extract/
+  expand-label, AEAD seal/open, ECDH key-share generation and shared-secret
+  derivation, signature verification, and injected-entropy random bytes, plus
+  an opaque `SigningKey` handle (so a software key today and an HSM/remote
+  signer later present the same interface), explicit `Capabilities` discovery
+  with `select*` negotiation helpers, and a classified error taxonomy that
+  distinguishes malformed input, unsupported capability, provider failure, and
+  authentication failure. `pure_zig.zig` is the first backend, built entirely
+  on `std.crypto`: HKDF over SHA-256/384, AES-128/256-GCM and
+  ChaCha20-Poly1305, X25519, and Ed25519 (signing via `SoftwareSigningKey`),
+  with secrets borrowed for the call only and scrubbed on the way out, entropy
+  drawn from an injected source (never ambient), and declared-but-absent
+  algorithms (secp256r1, ECDSA-P256, RSA-PSS) reported through capability
+  discovery rather than silently missing. Cross-checked against
+  `std.crypto`'s own HKDF/TLS helpers and exercised by seal/open, ECDH-agreement,
+  and sign/verify round-trips under `zig build test-crypto`. The OpenSSL
+  production adapter and migrating the existing QUIC/TLS modules onto the
+  boundary are follow-ups (#323–#326); see `docs/CRYPTO_PROVIDER.md`.
 - **QUIC CID routing, path validation, and migration policy (#251)** — the
   pure-Zig transport gains connection-ID lifecycle and path handling:
   `cid.zig` adds caller-entropy CID generation, a DCID→connection

--- a/build.zig
+++ b/build.zig
@@ -199,6 +199,20 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_quic_tests.step);
     test_step.dependOn(&run_quic_varint_tests.step);
 
+    // Pure-Zig cryptographic-provider package (#370, epic #327): the stable
+    // provider boundary plus its first backend. Standalone test target and part
+    // of the default `zig build test`. No system libraries.
+    const crypto_mod = b.createModule(.{
+        .root_source_file = b.path("src/crypto/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const crypto_tests = b.addTest(.{ .root_module = crypto_mod });
+    const run_crypto_tests = b.addRunArtifact(crypto_tests);
+    const crypto_step = b.step("test-crypto", "Run pure-Zig cryptographic-provider unit tests");
+    crypto_step.dependOn(&run_crypto_tests.step);
+    test_step.dependOn(&run_crypto_tests.step);
+
     const http3_mod = b.createModule(.{
         .root_source_file = b.path("src/http3/root.zig"),
         .target = target,

--- a/docs/CRYPTO_PROVIDER.md
+++ b/docs/CRYPTO_PROVIDER.md
@@ -1,0 +1,132 @@
+# Cryptographic-provider boundary (#370, epic #327)
+
+This note records the stable cryptographic-provider boundary Tardigrade's TLS,
+QUIC, and PKI code is written against, and the rules every implementation of it
+must obey. It is the deliverable of research story **327-A** and the foundation
+the rest of epic #327 builds on.
+
+## Context
+
+A working TLS state machine is not enough to replace or complement OpenSSL
+safely. The project needs one deliberate place where cryptography enters the
+protocol code, so that:
+
+- protocol modules (TLS 1.3, QUIC packet protection, X.509 verification, record
+  protection, tickets) never name a concrete primitive or a foreign TLS type;
+- more than one backend — a pure-Zig one built on `std.crypto`, and the approved
+  production OpenSSL one — can satisfy the same interface where their
+  capabilities overlap;
+- algorithm selection is explicit and cannot pick something a backend cannot do;
+- secret ownership and lifetime are stated, not assumed.
+
+Per epic #327, OpenSSL remains the approved production backend; the pure-Zig
+provider grows alongside it as an experimental and eventual alternative. This
+boundary is what keeps the two from coupling to each other.
+
+## Where it lives
+
+- `src/crypto/provider.zig` — the boundary: algorithm identifiers, capability
+  discovery, the error taxonomy, the injected `Entropy` source, the opaque
+  `SigningKey` handle, and the `CryptoProvider` interface (a `context` pointer
+  plus a `*const VTable`, the same seam shape as the QUIC `TlsBackend`).
+- `src/crypto/pure_zig.zig` — the first concrete backend, built entirely on
+  `std.crypto`. Implements the narrow first profile and advertises exactly that.
+- `src/crypto/root.zig` — the package aggregator.
+- Tests run under `zig build test-crypto` and as part of `zig build test`.
+
+The OpenSSL adapter is future work: a second file implementing the same
+`CryptoProvider.VTable`, selected at the composition root. No protocol code
+changes when it lands.
+
+## What the boundary covers
+
+- **HKDF** extract and expand-label over SHA-256 and SHA-384.
+- **AEAD** seal/open for AES-128-GCM, AES-256-GCM, and ChaCha20-Poly1305.
+- **Key exchange** — ephemeral key-share generation and shared-secret derivation
+  for X25519 and (declared, not yet implemented in pure Zig) secp256r1.
+- **Signatures** — verification, and signing through the opaque `SigningKey`
+  handle, for Ed25519 and (declared) ECDSA-P256 and RSA-PSS.
+- **Random bytes**, **constant-time comparison**, and **secure zeroing**.
+- **Opaque private-key handles** and **capability discovery**.
+
+The pure-Zig backend implements the overlap the TLS/QUIC engines need today:
+HKDF (SHA-256/384), all three AEADs, X25519, and Ed25519. The remaining
+algorithms are named by the interface so protocol and negotiation code is
+written once; capability discovery reports them absent and every entry point
+returns `error.UnsupportedCapability` until a backend provides them.
+
+## Design rules
+
+### Capability discovery is explicit
+
+A provider advertises exactly what it can do through `Capabilities` (sets of
+supported hashes, AEADs, groups, and signature schemes). Negotiation selects
+only from that set with the `select*` helpers, and every operation re-checks
+membership. An unsupported algorithm is therefore always a typed
+`error.UnsupportedCapability` — never a call into a primitive that cannot handle
+it, and never undefined behaviour.
+
+### Errors are classified
+
+The taxonomy lets the protocol layer map each failure to the correct alert
+without guessing:
+
+| Class | Meaning | Typical protocol response |
+| --- | --- | --- |
+| `InputError.InvalidInput` | Malformed or wrong-sized caller/peer input (bad point encoding, wrong-length key, undersized output buffer). | `decode_error` / `illegal_parameter`, QUIC `CRYPTO_ERROR`. |
+| `CapabilityError.UnsupportedCapability` | Well-formed but this backend cannot do it. A negotiation/config bug, not peer misbehaviour. | internal error; should be unreachable after negotiation. |
+| `ProviderError.{EntropyFailure, ProviderFailure}` | The provider itself failed, independent of input. | internal error; not fixable by renegotiating. |
+| `AuthError.AuthenticationFailed` | An AEAD tag or a signature did not verify. | `bad_record_mac` / handshake failure; never treated as a benign decode error. |
+
+### Secrets are borrowed, never retained
+
+Every slice handed to the provider — keys, IKM, plaintext, private scalars,
+peer public values — is valid only for the duration of the call. A backend must
+not retain a pointer to borrowed secret material after it returns. The only
+provider-owned secret is a `SigningKey`'s private key, which lives behind the
+opaque handle and is released by whatever created it (for the pure-Zig backend,
+a `SoftwareSigningKey` value that holds no heap allocation). Internally, backends
+copy secrets into fixed buffers only as long as a primitive needs them and
+`secureZero` those buffers on the way out; AEAD-open scrubs any partial
+plaintext on authentication failure.
+
+### Entropy is injected
+
+There is no ambient RNG, matching the rest of `src/quic/`. A provider draws all
+randomness — ephemeral scalars, nonces, per-signature noise — from the
+`Entropy` source handed in at construction. The composition root wires this to
+the OS CSPRNG in production; tests and reproducible fixtures use
+`pure_zig.DeterministicEntropy` (a seedable splitmix64 source that is explicitly
+*not* a CSPRNG). Entropy failure surfaces as `ProviderError.EntropyFailure`.
+
+### Private keys can move off-host later
+
+`SigningKey` is an opaque `context` + `VTable` pair, so a software key today and
+an HSM or remote signer tomorrow present the identical interface. The TLS engine
+holds a `SigningKey` and calls `sign`; it never learns where the private key
+lives. This is why signing goes through the handle rather than through the main
+provider vtable.
+
+## Acceptance criteria mapping (#370)
+
+- *Protocol modules compile against provider-owned types only* — the interface
+  exposes only its own enums, error sets, and handles; no `std.crypto` or
+  OpenSSL type crosses the seam. Migrating the existing QUIC/TLS modules onto it
+  is follow-up implementation work (#323–#326), which this boundary enables.
+- *Pure-Zig and OpenSSL providers satisfy the same interface where capabilities
+  overlap* — both implement `CryptoProvider.VTable`; overlap is exactly what
+  `Capabilities` makes queryable.
+- *Capability negotiation is explicit and cannot select unsupported algorithms*
+  — see "Capability discovery is explicit" above; covered by tests.
+- *Errors distinguish invalid peer input, unsupported capability, and provider
+  failure* — see the error taxonomy table; covered by tests.
+- *No provider retains borrowed secrets beyond documented call lifetimes* — see
+  "Secrets are borrowed, never retained".
+
+## Not in scope here
+
+TLS handshake behaviour (#323), X.509/Web PKI (#324), the TCP record layer
+(#325), and resumption/0-RTT (#326) live in their own stories. So do the
+differential-testing, Wycheproof-style corpora, fuzzing, performance budgets,
+and the pure-Zig production-readiness checklist enumerated in epic #327. This
+story defines the boundary they all attach to.

--- a/docs/CRYPTO_PROVIDER.md
+++ b/docs/CRYPTO_PROVIDER.md
@@ -84,11 +84,14 @@ Every slice handed to the provider — keys, IKM, plaintext, private scalars,
 peer public values — is valid only for the duration of the call. A backend must
 not retain a pointer to borrowed secret material after it returns. The only
 provider-owned secret is a `SigningKey`'s private key, which lives behind the
-opaque handle and is released by whatever created it (for the pure-Zig backend,
-a `SoftwareSigningKey` value that holds no heap allocation). Internally, backends
-copy secrets into fixed buffers only as long as a primitive needs them and
-`secureZero` those buffers on the way out; AEAD-open scrubs any partial
-plaintext on authentication failure.
+opaque handle; its owner scrubs it explicitly when retiring the key (for the
+pure-Zig backend, `SoftwareSigningKey.deinit` — a Zig value is not zeroed just
+by going out of scope). Internally, backends copy secrets into fixed buffers
+only as long as a primitive needs them and `secureZero` those buffers on the
+way out — including HKDF's per-block temporaries, the X25519 seed, ephemeral
+private scalar, and shared-secret copies. AEAD-open zeroes its output buffer on
+authentication failure so no unauthenticated plaintext is ever left for the
+caller to read.
 
 ### Entropy is injected
 

--- a/src/crypto/provider.zig
+++ b/src/crypto/provider.zig
@@ -1,0 +1,571 @@
+//! Stable cryptographic-provider boundary (#370, epic #327).
+//!
+//! One narrow interface for every cryptographic operation the TLS 1.3 engine,
+//! QUIC packet protection, X.509 verification, ticket protection, and the TLS
+//! record layer consume. Protocol code depends on the types in this file and
+//! never on a concrete implementation — neither `std.crypto` primitives nor a
+//! future OpenSSL binding leak across the seam.
+//!
+//! ## Why a provider seam
+//!
+//! The epic keeps OpenSSL as the approved production backend while a pure-Zig
+//! backend grows alongside it (`docs/CRYPTO_PROVIDER.md`). Both must satisfy
+//! *this* interface where their capabilities overlap, so protocol modules can
+//! be written once and run against either. The interface is intentionally
+//! runtime-dispatched (a `context` pointer plus a `*const VTable`) exactly like
+//! the QUIC `TlsBackend` seam (`src/quic/tls_handshake.zig`): the composition
+//! root picks the provider, the protocol never learns which one it got.
+//!
+//! ## Design rules encoded here
+//!
+//!   * **Capability discovery is explicit.** A provider advertises exactly the
+//!     hashes, AEADs, groups, and signature schemes it can perform
+//!     (`Capabilities`). Negotiation code selects only from that set, and every
+//!     operation re-checks it, so an unsupported algorithm is a typed
+//!     `error.UnsupportedCapability`, never undefined behaviour.
+//!   * **Errors are classified.** `InputError` (malformed/wrong-sized peer or
+//!     caller input), `CapabilityError` (well-formed but unsupported), and
+//!     `ProviderError` (the provider itself failed) are distinct, plus the
+//!     security-critical `error.AuthenticationFailed` for AEAD-open and
+//!     signature-verify. The protocol layer maps each class to the right alert
+//!     without guessing.
+//!   * **Secrets are borrowed, never retained.** Every slice a caller hands in
+//!     (keys, IKM, plaintext, private scalars) is valid only for the duration
+//!     of the call. A provider must not stash a pointer to borrowed secret
+//!     material past return. Provider-owned secrets (a `SigningKey`'s private
+//!     key) live behind an opaque handle the caller destroys explicitly.
+//!   * **Entropy is injected.** Like the rest of the QUIC stack there is no
+//!     ambient RNG; a provider draws randomness from an `Entropy` source given
+//!     at construction, which the composition root wires to the OS CSPRNG in
+//!     production and to a deterministic generator in tests.
+//!
+//! This module defines the boundary and its value types only. The pure-Zig
+//! implementation lives in `pure_zig.zig`; an OpenSSL adapter is future work
+//! that implements the same `VTable`.
+
+const std = @import("std");
+const crypto = std.crypto;
+
+// ---------------------------------------------------------------------------
+// Fixed capacities
+//
+// The seam moves cryptographic material through caller-owned buffers rather
+// than allocating, so it publishes the largest sizes the supported profile can
+// produce. Callers size stack buffers against these constants.
+// ---------------------------------------------------------------------------
+
+/// Largest hash / HKDF output in the supported profile (SHA-384 = 48 bytes).
+pub const max_digest_len = 48;
+/// Largest AEAD key in the supported profile (AES-256 / ChaCha20 = 32 bytes).
+pub const max_aead_key_len = 32;
+/// AEAD nonce length. Every supported AEAD (AES-GCM, ChaCha20-Poly1305 in the
+/// TLS/QUIC profile) uses a 12-byte nonce.
+pub const aead_nonce_len = 12;
+/// AEAD authentication tag length. Every supported AEAD uses a 16-byte tag.
+pub const aead_tag_len = 16;
+/// Largest key-exchange public value (uncompressed P-256 point = 65 bytes).
+pub const max_public_key_len = 65;
+/// Largest key-exchange private scalar in the supported profile (32 bytes).
+pub const max_private_scalar_len = 32;
+/// Largest shared secret an ECDH group in the supported profile derives.
+pub const max_shared_secret_len = 32;
+
+// ---------------------------------------------------------------------------
+// Error taxonomy
+// ---------------------------------------------------------------------------
+
+/// The caller or peer supplied malformed or wrong-sized input. Recoverable at
+/// the protocol layer — typically a `decode_error` / `illegal_parameter` alert
+/// or a QUIC `CRYPTO_ERROR`. Never the provider's fault.
+pub const InputError = error{
+    /// Input was structurally invalid (bad point encoding, wrong-length key,
+    /// output buffer too small, mismatched ciphertext/plaintext lengths).
+    InvalidInput,
+};
+
+/// The requested algorithm or parameter is well-formed but this provider does
+/// not implement it. Explicit capability negotiation is meant to prevent this;
+/// reaching it is a configuration or negotiation bug, not peer misbehaviour.
+pub const CapabilityError = error{
+    UnsupportedCapability,
+};
+
+/// The provider itself failed for reasons unrelated to the input: the entropy
+/// source returned an error, or an internal invariant broke. Not recoverable
+/// by renegotiating algorithms.
+pub const ProviderError = error{
+    EntropyFailure,
+    ProviderFailure,
+};
+
+/// Authentication failed: an AEAD tag did not verify, or a signature did not
+/// check out. Kept separate from `InputError` because it is the security-
+/// relevant "these bytes are not authentic" signal, and protocol code must not
+/// treat it as a benign decode error.
+pub const AuthError = error{
+    AuthenticationFailed,
+};
+
+/// HKDF extract/expand cannot fail on authentication and does not touch
+/// entropy; only capability and input sizing can go wrong.
+pub const HkdfError = InputError || CapabilityError;
+/// AEAD seal produces output; it can reject bad sizes or an unsupported AEAD.
+pub const SealError = InputError || CapabilityError;
+/// AEAD open additionally authenticates, so it adds `AuthenticationFailed`.
+pub const OpenError = InputError || CapabilityError || AuthError;
+/// Key-share generation draws entropy and can reject an unsupported group.
+pub const KeyShareError = CapabilityError || ProviderError;
+/// Shared-secret derivation validates the peer's public value (`InvalidInput`
+/// covers a low-order / all-zero point) and can reject an unsupported group.
+pub const DeriveError = InputError || CapabilityError;
+/// Signing draws entropy for some schemes and can fail inside the provider.
+pub const SignError = InputError || CapabilityError || ProviderError;
+/// Verification authenticates, so it carries `AuthenticationFailed`.
+pub const VerifyError = InputError || CapabilityError || AuthError;
+/// Random-byte generation only fails when the entropy source does.
+pub const RandomError = ProviderError;
+
+/// Entropy sources report failure with this narrow set; the provider maps it
+/// onto `ProviderError.EntropyFailure`.
+pub const EntropyError = error{
+    EntropyFailure,
+};
+
+// ---------------------------------------------------------------------------
+// Algorithm identifiers
+// ---------------------------------------------------------------------------
+
+/// Hash / HKDF families the boundary can name. The wire never sees these
+/// directly; they parameterise HKDF and the HMAC inside signature schemes.
+pub const Hash = enum {
+    sha256,
+    sha384,
+
+    /// Output length in bytes of this hash (and of its HKDF PRK).
+    pub fn digestLength(self: Hash) usize {
+        return switch (self) {
+            .sha256 => 32,
+            .sha384 => 48,
+        };
+    }
+};
+
+/// AEAD profiles for record and packet protection.
+pub const Aead = enum {
+    aes_128_gcm,
+    aes_256_gcm,
+    chacha20_poly1305,
+
+    pub fn keyLength(self: Aead) usize {
+        return switch (self) {
+            .aes_128_gcm => 16,
+            .aes_256_gcm, .chacha20_poly1305 => 32,
+        };
+    }
+
+    /// Nonce length. Uniform across the supported profile, exposed per-AEAD so
+    /// call sites stay algorithm-agnostic.
+    pub fn nonceLength(self: Aead) usize {
+        _ = self;
+        return aead_nonce_len;
+    }
+
+    pub fn tagLength(self: Aead) usize {
+        _ = self;
+        return aead_tag_len;
+    }
+};
+
+/// Key-exchange groups (ECDH). Names match the TLS `NamedGroup` registry.
+pub const Group = enum {
+    x25519,
+    secp256r1,
+
+    /// Length of the public key share this group puts on the wire.
+    pub fn publicKeyLength(self: Group) usize {
+        return switch (self) {
+            .x25519 => 32,
+            .secp256r1 => 65, // uncompressed point: 0x04 || X || Y
+        };
+    }
+
+    /// Length of the raw shared secret ECDH derives for this group.
+    pub fn sharedSecretLength(self: Group) usize {
+        return switch (self) {
+            .x25519 => 32,
+            .secp256r1 => 32, // the X coordinate
+        };
+    }
+};
+
+/// Signature schemes for CertificateVerify and (future) ticket authentication.
+/// Names match the TLS `SignatureScheme` registry.
+pub const SignatureScheme = enum {
+    ed25519,
+    ecdsa_secp256r1_sha256,
+    rsa_pss_rsae_sha256,
+};
+
+// ---------------------------------------------------------------------------
+// Capability discovery
+// ---------------------------------------------------------------------------
+
+/// The exact algorithm set a provider can perform. Negotiation selects only
+/// from these sets, and every operation re-checks membership, so an
+/// unsupported algorithm is always a typed error and never reaches a primitive
+/// that cannot handle it.
+pub const Capabilities = struct {
+    hashes: std.EnumSet(Hash) = .{},
+    aeads: std.EnumSet(Aead) = .{},
+    groups: std.EnumSet(Group) = .{},
+    signatures: std.EnumSet(SignatureScheme) = .{},
+
+    pub fn supportsHash(self: Capabilities, hash: Hash) bool {
+        return self.hashes.contains(hash);
+    }
+    pub fn supportsAead(self: Capabilities, aead: Aead) bool {
+        return self.aeads.contains(aead);
+    }
+    pub fn supportsGroup(self: Capabilities, group: Group) bool {
+        return self.groups.contains(group);
+    }
+    pub fn supportsSignature(self: Capabilities, scheme: SignatureScheme) bool {
+        return self.signatures.contains(scheme);
+    }
+
+    /// Walk `preferences` in caller order and return the first algorithm this
+    /// provider supports, or null when the sets do not intersect. The generic
+    /// form backs the typed `select*` helpers below; negotiation code should
+    /// prefer those so the element type is checked.
+    fn selectFrom(comptime T: type, set: std.EnumSet(T), preferences: []const T) ?T {
+        for (preferences) |candidate| {
+            if (set.contains(candidate)) return candidate;
+        }
+        return null;
+    }
+
+    pub fn selectAead(self: Capabilities, preferences: []const Aead) ?Aead {
+        return selectFrom(Aead, self.aeads, preferences);
+    }
+    pub fn selectGroup(self: Capabilities, preferences: []const Group) ?Group {
+        return selectFrom(Group, self.groups, preferences);
+    }
+    pub fn selectSignature(self: Capabilities, preferences: []const SignatureScheme) ?SignatureScheme {
+        return selectFrom(SignatureScheme, self.signatures, preferences);
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Entropy source
+// ---------------------------------------------------------------------------
+
+/// A caller-supplied randomness source. The composition root wires this to the
+/// OS CSPRNG in production and to a deterministic generator in tests, matching
+/// the "entropy is injected, never ambient" rule the QUIC stack already
+/// follows. A provider draws all randomness — ephemeral scalars, nonces,
+/// signature noise — through this.
+pub const Entropy = struct {
+    context: *anyopaque,
+    fillFn: *const fn (context: *anyopaque, buffer: []u8) EntropyError!void,
+
+    /// Fill `buffer` with cryptographically strong random bytes, or fail.
+    pub fn fill(self: Entropy, buffer: []u8) EntropyError!void {
+        return self.fillFn(self.context, buffer);
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Signing keys (opaque private-key handles)
+// ---------------------------------------------------------------------------
+
+/// An opaque handle to a private signing key. This is the single abstraction
+/// the epic calls out for supporting software keys today and hardware or
+/// remote signers later without changing TLS state: the TLS engine holds a
+/// `SigningKey` and calls `sign`, oblivious to whether the private key lives in
+/// process memory, an HSM, or a network signer.
+///
+/// The handle borrows nothing from the caller across `sign`; its own private
+/// material is owned by whatever produced it (e.g. a `pure_zig` software key)
+/// and released by that owner, not here.
+pub const SigningKey = struct {
+    context: *anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        /// The scheme this key signs with; negotiation must offer only this.
+        scheme: *const fn (context: *anyopaque) SignatureScheme,
+        /// Sign `message`, writing the signature into `out` and returning its
+        /// length. `out` must be large enough for the scheme's signature
+        /// (`error.InvalidInput` otherwise). `entropy` supplies any randomness
+        /// the scheme needs (ECDSA/RSA-PSS); Ed25519 ignores it.
+        sign: *const fn (
+            context: *anyopaque,
+            message: []const u8,
+            entropy: Entropy,
+            out: []u8,
+        ) SignError!usize,
+    };
+
+    pub fn scheme(self: SigningKey) SignatureScheme {
+        return self.vtable.scheme(self.context);
+    }
+
+    pub fn sign(self: SigningKey, message: []const u8, entropy: Entropy, out: []u8) SignError!usize {
+        return self.vtable.sign(self.context, message, entropy, out);
+    }
+};
+
+// ---------------------------------------------------------------------------
+// The provider interface
+// ---------------------------------------------------------------------------
+
+/// The cryptographic-provider boundary. All symmetric operations move key
+/// material through caller-owned slices (borrowed for the call only); the sole
+/// provider-owned secret handle is `SigningKey`.
+pub const CryptoProvider = struct {
+    context: *anyopaque,
+    vtable: *const VTable,
+    /// Entropy the provider draws all randomness from. Held here so the
+    /// interface documents that a provider has exactly one injected source.
+    entropy: Entropy,
+
+    pub const VTable = struct {
+        capabilities: *const fn (context: *anyopaque) Capabilities,
+
+        /// HKDF-Extract: `out` receives `hash.digestLength()` PRK bytes.
+        hkdfExtract: *const fn (
+            context: *anyopaque,
+            hash: Hash,
+            salt: []const u8,
+            ikm: []const u8,
+            out: []u8,
+        ) HkdfError!void,
+
+        /// HKDF-Expand-Label (RFC 8446 §7.1): derive `out.len` bytes bound to
+        /// `label` (the bare label, without the "tls13 " prefix the provider
+        /// adds) and `context`.
+        hkdfExpandLabel: *const fn (
+            context: *anyopaque,
+            hash: Hash,
+            secret: []const u8,
+            label: []const u8,
+            hash_context: []const u8,
+            out: []u8,
+        ) HkdfError!void,
+
+        /// AEAD seal. `ciphertext.len` must equal `plaintext.len`; the tag is
+        /// written separately to `tag` (`aead.tagLength()` bytes).
+        aeadSeal: *const fn (
+            context: *anyopaque,
+            aead: Aead,
+            key: []const u8,
+            nonce: []const u8,
+            associated_data: []const u8,
+            plaintext: []const u8,
+            ciphertext: []u8,
+            tag: []u8,
+        ) SealError!void,
+
+        /// AEAD open. Authenticates `tag` over `ciphertext` + `associated_data`
+        /// and writes `plaintext` on success; leaves `plaintext` untouched and
+        /// returns `error.AuthenticationFailed` otherwise.
+        aeadOpen: *const fn (
+            context: *anyopaque,
+            aead: Aead,
+            key: []const u8,
+            nonce: []const u8,
+            associated_data: []const u8,
+            ciphertext: []const u8,
+            tag: []const u8,
+            plaintext: []u8,
+        ) OpenError!void,
+
+        /// Generate an ephemeral key share for `group`. Writes the public value
+        /// to `public_out` and the private scalar to `private_out` (both sized
+        /// to the group). The private scalar is caller-owned; the caller wipes
+        /// it after `deriveSharedSecret`.
+        generateKeyShare: *const fn (
+            context: *anyopaque,
+            group: Group,
+            public_out: []u8,
+            private_out: []u8,
+        ) KeyShareError!void,
+
+        /// Derive the ECDH shared secret from our `private_scalar` and the
+        /// peer's `peer_public`. Rejects invalid peer points as
+        /// `error.InvalidInput`.
+        deriveSharedSecret: *const fn (
+            context: *anyopaque,
+            group: Group,
+            private_scalar: []const u8,
+            peer_public: []const u8,
+            out: []u8,
+        ) DeriveError!void,
+
+        /// Verify `signature` over `message` against `public_key` under
+        /// `scheme`. `public_key` is the scheme's raw public encoding.
+        verify: *const fn (
+            context: *anyopaque,
+            scheme: SignatureScheme,
+            public_key: []const u8,
+            message: []const u8,
+            signature: []const u8,
+        ) VerifyError!void,
+    };
+
+    pub fn capabilities(self: CryptoProvider) Capabilities {
+        return self.vtable.capabilities(self.context);
+    }
+
+    /// Fill `buffer` with random bytes from the injected entropy source,
+    /// classifying any failure as a provider error.
+    pub fn randomBytes(self: CryptoProvider, buffer: []u8) RandomError!void {
+        self.entropy.fill(buffer) catch return error.EntropyFailure;
+    }
+
+    pub fn hkdfExtract(self: CryptoProvider, hash: Hash, salt: []const u8, ikm: []const u8, out: []u8) HkdfError!void {
+        return self.vtable.hkdfExtract(self.context, hash, salt, ikm, out);
+    }
+
+    pub fn hkdfExpandLabel(
+        self: CryptoProvider,
+        hash: Hash,
+        secret: []const u8,
+        label: []const u8,
+        hash_context: []const u8,
+        out: []u8,
+    ) HkdfError!void {
+        return self.vtable.hkdfExpandLabel(self.context, hash, secret, label, hash_context, out);
+    }
+
+    pub fn aeadSeal(
+        self: CryptoProvider,
+        aead: Aead,
+        key: []const u8,
+        nonce: []const u8,
+        associated_data: []const u8,
+        plaintext: []const u8,
+        ciphertext: []u8,
+        tag: []u8,
+    ) SealError!void {
+        return self.vtable.aeadSeal(self.context, aead, key, nonce, associated_data, plaintext, ciphertext, tag);
+    }
+
+    pub fn aeadOpen(
+        self: CryptoProvider,
+        aead: Aead,
+        key: []const u8,
+        nonce: []const u8,
+        associated_data: []const u8,
+        ciphertext: []const u8,
+        tag: []const u8,
+        plaintext: []u8,
+    ) OpenError!void {
+        return self.vtable.aeadOpen(self.context, aead, key, nonce, associated_data, ciphertext, tag, plaintext);
+    }
+
+    pub fn generateKeyShare(self: CryptoProvider, group: Group, public_out: []u8, private_out: []u8) KeyShareError!void {
+        return self.vtable.generateKeyShare(self.context, group, public_out, private_out);
+    }
+
+    pub fn deriveSharedSecret(
+        self: CryptoProvider,
+        group: Group,
+        private_scalar: []const u8,
+        peer_public: []const u8,
+        out: []u8,
+    ) DeriveError!void {
+        return self.vtable.deriveSharedSecret(self.context, group, private_scalar, peer_public, out);
+    }
+
+    pub fn verify(
+        self: CryptoProvider,
+        scheme: SignatureScheme,
+        public_key: []const u8,
+        message: []const u8,
+        signature: []const u8,
+    ) VerifyError!void {
+        return self.vtable.verify(self.context, scheme, public_key, message, signature);
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Algorithm-independent helpers
+//
+// Constant-time comparison and secure zeroing do not depend on which provider
+// is in use, so they live here as free functions the whole stack shares rather
+// than as per-provider vtable entries.
+// ---------------------------------------------------------------------------
+
+/// Compare two byte slices in constant time with respect to their contents.
+/// The length check short-circuits (lengths are not secret), but for equal
+/// lengths the running time is independent of where — or whether — the bytes
+/// differ. Use this for MACs, Finished values, and any secret-derived tag.
+pub fn constantTimeEqual(a: []const u8, b: []const u8) bool {
+    if (a.len != b.len) return false;
+    var diff: u8 = 0;
+    for (a, b) |x, y| diff |= x ^ y;
+    return diff == 0;
+}
+
+/// Overwrite `buffer` with zeros in a way the optimiser may not elide. Call
+/// this on any stack or heap copy of secret material before it goes out of
+/// scope.
+pub fn secureZero(buffer: []u8) void {
+    crypto.secureZero(u8, buffer);
+}
+
+// ---------------------------------------------------------------------------
+// Tests for the pure interface (no implementation required)
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+test "algorithm metadata is self-consistent" {
+    try testing.expectEqual(@as(usize, 32), Hash.sha256.digestLength());
+    try testing.expectEqual(@as(usize, 48), Hash.sha384.digestLength());
+    try testing.expect(Hash.sha384.digestLength() <= max_digest_len);
+
+    try testing.expectEqual(@as(usize, 16), Aead.aes_128_gcm.keyLength());
+    try testing.expectEqual(@as(usize, 32), Aead.aes_256_gcm.keyLength());
+    try testing.expectEqual(@as(usize, 32), Aead.chacha20_poly1305.keyLength());
+    inline for (.{ Aead.aes_128_gcm, Aead.aes_256_gcm, Aead.chacha20_poly1305 }) |aead| {
+        try testing.expect(aead.keyLength() <= max_aead_key_len);
+        try testing.expectEqual(aead_nonce_len, aead.nonceLength());
+        try testing.expectEqual(aead_tag_len, aead.tagLength());
+    }
+
+    try testing.expect(Group.secp256r1.publicKeyLength() <= max_public_key_len);
+    try testing.expect(Group.x25519.sharedSecretLength() <= max_shared_secret_len);
+}
+
+test "capability negotiation only selects supported algorithms" {
+    var caps = Capabilities{};
+    caps.aeads.insert(.aes_128_gcm);
+    caps.aeads.insert(.chacha20_poly1305);
+
+    try testing.expect(caps.supportsAead(.aes_128_gcm));
+    try testing.expect(!caps.supportsAead(.aes_256_gcm));
+
+    // Caller prefers AES-256 first, but the provider lacks it, so negotiation
+    // falls through to the first supported preference.
+    const prefer = [_]Aead{ .aes_256_gcm, .chacha20_poly1305, .aes_128_gcm };
+    try testing.expectEqual(Aead.chacha20_poly1305, caps.selectAead(&prefer).?);
+
+    // No overlap yields null rather than an arbitrary pick.
+    const only_unsupported = [_]Aead{.aes_256_gcm};
+    try testing.expectEqual(@as(?Aead, null), caps.selectAead(&only_unsupported));
+}
+
+test "constantTimeEqual matches semantic equality" {
+    try testing.expect(constantTimeEqual("abcd", "abcd"));
+    try testing.expect(!constantTimeEqual("abcd", "abce"));
+    try testing.expect(!constantTimeEqual("abc", "abcd"));
+    try testing.expect(constantTimeEqual("", ""));
+}
+
+test "secureZero clears a buffer" {
+    var buf = [_]u8{0xAB} ** 16;
+    secureZero(&buf);
+    for (buf) |b| try testing.expectEqual(@as(u8, 0), b);
+}

--- a/src/crypto/provider.zig
+++ b/src/crypto/provider.zig
@@ -113,8 +113,9 @@ pub const HkdfError = InputError || CapabilityError;
 pub const SealError = InputError || CapabilityError;
 /// AEAD open additionally authenticates, so it adds `AuthenticationFailed`.
 pub const OpenError = InputError || CapabilityError || AuthError;
-/// Key-share generation draws entropy and can reject an unsupported group.
-pub const KeyShareError = CapabilityError || ProviderError;
+/// Key-share generation draws entropy, can reject an unsupported group, and
+/// rejects wrong-sized caller output buffers as `InvalidInput`.
+pub const KeyShareError = InputError || CapabilityError || ProviderError;
 /// Shared-secret derivation validates the peer's public value (`InvalidInput`
 /// covers a low-order / all-zero point) and can reject an unsupported group.
 pub const DeriveError = InputError || CapabilityError;
@@ -367,8 +368,10 @@ pub const CryptoProvider = struct {
         ) SealError!void,
 
         /// AEAD open. Authenticates `tag` over `ciphertext` + `associated_data`
-        /// and writes `plaintext` on success; leaves `plaintext` untouched and
-        /// returns `error.AuthenticationFailed` otherwise.
+        /// and writes `plaintext` on success. On `error.AuthenticationFailed`
+        /// the `plaintext` buffer is zeroed/invalidated — a provider must never
+        /// leave partially decrypted, unauthenticated output for the caller to
+        /// read.
         aeadOpen: *const fn (
             context: *anyopaque,
             aead: Aead,
@@ -502,10 +505,13 @@ pub const CryptoProvider = struct {
 /// lengths the running time is independent of where — or whether — the bytes
 /// differ. Use this for MACs, Finished values, and any secret-derived tag.
 pub fn constantTimeEqual(a: []const u8, b: []const u8) bool {
+    // Lengths are not secret, so the mismatch short-circuits. The content
+    // comparison is delegated to the standard library's dedicated timing-safe
+    // primitive rather than a hand-rolled loop. `timing_safe.eql` needs a
+    // comptime-fixed length; `timing_safe.compare` is its slice-based sibling
+    // and runs in constant time for equal-length inputs.
     if (a.len != b.len) return false;
-    var diff: u8 = 0;
-    for (a, b) |x, y| diff |= x ^ y;
-    return diff == 0;
+    return crypto.timing_safe.compare(u8, a, b, .big) == .eq;
 }
 
 /// Overwrite `buffer` with zeros in a way the optimiser may not elide. Call

--- a/src/crypto/pure_zig.zig
+++ b/src/crypto/pure_zig.zig
@@ -1,0 +1,658 @@
+//! Pure-Zig `CryptoProvider` (#370, epic #327).
+//!
+//! Satisfies the `provider.CryptoProvider` boundary using only `std.crypto`
+//! primitives — no external TLS/crypto library. This is the experimental
+//! backend the epic grows alongside OpenSSL; it implements the narrow first
+//! profile the TLS/QUIC engines target and advertises exactly that profile
+//! through capability discovery, so anything outside it is a typed
+//! `error.UnsupportedCapability` rather than a silent gap.
+//!
+//! Implemented here (the overlap where a pure-Zig and an OpenSSL provider must
+//! agree):
+//!
+//!   * HKDF-Extract / Expand-Label over SHA-256 and SHA-384
+//!   * AEAD seal/open for AES-128-GCM, AES-256-GCM, ChaCha20-Poly1305
+//!   * X25519 key-share generation and shared-secret derivation
+//!   * Ed25519 signing (via `SoftwareSigningKey`) and verification
+//!   * injected-entropy random bytes, constant-time compare, secure zero
+//!
+//! Declared by the interface but not yet implemented here — capability
+//! discovery reports them absent, and every entry point returns
+//! `error.UnsupportedCapability`:
+//!
+//!   * secp256r1 (P-256) ECDH, ECDSA-P256, RSA-PSS
+//!
+//! These arrive with the OpenSSL adapter and later pure-Zig work; the seam
+//! already names them so protocol code and negotiation are written once.
+//!
+//! The provider never draws ambient randomness: it fills key-share scalars and
+//! any per-signature noise from the `provider.Entropy` handed in at
+//! construction, exactly like the rest of `src/quic/`.
+
+const std = @import("std");
+const crypto = std.crypto;
+const provider = @import("provider.zig");
+
+const HmacSha256 = crypto.auth.hmac.sha2.HmacSha256;
+const HmacSha384 = crypto.auth.hmac.sha2.HmacSha384;
+const Aes128Gcm = crypto.aead.aes_gcm.Aes128Gcm;
+const Aes256Gcm = crypto.aead.aes_gcm.Aes256Gcm;
+const ChaCha20Poly1305 = crypto.aead.chacha_poly.ChaCha20Poly1305;
+const X25519 = crypto.dh.X25519;
+const Ed25519 = crypto.sign.Ed25519;
+
+/// The pure-Zig provider. Construct with an entropy source, then hand the
+/// interface view to protocol code via `cryptoProvider`.
+pub const Provider = struct {
+    entropy: provider.Entropy,
+
+    pub fn init(entropy: provider.Entropy) Provider {
+        return .{ .entropy = entropy };
+    }
+
+    /// Erase to the boundary type. The returned view borrows `self`, so `self`
+    /// must outlive every use of it.
+    pub fn cryptoProvider(self: *Provider) provider.CryptoProvider {
+        return .{ .context = self, .vtable = &vtable, .entropy = self.entropy };
+    }
+
+    /// The static algorithm profile this backend advertises.
+    pub fn capabilities() provider.Capabilities {
+        var caps = provider.Capabilities{};
+        caps.hashes.insert(.sha256);
+        caps.hashes.insert(.sha384);
+        caps.aeads.insert(.aes_128_gcm);
+        caps.aeads.insert(.aes_256_gcm);
+        caps.aeads.insert(.chacha20_poly1305);
+        caps.groups.insert(.x25519);
+        caps.signatures.insert(.ed25519);
+        return caps;
+    }
+
+    const vtable = provider.CryptoProvider.VTable{
+        .capabilities = capabilitiesImpl,
+        .hkdfExtract = hkdfExtractImpl,
+        .hkdfExpandLabel = hkdfExpandLabelImpl,
+        .aeadSeal = aeadSealImpl,
+        .aeadOpen = aeadOpenImpl,
+        .generateKeyShare = generateKeyShareImpl,
+        .deriveSharedSecret = deriveSharedSecretImpl,
+        .verify = verifyImpl,
+    };
+};
+
+// ---------------------------------------------------------------------------
+// Capability discovery
+// ---------------------------------------------------------------------------
+
+fn capabilitiesImpl(context: *anyopaque) provider.Capabilities {
+    _ = context;
+    return Provider.capabilities();
+}
+
+// ---------------------------------------------------------------------------
+// HKDF
+// ---------------------------------------------------------------------------
+
+fn hkdfExtractImpl(
+    context: *anyopaque,
+    hash: provider.Hash,
+    salt: []const u8,
+    ikm: []const u8,
+    out: []u8,
+) provider.HkdfError!void {
+    _ = context;
+    switch (hash) {
+        .sha256 => return extractWith(HmacSha256, salt, ikm, out),
+        .sha384 => return extractWith(HmacSha384, salt, ikm, out),
+    }
+}
+
+fn extractWith(comptime Hmac: type, salt: []const u8, ikm: []const u8, out: []u8) provider.HkdfError!void {
+    // HKDF-Extract(salt, IKM) = HMAC-Hash(key = salt, data = IKM). An empty
+    // salt matches the RFC 5869 default of HashLen zero bytes, because HMAC
+    // zero-pads its key to the block size either way.
+    if (out.len != Hmac.mac_length) return error.InvalidInput;
+    var prk: [Hmac.mac_length]u8 = undefined;
+    Hmac.create(&prk, ikm, salt);
+    @memcpy(out, &prk);
+    crypto.secureZero(u8, &prk);
+}
+
+fn hkdfExpandLabelImpl(
+    context: *anyopaque,
+    hash: provider.Hash,
+    secret: []const u8,
+    label: []const u8,
+    hash_context: []const u8,
+    out: []u8,
+) provider.HkdfError!void {
+    _ = context;
+    switch (hash) {
+        .sha256 => return expandLabelWith(HmacSha256, secret, label, hash_context, out),
+        .sha384 => return expandLabelWith(HmacSha384, secret, label, hash_context, out),
+    }
+}
+
+/// HKDF-Expand-Label (RFC 8446 §7.1) implemented over HMAC so it can write an
+/// arbitrary runtime-length `out`. Cross-checked against
+/// `std.crypto.tls.hkdfExpandLabel` in the tests below.
+fn expandLabelWith(
+    comptime Hmac: type,
+    secret: []const u8,
+    label: []const u8,
+    context: []const u8,
+    out: []u8,
+) provider.HkdfError!void {
+    const mac_len = Hmac.mac_length;
+    if (secret.len != mac_len) return error.InvalidInput;
+
+    const label_prefix = "tls13 ";
+    const full_label_len = label_prefix.len + label.len;
+    if (full_label_len > 255) return error.InvalidInput;
+    if (context.len > 255) return error.InvalidInput;
+    if (out.len == 0 or out.len > 255 * mac_len) return error.InvalidInput;
+
+    // Build the HkdfLabel structure:
+    //   uint16 length; opaque label<7..255>; opaque context<0..255>;
+    var info: [2 + 1 + 255 + 1 + 255]u8 = undefined;
+    var info_len: usize = 0;
+    info[0] = @intCast((out.len >> 8) & 0xff);
+    info[1] = @intCast(out.len & 0xff);
+    info_len = 2;
+    info[info_len] = @intCast(full_label_len);
+    info_len += 1;
+    @memcpy(info[info_len..][0..label_prefix.len], label_prefix);
+    info_len += label_prefix.len;
+    @memcpy(info[info_len..][0..label.len], label);
+    info_len += label.len;
+    info[info_len] = @intCast(context.len);
+    info_len += 1;
+    @memcpy(info[info_len..][0..context.len], context);
+    info_len += context.len;
+    const info_slice = info[0..info_len];
+
+    var prk: [mac_len]u8 = undefined;
+    @memcpy(&prk, secret);
+    defer crypto.secureZero(u8, &prk);
+
+    // HKDF-Expand: T(i) = HMAC(PRK, T(i-1) || info || i), truncated to out.len.
+    var block: [mac_len]u8 = undefined;
+    var message: [mac_len + info.len + 1]u8 = undefined;
+    var have_previous = false;
+    var counter: usize = 1;
+    var written: usize = 0;
+    while (written < out.len) : (counter += 1) {
+        var m: usize = 0;
+        if (have_previous) {
+            @memcpy(message[0..mac_len], &block);
+            m = mac_len;
+        }
+        @memcpy(message[m..][0..info_slice.len], info_slice);
+        m += info_slice.len;
+        message[m] = @intCast(counter); // counter <= 255 by the guard above
+        m += 1;
+        Hmac.create(&block, message[0..m], &prk);
+        const take = @min(mac_len, out.len - written);
+        @memcpy(out[written..][0..take], block[0..take]);
+        written += take;
+        have_previous = true;
+    }
+    crypto.secureZero(u8, &block);
+}
+
+// ---------------------------------------------------------------------------
+// AEAD
+// ---------------------------------------------------------------------------
+
+fn aeadSealImpl(
+    context: *anyopaque,
+    aead: provider.Aead,
+    key: []const u8,
+    nonce: []const u8,
+    associated_data: []const u8,
+    plaintext: []const u8,
+    ciphertext: []u8,
+    tag: []u8,
+) provider.SealError!void {
+    _ = context;
+    switch (aead) {
+        .aes_128_gcm => return sealWith(Aes128Gcm, key, nonce, associated_data, plaintext, ciphertext, tag),
+        .aes_256_gcm => return sealWith(Aes256Gcm, key, nonce, associated_data, plaintext, ciphertext, tag),
+        .chacha20_poly1305 => return sealWith(ChaCha20Poly1305, key, nonce, associated_data, plaintext, ciphertext, tag),
+    }
+}
+
+fn sealWith(
+    comptime Cipher: type,
+    key: []const u8,
+    nonce: []const u8,
+    associated_data: []const u8,
+    plaintext: []const u8,
+    ciphertext: []u8,
+    tag: []u8,
+) provider.SealError!void {
+    if (key.len != Cipher.key_length) return error.InvalidInput;
+    if (nonce.len != Cipher.nonce_length) return error.InvalidInput;
+    if (tag.len != Cipher.tag_length) return error.InvalidInput;
+    if (ciphertext.len != plaintext.len) return error.InvalidInput;
+
+    var k: [Cipher.key_length]u8 = undefined;
+    var n: [Cipher.nonce_length]u8 = undefined;
+    @memcpy(&k, key);
+    @memcpy(&n, nonce);
+    defer crypto.secureZero(u8, &k);
+
+    var t: [Cipher.tag_length]u8 = undefined;
+    Cipher.encrypt(ciphertext, &t, plaintext, associated_data, n, k);
+    @memcpy(tag, &t);
+}
+
+fn aeadOpenImpl(
+    context: *anyopaque,
+    aead: provider.Aead,
+    key: []const u8,
+    nonce: []const u8,
+    associated_data: []const u8,
+    ciphertext: []const u8,
+    tag: []const u8,
+    plaintext: []u8,
+) provider.OpenError!void {
+    _ = context;
+    switch (aead) {
+        .aes_128_gcm => return openWith(Aes128Gcm, key, nonce, associated_data, ciphertext, tag, plaintext),
+        .aes_256_gcm => return openWith(Aes256Gcm, key, nonce, associated_data, ciphertext, tag, plaintext),
+        .chacha20_poly1305 => return openWith(ChaCha20Poly1305, key, nonce, associated_data, ciphertext, tag, plaintext),
+    }
+}
+
+fn openWith(
+    comptime Cipher: type,
+    key: []const u8,
+    nonce: []const u8,
+    associated_data: []const u8,
+    ciphertext: []const u8,
+    tag: []const u8,
+    plaintext: []u8,
+) provider.OpenError!void {
+    if (key.len != Cipher.key_length) return error.InvalidInput;
+    if (nonce.len != Cipher.nonce_length) return error.InvalidInput;
+    if (tag.len != Cipher.tag_length) return error.InvalidInput;
+    if (plaintext.len != ciphertext.len) return error.InvalidInput;
+
+    var k: [Cipher.key_length]u8 = undefined;
+    var n: [Cipher.nonce_length]u8 = undefined;
+    var t: [Cipher.tag_length]u8 = undefined;
+    @memcpy(&k, key);
+    @memcpy(&n, nonce);
+    @memcpy(&t, tag);
+    defer crypto.secureZero(u8, &k);
+
+    Cipher.decrypt(plaintext, ciphertext, t, associated_data, n, k) catch {
+        // Never leak partial plaintext on authentication failure.
+        crypto.secureZero(u8, plaintext);
+        return error.AuthenticationFailed;
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Key exchange
+// ---------------------------------------------------------------------------
+
+fn generateKeyShareImpl(
+    context: *anyopaque,
+    group: provider.Group,
+    public_out: []u8,
+    private_out: []u8,
+) provider.KeyShareError!void {
+    const self: *Provider = @ptrCast(@alignCast(context));
+    switch (group) {
+        .x25519 => {
+            // Wrong-sized output buffers are a caller sizing bug, not peer
+            // input; the caller sizes against Group.publicKeyLength().
+            if (public_out.len != X25519.public_length) return error.ProviderFailure;
+            if (private_out.len != X25519.secret_length) return error.ProviderFailure;
+
+            var seed: [X25519.seed_length]u8 = undefined;
+            self.entropy.fill(&seed) catch return error.EntropyFailure;
+            defer crypto.secureZero(u8, &seed);
+
+            const key_pair = X25519.KeyPair.generateDeterministic(seed) catch return error.ProviderFailure;
+            @memcpy(public_out, &key_pair.public_key);
+            @memcpy(private_out, &key_pair.secret_key);
+        },
+        .secp256r1 => return error.UnsupportedCapability,
+    }
+}
+
+fn deriveSharedSecretImpl(
+    context: *anyopaque,
+    group: provider.Group,
+    private_scalar: []const u8,
+    peer_public: []const u8,
+    out: []u8,
+) provider.DeriveError!void {
+    _ = context;
+    switch (group) {
+        .x25519 => {
+            if (private_scalar.len != X25519.secret_length) return error.InvalidInput;
+            if (peer_public.len != X25519.public_length) return error.InvalidInput;
+            if (out.len != X25519.shared_length) return error.InvalidInput;
+
+            var scalar: [X25519.secret_length]u8 = undefined;
+            var point: [X25519.public_length]u8 = undefined;
+            @memcpy(&scalar, private_scalar);
+            @memcpy(&point, peer_public);
+            defer crypto.secureZero(u8, &scalar);
+
+            // scalarmult rejects the low-order / all-zero points that would
+            // yield an all-zero (identity) shared secret: peer input error.
+            const shared = X25519.scalarmult(scalar, point) catch return error.InvalidInput;
+            @memcpy(out, &shared);
+        },
+        .secp256r1 => return error.UnsupportedCapability,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Signature verification
+// ---------------------------------------------------------------------------
+
+fn verifyImpl(
+    context: *anyopaque,
+    scheme: provider.SignatureScheme,
+    public_key: []const u8,
+    message: []const u8,
+    signature: []const u8,
+) provider.VerifyError!void {
+    _ = context;
+    switch (scheme) {
+        .ed25519 => {
+            if (public_key.len != Ed25519.PublicKey.encoded_length) return error.InvalidInput;
+            if (signature.len != Ed25519.Signature.encoded_length) return error.InvalidInput;
+            const pk = Ed25519.PublicKey.fromBytes(public_key[0..Ed25519.PublicKey.encoded_length].*) catch
+                return error.InvalidInput;
+            const sig = Ed25519.Signature.fromBytes(signature[0..Ed25519.Signature.encoded_length].*);
+            sig.verify(message, pk) catch return error.AuthenticationFailed;
+        },
+        .ecdsa_secp256r1_sha256, .rsa_pss_rsae_sha256 => return error.UnsupportedCapability,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Software signing key (opaque private-key handle)
+// ---------------------------------------------------------------------------
+
+/// A software Ed25519 signing key. Produces a `provider.SigningKey` whose
+/// private material lives inside this value; keep it alive for as long as the
+/// handle is used, and let it go out of scope (it holds no heap allocation) to
+/// discard the key. A future HSM/remote signer implements the same
+/// `provider.SigningKey` vtable without the TLS engine noticing.
+pub const SoftwareSigningKey = struct {
+    key_pair: Ed25519.KeyPair,
+
+    /// Load from a 32-byte Ed25519 seed (RFC 8032 secret scalar seed).
+    pub fn fromSeed(seed: [Ed25519.KeyPair.seed_length]u8) provider.SignError!SoftwareSigningKey {
+        const key_pair = Ed25519.KeyPair.generateDeterministic(seed) catch return error.ProviderFailure;
+        return .{ .key_pair = key_pair };
+    }
+
+    /// Raw 32-byte Ed25519 public key, for pinning or CertificateVerify checks.
+    pub fn publicKey(self: *const SoftwareSigningKey) [Ed25519.PublicKey.encoded_length]u8 {
+        return self.key_pair.public_key.toBytes();
+    }
+
+    /// Erase to the opaque signing-key interface. Borrows `self`.
+    pub fn signingKey(self: *SoftwareSigningKey) provider.SigningKey {
+        return .{ .context = self, .vtable = &signing_vtable };
+    }
+
+    const signing_vtable = provider.SigningKey.VTable{
+        .scheme = signingSchemeImpl,
+        .sign = signingSignImpl,
+    };
+
+    fn signingSchemeImpl(context: *anyopaque) provider.SignatureScheme {
+        _ = context;
+        return .ed25519;
+    }
+
+    fn signingSignImpl(
+        context: *anyopaque,
+        message: []const u8,
+        entropy: provider.Entropy,
+        out: []u8,
+    ) provider.SignError!usize {
+        _ = entropy; // Ed25519 signatures are deterministic (RFC 8032); no noise needed.
+        const self: *SoftwareSigningKey = @ptrCast(@alignCast(context));
+        if (out.len < Ed25519.Signature.encoded_length) return error.InvalidInput;
+        const signature = self.key_pair.sign(message, null) catch return error.ProviderFailure;
+        const bytes = signature.toBytes();
+        @memcpy(out[0..bytes.len], &bytes);
+        return bytes.len;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Deterministic entropy (tests and reproducible flows)
+// ---------------------------------------------------------------------------
+
+/// A seedable, deterministic byte source built on splitmix64. It is **not** a
+/// CSPRNG and must never back a production provider; it exists so tests and
+/// reproducible fixtures can inject predictable "randomness" through the same
+/// `provider.Entropy` seam the OS CSPRNG uses in production.
+pub const DeterministicEntropy = struct {
+    state: u64,
+
+    pub fn init(seed: u64) DeterministicEntropy {
+        return .{ .state = seed };
+    }
+
+    pub fn entropy(self: *DeterministicEntropy) provider.Entropy {
+        return .{ .context = self, .fillFn = fillImpl };
+    }
+
+    fn fillImpl(context: *anyopaque, buffer: []u8) provider.EntropyError!void {
+        const self: *DeterministicEntropy = @ptrCast(@alignCast(context));
+        for (buffer) |*byte| {
+            self.state +%= 0x9E3779B97F4A7C15;
+            var z = self.state;
+            z = (z ^ (z >> 30)) *% 0xBF58476D1CE4E5B9;
+            z = (z ^ (z >> 27)) *% 0x94D049BB133111EB;
+            z = z ^ (z >> 31);
+            byte.* = @truncate(z);
+        }
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+test "capabilities advertise exactly the implemented profile" {
+    const caps = Provider.capabilities();
+    try testing.expect(caps.supportsHash(.sha256));
+    try testing.expect(caps.supportsHash(.sha384));
+    try testing.expect(caps.supportsAead(.aes_128_gcm));
+    try testing.expect(caps.supportsAead(.aes_256_gcm));
+    try testing.expect(caps.supportsAead(.chacha20_poly1305));
+    try testing.expect(caps.supportsGroup(.x25519));
+    try testing.expect(!caps.supportsGroup(.secp256r1));
+    try testing.expect(caps.supportsSignature(.ed25519));
+    try testing.expect(!caps.supportsSignature(.ecdsa_secp256r1_sha256));
+    try testing.expect(!caps.supportsSignature(.rsa_pss_rsae_sha256));
+}
+
+test "unsupported algorithms return UnsupportedCapability, not undefined behaviour" {
+    var det = DeterministicEntropy.init(1);
+    var p = Provider.init(det.entropy());
+    const cp = p.cryptoProvider();
+
+    var pub_buf: [65]u8 = undefined;
+    var priv_buf: [32]u8 = undefined;
+    try testing.expectError(error.UnsupportedCapability, cp.generateKeyShare(.secp256r1, &pub_buf, &priv_buf));
+    try testing.expectError(error.UnsupportedCapability, cp.deriveSharedSecret(.secp256r1, &priv_buf, pub_buf[0..32], priv_buf[0..32]));
+
+    var sig: [64]u8 = undefined;
+    try testing.expectError(error.UnsupportedCapability, cp.verify(.rsa_pss_rsae_sha256, &priv_buf, "m", &sig));
+}
+
+test "HKDF-Extract matches std.crypto.kdf.hkdf" {
+    var det = DeterministicEntropy.init(2);
+    var p = Provider.init(det.entropy());
+    const cp = p.cryptoProvider();
+
+    const salt = "salty";
+    const ikm = [_]u8{0xAB} ** 40;
+
+    const HkdfSha256 = crypto.kdf.hkdf.HkdfSha256;
+    const expected = HkdfSha256.extract(salt, &ikm);
+    var out: [32]u8 = undefined;
+    try cp.hkdfExtract(.sha256, salt, &ikm, &out);
+    try testing.expectEqualSlices(u8, &expected, &out);
+}
+
+test "HKDF-Expand-Label matches std.crypto.tls" {
+    var det = DeterministicEntropy.init(3);
+    var p = Provider.init(det.entropy());
+    const cp = p.cryptoProvider();
+
+    const HkdfSha256 = crypto.kdf.hkdf.HkdfSha256;
+    const secret = [_]u8{0x01} ** 32;
+
+    // A QUIC key derivation with empty context, and a longer output that spans
+    // two HKDF blocks, both cross-checked against the standard library.
+    const expected_key = crypto.tls.hkdfExpandLabel(HkdfSha256, secret, "quic key", "", 16);
+    var key: [16]u8 = undefined;
+    try cp.hkdfExpandLabel(.sha256, &secret, "quic key", "", &key);
+    try testing.expectEqualSlices(u8, &expected_key, &key);
+
+    const context = [_]u8{0x99} ** 32;
+    const expected_long = crypto.tls.hkdfExpandLabel(HkdfSha256, secret, "derived", &context, 40);
+    var long: [40]u8 = undefined;
+    try cp.hkdfExpandLabel(.sha256, &secret, "derived", &context, &long);
+    try testing.expectEqualSlices(u8, &expected_long, &long);
+}
+
+test "AEAD seal then open round-trips for every supported cipher" {
+    var det = DeterministicEntropy.init(4);
+    var p = Provider.init(det.entropy());
+    const cp = p.cryptoProvider();
+
+    const plaintext = "the tardigrade survives the vacuum of space";
+    const associated_data = "quic header";
+
+    inline for (.{ provider.Aead.aes_128_gcm, provider.Aead.aes_256_gcm, provider.Aead.chacha20_poly1305 }) |aead| {
+        var key = [_]u8{0} ** 32;
+        var nonce = [_]u8{0} ** provider.aead_nonce_len;
+        try cp.randomBytes(key[0..aead.keyLength()]);
+        try cp.randomBytes(&nonce);
+
+        var ciphertext: [plaintext.len]u8 = undefined;
+        var tag: [provider.aead_tag_len]u8 = undefined;
+        try cp.aeadSeal(aead, key[0..aead.keyLength()], &nonce, associated_data, plaintext, &ciphertext, &tag);
+
+        var recovered: [plaintext.len]u8 = undefined;
+        try cp.aeadOpen(aead, key[0..aead.keyLength()], &nonce, associated_data, &ciphertext, &tag, &recovered);
+        try testing.expectEqualSlices(u8, plaintext, &recovered);
+
+        // A single flipped ciphertext bit must fail authentication.
+        var tampered = ciphertext;
+        tampered[0] ^= 0x01;
+        try testing.expectError(
+            error.AuthenticationFailed,
+            cp.aeadOpen(aead, key[0..aead.keyLength()], &nonce, associated_data, &tampered, &tag, &recovered),
+        );
+
+        // Mismatched associated data must also fail.
+        try testing.expectError(
+            error.AuthenticationFailed,
+            cp.aeadOpen(aead, key[0..aead.keyLength()], &nonce, "wrong ad", &ciphertext, &tag, &recovered),
+        );
+    }
+}
+
+test "X25519 key shares agree and match std directly" {
+    var det = DeterministicEntropy.init(5);
+    var p = Provider.init(det.entropy());
+    const cp = p.cryptoProvider();
+
+    var a_pub: [32]u8 = undefined;
+    var a_priv: [32]u8 = undefined;
+    var b_pub: [32]u8 = undefined;
+    var b_priv: [32]u8 = undefined;
+    try cp.generateKeyShare(.x25519, &a_pub, &a_priv);
+    try cp.generateKeyShare(.x25519, &b_pub, &b_priv);
+
+    var a_shared: [32]u8 = undefined;
+    var b_shared: [32]u8 = undefined;
+    try cp.deriveSharedSecret(.x25519, &a_priv, &b_pub, &a_shared);
+    try cp.deriveSharedSecret(.x25519, &b_priv, &a_pub, &b_shared);
+    try testing.expectEqualSlices(u8, &a_shared, &b_shared);
+
+    const direct = try X25519.scalarmult(a_priv, b_pub);
+    try testing.expectEqualSlices(u8, &direct, &a_shared);
+}
+
+test "X25519 rejects an all-zero (low-order) peer point as InvalidInput" {
+    var det = DeterministicEntropy.init(6);
+    var p = Provider.init(det.entropy());
+    const cp = p.cryptoProvider();
+
+    var a_pub: [32]u8 = undefined;
+    var a_priv: [32]u8 = undefined;
+    try cp.generateKeyShare(.x25519, &a_pub, &a_priv);
+
+    const zero_point = [_]u8{0} ** 32;
+    var out: [32]u8 = undefined;
+    try testing.expectError(error.InvalidInput, cp.deriveSharedSecret(.x25519, &a_priv, &zero_point, &out));
+}
+
+test "Ed25519 sign then verify, with tamper and wrong-key rejection" {
+    var det = DeterministicEntropy.init(7);
+    var p = Provider.init(det.entropy());
+    const cp = p.cryptoProvider();
+
+    var seed: [32]u8 = undefined;
+    try cp.randomBytes(&seed);
+    var software_key = try SoftwareSigningKey.fromSeed(seed);
+    const signer = software_key.signingKey();
+    try testing.expectEqual(provider.SignatureScheme.ed25519, signer.scheme());
+
+    const message = "certificate verify transcript";
+    var signature: [64]u8 = undefined;
+    const sig_len = try signer.sign(message, cp.entropy, &signature);
+    try testing.expectEqual(@as(usize, 64), sig_len);
+
+    const public_key = software_key.publicKey();
+    try cp.verify(.ed25519, &public_key, message, &signature);
+
+    // Flip a signature bit: authentication must fail.
+    var bad_sig = signature;
+    bad_sig[0] ^= 0x01;
+    try testing.expectError(error.AuthenticationFailed, cp.verify(.ed25519, &public_key, message, &bad_sig));
+
+    // Verify under an unrelated key: authentication must fail.
+    var other_seed: [32]u8 = undefined;
+    try cp.randomBytes(&other_seed);
+    var other_key = try SoftwareSigningKey.fromSeed(other_seed);
+    const other_public = other_key.publicKey();
+    try testing.expectError(error.AuthenticationFailed, cp.verify(.ed25519, &other_public, message, &signature));
+}
+
+test "randomBytes surfaces entropy failure as a provider error" {
+    const Failing = struct {
+        fn fill(context: *anyopaque, buffer: []u8) provider.EntropyError!void {
+            _ = context;
+            _ = buffer;
+            return error.EntropyFailure;
+        }
+    };
+    var sentinel: u8 = 0;
+    var p = Provider.init(.{ .context = &sentinel, .fillFn = Failing.fill });
+    const cp = p.cryptoProvider();
+    var buf: [16]u8 = undefined;
+    try testing.expectError(error.EntropyFailure, cp.randomBytes(&buf));
+}

--- a/src/crypto/pure_zig.zig
+++ b/src/crypto/pure_zig.zig
@@ -177,8 +177,12 @@ fn expandLabelWith(
     defer crypto.secureZero(u8, &prk);
 
     // HKDF-Expand: T(i) = HMAC(PRK, T(i-1) || info || i), truncated to out.len.
+    // Both `block` (a raw output block) and `message` (which carries T(i-1))
+    // hold secret-derived material, so wipe them on every exit path.
     var block: [mac_len]u8 = undefined;
     var message: [mac_len + info.len + 1]u8 = undefined;
+    defer crypto.secureZero(u8, &block);
+    defer crypto.secureZero(u8, &message);
     var have_previous = false;
     var counter: usize = 1;
     var written: usize = 0;
@@ -198,7 +202,6 @@ fn expandLabelWith(
         written += take;
         have_previous = true;
     }
-    crypto.secureZero(u8, &block);
 }
 
 // ---------------------------------------------------------------------------
@@ -308,16 +311,22 @@ fn generateKeyShareImpl(
     const self: *Provider = @ptrCast(@alignCast(context));
     switch (group) {
         .x25519 => {
-            // Wrong-sized output buffers are a caller sizing bug, not peer
-            // input; the caller sizes against Group.publicKeyLength().
-            if (public_out.len != X25519.public_length) return error.ProviderFailure;
-            if (private_out.len != X25519.secret_length) return error.ProviderFailure;
+            // A wrong-sized caller output buffer violates the output-slice
+            // contract (see InputError); it is a caller bug, not an internal
+            // provider failure, so classify it as InvalidInput.
+            if (public_out.len != X25519.public_length) return error.InvalidInput;
+            if (private_out.len != X25519.secret_length) return error.InvalidInput;
 
             var seed: [X25519.seed_length]u8 = undefined;
-            self.entropy.fill(&seed) catch return error.EntropyFailure;
+            // Register the wipe before filling, so a source that partially
+            // fills and then fails does not leave seed bytes on the stack.
             defer crypto.secureZero(u8, &seed);
+            self.entropy.fill(&seed) catch return error.EntropyFailure;
 
-            const key_pair = X25519.KeyPair.generateDeterministic(seed) catch return error.ProviderFailure;
+            var key_pair = X25519.KeyPair.generateDeterministic(seed) catch return error.ProviderFailure;
+            // The local key pair keeps a copy of the private scalar after it is
+            // handed to the caller; scrub it on return.
+            defer crypto.secureZero(u8, &key_pair.secret_key);
             @memcpy(public_out, &key_pair.public_key);
             @memcpy(private_out, &key_pair.secret_key);
         },
@@ -347,7 +356,10 @@ fn deriveSharedSecretImpl(
 
             // scalarmult rejects the low-order / all-zero points that would
             // yield an all-zero (identity) shared secret: peer input error.
-            const shared = X25519.scalarmult(scalar, point) catch return error.InvalidInput;
+            var shared = X25519.scalarmult(scalar, point) catch return error.InvalidInput;
+            // The shared secret is a backend-created temporary; scrub our copy
+            // once it has been handed to the caller.
+            defer crypto.secureZero(u8, &shared);
             @memcpy(out, &shared);
         },
         .secp256r1 => return error.UnsupportedCapability,
@@ -385,9 +397,10 @@ fn verifyImpl(
 
 /// A software Ed25519 signing key. Produces a `provider.SigningKey` whose
 /// private material lives inside this value; keep it alive for as long as the
-/// handle is used, and let it go out of scope (it holds no heap allocation) to
-/// discard the key. A future HSM/remote signer implements the same
-/// `provider.SigningKey` vtable without the TLS engine noticing.
+/// handle is used, and call `deinit` to erase the private key when retiring it
+/// — Zig does not zero a value's bytes on scope exit, so dropping it is not
+/// enough. A future HSM/remote signer implements the same `provider.SigningKey`
+/// vtable without the TLS engine noticing.
 pub const SoftwareSigningKey = struct {
     key_pair: Ed25519.KeyPair,
 
@@ -395,6 +408,13 @@ pub const SoftwareSigningKey = struct {
     pub fn fromSeed(seed: [Ed25519.KeyPair.seed_length]u8) provider.SignError!SoftwareSigningKey {
         const key_pair = Ed25519.KeyPair.generateDeterministic(seed) catch return error.ProviderFailure;
         return .{ .key_pair = key_pair };
+    }
+
+    /// Securely erase the private key material. Callers must invoke this when
+    /// the key is no longer needed; letting the value go out of scope does not
+    /// scrub its bytes.
+    pub fn deinit(self: *SoftwareSigningKey) void {
+        crypto.secureZero(u8, &self.key_pair.secret_key.bytes);
     }
 
     /// Raw 32-byte Ed25519 public key, for pinning or CertificateVerify checks.
@@ -558,13 +578,16 @@ test "AEAD seal then open round-trips for every supported cipher" {
         try cp.aeadOpen(aead, key[0..aead.keyLength()], &nonce, associated_data, &ciphertext, &tag, &recovered);
         try testing.expectEqualSlices(u8, plaintext, &recovered);
 
-        // A single flipped ciphertext bit must fail authentication.
+        // A single flipped ciphertext bit must fail authentication, and the
+        // output buffer must be zeroed rather than left holding unauthenticated
+        // plaintext (the documented open contract).
         var tampered = ciphertext;
         tampered[0] ^= 0x01;
         try testing.expectError(
             error.AuthenticationFailed,
             cp.aeadOpen(aead, key[0..aead.keyLength()], &nonce, associated_data, &tampered, &tag, &recovered),
         );
+        for (recovered) |byte| try testing.expectEqual(@as(u8, 0), byte);
 
         // Mismatched associated data must also fail.
         try testing.expectError(
@@ -610,6 +633,19 @@ test "X25519 rejects an all-zero (low-order) peer point as InvalidInput" {
     try testing.expectError(error.InvalidInput, cp.deriveSharedSecret(.x25519, &a_priv, &zero_point, &out));
 }
 
+test "key-share generation rejects wrong-sized output buffers as InvalidInput" {
+    var det = DeterministicEntropy.init(8);
+    var p = Provider.init(det.entropy());
+    const cp = p.cryptoProvider();
+
+    // A wrong-sized caller buffer is a contract violation, not a provider
+    // failure — protocol code must not map it to an internal crypto error.
+    var full: [32]u8 = undefined;
+    var too_small: [16]u8 = undefined;
+    try testing.expectError(error.InvalidInput, cp.generateKeyShare(.x25519, &too_small, &full));
+    try testing.expectError(error.InvalidInput, cp.generateKeyShare(.x25519, &full, &too_small));
+}
+
 test "Ed25519 sign then verify, with tamper and wrong-key rejection" {
     var det = DeterministicEntropy.init(7);
     var p = Provider.init(det.entropy());
@@ -618,6 +654,7 @@ test "Ed25519 sign then verify, with tamper and wrong-key rejection" {
     var seed: [32]u8 = undefined;
     try cp.randomBytes(&seed);
     var software_key = try SoftwareSigningKey.fromSeed(seed);
+    defer software_key.deinit();
     const signer = software_key.signingKey();
     try testing.expectEqual(provider.SignatureScheme.ed25519, signer.scheme());
 
@@ -638,6 +675,7 @@ test "Ed25519 sign then verify, with tamper and wrong-key rejection" {
     var other_seed: [32]u8 = undefined;
     try cp.randomBytes(&other_seed);
     var other_key = try SoftwareSigningKey.fromSeed(other_seed);
+    defer other_key.deinit();
     const other_public = other_key.publicKey();
     try testing.expectError(error.AuthenticationFailed, cp.verify(.ed25519, &other_public, message, &signature));
 }

--- a/src/crypto/root.zig
+++ b/src/crypto/root.zig
@@ -1,0 +1,13 @@
+//! Pure-Zig cryptographic-provider package (#370, epic #327).
+//!
+//! `provider` is the stable boundary every TLS/QUIC/PKI module depends on;
+//! `pure_zig` is the first concrete backend behind it. An OpenSSL adapter will
+//! join as a second implementation of the same `provider.CryptoProvider`
+//! interface. See `docs/CRYPTO_PROVIDER.md`.
+
+pub const provider = @import("provider.zig");
+pub const pure_zig = @import("pure_zig.zig");
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}


### PR DESCRIPTION
**What changed and why**
Introduces `src/crypto/` — the single narrow interface that all TLS, QUIC, and PKI modules will consume cryptography through, so protocol code never names a concrete primitive or a foreign TLS type. This is research story **327-A** (epic #327) and the foundation the rest of that epic attaches to.

- `src/crypto/provider.zig` — the boundary. A runtime-dispatched `CryptoProvider` (`context` + `*const VTable`, the same seam shape as the QUIC `TlsBackend`) covering HKDF extract/expand-label, AEAD seal/open, ECDH key-share generation and shared-secret derivation, signature verification, and injected-entropy random bytes. Plus:
  - an opaque `SigningKey` handle, so a software key today and an HSM/remote signer later present the identical interface;
  - explicit `Capabilities` discovery with `select*` negotiation helpers, so an unsupported algorithm is always a typed error and never reaches a primitive that cannot handle it;
  - a classified error taxonomy distinguishing malformed input (`InvalidInput`), unsupported capability, provider failure, and authentication failure;
  - algorithm-independent `constantTimeEqual` / `secureZero` helpers.
- `src/crypto/pure_zig.zig` — the first backend, built entirely on `std.crypto`: HKDF over SHA-256/384, AES-128/256-GCM and ChaCha20-Poly1305, X25519, and Ed25519 (signing via `SoftwareSigningKey`). Secrets are borrowed for the call only and scrubbed on the way out, entropy is drawn from an injected source rather than ambient (matching the rest of `src/quic/`), and declared-but-absent algorithms (secp256r1, ECDSA-P256, RSA-PSS) are reported through capability discovery rather than silently missing.
- `docs/CRYPTO_PROVIDER.md` — documents the boundary, the design rules, the error taxonomy, and the acceptance-criteria mapping.

Scope note: this story *defines* the boundary. Migrating the existing QUIC/TLS modules onto it and adding the OpenSSL production adapter are follow-up implementation stories (#323–#326); the interface is deliberately built so that work changes no protocol code.

**Related issues**
Closes #370

**Tests**
New `zig build test-crypto` target (also run under the default `zig build test`), 14 tests in `src/crypto/`:
- capability discovery advertises exactly the implemented profile; unsupported algorithms return `UnsupportedCapability`;
- HKDF-Extract and HKDF-Expand-Label cross-checked against `std.crypto.kdf.hkdf` and `std.crypto.tls` (including a two-block output);
- AEAD seal→open round-trips for all three ciphers, with bit-flip and wrong-AD tamper rejection;
- X25519 key-share agreement (and match against `std.crypto`'s X25519 directly), plus all-zero/low-order peer point rejected as `InvalidInput`;
- Ed25519 sign→verify with tampered-signature and wrong-key rejection;
- entropy-source failure surfaced as `EntropyFailure`.

Full suite green (`zig build test`: 1092 passed / 1 pre-existing skip) and `zig fmt --check build.zig src/ tests/` clean; crypto tests also pass under `-Doptimize=ReleaseSafe`.

**Security impact**
This is foundational TLS/crypto code. The provider is designed around explicit secret lifetimes (borrowed-only, `secureZero` on exit, partial plaintext scrubbed on AEAD-open failure), injected (non-ambient) entropy, constant-time comparison for tags/MACs, and a capability model that cannot select an unsupported algorithm. Primitives are Zig `std.crypto` (AES-GCM, ChaCha20-Poly1305, X25519, Ed25519, HMAC/HKDF) — no primitive is reimplemented. No production code path consumes the new package yet; it is a standalone, tested seam.

**Performance impact**
None. The package is not yet on any runtime path; it is compiled and exercised only by tests.

**Checklist**
- [x] `zig fmt --check build.zig src/ tests/` passes
- [x] `zig build test --summary all` green
- [ ] `zig build test-integration` green (no integration surface: the package is standalone and not yet wired into any protocol path)
- [x] New behavior covered by tests
- [x] [docs/CODE_REVIEW_CHECKLIST.md](docs/CODE_REVIEW_CHECKLIST.md) completed
- [x] README / CHANGELOG updated if operator-visible behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUw2EjxU7YhEc5xUUGiHrq)_