### PR TITLE
tls: move backend transport contract into core

### DIFF
--- a/docs/QUIC_TLS.md
+++ b/docs/QUIC_TLS.md
@@ -20,23 +20,25 @@ lives under a protocol-neutral `src/tls/` core while the QUIC adapter keeps
 CRYPTO-frame transport and packet-key installation.**
 
 1. `src/quic/tls_handshake.zig` implements the connection-facing handshake
-   driver (`Handshake`) plus the backend interface (`TlsBackend`) and event
-   contract (`EventSink`). The driver owns none of the TLS cryptography; it only
-   routes handshake bytes through the adapter's CRYPTO streams, installs the
-   secrets the backend exports at the correct phase, authenticates transport
-   parameters, enforces ALPN `h3`, reports certificate state, and classifies
-   failures into a typed `HandshakeError`.
+   driver (`Handshake`) over the shared transport backend contract. The driver
+   owns none of the TLS cryptography; it only routes handshake bytes through the
+   adapter's CRYPTO streams, installs the secrets the backend exports at the
+   correct phase, authenticates transport parameters, enforces ALPN `h3`,
+   reports certificate state, and classifies failures into a typed
+   `HandshakeError`.
 
 2. `src/tls/` is the protocol-neutral TLS 1.3 core. `state.zig` defines roles,
    handshake states, and the explicit `quic` versus `record` transport modes;
    `events.zig` defines transport-neutral handshake byte, traffic-secret,
    certificate, ALPN, discard, completion, and TLS-level typed failure
-   vocabulary shared by QUIC and future record mode; `key_schedule.zig` owns
-   the SHA-256 TLS 1.3 key schedule with no QUIC, HTTP, socket, or record-layer
-   imports; and `engine.zig` is the shared shell that can be instantiated for
-   record mode before records exist. QUIC-only failures, such as CRYPTO-level
-   misuse or missing QUIC transport parameters, stay in the QUIC handshake
-   driver.
+   vocabulary shared by QUIC and future record mode; `transport.zig` defines
+   the generic backend vtable and bounded event sink that carriers instantiate
+   with their own epoch and transport-parameter payload types; `key_schedule.zig`
+   owns the SHA-256 TLS 1.3 key schedule with no QUIC, HTTP, socket, or
+   record-layer imports; and `engine.zig` is the shared shell that can be
+   instantiated for record mode before records exist. QUIC-only failures and
+   hooks, such as CRYPTO-level misuse, missing QUIC transport parameters, and
+   connection-ID binding, stay in the QUIC handshake driver.
 
 3. `src/quic/tls_backend.zig` is the concrete production adapter from that core
    to QUIC mode. It consumes and produces raw handshake messages per encryption

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -637,9 +637,11 @@ pub const Tls13Backend = struct {
 
     pub fn backend(self: *Tls13Backend) TlsBackend {
         return .{
-            .ptr = self,
-            .startFn = startImpl,
-            .receiveFn = receiveImpl,
+            .transport = .{
+                .ptr = self,
+                .startFn = startImpl,
+                .receiveFn = receiveImpl,
+            },
             .setCidBindingFn = setCidBindingImpl,
             .peerCidBindingFn = peerCidBindingImpl,
         };

--- a/src/quic/tls_handshake.zig
+++ b/src/quic/tls_handshake.zig
@@ -39,93 +39,25 @@ pub const HandshakeError = tls_core.events.HandshakeError || error{
     HandshakeBufferOverflow,
 };
 
-/// Events a `TlsBackend` reports to the driver in response to `start`/`receive`.
-/// Slices borrow the backend's own storage and are consumed by the driver
-/// before the next backend call, so no allocation crosses the seam.
-pub const Event = union(enum) {
-    /// Raw TLS handshake bytes to send at `level` (queued to the CRYPTO stream).
-    crypto: struct { level: EncryptionLevel, data: []const u8 },
-    /// A traffic secret to install for `level`/`direction`.
-    secret: struct { level: EncryptionLevel, direction: Direction, data: []const u8 },
-    /// The peer's transport parameters, as carried in the handshake extension.
-    peer_transport_parameters: config.TransportParameters,
-    /// The negotiated ALPN protocol.
-    alpn: []const u8,
-    /// The peer certificate validation outcome.
-    certificate: CertificateState,
-    /// Keys for `level` are no longer needed and should be discarded.
-    discard_keys: EncryptionLevel,
-    /// The handshake authenticated and completed on this side.
-    handshake_complete,
-};
+const TransportContract = tls_core.transport.ContractWithOptions(
+    config.TransportParameters,
+    EncryptionLevel,
+    HandshakeError,
+    16,
+    16 * 1024,
+    error.HandshakeBufferOverflow,
+);
 
-/// Bounded sink the backend fills with `Event`s during a single call. Byte
-/// payloads are copied into `scratch` so the driver can apply them after the
-/// backend returns without holding backend-internal pointers.
-pub const EventSink = struct {
-    pub const max_events = 16;
-    pub const max_bytes = 16 * 1024;
-
-    items: [max_events]Event = undefined,
-    len: usize = 0,
-    scratch: [max_bytes]u8 = undefined,
-    used: usize = 0,
-
-    fn reset(self: *EventSink) void {
-        self.len = 0;
-        self.used = 0;
-    }
-
-    fn store(self: *EventSink, bytes: []const u8) HandshakeError![]const u8 {
-        if (bytes.len > self.scratch.len - self.used) return error.HandshakeBufferOverflow;
-        const start = self.used;
-        @memcpy(self.scratch[start..][0..bytes.len], bytes);
-        self.used += bytes.len;
-        return self.scratch[start..][0..bytes.len];
-    }
-
-    fn push(self: *EventSink, event: Event) HandshakeError!void {
-        if (self.len == self.items.len) return error.HandshakeBufferOverflow;
-        self.items[self.len] = event;
-        self.len += 1;
-    }
-
-    pub fn emitCrypto(self: *EventSink, level: EncryptionLevel, data: []const u8) HandshakeError!void {
-        try self.push(.{ .crypto = .{ .level = level, .data = try self.store(data) } });
-    }
-
-    pub fn emitSecret(self: *EventSink, level: EncryptionLevel, direction: Direction, data: []const u8) HandshakeError!void {
-        try self.push(.{ .secret = .{ .level = level, .direction = direction, .data = try self.store(data) } });
-    }
-
-    pub fn emitPeerTransportParameters(self: *EventSink, params: config.TransportParameters) HandshakeError!void {
-        try self.push(.{ .peer_transport_parameters = params });
-    }
-
-    pub fn emitAlpn(self: *EventSink, protocol: []const u8) HandshakeError!void {
-        try self.push(.{ .alpn = try self.store(protocol) });
-    }
-
-    pub fn emitCertificate(self: *EventSink, state: CertificateState) HandshakeError!void {
-        try self.push(.{ .certificate = state });
-    }
-
-    pub fn emitDiscardKeys(self: *EventSink, level: EncryptionLevel) HandshakeError!void {
-        try self.push(.{ .discard_keys = level });
-    }
-
-    pub fn emitHandshakeComplete(self: *EventSink) HandshakeError!void {
-        try self.push(.handshake_complete);
-    }
-};
+pub const Event = TransportContract.Event;
+pub const EventSink = TransportContract.EventSink;
+pub const TlsTransportBackend = TransportContract.Backend;
 
 /// Runtime interface to a concrete TLS 1.3 engine. The engine consumes and
 /// produces raw handshake bytes and reports keying material / negotiation
-/// results through the `EventSink`; it never sees QUIC packets or the adapter.
+/// results through the shared transport `EventSink`; it never sees QUIC packets
+/// or the adapter. QUIC connection-ID binding hooks stay local to this wrapper.
 pub const TlsBackend = struct {
-    ptr: *anyopaque,
-    startFn: *const fn (ptr: *anyopaque, role: Role, params: config.TransportParameters, sink: *EventSink) HandshakeError!void,
-    receiveFn: *const fn (ptr: *anyopaque, level: EncryptionLevel, bytes: []const u8, sink: *EventSink) HandshakeError!void,
+    transport: TlsTransportBackend,
     /// Optional RFC 9000 §7.3 authentication-binding hooks. A backend that
     /// carries connection IDs in its transport parameters implements both; the
     /// in-memory test backend leaves them null.
@@ -133,19 +65,19 @@ pub const TlsBackend = struct {
     peerCidBindingFn: ?*const fn (ptr: *anyopaque) config.CidBinding = null,
 
     fn start(self: TlsBackend, role: Role, params: config.TransportParameters, sink: *EventSink) HandshakeError!void {
-        return self.startFn(self.ptr, role, params, sink);
+        return self.transport.start(role, params, sink);
     }
 
     fn receive(self: TlsBackend, level: EncryptionLevel, bytes: []const u8, sink: *EventSink) HandshakeError!void {
-        return self.receiveFn(self.ptr, level, bytes, sink);
+        return self.transport.receive(level, bytes, sink);
     }
 
     pub fn setCidBinding(self: TlsBackend, binding: config.CidBinding) void {
-        if (self.setCidBindingFn) |set| set(self.ptr, binding);
+        if (self.setCidBindingFn) |set| set(self.transport.ptr, binding);
     }
 
     pub fn peerCidBinding(self: TlsBackend) config.CidBinding {
-        if (self.peerCidBindingFn) |get| return get(self.ptr);
+        if (self.peerCidBindingFn) |get| return get(self.transport.ptr);
         return .{};
     }
 };
@@ -280,12 +212,12 @@ pub const Handshake = struct {
         var index: usize = 0;
         while (index < self.sink.len) : (index += 1) {
             switch (self.sink.items[index]) {
-                .crypto => |c| self.adapter.queueHandshakeOutput(c.level, c.data) catch |err| return self.fail(switch (err) {
+                .handshake_bytes => |c| self.adapter.queueHandshakeOutput(c.epoch, c.data) catch |err| return self.fail(switch (err) {
                     error.InvalidCryptoLevel => error.UnexpectedCryptoLevel,
                     error.CryptoBufferTooLarge => error.HandshakeBufferOverflow,
                 }),
-                .secret => |s| {
-                    const secret = Secret.init(s.level, s.direction, s.data) catch return self.fail(error.SecretExportFailed);
+                .traffic_secret => |s| {
+                    const secret = Secret.init(s.epoch, s.direction, s.data) catch return self.fail(error.SecretExportFailed);
                     if (s.data.len != traffic_secret_len) return self.fail(error.SecretExportFailed);
                     self.adapter.installSecret(secret);
                 },
@@ -298,7 +230,7 @@ pub const Handshake = struct {
                     self.adapter.setCertificateState(cert_state);
                     if (cert_state == .invalid) return self.fail(error.CertificateInvalid);
                 },
-                .discard_keys => |level| self.discardOrDefer(level),
+                .discard_epoch => |level| self.discardOrDefer(level),
                 .handshake_complete => try self.complete(),
             }
         }
@@ -359,7 +291,13 @@ pub const TestTlsBackend = struct {
     transcript_len: usize = 0,
 
     pub fn backend(self: *TestTlsBackend) TlsBackend {
-        return .{ .ptr = self, .startFn = startImpl, .receiveFn = receiveImpl };
+        return .{
+            .transport = .{
+                .ptr = self,
+                .startFn = startImpl,
+                .receiveFn = receiveImpl,
+            },
+        };
     }
 
     fn appendTranscript(self: *TestTlsBackend, bytes: []const u8) void {

--- a/src/tls/events.zig
+++ b/src/tls/events.zig
@@ -55,7 +55,7 @@ test "event vocabulary covers QUIC and record-mode TLS lifecycles" {
     try std.testing.expectEqual(CertificateState.valid, cert_event.certificate);
 }
 
-test "shared handshake errors include transport-required failure cases" {
+test "shared handshake errors include TLS-level failure cases" {
     const std = @import("std");
 
     const err: HandshakeError = error.MalformedHandshake;

--- a/src/tls/root.zig
+++ b/src/tls/root.zig
@@ -7,6 +7,7 @@ pub const messages = @import("messages.zig");
 pub const negotiation = @import("negotiation.zig");
 pub const policy = @import("policy.zig");
 pub const transcript = @import("transcript.zig");
+pub const transport = @import("transport.zig");
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/tls/transport.zig
+++ b/src/tls/transport.zig
@@ -1,0 +1,172 @@
+//! Generic transport contract between a TLS 1.3 engine and its carrier.
+//!
+//! TLS does not own QUIC CRYPTO streams or TCP record buffering here. Callers
+//! instantiate this contract with their own epoch and transport-parameter
+//! payload types, then translate the emitted events into their local framing.
+
+const std = @import("std");
+const events = @import("events.zig");
+const state = @import("state.zig");
+
+pub fn Contract(
+    comptime TransportParameters: type,
+    comptime Epoch: type,
+    comptime ErrorSet: type,
+) type {
+    return ContractWithOptions(
+        TransportParameters,
+        Epoch,
+        ErrorSet,
+        16,
+        16 * 1024,
+        error.TransportBufferOverflow,
+    );
+}
+
+pub fn ContractWithOptions(
+    comptime TransportParameters: type,
+    comptime Epoch: type,
+    comptime ErrorSet: type,
+    comptime max_event_count: usize,
+    comptime max_byte_count: usize,
+    comptime buffer_overflow_error: ErrorSet,
+) type {
+    return struct {
+        pub const Event = union(enum) {
+            /// Raw TLS handshake bytes to send at `epoch`.
+            handshake_bytes: struct { epoch: Epoch, data: []const u8 },
+            /// A traffic secret to install for `epoch`/`direction`.
+            traffic_secret: struct { epoch: Epoch, direction: events.SecretDirection, data: []const u8 },
+            /// Transport-owned peer parameters carried by the TLS handshake.
+            peer_transport_parameters: TransportParameters,
+            /// The negotiated ALPN protocol.
+            alpn: []const u8,
+            /// The peer certificate validation outcome.
+            certificate: events.CertificateState,
+            /// Keys for `epoch` are no longer needed and should be discarded.
+            discard_epoch: Epoch,
+            /// The handshake authenticated and completed on this side.
+            handshake_complete,
+        };
+
+        pub const EventSink = struct {
+            pub const max_events = max_event_count;
+            pub const max_bytes = max_byte_count;
+
+            items: [max_events]Event = undefined,
+            len: usize = 0,
+            scratch: [max_bytes]u8 = undefined,
+            used: usize = 0,
+
+            pub fn reset(self: *EventSink) void {
+                self.len = 0;
+                self.used = 0;
+            }
+
+            fn store(self: *EventSink, bytes: []const u8) ErrorSet![]const u8 {
+                if (bytes.len > self.scratch.len - self.used) return buffer_overflow_error;
+                const start = self.used;
+                @memcpy(self.scratch[start..][0..bytes.len], bytes);
+                self.used += bytes.len;
+                return self.scratch[start..][0..bytes.len];
+            }
+
+            fn push(self: *EventSink, event: Event) ErrorSet!void {
+                if (self.len == self.items.len) return buffer_overflow_error;
+                self.items[self.len] = event;
+                self.len += 1;
+            }
+
+            pub fn emitHandshakeBytes(self: *EventSink, epoch: Epoch, data: []const u8) ErrorSet!void {
+                try self.push(.{ .handshake_bytes = .{ .epoch = epoch, .data = try self.store(data) } });
+            }
+
+            /// Compatibility spelling for QUIC callers, where handshake bytes
+            /// are carried in CRYPTO streams.
+            pub fn emitCrypto(self: *EventSink, epoch: Epoch, data: []const u8) ErrorSet!void {
+                try self.emitHandshakeBytes(epoch, data);
+            }
+
+            pub fn emitSecret(self: *EventSink, epoch: Epoch, direction: events.SecretDirection, data: []const u8) ErrorSet!void {
+                try self.push(.{ .traffic_secret = .{ .epoch = epoch, .direction = direction, .data = try self.store(data) } });
+            }
+
+            pub fn emitPeerTransportParameters(self: *EventSink, params: TransportParameters) ErrorSet!void {
+                try self.push(.{ .peer_transport_parameters = params });
+            }
+
+            pub fn emitAlpn(self: *EventSink, protocol: []const u8) ErrorSet!void {
+                try self.push(.{ .alpn = try self.store(protocol) });
+            }
+
+            pub fn emitCertificate(self: *EventSink, cert_state: events.CertificateState) ErrorSet!void {
+                try self.push(.{ .certificate = cert_state });
+            }
+
+            pub fn emitDiscardEpoch(self: *EventSink, epoch: Epoch) ErrorSet!void {
+                try self.push(.{ .discard_epoch = epoch });
+            }
+
+            /// Compatibility spelling for QUIC callers.
+            pub fn emitDiscardKeys(self: *EventSink, epoch: Epoch) ErrorSet!void {
+                try self.emitDiscardEpoch(epoch);
+            }
+
+            pub fn emitHandshakeComplete(self: *EventSink) ErrorSet!void {
+                try self.push(.handshake_complete);
+            }
+        };
+
+        pub const Backend = struct {
+            ptr: *anyopaque,
+            startFn: *const fn (ptr: *anyopaque, role: state.Role, params: TransportParameters, sink: *EventSink) ErrorSet!void,
+            receiveFn: *const fn (ptr: *anyopaque, epoch: Epoch, bytes: []const u8, sink: *EventSink) ErrorSet!void,
+
+            pub fn start(self: Backend, role: state.Role, params: TransportParameters, sink: *EventSink) ErrorSet!void {
+                return self.startFn(self.ptr, role, params, sink);
+            }
+
+            pub fn receive(self: Backend, epoch: Epoch, bytes: []const u8, sink: *EventSink) ErrorSet!void {
+                return self.receiveFn(self.ptr, epoch, bytes, sink);
+            }
+        };
+    };
+}
+
+test "generic transport sink stores copied event payloads" {
+    const ErrorSet = error{TransportBufferOverflow};
+    const Epoch = enum { initial, handshake };
+    const Params = struct { enabled: bool = true };
+    const T = Contract(Params, Epoch, ErrorSet);
+
+    var sink = T.EventSink{};
+    try sink.emitHandshakeBytes(.initial, "hello");
+    try sink.emitSecret(.handshake, .write, "secret");
+    try sink.emitPeerTransportParameters(.{ .enabled = false });
+
+    try std.testing.expectEqual(@as(usize, 3), sink.len);
+    try std.testing.expectEqualStrings("hello", sink.items[0].handshake_bytes.data);
+    try std.testing.expectEqual(events.SecretDirection.write, sink.items[1].traffic_secret.direction);
+    try std.testing.expect(!sink.items[2].peer_transport_parameters.enabled);
+}
+
+test "generic transport sink enforces bounded payload storage" {
+    const ErrorSet = error{TransportBufferOverflow};
+    const Epoch = enum { initial };
+    const T = Contract(void, Epoch, ErrorSet);
+
+    var sink = T.EventSink{};
+    const oversized = [_]u8{0} ** (T.EventSink.max_bytes + 1);
+    try std.testing.expectError(error.TransportBufferOverflow, sink.emitHandshakeBytes(.initial, &oversized));
+}
+
+test "generic transport sink accepts caller-owned limits and overflow error names" {
+    const ErrorSet = error{CallerBufferFull};
+    const Epoch = enum { initial };
+    const T = ContractWithOptions(void, Epoch, ErrorSet, 1, 4, error.CallerBufferFull);
+
+    var sink = T.EventSink{};
+    try std.testing.expectError(error.CallerBufferFull, sink.emitHandshakeBytes(.initial, "hello"));
+    try sink.emitHandshakeBytes(.initial, "ok");
+    try std.testing.expectError(error.CallerBufferFull, sink.emitHandshakeBytes(.initial, ""));
+}


### PR DESCRIPTION
## Summary
- add a generic protocol-neutral TLS transport contract in src/tls/transport.zig
- instantiate that contract from the QUIC handshake driver while keeping QUIC CID binding hooks local
- move the backend event sink/vtable shape out of the QUIC module and document the ownership boundary

Part of #329. This intentionally avoids src/tls/alerts.zig / #332 work.

## Validation
- zig fmt --check build.zig src/ tests/
- zig build test-tls --summary all --error-style verbose
- zig build test-quic --summary all --error-style verbose
- zig build test --summary all --error-style verbose
