### PR TITLE
packaging: publish DEB and RPM release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,8 +97,12 @@ jobs:
         include:
           - os: ubuntu-latest
             archive_name: tardigrade-linux-x86_64
+            deb_arch: amd64
+            rpm_arch: x86_64
           - os: ubuntu-24.04-arm
             archive_name: tardigrade-linux-aarch64
+            deb_arch: arm64
+            rpm_arch: aarch64
 
     steps:
       - name: Checkout
@@ -113,6 +117,9 @@ jobs:
 
       - name: Install dependencies
         run: sudo apt-get install -y libssl-dev
+
+      - name: Install packaging prerequisites
+        run: sudo apt-get install -y rpm
 
       - name: Install Zig
         run: sh ./scripts/install-zig.sh 0.16.0
@@ -176,6 +183,30 @@ jobs:
         with:
           subject-path: ${{ steps.archive_artifacts.outputs.archive_path }}
 
+      - name: Build DEB package
+        env:
+          VERSION: ${{ needs.prepare-release.outputs.version }}
+          DEB_ARCH: ${{ matrix.deb_arch }}
+          ARTIFACT_DIR: ${{ steps.archive_artifacts.outputs.artifact_dir }}
+        run: |
+          ./packaging/deb/build.sh \
+            --version "$VERSION" \
+            --arch "$DEB_ARCH" \
+            --binary zig-out/bin/tardi \
+            --output "$ARTIFACT_DIR"
+
+      - name: Build RPM package
+        env:
+          VERSION: ${{ needs.prepare-release.outputs.version }}
+          RPM_ARCH: ${{ matrix.rpm_arch }}
+          ARTIFACT_DIR: ${{ steps.archive_artifacts.outputs.artifact_dir }}
+        run: |
+          ./packaging/rpm/build.sh \
+            --version "$VERSION" \
+            --arch "$RPM_ARCH" \
+            --binary zig-out/bin/tardi \
+            --output "$ARTIFACT_DIR"
+
       - name: Upload archive artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -199,6 +230,22 @@ jobs:
           path: ${{ steps.archive_artifacts.outputs.inventory_path }}
           if-no-files-found: error
           retention-days: 14
+
+      - name: Upload DEB artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: deb-${{ matrix.archive_name }}
+          path: ${{ steps.archive_artifacts.outputs.artifact_dir }}/*.deb
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload RPM artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: rpm-${{ matrix.archive_name }}
+          path: ${{ steps.archive_artifacts.outputs.artifact_dir }}/*.rpm
+          if-no-files-found: error
+          retention-days: 1
 
   publish-release:
     name: Publish GitHub release assets
@@ -234,7 +281,7 @@ jobs:
           set -euo pipefail
           mkdir -p "$DIST_DIR"
           install -m 0755 scripts/install.sh "$DIST_DIR/install.sh"
-          find "$DIST_DIR" -type f \( -name '*.tar.gz' -o -name 'install.sh' \) -print0 | sort -z | xargs -0 sha256sum > "$DIST_DIR/tardigrade-checksums.txt"
+          find "$DIST_DIR" -type f \( -name '*.tar.gz' -o -name '*.deb' -o -name '*.rpm' -o -name 'install.sh' \) -print0 | sort -z | xargs -0 sha256sum > "$DIST_DIR/tardigrade-checksums.txt"
 
       - name: Verify checksums
         env:
@@ -258,6 +305,8 @@ jobs:
           body_path: ${{ runner.temp }}/publish-release/release-notes/release-notes.md
           files: |
             ${{ runner.temp }}/publish-release/dist/*.tar.gz
+            ${{ runner.temp }}/publish-release/dist/*.deb
+            ${{ runner.temp }}/publish-release/dist/*.rpm
             ${{ runner.temp }}/publish-release/dist/*.spdx.json
             ${{ runner.temp }}/publish-release/dist/dependency-inventory-*.json
             ${{ runner.temp }}/publish-release/dist/install.sh

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ compatibility promise is documented in the [Core v1 support matrix](docs/SUPPORT
   metrics at `/status/metrics` by default.
 - Request limits, rate limiting, security headers, and release-gated security
   regression tests.
-- A native packaging path with release archives, DEB/RPM package builders,
+- A native packaging path with release archives, published DEB/RPM packages,
   service files, checksums, SBOMs, and provenance attestation.
 
 HTTP/2, HTTP/3/QUIC, WebSocket/SSE, ACME, FastCGI, uWSGI, SCGI, memcached, and
@@ -89,9 +89,10 @@ runtime dependency the DEB/RPM packages declare explicitly.
 Other install paths:
 
 - Download release archives directly from [GitHub Releases](https://github.com/Bare-Systems/Tardigrade/releases).
-- Native DEB/RPM packages, systemd/launchd service files, and a Homebrew
-  formula — see [packaging/README.md](packaging/README.md) for current
-  status and build instructions.
+- Native DEB/RPM packages (published on every release), systemd/launchd
+  service files, and a Homebrew formula — see
+  [packaging/README.md](packaging/README.md) for current status and
+  install/build instructions.
 - Build from source (see below).
 
 ## Build from source

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -24,9 +24,11 @@ Use this checklist before tagging and distributing a Tardigrade release.
 - [ ] Run `./scripts/test-install.sh` against a ReleaseFast build
 - [ ] Run `./scripts/test-deb-package.sh` on a Linux host with Docker
 - [ ] Run `./scripts/test-rpm-package.sh` on a Linux host with Docker
-- [ ] Verify release packaging paths and checksums
-- [ ] Note in the release that DEB/RPM/Homebrew/launchd are not published release
-      assets; only the Linux `.tar.gz` archives, `install.sh`, and checksums are
+- [ ] Verify release packaging paths and checksums, including the published
+      `.deb`/`.rpm` assets
+- [ ] Note in the release that Homebrew and launchd are not published release
+      assets; the Linux `.tar.gz` archives, `.deb`/`.rpm` packages, `install.sh`,
+      and checksums are
 - [ ] Confirm changelog entries for operator-visible changes are complete
 
 ## Branch Hygiene

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -11,8 +11,8 @@ versus what is a local-build-only tool.
 | --- | --- | --- |
 | Linux release archives (`.tar.gz`, x86_64/aarch64) | **Supported, published** | Built and attached to every GitHub release by `.github/workflows/release.yml`, alongside `install.sh`, `tardigrade-checksums.txt`, and per-arch SPDX SBOMs. |
 | macOS release archives (`.tar.gz`, darwin x86_64/arm64) | **Planned, not published** | CI builds and tests Tardigrade on `macos-14`, but the release workflow's build matrix only packages Linux. `install.sh` and the Homebrew formula already expect `tardigrade-darwin-*.tar.gz` assets that do not yet exist. |
-| DEB (`packaging/deb/build.sh`) | **Supported as a local builder, not published** | Produces a working `.deb` from a pre-built binary; smoke-tested on every PR/push via the `packaging-smoke` CI job (`scripts/test-deb-package.sh`). No `.deb` is attached to GitHub releases. |
-| RPM (`packaging/rpm/build.sh`) | **Supported as a local builder, not published** | Same status as DEB: builds and smoke-tests cleanly (`scripts/test-rpm-package.sh`), not published as a release asset. |
+| DEB (`packaging/deb/build.sh`) | **Supported, published** | Built for `amd64`/`arm64` from the same release binaries as the `.tar.gz` archives and attached to every GitHub release; also usable as a local builder (`packaging/deb/build.sh`). Smoke-tested on every PR/push via the `packaging-smoke` CI job (`scripts/test-deb-package.sh`). |
+| RPM (`packaging/rpm/build.sh`) | **Supported, published** | Same treatment as DEB, for `x86_64`/`aarch64`. Smoke-tested via `scripts/test-rpm-package.sh`. Built from the same Ubuntu-runner binary as the archives — see the glibc compatibility note below if targeting an older RHEL-family release. |
 | systemd unit (`packaging/systemd/tardigrade.service`) | **Supported** | Installed and exercised end-to-end by both the DEB and RPM smoke tests. |
 | launchd plist (`packaging/launchd/io.baresystems.tardigrade.plist`) | **Unverified template** | Ships as a template for macOS host-native installs; there is no macOS packaging pipeline or smoke test exercising it. |
 | Homebrew (`packaging/homebrew/tardigrade.rb`) | **Formula present, tap not published, macOS blocked** | The `on_linux` blocks can resolve once real release checksums are filled in; the `on_macos` blocks cannot resolve until macOS archives are published (see above). No `Bare-Systems/homebrew-tap` repo exists yet. |
@@ -30,7 +30,28 @@ This currently only resolves for Linux (`x86_64`/`aarch64`); see "Current status
 
 ## DEB (Debian / Ubuntu)
 
-Build a `.deb` package from a pre-built binary:
+### Install from a release (recommended)
+
+Every GitHub release publishes `tardigrade_<version>_amd64.deb` and
+`tardigrade_<version>_arm64.deb` alongside the `.tar.gz` archives and
+`tardigrade-checksums.txt`:
+
+```bash
+version=0.5.0   # match the release tag, without the leading "v"
+curl -fsSLO "https://github.com/Bare-Systems/Tardigrade/releases/download/v${version}/tardigrade_${version}_amd64.deb"
+curl -fsSLO "https://github.com/Bare-Systems/Tardigrade/releases/download/v${version}/tardigrade-checksums.txt"
+sha256sum --ignore-missing -c tardigrade-checksums.txt
+
+sudo apt install ./tardigrade_${version}_amd64.deb
+sudo systemctl enable --now tardigrade
+```
+
+Use `tardigrade_<version>_arm64.deb` on `arm64`/`aarch64` hosts.
+
+### Build locally
+
+Building your own `.deb` from a pre-built binary is still supported — useful
+for architectures the release workflow doesn't cover, or a custom build:
 
 ```bash
 # 1. Build the binary first (cross-compile for the target arch as needed)
@@ -58,6 +79,36 @@ The DEB package:
 - Creates `/var/lib/tardigrade` for the service working directory
 
 ## RPM (RHEL / Fedora / AlmaLinux)
+
+### Install from a release (recommended)
+
+Every GitHub release publishes `tardigrade-<version>-1.x86_64.rpm` and
+`tardigrade-<version>-1.aarch64.rpm` alongside the `.tar.gz` archives and
+`tardigrade-checksums.txt`:
+
+```bash
+version=0.5.0   # match the release tag, without the leading "v"
+curl -fsSLO "https://github.com/Bare-Systems/Tardigrade/releases/download/v${version}/tardigrade-${version}-1.x86_64.rpm"
+curl -fsSLO "https://github.com/Bare-Systems/Tardigrade/releases/download/v${version}/tardigrade-checksums.txt"
+sha256sum --ignore-missing -c tardigrade-checksums.txt
+
+sudo dnf install ./tardigrade-${version}-1.x86_64.rpm
+sudo systemctl enable --now tardigrade
+```
+
+Use `tardigrade-<version>-1.aarch64.rpm` on `aarch64` hosts. `rpm -i` works
+identically to `dnf install` for a local file.
+
+> **glibc compatibility note**: the published `.rpm` is built from the same
+> binary as the Linux `.tar.gz` archives, compiled on the `ubuntu-latest` /
+> `ubuntu-24.04-arm` GitHub-hosted runners. It links dynamically against that
+> runner's glibc. This is fine for current Fedora and RHEL 10+ family
+> distros; it may be *too new* for RHEL 9 / Rocky 9 / AlmaLinux 9 (glibc
+> 2.34), which would need a binary built on a matching older glibc. If that
+> matters for your target, build locally instead (below) on a host with a
+> compatible glibc.
+
+### Build locally
 
 ```bash
 # 1. Install prerequisites


### PR DESCRIPTION
## Summary

Implements #464: DEB and RPM packages are now built and published as GitHub release assets, alongside the existing `.tar.gz` archives.

Narrowly scoped per the issue:
- Reuses `packaging/deb/build.sh` and `packaging/rpm/build.sh` exactly as they are — **no changes to either script**.
- Builds packages for the two architectures already covered by the release matrix: `amd64`/`x86_64` (`ubuntu-latest`) and `arm64`/`aarch64` (`ubuntu-24.04-arm`).
- Adds the packages to the existing checksum manifest and uploads them alongside the current tarball assets.
- Updates packaging docs to show `apt install ./...deb` and `dnf install ./...rpm`.
- No hosted APT/YUM repository, no packaging redesign, no runtime code touched.

## What changed

**`.github/workflows/release.yml`** (`build-release` job):
- Matrix gains `deb_arch`/`rpm_arch` fields (`amd64`/`x86_64` and `arm64`/`aarch64`).
- Installs `rpm` (for `rpmbuild`) alongside the existing `libssl-dev` install step — `dpkg-deb` is already present on the Ubuntu runners.
- New "Build DEB package" / "Build RPM package" steps call the existing scripts against the already-built `zig-out/bin/tardi`, writing into the same per-arch artifact directory used for the `.tar.gz`.
- **Placement matters**: these steps run *after* "Generate SBOM" and "Attest build provenance", not before — the SBOM step scans the whole artifact directory, so building the packages first would have pulled `.deb`/`.rpm` metadata into the archive's SBOM. Provenance attestation is scoped to `archive_path` only, so it's unaffected either way, but SBOM scope needed the ordering fix.
- New "Upload DEB artifact" / "Upload RPM artifact" steps, following the existing per-artifact-type upload pattern (`deb-<archive_name>`, `rpm-<archive_name>`).

`publish-release` job:
- Checksum generation now globs `*.deb`/`*.rpm` alongside `*.tar.gz`/`install.sh`.
- `softprops/action-gh-release`'s `files:` list includes the new `.deb`/`.rpm` globs.

**`packaging/README.md`**:
- "Current status" table: DEB/RPM rows updated from "local builder, not published" to "Supported, published".
- DEB/RPM sections restructured into "Install from a release" (the new `apt install ./tardigrade_<version>_amd64.deb` / `dnf install ./tardigrade-<version>-1.x86_64.rpm` flow, with a checksum-verify step) and "Build locally" (the pre-existing workflow, kept as a documented alternative for other architectures or custom builds).
- Added a glibc-compatibility callout for the RPM: it's built from the same Ubuntu-runner binary as the archives (not a RHEL-family base like the Docker-based smoke test uses), so it may be too new for RHEL 9 / Rocky 9 / AlmaLinux 9 (glibc 2.34). Documented as a known characteristic, not fixed — fixing it would mean a second, RHEL-based build pipeline, which is exactly the kind of packaging redesign this issue is scoped to avoid.

**`README.md`**: "DEB/RPM package builders" → "published DEB/RPM packages" in the features list; Install section now notes DEB/RPM packages are published on every release.

**`docs/RELEASE_CHECKLIST.md`**: updated the note that previously said DEB/RPM/Homebrew/launchd aren't published — now only Homebrew/launchd remain unpublished.

## Validation

```bash
# YAML sanity
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); print('YAML OK')"

# Confirmed the exact deb build.sh invocation added to release.yml actually
# produces a correct package (using a fake binary in place of a real build):
./packaging/deb/build.sh --version 9.9.9 --arch amd64 --binary /tmp/faketardi/tardi --output /tmp/deb-out
dpkg-deb -c /tmp/deb-out/tardigrade_9.9.9_amd64.deb   # correct file layout: /usr/bin/tardi, symlink, systemd unit, etc.
dpkg-deb -I /tmp/deb-out/tardigrade_9.9.9_amd64.deb   # correct control metadata (Depends: libssl3 | libssl1.1, etc.)

# Simulated the updated publish-release checksum generation/verification
# against realistic filenames (tar.gz, deb, rpm, install.sh):
find /tmp/dist-sim -type f \( -name '*.tar.gz' -o -name '*.deb' -o -name '*.rpm' -o -name 'install.sh' \) \
  -print0 | sort -z | xargs -0 sha256sum > /tmp/dist-sim/tardigrade-checksums.txt
sha256sum --check tardigrade-checksums.txt   # all OK
```

`rpmbuild` isn't available in this sandbox, so the RPM build step itself
wasn't exercised end-to-end here — it uses the same `packaging/rpm/build.sh`
already exercised by `scripts/test-rpm-package.sh` in `ci.yml`'s
`packaging-smoke` job (unchanged by this PR), and by the `#464`-referenced
smoke test that installs and verifies the resulting RPM inside a Rocky Linux
9 container. `actionlint`/`shellcheck` weren't available either; no `.sh`
files were modified in this PR (only `release.yml` and docs), and `ci.yml`'s
`lint` job already covers this branch.

## Existing packaging smoke tests

`packaging/deb/build.sh`, `packaging/rpm/build.sh`, and
`ci.yml`'s `packaging-smoke` job (`scripts/test-deb-package.sh`,
`scripts/test-rpm-package.sh`) are all **unchanged** by this PR — the new
release-workflow steps call the exact same scripts with the same argument
shapes those smoke tests already exercise, so existing coverage carries over
directly to the new release path.

Closes #464


---
_Generated by [Claude Code](https://claude.ai/code/session_01FMHms54EbV6Djm22Z9RDFT)_