### PR TITLE
tls: implement TLS 1.3 PSK identities, modes, and binder verification

### DIFF
--- a/src/tls/algorithms.zig
+++ b/src/tls/algorithms.zig
@@ -50,7 +50,9 @@ pub const ExtensionType = enum(u16) {
     supported_groups = 10,
     signature_algorithms = 13,
     application_layer_protocol_negotiation = 16,
+    pre_shared_key = 41,
     supported_versions = 43,
+    psk_key_exchange_modes = 45,
     key_share = 51,
     quic_transport_parameters = 57,
 };

--- a/src/tls/handshake.zig
+++ b/src/tls/handshake.zig
@@ -78,12 +78,31 @@ pub const Core = struct {
     client_auth_inbound: ClientAuthInbound = .inactive,
     /// Client outbound sub-state for its own certificate flight.
     client_auth_outbound: ClientAuthOutbound = .inactive,
+    /// Set once a PSK-resumed handshake (#362) has been selected: the
+    /// server flight after EncryptedExtensions goes straight to Finished
+    /// (no CertificateRequest, Certificate, or CertificateVerify), and the
+    /// client expects Finished immediately after EncryptedExtensions. Both
+    /// sides set this — via `enterPskAuthenticated` — once they know a PSK
+    /// was selected (server: after choosing to accept it, before its own
+    /// EncryptedExtensions is sent; client: after parsing ServerHello's
+    /// selected_identity, before EncryptedExtensions arrives). Never set
+    /// together with `request_client_certificate`/a client-auth flight:
+    /// handshake-time client authentication forces full-handshake fallback.
+    psk_authenticated: bool = false,
 
     pub const ClientAuthInbound = enum { inactive, expect_certificate, expect_certificate_verify, expect_finished };
     pub const ClientAuthOutbound = enum { inactive, send_certificate, send_certificate_verify, send_finished };
 
     pub fn init(role: state.Role) Core {
         return .{ .role = role };
+    }
+
+    /// Declare that a PSK-resumed handshake was selected (#362): the
+    /// remaining flight on both sides skips straight from EncryptedExtensions
+    /// to Finished. Must be called before the EncryptedExtensions message
+    /// is sent (server) or accepted (client).
+    pub fn enterPskAuthenticated(self: *Core) void {
+        self.psk_authenticated = true;
     }
 
     /// Server: request that the client authenticate. Call before the server
@@ -250,8 +269,8 @@ pub const Core = struct {
                     self.expected_inbound = .encrypted_extensions;
                 },
                 .encrypted_extensions => {
-                    self.handshake_state = .certificate;
-                    self.expected_inbound = .certificate;
+                    self.handshake_state = if (self.psk_authenticated) .finished else .certificate;
+                    self.expected_inbound = if (self.psk_authenticated) .finished else .certificate;
                 },
                 .certificate => {
                     self.handshake_state = .certificate_verify;
@@ -287,8 +306,12 @@ pub const Core = struct {
             },
             .server => switch (kind) {
                 .server_hello => self.handshake_state = .encrypted_extensions,
-                .encrypted_extensions => self.handshake_state =
-                    if (self.request_client_certificate) .certificate_request else .certificate,
+                .encrypted_extensions => self.handshake_state = if (self.psk_authenticated)
+                    .finished
+                else if (self.request_client_certificate)
+                    .certificate_request
+                else
+                    .certificate,
                 .certificate_request => self.handshake_state = .certificate,
                 .certificate => self.handshake_state = .certificate_verify,
                 .certificate_verify => self.handshake_state = .finished,
@@ -333,6 +356,47 @@ test "core records both directions of a client and server flight" {
     const cf = try messages.encode(.finished, "", &bytes);
     try client.recordSent(cf);
     _ = try server.acceptReceived(cf);
+    try std.testing.expectEqual(.complete, client.handshake_lifecycle);
+    try std.testing.expectEqual(.complete, server.handshake_lifecycle);
+    const client_hash = client.transcriptHash();
+    const server_hash = server.transcriptHash();
+    try std.testing.expectEqualSlices(u8, &client_hash, &server_hash);
+}
+
+test "PSK-authenticated core skips Certificate/CertificateVerify and still completes both directions" {
+    var client = Core.init(.client);
+    var server = Core.init(.server);
+    try client.start();
+    try server.start();
+
+    var bytes: [8]u8 = undefined;
+    const ch = try messages.encode(.client_hello, "", &bytes);
+    try client.recordSent(ch);
+    _ = try server.acceptReceived(ch);
+    const sh = try messages.encode(.server_hello, "", &bytes);
+    try server.recordSent(sh);
+    _ = try client.acceptReceived(sh);
+
+    // Both sides learn PSK was selected before EncryptedExtensions crosses
+    // the wire (server: before sending it; client: before receiving it).
+    server.enterPskAuthenticated();
+    client.enterPskAuthenticated();
+
+    const ee = try messages.encode(.encrypted_extensions, "", &bytes);
+    try server.recordSent(ee);
+    _ = try client.acceptReceived(ee);
+
+    // Certificate/CertificateVerify are neither expected nor legal now.
+    const cert = try messages.encode(.certificate, "", &bytes);
+    try std.testing.expectError(error.UnexpectedHandshakeMessage, client.acceptReceived(cert));
+
+    const sf = try messages.encode(.finished, "", &bytes);
+    try server.recordSent(sf);
+    _ = try client.acceptReceived(sf);
+    const cf = try messages.encode(.finished, "", &bytes);
+    try client.recordSent(cf);
+    _ = try server.acceptReceived(cf);
+
     try std.testing.expectEqual(.complete, client.handshake_lifecycle);
     try std.testing.expectEqual(.complete, server.handshake_lifecycle);
     const client_hash = client.transcriptHash();

--- a/src/tls/key_schedule.zig
+++ b/src/tls/key_schedule.zig
@@ -42,8 +42,40 @@ pub const KeySchedule = struct {
     server_handshake_traffic: [hash_len]u8,
 
     pub fn init(shared: *const [shared_secret_len]u8, hello_transcript_hash: [hash_len]u8) KeySchedule {
+        return initFromEarlySecret(&derived_early_secret, shared, hello_transcript_hash);
+    }
+
+    /// PSK-resumed (`psk_dhe_ke`) handshake: the same key-schedule chain as
+    /// `init`, but starting from a real early secret derived from the
+    /// resumption PSK (RFC 8446 §7.1) instead of the comptime all-zero-PSK
+    /// early secret `init` uses. `psk` must already be exactly `hash_len`
+    /// bytes (the SHA-256 resumption PSK produced by
+    /// `resumptionPsk`/`KeySchedule.resumptionPsk`, matching this module's
+    /// concrete SHA-256 schedule). X25519 key share remains mandatory in
+    /// this profile, so `shared` is still the ECDHE shared secret.
+    pub fn initWithPsk(
+        psk: *const [hash_len]u8,
+        shared: *const [shared_secret_len]u8,
+        hello_transcript_hash: [hash_len]u8,
+    ) KeySchedule {
+        var early_secret = HkdfSha256.extract("", psk);
+        defer crypto.secureZero(u8, &early_secret);
+        var derived_early = tls.hkdfExpandLabel(HkdfSha256, early_secret, "derived", &empty_transcript_hash, hash_len);
+        defer crypto.secureZero(u8, &derived_early);
+        return initFromEarlySecret(&derived_early, shared, hello_transcript_hash);
+    }
+
+    /// Shared continuation from a "derived" early secret (RFC 8446 §7.1)
+    /// into the handshake/master secrets and handshake traffic secrets. Used
+    /// by both the zero-PSK (`init`) and real-PSK (`initWithPsk`) entry
+    /// points, which differ only in how `derived_early_secret` was produced.
+    fn initFromEarlySecret(
+        derived_early: *const [hash_len]u8,
+        shared: *const [shared_secret_len]u8,
+        hello_transcript_hash: [hash_len]u8,
+    ) KeySchedule {
         const zeros = [_]u8{0} ** hash_len;
-        var handshake_secret = HkdfSha256.extract(&derived_early_secret, shared);
+        var handshake_secret = HkdfSha256.extract(derived_early, shared);
         defer crypto.secureZero(u8, &handshake_secret);
         var derived_handshake = tls.hkdfExpandLabel(HkdfSha256, handshake_secret, "derived", &empty_transcript_hash, hash_len);
         defer crypto.secureZero(u8, &derived_handshake);
@@ -255,6 +287,43 @@ test "generic resumption master secret derivation supports SHA-384" {
     try KeySchedule.deriveResumptionMasterSecret(.sha384, &master_secret, &transcript_hash, &out);
     try std.testing.expectEqualSlices(u8, &hexBytes("4f9d68ff762f5b886f275d162b90c268db5ccc65c4e0b8fc810030429a070f8e9f12b641b209e15ae210b1153a68fc42"), &out);
     try std.testing.expectError(error.InvalidSecretLength, KeySchedule.deriveResumptionMasterSecret(.sha384, master_secret[0..hash_len], &transcript_hash, &out));
+}
+
+test "initWithPsk diverges from the zero-PSK schedule and is deterministic" {
+    const shared = [_]u8{0x42} ** shared_secret_len;
+    const transcript = [_]u8{0x24} ** hash_len;
+    const psk = [_]u8{0x99} ** hash_len;
+
+    var zero_psk_schedule = KeySchedule.init(&shared, transcript);
+    defer zero_psk_schedule.wipe();
+    var psk_schedule = KeySchedule.initWithPsk(&psk, &shared, transcript);
+    defer psk_schedule.wipe();
+    var psk_schedule_again = KeySchedule.initWithPsk(&psk, &shared, transcript);
+    defer psk_schedule_again.wipe();
+
+    try std.testing.expect(!std.mem.eql(u8, &zero_psk_schedule.handshake_secret, &psk_schedule.handshake_secret));
+    try std.testing.expect(!std.mem.eql(u8, &zero_psk_schedule.master_secret, &psk_schedule.master_secret));
+    try std.testing.expectEqualSlices(u8, &psk_schedule.handshake_secret, &psk_schedule_again.handshake_secret);
+    try std.testing.expectEqualSlices(u8, &psk_schedule.master_secret, &psk_schedule_again.master_secret);
+    try std.testing.expect(!std.mem.eql(u8, &psk_schedule.client_handshake_traffic, &psk_schedule.server_handshake_traffic));
+
+    var app = psk_schedule.applicationSecrets(transcript);
+    defer app.wipe();
+    try std.testing.expect(!std.mem.eql(u8, &app.client, &app.server));
+}
+
+test "a different resumption PSK produces a different PSK-resumed schedule" {
+    const shared = [_]u8{0x11} ** shared_secret_len;
+    const transcript = [_]u8{0x22} ** hash_len;
+    const psk_a = [_]u8{0xaa} ** hash_len;
+    const psk_b = [_]u8{0xbb} ** hash_len;
+
+    var schedule_a = KeySchedule.initWithPsk(&psk_a, &shared, transcript);
+    defer schedule_a.wipe();
+    var schedule_b = KeySchedule.initWithPsk(&psk_b, &shared, transcript);
+    defer schedule_b.wipe();
+
+    try std.testing.expect(!std.mem.eql(u8, &schedule_a.master_secret, &schedule_b.master_secret));
 }
 
 fn hexBytes(comptime hex: []const u8) [hex.len / 2]u8 {

--- a/src/tls/key_schedule.zig
+++ b/src/tls/key_schedule.zig
@@ -312,6 +312,29 @@ test "initWithPsk diverges from the zero-PSK schedule and is deterministic" {
     try std.testing.expect(!std.mem.eql(u8, &app.client, &app.server));
 }
 
+test "initWithPsk matches independently computed secrets" {
+    // Checked-in literals for the same inputs as "initWithPsk diverges from
+    // the zero-PSK schedule and is deterministic" above (psk=0x99*32,
+    // shared=0x42*32, transcript=0x24*32), computed independently of this
+    // module rather than by re-deriving with the same helpers under test.
+    const shared = [_]u8{0x42} ** shared_secret_len;
+    const transcript = [_]u8{0x24} ** hash_len;
+    const psk = [_]u8{0x99} ** hash_len;
+
+    var schedule = KeySchedule.initWithPsk(&psk, &shared, transcript);
+    defer schedule.wipe();
+
+    try std.testing.expectEqualSlices(u8, &hexBytes("ab0803d6203c8feddfe8adc74f986c9d89b817b3d4132fc55c866a3522d9ff49"), &schedule.handshake_secret);
+    try std.testing.expectEqualSlices(u8, &hexBytes("e92139285417b6a9a54a7a9153f4b6dcce44b99cdc0937b83dfea5c79805c920"), &schedule.client_handshake_traffic);
+    try std.testing.expectEqualSlices(u8, &hexBytes("739483d9d6a9508c73b4656de22fedd85a2a8d00e9a6ca1449d8cba678c94baf"), &schedule.server_handshake_traffic);
+    try std.testing.expectEqualSlices(u8, &hexBytes("abe96cce65361235f3126971c67760888b79d4c1724a6cb1e15f6d2ae128ff44"), &schedule.master_secret);
+
+    var app = schedule.applicationSecrets(transcript);
+    defer app.wipe();
+    try std.testing.expectEqualSlices(u8, &hexBytes("d1ba0b1be9862f1bd4c3bcc0d53b5a98c6a4951c4bad19243051237bc735031c"), &app.client);
+    try std.testing.expectEqualSlices(u8, &hexBytes("c7428c93109f1b656dcbf0971e5d1bad9c2d38b79420038b7e165a17c7f61fa1"), &app.server);
+}
+
 test "a different resumption PSK produces a different PSK-resumed schedule" {
     const shared = [_]u8{0x11} ** shared_secret_len;
     const transcript = [_]u8{0x22} ** hash_len;

--- a/src/tls/key_schedule.zig
+++ b/src/tls/key_schedule.zig
@@ -244,6 +244,24 @@ test "application traffic secret storage has explicit cleanup" {
     try std.testing.expect(std.mem.allEqual(u8, std.mem.asBytes(&app), 0));
 }
 
+test "KeySchedule.wipe zeroizes every derived secret" {
+    // Deliberately a plain (non-optional) local, wiped in place and
+    // inspected directly — unlike a backend-owned `?KeySchedule` that gets
+    // set to `null` right after wiping, there is no subsequent
+    // optional-invalidation step here whose own debug-safety poisoning
+    // could be mistaken for (or mask the absence of) this `wipe()` call's
+    // effect. That makes this the reliable place to prove the zeroing
+    // itself; backend-level tests should only assert that `schedule`
+    // becomes `null`, not re-inspect the bytes afterward.
+    const shared = [_]u8{0x77} ** shared_secret_len;
+    const transcript = [_]u8{0x88} ** hash_len;
+    var schedule = KeySchedule.init(&shared, transcript);
+    const bytes = std.mem.asBytes(&schedule);
+    try std.testing.expect(!std.mem.allEqual(u8, bytes, 0));
+    schedule.wipe();
+    try std.testing.expect(std.mem.allEqual(u8, bytes, 0));
+}
+
 test "resumption master secret and PSK derivation are deterministic" {
     const shared = hexBytes("8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d");
     const hello_hash = hexBytes("860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8");

--- a/src/tls/new_session_ticket.zig
+++ b/src/tls/new_session_ticket.zig
@@ -228,7 +228,7 @@ pub fn buildServerRecoverableState(
     });
 
     var state: session.ServerRecoverableState = .{};
-    state.init(&common);
+    state.init(&common, params.ticket_age_add);
     return state;
 }
 

--- a/src/tls/pre_shared_key.zig
+++ b/src/tls/pre_shared_key.zig
@@ -239,12 +239,14 @@ pub fn writeOffer(w: *messages.Writer, items: []const OfferItem) WriteError!Clie
         if (item.identity.len > max_vector_len) return error.IdentityTooLarge;
         identities_total += 2 + item.identity.len + 4;
         if (identities_total > max_vector_len) return error.IdentitiesVectorTooLarge;
-        // This writer only ever produces the digest lengths the module's own
-        // binder derivation supports (32 for SHA-256, 48 for SHA-384), a
-        // stricter bound than the wire's general 32..255 `PskBinderEntry`
-        // range — and exactly what fits the fixed zero-placeholder buffer
-        // below.
-        if (item.digest_len < min_binder_len or item.digest_len > provider.max_digest_len)
+        // The full wire range (RFC 8446 §4.2.11: `PskBinderEntry<32..255>`),
+        // matching what `OfferedPsks.parse` accepts — this is a general
+        // wire codec, not specific to the two digest lengths this module's
+        // own binder derivation happens to support. A caller preparing an
+        // actual offer (see `tls13_backend.zig`) is the one that only ever
+        // constructs 32- or 48-byte entries; that is backend policy, not a
+        // codec-level restriction.
+        if (item.digest_len < min_binder_len or item.digest_len > max_binder_len)
             return error.InvalidBinderLength;
         binders_total += 1 + item.digest_len;
         if (binders_total > max_vector_len) return error.BindersVectorTooLarge;
@@ -274,7 +276,7 @@ pub fn writeOffer(w: *messages.Writer, items: []const OfferItem) WriteError!Clie
     for (items, 0..) |item, i| {
         const entry_len_idx = try w.reserve(1);
         const slot_offset = w.len;
-        const zeros = [_]u8{0} ** provider.max_digest_len;
+        const zeros = [_]u8{0} ** max_binder_len;
         try w.bytes(zeros[0..item.digest_len]);
         w.patch(1, entry_len_idx);
         result.slots[i] = .{ .offset = slot_offset, .len = item.digest_len };
@@ -562,17 +564,27 @@ test "writeOffer rejects illegal shapes without ever mutating the writer" {
         try testing.expectError(error.EmptyIdentity, writeOffer(&w, &items));
         try testing.expectEqual(@as(usize, 0), w.len);
     }
-    // Binder/digest length outside what this module can produce (32..48).
+    // Binder length boundary, over the full RFC 8446 wire range (32..255),
+    // matching `OfferedPsks.parse` exactly rather than this module's own
+    // narrower SHA-256/384 digest lengths: 31 rejected, 32/48/255 accepted,
+    // 256 unrepresentable on the wire and rejected.
     {
         var w = messages.Writer{ .buf = &buf };
-        const too_short = [_]OfferItem{.{ .identity = "id", .obfuscated_ticket_age = 0, .digest_len = min_binder_len - 1 }};
+        const too_short = [_]OfferItem{.{ .identity = "id", .obfuscated_ticket_age = 0, .digest_len = 31 }};
         try testing.expectError(error.InvalidBinderLength, writeOffer(&w, &too_short));
         try testing.expectEqual(@as(usize, 0), w.len);
 
-        var w2 = messages.Writer{ .buf = &buf };
-        const too_long = [_]OfferItem{.{ .identity = "id", .obfuscated_ticket_age = 0, .digest_len = provider.max_digest_len + 1 }};
-        try testing.expectError(error.InvalidBinderLength, writeOffer(&w2, &too_long));
-        try testing.expectEqual(@as(usize, 0), w2.len);
+        inline for (.{ 32, 48, 255 }) |ok_len| {
+            var w_ok = messages.Writer{ .buf = &buf };
+            const items = [_]OfferItem{.{ .identity = "id", .obfuscated_ticket_age = 0, .digest_len = ok_len }};
+            const offer = try writeOffer(&w_ok, &items);
+            try testing.expectEqual(@as(usize, ok_len), offer.slots[0].len);
+        }
+
+        var w_too_long = messages.Writer{ .buf = &buf };
+        const too_long = [_]OfferItem{.{ .identity = "id", .obfuscated_ticket_age = 0, .digest_len = 256 }};
+        try testing.expectError(error.InvalidBinderLength, writeOffer(&w_too_long, &too_long));
+        try testing.expectEqual(@as(usize, 0), w_too_long.len);
     }
     // Exact boundary values succeed: min/max supported digest length, and a
     // full eight-identity offer.
@@ -580,7 +592,7 @@ test "writeOffer rejects illegal shapes without ever mutating the writer" {
         var w = messages.Writer{ .buf = &buf };
         const items = [_]OfferItem{
             .{ .identity = "a", .obfuscated_ticket_age = 0, .digest_len = min_binder_len },
-            .{ .identity = "b", .obfuscated_ticket_age = 0, .digest_len = provider.max_digest_len },
+            .{ .identity = "b", .obfuscated_ticket_age = 0, .digest_len = max_binder_len },
         };
         _ = try writeOffer(&w, &items);
 
@@ -653,43 +665,37 @@ test "OfferedPsks.parse rejects truncated and oversized binder lengths" {
     }
 }
 
-test "resumption binder derivation matches independently computed HKDF chain (SHA-256)" {
-    // Vector reuses the SHA-256 RFC 8448-style resumption PSK from
-    // key_schedule.zig's own resumption test so binder derivation is
-    // checked against a value derived independently of this module.
-    const key_schedule = @import("key_schedule.zig");
+test "resumption binder derivation matches an independently computed SHA-256 binder" {
+    // Checked-in literal, computed independently of this module (Python
+    // hashlib/hmac against the same RFC 8446 §4.2.11.2/§7.1 label chain) —
+    // not derived with the same `std.crypto.tls.hkdfExpandLabel` helper the
+    // implementation under test uses, so this actually detects a wrong
+    // label, wrong empty-hash input, or wrong transcript hash rather than
+    // only cross-checking this module against itself.
     const psk = hexBytes("c1392efd98f6932d62f5ccd42c724230871638e8ad0ac9ce9b2af89f5f919fed");
     const client_hello_prefix = "pretend-truncated-clienthello-bytes";
+    const expected = hexBytes("de7c7afec445f9419e4f769b6ef8e6371e1f599405eff6ecc014499f234a008e");
 
     var binder: [32]u8 = undefined;
     try deriveBinder(.sha256, &psk, client_hello_prefix, &binder);
-
-    // Independently recompute the same chain inline to cross-check.
-    var empty_hash: [32]u8 = undefined;
-    Sha256.hash("", &empty_hash, .{});
-    var early_secret = HkdfSha256.extract("", &psk);
-    var binder_key = tls.hkdfExpandLabel(HkdfSha256, early_secret, "res binder", &empty_hash, 32);
-    var finished_key = tls.hkdfExpandLabel(HkdfSha256, binder_key, "finished", "", 32);
-    var transcript: [32]u8 = undefined;
-    Sha256.hash(client_hello_prefix, &transcript, .{});
-    var expected: [32]u8 = undefined;
-    HmacSha256.create(&expected, &transcript, &finished_key);
-    crypto.secureZero(u8, &early_secret);
-    crypto.secureZero(u8, &binder_key);
-    crypto.secureZero(u8, &finished_key);
-
     try testing.expectEqualSlices(u8, &expected, &binder);
+
     try testing.expect(try verifyBinder(.sha256, &psk, client_hello_prefix, &binder));
     try testing.expect(!try verifyBinder(.sha256, &psk, "different prefix bytes here", &binder));
-
-    _ = key_schedule;
 }
 
-test "resumption binder derivation supports SHA-384 and rejects mismatched PSK length" {
+test "resumption binder derivation matches an independently computed SHA-384 binder" {
+    // Checked-in literal, independently computed (see the SHA-256 test
+    // above); the module's own concrete SHA-384 code path is entirely
+    // separate from the SHA-256 one, so this is not redundant with it.
     const psk384 = [_]u8{0x77} ** 48;
+    const expected = hexBytes(
+        "138b767e68513f232636a0d2b2c53d7a923ff2c0d7879985d4ea916281c5134" ++
+            "d3bc2b1ae31178e736fe22f2d906cfdd3",
+    );
     var binder: [48]u8 = undefined;
     try deriveBinder(.sha384, &psk384, "prefix", &binder);
-    try testing.expect(!std.mem.allEqual(u8, &binder, 0));
+    try testing.expectEqualSlices(u8, &expected, &binder);
 
     var short_binder: [47]u8 = undefined;
     try testing.expectError(error.InvalidSecretLength, deriveBinder(.sha384, &psk384, "prefix", &short_binder));

--- a/src/tls/pre_shared_key.zig
+++ b/src/tls/pre_shared_key.zig
@@ -604,6 +604,236 @@ test "writeOffer rejects illegal shapes without ever mutating the writer" {
     }
 }
 
+test "a literal framed ClientHello proves the exact binder truncation boundary" {
+    // A hand-assembled, fully framed ClientHello (handshake header through a
+    // trailing `pre_shared_key` extension with one identity "abcd" and one
+    // 32-byte binder), constructed byte-by-byte from the RFC 8446 grammar
+    // rather than via this module's own writer — every enclosing length
+    // (message, extensions vector, `pre_shared_key` extension, identities
+    // vector) is already final, exactly as the wire requires before hashing.
+    // The embedded binder itself was computed independently (Python
+    // hashlib/hmac, not this module) over the expected truncated prefix.
+    const message = hexBytes(
+        "0100006503037777777777777777777777777777777777777777777777777777" ++
+            "77777777777700000213010100003a002b00030203040029002f000a00046162" ++
+            "6364112233440021208f6e79d089388cd1e7ca42e346e44ba217289f0450609a" ++
+            "9827c4ee59f16568e6",
+    );
+    // The `pre_shared_key` extension_data begins at a fixed, independently
+    // computed offset within `message` (4-byte header + fixed ClientHello
+    // fields + the `supported_versions` extension that precedes it).
+    const ext_data_offset = 58;
+    const ext_data = message[ext_data_offset..];
+
+    var offered = try OfferedPsks.parse(ext_data);
+    try testing.expectEqual(@as(usize, 1), offered.count);
+    // Exactly the offset of the *2-byte binders-vector length field* —
+    // not the binder payload two bytes later.
+    try testing.expectEqual(@as(usize, 12), offered.binder_vector_offset);
+
+    const truncated_len = ext_data_offset + offered.binder_vector_offset;
+    try testing.expectEqual(@as(usize, 70), truncated_len);
+    const prefix = message[0..truncated_len];
+    const expected_prefix = hexBytes(
+        "0100006503037777777777777777777777777777777777777777777777777777" ++
+            "77777777777700000213010100003a002b00030203040029002f000a00046162" ++
+            "636411223344",
+    );
+    try testing.expectEqualSlices(u8, &expected_prefix, prefix);
+
+    const psk = [_]u8{0xaa} ** 32;
+    const expected_binder = hexBytes("8f6e79d089388cd1e7ca42e346e44ba217289f0450609a9827c4ee59f16568e6");
+    var binder: [32]u8 = undefined;
+    try deriveBinder(.sha256, &psk, prefix, &binder);
+    try testing.expectEqualSlices(u8, &expected_binder, &binder);
+
+    // Confirm the embedded pair's identity/binder round-trip through the
+    // borrowed paired iterator too.
+    var it = offered.pairs();
+    const pair = (try it.next()).?;
+    try testing.expectEqualStrings("abcd", pair.identity.identity);
+    try testing.expectEqual(@as(u32, 0x11223344), pair.identity.obfuscated_ticket_age);
+    try testing.expectEqualSlices(u8, &expected_binder, pair.binder);
+    try testing.expectEqual(@as(?OfferedPsks.PairIterator.Pair, null), try it.next());
+
+    // The offset is exact, not "close enough": hashing two bytes further
+    // (as if the binders-vector length field were mistakenly included in
+    // the prefix) must *not* reproduce the same binder.
+    var wrong_binder: [32]u8 = undefined;
+    try deriveBinder(.sha256, &psk, message[0 .. truncated_len + 2], &wrong_binder);
+    try testing.expect(!std.mem.eql(u8, &expected_binder, &wrong_binder));
+}
+
+test "every strict prefix of a valid OfferedPsks fixture is rejected, none silently accepted" {
+    // The `pre_shared_key` extension_data from the literal ClientHello
+    // fixture above: identities_len(2) + one identity(10) + binders_len(2)
+    // + one 32-byte binder(33). Every vector is length-prefixed and spans
+    // the whole fixture, so there is no shorter prefix that could
+    // coincidentally look complete.
+    const ext_data = hexBytes(
+        "000a000461626364112233440021208f6e79d089388cd1e7ca42e346e44ba217" ++
+            "289f0450609a9827c4ee59f16568e6",
+    );
+    try testing.expectEqual(@as(usize, 47), ext_data.len);
+    _ = try OfferedPsks.parse(&ext_data); // the full fixture does parse
+
+    var cut: usize = 0;
+    while (cut < ext_data.len) : (cut += 1) {
+        if (OfferedPsks.parse(ext_data[0..cut])) |_| {
+            std.debug.print("unexpected successful parse at cut={d}\n", .{cut});
+            return error.TestUnexpectedResult;
+        } else |_| {}
+    }
+}
+
+test "OfferedPsks identity length boundaries: zero, one, max representable, truncated" {
+    // identity length 0 is illegal regardless of what follows.
+    {
+        var buf: [64]u8 = undefined;
+        var w = messages.Writer{ .buf = &buf };
+        try w.u16_(6); // identities_len: 2(id_len)+0+4(age)
+        try w.u16_(0); // identity length 0
+        try w.bytes(&[_]u8{0} ** 4); // age
+        try w.u16_(33);
+        try w.u8_(32);
+        try w.bytes(&[_]u8{0} ** 32);
+        try testing.expectError(error.EmptyIdentity, OfferedPsks.parse(w.written()));
+    }
+    // identity length 1 (minimum non-empty) succeeds.
+    {
+        var buf: [64]u8 = undefined;
+        var w = messages.Writer{ .buf = &buf };
+        try w.u16_(7); // 2+1+4
+        try w.u16_(1);
+        try w.u8_('x');
+        try w.bytes(&[_]u8{0} ** 4);
+        try w.u16_(33);
+        try w.u8_(32);
+        try w.bytes(&[_]u8{0} ** 32);
+        const offered = try OfferedPsks.parse(w.written());
+        try testing.expectEqual(@as(usize, 1), offered.count);
+    }
+    // Declared identity length longer than the remaining identities-vector
+    // bytes (truncated identity) is a decode failure, not silently clamped.
+    {
+        var buf: [64]u8 = undefined;
+        var w = messages.Writer{ .buf = &buf };
+        try w.u16_(6); // claims 6, but only provides a 2-byte length + 2 bytes
+        try w.u16_(10); // identity claims length 10
+        try w.bytes(&[_]u8{ 'a', 'b' }); // only 2 bytes actually present
+        try testing.expectError(error.MalformedHandshake, OfferedPsks.parse(w.written()));
+    }
+    // Truncated obfuscated_ticket_age (identity present, age cut short).
+    {
+        var buf: [64]u8 = undefined;
+        var w = messages.Writer{ .buf = &buf };
+        try w.u16_(5); // 2(id_len)+1(id)+2(only 2 of 4 age bytes)
+        try w.u16_(1);
+        try w.u8_('x');
+        try w.bytes(&[_]u8{ 0, 0 }); // age truncated to 2 bytes
+        try testing.expectError(error.MalformedHandshake, OfferedPsks.parse(w.written()));
+    }
+}
+
+test "OfferedPsks vector-length boundaries: identities/binders zero, one-over, count mismatch" {
+    // identities_len = 0 is EmptyVector even with a well-formed binders
+    // vector following.
+    {
+        var buf: [64]u8 = undefined;
+        var w = messages.Writer{ .buf = &buf };
+        try w.u16_(0);
+        try w.u16_(33);
+        try w.u8_(32);
+        try w.bytes(&[_]u8{0} ** 32);
+        try testing.expectError(error.EmptyVector, OfferedPsks.parse(w.written()));
+    }
+    // binders_len = 0 is EmptyVector even with a well-formed identities
+    // vector preceding it.
+    {
+        var buf: [64]u8 = undefined;
+        var w = messages.Writer{ .buf = &buf };
+        try w.u16_(7);
+        try w.u16_(1);
+        try w.u8_('x');
+        try w.bytes(&[_]u8{0} ** 4);
+        try w.u16_(0);
+        try testing.expectError(error.EmptyVector, OfferedPsks.parse(w.written()));
+    }
+    // identities_len one byte short of what the single entry needs. Bytes
+    // after the truncation point are misinterpreted (this is a
+    // length-prefixed format, not self-delimiting), so the *specific*
+    // resulting error legitimately varies with the exact misalignment —
+    // this asserts only that decoding never silently succeeds.
+    {
+        var buf: [64]u8 = undefined;
+        var w = messages.Writer{ .buf = &buf };
+        try w.u16_(6); // needs 7 (2+1+4) for one entry; declares only 6
+        try w.u16_(1);
+        try w.u8_('x');
+        try w.bytes(&[_]u8{0} ** 4);
+        try w.u16_(33);
+        try w.u8_(32);
+        try w.bytes(&[_]u8{0} ** 32);
+        if (OfferedPsks.parse(w.written())) |_| {
+            return error.TestUnexpectedResult;
+        } else |_| {}
+    }
+    // Two identities, one binder: count mismatch.
+    {
+        var buf: [64]u8 = undefined;
+        var w = messages.Writer{ .buf = &buf };
+        try w.u16_(14); // two 7-byte entries
+        for (0..2) |_| {
+            try w.u16_(1);
+            try w.u8_('x');
+            try w.bytes(&[_]u8{0} ** 4);
+        }
+        try w.u16_(33);
+        try w.u8_(32);
+        try w.bytes(&[_]u8{0} ** 32);
+        try testing.expectError(error.CountMismatch, OfferedPsks.parse(w.written()));
+    }
+    // One identity, two binders: count mismatch the other direction.
+    {
+        var buf: [96]u8 = undefined;
+        var w = messages.Writer{ .buf = &buf };
+        try w.u16_(7);
+        try w.u16_(1);
+        try w.u8_('x');
+        try w.bytes(&[_]u8{0} ** 4);
+        try w.u16_(66); // two 33-byte binder entries
+        for (0..2) |_| {
+            try w.u8_(32);
+            try w.bytes(&[_]u8{0} ** 32);
+        }
+        try testing.expectError(error.CountMismatch, OfferedPsks.parse(w.written()));
+    }
+}
+
+test "psk_key_exchange_modes: duplicate-mode bytes, single non-psk_dhe_ke mode, and every truncation" {
+    // Duplicate mode bytes are wire-legal (the vector is just a byte list;
+    // this module reports whether a mode is *present*, not distinctness) —
+    // `hasMode` still correctly reports presence.
+    const dup = [_]u8{ 2, 1, 1 }; // len=2, [psk_dhe_ke, psk_dhe_ke]
+    try testing.expect(try hasMode(&dup, .psk_dhe_ke));
+    try testing.expect(!try hasMode(&dup, .psk_ke));
+
+    // A single psk_ke-only offer: psk_dhe_ke is correctly reported absent
+    // (the #362 profile only ever selects psk_dhe_ke, so the backend must
+    // treat this as "PSK not usable", not error).
+    var buf: [8]u8 = undefined;
+    var w = messages.Writer{ .buf = &buf };
+    try writeModes(&w, &.{.psk_ke});
+    try testing.expect(!try hasMode(w.written(), .psk_dhe_ke));
+
+    // Every strict prefix of a valid modes vector is rejected.
+    const valid = [_]u8{ 2, 0, 1 };
+    var cut: usize = 0;
+    while (cut < valid.len) : (cut += 1) {
+        try testing.expectError(error.MalformedHandshake, hasMode(valid[0..cut], .psk_dhe_ke));
+    }
+}
+
 test "OfferedPsks encode/decode round-trip via writeOffer and parse" {
     var buf: [512]u8 = undefined;
     var w = messages.Writer{ .buf = &buf };

--- a/src/tls/pre_shared_key.zig
+++ b/src/tls/pre_shared_key.zig
@@ -733,6 +733,28 @@ test "OfferedPsks identity length boundaries: zero, one, max representable, trun
         try w.bytes(&[_]u8{ 0, 0 }); // age truncated to 2 bytes
         try testing.expectError(error.MalformedHandshake, OfferedPsks.parse(w.written()));
     }
+    // The maximum representable single-entry identity length: the
+    // enclosing identities_len field is itself a u16, so the largest a
+    // lone identity can be is 65535 - 2 (its own length prefix) - 4 (age).
+    {
+        const max_identity_len = std.math.maxInt(u16) - 2 - 4;
+        const total = 2 + (2 + max_identity_len + 4) + 2 + (1 + 32);
+        const buf = try testing.allocator.alloc(u8, total);
+        defer testing.allocator.free(buf);
+        var w = messages.Writer{ .buf = buf };
+        try w.u16_(@intCast(2 + max_identity_len + 4));
+        try w.u16_(@intCast(max_identity_len));
+        try w.bytes(&[_]u8{'x'} ** max_identity_len);
+        try w.bytes(&[_]u8{0} ** 4);
+        try w.u16_(33);
+        try w.u8_(32);
+        try w.bytes(&[_]u8{0} ** 32);
+        const offered = try OfferedPsks.parse(w.written());
+        try testing.expectEqual(@as(usize, 1), offered.count);
+        var it = offered.pairs();
+        const pair = (try it.next()).?;
+        try testing.expectEqual(max_identity_len, pair.identity.identity.len);
+    }
 }
 
 test "OfferedPsks vector-length boundaries: identities/binders zero, one-over, count mismatch" {

--- a/src/tls/pre_shared_key.zig
+++ b/src/tls/pre_shared_key.zig
@@ -1,0 +1,650 @@
+//! TLS 1.3 resumption `pre_shared_key` / `psk_key_exchange_modes` extensions
+//! (RFC 8446 §4.2.11, RFC 9846). Resumption PSKs only — no external PSKs, no
+//! `ext binder`, no `psk_ke` selection, no 0-RTT.
+//!
+//! Owns only:
+//!   - `psk_key_exchange_modes` encode/decode;
+//!   - `OfferedPsks` (identities + binders) encode/decode and borrowed
+//!     paired iteration;
+//!   - the exact ClientHello binder-vector offset calculation;
+//!   - resumption binder derivation/verification for SHA-256 and SHA-384;
+//!   - obfuscated-ticket-age and age-observation helpers;
+//!   - the owned, move-oriented client offer set (`ClientPskOfferSet`);
+//!   - the provider-neutral server resolver contract (`ServerPskResolver`).
+//!
+//! It does not parse ClientHello beyond this one extension, does not choose
+//! the final selected identity (that is the backend's server-selection
+//! algorithm), does not own full-handshake fallback, and must not import
+//! cache, keyring, HTTP, QUIC packet, record-layer, or runtime policy types.
+
+const std = @import("std");
+const provider = @import("crypto").provider;
+const messages = @import("messages.zig");
+const session = @import("session.zig");
+
+const crypto = std.crypto;
+const tls = crypto.tls;
+const Sha256 = crypto.hash.sha2.Sha256;
+const Sha384 = crypto.hash.sha2.Sha384;
+const HmacSha384 = crypto.auth.hmac.sha2.HmacSha384;
+const HmacSha256 = crypto.auth.hmac.sha2.HmacSha256;
+const HkdfSha384 = crypto.kdf.hkdf.Hkdf(HmacSha384);
+const HkdfSha256 = crypto.kdf.hkdf.HkdfSha256;
+
+pub const ext_pre_shared_key: u16 = 41;
+pub const ext_psk_key_exchange_modes: u16 = 45;
+
+/// Hard ceiling on offered/candidate identities per ClientHello (also the
+/// bound on server-side identity-resolution attempts).
+pub const max_offered_identities: usize = 8;
+
+pub const min_binder_len: usize = 32;
+pub const max_binder_len: usize = 255;
+
+pub const PskKeyExchangeMode = enum(u8) {
+    psk_ke = 0,
+    psk_dhe_ke = 1,
+};
+
+pub const WriteError = messages.WriteError || error{TooManyIdentities};
+
+pub const ReadError = error{
+    MalformedHandshake,
+    EmptyVector,
+    EmptyIdentity,
+    CountMismatch,
+    InvalidBinderLength,
+};
+
+pub const BinderError = error{InvalidSecretLength};
+
+// -----------------------------------------------------------------------
+// psk_key_exchange_modes (RFC 8446 §4.2.9)
+// -----------------------------------------------------------------------
+
+/// Writes `struct { PskKeyExchangeMode ke_modes<1..255>; }` into `w`.
+pub fn writeModes(w: *messages.Writer, modes: []const PskKeyExchangeMode) messages.WriteError!void {
+    const len_idx = try w.reserve(1);
+    for (modes) |m| try w.u8_(@intFromEnum(m));
+    w.patch(1, len_idx);
+}
+
+/// Whether `mode` appears in a decoded `psk_key_exchange_modes` extension
+/// body. Malformed length/truncation/trailing bytes are decode failures.
+pub fn hasMode(ext_data: []const u8, mode: PskKeyExchangeMode) ReadError!bool {
+    var r = messages.Reader{ .bytes = ext_data };
+    const len = try r.u8_();
+    if (len == 0) return error.EmptyVector;
+    const list = try r.slice(len);
+    try r.expectEnd();
+    return std.mem.indexOfScalar(u8, list, @intFromEnum(mode)) != null;
+}
+
+// -----------------------------------------------------------------------
+// OfferedPsks (RFC 8446 §4.2.11): PskIdentity identities, PskBinderEntry
+// binders.
+// -----------------------------------------------------------------------
+
+pub const Identity = struct {
+    identity: []const u8,
+    obfuscated_ticket_age: u32,
+};
+
+/// A parsed, borrowed view over a received `pre_shared_key` extension body.
+/// Identities and binders are validated to be non-empty, well-formed, and
+/// of exactly equal entry count at parse time; per-entry contents are read
+/// lazily through `pairs()`.
+pub const OfferedPsks = struct {
+    identities_bytes: []const u8,
+    binders_bytes: []const u8,
+    /// Offset within the extension body (`ext_data`) where the 2-byte
+    /// binders-vector length field begins. Binders are computed over the
+    /// exact framed ClientHello up to (but excluding) this point — see
+    /// `deriveBinder`.
+    binder_vector_offset: usize,
+    count: usize,
+
+    pub fn parse(ext_data: []const u8) ReadError!OfferedPsks {
+        var r = messages.Reader{ .bytes = ext_data };
+        const identities_len = try r.u16_();
+        if (identities_len == 0) return error.EmptyVector;
+        const identities_bytes = try r.slice(identities_len);
+
+        const binder_vector_offset = r.offset;
+        const binders_len = try r.u16_();
+        if (binders_len == 0) return error.EmptyVector;
+        const binders_bytes = try r.slice(binders_len);
+        try r.expectEnd();
+
+        var id_count: usize = 0;
+        {
+            var ir = messages.Reader{ .bytes = identities_bytes };
+            while (ir.remaining() > 0) {
+                const id_len = try ir.u16_();
+                if (id_len == 0) return error.EmptyIdentity;
+                _ = try ir.slice(id_len);
+                _ = try ir.slice(4); // obfuscated_ticket_age
+                id_count += 1;
+            }
+        }
+        var binder_count: usize = 0;
+        {
+            var br = messages.Reader{ .bytes = binders_bytes };
+            while (br.remaining() > 0) {
+                const blen = try br.u8_();
+                if (blen < min_binder_len or blen > max_binder_len) return error.InvalidBinderLength;
+                _ = try br.slice(blen);
+                binder_count += 1;
+            }
+        }
+        if (id_count == 0 or binder_count == 0) return error.EmptyVector;
+        if (id_count != binder_count) return error.CountMismatch;
+
+        return .{
+            .identities_bytes = identities_bytes,
+            .binders_bytes = binders_bytes,
+            .binder_vector_offset = binder_vector_offset,
+            .count = id_count,
+        };
+    }
+
+    pub const PairIterator = struct {
+        id_reader: messages.Reader,
+        binder_reader: messages.Reader,
+
+        pub const Pair = struct { identity: Identity, binder: []const u8 };
+
+        pub fn next(self: *PairIterator) ReadError!?Pair {
+            if (self.id_reader.remaining() == 0) return null;
+            const id_len = try self.id_reader.u16_();
+            const identity = try self.id_reader.slice(id_len);
+            const age_bytes = try self.id_reader.slice(4);
+            const age = std.mem.readInt(u32, age_bytes[0..4], .big);
+            const blen = try self.binder_reader.u8_();
+            const binder = try self.binder_reader.slice(blen);
+            return .{ .identity = .{ .identity = identity, .obfuscated_ticket_age = age }, .binder = binder };
+        }
+    };
+
+    /// A borrowed, in-order (identity, binder) iterator. Both vectors were
+    /// already validated to have exactly equal, well-formed entry counts by
+    /// `parse`, so this cannot desynchronize.
+    pub fn pairs(self: *const OfferedPsks) PairIterator {
+        return .{
+            .id_reader = .{ .bytes = self.identities_bytes },
+            .binder_reader = .{ .bytes = self.binders_bytes },
+        };
+    }
+};
+
+pub const OfferItem = struct {
+    identity: []const u8,
+    obfuscated_ticket_age: u32,
+    /// The binder digest length for this identity's associated hash
+    /// (32 for SHA-256, 48 for SHA-384) — the caller computes and
+    /// overwrites this many placeholder bytes after `writeOffer` returns.
+    digest_len: usize,
+};
+
+pub const BinderSlot = struct { offset: usize, len: usize };
+
+pub const ClientOfferWrite = struct {
+    /// The exact prefix of the framed ClientHello (measured from the start
+    /// of the writer's buffer, i.e. including the handshake header) that
+    /// every binder must be computed over, once every enclosing length
+    /// field — message, extensions block, this extension, identities, and
+    /// binders — has been patched to its final value (RFC 8446 §4.2.11.2).
+    truncated_len: usize,
+    slots: [max_offered_identities]BinderSlot = undefined,
+    count: usize = 0,
+};
+
+/// Writes the `pre_shared_key` extension: identities followed by
+/// zero-valued binder placeholders sized to each item's digest length, with
+/// every length field patched. Per RFC 8446 §4.2.11, this must be the last
+/// extension the caller writes into `w`; the caller still patches the
+/// outer extensions-vector and message-length fields afterward, and must do
+/// so *before* hashing `w.written()[0..result.truncated_len]` — see
+/// `deriveBinder`. Returns the binder slot positions so the caller can
+/// overwrite each placeholder with the real binder afterward.
+pub fn writeOffer(w: *messages.Writer, items: []const OfferItem) WriteError!ClientOfferWrite {
+    if (items.len == 0 or items.len > max_offered_identities) return error.TooManyIdentities;
+
+    try w.u16_(ext_pre_shared_key);
+    const ext_len_idx = try w.reserve(2);
+
+    const ids_len_idx = try w.reserve(2);
+    for (items) |item| {
+        try w.u16_(@intCast(item.identity.len));
+        try w.bytes(item.identity);
+        var age_bytes: [4]u8 = undefined;
+        std.mem.writeInt(u32, &age_bytes, item.obfuscated_ticket_age, .big);
+        try w.bytes(&age_bytes);
+    }
+    w.patch(2, ids_len_idx);
+
+    var result: ClientOfferWrite = .{ .truncated_len = w.len };
+
+    const binders_len_idx = try w.reserve(2);
+    for (items, 0..) |item, i| {
+        const entry_len_idx = try w.reserve(1);
+        const slot_offset = w.len;
+        const zeros = [_]u8{0} ** provider.max_digest_len;
+        try w.bytes(zeros[0..item.digest_len]);
+        w.patch(1, entry_len_idx);
+        result.slots[i] = .{ .offset = slot_offset, .len = item.digest_len };
+        result.count += 1;
+    }
+    w.patch(2, binders_len_idx);
+    w.patch(2, ext_len_idx);
+    return result;
+}
+
+// -----------------------------------------------------------------------
+// Resumption binder derivation (RFC 8446 §4.2.11.2, §7.1):
+//   early_secret  = HKDF-Extract(0, PSK)
+//   binder_key    = Derive-Secret(early_secret, "res binder", "")
+//   finished_key  = HKDF-Expand-Label(binder_key, "finished", "", L)
+//   binder        = HMAC(finished_key, Hash(truncated ClientHello))
+// -----------------------------------------------------------------------
+
+/// Derives the resumption binder for `psk` (already exactly
+/// `hash.digestLength()` bytes — the caller derives it via
+/// `key_schedule.KeySchedule.resumptionPsk`) over `truncated_client_hello`
+/// (the exact framed-message prefix ending just before the binders
+/// vector's own length field) into `out` (must be exactly
+/// `hash.digestLength()` bytes).
+pub fn deriveBinder(
+    hash: provider.Hash,
+    psk: []const u8,
+    truncated_client_hello: []const u8,
+    out: []u8,
+) BinderError!void {
+    const expected_len = hash.digestLength();
+    if (psk.len != expected_len or out.len != expected_len) return error.InvalidSecretLength;
+    switch (hash) {
+        .sha256 => {
+            var empty_hash: [Sha256.digest_length]u8 = undefined;
+            Sha256.hash("", &empty_hash, .{});
+
+            var psk_fixed: [Sha256.digest_length]u8 = undefined;
+            @memcpy(&psk_fixed, psk);
+            defer crypto.secureZero(u8, &psk_fixed);
+
+            var early_secret = HkdfSha256.extract("", &psk_fixed);
+            defer crypto.secureZero(u8, &early_secret);
+            var binder_key = tls.hkdfExpandLabel(HkdfSha256, early_secret, "res binder", &empty_hash, Sha256.digest_length);
+            defer crypto.secureZero(u8, &binder_key);
+            var finished_key = tls.hkdfExpandLabel(HkdfSha256, binder_key, "finished", "", Sha256.digest_length);
+            defer crypto.secureZero(u8, &finished_key);
+
+            var transcript_hash: [Sha256.digest_length]u8 = undefined;
+            Sha256.hash(truncated_client_hello, &transcript_hash, .{});
+            var mac: [HmacSha256.mac_length]u8 = undefined;
+            HmacSha256.create(&mac, &transcript_hash, &finished_key);
+            @memcpy(out, &mac);
+        },
+        .sha384 => {
+            var empty_hash: [Sha384.digest_length]u8 = undefined;
+            Sha384.hash("", &empty_hash, .{});
+
+            var psk_fixed: [HmacSha384.mac_length]u8 = undefined;
+            @memcpy(&psk_fixed, psk);
+            defer crypto.secureZero(u8, &psk_fixed);
+
+            var early_secret = HkdfSha384.extract("", &psk_fixed);
+            defer crypto.secureZero(u8, &early_secret);
+            var binder_key = tls.hkdfExpandLabel(HkdfSha384, early_secret, "res binder", &empty_hash, HmacSha384.mac_length);
+            defer crypto.secureZero(u8, &binder_key);
+            var finished_key = tls.hkdfExpandLabel(HkdfSha384, binder_key, "finished", "", HmacSha384.mac_length);
+            defer crypto.secureZero(u8, &finished_key);
+
+            var transcript_hash: [Sha384.digest_length]u8 = undefined;
+            Sha384.hash(truncated_client_hello, &transcript_hash, .{});
+            var mac: [HmacSha384.mac_length]u8 = undefined;
+            HmacSha384.create(&mac, &transcript_hash, &finished_key);
+            @memcpy(out, &mac);
+        },
+    }
+}
+
+/// Constant-time binder verification: derives the expected binder for `psk`
+/// over `truncated_client_hello` and compares it against `candidate_binder`
+/// without early-exiting on a byte mismatch. A length mismatch (the binder
+/// on the wire is not `hash.digestLength()` bytes) is reported as a
+/// non-match, not an error — a wrong-length binder is simply wrong.
+pub fn verifyBinder(
+    hash: provider.Hash,
+    psk: []const u8,
+    truncated_client_hello: []const u8,
+    candidate_binder: []const u8,
+) BinderError!bool {
+    var computed: [provider.max_digest_len]u8 = undefined;
+    const out = computed[0..hash.digestLength()];
+    defer crypto.secureZero(u8, out);
+    try deriveBinder(hash, psk, truncated_client_hello, out);
+    if (out.len != candidate_binder.len) return false;
+    return switch (out.len) {
+        32 => crypto.timing_safe.eql([32]u8, out[0..32].*, candidate_binder[0..32].*),
+        48 => crypto.timing_safe.eql([48]u8, out[0..48].*, candidate_binder[0..48].*),
+        else => false,
+    };
+}
+
+// -----------------------------------------------------------------------
+// Obfuscated ticket age (RFC 8446 §4.2.11.1).
+// -----------------------------------------------------------------------
+
+/// `obfuscated_ticket_age = uint32(age_ms mod 2^32) +% ticket_age_add`.
+pub fn obfuscateTicketAge(age_ms: u64, ticket_age_add: u32) u32 {
+    const age_mod: u32 = @truncate(age_ms);
+    return age_mod +% ticket_age_add;
+}
+
+/// Recovers the client's apparent ticket age via wrapping subtraction.
+pub fn deobfuscateTicketAge(obfuscated_ticket_age: u32, ticket_age_add: u32) u32 {
+    return obfuscated_ticket_age -% ticket_age_add;
+}
+
+pub const AgeSkew = struct {
+    /// The apparent age the client reported (after deobfuscation).
+    apparent_age_ms: u32,
+    /// The server's own view of elapsed time since issuance.
+    actual_age_ms: u64,
+    /// `apparent - actual`, in milliseconds; positive means the client
+    /// reported an older ticket than the server's clock would expect.
+    skew_ms: i64,
+};
+
+/// Computes the signed age-skew observation used by #366 to reject or allow
+/// early data; skew alone never rejects ordinary 1-RTT resumption.
+pub fn observeAgeSkew(obfuscated_ticket_age: u32, ticket_age_add: u32, actual_age_ms: u64) AgeSkew {
+    const apparent = deobfuscateTicketAge(obfuscated_ticket_age, ticket_age_add);
+    const bounded_actual: i64 = @intCast(@min(actual_age_ms, @as(u64, std.math.maxInt(i64))));
+    return .{
+        .apparent_age_ms = apparent,
+        .actual_age_ms = actual_age_ms,
+        .skew_ms = @as(i64, apparent) - bounded_actual,
+    };
+}
+
+// -----------------------------------------------------------------------
+// Client offer ownership.
+// -----------------------------------------------------------------------
+
+/// An owned, move-oriented set of resumption tickets a client may offer,
+/// bounded to `max_offered_identities`. The backend takes ownership of a
+/// caller-built set at ClientHello emission and is responsible for wiping
+/// every entry on every success, fallback, and teardown path.
+pub const ClientPskOfferSet = struct {
+    tickets: [max_offered_identities]session.ClientTicketState = [_]session.ClientTicketState{.{}} ** max_offered_identities,
+    len: usize = 0,
+
+    pub const Error = error{TooManyOffers};
+
+    /// Moves ownership of `ticket` into the set; `ticket` is zero-valued on
+    /// success. Fails (leaving `ticket` untouched) once the set is full.
+    pub fn push(self: *ClientPskOfferSet, ticket: *session.ClientTicketState) Error!void {
+        if (self.len >= max_offered_identities) return error.TooManyOffers;
+        self.tickets[self.len].moveFrom(ticket);
+        self.len += 1;
+    }
+
+    pub fn slice(self: *ClientPskOfferSet) []session.ClientTicketState {
+        return self.tickets[0..self.len];
+    }
+
+    pub fn constSlice(self: *const ClientPskOfferSet) []const session.ClientTicketState {
+        return self.tickets[0..self.len];
+    }
+
+    pub fn isEmpty(self: *const ClientPskOfferSet) bool {
+        return self.len == 0;
+    }
+
+    /// Transfers ownership of `source`'s tickets into `self`, deinitializing
+    /// whatever `self` previously held first. `source` is left empty.
+    pub fn moveFrom(self: *ClientPskOfferSet, source: *ClientPskOfferSet) void {
+        if (self == source) return;
+        self.deinit();
+        self.* = source.*;
+        source.* = .{};
+    }
+
+    /// Wipes and deinitializes every remaining offer (unselected offers
+    /// after a selection, or the whole set when the server did not select
+    /// PSK, or on any error/teardown path).
+    pub fn deinit(self: *ClientPskOfferSet) void {
+        for (self.tickets[0..self.len]) |*t| t.deinit();
+        self.len = 0;
+    }
+
+    /// Moves the ticket at `index` out into `dest` (the backend's resumed
+    /// session state) and wipes every other, now-unselected offer.
+    pub fn takeSelected(self: *ClientPskOfferSet, index: usize, dest: *session.ClientTicketState) void {
+        dest.moveFrom(&self.tickets[index]);
+        self.deinit();
+    }
+};
+
+// -----------------------------------------------------------------------
+// Server resolver contract, shared by stateful (#364) and stateless (#363)
+// providers.
+// -----------------------------------------------------------------------
+
+pub const ResolveError = error{ResolverFailed};
+
+/// Provider-neutral identity resolver. `resolveFn` returns `true` with a
+/// completely owned, zero-valued-on-failure `out` when `identity` is a
+/// usable ticket/session identity; `false` (with `out` left untouched/zero)
+/// for any malformed, unknown, retired, or otherwise unusable identity —
+/// including a stateless envelope's own decode/authentication failures
+/// (#363), which are never distinguished from "unknown" at this contract.
+/// Operational failures (allocation, provider/configuration faults) are the
+/// typed `ResolveError`, never silently folded into an ordinary `false`.
+pub const ServerPskResolver = struct {
+    ctx: *anyopaque,
+    nowUnixMsFn: *const fn (*anyopaque) i64,
+    resolveFn: *const fn (
+        ctx: *anyopaque,
+        identity: []const u8,
+        out: *session.ServerRecoverableState,
+    ) ResolveError!bool,
+
+    pub fn nowUnixMs(self: ServerPskResolver) i64 {
+        return self.nowUnixMsFn(self.ctx);
+    }
+
+    pub fn resolve(self: ServerPskResolver, identity: []const u8, out: *session.ServerRecoverableState) ResolveError!bool {
+        return self.resolveFn(self.ctx, identity, out);
+    }
+};
+
+// -----------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------
+
+const testing = std.testing;
+
+test "psk_key_exchange_modes round-trips and rejects malformed vectors" {
+    var buf: [16]u8 = undefined;
+    var w = messages.Writer{ .buf = &buf };
+    try writeModes(&w, &.{ .psk_ke, .psk_dhe_ke });
+    try testing.expectEqualSlices(u8, &.{ 2, 0, 1 }, w.written());
+
+    try testing.expect(try hasMode(w.written(), .psk_dhe_ke));
+    try testing.expect(try hasMode(w.written(), .psk_ke));
+
+    // Empty vector.
+    try testing.expectError(error.EmptyVector, hasMode(&.{0}, .psk_dhe_ke));
+    // Truncated (declares 2 bytes, has 1).
+    try testing.expectError(error.MalformedHandshake, hasMode(&.{ 2, 1 }, .psk_dhe_ke));
+    // Trailing bytes after the declared vector.
+    try testing.expectError(error.MalformedHandshake, hasMode(&.{ 1, 1, 0xff }, .psk_dhe_ke));
+}
+
+test "OfferedPsks encode/decode round-trip via writeOffer and parse" {
+    var buf: [512]u8 = undefined;
+    var w = messages.Writer{ .buf = &buf };
+    const items = [_]OfferItem{
+        .{ .identity = "ticket-one", .obfuscated_ticket_age = 0x11223344, .digest_len = 32 },
+        .{ .identity = "ticket-two", .obfuscated_ticket_age = 0xaabbccdd, .digest_len = 48 },
+    };
+    const offer = try writeOffer(&w, &items);
+    try testing.expectEqual(@as(usize, 2), offer.count);
+
+    // ext_id(2) + ext_len(2) precede the region writeOffer wrote.
+    const ext_data = w.written()[4..];
+    var parsed = try OfferedPsks.parse(ext_data);
+    try testing.expectEqual(@as(usize, 2), parsed.count);
+
+    var it = parsed.pairs();
+    const first = (try it.next()).?;
+    try testing.expectEqualStrings("ticket-one", first.identity.identity);
+    try testing.expectEqual(@as(u32, 0x11223344), first.identity.obfuscated_ticket_age);
+    try testing.expectEqual(@as(usize, 32), first.binder.len);
+    try testing.expect(std.mem.allEqual(u8, first.binder, 0)); // placeholder, not yet patched
+
+    const second = (try it.next()).?;
+    try testing.expectEqualStrings("ticket-two", second.identity.identity);
+    try testing.expectEqual(@as(usize, 48), second.binder.len);
+
+    try testing.expectEqual(@as(?OfferedPsks.PairIterator.Pair, null), try it.next());
+}
+
+test "OfferedPsks.parse rejects mismatched identity/binder counts" {
+    // One identity, zero binders.
+    var buf: [64]u8 = undefined;
+    var w = messages.Writer{ .buf = &buf };
+    const id_len_idx = try w.reserve(2);
+    try w.u16_(4);
+    try w.bytes("abcd");
+    try w.bytes(&[_]u8{0} ** 4); // age
+    w.patch(2, id_len_idx);
+    try w.u16_(0); // empty binders vector length -- caught as EmptyVector first
+    try testing.expectError(error.EmptyVector, OfferedPsks.parse(w.written()));
+}
+
+test "OfferedPsks.parse rejects truncated and oversized binder lengths" {
+    var buf: [64]u8 = undefined;
+
+    // Binder length 31 (< 32) is illegal.
+    {
+        var w = messages.Writer{ .buf = &buf };
+        const id_len_idx = try w.reserve(2);
+        try w.u16_(4);
+        try w.bytes("abcd");
+        try w.bytes(&[_]u8{0} ** 4);
+        w.patch(2, id_len_idx);
+        const b_len_idx = try w.reserve(2);
+        try w.u8_(31);
+        try w.bytes(&[_]u8{0} ** 31);
+        w.patch(2, b_len_idx);
+        try testing.expectError(error.InvalidBinderLength, OfferedPsks.parse(w.written()));
+    }
+}
+
+test "resumption binder derivation matches independently computed HKDF chain (SHA-256)" {
+    // Vector reuses the SHA-256 RFC 8448-style resumption PSK from
+    // key_schedule.zig's own resumption test so binder derivation is
+    // checked against a value derived independently of this module.
+    const key_schedule = @import("key_schedule.zig");
+    const psk = hexBytes("c1392efd98f6932d62f5ccd42c724230871638e8ad0ac9ce9b2af89f5f919fed");
+    const client_hello_prefix = "pretend-truncated-clienthello-bytes";
+
+    var binder: [32]u8 = undefined;
+    try deriveBinder(.sha256, &psk, client_hello_prefix, &binder);
+
+    // Independently recompute the same chain inline to cross-check.
+    var empty_hash: [32]u8 = undefined;
+    Sha256.hash("", &empty_hash, .{});
+    var early_secret = HkdfSha256.extract("", &psk);
+    var binder_key = tls.hkdfExpandLabel(HkdfSha256, early_secret, "res binder", &empty_hash, 32);
+    var finished_key = tls.hkdfExpandLabel(HkdfSha256, binder_key, "finished", "", 32);
+    var transcript: [32]u8 = undefined;
+    Sha256.hash(client_hello_prefix, &transcript, .{});
+    var expected: [32]u8 = undefined;
+    HmacSha256.create(&expected, &transcript, &finished_key);
+    crypto.secureZero(u8, &early_secret);
+    crypto.secureZero(u8, &binder_key);
+    crypto.secureZero(u8, &finished_key);
+
+    try testing.expectEqualSlices(u8, &expected, &binder);
+    try testing.expect(try verifyBinder(.sha256, &psk, client_hello_prefix, &binder));
+    try testing.expect(!try verifyBinder(.sha256, &psk, "different prefix bytes here", &binder));
+
+    _ = key_schedule;
+}
+
+test "resumption binder derivation supports SHA-384 and rejects mismatched PSK length" {
+    const psk384 = [_]u8{0x77} ** 48;
+    var binder: [48]u8 = undefined;
+    try deriveBinder(.sha384, &psk384, "prefix", &binder);
+    try testing.expect(!std.mem.allEqual(u8, &binder, 0));
+
+    var short_binder: [47]u8 = undefined;
+    try testing.expectError(error.InvalidSecretLength, deriveBinder(.sha384, &psk384, "prefix", &short_binder));
+    try testing.expectError(error.InvalidSecretLength, deriveBinder(.sha256, &psk384, "prefix", short_binder[0..32]));
+}
+
+test "verifyBinder rejects a wrong-length candidate without erroring" {
+    const psk = [_]u8{0x11} ** 32;
+    var binder: [32]u8 = undefined;
+    try deriveBinder(.sha256, &psk, "prefix", &binder);
+    try testing.expect(!try verifyBinder(.sha256, &psk, "prefix", binder[0..31]));
+}
+
+test "obfuscated ticket age round-trips including u32 wraparound" {
+    const add: u32 = 0xffff_fff0;
+    const age_ms: u64 = 1000;
+    const obfuscated = obfuscateTicketAge(age_ms, add);
+    try testing.expectEqual(@as(u32, 1000) +% add, obfuscated);
+    try testing.expectEqual(@as(u32, 1000), deobfuscateTicketAge(obfuscated, add));
+
+    // age_ms itself exceeds 2^32: only the low 32 bits participate.
+    const huge_age: u64 = (@as(u64, 1) << 33) + 42;
+    const obfuscated2 = obfuscateTicketAge(huge_age, add);
+    try testing.expectEqual(@as(u32, 42) +% add, obfuscated2);
+}
+
+test "age skew observation reports signed drift without rejecting on its own" {
+    const add: u32 = 500;
+    const obfuscated = obfuscateTicketAge(10_000, add);
+    const skew = observeAgeSkew(obfuscated, add, 9_000);
+    try testing.expectEqual(@as(u32, 10_000), skew.apparent_age_ms);
+    try testing.expectEqual(@as(i64, 1_000), skew.skew_ms);
+}
+
+test "ClientPskOfferSet is bounded to eight, move-oriented, and fully wiped on deinit" {
+    var set: ClientPskOfferSet = .{};
+    var common: session.ResumableSessionCommon = .{};
+    try common.init(testing.allocator, .default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = &([_]u8{0x42} ** 32),
+        .auth_binding = .{ .bytes = [_]u8{0} ** session.auth_binding_len },
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 1000,
+    });
+    var ticket: session.ClientTicketState = .{};
+    try ticket.init(testing.allocator, .default, &common, .{
+        .ticket = "opaque-ticket",
+        .ticket_age_add = 7,
+        .ticket_nonce = "n",
+        .received_at_unix_ms = 0,
+    });
+    try set.push(&ticket);
+    try testing.expectEqual(@as(usize, 0), ticket.ticket.slice().len); // moved out
+    try testing.expectEqual(@as(usize, 1), set.len);
+
+    var dest: session.ClientTicketState = .{};
+    set.takeSelected(0, &dest);
+    try testing.expectEqualStrings("opaque-ticket", dest.ticket.slice());
+    try testing.expectEqual(@as(usize, 0), set.len);
+    dest.deinit();
+}
+
+fn hexBytes(comptime hex: []const u8) [hex.len / 2]u8 {
+    var bytes: [hex.len / 2]u8 = undefined;
+    _ = std.fmt.hexToBytes(&bytes, hex) catch unreachable;
+    return bytes;
+}

--- a/src/tls/pre_shared_key.zig
+++ b/src/tls/pre_shared_key.zig
@@ -46,7 +46,15 @@ pub const PskKeyExchangeMode = enum(u8) {
     psk_dhe_ke = 1,
 };
 
-pub const WriteError = messages.WriteError || error{TooManyIdentities};
+pub const WriteError = messages.WriteError || error{
+    TooManyIdentities,
+    EmptyIdentity,
+    IdentityTooLarge,
+    IdentitiesVectorTooLarge,
+    InvalidBinderLength,
+    BindersVectorTooLarge,
+    ExtensionTooLarge,
+};
 
 pub const ReadError = error{
     MalformedHandshake,
@@ -62,8 +70,14 @@ pub const BinderError = error{InvalidSecretLength};
 // psk_key_exchange_modes (RFC 8446 §4.2.9)
 // -----------------------------------------------------------------------
 
-/// Writes `struct { PskKeyExchangeMode ke_modes<1..255>; }` into `w`.
-pub fn writeModes(w: *messages.Writer, modes: []const PskKeyExchangeMode) messages.WriteError!void {
+pub const ModeError = error{ EmptyModes, TooManyModes };
+
+/// Writes `struct { PskKeyExchangeMode ke_modes<1..255>; }` into `w`. Rejects
+/// an empty or over-255 list before touching `w` — the 1-byte vector length
+/// otherwise cannot represent the count, and patching it would trap.
+pub fn writeModes(w: *messages.Writer, modes: []const PskKeyExchangeMode) (messages.WriteError || ModeError)!void {
+    if (modes.len == 0) return error.EmptyModes;
+    if (modes.len > 255) return error.TooManyModes;
     const len_idx = try w.reserve(1);
     for (modes) |m| try w.u8_(@intFromEnum(m));
     w.patch(1, len_idx);
@@ -199,6 +213,8 @@ pub const ClientOfferWrite = struct {
     count: usize = 0,
 };
 
+pub const max_vector_len = std.math.maxInt(u16);
+
 /// Writes the `pre_shared_key` extension: identities followed by
 /// zero-valued binder placeholders sized to each item's digest length, with
 /// every length field patched. Per RFC 8446 §4.2.11, this must be the last
@@ -207,8 +223,37 @@ pub const ClientOfferWrite = struct {
 /// so *before* hashing `w.written()[0..result.truncated_len]` — see
 /// `deriveBinder`. Returns the binder slot positions so the caller can
 /// overwrite each placeholder with the real binder afterward.
+///
+/// The complete structure — entry count, every identity length, and both
+/// vector totals — is validated against the wire's u16 vector limits before
+/// `w` is touched at all, so a caller-input structure this function's own
+/// parser would reject can never be written, and an oversized field can
+/// never reach the writer's `@intCast` length patch.
 pub fn writeOffer(w: *messages.Writer, items: []const OfferItem) WriteError!ClientOfferWrite {
     if (items.len == 0 or items.len > max_offered_identities) return error.TooManyIdentities;
+
+    var identities_total: usize = 0;
+    var binders_total: usize = 0;
+    for (items) |item| {
+        if (item.identity.len == 0) return error.EmptyIdentity;
+        if (item.identity.len > max_vector_len) return error.IdentityTooLarge;
+        identities_total += 2 + item.identity.len + 4;
+        if (identities_total > max_vector_len) return error.IdentitiesVectorTooLarge;
+        // This writer only ever produces the digest lengths the module's own
+        // binder derivation supports (32 for SHA-256, 48 for SHA-384), a
+        // stricter bound than the wire's general 32..255 `PskBinderEntry`
+        // range — and exactly what fits the fixed zero-placeholder buffer
+        // below.
+        if (item.digest_len < min_binder_len or item.digest_len > provider.max_digest_len)
+            return error.InvalidBinderLength;
+        binders_total += 1 + item.digest_len;
+        if (binders_total > max_vector_len) return error.BindersVectorTooLarge;
+    }
+    // extension_data = 2-byte identities_len + identities + 2-byte
+    // binders_len + binders; not itself wire-length-limited beyond the
+    // enclosing 2-byte extension-data length field.
+    const ext_data_len = 2 + identities_total + 2 + binders_total;
+    if (ext_data_len > max_vector_len) return error.ExtensionTooLarge;
 
     try w.u16_(ext_pre_shared_key);
     const ext_len_idx = try w.reserve(2);
@@ -483,6 +528,70 @@ test "psk_key_exchange_modes round-trips and rejects malformed vectors" {
     try testing.expectError(error.MalformedHandshake, hasMode(&.{ 1, 1, 0xff }, .psk_dhe_ke));
 }
 
+test "writeModes rejects empty and over-255 mode lists before touching the writer" {
+    var buf: [16]u8 = undefined;
+    var w = messages.Writer{ .buf = &buf };
+    try testing.expectError(error.EmptyModes, writeModes(&w, &.{}));
+    try testing.expectEqual(@as(usize, 0), w.len);
+
+    const too_many = [_]PskKeyExchangeMode{.psk_ke} ** 256;
+    try testing.expectError(error.TooManyModes, writeModes(&w, &too_many));
+    try testing.expectEqual(@as(usize, 0), w.len);
+}
+
+test "writeOffer rejects illegal shapes without ever mutating the writer" {
+    var buf: [512]u8 = undefined;
+
+    // Zero items.
+    {
+        var w = messages.Writer{ .buf = &buf };
+        try testing.expectError(error.TooManyIdentities, writeOffer(&w, &.{}));
+        try testing.expectEqual(@as(usize, 0), w.len);
+    }
+    // More than the maximum offered identities.
+    {
+        var w = messages.Writer{ .buf = &buf };
+        const items = [_]OfferItem{.{ .identity = "x", .obfuscated_ticket_age = 0, .digest_len = 32 }} ** (max_offered_identities + 1);
+        try testing.expectError(error.TooManyIdentities, writeOffer(&w, &items));
+        try testing.expectEqual(@as(usize, 0), w.len);
+    }
+    // Empty identity.
+    {
+        var w = messages.Writer{ .buf = &buf };
+        const items = [_]OfferItem{.{ .identity = "", .obfuscated_ticket_age = 0, .digest_len = 32 }};
+        try testing.expectError(error.EmptyIdentity, writeOffer(&w, &items));
+        try testing.expectEqual(@as(usize, 0), w.len);
+    }
+    // Binder/digest length outside what this module can produce (32..48).
+    {
+        var w = messages.Writer{ .buf = &buf };
+        const too_short = [_]OfferItem{.{ .identity = "id", .obfuscated_ticket_age = 0, .digest_len = min_binder_len - 1 }};
+        try testing.expectError(error.InvalidBinderLength, writeOffer(&w, &too_short));
+        try testing.expectEqual(@as(usize, 0), w.len);
+
+        var w2 = messages.Writer{ .buf = &buf };
+        const too_long = [_]OfferItem{.{ .identity = "id", .obfuscated_ticket_age = 0, .digest_len = provider.max_digest_len + 1 }};
+        try testing.expectError(error.InvalidBinderLength, writeOffer(&w2, &too_long));
+        try testing.expectEqual(@as(usize, 0), w2.len);
+    }
+    // Exact boundary values succeed: min/max supported digest length, and a
+    // full eight-identity offer.
+    {
+        var w = messages.Writer{ .buf = &buf };
+        const items = [_]OfferItem{
+            .{ .identity = "a", .obfuscated_ticket_age = 0, .digest_len = min_binder_len },
+            .{ .identity = "b", .obfuscated_ticket_age = 0, .digest_len = provider.max_digest_len },
+        };
+        _ = try writeOffer(&w, &items);
+
+        var w3 = messages.Writer{ .buf = &buf };
+        var eight: [max_offered_identities]OfferItem = undefined;
+        for (&eight) |*item| item.* = .{ .identity = "id", .obfuscated_ticket_age = 0, .digest_len = 32 };
+        const offer = try writeOffer(&w3, &eight);
+        try testing.expectEqual(max_offered_identities, offer.count);
+    }
+}
+
 test "OfferedPsks encode/decode round-trip via writeOffer and parse" {
     var buf: [512]u8 = undefined;
     var w = messages.Writer{ .buf = &buf };
@@ -641,6 +750,42 @@ test "ClientPskOfferSet is bounded to eight, move-oriented, and fully wiped on d
     try testing.expectEqualStrings("opaque-ticket", dest.ticket.slice());
     try testing.expectEqual(@as(usize, 0), set.len);
     dest.deinit();
+}
+
+test "ClientPskOfferSet accepts exactly eight offers and rejects a ninth" {
+    var set: ClientPskOfferSet = .{};
+    defer set.deinit();
+    var common: session.ResumableSessionCommon = .{};
+    try common.init(testing.allocator, .default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = &([_]u8{0x42} ** 32),
+        .auth_binding = .{ .bytes = [_]u8{0} ** session.auth_binding_len },
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 1000,
+    });
+    defer common.deinit();
+
+    var tickets: [max_offered_identities + 1]session.ClientTicketState = undefined;
+    for (&tickets, 0..) |*ticket, i| {
+        ticket.* = .{};
+        var clone: session.ResumableSessionCommon = .{};
+        try common.cloneInto(testing.allocator, &clone);
+        var id_buf: [1]u8 = .{@intCast(i)};
+        try ticket.init(testing.allocator, .default, &clone, .{
+            .ticket = &id_buf,
+            .ticket_age_add = 0,
+            .ticket_nonce = "n",
+            .received_at_unix_ms = 0,
+        });
+    }
+    defer for (&tickets) |*ticket| ticket.deinit();
+
+    for (tickets[0..max_offered_identities]) |*ticket| try set.push(ticket);
+    try testing.expectEqual(max_offered_identities, set.len);
+    try testing.expectError(error.TooManyOffers, set.push(&tickets[max_offered_identities]));
+    // A rejected push leaves both the set and the ticket untouched.
+    try testing.expectEqual(max_offered_identities, set.len);
+    try testing.expectEqualStrings(&[_]u8{max_offered_identities}, tickets[max_offered_identities].ticket.slice());
 }
 
 fn hexBytes(comptime hex: []const u8) [hex.len / 2]u8 {

--- a/src/tls/root.zig
+++ b/src/tls/root.zig
@@ -14,6 +14,7 @@ pub const messages = @import("messages.zig");
 pub const new_session_ticket = @import("new_session_ticket.zig");
 pub const negotiation = @import("negotiation.zig");
 pub const policy = @import("policy.zig");
+pub const pre_shared_key = @import("pre_shared_key.zig");
 pub const identity_loader = @import("identity_loader.zig");
 pub const production_crypto = @import("production_crypto.zig");
 pub const record_codec = @import("record_codec.zig");

--- a/src/tls/session.zig
+++ b/src/tls/session.zig
@@ -615,14 +615,22 @@ pub const ClientTicketState = struct {
 /// client-only bookkeeping and no provider/runtime handles.
 pub const ServerRecoverableState = struct {
     common: ResumableSessionCommon = .{},
+    /// The server's per-ticket `ticket_age_add` obfuscation value (#361
+    /// prerequisite amendment for #362/#363), recovered alongside `common`
+    /// after a stateful cache lookup or stateless-ticket decryption. Needed
+    /// to deobfuscate the client's offered `obfuscated_ticket_age` and
+    /// compute the age-skew observation; not itself secret, but scoped to
+    /// this record like every other recovered ticket field.
+    ticket_age_add: u32 = 0,
 
     /// Initializes `self` in place and takes ownership of `common` by
     /// moving it out of the caller's variable (see `ClientTicketState.init`).
     /// `self` must be zero-valued or a previously-initialized, live value
     /// — never `undefined` memory.
-    pub fn init(self: *ServerRecoverableState, common: *ResumableSessionCommon) void {
+    pub fn init(self: *ServerRecoverableState, common: *ResumableSessionCommon, ticket_age_add: u32) void {
         var next: ServerRecoverableState = .{};
         next.common.moveFrom(common);
+        next.ticket_age_add = ticket_age_add;
         self.moveFrom(&next);
     }
 
@@ -644,6 +652,7 @@ pub const ServerRecoverableState = struct {
         var next: ServerRecoverableState = .{};
         errdefer next.deinit();
         try self.common.cloneInto(allocator, &next.common);
+        next.ticket_age_add = self.ticket_age_add;
         out.moveFrom(&next);
     }
 
@@ -906,7 +915,7 @@ pub fn clientEncodedLen(state: *const ClientTicketState) usize {
 }
 
 pub fn serverEncodedLen(state: *const ServerRecoverableState) usize {
-    return header_len + commonEncodedLen(&state.common);
+    return header_len + commonEncodedLen(&state.common) + tlvLen(4);
 }
 
 fn commonFieldCount(common: *const ResumableSessionCommon) usize {
@@ -1004,7 +1013,7 @@ pub fn serverEncodedLenWithLimits(state: *const ServerRecoverableState, limits: 
     try limits.validate();
     try validateCommonForEncoding(&state.common);
     try checkCommonAgainstLimits(&state.common, limits);
-    const field_count = commonFieldCount(&state.common);
+    const field_count = commonFieldCount(&state.common) + 1; // ticket_age_add
     if (field_count > limits.max_fields) return error.TooManyFields;
     const needed = serverEncodedLen(state);
     if (needed > limits.max_serialized_len) return error.StateTooLarge;
@@ -1115,6 +1124,10 @@ pub fn encodeServer(state: *const ServerRecoverableState, limits: Limits, out: [
 
     var compat_scratch: [4 + hard_max_compat_len]u8 = undefined;
     writeCommon(out, &pos, &state.common, &compat_scratch);
+
+    var age_add_bytes: [4]u8 = undefined;
+    std.mem.writeInt(u32, &age_add_bytes, state.ticket_age_add, .big);
+    writeTlv(out, &pos, field_ticket_age_add, &age_add_bytes);
 
     std.debug.assert(pos == needed);
     return out[0..pos];
@@ -1365,21 +1378,31 @@ fn decodeClient(allocator: std.mem.Allocator, limits: Limits, bytes: []const u8)
 
 fn decodeServer(allocator: std.mem.Allocator, limits: Limits, bytes: []const u8) DecodeError!ServerRecoverableState {
     var common_fields = CommonFields{};
+    var ticket_age_add: ?u32 = null;
 
     var tracker = FieldTracker{ .max_fields = limits.max_fields };
     var offset: usize = 0;
     while (try nextTlv(bytes, &offset)) |tlv| {
         try tracker.observe(tlv.field_id);
         if (try parseSharedField(&common_fields, limits, tlv.field_id, tlv.value)) continue;
-        if (tlv.field_id & optional_field_mask != 0) continue;
-        return error.UnknownCriticalField;
+        switch (tlv.field_id) {
+            field_ticket_age_add => {
+                if (tlv.value.len != 4) return error.MalformedLength;
+                ticket_age_add = std.mem.readInt(u32, tlv.value[0..4], .big);
+            },
+            else => {
+                if (tlv.field_id & optional_field_mask != 0) continue;
+                return error.UnknownCriticalField;
+            },
+        }
     }
+    const age_add = ticket_age_add orelse return error.MissingField;
 
     var common: ResumableSessionCommon = .{};
     try buildCommon(allocator, limits, common_fields, &common);
 
     var state: ServerRecoverableState = .{};
-    state.init(&common);
+    state.init(&common, age_add);
     return state;
 }
 
@@ -1765,7 +1788,7 @@ test "client and server internal state round-trips deterministically" {
 
     var server_common = try sampleCommon(testing.allocator, &([_]u8{0xcd} ** 32));
     var server: ServerRecoverableState = .{};
-    server.init(&server_common);
+    server.init(&server_common, 0);
     defer server.deinit();
 
     var server_buf: [Limits.default.max_serialized_len]u8 = undefined;
@@ -1791,7 +1814,7 @@ test "absent SNI/ALPN round-trip without emitting a TLV" {
         .lifetime_seconds = 100,
     });
     var server: ServerRecoverableState = .{};
-    server.init(&common);
+    server.init(&common, 0);
     defer server.deinit();
 
     var buf: [Limits.default.max_serialized_len]u8 = undefined;
@@ -1951,7 +1974,7 @@ test "field-count limit accepts exactly max_fields and rejects one more" {
     // optional filler fields up to and past a tight max_fields boundary.
     var common = try sampleCommon(testing.allocator, &([_]u8{0xab} ** 32));
     var server: ServerRecoverableState = .{};
-    server.init(&common);
+    server.init(&common, 0);
     defer server.deinit();
 
     var buf: [Limits.default.max_serialized_len]u8 = undefined;
@@ -2180,7 +2203,7 @@ test "encode enforces max_transport_compat_len symmetrically with decode" {
         .transport_compat = .{ .format_id = 1, .format_version = 1, .bytes = &wide_blob },
     });
     var server: ServerRecoverableState = .{};
-    server.init(&common);
+    server.init(&common, 0);
     defer server.deinit();
 
     var tight_transport = wide;
@@ -2215,7 +2238,7 @@ test "encode enforces max_application_compat_len symmetrically with decode" {
         .application_compat = .{ .format_id = 2, .format_version = 1, .bytes = &wide_blob },
     });
     var server: ServerRecoverableState = .{};
-    server.init(&common);
+    server.init(&common, 0);
     defer server.deinit();
 
     var tight_application = wide;
@@ -2315,7 +2338,7 @@ test "clone produces an independent deep copy" {
 
     var server_common = try sampleCommon(testing.allocator, &([_]u8{0xef} ** 32));
     var server: ServerRecoverableState = .{};
-    server.init(&server_common);
+    server.init(&server_common, 0);
     defer server.deinit();
 
     var cloned_server: ServerRecoverableState = .{};
@@ -2424,7 +2447,7 @@ test "cloneInto is a safe no-op on every owning type when self == out" {
 
     var server_common = try sampleCommon(testing.allocator, &([_]u8{0xef} ** 32));
     var server: ServerRecoverableState = .{};
-    server.init(&server_common);
+    server.init(&server_common, 0);
     defer server.deinit();
     try server.cloneInto(testing.allocator, &server);
     try testing.expectEqualStrings("example.test", server.common.server_name.?.slice());
@@ -2449,12 +2472,12 @@ test "cloneInto into an already-live destination on every owning aggregate relea
 
     var server_common = try sampleCommon(testing.allocator, &([_]u8{0xcd} ** 32));
     var server: ServerRecoverableState = .{};
-    server.init(&server_common);
+    server.init(&server_common, 0);
     defer server.deinit();
 
     var stale_server_common = try sampleCommon(testing.allocator, &([_]u8{0xee} ** 32));
     var stale_server: ServerRecoverableState = .{};
-    stale_server.init(&stale_server_common);
+    stale_server.init(&stale_server_common, 0);
     try server.cloneInto(testing.allocator, &stale_server);
     defer stale_server.deinit();
     try testing.expectEqualStrings(
@@ -2733,8 +2756,8 @@ const client_fixture: [229]u8 = .{
     0x60,
 };
 
-const server_fixture: [177]u8 = .{
-    0x54, 0x52, 0x53, 0x31, 0x01, 0x02, 0x00, 0x00, 0x00, 0xa7, 0x00, 0x01,
+const server_fixture: [185]u8 = .{
+    0x54, 0x52, 0x53, 0x31, 0x01, 0x02, 0x00, 0x00, 0x00, 0xaf, 0x00, 0x01,
     0x00, 0x02, 0x13, 0x01, 0x00, 0x02, 0x00, 0x20, 0xcd, 0xcd, 0xcd, 0xcd,
     0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd,
     0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd,
@@ -2748,7 +2771,8 @@ const server_fixture: [177]u8 = .{
     0x00, 0x05, 0x01, 0x00, 0x00, 0x40, 0x00, 0x80, 0x01, 0x00, 0x0f, 0x00,
     0x01, 0x00, 0x01, 0x71, 0x75, 0x69, 0x63, 0x2d, 0x70, 0x61, 0x72, 0x61,
     0x6d, 0x73, 0x80, 0x02, 0x00, 0x0f, 0x00, 0x02, 0x00, 0x01, 0x68, 0x33,
-    0x2d, 0x73, 0x65, 0x74, 0x74, 0x69, 0x6e, 0x67, 0x73,
+    0x2d, 0x73, 0x65, 0x74, 0x74, 0x69, 0x6e, 0x67, 0x73, 0x00, 0x11, 0x00,
+    0x04, 0x00, 0x00, 0x00, 0x00,
 };
 
 fn fixtureCommonParams(psk: []const u8) ResumableSessionCommon.InitParams {
@@ -2808,6 +2832,7 @@ test "checked-in literal server-record byte fixture decodes to every expected fi
     try testing.expectEqualStrings("quic-params", s.common.transport_compat.?.slice());
     try testing.expectEqual(@as(u16, 2), s.common.application_compat.?.format_id);
     try testing.expectEqualStrings("h3-settings", s.common.application_compat.?.slice());
+    try testing.expectEqual(@as(u32, 0), s.ticket_age_add);
 }
 
 test "current encoder output exactly equals the checked-in fixtures" {
@@ -2828,7 +2853,7 @@ test "current encoder output exactly equals the checked-in fixtures" {
     var server_common: ResumableSessionCommon = .{};
     try server_common.init(testing.allocator, Limits.default, fixtureCommonParams(&([_]u8{0xcd} ** 32)));
     var server: ServerRecoverableState = .{};
-    server.init(&server_common);
+    server.init(&server_common, 0);
     defer server.deinit();
     var buf2: [Limits.default.max_serialized_len]u8 = undefined;
     const encoded2 = try encodeServer(&server, Limits.default, &buf2);
@@ -2924,7 +2949,7 @@ test "duplicating any known server field is rejected" {
     const all_server_field_ids = [_]u16{
         field_cipher_suite,     field_resumption_psk,     field_server_name,      field_application_protocol,
         field_auth_binding,     field_issued_at,          field_lifetime_seconds, field_early_data,
-        field_transport_compat, field_application_compat,
+        field_transport_compat, field_application_compat, field_ticket_age_add,
     };
     for (all_server_field_ids) |field_id| {
         var buf: [server_fixture.len + 64]u8 = undefined;
@@ -2935,8 +2960,9 @@ test "duplicating any known server field is rejected" {
 
 test "removing any mandatory server field is rejected as missing" {
     const mandatory_server_field_ids = [_]u16{
-        field_cipher_suite, field_resumption_psk,   field_auth_binding,
-        field_issued_at,    field_lifetime_seconds, field_early_data,
+        field_cipher_suite,   field_resumption_psk,   field_auth_binding,
+        field_issued_at,      field_lifetime_seconds, field_early_data,
+        field_ticket_age_add,
     };
     for (mandatory_server_field_ids) |field_id| {
         var buf: [server_fixture.len]u8 = undefined;

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -856,9 +856,17 @@ pub const Tls13Backend = struct {
     /// previously-initialized, live value — never `undefined`), returning
     /// its selected identity index. A one-shot accessor for #365/#366:
     /// returns `null` (leaving `out` untouched) when no PSK has been
-    /// selected on this connection, or once already taken.
+    /// selected on this connection, once already taken, or — critically —
+    /// before the resumed handshake has actually `handshake_committed`.
+    ///
+    /// The binder succeeding only proves the *client* authenticated; the
+    /// server's own handshake is not authenticated until the client's
+    /// Finished verifies (`onClientFinished`). Handing ownership of this
+    /// secret-bearing session out any earlier would let a caller retain it
+    /// past a subsequent bad-Finished failure — `clearFailedHandshakeState`
+    /// can only wipe state the backend still owns.
     pub fn takeSelectedServerPsk(self: *Tls13Backend, out: *session.ServerRecoverableState) ?u16 {
-        if (!self.selected_server_psk_present) return null;
+        if (!self.handshake_committed or !self.selected_server_psk_present) return null;
         out.moveFrom(&self.selected_server_psk.state);
         self.selected_server_psk_present = false;
         const index = self.selected_server_psk.index;

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -342,6 +342,12 @@ pub const TransportProfile = union(enum) {
                 ext_alpn,
                 ext_supported_versions,
                 ext_key_share,
+                // #362: reserve the TLS-owned PSK extension IDs too — a
+                // caller configuring a transport extension with either of
+                // these types would otherwise collide with (and be
+                // misparsed as) the PSK negotiation extensions.
+                pre_shared_key.ext_pre_shared_key,
+                pre_shared_key.ext_psk_key_exchange_modes,
                 => return error.InvalidTransportProfile,
                 else => {},
             }
@@ -534,6 +540,13 @@ pub const Tls13Backend = struct {
     /// fatal, or teardown).
     selected_client_psk: session.ClientTicketState = .{},
     selected_client_psk_present: bool = false,
+    /// Server (#362): the accepted session a successful PSK selection moved
+    /// into ownership — see `SelectedServerPsk`. Available to the caller
+    /// via `takeSelectedServerPsk` once the resumed handshake completes;
+    /// wiped on every fallback/error/teardown path along with the rest of
+    /// this connection's PSK state.
+    selected_server_psk: SelectedServerPsk = .{},
+    selected_server_psk_present: bool = false,
     /// Server (#362): the configured stateful/stateless identity resolver.
     /// `null` means this server never offers PSK resumption.
     psk_resolver: ?pre_shared_key.ServerPskResolver = null,
@@ -551,9 +564,16 @@ pub const Tls13Backend = struct {
     /// #362/#365 seam: the application-layer compatibility snapshot this
     /// connection is configured with, compared against a candidate PSK's
     /// stored `application_compat` (server) and used to recheck an offered
-    /// ticket (client). `null` means this connection has none configured —
-    /// symmetric with a ticket that also has none.
-    application_compat: ?new_session_ticket.CompatBlob = null,
+    /// ticket (client) — and, symmetrically, stamped into any ticket this
+    /// connection itself issues/receives. Copied into owned, bounded
+    /// storage by `setApplicationCompat` (not borrowed): it is read again
+    /// during *post-handshake* ticket issuance/ingestion, well past when a
+    /// merely-handshake-scoped borrow would be safe to assume live.
+    application_compat_format_id: u16 = 0,
+    application_compat_format_version: u16 = 0,
+    application_compat_bytes: [max_transport_extension_len]u8 = undefined,
+    application_compat_len: usize = 0,
+    application_compat_present: bool = false,
     /// #362: the most recent successful PSK selection's ticket-age skew
     /// observation (apparent vs. actual elapsed time since issuance), taken
     /// exactly once by `takePskAgeSkew`. Informational only — skew alone
@@ -564,6 +584,21 @@ pub const Tls13Backend = struct {
     const Slice = struct { start: usize, len: usize };
     const PendingStage = enum { server_select, server_sign, client_select, client_sign, peer_verify };
     const PskSelected = struct { index: usize, psk: [hash_len]u8 };
+
+    /// Server (#362): the accepted `ServerRecoverableState` a successful PSK
+    /// selection moves into backend ownership — not only the derived PSK
+    /// bytes — so #365/#366 can consume the authenticated selection
+    /// (early-data policy, compatibility metadata, ...) without resolving
+    /// the bearer identity a second time.
+    const SelectedServerPsk = struct {
+        index: u16 = 0,
+        state: session.ServerRecoverableState = .{},
+
+        fn deinit(self: *SelectedServerPsk) void {
+            self.state.deinit();
+            self.index = 0;
+        }
+    };
 
     /// Reassembler capacity is `max_message_len + 4` (see `initial_input`),
     /// so the capture buffer matches that bound exactly.
@@ -754,10 +789,36 @@ pub const Tls13Backend = struct {
     /// #362/#365: configure this connection's application-layer
     /// compatibility snapshot (e.g. HTTP/3 settings), compared against a
     /// candidate PSK's stored value on the server and used to recheck an
-    /// offered ticket on the client. `blob.bytes` must outlive the
-    /// handshake. Must be called before `start`.
-    pub fn setApplicationCompat(self: *Tls13Backend, blob: ?new_session_ticket.CompatBlob) void {
-        self.application_compat = blob;
+    /// offered ticket on the client. Copies `blob.bytes` into owned,
+    /// bounded storage — the caller's slice need not outlive this call —
+    /// because this value is read again during post-handshake ticket
+    /// issuance/ingestion, not only during the handshake itself. Must be
+    /// called before `start`.
+    pub fn setApplicationCompat(self: *Tls13Backend, blob: ?new_session_ticket.CompatBlob) HandshakeError!void {
+        if (blob) |b| {
+            if (b.bytes.len > self.application_compat_bytes.len) return error.TransportBufferOverflow;
+            self.application_compat_format_id = b.format_id;
+            self.application_compat_format_version = b.format_version;
+            @memcpy(self.application_compat_bytes[0..b.bytes.len], b.bytes);
+            self.application_compat_len = b.bytes.len;
+            self.application_compat_present = true;
+        } else {
+            self.application_compat_present = false;
+            self.application_compat_len = 0;
+        }
+    }
+
+    /// The owned `application_compat` snapshot configured via
+    /// `setApplicationCompat`, in the wire-neutral `CompatBlob` shape both
+    /// `resumptionContext()` (ticket issuance/ingestion) and
+    /// `candidateApplicationCompat()` (PSK compatibility evaluation) need.
+    pub fn ownedApplicationCompat(self: *const Tls13Backend) ?new_session_ticket.CompatBlob {
+        if (!self.application_compat_present) return null;
+        return .{
+            .format_id = self.application_compat_format_id,
+            .format_version = self.application_compat_format_version,
+            .bytes = self.application_compat_bytes[0..self.application_compat_len],
+        };
     }
 
     /// #362: takes (clears) the most recent successful PSK selection's
@@ -765,6 +826,21 @@ pub const Tls13Backend = struct {
     pub fn takePskAgeSkew(self: *Tls13Backend) ?pre_shared_key.AgeSkew {
         defer self.last_psk_age_skew = null;
         return self.last_psk_age_skew;
+    }
+
+    /// Server (#362): moves the session accepted by the most recent
+    /// successful PSK selection into `out` (which must be zero-valued or a
+    /// previously-initialized, live value — never `undefined`), returning
+    /// its selected identity index. A one-shot accessor for #365/#366:
+    /// returns `null` (leaving `out` untouched) when no PSK has been
+    /// selected on this connection, or once already taken.
+    pub fn takeSelectedServerPsk(self: *Tls13Backend, out: *session.ServerRecoverableState) ?u16 {
+        if (!self.selected_server_psk_present) return null;
+        out.moveFrom(&self.selected_server_psk.state);
+        self.selected_server_psk_present = false;
+        const index = self.selected_server_psk.index;
+        self.selected_server_psk.index = 0;
+        return index;
     }
 
     pub fn setSessionTicketConsumer(
@@ -893,10 +969,14 @@ pub const Tls13Backend = struct {
         self.psk_now_fn = null;
         self.psk_resolver = null;
         self.connection_auth_binding = null;
-        self.application_compat = null;
+        crypto.secureZero(u8, &self.application_compat_bytes);
+        self.application_compat_present = false;
+        self.application_compat_len = 0;
         self.last_psk_age_skew = null;
         self.selected_client_psk.deinit();
         self.selected_client_psk_present = false;
+        self.selected_server_psk.deinit();
+        self.selected_server_psk_present = false;
         self.clearClientHelloPsk();
         crypto.secureZero(u8, &self.expected_client_verify);
         self.wipeEphemeral();
@@ -957,8 +1037,39 @@ pub const Tls13Backend = struct {
         self.offered_psk_dhe_ke = false;
     }
 
+    /// #362: wipes owned PSK *negotiation* state on any handshake-phase
+    /// failure — installed via `errdefer` at the `receiveImpl`/`resumeAuth`
+    /// call boundary (not only inside the individual message handlers), so
+    /// a terminal failure that occurs before or between handler dispatch
+    /// (message-order rejection, wrong transport epoch, a malformed frame,
+    /// an async operation's own failure) cannot leave this state resident
+    /// in a backend that will not be torn down until some later, unrelated
+    /// `deinit()`.
+    ///
+    /// Deliberately a no-op once the handshake has actually completed:
+    /// `selected_server_psk` and `last_psk_age_skew` are meant to outlive a
+    /// *successful* handshake, for #365/#366 to consume via their one-shot
+    /// accessors — an unrelated post-handshake failure (a malformed
+    /// `NewSessionTicket`, say) must not destroy them before the caller has
+    /// had a chance to read them. A failure *during* the handshake, by
+    /// contrast, means the connection never actually succeeded, so there is
+    /// nothing legitimate left to preserve.
+    fn clearPskHandshakeState(self: *Tls13Backend) void {
+        if (self.core.handshake_lifecycle == .complete) return;
+        self.client_psk_offers.deinit();
+        self.selected_client_psk.deinit();
+        self.selected_client_psk_present = false;
+        self.selected_server_psk.deinit();
+        self.selected_server_psk_present = false;
+        self.last_psk_age_skew = null;
+        self.clearClientHelloPsk();
+        if (self.schedule) |*schedule| schedule.wipe();
+        self.schedule = null;
+    }
+
     fn startImpl(ptr: *anyopaque, role: Role, _: void, sink: *EventSink) HandshakeError!void {
         const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
+        errdefer self.clearPskHandshakeState();
         // The driver's role comes from Handshake.initClient/initServer and must
         // match how this backend was constructed; a mismatch is a wiring bug.
         std.debug.assert(role == self.role);
@@ -987,6 +1098,13 @@ pub const Tls13Backend = struct {
 
     fn receiveImpl(ptr: *anyopaque, level: EncryptionLevel, bytes: []const u8, sink: *EventSink) HandshakeError!void {
         const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
+        // Covers every terminal failure below — including those raised by
+        // `drainInput` itself (message ordering, transport epoch, framing)
+        // before any per-message handler ever runs — not only the ones the
+        // individual handlers already guard locally. See
+        // `clearPskHandshakeState` for why this is a no-op once the
+        // handshake has completed.
+        errdefer self.clearPskHandshakeState();
         switch (level) {
             .zero_rtt => return error.UnexpectedTransportEpoch,
             .application => {
@@ -1401,11 +1519,12 @@ pub const Tls13Backend = struct {
         return true;
     }
 
-    /// The application-compatibility candidate view of `self.application_compat`
-    /// (see `setApplicationCompat`), for both the client's eligibility
-    /// recheck and the server's candidate compatibility evaluation.
+    /// The application-compatibility candidate view of the owned
+    /// `application_compat` snapshot (see `setApplicationCompat`), for both
+    /// the client's eligibility recheck and the server's candidate
+    /// compatibility evaluation.
     fn candidateApplicationCompat(self: *const Tls13Backend) ?session.CandidateCompat {
-        const blob = self.application_compat orelse return null;
+        const blob = self.ownedApplicationCompat() orelse return null;
         return .{ .format_id = blob.format_id, .format_version = blob.format_version, .bytes = blob.bytes };
     }
 
@@ -1506,6 +1625,7 @@ pub const Tls13Backend = struct {
             const psk_slice = self.selected_client_psk.common.resumption_psk.slice();
             if (psk_slice.len != hash_len) return error.IllegalParameter;
             var buf: [hash_len]u8 = undefined;
+            defer crypto.secureZero(u8, &buf);
             @memcpy(&buf, psk_slice);
             psk_secret = buf;
         } else {
@@ -2490,6 +2610,13 @@ pub const Tls13Backend = struct {
                 candidate_state.ticket_age_add,
                 elapsedMillis(now, candidate_state.common.issued_at_unix_ms),
             );
+            // Move the accepted session into backend ownership instead of
+            // letting the loop-scoped `defer candidate_state.deinit()`
+            // above destroy it — `moveFrom` zero-values `candidate_state`
+            // first, so that deferred deinit becomes a safe no-op.
+            self.selected_server_psk.state.moveFrom(&candidate_state);
+            self.selected_server_psk.index = @intCast(attempts);
+            self.selected_server_psk_present = true;
             return .{ .index = attempts, .psk = psk_buf };
         }
         return null;
@@ -2748,6 +2875,11 @@ pub const Tls13Backend = struct {
     /// suspended, recording no handshake message twice; when it fails the typed
     /// failure is latched.
     pub fn resumeAuth(self: *Tls13Backend, sink: *EventSink) HandshakeError!void {
+        // A no-op when nothing is parked or the operation is still pending
+        // (both ordinary, non-error returns below); fires on the operation's
+        // own failure and on any terminal error from resuming into
+        // `dispatchResume`/`drainInput`.
+        errdefer self.clearPskHandshakeState();
         const op = self.pending_op orelse return;
         const stage = self.pending_stage;
         var completion: credentials.Completion = undefined;
@@ -2997,7 +3129,7 @@ pub const Tls13Backend = struct {
             .application_protocol = self.selectedAlpn(),
             .auth_binding = self.effectiveAuthBinding(),
             .transport_compat = self.peerTransportCompat(),
-            .application_compat = self.application_compat,
+            .application_compat = self.ownedApplicationCompat(),
         };
     }
 

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -25,6 +25,7 @@ const crypto_pkg = @import("crypto");
 const tls_handshake_codec = @import("handshake.zig");
 const tls_key_schedule = @import("key_schedule.zig");
 const new_session_ticket = @import("new_session_ticket.zig");
+const pre_shared_key = @import("pre_shared_key.zig");
 const session = @import("session.zig");
 const tls_state = @import("state.zig");
 const tls13_transport = @import("tls13_transport.zig");
@@ -518,9 +519,37 @@ pub const Tls13Backend = struct {
     pending_client_session_id_len: usize = 0,
     pending_client_share: [X25519.public_length]u8 = undefined,
     pending_client_hello_ready: bool = false,
+    /// Client (#362): resumption tickets this backend may offer, owned until
+    /// moved out at ClientHello emission or wiped after ServerHello selects
+    /// (or does not select) one.
+    client_psk_offers: pre_shared_key.ClientPskOfferSet = .{},
+    psk_now_ctx: ?*anyopaque = null,
+    psk_now_fn: ?*const fn (*anyopaque) i64 = null,
+    /// Server (#362): the configured stateful/stateless identity resolver.
+    /// `null` means this server never offers PSK resumption.
+    psk_resolver: ?pre_shared_key.ServerPskResolver = null,
+    offered_psk_modes_seen: bool = false,
+    offered_psk_dhe_ke: bool = false,
+    /// Server: a captured copy of the just-parsed ClientHello, kept only
+    /// long enough (within the synchronous credential-selection path) to
+    /// verify the selected identity's binder over the exact received bytes.
+    /// Cleared once selection has run, on every path.
+    client_hello_psk: ?ClientHelloPskCapture = null,
 
     const Slice = struct { start: usize, len: usize };
     const PendingStage = enum { server_select, server_sign, client_select, client_sign, peer_verify };
+    const PskSelected = struct { index: usize, psk: [hash_len]u8 };
+
+    /// Reassembler capacity is `max_message_len + 4` (see `initial_input`),
+    /// so the capture buffer matches that bound exactly.
+    const ClientHelloPskCapture = struct {
+        message: [max_message_len + handshake_header_len]u8 = undefined,
+        message_len: usize = 0,
+        /// Offset of the `pre_shared_key` extension's `extension_data`
+        /// within `message`.
+        ext_data_offset: usize = 0,
+        ext_data_len: usize = 0,
+    };
 
     pub const SessionTicketConsumer = struct {
         ctx: *anyopaque,
@@ -672,6 +701,31 @@ pub const Tls13Backend = struct {
         self.external_provider = provider;
     }
 
+    /// Client (#362): configure the resumption tickets to offer at the next
+    /// ClientHello and the clock used to check their expiry and compute
+    /// their obfuscated age. Takes ownership of `offers` (moved out; the
+    /// caller's set is left empty). Must be called before `start`.
+    pub fn setClientPskOffers(
+        self: *Tls13Backend,
+        offers: *pre_shared_key.ClientPskOfferSet,
+        now_ctx: *anyopaque,
+        nowUnixMsFn: *const fn (*anyopaque) i64,
+    ) void {
+        std.debug.assert(self.role == .client);
+        self.client_psk_offers.deinit();
+        self.client_psk_offers.moveFrom(offers);
+        self.psk_now_ctx = now_ctx;
+        self.psk_now_fn = nowUnixMsFn;
+    }
+
+    /// Server (#362): configure the stateful/stateless identity resolver
+    /// used to select and verify an offered resumption PSK. Without one, the
+    /// server never offers or accepts PSK resumption (full handshake only).
+    pub fn setServerPskResolver(self: *Tls13Backend, resolver: pre_shared_key.ServerPskResolver) void {
+        std.debug.assert(self.role == .server);
+        self.psk_resolver = resolver;
+    }
+
     pub fn setSessionTicketConsumer(
         self: *Tls13Backend,
         allocator: std.mem.Allocator,
@@ -793,6 +847,11 @@ pub const Tls13Backend = struct {
         self.schedule = null;
         self.resumption_master_secret.deinit();
         self.session_ticket_consumer = null;
+        self.client_psk_offers.deinit();
+        self.psk_now_ctx = null;
+        self.psk_now_fn = null;
+        self.psk_resolver = null;
+        self.clearClientHelloPsk();
         crypto.secureZero(u8, &self.expected_client_verify);
         self.wipeEphemeral();
         self.wipeIdentity();
@@ -834,6 +893,16 @@ pub const Tls13Backend = struct {
     fn wipeIdentity(self: *Tls13Backend) void {
         crypto.secureZero(u8, std.mem.asBytes(&self.identity));
         self.identity_present = false;
+    }
+
+    /// Clears the captured ClientHello PSK state (#362): on every path once
+    /// selection has run (success, fallback, or no PSK offered at all). Not
+    /// itself secret (the ClientHello is transcript-public wire data), but
+    /// scoped tightly to the connection it was captured for.
+    fn clearClientHelloPsk(self: *Tls13Backend) void {
+        self.client_hello_psk = null;
+        self.offered_psk_modes_seen = false;
+        self.offered_psk_dhe_ke = false;
     }
 
     fn startImpl(ptr: *anyopaque, role: Role, _: void, sink: *EventSink) HandshakeError!void {
@@ -1010,7 +1079,7 @@ pub const Tls13Backend = struct {
         // Dispatch the shared TLS semantics; transport extension contents stay
         // opaque and are consumed by the owning adapter.
         switch (kind) {
-            .client_hello => try self.onClientHello(body, sink),
+            .client_hello => try self.onClientHello(message.raw, sink),
             .server_hello => try self.onServerHello(body, sink),
             .encrypted_extensions => try self.onEncryptedExtensions(body, sink),
             .certificate_request => try self.onCertificateRequest(body),
@@ -1121,8 +1190,61 @@ pub const Tls13Backend = struct {
             try w.bytes(payload);
         }
 
+        // pre_shared_key (#362): the RFC 8446 §4.2.11 wire rule that it be
+        // the last ClientHello extension is what puts this block after every
+        // other extension above and before the final length patches below.
+        var psk_secrets: [pre_shared_key.max_offered_identities][hash_len]u8 = undefined;
+        var psk_count: usize = 0;
+        var psk_offer_write: ?pre_shared_key.ClientOfferWrite = null;
+        if (!self.client_psk_offers.isEmpty()) {
+            if (self.psk_now_fn) |nowFn| {
+                const now_ms = nowFn(self.psk_now_ctx.?);
+                var psk_items: [pre_shared_key.max_offered_identities]pre_shared_key.OfferItem = undefined;
+                for (self.client_psk_offers.constSlice()) |*ticket| {
+                    if (psk_count >= pre_shared_key.max_offered_identities) break;
+                    if (ticket.common.isExpired(now_ms) or ticket.common.isNotYetValid(now_ms)) continue;
+                    if (ticket.common.cipher_suite != .tls_aes_128_gcm_sha256) continue;
+                    const psk = ticket.common.resumption_psk.slice();
+                    if (psk.len != hash_len) continue;
+                    @memcpy(&psk_secrets[psk_count], psk);
+                    psk_items[psk_count] = .{
+                        .identity = ticket.ticket.slice(),
+                        .obfuscated_ticket_age = pre_shared_key.obfuscateTicketAge(ticket.ageMillis(now_ms), ticket.ticket_age_add),
+                        .digest_len = hash_len,
+                    };
+                    psk_count += 1;
+                }
+                if (psk_count > 0) {
+                    try w.u16_(pre_shared_key.ext_psk_key_exchange_modes);
+                    const modes_ext_len = try w.reserve(2);
+                    try pre_shared_key.writeModes(&w, &.{.psk_dhe_ke});
+                    w.patch(2, modes_ext_len);
+                    psk_offer_write = pre_shared_key.writeOffer(&w, psk_items[0..psk_count]) catch |err| switch (err) {
+                        error.TooManyIdentities => unreachable, // psk_count is capped above
+                        error.HandshakeBufferOverflow => return error.HandshakeBufferOverflow,
+                    };
+                }
+            }
+        }
+
         w.patch(2, extensions_len);
         w.patch(3, message_len);
+
+        // Every enclosing length field (message, extensions block, the PSK
+        // extension itself, identities, binders) is now patched to its
+        // final value, so the truncated prefix below is exactly what RFC
+        // 8446 §4.2.11.2 requires each binder to be computed over.
+        if (psk_offer_write) |offer| {
+            const prefix = buf[0..offer.truncated_len];
+            for (0..psk_count) |i| {
+                const slot = offer.slots[i];
+                var binder: [hash_len]u8 = undefined;
+                pre_shared_key.deriveBinder(.sha256, &psk_secrets[i], prefix, &binder) catch return error.SecretExportFailed;
+                @memcpy(buf[slot.offset..][0..slot.len], &binder);
+                crypto.secureZero(u8, &binder);
+            }
+        }
+        crypto.secureZero(u8, std.mem.asBytes(&psk_secrets));
 
         const message = buf[0..w.len];
         self.core.recordSent(message) catch |err| return mapCoreError(err);
@@ -1165,6 +1287,7 @@ pub const Tls13Backend = struct {
 
         var selected_version: ?u16 = null;
         var peer_share: ?[X25519.public_length]u8 = null;
+        var selected_identity: ?u16 = null;
         var guard = ExtensionGuard{};
         var extensions = Reader{ .bytes = try r.slice(try r.u16_()) };
         try r.expectEnd();
@@ -1180,6 +1303,10 @@ pub const Tls13Backend = struct {
                     peer_share = (try ext.slice(X25519.public_length))[0..X25519.public_length].*;
                     try ext.expectEnd();
                 },
+                pre_shared_key.ext_pre_shared_key => {
+                    selected_identity = try ext.u16_();
+                    try ext.expectEnd();
+                },
                 else => {},
             }
         }
@@ -1193,8 +1320,30 @@ pub const Tls13Backend = struct {
         var shared = X25519.scalarmult(self.key_pair.secret_key, share) catch
             return error.IllegalParameter;
         defer crypto.secureZero(u8, &shared);
+
+        // #362: consistency-check and consume the server's selected_identity
+        // (if any) against our own offers before wiping them — this is the
+        // client's own binder-free trust decision: it selects which *offer*
+        // the index names, never a value the server invented.
+        var psk_secret: ?[hash_len]u8 = null;
+        if (selected_identity) |idx| {
+            if (idx >= self.client_psk_offers.len) return error.IllegalParameter;
+            const psk_slice = self.client_psk_offers.tickets[idx].common.resumption_psk.slice();
+            if (psk_slice.len != hash_len) return error.IllegalParameter;
+            var buf: [hash_len]u8 = undefined;
+            @memcpy(&buf, psk_slice);
+            psk_secret = buf;
+        }
+        self.client_psk_offers.deinit();
+
         self.wipeEphemeral();
-        self.schedule = KeySchedule.init(&shared, self.core.transcriptHash());
+        if (psk_secret) |*psk| {
+            self.core.enterPskAuthenticated();
+            self.schedule = KeySchedule.initWithPsk(psk, &shared, self.core.transcriptHash());
+            crypto.secureZero(u8, psk);
+        } else {
+            self.schedule = KeySchedule.init(&shared, self.core.transcriptHash());
+        }
         try self.emitHandshakeSecrets(sink);
         try sink.emitDiscardKeys(.initial);
     }
@@ -1728,7 +1877,8 @@ pub const Tls13Backend = struct {
     // Server flight.
     // -----------------------------------------------------------------------
 
-    fn onClientHello(self: *Tls13Backend, body: []const u8, sink: *EventSink) HandshakeError!void {
+    fn onClientHello(self: *Tls13Backend, raw: []const u8, sink: *EventSink) HandshakeError!void {
+        const body = raw[handshake_header_len..];
         var r = Reader{ .bytes = body };
         if (try r.u16_() != legacy_version) return error.IllegalParameter;
         _ = try r.slice(32); // client random (already covered by the transcript)
@@ -1761,6 +1911,9 @@ pub const Tls13Backend = struct {
         var selected_alpn: ?[]const u8 = null;
         var selected_alpn_preference: usize = std.math.maxInt(usize);
         var transport_params: ?[]const u8 = null;
+        var psk_modes_seen = false;
+        var psk_dhe_ke_offered = false;
+        var psk_ext: ?struct { offset: usize, len: usize } = null;
 
         var guard = ExtensionGuard{};
         var extensions = Reader{ .bytes = try r.slice(try r.u16_()) };
@@ -1854,6 +2007,19 @@ pub const Tls13Backend = struct {
                     }
                     try list.expectEnd();
                 },
+                pre_shared_key.ext_psk_key_exchange_modes => {
+                    psk_dhe_ke_offered = pre_shared_key.hasMode(ext.bytes, .psk_dhe_ke) catch |err| return mapPskReadError(err);
+                    psk_modes_seen = true;
+                },
+                pre_shared_key.ext_pre_shared_key => {
+                    // RFC 8446 §4.2.11: pre_shared_key must be the last
+                    // ClientHello extension. `extensions` has already
+                    // consumed this entry's bytes above, so "nothing left"
+                    // here means it truly was last.
+                    if (extensions.remaining() != 0) return error.IllegalParameter;
+                    _ = pre_shared_key.OfferedPsks.parse(ext.bytes) catch |err| return mapPskReadError(err);
+                    psk_ext = .{ .offset = @intFromPtr(ext.bytes.ptr) - @intFromPtr(raw.ptr), .len = ext.bytes.len };
+                },
                 else => {
                     if (self.profile.extensionType()) |expected_type| {
                         if (expected_type == ext_id) transport_params = ext.bytes;
@@ -1862,6 +2028,19 @@ pub const Tls13Backend = struct {
             }
         }
         if (!offers_tls13 or !offers_x25519_group) return error.MalformedHandshake;
+        if (psk_ext != null and !psk_modes_seen) return error.MissingExtension;
+        self.clearClientHelloPsk();
+        if (psk_ext) |info| {
+            var capture: ClientHelloPskCapture = .{};
+            if (raw.len > capture.message.len) return error.MalformedHandshake;
+            @memcpy(capture.message[0..raw.len], raw);
+            capture.message_len = raw.len;
+            capture.ext_data_offset = info.offset;
+            capture.ext_data_len = info.len;
+            self.client_hello_psk = capture;
+            self.offered_psk_modes_seen = true;
+            self.offered_psk_dhe_ke = psk_dhe_ke_offered;
+        }
         // signature_algorithms is required whenever the server authenticates
         // with a certificate (RFC 8446 §9.2). A missing or empty list is a
         // malformed/missing required *peer* extension — attribute it to the
@@ -1946,6 +2125,14 @@ pub const Tls13Backend = struct {
         crypto.secureZero(u8, &key_pair.secret_key);
         self.wipeEphemeral();
 
+        // #362: credential selection (above, by the caller) happens before
+        // this — so a candidate ticket's stored `auth_binding` is compared
+        // against the identity we would otherwise authenticate with — and
+        // PSK selection/binder verification happens before any ServerHello
+        // byte is written, since a selected identity must be named in it.
+        const psk_selected = try self.selectPsk();
+        defer self.clearClientHelloPsk();
+
         // ServerHello (Initial level).
         var hello_buf: [256]u8 = undefined;
         var hello = Writer{ .buf = &hello_buf };
@@ -1966,6 +2153,11 @@ pub const Tls13Backend = struct {
         try hello.u16_(group_x25519);
         try hello.u16_(X25519.public_length);
         try hello.bytes(&key_pair.public_key);
+        if (psk_selected) |sel| {
+            try hello.u16_(pre_shared_key.ext_pre_shared_key);
+            try hello.u16_(2);
+            try hello.u16_(@intCast(sel.index));
+        }
         hello.patch(2, hello_extensions);
         hello.patch(3, hello_len);
         const server_hello = hello_buf[0..hello.len];
@@ -1973,12 +2165,155 @@ pub const Tls13Backend = struct {
         try sink.emitCrypto(.initial, server_hello);
         if (self.selectedAlpn()) |protocol| try sink.emitAlpn(protocol);
 
-        self.schedule = KeySchedule.init(&shared, self.core.transcriptHash());
+        if (psk_selected) |sel| {
+            var psk = sel.psk;
+            defer crypto.secureZero(u8, &psk);
+            self.schedule = KeySchedule.initWithPsk(&psk, &shared, self.core.transcriptHash());
+        } else {
+            self.schedule = KeySchedule.init(&shared, self.core.transcriptHash());
+        }
         try self.emitHandshakeSecrets(sink);
         try sink.emitDiscardKeys(.initial);
 
+        if (psk_selected != null) {
+            // PSK-resumed: no Certificate/CertificateVerify flight, so the
+            // selected credential (already validated by the caller) is
+            // never consumed — release it here, on the one success path
+            // that reaches this branch.
+            credential.release();
+            owned = false;
+            self.core.enterPskAuthenticated();
+            return self.emitPskFinishFlight(sink);
+        }
+
         owned = false;
         try self.emitServerAuthFlight(credential, sink);
+    }
+
+    /// #362 server selection algorithm: iterate the client's offered
+    /// identities in order (bounded to `pre_shared_key.max_offered_identities`
+    /// attempts), resolve each via the configured resolver, evaluate #360
+    /// compatibility against the *current* connection context, and verify
+    /// only the first compatible candidate's binder. A binder mismatch on
+    /// that candidate is fatal (`DecryptError`) and never probes a later
+    /// identity; an incompatible/unknown/undecryptable candidate simply
+    /// continues to the next offered identity. Returns `null` — meaning
+    /// "continue with the existing full-certificate flow" — whenever PSK is
+    /// not configured/offered/eligible, or no candidate is acceptable.
+    fn selectPsk(self: *Tls13Backend) HandshakeError!?PskSelected {
+        const resolver = self.psk_resolver orelse return null;
+        if (self.client_auth != .disabled) return null;
+        if (!self.offered_psk_modes_seen or !self.offered_psk_dhe_ke) return null;
+        const capture = self.client_hello_psk orelse return null;
+        const ext_data = capture.message[capture.ext_data_offset..][0..capture.ext_data_len];
+        // Already validated once in `onClientHello`; re-parsing the same
+        // captured bytes cannot fail.
+        const offered = pre_shared_key.OfferedPsks.parse(ext_data) catch return null;
+        const truncated_len = capture.ext_data_offset + offered.binder_vector_offset;
+        const truncated_prefix = capture.message[0..truncated_len];
+        const now = resolver.nowUnixMs();
+
+        var it = offered.pairs();
+        var attempts: usize = 0;
+        while (attempts < pre_shared_key.max_offered_identities) : (attempts += 1) {
+            const pair = (it.next() catch return null) orelse break;
+            var candidate_state: session.ServerRecoverableState = .{};
+            const found = resolver.resolve(pair.identity.identity, &candidate_state) catch
+                return error.CredentialProviderFailed;
+            if (!found) continue;
+
+            const candidate_ctx: session.CandidateContext = .{
+                .cipher_suite = .tls_aes_128_gcm_sha256,
+                .server_name = self.serverNameSlice(),
+                .application_protocol = self.selectedAlpn(),
+                .auth_binding = self.peerAuthBinding(),
+                .transport_compat = self.candidateTransportCompat(),
+            };
+            const decision = session.evaluateCompatibility(&candidate_state.common, candidate_ctx, now);
+            if (decision.resumption != .eligible) {
+                candidate_state.deinit();
+                continue;
+            }
+
+            const psk_slice = candidate_state.common.resumption_psk.slice();
+            if (psk_slice.len != hash_len) {
+                candidate_state.deinit();
+                return error.InvalidHandshakeState;
+            }
+            var psk_buf: [hash_len]u8 = undefined;
+            @memcpy(&psk_buf, psk_slice);
+            candidate_state.deinit();
+
+            const ok = pre_shared_key.verifyBinder(.sha256, &psk_buf, truncated_prefix, pair.binder) catch {
+                crypto.secureZero(u8, &psk_buf);
+                return error.InvalidHandshakeState;
+            };
+            if (!ok) {
+                crypto.secureZero(u8, &psk_buf);
+                return error.DecryptError;
+            }
+            return .{ .index = attempts, .psk = psk_buf };
+        }
+        return null;
+    }
+
+    fn candidateTransportCompat(self: *const Tls13Backend) ?session.CandidateCompat {
+        if (self.peer_transport_extension_len == 0) return null;
+        const ext_type = self.profile.extensionType() orelse return null;
+        return .{
+            .format_id = ext_type,
+            .format_version = 1,
+            .bytes = self.peer_transport_extension[0..self.peer_transport_extension_len],
+        };
+    }
+
+    /// PSK-resumed server flight: EncryptedExtensions straight to Finished —
+    /// no CertificateRequest, Certificate, or CertificateVerify (RFC 8446
+    /// §4.2.11, resumption-PSK-only profile).
+    fn emitPskFinishFlight(self: *Tls13Backend, sink: *EventSink) HandshakeError!void {
+        var buf: [max_message_len]u8 = undefined;
+        var w = Writer{ .buf = &buf };
+        try w.u8_(@intFromEnum(MessageType.encrypted_extensions));
+        const ee_len = try w.reserve(3);
+        const ee_extensions = try w.reserve(2);
+        if (self.selectedAlpn()) |negotiated_alpn| {
+            try w.u16_(ext_alpn);
+            const alpn_ext_len = try w.reserve(2);
+            const alpn_list_len = try w.reserve(2);
+            try w.u8_(@intCast(negotiated_alpn.len));
+            try w.bytes(negotiated_alpn);
+            w.patch(2, alpn_list_len);
+            w.patch(2, alpn_ext_len);
+        }
+        if (self.profile.extensionType()) |extension_type| {
+            const payload = self.profile.localExtension() orelse return error.MissingTransportExtension;
+            try w.u16_(extension_type);
+            try w.u16_(@intCast(payload.len));
+            try w.bytes(payload);
+        }
+        w.patch(2, ee_extensions);
+        w.patch(3, ee_len);
+        self.core.recordSent(buf[0..w.len]) catch |err| return mapCoreError(err);
+        try sink.emitCrypto(.handshake, buf[0..w.len]);
+
+        const schedule = &self.schedule.?;
+        var fbuf: [handshake_header_len + hash_len]u8 = undefined;
+        var fw = Writer{ .buf = &fbuf };
+        try fw.u8_(@intFromEnum(MessageType.finished));
+        const finished_len = try fw.reserve(3);
+        var server_verify = KeySchedule.verifyData(&schedule.server_handshake_traffic, self.core.transcriptHash());
+        defer crypto.secureZero(u8, &server_verify);
+        try fw.bytes(&server_verify);
+        fw.patch(3, finished_len);
+        const finished = fbuf[0..fw.len];
+        self.core.recordSent(finished) catch |err| return mapCoreError(err);
+        try sink.emitCrypto(.handshake, finished);
+
+        const finished_hash = self.core.transcriptHash();
+        var app = schedule.applicationSecrets(finished_hash);
+        defer app.wipe();
+        try self.emitSecret(sink, .application, .read, &app.client);
+        try self.emitSecret(sink, .application, .write, &app.server);
     }
 
     /// Validate the selected credential, emit EncryptedExtensions+Certificate,
@@ -2499,6 +2834,13 @@ pub const Tls13Backend = struct {
         crypto.secureZero(u8, &self.expected_client_verify);
     }
 };
+
+fn mapPskReadError(err: pre_shared_key.ReadError) HandshakeError {
+    return switch (err) {
+        error.MalformedHandshake, error.EmptyIdentity, error.InvalidBinderLength, error.EmptyVector => error.MalformedHandshake,
+        error.CountMismatch => error.IllegalParameter,
+    };
+}
 
 fn mapTicketDecodeError(err: new_session_ticket.DecodeError) HandshakeError {
     return switch (err) {

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -1383,20 +1383,22 @@ pub const Tls13Backend = struct {
         if (common.application_protocol) |*stored| {
             if (!self.profile.containsAlpn(stored.slice())) return false;
         }
-        if (!compatCompatible(common.transport_compat, self.candidateOwnTransportCompat())) return false;
+        // `common.transport_compat` is the *server's* transport snapshot
+        // (stamped via `peerTransportCompat()` at issuance, from the
+        // server's EncryptedExtensions) — there is no local value to
+        // prefilter it against here; comparing it to this client's own
+        // outbound extension (`profile.localExtension()`) would compare the
+        // wrong direction and could silently filter out every ticket
+        // whenever the two peers' payloads differ, which is the ordinary
+        // case for opaque transport parameters. The one correct-direction
+        // check — the stored peer snapshot against the newly *received*
+        // server extension — happens after ServerHello, in
+        // `onEncryptedExtensions`, once there is a value to compare it
+        // against; that failure is fatal there rather than a
+        // pre-offer fallback, since a PSK-selected ServerHello cannot be
+        // un-sent.
         if (!compatCompatible(common.application_compat, self.candidateApplicationCompat())) return false;
         return true;
-    }
-
-    /// The transport-compatibility snapshot for *this side's own* intended
-    /// transport extension, in the same `(format_id, format_version, bytes)`
-    /// convention `peerTransportCompat` uses for the peer's — so a client's
-    /// eligibility recheck and a server's candidate evaluation compare
-    /// snapshots built the same way.
-    fn candidateOwnTransportCompat(self: *const Tls13Backend) ?session.CandidateCompat {
-        const ext_type = self.profile.extensionType() orelse return null;
-        const payload = self.profile.localExtension() orelse return null;
-        return .{ .format_id = ext_type, .format_version = 1, .bytes = payload };
     }
 
     /// The application-compatibility candidate view of `self.application_compat`
@@ -1432,6 +1434,15 @@ pub const Tls13Backend = struct {
     }
 
     fn onServerHello(self: *Tls13Backend, body: []const u8, sink: *EventSink) HandshakeError!void {
+        // #362: any failure below — malformed framing, an out-of-range
+        // `selected_identity`, or anything else — must not leave owned PSK
+        // offer/selected-ticket state sitting in a now-failed backend past
+        // this call.
+        errdefer {
+            self.client_psk_offers.deinit();
+            self.selected_client_psk.deinit();
+            self.selected_client_psk_present = false;
+        }
         var r = Reader{ .bytes = body };
         if (try r.u16_() != legacy_version) return error.IllegalParameter;
         const random = try r.slice(32);
@@ -1514,6 +1525,13 @@ pub const Tls13Backend = struct {
     }
 
     fn onEncryptedExtensions(self: *Tls13Backend, body: []const u8, sink: *EventSink) HandshakeError!void {
+        // #362: a parse/ALPN/transport failure here — before the retained
+        // selected ticket is ever reached below — must not leave it alive
+        // in a now-failed backend.
+        errdefer if (self.selected_client_psk_present) {
+            self.selected_client_psk.deinit();
+            self.selected_client_psk_present = false;
+        };
         var r = Reader{ .bytes = body };
         var guard = ExtensionGuard{};
         var transport_extension_seen = false;
@@ -2225,18 +2243,6 @@ pub const Tls13Backend = struct {
         }
         if (!offers_tls13 or !offers_x25519_group) return error.MalformedHandshake;
         if (psk_ext != null and !psk_modes_seen) return error.MissingExtension;
-        self.clearClientHelloPsk();
-        if (psk_ext) |info| {
-            var capture: ClientHelloPskCapture = .{};
-            if (raw.len > capture.message.len) return error.MalformedHandshake;
-            @memcpy(capture.message[0..raw.len], raw);
-            capture.message_len = raw.len;
-            capture.ext_data_offset = info.offset;
-            capture.ext_data_len = info.len;
-            self.client_hello_psk = capture;
-            self.offered_psk_modes_seen = true;
-            self.offered_psk_dhe_ke = psk_dhe_ke_offered;
-        }
         // signature_algorithms is required whenever the server authenticates
         // with a certificate (RFC 8446 §9.2). A missing or empty list is a
         // malformed/missing required *peer* extension — attribute it to the
@@ -2255,6 +2261,31 @@ pub const Tls13Backend = struct {
             const extension = transport_params orelse return error.MissingTransportExtension;
             try self.capturePeerTransportExtension(extension);
         }
+
+        // #362: the PSK-bearing ClientHello is captured only once every
+        // other semantic check above has already succeeded — not eagerly
+        // as soon as it's parsed — so a later unrelated failure (missing
+        // signature_algorithms, ALPN mismatch, missing transport extension)
+        // can never leave a captured bearer ticket identity sitting in
+        // `client_hello_psk` past this call.
+        self.clearClientHelloPsk();
+        if (psk_ext) |info| {
+            var capture: ClientHelloPskCapture = .{};
+            if (raw.len > capture.message.len) return error.MalformedHandshake;
+            @memcpy(capture.message[0..raw.len], raw);
+            capture.message_len = raw.len;
+            capture.ext_data_offset = info.offset;
+            capture.ext_data_len = info.len;
+            self.client_hello_psk = capture;
+            self.offered_psk_modes_seen = true;
+            self.offered_psk_dhe_ke = psk_dhe_ke_offered;
+        }
+        // Covers every synchronous failure from here on (a bad session_id,
+        // a synchronous credential-selection failure); a no-op once
+        // `emitServerHelloAndAuthFlight` has already cleared it on its own
+        // path, and correctly does *not* fire when selection instead parks
+        // — the capture must survive for the async resume.
+        errdefer self.clearClientHelloPsk();
 
         try self.beginServerSelection(session_id, client_share, sink);
     }
@@ -2332,9 +2363,9 @@ pub const Tls13Backend = struct {
         // Installed before any fallible PSK step below, so a resolver or
         // binder failure still clears the captured ClientHello.
         defer self.clearClientHelloPsk();
-        const current_binding = try self.validateSelectedServerCredential(credential);
-        self.connection_auth_binding = current_binding;
-        var psk_selected = try self.selectPsk(current_binding);
+        const credential_info = try self.inspectSelectedServerCredential(credential);
+        self.connection_auth_binding = credential_info.binding;
+        var psk_selected = try self.selectPsk(credential_info.binding);
         defer if (psk_selected) |*sel| crypto.secureZero(u8, &sel.psk);
 
         // ServerHello (Initial level).
@@ -2390,7 +2421,7 @@ pub const Tls13Backend = struct {
         }
 
         owned = false;
-        try self.emitServerAuthFlight(credential, sink);
+        try self.emitServerAuthFlight(credential, credential_info.certificate_message_len, sink);
     }
 
     /// #362 server selection algorithm: iterate the client's offered
@@ -2526,37 +2557,22 @@ pub const Tls13Backend = struct {
     /// Validate the selected credential, emit EncryptedExtensions+Certificate,
     /// then sign CertificateVerify — synchronously, or by parking a pending
     /// signer. On any failure the handle is released exactly once.
-    fn emitServerAuthFlight(self: *Tls13Backend, credential: credentials.SelectedCredential, sink: *EventSink) HandshakeError!void {
+    /// `certificate_message_len` is `inspectSelectedServerCredential`'s
+    /// already-complete validation of `credential` (every chain entry, not
+    /// only the leaf, and the aggregate encoded size) — the single source
+    /// of truth for whether this credential is acceptable at all, shared
+    /// with the PSK path so neither validates it more weakly than the
+    /// other.
+    fn emitServerAuthFlight(
+        self: *Tls13Backend,
+        credential: credentials.SelectedCredential,
+        certificate_message_len: usize,
+        sink: *EventSink,
+    ) HandshakeError!void {
         var owned = true;
         errdefer if (owned) credential.release();
 
-        // Validate provider output before trusting it: the returned scheme must
-        // have been offered (else the CertificateVerify carries an algorithm the
-        // client never advertised), and the chain must fit the flight bounds. A
-        // violation is a local provider fault; signing never happens.
-        const selection = self.serverSelectionContext();
-        if (!selection.offersScheme(credential.scheme))
-            return self.failCredential(.invalid_callback_behavior);
         const chain = credential.certificateChain();
-        if (chain.count() == 0 or chain.count() > credentials.max_chain_entries)
-            return self.failCredential(.malformed_credential_chain);
-        // Sum the CertificateList entry encoding (each entry + its 5-byte
-        // framing) and the Certificate message's own header. The remaining
-        // preflight — that this plus EncryptedExtensions and CertificateRequest
-        // all fit one flight buffer — is completed after those messages are
-        // built, below, and before any state mutation.
-        var certificate_message_len: usize = certificate_message_overhead;
-        for (chain.entries) |entry| {
-            if (entry.len == 0 or entry.len > max_certificate_len)
-                return self.failCredential(.malformed_credential_chain);
-            // CertificateEntry framing overhead: 3-byte cert_data length +
-            // 2-byte extensions length.
-            certificate_message_len = std.math.add(usize, certificate_message_len, entry.len + 5) catch
-                return self.failCredential(.malformed_credential_chain);
-            if (certificate_message_len > max_message_len)
-                return self.failCredential(.malformed_credential_chain);
-        }
-
         var buf: [max_message_len]u8 = undefined;
         var w = Writer{ .buf = &buf };
 
@@ -3001,7 +3017,7 @@ pub const Tls13Backend = struct {
     /// A PSK-resumed connection has no Certificate message on either side to
     /// derive that from, so both roles instead stamp
     /// `connection_auth_binding` explicitly: the server from the credential
-    /// it validated before PSK selection (`validateSelectedServerCredential`
+    /// it validated before PSK selection (`inspectSelectedServerCredential`
     /// — the server's *own* leaf, not the client's), the client from the
     /// selected ticket's stored binding — so a later ticket issued on a
     /// resumed connection still carries the original server-certificate
@@ -3017,20 +3033,48 @@ pub const Tls13Backend = struct {
     /// candidate ticket is compared against the identity this connection
     /// actually authenticates with, not the (normally empty, client-side)
     /// peer chain.
-    fn validateSelectedServerCredential(
+    pub const SelectedServerCredentialInfo = struct {
+        binding: session.AuthBinding,
+        /// The exact encoded Certificate message length this chain would
+        /// produce (`certificate_message_overhead` + each entry's
+        /// `certificate_entry_overhead`-framed size) — reused by
+        /// `emitServerAuthFlight`'s own flight-size preflight instead of
+        /// recomputing it.
+        certificate_message_len: usize,
+    };
+
+    /// Complete validation of the credential selection already performed
+    /// for this ClientHello — every chain entry, not just the leaf, and the
+    /// aggregate encoded size, exactly as `emitServerAuthFlight` requires
+    /// before ever signing. Called unconditionally before PSK selection —
+    /// not only along the full-certificate path — so a malformed remaining
+    /// chain entry can never be accepted merely because PSK selection later
+    /// succeeds and skips the certificate flight entirely.
+    fn inspectSelectedServerCredential(
         self: *Tls13Backend,
         credential: credentials.SelectedCredential,
-    ) HandshakeError!session.AuthBinding {
+    ) HandshakeError!SelectedServerCredentialInfo {
         const selection = self.serverSelectionContext();
         if (!selection.offersScheme(credential.scheme))
             return self.failCredential(.invalid_callback_behavior);
         const chain = credential.certificateChain();
         if (chain.count() == 0 or chain.count() > credentials.max_chain_entries)
             return self.failCredential(.malformed_credential_chain);
-        const leaf = chain.entries[0];
-        if (leaf.len == 0 or leaf.len > max_certificate_len)
-            return self.failCredential(.malformed_credential_chain);
-        return session.AuthBinding.fromLeafCertificateDer(leaf);
+
+        var certificate_message_len: usize = certificate_message_overhead;
+        for (chain.entries) |entry| {
+            if (entry.len == 0 or entry.len > max_certificate_len)
+                return self.failCredential(.malformed_credential_chain);
+            certificate_message_len = std.math.add(usize, certificate_message_len, entry.len + certificate_entry_overhead) catch
+                return self.failCredential(.malformed_credential_chain);
+            if (certificate_message_len > max_message_len)
+                return self.failCredential(.malformed_credential_chain);
+        }
+
+        return .{
+            .binding = session.AuthBinding.fromLeafCertificateDer(chain.entries[0]),
+            .certificate_message_len = certificate_message_len,
+        };
     }
 
     fn peerTransportCompat(self: *const Tls13Backend) ?new_session_ticket.CompatBlob {

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -2629,7 +2629,7 @@ pub const Tls13Backend = struct {
             // error, and the success `return` below.
             defer candidate_state.deinit();
             const found = resolver.resolve(pair.identity.identity, &candidate_state) catch
-                return error.CredentialProviderFailed;
+                return self.failCredential(.provider_internal_failure);
             if (!found) continue;
 
             const candidate_ctx: session.CandidateContext = .{

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -547,6 +547,13 @@ pub const Tls13Backend = struct {
     /// this connection's PSK state.
     selected_server_psk: SelectedServerPsk = .{},
     selected_server_psk_present: bool = false,
+    /// True only once the terminal handshake-completion sequence
+    /// (Finished-MAC verification, resumption-master-secret capture, and
+    /// the completion event) has fully succeeded — distinct from
+    /// `core.handshake_lifecycle == .complete`, which `Core` sets as soon
+    /// as a Finished message's *ordering* is accepted, before any of that
+    /// has happened. See `clearFailedHandshakeState`.
+    handshake_committed: bool = false,
     /// Server (#362): the configured stateful/stateless identity resolver.
     /// `null` means this server never offers PSK resumption.
     psk_resolver: ?pre_shared_key.ServerPskResolver = null,
@@ -571,7 +578,14 @@ pub const Tls13Backend = struct {
     /// merely-handshake-scoped borrow would be safe to assume live.
     application_compat_format_id: u16 = 0,
     application_compat_format_version: u16 = 0,
-    application_compat_bytes: [max_transport_extension_len]u8 = undefined,
+    /// Sized to `session.hard_max_compat_len` — the actual ceiling the
+    /// shared session model allows for an application-compatibility
+    /// snapshot (`session.Limits.default.max_application_compat_len` is
+    /// 1024 of that 8192-byte hard maximum) — not
+    /// `max_transport_extension_len` (512), which bounds an unrelated
+    /// QUIC/H3 transport-extension payload and would silently reject a
+    /// snapshot the session model itself accepts.
+    application_compat_bytes: [session.hard_max_compat_len]u8 = undefined,
     application_compat_len: usize = 0,
     application_compat_present: bool = false,
     /// #362: the most recent successful PSK selection's ticket-age skew
@@ -764,14 +778,18 @@ pub const Tls13Backend = struct {
     /// Client (#362): configure the resumption tickets to offer at the next
     /// ClientHello and the clock used to check their expiry and compute
     /// their obfuscated age. Takes ownership of `offers` (moved out; the
-    /// caller's set is left empty). Must be called before `start`.
+    /// caller's set is left empty) only on success. Must be called before
+    /// `start` — replacing the offer set after ClientHello emission would
+    /// desync `onServerHello`'s `selected_identity` from the array it
+    /// actually indexes.
     pub fn setClientPskOffers(
         self: *Tls13Backend,
         offers: *pre_shared_key.ClientPskOfferSet,
         now_ctx: *anyopaque,
         nowUnixMsFn: *const fn (*anyopaque) i64,
-    ) void {
-        std.debug.assert(self.role == .client);
+    ) HandshakeError!void {
+        if (self.role != .client) return error.InvalidHandshakeState;
+        if (self.core.handshake_lifecycle != .idle) return error.InvalidHandshakeState;
         self.client_psk_offers.deinit();
         self.client_psk_offers.moveFrom(offers);
         self.psk_now_ctx = now_ctx;
@@ -781,8 +799,12 @@ pub const Tls13Backend = struct {
     /// Server (#362): configure the stateful/stateless identity resolver
     /// used to select and verify an offered resumption PSK. Without one, the
     /// server never offers or accepts PSK resumption (full handshake only).
-    pub fn setServerPskResolver(self: *Tls13Backend, resolver: pre_shared_key.ServerPskResolver) void {
-        std.debug.assert(self.role == .server);
+    /// Must be called before `start` — swapping the resolver mid-handshake
+    /// (e.g. while an async credential selection is pending) would change
+    /// the selection policy applied to an already-captured ClientHello.
+    pub fn setServerPskResolver(self: *Tls13Backend, resolver: pre_shared_key.ServerPskResolver) HandshakeError!void {
+        if (self.role != .server) return error.InvalidHandshakeState;
+        if (self.core.handshake_lifecycle != .idle) return error.InvalidHandshakeState;
         self.psk_resolver = resolver;
     }
 
@@ -793,8 +815,9 @@ pub const Tls13Backend = struct {
     /// bounded storage — the caller's slice need not outlive this call —
     /// because this value is read again during post-handshake ticket
     /// issuance/ingestion, not only during the handshake itself. Must be
-    /// called before `start`.
+    /// called before `start`, for the same reason as `setServerPskResolver`.
     pub fn setApplicationCompat(self: *Tls13Backend, blob: ?new_session_ticket.CompatBlob) HandshakeError!void {
+        if (self.core.handshake_lifecycle != .idle) return error.InvalidHandshakeState;
         if (blob) |b| {
             if (b.bytes.len > self.application_compat_bytes.len) return error.TransportBufferOverflow;
             self.application_compat_format_id = b.format_id;
@@ -977,6 +1000,7 @@ pub const Tls13Backend = struct {
         self.selected_client_psk_present = false;
         self.selected_server_psk.deinit();
         self.selected_server_psk_present = false;
+        self.handshake_committed = false;
         self.clearClientHelloPsk();
         crypto.secureZero(u8, &self.expected_client_verify);
         self.wipeEphemeral();
@@ -1037,25 +1061,34 @@ pub const Tls13Backend = struct {
         self.offered_psk_dhe_ke = false;
     }
 
-    /// #362: wipes owned PSK *negotiation* state on any handshake-phase
-    /// failure — installed via `errdefer` at the `receiveImpl`/`resumeAuth`
-    /// call boundary (not only inside the individual message handlers), so
-    /// a terminal failure that occurs before or between handler dispatch
-    /// (message-order rejection, wrong transport epoch, a malformed frame,
-    /// an async operation's own failure) cannot leave this state resident
-    /// in a backend that will not be torn down until some later, unrelated
-    /// `deinit()`.
+    /// Wipes owned PSK/schedule/RMS state on any handshake-phase failure —
+    /// installed via `errdefer` at the `receiveImpl`/`startImpl`/
+    /// `resumeAuth` call boundary (not only inside the individual message
+    /// handlers), so a terminal failure that occurs before or between
+    /// handler dispatch (message-order rejection, wrong transport epoch, a
+    /// malformed frame, an async operation's own failure) cannot leave this
+    /// state resident in a backend that will not be torn down until some
+    /// later, unrelated `deinit()`.
     ///
-    /// Deliberately a no-op once the handshake has actually completed:
-    /// `selected_server_psk` and `last_psk_age_skew` are meant to outlive a
-    /// *successful* handshake, for #365/#366 to consume via their one-shot
-    /// accessors — an unrelated post-handshake failure (a malformed
-    /// `NewSessionTicket`, say) must not destroy them before the caller has
-    /// had a chance to read them. A failure *during* the handshake, by
-    /// contrast, means the connection never actually succeeded, so there is
-    /// nothing legitimate left to preserve.
-    fn clearPskHandshakeState(self: *Tls13Backend) void {
-        if (self.core.handshake_lifecycle == .complete) return;
+    /// Gated on `handshake_committed`, **not** `core.handshake_lifecycle ==
+    /// .complete`: `Core` transitions to `.complete` as soon as the
+    /// Finished message's *ordering* is accepted — before this backend has
+    /// verified its MAC (`onClientFinished`/`onServerFinished`), captured
+    /// the resumption master secret, or emitted the completion event. A bad
+    /// Finished, or any failure in that terminal sequence, would otherwise
+    /// see `.complete` and skip cleanup entirely, leaving
+    /// `selected_server_psk`/`last_psk_age_skew`/the schedule/the RMS
+    /// exposed on a backend that never actually finished authenticating.
+    /// `handshake_committed` is set `true` only once every one of those
+    /// terminal fallible steps has actually succeeded (see
+    /// `completeClientHandshake` and `onClientFinished`), so this remains a
+    /// no-op only for a *genuinely* committed handshake — deliberately,
+    /// since `selected_server_psk`/`last_psk_age_skew` are meant to outlive
+    /// a real success for #365/#366's one-shot accessors, and an unrelated
+    /// post-handshake failure (a malformed `NewSessionTicket`, say) must
+    /// not destroy them before the caller has had a chance to read them.
+    fn clearFailedHandshakeState(self: *Tls13Backend) void {
+        if (self.handshake_committed) return;
         self.client_psk_offers.deinit();
         self.selected_client_psk.deinit();
         self.selected_client_psk_present = false;
@@ -1065,11 +1098,17 @@ pub const Tls13Backend = struct {
         self.clearClientHelloPsk();
         if (self.schedule) |*schedule| schedule.wipe();
         self.schedule = null;
+        self.resumption_master_secret.deinit();
+        self.core.psk_authenticated = false;
+        // `Core` may already have (incorrectly, from this backend's
+        // perspective) advanced to `.complete` on message ordering alone;
+        // correct that externally-visible state to match reality.
+        if (self.core.handshake_lifecycle != .idle) self.core.handshake_lifecycle = .failed;
     }
 
     fn startImpl(ptr: *anyopaque, role: Role, _: void, sink: *EventSink) HandshakeError!void {
         const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
-        errdefer self.clearPskHandshakeState();
+        errdefer self.clearFailedHandshakeState();
         // The driver's role comes from Handshake.initClient/initServer and must
         // match how this backend was constructed; a mismatch is a wiring bug.
         std.debug.assert(role == self.role);
@@ -1102,9 +1141,9 @@ pub const Tls13Backend = struct {
         // `drainInput` itself (message ordering, transport epoch, framing)
         // before any per-message handler ever runs — not only the ones the
         // individual handlers already guard locally. See
-        // `clearPskHandshakeState` for why this is a no-op once the
+        // `clearFailedHandshakeState` for why this is a no-op once the
         // handshake has completed.
-        errdefer self.clearPskHandshakeState();
+        errdefer self.clearFailedHandshakeState();
         switch (level) {
             .zero_rtt => return error.UnexpectedTransportEpoch,
             .application => {
@@ -2036,6 +2075,9 @@ pub const Tls13Backend = struct {
         try self.emitDiscardKeys(sink, .handshake);
         try sink.emitHandshakeComplete();
         self.finish();
+        // Only now — every terminal fallible step above has succeeded — is
+        // this handshake actually committed. See `clearFailedHandshakeState`.
+        self.handshake_committed = true;
     }
 
     /// The immutable selection context for choosing the client's own
@@ -2879,7 +2921,7 @@ pub const Tls13Backend = struct {
         // (both ordinary, non-error returns below); fires on the operation's
         // own failure and on any terminal error from resuming into
         // `dispatchResume`/`drainInput`.
-        errdefer self.clearPskHandshakeState();
+        errdefer self.clearFailedHandshakeState();
         const op = self.pending_op orelse return;
         const stage = self.pending_stage;
         var completion: credentials.Completion = undefined;
@@ -3066,6 +3108,9 @@ pub const Tls13Backend = struct {
         try self.emitDiscardKeys(sink, .handshake);
         try sink.emitHandshakeComplete();
         self.finish();
+        // Only now — every terminal fallible step above has succeeded — is
+        // this handshake actually committed. See `clearFailedHandshakeState`.
+        self.handshake_committed = true;
     }
 
     // -----------------------------------------------------------------------

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -616,13 +616,26 @@ pub const Tls13Backend = struct {
 
     /// Reassembler capacity is `max_message_len + 4` (see `initial_input`),
     /// so the capture buffer matches that bound exactly.
-    const ClientHelloPskCapture = struct {
+    pub const ClientHelloPskCapture = struct {
         message: [max_message_len + handshake_header_len]u8 = undefined,
         message_len: usize = 0,
         /// Offset of the `pre_shared_key` extension's `extension_data`
         /// within `message`.
         ext_data_offset: usize = 0,
         ext_data_len: usize = 0,
+
+        /// Zeroizes the captured bytes in place. Exposed (`pub`) so its
+        /// zeroing behavior can be proven directly, on a plain value, in
+        /// isolation from the `?ClientHelloPskCapture = null` transition
+        /// `clearClientHelloPsk` performs right after calling this —
+        /// reading the backend's own field after that transition would
+        /// observe whatever Zig's debug-safety instrumentation does to an
+        /// invalidated optional's payload, not necessarily this method's
+        /// effect.
+        pub fn wipe(self: *ClientHelloPskCapture) void {
+            crypto.secureZero(u8, self.message[0..self.message_len]);
+            self.message_len = 0;
+        }
     };
 
     pub const SessionTicketConsumer = struct {
@@ -1062,7 +1075,7 @@ pub const Tls13Backend = struct {
     /// captured it.
     fn clearClientHelloPsk(self: *Tls13Backend) void {
         if (self.client_hello_psk) |*capture| {
-            crypto.secureZero(u8, capture.message[0..capture.message_len]);
+            capture.wipe();
         }
         self.client_hello_psk = null;
         self.offered_psk_modes_seen = false;

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -525,6 +525,15 @@ pub const Tls13Backend = struct {
     client_psk_offers: pre_shared_key.ClientPskOfferSet = .{},
     psk_now_ctx: ?*anyopaque = null,
     psk_now_fn: ?*const fn (*anyopaque) i64 = null,
+    /// Client (#362): the ticket state named by the server's
+    /// `selected_identity`, retained (moved out of `client_psk_offers`)
+    /// until EncryptedExtensions has been checked against its stored
+    /// context and its `auth_binding` has been carried forward into
+    /// `connection_auth_binding`. Deinitialized once that has happened, on
+    /// every path (success, mismatch/fallback-is-not-possible-here-so-
+    /// fatal, or teardown).
+    selected_client_psk: session.ClientTicketState = .{},
+    selected_client_psk_present: bool = false,
     /// Server (#362): the configured stateful/stateless identity resolver.
     /// `null` means this server never offers PSK resumption.
     psk_resolver: ?pre_shared_key.ServerPskResolver = null,
@@ -535,6 +544,22 @@ pub const Tls13Backend = struct {
     /// verify the selected identity's binder over the exact received bytes.
     /// Cleared once selection has run, on every path.
     client_hello_psk: ?ClientHelloPskCapture = null,
+    /// #362: the authenticated identity binding for this connection, when it
+    /// differs from `peerAuthBinding()`'s peer-certificate-chain default —
+    /// see `effectiveAuthBinding`.
+    connection_auth_binding: ?session.AuthBinding = null,
+    /// #362/#365 seam: the application-layer compatibility snapshot this
+    /// connection is configured with, compared against a candidate PSK's
+    /// stored `application_compat` (server) and used to recheck an offered
+    /// ticket (client). `null` means this connection has none configured —
+    /// symmetric with a ticket that also has none.
+    application_compat: ?new_session_ticket.CompatBlob = null,
+    /// #362: the most recent successful PSK selection's ticket-age skew
+    /// observation (apparent vs. actual elapsed time since issuance), taken
+    /// exactly once by `takePskAgeSkew`. Informational only — skew alone
+    /// never rejects ordinary 1-RTT resumption; #366 is the intended
+    /// consumer (e.g. to gate early-data acceptance).
+    last_psk_age_skew: ?pre_shared_key.AgeSkew = null,
 
     const Slice = struct { start: usize, len: usize };
     const PendingStage = enum { server_select, server_sign, client_select, client_sign, peer_verify };
@@ -726,6 +751,22 @@ pub const Tls13Backend = struct {
         self.psk_resolver = resolver;
     }
 
+    /// #362/#365: configure this connection's application-layer
+    /// compatibility snapshot (e.g. HTTP/3 settings), compared against a
+    /// candidate PSK's stored value on the server and used to recheck an
+    /// offered ticket on the client. `blob.bytes` must outlive the
+    /// handshake. Must be called before `start`.
+    pub fn setApplicationCompat(self: *Tls13Backend, blob: ?new_session_ticket.CompatBlob) void {
+        self.application_compat = blob;
+    }
+
+    /// #362: takes (clears) the most recent successful PSK selection's
+    /// ticket-age skew observation, if any — a one-shot accessor for #366.
+    pub fn takePskAgeSkew(self: *Tls13Backend) ?pre_shared_key.AgeSkew {
+        defer self.last_psk_age_skew = null;
+        return self.last_psk_age_skew;
+    }
+
     pub fn setSessionTicketConsumer(
         self: *Tls13Backend,
         allocator: std.mem.Allocator,
@@ -851,6 +892,11 @@ pub const Tls13Backend = struct {
         self.psk_now_ctx = null;
         self.psk_now_fn = null;
         self.psk_resolver = null;
+        self.connection_auth_binding = null;
+        self.application_compat = null;
+        self.last_psk_age_skew = null;
+        self.selected_client_psk.deinit();
+        self.selected_client_psk_present = false;
         self.clearClientHelloPsk();
         crypto.secureZero(u8, &self.expected_client_verify);
         self.wipeEphemeral();
@@ -896,10 +942,16 @@ pub const Tls13Backend = struct {
     }
 
     /// Clears the captured ClientHello PSK state (#362): on every path once
-    /// selection has run (success, fallback, or no PSK offered at all). Not
-    /// itself secret (the ClientHello is transcript-public wire data), but
-    /// scoped tightly to the connection it was captured for.
+    /// selection has run (success, fallback, error, or no PSK offered at
+    /// all). The framed ClientHello bytes are transcript-public wire data,
+    /// not secret, but this still wipes the whole capture (rather than only
+    /// nulling the optional) so no scratch copy of a peer-supplied opaque
+    /// ticket identity lingers in backend storage past the connection that
+    /// captured it.
     fn clearClientHelloPsk(self: *Tls13Backend) void {
+        if (self.client_hello_psk) |*capture| {
+            crypto.secureZero(u8, capture.message[0..capture.message_len]);
+        }
         self.client_hello_psk = null;
         self.offered_psk_modes_seen = false;
         self.offered_psk_dhe_ke = false;
@@ -916,8 +968,14 @@ pub const Tls13Backend = struct {
         // configuration error; fail closed before any lifecycle or transcript
         // advance rather than emitting SNI for a truncated (wrong) host.
         if (self.server_name_overflow) return error.InvalidHandshakeState;
-        if (self.role == .client and try self.clientHelloEncodedLen() > max_message_len)
-            return error.InvalidTransportProfile;
+        if (self.role == .client) {
+            const base_len = try self.clientHelloEncodedLen();
+            if (base_len > max_message_len) return error.InvalidTransportProfile;
+            // #362: decide which offered tickets fit — and in what wire
+            // order — before any lifecycle/key-pair state is mutated below,
+            // so a too-large offer never partially advances the handshake.
+            _ = try self.planPskOffer(base_len);
+        }
         self.core.start() catch |err| return mapCoreError(err);
         switch (self.role) {
             .client => {
@@ -1133,6 +1191,11 @@ pub const Tls13Backend = struct {
         // the same bound as every other flight buffer makes that structurally
         // impossible rather than requiring a separate exact-size preflight.
         var buf: [max_message_len]u8 = undefined;
+        // #362: this buffer carries opaque bearer ticket identities and
+        // their binders once patched in below — wiped after the sink and
+        // transcript have their own copies, regardless of how the function
+        // returns.
+        defer crypto.secureZero(u8, &buf);
         var w = Writer{ .buf = &buf };
         try w.u8_(@intFromEnum(MessageType.client_hello));
         const message_len = try w.reserve(3);
@@ -1190,41 +1253,54 @@ pub const Tls13Backend = struct {
             try w.bytes(payload);
         }
 
-        // pre_shared_key (#362): the RFC 8446 §4.2.11 wire rule that it be
-        // the last ClientHello extension is what puts this block after every
-        // other extension above and before the final length patches below.
+        // pre_shared_key (#362): `self.client_psk_offers` was already
+        // compacted to exactly the eligible, size-fitting, wire-ordered
+        // subset by `planPskOffer` (called from `startImpl` before
+        // `core.start()`), so this block only needs to emit it verbatim —
+        // no further filtering here, which is what keeps the transmitted
+        // wire index aligned with `onServerHello`'s `selected_identity`.
+        // RFC 8446 §4.2.11's "last extension" rule is what puts this block
+        // after every other extension above and before the length patches.
         var psk_secrets: [pre_shared_key.max_offered_identities][hash_len]u8 = undefined;
+        defer crypto.secureZero(u8, std.mem.asBytes(&psk_secrets));
         var psk_count: usize = 0;
         var psk_offer_write: ?pre_shared_key.ClientOfferWrite = null;
         if (!self.client_psk_offers.isEmpty()) {
-            if (self.psk_now_fn) |nowFn| {
-                const now_ms = nowFn(self.psk_now_ctx.?);
-                var psk_items: [pre_shared_key.max_offered_identities]pre_shared_key.OfferItem = undefined;
-                for (self.client_psk_offers.constSlice()) |*ticket| {
-                    if (psk_count >= pre_shared_key.max_offered_identities) break;
-                    if (ticket.common.isExpired(now_ms) or ticket.common.isNotYetValid(now_ms)) continue;
-                    if (ticket.common.cipher_suite != .tls_aes_128_gcm_sha256) continue;
-                    const psk = ticket.common.resumption_psk.slice();
-                    if (psk.len != hash_len) continue;
-                    @memcpy(&psk_secrets[psk_count], psk);
-                    psk_items[psk_count] = .{
-                        .identity = ticket.ticket.slice(),
-                        .obfuscated_ticket_age = pre_shared_key.obfuscateTicketAge(ticket.ageMillis(now_ms), ticket.ticket_age_add),
-                        .digest_len = hash_len,
-                    };
-                    psk_count += 1;
-                }
-                if (psk_count > 0) {
-                    try w.u16_(pre_shared_key.ext_psk_key_exchange_modes);
-                    const modes_ext_len = try w.reserve(2);
-                    try pre_shared_key.writeModes(&w, &.{.psk_dhe_ke});
-                    w.patch(2, modes_ext_len);
-                    psk_offer_write = pre_shared_key.writeOffer(&w, psk_items[0..psk_count]) catch |err| switch (err) {
-                        error.TooManyIdentities => unreachable, // psk_count is capped above
-                        error.HandshakeBufferOverflow => return error.HandshakeBufferOverflow,
-                    };
-                }
+            const now_ms = self.psk_now_fn.?(self.psk_now_ctx.?);
+            var psk_items: [pre_shared_key.max_offered_identities]pre_shared_key.OfferItem = undefined;
+            for (self.client_psk_offers.constSlice()) |*ticket| {
+                @memcpy(&psk_secrets[psk_count], ticket.common.resumption_psk.slice());
+                psk_items[psk_count] = .{
+                    .identity = ticket.ticket.slice(),
+                    .obfuscated_ticket_age = pre_shared_key.obfuscateTicketAge(ticket.ageMillis(now_ms), ticket.ticket_age_add),
+                    .digest_len = hash_len,
+                };
+                psk_count += 1;
             }
+            try w.u16_(pre_shared_key.ext_psk_key_exchange_modes);
+            const modes_ext_len = try w.reserve(2);
+            pre_shared_key.writeModes(&w, &.{.psk_dhe_ke}) catch |err| switch (err) {
+                // Exactly one mode, always: never empty, never over 255.
+                error.EmptyModes, error.TooManyModes => unreachable,
+                error.HandshakeBufferOverflow => return error.HandshakeBufferOverflow,
+            };
+            w.patch(2, modes_ext_len);
+            psk_offer_write = pre_shared_key.writeOffer(&w, psk_items[0..psk_count]) catch |err| switch (err) {
+                error.TooManyIdentities => unreachable, // bounded by ClientPskOfferSet's own capacity
+                // `max_message_len` (8 KiB) is far below the u16 (65535)
+                // vector limits these guard, and `planPskOffer` already
+                // rejected any ticket with a zero/oversized identity before
+                // it ever reached `self.client_psk_offers` — so none of
+                // these are reachable through this concrete backend.
+                error.EmptyIdentity,
+                error.IdentityTooLarge,
+                error.IdentitiesVectorTooLarge,
+                error.InvalidBinderLength,
+                error.BindersVectorTooLarge,
+                error.ExtensionTooLarge,
+                => unreachable,
+                error.HandshakeBufferOverflow => return error.HandshakeBufferOverflow,
+            };
         }
 
         w.patch(2, extensions_len);
@@ -1237,18 +1313,98 @@ pub const Tls13Backend = struct {
         if (psk_offer_write) |offer| {
             const prefix = buf[0..offer.truncated_len];
             for (0..psk_count) |i| {
-                const slot = offer.slots[i];
                 var binder: [hash_len]u8 = undefined;
+                defer crypto.secureZero(u8, &binder);
                 pre_shared_key.deriveBinder(.sha256, &psk_secrets[i], prefix, &binder) catch return error.SecretExportFailed;
+                const slot = offer.slots[i];
                 @memcpy(buf[slot.offset..][0..slot.len], &binder);
-                crypto.secureZero(u8, &binder);
             }
         }
-        crypto.secureZero(u8, std.mem.asBytes(&psk_secrets));
 
         const message = buf[0..w.len];
         self.core.recordSent(message) catch |err| return mapCoreError(err);
         try sink.emitCrypto(.initial, message);
+    }
+
+    /// #362: decide, before `core.start()` mutates any lifecycle/key-pair
+    /// state, exactly which offered tickets will fit in the ClientHello and
+    /// in what wire order — compacting `self.client_psk_offers` in place to
+    /// exactly that subset (wiping whatever did not fit/qualify), so
+    /// `sendClientHello`'s later, unfiltered write and `onServerHello`'s
+    /// `selected_identity` interpretation can never disagree about wire
+    /// order. `base_len` is the ordinary (non-PSK) ClientHello length
+    /// already checked against `max_message_len` by the caller.
+    fn planPskOffer(self: *Tls13Backend, base_len: usize) HandshakeError!void {
+        if (self.client_psk_offers.isEmpty()) return;
+        const now_fn = self.psk_now_fn orelse {
+            self.client_psk_offers.deinit();
+            return;
+        };
+        const now_ms = now_fn(self.psk_now_ctx.?);
+
+        var emitted: pre_shared_key.ClientPskOfferSet = .{};
+        errdefer emitted.deinit();
+        // psk_key_exchange_modes: 2 type + 2 ext_len + 1 vector_len + 1 mode.
+        // pre_shared_key: 2 type + 2 ext_len + 2 identities_len + 2 binders_len.
+        var total = try checkedAdd(base_len, 6 + 8);
+
+        for (self.client_psk_offers.slice()) |*ticket| {
+            if (emitted.len >= pre_shared_key.max_offered_identities) break;
+            if (!self.ticketEligibleToOffer(ticket, now_ms)) continue;
+            const identity_len = ticket.ticket.slice().len;
+            if (identity_len == 0 or identity_len > std.math.maxInt(u16)) continue;
+            // identity: 2 len + bytes + 4 age; binder: 1 len + digest.
+            const entry_len = try checkedAdd(try checkedAdd(2, identity_len), 4);
+            const candidate_total = try checkedAdd(try checkedAdd(total, entry_len), 1 + hash_len);
+            if (candidate_total > max_message_len) break; // does not fit: stop, in offer order
+            total = candidate_total;
+            emitted.push(ticket) catch break; // bounded by the loop guard above
+        }
+
+        self.client_psk_offers.deinit(); // whatever was ineligible or did not fit
+        self.client_psk_offers.moveFrom(&emitted);
+    }
+
+    /// Whether `ticket` is still safe and compatible to offer *now*: not
+    /// expired/not-yet-valid, matching cipher suite, and — #362's "SNI,
+    /// ALPN, transport, and application context" recheck — matching the
+    /// currently intended SNI, an ALPN this connection is actually
+    /// offering, and the transport/application compatibility snapshots this
+    /// connection is configured with.
+    fn ticketEligibleToOffer(self: *const Tls13Backend, ticket: *const session.ClientTicketState, now_ms: i64) bool {
+        const common = &ticket.common;
+        if (common.isExpired(now_ms) or common.isNotYetValid(now_ms)) return false;
+        if (common.cipher_suite != .tls_aes_128_gcm_sha256) return false;
+        if (common.resumption_psk.slice().len != hash_len) return false;
+        if (common.server_name) |*stored| {
+            const intended = self.serverNameSlice() orelse return false;
+            if (!stored.eqlIgnoreCase(intended)) return false;
+        } else if (self.serverNameSlice() != null) return false;
+        if (common.application_protocol) |*stored| {
+            if (!self.profile.containsAlpn(stored.slice())) return false;
+        }
+        if (!compatCompatible(common.transport_compat, self.candidateOwnTransportCompat())) return false;
+        if (!compatCompatible(common.application_compat, self.candidateApplicationCompat())) return false;
+        return true;
+    }
+
+    /// The transport-compatibility snapshot for *this side's own* intended
+    /// transport extension, in the same `(format_id, format_version, bytes)`
+    /// convention `peerTransportCompat` uses for the peer's — so a client's
+    /// eligibility recheck and a server's candidate evaluation compare
+    /// snapshots built the same way.
+    fn candidateOwnTransportCompat(self: *const Tls13Backend) ?session.CandidateCompat {
+        const ext_type = self.profile.extensionType() orelse return null;
+        const payload = self.profile.localExtension() orelse return null;
+        return .{ .format_id = ext_type, .format_version = 1, .bytes = payload };
+    }
+
+    /// The application-compatibility candidate view of `self.application_compat`
+    /// (see `setApplicationCompat`), for both the client's eligibility
+    /// recheck and the server's candidate compatibility evaluation.
+    fn candidateApplicationCompat(self: *const Tls13Backend) ?session.CandidateCompat {
+        const blob = self.application_compat orelse return null;
+        return .{ .format_id = blob.format_id, .format_version = blob.format_version, .bytes = blob.bytes };
     }
 
     fn clientHelloEncodedLen(self: *const Tls13Backend) HandshakeError!usize {
@@ -1321,20 +1477,29 @@ pub const Tls13Backend = struct {
             return error.IllegalParameter;
         defer crypto.secureZero(u8, &shared);
 
-        // #362: consistency-check and consume the server's selected_identity
-        // (if any) against our own offers before wiping them — this is the
-        // client's own binder-free trust decision: it selects which *offer*
-        // the index names, never a value the server invented.
+        // #362: consistency-check the server's selected_identity (if any)
+        // against our own offers — `self.client_psk_offers` was already
+        // compacted to exactly the wire-emitted, wire-ordered subset by
+        // `planPskOffer`, so `idx` names an actual offer, never a value the
+        // server invented, and never a stale/filtered-out one. On success,
+        // move the selected ticket into `selected_client_psk` — retained
+        // (not deinitialized yet) until `onEncryptedExtensions` has checked
+        // it against the negotiated context and carried its `auth_binding`
+        // forward. Every other offer is wiped here, on every path (selected
+        // or not, malformed or not).
         var psk_secret: ?[hash_len]u8 = null;
         if (selected_identity) |idx| {
             if (idx >= self.client_psk_offers.len) return error.IllegalParameter;
-            const psk_slice = self.client_psk_offers.tickets[idx].common.resumption_psk.slice();
+            self.client_psk_offers.takeSelected(idx, &self.selected_client_psk);
+            self.selected_client_psk_present = true;
+            const psk_slice = self.selected_client_psk.common.resumption_psk.slice();
             if (psk_slice.len != hash_len) return error.IllegalParameter;
             var buf: [hash_len]u8 = undefined;
             @memcpy(&buf, psk_slice);
             psk_secret = buf;
+        } else {
+            self.client_psk_offers.deinit();
         }
-        self.client_psk_offers.deinit();
 
         self.wipeEphemeral();
         if (psk_secret) |*psk| {
@@ -1387,6 +1552,37 @@ pub const Tls13Backend = struct {
         }
         if (!alpn_seen and !self.profile.allowAbsentAlpn()) return error.AlpnMismatch;
         if (self.profile.extensionType() != null and !transport_extension_seen) return error.MissingTransportExtension;
+
+        // #362: a PSK-resumed connection has no Certificate message from
+        // which to (re)derive `connection_auth_binding`, so this is the one
+        // point the client can check the negotiated context against the
+        // selected ticket's stored one — and the only source for carrying
+        // its `auth_binding` forward (e.g. for a later NewSessionTicket on
+        // this same resumed connection). A mismatch here is fatal, not a
+        // fallback: the PSK was already selected and ServerHello already
+        // sent.
+        if (self.selected_client_psk_present) {
+            defer {
+                self.selected_client_psk.deinit();
+                self.selected_client_psk_present = false;
+            }
+            const stored = &self.selected_client_psk.common;
+            const negotiated_alpn = self.selectedAlpn();
+            const alpn_matches = if (stored.application_protocol) |*proto|
+                (negotiated_alpn != null and proto.eql(negotiated_alpn.?))
+            else
+                negotiated_alpn == null;
+            if (!alpn_matches) return error.IllegalParameter;
+
+            const received_transport: ?session.CandidateCompat = if (self.peerTransportCompat()) |blob|
+                .{ .format_id = blob.format_id, .format_version = blob.format_version, .bytes = blob.bytes }
+            else
+                null;
+            if (!compatCompatible(stored.transport_compat, received_transport)) return error.IllegalParameter;
+            if (!compatCompatible(stored.application_compat, self.candidateApplicationCompat())) return error.IllegalParameter;
+
+            self.connection_auth_binding = stored.auth_binding;
+        }
     }
 
     /// Client: a server CertificateRequest (RFC 8446 §4.3.2) asking us to
@@ -2126,15 +2322,24 @@ pub const Tls13Backend = struct {
         self.wipeEphemeral();
 
         // #362: credential selection (above, by the caller) happens before
-        // this — so a candidate ticket's stored `auth_binding` is compared
-        // against the identity we would otherwise authenticate with — and
-        // PSK selection/binder verification happens before any ServerHello
-        // byte is written, since a selected identity must be named in it.
-        const psk_selected = try self.selectPsk();
+        // this. Validate it and derive the binding for *this server's own*
+        // leaf certificate — not the (normally empty, client-only)
+        // peer-chain default `peerAuthBinding()` returns — so a candidate
+        // ticket's stored `auth_binding` is compared against the identity
+        // this connection actually authenticates with, and PSK
+        // selection/binder verification happens before any ServerHello byte
+        // is written, since a selected identity must be named in it.
+        // Installed before any fallible PSK step below, so a resolver or
+        // binder failure still clears the captured ClientHello.
         defer self.clearClientHelloPsk();
+        const current_binding = try self.validateSelectedServerCredential(credential);
+        self.connection_auth_binding = current_binding;
+        var psk_selected = try self.selectPsk(current_binding);
+        defer if (psk_selected) |*sel| crypto.secureZero(u8, &sel.psk);
 
         // ServerHello (Initial level).
         var hello_buf: [256]u8 = undefined;
+        defer crypto.secureZero(u8, &hello_buf);
         var hello = Writer{ .buf = &hello_buf };
         try hello.u8_(@intFromEnum(MessageType.server_hello));
         const hello_len = try hello.reserve(3);
@@ -2165,10 +2370,8 @@ pub const Tls13Backend = struct {
         try sink.emitCrypto(.initial, server_hello);
         if (self.selectedAlpn()) |protocol| try sink.emitAlpn(protocol);
 
-        if (psk_selected) |sel| {
-            var psk = sel.psk;
-            defer crypto.secureZero(u8, &psk);
-            self.schedule = KeySchedule.initWithPsk(&psk, &shared, self.core.transcriptHash());
+        if (psk_selected) |*sel| {
+            self.schedule = KeySchedule.initWithPsk(&sel.psk, &shared, self.core.transcriptHash());
         } else {
             self.schedule = KeySchedule.init(&shared, self.core.transcriptHash());
         }
@@ -2200,7 +2403,7 @@ pub const Tls13Backend = struct {
     /// continues to the next offered identity. Returns `null` — meaning
     /// "continue with the existing full-certificate flow" — whenever PSK is
     /// not configured/offered/eligible, or no candidate is acceptable.
-    fn selectPsk(self: *Tls13Backend) HandshakeError!?PskSelected {
+    fn selectPsk(self: *Tls13Backend, current_binding: session.AuthBinding) HandshakeError!?PskSelected {
         const resolver = self.psk_resolver orelse return null;
         if (self.client_auth != .disabled) return null;
         if (!self.offered_psk_modes_seen or !self.offered_psk_dhe_ke) return null;
@@ -2218,6 +2421,12 @@ pub const Tls13Backend = struct {
         while (attempts < pre_shared_key.max_offered_identities) : (attempts += 1) {
             const pair = (it.next() catch return null) orelse break;
             var candidate_state: session.ServerRecoverableState = .{};
+            // Unconditional: a resolver contract violation (a `false`/error
+            // return that nonetheless partially wrote `out`) must never
+            // leak recovered secret state, so this covers every exit from
+            // this iteration — not-found/ineligible `continue`, a resolver
+            // error, and the success `return` below.
+            defer candidate_state.deinit();
             const found = resolver.resolve(pair.identity.identity, &candidate_state) catch
                 return error.CredentialProviderFailed;
             if (!found) continue;
@@ -2226,32 +2435,30 @@ pub const Tls13Backend = struct {
                 .cipher_suite = .tls_aes_128_gcm_sha256,
                 .server_name = self.serverNameSlice(),
                 .application_protocol = self.selectedAlpn(),
-                .auth_binding = self.peerAuthBinding(),
+                .auth_binding = current_binding,
                 .transport_compat = self.candidateTransportCompat(),
+                .application_compat = self.candidateApplicationCompat(),
             };
             const decision = session.evaluateCompatibility(&candidate_state.common, candidate_ctx, now);
-            if (decision.resumption != .eligible) {
-                candidate_state.deinit();
-                continue;
-            }
+            if (decision.resumption != .eligible) continue;
 
             const psk_slice = candidate_state.common.resumption_psk.slice();
-            if (psk_slice.len != hash_len) {
-                candidate_state.deinit();
-                return error.InvalidHandshakeState;
-            }
+            if (psk_slice.len != hash_len) return error.InvalidHandshakeState;
             var psk_buf: [hash_len]u8 = undefined;
+            defer crypto.secureZero(u8, &psk_buf);
             @memcpy(&psk_buf, psk_slice);
-            candidate_state.deinit();
 
-            const ok = pre_shared_key.verifyBinder(.sha256, &psk_buf, truncated_prefix, pair.binder) catch {
-                crypto.secureZero(u8, &psk_buf);
+            const ok = pre_shared_key.verifyBinder(.sha256, &psk_buf, truncated_prefix, pair.binder) catch
                 return error.InvalidHandshakeState;
-            };
-            if (!ok) {
-                crypto.secureZero(u8, &psk_buf);
-                return error.DecryptError;
-            }
+            if (!ok) return error.DecryptError; // fatal: never probe a later identity
+
+            // #362: surface the ticket-age skew observation for #366 — skew
+            // alone never rejects this 1-RTT resumption.
+            self.last_psk_age_skew = pre_shared_key.observeAgeSkew(
+                pair.identity.obfuscated_ticket_age,
+                candidate_state.ticket_age_add,
+                elapsedMillis(now, candidate_state.common.issued_at_unix_ms),
+            );
             return .{ .index = attempts, .psk = psk_buf };
         }
         return null;
@@ -2543,6 +2750,12 @@ pub const Tls13Backend = struct {
                 credential.release();
                 self.pending_credential = null;
             }
+            // #362: a pending operation's own failure never reaches
+            // `emitServerHelloAndAuthFlight` (whose `defer` would otherwise
+            // clear this), so any captured server-side PSK offer state is
+            // wiped here explicitly. A no-op for every non-`server_select`
+            // stage, and for a connection that never offered PSK.
+            self.clearClientHelloPsk();
             return self.failCredential(switch (err) {
                 error.InvalidCallbackBehavior => .invalid_callback_behavior,
                 error.OperationFailed => pendingFailureClass(stage),
@@ -2578,12 +2791,20 @@ pub const Tls13Backend = struct {
                 .credential => |c| {
                     if (!self.pending_client_hello_ready) {
                         c.release();
+                        self.clearClientHelloPsk();
                         return error.InvalidHandshakeState;
                     }
                     const session_id = self.pending_client_session_id[0..self.pending_client_session_id_len];
                     const client_share = self.pending_client_share;
                     self.pending_client_hello_ready = false;
                     self.pending_client_session_id_len = 0;
+                    // `emitServerHelloAndAuthFlight` itself clears the PSK
+                    // capture (on every path) before returning, so this is
+                    // the exact same #362 selection this stage would have
+                    // reached synchronously — the captured ClientHello
+                    // (`client_hello_psk`) is backend-owned state, not tied
+                    // to the transient reassembly buffer that already
+                    // discarded the raw bytes when `onClientHello` returned.
                     return self.emitServerHelloAndAuthFlight(session_id, client_share, c, sink);
                 },
                 // Unlike the client, the server MUST authenticate itself in
@@ -2594,9 +2815,13 @@ pub const Tls13Backend = struct {
                 // fault. `Completion.no_credential` does not distinguish
                 // "unavailable" from "incompatible", so both collapse to the
                 // single canonical class here; the wire alert is unaffected.
-                .no_credential => return self.failCredential(.no_credential_available),
+                .no_credential => {
+                    self.clearClientHelloPsk();
+                    return self.failCredential(.no_credential_available);
+                },
                 else => {
                     releaseCompletionCredentials(completion, null);
+                    self.clearClientHelloPsk();
                     return self.failCredential(.invalid_callback_behavior);
                 },
             },
@@ -2754,8 +2979,9 @@ pub const Tls13Backend = struct {
             .cipher_suite = tls_algorithms.CipherSuite.tls_aes_128_gcm_sha256,
             .server_name = if (self.server_name_present) self.server_name[0..self.server_name_len] else null,
             .application_protocol = self.selectedAlpn(),
-            .auth_binding = self.peerAuthBinding(),
+            .auth_binding = self.effectiveAuthBinding(),
             .transport_compat = self.peerTransportCompat(),
+            .application_compat = self.application_compat,
         };
     }
 
@@ -2763,6 +2989,48 @@ pub const Tls13Backend = struct {
         if (self.peer_chain_count == 0) return session.AuthBinding.fromLeafCertificateDer("");
         const leaf = self.peer_chain_entries[0];
         return session.AuthBinding.fromLeafCertificateDer(self.peer_chain[leaf.start..][0..leaf.len]);
+    }
+
+    /// #362: the authenticated identity binding for *this* connection, used
+    /// both to compare a candidate PSK's stored binding and to stamp any
+    /// ticket this connection itself issues/receives.
+    ///
+    /// For an ordinary full handshake this is exactly `peerAuthBinding()`
+    /// (client: the server certificate it verified; server: the client
+    /// certificate, if any, from handshake-time client authentication).
+    /// A PSK-resumed connection has no Certificate message on either side to
+    /// derive that from, so both roles instead stamp
+    /// `connection_auth_binding` explicitly: the server from the credential
+    /// it validated before PSK selection (`validateSelectedServerCredential`
+    /// — the server's *own* leaf, not the client's), the client from the
+    /// selected ticket's stored binding — so a later ticket issued on a
+    /// resumed connection still carries the original server-certificate
+    /// binding forward instead of silently degrading to the empty sentinel.
+    fn effectiveAuthBinding(self: *const Tls13Backend) session.AuthBinding {
+        return self.connection_auth_binding orelse self.peerAuthBinding();
+    }
+
+    /// Server (#362): validates the credential selection already performed
+    /// for this ClientHello — the same checks `emitServerAuthFlight` applies
+    /// before signing — and returns the binding for the server's *own*
+    /// leaf certificate. Called unconditionally before PSK selection so a
+    /// candidate ticket is compared against the identity this connection
+    /// actually authenticates with, not the (normally empty, client-side)
+    /// peer chain.
+    fn validateSelectedServerCredential(
+        self: *Tls13Backend,
+        credential: credentials.SelectedCredential,
+    ) HandshakeError!session.AuthBinding {
+        const selection = self.serverSelectionContext();
+        if (!selection.offersScheme(credential.scheme))
+            return self.failCredential(.invalid_callback_behavior);
+        const chain = credential.certificateChain();
+        if (chain.count() == 0 or chain.count() > credentials.max_chain_entries)
+            return self.failCredential(.malformed_credential_chain);
+        const leaf = chain.entries[0];
+        if (leaf.len == 0 or leaf.len > max_certificate_len)
+            return self.failCredential(.malformed_credential_chain);
+        return session.AuthBinding.fromLeafCertificateDer(leaf);
     }
 
     fn peerTransportCompat(self: *const Tls13Backend) ?new_session_ticket.CompatBlob {
@@ -2834,6 +3102,28 @@ pub const Tls13Backend = struct {
         crypto.secureZero(u8, &self.expected_client_verify);
     }
 };
+
+/// Overflow-safe elapsed time in milliseconds since `issued_ms`, saturating
+/// to zero for a not-yet-valid/clock-skewed candidate rather than trapping
+/// or wrapping, computed in `i128` regardless of how close either input is
+/// to the `i64` extremes.
+fn elapsedMillis(now_ms: i64, issued_ms: i64) u64 {
+    const delta: i128 = @as(i128, now_ms) - @as(i128, issued_ms);
+    if (delta <= 0) return 0;
+    return @intCast(@min(delta, @as(i128, std.math.maxInt(u64))));
+}
+
+/// Symmetric optional equality for a stored `CompatSnapshot` against a
+/// candidate `CandidateCompat`, mirroring `session.zig`'s own (private)
+/// `compatSnapshotMatches`: a snapshot with none stored only matches a
+/// candidate that also supplies none.
+fn compatCompatible(stored: ?session.CompatSnapshot, candidate: ?session.CandidateCompat) bool {
+    if (stored) |*s| {
+        const c = candidate orelse return false;
+        return s.format_id == c.format_id and s.format_version == c.format_version and std.mem.eql(u8, s.slice(), c.bytes);
+    }
+    return candidate == null;
+}
 
 fn mapPskReadError(err: pre_shared_key.ReadError) HandshakeError {
     return switch (err) {

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -483,6 +483,179 @@ test "direct record handshake delivers large post-handshake ticket once" {
     try std.testing.expectEqualSlices(u8, server_state.common.resumption_psk.slice(), &capture.psk);
 }
 
+const pre_shared_key = tls_core.pre_shared_key;
+
+test "PSK round trip: an offered, resolved, and verified ticket resumes the handshake" {
+    // Phase 1: a full handshake, after which the server issues a ticket and
+    // the client captures the resulting ClientTicketState (#361 machinery).
+    var harness = DirectHarness.init();
+    defer harness.deinit();
+
+    const TicketCapture = struct {
+        ticket: session.ClientTicketState = .{},
+        fn now(_: *anyopaque) i64 {
+            return 1000;
+        }
+        fn onTicket(ctx: *anyopaque, ticket: *const session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            ticket.cloneInto(std.testing.allocator, &self.ticket) catch unreachable;
+        }
+    };
+    var capture = TicketCapture{};
+    defer capture.ticket.deinit();
+    const limits = session.Limits.default;
+    try harness.client_backend.setSessionTicketConsumer(std.testing.allocator, limits, .{
+        .ctx = &capture,
+        .nowUnixMsFn = TicketCapture.now,
+        .onTicketFn = TicketCapture.onTicket,
+    });
+    try harness.run();
+    try std.testing.expect(harness.client_driver.isComplete());
+    try std.testing.expect(harness.server_driver.isComplete());
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    var server_state = try harness.server_backend.emitNewSessionTicket(std.testing.allocator, &sink, .{
+        .ticket_lifetime = 3600,
+        .ticket_age_add = 500,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = "opaque-psk-ticket",
+        .issued_at_unix_ms = 1000,
+    }, limits);
+    defer server_state.deinit();
+    try std.testing.expectEqual(@as(usize, 1), sink.len);
+
+    // Deliver the ticket to the client over the (encrypted) application
+    // channel, exactly as a real deployment would.
+    const ticket_event = sink.items[0].handshake_bytes;
+    var protected: [record_codec.max_ciphertext_record_len * 2]u8 = undefined;
+    const records = (try harness.server_bridge.applyEvent(.{ .handshake_bytes = .{
+        .epoch = ticket_event.epoch,
+        .data = ticket_event.data,
+    } }, &protected)).?;
+    var parser = record_codec.Parser.init(.ciphertext);
+    var record_sink = record_codec.RecordSink(8, record_codec.max_ciphertext_fragment_len * 8){};
+    try parser.feed(records, &record_sink);
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    for (record_sink.items[0..record_sink.len]) |record| {
+        const opened = try harness.client_bridge.openHandshake(.application, record, &plaintext);
+        _ = try harness.client_driver.receive(.application, opened.inner.content);
+    }
+    try std.testing.expect(capture.ticket.ticket.slice().len > 0);
+    try std.testing.expectEqualSlices(u8, server_state.common.resumption_psk.slice(), capture.ticket.common.resumption_psk.slice());
+
+    // Phase 2: a fresh connection offers the captured ticket as a PSK. The
+    // server resolves it (a trivial in-memory "stateful cache" stand-in for
+    // #364), evaluates compatibility, verifies the binder, and both sides
+    // resume without a certificate flight.
+    var resumed = DirectHarness.init();
+    defer resumed.deinit();
+
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&capture.ticket);
+    var clock_dummy: u8 = 0;
+    const Clock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 2000;
+        }
+    };
+    resumed.client_backend.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+
+    const Resolver = struct {
+        state: session.ServerRecoverableState,
+        resolve_calls: usize = 0,
+
+        fn now(_: *anyopaque) i64 {
+            return 2000;
+        }
+        fn resolve(ctx: *anyopaque, identity: []const u8, out: *session.ServerRecoverableState) pre_shared_key.ResolveError!bool {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.resolve_calls += 1;
+            if (!std.mem.eql(u8, identity, "opaque-psk-ticket")) return false;
+            self.state.cloneInto(std.testing.allocator, out) catch return error.ResolverFailed;
+            return true;
+        }
+    };
+    var resolver_state: Resolver = .{ .state = server_state };
+    defer resolver_state.state.deinit();
+    resumed.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = Resolver.now,
+        .resolveFn = Resolver.resolve,
+    });
+
+    try resumed.run();
+
+    try std.testing.expect(resumed.client_driver.isComplete());
+    try std.testing.expect(resumed.server_driver.isComplete());
+    try std.testing.expectEqual(@as(usize, 1), resolver_state.resolve_calls);
+    try std.testing.expect(resumed.client_backend.core.psk_authenticated);
+    try std.testing.expect(resumed.server_backend.core.psk_authenticated);
+    // No certificate flight: the fixed server identity was never consumed.
+    try std.testing.expect(resumed.observed.certificate_state == null);
+
+    // The resumed connection is genuinely usable: application data flows
+    // both ways under the PSK-derived keys.
+    var protected2: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext2: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    const request = try resumed.client_bridge.sealApplicationData("resumed request", &protected2);
+    const opened_request = try resumed.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, request), &plaintext2);
+    try std.testing.expectEqualStrings("resumed request", opened_request.inner.content);
+}
+
+test "PSK round trip falls back to a full handshake when the resolver has no match" {
+    var harness = DirectHarness.init();
+    defer harness.deinit();
+
+    var ticket_common: session.ResumableSessionCommon = .{};
+    try ticket_common.init(std.testing.allocator, session.Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = &([_]u8{0x77} ** tls_backend.hash_len),
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer(""),
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 3600,
+    });
+    var offered_ticket: session.ClientTicketState = .{};
+    try offered_ticket.init(std.testing.allocator, session.Limits.default, &ticket_common, .{
+        .ticket = "unknown-to-server",
+        .ticket_age_add = 0,
+        .ticket_nonce = "n",
+        .received_at_unix_ms = 0,
+    });
+
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&offered_ticket);
+    var clock_dummy: u8 = 0;
+    const Clock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 0;
+        }
+    };
+    harness.client_backend.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+
+    const NoMatchResolver = struct {
+        fn now(_: *anyopaque) i64 {
+            return 0;
+        }
+        fn resolve(_: *anyopaque, _: []const u8, _: *session.ServerRecoverableState) pre_shared_key.ResolveError!bool {
+            return false;
+        }
+    };
+    harness.server_backend.setServerPskResolver(.{
+        .ctx = undefined,
+        .nowUnixMsFn = NoMatchResolver.now,
+        .resolveFn = NoMatchResolver.resolve,
+    });
+
+    try harness.run();
+
+    try std.testing.expect(harness.client_driver.isComplete());
+    try std.testing.expect(harness.server_driver.isComplete());
+    try std.testing.expect(!harness.client_backend.core.psk_authenticated);
+    try std.testing.expect(!harness.server_backend.core.psk_authenticated);
+    try std.testing.expectEqual(events.CertificateState.valid, harness.observed.certificate_state.?);
+}
+
 test "direct shared driver cleanup wipes secrets after record authentication failure" {
     var harness = DirectHarness.init();
     defer harness.deinit();

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -559,7 +559,7 @@ test "PSK round trip: an offered, resolved, and verified ticket resumes the hand
             return 2000;
         }
     };
-    resumed.client_backend.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+    try resumed.client_backend.setClientPskOffers(&offers, &clock_dummy, Clock.now);
 
     const Resolver = struct {
         state: *session.ServerRecoverableState,
@@ -581,7 +581,7 @@ test "PSK round trip: an offered, resolved, and verified ticket resumes the hand
     // not be shallow-copied, or its owned storage would be deinitialized
     // twice — once here, once by `server_state`'s own `defer` above.
     var resolver_state: Resolver = .{ .state = &server_state };
-    resumed.server_backend.setServerPskResolver(.{
+    try resumed.server_backend.setServerPskResolver(.{
         .ctx = &resolver_state,
         .nowUnixMsFn = Resolver.now,
         .resolveFn = Resolver.resolve,
@@ -682,7 +682,7 @@ test "PSK round trip resumes over the extension (QUIC-style) profile with asymme
             return 2000;
         }
     };
-    resumed.client_backend.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+    try resumed.client_backend.setClientPskOffers(&offers, &clock_dummy, Clock.now);
 
     const Resolver = struct {
         state: *session.ServerRecoverableState,
@@ -703,7 +703,7 @@ test "PSK round trip resumes over the extension (QUIC-style) profile with asymme
     // (this ticket has a non-null `transport_compat`), and shallow-copying
     // it here would double-free that storage.
     var resolver_state: Resolver = .{ .state = &server_state };
-    resumed.server_backend.setServerPskResolver(.{
+    try resumed.server_backend.setServerPskResolver(.{
         .ctx = &resolver_state,
         .nowUnixMsFn = Resolver.now,
         .resolveFn = Resolver.resolve,
@@ -754,7 +754,7 @@ test "PSK round trip falls back to a full handshake when the resolver has no mat
             return 0;
         }
     };
-    harness.client_backend.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+    try harness.client_backend.setClientPskOffers(&offers, &clock_dummy, Clock.now);
 
     const NoMatchResolver = struct {
         fn now(_: *anyopaque) i64 {
@@ -764,7 +764,7 @@ test "PSK round trip falls back to a full handshake when the resolver has no mat
             return false;
         }
     };
-    harness.server_backend.setServerPskResolver(.{
+    try harness.server_backend.setServerPskResolver(.{
         .ctx = undefined,
         .nowUnixMsFn = NoMatchResolver.now,
         .resolveFn = NoMatchResolver.resolve,
@@ -837,12 +837,12 @@ test "an ineligible offered ticket is filtered without desyncing the wire index 
             return 10_000; // well past the expired ticket's 1-second lifetime
         }
     };
-    harness.client_backend.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+    try harness.client_backend.setClientPskOffers(&offers, &clock_dummy, Clock.now);
 
     var stored_state = pskStoredState(&psk);
     defer stored_state.deinit();
     var resolver_state = CountingResolver{ .state = &stored_state, .identity = "valid-ticket" };
-    harness.server_backend.setServerPskResolver(.{
+    try harness.server_backend.setServerPskResolver(.{
         .ctx = &resolver_state,
         .nowUnixMsFn = CountingResolver.now,
         .resolveFn = CountingResolver.resolve,
@@ -889,12 +889,12 @@ test "handshake-time client authentication forces a full handshake even when a P
             return 0;
         }
     };
-    harness.client_backend.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+    try harness.client_backend.setClientPskOffers(&offers, &clock_dummy, Clock.now);
 
     var stored_state = pskStoredState(&psk);
     defer stored_state.deinit();
     var resolver_state = CountingResolver{ .state = &stored_state, .identity = "client-auth-ticket" };
-    harness.server_backend.setServerPskResolver(.{
+    try harness.server_backend.setServerPskResolver(.{
         .ctx = &resolver_state,
         .nowUnixMsFn = CountingResolver.now,
         .resolveFn = CountingResolver.resolve,
@@ -3008,7 +3008,7 @@ test "async credential selection resumes PSK selection identically to the synchr
     var stored_state = pskStoredState(&psk);
     defer stored_state.deinit();
     var resolver_state = CountingResolver{ .state = &stored_state, .identity = "async-ticket" };
-    server.setServerPskResolver(.{
+    try server.setServerPskResolver(.{
         .ctx = &resolver_state,
         .nowUnixMsFn = CountingResolver.now,
         .resolveFn = CountingResolver.resolve,
@@ -3050,7 +3050,7 @@ test "async credential selection failure clears the captured PSK offer" {
     var stored_state = pskStoredState(&psk);
     defer stored_state.deinit();
     var resolver_state = CountingResolver{ .state = &stored_state, .identity = "async-ticket" };
-    server.setServerPskResolver(.{
+    try server.setServerPskResolver(.{
         .ctx = &resolver_state,
         .nowUnixMsFn = CountingResolver.now,
         .resolveFn = CountingResolver.resolve,
@@ -3112,6 +3112,80 @@ test "setApplicationCompat copies the caller's bytes instead of borrowing them" 
     try std.testing.expectEqualStrings("old!", stored.bytes);
 }
 
+test "setApplicationCompat accepts a snapshot larger than the transport-extension bound" {
+    // Regression coverage: the owned storage used to be capped at
+    // `max_transport_extension_len` (512), an unrelated QUIC/H3
+    // transport-extension bound, silently rejecting an application
+    // snapshot the shared session model itself allows up to 1024 bytes by
+    // default (`session.Limits.default.max_application_compat_len`).
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    defer server.deinit();
+
+    var large: [session.Limits.default.max_application_compat_len]u8 = undefined;
+    @memset(&large, 0x5a);
+    try server.setApplicationCompat(.{ .format_id = 1, .format_version = 1, .bytes = &large });
+    const stored = server.ownedApplicationCompat().?;
+    try std.testing.expectEqual(large.len, stored.bytes.len);
+    try std.testing.expect(std.mem.allEqual(u8, stored.bytes, 0x5a));
+}
+
+test "PSK setters reject being called after start, leaving prior configuration unchanged" {
+    var client = tls_backend.Tls13Backend.initClient(
+        clientEntropy(),
+        .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+        .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } },
+    );
+    defer client.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try client.backend().start(.client, {}, &sink);
+
+    const psk = [_]u8{0x22} ** tls_backend.hash_len;
+    var common: session.ResumableSessionCommon = .{};
+    try common.init(std.testing.allocator, session.Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = &psk,
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer(""),
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 3600,
+    });
+    var ticket: session.ClientTicketState = .{};
+    try ticket.init(std.testing.allocator, session.Limits.default, &common, .{
+        .ticket = "late-offer",
+        .ticket_age_add = 0,
+        .ticket_nonce = "n",
+        .received_at_unix_ms = 0,
+    });
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&ticket);
+    var clock_dummy: u8 = 0;
+    const Clock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 0;
+        }
+    };
+    try std.testing.expectError(
+        error.InvalidHandshakeState,
+        client.setClientPskOffers(&offers, &clock_dummy, Clock.now),
+    );
+    // The rejected call took no ownership: the caller's offer is untouched.
+    try std.testing.expectEqual(@as(usize, 1), offers.len);
+    offers.deinit();
+
+    try std.testing.expectError(error.InvalidHandshakeState, client.setApplicationCompat(.{ .format_id = 1, .format_version = 1, .bytes = "x" }));
+
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    defer server.deinit();
+    var server_sink = DirectSink{};
+    defer server_sink.deinit();
+    try server.backend().start(.server, {}, &server_sink);
+    try std.testing.expectError(error.InvalidHandshakeState, server.setServerPskResolver(.{
+        .ctx = undefined,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    }));
+}
+
 test "handshake-phase failure wipes PSK offer state before ServerHello even arrives" {
     var client = tls_backend.Tls13Backend.initClient(
         clientEntropy(),
@@ -3144,7 +3218,7 @@ test "handshake-phase failure wipes PSK offer state before ServerHello even arri
             return 0;
         }
     };
-    client.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+    try client.setClientPskOffers(&offers, &clock_dummy, Clock.now);
 
     var sink = DirectSink{};
     defer sink.deinit();
@@ -3181,7 +3255,7 @@ test "the accepted server session survives PSK selection with its early-data and
     stored_state.init(&common, 0);
     defer stored_state.deinit();
     var resolver_state = CountingResolver{ .state = &stored_state, .identity = "early-data-ticket" };
-    server.setServerPskResolver(.{
+    try server.setServerPskResolver(.{
         .ctx = &resolver_state,
         .nowUnixMsFn = CountingResolver.now,
         .resolveFn = CountingResolver.resolve,
@@ -3201,6 +3275,48 @@ test "the accepted server session survives PSK selection with its early-data and
     try std.testing.expectEqual(@as(?u16, null), server.takeSelectedServerPsk(&second));
 }
 
+test "a bad client Finished after PSK selection clears the accepted session and secret state" {
+    // Regression coverage: `Core.acceptReceived` marks the server's
+    // handshake lifecycle `.complete` as soon as a Finished message's
+    // *ordering* is accepted — before this backend has verified its MAC.
+    // The old `clearFailedHandshakeState` guard (`core.handshake_lifecycle
+    // == .complete`) would therefore see `.complete` and skip cleanup
+    // entirely on exactly this path.
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    defer server.deinit();
+
+    const psk = [_]u8{0x77} ** tls_backend.hash_len;
+    var stored_state = pskStoredState(&psk);
+    defer stored_state.deinit();
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "bad-finished-ticket" };
+    try server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+
+    try driveServerSelection(&server, .{ .psk = .{ .items = &.{.{ .identity = "bad-finished-ticket", .binder_psk = &psk }} } });
+    try std.testing.expect(server.core.psk_authenticated);
+    try std.testing.expect(server.selected_server_psk_present);
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    var bad_finished_buf: [4 + tls_backend.hash_len]u8 = undefined;
+    const bad_finished = try tls_core.messages.encode(.finished, &([_]u8{0xaa} ** tls_backend.hash_len), &bad_finished_buf);
+    try std.testing.expectError(error.DecryptError, server.backend().receive(.handshake, bad_finished, &sink));
+
+    // Core's own lifecycle already (incorrectly, from this backend's
+    // perspective) reads `.complete` at this point — the actual assertion
+    // is that the backend's cleanup corrects it and wipes everything.
+    try std.testing.expectEqual(.failed, server.core.handshake_lifecycle);
+    try std.testing.expect(!server.core.psk_authenticated);
+    try std.testing.expect(server.schedule == null);
+    try std.testing.expectEqual(@as(usize, 0), server.resumption_master_secret.slice().len);
+    var taken: session.ServerRecoverableState = .{};
+    try std.testing.expectEqual(@as(?u16, null), server.takeSelectedServerPsk(&taken));
+    try std.testing.expectEqual(@as(?pre_shared_key.AgeSkew, null), server.takePskAgeSkew());
+}
+
 test "server selects the first compatible identity: unknown first, valid second" {
     var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
     defer server.deinit();
@@ -3209,7 +3325,7 @@ test "server selects the first compatible identity: unknown first, valid second"
     var stored_state = pskStoredState(&psk);
     defer stored_state.deinit();
     var resolver_state = CountingResolver{ .state = &stored_state, .identity = "known-ticket" };
-    server.setServerPskResolver(.{
+    try server.setServerPskResolver(.{
         .ctx = &resolver_state,
         .nowUnixMsFn = CountingResolver.now,
         .resolveFn = CountingResolver.resolve,
@@ -3234,7 +3350,7 @@ test "a compatible candidate with a wrong binder is fatal and never probes a lat
     var stored_state = pskStoredState(&psk);
     defer stored_state.deinit();
     var resolver_state = CountingResolver{ .state = &stored_state, .identity = "ticket-a" };
-    server.setServerPskResolver(.{
+    try server.setServerPskResolver(.{
         .ctx = &resolver_state,
         .nowUnixMsFn = CountingResolver.now,
         .resolveFn = CountingResolver.resolve,
@@ -3301,7 +3417,7 @@ test "a malformed non-leaf chain entry is rejected before PSK resolver/binder wo
     var stored_state = pskStoredState(&psk);
     defer stored_state.deinit();
     var resolver_state = CountingResolver{ .state = &stored_state, .identity = "leaf-ok-tail-bad" };
-    server.setServerPskResolver(.{
+    try server.setServerPskResolver(.{
         .ctx = &resolver_state,
         .nowUnixMsFn = CountingResolver.now,
         .resolveFn = CountingResolver.resolve,
@@ -3327,7 +3443,7 @@ test "an oversized non-leaf chain entry is rejected before PSK resolver/binder w
     var stored_state = pskStoredState(&psk);
     defer stored_state.deinit();
     var resolver_state = CountingResolver{ .state = &stored_state, .identity = "leaf-ok-tail-oversized" };
-    server.setServerPskResolver(.{
+    try server.setServerPskResolver(.{
         .ctx = &resolver_state,
         .nowUnixMsFn = CountingResolver.now,
         .resolveFn = CountingResolver.resolve,
@@ -3350,7 +3466,7 @@ test "a ticket bound to a different server certificate falls back to a full hand
     var stored_state = pskStoredStateWithBinding(&psk, session.AuthBinding.fromLeafCertificateDer("a different certificate entirely"));
     defer stored_state.deinit();
     var resolver_state = CountingResolver{ .state = &stored_state, .identity = "rotated-ticket" };
-    server.setServerPskResolver(.{
+    try server.setServerPskResolver(.{
         .ctx = &resolver_state,
         .nowUnixMsFn = CountingResolver.now,
         .resolveFn = CountingResolver.resolve,
@@ -3397,7 +3513,7 @@ test "an SNI mismatch falls back to a full handshake instead of rejecting the co
     stored_state.init(&common, 0);
     defer stored_state.deinit();
     var resolver_state = CountingResolver{ .state = &stored_state, .identity = "sni-ticket" };
-    server.setServerPskResolver(.{
+    try server.setServerPskResolver(.{
         .ctx = &resolver_state,
         .nowUnixMsFn = CountingResolver.now,
         .resolveFn = CountingResolver.resolve,

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -2228,6 +2228,13 @@ const PskOfferOptions = struct {
     /// Skip writing `psk_key_exchange_modes` — for the missing-extension
     /// malformed-input test.
     omit_modes: bool = false,
+    /// When set, write this literal `pre_shared_key` extension_data
+    /// verbatim instead of building it from `items` — bypasses
+    /// `pre_shared_key.writeOffer`'s own `max_offered_identities` cap, for
+    /// constructing a wire ClientHello with more offered identities than
+    /// this module ever legitimately emits (the resolver-attempt-cap
+    /// tests).
+    raw_ext_data: ?[]const u8 = null,
 };
 
 const PskOfferItemOptions = struct {
@@ -2322,14 +2329,20 @@ fn buildClientHello(buf: []u8, opts: ClientHelloOptions) ![]const u8 {
             try pre_shared_key.writeModes(&w, &.{.psk_dhe_ke});
             w.patch(2, modes_ext_len);
         }
-        for (psk_opt.items, 0..) |item, i| {
-            psk_items_buf[i] = .{
-                .identity = item.identity,
-                .obfuscated_ticket_age = item.obfuscated_ticket_age,
-                .digest_len = tls_backend.hash_len,
-            };
+        if (psk_opt.raw_ext_data) |raw| {
+            try w.u16_(pre_shared_key.ext_pre_shared_key);
+            try w.u16_(@intCast(raw.len));
+            try w.bytes(raw);
+        } else {
+            for (psk_opt.items, 0..) |item, i| {
+                psk_items_buf[i] = .{
+                    .identity = item.identity,
+                    .obfuscated_ticket_age = item.obfuscated_ticket_age,
+                    .digest_len = tls_backend.hash_len,
+                };
+            }
+            psk_offer = try pre_shared_key.writeOffer(&w, psk_items_buf[0..psk_opt.items.len]);
         }
-        psk_offer = try pre_shared_key.writeOffer(&w, psk_items_buf[0..psk_opt.items.len]);
     }
 
     w.patch(2, extensions_len);
@@ -2344,6 +2357,45 @@ fn buildClientHello(buf: []u8, opts: ClientHelloOptions) ![]const u8 {
             @memcpy(buf[slot.offset..][0..slot.len], &binder);
         }
     }
+    return buf[0..w.len];
+}
+
+const ServerHelloOptions = struct {
+    session_id: []const u8 = &.{},
+    key_share_seed: [X25519.seed_length]u8 = [_]u8{0x55} ** X25519.seed_length,
+    selected_identity: ?u16 = null,
+};
+
+/// Build a minimal, well-formed TLS 1.3 ServerHello — for driving a
+/// client's `onServerHello` directly with a chosen `selected_identity`
+/// (#362 client-side consistency tests), independent of any real server.
+fn buildServerHello(buf: []u8, opts: ServerHelloOptions) ![]const u8 {
+    const key_pair = try X25519.KeyPair.generateDeterministic(opts.key_share_seed);
+    var w = HsWriter{ .buf = buf };
+    try w.u8_(@intFromEnum(HsMessageType.server_hello));
+    const message_len = try w.reserve(3);
+    try w.u16_(0x0303); // legacy_version
+    try w.bytes(&([_]u8{0x51} ** 32)); // random
+    try w.u8_(@intCast(opts.session_id.len));
+    try w.bytes(opts.session_id);
+    try w.u16_(0x1301); // cipher_suite
+    try w.u8_(0); // legacy_compression_method
+    const extensions_len = try w.reserve(2);
+    try w.u16_(43); // supported_versions
+    try w.u16_(2);
+    try w.u16_(0x0304);
+    try w.u16_(51); // key_share
+    try w.u16_(2 + 2 + X25519.public_length);
+    try w.u16_(0x001d);
+    try w.u16_(X25519.public_length);
+    try w.bytes(&key_pair.public_key);
+    if (opts.selected_identity) |idx| {
+        try w.u16_(pre_shared_key.ext_pre_shared_key);
+        try w.u16_(2);
+        try w.u16_(idx);
+    }
+    w.patch(2, extensions_len);
+    w.patch(3, message_len);
     return buf[0..w.len];
 }
 
@@ -3236,6 +3288,115 @@ test "handshake-phase failure wipes PSK offer state before ServerHello even arri
     try std.testing.expect(client.client_psk_offers.isEmpty());
 }
 
+fn pushTestTicket(offers: *pre_shared_key.ClientPskOfferSet, psk: []const u8, ticket: []const u8) !void {
+    var common: session.ResumableSessionCommon = .{};
+    try common.init(std.testing.allocator, session.Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = psk,
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer(""),
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 3600,
+    });
+    var state: session.ClientTicketState = .{};
+    try state.init(std.testing.allocator, session.Limits.default, &common, .{
+        .ticket = ticket,
+        .ticket_age_add = 0,
+        .ticket_nonce = "n",
+        .received_at_unix_ms = 0,
+    });
+    try offers.push(&state);
+}
+
+test "client selects a later (non-zero) identity when the server names it" {
+    var client = tls_backend.Tls13Backend.initClient(
+        clientEntropy(),
+        .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+        .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } },
+    );
+    defer client.deinit();
+
+    const psk_a = [_]u8{0x11} ** tls_backend.hash_len;
+    const psk_b = [_]u8{0x22} ** tls_backend.hash_len;
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try pushTestTicket(&offers, &psk_a, "ticket-a");
+    try pushTestTicket(&offers, &psk_b, "ticket-b");
+    var clock_dummy: u8 = 0;
+    const Clock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 0;
+        }
+    };
+    try client.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try client.backend().start(.client, {}, &sink);
+    try std.testing.expectEqual(@as(usize, 2), client.client_psk_offers.len);
+
+    var buf: [512]u8 = undefined;
+    const hello = try buildServerHello(&buf, .{ .selected_identity = 1 });
+    try client.backend().receive(.initial, hello, &sink);
+
+    try std.testing.expect(client.core.psk_authenticated);
+    try std.testing.expect(client.selected_client_psk_present);
+    // Index 1 names the *second* offer: "ticket-b", not "ticket-a".
+    try std.testing.expectEqualStrings("ticket-b", client.selected_client_psk.ticket.slice());
+}
+
+test "client rejects a selected_identity equal to or beyond the emitted offer count" {
+    for ([_]u16{ 1, 5 }) |bad_index| {
+        var client = tls_backend.Tls13Backend.initClient(
+            clientEntropy(),
+            .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+            .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } },
+        );
+        defer client.deinit();
+
+        const psk = [_]u8{0x33} ** tls_backend.hash_len;
+        var offers: pre_shared_key.ClientPskOfferSet = .{};
+        try pushTestTicket(&offers, &psk, "only-ticket");
+        var clock_dummy: u8 = 0;
+        const Clock = struct {
+            fn now(_: *anyopaque) i64 {
+                return 0;
+            }
+        };
+        try client.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+
+        var sink = DirectSink{};
+        defer sink.deinit();
+        try client.backend().start(.client, {}, &sink);
+        try std.testing.expectEqual(@as(usize, 1), client.client_psk_offers.len); // one offer emitted, index 0 valid
+
+        var buf: [512]u8 = undefined;
+        const hello = try buildServerHello(&buf, .{ .selected_identity = bad_index });
+        try std.testing.expectError(error.IllegalParameter, client.backend().receive(.initial, hello, &sink));
+        try std.testing.expect(client.client_psk_offers.isEmpty());
+        try std.testing.expect(!client.selected_client_psk_present);
+        try std.testing.expect(!client.core.psk_authenticated);
+    }
+}
+
+test "client rejects a forged selected_identity when no PSK was ever offered" {
+    var client = tls_backend.Tls13Backend.initClient(
+        clientEntropy(),
+        .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+        .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } },
+    );
+    defer client.deinit();
+    try std.testing.expect(client.client_psk_offers.isEmpty());
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try client.backend().start(.client, {}, &sink);
+    try std.testing.expect(client.client_psk_offers.isEmpty());
+
+    var buf: [512]u8 = undefined;
+    const hello = try buildServerHello(&buf, .{ .selected_identity = 0 });
+    try std.testing.expectError(error.IllegalParameter, client.backend().receive(.initial, hello, &sink));
+    try std.testing.expect(!client.core.psk_authenticated);
+}
+
 /// Completes a PSK-resumed server handshake driven by `driveServerSelection`
 /// by feeding it the correct client Finished — computed from the server's
 /// own (symmetric) key schedule, since there is no real client driver in
@@ -3284,6 +3445,109 @@ test "takeSelectedServerPsk returns null before the client Finished commits the 
     var taken_after: session.ServerRecoverableState = .{};
     defer taken_after.deinit();
     try std.testing.expect(server.takeSelectedServerPsk(&taken_after) != null);
+}
+
+fn pskStoredStateTimed(psk: []const u8, issued_at_unix_ms: i64, ticket_age_add: u32) session.ServerRecoverableState {
+    var common: session.ResumableSessionCommon = .{};
+    common.init(std.testing.allocator, session.Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = psk,
+        .application_protocol = "h2",
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer(tls_backend.testdata.certificate_der),
+        .issued_at_unix_ms = issued_at_unix_ms,
+        .lifetime_seconds = 3600,
+    }) catch unreachable;
+    var state: session.ServerRecoverableState = .{};
+    state.init(&common, ticket_age_add);
+    return state;
+}
+
+const TimedResolver = struct {
+    state: *session.ServerRecoverableState,
+    identity: []const u8,
+    now_value: i64,
+    calls: usize = 0,
+
+    fn now(ctx: *anyopaque) i64 {
+        const self: *@This() = @ptrCast(@alignCast(ctx));
+        return self.now_value;
+    }
+    fn resolve(ctx: *anyopaque, identity: []const u8, out: *session.ServerRecoverableState) pre_shared_key.ResolveError!bool {
+        const self: *@This() = @ptrCast(@alignCast(ctx));
+        self.calls += 1;
+        if (!std.mem.eql(u8, identity, self.identity)) return false;
+        self.state.cloneInto(std.testing.allocator, out) catch return error.ResolverFailed;
+        return true;
+    }
+};
+
+test "takePskAgeSkew reports the exact signed observation and is one-shot" {
+    const Case = struct { apparent_age_ms: u32, actual_elapsed_ms: i64, expected_skew_ms: i64 };
+    const cases = [_]Case{
+        .{ .apparent_age_ms = 0, .actual_elapsed_ms = 0, .expected_skew_ms = 0 }, // exact zero
+        .{ .apparent_age_ms = 4200, .actual_elapsed_ms = 4200, .expected_skew_ms = 0 }, // normal, matching
+        .{ .apparent_age_ms = 5000, .actual_elapsed_ms = 3000, .expected_skew_ms = 2000 }, // positive skew
+        .{ .apparent_age_ms = 1000, .actual_elapsed_ms = 4000, .expected_skew_ms = -3000 }, // negative skew
+        .{ .apparent_age_ms = 1_000_000, .actual_elapsed_ms = 10, .expected_skew_ms = 999_990 }, // large skew, still 1-RTT
+    };
+    for (cases) |case| {
+        var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+        defer server.deinit();
+
+        const psk = [_]u8{0x88} ** tls_backend.hash_len;
+        const issued_at: i64 = 5_000_000;
+        const ticket_age_add: u32 = 0xdead_beef;
+        var stored_state = pskStoredStateTimed(&psk, issued_at, ticket_age_add);
+        defer stored_state.deinit();
+        var resolver_state = TimedResolver{
+            .state = &stored_state,
+            .identity = "aged-ticket",
+            .now_value = issued_at + case.actual_elapsed_ms,
+        };
+        try server.setServerPskResolver(.{
+            .ctx = &resolver_state,
+            .nowUnixMsFn = TimedResolver.now,
+            .resolveFn = TimedResolver.resolve,
+        });
+
+        const obfuscated = pre_shared_key.obfuscateTicketAge(case.apparent_age_ms, ticket_age_add);
+        try driveServerSelection(&server, .{ .psk = .{ .items = &.{
+            .{ .identity = "aged-ticket", .binder_psk = &psk, .obfuscated_ticket_age = obfuscated },
+        } } });
+
+        // Skew alone never rejects 1-RTT resumption, however large.
+        try std.testing.expect(server.core.psk_authenticated);
+
+        const skew = server.takePskAgeSkew().?;
+        try std.testing.expectEqual(case.apparent_age_ms, skew.apparent_age_ms);
+        try std.testing.expectEqual(case.expected_skew_ms, skew.skew_ms);
+        // One-shot: taken once, then null.
+        try std.testing.expectEqual(@as(?pre_shared_key.AgeSkew, null), server.takePskAgeSkew());
+    }
+}
+
+test "a rejected or fallback candidate publishes no age-skew observation" {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    defer server.deinit();
+
+    const psk = [_]u8{0x99} ** tls_backend.hash_len;
+    var stored_state = pskStoredStateTimed(&psk, 0, 0);
+    defer stored_state.deinit();
+    var resolver_state = TimedResolver{ .state = &stored_state, .identity = "never-offered", .now_value = 0 };
+    try server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = TimedResolver.now,
+        .resolveFn = TimedResolver.resolve,
+    });
+
+    // The offered identity never matches, so selection falls back — no
+    // candidate was ever compatible/binder-checked.
+    try driveServerSelection(&server, .{ .psk = .{ .items = &.{
+        .{ .identity = "unrelated-ticket", .binder_psk = &psk },
+    } } });
+
+    try std.testing.expect(!server.core.psk_authenticated);
+    try std.testing.expectEqual(@as(?pre_shared_key.AgeSkew, null), server.takePskAgeSkew());
 }
 
 test "the accepted server session survives PSK selection with its early-data and metadata intact" {
@@ -3367,6 +3631,228 @@ test "a bad client Finished after PSK selection clears the accepted session and 
     var taken: session.ServerRecoverableState = .{};
     try std.testing.expectEqual(@as(?u16, null), server.takeSelectedServerPsk(&taken));
     try std.testing.expectEqual(@as(?pre_shared_key.AgeSkew, null), server.takePskAgeSkew());
+}
+
+/// Writes a raw `pre_shared_key` extension_data with `count` identities
+/// named "id-0".."id-{count-1}", each with a zero-filled 32-byte binder
+/// placeholder — for the resolver-attempt-cap tests, which only care how
+/// many times (and in what order) the resolver is invoked, not binder
+/// validity (unknown/rejected identities never reach the binder check).
+fn buildRawOfferedPsks(buf: []u8, count: usize) ![]const u8 {
+    var w = HsWriter{ .buf = buf };
+    const ids_len_idx = try w.reserve(2);
+    var name_buf: [8]u8 = undefined;
+    for (0..count) |i| {
+        const name = try std.fmt.bufPrint(&name_buf, "id-{d}", .{i});
+        try w.u16_(@intCast(name.len));
+        try w.bytes(name);
+        try w.bytes(&[_]u8{0} ** 4); // age
+    }
+    w.patch(2, ids_len_idx);
+    const binders_len_idx = try w.reserve(2);
+    for (0..count) |_| {
+        try w.u8_(32);
+        try w.bytes(&[_]u8{0} ** 32);
+    }
+    w.patch(2, binders_len_idx);
+    return w.written();
+}
+
+test "resolver candidate cloning under injected allocation failure leaves no partial or retained state" {
+    // `selectPsk()`'s only allocation on the success path is the
+    // resolver's own `ServerRecoverableState.cloneInto` (the underlying
+    // allocation primitives — `ResumableSessionCommon.init`/`cloneInto`,
+    // `BoundedSecret`/`CompatSnapshot` — already have exhaustive
+    // `checkAllAllocationFailures` coverage in session.zig; this proves
+    // the *backend* PSK path degrades cleanly, not silently, when that
+    // allocation fails partway through selection).
+    const AllocFailResolver = struct {
+        state: *session.ServerRecoverableState,
+        allocator: std.mem.Allocator,
+        fn now(_: *anyopaque) i64 {
+            return 0;
+        }
+        fn resolve(ctx: *anyopaque, _: []const u8, out: *session.ServerRecoverableState) pre_shared_key.ResolveError!bool {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.state.cloneInto(self.allocator, out) catch return error.ResolverFailed;
+            return true;
+        }
+    };
+
+    var stored_common: session.ResumableSessionCommon = .{};
+    try stored_common.init(std.testing.allocator, session.Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = &([_]u8{0xbb} ** tls_backend.hash_len),
+        .application_protocol = "h2",
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer(tls_backend.testdata.certificate_der),
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 3600,
+        // An allocator-backed optional field, so cloning has more than one
+        // allocation point to fail at. `transport_compat` is deliberately
+        // left unset: the record profile never has a candidate to match it
+        // against, which would make every candidate incompatible rather
+        // than exercising the allocation-failure path.
+        .application_compat = .{ .format_id = 2, .format_version = 1, .bytes = "application-snapshot" },
+    });
+    var stored_state: session.ServerRecoverableState = .{};
+    stored_state.init(&stored_common, 0);
+    defer stored_state.deinit();
+
+    const psk = [_]u8{0xbb} ** tls_backend.hash_len;
+    var fail_index: usize = 0;
+    while (fail_index < 32) : (fail_index += 1) {
+        var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = fail_index });
+        var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+        defer server.deinit();
+        try server.setApplicationCompat(.{ .format_id = 2, .format_version = 1, .bytes = "application-snapshot" });
+        var resolver_state = AllocFailResolver{ .state = &stored_state, .allocator = failing.allocator() };
+        try server.setServerPskResolver(.{
+            .ctx = &resolver_state,
+            .nowUnixMsFn = AllocFailResolver.now,
+            .resolveFn = AllocFailResolver.resolve,
+        });
+
+        if (driveServerSelection(&server, .{ .psk = .{ .items = &.{
+            .{ .identity = "alloc-ticket", .binder_psk = &psk },
+        } } })) |_| {
+            // Enough allocations succeeded that the clone (and the rest of
+            // the handshake) completed normally.
+            try std.testing.expect(server.core.psk_authenticated);
+        } else |_| {
+            // The clone's allocation failed: the backend must fail closed
+            // rather than retain any partial selected state.
+            try std.testing.expect(!server.selected_server_psk_present);
+            try std.testing.expect(!server.core.psk_authenticated);
+        }
+    }
+}
+
+test "resolver identity-resolution attempts are bounded to eight even when a ninth would succeed" {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    defer server.deinit();
+
+    const psk = [_]u8{0x44} ** tls_backend.hash_len;
+    var stored_state = pskStoredState(&psk);
+    defer stored_state.deinit();
+    // Only the *ninth* (index 8, "id-8") wire identity would ever resolve.
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "id-8" };
+    try server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+
+    var ext_buf: [512]u8 = undefined;
+    const raw_ext_data = try buildRawOfferedPsks(&ext_buf, 9);
+
+    // Falls back to a full handshake: the one identity that would have
+    // resolved is never attempted, because it is the ninth.
+    try driveServerSelection(&server, .{ .psk = .{ .items = &.{}, .raw_ext_data = raw_ext_data } });
+
+    try std.testing.expectEqual(@as(usize, 8), resolver_state.calls);
+    try std.testing.expect(!server.core.psk_authenticated);
+}
+
+test "resolver identity-resolution attempts stop at exactly eight when all eight are unusable" {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    defer server.deinit();
+
+    const psk = [_]u8{0x55} ** tls_backend.hash_len;
+    var stored_state = pskStoredState(&psk);
+    defer stored_state.deinit();
+    // No wire identity matches this at all — exercises exactly eight misses,
+    // not nine, when there are only eight to try.
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "never-matches" };
+    try server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+
+    var ext_buf: [512]u8 = undefined;
+    const raw_ext_data = try buildRawOfferedPsks(&ext_buf, 8);
+    try driveServerSelection(&server, .{ .psk = .{ .items = &.{}, .raw_ext_data = raw_ext_data } });
+
+    try std.testing.expectEqual(@as(usize, 8), resolver_state.calls);
+    try std.testing.expect(!server.core.psk_authenticated);
+}
+
+test "a resolver operational failure is fatal and distinct from an ordinary miss" {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    defer server.deinit();
+
+    const FailingResolver = struct {
+        calls: usize = 0,
+        fn now(_: *anyopaque) i64 {
+            return 0;
+        }
+        fn resolve(ctx: *anyopaque, _: []const u8, _: *session.ServerRecoverableState) pre_shared_key.ResolveError!bool {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.calls += 1;
+            return error.ResolverFailed;
+        }
+    };
+    var resolver_state = FailingResolver{};
+    try server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = FailingResolver.now,
+        .resolveFn = FailingResolver.resolve,
+    });
+
+    const psk = [_]u8{0x66} ** tls_backend.hash_len;
+    try std.testing.expectError(error.CredentialProviderFailed, driveServerSelection(&server, .{
+        .psk = .{ .items = &.{.{ .identity = "any-ticket", .binder_psk = &psk }} },
+    }));
+    // Fatal on the very first failure: never retried against a later
+    // identity, unlike an ordinary "unknown" miss.
+    try std.testing.expectEqual(@as(usize, 1), resolver_state.calls);
+    try std.testing.expectEqual(tls_backend.CredentialFailure.provider_internal_failure, server.credentialFailure().?);
+}
+
+test "a resolver that partially populates its output before failing leaves no residue" {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    defer server.deinit();
+
+    const PartialResolver = struct {
+        calls: usize = 0,
+        fn now(_: *anyopaque) i64 {
+            return 0;
+        }
+        fn resolve(ctx: *anyopaque, _: []const u8, out: *session.ServerRecoverableState) pre_shared_key.ResolveError!bool {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.calls += 1;
+            // Contract violation: partially populate `out` (as if a
+            // stateless envelope had decrypted an identity binding but not
+            // yet finished validating it), then fail instead of returning
+            // `false`. The backend must not trust or leak this partial
+            // state.
+            var common: session.ResumableSessionCommon = .{};
+            common.init(std.testing.allocator, session.Limits.default, .{
+                .cipher_suite = .tls_aes_128_gcm_sha256,
+                .resumption_psk = &([_]u8{0x77} ** tls_backend.hash_len),
+                .auth_binding = session.AuthBinding.fromLeafCertificateDer(""),
+                .issued_at_unix_ms = 0,
+                .lifetime_seconds = 3600,
+            }) catch unreachable;
+            out.init(&common, 0);
+            return error.ResolverFailed;
+        }
+    };
+    var resolver_state = PartialResolver{};
+    try server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = PartialResolver.now,
+        .resolveFn = PartialResolver.resolve,
+    });
+
+    const psk = [_]u8{0x77} ** tls_backend.hash_len;
+    try std.testing.expectError(error.CredentialProviderFailed, driveServerSelection(&server, .{
+        .psk = .{ .items = &.{.{ .identity = "any-ticket", .binder_psk = &psk }} },
+    }));
+    try std.testing.expectEqual(@as(usize, 1), resolver_state.calls);
+    // No PSK state was retained despite the resolver populating `out`.
+    try std.testing.expect(!server.selected_server_psk_present);
+    try std.testing.expect(!server.core.psk_authenticated);
 }
 
 test "server selects the first compatible identity: unknown first, valid second" {

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -3236,6 +3236,56 @@ test "handshake-phase failure wipes PSK offer state before ServerHello even arri
     try std.testing.expect(client.client_psk_offers.isEmpty());
 }
 
+/// Completes a PSK-resumed server handshake driven by `driveServerSelection`
+/// by feeding it the correct client Finished — computed from the server's
+/// own (symmetric) key schedule, since there is no real client driver in
+/// these server-only tests.
+fn feedValidClientFinished(server: *tls_backend.Tls13Backend) !void {
+    const schedule = server.schedule.?;
+    var client_verify = tls_backend.KeySchedule.verifyData(&schedule.client_handshake_traffic, server.core.transcriptHash());
+    defer std.crypto.secureZero(u8, &client_verify);
+    var finished_buf: [4 + tls_backend.hash_len]u8 = undefined;
+    const finished = try tls_core.messages.encode(.finished, &client_verify, &finished_buf);
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().receive(.handshake, finished, &sink);
+}
+
+test "takeSelectedServerPsk returns null before the client Finished commits the handshake" {
+    // Regression coverage: the binder succeeding only proves the *client*
+    // authenticated — the server's own handshake is not committed until
+    // the client's Finished verifies. Handing the accepted session out any
+    // earlier would let a caller retain it past a subsequent bad-Finished
+    // failure, which `clearFailedHandshakeState` can then no longer reach.
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    defer server.deinit();
+
+    const psk = [_]u8{0x88} ** tls_backend.hash_len;
+    var stored_state = pskStoredState(&psk);
+    defer stored_state.deinit();
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "not-yet-committed" };
+    try server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+
+    try driveServerSelection(&server, .{ .psk = .{ .items = &.{.{ .identity = "not-yet-committed", .binder_psk = &psk }} } });
+    try std.testing.expect(server.core.psk_authenticated);
+    try std.testing.expect(server.selected_server_psk_present);
+
+    var taken: session.ServerRecoverableState = .{};
+    try std.testing.expectEqual(@as(?u16, null), server.takeSelectedServerPsk(&taken));
+    // Left untouched: still present, still retrievable once actually committed.
+    try std.testing.expect(server.selected_server_psk_present);
+
+    try feedValidClientFinished(&server);
+    try std.testing.expectEqual(.complete, server.core.handshake_lifecycle);
+    var taken_after: session.ServerRecoverableState = .{};
+    defer taken_after.deinit();
+    try std.testing.expect(server.takeSelectedServerPsk(&taken_after) != null);
+}
+
 test "the accepted server session survives PSK selection with its early-data and metadata intact" {
     var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
     defer server.deinit();
@@ -3262,8 +3312,10 @@ test "the accepted server session survives PSK selection with its early-data and
     });
 
     try driveServerSelection(&server, .{ .psk = .{ .items = &.{.{ .identity = "early-data-ticket", .binder_psk = &psk }} } });
+    try feedValidClientFinished(&server);
 
     try std.testing.expect(server.core.psk_authenticated);
+    try std.testing.expectEqual(.complete, server.core.handshake_lifecycle);
     var taken: session.ServerRecoverableState = .{};
     const index = server.takeSelectedServerPsk(&taken).?;
     defer taken.deinit();
@@ -3356,16 +3408,26 @@ test "a compatible candidate with a wrong binder is fatal and never probes a lat
         .resolveFn = CountingResolver.resolve,
     });
 
-    try std.testing.expectError(error.DecryptError, driveServerSelection(&server, .{
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+    const events_before_client_hello = sink.len;
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{
         .psk = .{
             .items = &.{
                 .{ .identity = "ticket-a", .binder_psk = &wrong_psk }, // resolvable and compatible, wrong binder
                 .{ .identity = "ticket-b", .binder_psk = &psk }, // would otherwise succeed; must never be tried
             },
         },
-    }));
+    });
+    try std.testing.expectError(error.DecryptError, server.backend().receive(.initial, hello, &sink));
 
     try std.testing.expectEqual(@as(usize, 1), resolver_state.calls);
+    // No ServerHello, secret, or any other event was emitted for the
+    // failed selection: the fatal binder mismatch is caught before
+    // anything is written to the wire.
+    try std.testing.expectEqual(events_before_client_hello, sink.len);
 }
 
 /// A hand-written `CredentialProvider` whose second chain entry is

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -2360,15 +2360,25 @@ fn buildClientHello(buf: []u8, opts: ClientHelloOptions) ![]const u8 {
     return buf[0..w.len];
 }
 
+/// Server key-share cases for the PSK-selected ServerHello consistency
+/// matrix (#362: "selected index/hash/key-share consistency is validated
+/// by the client").
+const ServerKeyShareCase = enum { valid, missing, wrong_group, wrong_length, low_order };
+
 const ServerHelloOptions = struct {
     session_id: []const u8 = &.{},
     key_share_seed: [X25519.seed_length]u8 = [_]u8{0x55} ** X25519.seed_length,
     selected_identity: ?u16 = null,
+    selected_version: u16 = 0x0304,
+    cipher_suite: u16 = 0x1301,
+    key_share: ServerKeyShareCase = .valid,
 };
 
-/// Build a minimal, well-formed TLS 1.3 ServerHello — for driving a
-/// client's `onServerHello` directly with a chosen `selected_identity`
-/// (#362 client-side consistency tests), independent of any real server.
+/// Build a minimal, well-formed (unless `opts` deliberately says
+/// otherwise) TLS 1.3 ServerHello — for driving a client's `onServerHello`
+/// directly with a chosen `selected_identity`, cipher suite, negotiated
+/// version, and key-share shape (#362 client-side consistency tests),
+/// independent of any real server.
 fn buildServerHello(buf: []u8, opts: ServerHelloOptions) ![]const u8 {
     const key_pair = try X25519.KeyPair.generateDeterministic(opts.key_share_seed);
     var w = HsWriter{ .buf = buf };
@@ -2378,17 +2388,44 @@ fn buildServerHello(buf: []u8, opts: ServerHelloOptions) ![]const u8 {
     try w.bytes(&([_]u8{0x51} ** 32)); // random
     try w.u8_(@intCast(opts.session_id.len));
     try w.bytes(opts.session_id);
-    try w.u16_(0x1301); // cipher_suite
+    try w.u16_(opts.cipher_suite);
     try w.u8_(0); // legacy_compression_method
     const extensions_len = try w.reserve(2);
     try w.u16_(43); // supported_versions
     try w.u16_(2);
-    try w.u16_(0x0304);
-    try w.u16_(51); // key_share
-    try w.u16_(2 + 2 + X25519.public_length);
-    try w.u16_(0x001d);
-    try w.u16_(X25519.public_length);
-    try w.bytes(&key_pair.public_key);
+    try w.u16_(opts.selected_version);
+    switch (opts.key_share) {
+        .missing => {},
+        .valid => {
+            try w.u16_(51);
+            try w.u16_(2 + 2 + X25519.public_length);
+            try w.u16_(0x001d); // x25519
+            try w.u16_(X25519.public_length);
+            try w.bytes(&key_pair.public_key);
+        },
+        .wrong_group => {
+            try w.u16_(51);
+            try w.u16_(2 + 2 + X25519.public_length);
+            try w.u16_(0x0017); // secp256r1, not x25519
+            try w.u16_(X25519.public_length);
+            try w.bytes(&key_pair.public_key);
+        },
+        .wrong_length => {
+            const short_len = X25519.public_length - 1;
+            try w.u16_(51);
+            try w.u16_(2 + 2 + short_len);
+            try w.u16_(0x001d);
+            try w.u16_(short_len);
+            try w.bytes(key_pair.public_key[0..short_len]);
+        },
+        .low_order => {
+            try w.u16_(51);
+            try w.u16_(2 + 2 + X25519.public_length);
+            try w.u16_(0x001d);
+            try w.u16_(X25519.public_length);
+            try w.bytes(&([_]u8{0} ** X25519.public_length)); // the identity point
+        },
+    }
     if (opts.selected_identity) |idx| {
         try w.u16_(pre_shared_key.ext_pre_shared_key);
         try w.u16_(2);
@@ -3122,6 +3159,48 @@ test "async credential selection failure clears the captured PSK offer" {
     try std.testing.expect(server.client_hello_psk == null);
 }
 
+test "async credential selection failure zeroes the captured ClientHello bytes, not just the pointer" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.async_select = true;
+    mock.pending_polls = 0;
+    mock.pending_fails = true;
+    var server = serverWithProvider(&mock);
+    defer server.deinit();
+
+    const psk = [_]u8{0x5a} ** tls_backend.hash_len;
+    var stored_state = pskStoredState(&psk);
+    defer stored_state.deinit();
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "async-ticket" };
+    try server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{ .psk = .{ .items = &.{.{ .identity = "async-ticket", .binder_psk = &psk }} } });
+    try server.backend().receive(.initial, hello, &sink);
+    try std.testing.expect(server.authPending());
+
+    // `client_hello_psk` is an embedded fixed-size buffer (no allocator
+    // involved), so its address is stable across the `= null` assignment
+    // below and directly re-inspectable afterward.
+    const capture = &server.client_hello_psk.?;
+    const message_memory = capture.message[0..capture.message_len];
+    try std.testing.expect(!std.mem.allEqual(u8, message_memory, 0));
+
+    try std.testing.expectError(error.CredentialProviderFailed, server.resumeAuth(&sink));
+    try std.testing.expect(server.client_hello_psk == null);
+    // Regression coverage: it is not enough to null the optional — the
+    // framed ClientHello bytes it pointed at must themselves be
+    // overwritten, or a scratch copy of the peer-supplied identity would
+    // linger in backend storage past this failed connection.
+    try std.testing.expect(std.mem.allEqual(u8, message_memory, 0));
+}
+
 test "a transport-extension type colliding with a TLS-owned PSK extension is rejected at start" {
     inline for (.{ pre_shared_key.ext_pre_shared_key, pre_shared_key.ext_psk_key_exchange_modes }) |colliding_type| {
         var client = tls_backend.Tls13Backend.initClient(
@@ -3397,6 +3476,136 @@ test "client rejects a forged selected_identity when no PSK was ever offered" {
     try std.testing.expect(!client.core.psk_authenticated);
 }
 
+test "a PSK-selected ServerHello with inconsistent suite/version/key-share is rejected and fully cleans up" {
+    const Case = struct { opts: ServerHelloOptions, expected: anyerror };
+    const cases = [_]Case{
+        // Wrong (unsupported) cipher suite — this profile only negotiates
+        // TLS_AES_128_GCM_SHA256.
+        .{ .opts = .{ .selected_identity = 0, .cipher_suite = 0x1302 }, .expected = error.IllegalParameter },
+        // Selected a non-TLS-1.3 version.
+        .{ .opts = .{ .selected_identity = 0, .selected_version = 0x0303 }, .expected = error.IllegalParameter },
+        // No key_share extension at all.
+        .{ .opts = .{ .selected_identity = 0, .key_share = .missing }, .expected = error.MalformedHandshake },
+        // key_share names a group other than x25519.
+        .{ .opts = .{ .selected_identity = 0, .key_share = .wrong_group }, .expected = error.IllegalParameter },
+        // key_share's declared length doesn't match x25519's fixed size.
+        .{ .opts = .{ .selected_identity = 0, .key_share = .wrong_length }, .expected = error.IllegalParameter },
+        // A well-formed but low-order/identity x25519 point.
+        .{ .opts = .{ .selected_identity = 0, .key_share = .low_order }, .expected = error.IllegalParameter },
+    };
+
+    for (cases) |case| {
+        var client = tls_backend.Tls13Backend.initClient(
+            clientEntropy(),
+            .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+            .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } },
+        );
+        defer client.deinit();
+
+        const psk = [_]u8{0x44} ** tls_backend.hash_len;
+        var offers: pre_shared_key.ClientPskOfferSet = .{};
+        try pushTestTicket(&offers, &psk, "consistency-ticket");
+        var clock_dummy: u8 = 0;
+        const Clock = struct {
+            fn now(_: *anyopaque) i64 {
+                return 0;
+            }
+        };
+        try client.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+
+        var sink = DirectSink{};
+        defer sink.deinit();
+        try client.backend().start(.client, {}, &sink);
+        try std.testing.expectEqual(@as(usize, 1), client.client_psk_offers.len);
+
+        var buf: [512]u8 = undefined;
+        const hello = try buildServerHello(&buf, case.opts);
+        try std.testing.expectError(case.expected, client.backend().receive(.initial, hello, &sink));
+
+        try std.testing.expect(client.client_psk_offers.isEmpty());
+        try std.testing.expect(!client.selected_client_psk_present);
+        try std.testing.expect(!client.core.psk_authenticated);
+        try std.testing.expect(client.schedule == null);
+    }
+}
+
+test "a rejected ServerHello observably zeroes the client's offered PSK bytes, not just the length" {
+    // `FixedBufferAllocator.free` is a no-op that never poisons its backing
+    // storage (unlike `std.testing.allocator`'s debug fill-on-free), so any
+    // zero bytes we observe here can only have come from this code's own
+    // explicit `secureZero` calls, not from allocator bookkeeping.
+    var backing = [_]u8{0xa5} ** 4096;
+    var fba = std.heap.FixedBufferAllocator.init(&backing);
+    const allocator = fba.allocator();
+
+    var client = tls_backend.Tls13Backend.initClient(
+        clientEntropy(),
+        .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+        .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } },
+    );
+    defer client.deinit();
+
+    const psk = [_]u8{0x99} ** tls_backend.hash_len;
+    var common: session.ResumableSessionCommon = .{};
+    try common.init(allocator, session.Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = &psk,
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer(""),
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 3600,
+    });
+    var ticket_state: session.ClientTicketState = .{};
+    try ticket_state.init(allocator, session.Limits.default, &common, .{
+        .ticket = "wipe-client-ticket",
+        .ticket_age_add = 0,
+        .ticket_nonce = "n",
+        .received_at_unix_ms = 0,
+    });
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&ticket_state);
+
+    var clock_dummy: u8 = 0;
+    const Clock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 0;
+        }
+    };
+    try client.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try client.backend().start(.client, {}, &sink);
+    try std.testing.expectEqual(@as(usize, 1), client.client_psk_offers.len);
+
+    // Captured from the offer's *final* resting place inside the backend
+    // (after every intervening move), not the now-defunct local variable
+    // above: only this copy is the one `clearFailedHandshakeState` must
+    // reach.
+    const settled = &client.client_psk_offers.tickets[0];
+    const psk_memory = settled.common.resumption_psk.bytes[0..settled.common.resumption_psk.len];
+    const ticket_memory = settled.ticket.slice();
+    const nonce_memory = settled.ticket_nonce.bytes[0..settled.ticket_nonce.len];
+    try std.testing.expect(!std.mem.allEqual(u8, psk_memory, 0));
+    try std.testing.expectEqualStrings("wipe-client-ticket", ticket_memory);
+    try std.testing.expect(!std.mem.allEqual(u8, nonce_memory, 0));
+
+    var buf: [512]u8 = undefined;
+    const hello = try buildServerHello(&buf, .{ .selected_identity = 5 }); // beyond the single emitted offer
+    try std.testing.expectError(error.IllegalParameter, client.backend().receive(.initial, hello, &sink));
+
+    try std.testing.expect(client.client_psk_offers.isEmpty());
+    // `resumption_psk`/`ticket_nonce` are embedded fixed-size arrays wiped
+    // in place by `secureZero`, so they are observably all-zero afterward.
+    // `ticket` is allocator-backed: Zig's `Allocator.free()` unconditionally
+    // `@memset`s freed memory to `undefined` (0xaa in this build) *after*
+    // our own `secureZero` runs, so an exact-zero check on it would fail
+    // for reasons unrelated to whether the secret was actually wiped —
+    // instead this proves the original ticket bytes no longer survive.
+    try std.testing.expect(std.mem.allEqual(u8, psk_memory, 0));
+    try std.testing.expect(!std.mem.eql(u8, ticket_memory, "wipe-client-ticket"));
+    try std.testing.expect(std.mem.allEqual(u8, nonce_memory, 0));
+}
+
 /// Completes a PSK-resumed server handshake driven by `driveServerSelection`
 /// by feeding it the correct client Finished — computed from the server's
 /// own (symmetric) key schedule, since there is no real client driver in
@@ -3445,6 +3654,46 @@ test "takeSelectedServerPsk returns null before the client Finished commits the 
     var taken_after: session.ServerRecoverableState = .{};
     defer taken_after.deinit();
     try std.testing.expect(server.takeSelectedServerPsk(&taken_after) != null);
+}
+
+test "backend teardown observably zeroes the key schedule and selected PSK session" {
+    // Deliberately stops short of feeding the client Finished: `finish()`
+    // already wipes `schedule` eagerly the moment the handshake actually
+    // completes (traffic secrets have been handed to the sink by then), so
+    // proving teardown-time zeroization needs a still-live, uncommitted
+    // schedule — exactly the state selection leaves behind (see
+    // `takeSelectedServerPsk returns null before the client Finished
+    // commits the handshake`, above).
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+
+    const psk = [_]u8{0xcc} ** tls_backend.hash_len;
+    var stored_state = pskStoredState(&psk);
+    defer stored_state.deinit();
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "teardown-ticket" };
+    try server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+
+    try driveServerSelection(&server, .{ .psk = .{ .items = &.{.{ .identity = "teardown-ticket", .binder_psk = &psk }} } });
+    try std.testing.expect(server.core.psk_authenticated);
+    try std.testing.expect(server.selected_server_psk_present);
+
+    // Both `schedule` and `selected_server_psk.state` are embedded directly
+    // in the backend (no separate heap allocation), so their addresses stay
+    // valid across `deinit()` and the bytes are directly inspectable —
+    // unlike allocator-backed secrets, nothing here goes through
+    // `Allocator.free`'s unconditional undefined-fill.
+    const schedule_memory = std.mem.asBytes(&server.schedule.?);
+    const selected_psk_memory = server.selected_server_psk.state.common.resumption_psk.bytes[0..server.selected_server_psk.state.common.resumption_psk.len];
+    try std.testing.expect(!std.mem.allEqual(u8, schedule_memory, 0));
+    try std.testing.expect(!std.mem.allEqual(u8, selected_psk_memory, 0));
+
+    server.deinit();
+
+    try std.testing.expect(std.mem.allEqual(u8, schedule_memory, 0));
+    try std.testing.expect(std.mem.allEqual(u8, selected_psk_memory, 0));
 }
 
 fn pskStoredStateTimed(psk: []const u8, issued_at_unix_ms: i64, ticket_age_add: u32) session.ServerRecoverableState {
@@ -3658,27 +3907,64 @@ fn buildRawOfferedPsks(buf: []u8, count: usize) ![]const u8 {
     return w.written();
 }
 
-test "resolver candidate cloning under injected allocation failure leaves no partial or retained state" {
+const AllocFailResolver = struct {
+    state: *session.ServerRecoverableState,
+    allocator: std.mem.Allocator,
+    saw_oom: bool = false,
+    fn now(_: *anyopaque) i64 {
+        return 0;
+    }
+    fn resolve(ctx: *anyopaque, _: []const u8, out: *session.ServerRecoverableState) pre_shared_key.ResolveError!bool {
+        const self: *@This() = @ptrCast(@alignCast(ctx));
+        self.state.cloneInto(self.allocator, out) catch |err| {
+            self.saw_oom = (err == error.OutOfMemory);
+            return error.ResolverFailed;
+        };
+        return true;
+    }
+};
+
+/// Exercises exactly the allocation `selectPsk()` performs on the success
+/// path — the resolver's own `ServerRecoverableState.cloneInto` — through
+/// the real backend, for `std.testing.checkAllAllocationFailures`. Only an
+/// allocation failure the resolver itself observed is translated back into
+/// `error.OutOfMemory`; any other failure is a genuine test failure, not a
+/// silently accepted one.
+fn exerciseResolverCloneThroughBackend(
+    allocator: std.mem.Allocator,
+    stored: *session.ServerRecoverableState,
+    psk: *const [tls_backend.hash_len]u8,
+) !void {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    defer server.deinit();
+    try server.setApplicationCompat(.{ .format_id = 2, .format_version = 1, .bytes = "application-snapshot" });
+
+    var resolver_state = AllocFailResolver{ .state = stored, .allocator = allocator };
+    try server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = AllocFailResolver.now,
+        .resolveFn = AllocFailResolver.resolve,
+    });
+
+    driveServerSelection(&server, .{ .psk = .{ .items = &.{
+        .{ .identity = "alloc-ticket", .binder_psk = psk },
+    } } }) catch |err| {
+        if (resolver_state.saw_oom and err == error.CredentialProviderFailed) return error.OutOfMemory;
+        return err;
+    };
+    try std.testing.expect(server.core.psk_authenticated);
+    try std.testing.expect(server.selected_server_psk_present);
+}
+
+test "resolver candidate cloning is proven correct across every allocation-failure point" {
     // `selectPsk()`'s only allocation on the success path is the
     // resolver's own `ServerRecoverableState.cloneInto` (the underlying
     // allocation primitives — `ResumableSessionCommon.init`/`cloneInto`,
     // `BoundedSecret`/`CompatSnapshot` — already have exhaustive
     // `checkAllAllocationFailures` coverage in session.zig; this proves
-    // the *backend* PSK path degrades cleanly, not silently, when that
-    // allocation fails partway through selection).
-    const AllocFailResolver = struct {
-        state: *session.ServerRecoverableState,
-        allocator: std.mem.Allocator,
-        fn now(_: *anyopaque) i64 {
-            return 0;
-        }
-        fn resolve(ctx: *anyopaque, _: []const u8, out: *session.ServerRecoverableState) pre_shared_key.ResolveError!bool {
-            const self: *@This() = @ptrCast(@alignCast(ctx));
-            self.state.cloneInto(self.allocator, out) catch return error.ResolverFailed;
-            return true;
-        }
-    };
-
+    // the *backend* PSK path degrades cleanly, not silently, at every one
+    // of those allocation points, and that a real success run exists once
+    // every allocation succeeds).
     var stored_common: session.ResumableSessionCommon = .{};
     try stored_common.init(std.testing.allocator, session.Limits.default, .{
         .cipher_suite = .tls_aes_128_gcm_sha256,
@@ -3697,34 +3983,13 @@ test "resolver candidate cloning under injected allocation failure leaves no par
     var stored_state: session.ServerRecoverableState = .{};
     stored_state.init(&stored_common, 0);
     defer stored_state.deinit();
-
     const psk = [_]u8{0xbb} ** tls_backend.hash_len;
-    var fail_index: usize = 0;
-    while (fail_index < 32) : (fail_index += 1) {
-        var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = fail_index });
-        var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
-        defer server.deinit();
-        try server.setApplicationCompat(.{ .format_id = 2, .format_version = 1, .bytes = "application-snapshot" });
-        var resolver_state = AllocFailResolver{ .state = &stored_state, .allocator = failing.allocator() };
-        try server.setServerPskResolver(.{
-            .ctx = &resolver_state,
-            .nowUnixMsFn = AllocFailResolver.now,
-            .resolveFn = AllocFailResolver.resolve,
-        });
 
-        if (driveServerSelection(&server, .{ .psk = .{ .items = &.{
-            .{ .identity = "alloc-ticket", .binder_psk = &psk },
-        } } })) |_| {
-            // Enough allocations succeeded that the clone (and the rest of
-            // the handshake) completed normally.
-            try std.testing.expect(server.core.psk_authenticated);
-        } else |_| {
-            // The clone's allocation failed: the backend must fail closed
-            // rather than retain any partial selected state.
-            try std.testing.expect(!server.selected_server_psk_present);
-            try std.testing.expect(!server.core.psk_authenticated);
-        }
-    }
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        exerciseResolverCloneThroughBackend,
+        .{ &stored_state, &psk },
+    );
 }
 
 test "resolver identity-resolution attempts are bounded to eight even when a ninth would succeed" {
@@ -3914,6 +4179,83 @@ test "a compatible candidate with a wrong binder is fatal and never probes a lat
     // failed selection: the fatal binder mismatch is caught before
     // anything is written to the wire.
     try std.testing.expectEqual(events_before_client_hello, sink.len);
+}
+
+const FbaCloningResolver = struct {
+    state: *session.ServerRecoverableState,
+    allocator: std.mem.Allocator,
+    identity: []const u8,
+
+    fn now(_: *anyopaque) i64 {
+        return 0;
+    }
+    fn resolve(ctx: *anyopaque, identity: []const u8, out: *session.ServerRecoverableState) pre_shared_key.ResolveError!bool {
+        const self: *@This() = @ptrCast(@alignCast(ctx));
+        if (!std.mem.eql(u8, identity, self.identity)) return false;
+        // Deliberately clones through a *different* allocator than the one
+        // backing `self.state` itself, so the only writes ever made into
+        // `allocator`'s backing storage are the transient per-attempt
+        // candidate this resolver hands back to `selectPsk` — isolating
+        // exactly the allocation this test means to observe.
+        self.state.cloneInto(self.allocator, out) catch return error.ResolverFailed;
+        return true;
+    }
+};
+
+test "a bad binder wipes the resolver's cloned candidate, including its compat blob" {
+    // See the zeroization test above for why `FixedBufferAllocator` (whose
+    // `free` never poisons memory, unlike the generic `Allocator.free`
+    // front-end which always does) is the only way to observe this
+    // reliably: it isolates the candidate clone's allocations to a backing
+    // array we can scan directly, independent of whatever exact byte
+    // pattern `free()` itself leaves behind.
+    var backing = [_]u8{0xa5} ** 4096;
+    var fba = std.heap.FixedBufferAllocator.init(&backing);
+    const clone_allocator = fba.allocator();
+
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    defer server.deinit();
+
+    const marker = "candidate-compat-blob-marker";
+    try server.setApplicationCompat(.{ .format_id = 3, .format_version = 1, .bytes = marker });
+
+    const psk = [_]u8{0x66} ** tls_backend.hash_len;
+    const wrong_psk = [_]u8{0x77} ** tls_backend.hash_len;
+    var common: session.ResumableSessionCommon = .{};
+    // Built with a plain allocator: this is the resolver's *source* record,
+    // never itself passed to `selectPsk` — only its clones (made through
+    // `clone_allocator` below) are, so this allocation must not alias the
+    // one under test.
+    try common.init(std.testing.allocator, session.Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = &psk,
+        .application_protocol = "h2",
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer(tls_backend.testdata.certificate_der),
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 3600,
+        .application_compat = .{ .format_id = 3, .format_version = 1, .bytes = marker },
+    });
+    var stored_state: session.ServerRecoverableState = .{};
+    stored_state.init(&common, 0);
+    defer stored_state.deinit();
+
+    var resolver_state = FbaCloningResolver{ .state = &stored_state, .allocator = clone_allocator, .identity = "bad-binder-ticket" };
+    try server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = FbaCloningResolver.now,
+        .resolveFn = FbaCloningResolver.resolve,
+    });
+
+    try std.testing.expectError(error.DecryptError, driveServerSelection(&server, .{
+        .psk = .{ .items = &.{.{ .identity = "bad-binder-ticket", .binder_psk = &wrong_psk }} },
+    }));
+
+    try std.testing.expect(!server.core.psk_authenticated);
+    try std.testing.expect(!server.selected_server_psk_present);
+    // The clone's compat blob was the only thing ever written into
+    // `backing`; a lingering copy here would mean the failed candidate's
+    // `deinit()` was skipped somewhere on the bad-binder path.
+    try std.testing.expect(std.mem.indexOf(u8, &backing, marker) == null);
 }
 
 /// A hand-written `CredentialProvider` whose second chain entry is

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -3070,6 +3070,137 @@ test "async credential selection failure clears the captured PSK offer" {
     try std.testing.expect(server.client_hello_psk == null);
 }
 
+test "a transport-extension type colliding with a TLS-owned PSK extension is rejected at start" {
+    inline for (.{ pre_shared_key.ext_pre_shared_key, pre_shared_key.ext_psk_key_exchange_modes }) |colliding_type| {
+        var client = tls_backend.Tls13Backend.initClient(
+            clientEntropy(),
+            .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+            .{ .extension = .{ .alpn = "h3", .extension_type = colliding_type, .local = "x" } },
+        );
+        defer client.deinit();
+        var sink = DirectSink{};
+        defer sink.deinit();
+        try std.testing.expectError(error.InvalidTransportProfile, client.backend().start(.client, {}, &sink));
+        try std.testing.expectEqual(.idle, client.core.handshake_lifecycle);
+        try std.testing.expectEqual(@as(usize, 0), sink.len);
+        try std.testing.expect(!client.key_pair_present);
+
+        var server = tls_backend.Tls13Backend.initServer(
+            serverEntropy(),
+            fixtureIdentity(),
+            .{ .extension = .{ .alpn = "h3", .extension_type = colliding_type, .local = "y" } },
+        );
+        defer server.deinit();
+        var server_sink = DirectSink{};
+        defer server_sink.deinit();
+        try std.testing.expectError(error.InvalidTransportProfile, server.backend().start(.server, {}, &server_sink));
+        try std.testing.expectEqual(.idle, server.core.handshake_lifecycle);
+    }
+}
+
+test "setApplicationCompat copies the caller's bytes instead of borrowing them" {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    defer server.deinit();
+
+    var scratch: [4]u8 = .{ 'o', 'l', 'd', '!' };
+    try server.setApplicationCompat(.{ .format_id = 7, .format_version = 1, .bytes = &scratch });
+    // The caller is free to mutate/reuse its own buffer immediately after
+    // the call returns — the stored value must not observe this.
+    @memset(&scratch, 'X');
+
+    const stored = server.ownedApplicationCompat().?;
+    try std.testing.expectEqualStrings("old!", stored.bytes);
+}
+
+test "handshake-phase failure wipes PSK offer state before ServerHello even arrives" {
+    var client = tls_backend.Tls13Backend.initClient(
+        clientEntropy(),
+        .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+        .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } },
+    );
+    defer client.deinit();
+
+    const psk = [_]u8{0x11} ** tls_backend.hash_len;
+    var common: session.ResumableSessionCommon = .{};
+    try common.init(std.testing.allocator, session.Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = &psk,
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer(""),
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 3600,
+    });
+    var ticket: session.ClientTicketState = .{};
+    try ticket.init(std.testing.allocator, session.Limits.default, &common, .{
+        .ticket = "offer",
+        .ticket_age_add = 0,
+        .ticket_nonce = "n",
+        .received_at_unix_ms = 0,
+    });
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&ticket);
+    var clock_dummy: u8 = 0;
+    const Clock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 0;
+        }
+    };
+    client.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try client.backend().start(.client, {}, &sink);
+    try std.testing.expect(!client.client_psk_offers.isEmpty());
+
+    // A Finished message at the initial epoch (ServerHello was expected) is
+    // a wrong-transport-epoch rejection raised by `drainInput` itself,
+    // before `core.acceptReceived` or any per-message handler — including
+    // the handler-local `errdefer` inside `onServerHello` — ever runs.
+    var buf: [8]u8 = undefined;
+    const finished = try tls_core.messages.encode(.finished, "", &buf);
+    try std.testing.expectError(error.UnexpectedTransportEpoch, client.backend().receive(.initial, finished, &sink));
+
+    try std.testing.expect(client.client_psk_offers.isEmpty());
+}
+
+test "the accepted server session survives PSK selection with its early-data and metadata intact" {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    defer server.deinit();
+
+    const psk = [_]u8{0x66} ** tls_backend.hash_len;
+    var common: session.ResumableSessionCommon = .{};
+    try common.init(std.testing.allocator, session.Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = &psk,
+        .application_protocol = "h2",
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer(tls_backend.testdata.certificate_der),
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 3600,
+        .early_data = .{ .early_data_capable = 12345 },
+    });
+    var stored_state: session.ServerRecoverableState = .{};
+    stored_state.init(&common, 0);
+    defer stored_state.deinit();
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "early-data-ticket" };
+    server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+
+    try driveServerSelection(&server, .{ .psk = .{ .items = &.{.{ .identity = "early-data-ticket", .binder_psk = &psk }} } });
+
+    try std.testing.expect(server.core.psk_authenticated);
+    var taken: session.ServerRecoverableState = .{};
+    const index = server.takeSelectedServerPsk(&taken).?;
+    defer taken.deinit();
+    try std.testing.expectEqual(@as(u16, 0), index);
+    try std.testing.expectEqual(@as(u32, 12345), taken.common.early_data.maxEarlyData());
+    try std.testing.expectEqualStrings("h2", taken.common.application_protocol.?.slice());
+    // One-shot: a second take returns null and leaves `out` untouched.
+    var second: session.ServerRecoverableState = .{};
+    try std.testing.expectEqual(@as(?u16, null), server.takeSelectedServerPsk(&second));
+}
+
 test "server selects the first compatible identity: unknown first, valid second" {
     var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
     defer server.deinit();

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -656,6 +656,139 @@ test "PSK round trip falls back to a full handshake when the resolver has no mat
     try std.testing.expectEqual(events.CertificateState.valid, harness.observed.certificate_state.?);
 }
 
+test "an ineligible offered ticket is filtered without desyncing the wire index of a later valid one" {
+    // Regression coverage: `sendClientHello` used to filter eligible
+    // tickets while writing the wire offer, but `onServerHello` indexed
+    // the *original*, unfiltered `client_psk_offers` array. With an
+    // expired ticket first and a valid one second, the wire would contain
+    // only the valid ticket at index 0, but the client would resolve
+    // `selected_identity = 0` back to the expired ticket's PSK — a silent
+    // secret mismatch. `client_psk_offers` is now compacted to exactly the
+    // wire-emitted, wire-ordered subset before `core.start()`, so this
+    // must complete cleanly with matching keys on both sides.
+    var harness = DirectHarness.init();
+    defer harness.deinit();
+
+    const psk = [_]u8{0x77} ** tls_backend.hash_len;
+    var expired_common: session.ResumableSessionCommon = .{};
+    try expired_common.init(std.testing.allocator, session.Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = &psk,
+        .application_protocol = "h2",
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer(tls_backend.testdata.certificate_der),
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 1,
+    });
+    var expired_ticket: session.ClientTicketState = .{};
+    try expired_ticket.init(std.testing.allocator, session.Limits.default, &expired_common, .{
+        .ticket = "expired-ticket",
+        .ticket_age_add = 0,
+        .ticket_nonce = "n",
+        .received_at_unix_ms = 0,
+    });
+
+    var valid_common: session.ResumableSessionCommon = .{};
+    try valid_common.init(std.testing.allocator, session.Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = &psk,
+        .application_protocol = "h2",
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer(tls_backend.testdata.certificate_der),
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 3600,
+    });
+    var valid_ticket: session.ClientTicketState = .{};
+    try valid_ticket.init(std.testing.allocator, session.Limits.default, &valid_common, .{
+        .ticket = "valid-ticket",
+        .ticket_age_add = 0,
+        .ticket_nonce = "n",
+        .received_at_unix_ms = 0,
+    });
+
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&expired_ticket); // offer index 0: filtered out at plan time
+    try offers.push(&valid_ticket); // offer index 1: the only one actually sent, as wire index 0
+
+    var clock_dummy: u8 = 0;
+    const Clock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 10_000; // well past the expired ticket's 1-second lifetime
+        }
+    };
+    harness.client_backend.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+
+    var stored_state = pskStoredState(&psk);
+    defer stored_state.deinit();
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "valid-ticket" };
+    harness.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+
+    try harness.run();
+
+    try std.testing.expect(harness.client_driver.isComplete());
+    try std.testing.expect(harness.server_driver.isComplete());
+    // Exactly one identity was ever offered (or resolved): the expired one
+    // never reached the wire at all.
+    try std.testing.expectEqual(@as(usize, 1), resolver_state.calls);
+    try std.testing.expect(harness.client_backend.core.psk_authenticated);
+    try std.testing.expect(harness.server_backend.core.psk_authenticated);
+}
+
+test "handshake-time client authentication forces a full handshake even when a PSK is offered" {
+    var harness = DirectHarness.init();
+    defer harness.deinit();
+    harness.configureClientAuth(.required, true, .{ .pinned_certificate = tls_backend.testdata.certificate_der });
+
+    const psk = [_]u8{0x88} ** tls_backend.hash_len;
+    var common: session.ResumableSessionCommon = .{};
+    try common.init(std.testing.allocator, session.Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = &psk,
+        .application_protocol = "h2",
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer(tls_backend.testdata.certificate_der),
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 3600,
+    });
+    var ticket: session.ClientTicketState = .{};
+    try ticket.init(std.testing.allocator, session.Limits.default, &common, .{
+        .ticket = "client-auth-ticket",
+        .ticket_age_add = 0,
+        .ticket_nonce = "n",
+        .received_at_unix_ms = 0,
+    });
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&ticket);
+    var clock_dummy: u8 = 0;
+    const Clock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 0;
+        }
+    };
+    harness.client_backend.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+
+    var stored_state = pskStoredState(&psk);
+    defer stored_state.deinit();
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "client-auth-ticket" };
+    harness.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+
+    try harness.run();
+
+    try std.testing.expect(harness.client_driver.isComplete());
+    try std.testing.expect(harness.server_driver.isComplete());
+    try std.testing.expect(!harness.client_backend.core.psk_authenticated);
+    try std.testing.expect(!harness.server_backend.core.psk_authenticated);
+    // The resolver is never even consulted: client_auth forces the full
+    // fallback before PSK selection begins.
+    try std.testing.expectEqual(@as(usize, 0), resolver_state.calls);
+    try std.testing.expectEqual(events.CertificateState.valid, harness.observed.certificate_state.?);
+}
+
 test "direct shared driver cleanup wipes secrets after record authentication failure" {
     var harness = DirectHarness.init();
     defer harness.deinit();
@@ -1959,6 +2092,25 @@ const ClientHelloOptions = struct {
     /// offer, for driving an extension-profile (#392 HTTP/3) server through
     /// selection the same way a real QUIC client would.
     transport_extension: ?struct { extension_type: u16, payload: []const u8 } = null,
+    /// #362: offer one or more resumption PSKs, in order, as the
+    /// (necessarily last) ClientHello extension. Each binder is computed
+    /// over the exact bytes this function ends up producing, from the
+    /// per-entry `binder_psk` — pass a value other than the identity's real
+    /// PSK to model a wrong binder.
+    psk: ?PskOfferOptions = null,
+};
+
+const PskOfferOptions = struct {
+    items: []const PskOfferItemOptions,
+    /// Skip writing `psk_key_exchange_modes` — for the missing-extension
+    /// malformed-input test.
+    omit_modes: bool = false,
+};
+
+const PskOfferItemOptions = struct {
+    identity: []const u8,
+    binder_psk: []const u8,
+    obfuscated_ticket_age: u32 = 0,
 };
 
 /// Build a minimal, well-formed TLS 1.3 ClientHello the server engine accepts,
@@ -2037,8 +2189,38 @@ fn buildClientHello(buf: []u8, opts: ClientHelloOptions) ![]const u8 {
         try w.u16_(@intCast(transport.payload.len));
         try w.bytes(transport.payload);
     }
+    // pre_shared_key (#362): must be the last extension.
+    var psk_offer: ?pre_shared_key.ClientOfferWrite = null;
+    var psk_items_buf: [pre_shared_key.max_offered_identities]pre_shared_key.OfferItem = undefined;
+    if (opts.psk) |psk_opt| {
+        if (!psk_opt.omit_modes) {
+            try w.u16_(pre_shared_key.ext_psk_key_exchange_modes);
+            const modes_ext_len = try w.reserve(2);
+            try pre_shared_key.writeModes(&w, &.{.psk_dhe_ke});
+            w.patch(2, modes_ext_len);
+        }
+        for (psk_opt.items, 0..) |item, i| {
+            psk_items_buf[i] = .{
+                .identity = item.identity,
+                .obfuscated_ticket_age = item.obfuscated_ticket_age,
+                .digest_len = tls_backend.hash_len,
+            };
+        }
+        psk_offer = try pre_shared_key.writeOffer(&w, psk_items_buf[0..psk_opt.items.len]);
+    }
+
     w.patch(2, extensions_len);
     w.patch(3, message_len);
+
+    if (psk_offer) |offer| {
+        const prefix = buf[0..offer.truncated_len];
+        for (opts.psk.?.items, 0..) |item, i| {
+            var binder: [tls_backend.hash_len]u8 = undefined;
+            try pre_shared_key.deriveBinder(.sha256, item.binder_psk, prefix, &binder);
+            const slot = offer.slots[i];
+            @memcpy(buf[slot.offset..][0..slot.len], &binder);
+        }
+    }
     return buf[0..w.len];
 }
 
@@ -2647,6 +2829,245 @@ test "an async credential selection suspends the handshake and resumes to comple
     try std.testing.expectEqual(@as(usize, 1), mock.op_release_count);
     try std.testing.expectEqual(@as(usize, 1), mock.sign_count);
     try std.testing.expectEqual(@as(usize, 1), mock.release_count);
+    try std.testing.expect(server.credentialFailure() == null);
+}
+
+fn pskStoredState(psk: []const u8) session.ServerRecoverableState {
+    return pskStoredStateWithBinding(psk, session.AuthBinding.fromLeafCertificateDer(tls_backend.testdata.certificate_der));
+}
+
+/// Like `pskStoredState`, but with an explicit `auth_binding` — for modelling
+/// a ticket issued under a *different* server certificate than the one
+/// currently selected (certificate-rotation fallback).
+fn pskStoredStateWithBinding(psk: []const u8, auth_binding: session.AuthBinding) session.ServerRecoverableState {
+    var common: session.ResumableSessionCommon = .{};
+    common.init(std.testing.allocator, session.Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = psk,
+        // Matches `buildClientHello`'s default `alpn_protocols = &.{"h2"}`
+        // and `serverWithProvider`'s "h2" record policy, so the candidate
+        // compatibility check (negotiated ALPN vs. stored) is satisfied.
+        .application_protocol = "h2",
+        .auth_binding = auth_binding,
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 3600,
+    }) catch unreachable;
+    var state: session.ServerRecoverableState = .{};
+    state.init(&common, 0);
+    return state;
+}
+
+const CountingResolver = struct {
+    state: *session.ServerRecoverableState,
+    identity: []const u8,
+    calls: usize = 0,
+
+    fn now(_: *anyopaque) i64 {
+        return 0;
+    }
+    fn resolve(ctx: *anyopaque, identity: []const u8, out: *session.ServerRecoverableState) pre_shared_key.ResolveError!bool {
+        const self: *@This() = @ptrCast(@alignCast(ctx));
+        self.calls += 1;
+        if (!std.mem.eql(u8, identity, self.identity)) return false;
+        self.state.cloneInto(std.testing.allocator, out) catch return error.ResolverFailed;
+        return true;
+    }
+};
+
+test "async credential selection resumes PSK selection identically to the synchronous path" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.async_select = true;
+    mock.pending_polls = 2;
+    var server = serverWithProvider(&mock);
+    defer server.deinit();
+
+    const psk = [_]u8{0x5a} ** tls_backend.hash_len;
+    var stored_state = pskStoredState(&psk);
+    defer stored_state.deinit();
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "async-ticket" };
+    server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{ .psk = .{ .items = &.{.{ .identity = "async-ticket", .binder_psk = &psk }} } });
+    try server.backend().receive(.initial, hello, &sink);
+
+    // Parked awaiting the async credential selection: no resolver or binder
+    // work has happened yet — PSK selection only runs once a credential is
+    // in hand, exactly as it does synchronously.
+    try std.testing.expect(server.authPending());
+    try std.testing.expectEqual(@as(usize, 0), resolver_state.calls);
+
+    try server.resumeAuth(&sink); // poll #1: still pending
+    try server.resumeAuth(&sink); // poll #2: still pending
+    try server.resumeAuth(&sink); // poll #3: completes, runs PSK selection + the rest of the flight
+    try std.testing.expect(!server.authPending());
+
+    try std.testing.expectEqual(@as(usize, 1), resolver_state.calls);
+    try std.testing.expect(server.core.psk_authenticated);
+    try std.testing.expect(server.credentialFailure() == null);
+    try std.testing.expect(server.client_hello_psk == null);
+}
+
+test "async credential selection failure clears the captured PSK offer" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.async_select = true;
+    mock.pending_polls = 0;
+    mock.pending_fails = true;
+    var server = serverWithProvider(&mock);
+    defer server.deinit();
+
+    const psk = [_]u8{0x5a} ** tls_backend.hash_len;
+    var stored_state = pskStoredState(&psk);
+    defer stored_state.deinit();
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "async-ticket" };
+    server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{ .psk = .{ .items = &.{.{ .identity = "async-ticket", .binder_psk = &psk }} } });
+    try server.backend().receive(.initial, hello, &sink);
+    try std.testing.expect(server.authPending());
+
+    try std.testing.expectError(error.CredentialProviderFailed, server.resumeAuth(&sink));
+    try std.testing.expect(!server.authPending());
+    try std.testing.expectEqual(@as(usize, 0), resolver_state.calls);
+    try std.testing.expect(server.client_hello_psk == null);
+}
+
+test "server selects the first compatible identity: unknown first, valid second" {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    defer server.deinit();
+
+    const psk = [_]u8{0x11} ** tls_backend.hash_len;
+    var stored_state = pskStoredState(&psk);
+    defer stored_state.deinit();
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "known-ticket" };
+    server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+
+    try driveServerSelection(&server, .{ .psk = .{ .items = &.{
+        .{ .identity = "unknown-ticket", .binder_psk = &psk },
+        .{ .identity = "known-ticket", .binder_psk = &psk },
+    } } });
+
+    try std.testing.expectEqual(@as(usize, 2), resolver_state.calls);
+    try std.testing.expect(server.core.psk_authenticated);
+    try std.testing.expect(server.credentialFailure() == null);
+}
+
+test "a compatible candidate with a wrong binder is fatal and never probes a later identity" {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    defer server.deinit();
+
+    const psk = [_]u8{0x22} ** tls_backend.hash_len;
+    const wrong_psk = [_]u8{0x33} ** tls_backend.hash_len;
+    var stored_state = pskStoredState(&psk);
+    defer stored_state.deinit();
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "ticket-a" };
+    server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+
+    try std.testing.expectError(error.DecryptError, driveServerSelection(&server, .{
+        .psk = .{
+            .items = &.{
+                .{ .identity = "ticket-a", .binder_psk = &wrong_psk }, // resolvable and compatible, wrong binder
+                .{ .identity = "ticket-b", .binder_psk = &psk }, // would otherwise succeed; must never be tried
+            },
+        },
+    }));
+
+    try std.testing.expectEqual(@as(usize, 1), resolver_state.calls);
+}
+
+test "a ticket bound to a different server certificate falls back to a full handshake" {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    defer server.deinit();
+
+    const psk = [_]u8{0x44} ** tls_backend.hash_len;
+    var stored_state = pskStoredStateWithBinding(&psk, session.AuthBinding.fromLeafCertificateDer("a different certificate entirely"));
+    defer stored_state.deinit();
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "rotated-ticket" };
+    server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+
+    try driveServerSelection(&server, .{ .psk = .{ .items = &.{
+        .{ .identity = "rotated-ticket", .binder_psk = &psk },
+    } } });
+
+    try std.testing.expectEqual(@as(usize, 1), resolver_state.calls);
+    try std.testing.expect(!server.core.psk_authenticated);
+    // Falls back to the ordinary full-certificate flight rather than
+    // failing the connection outright.
+    try std.testing.expectEqual(.running, server.core.handshake_lifecycle);
+    try std.testing.expect(server.credentialFailure() == null);
+}
+
+test "PSK offered without psk_key_exchange_modes is a missing_extension failure" {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    defer server.deinit();
+    const psk = [_]u8{0x55} ** tls_backend.hash_len;
+    try std.testing.expectError(error.MissingExtension, driveServerSelection(&server, .{ .psk = .{
+        .omit_modes = true,
+        .items = &.{.{ .identity = "ticket", .binder_psk = &psk }},
+    } }));
+}
+
+test "an SNI mismatch falls back to a full handshake instead of rejecting the connection" {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    defer server.deinit();
+
+    const psk = [_]u8{0x66} ** tls_backend.hash_len;
+    var common: session.ResumableSessionCommon = .{};
+    try common.init(std.testing.allocator, session.Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = &psk,
+        .application_protocol = "h2",
+        .server_name = "original.example",
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer(tls_backend.testdata.certificate_der),
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 3600,
+    });
+    var stored_state: session.ServerRecoverableState = .{};
+    stored_state.init(&common, 0);
+    defer stored_state.deinit();
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "sni-ticket" };
+    server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+
+    // The client now connects to a *different* host name than the ticket
+    // was issued for.
+    try driveServerSelection(&server, .{
+        .sni = "different.example",
+        .psk = .{ .items = &.{.{ .identity = "sni-ticket", .binder_psk = &psk }} },
+    });
+
+    try std.testing.expectEqual(@as(usize, 1), resolver_state.calls);
+    try std.testing.expect(!server.core.psk_authenticated);
     try std.testing.expect(server.credentialFailure() == null);
 }
 

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -3241,7 +3241,7 @@ test "handshake-phase failure wipes PSK offer state before ServerHello even arri
 /// own (symmetric) key schedule, since there is no real client driver in
 /// these server-only tests.
 fn feedValidClientFinished(server: *tls_backend.Tls13Backend) !void {
-    const schedule = server.schedule.?;
+    const schedule = &server.schedule.?;
     var client_verify = tls_backend.KeySchedule.verifyData(&schedule.client_handshake_traffic, server.core.transcriptHash());
     defer std.crypto.secureZero(u8, &client_verify);
     var finished_buf: [4 + tls_backend.hash_len]u8 = undefined;

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -3185,29 +3185,38 @@ test "async credential selection failure zeroes the captured ClientHello bytes, 
     try server.backend().receive(.initial, hello, &sink);
     try std.testing.expect(server.authPending());
 
-    // `client_hello_psk` is an embedded fixed-size buffer (no allocator
-    // involved), so its address is stable across the `= null` assignment
-    // below and directly re-inspectable afterward.
-    const capture = &server.client_hello_psk.?;
-    const message_memory = capture.message[0..capture.message_len];
-    try std.testing.expect(!std.mem.allEqual(u8, message_memory, 0));
-    const original_message = try std.testing.allocator.dupe(u8, message_memory);
-    defer std.testing.allocator.free(original_message);
+    try std.testing.expect(server.client_hello_psk.?.message_len > 0);
 
     try std.testing.expectError(error.CredentialProviderFailed, server.resumeAuth(&sink));
-    try std.testing.expect(server.client_hello_psk == null);
     // Regression coverage: it is not enough to null the optional — the
     // framed ClientHello bytes it pointed at must themselves be
     // overwritten, or a scratch copy of the peer-supplied identity would
-    // linger in backend storage past this failed connection. Checked
-    // against the original content rather than exact zero: once an
-    // optional transitions to `null`, Zig's own debug-safety
-    // instrumentation is free to poison the now-inactive payload with
-    // something other than zero (observed to differ between the x86_64
-    // and aarch64 backends in this Zig version), so an exact-zero
-    // assertion here would depend on that instrumentation rather than on
-    // this code's own `secureZero` call.
-    try std.testing.expect(!std.mem.eql(u8, message_memory, original_message));
+    // linger in backend storage past this failed connection. This test
+    // deliberately does *not* capture a slice into `client_hello_psk.?`
+    // and re-read it after this line sets the field to `null`: that would
+    // be reading through a reference invalidated by the very assignment
+    // being tested, and whatever byte pattern showed up afterward would be
+    // Zig's own debug-safety instrumentation for an inactive optional
+    // (observed to differ between the x86_64 and aarch64 backends in this
+    // Zig version), not necessarily evidence of `ClientHelloPskCapture
+    // .wipe()` having run. That zeroing is proven directly, on a plain
+    // non-optional value, by `"ClientHelloPskCapture.wipe zeroizes the
+    // captured message"` below; this test only asserts the state
+    // transition it should trigger.
+    try std.testing.expect(server.client_hello_psk == null);
+}
+
+test "ClientHelloPskCapture.wipe zeroizes the captured message" {
+    var capture: tls_backend.Tls13Backend.ClientHelloPskCapture = .{};
+    @memset(capture.message[0..64], 0x5c);
+    capture.message_len = 64;
+    const bytes = capture.message[0..capture.message_len];
+    try std.testing.expect(!std.mem.allEqual(u8, bytes, 0));
+
+    capture.wipe();
+
+    try std.testing.expect(std.mem.allEqual(u8, bytes, 0));
+    try std.testing.expectEqual(@as(usize, 0), capture.message_len);
 }
 
 test "a transport-extension type colliding with a TLS-owned PSK extension is rejected at start" {
@@ -3539,14 +3548,6 @@ test "a PSK-selected ServerHello with inconsistent suite/version/key-share is re
 }
 
 test "a rejected ServerHello observably zeroes the client's offered PSK bytes, not just the length" {
-    // `FixedBufferAllocator.free` is a no-op that never poisons its backing
-    // storage (unlike `std.testing.allocator`'s debug fill-on-free), so any
-    // zero bytes we observe here can only have come from this code's own
-    // explicit `secureZero` calls, not from allocator bookkeeping.
-    var backing = [_]u8{0xa5} ** 4096;
-    var fba = std.heap.FixedBufferAllocator.init(&backing);
-    const allocator = fba.allocator();
-
     var client = tls_backend.Tls13Backend.initClient(
         clientEntropy(),
         .{ .pinned_certificate = tls_backend.testdata.certificate_der },
@@ -3556,7 +3557,7 @@ test "a rejected ServerHello observably zeroes the client's offered PSK bytes, n
 
     const psk = [_]u8{0x99} ** tls_backend.hash_len;
     var common: session.ResumableSessionCommon = .{};
-    try common.init(allocator, session.Limits.default, .{
+    try common.init(std.testing.allocator, session.Limits.default, .{
         .cipher_suite = .tls_aes_128_gcm_sha256,
         .resumption_psk = &psk,
         .auth_binding = session.AuthBinding.fromLeafCertificateDer(""),
@@ -3564,7 +3565,7 @@ test "a rejected ServerHello observably zeroes the client's offered PSK bytes, n
         .lifetime_seconds = 3600,
     });
     var ticket_state: session.ClientTicketState = .{};
-    try ticket_state.init(allocator, session.Limits.default, &common, .{
+    try ticket_state.init(std.testing.allocator, session.Limits.default, &common, .{
         .ticket = "wipe-client-ticket",
         .ticket_age_add = 0,
         .ticket_nonce = "n",
@@ -3603,16 +3604,26 @@ test "a rejected ServerHello observably zeroes the client's offered PSK bytes, n
     try std.testing.expectError(error.IllegalParameter, client.backend().receive(.initial, hello, &sink));
 
     try std.testing.expect(client.client_psk_offers.isEmpty());
-    // `resumption_psk`/`ticket_nonce` are embedded fixed-size arrays wiped
-    // in place by `secureZero`, so they are observably all-zero afterward.
-    // `ticket` is allocator-backed: Zig's `Allocator.free()` unconditionally
-    // `@memset`s freed memory to `undefined` (0xaa in this build) *after*
-    // our own `secureZero` runs, so an exact-zero check on it would fail
-    // for reasons unrelated to whether the secret was actually wiped —
-    // instead this proves the original ticket bytes no longer survive.
+    // `resumption_psk`/`ticket_nonce` are embedded fixed-size arrays, never
+    // routed through an allocator or an optional-to-null transition, so
+    // `secureZero`'s effect is directly and reliably observable here.
     try std.testing.expect(std.mem.allEqual(u8, psk_memory, 0));
-    try std.testing.expect(!std.mem.eql(u8, ticket_memory, "wipe-client-ticket"));
     try std.testing.expect(std.mem.allEqual(u8, nonce_memory, 0));
+    // `ticket` (`BoundedSecret`) is allocator-backed: Zig's generic
+    // `Allocator.free()` front-end unconditionally `@memset`s freed memory
+    // to `undefined` *after* `BoundedSecret.deinit()`'s own `secureZero`
+    // runs, so re-inspecting `ticket_memory`'s bytes here would prove
+    // nothing about whether that `secureZero` call actually executed —
+    // the exact same undefined-fill would occur even if it were deleted.
+    // `BoundedSecret`'s own zero-before-free behavior is proven directly,
+    // without that interference, by `"bounded secret clears allocator
+    // backing storage before free"` in secrets.zig; what this test can
+    // reliably prove at the backend/type-integration boundary is that
+    // `deinit()` actually ran and released ownership — `.len` and
+    // `.bytes` are updated by this code's own explicit assignments, not
+    // by the allocator, so they are unaffected by that undefined-fill.
+    try std.testing.expectEqual(@as(usize, 0), settled.ticket.len);
+    try std.testing.expectEqual(@as(usize, 0), settled.ticket.bytes.len);
 }
 
 /// Completes a PSK-resumed server handshake driven by `driveServerSelection`
@@ -3688,33 +3699,30 @@ test "backend teardown observably zeroes the key schedule and selected PSK sessi
     try driveServerSelection(&server, .{ .psk = .{ .items = &.{.{ .identity = "teardown-ticket", .binder_psk = &psk }} } });
     try std.testing.expect(server.core.psk_authenticated);
     try std.testing.expect(server.selected_server_psk_present);
+    try std.testing.expect(server.schedule != null);
 
-    // Both `schedule` and `selected_server_psk.state` are embedded directly
-    // in the backend (no separate heap allocation), so their addresses stay
-    // valid across `deinit()` and the bytes are directly inspectable —
-    // unlike allocator-backed secrets, nothing here goes through
-    // `Allocator.free`'s unconditional undefined-fill.
-    const schedule_memory = std.mem.asBytes(&server.schedule.?);
+    // `selected_server_psk.state` is a plain (non-optional) field — never
+    // routed through a `?T = null` transition — so its address stays valid
+    // across `deinit()` and the bytes are directly, reliably inspectable
+    // for exact zero afterward.
     const selected_psk_memory = server.selected_server_psk.state.common.resumption_psk.bytes[0..server.selected_server_psk.state.common.resumption_psk.len];
-    try std.testing.expect(!std.mem.allEqual(u8, schedule_memory, 0));
     try std.testing.expect(!std.mem.allEqual(u8, selected_psk_memory, 0));
-    const original_schedule = try std.testing.allocator.dupe(u8, schedule_memory);
-    defer std.testing.allocator.free(original_schedule);
 
     server.deinit();
 
-    // `selected_server_psk.state` is a plain (non-optional) field — never
-    // routed through a `?T = null` transition — so it stays reliably
-    // exact-zero after `secureZero`. `schedule` (`?KeySchedule`) is
-    // checked against its original content rather than exact zero: once
-    // it transitions to `null`, Zig's debug-safety instrumentation is free
-    // to poison the now-inactive payload with something other than zero
-    // (observed to differ between the x86_64 and aarch64 backends in this
-    // Zig version), so an exact-zero assertion here would depend on that
-    // instrumentation rather than on `finish`'s/`deinit`'s own
-    // `secureZero` call.
-    try std.testing.expect(!std.mem.eql(u8, schedule_memory, original_schedule));
     try std.testing.expect(std.mem.allEqual(u8, selected_psk_memory, 0));
+    // `schedule` (`?KeySchedule`) is deliberately *not* re-inspected here:
+    // capturing a slice into `schedule.?`'s payload and reading it after
+    // `deinit()` sets `schedule = null` would be reading through a
+    // reference invalidated by that assignment — whatever byte pattern
+    // shows up afterward is Zig's own debug-safety instrumentation for an
+    // inactive optional (observed to differ between the x86_64 and
+    // aarch64 backends in this Zig version), not necessarily evidence of
+    // this code's `secureZero` call. `KeySchedule.wipe()`'s zeroing is
+    // proven directly, on a plain non-optional value, by `"KeySchedule.wipe
+    // zeroizes every derived secret"` in key_schedule.zig; what this test
+    // can reliably assert at the backend level is the state transition.
+    try std.testing.expect(server.schedule == null);
 }
 
 fn pskStoredStateTimed(psk: []const u8, issued_at_unix_ms: i64, ticket_age_add: u32) session.ServerRecoverableState {
@@ -4206,6 +4214,7 @@ const FbaCloningResolver = struct {
     state: *session.ServerRecoverableState,
     allocator: std.mem.Allocator,
     identity: []const u8,
+    calls: usize = 0,
 
     fn now(_: *anyopaque) i64 {
         return 0;
@@ -4213,6 +4222,7 @@ const FbaCloningResolver = struct {
     fn resolve(ctx: *anyopaque, identity: []const u8, out: *session.ServerRecoverableState) pre_shared_key.ResolveError!bool {
         const self: *@This() = @ptrCast(@alignCast(ctx));
         if (!std.mem.eql(u8, identity, self.identity)) return false;
+        self.calls += 1;
         // Deliberately clones through a *different* allocator than the one
         // backing `self.state` itself, so the only writes ever made into
         // `allocator`'s backing storage are the transient per-attempt
@@ -4224,15 +4234,23 @@ const FbaCloningResolver = struct {
 };
 
 test "a bad binder wipes the resolver's cloned candidate, including its compat blob" {
-    // See the zeroization test above for why `FixedBufferAllocator` (whose
-    // `free` never poisons memory, unlike the generic `Allocator.free`
-    // front-end which always does) is the only way to observe this
-    // reliably: it isolates the candidate clone's allocations to a backing
-    // array we can scan directly, independent of whatever exact byte
-    // pattern `free()` itself leaves behind.
+    // Zig's generic `Allocator.free()` front-end unconditionally
+    // `@memset`s freed memory to `undefined`, for *any* backing allocator
+    // (including `FixedBufferAllocator`) — so scanning `backing` for the
+    // absence of a marker byte string proves nothing: that scan would
+    // "pass" even if the candidate's `deinit()` were never called, because
+    // any full alloc/free round-trip on this allocator poisons the same
+    // bytes regardless. What genuinely distinguishes "freed" from "leaked"
+    // here is `FixedBufferAllocator`'s own *bookkeeping* (`end_index`),
+    // which the `Allocator.free()` wrapper does not touch and which only
+    // advances/retreats through real (de)allocations of the clone's
+    // backing storage: a full round-trip back to the starting offset can
+    // only happen if every byte this resolver allocated for the failed
+    // candidate was also freed.
     var backing = [_]u8{0xa5} ** 4096;
     var fba = std.heap.FixedBufferAllocator.init(&backing);
     const clone_allocator = fba.allocator();
+    const end_index_before_selection = fba.end_index;
 
     var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
     defer server.deinit();
@@ -4273,10 +4291,16 @@ test "a bad binder wipes the resolver's cloned candidate, including its compat b
 
     try std.testing.expect(!server.core.psk_authenticated);
     try std.testing.expect(!server.selected_server_psk_present);
-    // The clone's compat blob was the only thing ever written into
-    // `backing`; a lingering copy here would mean the failed candidate's
-    // `deinit()` was skipped somewhere on the bad-binder path.
-    try std.testing.expect(std.mem.indexOf(u8, &backing, marker) == null);
+    // The resolver really was invoked (and so really did clone a compat
+    // blob into `clone_allocator`, proving this exercised the allocator)...
+    try std.testing.expectEqual(@as(usize, 1), resolver_state.calls);
+    // ...and by the time selection has failed, every byte it allocated for
+    // that candidate has been released back to the allocator: `end_index`
+    // returned exactly to its starting point. This can only happen if the
+    // candidate's `deinit()` (which frees the cloned compat blob) actually
+    // ran on the bad-binder path — a leaked candidate would leave
+    // `end_index` permanently advanced.
+    try std.testing.expectEqual(end_index_before_selection, fba.end_index);
 }
 
 /// A hand-written `CredentialProvider` whose second chain entry is

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -3191,14 +3191,23 @@ test "async credential selection failure zeroes the captured ClientHello bytes, 
     const capture = &server.client_hello_psk.?;
     const message_memory = capture.message[0..capture.message_len];
     try std.testing.expect(!std.mem.allEqual(u8, message_memory, 0));
+    const original_message = try std.testing.allocator.dupe(u8, message_memory);
+    defer std.testing.allocator.free(original_message);
 
     try std.testing.expectError(error.CredentialProviderFailed, server.resumeAuth(&sink));
     try std.testing.expect(server.client_hello_psk == null);
     // Regression coverage: it is not enough to null the optional — the
     // framed ClientHello bytes it pointed at must themselves be
     // overwritten, or a scratch copy of the peer-supplied identity would
-    // linger in backend storage past this failed connection.
-    try std.testing.expect(std.mem.allEqual(u8, message_memory, 0));
+    // linger in backend storage past this failed connection. Checked
+    // against the original content rather than exact zero: once an
+    // optional transitions to `null`, Zig's own debug-safety
+    // instrumentation is free to poison the now-inactive payload with
+    // something other than zero (observed to differ between the x86_64
+    // and aarch64 backends in this Zig version), so an exact-zero
+    // assertion here would depend on that instrumentation rather than on
+    // this code's own `secureZero` call.
+    try std.testing.expect(!std.mem.eql(u8, message_memory, original_message));
 }
 
 test "a transport-extension type colliding with a TLS-owned PSK extension is rejected at start" {
@@ -3689,10 +3698,22 @@ test "backend teardown observably zeroes the key schedule and selected PSK sessi
     const selected_psk_memory = server.selected_server_psk.state.common.resumption_psk.bytes[0..server.selected_server_psk.state.common.resumption_psk.len];
     try std.testing.expect(!std.mem.allEqual(u8, schedule_memory, 0));
     try std.testing.expect(!std.mem.allEqual(u8, selected_psk_memory, 0));
+    const original_schedule = try std.testing.allocator.dupe(u8, schedule_memory);
+    defer std.testing.allocator.free(original_schedule);
 
     server.deinit();
 
-    try std.testing.expect(std.mem.allEqual(u8, schedule_memory, 0));
+    // `selected_server_psk.state` is a plain (non-optional) field — never
+    // routed through a `?T = null` transition — so it stays reliably
+    // exact-zero after `secureZero`. `schedule` (`?KeySchedule`) is
+    // checked against its original content rather than exact zero: once
+    // it transitions to `null`, Zig's debug-safety instrumentation is free
+    // to poison the now-inactive payload with something other than zero
+    // (observed to differ between the x86_64 and aarch64 backends in this
+    // Zig version), so an exact-zero assertion here would depend on that
+    // instrumentation rather than on `finish`'s/`deinit`'s own
+    // `secureZero` call.
+    try std.testing.expect(!std.mem.eql(u8, schedule_memory, original_schedule));
     try std.testing.expect(std.mem.allEqual(u8, selected_psk_memory, 0));
 }
 

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -562,7 +562,7 @@ test "PSK round trip: an offered, resolved, and verified ticket resumes the hand
     resumed.client_backend.setClientPskOffers(&offers, &clock_dummy, Clock.now);
 
     const Resolver = struct {
-        state: session.ServerRecoverableState,
+        state: *session.ServerRecoverableState,
         resolve_calls: usize = 0,
 
         fn now(_: *anyopaque) i64 {
@@ -576,8 +576,11 @@ test "PSK round trip: an offered, resolved, and verified ticket resumes the hand
             return true;
         }
     };
-    var resolver_state: Resolver = .{ .state = server_state };
-    defer resolver_state.state.deinit();
+    // `state` is a pointer, not a copy: `server_state` (below, an
+    // allocator-backed value with e.g. a non-null `transport_compat`) must
+    // not be shallow-copied, or its owned storage would be deinitialized
+    // twice — once here, once by `server_state`'s own `defer` above.
+    var resolver_state: Resolver = .{ .state = &server_state };
     resumed.server_backend.setServerPskResolver(.{
         .ctx = &resolver_state,
         .nowUnixMsFn = Resolver.now,
@@ -601,6 +604,126 @@ test "PSK round trip: an offered, resolved, and verified ticket resumes the hand
     const request = try resumed.client_bridge.sealApplicationData("resumed request", &protected2);
     const opened_request = try resumed.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, request), &plaintext2);
     try std.testing.expectEqualStrings("resumed request", opened_request.inner.content);
+}
+
+test "PSK round trip resumes over the extension (QUIC-style) profile with asymmetric client/server transport payloads" {
+    // Regression coverage: `ticketEligibleToOffer` used to compare the
+    // ticket's stored *server* transport snapshot against this client's own
+    // *local* outbound extension — the wrong direction, which would
+    // silently filter out every ticket whenever the two peers' transport
+    // payloads differ. `DirectHarness.initExtension()` deliberately uses
+    // different client/server payloads, so this both proves the ticket is
+    // still offered at all and completes a genuine QUIC-carrier-shaped
+    // (extension-profile) resumption, not only the record harness.
+    var harness = DirectHarness.initExtension();
+    defer harness.deinit();
+
+    const TicketCapture = struct {
+        ticket: session.ClientTicketState = .{},
+        fn now(_: *anyopaque) i64 {
+            return 1000;
+        }
+        fn onTicket(ctx: *anyopaque, ticket: *const session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            ticket.cloneInto(std.testing.allocator, &self.ticket) catch unreachable;
+        }
+    };
+    var capture = TicketCapture{};
+    defer capture.ticket.deinit();
+    const limits = session.Limits.default;
+    try harness.client_backend.setSessionTicketConsumer(std.testing.allocator, limits, .{
+        .ctx = &capture,
+        .nowUnixMsFn = TicketCapture.now,
+        .onTicketFn = TicketCapture.onTicket,
+    });
+    try harness.run();
+    try std.testing.expect(harness.client_driver.isComplete());
+    try std.testing.expect(harness.server_driver.isComplete());
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    var server_state = try harness.server_backend.emitNewSessionTicket(std.testing.allocator, &sink, .{
+        .ticket_lifetime = 3600,
+        .ticket_age_add = 500,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = "extension-profile-ticket",
+        .issued_at_unix_ms = 1000,
+    }, limits);
+    defer server_state.deinit();
+
+    const ticket_event = sink.items[0].handshake_bytes;
+    var protected: [record_codec.max_ciphertext_record_len * 2]u8 = undefined;
+    const records = (try harness.server_bridge.applyEvent(.{ .handshake_bytes = .{
+        .epoch = ticket_event.epoch,
+        .data = ticket_event.data,
+    } }, &protected)).?;
+    var parser = record_codec.Parser.init(.ciphertext);
+    var record_sink = record_codec.RecordSink(8, record_codec.max_ciphertext_fragment_len * 8){};
+    try parser.feed(records, &record_sink);
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    for (record_sink.items[0..record_sink.len]) |record| {
+        const opened = try harness.client_bridge.openHandshake(.application, record, &plaintext);
+        _ = try harness.client_driver.receive(.application, opened.inner.content);
+    }
+    try std.testing.expect(capture.ticket.ticket.slice().len > 0);
+    // The stored ticket carries the *server's* transport payload, not the
+    // client's — this is exactly the value the (fixed) client-side
+    // eligibility check must no longer compare against its own local one.
+    try std.testing.expectEqualStrings("server transport parameters", capture.ticket.common.transport_compat.?.slice());
+
+    var resumed = DirectHarness.initExtension();
+    defer resumed.deinit();
+
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&capture.ticket);
+    var clock_dummy: u8 = 0;
+    const Clock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 2000;
+        }
+    };
+    resumed.client_backend.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+
+    const Resolver = struct {
+        state: *session.ServerRecoverableState,
+        resolve_calls: usize = 0,
+        fn now(_: *anyopaque) i64 {
+            return 2000;
+        }
+        fn resolve(ctx: *anyopaque, identity: []const u8, out: *session.ServerRecoverableState) pre_shared_key.ResolveError!bool {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.resolve_calls += 1;
+            if (!std.mem.eql(u8, identity, "extension-profile-ticket")) return false;
+            self.state.cloneInto(std.testing.allocator, out) catch return error.ResolverFailed;
+            return true;
+        }
+    };
+    // Pointer, not a copy — see the identical note in the record-profile
+    // round-trip test above: `server_state` owns allocator-backed storage
+    // (this ticket has a non-null `transport_compat`), and shallow-copying
+    // it here would double-free that storage.
+    var resolver_state: Resolver = .{ .state = &server_state };
+    resumed.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = Resolver.now,
+        .resolveFn = Resolver.resolve,
+    });
+
+    try resumed.run();
+
+    try std.testing.expect(resumed.client_driver.isComplete());
+    try std.testing.expect(resumed.server_driver.isComplete());
+    // The ticket was actually offered and resolved (not silently filtered
+    // out by the wrong-direction transport-compat comparison).
+    try std.testing.expectEqual(@as(usize, 1), resolver_state.resolve_calls);
+    try std.testing.expect(resumed.client_backend.core.psk_authenticated);
+    try std.testing.expect(resumed.server_backend.core.psk_authenticated);
+
+    var protected2: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext2: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    const request = try resumed.client_bridge.sealApplicationData("resumed over quic-style transport", &protected2);
+    const opened_request = try resumed.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, request), &plaintext2);
+    try std.testing.expectEqualStrings("resumed over quic-style transport", opened_request.inner.content);
 }
 
 test "PSK round trip falls back to a full handshake when the resolver has no match" {
@@ -2996,6 +3119,96 @@ test "a compatible candidate with a wrong binder is fatal and never probes a lat
     }));
 
     try std.testing.expectEqual(@as(usize, 1), resolver_state.calls);
+}
+
+/// A hand-written `CredentialProvider` whose second chain entry is
+/// malformed (empty, or larger than `max_certificate_len`) — for proving
+/// `inspectSelectedServerCredential` validates every entry, not only the
+/// leaf, before PSK selection ever runs.
+const MalformedTailProvider = struct {
+    entries: [2][]const u8,
+    release_count: usize = 0,
+
+    fn provider(self: *MalformedTailProvider) credentials.CredentialProvider {
+        return .{ .ctx = self, .vtable = &vtable };
+    }
+
+    const vtable = credentials.CredentialProvider.VTable{ .select = select };
+
+    fn select(ctx: *anyopaque, selection: *const credentials.SelectionContext) credentials.SelectError!credentials.Progress(credentials.SelectedCredential) {
+        _ = selection;
+        return .{ .complete = .{ .handle = ctx, .scheme = .ed25519, .vtable = &cred_vtable } };
+    }
+
+    const cred_vtable = credentials.SelectedCredential.VTable{ .chain = chainFn, .sign = signFn, .release = releaseFn };
+
+    fn chainFn(handle: *anyopaque) credentials.CertificateChain {
+        const self: *MalformedTailProvider = @ptrCast(@alignCast(handle));
+        return .{ .entries = &self.entries };
+    }
+    fn signFn(handle: *anyopaque, scheme: credentials.SignatureScheme, input: []const u8, out: []u8) credentials.SignError!credentials.Progress(usize) {
+        _ = handle;
+        _ = scheme;
+        _ = input;
+        _ = out;
+        // Never reached: chain validation must fail before any signing is
+        // attempted, on both the PSK and full-handshake paths.
+        return error.SigningProviderFailure;
+    }
+    fn releaseFn(handle: *anyopaque) void {
+        const self: *MalformedTailProvider = @ptrCast(@alignCast(handle));
+        self.release_count += 1;
+    }
+};
+
+test "a malformed non-leaf chain entry is rejected before PSK resolver/binder work, even though the leaf is valid" {
+    var mock = MalformedTailProvider{ .entries = .{ tls_backend.testdata.certificate_der, "" } }; // entry 1: empty
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    defer server.deinit();
+
+    const psk = [_]u8{0x99} ** tls_backend.hash_len;
+    var stored_state = pskStoredState(&psk);
+    defer stored_state.deinit();
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "leaf-ok-tail-bad" };
+    server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+
+    try std.testing.expectError(error.CredentialProviderFailed, driveServerSelection(&server, .{
+        .psk = .{ .items = &.{.{ .identity = "leaf-ok-tail-bad", .binder_psk = &psk }} },
+    }));
+
+    try std.testing.expectEqual(tls_backend.CredentialFailure.malformed_credential_chain, server.credentialFailure().?);
+    // The resolver/binder path was never reached at all.
+    try std.testing.expectEqual(@as(usize, 0), resolver_state.calls);
+    try std.testing.expectEqual(@as(usize, 1), mock.release_count);
+}
+
+test "an oversized non-leaf chain entry is rejected before PSK resolver/binder work" {
+    const oversized = [_]u8{0} ** (tls_backend.max_certificate_len + 1);
+    var mock = MalformedTailProvider{ .entries = .{ tls_backend.testdata.certificate_der, &oversized } };
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    defer server.deinit();
+
+    const psk = [_]u8{0xaa} ** tls_backend.hash_len;
+    var stored_state = pskStoredState(&psk);
+    defer stored_state.deinit();
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "leaf-ok-tail-oversized" };
+    server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+
+    try std.testing.expectError(error.CredentialProviderFailed, driveServerSelection(&server, .{
+        .psk = .{ .items = &.{.{ .identity = "leaf-ok-tail-oversized", .binder_psk = &psk }} },
+    }));
+
+    try std.testing.expectEqual(tls_backend.CredentialFailure.malformed_credential_chain, server.credentialFailure().?);
+    try std.testing.expectEqual(@as(usize, 0), resolver_state.calls);
+    try std.testing.expectEqual(@as(usize, 1), mock.release_count);
 }
 
 test "a ticket bound to a different server certificate falls back to a full handshake" {


### PR DESCRIPTION
## Summary

Implements RFC 8446 §4.2.11 resumption-PSK negotiation on top of the existing session/`NewSessionTicket` model (#360, #361, PR #475/#477).

- **New `src/tls/pre_shared_key.zig`** — the shared module the issue centers on: `psk_key_exchange_modes`/`pre_shared_key` wire encode/decode (with full structural preflight — vector/length bounds validated before the writer is ever touched), `OfferedPsks` with borrowed paired iteration, the exact ClientHello binder-vector offset calculation, resumption binder derivation/constant-time verification for SHA-256 *and* SHA-384, obfuscated-ticket-age and age-skew helpers, an owned move-oriented `ClientPskOfferSet` (bounded to 8), and the provider-neutral `ServerPskResolver` contract shared by future stateful (#364) and stateless (#363) resolvers. It imports only `messages.zig`/`session.zig`, no cache/keyring/HTTP/QUIC/record-layer/policy types.
- **`session.zig`** — adds the `ticket_age_add: u32` prerequisite field to `ServerRecoverableState` (requested in the issue as a #361 amendment) and threads it through the codec.
- **`key_schedule.zig`** — `KeySchedule.initWithPsk`, a real-PSK early-secret initializer alongside the existing zero-PSK `init`.
- **`handshake.zig`** — `Core.psk_authenticated` / `enterPskAuthenticated()`: the resumed flight skips Certificate/CertificateVerify on both sides.
- **`tls13_backend.zig`** — wires client and server end to end, including the async credential-selection suspend/resume path:
  - the client plans (and compacts `client_psk_offers` to) exactly the eligible, size-fitting, wire-ordered offer subset *before* `core.start()` mutates any lifecycle/key-pair state, then offers those tickets as the last ClientHello extension with real binders (RFC 8446 §4.2.11.2 truncation/patch ordering);
  - the server resolves each offered identity (bounded to 8 attempts), evaluates #360 compatibility against the identity it's actually authenticating with (`inspectSelectedServerCredential` — every chain entry, not just the leaf), verifies only the first compatible candidate's binder (fatal `DecryptError`, never probes a later identity), and on success completes ServerHello → EncryptedExtensions → Finished with the PSK-derived key schedule and no certificate flight;
  - the client retains the selected ticket until EncryptedExtensions confirms it against the negotiated ALPN/transport/application context, then carries its certificate binding forward for any ticket issued on the resumed connection;
  - async server credential selection (the `pending_op`/`resumeAuth` suspend path) resumes through the identical PSK-selection code the synchronous path uses, since the captured ClientHello is backend-owned state rather than tied to the transient reassembly buffer;
  - every owned PSK/ticket/binder/schedule copy is wiped via `defer`/`errdefer` on every path — success, fallback, resolver failure, binder failure, malformed later ClientHello/ServerHello fields, and async cancellation/failure.

### Explicitly out of scope for this PR
- Ticket encryption at rest (#363) and session-cache storage (#364) — non-goals of #362 itself; this PR only defines the `ServerPskResolver` contract they'll adapt to.
- 0-RTT, HelloRetryRequest, external PSKs — all explicit non-goals per the issue.

## Test plan
- [x] `zig build test` — full workspace, 1851/1852 tests pass (1 pre-existing unrelated skip)
- [x] End-to-end PSK round trips in `tls13_backend_tests.zig`: a real ticket issued → offered → resolved → binder-verified → resumed handshake with application data exchanged under the PSK-derived keys, over both the record profile and an extension/QUIC-style profile with *asymmetric* client/server transport payloads; a resolver miss and a certificate-rotation mismatch each falling back to a full handshake; handshake-time client authentication forcing full-handshake fallback even when a PSK is offered
- [x] Server-selection-algorithm coverage: unknown-then-valid identity, a compatible candidate with a wrong binder (fatal, never probes a later identity), a malformed non-leaf credential chain entry (empty and oversized) rejected before the resolver/binder ever runs, `psk_key_exchange_modes` omitted (`MissingExtension`), an ineligible earlier offer not desyncing a later valid one's wire index
- [x] Async credential-selection parity: PSK selection resumes identically to the synchronous path; an async selection failure clears the captured offer
- [x] `pre_shared_key.zig` unit tests: wire round-trips, malformed/truncated vectors, writer structural preflight (empty/over-bound/oversized), binder cross-check, SHA-384, ticket-age wraparound and age-skew, offer-set move semantics and the 8/9 bound
- [x] `zig fmt --check` clean

Closes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)
