### PR TITLE
pki: add trust-store abstraction and root bundle loaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable user-facing changes to Tardigrade are documented here.
 ## [Unreleased]
 
 ### Features
+- **Provider-neutral PKI trust-store snapshots and bundle loading (#346, epic #324)** —
+  adds `src/pki/trust_store.zig`, a pure-Zig trust-anchor store that loads
+  configured PEM and DER root bundles, deduplicates anchors by exact DER with
+  first-occurrence wins, rejects malformed or non-CA anchors typed, and hands
+  immutable `[]const x509.Certificate` snapshots to the existing path builder
+  and validator without exposing any OpenSSL or platform-native trust-store
+  object. Reload swaps the active bundle without invalidating already-acquired
+  snapshots, so in-flight validations keep their owned anchor bytes while the
+  next validation can observe the updated store. A small provider-vtable seam
+  is included so later system-store adapters can materialize the same owned
+  snapshot contract without changing PKI callers. Covered under
+  `zig build test-pki` with mixed PEM/DER loading, file-backed bundles,
+  exact-DER dedup, typed malformed/non-CA rejection, and reload-safe
+  validation against the RFC 5280 path-validation fixtures.
 - **Deterministic RFC 5280 path-validation core (#345, epic #324)** — adds
   `src/pki/path_validator.zig`, an iterative, offline validator for
   `path_builder` candidate paths. It authenticates terminal anchors against

--- a/src/pki/root.zig
+++ b/src/pki/root.zig
@@ -17,6 +17,7 @@
 //! - `path_validator` — deterministic RFC 5280 candidate-path validation
 //! - `name_constraints` — bounded RFC 5280 permitted/excluded subtree state
 //! - `certificate_policy` — bounded RFC 9618 certificate-policy graph
+//! - `trust_store` — provider-neutral trust-anchor snapshots and bundle loader
 //!
 //! ## Policy summary
 //!
@@ -44,6 +45,7 @@ pub const path_builder = @import("path_builder.zig");
 pub const name_constraints = @import("name_constraints.zig");
 pub const certificate_policy = @import("certificate_policy.zig");
 pub const path_validator = @import("path_validator.zig");
+pub const trust_store = @import("trust_store.zig");
 
 test {
     @import("std").testing.refAllDecls(@This());
@@ -54,4 +56,5 @@ test {
     _ = @import("verify_tests.zig");
     _ = @import("path_builder_tests.zig");
     _ = @import("path_validator_tests.zig");
+    _ = @import("trust_store_tests.zig");
 }

--- a/src/pki/trust_store.zig
+++ b/src/pki/trust_store.zig
@@ -56,17 +56,8 @@ pub const Snapshot = struct {
         for (inputs) |input| {
             switch (input) {
                 .pem => |pem_text| {
-                    const chain = try pem.loadChainPem(allocator, pem_text, limits.loader);
-                    defer allocator.free(chain.certificates);
-                    for (chain.certificates) |certificate| {
-                        try appendOwnedCertificate(
-                            allocator,
-                            &owned_certs,
-                            &parsed_anchors,
-                            certificate,
-                            limits,
-                        );
-                    }
+                    var chain = try pem.loadChainPem(allocator, pem_text, limits.loader);
+                    try appendPemChain(allocator, &owned_certs, &parsed_anchors, &chain, limits);
                 },
                 .der => |der_bytes| {
                     const certificate = try pem.loadCertificateDer(allocator, der_bytes, limits.loader);
@@ -100,17 +91,8 @@ pub const Snapshot = struct {
         for (inputs) |input| {
             switch (input) {
                 .pem => |sub_path| {
-                    const chain = try pem.loadChainPemFile(allocator, io, dir, sub_path, limits.loader);
-                    defer allocator.free(chain.certificates);
-                    for (chain.certificates) |certificate| {
-                        try appendOwnedCertificate(
-                            allocator,
-                            &owned_certs,
-                            &parsed_anchors,
-                            certificate,
-                            limits,
-                        );
-                    }
+                    var chain = try pem.loadChainPemFile(allocator, io, dir, sub_path, limits.loader);
+                    try appendPemChain(allocator, &owned_certs, &parsed_anchors, &chain, limits);
                 },
                 .der => |sub_path| {
                     const certificate = try pem.loadCertificateDerFile(allocator, io, dir, sub_path, limits.loader);
@@ -288,6 +270,29 @@ fn appendOwnedCertificate(
         parsed.deinit(allocator);
         return err;
     };
+}
+
+fn appendPemChain(
+    allocator: std.mem.Allocator,
+    owned_certs: *std.ArrayList(pem.Certificate),
+    parsed_anchors: *std.ArrayList(x509.Certificate),
+    chain: *pem.CertificateChain,
+    limits: Limits,
+) Error!void {
+    var transferred: usize = 0;
+    errdefer {
+        for (chain.certificates[transferred..]) |*certificate| certificate.deinit(allocator);
+        allocator.free(chain.certificates);
+    }
+
+    for (chain.certificates, 0..) |*certificate, index| {
+        const owned = certificate.*;
+        certificate.* = undefined;
+        transferred = index + 1;
+        try appendOwnedCertificate(allocator, owned_certs, parsed_anchors, owned, limits);
+    }
+
+    allocator.free(chain.certificates);
 }
 
 fn containsDer(owned_certs: []const pem.Certificate, der_bytes: []const u8) bool {

--- a/src/pki/trust_store.zig
+++ b/src/pki/trust_store.zig
@@ -1,0 +1,332 @@
+//! Provider-neutral trust-anchor store for the pure-Zig PKI path (#346).
+//!
+//! The validator and path builder consume immutable `[]const x509.Certificate`
+//! anchor snapshots only; no platform-native or foreign-library handle leaks
+//! into this surface. Future system-store adapters can satisfy `Provider` by
+//! materializing the same owned snapshot contract.
+
+const std = @import("std");
+const pem = @import("pem.zig");
+const x509 = @import("x509.zig");
+
+pub const Limits = struct {
+    loader: pem.Limits = .{},
+    parser: x509.Limits = .{},
+    /// Maximum unique anchors retained after exact-DER deduplication.
+    max_anchors: usize = 256,
+};
+
+pub const default_limits: Limits = .{};
+
+pub const Error = pem.Error || x509.Error || error{
+    NoTrustAnchors,
+    TooManyAnchors,
+    NonCaAnchor,
+};
+
+pub const FileError = Error || std.Io.File.OpenError || std.Io.File.Reader.Error;
+
+pub const BufferInput = union(enum) {
+    pem: []const u8,
+    der: []const u8,
+};
+
+pub const FileInput = union(enum) {
+    pem: []const u8,
+    der: []const u8,
+};
+
+/// One immutable trust-anchor snapshot. Parsed certificates borrow the owned
+/// DER bytes in `owned_certs`; callers release both together via `deinit`.
+pub const Snapshot = struct {
+    owned_certs: []pem.Certificate,
+    parsed_anchors: []x509.Certificate,
+    parser_limits: x509.Limits,
+
+    pub fn loadBuffers(
+        allocator: std.mem.Allocator,
+        inputs: []const BufferInput,
+        limits: Limits,
+    ) Error!Snapshot {
+        var owned_certs: std.ArrayList(pem.Certificate) = .empty;
+        errdefer deinitOwnedArrayList(&owned_certs, allocator);
+        var parsed_anchors: std.ArrayList(x509.Certificate) = .empty;
+        errdefer deinitParsedArrayList(&parsed_anchors, allocator);
+
+        for (inputs) |input| {
+            switch (input) {
+                .pem => |pem_text| {
+                    const chain = try pem.loadChainPem(allocator, pem_text, limits.loader);
+                    defer allocator.free(chain.certificates);
+                    for (chain.certificates) |certificate| {
+                        try appendOwnedCertificate(
+                            allocator,
+                            &owned_certs,
+                            &parsed_anchors,
+                            certificate,
+                            limits,
+                        );
+                    }
+                },
+                .der => |der_bytes| {
+                    const certificate = try pem.loadCertificateDer(allocator, der_bytes, limits.loader);
+                    try appendOwnedCertificate(
+                        allocator,
+                        &owned_certs,
+                        &parsed_anchors,
+                        certificate,
+                        limits,
+                    );
+                },
+            }
+        }
+
+        if (parsed_anchors.items.len == 0) return error.NoTrustAnchors;
+        return finishSnapshot(allocator, &owned_certs, &parsed_anchors, limits.parser);
+    }
+
+    pub fn loadFiles(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        dir: std.Io.Dir,
+        inputs: []const FileInput,
+        limits: Limits,
+    ) FileError!Snapshot {
+        var owned_certs: std.ArrayList(pem.Certificate) = .empty;
+        errdefer deinitOwnedArrayList(&owned_certs, allocator);
+        var parsed_anchors: std.ArrayList(x509.Certificate) = .empty;
+        errdefer deinitParsedArrayList(&parsed_anchors, allocator);
+
+        for (inputs) |input| {
+            switch (input) {
+                .pem => |sub_path| {
+                    const chain = try pem.loadChainPemFile(allocator, io, dir, sub_path, limits.loader);
+                    defer allocator.free(chain.certificates);
+                    for (chain.certificates) |certificate| {
+                        try appendOwnedCertificate(
+                            allocator,
+                            &owned_certs,
+                            &parsed_anchors,
+                            certificate,
+                            limits,
+                        );
+                    }
+                },
+                .der => |sub_path| {
+                    const certificate = try pem.loadCertificateDerFile(allocator, io, dir, sub_path, limits.loader);
+                    try appendOwnedCertificate(
+                        allocator,
+                        &owned_certs,
+                        &parsed_anchors,
+                        certificate,
+                        limits,
+                    );
+                },
+            }
+        }
+
+        if (parsed_anchors.items.len == 0) return error.NoTrustAnchors;
+        return finishSnapshot(allocator, &owned_certs, &parsed_anchors, limits.parser);
+    }
+
+    pub fn anchors(self: *const Snapshot) []const x509.Certificate {
+        return self.parsed_anchors;
+    }
+
+    pub fn deinit(self: *Snapshot, allocator: std.mem.Allocator) void {
+        for (self.parsed_anchors) |*certificate| certificate.deinit(allocator);
+        allocator.free(self.parsed_anchors);
+        for (self.owned_certs) |*certificate| certificate.deinit(allocator);
+        allocator.free(self.owned_certs);
+        self.* = undefined;
+    }
+
+    fn clone(self: *const Snapshot, allocator: std.mem.Allocator) Error!Snapshot {
+        var owned_certs: std.ArrayList(pem.Certificate) = .empty;
+        errdefer deinitOwnedArrayList(&owned_certs, allocator);
+        var parsed_anchors: std.ArrayList(x509.Certificate) = .empty;
+        errdefer deinitParsedArrayList(&parsed_anchors, allocator);
+
+        for (self.owned_certs) |certificate| {
+            const der_copy = try allocator.dupe(u8, certificate.der);
+            const owned = pem.Certificate{ .der = der_copy };
+            try appendOwnedCertificate(
+                allocator,
+                &owned_certs,
+                &parsed_anchors,
+                owned,
+                .{
+                    .loader = .{},
+                    .parser = self.parser_limits,
+                    .max_anchors = self.parsed_anchors.len,
+                },
+            );
+        }
+
+        return finishSnapshot(allocator, &owned_certs, &parsed_anchors, self.parser_limits);
+    }
+};
+
+/// Trust-store interface for future platform-native adapters. Implementations
+/// provide immutable snapshots with the same ownership rules as `Snapshot`.
+pub const Provider = struct {
+    context: *const anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        snapshot: *const fn (context: *const anyopaque, allocator: std.mem.Allocator) Error!Snapshot,
+    };
+
+    pub fn snapshot(self: Provider, allocator: std.mem.Allocator) Error!Snapshot {
+        return self.vtable.snapshot(self.context, allocator);
+    }
+};
+
+/// Practical PEM/DER-backed trust store. Reload swaps the current bundle, and
+/// every acquired snapshot owns its bytes so in-flight validation survives.
+pub const BundleStore = struct {
+    current: Snapshot,
+
+    pub fn initBuffers(
+        allocator: std.mem.Allocator,
+        inputs: []const BufferInput,
+        limits: Limits,
+    ) Error!BundleStore {
+        return .{ .current = try Snapshot.loadBuffers(allocator, inputs, limits) };
+    }
+
+    pub fn initFiles(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        dir: std.Io.Dir,
+        inputs: []const FileInput,
+        limits: Limits,
+    ) FileError!BundleStore {
+        return .{ .current = try Snapshot.loadFiles(allocator, io, dir, inputs, limits) };
+    }
+
+    pub fn deinit(self: *BundleStore, allocator: std.mem.Allocator) void {
+        self.current.deinit(allocator);
+        self.* = undefined;
+    }
+
+    pub fn provider(self: *const BundleStore) Provider {
+        return .{ .context = self, .vtable = &provider_vtable };
+    }
+
+    pub fn snapshot(self: *const BundleStore, allocator: std.mem.Allocator) Error!Snapshot {
+        return self.current.clone(allocator);
+    }
+
+    pub fn reloadBuffers(
+        self: *BundleStore,
+        allocator: std.mem.Allocator,
+        inputs: []const BufferInput,
+        limits: Limits,
+    ) Error!void {
+        const next = try Snapshot.loadBuffers(allocator, inputs, limits);
+        self.current.deinit(allocator);
+        self.current = next;
+    }
+
+    pub fn reloadFiles(
+        self: *BundleStore,
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        dir: std.Io.Dir,
+        inputs: []const FileInput,
+        limits: Limits,
+    ) FileError!void {
+        const next = try Snapshot.loadFiles(allocator, io, dir, inputs, limits);
+        self.current.deinit(allocator);
+        self.current = next;
+    }
+
+    const provider_vtable = Provider.VTable{
+        .snapshot = providerSnapshot,
+    };
+
+    fn providerSnapshot(context: *const anyopaque, allocator: std.mem.Allocator) Error!Snapshot {
+        const self: *const BundleStore = @ptrCast(@alignCast(context));
+        return self.snapshot(allocator);
+    }
+};
+
+fn appendOwnedCertificate(
+    allocator: std.mem.Allocator,
+    owned_certs: *std.ArrayList(pem.Certificate),
+    parsed_anchors: *std.ArrayList(x509.Certificate),
+    certificate: pem.Certificate,
+    limits: Limits,
+) Error!void {
+    var owned = certificate;
+    if (containsDer(owned_certs.items, owned.der)) {
+        owned.deinit(allocator);
+        return;
+    }
+    if (owned_certs.items.len >= limits.max_anchors) {
+        owned.deinit(allocator);
+        return error.TooManyAnchors;
+    }
+
+    var parsed = x509.Certificate.parse(allocator, owned.der, limits.parser) catch |err| {
+        owned.deinit(allocator);
+        return err;
+    };
+    if (!isCaAnchor(&parsed)) {
+        parsed.deinit(allocator);
+        owned.deinit(allocator);
+        return error.NonCaAnchor;
+    }
+
+    owned_certs.append(allocator, owned) catch |err| {
+        parsed.deinit(allocator);
+        owned.deinit(allocator);
+        return err;
+    };
+    parsed_anchors.append(allocator, parsed) catch |err| {
+        parsed.deinit(allocator);
+        return err;
+    };
+}
+
+fn containsDer(owned_certs: []const pem.Certificate, der_bytes: []const u8) bool {
+    for (owned_certs) |certificate| {
+        if (std.mem.eql(u8, certificate.der, der_bytes)) return true;
+    }
+    return false;
+}
+
+fn isCaAnchor(certificate: *const x509.Certificate) bool {
+    const constraints = certificate.basicConstraints() orelse return false;
+    return constraints.is_ca;
+}
+
+fn finishSnapshot(
+    allocator: std.mem.Allocator,
+    owned_certs: *std.ArrayList(pem.Certificate),
+    parsed_anchors: *std.ArrayList(x509.Certificate),
+    parser_limits: x509.Limits,
+) Error!Snapshot {
+    const owned_slice = try owned_certs.toOwnedSlice(allocator);
+    errdefer {
+        for (owned_slice) |*certificate| certificate.deinit(allocator);
+        allocator.free(owned_slice);
+    }
+    const parsed_slice = try parsed_anchors.toOwnedSlice(allocator);
+    return .{
+        .owned_certs = owned_slice,
+        .parsed_anchors = parsed_slice,
+        .parser_limits = parser_limits,
+    };
+}
+
+fn deinitOwnedArrayList(list: *std.ArrayList(pem.Certificate), allocator: std.mem.Allocator) void {
+    for (list.items) |*certificate| certificate.deinit(allocator);
+    list.deinit(allocator);
+}
+
+fn deinitParsedArrayList(list: *std.ArrayList(x509.Certificate), allocator: std.mem.Allocator) void {
+    for (list.items) |*certificate| certificate.deinit(allocator);
+    list.deinit(allocator);
+}

--- a/src/pki/trust_store_tests.zig
+++ b/src/pki/trust_store_tests.zig
@@ -15,7 +15,6 @@ const name_constraints_leaf_pem = @embedFile("testdata/name_constraints/dns-good
 const openssl_root_pem = @embedFile("testdata/path_validator_ed25519_root.crt");
 const openssl_leaf_pem = @embedFile("testdata/path_validator_ed25519_leaf.crt");
 const validation_time_name_constraints: i64 = 1_784_332_800; // 2026-07-18T00:00:00Z
-const validation_time_direct_anchor: i64 = 1_782_864_000; // 2026-07-01T00:00:00Z
 
 const LoadedCertificate = struct {
     pem_certificate: pem.Certificate,
@@ -100,6 +99,10 @@ fn minimalCertDer(n: u8) [5]u8 {
     return .{ 0x30, 0x03, 0x02, 0x01, n };
 }
 
+fn concatPemBundle(allocator: std.mem.Allocator, parts: []const []const u8) ![]u8 {
+    return std.mem.concat(allocator, u8, parts);
+}
+
 test "snapshot loads mixed PEM and DER bundles with exact-DER dedup" {
     var primary_root = try loadFixture(testing.allocator, name_constraints_root_pem);
     defer primary_root.deinit(testing.allocator);
@@ -144,6 +147,42 @@ test "snapshot rejects malformed, non-CA, and empty anchor sets typed" {
         testing.allocator,
         &empty_inputs,
         .{},
+    ));
+}
+
+test "multi-certificate PEM bundle returns NonCaAnchor without leaking trailing entries" {
+    const bundle = try concatPemBundle(testing.allocator, &.{
+        name_constraints_root_pem,
+        openssl_leaf_pem,
+        openssl_root_pem,
+    });
+    defer testing.allocator.free(bundle);
+
+    const inputs = [_]trust_store.BufferInput{
+        .{ .pem = bundle },
+    };
+    try testing.expectError(error.NonCaAnchor, trust_store.Snapshot.loadBuffers(
+        testing.allocator,
+        &inputs,
+        .{},
+    ));
+}
+
+test "multi-certificate PEM bundle returns TooManyAnchors without leaking trailing entries" {
+    const bundle = try concatPemBundle(testing.allocator, &.{
+        name_constraints_root_pem,
+        openssl_root_pem,
+        name_constraints_root_pem,
+    });
+    defer testing.allocator.free(bundle);
+
+    const inputs = [_]trust_store.BufferInput{
+        .{ .pem = bundle },
+    };
+    try testing.expectError(error.TooManyAnchors, trust_store.Snapshot.loadBuffers(
+        testing.allocator,
+        &inputs,
+        .{ .max_anchors = 1 },
     ));
 }
 

--- a/src/pki/trust_store_tests.zig
+++ b/src/pki/trust_store_tests.zig
@@ -1,0 +1,223 @@
+//! Trust-store ownership, reload, and bundle-loading tests (#346).
+
+const std = @import("std");
+const crypto = @import("crypto");
+const path_builder = @import("path_builder.zig");
+const path_validator = @import("path_validator.zig");
+const pem = @import("pem.zig");
+const trust_store = @import("trust_store.zig");
+const x509 = @import("x509.zig");
+
+const testing = std.testing;
+const name_constraints_root_pem = @embedFile("testdata/name_constraints/root.crt");
+const name_constraints_intermediate_pem = @embedFile("testdata/name_constraints/intermediate.crt");
+const name_constraints_leaf_pem = @embedFile("testdata/name_constraints/dns-good.crt");
+const openssl_root_pem = @embedFile("testdata/path_validator_ed25519_root.crt");
+const openssl_leaf_pem = @embedFile("testdata/path_validator_ed25519_leaf.crt");
+const validation_time_name_constraints: i64 = 1_784_332_800; // 2026-07-18T00:00:00Z
+const validation_time_direct_anchor: i64 = 1_782_864_000; // 2026-07-01T00:00:00Z
+
+const LoadedCertificate = struct {
+    pem_certificate: pem.Certificate,
+    certificate: x509.Certificate,
+
+    fn deinit(self: *LoadedCertificate, allocator: std.mem.Allocator) void {
+        self.certificate.deinit(allocator);
+        self.pem_certificate.deinit(allocator);
+        self.* = undefined;
+    }
+};
+
+fn loadFixture(allocator: std.mem.Allocator, pem_text: []const u8) !LoadedCertificate {
+    var pem_certificate = try pem.loadCertificatePem(allocator, pem_text, .{});
+    errdefer pem_certificate.deinit(allocator);
+    const certificate = try x509.Certificate.parse(allocator, pem_certificate.der, .{});
+    return .{ .pem_certificate = pem_certificate, .certificate = certificate };
+}
+
+fn cryptoProvider(
+    entropy: *crypto.pure_zig.DeterministicEntropy,
+    provider: *crypto.pure_zig.Provider,
+) crypto.provider.CryptoProvider {
+    entropy.* = crypto.pure_zig.DeterministicEntropy.init(0x346);
+    provider.* = crypto.pure_zig.Provider.init(entropy.entropy());
+    return provider.cryptoProvider();
+}
+
+fn expectAccepted(
+    allocator: std.mem.Allocator,
+    leaf: *const x509.Certificate,
+    intermediates: []const x509.Certificate,
+    anchors: []const x509.Certificate,
+    validation_time: i64,
+) !void {
+    var candidates = try path_builder.build(allocator, leaf, intermediates, anchors, .{});
+    defer candidates.deinit(allocator);
+
+    var entropy: crypto.pure_zig.DeterministicEntropy = undefined;
+    var provider: crypto.pure_zig.Provider = undefined;
+    var result = path_validator.validateCandidates(
+        allocator,
+        candidates,
+        .{
+            .validation_time = validation_time,
+            .trust_anchors = anchors,
+        },
+        cryptoProvider(&entropy, &provider),
+    );
+    defer result.deinit(allocator);
+    try testing.expect(result == .accepted);
+}
+
+fn expectDirectAnchorAccepted(
+    allocator: std.mem.Allocator,
+    leaf: *const x509.Certificate,
+    anchors: []const x509.Certificate,
+    validation_time: i64,
+    expected_dns_name: []const u8,
+) !void {
+    const elements = [_]path_builder.Element{
+        .{ .certificate = leaf, .source = .leaf, .input_index = 0 },
+        .{ .certificate = &anchors[0], .source = .anchor, .input_index = 0 },
+    };
+    var entropy: crypto.pure_zig.DeterministicEntropy = undefined;
+    var provider: crypto.pure_zig.Provider = undefined;
+    var result = path_validator.validatePath(
+        allocator,
+        .{ .elements = &elements },
+        .{
+            .validation_time = validation_time,
+            .expected_dns_name = expected_dns_name,
+            .trust_anchors = anchors,
+        },
+        cryptoProvider(&entropy, &provider),
+    );
+    defer result.deinit(allocator);
+    try testing.expect(result == .accepted);
+}
+
+fn minimalCertDer(n: u8) [5]u8 {
+    return .{ 0x30, 0x03, 0x02, 0x01, n };
+}
+
+test "snapshot loads mixed PEM and DER bundles with exact-DER dedup" {
+    var primary_root = try loadFixture(testing.allocator, name_constraints_root_pem);
+    defer primary_root.deinit(testing.allocator);
+    var alternate_root = try loadFixture(testing.allocator, openssl_root_pem);
+    defer alternate_root.deinit(testing.allocator);
+
+    const inputs = [_]trust_store.BufferInput{
+        .{ .pem = name_constraints_root_pem },
+        .{ .der = alternate_root.pem_certificate.der },
+        .{ .pem = name_constraints_root_pem },
+    };
+    var snapshot = try trust_store.Snapshot.loadBuffers(testing.allocator, &inputs, .{});
+    defer snapshot.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 2), snapshot.anchors().len);
+    try testing.expectEqualSlices(u8, primary_root.pem_certificate.der, snapshot.anchors()[0].raw);
+    try testing.expectEqualSlices(u8, alternate_root.pem_certificate.der, snapshot.anchors()[1].raw);
+}
+
+test "snapshot rejects malformed, non-CA, and empty anchor sets typed" {
+    const malformed = minimalCertDer(1);
+    const malformed_inputs = [_]trust_store.BufferInput{
+        .{ .der = &malformed },
+    };
+    try testing.expectError(error.MalformedCertificate, trust_store.Snapshot.loadBuffers(
+        testing.allocator,
+        &malformed_inputs,
+        .{},
+    ));
+
+    const non_ca_inputs = [_]trust_store.BufferInput{
+        .{ .pem = openssl_leaf_pem },
+    };
+    try testing.expectError(error.NonCaAnchor, trust_store.Snapshot.loadBuffers(
+        testing.allocator,
+        &non_ca_inputs,
+        .{},
+    ));
+
+    const empty_inputs = [_]trust_store.BufferInput{};
+    try testing.expectError(error.NoTrustAnchors, trust_store.Snapshot.loadBuffers(
+        testing.allocator,
+        &empty_inputs,
+        .{},
+    ));
+}
+
+test "file-backed bundle loader indexes PEM and DER trust anchors" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var alternate_root = try loadFixture(testing.allocator, openssl_root_pem);
+    defer alternate_root.deinit(testing.allocator);
+
+    try tmp.dir.writeFile(io, .{ .sub_path = "roots.pem", .data = name_constraints_root_pem });
+    try tmp.dir.writeFile(io, .{ .sub_path = "alt-root.der", .data = alternate_root.pem_certificate.der });
+
+    const inputs = [_]trust_store.FileInput{
+        .{ .pem = "roots.pem" },
+        .{ .der = "alt-root.der" },
+    };
+    var snapshot = try trust_store.Snapshot.loadFiles(testing.allocator, io, tmp.dir, &inputs, .{});
+    defer snapshot.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 2), snapshot.anchors().len);
+}
+
+test "bundle store snapshots survive reload and validate the matching chains" {
+    var nc_intermediate = try loadFixture(testing.allocator, name_constraints_intermediate_pem);
+    defer nc_intermediate.deinit(testing.allocator);
+    var nc_leaf = try loadFixture(testing.allocator, name_constraints_leaf_pem);
+    defer nc_leaf.deinit(testing.allocator);
+    var direct_leaf = try loadFixture(testing.allocator, openssl_leaf_pem);
+    defer direct_leaf.deinit(testing.allocator);
+
+    const initial_inputs = [_]trust_store.BufferInput{
+        .{ .pem = name_constraints_root_pem },
+    };
+    var store = try trust_store.BundleStore.initBuffers(testing.allocator, &initial_inputs, .{});
+    defer store.deinit(testing.allocator);
+
+    const provider = store.provider();
+    var first_snapshot = try provider.snapshot(testing.allocator);
+    defer first_snapshot.deinit(testing.allocator);
+
+    const name_constraints_intermediates = [_]x509.Certificate{nc_intermediate.certificate};
+    try expectAccepted(
+        testing.allocator,
+        &nc_leaf.certificate,
+        &name_constraints_intermediates,
+        first_snapshot.anchors(),
+        validation_time_name_constraints,
+    );
+
+    const reloaded_inputs = [_]trust_store.BufferInput{
+        .{ .pem = openssl_root_pem },
+    };
+    try store.reloadBuffers(testing.allocator, &reloaded_inputs, .{});
+
+    var second_snapshot = try provider.snapshot(testing.allocator);
+    defer second_snapshot.deinit(testing.allocator);
+
+    try expectAccepted(
+        testing.allocator,
+        &nc_leaf.certificate,
+        &name_constraints_intermediates,
+        first_snapshot.anchors(),
+        validation_time_name_constraints,
+    );
+    try expectDirectAnchorAccepted(
+        testing.allocator,
+        &direct_leaf.certificate,
+        second_snapshot.anchors(),
+        validation_time_name_constraints,
+        "openssl.example.com",
+    );
+    try testing.expectEqual(@as(usize, 1), first_snapshot.anchors().len);
+    try testing.expectEqual(@as(usize, 1), second_snapshot.anchors().len);
+    try testing.expect(!std.mem.eql(u8, first_snapshot.anchors()[0].raw, second_snapshot.anchors()[0].raw));
+}


### PR DESCRIPTION
## Summary
- add a provider-neutral `pki.trust_store` module with immutable trust-anchor snapshots and a PEM/DER-backed `BundleStore`
- enforce exact-DER deduplication, typed malformed/non-CA anchor rejection, and reload-safe snapshot ownership
- cover mixed/file-backed loads plus reload-safe validation flows in new `test-pki` coverage

## Testing
- `zig fmt --check build.zig src/ tests/`
- `git diff --check`
- `zig build test-pki --summary all --error-style verbose`
- `zig build test --summary all --error-style verbose`

Closes #346
