### PR TITLE
pki: add pure-Zig PEM and certificate-chain loader (#340)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,24 @@ All notable user-facing changes to Tardigrade are documented here.
   and sign/verify round-trips under `zig build test-crypto`. The OpenSSL
   production adapter and migrating the existing QUIC/TLS modules onto the
   boundary are follow-ups (#323–#326); see `docs/CRYPTO_PROVIDER.md`.
+- **Pure-Zig PEM and certificate-chain loader (#340, epic #324)** — adds
+  `src/pki/pem.zig`, which loads X.509 certificates and ordered certificate
+  chains from PEM or DER buffers/files without constructing OpenSSL objects.
+  `CERTIFICATE` blocks are decoded with strict RFC 7468 handling — standard
+  base64 alphabet only, canonical padding, zero trailing bits, no data after
+  padding, and well-formed encapsulation boundaries — while surrounding text
+  and non-certificate blocks (private keys, parameters) are tolerated the way
+  real bundle files require, and LF/CRLF line endings both load. Every
+  decoded certificate must be exactly one definite-length DER SEQUENCE
+  (validated via `der.Reader`), exact DER bytes and input order are preserved
+  for #341, and configurable limits bound input size, per-certificate size,
+  and certificate count before any attacker-controlled allocation. Malformed
+  labels, base64, padding, trailing junk, empty chains, and oversized input
+  fail with typed errors; returned certificates own their DER copies and are
+  freed with explicit `deinit`. Memory-buffer APIs come first with thin
+  `std.Io`-based file helpers on top, plus a `fuzzLoadChainPem` entrypoint
+  for #327-G. Mixed-text, line-ending, multi-block, hostile-input, and
+  allocation-failure coverage runs under `zig build test-pki`.
 - **Bounded ASN.1 DER decoder for X.509 (#339)** — adds `src/pki/` with a
   strict, allocation-aware DER foundation for the #324 Web PKI epic:
   `der.zig` provides a bounded `Reader` with typed decoders (SEQUENCE/SET,

--- a/src/pki/pem.zig
+++ b/src/pki/pem.zig
@@ -1,0 +1,338 @@
+//! Pure-Zig PEM and certificate-chain loader (#340).
+//!
+//! Loads X.509 certificates and ordered certificate chains from PEM or DER
+//! buffers/files without constructing OpenSSL objects.
+//!
+//! ## PEM policy (RFC 7468 strict profile)
+//!
+//! - Only `CERTIFICATE` blocks yield certificates. Other well-formed blocks
+//!   (`PRIVATE KEY`, `X509 CRL`, ...) are skipped so combined cert+key files
+//!   load, but their boundaries must still pair up correctly.
+//! - Text outside encapsulation boundaries is ignored (OpenSSL-style
+//!   `subject=`/`issuer=` annotations between blocks are common).
+//! - Boundary lines must start at column zero and carry nothing after the
+//!   trailing dashes. A line starting with `-----` that is not a well-formed
+//!   boundary is rejected rather than silently treated as text.
+//! - Base64 is strict: standard alphabet only, mandatory canonical padding,
+//!   zero trailing bits, no whitespace inside lines, no data after padding.
+//! - LF and CRLF line endings are accepted (mixed freely); bare CR is not a
+//!   line terminator.
+//!
+//! ## DER policy
+//!
+//! Every decoded certificate must be exactly one definite-length SEQUENCE
+//! with no trailing bytes, validated by `der.Reader`. Full TBSCertificate
+//! parsing is #341; this module preserves the exact DER bytes and input
+//! order for it.
+//!
+//! ## Ownership
+//!
+//! Returned `Certificate` and `CertificateChain` values own copies of the
+//! DER bytes. Callers free them with `deinit`, passing the same allocator
+//! used to load. Input buffers are borrowed for the call only.
+
+const std = @import("std");
+const der = @import("der.zig");
+
+/// Configurable loader resource bounds.
+pub const Limits = struct {
+    /// Maximum PEM/DER input size accepted by buffer APIs and file helpers.
+    max_input_len: usize = 8 * 1024 * 1024,
+    /// Maximum DER size of a single certificate.
+    max_certificate_len: usize = 1024 * 1024,
+    /// Maximum number of certificates in one chain or bundle.
+    max_certificates: usize = 256,
+    /// Structural bounds applied when validating each certificate's DER.
+    der: der.Limits = .{},
+};
+
+pub const default_limits: Limits = .{};
+
+pub const Error = error{
+    /// Input (or file) exceeds `Limits.max_input_len`.
+    InputTooLarge,
+    /// A decoded certificate exceeds `Limits.max_certificate_len`.
+    CertificateTooLarge,
+    /// More than `Limits.max_certificates` certificates in the input.
+    TooManyCertificates,
+    /// No `CERTIFICATE` block (or empty DER input) — empty chains are invalid.
+    NoCertificates,
+    /// A line starting with `-----` is not a well-formed encapsulation
+    /// boundary, an END appeared without a BEGIN, a BEGIN appeared inside an
+    /// open block, or a label contains invalid characters.
+    MalformedPemBoundary,
+    /// An END boundary's label does not match the open BEGIN's label.
+    MismatchedPemLabel,
+    /// Input ended inside an encapsulated block.
+    UnterminatedPemBlock,
+    /// Invalid base64 character, non-canonical or missing padding, nonzero
+    /// trailing bits, data after padding, or a blank/whitespace line inside
+    /// an encapsulated block.
+    InvalidPemBase64,
+    /// A `CERTIFICATE` block decoded to zero bytes.
+    EmptyPemBlock,
+    /// Decoded bytes are not exactly one definite-length DER SEQUENCE.
+    MalformedCertificateDer,
+    OutOfMemory,
+};
+
+/// One certificate as exact DER bytes, owned by the loader's caller.
+pub const Certificate = struct {
+    der: []const u8,
+
+    pub fn deinit(self: *Certificate, allocator: std.mem.Allocator) void {
+        allocator.free(self.der);
+        self.* = undefined;
+    }
+};
+
+/// An ordered, non-empty certificate list preserving input order
+/// (leaf first when the input follows TLS chain convention).
+pub const CertificateChain = struct {
+    certificates: []Certificate,
+
+    pub fn deinit(self: *CertificateChain, allocator: std.mem.Allocator) void {
+        for (self.certificates) |cert| allocator.free(cert.der);
+        allocator.free(self.certificates);
+        self.* = undefined;
+    }
+};
+
+const begin_prefix = "-----BEGIN ";
+const end_prefix = "-----END ";
+const boundary_suffix = "-----";
+const certificate_label = "CERTIFICATE";
+
+/// Load every `CERTIFICATE` block from a PEM buffer, in input order.
+pub fn loadChainPem(allocator: std.mem.Allocator, pem_text: []const u8, limits: Limits) Error!CertificateChain {
+    if (pem_text.len > limits.max_input_len) return error.InputTooLarge;
+
+    var certificates: std.ArrayList(Certificate) = .empty;
+    defer {
+        for (certificates.items) |cert| allocator.free(cert.der);
+        certificates.deinit(allocator);
+    }
+
+    var base64_buf: std.ArrayList(u8) = .empty;
+    defer base64_buf.deinit(allocator);
+
+    const max_base64_len = base64EncodedLen(limits.max_certificate_len);
+
+    const State = union(enum) {
+        outside,
+        in_certificate,
+        in_skipped: []const u8,
+    };
+    var state: State = .outside;
+
+    var lines = std.mem.splitScalar(u8, pem_text, '\n');
+    while (lines.next()) |raw_line| {
+        const line = std.mem.trimEnd(u8, raw_line, "\r");
+        // A trailing newline at EOF yields one final empty segment; that is
+        // end-of-input, not a blank line inside a block.
+        if (line.len == 0 and lines.peek() == null) break;
+        switch (state) {
+            .outside => {
+                if (std.mem.startsWith(u8, line, "-----")) {
+                    const boundary = try parseBoundary(line);
+                    if (boundary.kind == .end) return error.MalformedPemBoundary;
+                    if (std.mem.eql(u8, boundary.label, certificate_label)) {
+                        base64_buf.clearRetainingCapacity();
+                        state = .in_certificate;
+                    } else {
+                        state = .{ .in_skipped = boundary.label };
+                    }
+                }
+                // Anything else outside a block is surrounding text; ignore.
+            },
+            .in_certificate => {
+                if (std.mem.startsWith(u8, line, "-----")) {
+                    const boundary = try parseBoundary(line);
+                    if (boundary.kind == .begin) return error.MalformedPemBoundary;
+                    if (!std.mem.eql(u8, boundary.label, certificate_label)) return error.MismatchedPemLabel;
+                    if (certificates.items.len >= limits.max_certificates) return error.TooManyCertificates;
+                    const der_bytes = try decodeCertificateBase64(allocator, base64_buf.items, limits);
+                    errdefer allocator.free(der_bytes);
+                    try certificates.append(allocator, .{ .der = der_bytes });
+                    state = .outside;
+                } else {
+                    try validateBase64Line(line);
+                    if (base64_buf.items.len + line.len > max_base64_len) return error.CertificateTooLarge;
+                    try base64_buf.appendSlice(allocator, line);
+                }
+            },
+            .in_skipped => |label| {
+                if (std.mem.startsWith(u8, line, "-----")) {
+                    const boundary = try parseBoundary(line);
+                    if (boundary.kind == .begin) return error.MalformedPemBoundary;
+                    if (!std.mem.eql(u8, boundary.label, label)) return error.MismatchedPemLabel;
+                    state = .outside;
+                } else {
+                    try validateBase64Line(line);
+                }
+            },
+        }
+    }
+    if (state != .outside) return error.UnterminatedPemBlock;
+    if (certificates.items.len == 0) return error.NoCertificates;
+
+    const owned = try certificates.toOwnedSlice(allocator);
+    return .{ .certificates = owned };
+}
+
+/// Load exactly one certificate from a PEM buffer. Rejects inputs carrying
+/// more than one `CERTIFICATE` block.
+pub fn loadCertificatePem(allocator: std.mem.Allocator, pem_text: []const u8, limits: Limits) Error!Certificate {
+    var chain = try loadChainPem(allocator, pem_text, limits);
+    if (chain.certificates.len != 1) {
+        chain.deinit(allocator);
+        return error.TooManyCertificates;
+    }
+    const cert = chain.certificates[0];
+    allocator.free(chain.certificates);
+    return cert;
+}
+
+/// Load a single certificate from raw DER bytes.
+pub fn loadCertificateDer(allocator: std.mem.Allocator, der_bytes: []const u8, limits: Limits) Error!Certificate {
+    if (der_bytes.len > limits.max_input_len) return error.InputTooLarge;
+    if (der_bytes.len == 0) return error.NoCertificates;
+    try validateCertificateDer(der_bytes, limits);
+    const copy = try allocator.dupe(u8, der_bytes);
+    return .{ .der = copy };
+}
+
+pub const FileError = Error || std.Io.File.OpenError || std.Io.File.Reader.Error;
+
+/// Thin file helper over `loadChainPem`. Reads at most
+/// `limits.max_input_len` bytes.
+pub fn loadChainPemFile(allocator: std.mem.Allocator, io: std.Io, dir: std.Io.Dir, sub_path: []const u8, limits: Limits) FileError!CertificateChain {
+    const text = readFileBounded(allocator, io, dir, sub_path, limits.max_input_len) catch |err| switch (err) {
+        error.StreamTooLong => return error.InputTooLarge,
+        else => |other| return other,
+    };
+    defer allocator.free(text);
+    return loadChainPem(allocator, text, limits);
+}
+
+/// Thin file helper over `loadCertificateDer`.
+pub fn loadCertificateDerFile(allocator: std.mem.Allocator, io: std.Io, dir: std.Io.Dir, sub_path: []const u8, limits: Limits) FileError!Certificate {
+    const bytes = readFileBounded(allocator, io, dir, sub_path, limits.max_input_len) catch |err| switch (err) {
+        error.StreamTooLong => return error.InputTooLarge,
+        else => |other| return other,
+    };
+    defer allocator.free(bytes);
+    return loadCertificateDer(allocator, bytes, limits);
+}
+
+fn readFileBounded(allocator: std.mem.Allocator, io: std.Io, dir: std.Io.Dir, sub_path: []const u8, limit: usize) ![]u8 {
+    return dir.readFileAlloc(io, sub_path, allocator, .limited(limit));
+}
+
+const BoundaryKind = enum { begin, end };
+
+const Boundary = struct {
+    kind: BoundaryKind,
+    label: []const u8,
+};
+
+/// Parse a line already known to start with `-----` as an encapsulation
+/// boundary. Labels follow RFC 7468: printable ASCII words separated by
+/// single spaces or hyphens, no leading/trailing separator.
+fn parseBoundary(line: []const u8) Error!Boundary {
+    var kind: BoundaryKind = undefined;
+    var rest: []const u8 = undefined;
+    if (std.mem.startsWith(u8, line, begin_prefix)) {
+        kind = .begin;
+        rest = line[begin_prefix.len..];
+    } else if (std.mem.startsWith(u8, line, end_prefix)) {
+        kind = .end;
+        rest = line[end_prefix.len..];
+    } else {
+        return error.MalformedPemBoundary;
+    }
+    if (!std.mem.endsWith(u8, rest, boundary_suffix)) return error.MalformedPemBoundary;
+    const label = rest[0 .. rest.len - boundary_suffix.len];
+    try validateLabel(label);
+    return .{ .kind = kind, .label = label };
+}
+
+fn validateLabel(label: []const u8) Error!void {
+    if (label.len == 0) return error.MalformedPemBoundary;
+    var prev_separator = true; // Disallow a leading separator.
+    for (label) |c| {
+        if (c == ' ' or c == '-') {
+            if (prev_separator) return error.MalformedPemBoundary;
+            prev_separator = true;
+        } else if (c >= 0x21 and c <= 0x7e) {
+            prev_separator = false;
+        } else {
+            return error.MalformedPemBoundary;
+        }
+    }
+    if (prev_separator) return error.MalformedPemBoundary;
+}
+
+/// Reject anything but base64 alphabet and padding before accumulation so
+/// interior whitespace, blank lines, and control bytes fail loudly instead
+/// of decoding by accident.
+fn validateBase64Line(line: []const u8) Error!void {
+    if (line.len == 0) return error.InvalidPemBase64;
+    for (line) |c| {
+        const valid = (c >= 'A' and c <= 'Z') or (c >= 'a' and c <= 'z') or
+            (c >= '0' and c <= '9') or c == '+' or c == '/' or c == '=';
+        if (!valid) return error.InvalidPemBase64;
+    }
+}
+
+fn decodeCertificateBase64(allocator: std.mem.Allocator, base64: []const u8, limits: Limits) Error![]u8 {
+    if (base64.len == 0) return error.EmptyPemBlock;
+    const decoder = std.base64.standard.Decoder;
+    const decoded_len = decoder.calcSizeForSlice(base64) catch return error.InvalidPemBase64;
+    if (decoded_len > limits.max_certificate_len) return error.CertificateTooLarge;
+    const decoded = try allocator.alloc(u8, decoded_len);
+    errdefer allocator.free(decoded);
+    decoder.decode(decoded, base64) catch return error.InvalidPemBase64;
+    if (decoded.len == 0) return error.EmptyPemBlock;
+    try validateCertificateDer(decoded, limits);
+    return decoded;
+}
+
+/// Certificate DER must be exactly one definite-length SEQUENCE spanning the
+/// whole buffer. Interior structure is #341's job.
+fn validateCertificateDer(bytes: []const u8, limits: Limits) Error!void {
+    if (bytes.len > limits.max_certificate_len) return error.CertificateTooLarge;
+    var reader = der.Reader.init(bytes, limits.der);
+    const elem = reader.readElement() catch return error.MalformedCertificateDer;
+    const sequence_tag = der.Tag.universal(@intFromEnum(der.UniversalTag.sequence), true);
+    if (!elem.tag.eql(sequence_tag)) return error.MalformedCertificateDer;
+    reader.expectEnd() catch return error.MalformedCertificateDer;
+}
+
+/// Base64 length (with padding) for `len` raw bytes.
+fn base64EncodedLen(len: usize) usize {
+    return ((len + 2) / 3) * 4;
+}
+
+/// Fuzz and regression entrypoint (#327-G): parse arbitrary bytes as a PEM
+/// bundle under strict limits without I/O, panics, or unbounded allocation.
+pub fn fuzzLoadChainPem(allocator: std.mem.Allocator, input: []const u8) void {
+    const limits: Limits = .{
+        .max_input_len = 1024 * 1024,
+        .max_certificate_len = 64 * 1024,
+        .max_certificates = 16,
+        .der = .{
+            .max_depth = 8,
+            .max_element_len = 64 * 1024,
+            .max_elements = 64,
+        },
+    };
+    var chain = loadChainPem(allocator, input, limits) catch return;
+    chain.deinit(allocator);
+}
+
+const testing = std.testing;
+
+test {
+    testing.refAllDecls(@This());
+}

--- a/src/pki/pem.zig
+++ b/src/pki/pem.zig
@@ -127,7 +127,12 @@ pub fn loadChainPem(allocator: std.mem.Allocator, pem_text: []const u8, limits: 
 
     var lines = std.mem.splitScalar(u8, pem_text, '\n');
     while (lines.next()) |raw_line| {
-        const line = std.mem.trimEnd(u8, raw_line, "\r");
+        // Strip exactly one CR from a CRLF terminator. Any further CR stays
+        // in the line and fails validation; bare CR is not a terminator.
+        const line = if (raw_line.len > 0 and raw_line[raw_line.len - 1] == '\r')
+            raw_line[0 .. raw_line.len - 1]
+        else
+            raw_line;
         // A trailing newline at EOF yields one final empty segment; that is
         // end-of-input, not a blank line inside a block.
         if (line.len == 0 and lines.peek() == null) break;
@@ -157,7 +162,9 @@ pub fn loadChainPem(allocator: std.mem.Allocator, pem_text: []const u8, limits: 
                     state = .outside;
                 } else {
                     try validateBase64Line(line);
-                    if (base64_buf.items.len + line.len > max_base64_len) return error.CertificateTooLarge;
+                    // items.len <= max_base64_len is an invariant, so the
+                    // subtraction cannot underflow and the check cannot wrap.
+                    if (line.len > max_base64_len - base64_buf.items.len) return error.CertificateTooLarge;
                     try base64_buf.appendSlice(allocator, line);
                 }
             },
@@ -309,9 +316,13 @@ fn validateCertificateDer(bytes: []const u8, limits: Limits) Error!void {
     reader.expectEnd() catch return error.MalformedCertificateDer;
 }
 
-/// Base64 length (with padding) for `len` raw bytes.
+/// Base64 length (with padding) for `len` raw bytes. `Limits` is
+/// caller-controlled, so this must not overflow for extreme values;
+/// saturating at maxInt just means the accumulation bound defers to
+/// `max_input_len`.
 fn base64EncodedLen(len: usize) usize {
-    return ((len + 2) / 3) * 4;
+    const groups = len / 3 + @intFromBool(len % 3 != 0);
+    return groups *| 4;
 }
 
 /// Fuzz and regression entrypoint (#327-G): parse arbitrary bytes as a PEM

--- a/src/pki/pem_tests.zig
+++ b/src/pki/pem_tests.zig
@@ -234,12 +234,54 @@ test "strict base64 rejects malformed data" {
         "====\n",
         // Bare CR inside a base64 line is not a line terminator.
         "MAMC\rAQE=\n",
+        // Doubled CR before LF: only one CR belongs to the CRLF terminator.
+        "MAMCAQE=\r\r\n",
     };
     for (cases) |body| {
         const text = try std.mem.concat(allocator, u8, &.{ prefix, body, suffix });
         defer allocator.free(text);
         try testing.expectError(error.InvalidPemBase64, pem.loadChainPem(allocator, text, .{}));
     }
+}
+
+test "doubled CR before LF on a boundary line fails typed" {
+    const allocator = testing.allocator;
+    try testing.expectError(error.MalformedPemBoundary, pem.loadChainPem(
+        allocator,
+        "-----BEGIN CERTIFICATE-----\r\r\nMAMCAQE=\r\n-----END CERTIFICATE-----\r\n",
+        .{},
+    ));
+}
+
+test "extreme caller-supplied limits do not overflow bound computation" {
+    const allocator = testing.allocator;
+    const cert = minimalCertDer(1);
+    const text = try certPem(allocator, &cert, "\n");
+    defer allocator.free(text);
+
+    // max_certificate_len at maxInt must not wrap in the base64 bound; the
+    // input is still bounded by max_input_len.
+    var chain = try pem.loadChainPem(allocator, text, .{
+        .max_certificate_len = std.math.maxInt(usize),
+        .max_input_len = std.math.maxInt(usize),
+        .max_certificates = std.math.maxInt(usize),
+    });
+    defer chain.deinit(allocator);
+    try testing.expectEqualSlices(u8, &cert, chain.certificates[0].der);
+
+    // Values just below the multiplication saturation point behave the same.
+    var chain2 = try pem.loadChainPem(allocator, text, .{
+        .max_certificate_len = std.math.maxInt(usize) / 4 * 3 + 1,
+    });
+    defer chain2.deinit(allocator);
+    try testing.expectEqual(@as(usize, 1), chain2.certificates.len);
+
+    var single = try pem.loadCertificateDer(allocator, &cert, .{
+        .max_certificate_len = std.math.maxInt(usize),
+        .max_input_len = std.math.maxInt(usize),
+    });
+    defer single.deinit(allocator);
+    try testing.expectEqualSlices(u8, &cert, single.der);
 }
 
 test "empty certificate block fails typed" {

--- a/src/pki/pem_tests.zig
+++ b/src/pki/pem_tests.zig
@@ -1,0 +1,403 @@
+//! PEM and certificate-chain loader regression and adversarial tests (#340).
+
+const std = @import("std");
+const der = @import("der.zig");
+const pem = @import("pem.zig");
+
+const testing = std.testing;
+
+/// Minimal valid "certificate" DER for structural tests: SEQUENCE { INTEGER n }.
+/// The loader only enforces the outer SEQUENCE shape; interior is #341.
+fn minimalCertDer(n: u8) [5]u8 {
+    return .{ 0x30, 0x03, 0x02, 0x01, n };
+}
+
+fn appendPemBlock(out: *std.ArrayList(u8), allocator: std.mem.Allocator, label: []const u8, der_bytes: []const u8, line_ending: []const u8) !void {
+    const encoder = std.base64.standard.Encoder;
+    const encoded = try allocator.alloc(u8, encoder.calcSize(der_bytes.len));
+    defer allocator.free(encoded);
+    _ = encoder.encode(encoded, der_bytes);
+
+    try out.appendSlice(allocator, "-----BEGIN ");
+    try out.appendSlice(allocator, label);
+    try out.appendSlice(allocator, "-----");
+    try out.appendSlice(allocator, line_ending);
+    var rest: []const u8 = encoded;
+    while (rest.len > 0) {
+        const take = @min(rest.len, 64);
+        try out.appendSlice(allocator, rest[0..take]);
+        try out.appendSlice(allocator, line_ending);
+        rest = rest[take..];
+    }
+    try out.appendSlice(allocator, "-----END ");
+    try out.appendSlice(allocator, label);
+    try out.appendSlice(allocator, "-----");
+    try out.appendSlice(allocator, line_ending);
+}
+
+fn certPem(allocator: std.mem.Allocator, der_bytes: []const u8, line_ending: []const u8) ![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(allocator);
+    try appendPemBlock(&out, allocator, "CERTIFICATE", der_bytes, line_ending);
+    return out.toOwnedSlice(allocator);
+}
+
+test "single certificate loads and preserves exact DER bytes" {
+    const allocator = testing.allocator;
+    const cert = minimalCertDer(1);
+    const text = try certPem(allocator, &cert, "\n");
+    defer allocator.free(text);
+
+    var chain = try pem.loadChainPem(allocator, text, .{});
+    defer chain.deinit(allocator);
+
+    try testing.expectEqual(@as(usize, 1), chain.certificates.len);
+    try testing.expectEqualSlices(u8, &cert, chain.certificates[0].der);
+}
+
+test "multi-certificate chain preserves input order" {
+    const allocator = testing.allocator;
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(allocator);
+    const leaf = minimalCertDer(1);
+    const intermediate = minimalCertDer(2);
+    const root = minimalCertDer(3);
+    try appendPemBlock(&out, allocator, "CERTIFICATE", &leaf, "\n");
+    try appendPemBlock(&out, allocator, "CERTIFICATE", &intermediate, "\n");
+    try appendPemBlock(&out, allocator, "CERTIFICATE", &root, "\n");
+
+    var chain = try pem.loadChainPem(allocator, out.items, .{});
+    defer chain.deinit(allocator);
+
+    try testing.expectEqual(@as(usize, 3), chain.certificates.len);
+    try testing.expectEqualSlices(u8, &leaf, chain.certificates[0].der);
+    try testing.expectEqualSlices(u8, &intermediate, chain.certificates[1].der);
+    try testing.expectEqualSlices(u8, &root, chain.certificates[2].der);
+}
+
+test "mixed surrounding text and OpenSSL-style annotations are ignored" {
+    const allocator = testing.allocator;
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(allocator);
+    const cert_a = minimalCertDer(1);
+    const cert_b = minimalCertDer(2);
+    try out.appendSlice(allocator, "# Root bundle exported 2026-07-12\n\n");
+    try out.appendSlice(allocator, "subject=CN = Test Leaf\nissuer=CN = Test CA\n");
+    try appendPemBlock(&out, allocator, "CERTIFICATE", &cert_a, "\n");
+    try out.appendSlice(allocator, "\nsubject=CN = Test CA\n");
+    try appendPemBlock(&out, allocator, "CERTIFICATE", &cert_b, "\n");
+    try out.appendSlice(allocator, "trailing commentary, no dashes\n");
+
+    var chain = try pem.loadChainPem(allocator, out.items, .{});
+    defer chain.deinit(allocator);
+    try testing.expectEqual(@as(usize, 2), chain.certificates.len);
+    try testing.expectEqualSlices(u8, &cert_a, chain.certificates[0].der);
+    try testing.expectEqualSlices(u8, &cert_b, chain.certificates[1].der);
+}
+
+test "CRLF and mixed line endings load identically to LF" {
+    const allocator = testing.allocator;
+    const cert = minimalCertDer(7);
+
+    const crlf_text = try certPem(allocator, &cert, "\r\n");
+    defer allocator.free(crlf_text);
+    var crlf_chain = try pem.loadChainPem(allocator, crlf_text, .{});
+    defer crlf_chain.deinit(allocator);
+    try testing.expectEqualSlices(u8, &cert, crlf_chain.certificates[0].der);
+
+    var mixed: std.ArrayList(u8) = .empty;
+    defer mixed.deinit(allocator);
+    const cert_b = minimalCertDer(8);
+    try appendPemBlock(&mixed, allocator, "CERTIFICATE", &cert, "\r\n");
+    try appendPemBlock(&mixed, allocator, "CERTIFICATE", &cert_b, "\n");
+    var mixed_chain = try pem.loadChainPem(allocator, mixed.items, .{});
+    defer mixed_chain.deinit(allocator);
+    try testing.expectEqual(@as(usize, 2), mixed_chain.certificates.len);
+}
+
+test "missing final newline after END boundary still loads" {
+    const allocator = testing.allocator;
+    const cert = minimalCertDer(1);
+    const text = try certPem(allocator, &cert, "\n");
+    defer allocator.free(text);
+    const trimmed = std.mem.trimEnd(u8, text, "\n");
+
+    var chain = try pem.loadChainPem(allocator, trimmed, .{});
+    defer chain.deinit(allocator);
+    try testing.expectEqual(@as(usize, 1), chain.certificates.len);
+}
+
+test "non-certificate blocks are skipped but must be well-formed" {
+    const allocator = testing.allocator;
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(allocator);
+    const cert = minimalCertDer(1);
+    const key_bytes = [_]u8{ 0x01, 0x02, 0x03, 0x04 };
+    try appendPemBlock(&out, allocator, "PRIVATE KEY", &key_bytes, "\n");
+    try appendPemBlock(&out, allocator, "CERTIFICATE", &cert, "\n");
+    try appendPemBlock(&out, allocator, "EC PARAMETERS", &key_bytes, "\n");
+
+    var chain = try pem.loadChainPem(allocator, out.items, .{});
+    defer chain.deinit(allocator);
+    try testing.expectEqual(@as(usize, 1), chain.certificates.len);
+    try testing.expectEqualSlices(u8, &cert, chain.certificates[0].der);
+}
+
+test "input with no certificate blocks fails typed" {
+    const allocator = testing.allocator;
+    try testing.expectError(error.NoCertificates, pem.loadChainPem(allocator, "just some text\n", .{}));
+    try testing.expectError(error.NoCertificates, pem.loadChainPem(allocator, "", .{}));
+
+    // A lone skipped block is well-formed but yields an empty chain.
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(allocator);
+    const key_bytes = [_]u8{ 0x01, 0x02 };
+    try appendPemBlock(&out, allocator, "PRIVATE KEY", &key_bytes, "\n");
+    try testing.expectError(error.NoCertificates, pem.loadChainPem(allocator, out.items, .{}));
+}
+
+test "malformed boundaries fail typed" {
+    const allocator = testing.allocator;
+    const cases = [_][]const u8{
+        // Dashes but not a boundary.
+        "-----GARBAGE-----\n",
+        // Truncated BEGIN keyword.
+        "-----BEGIN CERTIFICATE\n",
+        // Missing closing dashes.
+        "-----BEGIN CERTIFICATE---\nMTIz\n-----END CERTIFICATE-----\n",
+        // Empty label.
+        "-----BEGIN -----\n-----END -----\n",
+        // Label with control character.
+        "-----BEGIN CERT\tIFICATE-----\nMTIz\n-----END CERT\tIFICATE-----\n",
+        // Label with doubled separator.
+        "-----BEGIN NEW  CERTIFICATE-----\n-----END NEW  CERTIFICATE-----\n",
+        // Label with trailing separator.
+        "-----BEGIN CERTIFICATE- -----\n",
+        // Trailing junk after the closing dashes.
+        "-----BEGIN CERTIFICATE----- junk\nMTIz\n-----END CERTIFICATE-----\n",
+        // END with no open block.
+        "-----END CERTIFICATE-----\n",
+        // Nested BEGIN inside an open block.
+        "-----BEGIN CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\n",
+    };
+    for (cases) |case| {
+        try testing.expectError(error.MalformedPemBoundary, pem.loadChainPem(allocator, case, .{}));
+    }
+}
+
+test "mismatched END label fails typed" {
+    const allocator = testing.allocator;
+    try testing.expectError(error.MismatchedPemLabel, pem.loadChainPem(
+        allocator,
+        "-----BEGIN CERTIFICATE-----\nMAMCAQE=\n-----END PRIVATE KEY-----\n",
+        .{},
+    ));
+    try testing.expectError(error.MismatchedPemLabel, pem.loadChainPem(
+        allocator,
+        "-----BEGIN PRIVATE KEY-----\nMAMCAQE=\n-----END CERTIFICATE-----\n",
+        .{},
+    ));
+}
+
+test "unterminated block fails typed" {
+    const allocator = testing.allocator;
+    try testing.expectError(error.UnterminatedPemBlock, pem.loadChainPem(
+        allocator,
+        "-----BEGIN CERTIFICATE-----\nMAMCAQE=\n",
+        .{},
+    ));
+    try testing.expectError(error.UnterminatedPemBlock, pem.loadChainPem(
+        allocator,
+        "-----BEGIN PRIVATE KEY-----\nAAAA\n",
+        .{},
+    ));
+}
+
+test "strict base64 rejects malformed data" {
+    const allocator = testing.allocator;
+    const prefix = "-----BEGIN CERTIFICATE-----\n";
+    const suffix = "-----END CERTIFICATE-----\n";
+    const cases = [_][]const u8{
+        // Invalid character.
+        "MAMCAQ!=\n",
+        // Interior space.
+        "MAMC AQE=\n",
+        // Blank line inside the block.
+        "MAMC\n\nAQE=\n",
+        // Length not a multiple of four (missing padding).
+        "MAMCAQE\n",
+        // Data after padding within the block.
+        "MAMCAQE=\nAAAA\n",
+        // Nonzero trailing bits (non-canonical final symbol).
+        "MAMCAQF=\n",
+        // Padding only.
+        "====\n",
+        // Bare CR inside a base64 line is not a line terminator.
+        "MAMC\rAQE=\n",
+    };
+    for (cases) |body| {
+        const text = try std.mem.concat(allocator, u8, &.{ prefix, body, suffix });
+        defer allocator.free(text);
+        try testing.expectError(error.InvalidPemBase64, pem.loadChainPem(allocator, text, .{}));
+    }
+}
+
+test "empty certificate block fails typed" {
+    const allocator = testing.allocator;
+    try testing.expectError(error.EmptyPemBlock, pem.loadChainPem(
+        allocator,
+        "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n",
+        .{},
+    ));
+}
+
+test "decoded bytes that are not one DER SEQUENCE fail typed" {
+    const allocator = testing.allocator;
+
+    // INTEGER at top level instead of SEQUENCE.
+    const not_sequence = [_]u8{ 0x02, 0x01, 0x01 };
+    // Valid SEQUENCE followed by trailing bytes.
+    const trailing = [_]u8{ 0x30, 0x03, 0x02, 0x01, 0x01, 0x00 };
+    // Truncated SEQUENCE (length beyond content).
+    const truncated = [_]u8{ 0x30, 0x10, 0x02, 0x01 };
+    // BER indefinite length.
+    const indefinite = [_]u8{ 0x30, 0x80, 0x00, 0x00 };
+
+    for ([_][]const u8{ &not_sequence, &trailing, &truncated, &indefinite }) |bytes| {
+        const text = try certPem(allocator, bytes, "\n");
+        defer allocator.free(text);
+        try testing.expectError(error.MalformedCertificateDer, pem.loadChainPem(allocator, text, .{}));
+        try testing.expectError(error.MalformedCertificateDer, pem.loadCertificateDer(allocator, bytes, .{}));
+    }
+}
+
+test "certificate count limit fails typed" {
+    const allocator = testing.allocator;
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(allocator);
+    const cert_a = minimalCertDer(1);
+    const cert_b = minimalCertDer(2);
+    try appendPemBlock(&out, allocator, "CERTIFICATE", &cert_a, "\n");
+    try appendPemBlock(&out, allocator, "CERTIFICATE", &cert_b, "\n");
+
+    try testing.expectError(error.TooManyCertificates, pem.loadChainPem(allocator, out.items, .{ .max_certificates = 1 }));
+
+    var chain = try pem.loadChainPem(allocator, out.items, .{ .max_certificates = 2 });
+    defer chain.deinit(allocator);
+    try testing.expectEqual(@as(usize, 2), chain.certificates.len);
+}
+
+test "hostile oversized input fails before unbounded allocation" {
+    const allocator = testing.allocator;
+
+    // Input larger than max_input_len is rejected up front.
+    const big = try allocator.alloc(u8, 1024);
+    defer allocator.free(big);
+    @memset(big, 'A');
+    try testing.expectError(error.InputTooLarge, pem.loadChainPem(allocator, big, .{ .max_input_len = 512 }));
+    try testing.expectError(error.InputTooLarge, pem.loadCertificateDer(allocator, big, .{ .max_input_len = 512 }));
+
+    // A block whose base64 exceeds the per-certificate bound is rejected
+    // during accumulation, before base64 decoding or DER validation.
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(allocator);
+    try out.appendSlice(allocator, "-----BEGIN CERTIFICATE-----\n");
+    var i: usize = 0;
+    while (i < 40) : (i += 1) {
+        try out.appendSlice(allocator, "QUFB" ** 16);
+        try out.appendSlice(allocator, "\n");
+    }
+    try out.appendSlice(allocator, "-----END CERTIFICATE-----\n");
+    try testing.expectError(error.CertificateTooLarge, pem.loadChainPem(allocator, out.items, .{ .max_certificate_len = 1024 }));
+
+    // Same bound applies to the decoded size of a DER buffer.
+    const cert = minimalCertDer(1);
+    try testing.expectError(error.CertificateTooLarge, pem.loadCertificateDer(allocator, &cert, .{ .max_certificate_len = 4 }));
+}
+
+test "loadCertificatePem accepts exactly one block" {
+    const allocator = testing.allocator;
+    const cert = minimalCertDer(5);
+    const single = try certPem(allocator, &cert, "\n");
+    defer allocator.free(single);
+
+    var loaded = try pem.loadCertificatePem(allocator, single, .{});
+    defer loaded.deinit(allocator);
+    try testing.expectEqualSlices(u8, &cert, loaded.der);
+
+    var two: std.ArrayList(u8) = .empty;
+    defer two.deinit(allocator);
+    try appendPemBlock(&two, allocator, "CERTIFICATE", &cert, "\n");
+    try appendPemBlock(&two, allocator, "CERTIFICATE", &cert, "\n");
+    try testing.expectError(error.TooManyCertificates, pem.loadCertificatePem(allocator, two.items, .{}));
+}
+
+test "loadCertificateDer copies exact bytes and rejects empty input" {
+    const allocator = testing.allocator;
+    const cert = minimalCertDer(9);
+
+    var loaded = try pem.loadCertificateDer(allocator, &cert, .{});
+    defer loaded.deinit(allocator);
+    try testing.expectEqualSlices(u8, &cert, loaded.der);
+    // Owned copy, not a view into the input.
+    try testing.expect(loaded.der.ptr != @as([]const u8, &cert).ptr);
+
+    try testing.expectError(error.NoCertificates, pem.loadCertificateDer(allocator, &.{}, .{}));
+}
+
+test "file helpers load PEM chains and DER certificates" {
+    const allocator = testing.allocator;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const cert_a = minimalCertDer(1);
+    const cert_b = minimalCertDer(2);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(allocator);
+    try appendPemBlock(&out, allocator, "CERTIFICATE", &cert_a, "\n");
+    try appendPemBlock(&out, allocator, "CERTIFICATE", &cert_b, "\n");
+
+    try tmp.dir.writeFile(io, .{ .sub_path = "chain.pem", .data = out.items });
+    try tmp.dir.writeFile(io, .{ .sub_path = "cert.der", .data = &cert_a });
+
+    var chain = try pem.loadChainPemFile(allocator, io, tmp.dir, "chain.pem", .{});
+    defer chain.deinit(allocator);
+    try testing.expectEqual(@as(usize, 2), chain.certificates.len);
+    try testing.expectEqualSlices(u8, &cert_a, chain.certificates[0].der);
+    try testing.expectEqualSlices(u8, &cert_b, chain.certificates[1].der);
+
+    var single = try pem.loadCertificateDerFile(allocator, io, tmp.dir, "cert.der", .{});
+    defer single.deinit(allocator);
+    try testing.expectEqualSlices(u8, &cert_a, single.der);
+
+    try testing.expectError(error.FileNotFound, pem.loadChainPemFile(allocator, io, tmp.dir, "missing.pem", .{}));
+    try testing.expectError(error.InputTooLarge, pem.loadChainPemFile(allocator, io, tmp.dir, "chain.pem", .{ .max_input_len = 8 }));
+}
+
+test "loader is leak-free across allocation failure points" {
+    const cert_a = minimalCertDer(1);
+    const cert_b = minimalCertDer(2);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    try appendPemBlock(&out, testing.allocator, "CERTIFICATE", &cert_a, "\n");
+    try appendPemBlock(&out, testing.allocator, "CERTIFICATE", &cert_b, "\n");
+
+    try testing.checkAllAllocationFailures(testing.allocator, struct {
+        fn run(allocator: std.mem.Allocator, text: []const u8) !void {
+            var chain = try pem.loadChainPem(allocator, text, .{});
+            chain.deinit(allocator);
+        }
+    }.run, .{out.items});
+}
+
+test "fuzz entrypoint tolerates arbitrary input" {
+    const allocator = testing.allocator;
+    pem.fuzzLoadChainPem(allocator, "");
+    pem.fuzzLoadChainPem(allocator, "-----BEGIN CERTIFICATE-----");
+    pem.fuzzLoadChainPem(allocator, "-----BEGIN CERTIFICATE-----\n\x00\xff\n-----END CERTIFICATE-----\n");
+    const cert = minimalCertDer(1);
+    const text = try certPem(allocator, &cert, "\n");
+    defer allocator.free(text);
+    pem.fuzzLoadChainPem(allocator, text);
+}

--- a/src/pki/root.zig
+++ b/src/pki/root.zig
@@ -1,31 +1,37 @@
-//! Pure-Zig PKI foundation (#324, #339): bounded ASN.1 DER decoding for X.509.
+//! Pure-Zig PKI foundation (#324, #339, #340): bounded ASN.1 DER decoding and
+//! PEM/certificate-chain loading for X.509.
 //!
-//! This package is the DER foundation for the Web PKI epic (#324). It does not
-//! parse complete certificates (#341), load PEM (#340), or verify signatures.
+//! This package is the DER and PEM foundation for the Web PKI epic (#324). It
+//! does not parse complete certificates (#341) or verify signatures.
 //!
 //! ## Modules
 //!
 //! - `der` — TLV cursor, typed decoders, limits, fuzz entrypoint
 //! - `oid` — OBJECT IDENTIFIER component decoding
 //! - `time` — UTCTime and GeneralizedTime validation
+//! - `pem` — strict PEM decoding and DER certificate-chain loading
 //!
 //! ## Policy summary
 //!
 //! Definite-length DER only; reject BER indefinite lengths and non-minimal
 //! encodings. Zero-copy views into caller-owned input; call `expectEnd` to
-//! enforce complete consumption. See `der.Limits` for default bounds.
+//! enforce complete consumption. See `der.Limits` for default bounds. PEM
+//! loading is strict (RFC 7468 profile) and returns owned DER copies; see
+//! `pem.Limits` for input, size, and count bounds.
 //!
 //! ## Downstream usage
 //!
-//! #340 should base64-decode PEM blocks and hand DER bytes to `der.Reader`.
 //! #341 should map TBSCertificate, Name, and Extension sequences using child
-//! readers and the typed decoders exported here.
+//! readers and the typed decoders exported here, consuming exact DER bytes
+//! from `pem.CertificateChain`.
 
 pub const der = @import("der.zig");
 pub const oid = @import("oid.zig");
 pub const time = @import("time.zig");
+pub const pem = @import("pem.zig");
 
 test {
     @import("std").testing.refAllDecls(@This());
     _ = @import("der_tests.zig");
+    _ = @import("pem_tests.zig");
 }


### PR DESCRIPTION
**What changed and why**
Adds `src/pki/pem.zig`, a pure-Zig loader for X.509 certificates and ordered certificate chains from PEM or DER buffers/files, with no OpenSSL objects involved (story 324-B of the Web PKI epic #324). `CERTIFICATE` blocks are decoded with strict RFC 7468 handling: standard base64 alphabet only, canonical padding, zero trailing bits, no data after padding, and well-formed encapsulation boundaries with validated labels. Surrounding text (OpenSSL-style `subject=`/`issuer=` annotations) and well-formed non-certificate blocks (private keys, parameters) are tolerated the way real bundle files require; LF and CRLF line endings both load. Every decoded certificate must be exactly one definite-length DER SEQUENCE, validated with the #339 `der.Reader`, and exact DER bytes plus input order are preserved for #341. Memory-buffer APIs (`loadChainPem`, `loadCertificatePem`, `loadCertificateDer`) come first, with thin `std.Io`-based file helpers on top, plus a `fuzzLoadChainPem` entrypoint for #327-G.

Configurable `pem.Limits` bound total input size, per-certificate DER size, and certificate count, and are enforced *before* any attacker-driven allocation (oversized base64 is rejected during accumulation, decoded-size is checked before the DER buffer is allocated). All failures are typed errors (`MalformedPemBoundary`, `MismatchedPemLabel`, `UnterminatedPemBlock`, `InvalidPemBase64`, `EmptyPemBlock`, `MalformedCertificateDer`, `InputTooLarge`, `CertificateTooLarge`, `TooManyCertificates`, `NoCertificates`). Returned `Certificate`/`CertificateChain` values own copies of the DER bytes and are freed with explicit `deinit(allocator)`.

**Related issues**
Closes #340

**Tests**
`src/pki/pem_tests.zig` adds 18 tests: single certs, leaf/intermediate/root chain order preservation, exact-DER-byte preservation, mixed surrounding text, LF/CRLF/mixed line endings, missing final newline, skipped non-certificate blocks, empty inputs, ten malformed-boundary corpora, mismatched END labels, unterminated blocks, eight strict-base64 corpora (invalid chars, interior whitespace, blank lines, missing/mid-stream padding, data after padding, nonzero trailing bits, bare CR), empty blocks, non-SEQUENCE/trailing/truncated/indefinite-length DER, count limits, hostile oversized input (rejected before decode), file-helper round trips through `std.testing.tmpDir`, `checkAllAllocationFailures` leak coverage of every allocation-failure point, and fuzz-entrypoint smoke input.

**Security impact**
This is TLS-area code that parses untrusted input (certificate files/buffers). Reviewed: all size/count limits are enforced before allocation sized by attacker data; base64 decoding is strict (no whitespace tolerance inside lines, canonical padding, zero trailing bits); DER structural validation reuses the bounded #339 reader with its depth/length/element limits; no parser path reads outside the supplied slice; `errdefer`/`defer` guard every partial construction so error paths do not leak (verified by `checkAllAllocationFailures`). No existing header parsing, routing, auth, or logging paths are touched — this is a new leaf module not yet wired into the TLS runtime.

**Performance impact**
None. New standalone module; nothing on the event loop, worker pool, or any hot path. Loading is O(input length) with a single pass and one owned copy per certificate.

**Checklist**
- [x] `zig fmt --check build.zig src/ tests/` passes
- [x] `zig build test --summary all` green
- [x] `zig build test-integration` green (required for protocol, proxy, and TLS changes)
- [x] New behavior covered by tests
- [x] [docs/CODE_REVIEW_CHECKLIST.md](docs/CODE_REVIEW_CHECKLIST.md) completed
- [x] README / CHANGELOG updated if operator-visible behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXTLYSnUHiEhFV4mWVBMgN

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXTLYSnUHiEhFV4mWVBMgN)_