### PR TITLE
Add bounded crypto corpus runner

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -277,6 +277,21 @@ pub fn build(b: *std.Build) void {
     crypto_step.dependOn(&run_crypto_vector_tests.step);
     test_step.dependOn(&run_crypto_vector_tests.step);
 
+    // Bounded checked-in Wycheproof-style corpus (#374): reduced offline
+    // negative/edge vectors for provider-supported pure-Zig operations.
+    const crypto_corpus_mod = b.createModule(.{
+        .root_source_file = b.path("tests/crypto_corpus.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    crypto_corpus_mod.addImport("crypto", crypto_mod);
+    const crypto_corpus_tests = b.addTest(.{ .root_module = crypto_corpus_mod });
+    const run_crypto_corpus_tests = b.addRunArtifact(crypto_corpus_tests);
+    const crypto_corpus_step = b.step("test-crypto-corpus", "Run bounded checked-in crypto corpus");
+    crypto_corpus_step.dependOn(&run_crypto_corpus_tests.step);
+    crypto_step.dependOn(&run_crypto_corpus_tests.step);
+    test_step.dependOn(&run_crypto_corpus_tests.step);
+
     // Test-only: a real client/server TLS 1.3 handshake through the merged
     // record stack (#408 finding 6). This needs the "crypto" module (to
     // build a pure-Zig CryptoProvider for the record_epoch_bridge.Bridge

--- a/tests/crypto_corpus.zig
+++ b/tests/crypto_corpus.zig
@@ -174,12 +174,14 @@ fn parseCorpus(backing_allocator: std.mem.Allocator, input: []const u8, limits: 
     const skipped_suites = try parseSkippedSuites(allocator, try requireArray(root_object, "skippedSuites"), limits);
 
     var seen_cases = std.StringHashMap(void).init(allocator);
+    var parsed_cases: usize = 0;
     var decoded_total: usize = 0;
     const suites = try parseSuites(
         allocator,
         try requireArray(root_object, "suites"),
         allowlist,
         &seen_cases,
+        &parsed_cases,
         &decoded_total,
         limits,
     );
@@ -234,6 +236,7 @@ fn parseSuites(
     array: std.json.Array,
     allowlist: []const Algorithm,
     seen_cases: *std.StringHashMap(void),
+    parsed_cases: *usize,
     decoded_total: *usize,
     limits: Limits,
 ) ![]Suite {
@@ -252,6 +255,7 @@ fn parseSuites(
             algorithm,
             operation,
             seen_cases,
+            parsed_cases,
             decoded_total,
             limits,
         );
@@ -272,6 +276,7 @@ fn parseGroups(
     algorithm: Algorithm,
     operation: Operation,
     seen_cases: *std.StringHashMap(void),
+    parsed_cases: *usize,
     decoded_total: *usize,
     limits: Limits,
 ) ![]Group {
@@ -289,6 +294,7 @@ fn parseGroups(
                 algorithm,
                 operation,
                 seen_cases,
+                parsed_cases,
                 decoded_total,
                 limits,
             ),
@@ -303,6 +309,7 @@ fn parseCases(
     algorithm: Algorithm,
     operation: Operation,
     seen_cases: *std.StringHashMap(void),
+    parsed_cases: *usize,
     decoded_total: *usize,
     limits: Limits,
 ) ![]Case {
@@ -318,6 +325,8 @@ fn parseCases(
 
         const id = try requireId(obj, "id", limits);
         if (seen_cases.contains(id)) return error.DuplicateCaseId;
+        if (parsed_cases.* >= limits.max_cases) return error.TooManyCases;
+        parsed_cases.* += 1;
         try seen_cases.put(id, {});
 
         const classification = try parseClassification(try requireString(obj, "classification", limits));
@@ -387,9 +396,9 @@ fn runCorpus(corpus: *const Corpus) !Report {
 
 fn executeCase(cp: provider.CryptoProvider, suite: Suite, group: Group, case: Case) !void {
     const observed = switch (suite.operation) {
-        .aead_open => executeAeadOpen(cp, suite.algorithm.aead().?, case),
-        .derive_shared_secret => executeX25519(cp, case),
-        .verify => executeEd25519Verify(cp, case),
+        .aead_open => try executeAeadOpen(cp, suite.algorithm.aead().?, case),
+        .derive_shared_secret => try executeX25519(cp, case),
+        .verify => try executeEd25519Verify(cp, case),
     };
     if (observed != case.expected) {
         std.debug.print(
@@ -409,38 +418,38 @@ fn executeCase(cp: provider.CryptoProvider, suite: Suite, group: Group, case: Ca
     }
 }
 
-fn executeAeadOpen(cp: provider.CryptoProvider, aead: provider.Aead, case: Case) Expected {
-    const plaintext = testing.allocator.alloc(u8, case.ciphertext.len) catch return .invalid_input;
+fn executeAeadOpen(cp: provider.CryptoProvider, aead: provider.Aead, case: Case) !Expected {
+    const plaintext = try testing.allocator.alloc(u8, case.ciphertext.len);
     defer testing.allocator.free(plaintext);
     cp.aeadOpen(aead, case.key, case.nonce, case.aad, case.ciphertext, case.tag, plaintext) catch |err| {
-        return observedFromError(err);
+        return try observedFromError(err);
     };
     if (!std.mem.eql(u8, plaintext, case.message)) return .authentication_failed;
     return .success;
 }
 
-fn executeX25519(cp: provider.CryptoProvider, case: Case) Expected {
+fn executeX25519(cp: provider.CryptoProvider, case: Case) !Expected {
     var out: [provider.max_shared_secret_len]u8 = undefined;
     if (case.shared.len > out.len) return .invalid_input;
     cp.deriveSharedSecret(.x25519, case.private_key, case.public_key, out[0..case.shared.len]) catch |err| {
-        return observedFromError(err);
+        return try observedFromError(err);
     };
     if (!std.mem.eql(u8, out[0..case.shared.len], case.shared)) return .authentication_failed;
     return .success;
 }
 
-fn executeEd25519Verify(cp: provider.CryptoProvider, case: Case) Expected {
+fn executeEd25519Verify(cp: provider.CryptoProvider, case: Case) !Expected {
     cp.verify(.ed25519, case.public_key, case.message, case.signature) catch |err| {
-        return observedFromError(err);
+        return try observedFromError(err);
     };
     return .success;
 }
 
-fn observedFromError(err: anyerror) Expected {
+fn observedFromError(err: anyerror) !Expected {
     return switch (err) {
         error.AuthenticationFailed => .authentication_failed,
         error.InvalidInput => .invalid_input,
-        else => .invalid_input,
+        else => err,
     };
 }
 
@@ -671,6 +680,8 @@ test "crypto corpus parser rejects bounded failure paths" {
     try testing.expectError(error.OversizedValue, parseCorpus(testing.allocator, minimalCorpus(.oversized_id), .{}));
     try testing.expectError(error.DuplicateCaseId, parseCorpus(testing.allocator, minimalCorpus(.duplicate_case_id), .{}));
     try testing.expectError(error.UnknownField, parseCorpus(testing.allocator, minimalCorpus(.unknown_field), .{}));
+    try testing.expectError(error.TooManyCases, parseCorpus(testing.allocator, twoGroupCorpus(), .{ .max_cases = 1 }));
+    try testing.expectError(error.UnsupportedCapability, observedFromError(error.UnsupportedCapability));
 }
 
 test "crypto corpus executes through provider and registered manifest" {
@@ -759,4 +770,59 @@ fn minimalCorpus(comptime kind: MinimalKind) []const u8 {
         \\  }}]
         \\}}
     , .{ schema, source, algorithm, case_id, classification, key_hex, extra, second_case });
+}
+
+fn twoGroupCorpus() []const u8 {
+    return std.fmt.comptimePrint(
+        \\{{
+        \\  "schema": "{s}",
+        \\  "source": {{"name": "x", "repository": "x", "commit": "x", "license": "x", "reducedBy": "x"}},
+        \\  "allowlist": ["AES-128-GCM"],
+        \\  "skippedSuites": [],
+        \\  "suites": [{{
+        \\    "id": "suite-1",
+        \\    "algorithm": "AES-128-GCM",
+        \\    "operation": "aead-open",
+        \\    "sourceFile": "source.json",
+        \\    "groups": [
+        \\      {{
+        \\        "id": "group-1",
+        \\        "upstreamGroupIndex": 0,
+        \\        "cases": [{{
+        \\          "id": "case-1",
+        \\          "upstreamTcId": 1,
+        \\          "classification": "valid",
+        \\          "expected": "success",
+        \\          "comment": "",
+        \\          "flags": [],
+        \\          "key": "00000000000000000000000000000000",
+        \\          "nonce": "000000000000000000000000",
+        \\          "aad": "",
+        \\          "message": "",
+        \\          "ciphertext": "",
+        \\          "tag": "00000000000000000000000000000000"
+        \\        }}]
+        \\      }},
+        \\      {{
+        \\        "id": "group-2",
+        \\        "upstreamGroupIndex": 1,
+        \\        "cases": [{{
+        \\          "id": "case-2",
+        \\          "upstreamTcId": 2,
+        \\          "classification": "valid",
+        \\          "expected": "success",
+        \\          "comment": "",
+        \\          "flags": [],
+        \\          "key": "00000000000000000000000000000000",
+        \\          "nonce": "000000000000000000000000",
+        \\          "aad": "",
+        \\          "message": "",
+        \\          "ciphertext": "",
+        \\          "tag": "00000000000000000000000000000000"
+        \\        }}]
+        \\      }}
+        \\    ]
+        \\  }}]
+        \\}}
+    , .{schema_version});
 }

--- a/tests/crypto_corpus.zig
+++ b/tests/crypto_corpus.zig
@@ -5,6 +5,7 @@ const crypto_pkg = @import("crypto");
 const corpus_manifest = @import("crypto_corpus_manifest.zig");
 
 const provider = crypto_pkg.provider;
+const profile = crypto_pkg.profile;
 const pure_zig = crypto_pkg.pure_zig;
 const testing = std.testing;
 
@@ -74,6 +75,22 @@ const Expected = enum {
             .success => "success",
             .authentication_failed => "authentication-failed",
             .invalid_input => "invalid-input",
+        };
+    }
+};
+
+const Observed = enum {
+    success,
+    authentication_failed,
+    invalid_input,
+    output_mismatch,
+
+    fn name(self: Observed) []const u8 {
+        return switch (self) {
+            .success => "success",
+            .authentication_failed => "authentication-failed",
+            .invalid_input => "invalid-input",
+            .output_mismatch => "output-mismatch",
         };
     }
 };
@@ -331,7 +348,7 @@ fn parseCases(
 
         const classification = try parseClassification(try requireString(obj, "classification", limits));
         const expected = try parseExpected(try requireString(obj, "expected", limits));
-        if (classification == .acceptable and expected == .success) return error.AcceptableCaseNeedsPolicy;
+        try validateExpected(classification, expected);
 
         var parsed_case = Case{
             .id = id,
@@ -356,6 +373,11 @@ fn parseCases(
                 parsed_case.private_key = try requireHex(allocator, obj, "private", decoded_total, limits);
                 parsed_case.public_key = try requireHex(allocator, obj, "public", decoded_total, limits);
                 parsed_case.shared = try requireHex(allocator, obj, "shared", decoded_total, limits);
+                if (algorithm == .x25519) {
+                    if (parsed_case.private_key.len != provider.Group.x25519.sharedSecretLength()) return error.InvalidCorpus;
+                    if (parsed_case.public_key.len != provider.Group.x25519.publicKeyLength()) return error.InvalidCorpus;
+                    if (parsed_case.shared.len != provider.Group.x25519.sharedSecretLength()) return error.InvalidCorpus;
+                }
             },
             .verify => {
                 parsed_case.public_key = try requireHex(allocator, obj, "publicKey", decoded_total, limits);
@@ -400,7 +422,7 @@ fn executeCase(cp: provider.CryptoProvider, suite: Suite, group: Group, case: Ca
         .derive_shared_secret => try executeX25519(cp, case),
         .verify => try executeEd25519Verify(cp, case),
     };
-    if (observed != case.expected) {
+    if (observed != expectedObserved(case.expected)) {
         std.debug.print(
             "crypto corpus mismatch file={s} group={s} case={s} upstreamTcId={d} algorithm={s} classification={s} expected={s} observed={s}\n",
             .{
@@ -418,38 +440,47 @@ fn executeCase(cp: provider.CryptoProvider, suite: Suite, group: Group, case: Ca
     }
 }
 
-fn executeAeadOpen(cp: provider.CryptoProvider, aead: provider.Aead, case: Case) !Expected {
+fn executeAeadOpen(cp: provider.CryptoProvider, aead: provider.Aead, case: Case) !Observed {
     const plaintext = try testing.allocator.alloc(u8, case.ciphertext.len);
     defer testing.allocator.free(plaintext);
     cp.aeadOpen(aead, case.key, case.nonce, case.aad, case.ciphertext, case.tag, plaintext) catch |err| {
         return try observedFromError(err);
     };
-    if (!std.mem.eql(u8, plaintext, case.message)) return .authentication_failed;
+    if (!std.mem.eql(u8, plaintext, case.message)) return .output_mismatch;
     return .success;
 }
 
-fn executeX25519(cp: provider.CryptoProvider, case: Case) !Expected {
+fn executeX25519(cp: provider.CryptoProvider, case: Case) !Observed {
+    const shared_len = provider.Group.x25519.sharedSecretLength();
+    if (case.shared.len != shared_len) return error.InvalidCorpus;
     var out: [provider.max_shared_secret_len]u8 = undefined;
-    if (case.shared.len > out.len) return .invalid_input;
-    cp.deriveSharedSecret(.x25519, case.private_key, case.public_key, out[0..case.shared.len]) catch |err| {
+    cp.deriveSharedSecret(.x25519, case.private_key, case.public_key, out[0..shared_len]) catch |err| {
         return try observedFromError(err);
     };
-    if (!std.mem.eql(u8, out[0..case.shared.len], case.shared)) return .authentication_failed;
+    if (!std.mem.eql(u8, out[0..shared_len], case.shared)) return .output_mismatch;
     return .success;
 }
 
-fn executeEd25519Verify(cp: provider.CryptoProvider, case: Case) !Expected {
+fn executeEd25519Verify(cp: provider.CryptoProvider, case: Case) !Observed {
     cp.verify(.ed25519, case.public_key, case.message, case.signature) catch |err| {
         return try observedFromError(err);
     };
     return .success;
 }
 
-fn observedFromError(err: anyerror) !Expected {
+fn observedFromError(err: anyerror) !Observed {
     return switch (err) {
         error.AuthenticationFailed => .authentication_failed,
         error.InvalidInput => .invalid_input,
         else => err,
+    };
+}
+
+fn expectedObserved(expected: Expected) Observed {
+    return switch (expected) {
+        .success => .success,
+        .authentication_failed => .authentication_failed,
+        .invalid_input => .invalid_input,
     };
 }
 
@@ -463,6 +494,7 @@ fn validateManifestCoverage(corpus: *const Corpus, report: Report) !void {
             matched = true;
             try testing.expectEqual(expected_suite.case_count, countCases(actual_suite));
             try testing.expectEqualStrings(expected_suite.source_file, actual_suite.source_file);
+            try testing.expect(std.meta.eql(expected_suite.algorithm, profileAlgorithm(actual_suite.algorithm)));
         }
         if (!matched) return error.UnexecutedRegisteredSuite;
     }
@@ -477,6 +509,16 @@ fn validateManifestCoverage(corpus: *const Corpus, report: Report) !void {
         }
         if (!matched) return error.MissingSkippedSuite;
     }
+}
+
+fn profileAlgorithm(algorithm: Algorithm) profile.Algorithm {
+    return switch (algorithm) {
+        .aes_128_gcm => .{ .aead = .aes_128_gcm },
+        .aes_256_gcm => .{ .aead = .aes_256_gcm },
+        .chacha20_poly1305 => .{ .aead = .chacha20_poly1305 },
+        .x25519 => .{ .group = .x25519 },
+        .ed25519 => .{ .signature = .ed25519 },
+    };
 }
 
 fn countCases(suite: Suite) usize {
@@ -521,6 +563,14 @@ fn parseExpected(raw: []const u8) !Expected {
     if (std.mem.eql(u8, raw, "authentication-failed")) return .authentication_failed;
     if (std.mem.eql(u8, raw, "invalid-input")) return .invalid_input;
     return error.UnknownExpectedOutcome;
+}
+
+fn validateExpected(classification: Classification, expected: Expected) !void {
+    switch (classification) {
+        .valid => if (expected != .success) return error.InvalidExpectedOutcome,
+        .invalid => if (expected == .success) return error.InvalidExpectedOutcome,
+        .acceptable => {},
+    }
 }
 
 fn algorithmAllowed(algorithm: Algorithm, allowlist: []const Algorithm) bool {
@@ -682,6 +732,7 @@ test "crypto corpus parser rejects bounded failure paths" {
     try testing.expectError(error.UnknownField, parseCorpus(testing.allocator, minimalCorpus(.unknown_field), .{}));
     try testing.expectError(error.TooManyCases, parseCorpus(testing.allocator, twoGroupCorpus(), .{ .max_cases = 1 }));
     try testing.expectError(error.UnsupportedCapability, observedFromError(error.UnsupportedCapability));
+    try testing.expectError(error.InvalidCorpus, parseCorpus(testing.allocator, x25519ShortSharedCorpus(), .{}));
 }
 
 test "crypto corpus executes through provider and registered manifest" {
@@ -694,6 +745,44 @@ test "crypto corpus executes through provider and registered manifest" {
     try testing.expectEqual(@as(usize, 5), report.invalid);
     try testing.expectEqual(@as(usize, 1), report.acceptable);
     try testing.expectEqual(@as(usize, 3), report.skipped_suites);
+}
+
+test "crypto corpus validates classification policy" {
+    try validateExpected(.valid, .success);
+    try testing.expectError(error.InvalidExpectedOutcome, validateExpected(.valid, .authentication_failed));
+    try testing.expectError(error.InvalidExpectedOutcome, validateExpected(.valid, .invalid_input));
+
+    try testing.expectError(error.InvalidExpectedOutcome, validateExpected(.invalid, .success));
+    try validateExpected(.invalid, .authentication_failed);
+    try validateExpected(.invalid, .invalid_input);
+
+    try validateExpected(.acceptable, .success);
+    try validateExpected(.acceptable, .authentication_failed);
+    try validateExpected(.acceptable, .invalid_input);
+}
+
+test "crypto corpus runner rejects provider success with mismatched AEAD output" {
+    const key = [_]u8{0} ** provider.Aead.aes_128_gcm.keyLength();
+    const nonce = [_]u8{0} ** provider.aead_nonce_len;
+    const ciphertext = [_]u8{0};
+    const message = [_]u8{0};
+    const tag = [_]u8{0} ** provider.aead_tag_len;
+    const case = Case{
+        .id = "fake-case",
+        .upstream_tc_id = 1,
+        .classification = .invalid,
+        .expected = .authentication_failed,
+        .comment = "",
+        .flags = &.{},
+        .key = &key,
+        .nonce = &nonce,
+        .message = &message,
+        .ciphertext = &ciphertext,
+        .tag = &tag,
+    };
+    const observed = try executeAeadOpen(BadAeadProvider.cryptoProvider(), .aes_128_gcm, case);
+    try testing.expectEqual(Observed.output_mismatch, observed);
+    try testing.expect(observed != expectedObserved(case.expected));
 }
 
 const MinimalKind = enum {
@@ -826,3 +915,139 @@ fn twoGroupCorpus() []const u8 {
         \\}}
     , .{schema_version});
 }
+
+fn x25519ShortSharedCorpus() []const u8 {
+    return std.fmt.comptimePrint(
+        \\{{
+        \\  "schema": "{s}",
+        \\  "source": {{"name": "x", "repository": "x", "commit": "x", "license": "x", "reducedBy": "x"}},
+        \\  "allowlist": ["X25519"],
+        \\  "skippedSuites": [],
+        \\  "suites": [{{
+        \\    "id": "suite-1",
+        \\    "algorithm": "X25519",
+        \\    "operation": "derive-shared-secret",
+        \\    "sourceFile": "source.json",
+        \\    "groups": [{{
+        \\      "id": "group-1",
+        \\      "upstreamGroupIndex": 0,
+        \\      "cases": [{{
+        \\        "id": "x25519-short-shared",
+        \\        "upstreamTcId": 1,
+        \\        "classification": "valid",
+        \\        "expected": "success",
+        \\        "comment": "",
+        \\        "flags": [],
+        \\        "private": "c8a9d5a91091ad851c668b0736c1c9a02936c0d3ad62670858088047ba057475",
+        \\        "public": "504a36999f489cd2fdbc08baff3d88fa00569ba986cba22548ffde80f9806829",
+        \\        "shared": ""
+        \\      }}]
+        \\    }}]
+        \\  }}]
+        \\}}
+    , .{schema_version});
+}
+
+const BadAeadProvider = struct {
+    var context: u8 = 0;
+    var entropy_context: u8 = 0;
+
+    const vtable = provider.CryptoProvider.VTable{
+        .capabilities = capabilities,
+        .hkdfExtract = hkdfExtract,
+        .hkdfExpandLabel = hkdfExpandLabel,
+        .aeadSeal = aeadSeal,
+        .aeadOpen = aeadOpen,
+        .generateKeyShare = generateKeyShare,
+        .deriveSharedSecret = deriveSharedSecret,
+        .verify = verify,
+    };
+
+    fn cryptoProvider() provider.CryptoProvider {
+        return .{
+            .context = &context,
+            .vtable = &vtable,
+            .entropy = .{ .context = &entropy_context, .fillFn = fillEntropy },
+        };
+    }
+
+    fn capabilities(ctx: *anyopaque) provider.Capabilities {
+        _ = ctx;
+        var caps = provider.Capabilities{};
+        caps.aeads.insert(.aes_128_gcm);
+        return caps;
+    }
+
+    fn hkdfExtract(ctx: *anyopaque, hash: provider.Hash, salt: []const u8, ikm: []const u8, out: []u8) provider.HkdfError!void {
+        _ = ctx;
+        _ = hash;
+        _ = salt;
+        _ = ikm;
+        _ = out;
+        return error.UnsupportedCapability;
+    }
+
+    fn hkdfExpandLabel(ctx: *anyopaque, hash: provider.Hash, secret: []const u8, label: []const u8, hash_context: []const u8, out: []u8) provider.HkdfError!void {
+        _ = ctx;
+        _ = hash;
+        _ = secret;
+        _ = label;
+        _ = hash_context;
+        _ = out;
+        return error.UnsupportedCapability;
+    }
+
+    fn aeadSeal(ctx: *anyopaque, aead: provider.Aead, key: []const u8, nonce: []const u8, aad: []const u8, plaintext: []const u8, ciphertext: []u8, tag: []u8) provider.SealError!void {
+        _ = ctx;
+        _ = aead;
+        _ = key;
+        _ = nonce;
+        _ = aad;
+        _ = plaintext;
+        _ = ciphertext;
+        _ = tag;
+        return error.UnsupportedCapability;
+    }
+
+    fn aeadOpen(ctx: *anyopaque, aead: provider.Aead, key: []const u8, nonce: []const u8, aad: []const u8, ciphertext: []const u8, tag: []const u8, plaintext: []u8) provider.OpenError!void {
+        _ = ctx;
+        _ = aead;
+        _ = key;
+        _ = nonce;
+        _ = aad;
+        _ = ciphertext;
+        _ = tag;
+        @memset(plaintext, 0x42);
+    }
+
+    fn generateKeyShare(ctx: *anyopaque, group: provider.Group, public_out: []u8, private_out: []u8) provider.KeyShareError!void {
+        _ = ctx;
+        _ = group;
+        _ = public_out;
+        _ = private_out;
+        return error.UnsupportedCapability;
+    }
+
+    fn deriveSharedSecret(ctx: *anyopaque, group: provider.Group, private_scalar: []const u8, peer_public: []const u8, out: []u8) provider.DeriveError!void {
+        _ = ctx;
+        _ = group;
+        _ = private_scalar;
+        _ = peer_public;
+        _ = out;
+        return error.UnsupportedCapability;
+    }
+
+    fn verify(ctx: *anyopaque, scheme: provider.SignatureScheme, public_key: []const u8, message: []const u8, signature: []const u8) provider.VerifyError!void {
+        _ = ctx;
+        _ = scheme;
+        _ = public_key;
+        _ = message;
+        _ = signature;
+        return error.UnsupportedCapability;
+    }
+
+    fn fillEntropy(ctx: *anyopaque, buffer: []u8) provider.EntropyError!void {
+        _ = ctx;
+        @memset(buffer, 0);
+    }
+};

--- a/tests/crypto_corpus.zig
+++ b/tests/crypto_corpus.zig
@@ -1,0 +1,762 @@
+//! Offline bounded Wycheproof-style corpus runner for supported pure-Zig crypto.
+
+const std = @import("std");
+const crypto_pkg = @import("crypto");
+const corpus_manifest = @import("crypto_corpus_manifest.zig");
+
+const provider = crypto_pkg.provider;
+const pure_zig = crypto_pkg.pure_zig;
+const testing = std.testing;
+
+const corpus_file = "tests/vectors/wycheproof/corpus.json";
+const corpus_bytes = @embedFile("vectors/wycheproof/corpus.json");
+
+const schema_version = "tardigrade-wycheproof-reduced-v1";
+
+const Limits = struct {
+    max_file_size: usize = 64 * 1024,
+    max_depth: usize = 12,
+    max_groups: usize = 8,
+    max_cases: usize = 64,
+    max_identifier_len: usize = 96,
+    max_comment_len: usize = 256,
+    max_flags: usize = 8,
+    max_encoded_field_len: usize = 512,
+    max_decoded_total: usize = 8192,
+};
+
+const Classification = enum {
+    valid,
+    invalid,
+    acceptable,
+};
+
+const Algorithm = enum {
+    aes_128_gcm,
+    aes_256_gcm,
+    chacha20_poly1305,
+    x25519,
+    ed25519,
+
+    fn name(self: Algorithm) []const u8 {
+        return switch (self) {
+            .aes_128_gcm => "AES-128-GCM",
+            .aes_256_gcm => "AES-256-GCM",
+            .chacha20_poly1305 => "CHACHA20-POLY1305",
+            .x25519 => "X25519",
+            .ed25519 => "ED25519",
+        };
+    }
+
+    fn aead(self: Algorithm) ?provider.Aead {
+        return switch (self) {
+            .aes_128_gcm => .aes_128_gcm,
+            .aes_256_gcm => .aes_256_gcm,
+            .chacha20_poly1305 => .chacha20_poly1305,
+            .x25519, .ed25519 => null,
+        };
+    }
+};
+
+const Operation = enum {
+    aead_open,
+    derive_shared_secret,
+    verify,
+};
+
+const Expected = enum {
+    success,
+    authentication_failed,
+    invalid_input,
+
+    fn name(self: Expected) []const u8 {
+        return switch (self) {
+            .success => "success",
+            .authentication_failed => "authentication-failed",
+            .invalid_input => "invalid-input",
+        };
+    }
+};
+
+const Source = struct {
+    name: []const u8,
+    repository: []const u8,
+    commit: []const u8,
+    license: []const u8,
+    reduced_by: []const u8,
+};
+
+const SkippedSuite = struct {
+    algorithm: []const u8,
+    reason: []const u8,
+    tracking_issue: []const u8,
+};
+
+const Case = struct {
+    id: []const u8,
+    upstream_tc_id: u32,
+    classification: Classification,
+    expected: Expected,
+    comment: []const u8,
+    flags: []const []const u8,
+    key: []const u8 = &.{},
+    nonce: []const u8 = &.{},
+    aad: []const u8 = &.{},
+    message: []const u8 = &.{},
+    ciphertext: []const u8 = &.{},
+    tag: []const u8 = &.{},
+    private_key: []const u8 = &.{},
+    public_key: []const u8 = &.{},
+    shared: []const u8 = &.{},
+    signature: []const u8 = &.{},
+};
+
+const Group = struct {
+    id: []const u8,
+    upstream_group_index: u32,
+    cases: []Case,
+};
+
+const Suite = struct {
+    id: []const u8,
+    algorithm: Algorithm,
+    operation: Operation,
+    source_file: []const u8,
+    groups: []Group,
+};
+
+const Corpus = struct {
+    arena: std.heap.ArenaAllocator,
+    source: Source,
+    allowlist: []const Algorithm,
+    skipped_suites: []SkippedSuite,
+    suites: []Suite,
+
+    fn deinit(self: *Corpus) void {
+        self.arena.deinit();
+    }
+};
+
+const Report = struct {
+    executed_suites: usize = 0,
+    executed_cases: usize = 0,
+    valid: usize = 0,
+    invalid: usize = 0,
+    acceptable: usize = 0,
+    skipped_suites: usize = 0,
+};
+
+fn cryptoProvider() provider.CryptoProvider {
+    const Holder = struct {
+        var entropy = pure_zig.DeterministicEntropy.init(0x374);
+        var provider_instance = pure_zig.Provider.init(entropy.entropy());
+    };
+    return Holder.provider_instance.cryptoProvider();
+}
+
+fn parseCorpus(backing_allocator: std.mem.Allocator, input: []const u8, limits: Limits) !Corpus {
+    if (input.len > limits.max_file_size) return error.FileTooLarge;
+    if (maxJsonDepth(input) > limits.max_depth) return error.NestingDepthExceeded;
+
+    var arena = std.heap.ArenaAllocator.init(backing_allocator);
+    errdefer arena.deinit();
+    const allocator = arena.allocator();
+
+    const root = try std.json.parseFromSliceLeaky(std.json.Value, allocator, input, .{});
+    const root_object = try expectObject(root);
+    try ensureOnlyFields(root_object, &.{ "schema", "source", "allowlist", "skippedSuites", "suites" });
+    if (!std.mem.eql(u8, try requireString(root_object, "schema", limits), schema_version)) {
+        return error.UnsupportedSchema;
+    }
+
+    const source = try parseSource(try requireObject(root_object, "source"), limits);
+    const allowlist = try parseAllowlist(allocator, try requireArray(root_object, "allowlist"), limits);
+    const skipped_suites = try parseSkippedSuites(allocator, try requireArray(root_object, "skippedSuites"), limits);
+
+    var seen_cases = std.StringHashMap(void).init(allocator);
+    var decoded_total: usize = 0;
+    const suites = try parseSuites(
+        allocator,
+        try requireArray(root_object, "suites"),
+        allowlist,
+        &seen_cases,
+        &decoded_total,
+        limits,
+    );
+
+    return .{
+        .arena = arena,
+        .source = source,
+        .allowlist = allowlist,
+        .skipped_suites = skipped_suites,
+        .suites = suites,
+    };
+}
+
+fn parseSource(obj: std.json.ObjectMap, limits: Limits) !Source {
+    try ensureOnlyFields(obj, &.{ "name", "repository", "commit", "license", "reducedBy" });
+    return .{
+        .name = try requireString(obj, "name", limits),
+        .repository = try requireString(obj, "repository", limits),
+        .commit = try requireString(obj, "commit", limits),
+        .license = try requireString(obj, "license", limits),
+        .reduced_by = try requireString(obj, "reducedBy", limits),
+    };
+}
+
+fn parseAllowlist(allocator: std.mem.Allocator, array: std.json.Array, limits: Limits) ![]const Algorithm {
+    var out = std.array_list.Managed(Algorithm).init(allocator);
+    for (array.items) |value| {
+        const raw = try expectString(value, limits);
+        try out.append(try parseAlgorithm(raw));
+    }
+    return out.toOwnedSlice();
+}
+
+fn parseSkippedSuites(allocator: std.mem.Allocator, array: std.json.Array, limits: Limits) ![]SkippedSuite {
+    var out = std.array_list.Managed(SkippedSuite).init(allocator);
+    for (array.items) |value| {
+        const obj = try expectObject(value);
+        try ensureOnlyFields(obj, &.{ "algorithm", "reason", "trackingIssue" });
+        const skipped = SkippedSuite{
+            .algorithm = try requireString(obj, "algorithm", limits),
+            .reason = try requireString(obj, "reason", limits),
+            .tracking_issue = try requireString(obj, "trackingIssue", limits),
+        };
+        if (skipped.reason.len == 0 or skipped.tracking_issue.len == 0) return error.MissingField;
+        try out.append(skipped);
+    }
+    return out.toOwnedSlice();
+}
+
+fn parseSuites(
+    allocator: std.mem.Allocator,
+    array: std.json.Array,
+    allowlist: []const Algorithm,
+    seen_cases: *std.StringHashMap(void),
+    decoded_total: *usize,
+    limits: Limits,
+) ![]Suite {
+    var out = std.array_list.Managed(Suite).init(allocator);
+    for (array.items) |value| {
+        const obj = try expectObject(value);
+        try ensureOnlyFields(obj, &.{ "id", "algorithm", "operation", "sourceFile", "groups" });
+        const id = try requireId(obj, "id", limits);
+        const algorithm = try parseAlgorithm(try requireString(obj, "algorithm", limits));
+        if (!algorithmAllowed(algorithm, allowlist)) return error.UnsupportedAlgorithm;
+        const operation = try parseOperation(try requireString(obj, "operation", limits));
+        validateOperation(algorithm, operation) catch return error.UnsupportedOperation;
+        const groups = try parseGroups(
+            allocator,
+            try requireArray(obj, "groups"),
+            algorithm,
+            operation,
+            seen_cases,
+            decoded_total,
+            limits,
+        );
+        try out.append(.{
+            .id = id,
+            .algorithm = algorithm,
+            .operation = operation,
+            .source_file = try requireString(obj, "sourceFile", limits),
+            .groups = groups,
+        });
+    }
+    return out.toOwnedSlice();
+}
+
+fn parseGroups(
+    allocator: std.mem.Allocator,
+    array: std.json.Array,
+    algorithm: Algorithm,
+    operation: Operation,
+    seen_cases: *std.StringHashMap(void),
+    decoded_total: *usize,
+    limits: Limits,
+) ![]Group {
+    if (array.items.len > limits.max_groups) return error.TooManyGroups;
+    var out = std.array_list.Managed(Group).init(allocator);
+    for (array.items) |value| {
+        const obj = try expectObject(value);
+        try ensureOnlyFields(obj, &.{ "id", "upstreamGroupIndex", "cases" });
+        try out.append(.{
+            .id = try requireId(obj, "id", limits),
+            .upstream_group_index = try requireU32(obj, "upstreamGroupIndex"),
+            .cases = try parseCases(
+                allocator,
+                try requireArray(obj, "cases"),
+                algorithm,
+                operation,
+                seen_cases,
+                decoded_total,
+                limits,
+            ),
+        });
+    }
+    return out.toOwnedSlice();
+}
+
+fn parseCases(
+    allocator: std.mem.Allocator,
+    array: std.json.Array,
+    algorithm: Algorithm,
+    operation: Operation,
+    seen_cases: *std.StringHashMap(void),
+    decoded_total: *usize,
+    limits: Limits,
+) ![]Case {
+    if (array.items.len > limits.max_cases) return error.TooManyCases;
+    var out = std.array_list.Managed(Case).init(allocator);
+    for (array.items) |value| {
+        const obj = try expectObject(value);
+        switch (operation) {
+            .aead_open => try ensureOnlyFields(obj, &.{ "id", "upstreamTcId", "classification", "expected", "comment", "flags", "key", "nonce", "aad", "message", "ciphertext", "tag" }),
+            .derive_shared_secret => try ensureOnlyFields(obj, &.{ "id", "upstreamTcId", "classification", "expected", "comment", "flags", "private", "public", "shared" }),
+            .verify => try ensureOnlyFields(obj, &.{ "id", "upstreamTcId", "classification", "expected", "comment", "flags", "publicKey", "message", "signature" }),
+        }
+
+        const id = try requireId(obj, "id", limits);
+        if (seen_cases.contains(id)) return error.DuplicateCaseId;
+        try seen_cases.put(id, {});
+
+        const classification = try parseClassification(try requireString(obj, "classification", limits));
+        const expected = try parseExpected(try requireString(obj, "expected", limits));
+        if (classification == .acceptable and expected == .success) return error.AcceptableCaseNeedsPolicy;
+
+        var parsed_case = Case{
+            .id = id,
+            .upstream_tc_id = try requireU32(obj, "upstreamTcId"),
+            .classification = classification,
+            .expected = expected,
+            .comment = try requireComment(obj, "comment", limits),
+            .flags = try parseFlags(allocator, try requireArray(obj, "flags"), limits),
+        };
+
+        switch (operation) {
+            .aead_open => {
+                parsed_case.key = try requireHex(allocator, obj, "key", decoded_total, limits);
+                parsed_case.nonce = try requireHex(allocator, obj, "nonce", decoded_total, limits);
+                parsed_case.aad = try requireHex(allocator, obj, "aad", decoded_total, limits);
+                parsed_case.message = try requireHex(allocator, obj, "message", decoded_total, limits);
+                parsed_case.ciphertext = try requireHex(allocator, obj, "ciphertext", decoded_total, limits);
+                parsed_case.tag = try requireHex(allocator, obj, "tag", decoded_total, limits);
+                if (algorithm.aead() == null) return error.UnsupportedOperation;
+            },
+            .derive_shared_secret => {
+                parsed_case.private_key = try requireHex(allocator, obj, "private", decoded_total, limits);
+                parsed_case.public_key = try requireHex(allocator, obj, "public", decoded_total, limits);
+                parsed_case.shared = try requireHex(allocator, obj, "shared", decoded_total, limits);
+            },
+            .verify => {
+                parsed_case.public_key = try requireHex(allocator, obj, "publicKey", decoded_total, limits);
+                parsed_case.message = try requireHex(allocator, obj, "message", decoded_total, limits);
+                parsed_case.signature = try requireHex(allocator, obj, "signature", decoded_total, limits);
+            },
+        }
+        try out.append(parsed_case);
+    }
+    return out.toOwnedSlice();
+}
+
+fn runCorpus(corpus: *const Corpus) !Report {
+    const cp = cryptoProvider();
+    var report = Report{ .skipped_suites = corpus.skipped_suites.len };
+
+    for (corpus.suites) |suite| {
+        var suite_cases: usize = 0;
+        for (suite.groups) |group| {
+            for (group.cases) |case| {
+                try executeCase(cp, suite, group, case);
+                suite_cases += 1;
+                report.executed_cases += 1;
+                switch (case.classification) {
+                    .valid => report.valid += 1,
+                    .invalid => report.invalid += 1,
+                    .acceptable => report.acceptable += 1,
+                }
+            }
+        }
+        if (suite_cases == 0) return error.EmptySuite;
+        report.executed_suites += 1;
+    }
+
+    try validateManifestCoverage(corpus, report);
+    return report;
+}
+
+fn executeCase(cp: provider.CryptoProvider, suite: Suite, group: Group, case: Case) !void {
+    const observed = switch (suite.operation) {
+        .aead_open => executeAeadOpen(cp, suite.algorithm.aead().?, case),
+        .derive_shared_secret => executeX25519(cp, case),
+        .verify => executeEd25519Verify(cp, case),
+    };
+    if (observed != case.expected) {
+        std.debug.print(
+            "crypto corpus mismatch file={s} group={s} case={s} upstreamTcId={d} algorithm={s} classification={s} expected={s} observed={s}\n",
+            .{
+                corpus_file,
+                group.id,
+                case.id,
+                case.upstream_tc_id,
+                suite.algorithm.name(),
+                @tagName(case.classification),
+                case.expected.name(),
+                observed.name(),
+            },
+        );
+        return error.CorpusCaseMismatch;
+    }
+}
+
+fn executeAeadOpen(cp: provider.CryptoProvider, aead: provider.Aead, case: Case) Expected {
+    const plaintext = testing.allocator.alloc(u8, case.ciphertext.len) catch return .invalid_input;
+    defer testing.allocator.free(plaintext);
+    cp.aeadOpen(aead, case.key, case.nonce, case.aad, case.ciphertext, case.tag, plaintext) catch |err| {
+        return observedFromError(err);
+    };
+    if (!std.mem.eql(u8, plaintext, case.message)) return .authentication_failed;
+    return .success;
+}
+
+fn executeX25519(cp: provider.CryptoProvider, case: Case) Expected {
+    var out: [provider.max_shared_secret_len]u8 = undefined;
+    if (case.shared.len > out.len) return .invalid_input;
+    cp.deriveSharedSecret(.x25519, case.private_key, case.public_key, out[0..case.shared.len]) catch |err| {
+        return observedFromError(err);
+    };
+    if (!std.mem.eql(u8, out[0..case.shared.len], case.shared)) return .authentication_failed;
+    return .success;
+}
+
+fn executeEd25519Verify(cp: provider.CryptoProvider, case: Case) Expected {
+    cp.verify(.ed25519, case.public_key, case.message, case.signature) catch |err| {
+        return observedFromError(err);
+    };
+    return .success;
+}
+
+fn observedFromError(err: anyerror) Expected {
+    return switch (err) {
+        error.AuthenticationFailed => .authentication_failed,
+        error.InvalidInput => .invalid_input,
+        else => .invalid_input,
+    };
+}
+
+fn validateManifestCoverage(corpus: *const Corpus, report: Report) !void {
+    try testing.expectEqual(corpus_manifest.suites.len, report.executed_suites);
+    try testing.expectEqual(corpus_manifest.skipped_suites.len, report.skipped_suites);
+    for (corpus_manifest.suites) |expected_suite| {
+        var matched = false;
+        for (corpus.suites) |actual_suite| {
+            if (!std.mem.eql(u8, expected_suite.id, actual_suite.id)) continue;
+            matched = true;
+            try testing.expectEqual(expected_suite.case_count, countCases(actual_suite));
+            try testing.expectEqualStrings(expected_suite.source_file, actual_suite.source_file);
+        }
+        if (!matched) return error.UnexecutedRegisteredSuite;
+    }
+    for (corpus_manifest.skipped_suites) |expected_skip| {
+        var matched = false;
+        for (corpus.skipped_suites) |actual_skip| {
+            if (std.mem.eql(u8, expected_skip.algorithm, actual_skip.algorithm)) {
+                matched = true;
+                try testing.expect(actual_skip.reason.len > 0);
+                try testing.expectEqualStrings(expected_skip.tracking_issue, actual_skip.tracking_issue);
+            }
+        }
+        if (!matched) return error.MissingSkippedSuite;
+    }
+}
+
+fn countCases(suite: Suite) usize {
+    var total: usize = 0;
+    for (suite.groups) |group| total += group.cases.len;
+    return total;
+}
+
+fn parseAlgorithm(raw: []const u8) !Algorithm {
+    if (std.mem.eql(u8, raw, "AES-128-GCM")) return .aes_128_gcm;
+    if (std.mem.eql(u8, raw, "AES-256-GCM")) return .aes_256_gcm;
+    if (std.mem.eql(u8, raw, "CHACHA20-POLY1305")) return .chacha20_poly1305;
+    if (std.mem.eql(u8, raw, "X25519")) return .x25519;
+    if (std.mem.eql(u8, raw, "ED25519")) return .ed25519;
+    return error.UnsupportedAlgorithm;
+}
+
+fn parseOperation(raw: []const u8) !Operation {
+    if (std.mem.eql(u8, raw, "aead-open")) return .aead_open;
+    if (std.mem.eql(u8, raw, "derive-shared-secret")) return .derive_shared_secret;
+    if (std.mem.eql(u8, raw, "verify")) return .verify;
+    return error.UnsupportedOperation;
+}
+
+fn validateOperation(algorithm: Algorithm, operation: Operation) !void {
+    switch (algorithm) {
+        .aes_128_gcm, .aes_256_gcm, .chacha20_poly1305 => if (operation != .aead_open) return error.UnsupportedOperation,
+        .x25519 => if (operation != .derive_shared_secret) return error.UnsupportedOperation,
+        .ed25519 => if (operation != .verify) return error.UnsupportedOperation,
+    }
+}
+
+fn parseClassification(raw: []const u8) !Classification {
+    if (std.mem.eql(u8, raw, "valid")) return .valid;
+    if (std.mem.eql(u8, raw, "invalid")) return .invalid;
+    if (std.mem.eql(u8, raw, "acceptable")) return .acceptable;
+    return error.UnknownClassification;
+}
+
+fn parseExpected(raw: []const u8) !Expected {
+    if (std.mem.eql(u8, raw, "success")) return .success;
+    if (std.mem.eql(u8, raw, "authentication-failed")) return .authentication_failed;
+    if (std.mem.eql(u8, raw, "invalid-input")) return .invalid_input;
+    return error.UnknownExpectedOutcome;
+}
+
+fn algorithmAllowed(algorithm: Algorithm, allowlist: []const Algorithm) bool {
+    for (allowlist) |allowed| {
+        if (allowed == algorithm) return true;
+    }
+    return false;
+}
+
+fn requireHex(
+    allocator: std.mem.Allocator,
+    obj: std.json.ObjectMap,
+    key: []const u8,
+    decoded_total: *usize,
+    limits: Limits,
+) ![]const u8 {
+    const raw = try requireString(obj, key, limits);
+    if (raw.len > limits.max_encoded_field_len) return error.OversizedValue;
+    if (raw.len % 2 != 0) return error.MalformedHex;
+    const decoded_len = raw.len / 2;
+    if (decoded_total.* + decoded_len > limits.max_decoded_total) return error.DecodedByteLimitExceeded;
+    const out = try allocator.alloc(u8, decoded_len);
+    _ = std.fmt.hexToBytes(out, raw) catch return error.MalformedHex;
+    decoded_total.* += decoded_len;
+    return out;
+}
+
+fn parseFlags(allocator: std.mem.Allocator, array: std.json.Array, limits: Limits) ![]const []const u8 {
+    if (array.items.len > limits.max_flags) return error.TooManyFlags;
+    var out = std.array_list.Managed([]const u8).init(allocator);
+    for (array.items) |value| {
+        try out.append(try expectIdString(value, limits));
+    }
+    return out.toOwnedSlice();
+}
+
+fn requireObject(obj: std.json.ObjectMap, key: []const u8) !std.json.ObjectMap {
+    const value = obj.get(key) orelse return error.MissingField;
+    return expectObject(value);
+}
+
+fn requireArray(obj: std.json.ObjectMap, key: []const u8) !std.json.Array {
+    const value = obj.get(key) orelse return error.MissingField;
+    return expectArray(value);
+}
+
+fn requireString(obj: std.json.ObjectMap, key: []const u8, limits: Limits) ![]const u8 {
+    const value = obj.get(key) orelse return error.MissingField;
+    return expectString(value, limits);
+}
+
+fn requireId(obj: std.json.ObjectMap, key: []const u8, limits: Limits) ![]const u8 {
+    const value = obj.get(key) orelse return error.MissingField;
+    return expectIdString(value, limits);
+}
+
+fn requireComment(obj: std.json.ObjectMap, key: []const u8, limits: Limits) ![]const u8 {
+    const value = obj.get(key) orelse return error.MissingField;
+    const raw = try expectString(value, limits);
+    if (raw.len > limits.max_comment_len) return error.OversizedValue;
+    return raw;
+}
+
+fn requireU32(obj: std.json.ObjectMap, key: []const u8) !u32 {
+    const value = obj.get(key) orelse return error.MissingField;
+    return switch (value) {
+        .integer => |int| if (int >= 0 and int <= std.math.maxInt(u32)) @intCast(int) else error.OversizedValue,
+        else => error.TypeMismatch,
+    };
+}
+
+fn expectObject(value: std.json.Value) !std.json.ObjectMap {
+    return switch (value) {
+        .object => |object| object,
+        else => error.TypeMismatch,
+    };
+}
+
+fn expectArray(value: std.json.Value) !std.json.Array {
+    return switch (value) {
+        .array => |array| array,
+        else => error.TypeMismatch,
+    };
+}
+
+fn expectString(value: std.json.Value, limits: Limits) ![]const u8 {
+    return switch (value) {
+        .string => |string| {
+            if (string.len > limits.max_encoded_field_len) return error.OversizedValue;
+            return string;
+        },
+        else => error.TypeMismatch,
+    };
+}
+
+fn expectIdString(value: std.json.Value, limits: Limits) ![]const u8 {
+    const raw = try expectString(value, limits);
+    if (raw.len == 0 or raw.len > limits.max_identifier_len) return error.OversizedValue;
+    return raw;
+}
+
+fn ensureOnlyFields(obj: std.json.ObjectMap, comptime allowed: []const []const u8) !void {
+    var iterator = obj.iterator();
+    while (iterator.next()) |entry| {
+        inline for (allowed) |field| {
+            if (std.mem.eql(u8, entry.key_ptr.*, field)) break;
+        } else {
+            return error.UnknownField;
+        }
+    }
+}
+
+fn maxJsonDepth(input: []const u8) usize {
+    var in_string = false;
+    var escaped = false;
+    var depth: usize = 0;
+    var max_depth: usize = 0;
+    for (input) |byte| {
+        if (in_string) {
+            if (escaped) {
+                escaped = false;
+            } else if (byte == '\\') {
+                escaped = true;
+            } else if (byte == '"') {
+                in_string = false;
+            }
+            continue;
+        }
+        switch (byte) {
+            '"' => in_string = true,
+            '{', '[' => {
+                depth += 1;
+                max_depth = @max(max_depth, depth);
+            },
+            '}', ']' => depth -|= 1,
+            else => {},
+        }
+    }
+    return max_depth;
+}
+
+test "crypto corpus parser accepts checked-in corpus" {
+    var corpus = try parseCorpus(testing.allocator, corpus_bytes, .{});
+    defer corpus.deinit();
+    try testing.expectEqual(@as(usize, 5), corpus.suites.len);
+    try testing.expectEqual(@as(usize, 3), corpus.skipped_suites.len);
+}
+
+test "crypto corpus parser rejects bounded failure paths" {
+    try testing.expectError(error.FileTooLarge, parseCorpus(testing.allocator, "{}", .{ .max_file_size = 1 }));
+    try testing.expectError(error.NestingDepthExceeded, parseCorpus(testing.allocator, "[[[[]]]]", .{ .max_depth = 2 }));
+    try testing.expectError(error.UnsupportedSchema, parseCorpus(testing.allocator, minimalCorpus(.schema_bad), .{}));
+    try testing.expectError(error.MissingField, parseCorpus(testing.allocator, minimalCorpus(.missing_required), .{}));
+    try testing.expectError(error.UnsupportedAlgorithm, parseCorpus(testing.allocator, minimalCorpus(.unknown_algorithm), .{}));
+    try testing.expectError(error.UnknownClassification, parseCorpus(testing.allocator, minimalCorpus(.unknown_classification), .{}));
+    try testing.expectError(error.MalformedHex, parseCorpus(testing.allocator, minimalCorpus(.malformed_hex), .{}));
+    try testing.expectError(error.OversizedValue, parseCorpus(testing.allocator, minimalCorpus(.oversized_id), .{}));
+    try testing.expectError(error.DuplicateCaseId, parseCorpus(testing.allocator, minimalCorpus(.duplicate_case_id), .{}));
+    try testing.expectError(error.UnknownField, parseCorpus(testing.allocator, minimalCorpus(.unknown_field), .{}));
+}
+
+test "crypto corpus executes through provider and registered manifest" {
+    var corpus = try parseCorpus(testing.allocator, corpus_bytes, .{});
+    defer corpus.deinit();
+    const report = try runCorpus(&corpus);
+    try testing.expectEqual(@as(usize, 5), report.executed_suites);
+    try testing.expectEqual(@as(usize, 11), report.executed_cases);
+    try testing.expectEqual(@as(usize, 5), report.valid);
+    try testing.expectEqual(@as(usize, 5), report.invalid);
+    try testing.expectEqual(@as(usize, 1), report.acceptable);
+    try testing.expectEqual(@as(usize, 3), report.skipped_suites);
+}
+
+const MinimalKind = enum {
+    schema_bad,
+    missing_required,
+    unknown_algorithm,
+    unknown_classification,
+    malformed_hex,
+    oversized_id,
+    duplicate_case_id,
+    unknown_field,
+};
+
+fn minimalCorpus(comptime kind: MinimalKind) []const u8 {
+    const case_id = switch (kind) {
+        .oversized_id => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        else => "case-1",
+    };
+    const classification = if (kind == .unknown_classification) "legacy" else "valid";
+    const key_hex = if (kind == .malformed_hex) "0" else "00000000000000000000000000000000";
+    const algorithm = if (kind == .unknown_algorithm) "AES-192-GCM" else "AES-128-GCM";
+    const schema = if (kind == .schema_bad) "bad-schema" else schema_version;
+    const second_case = if (kind == .duplicate_case_id)
+        \\,{
+        \\  "id": "case-1",
+        \\  "upstreamTcId": 2,
+        \\  "classification": "valid",
+        \\  "expected": "success",
+        \\  "comment": "",
+        \\  "flags": [],
+        \\  "key": "00000000000000000000000000000000",
+        \\  "nonce": "000000000000000000000000",
+        \\  "aad": "",
+        \\  "message": "",
+        \\  "ciphertext": "",
+        \\  "tag": "00000000000000000000000000000000"
+        \\}
+    else
+        "";
+    const source = if (kind == .missing_required)
+        "\"source\": {\"name\": \"x\"},"
+    else
+        "\"source\": {\"name\": \"x\", \"repository\": \"x\", \"commit\": \"x\", \"license\": \"x\", \"reducedBy\": \"x\"},";
+    const extra = if (kind == .unknown_field) ", \"mode\": \"extra\"" else "";
+    return std.fmt.comptimePrint(
+        \\{{
+        \\  "schema": "{s}",
+        \\  {s}
+        \\  "allowlist": ["AES-128-GCM"],
+        \\  "skippedSuites": [],
+        \\  "suites": [{{
+        \\    "id": "suite-1",
+        \\    "algorithm": "{s}",
+        \\    "operation": "aead-open",
+        \\    "sourceFile": "source.json",
+        \\    "groups": [{{
+        \\      "id": "group-1",
+        \\      "upstreamGroupIndex": 0,
+        \\      "cases": [{{
+        \\        "id": "{s}",
+        \\        "upstreamTcId": 1,
+        \\        "classification": "{s}",
+        \\        "expected": "success",
+        \\        "comment": "",
+        \\        "flags": [],
+        \\        "key": "{s}",
+        \\        "nonce": "000000000000000000000000",
+        \\        "aad": "",
+        \\        "message": "",
+        \\        "ciphertext": "",
+        \\        "tag": "00000000000000000000000000000000"{s}
+        \\      }}{s}]
+        \\    }}]
+        \\  }}]
+        \\}}
+    , .{ schema, source, algorithm, case_id, classification, key_hex, extra, second_case });
+}

--- a/tests/crypto_corpus.zig
+++ b/tests/crypto_corpus.zig
@@ -726,12 +726,16 @@ test "crypto corpus parser rejects bounded failure paths" {
     try testing.expectError(error.MissingField, parseCorpus(testing.allocator, minimalCorpus(.missing_required), .{}));
     try testing.expectError(error.UnsupportedAlgorithm, parseCorpus(testing.allocator, minimalCorpus(.unknown_algorithm), .{}));
     try testing.expectError(error.UnknownClassification, parseCorpus(testing.allocator, minimalCorpus(.unknown_classification), .{}));
+    try testing.expectError(error.UnknownExpectedOutcome, parseCorpus(testing.allocator, minimalCorpus(.unknown_expected), .{}));
+    try testing.expectError(error.UnsupportedOperation, parseCorpus(testing.allocator, minimalCorpus(.unsupported_operation), .{}));
     try testing.expectError(error.MalformedHex, parseCorpus(testing.allocator, minimalCorpus(.malformed_hex), .{}));
     try testing.expectError(error.OversizedValue, parseCorpus(testing.allocator, minimalCorpus(.oversized_id), .{}));
     try testing.expectError(error.DuplicateCaseId, parseCorpus(testing.allocator, minimalCorpus(.duplicate_case_id), .{}));
     try testing.expectError(error.UnknownField, parseCorpus(testing.allocator, minimalCorpus(.unknown_field), .{}));
+    try testing.expectError(error.TooManyGroups, parseCorpus(testing.allocator, twoGroupCorpus(), .{ .max_groups = 1 }));
     try testing.expectError(error.TooManyCases, parseCorpus(testing.allocator, twoGroupCorpus(), .{ .max_cases = 1 }));
-    try testing.expectError(error.UnsupportedCapability, observedFromError(error.UnsupportedCapability));
+    try testing.expectError(error.TooManyFlags, parseCorpus(testing.allocator, minimalCorpus(.too_many_flags), .{}));
+    try testing.expectError(error.DecodedByteLimitExceeded, parseCorpus(testing.allocator, minimalCorpus(.valid), .{ .max_decoded_total = 0 }));
     try testing.expectError(error.InvalidCorpus, parseCorpus(testing.allocator, x25519ShortSharedCorpus(), .{}));
 }
 
@@ -747,18 +751,24 @@ test "crypto corpus executes through provider and registered manifest" {
     try testing.expectEqual(@as(usize, 3), report.skipped_suites);
 }
 
-test "crypto corpus validates classification policy" {
-    try validateExpected(.valid, .success);
-    try testing.expectError(error.InvalidExpectedOutcome, validateExpected(.valid, .authentication_failed));
-    try testing.expectError(error.InvalidExpectedOutcome, validateExpected(.valid, .invalid_input));
+test "crypto corpus validates classification policy through parser" {
+    var valid_success = try parseCorpus(testing.allocator, policyCorpus("valid", "success"), .{});
+    valid_success.deinit();
+    try testing.expectError(error.InvalidExpectedOutcome, parseCorpus(testing.allocator, policyCorpus("valid", "authentication-failed"), .{}));
+    try testing.expectError(error.InvalidExpectedOutcome, parseCorpus(testing.allocator, policyCorpus("valid", "invalid-input"), .{}));
 
-    try testing.expectError(error.InvalidExpectedOutcome, validateExpected(.invalid, .success));
-    try validateExpected(.invalid, .authentication_failed);
-    try validateExpected(.invalid, .invalid_input);
+    try testing.expectError(error.InvalidExpectedOutcome, parseCorpus(testing.allocator, policyCorpus("invalid", "success"), .{}));
+    var invalid_auth = try parseCorpus(testing.allocator, policyCorpus("invalid", "authentication-failed"), .{});
+    invalid_auth.deinit();
+    var invalid_input = try parseCorpus(testing.allocator, policyCorpus("invalid", "invalid-input"), .{});
+    invalid_input.deinit();
 
-    try validateExpected(.acceptable, .success);
-    try validateExpected(.acceptable, .authentication_failed);
-    try validateExpected(.acceptable, .invalid_input);
+    var acceptable_success = try parseCorpus(testing.allocator, policyCorpus("acceptable", "success"), .{});
+    acceptable_success.deinit();
+    var acceptable_auth = try parseCorpus(testing.allocator, policyCorpus("acceptable", "authentication-failed"), .{});
+    acceptable_auth.deinit();
+    var acceptable_input = try parseCorpus(testing.allocator, policyCorpus("acceptable", "invalid-input"), .{});
+    acceptable_input.deinit();
 }
 
 test "crypto corpus runner rejects provider success with mismatched AEAD output" {
@@ -785,15 +795,63 @@ test "crypto corpus runner rejects provider success with mismatched AEAD output"
     try testing.expect(observed != expectedObserved(case.expected));
 }
 
+test "crypto corpus runner propagates unexpected provider errors" {
+    const key = [_]u8{0} ** provider.Aead.aes_128_gcm.keyLength();
+    const nonce = [_]u8{0} ** provider.aead_nonce_len;
+    const tag = [_]u8{0} ** provider.aead_tag_len;
+    const suite = Suite{
+        .id = "fake-aead",
+        .algorithm = .aes_128_gcm,
+        .operation = .aead_open,
+        .source_file = "fake.json",
+        .groups = &.{},
+    };
+    const group = Group{
+        .id = "fake-group",
+        .upstream_group_index = 0,
+        .cases = &.{},
+    };
+    const case = Case{
+        .id = "fake-case",
+        .upstream_tc_id = 1,
+        .classification = .invalid,
+        .expected = .invalid_input,
+        .comment = "",
+        .flags = &.{},
+        .key = &key,
+        .nonce = &nonce,
+        .tag = &tag,
+    };
+    try testing.expectError(error.UnsupportedCapability, executeCase(UnsupportedAeadProvider.cryptoProvider(), suite, group, case));
+}
+
+test "crypto corpus manifest rejects algorithm mismatch" {
+    var corpus = try parseCorpus(testing.allocator, corpus_bytes, .{});
+    defer corpus.deinit();
+    corpus.suites[0].algorithm = .chacha20_poly1305;
+    try testing.expectError(error.TestUnexpectedResult, validateManifestCoverage(&corpus, .{
+        .executed_suites = corpus_manifest.suites.len,
+        .executed_cases = 11,
+        .valid = 5,
+        .invalid = 5,
+        .acceptable = 1,
+        .skipped_suites = corpus_manifest.skipped_suites.len,
+    }));
+}
+
 const MinimalKind = enum {
+    valid,
     schema_bad,
     missing_required,
     unknown_algorithm,
     unknown_classification,
+    unknown_expected,
+    unsupported_operation,
     malformed_hex,
     oversized_id,
     duplicate_case_id,
     unknown_field,
+    too_many_flags,
 };
 
 fn minimalCorpus(comptime kind: MinimalKind) []const u8 {
@@ -802,9 +860,12 @@ fn minimalCorpus(comptime kind: MinimalKind) []const u8 {
         else => "case-1",
     };
     const classification = if (kind == .unknown_classification) "legacy" else "valid";
+    const expected = if (kind == .unknown_expected) "maybe" else "success";
     const key_hex = if (kind == .malformed_hex) "0" else "00000000000000000000000000000000";
     const algorithm = if (kind == .unknown_algorithm) "AES-192-GCM" else "AES-128-GCM";
+    const operation = if (kind == .unsupported_operation) "verify" else "aead-open";
     const schema = if (kind == .schema_bad) "bad-schema" else schema_version;
+    const flags = if (kind == .too_many_flags) "[\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\"]" else "[]";
     const second_case = if (kind == .duplicate_case_id)
         \\,{
         \\  "id": "case-1",
@@ -836,7 +897,7 @@ fn minimalCorpus(comptime kind: MinimalKind) []const u8 {
         \\  "suites": [{{
         \\    "id": "suite-1",
         \\    "algorithm": "{s}",
-        \\    "operation": "aead-open",
+        \\    "operation": "{s}",
         \\    "sourceFile": "source.json",
         \\    "groups": [{{
         \\      "id": "group-1",
@@ -845,9 +906,9 @@ fn minimalCorpus(comptime kind: MinimalKind) []const u8 {
         \\        "id": "{s}",
         \\        "upstreamTcId": 1,
         \\        "classification": "{s}",
-        \\        "expected": "success",
+        \\        "expected": "{s}",
         \\        "comment": "",
-        \\        "flags": [],
+        \\        "flags": {s},
         \\        "key": "{s}",
         \\        "nonce": "000000000000000000000000",
         \\        "aad": "",
@@ -858,7 +919,42 @@ fn minimalCorpus(comptime kind: MinimalKind) []const u8 {
         \\    }}]
         \\  }}]
         \\}}
-    , .{ schema, source, algorithm, case_id, classification, key_hex, extra, second_case });
+    , .{ schema, source, algorithm, operation, case_id, classification, expected, flags, key_hex, extra, second_case });
+}
+
+fn policyCorpus(comptime classification: []const u8, comptime expected: []const u8) []const u8 {
+    return std.fmt.comptimePrint(
+        \\{{
+        \\  "schema": "{s}",
+        \\  "source": {{"name": "x", "repository": "x", "commit": "x", "license": "x", "reducedBy": "x"}},
+        \\  "allowlist": ["AES-128-GCM"],
+        \\  "skippedSuites": [],
+        \\  "suites": [{{
+        \\    "id": "suite-1",
+        \\    "algorithm": "AES-128-GCM",
+        \\    "operation": "aead-open",
+        \\    "sourceFile": "source.json",
+        \\    "groups": [{{
+        \\      "id": "group-1",
+        \\      "upstreamGroupIndex": 0,
+        \\      "cases": [{{
+        \\        "id": "case-1",
+        \\        "upstreamTcId": 1,
+        \\        "classification": "{s}",
+        \\        "expected": "{s}",
+        \\        "comment": "",
+        \\        "flags": [],
+        \\        "key": "00000000000000000000000000000000",
+        \\        "nonce": "000000000000000000000000",
+        \\        "aad": "",
+        \\        "message": "",
+        \\        "ciphertext": "",
+        \\        "tag": "00000000000000000000000000000000"
+        \\      }}]
+        \\    }}]
+        \\  }}]
+        \\}}
+    , .{ schema_version, classification, expected });
 }
 
 fn twoGroupCorpus() []const u8 {
@@ -1049,5 +1145,41 @@ const BadAeadProvider = struct {
     fn fillEntropy(ctx: *anyopaque, buffer: []u8) provider.EntropyError!void {
         _ = ctx;
         @memset(buffer, 0);
+    }
+};
+
+const UnsupportedAeadProvider = struct {
+    var context: u8 = 0;
+    var entropy_context: u8 = 0;
+
+    const vtable = provider.CryptoProvider.VTable{
+        .capabilities = BadAeadProvider.capabilities,
+        .hkdfExtract = BadAeadProvider.hkdfExtract,
+        .hkdfExpandLabel = BadAeadProvider.hkdfExpandLabel,
+        .aeadSeal = BadAeadProvider.aeadSeal,
+        .aeadOpen = aeadOpen,
+        .generateKeyShare = BadAeadProvider.generateKeyShare,
+        .deriveSharedSecret = BadAeadProvider.deriveSharedSecret,
+        .verify = BadAeadProvider.verify,
+    };
+
+    fn cryptoProvider() provider.CryptoProvider {
+        return .{
+            .context = &context,
+            .vtable = &vtable,
+            .entropy = .{ .context = &entropy_context, .fillFn = BadAeadProvider.fillEntropy },
+        };
+    }
+
+    fn aeadOpen(ctx: *anyopaque, aead: provider.Aead, key: []const u8, nonce: []const u8, aad: []const u8, ciphertext: []const u8, tag: []const u8, plaintext: []u8) provider.OpenError!void {
+        _ = ctx;
+        _ = aead;
+        _ = key;
+        _ = nonce;
+        _ = aad;
+        _ = ciphertext;
+        _ = tag;
+        _ = plaintext;
+        return error.UnsupportedCapability;
     }
 };

--- a/tests/crypto_corpus_manifest.zig
+++ b/tests/crypto_corpus_manifest.zig
@@ -1,0 +1,31 @@
+//! Shared manifest for checked-in Wycheproof-style crypto corpus suites.
+
+const crypto_pkg = @import("crypto");
+const profile = crypto_pkg.profile;
+
+pub const Suite = struct {
+    id: []const u8,
+    algorithm: profile.Algorithm,
+    source_file: []const u8,
+    case_count: usize,
+};
+
+pub const SkippedSuite = struct {
+    algorithm: []const u8,
+    reason: []const u8,
+    tracking_issue: []const u8,
+};
+
+pub const suites = [_]Suite{
+    .{ .id = "wycheproof-aes-128-gcm-reduced", .algorithm = .{ .aead = .aes_128_gcm }, .source_file = "testvectors_v1/aes_gcm_test.json", .case_count = 2 },
+    .{ .id = "wycheproof-aes-256-gcm-reduced", .algorithm = .{ .aead = .aes_256_gcm }, .source_file = "testvectors_v1/aes_gcm_test.json", .case_count = 2 },
+    .{ .id = "wycheproof-chacha20-poly1305-reduced", .algorithm = .{ .aead = .chacha20_poly1305 }, .source_file = "testvectors_v1/chacha20_poly1305_test.json", .case_count = 3 },
+    .{ .id = "wycheproof-x25519-reduced", .algorithm = .{ .group = .x25519 }, .source_file = "testvectors_v1/x25519_test.json", .case_count = 2 },
+    .{ .id = "wycheproof-ed25519-verify-reduced", .algorithm = .{ .signature = .ed25519 }, .source_file = "testvectors_v1/ed25519_test.json", .case_count = 2 },
+};
+
+pub const skipped_suites = [_]SkippedSuite{
+    .{ .algorithm = "RSA-PSS", .reason = "Provider capability remains deferred for issue #374 follow-up; pure-Zig provider currently returns UnsupportedCapability.", .tracking_issue = "#374" },
+    .{ .algorithm = "ECDSA-P256-SHA256", .reason = "Supported provider operation, but outside this first merge-sized #374 corpus slice.", .tracking_issue = "#374" },
+    .{ .algorithm = "X448", .reason = "Unsupported by the current provider capability matrix.", .tracking_issue = "#374" },
+};

--- a/tests/crypto_vectors.zig
+++ b/tests/crypto_vectors.zig
@@ -537,7 +537,9 @@ fn runUnsupportedCapabilityVectors(log: *ExecutionLog) !void {
 
 fn registerWycheproofCorpusSuites(log: *ExecutionLog) !void {
     for (corpus_manifest.suites) |suite| {
-        _ = try log.execute(suite.id);
+        const meta = try log.execute(suite.id);
+        const algorithm = meta.algorithm orelse return error.MissingCaseMetadata;
+        try testing.expect(algorithmEql(algorithm, suite.algorithm));
         try testing.expect(suite.case_count > 0);
     }
     for (corpus_manifest.skipped_suites) |suite| {

--- a/tests/crypto_vectors.zig
+++ b/tests/crypto_vectors.zig
@@ -7,6 +7,7 @@
 
 const std = @import("std");
 const crypto_pkg = @import("crypto");
+const corpus_manifest = @import("crypto_corpus_manifest.zig");
 const quic = @import("quic");
 const tls_core = @import("tls_core");
 
@@ -72,6 +73,11 @@ const case_registry = [_]CaseMeta{
     .{ .id = "secp256r1-unsupported", .algorithm = .{ .group = .secp256r1 }, .providers = pure_zig_only, .class = .negative, .source = "provider capability matrix", .license = "project fixture", .reproduction = "zig build test-crypto-vectors" },
     .{ .id = "ed25519-rfc8032-test-1", .algorithm = .{ .signature = .ed25519 }, .providers = pure_zig_only, .class = .positive, .source = "RFC 8032 Section 7.1", .license = "IETF Trust", .reproduction = "published RFC vector" },
     .{ .id = "ed25519-signature-rejection", .algorithm = .{ .signature = .ed25519 }, .providers = pure_zig_only, .class = .negative, .source = "provider contract", .license = "project fixture", .reproduction = "zig build test-crypto-vectors" },
+    .{ .id = "wycheproof-aes-128-gcm-reduced", .algorithm = .{ .aead = .aes_128_gcm }, .providers = pure_zig_only, .class = .negative, .source = "tests/vectors/wycheproof/corpus.json", .license = "Apache-2.0", .reproduction = "zig build test-crypto-corpus" },
+    .{ .id = "wycheproof-aes-256-gcm-reduced", .algorithm = .{ .aead = .aes_256_gcm }, .providers = pure_zig_only, .class = .negative, .source = "tests/vectors/wycheproof/corpus.json", .license = "Apache-2.0", .reproduction = "zig build test-crypto-corpus" },
+    .{ .id = "wycheproof-chacha20-poly1305-reduced", .algorithm = .{ .aead = .chacha20_poly1305 }, .providers = pure_zig_only, .class = .negative, .source = "tests/vectors/wycheproof/corpus.json", .license = "Apache-2.0", .reproduction = "zig build test-crypto-corpus" },
+    .{ .id = "wycheproof-x25519-reduced", .algorithm = .{ .group = .x25519 }, .providers = pure_zig_only, .class = .negative, .source = "tests/vectors/wycheproof/corpus.json", .license = "Apache-2.0", .reproduction = "zig build test-crypto-corpus" },
+    .{ .id = "wycheproof-ed25519-verify-reduced", .algorithm = .{ .signature = .ed25519 }, .providers = pure_zig_only, .class = .negative, .source = "tests/vectors/wycheproof/corpus.json", .license = "Apache-2.0", .reproduction = "zig build test-crypto-corpus" },
     .{ .id = "rsa-pss-unsupported", .algorithm = .{ .signature = .rsa_pss_rsae_sha256 }, .providers = pure_zig_only, .class = .negative, .source = "provider capability matrix", .license = "project fixture", .reproduction = "zig build test-crypto-vectors" },
     .{ .id = "deterministic-entropy-positive", .algorithm = .{ .entropy = .injected_random_bytes }, .providers = pure_zig_only, .class = .positive, .source = "provider contract", .license = "project fixture", .reproduction = "zig build test-crypto-vectors" },
     .{ .id = "secure-zero-positive", .algorithm = .{ .entropy = .secure_zero }, .providers = pure_zig_only, .class = .positive, .source = "provider contract", .license = "project fixture", .reproduction = "zig build test-crypto-vectors" },
@@ -529,6 +535,17 @@ fn runUnsupportedCapabilityVectors(log: *ExecutionLog) !void {
     try testing.expectError(error.UnsupportedCapability, cp.verify(.rsa_pss_rsae_sha256, "", "", ""));
 }
 
+fn registerWycheproofCorpusSuites(log: *ExecutionLog) !void {
+    for (corpus_manifest.suites) |suite| {
+        _ = try log.execute(suite.id);
+        try testing.expect(suite.case_count > 0);
+    }
+    for (corpus_manifest.skipped_suites) |suite| {
+        try testing.expect(suite.reason.len > 0);
+        try testing.expect(suite.tracking_issue.len > 0);
+    }
+}
+
 test "crypto vector suite executes registered coverage" {
     var log = ExecutionLog{};
     try runHkdfVectors(&log);
@@ -540,6 +557,7 @@ test "crypto vector suite executes registered coverage" {
     try runKeyExchangeAndSignatureVectors(&log);
     try runEntropyAndSecretHelperVectors(&log);
     try runUnsupportedCapabilityVectors(&log);
+    try registerWycheproofCorpusSuites(&log);
     try validateManifest(&log);
     try validateCapabilityMatrix(&log);
 }

--- a/tests/vectors/wycheproof/README.md
+++ b/tests/vectors/wycheproof/README.md
@@ -1,0 +1,82 @@
+# Reduced Wycheproof-style crypto corpus
+
+This directory contains a checked-in, offline corpus for `zig build test-crypto-corpus`.
+CI must not download upstream vectors.
+
+## Origin and License
+
+- Source: C2SP Project Wycheproof, `https://github.com/C2SP/wycheproof`
+- Upstream commit: `fc24cd5b787d8e496bff31b0468af693a652b0f2`
+- Upstream license: Apache-2.0
+- Local schema: `tardigrade-wycheproof-reduced-v1`
+
+The checked-in `corpus.json` is a reduced project-owned representation. It keeps
+the upstream source file, group index, `tcId`, result classification, comment,
+flags, and reproducible input values needed by the current `CryptoProvider`
+contract.
+
+## Included Suites
+
+- `wycheproof-aes-128-gcm-reduced`
+- `wycheproof-aes-256-gcm-reduced`
+- `wycheproof-chacha20-poly1305-reduced`
+- `wycheproof-x25519-reduced`
+- `wycheproof-ed25519-verify-reduced`
+
+These suites are the first pure-Zig-provider slice for issue `#374`. They cover
+only operations currently supported through the shared provider boundary.
+
+## Skipped Suites
+
+- RSA-PSS: provider capability remains deferred for issue `#374` follow-up.
+- ECDSA-P256-SHA256: supported provider operation, but outside this first
+  merge-sized `#374` corpus slice.
+- X448 and broader asymmetric formats: unsupported by the current provider
+  capability matrix.
+
+Every skipped suite must name a reason and tracking issue in both
+`corpus.json` and `tests/crypto_corpus_manifest.zig`.
+
+## Acceptable Case Policy
+
+Wycheproof `acceptable` means the upstream project allows more than one
+implementation policy. Tardigrade does not treat `acceptable` as success by
+default. Each acceptable case included in this reduced corpus must carry an
+explicit `expected` provider outcome. The current X25519 low-order public-key
+case is classified as upstream `acceptable` and expected to return
+`invalid-input` because the provider contract rejects all-zero shared secrets.
+
+## Parser Limits
+
+The runner enforces bounded parsing before execution:
+
+- file size: 64 KiB
+- JSON nesting depth: 12
+- groups per suite: 8
+- total cases: 64
+- identifier length: 96 bytes
+- comments: 256 bytes
+- flags per case: 8
+- encoded hex field: 512 bytes
+- decoded bytes across executable fields: 8192 bytes
+
+Malformed hex, duplicate case IDs, unsupported schema versions, unknown
+algorithms, unknown execution-affecting fields, missing required fields,
+unknown classifications, and oversized values are rejected.
+
+## Update Procedure
+
+1. Fetch the upstream commit recorded above, or deliberately choose and record a
+   new commit.
+2. Select only cases that execute through the shared `CryptoProvider`.
+3. Preserve upstream source file, group index, `tcId`, classification, comment,
+   and flags.
+4. Keep the reduced schema small enough for review.
+5. Update `tests/crypto_corpus_manifest.zig` case counts and skipped suites.
+6. Run `zig build test-crypto-corpus --summary all --error-style verbose`.
+7. Run `git diff --check`.
+
+When a corpus case exposes a bug, reduce it into a permanent focused regression
+fixture near the provider or protocol code that owns the behavior, then keep or
+add the corpus case as the broader provenance-backed guard.
+

--- a/tests/vectors/wycheproof/corpus.json
+++ b/tests/vectors/wycheproof/corpus.json
@@ -221,7 +221,7 @@
       "sourceFile": "testvectors_v1/ed25519_test.json",
       "groups": [
         {
-          "id": "ed25519-verify-valid-and-invalid",
+          "id": "ed25519-valid-group",
           "upstreamGroupIndex": 0,
           "cases": [
             {
@@ -234,7 +234,13 @@
               "publicKey": "7d4d0e7f6153a69b6242b522abbee685fda4420f8834b108c3bdae369ef549fa",
               "message": "",
               "signature": "d4fbdb52bfa726b44d1786a8c0d171c3e62ca83c9e5bbe63de0bb2483f8fd6cc1429ab72cafc41ab56af02ff8fcc43b99bfe4c7ae940f60f38ebaa9d311c4007"
-            },
+            }
+          ]
+        },
+        {
+          "id": "ed25519-invalid-signature-group",
+          "upstreamGroupIndex": 1,
+          "cases": [
             {
               "id": "ed25519-10",
               "upstreamTcId": 10,

--- a/tests/vectors/wycheproof/corpus.json
+++ b/tests/vectors/wycheproof/corpus.json
@@ -1,0 +1,254 @@
+{
+  "schema": "tardigrade-wycheproof-reduced-v1",
+  "source": {
+    "name": "C2SP Project Wycheproof",
+    "repository": "https://github.com/C2SP/wycheproof",
+    "commit": "fc24cd5b787d8e496bff31b0468af693a652b0f2",
+    "license": "Apache-2.0",
+    "reducedBy": "tests/vectors/wycheproof/README.md"
+  },
+  "allowlist": [
+    "AES-128-GCM",
+    "AES-256-GCM",
+    "CHACHA20-POLY1305",
+    "X25519",
+    "ED25519"
+  ],
+  "skippedSuites": [
+    {
+      "algorithm": "RSA-PSS",
+      "reason": "Provider capability remains deferred for issue #374 follow-up; pure-Zig provider currently returns UnsupportedCapability.",
+      "trackingIssue": "#374"
+    },
+    {
+      "algorithm": "ECDSA-P256-SHA256",
+      "reason": "Supported provider operation, but outside this first merge-sized #374 corpus slice.",
+      "trackingIssue": "#374"
+    },
+    {
+      "algorithm": "X448",
+      "reason": "Unsupported by the current provider capability matrix.",
+      "trackingIssue": "#374"
+    }
+  ],
+  "suites": [
+    {
+      "id": "wycheproof-aes-128-gcm-reduced",
+      "algorithm": "AES-128-GCM",
+      "operation": "aead-open",
+      "sourceFile": "testvectors_v1/aes_gcm_test.json",
+      "groups": [
+        {
+          "id": "aes-gcm-128-96-128",
+          "upstreamGroupIndex": 0,
+          "cases": [
+            {
+              "id": "aes-128-gcm-1",
+              "upstreamTcId": 1,
+              "classification": "valid",
+              "expected": "success",
+              "comment": "",
+              "flags": ["Ktv"],
+              "key": "5b9604fe14eadba931b0ccf34843dab9",
+              "nonce": "028318abc1824029138141a2",
+              "aad": "",
+              "message": "001d0c231287c1182784554ca3a21908",
+              "ciphertext": "26073cc1d851beff176384dc9896d5ff",
+              "tag": "0a3ea7a5487cb5f7d70fb6c58d038554"
+            },
+            {
+              "id": "aes-128-gcm-41",
+              "upstreamTcId": 41,
+              "classification": "invalid",
+              "expected": "authentication-failed",
+              "comment": "Flipped bit 0 in tag",
+              "flags": ["ModifiedTag"],
+              "key": "000102030405060708090a0b0c0d0e0f",
+              "nonce": "505152535455565758595a5b",
+              "aad": "",
+              "message": "202122232425262728292a2b2c2d2e2f",
+              "ciphertext": "eb156d081ed6b6b55f4612f021d87b39",
+              "tag": "d9847dbc326a06e988c77ad3863e6083"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "wycheproof-aes-256-gcm-reduced",
+      "algorithm": "AES-256-GCM",
+      "operation": "aead-open",
+      "sourceFile": "testvectors_v1/aes_gcm_test.json",
+      "groups": [
+        {
+          "id": "aes-gcm-256-96-128",
+          "upstreamGroupIndex": 3,
+          "cases": [
+            {
+              "id": "aes-256-gcm-91",
+              "upstreamTcId": 91,
+              "classification": "valid",
+              "expected": "success",
+              "comment": "",
+              "flags": ["Ktv"],
+              "key": "92ace3e348cd821092cd921aa3546374299ab46209691bc28b8752d17f123c20",
+              "nonce": "00112233445566778899aabb",
+              "aad": "00000000ffffffff",
+              "message": "00010203040506070809",
+              "ciphertext": "e27abdd2d2a53d2f136b",
+              "tag": "9a4a2579529301bcfb71c78d4060f52c"
+            },
+            {
+              "id": "aes-256-gcm-130",
+              "upstreamTcId": 130,
+              "classification": "invalid",
+              "expected": "authentication-failed",
+              "comment": "Flipped bit 0 in tag",
+              "flags": ["ModifiedTag"],
+              "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+              "nonce": "505152535455565758595a5b",
+              "aad": "",
+              "message": "202122232425262728292a2b2c2d2e2f",
+              "ciphertext": "b2061457c0759fc1749f174ee1ccadfa",
+              "tag": "9de8fef6d8ab1bf1bf887232eab590dd"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "wycheproof-chacha20-poly1305-reduced",
+      "algorithm": "CHACHA20-POLY1305",
+      "operation": "aead-open",
+      "sourceFile": "testvectors_v1/chacha20_poly1305_test.json",
+      "groups": [
+        {
+          "id": "chacha20-poly1305-96-128",
+          "upstreamGroupIndex": 0,
+          "cases": [
+            {
+              "id": "chacha20-poly1305-1",
+              "upstreamTcId": 1,
+              "classification": "valid",
+              "expected": "success",
+              "comment": "RFC 7539",
+              "flags": ["Ktv"],
+              "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+              "nonce": "070000004041424344454647",
+              "aad": "50515253c0c1c2c3c4c5c6c7",
+              "message": "4c616469657320616e642047656e746c656d656e206f662074686520636c617373206f66202739393a204966204920636f756c64206f6666657220796f75206f6e6c79206f6e652074697020666f7220746865206675747572652c2073756e73637265656e20776f756c642062652069742e",
+              "ciphertext": "d31a8d34648e60db7b86afbc53ef7ec2a4aded51296e08fea9e2b5a736ee62d63dbea45e8ca9671282fafb69da92728b1a71de0a9e060b2905d6a5b67ecd3b3692ddbd7f2d778b8c9803aee328091b58fab324e4fad675945585808b4831d7bc3ff4def08e4b7a9de576d26586cec64b6116",
+              "tag": "1ae10b594f09e26a7e902ecbd0600691"
+            },
+            {
+              "id": "chacha20-poly1305-146",
+              "upstreamTcId": 146,
+              "classification": "invalid",
+              "expected": "authentication-failed",
+              "comment": "Flipped bit 0 in tag expected tag:f4409bb729039d0814ac514054323f44",
+              "flags": ["ModifiedTag"],
+              "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+              "nonce": "000102030405060708090a0b",
+              "aad": "000102",
+              "message": "",
+              "ciphertext": "",
+              "tag": "f5409bb729039d0814ac514054323f44"
+            }
+          ]
+        },
+        {
+          "id": "chacha20-poly1305-invalid-nonce",
+          "upstreamGroupIndex": 2,
+          "cases": [
+            {
+              "id": "chacha20-poly1305-318",
+              "upstreamTcId": 318,
+              "classification": "invalid",
+              "expected": "invalid-input",
+              "comment": "nonce has size 8.",
+              "flags": ["InvalidNonceSize"],
+              "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+              "nonce": "0001020304050607",
+              "aad": "",
+              "message": "",
+              "ciphertext": "",
+              "tag": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "wycheproof-x25519-reduced",
+      "algorithm": "X25519",
+      "operation": "derive-shared-secret",
+      "sourceFile": "testvectors_v1/x25519_test.json",
+      "groups": [
+        {
+          "id": "x25519-comp",
+          "upstreamGroupIndex": 0,
+          "cases": [
+            {
+              "id": "x25519-1",
+              "upstreamTcId": 1,
+              "classification": "valid",
+              "expected": "success",
+              "comment": "normal case",
+              "flags": ["Normal"],
+              "private": "c8a9d5a91091ad851c668b0736c1c9a02936c0d3ad62670858088047ba057475",
+              "public": "504a36999f489cd2fdbc08baff3d88fa00569ba986cba22548ffde80f9806829",
+              "shared": "436a2c040cf45fea9b29a0cb81b1f41458f863d0d61b453d0a982720d6d61320"
+            },
+            {
+              "id": "x25519-32",
+              "upstreamTcId": 32,
+              "classification": "acceptable",
+              "expected": "invalid-input",
+              "comment": "public key = 0",
+              "flags": ["SmallPublicKey", "LowOrderPublic", "SpecialPublicKey", "ZeroSharedSecret"],
+              "private": "88227494038f2bb811d47805bcdf04a2ac585ada7f2f23389bfd4658f9ddd45e",
+              "public": "0000000000000000000000000000000000000000000000000000000000000000",
+              "shared": "0000000000000000000000000000000000000000000000000000000000000000"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "wycheproof-ed25519-verify-reduced",
+      "algorithm": "ED25519",
+      "operation": "verify",
+      "sourceFile": "testvectors_v1/ed25519_test.json",
+      "groups": [
+        {
+          "id": "ed25519-verify-valid-and-invalid",
+          "upstreamGroupIndex": 0,
+          "cases": [
+            {
+              "id": "ed25519-1",
+              "upstreamTcId": 1,
+              "classification": "valid",
+              "expected": "success",
+              "comment": "",
+              "flags": ["Valid"],
+              "publicKey": "7d4d0e7f6153a69b6242b522abbee685fda4420f8834b108c3bdae369ef549fa",
+              "message": "",
+              "signature": "d4fbdb52bfa726b44d1786a8c0d171c3e62ca83c9e5bbe63de0bb2483f8fd6cc1429ab72cafc41ab56af02ff8fcc43b99bfe4c7ae940f60f38ebaa9d311c4007"
+            },
+            {
+              "id": "ed25519-10",
+              "upstreamTcId": 10,
+              "classification": "invalid",
+              "expected": "authentication-failed",
+              "comment": "special values for r and s",
+              "flags": ["InvalidSignature"],
+              "publicKey": "7d4d0e7f6153a69b6242b522abbee685fda4420f8834b108c3bdae369ef549fa",
+              "message": "3f",
+              "signature": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Refs #374. This PR adds the first pure-Zig-provider slice of the Wycheproof-style negative/edge corpus work. It intentionally does not close #374 because OpenSSL differential execution, RSA-PSS coverage, ECDSA expansion, and broader corpus growth remain follow-up work.

## Included Algorithms and Counts

- AES-128-GCM: 2 cases (1 valid, 1 invalid)
- AES-256-GCM: 2 cases (1 valid, 1 invalid)
- ChaCha20-Poly1305: 3 cases (1 valid, 2 invalid, including invalid nonce length)
- X25519: 2 cases (1 valid, 1 acceptable with explicit `invalid-input` provider policy)
- Ed25519 verification: 2 cases (1 valid, 1 invalid)

Total executed corpus: 5 suites, 11 cases, 5 valid, 5 invalid, 1 acceptable.

## What Changed

- Added `tests/vectors/wycheproof/corpus.json`, a reduced offline schema preserving upstream source file, group index, `tcId`, classification, comments, flags, and reproducible inputs.
- Added `tests/vectors/wycheproof/README.md` with origin/license metadata, upstream commit, schema, parser limits, acceptable-case policy, update procedure, and skipped suites.
- Added `tests/crypto_corpus.zig`, a bounded parser and executor that runs cases through the shared `CryptoProvider` interface.
- Added `tests/crypto_corpus_manifest.zig` and registered the suite IDs with the existing crypto-vector coverage log.
- Added `zig build test-crypto-corpus` and wired it into `test-crypto` and the normal `zig build test` path.

## Parser Limits

- file size: 64 KiB
- JSON nesting depth: 12
- groups per suite: 8
- total cases: 64
- identifier length: 96 bytes
- comments: 256 bytes
- flags per case: 8
- encoded hex field: 512 bytes
- decoded bytes across executable fields: 8192 bytes

The parser rejects duplicate case IDs, unknown classifications, malformed hex, oversized values, unsupported schema versions, missing required fields, unknown algorithms, unsupported operation mappings, unknown execution-affecting fields, and acceptable cases without explicit provider policy.

## Deferred Suites

- RSA-PSS: provider capability remains deferred for #374 follow-up.
- ECDSA-P256-SHA256: supported provider operation, but outside this first merge-sized #374 corpus slice.
- X448 and broader asymmetric formats: unsupported by the current provider capability matrix.
- OpenSSL differential execution: deferred until the OpenSSL `CryptoProvider` adapter exists.

## Validation

- `zig fmt --check build.zig src/ tests/`
- `zig build test-crypto-corpus --summary all --error-style verbose`
- `zig build test-crypto-vectors --summary all --error-style verbose`
- `zig build test-crypto --summary all --error-style verbose`
- `zig build test --summary all --error-style verbose`
- `git diff --check`
