### PR TITLE
tls: add bounded stream watermarks and backpressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable user-facing changes to Tardigrade are documented here.
 ## [Unreleased]
 
 ### Features
+- **Bounded TLS stream watermarks and backpressure (#355, epic #325)** — adds
+  validated per-connection TLS buffer limits for inbound carrier ciphertext,
+  decrypted plaintext, outbound ciphertext, and handshake bytes while
+  preserving the fixed-capacity, allocation-free `PureZigRecordStream` queues.
+  TLS readiness now uses latched high/low hysteresis for carrier reads and
+  plaintext writes, exposes backend-neutral buffer snapshots with current and
+  peak owned bytes plus pause/resume/stall/hard-limit counters, and documents
+  the OpenSSL adapter accounting boundary for opaque backend-owned memory.
 - **TLS-owned reusable TLS 1.3 engine (#442, epic #325)** — relocates the
   concrete native handshake engine from `src/quic/` to
   `src/tls/tls13_backend.zig`. An explicit transport profile now separates

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -48,6 +48,16 @@ logs are written through `src/http/logger.zig`.
   `tardigrade_buffer_config_limit_bytes{direction,scope,limit}` for the
   per-stream low/high/hard watermarks plus per-origin/global hard-limit
   settings.
+- TLS record-stream backpressure state is exposed to runtime consumers through
+  the allocation-free `EncryptedStream.bufferSnapshot()` seam. The snapshot
+  contains current and peak stream-owned bytes for inbound carrier ciphertext,
+  decrypted plaintext, outbound ciphertext, and handshake bytes; configured
+  low/high/hard limits; latched carrier-read and plaintext-write pause state;
+  pause/resume counters; hard-limit counters by TLS queue; and stalled-drive
+  counts. These values are per TLS connection and deliberately carry no SNI,
+  URL, request ID, stream ID, or arbitrary protocol labels. OpenSSL-backed
+  adapters may expose measurable BIO/adapter bytes only; opaque internal
+  OpenSSL memory is outside the complete stream-owned accounting boundary.
 - reverse-proxy abort counters:
   `tardigrade_proxy_client_aborts_total` and
   `tardigrade_proxy_upstream_aborts_total`

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -51,13 +51,14 @@ logs are written through `src/http/logger.zig`.
 - TLS record-stream backpressure state is exposed to runtime consumers through
   the allocation-free `EncryptedStream.bufferSnapshot()` seam. The snapshot
   contains current and peak stream-owned bytes for inbound carrier ciphertext,
-  decrypted plaintext, outbound ciphertext, and handshake bytes; configured
-  low/high/hard limits; latched carrier-read and plaintext-write pause state;
-  pause/resume counters; hard-limit counters by TLS queue; and stalled-drive
-  counts. These values are per TLS connection and deliberately carry no SNI,
-  URL, request ID, stream ID, or arbitrary protocol labels. OpenSSL-backed
-  adapters may expose measurable BIO/adapter bytes only; opaque internal
-  OpenSSL memory is outside the complete stream-owned accounting boundary.
+  decrypted plaintext, outbound ciphertext, and handshake bytes; optional
+  low/high/hard limits plus whether the backend enforces them; latched
+  carrier-read and plaintext-write pause state; pause/resume counters;
+  hard-limit counters by TLS queue; and stalled-drive counts. These values are
+  per TLS connection and deliberately carry no SNI, URL, request ID, stream ID,
+  or arbitrary protocol labels. OpenSSL-backed adapters may expose measurable
+  BIO/adapter bytes only and leave unknown limits unset; opaque internal OpenSSL
+  memory is outside the complete stream-owned accounting boundary.
 - reverse-proxy abort counters:
   `tardigrade_proxy_client_aborts_total` and
   `tardigrade_proxy_upstream_aborts_total`

--- a/docs/TLS_RECORD_TRANSPORT.md
+++ b/docs/TLS_RECORD_TRANSPORT.md
@@ -87,11 +87,13 @@ true while queued ciphertext can drain.
 
 The backend-neutral `EncryptedStream.bufferSnapshot()` reports allocation-free
 state for metrics and HTTP integration: current and peak owned bytes by queue,
-peak total owned bytes, configured limits, pause state, pause/resume counters,
-hard-limit counters, and stalled-drive count. The pure-Zig record stream reports
-only bytes it owns. An OpenSSL adapter must report only measurable adapter/BIO
-state and mark opaque internal OpenSSL memory as outside the complete
-stream-owned accounting boundary rather than describing unknown memory as zero.
+peak total owned bytes, optional configured limits plus whether those limits are
+enforced by the backend, pause state, pause/resume counters, hard-limit counters,
+and stalled-drive count. The pure-Zig record stream reports complete owned bytes
+and enforced limits. An OpenSSL adapter must report only measurable adapter/BIO
+state, leave unknown limits unset, and mark opaque internal OpenSSL memory as
+outside the complete stream-owned accounting boundary rather than describing
+unknown memory as zero.
 
 Pure-Zig application writes seal accepted plaintext directly into the outbound
 ciphertext queue; there is no hidden pending-plaintext staging queue. HTTP/1.1

--- a/docs/TLS_RECORD_TRANSPORT.md
+++ b/docs/TLS_RECORD_TRANSPORT.md
@@ -62,3 +62,39 @@ one before closing. The contract only carries it; deciding *when* to
 synthesize an alert from a handshake failure — and the rest of alert /
 `close_notify` / truncation policy — is transport-specific and, for TCP record
 mode, tracked by #354.
+
+## Record-stream buffer limits
+
+`PureZigRecordStream` keeps its hot path allocation-free: inbound carrier
+ciphertext, decrypted application plaintext, outbound ciphertext, and inbound
+handshake bytes live in fixed-capacity queues owned by the stream. Runtime
+`BufferLimits` add effective low/high/hard watermarks inside those compile-time
+capacities; they do not replace the queues with dynamically growing buffers.
+
+Validation rejects zero or nonsensical watermarks (`low < high <= hard` is
+required), hard limits above the fixed queue capacity, and policies that cannot
+hold a maximum legal TLS fragment or the complete borrowed handshake event batch
+that record mode must serialize atomically. Existing constructors use safe
+defaults derived from the fixed capacities; callers that need tighter appliance
+profiles can use the explicit `init*WithLimits` constructors.
+
+Readiness uses latched hysteresis. Carrier reads pause when inbound ciphertext,
+plaintext, or handshake ownership reaches the relevant high watermark, and they
+resume only after all inbound queues drain to their low watermarks. Plaintext
+writes pause when outbound ciphertext reaches its high watermark and resume
+only after the ciphertext queue drains to or below low. `wants_write` remains
+true while queued ciphertext can drain.
+
+The backend-neutral `EncryptedStream.bufferSnapshot()` reports allocation-free
+state for metrics and HTTP integration: current and peak owned bytes by queue,
+peak total owned bytes, configured limits, pause state, pause/resume counters,
+hard-limit counters, and stalled-drive count. The pure-Zig record stream reports
+only bytes it owns. An OpenSSL adapter must report only measurable adapter/BIO
+state and mark opaque internal OpenSSL memory as outside the complete
+stream-owned accounting boundary rather than describing unknown memory as zero.
+
+Pure-Zig application writes seal accepted plaintext directly into the outbound
+ciphertext queue; there is no hidden pending-plaintext staging queue. HTTP/1.1
+and HTTP/2 consumers should use `can_write_plaintext`, `can_read_plaintext`,
+`wants_read`, `wants_write`, and the buffer snapshot to register only socket
+readiness that can make progress.

--- a/src/http/tls_termination.zig
+++ b/src/http/tls_termination.zig
@@ -339,6 +339,8 @@ pub const TlsConnection = struct {
     stream_failure: ?encrypted_stream.Error = null,
     stream_buffer_peaks: encrypted_stream.QueueBytes = .{},
     stream_peak_total: usize = 0,
+    stream_pause_state: encrypted_stream.PauseState = .{},
+    stream_buffer_counters: encrypted_stream.BufferCounters = .{},
 
     pub fn deinit(self: *TlsConnection) void {
         if (opensslShouldShutdownOnDeinit(self)) {
@@ -449,6 +451,7 @@ const OpenSslPendingWrite = struct {
 fn opensslClearRetry(self: *TlsConnection) void {
     self.retry_direction = .none;
     self.pending_write = null;
+    opensslObserveBackpressure(self);
 }
 
 fn opensslShouldShutdownOnDeinit(self: *const TlsConnection) bool {
@@ -482,11 +485,40 @@ fn opensslSetRetry(self: *TlsConnection, ssl_error: c_int) void {
         c.SSL_ERROR_WANT_WRITE => .write,
         else => .none,
     };
+    opensslObserveBackpressure(self);
 }
 
 fn opensslSetWriteRetry(self: *TlsConnection, bytes: []const u8, ssl_error: c_int) void {
-    opensslSetRetry(self, ssl_error);
+    self.retry_direction = switch (ssl_error) {
+        c.SSL_ERROR_WANT_READ => .read,
+        c.SSL_ERROR_WANT_WRITE => .write,
+        else => .none,
+    };
     self.pending_write = OpenSslPendingWrite.init(bytes);
+    opensslObserveBackpressure(self);
+}
+
+fn opensslDerivedPauseState(self: *TlsConnection) encrypted_stream.PauseState {
+    const readiness = opensslStreamReadiness(self);
+    return .{
+        .inbound_read_paused = self.stream_lifecycle == .open and !self.peer_closed and !readiness.wants_read and !readiness.can_read_plaintext,
+        .plaintext_write_paused = self.stream_lifecycle == .open and !readiness.can_write_plaintext,
+    };
+}
+
+fn opensslObserveBackpressure(self: *TlsConnection) void {
+    const next = opensslDerivedPauseState(self);
+    if (!self.stream_pause_state.inbound_read_paused and next.inbound_read_paused) {
+        self.stream_buffer_counters.inbound_read_pauses += 1;
+    } else if (self.stream_pause_state.inbound_read_paused and !next.inbound_read_paused) {
+        self.stream_buffer_counters.inbound_read_resumes += 1;
+    }
+    if (!self.stream_pause_state.plaintext_write_paused and next.plaintext_write_paused) {
+        self.stream_buffer_counters.plaintext_write_pauses += 1;
+    } else if (self.stream_pause_state.plaintext_write_paused and !next.plaintext_write_paused) {
+        self.stream_buffer_counters.plaintext_write_resumes += 1;
+    }
+    self.stream_pause_state = next;
 }
 
 fn opensslStreamBackend(_: *anyopaque) encrypted_stream.BackendKind {
@@ -579,6 +611,7 @@ fn opensslAdvanceShutdown(self: *TlsConnection) encrypted_stream.Error!bool {
     }
     if (rc == 0) {
         self.retry_direction = .read;
+        opensslObserveBackpressure(self);
         return true;
     }
 
@@ -591,6 +624,7 @@ fn opensslAdvanceShutdown(self: *TlsConnection) encrypted_stream.Error!bool {
         c.SSL_ERROR_ZERO_RETURN => peer_closed: {
             self.peer_closed = true;
             self.retry_direction = .write;
+            opensslObserveBackpressure(self);
             break :peer_closed true;
         },
         else => opensslStreamFail(self, error.SocketWriteFailed),
@@ -601,6 +635,7 @@ fn opensslStreamClose(ptr: *anyopaque) void {
     const self: *TlsConnection = @ptrCast(@alignCast(ptr));
     if (self.stream_lifecycle == .closed or self.stream_lifecycle == .failed) return;
     self.close_requested = true;
+    opensslObserveBackpressure(self);
     _ = opensslAdvanceShutdown(self) catch {};
 }
 
@@ -647,12 +682,14 @@ fn opensslStreamDrive(ptr: *anyopaque) encrypted_stream.Error!encrypted_stream.D
         try opensslAdvanceShutdown(self)
     else
         false;
+    if (!made_progress and (self.stream_pause_state.inbound_read_paused or self.stream_pause_state.plaintext_write_paused)) {
+        self.stream_buffer_counters.stalled_drives += 1;
+    }
     return .{ .made_progress = made_progress, .readiness = opensslStreamReadiness(ptr) };
 }
 
 fn opensslStreamBufferSnapshot(ptr: *anyopaque) encrypted_stream.BufferSnapshot {
     const self: *TlsConnection = @ptrCast(@alignCast(ptr));
-    const readiness = opensslStreamReadiness(ptr);
     const current = encrypted_stream.QueueBytes{
         .inbound_plaintext = if (self.stream_lifecycle == .open) self.pending() else 0,
     };
@@ -662,10 +699,8 @@ fn opensslStreamBufferSnapshot(ptr: *anyopaque) encrypted_stream.BufferSnapshot 
         .current = current,
         .peak = self.stream_buffer_peaks,
         .peak_total = self.stream_peak_total,
-        .pause_state = .{
-            .inbound_read_paused = self.stream_lifecycle == .open and !self.peer_closed and !readiness.wants_read and !readiness.can_read_plaintext,
-            .plaintext_write_paused = self.stream_lifecycle == .open and !readiness.can_write_plaintext,
-        },
+        .pause_state = self.stream_pause_state,
+        .counters = self.stream_buffer_counters,
         .accounting_boundary = .backend_opaque,
     };
 }
@@ -1362,6 +1397,10 @@ test "openssl encrypted stream adapter conforms over production connection" {
 
     var scratch: [32]u8 = undefined;
     try clientWriteAll(pair.client_ssl, "client-payload");
+    const pending_snapshot = stream.bufferSnapshot();
+    try std.testing.expectEqual(encrypted_stream.AccountingBoundary.backend_opaque, pending_snapshot.accounting_boundary);
+    try std.testing.expect(!pending_snapshot.limits_enforced);
+    try std.testing.expect(pending_snapshot.limits == null);
     const partial = try stream.read(scratch[0..6]);
     try std.testing.expectEqualStrings("client", scratch[0..partial]);
     try std.testing.expect(stream.readiness().can_read_plaintext);
@@ -1394,6 +1433,20 @@ test "openssl encrypted stream preserves write retry direction under socket back
     const blocked_drive = try stream.drive();
     try std.testing.expect(!blocked_drive.made_progress);
     try std.testing.expect(blocked_drive.readiness.wants_write);
+    const blocked_snapshot = stream.bufferSnapshot();
+    try std.testing.expectEqual(encrypted_stream.AccountingBoundary.backend_opaque, blocked_snapshot.accounting_boundary);
+    try std.testing.expect(!blocked_snapshot.limits_enforced);
+    try std.testing.expect(blocked_snapshot.limits == null);
+    try std.testing.expect(blocked_snapshot.pause_state.plaintext_write_paused);
+    try std.testing.expectEqual(@as(u64, 1), blocked_snapshot.counters.plaintext_write_pauses);
+    try std.testing.expectEqual(@as(u64, 0), blocked_snapshot.counters.plaintext_write_resumes);
+    try std.testing.expectEqual(@as(u64, 1), blocked_snapshot.counters.stalled_drives);
+    const repeated_blocked_drive = try stream.drive();
+    try std.testing.expect(!repeated_blocked_drive.made_progress);
+    const repeated_blocked_snapshot = stream.bufferSnapshot();
+    try std.testing.expectEqual(@as(u64, 1), repeated_blocked_snapshot.counters.plaintext_write_pauses);
+    try std.testing.expectEqual(@as(u64, 0), repeated_blocked_snapshot.counters.plaintext_write_resumes);
+    try std.testing.expectEqual(@as(u64, 2), repeated_blocked_snapshot.counters.stalled_drives);
 
     var interleaved_read: [1]u8 = undefined;
     try std.testing.expectError(error.RetryOperationPending, stream.read(&interleaved_read));
@@ -1431,6 +1484,9 @@ test "openssl encrypted stream preserves write retry direction under socket back
     try std.testing.expectEqualSlices(u8, target, received);
     try std.testing.expect(!stream.readiness().wants_write);
     try std.testing.expect(stream.readiness().can_write_plaintext);
+    const resumed_snapshot = stream.bufferSnapshot();
+    try std.testing.expect(!resumed_snapshot.pause_state.plaintext_write_paused);
+    try std.testing.expectEqual(@as(u64, 1), resumed_snapshot.counters.plaintext_write_resumes);
 }
 
 test "openssl encrypted stream preserves close requested during pending write retry" {

--- a/src/http/tls_termination.zig
+++ b/src/http/tls_termination.zig
@@ -337,6 +337,8 @@ pub const TlsConnection = struct {
     close_requested: bool = false,
     peer_closed: bool = false,
     stream_failure: ?encrypted_stream.Error = null,
+    stream_buffer_peaks: encrypted_stream.QueueBytes = .{},
+    stream_peak_total: usize = 0,
 
     pub fn deinit(self: *TlsConnection) void {
         if (opensslShouldShutdownOnDeinit(self)) {
@@ -648,6 +650,26 @@ fn opensslStreamDrive(ptr: *anyopaque) encrypted_stream.Error!encrypted_stream.D
     return .{ .made_progress = made_progress, .readiness = opensslStreamReadiness(ptr) };
 }
 
+fn opensslStreamBufferSnapshot(ptr: *anyopaque) encrypted_stream.BufferSnapshot {
+    const self: *TlsConnection = @ptrCast(@alignCast(ptr));
+    const readiness = opensslStreamReadiness(ptr);
+    const current = encrypted_stream.QueueBytes{
+        .inbound_plaintext = if (self.stream_lifecycle == .open) self.pending() else 0,
+    };
+    self.stream_buffer_peaks.inbound_plaintext = @max(self.stream_buffer_peaks.inbound_plaintext, current.inbound_plaintext);
+    self.stream_peak_total = @max(self.stream_peak_total, current.total());
+    return .{
+        .current = current,
+        .peak = self.stream_buffer_peaks,
+        .peak_total = self.stream_peak_total,
+        .pause_state = .{
+            .inbound_read_paused = self.stream_lifecycle == .open and !self.peer_closed and !readiness.wants_read and !readiness.can_read_plaintext,
+            .plaintext_write_paused = self.stream_lifecycle == .open and !readiness.can_write_plaintext,
+        },
+        .accounting_boundary = .backend_opaque,
+    };
+}
+
 const openssl_stream_vtable = encrypted_stream.EncryptedStream.VTable{
     .backendFn = opensslStreamBackend,
     .readFn = opensslStreamRead,
@@ -655,6 +677,7 @@ const openssl_stream_vtable = encrypted_stream.EncryptedStream.VTable{
     .closeFn = opensslStreamClose,
     .readinessFn = opensslStreamReadiness,
     .driveFn = opensslStreamDrive,
+    .bufferSnapshotFn = opensslStreamBufferSnapshot,
 };
 
 pub fn lastOpenSslError(allocator: std.mem.Allocator) ?[]u8 {

--- a/src/http/tls_termination.zig
+++ b/src/http/tls_termination.zig
@@ -451,7 +451,7 @@ const OpenSslPendingWrite = struct {
 fn opensslClearRetry(self: *TlsConnection) void {
     self.retry_direction = .none;
     self.pending_write = null;
-    opensslObserveBackpressure(self);
+    if (self.stream_lifecycle == .open and !self.close_requested) opensslObserveBackpressure(self);
 }
 
 fn opensslShouldShutdownOnDeinit(self: *const TlsConnection) bool {
@@ -462,6 +462,7 @@ fn opensslStreamFail(self: *TlsConnection, err: encrypted_stream.Error) encrypte
     self.stream_lifecycle = .failed;
     opensslClearRetry(self);
     self.close_requested = false;
+    self.stream_pause_state = .{};
     self.stream_failure = err;
     return err;
 }
@@ -485,7 +486,7 @@ fn opensslSetRetry(self: *TlsConnection, ssl_error: c_int) void {
         c.SSL_ERROR_WANT_WRITE => .write,
         else => .none,
     };
-    opensslObserveBackpressure(self);
+    if (self.stream_lifecycle == .open and !self.close_requested) opensslObserveBackpressure(self);
 }
 
 fn opensslSetWriteRetry(self: *TlsConnection, bytes: []const u8, ssl_error: c_int) void {
@@ -495,7 +496,20 @@ fn opensslSetWriteRetry(self: *TlsConnection, bytes: []const u8, ssl_error: c_in
         else => .none,
     };
     self.pending_write = OpenSslPendingWrite.init(bytes);
-    opensslObserveBackpressure(self);
+    if (self.stream_lifecycle == .open and !self.close_requested) opensslObserveBackpressure(self);
+}
+
+fn opensslCurrentBufferUsage(self: *const TlsConnection) encrypted_stream.QueueBytes {
+    return .{
+        .inbound_plaintext = if (self.stream_lifecycle == .failed or self.stream_lifecycle == .closed) 0 else self.pending(),
+    };
+}
+
+fn opensslObserveBufferUsage(self: *TlsConnection) encrypted_stream.QueueBytes {
+    const current = opensslCurrentBufferUsage(self);
+    self.stream_buffer_peaks.inbound_plaintext = @max(self.stream_buffer_peaks.inbound_plaintext, current.inbound_plaintext);
+    self.stream_peak_total = @max(self.stream_peak_total, current.total());
+    return current;
 }
 
 fn opensslDerivedPauseState(self: *TlsConnection) encrypted_stream.PauseState {
@@ -531,11 +545,14 @@ fn opensslStreamRead(ptr: *anyopaque, out: []u8) encrypted_stream.Error!usize {
     if (self.stream_lifecycle != .open) return error.StreamClosed;
     if (self.pending_write != null) return error.RetryOperationPending;
     if (self.close_requested) return error.StreamClosed;
+    _ = opensslObserveBufferUsage(self);
     c.ERR_clear_error();
     const rc = c.SSL_read(self.ssl, out.ptr, @intCast(out.len));
+    _ = opensslObserveBufferUsage(self);
     if (rc > 0) {
         opensslClearRetry(self);
         opensslRefreshPeerClosed(self);
+        _ = opensslObserveBufferUsage(self);
         return @intCast(rc);
     }
     const ssl_error = c.SSL_get_error(self.ssl, rc);
@@ -600,6 +617,7 @@ fn opensslAdvanceShutdown(self: *TlsConnection) encrypted_stream.Error!bool {
     if (self.pending_write != null) return error.RetryOperationPending;
 
     self.stream_lifecycle = .closing;
+    self.stream_pause_state = .{};
     c.ERR_clear_error();
     const rc = c.SSL_shutdown(self.ssl);
     opensslRefreshPeerClosed(self);
@@ -611,7 +629,6 @@ fn opensslAdvanceShutdown(self: *TlsConnection) encrypted_stream.Error!bool {
     }
     if (rc == 0) {
         self.retry_direction = .read;
-        opensslObserveBackpressure(self);
         return true;
     }
 
@@ -624,7 +641,6 @@ fn opensslAdvanceShutdown(self: *TlsConnection) encrypted_stream.Error!bool {
         c.SSL_ERROR_ZERO_RETURN => peer_closed: {
             self.peer_closed = true;
             self.retry_direction = .write;
-            opensslObserveBackpressure(self);
             break :peer_closed true;
         },
         else => opensslStreamFail(self, error.SocketWriteFailed),
@@ -635,7 +651,6 @@ fn opensslStreamClose(ptr: *anyopaque) void {
     const self: *TlsConnection = @ptrCast(@alignCast(ptr));
     if (self.stream_lifecycle == .closed or self.stream_lifecycle == .failed) return;
     self.close_requested = true;
-    opensslObserveBackpressure(self);
     _ = opensslAdvanceShutdown(self) catch {};
 }
 
@@ -690,11 +705,7 @@ fn opensslStreamDrive(ptr: *anyopaque) encrypted_stream.Error!encrypted_stream.D
 
 fn opensslStreamBufferSnapshot(ptr: *anyopaque) encrypted_stream.BufferSnapshot {
     const self: *TlsConnection = @ptrCast(@alignCast(ptr));
-    const current = encrypted_stream.QueueBytes{
-        .inbound_plaintext = if (self.stream_lifecycle == .open) self.pending() else 0,
-    };
-    self.stream_buffer_peaks.inbound_plaintext = @max(self.stream_buffer_peaks.inbound_plaintext, current.inbound_plaintext);
-    self.stream_peak_total = @max(self.stream_peak_total, current.total());
+    const current = opensslObserveBufferUsage(self);
     return .{
         .current = current,
         .peak = self.stream_buffer_peaks,
@@ -1404,10 +1415,16 @@ test "openssl encrypted stream adapter conforms over production connection" {
     const partial = try stream.read(scratch[0..6]);
     try std.testing.expectEqualStrings("client", scratch[0..partial]);
     try std.testing.expect(stream.readiness().can_read_plaintext);
+    var buffered_snapshot = stream.bufferSnapshot();
+    try std.testing.expect(buffered_snapshot.current.inbound_plaintext > 0);
+    try std.testing.expect(buffered_snapshot.peak.inbound_plaintext >= buffered_snapshot.current.inbound_plaintext);
 
     const rest = try stream.read(scratch[0..16]);
     try std.testing.expectEqualStrings("-payload", scratch[0..rest]);
     try std.testing.expect(!stream.readiness().can_read_plaintext);
+    buffered_snapshot = stream.bufferSnapshot();
+    try std.testing.expectEqual(@as(usize, 0), buffered_snapshot.current.inbound_plaintext);
+    try std.testing.expect(buffered_snapshot.peak.inbound_plaintext > 0);
 
     const written = try stream.write("server-reply");
     try std.testing.expectEqual(@as(usize, "server-reply".len), written);
@@ -1489,6 +1506,30 @@ test "openssl encrypted stream preserves write retry direction under socket back
     try std.testing.expectEqual(@as(u64, 1), resumed_snapshot.counters.plaintext_write_resumes);
 }
 
+test "openssl encrypted stream records pending plaintext peak before first snapshot" {
+    const allocator = std.testing.allocator;
+    var pair = try makeTestTlsPair(allocator);
+    defer pair.deinit();
+
+    const stream = pair.server.stream();
+    try clientWriteAll(pair.client_ssl, "client-payload");
+
+    var scratch: [6]u8 = undefined;
+    try std.testing.expectEqual(@as(usize, 6), try stream.read(&scratch));
+    try std.testing.expectEqualStrings("client", &scratch);
+
+    var rest: [16]u8 = undefined;
+    const rest_len = try stream.read(&rest);
+    try std.testing.expectEqualStrings("-payload", rest[0..rest_len]);
+
+    const snapshot = stream.bufferSnapshot();
+    try std.testing.expectEqual(@as(usize, 0), snapshot.current.inbound_plaintext);
+    try std.testing.expect(snapshot.peak.inbound_plaintext >= "-payload".len);
+    try std.testing.expect(snapshot.peak_total >= "-payload".len);
+    try std.testing.expect(!snapshot.limits_enforced);
+    try std.testing.expect(snapshot.limits == null);
+}
+
 test "openssl encrypted stream preserves close requested during pending write retry" {
     const allocator = std.testing.allocator;
     var pair = try makeTestTlsPair(allocator);
@@ -1547,6 +1588,48 @@ test "openssl encrypted stream preserves close requested during pending write re
     try std.testing.expectEqual(OpenSslStreamLifecycle.closed, pair.server.stream_lifecycle);
     try std.testing.expectEqualSlices(u8, blocked.expected.items, read_ctx.out.items);
     try encrypted_stream.expectClosedConformance(stream);
+}
+
+test "openssl encrypted stream close does not synthesize pause transitions" {
+    const allocator = std.testing.allocator;
+
+    {
+        var pair = try makeTestTlsPair(allocator);
+        defer pair.deinit();
+        const stream = pair.server.stream();
+
+        const before = stream.bufferSnapshot();
+        try std.testing.expectEqual(@as(u64, 0), before.counters.inbound_read_pauses);
+        try std.testing.expectEqual(@as(u64, 0), before.counters.plaintext_write_pauses);
+
+        stream.close();
+        const after = stream.bufferSnapshot();
+        try std.testing.expect(!after.pause_state.inbound_read_paused);
+        try std.testing.expect(!after.pause_state.plaintext_write_paused);
+        try std.testing.expectEqual(@as(u64, 0), after.counters.inbound_read_pauses);
+        try std.testing.expectEqual(@as(u64, 0), after.counters.inbound_read_resumes);
+        try std.testing.expectEqual(@as(u64, 0), after.counters.plaintext_write_pauses);
+        try std.testing.expectEqual(@as(u64, 0), after.counters.plaintext_write_resumes);
+    }
+
+    {
+        var pair = try makeTestTlsPair(allocator);
+        defer pair.deinit();
+        const stream = pair.server.stream();
+        var blocked: ForcedWriteBlock = .{};
+        defer blocked.deinit(allocator);
+        try forceOpenSslWriteBackpressure(allocator, &pair, stream, &blocked);
+
+        const before_close = stream.bufferSnapshot();
+        try std.testing.expect(before_close.pause_state.plaintext_write_paused);
+        try std.testing.expectEqual(@as(u64, 1), before_close.counters.plaintext_write_pauses);
+
+        stream.close();
+        const after_close = stream.bufferSnapshot();
+        try std.testing.expect(after_close.pause_state.plaintext_write_paused);
+        try std.testing.expectEqual(@as(u64, 1), after_close.counters.plaintext_write_pauses);
+        try std.testing.expectEqual(@as(u64, 0), after_close.counters.plaintext_write_resumes);
+    }
 }
 
 test "openssl encrypted stream cleanup skips shutdown with pending write retry" {

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -724,11 +724,16 @@ pub const PureZigRecordStream = struct {
             self.hasHardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, handshake_output_reserve);
     }
 
+    fn hasActiveInboundParser(self: *const PureZigRecordStream) bool {
+        return self.initial_parser.len > 0 or self.ciphertext_parser.len > 0;
+    }
+
     fn inboundCiphertextReadRoom(self: *const PureZigRecordStream) usize {
         const owned = self.inboundCiphertextOwned();
         const hard = self.buffer_limits.inbound_ciphertext.hard;
         if (owned >= hard) return 0;
         const hard_room = hard - owned;
+        if (self.hasActiveInboundParser()) return hard_room;
         const high = self.buffer_limits.inbound_ciphertext.high;
         const high_room = if (owned < high) high - owned else 0;
         return @min(hard_room, high_room);
@@ -1006,13 +1011,16 @@ pub const PureZigRecordStream = struct {
     pub fn feedHandshakeCiphertext(self: *PureZigRecordStream, epoch: events.EncryptionEpoch, bytes: []const u8) Error!usize {
         if (self.failed) |err| return err;
         if (self.lifecycle == .closed or self.lifecycle == .failed) return error.StreamClosed;
-        if (self.read_backpressured) return error.WouldBlock;
-        if (!self.hasHardRoom(.inbound_ciphertext, self.inboundCiphertextOwned(), bytes.len)) return self.rejectHardLimit(.inbound_ciphertext, error.WouldBlock);
+        if (self.read_backpressured and !self.hasActiveInboundParser()) return error.WouldBlock;
+        const owned = self.inboundCiphertextOwned();
+        const hard = self.buffer_limits.inbound_ciphertext.hard;
+        if (owned >= hard) return self.rejectHardLimit(.inbound_ciphertext, error.WouldBlock);
+        const feed_len = @min(bytes.len, hard - owned);
         if (self.inbound_handshake.available() < record_codec.max_plaintext_fragment_len) return error.WouldBlock;
         if (!self.hasHardRoom(.handshake, self.inbound_handshake.len, record_codec.max_plaintext_fragment_len)) return self.rejectHardLimit(.handshake, error.WouldBlock);
         var sink = record_codec.RecordSink(1, record_codec.max_ciphertext_fragment_len){};
         const parser = self.parserForEpoch(epoch);
-        const consumed = feedUntilOneRecord(parser, bytes, &sink) catch |err| return self.fail(err);
+        const consumed = feedUntilOneRecord(parser, bytes[0..feed_len], &sink) catch |err| return self.fail(err);
         self.noteQueueMutation();
         self.openHandshakeSink(epoch, &sink) catch |err| return self.fail(err);
         return consumed;
@@ -1042,13 +1050,25 @@ pub const PureZigRecordStream = struct {
         } else {
             if (!self.canProcessCarrierInput()) return error.WouldBlock;
         }
-        if (direct_external_feed and !self.hasHardRoom(.inbound_ciphertext, self.inboundCiphertextOwned(), bytes.len)) return self.rejectHardLimit(.inbound_ciphertext, error.WouldBlock);
+        var feed_bytes = bytes;
+        if (direct_external_feed) {
+            const owned = self.inboundCiphertextOwned();
+            const hard = self.buffer_limits.inbound_ciphertext.hard;
+            if (owned >= hard) return self.rejectHardLimit(.inbound_ciphertext, error.WouldBlock);
+            feed_bytes = bytes[0..@min(bytes.len, hard - owned)];
+        }
         if (self.inbound_plaintext.available() < record_codec.max_plaintext_fragment_len or self.inbound_handshake.available() < record_codec.max_plaintext_fragment_len) return error.WouldBlock;
-        if (!self.hasHardRoom(.inbound_plaintext, self.inbound_plaintext.len, record_codec.max_plaintext_fragment_len)) return self.rejectHardLimit(.inbound_plaintext, error.WouldBlock);
-        if (!self.hasHardRoom(.handshake, self.inbound_handshake.len, record_codec.max_plaintext_fragment_len)) return self.rejectHardLimit(.handshake, error.WouldBlock);
+        if (!self.hasHardRoom(.inbound_plaintext, self.inbound_plaintext.len, record_codec.max_plaintext_fragment_len)) {
+            if (direct_external_feed) return self.rejectHardLimit(.inbound_plaintext, error.WouldBlock);
+            return error.WouldBlock;
+        }
+        if (!self.hasHardRoom(.handshake, self.inbound_handshake.len, record_codec.max_plaintext_fragment_len)) {
+            if (direct_external_feed) return self.rejectHardLimit(.handshake, error.WouldBlock);
+            return error.WouldBlock;
+        }
         var sink = record_codec.RecordSink(1, record_codec.max_ciphertext_fragment_len){};
-        const consumed = feedUntilOneRecord(&self.ciphertext_parser, bytes, &sink) catch |err| return self.fail(err);
-        self.noteQueueMutation();
+        const consumed = feedUntilOneRecord(&self.ciphertext_parser, feed_bytes, &sink) catch |err| return self.fail(err);
+        if (direct_external_feed or consumed == 0) self.noteQueueMutation();
 
         var plaintext_buf: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
         for (sink.items[0..sink.len]) |record| {
@@ -1355,7 +1375,7 @@ pub const PureZigRecordStream = struct {
         var sink = record_codec.RecordSink(1, record_codec.max_ciphertext_fragment_len){};
         const parser = self.parserForEpoch(epoch);
         const consumed = feedUntilOneRecord(parser, bytes, &sink) catch |err| return self.fail(err);
-        self.noteQueueMutation();
+        if (consumed == 0) self.noteQueueMutation();
         var plaintext_buf: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
         for (sink.items[0..sink.len]) |record| {
             if (epoch == .initial and record.content_type == .alert) {
@@ -1396,7 +1416,7 @@ pub const PureZigRecordStream = struct {
 
     fn canAcceptCarrierRead(self: *const PureZigRecordStream) bool {
         return self.canProcessCarrierInput() and
-            !self.read_backpressured and
+            (!self.read_backpressured or self.hasActiveInboundParser()) and
             self.inbound_carrier.available() > 0;
     }
 
@@ -1957,15 +1977,15 @@ test "direct fragmented feed hard rejection leaves parser bytes retryable" {
         .high = record_codec.max_ciphertext_record_len,
         .hard = record_codec.max_ciphertext_record_len,
     };
-    stream_state.initial_parser.len = record_codec.max_ciphertext_record_len - 1;
+    stream_state.initial_parser.len = record_codec.max_ciphertext_record_len;
     stream_state.noteQueueMutation();
 
     const before = stream_state.stream().bufferSnapshot();
-    try testing.expectEqual(record_codec.max_ciphertext_record_len - 1, before.current.inbound_ciphertext);
+    try testing.expectEqual(record_codec.max_ciphertext_record_len, before.current.inbound_ciphertext);
     try testing.expectError(error.WouldBlock, stream_state.feedHandshakeCiphertext(.initial, &.{ 1, 2 }));
     const after = stream_state.stream().bufferSnapshot();
     try testing.expectEqual(before.current.inbound_ciphertext, after.current.inbound_ciphertext);
-    try testing.expectEqual(@as(usize, record_codec.max_ciphertext_record_len - 1), stream_state.initial_parser.len);
+    try testing.expectEqual(@as(usize, record_codec.max_ciphertext_record_len), stream_state.initial_parser.len);
     try testing.expectEqual(@as(u64, 1), after.counters.hard_limits.inbound_ciphertext);
 }
 
@@ -1995,15 +2015,8 @@ test "carrier reads cap at runtime high before hard limit" {
     };
 
     const cp = testProvider();
-    var bytes = [_]u8{0} ** record_codec.max_ciphertext_record_len;
-    bytes[0] = @intFromEnum(record_codec.ContentType.application_data);
-    bytes[1] = 0x03;
-    bytes[2] = 0x03;
-    std.mem.writeInt(u16, bytes[3..5], record_codec.max_ciphertext_fragment_len, .big);
-    const inbound_high = record_codec.max_plaintext_fragment_len;
-    const initial_owned = inbound_high - 8;
-    var carrier = SourceCarrier{ .bytes = bytes[initial_owned..], .expected_first_read_cap = 8 };
-    var stream_state = try PureZigRecordStream.initWithCarrierAndLimits(.server, cp, .tls_aes_128_gcm_sha256, carrier.carrier(), .{
+    const inbound_high = 64;
+    var stream_state = try PureZigRecordStream.initWithLimits(.server, cp, .tls_aes_128_gcm_sha256, .{
         .inbound_ciphertext = .{
             .low = 4,
             .high = inbound_high,
@@ -2025,22 +2038,100 @@ test "carrier reads cap at runtime high before hard limit" {
     var peer = PureZigRecordStream.init(.client, cp, .tls_aes_128_gcm_sha256);
     defer peer.deinit();
     try establish(&peer, &stream_state);
-    @memcpy(stream_state.ciphertext_parser.pending[0..initial_owned], bytes[0..initial_owned]);
-    stream_state.ciphertext_parser.len = initial_owned;
-    stream_state.noteQueueMutation();
-    try testing.expectEqual(initial_owned, stream_state.stream().bufferSnapshot().current.inbound_ciphertext);
 
-    while (!stream_state.stream().bufferSnapshot().pause_state.inbound_read_paused) {
-        const result = try stream_state.stream().drive();
-        try testing.expect(result.made_progress);
-    }
-    try testing.expectEqual(@as(usize, 8), carrier.offset);
+    var payload = [_]u8{'x'} ** 128;
+    try testing.expectEqual(payload.len, try peer.stream().write(&payload));
+    var record: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    const record_len = try peer.drainCiphertext(&record);
+    try testing.expect(record_len > inbound_high);
+
+    var carrier = SourceCarrier{ .bytes = record[0..record_len], .expected_first_read_cap = inbound_high };
+    stream_state.carrier = carrier.carrier();
+
+    const driven = try stream_state.stream().drive();
+    try testing.expect(driven.made_progress);
+    try testing.expectEqual(record_len, carrier.offset);
     const snapshot = stream_state.stream().bufferSnapshot();
-    try testing.expectEqual(inbound_high, snapshot.current.inbound_ciphertext);
-    try testing.expect(snapshot.pause_state.inbound_read_paused);
+    try testing.expectEqual(@as(usize, 0), snapshot.current.inbound_ciphertext);
+    try testing.expect(snapshot.peak.inbound_ciphertext <= record_len);
     try testing.expect(!snapshot.pause_state.plaintext_write_paused);
     try testing.expectEqual(@as(u64, 0), snapshot.counters.hard_limits.inbound_ciphertext);
     try testing.expectEqual(@as(u64, 1), snapshot.counters.inbound_read_pauses);
+
+    var out: [payload.len]u8 = undefined;
+    try testing.expectEqual(payload.len, try stream_state.stream().read(&out));
+    try testing.expectEqualSlices(u8, &payload, &out);
+    const resumed = stream_state.stream().bufferSnapshot();
+    try testing.expectEqual(@as(usize, 0), resumed.current.inbound_ciphertext);
+    try testing.expect(!resumed.pause_state.inbound_read_paused);
+    try testing.expectEqual(@as(u64, 1), resumed.counters.inbound_read_resumes);
+}
+
+test "internal carrier parser transfer does not double count partial records" {
+    const cp = testProvider();
+    var stream_state = try PureZigRecordStream.initWithLimits(.server, cp, .tls_aes_128_gcm_sha256, .{
+        .inbound_ciphertext = .{ .low = 32, .high = 64, .hard = record_codec.max_ciphertext_record_len },
+        .inbound_plaintext = BufferLimits.defaults().inbound_plaintext,
+        .outbound_ciphertext = BufferLimits.defaults().outbound_ciphertext,
+        .handshake = BufferLimits.defaults().handshake,
+    });
+    defer stream_state.deinit();
+    var peer = PureZigRecordStream.init(.client, cp, .tls_aes_128_gcm_sha256);
+    defer peer.deinit();
+    try establish(&peer, &stream_state);
+
+    try testing.expectEqual(@as(usize, 128), try peer.stream().write(&([_]u8{'p'} ** 128)));
+    var record: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    const record_len = try peer.drainCiphertext(&record);
+    try testing.expect(record_len > 40);
+
+    try stream_state.inbound_carrier.append(record[0..40]);
+    stream_state.noteQueueMutation();
+    var budget: usize = 1;
+    try testing.expect(try stream_state.processCarrierInputBudget(&budget));
+
+    const snapshot = stream_state.stream().bufferSnapshot();
+    try testing.expectEqual(@as(usize, 40), snapshot.current.inbound_ciphertext);
+    try testing.expectEqual(@as(usize, 40), snapshot.peak.inbound_ciphertext);
+    try testing.expect(!snapshot.pause_state.inbound_read_paused);
+}
+
+test "direct coalesced feed counts only consumed borrowed record against inbound hard limit" {
+    const cp = testProvider();
+    var client = PureZigRecordStream.init(.client, cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+    var server = try PureZigRecordStream.initWithLimits(.server, cp, .tls_aes_128_gcm_sha256, .{
+        .inbound_ciphertext = .{
+            .low = 4,
+            .high = record_codec.max_ciphertext_record_len,
+            .hard = record_codec.max_ciphertext_record_len,
+        },
+        .inbound_plaintext = BufferLimits.defaults().inbound_plaintext,
+        .outbound_ciphertext = BufferLimits.defaults().outbound_ciphertext,
+        .handshake = BufferLimits.defaults().handshake,
+    });
+    defer server.deinit();
+    try establish(&client, &server);
+
+    var coalesced: [record_codec.max_ciphertext_record_len * 2]u8 = undefined;
+    var payload = [_]u8{'m'} ** record_codec.max_plaintext_fragment_len;
+    try testing.expectEqual(payload.len, try client.stream().write(&payload));
+    const first_len = try client.drainCiphertext(coalesced[0..record_codec.max_ciphertext_record_len]);
+    try testing.expectEqual(payload.len, try client.stream().write(&payload));
+    const second_len = try client.drainCiphertext(coalesced[first_len..]);
+
+    const consumed = try server.feedCiphertext(coalesced[0 .. first_len + second_len]);
+    try testing.expectEqual(first_len, consumed);
+    var snapshot = server.stream().bufferSnapshot();
+    try testing.expectEqual(@as(u64, 0), snapshot.counters.hard_limits.inbound_ciphertext);
+    try testing.expectEqual(@as(usize, 0), snapshot.current.inbound_ciphertext);
+
+    var out: [record_codec.max_plaintext_fragment_len]u8 = undefined;
+    try testing.expectEqual(payload.len, try server.stream().read(&out));
+    try testing.expectEqualSlices(u8, &payload, &out);
+    try testing.expectEqual(second_len, try server.feedCiphertext(coalesced[first_len .. first_len + second_len]));
+    snapshot = server.stream().bufferSnapshot();
+    try testing.expectEqual(@as(u64, 0), snapshot.counters.hard_limits.inbound_ciphertext);
 }
 
 test "outbound ciphertext high-low hysteresis gates plaintext writes exactly once" {
@@ -2131,6 +2222,41 @@ test "paused drive reports no progress and counts stalls without transition infl
     try testing.expect(snapshot.pause_state.inbound_read_paused);
     try testing.expectEqual(@as(u64, 1), snapshot.counters.inbound_read_pauses);
     try testing.expectEqual(@as(u64, 0), snapshot.counters.inbound_read_resumes);
+    try testing.expectEqual(@as(u64, 2), snapshot.counters.stalled_drives);
+}
+
+test "internal destination hard backpressure does not inflate hard-limit counters" {
+    const cp = testProvider();
+    var client = PureZigRecordStream.init(.client, cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+    var server = try PureZigRecordStream.initWithLimits(.server, cp, .tls_aes_128_gcm_sha256, .{
+        .inbound_ciphertext = BufferLimits.defaults().inbound_ciphertext,
+        .inbound_plaintext = .{
+            .low = 1,
+            .high = 2,
+            .hard = record_codec.max_plaintext_fragment_len,
+        },
+        .outbound_ciphertext = BufferLimits.defaults().outbound_ciphertext,
+        .handshake = BufferLimits.defaults().handshake,
+    });
+    defer server.deinit();
+    try establish(&client, &server);
+
+    try testing.expectEqual(@as(usize, 5), try client.stream().write("block"));
+    var record: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    const record_len = try client.drainCiphertext(&record);
+    try server.inbound_carrier.append(record[0..record_len]);
+    try server.inbound_plaintext.append("hi");
+    server.noteQueueMutation();
+
+    for (0..2) |_| {
+        const result = try server.stream().drive();
+        try testing.expect(!result.made_progress);
+    }
+
+    const snapshot = server.stream().bufferSnapshot();
+    try testing.expect(snapshot.pause_state.inbound_read_paused);
+    try testing.expectEqual(@as(u64, 0), snapshot.counters.hard_limits.inbound_plaintext);
     try testing.expectEqual(@as(u64, 2), snapshot.counters.stalled_drives);
 }
 

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -704,17 +704,7 @@ pub const PureZigRecordStream = struct {
         self.noteQueueMutation();
     }
 
-    fn canReserveInboundPlaintextRecord(self: *PureZigRecordStream) bool {
-        return self.inbound_plaintext.available() >= record_codec.max_plaintext_fragment_len and
-            self.hasHardRoom(.inbound_plaintext, self.inbound_plaintext.len, record_codec.max_plaintext_fragment_len);
-    }
-
-    fn canReserveInboundHandshakeRecord(self: *PureZigRecordStream) bool {
-        return self.inbound_handshake.available() >= record_codec.max_plaintext_fragment_len and
-            self.hasHardRoom(.handshake, self.inbound_handshake.len, record_codec.max_plaintext_fragment_len);
-    }
-
-    fn canReserveOutboundRecord(self: *PureZigRecordStream) bool {
+    fn canReserveOutboundRecord(self: *const PureZigRecordStream) bool {
         return self.outbound_ciphertext.available() >= record_codec.max_ciphertext_record_len and
             self.hasHardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, record_codec.max_ciphertext_record_len);
     }
@@ -724,19 +714,49 @@ pub const PureZigRecordStream = struct {
             self.hasHardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, handshake_output_reserve);
     }
 
-    fn hasActiveInboundParser(self: *const PureZigRecordStream) bool {
-        return self.initial_parser.len > 0 or self.ciphertext_parser.len > 0;
+    fn activeInboundParser(self: *const PureZigRecordStream) *const record_codec.Parser {
+        if (self.bridge.handshake_complete) return &self.ciphertext_parser;
+        return switch (self.read_epoch) {
+            .initial => &self.initial_parser,
+            .handshake, .application, .zero_rtt => &self.ciphertext_parser,
+        };
     }
 
-    fn inboundCiphertextReadRoom(self: *const PureZigRecordStream) usize {
+    fn inboundCiphertextReadRoom(self: *const PureZigRecordStream) Error!usize {
         const owned = self.inboundCiphertextOwned();
         const hard = self.buffer_limits.inbound_ciphertext.hard;
         if (owned >= hard) return 0;
         const hard_room = hard - owned;
-        if (self.hasActiveInboundParser()) return hard_room;
+        const parser = self.activeInboundParser();
+        if (parser.len > 0) return @min(hard_room, try parser.pendingRecordBytesNeeded());
         const high = self.buffer_limits.inbound_ciphertext.high;
         const high_room = if (owned < high) high - owned else 0;
         return @min(hard_room, high_room);
+    }
+
+    fn inboundDestinationReserve(parser: *const record_codec.Parser, bytes: []const u8) Error!?usize {
+        const payload_len = try parser.pendingRecordPayloadLenWith(bytes) orelse return null;
+        // A TLSInnerPlaintext payload cannot contribute more than one plaintext
+        // fragment to either destination queue, even when ciphertext overhead
+        // makes its encoded payload larger.
+        return @min(payload_len, record_codec.max_plaintext_fragment_len);
+    }
+
+    fn hasInboundDestinationReserveFor(self: *const PureZigRecordStream, parser: *const record_codec.Parser, bytes: []const u8) Error!bool {
+        const needed = try inboundDestinationReserve(parser, bytes) orelse return true;
+        return self.inbound_plaintext.available() >= needed and
+            self.inbound_handshake.available() >= needed and
+            self.hasHardRoom(.inbound_plaintext, self.inbound_plaintext.len, needed) and
+            self.hasHardRoom(.handshake, self.inbound_handshake.len, needed);
+    }
+
+    fn hasRuntimeInboundDestinationReserve(self: *const PureZigRecordStream) Error!bool {
+        return self.hasInboundDestinationReserveFor(self.activeInboundParser(), &.{});
+    }
+
+    fn canContinueActiveRecord(self: *const PureZigRecordStream) bool {
+        const parser = self.activeInboundParser();
+        return parser.len > 0 and (self.inboundCiphertextReadRoom() catch return false) > 0;
     }
 
     pub fn applyEvent(self: *PureZigRecordStream, event: events.Event) Error!void {
@@ -1011,15 +1031,20 @@ pub const PureZigRecordStream = struct {
     pub fn feedHandshakeCiphertext(self: *PureZigRecordStream, epoch: events.EncryptionEpoch, bytes: []const u8) Error!usize {
         if (self.failed) |err| return err;
         if (self.lifecycle == .closed or self.lifecycle == .failed) return error.StreamClosed;
-        if (self.read_backpressured and !self.hasActiveInboundParser()) return error.WouldBlock;
         const owned = self.inboundCiphertextOwned();
         const hard = self.buffer_limits.inbound_ciphertext.hard;
         if (owned >= hard) return self.rejectHardLimit(.inbound_ciphertext, error.WouldBlock);
+        if (self.read_backpressured and !self.canContinueActiveRecord()) return error.WouldBlock;
         const feed_len = @min(bytes.len, hard - owned);
-        if (self.inbound_handshake.available() < record_codec.max_plaintext_fragment_len) return error.WouldBlock;
-        if (!self.hasHardRoom(.handshake, self.inbound_handshake.len, record_codec.max_plaintext_fragment_len)) return self.rejectHardLimit(.handshake, error.WouldBlock);
         var sink = record_codec.RecordSink(1, record_codec.max_ciphertext_fragment_len){};
         const parser = self.parserForEpoch(epoch);
+        if (!(self.hasInboundDestinationReserveFor(parser, bytes[0..feed_len]) catch |err| return self.fail(err))) {
+            const needed = inboundDestinationReserve(parser, bytes[0..feed_len]) catch |err| return self.fail(err);
+            if (needed) |reserve| {
+                if (self.inbound_handshake.available() < reserve) return error.WouldBlock;
+                if (!self.hasHardRoom(.handshake, self.inbound_handshake.len, reserve)) return self.rejectHardLimit(.handshake, error.WouldBlock);
+            }
+        }
         const consumed = feedUntilOneRecord(parser, bytes[0..feed_len], &sink) catch |err| return self.fail(err);
         self.noteQueueMutation();
         self.openHandshakeSink(epoch, &sink) catch |err| return self.fail(err);
@@ -1057,16 +1082,21 @@ pub const PureZigRecordStream = struct {
             if (owned >= hard) return self.rejectHardLimit(.inbound_ciphertext, error.WouldBlock);
             feed_bytes = bytes[0..@min(bytes.len, hard - owned)];
         }
-        if (self.inbound_plaintext.available() < record_codec.max_plaintext_fragment_len or self.inbound_handshake.available() < record_codec.max_plaintext_fragment_len) return error.WouldBlock;
-        if (!self.hasHardRoom(.inbound_plaintext, self.inbound_plaintext.len, record_codec.max_plaintext_fragment_len)) {
-            if (direct_external_feed) return self.rejectHardLimit(.inbound_plaintext, error.WouldBlock);
-            return error.WouldBlock;
-        }
-        if (!self.hasHardRoom(.handshake, self.inbound_handshake.len, record_codec.max_plaintext_fragment_len)) {
-            if (direct_external_feed) return self.rejectHardLimit(.handshake, error.WouldBlock);
-            return error.WouldBlock;
-        }
         var sink = record_codec.RecordSink(1, record_codec.max_ciphertext_fragment_len){};
+        if (!(self.hasInboundDestinationReserveFor(&self.ciphertext_parser, feed_bytes) catch |err| return self.fail(err))) {
+            const needed = inboundDestinationReserve(&self.ciphertext_parser, feed_bytes) catch |err| return self.fail(err);
+            if (needed) |reserve| {
+                if (self.inbound_plaintext.available() < reserve or self.inbound_handshake.available() < reserve) return error.WouldBlock;
+                if (!self.hasHardRoom(.inbound_plaintext, self.inbound_plaintext.len, reserve)) {
+                    if (direct_external_feed) return self.rejectHardLimit(.inbound_plaintext, error.WouldBlock);
+                    return error.WouldBlock;
+                }
+                if (!self.hasHardRoom(.handshake, self.inbound_handshake.len, reserve)) {
+                    if (direct_external_feed) return self.rejectHardLimit(.handshake, error.WouldBlock);
+                    return error.WouldBlock;
+                }
+            }
+        }
         const consumed = feedUntilOneRecord(&self.ciphertext_parser, feed_bytes, &sink) catch |err| return self.fail(err);
         if (direct_external_feed or consumed == 0) self.noteQueueMutation();
 
@@ -1160,7 +1190,7 @@ pub const PureZigRecordStream = struct {
             .wants_read = !self.carrier_eof and self.canAcceptCarrierRead(),
             .wants_write = self.outbound_ciphertext.len > 0 or (self.lifecycle == .closing and !self.close_notify_queued),
             .can_read_plaintext = self.inbound_plaintext.len > 0 or pending_terminal_read_ready,
-            .can_write_plaintext = self.pending_terminal_read_error == null and self.lifecycle == .open and self.bridge.handshake_complete and !self.write_backpressured and self.outbound_ciphertext.available() >= record_codec.max_ciphertext_record_len,
+            .can_write_plaintext = self.pending_terminal_read_error == null and self.lifecycle == .open and self.bridge.handshake_complete and !self.write_backpressured and self.canReserveOutboundRecord(),
             .peer_closed = self.peer_closed,
         };
     }
@@ -1246,7 +1276,8 @@ pub const PureZigRecordStream = struct {
             var read_total: usize = 0;
             while (!self.carrier_eof and read_total < drive_read_budget and self.canAcceptCarrierRead() and self.inbound_carrier.available() > 0) {
                 var buf: [drive_read_chunk]u8 = undefined;
-                const read_cap = @min(buf.len, @min(self.inbound_carrier.available(), @min(drive_read_budget - read_total, self.inboundCiphertextReadRoom())));
+                const read_room = self.inboundCiphertextReadRoom() catch |err| return self.fail(err);
+                const read_cap = @min(buf.len, @min(self.inbound_carrier.available(), @min(drive_read_budget - read_total, read_room)));
                 if (read_cap == 0) {
                     self.refreshBackpressure();
                     break;
@@ -1371,9 +1402,9 @@ pub const PureZigRecordStream = struct {
     /// plaintext: handshake content into the driver (applying its events),
     /// alerts through alert handling, anything else fails closed.
     fn feedHandshakeToDriver(self: *PureZigRecordStream, epoch: events.EncryptionEpoch, bytes: []const u8) Error!usize {
-        if (!self.canReserveInboundHandshakeRecord()) return error.WouldBlock;
         var sink = record_codec.RecordSink(1, record_codec.max_ciphertext_fragment_len){};
         const parser = self.parserForEpoch(epoch);
+        if (!(self.hasInboundDestinationReserveFor(parser, bytes) catch |err| return self.fail(err))) return error.WouldBlock;
         const consumed = feedUntilOneRecord(parser, bytes, &sink) catch |err| return self.fail(err);
         if (consumed == 0) self.noteQueueMutation();
         var plaintext_buf: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
@@ -1416,14 +1447,14 @@ pub const PureZigRecordStream = struct {
 
     fn canAcceptCarrierRead(self: *const PureZigRecordStream) bool {
         return self.canProcessCarrierInput() and
-            (!self.read_backpressured or self.hasActiveInboundParser()) and
-            self.inbound_carrier.available() > 0;
+            (!self.read_backpressured or self.canContinueActiveRecord()) and
+            self.inbound_carrier.available() > 0 and
+            (self.inboundCiphertextReadRoom() catch return false) > 0 and
+            (self.hasRuntimeInboundDestinationReserve() catch return false);
     }
 
     fn canProcessCarrierInput(self: *const PureZigRecordStream) bool {
-        return self.lifecycle != .closed and self.lifecycle != .failed and self.lifecycle != .closing and !self.peer_closed and
-            self.inbound_plaintext.available() >= record_codec.max_plaintext_fragment_len and
-            self.inbound_handshake.available() >= record_codec.max_plaintext_fragment_len;
+        return self.lifecycle != .closed and self.lifecycle != .failed and self.lifecycle != .closing and !self.peer_closed;
     }
 
     fn queueCloseNotify(self: *PureZigRecordStream) Error!bool {
@@ -1993,7 +2024,13 @@ test "carrier reads cap at runtime high before hard limit" {
     const SourceCarrier = struct {
         bytes: []const u8,
         offset: usize = 0,
-        expected_first_read_cap: usize,
+        expected_read_caps: []const usize,
+        read_index: usize = 0,
+        read_armed: bool = true,
+
+        fn rearm(self: *@This()) void {
+            self.read_armed = true;
+        }
 
         fn carrier(self: *@This()) Carrier {
             return .{ .ptr = self, .readFn = read, .writeFn = write };
@@ -2001,8 +2038,12 @@ test "carrier reads cap at runtime high before hard limit" {
 
         fn read(ptr: *anyopaque, out: []u8) Error!usize {
             const self: *@This() = @ptrCast(@alignCast(ptr));
+            if (!self.read_armed) return error.WouldBlock;
             if (self.offset == self.bytes.len) return error.WouldBlock;
-            if (self.offset == 0) testing.expectEqual(self.expected_first_read_cap, out.len) catch unreachable;
+            testing.expect(self.read_index < self.expected_read_caps.len) catch unreachable;
+            testing.expectEqual(self.expected_read_caps[self.read_index], out.len) catch unreachable;
+            self.read_index += 1;
+            self.read_armed = false;
             const n = @min(out.len, self.bytes.len - self.offset);
             @memcpy(out[0..n], self.bytes[self.offset..][0..n]);
             self.offset += n;
@@ -2041,19 +2082,31 @@ test "carrier reads cap at runtime high before hard limit" {
 
     var payload = [_]u8{'x'} ** 128;
     try testing.expectEqual(payload.len, try peer.stream().write(&payload));
-    var record: [record_codec.max_ciphertext_record_len]u8 = undefined;
-    const record_len = try peer.drainCiphertext(&record);
-    try testing.expect(record_len > inbound_high);
-
-    var carrier = SourceCarrier{ .bytes = record[0..record_len], .expected_first_read_cap = inbound_high };
+    var records: [record_codec.max_ciphertext_record_len * 2]u8 = undefined;
+    const first_len = try peer.drainCiphertext(records[0..record_codec.max_ciphertext_record_len]);
+    try testing.expect(first_len > inbound_high);
+    try testing.expectEqual(payload.len, try peer.stream().write(&payload));
+    const second_len = try peer.drainCiphertext(records[first_len..]);
+    const expected_read_caps = [_]usize{ inbound_high, first_len - inbound_high, inbound_high };
+    var carrier = SourceCarrier{
+        .bytes = records[0 .. first_len + second_len],
+        .expected_read_caps = &expected_read_caps,
+    };
     stream_state.carrier = carrier.carrier();
 
-    const driven = try stream_state.stream().drive();
-    try testing.expect(driven.made_progress);
-    try testing.expectEqual(record_len, carrier.offset);
+    const first = try stream_state.stream().drive();
+    try testing.expect(first.made_progress);
+    try testing.expectEqual(inbound_high, carrier.offset);
+    try testing.expect(stream_state.stream().bufferSnapshot().pause_state.inbound_read_paused);
+
+    carrier.rearm();
+    const continued = try stream_state.stream().drive();
+    try testing.expect(continued.made_progress);
+    try testing.expectEqual(first_len, carrier.offset);
+    try testing.expect(!continued.readiness.wants_read);
     const snapshot = stream_state.stream().bufferSnapshot();
     try testing.expectEqual(@as(usize, 0), snapshot.current.inbound_ciphertext);
-    try testing.expect(snapshot.peak.inbound_ciphertext <= record_len);
+    try testing.expect(snapshot.peak.inbound_ciphertext <= first_len);
     try testing.expect(!snapshot.pause_state.plaintext_write_paused);
     try testing.expectEqual(@as(u64, 0), snapshot.counters.hard_limits.inbound_ciphertext);
     try testing.expectEqual(@as(u64, 1), snapshot.counters.inbound_read_pauses);
@@ -2065,6 +2118,12 @@ test "carrier reads cap at runtime high before hard limit" {
     try testing.expectEqual(@as(usize, 0), resumed.current.inbound_ciphertext);
     try testing.expect(!resumed.pause_state.inbound_read_paused);
     try testing.expectEqual(@as(u64, 1), resumed.counters.inbound_read_resumes);
+
+    carrier.rearm();
+    const next_record = try stream_state.stream().drive();
+    try testing.expect(next_record.made_progress);
+    try testing.expectEqual(first_len + inbound_high, carrier.offset);
+    try testing.expectEqual(inbound_high, stream_state.ciphertext_parser.len);
 }
 
 test "internal carrier parser transfer does not double count partial records" {
@@ -2246,7 +2305,7 @@ test "internal destination hard backpressure does not inflate hard-limit counter
     var record: [record_codec.max_ciphertext_record_len]u8 = undefined;
     const record_len = try client.drainCiphertext(&record);
     try server.inbound_carrier.append(record[0..record_len]);
-    try server.inbound_plaintext.append("hi");
+    server.inbound_plaintext.len = record_codec.max_plaintext_fragment_len - 4;
     server.noteQueueMutation();
 
     for (0..2) |_| {
@@ -2276,6 +2335,9 @@ test "hard-limit write rejection leaves sequence and queue unchanged" {
     client.outbound_ciphertext.len = PureZigRecordStream.handshake_output_reserve - 1;
     const before_seq = client.bridge.write_application.?.sequence;
     const before_len = client.outbound_ciphertext.len;
+    try testing.expect(!client.stream().readiness().can_write_plaintext);
+    try testing.expect(!client.stream().readiness().can_write_plaintext);
+    try testing.expectEqual(@as(u64, 0), client.stream().bufferSnapshot().counters.hard_limits.outbound_ciphertext);
     try testing.expectError(error.WouldBlock, client.stream().write("no-mutate"));
     try testing.expectEqual(before_seq, client.bridge.write_application.?.sequence);
     try testing.expectEqual(before_len, client.outbound_ciphertext.len);
@@ -2405,8 +2467,8 @@ test "encrypted stream coalesced record backpressure consumes only retry-safe re
     const consumed = try server.feedCiphertext(coalesced[0..total_len]);
     try testing.expectEqual(first_len, consumed);
     try testing.expectEqual(read_seq + 1, server.bridge.read_application.?.sequence);
-    try testing.expectError(error.WouldBlock, server.feedCiphertext(coalesced[consumed..total_len]));
-    try testing.expectEqual(read_seq + 1, server.bridge.read_application.?.sequence);
+    try testing.expectEqual(second_len, try server.feedCiphertext(coalesced[consumed..total_len]));
+    try testing.expectEqual(read_seq + 2, server.bridge.read_application.?.sequence);
 }
 
 test "encrypted stream callers preserve partial feed suffixes across record boundaries" {
@@ -3268,12 +3330,17 @@ test "encrypted stream reports would-block and stable readiness without busy-loo
     try testing.expect(!before.can_read_plaintext);
     try testing.expect(!before.can_write_plaintext);
 
-    stream_state.inbound_handshake.len = 1;
+    stream_state.initial_parser.pending[0..5].* = .{ 22, 3, 3, 0, 2 };
+    stream_state.initial_parser.len = 5;
+    stream_state.inbound_handshake.len = PureZigRecordStream.max_handshake_queue - 1;
+    stream_state.noteQueueMutation();
     try testing.expect(!stream.readiness().wants_read);
     const blocked = try stream.drive();
     try testing.expect(!blocked.made_progress);
     try testing.expect(!blocked.readiness.wants_read);
     stream_state.inbound_handshake.len = 0;
+    stream_state.initial_parser.reset();
+    stream_state.noteQueueMutation();
 
     const drive = try stream.drive();
     try testing.expect(!drive.made_progress);

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -41,6 +41,7 @@ pub const Error = RecordHandshakeError || record_epoch_bridge.Error || error{
     WouldBlock,
     EndOfStream,
     StreamClosed,
+    InvalidBufferLimits,
     PlaintextBufferFull,
     CiphertextBufferFull,
     UnsupportedRecordContent,
@@ -84,6 +85,116 @@ pub const DriveResult = struct {
     readiness: Readiness,
 };
 
+pub const Watermark = struct {
+    low: usize,
+    high: usize,
+    hard: usize,
+
+    fn validate(self: Watermark, capacity: usize, reserve: usize) Error!void {
+        if (self.low == 0 or self.high == 0 or self.hard == 0) return error.InvalidBufferLimits;
+        if (!(self.low < self.high and self.high <= self.hard)) return error.InvalidBufferLimits;
+        if (self.hard > capacity) return error.InvalidBufferLimits;
+        if (self.hard < reserve) return error.InvalidBufferLimits;
+    }
+};
+
+pub const BufferLimits = struct {
+    inbound_ciphertext: Watermark,
+    inbound_plaintext: Watermark,
+    outbound_ciphertext: Watermark,
+    handshake: Watermark,
+
+    pub fn defaults() BufferLimits {
+        return .{
+            .inbound_ciphertext = defaultWatermark(PureZigRecordStream.max_carrier_input_queue, record_codec.max_ciphertext_record_len),
+            .inbound_plaintext = defaultWatermark(PureZigRecordStream.max_plaintext_queue, record_codec.max_plaintext_fragment_len),
+            .outbound_ciphertext = defaultWatermark(PureZigRecordStream.max_ciphertext_queue, PureZigRecordStream.handshake_output_reserve),
+            .handshake = defaultWatermark(PureZigRecordStream.max_handshake_queue, record_codec.max_plaintext_fragment_len),
+        };
+    }
+
+    pub fn validate(self: BufferLimits) Error!void {
+        try self.inbound_ciphertext.validate(PureZigRecordStream.max_carrier_input_queue, record_codec.max_ciphertext_record_len);
+        try self.inbound_plaintext.validate(PureZigRecordStream.max_plaintext_queue, record_codec.max_plaintext_fragment_len);
+        try self.outbound_ciphertext.validate(PureZigRecordStream.max_ciphertext_queue, PureZigRecordStream.handshake_output_reserve);
+        try self.handshake.validate(PureZigRecordStream.max_handshake_queue, record_codec.max_plaintext_fragment_len);
+    }
+
+    fn defaultWatermark(capacity: usize, reserve: usize) Watermark {
+        const low = @max(@as(usize, 1), @min(capacity / 4, capacity - 1));
+        _ = reserve;
+        const high_candidate = @max(low + 1, (capacity * 3) / 4);
+        return .{
+            .low = low,
+            .high = @min(high_candidate, capacity),
+            .hard = capacity,
+        };
+    }
+};
+
+pub const QueueBytes = struct {
+    inbound_ciphertext: usize = 0,
+    inbound_plaintext: usize = 0,
+    outbound_ciphertext: usize = 0,
+    handshake: usize = 0,
+
+    pub fn total(self: QueueBytes) usize {
+        return self.inbound_ciphertext + self.inbound_plaintext + self.outbound_ciphertext + self.handshake;
+    }
+};
+
+pub const QueueCounters = struct {
+    inbound_ciphertext: u64 = 0,
+    inbound_plaintext: u64 = 0,
+    outbound_ciphertext: u64 = 0,
+    handshake: u64 = 0,
+
+    fn increment(self: *QueueCounters, queue: BufferQueue) void {
+        switch (queue) {
+            .inbound_ciphertext => self.inbound_ciphertext += 1,
+            .inbound_plaintext => self.inbound_plaintext += 1,
+            .outbound_ciphertext => self.outbound_ciphertext += 1,
+            .handshake => self.handshake += 1,
+        }
+    }
+};
+
+pub const BufferCounters = struct {
+    inbound_read_pauses: u64 = 0,
+    inbound_read_resumes: u64 = 0,
+    plaintext_write_pauses: u64 = 0,
+    plaintext_write_resumes: u64 = 0,
+    hard_limits: QueueCounters = .{},
+    stalled_drives: u64 = 0,
+};
+
+pub const PauseState = struct {
+    inbound_read_paused: bool = false,
+    plaintext_write_paused: bool = false,
+};
+
+pub const AccountingBoundary = enum {
+    complete_stream_owned,
+    backend_opaque,
+};
+
+pub const BufferSnapshot = struct {
+    current: QueueBytes = .{},
+    peak: QueueBytes = .{},
+    peak_total: usize = 0,
+    limits: BufferLimits = BufferLimits.defaults(),
+    pause_state: PauseState = .{},
+    counters: BufferCounters = .{},
+    accounting_boundary: AccountingBoundary = .complete_stream_owned,
+};
+
+const BufferQueue = enum {
+    inbound_ciphertext,
+    inbound_plaintext,
+    outbound_ciphertext,
+    handshake,
+};
+
 pub const EncryptedStream = struct {
     ptr: *anyopaque,
     vtable: *const VTable,
@@ -95,6 +206,7 @@ pub const EncryptedStream = struct {
         closeFn: *const fn (*anyopaque) void,
         readinessFn: *const fn (*anyopaque) Readiness,
         driveFn: *const fn (*anyopaque) Error!DriveResult,
+        bufferSnapshotFn: *const fn (*anyopaque) BufferSnapshot,
     };
 
     pub fn backend(self: EncryptedStream) BackendKind {
@@ -122,6 +234,10 @@ pub const EncryptedStream = struct {
 
     pub fn drive(self: EncryptedStream) Error!DriveResult {
         return self.vtable.driveFn(self.ptr);
+    }
+
+    pub fn bufferSnapshot(self: EncryptedStream) BufferSnapshot {
+        return self.vtable.bufferSnapshotFn(self.ptr);
     }
 };
 
@@ -255,6 +371,12 @@ pub const PureZigRecordStream = struct {
     inbound_plaintext: ByteQueue(max_plaintext_queue, error.PlaintextBufferFull) = .{},
     outbound_ciphertext: ByteQueue(max_ciphertext_queue, error.CiphertextBufferFull) = .{},
     inbound_handshake: ByteQueue(max_handshake_queue, error.PlaintextBufferFull) = .{},
+    buffer_limits: BufferLimits = BufferLimits.defaults(),
+    buffer_peaks: QueueBytes = .{},
+    peak_total_owned: usize = 0,
+    buffer_counters: BufferCounters = .{},
+    read_backpressured: bool = false,
+    write_backpressured: bool = false,
     /// Negotiated ALPN protocol captured from the handshake, retained behind
     /// `negotiatedAlpn()` for later HTTP dispatch (out of scope here, #356).
     alpn_storage: [max_alpn_len]u8 = undefined,
@@ -297,9 +419,34 @@ pub const PureZigRecordStream = struct {
         };
     }
 
+    pub fn initWithLimits(
+        role: tls_state.Role,
+        crypto_provider: provider.CryptoProvider,
+        cipher_suite: algorithms.CipherSuite,
+        limits: BufferLimits,
+    ) Error!PureZigRecordStream {
+        try limits.validate();
+        var stream_state = init(role, crypto_provider, cipher_suite);
+        stream_state.buffer_limits = limits;
+        return stream_state;
+    }
+
     pub fn initWithCarrier(role: tls_state.Role, crypto_provider: provider.CryptoProvider, cipher_suite: algorithms.CipherSuite, carrier: Carrier) PureZigRecordStream {
         std.debug.assert(!carrier.owns_handle or carrier.closeFn != null);
         var stream_state = init(role, crypto_provider, cipher_suite);
+        stream_state.carrier = carrier;
+        return stream_state;
+    }
+
+    pub fn initWithCarrierAndLimits(
+        role: tls_state.Role,
+        crypto_provider: provider.CryptoProvider,
+        cipher_suite: algorithms.CipherSuite,
+        carrier: Carrier,
+        limits: BufferLimits,
+    ) Error!PureZigRecordStream {
+        std.debug.assert(!carrier.owns_handle or carrier.closeFn != null);
+        var stream_state = try initWithLimits(role, crypto_provider, cipher_suite, limits);
         stream_state.carrier = carrier;
         return stream_state;
     }
@@ -318,6 +465,18 @@ pub const PureZigRecordStream = struct {
         return stream_state;
     }
 
+    pub fn initWithBackendAndLimits(
+        role: tls_state.Role,
+        crypto_provider: provider.CryptoProvider,
+        cipher_suite: algorithms.CipherSuite,
+        backend: RecordHandshakeBackend,
+        limits: BufferLimits,
+    ) Error!PureZigRecordStream {
+        var stream_state = try initWithLimits(role, crypto_provider, cipher_suite, limits);
+        stream_state.handshake_driver = RecordHandshakeDriver.init(role, backend);
+        return stream_state;
+    }
+
     /// `initWithBackend` plus a nonblocking carrier, the production shape: a
     /// real backend driving a real handshake over a real byte-stream carrier.
     pub fn initWithCarrierAndBackend(
@@ -329,6 +488,20 @@ pub const PureZigRecordStream = struct {
     ) PureZigRecordStream {
         std.debug.assert(!carrier.owns_handle or carrier.closeFn != null);
         var stream_state = initWithBackend(role, crypto_provider, cipher_suite, backend);
+        stream_state.carrier = carrier;
+        return stream_state;
+    }
+
+    pub fn initWithCarrierBackendAndLimits(
+        role: tls_state.Role,
+        crypto_provider: provider.CryptoProvider,
+        cipher_suite: algorithms.CipherSuite,
+        carrier: Carrier,
+        backend: RecordHandshakeBackend,
+        limits: BufferLimits,
+    ) Error!PureZigRecordStream {
+        std.debug.assert(!carrier.owns_handle or carrier.closeFn != null);
+        var stream_state = try initWithBackendAndLimits(role, crypto_provider, cipher_suite, backend, limits);
         stream_state.carrier = carrier;
         return stream_state;
     }
@@ -359,10 +532,7 @@ pub const PureZigRecordStream = struct {
     pub fn deinit(self: *PureZigRecordStream) void {
         self.teardownDriver();
         self.bridge.deinit();
-        self.inbound_carrier.clear();
-        self.inbound_plaintext.clear();
-        self.outbound_ciphertext.clear();
-        self.inbound_handshake.clear();
+        self.clearOwnedQueues();
         self.clearHandshakeMetadata();
         self.initial_parser.reset();
         self.ciphertext_parser.reset();
@@ -408,13 +578,149 @@ pub const PureZigRecordStream = struct {
         return .{ .ptr = self, .vtable = &pure_zig_record_vtable };
     }
 
+    pub fn bufferSnapshot(self: *const PureZigRecordStream) BufferSnapshot {
+        return .{
+            .current = self.currentQueueBytes(),
+            .peak = self.buffer_peaks,
+            .peak_total = self.peak_total_owned,
+            .limits = self.buffer_limits,
+            .pause_state = .{
+                .inbound_read_paused = self.read_backpressured,
+                .plaintext_write_paused = self.write_backpressured,
+            },
+            .counters = self.buffer_counters,
+            .accounting_boundary = .complete_stream_owned,
+        };
+    }
+
+    fn currentQueueBytes(self: *const PureZigRecordStream) QueueBytes {
+        return .{
+            .inbound_ciphertext = self.inbound_carrier.len,
+            .inbound_plaintext = self.inbound_plaintext.len,
+            .outbound_ciphertext = self.outbound_ciphertext.len,
+            .handshake = self.inbound_handshake.len,
+        };
+    }
+
+    fn updateQueuePeaks(self: *PureZigRecordStream) void {
+        const current = self.currentQueueBytes();
+        self.buffer_peaks.inbound_ciphertext = @max(self.buffer_peaks.inbound_ciphertext, current.inbound_ciphertext);
+        self.buffer_peaks.inbound_plaintext = @max(self.buffer_peaks.inbound_plaintext, current.inbound_plaintext);
+        self.buffer_peaks.outbound_ciphertext = @max(self.buffer_peaks.outbound_ciphertext, current.outbound_ciphertext);
+        self.buffer_peaks.handshake = @max(self.buffer_peaks.handshake, current.handshake);
+        self.peak_total_owned = @max(self.peak_total_owned, current.total());
+    }
+
+    fn watermarkFor(self: *const PureZigRecordStream, queue: BufferQueue) Watermark {
+        return switch (queue) {
+            .inbound_ciphertext => self.buffer_limits.inbound_ciphertext,
+            .inbound_plaintext => self.buffer_limits.inbound_plaintext,
+            .outbound_ciphertext => self.buffer_limits.outbound_ciphertext,
+            .handshake => self.buffer_limits.handshake,
+        };
+    }
+
+    fn hardRoom(self: *PureZigRecordStream, queue: BufferQueue, current_len: usize, needed: usize) bool {
+        const hard = self.watermarkFor(queue).hard;
+        if (needed > hard or current_len > hard - needed) {
+            self.buffer_counters.hard_limits.increment(queue);
+            return false;
+        }
+        return true;
+    }
+
+    fn refreshBackpressure(self: *PureZigRecordStream) void {
+        const limits = self.buffer_limits;
+        const read_high = self.inbound_carrier.len >= limits.inbound_ciphertext.high or
+            self.inbound_plaintext.len >= limits.inbound_plaintext.high or
+            self.inbound_handshake.len >= limits.handshake.high;
+        const read_low = self.inbound_carrier.len <= limits.inbound_ciphertext.low and
+            self.inbound_plaintext.len <= limits.inbound_plaintext.low and
+            self.inbound_handshake.len <= limits.handshake.low;
+        if (!self.read_backpressured and read_high) {
+            self.read_backpressured = true;
+            self.buffer_counters.inbound_read_pauses += 1;
+        } else if (self.read_backpressured and read_low) {
+            self.read_backpressured = false;
+            self.buffer_counters.inbound_read_resumes += 1;
+        }
+
+        const write_high = self.outbound_ciphertext.len >= limits.outbound_ciphertext.high;
+        const write_low = self.outbound_ciphertext.len <= limits.outbound_ciphertext.low;
+        if (!self.write_backpressured and write_high) {
+            self.write_backpressured = true;
+            self.buffer_counters.plaintext_write_pauses += 1;
+        } else if (self.write_backpressured and write_low) {
+            self.write_backpressured = false;
+            self.buffer_counters.plaintext_write_resumes += 1;
+        }
+    }
+
+    fn noteQueueMutation(self: *PureZigRecordStream) void {
+        self.updateQueuePeaks();
+        self.refreshBackpressure();
+    }
+
+    fn clearOwnedQueues(self: *PureZigRecordStream) void {
+        self.inbound_carrier.clear();
+        self.inbound_plaintext.clear();
+        self.outbound_ciphertext.clear();
+        self.inbound_handshake.clear();
+        self.read_backpressured = false;
+        self.write_backpressured = false;
+    }
+
+    fn appendInboundCarrier(self: *PureZigRecordStream, bytes: []const u8) Error!void {
+        if (!self.hardRoom(.inbound_ciphertext, self.inbound_carrier.len, bytes.len)) return error.CarrierInputBufferFull;
+        try self.inbound_carrier.append(bytes);
+        self.noteQueueMutation();
+    }
+
+    fn appendInboundPlaintext(self: *PureZigRecordStream, bytes: []const u8) Error!void {
+        if (!self.hardRoom(.inbound_plaintext, self.inbound_plaintext.len, bytes.len)) return error.PlaintextBufferFull;
+        try self.inbound_plaintext.append(bytes);
+        self.noteQueueMutation();
+    }
+
+    fn appendInboundHandshake(self: *PureZigRecordStream, bytes: []const u8) Error!void {
+        if (!self.hardRoom(.handshake, self.inbound_handshake.len, bytes.len)) return error.PlaintextBufferFull;
+        try self.inbound_handshake.append(bytes);
+        self.noteQueueMutation();
+    }
+
+    fn appendOutboundCiphertext(self: *PureZigRecordStream, bytes: []const u8) Error!void {
+        if (!self.hardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, bytes.len)) return error.CiphertextBufferFull;
+        try self.outbound_ciphertext.append(bytes);
+        self.noteQueueMutation();
+    }
+
+    fn canReserveInboundPlaintextRecord(self: *PureZigRecordStream) bool {
+        return self.inbound_plaintext.available() >= record_codec.max_plaintext_fragment_len and
+            self.hardRoom(.inbound_plaintext, self.inbound_plaintext.len, record_codec.max_plaintext_fragment_len);
+    }
+
+    fn canReserveInboundHandshakeRecord(self: *PureZigRecordStream) bool {
+        return self.inbound_handshake.available() >= record_codec.max_plaintext_fragment_len and
+            self.hardRoom(.handshake, self.inbound_handshake.len, record_codec.max_plaintext_fragment_len);
+    }
+
+    fn canReserveOutboundRecord(self: *PureZigRecordStream) bool {
+        return self.outbound_ciphertext.available() >= record_codec.max_ciphertext_record_len and
+            self.hardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, record_codec.max_ciphertext_record_len);
+    }
+
+    fn canReserveHandshakeOutputBatch(self: *PureZigRecordStream) bool {
+        return self.outbound_ciphertext.available() >= handshake_output_reserve and
+            self.hardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, handshake_output_reserve);
+    }
+
     pub fn applyEvent(self: *PureZigRecordStream, event: events.Event) Error!void {
         if (self.failed) |err| return err;
         if (self.lifecycle == .closed or self.lifecycle == .failed or self.lifecycle == .closing) return error.StreamClosed;
-        if (event == .handshake_bytes and self.outbound_ciphertext.available() < record_codec.max_ciphertext_record_len) return error.WouldBlock;
+        if (event == .handshake_bytes and !self.canReserveOutboundRecord()) return error.WouldBlock;
         var record_buf: [record_codec.max_ciphertext_record_len]u8 = undefined;
         if (self.bridge.applyEvent(event, &record_buf) catch |err| return self.fail(err)) |record| {
-            self.outbound_ciphertext.append(record) catch |err| return self.fail(err);
+            self.appendOutboundCiphertext(record) catch |err| return self.fail(err);
         }
         // The initial epoch's plaintext parser is only safe to keep once
         // its keys are gone: nothing should ever arrive at that epoch
@@ -472,7 +778,7 @@ pub const PureZigRecordStream = struct {
     fn startHandshakeIfNeeded(self: *PureZigRecordStream) Error!bool {
         if (!self.driverPresent() or self.handshake_started) return false;
         if (self.bridge.handshake_complete or self.lifecycle != .handshaking) return false;
-        if (self.outbound_ciphertext.available() < handshake_output_reserve) return false;
+        if (!self.canReserveHandshakeOutputBatch()) return false;
         self.handshake_started = true;
         const driver = &self.handshake_driver.?;
         const outcome = driver.startOutcome({});
@@ -510,7 +816,7 @@ pub const PureZigRecordStream = struct {
                 .handshake_bytes => |hb| {
                     var record_buf: [record_codec.max_ciphertext_record_len]u8 = undefined;
                     const record = self.bridge.sealHandshake(hb.epoch, hb.data, &record_buf) catch |err| return self.fail(err);
-                    self.outbound_ciphertext.append(record) catch |err| return self.fail(err);
+                    self.appendOutboundCiphertext(record) catch |err| return self.fail(err);
                 },
                 .traffic_secret => |ts| {
                     self.bridge.installTrafficSecret(ts.epoch, ts.direction, ts.data) catch |err| return self.fail(err);
@@ -663,7 +969,7 @@ pub const PureZigRecordStream = struct {
     /// outbound queue. Silently skips if keys or capacity are unavailable --
     /// a lost alert must never erase the underlying handshake failure.
     fn queueFatalAlert(self: *PureZigRecordStream, desc: alerts.AlertDescription) void {
-        if (self.outbound_ciphertext.available() < record_codec.max_ciphertext_record_len) return;
+        if (!self.canReserveOutboundRecord()) return;
         const payload = [_]u8{ 2, @intFromEnum(desc) }; // level = fatal(2)
         var alert_buf: [record_codec.max_ciphertext_record_len]u8 = undefined;
         const record = switch (self.write_epoch) {
@@ -671,13 +977,13 @@ pub const PureZigRecordStream = struct {
             .handshake, .application => self.bridge.sealProtected(self.write_epoch, .alert, &payload, &alert_buf) catch return,
             .zero_rtt => return,
         };
-        self.outbound_ciphertext.append(record) catch return;
+        self.appendOutboundCiphertext(record) catch return;
     }
 
     pub fn feedHandshakeCiphertext(self: *PureZigRecordStream, epoch: events.EncryptionEpoch, bytes: []const u8) Error!usize {
         if (self.failed) |err| return err;
         if (self.lifecycle == .closed or self.lifecycle == .failed) return error.StreamClosed;
-        if (self.inbound_handshake.available() < record_codec.max_plaintext_fragment_len) return error.WouldBlock;
+        if (self.read_backpressured or !self.canReserveInboundHandshakeRecord()) return error.WouldBlock;
         var sink = record_codec.RecordSink(1, record_codec.max_ciphertext_fragment_len){};
         const parser = self.parserForEpoch(epoch);
         const consumed = feedUntilOneRecord(parser, bytes, &sink) catch |err| return self.fail(err);
@@ -688,7 +994,10 @@ pub const PureZigRecordStream = struct {
     pub fn readHandshake(self: *PureZigRecordStream, out: []u8) Error!usize {
         if (self.failed) |err| return err;
         if (self.lifecycle == .closed or self.lifecycle == .failed) return error.StreamClosed;
-        if (self.inbound_handshake.read(out)) |n| return n;
+        if (self.inbound_handshake.read(out)) |n| {
+            self.noteQueueMutation();
+            return n;
+        }
         try self.raisePendingTerminalError();
         return error.WouldBlock;
     }
@@ -698,6 +1007,7 @@ pub const PureZigRecordStream = struct {
         if (self.lifecycle == .closed or self.lifecycle == .failed) return error.StreamClosed;
         if (self.peer_closed) return bytes.len;
         if (!self.canAcceptCarrierRead()) return error.WouldBlock;
+        if (!self.canReserveInboundPlaintextRecord() or !self.canReserveInboundHandshakeRecord()) return error.WouldBlock;
         var sink = record_codec.RecordSink(1, record_codec.max_ciphertext_fragment_len){};
         const consumed = feedUntilOneRecord(&self.ciphertext_parser, bytes, &sink) catch |err| return self.fail(err);
 
@@ -705,8 +1015,8 @@ pub const PureZigRecordStream = struct {
         for (sink.items[0..sink.len]) |record| {
             const opened = self.bridge.openProtected(.application, record, &plaintext_buf) catch |err| return self.fail(err);
             switch (opened.inner.content_type) {
-                .application_data => self.inbound_plaintext.append(opened.inner.content) catch |err| return self.fail(err),
-                .handshake => self.inbound_handshake.append(opened.inner.content) catch |err| return self.fail(err),
+                .application_data => self.appendInboundPlaintext(opened.inner.content) catch |err| return self.fail(err),
+                .handshake => self.appendInboundHandshake(opened.inner.content) catch |err| return self.fail(err),
                 .alert => self.handleAlert(opened.inner.content) catch |err| return self.fail(err),
                 .change_cipher_spec => return self.fail(error.UnsupportedRecordContent),
             }
@@ -724,7 +1034,10 @@ pub const PureZigRecordStream = struct {
         if (self.failed) |err| return err;
         if (self.pending_terminal) |err| return err;
         if (self.lifecycle == .closed or self.lifecycle == .failed) return error.StreamClosed;
-        if (self.inbound_plaintext.read(out)) |n| return n;
+        if (self.inbound_plaintext.read(out)) |n| {
+            self.noteQueueMutation();
+            return n;
+        }
         try self.raisePendingTerminalError();
         if (self.peer_closed) return error.EndOfStream;
         return error.WouldBlock;
@@ -737,18 +1050,21 @@ pub const PureZigRecordStream = struct {
         if (self.pending_terminal_read_error) |err| return err;
         if (bytes.len == 0) return 0;
         if (self.lifecycle != .open or !self.bridge.handshake_complete) return error.WouldBlock;
-        if (self.outbound_ciphertext.available() < record_codec.max_ciphertext_record_len) return error.WouldBlock;
+        if (self.write_backpressured or !self.canReserveOutboundRecord()) return error.WouldBlock;
 
         const n = @min(bytes.len, record_codec.max_plaintext_fragment_len);
         var record_buf: [record_codec.max_ciphertext_record_len]u8 = undefined;
         const record = self.bridge.sealApplicationData(bytes[0..n], &record_buf) catch |err| return self.fail(err);
-        self.outbound_ciphertext.append(record) catch |err| return self.fail(err);
+        self.appendOutboundCiphertext(record) catch |err| return self.fail(err);
         return n;
     }
 
     pub fn drainCiphertext(self: *PureZigRecordStream, out: []u8) Error!usize {
         if (self.failed) |err| return err;
-        if (self.outbound_ciphertext.read(out)) |n| return n;
+        if (self.outbound_ciphertext.read(out)) |n| {
+            self.noteQueueMutation();
+            return n;
+        }
         if (self.lifecycle == .closed or self.lifecycle == .failed) return error.StreamClosed;
         return error.WouldBlock;
     }
@@ -761,6 +1077,7 @@ pub const PureZigRecordStream = struct {
     pub fn consumeCiphertext(self: *PureZigRecordStream, count: usize) Error!void {
         if (self.failed) |err| return err;
         try self.outbound_ciphertext.discard(count);
+        self.noteQueueMutation();
         if (self.lifecycle == .closing and self.carrier == null and self.close_notify_queued and self.outbound_ciphertext.len == 0) {
             self.lifecycle = .closed;
         }
@@ -781,7 +1098,7 @@ pub const PureZigRecordStream = struct {
             .wants_read = !self.carrier_eof and self.canAcceptCarrierRead(),
             .wants_write = self.outbound_ciphertext.len > 0 or (self.lifecycle == .closing and !self.close_notify_queued),
             .can_read_plaintext = self.inbound_plaintext.len > 0 or pending_terminal_read_ready,
-            .can_write_plaintext = self.pending_terminal_read_error == null and self.lifecycle == .open and self.bridge.handshake_complete and self.outbound_ciphertext.available() >= record_codec.max_ciphertext_record_len,
+            .can_write_plaintext = self.pending_terminal_read_error == null and self.lifecycle == .open and self.bridge.handshake_complete and !self.write_backpressured and self.outbound_ciphertext.available() >= record_codec.max_ciphertext_record_len,
             .peer_closed = self.peer_closed,
         };
     }
@@ -882,7 +1199,7 @@ pub const PureZigRecordStream = struct {
                         self.carrier_eof = true;
                         made_progress = true;
                     } else {
-                        self.inbound_carrier.append(buf[0..read_len]) catch |err| return self.fail(err);
+                        self.appendInboundCarrier(buf[0..read_len]) catch |err| return self.fail(err);
                         read_total += read_len;
                         made_progress = true;
                         if (try self.processCarrierInputBudget(&record_budget_remaining)) made_progress = true;
@@ -908,6 +1225,9 @@ pub const PureZigRecordStream = struct {
             self.lifecycle = .closed;
             self.closeCarrier();
             made_progress = true;
+        }
+        if (!made_progress and (self.read_backpressured or self.write_backpressured)) {
+            self.buffer_counters.stalled_drives += 1;
         }
         return .{ .made_progress = made_progress, .readiness = self.readiness() };
     }
@@ -935,7 +1255,7 @@ pub const PureZigRecordStream = struct {
             }
             const opened = try self.bridge.openProtected(epoch, record, &plaintext_buf);
             switch (opened.inner.content_type) {
-                .handshake => try self.inbound_handshake.append(opened.inner.content),
+                .handshake => try self.appendInboundHandshake(opened.inner.content),
                 .alert => try self.handleAlert(opened.inner.content),
                 .application_data,
                 .change_cipher_spec,
@@ -972,7 +1292,7 @@ pub const PureZigRecordStream = struct {
             if (self.pending_terminal != null) return error.WouldBlock;
             // Preflight so a full emitted event batch serializes atomically; if
             // the outbound queue is too full, wait for the carrier to drain.
-            if (self.outbound_ciphertext.available() < handshake_output_reserve) return error.WouldBlock;
+            if (!self.canReserveHandshakeOutputBatch()) return error.WouldBlock;
             return self.feedHandshakeToDriver(self.read_epoch, bytes);
         }
         const epoch: events.EncryptionEpoch = if (self.bridge.hasReadKeys(.handshake)) .handshake else .initial;
@@ -983,6 +1303,7 @@ pub const PureZigRecordStream = struct {
     /// plaintext: handshake content into the driver (applying its events),
     /// alerts through alert handling, anything else fails closed.
     fn feedHandshakeToDriver(self: *PureZigRecordStream, epoch: events.EncryptionEpoch, bytes: []const u8) Error!usize {
+        if (!self.canReserveInboundHandshakeRecord()) return error.WouldBlock;
         var sink = record_codec.RecordSink(1, record_codec.max_ciphertext_fragment_len){};
         const parser = self.parserForEpoch(epoch);
         const consumed = feedUntilOneRecord(parser, bytes, &sink) catch |err| return self.fail(err);
@@ -1025,8 +1346,13 @@ pub const PureZigRecordStream = struct {
     }
 
     fn canAcceptCarrierRead(self: *const PureZigRecordStream) bool {
+        return self.canProcessCarrierInput() and
+            !self.read_backpressured and
+            self.inbound_carrier.available() > 0;
+    }
+
+    fn canProcessCarrierInput(self: *const PureZigRecordStream) bool {
         return self.lifecycle != .closed and self.lifecycle != .failed and self.lifecycle != .closing and !self.peer_closed and
-            self.inbound_carrier.available() > 0 and
             self.inbound_plaintext.available() >= record_codec.max_plaintext_fragment_len and
             self.inbound_handshake.available() >= record_codec.max_plaintext_fragment_len;
     }
@@ -1034,23 +1360,23 @@ pub const PureZigRecordStream = struct {
     fn queueCloseNotify(self: *PureZigRecordStream) Error!bool {
         if (self.lifecycle != .closing or self.close_notify_queued) return false;
         if (!self.bridge.handshake_complete) {
-            self.outbound_ciphertext.clear();
+            self.clearOwnedQueues();
             self.lifecycle = .closed;
             self.closeCarrier();
             return true;
         }
         if (self.outbound_ciphertext.len > 0) return false;
-        if (self.outbound_ciphertext.available() < record_codec.max_ciphertext_record_len) return false;
+        if (!self.canReserveOutboundRecord()) return false;
         var alert_buf: [record_codec.max_ciphertext_record_len]u8 = undefined;
         const close_notify = self.bridge.sealProtected(.application, .alert, &.{ 1, 0 }, &alert_buf) catch |err| return self.fail(err);
-        self.outbound_ciphertext.append(close_notify) catch |err| return self.fail(err);
+        self.appendOutboundCiphertext(close_notify) catch |err| return self.fail(err);
         self.close_notify_queued = true;
         return true;
     }
 
     fn processCarrierInputBudget(self: *PureZigRecordStream, record_budget_remaining: *usize) Error!bool {
         const initial_budget = record_budget_remaining.*;
-        while (record_budget_remaining.* > 0 and self.inbound_carrier.len > 0 and self.canAcceptCarrierRead()) {
+        while (record_budget_remaining.* > 0 and self.inbound_carrier.len > 0 and self.canProcessCarrierInput()) {
             const pending = self.inbound_carrier.slice();
             const consumed = self.feedCarrierCiphertext(pending) catch |err| switch (err) {
                 error.WouldBlock => break,
@@ -1058,6 +1384,7 @@ pub const PureZigRecordStream = struct {
             };
             if (consumed == 0) break;
             try self.inbound_carrier.discard(consumed);
+            self.noteQueueMutation();
             record_budget_remaining.* -= 1;
         }
         return record_budget_remaining.* != initial_budget;
@@ -1097,10 +1424,7 @@ pub const PureZigRecordStream = struct {
     fn fail(self: *PureZigRecordStream, err: Error) Error {
         self.failed = err;
         self.lifecycle = .failed;
-        self.inbound_carrier.clear();
-        self.inbound_plaintext.clear();
-        self.outbound_ciphertext.clear();
-        self.inbound_handshake.clear();
+        self.clearOwnedQueues();
         self.clearHandshakeMetadata();
         self.initial_parser.reset();
         self.ciphertext_parser.reset();
@@ -1148,6 +1472,11 @@ fn pureDrive(ptr: *anyopaque) Error!DriveResult {
     return self.drive();
 }
 
+fn pureBufferSnapshot(ptr: *anyopaque) BufferSnapshot {
+    const self: *PureZigRecordStream = @ptrCast(@alignCast(ptr));
+    return self.bufferSnapshot();
+}
+
 const pure_zig_record_vtable = EncryptedStream.VTable{
     .backendFn = pureBackend,
     .readFn = pureRead,
@@ -1155,6 +1484,7 @@ const pure_zig_record_vtable = EncryptedStream.VTable{
     .closeFn = pureClose,
     .readinessFn = pureReadiness,
     .driveFn = pureDrive,
+    .bufferSnapshotFn = pureBufferSnapshot,
 };
 
 fn ByteQueue(comptime capacity: usize, comptime full_error: Error) type {
@@ -1449,6 +1779,215 @@ test "encrypted stream backpressure is atomic around record protection state" {
     try testing.expectError(error.WouldBlock, server.feedCiphertext(record_bytes[0..record_len]));
     try testing.expectEqual(read_seq, server.bridge.read_application.?.sequence);
     server.inbound_plaintext.len = 0;
+}
+
+fn testBufferLimits() BufferLimits {
+    return .{
+        .inbound_ciphertext = .{ .low = 32, .high = 64, .hard = PureZigRecordStream.max_carrier_input_queue },
+        .inbound_plaintext = .{ .low = 4, .high = 8, .hard = PureZigRecordStream.max_plaintext_queue },
+        .outbound_ciphertext = .{ .low = 24, .high = 48, .hard = PureZigRecordStream.max_ciphertext_queue },
+        .handshake = .{ .low = 4, .high = 8, .hard = PureZigRecordStream.max_handshake_queue },
+    };
+}
+
+test "TLS buffer defaults validate and expose bounded snapshot" {
+    const limits = BufferLimits.defaults();
+    try limits.validate();
+
+    const cp = testProvider();
+    var client = PureZigRecordStream.init(.client, cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+    var server = PureZigRecordStream.init(.server, cp, .tls_aes_128_gcm_sha256);
+    defer server.deinit();
+    try establish(&client, &server);
+
+    try expectOpenIdleConformance(client.stream(), .pure_zig_record);
+    const snapshot = client.stream().bufferSnapshot();
+    try testing.expectEqual(@as(usize, 0), snapshot.current.total());
+    try testing.expectEqual(limits.outbound_ciphertext.hard, snapshot.limits.outbound_ciphertext.hard);
+    try testing.expect(!snapshot.pause_state.inbound_read_paused);
+    try testing.expect(!snapshot.pause_state.plaintext_write_paused);
+    try testing.expectEqual(AccountingBoundary.complete_stream_owned, snapshot.accounting_boundary);
+}
+
+test "TLS buffer policy rejects invalid watermarks and over-capacity hard limits" {
+    var limits = BufferLimits.defaults();
+    limits.inbound_plaintext.low = 0;
+    try testing.expectError(error.InvalidBufferLimits, limits.validate());
+
+    limits = BufferLimits.defaults();
+    limits.inbound_plaintext.low = limits.inbound_plaintext.high;
+    try testing.expectError(error.InvalidBufferLimits, limits.validate());
+
+    limits = BufferLimits.defaults();
+    limits.outbound_ciphertext.high = limits.outbound_ciphertext.hard + 1;
+    try testing.expectError(error.InvalidBufferLimits, limits.validate());
+
+    limits = BufferLimits.defaults();
+    limits.handshake.hard = record_codec.max_plaintext_fragment_len - 1;
+    try testing.expectError(error.InvalidBufferLimits, limits.validate());
+
+    limits = BufferLimits.defaults();
+    limits.inbound_ciphertext.hard = PureZigRecordStream.max_carrier_input_queue + 1;
+    try testing.expectError(error.InvalidBufferLimits, limits.validate());
+}
+
+test "outbound ciphertext high-low hysteresis gates plaintext writes exactly once" {
+    const cp = testProvider();
+    var client = try PureZigRecordStream.initWithLimits(.client, cp, .tls_aes_128_gcm_sha256, testBufferLimits());
+    defer client.deinit();
+    var server = try PureZigRecordStream.initWithLimits(.server, cp, .tls_aes_128_gcm_sha256, testBufferLimits());
+    defer server.deinit();
+    try establish(&client, &server);
+
+    var writes: usize = 0;
+    while (client.stream().readiness().can_write_plaintext) : (writes += 1) {
+        _ = try client.stream().write("pause-me");
+    }
+    try testing.expect(writes > 0);
+
+    var snapshot = client.stream().bufferSnapshot();
+    try testing.expect(snapshot.current.outbound_ciphertext >= snapshot.limits.outbound_ciphertext.high);
+    try testing.expect(snapshot.pause_state.plaintext_write_paused);
+    try testing.expectEqual(@as(u64, 1), snapshot.counters.plaintext_write_pauses);
+    try testing.expectEqual(@as(u64, 0), snapshot.counters.plaintext_write_resumes);
+    try testing.expectError(error.WouldBlock, client.stream().write("blocked"));
+    try testing.expectEqual(@as(u64, 1), client.stream().bufferSnapshot().counters.plaintext_write_pauses);
+
+    var drained: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    while (client.stream().bufferSnapshot().current.outbound_ciphertext > snapshot.limits.outbound_ciphertext.low) {
+        _ = try client.drainCiphertext(drained[0..1]);
+    }
+    snapshot = client.stream().bufferSnapshot();
+    try testing.expect(!snapshot.pause_state.plaintext_write_paused);
+    try testing.expect(snapshot.current.outbound_ciphertext <= snapshot.limits.outbound_ciphertext.low);
+    try testing.expectEqual(@as(u64, 1), snapshot.counters.plaintext_write_resumes);
+    try testing.expect(client.stream().readiness().can_write_plaintext);
+}
+
+test "inbound plaintext high-low hysteresis gates carrier reads and resumes below low" {
+    const cp = testProvider();
+    var client = try PureZigRecordStream.initWithLimits(.client, cp, .tls_aes_128_gcm_sha256, testBufferLimits());
+    defer client.deinit();
+    var server = try PureZigRecordStream.initWithLimits(.server, cp, .tls_aes_128_gcm_sha256, testBufferLimits());
+    defer server.deinit();
+    try establish(&client, &server);
+
+    _ = try client.stream().write("0123456789");
+    var record: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    const record_len = try client.drainCiphertext(&record);
+    try feedAllCiphertext(&server, record[0..record_len]);
+
+    var snapshot = server.stream().bufferSnapshot();
+    try testing.expect(snapshot.current.inbound_plaintext >= snapshot.limits.inbound_plaintext.high);
+    try testing.expect(snapshot.pause_state.inbound_read_paused);
+    try testing.expect(!server.stream().readiness().wants_read);
+    try testing.expectEqual(@as(u64, 1), snapshot.counters.inbound_read_pauses);
+
+    const stable = server.stream().readiness();
+    try testing.expectEqual(stable, server.stream().readiness());
+    try testing.expectEqual(@as(u64, 1), server.stream().bufferSnapshot().counters.inbound_read_pauses);
+
+    var plain: [16]u8 = undefined;
+    _ = try server.stream().read(plain[0..6]);
+    snapshot = server.stream().bufferSnapshot();
+    try testing.expect(snapshot.current.inbound_plaintext <= snapshot.limits.inbound_plaintext.low);
+    try testing.expect(!snapshot.pause_state.inbound_read_paused);
+    try testing.expectEqual(@as(u64, 1), snapshot.counters.inbound_read_resumes);
+    try testing.expect(server.stream().readiness().wants_read);
+}
+
+test "paused drive reports no progress and counts stalls without transition inflation" {
+    const cp = testProvider();
+    var client = try PureZigRecordStream.initWithLimits(.client, cp, .tls_aes_128_gcm_sha256, testBufferLimits());
+    defer client.deinit();
+    var server = try PureZigRecordStream.initWithLimits(.server, cp, .tls_aes_128_gcm_sha256, testBufferLimits());
+    defer server.deinit();
+    try establish(&client, &server);
+
+    _ = try client.stream().write("0123456789");
+    var record: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    const record_len = try client.drainCiphertext(&record);
+    try feedAllCiphertext(&server, record[0..record_len]);
+
+    const first = try server.stream().drive();
+    const second = try server.stream().drive();
+    try testing.expect(!first.made_progress);
+    try testing.expect(!second.made_progress);
+    try testing.expectEqual(first.readiness, second.readiness);
+
+    const snapshot = server.stream().bufferSnapshot();
+    try testing.expect(snapshot.pause_state.inbound_read_paused);
+    try testing.expectEqual(@as(u64, 1), snapshot.counters.inbound_read_pauses);
+    try testing.expectEqual(@as(u64, 0), snapshot.counters.inbound_read_resumes);
+    try testing.expectEqual(@as(u64, 2), snapshot.counters.stalled_drives);
+}
+
+test "hard-limit write rejection leaves sequence and queue unchanged" {
+    const cp = testProvider();
+    var client = PureZigRecordStream.init(.client, cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+    var server = PureZigRecordStream.init(.server, cp, .tls_aes_128_gcm_sha256);
+    defer server.deinit();
+    try establish(&client, &server);
+
+    client.buffer_limits.outbound_ciphertext = .{
+        .low = 1,
+        .high = PureZigRecordStream.handshake_output_reserve,
+        .hard = PureZigRecordStream.handshake_output_reserve,
+    };
+    client.outbound_ciphertext.len = PureZigRecordStream.handshake_output_reserve - 1;
+    const before_seq = client.bridge.write_application.?.sequence;
+    const before_len = client.outbound_ciphertext.len;
+    try testing.expectError(error.WouldBlock, client.stream().write("no-mutate"));
+    try testing.expectEqual(before_seq, client.bridge.write_application.?.sequence);
+    try testing.expectEqual(before_len, client.outbound_ciphertext.len);
+
+    const snapshot = client.stream().bufferSnapshot();
+    try testing.expectEqual(@as(u64, 1), snapshot.counters.hard_limits.outbound_ciphertext);
+}
+
+test "handshake buffer backpressure is independent of application plaintext" {
+    const cp = testProvider();
+    var client = try PureZigRecordStream.initWithLimits(.client, cp, .tls_aes_128_gcm_sha256, testBufferLimits());
+    defer client.deinit();
+    var server = try PureZigRecordStream.initWithLimits(.server, cp, .tls_aes_128_gcm_sha256, testBufferLimits());
+    defer server.deinit();
+
+    try client.applyEvent(.{ .handshake_bytes = .{ .epoch = .initial, .data = "handshake!" } });
+    _ = try pumpHandshake(&client, &server, .initial, record_codec.max_ciphertext_record_len);
+
+    var snapshot = server.stream().bufferSnapshot();
+    try testing.expectEqual(@as(usize, 0), snapshot.current.inbound_plaintext);
+    try testing.expect(snapshot.current.handshake >= snapshot.limits.handshake.high);
+    try testing.expect(snapshot.pause_state.inbound_read_paused);
+
+    var handshake_buf: [32]u8 = undefined;
+    const n = try server.readHandshake(handshake_buf[0..6]);
+    try testing.expectEqual(@as(usize, 6), n);
+    snapshot = server.stream().bufferSnapshot();
+    try testing.expect(snapshot.current.handshake <= snapshot.limits.handshake.low);
+    try testing.expect(!snapshot.pause_state.inbound_read_paused);
+}
+
+test "buffer snapshot totals peaks and teardown current bytes are accurate" {
+    const cp = testProvider();
+    var client = try PureZigRecordStream.initWithLimits(.client, cp, .tls_aes_128_gcm_sha256, testBufferLimits());
+    var server = try PureZigRecordStream.initWithLimits(.server, cp, .tls_aes_128_gcm_sha256, testBufferLimits());
+    defer server.deinit();
+    try establish(&client, &server);
+
+    _ = try client.stream().write("snapshot");
+    var snapshot = client.stream().bufferSnapshot();
+    try testing.expect(snapshot.current.outbound_ciphertext > 0);
+    try testing.expectEqual(snapshot.current.total(), snapshot.current.inbound_ciphertext + snapshot.current.inbound_plaintext + snapshot.current.outbound_ciphertext + snapshot.current.handshake);
+    try testing.expect(snapshot.peak.outbound_ciphertext >= snapshot.current.outbound_ciphertext);
+    try testing.expect(snapshot.peak_total >= snapshot.current.total());
+
+    client.deinit();
+    snapshot = client.stream().bufferSnapshot();
+    try testing.expectEqual(@as(usize, 0), snapshot.current.total());
+    try testing.expect(snapshot.peak_total > 0);
 }
 
 test "encrypted stream coalesced record backpressure consumes only retry-safe records" {
@@ -2406,6 +2945,23 @@ test "encrypted stream interface accepts vtable-shaped and pure-Zig backends" {
             return .{ .made_progress = false, .readiness = readiness(ptr) };
         }
 
+        fn bufferSnapshot(ptr: *anyopaque) BufferSnapshot {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            return .{
+                .current = .{
+                    .inbound_plaintext = self.inbound.len,
+                    .outbound_ciphertext = self.outbound.len,
+                },
+                .peak = .{
+                    .inbound_plaintext = self.inbound.len,
+                    .outbound_ciphertext = self.outbound.len,
+                },
+                .peak_total = self.inbound.len + self.outbound.len,
+                .pause_state = .{ .plaintext_write_paused = self.closed or self.outbound.available() == 0 },
+                .accounting_boundary = .backend_opaque,
+            };
+        }
+
         const vtable = EncryptedStream.VTable{
             .backendFn = backend,
             .readFn = read,
@@ -2413,6 +2969,7 @@ test "encrypted stream interface accepts vtable-shaped and pure-Zig backends" {
             .closeFn = close,
             .readinessFn = readiness,
             .driveFn = drive,
+            .bufferSnapshotFn = bufferSnapshot,
         };
     };
 
@@ -2428,6 +2985,103 @@ test "encrypted stream interface accepts vtable-shaped and pure-Zig backends" {
     defer native.deinit();
     streams[0] = native.stream();
     try testing.expectEqual(BackendKind.pure_zig_record, streams[0].backend());
+}
+
+const MockHttpInterest = struct {
+    register_read: bool,
+    register_write: bool,
+    accept_plaintext: bool,
+    consume_plaintext: bool,
+    read_paused: bool,
+    write_paused: bool,
+};
+
+fn mockHttpInterest(stream: EncryptedStream) MockHttpInterest {
+    const readiness = stream.readiness();
+    const snapshot = stream.bufferSnapshot();
+    return .{
+        .register_read = readiness.wants_read,
+        .register_write = readiness.wants_write,
+        .accept_plaintext = readiness.can_write_plaintext,
+        .consume_plaintext = readiness.can_read_plaintext,
+        .read_paused = snapshot.pause_state.inbound_read_paused,
+        .write_paused = snapshot.pause_state.plaintext_write_paused,
+    };
+}
+
+test "backend-neutral mock HTTP consumer observes TLS backpressure without casts" {
+    const FakePausedOpenSsl = struct {
+        fn stream(self: *@This()) EncryptedStream {
+            return .{ .ptr = self, .vtable = &vtable };
+        }
+
+        fn backend(_: *anyopaque) BackendKind {
+            return .openssl;
+        }
+
+        fn read(_: *anyopaque, _: []u8) Error!usize {
+            return error.WouldBlock;
+        }
+
+        fn write(_: *anyopaque, _: []const u8) Error!usize {
+            return error.WouldBlock;
+        }
+
+        fn close(_: *anyopaque) void {}
+
+        fn readiness(_: *anyopaque) Readiness {
+            return .{ .wants_write = true };
+        }
+
+        fn drive(_: *anyopaque) Error!DriveResult {
+            return .{ .made_progress = false, .readiness = .{ .wants_write = true } };
+        }
+
+        fn bufferSnapshot(_: *anyopaque) BufferSnapshot {
+            return .{
+                .pause_state = .{ .inbound_read_paused = true, .plaintext_write_paused = true },
+                .accounting_boundary = .backend_opaque,
+            };
+        }
+
+        const vtable = EncryptedStream.VTable{
+            .backendFn = backend,
+            .readFn = read,
+            .writeFn = write,
+            .closeFn = close,
+            .readinessFn = readiness,
+            .driveFn = drive,
+            .bufferSnapshotFn = bufferSnapshot,
+        };
+    };
+
+    const cp = testProvider();
+    var native = try PureZigRecordStream.initWithLimits(.client, cp, .tls_aes_128_gcm_sha256, testBufferLimits());
+    defer native.deinit();
+    var peer = try PureZigRecordStream.initWithLimits(.server, cp, .tls_aes_128_gcm_sha256, testBufferLimits());
+    defer peer.deinit();
+    try establish(&native, &peer);
+
+    while (native.stream().readiness().can_write_plaintext) {
+        _ = try native.stream().write("pause-me");
+    }
+    const native_interest = mockHttpInterest(native.stream());
+    try testing.expect(native_interest.register_read);
+    try testing.expect(native_interest.register_write);
+    try testing.expect(!native_interest.accept_plaintext);
+    try testing.expect(!native_interest.consume_plaintext);
+    try testing.expect(!native_interest.read_paused);
+    try testing.expect(native_interest.write_paused);
+
+    var fake = FakePausedOpenSsl{};
+    const fake_interest = mockHttpInterest(fake.stream());
+    try testing.expect(!fake_interest.register_read);
+    try testing.expect(fake_interest.register_write);
+    try testing.expect(!fake_interest.accept_plaintext);
+    try testing.expect(!fake_interest.consume_plaintext);
+    try testing.expect(fake_interest.read_paused);
+    try testing.expect(fake_interest.write_paused);
+    try testing.expectEqual(AccountingBoundary.backend_opaque, fake.stream().bufferSnapshot().accounting_boundary);
 }
 
 test "server-role stream accepts the 0x0301 ClientHello compatibility version once, client-role does not" {

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -182,7 +182,8 @@ pub const BufferSnapshot = struct {
     current: QueueBytes = .{},
     peak: QueueBytes = .{},
     peak_total: usize = 0,
-    limits: BufferLimits = BufferLimits.defaults(),
+    limits: ?BufferLimits = null,
+    limits_enforced: bool = false,
     pause_state: PauseState = .{},
     counters: BufferCounters = .{},
     accounting_boundary: AccountingBoundary = .complete_stream_owned,
@@ -584,6 +585,7 @@ pub const PureZigRecordStream = struct {
             .peak = self.buffer_peaks,
             .peak_total = self.peak_total_owned,
             .limits = self.buffer_limits,
+            .limits_enforced = true,
             .pause_state = .{
                 .inbound_read_paused = self.read_backpressured,
                 .plaintext_write_paused = self.write_backpressured,
@@ -595,11 +597,15 @@ pub const PureZigRecordStream = struct {
 
     fn currentQueueBytes(self: *const PureZigRecordStream) QueueBytes {
         return .{
-            .inbound_ciphertext = self.inbound_carrier.len,
+            .inbound_ciphertext = self.inboundCiphertextOwned(),
             .inbound_plaintext = self.inbound_plaintext.len,
             .outbound_ciphertext = self.outbound_ciphertext.len,
             .handshake = self.inbound_handshake.len,
         };
+    }
+
+    fn inboundCiphertextOwned(self: *const PureZigRecordStream) usize {
+        return self.inbound_carrier.len + self.initial_parser.len + self.ciphertext_parser.len;
     }
 
     fn updateQueuePeaks(self: *PureZigRecordStream) void {
@@ -620,21 +626,23 @@ pub const PureZigRecordStream = struct {
         };
     }
 
-    fn hardRoom(self: *PureZigRecordStream, queue: BufferQueue, current_len: usize, needed: usize) bool {
+    fn hasHardRoom(self: *const PureZigRecordStream, queue: BufferQueue, current_len: usize, needed: usize) bool {
         const hard = self.watermarkFor(queue).hard;
-        if (needed > hard or current_len > hard - needed) {
-            self.buffer_counters.hard_limits.increment(queue);
-            return false;
-        }
-        return true;
+        return needed <= hard and current_len <= hard - needed;
+    }
+
+    fn rejectHardLimit(self: *PureZigRecordStream, queue: BufferQueue, err: Error) Error {
+        self.buffer_counters.hard_limits.increment(queue);
+        return err;
     }
 
     fn refreshBackpressure(self: *PureZigRecordStream) void {
         const limits = self.buffer_limits;
-        const read_high = self.inbound_carrier.len >= limits.inbound_ciphertext.high or
+        const inbound_ciphertext = self.inboundCiphertextOwned();
+        const read_high = inbound_ciphertext >= limits.inbound_ciphertext.high or
             self.inbound_plaintext.len >= limits.inbound_plaintext.high or
             self.inbound_handshake.len >= limits.handshake.high;
-        const read_low = self.inbound_carrier.len <= limits.inbound_ciphertext.low and
+        const read_low = inbound_ciphertext <= limits.inbound_ciphertext.low and
             self.inbound_plaintext.len <= limits.inbound_plaintext.low and
             self.inbound_handshake.len <= limits.handshake.low;
         if (!self.read_backpressured and read_high) {
@@ -666,58 +674,73 @@ pub const PureZigRecordStream = struct {
         self.inbound_plaintext.clear();
         self.outbound_ciphertext.clear();
         self.inbound_handshake.clear();
+        self.initial_parser.reset();
+        self.ciphertext_parser.reset();
         self.read_backpressured = false;
         self.write_backpressured = false;
     }
 
     fn appendInboundCarrier(self: *PureZigRecordStream, bytes: []const u8) Error!void {
-        if (!self.hardRoom(.inbound_ciphertext, self.inbound_carrier.len, bytes.len)) return error.CarrierInputBufferFull;
+        if (!self.hasHardRoom(.inbound_ciphertext, self.inboundCiphertextOwned(), bytes.len)) return self.rejectHardLimit(.inbound_ciphertext, error.CarrierInputBufferFull);
         try self.inbound_carrier.append(bytes);
         self.noteQueueMutation();
     }
 
     fn appendInboundPlaintext(self: *PureZigRecordStream, bytes: []const u8) Error!void {
-        if (!self.hardRoom(.inbound_plaintext, self.inbound_plaintext.len, bytes.len)) return error.PlaintextBufferFull;
+        if (!self.hasHardRoom(.inbound_plaintext, self.inbound_plaintext.len, bytes.len)) return self.rejectHardLimit(.inbound_plaintext, error.PlaintextBufferFull);
         try self.inbound_plaintext.append(bytes);
         self.noteQueueMutation();
     }
 
     fn appendInboundHandshake(self: *PureZigRecordStream, bytes: []const u8) Error!void {
-        if (!self.hardRoom(.handshake, self.inbound_handshake.len, bytes.len)) return error.PlaintextBufferFull;
+        if (!self.hasHardRoom(.handshake, self.inbound_handshake.len, bytes.len)) return self.rejectHardLimit(.handshake, error.PlaintextBufferFull);
         try self.inbound_handshake.append(bytes);
         self.noteQueueMutation();
     }
 
     fn appendOutboundCiphertext(self: *PureZigRecordStream, bytes: []const u8) Error!void {
-        if (!self.hardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, bytes.len)) return error.CiphertextBufferFull;
+        if (!self.hasHardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, bytes.len)) return self.rejectHardLimit(.outbound_ciphertext, error.CiphertextBufferFull);
         try self.outbound_ciphertext.append(bytes);
         self.noteQueueMutation();
     }
 
     fn canReserveInboundPlaintextRecord(self: *PureZigRecordStream) bool {
         return self.inbound_plaintext.available() >= record_codec.max_plaintext_fragment_len and
-            self.hardRoom(.inbound_plaintext, self.inbound_plaintext.len, record_codec.max_plaintext_fragment_len);
+            self.hasHardRoom(.inbound_plaintext, self.inbound_plaintext.len, record_codec.max_plaintext_fragment_len);
     }
 
     fn canReserveInboundHandshakeRecord(self: *PureZigRecordStream) bool {
         return self.inbound_handshake.available() >= record_codec.max_plaintext_fragment_len and
-            self.hardRoom(.handshake, self.inbound_handshake.len, record_codec.max_plaintext_fragment_len);
+            self.hasHardRoom(.handshake, self.inbound_handshake.len, record_codec.max_plaintext_fragment_len);
     }
 
     fn canReserveOutboundRecord(self: *PureZigRecordStream) bool {
         return self.outbound_ciphertext.available() >= record_codec.max_ciphertext_record_len and
-            self.hardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, record_codec.max_ciphertext_record_len);
+            self.hasHardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, record_codec.max_ciphertext_record_len);
     }
 
     fn canReserveHandshakeOutputBatch(self: *PureZigRecordStream) bool {
         return self.outbound_ciphertext.available() >= handshake_output_reserve and
-            self.hardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, handshake_output_reserve);
+            self.hasHardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, handshake_output_reserve);
+    }
+
+    fn inboundCiphertextReadRoom(self: *const PureZigRecordStream) usize {
+        const owned = self.inboundCiphertextOwned();
+        const hard = self.buffer_limits.inbound_ciphertext.hard;
+        if (owned >= hard) return 0;
+        const hard_room = hard - owned;
+        const high = self.buffer_limits.inbound_ciphertext.high;
+        const high_room = if (owned < high) high - owned else 0;
+        return @min(hard_room, high_room);
     }
 
     pub fn applyEvent(self: *PureZigRecordStream, event: events.Event) Error!void {
         if (self.failed) |err| return err;
         if (self.lifecycle == .closed or self.lifecycle == .failed or self.lifecycle == .closing) return error.StreamClosed;
-        if (event == .handshake_bytes and !self.canReserveOutboundRecord()) return error.WouldBlock;
+        if (event == .handshake_bytes) {
+            if (self.outbound_ciphertext.available() < record_codec.max_ciphertext_record_len) return error.WouldBlock;
+            if (!self.hasHardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, record_codec.max_ciphertext_record_len)) return self.rejectHardLimit(.outbound_ciphertext, error.WouldBlock);
+        }
         var record_buf: [record_codec.max_ciphertext_record_len]u8 = undefined;
         if (self.bridge.applyEvent(event, &record_buf) catch |err| return self.fail(err)) |record| {
             self.appendOutboundCiphertext(record) catch |err| return self.fail(err);
@@ -983,10 +1006,14 @@ pub const PureZigRecordStream = struct {
     pub fn feedHandshakeCiphertext(self: *PureZigRecordStream, epoch: events.EncryptionEpoch, bytes: []const u8) Error!usize {
         if (self.failed) |err| return err;
         if (self.lifecycle == .closed or self.lifecycle == .failed) return error.StreamClosed;
-        if (self.read_backpressured or !self.canReserveInboundHandshakeRecord()) return error.WouldBlock;
+        if (self.read_backpressured) return error.WouldBlock;
+        if (!self.hasHardRoom(.inbound_ciphertext, self.inboundCiphertextOwned(), bytes.len)) return self.rejectHardLimit(.inbound_ciphertext, error.WouldBlock);
+        if (self.inbound_handshake.available() < record_codec.max_plaintext_fragment_len) return error.WouldBlock;
+        if (!self.hasHardRoom(.handshake, self.inbound_handshake.len, record_codec.max_plaintext_fragment_len)) return self.rejectHardLimit(.handshake, error.WouldBlock);
         var sink = record_codec.RecordSink(1, record_codec.max_ciphertext_fragment_len){};
         const parser = self.parserForEpoch(epoch);
         const consumed = feedUntilOneRecord(parser, bytes, &sink) catch |err| return self.fail(err);
+        self.noteQueueMutation();
         self.openHandshakeSink(epoch, &sink) catch |err| return self.fail(err);
         return consumed;
     }
@@ -1003,13 +1030,25 @@ pub const PureZigRecordStream = struct {
     }
 
     pub fn feedCiphertext(self: *PureZigRecordStream, bytes: []const u8) Error!usize {
+        return self.feedCiphertextInternal(bytes, true);
+    }
+
+    fn feedCiphertextInternal(self: *PureZigRecordStream, bytes: []const u8, comptime direct_external_feed: bool) Error!usize {
         if (self.failed) |err| return err;
         if (self.lifecycle == .closed or self.lifecycle == .failed) return error.StreamClosed;
         if (self.peer_closed) return bytes.len;
-        if (!self.canAcceptCarrierRead()) return error.WouldBlock;
-        if (!self.canReserveInboundPlaintextRecord() or !self.canReserveInboundHandshakeRecord()) return error.WouldBlock;
+        if (direct_external_feed) {
+            if (!self.canAcceptCarrierRead()) return error.WouldBlock;
+        } else {
+            if (!self.canProcessCarrierInput()) return error.WouldBlock;
+        }
+        if (direct_external_feed and !self.hasHardRoom(.inbound_ciphertext, self.inboundCiphertextOwned(), bytes.len)) return self.rejectHardLimit(.inbound_ciphertext, error.WouldBlock);
+        if (self.inbound_plaintext.available() < record_codec.max_plaintext_fragment_len or self.inbound_handshake.available() < record_codec.max_plaintext_fragment_len) return error.WouldBlock;
+        if (!self.hasHardRoom(.inbound_plaintext, self.inbound_plaintext.len, record_codec.max_plaintext_fragment_len)) return self.rejectHardLimit(.inbound_plaintext, error.WouldBlock);
+        if (!self.hasHardRoom(.handshake, self.inbound_handshake.len, record_codec.max_plaintext_fragment_len)) return self.rejectHardLimit(.handshake, error.WouldBlock);
         var sink = record_codec.RecordSink(1, record_codec.max_ciphertext_fragment_len){};
         const consumed = feedUntilOneRecord(&self.ciphertext_parser, bytes, &sink) catch |err| return self.fail(err);
+        self.noteQueueMutation();
 
         var plaintext_buf: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
         for (sink.items[0..sink.len]) |record| {
@@ -1050,7 +1089,9 @@ pub const PureZigRecordStream = struct {
         if (self.pending_terminal_read_error) |err| return err;
         if (bytes.len == 0) return 0;
         if (self.lifecycle != .open or !self.bridge.handshake_complete) return error.WouldBlock;
-        if (self.write_backpressured or !self.canReserveOutboundRecord()) return error.WouldBlock;
+        if (self.write_backpressured) return error.WouldBlock;
+        if (self.outbound_ciphertext.available() < record_codec.max_ciphertext_record_len) return error.WouldBlock;
+        if (!self.hasHardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, record_codec.max_ciphertext_record_len)) return self.rejectHardLimit(.outbound_ciphertext, error.WouldBlock);
 
         const n = @min(bytes.len, record_codec.max_plaintext_fragment_len);
         var record_buf: [record_codec.max_ciphertext_record_len]u8 = undefined;
@@ -1079,6 +1120,7 @@ pub const PureZigRecordStream = struct {
         try self.outbound_ciphertext.discard(count);
         self.noteQueueMutation();
         if (self.lifecycle == .closing and self.carrier == null and self.close_notify_queued and self.outbound_ciphertext.len == 0) {
+            self.clearOwnedQueues();
             self.lifecycle = .closed;
         }
     }
@@ -1171,6 +1213,7 @@ pub const PureZigRecordStream = struct {
             }
 
             if (self.lifecycle == .closing and self.close_notify_queued and self.outbound_ciphertext.len == 0 and wrote_close_notify) {
+                self.clearOwnedQueues();
                 self.lifecycle = .closed;
                 self.closeCarrier();
                 made_progress = true;
@@ -1183,8 +1226,11 @@ pub const PureZigRecordStream = struct {
             var read_total: usize = 0;
             while (!self.carrier_eof and read_total < drive_read_budget and self.canAcceptCarrierRead() and self.inbound_carrier.available() > 0) {
                 var buf: [drive_read_chunk]u8 = undefined;
-                const read_cap = @min(buf.len, @min(self.inbound_carrier.available(), drive_read_budget - read_total));
-                if (read_cap == 0) break;
+                const read_cap = @min(buf.len, @min(self.inbound_carrier.available(), @min(drive_read_budget - read_total, self.inboundCiphertextReadRoom())));
+                if (read_cap == 0) {
+                    self.refreshBackpressure();
+                    break;
+                }
                 const maybe_read_len = carrier.read(buf[0..read_cap]) catch |err| switch (err) {
                     error.WouldBlock => null,
                     error.EndOfStream => eof: {
@@ -1214,6 +1260,7 @@ pub const PureZigRecordStream = struct {
         } else if (self.lifecycle == .closing) {
             if (try self.queueCloseNotify()) made_progress = true;
             if (self.close_notify_queued and self.outbound_ciphertext.len == 0) {
+                self.clearOwnedQueues();
                 self.lifecycle = .closed;
                 made_progress = true;
             }
@@ -1222,6 +1269,7 @@ pub const PureZigRecordStream = struct {
         }
 
         if (self.lifecycle == .closing and self.carrier != null and self.close_notify_queued and self.outbound_ciphertext.len == 0) {
+            self.clearOwnedQueues();
             self.lifecycle = .closed;
             self.closeCarrier();
             made_progress = true;
@@ -1285,7 +1333,7 @@ pub const PureZigRecordStream = struct {
     }
 
     fn feedCarrierCiphertext(self: *PureZigRecordStream, bytes: []const u8) Error!usize {
-        if (self.bridge.handshake_complete) return self.feedCiphertext(bytes);
+        if (self.bridge.handshake_complete) return self.feedCiphertextInternal(bytes, false);
         if (self.driverPresent()) {
             // A terminal handshake failure is pending its alert flush; stop
             // consuming carrier records until `drive()` latches it.
@@ -1307,6 +1355,7 @@ pub const PureZigRecordStream = struct {
         var sink = record_codec.RecordSink(1, record_codec.max_ciphertext_fragment_len){};
         const parser = self.parserForEpoch(epoch);
         const consumed = feedUntilOneRecord(parser, bytes, &sink) catch |err| return self.fail(err);
+        self.noteQueueMutation();
         var plaintext_buf: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
         for (sink.items[0..sink.len]) |record| {
             if (epoch == .initial and record.content_type == .alert) {
@@ -1515,8 +1564,11 @@ fn ByteQueue(comptime capacity: usize, comptime full_error: Error) type {
 
         fn discard(self: *Self, count: usize) Error!void {
             if (count > self.len) return error.WouldBlock;
-            std.mem.copyForwards(u8, self.buf[0 .. self.len - count], self.buf[count..self.len]);
-            self.len -= count;
+            const old_len = self.len;
+            const remaining = old_len - count;
+            std.mem.copyForwards(u8, self.buf[0..remaining], self.buf[count..old_len]);
+            @memset(self.buf[remaining..old_len], 0);
+            self.len = remaining;
         }
 
         fn available(self: *const Self) usize {
@@ -1524,7 +1576,7 @@ fn ByteQueue(comptime capacity: usize, comptime full_error: Error) type {
         }
 
         fn clear(self: *Self) void {
-            if (self.len > 0) @memset(self.buf[0..self.len], 0);
+            @memset(self.buf[0..], 0);
             self.len = 0;
         }
     };
@@ -1804,7 +1856,8 @@ test "TLS buffer defaults validate and expose bounded snapshot" {
     try expectOpenIdleConformance(client.stream(), .pure_zig_record);
     const snapshot = client.stream().bufferSnapshot();
     try testing.expectEqual(@as(usize, 0), snapshot.current.total());
-    try testing.expectEqual(limits.outbound_ciphertext.hard, snapshot.limits.outbound_ciphertext.hard);
+    try testing.expect(snapshot.limits_enforced);
+    try testing.expectEqual(limits.outbound_ciphertext.hard, snapshot.limits.?.outbound_ciphertext.hard);
     try testing.expect(!snapshot.pause_state.inbound_read_paused);
     try testing.expect(!snapshot.pause_state.plaintext_write_paused);
     try testing.expectEqual(AccountingBoundary.complete_stream_owned, snapshot.accounting_boundary);
@@ -1832,6 +1885,164 @@ test "TLS buffer policy rejects invalid watermarks and over-capacity hard limits
     try testing.expectError(error.InvalidBufferLimits, limits.validate());
 }
 
+test "TLS buffer policy rejects invalid combinations for every queue" {
+    inline for (.{ "inbound_ciphertext", "inbound_plaintext", "outbound_ciphertext", "handshake" }) |field| {
+        var zero = BufferLimits.defaults();
+        @field(zero, field).low = 0;
+        try testing.expectError(error.InvalidBufferLimits, zero.validate());
+
+        var ordered = BufferLimits.defaults();
+        @field(ordered, field).low = @field(ordered, field).high;
+        try testing.expectError(error.InvalidBufferLimits, ordered.validate());
+
+        var high_over_hard = BufferLimits.defaults();
+        @field(high_over_hard, field).high = @field(high_over_hard, field).hard + 1;
+        try testing.expectError(error.InvalidBufferLimits, high_over_hard.validate());
+
+        var over_capacity = BufferLimits.defaults();
+        @field(over_capacity, field).hard += 1;
+        try testing.expectError(error.InvalidBufferLimits, over_capacity.validate());
+    }
+
+    var inbound_below_reserve = BufferLimits.defaults();
+    inbound_below_reserve.inbound_ciphertext.hard = record_codec.max_ciphertext_record_len - 1;
+    try testing.expectError(error.InvalidBufferLimits, inbound_below_reserve.validate());
+
+    var plaintext_below_reserve = BufferLimits.defaults();
+    plaintext_below_reserve.inbound_plaintext.hard = record_codec.max_plaintext_fragment_len - 1;
+    try testing.expectError(error.InvalidBufferLimits, plaintext_below_reserve.validate());
+
+    var outbound_below_reserve = BufferLimits.defaults();
+    outbound_below_reserve.outbound_ciphertext.hard = PureZigRecordStream.handshake_output_reserve - 1;
+    try testing.expectError(error.InvalidBufferLimits, outbound_below_reserve.validate());
+
+    var handshake_below_reserve = BufferLimits.defaults();
+    handshake_below_reserve.handshake.hard = record_codec.max_plaintext_fragment_len - 1;
+    try testing.expectError(error.InvalidBufferLimits, handshake_below_reserve.validate());
+}
+
+test "fragmented records count parser-owned inbound ciphertext bytes" {
+    const cp = testProvider();
+    var stream_state = try PureZigRecordStream.initWithLimits(.server, cp, .tls_aes_128_gcm_sha256, testBufferLimits());
+    defer stream_state.deinit();
+
+    const payload = "fragmented";
+    var record: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    const encoded = try record_codec.encodePlaintextRecord(.handshake, payload, &record);
+
+    try testing.expectEqual(@as(usize, 2), try stream_state.feedHandshakeCiphertext(.initial, encoded[0..2]));
+    var snapshot = stream_state.stream().bufferSnapshot();
+    try testing.expectEqual(@as(usize, 2), snapshot.current.inbound_ciphertext);
+    try testing.expectEqual(@as(usize, 2), snapshot.peak.inbound_ciphertext);
+    try testing.expectEqual(@as(usize, 0), snapshot.current.handshake);
+
+    try testing.expectEqual(@as(usize, 3), try stream_state.feedHandshakeCiphertext(.initial, encoded[2..5]));
+    snapshot = stream_state.stream().bufferSnapshot();
+    try testing.expectEqual(@as(usize, 5), snapshot.current.inbound_ciphertext);
+    try testing.expectEqual(@as(usize, 5), snapshot.peak.inbound_ciphertext);
+
+    try testing.expectEqual(encoded.len - 5, try stream_state.feedHandshakeCiphertext(.initial, encoded[5..]));
+    snapshot = stream_state.stream().bufferSnapshot();
+    try testing.expectEqual(@as(usize, 0), snapshot.current.inbound_ciphertext);
+    try testing.expectEqual(@as(usize, 5), snapshot.peak.inbound_ciphertext);
+    try testing.expectEqual(payload.len, snapshot.current.handshake);
+}
+
+test "direct fragmented feed hard rejection leaves parser bytes retryable" {
+    const cp = testProvider();
+    var stream_state = PureZigRecordStream.init(.server, cp, .tls_aes_128_gcm_sha256);
+    defer stream_state.deinit();
+    stream_state.buffer_limits.inbound_ciphertext = .{
+        .low = 1,
+        .high = record_codec.max_ciphertext_record_len,
+        .hard = record_codec.max_ciphertext_record_len,
+    };
+    stream_state.initial_parser.len = record_codec.max_ciphertext_record_len - 1;
+    stream_state.noteQueueMutation();
+
+    const before = stream_state.stream().bufferSnapshot();
+    try testing.expectEqual(record_codec.max_ciphertext_record_len - 1, before.current.inbound_ciphertext);
+    try testing.expectError(error.WouldBlock, stream_state.feedHandshakeCiphertext(.initial, &.{ 1, 2 }));
+    const after = stream_state.stream().bufferSnapshot();
+    try testing.expectEqual(before.current.inbound_ciphertext, after.current.inbound_ciphertext);
+    try testing.expectEqual(@as(usize, record_codec.max_ciphertext_record_len - 1), stream_state.initial_parser.len);
+    try testing.expectEqual(@as(u64, 1), after.counters.hard_limits.inbound_ciphertext);
+}
+
+test "carrier reads cap at runtime high before hard limit" {
+    const SourceCarrier = struct {
+        bytes: []const u8,
+        offset: usize = 0,
+        expected_first_read_cap: usize,
+
+        fn carrier(self: *@This()) Carrier {
+            return .{ .ptr = self, .readFn = read, .writeFn = write };
+        }
+
+        fn read(ptr: *anyopaque, out: []u8) Error!usize {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            if (self.offset == self.bytes.len) return error.WouldBlock;
+            if (self.offset == 0) testing.expectEqual(self.expected_first_read_cap, out.len) catch unreachable;
+            const n = @min(out.len, self.bytes.len - self.offset);
+            @memcpy(out[0..n], self.bytes[self.offset..][0..n]);
+            self.offset += n;
+            return n;
+        }
+
+        fn write(_: *anyopaque, _: []const u8) Error!usize {
+            return error.WouldBlock;
+        }
+    };
+
+    const cp = testProvider();
+    var bytes = [_]u8{0} ** record_codec.max_ciphertext_record_len;
+    bytes[0] = @intFromEnum(record_codec.ContentType.application_data);
+    bytes[1] = 0x03;
+    bytes[2] = 0x03;
+    std.mem.writeInt(u16, bytes[3..5], record_codec.max_ciphertext_fragment_len, .big);
+    const inbound_high = record_codec.max_plaintext_fragment_len;
+    const initial_owned = inbound_high - 8;
+    var carrier = SourceCarrier{ .bytes = bytes[initial_owned..], .expected_first_read_cap = 8 };
+    var stream_state = try PureZigRecordStream.initWithCarrierAndLimits(.server, cp, .tls_aes_128_gcm_sha256, carrier.carrier(), .{
+        .inbound_ciphertext = .{
+            .low = 4,
+            .high = inbound_high,
+            .hard = record_codec.max_ciphertext_record_len,
+        },
+        .inbound_plaintext = .{
+            .low = 4,
+            .high = PureZigRecordStream.max_plaintext_queue,
+            .hard = PureZigRecordStream.max_plaintext_queue,
+        },
+        .outbound_ciphertext = BufferLimits.defaults().outbound_ciphertext,
+        .handshake = .{
+            .low = 4,
+            .high = PureZigRecordStream.max_handshake_queue,
+            .hard = PureZigRecordStream.max_handshake_queue,
+        },
+    });
+    defer stream_state.deinit();
+    var peer = PureZigRecordStream.init(.client, cp, .tls_aes_128_gcm_sha256);
+    defer peer.deinit();
+    try establish(&peer, &stream_state);
+    @memcpy(stream_state.ciphertext_parser.pending[0..initial_owned], bytes[0..initial_owned]);
+    stream_state.ciphertext_parser.len = initial_owned;
+    stream_state.noteQueueMutation();
+    try testing.expectEqual(initial_owned, stream_state.stream().bufferSnapshot().current.inbound_ciphertext);
+
+    while (!stream_state.stream().bufferSnapshot().pause_state.inbound_read_paused) {
+        const result = try stream_state.stream().drive();
+        try testing.expect(result.made_progress);
+    }
+    try testing.expectEqual(@as(usize, 8), carrier.offset);
+    const snapshot = stream_state.stream().bufferSnapshot();
+    try testing.expectEqual(inbound_high, snapshot.current.inbound_ciphertext);
+    try testing.expect(snapshot.pause_state.inbound_read_paused);
+    try testing.expect(!snapshot.pause_state.plaintext_write_paused);
+    try testing.expectEqual(@as(u64, 0), snapshot.counters.hard_limits.inbound_ciphertext);
+    try testing.expectEqual(@as(u64, 1), snapshot.counters.inbound_read_pauses);
+}
+
 test "outbound ciphertext high-low hysteresis gates plaintext writes exactly once" {
     const cp = testProvider();
     var client = try PureZigRecordStream.initWithLimits(.client, cp, .tls_aes_128_gcm_sha256, testBufferLimits());
@@ -1847,7 +2058,7 @@ test "outbound ciphertext high-low hysteresis gates plaintext writes exactly onc
     try testing.expect(writes > 0);
 
     var snapshot = client.stream().bufferSnapshot();
-    try testing.expect(snapshot.current.outbound_ciphertext >= snapshot.limits.outbound_ciphertext.high);
+    try testing.expect(snapshot.current.outbound_ciphertext >= snapshot.limits.?.outbound_ciphertext.high);
     try testing.expect(snapshot.pause_state.plaintext_write_paused);
     try testing.expectEqual(@as(u64, 1), snapshot.counters.plaintext_write_pauses);
     try testing.expectEqual(@as(u64, 0), snapshot.counters.plaintext_write_resumes);
@@ -1855,12 +2066,12 @@ test "outbound ciphertext high-low hysteresis gates plaintext writes exactly onc
     try testing.expectEqual(@as(u64, 1), client.stream().bufferSnapshot().counters.plaintext_write_pauses);
 
     var drained: [record_codec.max_ciphertext_record_len]u8 = undefined;
-    while (client.stream().bufferSnapshot().current.outbound_ciphertext > snapshot.limits.outbound_ciphertext.low) {
+    while (client.stream().bufferSnapshot().current.outbound_ciphertext > snapshot.limits.?.outbound_ciphertext.low) {
         _ = try client.drainCiphertext(drained[0..1]);
     }
     snapshot = client.stream().bufferSnapshot();
     try testing.expect(!snapshot.pause_state.plaintext_write_paused);
-    try testing.expect(snapshot.current.outbound_ciphertext <= snapshot.limits.outbound_ciphertext.low);
+    try testing.expect(snapshot.current.outbound_ciphertext <= snapshot.limits.?.outbound_ciphertext.low);
     try testing.expectEqual(@as(u64, 1), snapshot.counters.plaintext_write_resumes);
     try testing.expect(client.stream().readiness().can_write_plaintext);
 }
@@ -1879,7 +2090,7 @@ test "inbound plaintext high-low hysteresis gates carrier reads and resumes belo
     try feedAllCiphertext(&server, record[0..record_len]);
 
     var snapshot = server.stream().bufferSnapshot();
-    try testing.expect(snapshot.current.inbound_plaintext >= snapshot.limits.inbound_plaintext.high);
+    try testing.expect(snapshot.current.inbound_plaintext >= snapshot.limits.?.inbound_plaintext.high);
     try testing.expect(snapshot.pause_state.inbound_read_paused);
     try testing.expect(!server.stream().readiness().wants_read);
     try testing.expectEqual(@as(u64, 1), snapshot.counters.inbound_read_pauses);
@@ -1891,7 +2102,7 @@ test "inbound plaintext high-low hysteresis gates carrier reads and resumes belo
     var plain: [16]u8 = undefined;
     _ = try server.stream().read(plain[0..6]);
     snapshot = server.stream().bufferSnapshot();
-    try testing.expect(snapshot.current.inbound_plaintext <= snapshot.limits.inbound_plaintext.low);
+    try testing.expect(snapshot.current.inbound_plaintext <= snapshot.limits.?.inbound_plaintext.low);
     try testing.expect(!snapshot.pause_state.inbound_read_paused);
     try testing.expectEqual(@as(u64, 1), snapshot.counters.inbound_read_resumes);
     try testing.expect(server.stream().readiness().wants_read);
@@ -1947,6 +2158,27 @@ test "hard-limit write rejection leaves sequence and queue unchanged" {
     try testing.expectEqual(@as(u64, 1), snapshot.counters.hard_limits.outbound_ciphertext);
 }
 
+test "capacity probes do not increment hard-limit counters while output is stalled" {
+    const cp = testProvider();
+    var client = PureZigRecordStream.init(.client, cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+
+    client.buffer_limits.outbound_ciphertext = .{
+        .low = 1,
+        .high = PureZigRecordStream.handshake_output_reserve,
+        .hard = PureZigRecordStream.handshake_output_reserve,
+    };
+    client.outbound_ciphertext.len = PureZigRecordStream.handshake_output_reserve - 1;
+
+    for (0..3) |_| {
+        try testing.expect(!client.canReserveHandshakeOutputBatch());
+        try testing.expectEqual(@as(u64, 0), client.stream().bufferSnapshot().counters.hard_limits.outbound_ciphertext);
+    }
+
+    try testing.expectError(error.WouldBlock, client.applyEvent(.{ .handshake_bytes = .{ .epoch = .initial, .data = "blocked" } }));
+    try testing.expectEqual(@as(u64, 1), client.stream().bufferSnapshot().counters.hard_limits.outbound_ciphertext);
+}
+
 test "handshake buffer backpressure is independent of application plaintext" {
     const cp = testProvider();
     var client = try PureZigRecordStream.initWithLimits(.client, cp, .tls_aes_128_gcm_sha256, testBufferLimits());
@@ -1959,14 +2191,14 @@ test "handshake buffer backpressure is independent of application plaintext" {
 
     var snapshot = server.stream().bufferSnapshot();
     try testing.expectEqual(@as(usize, 0), snapshot.current.inbound_plaintext);
-    try testing.expect(snapshot.current.handshake >= snapshot.limits.handshake.high);
+    try testing.expect(snapshot.current.handshake >= snapshot.limits.?.handshake.high);
     try testing.expect(snapshot.pause_state.inbound_read_paused);
 
     var handshake_buf: [32]u8 = undefined;
     const n = try server.readHandshake(handshake_buf[0..6]);
     try testing.expectEqual(@as(usize, 6), n);
     snapshot = server.stream().bufferSnapshot();
-    try testing.expect(snapshot.current.handshake <= snapshot.limits.handshake.low);
+    try testing.expect(snapshot.current.handshake <= snapshot.limits.?.handshake.low);
     try testing.expect(!snapshot.pause_state.inbound_read_paused);
 }
 
@@ -1988,6 +2220,43 @@ test "buffer snapshot totals peaks and teardown current bytes are accurate" {
     snapshot = client.stream().bufferSnapshot();
     try testing.expectEqual(@as(usize, 0), snapshot.current.total());
     try testing.expect(snapshot.peak_total > 0);
+}
+
+test "byte queues wipe discarded and cleared storage" {
+    var queue = ByteQueue(16, error.PlaintextBufferFull){};
+
+    try queue.append("secret");
+    try queue.discard(3);
+    try testing.expectEqualStrings("ret", queue.slice());
+    try testing.expect(std.mem.allEqual(u8, queue.buf[3..6], 0));
+
+    queue.clear();
+    try testing.expectEqual(@as(usize, 0), queue.len);
+    try testing.expect(std.mem.allEqual(u8, queue.buf[0..], 0));
+}
+
+test "terminal cleanup clears parser-owned ciphertext and queued plaintext" {
+    const cp = testProvider();
+    var server = PureZigRecordStream.init(.server, cp, .tls_aes_128_gcm_sha256);
+
+    @memcpy(server.initial_parser.pending[0.."initial-secret".len], "initial-secret");
+    server.initial_parser.len = "initial-secret".len;
+    @memcpy(server.ciphertext_parser.pending[0.."cipher-secret".len], "cipher-secret");
+    server.ciphertext_parser.len = "cipher-secret".len;
+    try server.inbound_plaintext.append("plain-secret");
+    server.noteQueueMutation();
+
+    try testing.expect(server.stream().bufferSnapshot().current.total() > 0);
+    server.deinit();
+
+    const snapshot = server.stream().bufferSnapshot();
+    try testing.expectEqual(@as(usize, 0), snapshot.current.total());
+    try testing.expectEqual(@as(usize, 0), server.initial_parser.len);
+    try testing.expectEqual(@as(usize, 0), server.ciphertext_parser.len);
+    try testing.expectEqual(@as(usize, 0), server.inbound_plaintext.len);
+    try testing.expect(std.mem.indexOf(u8, server.initial_parser.pending[0..], "initial-secret") == null);
+    try testing.expect(std.mem.indexOf(u8, server.ciphertext_parser.pending[0..], "cipher-secret") == null);
+    try testing.expect(std.mem.indexOf(u8, server.inbound_plaintext.buf[0..], "plain-secret") == null);
 }
 
 test "encrypted stream coalesced record backpressure consumes only retry-safe records" {

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -728,7 +728,8 @@ pub const PureZigRecordStream = struct {
         if (owned >= hard) return 0;
         const hard_room = hard - owned;
         const parser = self.activeInboundParser();
-        if (parser.len > 0) return @min(hard_room, try parser.pendingRecordBytesNeeded());
+        const queued = self.inbound_carrier.slice();
+        if (parser.len > 0) return @min(hard_room, try parser.pendingRecordBytesNeededWith(queued));
         const high = self.buffer_limits.inbound_ciphertext.high;
         const high_room = if (owned < high) high - owned else 0;
         return @min(hard_room, high_room);
@@ -751,20 +752,24 @@ pub const PureZigRecordStream = struct {
     }
 
     fn hasRuntimeInboundDestinationReserve(self: *const PureZigRecordStream) Error!bool {
-        return self.hasInboundDestinationReserveFor(self.activeInboundParser(), &.{});
+        return self.hasInboundDestinationReserveFor(self.activeInboundParser(), self.inbound_carrier.slice());
+    }
+
+    fn canContinueParser(self: *const PureZigRecordStream, parser: *const record_codec.Parser, queued: []const u8) bool {
+        if (parser.len == 0 or self.inboundCiphertextOwned() >= self.buffer_limits.inbound_ciphertext.hard) return false;
+        return (parser.pendingRecordBytesNeededWith(queued) catch return false) > 0;
     }
 
     fn canContinueActiveRecord(self: *const PureZigRecordStream) bool {
-        const parser = self.activeInboundParser();
-        return parser.len > 0 and (self.inboundCiphertextReadRoom() catch return false) > 0;
+        return self.canContinueParser(self.activeInboundParser(), self.inbound_carrier.slice());
     }
 
     pub fn applyEvent(self: *PureZigRecordStream, event: events.Event) Error!void {
         if (self.failed) |err| return err;
         if (self.lifecycle == .closed or self.lifecycle == .failed or self.lifecycle == .closing) return error.StreamClosed;
         if (event == .handshake_bytes) {
-            if (self.outbound_ciphertext.available() < record_codec.max_ciphertext_record_len) return error.WouldBlock;
             if (!self.hasHardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, record_codec.max_ciphertext_record_len)) return self.rejectHardLimit(.outbound_ciphertext, error.WouldBlock);
+            if (self.outbound_ciphertext.available() < record_codec.max_ciphertext_record_len) return error.WouldBlock;
         }
         var record_buf: [record_codec.max_ciphertext_record_len]u8 = undefined;
         if (self.bridge.applyEvent(event, &record_buf) catch |err| return self.fail(err)) |record| {
@@ -1034,16 +1039,13 @@ pub const PureZigRecordStream = struct {
         const owned = self.inboundCiphertextOwned();
         const hard = self.buffer_limits.inbound_ciphertext.hard;
         if (owned >= hard) return self.rejectHardLimit(.inbound_ciphertext, error.WouldBlock);
-        if (self.read_backpressured and !self.canContinueActiveRecord()) return error.WouldBlock;
         const feed_len = @min(bytes.len, hard - owned);
         var sink = record_codec.RecordSink(1, record_codec.max_ciphertext_fragment_len){};
         const parser = self.parserForEpoch(epoch);
-        if (!(self.hasInboundDestinationReserveFor(parser, bytes[0..feed_len]) catch |err| return self.fail(err))) {
-            const needed = inboundDestinationReserve(parser, bytes[0..feed_len]) catch |err| return self.fail(err);
-            if (needed) |reserve| {
-                if (self.inbound_handshake.available() < reserve) return error.WouldBlock;
-                if (!self.hasHardRoom(.handshake, self.inbound_handshake.len, reserve)) return self.rejectHardLimit(.handshake, error.WouldBlock);
-            }
+        if (self.read_backpressured and !self.canContinueParser(parser, &.{})) return error.WouldBlock;
+        if (inboundDestinationReserve(parser, bytes[0..feed_len]) catch |err| return self.fail(err)) |reserve| {
+            if (!self.hasHardRoom(.handshake, self.inbound_handshake.len, reserve)) return self.rejectHardLimit(.handshake, error.WouldBlock);
+            if (self.inbound_handshake.available() < reserve) return error.WouldBlock;
         }
         const consumed = feedUntilOneRecord(parser, bytes[0..feed_len], &sink) catch |err| return self.fail(err);
         self.noteQueueMutation();
@@ -1070,9 +1072,7 @@ pub const PureZigRecordStream = struct {
         if (self.failed) |err| return err;
         if (self.lifecycle == .closed or self.lifecycle == .failed) return error.StreamClosed;
         if (self.peer_closed) return bytes.len;
-        if (direct_external_feed) {
-            if (!self.canAcceptCarrierRead()) return error.WouldBlock;
-        } else {
+        if (!direct_external_feed) {
             if (!self.canProcessCarrierInput()) return error.WouldBlock;
         }
         var feed_bytes = bytes;
@@ -1080,22 +1080,20 @@ pub const PureZigRecordStream = struct {
             const owned = self.inboundCiphertextOwned();
             const hard = self.buffer_limits.inbound_ciphertext.hard;
             if (owned >= hard) return self.rejectHardLimit(.inbound_ciphertext, error.WouldBlock);
+            if (self.read_backpressured and !self.canContinueParser(&self.ciphertext_parser, &.{})) return error.WouldBlock;
             feed_bytes = bytes[0..@min(bytes.len, hard - owned)];
         }
         var sink = record_codec.RecordSink(1, record_codec.max_ciphertext_fragment_len){};
-        if (!(self.hasInboundDestinationReserveFor(&self.ciphertext_parser, feed_bytes) catch |err| return self.fail(err))) {
-            const needed = inboundDestinationReserve(&self.ciphertext_parser, feed_bytes) catch |err| return self.fail(err);
-            if (needed) |reserve| {
-                if (self.inbound_plaintext.available() < reserve or self.inbound_handshake.available() < reserve) return error.WouldBlock;
-                if (!self.hasHardRoom(.inbound_plaintext, self.inbound_plaintext.len, reserve)) {
-                    if (direct_external_feed) return self.rejectHardLimit(.inbound_plaintext, error.WouldBlock);
-                    return error.WouldBlock;
-                }
-                if (!self.hasHardRoom(.handshake, self.inbound_handshake.len, reserve)) {
-                    if (direct_external_feed) return self.rejectHardLimit(.handshake, error.WouldBlock);
-                    return error.WouldBlock;
-                }
+        if (inboundDestinationReserve(&self.ciphertext_parser, feed_bytes) catch |err| return self.fail(err)) |reserve| {
+            if (!self.hasHardRoom(.inbound_plaintext, self.inbound_plaintext.len, reserve)) {
+                if (direct_external_feed) return self.rejectHardLimit(.inbound_plaintext, error.WouldBlock);
+                return error.WouldBlock;
             }
+            if (!self.hasHardRoom(.handshake, self.inbound_handshake.len, reserve)) {
+                if (direct_external_feed) return self.rejectHardLimit(.handshake, error.WouldBlock);
+                return error.WouldBlock;
+            }
+            if (self.inbound_plaintext.available() < reserve or self.inbound_handshake.available() < reserve) return error.WouldBlock;
         }
         const consumed = feedUntilOneRecord(&self.ciphertext_parser, feed_bytes, &sink) catch |err| return self.fail(err);
         if (direct_external_feed or consumed == 0) self.noteQueueMutation();
@@ -1140,8 +1138,8 @@ pub const PureZigRecordStream = struct {
         if (bytes.len == 0) return 0;
         if (self.lifecycle != .open or !self.bridge.handshake_complete) return error.WouldBlock;
         if (self.write_backpressured) return error.WouldBlock;
-        if (self.outbound_ciphertext.available() < record_codec.max_ciphertext_record_len) return error.WouldBlock;
         if (!self.hasHardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, record_codec.max_ciphertext_record_len)) return self.rejectHardLimit(.outbound_ciphertext, error.WouldBlock);
+        if (self.outbound_ciphertext.available() < record_codec.max_ciphertext_record_len) return error.WouldBlock;
 
         const n = @min(bytes.len, record_codec.max_plaintext_fragment_len);
         var record_buf: [record_codec.max_ciphertext_record_len]u8 = undefined;
@@ -2317,6 +2315,92 @@ test "internal destination hard backpressure does not inflate hard-limit counter
     try testing.expect(snapshot.pause_state.inbound_read_paused);
     try testing.expectEqual(@as(u64, 0), snapshot.counters.hard_limits.inbound_plaintext);
     try testing.expectEqual(@as(u64, 2), snapshot.counters.stalled_drives);
+}
+
+test "queued carrier header prefix blocks socket reads until destination room returns" {
+    const SourceCarrier = struct {
+        bytes: []const u8,
+        offset: usize = 0,
+        reads: usize = 0,
+
+        fn carrier(self: *@This()) Carrier {
+            return .{ .ptr = self, .readFn = read, .writeFn = write };
+        }
+
+        fn read(ptr: *anyopaque, out: []u8) Error!usize {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            if (self.offset == self.bytes.len) return error.WouldBlock;
+            const n = @min(out.len, self.bytes.len - self.offset);
+            @memcpy(out[0..n], self.bytes[self.offset..][0..n]);
+            self.offset += n;
+            self.reads += 1;
+            return n;
+        }
+
+        fn write(_: *anyopaque, _: []const u8) Error!usize {
+            return error.WouldBlock;
+        }
+    };
+
+    const cp = testProvider();
+    var client = PureZigRecordStream.init(.client, cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+    var server = try PureZigRecordStream.initWithLimits(.server, cp, .tls_aes_128_gcm_sha256, .{
+        .inbound_ciphertext = .{ .low = 8, .high = 16, .hard = record_codec.max_ciphertext_record_len },
+        .inbound_plaintext = .{ .low = 1, .high = 2, .hard = record_codec.max_plaintext_fragment_len },
+        .outbound_ciphertext = BufferLimits.defaults().outbound_ciphertext,
+        .handshake = BufferLimits.defaults().handshake,
+    });
+    defer server.deinit();
+    try establish(&client, &server);
+
+    try testing.expectEqual(@as(usize, 5), try client.stream().write("block"));
+    var record: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    const record_len = try client.drainCiphertext(&record);
+    @memcpy(server.ciphertext_parser.pending[0..4], record[0..4]);
+    server.ciphertext_parser.len = 4;
+    try server.inbound_carrier.append(record[4..5]);
+    server.inbound_plaintext.len = record_codec.max_plaintext_fragment_len - 1;
+    server.noteQueueMutation();
+
+    var carrier = SourceCarrier{ .bytes = record[5..record_len] };
+    server.carrier = carrier.carrier();
+    for (0..2) |_| {
+        const result = try server.stream().drive();
+        try testing.expect(!result.made_progress);
+        try testing.expect(!result.readiness.wants_read);
+    }
+    try testing.expectEqual(@as(usize, 0), carrier.reads);
+    const blocked = server.stream().bufferSnapshot();
+    try testing.expectEqual(@as(u64, 0), blocked.counters.hard_limits.inbound_plaintext);
+    try testing.expectEqual(@as(u64, 2), blocked.counters.stalled_drives);
+
+    server.inbound_plaintext.len = 0;
+    server.noteQueueMutation();
+    const resumed = try server.stream().drive();
+    try testing.expect(resumed.made_progress);
+    try testing.expect(carrier.reads > 0);
+}
+
+test "direct ciphertext hard rejection is counted independently of socket readiness" {
+    const cp = testProvider();
+    var client = PureZigRecordStream.init(.client, cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+    var server = PureZigRecordStream.init(.server, cp, .tls_aes_128_gcm_sha256);
+    defer server.deinit();
+    try establish(&client, &server);
+
+    server.inbound_carrier.len = server.buffer_limits.inbound_ciphertext.hard;
+    server.noteQueueMutation();
+    try testing.expect(!server.stream().readiness().wants_read);
+    try testing.expect(!server.stream().readiness().wants_read);
+    try testing.expectEqual(@as(u64, 0), server.stream().bufferSnapshot().counters.hard_limits.inbound_ciphertext);
+
+    const read_sequence = server.bridge.read_application.?.sequence;
+    try testing.expectError(error.WouldBlock, server.feedCiphertext("blocked"));
+    try testing.expectEqual(read_sequence, server.bridge.read_application.?.sequence);
+    try testing.expectEqual(@as(usize, server.buffer_limits.inbound_ciphertext.hard), server.inbound_carrier.len);
+    try testing.expectEqual(@as(u64, 1), server.stream().bufferSnapshot().counters.hard_limits.inbound_ciphertext);
 }
 
 test "hard-limit write rejection leaves sequence and queue unchanged" {

--- a/src/tls/record_codec.zig
+++ b/src/tls/record_codec.zig
@@ -233,6 +233,7 @@ pub const Parser = struct {
     }
 
     pub fn reset(self: *Parser) void {
+        @memset(self.pending[0..], 0);
         self.len = 0;
         self.parsed_first_record = false;
         self.client_hello_state = .idle;
@@ -347,8 +348,11 @@ pub const Parser = struct {
 
     fn discard(self: *Parser, count: usize) void {
         std.debug.assert(count <= self.len);
-        std.mem.copyForwards(u8, self.pending[0 .. self.len - count], self.pending[count..self.len]);
-        self.len -= count;
+        const old_len = self.len;
+        const remaining = old_len - count;
+        std.mem.copyForwards(u8, self.pending[0..remaining], self.pending[count..old_len]);
+        @memset(self.pending[remaining..old_len], 0);
+        self.len = remaining;
     }
 };
 
@@ -958,6 +962,27 @@ test "ciphertext parser requires application_data envelope and allows TLS 1.3 ex
 
     var bad_parser = Parser.init(.ciphertext);
     try testing.expectError(error.InvalidRecordType, bad_parser.feed(&.{ 22, 3, 3, 0, 0 }, &sink));
+}
+
+test "parser reset and discard wipe vacated pending bytes" {
+    var parser = Parser.init(.plaintext);
+    var sink = DefaultSink{};
+    var encoded: [64]u8 = undefined;
+    const record = try encodePlaintextRecord(.handshake, "secret", &encoded);
+
+    try testing.expectEqual(@as(usize, 4), (try parser.feedOne(record[0..4], &sink)).consumed);
+    try testing.expectEqual(@as(usize, 4), parser.len);
+    try testing.expect(std.mem.indexOf(u8, parser.pending[0..parser.len], record[0..4]) != null);
+    try testing.expectError(error.TruncatedRecord, parser.finish());
+
+    parser.reset();
+    try testing.expectEqual(@as(usize, 0), parser.len);
+    try testing.expect(std.mem.allEqual(u8, parser.pending[0..], 0));
+
+    try parser.feed(record, &sink);
+    try testing.expectEqual(@as(usize, 1), sink.len);
+    try testing.expectEqual(@as(usize, 0), parser.len);
+    try testing.expect(std.mem.indexOf(u8, parser.pending[0..], "secret") == null);
 }
 
 test "finish reports truncated records" {

--- a/src/tls/record_codec.zig
+++ b/src/tls/record_codec.zig
@@ -285,6 +285,32 @@ pub const Parser = struct {
         if (self.len != 0) return error.TruncatedRecord;
     }
 
+    /// Returns the number of bytes still needed to complete the buffered
+    /// record. A partial header needs only its remaining header bytes; once a
+    /// header is complete this is the exact encoded-record remainder.
+    pub fn pendingRecordBytesNeeded(self: *const Parser) Error!usize {
+        if (self.len < header_len) return header_len - self.len;
+        const header = try parseHeader(self.pending[0..header_len], self.mode, self.currentVersionPolicy());
+        return header_len + header.payload_len - self.len;
+    }
+
+    /// Returns the declared payload length when `bytes` completes the pending
+    /// header, without consuming either the parser or caller-owned input.
+    pub fn pendingRecordPayloadLenWith(self: *const Parser, bytes: []const u8) Error!?usize {
+        if (self.len >= header_len) {
+            const header = try parseHeader(self.pending[0..header_len], self.mode, self.currentVersionPolicy());
+            return header.payload_len;
+        }
+        if (self.len + bytes.len < header_len) return null;
+
+        var header_bytes: [header_len]u8 = undefined;
+        @memcpy(header_bytes[0..self.len], self.pending[0..self.len]);
+        const needed = header_len - self.len;
+        @memcpy(header_bytes[self.len..], bytes[0..needed]);
+        const header = try parseHeader(&header_bytes, self.mode, self.currentVersionPolicy());
+        return header.payload_len;
+    }
+
     fn drain(self: *Parser, sink: anytype) Error!void {
         while (self.len >= header_len) {
             const header = try parseHeader(self.pending[0..header_len], self.mode, self.currentVersionPolicy());

--- a/src/tls/record_codec.zig
+++ b/src/tls/record_codec.zig
@@ -289,9 +289,18 @@ pub const Parser = struct {
     /// record. A partial header needs only its remaining header bytes; once a
     /// header is complete this is the exact encoded-record remainder.
     pub fn pendingRecordBytesNeeded(self: *const Parser) Error!usize {
-        if (self.len < header_len) return header_len - self.len;
-        const header = try parseHeader(self.pending[0..header_len], self.mode, self.currentVersionPolicy());
-        return header_len + header.payload_len - self.len;
+        return self.pendingRecordBytesNeededWith(&.{});
+    }
+
+    /// Like `pendingRecordBytesNeeded`, but includes a caller-owned queued
+    /// prefix when determining how many *additional socket bytes* could still
+    /// advance this record. The queued prefix is not consumed or retained.
+    pub fn pendingRecordBytesNeededWith(self: *const Parser, queued: []const u8) Error!usize {
+        if (self.len + queued.len < header_len) return header_len - (self.len + queued.len);
+        const payload_len = try self.pendingRecordPayloadLenWith(queued) orelse unreachable;
+        const record_len = header_len + payload_len;
+        const already_owned = @min(record_len, self.len + queued.len);
+        return record_len - already_owned;
     }
 
     /// Returns the declared payload length when `bytes` completes the pending

--- a/tests/pki_differential.zig
+++ b/tests/pki_differential.zig
@@ -1597,7 +1597,11 @@ fn readRecordedPid(allocator: std.mem.Allocator, tmp_path: []const u8, file_name
         else => return err,
     };
     defer allocator.free(raw);
-    return try std.fmt.parseInt(std.posix.pid_t, std.mem.trim(u8, raw, " \t\r\n"), 10);
+    const trimmed = std.mem.trim(u8, raw, " \t\r\n");
+    if (trimmed.len == 0) return null;
+    return std.fmt.parseInt(std.posix.pid_t, trimmed, 10) catch |err| switch (err) {
+        error.InvalidCharacter, error.Overflow => null,
+    };
 }
 
 fn deleteRecordedPidFiles(tmp_path: []const u8) void {


### PR DESCRIPTION
## Summary

Closes #355.

Adds bounded, runtime-effective TLS stream watermarks while preserving the existing fixed-capacity, allocation-free `PureZigRecordStream` queues.

## BufferLimits model and defaults

- Adds `Watermark { low, high, hard }` and `BufferLimits` for inbound carrier ciphertext, inbound plaintext, outbound ciphertext, and handshake bytes.
- Defaults derive from existing compile-time capacities using 25% low / 75% high / capacity hard watermarks.
- Validation rejects zero/nonsensical `low < high <= hard` violations, hard limits above compile-time queue capacity, and hard limits that cannot hold one maximum legal fragment or the complete record-mode `handshake_output_reserve` batch.

## Compile-time capacity vs runtime limits

- The hot path still uses the existing fixed `ByteQueue` storage.
- Runtime hard limits sit inside those capacities; they do not allocate or grow dynamically.
- Existing constructors keep source compatibility by using defaults, with explicit `init*WithLimits` constructors for tighter policies.

## Queue ownership and accounting

| Queue | Owned bytes counted | Notes |
| --- | --- | --- |
| inbound ciphertext | `inbound_carrier.len + initial_parser.len + ciphertext_parser.len` | Stream-owned carrier bytes plus fragmented record bytes already copied into parsers |
| inbound plaintext | `inbound_plaintext.len` | Decrypted application bytes owned by the stream |
| outbound ciphertext | `outbound_ciphertext.len` | Sealed TLS records; accepted plaintext is not staged separately |
| handshake | `inbound_handshake.len` | Opened handshake bytes owned by record mode |

Pure-Zig application writes seal accepted plaintext directly into outbound ciphertext, so there is no hidden pending-plaintext queue. Queue and parser cleanup wipes vacated storage on discard, reset, terminal close, and deinit paths.

## Readiness and hysteresis

- Carrier reads latch paused at any inbound high watermark and resume only after all inbound queues drain to their lows.
- Plaintext writes latch paused at outbound ciphertext high and resume at/below outbound low.
- `wants_read` is false while read backpressure is latched unless an already-started parser-owned record needs bounded bytes to finish.
- `can_write_plaintext` is false while write backpressure is latched.
- `wants_write` remains true while draining ciphertext can make progress.
- Already-owned carrier ciphertext can still be processed while socket reads are paused.
- Carrier reads are capped to runtime inbound-ciphertext high room before starting a record and hard room while finishing an active parser-owned record.

## Hard-limit and atomicity behavior

- Runtime hard-limit failures are checked before sealing/opening records where sequence/parser state could otherwise move.
- Existing atomic guarantees remain covered: rejected plaintext writes do not advance write sequence, rejected inbound opens do not advance read sequence, and coalesced suffixes remain retry-safe.
- Borrowed direct-feed slices are capped to the remaining owned-byte hard room; unconsumed coalesced suffixes remain caller-owned and retryable.
- Hard-limit counters represent explicit rejection paths, not normal high-watermark pauses, side-effect-free capacity probes, or internal carrier retry backpressure.

## Metrics/snapshot interface

- Extends `EncryptedStream` with `bufferSnapshot()`.
- Snapshot includes current and peak bytes by queue, peak total, optional configured limits, whether limits are enforced, latched pause state, pause/resume counters, hard-limit counters, stalled-drive counts, and an accounting-boundary marker.
- Labels/cardinality remain bounded; no SNI, URL, connection id, request id, or arbitrary protocol labels are introduced.

## OpenSSL accounting boundary

- The OpenSSL adapter implements the same snapshot hook.
- It reports measurable `SSL_pending()` decrypted bytes and retry-derived pause/resume/stall state.
- It maintains `SSL_pending()` lifetime peaks at stream read/snapshot boundaries instead of relying only on snapshot polling.
- It marks the snapshot as `backend_opaque`, leaves unknown limits unset, and reports `limits_enforced = false`; opaque OpenSSL internal memory is not reported as complete stream-owned accounting.
- Borrowed pending-write caller memory is not counted as owned bytes.
- Close/shutdown/failure lifecycle transitions do not synthesize backpressure pause/resume events.

## HTTP consumer seam for #356

HTTP/1.1 and HTTP/2 consumers can use only backend-neutral APIs:

- `readiness().can_write_plaintext`
- `readiness().can_read_plaintext`
- `readiness().wants_read`
- `readiness().wants_write`
- `bufferSnapshot()` for pause reasons, usage, peaks, and limits when enforced/known

A mock HTTP consumer regression covers this without backend-specific casts.

## Validation

- `git diff --check` — passed
- `zig build test-tls --summary all --error-style verbose` — passed, 180/180 tests
- `zig build test --summary all --error-style verbose` — passed, 1447/1448 passed / 1 skipped
- `zig build test -Dtls-profile=appliance --summary all --error-style verbose` — passed, 1430/1431 passed / 1 skipped
- `zig build test-quic --summary all --error-style verbose` — passed, 311/311 tests
- `zig build test-integration --summary all --error-style verbose` — passed, 65/69 passed / 4 skipped
- `zig build test -Doptimize=ReleaseFast --summary all --error-style verbose` — passed, 1447/1448 passed / 1 skipped

## Review follow-up

- Parser-owned fragmented record bytes are included in inbound-ciphertext snapshots, peaks, watermarks, and hard-limit decisions.
- Side-effect-free capacity predicates no longer increment hard-limit counters; only actual API/append rejections do.
- Parser and queue storage is wiped on discard/reset/terminal cleanup paths, and snapshots drop to zero after teardown.
- Socket reads are capped by runtime inbound-ciphertext room before reading from the carrier, without permanently stalling active fragmented records.
- Internal carrier-to-parser transfers no longer double-count bytes or latch doubled peaks before queue discard.
- Direct coalesced borrowed feeds no longer reject solely because the borrowed suffix exceeds owned hard room.
- Internal retry backpressure behind destination hard limits no longer inflates hard-limit counters on repeated `drive()` calls.
- OpenSSL snapshots no longer claim Pure-Zig limits; they report opaque accounting, unenforced/unknown limits, retry-derived pause/resume/stall counters, lifetime pending-byte peaks, and no close-synthetic transitions.
- The failing Ubuntu pki allocation-failure cleanup path now tolerates empty/partial pid files left by a child that failed before recording its pid.

## Scope exclusions confirmed

This PR does not implement or depend on #334 credential hooks / closed PR #455, #347 SNI selection, #348 PKI corpus work, #356 HTTP dispatch, #357 KeyUpdate, or global/per-origin proxy accounting from #140.
