### PR TITLE
pki: add immutable SNI credential selection and reload

### DIFF
--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -22,6 +22,7 @@ pub const Identity = shared.Identity;
 pub const Trust = shared.Trust;
 pub const Entropy = shared.Entropy;
 pub const ClientOptions = shared.Tls13Backend.ClientOptions;
+pub const CredentialProvider = tls_core.credentials.CredentialProvider;
 pub const KeySchedule = shared.KeySchedule;
 pub const hash_len = shared.hash_len;
 pub const max_message_len = shared.max_message_len;
@@ -213,6 +214,14 @@ pub const Tls13Backend = struct {
 
     pub fn initServer(entropy: Entropy, identity: Identity) Tls13Backend {
         return .{ .engine = shared.Tls13Backend.initServer(entropy, identity, .{ .extension = .{
+            .alpn = "h3",
+            .extension_type = ext_quic_transport_parameters,
+            .local = "",
+        } }) };
+    }
+
+    pub fn initServerWithProvider(entropy: Entropy, provider: CredentialProvider) Tls13Backend {
+        return .{ .engine = shared.Tls13Backend.initServerWithProvider(entropy, provider, .{ .extension = .{
             .alpn = "h3",
             .extension_type = ext_quic_transport_parameters,
             .local = "",
@@ -440,18 +449,17 @@ const RealHandshakeHarness = struct {
     }
 
     fn initWithSniProvider(server_name: []const u8, provider: tls_core.credentials.CredentialProvider) !RealHandshakeHarness {
-        var harness = RealHandshakeHarness{
+        const harness = RealHandshakeHarness{
             .client_backend = Tls13Backend.initClientWithOptions(
                 .{ .hello_random = [_]u8{0xc1} ** 32, .key_share_seed = [_]u8{0x11} ** 32 },
                 .{ .pinned_certificate = testdata.certificate_der },
                 .{ .server_name = server_name },
             ),
-            .server_backend = Tls13Backend.initServer(
+            .server_backend = Tls13Backend.initServerWithProvider(
                 .{ .hello_random = [_]u8{0x51} ** 32, .key_share_seed = [_]u8{0x22} ** 32 },
-                try Identity.initPkcs8(testdata.certificate_der, testdata.private_key_pkcs8_der),
+                provider,
             ),
         };
-        harness.server_backend.engine.external_provider = provider;
         return harness;
     }
 

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -21,6 +21,7 @@ const EncryptionLevel = tls_adapter.EncryptionLevel;
 pub const Identity = shared.Identity;
 pub const Trust = shared.Trust;
 pub const Entropy = shared.Entropy;
+pub const ClientOptions = shared.Tls13Backend.ClientOptions;
 pub const KeySchedule = shared.KeySchedule;
 pub const hash_len = shared.hash_len;
 pub const max_message_len = shared.max_message_len;
@@ -199,11 +200,15 @@ pub const Tls13Backend = struct {
     scratch: RecordSink = .{},
 
     pub fn initClient(entropy: Entropy, trust: Trust) Tls13Backend {
-        return .{ .engine = shared.Tls13Backend.initClient(entropy, trust, .{ .extension = .{
+        return initClientWithOptions(entropy, trust, .{});
+    }
+
+    pub fn initClientWithOptions(entropy: Entropy, trust: Trust, options: ClientOptions) Tls13Backend {
+        return .{ .engine = shared.Tls13Backend.initClientWithOptions(entropy, trust, .{ .extension = .{
             .alpn = "h3",
             .extension_type = ext_quic_transport_parameters,
             .local = "",
-        } }) };
+        } }, options) };
     }
 
     pub fn initServer(entropy: Entropy, identity: Identity) Tls13Backend {
@@ -434,6 +439,22 @@ const RealHandshakeHarness = struct {
         };
     }
 
+    fn initWithSniProvider(server_name: []const u8, provider: tls_core.credentials.CredentialProvider) !RealHandshakeHarness {
+        var harness = RealHandshakeHarness{
+            .client_backend = Tls13Backend.initClientWithOptions(
+                .{ .hello_random = [_]u8{0xc1} ** 32, .key_share_seed = [_]u8{0x11} ** 32 },
+                .{ .pinned_certificate = testdata.certificate_der },
+                .{ .server_name = server_name },
+            ),
+            .server_backend = Tls13Backend.initServer(
+                .{ .hello_random = [_]u8{0x51} ** 32, .key_share_seed = [_]u8{0x22} ** 32 },
+                try Identity.initPkcs8(testdata.certificate_der, testdata.private_key_pkcs8_der),
+            ),
+        };
+        harness.server_backend.engine.external_provider = provider;
+        return harness;
+    }
+
     fn wire(self: *RealHandshakeHarness) !void {
         self.client = tls_handshake.Handshake.initClient(&self.client_adapter, self.client_backend.backend());
         self.server = tls_handshake.Handshake.initServer(&self.server_adapter, self.server_backend.backend());
@@ -498,6 +519,44 @@ test "QUIC handshake owner tears down shared and adapter storage on success" {
     harness.deinit();
     try expectQuicBackendWiped(&harness.client_backend);
     try expectQuicBackendWiped(&harness.server_backend);
+}
+
+fn quicSniConfig(patterns: []const []const u8, chain: []const []const u8) tls_core.sni_provider.CredentialBundleConfig {
+    return .{
+        .chain = chain,
+        .patterns = patterns,
+        .signer = tls_core.sni_provider.SignAdapter.fromIdentity(Identity.initPkcs8(testdata.certificate_der, testdata.private_key_pkcs8_der) catch unreachable),
+        .key_kind = .ed25519,
+        .is_default = true,
+    };
+}
+
+test "QUIC handshake uses the shared reloadable SNI provider" {
+    var provider = tls_core.sni_provider.ReloadableProvider.init(std.testing.allocator);
+    defer provider.deinit();
+
+    const chain = [_][]const u8{testdata.certificate_der};
+    const first_patterns = [_][]const u8{"quic-one.example.test"};
+    try provider.reload(&.{quicSniConfig(first_patterns[0..], chain[0..])}, .{ .unknown_sni_policy = .fail_handshake });
+    {
+        var harness = try RealHandshakeHarness.initWithSniProvider("quic-one.example.test", provider.provider());
+        defer harness.deinit();
+        try harness.wire();
+        try harness.run();
+        try std.testing.expect(harness.client.isComplete());
+        try std.testing.expect(harness.server.isComplete());
+    }
+
+    const second_patterns = [_][]const u8{"quic-two.example.test"};
+    try provider.reload(&.{quicSniConfig(second_patterns[0..], chain[0..])}, .{ .unknown_sni_policy = .fail_handshake });
+    {
+        var harness = try RealHandshakeHarness.initWithSniProvider("quic-two.example.test", provider.provider());
+        defer harness.deinit();
+        try harness.wire();
+        try harness.run();
+        try std.testing.expect(harness.client.isComplete());
+        try std.testing.expect(harness.server.isComplete());
+    }
 }
 
 test "QUIC handshake owner tears down shared and adapter storage on failure" {

--- a/src/tls/credentials.zig
+++ b/src/tls/credentials.zig
@@ -210,6 +210,8 @@ pub const SelectError = error{
     ProviderInternalFailure,
     /// The provider returned a handle that violates the contract.
     InvalidCallbackBehavior,
+    /// The provider could not allocate a selected-handle or operation.
+    OutOfMemory,
 };
 
 /// Selects a local credential for one handshake. Implementations are the fixed
@@ -466,6 +468,7 @@ pub fn classifySelectError(err: SelectError) FailureClass {
         error.MalformedCredentialChain => .malformed_credential_chain,
         error.ProviderInternalFailure => .provider_internal_failure,
         error.InvalidCallbackBehavior => .invalid_callback_behavior,
+        error.OutOfMemory => .provider_internal_failure,
     };
 }
 

--- a/src/tls/dns_name.zig
+++ b/src/tls/dns_name.zig
@@ -1,0 +1,48 @@
+//! Shared ASCII DNS host-name validation for TLS SNI.
+
+pub const max_name_len = 253;
+
+pub const Error = error{InvalidDnsName};
+
+pub fn validateHostName(name: []const u8) Error!void {
+    if (name.len == 0 or name.len > max_name_len) return error.InvalidDnsName;
+    if (name[0] == '.' or name[name.len - 1] == '.') return error.InvalidDnsName;
+    var label_len: usize = 0;
+    var label_start: usize = 0;
+    for (name, 0..) |ch, i| {
+        if (ch == '.') {
+            try validateLabel(name[label_start..i], label_len);
+            label_len = 0;
+            label_start = i + 1;
+            continue;
+        }
+        if (!isDnsLabelByte(ch)) return error.InvalidDnsName;
+        label_len += 1;
+    }
+    try validateLabel(name[label_start..], label_len);
+}
+
+pub fn validateWildcardSuffix(name: []const u8) Error!void {
+    try validateHostName(name);
+    if (labelCount(name) < 2) return error.InvalidDnsName;
+}
+
+fn validateLabel(label: []const u8, label_len: usize) Error!void {
+    if (label_len == 0 or label_len > 63) return error.InvalidDnsName;
+    if (label[0] == '-' or label[label.len - 1] == '-') return error.InvalidDnsName;
+}
+
+fn labelCount(name: []const u8) usize {
+    var count: usize = 1;
+    for (name) |ch| {
+        if (ch == '.') count += 1;
+    }
+    return count;
+}
+
+pub fn isDnsLabelByte(ch: u8) bool {
+    return (ch >= 'A' and ch <= 'Z') or
+        (ch >= 'a' and ch <= 'z') or
+        (ch >= '0' and ch <= '9') or
+        ch == '-';
+}

--- a/src/tls/negotiation.zig
+++ b/src/tls/negotiation.zig
@@ -227,12 +227,15 @@ fn parseKeyShares(bytes: []const u8, offers: *ClientHelloOffers) Error!void {
 
 fn parseServerName(bytes: []const u8, offers: *ClientHelloOffers) Error!void {
     var r = messages.Reader{ .bytes = bytes };
-    var names = messages.Reader{ .bytes = try r.slice(try r.u16_()) };
+    const list_len = try r.u16_();
+    if (list_len == 0) return error.MalformedExtension;
+    var names = messages.Reader{ .bytes = try r.slice(list_len) };
     try r.expectEnd();
     while (names.remaining() > 0) {
         const name_type = try names.u8_();
         const name = try names.slice(try names.u16_());
-        if (name_type == 0 and offers.server_name == null) {
+        if (name_type == 0) {
+            if (offers.server_name != null) return error.MalformedExtension;
             dns_name.validateHostName(name) catch return error.MalformedExtension;
             offers.server_name = name;
         }
@@ -403,6 +406,71 @@ test "ClientHello parser feeds policy negotiation with ALPN and SNI offers" {
     try testing.expect(selected.alpn.eql(algorithms.alpn.h2));
     try testing.expectEqualStrings("example.test", selected.server_name.?);
     try testing.expectEqualStrings("share", selected.key_share);
+}
+
+fn clientHelloWithServerNameExtension(buf: []u8, server_name_payload: []const u8) ![]const u8 {
+    var w = messages.Writer{ .buf = buf };
+    try w.u16_(algorithms.legacy_version);
+    try w.bytes(&([_]u8{0} ** 32));
+    try w.u8_(0);
+    try w.u16_(2);
+    try w.u16_(@intFromEnum(algorithms.CipherSuite.tls_aes_128_gcm_sha256));
+    try w.u8_(1);
+    try w.u8_(0);
+
+    const extensions_len = try w.reserve(2);
+    try w.u16_(@intFromEnum(algorithms.ExtensionType.supported_versions));
+    try w.u16_(3);
+    try w.u8_(2);
+    try w.u16_(@intFromEnum(algorithms.ProtocolVersion.tls13));
+
+    try w.u16_(@intFromEnum(algorithms.ExtensionType.supported_groups));
+    try w.u16_(4);
+    try w.u16_(2);
+    try w.u16_(@intFromEnum(algorithms.NamedGroup.x25519));
+
+    try w.u16_(@intFromEnum(algorithms.ExtensionType.signature_algorithms));
+    try w.u16_(4);
+    try w.u16_(2);
+    try w.u16_(@intFromEnum(algorithms.SignatureScheme.ed25519));
+
+    try w.u16_(@intFromEnum(algorithms.ExtensionType.key_share));
+    const key_share_ext = try w.reserve(2);
+    const key_shares = try w.reserve(2);
+    try w.u16_(@intFromEnum(algorithms.NamedGroup.x25519));
+    try w.u16_(5);
+    try w.bytes("share");
+    w.patch(2, key_shares);
+    w.patch(2, key_share_ext);
+
+    try w.u16_(@intFromEnum(algorithms.ExtensionType.server_name));
+    try w.u16_(@intCast(server_name_payload.len));
+    try w.bytes(server_name_payload);
+    w.patch(2, extensions_len);
+    return w.written();
+}
+
+test "ClientHello parser rejects empty SNI ServerNameList" {
+    var body: [192]u8 = undefined;
+    const empty_server_name_list = [_]u8{ 0, 0 };
+    const hello = try clientHelloWithServerNameExtension(&body, &empty_server_name_list);
+    try testing.expectError(error.MalformedExtension, parseClientHello(hello));
+}
+
+test "ClientHello parser rejects duplicate SNI host_name entries" {
+    var sni_payload: [2 + 2 * (1 + 2 + 12)]u8 = undefined;
+    var sni = messages.Writer{ .buf = &sni_payload };
+    const list_len = try sni.reserve(2);
+    inline for (0..2) |_| {
+        try sni.u8_(0);
+        try sni.u16_(12);
+        try sni.bytes("example.test");
+    }
+    sni.patch(2, list_len);
+
+    var body: [256]u8 = undefined;
+    const hello = try clientHelloWithServerNameExtension(&body, sni.written());
+    try testing.expectError(error.MalformedExtension, parseClientHello(hello));
 }
 
 test "recognized offer vectors allow general-purpose client sizes" {

--- a/src/tls/negotiation.zig
+++ b/src/tls/negotiation.zig
@@ -2,6 +2,7 @@
 
 const std = @import("std");
 const algorithms = @import("algorithms.zig");
+const dns_name = @import("dns_name.zig");
 const messages = @import("messages.zig");
 const policy_mod = @import("policy.zig");
 
@@ -231,7 +232,10 @@ fn parseServerName(bytes: []const u8, offers: *ClientHelloOffers) Error!void {
     while (names.remaining() > 0) {
         const name_type = try names.u8_();
         const name = try names.slice(try names.u16_());
-        if (name_type == 0 and offers.server_name == null) offers.server_name = name;
+        if (name_type == 0 and offers.server_name == null) {
+            dns_name.validateHostName(name) catch return error.MalformedExtension;
+            offers.server_name = name;
+        }
     }
 }
 

--- a/src/tls/root.zig
+++ b/src/tls/root.zig
@@ -1,5 +1,6 @@
 pub const alerts = @import("alerts.zig");
 pub const credentials = @import("credentials.zig");
+pub const dns_name = @import("dns_name.zig");
 pub const engine = @import("engine.zig");
 pub const encrypted_stream = @import("encrypted_stream.zig");
 pub const handshake = @import("handshake.zig");

--- a/src/tls/root.zig
+++ b/src/tls/root.zig
@@ -14,6 +14,7 @@ pub const policy = @import("policy.zig");
 pub const record_codec = @import("record_codec.zig");
 pub const record_epoch_bridge = @import("record_epoch_bridge.zig");
 pub const record_protection = @import("record_protection.zig");
+pub const sni_provider = @import("sni_provider.zig");
 pub const transcript = @import("transcript.zig");
 pub const transport = @import("transport.zig");
 pub const tls13_backend = @import("tls13_backend.zig");

--- a/src/tls/sni_provider.zig
+++ b/src/tls/sni_provider.zig
@@ -168,6 +168,13 @@ pub const CredentialBundleConfig = struct {
     is_default: bool = false,
 };
 
+fn releaseConfiguredSigners(configs: []const CredentialBundleConfig) void {
+    for (configs) |config| {
+        var signer = config.signer;
+        signer.release();
+    }
+}
+
 const CredentialBundle = struct {
     chain: []const []const u8,
     patterns: []const HostPattern,
@@ -229,10 +236,7 @@ pub const Snapshot = struct {
     ) BuildError!*Snapshot {
         var consumed: usize = 0;
         errdefer {
-            for (configs[consumed..]) |config| {
-                var signer = config.signer;
-                signer.release();
-            }
+            releaseConfiguredSigners(configs[consumed..]);
         }
 
         if (configs.len == 0) return error.EmptyCredentialSet;
@@ -379,6 +383,7 @@ pub const ReloadableProvider = struct {
         self.mutex.lock();
         if (self.next_generation == std.math.maxInt(u64)) {
             self.mutex.unlock();
+            releaseConfiguredSigners(configs);
             return error.GenerationOverflow;
         }
         const generation = self.next_generation;
@@ -1039,6 +1044,19 @@ test "external high generation install advances later reload generation" {
     var reload_selection = testSelection("reload.example.test", &.{0x0807});
     const selected = try syncSelect(provider.provider(), &reload_selection);
     selected.release();
+}
+
+test "generation overflow reload releases configured signers" {
+    var provider = ReloadableProvider.init(testing.allocator);
+    defer provider.deinit();
+
+    const terminal = try Snapshot.build(testing.allocator, &.{identityConfig(&.{"terminal.example.test"}, true)}, .{}, std.math.maxInt(u64) - 1);
+    try provider.install(terminal);
+
+    var ext = CountingExternal{};
+    const replacement = countedExternalConfig(&ext, &.{"replacement.example.test"}, true);
+    try testing.expectError(error.GenerationOverflow, provider.reload(&.{replacement}, .{}));
+    try testing.expectEqual(@as(usize, 1), ext.release_count);
 }
 
 test "failed reload leaves current snapshot usable" {

--- a/src/tls/sni_provider.zig
+++ b/src/tls/sni_provider.zig
@@ -232,7 +232,7 @@ pub const Snapshot = struct {
 
         var default_count: usize = 0;
         for (configs, 0..) |config, index| {
-            bundles[index] = try buildBundle(allocator, config, index, bundles[0..initialized]);
+            bundles[index] = try buildBundle(allocator, config, index);
             initialized += 1;
             if (bundles[index].is_default) default_count += 1;
         }
@@ -265,12 +265,12 @@ pub const Snapshot = struct {
         self.bundles = &.{};
     }
 
-    fn select(self: *Snapshot, allocator: std.mem.Allocator, selection: *const credentials.SelectionContext) credentials.SelectError!credentials.SelectedCredential {
+    fn select(self: *Snapshot, selection: *const credentials.SelectionContext) credentials.SelectError!credentials.SelectedCredential {
         const class = self.resolveClass(selection.server_name) orelse return error.NoCredentialAvailable;
         for (self.bundles, 0..) |*bundle, index| {
             if (!bundle.matchesPattern(class)) continue;
             const scheme = chooseCompatibleScheme(bundle, selection.peer_signature_schemes) orelse continue;
-            const handle = allocator.create(SelectedHandle) catch return error.OutOfMemory;
+            const handle = self.allocator.create(SelectedHandle) catch return error.OutOfMemory;
             handle.* = .{
                 .snapshot = self,
                 .bundle_index = index,
@@ -380,7 +380,7 @@ pub const ReloadableProvider = struct {
         const self: *ReloadableProvider = @ptrCast(@alignCast(ctx));
         const snapshot = self.acquireCurrent() orelse return error.NoCredentialAvailable;
         errdefer snapshot.release();
-        const selected = try snapshot.select(self.allocator, selection);
+        const selected = try snapshot.select(selection);
         return .{ .complete = selected };
     }
 };
@@ -435,7 +435,6 @@ fn buildBundle(
     allocator: std.mem.Allocator,
     config: CredentialBundleConfig,
     install_order: usize,
-    previous: []const CredentialBundle,
 ) BuildError!CredentialBundle {
     var signer = config.signer;
     var signer_owned = true;
@@ -473,7 +472,7 @@ fn buildBundle(
     for (config.patterns, 0..) |raw, i| {
         patterns[i] = try parseHostPattern(allocator, raw);
         copied_patterns += 1;
-        if (hasDuplicatePattern(previous, patterns[i]) or hasDuplicatePatternIn(patterns[0..i], patterns[i]))
+        if (hasDuplicatePatternIn(patterns[0..i], patterns[i]))
             return error.DuplicateHostPattern;
     }
 
@@ -605,13 +604,6 @@ fn isDnsLabelByte(ch: u8) bool {
         ch == '-';
 }
 
-fn hasDuplicatePattern(previous: []const CredentialBundle, candidate: HostPattern) bool {
-    for (previous) |bundle| {
-        if (hasDuplicatePatternIn(bundle.patterns, candidate)) return true;
-    }
-    return false;
-}
-
 fn hasDuplicatePatternIn(patterns: []const HostPattern, candidate: HostPattern) bool {
     for (patterns) |pattern| {
         if (@as(std.meta.Tag(HostPattern), pattern) != @as(std.meta.Tag(HostPattern), candidate)) continue;
@@ -696,6 +688,20 @@ fn tlsToProviderScheme(scheme: credentials.SignatureScheme) ?crypto_provider.Sig
 
 const testing = std.testing;
 
+const p256_test_certificate_pem =
+    \\-----BEGIN CERTIFICATE-----
+    \\MIIBmzCCAUGgAwIBAgIURydPBx1vjDTJUssyVTi74k48qnIwCgYIKoZIzj0EAwIw
+    \\IzEhMB8GA1UEAwwYVGFyZGlncmFkZSBUZXN0IEVDRFNBIENBMB4XDTI2MDcxMzAy
+    \\MDUxOFoXDTM0MDkyOTAyMDUxOFowIzEhMB8GA1UEAwwYVGFyZGlncmFkZSBUZXN0
+    \\IEVDRFNBIENBMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFjO2x/y3R5vvZdls
+    \\KPVExKzZR9mdUMqPOXp/SfN4Z7of1ddxFWzxLFOdHLTzlQb09zZT5V5WoQXrhTA3
+    \\pmhI0aNTMFEwHQYDVR0OBBYEFKe7pGrj6TrDR8CnvdL6MNPwkdKbMB8GA1UdIwQY
+    \\MBaAFKe7pGrj6TrDR8CnvdL6MNPwkdKbMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZI
+    \\zj0EAwIDSAAwRQIhAKPR86FA40f3W8x1OOMGerLsB4jN61BdmM4HRZGj9syMAiAc
+    \\i+PZtkI67r6m/9cgMaix6IarU20mIJdvt0bM4+4uqA==
+    \\-----END CERTIFICATE-----
+;
+
 fn testSelection(name: ?[]const u8, schemes: []const u16) credentials.SelectionContext {
     return .{
         .role = .server,
@@ -714,6 +720,17 @@ fn identityConfig(patterns: []const []const u8, default: bool) CredentialBundleC
         .patterns = patterns,
         .signer = SignAdapter.fromIdentity(credentials.testdata.identity()),
         .key_kind = .ed25519,
+        .is_default = default,
+    };
+}
+
+fn p256ExternalConfig(patterns: []const []const u8, chain: []const []const u8, default: bool) CredentialBundleConfig {
+    return .{
+        .chain = chain,
+        .patterns = patterns,
+        .signer = SignAdapter.fromExternal(@ptrCast(@constCast(&noop_external_context)), noopExternalSign, noopExternalRelease),
+        .key_kind = .ecdsa_p256,
+        .supported_schemes = &.{.ecdsa_secp256r1_sha256},
         .is_default = default,
     };
 }
@@ -739,7 +756,7 @@ test "wildcard matcher consumes exactly one label" {
     try testing.expect(wildcardMatchesSuffix("A.Example.Test", ".example.test"));
 }
 
-test "snapshot rejects invalid wildcards and duplicate normalized patterns" {
+test "snapshot rejects invalid wildcards and duplicate normalized patterns inside one bundle" {
     const invalid = [_][]const u8{
         "foo*.example.test",
         "*foo.example.test",
@@ -753,9 +770,48 @@ test "snapshot rejects invalid wildcards and duplicate normalized patterns" {
         try testing.expectError(error.InvalidWildcardPattern, Snapshot.build(testing.allocator, &.{config}, .{}, 1));
     }
 
-    const a = identityConfig(&.{"API.Example.Test"}, false);
-    const b = identityConfig(&.{"api.example.test"}, true);
-    try testing.expectError(error.DuplicateHostPattern, Snapshot.build(testing.allocator, &.{ a, b }, .{}, 1));
+    const exact = identityConfig(&.{ "API.Example.Test", "api.example.test" }, true);
+    try testing.expectError(error.DuplicateHostPattern, Snapshot.build(testing.allocator, &.{exact}, .{}, 1));
+
+    const wildcard = identityConfig(&.{ "*.Example.Test", "*.example.test" }, true);
+    try testing.expectError(error.DuplicateHostPattern, Snapshot.build(testing.allocator, &.{wildcard}, .{}, 1));
+}
+
+test "same SNI pattern can select among bundles by signature compatibility" {
+    const ecdsa_der = try decodeSinglePemCertificate(testing.allocator, p256_test_certificate_pem);
+    defer testing.allocator.free(ecdsa_der);
+    const ecdsa_chain = [_][]const u8{ecdsa_der};
+
+    {
+        var provider = ReloadableProvider.init(testing.allocator);
+        defer provider.deinit();
+        const ed_exact = identityConfig(&.{"api.example.test"}, false);
+        const p256_exact = p256ExternalConfig(&.{"API.Example.Test"}, ecdsa_chain[0..], false);
+        try provider.reload(&.{ ed_exact, p256_exact }, .{ .absent_sni_policy = .fail_handshake });
+
+        var ecdsa_only = testSelection("api.example.test", &.{0x0403});
+        const selected_p256 = try syncSelect(provider.provider(), &ecdsa_only);
+        defer selected_p256.release();
+        try testing.expectEqual(credentials.SignatureScheme.ecdsa_secp256r1_sha256, selected_p256.scheme);
+
+        var both = testSelection("api.example.test", &.{ 0x0403, 0x0807 });
+        const selected_ed = try syncSelect(provider.provider(), &both);
+        defer selected_ed.release();
+        try testing.expectEqual(credentials.SignatureScheme.ed25519, selected_ed.scheme);
+    }
+
+    {
+        var provider = ReloadableProvider.init(testing.allocator);
+        defer provider.deinit();
+        const ed_wildcard = identityConfig(&.{"*.example.test"}, false);
+        const p256_wildcard = p256ExternalConfig(&.{"*.Example.Test"}, ecdsa_chain[0..], false);
+        try provider.reload(&.{ ed_wildcard, p256_wildcard }, .{ .absent_sni_policy = .fail_handshake });
+
+        var ecdsa_only = testSelection("www.example.test", &.{0x0403});
+        const selected_p256 = try syncSelect(provider.provider(), &ecdsa_only);
+        defer selected_p256.release();
+        try testing.expectEqual(credentials.SignatureScheme.ecdsa_secp256r1_sha256, selected_p256.scheme);
+    }
 }
 
 test "snapshot build rejects invalid bundles before publication" {
@@ -834,10 +890,18 @@ test "signature compatibility follows peer order and exact class does not fall t
 
     var exact = identityConfig(&.{"api.example.test"}, false);
     exact.supported_schemes = &.{.ed25519};
-    try provider.reload(&.{ exact, wildcard }, .{});
+    const ecdsa_der = try decodeSinglePemCertificate(testing.allocator, p256_test_certificate_pem);
+    defer testing.allocator.free(ecdsa_der);
+    const ecdsa_chain = [_][]const u8{ecdsa_der};
+    const compatible_wildcard = p256ExternalConfig(&.{"*.example.test"}, ecdsa_chain[0..], true);
+    try provider.reload(&.{ exact, compatible_wildcard }, .{});
 
     var selection = testSelection("api.example.test", &.{0x0403});
     try testing.expectError(error.NoCompatibleSignatureAlgorithm, provider.provider().selectCredential(&selection));
+
+    var wildcard_selection = testSelection("www.example.test", &.{0x0403});
+    const wildcard_selected = try syncSelect(provider.provider(), &wildcard_selection);
+    wildcard_selected.release();
 
     selection.peer_signature_schemes = &.{ 0xffff, 0x0807 };
     const selected = try syncSelect(provider.provider(), &selection);
@@ -913,6 +977,23 @@ test "failed reload leaves current snapshot usable" {
     try testing.expectError(error.EmptyChain, provider.reload(&.{bad}, .{}));
 
     var selection = testSelection("ok.example.test", &.{0x0807});
+    const selected = try syncSelect(provider.provider(), &selection);
+    selected.release();
+}
+
+test "selected handle release uses snapshot allocator after external install" {
+    var snapshot_debug: std.heap.DebugAllocator(.{}) = .init;
+    defer std.debug.assert(snapshot_debug.deinit() == .ok);
+    const snapshot_allocator = snapshot_debug.allocator();
+
+    var provider = ReloadableProvider.init(testing.allocator);
+    defer provider.deinit();
+
+    const config = identityConfig(&.{"allocator.example.test"}, true);
+    const snapshot = try Snapshot.build(snapshot_allocator, &.{config}, .{}, 1);
+    provider.install(snapshot);
+
+    var selection = testSelection("allocator.example.test", &.{0x0807});
     const selected = try syncSelect(provider.provider(), &selection);
     selected.release();
 }
@@ -1033,20 +1114,7 @@ fn sniIdentityConfigForFuzz(patterns: []const []const u8, chain: []const []const
 }
 
 test "ECDSA P-256 certificate metadata is selectable with a P-256 signer handle" {
-    const ecdsa_pem =
-        \\-----BEGIN CERTIFICATE-----
-        \\MIIBmzCCAUGgAwIBAgIURydPBx1vjDTJUssyVTi74k48qnIwCgYIKoZIzj0EAwIw
-        \\IzEhMB8GA1UEAwwYVGFyZGlncmFkZSBUZXN0IEVDRFNBIENBMB4XDTI2MDcxMzAy
-        \\MDUxOFoXDTM0MDkyOTAyMDUxOFowIzEhMB8GA1UEAwwYVGFyZGlncmFkZSBUZXN0
-        \\IEVDRFNBIENBMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFjO2x/y3R5vvZdls
-        \\KPVExKzZR9mdUMqPOXp/SfN4Z7of1ddxFWzxLFOdHLTzlQb09zZT5V5WoQXrhTA3
-        \\pmhI0aNTMFEwHQYDVR0OBBYEFKe7pGrj6TrDR8CnvdL6MNPwkdKbMB8GA1UdIwQY
-        \\MBaAFKe7pGrj6TrDR8CnvdL6MNPwkdKbMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZI
-        \\zj0EAwIDSAAwRQIhAKPR86FA40f3W8x1OOMGerLsB4jN61BdmM4HRZGj9syMAiAc
-        \\i+PZtkI67r6m/9cgMaix6IarU20mIJdvt0bM4+4uqA==
-        \\-----END CERTIFICATE-----
-    ;
-    const ecdsa_der = try decodeSinglePemCertificate(testing.allocator, ecdsa_pem);
+    const ecdsa_der = try decodeSinglePemCertificate(testing.allocator, p256_test_certificate_pem);
     defer testing.allocator.free(ecdsa_der);
 
     var ext = CountingExternal{};

--- a/src/tls/sni_provider.zig
+++ b/src/tls/sni_provider.zig
@@ -67,6 +67,13 @@ pub const BuildError = error{
     OutOfMemory,
 };
 
+pub const PublicationError = error{
+    StaleSnapshotGeneration,
+    GenerationOverflow,
+};
+
+pub const ReloadError = BuildError || PublicationError;
+
 pub const SignAdapter = union(enum) {
     identity: credentials.Identity,
     external: ExternalSigner,
@@ -368,34 +375,49 @@ pub const ReloadableProvider = struct {
         if (retired) |snapshot| snapshot.release();
     }
 
-    pub fn buildSnapshot(self: *ReloadableProvider, configs: []const CredentialBundleConfig, options: SnapshotOptions) BuildError!*Snapshot {
+    pub fn buildSnapshot(self: *ReloadableProvider, configs: []const CredentialBundleConfig, options: SnapshotOptions) ReloadError!*Snapshot {
         self.mutex.lock();
+        if (self.next_generation == std.math.maxInt(u64)) {
+            self.mutex.unlock();
+            return error.GenerationOverflow;
+        }
         const generation = self.next_generation;
         self.next_generation += 1;
         self.mutex.unlock();
         return Snapshot.build(self.allocator, configs, options, generation);
     }
 
-    pub fn reload(self: *ReloadableProvider, configs: []const CredentialBundleConfig, options: SnapshotOptions) BuildError!void {
+    pub fn reload(self: *ReloadableProvider, configs: []const CredentialBundleConfig, options: SnapshotOptions) ReloadError!void {
         const replacement = try self.buildSnapshot(configs, options);
-        self.install(replacement);
+        try self.install(replacement);
     }
 
-    pub fn install(self: *ReloadableProvider, replacement: *Snapshot) void {
+    pub fn install(self: *ReloadableProvider, replacement: *Snapshot) PublicationError!void {
         self.mutex.lock();
         if (self.current) |current| {
             if (current == replacement) {
+                if (replacement.generation == std.math.maxInt(u64)) {
+                    self.mutex.unlock();
+                    return error.GenerationOverflow;
+                }
+                self.next_generation = @max(self.next_generation, replacement.generation + 1);
                 self.mutex.unlock();
                 return;
             }
             if (replacement.generation <= current.generation) {
                 self.mutex.unlock();
                 replacement.release();
-                return;
+                return error.StaleSnapshotGeneration;
             }
+        }
+        if (replacement.generation == std.math.maxInt(u64)) {
+            self.mutex.unlock();
+            replacement.release();
+            return error.GenerationOverflow;
         }
         const retired = self.current;
         self.current = replacement;
+        self.next_generation = @max(self.next_generation, replacement.generation + 1);
         self.mutex.unlock();
         if (retired) |snapshot| snapshot.release();
     }
@@ -959,7 +981,7 @@ test "reload keeps selected generation alive until handle release" {
 
     var first = try provider.buildSnapshot(&.{identityConfig(&.{"first.example.test"}, true)}, .{});
     first.deinit_count = &first_deinit;
-    provider.install(first);
+    try provider.install(first);
 
     var selection = testSelection("first.example.test", &.{0x0807});
     const selected = try syncSelect(provider.provider(), &selection);
@@ -967,7 +989,7 @@ test "reload keeps selected generation alive until handle release" {
 
     var second = try provider.buildSnapshot(&.{identityConfig(&.{"second.example.test"}, true)}, .{});
     second.deinit_count = &second_deinit;
-    provider.install(second);
+    try provider.install(second);
     try testing.expectEqual(@as(usize, 0), first_deinit.load(.monotonic));
 
     var old_sig: [128]u8 = undefined;
@@ -989,8 +1011,8 @@ test "install rejects stale generations without rolling back current snapshot" {
     const stale = try Snapshot.build(testing.allocator, &.{identityConfig(&.{"stale.example.test"}, true)}, .{}, 1);
     stale.deinit_count = &stale_deinit;
     const current = try Snapshot.build(testing.allocator, &.{identityConfig(&.{"current.example.test"}, true)}, .{}, 2);
-    provider.install(current);
-    provider.install(stale);
+    try provider.install(current);
+    try testing.expectError(error.StaleSnapshotGeneration, provider.install(stale));
     try testing.expectEqual(@as(usize, 1), stale_deinit.load(.monotonic));
 
     var old_selection = testSelection("stale.example.test", &.{0x0807});
@@ -998,6 +1020,24 @@ test "install rejects stale generations without rolling back current snapshot" {
 
     var current_selection = testSelection("current.example.test", &.{0x0807});
     const selected = try syncSelect(provider.provider(), &current_selection);
+    selected.release();
+}
+
+test "external high generation install advances later reload generation" {
+    var provider = ReloadableProvider.init(testing.allocator);
+    defer provider.deinit();
+
+    const external = try Snapshot.build(testing.allocator, &.{identityConfig(&.{"external.example.test"}, true)}, .{}, 100);
+    try provider.install(external);
+
+    try provider.reload(&.{identityConfig(&.{"reload.example.test"}, true)}, .{});
+    try testing.expectEqual(@as(u64, 101), provider.current.?.generation);
+
+    var external_selection = testSelection("external.example.test", &.{0x0807});
+    try testing.expectError(error.NoCredentialAvailable, provider.provider().selectCredential(&external_selection));
+
+    var reload_selection = testSelection("reload.example.test", &.{0x0807});
+    const selected = try syncSelect(provider.provider(), &reload_selection);
     selected.release();
 }
 
@@ -1026,7 +1066,7 @@ test "selected handle release uses snapshot allocator after external install" {
 
     const config = identityConfig(&.{"allocator.example.test"}, true);
     const snapshot = try Snapshot.build(snapshot_allocator, &.{config}, .{}, 1);
-    provider.install(snapshot);
+    try provider.install(snapshot);
 
     var selection = testSelection("allocator.example.test", &.{0x0807});
     const selected = try syncSelect(provider.provider(), &selection);

--- a/src/tls/sni_provider.zig
+++ b/src/tls/sni_provider.zig
@@ -928,6 +928,160 @@ test "allocation failure during snapshot build does not leak" {
     }.run, .{});
 }
 
+test "fuzz: SNI pattern parsing and matching never panic" {
+    try testing.fuzz({}, fuzzPatternParsing, .{ .corpus = &.{
+        "",
+        "*",
+        "*.example.test",
+        "api.example.test",
+        "foo*.example.test",
+        "a.b.example.test",
+        "UPPER.Example.Test",
+        "\x00\xff.example.test",
+    } });
+}
+
+fn fuzzPatternParsing(_: void, smith: *testing.Smith) !void {
+    var input_buf: [max_host_pattern_len + 8]u8 = undefined;
+    const len = smith.slice(&input_buf);
+    var storage: [1024]u8 = undefined;
+    var fba = std.heap.FixedBufferAllocator.init(&storage);
+    const allocator = fba.allocator();
+    if (parseHostPattern(allocator, input_buf[0..len])) |pattern| {
+        defer freePattern(allocator, pattern);
+        _ = wildcardMatchesSuffix(input_buf[0..len], pattern.text());
+        _ = asciiEqlIgnoreCase(input_buf[0..len], pattern.text());
+    } else |_| {}
+}
+
+test "fuzz: SNI selection is deterministic and wildcard consumes one label" {
+    try testing.fuzz({}, fuzzSelectionDeterminism, .{ .corpus = &.{
+        "",
+        "api.example.test",
+        "API.Example.Test",
+        "www.example.test",
+        "a.b.example.test",
+        "missing.example.net",
+    } });
+}
+
+const SelectionOutcome = union(enum) {
+    selected: struct {
+        scheme: credentials.SignatureScheme,
+        chain_count: usize,
+    },
+    err: credentials.SelectError,
+};
+
+fn selectOutcome(provider: credentials.CredentialProvider, selection: *const credentials.SelectionContext) SelectionOutcome {
+    const progress = provider.selectCredential(selection) catch |err| return .{ .err = err };
+    return switch (progress) {
+        .complete => |credential| blk: {
+            const chain_count = credential.certificateChain().count();
+            const scheme = credential.scheme;
+            credential.release();
+            break :blk .{ .selected = .{ .scheme = scheme, .chain_count = chain_count } };
+        },
+        .pending => |op| blk: {
+            op.cancel();
+            op.release();
+            break :blk .{ .err = error.ProviderInternalFailure };
+        },
+    };
+}
+
+fn expectSameOutcome(a: SelectionOutcome, b: SelectionOutcome) !void {
+    try testing.expectEqual(@as(std.meta.Tag(SelectionOutcome), a), @as(std.meta.Tag(SelectionOutcome), b));
+    switch (a) {
+        .selected => |selected| {
+            try testing.expectEqual(selected.scheme, b.selected.scheme);
+            try testing.expectEqual(selected.chain_count, b.selected.chain_count);
+        },
+        .err => |err| try testing.expectEqual(err, b.err),
+    }
+}
+
+fn fuzzSelectionDeterminism(_: void, smith: *testing.Smith) !void {
+    var raw_name: [max_host_pattern_len]u8 = undefined;
+    const name_len = smith.slice(&raw_name);
+    const sni: ?[]const u8 = if (name_len == 0) null else raw_name[0..name_len];
+    var provider = ReloadableProvider.init(testing.allocator);
+    defer provider.deinit();
+
+    const chain_one = [_][]const u8{credentials.testdata.certificate_der};
+    const chain_two = [_][]const u8{ credentials.testdata.certificate_der, credentials.testdata.certificate_der };
+    const configs = [_]CredentialBundleConfig{
+        sniIdentityConfigForFuzz(&.{"api.example.test"}, chain_one[0..], false),
+        sniIdentityConfigForFuzz(&.{"*.example.test"}, chain_two[0..], true),
+    };
+    try provider.reload(&configs, .{ .unknown_sni_policy = .fail_handshake });
+
+    var schemes = [_]u16{ 0xffff, 0x0807 };
+    var first = testSelection(sni, schemes[0..]);
+    var second = testSelection(sni, schemes[0..]);
+    try expectSameOutcome(selectOutcome(provider.provider(), &first), selectOutcome(provider.provider(), &second));
+}
+
+fn sniIdentityConfigForFuzz(patterns: []const []const u8, chain: []const []const u8, default: bool) CredentialBundleConfig {
+    return .{
+        .chain = chain,
+        .patterns = patterns,
+        .signer = SignAdapter.fromIdentity(credentials.testdata.identity()),
+        .key_kind = .ed25519,
+        .is_default = default,
+    };
+}
+
+test "ECDSA P-256 certificate metadata is selectable with a P-256 signer handle" {
+    const ecdsa_pem =
+        \\-----BEGIN CERTIFICATE-----
+        \\MIIBmzCCAUGgAwIBAgIURydPBx1vjDTJUssyVTi74k48qnIwCgYIKoZIzj0EAwIw
+        \\IzEhMB8GA1UEAwwYVGFyZGlncmFkZSBUZXN0IEVDRFNBIENBMB4XDTI2MDcxMzAy
+        \\MDUxOFoXDTM0MDkyOTAyMDUxOFowIzEhMB8GA1UEAwwYVGFyZGlncmFkZSBUZXN0
+        \\IEVDRFNBIENBMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFjO2x/y3R5vvZdls
+        \\KPVExKzZR9mdUMqPOXp/SfN4Z7of1ddxFWzxLFOdHLTzlQb09zZT5V5WoQXrhTA3
+        \\pmhI0aNTMFEwHQYDVR0OBBYEFKe7pGrj6TrDR8CnvdL6MNPwkdKbMB8GA1UdIwQY
+        \\MBaAFKe7pGrj6TrDR8CnvdL6MNPwkdKbMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZI
+        \\zj0EAwIDSAAwRQIhAKPR86FA40f3W8x1OOMGerLsB4jN61BdmM4HRZGj9syMAiAc
+        \\i+PZtkI67r6m/9cgMaix6IarU20mIJdvt0bM4+4uqA==
+        \\-----END CERTIFICATE-----
+    ;
+    const ecdsa_der = try decodeSinglePemCertificate(testing.allocator, ecdsa_pem);
+    defer testing.allocator.free(ecdsa_der);
+
+    var ext = CountingExternal{};
+    const config = CredentialBundleConfig{
+        .chain = &.{ecdsa_der},
+        .patterns = &.{"p256.example.test"},
+        .signer = SignAdapter.fromExternal(&ext, CountingExternal.sign, CountingExternal.release),
+        .key_kind = .ecdsa_p256,
+        .supported_schemes = &.{.ecdsa_secp256r1_sha256},
+        .is_default = true,
+    };
+    const snapshot = try Snapshot.build(testing.allocator, &.{config}, .{}, 1);
+    snapshot.release();
+    try testing.expectEqual(@as(usize, 1), ext.release_count);
+}
+
+fn decodeSinglePemCertificate(allocator: std.mem.Allocator, pem: []const u8) ![]u8 {
+    const begin = "-----BEGIN CERTIFICATE-----";
+    const end = "-----END CERTIFICATE-----";
+    const begin_at = std.mem.indexOf(u8, pem, begin) orelse return error.PemBlockNotFound;
+    const body_start = begin_at + begin.len;
+    const end_at = std.mem.indexOfPos(u8, pem, body_start, end) orelse return error.PemBlockNotFound;
+    var b64: std.ArrayList(u8) = .empty;
+    defer b64.deinit(allocator);
+    for (pem[body_start..end_at]) |ch| switch (ch) {
+        '\n', '\r', ' ', '\t' => {},
+        else => try b64.append(allocator, ch),
+    };
+    const decoded_len = std.base64.standard.Decoder.calcSizeForSlice(b64.items) catch return error.InvalidPemBase64;
+    const der = try allocator.alloc(u8, decoded_len);
+    errdefer allocator.free(der);
+    std.base64.standard.Decoder.decode(der, b64.items) catch return error.InvalidPemBase64;
+    return der;
+}
+
 const CountingExternal = struct {
     release_count: usize = 0,
 

--- a/src/tls/sni_provider.zig
+++ b/src/tls/sni_provider.zig
@@ -10,6 +10,7 @@ const std = @import("std");
 const std_crypto = std.crypto;
 const crypto_provider = @import("crypto").provider;
 const credentials = @import("credentials.zig");
+const dns_name = @import("dns_name.zig");
 
 pub const max_bundles = 64;
 pub const max_patterns_per_bundle = 16;
@@ -80,8 +81,16 @@ pub const SignAdapter = union(enum) {
     pub const SigningKeyAdapter = struct {
         key: crypto_provider.SigningKey,
         entropy: crypto_provider.Entropy,
-        release_context: ?*anyopaque = null,
-        release: ?*const fn (context: *anyopaque) void = null,
+        ownership: SigningKeyOwnership = .borrowed,
+    };
+
+    pub const SigningKeyOwnership = union(enum) {
+        borrowed,
+        owned: struct {
+            context: *anyopaque,
+            release: *const fn (context: *anyopaque) void,
+        },
+        invalid_release_contract,
     };
 
     pub fn fromIdentity(identity: credentials.Identity) SignAdapter {
@@ -102,7 +111,11 @@ pub const SignAdapter = union(enum) {
         release_context: ?*anyopaque,
         release_fn: ?*const fn (*anyopaque) void,
     ) SignAdapter {
-        return .{ .signing_key = .{ .key = key, .entropy = entropy, .release_context = release_context, .release = release_fn } };
+        const ownership: SigningKeyOwnership = if (release_fn) |release_callback| blk: {
+            const context = release_context orelse break :blk .invalid_release_contract;
+            break :blk .{ .owned = .{ .context = context, .release = release_callback } };
+        } else .borrowed;
+        return .{ .signing_key = .{ .key = key, .entropy = entropy, .ownership = ownership } };
     }
 
     fn sign(self: *SignAdapter, scheme: credentials.SignatureScheme, input: []const u8, out: []u8) credentials.SignError!usize {
@@ -131,8 +144,9 @@ pub const SignAdapter = union(enum) {
         switch (self.*) {
             .identity => |*identity| std_crypto.secureZero(u8, std.mem.asBytes(&identity.key)),
             .external => |external| external.release(external.context),
-            .signing_key => |adapter| if (adapter.release) |release_fn| {
-                release_fn(adapter.release_context.?);
+            .signing_key => |adapter| switch (adapter.ownership) {
+                .borrowed, .invalid_release_contract => {},
+                .owned => |owned| owned.release(owned.context),
             },
         }
     }
@@ -198,9 +212,7 @@ pub const Snapshot = struct {
     generation: u64,
     bundles: []CredentialBundle,
     ref_count: std.atomic.Value(usize) = std.atomic.Value(usize).init(1),
-    deinit_count: *usize = &noop_deinit_count,
-
-    var noop_deinit_count: usize = 0;
+    deinit_count: ?*std.atomic.Value(usize) = null,
 
     pub fn build(
         allocator: std.mem.Allocator,
@@ -208,6 +220,14 @@ pub const Snapshot = struct {
         options: SnapshotOptions,
         generation: u64,
     ) BuildError!*Snapshot {
+        var consumed: usize = 0;
+        errdefer {
+            for (configs[consumed..]) |config| {
+                var signer = config.signer;
+                signer.release();
+            }
+        }
+
         if (configs.len == 0) return error.EmptyCredentialSet;
         if (configs.len > max_bundles) return error.EmptyCredentialSet;
 
@@ -232,6 +252,7 @@ pub const Snapshot = struct {
 
         var default_count: usize = 0;
         for (configs, 0..) |config, index| {
+            consumed = index + 1;
             bundles[index] = try buildBundle(allocator, config, index);
             initialized += 1;
             if (bundles[index].is_default) default_count += 1;
@@ -259,7 +280,9 @@ pub const Snapshot = struct {
     }
 
     fn deinit(self: *Snapshot) void {
-        self.deinit_count.* += 1;
+        if (self.deinit_count) |counter| {
+            _ = counter.fetchAdd(1, .monotonic);
+        }
         for (self.bundles) |*bundle| bundle.deinit(self.allocator);
         self.allocator.free(self.bundles);
         self.bundles = &.{};
@@ -360,6 +383,17 @@ pub const ReloadableProvider = struct {
 
     pub fn install(self: *ReloadableProvider, replacement: *Snapshot) void {
         self.mutex.lock();
+        if (self.current) |current| {
+            if (current == replacement) {
+                self.mutex.unlock();
+                return;
+            }
+            if (replacement.generation <= current.generation) {
+                self.mutex.unlock();
+                replacement.release();
+                return;
+            }
+        }
         const retired = self.current;
         self.current = replacement;
         self.mutex.unlock();
@@ -486,7 +520,10 @@ fn buildBundle(
     switch (signer) {
         .external => {},
         .signing_key => |adapter| {
-            if (adapter.release != null and adapter.release_context == null) return error.InvalidOwnershipContract;
+            if (adapter.ownership == .invalid_release_contract) return error.InvalidOwnershipContract;
+            const actual = providerToTlsScheme(adapter.key.scheme()) orelse return error.NoSupportedSignatureScheme;
+            if (!schemeLegalForKeyKind(config.key_kind, actual) or !containsScheme(schemes, actual))
+                return error.KeySignerMismatch;
         },
         .identity => |*identity| if (identity.signatureScheme() != schemes[0] or !schemeLegalForKeyKind(config.key_kind, identity.signatureScheme()))
             return error.KeySignerMismatch,
@@ -565,43 +602,16 @@ fn parseHostPattern(allocator: std.mem.Allocator, raw: []const u8) BuildError!Ho
         if (star != 0 or raw.len < 3 or raw[1] != '.') return error.InvalidWildcardPattern;
         if (std.mem.indexOfScalar(u8, raw[1..], '*') != null) return error.InvalidWildcardPattern;
         const suffix_raw = raw[1..];
-        try validateDnsName(suffix_raw[1..], true);
+        dns_name.validateWildcardSuffix(suffix_raw[1..]) catch return error.InvalidWildcardPattern;
         const suffix = allocator.alloc(u8, suffix_raw.len) catch return error.OutOfMemory;
         for (suffix_raw, 0..) |ch, i| suffix[i] = asciiLower(ch);
         return .{ .wildcard_suffix = suffix };
     }
 
-    try validateDnsName(raw, false);
+    dns_name.validateHostName(raw) catch return error.InvalidHostPattern;
     const exact = allocator.alloc(u8, raw.len) catch return error.OutOfMemory;
     for (raw, 0..) |ch, i| exact[i] = asciiLower(ch);
     return .{ .exact = exact };
-}
-
-fn validateDnsName(name: []const u8, wildcard_suffix: bool) BuildError!void {
-    if (name.len == 0 or name.len > max_host_pattern_len) return error.InvalidHostPattern;
-    if (name[0] == '.' or name[name.len - 1] == '.') return if (wildcard_suffix) error.InvalidWildcardPattern else error.InvalidHostPattern;
-    var label_len: usize = 0;
-    var labels: usize = 0;
-    for (name) |ch| {
-        if (ch == '.') {
-            if (label_len == 0 or label_len > 63) return if (wildcard_suffix) error.InvalidWildcardPattern else error.InvalidHostPattern;
-            labels += 1;
-            label_len = 0;
-            continue;
-        }
-        if (!isDnsLabelByte(ch)) return if (wildcard_suffix) error.InvalidWildcardPattern else error.InvalidHostPattern;
-        label_len += 1;
-    }
-    if (label_len == 0 or label_len > 63) return if (wildcard_suffix) error.InvalidWildcardPattern else error.InvalidHostPattern;
-    labels += 1;
-    if (wildcard_suffix and labels < 2) return error.InvalidWildcardPattern;
-}
-
-fn isDnsLabelByte(ch: u8) bool {
-    return (ch >= 'A' and ch <= 'Z') or
-        (ch >= 'a' and ch <= 'z') or
-        (ch >= '0' and ch <= '9') or
-        ch == '-';
 }
 
 fn hasDuplicatePatternIn(patterns: []const HostPattern, candidate: HostPattern) bool {
@@ -642,9 +652,14 @@ pub fn wildcardMatchesSuffix(server_name: []const u8, suffix: []const u8) bool {
 
 fn lowerHostInto(raw: []const u8, out: *[max_host_pattern_len]u8) BuildError![]const u8 {
     if (raw.len == 0 or raw.len > out.len) return error.InvalidHostPattern;
-    try validateDnsName(raw, false);
+    dns_name.validateHostName(raw) catch return error.InvalidHostPattern;
     for (raw, 0..) |ch, i| out[i] = asciiLower(ch);
     return out[0..raw.len];
+}
+
+fn containsScheme(schemes: []const credentials.SignatureScheme, needle: credentials.SignatureScheme) bool {
+    for (schemes) |scheme| if (scheme == needle) return true;
+    return false;
 }
 
 fn chooseCompatibleScheme(bundle: *const CredentialBundle, offered: []const u16) ?credentials.SignatureScheme {
@@ -937,8 +952,8 @@ test "snapshot owns chain and pattern copies after caller mutation" {
 }
 
 test "reload keeps selected generation alive until handle release" {
-    var first_deinit: usize = 0;
-    var second_deinit: usize = 0;
+    var first_deinit = std.atomic.Value(usize).init(0);
+    var second_deinit = std.atomic.Value(usize).init(0);
     var provider = ReloadableProvider.init(testing.allocator);
     defer provider.deinit();
 
@@ -948,22 +963,42 @@ test "reload keeps selected generation alive until handle release" {
 
     var selection = testSelection("first.example.test", &.{0x0807});
     const selected = try syncSelect(provider.provider(), &selection);
-    try testing.expectEqual(@as(usize, 0), first_deinit);
+    try testing.expectEqual(@as(usize, 0), first_deinit.load(.monotonic));
 
     var second = try provider.buildSnapshot(&.{identityConfig(&.{"second.example.test"}, true)}, .{});
     second.deinit_count = &second_deinit;
     provider.install(second);
-    try testing.expectEqual(@as(usize, 0), first_deinit);
+    try testing.expectEqual(@as(usize, 0), first_deinit.load(.monotonic));
 
     var old_sig: [128]u8 = undefined;
     _ = try syncSign(selected, "still generation 1", &old_sig);
     selected.release();
-    try testing.expectEqual(@as(usize, 1), first_deinit);
+    try testing.expectEqual(@as(usize, 1), first_deinit.load(.monotonic));
 
     var new_selection = testSelection("second.example.test", &.{0x0807});
     const new_selected = try syncSelect(provider.provider(), &new_selection);
     new_selected.release();
-    try testing.expectEqual(@as(usize, 0), second_deinit);
+    try testing.expectEqual(@as(usize, 0), second_deinit.load(.monotonic));
+}
+
+test "install rejects stale generations without rolling back current snapshot" {
+    var stale_deinit = std.atomic.Value(usize).init(0);
+    var provider = ReloadableProvider.init(testing.allocator);
+    defer provider.deinit();
+
+    const stale = try Snapshot.build(testing.allocator, &.{identityConfig(&.{"stale.example.test"}, true)}, .{}, 1);
+    stale.deinit_count = &stale_deinit;
+    const current = try Snapshot.build(testing.allocator, &.{identityConfig(&.{"current.example.test"}, true)}, .{}, 2);
+    provider.install(current);
+    provider.install(stale);
+    try testing.expectEqual(@as(usize, 1), stale_deinit.load(.monotonic));
+
+    var old_selection = testSelection("stale.example.test", &.{0x0807});
+    try testing.expectError(error.NoCredentialAvailable, provider.provider().selectCredential(&old_selection));
+
+    var current_selection = testSelection("current.example.test", &.{0x0807});
+    const selected = try syncSelect(provider.provider(), &current_selection);
+    selected.release();
 }
 
 test "failed reload leaves current snapshot usable" {
@@ -1131,6 +1166,72 @@ test "ECDSA P-256 certificate metadata is selectable with a P-256 signer handle"
     try testing.expectEqual(@as(usize, 1), ext.release_count);
 }
 
+test "SigningKeyAdapter validates actual key scheme and ownership at build time" {
+    var fake_key = FakeSigningKey{ .scheme_value = .ecdsa_secp256r1_sha256 };
+    const mismatched = CredentialBundleConfig{
+        .chain = &.{credentials.testdata.certificate_der},
+        .patterns = &.{"mismatch.example.test"},
+        .signer = SignAdapter.fromSigningKey(fake_key.key(), fakeEntropy(), null, null),
+        .key_kind = .ed25519,
+        .supported_schemes = &.{.ed25519},
+        .is_default = true,
+    };
+    try testing.expectError(error.KeySignerMismatch, Snapshot.build(testing.allocator, &.{mismatched}, .{}, 1));
+
+    var release_count: usize = 0;
+    fake_key.scheme_value = .ed25519;
+    const invalid_owner = CredentialBundleConfig{
+        .chain = &.{credentials.testdata.certificate_der},
+        .patterns = &.{"invalid-owner.example.test"},
+        .signer = SignAdapter.fromSigningKey(fake_key.key(), fakeEntropy(), null, invalidSigningKeyRelease),
+        .key_kind = .ed25519,
+        .supported_schemes = &.{.ed25519},
+        .is_default = true,
+    };
+    invalid_release_count = &release_count;
+    defer invalid_release_count = null;
+    try testing.expectError(error.InvalidOwnershipContract, Snapshot.build(testing.allocator, &.{invalid_owner}, .{}, 1));
+    try testing.expectEqual(@as(usize, 0), release_count);
+}
+
+const FakeSigningKey = struct {
+    scheme_value: crypto_provider.SignatureScheme,
+
+    fn key(self: *FakeSigningKey) crypto_provider.SigningKey {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    const vtable = crypto_provider.SigningKey.VTable{
+        .scheme = scheme,
+        .sign = sign,
+    };
+
+    fn scheme(ctx: *anyopaque) crypto_provider.SignatureScheme {
+        const self: *FakeSigningKey = @ptrCast(@alignCast(ctx));
+        return self.scheme_value;
+    }
+
+    fn sign(_: *anyopaque, _: []const u8, _: crypto_provider.Entropy, _: []u8) crypto_provider.SignError!usize {
+        return error.ProviderFailure;
+    }
+};
+
+var fake_entropy_context: u8 = 0;
+
+fn fakeEntropy() crypto_provider.Entropy {
+    return .{ .context = &fake_entropy_context, .fillFn = fakeEntropyFill };
+}
+
+fn fakeEntropyFill(_: *anyopaque, buffer: []u8) crypto_provider.EntropyError!void {
+    @memset(buffer, 0);
+}
+
+var invalid_release_count: ?*usize = null;
+
+fn invalidSigningKeyRelease(_: *anyopaque) void {
+    if (invalid_release_count) |count| count.* += 1;
+}
+
 fn decodeSinglePemCertificate(allocator: std.mem.Allocator, pem: []const u8) ![]u8 {
     const begin = "-----BEGIN CERTIFICATE-----";
     const end = "-----END CERTIFICATE-----";
@@ -1163,6 +1264,17 @@ const CountingExternal = struct {
     }
 };
 
+fn countedExternalConfig(ctx: *CountingExternal, patterns: []const []const u8, default: bool) CredentialBundleConfig {
+    return .{
+        .chain = &.{credentials.testdata.certificate_der},
+        .patterns = patterns,
+        .signer = SignAdapter.fromExternal(ctx, CountingExternal.sign, CountingExternal.release),
+        .key_kind = .ed25519,
+        .supported_schemes = &.{.ed25519},
+        .is_default = default,
+    };
+}
+
 var noop_external_context: u8 = 0;
 
 fn noopExternalSign(_: *anyopaque, _: credentials.SignatureScheme, _: []const u8, _: []u8) credentials.SignError!usize {
@@ -1188,6 +1300,48 @@ test "external signer owner release callback runs exactly once" {
         try testing.expectEqual(@as(usize, 0), ext.release_count);
     }
     try testing.expectEqual(@as(usize, 1), ext.release_count);
+}
+
+test "failed multi-bundle build releases every configured signer exactly once" {
+    {
+        var ext = [_]CountingExternal{ .{}, .{}, .{} };
+        const configs = [_]CredentialBundleConfig{
+            countedExternalConfig(&ext[0], &.{"bad*.example.test"}, false),
+            countedExternalConfig(&ext[1], &.{"later-one.example.test"}, false),
+            countedExternalConfig(&ext[2], &.{"later-two.example.test"}, true),
+        };
+        try testing.expectError(error.InvalidWildcardPattern, Snapshot.build(testing.allocator, &configs, .{}, 1));
+        for (&ext) |item| try testing.expectEqual(@as(usize, 1), item.release_count);
+    }
+    {
+        var ext = [_]CountingExternal{ .{}, .{}, .{} };
+        const configs = [_]CredentialBundleConfig{
+            countedExternalConfig(&ext[0], &.{"first.example.test"}, false),
+            countedExternalConfig(&ext[1], &.{"bad*.example.test"}, false),
+            countedExternalConfig(&ext[2], &.{"later.example.test"}, true),
+        };
+        try testing.expectError(error.InvalidWildcardPattern, Snapshot.build(testing.allocator, &configs, .{}, 1));
+        for (&ext) |item| try testing.expectEqual(@as(usize, 1), item.release_count);
+    }
+}
+
+test "allocation failure during external multi-bundle build releases every signer" {
+    try testing.checkAllAllocationFailures(testing.allocator, struct {
+        fn run(allocator: std.mem.Allocator) !void {
+            var ext = [_]CountingExternal{ .{}, .{}, .{} };
+            const configs = [_]CredentialBundleConfig{
+                countedExternalConfig(&ext[0], &.{"one.example.test"}, false),
+                countedExternalConfig(&ext[1], &.{"two.example.test"}, false),
+                countedExternalConfig(&ext[2], &.{"default.example.test"}, true),
+            };
+            const snapshot = Snapshot.build(allocator, &configs, .{}, 1) catch |err| {
+                for (&ext) |item| try testing.expectEqual(@as(usize, 1), item.release_count);
+                return err;
+            };
+            snapshot.release();
+            for (&ext) |item| try testing.expectEqual(@as(usize, 1), item.release_count);
+        }
+    }.run, .{});
 }
 
 test "external signer is released when unpublished snapshot validation fails" {

--- a/src/tls/sni_provider.zig
+++ b/src/tls/sni_provider.zig
@@ -1,0 +1,983 @@
+//! Reloadable in-memory SNI credential provider (#347).
+//!
+//! This module implements the production multi-certificate selector behind the
+//! provider-neutral credential seam from `credentials.zig`. A published
+//! `Snapshot` is immutable; reload builds a complete replacement off-path and
+//! publishes it atomically. Selected handles retain their snapshot until
+//! release, so in-flight handshakes never observe mixed generations.
+
+const std = @import("std");
+const std_crypto = std.crypto;
+const crypto_provider = @import("crypto").provider;
+const credentials = @import("credentials.zig");
+
+pub const max_bundles = 64;
+pub const max_patterns_per_bundle = 16;
+pub const max_host_pattern_len = 253;
+
+pub const AbsentSniPolicy = enum {
+    use_default,
+    fail_handshake,
+};
+
+pub const UnknownSniPolicy = enum {
+    use_default,
+    fail_handshake,
+};
+
+pub const SnapshotOptions = struct {
+    absent_sni_policy: AbsentSniPolicy = .use_default,
+    unknown_sni_policy: UnknownSniPolicy = .fail_handshake,
+};
+
+pub const KeyKind = enum {
+    ed25519,
+    ecdsa_p256,
+};
+
+pub const HostPattern = union(enum) {
+    exact: []const u8,
+    wildcard_suffix: []const u8,
+
+    pub fn text(self: HostPattern) []const u8 {
+        return switch (self) {
+            .exact => |value| value,
+            .wildcard_suffix => |value| value,
+        };
+    }
+};
+
+pub const BuildError = error{
+    EmptyCredentialSet,
+    EmptyChain,
+    TooManyChainEntries,
+    InvalidChain,
+    InvalidLeafKey,
+    KeySignerMismatch,
+    UnsupportedKeyType,
+    EmptyHostPattern,
+    InvalidHostPattern,
+    InvalidWildcardPattern,
+    DuplicateHostPattern,
+    DuplicateDefaultBundle,
+    NoUsableDefaultBundle,
+    NoSupportedSignatureScheme,
+    InvalidOwnershipContract,
+    OutOfMemory,
+};
+
+pub const SignAdapter = union(enum) {
+    identity: credentials.Identity,
+    external: ExternalSigner,
+    signing_key: SigningKeyAdapter,
+
+    pub const ExternalSigner = struct {
+        context: *anyopaque,
+        sign: *const fn (context: *anyopaque, scheme: credentials.SignatureScheme, input: []const u8, out: []u8) credentials.SignError!usize,
+        release: *const fn (context: *anyopaque) void,
+    };
+
+    pub const SigningKeyAdapter = struct {
+        key: crypto_provider.SigningKey,
+        entropy: crypto_provider.Entropy,
+        release_context: ?*anyopaque = null,
+        release: ?*const fn (context: *anyopaque) void = null,
+    };
+
+    pub fn fromIdentity(identity: credentials.Identity) SignAdapter {
+        return .{ .identity = identity };
+    }
+
+    pub fn fromExternal(
+        context: *anyopaque,
+        sign_fn: *const fn (*anyopaque, credentials.SignatureScheme, []const u8, []u8) credentials.SignError!usize,
+        release_fn: *const fn (*anyopaque) void,
+    ) SignAdapter {
+        return .{ .external = .{ .context = context, .sign = sign_fn, .release = release_fn } };
+    }
+
+    pub fn fromSigningKey(
+        key: crypto_provider.SigningKey,
+        entropy: crypto_provider.Entropy,
+        release_context: ?*anyopaque,
+        release_fn: ?*const fn (*anyopaque) void,
+    ) SignAdapter {
+        return .{ .signing_key = .{ .key = key, .entropy = entropy, .release_context = release_context, .release = release_fn } };
+    }
+
+    fn sign(self: *SignAdapter, scheme: credentials.SignatureScheme, input: []const u8, out: []u8) credentials.SignError!usize {
+        return switch (self.*) {
+            .identity => |*identity| blk: {
+                if (identity.signatureScheme() != scheme) return error.InvalidCallbackBehavior;
+                break :blk try identity.sign(input, out);
+            },
+            .external => |external| try external.sign(external.context, scheme, input, out),
+            .signing_key => |adapter| blk: {
+                const provider_scheme = tlsToProviderScheme(scheme) orelse return error.InvalidCallbackBehavior;
+                if (adapter.key.scheme() != provider_scheme) return error.InvalidCallbackBehavior;
+                const written = adapter.key.sign(input, adapter.entropy, out) catch |err| switch (err) {
+                    error.InvalidInput => return error.SignatureOutputOverflow,
+                    error.UnsupportedCapability,
+                    error.EntropyFailure,
+                    error.ProviderFailure,
+                    => return error.SigningProviderFailure,
+                };
+                break :blk written;
+            },
+        };
+    }
+
+    fn release(self: *SignAdapter) void {
+        switch (self.*) {
+            .identity => |*identity| std_crypto.secureZero(u8, std.mem.asBytes(&identity.key)),
+            .external => |external| external.release(external.context),
+            .signing_key => |adapter| if (adapter.release) |release_fn| {
+                release_fn(adapter.release_context.?);
+            },
+        }
+    }
+};
+
+pub const CredentialBundleConfig = struct {
+    chain: []const []const u8,
+    patterns: []const []const u8,
+    signer: SignAdapter,
+    key_kind: KeyKind,
+    supported_schemes: []const credentials.SignatureScheme = &.{},
+    is_default: bool = false,
+};
+
+const CredentialBundle = struct {
+    chain: []const []const u8,
+    patterns: []const HostPattern,
+    signer: SignAdapter,
+    key_kind: KeyKind,
+    supported_schemes: []const credentials.SignatureScheme,
+    install_order: usize,
+    is_default: bool,
+
+    fn deinit(self: *CredentialBundle, allocator: std.mem.Allocator) void {
+        for (self.chain) |entry| allocator.free(entry);
+        allocator.free(self.chain);
+        for (self.patterns) |pattern| {
+            switch (pattern) {
+                .exact => |value| allocator.free(value),
+                .wildcard_suffix => |value| allocator.free(value),
+            }
+        }
+        allocator.free(self.patterns);
+        allocator.free(self.supported_schemes);
+        self.signer.release();
+        self.* = undefined;
+    }
+
+    fn matchesPattern(self: *const CredentialBundle, class: MatchClass) bool {
+        return switch (class) {
+            .exact => |name| for (self.patterns) |pattern| {
+                if (pattern == .exact and std.mem.eql(u8, pattern.exact, name)) break true;
+            } else false,
+            .wildcard => |suffix| for (self.patterns) |pattern| {
+                if (pattern == .wildcard_suffix and std.mem.eql(u8, pattern.wildcard_suffix, suffix)) break true;
+            } else false,
+            .default => self.is_default,
+        };
+    }
+
+    fn supportsScheme(self: *const CredentialBundle, scheme: credentials.SignatureScheme) bool {
+        if (!schemeLegalForKeyKind(self.key_kind, scheme)) return false;
+        for (self.supported_schemes) |candidate| {
+            if (candidate == scheme) return true;
+        }
+        return false;
+    }
+};
+
+pub const Snapshot = struct {
+    allocator: std.mem.Allocator,
+    options: SnapshotOptions,
+    generation: u64,
+    bundles: []CredentialBundle,
+    ref_count: std.atomic.Value(usize) = std.atomic.Value(usize).init(1),
+    deinit_count: *usize = &noop_deinit_count,
+
+    var noop_deinit_count: usize = 0;
+
+    pub fn build(
+        allocator: std.mem.Allocator,
+        configs: []const CredentialBundleConfig,
+        options: SnapshotOptions,
+        generation: u64,
+    ) BuildError!*Snapshot {
+        if (configs.len == 0) return error.EmptyCredentialSet;
+        if (configs.len > max_bundles) return error.EmptyCredentialSet;
+
+        var snapshot = allocator.create(Snapshot) catch return error.OutOfMemory;
+        snapshot.* = .{
+            .allocator = allocator,
+            .options = options,
+            .generation = generation,
+            .bundles = &.{},
+        };
+        errdefer {
+            snapshot.deinit();
+            allocator.destroy(snapshot);
+        }
+
+        var bundles = allocator.alloc(CredentialBundle, configs.len) catch return error.OutOfMemory;
+        var initialized: usize = 0;
+        errdefer {
+            for (bundles[0..initialized]) |*bundle| bundle.deinit(allocator);
+            allocator.free(bundles);
+        }
+
+        var default_count: usize = 0;
+        for (configs, 0..) |config, index| {
+            bundles[index] = try buildBundle(allocator, config, index, bundles[0..initialized]);
+            initialized += 1;
+            if (bundles[index].is_default) default_count += 1;
+        }
+        if (default_count > 1) return error.DuplicateDefaultBundle;
+        if (default_count == 0 and (options.absent_sni_policy == .use_default or options.unknown_sni_policy == .use_default))
+            return error.NoUsableDefaultBundle;
+
+        snapshot.bundles = bundles;
+        return snapshot;
+    }
+
+    pub fn retain(self: *Snapshot) void {
+        _ = self.ref_count.fetchAdd(1, .acq_rel);
+    }
+
+    pub fn release(self: *Snapshot) void {
+        const previous = self.ref_count.fetchSub(1, .acq_rel);
+        std.debug.assert(previous > 0);
+        if (previous == 1) {
+            const allocator = self.allocator;
+            self.deinit();
+            allocator.destroy(self);
+        }
+    }
+
+    fn deinit(self: *Snapshot) void {
+        self.deinit_count.* += 1;
+        for (self.bundles) |*bundle| bundle.deinit(self.allocator);
+        self.allocator.free(self.bundles);
+        self.bundles = &.{};
+    }
+
+    fn select(self: *Snapshot, allocator: std.mem.Allocator, selection: *const credentials.SelectionContext) credentials.SelectError!credentials.SelectedCredential {
+        const class = self.resolveClass(selection.server_name) orelse return error.NoCredentialAvailable;
+        for (self.bundles, 0..) |*bundle, index| {
+            if (!bundle.matchesPattern(class)) continue;
+            const scheme = chooseCompatibleScheme(bundle, selection.peer_signature_schemes) orelse continue;
+            const handle = allocator.create(SelectedHandle) catch return error.OutOfMemory;
+            handle.* = .{
+                .snapshot = self,
+                .bundle_index = index,
+                .chosen_scheme = scheme,
+            };
+            return .{ .handle = handle, .scheme = scheme, .vtable = &SelectedHandle.vtable };
+        }
+        return error.NoCompatibleSignatureAlgorithm;
+    }
+
+    fn resolveClass(self: *const Snapshot, server_name: ?[]const u8) ?MatchClass {
+        const raw_name = server_name orelse {
+            return switch (self.options.absent_sni_policy) {
+                .use_default => .default,
+                .fail_handshake => null,
+            };
+        };
+        if (raw_name.len == 0 or raw_name.len > max_host_pattern_len) return null;
+        var name_buf: [max_host_pattern_len]u8 = undefined;
+        const name = lowerHostInto(raw_name, &name_buf) catch return null;
+
+        for (self.bundles) |bundle| {
+            for (bundle.patterns) |pattern| {
+                if (pattern == .exact and std.mem.eql(u8, pattern.exact, name))
+                    return .{ .exact = pattern.exact };
+            }
+        }
+
+        var best: ?[]const u8 = null;
+        for (self.bundles) |bundle| {
+            for (bundle.patterns) |pattern| {
+                if (pattern != .wildcard_suffix) continue;
+                const suffix = pattern.wildcard_suffix;
+                if (!wildcardMatchesSuffix(name, suffix)) continue;
+                if (best == null or suffix.len > best.?.len) best = suffix;
+            }
+        }
+        if (best) |suffix| return .{ .wildcard = suffix };
+
+        return switch (self.options.unknown_sni_policy) {
+            .use_default => .default,
+            .fail_handshake => null,
+        };
+    }
+};
+
+const MatchClass = union(enum) {
+    exact: []const u8,
+    wildcard: []const u8,
+    default,
+};
+
+pub const ReloadableProvider = struct {
+    allocator: std.mem.Allocator,
+    mutex: SpinMutex = .{},
+    current: ?*Snapshot = null,
+    next_generation: u64 = 1,
+
+    pub fn init(allocator: std.mem.Allocator) ReloadableProvider {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn provider(self: *ReloadableProvider) credentials.CredentialProvider {
+        return .{ .ctx = self, .vtable = &provider_vtable };
+    }
+
+    pub fn deinit(self: *ReloadableProvider) void {
+        self.mutex.lock();
+        const retired = self.current;
+        self.current = null;
+        self.mutex.unlock();
+        if (retired) |snapshot| snapshot.release();
+    }
+
+    pub fn buildSnapshot(self: *ReloadableProvider, configs: []const CredentialBundleConfig, options: SnapshotOptions) BuildError!*Snapshot {
+        self.mutex.lock();
+        const generation = self.next_generation;
+        self.next_generation += 1;
+        self.mutex.unlock();
+        return Snapshot.build(self.allocator, configs, options, generation);
+    }
+
+    pub fn reload(self: *ReloadableProvider, configs: []const CredentialBundleConfig, options: SnapshotOptions) BuildError!void {
+        const replacement = try self.buildSnapshot(configs, options);
+        self.install(replacement);
+    }
+
+    pub fn install(self: *ReloadableProvider, replacement: *Snapshot) void {
+        self.mutex.lock();
+        const retired = self.current;
+        self.current = replacement;
+        self.mutex.unlock();
+        if (retired) |snapshot| snapshot.release();
+    }
+
+    fn acquireCurrent(self: *ReloadableProvider) ?*Snapshot {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const snapshot = self.current orelse return null;
+        snapshot.retain();
+        return snapshot;
+    }
+
+    const provider_vtable = credentials.CredentialProvider.VTable{ .select = select };
+
+    fn select(ctx: *anyopaque, selection: *const credentials.SelectionContext) credentials.SelectError!credentials.Progress(credentials.SelectedCredential) {
+        const self: *ReloadableProvider = @ptrCast(@alignCast(ctx));
+        const snapshot = self.acquireCurrent() orelse return error.NoCredentialAvailable;
+        errdefer snapshot.release();
+        const selected = try snapshot.select(self.allocator, selection);
+        return .{ .complete = selected };
+    }
+};
+
+const SpinMutex = struct {
+    state: std.atomic.Value(u8) = std.atomic.Value(u8).init(0),
+
+    fn lock(self: *SpinMutex) void {
+        while (self.state.cmpxchgStrong(0, 1, .acquire, .monotonic) != null) {
+            std.atomic.spinLoopHint();
+        }
+    }
+
+    fn unlock(self: *SpinMutex) void {
+        self.state.store(0, .release);
+    }
+};
+
+const SelectedHandle = struct {
+    snapshot: *Snapshot,
+    bundle_index: usize,
+    chosen_scheme: credentials.SignatureScheme,
+
+    const vtable = credentials.SelectedCredential.VTable{
+        .chain = chain,
+        .sign = sign,
+        .release = release,
+    };
+
+    fn chain(handle: *anyopaque) credentials.CertificateChain {
+        const self: *SelectedHandle = @ptrCast(@alignCast(handle));
+        return .{ .entries = self.snapshot.bundles[self.bundle_index].chain };
+    }
+
+    fn sign(handle: *anyopaque, scheme: credentials.SignatureScheme, input: []const u8, out: []u8) credentials.SignError!credentials.Progress(usize) {
+        const self: *SelectedHandle = @ptrCast(@alignCast(handle));
+        if (scheme != self.chosen_scheme) return error.InvalidCallbackBehavior;
+        const bundle = &self.snapshot.bundles[self.bundle_index];
+        return .{ .complete = try bundle.signer.sign(scheme, input, out) };
+    }
+
+    fn release(handle: *anyopaque) void {
+        const self: *SelectedHandle = @ptrCast(@alignCast(handle));
+        const snapshot = self.snapshot;
+        const allocator = snapshot.allocator;
+        allocator.destroy(self);
+        snapshot.release();
+    }
+};
+
+fn buildBundle(
+    allocator: std.mem.Allocator,
+    config: CredentialBundleConfig,
+    install_order: usize,
+    previous: []const CredentialBundle,
+) BuildError!CredentialBundle {
+    var signer = config.signer;
+    var signer_owned = true;
+    errdefer if (signer_owned) signer.release();
+
+    if (config.chain.len == 0) return error.EmptyChain;
+    if (config.chain.len > credentials.max_chain_entries) return error.TooManyChainEntries;
+    if (config.patterns.len == 0 or config.patterns.len > max_patterns_per_bundle) return error.EmptyHostPattern;
+
+    var chain = allocator.alloc([]const u8, config.chain.len) catch return error.OutOfMemory;
+    var copied_chain: usize = 0;
+    errdefer {
+        for (chain[0..copied_chain]) |entry| allocator.free(entry);
+        allocator.free(chain);
+    }
+    for (config.chain, 0..) |entry, i| {
+        if (entry.len == 0) return error.InvalidChain;
+        try validateCertificateDer(entry);
+        chain[i] = allocator.dupe(u8, entry) catch return error.OutOfMemory;
+        copied_chain += 1;
+    }
+
+    const leaf_kind = leafKeyKind(chain[0]) catch |err| switch (err) {
+        error.InvalidLeafKey => return error.InvalidLeafKey,
+        error.UnsupportedKeyType => return error.UnsupportedKeyType,
+    };
+    if (leaf_kind != config.key_kind) return error.KeySignerMismatch;
+
+    var patterns = allocator.alloc(HostPattern, config.patterns.len) catch return error.OutOfMemory;
+    var copied_patterns: usize = 0;
+    errdefer {
+        for (patterns[0..copied_patterns]) |pattern| freePattern(allocator, pattern);
+        allocator.free(patterns);
+    }
+    for (config.patterns, 0..) |raw, i| {
+        patterns[i] = try parseHostPattern(allocator, raw);
+        copied_patterns += 1;
+        if (hasDuplicatePattern(previous, patterns[i]) or hasDuplicatePatternIn(patterns[0..i], patterns[i]))
+            return error.DuplicateHostPattern;
+    }
+
+    const schemes = try copySupportedSchemes(allocator, config);
+    errdefer allocator.free(schemes);
+    if (schemes.len == 0) return error.NoSupportedSignatureScheme;
+    for (schemes) |scheme| {
+        if (!schemeLegalForKeyKind(config.key_kind, scheme)) return error.KeySignerMismatch;
+    }
+
+    switch (signer) {
+        .external => {},
+        .signing_key => |adapter| {
+            if (adapter.release != null and adapter.release_context == null) return error.InvalidOwnershipContract;
+        },
+        .identity => |*identity| if (identity.signatureScheme() != schemes[0] or !schemeLegalForKeyKind(config.key_kind, identity.signatureScheme()))
+            return error.KeySignerMismatch,
+    }
+
+    signer_owned = false;
+    return .{
+        .chain = chain,
+        .patterns = patterns,
+        .signer = signer,
+        .key_kind = config.key_kind,
+        .supported_schemes = schemes,
+        .install_order = install_order,
+        .is_default = config.is_default,
+    };
+}
+
+fn copySupportedSchemes(allocator: std.mem.Allocator, config: CredentialBundleConfig) BuildError![]credentials.SignatureScheme {
+    if (config.supported_schemes.len > 0) {
+        const out = allocator.dupe(credentials.SignatureScheme, config.supported_schemes) catch return error.OutOfMemory;
+        return out;
+    }
+    switch (config.signer) {
+        .identity => |*identity| {
+            const out = allocator.alloc(credentials.SignatureScheme, 1) catch return error.OutOfMemory;
+            out[0] = identity.signatureScheme();
+            return out;
+        },
+        .signing_key => |adapter| {
+            const scheme = providerToTlsScheme(adapter.key.scheme()) orelse return error.NoSupportedSignatureScheme;
+            const out = allocator.alloc(credentials.SignatureScheme, 1) catch return error.OutOfMemory;
+            out[0] = scheme;
+            return out;
+        },
+        .external => return error.NoSupportedSignatureScheme,
+    }
+}
+
+fn leafKeyKind(der: []const u8) error{ InvalidLeafKey, UnsupportedKeyType }!KeyKind {
+    const parsed = (std_crypto.Certificate{ .buffer = der, .index = 0 }).parse() catch return error.InvalidLeafKey;
+    return switch (parsed.pub_key_algo) {
+        .curveEd25519 => .ed25519,
+        .X9_62_id_ecPublicKey => |curve| if (curve == .X9_62_prime256v1) .ecdsa_p256 else error.UnsupportedKeyType,
+        else => error.UnsupportedKeyType,
+    };
+}
+
+fn validateCertificateDer(der: []const u8) BuildError!void {
+    if (!isCompleteDerSequence(der)) return error.InvalidChain;
+    _ = (std_crypto.Certificate{ .buffer = der, .index = 0 }).parse() catch return error.InvalidChain;
+}
+
+fn isCompleteDerSequence(der: []const u8) bool {
+    if (der.len < 2 or der[0] != 0x30) return false;
+    var len_len: usize = 1;
+    var payload_len: usize = der[1];
+    if ((payload_len & 0x80) != 0) {
+        len_len = payload_len & 0x7f;
+        if (len_len == 0 or len_len > @sizeOf(usize) or 2 + len_len > der.len) return false;
+        payload_len = 0;
+        for (der[2 .. 2 + len_len]) |byte| {
+            payload_len = std.math.mul(usize, payload_len, 256) catch return false;
+            payload_len = std.math.add(usize, payload_len, byte) catch return false;
+        }
+        if (payload_len < 128) return false;
+    }
+    const header_len = 1 + 1 + if ((der[1] & 0x80) != 0) len_len else 0;
+    return payload_len == der.len - header_len;
+}
+
+fn parseHostPattern(allocator: std.mem.Allocator, raw: []const u8) BuildError!HostPattern {
+    if (raw.len == 0) return error.EmptyHostPattern;
+    if (raw.len > max_host_pattern_len) return error.InvalidHostPattern;
+
+    if (std.mem.indexOfScalar(u8, raw, '*')) |star| {
+        if (star != 0 or raw.len < 3 or raw[1] != '.') return error.InvalidWildcardPattern;
+        if (std.mem.indexOfScalar(u8, raw[1..], '*') != null) return error.InvalidWildcardPattern;
+        const suffix_raw = raw[1..];
+        try validateDnsName(suffix_raw[1..], true);
+        const suffix = allocator.alloc(u8, suffix_raw.len) catch return error.OutOfMemory;
+        for (suffix_raw, 0..) |ch, i| suffix[i] = asciiLower(ch);
+        return .{ .wildcard_suffix = suffix };
+    }
+
+    try validateDnsName(raw, false);
+    const exact = allocator.alloc(u8, raw.len) catch return error.OutOfMemory;
+    for (raw, 0..) |ch, i| exact[i] = asciiLower(ch);
+    return .{ .exact = exact };
+}
+
+fn validateDnsName(name: []const u8, wildcard_suffix: bool) BuildError!void {
+    if (name.len == 0 or name.len > max_host_pattern_len) return error.InvalidHostPattern;
+    if (name[0] == '.' or name[name.len - 1] == '.') return if (wildcard_suffix) error.InvalidWildcardPattern else error.InvalidHostPattern;
+    var label_len: usize = 0;
+    var labels: usize = 0;
+    for (name) |ch| {
+        if (ch == '.') {
+            if (label_len == 0 or label_len > 63) return if (wildcard_suffix) error.InvalidWildcardPattern else error.InvalidHostPattern;
+            labels += 1;
+            label_len = 0;
+            continue;
+        }
+        if (!isDnsLabelByte(ch)) return if (wildcard_suffix) error.InvalidWildcardPattern else error.InvalidHostPattern;
+        label_len += 1;
+    }
+    if (label_len == 0 or label_len > 63) return if (wildcard_suffix) error.InvalidWildcardPattern else error.InvalidHostPattern;
+    labels += 1;
+    if (wildcard_suffix and labels < 2) return error.InvalidWildcardPattern;
+}
+
+fn isDnsLabelByte(ch: u8) bool {
+    return (ch >= 'A' and ch <= 'Z') or
+        (ch >= 'a' and ch <= 'z') or
+        (ch >= '0' and ch <= '9') or
+        ch == '-';
+}
+
+fn hasDuplicatePattern(previous: []const CredentialBundle, candidate: HostPattern) bool {
+    for (previous) |bundle| {
+        if (hasDuplicatePatternIn(bundle.patterns, candidate)) return true;
+    }
+    return false;
+}
+
+fn hasDuplicatePatternIn(patterns: []const HostPattern, candidate: HostPattern) bool {
+    for (patterns) |pattern| {
+        if (@as(std.meta.Tag(HostPattern), pattern) != @as(std.meta.Tag(HostPattern), candidate)) continue;
+        if (std.mem.eql(u8, pattern.text(), candidate.text())) return true;
+    }
+    return false;
+}
+
+fn freePattern(allocator: std.mem.Allocator, pattern: HostPattern) void {
+    switch (pattern) {
+        .exact => |value| allocator.free(value),
+        .wildcard_suffix => |value| allocator.free(value),
+    }
+}
+
+pub fn asciiLower(ch: u8) u8 {
+    return if (ch >= 'A' and ch <= 'Z') ch + ('a' - 'A') else ch;
+}
+
+pub fn asciiEqlIgnoreCase(a: []const u8, b: []const u8) bool {
+    if (a.len != b.len) return false;
+    for (a, b) |lhs, rhs| {
+        if (asciiLower(lhs) != asciiLower(rhs)) return false;
+    }
+    return true;
+}
+
+pub fn wildcardMatchesSuffix(server_name: []const u8, suffix: []const u8) bool {
+    if (suffix.len < 2 or suffix[0] != '.') return false;
+    if (server_name.len <= suffix.len) return false;
+    const suffix_start = server_name.len - suffix.len;
+    if (!asciiEqlIgnoreCase(server_name[suffix_start..], suffix)) return false;
+    const left_label = server_name[0..suffix_start];
+    return left_label.len > 0 and std.mem.indexOfScalar(u8, left_label, '.') == null;
+}
+
+fn lowerHostInto(raw: []const u8, out: *[max_host_pattern_len]u8) BuildError![]const u8 {
+    if (raw.len == 0 or raw.len > out.len) return error.InvalidHostPattern;
+    try validateDnsName(raw, false);
+    for (raw, 0..) |ch, i| out[i] = asciiLower(ch);
+    return out[0..raw.len];
+}
+
+fn chooseCompatibleScheme(bundle: *const CredentialBundle, offered: []const u16) ?credentials.SignatureScheme {
+    for (offered) |wire| {
+        const scheme = schemeFromWire(wire) orelse continue;
+        if (bundle.supportsScheme(scheme)) return scheme;
+    }
+    return null;
+}
+
+fn schemeFromWire(wire: u16) ?credentials.SignatureScheme {
+    return switch (wire) {
+        0x0807 => .ed25519,
+        0x0403 => .ecdsa_secp256r1_sha256,
+        else => null,
+    };
+}
+
+fn schemeLegalForKeyKind(kind: KeyKind, scheme: credentials.SignatureScheme) bool {
+    return switch (kind) {
+        .ed25519 => scheme == .ed25519,
+        .ecdsa_p256 => scheme == .ecdsa_secp256r1_sha256,
+    };
+}
+
+fn providerToTlsScheme(scheme: crypto_provider.SignatureScheme) ?credentials.SignatureScheme {
+    return switch (scheme) {
+        .ed25519 => .ed25519,
+        .ecdsa_secp256r1_sha256 => .ecdsa_secp256r1_sha256,
+        else => null,
+    };
+}
+
+fn tlsToProviderScheme(scheme: credentials.SignatureScheme) ?crypto_provider.SignatureScheme {
+    return switch (scheme) {
+        .ed25519 => .ed25519,
+        .ecdsa_secp256r1_sha256 => .ecdsa_secp256r1_sha256,
+        else => null,
+    };
+}
+
+const testing = std.testing;
+
+fn testSelection(name: ?[]const u8, schemes: []const u16) credentials.SelectionContext {
+    return .{
+        .role = .server,
+        .server_name = name,
+        .peer_signature_schemes = schemes,
+        .negotiated_version = 0x0304,
+        .cipher_suite = 0x1301,
+        .application_protocol = "h2",
+        .auth_policy = .{},
+    };
+}
+
+fn identityConfig(patterns: []const []const u8, default: bool) CredentialBundleConfig {
+    return .{
+        .chain = &.{credentials.testdata.certificate_der},
+        .patterns = patterns,
+        .signer = SignAdapter.fromIdentity(credentials.testdata.identity()),
+        .key_kind = .ed25519,
+        .is_default = default,
+    };
+}
+
+fn syncSelect(provider: credentials.CredentialProvider, selection: *const credentials.SelectionContext) !credentials.SelectedCredential {
+    return switch (try provider.selectCredential(selection)) {
+        .complete => |credential| credential,
+        .pending => error.TestUnexpectedPending,
+    };
+}
+
+fn syncSign(credential: credentials.SelectedCredential, input: []const u8, out: []u8) !usize {
+    return switch (try credential.sign(input, out)) {
+        .complete => |written| written,
+        .pending => error.TestUnexpectedPending,
+    };
+}
+
+test "wildcard matcher consumes exactly one label" {
+    try testing.expect(wildcardMatchesSuffix("a.example.test", ".example.test"));
+    try testing.expect(!wildcardMatchesSuffix("example.test", ".example.test"));
+    try testing.expect(!wildcardMatchesSuffix("a.b.example.test", ".example.test"));
+    try testing.expect(wildcardMatchesSuffix("A.Example.Test", ".example.test"));
+}
+
+test "snapshot rejects invalid wildcards and duplicate normalized patterns" {
+    const invalid = [_][]const u8{
+        "foo*.example.test",
+        "*foo.example.test",
+        "api.*.example.test",
+        "*.*.example.test",
+        "example.*",
+        "*",
+    };
+    for (invalid) |pattern| {
+        const config = identityConfig(&.{pattern}, true);
+        try testing.expectError(error.InvalidWildcardPattern, Snapshot.build(testing.allocator, &.{config}, .{}, 1));
+    }
+
+    const a = identityConfig(&.{"API.Example.Test"}, false);
+    const b = identityConfig(&.{"api.example.test"}, true);
+    try testing.expectError(error.DuplicateHostPattern, Snapshot.build(testing.allocator, &.{ a, b }, .{}, 1));
+}
+
+test "snapshot build rejects invalid bundles before publication" {
+    const valid = identityConfig(&.{"valid.example.test"}, true);
+
+    var empty_chain = valid;
+    empty_chain.chain = &.{};
+    try testing.expectError(error.EmptyChain, Snapshot.build(testing.allocator, &.{empty_chain}, .{}, 1));
+
+    var malformed_chain = valid;
+    malformed_chain.chain = &.{"not der"};
+    try testing.expectError(error.InvalidChain, Snapshot.build(testing.allocator, &.{malformed_chain}, .{}, 1));
+
+    const duplicate_default = identityConfig(&.{"other.example.test"}, true);
+    try testing.expectError(error.DuplicateDefaultBundle, Snapshot.build(testing.allocator, &.{ valid, duplicate_default }, .{}, 1));
+
+    var no_default = identityConfig(&.{"nodefault.example.test"}, false);
+    try testing.expectError(error.NoUsableDefaultBundle, Snapshot.build(testing.allocator, &.{no_default}, .{}, 1));
+
+    no_default.supported_schemes = &.{};
+    no_default.signer = SignAdapter.fromExternal(@ptrCast(@constCast(&noop_external_context)), noopExternalSign, noopExternalRelease);
+    try testing.expectError(error.NoSupportedSignatureScheme, Snapshot.build(testing.allocator, &.{no_default}, .{ .absent_sni_policy = .fail_handshake }, 1));
+}
+
+test "hostname precedence is exact then longest wildcard then default" {
+    var provider = ReloadableProvider.init(testing.allocator);
+    defer provider.deinit();
+    const configs = [_]CredentialBundleConfig{
+        identityConfig(&.{"*.example.test"}, false),
+        identityConfig(&.{"*.svc.example.test"}, false),
+        identityConfig(&.{"api.svc.example.test"}, false),
+        identityConfig(&.{"default.example.test"}, true),
+    };
+    try provider.reload(&configs, .{ .unknown_sni_policy = .use_default });
+
+    var exact = testSelection("API.Svc.Example.Test", &.{0x0807});
+    var selected = try syncSelect(provider.provider(), &exact);
+    defer selected.release();
+    try testing.expectEqual(@as(u64, 1), provider.current.?.generation);
+
+    var wildcard = testSelection("foo.svc.example.test", &.{0x0807});
+    const w = try syncSelect(provider.provider(), &wildcard);
+    w.release();
+
+    var defaulted = testSelection("unknown.example.net", &.{0x0807});
+    const d = try syncSelect(provider.provider(), &defaulted);
+    d.release();
+}
+
+test "unknown and absent SNI policies are distinct" {
+    var provider = ReloadableProvider.init(testing.allocator);
+    defer provider.deinit();
+    const config = identityConfig(&.{"default.example.test"}, true);
+    try provider.reload(&.{config}, .{ .absent_sni_policy = .use_default, .unknown_sni_policy = .fail_handshake });
+
+    var absent = testSelection(null, &.{0x0807});
+    const a = try syncSelect(provider.provider(), &absent);
+    a.release();
+
+    var unknown = testSelection("missing.example.test", &.{0x0807});
+    try testing.expectError(error.NoCredentialAvailable, provider.provider().selectCredential(&unknown));
+
+    var fail_absent_provider = ReloadableProvider.init(testing.allocator);
+    defer fail_absent_provider.deinit();
+    try fail_absent_provider.reload(&.{config}, .{ .absent_sni_policy = .fail_handshake, .unknown_sni_policy = .use_default });
+    try testing.expectError(error.NoCredentialAvailable, fail_absent_provider.provider().selectCredential(&absent));
+}
+
+test "signature compatibility follows peer order and exact class does not fall through" {
+    var provider = ReloadableProvider.init(testing.allocator);
+    defer provider.deinit();
+    var exact_bad = identityConfig(&.{"api.example.test"}, false);
+    exact_bad.supported_schemes = &.{.ecdsa_secp256r1_sha256};
+    const wildcard = identityConfig(&.{"*.example.test"}, true);
+    try testing.expectError(error.KeySignerMismatch, provider.reload(&.{ exact_bad, wildcard }, .{}));
+
+    var exact = identityConfig(&.{"api.example.test"}, false);
+    exact.supported_schemes = &.{.ed25519};
+    try provider.reload(&.{ exact, wildcard }, .{});
+
+    var selection = testSelection("api.example.test", &.{0x0403});
+    try testing.expectError(error.NoCompatibleSignatureAlgorithm, provider.provider().selectCredential(&selection));
+
+    selection.peer_signature_schemes = &.{ 0xffff, 0x0807 };
+    const selected = try syncSelect(provider.provider(), &selection);
+    defer selected.release();
+    try testing.expectEqual(credentials.SignatureScheme.ed25519, selected.scheme);
+}
+
+test "snapshot owns chain and pattern copies after caller mutation" {
+    var provider = ReloadableProvider.init(testing.allocator);
+    defer provider.deinit();
+
+    const cert_copy = try testing.allocator.dupe(u8, credentials.testdata.certificate_der);
+    defer testing.allocator.free(cert_copy);
+    const pattern = try testing.allocator.dupe(u8, "MUTABLE.Example.Test");
+    defer testing.allocator.free(pattern);
+
+    var chain_entries = [_][]const u8{cert_copy};
+    const config = CredentialBundleConfig{
+        .chain = chain_entries[0..],
+        .patterns = &.{pattern},
+        .signer = SignAdapter.fromIdentity(credentials.testdata.identity()),
+        .key_kind = .ed25519,
+        .is_default = true,
+    };
+    try provider.reload(&.{config}, .{});
+    @memset(cert_copy, 0);
+    @memset(pattern, 'x');
+
+    var selection = testSelection("mutable.example.test", &.{0x0807});
+    const selected = try syncSelect(provider.provider(), &selection);
+    defer selected.release();
+    try testing.expectEqualSlices(u8, credentials.testdata.certificate_der, selected.certificateChain().leaf().?);
+}
+
+test "reload keeps selected generation alive until handle release" {
+    var first_deinit: usize = 0;
+    var second_deinit: usize = 0;
+    var provider = ReloadableProvider.init(testing.allocator);
+    defer provider.deinit();
+
+    var first = try provider.buildSnapshot(&.{identityConfig(&.{"first.example.test"}, true)}, .{});
+    first.deinit_count = &first_deinit;
+    provider.install(first);
+
+    var selection = testSelection("first.example.test", &.{0x0807});
+    const selected = try syncSelect(provider.provider(), &selection);
+    try testing.expectEqual(@as(usize, 0), first_deinit);
+
+    var second = try provider.buildSnapshot(&.{identityConfig(&.{"second.example.test"}, true)}, .{});
+    second.deinit_count = &second_deinit;
+    provider.install(second);
+    try testing.expectEqual(@as(usize, 0), first_deinit);
+
+    var old_sig: [128]u8 = undefined;
+    _ = try syncSign(selected, "still generation 1", &old_sig);
+    selected.release();
+    try testing.expectEqual(@as(usize, 1), first_deinit);
+
+    var new_selection = testSelection("second.example.test", &.{0x0807});
+    const new_selected = try syncSelect(provider.provider(), &new_selection);
+    new_selected.release();
+    try testing.expectEqual(@as(usize, 0), second_deinit);
+}
+
+test "failed reload leaves current snapshot usable" {
+    var provider = ReloadableProvider.init(testing.allocator);
+    defer provider.deinit();
+    const good = identityConfig(&.{"ok.example.test"}, true);
+    try provider.reload(&.{good}, .{});
+
+    var bad = identityConfig(&.{"bad.example.test"}, false);
+    bad.chain = &.{};
+    try testing.expectError(error.EmptyChain, provider.reload(&.{bad}, .{}));
+
+    var selection = testSelection("ok.example.test", &.{0x0807});
+    const selected = try syncSelect(provider.provider(), &selection);
+    selected.release();
+}
+
+test "allocation failure during snapshot build does not leak" {
+    try testing.checkAllAllocationFailures(testing.allocator, struct {
+        fn run(allocator: std.mem.Allocator) !void {
+            var provider = ReloadableProvider.init(allocator);
+            defer provider.deinit();
+            const config = identityConfig(&.{"alloc.example.test"}, true);
+            try provider.reload(&.{config}, .{});
+        }
+    }.run, .{});
+}
+
+const CountingExternal = struct {
+    release_count: usize = 0,
+
+    fn sign(_: *anyopaque, _: credentials.SignatureScheme, _: []const u8, _: []u8) credentials.SignError!usize {
+        return error.SigningProviderFailure;
+    }
+
+    fn release(ctx: *anyopaque) void {
+        const self: *CountingExternal = @ptrCast(@alignCast(ctx));
+        self.release_count += 1;
+    }
+};
+
+var noop_external_context: u8 = 0;
+
+fn noopExternalSign(_: *anyopaque, _: credentials.SignatureScheme, _: []const u8, _: []u8) credentials.SignError!usize {
+    return error.SigningProviderFailure;
+}
+
+fn noopExternalRelease(_: *anyopaque) void {}
+
+test "external signer owner release callback runs exactly once" {
+    var ext = CountingExternal{};
+    {
+        var provider = ReloadableProvider.init(testing.allocator);
+        defer provider.deinit();
+        const config = CredentialBundleConfig{
+            .chain = &.{credentials.testdata.certificate_der},
+            .patterns = &.{"external.example.test"},
+            .signer = SignAdapter.fromExternal(&ext, CountingExternal.sign, CountingExternal.release),
+            .key_kind = .ed25519,
+            .supported_schemes = &.{.ed25519},
+            .is_default = true,
+        };
+        try provider.reload(&.{config}, .{});
+        try testing.expectEqual(@as(usize, 0), ext.release_count);
+    }
+    try testing.expectEqual(@as(usize, 1), ext.release_count);
+}
+
+test "external signer is released when unpublished snapshot validation fails" {
+    var ext = CountingExternal{};
+    const bad = CredentialBundleConfig{
+        .chain = &.{credentials.testdata.certificate_der},
+        .patterns = &.{"bad*.example.test"},
+        .signer = SignAdapter.fromExternal(&ext, CountingExternal.sign, CountingExternal.release),
+        .key_kind = .ed25519,
+        .supported_schemes = &.{.ed25519},
+        .is_default = true,
+    };
+    try testing.expectError(error.InvalidWildcardPattern, Snapshot.build(testing.allocator, &.{bad}, .{}, 1));
+    try testing.expectEqual(@as(usize, 1), ext.release_count);
+}

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -17,6 +17,7 @@
 //! rest of the native transport stack — no ambient RNG.
 
 const std = @import("std");
+const dns_name = @import("dns_name.zig");
 const events = @import("events.zig");
 const credentials = @import("credentials.zig");
 const tls_handshake_codec = @import("handshake.zig");
@@ -296,6 +297,10 @@ pub const Tls13Backend = struct {
     /// Stable, engine-owned signature output buffer. An async signer keeps a
     /// pointer to this across the suspend; the engine reads it on completion.
     pending_signature: [max_signature_len]u8 = undefined,
+    pending_client_session_id: [32]u8 = undefined,
+    pending_client_session_id_len: usize = 0,
+    pending_client_share: [X25519.public_length]u8 = undefined,
+    pending_client_hello_ready: bool = false,
 
     const Slice = struct { start: usize, len: usize };
     const PendingStage = enum { server_select, server_sign, client_select, client_sign, peer_verify };
@@ -497,6 +502,10 @@ pub const Tls13Backend = struct {
         // exactly once before tearing down the rest.
         self.cancelPendingAuth();
         crypto.secureZero(u8, &self.pending_signature);
+        crypto.secureZero(u8, &self.pending_client_session_id);
+        self.pending_client_session_id_len = 0;
+        crypto.secureZero(u8, &self.pending_client_share);
+        self.pending_client_hello_ready = false;
         if (self.schedule) |*schedule| schedule.wipe();
         self.schedule = null;
         crypto.secureZero(u8, &self.expected_client_verify);
@@ -1487,6 +1496,7 @@ pub const Tls13Backend = struct {
                         // RFC 6066: a given name_type must appear at most once.
                         if (self.server_name_present) return error.IllegalParameter;
                         if (name.len == 0 or name.len > self.server_name.len) return error.IllegalParameter;
+                        dns_name.validateHostName(name) catch return error.IllegalParameter;
                         @memcpy(self.server_name[0..name.len], name);
                         self.server_name_len = name.len;
                         self.server_name_present = true;
@@ -1528,6 +1538,69 @@ pub const Tls13Backend = struct {
         if (self.peer_sig_scheme_count == 0) return error.MalformedHandshake;
         const client_share = peer_share orelse return error.MalformedHandshake;
 
+        if (!alpn_match) {
+            // Report what the client offered instead of silently downgrading;
+            // the driver fails with AlpnMismatch before any flight is sent.
+            try sink.emitAlpn(first_alpn);
+            self.core.handshake_lifecycle = .failed;
+            return error.AlpnMismatch;
+        }
+        if (self.profile.extensionType() != null) {
+            const extension = transport_params orelse return error.MissingTransportExtension;
+            try self.capturePeerTransportExtension(extension);
+        }
+
+        try self.beginServerSelection(session_id, client_share, sink);
+    }
+
+    fn beginServerSelection(
+        self: *Tls13Backend,
+        session_id: []const u8,
+        client_share: [X25519.public_length]u8,
+        sink: *EventSink,
+    ) HandshakeError!void {
+        if (session_id.len > self.pending_client_session_id.len) return error.IllegalParameter;
+        var fixed_provider: credentials.FixedCredentialProvider = undefined;
+        var using_fixed = false;
+        const provider = if (self.external_provider) |p| p else blk: {
+            if (!self.identity_present) return self.failCredential(.no_credential_available);
+            fixed_provider = credentials.FixedCredentialProvider.init(self.identity);
+            using_fixed = true;
+            break :blk fixed_provider.provider();
+        };
+        // Wipe the fixed key material (stack copy and stored identity) on the
+        // way out, whatever the outcome.
+        defer if (using_fixed) {
+            fixed_provider.deinit();
+            self.wipeIdentity();
+        };
+
+        var selection = self.serverSelectionContext();
+        // Selection may complete synchronously or return a pending operation
+        // (e.g. an async SNI lookup); park the latter and resume later.
+        switch (provider.selectCredential(&selection) catch |err|
+            return self.failCredential(credentials.classifySelectError(err))) {
+            .complete => |credential| return self.emitServerHelloAndAuthFlight(session_id, client_share, credential, sink),
+            .pending => |op| {
+                @memcpy(self.pending_client_session_id[0..session_id.len], session_id);
+                self.pending_client_session_id_len = session_id.len;
+                self.pending_client_share = client_share;
+                self.pending_client_hello_ready = true;
+                return self.parkAuth(op, .server_select);
+            },
+        }
+    }
+
+    fn emitServerHelloAndAuthFlight(
+        self: *Tls13Backend,
+        session_id: []const u8,
+        client_share: [X25519.public_length]u8,
+        credential: credentials.SelectedCredential,
+        sink: *EventSink,
+    ) HandshakeError!void {
+        var owned = true;
+        errdefer if (owned) credential.release();
+
         // Validate the peer share before emitting anything: X25519.scalarmult
         // rejects low-order/identity public keys (all-zero shared secret)
         // rather than deriving a predictable secret.
@@ -1541,18 +1614,6 @@ pub const Tls13Backend = struct {
         defer crypto.secureZero(u8, &shared);
         crypto.secureZero(u8, &key_pair.secret_key);
         self.wipeEphemeral();
-
-        if (!alpn_match) {
-            // Report what the client offered instead of silently downgrading;
-            // the driver fails with AlpnMismatch before any flight is sent.
-            try sink.emitAlpn(first_alpn);
-            self.core.handshake_lifecycle = .failed;
-            return error.AlpnMismatch;
-        }
-        if (self.profile.extensionType() != null) {
-            const extension = transport_params orelse return error.MissingTransportExtension;
-            try self.capturePeerTransportExtension(extension);
-        }
 
         // ServerHello (Initial level).
         var hello_buf: [256]u8 = undefined;
@@ -1585,38 +1646,8 @@ pub const Tls13Backend = struct {
         try self.emitHandshakeSecrets(sink);
         try sink.emitDiscardKeys(.initial);
 
-        try self.sendServerFlight(sink);
-    }
-
-    /// EncryptedExtensions + Certificate + CertificateVerify + Finished at the
-    /// Handshake level, followed by the 1-RTT secrets.
-    fn sendServerFlight(self: *Tls13Backend, sink: *EventSink) HandshakeError!void {
-        // Resolve the credential provider — an external one, or the fixed
-        // identity wrapped in the identical production contract — and select a
-        // credential for the negotiated parameters. There is one path.
-        var fixed_provider: credentials.FixedCredentialProvider = undefined;
-        var using_fixed = false;
-        const provider = if (self.external_provider) |p| p else blk: {
-            if (!self.identity_present) return self.failCredential(.no_credential_available);
-            fixed_provider = credentials.FixedCredentialProvider.init(self.identity);
-            using_fixed = true;
-            break :blk fixed_provider.provider();
-        };
-        // Wipe the fixed key material (stack copy and stored identity) on the
-        // way out, whatever the outcome.
-        defer if (using_fixed) {
-            fixed_provider.deinit();
-            self.wipeIdentity();
-        };
-
-        var selection = self.serverSelectionContext();
-        // Selection may complete synchronously or return a pending operation
-        // (e.g. an async SNI lookup); park the latter and resume later.
-        switch (provider.selectCredential(&selection) catch |err|
-            return self.failCredential(credentials.classifySelectError(err))) {
-            .complete => |credential| return self.emitServerAuthFlight(credential, sink),
-            .pending => |op| return self.parkAuth(op, .server_select),
-        }
+        owned = false;
+        try self.emitServerAuthFlight(credential, sink);
     }
 
     /// Validate the selected credential, emit EncryptedExtensions+Certificate,
@@ -1877,7 +1908,17 @@ pub const Tls13Backend = struct {
     fn dispatchResume(self: *Tls13Backend, stage: PendingStage, completion: credentials.Completion, sink: *EventSink) HandshakeError!void {
         switch (stage) {
             .server_select => switch (completion) {
-                .credential => |c| return self.emitServerAuthFlight(c, sink),
+                .credential => |c| {
+                    if (!self.pending_client_hello_ready) {
+                        c.release();
+                        return error.InvalidHandshakeState;
+                    }
+                    const session_id = self.pending_client_session_id[0..self.pending_client_session_id_len];
+                    const client_share = self.pending_client_share;
+                    self.pending_client_hello_ready = false;
+                    self.pending_client_session_id_len = 0;
+                    return self.emitServerHelloAndAuthFlight(session_id, client_share, c, sink);
+                },
                 // Unlike the client, the server MUST authenticate itself in
                 // this profile: "no credential" from an async selector is the
                 // same normal-but-unusable outcome the synchronous path reports

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -347,15 +347,14 @@ pub const Tls13Backend = struct {
 
     fn applyClientOptions(self: *Tls13Backend, options: ClientOptions) void {
         if (options.server_name) |name| {
-            // A name too long for the bounded buffer is a caller error. Record
-            // the overflow and reject at `start` rather than truncating it to a
-            // different host (see `server_name_overflow`).
-            if (name.len == 0 or name.len > self.server_name.len) {
-                self.server_name_overflow = true;
-            } else {
+            // Invalid configured SNI is a caller error. Record it and reject at
+            // `start` rather than emitting malformed or truncated host_name.
+            if (dns_name.validateHostName(name)) |_| {
                 @memcpy(self.server_name[0..name.len], name);
                 self.server_name_len = name.len;
                 self.server_name_present = true;
+            } else |_| {
+                self.server_name_overflow = true;
             }
         }
     }

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -322,7 +322,13 @@ pub const Tls13Backend = struct {
     /// Allocation-free. The returned backend owns its copied entropy until
     /// `deinit`, which securely clears all private material.
     pub fn initClient(entropy: Entropy, trust: Trust, profile: TransportProfile) Tls13Backend {
-        return .{
+        return initClientWithOptions(entropy, trust, profile, .{});
+    }
+
+    /// Client construction with the built-in fixed trust policy plus explicit
+    /// client options such as intended SNI.
+    pub fn initClientWithOptions(entropy: Entropy, trust: Trust, profile: TransportProfile, options: ClientOptions) Tls13Backend {
+        var self: Tls13Backend = .{
             .role = .client,
             .profile = profile,
             .entropy = entropy,
@@ -330,6 +336,23 @@ pub const Tls13Backend = struct {
             .auth_policy = policyFromTrust(trust),
             .core = tls_handshake_codec.Core.init(.client),
         };
+        self.applyClientOptions(options);
+        return self;
+    }
+
+    fn applyClientOptions(self: *Tls13Backend, options: ClientOptions) void {
+        if (options.server_name) |name| {
+            // A name too long for the bounded buffer is a caller error. Record
+            // the overflow and reject at `start` rather than truncating it to a
+            // different host (see `server_name_overflow`).
+            if (name.len == 0 or name.len > self.server_name.len) {
+                self.server_name_overflow = true;
+            } else {
+                @memcpy(self.server_name[0..name.len], name);
+                self.server_name_len = name.len;
+                self.server_name_present = true;
+            }
+        }
     }
 
     /// Allocation-free. The returned backend owns its copy of `identity` and
@@ -374,18 +397,7 @@ pub const Tls13Backend = struct {
             .auth_policy = options.policy,
             .core = tls_handshake_codec.Core.init(.client),
         };
-        if (options.server_name) |name| {
-            // A name too long for the bounded buffer is a caller error. Record
-            // the overflow and reject at `start` rather than truncating it to a
-            // different host (see `server_name_overflow`).
-            if (name.len == 0 or name.len > self.server_name.len) {
-                self.server_name_overflow = true;
-            } else {
-                @memcpy(self.server_name[0..name.len], name);
-                self.server_name_len = name.len;
-                self.server_name_present = true;
-            }
-        }
+        self.applyClientOptions(options);
         return self;
     }
 

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -937,7 +937,41 @@ test "record engine pins selected SNI generation across provider reload" {
 
     const chain_one = [_][]const u8{tls_backend.testdata.certificate_der};
     const chain_two = [_][]const u8{ tls_backend.testdata.certificate_der, tls_backend.testdata.certificate_der };
-    try provider.reload(&.{sniIdentityConfig(&.{"pin.example.test"}, chain_one[0..], true)}, .{});
+    var first_deinit = std.atomic.Value(usize).init(0);
+    const BlockingSigner = struct {
+        entered: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+        release_sign: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+        release_count: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+
+        fn sign(ctx: *anyopaque, scheme: credentials.SignatureScheme, input: []const u8, out: []u8) credentials.SignError!usize {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            if (scheme != .ed25519) return error.InvalidCallbackBehavior;
+            self.entered.store(true, .release);
+            while (!self.release_sign.load(.acquire)) {
+                std.atomic.spinLoopHint();
+            }
+            var identity = fixtureIdentity();
+            defer std.crypto.secureZero(u8, std.mem.asBytes(&identity.key));
+            return identity.sign(input, out);
+        }
+
+        fn release(ctx: *anyopaque) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            _ = self.release_count.fetchAdd(1, .monotonic);
+        }
+    };
+    var blocking = BlockingSigner{};
+    const blocking_config = sni_provider.CredentialBundleConfig{
+        .chain = chain_one[0..],
+        .patterns = &.{"pin.example.test"},
+        .signer = sni_provider.SignAdapter.fromExternal(&blocking, BlockingSigner.sign, BlockingSigner.release),
+        .key_kind = .ed25519,
+        .supported_schemes = &.{.ed25519},
+        .is_default = true,
+    };
+    const first = try sni_provider.Snapshot.build(std.testing.allocator, &.{blocking_config}, .{}, 1);
+    first.deinit_count = &first_deinit;
+    try provider.install(first);
 
     var verifier = credentials.MockVerifier.init(.accepted);
     var client = tls_backend.Tls13Backend.initClientWithVerifier(
@@ -958,9 +992,54 @@ test "record engine pins selected SNI generation across provider reload" {
     var client_hello_buf: [1024]u8 = undefined;
     const client_hello = firstInitialCrypto(&client_sink, &client_hello_buf);
     try server.backend().start(.server, {}, &server_sink);
-    try server.backend().receive(.initial, client_hello, &server_sink);
+
+    const ServerReceiveThread = struct {
+        server_backend: *tls_backend.Tls13Backend,
+        hello: []const u8,
+        sink: *DirectSink,
+        result: ?anyerror = null,
+
+        fn run(self: *@This()) void {
+            self.server_backend.backend().receive(.initial, self.hello, self.sink) catch |err| {
+                self.result = err;
+            };
+        }
+    };
+    var receive_ctx = ServerReceiveThread{
+        .server_backend = &server,
+        .hello = client_hello,
+        .sink = &server_sink,
+    };
+    var thread = try std.Thread.spawn(.{}, ServerReceiveThread.run, .{&receive_ctx});
+    var thread_joined = false;
+    defer {
+        if (!thread_joined) {
+            blocking.release_sign.store(true, .release);
+            thread.join();
+        }
+    }
+
+    var spins: usize = 0;
+    while (!blocking.entered.load(.acquire) and spins < 1_000_000) : (spins += 1) {
+        std.Thread.yield() catch {};
+    }
+    if (!blocking.entered.load(.acquire)) {
+        blocking.release_sign.store(true, .release);
+        thread.join();
+        thread_joined = true;
+        if (receive_ctx.result) |err| return err;
+        return error.TestTimeout;
+    }
 
     try provider.reload(&.{sniIdentityConfig(&.{"pin.example.test"}, chain_two[0..], true)}, .{});
+    try std.testing.expectEqual(@as(usize, 0), first_deinit.load(.monotonic));
+
+    blocking.release_sign.store(true, .release);
+    thread.join();
+    thread_joined = true;
+    if (receive_ctx.result) |err| return err;
+    try std.testing.expectEqual(@as(usize, 1), first_deinit.load(.monotonic));
+    try std.testing.expectEqual(@as(usize, 1), blocking.release_count.load(.monotonic));
 
     var server_hello_buf: [512]u8 = undefined;
     const server_hello = firstInitialCrypto(&server_sink, &server_hello_buf);
@@ -970,6 +1049,11 @@ test "record engine pins selected SNI generation across provider reload" {
     try client.backend().receive(.initial, server_hello, &client_sink);
     try client.backend().receive(.handshake, server_flight, &client_sink);
     try std.testing.expectEqual(@as(usize, 1), verifier.last_chain_len);
+
+    var client_flight_buf: [8192]u8 = undefined;
+    const client_flight = collectHandshakeCrypto(&client_sink, &client_flight_buf);
+    try deliverClientFlightToServer(&server, &server_sink, client_flight, false);
+    try std.testing.expectEqual(tls_core.handshake.HandshakeLifecycle.complete, server.core.handshake_lifecycle);
 
     var later_verifier = credentials.MockVerifier.init(.accepted);
     const h = try SocketHarness.create(.{
@@ -2462,7 +2546,21 @@ test "a malformed async client selection completion is rejected as invalid callb
 
 test "an invalid configured server name is rejected at start rather than emitted" {
     var verifier = credentials.MockVerifier.init(.accepted);
-    for ([_][]const u8{ "", &([_]u8{'a'} ** 257) }) |name| {
+    const too_long = [_]u8{'a'} ** 254;
+    const too_long_label = [_]u8{'b'} ** 64;
+    const invalid_names = [_][]const u8{
+        "",
+        &too_long,
+        "bad..example",
+        "bad host.example",
+        "bad\x00host.example",
+        "-bad.example",
+        "bad-.example",
+        "bad.-example",
+        "bad.example-",
+        &too_long_label,
+    };
+    for (invalid_names) |name| {
         var client = tls_backend.Tls13Backend.initClientWithVerifier(
             clientEntropy(),
             verifier.verifier(),
@@ -2484,8 +2582,8 @@ test "a ClientHello combining maximum ALPN, SNI, and transport extension seriali
     // #334 review: with maximum-length ALPN (255, the largest a u8 length
     // prefix allows), SNI (256, max_server_name_len), and a maximum transport
     // extension (tls_backend.max_transport_extension_len = 512), the encoded
-    // ClientHello is roughly 1.15 KiB. The buffer that serializes it must be
-    // sized for this combination, not just the common case.
+    // ClientHello is roughly 1.15 KiB. This bypasses public client options to
+    // exercise the serializer's raw bounded buffer, not semantic DNS policy.
     const max_alpn = [_]u8{'a'} ** 255;
     const max_sni = [_]u8{'s'} ** 256;
     var max_transport_ext = [_]u8{0xab} ** tls_backend.max_transport_extension_len;

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -17,6 +17,7 @@ const tls_backend = tls_core.tls13_backend;
 const record_codec = tls_core.record_codec;
 const events = tls_core.events;
 const credentials = tls_core.credentials;
+const sni_provider = tls_core.sni_provider;
 
 fn clientEntropy() tls_backend.Entropy {
     return .{ .hello_random = [_]u8{0xc1} ** 32, .key_share_seed = [_]u8{0x11} ** 32 };
@@ -869,6 +870,110 @@ test "record stream completes a real TLS 1.3 handshake over a nonblocking socket
         }.done);
         try std.testing.expectError(error.EndOfStream, h.server.stream().read(&buf));
     }
+}
+
+fn sniIdentityConfig(patterns: []const []const u8, chain: []const []const u8, default: bool) sni_provider.CredentialBundleConfig {
+    return .{
+        .chain = chain,
+        .patterns = patterns,
+        .signer = sni_provider.SignAdapter.fromIdentity(fixtureIdentity()),
+        .key_kind = .ed25519,
+        .is_default = default,
+    };
+}
+
+test "record stream uses reloadable SNI provider for exact wildcard and default classes" {
+    var provider = sni_provider.ReloadableProvider.init(std.testing.allocator);
+    defer provider.deinit();
+
+    const chain_one = [_][]const u8{tls_backend.testdata.certificate_der};
+    const chain_two = [_][]const u8{ tls_backend.testdata.certificate_der, tls_backend.testdata.certificate_der };
+    const chain_three = [_][]const u8{ tls_backend.testdata.certificate_der, tls_backend.testdata.certificate_der, tls_backend.testdata.certificate_der };
+    const configs = [_]sni_provider.CredentialBundleConfig{
+        sniIdentityConfig(&.{"api.example.test"}, chain_one[0..], false),
+        sniIdentityConfig(&.{"*.example.test"}, chain_two[0..], false),
+        sniIdentityConfig(&.{"default.example.test"}, chain_three[0..], true),
+    };
+    try provider.reload(&configs, .{ .unknown_sni_policy = .use_default });
+
+    {
+        var verifier = credentials.MockVerifier.init(.accepted);
+        const h = try SocketHarness.create(.{
+            .server_provider = provider.provider(),
+            .client_verifier = verifier.verifier(),
+            .client_options = .{ .server_name = "API.Example.Test", .policy = .{ .require_peer_authentication = true } },
+        });
+        defer h.destroy();
+        try h.driveUntil(SocketHarness.bothComplete);
+        try std.testing.expectEqual(@as(usize, 1), verifier.last_chain_len);
+    }
+    {
+        var verifier = credentials.MockVerifier.init(.accepted);
+        const h = try SocketHarness.create(.{
+            .server_provider = provider.provider(),
+            .client_verifier = verifier.verifier(),
+            .client_options = .{ .server_name = "www.example.test", .policy = .{ .require_peer_authentication = true } },
+        });
+        defer h.destroy();
+        try h.driveUntil(SocketHarness.bothComplete);
+        try std.testing.expectEqual(@as(usize, 2), verifier.last_chain_len);
+    }
+    {
+        var verifier = credentials.MockVerifier.init(.accepted);
+        const h = try SocketHarness.create(.{
+            .server_provider = provider.provider(),
+            .client_verifier = verifier.verifier(),
+            .client_options = .{ .policy = .{ .require_peer_authentication = true } },
+        });
+        defer h.destroy();
+        try h.driveUntil(SocketHarness.bothComplete);
+        try std.testing.expectEqual(@as(usize, 3), verifier.last_chain_len);
+    }
+}
+
+test "record stream fails unknown SNI before application data is possible" {
+    var provider = sni_provider.ReloadableProvider.init(std.testing.allocator);
+    defer provider.deinit();
+
+    const chain = [_][]const u8{tls_backend.testdata.certificate_der};
+    const config = sniIdentityConfig(&.{"known.example.test"}, chain[0..], true);
+    try provider.reload(&.{config}, .{ .unknown_sni_policy = .fail_handshake });
+
+    var verifier = credentials.MockVerifier.init(.accepted);
+    const h = try SocketHarness.create(.{
+        .server_provider = provider.provider(),
+        .client_verifier = verifier.verifier(),
+        .client_options = .{ .server_name = "missing.example.test", .policy = .{ .require_peer_authentication = true } },
+    });
+    defer h.destroy();
+
+    try std.testing.expectError(error.NoApplicableCredential, h.driveUntil(SocketHarness.bothComplete));
+    try std.testing.expect(!h.client.bridge.handshake_complete);
+    try std.testing.expect(!h.client.readiness().can_write_plaintext);
+    try std.testing.expectEqual(tls_backend.CredentialFailure.no_credential_available, h.server_engine.credentialFailure().?);
+    try std.testing.expectEqual(@as(usize, 0), verifier.verify_count);
+}
+
+test "record stream SNI provider fails exact incompatible signature without wildcard fallback" {
+    var provider = sni_provider.ReloadableProvider.init(std.testing.allocator);
+    defer provider.deinit();
+    const chain = [_][]const u8{tls_backend.testdata.certificate_der};
+    const configs = [_]sni_provider.CredentialBundleConfig{
+        sniIdentityConfig(&.{"api.example.test"}, chain[0..], false),
+        sniIdentityConfig(&.{"*.example.test"}, chain[0..], true),
+    };
+    try provider.reload(&configs, .{});
+
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), provider.provider(), .{ .record = .{ .alpn = "h2" } });
+    defer server.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{ .sni = "api.example.test", .sig_schemes = &.{0x0403} });
+    try std.testing.expectError(error.NoApplicableCredential, server.backend().receive(.initial, hello, &sink));
+    try std.testing.expectEqual(tls_backend.CredentialFailure.no_compatible_signature_algorithm, server.credentialFailure().?);
 }
 
 test "record stream handshake fails closed when a ClientHello is corrupted in flight" {

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -931,6 +931,57 @@ test "record stream uses reloadable SNI provider for exact wildcard and default 
     }
 }
 
+test "record engine pins selected SNI generation across provider reload" {
+    var provider = sni_provider.ReloadableProvider.init(std.testing.allocator);
+    defer provider.deinit();
+
+    const chain_one = [_][]const u8{tls_backend.testdata.certificate_der};
+    const chain_two = [_][]const u8{ tls_backend.testdata.certificate_der, tls_backend.testdata.certificate_der };
+    try provider.reload(&.{sniIdentityConfig(&.{"pin.example.test"}, chain_one[0..], true)}, .{});
+
+    var verifier = credentials.MockVerifier.init(.accepted);
+    var client = tls_backend.Tls13Backend.initClientWithVerifier(
+        clientEntropy(),
+        verifier.verifier(),
+        .{ .record = .{ .alpn = "h2" } },
+        .{ .server_name = "pin.example.test", .policy = .{ .require_peer_authentication = true } },
+    );
+    defer client.deinit();
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), provider.provider(), .{ .record = .{ .alpn = "h2" } });
+    defer server.deinit();
+    var client_sink = DirectSink{};
+    defer client_sink.deinit();
+    var server_sink = DirectSink{};
+    defer server_sink.deinit();
+
+    try client.backend().start(.client, {}, &client_sink);
+    var client_hello_buf: [1024]u8 = undefined;
+    const client_hello = firstInitialCrypto(&client_sink, &client_hello_buf);
+    try server.backend().start(.server, {}, &server_sink);
+    try server.backend().receive(.initial, client_hello, &server_sink);
+
+    try provider.reload(&.{sniIdentityConfig(&.{"pin.example.test"}, chain_two[0..], true)}, .{});
+
+    var server_hello_buf: [512]u8 = undefined;
+    const server_hello = firstInitialCrypto(&server_sink, &server_hello_buf);
+    var server_flight_buf: [8192]u8 = undefined;
+    const server_flight = collectHandshakeCrypto(&server_sink, &server_flight_buf);
+    client_sink.reset();
+    try client.backend().receive(.initial, server_hello, &client_sink);
+    try client.backend().receive(.handshake, server_flight, &client_sink);
+    try std.testing.expectEqual(@as(usize, 1), verifier.last_chain_len);
+
+    var later_verifier = credentials.MockVerifier.init(.accepted);
+    const h = try SocketHarness.create(.{
+        .server_provider = provider.provider(),
+        .client_verifier = later_verifier.verifier(),
+        .client_options = .{ .server_name = "pin.example.test", .policy = .{ .require_peer_authentication = true } },
+    });
+    defer h.destroy();
+    try h.driveUntil(SocketHarness.bothComplete);
+    try std.testing.expectEqual(@as(usize, 2), later_verifier.last_chain_len);
+}
+
 test "record stream fails unknown SNI before application data is possible" {
     var provider = sni_provider.ReloadableProvider.init(std.testing.allocator);
     defer provider.deinit();
@@ -954,6 +1005,26 @@ test "record stream fails unknown SNI before application data is possible" {
     try std.testing.expectEqual(@as(usize, 0), verifier.verify_count);
 }
 
+test "unknown SNI fails before emitting ServerHello" {
+    var provider = sni_provider.ReloadableProvider.init(std.testing.allocator);
+    defer provider.deinit();
+
+    const chain = [_][]const u8{tls_backend.testdata.certificate_der};
+    const config = sniIdentityConfig(&.{"known.example.test"}, chain[0..], true);
+    try provider.reload(&.{config}, .{ .unknown_sni_policy = .fail_handshake });
+
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), provider.provider(), .{ .record = .{ .alpn = "h2" } });
+    defer server.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{ .sni = "missing.example.test" });
+    try std.testing.expectError(error.NoApplicableCredential, server.backend().receive(.initial, hello, &sink));
+    try std.testing.expectEqual(@as(usize, 0), countCryptoEvents(&sink, .initial));
+}
+
 test "record stream SNI provider fails exact incompatible signature without wildcard fallback" {
     var provider = sni_provider.ReloadableProvider.init(std.testing.allocator);
     defer provider.deinit();
@@ -974,6 +1045,32 @@ test "record stream SNI provider fails exact incompatible signature without wild
     const hello = try buildClientHello(&buf, .{ .sni = "api.example.test", .sig_schemes = &.{0x0403} });
     try std.testing.expectError(error.NoApplicableCredential, server.backend().receive(.initial, hello, &sink));
     try std.testing.expectEqual(tls_backend.CredentialFailure.no_compatible_signature_algorithm, server.credentialFailure().?);
+}
+
+test "pending server credential selection emits no ServerHello until resume" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.async_select = true;
+    mock.pending_polls = 1;
+    var server = serverWithProvider(&mock);
+    defer server.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{ .sni = "pending.example.test" });
+    try server.backend().receive(.initial, hello, &sink);
+    try std.testing.expect(server.authPending());
+    try std.testing.expectEqual(@as(usize, 1), mock.select_count);
+    try std.testing.expectEqual(@as(usize, 0), countCryptoEvents(&sink, .initial));
+
+    try server.backend().resumeAuth(&sink);
+    try std.testing.expect(server.authPending());
+    try std.testing.expectEqual(@as(usize, 0), countCryptoEvents(&sink, .initial));
+
+    try server.backend().resumeAuth(&sink);
+    try std.testing.expect(!server.authPending());
+    try std.testing.expectEqual(@as(usize, 1), countCryptoEvents(&sink, .initial));
 }
 
 test "record stream handshake fails closed when a ClientHello is corrupted in flight" {
@@ -1521,6 +1618,31 @@ fn expectServerReceiveError(server: *tls_backend.Tls13Backend, opts: ClientHello
     try std.testing.expectError(want, server.backend().receive(.initial, hello, &sink));
 }
 
+fn countCryptoEvents(sink: *const DirectSink, epoch: events.EncryptionEpoch) usize {
+    var count: usize = 0;
+    for (sink.items[0..sink.len]) |event| switch (event) {
+        .handshake_bytes => |bytes| {
+            if (bytes.epoch == epoch) count += 1;
+        },
+        else => {},
+    };
+    return count;
+}
+
+fn expectMalformedSniRejectedBeforeSelection(raw_sni: []const u8) !void {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    var server = serverWithProvider(&mock);
+    defer server.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+    var buf: [2048]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{ .sni = raw_sni });
+    try std.testing.expectError(error.IllegalParameter, server.backend().receive(.initial, hello, &sink));
+    try std.testing.expectEqual(@as(usize, 0), mock.select_count);
+    try std.testing.expectEqual(@as(usize, 0), countCryptoEvents(&sink, .initial));
+}
+
 test "a compatible signature scheme past the legacy cap is still selected" {
     // 17 filler schemes, then Ed25519 in slot 18: truncation at 16 would have
     // hidden it and produced a false NoCompatibleSignatureAlgorithm.
@@ -1579,6 +1701,22 @@ test "malformed SNI is rejected rather than collapsed into the default path" {
         const empty_list = [_]u8{ 0x00, 0x00 }; // ServerNameList<len=0>{}
         try expectServerReceiveError(&server, .{ .sni_raw = &empty_list }, error.IllegalParameter);
     }
+    try expectMalformedSniRejectedBeforeSelection("bad..example");
+    try expectMalformedSniRejectedBeforeSelection("bad host.example");
+    try expectMalformedSniRejectedBeforeSelection("bad\x00host.example");
+    try expectMalformedSniRejectedBeforeSelection("-bad.example");
+    try expectMalformedSniRejectedBeforeSelection("bad-.example");
+    try expectMalformedSniRejectedBeforeSelection("bad.-example");
+    try expectMalformedSniRejectedBeforeSelection("bad.example-");
+    const long_label = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.example";
+    try expectMalformedSniRejectedBeforeSelection(long_label);
+    const too_long_name =
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa." ++
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb." ++
+        "ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc." ++
+        "ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd." ++
+        "e.example";
+    try expectMalformedSniRejectedBeforeSelection(too_long_name);
 }
 
 test "a provider returning an unoffered scheme is rejected before signing" {


### PR DESCRIPTION
Claims #347 — exclusive Codex implementation

## Summary

- Adds `src/tls/sni_provider.zig`, a reloadable in-memory SNI credential provider behind the merged #334 `CredentialProvider` / `SelectedCredential` seam.
- Publishes immutable credential snapshots with mutex-protected retain/swap, monotonic generations, selected-handle snapshot pinning, and exactly-once signer/snapshot release.
- Implements deterministic exact, longest single-label wildcard, and default precedence; absent and unknown SNI policies; ASCII hostname canonicalization; duplicate/invalid pattern rejection; and no fallback from an exact class to wildcard/default on signature incompatibility.
- Validates snapshot inputs before publication: chain bounds, DER preflight, leaf key kind, signer/key/scheme compatibility, duplicate default, duplicate patterns, default usability, allocation cleanup, and external owner release.
- Supports opaque signer adapters for snapshot-owned software `Identity`, external signer handles, and crypto-provider `SigningKey`; no OpenSSL/X.509 object or private-key bytes cross the TLS provider interface.
- Adds record-mode and QUIC coverage through the existing shared backend. QUIC uses the same provider and a pass-through client-options constructor for SNI; no QUIC-specific selector was added.

## Ownership and reload notes

- Selection retains the current snapshot under a small pointer mutex, releases the mutex before matching/signing, and transfers that retained reference to the selected handle on success.
- Reload builds the replacement off-path, publishes only after complete validation, and releases retired snapshots only after the provider and every selected handle release their references.
- Selected handles return chains from their pinned generation and reject signing attempts with any scheme other than the chosen peer-offered compatible scheme.

## Policy and exclusions

- Wildcards are limited to a complete left-most `*.` label and match exactly one DNS label.
- Unknown SNI defaults to fail; absent SNI defaults to use the configured default bundle.
- This does not implement #356 HTTP dispatch, #392 appliance provisioning, #386 negotiation-registry migration, filesystem watching, remote/HSM async signing, RSA, public trust validation, or new ClientHello parsing.

## Validation

- `git diff --check` — passed
- `zig fmt --check build.zig src/ tests/` — passed
- `zig build test-tls --summary all --error-style verbose` — passed, 278/278 tests
- `zig build test-quic --summary all --error-style verbose` — passed, 381/381 tests
- `zig build test-integration --summary all --error-style verbose` — passed, 65/69 passed / 4 skipped on clean rerun; two immediately prior runs failed only the unrelated HTTP reload/static stress test at `tests/integration.zig:5228` after it had passed earlier
- `zig build test --summary all --error-style verbose` — passed, 1551/1552 passed / 1 skipped
- `zig build test -Dtls-profile=appliance --summary all --error-style verbose` — passed, 1534/1535 passed / 1 skipped
- `zig build test -Doptimize=ReleaseFast --summary all --error-style verbose` — passed, 1551/1552 passed / 1 skipped

Closes #347