### PR TITLE
pki: add bounded ASN.1 DER decoder foundation for X.509 (#339)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ All notable user-facing changes to Tardigrade are documented here.
   and sign/verify round-trips under `zig build test-crypto`. The OpenSSL
   production adapter and migrating the existing QUIC/TLS modules onto the
   boundary are follow-ups (#323–#326); see `docs/CRYPTO_PROVIDER.md`.
+- **Bounded ASN.1 DER decoder for X.509 (#339)** — adds `src/pki/` with a
+  strict, allocation-aware DER foundation for the #324 Web PKI epic:
+  `der.zig` provides a bounded `Reader` with typed decoders (SEQUENCE/SET,
+  INTEGER, BOOLEAN, BIT/OCTET STRING, NULL, OID, string types, UTCTime,
+  GeneralizedTime, and context-specific explicit/implicit tags), configurable
+  limits, zero-copy content views, complete-consumption checks, typed errors,
+  and a `fuzzParseInput` entrypoint for #376; `oid.zig` and `time.zig` cover
+  OBJECT IDENTIFIER and time parsing. `zig build test-pki` runs the regression
+  and adversarial corpora.
 - **QUIC CID routing, path validation, and migration policy (#251)** — the
   pure-Zig transport gains connection-ID lifecycle and path handling:
   `cid.zig` adds caller-entropy CID generation, a DCID→connection

--- a/build.zig
+++ b/build.zig
@@ -252,6 +252,18 @@ pub fn build(b: *std.Build) void {
     const run_quic_h3_smoke_tests = b.addRunArtifact(quic_h3_smoke_tests);
     quic_step.dependOn(&run_quic_h3_smoke_tests.step);
     test_step.dependOn(&run_quic_h3_smoke_tests.step);
+
+    // Pure-Zig PKI DER foundation (#339): no system libraries.
+    const pki_mod = b.createModule(.{
+        .root_source_file = b.path("src/pki/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const pki_tests = b.addTest(.{ .root_module = pki_mod });
+    const run_pki_tests = b.addRunArtifact(pki_tests);
+    const pki_step = b.step("test-pki", "Run pure-Zig PKI DER unit tests");
+    pki_step.dependOn(&run_pki_tests.step);
+    test_step.dependOn(&run_pki_tests.step);
 }
 
 fn pathExists(path: []const u8) bool {

--- a/src/pki/der.zig
+++ b/src/pki/der.zig
@@ -1,0 +1,604 @@
+//! Bounded ASN.1 DER decoder for X.509 (#339).
+//!
+//! ## Supported subset
+//!
+//! Universal types used by X.509: SEQUENCE, SET, INTEGER, BOOLEAN, BIT STRING,
+//! OCTET STRING, NULL, OBJECT IDENTIFIER, UTF8String, PrintableString, IA5String,
+//! BMPString, UTCTime, GeneralizedTime; plus context-specific explicit and
+//! implicit tags.
+//!
+//! ## DER-only policy
+//!
+//! Definite lengths only. BER indefinite lengths, non-minimal length encodings,
+//! and non-minimal INTEGER encodings are rejected. Malformed input is never
+//! silently normalized.
+//!
+//! ## Default limits
+//!
+//! See `Limits`: 32 nesting depth, 1 MiB per element, 4096 elements per reader
+//! tree, 32 OID components, 4096 integer bytes.
+//!
+//! ## Ownership and zero-copy
+//!
+//! `Reader` and `Element` hold borrowed slices into the caller-supplied input.
+//! The caller owns the backing buffer for the parser lifetime. Typed decoders
+//! return views (`IntegerView`, `BitStringView`, string slices) without copying
+//! untrusted content. Never allocate directly from an unchecked attacker length.
+//!
+//! ## Complete consumption
+//!
+//! Call `expectEnd` after parsing a bounded region to reject trailing bytes.
+//! Child readers from `readSequence` / `readSet` enforce their own boundaries.
+//!
+//! ## Intentionally unsupported
+//!
+//! BER indefinite length, SET OF sorting requirements, REAL, EXTERNAL, EMBEDDED
+//! PDV, unrestricted ANY, and non-DER string encodings.
+//!
+//! ## Consumers
+//!
+//! #340 (PEM/chain loading) should wrap DER blobs in `Reader` and enforce
+//! `expectEnd`. #341 (X.509 certificate model) should walk TBSCertificate and
+//! extension sequences via child readers and typed decoders defined here.
+
+const std = @import("std");
+const oid_mod = @import("oid.zig");
+const time_mod = @import("time.zig");
+
+pub const oid = oid_mod;
+pub const time = time_mod;
+
+/// Configurable parser resource bounds.
+pub const Limits = struct {
+    max_depth: usize = 32,
+    max_element_len: usize = 1024 * 1024,
+    max_elements: usize = 4096,
+    max_oid_components: usize = 32,
+    max_integer_bytes: usize = 4096,
+};
+
+pub const default_limits: Limits = .{};
+
+pub const TagClass = enum(u2) {
+    universal = 0,
+    application = 1,
+    context_specific = 2,
+    private = 3,
+};
+
+pub const UniversalTag = enum(u32) {
+    end_of_content = 0,
+    boolean = 1,
+    integer = 2,
+    bit_string = 3,
+    octet_string = 4,
+    null = 5,
+    object_identifier = 6,
+    utf8_string = 12,
+    sequence = 16,
+    set = 17,
+    printable_string = 19,
+    ia5_string = 22,
+    utc_time = 23,
+    generalized_time = 24,
+    bmp_string = 30,
+};
+
+pub const Tag = struct {
+    class: TagClass,
+    number: u32,
+    constructed: bool,
+
+    pub fn universal(number: u32, constructed: bool) Tag {
+        return .{ .class = .universal, .number = number, .constructed = constructed };
+    }
+
+    pub fn contextSpecific(number: u32, constructed: bool) Tag {
+        return .{ .class = .context_specific, .number = number, .constructed = constructed };
+    }
+
+    pub fn eql(self: Tag, other: Tag) bool {
+        return self.class == other.class and self.number == other.number and
+            self.constructed == other.constructed;
+    }
+};
+
+pub const Element = struct {
+    tag: Tag,
+    /// Full TLV bytes (tag + length + content) within the parent input slice.
+    encoded: []const u8,
+    /// Value bytes only.
+    content: []const u8,
+    /// Absolute offset of `content` in the root input slice.
+    content_offset: usize,
+};
+
+pub const IntegerView = struct {
+    /// Validated minimal big-endian two's-complement encoding.
+    content: []const u8,
+
+    pub fn isNegative(self: IntegerView) bool {
+        return self.content.len > 0 and (self.content[0] & 0x80) != 0;
+    }
+
+    pub fn isZero(self: IntegerView) bool {
+        return self.content.len == 1 and self.content[0] == 0;
+    }
+};
+
+pub const BitStringView = struct {
+    unused_bits: u3,
+    /// Payload bits excluding the leading unused-bits octet.
+    data: []const u8,
+};
+
+pub const Error = error{
+    Truncated,
+    InvalidTag,
+    InvalidLength,
+    NonMinimalLength,
+    IndefiniteLength,
+    LengthOverflow,
+    LengthBeyondInput,
+    NestingLimit,
+    ElementCountLimit,
+    UnexpectedTag,
+    MalformedInteger,
+    MalformedBoolean,
+    MalformedBitString,
+    MalformedOid,
+    MalformedString,
+    MalformedTime,
+    TrailingData,
+} || oid_mod.Error || time_mod.Error;
+
+pub const ParseError = struct {
+    err: Error,
+    offset: usize,
+};
+
+pub const Reader = struct {
+    input: []const u8,
+    start: usize,
+    end: usize,
+    offset: usize,
+    depth: usize,
+    element_count: usize,
+    limits: Limits,
+
+    pub fn init(input: []const u8, limits: Limits) Reader {
+        return .{
+            .input = input,
+            .start = 0,
+            .end = input.len,
+            .offset = 0,
+            .depth = 0,
+            .element_count = 0,
+            .limits = limits,
+        };
+    }
+
+    pub fn initBounded(input: []const u8, start: usize, end: usize, depth: usize, element_count: usize, limits: Limits) Reader {
+        return .{
+            .input = input,
+            .start = start,
+            .end = end,
+            .offset = start,
+            .depth = depth,
+            .element_count = element_count,
+            .limits = limits,
+        };
+    }
+
+    pub fn remaining(self: *const Reader) usize {
+        return self.end - self.offset;
+    }
+
+    pub fn currentOffset(self: *const Reader) usize {
+        return self.offset;
+    }
+
+    pub fn readElement(self: *Reader) Error!Element {
+        if (self.element_count >= self.limits.max_elements) return error.ElementCountLimit;
+        const elem_start = self.offset;
+        const tag = try self.readTag();
+        const content_len = try self.readDefiniteLength();
+        if (content_len > self.remaining()) return error.LengthBeyondInput;
+        const content_start = self.offset;
+        const content_end = content_start + content_len;
+        self.offset = content_end;
+        self.element_count += 1;
+        return .{
+            .tag = tag,
+            .encoded = self.input[elem_start..content_end],
+            .content = self.input[content_start..content_end],
+            .content_offset = content_start,
+        };
+    }
+
+    pub fn readSequence(self: *Reader) Error!Reader {
+        const elem = try self.readElement();
+        if (elem.tag.class != .universal or elem.tag.number != @intFromEnum(UniversalTag.sequence) or !elem.tag.constructed) {
+            return error.UnexpectedTag;
+        }
+        return self.childReader(elem.content_offset, elem.content.len);
+    }
+
+    pub fn readSet(self: *Reader) Error!Reader {
+        const elem = try self.readElement();
+        if (elem.tag.class != .universal or elem.tag.number != @intFromEnum(UniversalTag.set) or !elem.tag.constructed) {
+            return error.UnexpectedTag;
+        }
+        return self.childReader(elem.content_offset, elem.content.len);
+    }
+
+    pub fn childReader(self: *const Reader, content_offset: usize, content_len: usize) Error!Reader {
+        if (self.depth >= self.limits.max_depth) return error.NestingLimit;
+        const end = content_offset + content_len;
+        if (content_offset < self.start or end > self.end) return error.LengthBeyondInput;
+        return Reader.initBounded(self.input, content_offset, end, self.depth + 1, self.element_count, self.limits);
+    }
+
+    pub fn expectEnd(self: *const Reader) Error!void {
+        if (self.offset != self.end) return error.TrailingData;
+    }
+
+    pub fn expectTag(self: *Reader, expected: Tag) Error!Element {
+        const elem = try self.readElement();
+        if (!elem.tag.eql(expected)) return error.UnexpectedTag;
+        return elem;
+    }
+
+    pub fn readContextSpecific(self: *Reader, number: u32, constructed: bool) Error!Element {
+        const elem = try self.readElement();
+        if (elem.tag.class != .context_specific or elem.tag.number != number or elem.tag.constructed != constructed) {
+            return error.UnexpectedTag;
+        }
+        return elem;
+    }
+
+    /// Explicit context tag: outer constructed wrapper around one inner element.
+    pub fn readExplicitContext(self: *Reader, number: u32) Error!Element {
+        const wrapper = try self.readContextSpecific(number, true);
+        var inner = try self.childReader(wrapper.content_offset, wrapper.content.len);
+        const elem = try inner.readElement();
+        try inner.expectEnd();
+        return elem;
+    }
+
+    pub fn readInteger(self: *Reader) Error!IntegerView {
+        const elem = try self.readElement();
+        if (elem.tag.class != .universal or elem.tag.number != @intFromEnum(UniversalTag.integer)) {
+            return error.UnexpectedTag;
+        }
+        try validateInteger(elem.content, self.limits.max_integer_bytes);
+        return .{ .content = elem.content };
+    }
+
+    pub fn readBoolean(self: *Reader) Error!bool {
+        const elem = try self.readElement();
+        if (elem.tag.class != .universal or elem.tag.number != @intFromEnum(UniversalTag.boolean)) {
+            return error.UnexpectedTag;
+        }
+        if (elem.content.len != 1) return error.MalformedBoolean;
+        return switch (elem.content[0]) {
+            0x00 => false,
+            0xff => true,
+            else => error.MalformedBoolean,
+        };
+    }
+
+    pub fn readNull(self: *Reader) Error!void {
+        const elem = try self.readElement();
+        if (elem.tag.class != .universal or elem.tag.number != @intFromEnum(UniversalTag.null)) {
+            return error.UnexpectedTag;
+        }
+        if (elem.content.len != 0) return error.UnexpectedTag;
+    }
+
+    pub fn readOctetString(self: *Reader) Error![]const u8 {
+        const elem = try self.readElement();
+        if (elem.tag.class != .universal or elem.tag.number != @intFromEnum(UniversalTag.octet_string)) {
+            return error.UnexpectedTag;
+        }
+        return elem.content;
+    }
+
+    pub fn readBitString(self: *Reader) Error!BitStringView {
+        const elem = try self.readElement();
+        if (elem.tag.class != .universal or elem.tag.number != @intFromEnum(UniversalTag.bit_string)) {
+            return error.UnexpectedTag;
+        }
+        return decodeBitStringContent(elem.content);
+    }
+
+    pub fn readObjectIdentifier(self: *Reader) Error!oid_mod.ObjectIdentifier {
+        const elem = try self.readElement();
+        if (elem.tag.class != .universal or elem.tag.number != @intFromEnum(UniversalTag.object_identifier)) {
+            return error.UnexpectedTag;
+        }
+        return oid_mod.decode(elem.content, self.limits.max_oid_components);
+    }
+
+    pub fn readUtf8String(self: *Reader) Error![]const u8 {
+        const content = try self.readStringElement(.utf8_string);
+        try validateUtf8(content);
+        return content;
+    }
+
+    pub fn readPrintableString(self: *Reader) Error![]const u8 {
+        const content = try self.readStringElement(.printable_string);
+        try validatePrintableString(content);
+        return content;
+    }
+
+    pub fn readIa5String(self: *Reader) Error![]const u8 {
+        const content = try self.readStringElement(.ia5_string);
+        try validateIa5String(content);
+        return content;
+    }
+
+    pub fn readBmpString(self: *Reader) Error![]const u8 {
+        const content = try self.readStringElement(.bmp_string);
+        try validateBmpString(content);
+        return content;
+    }
+
+    pub fn readUtcTime(self: *Reader) Error!time_mod.UtcTime {
+        const elem = try self.readElement();
+        if (elem.tag.class != .universal or elem.tag.number != @intFromEnum(UniversalTag.utc_time)) {
+            return error.UnexpectedTag;
+        }
+        return time_mod.parseUtcTime(elem.content);
+    }
+
+    pub fn readGeneralizedTime(self: *Reader) Error!time_mod.GeneralizedTime {
+        const elem = try self.readElement();
+        if (elem.tag.class != .universal or elem.tag.number != @intFromEnum(UniversalTag.generalized_time)) {
+            return error.UnexpectedTag;
+        }
+        return time_mod.parseGeneralizedTime(elem.content);
+    }
+
+    fn readStringElement(self: *Reader, tag_number: UniversalTag) Error![]const u8 {
+        const elem = try self.readElement();
+        if (elem.tag.class != .universal or elem.tag.number != @intFromEnum(tag_number)) {
+            return error.UnexpectedTag;
+        }
+        return elem.content;
+    }
+
+    fn readTag(self: *Reader) Error!Tag {
+        if (self.remaining() == 0) return error.Truncated;
+        const first = self.input[self.offset];
+        self.offset += 1;
+
+        const class: TagClass = @enumFromInt(first >> 6);
+        const constructed = (first & 0x20) != 0;
+        var number: u32 = first & 0x1f;
+
+        if (number == 0x1f) {
+            number = 0;
+            var continuation_bytes: usize = 0;
+            while (true) {
+                if (self.remaining() == 0) return error.Truncated;
+                const b = self.input[self.offset];
+                self.offset += 1;
+                if (continuation_bytes == 0 and b == 0x80) return error.InvalidTag;
+                const chunk: u32 = b & 0x7f;
+                if (number > (std.math.maxInt(u32) >> 7)) return error.InvalidTag;
+                number = (number << 7) | chunk;
+                if (b & 0x80 == 0) break;
+                continuation_bytes += 1;
+                if (continuation_bytes > 4) return error.InvalidTag;
+            }
+            if (number < 31) return error.InvalidTag;
+        }
+
+        return .{ .class = class, .number = number, .constructed = constructed };
+    }
+
+    fn readDefiniteLength(self: *Reader) Error!usize {
+        if (self.remaining() == 0) return error.Truncated;
+        const first = self.input[self.offset];
+        self.offset += 1;
+
+        if (first & 0x80 == 0) {
+            return first;
+        }
+
+        const num_bytes = first & 0x7f;
+        if (num_bytes == 0) return error.IndefiniteLength;
+        if (num_bytes > 8) return error.InvalidLength;
+        if (self.remaining() < num_bytes) return error.Truncated;
+
+        var length: u64 = 0;
+        var i: usize = 0;
+        while (i < num_bytes) : (i += 1) {
+            length = (length << 8) | self.input[self.offset + i];
+        }
+        if (length < 128) return error.NonMinimalLength;
+        if (length > self.limits.max_element_len) return error.LengthOverflow;
+
+        const first_len_byte = self.input[self.offset];
+        if (num_bytes > 1 and first_len_byte == 0) return error.NonMinimalLength;
+        const minimal_bytes = minimalLengthBytes(length);
+        if (num_bytes != minimal_bytes) return error.NonMinimalLength;
+
+        self.offset += num_bytes;
+        const len: usize = @intCast(length);
+        if (len > self.remaining()) return error.LengthBeyondInput;
+        return len;
+    }
+};
+
+fn minimalLengthBytes(length: u64) usize {
+    if (length < 128) return 0;
+    var bytes: usize = 0;
+    var value = length;
+    while (value > 0) : (bytes += 1) {
+        value >>= 8;
+    }
+    return bytes;
+}
+
+pub fn validateInteger(content: []const u8, max_bytes: usize) Error!void {
+    if (content.len == 0) return error.MalformedInteger;
+    if (content.len > max_bytes) return error.MalformedInteger;
+    if (content.len > 1) {
+        const first = content[0];
+        const second = content[1];
+        if ((first == 0x00 and (second & 0x80) == 0) or (first == 0xff and (second & 0x80) != 0)) {
+            return error.MalformedInteger;
+        }
+    }
+}
+
+pub fn decodeBitStringContent(content: []const u8) Error!BitStringView {
+    if (content.len == 0) return error.MalformedBitString;
+    if (content[0] > 7) return error.MalformedBitString;
+    const unused_bits: u3 = @intCast(content[0]);
+    const data = content[1..];
+    if (data.len == 0 and unused_bits != 0) return error.MalformedBitString;
+    if (data.len > 0 and unused_bits > 0) {
+        const mask: u8 = @truncate((@as(u16, 1) << @intCast(unused_bits)) - 1);
+        if (data[data.len - 1] & mask != 0) return error.MalformedBitString;
+    }
+    return .{ .unused_bits = unused_bits, .data = data };
+}
+
+pub fn validateUtf8(content: []const u8) Error!void {
+    if (std.unicode.utf8ValidateSlice(content)) return;
+    return error.MalformedString;
+}
+
+pub fn validatePrintableString(content: []const u8) Error!void {
+    for (content) |c| {
+        if (!isPrintableChar(c)) return error.MalformedString;
+    }
+}
+
+fn isPrintableChar(c: u8) bool {
+    return (c >= 'a' and c <= 'z') or
+        (c >= 'A' and c <= 'Z') or
+        (c >= '0' and c <= '9') or
+        c == ' ' or c == '\'' or c == '(' or c == ')' or
+        c == '+' or c == ',' or c == '-' or c == '.' or
+        c == '/' or c == ':' or c == '=' or c == '?';
+}
+
+pub fn validateIa5String(content: []const u8) Error!void {
+    for (content) |c| {
+        if (c > 0x7f) return error.MalformedString;
+    }
+}
+
+pub fn validateBmpString(content: []const u8) Error!void {
+    if (@rem(content.len, 2) != 0) return error.MalformedString;
+    var i: usize = 0;
+    while (i < content.len) : (i += 2) {
+        const unit = std.mem.readInt(u16, content[i..][0..2], .big);
+        if (unit >= 0xd800 and unit <= 0xdfff) return error.MalformedString;
+        if (unit >= 0xfdd0 and unit <= 0xfdef) return error.MalformedString;
+        if (unit == 0xfffe or unit == 0xffff) return error.MalformedString;
+    }
+}
+
+/// Canonical DER length encoding for round-trip tests.
+pub fn encodeLength(length: usize, out: []u8) Error!usize {
+    if (length < 128) {
+        if (out.len == 0) return error.Truncated;
+        out[0] = @intCast(length);
+        return 1;
+    }
+    var tmp: [8]u8 = undefined;
+    var value = length;
+    var nbytes: usize = 0;
+    while (value > 0) {
+        tmp[7 - nbytes] = @intCast(value & 0xff);
+        value >>= 8;
+        nbytes += 1;
+    }
+    if (out.len < 1 + nbytes) return error.Truncated;
+    out[0] = @intCast(0x80 | nbytes);
+    @memcpy(out[1 .. 1 + nbytes], tmp[8 - nbytes ..][0..nbytes]);
+    return 1 + nbytes;
+}
+
+pub fn encodeTag(tag: Tag, out: []u8) Error!usize {
+    var first: u8 = @as(u8, @intFromEnum(tag.class)) * 0x40;
+    if (tag.constructed) first |= 0x20;
+    if (tag.number < 31) {
+        if (out.len == 0) return error.Truncated;
+        out[0] = first | @as(u8, @intCast(tag.number));
+        return 1;
+    }
+    if (out.len == 0) return error.Truncated;
+    out[0] = first | 0x1f;
+    var written: usize = 1;
+    var stack: [5]u8 = undefined;
+    var value = tag.number;
+    var count: usize = 0;
+    while (value > 0) : (count += 1) {
+        stack[count] = @intCast(value & 0x7f);
+        value >>= 7;
+    }
+    var i: usize = 0;
+    while (i < count - 1) : (i += 1) {
+        if (written >= out.len) return error.Truncated;
+        out[written] = stack[count - 1 - i] | 0x80;
+        written += 1;
+    }
+    if (written >= out.len) return error.Truncated;
+    out[written] = stack[0];
+    written += 1;
+    return written;
+}
+
+/// Fuzz and regression entrypoint (#376): parse arbitrary bytes under strict
+/// limits without I/O, panics, or unbounded allocation.
+pub fn fuzzParseInput(input: []const u8) void {
+    var reader = Reader.init(input, .{
+        .max_depth = 8,
+        .max_element_len = 4096,
+        .max_elements = 64,
+        .max_oid_components = 16,
+        .max_integer_bytes = 256,
+    });
+    fuzzParseReader(&reader) catch {};
+}
+
+fn fuzzParseReader(reader: *Reader) Error!void {
+    while (reader.remaining() > 0) {
+        const elem = reader.readElement() catch return;
+        if (elem.tag.constructed and elem.tag.class == .universal and
+            (elem.tag.number == @intFromEnum(UniversalTag.sequence) or elem.tag.number == @intFromEnum(UniversalTag.set)))
+        {
+            var child = try reader.childReader(elem.content_offset, elem.content.len);
+            try fuzzParseReader(&child);
+            try child.expectEnd();
+        } else if (elem.tag.class == .universal) {
+            switch (elem.tag.number) {
+                @intFromEnum(UniversalTag.integer) => try validateInteger(elem.content, reader.limits.max_integer_bytes),
+                @intFromEnum(UniversalTag.boolean) => {
+                    if (elem.content.len != 1 or (elem.content[0] != 0 and elem.content[0] != 0xff)) return error.MalformedBoolean;
+                },
+                @intFromEnum(UniversalTag.bit_string) => _ = try decodeBitStringContent(elem.content),
+                @intFromEnum(UniversalTag.object_identifier) => _ = try oid_mod.decode(elem.content, reader.limits.max_oid_components),
+                @intFromEnum(UniversalTag.utc_time) => _ = try time_mod.parseUtcTime(elem.content),
+                @intFromEnum(UniversalTag.generalized_time) => _ = try time_mod.parseGeneralizedTime(elem.content),
+                @intFromEnum(UniversalTag.utf8_string) => try validateUtf8(elem.content),
+                @intFromEnum(UniversalTag.printable_string) => try validatePrintableString(elem.content),
+                @intFromEnum(UniversalTag.ia5_string) => try validateIa5String(elem.content),
+                @intFromEnum(UniversalTag.bmp_string) => try validateBmpString(elem.content),
+                else => {},
+            }
+        }
+    }
+}
+
+const testing = std.testing;
+
+test {
+    testing.refAllDecls(@This());
+}

--- a/src/pki/der.zig
+++ b/src/pki/der.zig
@@ -15,7 +15,7 @@
 //!
 //! ## Default limits
 //!
-//! See `Limits`: 32 nesting depth, 1 MiB per element, 4096 elements per reader
+//! See `Limits`: 32 nesting depth, 1 MiB per element, 4096 elements per parse
 //! tree, 32 OID components, 4096 integer bytes.
 //!
 //! ## Ownership and zero-copy
@@ -154,7 +154,14 @@ pub const Error = error{
 
 pub const ParseError = struct {
     err: Error,
+    /// Absolute offset of the offending byte when known, otherwise the tag
+    /// start for the element whose parse failed.
     offset: usize,
+};
+
+pub const DiagnosticElement = union(enum) {
+    element: Element,
+    err: ParseError,
 };
 
 pub const Reader = struct {
@@ -164,6 +171,8 @@ pub const Reader = struct {
     offset: usize,
     depth: usize,
     element_count: usize,
+    shared_element_count: ?*usize,
+    last_error_offset: ?usize,
     limits: Limits,
 
     pub fn init(input: []const u8, limits: Limits) Reader {
@@ -174,11 +183,13 @@ pub const Reader = struct {
             .offset = 0,
             .depth = 0,
             .element_count = 0,
+            .shared_element_count = null,
+            .last_error_offset = null,
             .limits = limits,
         };
     }
 
-    pub fn initBounded(input: []const u8, start: usize, end: usize, depth: usize, element_count: usize, limits: Limits) Reader {
+    pub fn initBounded(input: []const u8, start: usize, end: usize, depth: usize, element_count: usize, shared_element_count: ?*usize, limits: Limits) Reader {
         return .{
             .input = input,
             .start = start,
@@ -186,6 +197,8 @@ pub const Reader = struct {
             .offset = start,
             .depth = depth,
             .element_count = element_count,
+            .shared_element_count = shared_element_count,
+            .last_error_offset = null,
             .limits = limits,
         };
     }
@@ -199,15 +212,18 @@ pub const Reader = struct {
     }
 
     pub fn readElement(self: *Reader) Error!Element {
-        if (self.element_count >= self.limits.max_elements) return error.ElementCountLimit;
+        if (self.currentElementCount() >= self.limits.max_elements) return self.fail(error.ElementCountLimit, self.offset);
         const elem_start = self.offset;
         const tag = try self.readTag();
+        if (tag.class == .universal and tag.number == @intFromEnum(UniversalTag.end_of_content)) {
+            return self.fail(error.InvalidTag, elem_start);
+        }
         const content_len = try self.readDefiniteLength();
-        if (content_len > self.remaining()) return error.LengthBeyondInput;
+        if (content_len > self.remaining()) return self.fail(error.LengthBeyondInput, self.offset);
         const content_start = self.offset;
         const content_end = content_start + content_len;
         self.offset = content_end;
-        self.element_count += 1;
+        self.incrementElementCount();
         return .{
             .tag = tag,
             .encoded = self.input[elem_start..content_end],
@@ -216,27 +232,35 @@ pub const Reader = struct {
         };
     }
 
+    /// Parse one element and capture typed error plus offset. The offset is the
+    /// offending byte when the low-level decoder can identify it; otherwise it
+    /// is the tag start for the element being parsed.
+    pub fn readElementDiagnostic(self: *Reader) DiagnosticElement {
+        const elem_start = self.offset;
+        const elem = self.readElement() catch |err| {
+            return .{ .err = .{ .err = err, .offset = self.last_error_offset orelse elem_start } };
+        };
+        return .{ .element = elem };
+    }
+
     pub fn readSequence(self: *Reader) Error!Reader {
         const elem = try self.readElement();
-        if (elem.tag.class != .universal or elem.tag.number != @intFromEnum(UniversalTag.sequence) or !elem.tag.constructed) {
-            return error.UnexpectedTag;
-        }
+        try self.expectUniversalTag(elem, .sequence, true);
         return self.childReader(elem.content_offset, elem.content.len);
     }
 
     pub fn readSet(self: *Reader) Error!Reader {
         const elem = try self.readElement();
-        if (elem.tag.class != .universal or elem.tag.number != @intFromEnum(UniversalTag.set) or !elem.tag.constructed) {
-            return error.UnexpectedTag;
-        }
+        try self.expectUniversalTag(elem, .set, true);
         return self.childReader(elem.content_offset, elem.content.len);
     }
 
-    pub fn childReader(self: *const Reader, content_offset: usize, content_len: usize) Error!Reader {
-        if (self.depth >= self.limits.max_depth) return error.NestingLimit;
+    pub fn childReader(self: *Reader, content_offset: usize, content_len: usize) Error!Reader {
+        if (self.depth >= self.limits.max_depth) return self.fail(error.NestingLimit, content_offset);
         const end = content_offset + content_len;
-        if (content_offset < self.start or end > self.end) return error.LengthBeyondInput;
-        return Reader.initBounded(self.input, content_offset, end, self.depth + 1, self.element_count, self.limits);
+        if (content_offset < self.start or end > self.end) return self.fail(error.LengthBeyondInput, content_offset);
+        const shared_count = self.shared_element_count orelse &self.element_count;
+        return Reader.initBounded(self.input, content_offset, end, self.depth + 1, self.currentElementCount(), shared_count, self.limits);
     }
 
     pub fn expectEnd(self: *const Reader) Error!void {
@@ -268,18 +292,14 @@ pub const Reader = struct {
 
     pub fn readInteger(self: *Reader) Error!IntegerView {
         const elem = try self.readElement();
-        if (elem.tag.class != .universal or elem.tag.number != @intFromEnum(UniversalTag.integer)) {
-            return error.UnexpectedTag;
-        }
+        try self.expectUniversalTag(elem, .integer, false);
         try validateInteger(elem.content, self.limits.max_integer_bytes);
         return .{ .content = elem.content };
     }
 
     pub fn readBoolean(self: *Reader) Error!bool {
         const elem = try self.readElement();
-        if (elem.tag.class != .universal or elem.tag.number != @intFromEnum(UniversalTag.boolean)) {
-            return error.UnexpectedTag;
-        }
+        try self.expectUniversalTag(elem, .boolean, false);
         if (elem.content.len != 1) return error.MalformedBoolean;
         return switch (elem.content[0]) {
             0x00 => false,
@@ -290,33 +310,25 @@ pub const Reader = struct {
 
     pub fn readNull(self: *Reader) Error!void {
         const elem = try self.readElement();
-        if (elem.tag.class != .universal or elem.tag.number != @intFromEnum(UniversalTag.null)) {
-            return error.UnexpectedTag;
-        }
+        try self.expectUniversalTag(elem, .null, false);
         if (elem.content.len != 0) return error.UnexpectedTag;
     }
 
     pub fn readOctetString(self: *Reader) Error![]const u8 {
         const elem = try self.readElement();
-        if (elem.tag.class != .universal or elem.tag.number != @intFromEnum(UniversalTag.octet_string)) {
-            return error.UnexpectedTag;
-        }
+        try self.expectUniversalTag(elem, .octet_string, false);
         return elem.content;
     }
 
     pub fn readBitString(self: *Reader) Error!BitStringView {
         const elem = try self.readElement();
-        if (elem.tag.class != .universal or elem.tag.number != @intFromEnum(UniversalTag.bit_string)) {
-            return error.UnexpectedTag;
-        }
+        try self.expectUniversalTag(elem, .bit_string, false);
         return decodeBitStringContent(elem.content);
     }
 
     pub fn readObjectIdentifier(self: *Reader) Error!oid_mod.ObjectIdentifier {
         const elem = try self.readElement();
-        if (elem.tag.class != .universal or elem.tag.number != @intFromEnum(UniversalTag.object_identifier)) {
-            return error.UnexpectedTag;
-        }
+        try self.expectUniversalTag(elem, .object_identifier, false);
         return oid_mod.decode(elem.content, self.limits.max_oid_components);
     }
 
@@ -346,30 +358,24 @@ pub const Reader = struct {
 
     pub fn readUtcTime(self: *Reader) Error!time_mod.UtcTime {
         const elem = try self.readElement();
-        if (elem.tag.class != .universal or elem.tag.number != @intFromEnum(UniversalTag.utc_time)) {
-            return error.UnexpectedTag;
-        }
+        try self.expectUniversalTag(elem, .utc_time, false);
         return time_mod.parseUtcTime(elem.content);
     }
 
     pub fn readGeneralizedTime(self: *Reader) Error!time_mod.GeneralizedTime {
         const elem = try self.readElement();
-        if (elem.tag.class != .universal or elem.tag.number != @intFromEnum(UniversalTag.generalized_time)) {
-            return error.UnexpectedTag;
-        }
+        try self.expectUniversalTag(elem, .generalized_time, false);
         return time_mod.parseGeneralizedTime(elem.content);
     }
 
     fn readStringElement(self: *Reader, tag_number: UniversalTag) Error![]const u8 {
         const elem = try self.readElement();
-        if (elem.tag.class != .universal or elem.tag.number != @intFromEnum(tag_number)) {
-            return error.UnexpectedTag;
-        }
+        try self.expectUniversalTag(elem, tag_number, false);
         return elem.content;
     }
 
     fn readTag(self: *Reader) Error!Tag {
-        if (self.remaining() == 0) return error.Truncated;
+        if (self.remaining() == 0) return self.fail(error.Truncated, self.offset);
         const first = self.input[self.offset];
         self.offset += 1;
 
@@ -381,54 +387,80 @@ pub const Reader = struct {
             number = 0;
             var continuation_bytes: usize = 0;
             while (true) {
-                if (self.remaining() == 0) return error.Truncated;
+                if (self.remaining() == 0) return self.fail(error.Truncated, self.offset);
                 const b = self.input[self.offset];
                 self.offset += 1;
-                if (continuation_bytes == 0 and b == 0x80) return error.InvalidTag;
+                if (continuation_bytes == 0 and b == 0x80) return self.fail(error.InvalidTag, self.offset - 1);
                 const chunk: u32 = b & 0x7f;
-                if (number > (std.math.maxInt(u32) >> 7)) return error.InvalidTag;
+                if (number > (std.math.maxInt(u32) >> 7)) return self.fail(error.InvalidTag, self.offset - 1);
                 number = (number << 7) | chunk;
                 if (b & 0x80 == 0) break;
                 continuation_bytes += 1;
-                if (continuation_bytes > 4) return error.InvalidTag;
+                if (continuation_bytes > 4) return self.fail(error.InvalidTag, self.offset - 1);
             }
-            if (number < 31) return error.InvalidTag;
+            if (number < 31) return self.fail(error.InvalidTag, self.offset - 1);
         }
 
         return .{ .class = class, .number = number, .constructed = constructed };
     }
 
     fn readDefiniteLength(self: *Reader) Error!usize {
-        if (self.remaining() == 0) return error.Truncated;
+        if (self.remaining() == 0) return self.fail(error.Truncated, self.offset);
         const first = self.input[self.offset];
         self.offset += 1;
 
         if (first & 0x80 == 0) {
+            if (first > self.limits.max_element_len) return self.fail(error.LengthOverflow, self.offset - 1);
             return first;
         }
 
         const num_bytes = first & 0x7f;
-        if (num_bytes == 0) return error.IndefiniteLength;
-        if (num_bytes > 8) return error.InvalidLength;
-        if (self.remaining() < num_bytes) return error.Truncated;
+        if (num_bytes == 0) return self.fail(error.IndefiniteLength, self.offset - 1);
+        if (num_bytes > 8) return self.fail(error.InvalidLength, self.offset - 1);
+        if (self.remaining() < num_bytes) return self.fail(error.Truncated, self.offset);
 
         var length: u64 = 0;
         var i: usize = 0;
         while (i < num_bytes) : (i += 1) {
             length = (length << 8) | self.input[self.offset + i];
         }
-        if (length < 128) return error.NonMinimalLength;
-        if (length > self.limits.max_element_len) return error.LengthOverflow;
+        if (length < 128) return self.fail(error.NonMinimalLength, self.offset);
+        if (length > self.limits.max_element_len) return self.fail(error.LengthOverflow, self.offset);
 
         const first_len_byte = self.input[self.offset];
-        if (num_bytes > 1 and first_len_byte == 0) return error.NonMinimalLength;
+        if (num_bytes > 1 and first_len_byte == 0) return self.fail(error.NonMinimalLength, self.offset);
         const minimal_bytes = minimalLengthBytes(length);
-        if (num_bytes != minimal_bytes) return error.NonMinimalLength;
+        if (num_bytes != minimal_bytes) return self.fail(error.NonMinimalLength, self.offset);
 
         self.offset += num_bytes;
         const len: usize = @intCast(length);
-        if (len > self.remaining()) return error.LengthBeyondInput;
+        if (len > self.remaining()) return self.fail(error.LengthBeyondInput, self.offset);
         return len;
+    }
+
+    fn currentElementCount(self: *const Reader) usize {
+        if (self.shared_element_count) |count| return count.*;
+        return self.element_count;
+    }
+
+    fn incrementElementCount(self: *Reader) void {
+        if (self.shared_element_count) |count| {
+            count.* += 1;
+        } else {
+            self.element_count += 1;
+        }
+    }
+
+    fn expectUniversalTag(self: *Reader, elem: Element, tag_number: UniversalTag, constructed: bool) Error!void {
+        if (elem.tag.class != .universal or elem.tag.number != @intFromEnum(tag_number) or elem.tag.constructed != constructed) {
+            const header_len = elem.encoded.len - elem.content.len;
+            return self.fail(error.UnexpectedTag, elem.content_offset - header_len);
+        }
+    }
+
+    fn fail(self: *Reader, err: Error, offset: usize) Error {
+        self.last_error_offset = offset;
+        return err;
     }
 };
 

--- a/src/pki/der_tests.zig
+++ b/src/pki/der_tests.zig
@@ -256,11 +256,70 @@ test "excessive nesting and element count" {
     try testing.expectError(error.ElementCountLimit, seq.readNull());
 }
 
+test "element count limit is shared across nested sibling containers" {
+    const allocator = testing.allocator;
+
+    var first_payload = std.ArrayList(u8).empty;
+    defer first_payload.deinit(allocator);
+    var second_payload = std.ArrayList(u8).empty;
+    defer second_payload.deinit(allocator);
+    var i: usize = 0;
+    while (i < 2) : (i += 1) {
+        var item = Builder.init();
+        defer item.deinit(allocator);
+        try item.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.null), false), &.{});
+        try first_payload.appendSlice(allocator, item.buf.items);
+        try second_payload.appendSlice(allocator, item.buf.items);
+    }
+
+    var outer_payload = std.ArrayList(u8).empty;
+    defer outer_payload.deinit(allocator);
+    var first_seq = Builder.init();
+    defer first_seq.deinit(allocator);
+    try first_seq.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.sequence), true), first_payload.items);
+    try outer_payload.appendSlice(allocator, first_seq.buf.items);
+    var second_seq = Builder.init();
+    defer second_seq.deinit(allocator);
+    try second_seq.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.sequence), true), second_payload.items);
+    try outer_payload.appendSlice(allocator, second_seq.buf.items);
+
+    var outer = Builder.init();
+    defer outer.deinit(allocator);
+    try outer.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.sequence), true), outer_payload.items);
+    const encoded = try outer.toOwnedSlice(allocator);
+    defer allocator.free(encoded);
+
+    var reader = der.Reader.init(encoded, .{ .max_elements = 5 });
+    var seq = try reader.readSequence();
+    var first = try seq.readSequence();
+    try first.readNull();
+    try first.readNull();
+    try first.expectEnd();
+    var second = try seq.readSequence();
+    try testing.expectError(error.ElementCountLimit, second.readNull());
+}
+
+test "short-form lengths honor max element length" {
+    const allocator = testing.allocator;
+    try testing.expectError(error.LengthOverflow, parseOneWithLimits(allocator, &.{ 0x04, 0x05, 1, 2, 3, 4, 5 }, .{ .max_element_len = 4 }));
+}
+
 test "non-minimal INTEGER encodings rejected" {
     const allocator = testing.allocator;
     try testing.expectError(error.MalformedInteger, parseInteger(allocator, &.{ 0x00, 0x01 }));
     try testing.expectError(error.MalformedInteger, parseInteger(allocator, &.{ 0xff, 0xff }));
     try testing.expectError(error.MalformedInteger, parseInteger(allocator, &.{}));
+}
+
+test "constructed encodings for primitive universal types rejected" {
+    const allocator = testing.allocator;
+    try testing.expectError(error.UnexpectedTag, parseIntegerTlv(allocator, &.{ 0x22, 0x01, 0x01 }));
+    try testing.expectError(error.UnexpectedTag, parseBooleanTlv(allocator, &.{ 0x21, 0x01, 0xff }));
+    try testing.expectError(error.UnexpectedTag, parseBitStringTlv(allocator, &.{ 0x23, 0x02, 0x00, 0x80 }));
+    try testing.expectError(error.UnexpectedTag, parseOidTlv(allocator, &.{ 0x26, 0x03, 0x55, 0x04, 0x03 }));
+    try testing.expectError(error.UnexpectedTag, parseUtcTlv(allocator, "\x37\x0d240101000000Z"));
+    try testing.expectError(error.UnexpectedTag, parseGenTlv(allocator, "\x38\x0f20240101000000Z"));
+    try testing.expectError(error.InvalidTag, parseOne(allocator, &.{ 0x00, 0x00 }));
 }
 
 test "invalid BOOLEAN values" {
@@ -287,8 +346,28 @@ test "malformed OID and component overflow" {
 test "invalid time syntax" {
     const allocator = testing.allocator;
     try testing.expectError(error.MalformedTime, parseUtc(allocator, "24010100000"));
+    try testing.expectError(error.MalformedTime, parseUtc(allocator, "2401010000Z"));
     try testing.expectError(error.MalformedTime, parseUtc(allocator, "240101000000"));
     try testing.expectError(error.MalformedTime, parseGen(allocator, "2024010100000Z"));
+    try testing.expectError(error.MalformedTime, parseGen(allocator, "202401010000Z"));
+}
+
+test "diagnostic read captures typed error offsets" {
+    try expectDiagnostic(&.{ 0x1f, 0x00, 0x00 }, error.InvalidTag, 1);
+    try expectDiagnostic(&.{ 0x30, 0x82, 0x01 }, error.Truncated, 2);
+    try expectDiagnostic(&.{ 0x04, 0x81, 0x01, 0x00 }, error.NonMinimalLength, 2);
+
+    const child_boundary = [_]u8{ 0x30, 0x03, 0x04, 0x05, 0x00 };
+    var reader = der.Reader.init(&child_boundary, der.default_limits);
+    var child = try reader.readSequence();
+    const diag = child.readElementDiagnostic();
+    switch (diag) {
+        .element => return error.TestExpectedError,
+        .err => |parse_err| {
+            try testing.expectEqual(error.LengthBeyondInput, parse_err.err);
+            try testing.expectEqual(@as(usize, 4), parse_err.offset);
+        },
+    }
 }
 
 test "trailing bytes and child boundary escape" {
@@ -378,6 +457,11 @@ fn parseInteger(allocator: std.mem.Allocator, content: []const u8) !void {
     _ = try reader.readInteger();
 }
 
+fn parseIntegerTlv(_: std.mem.Allocator, input: []const u8) !void {
+    var reader = der.Reader.init(input, der.default_limits);
+    _ = try reader.readInteger();
+}
+
 fn parseBoolean(allocator: std.mem.Allocator, content: []const u8) !void {
     var b = Builder.init();
     defer b.deinit(allocator);
@@ -385,6 +469,11 @@ fn parseBoolean(allocator: std.mem.Allocator, content: []const u8) !void {
     const encoded = try b.toOwnedSlice(allocator);
     defer allocator.free(encoded);
     var reader = der.Reader.init(encoded, der.default_limits);
+    _ = try reader.readBoolean();
+}
+
+fn parseBooleanTlv(_: std.mem.Allocator, input: []const u8) !void {
+    var reader = der.Reader.init(input, der.default_limits);
     _ = try reader.readBoolean();
 }
 
@@ -398,6 +487,11 @@ fn parseBitString(allocator: std.mem.Allocator, content: []const u8) !void {
     _ = try reader.readBitString();
 }
 
+fn parseBitStringTlv(_: std.mem.Allocator, input: []const u8) !void {
+    var reader = der.Reader.init(input, der.default_limits);
+    _ = try reader.readBitString();
+}
+
 fn parseOid(allocator: std.mem.Allocator, content: []const u8) !void {
     var b = Builder.init();
     defer b.deinit(allocator);
@@ -405,6 +499,11 @@ fn parseOid(allocator: std.mem.Allocator, content: []const u8) !void {
     const encoded = try b.toOwnedSlice(allocator);
     defer allocator.free(encoded);
     var reader = der.Reader.init(encoded, der.default_limits);
+    _ = try reader.readObjectIdentifier();
+}
+
+fn parseOidTlv(_: std.mem.Allocator, input: []const u8) !void {
+    var reader = der.Reader.init(input, der.default_limits);
     _ = try reader.readObjectIdentifier();
 }
 
@@ -418,6 +517,11 @@ fn parseUtc(allocator: std.mem.Allocator, content: []const u8) !void {
     _ = try reader.readUtcTime();
 }
 
+fn parseUtcTlv(_: std.mem.Allocator, input: []const u8) !void {
+    var reader = der.Reader.init(input, der.default_limits);
+    _ = try reader.readUtcTime();
+}
+
 fn parseGen(allocator: std.mem.Allocator, content: []const u8) !void {
     var b = Builder.init();
     defer b.deinit(allocator);
@@ -426,4 +530,21 @@ fn parseGen(allocator: std.mem.Allocator, content: []const u8) !void {
     defer allocator.free(encoded);
     var reader = der.Reader.init(encoded, der.default_limits);
     _ = try reader.readGeneralizedTime();
+}
+
+fn parseGenTlv(_: std.mem.Allocator, input: []const u8) !void {
+    var reader = der.Reader.init(input, der.default_limits);
+    _ = try reader.readGeneralizedTime();
+}
+
+fn expectDiagnostic(input: []const u8, expected_err: der.Error, expected_offset: usize) !void {
+    var reader = der.Reader.init(input, der.default_limits);
+    const diag = reader.readElementDiagnostic();
+    switch (diag) {
+        .element => return error.TestExpectedError,
+        .err => |parse_err| {
+            try testing.expectEqual(expected_err, parse_err.err);
+            try testing.expectEqual(expected_offset, parse_err.offset);
+        },
+    }
 }

--- a/src/pki/der_tests.zig
+++ b/src/pki/der_tests.zig
@@ -1,0 +1,429 @@
+//! DER decoder regression and adversarial tests (#339).
+
+const std = @import("std");
+const der = @import("der.zig");
+const oid = @import("oid.zig");
+const time = @import("time.zig");
+
+const testing = std.testing;
+
+const Builder = struct {
+    buf: std.ArrayList(u8),
+
+    fn init() Builder {
+        return .{ .buf = std.ArrayList(u8).empty };
+    }
+
+    fn deinit(self: *Builder, allocator: std.mem.Allocator) void {
+        self.buf.deinit(allocator);
+    }
+
+    fn appendTlv(self: *Builder, allocator: std.mem.Allocator, tag: der.Tag, content: []const u8) !void {
+        var tag_buf: [8]u8 = undefined;
+        const tag_len = try der.encodeTag(tag, &tag_buf);
+        try self.buf.appendSlice(allocator, tag_buf[0..tag_len]);
+        var len_buf: [9]u8 = undefined;
+        const len_written = try der.encodeLength(content.len, &len_buf);
+        try self.buf.appendSlice(allocator, len_buf[0..len_written]);
+        try self.buf.appendSlice(allocator, content);
+    }
+
+    fn toOwnedSlice(self: *Builder, allocator: std.mem.Allocator) ![]u8 {
+        return self.buf.toOwnedSlice(allocator);
+    }
+};
+
+fn appendIntegerContent(out: *std.ArrayList(u8), allocator: std.mem.Allocator, value: []const u8) !void {
+    try out.appendSlice(allocator, value);
+}
+
+test "canonical positive fixtures for X.509 building blocks" {
+    const allocator = testing.allocator;
+    var b = Builder.init();
+    defer b.deinit(allocator);
+
+    // AlgorithmIdentifier-like SEQUENCE { OID, NULL }
+    var inner = std.ArrayList(u8).empty;
+    defer inner.deinit(allocator);
+    var oid_buf: [32]u8 = undefined;
+    const oid_len = try oid.encodeComponents(&oid.well_known.rsa_encryption, &oid_buf);
+    var oid_builder = Builder.init();
+    defer oid_builder.deinit(allocator);
+    try oid_builder.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.object_identifier), false), oid_buf[0..oid_len]);
+    try inner.appendSlice(allocator, oid_builder.buf.items);
+    var null_builder = Builder.init();
+    defer null_builder.deinit(allocator);
+    try null_builder.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.null), false), &.{});
+    try inner.appendSlice(allocator, null_builder.buf.items);
+    try b.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.sequence), true), inner.items);
+
+    const encoded = try b.toOwnedSlice(allocator);
+    defer allocator.free(encoded);
+
+    var reader = der.Reader.init(encoded, der.default_limits);
+    var seq = try reader.readSequence();
+    const alg_oid = try seq.readObjectIdentifier();
+    try testing.expectEqual(@as(usize, 7), alg_oid.len);
+    for (alg_oid.components(), 0..) |component, i| {
+        try testing.expectEqual(oid.well_known.rsa_encryption[i], component);
+    }
+    try seq.readNull();
+    try seq.expectEnd();
+    try reader.expectEnd();
+}
+
+test "INTEGER positive and negative minimal encodings" {
+    const allocator = testing.allocator;
+    const cases = [_]struct { bytes: []const u8, negative: bool }{
+        .{ .bytes = &.{0x00}, .negative = false },
+        .{ .bytes = &.{0x01}, .negative = false },
+        .{ .bytes = &.{ 0x00, 0x80 }, .negative = false },
+        .{ .bytes = &.{0xff}, .negative = true },
+        .{ .bytes = &.{ 0xff, 0x7f }, .negative = true },
+    };
+    for (cases) |c| {
+        var b = Builder.init();
+        defer b.deinit(allocator);
+        var inner = std.ArrayList(u8).empty;
+        defer inner.deinit(allocator);
+        try appendIntegerContent(&inner, allocator, c.bytes);
+        try b.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.integer), false), inner.items);
+        const encoded = try b.toOwnedSlice(allocator);
+        defer allocator.free(encoded);
+        var reader = der.Reader.init(encoded, der.default_limits);
+        const value = try reader.readInteger();
+        try testing.expectEqual(c.negative, value.isNegative());
+        try reader.expectEnd();
+    }
+}
+
+test "BOOLEAN, BIT STRING, strings, and times" {
+    const allocator = testing.allocator;
+    var b = Builder.init();
+    defer b.deinit(allocator);
+
+    try b.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.boolean), false), &.{0xff});
+    try b.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.bit_string), false), &.{ 0x00, 0xA0 });
+    try b.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.octet_string), false), "deadbeef");
+    try b.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.utf8_string), false), "café");
+    try b.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.printable_string), false), "Test CA");
+    try b.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.ia5_string), false), "example.com");
+    try b.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.utc_time), false), "240630120000Z");
+    try b.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.generalized_time), false), "20240630120000Z");
+
+    const encoded = try b.toOwnedSlice(allocator);
+    defer allocator.free(encoded);
+
+    var reader = der.Reader.init(encoded, der.default_limits);
+    try testing.expect(try reader.readBoolean());
+    const bits = try reader.readBitString();
+    try testing.expectEqual(@as(u3, 0), bits.unused_bits);
+    try testing.expectEqual(@as(u8, 0xA0), bits.data[0]);
+    try testing.expectEqualStrings("deadbeef", try reader.readOctetString());
+    try testing.expectEqualStrings("café", try reader.readUtf8String());
+    try testing.expectEqualStrings("Test CA", try reader.readPrintableString());
+    try testing.expectEqualStrings("example.com", try reader.readIa5String());
+    const utc = try reader.readUtcTime();
+    try testing.expectEqual(@as(u16, 2024), utc.year);
+    const gen = try reader.readGeneralizedTime();
+    try testing.expectEqual(@as(u16, 2024), gen.year);
+    try reader.expectEnd();
+}
+
+test "explicit and implicit context-specific tagging" {
+    const allocator = testing.allocator;
+    var seq_content = std.ArrayList(u8).empty;
+    defer seq_content.deinit(allocator);
+
+    var int_tlv = Builder.init();
+    defer int_tlv.deinit(allocator);
+    try int_tlv.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.integer), false), &.{0x2a});
+    var explicit = Builder.init();
+    defer explicit.deinit(allocator);
+    try explicit.appendTlv(allocator, der.Tag.contextSpecific(0, true), int_tlv.buf.items);
+    try seq_content.appendSlice(allocator, explicit.buf.items);
+
+    var implicit = Builder.init();
+    defer implicit.deinit(allocator);
+    try implicit.appendTlv(allocator, der.Tag.contextSpecific(1, false), "implicit");
+    try seq_content.appendSlice(allocator, implicit.buf.items);
+
+    var outer = Builder.init();
+    defer outer.deinit(allocator);
+    try outer.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.sequence), true), seq_content.items);
+    const encoded = try outer.toOwnedSlice(allocator);
+    defer allocator.free(encoded);
+
+    var reader = der.Reader.init(encoded, der.default_limits);
+    var seq = try reader.readSequence();
+    const explicit_elem = try seq.readExplicitContext(0);
+    try testing.expect(explicit_elem.tag.number == @intFromEnum(der.UniversalTag.integer));
+    try testing.expectEqual(@as(u8, 0x2a), explicit_elem.content[0]);
+
+    const implicit_elem = try seq.readContextSpecific(1, false);
+    try testing.expectEqualStrings("implicit", implicit_elem.content);
+    try seq.expectEnd();
+}
+
+test "truncated tag and length" {
+    const allocator = testing.allocator;
+    try testing.expectError(error.Truncated, parseOne(allocator, &.{}));
+    try testing.expectError(error.Truncated, parseOne(allocator, &.{0x30}));
+    try testing.expectError(error.Truncated, parseOne(allocator, &.{ 0x30, 0x82 }));
+    try testing.expectError(error.Truncated, parseOne(allocator, &.{ 0x30, 0x82, 0x01 }));
+}
+
+fn parseOne(allocator: std.mem.Allocator, input: []const u8) !void {
+    return parseOneWithLimits(allocator, input, der.default_limits);
+}
+
+fn parseOneWithLimits(allocator: std.mem.Allocator, input: []const u8, limits: der.Limits) !void {
+    var reader = der.Reader.init(input, limits);
+    _ = try reader.readElement();
+    try reader.expectEnd();
+    _ = allocator;
+}
+
+test "high tag number edge cases" {
+    const allocator = testing.allocator;
+    // Tag 31 must use extended form; single-byte 0x1f is reserved as lead-in.
+    try testing.expectError(error.InvalidTag, parseOne(allocator, &.{ 0x1f, 0x00, 0x00 }));
+
+    var b = Builder.init();
+    defer b.deinit(allocator);
+    try b.appendTlv(allocator, der.Tag.universal(31, false), &.{0x00});
+    const encoded = try b.toOwnedSlice(allocator);
+    defer allocator.free(encoded);
+    var reader = der.Reader.init(encoded, der.default_limits);
+    const elem = try reader.readElement();
+    try testing.expectEqual(@as(u32, 31), elem.tag.number);
+}
+
+test "indefinite length rejected" {
+    const allocator = testing.allocator;
+    try testing.expectError(error.IndefiniteLength, parseOne(allocator, &.{ 0x30, 0x80, 0x00, 0x00 }));
+    try testing.expectError(error.IndefiniteLength, parseOne(allocator, &.{ 0x04, 0x80 }));
+}
+
+test "non-minimal long-form lengths rejected" {
+    const allocator = testing.allocator;
+    // Length 1 encoded as 0x81 0x01
+    try testing.expectError(error.NonMinimalLength, parseOne(allocator, &.{ 0x04, 0x81, 0x01, 0x00 }));
+    // Length 0x80 encoded with leading zero byte 0x82 0x00 0x80
+    var long_len_input: [4 + 0x80]u8 = undefined;
+    long_len_input[0] = 0x04;
+    long_len_input[1] = 0x82;
+    long_len_input[2] = 0x00;
+    long_len_input[3] = 0x80;
+    @memset(long_len_input[4..], 0);
+    try testing.expectError(error.NonMinimalLength, parseOne(allocator, &long_len_input));
+}
+
+test "length beyond input and overflow" {
+    const allocator = testing.allocator;
+    try testing.expectError(error.LengthBeyondInput, parseOne(allocator, &.{ 0x04, 0x05, 0x01, 0x02 }));
+    try testing.expectError(error.LengthOverflow, parseOneWithLimits(allocator, &.{ 0x04, 0x84, 0x00, 0x10, 0x00, 0x00 }, .{ .max_element_len = 1024 }));
+}
+
+test "excessive nesting and element count" {
+    const allocator = testing.allocator;
+    // Three nested empty SEQUENCEs: 30 06 30 04 30 02 30 00
+    const deep = [_]u8{ 0x30, 0x06, 0x30, 0x04, 0x30, 0x02, 0x30, 0x00 };
+    var reader = der.Reader.init(&deep, .{ .max_depth = 2 });
+    var level1 = try reader.readSequence();
+    var level2 = try level1.readSequence();
+    try testing.expectError(error.NestingLimit, level2.readSequence());
+
+    var b = Builder.init();
+    defer b.deinit(allocator);
+    var payload = std.ArrayList(u8).empty;
+    defer payload.deinit(allocator);
+    var i: usize = 0;
+    while (i < 8) : (i += 1) {
+        var item = Builder.init();
+        defer item.deinit(allocator);
+        try item.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.null), false), &.{});
+        try payload.appendSlice(allocator, item.buf.items);
+    }
+    try b.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.sequence), true), payload.items);
+    const encoded = try b.toOwnedSlice(allocator);
+    defer allocator.free(encoded);
+    var elem_reader = der.Reader.init(encoded, .{ .max_elements = 4 });
+    var seq = try elem_reader.readSequence();
+    try seq.readNull();
+    try seq.readNull();
+    try seq.readNull();
+    try testing.expectError(error.ElementCountLimit, seq.readNull());
+}
+
+test "non-minimal INTEGER encodings rejected" {
+    const allocator = testing.allocator;
+    try testing.expectError(error.MalformedInteger, parseInteger(allocator, &.{ 0x00, 0x01 }));
+    try testing.expectError(error.MalformedInteger, parseInteger(allocator, &.{ 0xff, 0xff }));
+    try testing.expectError(error.MalformedInteger, parseInteger(allocator, &.{}));
+}
+
+test "invalid BOOLEAN values" {
+    const allocator = testing.allocator;
+    try testing.expectError(error.MalformedBoolean, parseBoolean(allocator, &.{0x01}));
+    try testing.expectError(error.MalformedBoolean, parseBoolean(allocator, &.{ 0x00, 0x00 }));
+}
+
+test "invalid BIT STRING unused bits" {
+    const allocator = testing.allocator;
+    try testing.expectError(error.MalformedBitString, parseBitString(allocator, &.{}));
+    try testing.expectError(error.MalformedBitString, parseBitString(allocator, &.{8}));
+    try testing.expectError(error.MalformedBitString, parseBitString(allocator, &.{ 0x01, 0x03 }));
+}
+
+test "malformed OID and component overflow" {
+    const allocator = testing.allocator;
+    try testing.expectError(error.MalformedOid, parseOid(allocator, &.{}));
+    try testing.expectError(error.MalformedOid, parseOid(allocator, &.{ 0x55, 0x80 }));
+    // Non-minimal base128 for zero
+    try testing.expectError(error.MalformedOid, parseOid(allocator, &.{ 0x55, 0x80, 0x00 }));
+}
+
+test "invalid time syntax" {
+    const allocator = testing.allocator;
+    try testing.expectError(error.MalformedTime, parseUtc(allocator, "24010100000"));
+    try testing.expectError(error.MalformedTime, parseUtc(allocator, "240101000000"));
+    try testing.expectError(error.MalformedTime, parseGen(allocator, "2024010100000Z"));
+}
+
+test "trailing bytes and child boundary escape" {
+    const allocator = testing.allocator;
+    var b = Builder.init();
+    defer b.deinit(allocator);
+    try b.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.null), false), &.{});
+    try b.buf.append(allocator, 0x00);
+    const encoded = try b.toOwnedSlice(allocator);
+    defer allocator.free(encoded);
+    var reader = der.Reader.init(encoded, der.default_limits);
+    try reader.readNull();
+    try testing.expectError(error.TrailingData, reader.expectEnd());
+
+    var seq_b = Builder.init();
+    defer seq_b.deinit(allocator);
+    try seq_b.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.sequence), true), &.{});
+    const seq_bytes = try seq_b.toOwnedSlice(allocator);
+    defer allocator.free(seq_bytes);
+    var seq_reader = der.Reader.init(seq_bytes, der.default_limits);
+    var child = try seq_reader.readSequence();
+    try child.expectEnd();
+    try seq_reader.expectEnd();
+}
+
+test "empty and zero-length values" {
+    const allocator = testing.allocator;
+    var b = Builder.init();
+    defer b.deinit(allocator);
+    try b.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.sequence), true), &.{});
+    try b.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.octet_string), false), &.{});
+    const encoded = try b.toOwnedSlice(allocator);
+    defer allocator.free(encoded);
+    var reader = der.Reader.init(encoded, der.default_limits);
+    var seq = try reader.readSequence();
+    try seq.expectEnd();
+    try testing.expectEqual(@as(usize, 0), (try reader.readOctetString()).len);
+    try reader.expectEnd();
+}
+
+test "length encode/decode round-trip" {
+    const allocator = testing.allocator;
+    const lengths = [_]usize{ 0, 1, 127, 128, 255, 256 };
+    for (lengths) |len| {
+        var content = std.ArrayList(u8).empty;
+        defer content.deinit(allocator);
+        try content.appendNTimes(allocator, 0, len);
+        var b = Builder.init();
+        defer b.deinit(allocator);
+        try b.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.octet_string), false), content.items);
+        const encoded = try b.toOwnedSlice(allocator);
+        defer allocator.free(encoded);
+        var reader = der.Reader.init(encoded, der.default_limits);
+        const value = try reader.readOctetString();
+        try testing.expectEqual(len, value.len);
+        try reader.expectEnd();
+    }
+}
+
+test "fuzz: DER parser never panics or leaks on arbitrary input" {
+    try testing.fuzz({}, fuzzDerParse, .{ .corpus = &.{
+        "",
+        "\x30\x00",
+        "\x02\x01\x01",
+        "\x30\x80\x00\x00",
+        "\x04\x81\x01\x00",
+        "\x06\x03\x55\x04\x03",
+        "\x17\x0d\x32\x34\x30\x36\x30\x31\x30\x30\x30\x30\x30\x30\x5a",
+        "\x18\x0f\x32\x30\x32\x34\x30\x36\x30\x31\x30\x30\x30\x30\x30\x30\x5a",
+        "\xa0\x03\x02\x01\x2a",
+    } });
+}
+
+fn fuzzDerParse(_: void, smith: *testing.Smith) !void {
+    var buf: [8192]u8 = undefined;
+    const len = smith.slice(&buf);
+    der.fuzzParseInput(buf[0..len]);
+}
+
+fn parseInteger(allocator: std.mem.Allocator, content: []const u8) !void {
+    var b = Builder.init();
+    defer b.deinit(allocator);
+    try b.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.integer), false), content);
+    const encoded = try b.toOwnedSlice(allocator);
+    defer allocator.free(encoded);
+    var reader = der.Reader.init(encoded, der.default_limits);
+    _ = try reader.readInteger();
+}
+
+fn parseBoolean(allocator: std.mem.Allocator, content: []const u8) !void {
+    var b = Builder.init();
+    defer b.deinit(allocator);
+    try b.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.boolean), false), content);
+    const encoded = try b.toOwnedSlice(allocator);
+    defer allocator.free(encoded);
+    var reader = der.Reader.init(encoded, der.default_limits);
+    _ = try reader.readBoolean();
+}
+
+fn parseBitString(allocator: std.mem.Allocator, content: []const u8) !void {
+    var b = Builder.init();
+    defer b.deinit(allocator);
+    try b.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.bit_string), false), content);
+    const encoded = try b.toOwnedSlice(allocator);
+    defer allocator.free(encoded);
+    var reader = der.Reader.init(encoded, der.default_limits);
+    _ = try reader.readBitString();
+}
+
+fn parseOid(allocator: std.mem.Allocator, content: []const u8) !void {
+    var b = Builder.init();
+    defer b.deinit(allocator);
+    try b.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.object_identifier), false), content);
+    const encoded = try b.toOwnedSlice(allocator);
+    defer allocator.free(encoded);
+    var reader = der.Reader.init(encoded, der.default_limits);
+    _ = try reader.readObjectIdentifier();
+}
+
+fn parseUtc(allocator: std.mem.Allocator, content: []const u8) !void {
+    var b = Builder.init();
+    defer b.deinit(allocator);
+    try b.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.utc_time), false), content);
+    const encoded = try b.toOwnedSlice(allocator);
+    defer allocator.free(encoded);
+    var reader = der.Reader.init(encoded, der.default_limits);
+    _ = try reader.readUtcTime();
+}
+
+fn parseGen(allocator: std.mem.Allocator, content: []const u8) !void {
+    var b = Builder.init();
+    defer b.deinit(allocator);
+    try b.appendTlv(allocator, der.Tag.universal(@intFromEnum(der.UniversalTag.generalized_time), false), content);
+    const encoded = try b.toOwnedSlice(allocator);
+    defer allocator.free(encoded);
+    var reader = der.Reader.init(encoded, der.default_limits);
+    _ = try reader.readGeneralizedTime();
+}

--- a/src/pki/oid.zig
+++ b/src/pki/oid.zig
@@ -1,0 +1,161 @@
+//! OBJECT IDENTIFIER decoding for X.509 (#339).
+
+const std = @import("std");
+
+pub const Error = error{
+    MalformedOid,
+    OidComponentOverflow,
+    OidComponentLimit,
+};
+
+pub const max_components = 32;
+
+pub const ObjectIdentifier = struct {
+    storage: [max_components]u32 = undefined,
+    len: usize = 0,
+
+    pub fn components(self: ObjectIdentifier) []const u32 {
+        return self.storage[0..self.len];
+    }
+
+    pub fn fromComponents(values: []const u32) Error!ObjectIdentifier {
+        if (values.len > max_components) return error.OidComponentLimit;
+        var oid: ObjectIdentifier = .{};
+        @memcpy(oid.storage[0..values.len], values);
+        oid.len = values.len;
+        return oid;
+    }
+
+    pub fn eql(self: ObjectIdentifier, other: ObjectIdentifier) bool {
+        return std.mem.eql(u32, self.components(), other.components());
+    }
+
+    pub fn eqlComponents(self: ObjectIdentifier, values: []const u32) bool {
+        return std.mem.eql(u32, self.components(), values);
+    }
+};
+
+/// Decode DER OID content (value bytes only, not the TLV wrapper).
+pub fn decode(content: []const u8, component_limit: usize) Error!ObjectIdentifier {
+    if (content.len == 0) return error.MalformedOid;
+    if (component_limit > max_components) return error.OidComponentLimit;
+
+    var oid: ObjectIdentifier = .{};
+
+    const first = content[0];
+    const first_arc: u32 = if (first < 40) 0 else if (first < 80) 1 else 2;
+    const second_arc: u32 = if (first < 40) first else if (first < 80) first - 40 else first - 80;
+    if (first_arc < 2 and second_arc >= 40) return error.MalformedOid;
+    oid.storage[0] = first_arc;
+    oid.storage[1] = second_arc;
+    oid.len = 2;
+
+    var i: usize = 1;
+    while (i < content.len) {
+        if (oid.len >= component_limit) return error.OidComponentLimit;
+        const decoded = try decodeBase128(content, &i);
+        oid.storage[oid.len] = decoded;
+        oid.len += 1;
+    }
+
+    return oid;
+}
+
+fn decodeBase128(content: []const u8, index: *usize) Error!u32 {
+    var value: u32 = 0;
+    var continuation_bytes: usize = 0;
+    while (index.* < content.len) {
+        const b = content[index.*];
+        index.* += 1;
+        const chunk: u32 = b & 0x7f;
+        if (value > (std.math.maxInt(u32) >> 7)) return error.OidComponentOverflow;
+        value = (value << 7) | chunk;
+        if (b & 0x80 == 0) {
+            if (value < 128 and continuation_bytes > 0) return error.MalformedOid;
+            return value;
+        }
+        if (value == 0 and chunk == 0) return error.MalformedOid;
+        continuation_bytes += 1;
+        if (continuation_bytes > 4) return error.OidComponentOverflow;
+    }
+    return error.MalformedOid;
+}
+
+/// Encode OID components to canonical DER content bytes.
+pub fn encodeComponents(components: []const u32, out: []u8) Error!usize {
+    if (components.len < 2) return error.MalformedOid;
+    if (components[0] > 2) return error.MalformedOid;
+    if (components[0] < 2 and components[1] >= 40) return error.MalformedOid;
+
+    if (out.len == 0) return error.MalformedOid;
+    out[0] = @intCast(components[0] * 40 + components[1]);
+    var written: usize = 1;
+
+    for (components[2..]) |component| {
+        const n = try encodeBase128(component, out[written..]);
+        written += n;
+    }
+    return written;
+}
+
+fn encodeBase128(value: u32, out: []u8) Error!usize {
+    if (value == 0) {
+        if (out.len == 0) return error.MalformedOid;
+        out[0] = 0;
+        return 1;
+    }
+    var stack: [5]u8 = undefined;
+    var tmp = value;
+    var count: usize = 0;
+    while (tmp > 0) : (count += 1) {
+        stack[count] = @intCast(tmp & 0x7f);
+        tmp >>= 7;
+    }
+    if (out.len < count) return error.MalformedOid;
+    var i: usize = 0;
+    while (i < count - 1) : (i += 1) {
+        out[i] = stack[count - 1 - i] | 0x80;
+    }
+    out[count - 1] = stack[0];
+    return count;
+}
+
+/// Well-known directory / PKIX OIDs used in tests and later #341.
+pub const well_known = struct {
+    pub const rsa_encryption = [_]u32{ 1, 2, 840, 113549, 1, 1, 1 };
+    pub const common_name = [_]u32{ 2, 5, 4, 3 };
+    pub const organization = [_]u32{ 2, 5, 4, 10 };
+    pub const country = [_]u32{ 2, 5, 4, 6 };
+    pub const subject_alt_name = [_]u32{ 2, 5, 29, 17 };
+    pub const basic_constraints = [_]u32{ 2, 5, 29, 19 };
+    pub const key_usage = [_]u32{ 2, 5, 29, 15 };
+    pub const ext_key_usage = [_]u32{ 2, 5, 29, 37 };
+    pub const server_auth = [_]u32{ 1, 3, 6, 1, 5, 5, 7, 3, 1 };
+};
+
+const testing = std.testing;
+
+test "decode and encode known OIDs" {
+    var buf: [32]u8 = undefined;
+    const rsa_der = [_]u8{ 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01 };
+    const n_rsa = try encodeComponents(&well_known.rsa_encryption, &buf);
+    try testing.expectEqualSlices(u8, &rsa_der, buf[0..n_rsa]);
+    const rsa = try decode(buf[0..n_rsa], 32);
+    try testing.expectEqual(@as(usize, 7), rsa.len);
+    for (rsa.components(), 0..) |component, i| {
+        try testing.expectEqual(well_known.rsa_encryption[i], component);
+    }
+
+    const cn_der = [_]u8{ 0x55, 0x04, 0x03 };
+    const n_cn = try encodeComponents(&well_known.common_name, &buf);
+    try testing.expectEqualSlices(u8, &cn_der, buf[0..n_cn]);
+    const cn = try decode(buf[0..n_cn], 32);
+    try testing.expectEqual(@as(usize, 4), cn.len);
+    for (cn.components(), 0..) |component, i| {
+        try testing.expectEqual(well_known.common_name[i], component);
+    }
+}
+
+test {
+    testing.refAllDecls(@This());
+}

--- a/src/pki/oid.zig
+++ b/src/pki/oid.zig
@@ -14,7 +14,7 @@ pub const ObjectIdentifier = struct {
     storage: [max_components]u32 = undefined,
     len: usize = 0,
 
-    pub fn components(self: ObjectIdentifier) []const u32 {
+    pub fn components(self: *const ObjectIdentifier) []const u32 {
         return self.storage[0..self.len];
     }
 
@@ -26,11 +26,11 @@ pub const ObjectIdentifier = struct {
         return oid;
     }
 
-    pub fn eql(self: ObjectIdentifier, other: ObjectIdentifier) bool {
+    pub fn eql(self: *const ObjectIdentifier, other: *const ObjectIdentifier) bool {
         return std.mem.eql(u32, self.components(), other.components());
     }
 
-    pub fn eqlComponents(self: ObjectIdentifier, values: []const u32) bool {
+    pub fn eqlComponents(self: *const ObjectIdentifier, values: []const u32) bool {
         return std.mem.eql(u32, self.components(), values);
     }
 };
@@ -38,11 +38,13 @@ pub const ObjectIdentifier = struct {
 /// Decode DER OID content (value bytes only, not the TLV wrapper).
 pub fn decode(content: []const u8, component_limit: usize) Error!ObjectIdentifier {
     if (content.len == 0) return error.MalformedOid;
+    if (component_limit < 2) return error.OidComponentLimit;
     if (component_limit > max_components) return error.OidComponentLimit;
 
     var oid: ObjectIdentifier = .{};
 
-    const first = content[0];
+    var i: usize = 0;
+    const first = try decodeBase128(content, &i);
     const first_arc: u32 = if (first < 40) 0 else if (first < 80) 1 else 2;
     const second_arc: u32 = if (first < 40) first else if (first < 80) first - 40 else first - 80;
     if (first_arc < 2 and second_arc >= 40) return error.MalformedOid;
@@ -50,7 +52,6 @@ pub fn decode(content: []const u8, component_limit: usize) Error!ObjectIdentifie
     oid.storage[1] = second_arc;
     oid.len = 2;
 
-    var i: usize = 1;
     while (i < content.len) {
         if (oid.len >= component_limit) return error.OidComponentLimit;
         const decoded = try decodeBase128(content, &i);
@@ -87,9 +88,8 @@ pub fn encodeComponents(components: []const u32, out: []u8) Error!usize {
     if (components[0] > 2) return error.MalformedOid;
     if (components[0] < 2 and components[1] >= 40) return error.MalformedOid;
 
-    if (out.len == 0) return error.MalformedOid;
-    out[0] = @intCast(components[0] * 40 + components[1]);
-    var written: usize = 1;
+    const first_combined = components[0] * 40 + components[1];
+    var written = try encodeBase128(first_combined, out);
 
     for (components[2..]) |component| {
         const n = try encodeBase128(component, out[written..]);
@@ -154,6 +154,20 @@ test "decode and encode known OIDs" {
     for (cn.components(), 0..) |component, i| {
         try testing.expectEqual(well_known.common_name[i], component);
     }
+}
+
+test "decode and encode multi-octet first subidentifier" {
+    var buf: [16]u8 = undefined;
+    const components = [_]u32{ 2, 999, 3 };
+    const n = try encodeComponents(&components, &buf);
+    try testing.expectEqualSlices(u8, &.{ 0x88, 0x37, 0x03 }, buf[0..n]);
+    const decoded = try decode(buf[0..n], 3);
+    try testing.expect(decoded.eqlComponents(&components));
+}
+
+test "decode rejects limits below mandatory first two OID arcs" {
+    try testing.expectError(error.OidComponentLimit, decode(&.{0x55}, 0));
+    try testing.expectError(error.OidComponentLimit, decode(&.{0x55}, 1));
 }
 
 test {

--- a/src/pki/root.zig
+++ b/src/pki/root.zig
@@ -1,0 +1,31 @@
+//! Pure-Zig PKI foundation (#324, #339): bounded ASN.1 DER decoding for X.509.
+//!
+//! This package is the DER foundation for the Web PKI epic (#324). It does not
+//! parse complete certificates (#341), load PEM (#340), or verify signatures.
+//!
+//! ## Modules
+//!
+//! - `der` — TLV cursor, typed decoders, limits, fuzz entrypoint
+//! - `oid` — OBJECT IDENTIFIER component decoding
+//! - `time` — UTCTime and GeneralizedTime validation
+//!
+//! ## Policy summary
+//!
+//! Definite-length DER only; reject BER indefinite lengths and non-minimal
+//! encodings. Zero-copy views into caller-owned input; call `expectEnd` to
+//! enforce complete consumption. See `der.Limits` for default bounds.
+//!
+//! ## Downstream usage
+//!
+//! #340 should base64-decode PEM blocks and hand DER bytes to `der.Reader`.
+//! #341 should map TBSCertificate, Name, and Extension sequences using child
+//! readers and the typed decoders exported here.
+
+pub const der = @import("der.zig");
+pub const oid = @import("oid.zig");
+pub const time = @import("time.zig");
+
+test {
+    @import("std").testing.refAllDecls(@This());
+    _ = @import("der_tests.zig");
+}

--- a/src/pki/time.zig
+++ b/src/pki/time.zig
@@ -1,0 +1,125 @@
+//! UTCTime and GeneralizedTime parsing for X.509 (#339).
+
+const std = @import("std");
+
+pub const Error = error{
+    MalformedTime,
+};
+
+pub const UtcTime = struct {
+    year: u16,
+    month: u8,
+    day: u8,
+    hour: u8,
+    minute: u8,
+    second: ?u8,
+};
+
+pub const GeneralizedTime = struct {
+    year: u16,
+    month: u8,
+    day: u8,
+    hour: u8,
+    minute: u8,
+    second: ?u8,
+};
+
+pub fn parseUtcTime(content: []const u8) Error!UtcTime {
+    if (content.len != 11 and content.len != 13) return error.MalformedTime;
+    if (content[content.len - 1] != 'Z') return error.MalformedTime;
+
+    const yy = try parseTwoDigits(content[0..2]);
+    const year: u16 = if (yy >= 50) @as(u16, 1900) + yy else @as(u16, 2000) + yy;
+    const month = try parseTwoDigits(content[2..4]);
+    const day = try parseTwoDigits(content[4..6]);
+    const hour = try parseTwoDigits(content[6..8]);
+    const minute = try parseTwoDigits(content[8..10]);
+
+    const second: ?u8 = if (content.len == 13) try parseTwoDigits(content[10..12]) else null;
+
+    try validateDateTime(year, month, day, hour, minute, second);
+    return .{ .year = year, .month = month, .day = day, .hour = hour, .minute = minute, .second = second };
+}
+
+pub fn parseGeneralizedTime(content: []const u8) Error!GeneralizedTime {
+    if (content.len != 13 and content.len != 15) return error.MalformedTime;
+    if (content[content.len - 1] != 'Z') return error.MalformedTime;
+    for (content[0 .. content.len - 1]) |c| {
+        if (c < '0' or c > '9') return error.MalformedTime;
+    }
+
+    const year = try parseFourDigits(content[0..4]);
+    const month = try parseTwoDigits(content[4..6]);
+    const day = try parseTwoDigits(content[6..8]);
+    const hour = try parseTwoDigits(content[8..10]);
+    const minute = try parseTwoDigits(content[10..12]);
+
+    const second: ?u8 = if (content.len == 15) try parseTwoDigits(content[12..14]) else null;
+
+    try validateDateTime(year, month, day, hour, minute, second);
+    return .{ .year = year, .month = month, .day = day, .hour = hour, .minute = minute, .second = second };
+}
+
+fn parseTwoDigits(digits: []const u8) Error!u8 {
+    if (digits.len != 2) return error.MalformedTime;
+    if (digits[0] < '0' or digits[0] > '9') return error.MalformedTime;
+    if (digits[1] < '0' or digits[1] > '9') return error.MalformedTime;
+    return @intCast((digits[0] - '0') * 10 + (digits[1] - '0'));
+}
+
+fn parseFourDigits(digits: []const u8) Error!u16 {
+    if (digits.len != 4) return error.MalformedTime;
+    var value: u16 = 0;
+    for (digits) |c| {
+        if (c < '0' or c > '9') return error.MalformedTime;
+        value = value * 10 + (c - '0');
+    }
+    return value;
+}
+
+fn validateDateTime(year: u16, month: u8, day: u8, hour: u8, minute: u8, second: ?u8) Error!void {
+    if (month < 1 or month > 12) return error.MalformedTime;
+    if (day < 1 or day > daysInMonth(year, month)) return error.MalformedTime;
+    if (hour > 23) return error.MalformedTime;
+    if (minute > 59) return error.MalformedTime;
+    if (second) |s| {
+        if (s > 59) return error.MalformedTime;
+    }
+}
+
+fn daysInMonth(year: u16, month: u8) u8 {
+    return switch (month) {
+        1, 3, 5, 7, 8, 10, 12 => 31,
+        4, 6, 9, 11 => 30,
+        2 => if (isLeapYear(year)) 29 else 28,
+        else => 0,
+    };
+}
+
+fn isLeapYear(year: u16) bool {
+    if (@rem(year, 4) != 0) return false;
+    if (@rem(year, 100) != 0) return true;
+    return @rem(year, 400) == 0;
+}
+
+const testing = std.testing;
+
+test "parse canonical UTCTime and GeneralizedTime" {
+    const utc = try parseUtcTime("240101000000Z");
+    try testing.expectEqual(@as(u16, 2024), utc.year);
+    try testing.expectEqual(@as(u8, 1), utc.month);
+    try testing.expectEqual(@as(u8, 1), utc.day);
+
+    const gen = try parseGeneralizedTime("20240101000000Z");
+    try testing.expectEqual(@as(u16, 2024), gen.year);
+}
+
+test "reject invalid calendar values" {
+    try testing.expectError(error.MalformedTime, parseUtcTime("240231000000Z"));
+    try testing.expectError(error.MalformedTime, parseUtcTime("240101250000Z"));
+    try testing.expectError(error.MalformedTime, parseGeneralizedTime("20240230000000Z"));
+}
+
+test {
+    testing.refAllDecls(@This());
+}

--- a/src/pki/time.zig
+++ b/src/pki/time.zig
@@ -12,7 +12,7 @@ pub const UtcTime = struct {
     day: u8,
     hour: u8,
     minute: u8,
-    second: ?u8,
+    second: u8,
 };
 
 pub const GeneralizedTime = struct {
@@ -21,11 +21,11 @@ pub const GeneralizedTime = struct {
     day: u8,
     hour: u8,
     minute: u8,
-    second: ?u8,
+    second: u8,
 };
 
 pub fn parseUtcTime(content: []const u8) Error!UtcTime {
-    if (content.len != 11 and content.len != 13) return error.MalformedTime;
+    if (content.len != 13) return error.MalformedTime;
     if (content[content.len - 1] != 'Z') return error.MalformedTime;
 
     const yy = try parseTwoDigits(content[0..2]);
@@ -35,14 +35,14 @@ pub fn parseUtcTime(content: []const u8) Error!UtcTime {
     const hour = try parseTwoDigits(content[6..8]);
     const minute = try parseTwoDigits(content[8..10]);
 
-    const second: ?u8 = if (content.len == 13) try parseTwoDigits(content[10..12]) else null;
+    const second = try parseTwoDigits(content[10..12]);
 
     try validateDateTime(year, month, day, hour, minute, second);
     return .{ .year = year, .month = month, .day = day, .hour = hour, .minute = minute, .second = second };
 }
 
 pub fn parseGeneralizedTime(content: []const u8) Error!GeneralizedTime {
-    if (content.len != 13 and content.len != 15) return error.MalformedTime;
+    if (content.len != 15) return error.MalformedTime;
     if (content[content.len - 1] != 'Z') return error.MalformedTime;
     for (content[0 .. content.len - 1]) |c| {
         if (c < '0' or c > '9') return error.MalformedTime;
@@ -54,7 +54,7 @@ pub fn parseGeneralizedTime(content: []const u8) Error!GeneralizedTime {
     const hour = try parseTwoDigits(content[8..10]);
     const minute = try parseTwoDigits(content[10..12]);
 
-    const second: ?u8 = if (content.len == 15) try parseTwoDigits(content[12..14]) else null;
+    const second = try parseTwoDigits(content[12..14]);
 
     try validateDateTime(year, month, day, hour, minute, second);
     return .{ .year = year, .month = month, .day = day, .hour = hour, .minute = minute, .second = second };
@@ -77,14 +77,12 @@ fn parseFourDigits(digits: []const u8) Error!u16 {
     return value;
 }
 
-fn validateDateTime(year: u16, month: u8, day: u8, hour: u8, minute: u8, second: ?u8) Error!void {
+fn validateDateTime(year: u16, month: u8, day: u8, hour: u8, minute: u8, second: u8) Error!void {
     if (month < 1 or month > 12) return error.MalformedTime;
     if (day < 1 or day > daysInMonth(year, month)) return error.MalformedTime;
     if (hour > 23) return error.MalformedTime;
     if (minute > 59) return error.MalformedTime;
-    if (second) |s| {
-        if (s > 59) return error.MalformedTime;
-    }
+    if (second > 59) return error.MalformedTime;
 }
 
 fn daysInMonth(year: u16, month: u8) u8 {
@@ -118,6 +116,11 @@ test "reject invalid calendar values" {
     try testing.expectError(error.MalformedTime, parseUtcTime("240231000000Z"));
     try testing.expectError(error.MalformedTime, parseUtcTime("240101250000Z"));
     try testing.expectError(error.MalformedTime, parseGeneralizedTime("20240230000000Z"));
+}
+
+test "reject certificate times without mandatory seconds" {
+    try testing.expectError(error.MalformedTime, parseUtcTime("2401010000Z"));
+    try testing.expectError(error.MalformedTime, parseGeneralizedTime("202401010000Z"));
 }
 
 test {


### PR DESCRIPTION
Implement strict DER-only parsing with configurable limits, zero-copy views, typed decoders, adversarial tests, and a fuzz harness entrypoint for later PKI work (#340, #341).

**What changed and why**
Adds a bounded ASN.1 DER decoder foundation for X.509: TLV cursoring, typed primitive decoders, OID/time helpers, canonical DER rejection cases, parser limits, and fuzz/regression coverage for untrusted certificate input.

**Related issues**
Closes #339

**Tests**
Added pure-Zig PKI DER unit tests covering canonical X.509 building blocks, malformed tags/lengths, tree-wide element limits, DER primitive/constructed form rejection, OID round trips including multi-octet first subidentifiers, strict certificate time forms, diagnostic offsets, and fuzz corpus handling.

Results from this branch:
- `zig fmt build.zig src/ tests/ --check` passes
- `git diff --check` passes
- `zig build test-pki --summary all --error-style verbose` passes: 33/33 tests
- `zig build test --summary all --error-style verbose` passes: 1111/1112 tests, 1 skipped
- `zig build --summary all --error-style verbose` passes
- `zig build test-integration --summary all --error-style verbose` passes: 63/67 tests, 4 skipped

**Security impact**
Yes. This parser sits on the untrusted certificate boundary for later PEM and X.509 work. Review focused on strict DER canonicality, bounded recursion/element/length limits, zero-copy lifetime behavior, malformed-input diagnostics, and rejecting BER/non-canonical encodings before downstream certificate parsing relies on them.

**Performance impact**
Low. The parser is zero-copy and allocation-free on the decode path; added checks are constant-time per tag/length/value boundary and enforce existing configurable limits.

**Checklist**
- [x] `zig fmt --check build.zig src/ tests/` passes
- [x] `zig build test --summary all` green
- [x] `zig build test-integration` green (required for protocol, proxy, and TLS changes)
- [x] New behavior covered by tests
- [x] [docs/CODE_REVIEW_CHECKLIST.md](docs/CODE_REVIEW_CHECKLIST.md) completed
- [x] README / CHANGELOG updated if operator-visible behavior changed
