### PR TITLE
tls: implement TLS 1.3 NewSessionTicket

### DIFF
--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -2848,7 +2848,7 @@ const GatewayPendingNative = struct {
             .{ .server_name = "tardigrade.test" },
         );
         self.client_carrier = .{ .fd = fds[1] };
-        self.client_stream = try tls_core.encrypted_stream.PureZigRecordStream.initWithCarrierBackendAndAllocator(
+        self.client_stream = try tls_core.encrypted_stream.PureZigRecordStream.initWithCarrierAndBackend(
             allocator,
             .client,
             self.client_provider.cryptoProvider(),

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -2848,7 +2848,8 @@ const GatewayPendingNative = struct {
             .{ .server_name = "tardigrade.test" },
         );
         self.client_carrier = .{ .fd = fds[1] };
-        self.client_stream = tls_core.encrypted_stream.PureZigRecordStream.initWithCarrierAndBackend(
+        self.client_stream = try tls_core.encrypted_stream.PureZigRecordStream.initWithCarrierBackendAndAllocator(
+            allocator,
             .client,
             self.client_provider.cryptoProvider(),
             .tls_aes_128_gcm_sha256,

--- a/src/http/native_tls_connection.zig
+++ b/src/http/native_tls_connection.zig
@@ -196,7 +196,8 @@ pub const NativeTlsConnection = struct {
             .policy = policy,
         };
         self.crypto_provider_state = production_crypto.Provider.init(self.entropy_source.entropy());
-        record.* = try encrypted_stream.PureZigRecordStream.initWithCarrierBackendAndLimits(
+        record.* = try encrypted_stream.PureZigRecordStream.initWithCarrierBackendAllocatorAndLimits(
+            allocator,
             .server,
             self.crypto_provider_state.cryptoProvider(),
             .tls_aes_128_gcm_sha256,

--- a/src/http/native_tls_connection.zig
+++ b/src/http/native_tls_connection.zig
@@ -196,7 +196,7 @@ pub const NativeTlsConnection = struct {
             .policy = policy,
         };
         self.crypto_provider_state = production_crypto.Provider.init(self.entropy_source.entropy());
-        record.* = try encrypted_stream.PureZigRecordStream.initWithCarrierBackendAllocatorAndLimits(
+        record.* = try encrypted_stream.PureZigRecordStream.initWithCarrierBackendAndLimits(
             allocator,
             .server,
             self.crypto_provider_state.cryptoProvider(),

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -57,6 +57,7 @@ pub const State = enum {
 /// until DPLPMTUD lands under #256.
 pub const max_datagram_size: usize = recovery.max_datagram_size;
 pub const max_application_crypto_outstanding: usize = 2 * tls_core.tls13_transport.max_emitted_new_session_ticket_message_len;
+const min_application_crypto_payload: usize = max_datagram_size / 2;
 /// RFC 9000 §14.1: datagrams carrying Initial packets are padded to 1200.
 pub const min_initial_datagram: usize = 1200;
 
@@ -208,6 +209,28 @@ const RangeList = struct {
         try self.items.insert(allocator, index, merged);
     }
 
+    fn ensureUnusedCapacity(self: *RangeList, allocator: std.mem.Allocator, additional_count: usize) !void {
+        try self.items.ensureUnusedCapacity(allocator, additional_count);
+    }
+
+    fn insertAssumeCapacity(self: *RangeList, incoming: Range) void {
+        if (incoming.start >= incoming.end) return;
+        var merged = incoming;
+        var index: usize = 0;
+        while (index < self.items.items.len) {
+            const current = self.items.items[index];
+            if (merged.end < current.start) break;
+            if (current.end < merged.start) {
+                index += 1;
+                continue;
+            }
+            merged.start = @min(merged.start, current.start);
+            merged.end = @max(merged.end, current.end);
+            _ = self.items.orderedRemove(index);
+        }
+        self.items.insertAssumeCapacity(index, merged);
+    }
+
     /// Remove and return up to `max_len` bytes from the lowest range.
     fn takeFirst(self: *RangeList, max_len: u64) ?Range {
         if (self.items.items.len == 0) return null;
@@ -266,11 +289,11 @@ const CryptoTx = struct {
 
     fn markAcked(self: *CryptoTx, allocator: std.mem.Allocator, range: Range) void {
         const live = self.liveRange(range) orelse return;
-        self.acked.insert(allocator, live) catch {};
-        self.compactAcked();
+        self.acked.insertAssumeCapacity(live);
+        self.compactAcked(allocator);
     }
 
-    fn compactAcked(self: *CryptoTx) void {
+    fn compactAcked(self: *CryptoTx, allocator: std.mem.Allocator) void {
         while (self.acked.items.items.len > 0 and self.acked.items.items[0].end <= self.base) {
             _ = self.acked.items.orderedRemove(0);
         }
@@ -295,6 +318,12 @@ const CryptoTx = struct {
             self.acked.items.items[0].start = self.base;
         }
         self.trimPendingBelowBase();
+        if (self.data.items.len == 0 and self.data.capacity > 0) {
+            crypto_secrets.secureZero(self.data.allocatedSlice());
+            self.data.clearAndFree(allocator);
+            self.pending.items.clearAndFree(allocator);
+            self.acked.items.clearAndFree(allocator);
+        }
     }
 
     fn trimPendingBelowBase(self: *CryptoTx) void {
@@ -313,11 +342,13 @@ const CryptoTx = struct {
         if (bytes_len > max_outstanding) return error.CryptoBufferTooLarge;
         if (self.data.items.len > max_outstanding - bytes_len) return error.CryptoBufferTooLarge;
         if (self.data.capacity == 0) {
-            try self.data.ensureTotalCapacity(allocator, max_outstanding);
+            try self.data.ensureTotalCapacityPrecise(allocator, bytes_len);
         } else if (self.data.capacity < self.data.items.len + bytes_len) {
             return error.CryptoBufferTooLarge;
         }
-        try self.pending.items.ensureUnusedCapacity(allocator, 1);
+        const range_budget = applicationCryptoRangeBudget(bytes_len);
+        try self.pending.ensureUnusedCapacity(allocator, range_budget + 1);
+        try self.acked.ensureUnusedCapacity(allocator, range_budget);
     }
 
     fn appendReserved(self: *CryptoTx, bytes: []const u8) void {
@@ -329,6 +360,10 @@ const CryptoTx = struct {
         });
     }
 };
+
+fn applicationCryptoRangeBudget(bytes_len: usize) usize {
+    return (bytes_len + min_application_crypto_payload - 1) / min_application_crypto_payload + 8;
+}
 
 /// Driver-owned transmit buffer for one stream: bytes the application handed
 /// to `writeStream` that are unsent or unacked. `base` is the stream offset
@@ -1109,7 +1144,13 @@ pub const Connection = struct {
             };
             // If the level's keys are already discarded the buffer is gone.
             if (tx.data.items.len > 0) {
-                if (tx.liveRange(range)) |live| tx.pending.insert(self.allocator, live) catch {};
+                if (tx.liveRange(range)) |live| {
+                    if (record.space == .application) {
+                        tx.pending.insertAssumeCapacity(live);
+                    } else {
+                        tx.pending.insert(self.allocator, live) catch {};
+                    }
+                }
             }
         }
         for (record.streams[0..record.stream_count]) |sr| {
@@ -1271,6 +1312,8 @@ pub const Connection = struct {
         limits: tls_core.session.Limits,
     ) tls_handshake.HandshakeError!tls_core.session.ServerRecoverableState {
         if (self.state_ != .established or self.role != .server) return error.InvalidHandshakeState;
+        limits.validate() catch return error.IllegalParameter;
+        if (params.opaque_ticket.len == 0 or params.opaque_ticket.len > limits.max_ticket_len) return error.TicketTooLarge;
         const emit_params: tls_core.new_session_ticket.EmitParams = .{
             .ticket_lifetime = params.ticket_lifetime,
             .ticket_age_add = params.ticket_age_add,
@@ -1890,13 +1933,21 @@ pub const Connection = struct {
                 range = tx.liveRange(range) orelse continue;
                 if (record.crypto) |existing| {
                     if (existing.end != range.start) {
-                        tx.pending.insert(self.allocator, range) catch {};
+                        if (space == .application) {
+                            tx.pending.insertAssumeCapacity(range);
+                        } else {
+                            tx.pending.insert(self.allocator, range) catch {};
+                        }
                         break;
                     }
                 }
                 const data = tx.slice(range);
                 const n = frame.encodeCrypto(range.start, data, plain[plain_len..plain_budget]) catch {
-                    tx.pending.insert(self.allocator, range) catch {};
+                    if (space == .application) {
+                        tx.pending.insertAssumeCapacity(range);
+                    } else {
+                        tx.pending.insert(self.allocator, range) catch {};
+                    }
                     break;
                 };
                 plain_len += n;
@@ -2266,10 +2317,8 @@ test "application CRYPTO transmit ignores late duplicate ACKs and compacts later
     var tx = CryptoTx{};
     defer tx.deinit(allocator);
 
-    try tx.reserveAppend(allocator, 8, max_application_crypto_outstanding);
-    tx.appendReserved("ticket-1");
-    try tx.reserveAppend(allocator, 8, max_application_crypto_outstanding);
-    tx.appendReserved("ticket-2");
+    try tx.reserveAppend(allocator, 16, max_application_crypto_outstanding);
+    tx.appendReserved("ticket-1ticket-2");
 
     tx.markAcked(allocator, .{ .start = 0, .end = 8 });
     tx.markAcked(allocator, .{ .start = 0, .end = 8 });
@@ -2292,6 +2341,23 @@ test "application CRYPTO transmit clamps lost duplicate ranges below base" {
 
     const live = tx.liveRange(.{ .start = 0, .end = 16 }) orelse return error.TestUnexpectedResult;
     try testing.expectEqual(Range{ .start = 8, .end = 16 }, live);
+}
+
+test "application CRYPTO transmit allocates exact storage and frees after ACK" {
+    const allocator = testing.allocator;
+    var tx = CryptoTx{};
+    defer tx.deinit(allocator);
+
+    try tx.reserveAppend(allocator, 12, max_application_crypto_outstanding);
+    tx.appendReserved("small-ticket");
+    try testing.expectEqual(@as(usize, 12), tx.data.capacity);
+    try testing.expect(tx.data.capacity < max_application_crypto_outstanding);
+
+    tx.markAcked(allocator, .{ .start = 0, .end = 12 });
+    try testing.expectEqual(@as(usize, 0), tx.data.items.len);
+    try testing.expectEqual(@as(usize, 0), tx.data.capacity);
+    try testing.expect(tx.pending.isEmpty());
+    try testing.expect(tx.acked.isEmpty());
 }
 
 const TestPair = struct {
@@ -2628,6 +2694,28 @@ test "driver: application CRYPTO ticket budget refuses one-over before queueing"
         .issued_at_unix_ms = 10,
     }, tls_core.session.Limits.default));
     try testing.expectEqual(max_application_crypto_outstanding, pair.server.crypto_tx[2].data.items.len);
+}
+
+test "driver: ticket model limit refusal happens before CRYPTO allocation" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const too_large = try allocator.alloc(u8, tls_core.session.Limits.default.max_ticket_len + 1);
+    defer allocator.free(too_large);
+    @memset(too_large, 0x5a);
+
+    try testing.expectError(error.TicketTooLarge, pair.server.emitNewSessionTicket(.{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = too_large,
+        .issued_at_unix_ms = 10,
+    }, tls_core.session.Limits.default));
+    try testing.expectEqual(@as(usize, 0), pair.server.crypto_tx[2].data.items.len);
+    try testing.expectEqual(@as(usize, 0), pair.server.crypto_tx[2].data.capacity);
+    try testing.expect(pair.server.crypto_tx[2].pending.isEmpty());
 }
 
 test "driver: local close reaches the peer and both sides drain" {

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -21,6 +21,7 @@
 //! adapter's AEAD seal.
 
 const std = @import("std");
+const crypto_secrets = @import("crypto_secrets");
 const varint = @import("quic_varint");
 const config = @import("config.zig");
 const packet = @import("packet.zig");
@@ -234,10 +235,43 @@ const RangeList = struct {
 const CryptoTx = struct {
     data: std.ArrayList(u8) = .empty,
     pending: RangeList = .{},
+    acked: RangeList = .{},
+    base: u64 = 0,
 
     fn deinit(self: *CryptoTx, allocator: std.mem.Allocator) void {
+        crypto_secrets.secureZero(self.data.items);
         self.data.deinit(allocator);
         self.pending.deinit(allocator);
+        self.acked.deinit(allocator);
+    }
+
+    fn bufferedEnd(self: *const CryptoTx) u64 {
+        return self.base + self.data.items.len;
+    }
+
+    fn slice(self: *const CryptoTx, range: Range) []const u8 {
+        const start: usize = @intCast(range.start - self.base);
+        const end: usize = @intCast(range.end - self.base);
+        return self.data.items[start..end];
+    }
+
+    fn markAcked(self: *CryptoTx, allocator: std.mem.Allocator, range: Range) void {
+        self.acked.insert(allocator, range) catch {};
+        self.compactAcked();
+    }
+
+    fn compactAcked(self: *CryptoTx) void {
+        if (self.acked.items.items.len == 0) return;
+        const first = self.acked.items.items[0];
+        if (first.start != self.base or first.end <= self.base) return;
+        const release_len: usize = @intCast(@min(first.end, self.bufferedEnd()) - self.base);
+        if (release_len == 0) return;
+        crypto_secrets.secureZero(self.data.items[0..release_len]);
+        const keep_len = self.data.items.len - release_len;
+        if (keep_len > 0) std.mem.copyForwards(u8, self.data.items[0..keep_len], self.data.items[release_len..]);
+        self.data.shrinkRetainingCapacity(keep_len);
+        self.base += release_len;
+        if (first.end <= self.base) _ = self.acked.items.orderedRemove(0);
     }
 };
 
@@ -364,7 +398,7 @@ pub const Connection = struct {
     known_streams: std.AutoHashMap(StreamId, void),
     accept_queue: std.ArrayList(StreamId) = .empty,
 
-    crypto_tx: [2]CryptoTx = .{ .{}, .{} },
+    crypto_tx: [3]CryptoTx = .{ .{}, .{}, .{} },
     sent_records: std.ArrayList(SentRecord) = .empty,
 
     next_pn: [3]u64 = .{ 0, 0, 0 },
@@ -496,6 +530,7 @@ pub const Connection = struct {
 
     fn deinitPartial(self: *Connection) void {
         self.handshake.deinit();
+        self.adapter.deinit();
         if (self.streams) |*manager| manager.deinit();
         var it = self.send_queues.valueIterator();
         while (it.next()) |queue| {
@@ -959,6 +994,9 @@ pub const Connection = struct {
 
     fn onRecordAcked(self: *Connection, record: SentRecord) void {
         if (record.carried_handshake_done) self.handshake_done_acked = true;
+        if (record.crypto) |range| {
+            if (record.space == .application) self.crypto_tx[2].markAcked(self.allocator, range);
+        }
         for (record.streams[0..record.stream_count]) |sr| {
             if (self.send_queues.get(sr.id)) |queue| {
                 queue.acked.insert(self.allocator, sr.range) catch {};
@@ -1006,7 +1044,7 @@ pub const Connection = struct {
             const tx = switch (record.space) {
                 .initial => &self.crypto_tx[0],
                 .handshake => &self.crypto_tx[1],
-                .application => return,
+                .application => &self.crypto_tx[2],
             };
             // If the level's keys are already discarded the buffer is gone.
             if (tx.data.items.len > 0) {
@@ -1123,11 +1161,11 @@ pub const Connection = struct {
 
     /// Drain queued TLS output into the per-level retransmission buffers.
     fn collectCryptoOutput(self: *Connection) !void {
-        inline for (.{ EncryptionLevel.initial, EncryptionLevel.handshake }, 0..) |level, tx_index| {
+        inline for (.{ EncryptionLevel.initial, EncryptionLevel.handshake, EncryptionLevel.application }, 0..) |level, tx_index| {
             var chunk: [2048]u8 = undefined;
             while (self.handshake.pollOutput(level, &chunk) catch null) |output| {
                 const tx = &self.crypto_tx[tx_index];
-                std.debug.assert(output.offset == tx.data.items.len);
+                std.debug.assert(output.offset == tx.bufferedEnd());
                 try tx.data.appendSlice(self.allocator, output.bytes);
                 try tx.pending.insert(self.allocator, .{
                     .start = output.offset,
@@ -1163,6 +1201,33 @@ pub const Connection = struct {
             return;
         };
         self.afterHandshakeProgress(now_us);
+    }
+
+    pub fn emitNewSessionTicket(
+        self: *Connection,
+        params: tls_handshake.EmitNewSessionTicketParams,
+        limits: tls_core.session.Limits,
+    ) tls_handshake.HandshakeError!tls_core.session.ServerRecoverableState {
+        if (self.state_ != .established or self.role != .server) return error.InvalidHandshakeState;
+        var sink = tls_handshake.EventSink{};
+        defer sink.deinit();
+        var ticket_state = try self.tls.emitNewSessionTicket(self.allocator, &sink, params, limits);
+        errdefer ticket_state.deinit();
+        try self.queueTlsEvents(&sink);
+        self.collectCryptoOutput() catch return error.HandshakeBufferOverflow;
+        return ticket_state;
+    }
+
+    fn queueTlsEvents(self: *Connection, sink: *tls_handshake.EventSink) tls_handshake.HandshakeError!void {
+        for (sink.items[0..sink.len]) |event| {
+            switch (event) {
+                .handshake_bytes => |hb| self.adapter.queueHandshakeOutput(hb.epoch, hb.data) catch |err| return switch (err) {
+                    error.InvalidCryptoLevel => error.UnexpectedCryptoLevel,
+                    error.CryptoBufferTooLarge => error.HandshakeBufferOverflow,
+                },
+                else => {},
+            }
+        }
     }
 
     fn afterHandshakeProgress(self: *Connection, now_us: u64) void {
@@ -1682,7 +1747,7 @@ pub const Connection = struct {
         const has_crypto = switch (space) {
             .initial => !self.crypto_tx[0].pending.isEmpty(),
             .handshake => !self.crypto_tx[1].pending.isEmpty(),
-            .application => false,
+            .application => !self.crypto_tx[2].pending.isEmpty(),
         };
         const has_app = space == .application and self.hasAppContent();
         if (!want_ack and !has_crypto and !(has_app and can_send_data) and !probe) return null;
@@ -1741,12 +1806,12 @@ pub const Connection = struct {
             const tx = switch (space) {
                 .initial => &self.crypto_tx[0],
                 .handshake => &self.crypto_tx[1],
-                .application => unreachable,
+                .application => &self.crypto_tx[2],
             };
             while (!tx.pending.isEmpty() and plain_len + frame.max_crypto_overhead + 16 < plain_budget) {
                 const room: u64 = @intCast(plain_budget - plain_len - frame.max_crypto_overhead);
                 const range = tx.pending.takeFirst(room) orelse break;
-                const data = tx.data.items[@intCast(range.start)..@intCast(range.end)];
+                const data = tx.slice(range);
                 const n = frame.encodeCrypto(range.start, data, plain[plain_len..plain_budget]) catch {
                     tx.pending.insert(self.allocator, range) catch {};
                     break;
@@ -2113,11 +2178,13 @@ const TestPair = struct {
     fn init(allocator: std.mem.Allocator) !*TestPair {
         const pair = try allocator.create(TestPair);
         pair.* = .{
-            .client_backend = tls_backend_mod.Tls13Backend.initClient(
+            .client_backend = try tls_backend_mod.Tls13Backend.initClientWithAllocator(
+                allocator,
                 .{ .hello_random = [_]u8{0xc1} ** 32, .key_share_seed = [_]u8{0x11} ** 32 },
                 .{ .pinned_certificate = tls_backend_mod.testdata.certificate_der },
             ),
-            .server_backend = tls_backend_mod.Tls13Backend.initServer(
+            .server_backend = tls_backend_mod.Tls13Backend.initServerWithAllocator(
+                allocator,
                 .{ .hello_random = [_]u8{0x51} ** 32, .key_share_seed = [_]u8{0x22} ** 32 },
                 try tls_backend_mod.Identity.initPkcs8(
                     tls_backend_mod.testdata.certificate_der,
@@ -2146,6 +2213,49 @@ const TestPair = struct {
         return pair;
     }
 
+    fn initWithTicketConsumer(
+        allocator: std.mem.Allocator,
+        limits: tls_core.session.Limits,
+        consumer: tls_core.tls13_backend.Tls13Backend.SessionTicketConsumer,
+    ) !*TestPair {
+        const pair = try allocator.create(TestPair);
+        pair.* = .{
+            .client_backend = try tls_backend_mod.Tls13Backend.initClientWithAllocator(
+                allocator,
+                .{ .hello_random = [_]u8{0xc1} ** 32, .key_share_seed = [_]u8{0x11} ** 32 },
+                .{ .pinned_certificate = tls_backend_mod.testdata.certificate_der },
+            ),
+            .server_backend = tls_backend_mod.Tls13Backend.initServerWithAllocator(
+                allocator,
+                .{ .hello_random = [_]u8{0x51} ** 32, .key_share_seed = [_]u8{0x22} ** 32 },
+                try tls_backend_mod.Identity.initPkcs8(
+                    tls_backend_mod.testdata.certificate_der,
+                    tls_backend_mod.testdata.private_key_pkcs8_der,
+                ),
+            ),
+        };
+        errdefer allocator.destroy(pair);
+        try pair.client_backend.engine.setSessionTicketConsumer(allocator, limits, consumer);
+        pair.client = try Connection.init(allocator, .{
+            .role = .client,
+            .local_cid = &client_cid,
+            .original_dcid = &odcid,
+            .peer_cid = &odcid,
+            .tls = pair.client_backend.backend(),
+            .now_us = pair.now_us,
+        });
+        errdefer pair.client.deinit();
+        pair.server = try Connection.init(allocator, .{
+            .role = .server,
+            .local_cid = &odcid,
+            .original_dcid = &odcid,
+            .peer_cid = &client_cid,
+            .tls = pair.server_backend.backend(),
+            .now_us = pair.now_us,
+        });
+        return pair;
+    }
+
     fn initClientAuth(
         allocator: std.mem.Allocator,
         client_provider: tls_core.credentials.CredentialProvider,
@@ -2153,11 +2263,13 @@ const TestPair = struct {
     ) !*TestPair {
         const pair = try allocator.create(TestPair);
         pair.* = .{
-            .client_backend = tls_backend_mod.Tls13Backend.initClient(
+            .client_backend = try tls_backend_mod.Tls13Backend.initClientWithAllocator(
+                allocator,
                 .{ .hello_random = [_]u8{0xc1} ** 32, .key_share_seed = [_]u8{0x11} ** 32 },
                 .{ .pinned_certificate = tls_backend_mod.testdata.certificate_der },
             ),
-            .server_backend = tls_backend_mod.Tls13Backend.initServer(
+            .server_backend = tls_backend_mod.Tls13Backend.initServerWithAllocator(
+                allocator,
                 .{ .hello_random = [_]u8{0x51} ** 32, .key_share_seed = [_]u8{0x22} ** 32 },
                 try tls_backend_mod.Identity.initPkcs8(
                     tls_backend_mod.testdata.certificate_der,
@@ -2223,7 +2335,8 @@ test "Connection.init failure before the handshake is assigned does not deinit u
     // was assigned -- deinitPartial()'s errdefer would then call
     // .deinit() on undefined storage. This must fail cleanly instead.
     const too_short_dcid = [_]u8{0xaa} ** (tls_adapter.min_initial_dcid_len - 1);
-    var backend = tls_backend_mod.Tls13Backend.initClient(
+    var backend = try tls_backend_mod.Tls13Backend.initClientWithAllocator(
+        allocator,
         .{ .hello_random = [_]u8{0xc1} ** 32, .key_share_seed = [_]u8{0x11} ** 32 },
         .{ .pinned_certificate = tls_backend_mod.testdata.certificate_der },
     );
@@ -2281,6 +2394,62 @@ test "driver: bidirectional stream data round-trips with FIN" {
 
     try testing.expectEqual(quic_stream.StreamState.closed, pair.client.streamState(id).?);
     try testing.expectEqual(quic_stream.StreamState.closed, pair.server.streamState(id).?);
+}
+
+test "driver: server NewSessionTicket uses application CRYPTO retransmission and stream traffic continues" {
+    const Capture = struct {
+        count: usize = 0,
+        ticket_len: usize = 0,
+
+        fn now(_: *anyopaque) i64 {
+            return 10;
+        }
+
+        fn onTicket(ctx: *anyopaque, ticket: *const tls_core.session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.count += 1;
+            self.ticket_len = ticket.ticket.slice().len;
+        }
+    };
+
+    const allocator = testing.allocator;
+    var capture = Capture{};
+    var pair = try TestPair.initWithTicketConsumer(allocator, tls_core.session.Limits.default, .{
+        .ctx = &capture,
+        .nowUnixMsFn = Capture.now,
+        .onTicketFn = Capture.onTicket,
+    });
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    var server_state = try pair.server.emitNewSessionTicket(.{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = "connection-ticket",
+        .issued_at_unix_ms = 10,
+    }, tls_core.session.Limits.default);
+    defer server_state.deinit();
+
+    var datagram: [2048]u8 = undefined;
+    const dropped = pair.server.pollTransmit(&datagram, pair.now_us) orelse return error.TestExpectedEqual;
+    try testing.expect(dropped.len > 0);
+    const sent = pair.server.sent_records.items[pair.server.sent_records.items.len - 1];
+    try testing.expectEqual(PacketNumberSpace.application, sent.space);
+    try testing.expect(sent.crypto != null);
+    pair.server.requeueRecord(sent);
+
+    try pair.pump();
+    try testing.expectEqual(@as(usize, 1), capture.count);
+    try testing.expectEqual(@as(usize, "connection-ticket".len), capture.ticket_len);
+
+    const id = try pair.client.openStream(.bidi);
+    try testing.expectEqual(@as(usize, 5), try pair.client.writeStream(id, "after", true));
+    try pair.pump();
+    try testing.expectEqual(@as(?StreamId, id), pair.server.acceptStream());
+    var buf: [16]u8 = undefined;
+    const request = try pair.server.readStream(id, &buf);
+    try testing.expectEqualStrings("after", buf[0..request.len]);
 }
 
 test "driver: local close reaches the peer and both sides drain" {
@@ -2483,11 +2652,13 @@ test "a real Connection closes with handshake_failure when the server has no app
 
         const pair = try allocator.create(TestPair);
         pair.* = .{
-            .client_backend = tls_backend_mod.Tls13Backend.initClient(
+            .client_backend = try tls_backend_mod.Tls13Backend.initClientWithAllocator(
+                allocator,
                 .{ .hello_random = [_]u8{0xc1} ** 32, .key_share_seed = [_]u8{0x11} ** 32 },
                 .{ .pinned_certificate = tls_backend_mod.testdata.certificate_der },
             ),
-            .server_backend = tls_backend_mod.Tls13Backend.initServer(
+            .server_backend = tls_backend_mod.Tls13Backend.initServerWithAllocator(
+                allocator,
                 .{ .hello_random = [_]u8{0x51} ** 32, .key_share_seed = [_]u8{0x22} ** 32 },
                 try tls_backend_mod.Identity.initPkcs8(tls_backend_mod.testdata.certificate_der, tls_backend_mod.testdata.private_key_pkcs8_der),
             ),

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -341,20 +341,75 @@ const CryptoTx = struct {
     fn reserveAppend(self: *CryptoTx, allocator: std.mem.Allocator, bytes_len: usize, max_outstanding: usize) !void {
         if (bytes_len > max_outstanding) return error.CryptoBufferTooLarge;
         if (self.data.items.len > max_outstanding - bytes_len) return error.CryptoBufferTooLarge;
-        if (self.data.capacity == 0) {
-            try self.data.ensureTotalCapacityPrecise(allocator, bytes_len);
-        } else if (self.data.capacity < self.data.items.len + bytes_len) {
-            return error.CryptoBufferTooLarge;
+
+        const new_total = self.data.items.len + bytes_len;
+        const range_budget = applicationCryptoRangeBudget(new_total);
+        const pending_capacity = self.pending.items.items.len + range_budget + 1;
+        const acked_capacity = self.acked.items.items.len + range_budget;
+
+        var new_data: ?[]u8 = null;
+        errdefer if (new_data) |buf| {
+            crypto_secrets.secureZero(buf);
+            allocator.free(buf);
+        };
+        if (self.data.capacity < new_total) {
+            const replacement = try allocator.alloc(u8, new_total);
+            @memcpy(replacement[0..self.data.items.len], self.data.items);
+            new_data = replacement;
         }
-        const range_budget = applicationCryptoRangeBudget(bytes_len);
-        try self.pending.ensureUnusedCapacity(allocator, range_budget + 1);
-        try self.acked.ensureUnusedCapacity(allocator, range_budget);
+
+        var new_pending: ?[]Range = null;
+        errdefer if (new_pending) |buf| allocator.free(buf);
+        if (self.pending.items.capacity < pending_capacity) {
+            const replacement = try allocator.alloc(Range, pending_capacity);
+            @memcpy(replacement[0..self.pending.items.items.len], self.pending.items.items);
+            new_pending = replacement;
+        }
+
+        var new_acked: ?[]Range = null;
+        errdefer if (new_acked) |buf| allocator.free(buf);
+        if (self.acked.items.capacity < acked_capacity) {
+            const replacement = try allocator.alloc(Range, acked_capacity);
+            @memcpy(replacement[0..self.acked.items.items.len], self.acked.items.items);
+            new_acked = replacement;
+        }
+
+        if (new_pending) |replacement| {
+            self.replaceRangeCapacity(allocator, &self.pending, replacement);
+            new_pending = null;
+        }
+        if (new_acked) |replacement| {
+            self.replaceRangeCapacity(allocator, &self.acked, replacement);
+            new_acked = null;
+        }
+        if (new_data) |replacement| {
+            self.replaceDataCapacity(allocator, replacement);
+            new_data = null;
+        }
+    }
+
+    fn replaceRangeCapacity(self: *CryptoTx, allocator: std.mem.Allocator, list: *RangeList, replacement: []Range) void {
+        _ = self;
+        const old_len = list.items.items.len;
+        if (list.items.capacity > 0) allocator.free(list.items.allocatedSlice());
+        list.items.items = replacement[0..old_len];
+        list.items.capacity = replacement.len;
+    }
+
+    fn replaceDataCapacity(self: *CryptoTx, allocator: std.mem.Allocator, replacement: []u8) void {
+        const old_len = self.data.items.len;
+        if (self.data.capacity > 0) {
+            crypto_secrets.secureZero(self.data.allocatedSlice());
+            allocator.free(self.data.allocatedSlice());
+        }
+        self.data.items = replacement[0..old_len];
+        self.data.capacity = replacement.len;
     }
 
     fn appendReserved(self: *CryptoTx, bytes: []const u8) void {
         const start = self.bufferedEnd();
         self.data.appendSliceAssumeCapacity(bytes);
-        self.pending.items.appendAssumeCapacity(.{
+        self.pending.insertAssumeCapacity(.{
             .start = start,
             .end = start + bytes.len,
         });
@@ -2360,6 +2415,42 @@ test "application CRYPTO transmit allocates exact storage and frees after ACK" {
     try testing.expect(tx.acked.isEmpty());
 }
 
+test "application CRYPTO transmit allows second outstanding ticket" {
+    const allocator = testing.allocator;
+    var tx = CryptoTx{};
+    defer tx.deinit(allocator);
+
+    try tx.reserveAppend(allocator, 12, max_application_crypto_outstanding);
+    tx.appendReserved("first-ticket");
+    try tx.reserveAppend(allocator, 13, max_application_crypto_outstanding);
+    tx.appendReserved("second-ticket");
+
+    try testing.expectEqual(@as(usize, 25), tx.data.items.len);
+    try testing.expectEqual(@as(usize, 25), tx.data.capacity);
+    try testing.expectEqualStrings("first-ticketsecond-ticket", tx.data.items);
+    try testing.expect(tx.pending.coversPrefix(25));
+}
+
+test "application CRYPTO reservation failure leaves empty state retryable" {
+    for (0..3) |fail_index| {
+        var failing = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = fail_index });
+        var tx = CryptoTx{};
+        defer tx.deinit(testing.allocator);
+
+        try testing.expectError(error.OutOfMemory, tx.reserveAppend(failing.allocator(), 12, max_application_crypto_outstanding));
+        try testing.expectEqual(@as(usize, 0), tx.data.items.len);
+        try testing.expectEqual(@as(usize, 0), tx.data.capacity);
+        try testing.expect(tx.pending.isEmpty());
+        try testing.expect(tx.acked.isEmpty());
+
+        const retry = "larger-ticket-after-failed-reserve";
+        try tx.reserveAppend(testing.allocator, retry.len, max_application_crypto_outstanding);
+        tx.appendReserved(retry);
+        try testing.expectEqual(retry.len, tx.data.items.len);
+        tx.markAcked(testing.allocator, .{ .start = 0, .end = retry.len });
+    }
+}
+
 const TestPair = struct {
     client_backend: tls_backend_mod.Tls13Backend,
     server_backend: tls_backend_mod.Tls13Backend,
@@ -2635,6 +2726,76 @@ test "driver: server NewSessionTicket uses application CRYPTO retransmission and
     try pair.pump();
     try testing.expectEqual(@as(usize, 1), capture.count);
     try testing.expectEqual(@as(usize, "connection-ticket".len), capture.ticket_len);
+
+    const id = try pair.client.openStream(.bidi);
+    try testing.expectEqual(@as(usize, 5), try pair.client.writeStream(id, "after", true));
+    try pair.pump();
+    try testing.expectEqual(@as(?StreamId, id), pair.server.acceptStream());
+    var buf: [16]u8 = undefined;
+    const request = try pair.server.readStream(id, &buf);
+    try testing.expectEqualStrings("after", buf[0..request.len]);
+}
+
+test "driver: server emits two outstanding tickets in order before ACK" {
+    const Capture = struct {
+        count: usize = 0,
+        ticket_lens: [2]usize = .{ 0, 0 },
+        psks: [2][tls_core.session.max_psk_len]u8 = .{ [_]u8{0} ** tls_core.session.max_psk_len, [_]u8{0} ** tls_core.session.max_psk_len },
+        psk_lens: [2]usize = .{ 0, 0 },
+
+        fn now(_: *anyopaque) i64 {
+            return 10;
+        }
+
+        fn onTicket(ctx: *anyopaque, ticket: *const tls_core.session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            const index = self.count;
+            if (index < self.ticket_lens.len) {
+                self.ticket_lens[index] = ticket.ticket.slice().len;
+                const psk = ticket.common.resumption_psk.slice();
+                @memcpy(self.psks[index][0..psk.len], psk);
+                self.psk_lens[index] = psk.len;
+            }
+            self.count += 1;
+        }
+    };
+
+    const allocator = testing.allocator;
+    var capture = Capture{};
+    var pair = try TestPair.initWithTicketConsumer(allocator, tls_core.session.Limits.default, .{
+        .ctx = &capture,
+        .nowUnixMsFn = Capture.now,
+        .onTicketFn = Capture.onTicket,
+    });
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    var state_a = try pair.server.emitNewSessionTicket(.{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = "ticket-a",
+        .issued_at_unix_ms = 10,
+    }, tls_core.session.Limits.default);
+    defer state_a.deinit();
+    var state_b = try pair.server.emitNewSessionTicket(.{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 2,
+        .ticket_nonce = "\x02",
+        .opaque_ticket = "ticket-b",
+        .issued_at_unix_ms = 10,
+    }, tls_core.session.Limits.default);
+    defer state_b.deinit();
+
+    try pair.pump();
+    try testing.expectEqual(@as(usize, 2), capture.count);
+    try testing.expectEqual(@as(usize, "ticket-a".len), capture.ticket_lens[0]);
+    try testing.expectEqual(@as(usize, "ticket-b".len), capture.ticket_lens[1]);
+    try testing.expectEqual(state_a.common.resumption_psk.slice().len, capture.psk_lens[0]);
+    try testing.expectEqual(state_b.common.resumption_psk.slice().len, capture.psk_lens[1]);
+    try testing.expectEqualSlices(u8, state_a.common.resumption_psk.slice(), capture.psks[0][0..capture.psk_lens[0]]);
+    try testing.expectEqualSlices(u8, state_b.common.resumption_psk.slice(), capture.psks[1][0..capture.psk_lens[1]]);
+    try testing.expect(!std.mem.eql(u8, capture.psks[0][0..capture.psk_lens[0]], capture.psks[1][0..capture.psk_lens[1]]));
 
     const id = try pair.client.openStream(.bidi);
     try testing.expectEqual(@as(usize, 5), try pair.client.writeStream(id, "after", true));

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -2758,6 +2758,128 @@ test "driver: server NewSessionTicket uses application CRYPTO retransmission and
     try testing.expectEqualStrings("after", buf[0..request.len]);
 }
 
+test "driver: maximum NewSessionTicket survives real loss reordering PTO and ACK cleanup" {
+    const Capture = struct {
+        allocator: std.mem.Allocator,
+        retained: tls_core.session.ClientTicketState = .{},
+        count: usize = 0,
+
+        fn now(_: *anyopaque) i64 {
+            return 10;
+        }
+
+        fn onTicket(ctx: *anyopaque, ticket: *const tls_core.session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            ticket.cloneInto(self.allocator, &self.retained) catch unreachable;
+            self.count += 1;
+        }
+    };
+
+    const allocator = testing.allocator;
+    const limits = tls_core.session.Limits{
+        .max_ticket_len = tls_core.session.absolute_ticket_wire_max,
+        .max_serialized_len = 128 * 1024,
+    };
+    const opaque_ticket = try allocator.alloc(u8, tls_core.session.absolute_ticket_wire_max);
+    defer allocator.free(opaque_ticket);
+    for (opaque_ticket, 0..) |*byte, index| byte.* = @intCast(index % 251);
+
+    var capture = Capture{ .allocator = allocator };
+    defer capture.retained.deinit();
+    var pair = try TestPair.initWithTicketConsumer(allocator, limits, .{
+        .ctx = &capture,
+        .nowUnixMsFn = Capture.now,
+        .onTicketFn = Capture.onTicket,
+    });
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    var server_state = try pair.server.emitNewSessionTicket(.{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 0x11223344,
+        .ticket_nonce = "\x01\x02",
+        .opaque_ticket = opaque_ticket,
+        .issued_at_unix_ms = 10,
+    }, limits);
+    defer server_state.deinit();
+    try testing.expect(pair.server.crypto_tx[2].data.items.len > max_datagram_size);
+
+    var datagrams = std.ArrayList([]u8).empty;
+    defer {
+        for (datagrams.items) |copy| allocator.free(copy);
+        datagrams.deinit(allocator);
+    }
+    var buf: [max_datagram_size]u8 = undefined;
+    while (pair.server.pollTransmit(&buf, pair.now_us)) |datagram| {
+        const copy = try allocator.dupe(u8, datagram);
+        errdefer allocator.free(copy);
+        try datagrams.append(allocator, copy);
+        pair.now_us += 500;
+    }
+    try testing.expect(datagrams.items.len > 5);
+
+    var index = datagrams.items.len;
+    while (index > 0) {
+        index -= 1;
+        if (index == 1 or index == 3) continue;
+        try pair.client.ingest(datagrams.items[index], pair.now_us);
+        pair.now_us += 500;
+    }
+
+    while (pair.client.pollTransmit(&buf, pair.now_us)) |ack| {
+        try pair.server.ingest(ack, pair.now_us);
+        pair.now_us += 500;
+    }
+    if (pair.server.metrics.packets_lost == 0) {
+        if (pair.server.nextTimeoutUs()) |deadline| pair.now_us = @max(pair.now_us + 1, deadline);
+        pair.server.onTimeout(pair.now_us);
+    }
+    try testing.expect(pair.server.metrics.packets_lost > 0 or pair.server.metrics.pto_count_total > 0);
+
+    var rounds: usize = 0;
+    while (rounds < 400 and capture.count == 0) : (rounds += 1) {
+        try pair.pump();
+        if (capture.count != 0) break;
+        if (pair.server.nextTimeoutUs()) |deadline| {
+            pair.now_us = @max(pair.now_us + 1, deadline);
+            pair.server.onTimeout(pair.now_us);
+        }
+        if (pair.client.nextTimeoutUs()) |deadline| {
+            pair.now_us = @max(pair.now_us + 1, deadline);
+            pair.client.onTimeout(pair.now_us);
+        }
+    }
+    try testing.expectEqual(@as(usize, 1), capture.count);
+    try testing.expectEqualSlices(u8, opaque_ticket, capture.retained.ticket.slice());
+    try testing.expectEqualSlices(u8, "\x01\x02", capture.retained.ticket_nonce.slice());
+    try testing.expectEqualSlices(u8, server_state.common.resumption_psk.slice(), capture.retained.common.resumption_psk.slice());
+
+    rounds = 0;
+    while (rounds < 200 and pair.server.crypto_tx[2].data.capacity > 0) : (rounds += 1) {
+        if (pair.client.nextTimeoutUs()) |deadline| {
+            pair.now_us = @max(pair.now_us + 1, deadline);
+            pair.client.onTimeout(pair.now_us);
+        }
+        try pair.pump();
+        if (pair.server.nextTimeoutUs()) |deadline| {
+            pair.now_us = @max(pair.now_us + 1, deadline);
+            pair.server.onTimeout(pair.now_us);
+        }
+    }
+    try testing.expectEqual(@as(usize, 0), pair.server.crypto_tx[2].data.items.len);
+    try testing.expectEqual(@as(usize, 0), pair.server.crypto_tx[2].data.capacity);
+    try testing.expect(pair.server.crypto_tx[2].pending.isEmpty());
+    try testing.expect(pair.server.crypto_tx[2].acked.isEmpty());
+
+    const stream_id = try pair.client.openStream(.bidi);
+    try testing.expectEqual(@as(usize, 5), try pair.client.writeStream(stream_id, "after", true));
+    try pair.pump();
+    try testing.expectEqual(@as(?StreamId, stream_id), pair.server.acceptStream());
+    var stream_buf: [16]u8 = undefined;
+    const request = try pair.server.readStream(stream_id, &stream_buf);
+    try testing.expectEqualStrings("after", stream_buf[0..request.len]);
+}
+
 test "driver: server emits two outstanding tickets in order before ACK" {
     const Capture = struct {
         count: usize = 0,

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -262,6 +262,23 @@ const CryptoTx = struct {
     acked: RangeList = .{},
     base: u64 = 0,
 
+    const Reservation = struct {
+        allocator: std.mem.Allocator,
+        data: ?[]u8 = null,
+        pending: ?[]Range = null,
+        acked: ?[]Range = null,
+
+        fn deinit(self: *Reservation) void {
+            if (self.data) |buf| {
+                crypto_secrets.secureZero(buf);
+                self.allocator.free(buf);
+            }
+            if (self.pending) |buf| self.allocator.free(buf);
+            if (self.acked) |buf| self.allocator.free(buf);
+            self.* = .{ .allocator = self.allocator };
+        }
+    };
+
     fn deinit(self: *CryptoTx, allocator: std.mem.Allocator) void {
         crypto_secrets.secureZero(self.data.allocatedSlice());
         self.data.deinit(allocator);
@@ -339,6 +356,12 @@ const CryptoTx = struct {
     }
 
     fn reserveAppend(self: *CryptoTx, allocator: std.mem.Allocator, bytes_len: usize, max_outstanding: usize) !void {
+        var reservation = try self.prepareAppend(allocator, bytes_len, max_outstanding);
+        errdefer reservation.deinit();
+        self.commitReservation(&reservation);
+    }
+
+    fn prepareAppend(self: *CryptoTx, allocator: std.mem.Allocator, bytes_len: usize, max_outstanding: usize) !Reservation {
         if (bytes_len > max_outstanding) return error.CryptoBufferTooLarge;
         if (self.data.items.len > max_outstanding - bytes_len) return error.CryptoBufferTooLarge;
 
@@ -347,44 +370,41 @@ const CryptoTx = struct {
         const pending_capacity = self.pending.items.items.len + range_budget + 1;
         const acked_capacity = self.acked.items.items.len + range_budget;
 
-        var new_data: ?[]u8 = null;
-        errdefer if (new_data) |buf| {
-            crypto_secrets.secureZero(buf);
-            allocator.free(buf);
-        };
+        var reservation = Reservation{ .allocator = allocator };
+        errdefer reservation.deinit();
         if (self.data.capacity < new_total) {
             const replacement = try allocator.alloc(u8, new_total);
             @memcpy(replacement[0..self.data.items.len], self.data.items);
-            new_data = replacement;
+            reservation.data = replacement;
         }
 
-        var new_pending: ?[]Range = null;
-        errdefer if (new_pending) |buf| allocator.free(buf);
         if (self.pending.items.capacity < pending_capacity) {
             const replacement = try allocator.alloc(Range, pending_capacity);
             @memcpy(replacement[0..self.pending.items.items.len], self.pending.items.items);
-            new_pending = replacement;
+            reservation.pending = replacement;
         }
 
-        var new_acked: ?[]Range = null;
-        errdefer if (new_acked) |buf| allocator.free(buf);
         if (self.acked.items.capacity < acked_capacity) {
             const replacement = try allocator.alloc(Range, acked_capacity);
             @memcpy(replacement[0..self.acked.items.items.len], self.acked.items.items);
-            new_acked = replacement;
+            reservation.acked = replacement;
         }
 
-        if (new_pending) |replacement| {
-            self.replaceRangeCapacity(allocator, &self.pending, replacement);
-            new_pending = null;
+        return reservation;
+    }
+
+    fn commitReservation(self: *CryptoTx, reservation: *Reservation) void {
+        if (reservation.pending) |replacement| {
+            self.replaceRangeCapacity(reservation.allocator, &self.pending, replacement);
+            reservation.pending = null;
         }
-        if (new_acked) |replacement| {
-            self.replaceRangeCapacity(allocator, &self.acked, replacement);
-            new_acked = null;
+        if (reservation.acked) |replacement| {
+            self.replaceRangeCapacity(reservation.allocator, &self.acked, replacement);
+            reservation.acked = null;
         }
-        if (new_data) |replacement| {
-            self.replaceDataCapacity(allocator, replacement);
-            new_data = null;
+        if (reservation.data) |replacement| {
+            self.replaceDataCapacity(reservation.allocator, replacement);
+            reservation.data = null;
         }
     }
 
@@ -1379,12 +1399,14 @@ pub const Connection = struct {
         const body_len = tls_core.new_session_ticket.encodedLen(emit_params) catch return error.IllegalParameter;
         const message_len = 4 + body_len;
         const tx = &self.crypto_tx[2];
-        tx.reserveAppend(self.allocator, message_len, max_application_crypto_outstanding) catch return error.HandshakeBufferOverflow;
+        var reservation = tx.prepareAppend(self.allocator, message_len, max_application_crypto_outstanding) catch return error.HandshakeBufferOverflow;
+        defer reservation.deinit();
 
         var sink = tls_handshake.EventSink{};
         defer sink.deinit();
         var ticket_state = try self.tls.emitNewSessionTicket(self.allocator, &sink, params, limits);
         errdefer ticket_state.deinit();
+        tx.commitReservation(&reservation);
         try self.queueApplicationCryptoEventsReserved(&sink, message_len);
         return ticket_state;
     }
@@ -2877,6 +2899,35 @@ test "driver: ticket model limit refusal happens before CRYPTO allocation" {
     try testing.expectEqual(@as(usize, 0), pair.server.crypto_tx[2].data.items.len);
     try testing.expectEqual(@as(usize, 0), pair.server.crypto_tx[2].data.capacity);
     try testing.expect(pair.server.crypto_tx[2].pending.isEmpty());
+}
+
+test "driver: backend ticket rejection leaves CRYPTO reservation uncommitted" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    try testing.expectError(error.InvalidHandshakeState, pair.server.emitNewSessionTicket(.{
+        .ticket_lifetime = 0,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = "ticket",
+        .issued_at_unix_ms = 10,
+    }, tls_core.session.Limits.default));
+    try testing.expectEqual(@as(usize, 0), pair.server.crypto_tx[2].data.items.len);
+    try testing.expectEqual(@as(usize, 0), pair.server.crypto_tx[2].data.capacity);
+    try testing.expect(pair.server.crypto_tx[2].pending.isEmpty());
+    try testing.expect(pair.server.crypto_tx[2].acked.isEmpty());
+
+    var state = try pair.server.emitNewSessionTicket(.{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = "ticket",
+        .issued_at_unix_ms = 10,
+    }, tls_core.session.Limits.default);
+    defer state.deinit();
+    try testing.expect(pair.server.crypto_tx[2].data.items.len > 0);
 }
 
 test "driver: local close reaches the peer and both sides drain" {

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -56,6 +56,7 @@ pub const State = enum {
 /// The datagram size this driver sends. Conservative (RFC 9000 §14.1 minimum)
 /// until DPLPMTUD lands under #256.
 pub const max_datagram_size: usize = recovery.max_datagram_size;
+pub const max_application_crypto_outstanding: usize = 2 * tls_core.tls13_transport.max_emitted_new_session_ticket_message_len;
 /// RFC 9000 §14.1: datagrams carrying Initial packets are padded to 1200.
 pub const min_initial_datagram: usize = 1200;
 
@@ -239,7 +240,7 @@ const CryptoTx = struct {
     base: u64 = 0,
 
     fn deinit(self: *CryptoTx, allocator: std.mem.Allocator) void {
-        crypto_secrets.secureZero(self.data.items);
+        crypto_secrets.secureZero(self.data.allocatedSlice());
         self.data.deinit(allocator);
         self.pending.deinit(allocator);
         self.acked.deinit(allocator);
@@ -255,23 +256,77 @@ const CryptoTx = struct {
         return self.data.items[start..end];
     }
 
+    fn liveRange(self: *const CryptoTx, incoming: Range) ?Range {
+        if (incoming.end <= self.base) return null;
+        var range = incoming;
+        if (range.start < self.base) range.start = self.base;
+        if (range.start >= range.end) return null;
+        return range;
+    }
+
     fn markAcked(self: *CryptoTx, allocator: std.mem.Allocator, range: Range) void {
-        self.acked.insert(allocator, range) catch {};
+        const live = self.liveRange(range) orelse return;
+        self.acked.insert(allocator, live) catch {};
         self.compactAcked();
     }
 
     fn compactAcked(self: *CryptoTx) void {
-        if (self.acked.items.items.len == 0) return;
+        while (self.acked.items.items.len > 0 and self.acked.items.items[0].end <= self.base) {
+            _ = self.acked.items.orderedRemove(0);
+        }
+        if (self.acked.items.items.len == 0) {
+            self.trimPendingBelowBase();
+            return;
+        }
         const first = self.acked.items.items[0];
         if (first.start != self.base or first.end <= self.base) return;
         const release_len: usize = @intCast(@min(first.end, self.bufferedEnd()) - self.base);
         if (release_len == 0) return;
+        const old_len = self.data.items.len;
         crypto_secrets.secureZero(self.data.items[0..release_len]);
         const keep_len = self.data.items.len - release_len;
         if (keep_len > 0) std.mem.copyForwards(u8, self.data.items[0..keep_len], self.data.items[release_len..]);
+        crypto_secrets.secureZero(self.data.items[keep_len..old_len]);
         self.data.shrinkRetainingCapacity(keep_len);
         self.base += release_len;
-        if (first.end <= self.base) _ = self.acked.items.orderedRemove(0);
+        if (first.end <= self.base) {
+            _ = self.acked.items.orderedRemove(0);
+        } else {
+            self.acked.items.items[0].start = self.base;
+        }
+        self.trimPendingBelowBase();
+    }
+
+    fn trimPendingBelowBase(self: *CryptoTx) void {
+        var out: usize = 0;
+        var index: usize = 0;
+        while (index < self.pending.items.items.len) : (index += 1) {
+            if (self.liveRange(self.pending.items.items[index])) |range| {
+                self.pending.items.items[out] = range;
+                out += 1;
+            }
+        }
+        self.pending.items.shrinkRetainingCapacity(out);
+    }
+
+    fn reserveAppend(self: *CryptoTx, allocator: std.mem.Allocator, bytes_len: usize, max_outstanding: usize) !void {
+        if (bytes_len > max_outstanding) return error.CryptoBufferTooLarge;
+        if (self.data.items.len > max_outstanding - bytes_len) return error.CryptoBufferTooLarge;
+        if (self.data.capacity == 0) {
+            try self.data.ensureTotalCapacity(allocator, max_outstanding);
+        } else if (self.data.capacity < self.data.items.len + bytes_len) {
+            return error.CryptoBufferTooLarge;
+        }
+        try self.pending.items.ensureUnusedCapacity(allocator, 1);
+    }
+
+    fn appendReserved(self: *CryptoTx, bytes: []const u8) void {
+        const start = self.bufferedEnd();
+        self.data.appendSliceAssumeCapacity(bytes);
+        self.pending.items.appendAssumeCapacity(.{
+            .start = start,
+            .end = start + bytes.len,
+        });
     }
 };
 
@@ -516,6 +571,12 @@ pub const Connection = struct {
         );
         conn.handshake.manual_key_discard = true;
         conn.handshake.allow_unverified_certificate = options.allow_unverified_certificate;
+        if (options.role == .client) {
+            options.tls.setPostHandshakeAllocator(allocator) catch |err| {
+                conn.failHandshake(err);
+                return conn;
+            };
+        }
         conn.handshake.start(params) catch |err| {
             conn.failHandshake(err);
             return conn;
@@ -1048,7 +1109,7 @@ pub const Connection = struct {
             };
             // If the level's keys are already discarded the buffer is gone.
             if (tx.data.items.len > 0) {
-                tx.pending.insert(self.allocator, range) catch {};
+                if (tx.liveRange(range)) |live| tx.pending.insert(self.allocator, live) catch {};
             }
         }
         for (record.streams[0..record.stream_count]) |sr| {
@@ -1161,8 +1222,9 @@ pub const Connection = struct {
 
     /// Drain queued TLS output into the per-level retransmission buffers.
     fn collectCryptoOutput(self: *Connection) !void {
-        inline for (.{ EncryptionLevel.initial, EncryptionLevel.handshake, EncryptionLevel.application }, 0..) |level, tx_index| {
+        inline for (.{ EncryptionLevel.initial, EncryptionLevel.handshake }, 0..) |level, tx_index| {
             var chunk: [2048]u8 = undefined;
+            defer crypto_secrets.secureZero(&chunk);
             while (self.handshake.pollOutput(level, &chunk) catch null) |output| {
                 const tx = &self.crypto_tx[tx_index];
                 std.debug.assert(output.offset == tx.bufferedEnd());
@@ -1209,25 +1271,39 @@ pub const Connection = struct {
         limits: tls_core.session.Limits,
     ) tls_handshake.HandshakeError!tls_core.session.ServerRecoverableState {
         if (self.state_ != .established or self.role != .server) return error.InvalidHandshakeState;
+        const emit_params: tls_core.new_session_ticket.EmitParams = .{
+            .ticket_lifetime = params.ticket_lifetime,
+            .ticket_age_add = params.ticket_age_add,
+            .ticket_nonce = params.ticket_nonce,
+            .ticket = params.opaque_ticket,
+            .max_early_data_size = params.max_early_data_size,
+        };
+        const body_len = tls_core.new_session_ticket.encodedLen(emit_params) catch return error.IllegalParameter;
+        const message_len = 4 + body_len;
+        const tx = &self.crypto_tx[2];
+        tx.reserveAppend(self.allocator, message_len, max_application_crypto_outstanding) catch return error.HandshakeBufferOverflow;
+
         var sink = tls_handshake.EventSink{};
         defer sink.deinit();
         var ticket_state = try self.tls.emitNewSessionTicket(self.allocator, &sink, params, limits);
         errdefer ticket_state.deinit();
-        try self.queueTlsEvents(&sink);
-        self.collectCryptoOutput() catch return error.HandshakeBufferOverflow;
+        try self.queueApplicationCryptoEventsReserved(&sink, message_len);
         return ticket_state;
     }
 
-    fn queueTlsEvents(self: *Connection, sink: *tls_handshake.EventSink) tls_handshake.HandshakeError!void {
+    fn queueApplicationCryptoEventsReserved(self: *Connection, sink: *tls_handshake.EventSink, expected_bytes: usize) tls_handshake.HandshakeError!void {
+        var appended: usize = 0;
         for (sink.items[0..sink.len]) |event| {
             switch (event) {
-                .handshake_bytes => |hb| self.adapter.queueHandshakeOutput(hb.epoch, hb.data) catch |err| return switch (err) {
-                    error.InvalidCryptoLevel => error.UnexpectedCryptoLevel,
-                    error.CryptoBufferTooLarge => error.HandshakeBufferOverflow,
+                .handshake_bytes => |hb| {
+                    if (hb.epoch != .application) return error.UnexpectedCryptoLevel;
+                    self.crypto_tx[2].appendReserved(hb.data);
+                    appended += hb.data.len;
                 },
                 else => {},
             }
         }
+        if (appended != expected_bytes) return error.HandshakeBufferOverflow;
     }
 
     fn afterHandshakeProgress(self: *Connection, now_us: u64) void {
@@ -1810,7 +1886,14 @@ pub const Connection = struct {
             };
             while (!tx.pending.isEmpty() and plain_len + frame.max_crypto_overhead + 16 < plain_budget) {
                 const room: u64 = @intCast(plain_budget - plain_len - frame.max_crypto_overhead);
-                const range = tx.pending.takeFirst(room) orelse break;
+                var range = tx.pending.takeFirst(room) orelse break;
+                range = tx.liveRange(range) orelse continue;
+                if (record.crypto) |existing| {
+                    if (existing.end != range.start) {
+                        tx.pending.insert(self.allocator, range) catch {};
+                        break;
+                    }
+                }
                 const data = tx.slice(range);
                 const n = frame.encodeCrypto(range.start, data, plain[plain_len..plain_budget]) catch {
                     tx.pending.insert(self.allocator, range) catch {};
@@ -1821,9 +1904,7 @@ pub const Connection = struct {
                 // One crypto range per record keeps requeue simple; merge by
                 // extending when contiguous.
                 if (record.crypto) |existing| {
-                    if (existing.end == range.start) {
-                        record.crypto = .{ .start = existing.start, .end = range.end };
-                    }
+                    record.crypto = .{ .start = existing.start, .end = range.end };
                 } else {
                     record.crypto = range;
                 }
@@ -2165,6 +2246,54 @@ pub const Connection = struct {
 const testing = std.testing;
 const tls_backend_mod = @import("tls_backend.zig");
 
+test "application CRYPTO transmit ignores stale PTO ranges after original ACK" {
+    const allocator = testing.allocator;
+    var tx = CryptoTx{};
+    defer tx.deinit(allocator);
+
+    try tx.reserveAppend(allocator, 8, max_application_crypto_outstanding);
+    tx.appendReserved("ticket-1");
+    try tx.pending.insert(allocator, .{ .start = 0, .end = 8 });
+
+    tx.markAcked(allocator, .{ .start = 0, .end = 8 });
+    try testing.expectEqual(@as(u64, 8), tx.base);
+    try testing.expectEqual(@as(usize, 0), tx.data.items.len);
+    try testing.expect(tx.pending.isEmpty());
+}
+
+test "application CRYPTO transmit ignores late duplicate ACKs and compacts later data" {
+    const allocator = testing.allocator;
+    var tx = CryptoTx{};
+    defer tx.deinit(allocator);
+
+    try tx.reserveAppend(allocator, 8, max_application_crypto_outstanding);
+    tx.appendReserved("ticket-1");
+    try tx.reserveAppend(allocator, 8, max_application_crypto_outstanding);
+    tx.appendReserved("ticket-2");
+
+    tx.markAcked(allocator, .{ .start = 0, .end = 8 });
+    tx.markAcked(allocator, .{ .start = 0, .end = 8 });
+    tx.markAcked(allocator, .{ .start = 8, .end = 16 });
+
+    try testing.expectEqual(@as(u64, 16), tx.base);
+    try testing.expectEqual(@as(usize, 0), tx.data.items.len);
+    try testing.expect(tx.acked.isEmpty());
+    try testing.expect(tx.pending.isEmpty());
+}
+
+test "application CRYPTO transmit clamps lost duplicate ranges below base" {
+    const allocator = testing.allocator;
+    var tx = CryptoTx{};
+    defer tx.deinit(allocator);
+
+    try tx.reserveAppend(allocator, 16, max_application_crypto_outstanding);
+    tx.appendReserved("ticket-ticket-12");
+    tx.markAcked(allocator, .{ .start = 0, .end = 8 });
+
+    const live = tx.liveRange(.{ .start = 0, .end = 16 }) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(Range{ .start = 8, .end = 16 }, live);
+}
+
 const TestPair = struct {
     client_backend: tls_backend_mod.Tls13Backend,
     server_backend: tls_backend_mod.Tls13Backend,
@@ -2178,13 +2307,11 @@ const TestPair = struct {
     fn init(allocator: std.mem.Allocator) !*TestPair {
         const pair = try allocator.create(TestPair);
         pair.* = .{
-            .client_backend = try tls_backend_mod.Tls13Backend.initClientWithAllocator(
-                allocator,
+            .client_backend = tls_backend_mod.Tls13Backend.initClient(
                 .{ .hello_random = [_]u8{0xc1} ** 32, .key_share_seed = [_]u8{0x11} ** 32 },
                 .{ .pinned_certificate = tls_backend_mod.testdata.certificate_der },
             ),
-            .server_backend = tls_backend_mod.Tls13Backend.initServerWithAllocator(
-                allocator,
+            .server_backend = tls_backend_mod.Tls13Backend.initServer(
                 .{ .hello_random = [_]u8{0x51} ** 32, .key_share_seed = [_]u8{0x22} ** 32 },
                 try tls_backend_mod.Identity.initPkcs8(
                     tls_backend_mod.testdata.certificate_der,
@@ -2450,6 +2577,57 @@ test "driver: server NewSessionTicket uses application CRYPTO retransmission and
     var buf: [16]u8 = undefined;
     const request = try pair.server.readStream(id, &buf);
     try testing.expectEqualStrings("after", buf[0..request.len]);
+}
+
+test "driver: ordinary no-consumer client drops server ticket and remains usable" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    var server_state = try pair.server.emitNewSessionTicket(.{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = "drop-this-ticket",
+        .issued_at_unix_ms = 10,
+    }, tls_core.session.Limits.default);
+    defer server_state.deinit();
+    try pair.pump();
+
+    try testing.expectEqual(State.established, pair.client.state());
+    try testing.expectEqual(State.established, pair.server.state());
+
+    const id = try pair.client.openStream(.bidi);
+    try testing.expectEqual(@as(usize, 4), try pair.client.writeStream(id, "ping", true));
+    try pair.pump();
+    try testing.expectEqual(@as(?StreamId, id), pair.server.acceptStream());
+    var buf: [16]u8 = undefined;
+    const request = try pair.server.readStream(id, &buf);
+    try testing.expectEqualStrings("ping", buf[0..request.len]);
+}
+
+test "driver: application CRYPTO ticket budget refuses one-over before queueing" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    var tx = &pair.server.crypto_tx[2];
+    try tx.reserveAppend(allocator, max_application_crypto_outstanding, max_application_crypto_outstanding);
+    const filler = try allocator.alloc(u8, max_application_crypto_outstanding);
+    defer allocator.free(filler);
+    @memset(filler, 0xa5);
+    tx.appendReserved(filler);
+
+    try testing.expectError(error.HandshakeBufferOverflow, pair.server.emitNewSessionTicket(.{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = "one-over",
+        .issued_at_unix_ms = 10,
+    }, tls_core.session.Limits.default));
+    try testing.expectEqual(max_application_crypto_outstanding, pair.server.crypto_tx[2].data.items.len);
 }
 
 test "driver: local close reaches the peer and both sides drain" {

--- a/src/quic/tls_adapter.zig
+++ b/src/quic/tls_adapter.zig
@@ -28,7 +28,7 @@ const HkdfSha256 = crypto.kdf.hkdf.HkdfSha256;
 const Aes128Gcm = crypto.aead.aes_gcm.Aes128Gcm;
 const Aes128 = crypto.core.aes.Aes128;
 
-pub const max_crypto_buffer = 64 * 1024;
+pub const max_crypto_buffer = tls_core.tls13_transport.max_emitted_new_session_ticket_message_len;
 pub const max_crypto_ranges = 32;
 pub const max_handshake_record = 16 * 1024;
 pub const max_secret_len = 64;
@@ -340,14 +340,11 @@ pub const CryptoStream = struct {
     buffer: [max_crypto_buffer]u8 = undefined,
     ranges: [max_crypto_ranges]ByteRange = undefined,
     range_count: usize = 0,
+    base_offset: u64 = 0,
     consumed_offset: u64 = 0,
 
     pub fn insert(self: *CryptoStream, offset: u64, data: []const u8) error{ CryptoBufferTooLarge, TooManyCryptoRanges }!void {
         if (data.len == 0) return;
-        if (offset >= max_crypto_buffer) return error.CryptoBufferTooLarge;
-        const offset_usize: usize = @intCast(offset);
-        if (data.len > max_crypto_buffer - offset_usize) return error.CryptoBufferTooLarge;
-
         var start = offset;
         var bytes = data;
         if (start + bytes.len <= self.consumed_offset) return;
@@ -357,24 +354,50 @@ pub const CryptoStream = struct {
             bytes = bytes[skip..];
         }
         const end = start + bytes.len;
+        self.compactConsumed();
+        if (start < self.base_offset) return error.CryptoBufferTooLarge;
+        const relative_start = start - self.base_offset;
+        if (relative_start >= max_crypto_buffer) return error.CryptoBufferTooLarge;
+        const relative_end = end - self.base_offset;
+        if (relative_end > max_crypto_buffer) return error.CryptoBufferTooLarge;
 
         try self.addRangeMerged(.{ .start = start, .end = end });
-        @memcpy(self.buffer[@intCast(start)..@intCast(end)], bytes);
+        @memcpy(self.buffer[@intCast(relative_start)..@intCast(relative_end)], bytes);
     }
 
     pub fn contiguous(self: *const CryptoStream) []const u8 {
         const end = self.contiguousEnd();
         if (end <= self.consumed_offset) return &.{};
-        return self.buffer[@intCast(self.consumed_offset)..@intCast(end)];
+        return self.buffer[@intCast(self.consumed_offset - self.base_offset)..@intCast(end - self.base_offset)];
     }
 
     pub fn consumeContiguous(self: *CryptoStream) []const u8 {
         const end = self.contiguousEnd();
         if (end <= self.consumed_offset) return &.{};
-        const bytes = self.buffer[@intCast(self.consumed_offset)..@intCast(end)];
+        const bytes = self.buffer[@intCast(self.consumed_offset - self.base_offset)..@intCast(end - self.base_offset)];
         self.consumed_offset = end;
         self.dropConsumedRanges();
         return bytes;
+    }
+
+    fn compactConsumed(self: *CryptoStream) void {
+        if (self.consumed_offset == self.base_offset) return;
+        const keep_start = self.consumed_offset;
+        const keep_end = self.bufferedEnd();
+        if (keep_end > keep_start) {
+            const old_start: usize = @intCast(keep_start - self.base_offset);
+            const keep_len: usize = @intCast(keep_end - keep_start);
+            std.mem.copyForwards(u8, self.buffer[0..keep_len], self.buffer[old_start..][0..keep_len]);
+        }
+        self.base_offset = self.consumed_offset;
+    }
+
+    fn bufferedEnd(self: *const CryptoStream) u64 {
+        var end = self.consumed_offset;
+        for (self.ranges[0..self.range_count]) |range| {
+            end = @max(end, range.end);
+        }
+        return end;
     }
 
     fn addRangeMerged(self: *CryptoStream, new_range: ByteRange) error{TooManyCryptoRanges}!void {
@@ -1329,6 +1352,18 @@ test "adapter queues outbound TLS handshake bytes as CRYPTO stream data" {
     try testing.expectEqual(EncryptionLevel.handshake, handshake.level);
     try testing.expectEqual(@as(u64, 0), handshake.offset);
     try testing.expectEqualStrings("server", handshake.bytes);
+}
+
+test "CRYPTO input storage is bounded by outstanding data, not lifetime offset" {
+    var stream = CryptoStream{};
+    const first = [_]u8{0x11} ** (40 * 1024);
+    const second = [_]u8{0x22} ** (40 * 1024);
+
+    try stream.insert(0, &first);
+    try testing.expectEqualSlices(u8, &first, stream.consumeContiguous());
+    try stream.insert(first.len, &second);
+    try testing.expectEqualSlices(u8, &second, stream.consumeContiguous());
+    try testing.expect(stream.consumed_offset > 64 * 1024);
 }
 
 test "0-RTT secrets are allowed but CRYPTO streams reject zero_rtt level" {

--- a/src/quic/tls_adapter.zig
+++ b/src/quic/tls_adapter.zig
@@ -139,6 +139,15 @@ pub const SecretStore = struct {
         self.write[level.index()] = null;
     }
 
+    pub fn deinit(self: *SecretStore) void {
+        inline for (0..4) |index| {
+            if (self.read[index]) |*secret| wipe(secret);
+            if (self.write[index]) |*secret| wipe(secret);
+            self.read[index] = null;
+            self.write[index] = null;
+        }
+    }
+
     fn installSlot(slot: *?Secret, secret: Secret) void {
         if (slot.*) |*old_secret| wipe(old_secret);
         slot.* = secret;
@@ -371,23 +380,28 @@ pub const CryptoStream = struct {
         return self.buffer[@intCast(self.consumed_offset - self.base_offset)..@intCast(end - self.base_offset)];
     }
 
-    pub fn consumeContiguous(self: *CryptoStream) []const u8 {
-        const end = self.contiguousEnd();
-        if (end <= self.consumed_offset) return &.{};
-        const bytes = self.buffer[@intCast(self.consumed_offset - self.base_offset)..@intCast(end - self.base_offset)];
-        self.consumed_offset = end;
+    pub fn discardContiguous(self: *CryptoStream, len: usize) void {
+        const available = self.contiguous().len;
+        const n = @min(len, available);
+        if (n == 0) return;
+        const start: usize = @intCast(self.consumed_offset - self.base_offset);
+        crypto_secrets.secureZero(self.buffer[start..][0..n]);
+        self.consumed_offset += n;
         self.dropConsumedRanges();
-        return bytes;
     }
 
     fn compactConsumed(self: *CryptoStream) void {
         if (self.consumed_offset == self.base_offset) return;
         const keep_start = self.consumed_offset;
         const keep_end = self.bufferedEnd();
+        const old_end: usize = @intCast(keep_end - self.base_offset);
         if (keep_end > keep_start) {
             const old_start: usize = @intCast(keep_start - self.base_offset);
             const keep_len: usize = @intCast(keep_end - keep_start);
             std.mem.copyForwards(u8, self.buffer[0..keep_len], self.buffer[old_start..][0..keep_len]);
+            crypto_secrets.secureZero(self.buffer[keep_len..old_end]);
+        } else {
+            crypto_secrets.secureZero(self.buffer[0..old_end]);
         }
         self.base_offset = self.consumed_offset;
     }
@@ -473,9 +487,14 @@ pub const CryptoReassembler = struct {
         return self.streams[index].contiguous();
     }
 
-    pub fn consumeContiguous(self: *CryptoReassembler, level: EncryptionLevel) error{InvalidCryptoLevel}![]const u8 {
+    pub fn discardContiguous(self: *CryptoReassembler, level: EncryptionLevel, len: usize) error{InvalidCryptoLevel}!void {
         const index = try cryptoStreamIndex(level);
-        return self.streams[index].consumeContiguous();
+        self.streams[index].discardContiguous(len);
+    }
+
+    pub fn deinit(self: *CryptoReassembler) void {
+        crypto_secrets.secureZero(std.mem.asBytes(self));
+        self.* = .{};
     }
 };
 
@@ -511,27 +530,39 @@ pub const CryptoOutput = struct {
         return self.end - self.start;
     }
 
-    pub fn take(self: *CryptoOutput, max_bytes: usize) ?struct { offset: u64, bytes: []const u8 } {
+    pub fn peek(self: *CryptoOutput, max_bytes: usize) ?struct { offset: u64, bytes: []const u8 } {
         const available = self.pending();
         if (available == 0) return null;
         const len = @min(available, max_bytes);
         const offset = self.next_offset;
         const bytes = self.buffer[self.start .. self.start + len];
-        self.start += len;
-        self.next_offset += len;
+        return .{ .offset = offset, .bytes = bytes };
+    }
+
+    pub fn discardTaken(self: *CryptoOutput, len: usize) void {
+        const n = @min(len, self.pending());
+        if (n == 0) return;
+        crypto_secrets.secureZero(self.buffer[self.start..][0..n]);
+        self.start += n;
+        self.next_offset += n;
         if (self.start == self.end) {
             self.start = 0;
             self.end = 0;
         }
-        return .{ .offset = offset, .bytes = bytes };
     }
 
     fn compact(self: *CryptoOutput) void {
         if (self.start == 0) return;
         const available = self.pending();
         if (available > 0) std.mem.copyForwards(u8, self.buffer[0..available], self.buffer[self.start..self.end]);
+        crypto_secrets.secureZero(self.buffer[available..self.end]);
         self.start = 0;
         self.end = available;
+    }
+
+    pub fn deinit(self: *CryptoOutput) void {
+        crypto_secrets.secureZero(std.mem.asBytes(self));
+        self.* = .{};
     }
 };
 
@@ -560,6 +591,14 @@ pub const QuicTlsAdapter = struct {
     application_write_key_phase: u1 = 0,
     application_read_key_phase: u1 = 0,
     metrics: Metrics = .{},
+
+    pub fn deinit(self: *QuicTlsAdapter) void {
+        self.secrets.deinit();
+        self.reassembler.deinit();
+        for (&self.outbound) |*out| out.deinit();
+        crypto_secrets.secureZero(std.mem.asBytes(self));
+        self.* = .{};
+    }
 
     pub fn setLocalTransportParameters(self: *QuicTlsAdapter, params: config.TransportParameters) void {
         self.local_transport_parameters = params;
@@ -605,9 +644,13 @@ pub const QuicTlsAdapter = struct {
     }
 
     pub fn nextHandshakeInput(self: *QuicTlsAdapter, level: EncryptionLevel) error{InvalidCryptoLevel}!?HandshakeInput {
-        const bytes = try self.reassembler.consumeContiguous(level);
+        const bytes = try self.reassembler.contiguous(level);
         if (bytes.len == 0) return null;
         return .{ .level = level, .bytes = bytes };
+    }
+
+    pub fn discardHandshakeInput(self: *QuicTlsAdapter, level: EncryptionLevel, len: usize) error{InvalidCryptoLevel}!void {
+        try self.reassembler.discardContiguous(level, len);
     }
 
     pub fn queueHandshakeOutput(self: *QuicTlsAdapter, level: EncryptionLevel, bytes: []const u8) error{ CryptoBufferTooLarge, InvalidCryptoLevel }!void {
@@ -618,8 +661,13 @@ pub const QuicTlsAdapter = struct {
     pub fn nextHandshakeOutput(self: *QuicTlsAdapter, level: EncryptionLevel, max_bytes: usize) error{InvalidCryptoLevel}!?HandshakeOutput {
         const index = try cryptoStreamIndex(level);
         if (max_bytes == 0) return null;
-        const output = self.outbound[index].take(max_bytes) orelse return null;
+        const output = self.outbound[index].peek(max_bytes) orelse return null;
         return .{ .level = level, .offset = output.offset, .bytes = output.bytes };
+    }
+
+    pub fn discardHandshakeOutput(self: *QuicTlsAdapter, level: EncryptionLevel, len: usize) error{InvalidCryptoLevel}!void {
+        const index = try cryptoStreamIndex(level);
+        self.outbound[index].discardTaken(len);
     }
 
     pub fn installSecret(self: *QuicTlsAdapter, installed_secret: Secret) void {
@@ -1213,11 +1261,13 @@ test "CRYPTO reassembly emits only contiguous bytes by encryption level" {
     try testing.expectEqual(@as(usize, 0), (try reassembler.contiguous(.initial)).len);
 
     try reassembler.insert(.handshake, 0, "other");
-    try testing.expectEqualStrings("other", try reassembler.consumeContiguous(.handshake));
+    try testing.expectEqualStrings("other", try reassembler.contiguous(.handshake));
+    try reassembler.discardContiguous(.handshake, "other".len);
 
     try reassembler.insert(.initial, 0, "hello ");
-    try testing.expectEqualStrings("hello world", try reassembler.consumeContiguous(.initial));
-    try testing.expectEqual(@as(usize, 0), (try reassembler.consumeContiguous(.initial)).len);
+    try testing.expectEqualStrings("hello world", try reassembler.contiguous(.initial));
+    try reassembler.discardContiguous(.initial, "hello world".len);
+    try testing.expectEqual(@as(usize, 0), (try reassembler.contiguous(.initial)).len);
 }
 
 test "CRYPTO reassembly merges duplicate and overlapping fragments" {
@@ -1227,20 +1277,23 @@ test "CRYPTO reassembly merges duplicate and overlapping fragments" {
     try stream.insert(6, "g");
 
     try testing.expectEqual(@as(usize, 1), stream.range_count);
-    try testing.expectEqualStrings("abcdefg", stream.consumeContiguous());
+    try testing.expectEqualStrings("abcdefg", stream.contiguous());
+    stream.discardContiguous("abcdefg".len);
 }
 
 test "CRYPTO reassembly preserves a gap after consumed bytes" {
     var stream = CryptoStream{};
     try stream.insert(0, "abc");
     try stream.insert(6, "ghi");
-    try testing.expectEqualStrings("abc", stream.consumeContiguous());
+    try testing.expectEqualStrings("abc", stream.contiguous());
+    stream.discardContiguous("abc".len);
     try testing.expectEqual(@as(u64, 3), stream.consumed_offset);
     try testing.expectEqual(@as(usize, 1), stream.range_count);
     try testing.expectEqual(@as(usize, 0), stream.contiguous().len);
 
     try stream.insert(3, "def");
-    try testing.expectEqualStrings("defghi", stream.consumeContiguous());
+    try testing.expectEqualStrings("defghi", stream.contiguous());
+    stream.discardContiguous("defghi".len);
 }
 
 test "CRYPTO insert merges a full range set without partial failure" {
@@ -1278,7 +1331,8 @@ test "CRYPTO insert does not mutate bytes when range insertion fails" {
 test "CRYPTO insert ignores and trims consumed retransmits" {
     var stream = CryptoStream{};
     try stream.insert(0, "hello");
-    try testing.expectEqualStrings("hello", stream.consumeContiguous());
+    try testing.expectEqualStrings("hello", stream.contiguous());
+    stream.discardContiguous("hello".len);
     try testing.expectEqual(@as(u64, 5), stream.consumed_offset);
 
     try stream.insert(0, "hello");
@@ -1286,7 +1340,8 @@ test "CRYPTO insert ignores and trims consumed retransmits" {
     try testing.expectEqual(@as(usize, 0), stream.contiguous().len);
 
     try stream.insert(3, "lo world");
-    try testing.expectEqualStrings(" world", stream.consumeContiguous());
+    try testing.expectEqualStrings(" world", stream.contiguous());
+    stream.discardContiguous(" world".len);
 }
 
 test "adapter tracks transport parameters ALPN secrets and handshake input" {
@@ -1310,10 +1365,12 @@ test "adapter tracks transport parameters ALPN secrets and handshake input" {
     const first_input = (try adapter.nextHandshakeInput(.initial)).?;
     try testing.expectEqual(EncryptionLevel.initial, first_input.level);
     try testing.expectEqualStrings("hel", first_input.bytes);
+    try adapter.discardHandshakeInput(.initial, first_input.bytes.len);
     try adapter.receiveCrypto(.initial, 3, "l");
     const input = (try adapter.nextHandshakeInput(.initial)).?;
     try testing.expectEqual(EncryptionLevel.initial, input.level);
     try testing.expectEqualStrings("llo", input.bytes);
+    try adapter.discardHandshakeInput(.initial, input.bytes.len);
 }
 
 test "secret store returns pointers and wipes discarded secret bytes" {
@@ -1342,16 +1399,36 @@ test "adapter queues outbound TLS handshake bytes as CRYPTO stream data" {
     try testing.expectEqual(EncryptionLevel.initial, first.level);
     try testing.expectEqual(@as(u64, 0), first.offset);
     try testing.expectEqualStrings("client", first.bytes);
+    try adapter.discardHandshakeOutput(.initial, first.bytes.len);
 
     const second = (try adapter.nextHandshakeOutput(.initial, 32)).?;
     try testing.expectEqual(@as(u64, 6), second.offset);
     try testing.expectEqualStrings(" hello", second.bytes);
+    try adapter.discardHandshakeOutput(.initial, second.bytes.len);
     try testing.expect((try adapter.nextHandshakeOutput(.initial, 1)) == null);
 
     const handshake = (try adapter.nextHandshakeOutput(.handshake, 32)).?;
     try testing.expectEqual(EncryptionLevel.handshake, handshake.level);
     try testing.expectEqual(@as(u64, 0), handshake.offset);
     try testing.expectEqualStrings("server", handshake.bytes);
+    try adapter.discardHandshakeOutput(.handshake, handshake.bytes.len);
+}
+
+test "adapter wipes consumed CRYPTO input and drained output bytes" {
+    var adapter = QuicTlsAdapter{};
+    const input_pattern = "ticket-input-pattern";
+    try adapter.receiveCrypto(.application, 0, input_pattern);
+    const input = (try adapter.nextHandshakeInput(.application)).?;
+    try testing.expectEqualStrings(input_pattern, input.bytes);
+    try adapter.discardHandshakeInput(.application, input.bytes.len);
+    try testing.expect(std.mem.indexOf(u8, &adapter.reassembler.streams[EncryptionLevel.application.index()].buffer, input_pattern) == null);
+
+    const output_pattern = "ticket-output-pattern";
+    try adapter.queueHandshakeOutput(.application, output_pattern);
+    const output = (try adapter.nextHandshakeOutput(.application, output_pattern.len)).?;
+    try testing.expectEqualStrings(output_pattern, output.bytes);
+    try adapter.discardHandshakeOutput(.application, output.bytes.len);
+    try testing.expect(std.mem.indexOf(u8, &adapter.outbound[EncryptionLevel.application.index()].buffer, output_pattern) == null);
 }
 
 test "CRYPTO input storage is bounded by outstanding data, not lifetime offset" {
@@ -1360,9 +1437,11 @@ test "CRYPTO input storage is bounded by outstanding data, not lifetime offset" 
     const second = [_]u8{0x22} ** (40 * 1024);
 
     try stream.insert(0, &first);
-    try testing.expectEqualSlices(u8, &first, stream.consumeContiguous());
+    try testing.expectEqualSlices(u8, &first, stream.contiguous());
+    stream.discardContiguous(first.len);
     try stream.insert(first.len, &second);
-    try testing.expectEqualSlices(u8, &second, stream.consumeContiguous());
+    try testing.expectEqualSlices(u8, &second, stream.contiguous());
+    stream.discardContiguous(second.len);
     try testing.expect(stream.consumed_offset > 64 * 1024);
 }
 

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -314,7 +314,7 @@ pub const Tls13Backend = struct {
 fn translate(source: *const RecordSink, destination: *EventSink) HandshakeError!void {
     for (source.items[0..source.len]) |event| {
         switch (event) {
-            .handshake_bytes => |item| try destination.emitHandshakeBytes(toLevel(item.epoch), item.data),
+            .handshake_bytes => |item| try destination.emitOwnedHandshakeBytesCopy(toLevel(item.epoch), item.data),
             .traffic_secret => |item| try destination.emitSecret(toLevel(item.epoch), item.direction, item.data),
             .peer_transport_parameters => {},
             .alpn => |protocol| try destination.emitAlpn(protocol),
@@ -555,7 +555,7 @@ test "QUIC TLS backend delivers large post-handshake tickets through application
     var harness = try RealHandshakeHarness.init();
     defer harness.deinit();
     var capture = Capture{};
-    const limits = tls_core.session.Limits{ .max_ticket_len = 20 * 1024, .max_serialized_len = 32 * 1024 };
+    const limits = tls_core.session.Limits{ .max_ticket_len = tls_core.session.absolute_ticket_wire_max, .max_serialized_len = 128 * 1024 };
     try harness.client_backend.engine.setSessionTicketConsumer(std.testing.allocator, limits, .{
         .ctx = &capture,
         .nowUnixMsFn = Capture.now,
@@ -564,7 +564,7 @@ test "QUIC TLS backend delivers large post-handshake tickets through application
     try harness.wire();
     try harness.run();
 
-    const opaque_ticket = try std.testing.allocator.alloc(u8, 20 * 1024);
+    const opaque_ticket = try std.testing.allocator.alloc(u8, tls_core.session.absolute_ticket_wire_max);
     defer std.testing.allocator.free(opaque_ticket);
     @memset(opaque_ticket, 0xa5);
 
@@ -599,6 +599,42 @@ test "QUIC TLS backend delivers large post-handshake tickets through application
     try std.testing.expectEqual(@as(usize, 1), capture.count);
     try std.testing.expectEqual(opaque_ticket.len, capture.ticket_len);
     try std.testing.expectEqualSlices(u8, server_state.common.resumption_psk.slice(), &capture.psk);
+}
+
+test "QUIC TLS backend drops valid post-handshake ticket with no consumer" {
+    var harness = try RealHandshakeHarness.init();
+    defer harness.deinit();
+    try harness.wire();
+    try harness.run();
+
+    var shared_sink = RecordSink{};
+    defer shared_sink.deinit();
+    var server_state = try harness.server_backend.engine.emitNewSessionTicket(std.testing.allocator, &shared_sink, .{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = "drop-ticket",
+        .issued_at_unix_ms = 10,
+    }, tls_core.session.Limits.default);
+    defer server_state.deinit();
+
+    var quic_sink = EventSink{};
+    defer quic_sink.deinit();
+    try translate(&shared_sink, &quic_sink);
+    try harness.server_adapter.queueHandshakeOutput(
+        quic_sink.items[0].handshake_bytes.epoch,
+        quic_sink.items[0].handshake_bytes.data,
+    );
+
+    var chunks: usize = 0;
+    var buf: [4]u8 = undefined;
+    while (try harness.server.pollOutput(.application, &buf)) |out| {
+        chunks += 1;
+        try harness.client.onCrypto(.application, out.offset, out.bytes);
+    }
+    try std.testing.expect(chunks > 1);
+    try std.testing.expect(harness.client.isComplete());
+    try std.testing.expect(harness.server.isComplete());
 }
 
 fn quicSniConfig(patterns: []const []const u8, chain: []const []const u8) tls_core.sni_provider.CredentialBundleConfig {

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -267,6 +267,7 @@ pub const Tls13Backend = struct {
             },
             .setCidBindingFn = setCidBinding,
             .peerCidBindingFn = peerCidBinding,
+            .setPostHandshakeAllocatorFn = setPostHandshakeAllocator,
             .emitNewSessionTicketFn = emitNewSessionTicket,
         };
     }
@@ -304,6 +305,16 @@ pub const Tls13Backend = struct {
     fn peerCidBinding(ptr: *anyopaque) config.CidBinding {
         const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
         return self.peer_cid_binding;
+    }
+
+    fn setPostHandshakeAllocator(ptr: *anyopaque, allocator: std.mem.Allocator) HandshakeError!void {
+        const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
+        if (self.engine.role != .client) return;
+        if (self.allocator) |existing| {
+            if (existing.ptr == allocator.ptr and existing.vtable == allocator.vtable) return;
+        }
+        self.allocator = allocator;
+        self.engine.setPostHandshakeAllocator(allocator) catch |err| return mapError(err);
     }
 
     fn emitNewSessionTicket(

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -402,6 +402,11 @@ test "QUIC adapter owns CID binding round trip" {
     try std.testing.expectEqualDeep(local, peer);
 }
 
+test "QUIC TLS backend does not embed maximum ticket storage" {
+    try std.testing.expect(@sizeOf(Tls13Backend) < 128 * 1024);
+    try std.testing.expect(@sizeOf(Tls13Backend) < tls_core.tls13_transport.max_new_session_ticket_message_len);
+}
+
 test "QUIC adapter teardown wipes private scratch, parameters, and shared engine ownership" {
     const entropy = Entropy{ .hello_random = [_]u8{0x31} ** 32, .key_share_seed = [_]u8{0x32} ** 32 };
     var backend = Tls13Backend.initServer(
@@ -527,6 +532,73 @@ test "QUIC handshake owner tears down shared and adapter storage on success" {
     harness.deinit();
     try expectQuicBackendWiped(&harness.client_backend);
     try expectQuicBackendWiped(&harness.server_backend);
+}
+
+test "QUIC TLS backend delivers large post-handshake tickets through application CRYPTO chunks" {
+    const Capture = struct {
+        count: usize = 0,
+        psk: [hash_len]u8 = undefined,
+        ticket_len: usize = 0,
+
+        fn now(_: *anyopaque) i64 {
+            return 10;
+        }
+
+        fn onTicket(ctx: *anyopaque, ticket: *const tls_core.session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.count += 1;
+            @memcpy(&self.psk, ticket.common.resumption_psk.slice());
+            self.ticket_len = ticket.ticket.slice().len;
+        }
+    };
+
+    var harness = try RealHandshakeHarness.init();
+    defer harness.deinit();
+    var capture = Capture{};
+    const limits = tls_core.session.Limits{ .max_ticket_len = 20 * 1024, .max_serialized_len = 32 * 1024 };
+    try harness.client_backend.engine.setSessionTicketConsumer(std.testing.allocator, limits, .{
+        .ctx = &capture,
+        .nowUnixMsFn = Capture.now,
+        .onTicketFn = Capture.onTicket,
+    });
+    try harness.wire();
+    try harness.run();
+
+    const opaque_ticket = try std.testing.allocator.alloc(u8, 20 * 1024);
+    defer std.testing.allocator.free(opaque_ticket);
+    @memset(opaque_ticket, 0xa5);
+
+    var shared_sink = RecordSink{};
+    defer shared_sink.deinit();
+    var server_state = try harness.server_backend.engine.emitNewSessionTicket(std.testing.allocator, &shared_sink, .{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = opaque_ticket,
+        .issued_at_unix_ms = 10,
+    }, limits);
+    defer server_state.deinit();
+    try std.testing.expect(shared_sink.items[0].handshake_bytes.data.len > 16 * 1024);
+
+    var quic_sink = EventSink{};
+    defer quic_sink.deinit();
+    try translate(&shared_sink, &quic_sink);
+    try std.testing.expectEqual(@as(usize, 1), quic_sink.len);
+    try harness.server_adapter.queueHandshakeOutput(
+        quic_sink.items[0].handshake_bytes.epoch,
+        quic_sink.items[0].handshake_bytes.data,
+    );
+
+    var chunks: usize = 0;
+    var buf: [4096]u8 = undefined;
+    while (try harness.server.pollOutput(.application, &buf)) |out| {
+        chunks += 1;
+        try harness.client.onCrypto(.application, out.offset, out.bytes);
+    }
+    try std.testing.expect(chunks > 1);
+    try std.testing.expectEqual(@as(usize, 1), capture.count);
+    try std.testing.expectEqual(opaque_ticket.len, capture.ticket_len);
+    try std.testing.expectEqualSlices(u8, server_state.common.resumption_psk.slice(), &capture.psk);
 }
 
 fn quicSniConfig(patterns: []const []const u8, chain: []const []const u8) tls_core.sni_provider.CredentialBundleConfig {

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -193,6 +193,7 @@ fn integerParameter(value_bytes: []const u8) HandshakeError!u64 {
 }
 
 pub const Tls13Backend = struct {
+    allocator: ?std.mem.Allocator = null,
     engine: shared.Tls13Backend,
     alpn: []const u8 = "h3",
     cid_binding: config.CidBinding = .{},
@@ -212,6 +213,17 @@ pub const Tls13Backend = struct {
         } }, options) };
     }
 
+    pub fn initClientWithAllocator(allocator: std.mem.Allocator, entropy: Entropy, trust: Trust) HandshakeError!Tls13Backend {
+        return initClientWithAllocatorAndOptions(allocator, entropy, trust, .{});
+    }
+
+    pub fn initClientWithAllocatorAndOptions(allocator: std.mem.Allocator, entropy: Entropy, trust: Trust, options: ClientOptions) HandshakeError!Tls13Backend {
+        var self = initClientWithOptions(entropy, trust, options);
+        self.allocator = allocator;
+        self.engine.setPostHandshakeAllocator(allocator) catch |err| return mapError(err);
+        return self;
+    }
+
     pub fn initServer(entropy: Entropy, identity: Identity) Tls13Backend {
         return .{ .engine = shared.Tls13Backend.initServer(entropy, identity, .{ .extension = .{
             .alpn = "h3",
@@ -220,12 +232,24 @@ pub const Tls13Backend = struct {
         } }) };
     }
 
+    pub fn initServerWithAllocator(allocator: std.mem.Allocator, entropy: Entropy, identity: Identity) Tls13Backend {
+        var self = initServer(entropy, identity);
+        self.allocator = allocator;
+        return self;
+    }
+
     pub fn initServerWithProvider(entropy: Entropy, provider: CredentialProvider) Tls13Backend {
         return .{ .engine = shared.Tls13Backend.initServerWithProvider(entropy, provider, .{ .extension = .{
             .alpn = "h3",
             .extension_type = ext_quic_transport_parameters,
             .local = "",
         } }) };
+    }
+
+    pub fn initServerWithAllocatorAndProvider(allocator: std.mem.Allocator, entropy: Entropy, provider: CredentialProvider) Tls13Backend {
+        var self = initServerWithProvider(entropy, provider);
+        self.allocator = allocator;
+        return self;
     }
 
     pub fn backend(self: *Tls13Backend) tls_handshake.TlsBackend {
@@ -243,6 +267,7 @@ pub const Tls13Backend = struct {
             },
             .setCidBindingFn = setCidBinding,
             .peerCidBindingFn = peerCidBinding,
+            .emitNewSessionTicketFn = emitNewSessionTicket,
         };
     }
 
@@ -256,7 +281,7 @@ pub const Tls13Backend = struct {
         self.scratch.reset();
         const result = self.engine.resumeAuth(&self.scratch);
         try self.forwardPeerTransportParameters(sink);
-        try translate(&self.scratch, sink);
+        try translate(self.allocator, &self.scratch, sink);
         result catch |err| return mapError(err);
     }
 
@@ -281,6 +306,21 @@ pub const Tls13Backend = struct {
         return self.peer_cid_binding;
     }
 
+    fn emitNewSessionTicket(
+        ptr: *anyopaque,
+        allocator: std.mem.Allocator,
+        sink: *EventSink,
+        params: tls_handshake.EmitNewSessionTicketParams,
+        limits: tls_core.session.Limits,
+    ) HandshakeError!tls_core.session.ServerRecoverableState {
+        const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
+        self.scratch.reset();
+        var state = self.engine.emitNewSessionTicket(allocator, &self.scratch, params, limits) catch |err| return mapError(err);
+        errdefer state.deinit();
+        try translate(self.allocator, &self.scratch, sink);
+        return state;
+    }
+
     fn start(ptr: *anyopaque, role: tls_handshake.Role, params: config.TransportParameters, sink: *EventSink) HandshakeError!void {
         const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
         const encoded = try encodeTransportParametersBound(params, self.cid_binding, &self.local_transport_parameters);
@@ -292,7 +332,7 @@ pub const Tls13Backend = struct {
         self.scratch.reset();
         const result = self.engine.backend().start(role, {}, &self.scratch);
         try self.forwardPeerTransportParameters(sink);
-        try translate(&self.scratch, sink);
+        try translate(self.allocator, &self.scratch, sink);
         result catch |err| return mapError(err);
     }
 
@@ -301,7 +341,7 @@ pub const Tls13Backend = struct {
         self.scratch.reset();
         const result = self.engine.backend().receive(toEpoch(level), bytes, &self.scratch);
         try self.forwardPeerTransportParameters(sink);
-        try translate(&self.scratch, sink);
+        try translate(self.allocator, &self.scratch, sink);
         result catch |err| return mapError(err);
     }
 
@@ -311,10 +351,25 @@ pub const Tls13Backend = struct {
     }
 };
 
-fn translate(source: *const RecordSink, destination: *EventSink) HandshakeError!void {
-    for (source.items[0..source.len]) |event| {
+fn translate(allocator: ?std.mem.Allocator, source: *RecordSink, destination: *EventSink) HandshakeError!void {
+    var index: usize = 0;
+    while (index < source.len) : (index += 1) {
+        const event = source.items[index];
         switch (event) {
-            .handshake_bytes => |item| try destination.emitOwnedHandshakeBytesCopy(toLevel(item.epoch), item.data),
+            .handshake_bytes => |item| {
+                if (item.data.len <= EventSink.max_bytes) {
+                    try destination.emitHandshakeBytes(toLevel(item.epoch), item.data);
+                } else if (source.takeOwnedHandshakePayload(index)) |payload| {
+                    destination.emitOwnedHandshakeBytes(payload.allocator, toLevel(item.epoch), payload.bytes) catch |err| {
+                        std.crypto.secureZero(u8, payload.bytes);
+                        payload.allocator.free(payload.bytes);
+                        return err;
+                    };
+                } else {
+                    const explicit_allocator = allocator orelse return error.InvalidHandshakeState;
+                    try destination.emitOwnedHandshakeBytesCopy(explicit_allocator, toLevel(item.epoch), item.data);
+                }
+            },
             .traffic_secret => |item| try destination.emitSecret(toLevel(item.epoch), item.direction, item.data),
             .peer_transport_parameters => {},
             .alpn => |protocol| try destination.emitAlpn(protocol),
@@ -442,11 +497,13 @@ const RealHandshakeHarness = struct {
 
     fn init() !RealHandshakeHarness {
         return .{
-            .client_backend = Tls13Backend.initClient(
+            .client_backend = try Tls13Backend.initClientWithAllocator(
+                std.testing.allocator,
                 .{ .hello_random = [_]u8{0xc1} ** 32, .key_share_seed = [_]u8{0x11} ** 32 },
                 .{ .pinned_certificate = testdata.certificate_der },
             ),
-            .server_backend = Tls13Backend.initServer(
+            .server_backend = Tls13Backend.initServerWithAllocator(
+                std.testing.allocator,
                 .{ .hello_random = [_]u8{0x51} ** 32, .key_share_seed = [_]u8{0x22} ** 32 },
                 try Identity.initPkcs8(testdata.certificate_der, testdata.private_key_pkcs8_der),
             ),
@@ -455,12 +512,14 @@ const RealHandshakeHarness = struct {
 
     fn initWithSniProvider(server_name: []const u8, provider: tls_core.credentials.CredentialProvider) !RealHandshakeHarness {
         const harness = RealHandshakeHarness{
-            .client_backend = Tls13Backend.initClientWithOptions(
+            .client_backend = try Tls13Backend.initClientWithAllocatorAndOptions(
+                std.testing.allocator,
                 .{ .hello_random = [_]u8{0xc1} ** 32, .key_share_seed = [_]u8{0x11} ** 32 },
                 .{ .pinned_certificate = testdata.certificate_der },
                 .{ .server_name = server_name },
             ),
-            .server_backend = Tls13Backend.initServerWithProvider(
+            .server_backend = Tls13Backend.initServerWithAllocatorAndProvider(
+                std.testing.allocator,
                 .{ .hello_random = [_]u8{0x51} ** 32, .key_share_seed = [_]u8{0x22} ** 32 },
                 provider,
             ),
@@ -582,7 +641,7 @@ test "QUIC TLS backend delivers large post-handshake tickets through application
 
     var quic_sink = EventSink{};
     defer quic_sink.deinit();
-    try translate(&shared_sink, &quic_sink);
+    try translate(std.testing.allocator, &shared_sink, &quic_sink);
     try std.testing.expectEqual(@as(usize, 1), quic_sink.len);
     try harness.server_adapter.queueHandshakeOutput(
         quic_sink.items[0].handshake_bytes.epoch,
@@ -620,7 +679,7 @@ test "QUIC TLS backend drops valid post-handshake ticket with no consumer" {
 
     var quic_sink = EventSink{};
     defer quic_sink.deinit();
-    try translate(&shared_sink, &quic_sink);
+    try translate(std.testing.allocator, &shared_sink, &quic_sink);
     try harness.server_adapter.queueHandshakeOutput(
         quic_sink.items[0].handshake_bytes.epoch,
         quic_sink.items[0].handshake_bytes.data,

--- a/src/quic/tls_handshake.zig
+++ b/src/quic/tls_handshake.zig
@@ -69,6 +69,7 @@ pub const TlsBackend = struct {
     /// in-memory test backend leaves them null.
     setCidBindingFn: ?*const fn (ptr: *anyopaque, binding: config.CidBinding) void = null,
     peerCidBindingFn: ?*const fn (ptr: *anyopaque) config.CidBinding = null,
+    setPostHandshakeAllocatorFn: ?*const fn (ptr: *anyopaque, allocator: std.mem.Allocator) HandshakeError!void = null,
     emitNewSessionTicketFn: ?*const fn (
         ptr: *anyopaque,
         allocator: std.mem.Allocator,
@@ -92,6 +93,10 @@ pub const TlsBackend = struct {
     pub fn peerCidBinding(self: TlsBackend) config.CidBinding {
         if (self.peerCidBindingFn) |get| return get(self.transport.ptr);
         return .{};
+    }
+
+    pub fn setPostHandshakeAllocator(self: TlsBackend, allocator: std.mem.Allocator) HandshakeError!void {
+        if (self.setPostHandshakeAllocatorFn) |set| try set(self.transport.ptr, allocator);
     }
 
     pub fn emitNewSessionTicket(

--- a/src/quic/tls_handshake.zig
+++ b/src/quic/tls_handshake.zig
@@ -55,6 +55,7 @@ pub const Event = TransportContract.Event;
 pub const EventSink = TransportContract.EventSink;
 pub const TlsTransportBackend = TransportContract.Backend;
 pub const CoreDriver = tls_core.engine.Driver(TransportContract);
+pub const EmitNewSessionTicketParams = tls_core.tls13_backend.Tls13Backend.EmitNewSessionTicketParams;
 
 /// Runtime interface to a concrete TLS 1.3 engine. The engine consumes and
 /// produces raw handshake bytes and reports keying material / negotiation
@@ -68,6 +69,13 @@ pub const TlsBackend = struct {
     /// in-memory test backend leaves them null.
     setCidBindingFn: ?*const fn (ptr: *anyopaque, binding: config.CidBinding) void = null,
     peerCidBindingFn: ?*const fn (ptr: *anyopaque) config.CidBinding = null,
+    emitNewSessionTicketFn: ?*const fn (
+        ptr: *anyopaque,
+        allocator: std.mem.Allocator,
+        sink: *EventSink,
+        params: EmitNewSessionTicketParams,
+        limits: tls_core.session.Limits,
+    ) HandshakeError!tls_core.session.ServerRecoverableState = null,
 
     fn start(self: TlsBackend, role: Role, params: config.TransportParameters, sink: *EventSink) HandshakeError!void {
         return self.transport.start(role, params, sink);
@@ -84,6 +92,17 @@ pub const TlsBackend = struct {
     pub fn peerCidBinding(self: TlsBackend) config.CidBinding {
         if (self.peerCidBindingFn) |get| return get(self.transport.ptr);
         return .{};
+    }
+
+    pub fn emitNewSessionTicket(
+        self: TlsBackend,
+        allocator: std.mem.Allocator,
+        sink: *EventSink,
+        params: EmitNewSessionTicketParams,
+        limits: tls_core.session.Limits,
+    ) HandshakeError!tls_core.session.ServerRecoverableState {
+        const emit = self.emitNewSessionTicketFn orelse return error.InvalidHandshakeState;
+        return emit(self.transport.ptr, allocator, sink, params, limits);
     }
 
     pub fn deinit(self: TlsBackend) void {
@@ -154,7 +173,12 @@ pub const Handshake = struct {
         });
         while (true) {
             const input = (self.adapter.nextHandshakeInput(level) catch return self.fail(error.UnexpectedCryptoLevel)) orelse break;
-            try self.applyEvents(try self.driver.receive(input.level, input.bytes));
+            const sink = self.driver.receive(input.level, input.bytes) catch |err| {
+                self.adapter.discardHandshakeInput(input.level, input.bytes.len) catch {};
+                return err;
+            };
+            self.adapter.discardHandshakeInput(input.level, input.bytes.len) catch {};
+            try self.applyEvents(sink);
         }
     }
 
@@ -173,6 +197,9 @@ pub const Handshake = struct {
             error.InvalidCryptoLevel => error.UnexpectedCryptoLevel,
         })) orelse return null;
         @memcpy(buf[0..output.bytes.len], output.bytes);
+        self.adapter.discardHandshakeOutput(level, output.bytes.len) catch |err| return self.fail(switch (err) {
+            error.InvalidCryptoLevel => error.UnexpectedCryptoLevel,
+        });
         return .{ .offset = output.offset, .bytes = buf[0..output.bytes.len] };
     }
 

--- a/src/quic/tls_handshake.zig
+++ b/src/quic/tls_handshake.zig
@@ -47,7 +47,7 @@ const TransportContract = tls_core.transport.ContractWithOptions(
     EncryptionLevel,
     HandshakeError,
     16,
-    16 * 1024,
+    tls_core.tls13_transport.max_event_bytes,
     error.HandshakeBufferOverflow,
 );
 

--- a/src/tls/alerts.zig
+++ b/src/tls/alerts.zig
@@ -41,6 +41,7 @@ pub fn fromHandshakeError(err: events.HandshakeError) AlertDescription {
         error.UnsupportedCertificate => .unsupported_certificate,
         error.SecretExportFailed => .internal_error,
         error.InvalidHandshakeState => .internal_error,
+        error.TicketTooLarge => .internal_error,
         error.AlpnMismatch => .no_application_protocol,
         // This side could not produce an acceptable credential/signature for
         // the negotiated parameters (RFC 8446 §4.4.2.2).

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -466,7 +466,19 @@ pub const PureZigRecordStream = struct {
         backend: RecordHandshakeBackend,
     ) PureZigRecordStream {
         var stream_state = init(role, crypto_provider, cipher_suite);
-        if (role == .client) backend.setPostHandshakeAllocator(std.heap.smp_allocator) catch unreachable;
+        stream_state.handshake_driver = RecordHandshakeDriver.init(role, backend);
+        return stream_state;
+    }
+
+    pub fn initWithBackendAndAllocator(
+        allocator: std.mem.Allocator,
+        role: tls_state.Role,
+        crypto_provider: provider.CryptoProvider,
+        cipher_suite: algorithms.CipherSuite,
+        backend: RecordHandshakeBackend,
+    ) Error!PureZigRecordStream {
+        var stream_state = init(role, crypto_provider, cipher_suite);
+        if (role == .client) try backend.setPostHandshakeAllocator(allocator);
         stream_state.handshake_driver = RecordHandshakeDriver.init(role, backend);
         return stream_state;
     }
@@ -479,7 +491,20 @@ pub const PureZigRecordStream = struct {
         limits: BufferLimits,
     ) Error!PureZigRecordStream {
         var stream_state = try initWithLimits(role, crypto_provider, cipher_suite, limits);
-        if (role == .client) try backend.setPostHandshakeAllocator(std.heap.smp_allocator);
+        stream_state.handshake_driver = RecordHandshakeDriver.init(role, backend);
+        return stream_state;
+    }
+
+    pub fn initWithBackendAllocatorAndLimits(
+        allocator: std.mem.Allocator,
+        role: tls_state.Role,
+        crypto_provider: provider.CryptoProvider,
+        cipher_suite: algorithms.CipherSuite,
+        backend: RecordHandshakeBackend,
+        limits: BufferLimits,
+    ) Error!PureZigRecordStream {
+        var stream_state = try initWithLimits(role, crypto_provider, cipher_suite, limits);
+        if (role == .client) try backend.setPostHandshakeAllocator(allocator);
         stream_state.handshake_driver = RecordHandshakeDriver.init(role, backend);
         return stream_state;
     }
@@ -499,6 +524,20 @@ pub const PureZigRecordStream = struct {
         return stream_state;
     }
 
+    pub fn initWithCarrierBackendAndAllocator(
+        allocator: std.mem.Allocator,
+        role: tls_state.Role,
+        crypto_provider: provider.CryptoProvider,
+        cipher_suite: algorithms.CipherSuite,
+        carrier: Carrier,
+        backend: RecordHandshakeBackend,
+    ) Error!PureZigRecordStream {
+        std.debug.assert(!carrier.owns_handle or carrier.closeFn != null);
+        var stream_state = try initWithBackendAndAllocator(allocator, role, crypto_provider, cipher_suite, backend);
+        stream_state.carrier = carrier;
+        return stream_state;
+    }
+
     pub fn initWithCarrierBackendAndLimits(
         role: tls_state.Role,
         crypto_provider: provider.CryptoProvider,
@@ -509,6 +548,21 @@ pub const PureZigRecordStream = struct {
     ) Error!PureZigRecordStream {
         std.debug.assert(!carrier.owns_handle or carrier.closeFn != null);
         var stream_state = try initWithBackendAndLimits(role, crypto_provider, cipher_suite, backend, limits);
+        stream_state.carrier = carrier;
+        return stream_state;
+    }
+
+    pub fn initWithCarrierBackendAllocatorAndLimits(
+        allocator: std.mem.Allocator,
+        role: tls_state.Role,
+        crypto_provider: provider.CryptoProvider,
+        cipher_suite: algorithms.CipherSuite,
+        carrier: Carrier,
+        backend: RecordHandshakeBackend,
+        limits: BufferLimits,
+    ) Error!PureZigRecordStream {
+        std.debug.assert(!carrier.owns_handle or carrier.closeFn != null);
+        var stream_state = try initWithBackendAllocatorAndLimits(allocator, role, crypto_provider, cipher_suite, backend, limits);
         stream_state.carrier = carrier;
         return stream_state;
     }

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -460,17 +460,6 @@ pub const PureZigRecordStream = struct {
     /// injected `backend`. `drive()` then starts and progresses the real
     /// handshake itself rather than relying on callers to hand-apply events.
     pub fn initWithBackend(
-        role: tls_state.Role,
-        crypto_provider: provider.CryptoProvider,
-        cipher_suite: algorithms.CipherSuite,
-        backend: RecordHandshakeBackend,
-    ) PureZigRecordStream {
-        var stream_state = init(role, crypto_provider, cipher_suite);
-        stream_state.handshake_driver = RecordHandshakeDriver.init(role, backend);
-        return stream_state;
-    }
-
-    pub fn initWithBackendAndAllocator(
         allocator: std.mem.Allocator,
         role: tls_state.Role,
         crypto_provider: provider.CryptoProvider,
@@ -484,18 +473,6 @@ pub const PureZigRecordStream = struct {
     }
 
     pub fn initWithBackendAndLimits(
-        role: tls_state.Role,
-        crypto_provider: provider.CryptoProvider,
-        cipher_suite: algorithms.CipherSuite,
-        backend: RecordHandshakeBackend,
-        limits: BufferLimits,
-    ) Error!PureZigRecordStream {
-        var stream_state = try initWithLimits(role, crypto_provider, cipher_suite, limits);
-        stream_state.handshake_driver = RecordHandshakeDriver.init(role, backend);
-        return stream_state;
-    }
-
-    pub fn initWithBackendAllocatorAndLimits(
         allocator: std.mem.Allocator,
         role: tls_state.Role,
         crypto_provider: provider.CryptoProvider,
@@ -512,19 +489,6 @@ pub const PureZigRecordStream = struct {
     /// `initWithBackend` plus a nonblocking carrier, the production shape: a
     /// real backend driving a real handshake over a real byte-stream carrier.
     pub fn initWithCarrierAndBackend(
-        role: tls_state.Role,
-        crypto_provider: provider.CryptoProvider,
-        cipher_suite: algorithms.CipherSuite,
-        carrier: Carrier,
-        backend: RecordHandshakeBackend,
-    ) PureZigRecordStream {
-        std.debug.assert(!carrier.owns_handle or carrier.closeFn != null);
-        var stream_state = initWithBackend(role, crypto_provider, cipher_suite, backend);
-        stream_state.carrier = carrier;
-        return stream_state;
-    }
-
-    pub fn initWithCarrierBackendAndAllocator(
         allocator: std.mem.Allocator,
         role: tls_state.Role,
         crypto_provider: provider.CryptoProvider,
@@ -533,26 +497,12 @@ pub const PureZigRecordStream = struct {
         backend: RecordHandshakeBackend,
     ) Error!PureZigRecordStream {
         std.debug.assert(!carrier.owns_handle or carrier.closeFn != null);
-        var stream_state = try initWithBackendAndAllocator(allocator, role, crypto_provider, cipher_suite, backend);
+        var stream_state = try initWithBackend(allocator, role, crypto_provider, cipher_suite, backend);
         stream_state.carrier = carrier;
         return stream_state;
     }
 
     pub fn initWithCarrierBackendAndLimits(
-        role: tls_state.Role,
-        crypto_provider: provider.CryptoProvider,
-        cipher_suite: algorithms.CipherSuite,
-        carrier: Carrier,
-        backend: RecordHandshakeBackend,
-        limits: BufferLimits,
-    ) Error!PureZigRecordStream {
-        std.debug.assert(!carrier.owns_handle or carrier.closeFn != null);
-        var stream_state = try initWithBackendAndLimits(role, crypto_provider, cipher_suite, backend, limits);
-        stream_state.carrier = carrier;
-        return stream_state;
-    }
-
-    pub fn initWithCarrierBackendAllocatorAndLimits(
         allocator: std.mem.Allocator,
         role: tls_state.Role,
         crypto_provider: provider.CryptoProvider,
@@ -562,7 +512,7 @@ pub const PureZigRecordStream = struct {
         limits: BufferLimits,
     ) Error!PureZigRecordStream {
         std.debug.assert(!carrier.owns_handle or carrier.closeFn != null);
-        var stream_state = try initWithBackendAllocatorAndLimits(allocator, role, crypto_provider, cipher_suite, backend, limits);
+        var stream_state = try initWithBackendAndLimits(allocator, role, crypto_provider, cipher_suite, backend, limits);
         stream_state.carrier = carrier;
         return stream_state;
     }
@@ -3586,7 +3536,7 @@ test "pending authentication empty poll suppresses read readiness and makes no p
     var duplex = Duplex{ .max_chunk = record_codec.max_ciphertext_record_len };
     try duplex.s2c.append("peer bytes waiting");
     var backend = ScriptedRecordBackend{ .role = .client, .auth_pending = true, .auth_pending_polls = 10 };
-    var stream_state = PureZigRecordStream.initWithCarrierAndBackend(.client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), backend.recordBackend());
+    var stream_state = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), backend.recordBackend());
     defer stream_state.deinit();
     stream_state.handshake_started = true;
     const stream = stream_state.stream();
@@ -4081,10 +4031,10 @@ test "pure-Zig encrypted stream completes a driver-owned handshake over a fragme
         var duplex = Duplex{ .max_chunk = chunk };
         var client_backend = ScriptedRecordBackend{ .role = .client };
         var server_backend = ScriptedRecordBackend{ .role = .server };
-        var client = PureZigRecordStream.initWithCarrierAndBackend(.client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
+        var client = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
         defer client.deinit();
         try client.setExpectedAlpn("h1");
-        var server = PureZigRecordStream.initWithCarrierAndBackend(.server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
+        var server = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
         defer server.deinit();
 
         // No test-only establish(): both sides install genuine derived secrets
@@ -4131,10 +4081,10 @@ test "driver-owned client rejects an unoffered ALPN before sending Finished" {
     var duplex = Duplex{ .max_chunk = record_codec.max_ciphertext_record_len };
     var client_backend = ScriptedRecordBackend{ .role = .client, .selected_alpn = "h2" };
     var server_backend = ScriptedRecordBackend{ .role = .server };
-    var client = PureZigRecordStream.initWithCarrierAndBackend(.client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
+    var client = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
     defer client.deinit();
     try client.setExpectedAlpn("h1");
-    var server = PureZigRecordStream.initWithCarrierAndBackend(.server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
+    var server = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
     defer server.deinit();
 
     const errors = driveDriverPairUntilBothErrors(&client, &server);
@@ -4152,10 +4102,10 @@ test "driver-owned client requires ALPN before completion" {
     var duplex = Duplex{ .max_chunk = record_codec.max_ciphertext_record_len };
     var client_backend = ScriptedRecordBackend{ .role = .client, .selected_alpn = null };
     var server_backend = ScriptedRecordBackend{ .role = .server };
-    var client = PureZigRecordStream.initWithCarrierAndBackend(.client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
+    var client = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
     defer client.deinit();
     try client.setExpectedAlpn("h1");
-    var server = PureZigRecordStream.initWithCarrierAndBackend(.server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
+    var server = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
     defer server.deinit();
 
     const errors = driveDriverPairUntilBothErrors(&client, &server);
@@ -4172,10 +4122,10 @@ test "completion policy preflight rejects a missing certificate before sending F
     var duplex = Duplex{ .max_chunk = record_codec.max_ciphertext_record_len };
     var client_backend = ScriptedRecordBackend{ .role = .client, .emit_certificate = false };
     var server_backend = ScriptedRecordBackend{ .role = .server };
-    var client = PureZigRecordStream.initWithCarrierAndBackend(.client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
+    var client = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
     defer client.deinit();
     try client.setExpectedAlpn("h1");
-    var server = PureZigRecordStream.initWithCarrierAndBackend(.server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
+    var server = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
     defer server.deinit();
 
     const errors = driveDriverPairUntilBothErrors(&client, &server);
@@ -4192,9 +4142,9 @@ test "driver-owned handshake latches a terminal failure and flushes its fatal al
     var duplex = Duplex{ .max_chunk = record_codec.max_ciphertext_record_len };
     var client_backend = ScriptedRecordBackend{ .role = .client, .bad_hello = true };
     var server_backend = ScriptedRecordBackend{ .role = .server };
-    var client = PureZigRecordStream.initWithCarrierAndBackend(.client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
+    var client = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
     defer client.deinit();
-    var server = PureZigRecordStream.initWithCarrierAndBackend(.server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
+    var server = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
     defer server.deinit();
 
     // Client sends its (rejected) hello.
@@ -4323,7 +4273,7 @@ test "driver-owned cancellation releases owned carrier, driver, and secrets exac
     inline for (.{ true, false }) |install_keys| {
         var backend = CountingRecordBackend{ .install_keys = install_keys };
         var carrier = CountingOwnedCarrier{};
-        var stream = PureZigRecordStream.initWithCarrierAndBackend(.client, cp, .tls_aes_128_gcm_sha256, carrier.carrier(), backend.recordBackend());
+        var stream = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .client, cp, .tls_aes_128_gcm_sha256, carrier.carrier(), backend.recordBackend());
 
         // Start the driver: it installs sensitive state (keys and/or a queued
         // flight) that a blocked carrier keeps undrained.
@@ -4369,9 +4319,9 @@ test "driver-owned handshake preserves a pending fatal alert across write backpr
     var duplex = Duplex{ .max_chunk = record_codec.max_ciphertext_record_len, .block_s2c = true };
     var client_backend = ScriptedRecordBackend{ .role = .client, .bad_hello = true };
     var server_backend = ScriptedRecordBackend{ .role = .server };
-    var client = PureZigRecordStream.initWithCarrierAndBackend(.client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
+    var client = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
     defer client.deinit();
-    var server = PureZigRecordStream.initWithCarrierAndBackend(.server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
+    var server = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
     defer server.deinit();
 
     // Client sends its rejected hello.
@@ -4472,9 +4422,9 @@ test "driver-owned handshake latches on the flush deadline when a fatal alert ca
     var duplex = Duplex{ .max_chunk = record_codec.max_ciphertext_record_len, .block_s2c = true };
     var client_backend = ScriptedRecordBackend{ .role = .client, .bad_hello = true };
     var server_backend = ScriptedRecordBackend{ .role = .server };
-    var client = PureZigRecordStream.initWithCarrierAndBackend(.client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
+    var client = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
     defer client.deinit();
-    var server = PureZigRecordStream.initWithCarrierAndBackend(.server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
+    var server = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
     defer server.deinit();
 
     _ = try client.stream().drive();

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -466,6 +466,7 @@ pub const PureZigRecordStream = struct {
         backend: RecordHandshakeBackend,
     ) PureZigRecordStream {
         var stream_state = init(role, crypto_provider, cipher_suite);
+        if (role == .client) backend.setPostHandshakeAllocator(std.heap.smp_allocator) catch unreachable;
         stream_state.handshake_driver = RecordHandshakeDriver.init(role, backend);
         return stream_state;
     }
@@ -478,6 +479,7 @@ pub const PureZigRecordStream = struct {
         limits: BufferLimits,
     ) Error!PureZigRecordStream {
         var stream_state = try initWithLimits(role, crypto_provider, cipher_suite, limits);
+        if (role == .client) try backend.setPostHandshakeAllocator(std.heap.smp_allocator);
         stream_state.handshake_driver = RecordHandshakeDriver.init(role, backend);
         return stream_state;
     }

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -159,6 +159,10 @@ pub const QueueCounters = struct {
     }
 };
 
+fn handshakeRecordCount(bytes_len: usize) usize {
+    return (bytes_len + record_codec.max_plaintext_fragment_len - 1) / record_codec.max_plaintext_fragment_len;
+}
+
 pub const BufferCounters = struct {
     inbound_read_pauses: u64 = 0,
     inbound_read_resumes: u64 = 0,
@@ -317,7 +321,7 @@ pub const Carrier = struct {
 
 pub const PureZigRecordStream = struct {
     pub const max_plaintext_queue = 32 * 1024;
-    pub const max_ciphertext_queue = 4 * record_codec.max_ciphertext_record_len;
+    pub const max_ciphertext_queue = 8 * record_codec.max_ciphertext_record_len;
     pub const max_carrier_input_queue = 4 * record_codec.max_ciphertext_record_len;
     pub const max_handshake_queue = 16 * 1024;
     const drive_read_budget = 2 * record_codec.max_ciphertext_record_len;
@@ -716,6 +720,26 @@ pub const PureZigRecordStream = struct {
             self.hasHardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, record_codec.max_ciphertext_record_len);
     }
 
+    fn canReserveOutboundRecords(self: *const PureZigRecordStream, count: usize) bool {
+        const needed = count * record_codec.max_ciphertext_record_len;
+        return self.outbound_ciphertext.available() >= needed and
+            self.hasHardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, needed);
+    }
+
+    fn emitHandshakeRecords(self: *PureZigRecordStream, epoch: events.EncryptionEpoch, bytes: []const u8) Error!void {
+        const count = handshakeRecordCount(bytes.len);
+        if (!self.canReserveOutboundRecords(count)) return error.WouldBlock;
+
+        var offset: usize = 0;
+        while (offset < bytes.len) {
+            const take = @min(record_codec.max_plaintext_fragment_len, bytes.len - offset);
+            var record_buf: [record_codec.max_ciphertext_record_len]u8 = undefined;
+            const record = self.bridge.sealHandshake(epoch, bytes[offset..][0..take], &record_buf) catch |err| return self.fail(err);
+            self.appendOutboundCiphertext(record) catch |err| return self.fail(err);
+            offset += take;
+        }
+    }
+
     fn canReserveHandshakeOutputBatch(self: *PureZigRecordStream) bool {
         return self.outbound_ciphertext.available() >= handshake_output_reserve and
             self.hasHardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, handshake_output_reserve);
@@ -775,12 +799,18 @@ pub const PureZigRecordStream = struct {
         if (self.failed) |err| return err;
         if (self.lifecycle == .closed or self.lifecycle == .failed or self.lifecycle == .closing) return error.StreamClosed;
         if (event == .handshake_bytes) {
-            if (!self.hasHardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, record_codec.max_ciphertext_record_len)) return self.rejectHardLimit(.outbound_ciphertext, error.WouldBlock);
-            if (self.outbound_ciphertext.available() < record_codec.max_ciphertext_record_len) return error.WouldBlock;
+            const count = handshakeRecordCount(event.handshake_bytes.data.len);
+            const needed = count * record_codec.max_ciphertext_record_len;
+            if (!self.hasHardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, needed)) return self.rejectHardLimit(.outbound_ciphertext, error.WouldBlock);
+            if (self.outbound_ciphertext.available() < needed) return error.WouldBlock;
         }
-        var record_buf: [record_codec.max_ciphertext_record_len]u8 = undefined;
-        if (self.bridge.applyEvent(event, &record_buf) catch |err| return self.fail(err)) |record| {
-            self.appendOutboundCiphertext(record) catch |err| return self.fail(err);
+        if (event == .handshake_bytes) {
+            self.emitHandshakeRecords(event.handshake_bytes.epoch, event.handshake_bytes.data) catch |err| return self.fail(err);
+        } else {
+            var record_buf: [record_codec.max_ciphertext_record_len]u8 = undefined;
+            if (self.bridge.applyEvent(event, &record_buf) catch |err| return self.fail(err)) |record| {
+                self.appendOutboundCiphertext(record) catch |err| return self.fail(err);
+            }
         }
         // The initial epoch's plaintext parser is only safe to keep once
         // its keys are gone: nothing should ever arrive at that epoch
@@ -891,9 +921,7 @@ pub const PureZigRecordStream = struct {
         for (sink.items[0..sink.len]) |event| {
             switch (event) {
                 .handshake_bytes => |hb| {
-                    var record_buf: [record_codec.max_ciphertext_record_len]u8 = undefined;
-                    const record = self.bridge.sealHandshake(hb.epoch, hb.data, &record_buf) catch |err| return self.fail(err);
-                    self.appendOutboundCiphertext(record) catch |err| return self.fail(err);
+                    self.emitHandshakeRecords(hb.epoch, hb.data) catch |err| return self.fail(err);
                 },
                 .traffic_secret => |ts| {
                     self.bridge.installTrafficSecret(ts.epoch, ts.direction, ts.data) catch |err| return self.fail(err);
@@ -1144,7 +1172,13 @@ pub const PureZigRecordStream = struct {
             const opened = self.bridge.openProtected(.application, record, &plaintext_buf) catch |err| return self.fail(err);
             switch (opened.inner.content_type) {
                 .application_data => self.appendInboundPlaintext(opened.inner.content) catch |err| return self.fail(err),
-                .handshake => self.appendInboundHandshake(opened.inner.content) catch |err| return self.fail(err),
+                .handshake => {
+                    if (self.driverPresent()) {
+                        try self.driveReceive(.application, opened.inner.content);
+                    } else {
+                        self.appendInboundHandshake(opened.inner.content) catch |err| return self.fail(err);
+                    }
+                },
                 .alert => self.handleAlert(opened.inner.content) catch |err| return self.fail(err),
                 .change_cipher_spec => return self.fail(error.UnsupportedRecordContent),
             }

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -321,7 +321,7 @@ pub const Carrier = struct {
 
 pub const PureZigRecordStream = struct {
     pub const max_plaintext_queue = 32 * 1024;
-    pub const max_ciphertext_queue = 8 * record_codec.max_ciphertext_record_len;
+    pub const max_ciphertext_queue = 4 * record_codec.max_ciphertext_record_len;
     pub const max_carrier_input_queue = 4 * record_codec.max_ciphertext_record_len;
     pub const max_handshake_queue = 16 * 1024;
     const drive_read_budget = 2 * record_codec.max_ciphertext_record_len;
@@ -720,15 +720,14 @@ pub const PureZigRecordStream = struct {
             self.hasHardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, record_codec.max_ciphertext_record_len);
     }
 
-    fn canReserveOutboundRecords(self: *const PureZigRecordStream, count: usize) bool {
-        const needed = count * record_codec.max_ciphertext_record_len;
+    fn canReserveOutboundHandshakeBytes(self: *PureZigRecordStream, epoch: events.EncryptionEpoch, bytes_len: usize) Error!bool {
+        const needed = try self.bridge.sealedHandshakeLen(epoch, bytes_len);
         return self.outbound_ciphertext.available() >= needed and
             self.hasHardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, needed);
     }
 
     fn emitHandshakeRecords(self: *PureZigRecordStream, epoch: events.EncryptionEpoch, bytes: []const u8) Error!void {
-        const count = handshakeRecordCount(bytes.len);
-        if (!self.canReserveOutboundRecords(count)) return error.WouldBlock;
+        if (!try self.canReserveOutboundHandshakeBytes(epoch, bytes.len)) return error.WouldBlock;
 
         var offset: usize = 0;
         while (offset < bytes.len) {
@@ -799,8 +798,7 @@ pub const PureZigRecordStream = struct {
         if (self.failed) |err| return err;
         if (self.lifecycle == .closed or self.lifecycle == .failed or self.lifecycle == .closing) return error.StreamClosed;
         if (event == .handshake_bytes) {
-            const count = handshakeRecordCount(event.handshake_bytes.data.len);
-            const needed = count * record_codec.max_ciphertext_record_len;
+            const needed = try self.bridge.sealedHandshakeLen(event.handshake_bytes.epoch, event.handshake_bytes.data.len);
             if (!self.hasHardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, needed)) return self.rejectHardLimit(.outbound_ciphertext, error.WouldBlock);
             if (self.outbound_ciphertext.available() < needed) return error.WouldBlock;
         }
@@ -1998,6 +1996,14 @@ test "TLS buffer defaults validate and expose bounded snapshot" {
     try testing.expect(!snapshot.pause_state.inbound_read_paused);
     try testing.expect(!snapshot.pause_state.plaintext_write_paused);
     try testing.expectEqual(AccountingBoundary.complete_stream_owned, snapshot.accounting_boundary);
+}
+
+test "record stream maximum emitted ticket fits four-record ciphertext queue" {
+    try std.testing.expectEqual(4 * record_codec.max_ciphertext_record_len, PureZigRecordStream.max_ciphertext_queue);
+    const bytes_len = tls13_transport.max_emitted_new_session_ticket_message_len;
+    const records = handshakeRecordCount(bytes_len);
+    const protected_len = bytes_len + records * (record_codec.header_len + 1 + 16);
+    try std.testing.expect(protected_len <= PureZigRecordStream.max_ciphertext_queue);
 }
 
 test "TLS buffer policy rejects invalid watermarks and over-capacity hard limits" {

--- a/src/tls/events.zig
+++ b/src/tls/events.zig
@@ -63,6 +63,9 @@ pub const HandshakeError = error{
     SecretExportFailed,
     /// A local caller attempted an invalid handshake lifecycle transition.
     InvalidHandshakeState,
+    /// A ticket identity exceeded the caller-configured resumable-session
+    /// model bound even though it may still fit the absolute RFC wire range.
+    TicketTooLarge,
     /// This side cannot authenticate itself for the negotiated parameters: no
     /// local credential is available, or none is compatible with the peer's
     /// offered signature algorithms. A *local* configuration/selection failure,
@@ -130,7 +133,9 @@ test "syntax, semantic, and ordering failures are distinct cases" {
     const malformed: HandshakeError = error.MalformedHandshake;
     const illegal: HandshakeError = error.IllegalParameter;
     const unexpected: HandshakeError = error.UnexpectedHandshakeMessage;
+    const ticket_too_large: HandshakeError = error.TicketTooLarge;
     try std.testing.expect(malformed != illegal);
     try std.testing.expect(malformed != unexpected);
     try std.testing.expect(illegal != unexpected);
+    try std.testing.expect(ticket_too_large != malformed);
 }

--- a/src/tls/key_schedule.zig
+++ b/src/tls/key_schedule.zig
@@ -5,17 +5,21 @@
 //! both derive handshake/application traffic secrets through this shared core.
 
 const std = @import("std");
+const provider = @import("crypto").provider;
 
 const crypto = std.crypto;
 const tls = crypto.tls;
 const Sha256 = crypto.hash.sha2.Sha256;
+const HmacSha384 = crypto.auth.hmac.sha2.HmacSha384;
 const HmacSha256 = crypto.auth.hmac.sha2.HmacSha256;
+const HkdfSha384 = crypto.kdf.hkdf.Hkdf(HmacSha384);
 const HkdfSha256 = crypto.kdf.hkdf.HkdfSha256;
 const X25519 = crypto.dh.X25519;
 
 pub const TranscriptHash = Sha256;
 pub const hash_len = Sha256.digest_length;
 pub const shared_secret_len = X25519.shared_length;
+pub const Error = error{InvalidSecretLength};
 
 const empty_transcript_hash: [hash_len]u8 = blk: {
     @setEvalBranchQuota(100_000);
@@ -67,6 +71,53 @@ pub const KeySchedule = struct {
             .client = tls.hkdfExpandLabel(HkdfSha256, self.master_secret, "c ap traffic", &finished_transcript_hash, hash_len),
             .server = tls.hkdfExpandLabel(HkdfSha256, self.master_secret, "s ap traffic", &finished_transcript_hash, hash_len),
         };
+    }
+
+    pub fn resumptionMasterSecret(
+        self: *const KeySchedule,
+        handshake_complete_transcript_hash: []const u8,
+        out: []u8,
+    ) Error!void {
+        if (handshake_complete_transcript_hash.len != hash_len or out.len != hash_len)
+            return error.InvalidSecretLength;
+        var secret = tls.hkdfExpandLabel(
+            HkdfSha256,
+            self.master_secret,
+            "res master",
+            handshake_complete_transcript_hash,
+            hash_len,
+        );
+        defer crypto.secureZero(u8, &secret);
+        @memcpy(out, &secret);
+    }
+
+    pub fn resumptionPsk(
+        hash: provider.Hash,
+        resumption_master_secret: []const u8,
+        ticket_nonce: []const u8,
+        out: []u8,
+    ) Error!void {
+        const expected_len = hash.digestLength();
+        if (resumption_master_secret.len != expected_len or out.len != expected_len)
+            return error.InvalidSecretLength;
+        switch (hash) {
+            .sha256 => {
+                var secret: [Sha256.digest_length]u8 = undefined;
+                @memcpy(&secret, resumption_master_secret);
+                defer crypto.secureZero(u8, &secret);
+                var expanded = tls.hkdfExpandLabel(HkdfSha256, secret, "resumption", ticket_nonce, Sha256.digest_length);
+                defer crypto.secureZero(u8, &expanded);
+                @memcpy(out, &expanded);
+            },
+            .sha384 => {
+                var secret: [HmacSha384.mac_length]u8 = undefined;
+                @memcpy(&secret, resumption_master_secret);
+                defer crypto.secureZero(u8, &secret);
+                var expanded = tls.hkdfExpandLabel(HkdfSha384, secret, "resumption", ticket_nonce, HmacSha384.mac_length);
+                defer crypto.secureZero(u8, &expanded);
+                @memcpy(out, &expanded);
+            },
+        }
     }
 
     pub fn finishedKey(traffic_secret: *const [hash_len]u8) [hash_len]u8 {
@@ -126,6 +177,41 @@ test "application traffic secret storage has explicit cleanup" {
     try std.testing.expect(!std.mem.allEqual(u8, std.mem.asBytes(&app), 0));
     app.wipe();
     try std.testing.expect(std.mem.allEqual(u8, std.mem.asBytes(&app), 0));
+}
+
+test "resumption master secret and PSK derivation are deterministic" {
+    const shared = hexBytes("8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d");
+    const hello_hash = hexBytes("860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8");
+    var schedule = KeySchedule.init(&shared, hello_hash);
+    defer schedule.wipe();
+
+    const complete_hash = hexBytes("209145a96ee8e5751f3b7e74e573c01c384cff1b902e8ae503d6d3469c698d1c");
+    var rms: [hash_len]u8 = undefined;
+    defer crypto.secureZero(u8, &rms);
+    try schedule.resumptionMasterSecret(&complete_hash, &rms);
+    try std.testing.expectEqualSlices(u8, &hexBytes("9089b75df5e8d1720f8383601331c07ce14c8b8dbe4ded1511ce84c55ca2396c"), &rms);
+
+    var psk_empty: [hash_len]u8 = undefined;
+    var psk_nonce: [hash_len]u8 = undefined;
+    defer crypto.secureZero(u8, &psk_empty);
+    defer crypto.secureZero(u8, &psk_nonce);
+    try KeySchedule.resumptionPsk(.sha256, &rms, "", &psk_empty);
+    try KeySchedule.resumptionPsk(.sha256, &rms, "\x01", &psk_nonce);
+    try std.testing.expectEqualSlices(u8, &hexBytes("c1392efd98f6932d62f5ccd42c724230871638e8ad0ac9ce9b2af89f5f919fed"), &psk_empty);
+    try std.testing.expectEqualSlices(u8, &hexBytes("54d2811b66ec2ad537c626f21da4d6ed48c5aed25e2fd708e3f17cd08cb71077"), &psk_nonce);
+    try std.testing.expect(!std.mem.eql(u8, &psk_empty, &psk_nonce));
+}
+
+test "resumption PSK supports SHA-384 length and rejects inconsistent lengths" {
+    const rms384 = [_]u8{0x42} ** provider.Hash.sha384.digestLength();
+    var out384: [provider.Hash.sha384.digestLength()]u8 = undefined;
+    defer crypto.secureZero(u8, &out384);
+    try KeySchedule.resumptionPsk(.sha384, &rms384, "nonce", &out384);
+    try std.testing.expectEqualSlices(u8, &hexBytes("e72237478501a59682cd8580d7e2a526847e1e7049a83c3c0f7ef3dc3a950f3d88fb87be1d1e9d2cf94f038cb7b05033"), &out384);
+
+    var short_out: [hash_len - 1]u8 = undefined;
+    try std.testing.expectError(error.InvalidSecretLength, KeySchedule.resumptionPsk(.sha256, &rms384, "nonce", &short_out));
+    try std.testing.expectError(error.InvalidSecretLength, KeySchedule.resumptionPsk(.sha384, rms384[0..hash_len], "nonce", &out384));
 }
 
 fn hexBytes(comptime hex: []const u8) [hex.len / 2]u8 {

--- a/src/tls/key_schedule.zig
+++ b/src/tls/key_schedule.zig
@@ -78,17 +78,50 @@ pub const KeySchedule = struct {
         handshake_complete_transcript_hash: []const u8,
         out: []u8,
     ) Error!void {
-        if (handshake_complete_transcript_hash.len != hash_len or out.len != hash_len)
+        return deriveResumptionMasterSecret(.sha256, &self.master_secret, handshake_complete_transcript_hash, out);
+    }
+
+    pub fn deriveResumptionMasterSecret(
+        hash: provider.Hash,
+        master_secret: []const u8,
+        handshake_complete_transcript_hash: []const u8,
+        out: []u8,
+    ) Error!void {
+        const expected_len = hash.digestLength();
+        if (master_secret.len != expected_len or
+            handshake_complete_transcript_hash.len != expected_len or
+            out.len != expected_len)
             return error.InvalidSecretLength;
-        var secret = tls.hkdfExpandLabel(
-            HkdfSha256,
-            self.master_secret,
-            "res master",
-            handshake_complete_transcript_hash,
-            hash_len,
-        );
-        defer crypto.secureZero(u8, &secret);
-        @memcpy(out, &secret);
+        switch (hash) {
+            .sha256 => {
+                var secret: [Sha256.digest_length]u8 = undefined;
+                @memcpy(&secret, master_secret);
+                defer crypto.secureZero(u8, &secret);
+                var expanded = tls.hkdfExpandLabel(
+                    HkdfSha256,
+                    secret,
+                    "res master",
+                    handshake_complete_transcript_hash,
+                    Sha256.digest_length,
+                );
+                defer crypto.secureZero(u8, &expanded);
+                @memcpy(out, &expanded);
+            },
+            .sha384 => {
+                var secret: [HmacSha384.mac_length]u8 = undefined;
+                @memcpy(&secret, master_secret);
+                defer crypto.secureZero(u8, &secret);
+                var expanded = tls.hkdfExpandLabel(
+                    HkdfSha384,
+                    secret,
+                    "res master",
+                    handshake_complete_transcript_hash,
+                    HmacSha384.mac_length,
+                );
+                defer crypto.secureZero(u8, &expanded);
+                @memcpy(out, &expanded);
+            },
+        }
     }
 
     pub fn resumptionPsk(
@@ -212,6 +245,16 @@ test "resumption PSK supports SHA-384 length and rejects inconsistent lengths" {
     var short_out: [hash_len - 1]u8 = undefined;
     try std.testing.expectError(error.InvalidSecretLength, KeySchedule.resumptionPsk(.sha256, &rms384, "nonce", &short_out));
     try std.testing.expectError(error.InvalidSecretLength, KeySchedule.resumptionPsk(.sha384, rms384[0..hash_len], "nonce", &out384));
+}
+
+test "generic resumption master secret derivation supports SHA-384" {
+    const master_secret = [_]u8{0x11} ** provider.Hash.sha384.digestLength();
+    const transcript_hash = [_]u8{0x22} ** provider.Hash.sha384.digestLength();
+    var out: [provider.Hash.sha384.digestLength()]u8 = undefined;
+    defer crypto.secureZero(u8, &out);
+    try KeySchedule.deriveResumptionMasterSecret(.sha384, &master_secret, &transcript_hash, &out);
+    try std.testing.expectEqualSlices(u8, &hexBytes("4f9d68ff762f5b886f275d162b90c268db5ccc65c4e0b8fc810030429a070f8e9f12b641b209e15ae210b1153a68fc42"), &out);
+    try std.testing.expectError(error.InvalidSecretLength, KeySchedule.deriveResumptionMasterSecret(.sha384, master_secret[0..hash_len], &transcript_hash, &out));
 }
 
 fn hexBytes(comptime hex: []const u8) [hex.len / 2]u8 {

--- a/src/tls/messages.zig
+++ b/src/tls/messages.zig
@@ -222,13 +222,26 @@ pub fn Reassembler(comptime capacity: usize) type {
 
         pub fn discard(self: *Self, count: usize) ReassemblerError!void {
             if (count > self.len) return error.MalformedHandshake;
-            std.mem.copyForwards(u8, self.data[0 .. self.len - count], self.data[count..self.len]);
-            self.len -= count;
+            const old_len = self.len;
+            std.mem.copyForwards(u8, self.data[0 .. old_len - count], self.data[count..old_len]);
+            self.len = old_len - count;
+            std.crypto.secureZero(u8, self.data[self.len..old_len]);
         }
     };
 }
 
 const testing = std.testing;
+
+test "reassembler discard clears consumed tail bytes" {
+    var r = Reassembler(32){};
+    const first = [_]u8{ @intFromEnum(MessageType.finished), 0, 0, 4, 0xaa, 0xbb, 0xcc, 0xdd };
+    const second = [_]u8{ @intFromEnum(MessageType.finished), 0, 0, 1, 0xee };
+    try r.append(&first);
+    try r.append(&second);
+    try r.discard(first.len);
+    try testing.expectEqualSlices(u8, &second, r.data[0..r.len]);
+    try testing.expect(std.mem.allEqual(u8, r.data[r.len .. first.len + second.len], 0));
+}
 
 test "encode and decode exact handshake bytes" {
     var out: [16]u8 = undefined;

--- a/src/tls/new_session_ticket.zig
+++ b/src/tls/new_session_ticket.zig
@@ -1,0 +1,440 @@
+//! TLS 1.3 NewSessionTicket wire codec and session-model conversion.
+//!
+//! This module owns only the RFC 8446 handshake body shape. It borrows slices
+//! from validated input during decode and requires callers to supply all
+//! connection metadata explicitly when constructing owned resumable state.
+
+const std = @import("std");
+const crypto = std.crypto;
+const algorithms = @import("algorithms.zig");
+const key_schedule = @import("key_schedule.zig");
+const session = @import("session.zig");
+
+pub const max_lifetime_seconds = session.max_lifetime_seconds;
+pub const max_ticket_nonce_len = session.max_ticket_nonce_len;
+pub const absolute_ticket_wire_max = session.absolute_ticket_wire_max;
+pub const ext_early_data: u16 = 42;
+pub const max_extensions_wire_len: usize = std.math.maxInt(u16) - 1;
+
+pub const Parsed = struct {
+    ticket_lifetime: u32,
+    ticket_age_add: u32,
+    ticket_nonce: []const u8,
+    ticket: []const u8,
+    max_early_data_size: ?u32,
+};
+
+pub const EmitParams = struct {
+    ticket_lifetime: u32,
+    ticket_age_add: u32,
+    ticket_nonce: []const u8,
+    ticket: []const u8,
+    max_early_data_size: ?u32 = null,
+};
+
+pub const CompatBlob = session.ResumableSessionCommon.CompatBlobParams;
+
+pub const ConnectionResumptionContext = struct {
+    cipher_suite: algorithms.CipherSuite,
+    server_name: ?[]const u8 = null,
+    application_protocol: ?[]const u8 = null,
+    auth_binding: session.AuthBinding,
+    transport_compat: ?CompatBlob = null,
+    application_compat: ?CompatBlob = null,
+};
+
+pub const EncodeError = error{
+    IllegalParameter,
+    OutputTooSmall,
+    LengthOverflow,
+};
+
+pub const DecodeError = error{
+    MalformedHandshake,
+    IllegalParameter,
+};
+
+pub const BuildError =
+    key_schedule.Error ||
+    session.ResumableSessionCommon.InitError ||
+    session.ClientTicketState.InitError ||
+    error{InvalidLimits};
+
+pub const BuildServerError =
+    key_schedule.Error ||
+    session.ResumableSessionCommon.InitError ||
+    error{InvalidLimits};
+
+pub fn encodedLen(params: EmitParams) EncodeError!usize {
+    try validateEmitParams(params);
+    var len: usize = 0;
+    len = try checkedAdd(len, 4); // ticket_lifetime
+    len = try checkedAdd(len, 4); // ticket_age_add
+    len = try checkedAdd(len, 1 + params.ticket_nonce.len);
+    len = try checkedAdd(len, 2 + params.ticket.len);
+    len = try checkedAdd(len, 2 + extensionsLen(params));
+    return len;
+}
+
+pub fn encode(params: EmitParams, out: []u8) EncodeError![]const u8 {
+    const len = try encodedLen(params);
+    if (out.len < len) return error.OutputTooSmall;
+
+    var pos: usize = 0;
+    writeU32(out[pos..][0..4], params.ticket_lifetime);
+    pos += 4;
+    writeU32(out[pos..][0..4], params.ticket_age_add);
+    pos += 4;
+    out[pos] = @intCast(params.ticket_nonce.len);
+    pos += 1;
+    @memcpy(out[pos..][0..params.ticket_nonce.len], params.ticket_nonce);
+    pos += params.ticket_nonce.len;
+    writeU16(out[pos..][0..2], @intCast(params.ticket.len));
+    pos += 2;
+    @memcpy(out[pos..][0..params.ticket.len], params.ticket);
+    pos += params.ticket.len;
+    const ext_len = extensionsLen(params);
+    writeU16(out[pos..][0..2], @intCast(ext_len));
+    pos += 2;
+    if (params.max_early_data_size) |max_early_data_size| {
+        writeU16(out[pos..][0..2], ext_early_data);
+        pos += 2;
+        writeU16(out[pos..][0..2], 4);
+        pos += 2;
+        writeU32(out[pos..][0..4], max_early_data_size);
+        pos += 4;
+    }
+    std.debug.assert(pos == len);
+    return out[0..len];
+}
+
+pub fn decode(body: []const u8) DecodeError!Parsed {
+    var r = Reader{ .bytes = body };
+    const ticket_lifetime = try r.readU32();
+    const ticket_age_add = try r.readU32();
+    const ticket_nonce = try r.slice(try r.readU8());
+    const ticket = try r.slice(try r.readU16());
+    if (ticket.len == 0) return error.MalformedHandshake;
+    if (ticket_lifetime > max_lifetime_seconds) return error.IllegalParameter;
+
+    const extensions = try r.slice(try r.readU16());
+    try r.expectEnd();
+
+    var guard = ExtensionGuard{};
+    var ext_reader = Reader{ .bytes = extensions };
+    var max_early_data_size: ?u32 = null;
+    while (!ext_reader.atEnd()) {
+        const ext_type = try ext_reader.readU16();
+        const ext_body = try ext_reader.slice(try ext_reader.readU16());
+        try guard.check(ext_type);
+        if (ext_type == ext_early_data) {
+            if (ext_body.len != 4) return error.MalformedHandshake;
+            max_early_data_size = readIntU32(ext_body[0..4]);
+        }
+    }
+
+    return .{
+        .ticket_lifetime = ticket_lifetime,
+        .ticket_age_add = ticket_age_add,
+        .ticket_nonce = ticket_nonce,
+        .ticket = ticket,
+        .max_early_data_size = max_early_data_size,
+    };
+}
+
+pub fn buildClientTicketState(
+    allocator: std.mem.Allocator,
+    parsed: Parsed,
+    connection: ConnectionResumptionContext,
+    resumption_master_secret: []const u8,
+    received_at_unix_ms: i64,
+    limits: session.Limits,
+) BuildError!?session.ClientTicketState {
+    try limits.validate();
+    if (parsed.ticket_lifetime == 0) return null;
+
+    const hash = algorithms.transcriptHash(connection.cipher_suite);
+    var psk: [session.max_psk_len]u8 = undefined;
+    defer crypto.secureZero(u8, &psk);
+    try key_schedule.KeySchedule.resumptionPsk(
+        hash,
+        resumption_master_secret,
+        parsed.ticket_nonce,
+        psk[0..hash.digestLength()],
+    );
+
+    var common: session.ResumableSessionCommon = .{};
+    errdefer common.deinit();
+    try common.init(allocator, limits, .{
+        .cipher_suite = connection.cipher_suite,
+        .resumption_psk = psk[0..hash.digestLength()],
+        .server_name = connection.server_name,
+        .application_protocol = connection.application_protocol,
+        .auth_binding = connection.auth_binding,
+        .issued_at_unix_ms = received_at_unix_ms,
+        .lifetime_seconds = parsed.ticket_lifetime,
+        .early_data = earlyDataPolicy(parsed.max_early_data_size),
+        .transport_compat = connection.transport_compat,
+        .application_compat = connection.application_compat,
+    });
+
+    var state: session.ClientTicketState = .{};
+    try state.init(allocator, limits, &common, .{
+        .ticket = parsed.ticket,
+        .ticket_age_add = parsed.ticket_age_add,
+        .ticket_nonce = parsed.ticket_nonce,
+        .received_at_unix_ms = received_at_unix_ms,
+    });
+    return state;
+}
+
+pub fn buildServerRecoverableState(
+    allocator: std.mem.Allocator,
+    params: EmitParams,
+    connection: ConnectionResumptionContext,
+    resumption_master_secret: []const u8,
+    issued_at_unix_ms: i64,
+    limits: session.Limits,
+) BuildServerError!session.ServerRecoverableState {
+    try limits.validate();
+    if (params.ticket_lifetime == 0) return error.InvalidLifetime;
+    const hash = algorithms.transcriptHash(connection.cipher_suite);
+    var psk: [session.max_psk_len]u8 = undefined;
+    defer crypto.secureZero(u8, &psk);
+    try key_schedule.KeySchedule.resumptionPsk(
+        hash,
+        resumption_master_secret,
+        params.ticket_nonce,
+        psk[0..hash.digestLength()],
+    );
+
+    var common: session.ResumableSessionCommon = .{};
+    errdefer common.deinit();
+    try common.init(allocator, limits, .{
+        .cipher_suite = connection.cipher_suite,
+        .resumption_psk = psk[0..hash.digestLength()],
+        .server_name = connection.server_name,
+        .application_protocol = connection.application_protocol,
+        .auth_binding = connection.auth_binding,
+        .issued_at_unix_ms = issued_at_unix_ms,
+        .lifetime_seconds = params.ticket_lifetime,
+        .early_data = earlyDataPolicy(params.max_early_data_size),
+        .transport_compat = connection.transport_compat,
+        .application_compat = connection.application_compat,
+    });
+
+    var state: session.ServerRecoverableState = .{};
+    state.init(&common);
+    return state;
+}
+
+fn earlyDataPolicy(max_early_data_size: ?u32) session.EarlyDataPolicy {
+    return if (max_early_data_size) |max|
+        if (max == 0) .resume_only else .{ .early_data_capable = max }
+    else
+        .resume_only;
+}
+
+fn validateEmitParams(params: EmitParams) EncodeError!void {
+    if (params.ticket_lifetime > max_lifetime_seconds) return error.IllegalParameter;
+    if (params.ticket_nonce.len > max_ticket_nonce_len) return error.IllegalParameter;
+    if (params.ticket.len == 0 or params.ticket.len > absolute_ticket_wire_max) return error.IllegalParameter;
+    if (extensionsLen(params) > max_extensions_wire_len) return error.IllegalParameter;
+}
+
+fn extensionsLen(params: EmitParams) usize {
+    return if (params.max_early_data_size == null) 0 else 8;
+}
+
+fn checkedAdd(a: usize, b: usize) EncodeError!usize {
+    return std.math.add(usize, a, b) catch return error.LengthOverflow;
+}
+
+const Reader = struct {
+    bytes: []const u8,
+    pos: usize = 0,
+
+    fn atEnd(self: *const Reader) bool {
+        return self.pos == self.bytes.len;
+    }
+
+    fn readU8(self: *Reader) DecodeError!u8 {
+        return (try self.slice(1))[0];
+    }
+
+    fn readU16(self: *Reader) DecodeError!u16 {
+        return readIntU16(try self.slice(2));
+    }
+
+    fn readU32(self: *Reader) DecodeError!u32 {
+        return readIntU32(try self.slice(4));
+    }
+
+    fn slice(self: *Reader, len: usize) DecodeError![]const u8 {
+        if (len > self.bytes.len - self.pos) return error.MalformedHandshake;
+        const start = self.pos;
+        self.pos += len;
+        return self.bytes[start..self.pos];
+    }
+
+    fn expectEnd(self: *const Reader) DecodeError!void {
+        if (!self.atEnd()) return error.MalformedHandshake;
+    }
+};
+
+const ExtensionGuard = struct {
+    ids: [64]u16 = undefined,
+    len: usize = 0,
+
+    fn check(self: *ExtensionGuard, ext_type: u16) DecodeError!void {
+        for (self.ids[0..self.len]) |seen| {
+            if (seen == ext_type) return error.IllegalParameter;
+        }
+        if (self.len == self.ids.len) return error.MalformedHandshake;
+        self.ids[self.len] = ext_type;
+        self.len += 1;
+    }
+};
+
+fn readIntU16(bytes: []const u8) u16 {
+    return std.mem.readInt(u16, bytes[0..2], .big);
+}
+
+fn readIntU32(bytes: []const u8) u32 {
+    return std.mem.readInt(u32, bytes[0..4], .big);
+}
+
+fn writeU16(out: *[2]u8, value: u16) void {
+    std.mem.writeInt(u16, out, value, .big);
+}
+
+fn writeU32(out: *[4]u8, value: u32) void {
+    std.mem.writeInt(u32, out, value, .big);
+}
+
+test "NewSessionTicket codec round trips without extensions" {
+    var buf: [64]u8 = undefined;
+    const encoded = try encode(.{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 0x11223344,
+        .ticket_nonce = "\x01\x02",
+        .ticket = "ticket",
+    }, &buf);
+    try std.testing.expectEqual(try encodedLen(.{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 0x11223344,
+        .ticket_nonce = "\x01\x02",
+        .ticket = "ticket",
+    }), encoded.len);
+    const parsed = try decode(encoded);
+    try std.testing.expectEqual(@as(u32, 60), parsed.ticket_lifetime);
+    try std.testing.expectEqual(@as(u32, 0x11223344), parsed.ticket_age_add);
+    try std.testing.expectEqualSlices(u8, "\x01\x02", parsed.ticket_nonce);
+    try std.testing.expectEqualSlices(u8, "ticket", parsed.ticket);
+    try std.testing.expectEqual(@as(?u32, null), parsed.max_early_data_size);
+}
+
+test "NewSessionTicket codec handles early_data and ignores unknown extensions" {
+    var buf: [128]u8 = undefined;
+    const encoded = try encode(.{
+        .ticket_lifetime = max_lifetime_seconds,
+        .ticket_age_add = 7,
+        .ticket_nonce = "",
+        .ticket = "opaque",
+        .max_early_data_size = 16,
+    }, &buf);
+    const parsed = try decode(encoded);
+    try std.testing.expectEqual(@as(?u32, 16), parsed.max_early_data_size);
+
+    const with_unknown = [_]u8{
+        0, 0, 0,    1,
+        0, 0, 0,    2,
+        0, 0, 1,    'x',
+        0, 4, 0x12, 0x34,
+        0, 0,
+    };
+    const unknown = try decode(&with_unknown);
+    try std.testing.expectEqual(@as(?u32, null), unknown.max_early_data_size);
+}
+
+test "NewSessionTicket decode rejects malformed and illegal inputs distinctly" {
+    try std.testing.expectError(error.MalformedHandshake, decode(""));
+    const empty_ticket = [_]u8{
+        0, 0, 0, 1,
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        0,
+    };
+    try std.testing.expectError(error.MalformedHandshake, decode(&empty_ticket));
+
+    const too_long_lifetime = [_]u8{
+        0, 0x09, 0x3a, 0x81,
+        0, 0,    0,    0,
+        0, 0,    1,    'x',
+        0, 0,
+    };
+    try std.testing.expectError(error.IllegalParameter, decode(&too_long_lifetime));
+
+    const duplicate_unknown = [_]u8{
+        0, 0, 0,    1,
+        0, 0, 0,    0,
+        0, 0, 1,    'x',
+        0, 8, 0x12, 0x34,
+        0, 0, 0x12, 0x34,
+        0, 0,
+    };
+    try std.testing.expectError(error.IllegalParameter, decode(&duplicate_unknown));
+
+    const malformed_early_data = [_]u8{
+        0, 0, 0, 1,
+        0, 0, 0, 0,
+        0, 0, 1, 'x',
+        0, 5, 0, 42,
+        0, 1, 0,
+    };
+    try std.testing.expectError(error.MalformedHandshake, decode(&malformed_early_data));
+}
+
+test "NewSessionTicket encode validates bounds and output size" {
+    var buf: [8]u8 = undefined;
+    try std.testing.expectError(error.OutputTooSmall, encode(.{
+        .ticket_lifetime = 1,
+        .ticket_age_add = 0,
+        .ticket_nonce = "",
+        .ticket = "ticket",
+    }, &buf));
+    try std.testing.expectError(error.IllegalParameter, encodedLen(.{
+        .ticket_lifetime = max_lifetime_seconds + 1,
+        .ticket_age_add = 0,
+        .ticket_nonce = "",
+        .ticket = "ticket",
+    }));
+    try std.testing.expectError(error.IllegalParameter, encodedLen(.{
+        .ticket_lifetime = 1,
+        .ticket_age_add = 0,
+        .ticket_nonce = "",
+        .ticket = "",
+    }));
+}
+
+test "lifetime zero parses but does not build cacheable client state" {
+    const parsed = Parsed{
+        .ticket_lifetime = 0,
+        .ticket_age_add = 0,
+        .ticket_nonce = "",
+        .ticket = "ticket",
+        .max_early_data_size = null,
+    };
+    const state = try buildClientTicketState(
+        std.testing.allocator,
+        parsed,
+        .{
+            .cipher_suite = .tls_aes_128_gcm_sha256,
+            .auth_binding = session.AuthBinding.fromLeafCertificateDer("leaf"),
+        },
+        &([_]u8{0x42} ** 32),
+        123,
+        session.Limits.default,
+    );
+    try std.testing.expectEqual(@as(?session.ClientTicketState, null), state);
+}

--- a/src/tls/new_session_ticket.zig
+++ b/src/tls/new_session_ticket.zig
@@ -63,7 +63,7 @@ pub const BuildError =
 pub const BuildServerError =
     key_schedule.Error ||
     session.ResumableSessionCommon.InitError ||
-    error{ InvalidLimits, TicketTooLarge };
+    error{ InvalidLimits, TicketTooLarge, IllegalParameter };
 
 pub fn encodedLen(params: EmitParams) EncodeError!usize {
     try validateEmitParams(params);
@@ -123,12 +123,12 @@ pub fn decode(body: []const u8) DecodeError!Parsed {
     try r.expectEnd();
 
     var ext_reader = Reader{ .bytes = extensions };
+    var seen_extensions = ExtensionSeenSet{};
     var max_early_data_size: ?u32 = null;
     while (!ext_reader.atEnd()) {
-        const prefix_len = ext_reader.pos;
         const ext_type = try ext_reader.readU16();
         const ext_body = try ext_reader.slice(try ext_reader.readU16());
-        if (try extensionSeen(extensions[0..prefix_len], ext_type)) return error.IllegalParameter;
+        if (seen_extensions.mark(ext_type)) return error.IllegalParameter;
         if (ext_type == ext_early_data) {
             if (ext_body.len != 4) return error.MalformedHandshake;
             max_early_data_size = readIntU32(ext_body[0..4]);
@@ -199,6 +199,7 @@ pub fn buildServerRecoverableState(
     limits: session.Limits,
 ) BuildServerError!session.ServerRecoverableState {
     try limits.validate();
+    validateEmitParams(params) catch return error.IllegalParameter;
     if (params.ticket_lifetime == 0) return error.InvalidLifetime;
     if (params.ticket.len == 0 or params.ticket.len > limits.max_ticket_len) return error.TicketTooLarge;
     const hash = algorithms.transcriptHash(connection.cipher_suite);
@@ -285,15 +286,17 @@ const Reader = struct {
     }
 };
 
-fn extensionSeen(prefix: []const u8, target: u16) DecodeError!bool {
-    var r = Reader{ .bytes = prefix };
-    while (!r.atEnd()) {
-        const ext_type = try r.readU16();
-        _ = try r.slice(try r.readU16());
-        if (ext_type == target) return true;
+const ExtensionSeenSet = struct {
+    bits: [std.math.maxInt(u16) / 8 + 1]u8 = [_]u8{0} ** (std.math.maxInt(u16) / 8 + 1),
+
+    fn mark(self: *ExtensionSeenSet, ext_type: u16) bool {
+        const index: usize = @intCast(ext_type / 8);
+        const mask: u8 = @as(u8, 1) << @intCast(ext_type % 8);
+        const duplicate = (self.bits[index] & mask) != 0;
+        self.bits[index] |= mask;
+        return duplicate;
     }
-    return false;
-}
+};
 
 fn readIntU16(bytes: []const u8) u16 {
     return std.mem.readInt(u16, bytes[0..2], .big);
@@ -534,7 +537,7 @@ test "server recoverable state honors caller ticket limits" {
     const one_over = try std.testing.allocator.alloc(u8, absolute_ticket_wire_max + 1);
     defer std.testing.allocator.free(one_over);
     @memset(one_over, 0x5b);
-    try std.testing.expectError(error.TicketTooLarge, buildServerRecoverableState(
+    try std.testing.expectError(error.IllegalParameter, buildServerRecoverableState(
         std.testing.allocator,
         .{
             .ticket_lifetime = 1,
@@ -546,6 +549,36 @@ test "server recoverable state honors caller ticket limits" {
         &rms,
         1,
         .{ .max_ticket_len = absolute_ticket_wire_max },
+    ));
+
+    var nonce_255 = [_]u8{0x01} ** 255;
+    var nonce_256 = [_]u8{0x02} ** 256;
+    var nonce_state = try buildServerRecoverableState(
+        std.testing.allocator,
+        .{
+            .ticket_lifetime = 1,
+            .ticket_age_add = 0,
+            .ticket_nonce = &nonce_255,
+            .ticket = "ticket",
+        },
+        context,
+        &rms,
+        1,
+        session.Limits.default,
+    );
+    nonce_state.deinit();
+    try std.testing.expectError(error.IllegalParameter, buildServerRecoverableState(
+        std.testing.allocator,
+        .{
+            .ticket_lifetime = 1,
+            .ticket_age_add = 0,
+            .ticket_nonce = &nonce_256,
+            .ticket = "ticket",
+        },
+        context,
+        &rms,
+        1,
+        session.Limits.default,
     ));
 }
 
@@ -569,6 +602,45 @@ test "lifetime zero parses but does not build cacheable client state" {
         session.Limits.default,
     );
     try std.testing.expectEqual(@as(?session.ClientTicketState, null), state);
+}
+
+test "client ticket state derives distinct PSKs for distinct nonces" {
+    const context: ConnectionResumptionContext = .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer("leaf"),
+    };
+    const rms = [_]u8{0x42} ** 32;
+    var first = (try buildClientTicketState(
+        std.testing.allocator,
+        .{
+            .ticket_lifetime = 60,
+            .ticket_age_add = 0,
+            .ticket_nonce = "\x01",
+            .ticket = "ticket-1",
+            .max_early_data_size = null,
+        },
+        context,
+        &rms,
+        10,
+        session.Limits.default,
+    )).?;
+    defer first.deinit();
+    var second = (try buildClientTicketState(
+        std.testing.allocator,
+        .{
+            .ticket_lifetime = 60,
+            .ticket_age_add = 0,
+            .ticket_nonce = "\x02",
+            .ticket = "ticket-2",
+            .max_early_data_size = null,
+        },
+        context,
+        &rms,
+        10,
+        session.Limits.default,
+    )).?;
+    defer second.deinit();
+    try std.testing.expect(!std.mem.eql(u8, first.common.resumption_psk.slice(), second.common.resumption_psk.slice()));
 }
 
 fn appendBaseTicketPrefix(

--- a/src/tls/new_session_ticket.zig
+++ b/src/tls/new_session_ticket.zig
@@ -63,7 +63,7 @@ pub const BuildError =
 pub const BuildServerError =
     key_schedule.Error ||
     session.ResumableSessionCommon.InitError ||
-    error{InvalidLimits};
+    error{ InvalidLimits, TicketTooLarge };
 
 pub fn encodedLen(params: EmitParams) EncodeError!usize {
     try validateEmitParams(params);
@@ -117,16 +117,18 @@ pub fn decode(body: []const u8) DecodeError!Parsed {
     if (ticket.len == 0) return error.MalformedHandshake;
     if (ticket_lifetime > max_lifetime_seconds) return error.IllegalParameter;
 
-    const extensions = try r.slice(try r.readU16());
+    const extensions_len = try r.readU16();
+    if (extensions_len > max_extensions_wire_len) return error.MalformedHandshake;
+    const extensions = try r.slice(extensions_len);
     try r.expectEnd();
 
-    var guard = ExtensionGuard{};
     var ext_reader = Reader{ .bytes = extensions };
     var max_early_data_size: ?u32 = null;
     while (!ext_reader.atEnd()) {
+        const prefix_len = ext_reader.pos;
         const ext_type = try ext_reader.readU16();
         const ext_body = try ext_reader.slice(try ext_reader.readU16());
-        try guard.check(ext_type);
+        if (try extensionSeen(extensions[0..prefix_len], ext_type)) return error.IllegalParameter;
         if (ext_type == ext_early_data) {
             if (ext_body.len != 4) return error.MalformedHandshake;
             max_early_data_size = readIntU32(ext_body[0..4]);
@@ -198,6 +200,7 @@ pub fn buildServerRecoverableState(
 ) BuildServerError!session.ServerRecoverableState {
     try limits.validate();
     if (params.ticket_lifetime == 0) return error.InvalidLifetime;
+    if (params.ticket.len == 0 or params.ticket.len > limits.max_ticket_len) return error.TicketTooLarge;
     const hash = algorithms.transcriptHash(connection.cipher_suite);
     var psk: [session.max_psk_len]u8 = undefined;
     defer crypto.secureZero(u8, &psk);
@@ -282,19 +285,15 @@ const Reader = struct {
     }
 };
 
-const ExtensionGuard = struct {
-    ids: [64]u16 = undefined,
-    len: usize = 0,
-
-    fn check(self: *ExtensionGuard, ext_type: u16) DecodeError!void {
-        for (self.ids[0..self.len]) |seen| {
-            if (seen == ext_type) return error.IllegalParameter;
-        }
-        if (self.len == self.ids.len) return error.MalformedHandshake;
-        self.ids[self.len] = ext_type;
-        self.len += 1;
+fn extensionSeen(prefix: []const u8, target: u16) DecodeError!bool {
+    var r = Reader{ .bytes = prefix };
+    while (!r.atEnd()) {
+        const ext_type = try r.readU16();
+        _ = try r.slice(try r.readU16());
+        if (ext_type == target) return true;
     }
-};
+    return false;
+}
 
 fn readIntU16(bytes: []const u8) u16 {
     return std.mem.readInt(u16, bytes[0..2], .big);
@@ -395,6 +394,65 @@ test "NewSessionTicket decode rejects malformed and illegal inputs distinctly" {
     try std.testing.expectError(error.MalformedHandshake, decode(&malformed_early_data));
 }
 
+test "NewSessionTicket extension vector permits legal counts and rejects illegal length" {
+    const allocator = std.testing.allocator;
+    var many_extensions: std.ArrayList(u8) = .empty;
+    defer many_extensions.deinit(allocator);
+    try appendBaseTicketPrefix(&many_extensions, 1, 0, "", "x");
+    try many_extensions.appendSlice(allocator, &.{ 0, 0 });
+    const ext_len_pos = many_extensions.items.len - 2;
+    for (0..65) |i| {
+        try appendExtension(&many_extensions, @intCast(1000 + i), "");
+    }
+    std.mem.writeInt(u16, many_extensions.items[ext_len_pos..][0..2], @intCast(many_extensions.items.len - ext_len_pos - 2), .big);
+    const parsed_many = try decode(many_extensions.items);
+    try std.testing.expectEqualSlices(u8, "x", parsed_many.ticket);
+
+    var exact: std.ArrayList(u8) = .empty;
+    defer exact.deinit(allocator);
+    try appendBaseTicketPrefix(&exact, 1, 0, "", "x");
+    try exact.appendSlice(allocator, &.{ 0xff, 0xfe });
+    var written: usize = 0;
+    var ext_id: u16 = 1000;
+    while (written + 4 <= max_extensions_wire_len - 6) : ({
+        written += 4;
+        ext_id += 1;
+    }) {
+        try appendExtension(&exact, ext_id, "");
+    }
+    try appendExtension(&exact, ext_id, "\xaa\xbb");
+    written += 6;
+    try std.testing.expectEqual(max_extensions_wire_len, written);
+    const parsed_exact = try decode(exact.items);
+    try std.testing.expectEqualSlices(u8, "x", parsed_exact.ticket);
+
+    var illegal: std.ArrayList(u8) = .empty;
+    defer illegal.deinit(allocator);
+    try appendBaseTicketPrefix(&illegal, 1, 0, "", "x");
+    try illegal.appendSlice(allocator, &.{ 0xff, 0xff });
+    try illegal.appendNTimes(allocator, 0, std.math.maxInt(u16));
+    try std.testing.expectError(error.MalformedHandshake, decode(illegal.items));
+}
+
+test "NewSessionTicket duplicate known and unknown extensions are illegal" {
+    const allocator = std.testing.allocator;
+    var duplicate_known: std.ArrayList(u8) = .empty;
+    defer duplicate_known.deinit(allocator);
+    try appendBaseTicketPrefix(&duplicate_known, 1, 0, "", "x");
+    try duplicate_known.appendSlice(allocator, &.{ 0, 16 });
+    try appendExtension(&duplicate_known, ext_early_data, "\x00\x00\x00\x01");
+    try appendExtension(&duplicate_known, ext_early_data, "\x00\x00\x00\x02");
+    try std.testing.expectError(error.IllegalParameter, decode(duplicate_known.items));
+
+    var duplicate_unknown: std.ArrayList(u8) = .empty;
+    defer duplicate_unknown.deinit(allocator);
+    try appendBaseTicketPrefix(&duplicate_unknown, 1, 0, "", "x");
+    try duplicate_unknown.appendSlice(allocator, &.{ 0, 8 });
+    try appendExtension(&duplicate_unknown, 0x1234, "");
+    try appendExtension(&duplicate_unknown, 0x1234, "");
+    try std.testing.expectError(error.IllegalParameter, decode(duplicate_unknown.items));
+}
+
 test "NewSessionTicket encode validates bounds and output size" {
     var buf: [8]u8 = undefined;
     try std.testing.expectError(error.OutputTooSmall, encode(.{
@@ -417,6 +475,80 @@ test "NewSessionTicket encode validates bounds and output size" {
     }));
 }
 
+test "server recoverable state honors caller ticket limits" {
+    const context: ConnectionResumptionContext = .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer("leaf"),
+    };
+    const rms = [_]u8{0x42} ** 32;
+
+    var default_over = [_]u8{0xa5} ** (session.Limits.default.max_ticket_len + 1);
+    try std.testing.expectError(error.TicketTooLarge, buildServerRecoverableState(
+        std.testing.allocator,
+        .{
+            .ticket_lifetime = 1,
+            .ticket_age_add = 0,
+            .ticket_nonce = "",
+            .ticket = &default_over,
+        },
+        context,
+        &rms,
+        1,
+        session.Limits.default,
+    ));
+
+    const custom_limits = session.Limits{ .max_ticket_len = default_over.len };
+    var custom_state = try buildServerRecoverableState(
+        std.testing.allocator,
+        .{
+            .ticket_lifetime = 1,
+            .ticket_age_add = 0,
+            .ticket_nonce = "",
+            .ticket = &default_over,
+        },
+        context,
+        &rms,
+        1,
+        custom_limits,
+    );
+    custom_state.deinit();
+
+    const max_ticket = try std.testing.allocator.alloc(u8, absolute_ticket_wire_max);
+    defer std.testing.allocator.free(max_ticket);
+    @memset(max_ticket, 0x5a);
+    var max_state = try buildServerRecoverableState(
+        std.testing.allocator,
+        .{
+            .ticket_lifetime = 1,
+            .ticket_age_add = 0,
+            .ticket_nonce = "",
+            .ticket = max_ticket,
+        },
+        context,
+        &rms,
+        1,
+        .{ .max_ticket_len = absolute_ticket_wire_max, .max_serialized_len = session.Limits.default.max_serialized_len },
+    );
+    max_state.deinit();
+
+    const one_over = try std.testing.allocator.alloc(u8, absolute_ticket_wire_max + 1);
+    defer std.testing.allocator.free(one_over);
+    @memset(one_over, 0x5b);
+    try std.testing.expectError(error.TicketTooLarge, buildServerRecoverableState(
+        std.testing.allocator,
+        .{
+            .ticket_lifetime = 1,
+            .ticket_age_add = 0,
+            .ticket_nonce = "",
+            .ticket = one_over,
+        },
+        context,
+        &rms,
+        1,
+        .{ .max_ticket_len = absolute_ticket_wire_max },
+    ));
+}
+
 test "lifetime zero parses but does not build cacheable client state" {
     const parsed = Parsed{
         .ticket_lifetime = 0,
@@ -437,4 +569,35 @@ test "lifetime zero parses but does not build cacheable client state" {
         session.Limits.default,
     );
     try std.testing.expectEqual(@as(?session.ClientTicketState, null), state);
+}
+
+fn appendBaseTicketPrefix(
+    list: *std.ArrayList(u8),
+    lifetime: u32,
+    age_add: u32,
+    nonce: []const u8,
+    ticket: []const u8,
+) !void {
+    const allocator = std.testing.allocator;
+    var fixed: [4]u8 = undefined;
+    std.mem.writeInt(u32, &fixed, lifetime, .big);
+    try list.appendSlice(allocator, &fixed);
+    std.mem.writeInt(u32, &fixed, age_add, .big);
+    try list.appendSlice(allocator, &fixed);
+    try list.append(allocator, @intCast(nonce.len));
+    try list.appendSlice(allocator, nonce);
+    var len: [2]u8 = undefined;
+    std.mem.writeInt(u16, &len, @intCast(ticket.len), .big);
+    try list.appendSlice(allocator, &len);
+    try list.appendSlice(allocator, ticket);
+}
+
+fn appendExtension(list: *std.ArrayList(u8), ext_type: u16, payload: []const u8) !void {
+    const allocator = std.testing.allocator;
+    var encoded: [2]u8 = undefined;
+    std.mem.writeInt(u16, &encoded, ext_type, .big);
+    try list.appendSlice(allocator, &encoded);
+    std.mem.writeInt(u16, &encoded, @intCast(payload.len), .big);
+    try list.appendSlice(allocator, &encoded);
+    try list.appendSlice(allocator, payload);
 }

--- a/src/tls/new_session_ticket.zig
+++ b/src/tls/new_session_ticket.zig
@@ -458,12 +458,15 @@ test "NewSessionTicket duplicate known and unknown extensions are illegal" {
 
 test "NewSessionTicket encode validates bounds and output size" {
     var buf: [8]u8 = undefined;
+    @memset(&buf, 0xa5);
+    const before = buf;
     try std.testing.expectError(error.OutputTooSmall, encode(.{
         .ticket_lifetime = 1,
         .ticket_age_add = 0,
         .ticket_nonce = "",
         .ticket = "ticket",
     }, &buf));
+    try std.testing.expectEqualSlices(u8, &before, &buf);
     try std.testing.expectError(error.IllegalParameter, encodedLen(.{
         .ticket_lifetime = max_lifetime_seconds + 1,
         .ticket_age_add = 0,
@@ -476,6 +479,107 @@ test "NewSessionTicket encode validates bounds and output size" {
         .ticket_nonce = "",
         .ticket = "",
     }));
+}
+
+test "NewSessionTicket decode rejects every truncated fixture prefix" {
+    var storage: [128]u8 = undefined;
+    const fixture = try encode(.{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 0x11223344,
+        .ticket_nonce = "\x01\x02",
+        .ticket = "opaque-ticket",
+        .max_early_data_size = 32,
+    }, &storage);
+
+    for (0..fixture.len) |cut| {
+        try std.testing.expectError(error.MalformedHandshake, decode(fixture[0..cut]));
+    }
+    const parsed = try decode(fixture);
+    try std.testing.expectEqual(@as(u32, 60), parsed.ticket_lifetime);
+}
+
+test "NewSessionTicket length field mutation matrix" {
+    const allocator = std.testing.allocator;
+
+    const nonce_255 = try allocator.alloc(u8, 255);
+    defer allocator.free(nonce_255);
+    @memset(nonce_255, 0x01);
+    var nonce_buf: [512]u8 = undefined;
+    const nonce_exact = try encode(.{ .ticket_lifetime = 1, .ticket_age_add = 0, .ticket_nonce = nonce_255, .ticket = "x" }, &nonce_buf);
+    try std.testing.expectEqual(@as(usize, 255), (try decode(nonce_exact)).ticket_nonce.len);
+    const nonce_256 = try allocator.alloc(u8, 256);
+    defer allocator.free(nonce_256);
+    try std.testing.expectError(error.IllegalParameter, encodedLen(.{ .ticket_lifetime = 1, .ticket_age_add = 0, .ticket_nonce = nonce_256, .ticket = "x" }));
+
+    const default_ticket = try allocator.alloc(u8, session.Limits.default.max_ticket_len);
+    defer allocator.free(default_ticket);
+    @memset(default_ticket, 0x02);
+    const absolute_ticket = try allocator.alloc(u8, absolute_ticket_wire_max);
+    defer allocator.free(absolute_ticket);
+    @memset(absolute_ticket, 0x03);
+    const default_buf = try allocator.alloc(u8, try encodedLen(.{ .ticket_lifetime = 1, .ticket_age_add = 0, .ticket_nonce = "", .ticket = default_ticket }));
+    defer allocator.free(default_buf);
+    try std.testing.expectEqual(default_ticket.len, (try decode(try encode(.{ .ticket_lifetime = 1, .ticket_age_add = 0, .ticket_nonce = "", .ticket = default_ticket }, default_buf))).ticket.len);
+    const absolute_buf = try allocator.alloc(u8, try encodedLen(.{ .ticket_lifetime = 1, .ticket_age_add = 0, .ticket_nonce = "", .ticket = absolute_ticket }));
+    defer allocator.free(absolute_buf);
+    try std.testing.expectEqual(absolute_ticket.len, (try decode(try encode(.{ .ticket_lifetime = 1, .ticket_age_add = 0, .ticket_nonce = "", .ticket = absolute_ticket }, absolute_buf))).ticket.len);
+    const over_ticket = try allocator.alloc(u8, absolute_ticket_wire_max + 1);
+    defer allocator.free(over_ticket);
+    try std.testing.expectError(error.IllegalParameter, encodedLen(.{ .ticket_lifetime = 1, .ticket_age_add = 0, .ticket_nonce = "", .ticket = over_ticket }));
+
+    var empty_ticket = std.ArrayList(u8).empty;
+    defer empty_ticket.deinit(allocator);
+    try appendBaseTicketPrefix(&empty_ticket, 1, 0, "", "");
+    try empty_ticket.appendSlice(allocator, &.{ 0, 0 });
+    try std.testing.expectError(error.MalformedHandshake, decode(empty_ticket.items));
+    var trailing = std.ArrayList(u8).empty;
+    defer trailing.deinit(allocator);
+    try appendBaseTicketPrefix(&trailing, 1, 0, "", "x");
+    try trailing.appendSlice(allocator, &.{ 0, 0, 0xaa });
+    try std.testing.expectError(error.MalformedHandshake, decode(trailing.items));
+
+    var ext_zero = std.ArrayList(u8).empty;
+    defer ext_zero.deinit(allocator);
+    try appendBaseTicketPrefix(&ext_zero, 1, 0, "", "x");
+    try ext_zero.appendSlice(allocator, &.{ 0, 0 });
+    try std.testing.expectEqualSlices(u8, "x", (try decode(ext_zero.items)).ticket);
+    var ext_short = std.ArrayList(u8).empty;
+    defer ext_short.deinit(allocator);
+    try appendBaseTicketPrefix(&ext_short, 1, 0, "", "x");
+    try ext_short.appendSlice(allocator, &.{ 0, 3, 0, 42, 0 });
+    try std.testing.expectError(error.MalformedHandshake, decode(ext_short.items));
+    var ext_over_declared = std.ArrayList(u8).empty;
+    defer ext_over_declared.deinit(allocator);
+    try appendBaseTicketPrefix(&ext_over_declared, 1, 0, "", "x");
+    try ext_over_declared.appendSlice(allocator, &.{ 0, 9 });
+    try appendExtension(&ext_over_declared, ext_early_data, "\x00\x00\x00\x20");
+    try std.testing.expectError(error.MalformedHandshake, decode(ext_over_declared.items));
+
+    inline for (.{ 0, 3, 5 }) |bad_len| {
+        var early = std.ArrayList(u8).empty;
+        defer early.deinit(allocator);
+        try appendBaseTicketPrefix(&early, 1, 0, "", "x");
+        var ext_len: [2]u8 = undefined;
+        std.mem.writeInt(u16, &ext_len, 4 + bad_len, .big);
+        try early.appendSlice(allocator, &ext_len);
+        var payload = [_]u8{0} ** 5;
+        try appendExtension(&early, ext_early_data, payload[0..bad_len]);
+        try std.testing.expectError(error.MalformedHandshake, decode(early.items));
+    }
+    var early_ok = std.ArrayList(u8).empty;
+    defer early_ok.deinit(allocator);
+    try appendBaseTicketPrefix(&early_ok, 1, 0, "", "x");
+    try early_ok.appendSlice(allocator, &.{ 0, 8 });
+    try appendExtension(&early_ok, ext_early_data, "\x00\x00\x00\x20");
+    try std.testing.expectEqual(@as(?u32, 32), (try decode(early_ok.items)).max_early_data_size);
+
+    var lifetime_ok = [_]u8{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 'x', 0, 0 };
+    std.mem.writeInt(u32, lifetime_ok[0..4], max_lifetime_seconds, .big);
+    try std.testing.expectEqual(max_lifetime_seconds, (try decode(&lifetime_ok)).ticket_lifetime);
+    std.mem.writeInt(u32, lifetime_ok[0..4], max_lifetime_seconds + 1, .big);
+    try std.testing.expectError(error.IllegalParameter, decode(&lifetime_ok));
+    std.mem.writeInt(u32, lifetime_ok[0..4], 0, .big);
+    try std.testing.expectEqual(@as(u32, 0), (try decode(&lifetime_ok)).ticket_lifetime);
 }
 
 test "server recoverable state honors caller ticket limits" {
@@ -641,6 +745,97 @@ test "client ticket state derives distinct PSKs for distinct nonces" {
     )).?;
     defer second.deinit();
     try std.testing.expect(!std.mem.eql(u8, first.common.resumption_psk.slice(), second.common.resumption_psk.slice()));
+}
+
+test "ticket owned state builders and clone are allocation-failure clean" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, exerciseClientTicketBuild, .{});
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, exerciseServerTicketBuild, .{});
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, exerciseClientTicketClone, .{});
+}
+
+fn allocationSweepContext() ConnectionResumptionContext {
+    return .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .server_name = "example.com",
+        .application_protocol = "h2",
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer("leaf"),
+        .transport_compat = .{ .format_id = 1, .format_version = 1, .bytes = "transport-compat" },
+        .application_compat = .{ .format_id = 2, .format_version = 1, .bytes = "application-compat" },
+    };
+}
+
+fn exerciseClientTicketBuild(allocator: std.mem.Allocator) !void {
+    const rms = [_]u8{0x42} ** 32;
+    var state = (try buildClientTicketState(
+        allocator,
+        .{
+            .ticket_lifetime = 60,
+            .ticket_age_add = 0x11223344,
+            .ticket_nonce = "\x01\x02",
+            .ticket = "client-owned-ticket",
+            .max_early_data_size = 32,
+        },
+        allocationSweepContext(),
+        &rms,
+        1234,
+        session.Limits.default,
+    )).?;
+    defer state.deinit();
+    try std.testing.expectEqualSlices(u8, "client-owned-ticket", state.ticket.slice());
+    try std.testing.expectEqualSlices(u8, "\x01\x02", state.ticket_nonce.slice());
+    try std.testing.expectEqualStrings("example.com", state.common.server_name.?.slice());
+    try std.testing.expectEqualStrings("h2", state.common.application_protocol.?.slice());
+    try std.testing.expect(state.common.transport_compat != null);
+    try std.testing.expect(state.common.application_compat != null);
+}
+
+fn exerciseServerTicketBuild(allocator: std.mem.Allocator) !void {
+    const rms = [_]u8{0x42} ** 32;
+    var state = try buildServerRecoverableState(
+        allocator,
+        .{
+            .ticket_lifetime = 60,
+            .ticket_age_add = 0x11223344,
+            .ticket_nonce = "\x01\x02",
+            .ticket = "server-owned-ticket",
+            .max_early_data_size = 32,
+        },
+        allocationSweepContext(),
+        &rms,
+        1234,
+        session.Limits.default,
+    );
+    defer state.deinit();
+    try std.testing.expectEqualStrings("example.com", state.common.server_name.?.slice());
+    try std.testing.expectEqualStrings("h2", state.common.application_protocol.?.slice());
+    try std.testing.expect(state.common.transport_compat != null);
+    try std.testing.expect(state.common.application_compat != null);
+}
+
+fn exerciseClientTicketClone(allocator: std.mem.Allocator) !void {
+    const rms = [_]u8{0x42} ** 32;
+    var source = (try buildClientTicketState(
+        std.testing.allocator,
+        .{
+            .ticket_lifetime = 60,
+            .ticket_age_add = 0x11223344,
+            .ticket_nonce = "\x01\x02",
+            .ticket = "clone-owned-ticket",
+            .max_early_data_size = 32,
+        },
+        allocationSweepContext(),
+        &rms,
+        1234,
+        session.Limits.default,
+    )).?;
+    defer source.deinit();
+
+    var clone: session.ClientTicketState = .{};
+    try source.cloneInto(allocator, &clone);
+    defer clone.deinit();
+    try std.testing.expectEqualSlices(u8, source.ticket.slice(), clone.ticket.slice());
+    try std.testing.expectEqualSlices(u8, source.ticket_nonce.slice(), clone.ticket_nonce.slice());
+    try std.testing.expectEqualSlices(u8, source.common.resumption_psk.slice(), clone.common.resumption_psk.slice());
 }
 
 fn appendBaseTicketPrefix(

--- a/src/tls/record_epoch_bridge.zig
+++ b/src/tls/record_epoch_bridge.zig
@@ -209,6 +209,25 @@ pub const Bridge = struct {
         };
     }
 
+    pub fn sealedHandshakeLen(self: *Bridge, epoch: events.EncryptionEpoch, bytes_len: usize) Error!usize {
+        return switch (epoch) {
+            .initial => if (self.initial_discarded)
+                error.UnsupportedRecordEpoch
+            else
+                plaintextHandshakeRecordLen(bytes_len),
+            .handshake => blk: {
+                const write = self.writeHandshake() orelse return error.MissingWriteKeys;
+                break :blk protectedHandshakeRecordLen(write, bytes_len);
+            },
+            .application => blk: {
+                if (!self.handshake_complete) return error.HandshakeNotComplete;
+                const write = self.writeApplication() orelse return error.MissingWriteKeys;
+                break :blk protectedHandshakeRecordLen(write, bytes_len);
+            },
+            .zero_rtt => error.UnsupportedRecordEpoch,
+        };
+    }
+
     pub fn sealProtected(
         self: *Bridge,
         epoch: events.EncryptionEpoch,

--- a/src/tls/record_epoch_bridge.zig
+++ b/src/tls/record_epoch_bridge.zig
@@ -178,7 +178,35 @@ pub const Bridge = struct {
     }
 
     pub fn sealHandshake(self: *Bridge, epoch: events.EncryptionEpoch, bytes: []const u8, out: []u8) Error![]const u8 {
-        return self.sealProtected(epoch, .handshake, bytes, out);
+        if (bytes.len <= record_codec.max_plaintext_fragment_len) {
+            return self.sealProtected(epoch, .handshake, bytes, out);
+        }
+        return switch (epoch) {
+            .initial => blk: {
+                if (self.initial_discarded) return error.UnsupportedRecordEpoch;
+                const needed = plaintextHandshakeRecordLen(bytes.len);
+                if (out.len < needed) return error.RecordBufferOverflow;
+                var in_pos: usize = 0;
+                var out_pos: usize = 0;
+                while (in_pos < bytes.len) {
+                    const take = @min(record_codec.max_plaintext_fragment_len, bytes.len - in_pos);
+                    const record = try record_codec.encodePlaintextRecord(.handshake, bytes[in_pos..][0..take], out[out_pos..]);
+                    in_pos += take;
+                    out_pos += record.len;
+                }
+                break :blk out[0..out_pos];
+            },
+            .handshake => blk: {
+                const write = self.writeHandshake() orelse return error.MissingWriteKeys;
+                break :blk try sealHandshakeFragments(write, bytes, out);
+            },
+            .application => blk: {
+                if (!self.handshake_complete) return error.HandshakeNotComplete;
+                const write = self.writeApplication() orelse return error.MissingWriteKeys;
+                break :blk try sealHandshakeFragments(write, bytes, out);
+            },
+            .zero_rtt => error.UnsupportedRecordEpoch,
+        };
     }
 
     pub fn sealProtected(
@@ -326,6 +354,38 @@ fn clearWrite(slot: *?record_protection.WriteState) void {
     slot.* = null;
 }
 
+fn plaintextHandshakeRecordLen(bytes_len: usize) usize {
+    const chunks = (bytes_len + record_codec.max_plaintext_fragment_len - 1) / record_codec.max_plaintext_fragment_len;
+    return bytes_len + chunks * record_codec.header_len;
+}
+
+fn protectedHandshakeRecordLen(write: *const record_protection.WriteState, bytes_len: usize) usize {
+    const chunks = (bytes_len + record_codec.max_plaintext_fragment_len - 1) / record_codec.max_plaintext_fragment_len;
+    return bytes_len + chunks * (record_codec.header_len + 1 + write.keys.profile.aead.tagLength());
+}
+
+fn sealHandshakeFragments(
+    write: *record_protection.WriteState,
+    bytes: []const u8,
+    out: []u8,
+) Error![]const u8 {
+    if (write.exhausted) return error.SequenceExhausted;
+    const chunks = (bytes.len + record_codec.max_plaintext_fragment_len - 1) / record_codec.max_plaintext_fragment_len;
+    if (chunks > 0 and chunks - 1 > std.math.maxInt(u64) - write.sequence) return error.SequenceExhausted;
+    const needed = protectedHandshakeRecordLen(write, bytes.len);
+    if (out.len < needed) return error.RecordBufferOverflow;
+
+    var in_pos: usize = 0;
+    var out_pos: usize = 0;
+    while (in_pos < bytes.len) {
+        const take = @min(record_codec.max_plaintext_fragment_len, bytes.len - in_pos);
+        const record = try write.seal(.handshake, bytes[in_pos..][0..take], 0, out[out_pos..]);
+        in_pos += take;
+        out_pos += record.len;
+    }
+    return out[0..out_pos];
+}
+
 fn parseSingleRecord(mode: record_codec.RecordMode, bytes: []const u8) Error!record_codec.Record {
     if (bytes.len < record_codec.header_len) return error.TruncatedRecord;
     const header = try record_codec.parseHeader(bytes[0..record_codec.header_len], mode, .strict);
@@ -428,6 +488,52 @@ test "record epoch bridge drives event loopback across plaintext, handshake, app
     try testing.expectEqualStrings("new session ticket", opened_post_handshake.inner.content);
     try testing.expectEqual(@as(u64, 1), server.write_application.?.sequence);
     try testing.expectEqual(@as(u64, 1), client.read_application.?.sequence);
+}
+
+test "record epoch bridge fragments large post-handshake messages into multiple records" {
+    const cp = testProvider();
+    var server = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer server.deinit();
+    var client = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+
+    const hs = secret(0x71);
+    const app = secret(0x72);
+    try server.installTrafficSecret(.handshake, .read, &hs);
+    try server.installTrafficSecret(.handshake, .write, &hs);
+    try server.installTrafficSecret(.application, .read, &app);
+    try server.installTrafficSecret(.application, .write, &app);
+    try server.discardEpoch(.initial);
+    try server.discardEpoch(.handshake);
+    try server.markHandshakeComplete();
+
+    try client.installTrafficSecret(.handshake, .read, &hs);
+    try client.installTrafficSecret(.handshake, .write, &hs);
+    try client.installTrafficSecret(.application, .read, &app);
+    try client.installTrafficSecret(.application, .write, &app);
+    try client.discardEpoch(.initial);
+    try client.discardEpoch(.handshake);
+    try client.markHandshakeComplete();
+
+    const payload = [_]u8{0xa5} ** (record_codec.max_plaintext_fragment_len + 33);
+    var protected: [record_codec.max_ciphertext_record_len * 3]u8 = undefined;
+    const records = try server.sealHandshake(.application, &payload, &protected);
+
+    var parser = record_codec.Parser.init(.ciphertext);
+    var sink = record_codec.RecordSink(4, record_codec.max_ciphertext_fragment_len * 4){};
+    try parser.feed(records, &sink);
+    try testing.expectEqual(@as(usize, 2), sink.len);
+
+    var opened_buf: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    var reassembled: [payload.len]u8 = undefined;
+    var offset: usize = 0;
+    for (sink.items[0..sink.len]) |record| {
+        const opened = try client.openHandshake(.application, record, &opened_buf);
+        @memcpy(reassembled[offset..][0..opened.inner.content.len], opened.inner.content);
+        offset += opened.inner.content.len;
+    }
+    try testing.expectEqual(payload.len, offset);
+    try testing.expectEqualSlices(u8, &payload, &reassembled);
 }
 
 test "record epoch bridge rejects early, duplicate, missing, and unsupported transitions" {

--- a/src/tls/root.zig
+++ b/src/tls/root.zig
@@ -11,6 +11,7 @@ pub const algorithms = @import("algorithms.zig");
 pub const crypto_profile = @import("crypto_profile.zig");
 pub const key_schedule = @import("key_schedule.zig");
 pub const messages = @import("messages.zig");
+pub const new_session_ticket = @import("new_session_ticket.zig");
 pub const negotiation = @import("negotiation.zig");
 pub const policy = @import("policy.zig");
 pub const identity_loader = @import("identity_loader.zig");

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -20,8 +20,12 @@ const std = @import("std");
 const dns_name = @import("dns_name.zig");
 const events = @import("events.zig");
 const credentials = @import("credentials.zig");
+const tls_algorithms = @import("algorithms.zig");
+const crypto_pkg = @import("crypto");
 const tls_handshake_codec = @import("handshake.zig");
 const tls_key_schedule = @import("key_schedule.zig");
+const new_session_ticket = @import("new_session_ticket.zig");
+const session = @import("session.zig");
 const tls_state = @import("state.zig");
 const tls13_transport = @import("tls13_transport.zig");
 
@@ -42,9 +46,11 @@ const Reader = tls_handshake_codec.Reader;
 const Writer = tls_handshake_codec.Writer;
 
 pub const hash_len = tls_key_schedule.hash_len;
-/// Largest handshake message body we accept (u24 wire limit is 16 MiB; a
-/// single-certificate Ed25519 flight is far below this).
+/// Largest framed handshake message we accept during the main handshake.
 pub const max_message_len = 8 * 1024;
+/// Largest framed post-handshake NewSessionTicket message: a 65535-byte opaque
+/// ticket identity plus its handshake header and small fixed/vector fields.
+pub const max_new_session_ticket_message_len = session.absolute_ticket_wire_max + 4 + 4 + 4 + 1 + session.max_ticket_nonce_len + 2 + 2 + 8;
 pub const max_certificate_len = 2048;
 /// The Certificate handshake message's fixed framing overhead, counted in the
 /// flight-size preflight so a chain cannot pass validation and then overflow the
@@ -403,6 +409,8 @@ pub const Tls13Backend = struct {
     key_pair_present: bool = false,
     core: tls_handshake_codec.Core,
     schedule: ?KeySchedule = null,
+    resumption_master_secret: crypto_pkg.secrets.FixedSecret(session.max_psk_len) = .{},
+    session_ticket_consumer: ?ConfiguredSessionTicketConsumer = null,
     /// The client Finished verify_data the server expects (computed when its
     /// own flight is sent).
     expected_client_verify: [hash_len]u8 = undefined,
@@ -414,7 +422,7 @@ pub const Tls13Backend = struct {
     /// handshake message.
     initial_input: tls_handshake_codec.Reassembler(max_message_len + 4) = .{},
     handshake_input: tls_handshake_codec.Reassembler(max_message_len + 4) = .{},
-    application_input: tls_handshake_codec.Reassembler(max_message_len + 4) = .{},
+    application_input: tls_handshake_codec.Reassembler(max_new_session_ticket_message_len) = .{},
     /// The peer's reassembled certificate chain (immutable DER, surfaced to the
     /// verifier as views). `entries` index into `peer_chain`.
     peer_chain: [max_peer_chain_bytes]u8 = undefined,
@@ -440,6 +448,27 @@ pub const Tls13Backend = struct {
 
     const Slice = struct { start: usize, len: usize };
     const PendingStage = enum { server_select, server_sign, client_select, client_sign, peer_verify };
+
+    pub const SessionTicketConsumer = struct {
+        ctx: *anyopaque,
+        nowUnixMsFn: *const fn (*anyopaque) i64,
+        onTicketFn: *const fn (*anyopaque, *const session.ClientTicketState) void,
+    };
+
+    const ConfiguredSessionTicketConsumer = struct {
+        allocator: std.mem.Allocator,
+        limits: session.Limits,
+        consumer: SessionTicketConsumer,
+    };
+
+    pub const EmitNewSessionTicketParams = struct {
+        ticket_lifetime: u32,
+        ticket_age_add: u32,
+        ticket_nonce: []const u8,
+        opaque_ticket: []const u8,
+        max_early_data_size: ?u32 = null,
+        issued_at_unix_ms: i64,
+    };
 
     /// Options for a client that verifies its peer through an external verifier:
     /// the exact intended server name (emitted as SNI and handed to the
@@ -570,6 +599,21 @@ pub const Tls13Backend = struct {
         self.external_provider = provider;
     }
 
+    pub fn setSessionTicketConsumer(
+        self: *Tls13Backend,
+        allocator: std.mem.Allocator,
+        limits: session.Limits,
+        consumer: SessionTicketConsumer,
+    ) HandshakeError!void {
+        if (self.role != .client) return error.InvalidHandshakeState;
+        limits.validate() catch return error.InvalidTransportProfile;
+        self.session_ticket_consumer = .{
+            .allocator = allocator,
+            .limits = limits,
+            .consumer = consumer,
+        };
+    }
+
     pub fn backend(self: *Tls13Backend) TlsBackend {
         return .{
             .ptr = self,
@@ -659,6 +703,8 @@ pub const Tls13Backend = struct {
         self.pending_client_hello_ready = false;
         if (self.schedule) |*schedule| schedule.wipe();
         self.schedule = null;
+        self.resumption_master_secret.deinit();
+        self.session_ticket_consumer = null;
         crypto.secureZero(u8, &self.expected_client_verify);
         self.wipeEphemeral();
         self.wipeIdentity();
@@ -727,24 +773,28 @@ pub const Tls13Backend = struct {
 
     fn receiveImpl(ptr: *anyopaque, level: EncryptionLevel, bytes: []const u8, sink: *EventSink) HandshakeError!void {
         const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
-        const input = switch (level) {
-            .initial => &self.initial_input,
-            .handshake => &self.handshake_input,
-            // This deliberately narrow TLS profile does not implement 0-RTT.
+        switch (level) {
             .zero_rtt => return error.UnexpectedTransportEpoch,
-            // Application-epoch handshake input carries post-handshake messages.
-            .application => blk: {
+            .application => {
                 if (self.core.handshake_lifecycle != .complete) return error.UnexpectedTransportEpoch;
-                break :blk &self.application_input;
+                self.application_input.append(bytes) catch |err| return mapCoreError(err);
+                if (self.pending_op != null) return;
+                return self.drainInput(&self.application_input, level, sink);
             },
-        };
-        if (level != .application and self.core.handshake_lifecycle == .complete) {
+            .initial, .handshake => {},
+        }
+        if (self.core.handshake_lifecycle == .complete) {
             return error.UnexpectedHandshakeMessage;
         }
         if (self.rejectPeerHandshakeWhileClientAuthPending(level, bytes.len)) {
             self.cancelPendingAuth();
             return error.UnexpectedHandshakeMessage;
         }
+        const input = switch (level) {
+            .initial => &self.initial_input,
+            .handshake => &self.handshake_input,
+            .zero_rtt, .application => unreachable,
+        };
         input.append(bytes) catch |err| return mapCoreError(err);
         // Never begin dispatching while an authentication operation is parked:
         // buffer the freshly received bytes and wait for `resumeAuth`. Without
@@ -762,7 +812,7 @@ pub const Tls13Backend = struct {
     /// suspend point are drained automatically once the operation resolves.
     fn drainInput(
         self: *Tls13Backend,
-        input: *tls_handshake_codec.Reassembler(max_message_len + 4),
+        input: anytype,
         level: EncryptionLevel,
         sink: *EventSink,
     ) HandshakeError!void {
@@ -854,11 +904,7 @@ pub const Tls13Backend = struct {
             // server that receives one has been sent a message it must never
             // get, which is an ordering violation, not malformed bytes.
             if (self.role != .client) return error.UnexpectedHandshakeMessage;
-            // This backend does not implement resumption, so the ticket is
-            // ignored — but a compliant peer must still send a structurally
-            // valid one. Validate the framing so malformed wire data is
-            // rejected as `decode_error` rather than silently accepted.
-            try validateNewSessionTicket(body);
+            try self.onNewSessionTicket(body);
             return;
         }
 
@@ -880,28 +926,23 @@ pub const Tls13Backend = struct {
         }
     }
 
-    /// Minimally validate a NewSessionTicket's framing (RFC 8446 §4.6.1):
-    ///
-    ///   struct {
-    ///     uint32 ticket_lifetime;
-    ///     uint32 ticket_age_add;
-    ///     opaque ticket_nonce<0..255>;
-    ///     opaque ticket<1..2^16-1>;
-    ///     Extension extensions<0..2^16-2>;
-    ///   } NewSessionTicket;
-    ///
-    /// This backend does not implement resumption and ignores the ticket, but a
-    /// structurally invalid one is still malformed wire data. Any framing error
-    /// (including an empty `ticket`, which the spec forbids, or trailing bytes)
-    /// is a `MalformedHandshake` / `decode_error`.
-    fn validateNewSessionTicket(body: []const u8) HandshakeError!void {
-        var r = Reader{ .bytes = body };
-        _ = try r.slice(4); // ticket_lifetime
-        _ = try r.slice(4); // ticket_age_add
-        _ = try r.slice(try r.u8_()); // ticket_nonce
-        if ((try r.slice(try r.u16_())).len == 0) return error.MalformedHandshake; // ticket<1..>
-        _ = try r.slice(try r.u16_()); // extensions
-        try r.expectEnd();
+    fn onNewSessionTicket(self: *Tls13Backend, body: []const u8) HandshakeError!void {
+        const parsed = new_session_ticket.decode(body) catch |err| return mapTicketDecodeError(err);
+        const configured = self.session_ticket_consumer orelse return;
+        if (self.resumption_master_secret.slice().len == 0) return error.InvalidHandshakeState;
+        const received_at = configured.consumer.nowUnixMsFn(configured.consumer.ctx);
+        var state = new_session_ticket.buildClientTicketState(
+            configured.allocator,
+            parsed,
+            self.resumptionContext(),
+            self.resumption_master_secret.slice(),
+            received_at,
+            configured.limits,
+        ) catch return;
+        if (state) |*ticket| {
+            defer ticket.deinit();
+            configured.consumer.onTicketFn(configured.consumer.ctx, ticket);
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -1410,6 +1451,7 @@ pub const Tls13Backend = struct {
     /// Terminal steps shared by every client completion path: discard the
     /// handshake epoch, signal completion, and wipe the key schedule.
     fn completeClientHandshake(self: *Tls13Backend, sink: *EventSink) HandshakeError!void {
+        try self.captureResumptionMasterSecret();
         try self.emitDiscardKeys(sink, .handshake);
         try sink.emitHandshakeComplete();
         self.finish();
@@ -2214,6 +2256,7 @@ pub const Tls13Backend = struct {
         defer crypto.secureZero(u8, &expected);
         if (!crypto.timing_safe.eql([hash_len]u8, expected, body[0..hash_len].*)) return error.DecryptError;
         // Client Finished confirms the handshake for the server (RFC 8446 §4.4.4).
+        try self.captureResumptionMasterSecret();
         try self.emitDiscardKeys(sink, .handshake);
         try sink.emitHandshakeComplete();
         self.finish();
@@ -2264,6 +2307,87 @@ pub const Tls13Backend = struct {
         self.peer_transport_extension_pending = true;
     }
 
+    fn captureResumptionMasterSecret(self: *Tls13Backend) HandshakeError!void {
+        if (self.resumption_master_secret.slice().len != 0) return error.InvalidHandshakeState;
+        const schedule = &(self.schedule orelse return error.InvalidHandshakeState);
+        var rms: [hash_len]u8 = undefined;
+        defer crypto.secureZero(u8, &rms);
+        schedule.resumptionMasterSecret(&self.core.transcriptHash(), &rms) catch return error.SecretExportFailed;
+        self.resumption_master_secret.replace(&rms) catch return error.SecretExportFailed;
+    }
+
+    fn resumptionContext(self: *const Tls13Backend) new_session_ticket.ConnectionResumptionContext {
+        return .{
+            .cipher_suite = tls_algorithms.CipherSuite.tls_aes_128_gcm_sha256,
+            .server_name = if (self.server_name_present) self.server_name[0..self.server_name_len] else null,
+            .application_protocol = self.selectedAlpn(),
+            .auth_binding = self.peerAuthBinding(),
+            .transport_compat = self.peerTransportCompat(),
+        };
+    }
+
+    fn peerAuthBinding(self: *const Tls13Backend) session.AuthBinding {
+        if (self.peer_chain_count == 0) return session.AuthBinding.fromLeafCertificateDer("");
+        const leaf = self.peer_chain_entries[0];
+        return session.AuthBinding.fromLeafCertificateDer(self.peer_chain[leaf.start..][0..leaf.len]);
+    }
+
+    fn peerTransportCompat(self: *const Tls13Backend) ?new_session_ticket.CompatBlob {
+        if (self.peer_transport_extension_len == 0) return null;
+        const ext_type = self.profile.extensionType() orelse return null;
+        return .{
+            .format_id = ext_type,
+            .format_version = 1,
+            .bytes = self.peer_transport_extension[0..self.peer_transport_extension_len],
+        };
+    }
+
+    pub fn emitNewSessionTicket(
+        self: *Tls13Backend,
+        allocator: std.mem.Allocator,
+        sink: *EventSink,
+        params: EmitNewSessionTicketParams,
+        limits: session.Limits,
+    ) HandshakeError!session.ServerRecoverableState {
+        if (self.role != .server or self.core.handshake_lifecycle != .complete)
+            return error.InvalidHandshakeState;
+        if (self.resumption_master_secret.slice().len == 0)
+            return error.InvalidHandshakeState;
+        limits.validate() catch return error.InvalidTransportProfile;
+
+        const emit_params: new_session_ticket.EmitParams = .{
+            .ticket_lifetime = params.ticket_lifetime,
+            .ticket_age_add = params.ticket_age_add,
+            .ticket_nonce = params.ticket_nonce,
+            .ticket = params.opaque_ticket,
+            .max_early_data_size = params.max_early_data_size,
+        };
+        const body_len = new_session_ticket.encodedLen(emit_params) catch |err| return mapTicketEncodeError(err);
+        if (body_len > max_new_session_ticket_message_len - 4) return error.TransportBufferOverflow;
+
+        var state = new_session_ticket.buildServerRecoverableState(
+            allocator,
+            emit_params,
+            self.resumptionContext(),
+            self.resumption_master_secret.slice(),
+            params.issued_at_unix_ms,
+            limits,
+        ) catch return error.InvalidTransportProfile;
+        errdefer state.deinit();
+
+        var buf: [max_new_session_ticket_message_len]u8 = undefined;
+        var w = Writer{ .buf = &buf };
+        try w.u8_(@intFromEnum(MessageType.new_session_ticket));
+        const message_len = try w.reserve(3);
+        const body = new_session_ticket.encode(emit_params, buf[w.len..]) catch |err| return mapTicketEncodeError(err);
+        w.len += body.len;
+        w.patch(3, message_len);
+        const message = buf[0..w.len];
+        self.core.transcript.update(message);
+        try sink.emitCrypto(.application, message);
+        return state;
+    }
+
     /// The handshake is over: the transport sink owns every exported live
     /// secret, so wipe the engine's key schedule immediately.
     fn finish(self: *Tls13Backend) void {
@@ -2272,6 +2396,20 @@ pub const Tls13Backend = struct {
         crypto.secureZero(u8, &self.expected_client_verify);
     }
 };
+
+fn mapTicketDecodeError(err: new_session_ticket.DecodeError) HandshakeError {
+    return switch (err) {
+        error.MalformedHandshake => error.MalformedHandshake,
+        error.IllegalParameter => error.IllegalParameter,
+    };
+}
+
+fn mapTicketEncodeError(err: new_session_ticket.EncodeError) HandshakeError {
+    return switch (err) {
+        error.IllegalParameter => error.IllegalParameter,
+        error.OutputTooSmall, error.LengthOverflow => error.TransportBufferOverflow,
+    };
+}
 
 /// RFC 8446 §4.4.3 CertificateVerify content: 64 spaces, context string,
 /// separator, transcript hash.
@@ -2443,6 +2581,115 @@ test "client rejects malformed encrypted extensions ALPN framing" {
         0x00, // trailing byte outside the declared list
     };
     try std.testing.expectError(error.MalformedHandshake, backend.onEncryptedExtensions(&trailing_extension_byte, &sink));
+}
+
+test "client NewSessionTicket callback receives owned state and lifetime zero is dropped" {
+    const TicketCapture = struct {
+        count: usize = 0,
+        received_at: i64 = 123_456,
+        last_lifetime: u32 = 0,
+        last_age_add: u32 = 0,
+        last_ticket: [16]u8 = undefined,
+        last_ticket_len: usize = 0,
+        last_psk: [hash_len]u8 = undefined,
+
+        fn now(ctx: *anyopaque) i64 {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            return self.received_at;
+        }
+
+        fn onTicket(ctx: *anyopaque, ticket: *const session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.count += 1;
+            self.last_lifetime = ticket.common.lifetime_seconds;
+            self.last_age_add = ticket.ticket_age_add;
+            const raw_ticket = ticket.ticket.slice();
+            self.last_ticket_len = raw_ticket.len;
+            @memcpy(self.last_ticket[0..raw_ticket.len], raw_ticket);
+            @memcpy(&self.last_psk, ticket.common.resumption_psk.slice());
+        }
+    };
+
+    var capture = TicketCapture{};
+    var backend = Tls13Backend.initClient(
+        .{ .hello_random = [_]u8{0x41} ** 32, .key_share_seed = [_]u8{0x42} ** 32 },
+        .{ .pinned_certificate = testdata.certificate_der },
+        .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
+    );
+    defer backend.deinit();
+    backend.core.handshake_lifecycle = .complete;
+    try backend.resumption_master_secret.replace(&([_]u8{0x42} ** hash_len));
+    try backend.setSessionTicketConsumer(std.testing.allocator, session.Limits.default, .{
+        .ctx = &capture,
+        .nowUnixMsFn = TicketCapture.now,
+        .onTicketFn = TicketCapture.onTicket,
+    });
+
+    var body_buf: [128]u8 = undefined;
+    const body = try new_session_ticket.encode(.{
+        .ticket_lifetime = 120,
+        .ticket_age_add = 0xaabbccdd,
+        .ticket_nonce = "\x01",
+        .ticket = "opaque",
+    }, &body_buf);
+    try backend.onNewSessionTicket(body);
+    try std.testing.expectEqual(@as(usize, 1), capture.count);
+    try std.testing.expectEqual(@as(u32, 120), capture.last_lifetime);
+    try std.testing.expectEqual(@as(u32, 0xaabbccdd), capture.last_age_add);
+    try std.testing.expectEqualSlices(u8, "opaque", capture.last_ticket[0..capture.last_ticket_len]);
+    try std.testing.expect(!std.mem.allEqual(u8, &capture.last_psk, 0));
+
+    const discard_body = try new_session_ticket.encode(.{
+        .ticket_lifetime = 0,
+        .ticket_age_add = 0,
+        .ticket_nonce = "",
+        .ticket = "discard",
+    }, &body_buf);
+    try backend.onNewSessionTicket(discard_body);
+    try std.testing.expectEqual(@as(usize, 1), capture.count);
+}
+
+test "server explicitly emits NewSessionTicket and returns recoverable state" {
+    var server = Tls13Backend.initServer(
+        .{ .hello_random = [_]u8{0x51} ** 32, .key_share_seed = [_]u8{0x52} ** 32 },
+        try Identity.initPkcs8(testdata.certificate_der, testdata.private_key_pkcs8_der),
+        .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
+    );
+    defer server.deinit();
+
+    var sink = EventSink{};
+    defer sink.deinit();
+    try std.testing.expectError(error.InvalidHandshakeState, server.emitNewSessionTicket(std.testing.allocator, &sink, .{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = "ticket",
+        .issued_at_unix_ms = 10,
+    }, session.Limits.default));
+
+    server.core.handshake_lifecycle = .complete;
+    try server.resumption_master_secret.replace(&([_]u8{0x33} ** hash_len));
+    var state = try server.emitNewSessionTicket(std.testing.allocator, &sink, .{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = "ticket",
+        .max_early_data_size = 32,
+        .issued_at_unix_ms = 10,
+    }, session.Limits.default);
+    defer state.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), sink.len);
+    try std.testing.expectEqual(EncryptionLevel.application, sink.items[0].handshake_bytes.epoch);
+    const message = try tls_handshake_codec.decode(sink.items[0].handshake_bytes.data);
+    try std.testing.expectEqual(MessageType.new_session_ticket, message.kind);
+    const parsed = try new_session_ticket.decode(message.body);
+    try std.testing.expectEqual(@as(u32, 60), parsed.ticket_lifetime);
+    try std.testing.expectEqualSlices(u8, "ticket", parsed.ticket);
+    try std.testing.expectEqual(@as(?u32, 32), parsed.max_early_data_size);
+    try std.testing.expectEqual(@as(u32, 60), state.common.lifetime_seconds);
+    try std.testing.expectEqual(session.EarlyDataPolicy{ .early_data_capable = 32 }, state.common.early_data);
+    try std.testing.expect(!std.mem.allEqual(u8, state.common.resumption_psk.slice(), 0));
 }
 
 test "abandoned backend teardown wipes ephemeral and server identity storage" {

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -2978,6 +2978,54 @@ test "server ticket output failure is atomic and retryable" {
     try std.testing.expectEqual(@as(usize, 1), full_sink.len);
 }
 
+test "server ticket emission allocation failures leave transcript and sink clean" {
+    var saw_injected_failure = false;
+    var saw_success = false;
+
+    for (0..16) |fail_index| {
+        var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = fail_index });
+        var server = Tls13Backend.initServer(
+            .{ .hello_random = [_]u8{0x63} ** 32, .key_share_seed = [_]u8{0x64} ** 32 },
+            try Identity.initPkcs8(testdata.certificate_der, testdata.private_key_pkcs8_der),
+            .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
+        );
+        server.core.handshake_lifecycle = .complete;
+        try server.resumption_master_secret.replace(&([_]u8{0x33} ** hash_len));
+        var sink = EventSink{};
+        const before = server.core.transcriptHash();
+
+        var state = server.emitNewSessionTicket(failing.allocator(), &sink, .{
+            .ticket_lifetime = 60,
+            .ticket_age_add = 1,
+            .ticket_nonce = "\x01",
+            .opaque_ticket = "ticket",
+            .max_early_data_size = 32,
+            .issued_at_unix_ms = 10,
+        }, session.Limits.default) catch |err| {
+            if (!failing.has_induced_failure) return err;
+            saw_injected_failure = true;
+            try std.testing.expectEqual(error.CredentialProviderFailed, err);
+            try std.testing.expectEqualSlices(u8, &before, &server.core.transcriptHash());
+            try std.testing.expectEqual(@as(usize, 0), sink.len);
+            sink.deinit();
+            server.deinit();
+            try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
+            continue;
+        };
+        saw_success = true;
+        try std.testing.expect(!failing.has_induced_failure);
+        try std.testing.expectEqual(@as(usize, 1), sink.len);
+        state.deinit();
+        sink.deinit();
+        server.deinit();
+        try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
+        break;
+    }
+
+    try std.testing.expect(saw_injected_failure);
+    try std.testing.expect(saw_success);
+}
+
 test "large emitted ticket is delivered once after fragmented application receives" {
     const Capture = struct {
         count: usize = 0,

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -50,7 +50,7 @@ pub const hash_len = tls_key_schedule.hash_len;
 pub const max_message_len = 8 * 1024;
 /// Largest framed post-handshake NewSessionTicket message: a 65535-byte opaque
 /// ticket identity plus its handshake header and small fixed/vector fields.
-pub const max_new_session_ticket_message_len = session.absolute_ticket_wire_max + 4 + 4 + 4 + 1 + session.max_ticket_nonce_len + 2 + 2 + 8;
+pub const max_new_session_ticket_message_len = tls13_transport.max_new_session_ticket_message_len;
 pub const max_certificate_len = 2048;
 /// The Certificate handshake message's fixed framing overhead, counted in the
 /// flight-size preflight so a chain cannot pass validation and then overflow the
@@ -875,6 +875,7 @@ pub const Tls13Backend = struct {
             error.CertificateInvalid => error.CertificateInvalid,
             error.SecretExportFailed => error.SecretExportFailed,
             error.InvalidHandshakeState => error.InvalidHandshakeState,
+            error.TicketTooLarge => error.TicketTooLarge,
             // Surfaced only by this backend's credential/verification path, not
             // the codec core, but they are part of the shared error set.
             error.NoApplicableCredential => error.NoApplicableCredential,
@@ -2372,10 +2373,11 @@ pub const Tls13Backend = struct {
             self.resumption_master_secret.slice(),
             params.issued_at_unix_ms,
             limits,
-        ) catch return error.InvalidTransportProfile;
+        ) catch |err| return mapTicketBuildServerError(err);
         errdefer state.deinit();
 
         var buf: [max_new_session_ticket_message_len]u8 = undefined;
+        defer crypto.secureZero(u8, &buf);
         var w = Writer{ .buf = &buf };
         try w.u8_(@intFromEnum(MessageType.new_session_ticket));
         const message_len = try w.reserve(3);
@@ -2383,8 +2385,8 @@ pub const Tls13Backend = struct {
         w.len += body.len;
         w.patch(3, message_len);
         const message = buf[0..w.len];
-        self.core.transcript.update(message);
         try sink.emitCrypto(.application, message);
+        self.core.transcript.update(message);
         return state;
     }
 
@@ -2408,6 +2410,24 @@ fn mapTicketEncodeError(err: new_session_ticket.EncodeError) HandshakeError {
     return switch (err) {
         error.IllegalParameter => error.IllegalParameter,
         error.OutputTooSmall, error.LengthOverflow => error.TransportBufferOverflow,
+    };
+}
+
+fn mapTicketBuildServerError(err: new_session_ticket.BuildServerError) HandshakeError {
+    return switch (err) {
+        error.InvalidSecretLength => error.SecretExportFailed,
+        error.TicketTooLarge => error.TicketTooLarge,
+        error.InvalidLimits => error.InvalidTransportProfile,
+        error.OutOfMemory => error.CredentialProviderFailed,
+        error.InvalidDnsName,
+        error.EmptyServerName,
+        error.AlpnProtocolTooLarge,
+        error.EmptyApplicationProtocol,
+        error.InvalidPskLength,
+        error.InvalidLifetime,
+        error.InvalidEarlyDataPolicy,
+        error.CompatSnapshotTooLarge,
+        => error.InvalidTransportProfile,
     };
 }
 
@@ -2439,6 +2459,54 @@ fn certificateVerifyContent(signer: Role, transcript_hash: [hash_len]u8) Certifi
     len += hash_len;
     content.len = len;
     return content;
+}
+
+fn buildMaxNewSessionTicketMessage(allocator: std.mem.Allocator) ![]u8 {
+    const body_len = max_new_session_ticket_message_len - 4;
+    var message = try allocator.alloc(u8, max_new_session_ticket_message_len);
+    errdefer allocator.free(message);
+    var pos: usize = 0;
+    message[pos] = @intFromEnum(MessageType.new_session_ticket);
+    pos += 1;
+    std.mem.writeInt(u24, message[pos..][0..3], @intCast(body_len), .big);
+    pos += 3;
+    std.mem.writeInt(u32, message[pos..][0..4], 1, .big);
+    pos += 4;
+    std.mem.writeInt(u32, message[pos..][0..4], 0, .big);
+    pos += 4;
+    message[pos] = session.max_ticket_nonce_len;
+    pos += 1;
+    @memset(message[pos..][0..session.max_ticket_nonce_len], 0x01);
+    pos += session.max_ticket_nonce_len;
+    std.mem.writeInt(u16, message[pos..][0..2], @intCast(session.absolute_ticket_wire_max), .big);
+    pos += 2;
+    @memset(message[pos..][0..session.absolute_ticket_wire_max], 0xa5);
+    pos += session.absolute_ticket_wire_max;
+    std.mem.writeInt(u16, message[pos..][0..2], std.math.maxInt(u16) - 1, .big);
+    pos += 2;
+
+    var written: usize = 0;
+    var ext_id: u16 = 1000;
+    while (written + 4 <= (std.math.maxInt(u16) - 1) - 6) : ({
+        written += 4;
+        ext_id += 1;
+    }) {
+        std.mem.writeInt(u16, message[pos..][0..2], ext_id, .big);
+        pos += 2;
+        std.mem.writeInt(u16, message[pos..][0..2], 0, .big);
+        pos += 2;
+    }
+    std.mem.writeInt(u16, message[pos..][0..2], ext_id, .big);
+    pos += 2;
+    std.mem.writeInt(u16, message[pos..][0..2], 2, .big);
+    pos += 2;
+    message[pos] = 0xaa;
+    message[pos + 1] = 0xbb;
+    pos += 2;
+    written += 6;
+    std.debug.assert(written == std.math.maxInt(u16) - 1);
+    std.debug.assert(pos == message.len);
+    return message;
 }
 
 /// Deterministic local server identity fixture — see `credentials.testdata`.
@@ -2690,6 +2758,162 @@ test "server explicitly emits NewSessionTicket and returns recoverable state" {
     try std.testing.expectEqual(@as(u32, 60), state.common.lifetime_seconds);
     try std.testing.expectEqual(session.EarlyDataPolicy{ .early_data_capable = 32 }, state.common.early_data);
     try std.testing.expect(!std.mem.allEqual(u8, state.common.resumption_psk.slice(), 0));
+}
+
+test "server ticket output failure is atomic and retryable" {
+    var server = Tls13Backend.initServer(
+        .{ .hello_random = [_]u8{0x61} ** 32, .key_share_seed = [_]u8{0x62} ** 32 },
+        try Identity.initPkcs8(testdata.certificate_der, testdata.private_key_pkcs8_der),
+        .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
+    );
+    defer server.deinit();
+    server.core.handshake_lifecycle = .complete;
+    try server.resumption_master_secret.replace(&([_]u8{0x33} ** hash_len));
+
+    var full_sink = EventSink{};
+    defer full_sink.deinit();
+    for (0..EventSink.max_events) |_| try full_sink.emitHandshakeComplete();
+    const before = server.core.transcriptHash();
+    try std.testing.expectError(error.TransportBufferOverflow, server.emitNewSessionTicket(std.testing.allocator, &full_sink, .{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = "ticket",
+        .issued_at_unix_ms = 10,
+    }, session.Limits.default));
+    try std.testing.expectEqualSlices(u8, &before, &server.core.transcriptHash());
+
+    full_sink.reset();
+    var state = try server.emitNewSessionTicket(std.testing.allocator, &full_sink, .{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = "ticket",
+        .issued_at_unix_ms = 10,
+    }, session.Limits.default);
+    defer state.deinit();
+    try std.testing.expectEqual(@as(usize, 1), full_sink.len);
+}
+
+test "large emitted ticket is delivered once after fragmented application receives" {
+    const Capture = struct {
+        count: usize = 0,
+        psk: [hash_len]u8 = undefined,
+        ticket_len: usize = 0,
+
+        fn now(_: *anyopaque) i64 {
+            return 10;
+        }
+
+        fn onTicket(ctx: *anyopaque, ticket: *const session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.count += 1;
+            @memcpy(&self.psk, ticket.common.resumption_psk.slice());
+            self.ticket_len = ticket.ticket.slice().len;
+        }
+    };
+
+    const limits = session.Limits{ .max_ticket_len = 20 * 1024, .max_serialized_len = 32 * 1024 };
+    const opaque_ticket = try std.testing.allocator.alloc(u8, 20 * 1024);
+    defer std.testing.allocator.free(opaque_ticket);
+    @memset(opaque_ticket, 0xa5);
+
+    var server = Tls13Backend.initServer(
+        .{ .hello_random = [_]u8{0x71} ** 32, .key_share_seed = [_]u8{0x72} ** 32 },
+        try Identity.initPkcs8(testdata.certificate_der, testdata.private_key_pkcs8_der),
+        .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
+    );
+    defer server.deinit();
+    server.core.handshake_lifecycle = .complete;
+    try server.resumption_master_secret.replace(&([_]u8{0x44} ** hash_len));
+
+    var client = Tls13Backend.initClient(
+        .{ .hello_random = [_]u8{0x73} ** 32, .key_share_seed = [_]u8{0x74} ** 32 },
+        .{ .pinned_certificate = testdata.certificate_der },
+        .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
+    );
+    defer client.deinit();
+    client.core.handshake_lifecycle = .complete;
+    try client.resumption_master_secret.replace(&([_]u8{0x44} ** hash_len));
+    var capture = Capture{};
+    try client.setSessionTicketConsumer(std.testing.allocator, limits, .{
+        .ctx = &capture,
+        .nowUnixMsFn = Capture.now,
+        .onTicketFn = Capture.onTicket,
+    });
+
+    var sink = EventSink{};
+    defer sink.deinit();
+    var server_state = try server.emitNewSessionTicket(std.testing.allocator, &sink, .{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = opaque_ticket,
+        .issued_at_unix_ms = 10,
+    }, limits);
+    defer server_state.deinit();
+    const emitted = sink.items[0].handshake_bytes.data;
+    try std.testing.expect(emitted.len > 16 * 1024);
+
+    var client_sink = EventSink{};
+    defer client_sink.deinit();
+    try client.backend().receive(.application, emitted[0..17], &client_sink);
+    try client.backend().receive(.application, emitted[17..8191], &client_sink);
+    try client.backend().receive(.application, emitted[8191..], &client_sink);
+    try std.testing.expectEqual(@as(usize, 1), capture.count);
+    try std.testing.expectEqual(opaque_ticket.len, capture.ticket_len);
+    try std.testing.expectEqualSlices(u8, server_state.common.resumption_psk.slice(), &capture.psk);
+}
+
+test "application reassembler accepts exact maximum ticket and rejects one byte over" {
+    var client = Tls13Backend.initClient(
+        .{ .hello_random = [_]u8{0x81} ** 32, .key_share_seed = [_]u8{0x82} ** 32 },
+        .{ .pinned_certificate = testdata.certificate_der },
+        .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
+    );
+    defer client.deinit();
+    client.core.handshake_lifecycle = .complete;
+
+    const max_message = try buildMaxNewSessionTicketMessage(std.testing.allocator);
+    defer std.testing.allocator.free(max_message);
+    try std.testing.expectEqual(max_new_session_ticket_message_len, max_message.len);
+    var sink = EventSink{};
+    defer sink.deinit();
+    try client.backend().receive(.application, max_message[0..3], &sink);
+    try client.backend().receive(.application, max_message[3..4099], &sink);
+    try client.backend().receive(.application, max_message[4099..], &sink);
+
+    var over_client = Tls13Backend.initClient(
+        .{ .hello_random = [_]u8{0x83} ** 32, .key_share_seed = [_]u8{0x84} ** 32 },
+        .{ .pinned_certificate = testdata.certificate_der },
+        .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
+    );
+    defer over_client.deinit();
+    over_client.core.handshake_lifecycle = .complete;
+    const over = try std.testing.allocator.alloc(u8, max_new_session_ticket_message_len + 1);
+    defer std.testing.allocator.free(over);
+    @memset(over, 0);
+    try std.testing.expectError(error.HandshakeBufferOverflow, over_client.backend().receive(.application, over, &sink));
+}
+
+test "client cannot emit NewSessionTicket" {
+    var client = Tls13Backend.initClient(
+        .{ .hello_random = [_]u8{0x91} ** 32, .key_share_seed = [_]u8{0x92} ** 32 },
+        .{ .pinned_certificate = testdata.certificate_der },
+        .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
+    );
+    defer client.deinit();
+    client.core.handshake_lifecycle = .complete;
+    try client.resumption_master_secret.replace(&([_]u8{0x44} ** hash_len));
+    var sink = EventSink{};
+    defer sink.deinit();
+    try std.testing.expectError(error.InvalidHandshakeState, client.emitNewSessionTicket(std.testing.allocator, &sink, .{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = "ticket",
+        .issued_at_unix_ms = 10,
+    }, session.Limits.default));
 }
 
 test "abandoned backend teardown wipes ephemeral and server identity storage" {

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -703,6 +703,7 @@ pub const Tls13Backend = struct {
             .deinitFn = deinitImpl,
             .authPendingFn = authPendingImpl,
             .resumeFn = resumeImpl,
+            .setPostHandshakeAllocatorFn = setPostHandshakeAllocatorImpl,
         };
     }
 
@@ -714,6 +715,11 @@ pub const Tls13Backend = struct {
     fn resumeImpl(ptr: *anyopaque, sink: *EventSink) HandshakeError!void {
         const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
         return self.resumeAuth(sink);
+    }
+
+    fn setPostHandshakeAllocatorImpl(ptr: *anyopaque, allocator: std.mem.Allocator) HandshakeError!void {
+        const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
+        return self.setPostHandshakeAllocator(allocator);
     }
 
     pub fn alpn(self: *const Tls13Backend) []const u8 {

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -692,6 +692,7 @@ pub const Tls13Backend = struct {
     pub fn setPostHandshakeAllocator(self: *Tls13Backend, allocator: std.mem.Allocator) HandshakeError!void {
         if (self.role != .client) return error.InvalidHandshakeState;
         if (self.core.handshake_lifecycle != .idle) return error.InvalidHandshakeState;
+        if (self.application_input.allocator != null) return;
         try self.application_input.setAllocator(allocator);
     }
 

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -51,6 +51,73 @@ pub const max_message_len = 8 * 1024;
 /// Largest framed post-handshake NewSessionTicket message: a 65535-byte opaque
 /// ticket identity plus its handshake header and small fixed/vector fields.
 pub const max_new_session_ticket_message_len = tls13_transport.max_new_session_ticket_message_len;
+const handshake_header_len = 4;
+
+const PostHandshakeInput = struct {
+    allocator: ?std.mem.Allocator = null,
+    header: [handshake_header_len]u8 = undefined,
+    header_len: usize = 0,
+    buf: []u8 = &.{},
+    len: usize = 0,
+
+    fn setAllocator(self: *PostHandshakeInput, allocator: std.mem.Allocator) void {
+        self.allocator = allocator;
+    }
+
+    fn deinit(self: *PostHandshakeInput) void {
+        if (self.buf.len > 0) {
+            crypto.secureZero(u8, self.buf);
+            self.allocator.?.free(self.buf);
+        }
+        if (self.header_len > 0) crypto.secureZero(u8, self.header[0..self.header_len]);
+        self.* = .{};
+    }
+
+    fn append(self: *PostHandshakeInput, bytes: []const u8) HandshakeError!usize {
+        if (self.buf.len > 0 and self.len == self.buf.len) return 0;
+        var rest = bytes;
+        const original_len = bytes.len;
+        while (rest.len > 0) {
+            if (self.buf.len == 0) {
+                if (self.header_len < handshake_header_len) {
+                    const take = @min(handshake_header_len - self.header_len, rest.len);
+                    @memcpy(self.header[self.header_len..][0..take], rest[0..take]);
+                    self.header_len += take;
+                    rest = rest[take..];
+                    if (self.header_len < handshake_header_len) return original_len - rest.len;
+                }
+                const body_len: usize = @intCast(std.mem.readInt(u24, self.header[1..4], .big));
+                const frame_len = handshake_header_len + body_len;
+                if (frame_len > max_new_session_ticket_message_len) return error.HandshakeBufferOverflow;
+                const allocator = self.allocator orelse return error.InvalidHandshakeState;
+                self.buf = allocator.alloc(u8, frame_len) catch return error.CredentialProviderFailed;
+                @memcpy(self.buf[0..handshake_header_len], &self.header);
+                self.len = handshake_header_len;
+                crypto.secureZero(u8, &self.header);
+                self.header_len = 0;
+            }
+            const take = @min(self.buf.len - self.len, rest.len);
+            @memcpy(self.buf[self.len..][0..take], rest[0..take]);
+            self.len += take;
+            rest = rest[take..];
+            if (self.len == self.buf.len) break;
+        }
+        return original_len - rest.len;
+    }
+
+    fn peek(self: *PostHandshakeInput) tls_handshake_codec.Error!?tls_handshake_codec.Message {
+        if (self.buf.len == 0 or self.len < self.buf.len) return null;
+        return try tls_handshake_codec.decode(self.buf[0..self.len]);
+    }
+
+    fn discard(self: *PostHandshakeInput, len: usize) tls_handshake_codec.Error!void {
+        if (self.buf.len == 0 or len != self.buf.len) return error.MalformedHandshake;
+        crypto.secureZero(u8, self.buf);
+        self.allocator.?.free(self.buf);
+        self.buf = &.{};
+        self.len = 0;
+    }
+};
 pub const max_certificate_len = 2048;
 /// The Certificate handshake message's fixed framing overhead, counted in the
 /// flight-size preflight so a chain cannot pass validation and then overflow the
@@ -415,14 +482,12 @@ pub const Tls13Backend = struct {
     /// own flight is sent).
     expected_client_verify: [hash_len]u8 = undefined,
     /// Reassembled-but-unparsed handshake bytes per transport epoch; a message
-    /// may arrive split across TLS records or QUIC CRYPTO frames. The
-    /// application-level
-    /// buffer exists because post-handshake messages (NewSessionTicket) may be
-    /// fragmented across application-epoch transport chunks like any other
-    /// handshake message.
+    /// may arrive split across TLS records or QUIC CRYPTO frames.
     initial_input: tls_handshake_codec.Reassembler(max_message_len + 4) = .{},
     handshake_input: tls_handshake_codec.Reassembler(max_message_len + 4) = .{},
-    application_input: tls_handshake_codec.Reassembler(max_new_session_ticket_message_len) = .{},
+    /// Post-handshake messages can be much larger than main-handshake flights,
+    /// so their storage is allocated lazily after the declared length is known.
+    application_input: PostHandshakeInput = .{},
     /// The peer's reassembled certificate chain (immutable DER, surfaced to the
     /// verifier as views). `entries` index into `peer_chain`.
     peer_chain: [max_peer_chain_bytes]u8 = undefined,
@@ -607,11 +672,17 @@ pub const Tls13Backend = struct {
     ) HandshakeError!void {
         if (self.role != .client) return error.InvalidHandshakeState;
         limits.validate() catch return error.InvalidTransportProfile;
+        self.application_input.setAllocator(allocator);
         self.session_ticket_consumer = .{
             .allocator = allocator,
             .limits = limits,
             .consumer = consumer,
         };
+    }
+
+    pub fn setPostHandshakeAllocator(self: *Tls13Backend, allocator: std.mem.Allocator) HandshakeError!void {
+        if (self.role != .client) return error.InvalidHandshakeState;
+        self.application_input.setAllocator(allocator);
     }
 
     pub fn backend(self: *Tls13Backend) TlsBackend {
@@ -729,10 +800,9 @@ pub const Tls13Backend = struct {
         self.peer_transport_extension_pending = false;
         crypto.secureZero(u8, std.mem.asBytes(&self.initial_input));
         crypto.secureZero(u8, std.mem.asBytes(&self.handshake_input));
-        crypto.secureZero(u8, std.mem.asBytes(&self.application_input));
+        self.application_input.deinit();
         self.initial_input = .{};
         self.handshake_input = .{};
-        self.application_input = .{};
         crypto.secureZero(u8, std.mem.asBytes(&self.core));
         self.core = tls_handshake_codec.Core.init(self.role);
         self.core.handshake_lifecycle = .failed;
@@ -777,9 +847,8 @@ pub const Tls13Backend = struct {
             .zero_rtt => return error.UnexpectedTransportEpoch,
             .application => {
                 if (self.core.handshake_lifecycle != .complete) return error.UnexpectedTransportEpoch;
-                self.application_input.append(bytes) catch |err| return mapCoreError(err);
                 if (self.pending_op != null) return;
-                return self.drainInput(&self.application_input, level, sink);
+                return self.receivePostHandshake(bytes, sink);
             },
             .initial, .handshake => {},
         }
@@ -803,6 +872,17 @@ pub const Tls13Backend = struct {
         // handshake before the verdict resolves.
         if (self.pending_op != null) return;
         try self.drainInput(input, level, sink);
+    }
+
+    fn receivePostHandshake(self: *Tls13Backend, bytes: []const u8, sink: *EventSink) HandshakeError!void {
+        var rest = bytes;
+        while (rest.len > 0) {
+            const consumed = try self.application_input.append(rest);
+            rest = rest[consumed..];
+            try self.drainInput(&self.application_input, .application, sink);
+            if (consumed == 0) break;
+            if (self.pending_op != null) break;
+        }
     }
 
     /// Consume whole handshake messages from a reassembly buffer, dispatching
@@ -939,7 +1019,7 @@ pub const Tls13Backend = struct {
             self.resumption_master_secret.slice(),
             received_at,
             configured.limits,
-        ) catch return;
+        ) catch |err| return mapTicketBuildClientError(err);
         if (state) |*ticket| {
             defer ticket.deinit();
             configured.consumer.onTicketFn(configured.consumer.ctx, ticket);
@@ -2365,6 +2445,8 @@ pub const Tls13Backend = struct {
         };
         const body_len = new_session_ticket.encodedLen(emit_params) catch |err| return mapTicketEncodeError(err);
         if (body_len > max_new_session_ticket_message_len - 4) return error.TransportBufferOverflow;
+        const message_len = handshake_header_len + body_len;
+        if (message_len > EventSink.max_bytes) return error.TransportBufferOverflow;
 
         var state = new_session_ticket.buildServerRecoverableState(
             allocator,
@@ -2376,14 +2458,17 @@ pub const Tls13Backend = struct {
         ) catch |err| return mapTicketBuildServerError(err);
         errdefer state.deinit();
 
-        var buf: [max_new_session_ticket_message_len]u8 = undefined;
-        defer crypto.secureZero(u8, &buf);
-        var w = Writer{ .buf = &buf };
+        const buf = allocator.alloc(u8, message_len) catch return error.CredentialProviderFailed;
+        defer {
+            crypto.secureZero(u8, buf);
+            allocator.free(buf);
+        }
+        var w = Writer{ .buf = buf };
         try w.u8_(@intFromEnum(MessageType.new_session_ticket));
-        const message_len = try w.reserve(3);
+        const body_len_index = try w.reserve(3);
         const body = new_session_ticket.encode(emit_params, buf[w.len..]) catch |err| return mapTicketEncodeError(err);
         w.len += body.len;
-        w.patch(3, message_len);
+        w.patch(3, body_len_index);
         const message = buf[0..w.len];
         try sink.emitCrypto(.application, message);
         self.core.transcript.update(message);
@@ -2415,6 +2500,7 @@ fn mapTicketEncodeError(err: new_session_ticket.EncodeError) HandshakeError {
 
 fn mapTicketBuildServerError(err: new_session_ticket.BuildServerError) HandshakeError {
     return switch (err) {
+        error.IllegalParameter => error.IllegalParameter,
         error.InvalidSecretLength => error.SecretExportFailed,
         error.TicketTooLarge => error.TicketTooLarge,
         error.InvalidLimits => error.InvalidTransportProfile,
@@ -2427,6 +2513,27 @@ fn mapTicketBuildServerError(err: new_session_ticket.BuildServerError) Handshake
         error.InvalidLifetime,
         error.InvalidEarlyDataPolicy,
         error.CompatSnapshotTooLarge,
+        => error.InvalidTransportProfile,
+    };
+}
+
+fn mapTicketBuildClientError(err: new_session_ticket.BuildError) HandshakeError!void {
+    return switch (err) {
+        error.OutOfMemory,
+        error.TicketTooLarge,
+        error.CompatSnapshotTooLarge,
+        => {},
+        error.InvalidSecretLength,
+        error.InvalidPskLength,
+        => error.SecretExportFailed,
+        error.InvalidLimits,
+        error.InvalidDnsName,
+        error.EmptyServerName,
+        error.AlpnProtocolTooLarge,
+        error.EmptyApplicationProtocol,
+        error.NonceTooLarge,
+        error.InvalidLifetime,
+        error.InvalidEarlyDataPolicy,
         => error.InvalidTransportProfile,
     };
 }
@@ -2512,6 +2619,11 @@ fn buildMaxNewSessionTicketMessage(allocator: std.mem.Allocator) ![]u8 {
 /// Deterministic local server identity fixture — see `credentials.testdata`.
 /// Re-exported here so existing callers and tests keep their spelling.
 pub const testdata = credentials.testdata;
+
+test "TLS-owned backend does not embed maximum ticket storage" {
+    try std.testing.expect(@sizeOf(Tls13Backend) < 64 * 1024);
+    try std.testing.expect(@sizeOf(Tls13Backend) + EventSink.max_bytes < max_new_session_ticket_message_len);
+}
 
 test "TLS-owned backend teardown clears transcript-adjacent and peer scratch" {
     var backend = Tls13Backend.initClient(
@@ -2717,6 +2829,38 @@ test "client NewSessionTicket callback receives owned state and lifetime zero is
     try std.testing.expectEqual(@as(usize, 1), capture.count);
 }
 
+test "client parses and drops NewSessionTicket when no consumer is configured" {
+    var backend = Tls13Backend.initClient(
+        .{ .hello_random = [_]u8{0x45} ** 32, .key_share_seed = [_]u8{0x46} ** 32 },
+        .{ .pinned_certificate = testdata.certificate_der },
+        .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
+    );
+    defer backend.deinit();
+    backend.core.handshake_lifecycle = .complete;
+    try backend.setPostHandshakeAllocator(std.testing.allocator);
+
+    var body_buf: [128]u8 = undefined;
+    const body = try new_session_ticket.encode(.{
+        .ticket_lifetime = 120,
+        .ticket_age_add = 0,
+        .ticket_nonce = "\x01",
+        .ticket = "drop-me",
+    }, &body_buf);
+    var msg_buf: [132]u8 = undefined;
+    var w = Writer{ .buf = &msg_buf };
+    try w.u8_(@intFromEnum(MessageType.new_session_ticket));
+    const body_len = try w.reserve(3);
+    try w.bytes(body);
+    w.patch(3, body_len);
+    const message = w.written();
+    var sink = EventSink{};
+    defer sink.deinit();
+    try backend.backend().receive(.application, message[0..5], &sink);
+    try backend.backend().receive(.application, message[5..], &sink);
+    try std.testing.expectEqual(@as(usize, 0), backend.application_input.len);
+    try std.testing.expectEqual(@as(usize, 0), backend.application_input.buf.len);
+}
+
 test "server explicitly emits NewSessionTicket and returns recoverable state" {
     var server = Tls13Backend.initServer(
         .{ .hello_random = [_]u8{0x51} ** 32, .key_share_seed = [_]u8{0x52} ** 32 },
@@ -2873,6 +3017,7 @@ test "application reassembler accepts exact maximum ticket and rejects one byte 
     );
     defer client.deinit();
     client.core.handshake_lifecycle = .complete;
+    try client.setPostHandshakeAllocator(std.testing.allocator);
 
     const max_message = try buildMaxNewSessionTicketMessage(std.testing.allocator);
     defer std.testing.allocator.free(max_message);
@@ -2890,9 +3035,12 @@ test "application reassembler accepts exact maximum ticket and rejects one byte 
     );
     defer over_client.deinit();
     over_client.core.handshake_lifecycle = .complete;
+    try over_client.setPostHandshakeAllocator(std.testing.allocator);
     const over = try std.testing.allocator.alloc(u8, max_new_session_ticket_message_len + 1);
     defer std.testing.allocator.free(over);
     @memset(over, 0);
+    over[0] = @intFromEnum(MessageType.new_session_ticket);
+    std.mem.writeInt(u24, over[1..4], max_new_session_ticket_message_len - 3, .big);
     try std.testing.expectError(error.HandshakeBufferOverflow, over_client.backend().receive(.application, over, &sink));
 }
 

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -54,7 +54,7 @@ pub const max_new_session_ticket_message_len = tls13_transport.max_new_session_t
 const handshake_header_len = 4;
 
 const PostHandshakeInput = struct {
-    allocator: std.mem.Allocator = std.heap.page_allocator,
+    allocator: ?std.mem.Allocator = null,
     buf_allocator: ?std.mem.Allocator = null,
     header: [handshake_header_len]u8 = undefined,
     header_len: usize = 0,
@@ -91,7 +91,7 @@ const PostHandshakeInput = struct {
                 const body_len: usize = @intCast(std.mem.readInt(u24, self.header[1..4], .big));
                 const frame_len = handshake_header_len + body_len;
                 if (frame_len > max_new_session_ticket_message_len) return error.HandshakeBufferOverflow;
-                const allocator = self.allocator;
+                const allocator = self.allocator orelse return error.InvalidHandshakeState;
                 self.buf = allocator.alloc(u8, frame_len) catch return error.CredentialProviderFailed;
                 self.buf_allocator = allocator;
                 @memcpy(self.buf[0..handshake_header_len], &self.header);
@@ -2845,6 +2845,7 @@ test "client parses and drops NewSessionTicket when no consumer is configured" {
         .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
     );
     defer backend.deinit();
+    try backend.setPostHandshakeAllocator(std.testing.allocator);
     backend.core.handshake_lifecycle = .complete;
 
     var body_buf: [128]u8 = undefined;
@@ -3047,6 +3048,7 @@ test "application reassembler accepts exact maximum ticket and rejects one byte 
         .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
     );
     defer client.deinit();
+    try client.setPostHandshakeAllocator(std.testing.allocator);
     client.core.handshake_lifecycle = .complete;
 
     const max_message = try buildMaxNewSessionTicketMessage(std.testing.allocator);
@@ -3064,6 +3066,7 @@ test "application reassembler accepts exact maximum ticket and rejects one byte 
         .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
     );
     defer over_client.deinit();
+    try over_client.setPostHandshakeAllocator(std.testing.allocator);
     over_client.core.handshake_lifecycle = .complete;
     const over = try std.testing.allocator.alloc(u8, max_new_session_ticket_message_len + 1);
     defer std.testing.allocator.free(over);

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -54,20 +54,22 @@ pub const max_new_session_ticket_message_len = tls13_transport.max_new_session_t
 const handshake_header_len = 4;
 
 const PostHandshakeInput = struct {
-    allocator: ?std.mem.Allocator = null,
+    allocator: std.mem.Allocator = std.heap.page_allocator,
+    buf_allocator: ?std.mem.Allocator = null,
     header: [handshake_header_len]u8 = undefined,
     header_len: usize = 0,
     buf: []u8 = &.{},
     len: usize = 0,
 
-    fn setAllocator(self: *PostHandshakeInput, allocator: std.mem.Allocator) void {
+    fn setAllocator(self: *PostHandshakeInput, allocator: std.mem.Allocator) HandshakeError!void {
+        if (self.buf.len > 0 and !sameAllocator(self.buf_allocator.?, allocator)) return error.InvalidHandshakeState;
         self.allocator = allocator;
     }
 
     fn deinit(self: *PostHandshakeInput) void {
         if (self.buf.len > 0) {
             crypto.secureZero(u8, self.buf);
-            self.allocator.?.free(self.buf);
+            self.buf_allocator.?.free(self.buf);
         }
         if (self.header_len > 0) crypto.secureZero(u8, self.header[0..self.header_len]);
         self.* = .{};
@@ -89,8 +91,9 @@ const PostHandshakeInput = struct {
                 const body_len: usize = @intCast(std.mem.readInt(u24, self.header[1..4], .big));
                 const frame_len = handshake_header_len + body_len;
                 if (frame_len > max_new_session_ticket_message_len) return error.HandshakeBufferOverflow;
-                const allocator = self.allocator orelse return error.InvalidHandshakeState;
+                const allocator = self.allocator;
                 self.buf = allocator.alloc(u8, frame_len) catch return error.CredentialProviderFailed;
+                self.buf_allocator = allocator;
                 @memcpy(self.buf[0..handshake_header_len], &self.header);
                 self.len = handshake_header_len;
                 crypto.secureZero(u8, &self.header);
@@ -113,11 +116,16 @@ const PostHandshakeInput = struct {
     fn discard(self: *PostHandshakeInput, len: usize) tls_handshake_codec.Error!void {
         if (self.buf.len == 0 or len != self.buf.len) return error.MalformedHandshake;
         crypto.secureZero(u8, self.buf);
-        self.allocator.?.free(self.buf);
+        self.buf_allocator.?.free(self.buf);
+        self.buf_allocator = null;
         self.buf = &.{};
         self.len = 0;
     }
 };
+
+fn sameAllocator(a: std.mem.Allocator, b: std.mem.Allocator) bool {
+    return a.ptr == b.ptr and a.vtable == b.vtable;
+}
 pub const max_certificate_len = 2048;
 /// The Certificate handshake message's fixed framing overhead, counted in the
 /// flight-size preflight so a chain cannot pass validation and then overflow the
@@ -671,8 +679,9 @@ pub const Tls13Backend = struct {
         consumer: SessionTicketConsumer,
     ) HandshakeError!void {
         if (self.role != .client) return error.InvalidHandshakeState;
+        if (self.core.handshake_lifecycle != .idle) return error.InvalidHandshakeState;
         limits.validate() catch return error.InvalidTransportProfile;
-        self.application_input.setAllocator(allocator);
+        try self.application_input.setAllocator(allocator);
         self.session_ticket_consumer = .{
             .allocator = allocator,
             .limits = limits,
@@ -682,7 +691,8 @@ pub const Tls13Backend = struct {
 
     pub fn setPostHandshakeAllocator(self: *Tls13Backend, allocator: std.mem.Allocator) HandshakeError!void {
         if (self.role != .client) return error.InvalidHandshakeState;
-        self.application_input.setAllocator(allocator);
+        if (self.core.handshake_lifecycle != .idle) return error.InvalidHandshakeState;
+        try self.application_input.setAllocator(allocator);
     }
 
     pub fn backend(self: *Tls13Backend) TlsBackend {
@@ -2446,7 +2456,6 @@ pub const Tls13Backend = struct {
         const body_len = new_session_ticket.encodedLen(emit_params) catch |err| return mapTicketEncodeError(err);
         if (body_len > max_new_session_ticket_message_len - 4) return error.TransportBufferOverflow;
         const message_len = handshake_header_len + body_len;
-        if (message_len > EventSink.max_bytes) return error.TransportBufferOverflow;
 
         var state = new_session_ticket.buildServerRecoverableState(
             allocator,
@@ -2459,7 +2468,7 @@ pub const Tls13Backend = struct {
         errdefer state.deinit();
 
         const buf = allocator.alloc(u8, message_len) catch return error.CredentialProviderFailed;
-        defer {
+        errdefer {
             crypto.secureZero(u8, buf);
             allocator.free(buf);
         }
@@ -2470,7 +2479,7 @@ pub const Tls13Backend = struct {
         w.len += body.len;
         w.patch(3, body_len_index);
         const message = buf[0..w.len];
-        try sink.emitCrypto(.application, message);
+        try sink.emitOwnedCrypto(allocator, .application, message);
         self.core.transcript.update(message);
         return state;
     }
@@ -2797,13 +2806,13 @@ test "client NewSessionTicket callback receives owned state and lifetime zero is
         .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
     );
     defer backend.deinit();
-    backend.core.handshake_lifecycle = .complete;
-    try backend.resumption_master_secret.replace(&([_]u8{0x42} ** hash_len));
     try backend.setSessionTicketConsumer(std.testing.allocator, session.Limits.default, .{
         .ctx = &capture,
         .nowUnixMsFn = TicketCapture.now,
         .onTicketFn = TicketCapture.onTicket,
     });
+    backend.core.handshake_lifecycle = .complete;
+    try backend.resumption_master_secret.replace(&([_]u8{0x42} ** hash_len));
 
     var body_buf: [128]u8 = undefined;
     const body = try new_session_ticket.encode(.{
@@ -2837,7 +2846,6 @@ test "client parses and drops NewSessionTicket when no consumer is configured" {
     );
     defer backend.deinit();
     backend.core.handshake_lifecycle = .complete;
-    try backend.setPostHandshakeAllocator(std.testing.allocator);
 
     var body_buf: [128]u8 = undefined;
     const body = try new_session_ticket.encode(.{
@@ -2859,6 +2867,29 @@ test "client parses and drops NewSessionTicket when no consumer is configured" {
     try backend.backend().receive(.application, message[5..], &sink);
     try std.testing.expectEqual(@as(usize, 0), backend.application_input.len);
     try std.testing.expectEqual(@as(usize, 0), backend.application_input.buf.len);
+}
+
+test "post-handshake input rejects allocator replacement while a frame is active" {
+    var backing_a: [64]u8 = undefined;
+    var backing_b: [64]u8 = undefined;
+    var fba_a = std.heap.FixedBufferAllocator.init(&backing_a);
+    var fba_b = std.heap.FixedBufferAllocator.init(&backing_b);
+    var input = PostHandshakeInput{};
+    defer input.deinit();
+    try input.setAllocator(fba_a.allocator());
+
+    const prefix = [_]u8{
+        @intFromEnum(MessageType.new_session_ticket),
+        0,
+        0,
+        4,
+        1,
+    };
+    try std.testing.expectEqual(prefix.len, try input.append(&prefix));
+    try std.testing.expect(input.buf.len > 0);
+    try std.testing.expectError(error.InvalidHandshakeState, input.setAllocator(fba_b.allocator()));
+    try std.testing.expectEqual(@as(usize, 3), try input.append(&.{ 2, 3, 4 }));
+    try input.discard(input.buf.len);
 }
 
 test "server explicitly emits NewSessionTicket and returns recoverable state" {
@@ -2957,8 +2988,8 @@ test "large emitted ticket is delivered once after fragmented application receiv
         }
     };
 
-    const limits = session.Limits{ .max_ticket_len = 20 * 1024, .max_serialized_len = 32 * 1024 };
-    const opaque_ticket = try std.testing.allocator.alloc(u8, 20 * 1024);
+    const limits = session.Limits{ .max_ticket_len = session.absolute_ticket_wire_max, .max_serialized_len = 128 * 1024 };
+    const opaque_ticket = try std.testing.allocator.alloc(u8, session.absolute_ticket_wire_max);
     defer std.testing.allocator.free(opaque_ticket);
     @memset(opaque_ticket, 0xa5);
 
@@ -2977,14 +3008,14 @@ test "large emitted ticket is delivered once after fragmented application receiv
         .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
     );
     defer client.deinit();
-    client.core.handshake_lifecycle = .complete;
-    try client.resumption_master_secret.replace(&([_]u8{0x44} ** hash_len));
     var capture = Capture{};
     try client.setSessionTicketConsumer(std.testing.allocator, limits, .{
         .ctx = &capture,
         .nowUnixMsFn = Capture.now,
         .onTicketFn = Capture.onTicket,
     });
+    client.core.handshake_lifecycle = .complete;
+    try client.resumption_master_secret.replace(&([_]u8{0x44} ** hash_len));
 
     var sink = EventSink{};
     defer sink.deinit();
@@ -3017,7 +3048,6 @@ test "application reassembler accepts exact maximum ticket and rejects one byte 
     );
     defer client.deinit();
     client.core.handshake_lifecycle = .complete;
-    try client.setPostHandshakeAllocator(std.testing.allocator);
 
     const max_message = try buildMaxNewSessionTicketMessage(std.testing.allocator);
     defer std.testing.allocator.free(max_message);
@@ -3035,7 +3065,6 @@ test "application reassembler accepts exact maximum ticket and rejects one byte 
     );
     defer over_client.deinit();
     over_client.core.handshake_lifecycle = .complete;
-    try over_client.setPostHandshakeAllocator(std.testing.allocator);
     const over = try std.testing.allocator.alloc(u8, max_new_session_ticket_message_len + 1);
     defer std.testing.allocator.free(over);
     @memset(over, 0);

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -1033,7 +1033,6 @@ test "record stream drops valid ticket with no consumer and remains usable" {
     const h = try SocketHarness.create(.{
         .client_chunk = 1024,
         .server_chunk = 1024,
-        .client_post_handshake_allocator = std.testing.allocator,
     });
     defer h.destroy();
     try h.driveUntil(SocketHarness.bothComplete);

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -796,6 +796,7 @@ const SocketHarness = struct {
         server_provider: ?tls_backend.CredentialProvider = null,
         client_verifier: ?tls_backend.PeerVerifier = null,
         client_options: tls_backend.Tls13Backend.ClientOptions = .{},
+        client_post_handshake_allocator: ?std.mem.Allocator = null,
     };
 
     fn create(opts: Options) !*SocketHarness {
@@ -821,6 +822,9 @@ const SocketHarness = struct {
             tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), provider, server_record_profile)
         else
             tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), server_record_profile);
+        if (opts.client_post_handshake_allocator) |post_allocator| {
+            try self.client_engine.setPostHandshakeAllocator(post_allocator);
+        }
         self.client_carrier = .{ .fd = self.fds[0], .max_chunk = opts.client_chunk, .one_write_per_drive = opts.one_write_per_drive };
         self.server_carrier = .{ .fd = self.fds[1], .max_chunk = opts.server_chunk, .one_write_per_drive = opts.one_write_per_drive };
 
@@ -1026,7 +1030,11 @@ test "record stream delivers maximum post-handshake ticket and remains usable" {
 }
 
 test "record stream drops valid ticket with no consumer and remains usable" {
-    const h = try SocketHarness.create(.{ .client_chunk = 1024, .server_chunk = 1024 });
+    const h = try SocketHarness.create(.{
+        .client_chunk = 1024,
+        .server_chunk = 1024,
+        .client_post_handshake_allocator = std.testing.allocator,
+    });
     defer h.destroy();
     try h.driveUntil(SocketHarness.bothComplete);
 

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -435,7 +435,7 @@ test "direct record handshake delivers large post-handshake ticket once" {
     var harness = DirectHarness.init();
     defer harness.deinit();
     var capture = Capture{};
-    const limits = session.Limits{ .max_ticket_len = 20 * 1024, .max_serialized_len = 32 * 1024 };
+    const limits = session.Limits{ .max_ticket_len = session.absolute_ticket_wire_max, .max_serialized_len = 128 * 1024 };
     try harness.client_backend.setSessionTicketConsumer(std.testing.allocator, limits, .{
         .ctx = &capture,
         .nowUnixMsFn = Capture.now,
@@ -443,7 +443,7 @@ test "direct record handshake delivers large post-handshake ticket once" {
     });
     try harness.run();
 
-    const opaque_ticket = try std.testing.allocator.alloc(u8, 20 * 1024);
+    const opaque_ticket = try std.testing.allocator.alloc(u8, session.absolute_ticket_wire_max);
     defer std.testing.allocator.free(opaque_ticket);
     @memset(opaque_ticket, 0xa5);
 
@@ -461,14 +461,14 @@ test "direct record handshake delivers large post-handshake ticket once" {
 
     const ticket_event = sink.items[0].handshake_bytes;
     try std.testing.expect(ticket_event.data.len > record_codec.max_plaintext_fragment_len);
-    var protected: [record_codec.max_ciphertext_record_len * 3]u8 = undefined;
+    var protected: [record_codec.max_ciphertext_record_len * 8]u8 = undefined;
     const records = (try harness.server_bridge.applyEvent(.{ .handshake_bytes = .{
         .epoch = ticket_event.epoch,
         .data = ticket_event.data,
     } }, &protected)).?;
 
     var parser = record_codec.Parser.init(.ciphertext);
-    var record_sink = record_codec.RecordSink(4, record_codec.max_ciphertext_fragment_len * 4){};
+    var record_sink = record_codec.RecordSink(8, record_codec.max_ciphertext_fragment_len * 8){};
     try parser.feed(records, &record_sink);
     try std.testing.expect(record_sink.len > 1);
 
@@ -948,6 +948,119 @@ test "record stream completes a real TLS 1.3 handshake over a nonblocking socket
         }.done);
         try std.testing.expectError(error.EndOfStream, h.server.stream().read(&buf));
     }
+}
+
+test "record stream delivers maximum post-handshake ticket and remains usable" {
+    const Capture = struct {
+        count: usize = 0,
+        ticket_len: usize = 0,
+        psk: [tls_backend.hash_len]u8 = undefined,
+
+        fn now(_: *anyopaque) i64 {
+            return 10;
+        }
+
+        fn onTicket(ctx: *anyopaque, ticket: *const session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.count += 1;
+            self.ticket_len = ticket.ticket.slice().len;
+            @memcpy(&self.psk, ticket.common.resumption_psk.slice());
+        }
+    };
+
+    const h = try SocketHarness.create(.{ .client_chunk = 4096, .server_chunk = 4096 });
+    defer h.destroy();
+    var capture = Capture{};
+    const limits = session.Limits{ .max_ticket_len = session.absolute_ticket_wire_max, .max_serialized_len = 128 * 1024 };
+    try h.client_engine.setSessionTicketConsumer(std.testing.allocator, limits, .{
+        .ctx = &capture,
+        .nowUnixMsFn = Capture.now,
+        .onTicketFn = Capture.onTicket,
+    });
+    try h.driveUntil(SocketHarness.bothComplete);
+
+    try std.testing.expectEqual(@as(usize, 13), try h.client.stream().write("before-ticket"));
+    try h.driveUntil(struct {
+        fn done(hh: *SocketHarness) bool {
+            return hh.server.readiness().can_read_plaintext;
+        }
+    }.done);
+    var app_buf: [64]u8 = undefined;
+    try std.testing.expectEqualStrings("before-ticket", app_buf[0..try h.server.stream().read(&app_buf)]);
+
+    const opaque_ticket = try std.testing.allocator.alloc(u8, session.absolute_ticket_wire_max);
+    defer std.testing.allocator.free(opaque_ticket);
+    @memset(opaque_ticket, 0xa5);
+    var sink = DirectSink{};
+    defer sink.deinit();
+    var server_state = try h.server_engine.emitNewSessionTicket(std.testing.allocator, &sink, .{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = opaque_ticket,
+        .issued_at_unix_ms = 10,
+    }, limits);
+    defer server_state.deinit();
+    const ticket_event = sink.items[0].handshake_bytes;
+    try h.server.applyEvent(.{ .handshake_bytes = .{
+        .epoch = ticket_event.epoch,
+        .data = ticket_event.data,
+    } });
+
+    var rounds: usize = 0;
+    while (rounds < 5000 and capture.count == 0) : (rounds += 1) {
+        _ = try h.server.stream().drive();
+        _ = try h.client.stream().drive();
+    }
+    try std.testing.expectEqual(@as(usize, 1), capture.count);
+    try std.testing.expectEqual(opaque_ticket.len, capture.ticket_len);
+    try std.testing.expectEqualSlices(u8, server_state.common.resumption_psk.slice(), &capture.psk);
+
+    try std.testing.expectEqual(@as(usize, 12), try h.server.stream().write("after-ticket"));
+    try h.driveUntil(struct {
+        fn done(hh: *SocketHarness) bool {
+            return hh.client.readiness().can_read_plaintext;
+        }
+    }.done);
+    try std.testing.expectEqualStrings("after-ticket", app_buf[0..try h.client.stream().read(&app_buf)]);
+}
+
+test "record stream drops valid ticket with no consumer and remains usable" {
+    const h = try SocketHarness.create(.{ .client_chunk = 1024, .server_chunk = 1024 });
+    defer h.destroy();
+    try h.driveUntil(SocketHarness.bothComplete);
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    var server_state = try h.server_engine.emitNewSessionTicket(std.testing.allocator, &sink, .{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = "drop-ticket",
+        .issued_at_unix_ms = 10,
+    }, session.Limits.default);
+    defer server_state.deinit();
+    const ticket_event = sink.items[0].handshake_bytes;
+    try h.server.applyEvent(.{ .handshake_bytes = .{
+        .epoch = ticket_event.epoch,
+        .data = ticket_event.data,
+    } });
+
+    var rounds: usize = 0;
+    while (rounds < 1000) : (rounds += 1) {
+        const s = try h.server.stream().drive();
+        const c = try h.client.stream().drive();
+        if (!s.made_progress and !c.made_progress) break;
+    }
+
+    try std.testing.expectEqual(@as(usize, 9), try h.client.stream().write("afterdrop"));
+    try h.driveUntil(struct {
+        fn done(hh: *SocketHarness) bool {
+            return hh.server.readiness().can_read_plaintext;
+        }
+    }.done);
+    var app_buf: [32]u8 = undefined;
+    try std.testing.expectEqualStrings("afterdrop", app_buf[0..try h.server.stream().read(&app_buf)]);
 }
 
 test "pure-Zig HTTPS HTTP/1.1 bytes enter existing parser through EncryptedStream adapter" {

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -19,6 +19,7 @@ const http_request = @import("http_request");
 const record_codec = tls_core.record_codec;
 const events = tls_core.events;
 const credentials = tls_core.credentials;
+const session = tls_core.session;
 const sni_provider = tls_core.sni_provider;
 
 fn clientEntropy() tls_backend.Entropy {
@@ -411,6 +412,75 @@ test "direct shared driver preserves derivation, sequence, discard, and teardown
     try expectDirectSinkWiped(&harness.server_driver, server_used);
     try std.testing.expect(std.mem.allEqual(u8, &harness.client_backend.entropy.key_share_seed, 0));
     try std.testing.expect(std.mem.allEqual(u8, std.mem.asBytes(&harness.server_backend.identity), 0));
+}
+
+test "direct record handshake delivers large post-handshake ticket once" {
+    const Capture = struct {
+        count: usize = 0,
+        psk: [tls_backend.hash_len]u8 = undefined,
+        ticket_len: usize = 0,
+
+        fn now(_: *anyopaque) i64 {
+            return 10;
+        }
+
+        fn onTicket(ctx: *anyopaque, ticket: *const session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.count += 1;
+            @memcpy(&self.psk, ticket.common.resumption_psk.slice());
+            self.ticket_len = ticket.ticket.slice().len;
+        }
+    };
+
+    var harness = DirectHarness.init();
+    defer harness.deinit();
+    var capture = Capture{};
+    const limits = session.Limits{ .max_ticket_len = 20 * 1024, .max_serialized_len = 32 * 1024 };
+    try harness.client_backend.setSessionTicketConsumer(std.testing.allocator, limits, .{
+        .ctx = &capture,
+        .nowUnixMsFn = Capture.now,
+        .onTicketFn = Capture.onTicket,
+    });
+    try harness.run();
+
+    const opaque_ticket = try std.testing.allocator.alloc(u8, 20 * 1024);
+    defer std.testing.allocator.free(opaque_ticket);
+    @memset(opaque_ticket, 0xa5);
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    var server_state = try harness.server_backend.emitNewSessionTicket(std.testing.allocator, &sink, .{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = opaque_ticket,
+        .issued_at_unix_ms = 10,
+    }, limits);
+    defer server_state.deinit();
+    try std.testing.expectEqual(@as(usize, 1), sink.len);
+
+    const ticket_event = sink.items[0].handshake_bytes;
+    try std.testing.expect(ticket_event.data.len > record_codec.max_plaintext_fragment_len);
+    var protected: [record_codec.max_ciphertext_record_len * 3]u8 = undefined;
+    const records = (try harness.server_bridge.applyEvent(.{ .handshake_bytes = .{
+        .epoch = ticket_event.epoch,
+        .data = ticket_event.data,
+    } }, &protected)).?;
+
+    var parser = record_codec.Parser.init(.ciphertext);
+    var record_sink = record_codec.RecordSink(4, record_codec.max_ciphertext_fragment_len * 4){};
+    try parser.feed(records, &record_sink);
+    try std.testing.expect(record_sink.len > 1);
+
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    for (record_sink.items[0..record_sink.len]) |record| {
+        const opened = try harness.client_bridge.openHandshake(.application, record, &plaintext);
+        const next = try harness.client_driver.receive(.application, opened.inner.content);
+        try std.testing.expectEqual(@as(usize, 0), next.len);
+    }
+    try std.testing.expectEqual(@as(usize, 1), capture.count);
+    try std.testing.expectEqual(opaque_ticket.len, capture.ticket_len);
+    try std.testing.expectEqualSlices(u8, server_state.common.resumption_psk.slice(), &capture.psk);
 }
 
 test "direct shared driver cleanup wipes secrets after record authentication failure" {

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -828,7 +828,7 @@ const SocketHarness = struct {
         self.client_carrier = .{ .fd = self.fds[0], .max_chunk = opts.client_chunk, .one_write_per_drive = opts.one_write_per_drive };
         self.server_carrier = .{ .fd = self.fds[1], .max_chunk = opts.server_chunk, .one_write_per_drive = opts.one_write_per_drive };
 
-        self.client = es.PureZigRecordStream.initWithCarrierAndBackend(.client, clientProvider(), suite, self.client_carrier.carrier(), self.client_engine.backend());
+        self.client = try es.PureZigRecordStream.initWithCarrierBackendAndAllocator(allocator, .client, clientProvider(), suite, self.client_carrier.carrier(), self.client_engine.backend());
         self.server = es.PureZigRecordStream.initWithCarrierAndBackend(.server, serverProvider(), suite, self.server_carrier.carrier(), self.server_engine.backend());
         self.client.setExpectedAlpn(opts.client_alpn) catch unreachable;
         return self;

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -828,8 +828,8 @@ const SocketHarness = struct {
         self.client_carrier = .{ .fd = self.fds[0], .max_chunk = opts.client_chunk, .one_write_per_drive = opts.one_write_per_drive };
         self.server_carrier = .{ .fd = self.fds[1], .max_chunk = opts.server_chunk, .one_write_per_drive = opts.one_write_per_drive };
 
-        self.client = try es.PureZigRecordStream.initWithCarrierBackendAndAllocator(allocator, .client, clientProvider(), suite, self.client_carrier.carrier(), self.client_engine.backend());
-        self.server = es.PureZigRecordStream.initWithCarrierAndBackend(.server, serverProvider(), suite, self.server_carrier.carrier(), self.server_engine.backend());
+        self.client = try es.PureZigRecordStream.initWithCarrierAndBackend(allocator, .client, clientProvider(), suite, self.client_carrier.carrier(), self.client_engine.backend());
+        self.server = try es.PureZigRecordStream.initWithCarrierAndBackend(allocator, .server, serverProvider(), suite, self.server_carrier.carrier(), self.server_engine.backend());
         self.client.setExpectedAlpn(opts.client_alpn) catch unreachable;
         return self;
     }

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -1070,6 +1070,130 @@ test "record stream drops valid ticket with no consumer and remains usable" {
     try std.testing.expectEqualStrings("afterdrop", app_buf[0..try h.server.stream().read(&app_buf)]);
 }
 
+test "record stream ticket callback clone survives callback return" {
+    const Capture = struct {
+        allocator: std.mem.Allocator,
+        retained: session.ClientTicketState = .{},
+        count: usize = 0,
+
+        fn now(_: *anyopaque) i64 {
+            return 10;
+        }
+
+        fn onTicket(ctx: *anyopaque, ticket: *const session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            ticket.cloneInto(self.allocator, &self.retained) catch unreachable;
+            self.count += 1;
+        }
+    };
+
+    const h = try SocketHarness.create(.{ .client_chunk = 1024, .server_chunk = 1024 });
+    defer h.destroy();
+    var capture = Capture{ .allocator = std.testing.allocator };
+    defer capture.retained.deinit();
+    try h.client_engine.setSessionTicketConsumer(std.testing.allocator, session.Limits.default, .{
+        .ctx = &capture,
+        .nowUnixMsFn = Capture.now,
+        .onTicketFn = Capture.onTicket,
+    });
+    try h.driveUntil(SocketHarness.bothComplete);
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    var server_state = try h.server_engine.emitNewSessionTicket(std.testing.allocator, &sink, .{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 0x11223344,
+        .ticket_nonce = "\x01\x02",
+        .opaque_ticket = "clone-ticket",
+        .max_early_data_size = 32,
+        .issued_at_unix_ms = 10,
+    }, session.Limits.default);
+    defer server_state.deinit();
+    const ticket_event = sink.items[0].handshake_bytes;
+    try h.server.applyEvent(.{ .handshake_bytes = .{ .epoch = ticket_event.epoch, .data = ticket_event.data } });
+
+    var rounds: usize = 0;
+    while (rounds < 1000 and capture.count == 0) : (rounds += 1) {
+        _ = try h.server.stream().drive();
+        _ = try h.client.stream().drive();
+    }
+    try std.testing.expectEqual(@as(usize, 1), capture.count);
+    try std.testing.expectEqualSlices(u8, "clone-ticket", capture.retained.ticket.slice());
+    try std.testing.expectEqualSlices(u8, "\x01\x02", capture.retained.ticket_nonce.slice());
+    try std.testing.expectEqual(@as(u32, 0x11223344), capture.retained.ticket_age_add);
+    try std.testing.expectEqual(@as(i64, 10), capture.retained.received_at_unix_ms);
+    try std.testing.expectEqual(@as(u32, 60), capture.retained.common.lifetime_seconds);
+    try std.testing.expectEqual(session.EarlyDataPolicy{ .early_data_capable = 32 }, capture.retained.common.early_data);
+    try std.testing.expectEqualSlices(u8, server_state.common.resumption_psk.slice(), capture.retained.common.resumption_psk.slice());
+    try std.testing.expect(capture.retained.common.application_protocol != null);
+    try std.testing.expectEqualSlices(u8, "h2", capture.retained.common.application_protocol.?.slice());
+}
+
+test "record stream ticket callback clone refusal is nonfatal" {
+    const Capture = struct {
+        allocator: std.mem.Allocator,
+        storage_refused: bool = false,
+        callbacks: usize = 0,
+
+        fn now(_: *anyopaque) i64 {
+            return 10;
+        }
+
+        fn onTicket(ctx: *anyopaque, ticket: *const session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            var retained: session.ClientTicketState = .{};
+            ticket.cloneInto(self.allocator, &retained) catch {
+                self.storage_refused = true;
+                self.callbacks += 1;
+                return;
+            };
+            retained.deinit();
+            self.callbacks += 1;
+        }
+    };
+
+    const h = try SocketHarness.create(.{ .client_chunk = 1024, .server_chunk = 1024 });
+    defer h.destroy();
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
+    var capture = Capture{ .allocator = failing.allocator() };
+    try h.client_engine.setSessionTicketConsumer(std.testing.allocator, session.Limits.default, .{
+        .ctx = &capture,
+        .nowUnixMsFn = Capture.now,
+        .onTicketFn = Capture.onTicket,
+    });
+    try h.driveUntil(SocketHarness.bothComplete);
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    var server_state = try h.server_engine.emitNewSessionTicket(std.testing.allocator, &sink, .{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = "refuse-clone",
+        .issued_at_unix_ms = 10,
+    }, session.Limits.default);
+    defer server_state.deinit();
+    const ticket_event = sink.items[0].handshake_bytes;
+    try h.server.applyEvent(.{ .handshake_bytes = .{ .epoch = ticket_event.epoch, .data = ticket_event.data } });
+
+    var rounds: usize = 0;
+    while (rounds < 1000 and capture.callbacks == 0) : (rounds += 1) {
+        _ = try h.server.stream().drive();
+        _ = try h.client.stream().drive();
+    }
+    try std.testing.expect(capture.storage_refused);
+    try std.testing.expectEqual(@as(usize, 1), capture.callbacks);
+
+    try std.testing.expectEqual(@as(usize, 8), try h.client.stream().write("still-ok"));
+    try h.driveUntil(struct {
+        fn done(hh: *SocketHarness) bool {
+            return hh.server.readiness().can_read_plaintext;
+        }
+    }.done);
+    var buf: [16]u8 = undefined;
+    try std.testing.expectEqualStrings("still-ok", buf[0..try h.server.stream().read(&buf)]);
+}
+
 test "pure-Zig HTTPS HTTP/1.1 bytes enter existing parser through EncryptedStream adapter" {
     const h = try SocketHarness.create(.{
         .client_chunk = 3,

--- a/src/tls/tls13_transport.zig
+++ b/src/tls/tls13_transport.zig
@@ -4,8 +4,10 @@
 //! boundaries. Keeping the engine on this lower-level contract prevents it
 //! from depending on either encrypted byte streams or QUIC framing.
 
+const std = @import("std");
 const events = @import("events.zig");
 const messages = @import("messages.zig");
+const session = @import("session.zig");
 const transport = @import("transport.zig");
 
 pub const Error = events.HandshakeError || messages.ReadError || messages.WriteError || error{
@@ -15,7 +17,17 @@ pub const Error = events.HandshakeError || messages.ReadError || messages.WriteE
     InvalidTransportProfile,
 };
 
-pub const Contract = transport.Contract(void, events.EncryptionEpoch, Error);
+pub const max_new_session_ticket_message_len =
+    4 + 4 + 4 + 1 + session.max_ticket_nonce_len + 2 + session.absolute_ticket_wire_max + 2 + (std.math.maxInt(u16) - 1);
+
+pub const Contract = transport.ContractWithOptions(
+    void,
+    events.EncryptionEpoch,
+    Error,
+    16,
+    max_new_session_ticket_message_len,
+    error.TransportBufferOverflow,
+);
 pub const Backend = Contract.Backend;
 pub const EventSink = Contract.EventSink;
 

--- a/src/tls/tls13_transport.zig
+++ b/src/tls/tls13_transport.zig
@@ -20,12 +20,16 @@ pub const Error = events.HandshakeError || messages.ReadError || messages.WriteE
 pub const max_new_session_ticket_message_len =
     4 + 4 + 4 + 1 + session.max_ticket_nonce_len + 2 + session.absolute_ticket_wire_max + 2 + (std.math.maxInt(u16) - 1);
 
+/// The shared engine event sink stays small enough to embed in transport
+/// wrappers while still allowing tickets that cross a single TLS record.
+pub const max_event_bytes = 32 * 1024;
+
 pub const Contract = transport.ContractWithOptions(
     void,
     events.EncryptionEpoch,
     Error,
     16,
-    max_new_session_ticket_message_len,
+    max_event_bytes,
     error.TransportBufferOverflow,
 );
 pub const Backend = Contract.Backend;

--- a/src/tls/tls13_transport.zig
+++ b/src/tls/tls13_transport.zig
@@ -19,6 +19,8 @@ pub const Error = events.HandshakeError || messages.ReadError || messages.WriteE
 
 pub const max_new_session_ticket_message_len =
     4 + 4 + 4 + 1 + session.max_ticket_nonce_len + 2 + session.absolute_ticket_wire_max + 2 + (std.math.maxInt(u16) - 1);
+pub const max_emitted_new_session_ticket_message_len =
+    4 + 4 + 4 + 1 + session.max_ticket_nonce_len + 2 + session.absolute_ticket_wire_max + 2 + 8;
 
 /// The shared engine event sink stays small enough to embed in transport
 /// wrappers while still allowing tickets that cross a single TLS record.

--- a/src/tls/transport.zig
+++ b/src/tls/transport.zig
@@ -11,13 +11,14 @@
 //! an earlier record-mode-only `record_transport.zig` duplicated this and has
 //! been removed). Ownership rules are narrow and testable:
 //!
-//! - Every byte slice in an emitted event is copied into the driver-owned
-//!   `EventSink`. Slices borrow the sink and remain valid only until the next
-//!   `Driver.start`/`Driver.receive` call, both of which reset the sink.
-//! - `EventSink.reset` and `EventSink.deinit` securely zero the scratch range
-//!   a copied traffic secret occupied, so it does not survive past the event
-//!   lifetime above. `Driver.deinit` calls the latter; every owner of a
-//!   `Driver` must call it exactly once at teardown.
+//! - Byte slices in emitted events borrow the driver-owned `EventSink` and
+//!   remain valid only until the next `Driver.start`/`Driver.receive` call,
+//!   both of which reset the sink. Most payloads are copied into fixed scratch;
+//!   unusually large handshake messages may be transferred as owned allocations.
+//! - `EventSink.reset` and `EventSink.deinit` securely zero copied scratch and
+//!   owned payloads, so traffic secrets and large handshake bytes do not survive
+//!   past the event lifetime above. `Driver.deinit` calls the latter; every
+//!   owner of a `Driver` must call it exactly once at teardown.
 //! - Event emission is atomic: a rejected emit (event-count or byte overflow)
 //!   never leaves a partial payload in scratch or a phantom event in `items`.
 //! - The contract can carry terminal alert output (`Event.fatal_alert`) so a
@@ -85,7 +86,13 @@ pub fn ContractWithOptions(
             pub const max_events = max_event_count;
             pub const max_bytes = max_byte_count;
 
+            const OwnedPayload = struct {
+                allocator: std.mem.Allocator,
+                bytes: []u8,
+            };
+
             items: [max_events]Event = undefined,
+            owned: [max_events]?OwnedPayload = [_]?OwnedPayload{null} ** max_events,
             len: usize = 0,
             scratch: [max_bytes]u8 = undefined,
             used: usize = 0,
@@ -94,6 +101,7 @@ pub fn ContractWithOptions(
             /// traffic secrets (and other emitted bytes) occupied, so they do
             /// not survive past the event lifetime documented on `Backend`.
             pub fn reset(self: *EventSink) void {
+                self.freeOwnedPayloads();
                 self.zeroUsedScratch();
                 self.len = 0;
                 self.used = 0;
@@ -110,6 +118,16 @@ pub fn ContractWithOptions(
 
             fn zeroUsedScratch(self: *EventSink) void {
                 if (self.used > 0) crypto_secrets.secureZero(self.scratch[0..self.used]);
+            }
+
+            fn freeOwnedPayloads(self: *EventSink) void {
+                for (self.owned[0..self.len]) |*owned| {
+                    if (owned.*) |payload| {
+                        crypto_secrets.secureZero(payload.bytes);
+                        payload.allocator.free(payload.bytes);
+                        owned.* = null;
+                    }
+                }
             }
 
             /// True when `len` bytes can be copied into `scratch` without
@@ -137,6 +155,13 @@ pub fn ContractWithOptions(
             /// with `hasEventCapacity`; this never fails.
             fn pushUnchecked(self: *EventSink, event: Event) void {
                 self.items[self.len] = event;
+                self.owned[self.len] = null;
+                self.len += 1;
+            }
+
+            fn pushOwnedUnchecked(self: *EventSink, event: Event, payload: OwnedPayload) void {
+                self.items[self.len] = event;
+                self.owned[self.len] = payload;
                 self.len += 1;
             }
 
@@ -154,10 +179,36 @@ pub fn ContractWithOptions(
                 self.pushUnchecked(.{ .handshake_bytes = .{ .epoch = epoch, .data = stored } });
             }
 
+            /// Transfer a caller-owned allocation into this sink as one
+            /// handshake event. On failure, ownership remains with the caller.
+            pub fn emitOwnedHandshakeBytes(self: *EventSink, allocator: std.mem.Allocator, epoch: Epoch, data: []u8) ErrorSet!void {
+                if (!self.hasEventCapacity()) return buffer_overflow_error;
+                self.pushOwnedUnchecked(
+                    .{ .handshake_bytes = .{ .epoch = epoch, .data = data } },
+                    .{ .allocator = allocator, .bytes = data },
+                );
+            }
+
+            pub fn emitOwnedHandshakeBytesCopy(self: *EventSink, epoch: Epoch, data: []const u8) ErrorSet!void {
+                if (self.hasByteCapacity(data.len)) return self.emitHandshakeBytes(epoch, data);
+                if (!self.hasEventCapacity()) return buffer_overflow_error;
+                const copy = std.heap.page_allocator.alloc(u8, data.len) catch return buffer_overflow_error;
+                errdefer {
+                    crypto_secrets.secureZero(copy);
+                    std.heap.page_allocator.free(copy);
+                }
+                @memcpy(copy, data);
+                try self.emitOwnedHandshakeBytes(std.heap.page_allocator, epoch, copy);
+            }
+
             /// Compatibility spelling for QUIC callers, where handshake bytes
             /// are carried in CRYPTO streams.
             pub fn emitCrypto(self: *EventSink, epoch: Epoch, data: []const u8) ErrorSet!void {
                 try self.emitHandshakeBytes(epoch, data);
+            }
+
+            pub fn emitOwnedCrypto(self: *EventSink, allocator: std.mem.Allocator, epoch: Epoch, data: []u8) ErrorSet!void {
+                try self.emitOwnedHandshakeBytes(allocator, epoch, data);
             }
 
             pub fn emitSecret(self: *EventSink, epoch: Epoch, direction: events.SecretDirection, data: []const u8) ErrorSet!void {
@@ -277,6 +328,21 @@ test "generic transport sink enforces bounded payload storage" {
     var sink = T.EventSink{};
     const oversized = [_]u8{0} ** (T.EventSink.max_bytes + 1);
     try std.testing.expectError(error.TransportBufferOverflow, sink.emitHandshakeBytes(.initial, &oversized));
+}
+
+test "generic transport sink owns large transferred handshake payloads" {
+    const ErrorSet = error{TransportBufferOverflow};
+    const Epoch = enum { application };
+    const T = ContractWithOptions(void, Epoch, ErrorSet, 1, 4, error.TransportBufferOverflow);
+
+    var sink = T.EventSink{};
+    const payload = try std.testing.allocator.alloc(u8, 32);
+    @memset(payload, 0xa5);
+    try sink.emitOwnedHandshakeBytes(std.testing.allocator, .application, payload);
+    try std.testing.expectEqual(@as(usize, 1), sink.len);
+    try std.testing.expectEqualSlices(u8, payload, sink.items[0].handshake_bytes.data);
+    sink.reset();
+    try std.testing.expectEqual(@as(usize, 0), sink.len);
 }
 
 test "generic transport sink accepts caller-owned limits and overflow error names" {

--- a/src/tls/transport.zig
+++ b/src/tls/transport.zig
@@ -281,6 +281,7 @@ pub fn ContractWithOptions(
             /// handshake when it resolves.
             authPendingFn: ?*const fn (ptr: *anyopaque) bool = null,
             resumeFn: ?*const fn (ptr: *anyopaque, sink: *EventSink) ErrorSet!void = null,
+            setPostHandshakeAllocatorFn: ?*const fn (ptr: *anyopaque, allocator: std.mem.Allocator) ErrorSet!void = null,
 
             pub fn start(self: Backend, role: state.Role, params: TransportParameters, sink: *EventSink) ErrorSet!void {
                 return self.startFn(self.ptr, role, params, sink);
@@ -301,6 +302,10 @@ pub fn ContractWithOptions(
             /// backend does not support suspension.
             pub fn resumeAuth(self: Backend, sink: *EventSink) ErrorSet!void {
                 if (self.resumeFn) |f| return f(self.ptr, sink);
+            }
+
+            pub fn setPostHandshakeAllocator(self: Backend, allocator: std.mem.Allocator) ErrorSet!void {
+                if (self.setPostHandshakeAllocatorFn) |f| return f(self.ptr, allocator);
             }
 
             pub fn deinit(self: Backend) void {

--- a/src/tls/transport.zig
+++ b/src/tls/transport.zig
@@ -86,7 +86,7 @@ pub fn ContractWithOptions(
             pub const max_events = max_event_count;
             pub const max_bytes = max_byte_count;
 
-            const OwnedPayload = struct {
+            pub const OwnedPayload = struct {
                 allocator: std.mem.Allocator,
                 bytes: []u8,
             };
@@ -189,16 +189,23 @@ pub fn ContractWithOptions(
                 );
             }
 
-            pub fn emitOwnedHandshakeBytesCopy(self: *EventSink, epoch: Epoch, data: []const u8) ErrorSet!void {
+            pub fn takeOwnedHandshakePayload(self: *EventSink, index: usize) ?OwnedPayload {
+                if (index >= self.len) return null;
+                const payload = self.owned[index] orelse return null;
+                self.owned[index] = null;
+                return payload;
+            }
+
+            pub fn emitOwnedHandshakeBytesCopy(self: *EventSink, allocator: std.mem.Allocator, epoch: Epoch, data: []const u8) ErrorSet!void {
                 if (self.hasByteCapacity(data.len)) return self.emitHandshakeBytes(epoch, data);
                 if (!self.hasEventCapacity()) return buffer_overflow_error;
-                const copy = std.heap.page_allocator.alloc(u8, data.len) catch return buffer_overflow_error;
+                const copy = allocator.alloc(u8, data.len) catch return buffer_overflow_error;
                 errdefer {
                     crypto_secrets.secureZero(copy);
-                    std.heap.page_allocator.free(copy);
+                    allocator.free(copy);
                 }
                 @memcpy(copy, data);
-                try self.emitOwnedHandshakeBytes(std.heap.page_allocator, epoch, copy);
+                try self.emitOwnedHandshakeBytes(allocator, epoch, copy);
             }
 
             /// Compatibility spelling for QUIC callers, where handshake bytes

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -2460,7 +2460,8 @@ const PureZigTlsClient = struct {
             .{ .record = .{ .alpn = alpnPolicy(alpn) } },
             .{ .server_name = server_name },
         );
-        self.record = tls_core.encrypted_stream.PureZigRecordStream.initWithCarrierAndBackend(
+        self.record = try tls_core.encrypted_stream.PureZigRecordStream.initWithCarrierBackendAndAllocator(
+            allocator,
             .client,
             self.cryptoProviderState().cryptoProvider(),
             .tls_aes_128_gcm_sha256,
@@ -2494,7 +2495,8 @@ const PureZigTlsClient = struct {
             .{ .record = .{ .alpn = alpnPolicy(alpn) } },
             .{ .server_name = server_name },
         );
-        self.record = tls_core.encrypted_stream.PureZigRecordStream.initWithCarrierAndBackend(
+        self.record = try tls_core.encrypted_stream.PureZigRecordStream.initWithCarrierBackendAndAllocator(
+            allocator,
             .client,
             self.cryptoProviderState().cryptoProvider(),
             .tls_aes_128_gcm_sha256,

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -2460,7 +2460,7 @@ const PureZigTlsClient = struct {
             .{ .record = .{ .alpn = alpnPolicy(alpn) } },
             .{ .server_name = server_name },
         );
-        self.record = try tls_core.encrypted_stream.PureZigRecordStream.initWithCarrierBackendAndAllocator(
+        self.record = try tls_core.encrypted_stream.PureZigRecordStream.initWithCarrierAndBackend(
             allocator,
             .client,
             self.cryptoProviderState().cryptoProvider(),
@@ -2495,7 +2495,7 @@ const PureZigTlsClient = struct {
             .{ .record = .{ .alpn = alpnPolicy(alpn) } },
             .{ .server_name = server_name },
         );
-        self.record = try tls_core.encrypted_stream.PureZigRecordStream.initWithCarrierBackendAndAllocator(
+        self.record = try tls_core.encrypted_stream.PureZigRecordStream.initWithCarrierAndBackend(
             allocator,
             .client,
             self.cryptoProviderState().cryptoProvider(),


### PR DESCRIPTION
## Summary

- add RFC 8446 NewSessionTicket encode/decode support with bounds, extension validation, and conversion into the existing TLS session model
- derive resumption master secrets at handshake completion and per-ticket PSKs from ticket nonces
- add client ticket callback delivery and explicit server application-epoch ticket emission APIs

## Validation

- zig fmt --check build.zig src/ tests/
- zig build test-tls --summary all --error-style verbose
- zig build test-crypto --summary all --error-style verbose
- zig build test --summary all --error-style verbose
- zig build test-integration --summary all --error-style verbose
- zig build test-quic --summary all --error-style verbose
- zig build -Doptimize=ReleaseFast --summary all --error-style verbose

Closes #361