### PR TITLE
crypto: add deterministic TLS and QUIC vector harness

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -259,6 +259,24 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_crypto_tests.step);
     test_step.dependOn(&run_crypto_secret_tests.step);
 
+    // Deterministic crypto vector harness (#373): provider-neutral test
+    // vectors, TLS 1.3 key schedule values, QUIC packet-protection material,
+    // and explicit negative coverage for deferred capabilities.
+    const crypto_vector_mod = b.createModule(.{
+        .root_source_file = b.path("tests/crypto_vectors.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    crypto_vector_mod.addImport("crypto", crypto_mod);
+    crypto_vector_mod.addImport("tls_core", tls_core_mod);
+    crypto_vector_mod.addImport("quic", quic_mod);
+    const crypto_vector_tests = b.addTest(.{ .root_module = crypto_vector_mod });
+    const run_crypto_vector_tests = b.addRunArtifact(crypto_vector_tests);
+    const crypto_vector_step = b.step("test-crypto-vectors", "Run deterministic TLS/QUIC cryptographic vector harness");
+    crypto_vector_step.dependOn(&run_crypto_vector_tests.step);
+    crypto_step.dependOn(&run_crypto_vector_tests.step);
+    test_step.dependOn(&run_crypto_vector_tests.step);
+
     // Test-only: a real client/server TLS 1.3 handshake through the merged
     // record stack (#408 finding 6). This needs the "crypto" module (to
     // build a pure-Zig CryptoProvider for the record_epoch_bridge.Bridge

--- a/tests/crypto_vectors.zig
+++ b/tests/crypto_vectors.zig
@@ -1,0 +1,323 @@
+//! Deterministic TLS/QUIC cryptographic vector harness (#373).
+//!
+//! The cases in this file intentionally sit outside the module-local unit
+//! tests. They bind the provider capability matrix to externally sourced
+//! vectors and protocol derivation stages so adding or advertising a crypto
+//! capability requires either positive vector coverage or an explicit waiver.
+
+const std = @import("std");
+const crypto_pkg = @import("crypto");
+const quic = @import("quic");
+const tls_core = @import("tls_core");
+
+const testing = std.testing;
+const provider = crypto_pkg.provider;
+const profile = crypto_pkg.profile;
+const pure_zig = crypto_pkg.pure_zig;
+
+const Coverage = enum {
+    positive,
+    negative,
+    waived,
+};
+
+const VectorMeta = struct {
+    name: []const u8,
+    source: []const u8,
+    license: []const u8,
+};
+
+const vector_meta = [_]VectorMeta{
+    .{ .name = "hkdf-rfc5869-case-1", .source = "RFC 5869 Appendix A.1", .license = "IETF Trust" },
+    .{ .name = "tls13-rfc8448-simple-1rtt", .source = "RFC 8448 Section 3", .license = "IETF Trust" },
+    .{ .name = "tls13-record-protection-aes128-gcm", .source = "Independently computed with Python hmac/hashlib and pycryptodome", .license = "project fixture" },
+    .{ .name = "quic-v1-initial-rfc9001-a1", .source = "RFC 9001 Appendix A.1", .license = "IETF Trust" },
+    .{ .name = "aes-128-gcm-nist-zero-block", .source = "NIST SP 800-38D / CAVP GCM zero-block vector", .license = "public domain" },
+    .{ .name = "aes-256-gcm-nist-zero-block", .source = "NIST SP 800-38D / CAVP GCM zero-block vector", .license = "public domain" },
+    .{ .name = "chacha20-poly1305-rfc8439", .source = "RFC 8439 Section 2.8.2", .license = "IETF Trust" },
+    .{ .name = "x25519-rfc7748-alice-bob", .source = "RFC 7748 Section 6.1", .license = "IETF Trust" },
+    .{ .name = "ed25519-rfc8032-test-1", .source = "RFC 8032 Section 7.1", .license = "IETF Trust" },
+};
+
+fn hexBytes(comptime hex: []const u8) [hex.len / 2]u8 {
+    var bytes: [hex.len / 2]u8 = undefined;
+    _ = std.fmt.hexToBytes(&bytes, hex) catch unreachable;
+    return bytes;
+}
+
+fn expectStage(stage: []const u8, expected: []const u8, actual: []const u8) !void {
+    if (!std.mem.eql(u8, expected, actual)) {
+        std.debug.print("crypto vector mismatch at stage: {s}\n", .{stage});
+        return error.VectorMismatch;
+    }
+}
+
+fn expectVectorError(stage: []const u8, expected_error: anyerror, actual_error: anyerror) !void {
+    if (actual_error != expected_error) {
+        std.debug.print("crypto vector error mismatch at stage: {s}; got {s}\n", .{ stage, @errorName(actual_error) });
+        return error.VectorMismatch;
+    }
+}
+
+fn cryptoProvider() provider.CryptoProvider {
+    const Holder = struct {
+        var entropy = pure_zig.DeterministicEntropy.init(0x373);
+        var provider_instance = pure_zig.Provider.init(entropy.entropy());
+    };
+    return Holder.provider_instance.cryptoProvider();
+}
+
+fn coverageForAlgorithm(algorithm: profile.Algorithm) Coverage {
+    return switch (algorithm) {
+        .hash => |hash| switch (hash) {
+            .sha256 => .positive,
+            .sha384 => .positive,
+        },
+        .hkdf => |hash| switch (hash) {
+            .sha256 => .positive,
+            .sha384 => .positive,
+        },
+        .aead => |aead| switch (aead) {
+            .aes_128_gcm => .positive,
+            .aes_256_gcm => .positive,
+            .chacha20_poly1305 => .positive,
+        },
+        .group => |group| switch (group) {
+            .x25519 => .positive,
+            .secp256r1 => .negative,
+        },
+        .signature => |scheme| switch (scheme) {
+            .ed25519 => .positive,
+            .ecdsa_secp256r1_sha256 => .positive,
+            .rsa_pss_rsae_sha256 => .negative,
+        },
+        .certificate_helper => |helper| switch (helper) {
+            .der_parser => .waived,
+            .chain_builder => .waived,
+            .webpki_validation => .waived,
+        },
+        .entropy => |capability| switch (capability) {
+            .injected_random_bytes => .positive,
+            .secure_zero => .positive,
+            .constant_time_compare => .positive,
+        },
+    };
+}
+
+test "vector manifest records provenance and licensing" {
+    for (vector_meta) |entry| {
+        try testing.expect(entry.name.len > 0);
+        try testing.expect(entry.source.len > 0);
+        try testing.expect(entry.license.len > 0);
+    }
+}
+
+test "capability matrix has vector coverage or explicit waivers" {
+    for (profile.rows) |row| {
+        const coverage = coverageForAlgorithm(row.algorithm);
+        switch (row.pure_zig_status) {
+            .supported => try testing.expectEqual(Coverage.positive, coverage),
+            .provider_deferred, .unsupported => try testing.expect(coverage == .negative or coverage == .waived),
+        }
+    }
+}
+
+test "provider HKDF stages match RFC 5869 and TLS expand-label vectors" {
+    const cp = cryptoProvider();
+
+    const ikm = hexBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+    const salt = hexBytes("000102030405060708090a0b0c");
+    const info = hexBytes("f0f1f2f3f4f5f6f7f8f9");
+    const expected_prk = hexBytes("077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5");
+    var prk: [provider.Hash.sha256.digestLength()]u8 = undefined;
+    try cp.hkdfExtract(.sha256, &salt, &ikm, &prk);
+    try expectStage("hkdf extract sha256 / RFC 5869 A.1", &expected_prk, &prk);
+
+    const HkdfSha256 = std.crypto.kdf.hkdf.HkdfSha256;
+    const expected_okm = std.crypto.tls.hkdfExpandLabel(HkdfSha256, prk, "derived", &info, 42);
+    var okm: [42]u8 = undefined;
+    try cp.hkdfExpandLabel(.sha256, &prk, "derived", &info, &okm);
+    try expectStage("hkdf expand-label sha256 / TLS label", &expected_okm, &okm);
+
+    const secret384 = [_]u8{0x42} ** provider.Hash.sha384.digestLength();
+    const HkdfSha384 = std.crypto.kdf.hkdf.Hkdf(std.crypto.auth.hmac.sha2.HmacSha384);
+    const expected384 = std.crypto.tls.hkdfExpandLabel(HkdfSha384, secret384, "c hs traffic", "", 48);
+    var out384: [48]u8 = undefined;
+    try cp.hkdfExpandLabel(.sha384, &secret384, "c hs traffic", "", &out384);
+    try expectStage("hkdf expand-label sha384 / TLS label", &expected384, &out384);
+}
+
+test "TLS 1.3 key schedule and Finished value match RFC 8448" {
+    const KeySchedule = tls_core.key_schedule.KeySchedule;
+
+    const shared = hexBytes("8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d");
+    const hello_hash = hexBytes("860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8");
+    var schedule = KeySchedule.init(shared, hello_hash);
+    defer schedule.wipe();
+
+    try expectStage("tls13 handshake secret / RFC 8448", &hexBytes("1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac"), &schedule.handshake_secret);
+    try expectStage("tls13 client handshake traffic secret / RFC 8448", &hexBytes("b3eddb126e067f35a780b3abf45e2d8f3b1a950738f52e9600746a0e27a55a21"), &schedule.client_handshake_traffic);
+    try expectStage("tls13 server handshake traffic secret / RFC 8448", &hexBytes("b67b7d690cc16c4e75e54213cb2d37b4e9c912bcded9105d42befd59d391ad38"), &schedule.server_handshake_traffic);
+    try expectStage("tls13 master secret / RFC 8448", &hexBytes("18df06843d13a08bf2a449844c5f8a478001bc4d4c627984d5a41da8d0402919"), &schedule.master_secret);
+
+    const finished_hash = hexBytes("9608102a0f1ccc6db6250b7b7e417b1a000eaada3daae4777a7686c9ff83df13");
+    const app = schedule.applicationSecrets(finished_hash);
+    try expectStage("tls13 client application traffic secret / RFC 8448", &hexBytes("9e40646ce79a7f9dc05af8889bce6552875afa0b06df0087f792ebb7c17504a5"), &app.client);
+    try expectStage("tls13 server application traffic secret / RFC 8448", &hexBytes("a11af9f05531f856ad47116b45a950328204b4f44bfb6b3a4b4f1f3fcb631643"), &app.server);
+    try expectStage("tls13 server Finished key / RFC 8448", &hexBytes("008d3b66f816ea559f96b537e885c31fc068bf492c652f01f288a1d8cdc19fc8"), &KeySchedule.finishedKey(schedule.server_handshake_traffic));
+    try expectStage("tls13 server Finished verify_data / RFC 8448", &hexBytes("c5486af1426697c43c18dab6a79ef816a2188023ea743133b7e3b15a2c05c955"), &KeySchedule.verifyData(schedule.server_handshake_traffic, finished_hash));
+}
+
+test "TLS 1.3 record-protection keys and ciphertext match independent vector" {
+    const cp = cryptoProvider();
+    const record_protection = tls_core.record_protection;
+    const record_codec = tls_core.record_codec;
+
+    const secret = hexBytes("0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20");
+    var keys = try record_protection.TrafficKeys.derive(cp, .tls_aes_128_gcm_sha256, &secret);
+    defer keys.deinit();
+    try expectStage("tls record aes128 key / independent vector", &hexBytes("28596a230c2c30a952fe79483568e18e"), keys.key.slice());
+    try expectStage("tls record aes128 iv / independent vector", &hexBytes("fc73b522c6809e028f922c68"), keys.iv.slice());
+
+    var write = record_protection.WriteState.init(cp, try record_protection.TrafficKeys.derive(cp, .tls_aes_128_gcm_sha256, &secret));
+    defer write.deinit();
+    var protected: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    const record = try write.seal(.handshake, "server finished record", 4, &protected);
+    const expected_record = hexBytes("170303002b09a08c281b147b36e277f6ac671ccd9cbc6c479d903cc2805ada8981b69579074aaad50b620ab144a6022e");
+    try expectStage("tls record aes128 ciphertext / independent vector", &expected_record, record);
+
+    var read = record_protection.ReadState.init(cp, try record_protection.TrafficKeys.derive(cp, .tls_aes_128_gcm_sha256, &secret));
+    defer read.deinit();
+    const parsed: record_codec.TLSCiphertext = .{
+        .content_type = .application_data,
+        .legacy_version = record_codec.legacy_record_version,
+        .payload = record[record_codec.header_len..],
+    };
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    const inner = try read.open(parsed, &plaintext);
+    try testing.expectEqual(record_codec.ContentType.handshake, inner.content_type);
+    try testing.expectEqualStrings("server finished record", inner.content);
+    try testing.expectEqual(@as(usize, 4), inner.padding_len);
+}
+
+test "QUIC v1 initial secrets and packet-protection material match RFC 9001" {
+    const dcid = hexBytes("8394c8f03e515708");
+    const secrets = try quic.tls_adapter.deriveInitialSecretsV1(&dcid);
+
+    try expectStage("quic initial secret / RFC 9001 A.1", &hexBytes("7db5df06e7a69e432496adedb00851923595221596ae2ae9fb8115c1e9ed0a44"), &secrets.initial_secret);
+    try expectStage("quic client initial secret / RFC 9001 A.1", &hexBytes("c00cf151ca5be075ed0ebfb5c80323c42d6b7db67881289af4008f1f6c357aea"), &secrets.client.secret);
+    try expectStage("quic client initial key / RFC 9001 A.1", &hexBytes("1f369613dd76d5467730efcbe3b1a22d"), &secrets.client.key);
+    try expectStage("quic client initial iv / RFC 9001 A.1", &hexBytes("fa044b2f42a3fd3b46fb255c"), &secrets.client.iv);
+    try expectStage("quic client initial hp / RFC 9001 A.1", &hexBytes("9f50449e04a0e810283a1e9933adedd2"), &secrets.client.hp);
+    try expectStage("quic server initial secret / RFC 9001 A.1", &hexBytes("3c199828fd139efd216c155ad844cc81fb82fa8d7446fa7d78be803acdda951b"), &secrets.server.secret);
+    try expectStage("quic server initial key / RFC 9001 A.1", &hexBytes("cf3a5331653c364c88f0f379b6067e37"), &secrets.server.key);
+    try expectStage("quic server initial iv / RFC 9001 A.1", &hexBytes("0ac1493ca1905853b0bba03e"), &secrets.server.iv);
+    try expectStage("quic server initial hp / RFC 9001 A.1", &hexBytes("c206b8d9b9f0f37644430b490eeaa314"), &secrets.server.hp);
+
+    try expectStage("quic packet nonce / RFC 9001 A.2", &hexBytes("fa044b2f42a3fd3b46fb255e"), &secrets.client.nonce(2));
+
+    const sample = hexBytes("d1b1c98dd7689fb8ec11d242b123dc9b");
+    try expectStage("quic header-protection mask / RFC 9001 A.3", &hexBytes("437b9aec36"), &secrets.client.headerProtectionMask(sample));
+
+    var header = hexBytes("c300000001088394c8f03e5157080000449e00000002");
+    var plaintext = [_]u8{0} ** 32;
+    var sealed: [plaintext.len + quic.tls_adapter.packet_protection_tag_len]u8 = undefined;
+    const protected = try secrets.client.sealPayload(2, &header, &plaintext, &sealed);
+    var opened: [plaintext.len]u8 = undefined;
+    try expectStage("quic packet-protection open after seal", &plaintext, try secrets.client.openPayload(2, &header, protected, &opened));
+
+    sealed[sealed.len - 1] ^= 0x01;
+    _ = secrets.client.openPayload(2, &header, &sealed, &opened) catch |err| {
+        try expectVectorError("quic packet-protection auth tag rejection", error.AuthenticationFailed, err);
+        return;
+    };
+    return error.ExpectedAuthenticationFailure;
+}
+
+test "provider AEAD vectors seal, open, and reject authentication failures" {
+    const cp = cryptoProvider();
+
+    try runAeadVector(.aes_128_gcm, &hexBytes("00000000000000000000000000000000"), &hexBytes("000000000000000000000000"), "", &hexBytes("00000000000000000000000000000000"), &hexBytes("0388dace60b6a392f328c2b971b2fe78"), &hexBytes("ab6e47d42cec13bdf53a67b21257bddf"), "aes-128-gcm NIST zero-block", cp);
+    try runAeadVector(.aes_256_gcm, &hexBytes("0000000000000000000000000000000000000000000000000000000000000000"), &hexBytes("000000000000000000000000"), "", &hexBytes("00000000000000000000000000000000"), &hexBytes("cea7403d4d606b6e074ec5d3baf39d18"), &hexBytes("d0d1c8a799996bf0265b98b5d48ab919"), "aes-256-gcm NIST zero-block", cp);
+    try runAeadVector(
+        .chacha20_poly1305,
+        &hexBytes("808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f"),
+        &hexBytes("070000004041424344454647"),
+        &hexBytes("50515253c0c1c2c3c4c5c6c7"),
+        &hexBytes("4c616469657320616e642047656e746c656d656e206f662074686520636c617373206f66202739393a204966204920636f756c64206f6666657220796f75206f6e6c79206f6e652074697020666f7220746865206675747572652c2073756e73637265656e20776f756c642062652069742e"),
+        &hexBytes("d31a8d34648e60db7b86afbc53ef7ec2a4aded51296e08fea9e2b5a736ee62d63dbea45e8ca9671282fafb69da92728b1a71de0a9e060b2905d6a5b67ecd3b3692ddbd7f2d778b8c9803aee328091b58fab324e4fad675945585808b4831d7bc3ff4def08e4b7a9de576d26586cec64b6116"),
+        &hexBytes("1ae10b594f09e26a7e902ecbd0600691"),
+        "chacha20-poly1305 RFC 8439",
+        cp,
+    );
+}
+
+fn runAeadVector(
+    aead: provider.Aead,
+    key: []const u8,
+    nonce: []const u8,
+    aad: []const u8,
+    plaintext: []const u8,
+    expected_ciphertext: []const u8,
+    expected_tag: []const u8,
+    stage: []const u8,
+    cp: provider.CryptoProvider,
+) !void {
+    const ciphertext = try testing.allocator.alloc(u8, plaintext.len);
+    defer testing.allocator.free(ciphertext);
+    var tag: [provider.aead_tag_len]u8 = undefined;
+    try cp.aeadSeal(aead, key, nonce, aad, plaintext, ciphertext, &tag);
+    try expectStage(stage, expected_ciphertext, ciphertext);
+    try expectStage(stage, expected_tag, &tag);
+
+    const opened = try testing.allocator.alloc(u8, plaintext.len);
+    defer testing.allocator.free(opened);
+    try cp.aeadOpen(aead, key, nonce, aad, ciphertext, &tag, opened);
+    try expectStage(stage, plaintext, opened);
+
+    tag[0] ^= 0x01;
+    cp.aeadOpen(aead, key, nonce, aad, ciphertext, &tag, opened) catch |err| {
+        try expectVectorError(stage, error.AuthenticationFailed, err);
+        for (opened) |byte| try testing.expectEqual(@as(u8, 0), byte);
+        return;
+    };
+    return error.ExpectedAuthenticationFailure;
+}
+
+test "provider key exchange and signature vectors match RFC sources" {
+    const cp = cryptoProvider();
+
+    const alice_private = hexBytes("77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a");
+    const bob_public = hexBytes("de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f");
+    const expected_shared = hexBytes("4a5d9d5ba4ce2de1728e3bf480350f25e07e21c947d19e3376f09b3c1e161742");
+    var shared: [32]u8 = undefined;
+    try cp.deriveSharedSecret(.x25519, &alice_private, &bob_public, &shared);
+    try expectStage("x25519 shared secret / RFC 7748", &expected_shared, &shared);
+
+    const zero_point = [_]u8{0} ** 32;
+    cp.deriveSharedSecret(.x25519, &alice_private, &zero_point, &shared) catch |err| {
+        try expectVectorError("x25519 low-order point rejection", error.InvalidInput, err);
+    };
+
+    const ed_seed = hexBytes("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60");
+    const ed_public = hexBytes("d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a");
+    const ed_signature = hexBytes("e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b");
+    var key = try pure_zig.SoftwareSigningKey.fromSeed(ed_seed);
+    defer key.deinit();
+    const actual_public = key.publicKey();
+    try expectStage("ed25519 public key / RFC 8032", &ed_public, &actual_public);
+    var actual_signature: [64]u8 = undefined;
+    const len = try key.signingKey().sign("", cp.entropy, &actual_signature);
+    try testing.expectEqual(@as(usize, 64), len);
+    try expectStage("ed25519 signature / RFC 8032", &ed_signature, &actual_signature);
+    try cp.verify(.ed25519, &ed_public, "", &ed_signature);
+}
+
+test "unsupported provider capabilities are negative cases, not silent skips" {
+    const cp = cryptoProvider();
+    var scalar: [32]u8 = undefined;
+    var public: [65]u8 = undefined;
+    try testing.expectError(error.UnsupportedCapability, cp.generateKeyShare(.secp256r1, &public, &scalar));
+    try testing.expectError(error.UnsupportedCapability, cp.deriveSharedSecret(.secp256r1, &scalar, public[0..32], &scalar));
+    try testing.expectError(error.UnsupportedCapability, cp.verify(.rsa_pss_rsae_sha256, "", "", ""));
+}

--- a/tests/crypto_vectors.zig
+++ b/tests/crypto_vectors.zig
@@ -137,6 +137,27 @@ fn requireCase(id: []const u8) error{MissingCaseMetadata}!*const CaseMeta {
     return error.MissingCaseMetadata;
 }
 
+const ExecutionLog = struct {
+    ids: [case_registry.len][]const u8 = undefined,
+    len: usize = 0,
+
+    fn execute(self: *ExecutionLog, id: []const u8) !*const CaseMeta {
+        const meta = try requireCase(id);
+        if (!self.hasId(id)) {
+            self.ids[self.len] = id;
+            self.len += 1;
+        }
+        return meta;
+    }
+
+    fn hasId(self: *const ExecutionLog, id: []const u8) bool {
+        for (self.ids[0..self.len]) |executed| {
+            if (std.mem.eql(u8, executed, id)) return true;
+        }
+        return false;
+    }
+};
+
 fn algorithmEql(a: profile.Algorithm, b: profile.Algorithm) bool {
     return switch (a) {
         .hash => |value| b == .hash and b.hash == value,
@@ -149,8 +170,9 @@ fn algorithmEql(a: profile.Algorithm, b: profile.Algorithm) bool {
     };
 }
 
-fn hasCase(provider_kind: ProviderKind, algorithm: profile.Algorithm, class: CaseClass) bool {
-    for (case_registry) |entry| {
+fn executedCase(log: *const ExecutionLog, provider_kind: ProviderKind, algorithm: profile.Algorithm, class: CaseClass) bool {
+    for (log.ids[0..log.len]) |id| {
+        const entry = requireCase(id) catch unreachable;
         const entry_algorithm = entry.algorithm orelse continue;
         if (entry.class == class and entry.providers.has(provider_kind) and algorithmEql(entry_algorithm, algorithm)) return true;
     }
@@ -181,12 +203,13 @@ fn requiresNegativeCase(algorithm: profile.Algorithm) bool {
     };
 }
 
-test "vector manifest records provenance and licensing" {
+fn validateManifest(log: *const ExecutionLog) !void {
     for (case_registry) |entry| {
         try testing.expect(entry.id.len > 0);
         try testing.expect(entry.source.len > 0);
         try testing.expect(entry.license.len > 0);
         try testing.expect(entry.reproduction.len > 0);
+        try testing.expect(log.hasId(entry.id));
     }
     for (waivers) |waiver| {
         try testing.expect(waiver.reason.len > 0);
@@ -198,28 +221,29 @@ test "vector manifest records provenance and licensing" {
     }
 }
 
-test "capability matrix has vector coverage or explicit waivers" {
+fn validateCapabilityMatrix(log: *const ExecutionLog) !void {
     for (profile.rows) |row| {
         inline for (.{ ProviderKind.pure_zig, ProviderKind.openssl }) |provider_kind| {
             switch (rowStatus(provider_kind, row)) {
                 .supported => {
-                    try testing.expect(hasCase(provider_kind, row.algorithm, .positive) or hasWaiver(provider_kind, row.algorithm));
+                    try testing.expect(executedCase(log, provider_kind, row.algorithm, .positive) or hasWaiver(provider_kind, row.algorithm));
                     if (requiresNegativeCase(row.algorithm)) {
-                        try testing.expect(hasCase(provider_kind, row.algorithm, .negative) or hasWaiver(provider_kind, row.algorithm));
+                        try testing.expect(executedCase(log, provider_kind, row.algorithm, .negative) or hasWaiver(provider_kind, row.algorithm));
                     }
                 },
-                .provider_deferred, .unsupported => try testing.expect(hasCase(provider_kind, row.algorithm, .negative) or hasWaiver(provider_kind, row.algorithm)),
+                .provider_deferred, .unsupported => try testing.expect(executedCase(log, provider_kind, row.algorithm, .negative) or hasWaiver(provider_kind, row.algorithm)),
             }
         }
     }
 }
 
-test "provider HKDF stages match RFC 5869 and TLS expand-label vectors" {
-    _ = try requireCase("hkdf-rfc5869-extract-sha256");
-    _ = try requireCase("hkdf-expand-label-sha256-fixed");
-    _ = try requireCase("hkdf-expand-label-sha384-fixed");
-    _ = try requireCase("hkdf-invalid-secret-length");
-    _ = try requireCase("hkdf-invalid-secret-length-sha384");
+fn runHkdfVectors(log: *ExecutionLog) !void {
+    _ = try log.execute("hkdf-rfc5869-extract-sha256");
+    _ = try log.execute("hkdf-expand-label-sha256-fixed");
+    _ = try log.execute("hkdf-expand-label-sha384-fixed");
+    _ = try log.execute("sha384-expand-label-fixed");
+    _ = try log.execute("hkdf-invalid-secret-length");
+    _ = try log.execute("hkdf-invalid-secret-length-sha384");
     const cp = cryptoProvider();
 
     const ikm = hexBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
@@ -252,8 +276,8 @@ test "provider HKDF stages match RFC 5869 and TLS expand-label vectors" {
     try testing.expectError(error.InvalidInput, cp.hkdfExpandLabel(.sha384, "short", "derived", "", &invalid));
 }
 
-test "TLS 1.3 key schedule KAT matches RFC 8448 precomputed hashes" {
-    _ = try requireCase("tls13-key-schedule-rfc8448");
+fn runTlsKeyScheduleVector(log: *ExecutionLog) !void {
+    _ = try log.execute("tls13-key-schedule-rfc8448");
     const KeySchedule = tls_core.key_schedule.KeySchedule;
 
     const shared = hexBytes("8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d");
@@ -274,8 +298,8 @@ test "TLS 1.3 key schedule KAT matches RFC 8448 precomputed hashes" {
     try expectStage("tls13 server Finished verify_data / RFC 8448", &hexBytes("c5486af1426697c43c18dab6a79ef816a2188023ea743133b7e3b15a2c05c955"), &KeySchedule.verifyData(schedule.server_handshake_traffic, finished_hash));
 }
 
-test "TLS transcript helper hashes encoded handshake bytes and HRR message_hash" {
-    _ = try requireCase("sha256-transcript-hrr-rewrite");
+fn runTranscriptVector(log: *ExecutionLog) !void {
+    _ = try log.execute("sha256-transcript-hrr-rewrite");
     const Transcript = tls_core.transcript.Transcript;
 
     const client_hello_1 = hexBytes("01000003aabbcc");
@@ -297,8 +321,8 @@ test "TLS transcript helper hashes encoded handshake bytes and HRR message_hash"
     try expectStage("tls transcript after ClientHello2", &hexBytes("7ec9461d8bac7434b8ae63e99899d1ef75ce0b716c9ee12aadd5f5837e51d182"), &transcript.peek());
 }
 
-test "TLS 1.3 record-protection keys and ciphertext match independent vector" {
-    _ = try requireCase("tls13-record-aes128-gcm-independent");
+fn runTlsRecordVector(log: *ExecutionLog) !void {
+    _ = try log.execute("tls13-record-aes128-gcm-independent");
     const cp = cryptoProvider();
     const record_protection = tls_core.record_protection;
     const record_codec = tls_core.record_codec;
@@ -330,9 +354,9 @@ test "TLS 1.3 record-protection keys and ciphertext match independent vector" {
     try testing.expectEqual(@as(usize, 4), inner.padding_len);
 }
 
-test "QUIC v1 initial secrets and packet-protection material match RFC 9001" {
-    _ = try requireCase("quic-v1-initial-rfc9001");
-    _ = try requireCase("quic-v1-initial-auth-failure");
+fn runQuicInitialVector(log: *ExecutionLog) !void {
+    _ = try log.execute("quic-v1-initial-rfc9001");
+    _ = try log.execute("quic-v1-initial-auth-failure");
     const dcid = hexBytes("8394c8f03e515708");
     const secrets = try quic.tls_adapter.deriveInitialSecretsV1(&dcid);
 
@@ -382,17 +406,17 @@ test "QUIC v1 initial secrets and packet-protection material match RFC 9001" {
     return error.ExpectedAuthenticationFailure;
 }
 
-test "provider AEAD vectors seal, open, and reject authentication failures" {
+fn runAeadVectors(log: *ExecutionLog) !void {
     const cp = cryptoProvider();
 
-    _ = try requireCase("aes-128-gcm-nist-zero-block");
-    _ = try requireCase("aes-128-gcm-tag-rejection");
+    _ = try log.execute("aes-128-gcm-nist-zero-block");
+    _ = try log.execute("aes-128-gcm-tag-rejection");
     try runAeadVector(.aes_128_gcm, &hexBytes("00000000000000000000000000000000"), &hexBytes("000000000000000000000000"), "", &hexBytes("00000000000000000000000000000000"), &hexBytes("0388dace60b6a392f328c2b971b2fe78"), &hexBytes("ab6e47d42cec13bdf53a67b21257bddf"), "aes-128-gcm NIST zero-block", cp);
-    _ = try requireCase("aes-256-gcm-nist-zero-block");
-    _ = try requireCase("aes-256-gcm-tag-rejection");
+    _ = try log.execute("aes-256-gcm-nist-zero-block");
+    _ = try log.execute("aes-256-gcm-tag-rejection");
     try runAeadVector(.aes_256_gcm, &hexBytes("0000000000000000000000000000000000000000000000000000000000000000"), &hexBytes("000000000000000000000000"), "", &hexBytes("00000000000000000000000000000000"), &hexBytes("cea7403d4d606b6e074ec5d3baf39d18"), &hexBytes("d0d1c8a799996bf0265b98b5d48ab919"), "aes-256-gcm NIST zero-block", cp);
-    _ = try requireCase("chacha20-poly1305-rfc8439");
-    _ = try requireCase("chacha20-poly1305-tag-rejection");
+    _ = try log.execute("chacha20-poly1305-rfc8439");
+    _ = try log.execute("chacha20-poly1305-tag-rejection");
     try runAeadVector(
         .chacha20_poly1305,
         &hexBytes("808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f"),
@@ -438,11 +462,11 @@ fn runAeadVector(
     return error.ExpectedAuthenticationFailure;
 }
 
-test "provider key exchange and signature vectors match RFC sources" {
-    _ = try requireCase("x25519-rfc7748-alice-bob");
-    _ = try requireCase("x25519-low-order-rejection");
-    _ = try requireCase("ed25519-rfc8032-test-1");
-    _ = try requireCase("ed25519-signature-rejection");
+fn runKeyExchangeAndSignatureVectors(log: *ExecutionLog) !void {
+    _ = try log.execute("x25519-rfc7748-alice-bob");
+    _ = try log.execute("x25519-low-order-rejection");
+    _ = try log.execute("ed25519-rfc8032-test-1");
+    _ = try log.execute("ed25519-signature-rejection");
     const cp = cryptoProvider();
 
     const alice_private = hexBytes("77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a");
@@ -475,10 +499,10 @@ test "provider key exchange and signature vectors match RFC sources" {
     try testing.expectError(error.AuthenticationFailed, cp.verify(.ed25519, &ed_public, "", &bad_signature));
 }
 
-test "provider entropy and secret helpers are executable vector cases" {
-    _ = try requireCase("deterministic-entropy-positive");
-    _ = try requireCase("secure-zero-positive");
-    _ = try requireCase("constant-time-compare-positive");
+fn runEntropyAndSecretHelperVectors(log: *ExecutionLog) !void {
+    _ = try log.execute("deterministic-entropy-positive");
+    _ = try log.execute("secure-zero-positive");
+    _ = try log.execute("constant-time-compare-positive");
     var det = pure_zig.DeterministicEntropy.init(0x373);
     var p = pure_zig.Provider.init(det.entropy());
     const cp = p.cryptoProvider();
@@ -496,13 +520,28 @@ test "provider entropy and secret helpers are executable vector cases" {
     try testing.expect(!provider.constantTimeEqual("vector", "vextor"));
 }
 
-test "unsupported provider capabilities are negative cases, not silent skips" {
-    _ = try requireCase("secp256r1-unsupported");
-    _ = try requireCase("rsa-pss-unsupported");
+fn runUnsupportedCapabilityVectors(log: *ExecutionLog) !void {
+    _ = try log.execute("secp256r1-unsupported");
+    _ = try log.execute("rsa-pss-unsupported");
     const cp = cryptoProvider();
     var scalar: [32]u8 = undefined;
     var public: [65]u8 = undefined;
     try testing.expectError(error.UnsupportedCapability, cp.generateKeyShare(.secp256r1, &public, &scalar));
     try testing.expectError(error.UnsupportedCapability, cp.deriveSharedSecret(.secp256r1, &scalar, public[0..32], &scalar));
     try testing.expectError(error.UnsupportedCapability, cp.verify(.rsa_pss_rsae_sha256, "", "", ""));
+}
+
+test "crypto vector suite executes registered coverage" {
+    var log = ExecutionLog{};
+    try runHkdfVectors(&log);
+    try runTlsKeyScheduleVector(&log);
+    try runTranscriptVector(&log);
+    try runTlsRecordVector(&log);
+    try runQuicInitialVector(&log);
+    try runAeadVectors(&log);
+    try runKeyExchangeAndSignatureVectors(&log);
+    try runEntropyAndSecretHelperVectors(&log);
+    try runUnsupportedCapabilityVectors(&log);
+    try validateManifest(&log);
+    try validateCapabilityMatrix(&log);
 }

--- a/tests/crypto_vectors.zig
+++ b/tests/crypto_vectors.zig
@@ -15,28 +15,91 @@ const provider = crypto_pkg.provider;
 const profile = crypto_pkg.profile;
 const pure_zig = crypto_pkg.pure_zig;
 
-const Coverage = enum {
+const ProviderKind = enum {
+    pure_zig,
+    openssl,
+};
+
+const ProviderSet = struct {
+    pure_zig: bool = false,
+    openssl: bool = false,
+
+    fn has(self: ProviderSet, kind: ProviderKind) bool {
+        return switch (kind) {
+            .pure_zig => self.pure_zig,
+            .openssl => self.openssl,
+        };
+    }
+};
+
+const CaseClass = enum {
     positive,
     negative,
-    waived,
 };
 
-const VectorMeta = struct {
-    name: []const u8,
+const CaseMeta = struct {
+    id: []const u8,
+    algorithm: ?profile.Algorithm,
+    providers: ProviderSet,
+    class: CaseClass,
     source: []const u8,
     license: []const u8,
+    reproduction: []const u8,
 };
 
-const vector_meta = [_]VectorMeta{
-    .{ .name = "hkdf-rfc5869-case-1", .source = "RFC 5869 Appendix A.1", .license = "IETF Trust" },
-    .{ .name = "tls13-rfc8448-simple-1rtt", .source = "RFC 8448 Section 3", .license = "IETF Trust" },
-    .{ .name = "tls13-record-protection-aes128-gcm", .source = "Independently computed with Python hmac/hashlib and pycryptodome", .license = "project fixture" },
-    .{ .name = "quic-v1-initial-rfc9001-a1", .source = "RFC 9001 Appendix A.1", .license = "IETF Trust" },
-    .{ .name = "aes-128-gcm-nist-zero-block", .source = "NIST SP 800-38D / CAVP GCM zero-block vector", .license = "public domain" },
-    .{ .name = "aes-256-gcm-nist-zero-block", .source = "NIST SP 800-38D / CAVP GCM zero-block vector", .license = "public domain" },
-    .{ .name = "chacha20-poly1305-rfc8439", .source = "RFC 8439 Section 2.8.2", .license = "IETF Trust" },
-    .{ .name = "x25519-rfc7748-alice-bob", .source = "RFC 7748 Section 6.1", .license = "IETF Trust" },
-    .{ .name = "ed25519-rfc8032-test-1", .source = "RFC 8032 Section 7.1", .license = "IETF Trust" },
+const pure_zig_only: ProviderSet = .{ .pure_zig = true };
+
+const case_registry = [_]CaseMeta{
+    .{ .id = "hkdf-rfc5869-extract-sha256", .algorithm = .{ .hkdf = .sha256 }, .providers = pure_zig_only, .class = .positive, .source = "RFC 5869 Appendix A.1", .license = "IETF Trust", .reproduction = "tests/vectors/generate_crypto_vectors.js" },
+    .{ .id = "hkdf-expand-label-sha256-fixed", .algorithm = .{ .hkdf = .sha256 }, .providers = pure_zig_only, .class = .positive, .source = "tests/vectors/generate_crypto_vectors.js", .license = "project fixture", .reproduction = "node tests/vectors/generate_crypto_vectors.js" },
+    .{ .id = "hkdf-expand-label-sha384-fixed", .algorithm = .{ .hkdf = .sha384 }, .providers = pure_zig_only, .class = .positive, .source = "tests/vectors/generate_crypto_vectors.js", .license = "project fixture", .reproduction = "node tests/vectors/generate_crypto_vectors.js" },
+    .{ .id = "hkdf-invalid-secret-length", .algorithm = .{ .hkdf = .sha256 }, .providers = pure_zig_only, .class = .negative, .source = "provider contract", .license = "project fixture", .reproduction = "zig build test-crypto-vectors" },
+    .{ .id = "hkdf-invalid-secret-length-sha384", .algorithm = .{ .hkdf = .sha384 }, .providers = pure_zig_only, .class = .negative, .source = "provider contract", .license = "project fixture", .reproduction = "zig build test-crypto-vectors" },
+    .{ .id = "sha256-transcript-hrr-rewrite", .algorithm = .{ .hash = .sha256 }, .providers = pure_zig_only, .class = .positive, .source = "RFC 8446 Section 4.4.1 transcript_hash and message_hash", .license = "IETF Trust", .reproduction = "tests/vectors/generate_crypto_vectors.js" },
+    .{ .id = "sha384-expand-label-fixed", .algorithm = .{ .hash = .sha384 }, .providers = pure_zig_only, .class = .positive, .source = "tests/vectors/generate_crypto_vectors.js", .license = "project fixture", .reproduction = "node tests/vectors/generate_crypto_vectors.js" },
+    .{ .id = "tls13-key-schedule-rfc8448", .algorithm = null, .providers = pure_zig_only, .class = .positive, .source = "RFC 8448 Section 3", .license = "IETF Trust", .reproduction = "fixed literals from RFC 8448 plus HMAC-SHA256 Finished MAC" },
+    .{ .id = "tls13-record-aes128-gcm-independent", .algorithm = .{ .aead = .aes_128_gcm }, .providers = pure_zig_only, .class = .positive, .source = "tests/vectors/generate_crypto_vectors.js", .license = "project fixture", .reproduction = "node tests/vectors/generate_crypto_vectors.js" },
+    .{ .id = "quic-v1-initial-rfc9001", .algorithm = .{ .aead = .aes_128_gcm }, .providers = pure_zig_only, .class = .positive, .source = "RFC 9001 Appendix A.1/A.3", .license = "IETF Trust", .reproduction = "fixed RFC literals plus tests/vectors/generate_crypto_vectors.js small packet" },
+    .{ .id = "quic-v1-initial-auth-failure", .algorithm = .{ .aead = .aes_128_gcm }, .providers = pure_zig_only, .class = .negative, .source = "provider contract", .license = "project fixture", .reproduction = "zig build test-crypto-vectors" },
+    .{ .id = "aes-128-gcm-nist-zero-block", .algorithm = .{ .aead = .aes_128_gcm }, .providers = pure_zig_only, .class = .positive, .source = "NIST SP 800-38D / CAVP GCM zero-block vector", .license = "public domain", .reproduction = "published NIST vector" },
+    .{ .id = "aes-128-gcm-tag-rejection", .algorithm = .{ .aead = .aes_128_gcm }, .providers = pure_zig_only, .class = .negative, .source = "provider contract", .license = "project fixture", .reproduction = "zig build test-crypto-vectors" },
+    .{ .id = "aes-256-gcm-nist-zero-block", .algorithm = .{ .aead = .aes_256_gcm }, .providers = pure_zig_only, .class = .positive, .source = "NIST SP 800-38D / CAVP GCM zero-block vector", .license = "public domain", .reproduction = "published NIST vector" },
+    .{ .id = "aes-256-gcm-tag-rejection", .algorithm = .{ .aead = .aes_256_gcm }, .providers = pure_zig_only, .class = .negative, .source = "provider contract", .license = "project fixture", .reproduction = "zig build test-crypto-vectors" },
+    .{ .id = "chacha20-poly1305-rfc8439", .algorithm = .{ .aead = .chacha20_poly1305 }, .providers = pure_zig_only, .class = .positive, .source = "RFC 8439 Section 2.8.2", .license = "IETF Trust", .reproduction = "published RFC vector" },
+    .{ .id = "chacha20-poly1305-tag-rejection", .algorithm = .{ .aead = .chacha20_poly1305 }, .providers = pure_zig_only, .class = .negative, .source = "provider contract", .license = "project fixture", .reproduction = "zig build test-crypto-vectors" },
+    .{ .id = "x25519-rfc7748-alice-bob", .algorithm = .{ .group = .x25519 }, .providers = pure_zig_only, .class = .positive, .source = "RFC 7748 Section 6.1", .license = "IETF Trust", .reproduction = "published RFC vector" },
+    .{ .id = "x25519-low-order-rejection", .algorithm = .{ .group = .x25519 }, .providers = pure_zig_only, .class = .negative, .source = "RFC 7748 low-order input rejection", .license = "IETF Trust", .reproduction = "zig build test-crypto-vectors" },
+    .{ .id = "secp256r1-unsupported", .algorithm = .{ .group = .secp256r1 }, .providers = pure_zig_only, .class = .negative, .source = "provider capability matrix", .license = "project fixture", .reproduction = "zig build test-crypto-vectors" },
+    .{ .id = "ed25519-rfc8032-test-1", .algorithm = .{ .signature = .ed25519 }, .providers = pure_zig_only, .class = .positive, .source = "RFC 8032 Section 7.1", .license = "IETF Trust", .reproduction = "published RFC vector" },
+    .{ .id = "ed25519-signature-rejection", .algorithm = .{ .signature = .ed25519 }, .providers = pure_zig_only, .class = .negative, .source = "provider contract", .license = "project fixture", .reproduction = "zig build test-crypto-vectors" },
+    .{ .id = "rsa-pss-unsupported", .algorithm = .{ .signature = .rsa_pss_rsae_sha256 }, .providers = pure_zig_only, .class = .negative, .source = "provider capability matrix", .license = "project fixture", .reproduction = "zig build test-crypto-vectors" },
+    .{ .id = "deterministic-entropy-positive", .algorithm = .{ .entropy = .injected_random_bytes }, .providers = pure_zig_only, .class = .positive, .source = "provider contract", .license = "project fixture", .reproduction = "zig build test-crypto-vectors" },
+    .{ .id = "secure-zero-positive", .algorithm = .{ .entropy = .secure_zero }, .providers = pure_zig_only, .class = .positive, .source = "provider contract", .license = "project fixture", .reproduction = "zig build test-crypto-vectors" },
+    .{ .id = "constant-time-compare-positive", .algorithm = .{ .entropy = .constant_time_compare }, .providers = pure_zig_only, .class = .positive, .source = "provider contract", .license = "project fixture", .reproduction = "zig build test-crypto-vectors" },
+};
+
+const Waiver = struct {
+    provider_kind: ProviderKind,
+    algorithm: profile.Algorithm,
+    reason: []const u8,
+    tracking_issue: []const u8,
+};
+
+const ProviderWaiver = struct {
+    provider_kind: ProviderKind,
+    reason: []const u8,
+    tracking_issue: []const u8,
+};
+
+const provider_waivers = [_]ProviderWaiver{
+    .{ .provider_kind = .openssl, .reason = "The OpenSSL CryptoProvider adapter is documented as future work; this PR only registers the pure-Zig executable vector harness and leaves dual-provider execution open.", .tracking_issue = "#373" },
+};
+
+const waivers = [_]Waiver{
+    .{ .provider_kind = .pure_zig, .algorithm = .{ .signature = .ecdsa_secp256r1_sha256 }, .reason = "ECDSA verification exists in provider unit tests, but this top-level vector harness does not yet carry an independent DER fixture.", .tracking_issue = "#373" },
+    .{ .provider_kind = .pure_zig, .algorithm = .{ .certificate_helper = .der_parser }, .reason = "Certificate parser corpus coverage is owned by PKI stories; this crypto-provider slice does not add X.509 fixtures.", .tracking_issue = "#373" },
+    .{ .provider_kind = .pure_zig, .algorithm = .{ .certificate_helper = .chain_builder }, .reason = "Chain building is provider-deferred and covered by future PKI work.", .tracking_issue = "#373" },
+    .{ .provider_kind = .pure_zig, .algorithm = .{ .certificate_helper = .webpki_validation }, .reason = "WebPKI validation is provider-deferred and covered by future PKI work.", .tracking_issue = "#373" },
 };
 
 fn hexBytes(comptime hex: []const u8) [hex.len / 2]u8 {
@@ -67,62 +130,96 @@ fn cryptoProvider() provider.CryptoProvider {
     return Holder.provider_instance.cryptoProvider();
 }
 
-fn coverageForAlgorithm(algorithm: profile.Algorithm) Coverage {
+fn requireCase(id: []const u8) error{MissingCaseMetadata}!*const CaseMeta {
+    for (&case_registry) |*entry| {
+        if (std.mem.eql(u8, entry.id, id)) return entry;
+    }
+    return error.MissingCaseMetadata;
+}
+
+fn algorithmEql(a: profile.Algorithm, b: profile.Algorithm) bool {
+    return switch (a) {
+        .hash => |value| b == .hash and b.hash == value,
+        .hkdf => |value| b == .hkdf and b.hkdf == value,
+        .aead => |value| b == .aead and b.aead == value,
+        .group => |value| b == .group and b.group == value,
+        .signature => |value| b == .signature and b.signature == value,
+        .certificate_helper => |value| b == .certificate_helper and b.certificate_helper == value,
+        .entropy => |value| b == .entropy and b.entropy == value,
+    };
+}
+
+fn hasCase(provider_kind: ProviderKind, algorithm: profile.Algorithm, class: CaseClass) bool {
+    for (case_registry) |entry| {
+        const entry_algorithm = entry.algorithm orelse continue;
+        if (entry.class == class and entry.providers.has(provider_kind) and algorithmEql(entry_algorithm, algorithm)) return true;
+    }
+    return false;
+}
+
+fn hasWaiver(provider_kind: ProviderKind, algorithm: profile.Algorithm) bool {
+    for (provider_waivers) |waiver| {
+        if (waiver.provider_kind == provider_kind and waiver.reason.len > 0 and waiver.tracking_issue.len > 0) return true;
+    }
+    for (waivers) |waiver| {
+        if (waiver.provider_kind == provider_kind and algorithmEql(waiver.algorithm, algorithm)) return true;
+    }
+    return false;
+}
+
+fn rowStatus(kind: ProviderKind, row: profile.Row) profile.Status {
+    return switch (kind) {
+        .pure_zig => row.pure_zig_status,
+        .openssl => row.openssl_status,
+    };
+}
+
+fn requiresNegativeCase(algorithm: profile.Algorithm) bool {
     return switch (algorithm) {
-        .hash => |hash| switch (hash) {
-            .sha256 => .positive,
-            .sha384 => .positive,
-        },
-        .hkdf => |hash| switch (hash) {
-            .sha256 => .positive,
-            .sha384 => .positive,
-        },
-        .aead => |aead| switch (aead) {
-            .aes_128_gcm => .positive,
-            .aes_256_gcm => .positive,
-            .chacha20_poly1305 => .positive,
-        },
-        .group => |group| switch (group) {
-            .x25519 => .positive,
-            .secp256r1 => .negative,
-        },
-        .signature => |scheme| switch (scheme) {
-            .ed25519 => .positive,
-            .ecdsa_secp256r1_sha256 => .positive,
-            .rsa_pss_rsae_sha256 => .negative,
-        },
-        .certificate_helper => |helper| switch (helper) {
-            .der_parser => .waived,
-            .chain_builder => .waived,
-            .webpki_validation => .waived,
-        },
-        .entropy => |capability| switch (capability) {
-            .injected_random_bytes => .positive,
-            .secure_zero => .positive,
-            .constant_time_compare => .positive,
-        },
+        .aead, .group, .signature, .hkdf => true,
+        .hash, .certificate_helper, .entropy => false,
     };
 }
 
 test "vector manifest records provenance and licensing" {
-    for (vector_meta) |entry| {
-        try testing.expect(entry.name.len > 0);
+    for (case_registry) |entry| {
+        try testing.expect(entry.id.len > 0);
         try testing.expect(entry.source.len > 0);
         try testing.expect(entry.license.len > 0);
+        try testing.expect(entry.reproduction.len > 0);
+    }
+    for (waivers) |waiver| {
+        try testing.expect(waiver.reason.len > 0);
+        try testing.expect(waiver.tracking_issue.len > 0);
+    }
+    for (provider_waivers) |waiver| {
+        try testing.expect(waiver.reason.len > 0);
+        try testing.expect(waiver.tracking_issue.len > 0);
     }
 }
 
 test "capability matrix has vector coverage or explicit waivers" {
     for (profile.rows) |row| {
-        const coverage = coverageForAlgorithm(row.algorithm);
-        switch (row.pure_zig_status) {
-            .supported => try testing.expectEqual(Coverage.positive, coverage),
-            .provider_deferred, .unsupported => try testing.expect(coverage == .negative or coverage == .waived),
+        inline for (.{ ProviderKind.pure_zig, ProviderKind.openssl }) |provider_kind| {
+            switch (rowStatus(provider_kind, row)) {
+                .supported => {
+                    try testing.expect(hasCase(provider_kind, row.algorithm, .positive) or hasWaiver(provider_kind, row.algorithm));
+                    if (requiresNegativeCase(row.algorithm)) {
+                        try testing.expect(hasCase(provider_kind, row.algorithm, .negative) or hasWaiver(provider_kind, row.algorithm));
+                    }
+                },
+                .provider_deferred, .unsupported => try testing.expect(hasCase(provider_kind, row.algorithm, .negative) or hasWaiver(provider_kind, row.algorithm)),
+            }
         }
     }
 }
 
 test "provider HKDF stages match RFC 5869 and TLS expand-label vectors" {
+    _ = try requireCase("hkdf-rfc5869-extract-sha256");
+    _ = try requireCase("hkdf-expand-label-sha256-fixed");
+    _ = try requireCase("hkdf-expand-label-sha384-fixed");
+    _ = try requireCase("hkdf-invalid-secret-length");
+    _ = try requireCase("hkdf-invalid-secret-length-sha384");
     const cp = cryptoProvider();
 
     const ikm = hexBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
@@ -133,21 +230,30 @@ test "provider HKDF stages match RFC 5869 and TLS expand-label vectors" {
     try cp.hkdfExtract(.sha256, &salt, &ikm, &prk);
     try expectStage("hkdf extract sha256 / RFC 5869 A.1", &expected_prk, &prk);
 
-    const HkdfSha256 = std.crypto.kdf.hkdf.HkdfSha256;
-    const expected_okm = std.crypto.tls.hkdfExpandLabel(HkdfSha256, prk, "derived", &info, 42);
+    const expected_okm = hexBytes("e29ebe58889156b196d8f9c31e3a4658a71eabdc113c50e4bf9d7a97ed3af464e6286979f53caa6fba0c");
     var okm: [42]u8 = undefined;
     try cp.hkdfExpandLabel(.sha256, &prk, "derived", &info, &okm);
     try expectStage("hkdf expand-label sha256 / TLS label", &expected_okm, &okm);
+    const HkdfSha256 = std.crypto.kdf.hkdf.HkdfSha256;
+    const differential_okm = std.crypto.tls.hkdfExpandLabel(HkdfSha256, prk, "derived", &info, 42);
+    try expectStage("hkdf expand-label sha256 / stdlib differential", &expected_okm, &differential_okm);
 
     const secret384 = [_]u8{0x42} ** provider.Hash.sha384.digestLength();
-    const HkdfSha384 = std.crypto.kdf.hkdf.Hkdf(std.crypto.auth.hmac.sha2.HmacSha384);
-    const expected384 = std.crypto.tls.hkdfExpandLabel(HkdfSha384, secret384, "c hs traffic", "", 48);
+    const expected384 = hexBytes("dd8cacbd8b266f33a9d8cfc8484747d2de2b19084df353b4c6bfc7525d2ac301616e00d9bdc509cd9ac09d1d5384347e");
     var out384: [48]u8 = undefined;
     try cp.hkdfExpandLabel(.sha384, &secret384, "c hs traffic", "", &out384);
     try expectStage("hkdf expand-label sha384 / TLS label", &expected384, &out384);
+    const HkdfSha384 = std.crypto.kdf.hkdf.Hkdf(std.crypto.auth.hmac.sha2.HmacSha384);
+    const differential384 = std.crypto.tls.hkdfExpandLabel(HkdfSha384, secret384, "c hs traffic", "", 48);
+    try expectStage("hkdf expand-label sha384 / stdlib differential", &expected384, &differential384);
+
+    var invalid: [16]u8 = undefined;
+    try testing.expectError(error.InvalidInput, cp.hkdfExpandLabel(.sha256, "short", "derived", "", &invalid));
+    try testing.expectError(error.InvalidInput, cp.hkdfExpandLabel(.sha384, "short", "derived", "", &invalid));
 }
 
-test "TLS 1.3 key schedule and Finished value match RFC 8448" {
+test "TLS 1.3 key schedule KAT matches RFC 8448 precomputed hashes" {
+    _ = try requireCase("tls13-key-schedule-rfc8448");
     const KeySchedule = tls_core.key_schedule.KeySchedule;
 
     const shared = hexBytes("8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d");
@@ -168,7 +274,31 @@ test "TLS 1.3 key schedule and Finished value match RFC 8448" {
     try expectStage("tls13 server Finished verify_data / RFC 8448", &hexBytes("c5486af1426697c43c18dab6a79ef816a2188023ea743133b7e3b15a2c05c955"), &KeySchedule.verifyData(schedule.server_handshake_traffic, finished_hash));
 }
 
+test "TLS transcript helper hashes encoded handshake bytes and HRR message_hash" {
+    _ = try requireCase("sha256-transcript-hrr-rewrite");
+    const Transcript = tls_core.transcript.Transcript;
+
+    const client_hello_1 = hexBytes("01000003aabbcc");
+    const hello_retry_request = hexBytes("02000002cf21");
+    const client_hello_2 = hexBytes("01000002ddee");
+
+    var transcript = Transcript{};
+    transcript.update(&client_hello_1);
+    const ch1_hash = hexBytes("93e26e55d8fd5b5236e00556a269142fc88e0d9616836ca9b8607841ac0287a0");
+    try expectStage("tls transcript ClientHello1 hash", &ch1_hash, &transcript.peek());
+
+    transcript.replace(ch1_hash);
+    try expectStage("tls transcript HRR synthetic message_hash", &hexBytes("42a5f8938f2b4f45f63df268cf67218045831c80b841bdb54f46afefceee6218"), &transcript.peek());
+
+    transcript.update(&hello_retry_request);
+    try expectStage("tls transcript after HelloRetryRequest", &hexBytes("cb0a3fbd3c60144a08852ceb18f319fd65f5b352026cb23036f568a209d6a036"), &transcript.peek());
+
+    transcript.update(&client_hello_2);
+    try expectStage("tls transcript after ClientHello2", &hexBytes("7ec9461d8bac7434b8ae63e99899d1ef75ce0b716c9ee12aadd5f5837e51d182"), &transcript.peek());
+}
+
 test "TLS 1.3 record-protection keys and ciphertext match independent vector" {
+    _ = try requireCase("tls13-record-aes128-gcm-independent");
     const cp = cryptoProvider();
     const record_protection = tls_core.record_protection;
     const record_codec = tls_core.record_codec;
@@ -201,6 +331,8 @@ test "TLS 1.3 record-protection keys and ciphertext match independent vector" {
 }
 
 test "QUIC v1 initial secrets and packet-protection material match RFC 9001" {
+    _ = try requireCase("quic-v1-initial-rfc9001");
+    _ = try requireCase("quic-v1-initial-auth-failure");
     const dcid = hexBytes("8394c8f03e515708");
     const secrets = try quic.tls_adapter.deriveInitialSecretsV1(&dcid);
 
@@ -219,10 +351,26 @@ test "QUIC v1 initial secrets and packet-protection material match RFC 9001" {
     const sample = hexBytes("d1b1c98dd7689fb8ec11d242b123dc9b");
     try expectStage("quic header-protection mask / RFC 9001 A.3", &hexBytes("437b9aec36"), &secrets.client.headerProtectionMask(sample));
 
-    var header = hexBytes("c300000001088394c8f03e5157080000449e00000002");
+    var header = hexBytes("c300000001088394c8f03e5157080000403400000002");
     var plaintext = [_]u8{0} ** 32;
     var sealed: [plaintext.len + quic.tls_adapter.packet_protection_tag_len]u8 = undefined;
     const protected = try secrets.client.sealPayload(2, &header, &plaintext, &sealed);
+    try expectStage("quic small packet ciphertext / independent vector", &hexBytes("d7b1897cd6689f55ef1239ba4b752db2e103e17c8cebd5c2f167b3c8b2267f05"), protected[0..plaintext.len]);
+    try expectStage("quic small packet tag / independent vector", &hexBytes("52eb613c653b62fcc087fefe0e5479f9"), protected[plaintext.len..]);
+
+    var protected_header = header;
+    const pn_offset = protected_header.len - 4;
+    const hp_sample = protected[0..quic.tls_adapter.header_protection_sample_len].*;
+    const hp_mask = secrets.client.headerProtectionMask(hp_sample);
+    protected_header[0] ^= hp_mask[0] & 0x0f;
+    for (protected_header[pn_offset..], hp_mask[1..]) |*byte, mask_byte| byte.* ^= mask_byte;
+    try expectStage("quic small packet protected header / independent vector", &hexBytes("c300000001088394c8f03e515708000040340dabc95a"), &protected_header);
+
+    var final_packet: [header.len + sealed.len]u8 = undefined;
+    @memcpy(final_packet[0..header.len], &protected_header);
+    @memcpy(final_packet[header.len..], protected);
+    try expectStage("quic small packet final bytes / independent vector", &hexBytes("c300000001088394c8f03e515708000040340dabc95ad7b1897cd6689f55ef1239ba4b752db2e103e17c8cebd5c2f167b3c8b2267f0552eb613c653b62fcc087fefe0e5479f9"), &final_packet);
+
     var opened: [plaintext.len]u8 = undefined;
     try expectStage("quic packet-protection open after seal", &plaintext, try secrets.client.openPayload(2, &header, protected, &opened));
 
@@ -237,8 +385,14 @@ test "QUIC v1 initial secrets and packet-protection material match RFC 9001" {
 test "provider AEAD vectors seal, open, and reject authentication failures" {
     const cp = cryptoProvider();
 
+    _ = try requireCase("aes-128-gcm-nist-zero-block");
+    _ = try requireCase("aes-128-gcm-tag-rejection");
     try runAeadVector(.aes_128_gcm, &hexBytes("00000000000000000000000000000000"), &hexBytes("000000000000000000000000"), "", &hexBytes("00000000000000000000000000000000"), &hexBytes("0388dace60b6a392f328c2b971b2fe78"), &hexBytes("ab6e47d42cec13bdf53a67b21257bddf"), "aes-128-gcm NIST zero-block", cp);
+    _ = try requireCase("aes-256-gcm-nist-zero-block");
+    _ = try requireCase("aes-256-gcm-tag-rejection");
     try runAeadVector(.aes_256_gcm, &hexBytes("0000000000000000000000000000000000000000000000000000000000000000"), &hexBytes("000000000000000000000000"), "", &hexBytes("00000000000000000000000000000000"), &hexBytes("cea7403d4d606b6e074ec5d3baf39d18"), &hexBytes("d0d1c8a799996bf0265b98b5d48ab919"), "aes-256-gcm NIST zero-block", cp);
+    _ = try requireCase("chacha20-poly1305-rfc8439");
+    _ = try requireCase("chacha20-poly1305-tag-rejection");
     try runAeadVector(
         .chacha20_poly1305,
         &hexBytes("808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f"),
@@ -285,6 +439,10 @@ fn runAeadVector(
 }
 
 test "provider key exchange and signature vectors match RFC sources" {
+    _ = try requireCase("x25519-rfc7748-alice-bob");
+    _ = try requireCase("x25519-low-order-rejection");
+    _ = try requireCase("ed25519-rfc8032-test-1");
+    _ = try requireCase("ed25519-signature-rejection");
     const cp = cryptoProvider();
 
     const alice_private = hexBytes("77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a");
@@ -295,9 +453,9 @@ test "provider key exchange and signature vectors match RFC sources" {
     try expectStage("x25519 shared secret / RFC 7748", &expected_shared, &shared);
 
     const zero_point = [_]u8{0} ** 32;
-    cp.deriveSharedSecret(.x25519, &alice_private, &zero_point, &shared) catch |err| {
-        try expectVectorError("x25519 low-order point rejection", error.InvalidInput, err);
-    };
+    @memset(&shared, 0xa5);
+    try testing.expectError(error.InvalidInput, cp.deriveSharedSecret(.x25519, &alice_private, &zero_point, &shared));
+    try testing.expect(!std.mem.allEqual(u8, &shared, 0));
 
     const ed_seed = hexBytes("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60");
     const ed_public = hexBytes("d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a");
@@ -311,9 +469,36 @@ test "provider key exchange and signature vectors match RFC sources" {
     try testing.expectEqual(@as(usize, 64), len);
     try expectStage("ed25519 signature / RFC 8032", &ed_signature, &actual_signature);
     try cp.verify(.ed25519, &ed_public, "", &ed_signature);
+
+    var bad_signature = ed_signature;
+    bad_signature[0] ^= 0x80;
+    try testing.expectError(error.AuthenticationFailed, cp.verify(.ed25519, &ed_public, "", &bad_signature));
+}
+
+test "provider entropy and secret helpers are executable vector cases" {
+    _ = try requireCase("deterministic-entropy-positive");
+    _ = try requireCase("secure-zero-positive");
+    _ = try requireCase("constant-time-compare-positive");
+    var det = pure_zig.DeterministicEntropy.init(0x373);
+    var p = pure_zig.Provider.init(det.entropy());
+    const cp = p.cryptoProvider();
+
+    var bytes: [8]u8 = undefined;
+    try cp.randomBytes(&bytes);
+    try expectStage("deterministic entropy stream", &hexBytes("ae642de1b6769772"), &bytes);
+
+    var secret = [_]u8{0xab} ** 8;
+    provider.secureZero(&secret);
+    try expectStage("secure zero", &[_]u8{0} ** 8, &secret);
+
+    try testing.expect(provider.constantTimeEqual("vector", "vector"));
+    try testing.expect(!provider.constantTimeEqual("vector", "vectors"));
+    try testing.expect(!provider.constantTimeEqual("vector", "vextor"));
 }
 
 test "unsupported provider capabilities are negative cases, not silent skips" {
+    _ = try requireCase("secp256r1-unsupported");
+    _ = try requireCase("rsa-pss-unsupported");
     const cp = cryptoProvider();
     var scalar: [32]u8 = undefined;
     var public: [65]u8 = undefined;

--- a/tests/vectors/generate_crypto_vectors.js
+++ b/tests/vectors/generate_crypto_vectors.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+// Reproduce project-owned TLS/QUIC vector literals used by tests/crypto_vectors.zig.
+//
+// Runtime used when the fixture was added:
+//   node v24.1.0
+//
+// The script depends only on Node's built-in crypto module. It is intentionally
+// not wired into CI; the checked-in Zig tests use fixed bytes, while this file
+// documents exactly how the project-owned bytes were generated.
+
+const crypto = require("crypto");
+
+function fromHex(hex) {
+  return Buffer.from(hex, "hex");
+}
+
+function toHex(bytes) {
+  return Buffer.from(bytes).toString("hex");
+}
+
+function hmac(hash, key, data) {
+  return crypto.createHmac(hash, key).update(data).digest();
+}
+
+function hkdfExtract(hash, salt, ikm) {
+  return hmac(hash, salt, ikm);
+}
+
+function hkdfExpand(hash, prk, info, len) {
+  let previous = Buffer.alloc(0);
+  let output = Buffer.alloc(0);
+  let counter = 1;
+  while (output.length < len) {
+    previous = hmac(hash, prk, Buffer.concat([previous, info, Buffer.from([counter])]));
+    output = Buffer.concat([output, previous]);
+    counter += 1;
+  }
+  return output.subarray(0, len);
+}
+
+function hkdfLabel(label, context, len) {
+  const fullLabel = Buffer.from(`tls13 ${label}`, "ascii");
+  const info = Buffer.alloc(2 + 1 + fullLabel.length + 1 + context.length);
+  info.writeUInt16BE(len, 0);
+  info[2] = fullLabel.length;
+  fullLabel.copy(info, 3);
+  info[3 + fullLabel.length] = context.length;
+  context.copy(info, 4 + fullLabel.length);
+  return info;
+}
+
+function hkdfExpandLabel(hash, secret, label, context, len) {
+  return hkdfExpand(hash, secret, hkdfLabel(label, context, len), len);
+}
+
+function aeadSeal(cipher, key, nonce, aad, plaintext) {
+  const seal = crypto.createCipheriv(cipher, key, nonce, { authTagLength: 16 });
+  seal.setAAD(aad);
+  const ciphertext = Buffer.concat([seal.update(plaintext), seal.final()]);
+  return { ciphertext, tag: seal.getAuthTag() };
+}
+
+function aes128HeaderProtectionMask(key, sample) {
+  const block = crypto.createCipheriv("aes-128-ecb", key, null);
+  block.setAutoPadding(false);
+  return Buffer.concat([block.update(sample), block.final()]).subarray(0, 5);
+}
+
+function print(name, value) {
+  console.log(`${name}=${toHex(value)}`);
+}
+
+function generateHkdfVectors() {
+  const ikm = fromHex("0b".repeat(22));
+  const salt = fromHex("000102030405060708090a0b0c");
+  const context = fromHex("f0f1f2f3f4f5f6f7f8f9");
+  const prk = hkdfExtract("sha256", salt, ikm);
+  print("hkdf.rfc5869.sha256.prk", prk);
+  print("hkdf.expand_label.sha256.derived.len42", hkdfExpandLabel("sha256", prk, "derived", context, 42));
+
+  const secret384 = Buffer.alloc(48, 0x42);
+  print("hkdf.expand_label.sha384.c_hs_traffic.len48", hkdfExpandLabel("sha384", secret384, "c hs traffic", Buffer.alloc(0), 48));
+}
+
+function generateTranscriptVectors() {
+  const clientHello1 = fromHex("01000003aabbcc");
+  const helloRetryRequest = fromHex("02000002cf21");
+  const clientHello2 = fromHex("01000002ddee");
+  const ch1Hash = crypto.createHash("sha256").update(clientHello1).digest();
+  const synthetic = Buffer.concat([fromHex("fe000020"), ch1Hash]);
+  print("tls.transcript.client_hello_1_hash", ch1Hash);
+  print("tls.transcript.synthetic_message_hash", crypto.createHash("sha256").update(synthetic).digest());
+  print("tls.transcript.after_hrr", crypto.createHash("sha256").update(Buffer.concat([synthetic, helloRetryRequest])).digest());
+  print("tls.transcript.after_client_hello_2", crypto.createHash("sha256").update(Buffer.concat([synthetic, helloRetryRequest, clientHello2])).digest());
+}
+
+function generateTlsRecordVector() {
+  const secret = fromHex("0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20");
+  const key = hkdfExpandLabel("sha256", secret, "key", Buffer.alloc(0), 16);
+  const iv = hkdfExpandLabel("sha256", secret, "iv", Buffer.alloc(0), 12);
+  const plaintext = Buffer.concat([Buffer.from("server finished record", "ascii"), Buffer.from([0x16]), Buffer.alloc(4)]);
+  const aad = fromHex("170303002b");
+  const sealed = aeadSeal("aes-128-gcm", key, iv, aad, plaintext);
+  print("tls.record.aes128.key", key);
+  print("tls.record.aes128.iv", iv);
+  print("tls.record.aes128.ciphertext", sealed.ciphertext);
+  print("tls.record.aes128.tag", sealed.tag);
+  print("tls.record.aes128.record", Buffer.concat([aad, sealed.ciphertext, sealed.tag]));
+}
+
+function generateQuicSmallPacketVector() {
+  const dcid = fromHex("8394c8f03e515708");
+  const initialSalt = fromHex("38762cf7f55934b34d179ae6a4c80cadccbb7f0a");
+  const initialSecret = hkdfExtract("sha256", initialSalt, dcid);
+  const clientSecret = hkdfExpandLabel("sha256", initialSecret, "client in", Buffer.alloc(0), 32);
+  const key = hkdfExpandLabel("sha256", clientSecret, "quic key", Buffer.alloc(0), 16);
+  const iv = hkdfExpandLabel("sha256", clientSecret, "quic iv", Buffer.alloc(0), 12);
+  const hp = hkdfExpandLabel("sha256", clientSecret, "quic hp", Buffer.alloc(0), 16);
+
+  const packetNumber = Buffer.alloc(8);
+  packetNumber.writeBigUInt64BE(2n);
+  const nonce = Buffer.from(iv);
+  for (let i = 0; i < packetNumber.length; i += 1) {
+    nonce[nonce.length - packetNumber.length + i] ^= packetNumber[i];
+  }
+
+  // QUIC long header with pn_len=4, DCID 8394c8f03e515708, zero-length SCID
+  // and token, Length = packet_number_len + 32-byte plaintext + 16-byte tag.
+  const header = fromHex("c300000001088394c8f03e5157080000403400000002");
+  const plaintext = Buffer.alloc(32);
+  const sealed = aeadSeal("aes-128-gcm", key, nonce, header, plaintext);
+  const payload = Buffer.concat([sealed.ciphertext, sealed.tag]);
+  const sample = payload.subarray(0, 16);
+  const mask = aes128HeaderProtectionMask(hp, sample);
+  const protectedHeader = Buffer.from(header);
+  protectedHeader[0] ^= mask[0] & 0x0f;
+  for (let i = 0; i < 4; i += 1) {
+    protectedHeader[protectedHeader.length - 4 + i] ^= mask[i + 1];
+  }
+
+  print("quic.small.header", header);
+  print("quic.small.nonce", nonce);
+  print("quic.small.ciphertext", sealed.ciphertext);
+  print("quic.small.tag", sealed.tag);
+  print("quic.small.hp_sample", sample);
+  print("quic.small.hp_mask", mask);
+  print("quic.small.protected_header", protectedHeader);
+  print("quic.small.final_packet", Buffer.concat([protectedHeader, payload]));
+}
+
+generateHkdfVectors();
+generateTranscriptVectors();
+generateTlsRecordVector();
+generateQuicSmallPacketVector();


### PR DESCRIPTION
## Summary

- add a standalone `test-crypto-vectors` target for deterministic TLS/QUIC crypto vectors
- cover vector provenance, provider capability coverage/waivers, HKDF labels, TLS 1.3 key schedule and Finished values, transcript HRR `message_hash` handling, TLS record protection, QUIC initial packet protection, AEAD KATs, X25519, Ed25519, and deferred negative cases
- add `tests/vectors/generate_crypto_vectors.js` to reproduce project-owned HKDF, transcript, TLS record, and QUIC packet fixtures without new dependencies
- wire the harness into `zig build test` and `zig build test-crypto`

## Scope note

This PR establishes the pure-Zig executable vector harness slice for #373. It intentionally does **not** close #373 yet: OpenSSL `CryptoProvider` execution and the remaining full provider-neutral vector expansion are still tracked there.

## Validation

- `node tests/vectors/generate_crypto_vectors.js`
- `zig build test-crypto-vectors --summary all --error-style verbose`
- `zig fmt --check build.zig src/ tests/`
- `git diff --check`
- `zig build test-crypto --summary all --error-style verbose`
- `zig build test --summary all --error-style verbose`

Refs #373
