### PR TITLE
tls: add data-driven negotiation registry

### DIFF
--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -22,6 +22,7 @@ const config = @import("config.zig");
 const varint = @import("quic_varint");
 const tls_adapter = @import("tls_adapter.zig");
 const tls_handshake = @import("tls_handshake.zig");
+const tls_algorithms = @import("tls_core").algorithms;
 const tls_key_schedule = @import("tls_core").key_schedule;
 
 const crypto = std.crypto;
@@ -43,17 +44,17 @@ const TranscriptHash = tls_key_schedule.TranscriptHash;
 pub const max_message_len = 8 * 1024;
 pub const max_certificate_len = 2048;
 
-const tls13_version: u16 = 0x0304;
-const legacy_version: u16 = 0x0303;
-const cipher_tls_aes_128_gcm_sha256: u16 = 0x1301;
-const group_x25519: u16 = 0x001d;
-const sigalg_ed25519: u16 = 0x0807;
+const tls13_version: u16 = @intFromEnum(tls_algorithms.ProtocolVersion.tls13);
+const legacy_version: u16 = tls_algorithms.legacy_version;
+const cipher_tls_aes_128_gcm_sha256: u16 = @intFromEnum(tls_algorithms.CipherSuite.tls_aes_128_gcm_sha256);
+const group_x25519: u16 = @intFromEnum(tls_algorithms.NamedGroup.x25519);
+const sigalg_ed25519: u16 = @intFromEnum(tls_algorithms.SignatureScheme.ed25519);
 
-const ext_supported_groups: u16 = 10;
-const ext_signature_algorithms: u16 = 13;
-const ext_alpn: u16 = 16;
-const ext_supported_versions: u16 = 43;
-const ext_key_share: u16 = 51;
+const ext_supported_groups: u16 = @intFromEnum(tls_algorithms.ExtensionType.supported_groups);
+const ext_signature_algorithms: u16 = @intFromEnum(tls_algorithms.ExtensionType.signature_algorithms);
+const ext_alpn: u16 = @intFromEnum(tls_algorithms.ExtensionType.application_layer_protocol_negotiation);
+const ext_supported_versions: u16 = @intFromEnum(tls_algorithms.ExtensionType.supported_versions);
+const ext_key_share: u16 = @intFromEnum(tls_algorithms.ExtensionType.key_share);
 /// RFC 9001 §8.2.
 const ext_quic_transport_parameters: u16 = 57;
 

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -22,7 +22,6 @@ const config = @import("config.zig");
 const varint = @import("quic_varint");
 const tls_adapter = @import("tls_adapter.zig");
 const tls_handshake = @import("tls_handshake.zig");
-const tls_algorithms = @import("tls_core").algorithms;
 const tls_key_schedule = @import("tls_core").key_schedule;
 
 const crypto = std.crypto;
@@ -44,17 +43,17 @@ const TranscriptHash = tls_key_schedule.TranscriptHash;
 pub const max_message_len = 8 * 1024;
 pub const max_certificate_len = 2048;
 
-const tls13_version: u16 = @intFromEnum(tls_algorithms.ProtocolVersion.tls13);
-const legacy_version: u16 = tls_algorithms.legacy_version;
-const cipher_tls_aes_128_gcm_sha256: u16 = @intFromEnum(tls_algorithms.CipherSuite.tls_aes_128_gcm_sha256);
-const group_x25519: u16 = @intFromEnum(tls_algorithms.NamedGroup.x25519);
-const sigalg_ed25519: u16 = @intFromEnum(tls_algorithms.SignatureScheme.ed25519);
+const tls13_version: u16 = 0x0304;
+const legacy_version: u16 = 0x0303;
+const cipher_tls_aes_128_gcm_sha256: u16 = 0x1301;
+const group_x25519: u16 = 0x001d;
+const sigalg_ed25519: u16 = 0x0807;
 
-const ext_supported_groups: u16 = @intFromEnum(tls_algorithms.ExtensionType.supported_groups);
-const ext_signature_algorithms: u16 = @intFromEnum(tls_algorithms.ExtensionType.signature_algorithms);
-const ext_alpn: u16 = @intFromEnum(tls_algorithms.ExtensionType.application_layer_protocol_negotiation);
-const ext_supported_versions: u16 = @intFromEnum(tls_algorithms.ExtensionType.supported_versions);
-const ext_key_share: u16 = @intFromEnum(tls_algorithms.ExtensionType.key_share);
+const ext_supported_groups: u16 = 10;
+const ext_signature_algorithms: u16 = 13;
+const ext_alpn: u16 = 16;
+const ext_supported_versions: u16 = 43;
+const ext_key_share: u16 = 51;
 /// RFC 9001 §8.2.
 const ext_quic_transport_parameters: u16 = 57;
 

--- a/src/tls/algorithms.zig
+++ b/src/tls/algorithms.zig
@@ -1,0 +1,67 @@
+//! TLS 1.3 algorithm and extension registries.
+//!
+//! These values are protocol identifiers, not implementation choices. The
+//! policy layer decides which identifiers are enabled and preferred for a
+//! particular transport or provider.
+
+const std = @import("std");
+
+pub const ProtocolVersion = enum(u16) {
+    tls13 = 0x0304,
+};
+
+pub const legacy_version: u16 = 0x0303;
+
+pub const CipherSuite = enum(u16) {
+    tls_aes_128_gcm_sha256 = 0x1301,
+    tls_aes_256_gcm_sha384 = 0x1302,
+    tls_chacha20_poly1305_sha256 = 0x1303,
+};
+
+pub const NamedGroup = enum(u16) {
+    x25519 = 0x001d,
+    secp256r1 = 0x0017,
+    secp384r1 = 0x0018,
+};
+
+pub const SignatureScheme = enum(u16) {
+    rsa_pkcs1_sha256 = 0x0401,
+    ecdsa_secp256r1_sha256 = 0x0403,
+    rsa_pss_rsae_sha256 = 0x0804,
+    ed25519 = 0x0807,
+};
+
+pub const ExtensionType = enum(u16) {
+    server_name = 0,
+    supported_groups = 10,
+    signature_algorithms = 13,
+    application_layer_protocol_negotiation = 16,
+    supported_versions = 43,
+    key_share = 51,
+    quic_transport_parameters = 57,
+};
+
+pub const ProtocolName = struct {
+    bytes: []const u8,
+
+    pub fn eql(self: ProtocolName, other: ProtocolName) bool {
+        return std.mem.eql(u8, self.bytes, other.bytes);
+    }
+};
+
+pub const alpn = struct {
+    pub const h3: ProtocolName = .{ .bytes = "h3" };
+    pub const h2: ProtocolName = .{ .bytes = "h2" };
+    pub const http_1_1: ProtocolName = .{ .bytes = "http/1.1" };
+};
+
+pub fn fromInt(comptime T: type, value: u16) ?T {
+    return std.enums.fromInt(T, value);
+}
+
+test "registry exposes current TLS identifiers" {
+    try std.testing.expectEqual(@as(u16, 0x1301), @intFromEnum(CipherSuite.tls_aes_128_gcm_sha256));
+    try std.testing.expectEqual(@as(u16, 0x001d), @intFromEnum(NamedGroup.x25519));
+    try std.testing.expectEqual(@as(u16, 0x0807), @intFromEnum(SignatureScheme.ed25519));
+    try std.testing.expect(alpn.h3.eql(.{ .bytes = "h3" }));
+}

--- a/src/tls/negotiation.zig
+++ b/src/tls/negotiation.zig
@@ -16,9 +16,10 @@ pub const Error = messages.Error || error{
     NoMutualSignatureScheme,
     NoMutualAlpn,
     MissingServerName,
+    OfferVectorTooLarge,
 };
 
-pub const max_offers = 16;
+pub const max_offers = 64;
 
 pub const KeyShareOffer = struct {
     group: algorithms.NamedGroup,
@@ -41,37 +42,37 @@ pub const ClientHelloOffers = struct {
     server_name: ?[]const u8 = null,
 
     fn appendVersion(self: *ClientHelloOffers, value: algorithms.ProtocolVersion) Error!void {
-        if (self.versions_len == self.versions.len) return error.MalformedExtension;
+        if (self.versions_len == self.versions.len) return error.OfferVectorTooLarge;
         self.versions[self.versions_len] = value;
         self.versions_len += 1;
     }
 
     fn appendCipherSuite(self: *ClientHelloOffers, value: algorithms.CipherSuite) Error!void {
-        if (self.cipher_suites_len == self.cipher_suites.len) return error.MalformedExtension;
+        if (self.cipher_suites_len == self.cipher_suites.len) return error.OfferVectorTooLarge;
         self.cipher_suites[self.cipher_suites_len] = value;
         self.cipher_suites_len += 1;
     }
 
     fn appendSupportedGroup(self: *ClientHelloOffers, value: algorithms.NamedGroup) Error!void {
-        if (self.supported_groups_len == self.supported_groups.len) return error.MalformedExtension;
+        if (self.supported_groups_len == self.supported_groups.len) return error.OfferVectorTooLarge;
         self.supported_groups[self.supported_groups_len] = value;
         self.supported_groups_len += 1;
     }
 
     fn appendKeyShare(self: *ClientHelloOffers, value: KeyShareOffer) Error!void {
-        if (self.key_shares_len == self.key_shares.len) return error.MalformedExtension;
+        if (self.key_shares_len == self.key_shares.len) return error.OfferVectorTooLarge;
         self.key_shares[self.key_shares_len] = value;
         self.key_shares_len += 1;
     }
 
     fn appendSignatureScheme(self: *ClientHelloOffers, value: algorithms.SignatureScheme) Error!void {
-        if (self.signature_schemes_len == self.signature_schemes.len) return error.MalformedExtension;
+        if (self.signature_schemes_len == self.signature_schemes.len) return error.OfferVectorTooLarge;
         self.signature_schemes[self.signature_schemes_len] = value;
         self.signature_schemes_len += 1;
     }
 
     fn appendAlpn(self: *ClientHelloOffers, value: algorithms.ProtocolName) Error!void {
-        if (self.alpn_protocols_len == self.alpn_protocols.len) return error.MalformedExtension;
+        if (self.alpn_protocols_len == self.alpn_protocols.len) return error.OfferVectorTooLarge;
         self.alpn_protocols[self.alpn_protocols_len] = value;
         self.alpn_protocols_len += 1;
     }
@@ -318,6 +319,23 @@ test "configured provider capabilities change negotiated tuples" {
     try testing.expectEqual(algorithms.CipherSuite.tls_chacha20_poly1305_sha256, selected.cipher_suite);
 }
 
+test "identity-constrained policy selects the active certificate signature scheme" {
+    const alpns = [_]algorithms.ProtocolName{algorithms.alpn.h3};
+    const p256_policy = try policy_mod.Policy.fromIdentity(.quic, .{}, &alpns, .ecdsa_secp256r1);
+
+    var offers = ClientHelloOffers{};
+    try offers.appendVersion(.tls13);
+    try offers.appendCipherSuite(.tls_aes_128_gcm_sha256);
+    try offers.appendSupportedGroup(.x25519);
+    try offers.appendKeyShare(.{ .group = .x25519, .key_exchange = "share" });
+    try offers.appendSignatureScheme(.ed25519);
+    try offers.appendSignatureScheme(.ecdsa_secp256r1_sha256);
+    try offers.appendAlpn(algorithms.alpn.h3);
+
+    const selected = try negotiateServer(p256_policy, &offers);
+    try testing.expectEqual(algorithms.SignatureScheme.ecdsa_secp256r1_sha256, selected.signature_scheme);
+}
+
 test "ClientHello parser feeds policy negotiation with ALPN and SNI offers" {
     var body: [256]u8 = undefined;
     var w = messages.Writer{ .buf = &body };
@@ -381,6 +399,16 @@ test "ClientHello parser feeds policy negotiation with ALPN and SNI offers" {
     try testing.expect(selected.alpn.eql(algorithms.alpn.h2));
     try testing.expectEqualStrings("example.test", selected.server_name.?);
     try testing.expectEqualStrings("share", selected.key_share);
+}
+
+test "recognized offer vectors allow general-purpose client sizes" {
+    var offers = ClientHelloOffers{};
+    try offers.appendVersion(.tls13);
+    for (0..max_offers) |_| {
+        try offers.appendSignatureScheme(.rsa_pkcs1_sha256);
+    }
+    try testing.expectEqual(@as(usize, max_offers), offers.signature_schemes_len);
+    try testing.expectError(error.OfferVectorTooLarge, offers.appendSignatureScheme(.ed25519));
 }
 
 test "negotiation reports no-overlap failures without logging offer contents" {

--- a/src/tls/negotiation.zig
+++ b/src/tls/negotiation.zig
@@ -1,0 +1,432 @@
+//! Policy-driven TLS 1.3 ClientHello negotiation.
+
+const std = @import("std");
+const algorithms = @import("algorithms.zig");
+const messages = @import("messages.zig");
+const policy_mod = @import("policy.zig");
+
+pub const Error = messages.Error || error{
+    MalformedExtension,
+    MissingSupportedVersions,
+    UnsupportedProtocolVersion,
+    MissingCipherSuites,
+    NoMutualCipherSuite,
+    NoMutualNamedGroup,
+    MissingKeyShare,
+    NoMutualSignatureScheme,
+    NoMutualAlpn,
+    MissingServerName,
+};
+
+pub const max_offers = 16;
+
+pub const KeyShareOffer = struct {
+    group: algorithms.NamedGroup,
+    key_exchange: []const u8,
+};
+
+pub const ClientHelloOffers = struct {
+    versions: [max_offers]algorithms.ProtocolVersion = undefined,
+    versions_len: usize = 0,
+    cipher_suites: [max_offers]algorithms.CipherSuite = undefined,
+    cipher_suites_len: usize = 0,
+    supported_groups: [max_offers]algorithms.NamedGroup = undefined,
+    supported_groups_len: usize = 0,
+    key_shares: [max_offers]KeyShareOffer = undefined,
+    key_shares_len: usize = 0,
+    signature_schemes: [max_offers]algorithms.SignatureScheme = undefined,
+    signature_schemes_len: usize = 0,
+    alpn_protocols: [max_offers]algorithms.ProtocolName = undefined,
+    alpn_protocols_len: usize = 0,
+    server_name: ?[]const u8 = null,
+
+    fn appendVersion(self: *ClientHelloOffers, value: algorithms.ProtocolVersion) Error!void {
+        if (self.versions_len == self.versions.len) return error.MalformedExtension;
+        self.versions[self.versions_len] = value;
+        self.versions_len += 1;
+    }
+
+    fn appendCipherSuite(self: *ClientHelloOffers, value: algorithms.CipherSuite) Error!void {
+        if (self.cipher_suites_len == self.cipher_suites.len) return error.MalformedExtension;
+        self.cipher_suites[self.cipher_suites_len] = value;
+        self.cipher_suites_len += 1;
+    }
+
+    fn appendSupportedGroup(self: *ClientHelloOffers, value: algorithms.NamedGroup) Error!void {
+        if (self.supported_groups_len == self.supported_groups.len) return error.MalformedExtension;
+        self.supported_groups[self.supported_groups_len] = value;
+        self.supported_groups_len += 1;
+    }
+
+    fn appendKeyShare(self: *ClientHelloOffers, value: KeyShareOffer) Error!void {
+        if (self.key_shares_len == self.key_shares.len) return error.MalformedExtension;
+        self.key_shares[self.key_shares_len] = value;
+        self.key_shares_len += 1;
+    }
+
+    fn appendSignatureScheme(self: *ClientHelloOffers, value: algorithms.SignatureScheme) Error!void {
+        if (self.signature_schemes_len == self.signature_schemes.len) return error.MalformedExtension;
+        self.signature_schemes[self.signature_schemes_len] = value;
+        self.signature_schemes_len += 1;
+    }
+
+    fn appendAlpn(self: *ClientHelloOffers, value: algorithms.ProtocolName) Error!void {
+        if (self.alpn_protocols_len == self.alpn_protocols.len) return error.MalformedExtension;
+        self.alpn_protocols[self.alpn_protocols_len] = value;
+        self.alpn_protocols_len += 1;
+    }
+
+    pub fn containsVersion(self: *const ClientHelloOffers, value: algorithms.ProtocolVersion) bool {
+        return containsEnum(algorithms.ProtocolVersion, self.versions[0..self.versions_len], value);
+    }
+
+    pub fn keyShareFor(self: *const ClientHelloOffers, group: algorithms.NamedGroup) ?[]const u8 {
+        for (self.key_shares[0..self.key_shares_len]) |share| {
+            if (share.group == group) return share.key_exchange;
+        }
+        return null;
+    }
+};
+
+pub const Selection = struct {
+    version: algorithms.ProtocolVersion,
+    cipher_suite: algorithms.CipherSuite,
+    named_group: algorithms.NamedGroup,
+    key_share: []const u8,
+    signature_scheme: algorithms.SignatureScheme,
+    alpn: algorithms.ProtocolName,
+    server_name: ?[]const u8,
+};
+
+pub fn parseClientHello(body: []const u8) Error!ClientHelloOffers {
+    var offers = ClientHelloOffers{};
+    var r = messages.Reader{ .bytes = body };
+    if (try r.u16_() != algorithms.legacy_version) return error.MalformedHandshake;
+    _ = try r.slice(32);
+    _ = try r.slice(try r.u8_());
+
+    var cipher_reader = messages.Reader{ .bytes = try r.slice(try r.u16_()) };
+    if (cipher_reader.remaining() == 0 or cipher_reader.remaining() % 2 != 0) return error.MissingCipherSuites;
+    while (cipher_reader.remaining() > 0) {
+        if (algorithms.fromInt(algorithms.CipherSuite, try cipher_reader.u16_())) |cipher| {
+            try offers.appendCipherSuite(cipher);
+        }
+    }
+
+    var compression_reader = messages.Reader{ .bytes = try r.slice(try r.u8_()) };
+    var has_null_compression = false;
+    while (compression_reader.remaining() > 0) {
+        if (try compression_reader.u8_() == 0) has_null_compression = true;
+    }
+    if (!has_null_compression) return error.MalformedHandshake;
+
+    var extensions = messages.ExtensionIterator.init(try r.slice(try r.u16_()));
+    try r.expectEnd();
+    while (try extensions.next()) |extension| {
+        switch (algorithms.fromInt(algorithms.ExtensionType, extension.id) orelse continue) {
+            .supported_versions => try parseSupportedVersions(extension.data, &offers),
+            .supported_groups => try parseSupportedGroups(extension.data, &offers),
+            .signature_algorithms => try parseSignatureAlgorithms(extension.data, &offers),
+            .key_share => try parseKeyShares(extension.data, &offers),
+            .server_name => try parseServerName(extension.data, &offers),
+            .application_layer_protocol_negotiation => try parseAlpn(extension.data, &offers),
+            else => {},
+        }
+    }
+    if (offers.versions_len == 0) return error.MissingSupportedVersions;
+    return offers;
+}
+
+pub fn negotiateServer(policy: policy_mod.Policy, offers: *const ClientHelloOffers) Error!Selection {
+    if (!offers.containsVersion(.tls13)) return error.UnsupportedProtocolVersion;
+    if (policy.require_sni and offers.server_name == null) return error.MissingServerName;
+    const cipher_suite = pickEnum(algorithms.CipherSuite, policy.cipher_suites, offers.cipher_suites[0..offers.cipher_suites_len]) orelse
+        return error.NoMutualCipherSuite;
+    const named_group = pickEnum(algorithms.NamedGroup, policy.named_groups, offers.supported_groups[0..offers.supported_groups_len]) orelse
+        return error.NoMutualNamedGroup;
+    const key_share = offers.keyShareFor(named_group) orelse return error.MissingKeyShare;
+    const signature_scheme = pickEnum(algorithms.SignatureScheme, policy.signature_schemes, offers.signature_schemes[0..offers.signature_schemes_len]) orelse
+        return error.NoMutualSignatureScheme;
+    const alpn = pickAlpn(policy.alpn_protocols, offers.alpn_protocols[0..offers.alpn_protocols_len]) orelse
+        return error.NoMutualAlpn;
+    return .{
+        .version = .tls13,
+        .cipher_suite = cipher_suite,
+        .named_group = named_group,
+        .key_share = key_share,
+        .signature_scheme = signature_scheme,
+        .alpn = alpn,
+        .server_name = offers.server_name,
+    };
+}
+
+pub const ServerSelection = struct {
+    version: algorithms.ProtocolVersion,
+    cipher_suite: algorithms.CipherSuite,
+    named_group: algorithms.NamedGroup,
+    alpn: algorithms.ProtocolName,
+};
+
+pub fn validateServerSelection(policy: policy_mod.Policy, selection: ServerSelection) Error!void {
+    if (selection.version != .tls13) return error.UnsupportedProtocolVersion;
+    if (!containsEnum(algorithms.CipherSuite, policy.cipher_suites, selection.cipher_suite)) return error.NoMutualCipherSuite;
+    if (!containsEnum(algorithms.NamedGroup, policy.named_groups, selection.named_group)) return error.NoMutualNamedGroup;
+    if (!containsAlpn(policy.alpn_protocols, selection.alpn)) return error.NoMutualAlpn;
+}
+
+fn parseSupportedVersions(bytes: []const u8, offers: *ClientHelloOffers) Error!void {
+    var r = messages.Reader{ .bytes = bytes };
+    var versions = messages.Reader{ .bytes = try r.slice(try r.u8_()) };
+    try r.expectEnd();
+    if (versions.remaining() == 0 or versions.remaining() % 2 != 0) return error.MalformedExtension;
+    while (versions.remaining() > 0) {
+        if (algorithms.fromInt(algorithms.ProtocolVersion, try versions.u16_())) |version| {
+            try offers.appendVersion(version);
+        }
+    }
+}
+
+fn parseSupportedGroups(bytes: []const u8, offers: *ClientHelloOffers) Error!void {
+    var r = messages.Reader{ .bytes = bytes };
+    var groups = messages.Reader{ .bytes = try r.slice(try r.u16_()) };
+    try r.expectEnd();
+    if (groups.remaining() == 0 or groups.remaining() % 2 != 0) return error.MalformedExtension;
+    while (groups.remaining() > 0) {
+        if (algorithms.fromInt(algorithms.NamedGroup, try groups.u16_())) |group| {
+            try offers.appendSupportedGroup(group);
+        }
+    }
+}
+
+fn parseSignatureAlgorithms(bytes: []const u8, offers: *ClientHelloOffers) Error!void {
+    var r = messages.Reader{ .bytes = bytes };
+    var algorithms_reader = messages.Reader{ .bytes = try r.slice(try r.u16_()) };
+    try r.expectEnd();
+    if (algorithms_reader.remaining() == 0 or algorithms_reader.remaining() % 2 != 0) return error.MalformedExtension;
+    while (algorithms_reader.remaining() > 0) {
+        if (algorithms.fromInt(algorithms.SignatureScheme, try algorithms_reader.u16_())) |scheme| {
+            try offers.appendSignatureScheme(scheme);
+        }
+    }
+}
+
+fn parseKeyShares(bytes: []const u8, offers: *ClientHelloOffers) Error!void {
+    var r = messages.Reader{ .bytes = bytes };
+    var shares = messages.Reader{ .bytes = try r.slice(try r.u16_()) };
+    try r.expectEnd();
+    while (shares.remaining() > 0) {
+        const group_id = try shares.u16_();
+        const share = try shares.slice(try shares.u16_());
+        if (algorithms.fromInt(algorithms.NamedGroup, group_id)) |group| {
+            try offers.appendKeyShare(.{ .group = group, .key_exchange = share });
+        }
+    }
+}
+
+fn parseServerName(bytes: []const u8, offers: *ClientHelloOffers) Error!void {
+    var r = messages.Reader{ .bytes = bytes };
+    var names = messages.Reader{ .bytes = try r.slice(try r.u16_()) };
+    try r.expectEnd();
+    while (names.remaining() > 0) {
+        const name_type = try names.u8_();
+        const name = try names.slice(try names.u16_());
+        if (name_type == 0 and offers.server_name == null) offers.server_name = name;
+    }
+}
+
+fn parseAlpn(bytes: []const u8, offers: *ClientHelloOffers) Error!void {
+    var r = messages.Reader{ .bytes = bytes };
+    var protocols = messages.Reader{ .bytes = try r.slice(try r.u16_()) };
+    try r.expectEnd();
+    while (protocols.remaining() > 0) {
+        const name = try protocols.slice(try protocols.u8_());
+        if (name.len == 0) return error.MalformedExtension;
+        try offers.appendAlpn(.{ .bytes = name });
+    }
+}
+
+fn pickEnum(comptime T: type, local_preference: []const T, peer_offers: []const T) ?T {
+    for (local_preference) |local| {
+        if (containsEnum(T, peer_offers, local)) return local;
+    }
+    return null;
+}
+
+fn containsEnum(comptime T: type, list: []const T, value: T) bool {
+    for (list) |item| {
+        if (item == value) return true;
+    }
+    return false;
+}
+
+fn pickAlpn(local_preference: []const algorithms.ProtocolName, peer_offers: []const algorithms.ProtocolName) ?algorithms.ProtocolName {
+    for (local_preference) |local| {
+        if (containsAlpn(peer_offers, local)) return local;
+    }
+    return null;
+}
+
+fn containsAlpn(list: []const algorithms.ProtocolName, value: algorithms.ProtocolName) bool {
+    for (list) |item| {
+        if (item.eql(value)) return true;
+    }
+    return false;
+}
+
+const testing = std.testing;
+
+test "server negotiation follows policy preference order and surfaces SNI" {
+    var offers = ClientHelloOffers{};
+    try offers.appendVersion(.tls13);
+    try offers.appendCipherSuite(.tls_chacha20_poly1305_sha256);
+    try offers.appendCipherSuite(.tls_aes_128_gcm_sha256);
+    try offers.appendSupportedGroup(.x25519);
+    try offers.appendKeyShare(.{ .group = .x25519, .key_exchange = "share" });
+    try offers.appendSignatureScheme(.ed25519);
+    try offers.appendAlpn(algorithms.alpn.http_1_1);
+    try offers.appendAlpn(algorithms.alpn.h2);
+    offers.server_name = "example.test";
+
+    const selected = try negotiateServer(policy_mod.Policy.recordDefault(), &offers);
+    try testing.expectEqual(algorithms.CipherSuite.tls_aes_128_gcm_sha256, selected.cipher_suite);
+    try testing.expectEqual(algorithms.NamedGroup.x25519, selected.named_group);
+    try testing.expectEqual(algorithms.SignatureScheme.ed25519, selected.signature_scheme);
+    try testing.expect(selected.alpn.eql(algorithms.alpn.h2));
+    try testing.expectEqualStrings("example.test", selected.server_name.?);
+}
+
+test "configured provider capabilities change negotiated tuples" {
+    const ciphers = [_]algorithms.CipherSuite{.tls_chacha20_poly1305_sha256};
+    const groups = [_]algorithms.NamedGroup{.x25519};
+    const signatures = [_]algorithms.SignatureScheme{.ed25519};
+    const alpns = [_]algorithms.ProtocolName{algorithms.alpn.h3};
+    const configured = policy_mod.Policy.fromCapabilities(.quic, .{
+        .cipher_suites = &ciphers,
+        .named_groups = &groups,
+        .signature_schemes = &signatures,
+    }, &alpns);
+
+    var offers = ClientHelloOffers{};
+    try offers.appendVersion(.tls13);
+    try offers.appendCipherSuite(.tls_chacha20_poly1305_sha256);
+    try offers.appendSupportedGroup(.x25519);
+    try offers.appendKeyShare(.{ .group = .x25519, .key_exchange = "share" });
+    try offers.appendSignatureScheme(.ed25519);
+    try offers.appendAlpn(algorithms.alpn.h3);
+
+    const selected = try negotiateServer(configured, &offers);
+    try testing.expectEqual(algorithms.CipherSuite.tls_chacha20_poly1305_sha256, selected.cipher_suite);
+}
+
+test "ClientHello parser feeds policy negotiation with ALPN and SNI offers" {
+    var body: [256]u8 = undefined;
+    var w = messages.Writer{ .buf = &body };
+    try w.u16_(algorithms.legacy_version);
+    try w.bytes(&([_]u8{0} ** 32));
+    try w.u8_(0);
+    try w.u16_(4);
+    try w.u16_(@intFromEnum(algorithms.CipherSuite.tls_chacha20_poly1305_sha256));
+    try w.u16_(@intFromEnum(algorithms.CipherSuite.tls_aes_128_gcm_sha256));
+    try w.u8_(1);
+    try w.u8_(0);
+
+    const extensions_len = try w.reserve(2);
+    try w.u16_(@intFromEnum(algorithms.ExtensionType.supported_versions));
+    try w.u16_(3);
+    try w.u8_(2);
+    try w.u16_(@intFromEnum(algorithms.ProtocolVersion.tls13));
+
+    try w.u16_(@intFromEnum(algorithms.ExtensionType.supported_groups));
+    try w.u16_(4);
+    try w.u16_(2);
+    try w.u16_(@intFromEnum(algorithms.NamedGroup.x25519));
+
+    try w.u16_(@intFromEnum(algorithms.ExtensionType.signature_algorithms));
+    try w.u16_(4);
+    try w.u16_(2);
+    try w.u16_(@intFromEnum(algorithms.SignatureScheme.ed25519));
+
+    try w.u16_(@intFromEnum(algorithms.ExtensionType.key_share));
+    const key_share_ext = try w.reserve(2);
+    const key_shares = try w.reserve(2);
+    try w.u16_(@intFromEnum(algorithms.NamedGroup.x25519));
+    try w.u16_(5);
+    try w.bytes("share");
+    w.patch(2, key_shares);
+    w.patch(2, key_share_ext);
+
+    try w.u16_(@intFromEnum(algorithms.ExtensionType.server_name));
+    const sni_ext = try w.reserve(2);
+    const sni_list = try w.reserve(2);
+    try w.u8_(0);
+    try w.u16_(12);
+    try w.bytes("example.test");
+    w.patch(2, sni_list);
+    w.patch(2, sni_ext);
+
+    try w.u16_(@intFromEnum(algorithms.ExtensionType.application_layer_protocol_negotiation));
+    const alpn_ext = try w.reserve(2);
+    const alpn_list = try w.reserve(2);
+    try w.u8_(2);
+    try w.bytes("h2");
+    try w.u8_(8);
+    try w.bytes("http/1.1");
+    w.patch(2, alpn_list);
+    w.patch(2, alpn_ext);
+    w.patch(2, extensions_len);
+
+    const offers = try parseClientHello(w.written());
+    const selected = try negotiateServer(policy_mod.Policy.recordDefault(), &offers);
+    try testing.expectEqual(algorithms.CipherSuite.tls_aes_128_gcm_sha256, selected.cipher_suite);
+    try testing.expect(selected.alpn.eql(algorithms.alpn.h2));
+    try testing.expectEqualStrings("example.test", selected.server_name.?);
+    try testing.expectEqualStrings("share", selected.key_share);
+}
+
+test "negotiation reports no-overlap failures without logging offer contents" {
+    var offers = ClientHelloOffers{};
+    try offers.appendVersion(.tls13);
+    try offers.appendCipherSuite(.tls_chacha20_poly1305_sha256);
+    try offers.appendSupportedGroup(.x25519);
+    try offers.appendKeyShare(.{ .group = .x25519, .key_exchange = "share" });
+    try offers.appendSignatureScheme(.ed25519);
+    try offers.appendAlpn(algorithms.alpn.h3);
+
+    try testing.expectError(error.NoMutualCipherSuite, negotiateServer(policy_mod.Policy.quicDefault(), &offers));
+}
+
+test "client validates server selection against configured policy" {
+    try validateServerSelection(policy_mod.Policy.quicDefault(), .{
+        .version = .tls13,
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .named_group = .x25519,
+        .alpn = algorithms.alpn.h3,
+    });
+
+    try testing.expectError(error.NoMutualAlpn, validateServerSelection(policy_mod.Policy.quicDefault(), .{
+        .version = .tls13,
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .named_group = .x25519,
+        .alpn = algorithms.alpn.h2,
+    }));
+}
+
+test "malformed required extensions fail deterministically" {
+    var body: [128]u8 = undefined;
+    var w = messages.Writer{ .buf = &body };
+    try w.u16_(algorithms.legacy_version);
+    try w.bytes(&([_]u8{0} ** 32));
+    try w.u8_(0);
+    try w.u16_(2);
+    try w.u16_(@intFromEnum(algorithms.CipherSuite.tls_aes_128_gcm_sha256));
+    try w.u8_(1);
+    try w.u8_(0);
+    const extensions_len = try w.reserve(2);
+    try w.u16_(@intFromEnum(algorithms.ExtensionType.supported_versions));
+    try w.u16_(2);
+    try w.u8_(2);
+    try w.u8_(0x03);
+    w.patch(2, extensions_len);
+
+    try testing.expectError(error.MalformedHandshake, parseClientHello(w.written()));
+}

--- a/src/tls/policy.zig
+++ b/src/tls/policy.zig
@@ -10,9 +10,18 @@ pub const ProtocolName = algorithms.ProtocolName;
 
 const default_cipher_suites = [_]CipherSuite{.tls_aes_128_gcm_sha256};
 const default_named_groups = [_]NamedGroup{.x25519};
-const default_signature_schemes = [_]SignatureScheme{.ed25519};
+const default_signature_schemes = [_]SignatureScheme{ .ecdsa_secp256r1_sha256, .ed25519 };
+const ed25519_signature_schemes = [_]SignatureScheme{.ed25519};
+const ecdsa_p256_signature_schemes = [_]SignatureScheme{.ecdsa_secp256r1_sha256};
 const quic_alpns = [_]ProtocolName{algorithms.alpn.h3};
 const record_alpns = [_]ProtocolName{ algorithms.alpn.h2, algorithms.alpn.http_1_1 };
+
+pub const Error = error{UnsupportedIdentitySignature};
+
+pub const IdentityKey = enum {
+    ed25519,
+    ecdsa_secp256r1,
+};
 
 pub const Capabilities = struct {
     cipher_suites: []const CipherSuite = &default_cipher_suites,
@@ -57,7 +66,35 @@ pub const Policy = struct {
             .alpn_protocols = alpn_protocols,
         };
     }
+
+    pub fn fromIdentity(transport_mode: state.TransportMode, capabilities: Capabilities, alpn_protocols: []const ProtocolName, identity_key: IdentityKey) Error!Policy {
+        const identity_schemes = signatureSchemesForIdentity(identity_key);
+        for (identity_schemes) |scheme| {
+            if (!containsSignature(capabilities.signature_schemes, scheme)) return error.UnsupportedIdentitySignature;
+        }
+        return .{
+            .transport_mode = transport_mode,
+            .cipher_suites = capabilities.cipher_suites,
+            .named_groups = capabilities.named_groups,
+            .signature_schemes = identity_schemes,
+            .alpn_protocols = alpn_protocols,
+        };
+    }
 };
+
+pub fn signatureSchemesForIdentity(identity_key: IdentityKey) []const SignatureScheme {
+    return switch (identity_key) {
+        .ed25519 => &ed25519_signature_schemes,
+        .ecdsa_secp256r1 => &ecdsa_p256_signature_schemes,
+    };
+}
+
+fn containsSignature(schemes: []const SignatureScheme, needle: SignatureScheme) bool {
+    for (schemes) |scheme| {
+        if (scheme == needle) return true;
+    }
+    return false;
+}
 
 test "default policies keep QUIC and record ALPN choices separate" {
     const quic = Policy.quicDefault();
@@ -66,4 +103,16 @@ test "default policies keep QUIC and record ALPN choices separate" {
     const record = Policy.recordDefault();
     try @import("std").testing.expect(record.alpn_protocols[0].eql(algorithms.alpn.h2));
     try @import("std").testing.expect(record.alpn_protocols[1].eql(algorithms.alpn.http_1_1));
+}
+
+test "identity policies constrain usable signature schemes" {
+    const std = @import("std");
+    const alpns = [_]ProtocolName{algorithms.alpn.h3};
+
+    const p256 = try Policy.fromIdentity(.quic, .{}, &alpns, .ecdsa_secp256r1);
+    try std.testing.expectEqual(@as(usize, 1), p256.signature_schemes.len);
+    try std.testing.expectEqual(SignatureScheme.ecdsa_secp256r1_sha256, p256.signature_schemes[0]);
+
+    const ed25519_only = Capabilities{ .signature_schemes = &ed25519_signature_schemes };
+    try std.testing.expectError(error.UnsupportedIdentitySignature, Policy.fromIdentity(.quic, ed25519_only, &alpns, .ecdsa_secp256r1));
 }

--- a/src/tls/policy.zig
+++ b/src/tls/policy.zig
@@ -1,0 +1,69 @@
+//! TLS negotiation policy and provider capability vocabulary.
+
+const state = @import("state.zig");
+const algorithms = @import("algorithms.zig");
+
+pub const CipherSuite = algorithms.CipherSuite;
+pub const NamedGroup = algorithms.NamedGroup;
+pub const SignatureScheme = algorithms.SignatureScheme;
+pub const ProtocolName = algorithms.ProtocolName;
+
+const default_cipher_suites = [_]CipherSuite{.tls_aes_128_gcm_sha256};
+const default_named_groups = [_]NamedGroup{.x25519};
+const default_signature_schemes = [_]SignatureScheme{.ed25519};
+const quic_alpns = [_]ProtocolName{algorithms.alpn.h3};
+const record_alpns = [_]ProtocolName{ algorithms.alpn.h2, algorithms.alpn.http_1_1 };
+
+pub const Capabilities = struct {
+    cipher_suites: []const CipherSuite = &default_cipher_suites,
+    named_groups: []const NamedGroup = &default_named_groups,
+    signature_schemes: []const SignatureScheme = &default_signature_schemes,
+};
+
+pub const Policy = struct {
+    transport_mode: state.TransportMode,
+    cipher_suites: []const CipherSuite,
+    named_groups: []const NamedGroup,
+    signature_schemes: []const SignatureScheme,
+    alpn_protocols: []const ProtocolName,
+    require_sni: bool = false,
+
+    pub fn quicDefault() Policy {
+        return .{
+            .transport_mode = .quic,
+            .cipher_suites = &default_cipher_suites,
+            .named_groups = &default_named_groups,
+            .signature_schemes = &default_signature_schemes,
+            .alpn_protocols = &quic_alpns,
+        };
+    }
+
+    pub fn recordDefault() Policy {
+        return .{
+            .transport_mode = .record,
+            .cipher_suites = &default_cipher_suites,
+            .named_groups = &default_named_groups,
+            .signature_schemes = &default_signature_schemes,
+            .alpn_protocols = &record_alpns,
+        };
+    }
+
+    pub fn fromCapabilities(transport_mode: state.TransportMode, capabilities: Capabilities, alpn_protocols: []const ProtocolName) Policy {
+        return .{
+            .transport_mode = transport_mode,
+            .cipher_suites = capabilities.cipher_suites,
+            .named_groups = capabilities.named_groups,
+            .signature_schemes = capabilities.signature_schemes,
+            .alpn_protocols = alpn_protocols,
+        };
+    }
+};
+
+test "default policies keep QUIC and record ALPN choices separate" {
+    const quic = Policy.quicDefault();
+    try @import("std").testing.expect(quic.alpn_protocols[0].eql(algorithms.alpn.h3));
+
+    const record = Policy.recordDefault();
+    try @import("std").testing.expect(record.alpn_protocols[0].eql(algorithms.alpn.h2));
+    try @import("std").testing.expect(record.alpn_protocols[1].eql(algorithms.alpn.http_1_1));
+}

--- a/src/tls/root.zig
+++ b/src/tls/root.zig
@@ -1,8 +1,11 @@
 pub const engine = @import("engine.zig");
 pub const state = @import("state.zig");
 pub const events = @import("events.zig");
+pub const algorithms = @import("algorithms.zig");
 pub const key_schedule = @import("key_schedule.zig");
 pub const messages = @import("messages.zig");
+pub const negotiation = @import("negotiation.zig");
+pub const policy = @import("policy.zig");
 pub const transcript = @import("transcript.zig");
 
 test {


### PR DESCRIPTION
## Summary
- add shared TLS 1.3 registries for protocol versions, cipher suites, named groups, signature schemes, extension ids, and ALPN names
- add policy/capability defaults for QUIC and record-mode negotiation
- add ClientHello offer parsing and policy-driven server/client selection helpers with deterministic diagnostics
- point the existing QUIC TLS backend constants at the shared registry while preserving current behavior

## Tests
- `zig fmt build.zig src/ tests/ --check`
- `git diff --check`
- `zig build test-tls --summary all --error-style verbose`
- `zig build test-quic --summary all --error-style verbose`
- `zig build test --summary all --error-style verbose`

Closes #331
