### PR TITLE
Format crypto corpus manifest

### DIFF
--- a/tests/crypto_corpus_manifest.zig
+++ b/tests/crypto_corpus_manifest.zig
@@ -17,15 +17,52 @@ pub const SkippedSuite = struct {
 };
 
 pub const suites = [_]Suite{
-    .{ .id = "wycheproof-aes-128-gcm-reduced", .algorithm = .{ .aead = .aes_128_gcm }, .source_file = "testvectors_v1/aes_gcm_test.json", .case_count = 2 },
-    .{ .id = "wycheproof-aes-256-gcm-reduced", .algorithm = .{ .aead = .aes_256_gcm }, .source_file = "testvectors_v1/aes_gcm_test.json", .case_count = 2 },
-    .{ .id = "wycheproof-chacha20-poly1305-reduced", .algorithm = .{ .aead = .chacha20_poly1305 }, .source_file = "testvectors_v1/chacha20_poly1305_test.json", .case_count = 3 },
-    .{ .id = "wycheproof-x25519-reduced", .algorithm = .{ .group = .x25519 }, .source_file = "testvectors_v1/x25519_test.json", .case_count = 2 },
-    .{ .id = "wycheproof-ed25519-verify-reduced", .algorithm = .{ .signature = .ed25519 }, .source_file = "testvectors_v1/ed25519_test.json", .case_count = 2 },
+    .{
+        .id = "wycheproof-aes-128-gcm-reduced",
+        .algorithm = .{ .aead = .aes_128_gcm },
+        .source_file = "testvectors_v1/aes_gcm_test.json",
+        .case_count = 2,
+    },
+    .{
+        .id = "wycheproof-aes-256-gcm-reduced",
+        .algorithm = .{ .aead = .aes_256_gcm },
+        .source_file = "testvectors_v1/aes_gcm_test.json",
+        .case_count = 2,
+    },
+    .{
+        .id = "wycheproof-chacha20-poly1305-reduced",
+        .algorithm = .{ .aead = .chacha20_poly1305 },
+        .source_file = "testvectors_v1/chacha20_poly1305_test.json",
+        .case_count = 3,
+    },
+    .{
+        .id = "wycheproof-x25519-reduced",
+        .algorithm = .{ .group = .x25519 },
+        .source_file = "testvectors_v1/x25519_test.json",
+        .case_count = 2,
+    },
+    .{
+        .id = "wycheproof-ed25519-verify-reduced",
+        .algorithm = .{ .signature = .ed25519 },
+        .source_file = "testvectors_v1/ed25519_test.json",
+        .case_count = 2,
+    },
 };
 
 pub const skipped_suites = [_]SkippedSuite{
-    .{ .algorithm = "RSA-PSS", .reason = "Provider capability remains deferred for issue #374 follow-up; pure-Zig provider currently returns UnsupportedCapability.", .tracking_issue = "#374" },
-    .{ .algorithm = "ECDSA-P256-SHA256", .reason = "Supported provider operation, but outside this first merge-sized #374 corpus slice.", .tracking_issue = "#374" },
-    .{ .algorithm = "X448", .reason = "Unsupported by the current provider capability matrix.", .tracking_issue = "#374" },
+    .{
+        .algorithm = "RSA-PSS",
+        .reason = "Provider capability remains deferred for issue #374 follow-up; pure-Zig provider currently returns UnsupportedCapability.",
+        .tracking_issue = "#374",
+    },
+    .{
+        .algorithm = "ECDSA-P256-SHA256",
+        .reason = "Supported provider operation, but outside this first merge-sized #374 corpus slice.",
+        .tracking_issue = "#374",
+    },
+    .{
+        .algorithm = "X448",
+        .reason = "Unsupported by the current provider capability matrix.",
+        .tracking_issue = "#374",
+    },
 };


### PR DESCRIPTION
### Motivation
- Fix formatter/CI failures by adjusting test data to be formatter-friendly so `zig fmt --check` will pass.
- Ensure test manifest and related test code follow the project's preferred multi-line struct literal style for readability and linting.

### Description
- Rewrote entries in `tests/crypto_corpus_manifest.zig` from dense single-line struct literals into formatter-friendly multi-line struct literals for both `suites` and `skipped_suites`.
- Removed a duplicated `.commit` field in the `parseSource` return shape in `tests/crypto_corpus.zig` to eliminate an accidental duplicate assignment.
- Committed the formatting change with message `Format crypto corpus manifest`.

### Testing
- Ran `git diff --check` which succeeded with no whitespace/format issues detected.
- Attempted to run `sh ./scripts/install-zig.sh 0.16.0 && zig fmt --check build.zig src/ tests/` but the run was blocked by an external network error when downloading Zig (HTTP 403), so `zig fmt` could not be verified in this environment.
- No other automated test runs were possible here due to the environment network restrictions (download of Zig failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5855f8cb808327813fafc131ff85d7)