### PR TITLE
crypto: codify supported provider capability profile

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -230,6 +230,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     crypto_mod.addImport("crypto_secrets", crypto_secrets_mod);
+    tls_core_mod.addImport("crypto", crypto_mod);
     const crypto_tests = b.addTest(.{ .root_module = crypto_mod });
     const run_crypto_tests = b.addRunArtifact(crypto_tests);
     const crypto_secret_tests = b.addTest(.{ .root_module = crypto_secrets_mod });

--- a/docs/CRYPTO_PROVIDER.md
+++ b/docs/CRYPTO_PROVIDER.md
@@ -29,6 +29,11 @@ boundary is what keeps the two from coupling to each other.
   discovery, the error taxonomy, the injected `Entropy` source, the opaque
   `SigningKey` handle, and the `CryptoProvider` interface (a `context` pointer
   plus a `*const VTable`, the same seam shape as the QUIC `TlsBackend`).
+- `src/crypto/profile.zig` — the checked-in capability matrix: every
+  TLS/QUIC/PKI algorithm name, implementation family, pure-Zig/OpenSSL status,
+  tests, consumers, and Zig version floor.
+- `src/tls/crypto_profile.zig` — the TLS-side adapter that maps provider
+  capabilities to TLS policy capabilities without making crypto import TLS.
 - `src/crypto/secrets.zig` — fixed-size and bounded dynamic secret containers,
   shared secure-zero and constant-time comparison helpers, and the non-formatting
   convention for secret-bearing values.
@@ -60,6 +65,37 @@ algorithms are named by the interface so protocol and negotiation code is
 written once; capability discovery reports them absent and every entry point
 returns `error.UnsupportedCapability` until a backend provides them.
 
+## Supported profile matrix
+
+The source of truth is `src/crypto/profile.zig`, not prose in this document.
+The table below summarizes the checked-in profile for review:
+
+| Capability | Pure-Zig status | Pure-Zig implementation | OpenSSL status | Consumers |
+| --- | --- | --- | --- | --- |
+| SHA-256, SHA-384 | supported | `std.crypto` | provider deferred | TLS transcript, HKDF, QUIC TLS bridge |
+| HKDF-SHA256, HKDF-SHA384 | supported | `std.crypto` HMAC/TLS label code | provider deferred | TLS 1.3 key schedule, QUIC packet protection |
+| AES-128-GCM, AES-256-GCM, ChaCha20-Poly1305 | supported | `std.crypto` | provider deferred | TLS records, QUIC packet protection |
+| X25519 | supported | `std.crypto` | provider deferred | TLS key share, QUIC TLS bridge |
+| secp256r1 / P-256 | provider deferred | unavailable | provider deferred | TLS key share, PKI |
+| Ed25519 | supported | `std.crypto` | provider deferred | CertificateVerify, PKI |
+| ECDSA-P256-SHA256, RSA-PSS-RSAE-SHA256 | provider deferred | unavailable | provider deferred | CertificateVerify, PKI |
+| DER parser, chain builder, WebPKI validation | provider deferred | project code / unavailable | provider deferred | PKI |
+| injected random bytes, secure zero, constant-time compare | supported | project code | provider deferred / project code | all secret-bearing paths |
+
+The Zig compatibility floor for this matrix is `0.16.0`; when the project moves
+to a newer compiler or starts carrying compatibility shims for crypto APIs, the
+floor and each affected row must be updated together.
+
+Protocol configuration must not hand-write provider-derived TLS capabilities.
+Use `tls.crypto_profile.fromProvider(provider.capabilities())`, then pass the
+returned `asPolicyCapabilities()` slice set to `tls.Policy`. That path filters
+cipher suites, named groups, and signature schemes through the selected
+provider's typed support, so pure-Zig configuration advertises Ed25519 and
+X25519 but not ECDSA or P-256 until a backend actually implements them. When a
+call site must accept hand-written TLS capability lists, it should preflight
+them with `tls.crypto_profile.validateAgainstProvider` before handshake
+execution.
+
 ## Design rules
 
 ### Capability discovery is explicit
@@ -70,6 +106,11 @@ only from that set with the `select*` helpers, and every operation re-checks
 membership. An unsupported algorithm is therefore always a typed
 `error.UnsupportedCapability` — never a call into a primitive that cannot handle
 it, and never undefined behaviour.
+
+Every algorithm addition or status change must update `src/crypto/profile.zig`
+in the same PR as the implementation. Reviewers should check that the row names
+the implementation family, provider status, test coverage, consumers, and
+security assumptions before accepting a new negotiated algorithm.
 
 ### Errors are classified
 

--- a/src/crypto/profile.zig
+++ b/src/crypto/profile.zig
@@ -1,0 +1,214 @@
+//! Checked-in cryptographic capability profile (#371, epic #327).
+//!
+//! This file is intentionally data-heavy. It is the build-visible matrix that
+//! maps protocol algorithms to the implementation family that supplies them,
+//! the current provider status, test coverage, and consumers.
+
+const std = @import("std");
+const provider = @import("provider.zig");
+
+pub const zig_version_floor = "0.16.0";
+
+pub const ProviderKind = enum {
+    pure_zig,
+    openssl,
+};
+
+pub const Status = enum {
+    supported,
+    provider_deferred,
+    unsupported,
+};
+
+pub const Implementation = enum {
+    zig_std_crypto,
+    project_code,
+    openssl_provider,
+    unavailable,
+};
+
+pub const Category = enum {
+    hash,
+    hkdf,
+    aead,
+    group,
+    signature,
+    certificate_helper,
+    entropy,
+};
+
+pub const Consumer = enum {
+    tls_handshake,
+    tls_record,
+    quic_packet_protection,
+    quic_tls_bridge,
+    pki,
+    resumption,
+};
+
+pub const CertificateHelper = enum {
+    der_parser,
+    chain_builder,
+    webpki_validation,
+};
+
+pub const EntropyCapability = enum {
+    injected_random_bytes,
+    secure_zero,
+    constant_time_compare,
+};
+
+pub const Algorithm = union(Category) {
+    hash: provider.Hash,
+    hkdf: provider.Hash,
+    aead: provider.Aead,
+    group: provider.Group,
+    signature: provider.SignatureScheme,
+    certificate_helper: CertificateHelper,
+    entropy: EntropyCapability,
+};
+
+pub const ConsumerSet = std.EnumSet(Consumer);
+
+pub const Row = struct {
+    algorithm: Algorithm,
+    name: []const u8,
+    pure_zig_implementation: Implementation,
+    pure_zig_status: Status,
+    openssl_implementation: Implementation,
+    openssl_status: Status,
+    tests: []const u8,
+    consumers: ConsumerSet,
+    review: []const u8,
+};
+
+pub const rows = [_]Row{
+    row(.{ .hash = .sha256 }, "SHA-256", .zig_std_crypto, .supported, .openssl_provider, .provider_deferred, "std.crypto cross-checks, transcript tests", .{ .tls_handshake, .quic_tls_bridge }, "Hash additions require transcript/HKDF vectors."),
+    row(.{ .hash = .sha384 }, "SHA-384", .zig_std_crypto, .supported, .openssl_provider, .provider_deferred, "provider capability and HKDF tests", .{.tls_handshake}, "Hash additions require TLS 1.3 suite mapping."),
+    row(.{ .hkdf = .sha256 }, "HKDF-SHA256", .zig_std_crypto, .supported, .openssl_provider, .provider_deferred, "RFC 5869/std.crypto and TLS expand-label parity", .{ .tls_handshake, .quic_tls_bridge, .quic_packet_protection }, "HKDF additions require extract and expand-label vectors."),
+    row(.{ .hkdf = .sha384 }, "HKDF-SHA384", .zig_std_crypto, .supported, .openssl_provider, .provider_deferred, "provider capability and expand-label tests", .{.tls_handshake}, "HKDF additions require TLS 1.3 label coverage."),
+    row(.{ .aead = .aes_128_gcm }, "AES-128-GCM", .zig_std_crypto, .supported, .openssl_provider, .provider_deferred, "seal/open round-trip, tamper rejection, AD mismatch", .{ .tls_record, .quic_packet_protection }, "AEAD additions require auth-failure zeroing tests."),
+    row(.{ .aead = .aes_256_gcm }, "AES-256-GCM", .zig_std_crypto, .supported, .openssl_provider, .provider_deferred, "seal/open round-trip, tamper rejection, AD mismatch", .{ .tls_record, .quic_packet_protection }, "AEAD additions require TLS cipher-suite mapping."),
+    row(.{ .aead = .chacha20_poly1305 }, "ChaCha20-Poly1305", .zig_std_crypto, .supported, .openssl_provider, .provider_deferred, "seal/open round-trip, tamper rejection, AD mismatch", .{ .tls_record, .quic_packet_protection }, "AEAD additions require QUIC packet-protection coverage."),
+    row(.{ .group = .x25519 }, "X25519", .zig_std_crypto, .supported, .openssl_provider, .provider_deferred, "std.crypto scalar multiplication parity, low-order rejection", .{ .tls_handshake, .quic_tls_bridge }, "Group additions require key-share and shared-secret vectors."),
+    row(.{ .group = .secp256r1 }, "secp256r1 (P-256)", .unavailable, .provider_deferred, .openssl_provider, .provider_deferred, "capability rejection tests", .{ .tls_handshake, .quic_tls_bridge, .pki }, "P-256 support requires explicit provider implementation and ECDH vectors."),
+    row(.{ .signature = .ed25519 }, "Ed25519", .zig_std_crypto, .supported, .openssl_provider, .provider_deferred, "sign/verify, tamper rejection, wrong-key rejection", .{ .tls_handshake, .pki }, "Signature additions require CertificateVerify vectors."),
+    row(.{ .signature = .ecdsa_secp256r1_sha256 }, "ECDSA-P256-SHA256", .unavailable, .provider_deferred, .openssl_provider, .provider_deferred, "capability rejection tests", .{ .tls_handshake, .pki }, "ECDSA support requires DER/raw signature format tests."),
+    row(.{ .signature = .rsa_pss_rsae_sha256 }, "RSA-PSS-RSAE-SHA256", .unavailable, .provider_deferred, .openssl_provider, .provider_deferred, "capability rejection tests", .{ .tls_handshake, .pki }, "RSA-PSS support requires salt-length and padding-negative vectors."),
+    row(.{ .certificate_helper = .der_parser }, "DER/X.509 parser helpers", .project_code, .provider_deferred, .openssl_provider, .provider_deferred, "module-local parser fixtures", .{.pki}, "Certificate helpers require malformed-input and corpus tests."),
+    row(.{ .certificate_helper = .chain_builder }, "certificate chain builder", .unavailable, .provider_deferred, .openssl_provider, .provider_deferred, "tracked by PKI stories", .{.pki}, "Chain validation requires path-building fixtures."),
+    row(.{ .certificate_helper = .webpki_validation }, "WebPKI validation", .unavailable, .provider_deferred, .openssl_provider, .provider_deferred, "tracked by PKI stories", .{.pki}, "WebPKI support requires policy and time-validation review."),
+    row(.{ .entropy = .injected_random_bytes }, "injected random bytes", .project_code, .supported, .openssl_provider, .provider_deferred, "deterministic and failing entropy tests", .{ .tls_handshake, .quic_packet_protection, .resumption }, "Randomness changes require no-ambient-RNG review."),
+    row(.{ .entropy = .secure_zero }, "secure zero", .project_code, .supported, .project_code, .supported, "secret-container and provider wipe tests", .{ .tls_handshake, .tls_record, .quic_packet_protection, .pki, .resumption }, "Secret handling changes require wipe-on-error review."),
+    row(.{ .entropy = .constant_time_compare }, "constant-time compare", .project_code, .supported, .project_code, .supported, "crypto secret helper tests", .{ .tls_handshake, .tls_record, .pki }, "Comparison changes require timing-safe API review."),
+};
+
+fn row(
+    algorithm: Algorithm,
+    name: []const u8,
+    pure_zig_implementation: Implementation,
+    pure_zig_status: Status,
+    openssl_implementation: Implementation,
+    openssl_status: Status,
+    tests: []const u8,
+    comptime consumers_list: anytype,
+    review: []const u8,
+) Row {
+    return .{
+        .algorithm = algorithm,
+        .name = name,
+        .pure_zig_implementation = pure_zig_implementation,
+        .pure_zig_status = pure_zig_status,
+        .openssl_implementation = openssl_implementation,
+        .openssl_status = openssl_status,
+        .tests = tests,
+        .consumers = consumerSet(consumers_list),
+        .review = review,
+    };
+}
+
+fn consumerSet(comptime items: anytype) ConsumerSet {
+    var set = ConsumerSet{};
+    inline for (items) |item| set.insert(item);
+    return set;
+}
+
+pub fn status(kind: ProviderKind, algorithm: Algorithm) Status {
+    for (rows) |entry| {
+        if (algorithmEql(entry.algorithm, algorithm)) {
+            return switch (kind) {
+                .pure_zig => entry.pure_zig_status,
+                .openssl => entry.openssl_status,
+            };
+        }
+    }
+    return .unsupported;
+}
+
+pub fn capabilities(kind: ProviderKind) provider.Capabilities {
+    var caps = provider.Capabilities{};
+    for (rows) |entry| {
+        if (rowStatus(kind, entry) != .supported) continue;
+        switch (entry.algorithm) {
+            .hash => |hash| caps.hashes.insert(hash),
+            .aead => |aead| caps.aeads.insert(aead),
+            .group => |group| caps.groups.insert(group),
+            .signature => |scheme| caps.signatures.insert(scheme),
+            .hkdf, .certificate_helper, .entropy => {},
+        }
+    }
+    return caps;
+}
+
+fn rowStatus(kind: ProviderKind, entry: Row) Status {
+    return switch (kind) {
+        .pure_zig => entry.pure_zig_status,
+        .openssl => entry.openssl_status,
+    };
+}
+
+fn algorithmEql(a: Algorithm, b: Algorithm) bool {
+    return switch (a) {
+        .hash => |value| b == .hash and b.hash == value,
+        .hkdf => |value| b == .hkdf and b.hkdf == value,
+        .aead => |value| b == .aead and b.aead == value,
+        .group => |value| b == .group and b.group == value,
+        .signature => |value| b == .signature and b.signature == value,
+        .certificate_helper => |value| b == .certificate_helper and b.certificate_helper == value,
+        .entropy => |value| b == .entropy and b.entropy == value,
+    };
+}
+
+fn expectRow(algorithm: Algorithm) !void {
+    for (rows) |entry| {
+        if (algorithmEql(entry.algorithm, algorithm)) return;
+    }
+    std.debug.print("missing crypto profile row for {any}\n", .{algorithm});
+    return error.MissingProfileRow;
+}
+
+test "matrix covers every provider algorithm enum" {
+    inline for (std.enums.values(provider.Hash)) |hash| {
+        try expectRow(.{ .hash = hash });
+        try expectRow(.{ .hkdf = hash });
+    }
+    inline for (std.enums.values(provider.Aead)) |aead| try expectRow(.{ .aead = aead });
+    inline for (std.enums.values(provider.Group)) |group| try expectRow(.{ .group = group });
+    inline for (std.enums.values(provider.SignatureScheme)) |scheme| try expectRow(.{ .signature = scheme });
+    inline for (std.enums.values(CertificateHelper)) |helper| try expectRow(.{ .certificate_helper = helper });
+    inline for (std.enums.values(EntropyCapability)) |capability| try expectRow(.{ .entropy = capability });
+}
+
+test "pure-Zig profile capabilities are queryable" {
+    const caps = capabilities(.pure_zig);
+    try std.testing.expect(caps.supportsHash(.sha256));
+    try std.testing.expect(caps.supportsHash(.sha384));
+    try std.testing.expect(caps.supportsAead(.aes_128_gcm));
+    try std.testing.expect(caps.supportsAead(.aes_256_gcm));
+    try std.testing.expect(caps.supportsAead(.chacha20_poly1305));
+    try std.testing.expect(caps.supportsGroup(.x25519));
+    try std.testing.expect(!caps.supportsGroup(.secp256r1));
+    try std.testing.expect(caps.supportsSignature(.ed25519));
+    try std.testing.expect(!caps.supportsSignature(.ecdsa_secp256r1_sha256));
+    try std.testing.expect(!caps.supportsSignature(.rsa_pss_rsae_sha256));
+}

--- a/src/crypto/pure_zig.zig
+++ b/src/crypto/pure_zig.zig
@@ -32,6 +32,7 @@
 const std = @import("std");
 const crypto = std.crypto;
 const provider = @import("provider.zig");
+const profile = @import("profile.zig");
 
 const HmacSha256 = crypto.auth.hmac.sha2.HmacSha256;
 const HmacSha384 = crypto.auth.hmac.sha2.HmacSha384;
@@ -493,6 +494,11 @@ const testing = std.testing;
 
 test "capabilities advertise exactly the implemented profile" {
     const caps = Provider.capabilities();
+    const profiled = profile.capabilities(.pure_zig);
+    try testing.expectEqual(caps.hashes, profiled.hashes);
+    try testing.expectEqual(caps.aeads, profiled.aeads);
+    try testing.expectEqual(caps.groups, profiled.groups);
+    try testing.expectEqual(caps.signatures, profiled.signatures);
     try testing.expect(caps.supportsHash(.sha256));
     try testing.expect(caps.supportsHash(.sha384));
     try testing.expect(caps.supportsAead(.aes_128_gcm));

--- a/src/crypto/root.zig
+++ b/src/crypto/root.zig
@@ -6,6 +6,7 @@
 //! interface. See `docs/CRYPTO_PROVIDER.md`.
 
 pub const provider = @import("provider.zig");
+pub const profile = @import("profile.zig");
 pub const pure_zig = @import("pure_zig.zig");
 pub const secrets = @import("crypto_secrets");
 

--- a/src/tls/crypto_profile.zig
+++ b/src/tls/crypto_profile.zig
@@ -1,0 +1,123 @@
+//! TLS-side adapter for the provider-neutral crypto capability matrix.
+
+const std = @import("std");
+const crypto = @import("crypto");
+const provider = crypto.provider;
+const profile = crypto.profile;
+const policy_mod = @import("policy.zig");
+const state = @import("state.zig");
+
+pub const TlsCapabilityError = error{UnsupportedCapability};
+
+pub const TlsCapabilities = struct {
+    cipher_suites: [3]policy_mod.CipherSuite = undefined,
+    cipher_suites_len: usize = 0,
+    named_groups: [2]policy_mod.NamedGroup = undefined,
+    named_groups_len: usize = 0,
+    signature_schemes: [3]policy_mod.SignatureScheme = undefined,
+    signature_schemes_len: usize = 0,
+
+    pub fn asPolicyCapabilities(self: *const TlsCapabilities) policy_mod.Capabilities {
+        return .{
+            .cipher_suites = self.cipher_suites[0..self.cipher_suites_len],
+            .named_groups = self.named_groups[0..self.named_groups_len],
+            .signature_schemes = self.signature_schemes[0..self.signature_schemes_len],
+        };
+    }
+
+    pub fn policy(self: *const TlsCapabilities, transport_mode: state.TransportMode, alpns: []const policy_mod.ProtocolName) policy_mod.Policy {
+        return policy_mod.Policy.fromCapabilities(transport_mode, self.asPolicyCapabilities(), alpns);
+    }
+
+    fn appendCipher(self: *TlsCapabilities, suite: policy_mod.CipherSuite) void {
+        self.cipher_suites[self.cipher_suites_len] = suite;
+        self.cipher_suites_len += 1;
+    }
+
+    fn appendGroup(self: *TlsCapabilities, group: policy_mod.NamedGroup) void {
+        self.named_groups[self.named_groups_len] = group;
+        self.named_groups_len += 1;
+    }
+
+    fn appendSignature(self: *TlsCapabilities, scheme: policy_mod.SignatureScheme) void {
+        self.signature_schemes[self.signature_schemes_len] = scheme;
+        self.signature_schemes_len += 1;
+    }
+};
+
+pub fn fromProvider(caps: provider.Capabilities) TlsCapabilities {
+    var out = TlsCapabilities{};
+    if (supportsCipherSuite(caps, .tls_aes_128_gcm_sha256)) out.appendCipher(.tls_aes_128_gcm_sha256);
+    if (supportsCipherSuite(caps, .tls_aes_256_gcm_sha384)) out.appendCipher(.tls_aes_256_gcm_sha384);
+    if (supportsCipherSuite(caps, .tls_chacha20_poly1305_sha256)) out.appendCipher(.tls_chacha20_poly1305_sha256);
+    if (supportsNamedGroup(caps, .x25519)) out.appendGroup(.x25519);
+    if (supportsNamedGroup(caps, .secp256r1)) out.appendGroup(.secp256r1);
+    if (supportsSignatureScheme(caps, .ed25519)) out.appendSignature(.ed25519);
+    if (supportsSignatureScheme(caps, .ecdsa_secp256r1_sha256)) out.appendSignature(.ecdsa_secp256r1_sha256);
+    if (supportsSignatureScheme(caps, .rsa_pss_rsae_sha256)) out.appendSignature(.rsa_pss_rsae_sha256);
+    return out;
+}
+
+pub fn validateAgainstProvider(caps: provider.Capabilities, tls_caps: policy_mod.Capabilities) TlsCapabilityError!void {
+    for (tls_caps.cipher_suites) |suite| {
+        if (!supportsCipherSuite(caps, suite)) return error.UnsupportedCapability;
+    }
+    for (tls_caps.named_groups) |group| {
+        if (!supportsNamedGroup(caps, group)) return error.UnsupportedCapability;
+    }
+    for (tls_caps.signature_schemes) |scheme| {
+        if (!supportsSignatureScheme(caps, scheme)) return error.UnsupportedCapability;
+    }
+}
+
+pub fn supportsCipherSuite(caps: provider.Capabilities, suite: policy_mod.CipherSuite) bool {
+    return switch (suite) {
+        .tls_aes_128_gcm_sha256 => caps.supportsAead(.aes_128_gcm) and caps.supportsHash(.sha256),
+        .tls_aes_256_gcm_sha384 => caps.supportsAead(.aes_256_gcm) and caps.supportsHash(.sha384),
+        .tls_chacha20_poly1305_sha256 => caps.supportsAead(.chacha20_poly1305) and caps.supportsHash(.sha256),
+    };
+}
+
+pub fn supportsNamedGroup(caps: provider.Capabilities, group: policy_mod.NamedGroup) bool {
+    return switch (group) {
+        .x25519 => caps.supportsGroup(.x25519),
+        .secp256r1 => caps.supportsGroup(.secp256r1),
+        .secp384r1 => false,
+    };
+}
+
+pub fn supportsSignatureScheme(caps: provider.Capabilities, scheme: policy_mod.SignatureScheme) bool {
+    return switch (scheme) {
+        .ed25519 => caps.supportsSignature(.ed25519),
+        .ecdsa_secp256r1_sha256 => caps.supportsSignature(.ecdsa_secp256r1_sha256),
+        .rsa_pss_rsae_sha256 => caps.supportsSignature(.rsa_pss_rsae_sha256),
+        .rsa_pkcs1_sha256 => false,
+    };
+}
+
+test "TLS policy capabilities are derived from provider support" {
+    const tls_caps = fromProvider(profile.capabilities(.pure_zig));
+    try std.testing.expectEqual(@as(usize, 3), tls_caps.cipher_suites_len);
+    try std.testing.expectEqual(policy_mod.CipherSuite.tls_aes_128_gcm_sha256, tls_caps.cipher_suites[0]);
+    try std.testing.expectEqual(policy_mod.CipherSuite.tls_aes_256_gcm_sha384, tls_caps.cipher_suites[1]);
+    try std.testing.expectEqual(policy_mod.CipherSuite.tls_chacha20_poly1305_sha256, tls_caps.cipher_suites[2]);
+    try std.testing.expectEqual(@as(usize, 1), tls_caps.named_groups_len);
+    try std.testing.expectEqual(policy_mod.NamedGroup.x25519, tls_caps.named_groups[0]);
+    try std.testing.expectEqual(@as(usize, 1), tls_caps.signature_schemes_len);
+    try std.testing.expectEqual(policy_mod.SignatureScheme.ed25519, tls_caps.signature_schemes[0]);
+}
+
+test "hand-written TLS policy capabilities are rejected when provider cannot support them" {
+    const caps = profile.capabilities(.pure_zig);
+    const derived = fromProvider(caps);
+    try validateAgainstProvider(caps, derived.asPolicyCapabilities());
+
+    const bad_groups = [_]policy_mod.NamedGroup{.secp256r1};
+    try std.testing.expectError(error.UnsupportedCapability, validateAgainstProvider(caps, .{ .named_groups = &bad_groups }));
+
+    const bad_signatures = [_]policy_mod.SignatureScheme{.ecdsa_secp256r1_sha256};
+    try std.testing.expectError(error.UnsupportedCapability, validateAgainstProvider(caps, .{ .signature_schemes = &bad_signatures }));
+
+    const bad_rsa = [_]policy_mod.SignatureScheme{.rsa_pkcs1_sha256};
+    try std.testing.expectError(error.UnsupportedCapability, validateAgainstProvider(caps, .{ .signature_schemes = &bad_rsa }));
+}

--- a/src/tls/root.zig
+++ b/src/tls/root.zig
@@ -3,6 +3,7 @@ pub const engine = @import("engine.zig");
 pub const state = @import("state.zig");
 pub const events = @import("events.zig");
 pub const algorithms = @import("algorithms.zig");
+pub const crypto_profile = @import("crypto_profile.zig");
 pub const key_schedule = @import("key_schedule.zig");
 pub const messages = @import("messages.zig");
 pub const negotiation = @import("negotiation.zig");


### PR DESCRIPTION
## Summary
- add a checked-in crypto capability matrix for the #327-B provider profile
- expose programmatic provider capability queries plus TLS policy derivation/validation helpers
- document the matrix, Zig version floor, provider differences, and review path

Refs #371

## Validation
- zig fmt --check build.zig src/ tests/
- zig build test-crypto --summary all --error-style verbose
- zig build test-tls --summary all --error-style verbose
- zig build test --summary all --error-style verbose