### PR TITLE
packaging: RPM installs a starter config and creates its systemd WorkingDirectory

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -129,15 +129,10 @@ sudo rpm -i dist/tardigrade-0.50-1.x86_64.rpm
 sudo systemctl enable --now tardigrade
 ```
 
-The RPM package, unlike the DEB package, does **not** install a starter
-`/etc/tardigrade/tardigrade.conf` or create `/var/lib/tardigrade` (the
-systemd unit's `WorkingDirectory`). Create both before starting the service
-for the first time:
-
-```bash
-sudo install -d -o tardigrade -g tardigrade /var/lib/tardigrade
-sudo install -m 0644 packaging/tardigrade.conf /etc/tardigrade/tardigrade.conf
-```
+Like the DEB package, the RPM installs a starter
+`/etc/tardigrade/tardigrade.conf` and creates `/var/lib/tardigrade` (the
+systemd unit's `WorkingDirectory`) on install, so `systemctl enable --now
+tardigrade` works immediately after a fresh install.
 
 ## Upgrading
 
@@ -155,9 +150,9 @@ sudo systemctl reload tardigrade   # or: restart, if reload is insufficient
   declared in `DEBIAN/conffiles`; `dpkg`/`apt` will prompt on conflicting
   local edits rather than silently overwriting them.
 - RPM upgrades (`sudo rpm -U` or `dnf upgrade`) preserve
-  `/etc/tardigrade/tardigrade.env` via `%config(noreplace)`; since the RPM
-  does not package `tardigrade.conf` at all, there is nothing for `rpm` to
-  manage there — it is entirely operator-owned.
+  `/etc/tardigrade/tardigrade.env` and `/etc/tardigrade/tardigrade.conf` via
+  `%config(noreplace)`; an upgrade with local edits saves the new packaged
+  version alongside as `.rpmnew` rather than overwriting your changes.
 - For the plain release archive / `install.sh` path, replace the `tardi`
   binary, then run `tardi check <config>` against the existing config before
   restarting whatever process supervisor you are using.

--- a/packaging/rpm/build.sh
+++ b/packaging/rpm/build.sh
@@ -49,6 +49,7 @@ mkdir -p "${WORK_DIR}"/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 cp "$BINARY"                                                  "${WORK_DIR}/SOURCES/tardi"
 cp "${REPO_ROOT}/LICENSE"                                     "${WORK_DIR}/SOURCES/LICENSE"
 cp "${REPO_ROOT}/packaging/systemd/tardigrade.service"        "${WORK_DIR}/SOURCES/tardigrade.service"
+cp "${REPO_ROOT}/packaging/tardigrade.conf"                   "${WORK_DIR}/SOURCES/tardigrade.conf"
 cp "${REPO_ROOT}/packaging/rpm/tardigrade.spec"               "${WORK_DIR}/SPECS/tardigrade.spec"
 
 cat > "${WORK_DIR}/SOURCES/tardigrade.env" <<'ENVEOF'

--- a/packaging/rpm/tardigrade.spec
+++ b/packaging/rpm/tardigrade.spec
@@ -8,6 +8,7 @@ Source0:        tardi
 Source1:        tardigrade.service
 Source2:        tardigrade.env
 Source3:        LICENSE
+Source4:        tardigrade.conf
 
 BuildArch:      %{build_arch}
 Requires:       openssl-libs
@@ -22,6 +23,7 @@ ln -s tardi %{buildroot}%{_bindir}/tardigrade
 install -D -m 0644 %{SOURCE1} %{buildroot}%{_unitdir}/tardigrade.service
 install -D -m 0640 %{SOURCE2} %{buildroot}%{_sysconfdir}/tardigrade/tardigrade.env
 install -D -m 0644 %{SOURCE3} %{buildroot}%{_datadir}/licenses/%{name}/LICENSE
+install -D -m 0644 %{SOURCE4} %{buildroot}%{_sysconfdir}/tardigrade/tardigrade.conf
 install -d %{buildroot}%{_localstatedir}/log/tardigrade
 
 %pre
@@ -32,6 +34,7 @@ exit 0
 %post
 %systemd_post tardigrade.service
 chown root:tardigrade %{_sysconfdir}/tardigrade/tardigrade.env
+install -d -o tardigrade -g tardigrade %{_localstatedir}/lib/tardigrade
 exit 0
 
 %preun
@@ -48,6 +51,7 @@ exit 0
 %{_bindir}/tardigrade
 %{_unitdir}/tardigrade.service
 %config(noreplace) %{_sysconfdir}/tardigrade/tardigrade.env
+%config(noreplace) %{_sysconfdir}/tardigrade/tardigrade.conf
 %dir %{_localstatedir}/log/tardigrade
 
 %changelog

--- a/scripts/test-rpm-package.sh
+++ b/scripts/test-rpm-package.sh
@@ -78,12 +78,17 @@ docker run --rm \
         test -x /usr/bin/tardi
         /usr/bin/tardi version >/dev/null
         test -f /etc/tardigrade/tardigrade.env
+        test -f /etc/tardigrade/tardigrade.conf
         test -f /usr/lib/systemd/system/tardigrade.service
         test -f /usr/share/licenses/tardigrade/LICENSE
         test -d /var/log/tardigrade
+        test -d /var/lib/tardigrade
         test "$(stat -c "%a %U %G" /etc/tardigrade/tardigrade.env)" = "640 root tardigrade"
+        test "$(stat -c "%a %U %G" /etc/tardigrade/tardigrade.conf)" = "644 root root"
+        test "$(stat -c "%a %U %G" /var/lib/tardigrade)" = "755 tardigrade tardigrade"
         grep -F "EnvironmentFile=-/etc/tardigrade/tardigrade.env" /usr/lib/systemd/system/tardigrade.service
         grep -F "ExecStart=/usr/bin/tardi run -c /etc/tardigrade/tardigrade.conf" /usr/lib/systemd/system/tardigrade.service
+        grep -F "WorkingDirectory=/var/lib/tardigrade" /usr/lib/systemd/system/tardigrade.service
 
         dnf remove -y tardigrade
         test ! -e /usr/bin/tardi


### PR DESCRIPTION
## Summary

Fixes #465: a fresh `rpm -i tardigrade-*.rpm` + `systemctl enable --now tardigrade` previously failed to start. The RPM never installed a starter `/etc/tardigrade/tardigrade.conf` and never created `/var/lib/tardigrade` (the systemd unit's `WorkingDirectory=`), unlike the DEB package, which does both via its `postinst`. This was documented as a manual workaround in `packaging/README.md` by the #114 audit pass; this PR fixes it at the package level and removes the workaround note.

## What changed

**`packaging/rpm/tardigrade.spec`**:
- Added `Source4: tardigrade.conf`.
- `%install`: installs it to `/etc/tardigrade/tardigrade.conf` (mode 0644).
- `%files`: declared as `%config(noreplace)`, matching the existing treatment of `tardigrade.env` — upgrades won't clobber operator edits.
- `%post`: added `install -d -o tardigrade -g tardigrade %{_localstatedir}/lib/tardigrade` — the exact same command the DEB `postinst` already uses. Deliberately **not** added to `%files` (no `%dir` entry), so it isn't RPM-tracked and `dnf remove`/`rpm -e` won't delete operator state data on uninstall — this mirrors the DEB package, which also creates `/var/lib/tardigrade` purely via `postinst` rather than tracking it as a package file.

**`packaging/rpm/build.sh`**: stages `packaging/tardigrade.conf` into the rpmbuild `SOURCES` directory (one line, alongside the existing `tardigrade.service`/`LICENSE` staging).

**`scripts/test-rpm-package.sh`**: extended the existing Docker-based (Rocky Linux 9) smoke test to assert, mirroring the equivalent DEB smoke-test assertions:
- `/etc/tardigrade/tardigrade.conf` exists, mode `644 root:root`
- `/var/lib/tardigrade` exists, mode `755 tardigrade:tardigrade`
- the installed unit's `WorkingDirectory=/var/lib/tardigrade` line is present

**`packaging/README.md`**: removed the "RPM does not install a starter config..." workaround block (now false), and fixed the "Upgrading" section's claim that RPM doesn't manage `tardigrade.conf` — it now does, via `%config(noreplace)`, same as the DEB package.

No changes to `packaging/deb/build.sh`, `packaging/systemd/tardigrade.service`, `.github/workflows/release.yml`, or any runtime code.

## Validation

`rpmbuild` isn't installed by default in this sandbox, so I installed it and built the real package end-to-end against the updated spec:

```bash
sudo apt-get install -y rpm   # provides rpmbuild, not preinstalled here

./packaging/rpm/build.sh --version 9.9.9 --arch x86_64 \
  --binary /tmp/faketardi/tardi --output /tmp/rpm-out
# → built cleanly, no spec errors

rpm -qlp /tmp/rpm-out/tardigrade-9.9.9-1.x86_64.rpm
# /etc/tardigrade/tardigrade.conf
# /etc/tardigrade/tardigrade.env
# /usr/bin/tardi
# /usr/bin/tardigrade
# /usr/lib/systemd/system/tardigrade.service
# /usr/share/licenses/tardigrade/LICENSE
# /var/log/tardigrade

rpm -qcp /tmp/rpm-out/tardigrade-9.9.9-1.x86_64.rpm
# /etc/tardigrade/tardigrade.conf   <- now a tracked config file
# /etc/tardigrade/tardigrade.env

rpm -q --scripts -p /tmp/rpm-out/tardigrade-9.9.9-1.x86_64.rpm
# postinstall scriptlet includes:
#   install -d -o tardigrade -g tardigrade /var/lib/tardigrade
```

This confirms `tardigrade.conf` is now packaged as expected and the `%post` scriptlet creates `/var/lib/tardigrade` with the correct ownership — exactly what the Docker-based `scripts/test-rpm-package.sh` (which I could not run directly here — needs Docker + a real `zig`-built binary) now also asserts.

```bash
bash -n packaging/rpm/build.sh          # syntax OK
bash -n scripts/test-rpm-package.sh     # syntax OK
```

## Existing coverage

`scripts/test-rpm-package.sh` runs in `ci.yml`'s `packaging-smoke` job on every PR/push to `main` — this PR's extended assertions will run there automatically, exercising a real `zig`-built binary against Rocky Linux 9 in Docker, which this sandbox can't do directly.

Closes #465


---
_Generated by [Claude Code](https://claude.ai/code/session_01FMHms54EbV6Djm22Z9RDFT)_