### PR TITLE
crypto: add typed secret ownership helpers

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -25,11 +25,17 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    const crypto_secrets_mod = b.createModule(.{
+        .root_source_file = b.path("src/crypto/secrets.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
     const tls_core_mod = b.createModule(.{
         .root_source_file = b.path("src/tls/root.zig"),
         .target = target,
         .optimize = optimize,
     });
+    tls_core_mod.addImport("crypto_secrets", crypto_secrets_mod);
 
     // Shared leaf modules. A Zig source file belongs to exactly one module,
     // so anything consumed by both the exe tree and the quic/http3 packages
@@ -55,6 +61,7 @@ pub fn build(b: *std.Build) void {
     });
     quic_mod.addImport("quic_varint", quic_varint_mod);
     quic_mod.addImport("tls_core", tls_core_mod);
+    quic_mod.addImport("crypto_secrets", crypto_secrets_mod);
     const http3_mod = b.createModule(.{
         .root_source_file = b.path("src/http3/root.zig"),
         .target = target,
@@ -222,11 +229,16 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    crypto_mod.addImport("crypto_secrets", crypto_secrets_mod);
     const crypto_tests = b.addTest(.{ .root_module = crypto_mod });
     const run_crypto_tests = b.addRunArtifact(crypto_tests);
+    const crypto_secret_tests = b.addTest(.{ .root_module = crypto_secrets_mod });
+    const run_crypto_secret_tests = b.addRunArtifact(crypto_secret_tests);
     const crypto_step = b.step("test-crypto", "Run pure-Zig cryptographic-provider unit tests");
     crypto_step.dependOn(&run_crypto_tests.step);
+    crypto_step.dependOn(&run_crypto_secret_tests.step);
     test_step.dependOn(&run_crypto_tests.step);
+    test_step.dependOn(&run_crypto_secret_tests.step);
 
     const http3_tests = b.addTest(.{ .root_module = http3_mod });
     const run_http3_tests = b.addRunArtifact(http3_tests);

--- a/docs/CRYPTO_PROVIDER.md
+++ b/docs/CRYPTO_PROVIDER.md
@@ -104,7 +104,9 @@ storage with an explicit upper bound. These types copy input into owned memory,
 return borrowed slices through `slice`, wipe replaced contents before reuse, and
 must be `deinit`ed before the owning connection/key object is discarded. Secret
 containers deliberately provide a `format` method that fails compilation so
-accidental `{}` logging does not expose key material.
+accidental `{}` logging does not expose key material. `BoundedSecret` is
+initialized in place so callers do not receive an owning heap allocation by
+value; any ownership transfer must be explicit at the call site.
 
 ### Entropy is injected
 

--- a/docs/CRYPTO_PROVIDER.md
+++ b/docs/CRYPTO_PROVIDER.md
@@ -29,6 +29,9 @@ boundary is what keeps the two from coupling to each other.
   discovery, the error taxonomy, the injected `Entropy` source, the opaque
   `SigningKey` handle, and the `CryptoProvider` interface (a `context` pointer
   plus a `*const VTable`, the same seam shape as the QUIC `TlsBackend`).
+- `src/crypto/secrets.zig` — fixed-size and bounded dynamic secret containers,
+  shared secure-zero and constant-time comparison helpers, and the non-formatting
+  convention for secret-bearing values.
 - `src/crypto/pure_zig.zig` — the first concrete backend, built entirely on
   `std.crypto`. Implements the narrow first profile and advertises exactly that.
 - `src/crypto/root.zig` — the package aggregator.
@@ -47,6 +50,8 @@ changes when it lands.
 - **Signatures** — verification, and signing through the opaque `SigningKey`
   handle, for Ed25519 and (declared) ECDSA-P256 and RSA-PSS.
 - **Random bytes**, **constant-time comparison**, and **secure zeroing**.
+- **Secret containers** for fixed-size stack material and bounded heap material,
+  with explicit replacement and deinitialization rules.
 - **Opaque private-key handles** and **capability discovery**.
 
 The pure-Zig backend implements the overlap the TLS/QUIC engines need today:
@@ -92,6 +97,14 @@ way out — including HKDF's per-block temporaries, the X25519 seed, ephemeral
 private scalar, and shared-secret copies. AEAD-open zeroes its output buffer on
 authentication failure so no unauthenticated plaintext is ever left for the
 caller to read.
+
+Secret-bearing protocol state should use `crypto.secrets.FixedSecret(N)` for
+fixed-capacity storage and `crypto.secrets.BoundedSecret` for heap-backed
+storage with an explicit upper bound. These types copy input into owned memory,
+return borrowed slices through `slice`, wipe replaced contents before reuse, and
+must be `deinit`ed before the owning connection/key object is discarded. Secret
+containers deliberately provide a `format` method that fails compilation so
+accidental `{}` logging does not expose key material.
 
 ### Entropy is injected
 

--- a/src/crypto/provider.zig
+++ b/src/crypto/provider.zig
@@ -45,6 +45,7 @@
 
 const std = @import("std");
 const crypto = std.crypto;
+const secrets = @import("crypto_secrets");
 
 // ---------------------------------------------------------------------------
 // Fixed capacities
@@ -505,20 +506,14 @@ pub const CryptoProvider = struct {
 /// lengths the running time is independent of where — or whether — the bytes
 /// differ. Use this for MACs, Finished values, and any secret-derived tag.
 pub fn constantTimeEqual(a: []const u8, b: []const u8) bool {
-    // Lengths are not secret, so the mismatch short-circuits. The content
-    // comparison is delegated to the standard library's dedicated timing-safe
-    // primitive rather than a hand-rolled loop. `timing_safe.eql` needs a
-    // comptime-fixed length; `timing_safe.compare` is its slice-based sibling
-    // and runs in constant time for equal-length inputs.
-    if (a.len != b.len) return false;
-    return crypto.timing_safe.compare(u8, a, b, .big) == .eq;
+    return secrets.constantTimeEqual(a, b);
 }
 
 /// Overwrite `buffer` with zeros in a way the optimiser may not elide. Call
 /// this on any stack or heap copy of secret material before it goes out of
 /// scope.
 pub fn secureZero(buffer: []u8) void {
-    crypto.secureZero(u8, buffer);
+    secrets.secureZero(buffer);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/crypto/root.zig
+++ b/src/crypto/root.zig
@@ -7,6 +7,7 @@
 
 pub const provider = @import("provider.zig");
 pub const pure_zig = @import("pure_zig.zig");
+pub const secrets = @import("crypto_secrets");
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/crypto/secrets.zig
+++ b/src/crypto/secrets.zig
@@ -1,0 +1,203 @@
+//! Secret ownership and zeroization helpers (#372).
+//!
+//! These containers make secret lifetimes explicit. They copy caller-provided
+//! bytes into owned storage, expose only borrowed slices, wipe replaced values
+//! before reuse, and require `deinit` before the value is discarded.
+
+const std = @import("std");
+
+pub const Error = error{SecretTooLarge};
+
+pub fn secureZero(buffer: []u8) void {
+    std.crypto.secureZero(u8, buffer);
+}
+
+pub fn constantTimeEqual(a: []const u8, b: []const u8) bool {
+    if (a.len != b.len) return false;
+    return std.crypto.timing_safe.compare(u8, a, b, .big) == .eq;
+}
+
+pub fn FixedSecret(comptime capacity: usize) type {
+    return struct {
+        bytes: [capacity]u8 = [_]u8{0} ** capacity,
+        len: usize = 0,
+
+        const Self = @This();
+
+        pub fn init(value: []const u8) Error!Self {
+            var secret = Self{};
+            try secret.replace(value);
+            return secret;
+        }
+
+        pub fn replace(self: *Self, value: []const u8) Error!void {
+            if (value.len > self.bytes.len) return error.SecretTooLarge;
+            self.clear();
+            @memcpy(self.bytes[0..value.len], value);
+            self.len = value.len;
+        }
+
+        pub fn slice(self: *const Self) []const u8 {
+            return self.bytes[0..self.len];
+        }
+
+        pub fn copy(self: *const Self) Self {
+            var out = Self{};
+            out.replace(self.slice()) catch unreachable;
+            return out;
+        }
+
+        pub fn eql(self: *const Self, other: *const Self) bool {
+            return constantTimeEqual(self.slice(), other.slice());
+        }
+
+        pub fn deinit(self: *Self) void {
+            self.clear();
+        }
+
+        fn clear(self: *Self) void {
+            if (self.len > 0) secureZero(self.bytes[0..self.len]);
+            self.len = 0;
+        }
+
+        pub fn format(
+            _: Self,
+            comptime _: []const u8,
+            _: std.fmt.FormatOptions,
+            _: anytype,
+        ) !void {
+            @compileError("secret values must not be formatted or logged");
+        }
+    };
+}
+
+pub const BoundedSecret = struct {
+    allocator: std.mem.Allocator,
+    bytes: []u8,
+    len: usize = 0,
+
+    pub fn initCapacity(allocator: std.mem.Allocator, capacity: usize) !BoundedSecret {
+        const bytes = try allocator.alloc(u8, capacity);
+        @memset(bytes, 0);
+        return .{ .allocator = allocator, .bytes = bytes };
+    }
+
+    pub fn init(allocator: std.mem.Allocator, capacity: usize, value: []const u8) !BoundedSecret {
+        var secret = try initCapacity(allocator, capacity);
+        errdefer secret.deinit();
+        try secret.replace(value);
+        return secret;
+    }
+
+    pub fn replace(self: *BoundedSecret, value: []const u8) Error!void {
+        if (value.len > self.bytes.len) return error.SecretTooLarge;
+        self.clear();
+        @memcpy(self.bytes[0..value.len], value);
+        self.len = value.len;
+    }
+
+    pub fn slice(self: *const BoundedSecret) []const u8 {
+        return self.bytes[0..self.len];
+    }
+
+    pub fn eql(self: *const BoundedSecret, other: *const BoundedSecret) bool {
+        return constantTimeEqual(self.slice(), other.slice());
+    }
+
+    pub fn deinit(self: *BoundedSecret) void {
+        self.clearAll();
+        self.allocator.free(self.bytes);
+        self.bytes = self.bytes[0..0];
+        self.len = 0;
+    }
+
+    fn clear(self: *BoundedSecret) void {
+        if (self.len > 0) secureZero(self.bytes[0..self.len]);
+        self.len = 0;
+    }
+
+    fn clearAll(self: *BoundedSecret) void {
+        secureZero(self.bytes);
+        self.len = 0;
+    }
+
+    pub fn format(
+        _: BoundedSecret,
+        comptime _: []const u8,
+        _: std.fmt.FormatOptions,
+        _: anytype,
+    ) !void {
+        @compileError("secret values must not be formatted or logged");
+    }
+};
+
+const testing = std.testing;
+
+test "fixed secret copies, borrows, compares, and zeroizes" {
+    const Secret32 = FixedSecret(32);
+    var first = try Secret32.init("secret");
+    defer first.deinit();
+    var second = try Secret32.init("secret");
+    defer second.deinit();
+
+    try testing.expectEqualStrings("secret", first.slice());
+    try testing.expect(first.eql(&second));
+    first.deinit();
+    try testing.expectEqual(@as(usize, 0), first.len);
+    for (first.bytes) |byte| try testing.expectEqual(@as(u8, 0), byte);
+}
+
+test "fixed secret replace clears old tail before reuse" {
+    const Secret8 = FixedSecret(8);
+    var secret = try Secret8.init("abcdef");
+    try secret.replace("xy");
+
+    try testing.expectEqualStrings("xy", secret.slice());
+    try testing.expectEqual(@as(u8, 0), secret.bytes[2]);
+    try testing.expectEqual(@as(u8, 0), secret.bytes[5]);
+    secret.deinit();
+}
+
+test "fixed secret rejects oversized input without clobbering current value" {
+    const Secret4 = FixedSecret(4);
+    var secret = try Secret4.init("keep");
+    try testing.expectError(error.SecretTooLarge, secret.replace("too-large"));
+    try testing.expectEqualStrings("keep", secret.slice());
+    secret.deinit();
+}
+
+test "bounded secret clears allocator backing storage before free" {
+    var backing = [_]u8{0xcc} ** 128;
+    var fba = std.heap.FixedBufferAllocator.init(&backing);
+    var secret = try BoundedSecret.init(fba.allocator(), 32, &([_]u8{0xab} ** 16));
+    try testing.expectEqual(@as(usize, 16), secret.len);
+
+    secret.clearAll();
+    try testing.expect(std.mem.indexOfScalar(u8, &backing, 0xab) == null);
+    for (backing[0..32]) |byte| try testing.expectEqual(@as(u8, 0), byte);
+    secret.deinit();
+}
+
+test "bounded secret errdefer cleanup zeroizes early returns" {
+    var backing = [_]u8{0xcc} ** 128;
+    var fba = std.heap.FixedBufferAllocator.init(&backing);
+
+    const Helper = struct {
+        fn failAfterInit(allocator: std.mem.Allocator) !void {
+            var secret = try BoundedSecret.init(allocator, 32, &([_]u8{0xdd} ** 16));
+            errdefer secret.deinit();
+            return error.TestExpectedError;
+        }
+    };
+
+    try testing.expectError(error.TestExpectedError, Helper.failAfterInit(fba.allocator()));
+    try testing.expect(std.mem.indexOfScalar(u8, &backing, 0xdd) == null);
+}
+
+test "secret helpers expose non-formatting APIs" {
+    try testing.expect(@hasDecl(FixedSecret(8), "format"));
+    try testing.expect(@hasDecl(BoundedSecret, "format"));
+    try testing.expect(constantTimeEqual("same", "same"));
+    try testing.expect(!constantTimeEqual("same", "diff"));
+    try testing.expect(!constantTimeEqual("short", "shorter"));
+}

--- a/src/crypto/secrets.zig
+++ b/src/crypto/secrets.zig
@@ -32,8 +32,14 @@ pub fn FixedSecret(comptime capacity: usize) type {
 
         pub fn replace(self: *Self, value: []const u8) Error!void {
             if (value.len > self.bytes.len) return error.SecretTooLarge;
-            self.clear();
-            @memcpy(self.bytes[0..value.len], value);
+            const old_len = self.len;
+            if (overlaps(self.bytes[0..], value)) {
+                std.mem.copyForwards(u8, self.bytes[0..value.len], value);
+                if (old_len > value.len) secureZero(self.bytes[value.len..old_len]);
+            } else {
+                self.clear();
+                @memcpy(self.bytes[0..value.len], value);
+            }
             self.len = value.len;
         }
 
@@ -72,27 +78,33 @@ pub fn FixedSecret(comptime capacity: usize) type {
 }
 
 pub const BoundedSecret = struct {
-    allocator: std.mem.Allocator,
-    bytes: []u8,
+    allocator: ?std.mem.Allocator = null,
+    bytes: []u8 = &.{},
     len: usize = 0,
 
-    pub fn initCapacity(allocator: std.mem.Allocator, capacity: usize) !BoundedSecret {
-        const bytes = try allocator.alloc(u8, capacity);
-        @memset(bytes, 0);
-        return .{ .allocator = allocator, .bytes = bytes };
+    pub fn initCapacity(self: *BoundedSecret, allocator: std.mem.Allocator, capacity: usize) !void {
+        std.debug.assert(self.bytes.len == 0);
+        self.bytes = try allocator.alloc(u8, capacity);
+        self.allocator = allocator;
+        @memset(self.bytes, 0);
     }
 
-    pub fn init(allocator: std.mem.Allocator, capacity: usize, value: []const u8) !BoundedSecret {
-        var secret = try initCapacity(allocator, capacity);
-        errdefer secret.deinit();
-        try secret.replace(value);
-        return secret;
+    pub fn init(self: *BoundedSecret, allocator: std.mem.Allocator, capacity: usize, value: []const u8) !void {
+        try self.initCapacity(allocator, capacity);
+        errdefer self.deinit();
+        try self.replace(value);
     }
 
     pub fn replace(self: *BoundedSecret, value: []const u8) Error!void {
         if (value.len > self.bytes.len) return error.SecretTooLarge;
-        self.clear();
-        @memcpy(self.bytes[0..value.len], value);
+        const old_len = self.len;
+        if (overlaps(self.bytes, value)) {
+            std.mem.copyForwards(u8, self.bytes[0..value.len], value);
+            if (old_len > value.len) secureZero(self.bytes[value.len..old_len]);
+        } else {
+            self.clear();
+            @memcpy(self.bytes[0..value.len], value);
+        }
         self.len = value.len;
     }
 
@@ -106,7 +118,9 @@ pub const BoundedSecret = struct {
 
     pub fn deinit(self: *BoundedSecret) void {
         self.clearAll();
-        self.allocator.free(self.bytes);
+        const allocator = self.allocator orelse return;
+        allocator.free(self.bytes);
+        self.allocator = null;
         self.bytes = self.bytes[0..0];
         self.len = 0;
     }
@@ -130,6 +144,15 @@ pub const BoundedSecret = struct {
         @compileError("secret values must not be formatted or logged");
     }
 };
+
+fn overlaps(storage: []const u8, value: []const u8) bool {
+    if (storage.len == 0 or value.len == 0) return false;
+    const storage_start = @intFromPtr(storage.ptr);
+    const storage_end = storage_start + storage.len;
+    const value_start = @intFromPtr(value.ptr);
+    const value_end = value_start + value.len;
+    return value_start < storage_end and storage_start < value_end;
+}
 
 const testing = std.testing;
 
@@ -158,6 +181,15 @@ test "fixed secret replace clears old tail before reuse" {
     secret.deinit();
 }
 
+test "fixed secret replace handles self-overlapping input" {
+    const Secret8 = FixedSecret(8);
+    var secret = try Secret8.init("abcdef");
+    try secret.replace(secret.slice()[1..4]);
+    try testing.expectEqualStrings("bcd", secret.slice());
+    try testing.expectEqual(@as(u8, 0), secret.bytes[3]);
+    secret.deinit();
+}
+
 test "fixed secret rejects oversized input without clobbering current value" {
     const Secret4 = FixedSecret(4);
     var secret = try Secret4.init("keep");
@@ -169,7 +201,8 @@ test "fixed secret rejects oversized input without clobbering current value" {
 test "bounded secret clears allocator backing storage before free" {
     var backing = [_]u8{0xcc} ** 128;
     var fba = std.heap.FixedBufferAllocator.init(&backing);
-    var secret = try BoundedSecret.init(fba.allocator(), 32, &([_]u8{0xab} ** 16));
+    var secret = BoundedSecret{};
+    try secret.init(fba.allocator(), 32, &([_]u8{0xab} ** 16));
     try testing.expectEqual(@as(usize, 16), secret.len);
 
     secret.clearAll();
@@ -184,7 +217,8 @@ test "bounded secret errdefer cleanup zeroizes early returns" {
 
     const Helper = struct {
         fn failAfterInit(allocator: std.mem.Allocator) !void {
-            var secret = try BoundedSecret.init(allocator, 32, &([_]u8{0xdd} ** 16));
+            var secret = BoundedSecret{};
+            try secret.init(allocator, 32, &([_]u8{0xdd} ** 16));
             errdefer secret.deinit();
             return error.TestExpectedError;
         }
@@ -192,6 +226,18 @@ test "bounded secret errdefer cleanup zeroizes early returns" {
 
     try testing.expectError(error.TestExpectedError, Helper.failAfterInit(fba.allocator()));
     try testing.expect(std.mem.indexOfScalar(u8, &backing, 0xdd) == null);
+}
+
+test "bounded secret replace handles self-overlapping input" {
+    var backing = [_]u8{0xcc} ** 128;
+    var fba = std.heap.FixedBufferAllocator.init(&backing);
+    var secret = BoundedSecret{};
+    try secret.init(fba.allocator(), 32, "abcdef");
+    defer secret.deinit();
+
+    try secret.replace(secret.slice()[1..4]);
+    try testing.expectEqualStrings("bcd", secret.slice());
+    try testing.expectEqual(@as(u8, 0), secret.bytes[3]);
 }
 
 test "secret helpers expose non-formatting APIs" {

--- a/src/quic/tls_adapter.zig
+++ b/src/quic/tls_adapter.zig
@@ -18,6 +18,7 @@
 
 const std = @import("std");
 const config = @import("config.zig");
+const crypto_secrets = @import("crypto_secrets");
 const packet = @import("packet.zig");
 const tls_core = @import("tls_core");
 
@@ -100,19 +101,16 @@ pub const Secret = struct {
     level: EncryptionLevel,
     direction: Direction,
     phase: KeyPhase = .current,
-    bytes: [max_secret_len]u8 = [_]u8{0} ** max_secret_len,
-    len: usize = 0,
+    material: crypto_secrets.FixedSecret(max_secret_len) = .{},
 
     pub fn init(level: EncryptionLevel, direction: Direction, bytes: []const u8) error{SecretTooLarge}!Secret {
-        if (bytes.len > max_secret_len) return error.SecretTooLarge;
         var secret = Secret{ .level = level, .direction = direction };
-        @memcpy(secret.bytes[0..bytes.len], bytes);
-        secret.len = bytes.len;
+        secret.material.replace(bytes) catch return error.SecretTooLarge;
         return secret;
     }
 
     pub fn slice(self: *const Secret) []const u8 {
-        return self.bytes[0..self.len];
+        return self.material.slice();
     }
 };
 
@@ -147,8 +145,7 @@ pub const SecretStore = struct {
     }
 
     fn wipe(secret: *Secret) void {
-        @memset(secret.bytes[0..], 0);
-        secret.len = 0;
+        secret.material.deinit();
     }
 };
 
@@ -635,8 +632,9 @@ pub const QuicTlsAdapter = struct {
     pub fn protectionKeys(self: *const QuicTlsAdapter, level: EncryptionLevel, direction: Direction) ?PacketProtectionKeys {
         if (level == .zero_rtt and !self.zero_rtt_enabled) return null;
         const installed_secret = self.secret(level, direction) orelse return null;
-        if (installed_secret.len != traffic_secret_len) return null;
-        return deriveAes128GcmKeys(installed_secret.bytes[0..traffic_secret_len].*);
+        const secret_bytes = installed_secret.slice();
+        if (secret_bytes.len != traffic_secret_len) return null;
+        return deriveAes128GcmKeys(secret_bytes[0..traffic_secret_len].*);
     }
 
     /// Seal `plaintext` for `level`/`direction` into `out`, tracking a protected
@@ -723,8 +721,9 @@ pub const QuicTlsAdapter = struct {
 
     fn applicationTrafficSecret(self: *const QuicTlsAdapter, direction: Direction) ?[traffic_secret_len]u8 {
         const installed_secret = self.secret(.application, direction) orelse return null;
-        if (installed_secret.len != traffic_secret_len) return null;
-        return installed_secret.bytes[0..traffic_secret_len].*;
+        const secret_bytes = installed_secret.slice();
+        if (secret_bytes.len != traffic_secret_len) return null;
+        return secret_bytes[0..traffic_secret_len].*;
     }
 
     pub fn discardSecrets(self: *QuicTlsAdapter, level: EncryptionLevel) void {
@@ -1302,8 +1301,8 @@ test "secret store returns pointers and wipes discarded secret bytes" {
 
     var standalone = try Secret.init(.application, .write, "wipe-me");
     SecretStore.wipe(&standalone);
-    try testing.expectEqual(@as(usize, 0), standalone.len);
-    for (standalone.bytes) |byte| try testing.expectEqual(@as(u8, 0), byte);
+    try testing.expectEqual(@as(usize, 0), standalone.material.len);
+    for (standalone.material.bytes) |byte| try testing.expectEqual(@as(u8, 0), byte);
 
     store.discard(.application);
     try testing.expect(store.get(.application, .write) == null);

--- a/src/tls/record_transport.zig
+++ b/src/tls/record_transport.zig
@@ -16,6 +16,7 @@
 
 const std = @import("std");
 const alerts = @import("alerts.zig");
+const crypto_secrets = @import("crypto_secrets");
 const engine = @import("engine.zig");
 const events = @import("events.zig");
 const state = @import("state.zig");
@@ -84,7 +85,7 @@ pub const EventSink = struct {
     }
 
     fn zeroUsedScratch(self: *EventSink) void {
-        if (self.used > 0) std.crypto.secureZero(u8, self.scratch[0..self.used]);
+        if (self.used > 0) crypto_secrets.secureZero(self.scratch[0..self.used]);
     }
 
     fn store(self: *EventSink, bytes: []const u8) Error![]const u8 {


### PR DESCRIPTION
## Summary
- add shared `crypto_secrets` helpers with fixed-size and bounded dynamic secret containers
- centralize secure zeroing and constant-time equality through the new helper module
- migrate QUIC TLS traffic-secret storage and record transport scratch wiping onto the helper
- document secret ownership, replacement, deinit, and non-formatting conventions

## Validation
- `zig fmt --check build.zig src/ tests/`
- `zig build test-crypto --summary all --error-style verbose`
- `zig build test-tls --summary all --error-style verbose`
- `zig build test-quic --summary all --error-style verbose`
- `zig build test --summary all --error-style verbose`

Refs #372