### PR TITLE
test(quic): bound deterministic H3 driver scenarios

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -366,6 +366,8 @@ pub fn build(b: *std.Build) void {
     quic_h3_e2e_mod.addImport("stream_transport", stream_transport_mod);
     const quic_h3_e2e_tests = b.addTest(.{ .root_module = quic_h3_e2e_mod });
     const run_quic_h3_e2e_tests = b.addRunArtifact(quic_h3_e2e_tests);
+    const quic_h3_driver_step = b.step("test-quic-h3-driver", "Run deterministic native QUIC/H3 driver scenarios");
+    quic_h3_driver_step.dependOn(&run_quic_h3_e2e_tests.step);
     quic_step.dependOn(&run_quic_h3_e2e_tests.step);
     test_step.dependOn(&run_quic_h3_e2e_tests.step);
 

--- a/tests/quic_h3_e2e.zig
+++ b/tests/quic_h3_e2e.zig
@@ -30,6 +30,32 @@ const testing = std.testing;
 
 const H3 = http3.conn.Conn(Connection);
 
+const HarnessFailure = error{
+    NoProgress,
+    IterationLimit,
+    SimulatedTimeLimit,
+    QueueDatagramLimit,
+    QueueByteLimit,
+    PacketProductionLimit,
+    TimerEventLimit,
+    UnexpectedConnectionClosure,
+    DatagramTooLarge,
+};
+
+const Direction = enum { to_server, to_client };
+
+/// Hard resource and progress limits for every deterministic scenario. These
+/// are deliberately part of the harness configuration rather than implicit
+/// test-runner timeouts, so adversarial cases fail at a reproducible boundary.
+const Limits = struct {
+    max_iterations: usize = 16_384,
+    max_simulated_time_us: u64 = 90_000_000,
+    max_queued_datagrams: usize = 128,
+    max_queued_bytes: usize = 256 * 1024,
+    max_packets_per_iteration: usize = 64,
+    max_timer_events: usize = 2_048,
+};
+
 /// Per-direction delivery rules, indexed by datagram sequence number in that
 /// direction (0-based, counted at the sender).
 const Rules = struct {
@@ -59,8 +85,10 @@ const Rules = struct {
 const InFlight = struct {
     deliver_at_us: u64,
     len: usize,
-    bytes: [2048]u8,
+    bytes: [max_test_datagram_size]u8,
 };
+
+const max_test_datagram_size = 2048;
 
 const Pipe = struct {
     rules: Rules,
@@ -71,7 +99,20 @@ const Pipe = struct {
         self.queue.deinit(allocator);
     }
 
-    fn push(self: *Pipe, allocator: std.mem.Allocator, bytes: []const u8, now_us: u64) !void {
+    fn append(self: *Pipe, allocator: std.mem.Allocator, bytes: []const u8, deliver_at_us: u64) !void {
+        if (bytes.len > max_test_datagram_size) return error.DatagramTooLarge;
+        var entry = InFlight{ .deliver_at_us = deliver_at_us, .len = bytes.len, .bytes = undefined };
+        @memcpy(entry.bytes[0..bytes.len], bytes);
+        try self.queue.append(allocator, entry);
+    }
+
+    fn queuedBytes(self: *const Pipe) usize {
+        var total: usize = 0;
+        for (self.queue.items) |entry| total += entry.len;
+        return total;
+    }
+
+    fn schedule(self: *Pipe, allocator: std.mem.Allocator, bytes: []const u8, now_us: u64) !void {
         const index = self.sent;
         self.sent += 1;
         if (self.rules.shouldDrop(index)) return;
@@ -80,12 +121,9 @@ const Pipe = struct {
             // Delivered after its successor: push it further out.
             deliver_at += 2 * self.rules.latency_us;
         }
-        var entry = InFlight{ .deliver_at_us = deliver_at, .len = bytes.len, .bytes = undefined };
-        @memcpy(entry.bytes[0..bytes.len], bytes);
-        try self.queue.append(allocator, entry);
+        try self.append(allocator, bytes, deliver_at);
         if (self.rules.shouldDuplicate(index)) {
-            entry.deliver_at_us += 1;
-            try self.queue.append(allocator, entry);
+            try self.append(allocator, bytes, deliver_at + 1);
         }
     }
 
@@ -118,39 +156,136 @@ const Pipe = struct {
     }
 };
 
+/// Deterministic in-memory datagram network with aggregate queue bounds in
+/// both directions. `Pipe` owns ordering rules; this layer owns resource
+/// accounting so duplication and delay cannot grow memory without a cap.
+const TestNetwork = struct {
+    to_server: Pipe,
+    to_client: Pipe,
+    limits: Limits,
+    max_observed_datagrams: usize = 0,
+    max_observed_bytes: usize = 0,
+
+    fn deinit(self: *TestNetwork, allocator: std.mem.Allocator) void {
+        self.to_server.deinit(allocator);
+        self.to_client.deinit(allocator);
+    }
+
+    fn queuedDatagrams(self: *const TestNetwork) usize {
+        return self.to_server.queue.items.len + self.to_client.queue.items.len;
+    }
+
+    fn queuedBytes(self: *const TestNetwork) usize {
+        return self.to_server.queuedBytes() + self.to_client.queuedBytes();
+    }
+
+    fn enqueue(
+        self: *TestNetwork,
+        allocator: std.mem.Allocator,
+        comptime direction: Direction,
+        bytes: []const u8,
+        now_us: u64,
+    ) !void {
+        const pipe = switch (direction) {
+            .to_server => &self.to_server,
+            .to_client => &self.to_client,
+        };
+        const index = pipe.sent;
+        const copies: usize = if (pipe.rules.shouldDrop(index)) 0 else if (pipe.rules.shouldDuplicate(index)) 2 else 1;
+        if (bytes.len > max_test_datagram_size) return error.DatagramTooLarge;
+        if (self.queuedDatagrams() + copies > self.limits.max_queued_datagrams) return error.QueueDatagramLimit;
+        if (self.queuedBytes() + bytes.len * copies > self.limits.max_queued_bytes) return error.QueueByteLimit;
+
+        try pipe.schedule(allocator, bytes, now_us);
+        self.max_observed_datagrams = @max(self.max_observed_datagrams, self.queuedDatagrams());
+        self.max_observed_bytes = @max(self.max_observed_bytes, self.queuedBytes());
+    }
+
+    fn nextDeliveryUs(self: *const TestNetwork) ?u64 {
+        var next = self.to_server.nextDeliveryUs();
+        if (self.to_client.nextDeliveryUs()) |candidate| {
+            next = if (next) |current| @min(current, candidate) else candidate;
+        }
+        return next;
+    }
+};
+
 const Sim = struct {
     allocator: std.mem.Allocator,
     now_us: u64 = 1_000_000,
+    started_at_us: u64 = 1_000_000,
     /// When set, `step` never advances the clock past this point; reaching it
     /// reports quiescence instead (keeps idle timers out of short scenarios).
     clock_cap: ?u64 = null,
+    scenario: []const u8,
+    seed: u64,
+    limits: Limits,
+    log_failures: bool,
+    iterations: usize = 0,
+    timer_events: usize = 0,
+    last_failure: ?FailureSnapshot = null,
     client_backend: tls_backend.Tls13Backend,
     server_backend: tls_backend.Tls13Backend,
     client: *Connection,
     server: *Connection,
-    to_server: Pipe,
-    to_client: Pipe,
+    network: TestNetwork,
 
     const client_cid = [_]u8{ 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8 };
     const odcid = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08 };
 
     const Config = struct {
+        scenario: []const u8 = "unnamed",
+        seed: u64 = 0x247_5eed,
         to_server: Rules = .{},
         to_client: Rules = .{},
         quic: quic.config.Config = .{},
+        limits: Limits = .{},
+        log_failures: bool = true,
     };
+
+    const FailureSnapshot = struct {
+        reason: HarnessFailure,
+        scenario: []const u8,
+        seed: u64,
+        now_us: u64,
+        iterations: usize,
+        timer_events: usize,
+        queued_datagrams: usize,
+        queued_bytes: usize,
+        client_state: connection.State,
+        server_state: connection.State,
+    };
+
+    fn deterministicBytes(seed: u64, domain: u8) [32]u8 {
+        var input: [9]u8 = undefined;
+        std.mem.writeInt(u64, input[0..8], seed, .little);
+        input[8] = domain;
+        var output: [32]u8 = undefined;
+        std.crypto.hash.sha2.Sha256.hash(&input, &output, .{});
+        return output;
+    }
 
     fn init(allocator: std.mem.Allocator, sim_config: Config) !*Sim {
         const sim = try allocator.create(Sim);
         errdefer allocator.destroy(sim);
         sim.* = .{
             .allocator = allocator,
+            .scenario = sim_config.scenario,
+            .seed = sim_config.seed,
+            .limits = sim_config.limits,
+            .log_failures = sim_config.log_failures,
             .client_backend = tls_backend.Tls13Backend.initClient(
-                .{ .hello_random = [_]u8{0xc1} ** 32, .key_share_seed = [_]u8{0x11} ** 32 },
+                .{
+                    .hello_random = deterministicBytes(sim_config.seed, 0x01),
+                    .key_share_seed = deterministicBytes(sim_config.seed, 0x02),
+                },
                 .{ .pinned_certificate = tls_backend.testdata.certificate_der },
             ),
             .server_backend = tls_backend.Tls13Backend.initServer(
-                .{ .hello_random = [_]u8{0x51} ** 32, .key_share_seed = [_]u8{0x22} ** 32 },
+                .{
+                    .hello_random = deterministicBytes(sim_config.seed, 0x03),
+                    .key_share_seed = deterministicBytes(sim_config.seed, 0x04),
+                },
                 try tls_backend.Identity.initPkcs8(
                     tls_backend.testdata.certificate_der,
                     tls_backend.testdata.private_key_pkcs8_der,
@@ -158,8 +293,11 @@ const Sim = struct {
             ),
             .client = undefined,
             .server = undefined,
-            .to_server = .{ .rules = sim_config.to_server },
-            .to_client = .{ .rules = sim_config.to_client },
+            .network = .{
+                .to_server = .{ .rules = sim_config.to_server },
+                .to_client = .{ .rules = sim_config.to_client },
+                .limits = sim_config.limits,
+            },
         };
         sim.client = try Connection.init(allocator, .{
             .role = .client,
@@ -185,34 +323,91 @@ const Sim = struct {
     fn deinit(self: *Sim) void {
         self.client.deinit();
         self.server.deinit();
-        self.to_server.deinit(self.allocator);
-        self.to_client.deinit(self.allocator);
+        self.network.deinit(self.allocator);
         self.allocator.destroy(self);
+    }
+
+    fn fail(self: *Sim, reason: HarnessFailure) HarnessFailure {
+        if (self.last_failure == null) {
+            self.last_failure = .{
+                .reason = reason,
+                .scenario = self.scenario,
+                .seed = self.seed,
+                .now_us = self.now_us,
+                .iterations = self.iterations,
+                .timer_events = self.timer_events,
+                .queued_datagrams = self.network.queuedDatagrams(),
+                .queued_bytes = self.network.queuedBytes(),
+                .client_state = self.client.state(),
+                .server_state = self.server.state(),
+            };
+            if (self.log_failures) {
+                const failure = self.last_failure.?;
+                std.log.err(
+                    "QUIC/H3 scenario '{s}' seed=0x{x} failed: {s}; now_us={d} iterations={d} timer_events={d} queued={d}/{d}B client={s} server={s}",
+                    .{
+                        failure.scenario,
+                        failure.seed,
+                        @errorName(failure.reason),
+                        failure.now_us,
+                        failure.iterations,
+                        failure.timer_events,
+                        failure.queued_datagrams,
+                        failure.queued_bytes,
+                        @tagName(failure.client_state),
+                        @tagName(failure.server_state),
+                    },
+                );
+            }
+        }
+        return reason;
+    }
+
+    fn enqueue(self: *Sim, comptime direction: Direction, datagram: []const u8) !void {
+        self.network.enqueue(self.allocator, direction, datagram, self.now_us) catch |err| switch (err) {
+            error.DatagramTooLarge => return self.fail(error.DatagramTooLarge),
+            error.QueueDatagramLimit => return self.fail(error.QueueDatagramLimit),
+            error.QueueByteLimit => return self.fail(error.QueueByteLimit),
+            else => return err,
+        };
+    }
+
+    fn fireTimers(self: *Sim) !void {
+        if (self.timer_events >= self.limits.max_timer_events) return self.fail(error.TimerEventLimit);
+        self.client.onTimeout(self.now_us);
+        self.server.onTimeout(self.now_us);
+        self.timer_events += 1;
     }
 
     /// One simulation step: flush transmit queues, deliver due datagrams,
     /// then — if nothing moved — advance the clock to the next deadline.
     /// Returns false when no progress is possible (both sides quiescent).
     fn step(self: *Sim) !bool {
+        if (self.iterations >= self.limits.max_iterations) return self.fail(error.IterationLimit);
+        self.iterations += 1;
         var progressed = false;
-        var buf: [2048]u8 = undefined;
+        var packets_produced: usize = 0;
+        var buf: [max_test_datagram_size]u8 = undefined;
         while (self.client.pollTransmit(&buf, self.now_us)) |datagram| {
-            try self.to_server.push(self.allocator, datagram, self.now_us);
+            packets_produced += 1;
+            if (packets_produced > self.limits.max_packets_per_iteration) return self.fail(error.PacketProductionLimit);
+            try self.enqueue(.to_server, datagram);
             progressed = true;
         }
         while (self.server.pollTransmit(&buf, self.now_us)) |datagram| {
-            try self.to_client.push(self.allocator, datagram, self.now_us);
+            packets_produced += 1;
+            if (packets_produced > self.limits.max_packets_per_iteration) return self.fail(error.PacketProductionLimit);
+            try self.enqueue(.to_client, datagram);
             progressed = true;
         }
-        if (try self.to_server.deliverDue(self.server, self.now_us) > 0) progressed = true;
-        if (try self.to_client.deliverDue(self.client, self.now_us) > 0) progressed = true;
+        if (try self.network.to_server.deliverDue(self.server, self.now_us) > 0) progressed = true;
+        if (try self.network.to_client.deliverDue(self.client, self.now_us) > 0) progressed = true;
         if (progressed) return true;
 
         // Nothing due now: jump to the earliest of in-flight delivery times
         // and both connections' timer deadlines.
         var next: ?u64 = null;
-        if (self.to_server.nextDeliveryUs()) |t| next = minOpt(next, t);
-        if (self.to_client.nextDeliveryUs()) |t| next = minOpt(next, t);
+        if (self.network.nextDeliveryUs()) |t| next = minOpt(next, t);
         if (self.client.nextTimeoutUs()) |t| next = minOpt(next, t);
         if (self.server.nextTimeoutUs()) |t| next = minOpt(next, t);
         var target = next orelse return false;
@@ -222,13 +417,12 @@ const Sim = struct {
         }
         if (target <= self.now_us) {
             // A deadline already expired; fire timers without moving time.
-            self.client.onTimeout(self.now_us);
-            self.server.onTimeout(self.now_us);
+            try self.fireTimers();
             return true;
         }
         self.now_us = target;
-        self.client.onTimeout(self.now_us);
-        self.server.onTimeout(self.now_us);
+        if (self.now_us - self.started_at_us > self.limits.max_simulated_time_us) return self.fail(error.SimulatedTimeLimit);
+        try self.fireTimers();
         return true;
     }
 
@@ -239,15 +433,18 @@ const Sim = struct {
 
     /// Run until `predicate` holds or the simulated clock passes `budget_us`.
     fn runUntil(self: *Sim, comptime predicate: fn (*Sim) bool, budget_us: u64) !void {
-        const deadline = self.now_us + budget_us;
+        const deadline = self.now_us + @min(budget_us, self.limits.max_simulated_time_us);
         while (self.now_us < deadline) {
             if (predicate(self)) return;
+            if (self.client.state() == .closed or self.server.state() == .closed) {
+                return self.fail(error.UnexpectedConnectionClosure);
+            }
             if (!try self.step()) {
                 if (predicate(self)) return;
-                return error.SimulationQuiescent;
+                return self.fail(error.NoProgress);
             }
         }
-        return error.SimulationBudgetExceeded;
+        return self.fail(error.SimulatedTimeLimit);
     }
 
     fn bothEstablished(self: *Sim) bool {
@@ -313,10 +510,12 @@ fn runH3Exchange(sim: *Sim) !void {
     // Request stream is fully closed on both sides.
     try testing.expectEqual(quic.stream.StreamState.closed, sim.client.streamState(request_id).?);
     try testing.expectEqual(quic.stream.StreamState.closed, sim.server.streamState(request_id).?);
+    try testing.expect(sim.network.max_observed_datagrams <= sim.limits.max_queued_datagrams);
+    try testing.expect(sim.network.max_observed_bytes <= sim.limits.max_queued_bytes);
 }
 
 test "e2e: lossless handshake, SETTINGS, request/response, clean close" {
-    var sim = try Sim.init(testing.allocator, .{});
+    var sim = try Sim.init(testing.allocator, .{ .scenario = "lossless" });
     defer sim.deinit();
     try runH3Exchange(sim);
 
@@ -340,6 +539,7 @@ test "e2e: lossless handshake, SETTINGS, request/response, clean close" {
 test "e2e: lost client Initial recovers via PTO" {
     // Datagram 0 client->server is the first Initial (ClientHello).
     var sim = try Sim.init(testing.allocator, .{
+        .scenario = "lost-client-initial",
         .to_server = .{ .drop = &.{0} },
     });
     defer sim.deinit();
@@ -350,6 +550,7 @@ test "e2e: lost client Initial recovers via PTO" {
 test "e2e: lost server handshake flight recovers" {
     // Datagram 1 server->client carries part of the handshake flight.
     var sim = try Sim.init(testing.allocator, .{
+        .scenario = "lost-server-handshake-flight",
         .to_client = .{ .drop = &.{1} },
     });
     defer sim.deinit();
@@ -360,6 +561,7 @@ test "e2e: lost 1-RTT request datagram recovers" {
     // After the 4-datagram handshake exchange, subsequent client datagrams
     // carry the H3 control stream and the request; drop two of them.
     var sim = try Sim.init(testing.allocator, .{
+        .scenario = "lost-1rtt-request",
         .to_server = .{ .drop = &.{ 3, 4 } },
     });
     defer sim.deinit();
@@ -368,6 +570,7 @@ test "e2e: lost 1-RTT request datagram recovers" {
 
 test "e2e: reordered datagrams still complete the exchange" {
     var sim = try Sim.init(testing.allocator, .{
+        .scenario = "reordered-datagrams",
         .to_server = .{ .swap = &.{ 2, 4 } },
         .to_client = .{ .swap = &.{3} },
     });
@@ -377,6 +580,7 @@ test "e2e: reordered datagrams still complete the exchange" {
 
 test "e2e: duplicated datagrams are idempotent" {
     var sim = try Sim.init(testing.allocator, .{
+        .scenario = "duplicated-datagrams",
         .to_server = .{ .duplicate = &.{ 0, 2, 3 } },
         .to_client = .{ .duplicate = &.{ 1, 2 } },
     });
@@ -386,6 +590,7 @@ test "e2e: duplicated datagrams are idempotent" {
 
 test "e2e: loss in both directions during the handshake" {
     var sim = try Sim.init(testing.allocator, .{
+        .scenario = "bidirectional-handshake-loss",
         .to_server = .{ .drop = &.{1} },
         .to_client = .{ .drop = &.{0} },
     });
@@ -394,7 +599,7 @@ test "e2e: loss in both directions during the handshake" {
 }
 
 test "e2e: stream reset propagates across the simulated network" {
-    var sim = try Sim.init(testing.allocator, .{});
+    var sim = try Sim.init(testing.allocator, .{ .scenario = "stream-reset" });
     defer sim.deinit();
     try sim.runUntil(Sim.bothEstablished, 30_000_000);
 
@@ -414,6 +619,7 @@ test "e2e: flow-control blocking then resumed progress under tiny windows" {
     // Windows far below the body size force MAX_DATA / MAX_STREAM_DATA
     // credit round-trips mid-transfer.
     var sim = try Sim.init(testing.allocator, .{
+        .scenario = "flow-control-resume",
         .quic = .{
             .initial_max_data = 2048,
             .initial_max_stream_data_bidi_local = 1200,
@@ -452,7 +658,7 @@ test "e2e: flow-control blocking then resumed progress under tiny windows" {
 }
 
 test "e2e: repeated request/response loop on one connection" {
-    var sim = try Sim.init(testing.allocator, .{});
+    var sim = try Sim.init(testing.allocator, .{ .scenario = "repeated-requests" });
     defer sim.deinit();
     try sim.runUntil(Sim.bothEstablished, 30_000_000);
 
@@ -497,4 +703,152 @@ test "e2e: repeated request/response loop on one connection" {
     }
     try testing.expectEqual(@as(u64, 12), server_h3.metrics.requests_decoded);
     try testing.expectEqual(@as(u64, 12), client_h3.metrics.responses_decoded);
+}
+
+fn expectFailureSnapshot(sim: *Sim, expected: HarnessFailure, scenario: []const u8, seed: u64) !void {
+    const failure = sim.last_failure orelse return error.MissingFailureSnapshot;
+    try testing.expectEqual(expected, failure.reason);
+    try testing.expectEqualStrings(scenario, failure.scenario);
+    try testing.expectEqual(seed, failure.seed);
+    try testing.expectEqual(sim.iterations, failure.iterations);
+    try testing.expectEqual(sim.timer_events, failure.timer_events);
+}
+
+test "e2e harness: scenario seed reproduces the protected wire image" {
+    const seed = 0x247_d37e;
+    var first = try Sim.init(testing.allocator, .{ .scenario = "seed-first", .seed = seed });
+    defer first.deinit();
+    var second = try Sim.init(testing.allocator, .{ .scenario = "seed-second", .seed = seed });
+    defer second.deinit();
+
+    try testing.expect(try first.step());
+    try testing.expect(try second.step());
+    try testing.expectEqual(@as(usize, 1), first.network.to_server.queue.items.len);
+    try testing.expectEqual(@as(usize, 1), second.network.to_server.queue.items.len);
+    const first_initial = first.network.to_server.queue.items[0];
+    const second_initial = second.network.to_server.queue.items[0];
+    try testing.expectEqual(first_initial.len, second_initial.len);
+    try testing.expectEqualSlices(
+        u8,
+        first_initial.bytes[0..first_initial.len],
+        second_initial.bytes[0..second_initial.len],
+    );
+}
+
+test "e2e harness: queued datagram limit bounds duplication" {
+    const scenario = "queue-datagram-limit";
+    const seed = 0x247_0001;
+    var sim = try Sim.init(testing.allocator, .{
+        .scenario = scenario,
+        .seed = seed,
+        .to_server = .{ .duplicate = &.{0} },
+        .limits = .{ .max_queued_datagrams = 1 },
+        .log_failures = false,
+    });
+    defer sim.deinit();
+
+    try testing.expectError(error.QueueDatagramLimit, sim.step());
+    try expectFailureSnapshot(sim, error.QueueDatagramLimit, scenario, seed);
+    try testing.expectEqual(@as(usize, 0), sim.network.queuedDatagrams());
+    try testing.expectEqual(@as(usize, 0), sim.network.queuedBytes());
+}
+
+test "e2e harness: queued byte limit rejects oversized aggregate" {
+    const scenario = "queue-byte-limit";
+    const seed = 0x247_0002;
+    var sim = try Sim.init(testing.allocator, .{
+        .scenario = scenario,
+        .seed = seed,
+        .limits = .{ .max_queued_bytes = 1 },
+        .log_failures = false,
+    });
+    defer sim.deinit();
+
+    try testing.expectError(error.QueueByteLimit, sim.step());
+    try expectFailureSnapshot(sim, error.QueueByteLimit, scenario, seed);
+}
+
+test "e2e harness: packet production per iteration is bounded" {
+    const scenario = "packet-production-limit";
+    const seed = 0x247_0003;
+    var sim = try Sim.init(testing.allocator, .{
+        .scenario = scenario,
+        .seed = seed,
+        .limits = .{ .max_packets_per_iteration = 0 },
+        .log_failures = false,
+    });
+    defer sim.deinit();
+
+    try testing.expectError(error.PacketProductionLimit, sim.step());
+    try expectFailureSnapshot(sim, error.PacketProductionLimit, scenario, seed);
+}
+
+test "e2e harness: iteration limit fails at an exact boundary" {
+    const scenario = "iteration-limit";
+    const seed = 0x247_0004;
+    var sim = try Sim.init(testing.allocator, .{
+        .scenario = scenario,
+        .seed = seed,
+        .limits = .{ .max_iterations = 0 },
+        .log_failures = false,
+    });
+    defer sim.deinit();
+
+    try testing.expectError(error.IterationLimit, sim.step());
+    try expectFailureSnapshot(sim, error.IterationLimit, scenario, seed);
+    try testing.expectEqual(@as(usize, 0), sim.iterations);
+}
+
+test "e2e harness: timer event limit bounds repeated PTO work" {
+    const scenario = "timer-event-limit";
+    const seed = 0x247_0005;
+    var sim = try Sim.init(testing.allocator, .{
+        .scenario = scenario,
+        .seed = seed,
+        .to_server = .{ .drop = &.{0} },
+        .limits = .{ .max_timer_events = 0 },
+        .log_failures = false,
+    });
+    defer sim.deinit();
+
+    try testing.expect(try sim.step()); // Produce and deterministically drop Initial.
+    try testing.expectError(error.TimerEventLimit, sim.step());
+    try expectFailureSnapshot(sim, error.TimerEventLimit, scenario, seed);
+    try testing.expectEqual(@as(usize, 0), sim.timer_events);
+}
+
+test "e2e harness: simulated elapsed time is bounded without sleeping" {
+    const scenario = "simulated-time-limit";
+    const seed = 0x247_0006;
+    var sim = try Sim.init(testing.allocator, .{
+        .scenario = scenario,
+        .seed = seed,
+        .to_server = .{ .latency_us = 1_000 },
+        .limits = .{ .max_simulated_time_us = 500 },
+        .log_failures = false,
+    });
+    defer sim.deinit();
+
+    try testing.expect(try sim.step()); // Queue the Initial for delayed delivery.
+    try testing.expectError(error.SimulatedTimeLimit, sim.step());
+    try expectFailureSnapshot(sim, error.SimulatedTimeLimit, scenario, seed);
+}
+
+test "e2e harness: unexpected closure records endpoint states" {
+    const scenario = "unexpected-close";
+    const seed = 0x247_0007;
+    var sim = try Sim.init(testing.allocator, .{
+        .scenario = scenario,
+        .seed = seed,
+        .log_failures = false,
+    });
+    defer sim.deinit();
+
+    sim.client.close(0x247, "closed before establishment", sim.now_us);
+    sim.now_us += 10_000_000;
+    sim.client.onTimeout(sim.now_us);
+    try testing.expectEqual(connection.State.closed, sim.client.state());
+    try testing.expectError(error.UnexpectedConnectionClosure, sim.runUntil(Sim.bothEstablished, 1_000_000));
+    try expectFailureSnapshot(sim, error.UnexpectedConnectionClosure, scenario, seed);
+    try testing.expectEqual(connection.State.closed, sim.last_failure.?.client_state);
 }

--- a/tests/quic_h3_e2e.zig
+++ b/tests/quic_h3_e2e.zig
@@ -735,25 +735,25 @@ fn expectFailureSnapshot(sim: *Sim, expected: anyerror, scenario: []const u8, se
     try testing.expectEqual(sim.timer_events, failure.timer_events);
 }
 
+fn initialWireImage(scenario: []const u8, seed: u64) !InFlight {
+    var sim = try Sim.init(testing.allocator, .{
+        .scenario = scenario,
+        .seed = seed,
+    });
+    defer sim.deinit();
+    errdefer |err| sim.recordFailure(err);
+
+    try testing.expect(try sim.step());
+    try testing.expectEqual(@as(usize, 1), sim.network.to_server.queue.items.len);
+    return sim.network.to_server.queue.items[0];
+}
+
 test "e2e harness: scenario seed reproduces the protected wire image" {
     const seed = 0x247_d37e;
-    var first = try Sim.init(testing.allocator, .{ .scenario = "seed-first", .seed = seed });
-    defer first.deinit();
-    errdefer |err| first.recordFailure(err);
-    var second = try Sim.init(testing.allocator, .{ .scenario = "seed-second", .seed = seed });
-    defer second.deinit();
-    errdefer |err| second.recordFailure(err);
-    var different = try Sim.init(testing.allocator, .{ .scenario = "seed-different", .seed = seed + 1 });
-    defer different.deinit();
-    errdefer |err| different.recordFailure(err);
+    const first_initial = try initialWireImage("seed-first", seed);
+    const second_initial = try initialWireImage("seed-second", seed);
+    const different_initial = try initialWireImage("seed-different", seed + 1);
 
-    try testing.expect(try first.step());
-    try testing.expect(try second.step());
-    try testing.expect(try different.step());
-    try testing.expectEqual(@as(usize, 1), first.network.to_server.queue.items.len);
-    try testing.expectEqual(@as(usize, 1), second.network.to_server.queue.items.len);
-    const first_initial = first.network.to_server.queue.items[0];
-    const second_initial = second.network.to_server.queue.items[0];
     try testing.expectEqual(first_initial.len, second_initial.len);
     try testing.expectEqualSlices(
         u8,
@@ -761,7 +761,6 @@ test "e2e harness: scenario seed reproduces the protected wire image" {
         second_initial.bytes[0..second_initial.len],
     );
 
-    const different_initial = different.network.to_server.queue.items[0];
     try testing.expect(
         first_initial.len != different_initial.len or
             !std.mem.eql(
@@ -770,6 +769,11 @@ test "e2e harness: scenario seed reproduces the protected wire image" {
                 different_initial.bytes[0..different_initial.len],
             ),
     );
+}
+
+fn returnCapturedOrdinaryError(sim: *Sim) !void {
+    errdefer |err| sim.recordFailure(err);
+    return error.QpackRegression;
 }
 
 test "e2e harness: ordinary scenario errors retain deterministic context" {
@@ -781,11 +785,10 @@ test "e2e harness: ordinary scenario errors retain deterministic context" {
         .log_failures = false,
     });
     defer sim.deinit();
-    errdefer |err| sim.recordFailure(err);
 
     const client_state = sim.client.state();
     const server_state = sim.server.state();
-    sim.recordFailure(error.QpackRegression);
+    try testing.expectError(error.QpackRegression, returnCapturedOrdinaryError(sim));
     sim.recordFailure(error.LaterFailureMustNotOverwrite);
 
     try expectFailureSnapshot(sim, error.QpackRegression, scenario, seed);

--- a/tests/quic_h3_e2e.zig
+++ b/tests/quic_h3_e2e.zig
@@ -244,7 +244,7 @@ const Sim = struct {
     };
 
     const FailureSnapshot = struct {
-        reason: HarnessFailure,
+        reason: anyerror,
         scenario: []const u8,
         seed: u64,
         now_us: u64,
@@ -327,39 +327,44 @@ const Sim = struct {
         self.allocator.destroy(self);
     }
 
-    fn fail(self: *Sim, reason: HarnessFailure) HarnessFailure {
-        if (self.last_failure == null) {
-            self.last_failure = .{
-                .reason = reason,
-                .scenario = self.scenario,
-                .seed = self.seed,
-                .now_us = self.now_us,
-                .iterations = self.iterations,
-                .timer_events = self.timer_events,
-                .queued_datagrams = self.network.queuedDatagrams(),
-                .queued_bytes = self.network.queuedBytes(),
-                .client_state = self.client.state(),
-                .server_state = self.server.state(),
-            };
-            if (self.log_failures) {
-                const failure = self.last_failure.?;
-                std.log.err(
-                    "QUIC/H3 scenario '{s}' seed=0x{x} failed: {s}; now_us={d} iterations={d} timer_events={d} queued={d}/{d}B client={s} server={s}",
-                    .{
-                        failure.scenario,
-                        failure.seed,
-                        @errorName(failure.reason),
-                        failure.now_us,
-                        failure.iterations,
-                        failure.timer_events,
-                        failure.queued_datagrams,
-                        failure.queued_bytes,
-                        @tagName(failure.client_state),
-                        @tagName(failure.server_state),
-                    },
-                );
-            }
-        }
+    fn recordFailure(self: *Sim, reason: anyerror) void {
+        if (self.last_failure != null) return;
+        self.last_failure = .{
+            .reason = reason,
+            .scenario = self.scenario,
+            .seed = self.seed,
+            .now_us = self.now_us,
+            .iterations = self.iterations,
+            .timer_events = self.timer_events,
+            .queued_datagrams = self.network.queuedDatagrams(),
+            .queued_bytes = self.network.queuedBytes(),
+            .client_state = self.client.state(),
+            .server_state = self.server.state(),
+        };
+        if (self.log_failures) self.logFailure();
+    }
+
+    fn logFailure(self: *const Sim) void {
+        const failure = self.last_failure.?;
+        std.log.err(
+            "QUIC/H3 scenario '{s}' seed=0x{x} failed: {s}; now_us={d} iterations={d} timer_events={d} queued={d}/{d}B client={s} server={s}",
+            .{
+                failure.scenario,
+                failure.seed,
+                @errorName(failure.reason),
+                failure.now_us,
+                failure.iterations,
+                failure.timer_events,
+                failure.queued_datagrams,
+                failure.queued_bytes,
+                @tagName(failure.client_state),
+                @tagName(failure.server_state),
+            },
+        );
+    }
+
+    fn fail(self: *Sim, reason: anyerror) anyerror {
+        self.recordFailure(reason);
         return reason;
     }
 
@@ -377,6 +382,16 @@ const Sim = struct {
         self.client.onTimeout(self.now_us);
         self.server.onTimeout(self.now_us);
         self.timer_events += 1;
+    }
+
+    fn advanceAndFireTimers(self: *Sim, delta_us: u64) !void {
+        const target = std.math.add(u64, self.now_us, delta_us) catch
+            return self.fail(error.SimulatedTimeLimit);
+        if (target - self.started_at_us > self.limits.max_simulated_time_us) {
+            return self.fail(error.SimulatedTimeLimit);
+        }
+        self.now_us = target;
+        try self.fireTimers();
     }
 
     /// One simulation step: flush transmit queues, deliver due datagrams,
@@ -420,9 +435,7 @@ const Sim = struct {
             try self.fireTimers();
             return true;
         }
-        self.now_us = target;
-        if (self.now_us - self.started_at_us > self.limits.max_simulated_time_us) return self.fail(error.SimulatedTimeLimit);
-        try self.fireTimers();
+        try self.advanceAndFireTimers(target - self.now_us);
         return true;
     }
 
@@ -517,6 +530,7 @@ fn runH3Exchange(sim: *Sim) !void {
 test "e2e: lossless handshake, SETTINGS, request/response, clean close" {
     var sim = try Sim.init(testing.allocator, .{ .scenario = "lossless" });
     defer sim.deinit();
+    errdefer |err| sim.recordFailure(err);
     try runH3Exchange(sim);
 
     // Clean close: client closes, server drains, both reach closed.
@@ -526,9 +540,7 @@ test "e2e: lossless handshake, SETTINGS, request/response, clean close" {
         if (!try sim.step()) break;
     }
     // Force the 3×PTO close/drain timers if the pipes went quiet first.
-    sim.now_us += 10_000_000;
-    sim.client.onTimeout(sim.now_us);
-    sim.server.onTimeout(sim.now_us);
+    try sim.advanceAndFireTimers(10_000_000);
     try testing.expectEqual(connection.State.closed, sim.client.state());
     try testing.expectEqual(connection.State.closed, sim.server.state());
     const info = sim.server.closeInfo().?;
@@ -543,6 +555,7 @@ test "e2e: lost client Initial recovers via PTO" {
         .to_server = .{ .drop = &.{0} },
     });
     defer sim.deinit();
+    errdefer |err| sim.recordFailure(err);
     try runH3Exchange(sim);
     try testing.expect(sim.client.metrics.pto_count_total > 0);
 }
@@ -554,6 +567,7 @@ test "e2e: lost server handshake flight recovers" {
         .to_client = .{ .drop = &.{1} },
     });
     defer sim.deinit();
+    errdefer |err| sim.recordFailure(err);
     try runH3Exchange(sim);
 }
 
@@ -565,6 +579,7 @@ test "e2e: lost 1-RTT request datagram recovers" {
         .to_server = .{ .drop = &.{ 3, 4 } },
     });
     defer sim.deinit();
+    errdefer |err| sim.recordFailure(err);
     try runH3Exchange(sim);
 }
 
@@ -575,6 +590,7 @@ test "e2e: reordered datagrams still complete the exchange" {
         .to_client = .{ .swap = &.{3} },
     });
     defer sim.deinit();
+    errdefer |err| sim.recordFailure(err);
     try runH3Exchange(sim);
 }
 
@@ -585,6 +601,7 @@ test "e2e: duplicated datagrams are idempotent" {
         .to_client = .{ .duplicate = &.{ 1, 2 } },
     });
     defer sim.deinit();
+    errdefer |err| sim.recordFailure(err);
     try runH3Exchange(sim);
 }
 
@@ -595,12 +612,14 @@ test "e2e: loss in both directions during the handshake" {
         .to_client = .{ .drop = &.{0} },
     });
     defer sim.deinit();
+    errdefer |err| sim.recordFailure(err);
     try runH3Exchange(sim);
 }
 
 test "e2e: stream reset propagates across the simulated network" {
     var sim = try Sim.init(testing.allocator, .{ .scenario = "stream-reset" });
     defer sim.deinit();
+    errdefer |err| sim.recordFailure(err);
     try sim.runUntil(Sim.bothEstablished, 30_000_000);
 
     const id = try sim.client.openStream(.bidi);
@@ -628,6 +647,7 @@ test "e2e: flow-control blocking then resumed progress under tiny windows" {
         },
     });
     defer sim.deinit();
+    errdefer |err| sim.recordFailure(err);
     try sim.runUntil(Sim.bothEstablished, 30_000_000);
 
     const id = try sim.client.openStream(.bidi);
@@ -660,6 +680,7 @@ test "e2e: flow-control blocking then resumed progress under tiny windows" {
 test "e2e: repeated request/response loop on one connection" {
     var sim = try Sim.init(testing.allocator, .{ .scenario = "repeated-requests" });
     defer sim.deinit();
+    errdefer |err| sim.recordFailure(err);
     try sim.runUntil(Sim.bothEstablished, 30_000_000);
 
     var client_h3 = H3.init(sim.allocator, .client);
@@ -705,7 +726,7 @@ test "e2e: repeated request/response loop on one connection" {
     try testing.expectEqual(@as(u64, 12), client_h3.metrics.responses_decoded);
 }
 
-fn expectFailureSnapshot(sim: *Sim, expected: HarnessFailure, scenario: []const u8, seed: u64) !void {
+fn expectFailureSnapshot(sim: *Sim, expected: anyerror, scenario: []const u8, seed: u64) !void {
     const failure = sim.last_failure orelse return error.MissingFailureSnapshot;
     try testing.expectEqual(expected, failure.reason);
     try testing.expectEqualStrings(scenario, failure.scenario);
@@ -718,11 +739,17 @@ test "e2e harness: scenario seed reproduces the protected wire image" {
     const seed = 0x247_d37e;
     var first = try Sim.init(testing.allocator, .{ .scenario = "seed-first", .seed = seed });
     defer first.deinit();
+    errdefer |err| first.recordFailure(err);
     var second = try Sim.init(testing.allocator, .{ .scenario = "seed-second", .seed = seed });
     defer second.deinit();
+    errdefer |err| second.recordFailure(err);
+    var different = try Sim.init(testing.allocator, .{ .scenario = "seed-different", .seed = seed + 1 });
+    defer different.deinit();
+    errdefer |err| different.recordFailure(err);
 
     try testing.expect(try first.step());
     try testing.expect(try second.step());
+    try testing.expect(try different.step());
     try testing.expectEqual(@as(usize, 1), first.network.to_server.queue.items.len);
     try testing.expectEqual(@as(usize, 1), second.network.to_server.queue.items.len);
     const first_initial = first.network.to_server.queue.items[0];
@@ -733,6 +760,71 @@ test "e2e harness: scenario seed reproduces the protected wire image" {
         first_initial.bytes[0..first_initial.len],
         second_initial.bytes[0..second_initial.len],
     );
+
+    const different_initial = different.network.to_server.queue.items[0];
+    try testing.expect(
+        first_initial.len != different_initial.len or
+            !std.mem.eql(
+                u8,
+                first_initial.bytes[0..first_initial.len],
+                different_initial.bytes[0..different_initial.len],
+            ),
+    );
+}
+
+test "e2e harness: ordinary scenario errors retain deterministic context" {
+    const scenario = "ordinary-protocol-error";
+    const seed = 0x247_fa11;
+    var sim = try Sim.init(testing.allocator, .{
+        .scenario = scenario,
+        .seed = seed,
+        .log_failures = false,
+    });
+    defer sim.deinit();
+    errdefer |err| sim.recordFailure(err);
+
+    const client_state = sim.client.state();
+    const server_state = sim.server.state();
+    sim.recordFailure(error.QpackRegression);
+    sim.recordFailure(error.LaterFailureMustNotOverwrite);
+
+    try expectFailureSnapshot(sim, error.QpackRegression, scenario, seed);
+    try testing.expectEqual(client_state, sim.last_failure.?.client_state);
+    try testing.expectEqual(server_state, sim.last_failure.?.server_state);
+}
+
+test "e2e network: datagram limit is aggregate across directions" {
+    var network = TestNetwork{
+        .to_server = .{ .rules = .{} },
+        .to_client = .{ .rules = .{} },
+        .limits = .{ .max_queued_datagrams = 1 },
+    };
+    defer network.deinit(testing.allocator);
+
+    const byte = [_]u8{0xaa};
+    try network.enqueue(testing.allocator, .to_server, &byte, 0);
+    try testing.expectError(
+        error.QueueDatagramLimit,
+        network.enqueue(testing.allocator, .to_client, &byte, 0),
+    );
+    try testing.expectEqual(@as(usize, 1), network.queuedDatagrams());
+}
+
+test "e2e network: byte limit is aggregate across directions" {
+    var network = TestNetwork{
+        .to_server = .{ .rules = .{} },
+        .to_client = .{ .rules = .{} },
+        .limits = .{ .max_queued_bytes = 1 },
+    };
+    defer network.deinit(testing.allocator);
+
+    const byte = [_]u8{0xbb};
+    try network.enqueue(testing.allocator, .to_server, &byte, 0);
+    try testing.expectError(
+        error.QueueByteLimit,
+        network.enqueue(testing.allocator, .to_client, &byte, 0),
+    );
+    try testing.expectEqual(@as(usize, 1), network.queuedBytes());
 }
 
 test "e2e harness: queued datagram limit bounds duplication" {
@@ -746,6 +838,7 @@ test "e2e harness: queued datagram limit bounds duplication" {
         .log_failures = false,
     });
     defer sim.deinit();
+    errdefer |err| sim.recordFailure(err);
 
     try testing.expectError(error.QueueDatagramLimit, sim.step());
     try expectFailureSnapshot(sim, error.QueueDatagramLimit, scenario, seed);
@@ -763,6 +856,7 @@ test "e2e harness: queued byte limit rejects oversized aggregate" {
         .log_failures = false,
     });
     defer sim.deinit();
+    errdefer |err| sim.recordFailure(err);
 
     try testing.expectError(error.QueueByteLimit, sim.step());
     try expectFailureSnapshot(sim, error.QueueByteLimit, scenario, seed);
@@ -778,6 +872,7 @@ test "e2e harness: packet production per iteration is bounded" {
         .log_failures = false,
     });
     defer sim.deinit();
+    errdefer |err| sim.recordFailure(err);
 
     try testing.expectError(error.PacketProductionLimit, sim.step());
     try expectFailureSnapshot(sim, error.PacketProductionLimit, scenario, seed);
@@ -793,6 +888,7 @@ test "e2e harness: iteration limit fails at an exact boundary" {
         .log_failures = false,
     });
     defer sim.deinit();
+    errdefer |err| sim.recordFailure(err);
 
     try testing.expectError(error.IterationLimit, sim.step());
     try expectFailureSnapshot(sim, error.IterationLimit, scenario, seed);
@@ -810,6 +906,7 @@ test "e2e harness: timer event limit bounds repeated PTO work" {
         .log_failures = false,
     });
     defer sim.deinit();
+    errdefer |err| sim.recordFailure(err);
 
     try testing.expect(try sim.step()); // Produce and deterministically drop Initial.
     try testing.expectError(error.TimerEventLimit, sim.step());
@@ -828,6 +925,7 @@ test "e2e harness: simulated elapsed time is bounded without sleeping" {
         .log_failures = false,
     });
     defer sim.deinit();
+    errdefer |err| sim.recordFailure(err);
 
     try testing.expect(try sim.step()); // Queue the Initial for delayed delivery.
     try testing.expectError(error.SimulatedTimeLimit, sim.step());
@@ -843,10 +941,10 @@ test "e2e harness: unexpected closure records endpoint states" {
         .log_failures = false,
     });
     defer sim.deinit();
+    errdefer |err| sim.recordFailure(err);
 
     sim.client.close(0x247, "closed before establishment", sim.now_us);
-    sim.now_us += 10_000_000;
-    sim.client.onTimeout(sim.now_us);
+    try sim.advanceAndFireTimers(10_000_000);
     try testing.expectEqual(connection.State.closed, sim.client.state());
     try testing.expectError(error.UnexpectedConnectionClosure, sim.runUntil(Sim.bothEstablished, 1_000_000));
     try expectFailureSnapshot(sim, error.UnexpectedConnectionClosure, scenario, seed);


### PR DESCRIPTION
## Summary

- harden the existing native QUIC/H3 simulated network with aggregate queued-datagram and queued-byte limits
- bound driver iterations, simulated elapsed time, packets produced per iteration, and timer work with typed failures
- derive deterministic TLS test entropy from a reported scenario seed and retain failure snapshots with both endpoint states
- add focused regression coverage for every bound plus seed reproducibility
- expose the fast suite as `zig build test-quic-h3-driver` while retaining it in `test-quic` and the default test aggregate

## Investigation and reuse

This slice reuses the production `quic.connection.Connection` driver and its packet/frame codec, TLS adapter/backend, ACK and recovery timers, congestion state, streams and flow control, plus the production `http3.conn`/QPACK/session entrypoints. The existing in-process smoke and E2E harnesses remain the integration seams; no simplified protocol implementation or real-socket dependency was added.

The live tree already includes the baseline handshake and H3 exchange, deterministic loss/reordering/duplication/delay, real-UDP smoke, and optional external interop tooling. This PR therefore concentrates on the missing resource/progress bounds and reproducible failure diagnostics.

## Validation

- `zig build test-quic-h3-driver --summary all --error-style verbose` — 21/21 passed
- `zig build test-quic --summary all --error-style verbose` — 410/410 passed
- `zig build test --summary all --error-style verbose` — 1376/1377 passed, 1 existing skip
- `zig fmt --check build.zig src/ tests/`
- `git diff --check`

## Scope

This is a merge-sized deterministic driver-hardening slice of #247. It does not claim to complete the remaining scheduled soak, benchmark, wider malformed corpus, or full interop-runner acceptance criteria, so #247 should remain open after this PR merges.

Part of #247.