### PR TITLE
tls: make PureZigRecordStream own the record handshake driver (#410)

### DIFF
--- a/src/quic/record_mode_handshake_test.zig
+++ b/src/quic/record_mode_handshake_test.zig
@@ -510,6 +510,7 @@ const RecordModeBackend = struct {
         const result = self.engine.backend().transport.start(role, dummy_params, &self.scratch);
         try translate(&self.scratch, sink);
         result catch |err| return mapError(err);
+        if (self.deferredPolicyError()) |err| return err;
     }
 
     fn receive(ptr: *anyopaque, epoch: events.EncryptionEpoch, bytes: []const u8, sink: *es.RecordTransport.EventSink) es.RecordHandshakeError!void {
@@ -518,6 +519,24 @@ const RecordModeBackend = struct {
         const result = self.engine.backend().transport.receive(toLevel(epoch), bytes, &self.scratch);
         try translate(&self.scratch, sink);
         result catch |err| return mapError(err);
+        if (self.deferredPolicyError()) |err| return err;
+    }
+
+    /// The concrete engine reports ALPN/certificate policy results as events and
+    /// marks its own core failed while returning success -- it expects its
+    /// driver to convert those into terminal errors (the QUIC driver does the
+    /// same via `AlpnMismatch`/`CertificateInvalid`). Surface that here so the
+    /// record handshake fails closed instead of stalling with the peer's
+    /// `Finished` still buffered and no further record ever arriving.
+    fn deferredPolicyError(self: *RecordModeBackend) ?es.RecordHandshakeError {
+        if (self.engine.core.handshake_lifecycle != .failed) return null;
+        for (self.scratch.items[0..self.scratch.len]) |event| {
+            if (event == .certificate and event.certificate == .invalid) return error.CertificateInvalid;
+        }
+        for (self.scratch.items[0..self.scratch.len]) |event| {
+            if (event == .alpn) return error.AlpnMismatch;
+        }
+        return error.UnexpectedHandshakeMessage;
     }
 
     /// Securely wipe the last batch's copied secrets from the private sink. The
@@ -694,6 +713,7 @@ const FdCarrier = struct {
 /// keep stable pointers.
 const SocketHarness = struct {
     fds: [2]std.posix.fd_t,
+    fds_closed: [2]bool,
     client_engine: tls_backend.Tls13Backend,
     server_engine: tls_backend.Tls13Backend,
     client_wrapper: RecordModeBackend = undefined,
@@ -703,24 +723,45 @@ const SocketHarness = struct {
     client: es.PureZigRecordStream = undefined,
     server: es.PureZigRecordStream = undefined,
 
-    fn create(client_chunk: usize, server_chunk: usize) !*SocketHarness {
+    const Options = struct {
+        client_chunk: usize = std.math.maxInt(usize),
+        server_chunk: usize = std.math.maxInt(usize),
+        client_trust: tls_backend.Trust = .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+        client_alpn: []const u8 = "h3",
+        server_alpn: []const u8 = "h3",
+    };
+
+    fn create(opts: Options) !*SocketHarness {
         const self = try std.testing.allocator.create(SocketHarness);
         errdefer std.testing.allocator.destroy(self);
         self.fds = try testSocketPair();
+        self.fds_closed = .{ false, false };
 
-        self.client_engine = tls_backend.Tls13Backend.initClient(clientEntropy(), .{ .pinned_certificate = tls_backend.testdata.certificate_der });
+        self.client_engine = tls_backend.Tls13Backend.initClient(clientEntropy(), opts.client_trust);
         self.client_engine.omit_transport_parameters = true;
+        self.client_engine.alpn = opts.client_alpn;
         self.server_engine = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity());
         self.server_engine.omit_transport_parameters = true;
+        self.server_engine.alpn = opts.server_alpn;
 
         self.client_wrapper = RecordModeBackend.init(&self.client_engine);
         self.server_wrapper = RecordModeBackend.init(&self.server_engine);
-        self.client_carrier = .{ .fd = self.fds[0], .max_chunk = client_chunk };
-        self.server_carrier = .{ .fd = self.fds[1], .max_chunk = server_chunk };
+        self.client_carrier = .{ .fd = self.fds[0], .max_chunk = opts.client_chunk };
+        self.server_carrier = .{ .fd = self.fds[1], .max_chunk = opts.server_chunk };
 
         self.client = es.PureZigRecordStream.initWithCarrierAndBackend(.client, clientProvider(), suite, self.client_carrier.carrier(), self.client_wrapper.backend());
         self.server = es.PureZigRecordStream.initWithCarrierAndBackend(.server, serverProvider(), suite, self.server_carrier.carrier(), self.server_wrapper.backend());
         return self;
+    }
+
+    /// Close one endpoint exactly once (idempotent), so a test can close an
+    /// endpoint early to model peer EOF without `destroy` double-closing a
+    /// potentially-recycled descriptor.
+    fn closeEndpoint(self: *SocketHarness, index: usize) void {
+        if (!self.fds_closed[index]) {
+            closeFd(self.fds[index]);
+            self.fds_closed[index] = true;
+        }
     }
 
     fn destroy(self: *SocketHarness) void {
@@ -728,8 +769,8 @@ const SocketHarness = struct {
         self.server.deinit();
         self.client_engine.deinit();
         self.server_engine.deinit();
-        closeFd(self.fds[0]);
-        closeFd(self.fds[1]);
+        self.closeEndpoint(0);
+        self.closeEndpoint(1);
         std.testing.allocator.destroy(self);
     }
 
@@ -765,7 +806,7 @@ test "record stream completes a real TLS 1.3 handshake over a nonblocking socket
         .{ record_codec.max_ciphertext_record_len, record_codec.max_ciphertext_record_len },
     };
     for (chunks) |chunk| {
-        const h = try SocketHarness.create(chunk[0], chunk[1]);
+        const h = try SocketHarness.create(.{ .client_chunk = chunk[0], .server_chunk = chunk[1] });
         defer h.destroy();
 
         try h.driveUntil(SocketHarness.bothComplete);
@@ -815,7 +856,7 @@ test "record stream completes a real TLS 1.3 handshake over a nonblocking socket
 }
 
 test "record stream handshake fails closed when a ClientHello is corrupted in flight" {
-    const h = try SocketHarness.create(std.math.maxInt(usize), std.math.maxInt(usize));
+    const h = try SocketHarness.create(.{});
     defer h.destroy();
     // Flip a byte inside the ClientHello's 32-byte random (past the 5-byte
     // record header, 4-byte handshake header, and 2-byte legacy_version) as the
@@ -851,13 +892,14 @@ test "record stream handshake fails closed when a ClientHello is corrupted in fl
 }
 
 test "record stream handshake treats carrier EOF before close_notify as truncation" {
-    const h = try SocketHarness.create(std.math.maxInt(usize), std.math.maxInt(usize));
+    const h = try SocketHarness.create(.{});
     defer h.destroy();
 
     // Complete the handshake, then the server abruptly closes its socket
-    // instead of sending close_notify.
+    // instead of sending close_notify. `closeEndpoint` makes the harness the
+    // sole owner of each descriptor, so `destroy` never double-closes it.
     try h.driveUntil(SocketHarness.bothComplete);
-    closeFd(h.fds[1]);
+    h.closeEndpoint(1);
     h.server.stream().close();
 
     var client_error: ?anyerror = null;
@@ -870,4 +912,63 @@ test "record stream handshake treats carrier EOF before close_notify as truncati
     }
     try std.testing.expectEqual(@as(?anyerror, error.TruncatedStream), client_error);
     try std.testing.expect(h.client.lifecycle == .failed);
+}
+
+/// Drive both streams until one returns a terminal error or progress stalls,
+/// returning the first error observed (client checked before server each round).
+fn driveUntilError(h: *SocketHarness) ?anyerror {
+    var rounds: usize = 0;
+    while (rounds < 500) : (rounds += 1) {
+        const c = h.client.stream().drive() catch |err| return err;
+        const s = h.server.stream().drive() catch |err| return err;
+        if (h.client.lifecycle == .failed or h.server.lifecycle == .failed) {
+            // Give the failing side one more drive to surface its latched error.
+            _ = h.client.stream().drive() catch |err| return err;
+            _ = h.server.stream().drive() catch |err| return err;
+            return null;
+        }
+        if (!c.made_progress and !s.made_progress) return null;
+    }
+    return null;
+}
+
+test "record stream handshake fails closed with CertificateInvalid on a wrong pinned certificate" {
+    // The client pins a certificate that does not byte-equal the one the server
+    // presents. Proof-of-possession still checks out, so the engine emits
+    // `.certificate(.invalid)`, marks its core failed, and returns success --
+    // record mode must convert that into a terminal `CertificateInvalid` rather
+    // than stalling with the server `Finished` still buffered.
+    var wrong_pin: [tls_backend.testdata.certificate_der.len]u8 = undefined;
+    @memcpy(&wrong_pin, tls_backend.testdata.certificate_der);
+    wrong_pin[wrong_pin.len / 2] ^= 0xff;
+
+    const h = try SocketHarness.create(.{ .client_trust = .{ .pinned_certificate = &wrong_pin } });
+    defer h.destroy();
+
+    const failure = driveUntilError(h);
+    try std.testing.expect(!h.client.bridge.handshake_complete);
+    try std.testing.expect(!h.server.bridge.handshake_complete);
+    try std.testing.expect(h.client.lifecycle == .failed);
+    try std.testing.expect(failure != null);
+    try std.testing.expect(failure.? == error.CertificateInvalid);
+    // A repeated drive returns the stable, latched terminal error, and the
+    // fatal failure wiped the captured negotiation metadata.
+    try std.testing.expectError(error.CertificateInvalid, h.client.stream().drive());
+    try std.testing.expectEqual(events.CertificateState.not_checked, h.client.certificateState());
+}
+
+test "record stream handshake fails closed with AlpnMismatch when the server selects a different protocol" {
+    // The client offers h3; the server supports only h2. The engine reports the
+    // offered protocol, marks its core failed, and returns success, deferring
+    // the AlpnMismatch decision to record mode.
+    const h = try SocketHarness.create(.{ .server_alpn = "h2" });
+    defer h.destroy();
+
+    const failure = driveUntilError(h);
+    try std.testing.expect(!h.client.bridge.handshake_complete);
+    try std.testing.expect(!h.server.bridge.handshake_complete);
+    try std.testing.expect(h.server.lifecycle == .failed);
+    try std.testing.expect(failure != null);
+    try std.testing.expect(failure.? == error.AlpnMismatch);
+    try std.testing.expectError(error.AlpnMismatch, h.server.stream().drive());
 }

--- a/src/quic/record_mode_handshake_test.zig
+++ b/src/quic/record_mode_handshake_test.zig
@@ -761,6 +761,7 @@ const SocketHarness = struct {
 
         self.client = es.PureZigRecordStream.initWithCarrierAndBackend(.client, clientProvider(), suite, self.client_carrier.carrier(), self.client_wrapper.backend());
         self.server = es.PureZigRecordStream.initWithCarrierAndBackend(.server, serverProvider(), suite, self.server_carrier.carrier(), self.server_wrapper.backend());
+        self.client.setExpectedAlpn(opts.client_alpn) catch unreachable;
         return self;
     }
 

--- a/src/quic/record_mode_handshake_test.zig
+++ b/src/quic/record_mode_handshake_test.zig
@@ -680,9 +680,15 @@ const FdCarrier = struct {
     max_chunk: usize = std.math.maxInt(usize),
     read_offset: usize = 0,
     corrupt_at: ?usize = null,
+    one_write_per_drive: bool = false,
+    write_armed: bool = true,
 
     fn carrier(self: *FdCarrier) es.Carrier {
         return .{ .ptr = self, .readFn = read, .writeFn = write };
+    }
+
+    fn rearmWrite(self: *FdCarrier) void {
+        if (self.one_write_per_drive) self.write_armed = true;
     }
 
     fn read(ptr: *anyopaque, out: []u8) es.Error!usize {
@@ -702,9 +708,12 @@ const FdCarrier = struct {
 
     fn write(ptr: *anyopaque, bytes: []const u8) es.Error!usize {
         const self: *FdCarrier = @ptrCast(@alignCast(ptr));
+        if (self.one_write_per_drive and !self.write_armed) return error.WouldBlock;
         const cap = @min(bytes.len, self.max_chunk);
         if (cap == 0) return error.WouldBlock;
-        return writeFd(self.fd, bytes[0..cap]);
+        const written = try writeFd(self.fd, bytes[0..cap]);
+        if (self.one_write_per_drive and written > 0) self.write_armed = false;
+        return written;
     }
 };
 
@@ -729,6 +738,7 @@ const SocketHarness = struct {
         client_trust: tls_backend.Trust = .{ .pinned_certificate = tls_backend.testdata.certificate_der },
         client_alpn: []const u8 = "h3",
         server_alpn: []const u8 = "h3",
+        one_write_per_drive: bool = false,
     };
 
     fn create(opts: Options) !*SocketHarness {
@@ -746,8 +756,8 @@ const SocketHarness = struct {
 
         self.client_wrapper = RecordModeBackend.init(&self.client_engine);
         self.server_wrapper = RecordModeBackend.init(&self.server_engine);
-        self.client_carrier = .{ .fd = self.fds[0], .max_chunk = opts.client_chunk };
-        self.server_carrier = .{ .fd = self.fds[1], .max_chunk = opts.server_chunk };
+        self.client_carrier = .{ .fd = self.fds[0], .max_chunk = opts.client_chunk, .one_write_per_drive = opts.one_write_per_drive };
+        self.server_carrier = .{ .fd = self.fds[1], .max_chunk = opts.server_chunk, .one_write_per_drive = opts.one_write_per_drive };
 
         self.client = es.PureZigRecordStream.initWithCarrierAndBackend(.client, clientProvider(), suite, self.client_carrier.carrier(), self.client_wrapper.backend());
         self.server = es.PureZigRecordStream.initWithCarrierAndBackend(.server, serverProvider(), suite, self.server_carrier.carrier(), self.server_wrapper.backend());
@@ -778,12 +788,22 @@ const SocketHarness = struct {
     fn driveUntil(self: *SocketHarness, done: *const fn (*SocketHarness) bool) !void {
         var rounds: usize = 0;
         while (rounds < 5000) : (rounds += 1) {
-            const c = self.client.stream().drive() catch |err| return err;
-            const s = self.server.stream().drive() catch |err| return err;
+            const c = self.driveClient() catch |err| return err;
+            const s = self.driveServer() catch |err| return err;
             if (done(self)) return;
             if (!c.made_progress and !s.made_progress) return error.Stalled;
         }
         return error.Stalled;
+    }
+
+    fn driveClient(self: *SocketHarness) es.Error!es.DriveResult {
+        self.client_carrier.rearmWrite();
+        return self.client.stream().drive();
+    }
+
+    fn driveServer(self: *SocketHarness) es.Error!es.DriveResult {
+        self.server_carrier.rearmWrite();
+        return self.server.stream().drive();
     }
 
     fn bothComplete(self: *SocketHarness) bool {
@@ -919,8 +939,8 @@ test "record stream handshake treats carrier EOF before close_notify as truncati
 fn driveUntilError(h: *SocketHarness) ?anyerror {
     var rounds: usize = 0;
     while (rounds < 500) : (rounds += 1) {
-        const c = h.client.stream().drive() catch |err| return err;
-        const s = h.server.stream().drive() catch |err| return err;
+        const c = h.driveClient() catch |err| return err;
+        const s = h.driveServer() catch |err| return err;
         if (h.client.lifecycle == .failed or h.server.lifecycle == .failed) {
             // Give the failing side one more drive to surface its latched error.
             _ = h.client.stream().drive() catch |err| return err;
@@ -930,6 +950,32 @@ fn driveUntilError(h: *SocketHarness) ?anyerror {
         if (!c.made_progress and !s.made_progress) return null;
     }
     return null;
+}
+
+const PairErrors = struct {
+    client: ?anyerror = null,
+    server: ?anyerror = null,
+};
+
+/// Keep driving the non-failed peer after the policy-failing side latches its
+/// root error, so the test proves the complete synthesized-alert delivery path.
+fn driveUntilBothErrors(h: *SocketHarness) PairErrors {
+    var errors = PairErrors{};
+    var rounds: usize = 0;
+    while (rounds < 20_000) : (rounds += 1) {
+        if (errors.client == null) {
+            _ = h.driveClient() catch |err| {
+                errors.client = err;
+            };
+        }
+        if (errors.server == null) {
+            _ = h.driveServer() catch |err| {
+                errors.server = err;
+            };
+        }
+        if (errors.client != null and errors.server != null) return errors;
+    }
+    return errors;
 }
 
 test "record stream handshake fails closed with CertificateInvalid on a wrong pinned certificate" {
@@ -942,15 +988,20 @@ test "record stream handshake fails closed with CertificateInvalid on a wrong pi
     @memcpy(&wrong_pin, tls_backend.testdata.certificate_der);
     wrong_pin[wrong_pin.len / 2] ^= 0xff;
 
-    const h = try SocketHarness.create(.{ .client_trust = .{ .pinned_certificate = &wrong_pin } });
+    const h = try SocketHarness.create(.{
+        .client_chunk = 1,
+        .server_chunk = 1,
+        .client_trust = .{ .pinned_certificate = &wrong_pin },
+        .one_write_per_drive = true,
+    });
     defer h.destroy();
 
-    const failure = driveUntilError(h);
+    const failures = driveUntilBothErrors(h);
     try std.testing.expect(!h.client.bridge.handshake_complete);
     try std.testing.expect(!h.server.bridge.handshake_complete);
     try std.testing.expect(h.client.lifecycle == .failed);
-    try std.testing.expect(failure != null);
-    try std.testing.expect(failure.? == error.CertificateInvalid);
+    try std.testing.expectEqual(@as(?anyerror, error.CertificateInvalid), failures.client);
+    try std.testing.expectEqual(@as(?anyerror, error.PeerFatalAlert), failures.server);
     // A repeated drive returns the stable, latched terminal error, and the
     // fatal failure wiped the captured negotiation metadata.
     try std.testing.expectError(error.CertificateInvalid, h.client.stream().drive());
@@ -961,14 +1012,38 @@ test "record stream handshake fails closed with AlpnMismatch when the server sel
     // The client offers h3; the server supports only h2. The engine reports the
     // offered protocol, marks its core failed, and returns success, deferring
     // the AlpnMismatch decision to record mode.
-    const h = try SocketHarness.create(.{ .server_alpn = "h2" });
+    const h = try SocketHarness.create(.{
+        .client_chunk = 1,
+        .server_chunk = 1,
+        .server_alpn = "h2",
+        .one_write_per_drive = true,
+    });
     defer h.destroy();
 
-    const failure = driveUntilError(h);
+    const failures = driveUntilBothErrors(h);
     try std.testing.expect(!h.client.bridge.handshake_complete);
     try std.testing.expect(!h.server.bridge.handshake_complete);
     try std.testing.expect(h.server.lifecycle == .failed);
-    try std.testing.expect(failure != null);
-    try std.testing.expect(failure.? == error.AlpnMismatch);
+    try std.testing.expectEqual(@as(?anyerror, error.PeerFatalAlert), failures.client);
+    try std.testing.expectEqual(@as(?anyerror, error.AlpnMismatch), failures.server);
     try std.testing.expectError(error.AlpnMismatch, h.server.stream().drive());
+}
+
+test "record stream requires explicit opt-in for an unverified client certificate policy" {
+    const strict = try SocketHarness.create(.{ .client_trust = .insecure_no_verification });
+    defer strict.destroy();
+
+    const strict_failures = driveUntilBothErrors(strict);
+    try std.testing.expectEqual(@as(?anyerror, error.CertificateInvalid), strict_failures.client);
+    try std.testing.expectEqual(@as(?anyerror, error.PeerFatalAlert), strict_failures.server);
+    try std.testing.expect(!strict.client.bridge.handshake_complete);
+
+    const opted_in = try SocketHarness.create(.{ .client_trust = .insecure_no_verification });
+    defer opted_in.destroy();
+    opted_in.client.allow_unverified_certificate = true;
+
+    try opted_in.driveUntil(SocketHarness.bothComplete);
+    try std.testing.expect(opted_in.client.bridge.handshake_complete);
+    try std.testing.expect(opted_in.server.bridge.handshake_complete);
+    try std.testing.expectEqual(events.CertificateState.not_checked, opted_in.client.certificateState());
 }

--- a/src/quic/record_mode_handshake_test.zig
+++ b/src/quic/record_mode_handshake_test.zig
@@ -464,3 +464,410 @@ test "a tampered application record fails closed and cleanup still wipes secrets
     try expectDriverSinkWiped(&h.client_driver, client_driver_used);
     try expectDriverSinkWiped(&h.server_driver, server_driver_used);
 }
+
+// ===========================================================================
+// #410: PureZigRecordStream drives a real TLS 1.3 handshake over a nonblocking
+// socket-pair carrier.
+//
+// The pieces above proved the record stack in-memory by hand-pumping the
+// driver. Here the *stream* owns the driver end to end: `drive()` starts the
+// handshake, does nonblocking carrier I/O, parses/protects records, applies
+// every emitted event, installs and discards keys, completes, and shuts down --
+// with no test-only `establish()`, fabricated secrets, or hand-applied events.
+//
+// The real engine (`tls_backend.Tls13Backend`) is QUIC-shaped, so a thin
+// `RecordModeBackend` wrapper translates its QUIC-typed event batch into the
+// record-mode contract `PureZigRecordStream` owns. This wrapper is the
+// "smallest wrapper needed to instantiate the shared TLS backend in record
+// mode" the issue calls for; production HTTP dispatch over it is #356.
+// ===========================================================================
+
+const builtin = @import("builtin");
+const es = tls_core.encrypted_stream;
+
+const suite: tls_core.algorithms.CipherSuite = .tls_aes_128_gcm_sha256;
+
+/// Adapts the pure-Zig TLS 1.3 engine to the record-mode handshake backend the
+/// stream owns: it runs the engine into a private QUIC-typed sink, then
+/// translates each event into the record contract's epoch vocabulary, dropping
+/// the QUIC-only transport parameters. The engine must have
+/// `omit_transport_parameters = true`.
+const RecordModeBackend = struct {
+    engine: *tls_backend.Tls13Backend,
+    scratch: tls_handshake.EventSink = .{},
+
+    fn init(engine_ptr: *tls_backend.Tls13Backend) RecordModeBackend {
+        return .{ .engine = engine_ptr };
+    }
+
+    fn backend(self: *RecordModeBackend) es.RecordHandshakeBackend {
+        return .{ .ptr = self, .startFn = start, .receiveFn = receive, .deinitFn = deinit };
+    }
+
+    fn start(ptr: *anyopaque, role: tls_core.state.Role, _: void, sink: *es.RecordTransport.EventSink) es.RecordHandshakeError!void {
+        const self: *RecordModeBackend = @ptrCast(@alignCast(ptr));
+        self.scratch.reset();
+        const result = self.engine.backend().transport.start(role, dummy_params, &self.scratch);
+        try translate(&self.scratch, sink);
+        result catch |err| return mapError(err);
+    }
+
+    fn receive(ptr: *anyopaque, epoch: events.EncryptionEpoch, bytes: []const u8, sink: *es.RecordTransport.EventSink) es.RecordHandshakeError!void {
+        const self: *RecordModeBackend = @ptrCast(@alignCast(ptr));
+        self.scratch.reset();
+        const result = self.engine.backend().transport.receive(toLevel(epoch), bytes, &self.scratch);
+        try translate(&self.scratch, sink);
+        result catch |err| return mapError(err);
+    }
+
+    /// Securely wipe the last batch's copied secrets from the private sink. The
+    /// engine itself is owned (and deinitialized) by the harness, not here.
+    fn deinit(ptr: *anyopaque) void {
+        const self: *RecordModeBackend = @ptrCast(@alignCast(ptr));
+        self.scratch.deinit();
+    }
+
+    fn translate(qsink: *const tls_handshake.EventSink, rsink: *es.RecordTransport.EventSink) es.RecordHandshakeError!void {
+        for (qsink.items[0..qsink.len]) |event| {
+            switch (event) {
+                .handshake_bytes => |c| try rsink.emitHandshakeBytes(toEpoch(c.epoch), c.data),
+                .traffic_secret => |s| try rsink.emitSecret(toEpoch(s.epoch), s.direction, s.data),
+                .peer_transport_parameters => {}, // QUIC-only; record mode ignores it
+                .alpn => |protocol| try rsink.emitAlpn(protocol),
+                .certificate => |cert_state| try rsink.emitCertificate(cert_state),
+                .discard_epoch => |level| try rsink.emitDiscardEpoch(toEpoch(level)),
+                .handshake_complete => try rsink.emitHandshakeComplete(),
+                .fatal_alert => |alert| try rsink.emitFatalAlert(alert),
+            }
+        }
+    }
+
+    /// Every engine error except the three QUIC-transport-only ones (which
+    /// `omit_transport_parameters` + correct epoch mapping prevent here) is
+    /// already a member of the record error set.
+    fn mapError(err: tls_handshake.HandshakeError) es.RecordHandshakeError {
+        switch (err) {
+            error.UnexpectedCryptoLevel,
+            error.MissingTransportParameters,
+            error.InvalidTransportParameters,
+            => return error.MalformedHandshake,
+            else => {},
+        }
+        return @errorCast(err);
+    }
+
+    fn toEpoch(level: tls_adapter.EncryptionLevel) events.EncryptionEpoch {
+        return switch (level) {
+            .initial => .initial,
+            .zero_rtt => .zero_rtt,
+            .handshake => .handshake,
+            .application => .application,
+        };
+    }
+
+    fn toLevel(epoch: events.EncryptionEpoch) tls_adapter.EncryptionLevel {
+        return switch (epoch) {
+            .initial => .initial,
+            .zero_rtt => .zero_rtt,
+            .handshake => .handshake,
+            .application => .application,
+        };
+    }
+};
+
+// ── Nonblocking socket-pair carrier ─────────────────────────────────────────
+
+fn testSocketPair() ![2]std.posix.fd_t {
+    var fds: [2]std.posix.fd_t = undefined;
+    if (builtin.os.tag == .linux) {
+        const linux = std.os.linux;
+        const rc = linux.socketpair(linux.AF.UNIX, linux.SOCK.STREAM, 0, &fds);
+        if (linux.errno(rc) != .SUCCESS) return error.SocketPairFailed;
+    } else {
+        if (std.c.socketpair(std.posix.AF.UNIX, std.posix.SOCK.STREAM, 0, &fds) != 0) return error.SocketPairFailed;
+    }
+    errdefer closeFd(fds[0]);
+    errdefer closeFd(fds[1]);
+    try setNonBlocking(fds[0]);
+    try setNonBlocking(fds[1]);
+    return fds;
+}
+
+fn closeFd(fd: std.posix.fd_t) void {
+    if (builtin.os.tag == .linux) {
+        _ = std.os.linux.close(fd);
+    } else {
+        _ = std.c.close(fd);
+    }
+}
+
+fn setNonBlocking(fd: std.posix.fd_t) !void {
+    if (builtin.os.tag == .linux) {
+        const linux = std.os.linux;
+        const status_flags = linux.fcntl(fd, linux.F.GETFL, 0);
+        if (linux.errno(status_flags) != .SUCCESS) return error.FcntlFailed;
+        const nonblock: usize = @intCast(@as(u32, @bitCast(linux.O{ .NONBLOCK = true })));
+        const rc = linux.fcntl(fd, linux.F.SETFL, status_flags | nonblock);
+        if (linux.errno(rc) != .SUCCESS) return error.FcntlFailed;
+    } else {
+        const status_flags = std.c.fcntl(fd, std.c.F.GETFL, @as(c_int, 0));
+        if (status_flags < 0) return error.FcntlFailed;
+        const nonblock = @as(c_int, @bitCast(std.posix.O{ .NONBLOCK = true }));
+        if (std.c.fcntl(fd, std.c.F.SETFL, status_flags | nonblock) < 0) return error.FcntlFailed;
+    }
+}
+
+fn readFd(fd: std.posix.fd_t, out: []u8) es.Error!usize {
+    if (builtin.os.tag == .linux) {
+        const linux = std.os.linux;
+        const rc = linux.read(fd, out.ptr, out.len);
+        return switch (linux.errno(rc)) {
+            .SUCCESS => rc,
+            .AGAIN => error.WouldBlock,
+            else => error.SocketReadFailed,
+        };
+    }
+    const rc = std.c.read(fd, out.ptr, out.len);
+    if (rc < 0) {
+        if (std.posix.errno(rc) == .AGAIN) return error.WouldBlock;
+        return error.SocketReadFailed;
+    }
+    return @intCast(rc);
+}
+
+fn writeFd(fd: std.posix.fd_t, bytes: []const u8) es.Error!usize {
+    if (builtin.os.tag == .linux) {
+        const linux = std.os.linux;
+        const rc = linux.write(fd, bytes.ptr, bytes.len);
+        return switch (linux.errno(rc)) {
+            .SUCCESS => rc,
+            .AGAIN => error.WouldBlock,
+            else => error.SocketWriteFailed,
+        };
+    }
+    const rc = std.c.write(fd, bytes.ptr, bytes.len);
+    if (rc < 0) {
+        if (std.posix.errno(rc) == .AGAIN) return error.WouldBlock;
+        return error.SocketWriteFailed;
+    }
+    return @intCast(rc);
+}
+
+/// A nonblocking fd carrier with an optional per-call chunk cap (to force
+/// fragmented reads and partial writes) and an optional one-shot byte flip on
+/// the read path (to corrupt a message in flight).
+const FdCarrier = struct {
+    fd: std.posix.fd_t,
+    max_chunk: usize = std.math.maxInt(usize),
+    read_offset: usize = 0,
+    corrupt_at: ?usize = null,
+
+    fn carrier(self: *FdCarrier) es.Carrier {
+        return .{ .ptr = self, .readFn = read, .writeFn = write };
+    }
+
+    fn read(ptr: *anyopaque, out: []u8) es.Error!usize {
+        const self: *FdCarrier = @ptrCast(@alignCast(ptr));
+        const cap = @min(out.len, self.max_chunk);
+        if (cap == 0) return error.WouldBlock;
+        const n = try readFd(self.fd, out[0..cap]);
+        if (self.corrupt_at) |target| {
+            if (target >= self.read_offset and target < self.read_offset + n) {
+                out[target - self.read_offset] ^= 0xff;
+                self.corrupt_at = null;
+            }
+        }
+        self.read_offset += n;
+        return n;
+    }
+
+    fn write(ptr: *anyopaque, bytes: []const u8) es.Error!usize {
+        const self: *FdCarrier = @ptrCast(@alignCast(ptr));
+        const cap = @min(bytes.len, self.max_chunk);
+        if (cap == 0) return error.WouldBlock;
+        return writeFd(self.fd, bytes[0..cap]);
+    }
+};
+
+/// Owns the two engines, wrappers, carriers, and streams for one socket-pair
+/// handshake. Heap-allocated so the self-referential carrier/backend vtables
+/// keep stable pointers.
+const SocketHarness = struct {
+    fds: [2]std.posix.fd_t,
+    client_engine: tls_backend.Tls13Backend,
+    server_engine: tls_backend.Tls13Backend,
+    client_wrapper: RecordModeBackend = undefined,
+    server_wrapper: RecordModeBackend = undefined,
+    client_carrier: FdCarrier,
+    server_carrier: FdCarrier,
+    client: es.PureZigRecordStream = undefined,
+    server: es.PureZigRecordStream = undefined,
+
+    fn create(client_chunk: usize, server_chunk: usize) !*SocketHarness {
+        const self = try std.testing.allocator.create(SocketHarness);
+        errdefer std.testing.allocator.destroy(self);
+        self.fds = try testSocketPair();
+
+        self.client_engine = tls_backend.Tls13Backend.initClient(clientEntropy(), .{ .pinned_certificate = tls_backend.testdata.certificate_der });
+        self.client_engine.omit_transport_parameters = true;
+        self.server_engine = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity());
+        self.server_engine.omit_transport_parameters = true;
+
+        self.client_wrapper = RecordModeBackend.init(&self.client_engine);
+        self.server_wrapper = RecordModeBackend.init(&self.server_engine);
+        self.client_carrier = .{ .fd = self.fds[0], .max_chunk = client_chunk };
+        self.server_carrier = .{ .fd = self.fds[1], .max_chunk = server_chunk };
+
+        self.client = es.PureZigRecordStream.initWithCarrierAndBackend(.client, clientProvider(), suite, self.client_carrier.carrier(), self.client_wrapper.backend());
+        self.server = es.PureZigRecordStream.initWithCarrierAndBackend(.server, serverProvider(), suite, self.server_carrier.carrier(), self.server_wrapper.backend());
+        return self;
+    }
+
+    fn destroy(self: *SocketHarness) void {
+        self.client.deinit();
+        self.server.deinit();
+        self.client_engine.deinit();
+        self.server_engine.deinit();
+        closeFd(self.fds[0]);
+        closeFd(self.fds[1]);
+        std.testing.allocator.destroy(self);
+    }
+
+    /// Drive both streams until `done` holds, either fails, or progress stalls.
+    fn driveUntil(self: *SocketHarness, done: *const fn (*SocketHarness) bool) !void {
+        var rounds: usize = 0;
+        while (rounds < 5000) : (rounds += 1) {
+            const c = self.client.stream().drive() catch |err| return err;
+            const s = self.server.stream().drive() catch |err| return err;
+            if (done(self)) return;
+            if (!c.made_progress and !s.made_progress) return error.Stalled;
+        }
+        return error.Stalled;
+    }
+
+    fn bothComplete(self: *SocketHarness) bool {
+        return self.client.bridge.handshake_complete and self.server.bridge.handshake_complete;
+    }
+};
+
+test "record stream completes a real TLS 1.3 handshake over a nonblocking socket pair" {
+    // Fragmentation matrix: every practical carrier chunk size, from a
+    // one-byte trickle (each socket read/write splits records at arbitrary
+    // boundaries, including inside the initial record header) up to whole
+    // records at once, plus asymmetric client/server chunking.
+    const chunks = [_][2]usize{
+        .{ 1, 1 },
+        .{ 2, 3 },
+        .{ 3, 2 },
+        .{ 5, 5 },
+        .{ 7, 64 },
+        .{ 64, 7 },
+        .{ record_codec.max_ciphertext_record_len, record_codec.max_ciphertext_record_len },
+    };
+    for (chunks) |chunk| {
+        const h = try SocketHarness.create(chunk[0], chunk[1]);
+        defer h.destroy();
+
+        try h.driveUntil(SocketHarness.bothComplete);
+        try std.testing.expect(h.client.bridge.handshake_complete);
+        try std.testing.expect(h.server.bridge.handshake_complete);
+
+        // Both sides installed genuine derived 1-RTT secrets (client- and
+        // server-derived, from separate ECDH shares) -- proven by the peer
+        // being able to open what this side sealed, below.
+        try std.testing.expect(h.client.bridge.hasWriteKeys(.application));
+        try std.testing.expect(h.server.bridge.hasReadKeys(.application));
+        // Handshake keys were discarded on both sides by completion.
+        try std.testing.expect(!h.client.bridge.hasWriteKeys(.handshake));
+        try std.testing.expect(!h.server.bridge.hasReadKeys(.handshake));
+        // ALPN and certificate negotiation were captured through the same
+        // event contract records use.
+        try std.testing.expectEqualStrings("h3", h.client.negotiatedAlpn().?);
+        try std.testing.expectEqual(events.CertificateState.valid, h.client.certificateState());
+
+        // Application plaintext flows both ways after the real handshake.
+        try std.testing.expectEqual(@as(usize, 16), try h.client.stream().write("client to server"));
+        try h.driveUntil(struct {
+            fn done(hh: *SocketHarness) bool {
+                return hh.server.readiness().can_read_plaintext;
+            }
+        }.done);
+        var buf: [64]u8 = undefined;
+        try std.testing.expectEqualStrings("client to server", buf[0..try h.server.stream().read(&buf)]);
+
+        try std.testing.expectEqual(@as(usize, 16), try h.server.stream().write("server to client"));
+        try h.driveUntil(struct {
+            fn done(hh: *SocketHarness) bool {
+                return hh.client.readiness().can_read_plaintext;
+            }
+        }.done);
+        try std.testing.expectEqualStrings("server to client", buf[0..try h.client.stream().read(&buf)]);
+
+        // Orderly close_notify shutdown.
+        h.client.stream().close();
+        try h.driveUntil(struct {
+            fn done(hh: *SocketHarness) bool {
+                return hh.client.lifecycle == .closed and hh.server.readiness().peer_closed;
+            }
+        }.done);
+        try std.testing.expectError(error.EndOfStream, h.server.stream().read(&buf));
+    }
+}
+
+test "record stream handshake fails closed when a ClientHello is corrupted in flight" {
+    const h = try SocketHarness.create(std.math.maxInt(usize), std.math.maxInt(usize));
+    defer h.destroy();
+    // Flip a byte inside the ClientHello's 32-byte random (past the 5-byte
+    // record header, 4-byte handshake header, and 2-byte legacy_version) as the
+    // server reads it. The X25519 key_share is untouched, so both sides derive
+    // the same ECDH secret but a *different* transcript hash -- exactly the
+    // "bad Finished / authentication failure" case: the server seals its flight
+    // under keys the client (correct-transcript) cannot open.
+    h.server_carrier.corrupt_at = record_codec.header_len + 4 + 2 + 4;
+
+    var client_error: ?anyerror = null;
+    var server_error: ?anyerror = null;
+    var rounds: usize = 0;
+    while (rounds < 500) : (rounds += 1) {
+        _ = h.client.stream().drive() catch |err| {
+            client_error = err;
+            break;
+        };
+        _ = h.server.stream().drive() catch |err| {
+            server_error = err;
+            break;
+        };
+        if (h.client.lifecycle == .failed or h.server.lifecycle == .failed) break;
+    }
+    // Neither side completes, and the tamper surfaces as a stable AEAD
+    // authentication failure on whichever side first opens a record sealed
+    // under the diverged transcript (the client, opening the server flight).
+    try std.testing.expect(!h.client.bridge.handshake_complete);
+    try std.testing.expect(!h.server.bridge.handshake_complete);
+    try std.testing.expect(h.client.lifecycle == .failed or h.server.lifecycle == .failed);
+    const failure: ?anyerror = if (client_error) |e| e else server_error;
+    try std.testing.expect(failure != null);
+    try std.testing.expect(failure.? == error.AuthenticationFailed);
+}
+
+test "record stream handshake treats carrier EOF before close_notify as truncation" {
+    const h = try SocketHarness.create(std.math.maxInt(usize), std.math.maxInt(usize));
+    defer h.destroy();
+
+    // Complete the handshake, then the server abruptly closes its socket
+    // instead of sending close_notify.
+    try h.driveUntil(SocketHarness.bothComplete);
+    closeFd(h.fds[1]);
+    h.server.stream().close();
+
+    var client_error: ?anyerror = null;
+    var rounds: usize = 0;
+    while (rounds < 500) : (rounds += 1) {
+        _ = h.client.stream().drive() catch |err| {
+            client_error = err;
+            break;
+        };
+    }
+    try std.testing.expectEqual(@as(?anyerror, error.TruncatedStream), client_error);
+    try std.testing.expect(h.client.lifecycle == .failed);
+}

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -221,12 +221,21 @@ pub const PureZigRecordStream = struct {
     const handshake_output_reserve = 3 * record_codec.max_ciphertext_record_len;
     /// RFC 7301 caps a single ALPN protocol name at 255 bytes.
     const max_alpn_len = 255;
+    /// Bounded deadline for flushing a terminal fatal alert to a carrier that
+    /// never drains (peer gone, permanently full): after this many `drive()`
+    /// attempts the stream latches the preserved failure regardless, so a stuck
+    /// carrier cannot wedge the failure forever.
+    const max_terminal_flush_attempts = 16;
 
     bridge: record_epoch_bridge.Bridge,
     /// The shared TLS handshake driver, present only when a concrete backend was
     /// injected (`initWithBackend`/`initWithCarrierAndBackend`). Absent for the
     /// lower-level record-plumbing paths that drive events in by hand.
     handshake_driver: ?RecordHandshakeDriver = null,
+    /// Guards the driver against a second teardown (its backend `deinit` is not
+    /// idempotent). Set once `teardownDriver` runs; the driver value is left in
+    /// place afterward so its securely-wiped sink stays observable.
+    driver_torn_down: bool = false,
     handshake_started: bool = false,
     /// Explicit protocol epochs for inbound and outbound records. Tracked as a
     /// deliberate state machine rather than inferred from which keys happen to
@@ -253,6 +262,8 @@ pub const PureZigRecordStream = struct {
     /// to the carrier before the stream latches closed (`drive()` step 13). The
     /// underlying failure is preserved regardless of whether the alert lands.
     pending_terminal: ?Error = null,
+    /// Bounded flush attempts spent draining a pending terminal alert.
+    terminal_flush_attempts: usize = 0,
     carrier: ?Carrier = null,
     lifecycle: Lifecycle = .handshaking,
     peer_closed: bool = false,
@@ -340,17 +351,20 @@ pub const PureZigRecordStream = struct {
         self.close_notify_queued = false;
         self.pending_terminal_read_error = null;
         self.pending_terminal = null;
+        self.terminal_flush_attempts = 0;
         self.failed = null;
     }
 
     /// Tear the shared handshake driver down exactly once. `Driver.deinit`
     /// securely wipes any traffic secret still copied into its borrowed event
-    /// sink and releases the backend, per the contract's teardown rule.
+    /// sink and releases the backend, per the contract's teardown rule. The
+    /// driver value is deliberately left in place (rather than nulled) so its
+    /// wiped sink remains observable; `driver_torn_down` prevents a second,
+    /// non-idempotent backend `deinit`.
     fn teardownDriver(self: *PureZigRecordStream) void {
-        if (self.handshake_driver) |*driver| {
-            driver.deinit();
-            self.handshake_driver = null;
-        }
+        if (self.driver_torn_down) return;
+        if (self.handshake_driver) |*driver| driver.deinit();
+        self.driver_torn_down = true;
     }
 
     /// Wipe captured ALPN/certificate negotiation metadata back to its initial
@@ -424,7 +438,7 @@ pub const PureZigRecordStream = struct {
     // driver call. Callers no longer hand-install secrets or declare completion.
 
     fn driverPresent(self: *PureZigRecordStream) bool {
-        return self.handshake_driver != null;
+        return self.handshake_driver != null and !self.driver_torn_down;
     }
 
     /// Start the handshake driver exactly once. Refuses to progress until the
@@ -468,8 +482,22 @@ pub const PureZigRecordStream = struct {
                     self.bridge.installTrafficSecret(ts.epoch, ts.direction, ts.data) catch |err| return self.fail(err);
                     self.advanceEpochOnSecret(ts.epoch, ts.direction);
                 },
-                .alpn => |protocol| self.captureAlpn(protocol),
-                .certificate => |cert_state| self.certificate_state = cert_state,
+                .alpn => |protocol| try self.captureAlpn(protocol),
+                .certificate => |cert_state| {
+                    self.certificate_state = cert_state;
+                    // The concrete backend emits the certificate result and
+                    // defers the policy decision to its driver (its own core is
+                    // already marked failed on an invalid result and it stops
+                    // producing output). Record mode must convert an invalid
+                    // certificate into a terminal failure here, or the stream
+                    // would stall in `.handshaking` forever. Stop applying later
+                    // success events in the same batch so a bogus
+                    // `handshake_complete` after it can never open the stream.
+                    if (cert_state == .invalid) {
+                        self.deferHandshakeFailure(error.CertificateInvalid, fatal_alert);
+                        break;
+                    }
+                },
                 .discard_epoch => |epoch| {
                     self.bridge.discardEpoch(epoch) catch |err| return self.fail(err);
                     try self.applyDiscardSideEffects(epoch);
@@ -486,7 +514,12 @@ pub const PureZigRecordStream = struct {
                 .fatal_alert => |desc| fatal_alert = desc,
             }
         }
-        if (outcome.terminal_error) |err| self.deferHandshakeFailure(err, fatal_alert);
+        // A terminal backend error (e.g. the wrapper surfacing a deferred
+        // ALPN-mismatch) becomes the pending failure, unless a policy event
+        // above already latched a more specific one.
+        if (self.pending_terminal == null) {
+            if (outcome.terminal_error) |err| self.deferHandshakeFailure(err, fatal_alert);
+        }
     }
 
     /// Handshake secrets advance the explicit record epoch one step. Application
@@ -502,19 +535,25 @@ pub const PureZigRecordStream = struct {
         }
     }
 
-    fn captureAlpn(self: *PureZigRecordStream, protocol: []const u8) void {
-        const n = @min(protocol.len, max_alpn_len);
-        @memcpy(self.alpn_storage[0..n], protocol[0..n]);
-        self.alpn_len = n;
+    /// Capture the negotiated ALPN. RFC 7301 caps a protocol name at 255 bytes;
+    /// a longer value can only be a backend bug or malformed peer data, so fail
+    /// closed rather than silently truncating (which would change the protocol).
+    fn captureAlpn(self: *PureZigRecordStream, protocol: []const u8) Error!void {
+        if (protocol.len > max_alpn_len) return self.fail(error.MalformedHandshake);
+        @memcpy(self.alpn_storage[0..protocol.len], protocol);
+        self.alpn_len = protocol.len;
         self.alpn_captured = true;
     }
 
     /// Record a terminal handshake failure without immediately latching, first
     /// queuing any emitted fatal alert into the normal bounded outbound queue.
-    /// `drive()` flushes the queue, then hard-fails with the preserved error.
+    /// `drive()` then flushes that output within a bounded write budget and
+    /// latches the preserved error only once it drains (or the flush deadline
+    /// fires) -- never by a hidden synchronous retry-and-discard.
     fn deferHandshakeFailure(self: *PureZigRecordStream, err: Error, maybe_alert: ?alerts.AlertDescription) void {
         if (maybe_alert) |desc| self.queueFatalAlert(desc);
         self.pending_terminal = err;
+        self.terminal_flush_attempts = 0;
     }
 
     /// Best-effort: seal a fatal alert at the current write epoch into the
@@ -580,6 +619,7 @@ pub const PureZigRecordStream = struct {
 
     pub fn readPlaintext(self: *PureZigRecordStream, out: []u8) Error!usize {
         if (self.failed) |err| return err;
+        if (self.pending_terminal) |err| return err;
         if (self.lifecycle == .closed or self.lifecycle == .failed) return error.StreamClosed;
         if (self.inbound_plaintext.read(out)) |n| return n;
         try self.raisePendingTerminalError();
@@ -589,6 +629,7 @@ pub const PureZigRecordStream = struct {
 
     pub fn writePlaintext(self: *PureZigRecordStream, bytes: []const u8) Error!usize {
         if (self.failed) |err| return err;
+        if (self.pending_terminal) |err| return err;
         if (self.lifecycle == .closing or self.lifecycle == .closed or self.lifecycle == .failed) return error.StreamClosed;
         if (self.pending_terminal_read_error) |err| return err;
         if (bytes.len == 0) return 0;
@@ -626,6 +667,12 @@ pub const PureZigRecordStream = struct {
         if (self.failed != null or self.lifecycle == .failed or self.lifecycle == .closed) {
             return .{ .peer_closed = self.peer_closed };
         }
+        // A pending terminal failure is draining its queued fatal alert: the
+        // only useful action is a write, so advertise write readiness while
+        // output remains and nothing else. No new reads, no plaintext I/O.
+        if (self.pending_terminal != null) {
+            return .{ .wants_write = self.outbound_ciphertext.len != 0, .peer_closed = self.peer_closed };
+        }
         const pending_terminal_read_ready = self.pending_terminal_read_error != null and !self.hasBufferedInboundContent();
         return .{
             .wants_read = !self.carrier_eof and self.canAcceptCarrierRead(),
@@ -641,6 +688,23 @@ pub const PureZigRecordStream = struct {
         var made_progress = false;
         if (self.lifecycle == .closed or self.lifecycle == .failed) {
             return .{ .made_progress = false, .readiness = self.readiness() };
+        }
+
+        // A pending terminal handshake failure takes priority over all other
+        // work. Flush its queued output (the fatal alert, behind any earlier
+        // handshake bytes it sits after) within the bounded write budget while
+        // preserving the root error, and latch only once the queue drains or
+        // the bounded flush deadline fires. This is the sole socket write on
+        // this path -- readiness advertises `wants_write` so the event loop
+        // drives us back when the carrier is writable, rather than a hidden
+        // synchronous retry that would discard the alert on `WouldBlock`.
+        if (self.pending_terminal) |root| {
+            if (self.flushPendingAlert() > 0) made_progress = true;
+            self.terminal_flush_attempts += 1;
+            if (self.outbound_ciphertext.len == 0 or self.terminal_flush_attempts >= max_terminal_flush_attempts) {
+                return self.fail(root);
+            }
+            return .{ .made_progress = made_progress, .readiness = self.readiness() };
         }
 
         if (self.lifecycle == .closing and !self.bridge.handshake_complete) {
@@ -730,14 +794,6 @@ pub const PureZigRecordStream = struct {
             }
         } else {
             if (try self.processCarrierInput(drive_record_budget)) made_progress = true;
-        }
-
-        // A terminal handshake failure surfaced while routing records: flush the
-        // fatal alert the backend emitted (best effort, nonblocking) so the peer
-        // learns why, then latch the preserved failure and close.
-        if (self.pending_terminal) |err| {
-            _ = self.flushPendingAlert();
-            return self.fail(err);
         }
 
         if (self.lifecycle == .closing and self.carrier != null and self.close_notify_queued and self.outbound_ciphertext.len == 0) {
@@ -942,6 +998,7 @@ pub const PureZigRecordStream = struct {
         self.ciphertext_parser.reset();
         self.pending_terminal_read_error = null;
         self.pending_terminal = null;
+        self.terminal_flush_attempts = 0;
         self.teardownDriver();
         self.bridge.deinit();
         self.closeCarrier();
@@ -2417,6 +2474,9 @@ const Duplex = struct {
     c2s: Buf = .{},
     s2c: Buf = .{},
     max_chunk: usize,
+    /// When true the server's carrier write returns `WouldBlock`, modelling a
+    /// backpressured send side so a pending fatal alert cannot drain yet.
+    block_s2c: bool = false,
 
     const max_ciphertext_queue = PureZigRecordStream.max_ciphertext_queue;
 
@@ -2440,6 +2500,7 @@ const Duplex = struct {
 
     fn serverWrite(ptr: *anyopaque, bytes: []const u8) Error!usize {
         const self: *Duplex = @ptrCast(@alignCast(ptr));
+        if (self.block_s2c) return error.WouldBlock;
         return self.push(&self.s2c, bytes);
     }
 
@@ -2569,4 +2630,194 @@ test "driver-owned handshake latches a terminal failure and flushes its fatal al
     }
     try testing.expectEqual(@as(?anyerror, error.PeerFatalAlert), client_error);
     try testing.expectEqual(Lifecycle.failed, client.lifecycle);
+}
+
+/// A scripted backend whose start installs handshake key material and queues a
+/// flight, so a cancellation happening after `drive()` has sensitive state to
+/// release. Counts its own teardown so tests can prove it runs exactly once.
+const CountingRecordBackend = struct {
+    deinit_count: usize = 0,
+    started: bool = false,
+    /// When true, `start` installs handshake traffic secrets before queuing the
+    /// flight (cancellation after keys exist); when false it only queues an
+    /// initial-epoch flight (cancellation before any keys, first flight
+    /// undrained).
+    install_keys: bool = true,
+
+    fn recordBackend(self: *CountingRecordBackend) RecordHandshakeBackend {
+        return .{ .ptr = self, .startFn = start, .receiveFn = receive, .deinitFn = deinit };
+    }
+
+    fn start(ptr: *anyopaque, role: tls_state.Role, _: void, sink: *RecordTransport.EventSink) RecordHandshakeError!void {
+        const self: *CountingRecordBackend = @ptrCast(@alignCast(ptr));
+        std.debug.assert(role == .client);
+        self.started = true;
+        if (self.install_keys) {
+            try sink.emitSecret(.handshake, .write, &secret(0x11));
+            try sink.emitSecret(.handshake, .read, &secret(0x22));
+            try sink.emitHandshakeBytes(.handshake, "flight");
+        } else {
+            try sink.emitHandshakeBytes(.initial, "client hello");
+        }
+    }
+
+    fn receive(_: *anyopaque, _: events.EncryptionEpoch, _: []const u8, _: *RecordTransport.EventSink) RecordHandshakeError!void {}
+
+    fn deinit(ptr: *anyopaque) void {
+        const self: *CountingRecordBackend = @ptrCast(@alignCast(ptr));
+        self.deinit_count += 1;
+    }
+};
+
+/// An owned carrier that blocks writes (so the queued flight never drains) and
+/// counts how many times the stream closes it.
+const CountingOwnedCarrier = struct {
+    close_count: usize = 0,
+
+    fn carrier(self: *CountingOwnedCarrier) Carrier {
+        return .{ .ptr = self, .readFn = read, .writeFn = write, .closeFn = close, .owns_handle = true };
+    }
+
+    fn read(_: *anyopaque, _: []u8) Error!usize {
+        return error.WouldBlock;
+    }
+
+    fn write(_: *anyopaque, _: []const u8) Error!usize {
+        return error.WouldBlock;
+    }
+
+    fn close(ptr: *anyopaque) void {
+        const self: *CountingOwnedCarrier = @ptrCast(@alignCast(ptr));
+        self.close_count += 1;
+    }
+};
+
+test "driver-owned cancellation releases owned carrier, driver, and secrets exactly once" {
+    const cp = testProvider();
+    inline for (.{ true, false }) |install_keys| {
+        var backend = CountingRecordBackend{ .install_keys = install_keys };
+        var carrier = CountingOwnedCarrier{};
+        var stream = PureZigRecordStream.initWithCarrierAndBackend(.client, cp, .tls_aes_128_gcm_sha256, carrier.carrier(), backend.recordBackend());
+
+        // Start the driver: it installs sensitive state (keys and/or a queued
+        // flight) that a blocked carrier keeps undrained.
+        _ = try stream.stream().drive();
+        try testing.expect(backend.started);
+        try testing.expect(stream.queuedCiphertextLen() > 0);
+        if (install_keys) try testing.expect(stream.bridge.hasWriteKeys(.handshake));
+        const used_before = stream.handshake_driver.?.sink.used;
+        try testing.expect(used_before > 0);
+
+        // Cancel mid-handshake: the queued flight is dropped and the owned
+        // carrier is closed exactly once.
+        stream.stream().close();
+        _ = try stream.stream().drive();
+        try testing.expectEqual(Lifecycle.closed, stream.lifecycle);
+        try testing.expectEqual(@as(usize, 0), stream.queuedCiphertextLen());
+        try testing.expectEqual(@as(usize, 1), carrier.close_count);
+
+        // Teardown runs the driver's deinit (and its backend's) exactly once,
+        // wipes bridge key material, and does not re-close the carrier.
+        stream.deinit();
+        try testing.expectEqual(@as(usize, 1), carrier.close_count);
+        try testing.expectEqual(@as(usize, 1), backend.deinit_count);
+        try testing.expect(!stream.bridge.hasReadKeys(.handshake));
+        try testing.expect(!stream.bridge.hasWriteKeys(.handshake));
+
+        // The driver's borrowed event sink -- which had copied traffic-secret
+        // bytes into its scratch -- was securely zeroed by teardown.
+        try testing.expectEqual(@as(usize, 0), stream.handshake_driver.?.sink.used);
+        for (stream.handshake_driver.?.sink.scratch[0..used_before]) |b| {
+            try testing.expectEqual(@as(u8, 0), b);
+        }
+
+        // A second deinit is a no-op: the driver is not torn down twice.
+        stream.deinit();
+        try testing.expectEqual(@as(usize, 1), backend.deinit_count);
+        try testing.expectEqual(@as(usize, 1), carrier.close_count);
+    }
+}
+
+test "driver-owned handshake preserves a pending fatal alert across write backpressure" {
+    const cp = testProvider();
+    var duplex = Duplex{ .max_chunk = record_codec.max_ciphertext_record_len, .block_s2c = true };
+    var client_backend = ScriptedRecordBackend{ .role = .client, .bad_hello = true };
+    var server_backend = ScriptedRecordBackend{ .role = .server };
+    var client = PureZigRecordStream.initWithCarrierAndBackend(.client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
+    defer client.deinit();
+    var server = PureZigRecordStream.initWithCarrierAndBackend(.server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
+    defer server.deinit();
+
+    // Client sends its rejected hello.
+    _ = try client.stream().drive();
+
+    // First server drive reads and rejects the hello, queuing a fatal alert.
+    _ = try server.stream().drive();
+    try testing.expect(server.pending_terminal != null);
+
+    // The carrier write side is blocked. Within the bounded flush deadline the
+    // failure stays pending: the alert is neither dropped nor latched, and
+    // readiness asks to be driven when the carrier becomes writable -- no hidden
+    // synchronous retry-and-discard.
+    for (0..3) |_| {
+        const result = try server.stream().drive();
+        try testing.expect(!result.made_progress); // blocked write makes no progress
+    }
+    try testing.expect(server.pending_terminal != null);
+    try testing.expect(server.queuedCiphertextLen() > 0);
+    const blocked = server.readiness();
+    try testing.expect(blocked.wants_write);
+    try testing.expect(!blocked.wants_read);
+    try testing.expect(!blocked.can_read_plaintext);
+
+    // Unblock the carrier: the alert flushes and the preserved handshake error
+    // latches (never replaced by a carrier error).
+    duplex.block_s2c = false;
+    var server_error: ?anyerror = null;
+    for (0..8) |_| {
+        _ = server.stream().drive() catch |err| {
+            server_error = err;
+            break;
+        };
+    }
+    try testing.expectEqual(@as(?anyerror, error.UnexpectedHandshakeMessage), server_error);
+    try testing.expectEqual(Lifecycle.failed, server.lifecycle);
+
+    // The alert actually reached the peer, which fails closed on it.
+    var client_error: ?anyerror = null;
+    for (0..8) |_| {
+        _ = client.stream().drive() catch |err| {
+            client_error = err;
+            break;
+        };
+    }
+    try testing.expectEqual(@as(?anyerror, error.PeerFatalAlert), client_error);
+}
+
+test "driver-owned handshake latches on the flush deadline when a fatal alert can never be sent" {
+    const cp = testProvider();
+    var duplex = Duplex{ .max_chunk = record_codec.max_ciphertext_record_len, .block_s2c = true };
+    var client_backend = ScriptedRecordBackend{ .role = .client, .bad_hello = true };
+    var server_backend = ScriptedRecordBackend{ .role = .server };
+    var client = PureZigRecordStream.initWithCarrierAndBackend(.client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
+    defer client.deinit();
+    var server = PureZigRecordStream.initWithCarrierAndBackend(.server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
+    defer server.deinit();
+
+    _ = try client.stream().drive();
+
+    // The carrier never accepts the alert. The stream must not wedge forever:
+    // after a bounded number of flush attempts it latches the preserved error
+    // regardless, and the alert-send failure never erases that error.
+    var server_error: ?anyerror = null;
+    var attempts: usize = 0;
+    while (attempts < PureZigRecordStream.max_terminal_flush_attempts + 4) : (attempts += 1) {
+        _ = server.stream().drive() catch |err| {
+            server_error = err;
+            break;
+        };
+    }
+    try testing.expectEqual(@as(?anyerror, error.UnexpectedHandshakeMessage), server_error);
+    try testing.expectEqual(Lifecycle.failed, server.lifecycle);
+    try expectLatchedFailureConformance(server.stream(), error.UnexpectedHandshakeMessage);
 }

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -11,14 +11,38 @@ const builtin = @import("builtin");
 const crypto = @import("crypto");
 const algorithms = @import("algorithms.zig");
 const alerts = @import("alerts.zig");
+const engine = @import("engine.zig");
 const events = @import("events.zig");
+const messages = @import("messages.zig");
 const record_codec = @import("record_codec.zig");
 const record_epoch_bridge = @import("record_epoch_bridge.zig");
 const tls_state = @import("state.zig");
+const transport = @import("transport.zig");
 
 const provider = crypto.provider;
 
-pub const Error = record_epoch_bridge.Error || error{
+/// Error set the record-mode handshake driver/backend contract carries. It is a
+/// superset of every error the shared engine `Driver`, the `EventSink`, and the
+/// `record_epoch_bridge` can surface, so a concrete TLS backend wired in from a
+/// higher layer (#410) can report handshake failures without a lossy remap.
+pub const RecordHandshakeError = record_epoch_bridge.Error || events.HandshakeError ||
+    messages.ReadError || messages.WriteError || error{TransportBufferOverflow};
+
+/// The canonical record-mode handshake transport contract (#408): protocol
+/// events keyed on `events.EncryptionEpoch`, no transport-parameter payload
+/// (that is a QUIC concern), reusing the shared `transport.Contract`/
+/// `engine.Driver` rather than a parallel driver of its own.
+pub const RecordTransport = transport.Contract(void, events.EncryptionEpoch, RecordHandshakeError);
+/// The injected backend seam: a concrete TLS 1.3 engine (wired from a module
+/// above `tls_core`, e.g. the pure-Zig engine wrapped for record mode) drives
+/// the handshake through this vtable and reports keying/negotiation results
+/// through the shared `EventSink`.
+pub const RecordHandshakeBackend = RecordTransport.Backend;
+/// The shared engine driver instantiated for record mode. `PureZigRecordStream`
+/// owns one of these and progresses it inside `drive()`.
+pub const RecordHandshakeDriver = engine.Driver(RecordTransport);
+
+pub const Error = RecordHandshakeError || error{
     WouldBlock,
     EndOfStream,
     StreamClosed,
@@ -188,14 +212,47 @@ pub const PureZigRecordStream = struct {
     const drive_write_budget = 2 * record_codec.max_ciphertext_record_len;
     const drive_record_budget = 8;
     const drive_read_chunk = 4096;
+    /// Worst-case serialized output a single borrowed driver event batch can
+    /// produce (the shared `EventSink` bounds a batch to a few handshake-bytes
+    /// events, each sealing into at most one record). `drive()` refuses to
+    /// progress the backend unless the outbound queue has at least this much
+    /// room, so an entire batch can be serialized atomically -- no partial
+    /// application that would then have to overwrite the still-borrowed sink.
+    const handshake_output_reserve = 3 * record_codec.max_ciphertext_record_len;
+    /// RFC 7301 caps a single ALPN protocol name at 255 bytes.
+    const max_alpn_len = 255;
 
     bridge: record_epoch_bridge.Bridge,
+    /// The shared TLS handshake driver, present only when a concrete backend was
+    /// injected (`initWithBackend`/`initWithCarrierAndBackend`). Absent for the
+    /// lower-level record-plumbing paths that drive events in by hand.
+    handshake_driver: ?RecordHandshakeDriver = null,
+    handshake_started: bool = false,
+    /// Explicit protocol epochs for inbound and outbound records. Tracked as a
+    /// deliberate state machine rather than inferred from which keys happen to
+    /// be installed: after the server installs its application read secret the
+    /// peer's next record (its Finished) is still handshake-epoch, so key
+    /// presence alone cannot pick the epoch. `read`/`write` advance to
+    /// `.handshake` when that direction's handshake secret installs and to
+    /// `.application` only at authenticated `handshake_complete`.
+    read_epoch: events.EncryptionEpoch = .initial,
+    write_epoch: events.EncryptionEpoch = .initial,
     initial_parser: record_codec.Parser = record_codec.Parser.init(.plaintext),
     ciphertext_parser: record_codec.Parser = record_codec.Parser.init(.ciphertext),
     inbound_carrier: ByteQueue(max_carrier_input_queue, error.CarrierInputBufferFull) = .{},
     inbound_plaintext: ByteQueue(max_plaintext_queue, error.PlaintextBufferFull) = .{},
     outbound_ciphertext: ByteQueue(max_ciphertext_queue, error.CiphertextBufferFull) = .{},
     inbound_handshake: ByteQueue(max_handshake_queue, error.PlaintextBufferFull) = .{},
+    /// Negotiated ALPN protocol captured from the handshake, retained behind
+    /// `negotiatedAlpn()` for later HTTP dispatch (out of scope here, #356).
+    alpn_storage: [max_alpn_len]u8 = undefined,
+    alpn_len: usize = 0,
+    alpn_captured: bool = false,
+    certificate_state: events.CertificateState = .not_checked,
+    /// A terminal handshake failure whose emitted fatal alert is being flushed
+    /// to the carrier before the stream latches closed (`drive()` step 13). The
+    /// underlying failure is preserved regardless of whether the alert lands.
+    pending_terminal: ?Error = null,
     carrier: ?Carrier = null,
     lifecycle: Lifecycle = .handshaking,
     peer_closed: bool = false,
@@ -226,12 +283,54 @@ pub const PureZigRecordStream = struct {
         return stream_state;
     }
 
+    /// Like `init`, but the stream owns a shared TLS handshake driver over the
+    /// injected `backend`. `drive()` then starts and progresses the real
+    /// handshake itself rather than relying on callers to hand-apply events.
+    pub fn initWithBackend(
+        role: tls_state.Role,
+        crypto_provider: provider.CryptoProvider,
+        cipher_suite: algorithms.CipherSuite,
+        backend: RecordHandshakeBackend,
+    ) PureZigRecordStream {
+        var stream_state = init(role, crypto_provider, cipher_suite);
+        stream_state.handshake_driver = RecordHandshakeDriver.init(role, backend);
+        return stream_state;
+    }
+
+    /// `initWithBackend` plus a nonblocking carrier, the production shape: a
+    /// real backend driving a real handshake over a real byte-stream carrier.
+    pub fn initWithCarrierAndBackend(
+        role: tls_state.Role,
+        crypto_provider: provider.CryptoProvider,
+        cipher_suite: algorithms.CipherSuite,
+        carrier: Carrier,
+        backend: RecordHandshakeBackend,
+    ) PureZigRecordStream {
+        std.debug.assert(!carrier.owns_handle or carrier.closeFn != null);
+        var stream_state = initWithBackend(role, crypto_provider, cipher_suite, backend);
+        stream_state.carrier = carrier;
+        return stream_state;
+    }
+
+    /// The ALPN protocol negotiated by the handshake, or null if none was seen.
+    pub fn negotiatedAlpn(self: *const PureZigRecordStream) ?[]const u8 {
+        if (!self.alpn_captured) return null;
+        return self.alpn_storage[0..self.alpn_len];
+    }
+
+    /// The peer certificate validation outcome the backend reported.
+    pub fn certificateState(self: *const PureZigRecordStream) events.CertificateState {
+        return self.certificate_state;
+    }
+
     pub fn deinit(self: *PureZigRecordStream) void {
+        self.teardownDriver();
         self.bridge.deinit();
         self.inbound_carrier.clear();
         self.inbound_plaintext.clear();
         self.outbound_ciphertext.clear();
         self.inbound_handshake.clear();
+        self.clearHandshakeMetadata();
         self.initial_parser.reset();
         self.ciphertext_parser.reset();
         self.closeCarrier();
@@ -240,7 +339,30 @@ pub const PureZigRecordStream = struct {
         self.carrier_eof = false;
         self.close_notify_queued = false;
         self.pending_terminal_read_error = null;
+        self.pending_terminal = null;
         self.failed = null;
+    }
+
+    /// Tear the shared handshake driver down exactly once. `Driver.deinit`
+    /// securely wipes any traffic secret still copied into its borrowed event
+    /// sink and releases the backend, per the contract's teardown rule.
+    fn teardownDriver(self: *PureZigRecordStream) void {
+        if (self.handshake_driver) |*driver| {
+            driver.deinit();
+            self.handshake_driver = null;
+        }
+    }
+
+    /// Wipe captured ALPN/certificate negotiation metadata back to its initial
+    /// state, so no residue survives teardown or a fatal failure.
+    fn clearHandshakeMetadata(self: *PureZigRecordStream) void {
+        if (self.alpn_len > 0) @memset(self.alpn_storage[0..self.alpn_len], 0);
+        self.alpn_len = 0;
+        self.alpn_captured = false;
+        self.certificate_state = .not_checked;
+        self.read_epoch = .initial;
+        self.write_epoch = .initial;
+        self.handshake_started = false;
     }
 
     pub fn stream(self: *PureZigRecordStream) EncryptedStream {
@@ -261,24 +383,153 @@ pub const PureZigRecordStream = struct {
         // with it. Never reset `ciphertext_parser` here: it is shared
         // across the handshake and application epochs, and bytes already
         // buffered there may belong to the next (application) record.
-        if (event == .discard_epoch and event.discard_epoch == .initial) {
-            self.initial_parser.reset();
-        }
+        if (event == .discard_epoch) try self.applyDiscardSideEffects(event.discard_epoch);
+        if (event == .handshake_complete) self.lifecycle = .open;
+    }
+
+    /// The record-layer side effects of an epoch discard, shared by the manual
+    /// `applyEvent` path and the driver-owned path (`applyDriverOutcome`).
+    fn applyDiscardSideEffects(self: *PureZigRecordStream, epoch: events.EncryptionEpoch) Error!void {
+        // The initial epoch's plaintext parser is only safe to keep once its
+        // keys are gone: nothing should ever arrive at that epoch again after
+        // discard, so drop any partially-buffered state along with it. Never
+        // reset `ciphertext_parser` here: it is shared across the handshake and
+        // application epochs, and bytes already buffered there may belong to
+        // the next (application) record.
+        if (epoch == .initial) self.initial_parser.reset();
         // `ciphertext_parser` is fed through `feedOne`'s exact-consumption
-        // contract, so it only ever holds a genuinely incomplete record --
-        // any legitimate next-record suffix stays in the caller/carrier
-        // buffer instead. A nonzero `len` here at the `.handshake` epoch
-        // boundary therefore means a record started under handshake keys
-        // and has not finished, and its remaining bytes are about to be
-        // fed and opened under application keys instead. That is exactly
-        // the stale partial-record state the epoch transition must clear
-        // or reject; there is no way to safely resume mid-record across a
-        // key change, so fail the stream closed rather than silently
-        // reinterpreting those bytes under the wrong epoch.
-        if (event == .discard_epoch and event.discard_epoch == .handshake and self.ciphertext_parser.len != 0) {
+        // contract, so it only ever holds a genuinely incomplete record -- any
+        // legitimate next-record suffix stays in the caller/carrier buffer
+        // instead. A nonzero `len` here at the `.handshake` epoch boundary
+        // therefore means a record started under handshake keys and has not
+        // finished, and its remaining bytes are about to be fed and opened
+        // under application keys instead. That is exactly the stale
+        // partial-record state the epoch transition must clear or reject; there
+        // is no way to safely resume mid-record across a key change, so fail
+        // the stream closed rather than silently reinterpreting those bytes
+        // under the wrong epoch.
+        if (epoch == .handshake and self.ciphertext_parser.len != 0) {
             return self.fail(error.PartialRecordAtEpochTransition);
         }
-        if (event == .handshake_complete) self.lifecycle = .open;
+    }
+
+    // ── Driver-owned handshake progression (#410) ───────────────────────────
+    //
+    // When a backend was injected, `PureZigRecordStream` owns the shared
+    // `engine.Driver` and progresses a real TLS 1.3 handshake inside `drive()`:
+    // it starts the driver once, routes opened handshake plaintext into it, and
+    // applies every emitted event (sealing outbound handshake bytes, installing
+    // traffic secrets, tracking epochs, discarding keys, capturing ALPN/cert
+    // state, completing, and carrying a terminal fatal alert) before the next
+    // driver call. Callers no longer hand-install secrets or declare completion.
+
+    fn driverPresent(self: *PureZigRecordStream) bool {
+        return self.handshake_driver != null;
+    }
+
+    /// Start the handshake driver exactly once. Refuses to progress until the
+    /// outbound queue can absorb a full event batch, so the client's first
+    /// flight is never partially serialized. Returns true if it started here.
+    fn startHandshakeIfNeeded(self: *PureZigRecordStream) Error!bool {
+        if (!self.driverPresent() or self.handshake_started) return false;
+        if (self.bridge.handshake_complete or self.lifecycle != .handshaking) return false;
+        if (self.outbound_ciphertext.available() < handshake_output_reserve) return false;
+        self.handshake_started = true;
+        const driver = &self.handshake_driver.?;
+        const outcome = driver.startOutcome({});
+        try self.applyDriverOutcome(outcome);
+        return true;
+    }
+
+    /// Feed one opened handshake message into the driver and apply the events it
+    /// emits. Caller must have preflighted `handshake_output_reserve` so the
+    /// whole emitted batch serializes atomically.
+    fn driveReceive(self: *PureZigRecordStream, epoch: events.EncryptionEpoch, content: []const u8) Error!void {
+        const driver = &self.handshake_driver.?;
+        const outcome = driver.receiveOutcome(epoch, content);
+        try self.applyDriverOutcome(outcome);
+    }
+
+    /// Apply one borrowed driver event batch. Every payload slice is consumed,
+    /// copied, or serialized here, before any subsequent driver call resets the
+    /// sink. A terminal backend error is deferred (with its fatal alert queued)
+    /// rather than propagated, so `drive()` can flush the alert before latching.
+    fn applyDriverOutcome(self: *PureZigRecordStream, outcome: RecordHandshakeDriver.Outcome) Error!void {
+        var fatal_alert: ?alerts.AlertDescription = null;
+        const sink = outcome.sink;
+        for (sink.items[0..sink.len]) |event| {
+            switch (event) {
+                .handshake_bytes => |hb| {
+                    var record_buf: [record_codec.max_ciphertext_record_len]u8 = undefined;
+                    const record = self.bridge.sealHandshake(hb.epoch, hb.data, &record_buf) catch |err| return self.fail(err);
+                    self.outbound_ciphertext.append(record) catch |err| return self.fail(err);
+                },
+                .traffic_secret => |ts| {
+                    self.bridge.installTrafficSecret(ts.epoch, ts.direction, ts.data) catch |err| return self.fail(err);
+                    self.advanceEpochOnSecret(ts.epoch, ts.direction);
+                },
+                .alpn => |protocol| self.captureAlpn(protocol),
+                .certificate => |cert_state| self.certificate_state = cert_state,
+                .discard_epoch => |epoch| {
+                    self.bridge.discardEpoch(epoch) catch |err| return self.fail(err);
+                    try self.applyDiscardSideEffects(epoch);
+                },
+                .handshake_complete => {
+                    self.bridge.markHandshakeComplete() catch |err| return self.fail(err);
+                    self.read_epoch = .application;
+                    self.write_epoch = .application;
+                    self.lifecycle = .open;
+                    if (self.handshake_driver) |*driver| driver.complete();
+                },
+                // Record mode carries no QUIC transport parameters (#410).
+                .peer_transport_parameters => {},
+                .fatal_alert => |desc| fatal_alert = desc,
+            }
+        }
+        if (outcome.terminal_error) |err| self.deferHandshakeFailure(err, fatal_alert);
+    }
+
+    /// Handshake secrets advance the explicit record epoch one step. Application
+    /// secrets do NOT advance the epoch here: the peer may still be sending
+    /// handshake-epoch records (its Finished) after this side installs its
+    /// application read secret. The `.application` transition happens only at
+    /// authenticated `handshake_complete`.
+    fn advanceEpochOnSecret(self: *PureZigRecordStream, epoch: events.EncryptionEpoch, direction: events.SecretDirection) void {
+        if (epoch != .handshake) return;
+        switch (direction) {
+            .read => self.read_epoch = .handshake,
+            .write => self.write_epoch = .handshake,
+        }
+    }
+
+    fn captureAlpn(self: *PureZigRecordStream, protocol: []const u8) void {
+        const n = @min(protocol.len, max_alpn_len);
+        @memcpy(self.alpn_storage[0..n], protocol[0..n]);
+        self.alpn_len = n;
+        self.alpn_captured = true;
+    }
+
+    /// Record a terminal handshake failure without immediately latching, first
+    /// queuing any emitted fatal alert into the normal bounded outbound queue.
+    /// `drive()` flushes the queue, then hard-fails with the preserved error.
+    fn deferHandshakeFailure(self: *PureZigRecordStream, err: Error, maybe_alert: ?alerts.AlertDescription) void {
+        if (maybe_alert) |desc| self.queueFatalAlert(desc);
+        self.pending_terminal = err;
+    }
+
+    /// Best-effort: seal a fatal alert at the current write epoch into the
+    /// outbound queue. Silently skips if keys or capacity are unavailable --
+    /// a lost alert must never erase the underlying handshake failure.
+    fn queueFatalAlert(self: *PureZigRecordStream, desc: alerts.AlertDescription) void {
+        if (self.outbound_ciphertext.available() < record_codec.max_ciphertext_record_len) return;
+        const payload = [_]u8{ 2, @intFromEnum(desc) }; // level = fatal(2)
+        var alert_buf: [record_codec.max_ciphertext_record_len]u8 = undefined;
+        const record = switch (self.write_epoch) {
+            .initial => record_codec.encodePlaintextRecord(.alert, &payload, &alert_buf) catch return,
+            .handshake, .application => self.bridge.sealProtected(self.write_epoch, .alert, &payload, &alert_buf) catch return,
+            .zero_rtt => return,
+        };
+        self.outbound_ciphertext.append(record) catch return;
     }
 
     pub fn feedHandshakeCiphertext(self: *PureZigRecordStream, epoch: events.EncryptionEpoch, bytes: []const u8) Error!usize {
@@ -397,6 +648,11 @@ pub const PureZigRecordStream = struct {
             return .{ .made_progress = made_progress, .readiness = self.readiness() };
         }
 
+        // Start the shared handshake driver exactly once (client: emits the
+        // initial flight; server: arms the responder). The carrier write loop
+        // below flushes whatever it queued.
+        if (try self.startHandshakeIfNeeded()) made_progress = true;
+
         if (self.carrier) |carrier| {
             var written_total: usize = 0;
             while (self.outbound_ciphertext.len > 0 and written_total < drive_write_budget) {
@@ -476,6 +732,14 @@ pub const PureZigRecordStream = struct {
             if (try self.processCarrierInput(drive_record_budget)) made_progress = true;
         }
 
+        // A terminal handshake failure surfaced while routing records: flush the
+        // fatal alert the backend emitted (best effort, nonblocking) so the peer
+        // learns why, then latch the preserved failure and close.
+        if (self.pending_terminal) |err| {
+            _ = self.flushPendingAlert();
+            return self.fail(err);
+        }
+
         if (self.lifecycle == .closing and self.carrier != null and self.close_notify_queued and self.outbound_ciphertext.len == 0) {
             self.lifecycle = .closed;
             self.closeCarrier();
@@ -538,8 +802,62 @@ pub const PureZigRecordStream = struct {
 
     fn feedCarrierCiphertext(self: *PureZigRecordStream, bytes: []const u8) Error!usize {
         if (self.bridge.handshake_complete) return self.feedCiphertext(bytes);
+        if (self.driverPresent()) {
+            // A terminal handshake failure is pending its alert flush; stop
+            // consuming carrier records until `drive()` latches it.
+            if (self.pending_terminal != null) return error.WouldBlock;
+            // Preflight so a full emitted event batch serializes atomically; if
+            // the outbound queue is too full, wait for the carrier to drain.
+            if (self.outbound_ciphertext.available() < handshake_output_reserve) return error.WouldBlock;
+            return self.feedHandshakeToDriver(self.read_epoch, bytes);
+        }
         const epoch: events.EncryptionEpoch = if (self.bridge.hasReadKeys(.handshake)) .handshake else .initial;
         return self.feedHandshakeCiphertext(epoch, bytes);
+    }
+
+    /// Parse one record at `epoch`, open it through the bridge, and route the
+    /// plaintext: handshake content into the driver (applying its events),
+    /// alerts through alert handling, anything else fails closed.
+    fn feedHandshakeToDriver(self: *PureZigRecordStream, epoch: events.EncryptionEpoch, bytes: []const u8) Error!usize {
+        var sink = record_codec.RecordSink(1, record_codec.max_ciphertext_fragment_len){};
+        const parser = self.parserForEpoch(epoch);
+        const consumed = feedUntilOneRecord(parser, bytes, &sink) catch |err| return self.fail(err);
+        var plaintext_buf: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+        for (sink.items[0..sink.len]) |record| {
+            if (epoch == .initial and record.content_type == .alert) {
+                try self.handleAlert(record.payload);
+                continue;
+            }
+            const opened = self.bridge.openProtected(epoch, record, &plaintext_buf) catch |err| return self.fail(err);
+            switch (opened.inner.content_type) {
+                .handshake => try self.driveReceive(epoch, opened.inner.content),
+                .alert => try self.handleAlert(opened.inner.content),
+                .application_data,
+                .change_cipher_spec,
+                => return self.fail(error.UnexpectedRecordContent),
+            }
+            // A deferred terminal failure means the driver rejected this
+            // message; stop opening further coalesced records under it.
+            if (self.pending_terminal != null) break;
+        }
+        return consumed;
+    }
+
+    /// Best-effort nonblocking flush of a queued fatal alert to the carrier
+    /// before the stream latches closed. Returns bytes written.
+    fn flushPendingAlert(self: *PureZigRecordStream) usize {
+        const carrier = self.carrier orelse return 0;
+        var flushed: usize = 0;
+        while (self.outbound_ciphertext.len > 0 and flushed < drive_write_budget) {
+            const written = carrier.write(self.peekCiphertext()) catch |err| switch (err) {
+                error.WouldBlock => return flushed,
+                else => return flushed,
+            };
+            if (written == 0) return flushed;
+            self.consumeCiphertext(written) catch return flushed;
+            flushed += written;
+        }
+        return flushed;
     }
 
     fn canAcceptCarrierRead(self: *const PureZigRecordStream) bool {
@@ -619,9 +937,12 @@ pub const PureZigRecordStream = struct {
         self.inbound_plaintext.clear();
         self.outbound_ciphertext.clear();
         self.inbound_handshake.clear();
+        self.clearHandshakeMetadata();
         self.initial_parser.reset();
         self.ciphertext_parser.reset();
         self.pending_terminal_read_error = null;
+        self.pending_terminal = null;
+        self.teardownDriver();
         self.bridge.deinit();
         self.closeCarrier();
         return err;
@@ -2012,4 +2333,240 @@ test "handshake epoch discard fails closed when ciphertext_parser still holds a 
     try testing.expectError(error.PartialRecordAtEpochTransition, server.applyEvent(.{ .discard_epoch = .handshake }));
     // The stream is latched failed with that same error afterward.
     try testing.expectError(error.PartialRecordAtEpochTransition, server.applyEvent(.handshake_complete));
+}
+
+// ── Driver-owned handshake progression (#410) ───────────────────────────────
+//
+// A deterministic scripted record backend that completes a compact handshake
+// through the shared `engine.Driver` seam the stream now owns, so `drive()` can
+// be proven end to end without fabricated secrets or hand-applied events. Both
+// roles emit the *same* fixed secrets per direction, so the two bridges derive
+// matching keys -- the record layer only opens what the peer really sealed. The
+// production socket-pair proof with the real pure-Zig TLS engine lives in the
+// `quic` module, where that backend is visible (#410, module layering).
+
+const ScriptedRecordBackend = struct {
+    role: tls_state.Role,
+    /// Send a hello the server will reject, to drive the failure path.
+    bad_hello: bool = false,
+
+    const hs_c2s = secret(0x11);
+    const hs_s2c = secret(0x22);
+    const app_c2s = secret(0x33);
+    const app_s2c = secret(0x44);
+
+    fn recordBackend(self: *ScriptedRecordBackend) RecordHandshakeBackend {
+        return .{ .ptr = self, .startFn = start, .receiveFn = receive };
+    }
+
+    fn start(ptr: *anyopaque, role: tls_state.Role, _: void, sink: *RecordTransport.EventSink) RecordHandshakeError!void {
+        const self: *ScriptedRecordBackend = @ptrCast(@alignCast(ptr));
+        std.debug.assert(self.role == role);
+        if (role != .client) return; // server arms and waits for the client hello
+        try sink.emitHandshakeBytes(.initial, if (self.bad_hello) "BAD" else "CH");
+    }
+
+    fn receive(ptr: *anyopaque, epoch: events.EncryptionEpoch, bytes: []const u8, sink: *RecordTransport.EventSink) RecordHandshakeError!void {
+        const self: *ScriptedRecordBackend = @ptrCast(@alignCast(ptr));
+        switch (self.role) {
+            .server => {
+                if (epoch == .initial and std.mem.eql(u8, bytes, "CH")) {
+                    try sink.emitHandshakeBytes(.initial, "SH");
+                    try sink.emitSecret(.handshake, .read, &hs_c2s);
+                    try sink.emitSecret(.handshake, .write, &hs_s2c);
+                    try sink.emitDiscardEpoch(.initial);
+                    try sink.emitHandshakeBytes(.handshake, "SF");
+                    try sink.emitSecret(.application, .read, &app_c2s);
+                    try sink.emitSecret(.application, .write, &app_s2c);
+                } else if (epoch == .handshake and std.mem.eql(u8, bytes, "CF")) {
+                    try sink.emitDiscardEpoch(.handshake);
+                    try sink.emitHandshakeComplete();
+                } else {
+                    // Transport policy (#354): synthesize the fatal alert the
+                    // peer must receive, then surface the terminal error. The
+                    // driver's `receiveOutcome` keeps both observable together.
+                    try sink.emitFatalAlert(.unexpected_message);
+                    return error.UnexpectedHandshakeMessage;
+                }
+            },
+            .client => {
+                if (epoch == .initial and std.mem.eql(u8, bytes, "SH")) {
+                    try sink.emitSecret(.handshake, .write, &hs_c2s);
+                    try sink.emitSecret(.handshake, .read, &hs_s2c);
+                    try sink.emitDiscardEpoch(.initial);
+                    try sink.emitAlpn("h1");
+                } else if (epoch == .handshake and std.mem.eql(u8, bytes, "SF")) {
+                    try sink.emitSecret(.application, .write, &app_c2s);
+                    try sink.emitSecret(.application, .read, &app_s2c);
+                    try sink.emitHandshakeBytes(.handshake, "CF");
+                    try sink.emitDiscardEpoch(.handshake);
+                    try sink.emitHandshakeComplete();
+                } else {
+                    try sink.emitFatalAlert(.unexpected_message);
+                    return error.UnexpectedHandshakeMessage;
+                }
+            },
+        }
+    }
+};
+
+/// An in-memory bidirectional byte carrier for two streams, with a per-call
+/// chunk cap so tests can force fragmented reads and partial writes.
+const Duplex = struct {
+    const Buf = ByteQueue(max_ciphertext_queue, error.CiphertextBufferFull);
+    c2s: Buf = .{},
+    s2c: Buf = .{},
+    max_chunk: usize,
+
+    const max_ciphertext_queue = PureZigRecordStream.max_ciphertext_queue;
+
+    fn clientCarrier(self: *Duplex) Carrier {
+        return .{ .ptr = self, .readFn = clientRead, .writeFn = clientWrite };
+    }
+
+    fn serverCarrier(self: *Duplex) Carrier {
+        return .{ .ptr = self, .readFn = serverRead, .writeFn = serverWrite };
+    }
+
+    fn clientWrite(ptr: *anyopaque, bytes: []const u8) Error!usize {
+        const self: *Duplex = @ptrCast(@alignCast(ptr));
+        return self.push(&self.c2s, bytes);
+    }
+
+    fn clientRead(ptr: *anyopaque, out: []u8) Error!usize {
+        const self: *Duplex = @ptrCast(@alignCast(ptr));
+        return self.pull(&self.s2c, out);
+    }
+
+    fn serverWrite(ptr: *anyopaque, bytes: []const u8) Error!usize {
+        const self: *Duplex = @ptrCast(@alignCast(ptr));
+        return self.push(&self.s2c, bytes);
+    }
+
+    fn serverRead(ptr: *anyopaque, out: []u8) Error!usize {
+        const self: *Duplex = @ptrCast(@alignCast(ptr));
+        return self.pull(&self.c2s, out);
+    }
+
+    fn push(self: *Duplex, buf: *Buf, bytes: []const u8) Error!usize {
+        const n = @min(bytes.len, @min(self.max_chunk, buf.available()));
+        if (n == 0) return error.WouldBlock;
+        buf.append(bytes[0..n]) catch return error.WouldBlock;
+        return n;
+    }
+
+    fn pull(self: *Duplex, buf: *Buf, out: []u8) Error!usize {
+        if (buf.len == 0) return error.WouldBlock;
+        const n = @min(out.len, @min(self.max_chunk, buf.len));
+        @memcpy(out[0..n], buf.slice()[0..n]);
+        buf.discard(n) catch unreachable;
+        return n;
+    }
+};
+
+fn driveBothUntil(client: *PureZigRecordStream, server: *PureZigRecordStream, done: *const fn (*PureZigRecordStream, *PureZigRecordStream) bool) !void {
+    var rounds: usize = 0;
+    while (rounds < 1000) : (rounds += 1) {
+        const c = try client.stream().drive();
+        const s = try server.stream().drive();
+        if (done(client, server)) return;
+        if (!c.made_progress and !s.made_progress) return error.Stalled;
+    }
+    return error.Stalled;
+}
+
+fn bothComplete(client: *PureZigRecordStream, server: *PureZigRecordStream) bool {
+    return client.bridge.handshake_complete and server.bridge.handshake_complete;
+}
+
+test "pure-Zig encrypted stream completes a driver-owned handshake over a fragmented duplex carrier" {
+    const cp = testProvider();
+    inline for (.{ 1, 2, 3, 7, 64, record_codec.max_ciphertext_record_len }) |chunk| {
+        var duplex = Duplex{ .max_chunk = chunk };
+        var client_backend = ScriptedRecordBackend{ .role = .client };
+        var server_backend = ScriptedRecordBackend{ .role = .server };
+        var client = PureZigRecordStream.initWithCarrierAndBackend(.client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
+        defer client.deinit();
+        var server = PureZigRecordStream.initWithCarrierAndBackend(.server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
+        defer server.deinit();
+
+        // No test-only establish(): both sides install genuine derived secrets
+        // and reach completion purely by pumping drive().
+        try driveBothUntil(&client, &server, bothComplete);
+        try testing.expect(client.bridge.handshake_complete);
+        try testing.expect(server.bridge.handshake_complete);
+        try testing.expect(client.lifecycle == .open and server.lifecycle == .open);
+        try testing.expectEqualStrings("h1", client.negotiatedAlpn().?);
+        try testing.expectEqual(events.EncryptionEpoch.application, client.read_epoch);
+        try testing.expectEqual(events.EncryptionEpoch.application, server.write_epoch);
+
+        // Application plaintext flows both ways after the real handshake.
+        try testing.expectEqual(@as(usize, 11), try client.stream().write("ping-client"));
+        try driveBothUntil(&client, &server, struct {
+            fn done(_: *PureZigRecordStream, s: *PureZigRecordStream) bool {
+                return s.readiness().can_read_plaintext;
+            }
+        }.done);
+        var buf: [32]u8 = undefined;
+        try testing.expectEqualStrings("ping-client", buf[0..try server.stream().read(&buf)]);
+
+        try testing.expectEqual(@as(usize, 11), try server.stream().write("pong-server"));
+        try driveBothUntil(&client, &server, struct {
+            fn done(c: *PureZigRecordStream, _: *PureZigRecordStream) bool {
+                return c.readiness().can_read_plaintext;
+            }
+        }.done);
+        try testing.expectEqualStrings("pong-server", buf[0..try client.stream().read(&buf)]);
+
+        // Orderly close_notify shutdown from the client.
+        client.stream().close();
+        try driveBothUntil(&client, &server, struct {
+            fn done(c: *PureZigRecordStream, s: *PureZigRecordStream) bool {
+                return c.lifecycle == .closed and s.readiness().peer_closed;
+            }
+        }.done);
+        try testing.expectError(error.EndOfStream, server.stream().read(&buf));
+    }
+}
+
+test "driver-owned handshake latches a terminal failure and flushes its fatal alert to the peer" {
+    const cp = testProvider();
+    var duplex = Duplex{ .max_chunk = record_codec.max_ciphertext_record_len };
+    var client_backend = ScriptedRecordBackend{ .role = .client, .bad_hello = true };
+    var server_backend = ScriptedRecordBackend{ .role = .server };
+    var client = PureZigRecordStream.initWithCarrierAndBackend(.client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
+    defer client.deinit();
+    var server = PureZigRecordStream.initWithCarrierAndBackend(.server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
+    defer server.deinit();
+
+    // Client sends its (rejected) hello.
+    _ = try client.stream().drive();
+
+    // The server rejects it, queues a fatal alert, flushes it, then latches the
+    // stable terminal error -- the alert-send does not erase the failure.
+    var server_error: ?anyerror = null;
+    var rounds: usize = 0;
+    while (rounds < 100) : (rounds += 1) {
+        const r = server.stream().drive() catch |err| {
+            server_error = err;
+            break;
+        };
+        if (!r.made_progress) break;
+    }
+    try testing.expectEqual(@as(?anyerror, error.UnexpectedHandshakeMessage), server_error);
+    try testing.expectEqual(Lifecycle.failed, server.lifecycle);
+    try expectLatchedFailureConformance(server.stream(), error.UnexpectedHandshakeMessage);
+
+    // The peer observes the fatal alert the server flushed and fails closed.
+    var client_error: ?anyerror = null;
+    rounds = 0;
+    while (rounds < 100) : (rounds += 1) {
+        const r = client.stream().drive() catch |err| {
+            client_error = err;
+            break;
+        };
+        if (!r.made_progress) break;
+    }
+    try testing.expectEqual(@as(?anyerror, error.PeerFatalAlert), client_error);
+    try testing.expectEqual(Lifecycle.failed, client.lifecycle);
 }

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -228,6 +228,14 @@ pub const PureZigRecordStream = struct {
     const max_terminal_flush_attempts = 16;
 
     bridge: record_epoch_bridge.Bridge,
+    /// Handshake role retained for record-mode authentication policy. Clients
+    /// require an explicitly verified server certificate by default; servers
+    /// do not require client authentication in the current profile.
+    role: tls_state.Role,
+    /// Explicit opt-in for backends configured without certificate
+    /// verification. This mirrors the QUIC driver's policy and keeps
+    /// `.certificate(.not_checked)` from silently opening a client stream.
+    allow_unverified_certificate: bool = false,
     /// The shared TLS handshake driver, present only when a concrete backend was
     /// injected (`initWithBackend`/`initWithCarrierAndBackend`). Absent for the
     /// lower-level record-plumbing paths that drive events in by hand.
@@ -283,6 +291,7 @@ pub const PureZigRecordStream = struct {
             .strict;
         return .{
             .bridge = record_epoch_bridge.Bridge.init(crypto_provider, cipher_suite),
+            .role = role,
             .initial_parser = record_codec.Parser.initWithVersionPolicy(.plaintext, initial_policy),
         };
     }
@@ -493,7 +502,11 @@ pub const PureZigRecordStream = struct {
                     // would stall in `.handshaking` forever. Stop applying later
                     // success events in the same batch so a bogus
                     // `handshake_complete` after it can never open the stream.
-                    if (cert_state == .invalid) {
+                    if (cert_state == .invalid or
+                        (self.role == .client and
+                            cert_state == .not_checked and
+                            !self.allow_unverified_certificate))
+                    {
                         self.deferHandshakeFailure(error.CertificateInvalid, fatal_alert);
                         break;
                     }
@@ -503,6 +516,13 @@ pub const PureZigRecordStream = struct {
                     try self.applyDiscardSideEffects(epoch);
                 },
                 .handshake_complete => {
+                    if (self.role == .client and
+                        !self.allow_unverified_certificate and
+                        self.certificate_state != .valid)
+                    {
+                        self.deferHandshakeFailure(error.CertificateInvalid, fatal_alert);
+                        break;
+                    }
                     self.bridge.markHandshakeComplete() catch |err| return self.fail(err);
                     self.read_epoch = .application;
                     self.write_epoch = .application;
@@ -550,10 +570,27 @@ pub const PureZigRecordStream = struct {
     /// `drive()` then flushes that output within a bounded write budget and
     /// latches the preserved error only once it drains (or the flush deadline
     /// fires) -- never by a hidden synchronous retry-and-discard.
-    fn deferHandshakeFailure(self: *PureZigRecordStream, err: Error, maybe_alert: ?alerts.AlertDescription) void {
-        if (maybe_alert) |desc| self.queueFatalAlert(desc);
+    fn deferHandshakeFailure(self: *PureZigRecordStream, err: Error, emitted_alert: ?alerts.AlertDescription) void {
+        const alert = emitted_alert orelse mappedFatalAlert(err);
+        if (alert) |desc| self.queueFatalAlert(desc);
         self.pending_terminal = err;
         self.terminal_flush_attempts = 0;
+    }
+
+    /// Convert record-transport handshake policy failures into their canonical
+    /// TLS fatal alerts when a backend did not emit a more specific alert.
+    fn mappedFatalAlert(err: Error) ?alerts.AlertDescription {
+        return switch (err) {
+            error.MalformedHandshake,
+            error.IllegalParameter,
+            error.UnexpectedHandshakeMessage,
+            error.CertificateInvalid,
+            error.AlpnMismatch,
+            error.SecretExportFailed,
+            error.InvalidHandshakeState,
+            => alerts.fromHandshakeError(@errorCast(err)),
+            else => null,
+        };
     }
 
     /// Best-effort: seal a fatal alert at the current write epoch into the
@@ -699,8 +736,13 @@ pub const PureZigRecordStream = struct {
         // drives us back when the carrier is writable, rather than a hidden
         // synchronous retry that would discard the alert on `WouldBlock`.
         if (self.pending_terminal) |root| {
-            if (self.flushPendingAlert() > 0) made_progress = true;
-            self.terminal_flush_attempts += 1;
+            const flushed = self.flushPendingAlert();
+            if (flushed > 0) {
+                made_progress = true;
+                self.terminal_flush_attempts = 0;
+            } else {
+                self.terminal_flush_attempts += 1;
+            }
             if (self.outbound_ciphertext.len == 0 or self.terminal_flush_attempts >= max_terminal_flush_attempts) {
                 return self.fail(root);
             }
@@ -2455,6 +2497,9 @@ const ScriptedRecordBackend = struct {
                 } else if (epoch == .handshake and std.mem.eql(u8, bytes, "SF")) {
                     try sink.emitSecret(.application, .write, &app_c2s);
                     try sink.emitSecret(.application, .read, &app_s2c);
+                    // The secure record-stream default requires a client-side
+                    // certificate decision before authenticated completion.
+                    try sink.emitCertificate(.valid);
                     try sink.emitHandshakeBytes(.handshake, "CF");
                     try sink.emitDiscardEpoch(.handshake);
                     try sink.emitHandshakeComplete();
@@ -2692,6 +2737,35 @@ const CountingOwnedCarrier = struct {
     }
 };
 
+/// A deterministic carrier that accepts exactly one byte after each explicit
+/// re-arm, then returns `WouldBlock` until the next `drive()`. This models an
+/// edge-triggered event loop delivering repeated writable notifications while
+/// forcing a protected alert to span many drive calls.
+const OneBytePerDriveCarrier = struct {
+    captured: ByteQueue(PureZigRecordStream.max_ciphertext_queue, error.CiphertextBufferFull) = .{},
+    armed: bool = false,
+
+    fn carrier(self: *OneBytePerDriveCarrier) Carrier {
+        return .{ .ptr = self, .readFn = read, .writeFn = write };
+    }
+
+    fn rearm(self: *OneBytePerDriveCarrier) void {
+        self.armed = true;
+    }
+
+    fn read(_: *anyopaque, _: []u8) Error!usize {
+        return error.WouldBlock;
+    }
+
+    fn write(ptr: *anyopaque, bytes: []const u8) Error!usize {
+        const self: *OneBytePerDriveCarrier = @ptrCast(@alignCast(ptr));
+        if (!self.armed or bytes.len == 0) return error.WouldBlock;
+        self.armed = false;
+        self.captured.append(bytes[0..1]) catch return error.WouldBlock;
+        return 1;
+    }
+};
+
 test "driver-owned cancellation releases owned carrier, driver, and secrets exactly once" {
     const cp = testProvider();
     inline for (.{ true, false }) |install_keys| {
@@ -2792,6 +2866,53 @@ test "driver-owned handshake preserves a pending fatal alert across write backpr
         };
     }
     try testing.expectEqual(@as(?anyerror, error.PeerFatalAlert), client_error);
+}
+
+test "terminal alert flush deadline resets on partial-write progress" {
+    const cp = testProvider();
+    const hs_secret = secret(0x5a);
+    var carrier = OneBytePerDriveCarrier{};
+    var sender = PureZigRecordStream.initWithCarrier(.client, cp, .tls_aes_128_gcm_sha256, carrier.carrier());
+    defer sender.deinit();
+    var peer = PureZigRecordStream.init(.server, cp, .tls_aes_128_gcm_sha256);
+    defer peer.deinit();
+
+    try sender.bridge.installTrafficSecret(.handshake, .write, &hs_secret);
+    sender.write_epoch = .handshake;
+    try peer.bridge.installTrafficSecret(.handshake, .read, &hs_secret);
+
+    // Put a protected handshake record ahead of the synthesized alert so the
+    // queue takes substantially more than the 16-attempt no-progress deadline
+    // to drain at one byte per writable notification.
+    var record_buf: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    const earlier = try sender.bridge.sealHandshake(.handshake, "queued-before-alert", &record_buf);
+    try sender.outbound_ciphertext.append(earlier);
+    sender.deferHandshakeFailure(error.CertificateInvalid, null);
+    try testing.expectEqual(alerts.AlertDescription.bad_certificate, PureZigRecordStream.mappedFatalAlert(error.CertificateInvalid).?);
+    try testing.expect(sender.queuedCiphertextLen() > PureZigRecordStream.max_terminal_flush_attempts);
+
+    var drives: usize = 0;
+    while (drives < PureZigRecordStream.max_ciphertext_queue) : (drives += 1) {
+        carrier.rearm();
+        const result = sender.stream().drive() catch |err| {
+            try testing.expectEqual(error.CertificateInvalid, err);
+            break;
+        };
+        try testing.expect(result.made_progress);
+        try testing.expectEqual(@as(usize, 0), sender.terminal_flush_attempts);
+        try testing.expect(sender.pending_terminal != null);
+    }
+    try testing.expect(drives > PureZigRecordStream.max_terminal_flush_attempts);
+    try testing.expectEqual(Lifecycle.failed, sender.lifecycle);
+    try expectLatchedFailureConformance(sender.stream(), error.CertificateInvalid);
+
+    // The peer can consume the complete earlier handshake record and then
+    // opens the following protected fatal alert rather than seeing truncation.
+    const captured = carrier.captured.slice();
+    const consumed = try peer.feedHandshakeCiphertext(.handshake, captured);
+    var plaintext: [64]u8 = undefined;
+    try testing.expectEqualStrings("queued-before-alert", plaintext[0..try peer.readHandshake(&plaintext)]);
+    try testing.expectError(error.PeerFatalAlert, peer.feedHandshakeCiphertext(.handshake, captured[consumed..]));
 }
 
 test "driver-owned handshake latches on the flush deadline when a fatal alert can never be sent" {

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -265,6 +265,12 @@ pub const PureZigRecordStream = struct {
     alpn_storage: [max_alpn_len]u8 = undefined,
     alpn_len: usize = 0,
     alpn_captured: bool = false,
+    /// Optional stream-owned client ALPN policy. Negotiated metadata alone is
+    /// insufficient: a client that requires a protocol must reject both a
+    /// different server selection and a missing ALPN extension.
+    expected_alpn_storage: [max_alpn_len]u8 = undefined,
+    expected_alpn_len: usize = 0,
+    require_alpn: bool = false,
     certificate_state: events.CertificateState = .not_checked,
     /// A terminal handshake failure whose emitted fatal alert is being flushed
     /// to the carrier before the stream latches closed (`drive()` step 13). The
@@ -338,6 +344,18 @@ pub const PureZigRecordStream = struct {
         return self.alpn_storage[0..self.alpn_len];
     }
 
+    /// Require the peer to negotiate exactly `protocol`. Configure this before
+    /// the handshake starts; the value is copied because caller storage need
+    /// not outlive construction.
+    pub fn setExpectedAlpn(self: *PureZigRecordStream, protocol: []const u8) Error!void {
+        if (self.handshake_started) return error.InvalidHandshakeState;
+        if (protocol.len == 0 or protocol.len > max_alpn_len) return error.MalformedHandshake;
+        if (self.expected_alpn_len > 0) @memset(self.expected_alpn_storage[0..self.expected_alpn_len], 0);
+        @memcpy(self.expected_alpn_storage[0..protocol.len], protocol);
+        self.expected_alpn_len = protocol.len;
+        self.require_alpn = true;
+    }
+
     /// The peer certificate validation outcome the backend reported.
     pub fn certificateState(self: *const PureZigRecordStream) events.CertificateState {
         return self.certificate_state;
@@ -382,6 +400,9 @@ pub const PureZigRecordStream = struct {
         if (self.alpn_len > 0) @memset(self.alpn_storage[0..self.alpn_len], 0);
         self.alpn_len = 0;
         self.alpn_captured = false;
+        if (self.expected_alpn_len > 0) @memset(self.expected_alpn_storage[0..self.expected_alpn_len], 0);
+        self.expected_alpn_len = 0;
+        self.require_alpn = false;
         self.certificate_state = .not_checked;
         self.read_epoch = .initial;
         self.write_epoch = .initial;
@@ -480,6 +501,15 @@ pub const PureZigRecordStream = struct {
     fn applyDriverOutcome(self: *PureZigRecordStream, outcome: RecordHandshakeDriver.Outcome) Error!void {
         var fatal_alert: ?alerts.AlertDescription = null;
         const sink = outcome.sink;
+        // A completion batch may contain application secrets, Client Finished,
+        // and handshake-key discard before `handshake_complete`. Validate the
+        // batch's final authentication/ALPN state first so policy failure sends
+        // its alert with the existing handshake keys and applies none of those
+        // success effects.
+        if (self.completionPolicyError(sink)) |err| {
+            self.deferHandshakeFailure(err, findEmittedFatalAlert(sink));
+            return;
+        }
         for (sink.items[0..sink.len]) |event| {
             switch (event) {
                 .handshake_bytes => |hb| {
@@ -491,7 +521,13 @@ pub const PureZigRecordStream = struct {
                     self.bridge.installTrafficSecret(ts.epoch, ts.direction, ts.data) catch |err| return self.fail(err);
                     self.advanceEpochOnSecret(ts.epoch, ts.direction);
                 },
-                .alpn => |protocol| try self.captureAlpn(protocol),
+                .alpn => |protocol| {
+                    try self.captureAlpn(protocol);
+                    if (self.alpnPolicyError(protocol)) |err| {
+                        self.deferHandshakeFailure(err, fatal_alert);
+                        break;
+                    }
+                },
                 .certificate => |cert_state| {
                     self.certificate_state = cert_state;
                     // The concrete backend emits the certificate result and
@@ -516,13 +552,6 @@ pub const PureZigRecordStream = struct {
                     try self.applyDiscardSideEffects(epoch);
                 },
                 .handshake_complete => {
-                    if (self.role == .client and
-                        !self.allow_unverified_certificate and
-                        self.certificate_state != .valid)
-                    {
-                        self.deferHandshakeFailure(error.CertificateInvalid, fatal_alert);
-                        break;
-                    }
                     self.bridge.markHandshakeComplete() catch |err| return self.fail(err);
                     self.read_epoch = .application;
                     self.write_epoch = .application;
@@ -540,6 +569,48 @@ pub const PureZigRecordStream = struct {
         if (self.pending_terminal == null) {
             if (outcome.terminal_error) |err| self.deferHandshakeFailure(err, fatal_alert);
         }
+    }
+
+    /// Validate the final policy state represented by a completion batch before
+    /// applying any event from it. Event payloads are borrowed from `sink` and
+    /// are used only during this synchronous preflight.
+    fn completionPolicyError(self: *const PureZigRecordStream, sink: *const RecordTransport.EventSink) ?Error {
+        var certificate = self.certificate_state;
+        var selected_alpn = self.negotiatedAlpn();
+        var completes = false;
+
+        for (sink.items[0..sink.len]) |event| switch (event) {
+            .certificate => |state| certificate = state,
+            .alpn => |protocol| {
+                if (protocol.len > max_alpn_len) return error.MalformedHandshake;
+                selected_alpn = protocol;
+            },
+            .handshake_complete => completes = true,
+            else => {},
+        };
+
+        if (!completes) return null;
+        if (self.role == .client and !self.allow_unverified_certificate and certificate != .valid) {
+            return error.CertificateInvalid;
+        }
+        return self.alpnPolicyError(selected_alpn);
+    }
+
+    fn alpnPolicyError(self: *const PureZigRecordStream, selected: ?[]const u8) ?Error {
+        if (!self.require_alpn) return null;
+        const protocol = selected orelse return error.AlpnMismatch;
+        if (!std.mem.eql(u8, protocol, self.expected_alpn_storage[0..self.expected_alpn_len])) {
+            return error.AlpnMismatch;
+        }
+        return null;
+    }
+
+    fn findEmittedFatalAlert(sink: *const RecordTransport.EventSink) ?alerts.AlertDescription {
+        var emitted: ?alerts.AlertDescription = null;
+        for (sink.items[0..sink.len]) |event| {
+            if (event == .fatal_alert) emitted = event.fatal_alert;
+        }
+        return emitted;
     }
 
     /// Handshake secrets advance the explicit record epoch one step. Application
@@ -2448,6 +2519,11 @@ const ScriptedRecordBackend = struct {
     role: tls_state.Role,
     /// Send a hello the server will reject, to drive the failure path.
     bad_hello: bool = false,
+    /// Client-side adversarial knobs used to prove record-mode policy rather
+    /// than trusting an injected backend's event stream.
+    selected_alpn: ?[]const u8 = "h1",
+    emit_certificate: bool = true,
+    received_client_finished: bool = false,
 
     const hs_c2s = secret(0x11);
     const hs_s2c = secret(0x22);
@@ -2478,6 +2554,7 @@ const ScriptedRecordBackend = struct {
                     try sink.emitSecret(.application, .read, &app_c2s);
                     try sink.emitSecret(.application, .write, &app_s2c);
                 } else if (epoch == .handshake and std.mem.eql(u8, bytes, "CF")) {
+                    self.received_client_finished = true;
                     try sink.emitDiscardEpoch(.handshake);
                     try sink.emitHandshakeComplete();
                 } else {
@@ -2493,13 +2570,13 @@ const ScriptedRecordBackend = struct {
                     try sink.emitSecret(.handshake, .write, &hs_c2s);
                     try sink.emitSecret(.handshake, .read, &hs_s2c);
                     try sink.emitDiscardEpoch(.initial);
-                    try sink.emitAlpn("h1");
+                    if (self.selected_alpn) |protocol| try sink.emitAlpn(protocol);
                 } else if (epoch == .handshake and std.mem.eql(u8, bytes, "SF")) {
                     try sink.emitSecret(.application, .write, &app_c2s);
                     try sink.emitSecret(.application, .read, &app_s2c);
                     // The secure record-stream default requires a client-side
                     // certificate decision before authenticated completion.
-                    try sink.emitCertificate(.valid);
+                    if (self.emit_certificate) try sink.emitCertificate(.valid);
                     try sink.emitHandshakeBytes(.handshake, "CF");
                     try sink.emitDiscardEpoch(.handshake);
                     try sink.emitHandshakeComplete();
@@ -2585,6 +2662,30 @@ fn bothComplete(client: *PureZigRecordStream, server: *PureZigRecordStream) bool
     return client.bridge.handshake_complete and server.bridge.handshake_complete;
 }
 
+const DriverPairErrors = struct {
+    client: ?anyerror = null,
+    server: ?anyerror = null,
+};
+
+fn driveDriverPairUntilBothErrors(client: *PureZigRecordStream, server: *PureZigRecordStream) DriverPairErrors {
+    var errors = DriverPairErrors{};
+    var rounds: usize = 0;
+    while (rounds < 1000) : (rounds += 1) {
+        if (errors.client == null) {
+            _ = client.stream().drive() catch |err| {
+                errors.client = err;
+            };
+        }
+        if (errors.server == null) {
+            _ = server.stream().drive() catch |err| {
+                errors.server = err;
+            };
+        }
+        if (errors.client != null and errors.server != null) return errors;
+    }
+    return errors;
+}
+
 test "pure-Zig encrypted stream completes a driver-owned handshake over a fragmented duplex carrier" {
     const cp = testProvider();
     inline for (.{ 1, 2, 3, 7, 64, record_codec.max_ciphertext_record_len }) |chunk| {
@@ -2593,6 +2694,7 @@ test "pure-Zig encrypted stream completes a driver-owned handshake over a fragme
         var server_backend = ScriptedRecordBackend{ .role = .server };
         var client = PureZigRecordStream.initWithCarrierAndBackend(.client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
         defer client.deinit();
+        try client.setExpectedAlpn("h1");
         var server = PureZigRecordStream.initWithCarrierAndBackend(.server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
         defer server.deinit();
 
@@ -2633,6 +2735,67 @@ test "pure-Zig encrypted stream completes a driver-owned handshake over a fragme
         }.done);
         try testing.expectError(error.EndOfStream, server.stream().read(&buf));
     }
+}
+
+test "driver-owned client rejects an unoffered ALPN before sending Finished" {
+    const cp = testProvider();
+    var duplex = Duplex{ .max_chunk = record_codec.max_ciphertext_record_len };
+    var client_backend = ScriptedRecordBackend{ .role = .client, .selected_alpn = "h2" };
+    var server_backend = ScriptedRecordBackend{ .role = .server };
+    var client = PureZigRecordStream.initWithCarrierAndBackend(.client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
+    defer client.deinit();
+    try client.setExpectedAlpn("h1");
+    var server = PureZigRecordStream.initWithCarrierAndBackend(.server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
+    defer server.deinit();
+
+    const errors = driveDriverPairUntilBothErrors(&client, &server);
+    try testing.expectEqual(@as(?anyerror, error.AlpnMismatch), errors.client);
+    try testing.expectEqual(@as(?anyerror, error.PeerFatalAlert), errors.server);
+    try testing.expectEqual(alerts.AlertDescription.no_application_protocol, PureZigRecordStream.mappedFatalAlert(error.AlpnMismatch).?);
+    try testing.expect(!client.bridge.handshake_complete);
+    try testing.expect(!server.bridge.handshake_complete);
+    try testing.expect(!server_backend.received_client_finished);
+    try expectLatchedFailureConformance(client.stream(), error.AlpnMismatch);
+}
+
+test "driver-owned client requires ALPN before completion" {
+    const cp = testProvider();
+    var duplex = Duplex{ .max_chunk = record_codec.max_ciphertext_record_len };
+    var client_backend = ScriptedRecordBackend{ .role = .client, .selected_alpn = null };
+    var server_backend = ScriptedRecordBackend{ .role = .server };
+    var client = PureZigRecordStream.initWithCarrierAndBackend(.client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
+    defer client.deinit();
+    try client.setExpectedAlpn("h1");
+    var server = PureZigRecordStream.initWithCarrierAndBackend(.server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
+    defer server.deinit();
+
+    const errors = driveDriverPairUntilBothErrors(&client, &server);
+    try testing.expectEqual(@as(?anyerror, error.AlpnMismatch), errors.client);
+    try testing.expectEqual(@as(?anyerror, error.PeerFatalAlert), errors.server);
+    try testing.expect(!client.bridge.handshake_complete);
+    try testing.expect(!server.bridge.handshake_complete);
+    try testing.expect(!server_backend.received_client_finished);
+    try expectLatchedFailureConformance(client.stream(), error.AlpnMismatch);
+}
+
+test "completion policy preflight rejects a missing certificate before sending Finished" {
+    const cp = testProvider();
+    var duplex = Duplex{ .max_chunk = record_codec.max_ciphertext_record_len };
+    var client_backend = ScriptedRecordBackend{ .role = .client, .emit_certificate = false };
+    var server_backend = ScriptedRecordBackend{ .role = .server };
+    var client = PureZigRecordStream.initWithCarrierAndBackend(.client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
+    defer client.deinit();
+    try client.setExpectedAlpn("h1");
+    var server = PureZigRecordStream.initWithCarrierAndBackend(.server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
+    defer server.deinit();
+
+    const errors = driveDriverPairUntilBothErrors(&client, &server);
+    try testing.expectEqual(@as(?anyerror, error.CertificateInvalid), errors.client);
+    try testing.expectEqual(@as(?anyerror, error.PeerFatalAlert), errors.server);
+    try testing.expect(!client.bridge.handshake_complete);
+    try testing.expect(!server.bridge.handshake_complete);
+    try testing.expect(!server_backend.received_client_finished);
+    try expectLatchedFailureConformance(client.stream(), error.CertificateInvalid);
 }
 
 test "driver-owned handshake latches a terminal failure and flushes its fatal alert to the peer" {


### PR DESCRIPTION
## Summary

`PureZigRecordStream` now **owns the shared TLS handshake driver** and progresses a real TLS 1.3 handshake inside `drive()` — completing the pure-Zig TLS-over-TCP handshake ownership required by #353. The successful socket-pair path no longer installs fabricated traffic secrets, hand-applies arbitrary events, or declares completion manually.

### Ownership model
The stream owns an `engine.Driver` (`RecordHandshakeDriver`) over a canonical record-mode `transport.Contract` (`events.EncryptionEpoch`, no transport params), plus explicit inbound/outbound record epochs, the negotiated ALPN/certificate state, and a pending fatal-alert. The concrete backend is **injected** (`initWithCarrierAndBackend`): a thin `RecordModeBackend` wrapper adapts the pure-Zig `Tls13Backend` (which lives in the `quic` module and is QUIC-shaped) into the record-mode contract, since `tls_core` cannot import `quic`. This is the "smallest wrapper needed"; production HTTP dispatch over it is out of scope (#356).

### `drive()` progression
Starts the driver once → flushes pending ciphertext → reads bounded carrier ciphertext → parses records incrementally → routes handshake plaintext to `driver.receiveOutcome(epoch, …)` at the **explicit** inbound epoch → applies every emitted event before the next driver call → seals handshake bytes → installs read/write secrets → applies epoch discards → captures ALPN/cert → transitions to application mode only on the real `handshake_complete` → serializes a pending fatal alert before closing → stops on would-block / budget / completion / terminal failure.

### Handshake events handled
`handshake_bytes`, `traffic_secret`, `alpn`, `certificate`, `discard_epoch`, `handshake_complete`, `fatal_alert` (`peer_transport_parameters` is QUIC-only and ignored).

### Event lifetime & atomicity
Each borrowed event batch is applied fully — copied, installed, or serialized — before any subsequent driver call resets the sink. An outbound-capacity **preflight** (`handshake_output_reserve = 3 × max_ciphertext_record_len`) guards each `start`/`receive` so a full batch serializes atomically instead of partially overwriting the still-borrowed sink. Traffic-secret bytes are installed immediately and never retained. `startOutcome`/`receiveOutcome` keep a terminal error and its emitted fatal alert observable together.

### Epoch rules
`read`/`write` epochs advance to `.handshake` when that direction's handshake secret installs, and to `.application` **only** at authenticated `handshake_complete` — not merely because an application key is installed (the peer's Finished is still handshake-epoch after this side installs its app read secret). Initial-epoch plaintext, handshake-protected, and application-protected records are routed by the explicit epoch; a partial record spanning a `.handshake` discard fails closed; the RFC 8446 §5.1 `0x0301` ClientHello and existing compatibility handling are preserved.

### Error / alert behavior
A terminal handshake failure is deferred: any emitted fatal alert is sealed into the normal bounded outbound queue and flushed to the peer (best-effort, nonblocking) before the stream latches the **preserved** failure. Alert-send failure never erases the underlying error; repeated operations return the stable terminal failure; `close_notify`, peer fatal alerts, malformed alerts, truncation, and clean EOF stay distinct.

## Test plan
- [x] `zig fmt --check build.zig src/ tests/` — clean
- [x] `git diff --check` — clean
- [x] `zig build test-tls` — 135/135 (adds driver-owned duplex handshake across a fragmentation matrix + a fatal-alert/latched-failure path, all existing low-level record tests still green)
- [x] `zig build test-quic` — 413/413 (adds the real-backend socket-pair suite)
- [x] `zig build test-integration` — 65/69 (4 pre-existing skips, exit 0)
- [x] `zig build test` — 1414 passed, 1 skipped
- [x] Fragmented socket-pair scenarios run 5× — deterministic (exit 0 each)

### Socket-pair scenarios (real `Tls13Backend` on both ends)
**Success:** client produces the initial flight via `drive()`; server processes it in record mode; fragmentation matrix `{1,1}`,`{2,3}`,`{3,2}`,`{5,5}`,`{7,64}`,`{64,7}`, whole-record (covers split initial headers, fragmented/coalesced records, tiny reads & partial writes, would-block between flights); both install genuine derived 1-RTT secrets; both complete with **no `establish()`**; ALPN `h3` + valid certificate captured; bidirectional application plaintext; orderly `close_notify` shutdown.
**Failure:** in-flight ClientHello tamper (transcript divergence → `AuthenticationFailed`); carrier EOF before `close_notify` → `TruncatedStream`. The tls_core scripted-backend test additionally proves the fatal-alert flush + peer-alert + latched terminal error deterministically.

### Cleanup validation
Driver teardown runs exactly once (`teardownDriver` → `Driver.deinit` wipes the borrowed sink + backend); the wrapper securely zeroes its private QUIC sink; the bridge wipes all key material; ALPN/epoch metadata is cleared on both `deinit` and fatal `fail`. Owned carriers close exactly once and borrowed carriers are never closed by the stream (existing + new suites). Testing allocator + FD tracking pass on success, failure, and truncation paths.

## Scope
Focused on #410. No PKI files (#345/#346), HTTP dispatch (#356), watermarks (#355), KeyUpdate (#357), or QUIC handshake changes. Files changed: `src/tls/encrypted_stream.zig`, `src/quic/record_mode_handshake_test.zig`.

## #353
This clears the remaining #353 handshake-ownership acceptance criteria (real handshake + bidirectional app data over a fragmented nonblocking socket pair; no fabricated secrets on the success path; would-block without busy-loop; cleanup on success/failure/cancellation). #353 also spans the OpenSSL/pure-Zig abstraction unification and HTTP-startup interfaces (#356), so it is intentionally **not** closed here. The exact prerequisite now cleared for **#355** (watermarks/backpressure): a driver-owned `drive()` with bounded outbound serialization and stable would-block/readiness semantics for HTTP backpressure to hook into.

Closes #410
Refs #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)