### PR TITLE
tls: move backend driver lifecycle into core

### DIFF
--- a/docs/QUIC_TLS.md
+++ b/docs/QUIC_TLS.md
@@ -19,13 +19,13 @@ material; the rest of `src/quic/` must never see a concrete TLS type.
 lives under a protocol-neutral `src/tls/` core while the QUIC adapter keeps
 CRYPTO-frame transport and packet-key installation.**
 
-1. `src/quic/tls_handshake.zig` implements the connection-facing handshake
-   driver (`Handshake`) over the shared transport backend contract. The driver
-   owns none of the TLS cryptography; it only routes handshake bytes through the
-   adapter's CRYPTO streams, installs the secrets the backend exports at the
-   correct phase, authenticates transport parameters, enforces ALPN `h3`,
-   reports certificate state, and classifies failures into a typed
-   `HandshakeError`.
+1. `src/quic/tls_handshake.zig` implements the connection-facing QUIC wrapper
+   (`Handshake`) over the shared transport backend contract and generic core
+   driver. The wrapper owns none of the TLS cryptography; it only routes
+   handshake bytes through the adapter's CRYPTO streams, installs the secrets
+   the backend exports at the correct phase, authenticates transport parameters,
+   enforces ALPN `h3`, reports certificate state, and classifies failures into
+   a typed `HandshakeError`.
 
 2. `src/tls/` is the protocol-neutral TLS 1.3 core. `state.zig` defines roles,
    handshake states, and the explicit `quic` versus `record` transport modes;
@@ -33,12 +33,12 @@ CRYPTO-frame transport and packet-key installation.**
    certificate, ALPN, discard, completion, and TLS-level typed failure
    vocabulary shared by QUIC and future record mode; `transport.zig` defines
    the generic backend vtable and bounded event sink that carriers instantiate
-   with their own epoch and transport-parameter payload types; `key_schedule.zig`
-   owns the SHA-256 TLS 1.3 key schedule with no QUIC, HTTP, socket, or
-   record-layer imports; and `engine.zig` is the shared shell that can be
-   instantiated for record mode before records exist. QUIC-only failures and
-   hooks, such as CRYPTO-level misuse, missing QUIC transport parameters, and
-   connection-ID binding, stay in the QUIC handshake driver.
+   with their own epoch and transport-parameter payload types; `engine.zig`
+   owns generic backend start/receive progression, lifecycle state, and failure
+   capture over that contract; `key_schedule.zig` owns the SHA-256 TLS 1.3 key
+   schedule with no QUIC, HTTP, socket, or record-layer imports. QUIC-only
+   failures and hooks, such as CRYPTO-level misuse, missing QUIC transport
+   parameters, and connection-ID binding, stay in the QUIC handshake driver.
 
 3. `src/quic/tls_backend.zig` is the concrete production adapter from that core
    to QUIC mode. It consumes and produces raw handshake messages per encryption

--- a/src/quic/tls_handshake.zig
+++ b/src/quic/tls_handshake.zig
@@ -29,6 +29,8 @@ const traffic_secret_len = tls_adapter.traffic_secret_len;
 pub const Role = tls_core.state.Role;
 
 pub const HandshakeError = tls_core.events.HandshakeError || error{
+    /// The generic TLS driver was called in an invalid lifecycle state.
+    InvalidHandshakeState,
     /// A CRYPTO fragment arrived at a level the handshake never uses (0-RTT).
     UnexpectedCryptoLevel,
     /// Handshake completed without the peer's QUIC transport parameters.
@@ -51,6 +53,7 @@ const TransportContract = tls_core.transport.ContractWithOptions(
 pub const Event = TransportContract.Event;
 pub const EventSink = TransportContract.EventSink;
 pub const TlsTransportBackend = TransportContract.Backend;
+pub const CoreDriver = tls_core.engine.Driver(TransportContract);
 
 /// Runtime interface to a concrete TLS 1.3 engine. The engine consumes and
 /// produces raw handshake bytes and reports keying material / negotiation
@@ -89,16 +92,13 @@ pub const State = tls_core.state.DriverState;
 /// `isComplete()` or `failure()` is set.
 pub const Handshake = struct {
     adapter: *QuicTlsAdapter,
-    backend: TlsBackend,
-    role: Role,
+    driver: CoreDriver,
     /// Require ALPN to negotiate exactly `h3` (the QUIC/H3 path). Always true
     /// for HTTP/3; exposed so future ALPNs can reuse the driver.
     require_alpn_h3: bool = true,
     /// Local-only escape hatch to accept `.not_checked` certificate state at
     /// completion. Off by default; tests must opt in explicitly.
     allow_unverified_certificate: bool = false,
-    state: State = .idle,
-    failure_reason: ?HandshakeError = null,
     /// When true, the connection driver owns key-discard timing (RFC 9001
     /// §4.9 / RFC 9002 §6.4): backend discard events only mark the level in
     /// `discard_requested`, and the driver applies them through the adapter
@@ -113,39 +113,33 @@ pub const Handshake = struct {
     /// the Initial level in the same event batch that discards Initial keys),
     /// so the discard is applied once `pollOutput` drains the level.
     pending_discard: [4]bool = .{ false, false, false, false },
-    sink: EventSink = .{},
 
     pub fn initClient(adapter: *QuicTlsAdapter, backend: TlsBackend) Handshake {
-        return .{ .adapter = adapter, .backend = backend, .role = .client };
+        return .{ .adapter = adapter, .driver = CoreDriver.init(.client, backend.transport) };
     }
 
     pub fn initServer(adapter: *QuicTlsAdapter, backend: TlsBackend) Handshake {
-        return .{ .adapter = adapter, .backend = backend, .role = .server };
+        return .{ .adapter = adapter, .driver = CoreDriver.init(.server, backend.transport) };
     }
 
     /// Provide local transport parameters to TLS and emit the first flight
     /// (client) or arm the responder (server).
     pub fn start(self: *Handshake, local_params: config.TransportParameters) HandshakeError!void {
         self.adapter.setLocalTransportParameters(local_params);
-        self.state = .in_progress;
-        self.sink.reset();
-        self.backend.start(self.role, local_params, &self.sink) catch |err| return self.fail(err);
-        try self.applyEvents();
+        try self.applyEvents(try self.driver.start(local_params));
     }
 
     /// Feed a CRYPTO fragment received at `level`, reassemble it in order, and
     /// drive the backend with any newly contiguous handshake bytes.
     pub fn onCrypto(self: *Handshake, level: EncryptionLevel, offset: u64, bytes: []const u8) HandshakeError!void {
-        if (self.state == .failed) return self.failure_reason.?;
+        if (self.driver.state == .failed) return self.driver.failure().?;
         self.adapter.receiveCrypto(level, offset, bytes) catch |err| return self.fail(switch (err) {
             error.InvalidCryptoLevel => error.UnexpectedCryptoLevel,
             error.CryptoBufferTooLarge, error.TooManyCryptoRanges => error.MalformedHandshake,
         });
         while (true) {
             const input = (self.adapter.nextHandshakeInput(level) catch return self.fail(error.UnexpectedCryptoLevel)) orelse break;
-            self.sink.reset();
-            self.backend.receive(input.level, input.bytes, &self.sink) catch |err| return self.fail(err);
-            try self.applyEvents();
+            try self.applyEvents(try self.driver.receive(input.level, input.bytes));
         }
     }
 
@@ -168,17 +162,15 @@ pub const Handshake = struct {
     }
 
     pub fn isComplete(self: *const Handshake) bool {
-        return self.state == .complete;
+        return self.driver.isComplete();
     }
 
     pub fn failure(self: *const Handshake) ?HandshakeError {
-        return self.failure_reason;
+        return self.driver.failure();
     }
 
     fn fail(self: *Handshake, err: HandshakeError) HandshakeError {
-        self.state = .failed;
-        self.failure_reason = err;
-        return err;
+        return self.driver.fail(err);
     }
 
     /// True once the backend has signalled that keys for `level` are no
@@ -208,10 +200,10 @@ pub const Handshake = struct {
         self.adapter.discardSecrets(level);
     }
 
-    fn applyEvents(self: *Handshake) HandshakeError!void {
+    fn applyEvents(self: *Handshake, sink: *EventSink) HandshakeError!void {
         var index: usize = 0;
-        while (index < self.sink.len) : (index += 1) {
-            switch (self.sink.items[index]) {
+        while (index < sink.len) : (index += 1) {
+            switch (sink.items[index]) {
                 .handshake_bytes => |c| self.adapter.queueHandshakeOutput(c.epoch, c.data) catch |err| return self.fail(switch (err) {
                     error.InvalidCryptoLevel => error.UnexpectedCryptoLevel,
                     error.CryptoBufferTooLarge => error.HandshakeBufferOverflow,
@@ -241,13 +233,13 @@ pub const Handshake = struct {
         if (self.require_alpn_h3 and !self.adapter.negotiatedH3()) return self.fail(error.AlpnMismatch);
         // Only the client validates a peer certificate in the server-auth QUIC/H3
         // model; the server has no client certificate to check here.
-        if (self.role == .client and !self.allow_unverified_certificate and self.adapter.certificateState() != .valid) {
+        if (self.driver.role == .client and !self.allow_unverified_certificate and self.adapter.certificateState() != .valid) {
             return self.fail(error.CertificateInvalid);
         }
         // Transport parameters are only exposed to connection logic now that the
         // handshake has authenticated them.
         self.adapter.authenticatePeerTransportParameters();
-        self.state = .complete;
+        self.driver.complete();
     }
 };
 
@@ -613,7 +605,7 @@ const Harness = struct {
     /// Pump handshake bytes between the two sides until both complete or no side
     /// makes progress. Returns the first deterministic failure, if any.
     fn run(self: *Harness) HandshakeError!void {
-        try self.client.start(defaultParams());
+        if (self.client.driver.state == .idle) try self.client.start(defaultParams());
         var rounds: usize = 0;
         while (rounds < 64) : (rounds += 1) {
             var progressed = false;
@@ -830,7 +822,8 @@ test "the connection-facing driver exposes only the backend interface, not a con
     var adapter = QuicTlsAdapter{};
     var backend = TestTlsBackend{};
     const handshake = Handshake.initClient(&adapter, backend.backend());
-    // The driver holds the runtime TlsBackend vtable; no concrete backend type
-    // leaks into its public surface.
-    try testing.expect(@TypeOf(handshake.backend) == TlsBackend);
+    // The wrapper holds the protocol-neutral core driver over the runtime
+    // transport vtable; no concrete backend type leaks into its public surface.
+    try testing.expect(@TypeOf(handshake.driver) == CoreDriver);
+    try testing.expect(@TypeOf(handshake.driver.backend) == TlsTransportBackend);
 }

--- a/src/tls/engine.zig
+++ b/src/tls/engine.zig
@@ -35,9 +35,153 @@ pub const Engine = struct {
     }
 };
 
+pub fn Driver(comptime Transport: type) type {
+    return struct {
+        role: state.Role,
+        backend: Transport.Backend,
+        state: state.DriverState = .idle,
+        failure_reason: ?Transport.Error = null,
+        sink: Transport.EventSink = .{},
+
+        const Self = @This();
+
+        pub fn init(role: state.Role, backend: Transport.Backend) Self {
+            return .{ .role = role, .backend = backend };
+        }
+
+        /// Start the backend and return the driver's internal event sink.
+        /// The returned pointer and every event payload slice borrow storage
+        /// owned by this driver; they stay valid only until the next `start` or
+        /// `receive` call, both of which reset and overwrite the sink.
+        pub fn start(self: *Self, params: Transport.TransportParametersType) Transport.Error!*Transport.EventSink {
+            if (self.state != .idle) return self.fail(error.InvalidHandshakeState);
+            self.state = .in_progress;
+            self.sink.reset();
+            self.backend.start(self.role, params, &self.sink) catch |err| return self.fail(err);
+            return &self.sink;
+        }
+
+        /// Drive the backend with received handshake bytes and return the
+        /// driver's internal event sink. The returned pointer and payload slices
+        /// are borrowed only until the next `start` or `receive` call.
+        pub fn receive(self: *Self, epoch: Transport.EpochType, bytes: []const u8) Transport.Error!*Transport.EventSink {
+            if (self.state == .failed) return self.failure_reason.?;
+            self.sink.reset();
+            self.backend.receive(epoch, bytes, &self.sink) catch |err| return self.fail(err);
+            return &self.sink;
+        }
+
+        pub fn complete(self: *Self) void {
+            self.state = .complete;
+        }
+
+        pub fn isComplete(self: *const Self) bool {
+            return self.state == .complete;
+        }
+
+        pub fn failure(self: *const Self) ?Transport.Error {
+            return self.failure_reason;
+        }
+
+        pub fn fail(self: *Self, err: Transport.Error) Transport.Error {
+            self.state = .failed;
+            self.failure_reason = err;
+            return err;
+        }
+    };
+}
+
 test "core engine can be instantiated for record mode without record framing" {
     var engine = Engine.init(.{ .role = .server, .transport_mode = .record });
     try std.testing.expect(engine.canUseRecordLayer());
     engine.start();
     try std.testing.expectEqual(state.HandshakeState.idle, engine.handshake_state);
+}
+
+test "generic driver starts backend and stores emitted events" {
+    const T = @import("transport.zig").Contract(void, enum { initial }, error{ InvalidHandshakeState, TransportBufferOverflow });
+    const D = Driver(T);
+    const Backend = struct {
+        fn start(_: *anyopaque, role: state.Role, _: void, sink: *T.EventSink) T.Error!void {
+            std.debug.assert(role == .client);
+            try sink.emitHandshakeBytes(.initial, "hello");
+        }
+
+        fn receive(_: *anyopaque, _: T.EpochType, _: []const u8, _: *T.EventSink) T.Error!void {}
+    };
+
+    var context: u8 = 0;
+    var driver = D.init(.client, .{
+        .ptr = &context,
+        .startFn = Backend.start,
+        .receiveFn = Backend.receive,
+    });
+    const sink = try driver.start({});
+    try std.testing.expectEqual(state.DriverState.in_progress, driver.state);
+    try std.testing.expectEqual(@as(usize, 1), sink.len);
+    try std.testing.expectEqualStrings("hello", sink.items[0].handshake_bytes.data);
+}
+
+test "generic driver records backend failure" {
+    const T = @import("transport.zig").Contract(void, enum { initial }, error{ InvalidHandshakeState, TransportBufferOverflow });
+    const D = Driver(T);
+    const Backend = struct {
+        fn start(_: *anyopaque, _: state.Role, _: void, _: *T.EventSink) T.Error!void {
+            return error.TransportBufferOverflow;
+        }
+
+        fn receive(_: *anyopaque, _: T.EpochType, _: []const u8, _: *T.EventSink) T.Error!void {}
+    };
+
+    var context: u8 = 0;
+    var driver = D.init(.server, .{
+        .ptr = &context,
+        .startFn = Backend.start,
+        .receiveFn = Backend.receive,
+    });
+    try std.testing.expectError(error.TransportBufferOverflow, driver.start({}));
+    try std.testing.expectEqual(state.DriverState.failed, driver.state);
+    try std.testing.expectEqual(error.TransportBufferOverflow, driver.failure().?);
+}
+
+test "generic driver rejects repeated start calls" {
+    const T = @import("transport.zig").Contract(void, enum { initial }, error{ InvalidHandshakeState, TransportBufferOverflow });
+    const D = Driver(T);
+    const Backend = struct {
+        fn start(_: *anyopaque, _: state.Role, _: void, sink: *T.EventSink) T.Error!void {
+            try sink.emitHandshakeBytes(.initial, "hello");
+        }
+
+        fn receive(_: *anyopaque, _: T.EpochType, _: []const u8, _: *T.EventSink) T.Error!void {}
+    };
+
+    var context: u8 = 0;
+    var driver = D.init(.client, .{
+        .ptr = &context,
+        .startFn = Backend.start,
+        .receiveFn = Backend.receive,
+    });
+    _ = try driver.start({});
+    try std.testing.expectError(error.InvalidHandshakeState, driver.start({}));
+    try std.testing.expectEqual(state.DriverState.failed, driver.state);
+    try std.testing.expectEqual(error.InvalidHandshakeState, driver.failure().?);
+}
+
+test "generic driver rejects start after completion" {
+    const T = @import("transport.zig").Contract(void, enum { initial }, error{ InvalidHandshakeState, TransportBufferOverflow });
+    const D = Driver(T);
+    const Backend = struct {
+        fn start(_: *anyopaque, _: state.Role, _: void, _: *T.EventSink) T.Error!void {}
+        fn receive(_: *anyopaque, _: T.EpochType, _: []const u8, _: *T.EventSink) T.Error!void {}
+    };
+
+    var context: u8 = 0;
+    var driver = D.init(.server, .{
+        .ptr = &context,
+        .startFn = Backend.start,
+        .receiveFn = Backend.receive,
+    });
+    _ = try driver.start({});
+    driver.complete();
+    try std.testing.expectError(error.InvalidHandshakeState, driver.start({}));
 }

--- a/src/tls/transport.zig
+++ b/src/tls/transport.zig
@@ -32,6 +32,10 @@ pub fn ContractWithOptions(
     comptime buffer_overflow_error: ErrorSet,
 ) type {
     return struct {
+        pub const TransportParametersType = TransportParameters;
+        pub const EpochType = Epoch;
+        pub const Error = ErrorSet;
+
         pub const Event = union(enum) {
             /// Raw TLS handshake bytes to send at `epoch`.
             handshake_bytes: struct { epoch: Epoch, data: []const u8 },


### PR DESCRIPTION
## Summary
- add a generic tls_core.engine.Driver over the shared transport backend contract
- make the QUIC handshake wrapper delegate backend start/receive/failure lifecycle to the core driver
- keep QUIC-specific CRYPTO routing, secret installation, transport-parameter authentication, and CID binding in src/quic
- document the updated ownership split

Part of #329. This stays separate from #332 / PR #394 alert mapping work.

## Validation
- zig fmt --check build.zig src/ tests/
- zig build test-tls --summary all --error-style verbose
- zig build test-quic --summary all --error-style verbose
- zig build test --summary all --error-style verbose
