### PR TITLE
tls: extract shared handshake vocabulary

### DIFF
--- a/docs/QUIC_TLS.md
+++ b/docs/QUIC_TLS.md
@@ -30,10 +30,13 @@ CRYPTO-frame transport and packet-key installation.**
 2. `src/tls/` is the protocol-neutral TLS 1.3 core. `state.zig` defines roles,
    handshake states, and the explicit `quic` versus `record` transport modes;
    `events.zig` defines transport-neutral handshake byte, traffic-secret,
-   certificate, ALPN, discard, and completion events; `key_schedule.zig` owns
+   certificate, ALPN, discard, completion, and TLS-level typed failure
+   vocabulary shared by QUIC and future record mode; `key_schedule.zig` owns
    the SHA-256 TLS 1.3 key schedule with no QUIC, HTTP, socket, or record-layer
    imports; and `engine.zig` is the shared shell that can be instantiated for
-   record mode before records exist.
+   record mode before records exist. QUIC-only failures, such as CRYPTO-level
+   misuse or missing QUIC transport parameters, stay in the QUIC handshake
+   driver.
 
 3. `src/quic/tls_backend.zig` is the concrete production adapter from that core
    to QUIC mode. It consumes and produces raw handshake messages per encryption

--- a/src/quic/tls_adapter.zig
+++ b/src/quic/tls_adapter.zig
@@ -19,6 +19,7 @@
 const std = @import("std");
 const config = @import("config.zig");
 const packet = @import("packet.zig");
+const tls_core = @import("tls_core");
 
 const crypto = std.crypto;
 const tls = std.crypto.tls;
@@ -81,21 +82,14 @@ pub const PacketNumberSpace = enum {
     application,
 };
 
-pub const Direction = enum {
-    read,
-    write,
-};
+pub const Direction = tls_core.events.SecretDirection;
 
 pub const Perspective = enum {
     client,
     server,
 };
 
-pub const CertificateState = enum {
-    not_checked,
-    valid,
-    invalid,
-};
+pub const CertificateState = tls_core.events.CertificateState;
 
 pub const KeyPhase = enum {
     current,

--- a/src/quic/tls_handshake.zig
+++ b/src/quic/tls_handshake.zig
@@ -17,6 +17,7 @@
 const std = @import("std");
 const config = @import("config.zig");
 const tls_adapter = @import("tls_adapter.zig");
+const tls_core = @import("tls_core");
 
 const EncryptionLevel = tls_adapter.EncryptionLevel;
 const Direction = tls_adapter.Direction;
@@ -25,26 +26,16 @@ const Secret = tls_adapter.Secret;
 const QuicTlsAdapter = tls_adapter.QuicTlsAdapter;
 const traffic_secret_len = tls_adapter.traffic_secret_len;
 
-pub const Role = enum { client, server };
+pub const Role = tls_core.state.Role;
 
-/// Typed, deterministic handshake failures. The connection layer maps these to
-/// the right QUIC CONNECTION_CLOSE codes later; the driver only classifies.
-pub const HandshakeError = error{
+pub const HandshakeError = tls_core.events.HandshakeError || error{
     /// A CRYPTO fragment arrived at a level the handshake never uses (0-RTT).
     UnexpectedCryptoLevel,
-    /// The backend could not parse the peer's TLS handshake bytes.
-    MalformedHandshake,
-    /// ALPN did not negotiate exactly `h3`.
-    AlpnMismatch,
-    /// Peer certificate was rejected by the backend.
-    CertificateInvalid,
-    /// Handshake completed without the peer's transport parameters.
+    /// Handshake completed without the peer's QUIC transport parameters.
     MissingTransportParameters,
-    /// Peer transport parameters were malformed or carried an illegal value.
+    /// Peer QUIC transport parameters were malformed or carried an illegal value.
     InvalidTransportParameters,
-    /// A traffic secret could not be installed (wrong length from the backend).
-    SecretExportFailed,
-    /// The backend emitted more output than the driver can buffer in one step.
+    /// The backend or driver emitted more output than this bounded QUIC seam can buffer.
     HandshakeBufferOverflow,
 };
 
@@ -159,7 +150,7 @@ pub const TlsBackend = struct {
     }
 };
 
-pub const State = enum { idle, in_progress, complete, failed };
+pub const State = tls_core.state.DriverState;
 
 /// The connection-facing QUIC handshake driver. A QUIC connection calls
 /// `start`, then pumps `onCrypto` / `pollOutput` per encryption level until

--- a/src/tls/events.zig
+++ b/src/tls/events.zig
@@ -1,8 +1,33 @@
-//! Protocol-neutral events emitted by the TLS 1.3 core.
+//! Protocol-neutral TLS 1.3 event and failure vocabulary.
+//!
+//! The concrete transport integrations own their framing. QUIC maps these
+//! concepts to CRYPTO streams and packet-protection keys; future TCP record
+//! mode maps the same concepts to TLS records and encrypted byte streams.
 
-pub const EncryptionEpoch = enum { initial, handshake, application };
+pub const EncryptionEpoch = enum {
+    initial,
+    zero_rtt,
+    handshake,
+    application,
+};
+
 pub const SecretDirection = enum { read, write };
 pub const CertificateState = enum { not_checked, valid, invalid };
+
+/// Typed, deterministic TLS handshake failures. Transport layers translate
+/// these into their own close/error surfaces without losing the TLS reason.
+pub const HandshakeError = error{
+    /// The peer's TLS handshake bytes were malformed or arrived in an illegal
+    /// order.
+    MalformedHandshake,
+    /// ALPN did not negotiate an acceptable application protocol.
+    AlpnMismatch,
+    /// The peer certificate was rejected by local policy or failed proof of key
+    /// possession.
+    CertificateInvalid,
+    /// A traffic secret could not be exported or installed.
+    SecretExportFailed,
+};
 
 pub const Event = union(enum) {
     handshake_bytes: struct { epoch: EncryptionEpoch, data: []const u8 },
@@ -12,3 +37,27 @@ pub const Event = union(enum) {
     discard_epoch: EncryptionEpoch,
     handshake_complete,
 };
+
+test "event vocabulary covers QUIC and record-mode TLS lifecycles" {
+    const std = @import("std");
+
+    const secret_event = Event{
+        .traffic_secret = .{
+            .epoch = .handshake,
+            .direction = .write,
+            .data = "secret",
+        },
+    };
+    try std.testing.expectEqual(EncryptionEpoch.handshake, secret_event.traffic_secret.epoch);
+    try std.testing.expectEqual(SecretDirection.write, secret_event.traffic_secret.direction);
+
+    const cert_event = Event{ .certificate = .valid };
+    try std.testing.expectEqual(CertificateState.valid, cert_event.certificate);
+}
+
+test "shared handshake errors include transport-required failure cases" {
+    const std = @import("std");
+
+    const err: HandshakeError = error.MalformedHandshake;
+    try std.testing.expectEqual(error.MalformedHandshake, err);
+}

--- a/src/tls/state.zig
+++ b/src/tls/state.zig
@@ -20,3 +20,10 @@ pub const HandshakeState = enum {
     finished,
     complete,
 };
+
+pub const DriverState = enum {
+    idle,
+    in_progress,
+    complete,
+    failed,
+};


### PR DESCRIPTION
## Summary
- move shared TLS certificate state, secret direction, TLS-level handshake errors, and driver lifecycle vocabulary into the protocol-neutral tls_core package
- make the QUIC TLS adapter and handshake driver import the shared core vocabulary while keeping QUIC-specific failures local to the QUIC handshake seam
- document the shared QUIC/record-mode ownership boundary in docs/QUIC_TLS.md

Part of #329.

## Validation
- zig fmt --check build.zig src/ tests/
- zig build test-tls --summary all --error-style verbose
- zig build test-quic --summary all --error-style verbose
- zig build test --summary all --error-style verbose
