### PR TITLE
proxy: add buffer accounting metrics

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -40,10 +40,10 @@ logs are written through `src/http/logger.zig`.
   `tardigrade_buffer_read_resumes_total{side}`, and
   `tardigrade_buffer_limit_exceeded_total{direction,scope}`. Labels are fixed
   to protocol-independent directions, scopes, and sides; they never include
-  URLs, request IDs, or stream IDs. In the first implementation slice, current
-  byte gauges cover bounded buffered responses and HTTP/1 streaming relay
-  buffers. HTTP/2 per-stream queue accounting remains a follow-up enforcement
-  slice.
+  URLs, request IDs, or stream IDs. Current byte gauges cover bounded buffered
+  responses, HTTP/1 streaming relay buffers, and HTTP/2 streaming response queues.
+  Pause/resume counters are exported as reserved zero-valued series until a later
+  backpressure slice adds production pause/resume transition sites.
 - configured proxy buffer limits:
   `tardigrade_buffer_config_limit_bytes{direction,scope,limit}` for the
   per-stream low/high/hard watermarks plus per-origin/global hard-limit

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -33,6 +33,18 @@ logs are written through `src/http/logger.zig`.
 - reverse-proxy buffered byte gauges/counters:
   `tardigrade_proxy_buffered_bytes_current` and
   `tardigrade_proxy_buffered_bytes_total`
+- shared proxy buffer accounting gauges/counters:
+  `tardigrade_buffered_bytes_current{direction,scope}`,
+  `tardigrade_buffer_high_watermark_events_total{direction,scope}`,
+  `tardigrade_buffer_read_pauses_total{side}`,
+  `tardigrade_buffer_read_resumes_total{side}`, and
+  `tardigrade_buffer_limit_exceeded_total{direction,scope}`. Labels are fixed
+  to protocol-independent directions, scopes, and sides; they never include
+  URLs, request IDs, or stream IDs.
+- configured proxy buffer limits:
+  `tardigrade_buffer_config_limit_bytes{direction,scope,limit}` for the
+  per-stream low/high/hard watermarks plus per-origin/global hard-limit
+  settings.
 - reverse-proxy abort counters:
   `tardigrade_proxy_client_aborts_total` and
   `tardigrade_proxy_upstream_aborts_total`
@@ -97,6 +109,11 @@ Two outcome shapes exist:
 | Single header too large | `TARDIGRADE_MAX_HEADER_SIZE` | 8 KiB | `request_limits.validateHeaderSize` | `431`-class rejection |
 | All headers too large | `TARDIGRADE_MAX_HEADERS_TOTAL_SIZE` | 32 KiB | `request_limits.validateHeadersTotalSize` | `431` before body allocation |
 | Request body too large | `TARDIGRADE_MAX_BODY_SIZE` | 1 MiB | `request_limits.validateBodySize` | `413`-class rejection |
+| Proxy per-stream buffer low watermark | `TARDIGRADE_PROXY_BUFFER_PER_STREAM_LOW_WATERMARK_BYTES` | 256 KiB | proxy buffer accounting | Paired with high watermark for pause/resume decisions; must satisfy `low < high <= hard` |
+| Proxy per-stream buffer high watermark | `TARDIGRADE_PROXY_BUFFER_PER_STREAM_HIGH_WATERMARK_BYTES` | 768 KiB | proxy buffer accounting | High-watermark transition is observable through `tardigrade_buffer_high_watermark_events_total` |
+| Proxy per-stream buffer hard limit | `TARDIGRADE_PROXY_BUFFER_PER_STREAM_HARD_LIMIT_BYTES` | 1 MiB | proxy buffer accounting | Hard-limit exceedance is observable through `tardigrade_buffer_limit_exceeded_total`; enforcement lands per proxy path as backpressure work expands |
+| Proxy per-origin buffer hard limit | `TARDIGRADE_PROXY_BUFFER_PER_ORIGIN_HARD_LIMIT_BYTES` | 0 (not enforced yet) | future aggregate proxy buffer accounting | When non-zero, must be at least the per-stream hard limit |
+| Proxy global buffer hard limit | `TARDIGRADE_PROXY_BUFFER_GLOBAL_HARD_LIMIT_BYTES` | 0 (not enforced yet) | future aggregate proxy buffer accounting | When non-zero, must be at least the per-stream hard limit |
 | Parked keepalive backlog | idle-park timeout / `max_requests_per_connection` | — | `keepalive_park.ParkedRegistry` | Idle parked connections reaped on the timer tick (`timeouts_total`); none hold a worker while idle |
 
 The request-size limits are enforced in two layers: the HTTP parser

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -40,7 +40,10 @@ logs are written through `src/http/logger.zig`.
   `tardigrade_buffer_read_resumes_total{side}`, and
   `tardigrade_buffer_limit_exceeded_total{direction,scope}`. Labels are fixed
   to protocol-independent directions, scopes, and sides; they never include
-  URLs, request IDs, or stream IDs.
+  URLs, request IDs, or stream IDs. In the first implementation slice, current
+  byte gauges cover bounded buffered responses and HTTP/1 streaming relay
+  buffers. HTTP/2 per-stream queue accounting remains a follow-up enforcement
+  slice.
 - configured proxy buffer limits:
   `tardigrade_buffer_config_limit_bytes{direction,scope,limit}` for the
   per-stream low/high/hard watermarks plus per-origin/global hard-limit

--- a/docs/UPSTREAM_POOLING.md
+++ b/docs/UPSTREAM_POOLING.md
@@ -196,8 +196,8 @@ response eligibility are evaluated at different phases.
 
 Proxy buffer accounting is exposed separately from upstream pool reuse metrics.
 `tardigrade_buffered_bytes_current{direction,scope}` reports application-owned
-body bytes retained by the proxy for bounded buffered responses and HTTP/1
-streaming relay buffers in this first implementation slice, while
+body bytes retained by the proxy for bounded buffered responses, HTTP/1
+streaming relay buffers, and HTTP/2 streaming response queues, while
 `tardigrade_buffer_config_limit_bytes{direction,scope,limit}` exposes the
 configured low/high/hard limits operators need to interpret those gauges.
 

--- a/docs/UPSTREAM_POOLING.md
+++ b/docs/UPSTREAM_POOLING.md
@@ -194,6 +194,12 @@ upload-specific fallbacks: `chunked_request_upload`, `missing_content_length`,
 The metric counts fallback events, not unique requests, because upload and
 response eligibility are evaluated at different phases.
 
+Proxy buffer accounting is exposed separately from upstream pool reuse metrics.
+`tardigrade_buffered_bytes_current{direction,scope}` reports application-owned
+body bytes retained by the proxy, while
+`tardigrade_buffer_config_limit_bytes{direction,scope,limit}` exposes the
+configured low/high/hard limits operators need to interpret those gauges.
+
 The actor gains a streaming request mode next to the fully-buffered
 `request()`:
 

--- a/docs/UPSTREAM_POOLING.md
+++ b/docs/UPSTREAM_POOLING.md
@@ -196,7 +196,8 @@ response eligibility are evaluated at different phases.
 
 Proxy buffer accounting is exposed separately from upstream pool reuse metrics.
 `tardigrade_buffered_bytes_current{direction,scope}` reports application-owned
-body bytes retained by the proxy, while
+body bytes retained by the proxy for bounded buffered responses and HTTP/1
+streaming relay buffers in this first implementation slice, while
 `tardigrade_buffer_config_limit_bytes{direction,scope,limit}` exposes the
 configured low/high/hard limits operators need to interpret those gauges.
 

--- a/scripts/test-rpm-package.sh
+++ b/scripts/test-rpm-package.sh
@@ -50,7 +50,10 @@ docker run --rm \
     --volume "${OUTPUT_DIR}:/output" \
     --volume "${ZIG_DIR}:/opt/zig:ro" \
     rockylinux:9 bash -euxc '
-        dnf install -y rpm-build openssl-devel openssl-libs systemd-rpm-macros
+        # Rocky minor repos can briefly offer a newer best candidate before all
+        # matching dependency packages are mirrored. The smoke test only needs a
+        # coherent distro-provided OpenSSL development stack.
+        dnf --nobest install -y rpm-build openssl-devel openssl-libs systemd-rpm-macros
 
         export PATH="/opt/zig:${PATH}"
 

--- a/src/edge_config.zig
+++ b/src/edge_config.zig
@@ -403,6 +403,8 @@ pub const EdgeConfig = struct {
     max_connection_memory_bytes: usize,
     /// Maximum buffered bytes accepted from an upstream HTTP response body.
     max_buffered_upstream_response_bytes: usize,
+    /// Shared proxy body-buffer watermarks and future aggregate hard limits.
+    proxy_buffer_limits: http.proxy_buffer_account.Limits,
     /// Proxy streaming policy for data-plane HTTP proxy routes.
     proxy_streaming_mode: ProxyStreamingMode,
     /// Maximum relay buffer used per direction for streaming proxy transfers.
@@ -1165,6 +1167,13 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
     const max_buffered_upstream_resp_str = envOrDefault(allocator, "TARDIGRADE_MAX_BUFFERED_UPSTREAM_RESPONSE_BYTES", "262144") catch unreachable;
     defer allocator.free(max_buffered_upstream_resp_str);
     const max_buffered_upstream_response_bytes = std.fmt.parseInt(usize, max_buffered_upstream_resp_str, 10) catch 256 * 1024;
+    const proxy_buffer_limits = http.proxy_buffer_account.Limits{
+        .per_stream_low_watermark = parseIntEnv(usize, allocator, "TARDIGRADE_PROXY_BUFFER_PER_STREAM_LOW_WATERMARK_BYTES", 256 * 1024),
+        .per_stream_high_watermark = parseIntEnv(usize, allocator, "TARDIGRADE_PROXY_BUFFER_PER_STREAM_HIGH_WATERMARK_BYTES", 768 * 1024),
+        .per_stream_hard_limit = parseIntEnv(usize, allocator, "TARDIGRADE_PROXY_BUFFER_PER_STREAM_HARD_LIMIT_BYTES", 1024 * 1024),
+        .per_origin_hard_limit = parseIntEnv(usize, allocator, "TARDIGRADE_PROXY_BUFFER_PER_ORIGIN_HARD_LIMIT_BYTES", 0),
+        .global_hard_limit = parseIntEnv(usize, allocator, "TARDIGRADE_PROXY_BUFFER_GLOBAL_HARD_LIMIT_BYTES", 0),
+    };
 
     const proxy_streaming_mode_str = envOrDefault(allocator, "TARDIGRADE_PROXY_STREAMING_MODE", "off") catch unreachable;
     defer allocator.free(proxy_streaming_mode_str);
@@ -1538,6 +1547,7 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
         .connection_pool_size = connection_pool_size,
         .max_connection_memory_bytes = max_connection_memory_bytes,
         .max_buffered_upstream_response_bytes = max_buffered_upstream_response_bytes,
+        .proxy_buffer_limits = proxy_buffer_limits,
         .proxy_streaming_mode = proxy_streaming_mode,
         .proxy_stream_buffer_size = proxy_stream_buffer_size,
         .max_total_connection_memory_bytes = max_total_connection_memory_bytes,
@@ -2641,6 +2651,10 @@ pub fn validate(cfg: *const EdgeConfig) !void {
         std.log.err("config validation failed: TARDIGRADE_MAX_BUFFERED_UPSTREAM_RESPONSE_BYTES must be at least 1", .{});
         return error.InvalidConfigValue;
     };
+    cfg.proxy_buffer_limits.validate() catch {
+        std.log.err("config validation failed: proxy buffer watermarks must satisfy low < high <= hard and aggregate hard limits must be 0 or at least the per-stream hard limit", .{});
+        return error.InvalidConfigValue;
+    };
     validateProxyStreamBufferSize(cfg.proxy_stream_buffer_size) catch {
         std.log.err("config validation failed: TARDIGRADE_PROXY_STREAM_BUFFER_SIZE must be between 1 and 1048576 bytes", .{});
         return error.InvalidConfigValue;
@@ -3329,4 +3343,30 @@ test "validate proxy stream buffer size rejects zero and oversized buffers" {
     try validateProxyStreamBufferSize(1024 * 1024);
     try std.testing.expectError(error.InvalidConfigValue, validateProxyStreamBufferSize(0));
     try std.testing.expectError(error.InvalidConfigValue, validateProxyStreamBufferSize(1024 * 1024 + 1));
+}
+
+test "proxy buffer limits validate low high hard ordering" {
+    try (http.proxy_buffer_account.Limits{
+        .per_stream_low_watermark = 256 * 1024,
+        .per_stream_high_watermark = 768 * 1024,
+        .per_stream_hard_limit = 1024 * 1024,
+        .per_origin_hard_limit = 0,
+        .global_hard_limit = 0,
+    }).validate();
+
+    try std.testing.expectError(error.InvalidBufferLimits, (http.proxy_buffer_account.Limits{
+        .per_stream_low_watermark = 768 * 1024,
+        .per_stream_high_watermark = 256 * 1024,
+        .per_stream_hard_limit = 1024 * 1024,
+        .per_origin_hard_limit = 0,
+        .global_hard_limit = 0,
+    }).validate());
+
+    try std.testing.expectError(error.InvalidBufferLimits, (http.proxy_buffer_account.Limits{
+        .per_stream_low_watermark = 256 * 1024,
+        .per_stream_high_watermark = 768 * 1024,
+        .per_stream_hard_limit = 1024 * 1024,
+        .per_origin_hard_limit = 512 * 1024,
+        .global_hard_limit = 0,
+    }).validate());
 }

--- a/src/edge_config.zig
+++ b/src/edge_config.zig
@@ -2659,6 +2659,10 @@ pub fn validate(cfg: *const EdgeConfig) !void {
         std.log.err("config validation failed: TARDIGRADE_PROXY_STREAM_BUFFER_SIZE must be between 1 and 1048576 bytes", .{});
         return error.InvalidConfigValue;
     };
+    validateProxyBufferLimitsCoverRelayAllocations(cfg.proxy_buffer_limits, cfg.proxy_stream_buffer_size) catch {
+        std.log.err("config validation failed: TARDIGRADE_PROXY_BUFFER_PER_STREAM_HARD_LIMIT_BYTES must be at least the effective streaming relay allocation", .{});
+        return error.InvalidConfigValue;
+    };
 
     // Timeout relationship sanity checks — warn only, these are not hard errors
     // because operators may have intentional unusual configurations.
@@ -2706,6 +2710,11 @@ fn validateBufferedUpstreamResponseLimit(limit: usize) !void {
 
 fn validateProxyStreamBufferSize(size: usize) !void {
     if (size == 0 or size > 1024 * 1024) return error.InvalidConfigValue;
+}
+
+fn validateProxyBufferLimitsCoverRelayAllocations(limits: http.proxy_buffer_account.Limits, proxy_stream_buffer_size: usize) !void {
+    const effective_relay_bytes = @max(proxy_stream_buffer_size, 16 * 1024);
+    if (limits.per_stream_hard_limit < effective_relay_bytes) return error.InvalidConfigValue;
 }
 
 /// Emit log warnings for configurations that are valid but operationally risky.
@@ -3343,6 +3352,17 @@ test "validate proxy stream buffer size rejects zero and oversized buffers" {
     try validateProxyStreamBufferSize(1024 * 1024);
     try std.testing.expectError(error.InvalidConfigValue, validateProxyStreamBufferSize(0));
     try std.testing.expectError(error.InvalidConfigValue, validateProxyStreamBufferSize(1024 * 1024 + 1));
+}
+
+test "proxy buffer hard limit covers effective streaming relay allocation" {
+    const limits = http.proxy_buffer_account.Limits{
+        .per_stream_low_watermark = 1024,
+        .per_stream_high_watermark = 2048,
+        .per_stream_hard_limit = 4096,
+        .per_origin_hard_limit = 0,
+        .global_hard_limit = 0,
+    };
+    try std.testing.expectError(error.InvalidConfigValue, validateProxyBufferLimitsCoverRelayAllocations(limits, 16 * 1024));
 }
 
 test "proxy buffer limits validate low high hard ordering" {

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -110,6 +110,7 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
         .active_mux_subscriptions = 0,
         .connection_memory_estimate_bytes = if (cfg.max_connection_memory_bytes > 0) cfg.max_connection_memory_bytes else MAX_REQUEST_SIZE,
         .max_total_connection_memory_bytes = cfg.max_total_connection_memory_bytes,
+        .proxy_buffer_limits = cfg.proxy_buffer_limits,
         .upstream_rr_index = 0,
         .upstream_backup_rr_index = 0,
         .lb_random_state = 0x9e3779b97f4a7c15 ^ @as(u64, @intCast(http.event_loop.monotonicMs())),

--- a/src/gateway_proxy.zig
+++ b/src/gateway_proxy.zig
@@ -770,12 +770,16 @@ fn streamViaH2Pool(
                 if (streaming_body) |sb| {
                     var sent: usize = @min(sb.initial_bytes.len, sb.content_length);
                     if (sent > 0) {
+                        var initial_reservation = ProxyBufferReservation.init(.downstream_to_upstream, proxy_buffer_limits, proxy_buffer_observer);
+                        try initial_reservation.reserve(sent);
                         conn.writeStreamingRequestBody(stream, sb.initial_bytes[0..sent], sent == sb.content_length) catch |err| {
+                            initial_reservation.releaseAll();
                             conn.finishStreaming(stream);
                             if (!conn.healthy()) h2_pool.evict(key, conn);
                             h2_pool.release(conn);
                             return err;
                         };
+                        initial_reservation.releaseAll();
                     }
                     while (sent < sb.content_length) {
                         if (cancelStopped(cancel_token)) {
@@ -869,6 +873,7 @@ fn streamViaH2Pool(
                             h2_pool.release(conn);
                             return error.ClientAborted;
                         };
+                        conn.acknowledgeStreamingBody(stream, n);
                         body_bytes += n;
                     }
                     if (!aborted) {
@@ -1676,9 +1681,9 @@ fn sendStreamingProxyRequest(
     if (streaming_body) |sb| {
         var relay: [16 * 1024]u8 = undefined;
         var upload_reservation = ProxyBufferReservation.init(.downstream_to_upstream, proxy_buffer_limits, proxy_buffer_observer);
-        try upload_reservation.reserve(relay.len);
-        defer upload_reservation.releaseAll();
         var sent: usize = @min(sb.initial_bytes.len, sb.content_length);
+        try upload_reservation.reserve(@max(relay.len, sent));
+        defer upload_reservation.releaseAll();
         if (sent > 0) try transport.writeAll(sb.initial_bytes[0..sent]);
         while (sent < sb.content_length) {
             if (cancelStopped(cancel_token)) return error.RequestCancelled;
@@ -1745,6 +1750,12 @@ fn streamProxyOverTransport(
 
     const reason = gpres.upstreamReasonPhrase(@enumFromInt(head.status_code));
     const body_allowed = gpres.responseBodyAllowed(method, head.status_code);
+    var response_reservation: ?ProxyBufferReservation = null;
+    if (body_allowed) {
+        response_reservation = ProxyBufferReservation.init(.upstream_to_downstream, proxy_buffer_limits, proxy_buffer_observer);
+        try response_reservation.?.reserve(read_buf.len);
+    }
+    defer if (response_reservation) |*reservation| reservation.releaseAll();
 
     gpres.writeStreamedUpstreamResponseHeadFromHeaders(
         downstream_writer,
@@ -1762,9 +1773,6 @@ fn streamProxyOverTransport(
     var aborted = false;
     var reusable = head.http_1_1 and !head.connection_close;
     if (body_allowed) {
-        var response_reservation = ProxyBufferReservation.init(.upstream_to_downstream, proxy_buffer_limits, proxy_buffer_observer);
-        try response_reservation.reserve(read_buf.len);
-        defer response_reservation.releaseAll();
         const outcome = try relayUpstreamBody(&rb, transport, fd, read_deadline_ms, head.framing, downstream_writer, cancel_token);
         body_bytes = outcome.body_bytes;
         aborted = outcome.aborted;

--- a/src/gateway_proxy.zig
+++ b/src/gateway_proxy.zig
@@ -15,6 +15,7 @@ const gph = @import("gateway_proxy_headers.zig");
 const gpres = @import("gateway_proxy_response.zig");
 const gpt = @import("gateway_proxy_target.zig");
 const gconn = @import("gateway_connection.zig");
+const proxy_buffer_account = http.proxy_buffer_account;
 
 // Compatibility re-exports of the split-out proxy helper APIs (headers /
 // response / target modules) so existing callers that import this module keep
@@ -99,6 +100,55 @@ pub const BufferedUpstreamResponse = struct {
 pub const StreamingRequestBody = struct {
     content_length: usize,
     initial_bytes: []const u8 = &.{},
+};
+
+const ProxyBufferReservation = struct {
+    account: proxy_buffer_account.Account,
+    observer: proxy_buffer_account.Observer,
+    active: bool = false,
+
+    fn init(
+        direction: proxy_buffer_account.Direction,
+        limits: proxy_buffer_account.Limits,
+        observer: proxy_buffer_account.Observer,
+    ) ProxyBufferReservation {
+        return .{
+            .account = proxy_buffer_account.Account.init(direction, .stream, limits),
+            .observer = observer,
+        };
+    }
+
+    fn reserve(self: *ProxyBufferReservation, bytes: usize) !void {
+        const before = self.account.snapshot();
+        self.account.reserve(bytes) catch |err| {
+            const after = self.account.snapshot();
+            if (after.limit_exceeded_events > before.limit_exceeded_events) {
+                self.observer.recordReservation(self.account.direction, 0, false, true);
+            }
+            return err;
+        };
+        const after = self.account.snapshot();
+        self.observer.recordReservation(
+            self.account.direction,
+            bytes,
+            after.high_watermark_events > before.high_watermark_events,
+            after.limit_exceeded_events > before.limit_exceeded_events,
+        );
+        self.active = true;
+    }
+
+    fn release(self: *ProxyBufferReservation, bytes: usize) void {
+        if (!self.active) return;
+        self.account.release(bytes) catch unreachable;
+        self.observer.releaseReservation(self.account.direction, bytes);
+        self.active = self.account.snapshot().current != 0;
+    }
+
+    fn releaseAll(self: *ProxyBufferReservation) void {
+        const current = self.account.snapshot().current;
+        if (current == 0) return;
+        self.release(current);
+    }
 };
 
 pub const StreamingProxyResult = struct {
@@ -645,6 +695,8 @@ fn streamViaH2Pool(
     connect_timeout_ms: u32,
     read_deadline_ms: u32,
     cancel_token: ?*const CancellationToken,
+    proxy_buffer_limits: proxy_buffer_account.Limits,
+    proxy_buffer_observer: proxy_buffer_account.Observer,
 ) !StreamingProxyResult {
     const deadline_ms: u32 = if (read_deadline_ms > 0)
         read_deadline_ms
@@ -670,7 +722,7 @@ fn streamViaH2Pool(
                 if (h1_pool) |p| p.recordProtocol(false);
                 const start_ms = http.event_loop.monotonicMs();
                 var wrote_downstream = false;
-                const res = try streamProxyOverTransport(allocator, tls_ptr, tls_ptr.fd, read_buf, uri, method, extra_headers, buffered_body, streaming_body, downstream_conn, downstream_writer, security, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, &wrote_downstream);
+                const res = try streamProxyOverTransport(allocator, tls_ptr, tls_ptr.fd, read_buf, uri, method, extra_headers, buffered_body, streaming_body, downstream_conn, downstream_writer, security, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, &wrote_downstream, proxy_buffer_limits, proxy_buffer_observer);
                 if (h1_pool) |p| p.recordRequestLatency(false, http.event_loop.monotonicMs() - start_ms);
                 return res.result;
             },
@@ -701,6 +753,8 @@ fn streamViaH2Pool(
                     .headers = extra_headers,
                     .body = buffered_body,
                     .body_mode = if (streaming_body == null) .complete else .streaming,
+                    .proxy_buffer_limits = proxy_buffer_limits,
+                    .proxy_buffer_observer = proxy_buffer_observer,
                 }) catch |err| {
                     // Nothing has reached the client yet: evict the dead
                     // connection so new requests do not pick it, and retry
@@ -740,12 +794,16 @@ fn streamViaH2Pool(
                             h2_pool.release(conn);
                             return error.ClientAborted;
                         }
+                        var upload_reservation = ProxyBufferReservation.init(.downstream_to_upstream, proxy_buffer_limits, proxy_buffer_observer);
+                        try upload_reservation.reserve(n);
                         conn.writeStreamingRequestBody(stream, read_buf[0..n], sent + n == sb.content_length) catch |err| {
+                            upload_reservation.releaseAll();
                             conn.finishStreaming(stream);
                             if (!conn.healthy()) h2_pool.evict(key, conn);
                             h2_pool.release(conn);
                             return err;
                         };
+                        upload_reservation.releaseAll();
                         sent += n;
                     }
                     if (sb.content_length == 0) {
@@ -1583,6 +1641,8 @@ fn sendStreamingProxyRequest(
     streaming_body: ?StreamingRequestBody,
     downstream_conn: anytype,
     cancel_token: ?*const CancellationToken,
+    proxy_buffer_limits: proxy_buffer_account.Limits,
+    proxy_buffer_observer: proxy_buffer_account.Observer,
 ) !void {
     var req_aw: std.Io.Writer.Allocating = .init(allocator);
     defer req_aw.deinit();
@@ -1615,6 +1675,9 @@ fn sendStreamingProxyRequest(
 
     if (streaming_body) |sb| {
         var relay: [16 * 1024]u8 = undefined;
+        var upload_reservation = ProxyBufferReservation.init(.downstream_to_upstream, proxy_buffer_limits, proxy_buffer_observer);
+        try upload_reservation.reserve(relay.len);
+        defer upload_reservation.releaseAll();
         var sent: usize = @min(sb.initial_bytes.len, sb.content_length);
         if (sent > 0) try transport.writeAll(sb.initial_bytes[0..sent]);
         while (sent < sb.content_length) {
@@ -1654,9 +1717,23 @@ fn streamProxyOverTransport(
     read_deadline_ms: u32,
     cancel_token: ?*const CancellationToken,
     wrote_downstream: *bool,
+    proxy_buffer_limits: proxy_buffer_account.Limits,
+    proxy_buffer_observer: proxy_buffer_account.Observer,
 ) !struct { result: StreamingProxyResult, reusable: bool } {
     if (connect_timeout_ms > 0) setSocketTimeoutMs(fd, connect_timeout_ms, connect_timeout_ms) catch {};
-    try sendStreamingProxyRequest(allocator, transport, uri, method, extra_headers, buffered_body, streaming_body, downstream_conn, cancel_token);
+    try sendStreamingProxyRequest(
+        allocator,
+        transport,
+        uri,
+        method,
+        extra_headers,
+        buffered_body,
+        streaming_body,
+        downstream_conn,
+        cancel_token,
+        proxy_buffer_limits,
+        proxy_buffer_observer,
+    );
     if (read_deadline_ms > 0) setSocketRecvTimeoutMs(fd, read_deadline_ms) catch {};
 
     const ttfb_start_ms = http.event_loop.monotonicMs();
@@ -1685,6 +1762,9 @@ fn streamProxyOverTransport(
     var aborted = false;
     var reusable = head.http_1_1 and !head.connection_close;
     if (body_allowed) {
+        var response_reservation = ProxyBufferReservation.init(.upstream_to_downstream, proxy_buffer_limits, proxy_buffer_observer);
+        try response_reservation.reserve(read_buf.len);
+        defer response_reservation.releaseAll();
         const outcome = try relayUpstreamBody(&rb, transport, fd, read_deadline_ms, head.framing, downstream_writer, cancel_token);
         body_bytes = outcome.body_bytes;
         aborted = outcome.aborted;
@@ -1736,6 +1816,7 @@ pub fn executeStreamingHttpProxyRequest(
     security: *const http.security_headers.SecurityHeaders,
     sticky_set_cookie: ?[]const u8,
     cancel_token: ?*const CancellationToken,
+    proxy_buffer_observer: proxy_buffer_account.Observer,
     pool: ?*http.upstream_pool.UpstreamPool,
     /// Optional per-origin HTTP/2 multiplexing pool (#145).
     h2_pool: ?*http.upstream_h2.H2ConnPool,
@@ -1802,7 +1883,7 @@ pub fn executeStreamingHttpProxyRequest(
                 o.offer_h2 = true;
                 break :blk o;
             } else null;
-            return streamViaH2Pool(allocator, hp, pool, host, port, h2_opts, uri, method, extra_headers.items, buffered_body, streaming_body, read_buf, downstream_conn, downstream_writer, security, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token);
+            return streamViaH2Pool(allocator, hp, pool, host, port, h2_opts, uri, method, extra_headers.items, buffered_body, streaming_body, read_buf, downstream_conn, downstream_writer, security, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, cfg.proxy_buffer_limits, proxy_buffer_observer);
         }
         if (streaming_body != null) {
             if (pool) |p| p.recordH2StreamingUploadFallback();
@@ -1871,9 +1952,9 @@ pub fn executeStreamingHttpProxyRequest(
         const exchange_start_ms = http.event_loop.monotonicMs();
         const fd = conn.stream.handle;
         const res = (if (conn.tls) |tls|
-            streamProxyOverTransport(allocator, tls, fd, read_buf, uri, method, extra_headers.items, buffered_body, streaming_body, downstream_conn, downstream_writer, security, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, &wrote_downstream)
+            streamProxyOverTransport(allocator, tls, fd, read_buf, uri, method, extra_headers.items, buffered_body, streaming_body, downstream_conn, downstream_writer, security, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, &wrote_downstream, cfg.proxy_buffer_limits, proxy_buffer_observer)
         else
-            streamProxyOverTransport(allocator, compat.netStreamFromFd(fd), fd, read_buf, uri, method, extra_headers.items, buffered_body, streaming_body, downstream_conn, downstream_writer, security, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, &wrote_downstream)) catch |err| {
+            streamProxyOverTransport(allocator, compat.netStreamFromFd(fd), fd, read_buf, uri, method, extra_headers.items, buffered_body, streaming_body, downstream_conn, downstream_writer, security, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, &wrote_downstream, cfg.proxy_buffer_limits, proxy_buffer_observer)) catch |err| {
             // Tear down the connection (release handles active-- and close).
             if (active_pool) |p| {
                 p.release(key, conn, false, http.event_loop.monotonicMs());

--- a/src/gateway_proxy.zig
+++ b/src/gateway_proxy.zig
@@ -771,7 +771,11 @@ fn streamViaH2Pool(
                     var sent: usize = @min(sb.initial_bytes.len, sb.content_length);
                     if (sent > 0) {
                         var initial_reservation = ProxyBufferReservation.init(.downstream_to_upstream, proxy_buffer_limits, proxy_buffer_observer);
-                        try initial_reservation.reserve(sent);
+                        initial_reservation.reserve(sent) catch |err| {
+                            conn.finishStreaming(stream);
+                            h2_pool.release(conn);
+                            return err;
+                        };
                         conn.writeStreamingRequestBody(stream, sb.initial_bytes[0..sent], sent == sb.content_length) catch |err| {
                             initial_reservation.releaseAll();
                             conn.finishStreaming(stream);
@@ -799,7 +803,11 @@ fn streamViaH2Pool(
                             return error.ClientAborted;
                         }
                         var upload_reservation = ProxyBufferReservation.init(.downstream_to_upstream, proxy_buffer_limits, proxy_buffer_observer);
-                        try upload_reservation.reserve(n);
+                        upload_reservation.reserve(n) catch |err| {
+                            conn.finishStreaming(stream);
+                            h2_pool.release(conn);
+                            return err;
+                        };
                         conn.writeStreamingRequestBody(stream, read_buf[0..n], sent + n == sb.content_length) catch |err| {
                             upload_reservation.releaseAll();
                             conn.finishStreaming(stream);
@@ -1682,9 +1690,16 @@ fn sendStreamingProxyRequest(
         var relay: [16 * 1024]u8 = undefined;
         var upload_reservation = ProxyBufferReservation.init(.downstream_to_upstream, proxy_buffer_limits, proxy_buffer_observer);
         var sent: usize = @min(sb.initial_bytes.len, sb.content_length);
-        try upload_reservation.reserve(@max(relay.len, sent));
+        try upload_reservation.reserve(relay.len);
         defer upload_reservation.releaseAll();
-        if (sent > 0) try transport.writeAll(sb.initial_bytes[0..sent]);
+        if (sent > 0) {
+            try upload_reservation.reserve(sent);
+            transport.writeAll(sb.initial_bytes[0..sent]) catch |err| {
+                upload_reservation.release(sent);
+                return err;
+            };
+            upload_reservation.release(sent);
+        }
         while (sent < sb.content_length) {
             if (cancelStopped(cancel_token)) return error.RequestCancelled;
             const want = @min(relay.len, sb.content_length - sent);

--- a/src/gateway_proxy_runtime.zig
+++ b/src/gateway_proxy_runtime.zig
@@ -522,16 +522,7 @@ pub fn handleLocationProxyPass(
     const fallback_reason: StreamingFallbackReason = switch (streamingEligibilityForDataPlaneProxyRequest(cfg, matched_block, &resolved, upstream_url.value, max_attempts)) {
         .stream => {
             state.recordUpstreamAttemptStart(selection.base_url);
-            const relay_buffer_bytes = @max(cfg.proxy_stream_buffer_size, 16 * 1024);
-            state.metricsRecordProxyBufferBytes(.upstream_to_downstream, .stream, relay_buffer_bytes);
-            state.metricsRecordProxyBufferBytes(.upstream_to_downstream, .global, relay_buffer_bytes);
-            if (relay_buffer_bytes >= cfg.proxy_buffer_limits.per_stream_high_watermark) {
-                state.metricsRecordProxyBufferHighWatermark(.upstream_to_downstream, .stream);
-            }
-            defer {
-                state.metricsReleaseProxyBufferBytes(.upstream_to_downstream, .stream, relay_buffer_bytes);
-                state.metricsReleaseProxyBufferBytes(.upstream_to_downstream, .global, relay_buffer_bytes);
-            }
+            const proxy_buffer_observer = state.proxyBufferObserver();
             const streamed = executeStreamingHttpProxyRequest(
                 allocator,
                 cfg,
@@ -553,6 +544,7 @@ pub fn handleLocationProxyPass(
                 &state.security_headers,
                 sticky_set_cookie,
                 if (ctx.lifecycle) |lc| &lc.token else null,
+                proxy_buffer_observer,
                 &state.upstream_pool,
                 &state.h2_pool,
             ) catch |err| {

--- a/src/gateway_proxy_runtime.zig
+++ b/src/gateway_proxy_runtime.zig
@@ -522,6 +522,26 @@ pub fn handleLocationProxyPass(
     const fallback_reason: StreamingFallbackReason = switch (streamingEligibilityForDataPlaneProxyRequest(cfg, matched_block, &resolved, upstream_url.value, max_attempts)) {
         .stream => {
             state.recordUpstreamAttemptStart(selection.base_url);
+            const relay_buffer_bytes = @max(cfg.proxy_stream_buffer_size, 16 * 1024);
+            state.metricsRecordProxyBufferBytes(.upstream_to_downstream, .stream, relay_buffer_bytes);
+            state.metricsRecordProxyBufferBytes(.upstream_to_downstream, .global, relay_buffer_bytes);
+            const account_upload_relay = streaming_request_body != null;
+            if (account_upload_relay) {
+                state.metricsRecordProxyBufferBytes(.downstream_to_upstream, .stream, relay_buffer_bytes);
+                state.metricsRecordProxyBufferBytes(.downstream_to_upstream, .global, relay_buffer_bytes);
+            }
+            if (relay_buffer_bytes >= cfg.proxy_buffer_limits.per_stream_high_watermark) {
+                state.metricsRecordProxyBufferHighWatermark(.upstream_to_downstream, .stream);
+                if (account_upload_relay) state.metricsRecordProxyBufferHighWatermark(.downstream_to_upstream, .stream);
+            }
+            defer {
+                state.metricsReleaseProxyBufferBytes(.upstream_to_downstream, .stream, relay_buffer_bytes);
+                state.metricsReleaseProxyBufferBytes(.upstream_to_downstream, .global, relay_buffer_bytes);
+                if (account_upload_relay) {
+                    state.metricsReleaseProxyBufferBytes(.downstream_to_upstream, .stream, relay_buffer_bytes);
+                    state.metricsReleaseProxyBufferBytes(.downstream_to_upstream, .global, relay_buffer_bytes);
+                }
+            }
             const streamed = executeStreamingHttpProxyRequest(
                 allocator,
                 cfg,

--- a/src/gateway_proxy_runtime.zig
+++ b/src/gateway_proxy_runtime.zig
@@ -525,22 +525,12 @@ pub fn handleLocationProxyPass(
             const relay_buffer_bytes = @max(cfg.proxy_stream_buffer_size, 16 * 1024);
             state.metricsRecordProxyBufferBytes(.upstream_to_downstream, .stream, relay_buffer_bytes);
             state.metricsRecordProxyBufferBytes(.upstream_to_downstream, .global, relay_buffer_bytes);
-            const account_upload_relay = streaming_request_body != null;
-            if (account_upload_relay) {
-                state.metricsRecordProxyBufferBytes(.downstream_to_upstream, .stream, relay_buffer_bytes);
-                state.metricsRecordProxyBufferBytes(.downstream_to_upstream, .global, relay_buffer_bytes);
-            }
             if (relay_buffer_bytes >= cfg.proxy_buffer_limits.per_stream_high_watermark) {
                 state.metricsRecordProxyBufferHighWatermark(.upstream_to_downstream, .stream);
-                if (account_upload_relay) state.metricsRecordProxyBufferHighWatermark(.downstream_to_upstream, .stream);
             }
             defer {
                 state.metricsReleaseProxyBufferBytes(.upstream_to_downstream, .stream, relay_buffer_bytes);
                 state.metricsReleaseProxyBufferBytes(.upstream_to_downstream, .global, relay_buffer_bytes);
-                if (account_upload_relay) {
-                    state.metricsReleaseProxyBufferBytes(.downstream_to_upstream, .stream, relay_buffer_bytes);
-                    state.metricsReleaseProxyBufferBytes(.downstream_to_upstream, .global, relay_buffer_bytes);
-                }
             }
             const streamed = executeStreamingHttpProxyRequest(
                 allocator,

--- a/src/gateway_shutdown.zig
+++ b/src/gateway_shutdown.zig
@@ -102,7 +102,7 @@ pub fn hotReloadConfig(
     state.logger.info(null, "configuration hot-reload applied", .{});
 }
 
-fn applyReloadedRuntimeConfig(cfg: *const edge_config.EdgeConfig, state: *GatewayState) void {
+pub fn applyReloadedRuntimeConfig(cfg: *const edge_config.EdgeConfig, state: *GatewayState) void {
     // Warn when restart-only path/URL fields differ; they are NOT rebound here.
     if (!std.mem.eql(u8, state.session_store_path, cfg.session_store_path))
         state.logger.warn(null, "TARDIGRADE_SESSION_STORE_PATH changed on reload; restart required for new path to take effect (active: '{s}', new: '{s}')", .{ state.session_store_path, cfg.session_store_path });
@@ -177,6 +177,66 @@ pub fn runDnsDiscoveryRefresh(_: *const edge_config.EdgeConfig, state: *GatewayS
     if (state.dns_discovery.needsRefresh(now_ms)) {
         state.dns_discovery.refresh(now_ms);
     }
+}
+
+test "applyReloadedRuntimeConfig updates exported proxy buffer limits" {
+    const allocator = std.testing.allocator;
+    var cfg = try edge_config.loadFromEnv(allocator);
+    defer cfg.deinit(allocator);
+    cfg.proxy_buffer_limits = .{
+        .per_stream_low_watermark = 128 * 1024,
+        .per_stream_high_watermark = 384 * 1024,
+        .per_stream_hard_limit = 512 * 1024,
+        .per_origin_hard_limit = 2 * 1024 * 1024,
+        .global_hard_limit = 4 * 1024 * 1024,
+    };
+
+    var state: GatewayState = undefined;
+    state.allocator = allocator;
+    state.rate_limiter_mutex = .{};
+    state.rate_limiter = null;
+    state.proxy_cache_mutex = .{};
+    state.proxy_cache_store = null;
+    state.proxy_cache_path = "";
+    state.proxy_cache_ttl_seconds = 0;
+    state.runtime_mutex = .{};
+    state.metrics_mutex = .{};
+    state.metrics = http.metrics.Metrics.init();
+    state.add_headers = &.{};
+    state.http3_alt_svc = null;
+    state.hsts_value = "";
+    state.security_headers = http.security_headers.SecurityHeaders.api;
+    state.max_connections_per_ip = 0;
+    state.max_active_connections = 0;
+    state.max_in_flight_requests = 0;
+    state.max_total_connection_memory_bytes = 0;
+    state.connection_memory_estimate_bytes = MAX_REQUEST_SIZE;
+    state.proxy_buffer_limits = .{
+        .per_stream_low_watermark = 256 * 1024,
+        .per_stream_high_watermark = 768 * 1024,
+        .per_stream_hard_limit = 1024 * 1024,
+        .per_origin_hard_limit = 0,
+        .global_hard_limit = 0,
+    };
+    state.compression_config = .{};
+    state.logger = http.logger.Logger.init(.info, "test");
+    state.upstream_pool = http.upstream_pool.UpstreamPool.init(allocator, .{});
+    defer state.upstream_pool.deinit();
+    state.h2_pool = http.upstream_h2.H2ConnPool.init(allocator, .{});
+    defer state.h2_pool.deinit();
+    state.mux_subscriptions_by_device = std.StringHashMap(usize).init(allocator);
+    defer state.mux_subscriptions_by_device.deinit();
+    state.session_store_path = "";
+    state.approval_store_path = "";
+    state.approval_escalation_webhook = "";
+    state.transcript_store_path = "";
+
+    applyReloadedRuntimeConfig(&cfg, &state);
+
+    const prom = try state.metricsToPrometheus(allocator);
+    defer allocator.free(prom);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_config_limit_bytes{direction=\"upstream_to_downstream\",scope=\"stream\",limit=\"high\"} 393216\n") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_config_limit_bytes{direction=\"upstream_to_downstream\",scope=\"global\",limit=\"hard\"} 4194304\n") != null);
 }
 
 /// Context passed to the background health-probe thread.

--- a/src/gateway_shutdown.zig
+++ b/src/gateway_shutdown.zig
@@ -150,6 +150,7 @@ fn applyReloadedRuntimeConfig(cfg: *const edge_config.EdgeConfig, state: *Gatewa
     state.max_in_flight_requests = cfg.max_in_flight_requests;
     state.max_total_connection_memory_bytes = cfg.max_total_connection_memory_bytes;
     state.connection_memory_estimate_bytes = if (cfg.max_connection_memory_bytes > 0) cfg.max_connection_memory_bytes else MAX_REQUEST_SIZE;
+    state.proxy_buffer_limits = cfg.proxy_buffer_limits;
     state.compression_config = .{
         .enabled = cfg.compression_enabled,
         .min_size = cfg.compression_min_size,

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -1416,7 +1416,7 @@ pub const GatewayState = struct {
     pub fn metricsReleaseProxyBufferedBytes(self: *GatewayState, buffered_bytes: usize) void {
         self.metrics_mutex.lock();
         defer self.metrics_mutex.unlock();
-        self.metrics.releaseProxyBufferedBytes(buffered_bytes);
+        self.metrics.releaseProxyBufferedBytes(buffered_bytes) catch unreachable;
     }
 
     pub fn metricsRecordProxyClientAbort(self: *GatewayState) void {
@@ -1446,7 +1446,7 @@ pub const GatewayState = struct {
     pub fn metricsReleaseProxyBufferBytes(self: *GatewayState, direction: http.proxy_buffer_account.Direction, scope: http.proxy_buffer_account.Scope, bytes: usize) void {
         self.metrics_mutex.lock();
         defer self.metrics_mutex.unlock();
-        self.metrics.releaseProxyBufferBytes(direction, scope, bytes);
+        self.metrics.releaseProxyBufferBytes(direction, scope, bytes) catch unreachable;
     }
 
     pub fn metricsRecordProxyBufferHighWatermark(self: *GatewayState, direction: http.proxy_buffer_account.Direction, scope: http.proxy_buffer_account.Scope) void {
@@ -1673,7 +1673,10 @@ pub const GatewayState = struct {
         var combined = std.array_list.Managed(u8).init(allocator);
         errdefer combined.deinit();
         try combined.appendSlice(base);
-        try self.appendProxyBufferConfigPrometheus(&combined);
+        self.runtime_mutex.lock();
+        const proxy_buffer_limits = self.proxy_buffer_limits;
+        self.runtime_mutex.unlock();
+        try appendProxyBufferConfigPrometheus(&combined, proxy_buffer_limits);
         if (mux_snapshot.device_counts.len > 0) {
             try combined.appendSlice(
                 \\# HELP tardigrade_mux_device_channels Current active mux channels by device
@@ -1690,8 +1693,7 @@ pub const GatewayState = struct {
         return combined.toOwnedSlice();
     }
 
-    fn appendProxyBufferConfigPrometheus(self: *GatewayState, out: *std.array_list.Managed(u8)) !void {
-        const limits = self.proxy_buffer_limits;
+    fn appendProxyBufferConfigPrometheus(out: *std.array_list.Managed(u8), limits: http.proxy_buffer_account.Limits) !void {
         try out.appendSlice(
             \\# HELP tardigrade_buffer_config_limit_bytes Configured proxy buffer accounting limits in bytes
             \\# TYPE tardigrade_buffer_config_limit_bytes gauge
@@ -3095,6 +3097,7 @@ fn initSlotTestState(gs: *GatewayState, allocator: std.mem.Allocator) void {
     gs.allocator = allocator;
     gs.connection_mutex = .{};
     gs.metrics_mutex = .{};
+    gs.runtime_mutex = .{};
     gs.metrics = http.metrics.Metrics.init();
     gs.active_connections_total = 0;
     gs.max_active_connections = 0;
@@ -3361,6 +3364,7 @@ fn initMetricsJsonTestState(gs: *GatewayState, allocator: std.mem.Allocator) voi
     gs.allocator = allocator;
     gs.connection_mutex = .{};
     gs.metrics_mutex = .{};
+    gs.runtime_mutex = .{};
     gs.metrics = http.metrics.Metrics.init();
     gs.mux_subscriptions_by_device = std.StringHashMap(usize).init(allocator);
     // metricsToJson/metricsToPrometheus overlay the upstream pool's live
@@ -3428,4 +3432,28 @@ test "served Prometheus metrics expose h2 streaming upload fallback counter" {
     try std.testing.expect(std.mem.find(u8, prom, "# TYPE tardigrade_upstream_h2_streaming_upload_fallback_total counter") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_upstream_h2_streaming_upload_fallback_total 1\n") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_config_limit_bytes{direction=\"upstream_to_downstream\",scope=\"stream\",limit=\"high\"} 786432\n") != null);
+}
+
+test "served Prometheus metrics reflect updated proxy buffer limit snapshot" {
+    var gs: GatewayState = undefined;
+    initMetricsJsonTestState(&gs, std.testing.allocator);
+    defer gs.h2_pool.deinit();
+    defer gs.upstream_pool.deinit();
+    defer gs.mux_subscriptions_by_device.deinit();
+
+    gs.runtime_mutex.lock();
+    gs.proxy_buffer_limits = .{
+        .per_stream_low_watermark = 128 * 1024,
+        .per_stream_high_watermark = 384 * 1024,
+        .per_stream_hard_limit = 512 * 1024,
+        .per_origin_hard_limit = 2 * 1024 * 1024,
+        .global_hard_limit = 4 * 1024 * 1024,
+    };
+    gs.runtime_mutex.unlock();
+
+    const prom = try gs.metricsToPrometheus(std.testing.allocator);
+    defer std.testing.allocator.free(prom);
+
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_config_limit_bytes{direction=\"upstream_to_downstream\",scope=\"stream\",limit=\"high\"} 393216\n") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_config_limit_bytes{direction=\"downstream_to_upstream\",scope=\"global\",limit=\"hard\"} 4194304\n") != null);
 }

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -1437,22 +1437,46 @@ pub const GatewayState = struct {
         self.metrics.recordProxyStreamingFallback(reason);
     }
 
-    pub fn metricsRecordProxyBufferBytes(self: *GatewayState, direction: http.proxy_buffer_account.Direction, scope: http.proxy_buffer_account.Scope, bytes: usize) void {
+    pub fn metricsRecordProxyBufferReservation(
+        self: *GatewayState,
+        direction: http.proxy_buffer_account.Direction,
+        bytes: usize,
+        high_watermark: bool,
+        limit_exceeded: bool,
+    ) void {
         self.metrics_mutex.lock();
         defer self.metrics_mutex.unlock();
-        self.metrics.recordProxyBufferBytes(direction, scope, bytes);
+        self.metrics.recordProxyBufferReservation(direction, bytes, high_watermark, limit_exceeded);
     }
 
-    pub fn metricsReleaseProxyBufferBytes(self: *GatewayState, direction: http.proxy_buffer_account.Direction, scope: http.proxy_buffer_account.Scope, bytes: usize) void {
+    pub fn metricsReleaseProxyBufferReservation(self: *GatewayState, direction: http.proxy_buffer_account.Direction, bytes: usize) void {
         self.metrics_mutex.lock();
         defer self.metrics_mutex.unlock();
-        self.metrics.releaseProxyBufferBytes(direction, scope, bytes) catch unreachable;
+        self.metrics.releaseProxyBufferReservation(direction, bytes) catch unreachable;
     }
 
-    pub fn metricsRecordProxyBufferHighWatermark(self: *GatewayState, direction: http.proxy_buffer_account.Direction, scope: http.proxy_buffer_account.Scope) void {
-        self.metrics_mutex.lock();
-        defer self.metrics_mutex.unlock();
-        self.metrics.recordProxyBufferHighWatermark(direction, scope);
+    pub fn proxyBufferObserver(self: *GatewayState) http.proxy_buffer_account.Observer {
+        return .{
+            .context = self,
+            .recordReservationFn = recordProxyBufferReservationObserved,
+            .releaseReservationFn = releaseProxyBufferReservationObserved,
+        };
+    }
+
+    fn recordProxyBufferReservationObserved(
+        context: *anyopaque,
+        direction: http.proxy_buffer_account.Direction,
+        bytes: usize,
+        high_watermark: bool,
+        limit_exceeded: bool,
+    ) void {
+        const self: *GatewayState = @ptrCast(@alignCast(context));
+        self.metricsRecordProxyBufferReservation(direction, bytes, high_watermark, limit_exceeded);
+    }
+
+    fn releaseProxyBufferReservationObserved(context: *anyopaque, direction: http.proxy_buffer_account.Direction, bytes: usize) void {
+        const self: *GatewayState = @ptrCast(@alignCast(context));
+        self.metricsReleaseProxyBufferReservation(direction, bytes);
     }
 
     pub fn metricsSetWorkerPoolStats(self: *GatewayState, active_jobs: usize, queued_jobs: usize, worker_threads: usize, queue_capacity: usize) void {

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -452,6 +452,7 @@ pub const GatewayState = struct {
     active_mux_subscriptions: usize, // runtime accounting [connection_mutex]
     connection_memory_estimate_bytes: usize, // cfg-derived; updated on reload [runtime_mutex]
     max_total_connection_memory_bytes: usize, // cfg snapshot; updated on reload [runtime_mutex]
+    proxy_buffer_limits: http.proxy_buffer_account.Limits, // cfg snapshot; updated on reload [runtime_mutex]
     upstream_rr_index: usize, // LB selection state [upstream_mutex]
     upstream_backup_rr_index: usize, // LB selection state [upstream_mutex]
     lb_random_state: u64, // LB selection state [upstream_mutex]
@@ -1436,6 +1437,24 @@ pub const GatewayState = struct {
         self.metrics.recordProxyStreamingFallback(reason);
     }
 
+    pub fn metricsRecordProxyBufferBytes(self: *GatewayState, direction: http.proxy_buffer_account.Direction, scope: http.proxy_buffer_account.Scope, bytes: usize) void {
+        self.metrics_mutex.lock();
+        defer self.metrics_mutex.unlock();
+        self.metrics.recordProxyBufferBytes(direction, scope, bytes);
+    }
+
+    pub fn metricsReleaseProxyBufferBytes(self: *GatewayState, direction: http.proxy_buffer_account.Direction, scope: http.proxy_buffer_account.Scope, bytes: usize) void {
+        self.metrics_mutex.lock();
+        defer self.metrics_mutex.unlock();
+        self.metrics.releaseProxyBufferBytes(direction, scope, bytes);
+    }
+
+    pub fn metricsRecordProxyBufferHighWatermark(self: *GatewayState, direction: http.proxy_buffer_account.Direction, scope: http.proxy_buffer_account.Scope) void {
+        self.metrics_mutex.lock();
+        defer self.metrics_mutex.unlock();
+        self.metrics.recordProxyBufferHighWatermark(direction, scope);
+    }
+
     pub fn metricsSetWorkerPoolStats(self: *GatewayState, active_jobs: usize, queued_jobs: usize, worker_threads: usize, queue_capacity: usize) void {
         self.metrics_mutex.lock();
         defer self.metrics_mutex.unlock();
@@ -1654,6 +1673,7 @@ pub const GatewayState = struct {
         var combined = std.array_list.Managed(u8).init(allocator);
         errdefer combined.deinit();
         try combined.appendSlice(base);
+        try self.appendProxyBufferConfigPrometheus(&combined);
         if (mux_snapshot.device_counts.len > 0) {
             try combined.appendSlice(
                 \\# HELP tardigrade_mux_device_channels Current active mux channels by device
@@ -1668,6 +1688,22 @@ pub const GatewayState = struct {
         }
         try self.appendUpstreamPoolPrometheus(&combined);
         return combined.toOwnedSlice();
+    }
+
+    fn appendProxyBufferConfigPrometheus(self: *GatewayState, out: *std.array_list.Managed(u8)) !void {
+        const limits = self.proxy_buffer_limits;
+        try out.appendSlice(
+            \\# HELP tardigrade_buffer_config_limit_bytes Configured proxy buffer accounting limits in bytes
+            \\# TYPE tardigrade_buffer_config_limit_bytes gauge
+            \\
+        );
+        inline for (.{ "downstream_to_upstream", "upstream_to_downstream" }) |direction| {
+            try out.print("tardigrade_buffer_config_limit_bytes{{direction=\"{s}\",scope=\"stream\",limit=\"low\"}} {d}\n", .{ direction, limits.per_stream_low_watermark });
+            try out.print("tardigrade_buffer_config_limit_bytes{{direction=\"{s}\",scope=\"stream\",limit=\"high\"}} {d}\n", .{ direction, limits.per_stream_high_watermark });
+            try out.print("tardigrade_buffer_config_limit_bytes{{direction=\"{s}\",scope=\"stream\",limit=\"hard\"}} {d}\n", .{ direction, limits.per_stream_hard_limit });
+            try out.print("tardigrade_buffer_config_limit_bytes{{direction=\"{s}\",scope=\"origin\",limit=\"hard\"}} {d}\n", .{ direction, limits.per_origin_hard_limit });
+            try out.print("tardigrade_buffer_config_limit_bytes{{direction=\"{s}\",scope=\"global\",limit=\"hard\"}} {d}\n", .{ direction, limits.global_hard_limit });
+        }
     }
 
     /// HOT PATH (proxy mode): taken once per proxied request for LB selection.
@@ -3067,6 +3103,13 @@ fn initSlotTestState(gs: *GatewayState, allocator: std.mem.Allocator) void {
     gs.in_flight_requests = std.atomic.Value(u32).init(0);
     gs.connection_memory_estimate_bytes = 0;
     gs.max_total_connection_memory_bytes = 0;
+    gs.proxy_buffer_limits = .{
+        .per_stream_low_watermark = 256 * 1024,
+        .per_stream_high_watermark = 768 * 1024,
+        .per_stream_hard_limit = 1024 * 1024,
+        .per_origin_hard_limit = 0,
+        .global_hard_limit = 0,
+    };
     gs.active_connections_by_ip = std.StringHashMap(u32).init(allocator);
     gs.active_fds = std.AutoHashMap(std.posix.fd_t, void).init(allocator);
     gs.fd_to_ip = std.AutoHashMap(std.posix.fd_t, []u8).init(allocator);
@@ -3324,6 +3367,13 @@ fn initMetricsJsonTestState(gs: *GatewayState, allocator: std.mem.Allocator) voi
     // counters, so the pool must be a valid (empty) instance here.
     gs.upstream_pool = http.upstream_pool.UpstreamPool.init(allocator, .{});
     gs.h2_pool = http.upstream_h2.H2ConnPool.init(allocator, .{});
+    gs.proxy_buffer_limits = .{
+        .per_stream_low_watermark = 256 * 1024,
+        .per_stream_high_watermark = 768 * 1024,
+        .per_stream_hard_limit = 1024 * 1024,
+        .per_origin_hard_limit = 0,
+        .global_hard_limit = 0,
+    };
 }
 
 test "served metrics JSON exposes every counter the canonical serializer does" {
@@ -3377,4 +3427,5 @@ test "served Prometheus metrics expose h2 streaming upload fallback counter" {
     try std.testing.expect(std.mem.find(u8, prom, "# HELP tardigrade_upstream_h2_streaming_upload_fallback_total Streaming upload requests that requested h2/h2c upstreams but fell back to h1 because the h2 pool was unavailable") != null);
     try std.testing.expect(std.mem.find(u8, prom, "# TYPE tardigrade_upstream_h2_streaming_upload_fallback_total counter") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_upstream_h2_streaming_upload_fallback_total 1\n") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_config_limit_bytes{direction=\"upstream_to_downstream\",scope=\"stream\",limit=\"high\"} 786432\n") != null);
 }

--- a/src/http.zig
+++ b/src/http.zig
@@ -45,6 +45,7 @@ pub const access_log = @import("http/access_log.zig");
 pub const event_loop = @import("http/event_loop.zig");
 pub const worker_pool = @import("http/worker_pool.zig");
 pub const buffer_pool = @import("http/buffer_pool.zig");
+pub const proxy_buffer_account = @import("http/proxy_buffer_account.zig");
 pub const keepalive_park = @import("http/keepalive_park.zig");
 pub const upstream_pool = @import("http/upstream_pool.zig");
 /// TLS termination backend selected by `-Dtls-profile` (#379): the OpenSSL

--- a/src/http/metrics.zig
+++ b/src/http/metrics.zig
@@ -324,8 +324,39 @@ pub const Metrics = struct {
         const bytes: u64 = @intCast(buffered_bytes);
         if (bytes > self.proxy_buffered_bytes_current) return error.BufferAccountingUnderflow;
         self.proxy_buffered_bytes_current -= bytes;
-        try self.releaseProxyBufferBytes(.upstream_to_downstream, .stream, buffered_bytes);
-        try self.releaseProxyBufferBytes(.upstream_to_downstream, .global, buffered_bytes);
+        try self.releaseProxyBufferReservation(.upstream_to_downstream, buffered_bytes);
+    }
+
+    pub fn recordProxyBufferReservation(
+        self: *Metrics,
+        direction: proxy_buffer_account.Direction,
+        bytes: usize,
+        high_watermark: bool,
+        limit_exceeded: bool,
+    ) void {
+        self.recordProxyBufferBytes(direction, .stream, bytes);
+        self.recordProxyBufferBytes(direction, .global, bytes);
+        if (high_watermark) self.recordProxyBufferHighWatermark(direction, .stream);
+        if (limit_exceeded) self.recordProxyBufferLimitExceeded(direction, .stream);
+    }
+
+    pub fn releaseProxyBufferReservation(self: *Metrics, direction: proxy_buffer_account.Direction, bytes: usize) !void {
+        const value: u64 = @intCast(bytes);
+        var stream_slot: *u64 = undefined;
+        var global_slot: *u64 = undefined;
+        switch (direction) {
+            .downstream_to_upstream => {
+                stream_slot = &self.proxy_buffer_downstream_to_upstream_stream_current;
+                global_slot = &self.proxy_buffer_downstream_to_upstream_global_current;
+            },
+            .upstream_to_downstream => {
+                stream_slot = &self.proxy_buffer_upstream_to_downstream_stream_current;
+                global_slot = &self.proxy_buffer_upstream_to_downstream_global_current;
+            },
+        }
+        if (value > stream_slot.* or value > global_slot.*) return error.BufferAccountingUnderflow;
+        stream_slot.* -= value;
+        global_slot.* -= value;
     }
 
     pub fn recordProxyBufferBytes(self: *Metrics, direction: proxy_buffer_account.Direction, scope: proxy_buffer_account.Scope, bytes: usize) void {
@@ -630,7 +661,7 @@ pub const Metrics = struct {
         });
 
         try out.print(
-            \\# HELP tardigrade_buffered_bytes_current Current proxy-owned body bytes by direction and accounting scope (buffered responses and HTTP/1 relay buffers in this PR)
+            \\# HELP tardigrade_buffered_bytes_current Current proxy-owned body bytes by direction and accounting scope
             \\# TYPE tardigrade_buffered_bytes_current gauge
             \\tardigrade_buffered_bytes_current{{direction="downstream_to_upstream",scope="stream"}} {d}
             \\tardigrade_buffered_bytes_current{{direction="downstream_to_upstream",scope="global"}} {d}
@@ -640,11 +671,11 @@ pub const Metrics = struct {
             \\# TYPE tardigrade_buffer_high_watermark_events_total counter
             \\tardigrade_buffer_high_watermark_events_total{{direction="downstream_to_upstream",scope="stream"}} {d}
             \\tardigrade_buffer_high_watermark_events_total{{direction="upstream_to_downstream",scope="stream"}} {d}
-            \\# HELP tardigrade_buffer_read_pauses_total Proxy reads paused by stalled buffer pressure side
+            \\# HELP tardigrade_buffer_read_pauses_total Reserved for future proxy reads paused by stalled buffer pressure side
             \\# TYPE tardigrade_buffer_read_pauses_total counter
             \\tardigrade_buffer_read_pauses_total{{side="downstream"}} {d}
             \\tardigrade_buffer_read_pauses_total{{side="upstream"}} {d}
-            \\# HELP tardigrade_buffer_read_resumes_total Proxy reads resumed after buffer pressure drops
+            \\# HELP tardigrade_buffer_read_resumes_total Reserved for future proxy reads resumed after buffer pressure drops
             \\# TYPE tardigrade_buffer_read_resumes_total counter
             \\tardigrade_buffer_read_resumes_total{{side="downstream"}} {d}
             \\tardigrade_buffer_read_resumes_total{{side="upstream"}} {d}

--- a/src/http/metrics.zig
+++ b/src/http/metrics.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const compat = @import("../zig_compat.zig");
+const proxy_buffer_account = @import("proxy_buffer_account.zig");
 
 /// Server-wide metrics counters.
 ///
@@ -30,6 +31,18 @@ pub const Metrics = struct {
     proxy_buffered_requests: u64,
     proxy_buffered_bytes_current: u64,
     proxy_buffered_bytes_total: u64,
+    proxy_buffer_downstream_to_upstream_stream_current: u64,
+    proxy_buffer_downstream_to_upstream_global_current: u64,
+    proxy_buffer_upstream_to_downstream_stream_current: u64,
+    proxy_buffer_upstream_to_downstream_global_current: u64,
+    proxy_buffer_high_watermark_downstream_to_upstream_stream: u64,
+    proxy_buffer_high_watermark_upstream_to_downstream_stream: u64,
+    proxy_buffer_limit_exceeded_downstream_to_upstream_stream: u64,
+    proxy_buffer_limit_exceeded_upstream_to_downstream_stream: u64,
+    proxy_buffer_read_pauses_downstream: u64,
+    proxy_buffer_read_pauses_upstream: u64,
+    proxy_buffer_read_resumes_downstream: u64,
+    proxy_buffer_read_resumes_upstream: u64,
     proxy_client_aborts: u64,
     proxy_upstream_aborts: u64,
     proxy_streaming_fallback_policy_disabled: u64,
@@ -137,6 +150,18 @@ pub const Metrics = struct {
             .proxy_buffered_requests = 0,
             .proxy_buffered_bytes_current = 0,
             .proxy_buffered_bytes_total = 0,
+            .proxy_buffer_downstream_to_upstream_stream_current = 0,
+            .proxy_buffer_downstream_to_upstream_global_current = 0,
+            .proxy_buffer_upstream_to_downstream_stream_current = 0,
+            .proxy_buffer_upstream_to_downstream_global_current = 0,
+            .proxy_buffer_high_watermark_downstream_to_upstream_stream = 0,
+            .proxy_buffer_high_watermark_upstream_to_downstream_stream = 0,
+            .proxy_buffer_limit_exceeded_downstream_to_upstream_stream = 0,
+            .proxy_buffer_limit_exceeded_upstream_to_downstream_stream = 0,
+            .proxy_buffer_read_pauses_downstream = 0,
+            .proxy_buffer_read_pauses_upstream = 0,
+            .proxy_buffer_read_resumes_downstream = 0,
+            .proxy_buffer_read_resumes_upstream = 0,
             .proxy_client_aborts = 0,
             .proxy_upstream_aborts = 0,
             .proxy_streaming_fallback_policy_disabled = 0,
@@ -290,12 +315,81 @@ pub const Metrics = struct {
         self.proxy_buffered_requests += 1;
         self.proxy_buffered_bytes_current += bytes;
         self.proxy_buffered_bytes_total += bytes;
+        self.recordProxyBufferBytes(.upstream_to_downstream, .stream, buffered_bytes);
+        self.recordProxyBufferBytes(.upstream_to_downstream, .global, buffered_bytes);
         self.recordProxyTtfbMs(ttfb_ms);
     }
 
     pub fn releaseProxyBufferedBytes(self: *Metrics, buffered_bytes: usize) void {
         const bytes: u64 = @intCast(buffered_bytes);
         self.proxy_buffered_bytes_current = if (bytes >= self.proxy_buffered_bytes_current) 0 else self.proxy_buffered_bytes_current - bytes;
+        self.releaseProxyBufferBytes(.upstream_to_downstream, .stream, buffered_bytes);
+        self.releaseProxyBufferBytes(.upstream_to_downstream, .global, buffered_bytes);
+    }
+
+    pub fn recordProxyBufferBytes(self: *Metrics, direction: proxy_buffer_account.Direction, scope: proxy_buffer_account.Scope, bytes: usize) void {
+        const value: u64 = @intCast(bytes);
+        switch (direction) {
+            .downstream_to_upstream => switch (scope) {
+                .stream => self.proxy_buffer_downstream_to_upstream_stream_current += value,
+                .global => self.proxy_buffer_downstream_to_upstream_global_current += value,
+                else => {},
+            },
+            .upstream_to_downstream => switch (scope) {
+                .stream => self.proxy_buffer_upstream_to_downstream_stream_current += value,
+                .global => self.proxy_buffer_upstream_to_downstream_global_current += value,
+                else => {},
+            },
+        }
+    }
+
+    pub fn releaseProxyBufferBytes(self: *Metrics, direction: proxy_buffer_account.Direction, scope: proxy_buffer_account.Scope, bytes: usize) void {
+        const value: u64 = @intCast(bytes);
+        const slot = switch (direction) {
+            .downstream_to_upstream => switch (scope) {
+                .stream => &self.proxy_buffer_downstream_to_upstream_stream_current,
+                .global => &self.proxy_buffer_downstream_to_upstream_global_current,
+                else => return,
+            },
+            .upstream_to_downstream => switch (scope) {
+                .stream => &self.proxy_buffer_upstream_to_downstream_stream_current,
+                .global => &self.proxy_buffer_upstream_to_downstream_global_current,
+                else => return,
+            },
+        };
+        slot.* = if (value >= slot.*) 0 else slot.* - value;
+    }
+
+    pub fn recordProxyBufferHighWatermark(self: *Metrics, direction: proxy_buffer_account.Direction, scope: proxy_buffer_account.Scope) void {
+        if (scope != .stream) return;
+        switch (direction) {
+            .downstream_to_upstream => self.proxy_buffer_high_watermark_downstream_to_upstream_stream += 1,
+            .upstream_to_downstream => self.proxy_buffer_high_watermark_upstream_to_downstream_stream += 1,
+        }
+    }
+
+    pub fn recordProxyBufferLimitExceeded(self: *Metrics, direction: proxy_buffer_account.Direction, scope: proxy_buffer_account.Scope) void {
+        if (scope != .stream) return;
+        switch (direction) {
+            .downstream_to_upstream => self.proxy_buffer_limit_exceeded_downstream_to_upstream_stream += 1,
+            .upstream_to_downstream => self.proxy_buffer_limit_exceeded_upstream_to_downstream_stream += 1,
+        }
+    }
+
+    pub fn recordProxyBufferReadPause(self: *Metrics, side: []const u8) void {
+        if (std.mem.eql(u8, side, "downstream")) {
+            self.proxy_buffer_read_pauses_downstream += 1;
+        } else if (std.mem.eql(u8, side, "upstream")) {
+            self.proxy_buffer_read_pauses_upstream += 1;
+        }
+    }
+
+    pub fn recordProxyBufferReadResume(self: *Metrics, side: []const u8) void {
+        if (std.mem.eql(u8, side, "downstream")) {
+            self.proxy_buffer_read_resumes_downstream += 1;
+        } else if (std.mem.eql(u8, side, "upstream")) {
+            self.proxy_buffer_read_resumes_upstream += 1;
+        }
     }
 
     pub fn recordProxyClientAbort(self: *Metrics) void {
@@ -525,6 +619,54 @@ pub const Metrics = struct {
             \\# HELP tardigrade_proxy_buffered_bytes_total Total response bytes retained by buffered proxy requests
             \\# TYPE tardigrade_proxy_buffered_bytes_total counter
             \\tardigrade_proxy_buffered_bytes_total {d}
+            \\
+        , .{
+            self.proxy_streaming_requests,
+            self.proxy_buffered_requests,
+            self.proxy_buffered_bytes_current,
+            self.proxy_buffered_bytes_total,
+        });
+
+        try out.print(
+            \\# HELP tardigrade_buffered_bytes_current Current proxy-owned body bytes by direction and accounting scope
+            \\# TYPE tardigrade_buffered_bytes_current gauge
+            \\tardigrade_buffered_bytes_current{{direction="downstream_to_upstream",scope="stream"}} {d}
+            \\tardigrade_buffered_bytes_current{{direction="downstream_to_upstream",scope="global"}} {d}
+            \\tardigrade_buffered_bytes_current{{direction="upstream_to_downstream",scope="stream"}} {d}
+            \\tardigrade_buffered_bytes_current{{direction="upstream_to_downstream",scope="global"}} {d}
+            \\# HELP tardigrade_buffer_high_watermark_events_total Proxy buffer high-watermark transitions by direction and scope
+            \\# TYPE tardigrade_buffer_high_watermark_events_total counter
+            \\tardigrade_buffer_high_watermark_events_total{{direction="downstream_to_upstream",scope="stream"}} {d}
+            \\tardigrade_buffer_high_watermark_events_total{{direction="upstream_to_downstream",scope="stream"}} {d}
+            \\# HELP tardigrade_buffer_read_pauses_total Proxy reads paused by stalled buffer pressure side
+            \\# TYPE tardigrade_buffer_read_pauses_total counter
+            \\tardigrade_buffer_read_pauses_total{{side="downstream"}} {d}
+            \\tardigrade_buffer_read_pauses_total{{side="upstream"}} {d}
+            \\# HELP tardigrade_buffer_read_resumes_total Proxy reads resumed after buffer pressure drops
+            \\# TYPE tardigrade_buffer_read_resumes_total counter
+            \\tardigrade_buffer_read_resumes_total{{side="downstream"}} {d}
+            \\tardigrade_buffer_read_resumes_total{{side="upstream"}} {d}
+            \\# HELP tardigrade_buffer_limit_exceeded_total Proxy buffer hard-limit exceedance events by direction and scope
+            \\# TYPE tardigrade_buffer_limit_exceeded_total counter
+            \\tardigrade_buffer_limit_exceeded_total{{direction="downstream_to_upstream",scope="stream"}} {d}
+            \\tardigrade_buffer_limit_exceeded_total{{direction="upstream_to_downstream",scope="stream"}} {d}
+            \\
+        , .{
+            self.proxy_buffer_downstream_to_upstream_stream_current,
+            self.proxy_buffer_downstream_to_upstream_global_current,
+            self.proxy_buffer_upstream_to_downstream_stream_current,
+            self.proxy_buffer_upstream_to_downstream_global_current,
+            self.proxy_buffer_high_watermark_downstream_to_upstream_stream,
+            self.proxy_buffer_high_watermark_upstream_to_downstream_stream,
+            self.proxy_buffer_read_pauses_downstream,
+            self.proxy_buffer_read_pauses_upstream,
+            self.proxy_buffer_read_resumes_downstream,
+            self.proxy_buffer_read_resumes_upstream,
+            self.proxy_buffer_limit_exceeded_downstream_to_upstream_stream,
+            self.proxy_buffer_limit_exceeded_upstream_to_downstream_stream,
+        });
+
+        try out.print(
             \\# HELP tardigrade_proxy_client_aborts_total Total proxied transfers aborted by downstream clients
             \\# TYPE tardigrade_proxy_client_aborts_total counter
             \\tardigrade_proxy_client_aborts_total {d}
@@ -566,10 +708,6 @@ pub const Metrics = struct {
             \\tardigrade_upstream_stale_retries_total {d}
             \\
         , .{
-            self.proxy_streaming_requests,
-            self.proxy_buffered_requests,
-            self.proxy_buffered_bytes_current,
-            self.proxy_buffered_bytes_total,
             self.proxy_client_aborts,
             self.proxy_upstream_aborts,
             self.proxy_streaming_fallback_policy_disabled,
@@ -976,6 +1114,10 @@ test "Metrics toPrometheus produces valid Prometheus text" {
     m.recordRequest(500);
     m.recordProxyStreamingRequest(3);
     m.recordProxyBufferedRequest(42, 4);
+    m.recordProxyBufferHighWatermark(.upstream_to_downstream, .stream);
+    m.recordProxyBufferReadPause("upstream");
+    m.recordProxyBufferReadResume("upstream");
+    m.recordProxyBufferLimitExceeded(.upstream_to_downstream, .stream);
 
     const prom = try m.toPrometheus(allocator);
     defer allocator.free(prom);
@@ -992,6 +1134,11 @@ test "Metrics toPrometheus produces valid Prometheus text" {
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_proxy_streaming_requests_total 1") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_proxy_buffered_requests_total 1") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_proxy_buffered_bytes_current 42") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffered_bytes_current{direction=\"upstream_to_downstream\",scope=\"stream\"} 42") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_high_watermark_events_total{direction=\"upstream_to_downstream\",scope=\"stream\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_read_pauses_total{side=\"upstream\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_read_resumes_total{side=\"upstream\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_limit_exceeded_total{direction=\"upstream_to_downstream\",scope=\"stream\"} 1") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_proxy_ttfb_ms_count 2") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_worker_active_jobs") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_worker_queued_jobs") != null);

--- a/src/http/metrics.zig
+++ b/src/http/metrics.zig
@@ -320,11 +320,12 @@ pub const Metrics = struct {
         self.recordProxyTtfbMs(ttfb_ms);
     }
 
-    pub fn releaseProxyBufferedBytes(self: *Metrics, buffered_bytes: usize) void {
+    pub fn releaseProxyBufferedBytes(self: *Metrics, buffered_bytes: usize) !void {
         const bytes: u64 = @intCast(buffered_bytes);
-        self.proxy_buffered_bytes_current = if (bytes >= self.proxy_buffered_bytes_current) 0 else self.proxy_buffered_bytes_current - bytes;
-        self.releaseProxyBufferBytes(.upstream_to_downstream, .stream, buffered_bytes);
-        self.releaseProxyBufferBytes(.upstream_to_downstream, .global, buffered_bytes);
+        if (bytes > self.proxy_buffered_bytes_current) return error.BufferAccountingUnderflow;
+        self.proxy_buffered_bytes_current -= bytes;
+        try self.releaseProxyBufferBytes(.upstream_to_downstream, .stream, buffered_bytes);
+        try self.releaseProxyBufferBytes(.upstream_to_downstream, .global, buffered_bytes);
     }
 
     pub fn recordProxyBufferBytes(self: *Metrics, direction: proxy_buffer_account.Direction, scope: proxy_buffer_account.Scope, bytes: usize) void {
@@ -343,7 +344,7 @@ pub const Metrics = struct {
         }
     }
 
-    pub fn releaseProxyBufferBytes(self: *Metrics, direction: proxy_buffer_account.Direction, scope: proxy_buffer_account.Scope, bytes: usize) void {
+    pub fn releaseProxyBufferBytes(self: *Metrics, direction: proxy_buffer_account.Direction, scope: proxy_buffer_account.Scope, bytes: usize) !void {
         const value: u64 = @intCast(bytes);
         const slot = switch (direction) {
             .downstream_to_upstream => switch (scope) {
@@ -357,7 +358,8 @@ pub const Metrics = struct {
                 else => return,
             },
         };
-        slot.* = if (value >= slot.*) 0 else slot.* - value;
+        if (value > slot.*) return error.BufferAccountingUnderflow;
+        slot.* -= value;
     }
 
     pub fn recordProxyBufferHighWatermark(self: *Metrics, direction: proxy_buffer_account.Direction, scope: proxy_buffer_account.Scope) void {
@@ -628,7 +630,7 @@ pub const Metrics = struct {
         });
 
         try out.print(
-            \\# HELP tardigrade_buffered_bytes_current Current proxy-owned body bytes by direction and accounting scope
+            \\# HELP tardigrade_buffered_bytes_current Current proxy-owned body bytes by direction and accounting scope (buffered responses and HTTP/1 relay buffers in this PR)
             \\# TYPE tardigrade_buffered_bytes_current gauge
             \\tardigrade_buffered_bytes_current{{direction="downstream_to_upstream",scope="stream"}} {d}
             \\tardigrade_buffered_bytes_current{{direction="downstream_to_upstream",scope="global"}} {d}
@@ -1012,7 +1014,7 @@ test "Metrics tracks active connections and rejections" {
     m.recordMuxFrameError();
     m.recordProxyStreamingRequest(12);
     m.recordProxyBufferedRequest(128, 8);
-    m.releaseProxyBufferedBytes(64);
+    try m.releaseProxyBufferedBytes(64);
     m.recordProxyClientAbort();
     m.recordProxyUpstreamAbort();
 
@@ -1042,6 +1044,19 @@ test "Metrics tracks active connections and rejections" {
     m.recordErrorCode("overload");
     try std.testing.expectEqual(@as(u64, 1), m.err_invalid_request);
     try std.testing.expectEqual(@as(u64, 1), m.err_overload);
+}
+
+test "Metrics proxy buffer release reports accounting underflow" {
+    var m = Metrics.init();
+    m.recordProxyBufferBytes(.upstream_to_downstream, .stream, 32);
+    try m.releaseProxyBufferBytes(.upstream_to_downstream, .stream, 16);
+    try std.testing.expectEqual(@as(u64, 16), m.proxy_buffer_upstream_to_downstream_stream_current);
+    try std.testing.expectError(error.BufferAccountingUnderflow, m.releaseProxyBufferBytes(.upstream_to_downstream, .stream, 17));
+    try std.testing.expectEqual(@as(u64, 16), m.proxy_buffer_upstream_to_downstream_stream_current);
+
+    m.recordProxyBufferedRequest(8, 0);
+    try std.testing.expectError(error.BufferAccountingUnderflow, m.releaseProxyBufferedBytes(9));
+    try std.testing.expectEqual(@as(u64, 8), m.proxy_buffered_bytes_current);
 }
 
 test "recordErrorCode counts only the canonical overload label" {

--- a/src/http/proxy_buffer_account.zig
+++ b/src/http/proxy_buffer_account.zig
@@ -1,0 +1,177 @@
+const std = @import("std");
+
+pub const Direction = enum {
+    downstream_to_upstream,
+    upstream_to_downstream,
+
+    pub fn label(self: Direction) []const u8 {
+        return switch (self) {
+            .downstream_to_upstream => "downstream_to_upstream",
+            .upstream_to_downstream => "upstream_to_downstream",
+        };
+    }
+};
+
+pub const Scope = enum {
+    stream,
+    connection,
+    origin,
+    global,
+
+    pub fn label(self: Scope) []const u8 {
+        return switch (self) {
+            .stream => "stream",
+            .connection => "connection",
+            .origin => "origin",
+            .global => "global",
+        };
+    }
+};
+
+pub const Limits = struct {
+    per_stream_low_watermark: usize,
+    per_stream_high_watermark: usize,
+    per_stream_hard_limit: usize,
+    per_origin_hard_limit: usize,
+    global_hard_limit: usize,
+
+    pub fn validate(self: Limits) !void {
+        if (self.per_stream_low_watermark == 0 or
+            self.per_stream_high_watermark == 0 or
+            self.per_stream_hard_limit == 0)
+        {
+            return error.InvalidBufferLimits;
+        }
+        if (!(self.per_stream_low_watermark < self.per_stream_high_watermark and
+            self.per_stream_high_watermark <= self.per_stream_hard_limit))
+        {
+            return error.InvalidBufferLimits;
+        }
+        if (self.per_origin_hard_limit != 0 and self.per_origin_hard_limit < self.per_stream_hard_limit) {
+            return error.InvalidBufferLimits;
+        }
+        if (self.global_hard_limit != 0 and self.global_hard_limit < self.per_stream_hard_limit) {
+            return error.InvalidBufferLimits;
+        }
+    }
+};
+
+pub const Snapshot = struct {
+    current: usize,
+    high_watermark_events: u64,
+    limit_exceeded_events: u64,
+    above_high_watermark: bool,
+};
+
+/// Small owner-local accounting primitive for bytes currently retained by a
+/// proxy body buffer or queue. Shared aggregate accounting remains outside this
+/// type; callers record this object's transitions into the process metrics.
+pub const Account = struct {
+    direction: Direction,
+    scope: Scope,
+    limits: Limits,
+    current: usize = 0,
+    high_watermark_events: u64 = 0,
+    limit_exceeded_events: u64 = 0,
+    above_high_watermark: bool = false,
+
+    pub fn init(direction: Direction, scope: Scope, limits: Limits) Account {
+        return .{
+            .direction = direction,
+            .scope = scope,
+            .limits = limits,
+        };
+    }
+
+    pub fn reserve(self: *Account, bytes: usize) !void {
+        const next = std.math.add(usize, self.current, bytes) catch {
+            self.limit_exceeded_events += 1;
+            return error.BufferLimitExceeded;
+        };
+        if (next > self.limits.per_stream_hard_limit) {
+            self.limit_exceeded_events += 1;
+            return error.BufferLimitExceeded;
+        }
+        self.current = next;
+        if (!self.above_high_watermark and self.current >= self.limits.per_stream_high_watermark) {
+            self.above_high_watermark = true;
+            self.high_watermark_events += 1;
+        }
+    }
+
+    pub fn release(self: *Account, bytes: usize) void {
+        self.current = if (bytes >= self.current) 0 else self.current - bytes;
+        if (self.above_high_watermark and self.current <= self.limits.per_stream_low_watermark) {
+            self.above_high_watermark = false;
+        }
+    }
+
+    pub fn releaseAll(self: *Account) void {
+        self.current = 0;
+        self.above_high_watermark = false;
+    }
+
+    pub fn snapshot(self: *const Account) Snapshot {
+        return .{
+            .current = self.current,
+            .high_watermark_events = self.high_watermark_events,
+            .limit_exceeded_events = self.limit_exceeded_events,
+            .above_high_watermark = self.above_high_watermark,
+        };
+    }
+};
+
+test "proxy buffer account validates low high hard ordering" {
+    try (Limits{
+        .per_stream_low_watermark = 4,
+        .per_stream_high_watermark = 8,
+        .per_stream_hard_limit = 16,
+        .per_origin_hard_limit = 0,
+        .global_hard_limit = 0,
+    }).validate();
+
+    try std.testing.expectError(error.InvalidBufferLimits, (Limits{
+        .per_stream_low_watermark = 8,
+        .per_stream_high_watermark = 8,
+        .per_stream_hard_limit = 16,
+        .per_origin_hard_limit = 0,
+        .global_hard_limit = 0,
+    }).validate());
+
+    try std.testing.expectError(error.InvalidBufferLimits, (Limits{
+        .per_stream_low_watermark = 4,
+        .per_stream_high_watermark = 8,
+        .per_stream_hard_limit = 16,
+        .per_origin_hard_limit = 12,
+        .global_hard_limit = 0,
+    }).validate());
+}
+
+test "proxy buffer account tracks high low transitions and release" {
+    const limits = Limits{
+        .per_stream_low_watermark = 4,
+        .per_stream_high_watermark = 8,
+        .per_stream_hard_limit = 16,
+        .per_origin_hard_limit = 0,
+        .global_hard_limit = 0,
+    };
+    var account = Account.init(.upstream_to_downstream, .stream, limits);
+
+    try account.reserve(7);
+    try std.testing.expectEqual(@as(usize, 7), account.snapshot().current);
+    try std.testing.expect(!account.snapshot().above_high_watermark);
+
+    try account.reserve(1);
+    try std.testing.expect(account.snapshot().above_high_watermark);
+    try std.testing.expectEqual(@as(u64, 1), account.snapshot().high_watermark_events);
+
+    account.release(3);
+    try std.testing.expect(account.snapshot().above_high_watermark);
+    account.release(1);
+    try std.testing.expect(!account.snapshot().above_high_watermark);
+
+    try std.testing.expectError(error.BufferLimitExceeded, account.reserve(17));
+    try std.testing.expectEqual(@as(u64, 1), account.snapshot().limit_exceeded_events);
+    account.releaseAll();
+    try std.testing.expectEqual(@as(usize, 0), account.snapshot().current);
+}

--- a/src/http/proxy_buffer_account.zig
+++ b/src/http/proxy_buffer_account.zig
@@ -63,6 +63,20 @@ pub const Snapshot = struct {
     above_high_watermark: bool,
 };
 
+pub const Observer = struct {
+    context: *anyopaque,
+    recordReservationFn: *const fn (*anyopaque, Direction, usize, bool, bool) void,
+    releaseReservationFn: *const fn (*anyopaque, Direction, usize) void,
+
+    pub fn recordReservation(self: Observer, direction: Direction, bytes: usize, high_watermark: bool, limit_exceeded: bool) void {
+        self.recordReservationFn(self.context, direction, bytes, high_watermark, limit_exceeded);
+    }
+
+    pub fn releaseReservation(self: Observer, direction: Direction, bytes: usize) void {
+        self.releaseReservationFn(self.context, direction, bytes);
+    }
+};
+
 /// Small owner-local accounting primitive for bytes currently retained by a
 /// proxy body buffer or queue. Shared aggregate accounting remains outside this
 /// type; callers record this object's transitions into the process metrics.
@@ -76,6 +90,7 @@ pub const Account = struct {
     above_high_watermark: bool = false,
 
     pub fn init(direction: Direction, scope: Scope, limits: Limits) Account {
+        std.debug.assert(scope == .stream);
         return .{
             .direction = direction,
             .scope = scope,
@@ -99,8 +114,9 @@ pub const Account = struct {
         }
     }
 
-    pub fn release(self: *Account, bytes: usize) void {
-        self.current = if (bytes >= self.current) 0 else self.current - bytes;
+    pub fn release(self: *Account, bytes: usize) !void {
+        if (bytes > self.current) return error.BufferAccountingUnderflow;
+        self.current -= bytes;
         if (self.above_high_watermark and self.current <= self.limits.per_stream_low_watermark) {
             self.above_high_watermark = false;
         }
@@ -165,13 +181,28 @@ test "proxy buffer account tracks high low transitions and release" {
     try std.testing.expect(account.snapshot().above_high_watermark);
     try std.testing.expectEqual(@as(u64, 1), account.snapshot().high_watermark_events);
 
-    account.release(3);
+    try account.release(3);
     try std.testing.expect(account.snapshot().above_high_watermark);
-    account.release(1);
+    try account.release(1);
     try std.testing.expect(!account.snapshot().above_high_watermark);
 
     try std.testing.expectError(error.BufferLimitExceeded, account.reserve(17));
     try std.testing.expectEqual(@as(u64, 1), account.snapshot().limit_exceeded_events);
     account.releaseAll();
     try std.testing.expectEqual(@as(usize, 0), account.snapshot().current);
+}
+
+test "proxy buffer account reports over-release without changing current" {
+    const limits = Limits{
+        .per_stream_low_watermark = 4,
+        .per_stream_high_watermark = 8,
+        .per_stream_hard_limit = 16,
+        .per_origin_hard_limit = 0,
+        .global_hard_limit = 0,
+    };
+    var account = Account.init(.upstream_to_downstream, .stream, limits);
+
+    try account.reserve(6);
+    try std.testing.expectError(error.BufferAccountingUnderflow, account.release(7));
+    try std.testing.expectEqual(@as(usize, 6), account.snapshot().current);
 }

--- a/src/http/upstream_h2.zig
+++ b/src/http/upstream_h2.zig
@@ -27,6 +27,7 @@ const compat = @import("../zig_compat.zig");
 const frame = @import("http2_frame.zig");
 const hpack = @import("hpack.zig");
 const tls_termination = @import("tls_backend.zig");
+const proxy_buffer_account = @import("proxy_buffer_account.zig");
 
 /// HTTP/2 client connection preface (RFC 7540 §3.5).
 pub const PREFACE = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
@@ -84,6 +85,8 @@ pub const Request = struct {
     /// Whether `body` is the complete outbound request body or the first bytes
     /// of a request body that will continue through streaming DATA writes.
     body_mode: BodyMode = .complete,
+    proxy_buffer_limits: ?proxy_buffer_account.Limits = null,
+    proxy_buffer_observer: ?proxy_buffer_account.Observer = null,
 };
 
 pub const BodyMode = enum {
@@ -464,11 +467,55 @@ pub const Stream = struct {
     /// (idle state) would be a connection-level PROTOCOL_ERROR. Written and
     /// read only by the owning worker thread.
     wire_opened: bool = false,
+    proxy_body_account: ?proxy_buffer_account.Account = null,
+    proxy_buffer_observer: ?proxy_buffer_account.Observer = null,
 
     fn destroy(self: *Stream, allocator: std.mem.Allocator) void {
+        self.releaseQueuedBodyAccounting();
         freeHeaderList(allocator, &self.headers);
         self.body.deinit(allocator);
         allocator.destroy(self);
+    }
+
+    fn recordQueuedBody(self: *Stream, bytes: usize) !void {
+        if (self.proxy_body_account) |*account| {
+            const before = account.snapshot();
+            account.reserve(bytes) catch |err| {
+                const after = account.snapshot();
+                if (self.proxy_buffer_observer) |observer| {
+                    if (after.limit_exceeded_events > before.limit_exceeded_events) {
+                        observer.recordReservation(account.direction, 0, false, true);
+                    }
+                }
+                return err;
+            };
+            const after = account.snapshot();
+            if (self.proxy_buffer_observer) |observer| {
+                observer.recordReservation(
+                    account.direction,
+                    bytes,
+                    after.high_watermark_events > before.high_watermark_events,
+                    after.limit_exceeded_events > before.limit_exceeded_events,
+                );
+            }
+        }
+    }
+
+    fn releaseQueuedBody(self: *Stream, bytes: usize) void {
+        if (bytes == 0) return;
+        if (self.proxy_body_account) |*account| {
+            account.release(bytes) catch unreachable;
+            if (self.proxy_buffer_observer) |observer| {
+                observer.releaseReservation(account.direction, bytes);
+            }
+        }
+    }
+
+    fn releaseQueuedBodyAccounting(self: *Stream) void {
+        if (self.proxy_body_account) |*account| {
+            const current = account.snapshot().current;
+            if (current > 0) self.releaseQueuedBody(current);
+        }
     }
 };
 
@@ -686,6 +733,10 @@ pub fn H2Conn(comptime Transport: type) type {
         pub fn openStreaming(self: *Self, req: Request) !*Stream {
             const stream = try self.beginStream(true);
             errdefer self.finishStreaming(stream);
+            if (req.proxy_buffer_limits) |limits| {
+                stream.proxy_body_account = proxy_buffer_account.Account.init(.upstream_to_downstream, .stream, limits);
+                stream.proxy_buffer_observer = req.proxy_buffer_observer;
+            }
             try self.sendRequest(stream, req);
             return stream;
         }
@@ -740,6 +791,7 @@ pub fn H2Conn(comptime Transport: type) type {
                     const n = @min(avail, out.len);
                     @memcpy(out[0..n], stream.body.items[stream.body_read_off..][0..n]);
                     stream.body_read_off += n;
+                    stream.releaseQueuedBody(n);
                     if (stream.body_read_off == stream.body.items.len) {
                         stream.body.clearRetainingCapacity();
                         stream.body_read_off = 0;
@@ -1138,6 +1190,17 @@ pub fn H2Conn(comptime Transport: type) type {
                         flow_violation = true;
                         deliver = false;
                     }
+                }
+                if (deliver) {
+                    s.recordQueuedBody(fr.payload.len) catch |err| {
+                        if (err == error.BufferLimitExceeded) {
+                            if (s.err == null) s.err = err;
+                            deliver = false;
+                        } else {
+                            self.state_mutex.unlock();
+                            return err;
+                        }
+                    };
                 }
                 if (deliver) {
                     s.body.appendSlice(self.allocator, fr.payload) catch {

--- a/src/http/upstream_h2.zig
+++ b/src/http/upstream_h2.zig
@@ -467,6 +467,7 @@ pub const Stream = struct {
     /// (idle state) would be a connection-level PROTOCOL_ERROR. Written and
     /// read only by the owning worker thread.
     wire_opened: bool = false,
+    local_abort: bool = false,
     proxy_body_account: ?proxy_buffer_account.Account = null,
     proxy_buffer_observer: ?proxy_buffer_account.Observer = null,
 
@@ -509,6 +510,19 @@ pub const Stream = struct {
                 observer.releaseReservation(account.direction, bytes);
             }
         }
+    }
+
+    fn compactAcknowledgedBody(self: *Stream, bytes: usize) void {
+        if (bytes == 0) return;
+        std.debug.assert(bytes <= self.body_read_off);
+        std.debug.assert(bytes <= self.body.items.len);
+        const remaining = self.body.items.len - bytes;
+        if (remaining > 0) {
+            std.mem.copyForwards(u8, self.body.items[0..remaining], self.body.items[bytes..]);
+        }
+        self.body.shrinkRetainingCapacity(remaining);
+        self.body_read_off -= bytes;
+        if (self.body.items.len == 0) self.body_read_off = 0;
     }
 
     fn releaseQueuedBodyAccounting(self: *Stream) void {
@@ -781,8 +795,9 @@ pub fn H2Conn(comptime Transport: type) type {
 
         /// Copy the next chunk of a streaming response body into `out`,
         /// blocking (deadline-bounded) until data, end-of-stream, or an error.
-        /// Returns 0 at end of stream. Consuming bytes replenishes the
-        /// stream-level flow-control window so the origin may send more.
+        /// Returns 0 at end of stream. The caller must acknowledge each
+        /// non-zero read with `acknowledgeStreamingBody` only after the copied
+        /// bytes have been durably consumed downstream.
         pub fn readStreamingBody(self: *Self, stream: *Stream, out: []u8) !usize {
             self.state_mutex.lock();
             while (true) {
@@ -791,20 +806,7 @@ pub fn H2Conn(comptime Transport: type) type {
                     const n = @min(avail, out.len);
                     @memcpy(out[0..n], stream.body.items[stream.body_read_off..][0..n]);
                     stream.body_read_off += n;
-                    stream.releaseQueuedBody(n);
-                    if (stream.body_read_off == stream.body.items.len) {
-                        stream.body.clearRetainingCapacity();
-                        stream.body_read_off = 0;
-                    }
-                    stream.recv_window += @as(i64, @intCast(n));
-                    // No more data will arrive once END_STREAM was seen, so the
-                    // window only needs replenishing while the stream is open.
-                    const replenish = !stream.done;
                     self.state_mutex.unlock();
-                    if (replenish) {
-                        const inc = windowIncrement(n);
-                        self.writeControl(.window_update, 0, stream.id, &inc);
-                    }
                     return n;
                 }
                 if (stream.err) |e| {
@@ -825,6 +827,25 @@ pub fn H2Conn(comptime Transport: type) type {
             }
         }
 
+        /// Acknowledge bytes returned by `readStreamingBody` after the caller
+        /// has written them downstream. This is the ownership transfer point:
+        /// accounting is released, consumed queue prefixes are compacted, and
+        /// stream credit is replenished only after downstream consumption.
+        pub fn acknowledgeStreamingBody(self: *Self, stream: *Stream, bytes: usize) void {
+            if (bytes == 0) return;
+            self.state_mutex.lock();
+            stream.releaseQueuedBody(bytes);
+            stream.compactAcknowledgedBody(bytes);
+            stream.recv_window += @as(i64, @intCast(bytes));
+            const replenish = !stream.done;
+            const id = stream.id;
+            self.state_mutex.unlock();
+            if (replenish) {
+                const inc = windowIncrement(bytes);
+                self.writeControl(.window_update, 0, id, &inc);
+            }
+        }
+
         /// Finish a streaming request: detach the stream from the connection,
         /// reset it upstream if the response had not completed (so the origin
         /// stops sending on an abandoned stream), free the concurrency slot,
@@ -834,7 +855,7 @@ pub fn H2Conn(comptime Transport: type) type {
             self.state_mutex.lock();
             const removed = self.streams.remove(stream.id);
             if (removed and self.active_streams > 0) self.active_streams -= 1;
-            const need_rst = stream.wire_opened and stream.err == null and !stream.done and self.conn_err == null;
+            const need_rst = stream.wire_opened and (stream.err == null or stream.local_abort) and !stream.done and self.conn_err == null;
             const id = stream.id;
             self.state_mutex.unlock();
             self.last_activity_ms.store(nowMs(), .monotonic);
@@ -1173,7 +1194,7 @@ pub fn H2Conn(comptime Transport: type) type {
             const end_stream = (fr.flags & frame.Flags.END_STREAM) != 0;
             self.state_mutex.lock();
             const maybe_stream = self.streams.get(fr.stream_id);
-            var replenish_stream = true;
+            var replenish_stream = false;
             var flow_violation = false;
             if (maybe_stream) |s| {
                 var deliver = fr.payload.len > 0;
@@ -1190,11 +1211,14 @@ pub fn H2Conn(comptime Transport: type) type {
                         flow_violation = true;
                         deliver = false;
                     }
+                } else if (deliver) {
+                    replenish_stream = true;
                 }
                 if (deliver) {
                     s.recordQueuedBody(fr.payload.len) catch |err| {
                         if (err == error.BufferLimitExceeded) {
                             if (s.err == null) s.err = err;
+                            s.local_abort = true;
                             deliver = false;
                         } else {
                             self.state_mutex.unlock();
@@ -1760,6 +1784,40 @@ fn windowIncrement(n: usize) [4]u8 {
 }
 
 const testing = std.testing;
+
+const TestProxyBufferObserver = struct {
+    current: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+    limit_exceeded: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+
+    fn observer(self: *TestProxyBufferObserver) proxy_buffer_account.Observer {
+        return .{
+            .context = self,
+            .recordReservationFn = record,
+            .releaseReservationFn = release,
+        };
+    }
+
+    fn record(context: *anyopaque, _: proxy_buffer_account.Direction, bytes: usize, _: bool, limit_exceeded: bool) void {
+        const self: *TestProxyBufferObserver = @ptrCast(@alignCast(context));
+        if (bytes > 0) _ = self.current.fetchAdd(bytes, .monotonic);
+        if (limit_exceeded) _ = self.limit_exceeded.fetchAdd(1, .monotonic);
+    }
+
+    fn release(context: *anyopaque, _: proxy_buffer_account.Direction, bytes: usize) void {
+        const self: *TestProxyBufferObserver = @ptrCast(@alignCast(context));
+        if (bytes > 0) _ = self.current.fetchSub(bytes, .monotonic);
+    }
+};
+
+fn smallProxyBufferLimits(hard: usize) proxy_buffer_account.Limits {
+    return .{
+        .per_stream_low_watermark = 1,
+        .per_stream_high_watermark = @max(2, @min(hard, 8)),
+        .per_stream_hard_limit = hard,
+        .per_origin_hard_limit = 0,
+        .global_hard_limit = 0,
+    };
+}
 
 test "isConnectionSpecific filters hop-by-hop and Host headers" {
     try testing.expect(isConnectionSpecific("Connection"));
@@ -2330,6 +2388,7 @@ test "streaming request relays a multi-frame body with consumer-driven window re
         const n = try conn.readStreamingBody(stream, buf[0..]);
         if (n == 0) break;
         try got.appendSlice(testing.allocator, buf[0..n]);
+        conn.acknowledgeStreamingBody(stream, n);
     }
     conn.finishStreaming(stream);
 
@@ -2341,6 +2400,125 @@ test "streaming request relays a multi-frame body with consumer-driven window re
     conn.deinit();
     server.join();
     _ = std.c.close(fds[1]);
+}
+
+fn cannedSingleDataStreamingServer(peer_fd: std.posix.fd_t, body: []const u8, end_stream: bool) void {
+    const a = std.heap.page_allocator;
+    var srv = PlainTransport{ .fd = peer_fd };
+    var preface: [PREFACE.len]u8 = undefined;
+    readExact(&srv, peer_fd, preface[0..], 2000) catch return;
+    frame.writeSettings(a, &srv, &[_][2]u32{}) catch return;
+
+    var req_stream: u31 = 0;
+    while (req_stream == 0) {
+        var fr = readFrameBounded(&srv, peer_fd, a, 2000) catch return;
+        if (fr.typ == .headers) req_stream = fr.stream_id;
+        frame.deinitFrame(a, &fr);
+    }
+
+    const block = hpack.encodeLiteralHeaderBlock(a, &[_]hpack.HeaderField{
+        .{ .name = ":status", .value = "200" },
+    }) catch return;
+    defer a.free(block);
+    frame.writeFrame(&srv, .headers, frame.Flags.END_HEADERS, req_stream, block) catch return;
+    frame.writeFrame(&srv, .data, if (end_stream) frame.Flags.END_STREAM else 0, req_stream, body) catch return;
+
+    var scratch: [1]u8 = undefined;
+    _ = srv.read(scratch[0..]) catch {};
+}
+
+test "streaming body accounting releases only after consumer acknowledgement and compacts queue" {
+    const fds = try makeSocketpair();
+    const server = try std.Thread.spawn(.{}, cannedSingleDataStreamingServer, .{ fds[1], "payload", false });
+
+    var observer = TestProxyBufferObserver{};
+    var transport = PlainTransport{ .fd = fds[0] };
+    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 3000, null, null, null);
+
+    const stream = try conn.requestStreaming(.{
+        .method = "GET",
+        .authority = "account.test",
+        .path = "/",
+        .proxy_buffer_limits = smallProxyBufferLimits(64),
+        .proxy_buffer_observer = observer.observer(),
+    });
+    var buf: [16]u8 = undefined;
+    const n = try conn.readStreamingBody(stream, buf[0..]);
+    try testing.expectEqualStrings("payload", buf[0..n]);
+    try testing.expectEqual(@as(usize, 7), observer.current.load(.monotonic));
+    try testing.expectEqual(@as(usize, 7), stream.body.items.len);
+    try testing.expectEqual(@as(usize, 7), stream.body_read_off);
+
+    conn.acknowledgeStreamingBody(stream, n);
+    try testing.expectEqual(@as(usize, 0), observer.current.load(.monotonic));
+    try testing.expectEqual(@as(usize, 0), stream.body.items.len);
+    try testing.expectEqual(@as(usize, 0), stream.body_read_off);
+
+    conn.finishStreaming(stream);
+    conn.deinit();
+    server.join();
+    _ = std.c.close(fds[1]);
+}
+
+fn cannedLimitExceededStreamingServer(peer_fd: std.posix.fd_t, saw_rst: *std.atomic.Value(bool)) void {
+    const a = std.heap.page_allocator;
+    var srv = PlainTransport{ .fd = peer_fd };
+    var preface: [PREFACE.len]u8 = undefined;
+    readExact(&srv, peer_fd, preface[0..], 2000) catch return;
+    frame.writeSettings(a, &srv, &[_][2]u32{}) catch return;
+
+    var req_stream: u31 = 0;
+    while (req_stream == 0) {
+        var fr = readFrameBounded(&srv, peer_fd, a, 2000) catch return;
+        if (fr.typ == .headers) req_stream = fr.stream_id;
+        frame.deinitFrame(a, &fr);
+    }
+
+    const block = hpack.encodeLiteralHeaderBlock(a, &[_]hpack.HeaderField{
+        .{ .name = ":status", .value = "200" },
+    }) catch return;
+    defer a.free(block);
+    frame.writeFrame(&srv, .headers, frame.Flags.END_HEADERS, req_stream, block) catch return;
+    frame.writeFrame(&srv, .data, 0, req_stream, "0123456789abcdef") catch return;
+
+    while (true) {
+        var fr = readFrameBounded(&srv, peer_fd, a, 5000) catch return;
+        const is_rst = fr.typ == .rst_stream and fr.stream_id == req_stream;
+        frame.deinitFrame(a, &fr);
+        if (is_rst) {
+            saw_rst.store(true, .release);
+            return;
+        }
+    }
+}
+
+test "streaming body hard-limit abort resets stream and releases accounting" {
+    const fds = try makeSocketpair();
+    var saw_rst = std.atomic.Value(bool).init(false);
+    const server = try std.Thread.spawn(.{}, cannedLimitExceededStreamingServer, .{ fds[1], &saw_rst });
+
+    var observer = TestProxyBufferObserver{};
+    var transport = PlainTransport{ .fd = fds[0] };
+    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 3000, null, null, null);
+
+    const stream = try conn.requestStreaming(.{
+        .method = "GET",
+        .authority = "limit.test",
+        .path = "/",
+        .proxy_buffer_limits = smallProxyBufferLimits(8),
+        .proxy_buffer_observer = observer.observer(),
+    });
+    var buf: [16]u8 = undefined;
+    try testing.expectError(error.BufferLimitExceeded, conn.readStreamingBody(stream, buf[0..]));
+    conn.finishStreaming(stream);
+
+    conn.deinit();
+    server.join();
+    _ = std.c.close(fds[1]);
+
+    try testing.expect(saw_rst.load(.acquire));
+    try testing.expectEqual(@as(usize, 0), observer.current.load(.monotonic));
+    try testing.expectEqual(@as(u64, 1), observer.limit_exceeded.load(.monotonic));
 }
 
 /// Canned server: HEADERS + DATA + a trailer HEADERS block (END_STREAM). The
@@ -2389,6 +2567,7 @@ test "streaming response trailers end the stream and are discarded" {
         const n = try conn.readStreamingBody(stream, buf[0..]);
         if (n == 0) break;
         try got.appendSlice(testing.allocator, buf[0..n]);
+        conn.acknowledgeStreamingBody(stream, n);
     }
     try testing.expectEqualStrings("payload", got.items);
     for (stream.headers.items) |h| {
@@ -2471,6 +2650,7 @@ test "streaming stream fails when the peer overruns the advertised window" {
         const n = conn.readStreamingBody(stream, buf[0..]) catch |e| break e;
         try testing.expect(n != 0); // stream must not end cleanly
         total += n;
+        conn.acknowledgeStreamingBody(stream, n);
     };
     try testing.expectEqual(@as(usize, OUR_INITIAL_WINDOW), total);
     try testing.expectError(error.Http2FlowControlError, @as(anyerror!void, read_err));
@@ -2559,6 +2739,7 @@ fn muxStreamingClientThread(ctx: *MuxStreamingClientCtx) void {
         const n = ctx.conn.readStreamingBody(stream, got_buf[got_len..]) catch return;
         if (n == 0) break;
         got_len += n;
+        ctx.conn.acknowledgeStreamingBody(stream, n);
     }
     ctx.ok = std.mem.eql(u8, got_buf[0..got_len], path);
 }
@@ -2700,6 +2881,7 @@ test "streaming request upload sends DATA incrementally and waits for flow-contr
         const n = try conn.readStreamingBody(stream, buf[0..]);
         if (n == 0) break;
         try got.appendSlice(testing.allocator, buf[0..n]);
+        conn.acknowledgeStreamingBody(stream, n);
     }
 
     conn.finishStreaming(stream);

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -3640,8 +3640,8 @@ test "proxy full streaming mode relays fixed-length upload beyond request buffer
         });
         defer active_metrics.deinit();
         saw_active_upload =
-            std.mem.find(u8, active_metrics.body, "tardigrade_buffered_bytes_current{direction=\"downstream_to_upstream\",scope=\"stream\"} 32768") != null and
-            std.mem.find(u8, active_metrics.body, "tardigrade_buffered_bytes_current{direction=\"downstream_to_upstream\",scope=\"global\"} 32768") != null and
+            std.mem.find(u8, active_metrics.body, "tardigrade_buffered_bytes_current{direction=\"downstream_to_upstream\",scope=\"stream\"} 16384") != null and
+            std.mem.find(u8, active_metrics.body, "tardigrade_buffered_bytes_current{direction=\"downstream_to_upstream\",scope=\"global\"} 16384") != null and
             std.mem.find(u8, active_metrics.body, "tardigrade_buffered_bytes_current{direction=\"upstream_to_downstream\",scope=\"stream\"} 0") != null;
         if (!saw_active_upload) compat.sleepNs(25 * std.time.ns_per_ms);
     }

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -3605,21 +3605,47 @@ test "proxy full streaming mode relays fixed-length upload beyond request buffer
         .config_text = config_text,
         .extra_env = &.{
             .{ .name = "TARDIGRADE_PROXY_STREAMING_MODE", .value = "full" },
+            .{ .name = "TARDIGRADE_WORKER_THREADS", .value = "2" },
             .{ .name = "TARDIGRADE_PROXY_STREAM_BUFFER_SIZE", .value = "4096" },
             .{ .name = "TARDIGRADE_PROXY_BUFFER_PER_STREAM_LOW_WATERMARK_BYTES", .value = "1024" },
             .{ .name = "TARDIGRADE_PROXY_BUFFER_PER_STREAM_HIGH_WATERMARK_BYTES", .value = "2048" },
-            .{ .name = "TARDIGRADE_PROXY_BUFFER_PER_STREAM_HARD_LIMIT_BYTES", .value = "4096" },
+            .{ .name = "TARDIGRADE_PROXY_BUFFER_PER_STREAM_HARD_LIMIT_BYTES", .value = "16384" },
             .{ .name = "TARDIGRADE_MAX_BODY_SIZE", .value = "1048576" },
         },
     });
     defer tardigrade.stop();
 
-    var response = try sendRequest(allocator, tardigrade.port, .{
-        .method = "POST",
-        .path = "/upload",
-        .body = payload,
-        .headers = &.{.{ .name = "Content-Type", .value = "application/octet-stream" }},
-    });
+    var upload_stream = try compat.tcpConnectToHost(allocator, test_host, tardigrade.port);
+    defer upload_stream.close();
+    try setStreamTimeouts(&upload_stream, 5_000);
+    const upload_head = try std.fmt.allocPrint(
+        allocator,
+        "POST /upload HTTP/1.1\r\nHost: {s}:{d}\r\nConnection: close\r\nContent-Type: application/octet-stream\r\nContent-Length: {d}\r\n\r\n",
+        .{ test_host, tardigrade.port, payload.len },
+    );
+    defer allocator.free(upload_head);
+    try upload_stream.writeAll(upload_head);
+
+    var saw_active_upload = false;
+    var metrics_attempt: usize = 0;
+    while (metrics_attempt < 20 and !saw_active_upload) : (metrics_attempt += 1) {
+        var active_metrics = try sendRequest(allocator, tardigrade.port, .{
+            .method = "GET",
+            .path = "/status/metrics",
+            .body = "",
+            .headers = &.{},
+        });
+        defer active_metrics.deinit();
+        saw_active_upload =
+            std.mem.find(u8, active_metrics.body, "tardigrade_buffered_bytes_current{direction=\"downstream_to_upstream\",scope=\"stream\"} 16384") != null and
+            std.mem.find(u8, active_metrics.body, "tardigrade_buffered_bytes_current{direction=\"downstream_to_upstream\",scope=\"global\"} 16384") != null and
+            std.mem.find(u8, active_metrics.body, "tardigrade_buffered_bytes_current{direction=\"upstream_to_downstream\",scope=\"stream\"} 0") != null;
+        if (!saw_active_upload) compat.sleepNs(25 * std.time.ns_per_ms);
+    }
+    try std.testing.expect(saw_active_upload);
+
+    try upload_stream.writeAll(payload);
+    var response = try readHttpResponse(allocator, upload_stream);
     defer response.deinit();
     try std.testing.expectEqual(@as(u16, 200), response.status_code);
     try std.testing.expectEqualStrings("uploaded", response.body);
@@ -3637,7 +3663,7 @@ test "proxy full streaming mode relays fixed-length upload beyond request buffer
     });
     defer metrics.deinit();
     try std.testing.expect(std.mem.find(u8, metrics.body, "tardigrade_buffer_high_watermark_events_total{direction=\"upstream_to_downstream\",scope=\"stream\"} 1") != null);
-    try std.testing.expect(std.mem.find(u8, metrics.body, "tardigrade_buffer_high_watermark_events_total{direction=\"downstream_to_upstream\",scope=\"stream\"} 0") != null);
+    try std.testing.expect(std.mem.find(u8, metrics.body, "tardigrade_buffer_high_watermark_events_total{direction=\"downstream_to_upstream\",scope=\"stream\"} 1") != null);
     try std.testing.expect(std.mem.find(u8, metrics.body, "tardigrade_buffered_bytes_current{direction=\"upstream_to_downstream\",scope=\"global\"} 0") != null);
     try std.testing.expect(std.mem.find(u8, metrics.body, "tardigrade_buffered_bytes_current{direction=\"downstream_to_upstream\",scope=\"global\"} 0") != null);
 }

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -3606,6 +3606,9 @@ test "proxy full streaming mode relays fixed-length upload beyond request buffer
         .extra_env = &.{
             .{ .name = "TARDIGRADE_PROXY_STREAMING_MODE", .value = "full" },
             .{ .name = "TARDIGRADE_PROXY_STREAM_BUFFER_SIZE", .value = "4096" },
+            .{ .name = "TARDIGRADE_PROXY_BUFFER_PER_STREAM_LOW_WATERMARK_BYTES", .value = "1024" },
+            .{ .name = "TARDIGRADE_PROXY_BUFFER_PER_STREAM_HIGH_WATERMARK_BYTES", .value = "2048" },
+            .{ .name = "TARDIGRADE_PROXY_BUFFER_PER_STREAM_HARD_LIMIT_BYTES", .value = "4096" },
             .{ .name = "TARDIGRADE_MAX_BODY_SIZE", .value = "1048576" },
         },
     });
@@ -3625,6 +3628,18 @@ test "proxy full streaming mode relays fixed-length upload beyond request buffer
     defer allocator.free(captured);
     try std.testing.expectEqual(@as(usize, payload_len), captured.len);
     try std.testing.expectEqualStrings(payload, captured);
+
+    var metrics = try sendRequest(allocator, tardigrade.port, .{
+        .method = "GET",
+        .path = "/status/metrics",
+        .body = "",
+        .headers = &.{},
+    });
+    defer metrics.deinit();
+    try std.testing.expect(std.mem.find(u8, metrics.body, "tardigrade_buffer_high_watermark_events_total{direction=\"upstream_to_downstream\",scope=\"stream\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, metrics.body, "tardigrade_buffer_high_watermark_events_total{direction=\"downstream_to_upstream\",scope=\"stream\"} 0") != null);
+    try std.testing.expect(std.mem.find(u8, metrics.body, "tardigrade_buffered_bytes_current{direction=\"upstream_to_downstream\",scope=\"global\"} 0") != null);
+    try std.testing.expect(std.mem.find(u8, metrics.body, "tardigrade_buffered_bytes_current{direction=\"downstream_to_upstream\",scope=\"global\"} 0") != null);
 }
 
 test "proxy full streaming upload works for server block route override" {

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -3609,7 +3609,7 @@ test "proxy full streaming mode relays fixed-length upload beyond request buffer
             .{ .name = "TARDIGRADE_PROXY_STREAM_BUFFER_SIZE", .value = "4096" },
             .{ .name = "TARDIGRADE_PROXY_BUFFER_PER_STREAM_LOW_WATERMARK_BYTES", .value = "1024" },
             .{ .name = "TARDIGRADE_PROXY_BUFFER_PER_STREAM_HIGH_WATERMARK_BYTES", .value = "2048" },
-            .{ .name = "TARDIGRADE_PROXY_BUFFER_PER_STREAM_HARD_LIMIT_BYTES", .value = "16384" },
+            .{ .name = "TARDIGRADE_PROXY_BUFFER_PER_STREAM_HARD_LIMIT_BYTES", .value = "65536" },
             .{ .name = "TARDIGRADE_MAX_BODY_SIZE", .value = "1048576" },
         },
     });
@@ -3624,7 +3624,10 @@ test "proxy full streaming mode relays fixed-length upload beyond request buffer
         .{ test_host, tardigrade.port, payload.len },
     );
     defer allocator.free(upload_head);
-    try upload_stream.writeAll(upload_head);
+    const initial_prefix_len = 32 * 1024;
+    const initial_request = try std.mem.concat(allocator, u8, &.{ upload_head, payload[0..initial_prefix_len] });
+    defer allocator.free(initial_request);
+    try upload_stream.writeAll(initial_request);
 
     var saw_active_upload = false;
     var metrics_attempt: usize = 0;
@@ -3637,14 +3640,14 @@ test "proxy full streaming mode relays fixed-length upload beyond request buffer
         });
         defer active_metrics.deinit();
         saw_active_upload =
-            std.mem.find(u8, active_metrics.body, "tardigrade_buffered_bytes_current{direction=\"downstream_to_upstream\",scope=\"stream\"} 16384") != null and
-            std.mem.find(u8, active_metrics.body, "tardigrade_buffered_bytes_current{direction=\"downstream_to_upstream\",scope=\"global\"} 16384") != null and
+            std.mem.find(u8, active_metrics.body, "tardigrade_buffered_bytes_current{direction=\"downstream_to_upstream\",scope=\"stream\"} 32768") != null and
+            std.mem.find(u8, active_metrics.body, "tardigrade_buffered_bytes_current{direction=\"downstream_to_upstream\",scope=\"global\"} 32768") != null and
             std.mem.find(u8, active_metrics.body, "tardigrade_buffered_bytes_current{direction=\"upstream_to_downstream\",scope=\"stream\"} 0") != null;
         if (!saw_active_upload) compat.sleepNs(25 * std.time.ns_per_ms);
     }
     try std.testing.expect(saw_active_upload);
 
-    try upload_stream.writeAll(payload);
+    try upload_stream.writeAll(payload[initial_prefix_len..]);
     var response = try readHttpResponse(allocator, upload_stream);
     defer response.deinit();
     try std.testing.expectEqual(@as(u16, 200), response.status_code);


### PR DESCRIPTION
## Summary
- add shared proxy buffer accounting directions, scopes, limits, and owner-local reservation helper
- add validated proxy buffer watermark env config and expose configured limits in Prometheus
- add bounded-cardinality buffer current/high-watermark/pause/resume/limit metrics, fold legacy buffered-response bytes into the shared metric surface, and account streaming relay buffers during active streaming proxy exchanges
- document the new operator-facing metrics and config knobs

Refs #140

## Validation
- zig fmt --check build.zig src/ tests/
- git diff --check
- zig build test --summary all --error-style verbose
- zig build test-integration -- --test-filter "proxy streams upstream response incrementally"