### PR TITLE
docs(readme): reflect native HTTP/3 QUIC stack in the Overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,9 @@ proxying, and response writes.
 
 Idle HTTP/1.1 keep-alive connections are parked off the worker pool between
 requests, so idle clients do not consume worker capacity. HTTP/2 multiplexes
-internally and is tracked as an experimental surface rather than part of the
-default stable release contract.
+internally, and HTTP/3 is served over a built-in native Zig QUIC/H3 stack that
+needs no external QUIC libraries. Both HTTP/2 and HTTP/3 are tracked as
+experimental surfaces rather than part of the default stable release contract.
 
 Configuration is nginx-inspired and can be checked before startup with
 `tardigrade check <config>`. Runtime inspection commands such as `status` and


### PR DESCRIPTION
**What changed and why**
The README Overview described HTTP/2 as an experimental surface but said nothing about HTTP/3, even though the native Zig QUIC/H3 stack has since replaced ngtcp2/nghttp3 (#384, #328). This updates the Overview to mention HTTP/3 alongside HTTP/2 and to note it runs on the built-in stack with no external QUIC libraries.

Scope is deliberately narrow — the HTTP/1.1 tagline and the stable Features list are unchanged, since Core v1 remains HTTP/1.1 and HTTP/2·3 stay experimental. No stale ngtcp2/nghttp3 references remained in the README; the Build-from-source section already documented the native stack.

**Related issues**
Follow-up to #384 / #328.

**Tests**
None — documentation only.

**Security impact**
None.

**Performance impact**
None.

**Checklist**
- [x] Documentation-only change
- [x] No stale external-QUIC-library references remain in the README