### PR TITLE
github: standardize public Markdown issue intake

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,33 +1,81 @@
 ---
 name: Bug Report
-about: Something is broken or behaving unexpectedly
-labels: bug
+about: Report something broken or behaving unexpectedly
+title: "[Bug]: "
+labels: type:bug
 ---
 
+<!--
+Thanks for taking the time to report a bug! Please fill in as much of this
+template as you can — it helps us reproduce and fix the issue faster.
+
+Do not include in this issue:
+- Private keys
+- Certificates containing sensitive identity information
+- Tokens, credentials, or production secrets
+- Unredacted private configuration
+
+If this is a security vulnerability (auth bypass, header injection, path
+traversal, information disclosure, etc.), please do not open a public issue.
+Report it privately per SECURITY.md instead:
+https://github.com/Bare-Systems/Tardigrade/security/advisories/new
+-->
+
 **Summary**
-A clear, concise description of the problem.
+A clear, concise description of the bug.
 
-**Steps to reproduce**
-1. Config or env vars used
-2. Request sent (method, path, headers)
-3. What happened
+**Affected surface**
+Is the affected feature `stable`, `experimental`, or unknown? See the
+[Support Matrix](https://github.com/Bare-Systems/Tardigrade/blob/main/docs/SUPPORT_MATRIX.md).
 
-**Expected vs actual**
-- Expected:
-- Actual:
+- [ ] Stable
+- [ ] Experimental
+- [ ] Unknown / not sure
 
 **Environment**
-- Tardigrade version:
+- Tardigrade version, commit, or branch:
 - Zig version:
 - OS / architecture:
-- TLS enabled:
-- HTTP/3 enabled:
+- Installation or build method (release binary, `zig build`, container image, etc.):
 
-**Security impact**
-Does this bug have a security impact (e.g., auth bypass, header injection, path
-traversal, information disclosure)? If yes, consider reporting via the security
-policy in SECURITY.md instead of opening a public issue.
+**Configuration**
+Relevant configuration excerpt, with secrets and identifying details removed.
 
-**Test case**
-If possible, include a minimal reproducer or describe the regression test that
-would catch this bug.
+```
+# paste sanitized config here
+```
+
+**Steps to reproduce**
+1.
+2.
+3.
+
+**Expected behavior**
+What you expected to happen.
+
+**Actual behavior**
+What actually happened.
+
+**Logs, metrics, or traces**
+Relevant log lines, metrics output, stack traces, or packet traces. Redact
+tokens, credentials, and any identifying data first.
+
+```
+# paste sanitized output here
+```
+
+**Regression?**
+- [ ] Yes, this used to work
+- [ ] No / not sure
+
+If yes, last known working version, commit, or branch:
+
+**Troubleshooting already attempted**
+Tests, config changes, or workarounds you've already tried.
+
+**Minimal reproduction**
+- [ ] I can provide a minimal reproduction (repo, config, or script)
+- [ ] I cannot provide a minimal reproduction
+
+**Additional context**
+Anything else that might help — related issues, links, environment quirks.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerability Reporting
+    url: https://github.com/Bare-Systems/Tardigrade/security/advisories/new
+    about: Do not open a public issue for security vulnerabilities. Report them privately per SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,29 +1,76 @@
 ---
 name: Feature Request
 about: Propose a new capability or improvement
-labels: enhancement
+title: "[Feature]: "
+labels: type:feature
 ---
 
-**Problem or motivation**
-What gap does this address?
+<!--
+Thanks for proposing an improvement! Please fill in as much of this template
+as you can so maintainers can evaluate scope and impact.
 
-**Proposed solution**
+Do not include in this issue any private keys, certificates containing
+sensitive identity information, tokens, credentials, or production secrets.
+
+If this proposal is actually a security concern, please do not open a public
+issue — report it privately per SECURITY.md instead:
+https://github.com/Bare-Systems/Tardigrade/security/advisories/new
+-->
+
+**Problem statement**
+What gap or pain point does this address?
+
+**Operator or developer value**
+Who benefits and how? (operators running Tardigrade, contributors, downstream
+integrators, etc.)
+
+**Proposed behavior**
 What should Tardigrade do differently?
 
 **Alternatives considered**
-Any other approaches you evaluated.
+Other approaches you evaluated, including doing nothing.
 
-**Security impact**
-Does this feature touch auth, header handling, TLS, path serving, or logging?
-If yes, describe the security considerations.
+**Affected area or protocol**
+Which component, protocol, or subsystem does this touch (e.g. HTTP/1.1,
+HTTP/2, HTTP/3/QUIC, TLS, proxy/routing, config, auth, metrics, PKI)?
 
-**Performance impact**
-Does this feature affect the event loop, worker pool, or a hot path? If yes,
-describe the expected impact or what benchmarks would validate it.
+**Impact on the stable core**
+Does this touch a feature listed as `stable` in the
+[Support Matrix](https://github.com/Bare-Systems/Tardigrade/blob/main/docs/SUPPORT_MATRIX.md)?
+If so, describe the impact on the Core v1 compatibility promise.
 
-**Testing requirements**
-What tests would prove this feature is correct? (parsers → table-driven tests;
-security changes → regression tests; concurrency → shutdown/drain tests)
+**Compatibility or migration concerns**
+Any breaking changes, migration steps, or deprecations this would require.
+
+**Configuration or CLI implications**
+New config fields, CLI flags, defaults, or env vars this would introduce or
+change.
+
+**Documentation impact**
+What docs (README, Support Matrix, CONTRIBUTING, config reference) would need
+updates?
+
+**Testing and interoperability impact**
+What tests would prove this feature is correct, and does it affect
+interop with external clients/servers (e.g. QUIC/H3 interop peers)?
+
+**Security and resource-bound implications**
+Does this touch auth, header handling, TLS, path serving, logging, or
+introduce new unbounded resource usage (memory, connections, file handles)?
+
+**Related issue, epic, PR, standard, or RFC**
+Links to related work, prior discussion, or external specs.
+
+**Proposal type**
+- [ ] Release blocker
+- [ ] Epic child (part of a larger tracked epic)
+- [ ] Follow-up to existing work
+- [ ] Independent enhancement
+
+**Willingness to help**
+- [ ] I'm willing to implement this
+- [ ] I'm willing to test this
+- [ ] I'm just proposing the idea
 
 **Additional context**
 Links, prior art, config examples, etc.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,27 @@
 # Contributing
 
+## Reporting bugs and requesting features
+
+GitHub Issues is the public intake path for Tardigrade bug reports and
+feature requests — anyone is welcome to open one. When you open a new issue,
+please pick the template that fits:
+
+- **Bug Report** — something is broken or behaving unexpectedly.
+- **Feature Request** — propose a new capability or improvement.
+
+A few things to keep in mind:
+
+- **Security vulnerabilities do not go here.** Please follow
+  [SECURITY.md](SECURITY.md) instead of opening a public issue, so the report
+  isn't visible before a fix is available.
+- **Questions and support requests** are welcome as issues too (there isn't a
+  separate chat/forum yet) — use whichever template is the closest fit, or
+  the Feature Request template if it's more of a "how do I..." than a bug.
+- **Never include secrets** in a public report — private keys, certificates
+  with sensitive identity information, tokens, credentials, production
+  secrets, or unredacted private configuration. Sanitize config excerpts and
+  logs before pasting them.
+
 ## Before You Start
 
 Read the review checklist before making changes:


### PR DESCRIPTION
**What changed and why**
Per the maintainer decision on #308, GitHub Issues stays the public intake path for bug reports and feature requests (Markdown templates, not issue forms). This PR improves the existing Markdown templates rather than replacing them:

- `bug_report.md` — now collects surface stability (stable/experimental/unknown per `docs/SUPPORT_MATRIX.md`), version/commit/branch, Zig version, OS/arch, install method, sanitized config excerpt, repro steps, expected/actual behavior, logs/metrics/traces, regression status + last known good version, troubleshooting attempted, and minimal-repro willingness. Includes an explicit reminder not to post private keys, sensitive certs, tokens, credentials, or production secrets, and points security issues to `SECURITY.md` instead of a public issue.
- `feature_request.md` — now collects problem statement, operator/developer value, proposed behavior, alternatives, affected area/protocol, stable-core impact, compatibility/migration concerns, config/CLI implications, docs impact, testing/interop impact, security/resource-bound implications, related issue/epic/PR/RFC, proposal type (release blocker / epic child / follow-up / independent enhancement), and willingness to help implement/test.
- Both templates' default labels were fixed to the repo's actual normalized taxonomy (`type:bug`, `type:feature`) — the previous `bug` / `enhancement` labels don't exist in this repo.
- Added `.github/ISSUE_TEMPLATE/config.yml`: disables blank/unstructured issues while keeping both public templates, and adds a contact link routing security reports to the existing GitHub security-advisory flow (`SECURITY.md`) instead of inviting public vulnerability disclosure.
- `CONTRIBUTING.md` gained a short "Reporting bugs and requesting features" section stating Issues are the public intake path, how to pick a template, where security/support/questions go, and a reminder not to post secrets.

This is a documentation/repository-metadata-only change. No runtime, TLS, QUIC, PKI, crypto, build, or test files were touched.

**Related issues**
Closes #308

**Tests**
N/A — no code changed. Validated: Markdown front matter parses as valid YAML for both templates and `config.yml`; `git diff --check` is clean; the security-advisory and Support Matrix links match existing references elsewhere in the repo (`SECURITY.md`, `docs/SUPPORT_MATRIX.md`).

**Security impact**
None. Reinforces that vulnerabilities should go through the existing private `SECURITY.md` advisory process rather than a public issue; does not invent any new reporting address.

**Performance impact**
None.

**Checklist**
- [x] `zig fmt --check build.zig src/ tests/` — N/A, no source files changed
- [x] `zig build test --summary all` — N/A, no source files changed
- [x] `zig build test-integration` — N/A, no source files changed
- [x] New behavior covered by tests — N/A, documentation/metadata only
- [x] [docs/CODE_REVIEW_CHECKLIST.md](docs/CODE_REVIEW_CHECKLIST.md) reviewed — no security/performance-sensitive code paths touched
- [x] README / CHANGELOG — no operator-visible runtime behavior changed; contributor-facing docs updated in `CONTRIBUTING.md`


---
_Generated by [Claude Code](https://claude.ai/code/session_017BZaKJaMTnxj3CSrQRqzzF)_