### PR TITLE
test(pki): bound differential validator processes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,10 @@ processes. Stable corpus runs enforce a 10 second per-validator deadline with
 bounded stdout/stderr capture; the extended target uses a separately bounded
 30 second deadline for larger hostile-corpus cases. Child timeouts, crashes,
 launch failures, malformed validator output, or output-limit violations are
-harness failures, not ordinary certificate rejections.
+harness failures, not ordinary certificate rejections. The Go crypto/x509
+oracle is built once as a test helper and invoked directly; use
+`zig build -Dgo-bin=/path/to/go test-pki-differential` when a non-default Go
+tool is required.
 
 ## Failure-mode harness
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,13 @@ zig build test-quic
 zig build -Doptimize=ReleaseFast
 ```
 
+The PKI differential harness invokes OpenSSL and Go as argv-spawned child
+processes. Stable corpus runs enforce a 10 second per-validator deadline with
+bounded stdout/stderr capture; the extended target uses a separately bounded
+30 second deadline for larger hostile-corpus cases. Child timeouts, crashes,
+launch failures, malformed validator output, or output-limit violations are
+harness failures, not ordinary certificate rejections.
+
 ## Failure-mode harness
 
 `zig build test-failure` runs the production-safety suite defined in

--- a/build.zig
+++ b/build.zig
@@ -456,6 +456,22 @@ pub fn build(b: *std.Build) void {
     // OpenSSL and Go crypto/x509 are invoked as independent processes. These
     // targets stay opt-in because the external validators are test tools, not
     // production dependencies.
+    const pki_process_helper_mod = b.createModule(.{
+        .root_source_file = b.path("tests/pki_process_helper.zig"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    const pki_process_helper = b.addExecutable(.{
+        .name = "pki_process_helper",
+        .root_module = pki_process_helper_mod,
+    });
+    const pki_process_helper_install = b.addInstallArtifact(pki_process_helper, .{});
+    const pki_diff_options = b.addOptions();
+    pki_diff_options.addOption([]const u8, "process_helper_path", b.getInstallPath(.bin, "pki_process_helper"));
+    pki_diff_options.addOption(u32, "stable_validator_deadline_ms", 10_000);
+    pki_diff_options.addOption(u32, "extended_validator_deadline_ms", 30_000);
+
     const pki_differential_mod = b.createModule(.{
         .root_source_file = b.path("tests/pki_differential.zig"),
         .target = target,
@@ -464,6 +480,7 @@ pub fn build(b: *std.Build) void {
     pki_differential_mod.addImport("crypto", crypto_mod);
     pki_differential_mod.addImport("pki", pki_mod);
     pki_differential_mod.addImport("zig_compat", compat_mod);
+    pki_differential_mod.addImport("pki_diff_options", pki_diff_options.createModule());
     pki_differential_mod.addAnonymousImport("pki_root_crt", .{
         .root_source_file = b.path("tests/vectors/pki/root.crt"),
     });
@@ -501,6 +518,7 @@ pub fn build(b: *std.Build) void {
         .filters = &.{"pki reduce"},
     });
     const run_pki_reduce_tests = b.addRunArtifact(pki_reduce_tests);
+    run_pki_reduce_tests.step.dependOn(&pki_process_helper_install.step);
     const pki_reduce_step = b.step("test-pki-reduce", "Run offline PKI mismatch-minimization tests");
     pki_reduce_step.dependOn(&run_pki_reduce_tests.step);
     test_step.dependOn(&run_pki_reduce_tests.step);

--- a/build.zig
+++ b/build.zig
@@ -475,6 +475,7 @@ pub fn build(b: *std.Build) void {
     const pki_diff_options = b.addOptions();
     pki_diff_options.addOption([]const u8, "process_helper_path", b.getInstallPath(.bin, "pki_process_helper"));
     pki_diff_options.addOption([]const u8, "go_validator_path", b.getInstallPath(.bin, "pki_go_validator"));
+    pki_diff_options.addOption([]const u8, "go_bin", go_bin);
     pki_diff_options.addOption(u32, "stable_validator_deadline_ms", 10_000);
     pki_diff_options.addOption(u32, "extended_validator_deadline_ms", 30_000);
 

--- a/build.zig
+++ b/build.zig
@@ -17,6 +17,7 @@ pub fn build(b: *std.Build) void {
     const require_static_system_libs = b.option(bool, "require-static-system-libs", "Require static linking for system libraries") orelse false;
     const static_executable = b.option(bool, "static-executable", "Build the tardi executable as a static binary") orelse false;
     const app_version = b.option([]const u8, "version", "Version string embedded in the tardi binary") orelse "dev";
+    const go_bin = b.option([]const u8, "go-bin", "Go command used to build the PKI crypto/x509 oracle") orelse "go";
     const tls_profile = b.option(
         TlsProfile,
         "tls-profile",
@@ -467,8 +468,13 @@ pub fn build(b: *std.Build) void {
         .root_module = pki_process_helper_mod,
     });
     const pki_process_helper_install = b.addInstallArtifact(pki_process_helper, .{});
+    const pki_go_validator_build = b.addSystemCommand(&.{ go_bin, "build", "-trimpath", "-o" });
+    const pki_go_validator_output = pki_go_validator_build.addOutputFileArg("pki_go_validator");
+    pki_go_validator_build.addFileArg(b.path("tests/pki_go_validator.go"));
+    const pki_go_validator_install = b.addInstallBinFile(pki_go_validator_output, "pki_go_validator");
     const pki_diff_options = b.addOptions();
     pki_diff_options.addOption([]const u8, "process_helper_path", b.getInstallPath(.bin, "pki_process_helper"));
+    pki_diff_options.addOption([]const u8, "go_validator_path", b.getInstallPath(.bin, "pki_go_validator"));
     pki_diff_options.addOption(u32, "stable_validator_deadline_ms", 10_000);
     pki_diff_options.addOption(u32, "extended_validator_deadline_ms", 30_000);
 
@@ -499,6 +505,7 @@ pub fn build(b: *std.Build) void {
         .filters = &.{"pki differential core corpus"},
     });
     const run_pki_differential_core_tests = b.addRunArtifact(pki_differential_core_tests);
+    run_pki_differential_core_tests.step.dependOn(&pki_go_validator_install.step);
     const pki_differential_step = b.step("test-pki-differential", "Run stable PKI differential corpus against OpenSSL and Go");
     pki_differential_step.dependOn(&run_pki_differential_core_tests.step);
 
@@ -507,6 +514,7 @@ pub fn build(b: *std.Build) void {
         .filters = &.{"pki differential full corpus"},
     });
     const run_pki_differential_full_tests = b.addRunArtifact(pki_differential_full_tests);
+    run_pki_differential_full_tests.step.dependOn(&pki_go_validator_install.step);
     const pki_differential_extended_step = b.step("test-pki-differential-extended", "Run full PKI differential corpus against OpenSSL and Go");
     pki_differential_extended_step.dependOn(&run_pki_differential_full_tests.step);
 

--- a/tests/bounded_process.zig
+++ b/tests/bounded_process.zig
@@ -60,10 +60,13 @@ pub const Result = struct {
 
 pub fn run(allocator: std.mem.Allocator, options: Options) std.mem.Allocator.Error!Result {
     const io = compat.io();
-    const deadline_end_ms: ?i64 = if (options.deadline_ms == 0)
+    const deadline_end: ?std.Io.Clock.Timestamp = if (options.deadline_ms == 0)
         null
     else
-        compat.milliTimestamp() + @as(i64, @intCast(options.deadline_ms));
+        std.Io.Clock.Timestamp.fromNow(io, .{
+            .raw = .fromMilliseconds(options.deadline_ms),
+            .clock = .awake,
+        });
     var child = std.process.spawn(io, .{
         .argv = options.argv,
         .stdin = .ignore,
@@ -74,8 +77,9 @@ pub fn run(allocator: std.mem.Allocator, options: Options) std.mem.Allocator.Err
     }) catch |err| {
         return launchFailureResult(allocator, "launch failed: {s}", .{@errorName(err)});
     };
+    const pgid = child.id.?;
     var reaped = false;
-    defer if (!reaped) child.kill(io);
+    defer if (!reaped) reapProcessGroup(&child, pgid);
 
     var multi_reader_buffer: std.Io.File.MultiReader.Buffer(2) = undefined;
     var multi_reader: std.Io.File.MultiReader = undefined;
@@ -85,16 +89,17 @@ pub fn run(allocator: std.mem.Allocator, options: Options) std.mem.Allocator.Err
 
     const stdout_reader = multi_reader.reader(0);
     const stderr_reader = multi_reader.reader(1);
-    const deadline = if (options.deadline_ms == 0)
-        std.Io.Timeout.none
+    const deadline: std.Io.Timeout = if (deadline_end) |timestamp|
+        .{ .deadline = timestamp }
     else
-        (std.Io.Timeout{ .duration = .{ .raw = .fromMilliseconds(options.deadline_ms), .clock = .awake } }).toDeadline(io);
+        std.Io.Timeout.none;
 
     while (multi_reader.fill(64, deadline)) |_| {
         if (stdout_reader.buffered().len > options.stdout_limit) {
             return killedResult(
                 allocator,
                 &child,
+                pgid,
                 &reaped,
                 &multi_reader,
                 &reader_active,
@@ -107,6 +112,7 @@ pub fn run(allocator: std.mem.Allocator, options: Options) std.mem.Allocator.Err
             return killedResult(
                 allocator,
                 &child,
+                pgid,
                 &reaped,
                 &multi_reader,
                 &reader_active,
@@ -120,6 +126,7 @@ pub fn run(allocator: std.mem.Allocator, options: Options) std.mem.Allocator.Err
         error.Timeout => return killedResult(
             allocator,
             &child,
+            pgid,
             &reaped,
             &multi_reader,
             &reader_active,
@@ -130,6 +137,7 @@ pub fn run(allocator: std.mem.Allocator, options: Options) std.mem.Allocator.Err
         else => return killedResult(
             allocator,
             &child,
+            pgid,
             &reaped,
             &multi_reader,
             &reader_active,
@@ -144,6 +152,7 @@ pub fn run(allocator: std.mem.Allocator, options: Options) std.mem.Allocator.Err
         else => return killedResult(
             allocator,
             &child,
+            pgid,
             &reaped,
             &multi_reader,
             &reader_active,
@@ -153,7 +162,9 @@ pub fn run(allocator: std.mem.Allocator, options: Options) std.mem.Allocator.Err
         ),
     };
 
-    const term = waitForExit(&child, deadline_end_ms) catch |err| {
+    const term = waitForExit(&child, pgid, deadline_end) catch |err| {
+        reapProcessGroup(&child, pgid);
+        reaped = true;
         return failureFromBuffered(
             allocator,
             &multi_reader,
@@ -166,6 +177,7 @@ pub fn run(allocator: std.mem.Allocator, options: Options) std.mem.Allocator.Err
     } orelse return killedResult(
         allocator,
         &child,
+        pgid,
         &reaped,
         &multi_reader,
         &reader_active,
@@ -200,11 +212,15 @@ pub fn run(allocator: std.mem.Allocator, options: Options) std.mem.Allocator.Err
     };
 }
 
-fn waitForExit(child: *std.process.Child, deadline_end_ms: ?i64) !?std.process.Child.Term {
+fn waitForExit(
+    child: *std.process.Child,
+    pgid: std.posix.pid_t,
+    deadline_end: ?std.Io.Clock.Timestamp,
+) !?std.process.Child.Term {
     const pid = child.id.?;
-    if (deadline_end_ms == null) {
+    if (deadline_end == null) {
         const term = try child.wait(compat.io());
-        terminateProcessGroup(pid);
+        terminateProcessGroup(pgid);
         return term;
     }
 
@@ -217,10 +233,10 @@ fn waitForExit(child: *std.process.Child, deadline_end_ms: ?i64) !?std.process.C
         if (waited == pid) {
             child.id = null;
             closeChildPipes(child);
-            terminateProcessGroup(pid);
+            terminateProcessGroup(pgid);
             return statusToTerm(@bitCast(status));
         }
-        if (compat.milliTimestamp() >= deadline_end_ms.?) return null;
+        if (std.Io.Clock.Timestamp.now(compat.io(), .awake).compare(.gte, deadline_end.?)) return null;
         compat.sleepNs(10 * std.time.ns_per_ms);
     }
 }
@@ -284,6 +300,7 @@ fn launchFailureResult(
 fn killedResult(
     allocator: std.mem.Allocator,
     child: *std.process.Child,
+    pgid: std.posix.pid_t,
     reaped: *bool,
     multi_reader: *std.Io.File.MultiReader,
     reader_active: *bool,
@@ -291,21 +308,26 @@ fn killedResult(
     stdout_limit: usize,
     stderr_limit: usize,
 ) std.mem.Allocator.Error!Result {
+    reapProcessGroup(child, pgid);
+    reaped.* = true;
+
     const stdout = try boundedDupe(allocator, multi_reader.reader(0).buffered(), stdout_limit);
     errdefer allocator.free(stdout);
     const stderr = try boundedDupe(allocator, multi_reader.reader(1).buffered(), stderr_limit);
     errdefer allocator.free(stderr);
     reader_active.* = false;
     multi_reader.deinit();
-    terminateProcessGroup(child.id.?);
-    child.kill(compat.io());
-    reaped.* = true;
     return .{
         .outcome = outcome,
         .stdout = stdout,
         .stderr = stderr,
         .diagnostic = try diagnosticFor(allocator, outcome, stdout, stderr),
     };
+}
+
+fn reapProcessGroup(child: *std.process.Child, pgid: std.posix.pid_t) void {
+    terminateProcessGroup(pgid);
+    child.kill(compat.io());
 }
 
 fn terminateProcessGroup(pid: std.posix.pid_t) void {

--- a/tests/bounded_process.zig
+++ b/tests/bounded_process.zig
@@ -1,0 +1,277 @@
+const std = @import("std");
+const compat = @import("zig_compat");
+
+pub const default_deadline_ms: u32 = 10_000;
+pub const extended_deadline_ms: u32 = 30_000;
+
+pub const Outcome = union(enum) {
+    normal_exit: u8,
+    launch_failure,
+    timeout,
+    signal: std.posix.SIG,
+    unexpected_exit_code: u8,
+    stdout_limit_exceeded,
+    stderr_limit_exceeded,
+    malformed_validator_output,
+};
+
+pub const Options = struct {
+    argv: []const []const u8,
+    stdout_limit: usize,
+    stderr_limit: usize,
+    deadline_ms: u32 = default_deadline_ms,
+    accepted_exit_codes: []const u8 = &.{0},
+    cwd: std.process.Child.Cwd = .inherit,
+};
+
+pub const Result = struct {
+    outcome: Outcome,
+    stdout: []u8,
+    stderr: []u8,
+    diagnostic: []u8,
+
+    pub fn deinit(self: *Result, allocator: std.mem.Allocator) void {
+        allocator.free(self.stdout);
+        allocator.free(self.stderr);
+        allocator.free(self.diagnostic);
+        self.* = undefined;
+    }
+
+    pub fn malformedValidatorOutput(
+        allocator: std.mem.Allocator,
+        stdout: []const u8,
+        stderr: []const u8,
+        comptime fmt: []const u8,
+        args: anytype,
+    ) !Result {
+        const owned_stdout = try boundedDupe(allocator, stdout, 2048);
+        errdefer allocator.free(owned_stdout);
+        const owned_stderr = try boundedDupe(allocator, stderr, 2048);
+        errdefer allocator.free(owned_stderr);
+        return .{
+            .outcome = .malformed_validator_output,
+            .stdout = owned_stdout,
+            .stderr = owned_stderr,
+            .diagnostic = try std.fmt.allocPrint(allocator, fmt, args),
+        };
+    }
+};
+
+pub fn run(allocator: std.mem.Allocator, options: Options) std.mem.Allocator.Error!Result {
+    const io = compat.io();
+    var child = std.process.spawn(io, .{
+        .argv = options.argv,
+        .stdin = .ignore,
+        .stdout = .pipe,
+        .stderr = .pipe,
+        .cwd = options.cwd,
+    }) catch |err| {
+        return launchFailureResult(allocator, "launch failed: {s}", .{@errorName(err)});
+    };
+    var reaped = false;
+    defer if (!reaped) child.kill(io);
+
+    var multi_reader_buffer: std.Io.File.MultiReader.Buffer(2) = undefined;
+    var multi_reader: std.Io.File.MultiReader = undefined;
+    multi_reader.init(allocator, io, multi_reader_buffer.toStreams(), &.{ child.stdout.?, child.stderr.? });
+    var reader_active = true;
+    defer if (reader_active) multi_reader.deinit();
+
+    const stdout_reader = multi_reader.reader(0);
+    const stderr_reader = multi_reader.reader(1);
+    const deadline = if (options.deadline_ms == 0)
+        std.Io.Timeout.none
+    else
+        (std.Io.Timeout{ .duration = .{ .raw = .fromMilliseconds(options.deadline_ms), .clock = .awake } }).toDeadline(io);
+
+    while (multi_reader.fill(64, deadline)) |_| {
+        if (stdout_reader.buffered().len > options.stdout_limit) {
+            return killedResult(
+                allocator,
+                &child,
+                &reaped,
+                &multi_reader,
+                &reader_active,
+                .stdout_limit_exceeded,
+                options.stdout_limit,
+                options.stderr_limit,
+            );
+        }
+        if (stderr_reader.buffered().len > options.stderr_limit) {
+            return killedResult(
+                allocator,
+                &child,
+                &reaped,
+                &multi_reader,
+                &reader_active,
+                .stderr_limit_exceeded,
+                options.stdout_limit,
+                options.stderr_limit,
+            );
+        }
+    } else |err| switch (err) {
+        error.EndOfStream => {},
+        error.Timeout => return killedResult(
+            allocator,
+            &child,
+            &reaped,
+            &multi_reader,
+            &reader_active,
+            .timeout,
+            options.stdout_limit,
+            options.stderr_limit,
+        ),
+        else => return killedResult(
+            allocator,
+            &child,
+            &reaped,
+            &multi_reader,
+            &reader_active,
+            .launch_failure,
+            options.stdout_limit,
+            options.stderr_limit,
+        ),
+    }
+
+    multi_reader.checkAnyError() catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return killedResult(
+            allocator,
+            &child,
+            &reaped,
+            &multi_reader,
+            &reader_active,
+            .launch_failure,
+            options.stdout_limit,
+            options.stderr_limit,
+        ),
+    };
+
+    const term = child.wait(io) catch |err| {
+        return failureFromBuffered(
+            allocator,
+            &multi_reader,
+            options.stdout_limit,
+            options.stderr_limit,
+            .launch_failure,
+            "wait failed: {s}",
+            .{@errorName(err)},
+        );
+    };
+    reaped = true;
+
+    const outcome: Outcome = switch (term) {
+        .exited => |code| if (isAcceptedExit(code, options.accepted_exit_codes))
+            .{ .normal_exit = code }
+        else
+            .{ .unexpected_exit_code = code },
+        .signal => |sig| .{ .signal = sig },
+        .stopped => |sig| .{ .signal = sig },
+        .unknown => .launch_failure,
+    };
+
+    const stdout = try multi_reader.toOwnedSlice(0);
+    errdefer allocator.free(stdout);
+    const stderr = try multi_reader.toOwnedSlice(1);
+    errdefer allocator.free(stderr);
+    reader_active = false;
+    multi_reader.deinit();
+
+    return .{
+        .outcome = outcome,
+        .stdout = stdout,
+        .stderr = stderr,
+        .diagnostic = try diagnosticFor(allocator, outcome, stdout, stderr),
+    };
+}
+
+fn launchFailureResult(
+    allocator: std.mem.Allocator,
+    comptime fmt: []const u8,
+    args: anytype,
+) std.mem.Allocator.Error!Result {
+    const stdout = try allocator.dupe(u8, "");
+    errdefer allocator.free(stdout);
+    const stderr = try allocator.dupe(u8, "");
+    errdefer allocator.free(stderr);
+    return .{
+        .outcome = .launch_failure,
+        .stdout = stdout,
+        .stderr = stderr,
+        .diagnostic = try std.fmt.allocPrint(allocator, fmt, args),
+    };
+}
+
+fn killedResult(
+    allocator: std.mem.Allocator,
+    child: *std.process.Child,
+    reaped: *bool,
+    multi_reader: *std.Io.File.MultiReader,
+    reader_active: *bool,
+    outcome: Outcome,
+    stdout_limit: usize,
+    stderr_limit: usize,
+) std.mem.Allocator.Error!Result {
+    const stdout = try boundedDupe(allocator, multi_reader.reader(0).buffered(), stdout_limit);
+    errdefer allocator.free(stdout);
+    const stderr = try boundedDupe(allocator, multi_reader.reader(1).buffered(), stderr_limit);
+    errdefer allocator.free(stderr);
+    reader_active.* = false;
+    multi_reader.deinit();
+    child.kill(compat.io());
+    reaped.* = true;
+    return .{
+        .outcome = outcome,
+        .stdout = stdout,
+        .stderr = stderr,
+        .diagnostic = try diagnosticFor(allocator, outcome, stdout, stderr),
+    };
+}
+
+fn failureFromBuffered(
+    allocator: std.mem.Allocator,
+    multi_reader: *std.Io.File.MultiReader,
+    stdout_limit: usize,
+    stderr_limit: usize,
+    outcome: Outcome,
+    comptime fmt: []const u8,
+    args: anytype,
+) std.mem.Allocator.Error!Result {
+    const stdout = try boundedDupe(allocator, multi_reader.reader(0).buffered(), stdout_limit);
+    errdefer allocator.free(stdout);
+    const stderr = try boundedDupe(allocator, multi_reader.reader(1).buffered(), stderr_limit);
+    errdefer allocator.free(stderr);
+    return .{
+        .outcome = outcome,
+        .stdout = stdout,
+        .stderr = stderr,
+        .diagnostic = try std.fmt.allocPrint(allocator, fmt, args),
+    };
+}
+
+fn diagnosticFor(allocator: std.mem.Allocator, outcome: Outcome, stdout: []const u8, stderr: []const u8) ![]u8 {
+    const preferred = if (stderr.len != 0) stderr else stdout;
+    const trimmed = std.mem.trim(u8, preferred, " \t\r\n");
+    const detail = if (trimmed.len == 0) "no diagnostic" else trimmed[0..@min(trimmed.len, 2048)];
+    return switch (outcome) {
+        .normal_exit => allocator.dupe(u8, detail),
+        .launch_failure => std.fmt.allocPrint(allocator, "process failure: {s}", .{detail}),
+        .timeout => std.fmt.allocPrint(allocator, "process timed out: {s}", .{detail}),
+        .signal => |sig| std.fmt.allocPrint(allocator, "process terminated by signal {d}: {s}", .{ @intFromEnum(sig), detail }),
+        .unexpected_exit_code => |code| std.fmt.allocPrint(allocator, "unexpected exit code {d}: {s}", .{ code, detail }),
+        .stdout_limit_exceeded => std.fmt.allocPrint(allocator, "stdout limit exceeded: {s}", .{detail}),
+        .stderr_limit_exceeded => std.fmt.allocPrint(allocator, "stderr limit exceeded: {s}", .{detail}),
+        .malformed_validator_output => std.fmt.allocPrint(allocator, "malformed validator output: {s}", .{detail}),
+    };
+}
+
+fn boundedDupe(allocator: std.mem.Allocator, bytes: []const u8, limit: usize) ![]u8 {
+    return allocator.dupe(u8, bytes[0..@min(bytes.len, limit)]);
+}
+
+fn isAcceptedExit(code: u8, accepted: []const u8) bool {
+    for (accepted) |candidate| {
+        if (candidate == code) return true;
+    }
+    return false;
+}

--- a/tests/bounded_process.zig
+++ b/tests/bounded_process.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const compat = @import("zig_compat");
 
 pub const default_deadline_ms: u32 = 10_000;
@@ -59,12 +60,17 @@ pub const Result = struct {
 
 pub fn run(allocator: std.mem.Allocator, options: Options) std.mem.Allocator.Error!Result {
     const io = compat.io();
+    const deadline_end_ms: ?i64 = if (options.deadline_ms == 0)
+        null
+    else
+        compat.milliTimestamp() + @as(i64, @intCast(options.deadline_ms));
     var child = std.process.spawn(io, .{
         .argv = options.argv,
         .stdin = .ignore,
         .stdout = .pipe,
         .stderr = .pipe,
         .cwd = options.cwd,
+        .pgid = 0,
     }) catch |err| {
         return launchFailureResult(allocator, "launch failed: {s}", .{@errorName(err)});
     };
@@ -147,7 +153,7 @@ pub fn run(allocator: std.mem.Allocator, options: Options) std.mem.Allocator.Err
         ),
     };
 
-    const term = child.wait(io) catch |err| {
+    const term = waitForExit(&child, deadline_end_ms) catch |err| {
         return failureFromBuffered(
             allocator,
             &multi_reader,
@@ -157,7 +163,16 @@ pub fn run(allocator: std.mem.Allocator, options: Options) std.mem.Allocator.Err
             "wait failed: {s}",
             .{@errorName(err)},
         );
-    };
+    } orelse return killedResult(
+        allocator,
+        &child,
+        &reaped,
+        &multi_reader,
+        &reader_active,
+        .timeout,
+        options.stdout_limit,
+        options.stderr_limit,
+    );
     reaped = true;
 
     const outcome: Outcome = switch (term) {
@@ -183,6 +198,70 @@ pub fn run(allocator: std.mem.Allocator, options: Options) std.mem.Allocator.Err
         .stderr = stderr,
         .diagnostic = try diagnosticFor(allocator, outcome, stdout, stderr),
     };
+}
+
+fn waitForExit(child: *std.process.Child, deadline_end_ms: ?i64) !?std.process.Child.Term {
+    const pid = child.id.?;
+    if (deadline_end_ms == null) {
+        const term = try child.wait(compat.io());
+        terminateProcessGroup(pid);
+        return term;
+    }
+
+    while (true) {
+        var status: if (builtin.link_libc) c_int else u32 = undefined;
+        const waited = waitPidNoHang(pid, &status) catch |err| switch (err) {
+            error.Interrupted => continue,
+            else => return err,
+        };
+        if (waited == pid) {
+            child.id = null;
+            closeChildPipes(child);
+            terminateProcessGroup(pid);
+            return statusToTerm(@bitCast(status));
+        }
+        if (compat.milliTimestamp() >= deadline_end_ms.?) return null;
+        compat.sleepNs(10 * std.time.ns_per_ms);
+    }
+}
+
+fn waitPidNoHang(
+    pid: std.posix.pid_t,
+    status: *if (builtin.link_libc) c_int else u32,
+) error{ Interrupted, WaitFailed }!std.posix.pid_t {
+    const raw = std.posix.system.waitpid(pid, status, std.posix.W.NOHANG);
+    return switch (std.posix.errno(raw)) {
+        .SUCCESS => @intCast(raw),
+        .INTR => error.Interrupted,
+        else => error.WaitFailed,
+    };
+}
+
+fn statusToTerm(status: u32) std.process.Child.Term {
+    return if (std.posix.W.IFEXITED(status))
+        .{ .exited = std.posix.W.EXITSTATUS(status) }
+    else if (std.posix.W.IFSIGNALED(status))
+        .{ .signal = std.posix.W.TERMSIG(status) }
+    else if (std.posix.W.IFSTOPPED(status))
+        .{ .stopped = std.posix.W.STOPSIG(status) }
+    else
+        .{ .unknown = status };
+}
+
+fn closeChildPipes(child: *std.process.Child) void {
+    const io = compat.io();
+    if (child.stdin) |stdin| {
+        stdin.close(io);
+        child.stdin = null;
+    }
+    if (child.stdout) |stdout| {
+        stdout.close(io);
+        child.stdout = null;
+    }
+    if (child.stderr) |stderr| {
+        stderr.close(io);
+        child.stderr = null;
+    }
 }
 
 fn launchFailureResult(
@@ -218,6 +297,7 @@ fn killedResult(
     errdefer allocator.free(stderr);
     reader_active.* = false;
     multi_reader.deinit();
+    terminateProcessGroup(child.id.?);
     child.kill(compat.io());
     reaped.* = true;
     return .{
@@ -225,6 +305,14 @@ fn killedResult(
         .stdout = stdout,
         .stderr = stderr,
         .diagnostic = try diagnosticFor(allocator, outcome, stdout, stderr),
+    };
+}
+
+fn terminateProcessGroup(pid: std.posix.pid_t) void {
+    std.posix.kill(-pid, .KILL) catch |err| switch (err) {
+        error.ProcessNotFound => {},
+        error.PermissionDenied => {},
+        else => {},
     };
 }
 

--- a/tests/pki_differential.zig
+++ b/tests/pki_differential.zig
@@ -19,11 +19,15 @@ const crypto = @import("crypto");
 const pki = @import("pki");
 const manifest = @import("pki_differential_manifest.zig");
 const reduce_mod = @import("pki_reduce.zig");
+const bounded_process = @import("bounded_process.zig");
+const pki_diff_options = @import("pki_diff_options");
 
 const testing = std.testing;
 const validation_time: i64 = 1_784_332_800; // 2026-07-18T00:00:00Z
 const validation_time_argument = std.fmt.comptimePrint("{d}", .{validation_time});
 const max_oracle_output = 64 * 1024;
+const oracle_deadline_ms: u32 = pki_diff_options.stable_validator_deadline_ms;
+const extended_oracle_deadline_ms: u32 = pki_diff_options.extended_validator_deadline_ms;
 const max_fixture_size = 1024 * 1024;
 const default_artifact_dir = "zig-out/pki-differential-artifacts";
 const max_total_reduction_oracle_calls = 512;
@@ -102,6 +106,13 @@ fn observation(
     return .{
         .status = status,
         .diagnostic = try std.fmt.allocPrint(allocator, format, args),
+    };
+}
+
+fn processFailureObservation(allocator: std.mem.Allocator, result: bounded_process.Result) !Observation {
+    return .{
+        .status = .tool_failure,
+        .diagnostic = try allocator.dupe(u8, result.diagnostic[0..@min(result.diagnostic.len, 2048)]),
     };
 }
 
@@ -229,24 +240,22 @@ fn externalDiagnostic(allocator: std.mem.Allocator, stdout: []const u8, stderr: 
 }
 
 fn commandSummary(allocator: std.mem.Allocator, argv: []const []const u8) ![]u8 {
-    const result = std.process.run(allocator, compat.io(), .{
+    var result = try bounded_process.run(allocator, .{
         .argv = argv,
-        .stdout_limit = .limited(2048),
-        .stderr_limit = .limited(2048),
-    }) catch |err| return std.fmt.allocPrint(allocator, "unavailable: {s}", .{@errorName(err)});
-    defer allocator.free(result.stdout);
-    defer allocator.free(result.stderr);
+        .stdout_limit = 2048,
+        .stderr_limit = 2048,
+        .deadline_ms = oracle_deadline_ms,
+    });
+    defer result.deinit(allocator);
 
-    return switch (result.term) {
-        .exited => |code| if (code == 0)
-            externalDiagnostic(allocator, result.stdout, result.stderr)
-        else
-            std.fmt.allocPrint(
-                allocator,
-                "exited {d}: {s}",
-                .{ code, std.mem.trim(u8, if (result.stderr.len != 0) result.stderr else result.stdout, " \t\r\n") },
-            ),
-        else => allocator.dupe(u8, "terminated before producing a version string"),
+    return switch (result.outcome) {
+        .normal_exit => externalDiagnostic(allocator, result.stdout, result.stderr),
+        .unexpected_exit_code => |code| std.fmt.allocPrint(
+            allocator,
+            "exited {d}: {s}",
+            .{ code, std.mem.trim(u8, if (result.stderr.len != 0) result.stderr else result.stdout, " \t\r\n") },
+        ),
+        else => allocator.dupe(u8, result.diagnostic),
     };
 }
 
@@ -275,7 +284,7 @@ fn loadRuntimeIdentity(allocator: std.mem.Allocator) !RuntimeIdentity {
     };
 }
 
-fn opensslDecision(allocator: std.mem.Allocator, case: manifest.Case) !Observation {
+fn opensslDecision(allocator: std.mem.Allocator, case: manifest.Case, deadline_ms: u32) !Observation {
     const openssl = compat.getEnvVarOwned(allocator, "OPENSSL_BIN") catch
         try allocator.dupe(u8, "openssl");
     defer allocator.free(openssl);
@@ -296,16 +305,17 @@ fn opensslDecision(allocator: std.mem.Allocator, case: manifest.Case) !Observati
     if (case.dns_name) |dns_name| try argv.appendSlice(allocator, &.{ "-verify_hostname", dns_name });
     try argv.append(allocator, case.leaf_file);
 
-    const result = std.process.run(allocator, compat.io(), .{
+    var result = try bounded_process.run(allocator, .{
         .argv = argv.items,
-        .stdout_limit = .limited(max_oracle_output),
-        .stderr_limit = .limited(max_oracle_output),
-    }) catch |err| return observation(allocator, .tool_failure, "spawn failed: {s}", .{@errorName(err)});
-    defer allocator.free(result.stdout);
-    defer allocator.free(result.stderr);
+        .stdout_limit = max_oracle_output,
+        .stderr_limit = max_oracle_output,
+        .deadline_ms = deadline_ms,
+        .accepted_exit_codes = &.{ 0, 2 },
+    });
+    defer result.deinit(allocator);
 
-    const status: Status = switch (result.term) {
-        .exited => |code| switch (code) {
+    const status: Status = switch (result.outcome) {
+        .normal_exit => |code| switch (code) {
             0 => .accept,
             // `openssl verify` reserves 2 for a completed verification that
             // rejected the candidate. Usage, file, and setup failures use a
@@ -313,7 +323,7 @@ fn opensslDecision(allocator: std.mem.Allocator, case: manifest.Case) !Observati
             2 => .reject,
             else => .tool_failure,
         },
-        else => .tool_failure,
+        else => return processFailureObservation(allocator, result),
     };
     return .{
         .status = status,
@@ -327,7 +337,7 @@ const GoDecision = struct {
     diagnostic: []const u8,
 };
 
-fn goDecision(allocator: std.mem.Allocator, case: manifest.Case) !Observation {
+fn goDecision(allocator: std.mem.Allocator, case: manifest.Case, deadline_ms: u32) !Observation {
     const go_binary = compat.getEnvVarOwned(allocator, "GO_BIN") catch
         try allocator.dupe(u8, "go");
     defer allocator.free(go_binary);
@@ -350,30 +360,32 @@ fn goDecision(allocator: std.mem.Allocator, case: manifest.Case) !Observation {
     });
     if (case.dns_name) |dns_name| try argv.appendSlice(allocator, &.{ "--dns-name", dns_name });
 
-    const result = std.process.run(allocator, compat.io(), .{
+    var result = try bounded_process.run(allocator, .{
         .argv = argv.items,
-        .stdout_limit = .limited(max_oracle_output),
-        .stderr_limit = .limited(max_oracle_output),
-    }) catch |err| return observation(allocator, .tool_failure, "spawn failed: {s}", .{@errorName(err)});
-    defer allocator.free(result.stdout);
-    defer allocator.free(result.stderr);
+        .stdout_limit = max_oracle_output,
+        .stderr_limit = max_oracle_output,
+        .deadline_ms = deadline_ms,
+    });
+    defer result.deinit(allocator);
 
-    switch (result.term) {
-        .exited => |code| if (code != 0) {
-            return .{
-                .status = .tool_failure,
-                .diagnostic = try externalDiagnostic(allocator, result.stdout, result.stderr),
-            };
-        },
-        else => return .{
-            .status = .tool_failure,
-            .diagnostic = try externalDiagnostic(allocator, result.stdout, result.stderr),
-        },
+    switch (result.outcome) {
+        .normal_exit => {},
+        else => return processFailureObservation(allocator, result),
     }
 
     var parsed = std.json.parseFromSlice(GoDecision, allocator, result.stdout, .{
         .ignore_unknown_fields = false,
-    }) catch |err| return observation(allocator, .tool_failure, "invalid Go oracle JSON: {s}", .{@errorName(err)});
+    }) catch |err| {
+        var malformed = try bounded_process.Result.malformedValidatorOutput(
+            allocator,
+            result.stdout,
+            result.stderr,
+            "malformed Go oracle JSON: {s}",
+            .{@errorName(err)},
+        );
+        defer malformed.deinit(allocator);
+        return processFailureObservation(allocator, malformed);
+    };
     defer parsed.deinit();
     if (!std.mem.eql(u8, parsed.value.validator, "go-crypto-x509")) {
         return observation(allocator, .tool_failure, "unexpected Go oracle identity: {s}", .{parsed.value.validator});
@@ -1045,6 +1057,7 @@ fn verifyReducedCase(
     dir: compat.DirCompat,
     case: manifest.Case,
     paths: *const ReducedPaths,
+    deadline_ms: u32,
 ) !struct { Observation, Observation, Observation } {
     _ = dir;
     var reduced_case = case;
@@ -1053,9 +1066,9 @@ fn verifyReducedCase(
     reduced_case.leaf_file = paths.leaf_file;
     var tardigrade = try tardigradeDecision(allocator, reduced_case);
     errdefer tardigrade.deinit(allocator);
-    var openssl = try opensslDecision(allocator, reduced_case);
+    var openssl = try opensslDecision(allocator, reduced_case, deadline_ms);
     errdefer openssl.deinit(allocator);
-    const go = try goDecision(allocator, reduced_case);
+    const go = try goDecision(allocator, reduced_case, deadline_ms);
     return .{ tardigrade, openssl, go };
 }
 
@@ -1074,18 +1087,20 @@ fn verifyAndPersistReduced(
     case: manifest.Case,
     r: *Reduction,
     original_statuses: [3]Status,
+    deadline_ms: u32,
 ) !ReducedVerification {
-    return verifyAndPersistReducedWithVerifier(verifyReducedCase, allocator, dir, artifact_dir, case, r, original_statuses);
+    return verifyAndPersistReducedWithVerifier(verifyReducedCase, allocator, dir, artifact_dir, case, r, original_statuses, deadline_ms);
 }
 
 fn verifyAndPersistReducedWithVerifier(
-    comptime verifier: fn (std.mem.Allocator, compat.DirCompat, manifest.Case, *const ReducedPaths) anyerror!struct { Observation, Observation, Observation },
+    comptime verifier: fn (std.mem.Allocator, compat.DirCompat, manifest.Case, *const ReducedPaths, u32) anyerror!struct { Observation, Observation, Observation },
     allocator: std.mem.Allocator,
     dir: compat.DirCompat,
     artifact_dir: []const u8,
     case: manifest.Case,
     r: *Reduction,
     original_statuses: [3]Status,
+    deadline_ms: u32,
 ) !ReducedVerification {
     var best_index: ?usize = null;
     var best_tardigrade: ?Observation = null;
@@ -1113,7 +1128,7 @@ fn verifyAndPersistReducedWithVerifier(
             deleteProbeFiles(dir, &paths) catch {};
             paths.deinit(allocator);
         };
-        var tardigrade, var openssl, var go = try verifier(allocator, dir, case, &paths);
+        var tardigrade, var openssl, var go = try verifier(allocator, dir, case, &paths, deadline_ms);
         var owns_observations = true;
         errdefer if (owns_observations) {
             tardigrade.deinit(allocator);
@@ -1212,7 +1227,7 @@ fn verifyAndPersistReducedWithVerifier(
     var probe_paths = try persistReducedCase(allocator, dir, artifact_dir, case, r, "fallback-original");
     defer probe_paths.deinit(allocator);
     defer deleteProbeFiles(dir, &probe_paths) catch {};
-    var reverted_tardigrade, var reverted_openssl, var reverted_go = try verifier(allocator, dir, case, &probe_paths);
+    var reverted_tardigrade, var reverted_openssl, var reverted_go = try verifier(allocator, dir, case, &probe_paths, deadline_ms);
     errdefer reverted_tardigrade.deinit(allocator);
     errdefer reverted_openssl.deinit(allocator);
     errdefer reverted_go.deinit(allocator);
@@ -1356,12 +1371,12 @@ fn writeArtifact(
     return path;
 }
 
-fn runCase(allocator: std.mem.Allocator, runtime_identity: RuntimeIdentity, case: manifest.Case) !void {
+fn runCase(allocator: std.mem.Allocator, runtime_identity: RuntimeIdentity, case: manifest.Case, deadline_ms: u32) !void {
     var tardigrade = try tardigradeDecision(allocator, case);
     defer tardigrade.deinit(allocator);
-    var openssl = try opensslDecision(allocator, case);
+    var openssl = try opensslDecision(allocator, case, deadline_ms);
     defer openssl.deinit(allocator);
-    var go = try goDecision(allocator, case);
+    var go = try goDecision(allocator, case, deadline_ms);
     defer go.deinit(allocator);
 
     const matches = tardigrade.status == expectedStatus(case.expected.tardigrade) and
@@ -1381,7 +1396,7 @@ fn runCase(allocator: std.mem.Allocator, runtime_identity: RuntimeIdentity, case
             tardigrade.status,
             openssl.status,
             go.status,
-        }) catch |err| blk: {
+        }, deadline_ms) catch |err| blk: {
             if (err == error.OutOfMemory) return error.OutOfMemory;
             std.debug.print(
                 "failed to persist reduced inputs for {s}: {s}\n",
@@ -1491,7 +1506,8 @@ fn runCorpus(include_extended: bool) !void {
             if (!std.mem.eql(u8, id, case.id)) continue;
         }
         errdefer std.debug.print("failed PKI differential case: {s}\n", .{case.id});
-        try runCase(testing.allocator, runtime_identity, case);
+        const deadline_ms = if (case.profile == .extended) extended_oracle_deadline_ms else oracle_deadline_ms;
+        try runCase(testing.allocator, runtime_identity, case, deadline_ms);
         executed += 1;
     }
     try testing.expect(executed > 0);
@@ -1499,6 +1515,211 @@ fn runCorpus(include_extended: bool) !void {
 
 test "pki differential manifest is bounded and fully normalized" {
     try validateManifest();
+}
+
+fn expectNormalExit(result: bounded_process.Result, expected_code: u8) !void {
+    switch (result.outcome) {
+        .normal_exit => |code| try testing.expectEqual(expected_code, code),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+fn expectOutcomeTag(result: bounded_process.Result, expected: std.meta.Tag(bounded_process.Outcome)) !void {
+    try testing.expectEqual(expected, std.meta.activeTag(result.outcome));
+}
+
+fn parseHelperPid(stdout: []const u8) !std.posix.pid_t {
+    const trimmed = std.mem.trim(u8, stdout, " \t\r\n");
+    if (!std.mem.startsWith(u8, trimmed, "pid=")) return error.InvalidPidLine;
+    return try std.fmt.parseInt(std.posix.pid_t, trimmed["pid=".len..], 10);
+}
+
+fn expectNoProcess(allocator: std.mem.Allocator, pid: std.posix.pid_t) !void {
+    const pid_text = try std.fmt.allocPrint(allocator, "{d}", .{pid});
+    defer allocator.free(pid_text);
+    var result = try bounded_process.run(allocator, .{
+        .argv = &.{ "ps", "-p", pid_text },
+        .stdout_limit = 4096,
+        .stderr_limit = 4096,
+        .deadline_ms = 1000,
+        .accepted_exit_codes = &.{1},
+    });
+    defer result.deinit(allocator);
+    try expectNormalExit(result, 1);
+}
+
+fn expectDirEmpty(dir: std.Io.Dir) !void {
+    var it = dir.iterate();
+    while (try it.next(compat.io())) |entry| {
+        std.debug.print("unexpected temp entry left by bounded process runner: {s}\n", .{entry.name});
+        return error.TestUnexpectedResult;
+    }
+}
+
+test "pki reduce: bounded process captures successful output" {
+    var result = try bounded_process.run(testing.allocator, .{
+        .argv = &.{ pki_diff_options.process_helper_path, "success" },
+        .stdout_limit = 64,
+        .stderr_limit = 64,
+        .deadline_ms = 1000,
+    });
+    defer result.deinit(testing.allocator);
+    try expectNormalExit(result, 0);
+    try testing.expectEqualStrings("ok\n", result.stdout);
+    try testing.expectEqualStrings("", result.stderr);
+}
+
+test "pki reduce: bounded process treats configured nonzero rejection as normal exit" {
+    var result = try bounded_process.run(testing.allocator, .{
+        .argv = &.{ pki_diff_options.process_helper_path, "exit", "2" },
+        .stdout_limit = 64,
+        .stderr_limit = 64,
+        .deadline_ms = 1000,
+        .accepted_exit_codes = &.{ 0, 2 },
+    });
+    defer result.deinit(testing.allocator);
+    try expectNormalExit(result, 2);
+}
+
+test "pki reduce: bounded process reports launch failure" {
+    var result = try bounded_process.run(testing.allocator, .{
+        .argv = &.{"definitely-not-a-tardigrade-test-helper"},
+        .stdout_limit = 64,
+        .stderr_limit = 64,
+        .deadline_ms = 1000,
+    });
+    defer result.deinit(testing.allocator);
+    try expectOutcomeTag(result, .launch_failure);
+}
+
+test "pki reduce: bounded process timeout kills and reaps child" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var result = try bounded_process.run(testing.allocator, .{
+        .argv = &.{ pki_diff_options.process_helper_path, "hang" },
+        .stdout_limit = 64,
+        .stderr_limit = 64,
+        .deadline_ms = 100,
+        .cwd = .{ .dir = tmp.dir },
+    });
+    defer result.deinit(testing.allocator);
+    try expectOutcomeTag(result, .timeout);
+    const pid = try parseHelperPid(result.stdout);
+    try expectNoProcess(testing.allocator, pid);
+    try expectDirEmpty(tmp.dir);
+}
+
+test "pki reduce: bounded process reports abnormal signal termination" {
+    var result = try bounded_process.run(testing.allocator, .{
+        .argv = &.{ pki_diff_options.process_helper_path, "abort" },
+        .stdout_limit = 64,
+        .stderr_limit = 1024,
+        .deadline_ms = 1000,
+    });
+    defer result.deinit(testing.allocator);
+    try expectOutcomeTag(result, .signal);
+}
+
+test "pki reduce: bounded process kills stdout overflow and keeps bounded output" {
+    var result = try bounded_process.run(testing.allocator, .{
+        .argv = &.{ pki_diff_options.process_helper_path, "stdout", "128" },
+        .stdout_limit = 32,
+        .stderr_limit = 64,
+        .deadline_ms = 1000,
+    });
+    defer result.deinit(testing.allocator);
+    try expectOutcomeTag(result, .stdout_limit_exceeded);
+    try testing.expect(result.stdout.len <= 32);
+}
+
+test "pki reduce: bounded process kills stderr overflow and keeps bounded output" {
+    var result = try bounded_process.run(testing.allocator, .{
+        .argv = &.{ pki_diff_options.process_helper_path, "stderr", "128" },
+        .stdout_limit = 64,
+        .stderr_limit = 32,
+        .deadline_ms = 1000,
+    });
+    defer result.deinit(testing.allocator);
+    try expectOutcomeTag(result, .stderr_limit_exceeded);
+    try testing.expect(result.stderr.len <= 32);
+}
+
+fn expectFailureModeLeavesTmpEmpty(argv: []const []const u8, expected: std.meta.Tag(bounded_process.Outcome)) !void {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var result = try bounded_process.run(testing.allocator, .{
+        .argv = argv,
+        .stdout_limit = 32,
+        .stderr_limit = 32,
+        .deadline_ms = 100,
+        .cwd = .{ .dir = tmp.dir },
+    });
+    defer result.deinit(testing.allocator);
+    try expectOutcomeTag(result, expected);
+    try expectDirEmpty(tmp.dir);
+}
+
+test "pki reduce: bounded process leaves no temp files after failure modes" {
+    try expectFailureModeLeavesTmpEmpty(&.{"definitely-not-a-tardigrade-test-helper"}, .launch_failure);
+    try expectFailureModeLeavesTmpEmpty(&.{ pki_diff_options.process_helper_path, "exit", "7" }, .unexpected_exit_code);
+    try expectFailureModeLeavesTmpEmpty(&.{ pki_diff_options.process_helper_path, "stdout", "128" }, .stdout_limit_exceeded);
+    try expectFailureModeLeavesTmpEmpty(&.{ pki_diff_options.process_helper_path, "stderr", "128" }, .stderr_limit_exceeded);
+    try expectFailureModeLeavesTmpEmpty(&.{ pki_diff_options.process_helper_path, "hang" }, .timeout);
+}
+
+test "pki reduce: malformed validator output has a structured outcome" {
+    var raw = try bounded_process.run(testing.allocator, .{
+        .argv = &.{ pki_diff_options.process_helper_path, "malformed" },
+        .stdout_limit = 64,
+        .stderr_limit = 64,
+        .deadline_ms = 1000,
+    });
+    defer raw.deinit(testing.allocator);
+    try expectNormalExit(raw, 0);
+    var malformed = try bounded_process.Result.malformedValidatorOutput(
+        testing.allocator,
+        raw.stdout,
+        raw.stderr,
+        "malformed helper output",
+        .{},
+    );
+    defer malformed.deinit(testing.allocator);
+    try expectOutcomeTag(malformed, .malformed_validator_output);
+}
+
+test "pki reduce: bounded process classification is deterministic" {
+    var first = try bounded_process.run(testing.allocator, .{
+        .argv = &.{ pki_diff_options.process_helper_path, "exit", "7" },
+        .stdout_limit = 64,
+        .stderr_limit = 64,
+        .deadline_ms = 1000,
+    });
+    defer first.deinit(testing.allocator);
+    var second = try bounded_process.run(testing.allocator, .{
+        .argv = &.{ pki_diff_options.process_helper_path, "exit", "7" },
+        .stdout_limit = 64,
+        .stderr_limit = 64,
+        .deadline_ms = 1000,
+    });
+    defer second.deinit(testing.allocator);
+    try expectOutcomeTag(first, .unexpected_exit_code);
+    try expectOutcomeTag(second, .unexpected_exit_code);
+    try testing.expectEqual(std.meta.activeTag(first.outcome), std.meta.activeTag(second.outcome));
+}
+
+test "pki reduce: bounded process allocation failures clean up child state" {
+    try testing.checkAllAllocationFailures(testing.allocator, struct {
+        fn run(allocator: std.mem.Allocator) !void {
+            var result = try bounded_process.run(allocator, .{
+                .argv = &.{ pki_diff_options.process_helper_path, "success" },
+                .stdout_limit = 64,
+                .stderr_limit = 64,
+                .deadline_ms = 1000,
+            });
+            defer result.deinit(allocator);
+            try expectNormalExit(result, 0);
+        }
+    }.run, .{});
 }
 
 // The "pki reduce" tests below are offline: they classify with the in-process
@@ -1766,7 +1987,9 @@ fn fabricatedReducedVerifier(
     dir: compat.DirCompat,
     case: manifest.Case,
     paths: *const ReducedPaths,
+    deadline_ms: u32,
 ) !struct { Observation, Observation, Observation } {
+    _ = deadline_ms;
     const raw = try dir.readFileAlloc(allocator, paths.der_path, 1024);
     defer allocator.free(raw);
     const preserves = if (std.mem.eql(u8, case.id, "artifact-policy-fallback-succeeds"))
@@ -1938,6 +2161,7 @@ test "pki reduce: verification materializes the winning candidate to canonical a
         case,
         &reduction,
         .{ .reject, .reject, .accept },
+        oracle_deadline_ms,
     );
     defer verification.deinit(allocator);
     try testing.expect(verification.preserves);
@@ -2043,6 +2267,7 @@ test "pki reduce: non-reproducing original fallback fails instead of returning a
         case,
         &reduction,
         .{ .reject, .reject, .accept },
+        oracle_deadline_ms,
     ));
     try expectMissing(dir, "artifacts/artifact-policy-fallback-fails.candidate-0.candidate.der");
     try expectMissing(dir, "artifacts/artifact-policy-fallback-fails.candidate-0.candidate.crt");
@@ -2100,6 +2325,7 @@ test "pki reduce: successful original fallback uses the real verification state 
         case,
         &reduction,
         .{ .reject, .reject, .accept },
+        oracle_deadline_ms,
     );
     defer verification.deinit(allocator);
     try testing.expect(verification.preserves);

--- a/tests/pki_differential.zig
+++ b/tests/pki_differential.zig
@@ -1548,16 +1548,40 @@ fn expectNoProcess(allocator: std.mem.Allocator, pid: std.posix.pid_t) !void {
     try expectNormalExit(result, 1);
 }
 
-fn expectDirEmpty(dir: std.Io.Dir) !void {
+const ProcessTempDir = struct {
+    rel_path: []u8,
+    abs_path: []u8,
+
+    fn init(allocator: std.mem.Allocator, label: []const u8) !ProcessTempDir {
+        const rel_path = try std.fmt.allocPrint(
+            allocator,
+            ".zig-cache/pki-process-{s}-{d}",
+            .{ label, compat.nanoTimestamp() },
+        );
+        errdefer allocator.free(rel_path);
+        try compat.cwd().makePath(rel_path);
+        errdefer compat.cwd().deleteTree(rel_path) catch {};
+        const abs_path = try compat.cwd().realpathAlloc(allocator, rel_path);
+        errdefer allocator.free(abs_path);
+        return .{ .rel_path = rel_path, .abs_path = abs_path };
+    }
+
+    fn deinit(self: *ProcessTempDir, allocator: std.mem.Allocator) void {
+        compat.cwd().deleteTree(self.rel_path) catch {};
+        allocator.free(self.rel_path);
+        allocator.free(self.abs_path);
+        self.* = undefined;
+    }
+};
+
+fn expectDirEmptyPath(path: []const u8) !void {
+    var dir = try compat.cwd().openDir(path, .{ .iterate = true });
+    defer dir.close();
     var it = dir.iterate();
     while (try it.next(compat.io())) |entry| {
         std.debug.print("unexpected temp entry left by bounded process runner: {s}\n", .{entry.name});
         return error.TestUnexpectedResult;
     }
-}
-
-fn tmpDirPath(allocator: std.mem.Allocator, tmp: *std.testing.TmpDir) ![]u8 {
-    return compat.wrapDir(tmp.dir).realpathAlloc(allocator, ".");
 }
 
 test "pki reduce: bounded process captures successful output" {
@@ -1597,22 +1621,20 @@ test "pki reduce: bounded process reports launch failure" {
 }
 
 test "pki reduce: bounded process timeout kills and reaps child" {
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-    const tmp_path = try tmpDirPath(testing.allocator, &tmp);
-    defer testing.allocator.free(tmp_path);
+    var tmp = try ProcessTempDir.init(testing.allocator, "timeout");
+    defer tmp.deinit(testing.allocator);
     var result = try bounded_process.run(testing.allocator, .{
         .argv = &.{ pki_diff_options.process_helper_path, "hang" },
         .stdout_limit = 64,
         .stderr_limit = 64,
         .deadline_ms = 100,
-        .cwd = .{ .path = tmp_path },
+        .cwd = .{ .path = tmp.abs_path },
     });
     defer result.deinit(testing.allocator);
     try expectOutcomeTag(result, .timeout);
     const pid = try parseHelperPid(result.stdout);
     try expectNoProcess(testing.allocator, pid);
-    try expectDirEmpty(tmp.dir);
+    try expectDirEmptyPath(tmp.rel_path);
 }
 
 test "pki reduce: bounded process reports abnormal signal termination" {
@@ -1651,20 +1673,18 @@ test "pki reduce: bounded process kills stderr overflow and keeps bounded output
 }
 
 fn expectFailureModeLeavesTmpEmpty(argv: []const []const u8, expected: std.meta.Tag(bounded_process.Outcome)) !void {
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-    const tmp_path = try tmpDirPath(testing.allocator, &tmp);
-    defer testing.allocator.free(tmp_path);
+    var tmp = try ProcessTempDir.init(testing.allocator, @tagName(expected));
+    defer tmp.deinit(testing.allocator);
     var result = try bounded_process.run(testing.allocator, .{
         .argv = argv,
         .stdout_limit = 32,
         .stderr_limit = 32,
         .deadline_ms = 100,
-        .cwd = .{ .path = tmp_path },
+        .cwd = .{ .path = tmp.abs_path },
     });
     defer result.deinit(testing.allocator);
     try expectOutcomeTag(result, expected);
-    try expectDirEmpty(tmp.dir);
+    try expectDirEmptyPath(tmp.rel_path);
 }
 
 test "pki reduce: bounded process leaves no temp files after failure modes" {

--- a/tests/pki_differential.zig
+++ b/tests/pki_differential.zig
@@ -270,10 +270,11 @@ fn loadRuntimeIdentity(allocator: std.mem.Allocator) !RuntimeIdentity {
     const openssl_version = try commandSummary(allocator, &.{ openssl, "version" });
     errdefer allocator.free(openssl_version);
 
-    const go_binary = compat.getEnvVarOwned(allocator, "GO_BIN") catch
-        try allocator.dupe(u8, "go");
-    defer allocator.free(go_binary);
-    const go_version = try commandSummary(allocator, &.{ go_binary, "version" });
+    const go_version = try commandSummary(allocator, &.{
+        pki_diff_options.go_bin,
+        "version",
+        pki_diff_options.go_validator_path,
+    });
     errdefer allocator.free(go_version);
 
     return .{
@@ -1588,6 +1589,31 @@ fn expectDirEmptyPath(path: []const u8) !void {
     }
 }
 
+fn readRecordedPid(allocator: std.mem.Allocator, tmp_path: []const u8, file_name: []const u8) !?std.posix.pid_t {
+    const path = try std.fs.path.join(allocator, &.{ tmp_path, file_name });
+    defer allocator.free(path);
+    const raw = compat.cwd().readFileAlloc(allocator, path, 128) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => return err,
+    };
+    defer allocator.free(raw);
+    return try std.fmt.parseInt(std.posix.pid_t, std.mem.trim(u8, raw, " \t\r\n"), 10);
+}
+
+fn deleteRecordedPidFiles(tmp_path: []const u8) void {
+    var dir = compat.cwd().openDir(tmp_path, .{}) catch return;
+    defer dir.close();
+    dir.deleteFile("parent.pid") catch {};
+    dir.deleteFile("grandchild.pid") catch {};
+}
+
+fn expectRecordedProcessesGone(allocator: std.mem.Allocator, tmp_path: []const u8) !void {
+    const parent_pid = try readRecordedPid(allocator, tmp_path, "parent.pid");
+    const grandchild_pid = try readRecordedPid(allocator, tmp_path, "grandchild.pid");
+    if (parent_pid) |pid| try expectNoProcess(allocator, pid);
+    if (grandchild_pid) |pid| try expectNoProcess(allocator, pid);
+}
+
 test "pki reduce: bounded process captures successful output" {
     var result = try bounded_process.run(testing.allocator, .{
         .argv = &.{ pki_diff_options.process_helper_path, "success" },
@@ -1770,14 +1796,27 @@ test "pki reduce: bounded process classification is deterministic" {
 test "pki reduce: bounded process allocation failures clean up child state" {
     try testing.checkAllAllocationFailures(testing.allocator, struct {
         fn run(allocator: std.mem.Allocator) !void {
-            var result = try bounded_process.run(allocator, .{
-                .argv = &.{ pki_diff_options.process_helper_path, "success" },
+            var tmp = try ProcessTempDir.init(testing.allocator, "allocation-process-group");
+            defer tmp.deinit(testing.allocator);
+
+            var result = bounded_process.run(allocator, .{
+                .argv = &.{ pki_diff_options.process_helper_path, "spawn-grandchild-record-and-hang", tmp.abs_path },
                 .stdout_limit = 64,
                 .stderr_limit = 64,
-                .deadline_ms = 1000,
-            });
+                .deadline_ms = 100,
+            }) catch |err| {
+                if (err == error.OutOfMemory) {
+                    try expectRecordedProcessesGone(testing.allocator, tmp.rel_path);
+                    deleteRecordedPidFiles(tmp.rel_path);
+                    try expectDirEmptyPath(tmp.rel_path);
+                }
+                return err;
+            };
             defer result.deinit(allocator);
-            try expectNormalExit(result, 0);
+            try expectOutcomeTag(result, .timeout);
+            try expectRecordedProcessesGone(testing.allocator, tmp.rel_path);
+            deleteRecordedPidFiles(tmp.rel_path);
+            try expectDirEmptyPath(tmp.rel_path);
         }
     }.run, .{});
 }

--- a/tests/pki_differential.zig
+++ b/tests/pki_differential.zig
@@ -1556,6 +1556,10 @@ fn expectDirEmpty(dir: std.Io.Dir) !void {
     }
 }
 
+fn tmpDirPath(allocator: std.mem.Allocator, tmp: *std.testing.TmpDir) ![]u8 {
+    return compat.wrapDir(tmp.dir).realpathAlloc(allocator, ".");
+}
+
 test "pki reduce: bounded process captures successful output" {
     var result = try bounded_process.run(testing.allocator, .{
         .argv = &.{ pki_diff_options.process_helper_path, "success" },
@@ -1595,12 +1599,14 @@ test "pki reduce: bounded process reports launch failure" {
 test "pki reduce: bounded process timeout kills and reaps child" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
+    const tmp_path = try tmpDirPath(testing.allocator, &tmp);
+    defer testing.allocator.free(tmp_path);
     var result = try bounded_process.run(testing.allocator, .{
         .argv = &.{ pki_diff_options.process_helper_path, "hang" },
         .stdout_limit = 64,
         .stderr_limit = 64,
         .deadline_ms = 100,
-        .cwd = .{ .dir = tmp.dir },
+        .cwd = .{ .path = tmp_path },
     });
     defer result.deinit(testing.allocator);
     try expectOutcomeTag(result, .timeout);
@@ -1647,12 +1653,14 @@ test "pki reduce: bounded process kills stderr overflow and keeps bounded output
 fn expectFailureModeLeavesTmpEmpty(argv: []const []const u8, expected: std.meta.Tag(bounded_process.Outcome)) !void {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
+    const tmp_path = try tmpDirPath(testing.allocator, &tmp);
+    defer testing.allocator.free(tmp_path);
     var result = try bounded_process.run(testing.allocator, .{
         .argv = argv,
         .stdout_limit = 32,
         .stderr_limit = 32,
         .deadline_ms = 100,
-        .cwd = .{ .dir = tmp.dir },
+        .cwd = .{ .path = tmp_path },
     });
     defer result.deinit(testing.allocator);
     try expectOutcomeTag(result, expected);

--- a/tests/pki_differential.zig
+++ b/tests/pki_differential.zig
@@ -338,16 +338,10 @@ const GoDecision = struct {
 };
 
 fn goDecision(allocator: std.mem.Allocator, case: manifest.Case, deadline_ms: u32) !Observation {
-    const go_binary = compat.getEnvVarOwned(allocator, "GO_BIN") catch
-        try allocator.dupe(u8, "go");
-    defer allocator.free(go_binary);
-
     var argv: std.ArrayList([]const u8) = .empty;
     defer argv.deinit(allocator);
     try argv.appendSlice(allocator, &.{
-        go_binary,
-        "run",
-        "tests/pki_go_validator.go",
+        pki_diff_options.go_validator_path,
         "--root",
         case.root_file,
     });
@@ -1529,9 +1523,19 @@ fn expectOutcomeTag(result: bounded_process.Result, expected: std.meta.Tag(bound
 }
 
 fn parseHelperPid(stdout: []const u8) !std.posix.pid_t {
-    const trimmed = std.mem.trim(u8, stdout, " \t\r\n");
-    if (!std.mem.startsWith(u8, trimmed, "pid=")) return error.InvalidPidLine;
-    return try std.fmt.parseInt(std.posix.pid_t, trimmed["pid=".len..], 10);
+    return parsePidField(stdout, "pid");
+}
+
+fn parsePidField(stdout: []const u8, field: []const u8) !std.posix.pid_t {
+    var lines = std.mem.splitScalar(u8, stdout, '\n');
+    while (lines.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, " \t\r");
+        if (trimmed.len <= field.len + 1) continue;
+        if (!std.mem.startsWith(u8, trimmed, field)) continue;
+        if (trimmed[field.len] != '=') continue;
+        return std.fmt.parseInt(std.posix.pid_t, trimmed[field.len + 1 ..], 10);
+    }
+    return error.InvalidPidLine;
 }
 
 fn expectNoProcess(allocator: std.mem.Allocator, pid: std.posix.pid_t) !void {
@@ -1634,6 +1638,34 @@ test "pki reduce: bounded process timeout kills and reaps child" {
     try expectOutcomeTag(result, .timeout);
     const pid = try parseHelperPid(result.stdout);
     try expectNoProcess(testing.allocator, pid);
+    try expectDirEmptyPath(tmp.rel_path);
+}
+
+test "pki reduce: bounded process deadline covers wait after pipe EOF" {
+    var result = try bounded_process.run(testing.allocator, .{
+        .argv = &.{ pki_diff_options.process_helper_path, "close-stdio-hang" },
+        .stdout_limit = 64,
+        .stderr_limit = 64,
+        .deadline_ms = 100,
+    });
+    defer result.deinit(testing.allocator);
+    try expectOutcomeTag(result, .timeout);
+    try expectNoProcess(testing.allocator, try parseHelperPid(result.stdout));
+}
+
+test "pki reduce: bounded process timeout terminates process group" {
+    var tmp = try ProcessTempDir.init(testing.allocator, "process-group");
+    defer tmp.deinit(testing.allocator);
+    var result = try bounded_process.run(testing.allocator, .{
+        .argv = &.{ pki_diff_options.process_helper_path, "spawn-grandchild-and-hang", tmp.abs_path },
+        .stdout_limit = 256,
+        .stderr_limit = 256,
+        .deadline_ms = 100,
+    });
+    defer result.deinit(testing.allocator);
+    try expectOutcomeTag(result, .timeout);
+    try expectNoProcess(testing.allocator, try parsePidField(result.stdout, "pid"));
+    try expectNoProcess(testing.allocator, try parsePidField(result.stdout, "grandchild_pid"));
     try expectDirEmptyPath(tmp.rel_path);
 }
 

--- a/tests/pki_process_helper.zig
+++ b/tests/pki_process_helper.zig
@@ -62,6 +62,19 @@ pub fn main(init: std.process.Init.Minimal) !void {
         }
         hangForever();
     }
+    if (std.mem.eql(u8, mode, "spawn-grandchild-record-and-hang")) {
+        const tmp_dir = args.next() orelse return error.MissingTempDir;
+        const pid = std.c.getpid();
+        try writePidFile(tmp_dir, "parent.pid", pid);
+
+        const child_pid = std.c.fork();
+        if (child_pid < 0) return error.ForkFailed;
+        if (child_pid == 0) {
+            try writePidFile(tmp_dir, "grandchild.pid", std.c.getpid());
+            hangForever();
+        }
+        hangForever();
+    }
     if (std.mem.eql(u8, mode, "abort")) {
         switch (@import("builtin").os.tag) {
             .windows => @panic("abnormal termination"),
@@ -87,6 +100,16 @@ fn touchAndRemoveMarker(tmp_dir: []const u8, name: []const u8) !void {
     var file = try dir.createFile(io, name, .{});
     file.close(io);
     try dir.deleteFile(io, name);
+}
+
+fn writePidFile(tmp_dir: []const u8, name: []const u8, pid: std.posix.pid_t) !void {
+    var dir = try std.Io.Dir.cwd().openDir(io, tmp_dir, .{});
+    defer dir.close(io);
+    var file = try dir.createFile(io, name, .{ .truncate = true });
+    defer file.close(io);
+    var buf: [64]u8 = undefined;
+    const text = try std.fmt.bufPrint(&buf, "{d}\n", .{pid});
+    try file.writeStreamingAll(io, text);
 }
 
 fn writeRepeated(fd: c_int, byte: u8, len: usize) !void {

--- a/tests/pki_process_helper.zig
+++ b/tests/pki_process_helper.zig
@@ -1,0 +1,69 @@
+const std = @import("std");
+
+pub fn main(init: std.process.Init.Minimal) !void {
+    var args = init.args.iterate();
+    _ = args.next();
+    const mode = args.next() orelse return error.MissingMode;
+    if (std.mem.eql(u8, mode, "success")) {
+        try writeFd(1, "ok\n");
+        return;
+    }
+    if (std.mem.eql(u8, mode, "exit")) {
+        const code = try std.fmt.parseInt(u8, args.next() orelse return error.MissingStatus, 10);
+        std.process.exit(code);
+    }
+    if (std.mem.eql(u8, mode, "stdout")) {
+        const len = try std.fmt.parseInt(usize, args.next() orelse return error.MissingLength, 10);
+        try writeRepeated(1, 'o', len);
+        return;
+    }
+    if (std.mem.eql(u8, mode, "stderr")) {
+        const len = try std.fmt.parseInt(usize, args.next() orelse return error.MissingLength, 10);
+        try writeRepeated(2, 'e', len);
+        return;
+    }
+    if (std.mem.eql(u8, mode, "malformed")) {
+        try writeFd(1, "{not-json\n");
+        return;
+    }
+    if (std.mem.eql(u8, mode, "hang")) {
+        const pid = std.c.getpid();
+        var buf: [64]u8 = undefined;
+        const line = try std.fmt.bufPrint(&buf, "pid={d}\n", .{pid});
+        try writeFd(1, line);
+        var ts = std.c.timespec{ .sec = 10, .nsec = 0 };
+        while (true) {
+            _ = std.posix.system.nanosleep(&ts, &ts);
+        }
+    }
+    if (std.mem.eql(u8, mode, "abort")) {
+        switch (@import("builtin").os.tag) {
+            .windows => @panic("abnormal termination"),
+            else => {
+                try std.posix.raise(.ABRT);
+                unreachable;
+            },
+        }
+    }
+    return error.UnknownMode;
+}
+
+fn writeRepeated(fd: c_int, byte: u8, len: usize) !void {
+    var buf: [1024]u8 = undefined;
+    @memset(&buf, byte);
+    var remaining = len;
+    while (remaining > 0) {
+        const n = @min(remaining, buf.len);
+        try writeFd(fd, buf[0..n]);
+        remaining -= n;
+    }
+}
+
+fn writeFd(fd: c_int, bytes: []const u8) !void {
+    var written: usize = 0;
+    while (written < bytes.len) {
+        const n = std.c.write(fd, bytes.ptr + written, bytes.len - written);
+        if (n <= 0) return error.WriteFailed;
+        written += @intCast(n);
+    }
+}

--- a/tests/pki_process_helper.zig
+++ b/tests/pki_process_helper.zig
@@ -1,8 +1,9 @@
 const std = @import("std");
+const io = std.Io.Threaded.global_single_threaded.io();
 
 pub fn main(init: std.process.Init.Minimal) !void {
     var args = init.args.iterate();
-    _ = args.next();
+    _ = args.next() orelse return error.MissingExecutablePath;
     const mode = args.next() orelse return error.MissingMode;
     if (std.mem.eql(u8, mode, "success")) {
         try writeFd(1, "ok\n");
@@ -31,10 +32,35 @@ pub fn main(init: std.process.Init.Minimal) !void {
         var buf: [64]u8 = undefined;
         const line = try std.fmt.bufPrint(&buf, "pid={d}\n", .{pid});
         try writeFd(1, line);
-        var ts = std.c.timespec{ .sec = 10, .nsec = 0 };
-        while (true) {
-            _ = std.posix.system.nanosleep(&ts, &ts);
+        hangForever();
+    }
+    if (std.mem.eql(u8, mode, "close-stdio-hang")) {
+        const pid = std.c.getpid();
+        var buf: [64]u8 = undefined;
+        const line = try std.fmt.bufPrint(&buf, "pid={d}\n", .{pid});
+        try writeFd(1, line);
+        _ = std.c.close(1);
+        _ = std.c.close(2);
+        hangForever();
+    }
+    if (std.mem.eql(u8, mode, "spawn-grandchild-and-hang")) {
+        const tmp_dir = args.next() orelse return error.MissingTempDir;
+        const pid = std.c.getpid();
+        var parent_buf: [64]u8 = undefined;
+        const parent_line = try std.fmt.bufPrint(&parent_buf, "pid={d}\n", .{pid});
+        try writeFd(1, parent_line);
+        try touchAndRemoveMarker(tmp_dir, "parent.marker");
+
+        const child_pid = std.c.fork();
+        if (child_pid < 0) return error.ForkFailed;
+        if (child_pid == 0) {
+            const grandchild_pid = std.c.getpid();
+            var child_buf: [96]u8 = undefined;
+            const child_line = try std.fmt.bufPrint(&child_buf, "grandchild_pid={d}\n", .{grandchild_pid});
+            try writeFd(1, child_line);
+            hangForever();
         }
+        hangForever();
     }
     if (std.mem.eql(u8, mode, "abort")) {
         switch (@import("builtin").os.tag) {
@@ -46,6 +72,21 @@ pub fn main(init: std.process.Init.Minimal) !void {
         }
     }
     return error.UnknownMode;
+}
+
+fn hangForever() noreturn {
+    var ts = std.c.timespec{ .sec = 10, .nsec = 0 };
+    while (true) {
+        _ = std.posix.system.nanosleep(&ts, &ts);
+    }
+}
+
+fn touchAndRemoveMarker(tmp_dir: []const u8, name: []const u8) !void {
+    var dir = try std.Io.Dir.cwd().openDir(io, tmp_dir, .{});
+    defer dir.close(io);
+    var file = try dir.createFile(io, name, .{});
+    file.close(io);
+    try dir.deleteFile(io, name);
 }
 
 fn writeRepeated(fd: c_int, byte: u8, len: usize) !void {


### PR DESCRIPTION
## Summary

- add a reusable bounded child-process runner for PKI differential validators
- route OpenSSL and Go oracle invocations through deadline/output-limit/structured-outcome handling
- add a deterministic compiled helper and offline tests for success, rejection-style exits, launch failure, timeout/reaping, signal termination, stdout/stderr overflow, malformed output classification, temp-dir cleanup, deterministic classification, and allocation-failure cleanup
- document stable and extended per-validator deadlines

## Validation

- git diff --check
- zig fmt --check build.zig src/ tests/
- zig build test-pki-reduce --summary all --error-style verbose
- zig build test-pki --summary all --error-style verbose
- zig build test-pki-differential --summary all --error-style verbose --test-timeout 2m
- zig build test-pki-differential-extended --summary all --error-style verbose --test-timeout 10m
- zig build test-pki-openssl --summary all --error-style verbose
- zig build test-pki-policy-openssl --summary all --error-style verbose
- zig build test --summary all --error-style verbose --test-timeout 2m
- zig build -Doptimize=ReleaseFast

Refs #348