### PR TITLE
docs: document branch cleanup policy and root-cause security test plan F-07

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -25,3 +25,9 @@ Use this checklist before tagging and distributing a Tardigrade release.
 - [ ] Run `./scripts/test-deb-package.sh` on a Linux host with Docker
 - [ ] Verify release packaging paths and checksums
 - [ ] Confirm changelog entries for operator-visible changes are complete
+
+## Branch Hygiene
+
+- [ ] After each PR merges (squash merge is standard for this repo), delete its head branch. Prefer enabling "Automatically delete head branches" in repo settings so this happens without a manual step.
+- [ ] Periodically (at least once per release cycle), diff open remote branches against merged PRs and closed issues; delete or archive any branch whose work already landed on `main` or was abandoned in favor of a different branch.
+- [ ] Never delete a branch backing an open PR, or the branch currently checked out for active work.

--- a/docs/SECURITY_TEST_PLAN.md
+++ b/docs/SECURITY_TEST_PLAN.md
@@ -51,17 +51,22 @@ a release gate, not a best-effort activity.
 
 ## Commands
 
-Use the repo-pinned Zig toolchain, not the shell default `zig`.
+Use Zig `0.16.0` (see `CONTRIBUTING.md`). If it is not already on `PATH`,
+bootstrap it first:
+
+```bash
+sh ./scripts/install-zig.sh 0.16.0
+```
 
 ```bash
 # Unit + parser/path/auth hardening coverage
-./.zig-toolchain/0.16.0/zig-aarch64-macos-0.16.0/zig build test
+zig build test
 
 # Seed corpus replay + deterministic mutation pass
-./.zig-toolchain/0.16.0/zig-aarch64-macos-0.16.0/zig build test-security-corpus
+zig build test-security-corpus
 
 # Live-process integration coverage
-./.zig-toolchain/0.16.0/zig-aarch64-macos-0.16.0/zig build test-integration
+zig build test-integration
 ```
 
 ## Release Gate
@@ -113,6 +118,14 @@ IDs against the `tg-<decimal>-<lowercase-hex>` format. Arbitrary client values
 are discarded and a fresh ID is generated. Covered by unit tests in
 `correlation_id.zig`.
 
+**F-07 — Static file serving via catch-all `location /` non-functional** ✅ ROOT-CAUSED, TRACKED SEPARATELY
+Root-caused by code trace: a `location` block with `root` but no `index` or
+`try_files` directive 404s on directory requests because static serving has
+no default index value (unlike nginx's implicit `index index.html;`). The
+fix requires a maintainer decision (default index vs. fail-fast config
+validation vs. document as intentional), so it now has its own tracked issue,
+#437, with the full reproduction and code references.
+
 ### Open Gaps
 
 **F-05 — TLS surface pass still pending**
@@ -122,11 +135,6 @@ yet been completed with `tls_scan`. Run against an isolated lab target.
 **F-06 — Auth enforcement pass still pending**
 Bearer auth bypass, malformed bearer, token replay, and method-change bypass
 have not been probed against a live edge with auth configured.
-
-**F-07 — Static file serving via catch-all `location /` non-functional**
-Files in a configured `doc_root` return 404 despite `root` directive in
-`location /`. Investigate whether this is a static-serving bug or intentional;
-add integration test for static root fallback.
 
 ## Proxy Security Behavior Reference
 


### PR DESCRIPTION
**What changed and why**
- Adds a "Branch Hygiene" section to `docs/RELEASE_CHECKLIST.md` documenting post-merge branch deletion and periodic pruning of stale topic branches (#309). The actual branch audit/deletion for #309 was done out-of-band (109 stale branches verified against merged PR head SHAs and deleted).
- `docs/SECURITY_TEST_PLAN.md`: drops hardcoded macOS/aarch64 toolchain paths in favor of plain `zig build ...` commands matching `CONTRIBUTING.md`/CI, with a `scripts/install-zig.sh` bootstrap note. Root-causes gap F-07 via code trace (static serving has no default `index` value, unlike nginx's implicit `index index.html;`, so `location / { root ...; }` without an explicit `index`/`try_files` 404s on `/`) and moves it to Resolved Gaps. The actual behavior fix needs a maintainer decision, so it's split into #437 (#307).

**Related issues**
Closes #307

**Tests**
Docs-only change. No test coverage added; `git diff --check` was run and passes clean on both files. The F-07 root cause itself is derived from static code analysis (no network access to fetch the Zig toolchain in the authoring session to run a live repro) — #437 tracks adding a regression test once the fix approach is decided.

**Security impact**
None. Documentation only; no code paths changed.

**Performance impact**
None.

**Checklist**
- [ ] `zig fmt --check build.zig src/ tests/` passes
- [ ] `zig build test --summary all` green
- [ ] `zig build test-integration` green (required for protocol, proxy, and TLS changes)
- [x] New behavior covered by tests — N/A, docs-only change
- [x] [docs/CODE_REVIEW_CHECKLIST.md](docs/CODE_REVIEW_CHECKLIST.md) completed — docs-only change, no code review checklist items apply
- [x] README / CHANGELOG updated if operator-visible behavior changed — no operator-visible behavior changed


---
_Generated by [Claude Code](https://claude.ai/code/session_011hcQ4GtPJu2tBDMngSf2h2)_