### PR TITLE
tls: complete native backpressure production wiring

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -48,17 +48,23 @@ logs are written through `src/http/logger.zig`.
   `tardigrade_buffer_config_limit_bytes{direction,scope,limit}` for the
   per-stream low/high/hard watermarks plus per-origin/global hard-limit
   settings.
-- TLS record-stream backpressure state is exposed to runtime consumers through
-  the allocation-free `EncryptedStream.bufferSnapshot()` seam. The snapshot
-  contains current and peak stream-owned bytes for inbound carrier ciphertext,
-  decrypted plaintext, outbound ciphertext, and handshake bytes; optional
-  low/high/hard limits plus whether the backend enforces them; latched
-  carrier-read and plaintext-write pause state; pause/resume counters;
-  hard-limit counters by TLS queue; and stalled-drive counts. These values are
-  per TLS connection and deliberately carry no SNI, URL, request ID, stream ID,
-  or arbitrary protocol labels. OpenSSL-backed adapters may expose measurable
-  BIO/adapter bytes only and leave unknown limits unset; opaque internal OpenSSL
-  memory is outside the complete stream-owned accounting boundary.
+- TLS record-stream backpressure gauges/counters from the allocation-free
+  `EncryptedStream.bufferSnapshot()` seam:
+  `tardigrade_tls_buffered_bytes_current{backend,queue}`,
+  `tardigrade_tls_buffer_pause_events_total{backend,direction}`,
+  `tardigrade_tls_buffer_resume_events_total{backend,direction}`,
+  `tardigrade_tls_buffer_limit_exceeded_total{backend,queue}`, and
+  `tardigrade_tls_buffer_stalled_drives_total{backend}`. Labels are fixed to
+  `pure_zig_record`/`openssl`, the four TLS queues, and the two pause
+  directions; they never include SNI, URL, IP, request ID, connection ID, or
+  stream ID. OpenSSL-backed adapters expose only measurable adapter/BIO bytes
+  and mark opaque internal OpenSSL memory outside complete stream-owned
+  accounting.
+- configured native TLS buffer limits:
+  `tardigrade_tls_buffer_config_limit_bytes{queue,limit}` for the pure-Zig
+  listener's inbound ciphertext, inbound plaintext, outbound ciphertext, and
+  handshake low/high/hard watermarks. These are not described as enforced by
+  OpenSSL.
 - reverse-proxy abort counters:
   `tardigrade_proxy_client_aborts_total` and
   `tardigrade_proxy_upstream_aborts_total`
@@ -128,6 +134,10 @@ Two outcome shapes exist:
 | Proxy per-stream buffer hard limit | `TARDIGRADE_PROXY_BUFFER_PER_STREAM_HARD_LIMIT_BYTES` | 1 MiB | proxy buffer accounting | Hard-limit exceedance is observable through `tardigrade_buffer_limit_exceeded_total`; enforcement lands per proxy path as backpressure work expands |
 | Proxy per-origin buffer hard limit | `TARDIGRADE_PROXY_BUFFER_PER_ORIGIN_HARD_LIMIT_BYTES` | 0 (not enforced yet) | future aggregate proxy buffer accounting | When non-zero, must be at least the per-stream hard limit |
 | Proxy global buffer hard limit | `TARDIGRADE_PROXY_BUFFER_GLOBAL_HARD_LIMIT_BYTES` | 0 (not enforced yet) | future aggregate proxy buffer accounting | When non-zero, must be at least the per-stream hard limit |
+| Native TLS inbound ciphertext watermarks | `TARDIGRADE_TLS_INBOUND_CIPHERTEXT_LOW_WATERMARK_BYTES`, `TARDIGRADE_TLS_INBOUND_CIPHERTEXT_HIGH_WATERMARK_BYTES`, `TARDIGRADE_TLS_INBOUND_CIPHERTEXT_HARD_LIMIT_BYTES` | TLS core defaults | pure-Zig TLS record stream | Invalid ordering, capacity overflow, or reserve violations reject startup/reload |
+| Native TLS inbound plaintext watermarks | `TARDIGRADE_TLS_INBOUND_PLAINTEXT_LOW_WATERMARK_BYTES`, `TARDIGRADE_TLS_INBOUND_PLAINTEXT_HIGH_WATERMARK_BYTES`, `TARDIGRADE_TLS_INBOUND_PLAINTEXT_HARD_LIMIT_BYTES` | TLS core defaults | pure-Zig TLS record stream | High pauses carrier reads; resume occurs only after all inbound queues drain to low |
+| Native TLS outbound ciphertext watermarks | `TARDIGRADE_TLS_OUTBOUND_CIPHERTEXT_LOW_WATERMARK_BYTES`, `TARDIGRADE_TLS_OUTBOUND_CIPHERTEXT_HIGH_WATERMARK_BYTES`, `TARDIGRADE_TLS_OUTBOUND_CIPHERTEXT_HARD_LIMIT_BYTES` | TLS core defaults | pure-Zig TLS record stream | High pauses plaintext writes; hard-limit rejection does not advance write state |
+| Native TLS handshake watermarks | `TARDIGRADE_TLS_HANDSHAKE_LOW_WATERMARK_BYTES`, `TARDIGRADE_TLS_HANDSHAKE_HIGH_WATERMARK_BYTES`, `TARDIGRADE_TLS_HANDSHAKE_HARD_LIMIT_BYTES` | TLS core defaults | pure-Zig TLS record stream | Handshake buffering is bounded separately from application plaintext |
 | Parked keepalive backlog | idle-park timeout / `max_requests_per_connection` | — | `keepalive_park.ParkedRegistry` | Idle parked connections reaped on the timer tick (`timeouts_total`); none hold a worker while idle |
 
 The request-size limits are enforced in two layers: the HTTP parser

--- a/docs/TLS_RECORD_TRANSPORT.md
+++ b/docs/TLS_RECORD_TRANSPORT.md
@@ -100,3 +100,16 @@ ciphertext queue; there is no hidden pending-plaintext staging queue. HTTP/1.1
 and HTTP/2 consumers should use `can_write_plaintext`, `can_read_plaintext`,
 `wants_read`, `wants_write`, and the buffer snapshot to register only socket
 readiness that can make progress.
+
+Production native TLS listeners receive an immutable `BufferLimits` policy from
+validated edge configuration. The environment keys are
+`TARDIGRADE_TLS_{INBOUND_CIPHERTEXT,INBOUND_PLAINTEXT,OUTBOUND_CIPHERTEXT,HANDSHAKE}_{LOW_WATERMARK_BYTES,HIGH_WATERMARK_BYTES,HARD_LIMIT_BYTES}`;
+omitted values use `BufferLimits.defaults()`. Reload rejects invalid ordering,
+capacity, or atomic-reserve violations before replacing the active config.
+
+For encrypted HTTP transports, application readiness and raw fd readiness are
+intentionally separate. `can_read_plaintext` and `can_write_plaintext` allow
+immediate application work; raw socket registration is derived only from
+`wants_read` and `wants_write`. A plaintext read blocked on a TLS write retry
+therefore registers only write interest, and a plaintext write blocked on a TLS
+read retry registers only read interest.

--- a/src/edge_config.zig
+++ b/src/edge_config.zig
@@ -1182,7 +1182,7 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
 
     const request_total_timeout_ms = parseIntEnv(u32, allocator, "TARDIGRADE_REQUEST_TOTAL_TIMEOUT_MS", 0);
     const tls_handshake_timeout_ms = parseIntEnv(u32, allocator, "TARDIGRADE_TLS_HANDSHAKE_TIMEOUT_MS", 5_000);
-    const tls_buffer_limits = tlsBufferLimitsFromEnv(allocator);
+    const tls_buffer_limits = try tlsBufferLimitsFromEnv(allocator);
     const downstream_write_timeout_ms = parseIntEnv(u32, allocator, "TARDIGRADE_DOWNSTREAM_WRITE_TIMEOUT_MS", 30_000);
 
     const max_req_conn_str = envOrDefault(allocator, "TARDIGRADE_MAX_REQUESTS_PER_CONNECTION", "100") catch unreachable;
@@ -2886,21 +2886,37 @@ fn validateBufferedUpstreamResponseLimit(limit: usize) !void {
     if (limit == 0) return error.InvalidConfigValue;
 }
 
-fn tlsBufferLimitsFromEnv(allocator: std.mem.Allocator) encrypted_stream.BufferLimits {
+fn tlsBufferLimitsFromEnv(allocator: std.mem.Allocator) !encrypted_stream.BufferLimits {
     const defaults = encrypted_stream.BufferLimits.defaults();
+    const limits = encrypted_stream.BufferLimits{
+        .inbound_ciphertext = try tlsWatermarkFromEnv(allocator, "TARDIGRADE_TLS_INBOUND_CIPHERTEXT", defaults.inbound_ciphertext),
+        .inbound_plaintext = try tlsWatermarkFromEnv(allocator, "TARDIGRADE_TLS_INBOUND_PLAINTEXT", defaults.inbound_plaintext),
+        .outbound_ciphertext = try tlsWatermarkFromEnv(allocator, "TARDIGRADE_TLS_OUTBOUND_CIPHERTEXT", defaults.outbound_ciphertext),
+        .handshake = try tlsWatermarkFromEnv(allocator, "TARDIGRADE_TLS_HANDSHAKE", defaults.handshake),
+    };
+    limits.validate() catch |err| {
+        logConfigDiagnostic("config validation failed: TARDIGRADE_TLS_* buffer limits are invalid: {}", .{err});
+        return error.InvalidConfigValue;
+    };
+    return limits;
+}
+
+fn tlsWatermarkFromEnv(allocator: std.mem.Allocator, comptime prefix: []const u8, defaults: encrypted_stream.Watermark) !encrypted_stream.Watermark {
     return .{
-        .inbound_ciphertext = tlsWatermarkFromEnv(allocator, "TARDIGRADE_TLS_INBOUND_CIPHERTEXT", defaults.inbound_ciphertext),
-        .inbound_plaintext = tlsWatermarkFromEnv(allocator, "TARDIGRADE_TLS_INBOUND_PLAINTEXT", defaults.inbound_plaintext),
-        .outbound_ciphertext = tlsWatermarkFromEnv(allocator, "TARDIGRADE_TLS_OUTBOUND_CIPHERTEXT", defaults.outbound_ciphertext),
-        .handshake = tlsWatermarkFromEnv(allocator, "TARDIGRADE_TLS_HANDSHAKE", defaults.handshake),
+        .low = try parseTlsLimitEnv(allocator, prefix ++ "_LOW_WATERMARK_BYTES", defaults.low),
+        .high = try parseTlsLimitEnv(allocator, prefix ++ "_HIGH_WATERMARK_BYTES", defaults.high),
+        .hard = try parseTlsLimitEnv(allocator, prefix ++ "_HARD_LIMIT_BYTES", defaults.hard),
     };
 }
 
-fn tlsWatermarkFromEnv(allocator: std.mem.Allocator, comptime prefix: []const u8, defaults: encrypted_stream.Watermark) encrypted_stream.Watermark {
-    return .{
-        .low = parseIntEnv(usize, allocator, prefix ++ "_LOW_WATERMARK_BYTES", defaults.low),
-        .high = parseIntEnv(usize, allocator, prefix ++ "_HIGH_WATERMARK_BYTES", defaults.high),
-        .hard = parseIntEnv(usize, allocator, prefix ++ "_HARD_LIMIT_BYTES", defaults.hard),
+fn parseTlsLimitEnv(allocator: std.mem.Allocator, key: []const u8, default_value: usize) !usize {
+    const raw = envOrDefault(allocator, key, "") catch return default_value;
+    defer allocator.free(raw);
+    const value = std.mem.trim(u8, raw, " \t\r\n");
+    if (value.len == 0) return default_value;
+    return std.fmt.parseInt(usize, value, 10) catch {
+        logConfigDiagnostic("config validation failed: {s} must be a non-negative integer byte count", .{key});
+        return error.InvalidConfigValue;
     };
 }
 
@@ -3295,6 +3311,98 @@ test "conflicting file override value detects env/file mismatch" {
     try std.testing.expectEqualStrings("8069", conflictingFileOverrideValue("TARDIGRADE_LISTEN_PORT", "18069").?);
     try std.testing.expect(conflictingFileOverrideValue("TARDIGRADE_LISTEN_PORT", "8069") == null);
     try std.testing.expect(conflictingFileOverrideValue("TARDIGRADE_WORKER_THREADS", "4") == null);
+}
+
+const TestConfigOverride = struct {
+    key: []const u8,
+    value: []const u8,
+};
+
+fn putTestOverride(allocator: std.mem.Allocator, overrides: *http.config_file.Overrides, key: []const u8, value: []const u8) !void {
+    try overrides.map.put(try allocator.dupe(u8, key), try allocator.dupe(u8, value));
+}
+
+fn putTestOverrideFmt(
+    allocator: std.mem.Allocator,
+    overrides: *http.config_file.Overrides,
+    key: []const u8,
+    comptime fmt: []const u8,
+    args: anytype,
+) !void {
+    try overrides.map.put(try allocator.dupe(u8, key), try std.fmt.allocPrint(allocator, fmt, args));
+}
+
+fn expectTlsLimitOverridesError(allocator: std.mem.Allocator, entries: []const TestConfigOverride) !void {
+    var overrides = http.config_file.Overrides.init(allocator);
+    defer overrides.deinit(allocator);
+    for (entries) |entry| try putTestOverride(allocator, &overrides, entry.key, entry.value);
+
+    const previous = active_file_overrides;
+    active_file_overrides = &overrides;
+    defer active_file_overrides = previous;
+
+    try std.testing.expectError(error.InvalidConfigValue, tlsBufferLimitsFromEnv(allocator));
+}
+
+test "TLS buffer limits parse explicit override values" {
+    const allocator = std.testing.allocator;
+    const defaults = encrypted_stream.BufferLimits.defaults();
+    var overrides = http.config_file.Overrides.init(allocator);
+    defer overrides.deinit(allocator);
+
+    try putTestOverrideFmt(allocator, &overrides, "TARDIGRADE_TLS_INBOUND_CIPHERTEXT_LOW_WATERMARK_BYTES", "{d}", .{defaults.inbound_ciphertext.low + 1});
+    try putTestOverrideFmt(allocator, &overrides, "TARDIGRADE_TLS_INBOUND_CIPHERTEXT_HIGH_WATERMARK_BYTES", "{d}", .{defaults.inbound_ciphertext.high});
+    try putTestOverrideFmt(allocator, &overrides, "TARDIGRADE_TLS_INBOUND_CIPHERTEXT_HARD_LIMIT_BYTES", "{d}", .{defaults.inbound_ciphertext.hard});
+    try putTestOverrideFmt(allocator, &overrides, "TARDIGRADE_TLS_INBOUND_PLAINTEXT_LOW_WATERMARK_BYTES", "{d}", .{defaults.inbound_plaintext.low + 1});
+    try putTestOverrideFmt(allocator, &overrides, "TARDIGRADE_TLS_INBOUND_PLAINTEXT_HIGH_WATERMARK_BYTES", "{d}", .{defaults.inbound_plaintext.high});
+    try putTestOverrideFmt(allocator, &overrides, "TARDIGRADE_TLS_INBOUND_PLAINTEXT_HARD_LIMIT_BYTES", "{d}", .{defaults.inbound_plaintext.hard});
+    try putTestOverrideFmt(allocator, &overrides, "TARDIGRADE_TLS_OUTBOUND_CIPHERTEXT_LOW_WATERMARK_BYTES", "{d}", .{defaults.outbound_ciphertext.low + 1});
+    try putTestOverrideFmt(allocator, &overrides, "TARDIGRADE_TLS_OUTBOUND_CIPHERTEXT_HIGH_WATERMARK_BYTES", "{d}", .{defaults.outbound_ciphertext.high});
+    try putTestOverrideFmt(allocator, &overrides, "TARDIGRADE_TLS_OUTBOUND_CIPHERTEXT_HARD_LIMIT_BYTES", "{d}", .{defaults.outbound_ciphertext.hard});
+    try putTestOverrideFmt(allocator, &overrides, "TARDIGRADE_TLS_HANDSHAKE_LOW_WATERMARK_BYTES", "{d}", .{defaults.handshake.low + 1});
+    try putTestOverrideFmt(allocator, &overrides, "TARDIGRADE_TLS_HANDSHAKE_HIGH_WATERMARK_BYTES", "{d}", .{defaults.handshake.high});
+    try putTestOverrideFmt(allocator, &overrides, "TARDIGRADE_TLS_HANDSHAKE_HARD_LIMIT_BYTES", "{d}", .{defaults.handshake.hard});
+
+    const previous = active_file_overrides;
+    active_file_overrides = &overrides;
+    defer active_file_overrides = previous;
+
+    const limits = try tlsBufferLimitsFromEnv(allocator);
+    try std.testing.expectEqual(defaults.inbound_ciphertext.low + 1, limits.inbound_ciphertext.low);
+    try std.testing.expectEqual(defaults.inbound_plaintext.low + 1, limits.inbound_plaintext.low);
+    try std.testing.expectEqual(defaults.outbound_ciphertext.low + 1, limits.outbound_ciphertext.low);
+    try std.testing.expectEqual(defaults.handshake.low + 1, limits.handshake.low);
+}
+
+test "TLS buffer limits reject malformed explicit override values" {
+    const allocator = std.testing.allocator;
+    try expectTlsLimitOverridesError(allocator, &.{.{ .key = "TARDIGRADE_TLS_INBOUND_CIPHERTEXT_LOW_WATERMARK_BYTES", .value = "not-a-number" }});
+    try expectTlsLimitOverridesError(allocator, &.{.{ .key = "TARDIGRADE_TLS_INBOUND_CIPHERTEXT_LOW_WATERMARK_BYTES", .value = "-1" }});
+    try expectTlsLimitOverridesError(allocator, &.{.{ .key = "TARDIGRADE_TLS_INBOUND_CIPHERTEXT_LOW_WATERMARK_BYTES", .value = "184467440737095516160" }});
+}
+
+test "TLS buffer limits reject ordering capacity and reserve violations" {
+    const allocator = std.testing.allocator;
+    try expectTlsLimitOverridesError(allocator, &.{.{ .key = "TARDIGRADE_TLS_INBOUND_CIPHERTEXT_LOW_WATERMARK_BYTES", .value = "0" }});
+    try expectTlsLimitOverridesError(allocator, &.{
+        .{ .key = "TARDIGRADE_TLS_INBOUND_CIPHERTEXT_LOW_WATERMARK_BYTES", .value = "4096" },
+        .{ .key = "TARDIGRADE_TLS_INBOUND_CIPHERTEXT_HIGH_WATERMARK_BYTES", .value = "4096" },
+    });
+    try expectTlsLimitOverridesError(allocator, &.{
+        .{ .key = "TARDIGRADE_TLS_INBOUND_CIPHERTEXT_LOW_WATERMARK_BYTES", .value = "4096" },
+        .{ .key = "TARDIGRADE_TLS_INBOUND_CIPHERTEXT_HIGH_WATERMARK_BYTES", .value = "8192" },
+        .{ .key = "TARDIGRADE_TLS_INBOUND_CIPHERTEXT_HARD_LIMIT_BYTES", .value = "4096" },
+    });
+    try expectTlsLimitOverridesError(allocator, &.{
+        .{ .key = "TARDIGRADE_TLS_INBOUND_CIPHERTEXT_LOW_WATERMARK_BYTES", .value = "1" },
+        .{ .key = "TARDIGRADE_TLS_INBOUND_CIPHERTEXT_HIGH_WATERMARK_BYTES", .value = "2" },
+        .{ .key = "TARDIGRADE_TLS_INBOUND_CIPHERTEXT_HARD_LIMIT_BYTES", .value = "18446744073709551615" },
+    });
+    try expectTlsLimitOverridesError(allocator, &.{
+        .{ .key = "TARDIGRADE_TLS_OUTBOUND_CIPHERTEXT_LOW_WATERMARK_BYTES", .value = "1" },
+        .{ .key = "TARDIGRADE_TLS_OUTBOUND_CIPHERTEXT_HIGH_WATERMARK_BYTES", .value = "2" },
+        .{ .key = "TARDIGRADE_TLS_OUTBOUND_CIPHERTEXT_HARD_LIMIT_BYTES", .value = "3" },
+    });
 }
 
 test "parse upstream health success status overrides" {

--- a/src/edge_config.zig
+++ b/src/edge_config.zig
@@ -3,6 +3,9 @@ const builtin = @import("builtin");
 const build_options = @import("build_options");
 const compat = @import("zig_compat.zig");
 const http = @import("http.zig");
+const tls_core = @import("tls_core");
+
+const encrypted_stream = tls_core.encrypted_stream;
 
 var active_file_overrides: ?*const http.config_file.Overrides = null;
 var active_secret_overrides: ?*const http.secrets.Overrides = null;
@@ -397,6 +400,9 @@ pub const EdgeConfig = struct {
     /// Applied as SO_RCVTIMEO before SSL_accept to bound slow or stalled clients.
     /// 0 falls back to keep_alive_timeout_ms. Default: 5000.
     tls_handshake_timeout_ms: u32,
+    /// Runtime-effective TLS record-stream watermarks for the native pure-Zig
+    /// listener path. Defaults are derived from the fixed record-stream queues.
+    tls_buffer_limits: encrypted_stream.BufferLimits,
     /// Downstream write timeout in milliseconds (TARDIGRADE_DOWNSTREAM_WRITE_TIMEOUT_MS).
     /// Applied as SO_SNDTIMEO during response writes; distinct from read timeouts.
     /// 0 = no explicit write deadline. Default: 30000.
@@ -1176,6 +1182,7 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
 
     const request_total_timeout_ms = parseIntEnv(u32, allocator, "TARDIGRADE_REQUEST_TOTAL_TIMEOUT_MS", 0);
     const tls_handshake_timeout_ms = parseIntEnv(u32, allocator, "TARDIGRADE_TLS_HANDSHAKE_TIMEOUT_MS", 5_000);
+    const tls_buffer_limits = tlsBufferLimitsFromEnv(allocator);
     const downstream_write_timeout_ms = parseIntEnv(u32, allocator, "TARDIGRADE_DOWNSTREAM_WRITE_TIMEOUT_MS", 30_000);
 
     const max_req_conn_str = envOrDefault(allocator, "TARDIGRADE_MAX_REQUESTS_PER_CONNECTION", "100") catch unreachable;
@@ -1571,6 +1578,7 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
         .keep_alive_timeout_ms = keep_alive_timeout_ms,
         .request_total_timeout_ms = request_total_timeout_ms,
         .tls_handshake_timeout_ms = tls_handshake_timeout_ms,
+        .tls_buffer_limits = tls_buffer_limits,
         .downstream_write_timeout_ms = downstream_write_timeout_ms,
         .max_requests_per_connection = max_requests_per_connection,
         .connection_pool_size = connection_pool_size,
@@ -2589,7 +2597,6 @@ pub const is_appliance_tls_profile =
 /// present when TLS is enabled and the multi-identity `tls_sni_certs`
 /// mechanism is rejected.
 fn validateTlsServerNamePolicy(cfg: *const EdgeConfig) !void {
-    const tls_core = @import("tls_core");
     if (cfg.tls_server_name.len > 0) {
         tls_core.appliance_credentials.validateServerName(cfg.tls_server_name) catch {
             std.log.err("config validation failed: TARDIGRADE_TLS_SERVER_NAME must be a single non-wildcard DNS host name", .{});
@@ -2818,6 +2825,10 @@ pub fn validate(cfg: *const EdgeConfig) !void {
         std.log.err("config validation failed: TARDIGRADE_MAX_BUFFERED_UPSTREAM_RESPONSE_BYTES must be at least 1", .{});
         return error.InvalidConfigValue;
     };
+    cfg.tls_buffer_limits.validate() catch {
+        std.log.err("config validation failed: TLS buffer watermarks must satisfy low < high <= hard, fit native queue capacity, and preserve record/handshake reserves", .{});
+        return error.InvalidConfigValue;
+    };
     cfg.proxy_buffer_limits.validate() catch {
         std.log.err("config validation failed: proxy buffer watermarks must satisfy low < high <= hard and aggregate hard limits must be 0 or at least the per-stream hard limit", .{});
         return error.InvalidConfigValue;
@@ -2873,6 +2884,24 @@ fn validateUpstreamRetryAttempts(attempts: u32) !void {
 
 fn validateBufferedUpstreamResponseLimit(limit: usize) !void {
     if (limit == 0) return error.InvalidConfigValue;
+}
+
+fn tlsBufferLimitsFromEnv(allocator: std.mem.Allocator) encrypted_stream.BufferLimits {
+    const defaults = encrypted_stream.BufferLimits.defaults();
+    return .{
+        .inbound_ciphertext = tlsWatermarkFromEnv(allocator, "TARDIGRADE_TLS_INBOUND_CIPHERTEXT", defaults.inbound_ciphertext),
+        .inbound_plaintext = tlsWatermarkFromEnv(allocator, "TARDIGRADE_TLS_INBOUND_PLAINTEXT", defaults.inbound_plaintext),
+        .outbound_ciphertext = tlsWatermarkFromEnv(allocator, "TARDIGRADE_TLS_OUTBOUND_CIPHERTEXT", defaults.outbound_ciphertext),
+        .handshake = tlsWatermarkFromEnv(allocator, "TARDIGRADE_TLS_HANDSHAKE", defaults.handshake),
+    };
+}
+
+fn tlsWatermarkFromEnv(allocator: std.mem.Allocator, comptime prefix: []const u8, defaults: encrypted_stream.Watermark) encrypted_stream.Watermark {
+    return .{
+        .low = parseIntEnv(usize, allocator, prefix ++ "_LOW_WATERMARK_BYTES", defaults.low),
+        .high = parseIntEnv(usize, allocator, prefix ++ "_HIGH_WATERMARK_BYTES", defaults.high),
+        .hard = parseIntEnv(usize, allocator, prefix ++ "_HARD_LIMIT_BYTES", defaults.hard),
+    };
 }
 
 fn validateProxyStreamBufferSize(size: usize) !void {
@@ -3709,4 +3738,14 @@ test "proxy buffer limits validate low high hard ordering" {
         .per_origin_hard_limit = 512 * 1024,
         .global_hard_limit = 0,
     }).validate());
+}
+
+test "TLS buffer limits default from TLS core" {
+    const allocator = std.testing.allocator;
+    var cfg = try loadFromEnv(allocator);
+    defer cfg.deinit(allocator);
+
+    try std.testing.expectEqualDeep(encrypted_stream.BufferLimits.defaults(), cfg.tls_buffer_limits);
+    cfg.tls_buffer_limits.inbound_plaintext.low = cfg.tls_buffer_limits.inbound_plaintext.high;
+    try std.testing.expectError(error.InvalidBufferLimits, cfg.tls_buffer_limits.validate());
 }

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -11,6 +11,7 @@ const JSON_CONTENT_TYPE = "application/json";
 const HTTP2_PREFACE = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 const HTTP2_MAX_FRAME_SIZE: usize = 16 * 1024;
 const WS_MUX_MAX_CHANNELS: usize = 32;
+const ACTIVE_DRIVE_POLL_INTERVAL_MS: u64 = 250;
 /// Fallback approval TTL when no config value is provided (5 minutes).
 const APPROVAL_TIMEOUT_MS_DEFAULT: i64 = 300_000;
 
@@ -702,6 +703,7 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
             // Close keepalive connections idle longer than the keepalive timeout
             // while parked off the worker pool (#138).
             _ = parked.reapIdle(http.event_loop.monotonicMs(), current_cfg.keep_alive_timeout_ms);
+            dispatchDueActiveDrivePolls(&active, &state, &event_loop, &worker_pool);
             reapActiveConnections(&active, &state, &event_loop);
             // Evict idle upstream keep-alive connections past their idle/lifetime
             // caps (#141).
@@ -973,6 +975,7 @@ fn startNewConnection(ctx: *WorkerContext, client_fd: std.posix.fd_t) void {
             }
             return;
         };
+        tls_conn.attachBufferMetrics(&ctx.state.metrics, &ctx.state.metrics_mutex);
         // The TLS object now needs teardown on every exit; record it so the
         // teardown defer (or a failed park) frees it exactly once.
         tls_to_park = tls_conn;
@@ -991,9 +994,11 @@ fn startNewConnection(ctx: *WorkerContext, client_fd: std.posix.fd_t) void {
             return;
         };
         const dispatch_result = dispatchNegotiatedHttp(ctx, &tls_conn, negotiated, session, cfg, connection_ip, &served) catch |err| {
+            tls_to_park = tls_conn;
             ctx.state.logger.err(null, "negotiated HTTP dispatch error: {}", .{err});
             return;
         };
+        tls_to_park = tls_conn;
         if (dispatch_result == .park) {
             transferred = true;
             parkConnection(ctx, client_fd, session, tls_conn, served, connection_ip);
@@ -1253,16 +1258,45 @@ fn reapActiveConnections(
     }
 }
 
+fn dispatchDueActiveDrivePolls(
+    active: *http.downstream_connection.ActiveRegistry,
+    state: *GatewayState,
+    event_loop: *http.event_loop.EventLoop,
+    worker_pool: *http.worker_pool.WorkerPool,
+) void {
+    var fds: [32]std.posix.fd_t = undefined;
+    while (true) {
+        const count = active.dueDrivePollFds(http.event_loop.monotonicMs(), fds[0..]);
+        if (count == 0) break;
+        for (fds[0..count]) |fd| {
+            event_loop.remove(fd) catch {};
+            worker_pool.submit(fd) catch |err| {
+                state.logger.warn(null, "active connection drive-poll submit failed: {}", .{err});
+                if (active.checkout(fd)) |taken| {
+                    var conn = taken;
+                    conn.deinit();
+                }
+            };
+        }
+        if (count < fds.len) break;
+    }
+}
+
 fn rearmActiveConnection(ctx: *WorkerContext, managed: *http.downstream_connection.ManagedConnection, requested: http.event_loop.Interest) void {
     const fd = managed.fd;
-    if (managed.encryptedWaitFor(requested)) |wait| switch (wait) {
+    const now_ms = http.event_loop.monotonicMs();
+    if (managed.encryptedWaitForAt(requested, now_ms, ACTIVE_DRIVE_POLL_INTERVAL_MS)) |wait| switch (wait) {
         .ready_now => {
             advanceActiveConnection(ctx, managed);
             return;
         },
-        .socket, .stalled => {},
+        .socket, .retry_at_ms, .stalled => {},
     };
-    const interest = managed.updateInterestFor(requested);
+    const interest = switch (managed.updateWaitFor(requested, now_ms, ACTIVE_DRIVE_POLL_INTERVAL_MS) orelse
+        http.downstream_connection.EncryptedWait{ .socket = requested }) {
+        .socket => |socket_interest| socket_interest,
+        .ready_now, .retry_at_ms, .stalled => http.event_loop.Interest{},
+    };
     _ = ctx.active.rearm(managed) catch |err| {
         ctx.state.logger.warn(null, "active connection rearm failed: {}", .{err});
         managed.deinit();
@@ -1306,10 +1340,6 @@ fn advanceNativeHandshake(ctx: *WorkerContext, managed: *http.downstream_connect
         };
         if (native.record.applicationDataOpen()) break;
         if (!driven.made_progress) {
-            managed.phase.native_handshake.deadline_ms = deadlineFromNow(
-                http.event_loop.monotonicMs(),
-                managed.lifecycle.handshake_timeout_ms,
-            );
             rearmActiveConnection(ctx, managed, .{ .read = true });
             return;
         }
@@ -1363,6 +1393,9 @@ const WaitingEncryptedHttpConnection = struct {
     inner: http.encrypted_stream_connection.EncryptedStreamHttpConnection,
     read_timeout_ms: u32,
     write_timeout_ms: u32,
+    tls_metrics: ?*http.metrics.Metrics = null,
+    tls_metrics_mutex: ?*compat.Mutex = null,
+    tls_metrics_state: ?*http.metrics.TlsBufferConnectionMetrics = null,
 
     fn init(
         inner: http.encrypted_stream_connection.EncryptedStreamHttpConnection,
@@ -1376,15 +1409,45 @@ const WaitingEncryptedHttpConnection = struct {
         };
     }
 
+    fn initWithMetrics(
+        inner: http.encrypted_stream_connection.EncryptedStreamHttpConnection,
+        read_timeout_ms: u32,
+        write_timeout_ms: u32,
+        metrics: ?*http.metrics.Metrics,
+        metrics_mutex: ?*compat.Mutex,
+        metrics_state: ?*http.metrics.TlsBufferConnectionMetrics,
+    ) WaitingEncryptedHttpConnection {
+        var adapter = init(inner, read_timeout_ms, write_timeout_ms);
+        adapter.tls_metrics = metrics;
+        adapter.tls_metrics_mutex = metrics_mutex;
+        adapter.tls_metrics_state = metrics_state;
+        return adapter;
+    }
+
+    fn observeTlsBufferMetrics(self: *WaitingEncryptedHttpConnection) void {
+        const metrics = self.tls_metrics orelse return;
+        const mutex = self.tls_metrics_mutex orelse return;
+        const state = self.tls_metrics_state orelse return;
+        const snapshot = self.inner.bufferSnapshot();
+        const backend = self.inner.stream.backend();
+        mutex.lock();
+        defer mutex.unlock();
+        metrics.observeTlsBufferSnapshot(state, backend, snapshot) catch
+            @panic("TLS buffer accounting underflow");
+    }
+
     pub fn read(self: *WaitingEncryptedHttpConnection, out: []u8) !usize {
         while (true) {
-            return self.inner.read(out) catch |err| switch (err) {
+            const n = self.inner.read(out) catch |err| switch (err) {
                 error.WouldBlock => {
+                    self.observeTlsBufferMetrics();
                     try self.waitFor(.{ .read = true }, self.read_timeout_ms);
                     continue;
                 },
-                else => err,
+                else => return err,
             };
+            self.observeTlsBufferMetrics();
+            return n;
         }
     }
 
@@ -1392,11 +1455,13 @@ const WaitingEncryptedHttpConnection = struct {
         while (true) {
             const n = self.inner.write(bytes) catch |err| switch (err) {
                 error.WouldBlock => {
+                    self.observeTlsBufferMetrics();
                     try self.waitFor(.{ .write = true }, self.write_timeout_ms);
                     continue;
                 },
-                else => err,
+                else => return err,
             };
+            self.observeTlsBufferMetrics();
             try self.flush();
             return n;
         }
@@ -1406,11 +1471,13 @@ const WaitingEncryptedHttpConnection = struct {
         while (self.inner.readiness().wants_write) {
             self.inner.flush() catch |err| switch (err) {
                 error.WouldBlock => {
+                    self.observeTlsBufferMetrics();
                     try self.waitFor(.{ .write = true }, self.write_timeout_ms);
                     continue;
                 },
                 else => return err,
             };
+            self.observeTlsBufferMetrics();
         }
     }
 
@@ -1471,6 +1538,7 @@ const WaitingEncryptedHttpConnection = struct {
         const interest = switch (http.downstream_connection.encryptedWaitForInterest(readiness, requested)) {
             .ready_now => return,
             .socket => |socket_interest| socket_interest,
+            .retry_at_ms => return error.WouldBlock,
             .stalled => return error.WouldBlock,
         };
 
@@ -1505,10 +1573,13 @@ fn advanceNativeHttp1(ctx: *WorkerContext, managed: *http.downstream_connection.
         managed.deinit();
         return;
     };
-    var adapter = WaitingEncryptedHttpConnection.init(
+    var adapter = WaitingEncryptedHttpConnection.initWithMetrics(
         native.httpConnection(),
         managed.lifecycle.header_timeout_ms,
         managed.lifecycle.write_timeout_ms,
+        managed.lifecycle.metrics,
+        managed.lifecycle.metrics_mutex,
+        &managed.lifecycle.tls_buffer_metrics,
     );
     const connection_ip = managed.lifecycle.connectionIp();
     var served = switch (managed.phase) {
@@ -1532,6 +1603,7 @@ fn advanceNativeHttp1(ctx: *WorkerContext, managed: *http.downstream_connection.
                     managed.deinit();
                     return;
                 };
+                managed.observeTlsBufferMetrics();
                 if (adapter.pending() > 0 or managed.transport.pendingPlaintext() > 0) continue;
                 rearmActiveConnection(ctx, managed, .{ .read = true });
                 return;
@@ -1565,10 +1637,13 @@ fn advanceNativeHttp2(ctx: *WorkerContext, managed: *http.downstream_connection.
         return;
     };
 
-    var adapter = WaitingEncryptedHttpConnection.init(
+    var adapter = WaitingEncryptedHttpConnection.initWithMetrics(
         native.httpConnection(),
         managed.lifecycle.header_timeout_ms,
         managed.lifecycle.write_timeout_ms,
+        managed.lifecycle.metrics,
+        managed.lifecycle.metrics_mutex,
+        &managed.lifecycle.tls_buffer_metrics,
     );
     handleHttp2Connection(&adapter, session, cfg, ctx.state, managed.lifecycle.connectionIp()) catch |err| {
         if (isBenignDisconnect(err)) {

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -1,5 +1,6 @@
 const compat = @import("zig_compat.zig");
 const std = @import("std");
+const builtin = @import("builtin");
 const http = @import("http.zig");
 const edge_config = @import("edge_config.zig");
 const runtime_allocator = @import("runtime_allocator.zig");
@@ -39,6 +40,9 @@ const Http2PendingStream = gs.Http2PendingStream;
 const CommandLifecycleEntry = gs.CommandLifecycleEntry;
 const ApprovalEntry = gs.ApprovalEntry;
 const MuxResumeState = gs.MuxResumeState;
+
+const ActiveDrivePollRemoveFn = *const fn (*anyopaque, std.posix.fd_t) anyerror!void;
+const ActiveDrivePollSubmitFn = *const fn (*anyopaque, std.posix.fd_t) anyerror!void;
 
 pub fn run(cfg: *const edge_config.EdgeConfig) !void {
     const state_allocator = runtime_allocator.runtimeAllocator();
@@ -798,15 +802,38 @@ fn handleAcceptedClient(raw_ctx: *anyopaque, item: http.worker_pool.WorkItem) vo
             if (ctx.parked.checkout(fd)) |pc| resumeParkedConnection(ctx, pc);
         },
         .active_socket_ready, .active_drive_poll => |fd| {
-            var conn = ctx.active.checkout(fd) orelse return;
-            if (conn.expired(http.event_loop.monotonicMs())) {
-                ctx.state.logger.debug(null, "active native downstream connection deadline expired before worker dispatch fd={d}", .{fd});
-                conn.deinit();
-                return;
+            switch (checkoutActiveForWorkerAt(ctx.active, fd, http.event_loop.monotonicMs())) {
+                .missing => return,
+                .expired => {
+                    ctx.state.logger.debug(null, "active native downstream connection deadline expired before worker dispatch fd={d}", .{fd});
+                    return;
+                },
+                .ready => |conn| {
+                    var mutable = conn;
+                    advanceActiveConnection(ctx, &mutable);
+                },
             }
-            advanceActiveConnection(ctx, &conn);
         },
     }
+}
+
+const ActiveCheckoutResult = union(enum) {
+    missing,
+    expired,
+    ready: http.downstream_connection.ManagedConnection,
+};
+
+fn checkoutActiveForWorkerAt(
+    active: *http.downstream_connection.ActiveRegistry,
+    fd: std.posix.fd_t,
+    now_ms: u64,
+) ActiveCheckoutResult {
+    var conn = active.checkout(fd) orelse return .missing;
+    if (conn.expired(now_ms)) {
+        conn.deinit();
+        return .expired;
+    }
+    return .{ .ready = conn };
 }
 
 /// Outcome of serving one request on a keepalive HTTP/1.1 connection.
@@ -1268,13 +1295,33 @@ fn dispatchDueActiveDrivePolls(
     event_loop: *http.event_loop.EventLoop,
     worker_pool: *http.worker_pool.WorkerPool,
 ) void {
+    dispatchDueActiveDrivePollsAt(
+        active,
+        state,
+        http.event_loop.monotonicMs(),
+        event_loop,
+        removeActiveDrivePollFd,
+        worker_pool,
+        submitActiveDrivePollWork,
+    );
+}
+
+fn dispatchDueActiveDrivePollsAt(
+    active: *http.downstream_connection.ActiveRegistry,
+    state: *GatewayState,
+    now_ms: u64,
+    remove_ctx: *anyopaque,
+    remove_fn: ActiveDrivePollRemoveFn,
+    submit_ctx: *anyopaque,
+    submit_fn: ActiveDrivePollSubmitFn,
+) void {
     var fds: [32]std.posix.fd_t = undefined;
     while (true) {
-        const count = active.dueDrivePollFds(http.event_loop.monotonicMs(), fds[0..]);
+        const count = active.dueDrivePollFds(now_ms, fds[0..]);
         if (count == 0) break;
         for (fds[0..count]) |fd| {
-            event_loop.remove(fd) catch {};
-            worker_pool.submitActiveDrivePoll(fd) catch |err| {
+            remove_fn(remove_ctx, fd) catch {};
+            submit_fn(submit_ctx, fd) catch |err| {
                 state.logger.warn(null, "active connection drive-poll submit failed: {}", .{err});
                 if (active.checkout(fd)) |taken| {
                     var conn = taken;
@@ -1284,6 +1331,16 @@ fn dispatchDueActiveDrivePolls(
         }
         if (count < fds.len) break;
     }
+}
+
+fn removeActiveDrivePollFd(raw_ctx: *anyopaque, fd: std.posix.fd_t) !void {
+    const event_loop: *http.event_loop.EventLoop = @ptrCast(@alignCast(raw_ctx));
+    try event_loop.remove(fd);
+}
+
+fn submitActiveDrivePollWork(raw_ctx: *anyopaque, fd: std.posix.fd_t) !void {
+    const worker_pool: *http.worker_pool.WorkerPool = @ptrCast(@alignCast(raw_ctx));
+    try worker_pool.submitActiveDrivePoll(fd);
 }
 
 fn rearmActiveConnection(ctx: *WorkerContext, managed: *http.downstream_connection.ManagedConnection, requested: http.event_loop.Interest) void {
@@ -2671,6 +2728,296 @@ test "connection timeout helper resets read and write timeouts" {
     setConnTimeouts(&conn, 0, 0);
     try std.testing.expectEqual(@as(u32, 0), conn.read_timeout_ms);
     try std.testing.expectEqual(@as(u32, 0), conn.write_timeout_ms);
+}
+
+const GatewaySchedulerTestSubmit = struct {
+    submitted: usize = 0,
+    item: ?http.worker_pool.WorkItem = null,
+
+    fn submit(raw_ctx: *anyopaque, fd: std.posix.fd_t) !void {
+        const self: *GatewaySchedulerTestSubmit = @ptrCast(@alignCast(raw_ctx));
+        self.submitted += 1;
+        self.item = .{ .active_drive_poll = fd };
+    }
+};
+
+const GatewaySchedulerTestRemove = struct {
+    removed: usize = 0,
+    fd: std.posix.fd_t = -1,
+
+    fn remove(raw_ctx: *anyopaque, fd: std.posix.fd_t) !void {
+        const self: *GatewaySchedulerTestRemove = @ptrCast(@alignCast(raw_ctx));
+        self.removed += 1;
+        self.fd = fd;
+    }
+};
+
+const GatewaySchedulerCloseProbe = struct {
+    closes: usize = 0,
+    last_fd: std.posix.fd_t = -1,
+
+    fn close(raw_ctx: *anyopaque, fd: std.posix.fd_t) void {
+        const self: *GatewaySchedulerCloseProbe = @ptrCast(@alignCast(raw_ctx));
+        self.closes += 1;
+        self.last_fd = fd;
+    }
+};
+
+const GatewayTestFdCarrier = struct {
+    fd: std.posix.fd_t,
+
+    fn carrier(self: *GatewayTestFdCarrier) tls_core.encrypted_stream.Carrier {
+        return .{ .ptr = self, .readFn = read, .writeFn = write };
+    }
+
+    fn read(raw_ctx: *anyopaque, out: []u8) tls_core.encrypted_stream.Error!usize {
+        const self: *GatewayTestFdCarrier = @ptrCast(@alignCast(raw_ctx));
+        return gatewayTestReadFd(self.fd, out);
+    }
+
+    fn write(raw_ctx: *anyopaque, bytes: []const u8) tls_core.encrypted_stream.Error!usize {
+        const self: *GatewayTestFdCarrier = @ptrCast(@alignCast(raw_ctx));
+        return gatewayTestWriteFd(self.fd, bytes);
+    }
+};
+
+const GatewayPendingNative = struct {
+    allocator: std.mem.Allocator,
+    fd: std.posix.fd_t,
+    peer_fd: std.posix.fd_t,
+    mock: *tls_core.credentials.MockCredentialProvider,
+    client_entropy_source: tls_core.production_crypto.OsEntropy = .{},
+    client_provider: tls_core.production_crypto.Provider = undefined,
+    client_backend: tls_core.tls13_backend.Tls13Backend = undefined,
+    client_carrier: GatewayTestFdCarrier = undefined,
+    client_stream: tls_core.encrypted_stream.PureZigRecordStream = undefined,
+    native: *http.native_tls_connection.NativeTlsConnection,
+
+    fn create(allocator: std.mem.Allocator, pending_polls: usize) !*GatewayPendingNative {
+        const self = try allocator.create(GatewayPendingNative);
+        errdefer allocator.destroy(self);
+
+        const fds = try gatewayTestSocketPair();
+        errdefer gatewayTestCloseFd(fds[0]);
+        errdefer gatewayTestCloseFd(fds[1]);
+
+        const mock = try allocator.create(tls_core.credentials.MockCredentialProvider);
+        errdefer allocator.destroy(mock);
+        mock.* = tls_core.credentials.MockCredentialProvider.init(tls_core.credentials.testdata.identity());
+        mock.async_select = true;
+        mock.pending_polls = pending_polls;
+
+        const native = try http.native_tls_connection.NativeTlsConnection.create(
+            allocator,
+            fds[0],
+            .{ .http1_enabled = true, .http2_enabled = true },
+            mock.provider(),
+        );
+        errdefer native.destroy();
+
+        self.* = GatewayPendingNative{
+            .allocator = allocator,
+            .fd = fds[0],
+            .peer_fd = fds[1],
+            .mock = mock,
+            .native = native,
+        };
+        self.client_provider = tls_core.production_crypto.Provider.init(self.client_entropy_source.entropy());
+        self.client_backend = tls_core.tls13_backend.Tls13Backend.initClientWithOptions(
+            .{ .hello_random = [_]u8{0xc1} ** 32, .key_share_seed = [_]u8{0x11} ** 32 },
+            .{ .pinned_certificate = tls_core.tls13_backend.testdata.certificate_der },
+            .{ .record = .{ .alpn = tls_core.tls13_backend.recordAlpnPolicy("h2") } },
+            .{ .server_name = "tardigrade.test" },
+        );
+        self.client_carrier = .{ .fd = fds[1] };
+        self.client_stream = tls_core.encrypted_stream.PureZigRecordStream.initWithCarrierAndBackend(
+            .client,
+            self.client_provider.cryptoProvider(),
+            .tls_aes_128_gcm_sha256,
+            self.client_carrier.carrier(),
+            self.client_backend.backend(),
+        );
+
+        var rounds: usize = 0;
+        while (!native.backend.authPending()) : (rounds += 1) {
+            if (rounds >= 20) return error.Stalled;
+            const client_result = try self.client_stream.drive();
+            const server_result = try native.drive();
+            if (!client_result.made_progress and !server_result.made_progress) return error.Stalled;
+        }
+        try std.testing.expect(native.backend.authPending());
+        try std.testing.expectEqual(@as(usize, 1), self.mock.select_count);
+        return self;
+    }
+
+    fn deinitPeer(self: *GatewayPendingNative) void {
+        self.client_stream.deinit();
+        self.client_backend.deinit();
+        gatewayTestCloseFd(self.peer_fd);
+        const allocator = self.allocator;
+        allocator.destroy(self.mock);
+        self.* = undefined;
+        allocator.destroy(self);
+    }
+};
+
+test "gateway active-drive scheduler polls pending native auth and expires queued work without fd reuse (#355)" {
+    const allocator = std.testing.allocator;
+
+    const pending = try GatewayPendingNative.create(allocator, 2);
+    defer pending.deinitPeer();
+
+    var registry = http.downstream_connection.ActiveRegistry.init(allocator);
+    defer registry.deinit();
+
+    var close_probe = GatewaySchedulerCloseProbe{};
+    var managed = http.downstream_connection.ManagedConnection.init(
+        .{ .native = pending.native },
+        .{ .native_handshake = .{ .deadline_ms = 1_000 } },
+    );
+    managed.lifecycle.close_ctx = &close_probe;
+    managed.lifecycle.close_fn = GatewaySchedulerCloseProbe.close;
+    const wait = managed.updateWaitFor(.{ .read = true }, 100, ACTIVE_DRIVE_POLL_INTERVAL_MS) orelse
+        return error.TestExpectedEncryptedWait;
+    try std.testing.expectEqual(http.downstream_connection.EncryptedWait{ .retry_at_ms = 350 }, wait);
+    try registry.insert(&managed);
+
+    var state: GatewayState = undefined;
+    var remove_probe = GatewaySchedulerTestRemove{};
+    var submit_probe = GatewaySchedulerTestSubmit{};
+    dispatchDueActiveDrivePollsAt(&registry, &state, 349, &remove_probe, GatewaySchedulerTestRemove.remove, &submit_probe, GatewaySchedulerTestSubmit.submit);
+    try std.testing.expectEqual(@as(usize, 0), submit_probe.submitted);
+    try std.testing.expect(registry.contains(pending.fd));
+
+    dispatchDueActiveDrivePollsAt(&registry, &state, 350, &remove_probe, GatewaySchedulerTestRemove.remove, &submit_probe, GatewaySchedulerTestSubmit.submit);
+    try std.testing.expectEqual(@as(usize, 1), submit_probe.submitted);
+    try std.testing.expectEqual(http.worker_pool.WorkItem{ .active_drive_poll = pending.fd }, submit_probe.item.?);
+    try std.testing.expectEqual(pending.fd, remove_probe.fd);
+    try std.testing.expect(registry.contains(pending.fd));
+
+    var expired_out: [1]http.downstream_connection.ManagedConnection = undefined;
+    try std.testing.expectEqual(@as(usize, 0), registry.reapExpired(1_001, expired_out[0..]));
+
+    var ready = switch (checkoutActiveForWorkerAt(&registry, pending.fd, 600)) {
+        .ready => |conn| conn,
+        .missing, .expired => return error.TestExpectedReadyActiveConnection,
+    };
+    _ = try ready.transport.native.drive();
+    try std.testing.expect(ready.transport.native.backend.authPending());
+    try std.testing.expectEqual(@as(usize, 1), pending.mock.poll_count);
+    try std.testing.expectEqual(@as(usize, 0), close_probe.closes);
+    ready.deinit();
+
+    const expired_pending = try GatewayPendingNative.create(allocator, 5);
+    defer expired_pending.deinitPeer();
+    var expired_probe = GatewaySchedulerCloseProbe{};
+    var expired_managed = http.downstream_connection.ManagedConnection.init(
+        .{ .native = expired_pending.native },
+        .{ .native_handshake = .{ .deadline_ms = 1_000 } },
+    );
+    expired_managed.lifecycle.close_ctx = &expired_probe;
+    expired_managed.lifecycle.close_fn = GatewaySchedulerCloseProbe.close;
+    _ = expired_managed.updateWaitFor(.{ .read = true }, 100, ACTIVE_DRIVE_POLL_INTERVAL_MS);
+    try registry.insert(&expired_managed);
+
+    submit_probe = .{};
+    dispatchDueActiveDrivePollsAt(&registry, &state, 350, &remove_probe, GatewaySchedulerTestRemove.remove, &submit_probe, GatewaySchedulerTestSubmit.submit);
+    try std.testing.expectEqual(@as(usize, 1), submit_probe.submitted);
+    try std.testing.expectEqual(@as(usize, 0), registry.reapExpired(1_001, expired_out[0..]));
+
+    const stale_fd = expired_pending.fd;
+    try std.testing.expectEqual(ActiveCheckoutResult.expired, checkoutActiveForWorkerAt(&registry, stale_fd, 1_001));
+    try std.testing.expectEqual(@as(usize, 1), expired_probe.closes);
+    try std.testing.expectEqual(stale_fd, expired_probe.last_fd);
+    try std.testing.expectEqual(@as(usize, 1), expired_pending.mock.cancel_count);
+    try std.testing.expectEqual(@as(usize, 1), expired_pending.mock.op_release_count);
+
+    const reused = try gatewayTestSocketPair();
+    defer gatewayTestCloseFd(reused[1]);
+    defer gatewayTestCloseFd(stale_fd);
+    if (reused[0] != stale_fd) {
+        if (std.c.dup2(reused[0], stale_fd) < 0) return error.Dup2Failed;
+        gatewayTestCloseFd(reused[0]);
+    }
+    try std.testing.expectEqual(ActiveCheckoutResult.missing, checkoutActiveForWorkerAt(&registry, stale_fd, 1_001));
+    try std.testing.expectEqual(@as(usize, 1), expired_probe.closes);
+    _ = try gatewayTestWriteFd(stale_fd, "x");
+}
+
+fn gatewayTestSocketPair() ![2]std.posix.fd_t {
+    var fds: [2]std.posix.fd_t = undefined;
+    if (builtin.os.tag == .linux) {
+        const linux = std.os.linux;
+        const rc = linux.socketpair(linux.AF.UNIX, linux.SOCK.STREAM, 0, &fds);
+        if (linux.errno(rc) != .SUCCESS) return error.SocketPairFailed;
+    } else {
+        if (std.c.socketpair(std.posix.AF.UNIX, std.posix.SOCK.STREAM, 0, &fds) != 0) return error.SocketPairFailed;
+    }
+    errdefer gatewayTestCloseFd(fds[0]);
+    errdefer gatewayTestCloseFd(fds[1]);
+    try gatewayTestSetNonBlocking(fds[0]);
+    try gatewayTestSetNonBlocking(fds[1]);
+    return fds;
+}
+
+fn gatewayTestCloseFd(fd: std.posix.fd_t) void {
+    if (builtin.os.tag == .linux) {
+        _ = std.os.linux.close(fd);
+    } else {
+        _ = std.c.close(fd);
+    }
+}
+
+fn gatewayTestSetNonBlocking(fd: std.posix.fd_t) !void {
+    if (builtin.os.tag == .linux) {
+        const linux = std.os.linux;
+        const status_flags = linux.fcntl(fd, linux.F.GETFL, 0);
+        if (linux.errno(status_flags) != .SUCCESS) return error.FcntlFailed;
+        const nonblock: usize = @intCast(@as(u32, @bitCast(linux.O{ .NONBLOCK = true })));
+        const rc = linux.fcntl(fd, linux.F.SETFL, status_flags | nonblock);
+        if (linux.errno(rc) != .SUCCESS) return error.FcntlFailed;
+    } else {
+        const status_flags = std.c.fcntl(fd, std.c.F.GETFL, @as(c_int, 0));
+        if (status_flags < 0) return error.FcntlFailed;
+        const nonblock = @as(c_int, @bitCast(std.posix.O{ .NONBLOCK = true }));
+        if (std.c.fcntl(fd, std.c.F.SETFL, status_flags | nonblock) < 0) return error.FcntlFailed;
+    }
+}
+
+fn gatewayTestReadFd(fd: std.posix.fd_t, out: []u8) tls_core.encrypted_stream.Error!usize {
+    if (builtin.os.tag == .linux) {
+        const linux = std.os.linux;
+        const rc = linux.read(fd, out.ptr, out.len);
+        return switch (linux.errno(rc)) {
+            .SUCCESS => rc,
+            .AGAIN => error.WouldBlock,
+            else => error.SocketReadFailed,
+        };
+    }
+    const rc = std.c.read(fd, out.ptr, out.len);
+    if (rc < 0) {
+        if (std.posix.errno(rc) == .AGAIN) return error.WouldBlock;
+        return error.SocketReadFailed;
+    }
+    return @intCast(rc);
+}
+
+fn gatewayTestWriteFd(fd: std.posix.fd_t, bytes: []const u8) tls_core.encrypted_stream.Error!usize {
+    if (builtin.os.tag == .linux) {
+        const linux = std.os.linux;
+        const rc = linux.write(fd, bytes.ptr, bytes.len);
+        return switch (linux.errno(rc)) {
+            .SUCCESS => rc,
+            .AGAIN => error.WouldBlock,
+            else => error.SocketWriteFailed,
+        };
+    }
+    const rc = std.c.write(fd, bytes.ptr, bytes.len);
+    if (rc < 0) {
+        if (std.posix.errno(rc) == .AGAIN) return error.WouldBlock;
+        return error.SocketWriteFailed;
+    }
+    return @intCast(rc);
 }
 
 // Pull gateway_handlers (and its transitive imports, including

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -114,6 +114,7 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
         .connection_memory_estimate_bytes = if (cfg.max_connection_memory_bytes > 0) cfg.max_connection_memory_bytes else MAX_REQUEST_SIZE,
         .max_total_connection_memory_bytes = cfg.max_total_connection_memory_bytes,
         .proxy_buffer_limits = cfg.proxy_buffer_limits,
+        .tls_buffer_limits = cfg.tls_buffer_limits,
         .upstream_rr_index = 0,
         .upstream_backup_rr_index = 0,
         .lb_random_state = 0x9e3779b97f4a7c15 ^ @as(u64, @intCast(http.event_loop.monotonicMs())),
@@ -1008,11 +1009,12 @@ fn startNewConnection(ctx: *WorkerContext, client_fd: std.posix.fd_t) void {
             return;
         }
         const tls_protocol_policy = gprotocol_policy.listenerPolicyFromConfig(cfg);
-        const native = http.native_tls_connection.NativeTlsConnection.create(
+        const native = http.native_tls_connection.NativeTlsConnection.createWithOptions(
             ctx.state.allocator,
             client_fd,
             tls_protocol_policy,
             native_provider,
+            .{ .buffer_limits = cfg.tls_buffer_limits },
         ) catch |err| {
             ctx.state.logger.warn(null, "native tls connection setup failed: {}", .{err});
             return;
@@ -1033,6 +1035,8 @@ fn startNewConnection(ctx: *WorkerContext, client_fd: std.posix.fd_t) void {
             .release_config_fn = activeReleaseConfig,
             .close_ctx = ctx.state,
             .close_fn = activeConnectionCloseHook,
+            .metrics = &ctx.state.metrics,
+            .metrics_mutex = &ctx.state.metrics_mutex,
             .owned_ip = if (owned_connection_ip) |ip| @constCast(ip) else null,
             .allocator = ctx.state.allocator,
             .config_generation = cfg_lease.version.generation,
@@ -1251,12 +1255,20 @@ fn reapActiveConnections(
 
 fn rearmActiveConnection(ctx: *WorkerContext, managed: *http.downstream_connection.ManagedConnection, requested: http.event_loop.Interest) void {
     const fd = managed.fd;
+    if (managed.encryptedWaitFor(requested)) |wait| switch (wait) {
+        .ready_now => {
+            advanceActiveConnection(ctx, managed);
+            return;
+        },
+        .socket, .stalled => {},
+    };
     const interest = managed.updateInterestFor(requested);
     _ = ctx.active.rearm(managed) catch |err| {
         ctx.state.logger.warn(null, "active connection rearm failed: {}", .{err});
         managed.deinit();
         return;
     };
+    if (!interest.read and !interest.write) return;
     ctx.event_loop.add(fd, interest) catch |err| {
         ctx.state.logger.warn(null, "active connection event registration failed: {}", .{err});
         if (ctx.active.checkout(fd)) |taken| {
@@ -1456,8 +1468,11 @@ const WaitingEncryptedHttpConnection = struct {
 
     fn waitFor(self: *WaitingEncryptedHttpConnection, requested: http.event_loop.Interest, timeout_ms: u32) !void {
         const readiness = self.inner.readiness();
-        var interest = http.downstream_connection.combinedInterest(requested, readiness);
-        if (!interest.read and !interest.write) interest = requested;
+        const interest = switch (http.downstream_connection.encryptedWaitForInterest(readiness, requested)) {
+            .ready_now => return,
+            .socket => |socket_interest| socket_interest,
+            .stalled => return error.WouldBlock,
+        };
 
         var events: i16 = std.posix.POLL.ERR | std.posix.POLL.HUP;
         if (interest.read) events |= std.posix.POLL.IN;

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -1353,12 +1353,13 @@ fn rearmActiveConnection(ctx: *WorkerContext, managed: *http.downstream_connecti
         },
         .socket, .retry_at_ms, .stalled => {},
     };
-    const interest = switch (managed.updateWaitFor(requested, now_ms, ACTIVE_DRIVE_POLL_INTERVAL_MS) orelse
-        http.downstream_connection.EncryptedWait{ .socket = requested }) {
-        .socket => |socket_interest| socket_interest,
-        .ready_now, .retry_at_ms, .stalled => http.event_loop.Interest{},
-    };
-    _ = ctx.active.rearm(managed) catch |err| {
+    const interest = rearmActiveConnectionInRegistryAt(
+        ctx.active,
+        managed,
+        requested,
+        now_ms,
+        ACTIVE_DRIVE_POLL_INTERVAL_MS,
+    ) catch |err| {
         ctx.state.logger.warn(null, "active connection rearm failed: {}", .{err});
         managed.deinit();
         return;
@@ -1371,6 +1372,23 @@ fn rearmActiveConnection(ctx: *WorkerContext, managed: *http.downstream_connecti
             conn.deinit();
         }
     };
+}
+
+fn rearmActiveConnectionInRegistryAt(
+    active: *http.downstream_connection.ActiveRegistry,
+    managed: *http.downstream_connection.ManagedConnection,
+    requested: http.event_loop.Interest,
+    now_ms: u64,
+    retry_interval_ms: u64,
+) !http.event_loop.Interest {
+    const wait = managed.updateWaitFor(requested, now_ms, retry_interval_ms) orelse
+        http.downstream_connection.EncryptedWait{ .socket = requested };
+    const interest = switch (wait) {
+        .socket => |socket_interest| socket_interest,
+        .ready_now, .retry_at_ms, .stalled => http.event_loop.Interest{},
+    };
+    _ = try active.rearm(managed);
+    return interest;
 }
 
 fn advanceActiveConnection(ctx: *WorkerContext, managed: *http.downstream_connection.ManagedConnection) void {
@@ -2898,15 +2916,45 @@ test "gateway active-drive scheduler polls pending native auth and expires queue
     var expired_out: [1]http.downstream_connection.ManagedConnection = undefined;
     try std.testing.expectEqual(@as(usize, 0), registry.reapExpired(1_001, expired_out[0..]));
 
-    var ready = switch (checkoutActiveForWorkerAt(&registry, pending.fd, 600)) {
-        .ready => |conn| conn,
-        .missing, .expired => return error.TestExpectedReadyActiveConnection,
-    };
-    _ = try ready.transport.native.drive();
-    try std.testing.expect(ready.transport.native.backend.authPending());
-    try std.testing.expectEqual(@as(usize, 1), pending.mock.poll_count);
-    try std.testing.expectEqual(@as(usize, 0), close_probe.closes);
-    ready.deinit();
+    const poll_times = [_]u64{ 350, 600, 850 };
+    for (poll_times, 1..) |poll_time, expected_poll_count| {
+        var ready = switch (checkoutActiveForWorkerAt(&registry, pending.fd, poll_time)) {
+            .ready => |conn| conn,
+            .missing, .expired => return error.TestExpectedReadyActiveConnection,
+        };
+        try std.testing.expectEqual(@as(u64, 1_000), ready.phase.native_handshake.deadline_ms);
+
+        const driven = try ready.transport.native.drive();
+        try std.testing.expectEqual(expected_poll_count, pending.mock.poll_count);
+        try std.testing.expectEqual(@as(u64, 1_000), ready.phase.native_handshake.deadline_ms);
+        try std.testing.expectEqual(@as(usize, 0), close_probe.closes);
+
+        if (expected_poll_count < poll_times.len) {
+            try std.testing.expect(ready.transport.native.backend.authPending());
+            const interest = try rearmActiveConnectionInRegistryAt(
+                &registry,
+                &ready,
+                .{ .read = true },
+                poll_time,
+                ACTIVE_DRIVE_POLL_INTERVAL_MS,
+            );
+            try std.testing.expectEqual(http.event_loop.Interest{}, interest);
+
+            submit_probe = .{};
+            dispatchDueActiveDrivePollsAt(&registry, &state, poll_time + ACTIVE_DRIVE_POLL_INTERVAL_MS - 1, &remove_probe, GatewaySchedulerTestRemove.remove, &submit_probe, GatewaySchedulerTestSubmit.submit);
+            try std.testing.expectEqual(@as(usize, 0), submit_probe.submitted);
+            dispatchDueActiveDrivePollsAt(&registry, &state, poll_time + ACTIVE_DRIVE_POLL_INTERVAL_MS, &remove_probe, GatewaySchedulerTestRemove.remove, &submit_probe, GatewaySchedulerTestSubmit.submit);
+            try std.testing.expectEqual(@as(usize, 1), submit_probe.submitted);
+            try std.testing.expectEqual(http.worker_pool.WorkItem{ .active_drive_poll = pending.fd }, submit_probe.item.?);
+        } else {
+            try std.testing.expect(driven.made_progress);
+            try std.testing.expect(!ready.transport.native.backend.authPending());
+            try std.testing.expectEqual(@as(usize, 3), pending.mock.poll_count);
+            try std.testing.expectEqual(@as(usize, 1), pending.mock.op_release_count);
+            try std.testing.expectEqual(@as(usize, 0), pending.mock.cancel_count);
+            ready.deinit();
+        }
+    }
 
     const expired_pending = try GatewayPendingNative.create(allocator, 5);
     defer expired_pending.deinitPeer();
@@ -2942,6 +2990,178 @@ test "gateway active-drive scheduler polls pending native auth and expires queue
     try std.testing.expectEqual(ActiveCheckoutResult.missing, checkoutActiveForWorkerAt(&registry, stale_fd, 1_001));
     try std.testing.expectEqual(@as(usize, 1), expired_probe.closes);
     _ = try gatewayTestWriteFd(stale_fd, "x");
+}
+
+const GatewayMetricStream = struct {
+    snapshot: tls_core.encrypted_stream.BufferSnapshot = .{},
+    readiness_state: tls_core.encrypted_stream.Readiness = .{ .can_write_plaintext = true },
+    read_payload: []const u8 = "",
+    read_offset: usize = 0,
+    write_count: usize = 0,
+
+    fn stream(self: *GatewayMetricStream) tls_core.encrypted_stream.EncryptedStream {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    fn backend(_: *anyopaque) tls_core.encrypted_stream.BackendKind {
+        return .pure_zig_record;
+    }
+
+    fn read(raw_ctx: *anyopaque, out: []u8) tls_core.encrypted_stream.Error!usize {
+        const self: *GatewayMetricStream = @ptrCast(@alignCast(raw_ctx));
+        if (self.read_offset >= self.read_payload.len) return error.WouldBlock;
+        const n = @min(out.len, self.read_payload.len - self.read_offset);
+        @memcpy(out[0..n], self.read_payload[self.read_offset..][0..n]);
+        self.read_offset += n;
+        self.snapshot.current.inbound_plaintext = self.read_payload.len - self.read_offset;
+        self.readiness_state.can_read_plaintext = self.read_offset < self.read_payload.len;
+        return n;
+    }
+
+    fn write(raw_ctx: *anyopaque, bytes: []const u8) tls_core.encrypted_stream.Error!usize {
+        const self: *GatewayMetricStream = @ptrCast(@alignCast(raw_ctx));
+        self.write_count += 1;
+        return bytes.len;
+    }
+
+    fn close(_: *anyopaque) void {}
+
+    fn readiness(raw_ctx: *anyopaque) tls_core.encrypted_stream.Readiness {
+        const self: *GatewayMetricStream = @ptrCast(@alignCast(raw_ctx));
+        return self.readiness_state;
+    }
+
+    fn drive(raw_ctx: *anyopaque) tls_core.encrypted_stream.Error!tls_core.encrypted_stream.DriveResult {
+        const self: *GatewayMetricStream = @ptrCast(@alignCast(raw_ctx));
+        return .{ .made_progress = false, .readiness = self.readiness_state };
+    }
+
+    fn bufferSnapshot(raw_ctx: *anyopaque) tls_core.encrypted_stream.BufferSnapshot {
+        const self: *GatewayMetricStream = @ptrCast(@alignCast(raw_ctx));
+        return self.snapshot;
+    }
+
+    const vtable = tls_core.encrypted_stream.EncryptedStream.VTable{
+        .backendFn = backend,
+        .readFn = read,
+        .writeFn = write,
+        .closeFn = close,
+        .readinessFn = readiness,
+        .driveFn = drive,
+        .bufferSnapshotFn = bufferSnapshot,
+    };
+};
+
+test "waiting encrypted HTTP adapter records live HTTP/1 writer TLS gauge pause resume and teardown zero (#355)" {
+    const allocator = std.testing.allocator;
+    var metrics = http.metrics.Metrics.init();
+    var metrics_mutex = compat.Mutex{};
+    var metrics_state = http.metrics.TlsBufferConnectionMetrics{};
+    var fake = GatewayMetricStream{ .snapshot = .{
+        .current = .{ .outbound_ciphertext = 9 },
+        .pause_state = .{ .plaintext_write_paused = true },
+        .counters = .{ .plaintext_write_pauses = 1 },
+        .limits_enforced = true,
+        .limits = tls_core.encrypted_stream.BufferLimits.defaults(),
+    } };
+    const inner = http.encrypted_stream_connection.EncryptedStreamHttpConnection.init(fake.stream());
+    var adapter = WaitingEncryptedHttpConnection.initWithMetrics(
+        inner,
+        1,
+        1,
+        &metrics,
+        &metrics_mutex,
+        &metrics_state,
+    );
+
+    try std.testing.expectEqual(@as(usize, 9), try adapter.write("http-body"));
+    try std.testing.expectEqual(@as(usize, 1), fake.write_count);
+    {
+        const prom = try metrics.toPrometheus(allocator);
+        defer allocator.free(prom);
+        try std.testing.expect(std.mem.find(u8, prom, "tardigrade_tls_buffered_bytes_current{backend=\"pure_zig_record\",queue=\"outbound_ciphertext\"} 9\n") != null);
+        try std.testing.expect(std.mem.find(u8, prom, "tardigrade_tls_buffer_pause_events_total{backend=\"pure_zig_record\",direction=\"plaintext_write\"} 1\n") != null);
+    }
+
+    fake.snapshot = .{
+        .current = .{},
+        .pause_state = .{},
+        .counters = .{
+            .plaintext_write_pauses = 1,
+            .plaintext_write_resumes = 1,
+        },
+        .limits_enforced = true,
+        .limits = tls_core.encrypted_stream.BufferLimits.defaults(),
+    };
+    try std.testing.expectEqual(@as(usize, 5), try adapter.write("drain"));
+    {
+        const prom = try metrics.toPrometheus(allocator);
+        defer allocator.free(prom);
+        try std.testing.expect(std.mem.find(u8, prom, "tardigrade_tls_buffered_bytes_current{backend=\"pure_zig_record\",queue=\"outbound_ciphertext\"} 0\n") != null);
+        try std.testing.expect(std.mem.find(u8, prom, "tardigrade_tls_buffer_pause_events_total{backend=\"pure_zig_record\",direction=\"plaintext_write\"} 1\n") != null);
+        try std.testing.expect(std.mem.find(u8, prom, "tardigrade_tls_buffer_resume_events_total{backend=\"pure_zig_record\",direction=\"plaintext_write\"} 1\n") != null);
+    }
+
+    metrics_mutex.lock();
+    defer metrics_mutex.unlock();
+    try metrics.releaseTlsBufferSnapshot(&metrics_state);
+}
+
+test "waiting encrypted HTTP adapter records live HTTP/2 writer TLS metrics through frame serializer (#355)" {
+    const allocator = std.testing.allocator;
+    var metrics = http.metrics.Metrics.init();
+    var metrics_mutex = compat.Mutex{};
+    var metrics_state = http.metrics.TlsBufferConnectionMetrics{};
+    var fake = GatewayMetricStream{ .snapshot = .{
+        .current = .{ .outbound_ciphertext = 13 },
+        .pause_state = .{ .plaintext_write_paused = true },
+        .counters = .{ .plaintext_write_pauses = 1 },
+        .limits_enforced = true,
+        .limits = tls_core.encrypted_stream.BufferLimits.defaults(),
+    } };
+    const inner = http.encrypted_stream_connection.EncryptedStreamHttpConnection.init(fake.stream());
+    var adapter = WaitingEncryptedHttpConnection.initWithMetrics(
+        inner,
+        1,
+        1,
+        &metrics,
+        &metrics_mutex,
+        &metrics_state,
+    );
+
+    try http.http2_frame.writeSettings(allocator, adapter.writer(), &[_][2]u32{
+        .{ 0x3, 100 },
+        .{ 0x4, 1024 },
+    });
+    try std.testing.expect(fake.write_count > 0);
+    {
+        const prom = try metrics.toPrometheus(allocator);
+        defer allocator.free(prom);
+        try std.testing.expect(std.mem.find(u8, prom, "tardigrade_tls_buffered_bytes_current{backend=\"pure_zig_record\",queue=\"outbound_ciphertext\"} 13\n") != null);
+        try std.testing.expect(std.mem.find(u8, prom, "tardigrade_tls_buffer_pause_events_total{backend=\"pure_zig_record\",direction=\"plaintext_write\"} 1\n") != null);
+    }
+
+    fake.snapshot = .{
+        .current = .{},
+        .pause_state = .{},
+        .counters = .{
+            .plaintext_write_pauses = 1,
+            .plaintext_write_resumes = 1,
+        },
+        .limits_enforced = true,
+        .limits = tls_core.encrypted_stream.BufferLimits.defaults(),
+    };
+    try http.http2_frame.writeSettingsAck(adapter.writer());
+    {
+        const prom = try metrics.toPrometheus(allocator);
+        defer allocator.free(prom);
+        try std.testing.expect(std.mem.find(u8, prom, "tardigrade_tls_buffered_bytes_current{backend=\"pure_zig_record\",queue=\"outbound_ciphertext\"} 0\n") != null);
+        try std.testing.expect(std.mem.find(u8, prom, "tardigrade_tls_buffer_resume_events_total{backend=\"pure_zig_record\",direction=\"plaintext_write\"} 1\n") != null);
+    }
+
+    metrics_mutex.lock();
+    defer metrics_mutex.unlock();
+    try metrics.releaseTlsBufferSnapshot(&metrics_state);
 }
 
 fn gatewayTestSocketPair() ![2]std.posix.fd_t {

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -652,7 +652,8 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
             const ev = ready_events[i];
             if (active.contains(ev.fd)) {
                 event_loop.remove(ev.fd) catch {};
-                worker_pool.submit(ev.fd) catch |err| {
+                if (!active.reserveWork(ev.fd)) continue;
+                worker_pool.submitActiveSocketReady(ev.fd) catch |err| {
                     state.logger.warn(null, "active connection worker submit failed: {}", .{err});
                     if (active.checkout(ev.fd)) |taken| {
                         var conn = taken;
@@ -670,7 +671,7 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
                 // request and re-parks or closes. The connection slot acquired
                 // at accept stays held across the park/resume cycle.
                 event_loop.removeReadFd(ev.fd) catch {};
-                worker_pool.submit(ev.fd) catch {
+                worker_pool.submitParkedReady(ev.fd) catch {
                     if (parked.checkout(ev.fd)) |pc| parked.closeSlot(pc, .@"error");
                 };
             }
@@ -785,24 +786,27 @@ fn workerQueueWaitCallback(raw_ctx: *anyopaque, wait_ns: i64) void {
     state.metricsRecordWorkerQueueWaitNs(wait_ns);
 }
 
-fn handleAcceptedClient(raw_ctx: *anyopaque, client_fd: std.posix.fd_t) void {
+fn handleAcceptedClient(raw_ctx: *anyopaque, item: http.worker_pool.WorkItem) void {
     const ctx: *WorkerContext = @ptrCast(@alignCast(raw_ctx));
 
-    if (ctx.active.checkout(client_fd)) |taken| {
-        var conn = taken;
-        advanceActiveConnection(ctx, &conn);
-        return;
+    switch (item) {
+        .accepted => |client_fd| startNewConnection(ctx, client_fd),
+        .parked_ready => |fd| {
+            // Resume path (#138): the event loop dispatched a parked keepalive
+            // connection that became readable. Its session, TLS state, and
+            // connection slot are already owned by the parked registry.
+            if (ctx.parked.checkout(fd)) |pc| resumeParkedConnection(ctx, pc);
+        },
+        .active_socket_ready, .active_drive_poll => |fd| {
+            var conn = ctx.active.checkout(fd) orelse return;
+            if (conn.expired(http.event_loop.monotonicMs())) {
+                ctx.state.logger.debug(null, "active native downstream connection deadline expired before worker dispatch fd={d}", .{fd});
+                conn.deinit();
+                return;
+            }
+            advanceActiveConnection(ctx, &conn);
+        },
     }
-
-    // Resume path (#138): the event loop dispatched a parked keepalive
-    // connection that became readable. Its session, TLS state, and connection
-    // slot are already established and owned by the parked registry.
-    if (ctx.parked.checkout(client_fd)) |pc| {
-        resumeParkedConnection(ctx, pc);
-        return;
-    }
-
-    startNewConnection(ctx, client_fd);
 }
 
 /// Outcome of serving one request on a keepalive HTTP/1.1 connection.
@@ -1270,7 +1274,7 @@ fn dispatchDueActiveDrivePolls(
         if (count == 0) break;
         for (fds[0..count]) |fd| {
             event_loop.remove(fd) catch {};
-            worker_pool.submit(fd) catch |err| {
+            worker_pool.submitActiveDrivePoll(fd) catch |err| {
                 state.logger.warn(null, "active connection drive-poll submit failed: {}", .{err});
                 if (active.checkout(fd)) |taken| {
                     var conn = taken;

--- a/src/gateway_shutdown.zig
+++ b/src/gateway_shutdown.zig
@@ -313,6 +313,7 @@ pub fn applyReloadedRuntimeConfig(cfg: *const edge_config.EdgeConfig, state: *Ga
     state.max_total_connection_memory_bytes = cfg.max_total_connection_memory_bytes;
     state.connection_memory_estimate_bytes = if (cfg.max_connection_memory_bytes > 0) cfg.max_connection_memory_bytes else MAX_REQUEST_SIZE;
     state.proxy_buffer_limits = cfg.proxy_buffer_limits;
+    state.tls_buffer_limits = cfg.tls_buffer_limits;
     state.compression_config = .{
         .enabled = cfg.compression_enabled,
         .min_size = cfg.compression_min_size,
@@ -352,6 +353,7 @@ test "applyReloadedRuntimeConfig updates exported proxy buffer limits" {
         .per_origin_hard_limit = 2 * 1024 * 1024,
         .global_hard_limit = 4 * 1024 * 1024,
     };
+    cfg.tls_buffer_limits.outbound_ciphertext.high = cfg.tls_buffer_limits.outbound_ciphertext.low + 16;
 
     var state: GatewayState = undefined;
     state.allocator = allocator;
@@ -380,6 +382,7 @@ test "applyReloadedRuntimeConfig updates exported proxy buffer limits" {
         .per_origin_hard_limit = 0,
         .global_hard_limit = 0,
     };
+    state.tls_buffer_limits = @import("tls_core").encrypted_stream.BufferLimits.defaults();
     state.compression_config = .{};
     state.logger = http.logger.Logger.init(.info, "test");
     state.upstream_pool = http.upstream_pool.UpstreamPool.init(allocator, .{});
@@ -399,6 +402,9 @@ test "applyReloadedRuntimeConfig updates exported proxy buffer limits" {
     defer allocator.free(prom);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_config_limit_bytes{direction=\"upstream_to_downstream\",scope=\"stream\",limit=\"high\"} 393216\n") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_config_limit_bytes{direction=\"upstream_to_downstream\",scope=\"global\",limit=\"hard\"} 4194304\n") != null);
+    const tls_high = try std.fmt.allocPrint(allocator, "tardigrade_tls_buffer_config_limit_bytes{{queue=\"outbound_ciphertext\",limit=\"high\"}} {d}\n", .{cfg.tls_buffer_limits.outbound_ciphertext.high});
+    defer allocator.free(tls_high);
+    try std.testing.expect(std.mem.find(u8, prom, tls_high) != null);
 }
 
 /// Context passed to the background health-probe thread.

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -454,6 +454,7 @@ pub const GatewayState = struct {
     connection_memory_estimate_bytes: usize, // cfg-derived; updated on reload [runtime_mutex]
     max_total_connection_memory_bytes: usize, // cfg snapshot; updated on reload [runtime_mutex]
     proxy_buffer_limits: http.proxy_buffer_account.Limits, // cfg snapshot; updated on reload [runtime_mutex]
+    tls_buffer_limits: @import("tls_core").encrypted_stream.BufferLimits, // cfg snapshot for native TLS; updated on reload [runtime_mutex]
     upstream_rr_index: usize, // LB selection state [upstream_mutex]
     upstream_backup_rr_index: usize, // LB selection state [upstream_mutex]
     lb_random_state: u64, // LB selection state [upstream_mutex]
@@ -1700,8 +1701,10 @@ pub const GatewayState = struct {
         try combined.appendSlice(base);
         self.runtime_mutex.lock();
         const proxy_buffer_limits = self.proxy_buffer_limits;
+        const tls_buffer_limits = self.tls_buffer_limits;
         self.runtime_mutex.unlock();
         try appendProxyBufferConfigPrometheus(&combined, proxy_buffer_limits);
+        try appendTlsBufferConfigPrometheus(&combined, tls_buffer_limits);
         if (mux_snapshot.device_counts.len > 0) {
             try combined.appendSlice(
                 \\# HELP tardigrade_mux_device_channels Current active mux channels by device
@@ -1730,6 +1733,24 @@ pub const GatewayState = struct {
             try out.print("tardigrade_buffer_config_limit_bytes{{direction=\"{s}\",scope=\"stream\",limit=\"hard\"}} {d}\n", .{ direction, limits.per_stream_hard_limit });
             try out.print("tardigrade_buffer_config_limit_bytes{{direction=\"{s}\",scope=\"origin\",limit=\"hard\"}} {d}\n", .{ direction, limits.per_origin_hard_limit });
             try out.print("tardigrade_buffer_config_limit_bytes{{direction=\"{s}\",scope=\"global\",limit=\"hard\"}} {d}\n", .{ direction, limits.global_hard_limit });
+        }
+    }
+
+    fn appendTlsBufferConfigPrometheus(out: *std.array_list.Managed(u8), limits: @import("tls_core").encrypted_stream.BufferLimits) !void {
+        try out.appendSlice(
+            \\# HELP tardigrade_tls_buffer_config_limit_bytes Configured native TLS buffer limits in bytes
+            \\# TYPE tardigrade_tls_buffer_config_limit_bytes gauge
+            \\
+        );
+        inline for (.{
+            .{ "inbound_ciphertext", limits.inbound_ciphertext },
+            .{ "inbound_plaintext", limits.inbound_plaintext },
+            .{ "outbound_ciphertext", limits.outbound_ciphertext },
+            .{ "handshake", limits.handshake },
+        }) |entry| {
+            try out.print("tardigrade_tls_buffer_config_limit_bytes{{queue=\"{s}\",limit=\"low\"}} {d}\n", .{ entry[0], entry[1].low });
+            try out.print("tardigrade_tls_buffer_config_limit_bytes{{queue=\"{s}\",limit=\"high\"}} {d}\n", .{ entry[0], entry[1].high });
+            try out.print("tardigrade_tls_buffer_config_limit_bytes{{queue=\"{s}\",limit=\"hard\"}} {d}\n", .{ entry[0], entry[1].hard });
         }
     }
 
@@ -3158,6 +3179,7 @@ fn initSlotTestState(gs: *GatewayState, allocator: std.mem.Allocator) void {
         .per_origin_hard_limit = 0,
         .global_hard_limit = 0,
     };
+    gs.tls_buffer_limits = @import("tls_core").encrypted_stream.BufferLimits.defaults();
     gs.active_connections_by_ip = std.StringHashMap(u32).init(allocator);
     gs.active_fds = std.AutoHashMap(std.posix.fd_t, void).init(allocator);
     gs.fd_to_ip = std.AutoHashMap(std.posix.fd_t, []u8).init(allocator);
@@ -3423,6 +3445,7 @@ fn initMetricsJsonTestState(gs: *GatewayState, allocator: std.mem.Allocator) voi
         .per_origin_hard_limit = 0,
         .global_hard_limit = 0,
     };
+    gs.tls_buffer_limits = @import("tls_core").encrypted_stream.BufferLimits.defaults();
 }
 
 test "served metrics JSON exposes every counter the canonical serializer does" {
@@ -3477,6 +3500,7 @@ test "served Prometheus metrics expose h2 streaming upload fallback counter" {
     try std.testing.expect(std.mem.find(u8, prom, "# TYPE tardigrade_upstream_h2_streaming_upload_fallback_total counter") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_upstream_h2_streaming_upload_fallback_total 1\n") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_config_limit_bytes{direction=\"upstream_to_downstream\",scope=\"stream\",limit=\"high\"} 786432\n") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_tls_buffer_config_limit_bytes{queue=\"outbound_ciphertext\",limit=\"hard\"}") != null);
 }
 
 test "served Prometheus metrics reflect updated proxy buffer limit snapshot" {
@@ -3494,6 +3518,7 @@ test "served Prometheus metrics reflect updated proxy buffer limit snapshot" {
         .per_origin_hard_limit = 2 * 1024 * 1024,
         .global_hard_limit = 4 * 1024 * 1024,
     };
+    gs.tls_buffer_limits.outbound_ciphertext.high = gs.tls_buffer_limits.outbound_ciphertext.low + 16;
     gs.runtime_mutex.unlock();
 
     const prom = try gs.metricsToPrometheus(std.testing.allocator);

--- a/src/http/downstream_connection.zig
+++ b/src/http/downstream_connection.zig
@@ -27,6 +27,7 @@ pub const EncryptedOperation = enum {
 pub const EncryptedWait = union(enum) {
     ready_now,
     socket: event_loop.Interest,
+    retry_at_ms: u64,
     stalled,
 };
 
@@ -244,6 +245,7 @@ pub const ManagedConnection = struct {
         metrics: ?*metrics_mod.Metrics = null,
         metrics_mutex: ?*compat.Mutex = null,
         tls_buffer_metrics: metrics_mod.TlsBufferConnectionMetrics = .{},
+        drive_poll_due_ms: u64 = 0,
         owned_ip: ?[]u8 = null,
         allocator: ?std.mem.Allocator = null,
         config_generation: u64 = 0,
@@ -300,21 +302,45 @@ pub const ManagedConnection = struct {
     }
 
     pub fn updateInterestFor(self: *ManagedConnection, requested: event_loop.Interest) event_loop.Interest {
-        self.interest = switch (self.transport) {
-            .plaintext => requested,
-            else => switch (encryptedWaitForInterest(self.transport.readiness(), requested)) {
-                .socket => |interest| interest,
-                .ready_now, .stalled => .{},
-            },
-        };
-        self.observeTlsBufferMetrics();
+        _ = self.updateWaitFor(requested, 0, 0);
         return self.interest;
     }
 
+    pub fn updateWaitFor(
+        self: *ManagedConnection,
+        requested: event_loop.Interest,
+        now_ms: u64,
+        retry_interval_ms: u64,
+    ) ?EncryptedWait {
+        const wait: ?EncryptedWait = switch (self.transport) {
+            .plaintext => null,
+            else => encryptedWaitForInterestAt(self.transport.readiness(), requested, now_ms, retry_interval_ms),
+        };
+        self.interest = switch (wait orelse EncryptedWait{ .socket = requested }) {
+            .socket => |interest| interest,
+            .ready_now, .retry_at_ms, .stalled => .{},
+        };
+        self.lifecycle.drive_poll_due_ms = switch (wait orelse EncryptedWait{ .socket = requested }) {
+            .retry_at_ms => |due| due,
+            else => 0,
+        };
+        self.observeTlsBufferMetrics();
+        return wait;
+    }
+
     pub fn encryptedWaitFor(self: *ManagedConnection, requested: event_loop.Interest) ?EncryptedWait {
+        return self.encryptedWaitForAt(requested, 0, 0);
+    }
+
+    pub fn encryptedWaitForAt(
+        self: *ManagedConnection,
+        requested: event_loop.Interest,
+        now_ms: u64,
+        retry_interval_ms: u64,
+    ) ?EncryptedWait {
         return switch (self.transport) {
             .plaintext => null,
-            else => encryptedWaitForInterest(self.transport.readiness(), requested),
+            else => encryptedWaitForInterestAt(self.transport.readiness(), requested, now_ms, retry_interval_ms),
         };
     }
 
@@ -328,7 +354,7 @@ pub const ManagedConnection = struct {
         self.* = undefined;
     }
 
-    fn observeTlsBufferMetrics(self: *ManagedConnection) void {
+    pub fn observeTlsBufferMetrics(self: *ManagedConnection) void {
         const metrics = self.lifecycle.metrics orelse return;
         const mutex = self.lifecycle.metrics_mutex orelse return;
         var transport = self.transport;
@@ -336,15 +362,17 @@ pub const ManagedConnection = struct {
         const snapshot = stream.bufferSnapshot();
         mutex.lock();
         defer mutex.unlock();
-        metrics.observeTlsBufferSnapshot(&self.lifecycle.tls_buffer_metrics, stream.backend(), snapshot);
+        metrics.observeTlsBufferSnapshot(&self.lifecycle.tls_buffer_metrics, stream.backend(), snapshot) catch
+            @panic("TLS buffer accounting underflow");
     }
 
-    fn releaseTlsBufferMetrics(self: *ManagedConnection) void {
+    pub fn releaseTlsBufferMetrics(self: *ManagedConnection) void {
         const metrics = self.lifecycle.metrics orelse return;
         const mutex = self.lifecycle.metrics_mutex orelse return;
         mutex.lock();
         defer mutex.unlock();
-        metrics.releaseTlsBufferSnapshot(&self.lifecycle.tls_buffer_metrics);
+        metrics.releaseTlsBufferSnapshot(&self.lifecycle.tls_buffer_metrics) catch
+            @panic("TLS buffer accounting underflow");
     }
 
     pub fn expired(self: *const ManagedConnection, now_ms: u64) bool {
@@ -459,6 +487,24 @@ pub const ActiveRegistry = struct {
         }
         return out_len;
     }
+
+    pub fn dueDrivePollFds(self: *ActiveRegistry, now_ms: u64, out: []std.posix.fd_t) usize {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        var out_len: usize = 0;
+        var it = self.map.iterator();
+        while (it.next()) |entry| {
+            if (out_len >= out.len) break;
+            if (entry.value_ptr.expired(now_ms)) continue;
+            const due = entry.value_ptr.lifecycle.drive_poll_due_ms;
+            if (due == 0 or now_ms < due) continue;
+            entry.value_ptr.lifecycle.drive_poll_due_ms = 0;
+            out[out_len] = entry.key_ptr.*;
+            out_len += 1;
+        }
+        return out_len;
+    }
 };
 
 fn deinitPhase(phase: *ConnectionPhase) void {
@@ -471,6 +517,15 @@ fn deinitPhase(phase: *ConnectionPhase) void {
 }
 
 pub fn encryptedWait(readiness: encrypted_stream.Readiness, operation: EncryptedOperation) EncryptedWait {
+    return encryptedWaitAt(readiness, operation, 0, 0);
+}
+
+pub fn encryptedWaitAt(
+    readiness: encrypted_stream.Readiness,
+    operation: EncryptedOperation,
+    now_ms: u64,
+    retry_interval_ms: u64,
+) EncryptedWait {
     switch (operation) {
         .read_plaintext => if (readiness.can_read_plaintext) return .ready_now,
         .write_plaintext => if (readiness.can_write_plaintext) return .ready_now,
@@ -478,17 +533,29 @@ pub fn encryptedWait(readiness: encrypted_stream.Readiness, operation: Encrypted
     }
     const interest = native_tls_connection.interestForReadiness(readiness);
     if (interest.read or interest.write) return .{ .socket = interest };
+    if (retry_interval_ms > 0) {
+        return .{ .retry_at_ms = std.math.add(u64, now_ms, retry_interval_ms) catch std.math.maxInt(u64) };
+    }
     return .stalled;
 }
 
 pub fn encryptedWaitForInterest(readiness: encrypted_stream.Readiness, requested: event_loop.Interest) EncryptedWait {
+    return encryptedWaitForInterestAt(readiness, requested, 0, 0);
+}
+
+pub fn encryptedWaitForInterestAt(
+    readiness: encrypted_stream.Readiness,
+    requested: event_loop.Interest,
+    now_ms: u64,
+    retry_interval_ms: u64,
+) EncryptedWait {
     const operation: EncryptedOperation = if (requested.read and !requested.write)
         .read_plaintext
     else if (requested.write and !requested.read)
         .write_plaintext
     else
         .drive;
-    return encryptedWait(readiness, operation);
+    return encryptedWaitAt(readiness, operation, now_ms, retry_interval_ms);
 }
 
 fn closeFd(fd: std.posix.fd_t) void {
@@ -612,6 +679,28 @@ test "active registry reaps expired protocol deadlines" {
     try std.testing.expect(registry.contains(-2));
 }
 
+test "active registry returns due drive polls exactly once without extending deadlines" {
+    var registry = ActiveRegistry.init(std.testing.allocator);
+    defer registry.deinit();
+
+    var pending = ManagedConnection.init(
+        .{ .plaintext = -1 },
+        .{ .native_handshake = .{ .deadline_ms = 100 } },
+    );
+    pending.lifecycle.drive_poll_due_ms = 10;
+    try registry.insert(&pending);
+
+    var out: [2]std.posix.fd_t = undefined;
+    try std.testing.expectEqual(@as(usize, 0), registry.dueDrivePollFds(9, out[0..]));
+    try std.testing.expectEqual(@as(usize, 1), registry.dueDrivePollFds(10, out[0..]));
+    try std.testing.expectEqual(@as(std.posix.fd_t, -1), out[0]);
+    try std.testing.expectEqual(@as(usize, 0), registry.dueDrivePollFds(10, out[0..]));
+
+    var checked_out = registry.checkout(-1) orelse return error.TestExpectedConnection;
+    defer checked_out.deinit();
+    try std.testing.expectEqual(@as(u64, 100), checked_out.phase.native_handshake.deadline_ms);
+}
+
 test "managed connection preserves protocol write interest for plaintext wait-write" {
     const h1 = try Http1ConnectionState.init(std.testing.allocator, 1024);
     var managed = ManagedConnection.init(
@@ -651,6 +740,10 @@ test "encrypted wait maps blocked operations to TLS raw readiness only" {
     try std.testing.expectEqual(
         EncryptedWait.stalled,
         encryptedWaitForInterest(.{}, .{ .read = true }),
+    );
+    try std.testing.expectEqual(
+        EncryptedWait{ .retry_at_ms = 1250 },
+        encryptedWaitForInterestAt(.{}, .{ .read = true }, 1000, 250),
     );
 }
 

--- a/src/http/downstream_connection.zig
+++ b/src/http/downstream_connection.zig
@@ -284,6 +284,7 @@ pub const ManagedConnection = struct {
     transport: DownstreamTransport,
     phase: ConnectionPhase,
     interest: event_loop.Interest,
+    active_work_queued: bool = false,
     lifecycle: Lifecycle = .{},
 
     pub fn init(transport: DownstreamTransport, phase: ConnectionPhase) ManagedConnection {
@@ -411,6 +412,7 @@ pub const ActiveRegistry = struct {
 
         if (self.map.contains(conn.fd)) return error.DuplicateConnection;
         try self.map.ensureUnusedCapacity(1);
+        conn.active_work_queued = false;
         self.map.putAssumeCapacity(conn.fd, conn.*);
         conn.* = undefined;
     }
@@ -432,6 +434,15 @@ pub const ActiveRegistry = struct {
         const interest = conn.interest;
         try self.insert(conn);
         return interest;
+    }
+
+    pub fn reserveWork(self: *ActiveRegistry, fd: std.posix.fd_t) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const conn = self.map.getPtr(fd) orelse return false;
+        if (conn.active_work_queued) return false;
+        conn.active_work_queued = true;
+        return true;
     }
 
     pub fn close(self: *ActiveRegistry, fd: std.posix.fd_t) bool {
@@ -476,6 +487,7 @@ pub const ActiveRegistry = struct {
             var expired_fd: ?std.posix.fd_t = null;
             var it = self.map.iterator();
             while (it.next()) |entry| {
+                if (entry.value_ptr.active_work_queued) continue;
                 if (!entry.value_ptr.expired(now_ms)) continue;
                 expired_fd = entry.key_ptr.*;
                 break;
@@ -497,9 +509,11 @@ pub const ActiveRegistry = struct {
         while (it.next()) |entry| {
             if (out_len >= out.len) break;
             if (entry.value_ptr.expired(now_ms)) continue;
+            if (entry.value_ptr.active_work_queued) continue;
             const due = entry.value_ptr.lifecycle.drive_poll_due_ms;
             if (due == 0 or now_ms < due) continue;
             entry.value_ptr.lifecycle.drive_poll_due_ms = 0;
+            entry.value_ptr.active_work_queued = true;
             out[out_len] = entry.key_ptr.*;
             out_len += 1;
         }
@@ -695,10 +709,35 @@ test "active registry returns due drive polls exactly once without extending dea
     try std.testing.expectEqual(@as(usize, 1), registry.dueDrivePollFds(10, out[0..]));
     try std.testing.expectEqual(@as(std.posix.fd_t, -1), out[0]);
     try std.testing.expectEqual(@as(usize, 0), registry.dueDrivePollFds(10, out[0..]));
+    var expired: [1]ManagedConnection = undefined;
+    try std.testing.expectEqual(@as(usize, 0), registry.reapExpired(101, expired[0..]));
 
     var checked_out = registry.checkout(-1) orelse return error.TestExpectedConnection;
     defer checked_out.deinit();
     try std.testing.expectEqual(@as(u64, 100), checked_out.phase.native_handshake.deadline_ms);
+    try std.testing.expect(checked_out.expired(101));
+}
+
+test "active registry reserves socket-ready work and skips duplicate queueing" {
+    var registry = ActiveRegistry.init(std.testing.allocator);
+    defer registry.deinit();
+
+    var managed = ManagedConnection.init(
+        .{ .plaintext = -1 },
+        .{ .native_handshake = .{ .deadline_ms = 10 } },
+    );
+    try registry.insert(&managed);
+
+    try std.testing.expect(registry.reserveWork(-1));
+    try std.testing.expect(!registry.reserveWork(-1));
+    try std.testing.expect(!registry.reserveWork(-2));
+
+    var expired: [1]ManagedConnection = undefined;
+    try std.testing.expectEqual(@as(usize, 0), registry.reapExpired(11, expired[0..]));
+
+    var checked_out = registry.checkout(-1) orelse return error.TestExpectedConnection;
+    defer checked_out.deinit();
+    try std.testing.expect(checked_out.expired(11));
 }
 
 test "managed connection preserves protocol write interest for plaintext wait-write" {

--- a/src/http/downstream_connection.zig
+++ b/src/http/downstream_connection.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const tls_core = @import("tls_core");
 const compat = @import("../zig_compat.zig");
 const event_loop = @import("event_loop.zig");
+const metrics_mod = @import("metrics.zig");
 const native_tls_connection = @import("native_tls_connection.zig");
 const request_mod = @import("request.zig");
 const response_mod = @import("response.zig");
@@ -15,6 +16,18 @@ pub const RuntimeOutcome = union(enum) {
     wait: event_loop.Interest,
     idle_keepalive,
     close,
+};
+
+pub const EncryptedOperation = enum {
+    read_plaintext,
+    write_plaintext,
+    drive,
+};
+
+pub const EncryptedWait = union(enum) {
+    ready_now,
+    socket: event_loop.Interest,
+    stalled,
 };
 
 pub const OpenSslTransport = struct {
@@ -228,6 +241,9 @@ pub const ManagedConnection = struct {
         release_config_fn: ?*const fn (*anyopaque, *anyopaque) void = null,
         close_ctx: ?*anyopaque = null,
         close_fn: ?*const fn (*anyopaque, std.posix.fd_t) void = null,
+        metrics: ?*metrics_mod.Metrics = null,
+        metrics_mutex: ?*compat.Mutex = null,
+        tls_buffer_metrics: metrics_mod.TlsBufferConnectionMetrics = .{},
         owned_ip: ?[]u8 = null,
         allocator: ?std.mem.Allocator = null,
         config_generation: u64 = 0,
@@ -286,17 +302,49 @@ pub const ManagedConnection = struct {
     pub fn updateInterestFor(self: *ManagedConnection, requested: event_loop.Interest) event_loop.Interest {
         self.interest = switch (self.transport) {
             .plaintext => requested,
-            else => combinedInterest(requested, self.transport.readiness()),
+            else => switch (encryptedWaitForInterest(self.transport.readiness(), requested)) {
+                .socket => |interest| interest,
+                .ready_now, .stalled => .{},
+            },
         };
+        self.observeTlsBufferMetrics();
         return self.interest;
+    }
+
+    pub fn encryptedWaitFor(self: *ManagedConnection, requested: event_loop.Interest) ?EncryptedWait {
+        return switch (self.transport) {
+            .plaintext => null,
+            else => encryptedWaitForInterest(self.transport.readiness(), requested),
+        };
     }
 
     pub fn deinit(self: *ManagedConnection) void {
         const fd = self.fd;
+        self.observeTlsBufferMetrics();
+        self.releaseTlsBufferMetrics();
         deinitPhase(&self.phase);
         self.transport.deinit();
         self.lifecycle.deinit(fd);
         self.* = undefined;
+    }
+
+    fn observeTlsBufferMetrics(self: *ManagedConnection) void {
+        const metrics = self.lifecycle.metrics orelse return;
+        const mutex = self.lifecycle.metrics_mutex orelse return;
+        var transport = self.transport;
+        const stream = transport.encryptedStream() orelse return;
+        const snapshot = stream.bufferSnapshot();
+        mutex.lock();
+        defer mutex.unlock();
+        metrics.observeTlsBufferSnapshot(&self.lifecycle.tls_buffer_metrics, stream.backend(), snapshot);
+    }
+
+    fn releaseTlsBufferMetrics(self: *ManagedConnection) void {
+        const metrics = self.lifecycle.metrics orelse return;
+        const mutex = self.lifecycle.metrics_mutex orelse return;
+        mutex.lock();
+        defer mutex.unlock();
+        metrics.releaseTlsBufferSnapshot(&self.lifecycle.tls_buffer_metrics);
     }
 
     pub fn expired(self: *const ManagedConnection, now_ms: u64) bool {
@@ -422,11 +470,25 @@ fn deinitPhase(phase: *ConnectionPhase) void {
     phase.* = .idle_http1;
 }
 
-pub fn combinedInterest(requested: event_loop.Interest, readiness: encrypted_stream.Readiness) event_loop.Interest {
-    return .{
-        .read = requested.read or readiness.wants_read,
-        .write = requested.write or readiness.wants_write,
-    };
+pub fn encryptedWait(readiness: encrypted_stream.Readiness, operation: EncryptedOperation) EncryptedWait {
+    switch (operation) {
+        .read_plaintext => if (readiness.can_read_plaintext) return .ready_now,
+        .write_plaintext => if (readiness.can_write_plaintext) return .ready_now,
+        .drive => {},
+    }
+    const interest = native_tls_connection.interestForReadiness(readiness);
+    if (interest.read or interest.write) return .{ .socket = interest };
+    return .stalled;
+}
+
+pub fn encryptedWaitForInterest(readiness: encrypted_stream.Readiness, requested: event_loop.Interest) EncryptedWait {
+    const operation: EncryptedOperation = if (requested.read and !requested.write)
+        .read_plaintext
+    else if (requested.write and !requested.read)
+        .write_plaintext
+    else
+        .drive;
+    return encryptedWait(readiness, operation);
 }
 
 fn closeFd(fd: std.posix.fd_t) void {
@@ -573,14 +635,22 @@ test "native http1 managed phase does not allocate request buffer state" {
     try std.testing.expectEqual(@as(u32, 1), managed.phase.native_http1.served);
 }
 
-test "combined interest keeps phase demand and TLS carrier readiness" {
+test "encrypted wait maps blocked operations to TLS raw readiness only" {
     try std.testing.expectEqual(
-        event_loop.Interest{ .read = true, .write = true },
-        combinedInterest(.{ .read = true }, .{ .wants_write = true }),
+        EncryptedWait{ .socket = .{ .write = true } },
+        encryptedWaitForInterest(.{ .wants_write = true }, .{ .read = true }),
     );
     try std.testing.expectEqual(
-        event_loop.Interest{ .read = true, .write = true },
-        combinedInterest(.{ .write = true }, .{ .wants_read = true }),
+        EncryptedWait{ .socket = .{ .read = true } },
+        encryptedWaitForInterest(.{ .wants_read = true }, .{ .write = true }),
+    );
+    try std.testing.expectEqual(
+        EncryptedWait.ready_now,
+        encryptedWaitForInterest(.{ .can_read_plaintext = true }, .{ .read = true }),
+    );
+    try std.testing.expectEqual(
+        EncryptedWait.stalled,
+        encryptedWaitForInterest(.{}, .{ .read = true }),
     );
 }
 

--- a/src/http/metrics.zig
+++ b/src/http/metrics.zig
@@ -1,6 +1,21 @@
 const std = @import("std");
 const compat = @import("../zig_compat.zig");
 const proxy_buffer_account = @import("proxy_buffer_account.zig");
+const encrypted_stream = @import("tls_core").encrypted_stream;
+
+pub const TlsBufferConnectionMetrics = struct {
+    active: bool = false,
+    backend: encrypted_stream.BackendKind = .openssl,
+    current: encrypted_stream.QueueBytes = .{},
+    counters: encrypted_stream.BufferCounters = .{},
+};
+
+const tls_backend_count = 2;
+const tls_queue_count = 4;
+const tls_direction_count = 2;
+
+const TlsQueue = enum { inbound_ciphertext, inbound_plaintext, outbound_ciphertext, handshake };
+const TlsDirection = enum { carrier_read, plaintext_write };
 
 /// Server-wide metrics counters.
 ///
@@ -43,6 +58,11 @@ pub const Metrics = struct {
     proxy_buffer_read_pauses_upstream: u64,
     proxy_buffer_read_resumes_downstream: u64,
     proxy_buffer_read_resumes_upstream: u64,
+    tls_buffered_bytes_current: [tls_backend_count][tls_queue_count]u64,
+    tls_buffer_pause_events: [tls_backend_count][tls_direction_count]u64,
+    tls_buffer_resume_events: [tls_backend_count][tls_direction_count]u64,
+    tls_buffer_limit_exceeded: [tls_backend_count][tls_queue_count]u64,
+    tls_buffer_stalled_drives: [tls_backend_count]u64,
     proxy_client_aborts: u64,
     proxy_upstream_aborts: u64,
     proxy_streaming_fallback_policy_disabled: u64,
@@ -163,6 +183,11 @@ pub const Metrics = struct {
             .proxy_buffer_read_pauses_upstream = 0,
             .proxy_buffer_read_resumes_downstream = 0,
             .proxy_buffer_read_resumes_upstream = 0,
+            .tls_buffered_bytes_current = zeroTlsQueueMatrix(),
+            .tls_buffer_pause_events = zeroTlsDirectionMatrix(),
+            .tls_buffer_resume_events = zeroTlsDirectionMatrix(),
+            .tls_buffer_limit_exceeded = zeroTlsQueueMatrix(),
+            .tls_buffer_stalled_drives = .{0} ** tls_backend_count,
             .proxy_client_aborts = 0,
             .proxy_upstream_aborts = 0,
             .proxy_streaming_fallback_policy_disabled = 0,
@@ -425,6 +450,67 @@ pub const Metrics = struct {
         } else if (std.mem.eql(u8, side, "upstream")) {
             self.proxy_buffer_read_resumes_upstream += 1;
         }
+    }
+
+    pub fn observeTlsBufferSnapshot(
+        self: *Metrics,
+        state: *TlsBufferConnectionMetrics,
+        backend: encrypted_stream.BackendKind,
+        snapshot: encrypted_stream.BufferSnapshot,
+    ) void {
+        if (state.active) self.releaseTlsCurrentBytes(state.backend, state.current);
+        self.recordTlsCurrentBytes(backend, snapshot.current);
+        if (state.active and state.backend == backend) {
+            self.recordTlsCounterDeltas(backend, state.counters, snapshot.counters);
+        } else {
+            self.recordTlsCounterDeltas(backend, .{}, snapshot.counters);
+        }
+        state.* = .{
+            .active = true,
+            .backend = backend,
+            .current = snapshot.current,
+            .counters = snapshot.counters,
+        };
+    }
+
+    pub fn releaseTlsBufferSnapshot(self: *Metrics, state: *TlsBufferConnectionMetrics) void {
+        if (!state.active) return;
+        self.releaseTlsCurrentBytes(state.backend, state.current);
+        state.* = .{};
+    }
+
+    fn recordTlsCurrentBytes(self: *Metrics, backend: encrypted_stream.BackendKind, current: encrypted_stream.QueueBytes) void {
+        const backend_idx = tlsBackendIndex(backend);
+        self.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.inbound_ciphertext)] += @intCast(current.inbound_ciphertext);
+        self.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.inbound_plaintext)] += @intCast(current.inbound_plaintext);
+        self.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.outbound_ciphertext)] += @intCast(current.outbound_ciphertext);
+        self.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.handshake)] += @intCast(current.handshake);
+    }
+
+    fn releaseTlsCurrentBytes(self: *Metrics, backend: encrypted_stream.BackendKind, current: encrypted_stream.QueueBytes) void {
+        const backend_idx = tlsBackendIndex(backend);
+        subtractGauge(&self.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.inbound_ciphertext)], current.inbound_ciphertext);
+        subtractGauge(&self.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.inbound_plaintext)], current.inbound_plaintext);
+        subtractGauge(&self.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.outbound_ciphertext)], current.outbound_ciphertext);
+        subtractGauge(&self.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.handshake)], current.handshake);
+    }
+
+    fn recordTlsCounterDeltas(
+        self: *Metrics,
+        backend: encrypted_stream.BackendKind,
+        previous: encrypted_stream.BufferCounters,
+        next: encrypted_stream.BufferCounters,
+    ) void {
+        const backend_idx = tlsBackendIndex(backend);
+        self.tls_buffer_pause_events[backend_idx][tlsDirectionIndex(.carrier_read)] += monotonicDelta(previous.inbound_read_pauses, next.inbound_read_pauses);
+        self.tls_buffer_resume_events[backend_idx][tlsDirectionIndex(.carrier_read)] += monotonicDelta(previous.inbound_read_resumes, next.inbound_read_resumes);
+        self.tls_buffer_pause_events[backend_idx][tlsDirectionIndex(.plaintext_write)] += monotonicDelta(previous.plaintext_write_pauses, next.plaintext_write_pauses);
+        self.tls_buffer_resume_events[backend_idx][tlsDirectionIndex(.plaintext_write)] += monotonicDelta(previous.plaintext_write_resumes, next.plaintext_write_resumes);
+        self.tls_buffer_limit_exceeded[backend_idx][tlsQueueIndex(.inbound_ciphertext)] += monotonicDelta(previous.hard_limits.inbound_ciphertext, next.hard_limits.inbound_ciphertext);
+        self.tls_buffer_limit_exceeded[backend_idx][tlsQueueIndex(.inbound_plaintext)] += monotonicDelta(previous.hard_limits.inbound_plaintext, next.hard_limits.inbound_plaintext);
+        self.tls_buffer_limit_exceeded[backend_idx][tlsQueueIndex(.outbound_ciphertext)] += monotonicDelta(previous.hard_limits.outbound_ciphertext, next.hard_limits.outbound_ciphertext);
+        self.tls_buffer_limit_exceeded[backend_idx][tlsQueueIndex(.handshake)] += monotonicDelta(previous.hard_limits.handshake, next.hard_limits.handshake);
+        self.tls_buffer_stalled_drives[backend_idx] += monotonicDelta(previous.stalled_drives, next.stalled_drives);
     }
 
     pub fn recordProxyClientAbort(self: *Metrics) void {
@@ -703,6 +789,8 @@ pub const Metrics = struct {
             self.proxy_buffer_limit_exceeded_upstream_to_downstream_stream,
         });
 
+        try self.appendTlsBufferPrometheus(&out);
+
         try out.print(
             \\# HELP tardigrade_proxy_client_aborts_total Total proxied transfers aborted by downstream clients
             \\# TYPE tardigrade_proxy_client_aborts_total counter
@@ -934,6 +1022,76 @@ pub const Metrics = struct {
         return out.toOwnedSlice();
     }
 
+    fn appendTlsBufferPrometheus(self: *const Metrics, out: *std.array_list.Managed(u8)) !void {
+        try out.appendSlice(
+            \\# HELP tardigrade_tls_buffered_bytes_current Current TLS-owned or adapter-measurable bytes by backend and queue
+            \\# TYPE tardigrade_tls_buffered_bytes_current gauge
+            \\
+        );
+        inline for (.{ encrypted_stream.BackendKind.openssl, encrypted_stream.BackendKind.pure_zig_record }) |backend| {
+            inline for (.{ TlsQueue.inbound_ciphertext, TlsQueue.inbound_plaintext, TlsQueue.outbound_ciphertext, TlsQueue.handshake }) |queue| {
+                try out.print("tardigrade_tls_buffered_bytes_current{{backend=\"{s}\",queue=\"{s}\"}} {d}\n", .{
+                    tlsBackendLabel(backend),
+                    tlsQueueLabel(queue),
+                    self.tls_buffered_bytes_current[tlsBackendIndex(backend)][tlsQueueIndex(queue)],
+                });
+            }
+        }
+        try out.appendSlice(
+            \\# HELP tardigrade_tls_buffer_pause_events_total TLS buffer pause transitions by backend and direction
+            \\# TYPE tardigrade_tls_buffer_pause_events_total counter
+            \\
+        );
+        inline for (.{ encrypted_stream.BackendKind.openssl, encrypted_stream.BackendKind.pure_zig_record }) |backend| {
+            inline for (.{ TlsDirection.carrier_read, TlsDirection.plaintext_write }) |direction| {
+                try out.print("tardigrade_tls_buffer_pause_events_total{{backend=\"{s}\",direction=\"{s}\"}} {d}\n", .{
+                    tlsBackendLabel(backend),
+                    tlsDirectionLabel(direction),
+                    self.tls_buffer_pause_events[tlsBackendIndex(backend)][tlsDirectionIndex(direction)],
+                });
+            }
+        }
+        try out.appendSlice(
+            \\# HELP tardigrade_tls_buffer_resume_events_total TLS buffer resume transitions by backend and direction
+            \\# TYPE tardigrade_tls_buffer_resume_events_total counter
+            \\
+        );
+        inline for (.{ encrypted_stream.BackendKind.openssl, encrypted_stream.BackendKind.pure_zig_record }) |backend| {
+            inline for (.{ TlsDirection.carrier_read, TlsDirection.plaintext_write }) |direction| {
+                try out.print("tardigrade_tls_buffer_resume_events_total{{backend=\"{s}\",direction=\"{s}\"}} {d}\n", .{
+                    tlsBackendLabel(backend),
+                    tlsDirectionLabel(direction),
+                    self.tls_buffer_resume_events[tlsBackendIndex(backend)][tlsDirectionIndex(direction)],
+                });
+            }
+        }
+        try out.appendSlice(
+            \\# HELP tardigrade_tls_buffer_limit_exceeded_total TLS buffer hard-limit exceedance events by backend and queue
+            \\# TYPE tardigrade_tls_buffer_limit_exceeded_total counter
+            \\
+        );
+        inline for (.{ encrypted_stream.BackendKind.openssl, encrypted_stream.BackendKind.pure_zig_record }) |backend| {
+            inline for (.{ TlsQueue.inbound_ciphertext, TlsQueue.inbound_plaintext, TlsQueue.outbound_ciphertext, TlsQueue.handshake }) |queue| {
+                try out.print("tardigrade_tls_buffer_limit_exceeded_total{{backend=\"{s}\",queue=\"{s}\"}} {d}\n", .{
+                    tlsBackendLabel(backend),
+                    tlsQueueLabel(queue),
+                    self.tls_buffer_limit_exceeded[tlsBackendIndex(backend)][tlsQueueIndex(queue)],
+                });
+            }
+        }
+        try out.appendSlice(
+            \\# HELP tardigrade_tls_buffer_stalled_drives_total TLS drive calls that made no progress while backpressured
+            \\# TYPE tardigrade_tls_buffer_stalled_drives_total counter
+            \\
+        );
+        inline for (.{ encrypted_stream.BackendKind.openssl, encrypted_stream.BackendKind.pure_zig_record }) |backend| {
+            try out.print("tardigrade_tls_buffer_stalled_drives_total{{backend=\"{s}\"}} {d}\n", .{
+                tlsBackendLabel(backend),
+                self.tls_buffer_stalled_drives[tlsBackendIndex(backend)],
+            });
+        }
+    }
+
     /// Format metrics as a JSON string.
     /// Caller owns the returned memory.
     pub fn toJson(self: *const Metrics, allocator: std.mem.Allocator) ![]u8 {
@@ -1002,6 +1160,69 @@ pub const Metrics = struct {
         return out.toOwnedSlice();
     }
 };
+
+fn zeroTlsQueueMatrix() [tls_backend_count][tls_queue_count]u64 {
+    return .{.{0} ** tls_queue_count} ** tls_backend_count;
+}
+
+fn zeroTlsDirectionMatrix() [tls_backend_count][tls_direction_count]u64 {
+    return .{.{0} ** tls_direction_count} ** tls_backend_count;
+}
+
+fn tlsBackendIndex(backend: encrypted_stream.BackendKind) usize {
+    return switch (backend) {
+        .openssl => 0,
+        .pure_zig_record => 1,
+    };
+}
+
+fn tlsQueueIndex(queue: TlsQueue) usize {
+    return switch (queue) {
+        .inbound_ciphertext => 0,
+        .inbound_plaintext => 1,
+        .outbound_ciphertext => 2,
+        .handshake => 3,
+    };
+}
+
+fn tlsDirectionIndex(direction: TlsDirection) usize {
+    return switch (direction) {
+        .carrier_read => 0,
+        .plaintext_write => 1,
+    };
+}
+
+fn tlsBackendLabel(backend: encrypted_stream.BackendKind) []const u8 {
+    return switch (backend) {
+        .openssl => "openssl",
+        .pure_zig_record => "pure_zig_record",
+    };
+}
+
+fn tlsQueueLabel(queue: TlsQueue) []const u8 {
+    return switch (queue) {
+        .inbound_ciphertext => "inbound_ciphertext",
+        .inbound_plaintext => "inbound_plaintext",
+        .outbound_ciphertext => "outbound_ciphertext",
+        .handshake => "handshake",
+    };
+}
+
+fn tlsDirectionLabel(direction: TlsDirection) []const u8 {
+    return switch (direction) {
+        .carrier_read => "carrier_read",
+        .plaintext_write => "plaintext_write",
+    };
+}
+
+fn monotonicDelta(previous: u64, next: u64) u64 {
+    return if (next >= previous) next - previous else next;
+}
+
+fn subtractGauge(slot: *u64, amount: usize) void {
+    const value: u64 = @intCast(amount);
+    slot.* = if (value >= slot.*) 0 else slot.* - value;
+}
 
 // Tests
 
@@ -1099,6 +1320,44 @@ test "Metrics proxy buffer release reports accounting underflow" {
     m.recordProxyBufferedRequest(8, 0);
     try std.testing.expectError(error.BufferAccountingUnderflow, m.releaseProxyBufferedBytes(9));
     try std.testing.expectEqual(@as(u64, 8), m.proxy_buffered_bytes_current);
+}
+
+test "Metrics TLS buffer observation applies current bytes and counter deltas once" {
+    var m = Metrics.init();
+    var state = TlsBufferConnectionMetrics{};
+    const backend = encrypted_stream.BackendKind.pure_zig_record;
+    const backend_idx = tlsBackendIndex(backend);
+
+    const snapshot = encrypted_stream.BufferSnapshot{
+        .current = .{
+            .inbound_ciphertext = 11,
+            .inbound_plaintext = 7,
+            .outbound_ciphertext = 13,
+            .handshake = 3,
+        },
+        .counters = .{
+            .inbound_read_pauses = 1,
+            .inbound_read_resumes = 1,
+            .plaintext_write_pauses = 2,
+            .plaintext_write_resumes = 1,
+            .hard_limits = .{ .outbound_ciphertext = 1 },
+            .stalled_drives = 4,
+        },
+    };
+
+    m.observeTlsBufferSnapshot(&state, backend, snapshot);
+    m.observeTlsBufferSnapshot(&state, backend, snapshot);
+
+    try std.testing.expectEqual(@as(u64, 11), m.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.inbound_ciphertext)]);
+    try std.testing.expectEqual(@as(u64, 13), m.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.outbound_ciphertext)]);
+    try std.testing.expectEqual(@as(u64, 1), m.tls_buffer_pause_events[backend_idx][tlsDirectionIndex(.carrier_read)]);
+    try std.testing.expectEqual(@as(u64, 2), m.tls_buffer_pause_events[backend_idx][tlsDirectionIndex(.plaintext_write)]);
+    try std.testing.expectEqual(@as(u64, 1), m.tls_buffer_limit_exceeded[backend_idx][tlsQueueIndex(.outbound_ciphertext)]);
+    try std.testing.expectEqual(@as(u64, 4), m.tls_buffer_stalled_drives[backend_idx]);
+
+    m.releaseTlsBufferSnapshot(&state);
+    try std.testing.expectEqual(@as(u64, 0), m.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.inbound_ciphertext)]);
+    try std.testing.expectEqual(@as(u64, 0), m.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.outbound_ciphertext)]);
 }
 
 test "recordErrorCode counts only the canonical overload label" {

--- a/src/http/metrics.zig
+++ b/src/http/metrics.zig
@@ -457,8 +457,8 @@ pub const Metrics = struct {
         state: *TlsBufferConnectionMetrics,
         backend: encrypted_stream.BackendKind,
         snapshot: encrypted_stream.BufferSnapshot,
-    ) void {
-        if (state.active) self.releaseTlsCurrentBytes(state.backend, state.current);
+    ) !void {
+        if (state.active) try self.releaseTlsCurrentBytes(state.backend, state.current);
         self.recordTlsCurrentBytes(backend, snapshot.current);
         if (state.active and state.backend == backend) {
             self.recordTlsCounterDeltas(backend, state.counters, snapshot.counters);
@@ -473,9 +473,9 @@ pub const Metrics = struct {
         };
     }
 
-    pub fn releaseTlsBufferSnapshot(self: *Metrics, state: *TlsBufferConnectionMetrics) void {
+    pub fn releaseTlsBufferSnapshot(self: *Metrics, state: *TlsBufferConnectionMetrics) !void {
         if (!state.active) return;
-        self.releaseTlsCurrentBytes(state.backend, state.current);
+        try self.releaseTlsCurrentBytes(state.backend, state.current);
         state.* = .{};
     }
 
@@ -487,12 +487,12 @@ pub const Metrics = struct {
         self.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.handshake)] += @intCast(current.handshake);
     }
 
-    fn releaseTlsCurrentBytes(self: *Metrics, backend: encrypted_stream.BackendKind, current: encrypted_stream.QueueBytes) void {
+    fn releaseTlsCurrentBytes(self: *Metrics, backend: encrypted_stream.BackendKind, current: encrypted_stream.QueueBytes) !void {
         const backend_idx = tlsBackendIndex(backend);
-        subtractGauge(&self.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.inbound_ciphertext)], current.inbound_ciphertext);
-        subtractGauge(&self.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.inbound_plaintext)], current.inbound_plaintext);
-        subtractGauge(&self.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.outbound_ciphertext)], current.outbound_ciphertext);
-        subtractGauge(&self.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.handshake)], current.handshake);
+        try subtractGauge(&self.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.inbound_ciphertext)], current.inbound_ciphertext);
+        try subtractGauge(&self.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.inbound_plaintext)], current.inbound_plaintext);
+        try subtractGauge(&self.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.outbound_ciphertext)], current.outbound_ciphertext);
+        try subtractGauge(&self.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.handshake)], current.handshake);
     }
 
     fn recordTlsCounterDeltas(
@@ -1219,9 +1219,10 @@ fn monotonicDelta(previous: u64, next: u64) u64 {
     return if (next >= previous) next - previous else next;
 }
 
-fn subtractGauge(slot: *u64, amount: usize) void {
+fn subtractGauge(slot: *u64, amount: usize) !void {
     const value: u64 = @intCast(amount);
-    slot.* = if (value >= slot.*) 0 else slot.* - value;
+    if (value > slot.*) return error.BufferAccountingUnderflow;
+    slot.* -= value;
 }
 
 // Tests
@@ -1345,8 +1346,8 @@ test "Metrics TLS buffer observation applies current bytes and counter deltas on
         },
     };
 
-    m.observeTlsBufferSnapshot(&state, backend, snapshot);
-    m.observeTlsBufferSnapshot(&state, backend, snapshot);
+    try m.observeTlsBufferSnapshot(&state, backend, snapshot);
+    try m.observeTlsBufferSnapshot(&state, backend, snapshot);
 
     try std.testing.expectEqual(@as(u64, 11), m.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.inbound_ciphertext)]);
     try std.testing.expectEqual(@as(u64, 13), m.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.outbound_ciphertext)]);
@@ -1355,9 +1356,33 @@ test "Metrics TLS buffer observation applies current bytes and counter deltas on
     try std.testing.expectEqual(@as(u64, 1), m.tls_buffer_limit_exceeded[backend_idx][tlsQueueIndex(.outbound_ciphertext)]);
     try std.testing.expectEqual(@as(u64, 4), m.tls_buffer_stalled_drives[backend_idx]);
 
-    m.releaseTlsBufferSnapshot(&state);
+    try m.releaseTlsBufferSnapshot(&state);
     try std.testing.expectEqual(@as(u64, 0), m.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.inbound_ciphertext)]);
     try std.testing.expectEqual(@as(u64, 0), m.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.outbound_ciphertext)]);
+}
+
+test "Metrics TLS buffer current bytes remain per connection and underflow reports" {
+    var m = Metrics.init();
+    var first = TlsBufferConnectionMetrics{};
+    var second = TlsBufferConnectionMetrics{};
+    const backend = encrypted_stream.BackendKind.pure_zig_record;
+    const backend_idx = tlsBackendIndex(backend);
+
+    try m.observeTlsBufferSnapshot(&first, backend, .{ .current = .{ .inbound_plaintext = 10 } });
+    try m.observeTlsBufferSnapshot(&second, backend, .{ .current = .{ .inbound_plaintext = 7 } });
+    try std.testing.expectEqual(@as(u64, 17), m.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.inbound_plaintext)]);
+
+    try m.releaseTlsBufferSnapshot(&first);
+    try std.testing.expectEqual(@as(u64, 7), m.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.inbound_plaintext)]);
+    try m.releaseTlsBufferSnapshot(&second);
+    try std.testing.expectEqual(@as(u64, 0), m.tls_buffered_bytes_current[backend_idx][tlsQueueIndex(.inbound_plaintext)]);
+
+    var corrupted = TlsBufferConnectionMetrics{
+        .active = true,
+        .backend = backend,
+        .current = .{ .inbound_plaintext = 1 },
+    };
+    try std.testing.expectError(error.BufferAccountingUnderflow, m.releaseTlsBufferSnapshot(&corrupted));
 }
 
 test "recordErrorCode counts only the canonical overload label" {

--- a/src/http/native_tls_connection.zig
+++ b/src/http/native_tls_connection.zig
@@ -136,6 +136,10 @@ fn keyKindForScheme(scheme: credentials.SignatureScheme) sni_provider.KeyKind {
 }
 
 pub const NativeTlsConnection = struct {
+    pub const Options = struct {
+        buffer_limits: encrypted_stream.BufferLimits = encrypted_stream.BufferLimits.defaults(),
+    };
+
     allocator: std.mem.Allocator,
     fd: std.posix.fd_t,
     backend: *tls_backend.Tls13Backend,
@@ -151,7 +155,18 @@ pub const NativeTlsConnection = struct {
         policy: ListenerProtocolPolicy,
         provider: credentials.CredentialProvider,
     ) !*NativeTlsConnection {
+        return createWithOptions(allocator, fd, policy, provider, .{});
+    }
+
+    pub fn createWithOptions(
+        allocator: std.mem.Allocator,
+        fd: std.posix.fd_t,
+        policy: ListenerProtocolPolicy,
+        provider: credentials.CredentialProvider,
+        options: Options,
+    ) !*NativeTlsConnection {
         if (!policy.http1_enabled and !policy.http2_enabled) return error.ProtocolConfigFailed;
+        try options.buffer_limits.validate();
         try setNonBlocking(fd);
         const handshake_entropy = try production_crypto.freshHandshakeEntropy();
 
@@ -181,12 +196,13 @@ pub const NativeTlsConnection = struct {
             .policy = policy,
         };
         self.crypto_provider_state = production_crypto.Provider.init(self.entropy_source.entropy());
-        record.* = encrypted_stream.PureZigRecordStream.initWithCarrierAndBackend(
+        record.* = try encrypted_stream.PureZigRecordStream.initWithCarrierBackendAndLimits(
             .server,
             self.crypto_provider_state.cryptoProvider(),
             .tls_aes_128_gcm_sha256,
             self.socketCarrier(),
             backend.backend(),
+            options.buffer_limits,
         );
         backend_owned_by_record = true;
         return self;
@@ -401,6 +417,28 @@ test "native TLS owner heap-stabilizes backend record and owns fd close" {
     conn.destroy();
 
     try std.testing.expectError(error.SocketWriteFailed, writeFd(original_fd, "x"));
+}
+
+test "native TLS createWithOptions applies validated buffer limits" {
+    var fixed = credentials.FixedCredentialProvider.init(credentials.testdata.identity());
+    defer fixed.deinit();
+    const fds = try testSocketPair();
+    defer closeFd(fds[1]);
+
+    var limits = encrypted_stream.BufferLimits.defaults();
+    limits.outbound_ciphertext.high = limits.outbound_ciphertext.low + 16;
+    const conn = try NativeTlsConnection.createWithOptions(
+        std.testing.allocator,
+        fds[0],
+        .{ .http1_enabled = true, .http2_enabled = true },
+        fixed.provider(),
+        .{ .buffer_limits = limits },
+    );
+    defer conn.destroy();
+
+    const snapshot = conn.stream().bufferSnapshot();
+    try std.testing.expect(snapshot.limits_enforced);
+    try std.testing.expectEqual(limits.outbound_ciphertext.high, snapshot.limits.?.outbound_ciphertext.high);
 }
 
 test "native TLS negotiated protocol is unavailable before application data opens" {

--- a/src/http/tls_termination.zig
+++ b/src/http/tls_termination.zig
@@ -2294,6 +2294,57 @@ test "openssl encrypted stream records pending plaintext peak before first snaps
     try std.testing.expect(snapshot.limits == null);
 }
 
+test "openssl TLS metrics export measurable pending and retry state then release" {
+    const allocator = std.testing.allocator;
+    var metrics = metrics_mod.Metrics.init();
+    var metrics_mutex = compat.Mutex{};
+
+    var pair = try makeTestTlsPair(allocator);
+    pair.server.attachBufferMetrics(&metrics, &metrics_mutex);
+    const stream = pair.server.stream();
+
+    try clientWriteAll(pair.client_ssl, "client-payload");
+    var scratch: [6]u8 = undefined;
+    try std.testing.expectEqual(@as(usize, 6), try stream.read(&scratch));
+    try std.testing.expectEqualStrings("client", &scratch);
+
+    {
+        const prom = try metrics.toPrometheus(allocator);
+        defer allocator.free(prom);
+        try std.testing.expect(std.mem.find(u8, prom, "tardigrade_tls_buffered_bytes_current{backend=\"openssl\",queue=\"inbound_plaintext\"} 8\n") != null);
+    }
+
+    var rest: [16]u8 = undefined;
+    const rest_len = try stream.read(&rest);
+    try std.testing.expectEqualStrings("-payload", rest[0..rest_len]);
+
+    {
+        const prom = try metrics.toPrometheus(allocator);
+        defer allocator.free(prom);
+        try std.testing.expect(std.mem.find(u8, prom, "tardigrade_tls_buffered_bytes_current{backend=\"openssl\",queue=\"inbound_plaintext\"} 0\n") != null);
+    }
+
+    var blocked: ForcedWriteBlock = .{};
+    defer blocked.deinit(allocator);
+    try forceOpenSslWriteBackpressure(allocator, &pair, stream, &blocked);
+    _ = try stream.drive();
+
+    {
+        const prom = try metrics.toPrometheus(allocator);
+        defer allocator.free(prom);
+        try std.testing.expect(std.mem.find(u8, prom, "tardigrade_tls_buffer_pause_events_total{backend=\"openssl\",direction=\"plaintext_write\"} 1\n") != null);
+        try std.testing.expect(std.mem.find(u8, prom, "tardigrade_tls_buffer_stalled_drives_total{backend=\"openssl\"} 1\n") != null);
+        try std.testing.expect(std.mem.find(u8, prom, "tardigrade_tls_buffer_pause_events_total{backend=\"pure_zig_record\",direction=\"plaintext_write\"} 0\n") != null);
+    }
+
+    pair.deinit();
+    {
+        const prom = try metrics.toPrometheus(allocator);
+        defer allocator.free(prom);
+        try std.testing.expect(std.mem.find(u8, prom, "tardigrade_tls_buffered_bytes_current{backend=\"openssl\",queue=\"inbound_plaintext\"} 0\n") != null);
+    }
+}
+
 test "openssl encrypted stream preserves close requested during pending write retry" {
     const allocator = std.testing.allocator;
     var pair = try makeTestTlsPair(allocator);

--- a/src/http/tls_termination.zig
+++ b/src/http/tls_termination.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const compat = @import("../zig_compat.zig");
 const acme_client = @import("acme_client.zig");
 const encrypted_stream = @import("tls_core").encrypted_stream;
+const metrics_mod = @import("metrics.zig");
 const negotiated_dispatch = @import("negotiated_dispatch.zig");
 
 const c = @cImport({
@@ -401,11 +402,16 @@ pub const TlsConnection = struct {
     stream_peak_total: usize = 0,
     stream_pause_state: encrypted_stream.PauseState = .{},
     stream_buffer_counters: encrypted_stream.BufferCounters = .{},
+    metrics: ?*metrics_mod.Metrics = null,
+    metrics_mutex: ?*compat.Mutex = null,
+    tls_buffer_metrics: metrics_mod.TlsBufferConnectionMetrics = .{},
     protocol_policy: negotiated_dispatch.ListenerProtocolPolicy = .{},
     policy_box: ?*negotiated_dispatch.ListenerProtocolPolicy = null,
     policy_ex_index: c_int = -1,
 
     pub fn deinit(self: *TlsConnection) void {
+        self.observeTlsBufferMetrics();
+        self.releaseTlsBufferMetrics();
         if (self.policy_ex_index >= 0) _ = c.SSL_set_ex_data(self.ssl, self.policy_ex_index, null);
         if (opensslShouldShutdownOnDeinit(self)) {
             c.ERR_clear_error();
@@ -417,10 +423,16 @@ pub const TlsConnection = struct {
     }
 
     pub fn read(self: *TlsConnection, buf: []u8) TlsError!usize {
+        defer self.observeTlsBufferMetrics();
         const rc = c.SSL_read(self.ssl, buf.ptr, @intCast(buf.len));
         if (rc > 0) return @intCast(rc);
         if (c.SSL_get_error(self.ssl, rc) == c.SSL_ERROR_ZERO_RETURN) return 0;
         return error.TlsReadFailed;
+    }
+
+    pub fn attachBufferMetrics(self: *TlsConnection, metrics: *metrics_mod.Metrics, mutex: *compat.Mutex) void {
+        self.metrics = metrics;
+        self.metrics_mutex = mutex;
     }
 
     /// Bytes of already-decrypted application data buffered inside OpenSSL,
@@ -489,9 +501,29 @@ pub const TlsConnection = struct {
     }
 
     fn writeFn(self: *TlsConnection, data: []const u8) TlsError!usize {
+        defer self.observeTlsBufferMetrics();
         const rc = c.SSL_write(self.ssl, data.ptr, @intCast(data.len));
         if (rc > 0) return @intCast(rc);
         return error.TlsWriteFailed;
+    }
+
+    fn observeTlsBufferMetrics(self: *TlsConnection) void {
+        const metrics = self.metrics orelse return;
+        const mutex = self.metrics_mutex orelse return;
+        const snapshot = opensslStreamBufferSnapshot(self);
+        mutex.lock();
+        defer mutex.unlock();
+        metrics.observeTlsBufferSnapshot(&self.tls_buffer_metrics, .openssl, snapshot) catch
+            @panic("TLS buffer accounting underflow");
+    }
+
+    fn releaseTlsBufferMetrics(self: *TlsConnection) void {
+        const metrics = self.metrics orelse return;
+        const mutex = self.metrics_mutex orelse return;
+        mutex.lock();
+        defer mutex.unlock();
+        metrics.releaseTlsBufferSnapshot(&self.tls_buffer_metrics) catch
+            @panic("TLS buffer accounting underflow");
     }
 };
 
@@ -618,6 +650,7 @@ fn opensslStreamRead(ptr: *anyopaque, out: []u8) encrypted_stream.Error!usize {
     if (self.stream_lifecycle != .open) return error.StreamClosed;
     if (self.pending_write != null) return error.RetryOperationPending;
     if (self.close_requested) return error.StreamClosed;
+    defer self.observeTlsBufferMetrics();
     _ = opensslObserveBufferUsage(self);
     c.ERR_clear_error();
     const rc = c.SSL_read(self.ssl, out.ptr, @intCast(out.len));
@@ -661,6 +694,7 @@ fn opensslStreamWrite(ptr: *anyopaque, bytes: []const u8) encrypted_stream.Error
         if (self.close_requested) return error.StreamClosed;
         if (bytes.len == 0) return 0;
     }
+    defer self.observeTlsBufferMetrics();
     c.ERR_clear_error();
     const rc = c.SSL_write(self.ssl, bytes.ptr, @intCast(bytes.len));
     if (rc > 0) {
@@ -766,6 +800,7 @@ fn opensslStreamReadiness(ptr: *anyopaque) encrypted_stream.Readiness {
 fn opensslStreamDrive(ptr: *anyopaque) encrypted_stream.Error!encrypted_stream.DriveResult {
     const self: *TlsConnection = @ptrCast(@alignCast(ptr));
     if (self.stream_failure) |err| return err;
+    defer self.observeTlsBufferMetrics();
     const made_progress = if (self.stream_lifecycle == .closing or (self.close_requested and self.pending_write == null))
         try opensslAdvanceShutdown(self)
     else

--- a/src/http/tls_termination_stub.zig
+++ b/src/http/tls_termination_stub.zig
@@ -138,6 +138,12 @@ pub const TlsConnection = struct {
         return error.TlsReadFailed;
     }
 
+    pub fn attachBufferMetrics(self: *TlsConnection, metrics: anytype, mutex: anytype) void {
+        _ = self;
+        _ = metrics;
+        _ = mutex;
+    }
+
     pub fn pending(self: *const TlsConnection) usize {
         _ = self;
         return 0;

--- a/src/http/worker_pool.zig
+++ b/src/http/worker_pool.zig
@@ -25,11 +25,31 @@ const compat = @import("../zig_compat.zig");
 const builtin = @import("builtin");
 const std = @import("std");
 
-pub const HandlerFn = *const fn (ctx: *anyopaque, fd: std.posix.fd_t) void;
+pub const WorkItem = union(enum) {
+    accepted: std.posix.fd_t,
+    parked_ready: std.posix.fd_t,
+    active_socket_ready: std.posix.fd_t,
+    active_drive_poll: std.posix.fd_t,
+
+    pub fn fd(self: WorkItem) std.posix.fd_t {
+        return switch (self) {
+            inline else => |value| value,
+        };
+    }
+
+    fn queueOwnsFd(self: WorkItem) bool {
+        return switch (self) {
+            .accepted => true,
+            .parked_ready, .active_socket_ready, .active_drive_poll => false,
+        };
+    }
+};
+
+pub const HandlerFn = *const fn (ctx: *anyopaque, item: WorkItem) void;
 pub const WaitCallbackFn = *const fn (ctx: *anyopaque, wait_ns: i64) void;
 
 const QueueEntry = struct {
-    fd: std.posix.fd_t,
+    item: WorkItem,
     enqueued_ns: i128,
 };
 
@@ -140,8 +160,24 @@ pub const WorkerPool = struct {
     }
 
     pub fn submit(self: *WorkerPool, fd: std.posix.fd_t) !void {
+        return self.submitWork(.{ .accepted = fd });
+    }
+
+    pub fn submitParkedReady(self: *WorkerPool, fd: std.posix.fd_t) !void {
+        return self.submitWork(.{ .parked_ready = fd });
+    }
+
+    pub fn submitActiveSocketReady(self: *WorkerPool, fd: std.posix.fd_t) !void {
+        return self.submitWork(.{ .active_socket_ready = fd });
+    }
+
+    pub fn submitActiveDrivePoll(self: *WorkerPool, fd: std.posix.fd_t) !void {
+        return self.submitWork(.{ .active_drive_poll = fd });
+    }
+
+    fn submitWork(self: *WorkerPool, item: WorkItem) !void {
         if (builtin.single_threaded) {
-            self.handler(self.handler_ctx, fd);
+            self.handler(self.handler_ctx, item);
             return;
         }
 
@@ -157,7 +193,7 @@ pub const WorkerPool = struct {
             self.worker_queues[queue_index].items.len >= self.max_per_worker_queue_len)
             return error.QueueFull;
         try self.worker_queues[queue_index].items.pushBack(self.allocator, .{
-            .fd = fd,
+            .item = item,
             .enqueued_ns = compat.nanoTimestamp(),
         });
         self.queued_jobs += 1;
@@ -222,8 +258,10 @@ pub const WorkerPool = struct {
             // Immediate: close queued fds without waiting (configured no-drain).
             for (self.worker_queues) |*wq| {
                 while (wq.items.popFront()) |entry| {
-                    _ = std.c.close(entry.fd);
-                    result.forced_closes += 1;
+                    if (entry.item.queueOwnsFd()) {
+                        _ = std.c.close(entry.item.fd());
+                        result.forced_closes += 1;
+                    }
                 }
             }
             self.queued_jobs = 0;
@@ -237,8 +275,10 @@ pub const WorkerPool = struct {
                     result.timed_out = true;
                     for (self.worker_queues) |*wq| {
                         while (wq.items.popFront()) |entry| {
-                            _ = std.c.close(entry.fd);
-                            result.forced_closes += 1;
+                            if (entry.item.queueOwnsFd()) {
+                                _ = std.c.close(entry.item.fd());
+                                result.forced_closes += 1;
+                            }
                         }
                     }
                     self.queued_jobs = 0;
@@ -290,7 +330,7 @@ pub const WorkerPool = struct {
                 cb(self.wait_callback_ctx.?, wait_ns);
             }
 
-            self.handler(self.handler_ctx, entry.fd);
+            self.handler(self.handler_ctx, entry.item);
 
             self.mutex.lock();
             self.active_jobs -= 1;
@@ -353,10 +393,10 @@ test "worker pool processes submitted items" {
     var ctx = Ctx{};
 
     const handler = struct {
-        fn run(raw_ctx: *anyopaque, fd: std.posix.fd_t) void {
+        fn run(raw_ctx: *anyopaque, item: WorkItem) void {
             const typed: *Ctx = @ptrCast(@alignCast(raw_ctx));
             typed.mutex.lock();
-            typed.total += @intCast(fd);
+            typed.total += @intCast(item.fd());
             typed.mutex.unlock();
         }
     }.run;
@@ -386,7 +426,7 @@ test "worker pool shutdown drains in-flight work" {
     var ctx = Ctx{};
 
     const handler = struct {
-        fn run(raw_ctx: *anyopaque, _: std.posix.fd_t) void {
+        fn run(raw_ctx: *anyopaque, _: WorkItem) void {
             const typed: *Ctx = @ptrCast(@alignCast(raw_ctx));
             std.Io.sleep(compat.io(), .fromMilliseconds(20), .awake) catch unreachable;
             typed.mutex.lock();
@@ -422,9 +462,9 @@ test "worker pool queue selection prefers least-loaded worker queue" {
         for (queues) |*q| q.items.deinit(std.testing.allocator);
     }
 
-    try queues[0].items.pushBack(std.testing.allocator, .{ .fd = 10, .enqueued_ns = 0 });
-    try queues[0].items.pushBack(std.testing.allocator, .{ .fd = 11, .enqueued_ns = 0 });
-    try queues[1].items.pushBack(std.testing.allocator, .{ .fd = 20, .enqueued_ns = 0 });
+    try queues[0].items.pushBack(std.testing.allocator, .{ .item = .{ .accepted = 10 }, .enqueued_ns = 0 });
+    try queues[0].items.pushBack(std.testing.allocator, .{ .item = .{ .accepted = 11 }, .enqueued_ns = 0 });
+    try queues[1].items.pushBack(std.testing.allocator, .{ .item = .{ .accepted = 20 }, .enqueued_ns = 0 });
 
     var pool = WorkerPool{
         .allocator = std.testing.allocator,
@@ -475,7 +515,7 @@ test "worker pool popWorkLocked steals from peer queue" {
         for (queues) |*q| q.items.deinit(std.testing.allocator);
     }
 
-    try queues[1].items.pushBack(std.testing.allocator, .{ .fd = 42, .enqueued_ns = 0 });
+    try queues[1].items.pushBack(std.testing.allocator, .{ .item = .{ .accepted = 42 }, .enqueued_ns = 0 });
 
     var pool = WorkerPool{
         .allocator = std.testing.allocator,
@@ -490,7 +530,7 @@ test "worker pool popWorkLocked steals from peer queue" {
     };
 
     const stolen = pool.popWorkLocked(0);
-    try std.testing.expectEqual(@as(?QueueEntry, .{ .fd = 42, .enqueued_ns = 0 }), stolen);
+    try std.testing.expectEqual(@as(?QueueEntry, .{ .item = .{ .accepted = 42 }, .enqueued_ns = 0 }), stolen);
     try std.testing.expectEqual(@as(usize, 0), pool.queued_jobs);
 }
 
@@ -506,7 +546,7 @@ test "shutdownAndJoin drain_timeout_ms=0 closes queued fds immediately" {
     var ctx = Ctx{};
 
     const handler = struct {
-        fn run(raw_ctx: *anyopaque, _: std.posix.fd_t) void {
+        fn run(raw_ctx: *anyopaque, _: WorkItem) void {
             // This should not be called because we force-close before dispatch.
             const typed: *Ctx = @ptrCast(@alignCast(raw_ctx));
             typed.mutex.lock();
@@ -540,7 +580,7 @@ test "shutdownAndJoin drain_timeout_ms positive drains in-flight work before tim
     var ctx = Ctx{};
 
     const handler = struct {
-        fn run(raw_ctx: *anyopaque, _: std.posix.fd_t) void {
+        fn run(raw_ctx: *anyopaque, _: WorkItem) void {
             const typed: *Ctx = @ptrCast(@alignCast(raw_ctx));
             std.Io.sleep(compat.io(), .fromMilliseconds(10), .awake) catch unreachable;
             typed.mutex.lock();
@@ -581,7 +621,7 @@ test "shutdownAndJoin drain_timeout_ms expires and returns" {
     var ctx = Ctx{};
 
     const handler = struct {
-        fn run(ctx_ptr: *anyopaque, _: std.posix.fd_t) void {
+        fn run(ctx_ptr: *anyopaque, _: WorkItem) void {
             const c: *Ctx = @ptrCast(@alignCast(ctx_ptr));
             c.started.store(true, .release);
             const deadline = compat.milliTimestamp() + 200;
@@ -624,9 +664,9 @@ test "shutdownAndJoin counts queued connections force-closed (#170)" {
     for (queues) |*q| q.* = .{ .items = .empty };
     defer for (queues) |*q| q.items.deinit(std.testing.allocator);
 
-    try queues[0].items.pushBack(std.testing.allocator, .{ .fd = 90001, .enqueued_ns = 0 });
-    try queues[0].items.pushBack(std.testing.allocator, .{ .fd = 90002, .enqueued_ns = 0 });
-    try queues[1].items.pushBack(std.testing.allocator, .{ .fd = 90003, .enqueued_ns = 0 });
+    try queues[0].items.pushBack(std.testing.allocator, .{ .item = .{ .accepted = 90001 }, .enqueued_ns = 0 });
+    try queues[0].items.pushBack(std.testing.allocator, .{ .item = .{ .accepted = 90002 }, .enqueued_ns = 0 });
+    try queues[1].items.pushBack(std.testing.allocator, .{ .item = .{ .accepted = 90003 }, .enqueued_ns = 0 });
 
     var pool = WorkerPool{
         .allocator = std.testing.allocator,
@@ -647,6 +687,36 @@ test "shutdownAndJoin counts queued connections force-closed (#170)" {
     try std.testing.expectEqual(@as(usize, 0), pool.queued_jobs);
 }
 
+test "shutdownAndJoin does not force-close queued registry-owned work" {
+    if (builtin.single_threaded) return;
+
+    var queues = try std.testing.allocator.alloc(WorkerQueue, 1);
+    defer std.testing.allocator.free(queues);
+    queues[0] = .{ .items = .empty };
+    defer queues[0].items.deinit(std.testing.allocator);
+
+    try queues[0].items.pushBack(std.testing.allocator, .{ .item = .{ .accepted = 90001 }, .enqueued_ns = 0 });
+    try queues[0].items.pushBack(std.testing.allocator, .{ .item = .{ .active_drive_poll = 90002 }, .enqueued_ns = 0 });
+    try queues[0].items.pushBack(std.testing.allocator, .{ .item = .{ .active_socket_ready = 90003 }, .enqueued_ns = 0 });
+
+    var pool = WorkerPool{
+        .allocator = std.testing.allocator,
+        .threads = if (builtin.single_threaded) .{} else &.{},
+        .worker_queues = queues,
+        .worker_ids = &.{},
+        .handler = undefined,
+        .handler_ctx = undefined,
+        .max_queue_len = 128,
+        .queued_jobs = 3,
+        .next_queue = 0,
+    };
+
+    const drain = pool.shutdownAndJoin(0);
+    try std.testing.expect(!drain.timed_out);
+    try std.testing.expectEqual(@as(usize, 1), drain.forced_closes);
+    try std.testing.expectEqual(@as(usize, 0), pool.queued_jobs);
+}
+
 test "worker pool global queue cap rejects without unbounded growth" {
     if (builtin.single_threaded) return;
 
@@ -660,7 +730,7 @@ test "worker pool global queue cap rejects without unbounded growth" {
     var ctx = Ctx{};
 
     const handler = struct {
-        fn run(raw_ctx: *anyopaque, _: std.posix.fd_t) void {
+        fn run(raw_ctx: *anyopaque, _: WorkItem) void {
             const typed: *Ctx = @ptrCast(@alignCast(raw_ctx));
             while (true) {
                 std.Io.sleep(compat.io(), .fromMilliseconds(1), .awake) catch {};
@@ -712,7 +782,7 @@ test "worker pool per-worker queue depth limit rejects when all worker queues ar
     var ctx = Ctx{};
 
     const handler = struct {
-        fn run(raw_ctx: *anyopaque, _: std.posix.fd_t) void {
+        fn run(raw_ctx: *anyopaque, _: WorkItem) void {
             const typed: *Ctx = @ptrCast(@alignCast(raw_ctx));
             // Block until the test signals proceed so the queue doesn't drain.
             while (true) {

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -2813,7 +2813,7 @@ test "the record stream production driver resumes async client authentication en
     // over a real socket pair.
     var client_credential = credentials.MockCredentialProvider.init(fixtureIdentity());
     client_credential.async_sign = true;
-    client_credential.pending_polls = 0;
+    client_credential.pending_polls = 2;
     var server_verifier = credentials.MockVerifier.init(.accepted);
     var client_verifier = credentials.MockVerifier.init(.accepted);
 
@@ -2824,13 +2824,33 @@ test "the record stream production driver resumes async client authentication en
     h.client_engine.setLocalCredentialProvider(client_credential.provider());
     h.server_engine.requestClientAuthentication(.required, server_verifier.verifier());
 
+    while (!h.client_engine.authPending()) {
+        const c = try h.driveClient();
+        const s = try h.driveServer();
+        if (!c.made_progress and !s.made_progress) return error.Stalled;
+    }
+    try std.testing.expectEqual(@as(usize, 0), client_credential.poll_count);
+
+    _ = try h.driveClient();
+    try std.testing.expect(h.client_engine.authPending());
+    try std.testing.expectEqual(@as(usize, 1), client_credential.poll_count);
+
+    _ = try h.driveClient();
+    try std.testing.expect(h.client_engine.authPending());
+    try std.testing.expectEqual(@as(usize, 2), client_credential.poll_count);
+
+    const completion_poll = try h.driveClient();
+    try std.testing.expect(completion_poll.made_progress);
+    try std.testing.expect(!h.client_engine.authPending());
     try h.driveUntil(SocketHarness.bothComplete);
     try std.testing.expect(h.client.bridge.handshake_complete);
     try std.testing.expect(h.server.bridge.handshake_complete);
     // The async signature was polled to completion through the driver, and the
     // server verified the client certificate.
     try std.testing.expectEqual(@as(usize, 1), client_credential.sign_count);
+    try std.testing.expectEqual(@as(usize, 3), client_credential.poll_count);
     try std.testing.expectEqual(@as(usize, 1), client_credential.op_release_count);
+    try std.testing.expectEqual(@as(usize, 0), client_credential.cancel_count);
     try std.testing.expectEqual(@as(usize, 1), server_verifier.verify_count);
     try std.testing.expect(h.client_engine.credentialFailure() == null);
     try std.testing.expect(h.server_engine.credentialFailure() == null);

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -6204,6 +6204,95 @@ test "invalid reload leaves the previous config active (#170)" {
     try assertContains(status.body, "\"ok\":false");
 }
 
+test "invalid TLS buffer reload keeps previous config limits active (#355)" {
+    const allocator = std.testing.allocator;
+    const defaults = tls_core.encrypted_stream.BufferLimits.defaults();
+    const custom_high = defaults.outbound_ciphertext.low + 1;
+
+    const valid_config = try std.fmt.allocPrint(allocator,
+        \\location /healthz {{
+        \\    return 200 alive;
+        \\}}
+        \\tls_outbound_ciphertext_low_watermark_bytes {d};
+        \\tls_outbound_ciphertext_high_watermark_bytes {d};
+        \\tls_outbound_ciphertext_hard_limit_bytes {d};
+    , .{
+        defaults.outbound_ciphertext.low,
+        custom_high,
+        defaults.outbound_ciphertext.hard,
+    });
+    defer allocator.free(valid_config);
+
+    var tardigrade = try TardigradeProcess.start(allocator, .{
+        .config_text = valid_config,
+        .ready_path = "/healthz",
+    });
+    defer tardigrade.stop();
+
+    const active_high_line = try std.fmt.allocPrint(allocator, "tardigrade_tls_buffer_config_limit_bytes{{queue=\"outbound_ciphertext\",limit=\"high\"}} {d}\n", .{custom_high});
+    defer allocator.free(active_high_line);
+    const rejected_high_line = try std.fmt.allocPrint(allocator, "tardigrade_tls_buffer_config_limit_bytes{{queue=\"outbound_ciphertext\",limit=\"high\"}} {d}\n", .{defaults.outbound_ciphertext.low});
+    defer allocator.free(rejected_high_line);
+    const rejected_hard_line = try std.fmt.allocPrint(allocator, "tardigrade_tls_buffer_config_limit_bytes{{queue=\"outbound_ciphertext\",limit=\"hard\"}} {d}\n", .{std.math.maxInt(usize)});
+    defer allocator.free(rejected_hard_line);
+
+    var initial_metrics = try sendRequest(allocator, tardigrade.port, .{ .method = "GET", .path = "/status/metrics", .body = null, .headers = &.{} });
+    defer initial_metrics.deinit();
+    try std.testing.expectEqual(@as(u16, 200), initial_metrics.status_code);
+    try assertContains(initial_metrics.body, active_high_line);
+
+    const invalid_configs = [_][]const u8{
+        \\location /healthz {
+        \\    return 200 alive;
+        \\}
+        \\tls_outbound_ciphertext_high_watermark_bytes not-a-number;
+        ,
+        try std.fmt.allocPrint(allocator,
+            \\location /healthz {{
+            \\    return 200 alive;
+            \\}}
+            \\tls_outbound_ciphertext_low_watermark_bytes {d};
+            \\tls_outbound_ciphertext_high_watermark_bytes {d};
+            \\tls_outbound_ciphertext_hard_limit_bytes {d};
+        , .{
+            defaults.outbound_ciphertext.low,
+            defaults.outbound_ciphertext.low,
+            defaults.outbound_ciphertext.hard,
+        }),
+        try std.fmt.allocPrint(allocator,
+            \\location /healthz {{
+            \\    return 200 alive;
+            \\}}
+            \\tls_outbound_ciphertext_low_watermark_bytes 1;
+            \\tls_outbound_ciphertext_high_watermark_bytes 2;
+            \\tls_outbound_ciphertext_hard_limit_bytes {d};
+        , .{std.math.maxInt(usize)}),
+    };
+    defer allocator.free(invalid_configs[1]);
+    defer allocator.free(invalid_configs[2]);
+
+    for (invalid_configs, 1..) |invalid_config, expected_failures| {
+        try tardigrade.rewriteConfig(invalid_config);
+        tardigrade.sendSignal(std.posix.SIG.HUP);
+        try waitForMetricAtLeast(allocator, tardigrade.port, "tardigrade_reload_failure_total", expected_failures, 3_000);
+
+        var status = try sendRequest(allocator, tardigrade.port, .{ .method = "GET", .path = "/tardigrade/reload/status", .body = null, .headers = &.{} });
+        defer status.deinit();
+        try assertContains(status.body, "\"ok\":false");
+
+        var health = try sendRequest(allocator, tardigrade.port, .{ .method = "GET", .path = "/healthz", .body = null, .headers = &.{} });
+        defer health.deinit();
+        try std.testing.expectEqual(@as(u16, 200), health.status_code);
+        try assertContains(health.body, "alive");
+
+        var metrics = try sendRequest(allocator, tardigrade.port, .{ .method = "GET", .path = "/status/metrics", .body = null, .headers = &.{} });
+        defer metrics.deinit();
+        try assertContains(metrics.body, active_high_line);
+        try std.testing.expect(std.mem.find(u8, metrics.body, rejected_high_line) == null);
+        try std.testing.expect(std.mem.find(u8, metrics.body, rejected_hard_line) == null);
+    }
+}
+
 test "hot reload does not warn about restart-only store paths when they are unchanged (#191)" {
     const allocator = std.testing.allocator;
 


### PR DESCRIPTION
## Summary

Refs #355.

This PR completes the remaining production wiring after merged PRs #457 and #470. It does not reimplement the record-layer queue model, ALPN dispatch, credential/provider work, global #140 proxy accounting, or any new TLS crypto behavior.

## BufferLimits model and defaults

- Native pure-Zig TLS listeners now receive an immutable `encrypted_stream.BufferLimits` policy from `EdgeConfig`.
- Defaults come from `BufferLimits.defaults()` so operator config and stream construction share the TLS core defaults.
- Existing `NativeTlsConnection.create()` remains source-compatible and delegates to `createWithOptions(..., .{})`.

## Compile-time capacity vs runtime limits

- Runtime low/high/hard watermarks are validated by TLS core before stream use.
- Invalid ordering, over-capacity limits, or reserve violations reject startup/reload before replacing the active config.
- OpenSSL is not presented as enforcing these native pure-Zig limits.

## Queue ownership/accounting

| Queue | Ownership source | Runtime metric label |
| --- | --- | --- |
| inbound carrier ciphertext | stream-owned pure-Zig queue/parser bytes | `queue="inbound_ciphertext"` |
| decrypted plaintext | stream-owned pure-Zig plaintext queue, or measurable OpenSSL pending plaintext | `queue="inbound_plaintext"` |
| outbound ciphertext | stream-owned pure-Zig ciphertext queue | `queue="outbound_ciphertext"` |
| handshake bytes | stream-owned pure-Zig handshake queue | `queue="handshake"` |

Pure-Zig writes continue sealing accepted plaintext directly into outbound ciphertext; no hidden pending-plaintext queue was added.

## Readiness and hysteresis state machine

- Encrypted raw fd registration now comes only from `Readiness.wants_read` and `Readiness.wants_write`.
- `can_read_plaintext` and `can_write_plaintext` are treated as immediate application work, not socket interest.
- The event-loop rearm path and synchronous `poll()` path share the same `EncryptedWait` mapping and no longer OR/fallback to nominal application directions.
- Empty-interest states are represented as stalled/no registration rather than passed to the event loop.

## Hard-limit and atomicity behavior

This PR preserves the #457 record-layer hard-limit and atomicity behavior. The new production config path validates policies before constructing native streams and passes the validated policy into `initWithCarrierBackendAndLimits()`.

## Metrics and snapshot interface

- Runtime metrics now aggregate `EncryptedStream.bufferSnapshot()` through per-connection last-observed state.
- Current byte gauges are replaced by subtract/add observation and released exactly once on managed connection teardown.
- Counter deltas are monotonic and are not double-counted on repeated observation.
- Prometheus series added:
  - `tardigrade_tls_buffered_bytes_current{backend,queue}`
  - `tardigrade_tls_buffer_pause_events_total{backend,direction}`
  - `tardigrade_tls_buffer_resume_events_total{backend,direction}`
  - `tardigrade_tls_buffer_limit_exceeded_total{backend,queue}`
  - `tardigrade_tls_buffer_stalled_drives_total{backend}`
  - `tardigrade_tls_buffer_config_limit_bytes{queue,limit}`

Labels are fixed to bounded backend, queue, direction, and limit enums. No SNI, URL, IP, request ID, connection ID, or stream ID labels were added.

## OpenSSL accounting boundary

OpenSSL snapshots remain limited to adapter/BIO-measurable state and `backend_opaque` accounting. Native TLS config-limit metrics describe the pure-Zig listener policy only and are not reported as OpenSSL-enforced limits.

## #356 HTTP consumer seam

HTTP/1.1 and HTTP/2 encrypted consumers can use the backend-neutral readiness mapping without backend-specific casts. Blocked plaintext reads/writes register only the TLS raw direction that can make progress.

## Validation

- `git diff --check`
- `zig fmt --check build.zig src/ tests/`
- `zig build test-tls --summary all --error-style verbose` (325/325 passed)
- `zig build test-quic --summary all --error-style verbose` (392/392 passed)
- `zig build test-integration --summary all --error-style verbose` (72/89 passed, 17 skipped)
- `zig build test-integration-native-tls -Dtls-profile=appliance --summary all --error-style verbose` (8/8 passed)
- `zig build test -Dtls-profile=appliance --summary all --error-style verbose` (1644/1645 passed, 1 skipped)
- `zig build test --summary all --error-style verbose` (1672/1673 passed, 1 skipped)
- `zig build -Doptimize=ReleaseFast -Dtls-profile=appliance --summary all --error-style verbose`

## Explicit exclusions

This PR does not implement #334, #347, #348, #356 ALPN/runtime expansion, global/per-origin #140 proxy accounting, KeyUpdate, new TLS queues, dynamic hot-path growth, or new cryptographic algorithms.
