### PR TITLE
build: enforce TLS dependency audit and pure-Zig cutover checklist (#379)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,61 @@ jobs:
       - name: Run shellcheck
         run: find scripts/ packaging/ -name "*.sh" -exec shellcheck {} +
 
+  # ── TLS dependency audit ──────────────────────────────────────────────────────
+  # Enforces the external-library policy (#379): forbidden TLS/crypto/QUIC/H3
+  # dependency names must not be configured, OpenSSL must stay behind the
+  # adapter boundary, native paths must be @cImport-free, and produced
+  # appliance/general artifacts must have the expected linkage. This is a
+  # required v0.5 release gate for the Bare Systems appliance (#391).
+  dependency-audit:
+    name: TLS dependency audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Source and configuration audit
+        run: ./scripts/audit-dependencies.sh
+
+      - name: Install system dependencies (general profile)
+        run: sudo apt-get install -y libssl-dev
+
+      - name: Install Zig
+        run: sh ./scripts/install-zig.sh 0.16.0
+
+      - name: Build appliance profile (no OpenSSL)
+        run: zig build -Doptimize=ReleaseFast -Dtls-profile=appliance
+
+      - name: Audit appliance artifact linkage
+        run: |
+          ./scripts/audit-release-binary.sh \
+            --binary zig-out/bin/tardigrade \
+            --profile appliance \
+            --output "$RUNNER_TEMP/dependency-inventory-appliance.json"
+
+      - name: Build general profile (OpenSSL adapter)
+        run: zig build -Doptimize=ReleaseFast -Dtls-profile=general
+
+      - name: Audit general artifact linkage
+        run: |
+          ./scripts/audit-release-binary.sh \
+            --binary zig-out/bin/tardigrade \
+            --profile general \
+            --output "$RUNNER_TEMP/dependency-inventory-general.json"
+
+      - name: Upload dependency inventories
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dependency-inventory
+          path: ${{ runner.temp }}/dependency-inventory-*.json
+          if-no-files-found: error
+          retention-days: 14
+
   # ── Unit tests ────────────────────────────────────────────────────────────────
   # Runs unit tests across platforms. Required on every PR and push.
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,12 +132,25 @@ jobs:
             echo "artifact_dir=$artifact_dir"
             echo "archive_path=$artifact_dir/$ARCHIVE_NAME.tar.gz"
             echo "sbom_path=$artifact_dir/sbom-$ARCHIVE_NAME.spdx.json"
+            echo "inventory_path=$artifact_dir/dependency-inventory-$ARCHIVE_NAME.json"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Source and configuration audit
+        run: ./scripts/audit-dependencies.sh
 
       - name: Build release binary
         env:
           VERSION: ${{ needs.prepare-release.outputs.version }}
         run: zig build -Doptimize=ReleaseFast "-Dversion=$VERSION"
+
+      - name: Audit release binary linkage and record inventory
+        env:
+          INVENTORY_PATH: ${{ steps.archive_artifacts.outputs.inventory_path }}
+        run: |
+          ./scripts/audit-release-binary.sh \
+            --binary zig-out/bin/tardigrade \
+            --profile general \
+            --output "$INVENTORY_PATH"
 
       - name: Package artifact
         env:
@@ -178,6 +191,14 @@ jobs:
           path: ${{ steps.archive_artifacts.outputs.sbom_path }}
           if-no-files-found: error
           retention-days: 1
+
+      - name: Upload dependency inventory artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dependency-inventory-${{ matrix.archive_name }}
+          path: ${{ steps.archive_artifacts.outputs.inventory_path }}
+          if-no-files-found: error
+          retention-days: 14
 
   publish-release:
     name: Publish GitHub release assets
@@ -238,6 +259,7 @@ jobs:
           files: |
             ${{ runner.temp }}/publish-release/dist/*.tar.gz
             ${{ runner.temp }}/publish-release/dist/*.spdx.json
+            ${{ runner.temp }}/publish-release/dist/dependency-inventory-*.json
             ${{ runner.temp }}/publish-release/dist/install.sh
             ${{ runner.temp }}/publish-release/dist/tardigrade-checksums.txt
           fail_on_unmatched_files: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable user-facing changes to Tardigrade are documented here.
 ## [Unreleased]
 
 ### Features
+- **TLS dependency audit and pure-Zig cutover enforcement (#379, epic #327)** —
+  Tardigrade's external-library policy is now enforced in source, build
+  configuration, CI, and release artifacts rather than only documented. A new
+  `-Dtls-profile` build option selects between two profiles: `general` (the
+  default) links the single approved OpenSSL adapter as a compatibility
+  backend, while `appliance` (the Bare Systems profile) forbids all foreign
+  TLS/crypto linkage — `src/http/tls_backend.zig` swaps the OpenSSL adapter for
+  a no-OpenSSL stub (`src/http/tls_termination_stub.zig`) at the module graph,
+  so an appliance binary never analyzes `@cImport("openssl/...")`, never links
+  `libssl`/`libcrypto`, and has no runtime fallback (the stub fails closed until
+  the native TLS path lands under #391). `tardigrade version` now reports the
+  built-in profile and backend so an artifact is self-identifying. Two audit
+  scripts enforce the policy: `scripts/audit-dependencies.sh` fails if a
+  forbidden dependency (ngtcp2, nghttp3, quiche, BoringSSL, mbedTLS, …) is
+  configured, if an OpenSSL include escapes the adapter boundary, or if any
+  `@cImport` appears in a native path (`src/tls`, `src/pki`, `src/quic`,
+  `src/crypto`, `src/http3`); `scripts/audit-release-binary.sh` inspects a
+  built binary's dynamic dependencies (`ldd`/`otool -L`), fails a forbidden
+  linkage, and emits a machine-readable dependency inventory. CI gains a
+  required `TLS dependency audit` job that builds and audits both profiles, and
+  the release workflow audits each published binary and ships its inventory
+  alongside the SBOM. See `docs/TLS_DEPENDENCY_POLICY.md` for the policy and the
+  appliance/general cutover checklist. The stale `build.zig.zon` note about an
+  optional ngtcp2/nghttp3 link path (removed in #328) is corrected.
 - **Stable cryptographic-provider boundary (#370, epic #327)** — a new
   `src/crypto/` package defines the single narrow interface every TLS, QUIC,
   and PKI module will consume cryptography through, so protocol code never

--- a/build.zig
+++ b/build.zig
@@ -1,5 +1,15 @@
 const std = @import("std");
 
+/// TLS/crypto build profile (#379, epic #327). `general` links the single
+/// approved OpenSSL adapter as a compatibility backend; `appliance` is the
+/// Bare Systems profile: no OpenSSL configuration, import, or linkage — the
+/// OpenSSL adapter module is replaced with a native stub at the build graph
+/// level, so `@cImport("openssl/...")` is never analyzed and `libssl`/
+/// `libcrypto` are never linked. There is no runtime fallback between
+/// profiles; the selection is embedded in the binary and reported by
+/// `tardigrade version`. See docs/TLS_DEPENDENCY_POLICY.md.
+const TlsProfile = enum { general, appliance };
+
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
@@ -7,9 +17,17 @@ pub fn build(b: *std.Build) void {
     const require_static_system_libs = b.option(bool, "require-static-system-libs", "Require static linking for system libraries") orelse false;
     const static_executable = b.option(bool, "static-executable", "Build the tardigrade executable as a static binary") orelse false;
     const app_version = b.option([]const u8, "version", "Version string embedded in the tardigrade binary") orelse "dev";
+    const tls_profile = b.option(
+        TlsProfile,
+        "tls-profile",
+        "TLS/crypto profile: 'general' (default) links the approved OpenSSL adapter; 'appliance' forbids all foreign TLS/crypto linkage (#379)",
+    ) orelse .general;
+    const link_openssl_adapter = tls_profile == .general;
 
     const build_options = b.addOptions();
     build_options.addOption([]const u8, "version", app_version);
+    build_options.addOption([]const u8, "tls_profile", @tagName(tls_profile));
+    build_options.addOption(bool, "tls_openssl_adapter", link_openssl_adapter);
     const compat_mod = b.createModule(.{
         .root_source_file = b.path("src/zig_compat.zig"),
         .target = target,
@@ -90,7 +108,7 @@ pub fn build(b: *std.Build) void {
         .root_module = exe_mod,
         .linkage = if (static_executable) .static else null,
     });
-    configureSsl(exe, prefer_static_system_libs, require_static_system_libs);
+    if (link_openssl_adapter) configureSsl(exe, prefer_static_system_libs, require_static_system_libs);
     b.installArtifact(exe);
 
     const run_cmd = b.addRunArtifact(exe);
@@ -102,7 +120,7 @@ pub fn build(b: *std.Build) void {
     const exe_unit_tests = b.addTest(.{
         .root_module = exe_mod,
     });
-    configureSsl(exe_unit_tests, prefer_static_system_libs, require_static_system_libs);
+    if (link_openssl_adapter) configureSsl(exe_unit_tests, prefer_static_system_libs, require_static_system_libs);
 
     const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
     const test_step = b.step("test", "Run unit tests");
@@ -132,7 +150,7 @@ pub fn build(b: *std.Build) void {
         .root_module = allocation_regression_mod,
         .filters = &.{"allocation"},
     });
-    configureSsl(allocation_regression_tests, prefer_static_system_libs, require_static_system_libs);
+    if (link_openssl_adapter) configureSsl(allocation_regression_tests, prefer_static_system_libs, require_static_system_libs);
     const run_allocation_regression_tests = b.addRunArtifact(allocation_regression_tests);
     test_step.dependOn(&run_allocation_regression_tests.step);
 
@@ -140,7 +158,7 @@ pub fn build(b: *std.Build) void {
         .name = "allocation_regression",
         .root_module = allocation_regression_mod,
     });
-    configureSsl(allocation_regression_exe, prefer_static_system_libs, require_static_system_libs);
+    if (link_openssl_adapter) configureSsl(allocation_regression_exe, prefer_static_system_libs, require_static_system_libs);
     const run_allocation_regression = b.addRunArtifact(allocation_regression_exe);
     const allocation_regression_step = b.step("bench-allocations", "Report hot-path allocation budgets as JSON");
     allocation_regression_step.dependOn(&run_allocation_regression.step);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -36,11 +36,12 @@
     // Once all dependencies are fetched, `zig build` no longer requires
     // internet connectivity.
     //
-    // Tardigrade keeps HTTP/3 / QUIC support behind explicit build flags. The
-    // C-backed path links ngtcp2/nghttp3 system libraries only when
-    // `-Denable-http3-ngtcp2` is enabled. The pure-Zig path uses
-    // `-Denable-http3-zig` and has no package-manager or system-library
-    // dependency on those optional HTTP/3 libraries.
+    // Tardigrade has no package-manager dependencies. HTTP/3 and QUIC run on
+    // the pure-Zig transport (#328 removed the former C-backed ngtcp2/nghttp3
+    // path); TLS/crypto is either the pure-Zig native path or the single
+    // approved OpenSSL adapter, selected by `-Dtls-profile` and enforced by
+    // scripts/audit-dependencies.sh (#379). External TLS/QUIC/H3
+    // implementations may run only as out-of-process interoperability peers.
     .dependencies = .{
         // See `zig fetch --save <url>` for a command-line interface for adding dependencies.
         //.example = .{

--- a/docs/TLS_DEPENDENCY_POLICY.md
+++ b/docs/TLS_DEPENDENCY_POLICY.md
@@ -1,0 +1,151 @@
+# TLS/crypto dependency policy and pure-Zig cutover (#379, epic #327)
+
+This note records Tardigrade's external-library policy for TLS, crypto, QUIC,
+HTTP/3, and certificate handling, how that policy is enforced in source, build
+configuration, CI, and release artifacts, and the checklist that governs the
+cutover to the pure-Zig implementation. It is the deliverable of research story
+**327-J** and a required v0.5 release gate for the Bare Systems appliance
+(#391).
+
+## Why
+
+Tardigrade is moving its TLS/crypto stack from OpenSSL to a pure-Zig
+implementation (epic #327). During that transition two products ship from one
+tree, and their dependency rules differ:
+
+- The **Bare Systems appliance** must contain no OpenSSL or other foreign
+  TLS/crypto implementation at all — no linkage, no configuration, no hidden
+  runtime fallback.
+- **General-purpose Tardigrade** may keep a single, narrowly isolated OpenSSL
+  adapter as a compatibility backend until the native path reaches the v1.0
+  support contract.
+
+A policy that is only written down drifts. This one is enforced by the build
+graph and by CI, and every release artifact makes its selected profile and
+linked dependencies inspectable.
+
+## Approved build profiles
+
+The profile is selected at build time with `-Dtls-profile` and is baked into
+the binary. There is no runtime switch and no fallback between profiles.
+
+### Bare Systems appliance profile (`-Dtls-profile=appliance`)
+
+- Uses the native Zig TLS/crypto path only.
+- Must not link `libssl`, `libcrypto`, or any other foreign TLS, crypto, QUIC,
+  HTTP/3, or certificate library.
+- The OpenSSL adapter module (`src/http/tls_termination.zig`) is **replaced in
+  the module graph** by a no-OpenSSL stub (`src/http/tls_termination_stub.zig`)
+  via `src/http/tls_backend.zig`. Because the adapter source is never imported,
+  its `@cImport("openssl/...")` is never analyzed and OpenSSL is never linked.
+- Until the native TLS termination path lands, the stub fails closed at startup
+  (`error.ContextInitFailed`) rather than silently degrading. The supported
+  TLS/certificate/client matrix for the appliance is defined by #391.
+
+### General-purpose profile (`-Dtls-profile=general`, default)
+
+- Links the single approved OpenSSL adapter as a compatibility/reference
+  backend.
+- OpenSSL types and state stay behind the adapter boundary
+  (`src/http/tls_termination.zig`, `src/http/acme_client.zig`) and must not
+  shape TLS, HTTP, QUIC, PKI, or application interfaces.
+- No external TLS/crypto implementation other than the approved OpenSSL adapter
+  may be linked.
+
+### Shared policy
+
+- ngtcp2/nghttp3 remain fully removed (#328); HTTP/3 and QUIC run on the
+  pure-Zig transport.
+- External TLS/QUIC/H3 implementations may run only as out-of-process or
+  containerized interoperability peers (`scripts/interop/`), never in the
+  Tardigrade link graph.
+- Build and release artifacts must make their selected profile and linked
+  dependencies inspectable.
+
+## How the binary reports its profile
+
+`tardigrade version` prints the profile and backend, so operators and release
+audits can verify an artifact without inspecting its link graph:
+
+```
+$ tardigrade version
+0.5.0 (tls-profile=appliance, tls-backend=native)
+$ tardigrade version
+0.5.0 (tls-profile=general, tls-backend=openssl-adapter)
+```
+
+## Enforcement
+
+### Source and configuration audit — `scripts/audit-dependencies.sh`
+
+Runs before anything is compiled and fails if:
+
+1. A forbidden TLS/crypto/QUIC/H3 dependency name (ngtcp2, nghttp3, quiche,
+   BoringSSL, mbedTLS, wolfSSL, GnuTLS, LibreSSL, rustls, s2n-tls, botan, …) is
+   **configured** in `build.zig`, `build.zig.zon`, workflows, scripts,
+   Dockerfiles, or packaging metadata. Comments are stripped before matching so
+   the policy can be documented in prose; only real configuration fails.
+2. An OpenSSL `@cInclude` appears outside the approved adapter boundary.
+3. Any `@cImport` appears in a native implementation path (`src/tls`,
+   `src/pki`, `src/quic`, `src/crypto`, `src/http3`).
+
+### Binary linkage audit — `scripts/audit-release-binary.sh`
+
+Inspects a produced binary's dynamic dependencies (`ldd` on Linux, `otool -L`
+on macOS) and emits a machine-readable JSON inventory. It fails if:
+
+- an appliance artifact links OpenSSL or any forbidden foreign library, or does
+  not self-report the native TLS path; or
+- a general artifact's actual linkage disagrees with its self-reported backend
+  (so the inventory cannot lie).
+
+The inventory records the binary, profile, host OS, inspection tool,
+self-reported backend, full dependency list, and any violations.
+
+### CI
+
+The `TLS dependency audit` job in `.github/workflows/ci.yml` runs the source
+audit, builds **both** profiles, and runs the binary audit against each,
+uploading the inventories as artifacts. It is a required check: CI fails if any
+forbidden implementation is configured, imported, or linked in any profile.
+
+### Release
+
+`.github/workflows/release.yml` re-runs the source audit, audits each released
+(general-profile) binary's linkage, and publishes the dependency inventory
+alongside the release assets and SBOM.
+
+## Cutover checklist
+
+### Bare Systems appliance (blocks #391)
+
+- [x] `appliance` build profile selects the native TLS/crypto path.
+- [x] Appliance builds link no OpenSSL/libcrypto/foreign TLS library (enforced
+      by binary audit).
+- [x] No hidden runtime fallback to OpenSSL (stub fails closed; profile is a
+      build-graph decision).
+- [x] Appliance artifact self-reports the native TLS path.
+- [x] CI builds and audits the appliance artifact on every change.
+- [ ] Native TLS termination and client paths implement the #391 appliance
+      support matrix (handshake, certificate verification, session resumption).
+      **Until this lands the appliance profile compiles and audits clean but
+      refuses TLS connections at runtime.**
+- [ ] Appliance integration/interop coverage proves live operation through the
+      native path.
+
+### General-purpose native-TLS parity (governs OpenSSL adapter removal)
+
+- [x] OpenSSL confined to the adapter boundary; no OpenSSL types in TLS/HTTP/
+      QUIC/PKI/application interfaces (enforced by source audit).
+- [x] General artifacts expose a complete dependency inventory and identify the
+      selected backend.
+- [ ] Native TLS reaches the v1.0 general-purpose support contract
+      (`docs/SUPPORT_MATRIX.md`).
+- [ ] Native path passes the TLS/interop conformance suite at parity with the
+      OpenSSL adapter.
+- [ ] Default profile flips from `general` to native once parity holds.
+- [ ] OpenSSL adapter removed from all builds; `configureSsl`, the adapter
+      modules, and the general profile retired.
+
+When the final boxes are checked, the OpenSSL adapter and the `-Dtls-profile`
+switch can be removed and Tardigrade ships a single pure-Zig TLS stack.

--- a/scripts/audit-dependencies.sh
+++ b/scripts/audit-dependencies.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# TLS dependency source/configuration audit (#379, epic #327).
+#
+# Enforces Tardigrade's external-library policy before anything is compiled:
+#
+#   1. Forbidden TLS/crypto/QUIC/H3 dependency names must not appear in build
+#      configuration, workflows, scripts, or packaging metadata. External
+#      implementations are allowed only as out-of-process interoperability
+#      peers (scripts/interop/), never in the link graph.
+#   2. OpenSSL headers may be included only inside the approved
+#      general-profile adapter boundary.
+#   3. Native implementation paths (TLS, PKI, QUIC, crypto, HTTP/3) must not
+#      contain any @cImport at all.
+#
+# Exit code 0 means the audit passed; any violation prints the offending
+# file/line and exits 1. Run from anywhere; paths resolve from the repo root.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+failures=0
+
+fail() {
+    echo "AUDIT FAIL: $1" >&2
+    failures=$((failures + 1))
+}
+
+# ── 1. Forbidden dependency identifiers in build/config surfaces ─────────────
+# openssl itself is not in this list: the general profile's adapter is the
+# single approved exception, enforced separately by checks 2 and 3 and by the
+# binary audit (scripts/audit-release-binary.sh).
+#
+# The check targets configuration that would actually pull a dependency into
+# the build or link graph, so comments are stripped before matching: policy
+# permits naming these libraries in prose (e.g. documenting that external
+# peers run out-of-process). A real dependency declaration is never inside a
+# comment.
+FORBIDDEN_NAMES='ngtcp2|nghttp3|quiche|boringssl|mbedtls|wolfssl|gnutls|libressl|rustls|s2n-tls|libtls|botan'
+
+# Strip comments from a file according to its type, then print the result.
+# .zig/.zon use `//`; shell/yaml/toml/Dockerfiles use `#`. Stripping is
+# type-scoped so a URL scheme's `//` in a shell script is preserved.
+strip_comments() {
+    local file="$1"
+    case "$file" in
+    *.zig | *.zon) sed 's://.*$::' "$file" ;;
+    *.sh | *.yml | *.yaml | *.toml | *Dockerfile* | *.spec | *.control) sed 's:#.*$::' "$file" ;;
+    *) cat "$file" ;;
+    esac
+}
+
+# Build configuration, automation, and packaging surfaces. Interop tooling
+# (scripts/interop/) is excluded by policy: it drives external peers as
+# separate processes and must name them. The audit scripts are excluded
+# because they define the deny list.
+scan_files=(build.zig build.zig.zon)
+while IFS= read -r f; do
+    scan_files+=("$f")
+done < <(find .github/workflows packaging -type f 2>/dev/null | sort)
+if [ -d scripts ]; then
+    while IFS= read -r script; do
+        case "$script" in
+        scripts/interop/*) ;;
+        scripts/audit-dependencies.sh | scripts/audit-release-binary.sh) ;;
+        *) scan_files+=("$script") ;;
+        esac
+    done < <(find scripts -type f | sort)
+fi
+while IFS= read -r dockerfile; do
+    scan_files+=("$dockerfile")
+done < <(find . -path ./.zig-cache -prune -o -path ./zig-out -prune -o -name 'Dockerfile*' -type f -print | sed 's|^\./||' | sort)
+
+for file in "${scan_files[@]}"; do
+    [ -f "$file" ] || continue
+    if matches="$(strip_comments "$file" | grep -niE "$FORBIDDEN_NAMES" 2>/dev/null)"; then
+        while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            fail "forbidden dependency configuration in $file: $line"
+        done <<<"$matches"
+    fi
+done
+
+# ── 2. OpenSSL includes restricted to the approved adapter boundary ──────────
+OPENSSL_INCLUDE_ALLOWLIST=(
+    src/http/tls_termination.zig
+    src/http/acme_client.zig
+)
+
+if matches="$(grep -rn '@cInclude("openssl/' src/ 2>/dev/null)"; then
+    while IFS= read -r line; do
+        file="${line%%:*}"
+        allowed=false
+        for allowed_file in "${OPENSSL_INCLUDE_ALLOWLIST[@]}"; do
+            if [ "$file" = "$allowed_file" ]; then
+                allowed=true
+                break
+            fi
+        done
+        if [ "$allowed" = false ]; then
+            fail "OpenSSL include outside the approved adapter boundary: $line"
+        fi
+    done <<<"$matches"
+fi
+
+# ── 3. Native implementation paths must be free of @cImport entirely ─────────
+NATIVE_PATHS=(src/tls src/pki src/quic src/crypto src/http3)
+
+for path in "${NATIVE_PATHS[@]}"; do
+    [ -d "$path" ] || continue
+    if matches="$(grep -rn '@cImport' "$path" 2>/dev/null)"; then
+        while IFS= read -r line; do
+            fail "@cImport in native implementation path: $line"
+        done <<<"$matches"
+    fi
+done
+
+# ── Result ────────────────────────────────────────────────────────────────────
+if [ "$failures" -gt 0 ]; then
+    echo "dependency audit failed with $failures violation(s)" >&2
+    exit 1
+fi
+echo "dependency audit passed: no forbidden dependencies, OpenSSL confined to the adapter boundary, native paths free of @cImport"

--- a/scripts/audit-dependencies.sh
+++ b/scripts/audit-dependencies.sh
@@ -7,8 +7,8 @@
 #      configuration, workflows, scripts, or packaging metadata. External
 #      implementations are allowed only as out-of-process interoperability
 #      peers (scripts/interop/), never in the link graph.
-#   2. OpenSSL headers may be included only inside the approved
-#      general-profile adapter boundary.
+#   2. OpenSSL may be referenced only inside the approved general-profile
+#      adapter boundary.
 #   3. Native implementation paths (TLS, PKI, QUIC, crypto, HTTP/3) must not
 #      contain any @cImport at all.
 #
@@ -27,35 +27,101 @@ fail() {
     failures=$((failures + 1))
 }
 
+# Strip comments from a line stream while respecting string literals, so a
+# forbidden name inside a real declaration (e.g. a `.url = "https://.../ngtcp2"`
+# dependency, whose `//` would otherwise be mistaken for a comment) is never
+# hidden, while a mention in prose is ignored. `style` is `zig` (// comments,
+# " and ' string/char literals, \\ multiline-string lines kept verbatim) or
+# `hash` (# comments that start a token, ' and " strings).
+strip_comments() {
+    awk -v style="$2" '
+    BEGIN { dq = sprintf("%c", 34); sq = sprintf("%c", 39) }
+    {
+        line = $0
+        if (style == "zig") {
+            tmp = line
+            sub(/^[ \t]+/, "", tmp)
+            if (substr(tmp, 1, 2) == "\\\\") { print line; next }
+        }
+        out = ""; inq = ""; n = length(line); i = 1
+        while (i <= n) {
+            ch = substr(line, i, 1)
+            if (inq != "") {
+                out = out ch
+                if (ch == "\\") { i++; if (i <= n) out = out substr(line, i, 1); i++; continue }
+                if (ch == inq) inq = ""
+                i++; continue
+            }
+            if (ch == dq || ch == sq) { inq = ch; out = out ch; i++; continue }
+            if (style == "zig" && ch == "/" && substr(line, i + 1, 1) == "/") break
+            if (style == "hash" && ch == "#") {
+                prev = (i == 1) ? " " : substr(line, i - 1, 1)
+                if (prev == " " || prev == "\t") break
+            }
+            out = out ch; i++
+        }
+        print out
+    }' "$1"
+}
+
+comment_style_for() {
+    case "$1" in
+    *.zig | *.zon) echo zig ;;
+    *.sh | *.yml | *.yaml | *.toml | *Dockerfile* | *.spec | *.control) echo hash ;;
+    *) echo none ;;
+    esac
+}
+
+stripped() {
+    local style
+    style="$(comment_style_for "$1")"
+    if [ "$style" = none ]; then
+        cat "$1"
+    else
+        strip_comments "$1" "$style"
+    fi
+}
+
+# Resolve build.zig's transitive `@import("*.zig")` closure so linkage moved
+# into an imported build helper (e.g. `build/dependencies.zig`) is still
+# audited, rather than trusting the root file to hold every declaration.
+resolve_build_sources() {
+    local -a queue=("build.zig")
+    local -A seen=()
+    local f dir imp target
+    while [ "${#queue[@]}" -gt 0 ]; do
+        f="${queue[0]}"
+        queue=("${queue[@]:1}")
+        [ -n "${seen[$f]:-}" ] && continue
+        seen[$f]=1
+        [ -f "$f" ] || continue
+        printf '%s\n' "$f"
+        dir="$(dirname "$f")"
+        while IFS= read -r imp; do
+            [ -z "$imp" ] && continue
+            target="$(realpath -m --relative-to="$REPO_ROOT" "$REPO_ROOT/$dir/$imp" 2>/dev/null || true)"
+            case "$target" in
+            "" | ../*) continue ;; # outside the repo
+            esac
+            queue+=("$target")
+        done < <(grep -oE '@import\("[^"]+\.zig"\)' "$f" 2>/dev/null | sed -E 's/.*@import\("([^"]+)"\).*/\1/')
+    done
+}
+
 # ── 1. Forbidden dependency identifiers in build/config surfaces ─────────────
 # openssl itself is not in this list: the general profile's adapter is the
 # single approved exception, enforced separately by checks 2 and 3 and by the
 # binary audit (scripts/audit-release-binary.sh).
-#
-# The check targets configuration that would actually pull a dependency into
-# the build or link graph, so comments are stripped before matching: policy
-# permits naming these libraries in prose (e.g. documenting that external
-# peers run out-of-process). A real dependency declaration is never inside a
-# comment.
 FORBIDDEN_NAMES='ngtcp2|nghttp3|quiche|boringssl|mbedtls|wolfssl|gnutls|libressl|rustls|s2n-tls|libtls|botan'
 
-# Strip comments from a file according to its type, then print the result.
-# .zig/.zon use `//`; shell/yaml/toml/Dockerfiles use `#`. Stripping is
-# type-scoped so a URL scheme's `//` in a shell script is preserved.
-strip_comments() {
-    local file="$1"
-    case "$file" in
-    *.zig | *.zon) sed 's://.*$::' "$file" ;;
-    *.sh | *.yml | *.yaml | *.toml | *Dockerfile* | *.spec | *.control) sed 's:#.*$::' "$file" ;;
-    *) cat "$file" ;;
-    esac
-}
-
-# Build configuration, automation, and packaging surfaces. Interop tooling
-# (scripts/interop/) is excluded by policy: it drives external peers as
-# separate processes and must name them. The audit scripts are excluded
-# because they define the deny list.
-scan_files=(build.zig build.zig.zon)
+# Build configuration (the resolved build-graph sources plus the manifest),
+# automation, and packaging surfaces. Interop tooling (scripts/interop/) is
+# excluded by policy: it drives external peers as separate processes and must
+# name them. The audit scripts are excluded because they define the deny list.
+scan_files=("build.zig.zon")
+while IFS= read -r f; do
+    scan_files+=("$f")
+done < <(resolve_build_sources)
 while IFS= read -r f; do
     scan_files+=("$f")
 done < <(find .github/workflows packaging -type f 2>/dev/null | sort)
@@ -72,9 +138,13 @@ while IFS= read -r dockerfile; do
     scan_files+=("$dockerfile")
 done < <(find . -path ./.zig-cache -prune -o -path ./zig-out -prune -o -name 'Dockerfile*' -type f -print | sed 's|^\./||' | sort)
 
+# De-duplicate (build.zig may already appear via the graph and via a glob).
+declare -A scanned=()
 for file in "${scan_files[@]}"; do
     [ -f "$file" ] || continue
-    if matches="$(strip_comments "$file" | grep -niE "$FORBIDDEN_NAMES" 2>/dev/null)"; then
+    [ -n "${scanned[$file]:-}" ] && continue
+    scanned[$file]=1
+    if matches="$(stripped "$file" | grep -niE "$FORBIDDEN_NAMES" 2>/dev/null)"; then
         while IFS= read -r line; do
             [ -z "$line" ] && continue
             fail "forbidden dependency configuration in $file: $line"
@@ -82,38 +152,45 @@ for file in "${scan_files[@]}"; do
     fi
 done
 
-# ── 2. OpenSSL includes restricted to the approved adapter boundary ──────────
-OPENSSL_INCLUDE_ALLOWLIST=(
+# ── 2. OpenSSL references restricted to the approved adapter boundary ─────────
+# Match the literal `openssl/` header path anywhere in comment-stripped source
+# rather than one exact @cInclude spelling, so whitespace variants and
+# reformatted includes cannot escape the allowlist.
+OPENSSL_ALLOWLIST=(
     src/http/tls_termination.zig
     src/http/acme_client.zig
 )
 
-if matches="$(grep -rn '@cInclude("openssl/' src/ 2>/dev/null)"; then
-    while IFS= read -r line; do
-        file="${line%%:*}"
-        allowed=false
-        for allowed_file in "${OPENSSL_INCLUDE_ALLOWLIST[@]}"; do
-            if [ "$file" = "$allowed_file" ]; then
-                allowed=true
-                break
-            fi
-        done
-        if [ "$allowed" = false ]; then
-            fail "OpenSSL include outside the approved adapter boundary: $line"
+while IFS= read -r zigfile; do
+    allowed=false
+    for allowed_file in "${OPENSSL_ALLOWLIST[@]}"; do
+        if [ "$zigfile" = "$allowed_file" ]; then
+            allowed=true
+            break
         fi
-    done <<<"$matches"
-fi
+    done
+    [ "$allowed" = true ] && continue
+    if matches="$(stripped "$zigfile" | grep -niE 'openssl/' 2>/dev/null)"; then
+        while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            fail "OpenSSL reference outside the approved adapter boundary in $zigfile: $line"
+        done <<<"$matches"
+    fi
+done < <(find src -name '*.zig' -type f | sort)
 
 # ── 3. Native implementation paths must be free of @cImport entirely ─────────
 NATIVE_PATHS=(src/tls src/pki src/quic src/crypto src/http3)
 
 for path in "${NATIVE_PATHS[@]}"; do
     [ -d "$path" ] || continue
-    if matches="$(grep -rn '@cImport' "$path" 2>/dev/null)"; then
-        while IFS= read -r line; do
-            fail "@cImport in native implementation path: $line"
-        done <<<"$matches"
-    fi
+    while IFS= read -r zigfile; do
+        if matches="$(stripped "$zigfile" | grep -niE '@cImport' 2>/dev/null)"; then
+            while IFS= read -r line; do
+                [ -z "$line" ] && continue
+                fail "@cImport in native implementation path $zigfile: $line"
+            done <<<"$matches"
+        fi
+    done < <(find "$path" -name '*.zig' -type f | sort)
 done
 
 # ── Result ────────────────────────────────────────────────────────────────────

--- a/scripts/audit-release-binary.sh
+++ b/scripts/audit-release-binary.sh
@@ -75,30 +75,61 @@ esac
 FORBIDDEN_LIB_PATTERNS='ngtcp2|nghttp3|quiche|boringssl|mbedtls|wolfssl|gnutls|libtls|libressl|botan|s2n'
 
 # ── Collect dynamic dependencies across platforms ────────────────────────────
+#
+# The inspection must distinguish two very different outcomes: a binary with no
+# dynamic dependencies (a valid, fully static build — an empty dependency list)
+# from a failed inspection (missing tool, unreadable/corrupt binary, wrong
+# architecture). The former is legitimate; the latter must never be reported as
+# a clean, dependency-free appliance artifact, so it exits with an error rather
+# than an empty list. On Linux we read the ELF dynamic section directly
+# (readelf/objdump) instead of executing the binary through `ldd`.
 os="$(uname -s)"
 deps=""
 inspection_tool=""
 case "$os" in
 Linux)
-    inspection_tool="ldd"
-    # ldd returns nonzero for a static binary ("not a dynamic executable");
-    # that is a valid, dependency-free result, so tolerate the failure.
-    deps="$(ldd "$BINARY" 2>/dev/null || true)"
+    if command -v readelf >/dev/null 2>&1; then
+        inspection_tool="readelf -d"
+        if ! deps="$(readelf -d "$BINARY" 2>/dev/null)"; then
+            echo "inspection failed: readelf could not read '$BINARY' (not an ELF object, corrupt, or wrong architecture)" >&2
+            exit 2
+        fi
+    elif command -v objdump >/dev/null 2>&1; then
+        inspection_tool="objdump -p"
+        if ! deps="$(objdump -p "$BINARY" 2>/dev/null)"; then
+            echo "inspection failed: objdump could not read '$BINARY'" >&2
+            exit 2
+        fi
+    else
+        echo "inspection failed: no ELF inspection tool (readelf or objdump) available" >&2
+        exit 2
+    fi
+    # readelf/objdump both render NEEDED entries as "[libfoo.so.N]"; a static
+    # binary simply has none. No match therefore means static, not a failure.
+    dep_names="$(printf '%s\n' "$deps" |
+        grep -E 'NEEDED' |
+        grep -oE '\[[^][]+\]' |
+        tr -d '[]' |
+        sort -u || true)"
     ;;
 Darwin)
     inspection_tool="otool -L"
-    deps="$(otool -L "$BINARY" 2>/dev/null || true)"
+    if ! deps="$(otool -L "$BINARY" 2>/dev/null)"; then
+        echo "inspection failed: otool could not read '$BINARY' (not a Mach-O object, corrupt, or wrong architecture)" >&2
+        exit 2
+    fi
+    # otool -L lists the binary path on the first line, then one dependency
+    # path per indented line; keep the shared-library leaf names.
+    dep_names="$(printf '%s\n' "$deps" |
+        tail -n +2 |
+        grep -oE '(lib[a-zA-Z0-9._+-]+\.dylib)' |
+        sort -u || true)"
     ;;
 *)
     echo "unsupported host OS for binary inspection: $os" >&2
     exit 2
     ;;
 esac
-
-# Normalize to one shared-object name per line for scanning and inventory.
-dep_names="$(printf '%s\n' "$deps" |
-    grep -oE '(lib[a-zA-Z0-9._+-]+\.(so|dylib)[0-9.]*)' |
-    sort -u || true)"
 
 links_openssl=false
 if printf '%s\n' "$dep_names" | grep -qiE 'libssl|libcrypto'; then
@@ -108,12 +139,18 @@ fi
 forbidden_hits="$(printf '%s\n' "$dep_names" | grep -iE "$FORBIDDEN_LIB_PATTERNS" || true)"
 
 # ── Binary self-report (the version line records the built-in profile) ───────
+# Both the profile and the backend are parsed and checked: the requested
+# --profile must match the profile compiled into the artifact, and the backend
+# must be consistent with it. A binary that cannot report its profile is a
+# violation, not a pass.
 self_report="$("$BINARY" version 2>/dev/null || true)"
 reported_backend="unknown"
 case "$self_report" in
 *"tls-backend=native"*) reported_backend="native" ;;
 *"tls-backend=openssl-adapter"*) reported_backend="openssl-adapter" ;;
 esac
+reported_profile="$(printf '%s' "$self_report" | sed -nE 's/.*tls-profile=([a-zA-Z0-9_-]+).*/\1/p')"
+[ -n "$reported_profile" ] || reported_profile="unknown"
 
 # ── Policy evaluation ────────────────────────────────────────────────────────
 status="pass"
@@ -124,6 +161,13 @@ if [ -n "$forbidden_hits" ]; then
         [ -z "$hit" ] && continue
         violations+=("forbidden foreign TLS/crypto/QUIC library linked: $hit")
     done <<<"$forbidden_hits"
+fi
+
+# The artifact must actually be the profile it is being audited as, regardless
+# of profile: a native appliance binary audited as general (or vice versa) is a
+# mismatch, not a pass.
+if [ "$reported_profile" != "$PROFILE" ]; then
+    violations+=("artifact self-reports tls-profile '$reported_profile' but was audited as '$PROFILE'")
 fi
 
 if [ "$PROFILE" = "appliance" ]; then
@@ -155,6 +199,7 @@ emit_inventory() {
     printf '  "profile": %s,\n' "$(json_string "$PROFILE")"
     printf '  "host_os": %s,\n' "$(json_string "$os")"
     printf '  "inspection_tool": %s,\n' "$(json_string "$inspection_tool")"
+    printf '  "reported_profile": %s,\n' "$(json_string "$reported_profile")"
     printf '  "reported_backend": %s,\n' "$(json_string "$reported_backend")"
     printf '  "self_report": %s,\n' "$(json_string "$self_report")"
     printf '  "links_openssl": %s,\n' "$links_openssl"

--- a/scripts/audit-release-binary.sh
+++ b/scripts/audit-release-binary.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# TLS/crypto binary linkage audit and dependency inventory (#379, epic #327).
+#
+# Inspects a produced tardigrade binary's dynamic dependencies and emits a
+# machine-readable inventory. For the Bare Systems appliance profile it fails
+# if the binary links OpenSSL, libcrypto, or any other foreign TLS/crypto/
+# QUIC/H3/certificate library, and confirms the binary self-reports the
+# native TLS path. For the general profile it records whether the OpenSSL
+# adapter was selected and lists the full dependency set.
+#
+# Usage:
+#   audit-release-binary.sh --binary PATH --profile {general|appliance} \
+#       [--output inventory.json]
+#
+# Exit code 0 means the audit passed. A forbidden linkage, or a profile that
+# disagrees with the binary's self-report, exits 1.
+
+set -euo pipefail
+
+BINARY=""
+PROFILE=""
+OUTPUT=""
+
+usage() {
+    cat <<'EOF'
+Usage: audit-release-binary.sh --binary PATH --profile {general|appliance} [--output FILE]
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+    --binary)
+        BINARY="$2"
+        shift 2
+        ;;
+    --profile)
+        PROFILE="$2"
+        shift 2
+        ;;
+    --output)
+        OUTPUT="$2"
+        shift 2
+        ;;
+    -h | --help)
+        usage
+        exit 0
+        ;;
+    *)
+        echo "unknown argument: $1" >&2
+        usage
+        exit 2
+        ;;
+    esac
+done
+
+if [ -z "$BINARY" ] || [ -z "$PROFILE" ]; then
+    usage
+    exit 2
+fi
+if [ ! -f "$BINARY" ]; then
+    echo "binary not found: $BINARY" >&2
+    exit 2
+fi
+case "$PROFILE" in
+general | appliance) ;;
+*)
+    echo "invalid profile: $PROFILE (expected general or appliance)" >&2
+    exit 2
+    ;;
+esac
+
+# Foreign TLS/crypto/QUIC/H3/certificate libraries that must never appear in a
+# Tardigrade link graph. openssl/crypto are handled separately: forbidden in
+# the appliance profile, the approved adapter in the general profile.
+FORBIDDEN_LIB_PATTERNS='ngtcp2|nghttp3|quiche|boringssl|mbedtls|wolfssl|gnutls|libtls|libressl|botan|s2n'
+
+# ── Collect dynamic dependencies across platforms ────────────────────────────
+os="$(uname -s)"
+deps=""
+inspection_tool=""
+case "$os" in
+Linux)
+    inspection_tool="ldd"
+    # ldd returns nonzero for a static binary ("not a dynamic executable");
+    # that is a valid, dependency-free result, so tolerate the failure.
+    deps="$(ldd "$BINARY" 2>/dev/null || true)"
+    ;;
+Darwin)
+    inspection_tool="otool -L"
+    deps="$(otool -L "$BINARY" 2>/dev/null || true)"
+    ;;
+*)
+    echo "unsupported host OS for binary inspection: $os" >&2
+    exit 2
+    ;;
+esac
+
+# Normalize to one shared-object name per line for scanning and inventory.
+dep_names="$(printf '%s\n' "$deps" |
+    grep -oE '(lib[a-zA-Z0-9._+-]+\.(so|dylib)[0-9.]*)' |
+    sort -u || true)"
+
+links_openssl=false
+if printf '%s\n' "$dep_names" | grep -qiE 'libssl|libcrypto'; then
+    links_openssl=true
+fi
+
+forbidden_hits="$(printf '%s\n' "$dep_names" | grep -iE "$FORBIDDEN_LIB_PATTERNS" || true)"
+
+# ── Binary self-report (the version line records the built-in profile) ───────
+self_report="$("$BINARY" version 2>/dev/null || true)"
+reported_backend="unknown"
+case "$self_report" in
+*"tls-backend=native"*) reported_backend="native" ;;
+*"tls-backend=openssl-adapter"*) reported_backend="openssl-adapter" ;;
+esac
+
+# ── Policy evaluation ────────────────────────────────────────────────────────
+status="pass"
+declare -a violations=()
+
+if [ -n "$forbidden_hits" ]; then
+    while IFS= read -r hit; do
+        [ -z "$hit" ] && continue
+        violations+=("forbidden foreign TLS/crypto/QUIC library linked: $hit")
+    done <<<"$forbidden_hits"
+fi
+
+if [ "$PROFILE" = "appliance" ]; then
+    if [ "$links_openssl" = true ]; then
+        violations+=("appliance artifact links OpenSSL (libssl/libcrypto)")
+    fi
+    if [ "$reported_backend" != "native" ]; then
+        violations+=("appliance artifact does not self-report the native TLS path (got '$reported_backend')")
+    fi
+else
+    # General profile: OpenSSL is permitted, but the binary's self-report must
+    # match its actual linkage so the inventory is trustworthy.
+    if [ "$links_openssl" = true ] && [ "$reported_backend" != "openssl-adapter" ]; then
+        violations+=("general artifact links OpenSSL but self-reports backend '$reported_backend'")
+    fi
+    if [ "$links_openssl" = false ] && [ "$reported_backend" = "openssl-adapter" ]; then
+        violations+=("general artifact self-reports the OpenSSL adapter but does not link OpenSSL")
+    fi
+fi
+
+if [ "${#violations[@]}" -gt 0 ]; then
+    status="fail"
+fi
+
+# ── Emit machine-readable inventory ──────────────────────────────────────────
+emit_inventory() {
+    printf '{\n'
+    printf '  "binary": %s,\n' "$(json_string "$BINARY")"
+    printf '  "profile": %s,\n' "$(json_string "$PROFILE")"
+    printf '  "host_os": %s,\n' "$(json_string "$os")"
+    printf '  "inspection_tool": %s,\n' "$(json_string "$inspection_tool")"
+    printf '  "reported_backend": %s,\n' "$(json_string "$reported_backend")"
+    printf '  "self_report": %s,\n' "$(json_string "$self_report")"
+    printf '  "links_openssl": %s,\n' "$links_openssl"
+    printf '  "status": %s,\n' "$(json_string "$status")"
+    printf '  "dependencies": ['
+    first=true
+    while IFS= read -r dep; do
+        [ -z "$dep" ] && continue
+        if [ "$first" = true ]; then
+            first=false
+            printf '\n'
+        else
+            printf ',\n'
+        fi
+        printf '    %s' "$(json_string "$dep")"
+    done <<<"$dep_names"
+    [ "$first" = false ] && printf '\n  '
+    printf '],\n'
+    printf '  "violations": ['
+    first=true
+    for violation in "${violations[@]:-}"; do
+        [ -z "$violation" ] && continue
+        if [ "$first" = true ]; then
+            first=false
+            printf '\n'
+        else
+            printf ',\n'
+        fi
+        printf '    %s' "$(json_string "$violation")"
+    done
+    [ "$first" = false ] && printf '\n  '
+    printf ']\n'
+    printf '}\n'
+}
+
+json_string() {
+    # Minimal JSON string escaping for the fields we emit (paths, lib names,
+    # a version line): backslash, double-quote, and control-free ASCII.
+    printf '"%s"' "$(printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+}
+
+inventory="$(emit_inventory)"
+if [ -n "$OUTPUT" ]; then
+    printf '%s\n' "$inventory" >"$OUTPUT"
+fi
+printf '%s\n' "$inventory"
+
+if [ "$status" = "fail" ]; then
+    echo "binary audit failed for profile '$PROFILE':" >&2
+    for violation in "${violations[@]}"; do
+        echo "  - $violation" >&2
+    done
+    exit 1
+fi
+
+echo "binary audit passed for profile '$PROFILE' (backend: $reported_backend)" >&2

--- a/src/http.zig
+++ b/src/http.zig
@@ -47,8 +47,16 @@ pub const worker_pool = @import("http/worker_pool.zig");
 pub const buffer_pool = @import("http/buffer_pool.zig");
 pub const keepalive_park = @import("http/keepalive_park.zig");
 pub const upstream_pool = @import("http/upstream_pool.zig");
-pub const tls_termination = @import("http/tls_termination.zig");
-pub const acme_client = @import("http/acme_client.zig");
+/// TLS termination backend selected by `-Dtls-profile` (#379): the OpenSSL
+/// adapter in the general profile, a no-OpenSSL stub in the Bare Systems
+/// appliance profile. The swap happens in `http/tls_backend.zig` — at the
+/// module graph, not at runtime — so an appliance binary never analyzes
+/// `@cImport("openssl/...")` and cannot silently fall back to the C adapter.
+pub const tls_termination = @import("http/tls_backend.zig");
+/// ACME client backend selected by `-Dtls-profile` (#379): OpenSSL-backed in
+/// the general profile, a no-OpenSSL stub in the appliance profile. Selected
+/// at the module graph so the appliance never links OpenSSL through ACME.
+pub const acme_client = @import("http/acme_backend.zig");
 pub const hpack = @import("http/hpack.zig");
 pub const http2_frame = @import("http/http2_frame.zig");
 pub const http2_stream = @import("http/http2_stream.zig");

--- a/src/http/acme_backend.zig
+++ b/src/http/acme_backend.zig
@@ -1,0 +1,22 @@
+//! ACME client backend selector (#379, epic #327).
+//!
+//! Mirrors `tls_backend.zig`: `-Dtls-profile=general` selects the
+//! OpenSSL-backed ACME client, `-Dtls-profile=appliance` selects the
+//! no-OpenSSL stub, so an appliance binary never analyzes the ACME client's
+//! `@cImport("openssl/...")` and never links OpenSSL through the ACME path.
+//! The pure-Zig `ChallengeStore` is identical in both backends.
+
+const selected = if (@import("build_options").tls_openssl_adapter)
+    @import("acme_client.zig")
+else
+    @import("acme_client_stub.zig");
+
+pub const AcmeError = selected.AcmeError;
+pub const ChallengeStore = selected.ChallengeStore;
+pub const AcmeOptions = selected.AcmeOptions;
+pub const daysUntilExpiry = selected.daysUntilExpiry;
+pub const runOnce = selected.runOnce;
+
+test {
+    _ = selected;
+}

--- a/src/http/acme_challenge_store.zig
+++ b/src/http/acme_challenge_store.zig
@@ -1,0 +1,83 @@
+//! HTTP-01 ACME challenge token store (pure Zig, no OpenSSL).
+//!
+//! Extracted from `acme_client.zig` (#379) so both the OpenSSL-backed ACME
+//! client (general profile) and the no-OpenSSL stub (appliance profile) share
+//! one implementation, and so the store can be referenced without pulling the
+//! ACME client's `@cImport` into the appliance link graph. The edge gateway
+//! reads from this store to serve `/.well-known/acme-challenge/<token>`.
+
+const std = @import("std");
+const compat = @import("../zig_compat.zig");
+
+/// Thread-safe store for HTTP-01 ACME challenge tokens.
+pub const ChallengeStore = struct {
+    allocator: std.mem.Allocator,
+    mutex: compat.Mutex = .{},
+    tokens: std.StringHashMap([]u8),
+
+    pub fn init(allocator: std.mem.Allocator) ChallengeStore {
+        return .{
+            .allocator = allocator,
+            .tokens = std.StringHashMap([]u8).init(allocator),
+        };
+    }
+
+    pub fn deinit(self: *ChallengeStore) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        var it = self.tokens.iterator();
+        while (it.next()) |entry| {
+            self.allocator.free(entry.key_ptr.*);
+            self.allocator.free(entry.value_ptr.*);
+        }
+        self.tokens.deinit();
+    }
+
+    pub fn put(self: *ChallengeStore, token: []const u8, key_auth: []const u8) !void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const owned_token = try self.allocator.dupe(u8, token);
+        errdefer self.allocator.free(owned_token);
+        const owned_auth = try self.allocator.dupe(u8, key_auth);
+        errdefer self.allocator.free(owned_auth);
+        const gop = try self.tokens.getOrPut(owned_token);
+        if (gop.found_existing) {
+            self.allocator.free(gop.key_ptr.*);
+            self.allocator.free(gop.value_ptr.*);
+            gop.key_ptr.* = owned_token;
+        }
+        gop.value_ptr.* = owned_auth;
+    }
+
+    /// Returns an owned copy of the key authorization for the token, or null.
+    /// Caller must free the returned slice.
+    pub fn getCopy(self: *ChallengeStore, allocator: std.mem.Allocator, token: []const u8) ?[]u8 {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const val = self.tokens.get(token) orelse return null;
+        return allocator.dupe(u8, val) catch null;
+    }
+
+    pub fn remove(self: *ChallengeStore, token: []const u8) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (self.tokens.fetchRemove(token)) |entry| {
+            self.allocator.free(entry.key);
+            self.allocator.free(entry.value);
+        }
+    }
+};
+
+test "ChallengeStore put/getCopy/remove" {
+    const allocator = std.testing.allocator;
+    var store = ChallengeStore.init(allocator);
+    defer store.deinit();
+
+    try store.put("abc123", "abc123.thumbprint");
+    const val = store.getCopy(allocator, "abc123").?;
+    defer allocator.free(val);
+    try std.testing.expectEqualStrings("abc123.thumbprint", val);
+
+    store.remove("abc123");
+    try std.testing.expect(store.getCopy(allocator, "abc123") == null);
+}

--- a/src/http/acme_client.zig
+++ b/src/http/acme_client.zig
@@ -41,66 +41,10 @@ pub const AcmeError = error{
 // Challenge token store (HTTP-01)
 // ---------------------------------------------------------------------------
 
-/// Thread-safe store for HTTP-01 ACME challenge tokens.
-/// The edge gateway reads from this store to serve
-/// /.well-known/acme-challenge/<token> responses.
-pub const ChallengeStore = struct {
-    allocator: std.mem.Allocator,
-    mutex: compat.Mutex = .{},
-    tokens: std.StringHashMap([]u8),
-
-    pub fn init(allocator: std.mem.Allocator) ChallengeStore {
-        return .{
-            .allocator = allocator,
-            .tokens = std.StringHashMap([]u8).init(allocator),
-        };
-    }
-
-    pub fn deinit(self: *ChallengeStore) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
-        var it = self.tokens.iterator();
-        while (it.next()) |entry| {
-            self.allocator.free(entry.key_ptr.*);
-            self.allocator.free(entry.value_ptr.*);
-        }
-        self.tokens.deinit();
-    }
-
-    pub fn put(self: *ChallengeStore, token: []const u8, key_auth: []const u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
-        const owned_token = try self.allocator.dupe(u8, token);
-        errdefer self.allocator.free(owned_token);
-        const owned_auth = try self.allocator.dupe(u8, key_auth);
-        errdefer self.allocator.free(owned_auth);
-        const gop = try self.tokens.getOrPut(owned_token);
-        if (gop.found_existing) {
-            self.allocator.free(gop.key_ptr.*);
-            self.allocator.free(gop.value_ptr.*);
-            gop.key_ptr.* = owned_token;
-        }
-        gop.value_ptr.* = owned_auth;
-    }
-
-    /// Returns an owned copy of the key authorization for the token, or null.
-    /// Caller must free the returned slice.
-    pub fn getCopy(self: *ChallengeStore, allocator: std.mem.Allocator, token: []const u8) ?[]u8 {
-        self.mutex.lock();
-        defer self.mutex.unlock();
-        const val = self.tokens.get(token) orelse return null;
-        return allocator.dupe(u8, val) catch null;
-    }
-
-    pub fn remove(self: *ChallengeStore, token: []const u8) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
-        if (self.tokens.fetchRemove(token)) |entry| {
-            self.allocator.free(entry.key);
-            self.allocator.free(entry.value);
-        }
-    }
-};
+/// Re-exported from the shared pure-Zig store (#379) so the appliance stub
+/// and every caller reference the same type without pulling this file's
+/// OpenSSL `@cImport` into their link graph.
+pub const ChallengeStore = @import("acme_challenge_store.zig").ChallengeStore;
 
 // ---------------------------------------------------------------------------
 // Base64url helpers
@@ -729,20 +673,6 @@ pub fn runOnce(opts: AcmeOptions) AcmeError!void {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
-
-test "ChallengeStore put/getCopy/remove" {
-    const allocator = std.testing.allocator;
-    var store = ChallengeStore.init(allocator);
-    defer store.deinit();
-
-    try store.put("abc123", "abc123.thumbprint");
-    const val = store.getCopy(allocator, "abc123").?;
-    defer allocator.free(val);
-    try std.testing.expectEqualStrings("abc123.thumbprint", val);
-
-    store.remove("abc123");
-    try std.testing.expect(store.getCopy(allocator, "abc123") == null);
-}
 
 test "b64urlEncode round-trip" {
     const allocator = std.testing.allocator;

--- a/src/http/acme_client_stub.zig
+++ b/src/http/acme_client_stub.zig
@@ -1,0 +1,78 @@
+//! No-OpenSSL ACME client stub for the Bare Systems appliance profile (#379).
+//!
+//! Selected by `-Dtls-profile=appliance` via `src/http/acme_backend.zig`.
+//! Presents the same public surface as `acme_client.zig` — so the gateway and
+//! TLS termination code compile unchanged — but contains no `@cImport` and no
+//! OpenSSL. The pure-Zig `ChallengeStore` is shared with the real client; the
+//! issuance/renewal workflow, which needs EC key generation, CSR building, and
+//! signing, is not yet available on the native path and fails closed rather
+//! than silently doing nothing. Automated ACME for the appliance is tracked
+//! alongside the native TLS matrix (#391).
+
+const std = @import("std");
+
+pub const AcmeError = error{
+    OutOfMemory,
+    KeyGenFailed,
+    KeyLoadFailed,
+    KeySaveFailed,
+    JsonParseFailed,
+    NetworkError,
+    AcmeProtocolError,
+    ChallengeFailed,
+    CsrFailed,
+    CertDownloadFailed,
+    CertSaveFailed,
+    CertNotYetDue,
+};
+
+/// Shared pure-Zig challenge token store (identical to the general profile).
+pub const ChallengeStore = @import("acme_challenge_store.zig").ChallengeStore;
+
+pub const AcmeOptions = struct {
+    allocator: std.mem.Allocator,
+    directory_url: []const u8,
+    domains: []const []const u8,
+    email: []const u8,
+    account_key_path: []const u8,
+    cert_dir: []const u8,
+    renew_days_before_expiry: u32,
+    challenge_store: *ChallengeStore,
+    challenge_timeout_s: u32 = 120,
+};
+
+/// Certificate expiry inspection needs X.509 parsing that the native path does
+/// not yet expose here; report "unknown" so callers treat it as not-due rather
+/// than forcing a renewal that cannot run.
+pub fn daysUntilExpiry(cert_path: []const u8) ?i64 {
+    _ = cert_path;
+    return null;
+}
+
+/// The ACME issuance/renewal workflow is unavailable in the appliance profile.
+/// Fail closed with an inspectable error instead of a hidden no-op.
+pub fn runOnce(opts: AcmeOptions) AcmeError!void {
+    _ = opts;
+    return error.AcmeProtocolError;
+}
+
+test "stub ACME runOnce fails closed and shares the challenge store" {
+    var store = ChallengeStore.init(std.testing.allocator);
+    defer store.deinit();
+    try store.put("tok", "tok.key");
+    const copy = store.getCopy(std.testing.allocator, "tok").?;
+    defer std.testing.allocator.free(copy);
+    try std.testing.expectEqualStrings("tok.key", copy);
+
+    try std.testing.expectEqual(@as(?i64, null), daysUntilExpiry("whatever.crt"));
+    try std.testing.expectError(error.AcmeProtocolError, runOnce(.{
+        .allocator = std.testing.allocator,
+        .directory_url = "",
+        .domains = &.{"example.com"},
+        .email = "",
+        .account_key_path = "",
+        .cert_dir = "",
+        .renew_days_before_expiry = 30,
+        .challenge_store = &store,
+    }));
+}

--- a/src/http/keepalive_park.zig
+++ b/src/http/keepalive_park.zig
@@ -28,7 +28,7 @@
 const std = @import("std");
 const compat = @import("../zig_compat.zig");
 const gateway_state = @import("../gateway_state.zig");
-const tls_termination = @import("tls_termination.zig");
+const tls_termination = @import("tls_backend.zig");
 
 const ConnectionSession = gateway_state.ConnectionSession;
 const ConnectionSessionPool = gateway_state.ConnectionSessionPool;

--- a/src/http/tls_backend.zig
+++ b/src/http/tls_backend.zig
@@ -1,0 +1,29 @@
+//! TLS termination backend selector (#379, epic #327).
+//!
+//! Every consumer of TLS termination — `http.zig`'s public alias and the
+//! direct importers inside `src/http/` — goes through this file, so exactly
+//! one backend type set exists per build. `-Dtls-profile=general` selects
+//! the approved OpenSSL adapter; `-Dtls-profile=appliance` selects the
+//! no-OpenSSL stub, in which case `tls_termination.zig` is never analyzed,
+//! `@cImport("openssl/...")` never runs, and no `libssl`/`libcrypto`
+//! linkage exists. The selection is a build-graph decision with no runtime
+//! fallback; see docs/TLS_DEPENDENCY_POLICY.md.
+
+const selected = if (@import("build_options").tls_openssl_adapter)
+    @import("tls_termination.zig")
+else
+    @import("tls_termination_stub.zig");
+
+pub const TlsError = selected.TlsError;
+pub const SniCertSpec = selected.SniCertSpec;
+pub const TlsOptions = selected.TlsOptions;
+pub const NegotiatedProtocol = selected.NegotiatedProtocol;
+pub const TlsTerminator = selected.TlsTerminator;
+pub const TlsConnection = selected.TlsConnection;
+pub const UpstreamTlsOptions = selected.UpstreamTlsOptions;
+pub const UpstreamTlsConn = selected.UpstreamTlsConn;
+pub const lastOpenSslError = selected.lastOpenSslError;
+
+test {
+    _ = selected;
+}

--- a/src/http/tls_termination_stub.zig
+++ b/src/http/tls_termination_stub.zig
@@ -1,0 +1,232 @@
+//! No-OpenSSL TLS termination stub for the Bare Systems appliance profile
+//! (#379, epic #327).
+//!
+//! Selected by `-Dtls-profile=appliance` in `src/http.zig`. Presents the
+//! same public surface as `tls_termination.zig` so every call site compiles
+//! unchanged, but contains no `@cImport`, no OpenSSL types, and no C
+//! linkage. Until the native TLS path lands (#391 defines the appliance
+//! support matrix), any attempt to construct a terminator or upstream TLS
+//! connection fails closed at startup with `error.ContextInitFailed` — a
+//! deliberate, inspectable failure rather than a hidden runtime fallback.
+//!
+//! Option structs are duplicated field-for-field from the adapter so
+//! configuration parsing behaves identically in both profiles; only the
+//! I/O-bearing types are inert.
+
+const std = @import("std");
+
+pub const TlsError = error{
+    OutOfMemory,
+    OpenSslInitFailed,
+    ContextInitFailed,
+    CertificateLoadFailed,
+    PrivateKeyLoadFailed,
+    CertificateKeyMismatch,
+    ProtocolConfigFailed,
+    CipherConfigFailed,
+    VerifyConfigFailed,
+    CrlLoadFailed,
+    OcspLoadFailed,
+    HandshakeFailed,
+    TlsReadFailed,
+    TlsWriteFailed,
+};
+
+pub const SniCertSpec = struct {
+    server_name: []const u8,
+    cert_path: []const u8,
+    key_path: []const u8,
+};
+
+pub const TlsOptions = struct {
+    cert_path: []const u8,
+    key_path: []const u8,
+    min_version: []const u8 = "1.2",
+    max_version: []const u8 = "1.3",
+    cipher_list: []const u8 = "",
+    cipher_suites: []const u8 = "",
+    sni_certs: []const SniCertSpec = &[_]SniCertSpec{},
+    session_cache_enabled: bool = true,
+    session_cache_size: u32 = 20_480,
+    session_timeout_seconds: u32 = 300,
+    session_tickets_enabled: bool = true,
+    ocsp_stapling_enabled: bool = false,
+    ocsp_response_path: []const u8 = "",
+    ocsp_auto_refresh_enabled: bool = false,
+    ocsp_refresh_interval_ms: u64 = 3_600_000,
+    ocsp_refresh_timeout_ms: u32 = 10_000,
+    client_ca_path: []const u8 = "",
+    client_verify: bool = false,
+    client_verify_depth: u32 = 3,
+    crl_path: []const u8 = "",
+    crl_check: bool = false,
+    dynamic_reload_interval_ms: u64 = 5_000,
+    acme_enabled: bool = false,
+    acme_cert_dir: []const u8 = "",
+    acme_auto_issue: bool = false,
+    acme_directory_url: []const u8 = "https://acme-v02.api.letsencrypt.org/directory",
+    acme_domains: []const []const u8 = &.{},
+    acme_email: []const u8 = "",
+    acme_account_key_path: []const u8 = "",
+    acme_renew_days_before_expiry: u32 = 30,
+    acme_challenge_store: ?*@import("acme_challenge_store.zig").ChallengeStore = null,
+    http2_enabled: bool = true,
+};
+
+pub const NegotiatedProtocol = enum {
+    http1_1,
+    http2,
+};
+
+const unavailable_message = "TLS termination is unavailable: this binary was built with " ++
+    "-Dtls-profile=appliance and contains no OpenSSL adapter; the native TLS " ++
+    "path is tracked by #391";
+
+pub const TlsTerminator = struct {
+    allocator: std.mem.Allocator,
+
+    pub fn init(allocator: std.mem.Allocator, opts: TlsOptions) TlsError!TlsTerminator {
+        _ = allocator;
+        _ = opts;
+        return error.ContextInitFailed;
+    }
+
+    pub fn deinit(self: *TlsTerminator) void {
+        self.* = undefined;
+    }
+
+    pub fn runMaintenance(self: *TlsTerminator, now_ms: u64) void {
+        _ = self;
+        _ = now_ms;
+    }
+
+    pub fn accept(self: *TlsTerminator, fd: std.posix.fd_t) TlsError!TlsConnection {
+        _ = self;
+        _ = fd;
+        return error.HandshakeFailed;
+    }
+};
+
+pub const TlsConnection = struct {
+    pub fn deinit(self: *TlsConnection) void {
+        self.* = undefined;
+    }
+
+    pub fn read(self: *TlsConnection, buf: []u8) TlsError!usize {
+        _ = self;
+        _ = buf;
+        return error.TlsReadFailed;
+    }
+
+    pub fn pending(self: *const TlsConnection) usize {
+        _ = self;
+        return 0;
+    }
+
+    pub fn rawFd(self: *const TlsConnection) std.posix.fd_t {
+        _ = self;
+        return -1;
+    }
+
+    pub const Writer = struct {
+        conn: *TlsConnection,
+
+        pub fn writeAll(self: Writer, data: []const u8) TlsError!void {
+            _ = self;
+            _ = data;
+            return error.TlsWriteFailed;
+        }
+
+        pub fn print(self: Writer, comptime fmt: []const u8, args: anytype) !void {
+            var buf: [4096]u8 = undefined;
+            const s = try std.fmt.bufPrint(&buf, fmt, args);
+            return self.writeAll(s);
+        }
+
+        pub fn writeByte(self: Writer, byte: u8) TlsError!void {
+            return self.writeAll(&[_]u8{byte});
+        }
+    };
+
+    pub fn writer(self: *TlsConnection) Writer {
+        return .{ .conn = self };
+    }
+
+    pub fn negotiatedProtocol(self: *const TlsConnection) NegotiatedProtocol {
+        _ = self;
+        return .http1_1;
+    }
+};
+
+/// In the OpenSSL adapter this drains the error queue; here it reports why
+/// TLS is unavailable so handshake-failure logs stay self-explanatory.
+pub fn lastOpenSslError(allocator: std.mem.Allocator) ?[]u8 {
+    return allocator.dupe(u8, unavailable_message) catch null;
+}
+
+pub const UpstreamTlsOptions = struct {
+    skip_verify: bool = false,
+    ca_bundle_path: []const u8 = "",
+    sni_override: []const u8 = "",
+    client_cert_path: []const u8 = "",
+    client_key_path: []const u8 = "",
+    offer_h2: bool = false,
+};
+
+pub const UpstreamTlsConn = struct {
+    fd: std.posix.fd_t = -1,
+
+    pub fn connect(
+        fd: std.posix.fd_t,
+        host: []const u8,
+        opts: UpstreamTlsOptions,
+    ) TlsError!UpstreamTlsConn {
+        _ = fd;
+        _ = host;
+        _ = opts;
+        return error.ContextInitFailed;
+    }
+
+    pub fn deinit(self: *UpstreamTlsConn) void {
+        self.* = undefined;
+    }
+
+    pub fn close(self: *UpstreamTlsConn) void {
+        const fd = self.fd;
+        self.deinit();
+        if (fd >= 0) _ = std.c.close(fd);
+    }
+
+    pub fn read(self: *UpstreamTlsConn, buf: []u8) TlsError!usize {
+        _ = self;
+        _ = buf;
+        return error.TlsReadFailed;
+    }
+
+    pub fn writeAll(self: *UpstreamTlsConn, data: []const u8) TlsError!void {
+        _ = self;
+        _ = data;
+        return error.TlsWriteFailed;
+    }
+
+    pub fn pending(self: *const UpstreamTlsConn) usize {
+        _ = self;
+        return 0;
+    }
+
+    pub fn negotiatedProtocol(self: *const UpstreamTlsConn) NegotiatedProtocol {
+        _ = self;
+        return .http1_1;
+    }
+};
+
+test "stub terminator and upstream connections fail closed" {
+    try std.testing.expectError(error.ContextInitFailed, TlsTerminator.init(std.testing.allocator, .{
+        .cert_path = "unused.crt",
+        .key_path = "unused.key",
+    }));
+    try std.testing.expectError(error.ContextInitFailed, UpstreamTlsConn.connect(-1, "example.com", .{}));
+    const message = lastOpenSslError(std.testing.allocator) orelse return error.TestUnexpectedResult;
+    defer std.testing.allocator.free(message);
+    try std.testing.expect(std.mem.startsWith(u8, message, "TLS termination is unavailable"));
+}

--- a/src/http/upstream_h2.zig
+++ b/src/http/upstream_h2.zig
@@ -26,7 +26,7 @@ const std = @import("std");
 const compat = @import("../zig_compat.zig");
 const frame = @import("http2_frame.zig");
 const hpack = @import("hpack.zig");
-const tls_termination = @import("tls_termination.zig");
+const tls_termination = @import("tls_backend.zig");
 
 /// HTTP/2 client connection preface (RFC 7540 §3.5).
 pub const PREFACE = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";

--- a/src/http/upstream_pool.zig
+++ b/src/http/upstream_pool.zig
@@ -17,7 +17,7 @@
 
 const std = @import("std");
 const compat = @import("../zig_compat.zig");
-const tls_termination = @import("tls_termination.zig");
+const tls_termination = @import("tls_backend.zig");
 
 pub const Config = struct {
     enabled: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const build_options = @import("build_options");
 const compat = @import("zig_compat.zig");
 const edge_config = @import("edge_config.zig");
 const edge_gateway = @import("edge_gateway.zig");
@@ -109,9 +110,16 @@ pub fn main(init: std.process.Init.Minimal) !void {
             try stdout.flush();
         },
         .version => {
-            var stdout_buf: [128]u8 = undefined;
+            var stdout_buf: [256]u8 = undefined;
             var stdout = compat.stdoutWriter(&stdout_buf);
-            try stdout.print("{s}\n", .{http.SERVER_VERSION});
+            // The selected TLS profile is part of the artifact's identity
+            // (#379): operators and release audits verify from this line
+            // which backend a binary was built with.
+            try stdout.print("{s} (tls-profile={s}, tls-backend={s})\n", .{
+                http.SERVER_VERSION,
+                build_options.tls_profile,
+                if (build_options.tls_openssl_adapter) "openssl-adapter" else "native",
+            });
             try stdout.flush();
         },
         .config_init => |options| try writeStarterConfig(options),


### PR DESCRIPTION
**What changed and why**
Enforces Tardigrade's external-library policy (epic #327, story 327-J) in source, build configuration, CI, and release artifacts, so the Bare Systems appliance can be proven free of OpenSSL and any other foreign TLS/crypto implementation rather than relying on convention.

- **Build profiles.** A new `-Dtls-profile` option selects between `general` (default; links the single approved OpenSSL adapter) and `appliance` (forbids all foreign TLS/crypto linkage). `src/http/tls_backend.zig` and `src/http/acme_backend.zig` swap the OpenSSL adapters (`tls_termination.zig`, `acme_client.zig`) for no-OpenSSL stubs **at the module graph**, so an appliance binary never analyzes `@cImport("openssl/...")`, never links `libssl`/`libcrypto`, and has no runtime fallback. The stubs fail closed (`error.ContextInitFailed` / `error.AcmeProtocolError`) until the native TLS path lands under #391 — a deliberate, inspectable failure, not a silent no-op. The pure-Zig ACME `ChallengeStore` is extracted to `src/http/acme_challenge_store.zig` so both profiles and all callers share one implementation without pulling OpenSSL into the appliance graph.
- **Self-identifying artifacts.** `tardigrade version` now prints `tls-profile=…, tls-backend=…`, so an artifact reports its own profile.
- **Audit scripts.** `scripts/audit-dependencies.sh` fails if a forbidden dependency (ngtcp2, nghttp3, quiche, BoringSSL, mbedTLS, wolfSSL, GnuTLS, LibreSSL, …) is configured (comments stripped so prose can document policy), if an OpenSSL include escapes the adapter boundary, or if any `@cImport` appears in a native path (`src/tls`, `src/pki`, `src/quic`, `src/crypto`, `src/http3`). `scripts/audit-release-binary.sh` inspects a built binary's dynamic dependencies (`ldd`/`otool -L`), fails a forbidden linkage or a self-report that disagrees with actual linkage, and emits a machine-readable dependency inventory.
- **CI and release.** A required `TLS dependency audit` CI job runs the source audit, builds **both** profiles, and audits each binary's linkage, uploading the inventories. The release workflow re-runs the source audit, audits each published binary, and ships its inventory beside the SBOM.
- The stale `build.zig.zon` note claiming an optional ngtcp2/nghttp3 link path (removed in #328) is corrected. Policy and the appliance/general cutover checklist are documented in `docs/TLS_DEPENDENCY_POLICY.md`.

**Related issues**
Closes #379. Coordinates with #328 (ngtcp2/nghttp3 removal linkage checks) and #391 (appliance binary-linkage/runtime-path gate).

**Tests**
Verified locally with Zig 0.16.0:
- Appliance build links only `libc`/`libm` (`ldd`); binary audit passes with `links_openssl: false` and `tls-backend=native`.
- General build links `libssl`/`libcrypto`; binary audit passes with `tls-backend=openssl-adapter`.
- Negative check: auditing the general binary under `--profile appliance` fails with the OpenSSL-linkage and native-self-report violations, confirming the gate bites.
- Source audit passes; both audit scripts are shellcheck-clean.
- New unit tests: the TLS-termination and ACME stubs fail closed and share the pure-Zig challenge store.
- `zig build test` green under both `-Dtls-profile=general` (1119/1120, 1 skip) and `-Dtls-profile=appliance` (1117/1118, 1 skip); `zig build test-integration` green (63/67, 4 skip).

**Security impact**
Directly strengthens TLS supply-chain posture: it makes "no OpenSSL in the appliance" a machine-checked property of both the source graph and the produced binary, with no hidden runtime fallback, and forbids unapproved foreign TLS/crypto/QUIC/H3 libraries across all profiles. OpenSSL remains confined to the approved adapter boundary in the general profile (enforced by the source audit). No request-parsing, routing, auth, or logging behavior changes.

**Performance impact**
None. Build-graph selection and CI/release tooling only; no runtime code path on the event loop or hot paths changes.

**Checklist**
- [x] `zig fmt --check build.zig src/ tests/` passes
- [x] `zig build test --summary all` green (both profiles)
- [x] `zig build test-integration` green
- [x] New behavior covered by tests
- [x] [docs/CODE_REVIEW_CHECKLIST.md](docs/CODE_REVIEW_CHECKLIST.md) completed
- [x] README / CHANGELOG updated if operator-visible behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXTLYSnUHiEhFV4mWVBMgN

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXTLYSnUHiEhFV4mWVBMgN)_