### PR TITLE
perf: add route-level proxy streaming policy

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -36,6 +36,13 @@ logs are written through `src/http/logger.zig`.
 - reverse-proxy abort counters:
   `tardigrade_proxy_client_aborts_total` and
   `tardigrade_proxy_upstream_aborts_total`
+- reverse-proxy streaming fallback counter:
+  `tardigrade_proxy_streaming_fallback_total{reason=...}` with fixed reasons
+  `policy_disabled`, `retries_configured`, `unix_socket_target`, and
+  `upstream_mtls_target` for response-path eligibility plus
+  `chunked_request_upload`, `missing_content_length`, `body_too_large`,
+  `body_dependent_middleware`, and `unsupported_route_type` for request-upload
+  eligibility
 - reverse-proxy upstream TTFB summary: `tardigrade_proxy_ttfb_ms`
 
 The latency histogram is intentionally global rather than route-labeled to keep

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -36,13 +36,14 @@ logs are written through `src/http/logger.zig`.
 - reverse-proxy abort counters:
   `tardigrade_proxy_client_aborts_total` and
   `tardigrade_proxy_upstream_aborts_total`
-- reverse-proxy streaming fallback counter:
+- reverse-proxy streaming fallback event counter:
   `tardigrade_proxy_streaming_fallback_total{reason=...}` with fixed reasons
   `policy_disabled`, `retries_configured`, `unix_socket_target`, and
   `upstream_mtls_target` for response-path eligibility plus
   `chunked_request_upload`, `missing_content_length`, `body_too_large`,
   `body_dependent_middleware`, and `unsupported_route_type` for request-upload
-  eligibility
+  eligibility. Upload and response eligibility are evaluated separately, so one
+  request can contribute more than one fallback event.
 - reverse-proxy upstream TTFB summary: `tardigrade_proxy_ttfb_ms`
 
 The latency histogram is intentionally global rather than route-labeled to keep

--- a/docs/UPSTREAM_POOLING.md
+++ b/docs/UPSTREAM_POOLING.md
@@ -177,10 +177,20 @@ busy worker).
 
 The streaming proxy path (`TARDIGRADE_PROXY_STREAMING_MODE=response|full`) now
 multiplexes over the same per-origin h2 connection instead of always speaking
-HTTP/1.1. `executeStreamingHttpProxyRequest` routes HTTPS targets through
+HTTP/1.1. Individual `location` blocks may override the global mode with
+`proxy_streaming inherit|off|response|full`; omitted route policy inherits the
+global setting. `executeStreamingHttpProxyRequest` routes HTTPS targets through
 `streamViaH2Pool` when `TARDIGRADE_UPSTREAM_PROTOCOL=h2|auto`; ALPN `http/1.1`
 origins fall back to the h1 streaming relay on that (fresh, unpooled)
 connection.
+
+Streaming eligibility is deterministic and observable. A request that falls
+back to the bounded buffered path increments
+`tardigrade_proxy_streaming_fallback_total{reason=...}` with one of:
+`policy_disabled`, `retries_configured`, `unix_socket_target`, or
+`upstream_mtls_target`. Full-mode upload eligibility uses the same metric for
+upload-specific fallbacks: `chunked_request_upload`, `missing_content_length`,
+`body_too_large`, `body_dependent_middleware`, and `unsupported_route_type`.
 
 The actor gains a streaming request mode next to the fully-buffered
 `request()`:

--- a/docs/UPSTREAM_POOLING.md
+++ b/docs/UPSTREAM_POOLING.md
@@ -184,13 +184,15 @@ global setting. `executeStreamingHttpProxyRequest` routes HTTPS targets through
 origins fall back to the h1 streaming relay on that (fresh, unpooled)
 connection.
 
-Streaming eligibility is deterministic and observable. A request that falls
-back to the bounded buffered path increments
+Streaming eligibility is deterministic and observable. An eligibility check that
+falls back to the bounded buffered path increments
 `tardigrade_proxy_streaming_fallback_total{reason=...}` with one of:
 `policy_disabled`, `retries_configured`, `unix_socket_target`, or
 `upstream_mtls_target`. Full-mode upload eligibility uses the same metric for
 upload-specific fallbacks: `chunked_request_upload`, `missing_content_length`,
 `body_too_large`, `body_dependent_middleware`, and `unsupported_route_type`.
+The metric counts fallback events, not unique requests, because upload and
+response eligibility are evaluated at different phases.
 
 The actor gains a streaming request mode next to the fully-buffered
 `request()`:

--- a/src/edge_config.zig
+++ b/src/edge_config.zig
@@ -2329,11 +2329,16 @@ fn parseLocationBlocks(allocator: std.mem.Allocator, raw: []const u8) ![]EdgeCon
         }
 
         var auth: http.location_router.AuthMode = .off;
-        if (fields.next()) |auth_raw| {
-            const trimmed_auth = std.mem.trim(u8, auth_raw, " \t\r\n");
-            if (!std.mem.startsWith(u8, trimmed_auth, "auth:")) return error.InvalidLocationBlockFormat;
-            auth = http.location_router.AuthMode.parse(trimmed_auth["auth:".len..]) orelse return error.InvalidLocationBlockFormat;
-            if (fields.next() != null) return error.InvalidLocationBlockFormat;
+        var proxy_streaming_policy: http.location_router.ProxyStreamingPolicy = .inherit;
+        while (fields.next()) |option_raw| {
+            const option = std.mem.trim(u8, option_raw, " \t\r\n");
+            if (std.mem.startsWith(u8, option, "auth:")) {
+                auth = http.location_router.AuthMode.parse(option["auth:".len..]) orelse return error.InvalidLocationBlockFormat;
+            } else if (std.mem.startsWith(u8, option, "stream:")) {
+                proxy_streaming_policy = http.location_router.ProxyStreamingPolicy.parse(option["stream:".len..]) orelse return error.InvalidLocationBlockFormat;
+            } else {
+                return error.InvalidLocationBlockFormat;
+            }
         }
 
         try out.append(allocator, .{
@@ -2343,6 +2348,7 @@ fn parseLocationBlocks(allocator: std.mem.Allocator, raw: []const u8) ![]EdgeCon
             .action = action,
             .error_pages = &.{},
             .auth = auth,
+            .proxy_streaming_policy = proxy_streaming_policy,
         });
     }
 
@@ -2909,6 +2915,17 @@ test "parse proxy streaming mode aliases" {
     try std.testing.expect(ProxyStreamingMode.parse("invalid") == null);
 }
 
+test "parse route proxy streaming policy aliases" {
+    try std.testing.expectEqual(http.location_router.ProxyStreamingPolicy.inherit, http.location_router.ProxyStreamingPolicy.parse("inherit").?);
+    try std.testing.expectEqual(http.location_router.ProxyStreamingPolicy.off, http.location_router.ProxyStreamingPolicy.parse("buffered").?);
+    try std.testing.expectEqual(http.location_router.ProxyStreamingPolicy.response, http.location_router.ProxyStreamingPolicy.parse("responses").?);
+    try std.testing.expectEqual(http.location_router.ProxyStreamingPolicy.full, http.location_router.ProxyStreamingPolicy.parse("request-response").?);
+    try std.testing.expect(!http.location_router.ProxyStreamingPolicy.off.responseStreamingEnabled(true));
+    try std.testing.expect(http.location_router.ProxyStreamingPolicy.inherit.responseStreamingEnabled(true));
+    try std.testing.expect(http.location_router.ProxyStreamingPolicy.full.requestStreamingEnabled(false));
+    try std.testing.expect(http.location_router.ProxyStreamingPolicy.parse("sometimes") == null);
+}
+
 test "config port parser rejects invalid listener values" {
     try std.testing.expectEqual(@as(u16, 8069), try parseConfigPort("listen_port", "8069"));
     try std.testing.expectError(error.InvalidConfigPort, parseConfigPort("listen_port", "0"));
@@ -3151,6 +3168,25 @@ test "parse location blocks csv" {
         },
         else => return error.UnexpectedTestResult,
     }
+}
+
+test "parse location blocks include route streaming policy option" {
+    const allocator = std.testing.allocator;
+    const blocks = try parseLocationBlocks(
+        allocator,
+        "prefix|/buffered/|proxy_pass|http://127.0.0.1:9001|stream:off;prefix|/full/|proxy_pass|http://127.0.0.1:9002|auth:required|stream:full",
+    );
+    defer {
+        for (blocks) |*block| {
+            block.deinit(allocator);
+        }
+        allocator.free(blocks);
+    }
+
+    try std.testing.expectEqual(@as(usize, 2), blocks.len);
+    try std.testing.expectEqual(http.location_router.ProxyStreamingPolicy.off, blocks[0].proxy_streaming_policy);
+    try std.testing.expectEqual(http.location_router.ProxyStreamingPolicy.full, blocks[1].proxy_streaming_policy);
+    try std.testing.expectEqual(http.location_router.AuthMode.required, blocks[1].auth);
 }
 
 test "apply location error pages csv" {

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -1311,33 +1311,63 @@ fn targetSupportsStdHttpStreaming(cfg: *const edge_config.EdgeConfig, target: []
     return !(cfg.upstream_tls_client_cert.len > 0 and std.mem.startsWith(u8, cfg.upstream_base_url, "https://"));
 }
 
-fn streamingUploadAllowedBeforeBodyRead(
+const RequestUploadStreamingEligibility = union(enum) {
+    stream,
+    fallback: gproxy_runtime.StreamingFallbackReason,
+    not_applicable,
+};
+
+fn targetStreamingFallbackReason(
+    cfg: *const edge_config.EdgeConfig,
+    target: []const u8,
+) ?gproxy_runtime.StreamingFallbackReason {
+    const trimmed = std.mem.trim(u8, target, " \t\r\n");
+    if (trimmed.len == 0) return .unsupported_route_type;
+    if (gp.unixSocketPathFromEndpoint(trimmed) != null) return .unix_socket_target;
+    if (isHttpUrl(trimmed)) {
+        if (cfg.upstream_tls_client_cert.len > 0 and std.mem.startsWith(u8, trimmed, "https://")) return .upstream_mtls_target;
+        return null;
+    }
+    if (gp.unixSocketPathFromEndpoint(cfg.upstream_base_url) != null) return .unix_socket_target;
+    if (cfg.upstream_tls_client_cert.len > 0 and std.mem.startsWith(u8, cfg.upstream_base_url, "https://")) return .upstream_mtls_target;
+    return null;
+}
+
+fn streamingUploadEligibilityBeforeBodyRead(
     cfg: *const edge_config.EdgeConfig,
     request: *const http.Request,
-) bool {
-    if (!cfg.proxy_streaming_mode.requestStreamingEnabled()) return false;
-    if (!request.method.hasRequestBody()) return false;
-    if (request.hasTransferEncoding()) return false;
-    const content_length = request.contentLength() orelse return false;
-    if (content_length == 0) return false;
-    if (content_length > cfg.request_limits.effectiveMaxBodySize()) return false;
+) RequestUploadStreamingEligibility {
+    if (!request.method.hasRequestBody()) return .not_applicable;
+    if (request.hasTransferEncoding()) return .{ .fallback = .chunked_request_upload };
+    const content_length = request.contentLength() orelse return .{ .fallback = .missing_content_length };
+    if (content_length == 0) return .not_applicable;
+    if (content_length > cfg.request_limits.effectiveMaxBodySize()) return .{ .fallback = .body_too_large };
 
     if (cfg.rewrite_rules.len > 0 or cfg.return_rules.len > 0 or
         cfg.conditional_rules.len > 0 or cfg.internal_redirect_rules.len > 0 or
         cfg.mirror_rules.len > 0 or cfg.auth_request_url.len > 0)
     {
-        return false;
+        return .{ .fallback = .body_dependent_middleware };
     }
     if (cfg.upstream_retry_attempts > 1) {
-        if (!cfg.upstream_retry_idempotent_only) return false;
-        if (request.method.isIdempotent()) return false;
+        if (!cfg.upstream_retry_idempotent_only) return .{ .fallback = .retries_configured };
+        if (request.method.isIdempotent()) return .{ .fallback = .retries_configured };
     }
 
-    const matched = http.location_router.matchLocation(request.uri.path, cfg.location_blocks) orelse return false;
+    const matched = http.location_router.matchLocation(request.uri.path, cfg.location_blocks) orelse return .{ .fallback = .unsupported_route_type };
+    if (!matched.block.proxy_streaming_policy.requestStreamingEnabled(cfg.proxy_streaming_mode.requestStreamingEnabled())) return .{ .fallback = .policy_disabled };
     return switch (matched.block.action) {
-        .proxy_pass => |target| targetSupportsStdHttpStreaming(cfg, target),
-        else => false,
+        .proxy_pass => |target| if (targetStreamingFallbackReason(cfg, target)) |reason| .{ .fallback = reason } else .stream,
+        else => .{ .fallback = .unsupported_route_type },
     };
+}
+
+fn mayNeedStreamingRequestBodyPreRead(cfg: *const edge_config.EdgeConfig) bool {
+    if (cfg.proxy_streaming_mode.requestStreamingEnabled()) return true;
+    for (cfg.location_blocks) |block| {
+        if (block.proxy_streaming_policy.requestStreamingEnabled(false)) return true;
+    }
+    return false;
 }
 
 fn streamingRequestBodyFromHead(
@@ -1409,7 +1439,7 @@ fn handleConnection(conn: anytype, session: *ConnectionSession, cfg: *const edge
     var request_initialized = false;
     defer if (request_initialized) request.deinit();
 
-    if (cfg.proxy_streaming_mode.requestStreamingEnabled()) {
+    if (mayNeedStreamingRequestBodyPreRead(cfg)) {
         const head_read = try gconn.readHttpRequestHead(conn, pending_buf, &session.pending_len);
         if (head_read.total_read == 0) return;
         if (cfg.max_connection_memory_bytes > 0 and head_read.total_read > cfg.max_connection_memory_bytes) {
@@ -1425,47 +1455,56 @@ fn handleConnection(conn: anytype, session: *ConnectionSession, cfg: *const edge
         };
         var pre_effective_cfg_storage = cfg.*;
         const pre_effective_cfg = ga.resolveRequestConfig(cfg, head_parse.request.headers.get("host"), &pre_effective_cfg_storage) orelse cfg;
-        if (streamingUploadAllowedBeforeBodyRead(pre_effective_cfg, &head_parse.request)) {
-            streaming_request_body = streamingRequestBodyFromHead(&head_parse.request, pending_buf, head_read, head_parse.bytes_consumed);
-            request = head_parse.request;
-            request_initialized = true;
-            session.pending_len = 0;
-        } else {
-            head_parse.request.deinit();
-            // Switch SO_RCVTIMEO from header phase to body read phase.
-            const body_timeout_ms = cfg.request_limits.effectiveBodyTimeout();
-            if (body_timeout_ms > 0) {
-                if (connRawFd(conn)) |fd| {
-                    const write_timeout_ms = if (cfg.downstream_write_timeout_ms > 0)
-                        cfg.downstream_write_timeout_ms
-                    else
-                        cfg.request_limits.effectiveHeaderTimeout();
-                    gconn.setSocketTimeoutMs(fd, body_timeout_ms, write_timeout_ms) catch {};
+        const upload_eligibility = streamingUploadEligibilityBeforeBodyRead(pre_effective_cfg, &head_parse.request);
+        switch (upload_eligibility) {
+            .stream => {
+                streaming_request_body = streamingRequestBodyFromHead(&head_parse.request, pending_buf, head_read, head_parse.bytes_consumed);
+                request = head_parse.request;
+                request_initialized = true;
+                session.pending_len = 0;
+            },
+            .fallback, .not_applicable => {
+                if (upload_eligibility == .fallback) {
+                    const reason = upload_eligibility.fallback;
+                    state.metricsRecordProxyStreamingFallback(reason.metricLabel());
+                    state.logger.debug(null, "proxy upload streaming fallback: {s}", .{reason.metricLabel()});
                 }
-            }
-            const total_read = try gconn.readHttpRequest(conn, pending_buf, &session.pending_len);
-            if (total_read == 0) return;
-            if (cfg.max_connection_memory_bytes > 0 and total_read > cfg.max_connection_memory_bytes) {
-                session.pending_len = 0;
-                try gp.sendApiError(allocator, conn.writer(), .payload_too_large, "invalid_request", "Connection memory limit exceeded", null, false, state);
-                return;
-            }
-            const parse_result = http.Request.parse(allocator, pending_buf[0..total_read], MAX_REQUEST_SIZE) catch |err| {
-                if (err == error.OutOfMemory) return err; // resource failure, not a client parse error
-                try gp.sendApiError(allocator, conn.writer(), parseRequestErrorStatus(err), "invalid_request", "Malformed request", null, keep_alive, state);
-                state.logger.warn(null, "parse error: {}", .{err});
-                return;
-            };
-            const bytes_consumed = parse_result.bytes_consumed;
-            if (bytes_consumed < total_read) {
-                const remaining = total_read - bytes_consumed;
-                std.mem.copyForwards(u8, pending_buf[0..remaining], pending_buf[bytes_consumed..total_read]);
-                session.pending_len = remaining;
-            } else {
-                session.pending_len = 0;
-            }
-            request = parse_result.request;
-            request_initialized = true;
+                head_parse.request.deinit();
+                // Switch SO_RCVTIMEO from header phase to body read phase.
+                const body_timeout_ms = cfg.request_limits.effectiveBodyTimeout();
+                if (body_timeout_ms > 0) {
+                    if (connRawFd(conn)) |fd| {
+                        const write_timeout_ms = if (cfg.downstream_write_timeout_ms > 0)
+                            cfg.downstream_write_timeout_ms
+                        else
+                            cfg.request_limits.effectiveHeaderTimeout();
+                        gconn.setSocketTimeoutMs(fd, body_timeout_ms, write_timeout_ms) catch {};
+                    }
+                }
+                const total_read = try gconn.readHttpRequest(conn, pending_buf, &session.pending_len);
+                if (total_read == 0) return;
+                if (cfg.max_connection_memory_bytes > 0 and total_read > cfg.max_connection_memory_bytes) {
+                    session.pending_len = 0;
+                    try gp.sendApiError(allocator, conn.writer(), .payload_too_large, "invalid_request", "Connection memory limit exceeded", null, false, state);
+                    return;
+                }
+                const parse_result = http.Request.parse(allocator, pending_buf[0..total_read], MAX_REQUEST_SIZE) catch |err| {
+                    if (err == error.OutOfMemory) return err; // resource failure, not a client parse error
+                    try gp.sendApiError(allocator, conn.writer(), parseRequestErrorStatus(err), "invalid_request", "Malformed request", null, keep_alive, state);
+                    state.logger.warn(null, "parse error: {}", .{err});
+                    return;
+                };
+                const bytes_consumed = parse_result.bytes_consumed;
+                if (bytes_consumed < total_read) {
+                    const remaining = total_read - bytes_consumed;
+                    std.mem.copyForwards(u8, pending_buf[0..remaining], pending_buf[bytes_consumed..total_read]);
+                    session.pending_len = remaining;
+                } else {
+                    session.pending_len = 0;
+                }
+                request = parse_result.request;
+                request_initialized = true;
+            },
         }
     } else {
         const total_read = try gconn.readHttpRequest(conn, pending_buf, &session.pending_len);
@@ -1815,6 +1854,72 @@ test "return_response method enforcement — non-GET/HEAD rejected on static ret
     // Redirect: method enforcement is skipped
     const is_redirect_302 = (302 >= 300 and 302 < 400);
     try std.testing.expect(is_redirect_302);
+}
+
+fn initUploadEligibilityTestConfig(blocks: []edge_config.EdgeConfig.LocationBlock) edge_config.EdgeConfig {
+    var cfg: edge_config.EdgeConfig = undefined;
+    cfg.proxy_streaming_mode = .off;
+    cfg.request_limits = http.request_limits.RequestLimits.default;
+    cfg.rewrite_rules = &.{};
+    cfg.return_rules = &.{};
+    cfg.conditional_rules = &.{};
+    cfg.internal_redirect_rules = &.{};
+    cfg.mirror_rules = &.{};
+    cfg.auth_request_url = "";
+    cfg.upstream_retry_attempts = 1;
+    cfg.upstream_retry_idempotent_only = true;
+    cfg.location_blocks = blocks;
+    cfg.upstream_base_url = "http://127.0.0.1:9001";
+    cfg.upstream_tls_client_cert = "";
+    return cfg;
+}
+
+test "streaming upload eligibility reports typed fallback reasons" {
+    const allocator = std.testing.allocator;
+    var blocks = [_]edge_config.EdgeConfig.LocationBlock{
+        .{
+            .match_type = .prefix,
+            .pattern = "/upload/",
+            .priority = 0,
+            .action = .{ .proxy_pass = "http://127.0.0.1:9001" },
+            .proxy_streaming_policy = .full,
+        },
+        .{
+            .match_type = .prefix,
+            .pattern = "/compat/",
+            .priority = 1,
+            .action = .{ .proxy_pass = "http://127.0.0.1:9001" },
+            .proxy_streaming_policy = .off,
+        },
+    };
+    var cfg = initUploadEligibilityTestConfig(&blocks);
+
+    var upload_head = try http.Request.parseHead(
+        allocator,
+        "POST /upload/body HTTP/1.1\r\nHost: example.test\r\nContent-Length: 4\r\n\r\n",
+        MAX_REQUEST_SIZE,
+    );
+    defer upload_head.request.deinit();
+    try std.testing.expectEqual(RequestUploadStreamingEligibility.stream, streamingUploadEligibilityBeforeBodyRead(&cfg, &upload_head.request));
+
+    var chunked_head = try http.Request.parseHead(
+        allocator,
+        "POST /upload/body HTTP/1.1\r\nHost: example.test\r\nTransfer-Encoding: chunked\r\n\r\n",
+        MAX_REQUEST_SIZE,
+    );
+    defer chunked_head.request.deinit();
+    try std.testing.expectEqual(RequestUploadStreamingEligibility{ .fallback = .chunked_request_upload }, streamingUploadEligibilityBeforeBodyRead(&cfg, &chunked_head.request));
+
+    var compat_head = try http.Request.parseHead(
+        allocator,
+        "POST /compat/body HTTP/1.1\r\nHost: example.test\r\nContent-Length: 4\r\n\r\n",
+        MAX_REQUEST_SIZE,
+    );
+    defer compat_head.request.deinit();
+    try std.testing.expectEqual(RequestUploadStreamingEligibility{ .fallback = .policy_disabled }, streamingUploadEligibilityBeforeBodyRead(&cfg, &compat_head.request));
+
+    cfg.auth_request_url = "http://auth.example.test/check";
+    try std.testing.expectEqual(RequestUploadStreamingEligibility{ .fallback = .body_dependent_middleware }, streamingUploadEligibilityBeforeBodyRead(&cfg, &upload_head.request));
 }
 
 // Pull gateway_handlers (and its transitive imports, including

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -1338,10 +1338,9 @@ fn streamingUploadEligibilityBeforeBodyRead(
     request: *const http.Request,
 ) RequestUploadStreamingEligibility {
     if (!request.method.hasRequestBody()) return .not_applicable;
-    if (request.hasTransferEncoding()) return .{ .fallback = .chunked_request_upload };
-    const content_length = request.contentLength() orelse return .{ .fallback = .missing_content_length };
-    if (content_length == 0) return .not_applicable;
-    if (content_length > cfg.request_limits.effectiveMaxBodySize()) return .{ .fallback = .body_too_large };
+
+    const matched = http.location_router.matchLocation(request.uri.path, cfg.location_blocks) orelse return .{ .fallback = .unsupported_route_type };
+    if (!matched.block.proxy_streaming_policy.requestStreamingEnabled(cfg.proxy_streaming_mode.requestStreamingEnabled())) return .{ .fallback = .policy_disabled };
 
     if (cfg.rewrite_rules.len > 0 or cfg.return_rules.len > 0 or
         cfg.conditional_rules.len > 0 or cfg.internal_redirect_rules.len > 0 or
@@ -1354,8 +1353,11 @@ fn streamingUploadEligibilityBeforeBodyRead(
         if (request.method.isIdempotent()) return .{ .fallback = .retries_configured };
     }
 
-    const matched = http.location_router.matchLocation(request.uri.path, cfg.location_blocks) orelse return .{ .fallback = .unsupported_route_type };
-    if (!matched.block.proxy_streaming_policy.requestStreamingEnabled(cfg.proxy_streaming_mode.requestStreamingEnabled())) return .{ .fallback = .policy_disabled };
+    if (request.hasTransferEncoding()) return .{ .fallback = .chunked_request_upload };
+    const content_length = request.contentLength() orelse return .{ .fallback = .missing_content_length };
+    if (content_length == 0) return .not_applicable;
+    if (content_length > cfg.request_limits.effectiveMaxBodySize()) return .{ .fallback = .body_too_large };
+
     return switch (matched.block.action) {
         .proxy_pass => |target| if (targetStreamingFallbackReason(cfg, target)) |reason| .{ .fallback = reason } else .stream,
         else => .{ .fallback = .unsupported_route_type },
@@ -1366,6 +1368,11 @@ fn mayNeedStreamingRequestBodyPreRead(cfg: *const edge_config.EdgeConfig) bool {
     if (cfg.proxy_streaming_mode.requestStreamingEnabled()) return true;
     for (cfg.location_blocks) |block| {
         if (block.proxy_streaming_policy.requestStreamingEnabled(false)) return true;
+    }
+    for (cfg.server_blocks) |server_block| {
+        for (server_block.location_blocks) |block| {
+            if (block.proxy_streaming_policy.requestStreamingEnabled(false)) return true;
+        }
     }
     return false;
 }
@@ -1869,6 +1876,7 @@ fn initUploadEligibilityTestConfig(blocks: []edge_config.EdgeConfig.LocationBloc
     cfg.upstream_retry_attempts = 1;
     cfg.upstream_retry_idempotent_only = true;
     cfg.location_blocks = blocks;
+    cfg.server_blocks = &.{};
     cfg.upstream_base_url = "http://127.0.0.1:9001";
     cfg.upstream_tls_client_cert = "";
     return cfg;
@@ -1918,8 +1926,55 @@ test "streaming upload eligibility reports typed fallback reasons" {
     defer compat_head.request.deinit();
     try std.testing.expectEqual(RequestUploadStreamingEligibility{ .fallback = .policy_disabled }, streamingUploadEligibilityBeforeBodyRead(&cfg, &compat_head.request));
 
+    var compat_chunked_head = try http.Request.parseHead(
+        allocator,
+        "POST /compat/body HTTP/1.1\r\nHost: example.test\r\nTransfer-Encoding: chunked\r\n\r\n",
+        MAX_REQUEST_SIZE,
+    );
+    defer compat_chunked_head.request.deinit();
+    try std.testing.expectEqual(RequestUploadStreamingEligibility{ .fallback = .policy_disabled }, streamingUploadEligibilityBeforeBodyRead(&cfg, &compat_chunked_head.request));
+
     cfg.auth_request_url = "http://auth.example.test/check";
     try std.testing.expectEqual(RequestUploadStreamingEligibility{ .fallback = .body_dependent_middleware }, streamingUploadEligibilityBeforeBodyRead(&cfg, &upload_head.request));
+}
+
+test "streaming upload pre-read scan includes server block routes" {
+    var base_blocks = [_]edge_config.EdgeConfig.LocationBlock{
+        .{
+            .match_type = .prefix,
+            .pattern = "/",
+            .priority = 0,
+            .action = .{ .proxy_pass = "http://127.0.0.1:9001" },
+            .proxy_streaming_policy = .inherit,
+        },
+    };
+    var server_blocks = [_]edge_config.EdgeConfig.LocationBlock{
+        .{
+            .match_type = .prefix,
+            .pattern = "/upload/",
+            .priority = 0,
+            .action = .{ .proxy_pass = "http://127.0.0.1:9002" },
+            .proxy_streaming_policy = .full,
+        },
+    };
+    var server_names = [_][]const u8{"api.example.test"};
+    var server_block_entries = [_]edge_config.EdgeConfig.ServerBlock{
+        .{
+            .server_names = &server_names,
+            .doc_root = "",
+            .try_files = "",
+            .location_blocks = &server_blocks,
+            .tls_cert_path = "",
+            .tls_key_path = "",
+            .upstream_base_url = "",
+            .proxy_pass_chat = "",
+            .proxy_pass_commands_prefix = "",
+        },
+    };
+    var cfg = initUploadEligibilityTestConfig(&base_blocks);
+    cfg.server_blocks = &server_block_entries;
+
+    try std.testing.expect(mayNeedStreamingRequestBodyPreRead(&cfg));
 }
 
 // Pull gateway_handlers (and its transitive imports, including

--- a/src/gateway_handlers.zig
+++ b/src/gateway_handlers.zig
@@ -227,6 +227,7 @@ pub fn routeRequest(
                         ctx.scopes,
                         request.headers.get("host"),
                         matched.block.pattern,
+                        matched.block,
                         streaming_request_body,
                     );
                 },

--- a/src/gateway_proxy_runtime.zig
+++ b/src/gateway_proxy_runtime.zig
@@ -35,6 +35,37 @@ const writeBufferedUpstreamResponse = gp.writeBufferedUpstreamResponse;
 
 pub const StreamingRequestBody = gp.StreamingRequestBody;
 
+pub const StreamingFallbackReason = enum {
+    policy_disabled,
+    retries_configured,
+    unix_socket_target,
+    upstream_mtls_target,
+    chunked_request_upload,
+    missing_content_length,
+    body_too_large,
+    body_dependent_middleware,
+    unsupported_route_type,
+
+    pub fn metricLabel(self: StreamingFallbackReason) []const u8 {
+        return switch (self) {
+            .policy_disabled => "policy_disabled",
+            .retries_configured => "retries_configured",
+            .unix_socket_target => "unix_socket_target",
+            .upstream_mtls_target => "upstream_mtls_target",
+            .chunked_request_upload => "chunked_request_upload",
+            .missing_content_length => "missing_content_length",
+            .body_too_large => "body_too_large",
+            .body_dependent_middleware => "body_dependent_middleware",
+            .unsupported_route_type => "unsupported_route_type",
+        };
+    }
+};
+
+const StreamingEligibility = union(enum) {
+    stream,
+    fallback: StreamingFallbackReason,
+};
+
 pub const DataPlaneProxyResponse = union(enum) {
     bounded_buffered: BufferedUpstreamResponse,
 
@@ -147,17 +178,25 @@ pub fn executeBufferedDataPlaneProxyRequest(
     ) };
 }
 
-fn canStreamDataPlaneProxyRequest(
+fn routeResponseStreamingEnabled(
     cfg: *const edge_config.EdgeConfig,
+    block: *const edge_config.EdgeConfig.LocationBlock,
+) bool {
+    return block.proxy_streaming_policy.responseStreamingEnabled(cfg.proxy_streaming_mode.responseStreamingEnabled());
+}
+
+fn streamingEligibilityForDataPlaneProxyRequest(
+    cfg: *const edge_config.EdgeConfig,
+    block: *const edge_config.EdgeConfig.LocationBlock,
     resolved: *const gp.ResolvedProxyTarget,
     url: []const u8,
     max_attempts: usize,
-) bool {
-    if (!cfg.proxy_streaming_mode.responseStreamingEnabled()) return false;
-    if (max_attempts != 1) return false;
-    if (resolved.unix_socket_path != null) return false;
-    if (cfg.upstream_tls_client_cert.len > 0 and std.mem.startsWith(u8, url, "https://")) return false;
-    return true;
+) StreamingEligibility {
+    if (!routeResponseStreamingEnabled(cfg, block)) return .{ .fallback = .policy_disabled };
+    if (max_attempts != 1) return .{ .fallback = .retries_configured };
+    if (resolved.unix_socket_path != null) return .{ .fallback = .unix_socket_target };
+    if (cfg.upstream_tls_client_cert.len > 0 and std.mem.startsWith(u8, url, "https://")) return .{ .fallback = .upstream_mtls_target };
+    return .stream;
 }
 
 pub fn dataPlaneBufferedCompatibilityResponseLimit(cfg: *const edge_config.EdgeConfig) usize {
@@ -436,6 +475,7 @@ pub fn handleLocationProxyPass(
     auth_scopes: ?[]const u8,
     incoming_host: ?[]const u8,
     location_id: []const u8,
+    matched_block: *const edge_config.EdgeConfig.LocationBlock,
     streaming_request_body: ?StreamingRequestBody,
 ) !u16 {
     const upstream_scope = .global;
@@ -479,99 +519,104 @@ pub fn handleLocationProxyPass(
     const max_attempts = proxyRetryAttemptLimit(cfg.upstream_retry_attempts, cfg.upstream_retry_idempotent_only, method_str);
     const budget_start_ms = http.event_loop.monotonicMs();
 
-    if (canStreamDataPlaneProxyRequest(cfg, &resolved, upstream_url.value, max_attempts)) {
-        state.recordUpstreamAttemptStart(selection.base_url);
-        const streamed = executeStreamingHttpProxyRequest(
-            allocator,
-            cfg,
-            upstream_url.value,
-            method_str,
-            &request.headers,
-            body,
-            streaming_request_body,
-            downstream_conn,
-            writer,
-            correlation_id,
-            client_ip,
-            forwarded_proto,
-            request.headers.get("host"),
-            auth_identity,
-            auth_user_id,
-            auth_device_id,
-            auth_scopes,
-            &state.security_headers,
-            sticky_set_cookie,
-            if (ctx.lifecycle) |lc| &lc.token else null,
-            &state.upstream_pool,
-            &state.h2_pool,
-        ) catch |err| {
-            state.recordUpstreamAttemptEnd(selection.base_url);
-            if (err == error.ClientAborted) {
-                state.metricsRecordProxyClientAbort();
-                return err;
-            }
-            if (err == error.UpstreamAtCapacity) {
-                // Fail-fast at the per-origin active cap (#239): a local
-                // saturation rejection, not an origin failure — do not count
-                // it against upstream health / circuit-breaker state.
-                try sendApiError(allocator, writer, .service_unavailable, "upstream_saturated", "Upstream connection limit reached", correlation_id, false, state);
-                ctx.setUpstreamResult(resolved.upstream_host, @intFromEnum(http.Status.service_unavailable), 0);
-                return @intFromEnum(http.Status.service_unavailable);
-            }
-            state.recordUpstreamFailure(cfg, selection.base_url);
-            if (err == error.RequestCancelled) {
-                if (ctx.lifecycle) |lc| lc.logTimeout("upstream_connect");
-                try sendApiError(allocator, writer, .gateway_timeout, "upstream_timeout", "Upstream request timed out", correlation_id, false, state);
-                ctx.setUpstreamResult(resolved.upstream_host, @intFromEnum(http.Status.gateway_timeout), 0);
-                return @intFromEnum(http.Status.gateway_timeout);
-            }
-            if (err == error.OutOfMemory) return error.OutOfMemory;
-            const err_status: http.Status = switch (err) {
-                error.Timeout, error.WouldBlock => .gateway_timeout,
-                else => .bad_gateway,
-            };
-            const err_code = if (err_status == .gateway_timeout) "upstream_timeout" else "upstream_error";
-            const err_msg = if (err_status == .gateway_timeout) "Upstream request timed out" else "Upstream connection failed";
-            state.logger.warn(correlation_id, "streaming upstream request failed: {}", .{err});
-            try sendApiError(allocator, writer, err_status, err_code, err_msg, correlation_id, false, state);
-            ctx.setUpstreamResult(resolved.upstream_host, @intFromEnum(err_status), 0);
-            return @intFromEnum(err_status);
-        };
-        state.recordUpstreamAttemptEnd(selection.base_url);
-
-        const transcript_redactions: []const []const u8 = if (request.headers.get("authorization")) |raw_auth|
-            if (http.auth.parseBearerToken(raw_auth)) |token| &.{token} else &.{}
-        else
-            &.{};
-        state.appendTranscript(
-            upstreamScopeName(proxyScopeForPath(request.uri.path)),
-            request.uri.path,
-            correlation_id,
-            auth_identity,
-            client_ip,
-            upstream_url.value,
-            if (streaming_request_body == null) body else "",
-            streamed.status_code,
-            "application/octet-stream",
-            "",
-            transcript_redactions,
-        );
-        if (!isAbsoluteHttpUrl(std.mem.trim(u8, target, " \t\r\n"))) {
-            if (streamed.status_code >= 500 or streamed.upstream_aborted) {
+    const fallback_reason: StreamingFallbackReason = switch (streamingEligibilityForDataPlaneProxyRequest(cfg, matched_block, &resolved, upstream_url.value, max_attempts)) {
+        .stream => {
+            state.recordUpstreamAttemptStart(selection.base_url);
+            const streamed = executeStreamingHttpProxyRequest(
+                allocator,
+                cfg,
+                upstream_url.value,
+                method_str,
+                &request.headers,
+                body,
+                streaming_request_body,
+                downstream_conn,
+                writer,
+                correlation_id,
+                client_ip,
+                forwarded_proto,
+                request.headers.get("host"),
+                auth_identity,
+                auth_user_id,
+                auth_device_id,
+                auth_scopes,
+                &state.security_headers,
+                sticky_set_cookie,
+                if (ctx.lifecycle) |lc| &lc.token else null,
+                &state.upstream_pool,
+                &state.h2_pool,
+            ) catch |err| {
+                state.recordUpstreamAttemptEnd(selection.base_url);
+                if (err == error.ClientAborted) {
+                    state.metricsRecordProxyClientAbort();
+                    return err;
+                }
+                if (err == error.UpstreamAtCapacity) {
+                    // Fail-fast at the per-origin active cap (#239): a local
+                    // saturation rejection, not an origin failure — do not count
+                    // it against upstream health / circuit-breaker state.
+                    try sendApiError(allocator, writer, .service_unavailable, "upstream_saturated", "Upstream connection limit reached", correlation_id, false, state);
+                    ctx.setUpstreamResult(resolved.upstream_host, @intFromEnum(http.Status.service_unavailable), 0);
+                    return @intFromEnum(http.Status.service_unavailable);
+                }
                 state.recordUpstreamFailure(cfg, selection.base_url);
-            } else {
-                state.recordUpstreamSuccess(cfg, selection.base_url);
+                if (err == error.RequestCancelled) {
+                    if (ctx.lifecycle) |lc| lc.logTimeout("upstream_connect");
+                    try sendApiError(allocator, writer, .gateway_timeout, "upstream_timeout", "Upstream request timed out", correlation_id, false, state);
+                    ctx.setUpstreamResult(resolved.upstream_host, @intFromEnum(http.Status.gateway_timeout), 0);
+                    return @intFromEnum(http.Status.gateway_timeout);
+                }
+                if (err == error.OutOfMemory) return error.OutOfMemory;
+                const err_status: http.Status = switch (err) {
+                    error.Timeout, error.WouldBlock => .gateway_timeout,
+                    else => .bad_gateway,
+                };
+                const err_code = if (err_status == .gateway_timeout) "upstream_timeout" else "upstream_error";
+                const err_msg = if (err_status == .gateway_timeout) "Upstream request timed out" else "Upstream connection failed";
+                state.logger.warn(correlation_id, "streaming upstream request failed: {}", .{err});
+                try sendApiError(allocator, writer, err_status, err_code, err_msg, correlation_id, false, state);
+                ctx.setUpstreamResult(resolved.upstream_host, @intFromEnum(err_status), 0);
+                return @intFromEnum(err_status);
+            };
+            state.recordUpstreamAttemptEnd(selection.base_url);
+
+            const transcript_redactions: []const []const u8 = if (request.headers.get("authorization")) |raw_auth|
+                if (http.auth.parseBearerToken(raw_auth)) |token| &.{token} else &.{}
+            else
+                &.{};
+            state.appendTranscript(
+                upstreamScopeName(proxyScopeForPath(request.uri.path)),
+                request.uri.path,
+                correlation_id,
+                auth_identity,
+                client_ip,
+                upstream_url.value,
+                if (streaming_request_body == null) body else "",
+                streamed.status_code,
+                "application/octet-stream",
+                "",
+                transcript_redactions,
+            );
+            if (!isAbsoluteHttpUrl(std.mem.trim(u8, target, " \t\r\n"))) {
+                if (streamed.status_code >= 500 or streamed.upstream_aborted) {
+                    state.recordUpstreamFailure(cfg, selection.base_url);
+                } else {
+                    state.recordUpstreamSuccess(cfg, selection.base_url);
+                }
             }
-        }
-        if (streamed.upstream_aborted) state.metricsRecordProxyUpstreamAbort();
-        state.metricsRecordProxyStreamingRequest(streamed.upstream_ttfb_ms);
-        ctx.setUpstreamResult(resolved.upstream_host, streamed.status_code, streamed.response_body_bytes);
-        state.metricsRecord(streamed.status_code);
-        return streamed.status_code;
-    }
+            if (streamed.upstream_aborted) state.metricsRecordProxyUpstreamAbort();
+            state.metricsRecordProxyStreamingRequest(streamed.upstream_ttfb_ms);
+            ctx.setUpstreamResult(resolved.upstream_host, streamed.status_code, streamed.response_body_bytes);
+            state.metricsRecord(streamed.status_code);
+            return streamed.status_code;
+        },
+        .fallback => |reason| reason,
+    };
+    state.metricsRecordProxyStreamingFallback(fallback_reason.metricLabel());
+    state.logger.debug(correlation_id, "proxy streaming fallback: {s}", .{fallback_reason.metricLabel()});
 
     if (streaming_request_body != null) {
-        state.logger.warn(correlation_id, "streaming upload could not use streaming proxy path after routing", .{});
+        state.logger.warn(correlation_id, "streaming upload could not use streaming proxy path after routing: {s}", .{fallback_reason.metricLabel()});
         try sendApiError(allocator, writer, .bad_gateway, "upstream_error", "Streaming upload could not be proxied", correlation_id, false, state);
         ctx.setUpstreamResult(resolved.upstream_host, @intFromEnum(http.Status.bad_gateway), 0);
         return @intFromEnum(http.Status.bad_gateway);
@@ -808,6 +853,60 @@ test "data-plane buffered compatibility response limit uses dedicated upstream c
 
     cfg.max_buffered_upstream_response_bytes = 768 * 1024;
     try std.testing.expectEqual(@as(usize, 768 * 1024), dataPlaneBufferedCompatibilityResponseLimit(&cfg));
+}
+
+test "streaming eligibility returns typed fallback reasons" {
+    var cfg: edge_config.EdgeConfig = undefined;
+    cfg.proxy_streaming_mode = .response;
+    cfg.upstream_tls_client_cert = "";
+
+    const block = edge_config.EdgeConfig.LocationBlock{
+        .match_type = .prefix,
+        .pattern = "/",
+        .priority = 0,
+        .action = .{ .proxy_pass = "http://127.0.0.1:9001" },
+        .proxy_streaming_policy = .inherit,
+    };
+    const url: []const u8 = "http://127.0.0.1:9001/";
+    const resolved = gp.ResolvedProxyTarget{
+        .url = @constCast(url),
+        .upstream_host = "127.0.0.1:9001",
+    };
+
+    try std.testing.expectEqual(StreamingEligibility.stream, streamingEligibilityForDataPlaneProxyRequest(&cfg, &block, &resolved, url, 1));
+
+    var off_block = block;
+    off_block.proxy_streaming_policy = .off;
+    try std.testing.expectEqual(StreamingEligibility{ .fallback = .policy_disabled }, streamingEligibilityForDataPlaneProxyRequest(&cfg, &off_block, &resolved, url, 1));
+    try std.testing.expectEqual(StreamingEligibility{ .fallback = .retries_configured }, streamingEligibilityForDataPlaneProxyRequest(&cfg, &block, &resolved, url, 2));
+
+    var unix_resolved = resolved;
+    unix_resolved.unix_socket_path = "/tmp/upstream.sock";
+    try std.testing.expectEqual(StreamingEligibility{ .fallback = .unix_socket_target }, streamingEligibilityForDataPlaneProxyRequest(&cfg, &block, &unix_resolved, url, 1));
+
+    cfg.upstream_tls_client_cert = "/cert.pem";
+    try std.testing.expectEqual(StreamingEligibility{ .fallback = .upstream_mtls_target }, streamingEligibilityForDataPlaneProxyRequest(&cfg, &block, &resolved, "https://127.0.0.1:9001/", 1));
+}
+
+test "route streaming policy can override global mode" {
+    var cfg: edge_config.EdgeConfig = undefined;
+    cfg.proxy_streaming_mode = .off;
+    cfg.upstream_tls_client_cert = "";
+
+    const block = edge_config.EdgeConfig.LocationBlock{
+        .match_type = .prefix,
+        .pattern = "/bulk/",
+        .priority = 0,
+        .action = .{ .proxy_pass = "http://127.0.0.1:9001" },
+        .proxy_streaming_policy = .response,
+    };
+    const url: []const u8 = "http://127.0.0.1:9001/";
+    const resolved = gp.ResolvedProxyTarget{
+        .url = @constCast(url),
+        .upstream_host = "127.0.0.1:9001",
+    };
+
+    try std.testing.expectEqual(StreamingEligibility.stream, streamingEligibilityForDataPlaneProxyRequest(&cfg, &block, &resolved, url, 1));
 }
 
 test "proxySuffixPathForLocation uses mount prefix for split upstream exact route" {

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -1430,6 +1430,12 @@ pub const GatewayState = struct {
         self.metrics.recordProxyUpstreamAbort();
     }
 
+    pub fn metricsRecordProxyStreamingFallback(self: *GatewayState, reason: []const u8) void {
+        self.metrics_mutex.lock();
+        defer self.metrics_mutex.unlock();
+        self.metrics.recordProxyStreamingFallback(reason);
+    }
+
     pub fn metricsSetWorkerPoolStats(self: *GatewayState, active_jobs: usize, queued_jobs: usize, worker_threads: usize, queue_capacity: usize) void {
         self.metrics_mutex.lock();
         defer self.metrics_mutex.unlock();

--- a/src/http/config_file.zig
+++ b/src/http/config_file.zig
@@ -80,6 +80,7 @@ const LocationBlockBuilder = struct {
     rewrite_replacement: ?[]u8 = null,
     rewrite_flag: ?[]u8 = null,
     auth: ?[]u8 = null,
+    proxy_streaming: ?[]u8 = null,
     error_pages: std.ArrayList(ErrorPageBuilder) = .empty,
 
     fn actionKind(self: *const LocationBlockBuilder) ?[]const u8 {
@@ -108,6 +109,7 @@ const LocationBlockBuilder = struct {
         if (self.rewrite_replacement) |value| allocator.free(value);
         if (self.rewrite_flag) |value| allocator.free(value);
         if (self.auth) |value| allocator.free(value);
+        if (self.proxy_streaming) |value| allocator.free(value);
         for (self.error_pages.items) |entry| {
             allocator.free(entry.status_codes_csv);
             allocator.free(entry.target);
@@ -781,6 +783,25 @@ fn parseLocationStatement(
         try replaceOptionalOwned(allocator, &builder.auth, value_interp);
         return;
     }
+    if (std.ascii.eqlIgnoreCase(directive, "proxy_streaming") or std.ascii.eqlIgnoreCase(directive, "proxy_streaming_mode")) {
+        if (!isLocationProxyStreamingPolicy(value_interp)) {
+            std.log.err("config syntax error at {s}:{d}: proxy_streaming must be one of inherit, off, response, full", .{ file_path, line_no });
+            return error.InvalidConfigSyntax;
+        }
+        try replaceOptionalOwned(allocator, &builder.proxy_streaming, value_interp);
+        return;
+    }
+}
+
+fn isLocationProxyStreamingPolicy(value: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(value, "inherit") or
+        std.ascii.eqlIgnoreCase(value, "off") or
+        std.ascii.eqlIgnoreCase(value, "buffered") or
+        std.ascii.eqlIgnoreCase(value, "response") or
+        std.ascii.eqlIgnoreCase(value, "responses") or
+        std.ascii.eqlIgnoreCase(value, "full") or
+        std.ascii.eqlIgnoreCase(value, "request_response") or
+        std.ascii.eqlIgnoreCase(value, "request-response");
 }
 
 fn ensureLocationActionAllowed(
@@ -842,6 +863,13 @@ fn buildLocationBlockEntry(allocator: std.mem.Allocator, builder: *LocationBlock
             const with_auth = try std.fmt.allocPrint(allocator, "{s}|auth:{s}", .{ entry, auth_mode });
             allocator.free(entry);
             entry = with_auth;
+        }
+    }
+    if (builder.proxy_streaming) |mode| {
+        if (!std.ascii.eqlIgnoreCase(mode, "inherit")) {
+            const with_stream_policy = try std.fmt.allocPrint(allocator, "{s}|stream:{s}", .{ entry, mode });
+            allocator.free(entry);
+            entry = with_stream_policy;
         }
     }
     return entry;
@@ -1224,6 +1252,47 @@ test "location blocks accumulate into location block env" {
 
     try std.testing.expectEqualStrings(
         "exact|/health|return|200|ok;prefix_priority|/api/private/|proxy_pass|http://127.0.0.1:9001;regex_case_insensitive|^/assets/.*$|static_root|/srv/www|off|off|index.html|$uri /index.html",
+        overrides.map.get("TARDIGRADE_LOCATION_BLOCKS").?,
+    );
+}
+
+test "location block serializes proxy streaming policy" {
+    const allocator = std.testing.allocator;
+    var cfg_dir = std.testing.tmpDir(.{});
+    defer cfg_dir.cleanup();
+
+    try compat.wrapDir(cfg_dir.dir).writeFile(.{
+        .sub_path = "location-streaming.conf",
+        .data =
+        \\location /bulk/ {
+        \\    proxy_pass http://127.0.0.1:9001;
+        \\    proxy_streaming full;
+        \\}
+        \\location /compat/ {
+        \\    proxy_pass http://127.0.0.1:9002;
+        \\    proxy_streaming_mode off;
+        \\}
+        ,
+    });
+
+    const absolute = try compat.wrapDir(cfg_dir.dir).realpathAlloc(allocator, "location-streaming.conf");
+    defer allocator.free(absolute);
+
+    var overrides = Overrides.init(allocator);
+    defer overrides.deinit(allocator);
+    var vars = std.StringHashMap([]const u8).init(allocator);
+    defer vars.deinit();
+    var visited = std.StringHashMap(void).init(allocator);
+    defer {
+        var it = visited.iterator();
+        while (it.next()) |entry| allocator.free(entry.key_ptr.*);
+        visited.deinit();
+    }
+
+    try parseFile(allocator, absolute, &overrides, &vars, &visited);
+
+    try std.testing.expectEqualStrings(
+        "prefix|/bulk/|proxy_pass|http://127.0.0.1:9001|stream:full;prefix|/compat/|proxy_pass|http://127.0.0.1:9002|stream:off",
         overrides.map.get("TARDIGRADE_LOCATION_BLOCKS").?,
     );
 }

--- a/src/http/location_router.zig
+++ b/src/http/location_router.zig
@@ -75,6 +75,37 @@ pub const AuthMode = enum {
     }
 };
 
+pub const ProxyStreamingPolicy = enum {
+    inherit,
+    off,
+    response,
+    full,
+
+    pub fn parse(value: []const u8) ?ProxyStreamingPolicy {
+        if (std.ascii.eqlIgnoreCase(value, "inherit")) return .inherit;
+        if (std.ascii.eqlIgnoreCase(value, "off") or std.ascii.eqlIgnoreCase(value, "buffered")) return .off;
+        if (std.ascii.eqlIgnoreCase(value, "response") or std.ascii.eqlIgnoreCase(value, "responses")) return .response;
+        if (std.ascii.eqlIgnoreCase(value, "full") or std.ascii.eqlIgnoreCase(value, "request_response") or std.ascii.eqlIgnoreCase(value, "request-response")) return .full;
+        return null;
+    }
+
+    pub fn responseStreamingEnabled(self: ProxyStreamingPolicy, inherited_enabled: bool) bool {
+        return switch (self) {
+            .inherit => inherited_enabled,
+            .off => false,
+            .response, .full => true,
+        };
+    }
+
+    pub fn requestStreamingEnabled(self: ProxyStreamingPolicy, inherited_enabled: bool) bool {
+        return switch (self) {
+            .inherit => inherited_enabled,
+            .off, .response => false,
+            .full => true,
+        };
+    }
+};
+
 pub const LocationBlock = struct {
     match_type: MatchType,
     pattern: []const u8,
@@ -82,6 +113,7 @@ pub const LocationBlock = struct {
     action: Action,
     error_pages: []ErrorPageRule = &.{},
     auth: AuthMode = .off,
+    proxy_streaming_policy: ProxyStreamingPolicy = .inherit,
 
     pub fn deinit(self: *LocationBlock, allocator: std.mem.Allocator) void {
         allocator.free(self.pattern);

--- a/src/http/metrics.zig
+++ b/src/http/metrics.zig
@@ -531,7 +531,7 @@ pub const Metrics = struct {
             \\# HELP tardigrade_proxy_upstream_aborts_total Total proxied transfers aborted by upstream origins
             \\# TYPE tardigrade_proxy_upstream_aborts_total counter
             \\tardigrade_proxy_upstream_aborts_total {d}
-            \\# HELP tardigrade_proxy_streaming_fallback_total Total proxied requests that used the buffered path after streaming eligibility checks
+            \\# HELP tardigrade_proxy_streaming_fallback_total Total streaming eligibility fallback events by reason
             \\# TYPE tardigrade_proxy_streaming_fallback_total counter
             \\tardigrade_proxy_streaming_fallback_total{{reason="policy_disabled"}} {d}
             \\tardigrade_proxy_streaming_fallback_total{{reason="retries_configured"}} {d}

--- a/src/http/metrics.zig
+++ b/src/http/metrics.zig
@@ -32,6 +32,15 @@ pub const Metrics = struct {
     proxy_buffered_bytes_total: u64,
     proxy_client_aborts: u64,
     proxy_upstream_aborts: u64,
+    proxy_streaming_fallback_policy_disabled: u64,
+    proxy_streaming_fallback_retries_configured: u64,
+    proxy_streaming_fallback_unix_socket_target: u64,
+    proxy_streaming_fallback_upstream_mtls_target: u64,
+    proxy_streaming_fallback_chunked_request_upload: u64,
+    proxy_streaming_fallback_missing_content_length: u64,
+    proxy_streaming_fallback_body_too_large: u64,
+    proxy_streaming_fallback_body_dependent_middleware: u64,
+    proxy_streaming_fallback_unsupported_route_type: u64,
     proxy_ttfb_ms_count: u64,
     proxy_ttfb_ms_sum: u64,
     // Upstream keep-alive connection pool (#141). Populated from the pool's own
@@ -130,6 +139,15 @@ pub const Metrics = struct {
             .proxy_buffered_bytes_total = 0,
             .proxy_client_aborts = 0,
             .proxy_upstream_aborts = 0,
+            .proxy_streaming_fallback_policy_disabled = 0,
+            .proxy_streaming_fallback_retries_configured = 0,
+            .proxy_streaming_fallback_unix_socket_target = 0,
+            .proxy_streaming_fallback_upstream_mtls_target = 0,
+            .proxy_streaming_fallback_chunked_request_upload = 0,
+            .proxy_streaming_fallback_missing_content_length = 0,
+            .proxy_streaming_fallback_body_too_large = 0,
+            .proxy_streaming_fallback_body_dependent_middleware = 0,
+            .proxy_streaming_fallback_unsupported_route_type = 0,
             .proxy_ttfb_ms_count = 0,
             .proxy_ttfb_ms_sum = 0,
             .upstream_connections_new = 0,
@@ -286,6 +304,28 @@ pub const Metrics = struct {
 
     pub fn recordProxyUpstreamAbort(self: *Metrics) void {
         self.proxy_upstream_aborts += 1;
+    }
+
+    pub fn recordProxyStreamingFallback(self: *Metrics, reason: []const u8) void {
+        if (std.mem.eql(u8, reason, "policy_disabled")) {
+            self.proxy_streaming_fallback_policy_disabled += 1;
+        } else if (std.mem.eql(u8, reason, "retries_configured")) {
+            self.proxy_streaming_fallback_retries_configured += 1;
+        } else if (std.mem.eql(u8, reason, "unix_socket_target")) {
+            self.proxy_streaming_fallback_unix_socket_target += 1;
+        } else if (std.mem.eql(u8, reason, "upstream_mtls_target")) {
+            self.proxy_streaming_fallback_upstream_mtls_target += 1;
+        } else if (std.mem.eql(u8, reason, "chunked_request_upload")) {
+            self.proxy_streaming_fallback_chunked_request_upload += 1;
+        } else if (std.mem.eql(u8, reason, "missing_content_length")) {
+            self.proxy_streaming_fallback_missing_content_length += 1;
+        } else if (std.mem.eql(u8, reason, "body_too_large")) {
+            self.proxy_streaming_fallback_body_too_large += 1;
+        } else if (std.mem.eql(u8, reason, "body_dependent_middleware")) {
+            self.proxy_streaming_fallback_body_dependent_middleware += 1;
+        } else if (std.mem.eql(u8, reason, "unsupported_route_type")) {
+            self.proxy_streaming_fallback_unsupported_route_type += 1;
+        }
     }
 
     fn recordProxyTtfbMs(self: *Metrics, ttfb_ms: u64) void {
@@ -491,6 +531,17 @@ pub const Metrics = struct {
             \\# HELP tardigrade_proxy_upstream_aborts_total Total proxied transfers aborted by upstream origins
             \\# TYPE tardigrade_proxy_upstream_aborts_total counter
             \\tardigrade_proxy_upstream_aborts_total {d}
+            \\# HELP tardigrade_proxy_streaming_fallback_total Total proxied requests that used the buffered path after streaming eligibility checks
+            \\# TYPE tardigrade_proxy_streaming_fallback_total counter
+            \\tardigrade_proxy_streaming_fallback_total{{reason="policy_disabled"}} {d}
+            \\tardigrade_proxy_streaming_fallback_total{{reason="retries_configured"}} {d}
+            \\tardigrade_proxy_streaming_fallback_total{{reason="unix_socket_target"}} {d}
+            \\tardigrade_proxy_streaming_fallback_total{{reason="upstream_mtls_target"}} {d}
+            \\tardigrade_proxy_streaming_fallback_total{{reason="chunked_request_upload"}} {d}
+            \\tardigrade_proxy_streaming_fallback_total{{reason="missing_content_length"}} {d}
+            \\tardigrade_proxy_streaming_fallback_total{{reason="body_too_large"}} {d}
+            \\tardigrade_proxy_streaming_fallback_total{{reason="body_dependent_middleware"}} {d}
+            \\tardigrade_proxy_streaming_fallback_total{{reason="unsupported_route_type"}} {d}
             \\# HELP tardigrade_proxy_ttfb_ms Proxied upstream time to first byte in milliseconds
             \\# TYPE tardigrade_proxy_ttfb_ms summary
             \\tardigrade_proxy_ttfb_ms_sum {d}
@@ -521,6 +572,15 @@ pub const Metrics = struct {
             self.proxy_buffered_bytes_total,
             self.proxy_client_aborts,
             self.proxy_upstream_aborts,
+            self.proxy_streaming_fallback_policy_disabled,
+            self.proxy_streaming_fallback_retries_configured,
+            self.proxy_streaming_fallback_unix_socket_target,
+            self.proxy_streaming_fallback_upstream_mtls_target,
+            self.proxy_streaming_fallback_chunked_request_upload,
+            self.proxy_streaming_fallback_missing_content_length,
+            self.proxy_streaming_fallback_body_too_large,
+            self.proxy_streaming_fallback_body_dependent_middleware,
+            self.proxy_streaming_fallback_unsupported_route_type,
             self.proxy_ttfb_ms_sum,
             self.proxy_ttfb_ms_count,
             self.upstream_connections_new,
@@ -938,6 +998,32 @@ test "Metrics toPrometheus produces valid Prometheus text" {
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_error_invalid_request_total") != null);
     try std.testing.expect(std.mem.find(u8, prom, "# TYPE tardigrade_requests_total counter") != null);
     try std.testing.expect(std.mem.find(u8, prom, "# TYPE tardigrade_uptime_seconds gauge") != null);
+}
+
+test "Metrics records proxy streaming fallback reasons" {
+    const allocator = std.testing.allocator;
+    var m = Metrics.init();
+    m.recordProxyStreamingFallback("policy_disabled");
+    m.recordProxyStreamingFallback("retries_configured");
+    m.recordProxyStreamingFallback("unix_socket_target");
+    m.recordProxyStreamingFallback("upstream_mtls_target");
+    m.recordProxyStreamingFallback("chunked_request_upload");
+    m.recordProxyStreamingFallback("missing_content_length");
+    m.recordProxyStreamingFallback("body_too_large");
+    m.recordProxyStreamingFallback("body_dependent_middleware");
+    m.recordProxyStreamingFallback("unsupported_route_type");
+
+    const prom = try m.toPrometheus(allocator);
+    defer allocator.free(prom);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_proxy_streaming_fallback_total{reason=\"policy_disabled\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_proxy_streaming_fallback_total{reason=\"retries_configured\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_proxy_streaming_fallback_total{reason=\"unix_socket_target\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_proxy_streaming_fallback_total{reason=\"upstream_mtls_target\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_proxy_streaming_fallback_total{reason=\"chunked_request_upload\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_proxy_streaming_fallback_total{reason=\"missing_content_length\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_proxy_streaming_fallback_total{reason=\"body_too_large\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_proxy_streaming_fallback_total{reason=\"body_dependent_middleware\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_proxy_streaming_fallback_total{reason=\"unsupported_route_type\"} 1") != null);
 }
 
 test "Metrics toJson produces valid JSON" {

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -3350,6 +3350,101 @@ test "proxy streaming mode relays upstream body beyond buffered cap" {
     try std.testing.expectEqual(@as(u64, 0), buffered);
 }
 
+test "proxy route streaming policy overrides global mode" {
+    const allocator = std.testing.allocator;
+    const payload_len = 256 * 1024;
+    const payload = try allocator.alloc(u8, payload_len);
+    defer allocator.free(payload);
+    @memset(payload, 'x');
+
+    var streaming_upstream = try UpstreamServer.start(allocator, &.{.{
+        .body = payload,
+        .headers = &.{.{ .name = "Content-Type", .value = "application/octet-stream" }},
+    }});
+    defer streaming_upstream.stop();
+    try streaming_upstream.run();
+
+    const streaming_config = try std.fmt.allocPrint(allocator,
+        \\location /stream/ {{
+        \\    proxy_pass http://{s}:{d};
+        \\    proxy_streaming response;
+        \\}}
+    , .{ test_host, streaming_upstream.port() });
+    defer allocator.free(streaming_config);
+
+    var streaming_tardigrade = try TardigradeProcess.start(allocator, .{
+        .config_text = streaming_config,
+        .extra_env = &.{
+            .{ .name = "TARDIGRADE_PROXY_STREAMING_MODE", .value = "off" },
+            .{ .name = "TARDIGRADE_PROXY_STREAM_BUFFER_SIZE", .value = "4096" },
+            .{ .name = "TARDIGRADE_MAX_BUFFERED_UPSTREAM_RESPONSE_BYTES", .value = "65536" },
+        },
+    });
+    defer streaming_tardigrade.stop();
+
+    var streamed_response = try sendRequest(allocator, streaming_tardigrade.port, .{
+        .method = "GET",
+        .path = "/stream/large.bin",
+        .body = null,
+        .headers = &.{},
+    });
+    defer streamed_response.deinit();
+    try std.testing.expectEqual(@as(u16, 200), streamed_response.status_code);
+    try std.testing.expectEqual(@as(usize, payload_len), streamed_response.body.len);
+
+    var streaming_metrics = try sendRequest(allocator, streaming_tardigrade.port, .{
+        .method = "GET",
+        .path = "/status/metrics",
+        .body = null,
+        .headers = &.{},
+    });
+    defer streaming_metrics.deinit();
+    const streamed = prometheusMetricValue(streaming_metrics.body, "tardigrade_proxy_streaming_requests_total") orelse return error.InvalidHttpResponse;
+    try std.testing.expect(streamed >= 1);
+
+    var buffered_upstream = try UpstreamServer.start(allocator, &.{.{
+        .body = "small buffered response",
+        .headers = &.{.{ .name = "Content-Type", .value = "text/plain" }},
+    }});
+    defer buffered_upstream.stop();
+    try buffered_upstream.run();
+
+    const buffered_config = try std.fmt.allocPrint(allocator,
+        \\location /compat/ {{
+        \\    proxy_pass http://{s}:{d};
+        \\    proxy_streaming off;
+        \\}}
+    , .{ test_host, buffered_upstream.port() });
+    defer allocator.free(buffered_config);
+
+    var buffered_tardigrade = try TardigradeProcess.start(allocator, .{
+        .config_text = buffered_config,
+        .extra_env = &.{
+            .{ .name = "TARDIGRADE_PROXY_STREAMING_MODE", .value = "response" },
+        },
+    });
+    defer buffered_tardigrade.stop();
+
+    var buffered_response = try sendRequest(allocator, buffered_tardigrade.port, .{
+        .method = "GET",
+        .path = "/compat/small.txt",
+        .body = null,
+        .headers = &.{},
+    });
+    defer buffered_response.deinit();
+    try std.testing.expectEqual(@as(u16, 200), buffered_response.status_code);
+    try std.testing.expectEqualStrings("small buffered response", buffered_response.body);
+
+    var buffered_metrics = try sendRequest(allocator, buffered_tardigrade.port, .{
+        .method = "GET",
+        .path = "/status/metrics",
+        .body = null,
+        .headers = &.{},
+    });
+    defer buffered_metrics.deinit();
+    try std.testing.expect(std.mem.find(u8, buffered_metrics.body, "tardigrade_proxy_streaming_fallback_total{reason=\"policy_disabled\"} 1") != null);
+}
+
 test "proxy streaming mode handles chunked and no-body upstream responses" {
     const allocator = std.testing.allocator;
 

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -3420,16 +3420,16 @@ test "proxy route streaming policy overrides global mode" {
     var buffered_tardigrade = try TardigradeProcess.start(allocator, .{
         .config_text = buffered_config,
         .extra_env = &.{
-            .{ .name = "TARDIGRADE_PROXY_STREAMING_MODE", .value = "response" },
+            .{ .name = "TARDIGRADE_PROXY_STREAMING_MODE", .value = "full" },
         },
     });
     defer buffered_tardigrade.stop();
 
     var buffered_response = try sendRequest(allocator, buffered_tardigrade.port, .{
-        .method = "GET",
+        .method = "POST",
         .path = "/compat/small.txt",
-        .body = null,
-        .headers = &.{},
+        .body = "request body",
+        .headers = &.{.{ .name = "Content-Type", .value = "text/plain" }},
     });
     defer buffered_response.deinit();
     try std.testing.expectEqual(@as(u16, 200), buffered_response.status_code);
@@ -3442,7 +3442,7 @@ test "proxy route streaming policy overrides global mode" {
         .headers = &.{},
     });
     defer buffered_metrics.deinit();
-    try std.testing.expect(std.mem.find(u8, buffered_metrics.body, "tardigrade_proxy_streaming_fallback_total{reason=\"policy_disabled\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, buffered_metrics.body, "tardigrade_proxy_streaming_fallback_total{reason=\"policy_disabled\"} 2") != null);
 }
 
 test "proxy streaming mode handles chunked and no-body upstream responses" {
@@ -3620,6 +3620,60 @@ test "proxy full streaming mode relays fixed-length upload beyond request buffer
     defer response.deinit();
     try std.testing.expectEqual(@as(u16, 200), response.status_code);
     try std.testing.expectEqualStrings("uploaded", response.body);
+
+    const captured = try upstream.capturedBody(allocator);
+    defer allocator.free(captured);
+    try std.testing.expectEqual(@as(usize, payload_len), captured.len);
+    try std.testing.expectEqualStrings(payload, captured);
+}
+
+test "proxy full streaming upload works for server block route override" {
+    const allocator = std.testing.allocator;
+    const payload_len = 384 * 1024;
+    const payload = try allocator.alloc(u8, payload_len);
+    defer allocator.free(payload);
+    @memset(payload, 'v');
+
+    var upstream = try UpstreamServer.start(allocator, &.{.{
+        .body = "vhost uploaded",
+        .headers = &.{.{ .name = "Content-Type", .value = "text/plain" }},
+    }});
+    defer upstream.stop();
+    try upstream.run();
+
+    const config_text = try std.fmt.allocPrint(allocator,
+        \\server {{
+        \\    server_name uploads.example.test;
+        \\    location /upload {{
+        \\        proxy_pass http://{s}:{d}/upload;
+        \\        proxy_streaming full;
+        \\    }}
+        \\}}
+    , .{ test_host, upstream.port() });
+    defer allocator.free(config_text);
+
+    var tardigrade = try TardigradeProcess.start(allocator, .{
+        .config_text = config_text,
+        .extra_env = &.{
+            .{ .name = "TARDIGRADE_PROXY_STREAMING_MODE", .value = "off" },
+            .{ .name = "TARDIGRADE_PROXY_STREAM_BUFFER_SIZE", .value = "4096" },
+            .{ .name = "TARDIGRADE_MAX_BODY_SIZE", .value = "524288" },
+        },
+    });
+    defer tardigrade.stop();
+
+    var response = try sendRequest(allocator, tardigrade.port, .{
+        .method = "POST",
+        .path = "/upload",
+        .body = payload,
+        .headers = &.{
+            .{ .name = "Host", .value = "uploads.example.test" },
+            .{ .name = "Content-Type", .value = "application/octet-stream" },
+        },
+    });
+    defer response.deinit();
+    try std.testing.expectEqual(@as(u16, 200), response.status_code);
+    try std.testing.expectEqualStrings("vhost uploaded", response.body);
 
     const captured = try upstream.capturedBody(allocator);
     defer allocator.free(captured);


### PR DESCRIPTION
## Summary
- add inheritable per-location proxy streaming policy (`inherit`, `off`, `response`, `full`) for config-file and location-blob routes
- replace streaming eligibility booleans with typed fallback reasons for response streaming and full-mode upload decisions
- expose fallback reasons through `tardigrade_proxy_streaming_fallback_total{reason=...}` and document the route policy/metric
- add unit and integration coverage for route overrides, fallback metrics, and upload eligibility reasons

This implements the policy and observability slice recommended as PR 1 in #139. Request-upload completion and the broader gateway conformance matrix remain separate follow-up slices from the issue body.

## Validation
- `zig fmt --check build.zig src/ tests/`
- `git diff --check`
- `zig build test --summary all --error-style verbose`
- `zig build test-integration -- --test-filter "proxy route streaming policy overrides global mode"`

Closes part of #139
