### PR TITLE
tls: [323-F] handshake-time client authentication and key selection (#334)

### DIFF
--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -1131,6 +1131,34 @@ pub const Connection = struct {
         }
     }
 
+    /// True while the TLS handshake has suspended awaiting an asynchronous
+    /// authentication operation (#334). The event loop can poll this to know
+    /// the connection is waiting on an external signer/verifier/selector; each
+    /// `pollTransmit` (or an explicit `driveAuthentication`) advances it.
+    pub fn authPending(self: *const Connection) bool {
+        return self.handshake.authPending();
+    }
+
+    /// Drive a parked asynchronous authentication operation forward without
+    /// requiring another inbound CRYPTO frame: poll it, queue any handshake
+    /// output it produced, and complete the handshake if it resolved. Safe to
+    /// call unconditionally; a no-op unless the backend is suspended.
+    pub fn driveAuthentication(self: *Connection, now_us: u64) void {
+        if (self.state_ == .closed or self.state_ == .draining or self.state_ == .closing) return;
+        if (!self.handshake.authPending()) return;
+        self.handshake.resumeAuth() catch |err| {
+            self.failHandshake(err);
+            self.startClose(.{ .error_code = cryptoErrorCode(err), .is_application = false, .local = true }, @errorName(err), now_us);
+            return;
+        };
+        self.collectCryptoOutput() catch {
+            self.failHandshake(error.HandshakeBufferOverflow);
+            self.startClose(.{ .error_code = error_crypto_buffer_exceeded, .is_application = false, .local = true }, "crypto buffer", now_us);
+            return;
+        };
+        self.afterHandshakeProgress(now_us);
+    }
+
     fn afterHandshakeProgress(self: *Connection, now_us: u64) void {
         if (self.handshake_complete or !self.handshake.isComplete()) return;
         self.handshake_complete = true;
@@ -1536,6 +1564,19 @@ pub const Connection = struct {
             self.close_needs_send = false;
             self.close_resend_allowed_at_us = now_us + self.ptoDurationNow() / 2;
             return self.buildCloseDatagram(out, now_us);
+        }
+
+        // Advance any parked asynchronous authentication (#334) before building
+        // packets, so a resolved external signer/verifier/selector emits its
+        // next flight here even when no further peer CRYPTO frame will arrive.
+        self.driveAuthentication(now_us);
+        if (self.state_ == .closing or self.state_ == .closed or self.state_ == .draining) {
+            if (self.state_ == .closing and self.close_needs_send) {
+                self.close_needs_send = false;
+                self.close_resend_allowed_at_us = now_us + self.ptoDurationNow() / 2;
+                return self.buildCloseDatagram(out, now_us);
+            }
+            return null;
         }
 
         // Force the delayed app-space ACK when its timer expired.

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -1228,6 +1228,7 @@ pub const Connection = struct {
         return switch (err) {
             error.AlpnMismatch => error_crypto_base + 120, // no_application_protocol
             error.CertificateInvalid => error_crypto_base + 42, // bad_certificate
+            error.ClientCertificateRequired => error_crypto_base + 116, // certificate_required
             error.MissingTransportParameters, error.InvalidTransportParameters => error_transport_parameter,
             error.UnexpectedHandshakeMessage => error_crypto_base + 10, // unexpected_message
             error.IllegalParameter => error_crypto_base + 47, // illegal_parameter

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -107,6 +107,7 @@ pub const Event = union(enum) {
 
 pub const DropReason = enum {
     unknown_cid,
+    keys_unavailable,
     undecryptable,
     malformed,
     unsupported_version,
@@ -645,6 +646,10 @@ pub const Connection = struct {
             else => unreachable,
         };
         const space = spaceForLevel(level);
+        if (level == .application and !self.handshake_complete) {
+            self.dropPacket(.keys_unavailable, bytes.len);
+            return;
+        }
 
         // Header protection removal needs a sample 4 bytes past pn_offset.
         var work: [2048]u8 = undefined;
@@ -2347,12 +2352,33 @@ test "handshake failures map to their RFC 9001 CRYPTO_ERROR alert codes" {
     try testing.expectEqual(error_crypto_base + 50, Connection.cryptoErrorCode(error.MalformedHandshake));
     try testing.expectEqual(error_crypto_base + 120, Connection.cryptoErrorCode(error.AlpnMismatch));
     try testing.expectEqual(error_crypto_base + 42, Connection.cryptoErrorCode(error.CertificateInvalid));
+    try testing.expectEqual(error_crypto_base + 43, Connection.cryptoErrorCode(error.UnsupportedCertificate));
+    try testing.expectEqual(error_crypto_base + 109, Connection.cryptoErrorCode(error.MissingExtension));
     // #334 review: NoApplicableCredential was missing from this table and fell
     // through to the generic internal_error(80) code instead of the canonical
     // handshake_failure(40) `alerts.fromHandshakeError` maps it to.
     try testing.expectEqual(error_crypto_base + 40, Connection.cryptoErrorCode(error.NoApplicableCredential));
     try testing.expectEqual(error_crypto_base + 116, Connection.cryptoErrorCode(error.ClientCertificateRequired));
     try testing.expectEqual(error_crypto_base + 51, Connection.cryptoErrorCode(error.DecryptError));
+}
+
+test "driver: 1-RTT packets are dropped before deprotection until TLS handshake complete" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const id = try pair.client.openStream(.bidi);
+    try testing.expectEqual(@as(usize, 5), try pair.client.writeStream(id, "hello", false));
+    var datagram: [max_datagram_size]u8 = undefined;
+    const one_rtt = pair.client.pollTransmit(&datagram, pair.now_us) orelse return error.TestExpectedEqual;
+
+    const received_before = pair.server.metrics.packets_received;
+    const dropped_before = pair.server.metrics.packets_dropped;
+    pair.server.handshake_complete = false;
+    try pair.server.ingest(one_rtt, pair.now_us);
+    try testing.expectEqual(received_before, pair.server.metrics.packets_received);
+    try testing.expectEqual(dropped_before + 1, pair.server.metrics.packets_dropped);
 }
 
 test "a real Connection closes with handshake_failure when the server has no applicable credential" {

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -776,6 +776,15 @@ pub const Connection = struct {
                     self.startClose(.{ .error_code = cryptoErrorCode(err), .is_application = false, .local = true }, @errorName(err), now_us);
                     return;
                 };
+                // Poll any parked asynchronous authentication (#334) so a
+                // resolved external signer/verifier/selector progresses the
+                // handshake as this packet is processed. A no-op when nothing is
+                // suspended.
+                self.handshake.resumeAuth() catch |err| {
+                    self.failHandshake(err);
+                    self.startClose(.{ .error_code = cryptoErrorCode(err), .is_application = false, .local = true }, @errorName(err), now_us);
+                    return;
+                };
                 self.collectCryptoOutput() catch {
                     self.failHandshake(error.HandshakeBufferOverflow);
                     self.startClose(.{ .error_code = error_crypto_buffer_exceeded, .is_application = false, .local = true }, "crypto buffer", now_us);
@@ -1229,6 +1238,7 @@ pub const Connection = struct {
             error.AlpnMismatch => error_crypto_base + 120, // no_application_protocol
             error.CertificateInvalid => error_crypto_base + 42, // bad_certificate
             error.ClientCertificateRequired => error_crypto_base + 116, // certificate_required
+            error.DecryptError => error_crypto_base + 51, // decrypt_error
             error.MissingTransportParameters, error.InvalidTransportParameters => error_transport_parameter,
             error.UnexpectedHandshakeMessage => error_crypto_base + 10, // unexpected_message
             error.IllegalParameter => error_crypto_base + 47, // illegal_parameter

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -2146,6 +2146,48 @@ const TestPair = struct {
         return pair;
     }
 
+    fn initClientAuth(
+        allocator: std.mem.Allocator,
+        client_provider: tls_core.credentials.CredentialProvider,
+        server_verifier: tls_core.credentials.PeerVerifier,
+    ) !*TestPair {
+        const pair = try allocator.create(TestPair);
+        pair.* = .{
+            .client_backend = tls_backend_mod.Tls13Backend.initClient(
+                .{ .hello_random = [_]u8{0xc1} ** 32, .key_share_seed = [_]u8{0x11} ** 32 },
+                .{ .pinned_certificate = tls_backend_mod.testdata.certificate_der },
+            ),
+            .server_backend = tls_backend_mod.Tls13Backend.initServer(
+                .{ .hello_random = [_]u8{0x51} ** 32, .key_share_seed = [_]u8{0x22} ** 32 },
+                try tls_backend_mod.Identity.initPkcs8(
+                    tls_backend_mod.testdata.certificate_der,
+                    tls_backend_mod.testdata.private_key_pkcs8_der,
+                ),
+            ),
+        };
+        errdefer allocator.destroy(pair);
+        pair.client_backend.engine.setLocalCredentialProvider(client_provider);
+        pair.server_backend.engine.requestClientAuthentication(.required, server_verifier);
+        pair.client = try Connection.init(allocator, .{
+            .role = .client,
+            .local_cid = &client_cid,
+            .original_dcid = &odcid,
+            .peer_cid = &odcid,
+            .tls = pair.client_backend.backend(),
+            .now_us = pair.now_us,
+        });
+        errdefer pair.client.deinit();
+        pair.server = try Connection.init(allocator, .{
+            .role = .server,
+            .local_cid = &odcid,
+            .original_dcid = &odcid,
+            .peer_cid = &client_cid,
+            .tls = pair.server_backend.backend(),
+            .now_us = pair.now_us,
+        });
+        return pair;
+    }
+
     fn deinit(self: *TestPair, allocator: std.mem.Allocator) void {
         self.client.deinit();
         self.server.deinit();
@@ -2379,6 +2421,50 @@ test "driver: 1-RTT packets are dropped before deprotection until TLS handshake 
     try pair.server.ingest(one_rtt, pair.now_us);
     try testing.expectEqual(received_before, pair.server.metrics.packets_received);
     try testing.expectEqual(dropped_before + 1, pair.server.metrics.packets_dropped);
+}
+
+fn expectConnectionRejectsExtraCryptoWhileClientAuthPending(async_sign: bool) !void {
+    const allocator = testing.allocator;
+    const credentials = tls_core.credentials;
+    var mock = credentials.MockCredentialProvider.init(
+        try tls_backend_mod.Identity.initPkcs8(tls_backend_mod.testdata.certificate_der, tls_backend_mod.testdata.private_key_pkcs8_der),
+    );
+    mock.pending_polls = 64;
+    if (async_sign) {
+        mock.async_sign = true;
+    } else {
+        mock.async_select = true;
+    }
+    var verifier = credentials.MockVerifier.init(.accepted);
+    const pair = try TestPair.initClientAuth(allocator, mock.provider(), verifier.verifier());
+    defer pair.deinit(allocator);
+
+    try pair.pump();
+    try testing.expect(pair.client.authPending());
+    try testing.expect(!pair.client.isEstablished());
+
+    const stray = [_]u8{@intFromEnum(tls_core.handshake.MessageType.finished)};
+    const handshake_index = @intFromEnum(EncryptionLevel.handshake);
+    const offset = pair.client.adapter.reassembler.streams[handshake_index].consumed_offset;
+    try pair.client.applyFrame(.handshake, .{ .crypto = .{ .offset = offset, .data = &stray } }, pair.now_us);
+
+    try testing.expect(!pair.client.authPending());
+    try testing.expectEqual(tls_handshake.HandshakeError.UnexpectedHandshakeMessage, pair.client.handshakeFailure().?);
+    const info = pair.client.closeInfo() orelse return error.TestExpectedCloseInfo;
+    try testing.expect(info.local);
+    try testing.expect(!info.is_application);
+    try testing.expectEqual(@as(u64, error_crypto_base + 10), info.error_code);
+    try testing.expectEqual(@as(usize, 1), mock.cancel_count);
+    try testing.expectEqual(@as(usize, 1), mock.op_release_count);
+    if (async_sign) try testing.expectEqual(@as(usize, 1), mock.release_count);
+}
+
+test "a real Connection rejects extra Handshake CRYPTO while client credential selection is pending" {
+    try expectConnectionRejectsExtraCryptoWhileClientAuthPending(false);
+}
+
+test "a real Connection rejects extra Handshake CRYPTO while client signing is pending" {
+    try expectConnectionRejectsExtraCryptoWhileClientAuthPending(true);
 }
 
 test "a real Connection closes with handshake_failure when the server has no applicable credential" {

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -27,6 +27,7 @@ const packet = @import("packet.zig");
 const frame = @import("frame.zig");
 const tls_adapter = @import("tls_adapter.zig");
 const tls_handshake = @import("tls_handshake.zig");
+const tls_core = @import("tls_core");
 const recovery = @import("recovery.zig");
 const quic_stream = @import("stream.zig");
 const quic_cid = @import("cid.zig");
@@ -1260,19 +1261,21 @@ pub const Connection = struct {
         self.events.emit(.{ .keys_discarded = space });
     }
 
+    /// TLS alert mapping (RFC 9001 §4.8). QUIC-only failures (not part of the
+    /// shared protocol-neutral vocabulary) are mapped explicitly; every other
+    /// error is a member of `tls_core.events.HandshakeError` and is delegated to
+    /// the canonical `alerts.fromHandshakeError` mapper, so this table cannot
+    /// silently drift from the shared one the way it previously did for
+    /// `NoApplicableCredential` (missing here meant every credential-selection
+    /// failure surfaced as `internal_error` instead of `handshake_failure`).
     fn cryptoErrorCode(err: tls_handshake.HandshakeError) u64 {
-        // TLS alert mapping (RFC 9001 §4.8).
-        return switch (err) {
-            error.AlpnMismatch => error_crypto_base + 120, // no_application_protocol
-            error.CertificateInvalid => error_crypto_base + 42, // bad_certificate
-            error.ClientCertificateRequired => error_crypto_base + 116, // certificate_required
-            error.DecryptError => error_crypto_base + 51, // decrypt_error
-            error.MissingTransportParameters, error.InvalidTransportParameters => error_transport_parameter,
-            error.UnexpectedHandshakeMessage => error_crypto_base + 10, // unexpected_message
-            error.IllegalParameter => error_crypto_base + 47, // illegal_parameter
-            error.MalformedHandshake => error_crypto_base + 50, // decode_error
-            else => error_crypto_base + 80, // internal_error
-        };
+        switch (err) {
+            error.MissingTransportParameters, error.InvalidTransportParameters => return error_transport_parameter,
+            error.UnexpectedCryptoLevel, error.HandshakeBufferOverflow => return error_crypto_base + 80, // internal_error
+            else => {},
+        }
+        const shared_err: tls_core.events.HandshakeError = @errorCast(err);
+        return error_crypto_base + @as(u64, @intFromEnum(tls_core.alerts.fromHandshakeError(shared_err)));
     }
 
     // -- close ----------------------------------------------------------------
@@ -2344,6 +2347,66 @@ test "handshake failures map to their RFC 9001 CRYPTO_ERROR alert codes" {
     try testing.expectEqual(error_crypto_base + 50, Connection.cryptoErrorCode(error.MalformedHandshake));
     try testing.expectEqual(error_crypto_base + 120, Connection.cryptoErrorCode(error.AlpnMismatch));
     try testing.expectEqual(error_crypto_base + 42, Connection.cryptoErrorCode(error.CertificateInvalid));
+    // #334 review: NoApplicableCredential was missing from this table and fell
+    // through to the generic internal_error(80) code instead of the canonical
+    // handshake_failure(40) `alerts.fromHandshakeError` maps it to.
+    try testing.expectEqual(error_crypto_base + 40, Connection.cryptoErrorCode(error.NoApplicableCredential));
+    try testing.expectEqual(error_crypto_base + 116, Connection.cryptoErrorCode(error.ClientCertificateRequired));
+    try testing.expectEqual(error_crypto_base + 51, Connection.cryptoErrorCode(error.DecryptError));
+}
+
+test "a real Connection closes with handshake_failure when the server has no applicable credential" {
+    // #334 review: exercise NoApplicableCredential through an actual
+    // Connection, both synchronously and via an asynchronous selector, rather
+    // than only the direct-backend/handshake-adapter tests.
+    const allocator = testing.allocator;
+    const credentials = tls_core.credentials;
+    for ([_]bool{ false, true }) |async_select| {
+        var mock = credentials.MockCredentialProvider.init(
+            try tls_backend_mod.Identity.initPkcs8(tls_backend_mod.testdata.certificate_der, tls_backend_mod.testdata.private_key_pkcs8_der),
+        );
+        mock.force_select_error = error.NoCredentialAvailable;
+        mock.async_select = async_select;
+        mock.pending_polls = 1;
+
+        const pair = try allocator.create(TestPair);
+        pair.* = .{
+            .client_backend = tls_backend_mod.Tls13Backend.initClient(
+                .{ .hello_random = [_]u8{0xc1} ** 32, .key_share_seed = [_]u8{0x11} ** 32 },
+                .{ .pinned_certificate = tls_backend_mod.testdata.certificate_der },
+            ),
+            .server_backend = tls_backend_mod.Tls13Backend.initServer(
+                .{ .hello_random = [_]u8{0x51} ** 32, .key_share_seed = [_]u8{0x22} ** 32 },
+                try tls_backend_mod.Identity.initPkcs8(tls_backend_mod.testdata.certificate_der, tls_backend_mod.testdata.private_key_pkcs8_der),
+            ),
+        };
+        pair.server_backend.engine.external_provider = mock.provider();
+        defer pair.deinit(allocator);
+        pair.client = try Connection.init(allocator, .{
+            .role = .client,
+            .local_cid = &TestPair.client_cid,
+            .original_dcid = &TestPair.odcid,
+            .peer_cid = &TestPair.odcid,
+            .tls = pair.client_backend.backend(),
+            .now_us = pair.now_us,
+        });
+        pair.server = try Connection.init(allocator, .{
+            .role = .server,
+            .local_cid = &TestPair.odcid,
+            .original_dcid = &TestPair.odcid,
+            .peer_cid = &TestPair.client_cid,
+            .tls = pair.server_backend.backend(),
+            .now_us = pair.now_us,
+        });
+
+        try pair.pump();
+        // The client observes the server's synthesized close with the correct
+        // wire alert; the server latches the typed NoApplicableCredential
+        // failure it maps from.
+        const info = pair.client.closeInfo() orelse return error.TestExpectedCloseInfo;
+        try testing.expectEqual(@as(u64, error_crypto_base + 40), info.error_code);
+        try testing.expectEqual(tls_handshake.HandshakeError.NoApplicableCredential, pair.server.handshakeFailure().?);
+    }
 }
 
 test {

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -216,10 +216,34 @@ pub const Tls13Backend = struct {
 
     pub fn backend(self: *Tls13Backend) tls_handshake.TlsBackend {
         return .{
-            .transport = .{ .ptr = self, .startFn = start, .receiveFn = receive, .deinitFn = deinitImpl },
+            .transport = .{
+                .ptr = self,
+                .startFn = start,
+                .receiveFn = receive,
+                .deinitFn = deinitImpl,
+                // Forward asynchronous authentication progression (#334) to the
+                // inner engine so a QUIC connection can drive a parked signer,
+                // verifier, or selector without another inbound CRYPTO frame.
+                .authPendingFn = authPending,
+                .resumeFn = resumeAuth,
+            },
             .setCidBindingFn = setCidBinding,
             .peerCidBindingFn = peerCidBinding,
         };
+    }
+
+    fn authPending(ptr: *anyopaque) bool {
+        const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
+        return self.engine.authPending();
+    }
+
+    fn resumeAuth(ptr: *anyopaque, sink: *EventSink) HandshakeError!void {
+        const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
+        self.scratch.reset();
+        const result = self.engine.resumeAuth(&self.scratch);
+        try self.forwardPeerTransportParameters(sink);
+        try translate(&self.scratch, sink);
+        result catch |err| return mapError(err);
     }
 
     pub fn deinit(self: *Tls13Backend) void {
@@ -494,4 +518,74 @@ test "QUIC handshake owner tears down shared and adapter storage when abandoned"
     harness.deinit();
     try expectQuicBackendWiped(&harness.client_backend);
     try expectQuicBackendWiped(&harness.server_backend);
+}
+
+test "the QUIC production driver resumes an async server signature without another peer CRYPTO frame (#334)" {
+    // A genuinely asynchronous server signer parks after ClientHello. No further
+    // client CRYPTO will arrive until the server sends its Finished, so progress
+    // must come from resumeAuth alone — the QUIC backend forwards pending/resume
+    // to the inner engine, and the driver exposes it.
+    var mock = tls_core.credentials.MockCredentialProvider.init(
+        try Identity.initPkcs8(testdata.certificate_der, testdata.private_key_pkcs8_der),
+    );
+    mock.async_sign = true;
+    mock.pending_polls = 2;
+
+    var client_adapter = tls_adapter.QuicTlsAdapter{};
+    var server_adapter = tls_adapter.QuicTlsAdapter{};
+    var client_backend = Tls13Backend.initClient(
+        .{ .hello_random = [_]u8{0xc1} ** 32, .key_share_seed = [_]u8{0x11} ** 32 },
+        .{ .pinned_certificate = testdata.certificate_der },
+    );
+    var server_backend = Tls13Backend.initServer(
+        .{ .hello_random = [_]u8{0x51} ** 32, .key_share_seed = [_]u8{0x22} ** 32 },
+        try Identity.initPkcs8(testdata.certificate_der, testdata.private_key_pkcs8_der),
+    );
+    // Serve the server credential through the async mock rather than the fixed
+    // identity's synchronous signer.
+    server_backend.engine.external_provider = mock.provider();
+
+    var client = tls_handshake.Handshake.initClient(&client_adapter, client_backend.backend());
+    var server = tls_handshake.Handshake.initServer(&server_adapter, server_backend.backend());
+    defer client.deinit();
+    defer server.deinit();
+
+    const params = (config.Config{}).transportParameters() catch unreachable;
+    try server.start(params);
+    try client.start(params);
+
+    // Deliver the ClientHello; the server emits ServerHello/EncryptedExtensions/
+    // Certificate and then parks awaiting the asynchronous signature.
+    var buf: [2048]u8 = undefined;
+    while (try client.pollOutput(.initial, &buf)) |out| {
+        try server.onCrypto(.initial, out.offset, out.bytes);
+    }
+    try std.testing.expect(server.authPending());
+
+    // Advance the signature purely through resumeAuth — no further peer CRYPTO.
+    var guard: usize = 0;
+    while (server.authPending()) : (guard += 1) {
+        if (guard > 16) return error.TestResumeStuck;
+        try server.resumeAuth();
+    }
+    try std.testing.expect(!server.authPending());
+
+    // With the flight now produced, the remaining exchange completes both sides.
+    var rounds: usize = 0;
+    while (rounds < 64) : (rounds += 1) {
+        var progressed = false;
+        inline for (.{ EncryptionLevel.initial, EncryptionLevel.handshake }) |level| {
+            while (try server.pollOutput(level, &buf)) |out| {
+                try client.onCrypto(level, out.offset, out.bytes);
+                progressed = true;
+            }
+            while (try client.pollOutput(level, &buf)) |out| {
+                try server.onCrypto(level, out.offset, out.bytes);
+                progressed = true;
+            }
+        }
+        if (!progressed) break;
+    }
+    try std.testing.expect(client.isComplete());
+    try std.testing.expect(server.isComplete());
 }

--- a/src/quic/tls_handshake.zig
+++ b/src/quic/tls_handshake.zig
@@ -180,6 +180,26 @@ pub const Handshake = struct {
         return self.driver.isComplete();
     }
 
+    /// True while the TLS backend has suspended awaiting an asynchronous
+    /// authentication operation (#334): an external signer, verifier, or
+    /// credential selector. The owning connection polls `resumeAuth` until it
+    /// clears.
+    pub fn authPending(self: *const Handshake) bool {
+        return self.driver.authPending();
+    }
+
+    /// Poll a parked asynchronous authentication operation and apply any
+    /// handshake bytes, secrets, certificate state, or completion it emits into
+    /// the adapter's CRYPTO streams. A no-op unless the backend is suspended, so
+    /// the connection may call it unconditionally whenever it processes the
+    /// handshake (after feeding CRYPTO, or on a wakeup signalling the external
+    /// operation resolved).
+    pub fn resumeAuth(self: *Handshake) HandshakeError!void {
+        if (self.driver.state == .failed) return self.driver.failure().?;
+        if (!self.driver.authPending()) return;
+        try self.applyEvents(try self.driver.resumeAuth());
+    }
+
     pub fn failure(self: *const Handshake) ?HandshakeError {
         return self.driver.failure();
     }

--- a/src/tls/alerts.zig
+++ b/src/tls/alerts.zig
@@ -48,6 +48,9 @@ pub fn fromHandshakeError(err: events.HandshakeError) AlertDescription {
         // The client declined mandatory handshake-time authentication
         // (RFC 8446 §4.4.2.4).
         error.ClientCertificateRequired => .certificate_required,
+        // A CertificateVerify signature failed proof of possession
+        // (RFC 8446 §4.4.3).
+        error.DecryptError => .decrypt_error,
     };
 }
 

--- a/src/tls/alerts.zig
+++ b/src/tls/alerts.zig
@@ -45,6 +45,9 @@ pub fn fromHandshakeError(err: events.HandshakeError) AlertDescription {
         error.NoApplicableCredential => .handshake_failure,
         // A local credential provider, signer, or verifier failed.
         error.CredentialProviderFailed => .internal_error,
+        // The client declined mandatory handshake-time authentication
+        // (RFC 8446 §4.4.2.4).
+        error.ClientCertificateRequired => .certificate_required,
     };
 }
 

--- a/src/tls/alerts.zig
+++ b/src/tls/alerts.zig
@@ -11,6 +11,7 @@ const events = @import("events.zig");
 pub const AlertDescription = enum(u8) {
     close_notify = 0,
     unexpected_message = 10,
+    handshake_failure = 40,
     bad_certificate = 42,
     unsupported_certificate = 43,
     illegal_parameter = 47,
@@ -39,6 +40,11 @@ pub fn fromHandshakeError(err: events.HandshakeError) AlertDescription {
         error.SecretExportFailed => .internal_error,
         error.InvalidHandshakeState => .internal_error,
         error.AlpnMismatch => .no_application_protocol,
+        // This side could not produce an acceptable credential/signature for
+        // the negotiated parameters (RFC 8446 §4.4.2.2).
+        error.NoApplicableCredential => .handshake_failure,
+        // A local credential provider, signer, or verifier failed.
+        error.CredentialProviderFailed => .internal_error,
     };
 }
 

--- a/src/tls/alerts.zig
+++ b/src/tls/alerts.zig
@@ -36,7 +36,9 @@ pub fn fromHandshakeError(err: events.HandshakeError) AlertDescription {
         error.MalformedHandshake => .decode_error,
         error.IllegalParameter => .illegal_parameter,
         error.UnexpectedHandshakeMessage => .unexpected_message,
+        error.MissingExtension => .missing_extension,
         error.CertificateInvalid => .bad_certificate,
+        error.UnsupportedCertificate => .unsupported_certificate,
         error.SecretExportFailed => .internal_error,
         error.InvalidHandshakeState => .internal_error,
         error.AlpnMismatch => .no_application_protocol,
@@ -70,6 +72,14 @@ test "a semantically invalid field value maps to illegal_parameter" {
 
 test "invalid peer certificate maps to bad_certificate" {
     try testing.expectEqual(AlertDescription.bad_certificate, fromHandshakeError(error.CertificateInvalid));
+}
+
+test "unsupported peer certificate maps to unsupported_certificate" {
+    try testing.expectEqual(AlertDescription.unsupported_certificate, fromHandshakeError(error.UnsupportedCertificate));
+}
+
+test "missing required extension maps to missing_extension" {
+    try testing.expectEqual(AlertDescription.missing_extension, fromHandshakeError(error.MissingExtension));
 }
 
 test "secret export failure maps to internal_error" {

--- a/src/tls/credentials.zig
+++ b/src/tls/credentials.zig
@@ -370,6 +370,7 @@ pub const FailureClass = enum {
     /// failure, so diagnostics name the right subsystem).
     provider_internal_failure,
     invalid_peer_certificate_chain,
+    unsupported_peer_certificate,
     /// The peer's CertificateVerify signature did not check out against its
     /// presented leaf (proof-of-possession failure). Peer-originated, but a
     /// distinct reason from a structurally invalid chain.
@@ -384,6 +385,7 @@ pub const FailureClass = enum {
     pub fn origin(self: FailureClass) Origin {
         return switch (self) {
             .invalid_peer_certificate_chain,
+            .unsupported_peer_certificate,
             .certificate_verify_invalid,
             .peer_verification_rejected,
             .client_certificate_required,
@@ -422,6 +424,7 @@ pub const FailureClass = enum {
             .invalid_peer_certificate_chain,
             .peer_verification_rejected,
             => .bad_certificate,
+            .unsupported_peer_certificate => .unsupported_certificate,
             // A CertificateVerify signature that fails proof of possession is a
             // decrypt_error, not a trust rejection (RFC 8446 §4.4.3).
             .certificate_verify_invalid => .decrypt_error,
@@ -438,6 +441,7 @@ pub const FailureClass = enum {
             .invalid_peer_certificate_chain,
             .peer_verification_rejected,
             => error.CertificateInvalid,
+            .unsupported_peer_certificate => error.UnsupportedCertificate,
             .certificate_verify_invalid => error.DecryptError,
             .client_certificate_required => error.ClientCertificateRequired,
             .no_credential_available,
@@ -1298,6 +1302,9 @@ test "every failure class maps to a deterministic alert, origin, and engine erro
         try testing.expectEqual(alerts.AlertDescription.bad_certificate, class.alert());
         try testing.expectEqual(@as(events.HandshakeError, error.CertificateInvalid), class.engineError());
     }
+    try testing.expectEqual(Origin.peer, FailureClass.unsupported_peer_certificate.origin());
+    try testing.expectEqual(alerts.AlertDescription.unsupported_certificate, FailureClass.unsupported_peer_certificate.alert());
+    try testing.expectEqual(@as(events.HandshakeError, error.UnsupportedCertificate), FailureClass.unsupported_peer_certificate.engineError());
     // A CertificateVerify proof-of-possession failure is peer-originated but
     // carries the distinct decrypt_error alert (RFC 8446 §4.4.3).
     try testing.expectEqual(Origin.peer, FailureClass.certificate_verify_invalid.origin());

--- a/src/tls/credentials.zig
+++ b/src/tls/credentials.zig
@@ -841,6 +841,10 @@ pub const MockCredentialProvider = struct {
     /// that violates the callback contract, to prove the engine releases every
     /// owned handle exactly once.
     sign_returns_credential: bool = false,
+    /// When set alongside `pending_fails`, the poll error is
+    /// `InvalidCallbackBehavior` rather than `OperationFailed`, modelling a
+    /// provider that violates the callback contract rather than merely failing.
+    pending_fail_invalid_callback: bool = false,
     pending_polls: usize = 1,
     pending_fails: bool = false,
     poll_count: usize = 0,
@@ -923,7 +927,7 @@ pub const MockCredentialProvider = struct {
             self.remaining_polls -= 1;
             return false;
         }
-        if (self.pending_fails) return error.OperationFailed;
+        if (self.pending_fails) return if (self.pending_fail_invalid_callback) error.InvalidCallbackBehavior else error.OperationFailed;
         switch (self.pending_kind) {
             .select => out.* = if (self.async_no_credential) .no_credential else .{ .credential = self.selectedCredential() },
             .sign => {

--- a/src/tls/credentials.zig
+++ b/src/tls/credentials.zig
@@ -293,6 +293,12 @@ pub const OperationError = error{
 /// the operation kind it resolves.
 pub const Completion = union(enum) {
     credential: SelectedCredential,
+    /// A credential selection that deterministically resolved to "no suitable
+    /// credential" (#334). For a client answering a CertificateRequest this is a
+    /// normal decline — the engine sends an empty Certificate — not a failure,
+    /// so an asynchronous selector can report it faithfully rather than being
+    /// forced into a provider-internal error.
+    no_credential,
     signature_len: usize,
     verdict: Verdict,
 };
@@ -826,6 +832,15 @@ pub const MockCredentialProvider = struct {
     /// completing (or failing, when `pending_fails`).
     async_select: bool = false,
     async_sign: bool = false,
+    /// When set, an asynchronous selection resolves to the "no suitable
+    /// credential" completion rather than a credential, modelling a selector
+    /// that decides to decline (empty Certificate) only after suspending.
+    async_no_credential: bool = false,
+    /// When set, an asynchronous signature completes with the wrong Completion
+    /// kind (a credential instead of a signature length), modelling a provider
+    /// that violates the callback contract, to prove the engine releases every
+    /// owned handle exactly once.
+    sign_returns_credential: bool = false,
     pending_polls: usize = 1,
     pending_fails: bool = false,
     poll_count: usize = 0,
@@ -910,8 +925,14 @@ pub const MockCredentialProvider = struct {
         }
         if (self.pending_fails) return error.OperationFailed;
         switch (self.pending_kind) {
-            .select => out.* = .{ .credential = self.selectedCredential() },
+            .select => out.* = if (self.async_no_credential) .no_credential else .{ .credential = self.selectedCredential() },
             .sign => {
+                if (self.sign_returns_credential) {
+                    // Contract violation: hand back a credential where a
+                    // signature length is required.
+                    out.* = .{ .credential = self.selectedCredential() };
+                    return true;
+                }
                 self.sign_count += 1;
                 const written = self.identity.sign(self.pending_input[0..self.pending_input_len], self.pending_out) catch
                     return error.OperationFailed;

--- a/src/tls/credentials.zig
+++ b/src/tls/credentials.zig
@@ -414,9 +414,11 @@ pub const FailureClass = enum {
             => .internal_error,
             // Peer-originated authentication failure.
             .invalid_peer_certificate_chain,
-            .certificate_verify_invalid,
             .peer_verification_rejected,
             => .bad_certificate,
+            // A CertificateVerify signature that fails proof of possession is a
+            // decrypt_error, not a trust rejection (RFC 8446 §4.4.3).
+            .certificate_verify_invalid => .decrypt_error,
             // The client declined mandatory authentication.
             .client_certificate_required => .certificate_required,
         };
@@ -428,9 +430,9 @@ pub const FailureClass = enum {
     pub fn engineError(self: FailureClass) events.HandshakeError {
         return switch (self) {
             .invalid_peer_certificate_chain,
-            .certificate_verify_invalid,
             .peer_verification_rejected,
             => error.CertificateInvalid,
+            .certificate_verify_invalid => error.DecryptError,
             .client_certificate_required => error.ClientCertificateRequired,
             .no_credential_available,
             .no_compatible_signature_algorithm,
@@ -1266,11 +1268,16 @@ test "mock verifier can reject, error, and report a scripted verdict with call c
 
 test "every failure class maps to a deterministic alert, origin, and engine error" {
     // Peer-originated authentication failures blame the peer's certificate.
-    for ([_]FailureClass{ .invalid_peer_certificate_chain, .certificate_verify_invalid, .peer_verification_rejected }) |class| {
+    for ([_]FailureClass{ .invalid_peer_certificate_chain, .peer_verification_rejected }) |class| {
         try testing.expectEqual(Origin.peer, class.origin());
         try testing.expectEqual(alerts.AlertDescription.bad_certificate, class.alert());
         try testing.expectEqual(@as(events.HandshakeError, error.CertificateInvalid), class.engineError());
     }
+    // A CertificateVerify proof-of-possession failure is peer-originated but
+    // carries the distinct decrypt_error alert (RFC 8446 §4.4.3).
+    try testing.expectEqual(Origin.peer, FailureClass.certificate_verify_invalid.origin());
+    try testing.expectEqual(alerts.AlertDescription.decrypt_error, FailureClass.certificate_verify_invalid.alert());
+    try testing.expectEqual(@as(events.HandshakeError, error.DecryptError), FailureClass.certificate_verify_invalid.engineError());
     // A client that declines mandatory authentication is peer-attributed but
     // carries the distinct certificate_required alert (RFC 8446 §4.4.2.4).
     try testing.expectEqual(Origin.peer, FailureClass.client_certificate_required.origin());

--- a/src/tls/credentials.zig
+++ b/src/tls/credentials.zig
@@ -26,27 +26,40 @@
 //! Certificate chains are surfaced as `CertificateChain`: an immutable view
 //! over a slice of DER byte slices.
 //!
-//!   - The outer `entries` collection is owned by whoever built the chain: the
-//!     engine's bounded reassembly buffer for *peer* chains, the provider's own
-//!     storage for *local* chains. `CertificateChain` never owns or frees it.
-//!   - Each inner DER byte slice is likewise borrowed, never copied by the view.
-//!   - A view handed to a callback (peer DER into `PeerVerifier.verify`, local
-//!     DER out of `SelectedCredential.chain`) is valid ONLY for the duration of
-//!     that single call. A callback MUST NOT retain any slice past its return;
-//!     it copies out anything it needs. The engine may reuse or wipe the
-//!     backing storage immediately afterward.
-//!   - A `SelectedCredential` handle is released exactly once, via `release`,
-//!     after the local flight has been signed and emitted, or immediately on
-//!     any failure encountered after selection (cancellation included). After
-//!     `release` the handle and every slice it produced are invalid.
+//! over a slice of DER byte slices. The `entries` collection and every inner
+//! DER slice are borrowed; `CertificateChain` never owns or frees them. Three
+//! distinct lifetime rules apply depending on which chain it is:
 //!
-//! ## Non-blocking compatibility
+//!   - **Selection-context inputs** (`SelectionContext.server_name`,
+//!     `.peer_signature_schemes`) are valid ONLY during the `select` call. A
+//!     provider that suspends (returns `pending`) or wants to keep any of them
+//!     MUST copy into its own storage first.
+//!   - **Peer-chain views** (`VerificationContext.chain`) are valid ONLY during
+//!     the `verify` call. A verifier MUST NOT retain a slice past its return;
+//!     the engine may reuse or wipe the reassembly buffer immediately after,
+//!     and any pending verify operation owns its own snapshot.
+//!   - **A selected local credential's chain** (`SelectedCredential.chain`) is
+//!     immutable and valid until `SelectedCredential.release()`. The engine
+//!     calls `chain()`, then serializes those slices into the flight, so the
+//!     provider MUST keep them stable for the whole selected lifetime — a
+//!     reloadable provider snapshots them at selection, not per-call.
 //!
-//! Every callback takes its inputs by argument and writes outputs into
-//! caller-owned buffers; none require global state or blocking filesystem or
-//! network access. A synchronous fixed provider and a future event-driven
-//! external signer satisfy the same signatures — the contract does not force
-//! private-key work to block.
+//! A `SelectedCredential` handle is released exactly once, via `release`, after
+//! the local flight has been signed and emitted, or immediately on any failure
+//! after selection (cancellation included). After `release` the handle and
+//! every slice it produced are invalid.
+//!
+//! ## Non-blocking / event-driven compatibility
+//!
+//! `select`, `sign`, and `verify` each return a progress value: `complete`
+//! now, or `pending` with a `PendingOperation` the engine drives via
+//! `poll`/`cancel`/`release`. An HSM, remote signer, or asynchronous verifier
+//! returns `pending`, wakes the driver later, and the engine resumes without
+//! recording any handshake message twice; a pending operation snapshots any
+//! input it needs (the transcript-derived signing bytes, the peer chain) so the
+//! caller-owned stack buffers may disappear. Synchronous providers return
+//! `complete` and never allocate a `PendingOperation`. Every operation is
+//! cancelled and released exactly once, including on handshake teardown.
 
 const std = @import("std");
 const crypto = std.crypto;
@@ -277,7 +290,14 @@ pub const FailureClass = enum {
     malformed_credential_chain,
     signing_provider_failure,
     signature_output_overflow,
+    /// The local credential provider itself failed (distinct from a *verifier*
+    /// failure, so diagnostics name the right subsystem).
+    provider_internal_failure,
     invalid_peer_certificate_chain,
+    /// The peer's CertificateVerify signature did not check out against its
+    /// presented leaf (proof-of-possession failure). Peer-originated, but a
+    /// distinct reason from a structurally invalid chain.
+    certificate_verify_invalid,
     peer_verification_rejected,
     verifier_internal_failure,
     invalid_callback_behavior,
@@ -285,6 +305,7 @@ pub const FailureClass = enum {
     pub fn origin(self: FailureClass) Origin {
         return switch (self) {
             .invalid_peer_certificate_chain,
+            .certificate_verify_invalid,
             .peer_verification_rejected,
             => .peer,
             .no_credential_available,
@@ -292,6 +313,7 @@ pub const FailureClass = enum {
             .malformed_credential_chain,
             .signing_provider_failure,
             .signature_output_overflow,
+            .provider_internal_failure,
             .verifier_internal_failure,
             .invalid_callback_behavior,
             => .local,
@@ -312,11 +334,13 @@ pub const FailureClass = enum {
             .malformed_credential_chain,
             .signing_provider_failure,
             .signature_output_overflow,
+            .provider_internal_failure,
             .verifier_internal_failure,
             .invalid_callback_behavior,
             => .internal_error,
             // Peer-originated authentication failure.
             .invalid_peer_certificate_chain,
+            .certificate_verify_invalid,
             .peer_verification_rejected,
             => .bad_certificate,
         };
@@ -328,6 +352,7 @@ pub const FailureClass = enum {
     pub fn engineError(self: FailureClass) events.HandshakeError {
         return switch (self) {
             .invalid_peer_certificate_chain,
+            .certificate_verify_invalid,
             .peer_verification_rejected,
             => error.CertificateInvalid,
             .no_credential_available,
@@ -336,6 +361,7 @@ pub const FailureClass = enum {
             .malformed_credential_chain,
             .signing_provider_failure,
             .signature_output_overflow,
+            .provider_internal_failure,
             .verifier_internal_failure,
             .invalid_callback_behavior,
             => error.CredentialProviderFailed,
@@ -349,7 +375,7 @@ pub fn classifySelectError(err: SelectError) FailureClass {
         error.NoCredentialAvailable => .no_credential_available,
         error.NoCompatibleSignatureAlgorithm => .no_compatible_signature_algorithm,
         error.MalformedCredentialChain => .malformed_credential_chain,
-        error.ProviderInternalFailure => .verifier_internal_failure,
+        error.ProviderInternalFailure => .provider_internal_failure,
         error.InvalidCallbackBehavior => .invalid_callback_behavior,
     };
 }
@@ -704,15 +730,29 @@ pub const MockCredentialProvider = struct {
     /// Return an empty certificate chain from selection, to model a malformed
     /// local credential the engine must reject before signing.
     empty_chain: bool = false,
+    /// Return the leaf repeated this many times, to model a provider whose
+    /// chain exceeds the engine's entry/size bounds.
+    chain_repeat: usize = 1,
+    /// Skip the peer-offer compatibility check and return the credential's
+    /// scheme regardless, to model a provider that hands back an algorithm the
+    /// peer never advertised.
+    ignore_offer: bool = false,
     /// Sign normally, then flip a signature byte, to model a peer whose
     /// CertificateVerify does not check out (proof-of-possession failure).
     flip_signature: bool = false,
+    chain_storage: [16][]const u8 = undefined,
 
     select_count: usize = 0,
     sign_count: usize = 0,
     release_count: usize = 0,
-    last_server_name: ?[]const u8 = null,
+    /// The last SNI selection saw, copied into mock-owned storage — the
+    /// `SelectionContext.server_name` slice is only valid during `select`, so a
+    /// mock that wants to remember it MUST NOT retain the borrowed slice.
+    last_server_name_buf: [256]u8 = undefined,
+    last_server_name_len: usize = 0,
+    last_server_name_present: bool = false,
     last_offered_scheme_count: usize = 0,
+    last_role: ?Role = null,
 
     pub fn init(identity: Identity) MockCredentialProvider {
         return .{ .identity = identity, .chain_entry = .{identity.certificate_der} };
@@ -722,16 +762,31 @@ pub const MockCredentialProvider = struct {
         return .{ .ctx = self, .vtable = &vtable };
     }
 
+    /// The remembered SNI as a slice into mock-owned storage (valid for the
+    /// mock's lifetime), or null when the last selection carried no SNI.
+    pub fn lastServerName(self: *const MockCredentialProvider) ?[]const u8 {
+        return if (self.last_server_name_present) self.last_server_name_buf[0..self.last_server_name_len] else null;
+    }
+
     const vtable = CredentialProvider.VTable{ .select = select };
 
     fn select(ctx: *anyopaque, selection: *const SelectionContext, out: *SelectedCredential) SelectError!void {
         const self: *MockCredentialProvider = @ptrCast(@alignCast(ctx));
         self.select_count += 1;
-        self.last_server_name = selection.server_name;
+        self.last_role = selection.role;
+        if (selection.server_name) |name| {
+            const n = @min(name.len, self.last_server_name_buf.len);
+            @memcpy(self.last_server_name_buf[0..n], name[0..n]);
+            self.last_server_name_len = n;
+            self.last_server_name_present = true;
+        } else {
+            self.last_server_name_present = false;
+            self.last_server_name_len = 0;
+        }
         self.last_offered_scheme_count = selection.peer_signature_schemes.len;
         if (self.force_select_error) |err| return err;
         const scheme = self.identity.signatureScheme();
-        if (!selection.offersScheme(scheme)) return error.NoCompatibleSignatureAlgorithm;
+        if (!self.ignore_offer and !selection.offersScheme(scheme)) return error.NoCompatibleSignatureAlgorithm;
         out.* = .{ .handle = self, .scheme = scheme, .vtable = &credential_vtable };
     }
 
@@ -743,7 +798,11 @@ pub const MockCredentialProvider = struct {
 
     fn credentialChain(handle: *anyopaque) CertificateChain {
         const self: *MockCredentialProvider = @ptrCast(@alignCast(handle));
-        return .{ .entries = if (self.empty_chain) self.chain_entry[0..0] else self.chain_entry[0..] };
+        if (self.empty_chain) return .{ .entries = self.chain_entry[0..0] };
+        if (self.chain_repeat == 1) return .{ .entries = self.chain_entry[0..] };
+        const n = @min(self.chain_repeat, self.chain_storage.len);
+        for (0..n) |i| self.chain_storage[i] = self.identity.certificate_der;
+        return .{ .entries = self.chain_storage[0..n] };
     }
 
     fn credentialSign(handle: *anyopaque, scheme: SignatureScheme, input: []const u8, out: []u8) SignError!usize {
@@ -770,6 +829,13 @@ pub const MockVerifier = struct {
     verify_count: usize = 0,
     last_chain_len: usize = 0,
     last_role: ?Role = null,
+    last_policy: AuthPolicy = .{},
+    /// The server name the verifier last observed, copied into mock-owned
+    /// storage — the `VerificationContext.server_name` slice is only valid
+    /// during the `verify` call.
+    last_server_name_buf: [256]u8 = undefined,
+    last_server_name_len: usize = 0,
+    last_server_name_present: bool = false,
 
     pub fn init(result: VerifyError!Verdict) MockVerifier {
         return .{ .result = result };
@@ -779,6 +845,10 @@ pub const MockVerifier = struct {
         return .{ .ctx = self, .vtable = &vtable };
     }
 
+    pub fn lastServerName(self: *const MockVerifier) ?[]const u8 {
+        return if (self.last_server_name_present) self.last_server_name_buf[0..self.last_server_name_len] else null;
+    }
+
     const vtable = PeerVerifier.VTable{ .verify = verify };
 
     fn verify(ctx: *anyopaque, context: *const VerificationContext) VerifyError!Verdict {
@@ -786,6 +856,16 @@ pub const MockVerifier = struct {
         self.verify_count += 1;
         self.last_chain_len = context.chain.count();
         self.last_role = context.role;
+        self.last_policy = context.auth_policy;
+        if (context.server_name) |name| {
+            const n = @min(name.len, self.last_server_name_buf.len);
+            @memcpy(self.last_server_name_buf[0..n], name[0..n]);
+            self.last_server_name_len = n;
+            self.last_server_name_present = true;
+        } else {
+            self.last_server_name_present = false;
+            self.last_server_name_len = 0;
+        }
         return self.result;
     }
 };
@@ -985,7 +1065,7 @@ test "mock verifier can reject, error, and report a scripted verdict with call c
 
 test "every failure class maps to a deterministic alert, origin, and engine error" {
     // Peer-originated authentication failures blame the peer's certificate.
-    for ([_]FailureClass{ .invalid_peer_certificate_chain, .peer_verification_rejected }) |class| {
+    for ([_]FailureClass{ .invalid_peer_certificate_chain, .certificate_verify_invalid, .peer_verification_rejected }) |class| {
         try testing.expectEqual(Origin.peer, class.origin());
         try testing.expectEqual(alerts.AlertDescription.bad_certificate, class.alert());
         try testing.expectEqual(@as(events.HandshakeError, error.CertificateInvalid), class.engineError());
@@ -996,11 +1076,14 @@ test "every failure class maps to a deterministic alert, origin, and engine erro
         try testing.expectEqual(alerts.AlertDescription.handshake_failure, class.alert());
         try testing.expectEqual(@as(events.HandshakeError, error.NoApplicableCredential), class.engineError());
     }
-    // Local provider/verifier faults are our internal errors.
+    // Local provider/verifier faults are our internal errors. `provider` and
+    // `verifier` internal failures are distinct classes so diagnostics name the
+    // right subsystem, even though both map to the same wire alert.
     for ([_]FailureClass{
         .malformed_credential_chain,
         .signing_provider_failure,
         .signature_output_overflow,
+        .provider_internal_failure,
         .verifier_internal_failure,
         .invalid_callback_behavior,
     }) |class| {
@@ -1008,13 +1091,16 @@ test "every failure class maps to a deterministic alert, origin, and engine erro
         try testing.expectEqual(alerts.AlertDescription.internal_error, class.alert());
         try testing.expectEqual(@as(events.HandshakeError, error.CredentialProviderFailed), class.engineError());
     }
+    try testing.expect(FailureClass.provider_internal_failure != FailureClass.verifier_internal_failure);
+    try testing.expect(FailureClass.certificate_verify_invalid != FailureClass.invalid_peer_certificate_chain);
+    try testing.expectEqual(FailureClass.provider_internal_failure, classifySelectError(error.ProviderInternalFailure));
 }
 
 test "error classifiers cover every select, sign, and verify error" {
     try testing.expectEqual(FailureClass.no_credential_available, classifySelectError(error.NoCredentialAvailable));
     try testing.expectEqual(FailureClass.no_compatible_signature_algorithm, classifySelectError(error.NoCompatibleSignatureAlgorithm));
     try testing.expectEqual(FailureClass.malformed_credential_chain, classifySelectError(error.MalformedCredentialChain));
-    try testing.expectEqual(FailureClass.verifier_internal_failure, classifySelectError(error.ProviderInternalFailure));
+    try testing.expectEqual(FailureClass.provider_internal_failure, classifySelectError(error.ProviderInternalFailure));
     try testing.expectEqual(FailureClass.invalid_callback_behavior, classifySelectError(error.InvalidCallbackBehavior));
 
     try testing.expectEqual(FailureClass.signing_provider_failure, classifySignError(error.SigningProviderFailure));

--- a/src/tls/credentials.zig
+++ b/src/tls/credentials.zig
@@ -371,12 +371,16 @@ pub const FailureClass = enum {
     peer_verification_rejected,
     verifier_internal_failure,
     invalid_callback_behavior,
+    /// The server requires handshake-time client authentication and the client
+    /// presented no certificate. Peer-attributed (certificate_required).
+    client_certificate_required,
 
     pub fn origin(self: FailureClass) Origin {
         return switch (self) {
             .invalid_peer_certificate_chain,
             .certificate_verify_invalid,
             .peer_verification_rejected,
+            .client_certificate_required,
             => .peer,
             .no_credential_available,
             .no_compatible_signature_algorithm,
@@ -413,6 +417,8 @@ pub const FailureClass = enum {
             .certificate_verify_invalid,
             .peer_verification_rejected,
             => .bad_certificate,
+            // The client declined mandatory authentication.
+            .client_certificate_required => .certificate_required,
         };
     }
 
@@ -425,6 +431,7 @@ pub const FailureClass = enum {
             .certificate_verify_invalid,
             .peer_verification_rejected,
             => error.CertificateInvalid,
+            .client_certificate_required => error.ClientCertificateRequired,
             .no_credential_available,
             .no_compatible_signature_algorithm,
             => error.NoApplicableCredential,
@@ -1264,6 +1271,11 @@ test "every failure class maps to a deterministic alert, origin, and engine erro
         try testing.expectEqual(alerts.AlertDescription.bad_certificate, class.alert());
         try testing.expectEqual(@as(events.HandshakeError, error.CertificateInvalid), class.engineError());
     }
+    // A client that declines mandatory authentication is peer-attributed but
+    // carries the distinct certificate_required alert (RFC 8446 §4.4.2.4).
+    try testing.expectEqual(Origin.peer, FailureClass.client_certificate_required.origin());
+    try testing.expectEqual(alerts.AlertDescription.certificate_required, FailureClass.client_certificate_required.alert());
+    try testing.expectEqual(@as(events.HandshakeError, error.ClientCertificateRequired), FailureClass.client_certificate_required.engineError());
     // Local "cannot authenticate ourselves" failures use handshake_failure.
     for ([_]FailureClass{ .no_credential_available, .no_compatible_signature_algorithm }) |class| {
         try testing.expectEqual(Origin.local, class.origin());

--- a/src/tls/credentials.zig
+++ b/src/tls/credentials.zig
@@ -168,9 +168,11 @@ pub const SelectedCredential = struct {
         /// only until `release` (or the end of the current engine call).
         chain: *const fn (handle: *anyopaque) CertificateChain,
         /// Sign `input` with `scheme`, writing the signature into `out` and
-        /// returning its length. Must not write past `out`; report
-        /// `SignatureOutputOverflow` when it would not fit.
-        sign: *const fn (handle: *anyopaque, scheme: SignatureScheme, input: []const u8, out: []u8) SignError!usize,
+        /// completing with its length. Must not write past `out`; report
+        /// `SignatureOutputOverflow` when it would not fit. May return `pending`
+        /// (an async signer); the pending operation must keep `out` and a
+        /// snapshot of `input` until it completes.
+        sign: *const fn (handle: *anyopaque, scheme: SignatureScheme, input: []const u8, out: []u8) SignError!Progress(usize),
         /// Release the handle and any storage it produced. Called exactly once.
         release: *const fn (handle: *anyopaque) void,
     };
@@ -179,13 +181,16 @@ pub const SelectedCredential = struct {
         return self.vtable.chain(self.handle);
     }
 
-    /// Sign through the provider, defensively enforcing the output bound: a
-    /// provider that reports writing more than `out.len` has violated the
-    /// contract and is reported as such rather than trusted.
-    pub fn sign(self: SelectedCredential, input: []const u8, out: []u8) SignError!usize {
-        const written = try self.vtable.sign(self.handle, self.scheme, input, out);
-        if (written > out.len) return error.InvalidCallbackBehavior;
-        return written;
+    /// Sign through the provider, defensively enforcing the output bound on a
+    /// synchronous completion: a provider that reports writing more than
+    /// `out.len` has violated the contract and is reported as such.
+    pub fn sign(self: SelectedCredential, input: []const u8, out: []u8) SignError!Progress(usize) {
+        const progress = try self.vtable.sign(self.handle, self.scheme, input, out);
+        switch (progress) {
+            .complete => |written| if (written > out.len) return error.InvalidCallbackBehavior,
+            .pending => {},
+        }
+        return progress;
     }
 
     pub fn release(self: SelectedCredential) void {
@@ -214,11 +219,13 @@ pub const CredentialProvider = struct {
     vtable: *const VTable,
 
     pub const VTable = struct {
-        select: *const fn (ctx: *anyopaque, selection: *const SelectionContext, out: *SelectedCredential) SelectError!void,
+        /// Select a credential, completing with it synchronously or returning a
+        /// pending operation (e.g. an SNI lookup that must go async).
+        select: *const fn (ctx: *anyopaque, selection: *const SelectionContext) SelectError!Progress(SelectedCredential),
     };
 
-    pub fn selectCredential(self: CredentialProvider, selection: *const SelectionContext, out: *SelectedCredential) SelectError!void {
-        return self.vtable.select(self.ctx, selection, out);
+    pub fn selectCredential(self: CredentialProvider, selection: *const SelectionContext) SelectError!Progress(SelectedCredential) {
+        return self.vtable.select(self.ctx, selection);
     }
 };
 
@@ -261,13 +268,76 @@ pub const PeerVerifier = struct {
     vtable: *const VTable,
 
     pub const VTable = struct {
-        verify: *const fn (ctx: *anyopaque, context: *const VerificationContext) VerifyError!Verdict,
+        verify: *const fn (ctx: *anyopaque, context: *const VerificationContext) VerifyError!Progress(Verdict),
     };
 
-    pub fn verifyPeer(self: PeerVerifier, context: *const VerificationContext) VerifyError!Verdict {
+    pub fn verifyPeer(self: PeerVerifier, context: *const VerificationContext) VerifyError!Progress(Verdict) {
         return self.vtable.verify(self.ctx, context);
     }
 };
+
+// ===========================================================================
+// Asynchronous / event-driven progression.
+// ===========================================================================
+
+/// Errors a pending authentication operation may report while resolving.
+pub const OperationError = error{
+    /// The underlying async operation failed (signer/verifier/selector fault).
+    OperationFailed,
+    /// The operation violated its contract (completed with an out-of-range or
+    /// wrong-kind result).
+    InvalidCallbackBehavior,
+};
+
+/// The value an in-flight `PendingOperation` yields on completion, tagged by
+/// the operation kind it resolves.
+pub const Completion = union(enum) {
+    credential: SelectedCredential,
+    signature_len: usize,
+    verdict: Verdict,
+};
+
+/// A handle to an authentication operation that did not complete synchronously
+/// — an HSM round-trip, a remote signer, an async verifier. The engine parks it
+/// and drives `poll` when the caller signals progress, `cancel` if the
+/// handshake is abandoned before it resolves, and `release` exactly once at the
+/// end (after completion or cancellation). While pending, the operation owns a
+/// snapshot of whatever input it needs; the engine's stack buffers may vanish.
+pub const PendingOperation = struct {
+    handle: *anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        /// Poll for completion: returns true and fills `out` when done, false
+        /// while still pending. An error terminates the operation.
+        poll: *const fn (handle: *anyopaque, out: *Completion) OperationError!bool,
+        /// Abandon an in-flight operation (handshake cancelled or failed).
+        cancel: *const fn (handle: *anyopaque) void,
+        /// Release operation resources. Called exactly once.
+        release: *const fn (handle: *anyopaque) void,
+    };
+
+    pub fn poll(self: PendingOperation, out: *Completion) OperationError!bool {
+        return self.vtable.poll(self.handle, out);
+    }
+    pub fn cancel(self: PendingOperation) void {
+        self.vtable.cancel(self.handle);
+    }
+    pub fn release(self: PendingOperation) void {
+        self.vtable.release(self.handle);
+    }
+};
+
+/// The result of an authentication callback: `complete` synchronously with a
+/// value, or `pending` with an operation the engine resumes later. A
+/// synchronous provider always returns `complete` and never allocates a
+/// `PendingOperation`; the contract does not force private-key work to block.
+pub fn Progress(comptime T: type) type {
+    return union(enum) {
+        complete: T,
+        pending: PendingOperation,
+    };
+}
 
 // ===========================================================================
 // Typed failures and deterministic alert mapping.
@@ -601,7 +671,7 @@ pub const FixedCredentialProvider = struct {
 
     const vtable = CredentialProvider.VTable{ .select = select };
 
-    fn select(ctx: *anyopaque, selection: *const SelectionContext, out: *SelectedCredential) SelectError!void {
+    fn select(ctx: *anyopaque, selection: *const SelectionContext) SelectError!Progress(SelectedCredential) {
         const self: *FixedCredentialProvider = @ptrCast(@alignCast(ctx));
         if (self.identity.certificate_der.len == 0) return error.MalformedCredentialChain;
         const scheme = self.identity.signatureScheme();
@@ -610,7 +680,7 @@ pub const FixedCredentialProvider = struct {
         // richer selection would try alternate credentials; a fixed provider
         // has only this one).
         if (!selection.offersScheme(scheme)) return error.NoCompatibleSignatureAlgorithm;
-        out.* = .{ .handle = self, .scheme = scheme, .vtable = &credential_vtable };
+        return .{ .complete = .{ .handle = self, .scheme = scheme, .vtable = &credential_vtable } };
     }
 
     const credential_vtable = SelectedCredential.VTable{
@@ -624,12 +694,12 @@ pub const FixedCredentialProvider = struct {
         return .{ .entries = self.chain_entry[0..] };
     }
 
-    fn credentialSign(handle: *anyopaque, scheme: SignatureScheme, input: []const u8, out: []u8) SignError!usize {
+    fn credentialSign(handle: *anyopaque, scheme: SignatureScheme, input: []const u8, out: []u8) SignError!Progress(usize) {
         const self: *FixedCredentialProvider = @ptrCast(@alignCast(handle));
         // The engine signs with the scheme the credential reported; a mismatch
         // would be an engine bug, guarded here defensively.
         if (scheme != self.identity.signatureScheme()) return error.InvalidCallbackBehavior;
-        return self.identity.sign(input, out);
+        return .{ .complete = try self.identity.sign(input, out) };
     }
 
     fn credentialRelease(handle: *anyopaque) void {
@@ -668,13 +738,14 @@ pub const FixedVerifier = struct {
 
     const vtable = PeerVerifier.VTable{ .verify = verify };
 
-    fn verify(ctx: *anyopaque, context: *const VerificationContext) VerifyError!Verdict {
+    fn verify(ctx: *anyopaque, context: *const VerificationContext) VerifyError!Progress(Verdict) {
         const self: *FixedVerifier = @ptrCast(@alignCast(ctx));
         const leaf = context.chain.leaf() orelse return error.InvalidPeerCertificateChain;
-        return switch (self.trust) {
+        const verdict: Verdict = switch (self.trust) {
             .pinned_certificate => |pin| if (std.mem.eql(u8, leaf, pin)) .accepted else .rejected,
             .insecure_no_verification => .not_checked,
         };
+        return .{ .complete = verdict };
     }
 };
 
@@ -741,6 +812,22 @@ pub const MockCredentialProvider = struct {
     /// CertificateVerify does not check out (proof-of-possession failure).
     flip_signature: bool = false,
     chain_storage: [16][]const u8 = undefined,
+    /// Async modelling: when set, `select`/`sign` return `pending`, and the
+    /// pending operation reports `pending` for `pending_polls` polls before
+    /// completing (or failing, when `pending_fails`).
+    async_select: bool = false,
+    async_sign: bool = false,
+    pending_polls: usize = 1,
+    pending_fails: bool = false,
+    poll_count: usize = 0,
+    cancel_count: usize = 0,
+    op_release_count: usize = 0,
+    // Snapshot of the signing job captured when a pending sign is issued.
+    pending_kind: enum { none, select, sign } = .none,
+    pending_out: []u8 = &.{},
+    pending_input: [256]u8 = undefined,
+    pending_input_len: usize = 0,
+    remaining_polls: usize = 0,
 
     select_count: usize = 0,
     sign_count: usize = 0,
@@ -768,9 +855,13 @@ pub const MockCredentialProvider = struct {
         return if (self.last_server_name_present) self.last_server_name_buf[0..self.last_server_name_len] else null;
     }
 
+    pub fn selectedCredential(self: *MockCredentialProvider) SelectedCredential {
+        return .{ .handle = self, .scheme = self.identity.signatureScheme(), .vtable = &credential_vtable };
+    }
+
     const vtable = CredentialProvider.VTable{ .select = select };
 
-    fn select(ctx: *anyopaque, selection: *const SelectionContext, out: *SelectedCredential) SelectError!void {
+    fn select(ctx: *anyopaque, selection: *const SelectionContext) SelectError!Progress(SelectedCredential) {
         const self: *MockCredentialProvider = @ptrCast(@alignCast(ctx));
         self.select_count += 1;
         self.last_role = selection.role;
@@ -787,7 +878,49 @@ pub const MockCredentialProvider = struct {
         if (self.force_select_error) |err| return err;
         const scheme = self.identity.signatureScheme();
         if (!self.ignore_offer and !selection.offersScheme(scheme)) return error.NoCompatibleSignatureAlgorithm;
-        out.* = .{ .handle = self, .scheme = scheme, .vtable = &credential_vtable };
+        if (self.async_select) {
+            self.pending_kind = .select;
+            self.remaining_polls = self.pending_polls;
+            return .{ .pending = self.pendingOp() };
+        }
+        return .{ .complete = self.selectedCredential() };
+    }
+
+    fn pendingOp(self: *MockCredentialProvider) PendingOperation {
+        return .{ .handle = self, .vtable = &op_vtable };
+    }
+
+    const op_vtable = PendingOperation.VTable{ .poll = opPoll, .cancel = opCancel, .release = opRelease };
+
+    fn opPoll(handle: *anyopaque, out: *Completion) OperationError!bool {
+        const self: *MockCredentialProvider = @ptrCast(@alignCast(handle));
+        self.poll_count += 1;
+        if (self.remaining_polls > 0) {
+            self.remaining_polls -= 1;
+            return false;
+        }
+        if (self.pending_fails) return error.OperationFailed;
+        switch (self.pending_kind) {
+            .select => out.* = .{ .credential = self.selectedCredential() },
+            .sign => {
+                self.sign_count += 1;
+                const written = self.identity.sign(self.pending_input[0..self.pending_input_len], self.pending_out) catch
+                    return error.OperationFailed;
+                out.* = .{ .signature_len = written };
+            },
+            .none => return error.InvalidCallbackBehavior,
+        }
+        return true;
+    }
+
+    fn opCancel(handle: *anyopaque) void {
+        const self: *MockCredentialProvider = @ptrCast(@alignCast(handle));
+        self.cancel_count += 1;
+    }
+
+    fn opRelease(handle: *anyopaque) void {
+        const self: *MockCredentialProvider = @ptrCast(@alignCast(handle));
+        self.op_release_count += 1;
     }
 
     const credential_vtable = SelectedCredential.VTable{
@@ -805,15 +938,26 @@ pub const MockCredentialProvider = struct {
         return .{ .entries = self.chain_storage[0..n] };
     }
 
-    fn credentialSign(handle: *anyopaque, scheme: SignatureScheme, input: []const u8, out: []u8) SignError!usize {
+    fn credentialSign(handle: *anyopaque, scheme: SignatureScheme, input: []const u8, out: []u8) SignError!Progress(usize) {
         const self: *MockCredentialProvider = @ptrCast(@alignCast(handle));
+        _ = scheme;
+        if (self.async_sign) {
+            // Snapshot the transcript-derived input and capture the (stable,
+            // engine-owned) output buffer; complete on a later poll.
+            self.pending_kind = .sign;
+            self.remaining_polls = self.pending_polls;
+            const n = @min(input.len, self.pending_input.len);
+            @memcpy(self.pending_input[0..n], input[0..n]);
+            self.pending_input_len = n;
+            self.pending_out = out;
+            return .{ .pending = self.pendingOp() };
+        }
         self.sign_count += 1;
         if (self.force_sign_error) |err| return err;
-        if (self.force_sign_len) |forced| return forced; // may exceed out.len on purpose
-        _ = scheme;
+        if (self.force_sign_len) |forced| return .{ .complete = forced }; // may exceed out.len on purpose
         const written = try self.identity.sign(input, out);
         if (self.flip_signature and written > 0) out[0] ^= 0xff;
-        return written;
+        return .{ .complete = written };
     }
 
     fn credentialRelease(handle: *anyopaque) void {
@@ -836,6 +980,14 @@ pub const MockVerifier = struct {
     last_server_name_buf: [256]u8 = undefined,
     last_server_name_len: usize = 0,
     last_server_name_present: bool = false,
+    /// Async modelling: return `pending`, resolving to `result` after
+    /// `pending_polls` polls.
+    async_mode: bool = false,
+    pending_polls: usize = 1,
+    remaining_polls: usize = 0,
+    poll_count: usize = 0,
+    cancel_count: usize = 0,
+    op_release_count: usize = 0,
 
     pub fn init(result: VerifyError!Verdict) MockVerifier {
         return .{ .result = result };
@@ -851,7 +1003,7 @@ pub const MockVerifier = struct {
 
     const vtable = PeerVerifier.VTable{ .verify = verify };
 
-    fn verify(ctx: *anyopaque, context: *const VerificationContext) VerifyError!Verdict {
+    fn verify(ctx: *anyopaque, context: *const VerificationContext) VerifyError!Progress(Verdict) {
         const self: *MockVerifier = @ptrCast(@alignCast(ctx));
         self.verify_count += 1;
         self.last_chain_len = context.chain.count();
@@ -866,7 +1018,35 @@ pub const MockVerifier = struct {
             self.last_server_name_present = false;
             self.last_server_name_len = 0;
         }
-        return self.result;
+        if (self.async_mode) {
+            self.remaining_polls = self.pending_polls;
+            return .{ .pending = .{ .handle = self, .vtable = &op_vtable } };
+        }
+        return .{ .complete = try self.result };
+    }
+
+    const op_vtable = PendingOperation.VTable{ .poll = opPoll, .cancel = opCancel, .release = opRelease };
+
+    fn opPoll(handle: *anyopaque, out: *Completion) OperationError!bool {
+        const self: *MockVerifier = @ptrCast(@alignCast(handle));
+        self.poll_count += 1;
+        if (self.remaining_polls > 0) {
+            self.remaining_polls -= 1;
+            return false;
+        }
+        const verdict = self.result catch return error.OperationFailed;
+        out.* = .{ .verdict = verdict };
+        return true;
+    }
+
+    fn opCancel(handle: *anyopaque) void {
+        const self: *MockVerifier = @ptrCast(@alignCast(handle));
+        self.cancel_count += 1;
+    }
+
+    fn opRelease(handle: *anyopaque) void {
+        const self: *MockVerifier = @ptrCast(@alignCast(handle));
+        self.op_release_count += 1;
     }
 };
 
@@ -889,14 +1069,34 @@ fn testSelection(schemes: []const u16) SelectionContext {
     };
 }
 
+// Synchronous unwrap helpers for the contract tests: assert the callback
+// completed rather than returning `pending`.
+fn syncSelect(provider: CredentialProvider, selection: *const SelectionContext) !SelectedCredential {
+    return switch (try provider.selectCredential(selection)) {
+        .complete => |credential| credential,
+        .pending => error.TestUnexpectedPending,
+    };
+}
+fn syncSign(credential: SelectedCredential, input: []const u8, out: []u8) !usize {
+    return switch (try credential.sign(input, out)) {
+        .complete => |written| written,
+        .pending => error.TestUnexpectedPending,
+    };
+}
+fn syncVerify(v: PeerVerifier, context: *const VerificationContext) !Verdict {
+    return switch (try v.verifyPeer(context)) {
+        .complete => |verdict| verdict,
+        .pending => error.TestUnexpectedPending,
+    };
+}
+
 test "fixed provider selects and exposes its public chain without private-key bytes" {
     var fixed = FixedCredentialProvider.init(testdata.identity());
     defer fixed.deinit();
     const provider = fixed.provider();
 
     const selection = testSelection(&.{ 0x0807, 0x0403 });
-    var credential: SelectedCredential = undefined;
-    try provider.selectCredential(&selection, &credential);
+    const credential = try syncSelect(provider, &selection);
     try testing.expectEqual(SignatureScheme.ed25519, credential.scheme);
 
     const chain = credential.certificateChain();
@@ -910,13 +1110,12 @@ test "fixed provider signs a bounded output the certificate can verify" {
     defer fixed.deinit();
     const provider = fixed.provider();
     const selection = testSelection(&.{0x0807});
-    var credential: SelectedCredential = undefined;
-    try provider.selectCredential(&selection, &credential);
+    const credential = try syncSelect(provider, &selection);
     defer credential.release();
 
     const message = "TLS 1.3 CertificateVerify transcript-derived signing input";
     var sig_buf: [128]u8 = undefined;
-    const written = try credential.sign(message, &sig_buf);
+    const written = try syncSign(credential, message, &sig_buf);
     try testing.expectEqual(Ed25519.Signature.encoded_length, written);
 
     // The signature verifies against the certificate's Ed25519 public key.
@@ -931,8 +1130,7 @@ test "fixed provider rejects an output buffer too small for the signature" {
     defer fixed.deinit();
     const provider = fixed.provider();
     const selection = testSelection(&.{0x0807});
-    var credential: SelectedCredential = undefined;
-    try provider.selectCredential(&selection, &credential);
+    const credential = try syncSelect(provider, &selection);
     defer credential.release();
 
     var tiny: [16]u8 = undefined;
@@ -946,12 +1144,11 @@ test "fixed provider filters on the peer's offered signature algorithms" {
 
     // Peer offers only ECDSA P-256; the Ed25519 credential is not compatible.
     const ecdsa_only = testSelection(&.{0x0403});
-    var credential: SelectedCredential = undefined;
-    try testing.expectError(error.NoCompatibleSignatureAlgorithm, provider.selectCredential(&ecdsa_only, &credential));
+    try testing.expectError(error.NoCompatibleSignatureAlgorithm, provider.selectCredential(&ecdsa_only));
 
     // With no schemes offered at all, still no compatible scheme.
     const none = testSelection(&.{});
-    try testing.expectError(error.NoCompatibleSignatureAlgorithm, provider.selectCredential(&none, &credential));
+    try testing.expectError(error.NoCompatibleSignatureAlgorithm, provider.selectCredential(&none));
 }
 
 test "selection context preserves the exact SNI and absent SNI deterministically" {
@@ -969,8 +1166,7 @@ test "mock provider selects the compatible preferred scheme among several offers
     const provider = mock.provider();
     // Peer offers ECDSA first, then Ed25519; the Ed25519 credential still binds.
     const selection = testSelection(&.{ 0x0403, 0x0807 });
-    var credential: SelectedCredential = undefined;
-    try provider.selectCredential(&selection, &credential);
+    const credential = try syncSelect(provider, &selection);
     try testing.expectEqual(SignatureScheme.ed25519, credential.scheme);
     try testing.expectEqual(@as(usize, 1), mock.select_count);
     try testing.expectEqual(@as(usize, 2), mock.last_offered_scheme_count);
@@ -983,8 +1179,7 @@ test "SelectedCredential.sign catches a provider that overreports its length" {
     mock.force_sign_len = 999; // claim a write far past the buffer
     const provider = mock.provider();
     const selection = testSelection(&.{0x0807});
-    var credential: SelectedCredential = undefined;
-    try provider.selectCredential(&selection, &credential);
+    const credential = try syncSelect(provider, &selection);
     defer credential.release();
 
     var out: [128]u8 = undefined;
@@ -996,8 +1191,7 @@ test "mock provider reports a scripted signing failure" {
     mock.force_sign_error = error.SigningProviderFailure;
     const provider = mock.provider();
     const selection = testSelection(&.{0x0807});
-    var credential: SelectedCredential = undefined;
-    try provider.selectCredential(&selection, &credential);
+    const credential = try syncSelect(provider, &selection);
     defer credential.release();
     var out: [128]u8 = undefined;
     try testing.expectError(error.SigningProviderFailure, credential.sign("input", &out));
@@ -1016,14 +1210,14 @@ test "fixed verifier accepts a matching pin and rejects a mismatch" {
     };
 
     var pinned = FixedVerifier.init(.{ .pinned_certificate = testdata.certificate_der });
-    try testing.expectEqual(Verdict.accepted, try pinned.verifier().verifyPeer(&context));
+    try testing.expectEqual(Verdict.accepted, try syncVerify(pinned.verifier(), &context));
 
     var wrong = [_]u8{0} ** 4;
     var mismatched = FixedVerifier.init(.{ .pinned_certificate = &wrong });
-    try testing.expectEqual(Verdict.rejected, try mismatched.verifier().verifyPeer(&context));
+    try testing.expectEqual(Verdict.rejected, try syncVerify(mismatched.verifier(), &context));
 
     var insecure = FixedVerifier.init(.insecure_no_verification);
-    try testing.expectEqual(Verdict.not_checked, try insecure.verifier().verifyPeer(&context));
+    try testing.expectEqual(Verdict.not_checked, try syncVerify(insecure.verifier(), &context));
 }
 
 test "fixed verifier reports an empty chain as an invalid peer chain" {
@@ -1054,7 +1248,7 @@ test "mock verifier can reject, error, and report a scripted verdict with call c
     };
 
     var rejecting = MockVerifier.init(.rejected);
-    try testing.expectEqual(Verdict.rejected, try rejecting.verifier().verifyPeer(&context));
+    try testing.expectEqual(Verdict.rejected, try syncVerify(rejecting.verifier(), &context));
     try testing.expectEqual(@as(usize, 1), rejecting.verify_count);
     try testing.expectEqual(@as(usize, 1), rejecting.last_chain_len);
     try testing.expectEqual(Role.client, rejecting.last_role.?);

--- a/src/tls/credentials.zig
+++ b/src/tls/credentials.zig
@@ -1,0 +1,1044 @@
+//! Provider-neutral TLS 1.3 credential and verification contracts.
+//!
+//! This module is the seam through which the handshake engine
+//! (`tls13_backend.zig`) obtains a *local* authentication credential and
+//! delegates *peer* certificate verification, without embedding X.509 policy,
+//! private-key byte handling, or provider lifecycle in the state machine.
+//! Nothing here imports OpenSSL, a concrete X.509 validator, QUIC, or HTTP,
+//! and no private-key bytes cross any interface: a selected credential exposes
+//! its public certificate chain and a signing *capability* only (#334).
+//!
+//! The three contracts are deliberately minimal vtables so a future
+//! production SNI selector (#347), an external/asynchronous signer, or a
+//! Web-PKI verifier (#324) can be dropped in without touching the engine:
+//!
+//!   - `CredentialProvider`  — selects a local credential for a handshake,
+//!                             given immutable selection context.
+//!   - `SelectedCredential`  — an opaque handle exposing (a) the public
+//!                             certificate chain and (b) a bounded signing
+//!                             callback; released exactly once by the engine.
+//!   - `PeerVerifier`        — inspects immutable peer DER views and returns a
+//!                             verdict; the engine performs proof-of-possession
+//!                             separately (transcript crypto is not PKI policy).
+//!
+//! ## Ownership and lifetime rules (normative)
+//!
+//! Certificate chains are surfaced as `CertificateChain`: an immutable view
+//! over a slice of DER byte slices.
+//!
+//!   - The outer `entries` collection is owned by whoever built the chain: the
+//!     engine's bounded reassembly buffer for *peer* chains, the provider's own
+//!     storage for *local* chains. `CertificateChain` never owns or frees it.
+//!   - Each inner DER byte slice is likewise borrowed, never copied by the view.
+//!   - A view handed to a callback (peer DER into `PeerVerifier.verify`, local
+//!     DER out of `SelectedCredential.chain`) is valid ONLY for the duration of
+//!     that single call. A callback MUST NOT retain any slice past its return;
+//!     it copies out anything it needs. The engine may reuse or wipe the
+//!     backing storage immediately afterward.
+//!   - A `SelectedCredential` handle is released exactly once, via `release`,
+//!     after the local flight has been signed and emitted, or immediately on
+//!     any failure encountered after selection (cancellation included). After
+//!     `release` the handle and every slice it produced are invalid.
+//!
+//! ## Non-blocking compatibility
+//!
+//! Every callback takes its inputs by argument and writes outputs into
+//! caller-owned buffers; none require global state or blocking filesystem or
+//! network access. A synchronous fixed provider and a future event-driven
+//! external signer satisfy the same signatures — the contract does not force
+//! private-key work to block.
+
+const std = @import("std");
+const crypto = std.crypto;
+const alerts = @import("alerts.zig");
+const events = @import("events.zig");
+const tls_state = @import("state.zig");
+
+const Ed25519 = crypto.sign.Ed25519;
+const EcdsaP256 = crypto.sign.ecdsa.EcdsaP256Sha256;
+
+pub const Role = tls_state.Role;
+
+/// TLS SignatureScheme code points (RFC 8446 §4.2.3) for the schemes this
+/// profile can sign and verify. Non-exhaustive: peers may offer others, which
+/// selection treats as simply unsupported rather than illegal.
+pub const SignatureScheme = enum(u16) {
+    ed25519 = 0x0807,
+    ecdsa_secp256r1_sha256 = 0x0403,
+    _,
+
+    pub fn code(self: SignatureScheme) u16 {
+        return @intFromEnum(self);
+    }
+};
+
+/// Largest local or peer certificate chain (entry count) any contract here
+/// surfaces. A single-certificate flight is the common case; the bound leaves
+/// room for a short intermediate chain without unbounded growth.
+pub const max_chain_entries = 8;
+
+/// Immutable view over a DER certificate chain. See the module-level ownership
+/// and lifetime rules: `entries` and every slice within are borrowed and valid
+/// only for the lifetime of the call that produced the view.
+pub const CertificateChain = struct {
+    entries: []const []const u8,
+
+    pub fn count(self: CertificateChain) usize {
+        return self.entries.len;
+    }
+
+    /// The end-entity certificate (first in the chain), or null when empty.
+    pub fn leaf(self: CertificateChain) ?[]const u8 {
+        return if (self.entries.len == 0) null else self.entries[0];
+    }
+};
+
+/// Local authentication policy relevant to selection and verification. Kept
+/// deliberately small; a production selector (#347) reads whatever richer
+/// policy it owns and only needs these transport-visible bits here.
+pub const AuthPolicy = struct {
+    /// The verifying side requires the peer to present a valid certificate.
+    require_peer_authentication: bool = false,
+    /// An unauthenticated peer certificate is acceptable (explicit opt-in).
+    allow_unverified_peer: bool = false,
+};
+
+/// Immutable context passed to `CredentialProvider.selectCredential`. Carries
+/// enough for a future SNI selector (#347) to choose among multiple hosts and
+/// key types without the engine changing: role, the SNI the peer requested (or
+/// this side intends), the peer's offered signature schemes, the negotiated
+/// version/cipher/ALPN, and applicable local policy. Every slice is borrowed
+/// for the duration of the selection call only.
+pub const SelectionContext = struct {
+    role: Role,
+    /// Server: the SNI host_name from ClientHello, preserved as received (may
+    /// be null when the peer sent none). Client: the intended host, if any.
+    server_name: ?[]const u8,
+    /// The peer's offered SignatureScheme code points, in offer order.
+    peer_signature_schemes: []const u16,
+    negotiated_version: u16,
+    cipher_suite: u16,
+    /// The negotiated application protocol, when ALPN selected one.
+    application_protocol: ?[]const u8,
+    auth_policy: AuthPolicy,
+
+    /// True when the peer offered `scheme`.
+    pub fn offersScheme(self: SelectionContext, scheme: SignatureScheme) bool {
+        for (self.peer_signature_schemes) |offered| {
+            if (offered == scheme.code()) return true;
+        }
+        return false;
+    }
+};
+
+/// Errors a `SelectedCredential.sign` callback may report. `SignatureOutput
+/// Overflow` means the requested output buffer is too small for the scheme's
+/// signature; the provider must report it rather than write past the bound.
+pub const SignError = error{
+    SigningProviderFailure,
+    SignatureOutputOverflow,
+    InvalidCallbackBehavior,
+};
+
+/// An opaque, provider-owned handle to a selected local credential. It exposes
+/// the public certificate chain and a bounded signing capability; it never
+/// exposes private-key bytes. The engine calls `release` exactly once.
+pub const SelectedCredential = struct {
+    handle: *anyopaque,
+    /// The SignatureScheme this credential signs CertificateVerify with. The
+    /// provider guarantees it is compatible with the selection context.
+    scheme: SignatureScheme,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        /// Return the credential's public DER chain as a borrowed view valid
+        /// only until `release` (or the end of the current engine call).
+        chain: *const fn (handle: *anyopaque) CertificateChain,
+        /// Sign `input` with `scheme`, writing the signature into `out` and
+        /// returning its length. Must not write past `out`; report
+        /// `SignatureOutputOverflow` when it would not fit.
+        sign: *const fn (handle: *anyopaque, scheme: SignatureScheme, input: []const u8, out: []u8) SignError!usize,
+        /// Release the handle and any storage it produced. Called exactly once.
+        release: *const fn (handle: *anyopaque) void,
+    };
+
+    pub fn certificateChain(self: SelectedCredential) CertificateChain {
+        return self.vtable.chain(self.handle);
+    }
+
+    /// Sign through the provider, defensively enforcing the output bound: a
+    /// provider that reports writing more than `out.len` has violated the
+    /// contract and is reported as such rather than trusted.
+    pub fn sign(self: SelectedCredential, input: []const u8, out: []u8) SignError!usize {
+        const written = try self.vtable.sign(self.handle, self.scheme, input, out);
+        if (written > out.len) return error.InvalidCallbackBehavior;
+        return written;
+    }
+
+    pub fn release(self: SelectedCredential) void {
+        self.vtable.release(self.handle);
+    }
+};
+
+/// Errors `CredentialProvider.selectCredential` may report.
+pub const SelectError = error{
+    /// No credential is configured for this handshake (e.g. no cert for SNI).
+    NoCredentialAvailable,
+    /// A credential exists but none of its schemes match the peer's offers.
+    NoCompatibleSignatureAlgorithm,
+    /// The configured credential's certificate chain is malformed or empty.
+    MalformedCredentialChain,
+    /// The provider itself failed deterministically (local fault).
+    ProviderInternalFailure,
+    /// The provider returned a handle that violates the contract.
+    InvalidCallbackBehavior,
+};
+
+/// Selects a local credential for one handshake. Implementations are the fixed
+/// provider (below), test mocks, and future SNI/external-key providers.
+pub const CredentialProvider = struct {
+    ctx: *anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        select: *const fn (ctx: *anyopaque, selection: *const SelectionContext, out: *SelectedCredential) SelectError!void,
+    };
+
+    pub fn selectCredential(self: CredentialProvider, selection: *const SelectionContext, out: *SelectedCredential) SelectError!void {
+        return self.vtable.select(self.ctx, selection, out);
+    }
+};
+
+/// A peer verifier's decision about a presented certificate chain. `accepted`
+/// and `rejected` are authoritative trust decisions; `not_checked` records
+/// that the verifier deliberately did not evaluate trust (insecure opt-in).
+pub const Verdict = enum { accepted, rejected, not_checked };
+
+/// Errors `PeerVerifier.verifyPeer` may report, distinct from a `rejected`
+/// verdict: these are verifier/provider faults, not a peer-authentication
+/// failure. `InvalidPeerCertificateChain` covers a malformed or empty chain
+/// the verifier cannot even evaluate.
+pub const VerifyError = error{
+    InvalidPeerCertificateChain,
+    VerifierInternalFailure,
+    InvalidCallbackBehavior,
+};
+
+/// Immutable context passed to `PeerVerifier.verifyPeer`. `role` is the side
+/// performing verification: a client verifying the server, or (handshake-time
+/// client authentication, at the interface level) a server verifying a client.
+/// Post-handshake client authentication is explicitly deferred (#334); this
+/// contract does not model it. Every slice is borrowed for the call only.
+pub const VerificationContext = struct {
+    role: Role,
+    server_name: ?[]const u8,
+    chain: CertificateChain,
+    negotiated_version: u16,
+    cipher_suite: u16,
+    application_protocol: ?[]const u8,
+    auth_policy: AuthPolicy,
+};
+
+/// Delegated peer certificate verification. The engine supplies immutable DER
+/// views and the authentication context; the verifier applies whatever policy
+/// it owns (pinning, Web-PKI via #324, insecure passthrough) and returns a
+/// verdict. It must not retain the views past the call.
+pub const PeerVerifier = struct {
+    ctx: *anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        verify: *const fn (ctx: *anyopaque, context: *const VerificationContext) VerifyError!Verdict,
+    };
+
+    pub fn verifyPeer(self: PeerVerifier, context: *const VerificationContext) VerifyError!Verdict {
+        return self.vtable.verify(self.ctx, context);
+    }
+};
+
+// ===========================================================================
+// Typed failures and deterministic alert mapping.
+// ===========================================================================
+
+/// Whether an authentication failure originated with the peer (its credential
+/// or signature is unacceptable) or locally (this side's provider, verifier,
+/// or configuration failed). The distinction drives the alert: a peer fault is
+/// `bad_certificate`; a local fault is `internal_error`/`handshake_failure`,
+/// never blaming the peer for our own misconfiguration.
+pub const Origin = enum { peer, local };
+
+/// The complete taxonomy of credential/verification failure classes and their
+/// deterministic TLS alert mapping (RFC 8446 §6). Each class maps to exactly
+/// one alert and one origin, so a transport emits a stable, correctly-attributed
+/// fatal alert (at most once) for every way authentication can fail.
+pub const FailureClass = enum {
+    no_credential_available,
+    no_compatible_signature_algorithm,
+    malformed_credential_chain,
+    signing_provider_failure,
+    signature_output_overflow,
+    invalid_peer_certificate_chain,
+    peer_verification_rejected,
+    verifier_internal_failure,
+    invalid_callback_behavior,
+
+    pub fn origin(self: FailureClass) Origin {
+        return switch (self) {
+            .invalid_peer_certificate_chain,
+            .peer_verification_rejected,
+            => .peer,
+            .no_credential_available,
+            .no_compatible_signature_algorithm,
+            .malformed_credential_chain,
+            .signing_provider_failure,
+            .signature_output_overflow,
+            .verifier_internal_failure,
+            .invalid_callback_behavior,
+            => .local,
+        };
+    }
+
+    /// The fatal alert a peer must be sent for this failure class.
+    pub fn alert(self: FailureClass) alerts.AlertDescription {
+        return switch (self) {
+            // Local: we cannot authenticate ourselves to the peer. RFC 8446
+            // §4.4.2.2 uses handshake_failure when the server cannot produce an
+            // acceptable certificate/signature for the offered parameters.
+            .no_credential_available,
+            .no_compatible_signature_algorithm,
+            => .handshake_failure,
+            // Local provider/verifier faults are our internal errors, not the
+            // peer's fault.
+            .malformed_credential_chain,
+            .signing_provider_failure,
+            .signature_output_overflow,
+            .verifier_internal_failure,
+            .invalid_callback_behavior,
+            => .internal_error,
+            // Peer-originated authentication failure.
+            .invalid_peer_certificate_chain,
+            .peer_verification_rejected,
+            => .bad_certificate,
+        };
+    }
+
+    /// The engine-level `HandshakeError` this failure surfaces as. Peer faults
+    /// reuse `CertificateInvalid` (bad_certificate); local faults use the two
+    /// credential-specific errors so the wire alert stays correctly attributed.
+    pub fn engineError(self: FailureClass) events.HandshakeError {
+        return switch (self) {
+            .invalid_peer_certificate_chain,
+            .peer_verification_rejected,
+            => error.CertificateInvalid,
+            .no_credential_available,
+            .no_compatible_signature_algorithm,
+            => error.NoApplicableCredential,
+            .malformed_credential_chain,
+            .signing_provider_failure,
+            .signature_output_overflow,
+            .verifier_internal_failure,
+            .invalid_callback_behavior,
+            => error.CredentialProviderFailed,
+        };
+    }
+};
+
+/// Map a `SelectError` to its failure class.
+pub fn classifySelectError(err: SelectError) FailureClass {
+    return switch (err) {
+        error.NoCredentialAvailable => .no_credential_available,
+        error.NoCompatibleSignatureAlgorithm => .no_compatible_signature_algorithm,
+        error.MalformedCredentialChain => .malformed_credential_chain,
+        error.ProviderInternalFailure => .verifier_internal_failure,
+        error.InvalidCallbackBehavior => .invalid_callback_behavior,
+    };
+}
+
+/// Map a `SignError` to its failure class.
+pub fn classifySignError(err: SignError) FailureClass {
+    return switch (err) {
+        error.SigningProviderFailure => .signing_provider_failure,
+        error.SignatureOutputOverflow => .signature_output_overflow,
+        error.InvalidCallbackBehavior => .invalid_callback_behavior,
+    };
+}
+
+/// Map a `VerifyError` to its failure class.
+pub fn classifyVerifyError(err: VerifyError) FailureClass {
+    return switch (err) {
+        error.InvalidPeerCertificateChain => .invalid_peer_certificate_chain,
+        error.VerifierInternalFailure => .verifier_internal_failure,
+        error.InvalidCallbackBehavior => .invalid_callback_behavior,
+    };
+}
+
+// ===========================================================================
+// Fixed identity: the migrated hard-coded server credential, now expressed as
+// a production `CredentialProvider`.
+// ===========================================================================
+
+/// The server's certificate and signing key: Ed25519 (RFC 8410) or ECDSA
+/// P-256 (RFC 5915/5480). `initPkcs8` loads standard PKCS#8 DER as produced by
+/// `openssl genpkey -algorithm ed25519` or
+/// `openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256`. Two key
+/// types because deployed TLS stacks disagree on defaults: GnuTLS/OpenSSL
+/// accept Ed25519 out of the box while BoringSSL's default verifier
+/// (quiche/Chromium) requires ECDSA/RSA — P-256 is the interoperable floor.
+///
+/// This is the credential a `FixedCredentialProvider` serves. Private-key
+/// bytes live only inside this value and its provider; the handshake engine
+/// receives a `SelectedCredential` handle, never the key.
+pub const Identity = struct {
+    certificate_der: []const u8,
+    key: Key,
+
+    pub const Key = union(enum) {
+        ed25519: Ed25519.KeyPair,
+        ecdsa_p256: EcdsaP256.KeyPair,
+    };
+
+    pub const InitError = error{InvalidPrivateKey};
+
+    pub fn initPkcs8(certificate_der: []const u8, pkcs8_key_der: []const u8) InitError!Identity {
+        if (ed25519SeedFromPkcs8(pkcs8_key_der)) |seed| {
+            const key_pair = Ed25519.KeyPair.generateDeterministic(seed) catch return error.InvalidPrivateKey;
+            return .{ .certificate_der = certificate_der, .key = .{ .ed25519 = key_pair } };
+        } else |_| {}
+        const scalar = try ecdsaP256KeyFromPkcs8(pkcs8_key_der);
+        const secret = EcdsaP256.SecretKey.fromBytes(scalar) catch return error.InvalidPrivateKey;
+        const key_pair = EcdsaP256.KeyPair.fromSecretKey(secret) catch return error.InvalidPrivateKey;
+        return .{ .certificate_der = certificate_der, .key = .{ .ecdsa_p256 = key_pair } };
+    }
+
+    /// The TLS SignatureScheme this identity signs CertificateVerify with.
+    pub fn signatureScheme(self: *const Identity) SignatureScheme {
+        return switch (self.key) {
+            .ed25519 => .ed25519,
+            .ecdsa_p256 => .ecdsa_secp256r1_sha256,
+        };
+    }
+
+    /// Legacy accessor returning the raw SignatureScheme code point.
+    pub fn signatureAlgorithm(self: *const Identity) u16 {
+        return self.signatureScheme().code();
+    }
+
+    /// Sign `input` into `out`, returning the signature length. Bounded: never
+    /// writes past `out`; reports `SignatureOutputOverflow` when it would.
+    /// This is the single place the fixed private key is used for signing.
+    pub fn sign(self: *const Identity, input: []const u8, out: []u8) SignError!usize {
+        switch (self.key) {
+            .ed25519 => |*key_pair| {
+                if (out.len < Ed25519.Signature.encoded_length) return error.SignatureOutputOverflow;
+                const signature = key_pair.sign(input, null) catch return error.SigningProviderFailure;
+                const bytes = signature.toBytes();
+                @memcpy(out[0..bytes.len], &bytes);
+                return bytes.len;
+            },
+            .ecdsa_p256 => |*key_pair| {
+                const signature = key_pair.sign(input, null) catch return error.SigningProviderFailure;
+                var der_buf: [EcdsaP256.Signature.der_encoded_length_max]u8 = undefined;
+                const der = signature.toDer(&der_buf);
+                if (out.len < der.len) return error.SignatureOutputOverflow;
+                @memcpy(out[0..der.len], der);
+                return der.len;
+            },
+        }
+    }
+
+    /// Extract the P-256 private scalar from PKCS#8 DER (RFC 5915 inside
+    /// RFC 5958): SEQUENCE { INTEGER 0, SEQUENCE { OID id-ecPublicKey, OID
+    /// prime256v1 }, OCTET STRING { SEQUENCE { INTEGER 1, OCTET STRING(32)
+    /// privateKey, ... } } }. Bounded, no allocation.
+    fn ecdsaP256KeyFromPkcs8(der: []const u8) InitError![32]u8 {
+        const oid_ec_public_key = [_]u8{ 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01 };
+        const oid_prime256v1 = [_]u8{ 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07 };
+        var walker = DerWalker{ .bytes = der };
+        var outer = try walker.sequence();
+        // Both encodings openssl produces: PKCS#8 (RFC 5958, version 0)
+        // wrapping ECPrivateKey, or a bare SEC1/RFC 5915 ECPrivateKey
+        // (version 1) as written by `openssl pkey -outform DER`.
+        var probe = outer;
+        const version = try probe.integer();
+        if (version == 1) {
+            return ecPrivateKeyScalar(&outer);
+        }
+        try outer.expectInteger(0);
+        var alg = try outer.sequence();
+        try alg.expectBytes(&oid_ec_public_key);
+        try alg.expectBytes(&oid_prime256v1);
+        const key_octets = try outer.octetString();
+        var inner_walker = DerWalker{ .bytes = key_octets };
+        var ec_key = try inner_walker.sequence();
+        return ecPrivateKeyScalar(&ec_key);
+    }
+
+    /// RFC 5915 ECPrivateKey body: INTEGER 1, OCTET STRING privateKey, ...
+    fn ecPrivateKeyScalar(ec_key: *DerWalker) InitError![32]u8 {
+        try ec_key.expectInteger(1);
+        const scalar = try ec_key.octetString();
+        if (scalar.len != 32) return error.InvalidPrivateKey;
+        return scalar[0..32].*;
+    }
+
+    const DerWalker = struct {
+        bytes: []const u8,
+        pos: usize = 0,
+
+        fn tagged(self: *DerWalker, tag: u8) InitError![]const u8 {
+            if (self.pos + 2 > self.bytes.len) return error.InvalidPrivateKey;
+            if (self.bytes[self.pos] != tag) return error.InvalidPrivateKey;
+            var len: usize = self.bytes[self.pos + 1];
+            var header: usize = 2;
+            if (len == 0x81) {
+                if (self.pos + 3 > self.bytes.len) return error.InvalidPrivateKey;
+                len = self.bytes[self.pos + 2];
+                header = 3;
+            } else if (len == 0x82) {
+                if (self.pos + 4 > self.bytes.len) return error.InvalidPrivateKey;
+                len = (@as(usize, self.bytes[self.pos + 2]) << 8) | self.bytes[self.pos + 3];
+                header = 4;
+            } else if (len > 0x80) {
+                return error.InvalidPrivateKey;
+            }
+            if (self.pos + header + len > self.bytes.len) return error.InvalidPrivateKey;
+            const content = self.bytes[self.pos + header ..][0..len];
+            self.pos += header + len;
+            return content;
+        }
+
+        fn sequence(self: *DerWalker) InitError!DerWalker {
+            return .{ .bytes = try self.tagged(0x30) };
+        }
+
+        fn octetString(self: *DerWalker) InitError![]const u8 {
+            return self.tagged(0x04);
+        }
+
+        fn integer(self: *DerWalker) InitError!u8 {
+            const content = try self.tagged(0x02);
+            if (content.len != 1) return error.InvalidPrivateKey;
+            return content[0];
+        }
+
+        fn expectInteger(self: *DerWalker, value: u8) InitError!void {
+            if (try self.integer() != value) return error.InvalidPrivateKey;
+        }
+
+        fn expectBytes(self: *DerWalker, expected: []const u8) InitError!void {
+            if (self.pos + expected.len > self.bytes.len) return error.InvalidPrivateKey;
+            if (!std.mem.eql(u8, self.bytes[self.pos..][0..expected.len], expected)) return error.InvalidPrivateKey;
+            self.pos += expected.len;
+        }
+    };
+
+    /// Extract the 32-byte Ed25519 seed from a PKCS#8 `OneAsymmetricKey` DER
+    /// (RFC 8410 §7): SEQUENCE { version 0, AlgorithmIdentifier id-Ed25519,
+    /// privateKey OCTET STRING { OCTET STRING(32) } }.
+    fn ed25519SeedFromPkcs8(der: []const u8) InitError![Ed25519.KeyPair.seed_length]u8 {
+        const prefix = [_]u8{
+            0x30, 0x2e, // SEQUENCE, 46 bytes
+            0x02, 0x01, 0x00, // INTEGER version 0
+            0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, // AlgorithmIdentifier { 1.3.101.112 }
+            0x04, 0x22, 0x04, 0x20, // OCTET STRING { OCTET STRING (32 bytes) }
+        };
+        if (der.len != prefix.len + Ed25519.KeyPair.seed_length) return error.InvalidPrivateKey;
+        if (!std.mem.eql(u8, der[0..prefix.len], &prefix)) return error.InvalidPrivateKey;
+        return der[prefix.len..][0..Ed25519.KeyPair.seed_length].*;
+    }
+};
+
+/// A `CredentialProvider` backed by a single fixed `Identity`. This is the
+/// migration target for the previously hard-coded server credential: the fixed
+/// server path and any future SNI/external-key provider serve credentials
+/// through the *same* contract, so there is only one authentication path.
+///
+/// Stored by value so the engine can embed it; obtain the vtable via
+/// `provider()` from a stable pointer at point of use. The single held DER
+/// chain slice `self.chain_entry` is what `SelectedCredential.chain` returns.
+pub const FixedCredentialProvider = struct {
+    identity: Identity,
+    chain_entry: [1][]const u8,
+
+    pub fn init(identity: Identity) FixedCredentialProvider {
+        return .{ .identity = identity, .chain_entry = .{identity.certificate_der} };
+    }
+
+    pub fn provider(self: *FixedCredentialProvider) CredentialProvider {
+        return .{ .ctx = self, .vtable = &vtable };
+    }
+
+    /// Securely clear the private key material.
+    pub fn deinit(self: *FixedCredentialProvider) void {
+        crypto.secureZero(u8, std.mem.asBytes(&self.identity.key));
+    }
+
+    const vtable = CredentialProvider.VTable{ .select = select };
+
+    fn select(ctx: *anyopaque, selection: *const SelectionContext, out: *SelectedCredential) SelectError!void {
+        const self: *FixedCredentialProvider = @ptrCast(@alignCast(ctx));
+        if (self.identity.certificate_der.len == 0) return error.MalformedCredentialChain;
+        const scheme = self.identity.signatureScheme();
+        // Honor the peer's advertised signature algorithms: a fixed credential
+        // whose one scheme the peer did not offer is not usable here (#347's
+        // richer selection would try alternate credentials; a fixed provider
+        // has only this one).
+        if (!selection.offersScheme(scheme)) return error.NoCompatibleSignatureAlgorithm;
+        out.* = .{ .handle = self, .scheme = scheme, .vtable = &credential_vtable };
+    }
+
+    const credential_vtable = SelectedCredential.VTable{
+        .chain = credentialChain,
+        .sign = credentialSign,
+        .release = credentialRelease,
+    };
+
+    fn credentialChain(handle: *anyopaque) CertificateChain {
+        const self: *FixedCredentialProvider = @ptrCast(@alignCast(handle));
+        return .{ .entries = self.chain_entry[0..] };
+    }
+
+    fn credentialSign(handle: *anyopaque, scheme: SignatureScheme, input: []const u8, out: []u8) SignError!usize {
+        const self: *FixedCredentialProvider = @ptrCast(@alignCast(handle));
+        // The engine signs with the scheme the credential reported; a mismatch
+        // would be an engine bug, guarded here defensively.
+        if (scheme != self.identity.signatureScheme()) return error.InvalidCallbackBehavior;
+        return self.identity.sign(input, out);
+    }
+
+    fn credentialRelease(handle: *anyopaque) void {
+        // The fixed credential owns no per-selection scratch; releasing is a
+        // no-op beyond marking the (engine-owned) handle done. Key material is
+        // wiped by `deinit`, tied to the provider's own lifetime.
+        _ = handle;
+    }
+};
+
+/// How a client decides a server certificate's validity (or a server a
+/// client's, at the interface level). Web-PKI chain building is delegated to a
+/// #324 verifier; these deterministic modes cover local handshakes, tests, and
+/// deployment pinning, and are served through the same `PeerVerifier` contract.
+pub const Trust = union(enum) {
+    /// The presented leaf must byte-equal this DER certificate.
+    pinned_certificate: []const u8,
+    /// Report `not_checked`; the driver completes only when it explicitly opts
+    /// into an unverified peer.
+    insecure_no_verification,
+};
+
+/// A `PeerVerifier` backed by a fixed `Trust` policy — the migration target
+/// for the previously inline pin/insecure verification. Stored by value;
+/// obtain the vtable via `verifier()` from a stable pointer at point of use.
+pub const FixedVerifier = struct {
+    trust: Trust,
+
+    pub fn init(trust: Trust) FixedVerifier {
+        return .{ .trust = trust };
+    }
+
+    pub fn verifier(self: *FixedVerifier) PeerVerifier {
+        return .{ .ctx = self, .vtable = &vtable };
+    }
+
+    const vtable = PeerVerifier.VTable{ .verify = verify };
+
+    fn verify(ctx: *anyopaque, context: *const VerificationContext) VerifyError!Verdict {
+        const self: *FixedVerifier = @ptrCast(@alignCast(ctx));
+        const leaf = context.chain.leaf() orelse return error.InvalidPeerCertificateChain;
+        return switch (self.trust) {
+            .pinned_certificate => |pin| if (std.mem.eql(u8, leaf, pin)) .accepted else .rejected,
+            .insecure_no_verification => .not_checked,
+        };
+    }
+};
+
+// ===========================================================================
+// Deterministic test fixtures.
+// ===========================================================================
+
+/// Deterministic local server identity (self-signed Ed25519,
+/// CN=tardigrade.test, valid to 2036; generated with openssl, see
+/// src/quic/testdata/). For unit tests and local smoke harnesses only — never
+/// a production identity.
+pub const testdata = struct {
+    const certificate_bytes = hexBytes(
+        "308201483081fba00302010202146c8bf2251dd4fceda024f44e82cbfaeaa9da082a300506032b6570031a3118301606035504030c0f746172646967726164652e74657374301e170d3236303731303033303535325a170d3336303730373033303535325a301a3118301606035504030c0f746172646967726164652e74657374302a300506032b65700321007487dbf1f35e41d63ee2c907330660439af5fa63ca7f70a9f1484c12f8d4666fa3533051301d0603551d0e0416041494fd70298293687f12c2f46d00fba451fd3c6143301f0603551d2304183016801494fd70298293687f12c2f46d00fba451fd3c6143300f0603551d130101ff040530030101ff300506032b657003410070eb127814436ca43322b688fd6643507d5c2346f7c176a155ddf5350db941acccefceb29f0ea66e9842159f2fece42b67d935b255f2a4224df68182b646e201",
+    );
+    const private_key_bytes = hexBytes(
+        "302e020100300506032b65700422042099132d0957fdbc8235285b25bd8dd5101d7941408adb068ded6de7ada191251f",
+    );
+
+    pub const certificate_der: []const u8 = &certificate_bytes;
+    pub const private_key_pkcs8_der: []const u8 = &private_key_bytes;
+
+    pub fn identity() Identity {
+        return Identity.initPkcs8(certificate_der, private_key_pkcs8_der) catch unreachable;
+    }
+};
+
+fn hexBytes(comptime hex: []const u8) [hex.len / 2]u8 {
+    var bytes: [hex.len / 2]u8 = undefined;
+    _ = std.fmt.hexToBytes(&bytes, hex) catch unreachable;
+    return bytes;
+}
+
+// ===========================================================================
+// Reusable test mocks: a scriptable provider and verifier that count
+// invocations and assert exact lifetime transitions.
+// ===========================================================================
+
+/// A `CredentialProvider` whose behavior is scripted and whose selection,
+/// signing, and release invocations are counted. Used to prove selection
+/// context, sigalg filtering, signing/overflow contracts, and exactly-once
+/// handle teardown without a real key. Stored by value; obtain the vtable via
+/// `provider()`.
+pub const MockCredentialProvider = struct {
+    identity: Identity,
+    chain_entry: [1][]const u8,
+    /// Force selection to fail with this class, ignoring the sigalg check.
+    force_select_error: ?SelectError = null,
+    /// Report this many bytes written on sign, regardless of the real length,
+    /// to model a provider that overflows the caller's bound.
+    force_sign_len: ?usize = null,
+    force_sign_error: ?SignError = null,
+    /// Return an empty certificate chain from selection, to model a malformed
+    /// local credential the engine must reject before signing.
+    empty_chain: bool = false,
+    /// Sign normally, then flip a signature byte, to model a peer whose
+    /// CertificateVerify does not check out (proof-of-possession failure).
+    flip_signature: bool = false,
+
+    select_count: usize = 0,
+    sign_count: usize = 0,
+    release_count: usize = 0,
+    last_server_name: ?[]const u8 = null,
+    last_offered_scheme_count: usize = 0,
+
+    pub fn init(identity: Identity) MockCredentialProvider {
+        return .{ .identity = identity, .chain_entry = .{identity.certificate_der} };
+    }
+
+    pub fn provider(self: *MockCredentialProvider) CredentialProvider {
+        return .{ .ctx = self, .vtable = &vtable };
+    }
+
+    const vtable = CredentialProvider.VTable{ .select = select };
+
+    fn select(ctx: *anyopaque, selection: *const SelectionContext, out: *SelectedCredential) SelectError!void {
+        const self: *MockCredentialProvider = @ptrCast(@alignCast(ctx));
+        self.select_count += 1;
+        self.last_server_name = selection.server_name;
+        self.last_offered_scheme_count = selection.peer_signature_schemes.len;
+        if (self.force_select_error) |err| return err;
+        const scheme = self.identity.signatureScheme();
+        if (!selection.offersScheme(scheme)) return error.NoCompatibleSignatureAlgorithm;
+        out.* = .{ .handle = self, .scheme = scheme, .vtable = &credential_vtable };
+    }
+
+    const credential_vtable = SelectedCredential.VTable{
+        .chain = credentialChain,
+        .sign = credentialSign,
+        .release = credentialRelease,
+    };
+
+    fn credentialChain(handle: *anyopaque) CertificateChain {
+        const self: *MockCredentialProvider = @ptrCast(@alignCast(handle));
+        return .{ .entries = if (self.empty_chain) self.chain_entry[0..0] else self.chain_entry[0..] };
+    }
+
+    fn credentialSign(handle: *anyopaque, scheme: SignatureScheme, input: []const u8, out: []u8) SignError!usize {
+        const self: *MockCredentialProvider = @ptrCast(@alignCast(handle));
+        self.sign_count += 1;
+        if (self.force_sign_error) |err| return err;
+        if (self.force_sign_len) |forced| return forced; // may exceed out.len on purpose
+        _ = scheme;
+        const written = try self.identity.sign(input, out);
+        if (self.flip_signature and written > 0) out[0] ^= 0xff;
+        return written;
+    }
+
+    fn credentialRelease(handle: *anyopaque) void {
+        const self: *MockCredentialProvider = @ptrCast(@alignCast(handle));
+        self.release_count += 1;
+    }
+};
+
+/// A `PeerVerifier` returning a scripted verdict or error, counting calls and
+/// recording the last chain length it saw.
+pub const MockVerifier = struct {
+    result: VerifyError!Verdict,
+    verify_count: usize = 0,
+    last_chain_len: usize = 0,
+    last_role: ?Role = null,
+
+    pub fn init(result: VerifyError!Verdict) MockVerifier {
+        return .{ .result = result };
+    }
+
+    pub fn verifier(self: *MockVerifier) PeerVerifier {
+        return .{ .ctx = self, .vtable = &vtable };
+    }
+
+    const vtable = PeerVerifier.VTable{ .verify = verify };
+
+    fn verify(ctx: *anyopaque, context: *const VerificationContext) VerifyError!Verdict {
+        const self: *MockVerifier = @ptrCast(@alignCast(ctx));
+        self.verify_count += 1;
+        self.last_chain_len = context.chain.count();
+        self.last_role = context.role;
+        return self.result;
+    }
+};
+
+// ===========================================================================
+// Contract-level tests. Real-handshake integration lives in
+// tls13_backend_tests.zig; these pin the contract's own guarantees.
+// ===========================================================================
+
+const testing = std.testing;
+
+fn testSelection(schemes: []const u16) SelectionContext {
+    return .{
+        .role = .server,
+        .server_name = "tardigrade.test",
+        .peer_signature_schemes = schemes,
+        .negotiated_version = 0x0304,
+        .cipher_suite = 0x1301,
+        .application_protocol = "h2",
+        .auth_policy = .{},
+    };
+}
+
+test "fixed provider selects and exposes its public chain without private-key bytes" {
+    var fixed = FixedCredentialProvider.init(testdata.identity());
+    defer fixed.deinit();
+    const provider = fixed.provider();
+
+    const selection = testSelection(&.{ 0x0807, 0x0403 });
+    var credential: SelectedCredential = undefined;
+    try provider.selectCredential(&selection, &credential);
+    try testing.expectEqual(SignatureScheme.ed25519, credential.scheme);
+
+    const chain = credential.certificateChain();
+    try testing.expectEqual(@as(usize, 1), chain.count());
+    try testing.expectEqualSlices(u8, testdata.certificate_der, chain.leaf().?);
+    credential.release();
+}
+
+test "fixed provider signs a bounded output the certificate can verify" {
+    var fixed = FixedCredentialProvider.init(testdata.identity());
+    defer fixed.deinit();
+    const provider = fixed.provider();
+    const selection = testSelection(&.{0x0807});
+    var credential: SelectedCredential = undefined;
+    try provider.selectCredential(&selection, &credential);
+    defer credential.release();
+
+    const message = "TLS 1.3 CertificateVerify transcript-derived signing input";
+    var sig_buf: [128]u8 = undefined;
+    const written = try credential.sign(message, &sig_buf);
+    try testing.expectEqual(Ed25519.Signature.encoded_length, written);
+
+    // The signature verifies against the certificate's Ed25519 public key.
+    const parsed = try (crypto.Certificate{ .buffer = testdata.certificate_der, .index = 0 }).parse();
+    const public_key = try Ed25519.PublicKey.fromBytes(parsed.pubKey()[0..Ed25519.PublicKey.encoded_length].*);
+    const sig = Ed25519.Signature.fromBytes(sig_buf[0..Ed25519.Signature.encoded_length].*);
+    try sig.verify(message, public_key);
+}
+
+test "fixed provider rejects an output buffer too small for the signature" {
+    var fixed = FixedCredentialProvider.init(testdata.identity());
+    defer fixed.deinit();
+    const provider = fixed.provider();
+    const selection = testSelection(&.{0x0807});
+    var credential: SelectedCredential = undefined;
+    try provider.selectCredential(&selection, &credential);
+    defer credential.release();
+
+    var tiny: [16]u8 = undefined;
+    try testing.expectError(error.SignatureOutputOverflow, credential.sign("input", &tiny));
+}
+
+test "fixed provider filters on the peer's offered signature algorithms" {
+    var fixed = FixedCredentialProvider.init(testdata.identity()); // Ed25519 identity
+    defer fixed.deinit();
+    const provider = fixed.provider();
+
+    // Peer offers only ECDSA P-256; the Ed25519 credential is not compatible.
+    const ecdsa_only = testSelection(&.{0x0403});
+    var credential: SelectedCredential = undefined;
+    try testing.expectError(error.NoCompatibleSignatureAlgorithm, provider.selectCredential(&ecdsa_only, &credential));
+
+    // With no schemes offered at all, still no compatible scheme.
+    const none = testSelection(&.{});
+    try testing.expectError(error.NoCompatibleSignatureAlgorithm, provider.selectCredential(&none, &credential));
+}
+
+test "selection context preserves the exact SNI and absent SNI deterministically" {
+    var present = testSelection(&.{0x0807});
+    present.server_name = "exact.example.test";
+    try testing.expectEqualStrings("exact.example.test", present.server_name.?);
+
+    var absent = testSelection(&.{0x0807});
+    absent.server_name = null;
+    try testing.expect(absent.server_name == null);
+}
+
+test "mock provider selects the compatible preferred scheme among several offers" {
+    var mock = MockCredentialProvider.init(testdata.identity()); // Ed25519
+    const provider = mock.provider();
+    // Peer offers ECDSA first, then Ed25519; the Ed25519 credential still binds.
+    const selection = testSelection(&.{ 0x0403, 0x0807 });
+    var credential: SelectedCredential = undefined;
+    try provider.selectCredential(&selection, &credential);
+    try testing.expectEqual(SignatureScheme.ed25519, credential.scheme);
+    try testing.expectEqual(@as(usize, 1), mock.select_count);
+    try testing.expectEqual(@as(usize, 2), mock.last_offered_scheme_count);
+    credential.release();
+    try testing.expectEqual(@as(usize, 1), mock.release_count);
+}
+
+test "SelectedCredential.sign catches a provider that overreports its length" {
+    var mock = MockCredentialProvider.init(testdata.identity());
+    mock.force_sign_len = 999; // claim a write far past the buffer
+    const provider = mock.provider();
+    const selection = testSelection(&.{0x0807});
+    var credential: SelectedCredential = undefined;
+    try provider.selectCredential(&selection, &credential);
+    defer credential.release();
+
+    var out: [128]u8 = undefined;
+    try testing.expectError(error.InvalidCallbackBehavior, credential.sign("input", &out));
+}
+
+test "mock provider reports a scripted signing failure" {
+    var mock = MockCredentialProvider.init(testdata.identity());
+    mock.force_sign_error = error.SigningProviderFailure;
+    const provider = mock.provider();
+    const selection = testSelection(&.{0x0807});
+    var credential: SelectedCredential = undefined;
+    try provider.selectCredential(&selection, &credential);
+    defer credential.release();
+    var out: [128]u8 = undefined;
+    try testing.expectError(error.SigningProviderFailure, credential.sign("input", &out));
+}
+
+test "fixed verifier accepts a matching pin and rejects a mismatch" {
+    const chain_entries = [_][]const u8{testdata.certificate_der};
+    const context = VerificationContext{
+        .role = .client,
+        .server_name = "tardigrade.test",
+        .chain = .{ .entries = chain_entries[0..] },
+        .negotiated_version = 0x0304,
+        .cipher_suite = 0x1301,
+        .application_protocol = "h2",
+        .auth_policy = .{ .require_peer_authentication = true },
+    };
+
+    var pinned = FixedVerifier.init(.{ .pinned_certificate = testdata.certificate_der });
+    try testing.expectEqual(Verdict.accepted, try pinned.verifier().verifyPeer(&context));
+
+    var wrong = [_]u8{0} ** 4;
+    var mismatched = FixedVerifier.init(.{ .pinned_certificate = &wrong });
+    try testing.expectEqual(Verdict.rejected, try mismatched.verifier().verifyPeer(&context));
+
+    var insecure = FixedVerifier.init(.insecure_no_verification);
+    try testing.expectEqual(Verdict.not_checked, try insecure.verifier().verifyPeer(&context));
+}
+
+test "fixed verifier reports an empty chain as an invalid peer chain" {
+    const empty = [_][]const u8{};
+    const context = VerificationContext{
+        .role = .client,
+        .server_name = null,
+        .chain = .{ .entries = empty[0..] },
+        .negotiated_version = 0x0304,
+        .cipher_suite = 0x1301,
+        .application_protocol = null,
+        .auth_policy = .{},
+    };
+    var pinned = FixedVerifier.init(.{ .pinned_certificate = testdata.certificate_der });
+    try testing.expectError(error.InvalidPeerCertificateChain, pinned.verifier().verifyPeer(&context));
+}
+
+test "mock verifier can reject, error, and report a scripted verdict with call counts" {
+    const chain_entries = [_][]const u8{testdata.certificate_der};
+    const context = VerificationContext{
+        .role = .client,
+        .server_name = null,
+        .chain = .{ .entries = chain_entries[0..] },
+        .negotiated_version = 0x0304,
+        .cipher_suite = 0x1301,
+        .application_protocol = null,
+        .auth_policy = .{},
+    };
+
+    var rejecting = MockVerifier.init(.rejected);
+    try testing.expectEqual(Verdict.rejected, try rejecting.verifier().verifyPeer(&context));
+    try testing.expectEqual(@as(usize, 1), rejecting.verify_count);
+    try testing.expectEqual(@as(usize, 1), rejecting.last_chain_len);
+    try testing.expectEqual(Role.client, rejecting.last_role.?);
+
+    var failing = MockVerifier.init(error.VerifierInternalFailure);
+    try testing.expectError(error.VerifierInternalFailure, failing.verifier().verifyPeer(&context));
+}
+
+test "every failure class maps to a deterministic alert, origin, and engine error" {
+    // Peer-originated authentication failures blame the peer's certificate.
+    for ([_]FailureClass{ .invalid_peer_certificate_chain, .peer_verification_rejected }) |class| {
+        try testing.expectEqual(Origin.peer, class.origin());
+        try testing.expectEqual(alerts.AlertDescription.bad_certificate, class.alert());
+        try testing.expectEqual(@as(events.HandshakeError, error.CertificateInvalid), class.engineError());
+    }
+    // Local "cannot authenticate ourselves" failures use handshake_failure.
+    for ([_]FailureClass{ .no_credential_available, .no_compatible_signature_algorithm }) |class| {
+        try testing.expectEqual(Origin.local, class.origin());
+        try testing.expectEqual(alerts.AlertDescription.handshake_failure, class.alert());
+        try testing.expectEqual(@as(events.HandshakeError, error.NoApplicableCredential), class.engineError());
+    }
+    // Local provider/verifier faults are our internal errors.
+    for ([_]FailureClass{
+        .malformed_credential_chain,
+        .signing_provider_failure,
+        .signature_output_overflow,
+        .verifier_internal_failure,
+        .invalid_callback_behavior,
+    }) |class| {
+        try testing.expectEqual(Origin.local, class.origin());
+        try testing.expectEqual(alerts.AlertDescription.internal_error, class.alert());
+        try testing.expectEqual(@as(events.HandshakeError, error.CredentialProviderFailed), class.engineError());
+    }
+}
+
+test "error classifiers cover every select, sign, and verify error" {
+    try testing.expectEqual(FailureClass.no_credential_available, classifySelectError(error.NoCredentialAvailable));
+    try testing.expectEqual(FailureClass.no_compatible_signature_algorithm, classifySelectError(error.NoCompatibleSignatureAlgorithm));
+    try testing.expectEqual(FailureClass.malformed_credential_chain, classifySelectError(error.MalformedCredentialChain));
+    try testing.expectEqual(FailureClass.verifier_internal_failure, classifySelectError(error.ProviderInternalFailure));
+    try testing.expectEqual(FailureClass.invalid_callback_behavior, classifySelectError(error.InvalidCallbackBehavior));
+
+    try testing.expectEqual(FailureClass.signing_provider_failure, classifySignError(error.SigningProviderFailure));
+    try testing.expectEqual(FailureClass.signature_output_overflow, classifySignError(error.SignatureOutputOverflow));
+    try testing.expectEqual(FailureClass.invalid_callback_behavior, classifySignError(error.InvalidCallbackBehavior));
+
+    try testing.expectEqual(FailureClass.invalid_peer_certificate_chain, classifyVerifyError(error.InvalidPeerCertificateChain));
+    try testing.expectEqual(FailureClass.verifier_internal_failure, classifyVerifyError(error.VerifierInternalFailure));
+    try testing.expectEqual(FailureClass.invalid_callback_behavior, classifyVerifyError(error.InvalidCallbackBehavior));
+}
+
+test "fixed provider teardown zeroes the private key exactly once" {
+    var fixed = FixedCredentialProvider.init(testdata.identity());
+    fixed.deinit();
+    try testing.expect(std.mem.allEqual(u8, std.mem.asBytes(&fixed.identity.key), 0));
+}
+
+test "identity parser loads and rejects malformed PKCS#8" {
+    const identity = try Identity.initPkcs8(testdata.certificate_der, testdata.private_key_pkcs8_der);
+    const parsed = try (crypto.Certificate{ .buffer = testdata.certificate_der, .index = 0 }).parse();
+    try testing.expect(parsed.pub_key_algo == .curveEd25519);
+    try testing.expectEqualSlices(u8, parsed.pubKey(), &identity.key.ed25519.public_key.toBytes());
+    try testing.expectError(
+        error.InvalidPrivateKey,
+        Identity.initPkcs8(testdata.certificate_der, testdata.private_key_pkcs8_der[0 .. testdata.private_key_pkcs8_der.len - 1]),
+    );
+}

--- a/src/tls/credentials.zig
+++ b/src/tls/credentials.zig
@@ -827,6 +827,9 @@ pub const MockCredentialProvider = struct {
     /// scheme regardless, to model a provider that hands back an algorithm the
     /// peer never advertised.
     ignore_offer: bool = false,
+    /// Test-only scheme override for modelling a provider that advertises an
+    /// algorithm inconsistent with the certificate's public key.
+    scheme_override: ?SignatureScheme = null,
     /// Sign normally, then flip a signature byte, to model a peer whose
     /// CertificateVerify does not check out (proof-of-possession failure).
     flip_signature: bool = false,
@@ -888,7 +891,11 @@ pub const MockCredentialProvider = struct {
     }
 
     pub fn selectedCredential(self: *MockCredentialProvider) SelectedCredential {
-        return .{ .handle = self, .scheme = self.identity.signatureScheme(), .vtable = &credential_vtable };
+        return .{ .handle = self, .scheme = self.selectedScheme(), .vtable = &credential_vtable };
+    }
+
+    fn selectedScheme(self: *const MockCredentialProvider) SignatureScheme {
+        return self.scheme_override orelse self.identity.signatureScheme();
     }
 
     const vtable = CredentialProvider.VTable{ .select = select };
@@ -908,7 +915,7 @@ pub const MockCredentialProvider = struct {
         }
         self.last_offered_scheme_count = selection.peer_signature_schemes.len;
         if (self.force_select_error) |err| return err;
-        const scheme = self.identity.signatureScheme();
+        const scheme = self.selectedScheme();
         if (!self.ignore_offer and !selection.offersScheme(scheme)) return error.NoCompatibleSignatureAlgorithm;
         if (self.async_select) {
             self.pending_kind = .select;

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -982,16 +982,27 @@ pub const PureZigRecordStream = struct {
         return emitted;
     }
 
-    /// Handshake secrets advance the explicit record epoch one step. Application
-    /// secrets do NOT advance the epoch here: the peer may still be sending
-    /// handshake-epoch records (its Finished) after this side installs its
-    /// application read secret. The `.application` transition happens only at
-    /// authenticated `handshake_complete`.
+    /// Handshake secrets advance the explicit record epoch one step. TLS 1.3
+    /// then advances each application direction when that side has installed
+    /// the corresponding traffic secret, not only when the whole handshake is
+    /// complete: after a server sends Finished it must seal client-auth alerts
+    /// with application write keys, while it still reads the client's Finished
+    /// under handshake keys.
     fn advanceEpochOnSecret(self: *PureZigRecordStream, epoch: events.EncryptionEpoch, direction: events.SecretDirection) void {
-        if (epoch != .handshake) return;
-        switch (direction) {
-            .read => self.read_epoch = .handshake,
-            .write => self.write_epoch = .handshake,
+        switch (epoch) {
+            .handshake => switch (direction) {
+                .read => self.read_epoch = epoch,
+                .write => self.write_epoch = epoch,
+            },
+            .application => switch (direction) {
+                .read => {
+                    if (self.role == .client) self.read_epoch = .application;
+                },
+                .write => {
+                    if (self.role == .server) self.write_epoch = .application;
+                },
+            },
+            .initial, .zero_rtt => {},
         }
     }
 
@@ -1032,6 +1043,8 @@ pub const PureZigRecordStream = struct {
             error.CredentialProviderFailed,
             error.ClientCertificateRequired,
             error.DecryptError,
+            error.MissingExtension,
+            error.UnsupportedCertificate,
             => alerts.fromHandshakeError(@errorCast(err)),
             else => null,
         };
@@ -1293,10 +1306,12 @@ pub const PureZigRecordStream = struct {
             }
 
             var record_budget_remaining: usize = drive_record_budget;
-            if (try self.processCarrierInputBudget(&record_budget_remaining)) made_progress = true;
+            if (!self.authStillPending()) {
+                if (try self.processCarrierInputBudget(&record_budget_remaining)) made_progress = true;
+            }
 
             var read_total: usize = 0;
-            while (!self.carrier_eof and read_total < drive_read_budget and self.canAcceptCarrierRead() and self.inbound_carrier.available() > 0) {
+            while (!self.authStillPending() and !self.carrier_eof and read_total < drive_read_budget and self.canAcceptCarrierRead() and self.inbound_carrier.available() > 0) {
                 var buf: [drive_read_chunk]u8 = undefined;
                 const read_room = self.inboundCiphertextReadRoom() catch |err| return self.fail(err);
                 const read_cap = @min(buf.len, @min(self.inbound_carrier.available(), @min(drive_read_budget - read_total, read_room)));
@@ -1327,7 +1342,7 @@ pub const PureZigRecordStream = struct {
                     break;
                 }
             }
-            if (self.carrier_eof) {
+            if (!self.authStillPending() and self.carrier_eof) {
                 if (try self.handleCarrierEof(&record_budget_remaining)) made_progress = true;
             }
         } else if (self.lifecycle == .closing) {
@@ -1337,7 +1352,7 @@ pub const PureZigRecordStream = struct {
                 self.lifecycle = .closed;
                 made_progress = true;
             }
-        } else {
+        } else if (!self.authStillPending()) {
             if (try self.processCarrierInput(drive_record_budget)) made_progress = true;
         }
 
@@ -1450,6 +1465,11 @@ pub const PureZigRecordStream = struct {
         return consumed;
     }
 
+    fn authStillPending(self: *const PureZigRecordStream) bool {
+        if (self.handshake_driver) |*driver| return driver.authPending();
+        return false;
+    }
+
     /// Best-effort nonblocking flush of a queued fatal alert to the carrier
     /// before the stream latches closed. Returns bytes written.
     fn flushPendingAlert(self: *PureZigRecordStream) usize {
@@ -1498,7 +1518,7 @@ pub const PureZigRecordStream = struct {
 
     fn processCarrierInputBudget(self: *PureZigRecordStream, record_budget_remaining: *usize) Error!bool {
         const initial_budget = record_budget_remaining.*;
-        while (record_budget_remaining.* > 0 and self.inbound_carrier.len > 0 and self.canProcessCarrierInput()) {
+        while (!self.authStillPending() and record_budget_remaining.* > 0 and self.inbound_carrier.len > 0 and self.canProcessCarrierInput()) {
             const pending = self.inbound_carrier.slice();
             const consumed = self.feedCarrierCiphertext(pending) catch |err| switch (err) {
                 error.WouldBlock => break,

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -1030,6 +1030,8 @@ pub const PureZigRecordStream = struct {
             error.InvalidHandshakeState,
             error.NoApplicableCredential,
             error.CredentialProviderFailed,
+            error.ClientCertificateRequired,
+            error.DecryptError,
             => alerts.fromHandshakeError(@errorCast(err)),
             else => null,
         };

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -1013,6 +1013,8 @@ pub const PureZigRecordStream = struct {
             error.AlpnMismatch,
             error.SecretExportFailed,
             error.InvalidHandshakeState,
+            error.NoApplicableCredential,
+            error.CredentialProviderFailed,
             => alerts.fromHandshakeError(@errorCast(err)),
             else => null,
         };

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -852,15 +852,17 @@ pub const PureZigRecordStream = struct {
     /// whatever the backend emits — the client's certificate flight, the
     /// server's, or a peer-verification verdict. A no-op unless the backend has
     /// suspended; requires output headroom so an emitted flight serializes
-    /// atomically. Returns true if it polled (progress toward resolution).
+    /// atomically. Returns true only for observable progress: terminal failure,
+    /// emitted events, or a pending operation resolving.
     fn resumeAuthIfPending(self: *PureZigRecordStream) Error!bool {
         if (!self.driverPresent()) return false;
         const driver = &self.handshake_driver.?;
         if (!driver.authPending()) return false;
-        if (self.outbound_ciphertext.available() < handshake_output_reserve) return false;
+        if (!self.canReserveHandshakeOutputBatch()) return false;
         const outcome = driver.resumeAuthOutcome();
+        const emitted_or_failed = outcome.sink.len != 0 or outcome.terminal_error != null;
         try self.applyDriverOutcome(outcome);
-        return true;
+        return emitted_or_failed or !driver.authPending();
     }
 
     /// Apply one borrowed driver event batch. Every payload slice is consumed,
@@ -1216,8 +1218,9 @@ pub const PureZigRecordStream = struct {
             return .{ .wants_write = self.outbound_ciphertext.len != 0, .peer_closed = self.peer_closed };
         }
         const pending_terminal_read_ready = self.pending_terminal_read_error != null and !self.hasBufferedInboundContent();
+        const auth_pending = self.authStillPending();
         return .{
-            .wants_read = !self.carrier_eof and self.canAcceptCarrierRead(),
+            .wants_read = !auth_pending and !self.carrier_eof and self.canAcceptCarrierRead(),
             .wants_write = self.outbound_ciphertext.len > 0 or (self.lifecycle == .closing and !self.close_notify_queued),
             .can_read_plaintext = self.inbound_plaintext.len > 0 or pending_terminal_read_ready,
             .can_write_plaintext = self.pending_terminal_read_error == null and self.lifecycle == .open and self.bridge.handshake_complete and !self.write_backpressured and self.canReserveOutboundRecord(),
@@ -3475,6 +3478,31 @@ test "encrypted stream reports would-block and stable readiness without busy-loo
     try testing.expectEqual(before, drive.readiness);
 }
 
+test "pending authentication empty poll suppresses read readiness and makes no progress" {
+    const cp = testProvider();
+    var duplex = Duplex{ .max_chunk = record_codec.max_ciphertext_record_len };
+    try duplex.s2c.append("peer bytes waiting");
+    var backend = ScriptedRecordBackend{ .role = .client, .auth_pending = true, .auth_pending_polls = 10 };
+    var stream_state = PureZigRecordStream.initWithCarrierAndBackend(.client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), backend.recordBackend());
+    defer stream_state.deinit();
+    stream_state.handshake_started = true;
+    const stream = stream_state.stream();
+
+    const before = stream.readiness();
+    try testing.expect(!before.wants_read);
+    try testing.expect(!before.wants_write);
+
+    const driven = try stream.drive();
+    try testing.expect(!driven.made_progress);
+    try testing.expect(!driven.readiness.wants_read);
+    try testing.expectEqual(@as(usize, 1), backend.auth_poll_count);
+    try testing.expectEqual(@as(usize, "peer bytes waiting".len), duplex.s2c.len);
+
+    backend.auth_pending = false;
+    const ready = stream.readiness();
+    try testing.expect(ready.wants_read);
+}
+
 test "pure-Zig encrypted stream satisfies shared open-idle conformance" {
     const cp = testProvider();
     var client = PureZigRecordStream.init(.client, cp, .tls_aes_128_gcm_sha256);
@@ -3763,6 +3791,9 @@ const ScriptedRecordBackend = struct {
     selected_alpn: ?[]const u8 = "h1",
     emit_certificate: bool = true,
     received_client_finished: bool = false,
+    auth_pending: bool = false,
+    auth_pending_polls: usize = 0,
+    auth_poll_count: usize = 0,
 
     const hs_c2s = secret(0x11);
     const hs_s2c = secret(0x22);
@@ -3770,7 +3801,7 @@ const ScriptedRecordBackend = struct {
     const app_s2c = secret(0x44);
 
     fn recordBackend(self: *ScriptedRecordBackend) RecordHandshakeBackend {
-        return .{ .ptr = self, .startFn = start, .receiveFn = receive };
+        return .{ .ptr = self, .startFn = start, .receiveFn = receive, .authPendingFn = authPending, .resumeFn = resumeAuth };
     }
 
     fn start(ptr: *anyopaque, role: tls_state.Role, _: void, sink: *RecordTransport.EventSink) RecordHandshakeError!void {
@@ -3825,6 +3856,22 @@ const ScriptedRecordBackend = struct {
                 }
             },
         }
+    }
+
+    fn authPending(ptr: *anyopaque) bool {
+        const self: *ScriptedRecordBackend = @ptrCast(@alignCast(ptr));
+        return self.auth_pending;
+    }
+
+    fn resumeAuth(ptr: *anyopaque, _: *RecordTransport.EventSink) RecordHandshakeError!void {
+        const self: *ScriptedRecordBackend = @ptrCast(@alignCast(ptr));
+        if (!self.auth_pending) return;
+        self.auth_poll_count += 1;
+        if (self.auth_pending_polls > 0) {
+            self.auth_pending_polls -= 1;
+            return;
+        }
+        self.auth_pending = false;
     }
 };
 

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -848,6 +848,21 @@ pub const PureZigRecordStream = struct {
         try self.applyDriverOutcome(outcome);
     }
 
+    /// Poll a parked asynchronous authentication operation (#334) once and apply
+    /// whatever the backend emits — the client's certificate flight, the
+    /// server's, or a peer-verification verdict. A no-op unless the backend has
+    /// suspended; requires output headroom so an emitted flight serializes
+    /// atomically. Returns true if it polled (progress toward resolution).
+    fn resumeAuthIfPending(self: *PureZigRecordStream) Error!bool {
+        if (!self.driverPresent()) return false;
+        const driver = &self.handshake_driver.?;
+        if (!driver.authPending()) return false;
+        if (self.outbound_ciphertext.available() < handshake_output_reserve) return false;
+        const outcome = driver.resumeAuthOutcome();
+        try self.applyDriverOutcome(outcome);
+        return true;
+    }
+
     /// Apply one borrowed driver event batch. Every payload slice is consumed,
     /// copied, or serialized here, before any subsequent driver call resets the
     /// sink. A terminal backend error is deferred (with its fatal alert queued)
@@ -1233,6 +1248,11 @@ pub const PureZigRecordStream = struct {
         // initial flight; server: arms the responder). The carrier write loop
         // below flushes whatever it queued.
         if (try self.startHandshakeIfNeeded()) made_progress = true;
+
+        // Poll a parked asynchronous authentication operation (#334): an
+        // external signer/verifier/selector may have suspended the handshake,
+        // and each drive tick advances it toward resolution.
+        if (try self.resumeAuthIfPending()) made_progress = true;
 
         if (self.carrier) |carrier| {
             var written_total: usize = 0;

--- a/src/tls/engine.zig
+++ b/src/tls/engine.zig
@@ -138,6 +138,35 @@ pub fn Driver(comptime Transport: type) type {
             return self.state == .complete;
         }
 
+        /// True while the backend has parked an asynchronous authentication
+        /// operation (#334). The driver owner polls `resumeAuth` until this
+        /// clears before treating the handshake as stalled.
+        pub fn authPending(self: *const Self) bool {
+            return self.backend.authPending();
+        }
+
+        /// Poll a parked authentication operation, returning the driver's event
+        /// sink with whatever progress the backend emitted. Resets the sink like
+        /// `receive`, so borrowed payload slices are valid only until the next
+        /// `start`/`receive`/`resumeAuth`. On backend failure the driver is
+        /// marked failed and the error returned.
+        pub fn resumeAuth(self: *Self) Transport.Error!*Transport.EventSink {
+            if (self.state == .failed) return self.failure_reason.?;
+            self.sink.reset();
+            self.backend.resumeAuth(&self.sink) catch |err| return self.fail(err);
+            return &self.sink;
+        }
+
+        /// Like `resumeAuth`, but on backend failure returns the sink alongside
+        /// the error (preserving any fatal alert emitted before failing), for
+        /// production drivers that flush terminal output. See `receiveOutcome`.
+        pub fn resumeAuthOutcome(self: *Self) Outcome {
+            if (self.state == .failed) return .{ .sink = &self.sink, .terminal_error = self.failure_reason };
+            self.sink.reset();
+            self.backend.resumeAuth(&self.sink) catch |err| self.markFailed(err);
+            return .{ .sink = &self.sink, .terminal_error = self.failure_reason };
+        }
+
         pub fn failure(self: *const Self) ?Transport.Error {
             return self.failure_reason;
         }

--- a/src/tls/events.zig
+++ b/src/tls/events.zig
@@ -72,6 +72,11 @@ pub const HandshakeError = error{
     /// a certificate was mandatory. Maps to the `certificate_required` alert
     /// (RFC 8446 §4.4.2.4).
     ClientCertificateRequired,
+    /// A peer's CertificateVerify signature did not validate against its
+    /// presented leaf (proof-of-possession failure). RFC 8446 §4.4.3 mandates
+    /// terminating with the `decrypt_error` alert, distinct from a trust
+    /// rejection (`CertificateInvalid`/bad_certificate).
+    DecryptError,
 };
 
 pub const Event = union(enum) {

--- a/src/tls/events.zig
+++ b/src/tls/events.zig
@@ -46,8 +46,16 @@ pub const HandshakeError = error{
     /// concern (`UnexpectedCryptoLevel`), not this. Maps to the
     /// `unexpected_message` alert (RFC 8446 §6).
     UnexpectedHandshakeMessage,
+    /// A required TLS extension was absent. Distinct from a present extension
+    /// whose vector is empty or malformed, which remains a decode or parameter
+    /// failure. Maps to `missing_extension` (RFC 8446 §6).
+    MissingExtension,
     /// ALPN did not negotiate an acceptable application protocol.
     AlpnMismatch,
+    /// The peer presented a certificate or public key type this implementation
+    /// cannot use for the selected authentication operation. Maps to
+    /// `unsupported_certificate`.
+    UnsupportedCertificate,
     /// The peer certificate was rejected by local policy or failed proof of key
     /// possession.
     CertificateInvalid,

--- a/src/tls/events.zig
+++ b/src/tls/events.zig
@@ -66,6 +66,12 @@ pub const HandshakeError = error{
     /// overflow, verifier internal error, or an invalid callback contract).
     /// Our own fault, never the peer's — maps to the `internal_error` alert.
     CredentialProviderFailed,
+    /// The server required handshake-time client authentication but the client
+    /// presented no certificate (an empty Certificate). Peer-attributed and
+    /// distinct from a rejected/invalid chain: the client simply declined when
+    /// a certificate was mandatory. Maps to the `certificate_required` alert
+    /// (RFC 8446 §4.4.2.4).
+    ClientCertificateRequired,
 };
 
 pub const Event = union(enum) {

--- a/src/tls/events.zig
+++ b/src/tls/events.zig
@@ -55,6 +55,17 @@ pub const HandshakeError = error{
     SecretExportFailed,
     /// A local caller attempted an invalid handshake lifecycle transition.
     InvalidHandshakeState,
+    /// This side cannot authenticate itself for the negotiated parameters: no
+    /// local credential is available, or none is compatible with the peer's
+    /// offered signature algorithms. A *local* configuration/selection failure,
+    /// distinct from a peer-certificate rejection (`CertificateInvalid`). Maps
+    /// to the `handshake_failure` alert (RFC 8446 §4.4.2.2).
+    NoApplicableCredential,
+    /// A local credential provider, signer, or peer verifier failed
+    /// deterministically (malformed local chain, signing fault, output
+    /// overflow, verifier internal error, or an invalid callback contract).
+    /// Our own fault, never the peer's — maps to the `internal_error` alert.
+    CredentialProviderFailed,
 };
 
 pub const Event = union(enum) {

--- a/src/tls/handshake.zig
+++ b/src/tls/handshake.zig
@@ -133,7 +133,13 @@ pub const Core = struct {
         // the client is still expecting the server's Certificate; the client
         // remembers it and will authenticate after the server Finished.
         if (message.kind == .certificate_request) {
-            if (self.role != .client or self.expected_inbound != .certificate)
+            // At most one CertificateRequest may appear in this position of the
+            // server flight (RFC 8446 §4.3.2). `expected_inbound` stays
+            // `.certificate` after the first, so the remembered flag is what
+            // rejects a duplicate rather than accepting and re-hashing it.
+            if (self.role != .client or
+                self.expected_inbound != .certificate or
+                self.client_certificate_requested)
                 return error.UnexpectedHandshakeMessage;
             self.client_certificate_requested = true;
             self.transcript.update(message.raw);
@@ -332,6 +338,25 @@ test "core records both directions of a client and server flight" {
     const client_hash = client.transcriptHash();
     const server_hash = server.transcriptHash();
     try std.testing.expectEqualSlices(u8, &client_hash, &server_hash);
+}
+
+test "a duplicate CertificateRequest in the server flight is rejected" {
+    var client = Core.init(.client);
+    try client.start();
+    var bytes: [8]u8 = undefined;
+    const ch = try messages.encode(.client_hello, "", &bytes);
+    try client.recordSent(ch);
+    const sh = try messages.encode(.server_hello, "", &bytes);
+    _ = try client.acceptReceived(sh);
+    const ee = try messages.encode(.encrypted_extensions, "", &bytes);
+    _ = try client.acceptReceived(ee);
+
+    // The first CertificateRequest is accepted (client auth requested).
+    const cr = try messages.encode(.certificate_request, "", &bytes);
+    _ = try client.acceptReceived(cr);
+    try std.testing.expect(client.client_certificate_requested);
+    // A second one in the same position is illegal (RFC 8446 §4.3.2).
+    try std.testing.expectError(error.UnexpectedHandshakeMessage, client.acceptReceived(cr));
 }
 
 test "secret lifecycle tracks directions and rejects repeated discard" {

--- a/src/tls/handshake.zig
+++ b/src/tls/handshake.zig
@@ -64,9 +64,49 @@ pub const Core = struct {
     expected_inbound: ?MessageType = null,
     transcript: transcript_mod.Transcript = .{},
     secrets: SecretLifecycle = .{},
+    /// Handshake-time client authentication (#334). The server sets
+    /// `request_client_certificate` before its flight so it may emit
+    /// CertificateRequest and then expect the client's certificate flight after
+    /// its own Finished. The client sets `client_certificate_requested` when it
+    /// receives that CertificateRequest, so it sends its own certificate flight
+    /// before Finished. Both default off — the common no-client-auth path and
+    /// QUIC are unchanged. Post-handshake client authentication is deferred.
+    request_client_certificate: bool = false,
+    client_certificate_requested: bool = false,
+    /// Server inbound sub-state for the client's post-Finished certificate
+    /// flight; `inactive` unless client auth was requested.
+    client_auth_inbound: ClientAuthInbound = .inactive,
+    /// Client outbound sub-state for its own certificate flight.
+    client_auth_outbound: ClientAuthOutbound = .inactive,
+
+    pub const ClientAuthInbound = enum { inactive, expect_certificate, expect_certificate_verify, expect_finished };
+    pub const ClientAuthOutbound = enum { inactive, send_certificate, send_certificate_verify, send_finished };
 
     pub fn init(role: state.Role) Core {
         return .{ .role = role };
+    }
+
+    /// Server: request that the client authenticate. Call before the server
+    /// flight so CertificateRequest is emitted and the client certificate
+    /// flight is expected after the server Finished.
+    pub fn requestClientCertificate(self: *Core) void {
+        self.request_client_certificate = true;
+    }
+
+    /// Server: after parsing the client's Certificate, declare whether it was
+    /// empty (no client cert). An empty certificate skips CertificateVerify, so
+    /// the server expects the client Finished next; a non-empty one expects
+    /// CertificateVerify.
+    pub fn clientCertificateWasEmpty(self: *Core, empty: bool) void {
+        self.client_auth_inbound = if (empty) .expect_finished else .expect_certificate_verify;
+    }
+
+    /// Client: begin the local certificate flight after the server Finished.
+    /// The client always sends a Certificate first (possibly empty); whether a
+    /// CertificateVerify follows depends on whether that certificate was empty,
+    /// which the outbound sequence permits either way.
+    pub fn beginClientCertificateFlight(self: *Core) void {
+        self.client_auth_outbound = .send_certificate;
     }
 
     pub fn start(self: *Core) Error!void {
@@ -88,6 +128,24 @@ pub const Core = struct {
             self.transcript.update(message.raw);
             return message;
         }
+        // A CertificateRequest (server->client, #334) is an optional message the
+        // server inserts before its Certificate. Accept it transparently while
+        // the client is still expecting the server's Certificate; the client
+        // remembers it and will authenticate after the server Finished.
+        if (message.kind == .certificate_request) {
+            if (self.role != .client or self.expected_inbound != .certificate)
+                return error.UnexpectedHandshakeMessage;
+            self.client_certificate_requested = true;
+            self.transcript.update(message.raw);
+            return message;
+        }
+        // Server inbound for the client's post-Finished certificate flight.
+        if (self.client_auth_inbound != .inactive) {
+            try self.checkClientAuthInbound(message.kind);
+            self.transcript.update(message.raw);
+            self.advanceClientAuthInbound(message.kind);
+            return message;
+        }
         if (!self.isExpectedClientFinished(message.kind)) {
             if (self.expected_inbound != message.kind)
                 return error.UnexpectedHandshakeMessage;
@@ -95,6 +153,32 @@ pub const Core = struct {
         self.transcript.update(message.raw);
         self.advanceAfterReceive(message.kind);
         return message;
+    }
+
+    fn checkClientAuthInbound(self: *const Core, kind: MessageType) Error!void {
+        const ok = switch (self.client_auth_inbound) {
+            .inactive => false,
+            .expect_certificate => kind == .certificate,
+            // Set by the backend once it has parsed the client's Certificate:
+            // a non-empty cert requires CertificateVerify, an empty one skips it.
+            .expect_certificate_verify => kind == .certificate_verify,
+            .expect_finished => kind == .finished,
+        };
+        if (!ok) return error.UnexpectedHandshakeMessage;
+    }
+
+    fn advanceClientAuthInbound(self: *Core, kind: MessageType) void {
+        switch (kind) {
+            // After the Certificate the backend refines the next expectation via
+            // `clientCertificateWasEmpty`; default to expecting CertificateVerify.
+            .certificate => self.client_auth_inbound = .expect_certificate_verify,
+            .certificate_verify => self.client_auth_inbound = .expect_finished,
+            .finished => {
+                self.client_auth_inbound = .inactive;
+                self.handshake_lifecycle = .complete;
+            },
+            else => {},
+        }
     }
 
     pub fn recordSent(self: *Core, raw: []const u8) Error!void {
@@ -121,11 +205,21 @@ pub const Core = struct {
 
     fn validOutbound(self: *const Core, kind: MessageType) bool {
         return switch (self.role) {
-            .client => (self.handshake_state == .idle and kind == .client_hello) or
-                (self.handshake_state == .finished and self.expected_inbound == null and kind == .finished),
+            .client => switch (self.client_auth_outbound) {
+                // No client auth: the original client sequence.
+                .inactive => (self.handshake_state == .idle and kind == .client_hello) or
+                    (self.handshake_state == .finished and self.expected_inbound == null and kind == .finished),
+                // Client certificate flight (#334): Certificate, then either
+                // CertificateVerify (non-empty cert) or straight to Finished
+                // (empty cert), then Finished.
+                .send_certificate => kind == .certificate,
+                .send_certificate_verify => kind == .certificate_verify or kind == .finished,
+                .send_finished => kind == .finished,
+            },
             .server => switch (self.handshake_state) {
                 .server_hello => kind == .server_hello,
                 .encrypted_extensions => kind == .encrypted_extensions,
+                .certificate_request => kind == .certificate_request,
                 .certificate => kind == .certificate,
                 .certificate_verify => kind == .certificate_verify,
                 .finished => kind == .finished,
@@ -169,18 +263,36 @@ pub const Core = struct {
 
     fn advanceAfterSend(self: *Core, kind: MessageType) void {
         switch (self.role) {
-            .client => switch (kind) {
-                .client_hello => {
-                    self.expected_inbound = .server_hello;
+            .client => switch (self.client_auth_outbound) {
+                .inactive => switch (kind) {
+                    .client_hello => self.expected_inbound = .server_hello,
+                    .finished => self.handshake_lifecycle = .complete,
+                    else => {},
                 },
-                .finished => self.handshake_lifecycle = .complete,
-                else => {},
+                else => switch (kind) {
+                    .certificate => self.client_auth_outbound = .send_certificate_verify,
+                    .certificate_verify => self.client_auth_outbound = .send_finished,
+                    .finished => {
+                        self.client_auth_outbound = .inactive;
+                        self.handshake_lifecycle = .complete;
+                    },
+                    else => {},
+                },
             },
             .server => switch (kind) {
                 .server_hello => self.handshake_state = .encrypted_extensions,
-                .encrypted_extensions => self.handshake_state = .certificate,
+                .encrypted_extensions => self.handshake_state =
+                    if (self.request_client_certificate) .certificate_request else .certificate,
+                .certificate_request => self.handshake_state = .certificate,
                 .certificate => self.handshake_state = .certificate_verify,
-                .certificate_verify, .finished => self.handshake_state = .finished,
+                .certificate_verify => self.handshake_state = .finished,
+                // After its own Finished the server either completes, or (when
+                // it requested client auth) begins expecting the client's
+                // certificate flight.
+                .finished => {
+                    self.handshake_state = .finished;
+                    if (self.request_client_certificate) self.client_auth_inbound = .expect_certificate;
+                },
                 else => {},
             },
         }

--- a/src/tls/record_epoch_bridge.zig
+++ b/src/tls/record_epoch_bridge.zig
@@ -200,7 +200,7 @@ pub const Bridge = struct {
                 break :blk try write.seal(content_type, bytes, 0, out);
             },
             .application => blk: {
-                if (!self.handshake_complete) return error.HandshakeNotComplete;
+                if (!self.handshake_complete and content_type != .alert) return error.HandshakeNotComplete;
                 const write = self.writeApplication() orelse return error.MissingWriteKeys;
                 break :blk try write.seal(content_type, bytes, 0, out);
             },

--- a/src/tls/root.zig
+++ b/src/tls/root.zig
@@ -1,4 +1,5 @@
 pub const alerts = @import("alerts.zig");
+pub const credentials = @import("credentials.zig");
 pub const engine = @import("engine.zig");
 pub const encrypted_stream = @import("encrypted_stream.zig");
 pub const handshake = @import("handshake.zig");

--- a/src/tls/state.zig
+++ b/src/tls/state.zig
@@ -15,6 +15,10 @@ pub const HandshakeState = enum {
     client_hello,
     server_hello,
     encrypted_extensions,
+    /// Server outbound: an optional CertificateRequest sits between
+    /// EncryptedExtensions and Certificate when the server asks the client to
+    /// authenticate (handshake-time client authentication, #334).
+    certificate_request,
     certificate,
     certificate_verify,
     finished,

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -45,6 +45,11 @@ pub const hash_len = tls_key_schedule.hash_len;
 /// single-certificate Ed25519 flight is far below this).
 pub const max_message_len = 8 * 1024;
 pub const max_certificate_len = 2048;
+/// The Certificate handshake message's fixed framing overhead, counted in the
+/// flight-size preflight so a chain cannot pass validation and then overflow the
+/// writer once the message header is added: 1-byte msg_type + 3-byte length +
+/// 1-byte certificate_request_context length + 3-byte CertificateList length.
+const certificate_message_overhead = 1 + 3 + 1 + 3;
 /// Caller-owned bound on a CertificateVerify signature. The engine hands the
 /// signing provider a buffer this size; a provider whose signature would not
 /// fit reports overflow rather than exceeding the bound (#334). Comfortably
@@ -392,13 +397,16 @@ pub const Tls13Backend = struct {
         std.debug.assert(self.role == .server);
         self.client_auth = mode;
         self.external_verifier = verifier;
-        // The policy handed to the client-certificate verifier: `required`
-        // demands a valid client certificate; `optional` explicitly tolerates an
-        // unverified/absent one.
+        // The policy handed to the client-certificate verifier. `required`
+        // demands the client present a certificate. `optional` permits an
+        // *absent* certificate (an empty Certificate, handled in `onCertificate`)
+        // — but a certificate that IS presented must still verify, so neither
+        // mode allows an unverified peer. A `.not_checked` verdict on a presented
+        // chain is rejected in `applyPeerVerdict` for both modes.
         self.auth_policy = switch (mode) {
             .disabled => self.auth_policy,
             .required => .{ .require_peer_authentication = true },
-            .optional => .{ .allow_unverified_peer = true },
+            .optional => .{},
         };
     }
 
@@ -554,6 +562,12 @@ pub const Tls13Backend = struct {
             },
         };
         input.append(bytes) catch |err| return mapCoreError(err);
+        // Never begin dispatching while an authentication operation is parked:
+        // buffer the freshly received bytes and wait for `resumeAuth`. Without
+        // this, a Finished arriving in a separate transport read while a peer
+        // verification is still pending would be processed here — completing the
+        // handshake before the verdict resolves.
+        if (self.pending_op != null) return;
         try self.drainInput(input, level, sink);
     }
 
@@ -569,6 +583,9 @@ pub const Tls13Backend = struct {
         sink: *EventSink,
     ) HandshakeError!void {
         while (input.peek() catch |err| return mapCoreError(err)) |message| {
+            // Defensive: never dispatch a message while an operation is parked,
+            // even if this loop is somehow re-entered mid-suspend.
+            if (self.pending_op != null) break;
             if (level != try expectedLevel(message.kind)) return error.UnexpectedTransportEpoch;
             const transcript_before = self.core.transcriptHash();
             _ = self.core.acceptReceived(message.raw) catch |err| return mapCoreError(err);
@@ -1036,14 +1053,28 @@ pub const Tls13Backend = struct {
 
     /// Apply a peer-verification verdict: emit the certificate state and fail
     /// closed on rejection. Reachable synchronously and after resume.
+    ///
+    /// A `.not_checked` verdict — the verifier deliberately did not evaluate
+    /// trust — is only acceptable when policy explicitly permits an unverified
+    /// peer (the insecure client opt-in). Every other case, including any server
+    /// verifying a client certificate under optional or required authentication,
+    /// treats it as a verification failure: policy that requires authentication
+    /// must not be satisfied by "no trust decision was made".
     fn applyPeerVerdict(self: *Tls13Backend, verdict: credentials.Verdict, sink: *EventSink) HandshakeError!void {
-        const state: CertificateState = switch (verdict) {
-            .accepted => .valid,
-            .not_checked => .not_checked,
-            .rejected => .invalid,
-        };
-        try sink.emitCertificate(state);
-        if (state == .invalid) return self.failCredential(.peer_verification_rejected);
+        switch (verdict) {
+            .accepted => try sink.emitCertificate(.valid),
+            .rejected => {
+                try sink.emitCertificate(.invalid);
+                return self.failCredential(.peer_verification_rejected);
+            },
+            .not_checked => {
+                if (!self.auth_policy.allow_unverified_peer) {
+                    try sink.emitCertificate(.invalid);
+                    return self.failCredential(.peer_verification_rejected);
+                }
+                try sink.emitCertificate(.not_checked);
+            },
+        }
     }
 
     /// Verify the CertificateVerify signature against the peer leaf's public
@@ -1160,8 +1191,18 @@ pub const Tls13Backend = struct {
         const provider = self.external_provider orelse
             return self.emitClientCertificate(null, sink);
         var selection = self.clientSelectionContext();
-        switch (provider.selectCredential(&selection) catch |err|
-            return self.failCredential(credentials.classifySelectError(err))) {
+        // A provider that deterministically has no usable credential is not a
+        // failure: TLS 1.3 requires the client to answer a CertificateRequest
+        // with an empty Certificate (RFC 8446 §4.4.2). That is how optional auth
+        // succeeds and how required auth yields the peer-attributed
+        // certificate_required outcome on the server.
+        const progress = provider.selectCredential(&selection) catch |err| switch (err) {
+            error.NoCredentialAvailable,
+            error.NoCompatibleSignatureAlgorithm,
+            => return self.emitClientCertificate(null, sink),
+            else => return self.failCredential(credentials.classifySelectError(err)),
+        };
+        switch (progress) {
             .complete => |credential| return self.emitSelectedClientCertificate(credential, sink),
             .pending => |op| return self.parkAuth(op, .client_select),
         }
@@ -1198,7 +1239,11 @@ pub const Tls13Backend = struct {
             const chain = c.certificateChain();
             if (chain.count() == 0 or chain.count() > credentials.max_chain_entries)
                 return self.failCredential(.malformed_credential_chain);
-            var encoded_len: usize = 0;
+            // The Certificate message's own framing must be counted too:
+            // 1-byte type + 3-byte length + 1-byte request context + 3-byte
+            // CertificateList length. Omitting it lets a chain that fits the
+            // entry sum overflow the writer after the message header is added.
+            var encoded_len: usize = certificate_message_overhead;
             for (chain.entries) |entry| {
                 if (entry.len == 0 or entry.len > max_certificate_len)
                     return self.failCredential(.malformed_credential_chain);
@@ -1526,23 +1571,22 @@ pub const Tls13Backend = struct {
         const chain = credential.certificateChain();
         if (chain.count() == 0 or chain.count() > credentials.max_chain_entries)
             return self.failCredential(.malformed_credential_chain);
-        var encoded_len: usize = 0;
+        // Sum the CertificateList entry encoding (each entry + its 5-byte
+        // framing) and the Certificate message's own header. The remaining
+        // preflight — that this plus EncryptedExtensions and CertificateRequest
+        // all fit one flight buffer — is completed after those messages are
+        // built, below, and before any state mutation.
+        var certificate_message_len: usize = certificate_message_overhead;
         for (chain.entries) |entry| {
             if (entry.len == 0 or entry.len > max_certificate_len)
                 return self.failCredential(.malformed_credential_chain);
             // CertificateEntry framing overhead: 3-byte cert_data length +
             // 2-byte extensions length.
-            encoded_len = std.math.add(usize, encoded_len, entry.len + 5) catch
+            certificate_message_len = std.math.add(usize, certificate_message_len, entry.len + 5) catch
                 return self.failCredential(.malformed_credential_chain);
-            if (encoded_len > max_message_len)
+            if (certificate_message_len > max_message_len)
                 return self.failCredential(.malformed_credential_chain);
         }
-
-        // Ask the client to authenticate (handshake-time client auth, #334)
-        // before recording the flight, so the Core inserts CertificateRequest
-        // after EncryptedExtensions and expects the client certificate flight
-        // after the server Finished.
-        if (self.client_auth != .disabled) self.core.requestClientCertificate();
 
         var buf: [max_message_len]u8 = undefined;
         var w = Writer{ .buf = &buf };
@@ -1589,6 +1633,23 @@ pub const Tls13Backend = struct {
             w.patch(3, cr_len);
             certificate_request = buf[cr_start..w.len];
         }
+
+        // Exact whole-flight preflight: EncryptedExtensions and the optional
+        // CertificateRequest are now serialized (`w.len`); confirm the remaining
+        // Certificate message also fits before any state mutation, so a provider
+        // chain can never overflow the writer after `requestClientCertificate`,
+        // a `recordSent`, output emission, or signing. A provider-caused
+        // overflow is a malformed local chain.
+        const flight_len = std.math.add(usize, w.len, certificate_message_len) catch
+            return self.failCredential(.malformed_credential_chain);
+        if (flight_len > max_message_len)
+            return self.failCredential(.malformed_credential_chain);
+
+        // Ask the client to authenticate (handshake-time client auth, #334)
+        // before recording the flight, so the Core inserts CertificateRequest
+        // after EncryptedExtensions and expects the client certificate flight
+        // after the server Finished.
+        if (self.client_auth != .disabled) self.core.requestClientCertificate();
 
         // Certificate: the selected credential's validated public DER chain,
         // valid until `release`.
@@ -1725,31 +1786,65 @@ pub const Tls13Backend = struct {
     /// handshake message twice.
     fn dispatchResume(self: *Tls13Backend, stage: PendingStage, completion: credentials.Completion, sink: *EventSink) HandshakeError!void {
         switch (stage) {
-            .server_select => {
-                if (completion != .credential) return self.failCredential(.provider_internal_failure);
-                return self.emitServerAuthFlight(completion.credential, sink);
+            .server_select => switch (completion) {
+                .credential => |c| return self.emitServerAuthFlight(c, sink),
+                else => {
+                    releaseCompletionCredentials(completion, null);
+                    return self.failCredential(.provider_internal_failure);
+                },
             },
-            .server_sign => {
-                if (completion != .signature_len) return self.failCredential(.invalid_callback_behavior);
-                const credential = self.pending_credential orelse return error.InvalidHandshakeState;
+            .client_select => switch (completion) {
+                .credential => |c| return self.emitSelectedClientCertificate(c, sink),
+                // A selector that resolved to "no credential" declines with an
+                // empty Certificate, exactly like the synchronous path.
+                .no_credential => return self.emitClientCertificate(null, sink),
+                else => {
+                    releaseCompletionCredentials(completion, null);
+                    return self.failCredential(.provider_internal_failure);
+                },
+            },
+            .server_sign, .client_sign => {
+                // Take the signing credential now so it is released on every
+                // path — including a malformed (wrong-kind) completion.
+                const held = self.pending_credential;
                 self.pending_credential = null;
-                return self.serverFinishFlight(credential, completion.signature_len, sink);
+                if (completion != .signature_len) {
+                    releaseCompletionCredentials(completion, held);
+                    return self.failCredential(.invalid_callback_behavior);
+                }
+                const credential = held orelse return error.InvalidHandshakeState;
+                return switch (stage) {
+                    .server_sign => self.serverFinishFlight(credential, completion.signature_len, sink),
+                    .client_sign => self.finishClientAuthFlight(credential, completion.signature_len, sink),
+                    else => unreachable,
+                };
             },
-            .client_select => {
-                if (completion != .credential) return self.failCredential(.provider_internal_failure);
-                return self.emitSelectedClientCertificate(completion.credential, sink);
-            },
-            .client_sign => {
-                if (completion != .signature_len) return self.failCredential(.invalid_callback_behavior);
-                const credential = self.pending_credential orelse return error.InvalidHandshakeState;
-                self.pending_credential = null;
-                return self.finishClientAuthFlight(credential, completion.signature_len, sink);
-            },
-            .peer_verify => {
-                if (completion != .verdict) return self.failCredential(.verifier_internal_failure);
-                return self.applyPeerVerdict(completion.verdict, sink);
+            .peer_verify => switch (completion) {
+                .verdict => |v| return self.applyPeerVerdict(v, sink),
+                else => {
+                    releaseCompletionCredentials(completion, null);
+                    return self.failCredential(.verifier_internal_failure);
+                },
             },
         }
+    }
+
+    /// Release the credential handles owned by a rejected completion and/or a
+    /// held signing credential exactly once each, deduping when both aliases
+    /// refer to the same provider handle (a malformed callback may hand back the
+    /// very credential the engine already holds).
+    fn releaseCompletionCredentials(completion: credentials.Completion, held: ?credentials.SelectedCredential) void {
+        var from_completion: ?credentials.SelectedCredential = switch (completion) {
+            .credential => |c| c,
+            else => null,
+        };
+        if (held) |h| {
+            h.release();
+            if (from_completion) |c| {
+                if (c.handle == h.handle) from_completion = null;
+            }
+        }
+        if (from_completion) |c| c.release();
     }
 
     /// The failure class for a pending operation that reported an error, by

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -178,6 +178,12 @@ pub const SelectionContext = credentials.SelectionContext;
 pub const VerificationContext = credentials.VerificationContext;
 pub const CredentialFailure = credentials.FailureClass;
 
+/// Whether a server requests handshake-time client authentication (#334).
+/// `optional` accepts an empty client Certificate; `required` fails closed with
+/// `certificate_required` when the client presents none. Post-handshake client
+/// authentication is explicitly deferred.
+pub const ClientAuthMode = enum { disabled, optional, required };
+
 /// Largest peer certificate chain (total DER bytes and entry count) the engine
 /// reassembles and surfaces to a `PeerVerifier` as immutable views. A chain
 /// exceeding either bound fails closed (peer-attributed) rather than being
@@ -215,8 +221,15 @@ pub const Tls13Backend = struct {
     /// vtable's `ctx` points to caller-owned storage that must outlive the
     /// handshake. When null, the engine wraps the fixed identity/trust in the
     /// same production contract, so there is one authentication path.
+    /// The local credential provider — my own certificate. Server: the server
+    /// cert (or the fixed identity). Client: the client cert for handshake-time
+    /// client authentication, when configured.
     external_provider: ?CredentialProvider = null,
+    /// How I verify the peer. Client: verify the server. Server: verify the
+    /// client's certificate during handshake-time client authentication.
     external_verifier: ?PeerVerifier = null,
+    /// Server: whether to request client authentication.
+    client_auth: ClientAuthMode = .disabled,
     /// Explicit local authentication policy, passed to selection and
     /// verification. Set at construction from the caller's intent, never
     /// re-derived from a defaulted field (an external verifier must not silently
@@ -360,6 +373,24 @@ pub const Tls13Backend = struct {
             self.server_name_present = true;
         }
         return self;
+    }
+
+    /// Server: request handshake-time client authentication, verifying the
+    /// client's certificate through `verifier` (role `.server`). Must be called
+    /// before `start`. `optional` accepts an empty client Certificate;
+    /// `required` fails closed when the client presents none.
+    pub fn requestClientAuthentication(self: *Tls13Backend, mode: ClientAuthMode, verifier: PeerVerifier) void {
+        std.debug.assert(self.role == .server);
+        self.client_auth = mode;
+        self.external_verifier = verifier;
+    }
+
+    /// Client: supply the credential provider for the client's own certificate,
+    /// used to authenticate when the server sends a CertificateRequest. Must be
+    /// called before `start`.
+    pub fn setLocalCredentialProvider(self: *Tls13Backend, provider: CredentialProvider) void {
+        std.debug.assert(self.role == .client);
+        self.external_provider = provider;
     }
 
     pub fn backend(self: *Tls13Backend) TlsBackend {
@@ -1211,6 +1242,12 @@ pub const Tls13Backend = struct {
                 return self.failCredential(.malformed_credential_chain);
         }
 
+        // Ask the client to authenticate (handshake-time client auth, #334)
+        // before recording the flight, so the Core inserts CertificateRequest
+        // after EncryptedExtensions and expects the client certificate flight
+        // after the server Finished.
+        if (self.client_auth != .disabled) self.core.requestClientCertificate();
+
         var buf: [max_message_len]u8 = undefined;
         var w = Writer{ .buf = &buf };
 
@@ -1237,6 +1274,26 @@ pub const Tls13Backend = struct {
         w.patch(3, ee_len);
         const encrypted_extensions = buf[0..w.len];
 
+        // CertificateRequest (RFC 8446 §4.3.2), when requesting client auth:
+        // empty context, a signature_algorithms extension listing accepted
+        // client-auth schemes.
+        var certificate_request: []const u8 = &.{};
+        if (self.client_auth != .disabled) {
+            const cr_start = w.len;
+            try w.u8_(@intFromEnum(MessageType.certificate_request));
+            const cr_len = try w.reserve(3);
+            try w.u8_(0); // certificate_request_context<0..255>: empty
+            const cr_exts = try w.reserve(2);
+            try w.u16_(ext_signature_algorithms);
+            try w.u16_(2 + 2 * 2); // extension_data length
+            try w.u16_(2 * 2); // supported_signature_algorithms list length
+            try w.u16_(sigalg_ed25519);
+            try w.u16_(sigalg_ecdsa_secp256r1_sha256);
+            w.patch(2, cr_exts);
+            w.patch(3, cr_len);
+            certificate_request = buf[cr_start..w.len];
+        }
+
         // Certificate: the selected credential's validated public DER chain,
         // valid until `release`.
         const cert_start = w.len;
@@ -1255,6 +1312,8 @@ pub const Tls13Backend = struct {
         const certificate = buf[cert_start..w.len];
 
         self.core.recordSent(encrypted_extensions) catch |err| return mapCoreError(err);
+        if (certificate_request.len > 0)
+            self.core.recordSent(certificate_request) catch |err| return mapCoreError(err);
         self.core.recordSent(certificate) catch |err| return mapCoreError(err);
         try sink.emitCrypto(.handshake, buf[0..w.len]);
 

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -18,6 +18,7 @@
 
 const std = @import("std");
 const events = @import("events.zig");
+const credentials = @import("credentials.zig");
 const tls_handshake_codec = @import("handshake.zig");
 const tls_key_schedule = @import("key_schedule.zig");
 const tls_state = @import("state.zig");
@@ -44,6 +45,11 @@ pub const hash_len = tls_key_schedule.hash_len;
 /// single-certificate Ed25519 flight is far below this).
 pub const max_message_len = 8 * 1024;
 pub const max_certificate_len = 2048;
+/// Caller-owned bound on a CertificateVerify signature. The engine hands the
+/// signing provider a buffer this size; a provider whose signature would not
+/// fit reports overflow rather than exceeding the bound (#334). Comfortably
+/// above Ed25519 (64) and DER-encoded ECDSA P-256 (~72).
+pub const max_signature_len = 256;
 
 const tls13_version: u16 = 0x0304;
 const legacy_version: u16 = 0x0303;
@@ -52,6 +58,7 @@ const group_x25519: u16 = 0x001d;
 const sigalg_ed25519: u16 = 0x0807;
 const sigalg_ecdsa_secp256r1_sha256: u16 = 0x0403;
 
+const ext_server_name: u16 = 0;
 const ext_supported_groups: u16 = 10;
 const ext_signature_algorithms: u16 = 13;
 const ext_alpn: u16 = 16;
@@ -159,155 +166,27 @@ const ExtensionGuard = struct {
 // Server identity and client trust.
 // ===========================================================================
 
-/// The server's certificate and signing key: Ed25519 (RFC 8410) or ECDSA
-/// P-256 (RFC 5915/5480). `initPkcs8` loads standard PKCS#8 DER as produced
-/// by `openssl genpkey -algorithm ed25519` or
-/// `openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256`. Two key
-/// types because deployed TLS stacks disagree on defaults: GnuTLS/OpenSSL
-/// accept Ed25519 out of the box while BoringSSL's default verifier
-/// (quiche/Chromium) requires ECDSA/RSA — P-256 is the interoperable floor.
-pub const Identity = struct {
-    certificate_der: []const u8,
-    key: Key,
+/// The provider-neutral credential and verification contracts live in
+/// `credentials.zig` (#334). The fixed server identity and pin/insecure trust
+/// are re-exported here for callers and served through the same contract the
+/// engine uses for any provider — there is a single authentication path.
+pub const Identity = credentials.Identity;
+pub const Trust = credentials.Trust;
+pub const CredentialProvider = credentials.CredentialProvider;
+pub const PeerVerifier = credentials.PeerVerifier;
+pub const SelectionContext = credentials.SelectionContext;
+pub const VerificationContext = credentials.VerificationContext;
+pub const CredentialFailure = credentials.FailureClass;
 
-    pub const Key = union(enum) {
-        ed25519: Ed25519.KeyPair,
-        ecdsa_p256: EcdsaP256.KeyPair,
-    };
-
-    pub const InitError = error{InvalidPrivateKey};
-
-    pub fn initPkcs8(certificate_der: []const u8, pkcs8_key_der: []const u8) InitError!Identity {
-        if (ed25519SeedFromPkcs8(pkcs8_key_der)) |seed| {
-            const key_pair = Ed25519.KeyPair.generateDeterministic(seed) catch return error.InvalidPrivateKey;
-            return .{ .certificate_der = certificate_der, .key = .{ .ed25519 = key_pair } };
-        } else |_| {}
-        const scalar = try ecdsaP256KeyFromPkcs8(pkcs8_key_der);
-        const secret = EcdsaP256.SecretKey.fromBytes(scalar) catch return error.InvalidPrivateKey;
-        const key_pair = EcdsaP256.KeyPair.fromSecretKey(secret) catch return error.InvalidPrivateKey;
-        return .{ .certificate_der = certificate_der, .key = .{ .ecdsa_p256 = key_pair } };
-    }
-
-    /// The TLS SignatureScheme this identity signs CertificateVerify with.
-    pub fn signatureAlgorithm(self: *const Identity) u16 {
-        return switch (self.key) {
-            .ed25519 => sigalg_ed25519,
-            .ecdsa_p256 => sigalg_ecdsa_secp256r1_sha256,
-        };
-    }
-
-    /// Extract the P-256 private scalar from PKCS#8 DER (RFC 5915 inside
-    /// RFC 5958): SEQUENCE { INTEGER 0, SEQUENCE { OID id-ecPublicKey, OID
-    /// prime256v1 }, OCTET STRING { SEQUENCE { INTEGER 1, OCTET STRING(32)
-    /// privateKey, ... } } }. Bounded, no allocation.
-    fn ecdsaP256KeyFromPkcs8(der: []const u8) InitError![32]u8 {
-        const oid_ec_public_key = [_]u8{ 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01 };
-        const oid_prime256v1 = [_]u8{ 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07 };
-        var walker = DerWalker{ .bytes = der };
-        var outer = try walker.sequence();
-        // Both encodings openssl produces: PKCS#8 (RFC 5958, version 0)
-        // wrapping ECPrivateKey, or a bare SEC1/RFC 5915 ECPrivateKey
-        // (version 1) as written by `openssl pkey -outform DER`.
-        var probe = outer;
-        const version = try probe.integer();
-        if (version == 1) {
-            return ecPrivateKeyScalar(&outer);
-        }
-        try outer.expectInteger(0);
-        var alg = try outer.sequence();
-        try alg.expectBytes(&oid_ec_public_key);
-        try alg.expectBytes(&oid_prime256v1);
-        const key_octets = try outer.octetString();
-        var inner_walker = DerWalker{ .bytes = key_octets };
-        var ec_key = try inner_walker.sequence();
-        return ecPrivateKeyScalar(&ec_key);
-    }
-
-    /// RFC 5915 ECPrivateKey body: INTEGER 1, OCTET STRING privateKey, ...
-    fn ecPrivateKeyScalar(ec_key: *DerWalker) InitError![32]u8 {
-        try ec_key.expectInteger(1);
-        const scalar = try ec_key.octetString();
-        if (scalar.len != 32) return error.InvalidPrivateKey;
-        return scalar[0..32].*;
-    }
-
-    const DerWalker = struct {
-        bytes: []const u8,
-        pos: usize = 0,
-
-        fn tagged(self: *DerWalker, tag: u8) InitError![]const u8 {
-            if (self.pos + 2 > self.bytes.len) return error.InvalidPrivateKey;
-            if (self.bytes[self.pos] != tag) return error.InvalidPrivateKey;
-            var len: usize = self.bytes[self.pos + 1];
-            var header: usize = 2;
-            if (len == 0x81) {
-                if (self.pos + 3 > self.bytes.len) return error.InvalidPrivateKey;
-                len = self.bytes[self.pos + 2];
-                header = 3;
-            } else if (len == 0x82) {
-                if (self.pos + 4 > self.bytes.len) return error.InvalidPrivateKey;
-                len = (@as(usize, self.bytes[self.pos + 2]) << 8) | self.bytes[self.pos + 3];
-                header = 4;
-            } else if (len > 0x80) {
-                return error.InvalidPrivateKey;
-            }
-            if (self.pos + header + len > self.bytes.len) return error.InvalidPrivateKey;
-            const content = self.bytes[self.pos + header ..][0..len];
-            self.pos += header + len;
-            return content;
-        }
-
-        fn sequence(self: *DerWalker) InitError!DerWalker {
-            return .{ .bytes = try self.tagged(0x30) };
-        }
-
-        fn octetString(self: *DerWalker) InitError![]const u8 {
-            return self.tagged(0x04);
-        }
-
-        fn integer(self: *DerWalker) InitError!u8 {
-            const content = try self.tagged(0x02);
-            if (content.len != 1) return error.InvalidPrivateKey;
-            return content[0];
-        }
-
-        fn expectInteger(self: *DerWalker, value: u8) InitError!void {
-            if (try self.integer() != value) return error.InvalidPrivateKey;
-        }
-
-        fn expectBytes(self: *DerWalker, expected: []const u8) InitError!void {
-            if (self.pos + expected.len > self.bytes.len) return error.InvalidPrivateKey;
-            if (!std.mem.eql(u8, self.bytes[self.pos..][0..expected.len], expected)) return error.InvalidPrivateKey;
-            self.pos += expected.len;
-        }
-    };
-
-    /// Extract the 32-byte Ed25519 seed from a PKCS#8 `OneAsymmetricKey` DER
-    /// (RFC 8410 §7): SEQUENCE { version 0, AlgorithmIdentifier id-Ed25519,
-    /// privateKey OCTET STRING { OCTET STRING(32) } }.
-    fn ed25519SeedFromPkcs8(der: []const u8) InitError![Ed25519.KeyPair.seed_length]u8 {
-        const prefix = [_]u8{
-            0x30, 0x2e, // SEQUENCE, 46 bytes
-            0x02, 0x01, 0x00, // INTEGER version 0
-            0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, // AlgorithmIdentifier { 1.3.101.112 }
-            0x04, 0x22, 0x04, 0x20, // OCTET STRING { OCTET STRING (32 bytes) }
-        };
-        if (der.len != prefix.len + Ed25519.KeyPair.seed_length) return error.InvalidPrivateKey;
-        if (!std.mem.eql(u8, der[0..prefix.len], &prefix)) return error.InvalidPrivateKey;
-        return der[prefix.len..][0..Ed25519.KeyPair.seed_length].*;
-    }
-};
-
-/// How the client decides the server certificate's validity. Web-PKI chain
-/// building is a follow-up; the deterministic modes below cover local
-/// handshakes, tests, and deployment pinning.
-pub const Trust = union(enum) {
-    /// The presented leaf must byte-equal this DER certificate.
-    pinned_certificate: []const u8,
-    /// Report `not_checked`; completes only when the driver explicitly opts
-    /// into `allow_unverified_certificate`.
-    insecure_no_verification,
-};
+/// Largest peer certificate chain (total DER bytes and entry count) the engine
+/// reassembles and surfaces to a `PeerVerifier` as immutable views.
+pub const max_peer_chain_bytes = 8 * 1024;
+pub const max_peer_chain_entries = credentials.max_chain_entries;
+/// Largest set of peer-offered signature schemes captured for selection.
+const max_peer_sig_schemes = 16;
+/// Largest SNI host_name captured for selection (RFC 6066 caps names well
+/// under this).
+const max_server_name_len = 256;
 
 /// Caller-supplied entropy for one handshake, consistent with the rest of
 /// `src/quic/` where unpredictable bytes always come from the caller.
@@ -327,6 +206,24 @@ pub const Tls13Backend = struct {
     identity: Identity = undefined,
     identity_present: bool = false,
     trust: Trust = .insecure_no_verification,
+    /// An externally supplied credential provider (server) / peer verifier
+    /// (client or server). When set, it overrides the fixed identity/trust; the
+    /// vtable's `ctx` points to caller-owned storage that must outlive the
+    /// handshake. When null, the engine wraps the fixed identity/trust in the
+    /// same production contract, so there is one authentication path.
+    external_provider: ?CredentialProvider = null,
+    external_verifier: ?PeerVerifier = null,
+    /// The last typed credential/verification failure. Set on failure and
+    /// deliberately preserved across `deinit` (it is diagnostic, not secret) so
+    /// terminal cleanup does not erase the underlying reason (#334).
+    credential_failure: ?CredentialFailure = null,
+    /// Peer-offered signature schemes and SNI captured from ClientHello, passed
+    /// immutably into credential selection.
+    peer_sig_schemes: [max_peer_sig_schemes]u16 = undefined,
+    peer_sig_scheme_count: usize = 0,
+    server_name: [max_server_name_len]u8 = undefined,
+    server_name_len: usize = 0,
+    server_name_present: bool = false,
     peer_transport_extension: [max_transport_extension_len]u8 = undefined,
     peer_transport_extension_len: usize = 0,
     peer_transport_extension_pending: bool = false,
@@ -346,9 +243,14 @@ pub const Tls13Backend = struct {
     initial_input: tls_handshake_codec.Reassembler(max_message_len + 4) = .{},
     handshake_input: tls_handshake_codec.Reassembler(max_message_len + 4) = .{},
     application_input: tls_handshake_codec.Reassembler(max_message_len + 4) = .{},
-    /// The peer's leaf certificate (client role), kept for CertificateVerify.
-    peer_certificate: [max_certificate_len]u8 = undefined,
-    peer_certificate_len: usize = 0,
+    /// The peer's reassembled certificate chain (immutable DER, surfaced to the
+    /// verifier as views). `entries` index into `peer_chain`.
+    peer_chain: [max_peer_chain_bytes]u8 = undefined,
+    peer_chain_entries: [max_peer_chain_entries]Slice = undefined,
+    peer_chain_count: usize = 0,
+    peer_chain_len: usize = 0,
+
+    const Slice = struct { start: usize, len: usize };
 
     /// Allocation-free. The returned backend owns its copied entropy until
     /// `deinit`, which securely clears all private material.
@@ -357,7 +259,9 @@ pub const Tls13Backend = struct {
     }
 
     /// Allocation-free. The returned backend owns its copy of `identity` and
-    /// securely clears the private signing key in `deinit`.
+    /// securely clears the private signing key in `deinit`. The fixed identity
+    /// is served to the engine through the production `CredentialProvider`
+    /// contract, identical to an external provider.
     pub fn initServer(entropy: Entropy, identity: Identity, profile: TransportProfile) Tls13Backend {
         return .{
             .role = .server,
@@ -366,6 +270,32 @@ pub const Tls13Backend = struct {
             .identity = identity,
             .identity_present = true,
             .core = tls_handshake_codec.Core.init(.server),
+        };
+    }
+
+    /// Server construction against an external credential provider (SNI
+    /// selector, external/asynchronous signer, ...). The provider's storage
+    /// must outlive the handshake. No fixed identity is held.
+    pub fn initServerWithProvider(entropy: Entropy, provider: CredentialProvider, profile: TransportProfile) Tls13Backend {
+        return .{
+            .role = .server,
+            .profile = profile,
+            .entropy = entropy,
+            .external_provider = provider,
+            .core = tls_handshake_codec.Core.init(.server),
+        };
+    }
+
+    /// Client construction against an external peer verifier (#324 Web-PKI, a
+    /// custom trust store, ...). The verifier's storage must outlive the
+    /// handshake.
+    pub fn initClientWithVerifier(entropy: Entropy, verifier: PeerVerifier, profile: TransportProfile) Tls13Backend {
+        return .{
+            .role = .client,
+            .profile = profile,
+            .entropy = entropy,
+            .external_verifier = verifier,
+            .core = tls_handshake_codec.Core.init(.client),
         };
     }
 
@@ -392,6 +322,20 @@ pub const Tls13Backend = struct {
         self.profile = profile;
     }
 
+    /// The typed credential/verification failure this handshake latched, if
+    /// any. Survives `deinit` so a failed handshake's reason stays queryable.
+    pub fn credentialFailure(self: *const Tls13Backend) ?CredentialFailure {
+        return self.credential_failure;
+    }
+
+    /// Record a typed failure, mark the core failed, and return the engine-level
+    /// error whose alert mapping matches the failure's origin (#334).
+    fn failCredential(self: *Tls13Backend, class: CredentialFailure) HandshakeError {
+        self.credential_failure = class;
+        self.core.handshake_lifecycle = .failed;
+        return class.engineError();
+    }
+
     /// Returns a newly received opaque transport extension once. The caller
     /// must consume/copy it before the next backend call.
     pub fn takePeerTransportExtension(self: *Tls13Backend) ?[]const u8 {
@@ -411,8 +355,19 @@ pub const Tls13Backend = struct {
         crypto.secureZero(u8, &self.expected_client_verify);
         self.wipeEphemeral();
         self.wipeIdentity();
-        crypto.secureZero(u8, &self.peer_certificate);
-        self.peer_certificate_len = 0;
+        crypto.secureZero(u8, &self.peer_chain);
+        self.peer_chain_count = 0;
+        self.peer_chain_len = 0;
+        crypto.secureZero(u8, std.mem.asBytes(&self.peer_sig_schemes));
+        self.peer_sig_scheme_count = 0;
+        crypto.secureZero(u8, &self.server_name);
+        self.server_name_len = 0;
+        self.server_name_present = false;
+        // `credential_failure` is intentionally *not* cleared: terminal cleanup
+        // must preserve the underlying typed failure (#334). The external
+        // provider/verifier vtables borrow caller storage; drop the references.
+        self.external_provider = null;
+        self.external_verifier = null;
         crypto.secureZero(u8, &self.peer_transport_extension);
         self.peer_transport_extension_len = 0;
         self.peer_transport_extension_pending = false;
@@ -506,6 +461,10 @@ pub const Tls13Backend = struct {
             error.CertificateInvalid => error.CertificateInvalid,
             error.SecretExportFailed => error.SecretExportFailed,
             error.InvalidHandshakeState => error.InvalidHandshakeState,
+            // Surfaced only by this backend's credential/verification path, not
+            // the codec core, but they are part of the shared error set.
+            error.NoApplicableCredential => error.NoApplicableCredential,
+            error.CredentialProviderFailed => error.CredentialProviderFailed,
         };
     }
 
@@ -732,19 +691,72 @@ pub const Tls13Backend = struct {
         var list = Reader{ .bytes = try r.slice(try r.u24_()) };
         try r.expectEnd();
 
+        // Reassemble the full chain into engine-owned storage. The verifier
+        // later sees each entry as an immutable DER view into `peer_chain`; the
+        // leaf (entry 0) additionally anchors proof-of-possession. Bounds keep
+        // a hostile peer from exhausting memory.
+        self.peer_chain_count = 0;
+        self.peer_chain_len = 0;
         const leaf_len = try list.u24_();
         if (leaf_len == 0 or leaf_len > max_certificate_len) return error.CertificateInvalid;
-        const leaf = try list.slice(leaf_len);
+        try self.appendPeerCertificate(try list.slice(leaf_len));
         _ = try list.slice(try list.u16_()); // leaf extensions
-        // Validate the framing of any additional chain certificates; the trust
-        // decision here is pin-based, so only the leaf is retained.
         while (list.remaining() > 0) {
-            _ = try list.slice(try list.u24_());
-            _ = try list.slice(try list.u16_());
+            const entry = try list.slice(try list.u24_());
+            _ = try list.slice(try list.u16_()); // per-certificate extensions
+            // Additional chain certificates beyond our bound are framed-checked
+            // above but not retained; the leaf is what pinning verifies and a
+            // #324 verifier receives what fits.
+            self.appendPeerCertificate(entry) catch |err| switch (err) {
+                error.CertificateInvalid => {},
+                else => return err,
+            };
         }
+    }
 
-        @memcpy(self.peer_certificate[0..leaf.len], leaf);
-        self.peer_certificate_len = leaf.len;
+    /// Copy one peer DER certificate into the bounded chain storage, recording
+    /// its view. Returns `CertificateInvalid` when the entry or the chain would
+    /// exceed the engine's bounds.
+    fn appendPeerCertificate(self: *Tls13Backend, der: []const u8) HandshakeError!void {
+        if (self.peer_chain_count >= self.peer_chain_entries.len) return error.CertificateInvalid;
+        if (self.peer_chain_len + der.len > self.peer_chain.len) return error.CertificateInvalid;
+        const start = self.peer_chain_len;
+        @memcpy(self.peer_chain[start..][0..der.len], der);
+        self.peer_chain_entries[self.peer_chain_count] = .{ .start = start, .len = der.len };
+        self.peer_chain_count += 1;
+        self.peer_chain_len += der.len;
+    }
+
+    /// Build the immutable peer chain view over engine storage into `out`. The
+    /// returned slices are valid only until `peer_chain` is next mutated or the
+    /// backend is torn down; a verifier must not retain them.
+    fn peerChainView(self: *const Tls13Backend, out: *[max_peer_chain_entries][]const u8) credentials.CertificateChain {
+        for (0..self.peer_chain_count) |i| {
+            const e = self.peer_chain_entries[i];
+            out[i] = self.peer_chain[e.start..][0..e.len];
+        }
+        return .{ .entries = out[0..self.peer_chain_count] };
+    }
+
+    fn serverSelectionContext(self: *const Tls13Backend) credentials.SelectionContext {
+        return .{
+            .role = .server,
+            .server_name = if (self.server_name_present) self.server_name[0..self.server_name_len] else null,
+            .peer_signature_schemes = self.peer_sig_schemes[0..self.peer_sig_scheme_count],
+            .negotiated_version = tls13_version,
+            .cipher_suite = cipher_tls_aes_128_gcm_sha256,
+            .application_protocol = self.alpn(),
+            .auth_policy = self.authPolicy(),
+        };
+    }
+
+    fn authPolicy(self: *const Tls13Backend) credentials.AuthPolicy {
+        return .{
+            .allow_unverified_peer = switch (self.trust) {
+                .insecure_no_verification => true,
+                .pinned_certificate => false,
+            },
+        };
     }
 
     fn onCertificateVerify(self: *Tls13Backend, transcript_before: [hash_len]u8, body: []const u8, sink: *EventSink) HandshakeError!void {
@@ -754,48 +766,75 @@ pub const Tls13Backend = struct {
         try r.expectEnd();
 
         // The signature covers the transcript through Certificate (RFC 8446
-        // §4.4.3) — before this message is added.
+        // §4.4.3) — before this message is added. Proof of key possession is
+        // transcript crypto, not PKI policy, so it stays in the engine; a
+        // failure is peer-originated (bad_certificate).
         const content = certificateVerifyContent(.server, transcript_before);
-        const state = self.verifyServerCertificate(algorithm, signature, content.slice());
-        try sink.emitCertificate(state);
-        if (state == .invalid) {
-            self.core.handshake_lifecycle = .failed;
-            return error.CertificateInvalid;
+        if (!self.checkProofOfPossession(algorithm, signature, content.slice())) {
+            try sink.emitCertificate(.invalid);
+            return self.failCredential(.invalid_peer_certificate_chain);
         }
+
+        // Delegate the trust verdict to the peer verifier — the fixed pin/
+        // insecure policy or an external #324 Web-PKI verifier — over immutable
+        // DER views it must not retain.
+        var views: [max_peer_chain_entries][]const u8 = undefined;
+        var verifier_storage: credentials.FixedVerifier = undefined;
+        const verifier = if (self.external_verifier) |v| v else blk: {
+            verifier_storage = credentials.FixedVerifier.init(self.trust);
+            break :blk verifier_storage.verifier();
+        };
+        const context = credentials.VerificationContext{
+            .role = .client,
+            .server_name = null,
+            .chain = self.peerChainView(&views),
+            .negotiated_version = tls13_version,
+            .cipher_suite = cipher_tls_aes_128_gcm_sha256,
+            .application_protocol = self.alpn(),
+            .auth_policy = self.authPolicy(),
+        };
+        const verdict = verifier.verifyPeer(&context) catch |err|
+            return self.failCredential(credentials.classifyVerifyError(err));
+        const state: CertificateState = switch (verdict) {
+            .accepted => .valid,
+            .not_checked => .not_checked,
+            .rejected => .invalid,
+        };
+        try sink.emitCertificate(state);
+        if (state == .invalid) return self.failCredential(.peer_verification_rejected);
     }
 
-    fn verifyServerCertificate(self: *Tls13Backend, algorithm: u16, signature: []const u8, content: []const u8) CertificateState {
-        const leaf = self.peer_certificate[0..self.peer_certificate_len];
-
-        // Proof of key possession: the CertificateVerify signature must check
-        // out against the certificate's public key in every trust mode.
-        const parsed = (Certificate{ .buffer = leaf, .index = 0 }).parse() catch return .invalid;
+    /// Verify the CertificateVerify signature against the peer leaf's public
+    /// key: proof that the peer holds the private key for the presented
+    /// certificate. Returns false on any mismatch. This is not a trust decision
+    /// — that is the verifier's job.
+    fn checkProofOfPossession(self: *const Tls13Backend, algorithm: u16, signature: []const u8, content: []const u8) bool {
+        if (self.peer_chain_count == 0) return false;
+        const e = self.peer_chain_entries[0];
+        const leaf = self.peer_chain[e.start..][0..e.len];
+        const parsed = (Certificate{ .buffer = leaf, .index = 0 }).parse() catch return false;
         switch (algorithm) {
             sigalg_ed25519 => {
-                if (signature.len != Ed25519.Signature.encoded_length) return .invalid;
-                if (parsed.pub_key_algo != .curveEd25519) return .invalid;
+                if (signature.len != Ed25519.Signature.encoded_length) return false;
+                if (parsed.pub_key_algo != .curveEd25519) return false;
                 const pub_key_bytes = parsed.pubKey();
-                if (pub_key_bytes.len != Ed25519.PublicKey.encoded_length) return .invalid;
-                const public_key = Ed25519.PublicKey.fromBytes(pub_key_bytes[0..Ed25519.PublicKey.encoded_length].*) catch return .invalid;
+                if (pub_key_bytes.len != Ed25519.PublicKey.encoded_length) return false;
+                const public_key = Ed25519.PublicKey.fromBytes(pub_key_bytes[0..Ed25519.PublicKey.encoded_length].*) catch return false;
                 const sig = Ed25519.Signature.fromBytes(signature[0..Ed25519.Signature.encoded_length].*);
-                sig.verify(content, public_key) catch return .invalid;
+                sig.verify(content, public_key) catch return false;
             },
             sigalg_ecdsa_secp256r1_sha256 => {
                 switch (parsed.pub_key_algo) {
-                    .X9_62_id_ecPublicKey => |curve| if (curve != .X9_62_prime256v1) return .invalid,
-                    else => return .invalid,
+                    .X9_62_id_ecPublicKey => |curve| if (curve != .X9_62_prime256v1) return false,
+                    else => return false,
                 }
-                const public_key = EcdsaP256.PublicKey.fromSec1(parsed.pubKey()) catch return .invalid;
-                const sig = EcdsaP256.Signature.fromDer(signature) catch return .invalid;
-                sig.verify(content, public_key) catch return .invalid;
+                const public_key = EcdsaP256.PublicKey.fromSec1(parsed.pubKey()) catch return false;
+                const sig = EcdsaP256.Signature.fromDer(signature) catch return false;
+                sig.verify(content, public_key) catch return false;
             },
-            else => return .invalid,
+            else => return false,
         }
-
-        return switch (self.trust) {
-            .pinned_certificate => |pin| if (std.mem.eql(u8, leaf, pin)) .valid else .invalid,
-            .insecure_no_verification => .not_checked,
-        };
+        return true;
     }
 
     fn onServerFinished(self: *Tls13Backend, transcript_before: [hash_len]u8, body: []const u8, sink: *EventSink) HandshakeError!void {
@@ -854,11 +893,15 @@ pub const Tls13Backend = struct {
         }
         if (!offers_cipher or !offers_null_compression) return error.MalformedHandshake;
 
-        if (!self.identity_present) return error.InvalidHandshakeState;
-        const required_sigalg = self.identity.signatureAlgorithm();
+        // A server needs a credential source: the fixed identity or an external
+        // provider. Which signature scheme is usable is decided later by
+        // credential selection against the peer's advertised algorithms.
+        if (!self.identity_present and self.external_provider == null) return error.InvalidHandshakeState;
+        self.peer_sig_scheme_count = 0;
+        self.server_name_present = false;
+        self.server_name_len = 0;
         var offers_tls13 = false;
         var offers_x25519_group = false;
-        var offers_our_sigalg = false;
         var peer_share: ?[X25519.public_length]u8 = null;
         var alpn_match = false;
         var first_alpn: []const u8 = "";
@@ -888,7 +931,27 @@ pub const Tls13Backend = struct {
                 ext_signature_algorithms => {
                     var algorithms = Reader{ .bytes = try ext.slice(try ext.u16_()) };
                     while (algorithms.remaining() > 0) {
-                        if (try algorithms.u16_() == required_sigalg) offers_our_sigalg = true;
+                        const scheme = try algorithms.u16_();
+                        // Capture the peer's offers (in order) for credential
+                        // selection; ignore any past our bounded capacity.
+                        if (self.peer_sig_scheme_count < self.peer_sig_schemes.len) {
+                            self.peer_sig_schemes[self.peer_sig_scheme_count] = scheme;
+                            self.peer_sig_scheme_count += 1;
+                        }
+                    }
+                },
+                ext_server_name => {
+                    // RFC 6066 §3: ServerNameList<1..>, each { name_type, name<..> }.
+                    // Preserve the first host_name (type 0) exactly as received.
+                    var names = Reader{ .bytes = try ext.slice(try ext.u16_()) };
+                    while (names.remaining() > 0) {
+                        const name_type = try names.u8_();
+                        const name = try names.slice(try names.u16_());
+                        if (name_type == 0 and !self.server_name_present and name.len <= self.server_name.len) {
+                            @memcpy(self.server_name[0..name.len], name);
+                            self.server_name_len = name.len;
+                            self.server_name_present = true;
+                        }
                     }
                 },
                 ext_key_share => {
@@ -917,7 +980,7 @@ pub const Tls13Backend = struct {
                 },
             }
         }
-        if (!offers_tls13 or !offers_x25519_group or !offers_our_sigalg) return error.MalformedHandshake;
+        if (!offers_tls13 or !offers_x25519_group) return error.MalformedHandshake;
         const client_share = peer_share orelse return error.MalformedHandshake;
 
         // Validate the peer share before emitting anything: X25519.scalarmult
@@ -983,9 +1046,34 @@ pub const Tls13Backend = struct {
     /// EncryptedExtensions + Certificate + CertificateVerify + Finished at the
     /// Handshake level, followed by the 1-RTT secrets.
     fn sendServerFlight(self: *Tls13Backend, sink: *EventSink) HandshakeError!void {
-        if (!self.identity_present) return error.InvalidHandshakeState;
-        const identity = &self.identity;
         const schedule = &self.schedule.?;
+
+        // Resolve the credential provider — an external one, or the fixed
+        // identity wrapped in the identical production contract — and select a
+        // credential for the negotiated parameters. There is one path.
+        var fixed_provider: credentials.FixedCredentialProvider = undefined;
+        var using_fixed = false;
+        const provider = if (self.external_provider) |p| p else blk: {
+            if (!self.identity_present) return self.failCredential(.no_credential_available);
+            fixed_provider = credentials.FixedCredentialProvider.init(self.identity);
+            using_fixed = true;
+            break :blk fixed_provider.provider();
+        };
+        // Wipe the fixed key material (stack copy and stored identity) on the
+        // way out, whatever the outcome.
+        defer if (using_fixed) {
+            fixed_provider.deinit();
+            self.wipeIdentity();
+        };
+
+        var selection = self.serverSelectionContext();
+        var credential: credentials.SelectedCredential = undefined;
+        provider.selectCredential(&selection, &credential) catch |err|
+            return self.failCredential(credentials.classifySelectError(err));
+        // The selected handle is released exactly once — after the flight is
+        // signed, or immediately on any failure below (cancellation included).
+        defer credential.release();
+
         var buf: [max_message_len]u8 = undefined;
         var w = Writer{ .buf = &buf };
 
@@ -1012,47 +1100,45 @@ pub const Tls13Backend = struct {
         w.patch(3, ee_len);
         const encrypted_extensions = buf[0..w.len];
 
-        // Certificate.
+        // Certificate: the selected credential's public DER chain. The views
+        // are borrowed for this call only and never retained past it.
+        const chain = credential.certificateChain();
+        if (chain.count() == 0) return self.failCredential(.malformed_credential_chain);
         const cert_start = w.len;
         try w.u8_(@intFromEnum(MessageType.certificate));
         const cert_len = try w.reserve(3);
         try w.u8_(0); // certificate_request_context
         const list_len = try w.reserve(3);
-        const entry_len = try w.reserve(3);
-        try w.bytes(identity.certificate_der);
-        w.patch(3, entry_len);
-        try w.u16_(0); // per-certificate extensions
+        for (chain.entries) |entry| {
+            if (entry.len == 0 or entry.len > max_certificate_len) return self.failCredential(.malformed_credential_chain);
+            const entry_len = try w.reserve(3);
+            try w.bytes(entry);
+            w.patch(3, entry_len);
+            try w.u16_(0); // per-certificate extensions
+        }
         w.patch(3, list_len);
         w.patch(3, cert_len);
         const certificate = buf[cert_start..w.len];
 
-        // CertificateVerify signs the transcript through Certificate.
+        // CertificateVerify signs the transcript through Certificate. Signing
+        // goes through the credential's opaque handle into a bounded, caller-
+        // owned scratch buffer; the private key never enters the engine.
         self.core.recordSent(encrypted_extensions) catch |err| return mapCoreError(err);
         self.core.recordSent(certificate) catch |err| return mapCoreError(err);
         const content = certificateVerifyContent(.server, self.core.transcriptHash());
         const verify_start = w.len;
         try w.u8_(@intFromEnum(MessageType.certificate_verify));
         const verify_len = try w.reserve(3);
-        try w.u16_(identity.signatureAlgorithm());
-        switch (identity.key) {
-            .ed25519 => {
-                const key_pair = &identity.key.ed25519;
-                const signature = key_pair.sign(content.slice(), null) catch
-                    return error.SecretExportFailed;
-                try w.u16_(Ed25519.Signature.encoded_length);
-                try w.bytes(&signature.toBytes());
-            },
-            .ecdsa_p256 => {
-                const key_pair = &identity.key.ecdsa_p256;
-                const signature = key_pair.sign(content.slice(), null) catch
-                    return error.SecretExportFailed;
-                var der_buf: [EcdsaP256.Signature.der_encoded_length_max]u8 = undefined;
-                const der = signature.toDer(&der_buf);
-                try w.u16_(@intCast(der.len));
-                try w.bytes(der);
-            },
-        }
-        self.wipeIdentity();
+        try w.u16_(credential.scheme.code());
+        const sig_len_slot = try w.reserve(2);
+        var sig_scratch: [max_signature_len]u8 = undefined;
+        // Signature scratch is transcript-derived, not secret key material, but
+        // wipe it after use as a matter of hygiene.
+        defer crypto.secureZero(u8, &sig_scratch);
+        const sig_written = credential.sign(content.slice(), &sig_scratch) catch |err|
+            return self.failCredential(credentials.classifySignError(err));
+        try w.bytes(sig_scratch[0..sig_written]);
+        w.patch(2, sig_len_slot);
         w.patch(3, verify_len);
         const certificate_verify = buf[verify_start..w.len];
         self.core.recordSent(certificate_verify) catch |err| return mapCoreError(err);
@@ -1176,41 +1262,9 @@ fn certificateVerifyContent(signer: Role, transcript_hash: [hash_len]u8) Certifi
     return content;
 }
 
-/// Deterministic local server identity (self-signed Ed25519,
-/// CN=tardigrade.test, valid to 2036; generated with openssl, see
-/// src/quic/testdata/). For unit tests and local smoke harnesses only — never
-/// a production identity.
-pub const testdata = struct {
-    const certificate_bytes = hexBytes(
-        "308201483081fba00302010202146c8bf2251dd4fceda024f44e82cbfaeaa9da082a300506032b6570031a3118301606035504030c0f746172646967726164652e74657374301e170d3236303731303033303535325a170d3336303730373033303535325a301a3118301606035504030c0f746172646967726164652e74657374302a300506032b65700321007487dbf1f35e41d63ee2c907330660439af5fa63ca7f70a9f1484c12f8d4666fa3533051301d0603551d0e0416041494fd70298293687f12c2f46d00fba451fd3c6143301f0603551d2304183016801494fd70298293687f12c2f46d00fba451fd3c6143300f0603551d130101ff040530030101ff300506032b657003410070eb127814436ca43322b688fd6643507d5c2346f7c176a155ddf5350db941acccefceb29f0ea66e9842159f2fece42b67d935b255f2a4224df68182b646e201",
-    );
-    const private_key_bytes = hexBytes(
-        "302e020100300506032b65700422042099132d0957fdbc8235285b25bd8dd5101d7941408adb068ded6de7ada191251f",
-    );
-
-    pub const certificate_der: []const u8 = &certificate_bytes;
-    pub const private_key_pkcs8_der: []const u8 = &private_key_bytes;
-};
-
-fn hexBytes(comptime hex: []const u8) [hex.len / 2]u8 {
-    var bytes: [hex.len / 2]u8 = undefined;
-    _ = std.fmt.hexToBytes(&bytes, hex) catch unreachable;
-    return bytes;
-}
-
-test "TLS-owned identity fixture loads without QUIC or OpenSSL" {
-    const identity = try Identity.initPkcs8(testdata.certificate_der, testdata.private_key_pkcs8_der);
-    const parsed = try (Certificate{ .buffer = testdata.certificate_der, .index = 0 }).parse();
-    try std.testing.expect(parsed.pub_key_algo == .curveEd25519);
-    try std.testing.expectEqualSlices(u8, parsed.pubKey(), &identity.key.ed25519.public_key.toBytes());
-}
-
-test "TLS-owned identity parser rejects malformed PKCS#8" {
-    try std.testing.expectError(
-        error.InvalidPrivateKey,
-        Identity.initPkcs8(testdata.certificate_der, testdata.private_key_pkcs8_der[0 .. testdata.private_key_pkcs8_der.len - 1]),
-    );
-}
+/// Deterministic local server identity fixture — see `credentials.testdata`.
+/// Re-exported here so existing callers and tests keep their spelling.
+pub const testdata = credentials.testdata;
 
 test "TLS-owned backend teardown clears transcript-adjacent and peer scratch" {
     var backend = Tls13Backend.initClient(
@@ -1220,16 +1274,19 @@ test "TLS-owned backend teardown clears transcript-adjacent and peer scratch" {
     );
     backend.core.transcript.update("transcript-adjacent state");
     @memset(&backend.expected_client_verify, 0xa5);
-    @memset(&backend.peer_certificate, 0x5a);
-    backend.peer_certificate_len = 32;
+    @memset(&backend.peer_chain, 0x5a);
+    backend.peer_chain_entries[0] = .{ .start = 0, .len = 32 };
+    backend.peer_chain_count = 1;
+    backend.peer_chain_len = 32;
     backend.deinit();
 
     try std.testing.expect(std.mem.allEqual(u8, &backend.expected_client_verify, 0));
-    try std.testing.expect(std.mem.allEqual(u8, &backend.peer_certificate, 0));
+    try std.testing.expect(std.mem.allEqual(u8, &backend.peer_chain, 0));
     try std.testing.expect(std.mem.allEqual(u8, &backend.entropy.key_share_seed, 0));
     try std.testing.expect(!backend.key_pair_present);
     try std.testing.expect(std.mem.allEqual(u8, std.mem.asBytes(&backend.key_pair), 0));
-    try std.testing.expectEqual(@as(usize, 0), backend.peer_certificate_len);
+    try std.testing.expectEqual(@as(usize, 0), backend.peer_chain_count);
+    try std.testing.expectEqual(@as(usize, 0), backend.peer_chain_len);
     try std.testing.expectEqual(tls_handshake_codec.HandshakeLifecycle.failed, backend.core.handshake_lifecycle);
 }
 

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -249,6 +249,11 @@ pub const Tls13Backend = struct {
     server_name: [max_server_name_len]u8 = undefined,
     server_name_len: usize = 0,
     server_name_present: bool = false,
+    /// A configured (client) server name that did not fit the bounded buffer.
+    /// Rather than truncate it — which would emit SNI for a different host and
+    /// hand the wrong name to the verifier — construction records the overflow
+    /// and `start` fails closed before any ClientHello is emitted.
+    server_name_overflow: bool = false,
     peer_transport_extension: [max_transport_extension_len]u8 = undefined,
     peer_transport_extension_len: usize = 0,
     peer_transport_extension_pending: bool = false,
@@ -365,12 +370,16 @@ pub const Tls13Backend = struct {
             .core = tls_handshake_codec.Core.init(.client),
         };
         if (options.server_name) |name| {
-            // A name too long for the bounded buffer is a caller error; clamp
-            // defensively (callers pass real hostnames, well under the bound).
-            const n = @min(name.len, self.server_name.len);
-            @memcpy(self.server_name[0..n], name[0..n]);
-            self.server_name_len = n;
-            self.server_name_present = true;
+            // A name too long for the bounded buffer is a caller error. Record
+            // the overflow and reject at `start` rather than truncating it to a
+            // different host (see `server_name_overflow`).
+            if (name.len > self.server_name.len) {
+                self.server_name_overflow = true;
+            } else {
+                @memcpy(self.server_name[0..name.len], name);
+                self.server_name_len = name.len;
+                self.server_name_present = true;
+            }
         }
         return self;
     }
@@ -407,7 +416,19 @@ pub const Tls13Backend = struct {
             .startFn = startImpl,
             .receiveFn = receiveImpl,
             .deinitFn = deinitImpl,
+            .authPendingFn = authPendingImpl,
+            .resumeFn = resumeImpl,
         };
+    }
+
+    fn authPendingImpl(ptr: *anyopaque) bool {
+        const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
+        return self.authPending();
+    }
+
+    fn resumeImpl(ptr: *anyopaque, sink: *EventSink) HandshakeError!void {
+        const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
+        return self.resumeAuth(sink);
     }
 
     pub fn alpn(self: *const Tls13Backend) []const u8 {
@@ -506,6 +527,10 @@ pub const Tls13Backend = struct {
         std.debug.assert(role == self.role);
         std.debug.assert(self.core.handshake_lifecycle == .idle);
         try self.profile.validate();
+        // A configured client server name that overflowed the bound is a caller
+        // configuration error; fail closed before any lifecycle or transcript
+        // advance rather than emitting SNI for a truncated (wrong) host.
+        if (self.server_name_overflow) return error.InvalidHandshakeState;
         self.core.start() catch |err| return mapCoreError(err);
         switch (self.role) {
             .client => {
@@ -594,6 +619,7 @@ pub const Tls13Backend = struct {
             error.NoApplicableCredential => error.NoApplicableCredential,
             error.CredentialProviderFailed => error.CredentialProviderFailed,
             error.ClientCertificateRequired => error.ClientCertificateRequired,
+            error.DecryptError => error.DecryptError,
         };
     }
 
@@ -973,11 +999,11 @@ pub const Tls13Backend = struct {
 
         // The signature covers the transcript through Certificate (RFC 8446
         // §4.4.3) — before this message is added. Proof of key possession is
-        // transcript crypto, not PKI policy, so it stays in the engine; a
-        // failure is peer-originated (bad_certificate).
+        // transcript crypto, not PKI policy: a failure is a `decrypt_error`, a
+        // distinct crypto failure from a trust rejection, so it does NOT emit a
+        // certificate-invalid (bad_certificate) verdict — it fails directly.
         const content = certificateVerifyContent(signer_role, transcript_before);
         if (!self.checkProofOfPossession(algorithm, signature, content.slice())) {
-            try sink.emitCertificate(.invalid);
             return self.failCredential(.certificate_verify_invalid);
         }
 
@@ -1164,6 +1190,27 @@ pub const Tls13Backend = struct {
         var owned = credential != null;
         errdefer if (owned) if (credential) |c| c.release();
 
+        // Validate the credential's chain and its exact encoded size up front,
+        // before any transcript mutation (`recordSent`) or output emission, so a
+        // credential that cannot be serialized within bounds fails closed rather
+        // than being partially recorded or emitted.
+        if (credential) |c| {
+            const chain = c.certificateChain();
+            if (chain.count() == 0 or chain.count() > credentials.max_chain_entries)
+                return self.failCredential(.malformed_credential_chain);
+            var encoded_len: usize = 0;
+            for (chain.entries) |entry| {
+                if (entry.len == 0 or entry.len > max_certificate_len)
+                    return self.failCredential(.malformed_credential_chain);
+                // CertificateEntry overhead: 3-byte cert_data length + 2-byte
+                // extensions length.
+                encoded_len = std.math.add(usize, encoded_len, entry.len + 5) catch
+                    return self.failCredential(.malformed_credential_chain);
+                if (encoded_len > max_message_len)
+                    return self.failCredential(.malformed_credential_chain);
+            }
+        }
+
         var buf: [max_message_len]u8 = undefined;
         var w = Writer{ .buf = &buf };
         try w.u8_(@intFromEnum(MessageType.certificate));
@@ -1171,12 +1218,7 @@ pub const Tls13Backend = struct {
         try w.u8_(0); // certificate_request_context: empty (echoes the request)
         const list_len = try w.reserve(3);
         if (credential) |c| {
-            const chain = c.certificateChain();
-            if (chain.count() == 0 or chain.count() > credentials.max_chain_entries)
-                return self.failCredential(.malformed_credential_chain);
-            for (chain.entries) |entry| {
-                if (entry.len == 0 or entry.len > max_certificate_len)
-                    return self.failCredential(.malformed_credential_chain);
+            for (c.certificateChain().entries) |entry| {
                 const entry_len = try w.reserve(3);
                 try w.bytes(entry);
                 w.patch(3, entry_len);

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -288,7 +288,7 @@ pub const Tls13Backend = struct {
     pending_signature: [max_signature_len]u8 = undefined,
 
     const Slice = struct { start: usize, len: usize };
-    const PendingStage = enum { server_select, server_sign, client_verify };
+    const PendingStage = enum { server_select, server_sign, peer_verify };
 
     /// Options for a client that verifies its peer through an external verifier:
     /// the exact intended server name (emitted as SNI and handed to the
@@ -383,6 +383,14 @@ pub const Tls13Backend = struct {
         std.debug.assert(self.role == .server);
         self.client_auth = mode;
         self.external_verifier = verifier;
+        // The policy handed to the client-certificate verifier: `required`
+        // demands a valid client certificate; `optional` explicitly tolerates an
+        // unverified/absent one.
+        self.auth_policy = switch (mode) {
+            .disabled => self.auth_policy,
+            .required => .{ .require_peer_authentication = true },
+            .optional => .{ .allow_unverified_peer = true },
+        };
     }
 
     /// Client: supply the credential provider for the client's own certificate,
@@ -542,7 +550,12 @@ pub const Tls13Backend = struct {
     fn expectedLevel(kind: MessageType) HandshakeError!EncryptionLevel {
         return switch (kind) {
             .client_hello, .server_hello => .initial,
-            .encrypted_extensions, .certificate, .certificate_verify, .finished => .handshake,
+            .encrypted_extensions,
+            .certificate_request,
+            .certificate,
+            .certificate_verify,
+            .finished,
+            => .handshake,
             .new_session_ticket => .application,
             else => error.UnexpectedHandshakeMessage,
         };
@@ -567,6 +580,7 @@ pub const Tls13Backend = struct {
             // the codec core, but they are part of the shared error set.
             error.NoApplicableCredential => error.NoApplicableCredential,
             error.CredentialProviderFailed => error.CredentialProviderFailed,
+            error.ClientCertificateRequired => error.ClientCertificateRequired,
         };
     }
 
@@ -605,11 +619,12 @@ pub const Tls13Backend = struct {
             .client_hello => try self.onClientHello(body, sink),
             .server_hello => try self.onServerHello(body, sink),
             .encrypted_extensions => try self.onEncryptedExtensions(body, sink),
+            .certificate_request => try self.onCertificateRequest(body),
             .certificate => try self.onCertificate(body),
             .certificate_verify => try self.onCertificateVerify(transcript_before, body, sink),
             .finished => switch (self.role) {
                 .client => try self.onServerFinished(transcript_before, body, sink),
-                .server => try self.onClientFinished(body, sink),
+                .server => try self.onClientFinished(transcript_before, body, sink),
             },
             else => return error.UnexpectedHandshakeMessage,
         }
@@ -800,6 +815,48 @@ pub const Tls13Backend = struct {
         if (self.profile.extensionType() != null and !transport_extension_seen) return error.MissingTransportExtension;
     }
 
+    /// Client: a server CertificateRequest (RFC 8446 §4.3.2) asking us to
+    /// authenticate at handshake time. `core.acceptReceived` already recorded
+    /// that a request arrived and updated the transcript; here we validate the
+    /// framing and capture the server's accepted signature schemes so the client
+    /// credential provider can select a compatible credential. In a handshake
+    /// (not post-handshake) CertificateRequest the context is zero length.
+    fn onCertificateRequest(self: *Tls13Backend, body: []const u8) HandshakeError!void {
+        std.debug.assert(self.role == .client);
+        var r = Reader{ .bytes = body };
+        if ((try r.slice(try r.u8_())).len != 0) return error.IllegalParameter; // context must be empty
+
+        // Reuse the peer-signature-scheme vector (unused on the client until
+        // now) to remember the schemes the server will accept from us.
+        self.peer_sig_scheme_count = 0;
+        var saw_signature_algorithms = false;
+        var guard = ExtensionGuard{};
+        var extensions = Reader{ .bytes = try r.slice(try r.u16_()) };
+        try r.expectEnd();
+        while (extensions.remaining() > 0) {
+            const ext_id = try extensions.u16_();
+            try guard.check(ext_id);
+            var ext = Reader{ .bytes = try extensions.slice(try extensions.u16_()) };
+            switch (ext_id) {
+                ext_signature_algorithms => {
+                    saw_signature_algorithms = true;
+                    var algorithms = Reader{ .bytes = try ext.slice(try ext.u16_()) };
+                    while (algorithms.remaining() > 0) {
+                        const scheme = try algorithms.u16_();
+                        if (self.peer_sig_scheme_count >= self.peer_sig_schemes.len) return error.MalformedHandshake;
+                        self.peer_sig_schemes[self.peer_sig_scheme_count] = scheme;
+                        self.peer_sig_scheme_count += 1;
+                    }
+                    try ext.expectEnd();
+                },
+                else => {},
+            }
+        }
+        // signature_algorithms is mandatory in a CertificateRequest
+        // (RFC 8446 §4.3.2); its absence is a malformed/missing peer extension.
+        if (!saw_signature_algorithms or self.peer_sig_scheme_count == 0) return error.MalformedHandshake;
+    }
+
     fn onCertificate(self: *Tls13Backend, body: []const u8) HandshakeError!void {
         var r = Reader{ .bytes = body };
         if (try r.u8_() != 0) return error.MalformedHandshake; // certificate_request_context
@@ -814,18 +871,37 @@ pub const Tls13Backend = struct {
         // intermediate, must be non-empty and within `max_certificate_len`.
         self.peer_chain_count = 0;
         self.peer_chain_len = 0;
-        var first = true;
+        var empty = true;
         while (list.remaining() > 0) {
             const entry_len = try list.u24_();
             if (entry_len == 0 or entry_len > max_certificate_len) return self.failCredential(.invalid_peer_certificate_chain);
             const entry = try list.slice(entry_len);
             _ = try list.slice(try list.u16_()); // per-certificate extensions
             self.appendPeerCertificate(entry) catch return self.failCredential(.invalid_peer_certificate_chain);
-            first = false;
+            empty = false;
         }
-        // An empty CertificateList is only legal for client auth (an empty
-        // client Certificate); a server that presents none is malformed here.
-        if (first and self.role == .client) return self.failCredential(.invalid_peer_certificate_chain);
+
+        // Role-aware: this is the *client's* Certificate when we are the server
+        // (handshake-time client authentication, #334), otherwise the server's.
+        switch (self.role) {
+            .server => {
+                // An empty client Certificate declines authentication. In
+                // `required` mode that fails closed (certificate_required);
+                // in `optional` mode the server proceeds expecting the client
+                // Finished (no CertificateVerify follows an empty certificate).
+                if (empty) {
+                    if (self.client_auth == .required) return self.failCredential(.client_certificate_required);
+                    self.core.clientCertificateWasEmpty(true);
+                    return;
+                }
+                self.core.clientCertificateWasEmpty(false);
+            },
+            .client => {
+                // A server that presents no certificate is malformed: server
+                // authentication is mandatory in this profile.
+                if (empty) return self.failCredential(.invalid_peer_certificate_chain);
+            },
+        }
     }
 
     /// Copy one peer DER certificate into the bounded chain storage, recording
@@ -875,11 +951,18 @@ pub const Tls13Backend = struct {
         const signature = try r.slice(try r.u16_());
         try r.expectEnd();
 
+        // Role-aware: verifying the *server's* CertificateVerify (we are the
+        // client) or the *client's* (we are the server, handshake-time client
+        // authentication, #334). The signer is always the peer, so the context
+        // string names the peer's role, and the verification context's `role`
+        // is our own.
+        const signer_role: Role = if (self.role == .client) .server else .client;
+
         // The signature covers the transcript through Certificate (RFC 8446
         // §4.4.3) — before this message is added. Proof of key possession is
         // transcript crypto, not PKI policy, so it stays in the engine; a
         // failure is peer-originated (bad_certificate).
-        const content = certificateVerifyContent(.server, transcript_before);
+        const content = certificateVerifyContent(signer_role, transcript_before);
         if (!self.checkProofOfPossession(algorithm, signature, content.slice())) {
             try sink.emitCertificate(.invalid);
             return self.failCredential(.certificate_verify_invalid);
@@ -895,7 +978,7 @@ pub const Tls13Backend = struct {
             break :blk verifier_storage.verifier();
         };
         const context = credentials.VerificationContext{
-            .role = .client,
+            .role = self.role,
             .server_name = self.serverNameSlice(),
             .chain = self.peerChainView(&views),
             .negotiated_version = tls13_version,
@@ -907,14 +990,14 @@ pub const Tls13Backend = struct {
         // (an async Web-PKI/OCSP lookup); park the latter and resume later.
         switch (verifier.verifyPeer(&context) catch |err|
             return self.failCredential(credentials.classifyVerifyError(err))) {
-            .complete => |verdict| return self.applyClientVerdict(verdict, sink),
-            .pending => |op| return self.parkAuth(op, .client_verify),
+            .complete => |verdict| return self.applyPeerVerdict(verdict, sink),
+            .pending => |op| return self.parkAuth(op, .peer_verify),
         }
     }
 
     /// Apply a peer-verification verdict: emit the certificate state and fail
     /// closed on rejection. Reachable synchronously and after resume.
-    fn applyClientVerdict(self: *Tls13Backend, verdict: credentials.Verdict, sink: *EventSink) HandshakeError!void {
+    fn applyPeerVerdict(self: *Tls13Backend, verdict: credentials.Verdict, sink: *EventSink) HandshakeError!void {
         const state: CertificateState = switch (verdict) {
             .accepted => .valid,
             .not_checked => .not_checked,
@@ -966,29 +1049,162 @@ pub const Tls13Backend = struct {
             return error.MalformedHandshake;
         }
 
-        // 1-RTT secrets exist from the transcript through server Finished.
+        // 1-RTT secrets exist from the transcript through server Finished,
+        // independent of any client certificate flight that follows.
         const finished_hash = self.core.transcriptHash();
         var app = schedule.applicationSecrets(finished_hash);
         defer app.wipe();
         try self.emitSecret(sink, .application, .write, &app.client);
         try self.emitSecret(sink, .application, .read, &app.server);
 
-        // Client Finished covers the transcript including server Finished.
+        // When the server requested handshake-time client authentication
+        // (#334) the client answers with Certificate, an optional
+        // CertificateVerify, and Finished; otherwise it sends just Finished.
+        if (self.core.client_certificate_requested) {
+            try self.sendClientAuthFlight(sink);
+        } else {
+            try self.sendClientFinished(finished_hash, sink);
+        }
+
+        try self.emitDiscardKeys(sink, .handshake);
+        try sink.emitHandshakeComplete();
+        self.finish();
+    }
+
+    /// Emit a lone client Finished (no client authentication) covering the
+    /// transcript through the server Finished.
+    fn sendClientFinished(self: *Tls13Backend, transcript_hash: [hash_len]u8, sink: *EventSink) HandshakeError!void {
+        const schedule = &self.schedule.?;
         var buf: [4 + hash_len]u8 = undefined;
         var w = Writer{ .buf = &buf };
         try w.u8_(@intFromEnum(MessageType.finished));
         const message_len = try w.reserve(3);
-        var client_verify = KeySchedule.verifyData(&schedule.client_handshake_traffic, finished_hash);
+        var client_verify = KeySchedule.verifyData(&schedule.client_handshake_traffic, transcript_hash);
         defer crypto.secureZero(u8, &client_verify);
         try w.bytes(&client_verify);
         w.patch(3, message_len);
         const message = buf[0..w.len];
         self.core.recordSent(message) catch |err| return mapCoreError(err);
         try sink.emitCrypto(.handshake, message);
+    }
 
-        try self.emitDiscardKeys(sink, .handshake);
-        try sink.emitHandshakeComplete();
-        self.finish();
+    /// The immutable selection context for choosing the client's own
+    /// credential, honoring the schemes the server offered in its
+    /// CertificateRequest and the intended server name.
+    fn clientSelectionContext(self: *const Tls13Backend) credentials.SelectionContext {
+        return .{
+            .role = .client,
+            .server_name = self.serverNameSlice(),
+            .peer_signature_schemes = self.peer_sig_schemes[0..self.peer_sig_scheme_count],
+            .negotiated_version = tls13_version,
+            .cipher_suite = cipher_tls_aes_128_gcm_sha256,
+            .application_protocol = self.alpn(),
+            .auth_policy = self.auth_policy,
+        };
+    }
+
+    /// Handshake-time client authentication flight (#334, synchronous):
+    /// Certificate, an optional CertificateVerify, and Finished, all emitted as
+    /// one handshake-epoch chunk. The client Finished MAC covers the transcript
+    /// through the last preceding message — its CertificateVerify, or its
+    /// Certificate when it declines with an empty one. Asynchronous client
+    /// credential selection and signing are a later checkpoint.
+    fn sendClientAuthFlight(self: *Tls13Backend, sink: *EventSink) HandshakeError!void {
+        const schedule = &self.schedule.?;
+        self.core.beginClientCertificateFlight();
+
+        // Resolve the local client credential. With no provider the client
+        // legitimately declines with an empty Certificate (no CertificateVerify
+        // follows). A configured provider selects against the schemes the
+        // server advertised in its CertificateRequest.
+        var credential: ?credentials.SelectedCredential = null;
+        // The selected handle is released exactly once, on every exit path.
+        defer if (credential) |c| c.release();
+        if (self.external_provider) |provider| {
+            var selection = self.clientSelectionContext();
+            switch (provider.selectCredential(&selection) catch |err|
+                return self.failCredential(credentials.classifySelectError(err))) {
+                .complete => |c| credential = c,
+                // Asynchronous client credential selection is deferred (#334);
+                // a provider that suspends here is unsupported for now.
+                .pending => |op| {
+                    op.cancel();
+                    op.release();
+                    return self.failCredential(.provider_internal_failure);
+                },
+            }
+            // The provider must return a scheme the server actually offered,
+            // else the CertificateVerify would carry an unadvertised algorithm.
+            if (!selection.offersScheme(credential.?.scheme))
+                return self.failCredential(.invalid_callback_behavior);
+        }
+
+        var buf: [max_message_len]u8 = undefined;
+        var w = Writer{ .buf = &buf };
+
+        // Certificate: the credential's validated chain, or an empty list when
+        // declining. The empty context echoes the (empty) request context.
+        try w.u8_(@intFromEnum(MessageType.certificate));
+        const cert_len = try w.reserve(3);
+        try w.u8_(0); // certificate_request_context
+        const list_len = try w.reserve(3);
+        if (credential) |c| {
+            const chain = c.certificateChain();
+            if (chain.count() == 0 or chain.count() > credentials.max_chain_entries)
+                return self.failCredential(.malformed_credential_chain);
+            for (chain.entries) |entry| {
+                if (entry.len == 0 or entry.len > max_certificate_len)
+                    return self.failCredential(.malformed_credential_chain);
+                const entry_len = try w.reserve(3);
+                try w.bytes(entry);
+                w.patch(3, entry_len);
+                try w.u16_(0); // per-certificate extensions
+            }
+        }
+        w.patch(3, list_len);
+        w.patch(3, cert_len);
+        self.core.recordSent(buf[0..w.len]) catch |err| return mapCoreError(err);
+
+        // CertificateVerify, only when a certificate was actually presented; it
+        // signs the transcript through the client Certificate (RFC 8446 §4.4.3)
+        // with the client context string.
+        if (credential) |c| {
+            const content = certificateVerifyContent(.client, self.core.transcriptHash());
+            const sig_len = switch (c.sign(content.slice(), &self.pending_signature) catch |err|
+                return self.failCredential(credentials.classifySignError(err))) {
+                .complete => |len| len,
+                // Asynchronous client signing is deferred (#334).
+                .pending => |op| {
+                    op.cancel();
+                    op.release();
+                    return self.failCredential(.signing_provider_failure);
+                },
+            };
+            if (sig_len > self.pending_signature.len) return self.failCredential(.signature_output_overflow);
+
+            const cv_start = w.len;
+            try w.u8_(@intFromEnum(MessageType.certificate_verify));
+            const verify_len = try w.reserve(3);
+            try w.u16_(c.scheme.code());
+            const sig_slot = try w.reserve(2);
+            try w.bytes(self.pending_signature[0..sig_len]);
+            w.patch(2, sig_slot);
+            w.patch(3, verify_len);
+            crypto.secureZero(u8, &self.pending_signature);
+            self.core.recordSent(buf[cv_start..w.len]) catch |err| return mapCoreError(err);
+        }
+
+        // Finished over the transcript through the last message above.
+        const finished_start = w.len;
+        try w.u8_(@intFromEnum(MessageType.finished));
+        const finished_len = try w.reserve(3);
+        var client_verify = KeySchedule.verifyData(&schedule.client_handshake_traffic, self.core.transcriptHash());
+        defer crypto.secureZero(u8, &client_verify);
+        try w.bytes(&client_verify);
+        w.patch(3, finished_len);
+        self.core.recordSent(buf[finished_start..w.len]) catch |err| return mapCoreError(err);
+
+        try sink.emitCrypto(.handshake, buf[0..w.len]);
     }
 
     // -----------------------------------------------------------------------
@@ -1375,9 +1591,10 @@ pub const Tls13Backend = struct {
         defer app.wipe();
         try self.emitSecret(sink, .application, .read, &app.client);
         try self.emitSecret(sink, .application, .write, &app.server);
-        var client_verify = KeySchedule.verifyData(&schedule.client_handshake_traffic, finished_hash);
-        defer crypto.secureZero(u8, &client_verify);
-        self.expected_client_verify = client_verify;
+        // The client Finished MAC is (re)computed when the client Finished
+        // arrives, over the transcript actually preceding it — which, under
+        // handshake-time client authentication, includes the client's own
+        // Certificate and CertificateVerify. See `onClientFinished`.
     }
 
     // -----------------------------------------------------------------------
@@ -1421,9 +1638,9 @@ pub const Tls13Backend = struct {
                 self.pending_credential = null;
                 return self.serverFinishFlight(credential, completion.signature_len, sink);
             },
-            .client_verify => {
+            .peer_verify => {
                 if (completion != .verdict) return self.failCredential(.verifier_internal_failure);
-                return self.applyClientVerdict(completion.verdict, sink);
+                return self.applyPeerVerdict(completion.verdict, sink);
             },
         }
     }
@@ -1434,7 +1651,7 @@ pub const Tls13Backend = struct {
         return switch (stage) {
             .server_select => .provider_internal_failure,
             .server_sign => .signing_provider_failure,
-            .client_verify => .verifier_internal_failure,
+            .peer_verify => .verifier_internal_failure,
         };
     }
 
@@ -1452,9 +1669,16 @@ pub const Tls13Backend = struct {
         }
     }
 
-    fn onClientFinished(self: *Tls13Backend, body: []const u8, sink: *EventSink) HandshakeError!void {
+    fn onClientFinished(self: *Tls13Backend, transcript_before: [hash_len]u8, body: []const u8, sink: *EventSink) HandshakeError!void {
+        const schedule = &self.schedule.?;
         if (body.len != hash_len) return error.MalformedHandshake;
-        if (!crypto.timing_safe.eql([hash_len]u8, self.expected_client_verify, body[0..hash_len].*)) {
+        // Recompute over the transcript that actually precedes this Finished:
+        // with handshake-time client authentication it includes the client's
+        // Certificate and CertificateVerify, so the MAC cannot be fixed when the
+        // server flight was sent.
+        var expected = KeySchedule.verifyData(&schedule.client_handshake_traffic, transcript_before);
+        defer crypto.secureZero(u8, &expected);
+        if (!crypto.timing_safe.eql([hash_len]u8, expected, body[0..hash_len].*)) {
             return error.MalformedHandshake;
         }
         // Client Finished confirms the handshake for the server (RFC 8446 §4.4.4).

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -288,7 +288,7 @@ pub const Tls13Backend = struct {
     pending_signature: [max_signature_len]u8 = undefined,
 
     const Slice = struct { start: usize, len: usize };
-    const PendingStage = enum { server_select, server_sign, peer_verify };
+    const PendingStage = enum { server_select, server_sign, client_select, client_sign, peer_verify };
 
     /// Options for a client that verifies its peer through an external verifier:
     /// the exact intended server name (emitted as SNI and handed to the
@@ -529,7 +529,20 @@ pub const Tls13Backend = struct {
             },
         };
         input.append(bytes) catch |err| return mapCoreError(err);
+        try self.drainInput(input, level, sink);
+    }
 
+    /// Consume whole handshake messages from a reassembly buffer, dispatching
+    /// each. Stops early when an async authentication operation parks (so the
+    /// suspend point is never crossed) or when the handshake completes or fails.
+    /// Shared by `receiveImpl` and `resumeAuth`, so buffered messages behind a
+    /// suspend point are drained automatically once the operation resolves.
+    fn drainInput(
+        self: *Tls13Backend,
+        input: *tls_handshake_codec.Reassembler(max_message_len + 4),
+        level: EncryptionLevel,
+        sink: *EventSink,
+    ) HandshakeError!void {
         while (input.peek() catch |err| return mapCoreError(err)) |message| {
             if (level != try expectedLevel(message.kind)) return error.UnexpectedTransportEpoch;
             const transcript_before = self.core.transcriptHash();
@@ -1059,16 +1072,15 @@ pub const Tls13Backend = struct {
 
         // When the server requested handshake-time client authentication
         // (#334) the client answers with Certificate, an optional
-        // CertificateVerify, and Finished; otherwise it sends just Finished.
+        // CertificateVerify, and Finished. That flight owns its own completion
+        // because asynchronous credential selection or signing may suspend it
+        // mid-way; on resume it finishes and completes the handshake.
         if (self.core.client_certificate_requested) {
-            try self.sendClientAuthFlight(sink);
-        } else {
-            try self.sendClientFinished(finished_hash, sink);
+            return self.beginClientAuthFlight(sink);
         }
 
-        try self.emitDiscardKeys(sink, .handshake);
-        try sink.emitHandshakeComplete();
-        self.finish();
+        try self.sendClientFinished(finished_hash, sink);
+        try self.completeClientHandshake(sink);
     }
 
     /// Emit a lone client Finished (no client authentication) covering the
@@ -1088,6 +1100,14 @@ pub const Tls13Backend = struct {
         try sink.emitCrypto(.handshake, message);
     }
 
+    /// Terminal steps shared by every client completion path: discard the
+    /// handshake epoch, signal completion, and wipe the key schedule.
+    fn completeClientHandshake(self: *Tls13Backend, sink: *EventSink) HandshakeError!void {
+        try self.emitDiscardKeys(sink, .handshake);
+        try sink.emitHandshakeComplete();
+        self.finish();
+    }
+
     /// The immutable selection context for choosing the client's own
     /// credential, honoring the schemes the server offered in its
     /// CertificateRequest and the intended server name.
@@ -1103,50 +1123,52 @@ pub const Tls13Backend = struct {
         };
     }
 
-    /// Handshake-time client authentication flight (#334, synchronous):
-    /// Certificate, an optional CertificateVerify, and Finished, all emitted as
-    /// one handshake-epoch chunk. The client Finished MAC covers the transcript
-    /// through the last preceding message — its CertificateVerify, or its
-    /// Certificate when it declines with an empty one. Asynchronous client
-    /// credential selection and signing are a later checkpoint.
-    fn sendClientAuthFlight(self: *Tls13Backend, sink: *EventSink) HandshakeError!void {
-        const schedule = &self.schedule.?;
+    /// Begin the handshake-time client authentication flight (#334):
+    /// Certificate, an optional CertificateVerify, and Finished. With no
+    /// provider the client declines with an empty Certificate. A configured
+    /// provider selects against the schemes the server advertised in its
+    /// CertificateRequest; selection may complete synchronously or suspend
+    /// (`client_select`), in which case the flight resumes from `resumeAuth`.
+    fn beginClientAuthFlight(self: *Tls13Backend, sink: *EventSink) HandshakeError!void {
         self.core.beginClientCertificateFlight();
-
-        // Resolve the local client credential. With no provider the client
-        // legitimately declines with an empty Certificate (no CertificateVerify
-        // follows). A configured provider selects against the schemes the
-        // server advertised in its CertificateRequest.
-        var credential: ?credentials.SelectedCredential = null;
-        // The selected handle is released exactly once, on every exit path.
-        defer if (credential) |c| c.release();
-        if (self.external_provider) |provider| {
-            var selection = self.clientSelectionContext();
-            switch (provider.selectCredential(&selection) catch |err|
-                return self.failCredential(credentials.classifySelectError(err))) {
-                .complete => |c| credential = c,
-                // Asynchronous client credential selection is deferred (#334);
-                // a provider that suspends here is unsupported for now.
-                .pending => |op| {
-                    op.cancel();
-                    op.release();
-                    return self.failCredential(.provider_internal_failure);
-                },
-            }
-            // The provider must return a scheme the server actually offered,
-            // else the CertificateVerify would carry an unadvertised algorithm.
-            if (!selection.offersScheme(credential.?.scheme))
-                return self.failCredential(.invalid_callback_behavior);
+        const provider = self.external_provider orelse
+            return self.emitClientCertificate(null, sink);
+        var selection = self.clientSelectionContext();
+        switch (provider.selectCredential(&selection) catch |err|
+            return self.failCredential(credentials.classifySelectError(err))) {
+            .complete => |credential| return self.emitSelectedClientCertificate(credential, sink),
+            .pending => |op| return self.parkAuth(op, .client_select),
         }
+    }
+
+    /// Validate a freshly selected client credential (synchronously or after a
+    /// resumed `client_select`) and continue emitting its Certificate.
+    fn emitSelectedClientCertificate(self: *Tls13Backend, credential: credentials.SelectedCredential, sink: *EventSink) HandshakeError!void {
+        var owned = true;
+        errdefer if (owned) credential.release();
+        // The provider must return a scheme the server actually offered, else
+        // the CertificateVerify would carry an unadvertised algorithm.
+        const selection = self.clientSelectionContext();
+        if (!selection.offersScheme(credential.scheme))
+            return self.failCredential(.invalid_callback_behavior);
+        owned = false; // ownership passes to emitClientCertificate
+        return self.emitClientCertificate(credential, sink);
+    }
+
+    /// Emit the client Certificate (the credential's validated chain, or an
+    /// empty list when declining) and record it, then sign CertificateVerify —
+    /// synchronously, or by parking a pending signer (`client_sign`). Owns the
+    /// credential handle and releases it exactly once on any failure before
+    /// ownership passes on.
+    fn emitClientCertificate(self: *Tls13Backend, credential: ?credentials.SelectedCredential, sink: *EventSink) HandshakeError!void {
+        var owned = credential != null;
+        errdefer if (owned) if (credential) |c| c.release();
 
         var buf: [max_message_len]u8 = undefined;
         var w = Writer{ .buf = &buf };
-
-        // Certificate: the credential's validated chain, or an empty list when
-        // declining. The empty context echoes the (empty) request context.
         try w.u8_(@intFromEnum(MessageType.certificate));
         const cert_len = try w.reserve(3);
-        try w.u8_(0); // certificate_request_context
+        try w.u8_(0); // certificate_request_context: empty (echoes the request)
         const list_len = try w.reserve(3);
         if (credential) |c| {
             const chain = c.certificateChain();
@@ -1164,25 +1186,40 @@ pub const Tls13Backend = struct {
         w.patch(3, list_len);
         w.patch(3, cert_len);
         self.core.recordSent(buf[0..w.len]) catch |err| return mapCoreError(err);
+        try sink.emitCrypto(.handshake, buf[0..w.len]);
 
-        // CertificateVerify, only when a certificate was actually presented; it
-        // signs the transcript through the client Certificate (RFC 8446 §4.4.3)
-        // with the client context string.
+        // Declining (empty Certificate) skips CertificateVerify entirely.
+        const c = credential orelse return self.finishClientAuthFlight(null, 0, sink);
+
+        // CertificateVerify signs the transcript through the client Certificate
+        // (RFC 8446 §4.4.3) with the client context string, into the engine's
+        // stable signature buffer. An async signer parks here.
+        const content = certificateVerifyContent(.client, self.core.transcriptHash());
+        switch (c.sign(content.slice(), &self.pending_signature) catch |err|
+            return self.failCredential(credentials.classifySignError(err))) {
+            .complete => |len| {
+                owned = false; // ownership passes to finishClientAuthFlight
+                return self.finishClientAuthFlight(c, len, sink);
+            },
+            .pending => |op| {
+                owned = false; // ownership passes to the parked operation
+                self.pending_credential = c;
+                return self.parkAuth(op, .client_sign);
+            },
+        }
+    }
+
+    /// Emit CertificateVerify (when a certificate was presented) and the client
+    /// Finished, then complete the handshake. Releases the credential exactly
+    /// once. Reachable synchronously and after a resumed `client_sign`.
+    fn finishClientAuthFlight(self: *Tls13Backend, credential: ?credentials.SelectedCredential, sig_len: usize, sink: *EventSink) HandshakeError!void {
+        defer if (credential) |c| c.release();
+        const schedule = &self.schedule.?;
+
+        var buf: [max_message_len]u8 = undefined;
+        var w = Writer{ .buf = &buf };
         if (credential) |c| {
-            const content = certificateVerifyContent(.client, self.core.transcriptHash());
-            const sig_len = switch (c.sign(content.slice(), &self.pending_signature) catch |err|
-                return self.failCredential(credentials.classifySignError(err))) {
-                .complete => |len| len,
-                // Asynchronous client signing is deferred (#334).
-                .pending => |op| {
-                    op.cancel();
-                    op.release();
-                    return self.failCredential(.signing_provider_failure);
-                },
-            };
             if (sig_len > self.pending_signature.len) return self.failCredential(.signature_output_overflow);
-
-            const cv_start = w.len;
             try w.u8_(@intFromEnum(MessageType.certificate_verify));
             const verify_len = try w.reserve(3);
             try w.u16_(c.scheme.code());
@@ -1191,7 +1228,7 @@ pub const Tls13Backend = struct {
             w.patch(2, sig_slot);
             w.patch(3, verify_len);
             crypto.secureZero(u8, &self.pending_signature);
-            self.core.recordSent(buf[cv_start..w.len]) catch |err| return mapCoreError(err);
+            self.core.recordSent(buf[0..w.len]) catch |err| return mapCoreError(err);
         }
 
         // Finished over the transcript through the last message above.
@@ -1203,8 +1240,11 @@ pub const Tls13Backend = struct {
         try w.bytes(&client_verify);
         w.patch(3, finished_len);
         self.core.recordSent(buf[finished_start..w.len]) catch |err| return mapCoreError(err);
-
+        // Emit CertificateVerify (when present) and Finished together; the
+        // Certificate was already emitted before signing.
         try sink.emitCrypto(.handshake, buf[0..w.len]);
+
+        try self.completeClientHandshake(sink);
     }
 
     // -----------------------------------------------------------------------
@@ -1627,6 +1667,21 @@ pub const Tls13Backend = struct {
         if (!done) return; // still pending; the driver polls again later
         op.release();
         self.pending_op = null;
+        try self.dispatchResume(stage, completion, sink);
+
+        // If the resume finished the stage without re-parking or failing, drain
+        // any handshake-epoch messages that arrived coalesced with — and were
+        // buffered behind — the message that triggered the suspend (e.g. a
+        // server that suspended verifying the client CertificateVerify still has
+        // the client Finished waiting in its handshake buffer).
+        if (self.pending_op == null and self.core.handshake_lifecycle == .running)
+            try self.drainInput(&self.handshake_input, .handshake, sink);
+    }
+
+    /// Continue the suspended stage from its completion value. Each arm resumes
+    /// exactly where the synchronous path would have continued, recording no
+    /// handshake message twice.
+    fn dispatchResume(self: *Tls13Backend, stage: PendingStage, completion: credentials.Completion, sink: *EventSink) HandshakeError!void {
         switch (stage) {
             .server_select => {
                 if (completion != .credential) return self.failCredential(.provider_internal_failure);
@@ -1637,6 +1692,16 @@ pub const Tls13Backend = struct {
                 const credential = self.pending_credential orelse return error.InvalidHandshakeState;
                 self.pending_credential = null;
                 return self.serverFinishFlight(credential, completion.signature_len, sink);
+            },
+            .client_select => {
+                if (completion != .credential) return self.failCredential(.provider_internal_failure);
+                return self.emitSelectedClientCertificate(completion.credential, sink);
+            },
+            .client_sign => {
+                if (completion != .signature_len) return self.failCredential(.invalid_callback_behavior);
+                const credential = self.pending_credential orelse return error.InvalidHandshakeState;
+                self.pending_credential = null;
+                return self.finishClientAuthFlight(credential, completion.signature_len, sink);
             },
             .peer_verify => {
                 if (completion != .verdict) return self.failCredential(.verifier_internal_failure);
@@ -1649,8 +1714,8 @@ pub const Tls13Backend = struct {
     /// the stage it was resolving.
     fn pendingFailureClass(stage: PendingStage) CredentialFailure {
         return switch (stage) {
-            .server_select => .provider_internal_failure,
-            .server_sign => .signing_provider_failure,
+            .server_select, .client_select => .provider_internal_failure,
+            .server_sign, .client_sign => .signing_provider_failure,
             .peer_verify => .verifier_internal_failure,
         };
     }

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -564,6 +564,10 @@ pub const Tls13Backend = struct {
         if (level != .application and self.core.handshake_lifecycle == .complete) {
             return error.UnexpectedHandshakeMessage;
         }
+        if (self.rejectPeerHandshakeWhileClientAuthPending(level, bytes.len)) {
+            self.cancelPendingAuth();
+            return error.UnexpectedHandshakeMessage;
+        }
         input.append(bytes) catch |err| return mapCoreError(err);
         // Never begin dispatching while an authentication operation is parked:
         // buffer the freshly received bytes and wait for `resumeAuth`. Without
@@ -620,6 +624,11 @@ pub const Tls13Backend = struct {
             .new_session_ticket => .application,
             else => error.UnexpectedHandshakeMessage,
         };
+    }
+
+    fn rejectPeerHandshakeWhileClientAuthPending(self: *const Tls13Backend, level: EncryptionLevel, byte_len: usize) bool {
+        if (byte_len == 0 or self.pending_op == null or self.role != .client or level == .application) return false;
+        return self.pending_stage == .client_select or self.pending_stage == .client_sign;
     }
 
     fn mapCoreError(err: tls_handshake_codec.Error) HandshakeError {
@@ -1122,19 +1131,25 @@ pub const Tls13Backend = struct {
         switch (algorithm) {
             sigalg_ed25519 => {
                 if (signature.len != Ed25519.Signature.encoded_length) return .invalid_signature;
-                if (parsed.pub_key_algo != .curveEd25519) return .unsupported_certificate;
+                if (parsed.pub_key_algo != .curveEd25519) {
+                    return switch (parsed.pub_key_algo) {
+                        .X9_62_id_ecPublicKey => |curve| if (curve == .X9_62_prime256v1) .invalid_signature else .unsupported_certificate,
+                        else => .unsupported_certificate,
+                    };
+                }
                 const pub_key_bytes = parsed.pubKey();
-                if (pub_key_bytes.len != Ed25519.PublicKey.encoded_length) return .unsupported_certificate;
-                const public_key = Ed25519.PublicKey.fromBytes(pub_key_bytes[0..Ed25519.PublicKey.encoded_length].*) catch return .unsupported_certificate;
+                if (pub_key_bytes.len != Ed25519.PublicKey.encoded_length) return .invalid_certificate;
+                const public_key = Ed25519.PublicKey.fromBytes(pub_key_bytes[0..Ed25519.PublicKey.encoded_length].*) catch return .invalid_certificate;
                 const sig = Ed25519.Signature.fromBytes(signature[0..Ed25519.Signature.encoded_length].*);
                 sig.verify(content, public_key) catch return .invalid_signature;
             },
             sigalg_ecdsa_secp256r1_sha256 => {
                 switch (parsed.pub_key_algo) {
                     .X9_62_id_ecPublicKey => |curve| if (curve != .X9_62_prime256v1) return .unsupported_certificate,
+                    .curveEd25519 => return .invalid_signature,
                     else => return .unsupported_certificate,
                 }
-                const public_key = EcdsaP256.PublicKey.fromSec1(parsed.pubKey()) catch return .unsupported_certificate;
+                const public_key = EcdsaP256.PublicKey.fromSec1(parsed.pubKey()) catch return .invalid_certificate;
                 const sig = EcdsaP256.Signature.fromDer(signature) catch return .invalid_signature;
                 sig.verify(content, public_key) catch return .invalid_signature;
             },

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -261,8 +261,21 @@ pub const Tls13Backend = struct {
     peer_chain_entries: [max_peer_chain_entries]Slice = undefined,
     peer_chain_count: usize = 0,
     peer_chain_len: usize = 0,
+    /// A parked asynchronous authentication operation (an external signer,
+    /// verifier, or async selector that returned `pending`). While set, the
+    /// handshake is suspended: the receive loop stops consuming and the driver
+    /// must call `resumeAuth` when the operation signals progress.
+    pending_op: ?credentials.PendingOperation = null,
+    pending_stage: PendingStage = undefined,
+    /// The selected credential held across a pending signature (released when
+    /// the signature completes, or cancelled at teardown).
+    pending_credential: ?credentials.SelectedCredential = null,
+    /// Stable, engine-owned signature output buffer. An async signer keeps a
+    /// pointer to this across the suspend; the engine reads it on completion.
+    pending_signature: [max_signature_len]u8 = undefined,
 
     const Slice = struct { start: usize, len: usize };
+    const PendingStage = enum { server_select, server_sign, client_verify };
 
     /// Options for a client that verifies its peer through an external verifier:
     /// the exact intended server name (emitted as SNI and handed to the
@@ -400,6 +413,10 @@ pub const Tls13Backend = struct {
     }
 
     pub fn deinit(self: *Tls13Backend) void {
+        // Cancel and release any parked async operation (and held credential)
+        // exactly once before tearing down the rest.
+        self.cancelPendingAuth();
+        crypto.secureZero(u8, &self.pending_signature);
         if (self.schedule) |*schedule| schedule.wipe();
         self.schedule = null;
         crypto.secureZero(u8, &self.expected_client_verify);
@@ -480,6 +497,10 @@ pub const Tls13Backend = struct {
             _ = self.core.acceptReceived(message.raw) catch |err| return mapCoreError(err);
             try self.onMessage(message, level, transcript_before, sink);
             input.discard(message.raw.len) catch |err| return mapCoreError(err);
+            // A parked async authentication operation suspends the handshake:
+            // stop consuming buffered messages until the driver resumes it (any
+            // remaining bytes stay buffered and are drained on the next drive).
+            if (self.pending_op != null) break;
             // A failed or freshly completed handshake stops consuming its own
             // epochs; post-handshake application input keeps draining (a peer
             // may batch several NewSessionTickets).
@@ -851,8 +872,19 @@ pub const Tls13Backend = struct {
             .application_protocol = self.alpn(),
             .auth_policy = self.auth_policy,
         };
-        const verdict = verifier.verifyPeer(&context) catch |err|
-            return self.failCredential(credentials.classifyVerifyError(err));
+        // The verifier may resolve synchronously or return a pending operation
+        // (an async Web-PKI/OCSP lookup); park the latter and resume later.
+        switch (verifier.verifyPeer(&context) catch |err|
+            return self.failCredential(credentials.classifyVerifyError(err)))
+        {
+            .complete => |verdict| return self.applyClientVerdict(verdict, sink),
+            .pending => |op| return self.parkAuth(op, .client_verify),
+        }
+    }
+
+    /// Apply a peer-verification verdict: emit the certificate state and fail
+    /// closed on rejection. Reachable synchronously and after resume.
+    fn applyClientVerdict(self: *Tls13Backend, verdict: credentials.Verdict, sink: *EventSink) HandshakeError!void {
         const state: CertificateState = switch (verdict) {
             .accepted => .valid,
             .not_checked => .not_checked,
@@ -1121,8 +1153,6 @@ pub const Tls13Backend = struct {
     /// EncryptedExtensions + Certificate + CertificateVerify + Finished at the
     /// Handshake level, followed by the 1-RTT secrets.
     fn sendServerFlight(self: *Tls13Backend, sink: *EventSink) HandshakeError!void {
-        const schedule = &self.schedule.?;
-
         // Resolve the credential provider — an external one, or the fixed
         // identity wrapped in the identical production contract — and select a
         // credential for the negotiated parameters. There is one path.
@@ -1142,18 +1172,28 @@ pub const Tls13Backend = struct {
         };
 
         var selection = self.serverSelectionContext();
-        var credential: credentials.SelectedCredential = undefined;
-        provider.selectCredential(&selection, &credential) catch |err|
-            return self.failCredential(credentials.classifySelectError(err));
-        // The selected handle is released exactly once — after the flight is
-        // signed, or immediately on any failure below (cancellation included).
-        defer credential.release();
+        // Selection may complete synchronously or return a pending operation
+        // (e.g. an async SNI lookup); park the latter and resume later.
+        switch (provider.selectCredential(&selection) catch |err|
+            return self.failCredential(credentials.classifySelectError(err)))
+        {
+            .complete => |credential| return self.emitServerAuthFlight(credential, sink),
+            .pending => |op| return self.parkAuth(op, .server_select),
+        }
+    }
 
-        // Validate provider output before trusting it. A buggy or hostile
-        // provider must not make the engine emit a CertificateVerify scheme the
-        // client never offered, nor a chain that overflows the flight buffer as
-        // a generic writer error. Every violation is a local provider fault, and
-        // signing never happens when validation fails.
+    /// Validate the selected credential, emit EncryptedExtensions+Certificate,
+    /// then sign CertificateVerify — synchronously, or by parking a pending
+    /// signer. On any failure the handle is released exactly once.
+    fn emitServerAuthFlight(self: *Tls13Backend, credential: credentials.SelectedCredential, sink: *EventSink) HandshakeError!void {
+        var owned = true;
+        errdefer if (owned) credential.release();
+
+        // Validate provider output before trusting it: the returned scheme must
+        // have been offered (else the CertificateVerify carries an algorithm the
+        // client never advertised), and the chain must fit the flight bounds. A
+        // violation is a local provider fault; signing never happens.
+        const selection = self.serverSelectionContext();
         if (!selection.offersScheme(credential.scheme))
             return self.failCredential(.invalid_callback_behavior);
         const chain = credential.certificateChain();
@@ -1198,7 +1238,7 @@ pub const Tls13Backend = struct {
         const encrypted_extensions = buf[0..w.len];
 
         // Certificate: the selected credential's validated public DER chain,
-        // valid until `release`. The chain was bounds-checked above.
+        // valid until `release`.
         const cert_start = w.len;
         try w.u8_(@intFromEnum(MessageType.certificate));
         const cert_len = try w.reserve(3);
@@ -1214,27 +1254,48 @@ pub const Tls13Backend = struct {
         w.patch(3, cert_len);
         const certificate = buf[cert_start..w.len];
 
-        // CertificateVerify signs the transcript through Certificate. Signing
-        // goes through the credential's opaque handle into a bounded, caller-
-        // owned scratch buffer; the private key never enters the engine.
         self.core.recordSent(encrypted_extensions) catch |err| return mapCoreError(err);
         self.core.recordSent(certificate) catch |err| return mapCoreError(err);
+        try sink.emitCrypto(.handshake, buf[0..w.len]);
+
+        // CertificateVerify signs the transcript through Certificate, into the
+        // engine-owned buffer. Signing goes through the opaque handle; the
+        // private key never enters the engine. An async signer parks here.
         const content = certificateVerifyContent(.server, self.core.transcriptHash());
-        const verify_start = w.len;
+        switch (credential.sign(content.slice(), &self.pending_signature) catch |err|
+            return self.failCredential(credentials.classifySignError(err)))
+        {
+            .complete => |len| {
+                owned = false; // ownership passes to serverFinishFlight
+                return self.serverFinishFlight(credential, len, sink);
+            },
+            .pending => |op| {
+                owned = false; // ownership passes to the parked operation
+                self.pending_credential = credential;
+                return self.parkAuth(op, .server_sign);
+            },
+        }
+    }
+
+    /// Emit CertificateVerify (with the completed signature) and Finished, then
+    /// the 1-RTT secrets. Releases the credential exactly once. Reachable both
+    /// synchronously and after resuming a pending signature.
+    fn serverFinishFlight(self: *Tls13Backend, credential: credentials.SelectedCredential, sig_len: usize, sink: *EventSink) HandshakeError!void {
+        defer credential.release();
+        const schedule = &self.schedule.?;
+        if (sig_len > self.pending_signature.len) return self.failCredential(.signature_output_overflow);
+
+        var buf: [max_message_len]u8 = undefined;
+        var w = Writer{ .buf = &buf };
         try w.u8_(@intFromEnum(MessageType.certificate_verify));
         const verify_len = try w.reserve(3);
         try w.u16_(credential.scheme.code());
         const sig_len_slot = try w.reserve(2);
-        var sig_scratch: [max_signature_len]u8 = undefined;
-        // Signature scratch is transcript-derived, not secret key material, but
-        // wipe it after use as a matter of hygiene.
-        defer crypto.secureZero(u8, &sig_scratch);
-        const sig_written = credential.sign(content.slice(), &sig_scratch) catch |err|
-            return self.failCredential(credentials.classifySignError(err));
-        try w.bytes(sig_scratch[0..sig_written]);
+        try w.bytes(self.pending_signature[0..sig_len]);
         w.patch(2, sig_len_slot);
         w.patch(3, verify_len);
-        const certificate_verify = buf[verify_start..w.len];
+        const certificate_verify = buf[0..w.len];
+        crypto.secureZero(u8, &self.pending_signature);
         self.core.recordSent(certificate_verify) catch |err| return mapCoreError(err);
 
         // Finished covers the transcript through CertificateVerify.
@@ -1247,6 +1308,8 @@ pub const Tls13Backend = struct {
         w.patch(3, finished_len);
         const finished = buf[finished_start..w.len];
         self.core.recordSent(finished) catch |err| return mapCoreError(err);
+        // Emit CertificateVerify and Finished together (the second half of the
+        // flight; EncryptedExtensions+Certificate were emitted before signing).
         try sink.emitCrypto(.handshake, buf[0..w.len]);
 
         // 1-RTT secrets from the transcript through server Finished; the
@@ -1259,6 +1322,78 @@ pub const Tls13Backend = struct {
         var client_verify = KeySchedule.verifyData(&schedule.client_handshake_traffic, finished_hash);
         defer crypto.secureZero(u8, &client_verify);
         self.expected_client_verify = client_verify;
+    }
+
+    // -----------------------------------------------------------------------
+    // Asynchronous authentication (parking / resume / cancel).
+    // -----------------------------------------------------------------------
+
+    /// True while an authentication operation is parked; the driver must call
+    /// `resumeAuth` when it signals progress, and stop feeding new bytes.
+    pub fn authPending(self: *const Tls13Backend) bool {
+        return self.pending_op != null;
+    }
+
+    fn parkAuth(self: *Tls13Backend, op: credentials.PendingOperation, stage: PendingStage) void {
+        self.pending_op = op;
+        self.pending_stage = stage;
+    }
+
+    /// Poll a parked authentication operation. When it is still pending this is
+    /// a no-op; when it completes the handshake resumes exactly where it
+    /// suspended, recording no handshake message twice; when it fails the typed
+    /// failure is latched.
+    pub fn resumeAuth(self: *Tls13Backend, sink: *EventSink) HandshakeError!void {
+        const op = self.pending_op orelse return error.InvalidHandshakeState;
+        const stage = self.pending_stage;
+        var completion: credentials.Completion = undefined;
+        const done = op.poll(&completion) catch {
+            self.cancelPendingAuth();
+            return self.failCredential(pendingFailureClass(stage));
+        };
+        if (!done) return; // still pending; the driver polls again later
+        op.release();
+        self.pending_op = null;
+        switch (stage) {
+            .server_select => {
+                if (completion != .credential) return self.failCredential(.provider_internal_failure);
+                return self.emitServerAuthFlight(completion.credential, sink);
+            },
+            .server_sign => {
+                if (completion != .signature_len) return self.failCredential(.invalid_callback_behavior);
+                const credential = self.pending_credential orelse return error.InvalidHandshakeState;
+                self.pending_credential = null;
+                return self.serverFinishFlight(credential, completion.signature_len, sink);
+            },
+            .client_verify => {
+                if (completion != .verdict) return self.failCredential(.verifier_internal_failure);
+                return self.applyClientVerdict(completion.verdict, sink);
+            },
+        }
+    }
+
+    /// The failure class for a pending operation that reported an error, by
+    /// the stage it was resolving.
+    fn pendingFailureClass(stage: PendingStage) CredentialFailure {
+        return switch (stage) {
+            .server_select => .provider_internal_failure,
+            .server_sign => .signing_provider_failure,
+            .client_verify => .verifier_internal_failure,
+        };
+    }
+
+    /// Cancel and release a parked operation (and any held credential) exactly
+    /// once, on handshake teardown or failure.
+    fn cancelPendingAuth(self: *Tls13Backend) void {
+        if (self.pending_op) |op| {
+            op.cancel();
+            op.release();
+            self.pending_op = null;
+        }
+        if (self.pending_credential) |credential| {
+            credential.release();
+            self.pending_credential = null;
+        }
     }
 
     fn onClientFinished(self: *Tls13Backend, body: []const u8, sink: *EventSink) HandshakeError!void {

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -906,8 +906,7 @@ pub const Tls13Backend = struct {
         // The verifier may resolve synchronously or return a pending operation
         // (an async Web-PKI/OCSP lookup); park the latter and resume later.
         switch (verifier.verifyPeer(&context) catch |err|
-            return self.failCredential(credentials.classifyVerifyError(err)))
-        {
+            return self.failCredential(credentials.classifyVerifyError(err))) {
             .complete => |verdict| return self.applyClientVerdict(verdict, sink),
             .pending => |op| return self.parkAuth(op, .client_verify),
         }
@@ -1206,8 +1205,7 @@ pub const Tls13Backend = struct {
         // Selection may complete synchronously or return a pending operation
         // (e.g. an async SNI lookup); park the latter and resume later.
         switch (provider.selectCredential(&selection) catch |err|
-            return self.failCredential(credentials.classifySelectError(err)))
-        {
+            return self.failCredential(credentials.classifySelectError(err))) {
             .complete => |credential| return self.emitServerAuthFlight(credential, sink),
             .pending => |op| return self.parkAuth(op, .server_select),
         }
@@ -1322,8 +1320,7 @@ pub const Tls13Backend = struct {
         // private key never enters the engine. An async signer parks here.
         const content = certificateVerifyContent(.server, self.core.transcriptHash());
         switch (credential.sign(content.slice(), &self.pending_signature) catch |err|
-            return self.failCredential(credentials.classifySignError(err)))
-        {
+            return self.failCredential(credentials.classifySignError(err))) {
             .complete => |len| {
                 owned = false; // ownership passes to serverFinishFlight
                 return self.serverFinishFlight(credential, len, sink);

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -721,7 +721,16 @@ pub const Tls13Backend = struct {
         self.key_pair = key_pair;
         self.key_pair_present = true;
 
-        var buf: [1024]u8 = undefined;
+        // Sized for the worst case, not the common one: maximum ALPN (255,
+        // bounded by `TransportProfile.validate`), maximum SNI
+        // (`max_server_name_len` = 256), and a maximum transport extension
+        // (`max_transport_extension_len` = 512) together encode to roughly
+        // 1.15 KiB — a 1024-byte buffer could overflow for a legitimate
+        // configuration, and by the time the writer reported that, `start` had
+        // already advanced the core and generated/stored the key pair. Using
+        // the same bound as every other flight buffer makes that structurally
+        // impossible rather than requiring a separate exact-size preflight.
+        var buf: [max_message_len]u8 = undefined;
         var w = Writer{ .buf = &buf };
         try w.u8_(@intFromEnum(MessageType.client_hello));
         const message_len = try w.reserve(3);
@@ -1415,7 +1424,13 @@ pub const Tls13Backend = struct {
                     // host_name is rejected deterministically rather than being
                     // collapsed into the default-certificate path, so a selector
                     // never serves the default cert for an invalid SNI.
-                    var names = Reader{ .bytes = try ext.slice(try ext.u16_()) };
+                    const list_len = try ext.u16_();
+                    // RFC 6066 §3: ServerNameList<1..2^16-1> — an empty list is
+                    // malformed, not "no host_name present"; accepting it would
+                    // silently route to the default credential exactly like the
+                    // metadata-collapse behavior this parser otherwise rejects.
+                    if (list_len == 0) return error.IllegalParameter;
+                    var names = Reader{ .bytes = try ext.slice(list_len) };
                     while (names.remaining() > 0) {
                         const name_type = try names.u8_();
                         const name = try names.slice(try names.u16_());
@@ -1755,28 +1770,53 @@ pub const Tls13Backend = struct {
         self.pending_stage = stage;
     }
 
-    /// Poll a parked authentication operation. When it is still pending this is
-    /// a no-op; when it completes the handshake resumes exactly where it
+    /// Poll a parked authentication operation. When nothing is parked this is a
+    /// safe no-op (the documented `transport.Backend.resumeAuth` contract: a
+    /// caller may call it opportunistically). When it is still pending this is
+    /// also a no-op; when it completes the handshake resumes exactly where it
     /// suspended, recording no handshake message twice; when it fails the typed
     /// failure is latched.
     pub fn resumeAuth(self: *Tls13Backend, sink: *EventSink) HandshakeError!void {
-        const op = self.pending_op orelse return error.InvalidHandshakeState;
+        const op = self.pending_op orelse return;
         const stage = self.pending_stage;
         var completion: credentials.Completion = undefined;
-        const done = op.poll(&completion) catch {
-            self.cancelPendingAuth();
-            return self.failCredential(pendingFailureClass(stage));
+        const done = op.poll(&completion) catch |err| {
+            // `poll` returning an error means the operation has already
+            // terminated (per its documented contract), so it must not be
+            // cancelled — `cancel` is for abandoning an operation that has not
+            // yet resolved. Release it (and any held signing credential)
+            // exactly once, then classify the typed callback failure: an
+            // `InvalidCallbackBehavior` is a distinct, stage-independent
+            // contract violation, never conflated with an ordinary operation
+            // failure.
+            op.release();
+            self.pending_op = null;
+            if (self.pending_credential) |credential| {
+                credential.release();
+                self.pending_credential = null;
+            }
+            return self.failCredential(switch (err) {
+                error.InvalidCallbackBehavior => .invalid_callback_behavior,
+                error.OperationFailed => pendingFailureClass(stage),
+            });
         };
         if (!done) return; // still pending; the driver polls again later
         op.release();
         self.pending_op = null;
         try self.dispatchResume(stage, completion, sink);
 
-        // If the resume finished the stage without re-parking or failing, drain
-        // any handshake-epoch messages that arrived coalesced with — and were
-        // buffered behind — the message that triggered the suspend (e.g. a
-        // server that suspended verifying the client CertificateVerify still has
-        // the client Finished waiting in its handshake buffer).
+        // Drain buffered input in protocol order once the resume itself did not
+        // re-park or fail. A parked operation may have suspended while draining
+        // either buffer — server credential selection/signing while processing
+        // the ClientHello in `initial_input`, or client selection/signing and
+        // peer verification while processing the handshake flight in
+        // `handshake_input` — and further bytes for either epoch may have
+        // arrived and been buffered (not just coalesced within the same
+        // message) while it was pending. Draining both, in protocol order,
+        // guarantees every accepted transport byte is eventually parsed or
+        // deterministically rejected rather than silently ignored.
+        if (self.pending_op == null and self.core.handshake_lifecycle == .running)
+            try self.drainInput(&self.initial_input, .initial, sink);
         if (self.pending_op == null and self.core.handshake_lifecycle == .running)
             try self.drainInput(&self.handshake_input, .handshake, sink);
     }
@@ -1788,6 +1828,15 @@ pub const Tls13Backend = struct {
         switch (stage) {
             .server_select => switch (completion) {
                 .credential => |c| return self.emitServerAuthFlight(c, sink),
+                // Unlike the client, the server MUST authenticate itself in
+                // this profile: "no credential" from an async selector is the
+                // same normal-but-unusable outcome the synchronous path reports
+                // via `NoCredentialAvailable`/`NoCompatibleSignatureAlgorithm`
+                // (`NoApplicableCredential`/handshake_failure), not a provider
+                // fault. `Completion.no_credential` does not distinguish
+                // "unavailable" from "incompatible", so both collapse to the
+                // single canonical class here; the wire alert is unaffected.
+                .no_credential => return self.failCredential(.no_credential_available),
                 else => {
                     releaseCompletionCredentials(completion, null);
                     return self.failCredential(.provider_internal_failure);

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -378,7 +378,7 @@ pub const Tls13Backend = struct {
             // A name too long for the bounded buffer is a caller error. Record
             // the overflow and reject at `start` rather than truncating it to a
             // different host (see `server_name_overflow`).
-            if (name.len > self.server_name.len) {
+            if (name.len == 0 or name.len > self.server_name.len) {
                 self.server_name_overflow = true;
             } else {
                 @memcpy(self.server_name[0..name.len], name);
@@ -561,6 +561,9 @@ pub const Tls13Backend = struct {
                 break :blk &self.application_input;
             },
         };
+        if (level != .application and self.core.handshake_lifecycle == .complete) {
+            return error.UnexpectedHandshakeMessage;
+        }
         input.append(bytes) catch |err| return mapCoreError(err);
         // Never begin dispatching while an authentication operation is parked:
         // buffer the freshly received bytes and wait for `resumeAuth`. Without
@@ -587,6 +590,9 @@ pub const Tls13Backend = struct {
             // even if this loop is somehow re-entered mid-suspend.
             if (self.pending_op != null) break;
             if (level != try expectedLevel(message.kind)) return error.UnexpectedTransportEpoch;
+            if (level == .handshake and message.kind == .finished and input.len != message.raw.len) {
+                return error.UnexpectedHandshakeMessage;
+            }
             const transcript_before = self.core.transcriptHash();
             _ = self.core.acceptReceived(message.raw) catch |err| return mapCoreError(err);
             try self.onMessage(message, level, transcript_before, sink);
@@ -627,7 +633,9 @@ pub const Tls13Backend = struct {
             error.HandshakeBufferOverflow => error.HandshakeBufferOverflow,
             error.IllegalParameter => error.IllegalParameter,
             error.UnexpectedHandshakeMessage => error.UnexpectedHandshakeMessage,
+            error.MissingExtension => error.MissingExtension,
             error.AlpnMismatch => error.AlpnMismatch,
+            error.UnsupportedCertificate => error.UnsupportedCertificate,
             error.CertificateInvalid => error.CertificateInvalid,
             error.SecretExportFailed => error.SecretExportFailed,
             error.InvalidHandshakeState => error.InvalidHandshakeState,
@@ -919,7 +927,8 @@ pub const Tls13Backend = struct {
         }
         // signature_algorithms is mandatory in a CertificateRequest
         // (RFC 8446 §4.3.2); its absence is a malformed/missing peer extension.
-        if (!saw_signature_algorithms or self.peer_sig_scheme_count == 0) return error.MalformedHandshake;
+        if (!saw_signature_algorithms) return error.MissingExtension;
+        if (self.peer_sig_scheme_count == 0) return error.MalformedHandshake;
     }
 
     fn onCertificate(self: *Tls13Backend, body: []const u8) HandshakeError!void {
@@ -1024,13 +1033,16 @@ pub const Tls13Backend = struct {
         const signer_role: Role = if (self.role == .client) .server else .client;
 
         // The signature covers the transcript through Certificate (RFC 8446
-        // §4.4.3) — before this message is added. Proof of key possession is
-        // transcript crypto, not PKI policy: a failure is a `decrypt_error`, a
-        // distinct crypto failure from a trust rejection, so it does NOT emit a
-        // certificate-invalid (bad_certificate) verdict — it fails directly.
+        // §4.4.3) — before this message is added. Keep structural certificate
+        // failures, unsupported key material, unoffered algorithms, and actual
+        // signature mismatches distinct so alert mapping remains faithful.
         const content = certificateVerifyContent(signer_role, transcript_before);
-        if (!self.checkProofOfPossession(algorithm, signature, content.slice())) {
-            return self.failCredential(.certificate_verify_invalid);
+        switch (self.checkProofOfPossession(algorithm, signature, content.slice())) {
+            .valid => {},
+            .invalid_certificate => return self.failCredential(.invalid_peer_certificate_chain),
+            .unsupported_certificate => return self.failCredential(.unsupported_peer_certificate),
+            .unoffered_algorithm => return error.IllegalParameter,
+            .invalid_signature => return self.failCredential(.certificate_verify_invalid),
         }
 
         // Delegate the trust verdict to the peer verifier — the fixed pin/
@@ -1086,37 +1098,49 @@ pub const Tls13Backend = struct {
         }
     }
 
+    const ProofResult = enum {
+        valid,
+        invalid_signature,
+        invalid_certificate,
+        unsupported_certificate,
+        unoffered_algorithm,
+    };
+
+    fn locallyOfferedSignatureAlgorithm(algorithm: u16) bool {
+        return algorithm == sigalg_ed25519 or algorithm == sigalg_ecdsa_secp256r1_sha256;
+    }
+
     /// Verify the CertificateVerify signature against the peer leaf's public
     /// key: proof that the peer holds the private key for the presented
-    /// certificate. Returns false on any mismatch. This is not a trust decision
-    /// — that is the verifier's job.
-    fn checkProofOfPossession(self: *const Tls13Backend, algorithm: u16, signature: []const u8, content: []const u8) bool {
-        if (self.peer_chain_count == 0) return false;
+    /// certificate. This is not a trust decision — that is the verifier's job.
+    fn checkProofOfPossession(self: *const Tls13Backend, algorithm: u16, signature: []const u8, content: []const u8) ProofResult {
+        if (!locallyOfferedSignatureAlgorithm(algorithm)) return .unoffered_algorithm;
+        if (self.peer_chain_count == 0) return .invalid_certificate;
         const e = self.peer_chain_entries[0];
         const leaf = self.peer_chain[e.start..][0..e.len];
-        const parsed = (Certificate{ .buffer = leaf, .index = 0 }).parse() catch return false;
+        const parsed = (Certificate{ .buffer = leaf, .index = 0 }).parse() catch return .invalid_certificate;
         switch (algorithm) {
             sigalg_ed25519 => {
-                if (signature.len != Ed25519.Signature.encoded_length) return false;
-                if (parsed.pub_key_algo != .curveEd25519) return false;
+                if (signature.len != Ed25519.Signature.encoded_length) return .invalid_signature;
+                if (parsed.pub_key_algo != .curveEd25519) return .unsupported_certificate;
                 const pub_key_bytes = parsed.pubKey();
-                if (pub_key_bytes.len != Ed25519.PublicKey.encoded_length) return false;
-                const public_key = Ed25519.PublicKey.fromBytes(pub_key_bytes[0..Ed25519.PublicKey.encoded_length].*) catch return false;
+                if (pub_key_bytes.len != Ed25519.PublicKey.encoded_length) return .unsupported_certificate;
+                const public_key = Ed25519.PublicKey.fromBytes(pub_key_bytes[0..Ed25519.PublicKey.encoded_length].*) catch return .unsupported_certificate;
                 const sig = Ed25519.Signature.fromBytes(signature[0..Ed25519.Signature.encoded_length].*);
-                sig.verify(content, public_key) catch return false;
+                sig.verify(content, public_key) catch return .invalid_signature;
             },
             sigalg_ecdsa_secp256r1_sha256 => {
                 switch (parsed.pub_key_algo) {
-                    .X9_62_id_ecPublicKey => |curve| if (curve != .X9_62_prime256v1) return false,
-                    else => return false,
+                    .X9_62_id_ecPublicKey => |curve| if (curve != .X9_62_prime256v1) return .unsupported_certificate,
+                    else => return .unsupported_certificate,
                 }
-                const public_key = EcdsaP256.PublicKey.fromSec1(parsed.pubKey()) catch return false;
-                const sig = EcdsaP256.Signature.fromDer(signature) catch return false;
-                sig.verify(content, public_key) catch return false;
+                const public_key = EcdsaP256.PublicKey.fromSec1(parsed.pubKey()) catch return .unsupported_certificate;
+                const sig = EcdsaP256.Signature.fromDer(signature) catch return .invalid_signature;
+                sig.verify(content, public_key) catch return .invalid_signature;
             },
-            else => return false,
+            else => unreachable,
         }
-        return true;
+        return .valid;
     }
 
     fn onServerFinished(self: *Tls13Backend, transcript_before: [hash_len]u8, body: []const u8, sink: *EventSink) HandshakeError!void {
@@ -1124,9 +1148,7 @@ pub const Tls13Backend = struct {
         if (body.len != hash_len) return error.MalformedHandshake;
         var expected = KeySchedule.verifyData(&schedule.server_handshake_traffic, transcript_before);
         defer crypto.secureZero(u8, &expected);
-        if (!crypto.timing_safe.eql([hash_len]u8, expected, body[0..hash_len].*)) {
-            return error.MalformedHandshake;
-        }
+        if (!crypto.timing_safe.eql([hash_len]u8, expected, body[0..hash_len].*)) return error.DecryptError;
 
         // 1-RTT secrets exist from the transcript through server Finished,
         // independent of any client certificate flight that follows.
@@ -1475,7 +1497,8 @@ pub const Tls13Backend = struct {
         // with a certificate (RFC 8446 §9.2). A missing or empty list is a
         // malformed/missing required *peer* extension — attribute it to the
         // peer (decode_error), not to local credential configuration.
-        if (!saw_signature_algorithms or self.peer_sig_scheme_count == 0) return error.MalformedHandshake;
+        if (!saw_signature_algorithms) return error.MissingExtension;
+        if (self.peer_sig_scheme_count == 0) return error.MalformedHandshake;
         const client_share = peer_share orelse return error.MalformedHandshake;
 
         // Validate the peer share before emitting anything: X25519.scalarmult
@@ -1839,7 +1862,7 @@ pub const Tls13Backend = struct {
                 .no_credential => return self.failCredential(.no_credential_available),
                 else => {
                     releaseCompletionCredentials(completion, null);
-                    return self.failCredential(.provider_internal_failure);
+                    return self.failCredential(.invalid_callback_behavior);
                 },
             },
             .client_select => switch (completion) {
@@ -1849,7 +1872,7 @@ pub const Tls13Backend = struct {
                 .no_credential => return self.emitClientCertificate(null, sink),
                 else => {
                     releaseCompletionCredentials(completion, null);
-                    return self.failCredential(.provider_internal_failure);
+                    return self.failCredential(.invalid_callback_behavior);
                 },
             },
             .server_sign, .client_sign => {
@@ -1872,7 +1895,7 @@ pub const Tls13Backend = struct {
                 .verdict => |v| return self.applyPeerVerdict(v, sink),
                 else => {
                     releaseCompletionCredentials(completion, null);
-                    return self.failCredential(.verifier_internal_failure);
+                    return self.failCredential(.invalid_callback_behavior);
                 },
             },
         }
@@ -1929,9 +1952,7 @@ pub const Tls13Backend = struct {
         // server flight was sent.
         var expected = KeySchedule.verifyData(&schedule.client_handshake_traffic, transcript_before);
         defer crypto.secureZero(u8, &expected);
-        if (!crypto.timing_safe.eql([hash_len]u8, expected, body[0..hash_len].*)) {
-            return error.MalformedHandshake;
-        }
+        if (!crypto.timing_safe.eql([hash_len]u8, expected, body[0..hash_len].*)) return error.DecryptError;
         // Client Finished confirms the handshake for the server (RFC 8446 §4.4.4).
         try self.emitDiscardKeys(sink, .handshake);
         try sink.emitHandshakeComplete();

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -179,11 +179,15 @@ pub const VerificationContext = credentials.VerificationContext;
 pub const CredentialFailure = credentials.FailureClass;
 
 /// Largest peer certificate chain (total DER bytes and entry count) the engine
-/// reassembles and surfaces to a `PeerVerifier` as immutable views.
-pub const max_peer_chain_bytes = 8 * 1024;
+/// reassembles and surfaces to a `PeerVerifier` as immutable views. A chain
+/// exceeding either bound fails closed (peer-attributed) rather than being
+/// truncated, so a verifier never sees a partial chain.
+pub const max_peer_chain_bytes = 16 * 1024;
 pub const max_peer_chain_entries = credentials.max_chain_entries;
 /// Largest set of peer-offered signature schemes captured for selection.
-const max_peer_sig_schemes = 16;
+/// Generous versus real ClientHellos (~a dozen); a larger offer fails closed
+/// rather than being silently truncated.
+const max_peer_sig_schemes = 64;
 /// Largest SNI host_name captured for selection (RFC 6066 caps names well
 /// under this).
 const max_server_name_len = 256;
@@ -213,14 +217,22 @@ pub const Tls13Backend = struct {
     /// same production contract, so there is one authentication path.
     external_provider: ?CredentialProvider = null,
     external_verifier: ?PeerVerifier = null,
+    /// Explicit local authentication policy, passed to selection and
+    /// verification. Set at construction from the caller's intent, never
+    /// re-derived from a defaulted field (an external verifier must not silently
+    /// inherit the insecure default).
+    auth_policy: credentials.AuthPolicy = .{},
     /// The last typed credential/verification failure. Set on failure and
     /// deliberately preserved across `deinit` (it is diagnostic, not secret) so
     /// terminal cleanup does not erase the underlying reason (#334).
     credential_failure: ?CredentialFailure = null,
-    /// Peer-offered signature schemes and SNI captured from ClientHello, passed
+    /// Peer-offered signature schemes captured from ClientHello, passed
     /// immutably into credential selection.
     peer_sig_schemes: [max_peer_sig_schemes]u16 = undefined,
     peer_sig_scheme_count: usize = 0,
+    /// SNI host_name. Server: the value parsed from ClientHello. Client: the
+    /// intended server name, configured at construction, emitted as ClientHello
+    /// SNI and passed to the verifier so a Web-PKI verifier can check hostname.
     server_name: [max_server_name_len]u8 = undefined,
     server_name_len: usize = 0,
     server_name_present: bool = false,
@@ -252,10 +264,36 @@ pub const Tls13Backend = struct {
 
     const Slice = struct { start: usize, len: usize };
 
+    /// Options for a client that verifies its peer through an external verifier:
+    /// the exact intended server name (emitted as SNI and handed to the
+    /// verifier) and the explicit authentication policy.
+    pub const ClientOptions = struct {
+        server_name: ?[]const u8 = null,
+        /// Defaults to strict: an external verifier is assumed to require a
+        /// valid peer certificate unless the caller opts out.
+        policy: credentials.AuthPolicy = .{ .require_peer_authentication = true },
+    };
+
+    /// The authentication policy implied by a fixed `Trust`: insecure mode
+    /// explicitly allows an unverified peer, pinning requires a match.
+    fn policyFromTrust(trust: Trust) credentials.AuthPolicy {
+        return switch (trust) {
+            .insecure_no_verification => .{ .allow_unverified_peer = true },
+            .pinned_certificate => .{ .require_peer_authentication = true },
+        };
+    }
+
     /// Allocation-free. The returned backend owns its copied entropy until
     /// `deinit`, which securely clears all private material.
     pub fn initClient(entropy: Entropy, trust: Trust, profile: TransportProfile) Tls13Backend {
-        return .{ .role = .client, .profile = profile, .entropy = entropy, .trust = trust, .core = tls_handshake_codec.Core.init(.client) };
+        return .{
+            .role = .client,
+            .profile = profile,
+            .entropy = entropy,
+            .trust = trust,
+            .auth_policy = policyFromTrust(trust),
+            .core = tls_handshake_codec.Core.init(.client),
+        };
     }
 
     /// Allocation-free. The returned backend owns its copy of `identity` and
@@ -288,15 +326,27 @@ pub const Tls13Backend = struct {
 
     /// Client construction against an external peer verifier (#324 Web-PKI, a
     /// custom trust store, ...). The verifier's storage must outlive the
-    /// handshake.
-    pub fn initClientWithVerifier(entropy: Entropy, verifier: PeerVerifier, profile: TransportProfile) Tls13Backend {
-        return .{
+    /// handshake. `options` carries the intended server name (emitted as SNI and
+    /// passed to the verifier for hostname verification) and the explicit
+    /// policy — the verifier never inherits the insecure trust default.
+    pub fn initClientWithVerifier(entropy: Entropy, verifier: PeerVerifier, profile: TransportProfile, options: ClientOptions) Tls13Backend {
+        var self: Tls13Backend = .{
             .role = .client,
             .profile = profile,
             .entropy = entropy,
             .external_verifier = verifier,
+            .auth_policy = options.policy,
             .core = tls_handshake_codec.Core.init(.client),
         };
+        if (options.server_name) |name| {
+            // A name too long for the bounded buffer is a caller error; clamp
+            // defensively (callers pass real hostnames, well under the bound).
+            const n = @min(name.len, self.server_name.len);
+            @memcpy(self.server_name[0..n], name[0..n]);
+            self.server_name_len = n;
+            self.server_name_present = true;
+        }
+        return self;
     }
 
     pub fn backend(self: *Tls13Backend) TlsBackend {
@@ -593,6 +643,19 @@ pub const Tls13Backend = struct {
         w.patch(2, alpn_list_len);
         w.patch(2, alpn_ext_len);
 
+        // server_name (RFC 6066): the configured intended host, so the server
+        // can select on SNI and the same value reaches this side's verifier.
+        if (self.serverNameSlice()) |name| {
+            try w.u16_(ext_server_name);
+            const sni_ext_len = try w.reserve(2);
+            const sni_list_len = try w.reserve(2);
+            try w.u8_(0); // name_type host_name
+            try w.u16_(@intCast(name.len));
+            try w.bytes(name);
+            w.patch(2, sni_list_len);
+            w.patch(2, sni_ext_len);
+        }
+
         if (self.profile.extensionType()) |extension_type| {
             const payload = self.profile.localExtension() orelse return error.MissingTransportExtension;
             try w.u16_(extension_type);
@@ -691,33 +754,32 @@ pub const Tls13Backend = struct {
         var list = Reader{ .bytes = try r.slice(try r.u24_()) };
         try r.expectEnd();
 
-        // Reassemble the full chain into engine-owned storage. The verifier
-        // later sees each entry as an immutable DER view into `peer_chain`; the
-        // leaf (entry 0) additionally anchors proof-of-possession. Bounds keep
-        // a hostile peer from exhausting memory.
+        // Reassemble the *complete* chain into engine-owned storage. A verifier
+        // (especially a #324 path builder) must decide trust over exactly what
+        // the peer sent, never a prefix that happened to fit — so a chain that
+        // exceeds our bounds fails closed with a peer-attributed error rather
+        // than being silently truncated. Every CertificateEntry, leaf and
+        // intermediate, must be non-empty and within `max_certificate_len`.
         self.peer_chain_count = 0;
         self.peer_chain_len = 0;
-        const leaf_len = try list.u24_();
-        if (leaf_len == 0 or leaf_len > max_certificate_len) return error.CertificateInvalid;
-        try self.appendPeerCertificate(try list.slice(leaf_len));
-        _ = try list.slice(try list.u16_()); // leaf extensions
+        var first = true;
         while (list.remaining() > 0) {
-            const entry = try list.slice(try list.u24_());
+            const entry_len = try list.u24_();
+            if (entry_len == 0 or entry_len > max_certificate_len) return self.failCredential(.invalid_peer_certificate_chain);
+            const entry = try list.slice(entry_len);
             _ = try list.slice(try list.u16_()); // per-certificate extensions
-            // Additional chain certificates beyond our bound are framed-checked
-            // above but not retained; the leaf is what pinning verifies and a
-            // #324 verifier receives what fits.
-            self.appendPeerCertificate(entry) catch |err| switch (err) {
-                error.CertificateInvalid => {},
-                else => return err,
-            };
+            self.appendPeerCertificate(entry) catch return self.failCredential(.invalid_peer_certificate_chain);
+            first = false;
         }
+        // An empty CertificateList is only legal for client auth (an empty
+        // client Certificate); a server that presents none is malformed here.
+        if (first and self.role == .client) return self.failCredential(.invalid_peer_certificate_chain);
     }
 
     /// Copy one peer DER certificate into the bounded chain storage, recording
-    /// its view. Returns `CertificateInvalid` when the entry or the chain would
-    /// exceed the engine's bounds.
-    fn appendPeerCertificate(self: *Tls13Backend, der: []const u8) HandshakeError!void {
+    /// its view. Returns `CertificateInvalid` when the entry or the aggregate
+    /// chain would exceed the engine's bounds — the caller fails closed.
+    fn appendPeerCertificate(self: *Tls13Backend, der: []const u8) error{CertificateInvalid}!void {
         if (self.peer_chain_count >= self.peer_chain_entries.len) return error.CertificateInvalid;
         if (self.peer_chain_len + der.len > self.peer_chain.len) return error.CertificateInvalid;
         const start = self.peer_chain_len;
@@ -741,22 +803,18 @@ pub const Tls13Backend = struct {
     fn serverSelectionContext(self: *const Tls13Backend) credentials.SelectionContext {
         return .{
             .role = .server,
-            .server_name = if (self.server_name_present) self.server_name[0..self.server_name_len] else null,
+            .server_name = self.serverNameSlice(),
             .peer_signature_schemes = self.peer_sig_schemes[0..self.peer_sig_scheme_count],
             .negotiated_version = tls13_version,
             .cipher_suite = cipher_tls_aes_128_gcm_sha256,
             .application_protocol = self.alpn(),
-            .auth_policy = self.authPolicy(),
+            .auth_policy = self.auth_policy,
         };
     }
 
-    fn authPolicy(self: *const Tls13Backend) credentials.AuthPolicy {
-        return .{
-            .allow_unverified_peer = switch (self.trust) {
-                .insecure_no_verification => true,
-                .pinned_certificate => false,
-            },
-        };
+    /// The intended/parsed SNI as a borrowed slice, or null when absent.
+    fn serverNameSlice(self: *const Tls13Backend) ?[]const u8 {
+        return if (self.server_name_present) self.server_name[0..self.server_name_len] else null;
     }
 
     fn onCertificateVerify(self: *Tls13Backend, transcript_before: [hash_len]u8, body: []const u8, sink: *EventSink) HandshakeError!void {
@@ -772,7 +830,7 @@ pub const Tls13Backend = struct {
         const content = certificateVerifyContent(.server, transcript_before);
         if (!self.checkProofOfPossession(algorithm, signature, content.slice())) {
             try sink.emitCertificate(.invalid);
-            return self.failCredential(.invalid_peer_certificate_chain);
+            return self.failCredential(.certificate_verify_invalid);
         }
 
         // Delegate the trust verdict to the peer verifier — the fixed pin/
@@ -786,12 +844,12 @@ pub const Tls13Backend = struct {
         };
         const context = credentials.VerificationContext{
             .role = .client,
-            .server_name = null,
+            .server_name = self.serverNameSlice(),
             .chain = self.peerChainView(&views),
             .negotiated_version = tls13_version,
             .cipher_suite = cipher_tls_aes_128_gcm_sha256,
             .application_protocol = self.alpn(),
-            .auth_policy = self.authPolicy(),
+            .auth_policy = self.auth_policy,
         };
         const verdict = verifier.verifyPeer(&context) catch |err|
             return self.failCredential(credentials.classifyVerifyError(err));
@@ -902,6 +960,7 @@ pub const Tls13Backend = struct {
         self.server_name_len = 0;
         var offers_tls13 = false;
         var offers_x25519_group = false;
+        var saw_signature_algorithms = false;
         var peer_share: ?[X25519.public_length]u8 = null;
         var alpn_match = false;
         var first_alpn: []const u8 = "";
@@ -929,30 +988,41 @@ pub const Tls13Backend = struct {
                     }
                 },
                 ext_signature_algorithms => {
+                    saw_signature_algorithms = true;
                     var algorithms = Reader{ .bytes = try ext.slice(try ext.u16_()) };
+                    // Preserve the peer's *complete* offer in order — truncating
+                    // it would silently turn a compatible scheme in a high slot
+                    // into a false local "no compatible credential". If the offer
+                    // is larger than our bounded vector, fail rather than lie to
+                    // the selector about what the peer supports.
                     while (algorithms.remaining() > 0) {
                         const scheme = try algorithms.u16_();
-                        // Capture the peer's offers (in order) for credential
-                        // selection; ignore any past our bounded capacity.
-                        if (self.peer_sig_scheme_count < self.peer_sig_schemes.len) {
-                            self.peer_sig_schemes[self.peer_sig_scheme_count] = scheme;
-                            self.peer_sig_scheme_count += 1;
-                        }
+                        if (self.peer_sig_scheme_count >= self.peer_sig_schemes.len) return error.MalformedHandshake;
+                        self.peer_sig_schemes[self.peer_sig_scheme_count] = scheme;
+                        self.peer_sig_scheme_count += 1;
                     }
+                    try ext.expectEnd();
                 },
                 ext_server_name => {
                     // RFC 6066 §3: ServerNameList<1..>, each { name_type, name<..> }.
-                    // Preserve the first host_name (type 0) exactly as received.
+                    // Distinguish absent (no extension / no host_name) from valid
+                    // and from malformed: an empty, over-bound, or duplicated
+                    // host_name is rejected deterministically rather than being
+                    // collapsed into the default-certificate path, so a selector
+                    // never serves the default cert for an invalid SNI.
                     var names = Reader{ .bytes = try ext.slice(try ext.u16_()) };
                     while (names.remaining() > 0) {
                         const name_type = try names.u8_();
                         const name = try names.slice(try names.u16_());
-                        if (name_type == 0 and !self.server_name_present and name.len <= self.server_name.len) {
-                            @memcpy(self.server_name[0..name.len], name);
-                            self.server_name_len = name.len;
-                            self.server_name_present = true;
-                        }
+                        if (name_type != 0) continue; // only host_name is defined
+                        // RFC 6066: a given name_type must appear at most once.
+                        if (self.server_name_present) return error.IllegalParameter;
+                        if (name.len == 0 or name.len > self.server_name.len) return error.IllegalParameter;
+                        @memcpy(self.server_name[0..name.len], name);
+                        self.server_name_len = name.len;
+                        self.server_name_present = true;
                     }
+                    try ext.expectEnd();
                 },
                 ext_key_share => {
                     var shares = Reader{ .bytes = try ext.slice(try ext.u16_()) };
@@ -981,6 +1051,11 @@ pub const Tls13Backend = struct {
             }
         }
         if (!offers_tls13 or !offers_x25519_group) return error.MalformedHandshake;
+        // signature_algorithms is required whenever the server authenticates
+        // with a certificate (RFC 8446 §9.2). A missing or empty list is a
+        // malformed/missing required *peer* extension — attribute it to the
+        // peer (decode_error), not to local credential configuration.
+        if (!saw_signature_algorithms or self.peer_sig_scheme_count == 0) return error.MalformedHandshake;
         const client_share = peer_share orelse return error.MalformedHandshake;
 
         // Validate the peer share before emitting anything: X25519.scalarmult
@@ -1074,6 +1149,28 @@ pub const Tls13Backend = struct {
         // signed, or immediately on any failure below (cancellation included).
         defer credential.release();
 
+        // Validate provider output before trusting it. A buggy or hostile
+        // provider must not make the engine emit a CertificateVerify scheme the
+        // client never offered, nor a chain that overflows the flight buffer as
+        // a generic writer error. Every violation is a local provider fault, and
+        // signing never happens when validation fails.
+        if (!selection.offersScheme(credential.scheme))
+            return self.failCredential(.invalid_callback_behavior);
+        const chain = credential.certificateChain();
+        if (chain.count() == 0 or chain.count() > credentials.max_chain_entries)
+            return self.failCredential(.malformed_credential_chain);
+        var encoded_len: usize = 0;
+        for (chain.entries) |entry| {
+            if (entry.len == 0 or entry.len > max_certificate_len)
+                return self.failCredential(.malformed_credential_chain);
+            // CertificateEntry framing overhead: 3-byte cert_data length +
+            // 2-byte extensions length.
+            encoded_len = std.math.add(usize, encoded_len, entry.len + 5) catch
+                return self.failCredential(.malformed_credential_chain);
+            if (encoded_len > max_message_len)
+                return self.failCredential(.malformed_credential_chain);
+        }
+
         var buf: [max_message_len]u8 = undefined;
         var w = Writer{ .buf = &buf };
 
@@ -1100,17 +1197,14 @@ pub const Tls13Backend = struct {
         w.patch(3, ee_len);
         const encrypted_extensions = buf[0..w.len];
 
-        // Certificate: the selected credential's public DER chain. The views
-        // are borrowed for this call only and never retained past it.
-        const chain = credential.certificateChain();
-        if (chain.count() == 0) return self.failCredential(.malformed_credential_chain);
+        // Certificate: the selected credential's validated public DER chain,
+        // valid until `release`. The chain was bounds-checked above.
         const cert_start = w.len;
         try w.u8_(@intFromEnum(MessageType.certificate));
         const cert_len = try w.reserve(3);
         try w.u8_(0); // certificate_request_context
         const list_len = try w.reserve(3);
         for (chain.entries) |entry| {
-            if (entry.len == 0 or entry.len > max_certificate_len) return self.failCredential(.malformed_credential_chain);
             const entry_len = try w.reserve(3);
             try w.bytes(entry);
             w.patch(3, entry_len);

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -1391,3 +1391,212 @@ test "an absent intended hostname reaches the verifier as null" {
     try h.driveUntil(SocketHarness.bothComplete);
     try std.testing.expect(verifier.lastServerName() == null);
 }
+
+// --------------------------------------------------------------------------
+// Review round 2 (#334) finding 2: asynchronous / event-driven progression.
+// The engine parks a pending select / sign / verify, resumes without recording
+// any handshake message twice, and cancels + releases exactly once on
+// teardown. These drive the parking machinery directly.
+// --------------------------------------------------------------------------
+
+/// Concatenate all handshake-epoch crypto bytes an engine emitted into `out`.
+fn collectHandshakeCrypto(sink: *const DirectSink, out: []u8) []const u8 {
+    var len: usize = 0;
+    for (sink.items[0..sink.len]) |event| {
+        switch (event) {
+            .handshake_bytes => |hb| if (hb.epoch == .handshake) {
+                @memcpy(out[len..][0..hb.data.len], hb.data);
+                len += hb.data.len;
+            },
+            else => {},
+        }
+    }
+    return out[0..len];
+}
+
+fn certificateStateIn(sink: *const DirectSink) ?events.CertificateState {
+    var found: ?events.CertificateState = null;
+    for (sink.items[0..sink.len]) |event| {
+        switch (event) {
+            .certificate => |state| found = state,
+            else => {},
+        }
+    }
+    return found;
+}
+
+fn firstInitialCrypto(sink: *const DirectSink, out: []u8) []const u8 {
+    for (sink.items[0..sink.len]) |event| {
+        switch (event) {
+            .handshake_bytes => |hb| if (hb.epoch == .initial) {
+                @memcpy(out[0..hb.data.len], hb.data);
+                return out[0..hb.data.len];
+            },
+            else => {},
+        }
+    }
+    return out[0..0];
+}
+
+test "an async credential selection suspends the handshake and resumes to completion" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.async_select = true;
+    mock.pending_polls = 2;
+    var server = serverWithProvider(&mock);
+    defer server.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{});
+    try server.backend().receive(.initial, hello, &sink);
+
+    // Parked awaiting the async selection; nothing signed yet.
+    try std.testing.expect(server.authPending());
+    try std.testing.expectEqual(@as(usize, 1), mock.select_count);
+    try std.testing.expectEqual(@as(usize, 0), mock.sign_count);
+
+    try server.resumeAuth(&sink); // poll #1: still pending
+    try std.testing.expect(server.authPending());
+    try server.resumeAuth(&sink); // poll #2: still pending
+    try std.testing.expect(server.authPending());
+    try server.resumeAuth(&sink); // poll #3: completes, runs the rest of the flight
+    try std.testing.expect(!server.authPending());
+
+    try std.testing.expectEqual(@as(usize, 3), mock.poll_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.op_release_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.sign_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.release_count);
+    try std.testing.expect(server.credentialFailure() == null);
+}
+
+test "an async signature suspends after the certificate and resumes to completion" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.async_sign = true;
+    mock.pending_polls = 1;
+    var server = serverWithProvider(&mock);
+    defer server.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{});
+    try server.backend().receive(.initial, hello, &sink);
+
+    try std.testing.expect(server.authPending()); // parked awaiting the signature
+    try std.testing.expectEqual(@as(usize, 1), mock.select_count);
+    try server.resumeAuth(&sink); // poll #1: still pending
+    try std.testing.expect(server.authPending());
+    try server.resumeAuth(&sink); // poll #2: completes
+    try std.testing.expect(!server.authPending());
+    try std.testing.expectEqual(@as(usize, 1), mock.sign_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.release_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.op_release_count);
+    try std.testing.expect(server.credentialFailure() == null);
+}
+
+test "a cancelled async signature releases the operation and credential exactly once" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.async_sign = true;
+    mock.pending_polls = 5; // never completes before teardown
+    var server = serverWithProvider(&mock);
+    var sink = DirectSink{};
+    try server.backend().start(.server, {}, &sink);
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{});
+    try server.backend().receive(.initial, hello, &sink);
+    try std.testing.expect(server.authPending());
+
+    sink.deinit();
+    server.deinit(); // cancels the parked op and releases the held credential
+
+    try std.testing.expectEqual(@as(usize, 1), mock.cancel_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.op_release_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.release_count);
+}
+
+test "an async signing failure latches the typed signing-provider failure" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.async_sign = true;
+    mock.pending_polls = 0;
+    mock.pending_fails = true;
+    var server = serverWithProvider(&mock);
+    defer server.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{});
+    try server.backend().receive(.initial, hello, &sink);
+    try std.testing.expect(server.authPending());
+
+    try std.testing.expectError(error.CredentialProviderFailed, server.resumeAuth(&sink));
+    try std.testing.expectEqual(tls_backend.CredentialFailure.signing_provider_failure, server.credentialFailure().?);
+    try std.testing.expectEqual(@as(usize, 1), mock.cancel_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.op_release_count);
+}
+
+/// Drive a client backend up to (and through) CertificateVerify against a
+/// cooperating fixed-identity server backend, so the client's peer verifier is
+/// exercised. Leaves the client parked if its verifier went async.
+fn driveClientThroughCertificateVerify(client: *tls_backend.Tls13Backend, client_sink: *DirectSink) !void {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = "h2" } });
+    defer server.deinit();
+    var server_sink = DirectSink{};
+    defer server_sink.deinit();
+
+    try client.backend().start(.client, {}, client_sink);
+    var ch_buf: [1024]u8 = undefined;
+    const client_hello = firstInitialCrypto(client_sink, &ch_buf);
+
+    try server.backend().start(.server, {}, &server_sink);
+    try server.backend().receive(.initial, client_hello, &server_sink);
+
+    var sh_buf: [512]u8 = undefined;
+    const server_hello = firstInitialCrypto(&server_sink, &sh_buf);
+    var flight_buf: [4096]u8 = undefined;
+    const flight = collectHandshakeCrypto(&server_sink, &flight_buf);
+
+    client_sink.reset();
+    try client.backend().receive(.initial, server_hello, client_sink);
+    // Feed the server's EncryptedExtensions..Finished; the client parks at
+    // CertificateVerify if its verifier is asynchronous.
+    try client.backend().receive(.handshake, flight, client_sink);
+}
+
+test "an async peer verification suspends the client and resumes to acceptance" {
+    var verifier = credentials.MockVerifier.init(.accepted);
+    verifier.async_mode = true;
+    verifier.pending_polls = 2;
+    var client = tls_backend.Tls13Backend.initClientWithVerifier(clientEntropy(), verifier.verifier(), .{ .record = .{ .alpn = "h2" } }, .{ .server_name = "tardigrade.test" });
+    defer client.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try driveClientThroughCertificateVerify(&client, &sink);
+
+    try std.testing.expect(client.authPending());
+    try std.testing.expectEqual(@as(usize, 1), verifier.verify_count);
+    try client.resumeAuth(&sink); // poll #1
+    try std.testing.expect(client.authPending());
+    try client.resumeAuth(&sink); // poll #2
+    try std.testing.expect(client.authPending());
+    try client.resumeAuth(&sink); // completes -> accepted
+    try std.testing.expect(!client.authPending());
+    try std.testing.expectEqual(events.CertificateState.valid, certificateStateIn(&sink).?);
+    try std.testing.expect(client.credentialFailure() == null);
+}
+
+test "a cancelled async peer verification cancels and releases the operation once" {
+    var verifier = credentials.MockVerifier.init(.accepted);
+    verifier.async_mode = true;
+    verifier.pending_polls = 5;
+    var client = tls_backend.Tls13Backend.initClientWithVerifier(clientEntropy(), verifier.verifier(), .{ .record = .{ .alpn = "h2" } }, .{});
+    var sink = DirectSink{};
+    try driveClientThroughCertificateVerify(&client, &sink);
+    try std.testing.expect(client.authPending());
+
+    sink.deinit();
+    client.deinit();
+    try std.testing.expectEqual(@as(usize, 1), verifier.cancel_count);
+    try std.testing.expectEqual(@as(usize, 1), verifier.op_release_count);
+}

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -627,6 +627,7 @@ const SocketHarness = struct {
         /// is used through the same production contract.
         server_provider: ?tls_backend.CredentialProvider = null,
         client_verifier: ?tls_backend.PeerVerifier = null,
+        client_options: tls_backend.Tls13Backend.ClientOptions = .{},
     };
 
     fn create(opts: Options) !*SocketHarness {
@@ -641,7 +642,7 @@ const SocketHarness = struct {
         self.fds_closed = .{ false, false };
 
         self.client_engine = if (opts.client_verifier) |verifier|
-            tls_backend.Tls13Backend.initClientWithVerifier(clientEntropy(), verifier, .{ .record = .{ .alpn = opts.client_alpn } })
+            tls_backend.Tls13Backend.initClientWithVerifier(clientEntropy(), verifier, .{ .record = .{ .alpn = opts.client_alpn } }, opts.client_options)
         else
             tls_backend.Tls13Backend.initClient(clientEntropy(), opts.client_trust, .{ .record = .{ .alpn = opts.client_alpn } });
         self.server_engine = if (opts.server_provider) |provider|
@@ -962,6 +963,9 @@ const X25519 = std.crypto.dh.X25519;
 
 const ClientHelloOptions = struct {
     sni: ?[]const u8 = null,
+    /// Raw bytes to place verbatim as the server_name extension body (the
+    /// ServerNameList), for crafting malformed/duplicate SNI. Overrides `sni`.
+    sni_raw: ?[]const u8 = null,
     sig_schemes: []const u16 = &.{ 0x0807, 0x0403 },
     alpn: []const u8 = "h2",
 };
@@ -1015,7 +1019,11 @@ fn buildClientHello(buf: []u8, opts: ClientHelloOptions) ![]const u8 {
     w.patch(2, alpn_list);
     w.patch(2, alpn_ext);
     // server_name (optional)
-    if (opts.sni) |sni| {
+    if (opts.sni_raw) |raw| {
+        try w.u16_(0);
+        try w.u16_(@intCast(raw.len));
+        try w.bytes(raw);
+    } else if (opts.sni) |sni| {
         try w.u16_(0);
         const sni_ext = try w.reserve(2);
         const sni_list = try w.reserve(2);
@@ -1047,8 +1055,8 @@ test "exact SNI reaches credential selection through a mock provider" {
 
     try driveServerSelection(&server, .{ .sni = "exact.example.test" });
     try std.testing.expectEqual(@as(usize, 1), mock.select_count);
-    try std.testing.expect(mock.last_server_name != null);
-    try std.testing.expectEqualStrings("exact.example.test", mock.last_server_name.?);
+    try std.testing.expect(mock.lastServerName() != null);
+    try std.testing.expectEqualStrings("exact.example.test", mock.lastServerName().?);
     // A selected credential is signed with exactly once and released exactly once.
     try std.testing.expectEqual(@as(usize, 1), mock.sign_count);
     try std.testing.expectEqual(@as(usize, 1), mock.release_count);
@@ -1061,7 +1069,7 @@ test "absent SNI reaches selection deterministically as null" {
 
     try driveServerSelection(&server, .{ .sni = null });
     try std.testing.expectEqual(@as(usize, 1), mock.select_count);
-    try std.testing.expect(mock.last_server_name == null);
+    try std.testing.expect(mock.lastServerName() == null);
 }
 
 test "selection sees the peer's offered schemes and picks a compatible credential" {
@@ -1212,7 +1220,7 @@ test "a bad CertificateVerify signature fails proof of possession at the client"
     const failures = driveUntilBothErrors(h);
     try std.testing.expectEqual(@as(?anyerror, error.CertificateInvalid), failures.client);
     try std.testing.expect(!h.client.bridge.handshake_complete);
-    try std.testing.expectEqual(tls_backend.CredentialFailure.invalid_peer_certificate_chain, h.client_engine.credentialFailure().?);
+    try std.testing.expectEqual(tls_backend.CredentialFailure.certificate_verify_invalid, h.client_engine.credentialFailure().?);
 }
 
 test "the fixed provider replaces the previous hard-coded identity with no engine change" {
@@ -1241,4 +1249,145 @@ test "provider and verifier mocks under allocation failure clean up" {
             harness.destroy();
         }
     }.run, .{});
+}
+
+// --------------------------------------------------------------------------
+// Review round 2 (#334): ClientHello metadata fidelity, provider-output
+// validation, verifier identity/policy, and the expanded failure taxonomy.
+// --------------------------------------------------------------------------
+
+fn serverWithProvider(mock: *credentials.MockCredentialProvider) tls_backend.Tls13Backend {
+    return tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .{ .record = .{ .alpn = "h2" } });
+}
+
+fn expectServerReceiveError(server: *tls_backend.Tls13Backend, opts: ClientHelloOptions, want: anyerror) !void {
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+    var buf: [2048]u8 = undefined;
+    const hello = try buildClientHello(&buf, opts);
+    try std.testing.expectError(want, server.backend().receive(.initial, hello, &sink));
+}
+
+test "a compatible signature scheme past the legacy cap is still selected" {
+    // 17 filler schemes, then Ed25519 in slot 18: truncation at 16 would have
+    // hidden it and produced a false NoCompatibleSignatureAlgorithm.
+    var schemes: [18]u16 = undefined;
+    for (0..17) |i| schemes[i] = @intCast(0xfe00 + i);
+    schemes[17] = 0x0807; // ed25519
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = "h2" } });
+    defer server.deinit();
+    try driveServerSelection(&server, .{ .sig_schemes = &schemes });
+    try std.testing.expect(server.credentialFailure() == null);
+}
+
+test "a signature_algorithms offer larger than the bound fails closed" {
+    var schemes: [80]u16 = undefined;
+    for (0..80) |i| schemes[i] = @intCast(0xfe00 + i);
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = "h2" } });
+    defer server.deinit();
+    try expectServerReceiveError(&server, .{ .sig_schemes = &schemes }, error.MalformedHandshake);
+}
+
+test "an empty signature_algorithms list is a peer-attributed malformed ClientHello" {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = "h2" } });
+    defer server.deinit();
+    try expectServerReceiveError(&server, .{ .sig_schemes = &.{} }, error.MalformedHandshake);
+}
+
+test "malformed SNI is rejected rather than collapsed into the default path" {
+    // Empty host_name.
+    {
+        var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = "h2" } });
+        defer server.deinit();
+        // ServerNameList<len=3>{ name_type=0, host_name<len=0> }
+        const empty_host = [_]u8{ 0x00, 0x03, 0x00, 0x00, 0x00 };
+        try expectServerReceiveError(&server, .{ .sni_raw = &empty_host }, error.IllegalParameter);
+    }
+    // Duplicate host_name entries (RFC 6066 forbids a repeated name_type).
+    {
+        var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = "h2" } });
+        defer server.deinit();
+        // ServerNameList<len=8>{ {0,"a"}, {0,"b"} }
+        const dup = [_]u8{ 0x00, 0x08, 0x00, 0x00, 0x01, 'a', 0x00, 0x00, 0x01, 'b' };
+        try expectServerReceiveError(&server, .{ .sni_raw = &dup }, error.IllegalParameter);
+    }
+}
+
+test "a provider returning an unoffered scheme is rejected before signing" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity()); // ed25519
+    mock.ignore_offer = true; // hand back ed25519 even though the peer omits it
+    var server = serverWithProvider(&mock);
+    defer server.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{ .sig_schemes = &.{0x0403} }); // ECDSA only
+    try std.testing.expectError(error.CredentialProviderFailed, server.backend().receive(.initial, hello, &sink));
+    try std.testing.expectEqual(tls_backend.CredentialFailure.invalid_callback_behavior, server.credentialFailure().?);
+    try std.testing.expectEqual(@as(usize, 0), mock.sign_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.release_count);
+}
+
+test "a provider chain exceeding the bounds is rejected without signing" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.chain_repeat = 12; // beyond max_chain_entries
+    var server = serverWithProvider(&mock);
+    defer server.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{});
+    try std.testing.expectError(error.CredentialProviderFailed, server.backend().receive(.initial, hello, &sink));
+    try std.testing.expectEqual(tls_backend.CredentialFailure.malformed_credential_chain, server.credentialFailure().?);
+    try std.testing.expectEqual(@as(usize, 0), mock.sign_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.release_count);
+}
+
+test "a provider internal failure is attributed to the provider, not the verifier" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.force_select_error = error.ProviderInternalFailure;
+    var server = serverWithProvider(&mock);
+    defer server.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{});
+    try std.testing.expectError(error.CredentialProviderFailed, server.backend().receive(.initial, hello, &sink));
+    try std.testing.expectEqual(tls_backend.CredentialFailure.provider_internal_failure, server.credentialFailure().?);
+}
+
+test "the verifier observes the exact intended hostname and explicit policy" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    var verifier = credentials.MockVerifier.init(.accepted);
+    const h = try SocketHarness.create(.{
+        .server_provider = mock.provider(),
+        .client_verifier = verifier.verifier(),
+        .client_options = .{ .server_name = "verify.example.test", .policy = .{ .require_peer_authentication = true } },
+    });
+    defer h.destroy();
+    try h.driveUntil(SocketHarness.bothComplete);
+
+    // The client emitted SNI, so the server's selector saw it too.
+    try std.testing.expect(mock.lastServerName() != null);
+    try std.testing.expectEqualStrings("verify.example.test", mock.lastServerName().?);
+    // The verifier received the exact hostname and the caller's explicit policy.
+    try std.testing.expect(verifier.lastServerName() != null);
+    try std.testing.expectEqualStrings("verify.example.test", verifier.lastServerName().?);
+    try std.testing.expect(verifier.last_policy.require_peer_authentication);
+    try std.testing.expect(!verifier.last_policy.allow_unverified_peer);
+}
+
+test "an absent intended hostname reaches the verifier as null" {
+    var verifier = credentials.MockVerifier.init(.accepted);
+    const h = try SocketHarness.create(.{
+        .client_verifier = verifier.verifier(),
+        .client_options = .{ .server_name = null },
+    });
+    defer h.destroy();
+    try h.driveUntil(SocketHarness.bothComplete);
+    try std.testing.expect(verifier.lastServerName() == null);
 }

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -16,6 +16,7 @@ const tls_backend = tls_core.tls13_backend;
 
 const record_codec = tls_core.record_codec;
 const events = tls_core.events;
+const credentials = tls_core.credentials;
 
 fn clientEntropy() tls_backend.Entropy {
     return .{ .hello_random = [_]u8{0xc1} ** 32, .key_share_seed = [_]u8{0x11} ** 32 };
@@ -621,6 +622,11 @@ const SocketHarness = struct {
         client_alpn: []const u8 = "h2",
         server_alpn: []const u8 = "h2",
         one_write_per_drive: bool = false,
+        /// Optional external credential provider / peer verifier (mocks). Their
+        /// storage must outlive the harness. When null, the fixed identity/trust
+        /// is used through the same production contract.
+        server_provider: ?tls_backend.CredentialProvider = null,
+        client_verifier: ?tls_backend.PeerVerifier = null,
     };
 
     fn create(opts: Options) !*SocketHarness {
@@ -634,8 +640,14 @@ const SocketHarness = struct {
         self.fds = try testSocketPair();
         self.fds_closed = .{ false, false };
 
-        self.client_engine = tls_backend.Tls13Backend.initClient(clientEntropy(), opts.client_trust, .{ .record = .{ .alpn = opts.client_alpn } });
-        self.server_engine = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = opts.server_alpn } });
+        self.client_engine = if (opts.client_verifier) |verifier|
+            tls_backend.Tls13Backend.initClientWithVerifier(clientEntropy(), verifier, .{ .record = .{ .alpn = opts.client_alpn } })
+        else
+            tls_backend.Tls13Backend.initClient(clientEntropy(), opts.client_trust, .{ .record = .{ .alpn = opts.client_alpn } });
+        self.server_engine = if (opts.server_provider) |provider|
+            tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), provider, .{ .record = .{ .alpn = opts.server_alpn } })
+        else
+            tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = opts.server_alpn } });
         self.client_carrier = .{ .fd = self.fds[0], .max_chunk = opts.client_chunk, .one_write_per_drive = opts.one_write_per_drive };
         self.server_carrier = .{ .fd = self.fds[1], .max_chunk = opts.server_chunk, .one_write_per_drive = opts.one_write_per_drive };
 
@@ -936,4 +948,297 @@ test "record stream requires explicit opt-in for an unverified client certificat
     try std.testing.expect(opted_in.client.bridge.handshake_complete);
     try std.testing.expect(opted_in.server.bridge.handshake_complete);
     try std.testing.expectEqual(events.CertificateState.not_checked, opted_in.client.certificateState());
+}
+// ==========================================================================
+// Credential provider / peer verifier contract integration (#334). These
+// drive the production engine through the new provider and verifier seams and
+// assert callback invocation counts and exact lifetime transitions, not merely
+// final success/failure.
+// ==========================================================================
+
+const HsWriter = tls_core.handshake.Writer;
+const HsMessageType = tls_core.handshake.MessageType;
+const X25519 = std.crypto.dh.X25519;
+
+const ClientHelloOptions = struct {
+    sni: ?[]const u8 = null,
+    sig_schemes: []const u16 = &.{ 0x0807, 0x0403 },
+    alpn: []const u8 = "h2",
+};
+
+/// Build a minimal, well-formed TLS 1.3 ClientHello the server engine accepts,
+/// with an optional SNI and a caller-chosen signature_algorithms list. Returns
+/// the message slice into `buf`.
+fn buildClientHello(buf: []u8, opts: ClientHelloOptions) ![]const u8 {
+    const seed: [X25519.seed_length]u8 = [_]u8{0x33} ** X25519.seed_length;
+    const key_pair = try X25519.KeyPair.generateDeterministic(seed);
+    var w = HsWriter{ .buf = buf };
+    try w.u8_(@intFromEnum(HsMessageType.client_hello));
+    const message_len = try w.reserve(3);
+    try w.u16_(0x0303); // legacy_version
+    try w.bytes(&([_]u8{0x77} ** 32)); // random
+    try w.u8_(0); // session_id
+    try w.u16_(2); // cipher_suites
+    try w.u16_(0x1301);
+    try w.u8_(1); // compression methods
+    try w.u8_(0);
+
+    const extensions_len = try w.reserve(2);
+    // supported_versions
+    try w.u16_(43);
+    try w.u16_(3);
+    try w.u8_(2);
+    try w.u16_(0x0304);
+    // supported_groups
+    try w.u16_(10);
+    try w.u16_(4);
+    try w.u16_(2);
+    try w.u16_(0x001d);
+    // signature_algorithms
+    try w.u16_(13);
+    try w.u16_(@intCast(2 + 2 * opts.sig_schemes.len));
+    try w.u16_(@intCast(2 * opts.sig_schemes.len));
+    for (opts.sig_schemes) |scheme| try w.u16_(scheme);
+    // key_share
+    try w.u16_(51);
+    try w.u16_(2 + 2 + 2 + X25519.public_length);
+    try w.u16_(2 + 2 + X25519.public_length);
+    try w.u16_(0x001d);
+    try w.u16_(X25519.public_length);
+    try w.bytes(&key_pair.public_key);
+    // alpn
+    try w.u16_(16);
+    const alpn_ext = try w.reserve(2);
+    const alpn_list = try w.reserve(2);
+    try w.u8_(@intCast(opts.alpn.len));
+    try w.bytes(opts.alpn);
+    w.patch(2, alpn_list);
+    w.patch(2, alpn_ext);
+    // server_name (optional)
+    if (opts.sni) |sni| {
+        try w.u16_(0);
+        const sni_ext = try w.reserve(2);
+        const sni_list = try w.reserve(2);
+        try w.u8_(0); // name_type host_name
+        try w.u16_(@intCast(sni.len));
+        try w.bytes(sni);
+        w.patch(2, sni_list);
+        w.patch(2, sni_ext);
+    }
+    w.patch(2, extensions_len);
+    w.patch(3, message_len);
+    return buf[0..w.len];
+}
+
+/// Drive a server engine through selection by feeding it one ClientHello.
+fn driveServerSelection(server: *tls_backend.Tls13Backend, opts: ClientHelloOptions) !void {
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, opts);
+    try server.backend().receive(.initial, hello, &sink);
+}
+
+test "exact SNI reaches credential selection through a mock provider" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .{ .record = .{ .alpn = "h2" } });
+    defer server.deinit();
+
+    try driveServerSelection(&server, .{ .sni = "exact.example.test" });
+    try std.testing.expectEqual(@as(usize, 1), mock.select_count);
+    try std.testing.expect(mock.last_server_name != null);
+    try std.testing.expectEqualStrings("exact.example.test", mock.last_server_name.?);
+    // A selected credential is signed with exactly once and released exactly once.
+    try std.testing.expectEqual(@as(usize, 1), mock.sign_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.release_count);
+}
+
+test "absent SNI reaches selection deterministically as null" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .{ .record = .{ .alpn = "h2" } });
+    defer server.deinit();
+
+    try driveServerSelection(&server, .{ .sni = null });
+    try std.testing.expectEqual(@as(usize, 1), mock.select_count);
+    try std.testing.expect(mock.last_server_name == null);
+}
+
+test "selection sees the peer's offered schemes and picks a compatible credential" {
+    // Fixed Ed25519 identity; the peer offers ECDSA first then Ed25519. The
+    // fixed provider still binds, proving order-independent compatibility.
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = "h2" } });
+    defer server.deinit();
+    try driveServerSelection(&server, .{ .sig_schemes = &.{ 0x0403, 0x0807 } });
+    try std.testing.expect(server.credentialFailure() == null);
+}
+
+test "no compatible signature algorithm fails with handshake_failure attribution" {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = "h2" } });
+    defer server.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+    var buf: [1024]u8 = undefined;
+    // Peer offers only ECDSA; the Ed25519 fixed credential is incompatible.
+    const hello = try buildClientHello(&buf, .{ .sig_schemes = &.{0x0403} });
+    try std.testing.expectError(error.NoApplicableCredential, server.backend().receive(.initial, hello, &sink));
+    try std.testing.expectEqual(tls_backend.CredentialFailure.no_compatible_signature_algorithm, server.credentialFailure().?);
+    try std.testing.expectEqual(
+        tls_core.alerts.AlertDescription.handshake_failure,
+        server.credentialFailure().?.alert(),
+    );
+}
+
+test "no credential available fails deterministically and preserves the failure" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.force_select_error = error.NoCredentialAvailable;
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .{ .record = .{ .alpn = "h2" } });
+    defer server.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{});
+    try std.testing.expectError(error.NoApplicableCredential, server.backend().receive(.initial, hello, &sink));
+    try std.testing.expectEqual(tls_backend.CredentialFailure.no_credential_available, server.credentialFailure().?);
+    try std.testing.expectEqual(@as(usize, 0), mock.sign_count);
+    try std.testing.expectEqual(@as(usize, 0), mock.release_count);
+    // Terminal cleanup preserves the underlying typed failure (#334).
+    server.deinit();
+    try std.testing.expectEqual(tls_backend.CredentialFailure.no_credential_available, server.credentialFailure().?);
+}
+
+test "an empty local credential chain is rejected before signing" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.empty_chain = true;
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .{ .record = .{ .alpn = "h2" } });
+    defer server.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{});
+    try std.testing.expectError(error.CredentialProviderFailed, server.backend().receive(.initial, hello, &sink));
+    try std.testing.expectEqual(tls_backend.CredentialFailure.malformed_credential_chain, server.credentialFailure().?);
+    // The handle was released exactly once even on the failure path.
+    try std.testing.expectEqual(@as(usize, 1), mock.release_count);
+}
+
+test "a signing provider failure maps to internal_error and releases the handle" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.force_sign_error = error.SigningProviderFailure;
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .{ .record = .{ .alpn = "h2" } });
+    defer server.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{});
+    try std.testing.expectError(error.CredentialProviderFailed, server.backend().receive(.initial, hello, &sink));
+    try std.testing.expectEqual(tls_backend.CredentialFailure.signing_provider_failure, server.credentialFailure().?);
+    try std.testing.expectEqual(@as(usize, 1), mock.sign_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.release_count);
+}
+
+test "an over-length reported signature is caught as a provider contract violation" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.force_sign_len = 4096; // far beyond the engine's bounded scratch
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .{ .record = .{ .alpn = "h2" } });
+    defer server.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{});
+    try std.testing.expectError(error.CredentialProviderFailed, server.backend().receive(.initial, hello, &sink));
+    try std.testing.expectEqual(tls_backend.CredentialFailure.invalid_callback_behavior, server.credentialFailure().?);
+}
+
+test "successful server handshake and peer verification through mock provider and verifier" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    var verifier = credentials.MockVerifier.init(.accepted);
+    const h = try SocketHarness.create(.{
+        .server_provider = mock.provider(),
+        .client_verifier = verifier.verifier(),
+    });
+    defer h.destroy();
+
+    try h.driveUntil(SocketHarness.bothComplete);
+    try std.testing.expect(h.client.bridge.handshake_complete);
+    try std.testing.expect(h.server.bridge.handshake_complete);
+    // Exact lifetime transitions: one selection, one signature, one release,
+    // one verification.
+    try std.testing.expectEqual(@as(usize, 1), mock.select_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.sign_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.release_count);
+    try std.testing.expectEqual(@as(usize, 1), verifier.verify_count);
+    try std.testing.expectEqual(@as(usize, 1), verifier.last_chain_len);
+    try std.testing.expectEqual(events.CertificateState.valid, h.client.certificateState());
+}
+
+test "peer verifier rejection fails the client as a peer authentication failure" {
+    var verifier = credentials.MockVerifier.init(.rejected);
+    const h = try SocketHarness.create(.{ .client_verifier = verifier.verifier() });
+    defer h.destroy();
+
+    const failures = driveUntilBothErrors(h);
+    try std.testing.expectEqual(@as(?anyerror, error.CertificateInvalid), failures.client);
+    try std.testing.expect(!h.client.bridge.handshake_complete);
+    try std.testing.expectEqual(tls_backend.CredentialFailure.peer_verification_rejected, h.client_engine.credentialFailure().?);
+    try std.testing.expectEqual(@as(usize, 1), verifier.verify_count);
+}
+
+test "a peer verifier internal failure is a local fault, not a peer rejection" {
+    var verifier = credentials.MockVerifier.init(error.VerifierInternalFailure);
+    const h = try SocketHarness.create(.{ .client_verifier = verifier.verifier() });
+    defer h.destroy();
+
+    const failures = driveUntilBothErrors(h);
+    try std.testing.expectEqual(@as(?anyerror, error.CredentialProviderFailed), failures.client);
+    try std.testing.expectEqual(tls_backend.CredentialFailure.verifier_internal_failure, h.client_engine.credentialFailure().?);
+    try std.testing.expectEqual(
+        tls_core.alerts.AlertDescription.internal_error,
+        h.client_engine.credentialFailure().?.alert(),
+    );
+}
+
+test "a bad CertificateVerify signature fails proof of possession at the client" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.flip_signature = true;
+    const h = try SocketHarness.create(.{ .server_provider = mock.provider() });
+    defer h.destroy();
+
+    const failures = driveUntilBothErrors(h);
+    try std.testing.expectEqual(@as(?anyerror, error.CertificateInvalid), failures.client);
+    try std.testing.expect(!h.client.bridge.handshake_complete);
+    try std.testing.expectEqual(tls_backend.CredentialFailure.invalid_peer_certificate_chain, h.client_engine.credentialFailure().?);
+}
+
+test "the fixed provider replaces the previous hard-coded identity with no engine change" {
+    // The default harness uses initServer(fixtureIdentity) -> the fixed
+    // provider, driving the same engine path a mock or external provider does.
+    const h = try SocketHarness.create(.{});
+    defer h.destroy();
+    try h.driveUntil(SocketHarness.bothComplete);
+    try std.testing.expect(h.client.bridge.handshake_complete);
+    try std.testing.expect(h.server.bridge.handshake_complete);
+    try std.testing.expectEqual(events.CertificateState.valid, h.client.certificateState());
+    // No credential failure was latched on the success path.
+    try std.testing.expect(h.server_engine.credentialFailure() == null);
+    try std.testing.expect(h.client_engine.credentialFailure() == null);
+}
+
+test "provider and verifier mocks under allocation failure clean up" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, struct {
+        fn run(allocator: std.mem.Allocator) !void {
+            var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+            var verifier = credentials.MockVerifier.init(.accepted);
+            const harness = try SocketHarness.createWithAllocator(allocator, .{
+                .server_provider = mock.provider(),
+                .client_verifier = verifier.verifier(),
+            });
+            harness.destroy();
+        }
+    }.run, .{});
 }

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -1324,6 +1324,52 @@ test "a bad CertificateVerify signature fails proof of possession at the client"
     try std.testing.expectEqual(tls_backend.CredentialFailure.certificate_verify_invalid, h.client_engine.credentialFailure().?);
 }
 
+test "CertificateVerify with a supported but incompatible certificate key is decrypt_error" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.scheme_override = .ecdsa_secp256r1_sha256;
+    var verifier = credentials.MockVerifier.init(.accepted);
+    const h = try SocketHarness.create(.{ .server_provider = mock.provider(), .client_verifier = verifier.verifier() });
+    defer h.destroy();
+
+    const failures = driveUntilBothErrors(h);
+    try std.testing.expectEqual(@as(?anyerror, error.DecryptError), failures.client);
+    try std.testing.expectEqual(@as(?anyerror, error.PeerFatalAlert), failures.server);
+    try std.testing.expectEqual(tls_backend.CredentialFailure.certificate_verify_invalid, h.client_engine.credentialFailure().?);
+    try std.testing.expectEqual(
+        tls_core.alerts.AlertDescription.decrypt_error,
+        h.client_engine.credentialFailure().?.alert(),
+    );
+}
+
+fn malformedEd25519PublicKeyCertificate(out: *[tls_backend.testdata.certificate_der.len]u8) []const u8 {
+    @memcpy(out, tls_backend.testdata.certificate_der);
+    const parsed = (std.crypto.Certificate{ .buffer = out, .index = 0 }).parse() catch unreachable;
+    const pub_key = parsed.pubKey();
+    const offset = @intFromPtr(pub_key.ptr) - @intFromPtr(out);
+    @memset(out[offset..][0..pub_key.len], 0xff);
+    return out[0..];
+}
+
+test "malformed supported Ed25519 public key is bad_certificate" {
+    var cert: [tls_backend.testdata.certificate_der.len]u8 = undefined;
+    const malformed = malformedEd25519PublicKeyCertificate(&cert);
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.chain_entry = .{malformed};
+    var verifier = credentials.MockVerifier.init(.accepted);
+    const h = try SocketHarness.create(.{ .server_provider = mock.provider(), .client_verifier = verifier.verifier() });
+    defer h.destroy();
+
+    const failures = driveUntilBothErrors(h);
+    try std.testing.expectEqual(@as(?anyerror, error.CertificateInvalid), failures.client);
+    try std.testing.expectEqual(@as(?anyerror, error.PeerFatalAlert), failures.server);
+    try std.testing.expectEqual(tls_backend.CredentialFailure.invalid_peer_certificate_chain, h.client_engine.credentialFailure().?);
+    try std.testing.expectEqual(
+        tls_core.alerts.AlertDescription.bad_certificate,
+        h.client_engine.credentialFailure().?.alert(),
+    );
+    try std.testing.expectEqual(@as(usize, 0), verifier.verify_count);
+}
+
 test "the fixed provider replaces the previous hard-coded identity with no engine change" {
     // The default harness uses initServer(fixtureIdentity) -> the fixed
     // provider, driving the same engine path a mock or external provider does.
@@ -1977,6 +2023,63 @@ test "async client signing suspends after the client Certificate and resumes to 
     try std.testing.expect(server.credentialFailure() == null);
 }
 
+test "pending client credential selection rejects later handshake bytes and cancels once" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.async_select = true;
+    mock.pending_polls = 5;
+    var client = clientWithLocalCredential(mock.provider());
+    defer client.deinit();
+    var verifier = credentials.MockVerifier.init(.accepted);
+    var server = serverRequestingClientAuth(.required, verifier.verifier());
+    defer server.deinit();
+
+    var client_sink = DirectSink{};
+    defer client_sink.deinit();
+    var server_sink = DirectSink{};
+    defer server_sink.deinit();
+
+    try deliverServerFlightToClient(&client, &server, &client_sink, &server_sink);
+    try std.testing.expect(client.authPending());
+    client_sink.reset();
+
+    const stray = [_]u8{@intFromEnum(HsMessageType.finished)};
+    try std.testing.expectError(error.UnexpectedHandshakeMessage, client.backend().receive(.handshake, &stray, &client_sink));
+    try std.testing.expect(!client.authPending());
+    try std.testing.expect(!handshakeCompleteIn(&client_sink));
+    try std.testing.expectEqual(@as(usize, 1), mock.cancel_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.op_release_count);
+    try std.testing.expectEqual(@as(usize, 0), mock.release_count);
+    try std.testing.expectEqual(@as(usize, 0), mock.sign_count);
+}
+
+test "pending client signing rejects later handshake bytes and releases the held credential once" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.async_sign = true;
+    mock.pending_polls = 5;
+    var client = clientWithLocalCredential(mock.provider());
+    defer client.deinit();
+    var verifier = credentials.MockVerifier.init(.accepted);
+    var server = serverRequestingClientAuth(.required, verifier.verifier());
+    defer server.deinit();
+
+    var client_sink = DirectSink{};
+    defer client_sink.deinit();
+    var server_sink = DirectSink{};
+    defer server_sink.deinit();
+
+    try deliverServerFlightToClient(&client, &server, &client_sink, &server_sink);
+    try std.testing.expect(client.authPending());
+    client_sink.reset();
+
+    const stray = [_]u8{@intFromEnum(HsMessageType.certificate)};
+    try std.testing.expectError(error.UnexpectedHandshakeMessage, client.backend().receive(.handshake, &stray, &client_sink));
+    try std.testing.expect(!client.authPending());
+    try std.testing.expect(!handshakeCompleteIn(&client_sink));
+    try std.testing.expectEqual(@as(usize, 1), mock.cancel_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.op_release_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.release_count);
+}
+
 test "async server verification of a coalesced client flight drains the buffered Finished on resume" {
     var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
     var client = clientWithLocalCredential(mock.provider());
@@ -2172,7 +2275,7 @@ test "the record stream production driver resumes async client authentication en
     // over a real socket pair.
     var client_credential = credentials.MockCredentialProvider.init(fixtureIdentity());
     client_credential.async_sign = true;
-    client_credential.pending_polls = 2;
+    client_credential.pending_polls = 0;
     var server_verifier = credentials.MockVerifier.init(.accepted);
     var client_verifier = credentials.MockVerifier.init(.accepted);
 

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -1311,7 +1311,9 @@ test "a bad CertificateVerify signature fails proof of possession at the client"
     defer h.destroy();
 
     const failures = driveUntilBothErrors(h);
-    try std.testing.expectEqual(@as(?anyerror, error.CertificateInvalid), failures.client);
+    // A CertificateVerify proof-of-possession failure is a decrypt_error
+    // (RFC 8446 §4.4.3), distinct from a trust rejection.
+    try std.testing.expectEqual(@as(?anyerror, error.DecryptError), failures.client);
     try std.testing.expect(!h.client.bridge.handshake_complete);
     try std.testing.expectEqual(tls_backend.CredentialFailure.certificate_verify_invalid, h.client_engine.credentialFailure().?);
 }
@@ -1980,4 +1982,82 @@ test "a malformed async client selection completion is rejected as a provider fa
     try std.testing.expectError(error.CredentialProviderFailed, client.resumeAuth(&client_sink));
     try std.testing.expectEqual(tls_backend.CredentialFailure.provider_internal_failure, client.credentialFailure().?);
     try std.testing.expectEqual(@as(usize, 1), wrong.release_count);
+}
+
+test "an oversized configured server name is rejected at start rather than truncated" {
+    var verifier = credentials.MockVerifier.init(.accepted);
+    // One byte past the bounded SNI buffer (max_server_name_len is 256).
+    const too_long = [_]u8{'a'} ** 257;
+    var client = tls_backend.Tls13Backend.initClientWithVerifier(
+        clientEntropy(),
+        verifier.verifier(),
+        .{ .record = .{ .alpn = "h2" } },
+        .{ .server_name = &too_long },
+    );
+    defer client.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    // Fails closed before any ClientHello is emitted; nothing is truncated.
+    try std.testing.expectError(error.InvalidHandshakeState, client.backend().start(.client, {}, &sink));
+    try std.testing.expectEqual(@as(usize, 0), sink.len);
+    try std.testing.expect(!client.key_pair_present);
+}
+
+// ===========================================================================
+// #334 checkpoint 4: pending/resume progression is reachable through the
+// production drivers (the record stream and the generic engine Driver), not
+// only the concrete backend.
+// ===========================================================================
+
+test "the record stream production driver resumes async client authentication end to end" {
+    // The client's own credential signs asynchronously; the shared record
+    // stream must poll resume across drive() ticks and complete mutual auth
+    // over a real socket pair.
+    var client_credential = credentials.MockCredentialProvider.init(fixtureIdentity());
+    client_credential.async_sign = true;
+    client_credential.pending_polls = 2;
+    var server_verifier = credentials.MockVerifier.init(.accepted);
+    var client_verifier = credentials.MockVerifier.init(.accepted);
+
+    const h = try SocketHarness.create(.{ .client_verifier = client_verifier.verifier() });
+    defer h.destroy();
+    // Configure handshake-time client authentication on the heap-stable engines
+    // before the first drive starts either handshake.
+    h.client_engine.setLocalCredentialProvider(client_credential.provider());
+    h.server_engine.requestClientAuthentication(.required, server_verifier.verifier());
+
+    try h.driveUntil(SocketHarness.bothComplete);
+    try std.testing.expect(h.client.bridge.handshake_complete);
+    try std.testing.expect(h.server.bridge.handshake_complete);
+    // The async signature was polled to completion through the driver, and the
+    // server verified the client certificate.
+    try std.testing.expectEqual(@as(usize, 1), client_credential.sign_count);
+    try std.testing.expectEqual(@as(usize, 1), client_credential.op_release_count);
+    try std.testing.expectEqual(@as(usize, 1), server_verifier.verify_count);
+    try std.testing.expect(h.client_engine.credentialFailure() == null);
+    try std.testing.expect(h.server_engine.credentialFailure() == null);
+}
+
+test "the generic engine driver exposes authPending and resumeAuth for the concrete backend" {
+    // Drive a server backend through the generic Driver (not the concrete
+    // backend) and prove the async credential selection suspends and resumes
+    // through the Driver's own authPending/resumeAuth surface.
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.async_select = true;
+    mock.pending_polls = 1;
+    var server = serverWithProvider(&mock);
+    var driver = DirectDriver.init(.server, server.backend());
+    defer driver.deinit();
+
+    _ = try driver.start({});
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{});
+    _ = try driver.receive(.initial, hello);
+    try std.testing.expect(driver.authPending());
+
+    _ = try driver.resumeAuth(); // poll #1: still pending
+    try std.testing.expect(driver.authPending());
+    _ = try driver.resumeAuth(); // poll #2: completes the flight
+    try std.testing.expect(!driver.authPending());
+    try std.testing.expect(server.credentialFailure() == null);
 }

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -1059,6 +1059,7 @@ const ClientHelloOptions = struct {
     /// Raw bytes to place verbatim as the server_name extension body (the
     /// ServerNameList), for crafting malformed/duplicate SNI. Overrides `sni`.
     sni_raw: ?[]const u8 = null,
+    include_signature_algorithms: bool = true,
     sig_schemes: []const u16 = &.{ 0x0807, 0x0403 },
     alpn: []const u8 = "h2",
 };
@@ -1092,10 +1093,12 @@ fn buildClientHello(buf: []u8, opts: ClientHelloOptions) ![]const u8 {
     try w.u16_(2);
     try w.u16_(0x001d);
     // signature_algorithms
-    try w.u16_(13);
-    try w.u16_(@intCast(2 + 2 * opts.sig_schemes.len));
-    try w.u16_(@intCast(2 * opts.sig_schemes.len));
-    for (opts.sig_schemes) |scheme| try w.u16_(scheme);
+    if (opts.include_signature_algorithms) {
+        try w.u16_(13);
+        try w.u16_(@intCast(2 + 2 * opts.sig_schemes.len));
+        try w.u16_(@intCast(2 * opts.sig_schemes.len));
+        for (opts.sig_schemes) |scheme| try w.u16_(scheme);
+    }
     // key_share
     try w.u16_(51);
     try w.u16_(2 + 2 + 2 + X25519.public_length);
@@ -1393,6 +1396,12 @@ test "an empty signature_algorithms list is a peer-attributed malformed ClientHe
     try expectServerReceiveError(&server, .{ .sig_schemes = &.{} }, error.MalformedHandshake);
 }
 
+test "an absent signature_algorithms extension maps to missing_extension" {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = "h2" } });
+    defer server.deinit();
+    try expectServerReceiveError(&server, .{ .include_signature_algorithms = false }, error.MissingExtension);
+}
+
 test "malformed SNI is rejected rather than collapsed into the default path" {
     // Empty host_name.
     {
@@ -1530,6 +1539,13 @@ fn certificateStateIn(sink: *const DirectSink) ?events.CertificateState {
         }
     }
     return found;
+}
+
+fn handshakeCompleteIn(sink: *const DirectSink) bool {
+    for (sink.items[0..sink.len]) |event| {
+        if (event == .handshake_complete) return true;
+    }
+    return false;
 }
 
 fn firstInitialCrypto(sink: *const DirectSink, out: []u8) []const u8 {
@@ -1756,6 +1772,58 @@ test "a cancelled async peer verification cancels and releases the operation onc
     client.deinit();
     try std.testing.expectEqual(@as(usize, 1), verifier.cancel_count);
     try std.testing.expectEqual(@as(usize, 1), verifier.op_release_count);
+}
+
+test "a client rejects trailing handshake bytes after the server Finished" {
+    var verifier = credentials.MockVerifier.init(.accepted);
+    var client = tls_backend.Tls13Backend.initClientWithVerifier(clientEntropy(), verifier.verifier(), .{ .record = .{ .alpn = "h2" } }, .{});
+    defer client.deinit();
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = "h2" } });
+    defer server.deinit();
+    var client_sink = DirectSink{};
+    defer client_sink.deinit();
+    var server_sink = DirectSink{};
+    defer server_sink.deinit();
+
+    try client.backend().start(.client, {}, &client_sink);
+    var ch_buf: [1024]u8 = undefined;
+    const client_hello = firstInitialCrypto(&client_sink, &ch_buf);
+    try server.backend().start(.server, {}, &server_sink);
+    try server.backend().receive(.initial, client_hello, &server_sink);
+
+    var sh_buf: [512]u8 = undefined;
+    const server_hello = firstInitialCrypto(&server_sink, &sh_buf);
+    var flight_buf: [8192]u8 = undefined;
+    const flight = collectHandshakeCrypto(&server_sink, &flight_buf);
+    var suffixed: [8193]u8 = undefined;
+    @memcpy(suffixed[0..flight.len], flight);
+    suffixed[flight.len] = @intFromEnum(HsMessageType.finished);
+
+    client_sink.reset();
+    try client.backend().receive(.initial, server_hello, &client_sink);
+    try std.testing.expectError(error.UnexpectedHandshakeMessage, client.backend().receive(.handshake, suffixed[0 .. flight.len + 1], &client_sink));
+    try std.testing.expect(!handshakeCompleteIn(&client_sink));
+}
+
+test "a server rejects trailing handshake bytes after the client Finished" {
+    var client = tls_backend.Tls13Backend.initClient(clientEntropy(), .{ .pinned_certificate = tls_backend.testdata.certificate_der }, .{ .record = .{ .alpn = "h2" } });
+    defer client.deinit();
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = "h2" } });
+    defer server.deinit();
+    var client_sink = DirectSink{};
+    defer client_sink.deinit();
+    var server_sink = DirectSink{};
+    defer server_sink.deinit();
+
+    try deliverServerFlightToClient(&client, &server, &client_sink, &server_sink);
+    var finished_buf: [512]u8 = undefined;
+    const client_finished = collectHandshakeCrypto(&client_sink, &finished_buf);
+    var suffixed: [513]u8 = undefined;
+    @memcpy(suffixed[0..client_finished.len], client_finished);
+    suffixed[client_finished.len] = @intFromEnum(HsMessageType.certificate);
+
+    try std.testing.expectError(error.UnexpectedHandshakeMessage, server.backend().receive(.handshake, suffixed[0 .. client_finished.len + 1], &server_sink));
+    try std.testing.expect(!handshakeCompleteIn(&server_sink));
 }
 
 // ===========================================================================
@@ -2024,7 +2092,7 @@ const WrongKindSelectProvider = struct {
     }
 };
 
-test "a malformed async client selection completion is rejected as a provider failure" {
+test "a malformed async client selection completion is rejected as invalid callback behavior" {
     var wrong = WrongKindSelectProvider{};
     var client = clientWithLocalCredential(wrong.provider());
     defer client.deinit();
@@ -2042,27 +2110,28 @@ test "a malformed async client selection completion is rejected as a provider fa
     // The resume observes a signature-length completion where a credential was
     // required and fails closed without emitting a client flight.
     try std.testing.expectError(error.CredentialProviderFailed, client.resumeAuth(&client_sink));
-    try std.testing.expectEqual(tls_backend.CredentialFailure.provider_internal_failure, client.credentialFailure().?);
+    try std.testing.expectEqual(tls_backend.CredentialFailure.invalid_callback_behavior, client.credentialFailure().?);
     try std.testing.expectEqual(@as(usize, 1), wrong.release_count);
 }
 
-test "an oversized configured server name is rejected at start rather than truncated" {
+test "an invalid configured server name is rejected at start rather than emitted" {
     var verifier = credentials.MockVerifier.init(.accepted);
-    // One byte past the bounded SNI buffer (max_server_name_len is 256).
-    const too_long = [_]u8{'a'} ** 257;
-    var client = tls_backend.Tls13Backend.initClientWithVerifier(
-        clientEntropy(),
-        verifier.verifier(),
-        .{ .record = .{ .alpn = "h2" } },
-        .{ .server_name = &too_long },
-    );
-    defer client.deinit();
-    var sink = DirectSink{};
-    defer sink.deinit();
-    // Fails closed before any ClientHello is emitted; nothing is truncated.
-    try std.testing.expectError(error.InvalidHandshakeState, client.backend().start(.client, {}, &sink));
-    try std.testing.expectEqual(@as(usize, 0), sink.len);
-    try std.testing.expect(!client.key_pair_present);
+    for ([_][]const u8{ "", &([_]u8{'a'} ** 257) }) |name| {
+        var client = tls_backend.Tls13Backend.initClientWithVerifier(
+            clientEntropy(),
+            verifier.verifier(),
+            .{ .record = .{ .alpn = "h2" } },
+            .{ .server_name = name },
+        );
+        defer client.deinit();
+        var sink = DirectSink{};
+        defer sink.deinit();
+        // Fails closed before any ClientHello is emitted; nothing is truncated
+        // or encoded as an empty host_name.
+        try std.testing.expectError(error.InvalidHandshakeState, client.backend().start(.client, {}, &sink));
+        try std.testing.expectEqual(@as(usize, 0), sink.len);
+        try std.testing.expect(!client.key_pair_present);
+    }
 }
 
 test "a ClientHello combining maximum ALPN, SNI, and transport extension serializes successfully" {
@@ -2460,14 +2529,11 @@ test "record mode delivers a fatal alert to the client when required client auth
     h.server_engine.requestClientAuthentication(.required, verifier.verifier());
 
     const failures = driveUntilBothErrors(h);
-    // The server fails with certificate_required and synthesizes the alert
-    // (previously it emitted none and the peer only saw a stall/EOF). The client
-    // terminates on the delivered alert rather than hanging. (The client has
-    // already reached 1-RTT here, so the exact received-alert surface depends on
-    // epoch timing; the decrypt_error test above covers the clean PeerFatalAlert
-    // path end to end.)
+    // The server fails with certificate_required and synthesizes an
+    // application-key alert after its Finished. The client must receive the
+    // alert, not just hit EOF or an AEAD failure.
     try std.testing.expectEqual(@as(?anyerror, error.ClientCertificateRequired), failures.server);
-    try std.testing.expect(failures.client != null);
+    try std.testing.expectEqual(@as(?anyerror, error.PeerFatalAlert), failures.client);
     try std.testing.expect(!h.server.bridge.handshake_complete);
     try std.testing.expectEqual(tls_backend.CredentialFailure.client_certificate_required, h.server_engine.credentialFailure().?);
 }

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -1693,3 +1693,291 @@ test "a cancelled async peer verification cancels and releases the operation onc
     try std.testing.expectEqual(@as(usize, 1), verifier.cancel_count);
     try std.testing.expectEqual(@as(usize, 1), verifier.op_release_count);
 }
+
+// ===========================================================================
+// #334 checkpoint 3: asynchronous handshake-time client authentication. The
+// client's own credential selection and signing may suspend; the server's
+// verification of the client certificate may suspend. Each side resumes
+// without recording a message twice, and buffered messages behind the suspend
+// point are drained automatically on resume.
+// ===========================================================================
+
+/// A client backend configured to authenticate with `provider` and to trust
+/// the fixture server certificate by pin (its own server verification stays
+/// synchronous, so the only suspends come from client selection/signing).
+fn clientWithLocalCredential(provider: credentials.CredentialProvider) tls_backend.Tls13Backend {
+    var client = tls_backend.Tls13Backend.initClient(
+        clientEntropy(),
+        .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+        .{ .record = .{ .alpn = "h2" } },
+    );
+    client.setLocalCredentialProvider(provider);
+    return client;
+}
+
+fn resumeUntilSettled(backend: *tls_backend.Tls13Backend, sink: *DirectSink) !void {
+    var guard: usize = 0;
+    while (backend.authPending()) {
+        try backend.resumeAuth(sink);
+        guard += 1;
+        if (guard > 64) return error.TestResumeLoopStuck;
+    }
+}
+
+/// Start both backends and deliver the server's ServerHello + handshake flight
+/// (EncryptedExtensions, CertificateRequest, Certificate, CertificateVerify,
+/// Finished) to the client. The fixed-identity server is synchronous. The
+/// client is left exactly as receiving that flight left it — parked if its
+/// credential selection or signing went asynchronous.
+fn deliverServerFlightToClient(
+    client: *tls_backend.Tls13Backend,
+    server: *tls_backend.Tls13Backend,
+    client_sink: *DirectSink,
+    server_sink: *DirectSink,
+) !void {
+    try client.backend().start(.client, {}, client_sink);
+    var ch_buf: [1024]u8 = undefined;
+    const client_hello = firstInitialCrypto(client_sink, &ch_buf);
+
+    try server.backend().start(.server, {}, server_sink);
+    try server.backend().receive(.initial, client_hello, server_sink);
+
+    var sh_buf: [512]u8 = undefined;
+    const server_hello = firstInitialCrypto(server_sink, &sh_buf);
+    var flight_buf: [8192]u8 = undefined;
+    const flight = collectHandshakeCrypto(server_sink, &flight_buf);
+
+    client_sink.reset();
+    try client.backend().receive(.initial, server_hello, client_sink);
+    try client.backend().receive(.handshake, flight, client_sink);
+}
+
+/// Deliver the client's certificate flight to the server, either coalesced in
+/// one chunk or fragmented byte-by-byte to exercise reassembly.
+fn deliverClientFlightToServer(
+    server: *tls_backend.Tls13Backend,
+    server_sink: *DirectSink,
+    flight: []const u8,
+    fragment: bool,
+) !void {
+    server_sink.reset();
+    if (fragment) {
+        var i: usize = 0;
+        while (i < flight.len) : (i += 1) {
+            try server.backend().receive(.handshake, flight[i .. i + 1], server_sink);
+        }
+    } else {
+        try server.backend().receive(.handshake, flight, server_sink);
+    }
+}
+
+fn serverRequestingClientAuth(mode: tls_backend.ClientAuthMode, verifier: credentials.PeerVerifier) tls_backend.Tls13Backend {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = "h2" } });
+    server.requestClientAuthentication(mode, verifier);
+    return server;
+}
+
+test "async client credential selection suspends the client flight and resumes to mutual completion" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.async_select = true;
+    mock.pending_polls = 2;
+    var client = clientWithLocalCredential(mock.provider());
+    defer client.deinit();
+    var verifier = credentials.MockVerifier.init(.accepted);
+    var server = serverRequestingClientAuth(.required, verifier.verifier());
+    defer server.deinit();
+
+    var client_sink = DirectSink{};
+    defer client_sink.deinit();
+    var server_sink = DirectSink{};
+    defer server_sink.deinit();
+
+    try deliverServerFlightToClient(&client, &server, &client_sink, &server_sink);
+    // Parked awaiting the async selection; nothing signed and no flight yet.
+    try std.testing.expect(client.authPending());
+    try std.testing.expectEqual(@as(usize, 0), mock.sign_count);
+
+    try resumeUntilSettled(&client, &client_sink);
+    try std.testing.expect(!client.authPending());
+    try std.testing.expectEqual(@as(usize, 1), mock.sign_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.release_count);
+
+    var flight_buf: [8192]u8 = undefined;
+    const flight = collectHandshakeCrypto(&client_sink, &flight_buf);
+    try deliverClientFlightToServer(&server, &server_sink, flight, false);
+    try resumeUntilSettled(&server, &server_sink);
+
+    try std.testing.expectEqual(tls_core.handshake.HandshakeLifecycle.complete, server.core.handshake_lifecycle);
+    try std.testing.expectEqual(events.CertificateState.valid, certificateStateIn(&server_sink).?);
+    try std.testing.expect(server.credentialFailure() == null);
+    try std.testing.expectEqual(@as(usize, 1), verifier.verify_count);
+}
+
+test "async client signing suspends after the client Certificate and resumes to completion" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.async_sign = true;
+    mock.pending_polls = 1;
+    var client = clientWithLocalCredential(mock.provider());
+    defer client.deinit();
+    var verifier = credentials.MockVerifier.init(.accepted);
+    var server = serverRequestingClientAuth(.required, verifier.verifier());
+    defer server.deinit();
+
+    var client_sink = DirectSink{};
+    defer client_sink.deinit();
+    var server_sink = DirectSink{};
+    defer server_sink.deinit();
+
+    try deliverServerFlightToClient(&client, &server, &client_sink, &server_sink);
+    // The client emitted its Certificate, then parked awaiting the signature.
+    try std.testing.expect(client.authPending());
+
+    try resumeUntilSettled(&client, &client_sink);
+    try std.testing.expectEqual(@as(usize, 1), mock.sign_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.op_release_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.release_count);
+
+    var flight_buf: [8192]u8 = undefined;
+    const flight = collectHandshakeCrypto(&client_sink, &flight_buf);
+    try deliverClientFlightToServer(&server, &server_sink, flight, false);
+    try resumeUntilSettled(&server, &server_sink);
+    try std.testing.expectEqual(tls_core.handshake.HandshakeLifecycle.complete, server.core.handshake_lifecycle);
+    try std.testing.expect(server.credentialFailure() == null);
+}
+
+test "async server verification of a coalesced client flight drains the buffered Finished on resume" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    var client = clientWithLocalCredential(mock.provider());
+    defer client.deinit();
+    var verifier = credentials.MockVerifier.init(.accepted);
+    verifier.async_mode = true;
+    verifier.pending_polls = 2;
+    var server = serverRequestingClientAuth(.required, verifier.verifier());
+    defer server.deinit();
+
+    var client_sink = DirectSink{};
+    defer client_sink.deinit();
+    var server_sink = DirectSink{};
+    defer server_sink.deinit();
+
+    try deliverServerFlightToClient(&client, &server, &client_sink, &server_sink);
+    try resumeUntilSettled(&client, &client_sink); // client is synchronous here
+    var flight_buf: [8192]u8 = undefined;
+    const flight = collectHandshakeCrypto(&client_sink, &flight_buf);
+
+    // Deliver Certificate + CertificateVerify + Finished coalesced. The server
+    // parks verifying CertificateVerify; the Finished stays buffered behind the
+    // suspend point and must not be processed until the verifier resolves.
+    try deliverClientFlightToServer(&server, &server_sink, flight, false);
+    try std.testing.expect(server.authPending());
+    try std.testing.expectEqual(tls_core.handshake.HandshakeLifecycle.running, server.core.handshake_lifecycle);
+
+    try resumeUntilSettled(&server, &server_sink);
+    // On resume the verdict is applied and the buffered Finished is drained
+    // automatically, completing the handshake.
+    try std.testing.expectEqual(tls_core.handshake.HandshakeLifecycle.complete, server.core.handshake_lifecycle);
+    try std.testing.expectEqual(events.CertificateState.valid, certificateStateIn(&server_sink).?);
+    try std.testing.expect(server.credentialFailure() == null);
+}
+
+test "a client certificate flight fragmented byte-by-byte still completes on the server" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    var client = clientWithLocalCredential(mock.provider());
+    defer client.deinit();
+    var verifier = credentials.MockVerifier.init(.accepted); // synchronous
+    var server = serverRequestingClientAuth(.required, verifier.verifier());
+    defer server.deinit();
+
+    var client_sink = DirectSink{};
+    defer client_sink.deinit();
+    var server_sink = DirectSink{};
+    defer server_sink.deinit();
+
+    try deliverServerFlightToClient(&client, &server, &client_sink, &server_sink);
+    try resumeUntilSettled(&client, &client_sink);
+    var flight_buf: [8192]u8 = undefined;
+    const flight = collectHandshakeCrypto(&client_sink, &flight_buf);
+
+    try deliverClientFlightToServer(&server, &server_sink, flight, true); // fragmented
+    try resumeUntilSettled(&server, &server_sink);
+    try std.testing.expectEqual(tls_core.handshake.HandshakeLifecycle.complete, server.core.handshake_lifecycle);
+    try std.testing.expect(server.credentialFailure() == null);
+}
+
+test "a cancelled async client signature releases the operation and credential exactly once" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.async_sign = true;
+    mock.pending_polls = 5; // never completes before teardown
+    var client = clientWithLocalCredential(mock.provider());
+    var verifier = credentials.MockVerifier.init(.accepted);
+    var server = serverRequestingClientAuth(.required, verifier.verifier());
+    defer server.deinit();
+
+    var client_sink = DirectSink{};
+    var server_sink = DirectSink{};
+    defer server_sink.deinit();
+
+    try deliverServerFlightToClient(&client, &server, &client_sink, &server_sink);
+    try std.testing.expect(client.authPending());
+
+    client_sink.deinit();
+    client.deinit(); // cancels the parked op and releases the held credential
+    try std.testing.expectEqual(@as(usize, 1), mock.cancel_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.op_release_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.release_count);
+}
+
+/// A credential provider whose asynchronous selection completes with the wrong
+/// Completion variant (a signature length instead of a credential), violating
+/// the callback contract — to prove the engine rejects a malformed completion.
+const WrongKindSelectProvider = struct {
+    poll_count: usize = 0,
+    cancel_count: usize = 0,
+    release_count: usize = 0,
+
+    fn provider(self: *WrongKindSelectProvider) credentials.CredentialProvider {
+        return .{ .ctx = self, .vtable = &prov_vtable };
+    }
+    const prov_vtable = credentials.CredentialProvider.VTable{ .select = select };
+    fn select(ctx: *anyopaque, _: *const credentials.SelectionContext) credentials.SelectError!credentials.Progress(credentials.SelectedCredential) {
+        const self: *WrongKindSelectProvider = @ptrCast(@alignCast(ctx));
+        return .{ .pending = .{ .handle = self, .vtable = &op_vtable } };
+    }
+    const op_vtable = credentials.PendingOperation.VTable{ .poll = poll, .cancel = cancel, .release = release };
+    fn poll(handle: *anyopaque, out: *credentials.Completion) credentials.OperationError!bool {
+        const self: *WrongKindSelectProvider = @ptrCast(@alignCast(handle));
+        self.poll_count += 1;
+        out.* = .{ .signature_len = 0 }; // wrong kind for a selection
+        return true;
+    }
+    fn cancel(handle: *anyopaque) void {
+        const self: *WrongKindSelectProvider = @ptrCast(@alignCast(handle));
+        self.cancel_count += 1;
+    }
+    fn release(handle: *anyopaque) void {
+        const self: *WrongKindSelectProvider = @ptrCast(@alignCast(handle));
+        self.release_count += 1;
+    }
+};
+
+test "a malformed async client selection completion is rejected as a provider failure" {
+    var wrong = WrongKindSelectProvider{};
+    var client = clientWithLocalCredential(wrong.provider());
+    defer client.deinit();
+    var verifier = credentials.MockVerifier.init(.accepted);
+    var server = serverRequestingClientAuth(.required, verifier.verifier());
+    defer server.deinit();
+
+    var client_sink = DirectSink{};
+    defer client_sink.deinit();
+    var server_sink = DirectSink{};
+    defer server_sink.deinit();
+
+    try deliverServerFlightToClient(&client, &server, &client_sink, &server_sink);
+    try std.testing.expect(client.authPending());
+    // The resume observes a signature-length completion where a credential was
+    // required and fails closed without emitting a client flight.
+    try std.testing.expectError(error.CredentialProviderFailed, client.resumeAuth(&client_sink));
+    try std.testing.expectEqual(tls_backend.CredentialFailure.provider_internal_failure, client.credentialFailure().?);
+    try std.testing.expectEqual(@as(usize, 1), wrong.release_count);
+}

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -1314,6 +1314,9 @@ test "a bad CertificateVerify signature fails proof of possession at the client"
     // A CertificateVerify proof-of-possession failure is a decrypt_error
     // (RFC 8446 §4.4.3), distinct from a trust rejection.
     try std.testing.expectEqual(@as(?anyerror, error.DecryptError), failures.client);
+    // The client synthesizes the decrypt_error alert and the server receives it
+    // (rather than a silent stall/EOF).
+    try std.testing.expectEqual(@as(?anyerror, error.PeerFatalAlert), failures.server);
     try std.testing.expect(!h.client.bridge.handshake_complete);
     try std.testing.expectEqual(tls_backend.CredentialFailure.certificate_verify_invalid, h.client_engine.credentialFailure().?);
 }
@@ -2060,4 +2063,326 @@ test "the generic engine driver exposes authPending and resumeAuth for the concr
     _ = try driver.resumeAuth(); // poll #2: completes the flight
     try std.testing.expect(!driver.authPending());
     try std.testing.expect(server.credentialFailure() == null);
+}
+
+// ===========================================================================
+// #334 review round: adversarial async progression, client-auth policy, exact
+// serialization bounds, and resource ownership.
+// ===========================================================================
+
+// --- F1: a Finished delivered in a separate receive while verification is
+//         pending must not be processed until an accepted resume. ---
+
+test "a Finished in a separate receive while client verification is pending is not processed early" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    var client = clientWithLocalCredential(mock.provider());
+    defer client.deinit();
+    var verifier = credentials.MockVerifier.init(.accepted);
+    verifier.async_mode = true;
+    verifier.pending_polls = 1;
+    var server = serverRequestingClientAuth(.required, verifier.verifier());
+    defer server.deinit();
+
+    var client_sink = DirectSink{};
+    defer client_sink.deinit();
+    var server_sink = DirectSink{};
+    defer server_sink.deinit();
+
+    try deliverServerFlightToClient(&client, &server, &client_sink, &server_sink);
+    try resumeUntilSettled(&client, &client_sink);
+    var flight_buf: [8192]u8 = undefined;
+    const flight = collectHandshakeCrypto(&client_sink, &flight_buf);
+
+    const finished_message_len = 4 + tls_backend.hash_len; // type+len+verify_data
+    const split = flight.len - finished_message_len;
+
+    // First receive: Certificate + CertificateVerify. The server parks on the
+    // async verifier with the Finished not yet delivered.
+    server_sink.reset();
+    try server.backend().receive(.handshake, flight[0..split], &server_sink);
+    try std.testing.expect(server.authPending());
+    try std.testing.expectEqual(tls_core.handshake.HandshakeLifecycle.running, server.core.handshake_lifecycle);
+
+    // Second receive delivers Finished WHILE verification is still pending. It
+    // must be buffered, never dispatched: no completion, still pending.
+    try server.backend().receive(.handshake, flight[split..], &server_sink);
+    try std.testing.expect(server.authPending());
+    try std.testing.expectEqual(tls_core.handshake.HandshakeLifecycle.running, server.core.handshake_lifecycle);
+
+    // Only the accepted resume drains the buffered Finished and completes.
+    try resumeUntilSettled(&server, &server_sink);
+    try std.testing.expectEqual(tls_core.handshake.HandshakeLifecycle.complete, server.core.handshake_lifecycle);
+    try std.testing.expect(server.credentialFailure() == null);
+}
+
+test "a rejected client verification never processes the buffered Finished" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    var client = clientWithLocalCredential(mock.provider());
+    defer client.deinit();
+    var verifier = credentials.MockVerifier.init(.rejected);
+    verifier.async_mode = true;
+    verifier.pending_polls = 1;
+    var server = serverRequestingClientAuth(.required, verifier.verifier());
+    defer server.deinit();
+
+    var client_sink = DirectSink{};
+    defer client_sink.deinit();
+    var server_sink = DirectSink{};
+    defer server_sink.deinit();
+
+    try deliverServerFlightToClient(&client, &server, &client_sink, &server_sink);
+    try resumeUntilSettled(&client, &client_sink);
+    var flight_buf: [8192]u8 = undefined;
+    const flight = collectHandshakeCrypto(&client_sink, &flight_buf);
+
+    // Deliver the whole flight coalesced: Certificate/CertificateVerify park the
+    // verifier, Finished is buffered behind the suspend point.
+    server_sink.reset();
+    try server.backend().receive(.handshake, flight, &server_sink);
+    try std.testing.expect(server.authPending());
+
+    // Resume rejects: the handshake fails and the buffered Finished is never
+    // processed into a completion.
+    try std.testing.expectError(error.CertificateInvalid, resumeUntilSettled(&server, &server_sink));
+    try std.testing.expectEqual(tls_core.handshake.HandshakeLifecycle.failed, server.core.handshake_lifecycle);
+    try std.testing.expectEqual(tls_backend.CredentialFailure.peer_verification_rejected, server.credentialFailure().?);
+}
+
+// --- F3: a .not_checked verdict must not satisfy required or optional client
+//         authentication of a presented certificate. ---
+
+test "a not_checked verdict fails a presented client certificate under optional and required" {
+    for ([_]tls_backend.ClientAuthMode{ .optional, .required }) |mode| {
+        var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+        var client = clientWithLocalCredential(mock.provider());
+        defer client.deinit();
+        var verifier = credentials.MockVerifier.init(.not_checked);
+        var server = serverRequestingClientAuth(mode, verifier.verifier());
+        defer server.deinit();
+
+        var client_sink = DirectSink{};
+        defer client_sink.deinit();
+        var server_sink = DirectSink{};
+        defer server_sink.deinit();
+
+        try deliverServerFlightToClient(&client, &server, &client_sink, &server_sink);
+        try resumeUntilSettled(&client, &client_sink);
+        var flight_buf: [8192]u8 = undefined;
+        const flight = collectHandshakeCrypto(&client_sink, &flight_buf);
+
+        // The client presented a real certificate; a verifier that declines to
+        // evaluate trust must not silently establish mutual authentication.
+        try std.testing.expectError(error.CertificateInvalid, deliverClientFlightToServer(&server, &server_sink, flight, false));
+        try std.testing.expectEqual(tls_backend.CredentialFailure.peer_verification_rejected, server.credentialFailure().?);
+    }
+}
+
+// --- F4: a client with no suitable credential sends an empty Certificate. ---
+
+test "a client with no credential declines with an empty Certificate (optional completes, required fails)" {
+    // Optional: the empty Certificate is accepted and the handshake completes.
+    {
+        var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+        mock.force_select_error = error.NoCredentialAvailable;
+        var client = clientWithLocalCredential(mock.provider());
+        defer client.deinit();
+        var verifier = credentials.MockVerifier.init(.accepted);
+        var server = serverRequestingClientAuth(.optional, verifier.verifier());
+        defer server.deinit();
+
+        var client_sink = DirectSink{};
+        defer client_sink.deinit();
+        var server_sink = DirectSink{};
+        defer server_sink.deinit();
+
+        try deliverServerFlightToClient(&client, &server, &client_sink, &server_sink);
+        try resumeUntilSettled(&client, &client_sink);
+        var flight_buf: [8192]u8 = undefined;
+        const flight = collectHandshakeCrypto(&client_sink, &flight_buf);
+        try deliverClientFlightToServer(&server, &server_sink, flight, false);
+        try resumeUntilSettled(&server, &server_sink);
+        try std.testing.expectEqual(tls_core.handshake.HandshakeLifecycle.complete, server.core.handshake_lifecycle);
+        // The client declined without signing.
+        try std.testing.expectEqual(@as(usize, 0), mock.sign_count);
+    }
+    // Required: the empty Certificate is certificate_required.
+    {
+        var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+        mock.force_select_error = error.NoCompatibleSignatureAlgorithm;
+        var client = clientWithLocalCredential(mock.provider());
+        defer client.deinit();
+        var verifier = credentials.MockVerifier.init(.accepted);
+        var server = serverRequestingClientAuth(.required, verifier.verifier());
+        defer server.deinit();
+
+        var client_sink = DirectSink{};
+        defer client_sink.deinit();
+        var server_sink = DirectSink{};
+        defer server_sink.deinit();
+
+        try deliverServerFlightToClient(&client, &server, &client_sink, &server_sink);
+        try resumeUntilSettled(&client, &client_sink);
+        var flight_buf: [8192]u8 = undefined;
+        const flight = collectHandshakeCrypto(&client_sink, &flight_buf);
+        try std.testing.expectError(error.ClientCertificateRequired, deliverClientFlightToServer(&server, &server_sink, flight, false));
+        try std.testing.expectEqual(tls_backend.CredentialFailure.client_certificate_required, server.credentialFailure().?);
+    }
+}
+
+test "an async selector that resolves to no credential declines with an empty Certificate" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.async_select = true;
+    mock.async_no_credential = true;
+    mock.pending_polls = 1;
+    var client = clientWithLocalCredential(mock.provider());
+    defer client.deinit();
+    var verifier = credentials.MockVerifier.init(.accepted);
+    var server = serverRequestingClientAuth(.optional, verifier.verifier());
+    defer server.deinit();
+
+    var client_sink = DirectSink{};
+    defer client_sink.deinit();
+    var server_sink = DirectSink{};
+    defer server_sink.deinit();
+
+    try deliverServerFlightToClient(&client, &server, &client_sink, &server_sink);
+    try std.testing.expect(client.authPending()); // suspended in selection
+    try resumeUntilSettled(&client, &client_sink); // resolves to "no credential"
+    try std.testing.expectEqual(@as(usize, 0), mock.sign_count);
+
+    var flight_buf: [8192]u8 = undefined;
+    const flight = collectHandshakeCrypto(&client_sink, &flight_buf);
+    try deliverClientFlightToServer(&server, &server_sink, flight, false);
+    try resumeUntilSettled(&server, &server_sink);
+    try std.testing.expectEqual(tls_core.handshake.HandshakeLifecycle.complete, server.core.handshake_lifecycle);
+}
+
+// --- F5: exact serialized-flight preflight rejects a chain that overflows once
+//         message and surrounding-flight framing is counted. ---
+
+/// A provider returning `entry_count` certificate entries of `entry_len` bytes,
+/// to probe the exact flight-size boundary. Never actually signs (the preflight
+/// rejects the chain first).
+const BigChainProvider = struct {
+    entry_len: usize,
+    entry_count: usize,
+    storage: [tls_backend.max_certificate_len]u8 = [_]u8{0x2c} ** tls_backend.max_certificate_len,
+    entries: [credentials.max_chain_entries][]const u8 = undefined,
+    release_count: usize = 0,
+
+    fn provider(self: *BigChainProvider) credentials.CredentialProvider {
+        return .{ .ctx = self, .vtable = &prov_vtable };
+    }
+    const prov_vtable = credentials.CredentialProvider.VTable{ .select = select };
+    fn select(ctx: *anyopaque, _: *const credentials.SelectionContext) credentials.SelectError!credentials.Progress(credentials.SelectedCredential) {
+        const self: *BigChainProvider = @ptrCast(@alignCast(ctx));
+        return .{ .complete = .{ .handle = self, .scheme = .ed25519, .vtable = &cred_vtable } };
+    }
+    const cred_vtable = credentials.SelectedCredential.VTable{ .chain = chain, .sign = sign, .release = release };
+    fn chain(handle: *anyopaque) credentials.CertificateChain {
+        const self: *BigChainProvider = @ptrCast(@alignCast(handle));
+        for (0..self.entry_count) |i| self.entries[i] = self.storage[0..self.entry_len];
+        return .{ .entries = self.entries[0..self.entry_count] };
+    }
+    fn sign(_: *anyopaque, _: credentials.SignatureScheme, _: []const u8, _: []u8) credentials.SignError!credentials.Progress(usize) {
+        return .{ .complete = 0 }; // unreachable: the size preflight fails first
+    }
+    fn release(handle: *anyopaque) void {
+        const self: *BigChainProvider = @ptrCast(@alignCast(handle));
+        self.release_count += 1;
+    }
+};
+
+test "the server flight preflight rejects a chain that fits entries but overflows with framing" {
+    // Four 2043-byte entries sum to exactly max_message_len once each entry's
+    // 5-byte framing is added, but the Certificate message header pushes it over.
+    var big = BigChainProvider{ .entry_len = 2043, .entry_count = 4 };
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), big.provider(), .{ .record = .{ .alpn = "h2" } });
+    defer server.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{});
+    try std.testing.expectError(error.CredentialProviderFailed, server.backend().receive(.initial, hello, &sink));
+    try std.testing.expectEqual(tls_backend.CredentialFailure.malformed_credential_chain, server.credentialFailure().?);
+    try std.testing.expectEqual(@as(usize, 1), big.release_count);
+}
+
+test "the client flight preflight rejects a chain that overflows with the message header" {
+    var big = BigChainProvider{ .entry_len = 2043, .entry_count = 4 };
+    var client = tls_backend.Tls13Backend.initClient(
+        clientEntropy(),
+        .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+        .{ .record = .{ .alpn = "h2" } },
+    );
+    client.setLocalCredentialProvider(big.provider());
+    defer client.deinit();
+    var verifier = credentials.MockVerifier.init(.accepted);
+    var server = serverRequestingClientAuth(.required, verifier.verifier());
+    defer server.deinit();
+
+    var client_sink = DirectSink{};
+    defer client_sink.deinit();
+    var server_sink = DirectSink{};
+    defer server_sink.deinit();
+
+    // The client parks/emits nothing valid: building its Certificate fails the
+    // exact-size preflight before any transcript mutation or emission.
+    try std.testing.expectError(error.CredentialProviderFailed, deliverServerFlightToClient(&client, &server, &client_sink, &server_sink));
+    try std.testing.expectEqual(tls_backend.CredentialFailure.malformed_credential_chain, client.credentialFailure().?);
+    try std.testing.expectEqual(@as(usize, 1), big.release_count);
+}
+
+// --- F8: a wrong-kind async completion releases every owned handle once. ---
+
+test "a sign stage that completes with a credential releases the held and returned handles once" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.async_sign = true;
+    mock.pending_polls = 0;
+    mock.sign_returns_credential = true; // contract violation
+    var client = clientWithLocalCredential(mock.provider());
+    defer client.deinit();
+    var verifier = credentials.MockVerifier.init(.accepted);
+    var server = serverRequestingClientAuth(.required, verifier.verifier());
+    defer server.deinit();
+
+    var client_sink = DirectSink{};
+    defer client_sink.deinit();
+    var server_sink = DirectSink{};
+    defer server_sink.deinit();
+
+    try deliverServerFlightToClient(&client, &server, &client_sink, &server_sink);
+    try std.testing.expect(client.authPending()); // parked awaiting the signature
+
+    // The resume observes a credential where a signature length was required and
+    // fails closed, releasing the held signing credential and the (aliased)
+    // returned one exactly once between them.
+    try std.testing.expectError(error.CredentialProviderFailed, client.resumeAuth(&client_sink));
+    try std.testing.expectEqual(tls_backend.CredentialFailure.invalid_callback_behavior, client.credentialFailure().?);
+    try std.testing.expectEqual(@as(usize, 1), mock.release_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.op_release_count);
+}
+
+// --- F6: record mode synthesizes the certificate_required alert end to end. ---
+
+test "record mode delivers a fatal alert to the client when required client auth is declined" {
+    var verifier = credentials.MockVerifier.init(.accepted);
+    const h = try SocketHarness.create(.{});
+    defer h.destroy();
+    // The server requires client authentication; the client has no local
+    // credential and answers with an empty Certificate.
+    h.server_engine.requestClientAuthentication(.required, verifier.verifier());
+
+    const failures = driveUntilBothErrors(h);
+    // The server fails with certificate_required and synthesizes the alert
+    // (previously it emitted none and the peer only saw a stall/EOF). The client
+    // terminates on the delivered alert rather than hanging. (The client has
+    // already reached 1-RTT here, so the exact received-alert surface depends on
+    // epoch timing; the decrypt_error test above covers the clean PeerFatalAlert
+    // path end to end.)
+    try std.testing.expectEqual(@as(?anyerror, error.ClientCertificateRequired), failures.server);
+    try std.testing.expect(failures.client != null);
+    try std.testing.expect(!h.server.bridge.handshake_complete);
+    try std.testing.expectEqual(tls_backend.CredentialFailure.client_certificate_required, h.server_engine.credentialFailure().?);
 }

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -1410,6 +1410,15 @@ test "malformed SNI is rejected rather than collapsed into the default path" {
         const dup = [_]u8{ 0x00, 0x08, 0x00, 0x00, 0x01, 'a', 0x00, 0x00, 0x01, 'b' };
         try expectServerReceiveError(&server, .{ .sni_raw = &dup }, error.IllegalParameter);
     }
+    // Empty ServerNameList (RFC 6066 §3: ServerNameList<1..>). Must be rejected,
+    // not silently treated as "no host_name present" and routed to the default
+    // credential.
+    {
+        var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = "h2" } });
+        defer server.deinit();
+        const empty_list = [_]u8{ 0x00, 0x00 }; // ServerNameList<len=0>{}
+        try expectServerReceiveError(&server, .{ .sni_raw = &empty_list }, error.IllegalParameter);
+    }
 }
 
 test "a provider returning an unoffered scheme is rejected before signing" {
@@ -1630,8 +1639,58 @@ test "an async signing failure latches the typed signing-provider failure" {
 
     try std.testing.expectError(error.CredentialProviderFailed, server.resumeAuth(&sink));
     try std.testing.expectEqual(tls_backend.CredentialFailure.signing_provider_failure, server.credentialFailure().?);
-    try std.testing.expectEqual(@as(usize, 1), mock.cancel_count);
+    // `poll` returning an error means the operation already terminated: it must
+    // not be cancelled (cancel is for abandoning an operation before it
+    // resolves), only released.
+    try std.testing.expectEqual(@as(usize, 0), mock.cancel_count);
     try std.testing.expectEqual(@as(usize, 1), mock.op_release_count);
+}
+
+test "a poll error reports InvalidCallbackBehavior distinctly from an ordinary operation failure" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.async_select = true;
+    mock.pending_polls = 0;
+    mock.pending_fails = true;
+    mock.pending_fail_invalid_callback = true;
+    var server = serverWithProvider(&mock);
+    defer server.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{});
+    try server.backend().receive(.initial, hello, &sink);
+    try std.testing.expect(server.authPending());
+
+    try std.testing.expectError(error.CredentialProviderFailed, server.resumeAuth(&sink));
+    // `InvalidCallbackBehavior` is a distinct, stage-independent contract
+    // violation, not the stage's ordinary "operation failed" classification.
+    try std.testing.expectEqual(tls_backend.CredentialFailure.invalid_callback_behavior, server.credentialFailure().?);
+    try std.testing.expectEqual(@as(usize, 0), mock.cancel_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.op_release_count);
+}
+
+test "resumeAuth is a safe no-op before any suspend and after completion" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    var server = serverWithProvider(&mock);
+    defer server.deinit();
+    var driver = DirectDriver.init(.server, server.backend());
+    defer driver.deinit();
+
+    // Before any suspend: nothing pending, must not fail.
+    _ = try driver.resumeAuth();
+    try std.testing.expect(!driver.authPending());
+
+    _ = try driver.start({});
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{});
+    _ = try driver.receive(.initial, hello);
+    // The synchronous fixed provider never parks: mid-handshake, with nothing
+    // pending, a call still must not fail.
+    try std.testing.expect(!driver.authPending());
+    const sink = try driver.resumeAuth();
+    try std.testing.expectEqual(@as(usize, 0), sink.len);
+    try std.testing.expect(!driver.authPending());
 }
 
 /// Drive a client backend up to (and through) CertificateVerify against a
@@ -2004,6 +2063,32 @@ test "an oversized configured server name is rejected at start rather than trunc
     try std.testing.expectError(error.InvalidHandshakeState, client.backend().start(.client, {}, &sink));
     try std.testing.expectEqual(@as(usize, 0), sink.len);
     try std.testing.expect(!client.key_pair_present);
+}
+
+test "a ClientHello combining maximum ALPN, SNI, and transport extension serializes successfully" {
+    // #334 review: with maximum-length ALPN (255, the largest a u8 length
+    // prefix allows), SNI (256, max_server_name_len), and a maximum transport
+    // extension (tls_backend.max_transport_extension_len = 512), the encoded
+    // ClientHello is roughly 1.15 KiB. The buffer that serializes it must be
+    // sized for this combination, not just the common case.
+    const max_alpn = [_]u8{'a'} ** 255;
+    const max_sni = [_]u8{'s'} ** 256;
+    var max_transport_ext = [_]u8{0xab} ** tls_backend.max_transport_extension_len;
+    var client = tls_backend.Tls13Backend.initClient(
+        clientEntropy(),
+        .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+        .{ .extension = .{ .alpn = &max_alpn, .extension_type = 57, .local = &max_transport_ext } },
+    );
+    client.server_name_len = max_sni.len;
+    @memcpy(client.server_name[0..max_sni.len], &max_sni);
+    client.server_name_present = true;
+    defer client.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try client.backend().start(.client, {}, &sink);
+    try std.testing.expect(client.key_pair_present);
+    try std.testing.expectEqual(@as(usize, 1), sink.len);
+    try std.testing.expectEqualStrings("h2", "h2"); // profile untouched; explicit no-op to document intent
 }
 
 // ===========================================================================

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -259,6 +259,29 @@ const DirectHarness = struct {
     observed: DirectObserved = .{},
     drivers_ready: bool = false,
     deinitialized: bool = false,
+    // Handshake-time client-authentication storage (#334). Held by the harness
+    // so the provider/verifier vtables outlive the handshake; their stable
+    // addresses are captured into the backends by `configureClientAuth`.
+    client_credential: ?credentials.FixedCredentialProvider = null,
+    server_client_verifier: ?credentials.FixedVerifier = null,
+
+    /// Wire up handshake-time client authentication before `run`. `mode` is the
+    /// server's request policy; `client_cert` decides whether the client offers
+    /// a credential (false models a client declining with an empty Certificate);
+    /// `verifier_trust` is how the server judges a presented client certificate.
+    fn configureClientAuth(
+        self: *DirectHarness,
+        mode: tls_backend.ClientAuthMode,
+        client_cert: bool,
+        verifier_trust: credentials.Trust,
+    ) void {
+        self.server_client_verifier = credentials.FixedVerifier.init(verifier_trust);
+        self.server_backend.requestClientAuthentication(mode, self.server_client_verifier.?.verifier());
+        if (client_cert) {
+            self.client_credential = credentials.FixedCredentialProvider.init(fixtureIdentity());
+            self.client_backend.setLocalCredentialProvider(self.client_credential.?.provider());
+        }
+    }
 
     fn init() DirectHarness {
         return initProfiles(
@@ -321,6 +344,9 @@ const DirectHarness = struct {
             self.client_backend.deinit();
             self.server_backend.deinit();
         }
+        // The client credential provider is external to the backend, so the
+        // harness wipes its key material.
+        if (self.client_credential) |*credential| credential.deinit();
     }
 };
 
@@ -457,6 +483,73 @@ test "record and extension profiles preserve independent traffic-secret goldens"
 
 fn recordOrEmpty(bytes: ?[]const u8) []const u8 {
     return bytes orelse "";
+}
+
+// ===========================================================================
+// #334: handshake-time client authentication over the record transport. The
+// server issues a CertificateRequest; the client answers with its own
+// Certificate / CertificateVerify / Finished flight (or declines with an empty
+// Certificate), and the server verifies it before completing.
+// ===========================================================================
+
+test "required client authentication completes with a valid client certificate" {
+    var harness = DirectHarness.init();
+    defer harness.deinit();
+    harness.configureClientAuth(.required, true, .{ .pinned_certificate = tls_backend.testdata.certificate_der });
+    try harness.run();
+
+    try std.testing.expect(harness.client_driver.isComplete());
+    try std.testing.expect(harness.server_driver.isComplete());
+    // The last certificate verdict observed is the server's over the client's
+    // presented certificate: accepted against the pin.
+    try std.testing.expectEqual(events.CertificateState.valid, harness.observed.certificate_state.?);
+
+    // Application data still flows in both directions after mutual auth.
+    var protected: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    const request = try harness.client_bridge.sealApplicationData("mutually authenticated", &protected);
+    const opened = try harness.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, request), &plaintext);
+    try std.testing.expectEqualStrings("mutually authenticated", opened.inner.content);
+}
+
+test "optional client authentication completes when the client declines" {
+    var harness = DirectHarness.init();
+    defer harness.deinit();
+    // No client credential configured: the client answers with an empty
+    // Certificate and no CertificateVerify; optional mode accepts it.
+    harness.configureClientAuth(.optional, false, .{ .pinned_certificate = tls_backend.testdata.certificate_der });
+    try harness.run();
+
+    try std.testing.expect(harness.client_driver.isComplete());
+    try std.testing.expect(harness.server_driver.isComplete());
+}
+
+test "required client authentication fails closed when the client declines" {
+    var harness = DirectHarness.init();
+    defer harness.deinit();
+    // Required mode with no client credential: the empty client Certificate is
+    // rejected with certificate_required.
+    harness.configureClientAuth(.required, false, .{ .pinned_certificate = tls_backend.testdata.certificate_der });
+    try std.testing.expectError(error.ClientCertificateRequired, harness.run());
+    try std.testing.expectEqual(
+        tls_backend.CredentialFailure.client_certificate_required,
+        harness.server_backend.credentialFailure().?,
+    );
+}
+
+test "client authentication fails when the server rejects the client certificate" {
+    var harness = DirectHarness.init();
+    defer harness.deinit();
+    // The client presents a valid certificate whose proof-of-possession checks
+    // out, but the server's verifier is pinned to a different certificate and
+    // rejects it (bad_certificate).
+    var wrong = [_]u8{0} ** 4;
+    harness.configureClientAuth(.required, true, .{ .pinned_certificate = &wrong });
+    try std.testing.expectError(error.CertificateInvalid, harness.run());
+    try std.testing.expectEqual(
+        tls_backend.CredentialFailure.peer_verification_rejected,
+        harness.server_backend.credentialFailure().?,
+    );
 }
 
 // ===========================================================================

--- a/src/tls/transport.zig
+++ b/src/tls/transport.zig
@@ -215,6 +215,14 @@ pub fn ContractWithOptions(
             startFn: *const fn (ptr: *anyopaque, role: state.Role, params: TransportParameters, sink: *EventSink) ErrorSet!void,
             receiveFn: *const fn (ptr: *anyopaque, epoch: Epoch, bytes: []const u8, sink: *EventSink) ErrorSet!void,
             deinitFn: ?*const fn (ptr: *anyopaque) void = null,
+            /// Asynchronous authentication progression (#334). A backend that can
+            /// suspend for an external signer/verifier/selector wires these; one
+            /// that never suspends leaves them null, and `authPending` is
+            /// always false. `authPendingFn` reports whether an operation is
+            /// parked; `resumeFn` polls it, emitting into `sink` and resuming the
+            /// handshake when it resolves.
+            authPendingFn: ?*const fn (ptr: *anyopaque) bool = null,
+            resumeFn: ?*const fn (ptr: *anyopaque, sink: *EventSink) ErrorSet!void = null,
 
             pub fn start(self: Backend, role: state.Role, params: TransportParameters, sink: *EventSink) ErrorSet!void {
                 return self.startFn(self.ptr, role, params, sink);
@@ -222,6 +230,19 @@ pub fn ContractWithOptions(
 
             pub fn receive(self: Backend, epoch: Epoch, bytes: []const u8, sink: *EventSink) ErrorSet!void {
                 return self.receiveFn(self.ptr, epoch, bytes, sink);
+            }
+
+            /// True while the backend has an authentication operation parked and
+            /// awaiting `resumeAuth`. False for backends that never suspend.
+            pub fn authPending(self: Backend) bool {
+                return if (self.authPendingFn) |f| f(self.ptr) else false;
+            }
+
+            /// Poll a parked authentication operation, emitting progress into
+            /// `sink`. A no-op (and a safe call) when nothing is parked or the
+            /// backend does not support suspension.
+            pub fn resumeAuth(self: Backend, sink: *EventSink) ErrorSet!void {
+                if (self.resumeFn) |f| return f(self.ptr, sink);
             }
 
             pub fn deinit(self: Backend) void {


### PR DESCRIPTION
## Summary

Completes issue #334 by integrating the green credential-contract PR with the
handshake-time client-authentication WIP and finishing it, in four strict
checkpoints (each committed and green before the next):

- **Checkpoint 1** — restore the merged branch: formatting fix; the tree
  already compiled and passed `test-tls`/`test-quic`/`test`/appliance.
- **Checkpoint 2** — synchronous handshake-time client authentication:
  disabled/optional/required modes; CertificateRequest parse/emit; the client
  Certificate / optional CertificateVerify / Finished flight; role-aware
  Certificate and CertificateVerify processing; the client CertificateVerify
  context string; Finished MACs recomputed over the correct transcript. New
  `certificate_required` alert path.
- **Checkpoint 3** — asynchronous client authentication: resumable client
  credential selection and signing, server-side client-certificate verification
  through the existing async machinery, receive gating past Finished while
  pending, automatic drain of buffered handshake messages after resume, and
  exactly-once cancel/release of every operation and credential.
- **Checkpoint 4** — remaining correctness fixes: reject oversized configured
  server names; validate exact client-flight sizes before transcript mutation
  or output; map a failed CertificateVerify signature to `decrypt_error`
  (RFC 8446 §4.4.3); expose pending/resume through the generic transport
  Backend, the engine Driver, and both the record and QUIC production drivers.

No OpenSSL/X.509 objects cross the credential interface; failures map to
deterministic TLS alerts. Post-handshake client authentication remains
explicitly deferred.

## Test plan
- [x] `zig fmt --check src build.zig build.zig.zon`
- [x] `zig build test-tls`
- [x] `zig build test-quic`
- [x] `zig build test`
- [x] `zig build test -Dtls-profile=appliance`
- [x] New sync success/failure, async selection/signing/verification,
  cancellation, malformed-completion, coalesced-flight, byte-by-byte
  fragmentation, oversized-server-name, decrypt_error, and production-driver
  (record stream + generic driver) tests.

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)