### PR TITLE
tls: drive native negotiation from policy registry

### DIFF
--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -2841,10 +2841,10 @@ const GatewayPendingNative = struct {
             .native = native,
         };
         self.client_provider = tls_core.production_crypto.Provider.init(self.client_entropy_source.entropy());
-        self.client_backend = tls_core.tls13_backend.Tls13Backend.initClientWithOptions(
+        self.client_backend = tls_core.tls13_backend.Tls13Backend.initClientConfigured(
             .{ .hello_random = [_]u8{0xc1} ** 32, .key_share_seed = [_]u8{0x11} ** 32 },
             .{ .pinned_certificate = tls_core.tls13_backend.testdata.certificate_der },
-            .{ .record = .{ .alpn = tls_core.tls13_backend.recordAlpnPolicy("h2") } },
+            tls_core.tls13_backend.recordConfig(tls_core.policy.Policy.recordH2Only()),
             .{ .server_name = "tardigrade.test" },
         );
         self.client_carrier = .{ .fd = fds[1] };

--- a/src/http/native_tls_connection.zig
+++ b/src/http/native_tls_connection.zig
@@ -179,10 +179,13 @@ pub const NativeTlsConnection = struct {
             backend.deinit();
             allocator.destroy(backend);
         };
-        backend.* = tls_backend.Tls13Backend.initServerWithProvider(
+        backend.* = tls_backend.Tls13Backend.initServerWithProviderConfigured(
             handshake_entropy,
             provider,
-            .{ .record = .{ .alpn = policy.nativeAlpnPolicy() } },
+            .{
+                .policy = policy.nativeTlsPolicy(),
+                .transport = .record,
+            },
         );
 
         const record = try allocator.create(encrypted_stream.PureZigRecordStream);
@@ -354,34 +357,33 @@ fn setNonBlocking(fd: std.posix.fd_t) !void {
     }
 }
 
-test "native ALPN policy follows listener preference and fallback" {
+test "native TLS policy follows listener preference and fallback" {
     const dual = (ListenerProtocolPolicy{
         .http1_enabled = true,
         .http2_enabled = true,
         .allow_http1_without_alpn = true,
-    }).nativeAlpnPolicy();
-    try std.testing.expectEqual(@as(usize, 2), dual.protocols.len);
-    try std.testing.expectEqualStrings("h2", dual.protocols[0]);
-    try std.testing.expectEqualStrings("http/1.1", dual.protocols[1]);
-    try std.testing.expect(dual.allow_absent);
+    }).nativeTlsPolicy();
+    try std.testing.expectEqual(@as(usize, 2), dual.alpn_protocols.len);
+    try std.testing.expect(dual.alpn_protocols[0].eql(tls.algorithms.alpn.h2));
+    try std.testing.expect(dual.alpn_protocols[1].eql(tls.algorithms.alpn.http_1_1));
+    try std.testing.expect(dual.allow_absent_alpn);
 
     const h2_only = (ListenerProtocolPolicy{
         .http1_enabled = false,
         .http2_enabled = true,
         .allow_http1_without_alpn = true,
-    }).nativeAlpnPolicy();
-    try std.testing.expectEqual(@as(usize, 1), h2_only.protocols.len);
-    try std.testing.expectEqualStrings("h2", h2_only.protocols[0]);
-    try std.testing.expect(!h2_only.allow_absent);
+    }).nativeTlsPolicy();
+    try std.testing.expectEqual(@as(usize, 1), h2_only.alpn_protocols.len);
+    try std.testing.expect(h2_only.alpn_protocols[0].eql(tls.algorithms.alpn.h2));
+    try std.testing.expect(!h2_only.allow_absent_alpn);
 
     const disabled = (ListenerProtocolPolicy{
         .http1_enabled = false,
         .http2_enabled = false,
         .allow_http1_without_alpn = true,
-    }).nativeAlpnPolicy();
-    try std.testing.expectEqual(@as(usize, 0), disabled.protocols.len);
-    try std.testing.expect(!disabled.allow_absent);
-    try std.testing.expectError(error.InvalidTransportProfile, disabled.validate());
+    }).nativeTlsPolicy();
+    try std.testing.expectEqual(@as(usize, 0), disabled.alpn_protocols.len);
+    try std.testing.expect(!disabled.allow_absent_alpn);
 }
 
 test "native readiness maps directly to event-loop interest" {

--- a/src/http/negotiated_dispatch.zig
+++ b/src/http/negotiated_dispatch.zig
@@ -57,23 +57,21 @@ pub const ListenerProtocolPolicy = struct {
         return "";
     }
 
-    pub fn nativeAlpnPolicy(self: ListenerProtocolPolicy) tls.tls13_backend.AlpnPolicy {
+    pub fn nativeTlsPolicy(self: ListenerProtocolPolicy) tls.policy.Policy {
         if (self.http2_enabled and self.http1_enabled) {
-            return .{
-                .protocols = &.{ "h2", "http/1.1" },
-                .allow_absent = self.allow_http1_without_alpn,
-            };
+            var policy = tls.policy.Policy.recordDefault();
+            policy.allow_absent_alpn = self.allow_http1_without_alpn;
+            return policy;
         }
         if (self.http2_enabled) {
-            return .{ .protocols = &.{"h2"} };
+            return tls.policy.Policy.recordH2Only();
         }
         if (!self.http1_enabled) {
-            return .{ .protocols = &.{}, .allow_absent = false };
+            var policy = tls.policy.Policy.recordDefault();
+            policy.alpn_protocols = &.{};
+            return policy;
         }
-        return .{
-            .protocols = &.{"http/1.1"},
-            .allow_absent = self.allow_http1_without_alpn,
-        };
+        return tls.policy.Policy.recordHttp1Only(self.allow_http1_without_alpn);
     }
 };
 

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -29,7 +29,7 @@ pub const max_message_len = shared.max_message_len;
 pub const max_certificate_len = shared.max_certificate_len;
 pub const testdata = shared.testdata;
 
-const ext_quic_transport_parameters: u16 = 57;
+const ext_quic_transport_parameters: u16 = @intFromEnum(tls_core.algorithms.ExtensionType.quic_transport_parameters);
 const tp_max_idle_timeout: u64 = 0x01;
 const tp_max_udp_payload_size: u64 = 0x03;
 const tp_initial_max_data: u64 = 0x04;
@@ -206,11 +206,13 @@ pub const Tls13Backend = struct {
     }
 
     pub fn initClientWithOptions(entropy: Entropy, trust: Trust, options: ClientOptions) Tls13Backend {
-        return .{ .engine = shared.Tls13Backend.initClientWithOptions(entropy, trust, .{ .extension = .{
-            .alpn = "h3",
-            .extension_type = ext_quic_transport_parameters,
-            .local = "",
-        } }, options) };
+        return .{ .engine = shared.Tls13Backend.initClientConfigured(entropy, trust, .{
+            .policy = tls_core.policy.Policy.quicDefault(),
+            .transport = .{ .extension = .{
+                .extension_type = ext_quic_transport_parameters,
+                .local = "",
+            } },
+        }, options) };
     }
 
     pub fn initClientWithAllocator(allocator: std.mem.Allocator, entropy: Entropy, trust: Trust) HandshakeError!Tls13Backend {
@@ -225,11 +227,13 @@ pub const Tls13Backend = struct {
     }
 
     pub fn initServer(entropy: Entropy, identity: Identity) Tls13Backend {
-        return .{ .engine = shared.Tls13Backend.initServer(entropy, identity, .{ .extension = .{
-            .alpn = "h3",
-            .extension_type = ext_quic_transport_parameters,
-            .local = "",
-        } }) };
+        return .{ .engine = shared.Tls13Backend.initServerConfigured(entropy, identity, .{
+            .policy = tls_core.policy.Policy.quicDefault(),
+            .transport = .{ .extension = .{
+                .extension_type = ext_quic_transport_parameters,
+                .local = "",
+            } },
+        }) };
     }
 
     pub fn initServerWithAllocator(allocator: std.mem.Allocator, entropy: Entropy, identity: Identity) Tls13Backend {
@@ -239,11 +243,13 @@ pub const Tls13Backend = struct {
     }
 
     pub fn initServerWithProvider(entropy: Entropy, provider: CredentialProvider) Tls13Backend {
-        return .{ .engine = shared.Tls13Backend.initServerWithProvider(entropy, provider, .{ .extension = .{
-            .alpn = "h3",
-            .extension_type = ext_quic_transport_parameters,
-            .local = "",
-        } }) };
+        return .{ .engine = shared.Tls13Backend.initServerWithProviderConfigured(entropy, provider, .{
+            .policy = tls_core.policy.Policy.quicDefault(),
+            .transport = .{ .extension = .{
+                .extension_type = ext_quic_transport_parameters,
+                .local = "",
+            } },
+        }) };
     }
 
     pub fn initServerWithAllocatorAndProvider(allocator: std.mem.Allocator, entropy: Entropy, provider: CredentialProvider) Tls13Backend {
@@ -336,7 +342,6 @@ pub const Tls13Backend = struct {
         const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
         const encoded = try encodeTransportParametersBound(params, self.cid_binding, &self.local_transport_parameters);
         self.engine.profile = .{ .extension = .{
-            .alpn = self.alpn,
             .extension_type = ext_quic_transport_parameters,
             .local = encoded,
         } };
@@ -748,9 +753,9 @@ test "QUIC handshake uses the shared reloadable SNI provider" {
 test "QUIC handshake owner tears down shared and adapter storage on failure" {
     var harness = try RealHandshakeHarness.init();
     defer harness.deinit();
-    harness.server_backend.alpn = "h2";
+    harness.client_backend.engine.trust = .{ .pinned_certificate = "not the server certificate" };
     try harness.wire();
-    try std.testing.expectError(error.AlpnMismatch, harness.run());
+    try std.testing.expectError(error.CertificateInvalid, harness.run());
     harness.deinit();
     try expectQuicBackendWiped(&harness.client_backend);
     try expectQuicBackendWiped(&harness.server_backend);

--- a/src/tls/credentials.zig
+++ b/src/tls/credentials.zig
@@ -876,6 +876,9 @@ pub const MockCredentialProvider = struct {
     last_server_name_buf: [256]u8 = undefined,
     last_server_name_len: usize = 0,
     last_server_name_present: bool = false,
+    last_application_protocol_buf: [255]u8 = undefined,
+    last_application_protocol_len: usize = 0,
+    last_application_protocol_present: bool = false,
     last_offered_scheme_count: usize = 0,
     last_role: ?Role = null,
 
@@ -891,6 +894,10 @@ pub const MockCredentialProvider = struct {
     /// mock's lifetime), or null when the last selection carried no SNI.
     pub fn lastServerName(self: *const MockCredentialProvider) ?[]const u8 {
         return if (self.last_server_name_present) self.last_server_name_buf[0..self.last_server_name_len] else null;
+    }
+
+    pub fn lastApplicationProtocol(self: *const MockCredentialProvider) ?[]const u8 {
+        return if (self.last_application_protocol_present) self.last_application_protocol_buf[0..self.last_application_protocol_len] else null;
     }
 
     pub fn selectedCredential(self: *MockCredentialProvider) SelectedCredential {
@@ -915,6 +922,15 @@ pub const MockCredentialProvider = struct {
         } else {
             self.last_server_name_present = false;
             self.last_server_name_len = 0;
+        }
+        if (selection.application_protocol) |protocol| {
+            const n = @min(protocol.len, self.last_application_protocol_buf.len);
+            @memcpy(self.last_application_protocol_buf[0..n], protocol[0..n]);
+            self.last_application_protocol_len = n;
+            self.last_application_protocol_present = true;
+        } else {
+            self.last_application_protocol_present = false;
+            self.last_application_protocol_len = 0;
         }
         self.last_offered_scheme_count = selection.peer_signature_schemes.len;
         if (self.force_select_error) |err| return err;
@@ -1028,6 +1044,9 @@ pub const MockVerifier = struct {
     last_server_name_buf: [256]u8 = undefined,
     last_server_name_len: usize = 0,
     last_server_name_present: bool = false,
+    last_application_protocol_buf: [255]u8 = undefined,
+    last_application_protocol_len: usize = 0,
+    last_application_protocol_present: bool = false,
     /// Async modelling: return `pending`, resolving to `result` after
     /// `pending_polls` polls.
     async_mode: bool = false,
@@ -1049,6 +1068,10 @@ pub const MockVerifier = struct {
         return if (self.last_server_name_present) self.last_server_name_buf[0..self.last_server_name_len] else null;
     }
 
+    pub fn lastApplicationProtocol(self: *const MockVerifier) ?[]const u8 {
+        return if (self.last_application_protocol_present) self.last_application_protocol_buf[0..self.last_application_protocol_len] else null;
+    }
+
     const vtable = PeerVerifier.VTable{ .verify = verify };
 
     fn verify(ctx: *anyopaque, context: *const VerificationContext) VerifyError!Progress(Verdict) {
@@ -1065,6 +1088,15 @@ pub const MockVerifier = struct {
         } else {
             self.last_server_name_present = false;
             self.last_server_name_len = 0;
+        }
+        if (context.application_protocol) |protocol| {
+            const n = @min(protocol.len, self.last_application_protocol_buf.len);
+            @memcpy(self.last_application_protocol_buf[0..n], protocol[0..n]);
+            self.last_application_protocol_len = n;
+            self.last_application_protocol_present = true;
+        } else {
+            self.last_application_protocol_present = false;
+            self.last_application_protocol_len = 0;
         }
         if (self.async_mode) {
             self.remaining_polls = self.pending_polls;

--- a/src/tls/negotiation.zig
+++ b/src/tls/negotiation.zig
@@ -9,6 +9,8 @@ const policy_mod = @import("policy.zig");
 pub const Error = messages.Error || error{
     MalformedExtension,
     MissingSupportedVersions,
+    MissingExtension,
+    IllegalParameter,
     UnsupportedProtocolVersion,
     MissingCipherSuites,
     NoMutualCipherSuite,
@@ -38,6 +40,8 @@ pub const ClientHelloOffers = struct {
     key_shares_len: usize = 0,
     signature_schemes: [max_offers]algorithms.SignatureScheme = undefined,
     signature_schemes_len: usize = 0,
+    raw_signature_schemes: [max_offers]u16 = undefined,
+    raw_signature_schemes_len: usize = 0,
     alpn_protocols: [max_offers]algorithms.ProtocolName = undefined,
     alpn_protocols_len: usize = 0,
     server_name: ?[]const u8 = null,
@@ -72,6 +76,12 @@ pub const ClientHelloOffers = struct {
         self.signature_schemes_len += 1;
     }
 
+    fn appendRawSignatureScheme(self: *ClientHelloOffers, value: u16) Error!void {
+        if (self.raw_signature_schemes_len == self.raw_signature_schemes.len) return error.OfferVectorTooLarge;
+        self.raw_signature_schemes[self.raw_signature_schemes_len] = value;
+        self.raw_signature_schemes_len += 1;
+    }
+
     fn appendAlpn(self: *ClientHelloOffers, value: algorithms.ProtocolName) Error!void {
         if (self.alpn_protocols_len == self.alpn_protocols.len) return error.OfferVectorTooLarge;
         self.alpn_protocols[self.alpn_protocols_len] = value;
@@ -100,12 +110,47 @@ pub const Selection = struct {
     server_name: ?[]const u8,
 };
 
+pub const ExtensionObservation = struct {
+    id: u16,
+    data: []const u8,
+    data_offset_in_body: usize,
+    is_last: bool,
+};
+
+pub const ExtensionObserver = struct {
+    ctx: *anyopaque,
+    observeFn: *const fn (*anyopaque, ExtensionObservation) Error!void,
+
+    fn observe(self: ExtensionObserver, observation: ExtensionObservation) Error!void {
+        return self.observeFn(self.ctx, observation);
+    }
+};
+
+pub const ParsedClientHello = struct {
+    offers: ClientHelloOffers,
+    legacy_session_id: []const u8,
+    offered_null_compression: bool,
+};
+
+pub const HelloSelection = struct {
+    version: algorithms.ProtocolVersion,
+    cipher_suite: algorithms.CipherSuite,
+    named_group: algorithms.NamedGroup,
+    key_share: []const u8,
+    alpn: ?algorithms.ProtocolName,
+    server_name: ?[]const u8,
+};
+
 pub fn parseClientHello(body: []const u8) Error!ClientHelloOffers {
+    return (try parseClientHelloObserved(body, null)).offers;
+}
+
+pub fn parseClientHelloObserved(body: []const u8, observer: ?ExtensionObserver) Error!ParsedClientHello {
     var offers = ClientHelloOffers{};
     var r = messages.Reader{ .bytes = body };
     if (try r.u16_() != algorithms.legacy_version) return error.MalformedHandshake;
     _ = try r.slice(32);
-    _ = try r.slice(try r.u8_());
+    const legacy_session_id = try r.slice(try r.u8_());
 
     var cipher_reader = messages.Reader{ .bytes = try r.slice(try r.u16_()) };
     if (cipher_reader.remaining() == 0 or cipher_reader.remaining() % 2 != 0) return error.MissingCipherSuites;
@@ -122,11 +167,24 @@ pub fn parseClientHello(body: []const u8) Error!ClientHelloOffers {
     }
     if (!has_null_compression) return error.MalformedHandshake;
 
-    var extensions = messages.ExtensionIterator.init(try r.slice(try r.u16_()));
+    const extensions_bytes = try r.slice(try r.u16_());
+    var extensions = messages.ExtensionIterator.init(extensions_bytes);
+    var saw_supported_versions = false;
     try r.expectEnd();
     while (try extensions.next()) |extension| {
+        if (observer) |obs| {
+            try obs.observe(.{
+                .id = extension.id,
+                .data = extension.data,
+                .data_offset_in_body = @intFromPtr(extension.data.ptr) - @intFromPtr(body.ptr),
+                .is_last = extensions.reader.remaining() == 0,
+            });
+        }
         switch (algorithms.fromInt(algorithms.ExtensionType, extension.id) orelse continue) {
-            .supported_versions => try parseSupportedVersions(extension.data, &offers),
+            .supported_versions => {
+                saw_supported_versions = true;
+                try parseSupportedVersions(extension.data, &offers);
+            },
             .supported_groups => try parseSupportedGroups(extension.data, &offers),
             .signature_algorithms => try parseSignatureAlgorithms(extension.data, &offers),
             .key_share => try parseKeyShares(extension.data, &offers),
@@ -135,28 +193,48 @@ pub fn parseClientHello(body: []const u8) Error!ClientHelloOffers {
             else => {},
         }
     }
-    if (offers.versions_len == 0) return error.MissingSupportedVersions;
-    return offers;
+    if (!saw_supported_versions) return error.MissingSupportedVersions;
+    if (offers.versions_len == 0) return error.UnsupportedProtocolVersion;
+    return .{
+        .offers = offers,
+        .legacy_session_id = legacy_session_id,
+        .offered_null_compression = has_null_compression,
+    };
 }
 
 pub fn negotiateServer(policy: policy_mod.Policy, offers: *const ClientHelloOffers) Error!Selection {
-    if (!offers.containsVersion(.tls13)) return error.UnsupportedProtocolVersion;
+    const hello = try negotiateServerHello(policy, offers);
+    const signature_scheme = pickEnum(algorithms.SignatureScheme, policy.signature_schemes, offers.signature_schemes[0..offers.signature_schemes_len]) orelse
+        return error.NoMutualSignatureScheme;
+    return .{
+        .version = hello.version,
+        .cipher_suite = hello.cipher_suite,
+        .named_group = hello.named_group,
+        .key_share = hello.key_share,
+        .signature_scheme = signature_scheme,
+        .alpn = hello.alpn orelse return error.NoMutualAlpn,
+        .server_name = hello.server_name,
+    };
+}
+
+pub fn negotiateServerHello(policy: policy_mod.Policy, offers: *const ClientHelloOffers) Error!HelloSelection {
+    const version = pickEnum(algorithms.ProtocolVersion, policy.protocol_versions, offers.versions[0..offers.versions_len]) orelse
+        return error.UnsupportedProtocolVersion;
     if (policy.require_sni and offers.server_name == null) return error.MissingServerName;
     const cipher_suite = pickEnum(algorithms.CipherSuite, policy.cipher_suites, offers.cipher_suites[0..offers.cipher_suites_len]) orelse
         return error.NoMutualCipherSuite;
     const named_group = pickEnum(algorithms.NamedGroup, policy.named_groups, offers.supported_groups[0..offers.supported_groups_len]) orelse
         return error.NoMutualNamedGroup;
     const key_share = offers.keyShareFor(named_group) orelse return error.MissingKeyShare;
-    const signature_scheme = pickEnum(algorithms.SignatureScheme, policy.signature_schemes, offers.signature_schemes[0..offers.signature_schemes_len]) orelse
-        return error.NoMutualSignatureScheme;
-    const alpn = pickAlpn(policy.alpn_protocols, offers.alpn_protocols[0..offers.alpn_protocols_len]) orelse
+    const alpn = pickAlpn(policy.alpn_protocols, offers.alpn_protocols[0..offers.alpn_protocols_len]) orelse blk: {
+        if (offers.alpn_protocols_len == 0 and policy.allow_absent_alpn) break :blk null;
         return error.NoMutualAlpn;
+    };
     return .{
-        .version = .tls13,
+        .version = version,
         .cipher_suite = cipher_suite,
         .named_group = named_group,
         .key_share = key_share,
-        .signature_scheme = signature_scheme,
         .alpn = alpn,
         .server_name = offers.server_name,
     };
@@ -166,14 +244,33 @@ pub const ServerSelection = struct {
     version: algorithms.ProtocolVersion,
     cipher_suite: algorithms.CipherSuite,
     named_group: algorithms.NamedGroup,
-    alpn: algorithms.ProtocolName,
+    alpn: ?algorithms.ProtocolName,
 };
 
-pub fn validateServerSelection(policy: policy_mod.Policy, selection: ServerSelection) Error!void {
-    if (selection.version != .tls13) return error.UnsupportedProtocolVersion;
+pub fn validateServerHelloTuple(policy: policy_mod.Policy, selection: ServerSelection) Error!void {
+    if (!containsEnum(algorithms.ProtocolVersion, policy.protocol_versions, selection.version)) return error.UnsupportedProtocolVersion;
     if (!containsEnum(algorithms.CipherSuite, policy.cipher_suites, selection.cipher_suite)) return error.NoMutualCipherSuite;
     if (!containsEnum(algorithms.NamedGroup, policy.named_groups, selection.named_group)) return error.NoMutualNamedGroup;
-    if (!containsAlpn(policy.alpn_protocols, selection.alpn)) return error.NoMutualAlpn;
+}
+
+pub fn validateServerSelection(policy: policy_mod.Policy, selection: ServerSelection) Error!void {
+    try validateServerHelloTuple(policy, selection);
+    if (selection.alpn) |alpn| {
+        if (!containsAlpn(policy.alpn_protocols, alpn)) return error.NoMutualAlpn;
+    } else if (!policy.allow_absent_alpn) return error.NoMutualAlpn;
+}
+
+pub fn validateCredentialSignature(
+    policy: policy_mod.Policy,
+    peer_raw_offers: []const u16,
+    selected: algorithms.SignatureScheme,
+) Error!void {
+    if (!containsEnum(algorithms.SignatureScheme, policy.signature_schemes, selected)) return error.NoMutualSignatureScheme;
+    const selected_raw = @intFromEnum(selected);
+    for (peer_raw_offers) |raw| {
+        if (raw == selected_raw) return;
+    }
+    return error.NoMutualSignatureScheme;
 }
 
 fn parseSupportedVersions(bytes: []const u8, offers: *ClientHelloOffers) Error!void {
@@ -206,7 +303,9 @@ fn parseSignatureAlgorithms(bytes: []const u8, offers: *ClientHelloOffers) Error
     try r.expectEnd();
     if (algorithms_reader.remaining() == 0 or algorithms_reader.remaining() % 2 != 0) return error.MalformedExtension;
     while (algorithms_reader.remaining() > 0) {
-        if (algorithms.fromInt(algorithms.SignatureScheme, try algorithms_reader.u16_())) |scheme| {
+        const raw = try algorithms_reader.u16_();
+        try offers.appendRawSignatureScheme(raw);
+        if (algorithms.fromInt(algorithms.SignatureScheme, raw)) |scheme| {
             try offers.appendSignatureScheme(scheme);
         }
     }
@@ -228,15 +327,15 @@ fn parseKeyShares(bytes: []const u8, offers: *ClientHelloOffers) Error!void {
 fn parseServerName(bytes: []const u8, offers: *ClientHelloOffers) Error!void {
     var r = messages.Reader{ .bytes = bytes };
     const list_len = try r.u16_();
-    if (list_len == 0) return error.MalformedExtension;
+    if (list_len == 0) return error.IllegalParameter;
     var names = messages.Reader{ .bytes = try r.slice(list_len) };
     try r.expectEnd();
     while (names.remaining() > 0) {
         const name_type = try names.u8_();
         const name = try names.slice(try names.u16_());
         if (name_type == 0) {
-            if (offers.server_name != null) return error.MalformedExtension;
-            dns_name.validateHostName(name) catch return error.MalformedExtension;
+            if (offers.server_name != null) return error.IllegalParameter;
+            dns_name.validateHostName(name) catch return error.IllegalParameter;
             offers.server_name = name;
         }
     }
@@ -246,6 +345,7 @@ fn parseAlpn(bytes: []const u8, offers: *ClientHelloOffers) Error!void {
     var r = messages.Reader{ .bytes = bytes };
     var protocols = messages.Reader{ .bytes = try r.slice(try r.u16_()) };
     try r.expectEnd();
+    if (protocols.remaining() == 0) return error.MalformedExtension;
     while (protocols.remaining() > 0) {
         const name = try protocols.slice(try protocols.u8_());
         if (name.len == 0) return error.MalformedExtension;
@@ -454,7 +554,7 @@ test "ClientHello parser rejects empty SNI ServerNameList" {
     var body: [192]u8 = undefined;
     const empty_server_name_list = [_]u8{ 0, 0 };
     const hello = try clientHelloWithServerNameExtension(&body, &empty_server_name_list);
-    try testing.expectError(error.MalformedExtension, parseClientHello(hello));
+    try testing.expectError(error.IllegalParameter, parseClientHello(hello));
 }
 
 test "ClientHello parser rejects duplicate SNI host_name entries" {
@@ -470,7 +570,7 @@ test "ClientHello parser rejects duplicate SNI host_name entries" {
 
     var body: [256]u8 = undefined;
     const hello = try clientHelloWithServerNameExtension(&body, sni.written());
-    try testing.expectError(error.MalformedExtension, parseClientHello(hello));
+    try testing.expectError(error.IllegalParameter, parseClientHello(hello));
 }
 
 test "recognized offer vectors allow general-purpose client sizes" {
@@ -481,6 +581,74 @@ test "recognized offer vectors allow general-purpose client sizes" {
     }
     try testing.expectEqual(@as(usize, max_offers), offers.signature_schemes_len);
     try testing.expectError(error.OfferVectorTooLarge, offers.appendSignatureScheme(.ed25519));
+}
+
+test "unknown signature schemes are preserved in raw offer order" {
+    var body: [192]u8 = undefined;
+    var w = messages.Writer{ .buf = &body };
+    try w.u16_(algorithms.legacy_version);
+    try w.bytes(&([_]u8{0} ** 32));
+    try w.u8_(0);
+    try w.u16_(2);
+    try w.u16_(@intFromEnum(algorithms.CipherSuite.tls_aes_128_gcm_sha256));
+    try w.u8_(1);
+    try w.u8_(0);
+    const extensions_len = try w.reserve(2);
+    try w.u16_(@intFromEnum(algorithms.ExtensionType.supported_versions));
+    try w.u16_(3);
+    try w.u8_(2);
+    try w.u16_(@intFromEnum(algorithms.ProtocolVersion.tls13));
+    try w.u16_(@intFromEnum(algorithms.ExtensionType.signature_algorithms));
+    try w.u16_(6);
+    try w.u16_(4);
+    try w.u16_(0xeeee);
+    try w.u16_(@intFromEnum(algorithms.SignatureScheme.ed25519));
+    w.patch(2, extensions_len);
+
+    const offers = try parseClientHello(w.written());
+    try testing.expectEqual(@as(usize, 2), offers.raw_signature_schemes_len);
+    try testing.expectEqual(@as(u16, 0xeeee), offers.raw_signature_schemes[0]);
+    try testing.expectEqual(@intFromEnum(algorithms.SignatureScheme.ed25519), offers.raw_signature_schemes[1]);
+    try testing.expectEqual(@as(usize, 1), offers.signature_schemes_len);
+    try testing.expectEqual(algorithms.SignatureScheme.ed25519, offers.signature_schemes[0]);
+}
+
+test "hello negotiation permits absent ALPN only when policy allows it" {
+    var offers = ClientHelloOffers{};
+    try offers.appendVersion(.tls13);
+    try offers.appendCipherSuite(.tls_aes_128_gcm_sha256);
+    try offers.appendSupportedGroup(.x25519);
+    try offers.appendKeyShare(.{ .group = .x25519, .key_exchange = "share" });
+
+    var policy = policy_mod.Policy.recordHttp1Only(true);
+    const selected = try negotiateServerHello(policy, &offers);
+    try testing.expect(selected.alpn == null);
+
+    policy.allow_absent_alpn = false;
+    try testing.expectError(error.NoMutualAlpn, negotiateServerHello(policy, &offers));
+}
+
+test "ClientHello parser rejects present ALPN extension with empty protocol list" {
+    var body: [128]u8 = undefined;
+    var w = messages.Writer{ .buf = &body };
+    try w.u16_(algorithms.legacy_version);
+    try w.bytes(&([_]u8{0} ** 32));
+    try w.u8_(0);
+    try w.u16_(2);
+    try w.u16_(@intFromEnum(algorithms.CipherSuite.tls_aes_128_gcm_sha256));
+    try w.u8_(1);
+    try w.u8_(0);
+    const extensions_len = try w.reserve(2);
+    try w.u16_(@intFromEnum(algorithms.ExtensionType.supported_versions));
+    try w.u16_(3);
+    try w.u8_(2);
+    try w.u16_(@intFromEnum(algorithms.ProtocolVersion.tls13));
+    try w.u16_(@intFromEnum(algorithms.ExtensionType.application_layer_protocol_negotiation));
+    try w.u16_(2);
+    try w.u16_(0);
+    w.patch(2, extensions_len);
+
+    try testing.expectError(error.MalformedExtension, parseClientHello(w.written()));
 }
 
 test "negotiation reports no-overlap failures without logging offer contents" {

--- a/src/tls/policy.zig
+++ b/src/tls/policy.zig
@@ -6,14 +6,18 @@ const algorithms = @import("algorithms.zig");
 pub const CipherSuite = algorithms.CipherSuite;
 pub const NamedGroup = algorithms.NamedGroup;
 pub const SignatureScheme = algorithms.SignatureScheme;
+pub const ProtocolVersion = algorithms.ProtocolVersion;
 pub const ProtocolName = algorithms.ProtocolName;
 
+const default_protocol_versions = [_]ProtocolVersion{.tls13};
 const default_cipher_suites = [_]CipherSuite{.tls_aes_128_gcm_sha256};
 const default_named_groups = [_]NamedGroup{.x25519};
-const default_signature_schemes = [_]SignatureScheme{ .ecdsa_secp256r1_sha256, .ed25519 };
+const default_signature_schemes = [_]SignatureScheme{ .ed25519, .ecdsa_secp256r1_sha256 };
 const ed25519_signature_schemes = [_]SignatureScheme{.ed25519};
 const ecdsa_p256_signature_schemes = [_]SignatureScheme{.ecdsa_secp256r1_sha256};
 const quic_alpns = [_]ProtocolName{algorithms.alpn.h3};
+const record_h2_alpns = [_]ProtocolName{algorithms.alpn.h2};
+const record_http1_alpns = [_]ProtocolName{algorithms.alpn.http_1_1};
 const record_alpns = [_]ProtocolName{ algorithms.alpn.h2, algorithms.alpn.http_1_1 };
 
 pub const Error = error{UnsupportedIdentitySignature};
@@ -24,6 +28,7 @@ pub const IdentityKey = enum {
 };
 
 pub const Capabilities = struct {
+    protocol_versions: []const ProtocolVersion = &default_protocol_versions,
     cipher_suites: []const CipherSuite = &default_cipher_suites,
     named_groups: []const NamedGroup = &default_named_groups,
     signature_schemes: []const SignatureScheme = &default_signature_schemes,
@@ -31,15 +36,18 @@ pub const Capabilities = struct {
 
 pub const Policy = struct {
     transport_mode: state.TransportMode,
+    protocol_versions: []const ProtocolVersion = &default_protocol_versions,
     cipher_suites: []const CipherSuite,
     named_groups: []const NamedGroup,
     signature_schemes: []const SignatureScheme,
     alpn_protocols: []const ProtocolName,
     require_sni: bool = false,
+    allow_absent_alpn: bool = false,
 
     pub fn quicDefault() Policy {
         return .{
             .transport_mode = .quic,
+            .protocol_versions = &default_protocol_versions,
             .cipher_suites = &default_cipher_suites,
             .named_groups = &default_named_groups,
             .signature_schemes = &default_signature_schemes,
@@ -50,6 +58,7 @@ pub const Policy = struct {
     pub fn recordDefault() Policy {
         return .{
             .transport_mode = .record,
+            .protocol_versions = &default_protocol_versions,
             .cipher_suites = &default_cipher_suites,
             .named_groups = &default_named_groups,
             .signature_schemes = &default_signature_schemes,
@@ -57,9 +66,33 @@ pub const Policy = struct {
         };
     }
 
+    pub fn recordH2Only() Policy {
+        return .{
+            .transport_mode = .record,
+            .protocol_versions = &default_protocol_versions,
+            .cipher_suites = &default_cipher_suites,
+            .named_groups = &default_named_groups,
+            .signature_schemes = &default_signature_schemes,
+            .alpn_protocols = &record_h2_alpns,
+        };
+    }
+
+    pub fn recordHttp1Only(allow_absent_alpn: bool) Policy {
+        return .{
+            .transport_mode = .record,
+            .protocol_versions = &default_protocol_versions,
+            .cipher_suites = &default_cipher_suites,
+            .named_groups = &default_named_groups,
+            .signature_schemes = &default_signature_schemes,
+            .alpn_protocols = &record_http1_alpns,
+            .allow_absent_alpn = allow_absent_alpn,
+        };
+    }
+
     pub fn fromCapabilities(transport_mode: state.TransportMode, capabilities: Capabilities, alpn_protocols: []const ProtocolName) Policy {
         return .{
             .transport_mode = transport_mode,
+            .protocol_versions = capabilities.protocol_versions,
             .cipher_suites = capabilities.cipher_suites,
             .named_groups = capabilities.named_groups,
             .signature_schemes = capabilities.signature_schemes,
@@ -74,11 +107,39 @@ pub const Policy = struct {
         }
         return .{
             .transport_mode = transport_mode,
+            .protocol_versions = capabilities.protocol_versions,
             .cipher_suites = capabilities.cipher_suites,
             .named_groups = capabilities.named_groups,
             .signature_schemes = identity_schemes,
             .alpn_protocols = alpn_protocols,
         };
+    }
+
+    pub fn containsProtocolVersion(self: Policy, version: ProtocolVersion) bool {
+        return containsEnum(ProtocolVersion, self.protocol_versions, version);
+    }
+
+    pub fn containsCipherSuite(self: Policy, cipher_suite: CipherSuite) bool {
+        return containsEnum(CipherSuite, self.cipher_suites, cipher_suite);
+    }
+
+    pub fn containsNamedGroup(self: Policy, group: NamedGroup) bool {
+        return containsEnum(NamedGroup, self.named_groups, group);
+    }
+
+    pub fn containsSignatureScheme(self: Policy, scheme: SignatureScheme) bool {
+        return containsEnum(SignatureScheme, self.signature_schemes, scheme);
+    }
+
+    pub fn containsAlpn(self: Policy, name: []const u8) bool {
+        for (self.alpn_protocols) |protocol| {
+            if (protocol.eql(.{ .bytes = name })) return true;
+        }
+        return false;
+    }
+
+    pub fn firstAlpn(self: Policy) []const u8 {
+        return if (self.alpn_protocols.len > 0) self.alpn_protocols[0].bytes else "";
     }
 };
 
@@ -90,10 +151,25 @@ pub fn signatureSchemesForIdentity(identity_key: IdentityKey) []const SignatureS
 }
 
 fn containsSignature(schemes: []const SignatureScheme, needle: SignatureScheme) bool {
-    for (schemes) |scheme| {
-        if (scheme == needle) return true;
+    return containsEnum(SignatureScheme, schemes, needle);
+}
+
+fn containsEnum(comptime T: type, values: []const T, needle: T) bool {
+    for (values) |value| {
+        if (value == needle) return true;
     }
     return false;
+}
+
+pub fn alpnFromBytes(bytes: []const u8) ProtocolName {
+    return .{ .bytes = bytes };
+}
+
+pub fn alpnListFromByteNames(out: []ProtocolName, names: []const []const u8) []const ProtocolName {
+    for (names, 0..) |name, i| {
+        out[i] = .{ .bytes = name };
+    }
+    return out[0..names.len];
 }
 
 test "default policies keep QUIC and record ALPN choices separate" {

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -21,6 +21,8 @@ const dns_name = @import("dns_name.zig");
 const events = @import("events.zig");
 const credentials = @import("credentials.zig");
 const tls_algorithms = @import("algorithms.zig");
+const tls_negotiation = @import("negotiation.zig");
+const tls_policy = @import("policy.zig");
 const crypto_pkg = @import("crypto");
 const tls_handshake_codec = @import("handshake.zig");
 const tls_key_schedule = @import("key_schedule.zig");
@@ -155,8 +157,8 @@ pub const max_signature_len = 256;
 ///     2-byte extensions-vector length = 6 bytes.
 ///   - The ALPN extension at its legal maximum: 2-byte extension type +
 ///     2-byte extension length + 2-byte protocol-list length + 1-byte
-///     protocol length + up to 255 protocol bytes (`AlpnPolicy.validate`'s
-///     own `name.len > std.math.maxInt(u8)` bound) = 262 bytes.
+///     protocol length + up to 255 protocol bytes (`Policy`'s ALPN validation
+///     bound) = 262 bytes.
 ///   - The opaque transport extension (QUIC/H3 profile only; record mode
 ///     carries none): 2-byte type + 2-byte length + `max_transport_extension_len`
 ///     payload = 516 bytes.
@@ -176,49 +178,47 @@ fn checkedAdd(a: usize, b: usize) HandshakeError!usize {
     return std.math.add(usize, a, b) catch return error.InvalidTransportProfile;
 }
 
-const tls13_version: u16 = 0x0304;
-const legacy_version: u16 = 0x0303;
-const cipher_tls_aes_128_gcm_sha256: u16 = 0x1301;
-const group_x25519: u16 = 0x001d;
-const sigalg_ed25519: u16 = 0x0807;
-const sigalg_ecdsa_secp256r1_sha256: u16 = 0x0403;
+const tls13_version: u16 = @intFromEnum(tls_algorithms.ProtocolVersion.tls13);
+const legacy_version: u16 = tls_algorithms.legacy_version;
+const cipher_tls_aes_128_gcm_sha256: u16 = @intFromEnum(tls_algorithms.CipherSuite.tls_aes_128_gcm_sha256);
+const group_x25519: u16 = @intFromEnum(tls_algorithms.NamedGroup.x25519);
+const sigalg_ed25519: u16 = @intFromEnum(tls_algorithms.SignatureScheme.ed25519);
+const sigalg_ecdsa_secp256r1_sha256: u16 = @intFromEnum(tls_algorithms.SignatureScheme.ecdsa_secp256r1_sha256);
 
-const ext_server_name: u16 = 0;
-const ext_supported_groups: u16 = 10;
-const ext_signature_algorithms: u16 = 13;
-const ext_alpn: u16 = 16;
-const ext_supported_versions: u16 = 43;
-const ext_key_share: u16 = 51;
+const ext_server_name: u16 = @intFromEnum(tls_algorithms.ExtensionType.server_name);
+const ext_supported_groups: u16 = @intFromEnum(tls_algorithms.ExtensionType.supported_groups);
+const ext_signature_algorithms: u16 = @intFromEnum(tls_algorithms.ExtensionType.signature_algorithms);
+const ext_alpn: u16 = @intFromEnum(tls_algorithms.ExtensionType.application_layer_protocol_negotiation);
+const ext_supported_versions: u16 = @intFromEnum(tls_algorithms.ExtensionType.supported_versions);
+const ext_key_share: u16 = @intFromEnum(tls_algorithms.ExtensionType.key_share);
 pub const max_transport_extension_len = 512;
 
-pub const AlpnPolicy = struct {
-    protocols: []const []const u8,
-    allow_absent: bool = false,
+const native_protocol_versions = [_]tls_algorithms.ProtocolVersion{.tls13};
+const native_cipher_suites = [_]tls_algorithms.CipherSuite{.tls_aes_128_gcm_sha256};
+const native_named_groups = [_]tls_algorithms.NamedGroup{.x25519};
+const native_signature_schemes = [_]tls_algorithms.SignatureScheme{ .ed25519, .ecdsa_secp256r1_sha256 };
 
-    pub fn validate(self: AlpnPolicy) HandshakeError!void {
-        if (self.protocols.len == 0 and !self.allow_absent) return error.InvalidTransportProfile;
-        var total: usize = 0;
-        for (self.protocols, 0..) |name, i| {
-            if (name.len == 0 or name.len > std.math.maxInt(u8)) return error.InvalidTransportProfile;
-            total = std.math.add(usize, total, 1 + name.len) catch return error.InvalidTransportProfile;
-            if (total > std.math.maxInt(u16)) return error.InvalidTransportProfile;
-            if (total + 6 > max_message_len) return error.InvalidTransportProfile;
-            for (self.protocols[0..i]) |prior| {
-                if (std.mem.eql(u8, prior, name)) return error.InvalidTransportProfile;
-            }
-        }
-    }
-
-    pub fn contains(self: AlpnPolicy, name: []const u8) bool {
-        for (self.protocols) |protocol| {
-            if (std.mem.eql(u8, protocol, name)) return true;
-        }
-        return false;
-    }
+pub const native_capabilities = tls_policy.Capabilities{
+    .protocol_versions = &native_protocol_versions,
+    .cipher_suites = &native_cipher_suites,
+    .named_groups = &native_named_groups,
+    .signature_schemes = &native_signature_schemes,
 };
 
-pub fn recordAlpnPolicy(comptime protocol: []const u8) AlpnPolicy {
-    return .{ .protocols = &.{protocol} };
+pub const BackendConfig = struct {
+    policy: tls_policy.Policy,
+    transport: TransportProfile,
+};
+
+pub fn recordConfig(policy: tls_policy.Policy) BackendConfig {
+    return .{ .policy = policy, .transport = .record };
+}
+
+fn defaultConfigForTransport(transport: TransportProfile) BackendConfig {
+    return switch (transport) {
+        .record => recordConfig(tls_policy.Policy.recordH2Only()),
+        .extension => .{ .policy = tls_policy.Policy.quicDefault(), .transport = transport },
+    };
 }
 
 /// Transport differences are explicit production configuration, never a
@@ -226,93 +226,15 @@ pub fn recordAlpnPolicy(comptime protocol: []const u8) AlpnPolicy {
 /// opaque; the owning transport adapter is responsible for its codec and
 /// policy. Record mode carries no transport-specific extension.
 pub const TransportProfile = union(enum) {
-    record: RecordOptions,
+    record,
     extension: ExtensionOptions,
 
-    pub const RecordOptions = struct {
-        alpn: AlpnPolicy,
-    };
-
     pub const ExtensionOptions = struct {
-        alpn: []const u8,
         extension_type: u16,
         /// Borrowed from the transport adapter. It must remain valid until the
         /// local ClientHello or EncryptedExtensions flight has been emitted.
         local: []const u8,
     };
-
-    fn firstConfiguredAlpn(self: TransportProfile) []const u8 {
-        return switch (self) {
-            .record => |options| if (options.alpn.protocols.len > 0) options.alpn.protocols[0] else "",
-            .extension => |options| options.alpn,
-        };
-    }
-
-    fn allowAbsentAlpn(self: TransportProfile) bool {
-        return switch (self) {
-            .record => |options| options.alpn.allow_absent,
-            .extension => false,
-        };
-    }
-
-    fn containsAlpn(self: TransportProfile, name: []const u8) bool {
-        return switch (self) {
-            .record => |options| options.alpn.contains(name),
-            .extension => |options| std.mem.eql(u8, options.alpn, name),
-        };
-    }
-
-    fn alpnPreference(self: TransportProfile, name: []const u8) ?usize {
-        return switch (self) {
-            .record => |options| blk: {
-                for (options.alpn.protocols, 0..) |protocol, index| {
-                    if (std.mem.eql(u8, protocol, name)) break :blk index;
-                }
-                break :blk null;
-            },
-            .extension => |options| if (std.mem.eql(u8, options.alpn, name)) 0 else null,
-        };
-    }
-
-    fn writeAlpnOffer(self: TransportProfile, w: *Writer) HandshakeError!void {
-        switch (self) {
-            .record => |options| {
-                if (options.alpn.protocols.len == 0) return;
-                try w.u16_(ext_alpn);
-                const alpn_ext_len = try w.reserve(2);
-                const alpn_list_len = try w.reserve(2);
-                for (options.alpn.protocols) |protocol| {
-                    try w.u8_(@intCast(protocol.len));
-                    try w.bytes(protocol);
-                }
-                w.patch(2, alpn_list_len);
-                w.patch(2, alpn_ext_len);
-            },
-            .extension => |options| {
-                try w.u16_(ext_alpn);
-                const alpn_ext_len = try w.reserve(2);
-                const alpn_list_len = try w.reserve(2);
-                try w.u8_(@intCast(options.alpn.len));
-                try w.bytes(options.alpn);
-                w.patch(2, alpn_list_len);
-                w.patch(2, alpn_ext_len);
-            },
-        }
-    }
-
-    fn alpnOfferEncodedLen(self: TransportProfile) HandshakeError!usize {
-        return switch (self) {
-            .record => |options| blk: {
-                if (options.alpn.protocols.len == 0) break :blk 0;
-                var list_len: usize = 0;
-                for (options.alpn.protocols) |protocol| {
-                    list_len = try checkedAdd(list_len, 1 + protocol.len);
-                }
-                break :blk try checkedAdd(6, list_len);
-            },
-            .extension => |options| try checkedAdd(7, options.alpn.len),
-        };
-    }
 
     fn extensionType(self: TransportProfile) ?u16 {
         return switch (self) {
@@ -329,14 +251,11 @@ pub const TransportProfile = union(enum) {
     }
 
     fn validate(self: TransportProfile) HandshakeError!void {
-        switch (self) {
-            .record => |options| try options.alpn.validate(),
-            .extension => |options| if (options.alpn.len == 0 or options.alpn.len > std.math.maxInt(u8)) return error.InvalidTransportProfile,
-        }
         if (self == .extension) {
             const options = self.extension;
             if (options.local.len > max_transport_extension_len) return error.InvalidTransportProfile;
             switch (options.extension_type) {
+                ext_server_name,
                 ext_supported_groups,
                 ext_signature_algorithms,
                 ext_alpn,
@@ -439,6 +358,7 @@ pub const Entropy = struct {
 pub const Tls13Backend = struct {
     role: Role,
     profile: TransportProfile,
+    policy: tls_policy.Policy,
     entropy: Entropy,
     identity: Identity = undefined,
     identity_present: bool = false,
@@ -484,6 +404,9 @@ pub const Tls13Backend = struct {
     selected_alpn: [255]u8 = undefined,
     selected_alpn_len: usize = 0,
     selected_alpn_present: bool = false,
+    negotiated_version: tls_algorithms.ProtocolVersion = .tls13,
+    negotiated_cipher_suite: tls_algorithms.CipherSuite = .tls_aes_128_gcm_sha256,
+    negotiated_named_group: tls_algorithms.NamedGroup = .x25519,
     peer_transport_extension: [max_transport_extension_len]u8 = undefined,
     peer_transport_extension_len: usize = 0,
     peer_transport_extension_pending: bool = false,
@@ -681,15 +604,14 @@ pub const Tls13Backend = struct {
     /// Allocation-free. The returned backend owns its copied entropy until
     /// `deinit`, which securely clears all private material.
     pub fn initClient(entropy: Entropy, trust: Trust, profile: TransportProfile) Tls13Backend {
-        return initClientWithOptions(entropy, trust, profile, .{});
+        return initClientConfigured(entropy, trust, defaultConfigForTransport(profile), .{});
     }
 
-    /// Client construction with the built-in fixed trust policy plus explicit
-    /// client options such as intended SNI.
-    pub fn initClientWithOptions(entropy: Entropy, trust: Trust, profile: TransportProfile, options: ClientOptions) Tls13Backend {
+    pub fn initClientConfigured(entropy: Entropy, trust: Trust, config: BackendConfig, options: ClientOptions) Tls13Backend {
         var self: Tls13Backend = .{
             .role = .client,
-            .profile = profile,
+            .profile = config.transport,
+            .policy = config.policy,
             .entropy = entropy,
             .trust = trust,
             .auth_policy = policyFromTrust(trust),
@@ -697,6 +619,12 @@ pub const Tls13Backend = struct {
         };
         self.applyClientOptions(options);
         return self;
+    }
+
+    /// Client construction with the built-in fixed trust policy plus explicit
+    /// client options such as intended SNI.
+    pub fn initClientWithOptions(entropy: Entropy, trust: Trust, profile: TransportProfile, options: ClientOptions) Tls13Backend {
+        return initClientConfigured(entropy, trust, defaultConfigForTransport(profile), options);
     }
 
     fn applyClientOptions(self: *Tls13Backend, options: ClientOptions) void {
@@ -718,9 +646,14 @@ pub const Tls13Backend = struct {
     /// is served to the engine through the production `CredentialProvider`
     /// contract, identical to an external provider.
     pub fn initServer(entropy: Entropy, identity: Identity, profile: TransportProfile) Tls13Backend {
+        return initServerConfigured(entropy, identity, defaultConfigForTransport(profile));
+    }
+
+    pub fn initServerConfigured(entropy: Entropy, identity: Identity, config: BackendConfig) Tls13Backend {
         return .{
             .role = .server,
-            .profile = profile,
+            .profile = config.transport,
+            .policy = config.policy,
             .entropy = entropy,
             .identity = identity,
             .identity_present = true,
@@ -732,9 +665,14 @@ pub const Tls13Backend = struct {
     /// selector, external/asynchronous signer, ...). The provider's storage
     /// must outlive the handshake. No fixed identity is held.
     pub fn initServerWithProvider(entropy: Entropy, provider: CredentialProvider, profile: TransportProfile) Tls13Backend {
+        return initServerWithProviderConfigured(entropy, provider, defaultConfigForTransport(profile));
+    }
+
+    pub fn initServerWithProviderConfigured(entropy: Entropy, provider: CredentialProvider, config: BackendConfig) Tls13Backend {
         return .{
             .role = .server,
-            .profile = profile,
+            .profile = config.transport,
+            .policy = config.policy,
             .entropy = entropy,
             .external_provider = provider,
             .core = tls_handshake_codec.Core.init(.server),
@@ -747,9 +685,14 @@ pub const Tls13Backend = struct {
     /// passed to the verifier for hostname verification) and the explicit
     /// policy — the verifier never inherits the insecure trust default.
     pub fn initClientWithVerifier(entropy: Entropy, verifier: PeerVerifier, profile: TransportProfile, options: ClientOptions) Tls13Backend {
+        return initClientWithVerifierConfigured(entropy, verifier, defaultConfigForTransport(profile), options);
+    }
+
+    pub fn initClientWithVerifierConfigured(entropy: Entropy, verifier: PeerVerifier, config: BackendConfig, options: ClientOptions) Tls13Backend {
         var self: Tls13Backend = .{
             .role = .client,
-            .profile = profile,
+            .profile = config.transport,
+            .policy = config.policy,
             .entropy = entropy,
             .external_verifier = verifier,
             .auth_policy = options.policy,
@@ -939,7 +882,7 @@ pub const Tls13Backend = struct {
     }
 
     pub fn alpn(self: *const Tls13Backend) []const u8 {
-        return self.profile.firstConfiguredAlpn();
+        return self.policy.firstAlpn();
     }
 
     fn setSelectedAlpn(self: *Tls13Backend, name: []const u8) void {
@@ -954,13 +897,20 @@ pub const Tls13Backend = struct {
         return if (self.selected_alpn_present) self.selected_alpn[0..self.selected_alpn_len] else null;
     }
 
-    fn selectedAlpnForAuth(self: *const Tls13Backend) []const u8 {
-        return self.selectedAlpn() orelse "";
+    fn negotiatedVersionCode(self: *const Tls13Backend) u16 {
+        return @intFromEnum(self.negotiated_version);
+    }
+
+    fn negotiatedCipherCode(self: *const Tls13Backend) u16 {
+        return @intFromEnum(self.negotiated_cipher_suite);
+    }
+
+    fn negotiatedGroupCode(self: *const Tls13Backend) u16 {
+        return @intFromEnum(self.negotiated_named_group);
     }
 
     pub fn setExtensionProfile(self: *Tls13Backend, extension_type: u16, local: []const u8) HandshakeError!void {
         const profile: TransportProfile = .{ .extension = .{
-            .alpn = self.profile.firstConfiguredAlpn(),
             .extension_type = extension_type,
             .local = local,
         } };
@@ -1037,6 +987,9 @@ pub const Tls13Backend = struct {
         crypto.secureZero(u8, &self.selected_alpn);
         self.selected_alpn_len = 0;
         self.selected_alpn_present = false;
+        self.negotiated_version = .tls13;
+        self.negotiated_cipher_suite = .tls_aes_128_gcm_sha256;
+        self.negotiated_named_group = .x25519;
         // `credential_failure` is intentionally *not* cleared: terminal cleanup
         // must preserve the underlying typed failure (#334). The external
         // provider/verifier vtables borrow caller storage; drop the references.
@@ -1135,6 +1088,7 @@ pub const Tls13Backend = struct {
         std.debug.assert(role == self.role);
         std.debug.assert(self.core.handshake_lifecycle == .idle);
         try self.profile.validate();
+        try self.validateNativePolicy();
         // A configured client server name that overflowed the bound is a caller
         // configuration error; fail closed before any lifecycle or transcript
         // advance rather than emitting SNI for a truncated (wrong) host.
@@ -1154,6 +1108,79 @@ pub const Tls13Backend = struct {
             },
             .server => {},
         }
+    }
+
+    fn validateNativePolicy(self: *const Tls13Backend) HandshakeError!void {
+        switch (self.policy.transport_mode) {
+            .record => if (self.profile != .record) return error.InvalidTransportProfile,
+            .quic => if (self.profile != .extension) return error.InvalidTransportProfile,
+        }
+        if (self.policy.protocol_versions.len == 0 or
+            self.policy.cipher_suites.len == 0 or
+            self.policy.named_groups.len == 0 or
+            self.policy.signature_schemes.len == 0)
+            return error.InvalidTransportProfile;
+
+        if (self.policy.protocol_versions.len > std.math.maxInt(u8) / 2) return error.InvalidTransportProfile;
+        if (self.policy.cipher_suites.len > std.math.maxInt(u16) / 2) return error.InvalidTransportProfile;
+        if (self.policy.named_groups.len > std.math.maxInt(u16) / 2) return error.InvalidTransportProfile;
+        if (self.policy.signature_schemes.len > std.math.maxInt(u16) / 2) return error.InvalidTransportProfile;
+
+        for (self.policy.protocol_versions, 0..) |version, i| {
+            if (version != .tls13) return error.InvalidTransportProfile;
+            if (containsEnum(tls_algorithms.ProtocolVersion, self.policy.protocol_versions[0..i], version)) return error.InvalidTransportProfile;
+        }
+        for (self.policy.cipher_suites, 0..) |cipher, i| {
+            if (cipher != .tls_aes_128_gcm_sha256) return error.InvalidTransportProfile;
+            if (containsEnum(tls_algorithms.CipherSuite, self.policy.cipher_suites[0..i], cipher)) return error.InvalidTransportProfile;
+        }
+        for (self.policy.named_groups, 0..) |group, i| {
+            if (group != .x25519) return error.InvalidTransportProfile;
+            if (containsEnum(tls_algorithms.NamedGroup, self.policy.named_groups[0..i], group)) return error.InvalidTransportProfile;
+        }
+        for (self.policy.signature_schemes, 0..) |scheme, i| {
+            switch (scheme) {
+                .ed25519, .ecdsa_secp256r1_sha256 => {},
+                else => return error.InvalidTransportProfile,
+            }
+            if (containsEnum(tls_algorithms.SignatureScheme, self.policy.signature_schemes[0..i], scheme)) return error.InvalidTransportProfile;
+        }
+        if (self.policy.alpn_protocols.len == 0 and !self.policy.allow_absent_alpn) return error.InvalidTransportProfile;
+        var alpn_total: usize = 0;
+        for (self.policy.alpn_protocols, 0..) |protocol, i| {
+            const name = protocol.bytes;
+            if (name.len == 0 or name.len > std.math.maxInt(u8)) return error.InvalidTransportProfile;
+            alpn_total = checkedAdd(alpn_total, 1 + name.len) catch return error.InvalidTransportProfile;
+            if (alpn_total > std.math.maxInt(u16) or alpn_total + 6 > max_message_len) return error.InvalidTransportProfile;
+            for (self.policy.alpn_protocols[0..i]) |prior| {
+                if (prior.eql(protocol)) return error.InvalidTransportProfile;
+            }
+        }
+        _ = try self.maxServerFlightPreflightLen();
+    }
+
+    fn containsEnum(comptime T: type, haystack: []const T, needle: T) bool {
+        for (haystack) |item| {
+            if (item == needle) return true;
+        }
+        return false;
+    }
+
+    fn maxServerFlightPreflightLen(self: *const Tls13Backend) HandshakeError!usize {
+        var len: usize = 0;
+        len = try checkedAdd(len, 1 + 3 + 2); // EncryptedExtensions header + extension vector length
+        if (self.policy.alpn_protocols.len > 0) {
+            len = try checkedAdd(len, try self.policyAlpnOfferEncodedLen());
+        }
+        if (self.profile.localExtension()) |payload| {
+            len = try checkedAdd(len, 2 + 2 + payload.len);
+        }
+        if (self.client_auth != .disabled) {
+            len = try checkedAdd(len, 1 + 3 + 1 + 2); // CertificateRequest header, empty context, extensions vector
+            len = try checkedAdd(len, 2 + 2 + 2 + 2 * self.policy.signature_schemes.len);
+        }
+        if (len > max_message_len) return error.InvalidTransportProfile;
+        return len;
     }
 
     fn receiveImpl(ptr: *anyopaque, level: EncryptionLevel, bytes: []const u8, sink: *EventSink) HandshakeError!void {
@@ -1287,6 +1314,34 @@ pub const Tls13Backend = struct {
         };
     }
 
+    fn mapNegotiationError(err: tls_negotiation.Error) HandshakeError {
+        return switch (err) {
+            error.MalformedHandshake,
+            error.MalformedExtension,
+            error.MissingCipherSuites,
+            error.OfferVectorTooLarge,
+            error.TooManyExtensions,
+            => error.MalformedHandshake,
+            error.HandshakeBufferOverflow => error.HandshakeBufferOverflow,
+            error.MissingSupportedVersions,
+            error.MissingExtension,
+            => error.MissingExtension,
+            error.UnsupportedProtocolVersion,
+            error.NoMutualCipherSuite,
+            error.NoMutualNamedGroup,
+            error.MissingKeyShare,
+            error.NoMutualSignatureScheme,
+            error.IllegalParameter,
+            error.DuplicateExtension,
+            => error.IllegalParameter,
+            error.NoMutualAlpn => error.AlpnMismatch,
+            error.MissingServerName => error.MissingExtension,
+            error.IncompleteHandshake,
+            error.MessageTooLarge,
+            => error.MalformedHandshake,
+        };
+    }
+
     fn onMessage(
         self: *Tls13Backend,
         message: tls_handshake_codec.Message,
@@ -1380,27 +1435,34 @@ pub const Tls13Backend = struct {
         try w.u16_(legacy_version);
         try w.bytes(&self.entropy.hello_random);
         try w.u8_(0); // legacy_session_id: this profile does not use compatibility mode
-        try w.u16_(2); // cipher_suites
-        try w.u16_(cipher_tls_aes_128_gcm_sha256);
+        try w.u16_(@intCast(2 * self.policy.cipher_suites.len)); // cipher_suites
+        for (self.policy.cipher_suites) |cipher_suite| {
+            try w.u16_(@intFromEnum(cipher_suite));
+        }
         try w.u8_(1); // legacy_compression_methods
         try w.u8_(0);
 
         const extensions_len = try w.reserve(2);
         try w.u16_(ext_supported_versions);
-        try w.u16_(3);
-        try w.u8_(2);
-        try w.u16_(tls13_version);
+        try w.u16_(@intCast(1 + 2 * self.policy.protocol_versions.len));
+        try w.u8_(@intCast(2 * self.policy.protocol_versions.len));
+        for (self.policy.protocol_versions) |version| {
+            try w.u16_(@intFromEnum(version));
+        }
 
         try w.u16_(ext_supported_groups);
-        try w.u16_(4);
-        try w.u16_(2);
-        try w.u16_(group_x25519);
+        try w.u16_(@intCast(2 + 2 * self.policy.named_groups.len));
+        try w.u16_(@intCast(2 * self.policy.named_groups.len));
+        for (self.policy.named_groups) |group| {
+            try w.u16_(@intFromEnum(group));
+        }
 
         try w.u16_(ext_signature_algorithms);
-        try w.u16_(6);
-        try w.u16_(4);
-        try w.u16_(sigalg_ed25519);
-        try w.u16_(sigalg_ecdsa_secp256r1_sha256);
+        try w.u16_(@intCast(2 + 2 * self.policy.signature_schemes.len));
+        try w.u16_(@intCast(2 * self.policy.signature_schemes.len));
+        for (self.policy.signature_schemes) |scheme| {
+            try w.u16_(@intFromEnum(scheme));
+        }
 
         try w.u16_(ext_key_share);
         try w.u16_(2 + 2 + 2 + X25519.public_length);
@@ -1409,7 +1471,7 @@ pub const Tls13Backend = struct {
         try w.u16_(X25519.public_length);
         try w.bytes(&key_pair.public_key);
 
-        try self.profile.writeAlpnOffer(&w);
+        try self.writePolicyAlpnOffer(&w);
 
         // server_name (RFC 6066): the configured intended host, so the server
         // can select on SNI and the same value reaches this side's verifier.
@@ -1552,14 +1614,14 @@ pub const Tls13Backend = struct {
     fn ticketEligibleToOffer(self: *const Tls13Backend, ticket: *const session.ClientTicketState, now_ms: i64) bool {
         const common = &ticket.common;
         if (common.isExpired(now_ms) or common.isNotYetValid(now_ms)) return false;
-        if (common.cipher_suite != .tls_aes_128_gcm_sha256) return false;
+        if (!self.policy.containsCipherSuite(common.cipher_suite)) return false;
         if (common.resumption_psk.slice().len != hash_len) return false;
         if (common.server_name) |*stored| {
             const intended = self.serverNameSlice() orelse return false;
             if (!stored.eqlIgnoreCase(intended)) return false;
         } else if (self.serverNameSlice() != null) return false;
         if (common.application_protocol) |*stored| {
-            if (!self.profile.containsAlpn(stored.slice())) return false;
+            if (!self.policy.containsAlpn(stored.slice())) return false;
         }
         // `common.transport_compat` is the *server's* transport snapshot
         // (stamped via `peerTransportCompat()` at issuance, from the
@@ -1594,14 +1656,14 @@ pub const Tls13Backend = struct {
         len = try checkedAdd(len, 2); // legacy_version
         len = try checkedAdd(len, 32); // random
         len = try checkedAdd(len, 1); // legacy_session_id
-        len = try checkedAdd(len, 2 + 2); // cipher_suites vector + one suite
+        len = try checkedAdd(len, 2 + 2 * self.policy.cipher_suites.len); // cipher_suites vector
         len = try checkedAdd(len, 1 + 1); // compression_methods vector + null
         len = try checkedAdd(len, 2); // extensions vector length
-        len = try checkedAdd(len, 2 + 2 + 3); // supported_versions
-        len = try checkedAdd(len, 2 + 2 + 4); // supported_groups
-        len = try checkedAdd(len, 2 + 2 + 6); // signature_algorithms
+        len = try checkedAdd(len, 2 + 2 + 1 + 2 * self.policy.protocol_versions.len); // supported_versions
+        len = try checkedAdd(len, 2 + 2 + 2 + 2 * self.policy.named_groups.len); // supported_groups
+        len = try checkedAdd(len, 2 + 2 + 2 + 2 * self.policy.signature_schemes.len); // signature_algorithms
         len = try checkedAdd(len, 2 + 2 + 2 + 2 + 2 + X25519.public_length); // key_share
-        len = try checkedAdd(len, try self.profile.alpnOfferEncodedLen());
+        len = try checkedAdd(len, try self.policyAlpnOfferEncodedLen());
         if (self.serverNameSlice()) |name| {
             len = try checkedAdd(len, 2 + 2 + 2 + 1 + 2 + name.len);
         }
@@ -1610,6 +1672,28 @@ pub const Tls13Backend = struct {
             len = try checkedAdd(len, 2 + 2 + payload.len);
         }
         return len;
+    }
+
+    fn writePolicyAlpnOffer(self: *const Tls13Backend, w: *Writer) HandshakeError!void {
+        if (self.policy.alpn_protocols.len == 0) return;
+        try w.u16_(ext_alpn);
+        const alpn_ext_len = try w.reserve(2);
+        const alpn_list_len = try w.reserve(2);
+        for (self.policy.alpn_protocols) |protocol| {
+            try w.u8_(@intCast(protocol.bytes.len));
+            try w.bytes(protocol.bytes);
+        }
+        w.patch(2, alpn_list_len);
+        w.patch(2, alpn_ext_len);
+    }
+
+    fn policyAlpnOfferEncodedLen(self: *const Tls13Backend) HandshakeError!usize {
+        if (self.policy.alpn_protocols.len == 0) return 0;
+        var list_len: usize = 0;
+        for (self.policy.alpn_protocols) |protocol| {
+            list_len = try checkedAdd(list_len, 1 + protocol.bytes.len);
+        }
+        return try checkedAdd(6, list_len);
     }
 
     fn onServerHello(self: *Tls13Backend, body: []const u8, sink: *EventSink) HandshakeError!void {
@@ -1628,10 +1712,11 @@ pub const Tls13Backend = struct {
         if (std.mem.eql(u8, random, &hello_retry_request_random)) return error.IllegalParameter;
         const session_id_len = try r.u8_();
         _ = try r.slice(session_id_len);
-        if (try r.u16_() != cipher_tls_aes_128_gcm_sha256) return error.IllegalParameter;
+        const selected_cipher = tls_algorithms.fromInt(tls_algorithms.CipherSuite, try r.u16_()) orelse return error.IllegalParameter;
         if (try r.u8_() != 0) return error.IllegalParameter;
 
-        var selected_version: ?u16 = null;
+        var selected_version: ?tls_algorithms.ProtocolVersion = null;
+        var selected_group: ?tls_algorithms.NamedGroup = null;
         var peer_share: ?[X25519.public_length]u8 = null;
         var selected_identity: ?u16 = null;
         var guard = ExtensionGuard{};
@@ -1642,11 +1727,15 @@ pub const Tls13Backend = struct {
             try guard.check(ext_id);
             var ext = Reader{ .bytes = try extensions.slice(try extensions.u16_()) };
             switch (ext_id) {
-                ext_supported_versions => selected_version = try ext.u16_(),
+                ext_supported_versions => {
+                    selected_version = tls_algorithms.fromInt(tls_algorithms.ProtocolVersion, try ext.u16_()) orelse return error.IllegalParameter;
+                    try ext.expectEnd();
+                },
                 ext_key_share => {
-                    if (try ext.u16_() != group_x25519) return error.IllegalParameter;
+                    const group = tls_algorithms.fromInt(tls_algorithms.NamedGroup, try ext.u16_()) orelse return error.IllegalParameter;
                     if (try ext.u16_() != X25519.public_length) return error.IllegalParameter;
                     peer_share = (try ext.slice(X25519.public_length))[0..X25519.public_length].*;
+                    selected_group = group;
                     try ext.expectEnd();
                 },
                 pre_shared_key.ext_pre_shared_key => {
@@ -1656,7 +1745,18 @@ pub const Tls13Backend = struct {
                 else => {},
             }
         }
-        if (selected_version != tls13_version) return error.IllegalParameter;
+        const protocol_version = selected_version orelse return error.MissingExtension;
+        const named_group = selected_group orelse return error.MalformedHandshake;
+        tls_negotiation.validateServerHelloTuple(self.policy, .{
+            .version = protocol_version,
+            .cipher_suite = selected_cipher,
+            .named_group = named_group,
+            .alpn = null,
+        }) catch |err| return mapNegotiationError(err);
+        if (selected_cipher != .tls_aes_128_gcm_sha256 or named_group != .x25519 or protocol_version != .tls13) return error.IllegalParameter;
+        self.negotiated_version = protocol_version;
+        self.negotiated_cipher_suite = selected_cipher;
+        self.negotiated_named_group = named_group;
         const share = peer_share orelse return error.MalformedHandshake;
 
         // A low-order/identity peer share is a well-formed 32-byte field with an
@@ -1733,7 +1833,7 @@ pub const Tls13Backend = struct {
                     const name = try list.slice(name_len);
                     // The server selects exactly one protocol (RFC 7301 §3.1).
                     try list.expectEnd();
-                    if (!self.profile.containsAlpn(name)) return error.AlpnMismatch;
+                    if (!self.policy.containsAlpn(name)) return error.AlpnMismatch;
                     self.setSelectedAlpn(name);
                     alpn_seen = true;
                     try sink.emitAlpn(name);
@@ -1748,7 +1848,13 @@ pub const Tls13Backend = struct {
                 },
             }
         }
-        if (!alpn_seen and !self.profile.allowAbsentAlpn()) return error.AlpnMismatch;
+        if (!alpn_seen and !self.policy.allow_absent_alpn) return error.AlpnMismatch;
+        tls_negotiation.validateServerSelection(self.policy, .{
+            .version = self.negotiated_version,
+            .cipher_suite = self.negotiated_cipher_suite,
+            .named_group = self.negotiated_named_group,
+            .alpn = if (self.selectedAlpn()) |protocol| .{ .bytes = protocol } else null,
+        }) catch |err| return mapNegotiationError(err);
         if (self.profile.extensionType() != null and !transport_extension_seen) return error.MissingTransportExtension;
 
         // #362: a PSK-resumed connection has no Certificate message from
@@ -1902,9 +2008,9 @@ pub const Tls13Backend = struct {
             .role = .server,
             .server_name = self.serverNameSlice(),
             .peer_signature_schemes = self.peer_sig_schemes[0..self.peer_sig_scheme_count],
-            .negotiated_version = tls13_version,
-            .cipher_suite = cipher_tls_aes_128_gcm_sha256,
-            .application_protocol = self.selectedAlpnForAuth(),
+            .negotiated_version = self.negotiatedVersionCode(),
+            .cipher_suite = self.negotiatedCipherCode(),
+            .application_protocol = self.selectedAlpn(),
             .auth_policy = self.auth_policy,
         };
     }
@@ -1953,9 +2059,9 @@ pub const Tls13Backend = struct {
             .role = self.role,
             .server_name = self.serverNameSlice(),
             .chain = self.peerChainView(&views),
-            .negotiated_version = tls13_version,
-            .cipher_suite = cipher_tls_aes_128_gcm_sha256,
-            .application_protocol = self.selectedAlpnForAuth(),
+            .negotiated_version = self.negotiatedVersionCode(),
+            .cipher_suite = self.negotiatedCipherCode(),
+            .application_protocol = self.selectedAlpn(),
             .auth_policy = self.auth_policy,
         };
         // The verifier may resolve synchronously or return a pending operation
@@ -2001,15 +2107,16 @@ pub const Tls13Backend = struct {
         unoffered_algorithm,
     };
 
-    fn locallyOfferedSignatureAlgorithm(algorithm: u16) bool {
-        return algorithm == sigalg_ed25519 or algorithm == sigalg_ecdsa_secp256r1_sha256;
+    fn locallyOfferedSignatureAlgorithm(self: *const Tls13Backend, algorithm: u16) bool {
+        const scheme = tls_algorithms.fromInt(tls_algorithms.SignatureScheme, algorithm) orelse return false;
+        return self.policy.containsSignatureScheme(scheme);
     }
 
     /// Verify the CertificateVerify signature against the peer leaf's public
     /// key: proof that the peer holds the private key for the presented
     /// certificate. This is not a trust decision — that is the verifier's job.
     fn checkProofOfPossession(self: *const Tls13Backend, algorithm: u16, signature: []const u8, content: []const u8) ProofResult {
-        if (!locallyOfferedSignatureAlgorithm(algorithm)) return .unoffered_algorithm;
+        if (!self.locallyOfferedSignatureAlgorithm(algorithm)) return .unoffered_algorithm;
         if (self.peer_chain_count == 0) return .invalid_certificate;
         const e = self.peer_chain_entries[0];
         const leaf = self.peer_chain[e.start..][0..e.len];
@@ -2109,9 +2216,9 @@ pub const Tls13Backend = struct {
             .role = .client,
             .server_name = self.serverNameSlice(),
             .peer_signature_schemes = self.peer_sig_schemes[0..self.peer_sig_scheme_count],
-            .negotiated_version = tls13_version,
-            .cipher_suite = cipher_tls_aes_128_gcm_sha256,
-            .application_protocol = self.selectedAlpnForAuth(),
+            .negotiated_version = self.negotiatedVersionCode(),
+            .cipher_suite = self.negotiatedCipherCode(),
+            .application_protocol = self.selectedAlpn(),
             .auth_policy = self.auth_policy,
         };
     }
@@ -2125,7 +2232,7 @@ pub const Tls13Backend = struct {
     fn beginClientAuthFlight(self: *Tls13Backend, sink: *EventSink) HandshakeError!void {
         self.core.beginClientCertificateFlight();
         const provider = self.external_provider orelse
-            return self.emitClientCertificate(null, sink);
+            return self.emitClientCertificate(null, certificate_message_overhead, sink);
         var selection = self.clientSelectionContext();
         // A provider that deterministically has no usable credential is not a
         // failure: TLS 1.3 requires the client to answer a CertificateRequest
@@ -2135,7 +2242,7 @@ pub const Tls13Backend = struct {
         const progress = provider.selectCredential(&selection) catch |err| switch (err) {
             error.NoCredentialAvailable,
             error.NoCompatibleSignatureAlgorithm,
-            => return self.emitClientCertificate(null, sink),
+            => return self.emitClientCertificate(null, certificate_message_overhead, sink),
             else => return self.failCredential(credentials.classifySelectError(err)),
         };
         switch (progress) {
@@ -2149,13 +2256,9 @@ pub const Tls13Backend = struct {
     fn emitSelectedClientCertificate(self: *Tls13Backend, credential: credentials.SelectedCredential, sink: *EventSink) HandshakeError!void {
         var owned = true;
         errdefer if (owned) credential.release();
-        // The provider must return a scheme the server actually offered, else
-        // the CertificateVerify would carry an unadvertised algorithm.
-        const selection = self.clientSelectionContext();
-        if (!selection.offersScheme(credential.scheme))
-            return self.failCredential(.invalid_callback_behavior);
+        const credential_info = try self.inspectSelectedCredential(credential);
         owned = false; // ownership passes to emitClientCertificate
-        return self.emitClientCertificate(credential, sink);
+        return self.emitClientCertificate(credential, credential_info.certificate_message_len, sink);
     }
 
     /// Emit the client Certificate (the credential's validated chain, or an
@@ -2163,34 +2266,15 @@ pub const Tls13Backend = struct {
     /// synchronously, or by parking a pending signer (`client_sign`). Owns the
     /// credential handle and releases it exactly once on any failure before
     /// ownership passes on.
-    fn emitClientCertificate(self: *Tls13Backend, credential: ?credentials.SelectedCredential, sink: *EventSink) HandshakeError!void {
+    fn emitClientCertificate(
+        self: *Tls13Backend,
+        credential: ?credentials.SelectedCredential,
+        certificate_message_len: usize,
+        sink: *EventSink,
+    ) HandshakeError!void {
         var owned = credential != null;
         errdefer if (owned) if (credential) |c| c.release();
-
-        // Validate the credential's chain and its exact encoded size up front,
-        // before any transcript mutation (`recordSent`) or output emission, so a
-        // credential that cannot be serialized within bounds fails closed rather
-        // than being partially recorded or emitted.
-        if (credential) |c| {
-            const chain = c.certificateChain();
-            if (chain.count() == 0 or chain.count() > credentials.max_chain_entries)
-                return self.failCredential(.malformed_credential_chain);
-            // The Certificate message's own framing must be counted too:
-            // 1-byte type + 3-byte length + 1-byte request context + 3-byte
-            // CertificateList length. Omitting it lets a chain that fits the
-            // entry sum overflow the writer after the message header is added.
-            var encoded_len: usize = certificate_message_overhead;
-            for (chain.entries) |entry| {
-                if (entry.len == 0 or entry.len > max_certificate_len)
-                    return self.failCredential(.malformed_credential_chain);
-                // CertificateEntry overhead: 3-byte cert_data length + 2-byte
-                // extensions length.
-                encoded_len = std.math.add(usize, encoded_len, entry.len + 5) catch
-                    return self.failCredential(.malformed_credential_chain);
-                if (encoded_len > max_message_len)
-                    return self.failCredential(.malformed_credential_chain);
-            }
-        }
+        if (certificate_message_len > max_message_len) return self.failCredential(.malformed_credential_chain);
 
         var buf: [max_message_len]u8 = undefined;
         var w = Writer{ .buf = &buf };
@@ -2276,23 +2360,6 @@ pub const Tls13Backend = struct {
 
     fn onClientHello(self: *Tls13Backend, raw: []const u8, sink: *EventSink) HandshakeError!void {
         const body = raw[handshake_header_len..];
-        var r = Reader{ .bytes = body };
-        if (try r.u16_() != legacy_version) return error.IllegalParameter;
-        _ = try r.slice(32); // client random (already covered by the transcript)
-        const session_id = try r.slice(try r.u8_());
-
-        var offers_cipher = false;
-        var ciphers = Reader{ .bytes = try r.slice(try r.u16_()) };
-        while (ciphers.remaining() > 0) {
-            if (try ciphers.u16_() == cipher_tls_aes_128_gcm_sha256) offers_cipher = true;
-        }
-        var offers_null_compression = false;
-        var compressions = Reader{ .bytes = try r.slice(try r.u8_()) };
-        while (compressions.remaining() > 0) {
-            if (try compressions.u8_() == 0) offers_null_compression = true;
-        }
-        if (!offers_cipher or !offers_null_compression) return error.MalformedHandshake;
-
         // A server needs a credential source: the fixed identity or an external
         // provider. Which signature scheme is usable is decided later by
         // credential selection against the peer's advertised algorithms.
@@ -2300,149 +2367,81 @@ pub const Tls13Backend = struct {
         self.peer_sig_scheme_count = 0;
         self.server_name_present = false;
         self.server_name_len = 0;
-        var offers_tls13 = false;
-        var offers_x25519_group = false;
-        var saw_signature_algorithms = false;
-        var peer_share: ?[X25519.public_length]u8 = null;
-        var alpn_offered = false;
-        var selected_alpn: ?[]const u8 = null;
-        var selected_alpn_preference: usize = std.math.maxInt(usize);
-        var transport_params: ?[]const u8 = null;
-        var psk_modes_seen = false;
-        var psk_dhe_ke_offered = false;
-        var psk_ext: ?struct { offset: usize, len: usize } = null;
 
-        var guard = ExtensionGuard{};
-        var extensions = Reader{ .bytes = try r.slice(try r.u16_()) };
-        try r.expectEnd();
-        while (extensions.remaining() > 0) {
-            const ext_id = try extensions.u16_();
-            try guard.check(ext_id);
-            var ext = Reader{ .bytes = try extensions.slice(try extensions.u16_()) };
-            switch (ext_id) {
-                ext_supported_versions => {
-                    var versions = Reader{ .bytes = try ext.slice(try ext.u8_()) };
-                    while (versions.remaining() > 0) {
-                        if (try versions.u16_() == tls13_version) offers_tls13 = true;
-                    }
-                },
-                ext_supported_groups => {
-                    var groups = Reader{ .bytes = try ext.slice(try ext.u16_()) };
-                    while (groups.remaining() > 0) {
-                        if (try groups.u16_() == group_x25519) offers_x25519_group = true;
-                    }
-                },
-                ext_signature_algorithms => {
-                    saw_signature_algorithms = true;
-                    var algorithms = Reader{ .bytes = try ext.slice(try ext.u16_()) };
-                    // Preserve the peer's *complete* offer in order — truncating
-                    // it would silently turn a compatible scheme in a high slot
-                    // into a false local "no compatible credential". If the offer
-                    // is larger than our bounded vector, fail rather than lie to
-                    // the selector about what the peer supports.
-                    while (algorithms.remaining() > 0) {
-                        const scheme = try algorithms.u16_();
-                        if (self.peer_sig_scheme_count >= self.peer_sig_schemes.len) return error.MalformedHandshake;
-                        self.peer_sig_schemes[self.peer_sig_scheme_count] = scheme;
-                        self.peer_sig_scheme_count += 1;
-                    }
-                    try ext.expectEnd();
-                },
-                ext_server_name => {
-                    // RFC 6066 §3: ServerNameList<1..>, each { name_type, name<..> }.
-                    // Distinguish absent (no extension / no host_name) from valid
-                    // and from malformed: an empty, over-bound, or duplicated
-                    // host_name is rejected deterministically rather than being
-                    // collapsed into the default-certificate path, so a selector
-                    // never serves the default cert for an invalid SNI.
-                    const list_len = try ext.u16_();
-                    // RFC 6066 §3: ServerNameList<1..2^16-1> — an empty list is
-                    // malformed, not "no host_name present"; accepting it would
-                    // silently route to the default credential exactly like the
-                    // metadata-collapse behavior this parser otherwise rejects.
-                    if (list_len == 0) return error.IllegalParameter;
-                    var names = Reader{ .bytes = try ext.slice(list_len) };
-                    while (names.remaining() > 0) {
-                        const name_type = try names.u8_();
-                        const name = try names.slice(try names.u16_());
-                        if (name_type != 0) continue; // only host_name is defined
-                        // RFC 6066: a given name_type must appear at most once.
-                        if (self.server_name_present) return error.IllegalParameter;
-                        if (name.len == 0 or name.len > self.server_name.len) return error.IllegalParameter;
-                        dns_name.validateHostName(name) catch return error.IllegalParameter;
-                        @memcpy(self.server_name[0..name.len], name);
-                        self.server_name_len = name.len;
-                        self.server_name_present = true;
-                    }
-                    try ext.expectEnd();
-                },
-                ext_key_share => {
-                    var shares = Reader{ .bytes = try ext.slice(try ext.u16_()) };
-                    while (shares.remaining() > 0) {
-                        const group = try shares.u16_();
-                        const share = try shares.slice(try shares.u16_());
-                        if (group == group_x25519 and share.len == X25519.public_length) {
-                            peer_share = share[0..X25519.public_length].*;
-                        }
-                    }
-                },
-                ext_alpn => {
-                    const list_len = try ext.u16_();
-                    if (list_len == 0) return error.MalformedHandshake;
-                    var list = Reader{ .bytes = try ext.slice(list_len) };
-                    try ext.expectEnd();
-                    while (list.remaining() > 0) {
-                        const name_len = try list.u8_();
-                        if (name_len == 0) return error.MalformedHandshake;
-                        const name = try list.slice(name_len);
-                        alpn_offered = true;
-                        if (self.profile.alpnPreference(name)) |preference| {
-                            if (preference >= selected_alpn_preference) continue;
-                            selected_alpn = name;
-                            selected_alpn_preference = preference;
-                        }
-                    }
-                    try list.expectEnd();
-                },
-                pre_shared_key.ext_psk_key_exchange_modes => {
-                    psk_dhe_ke_offered = pre_shared_key.hasMode(ext.bytes, .psk_dhe_ke) catch |err| return mapPskReadError(err);
-                    psk_modes_seen = true;
-                },
-                pre_shared_key.ext_pre_shared_key => {
-                    // RFC 8446 §4.2.11: pre_shared_key must be the last
-                    // ClientHello extension. `extensions` has already
-                    // consumed this entry's bytes above, so "nothing left"
-                    // here means it truly was last.
-                    if (extensions.remaining() != 0) return error.IllegalParameter;
-                    _ = pre_shared_key.OfferedPsks.parse(ext.bytes) catch |err| return mapPskReadError(err);
-                    psk_ext = .{ .offset = @intFromPtr(ext.bytes.ptr) - @intFromPtr(raw.ptr), .len = ext.bytes.len };
-                },
-                else => {
-                    if (self.profile.extensionType()) |expected_type| {
-                        if (expected_type == ext_id) transport_params = ext.bytes;
-                    }
-                },
+        const ClientHelloObserver = struct {
+            transport_extension_type: ?u16,
+            transport_params: ?[]const u8 = null,
+            psk_modes_seen: bool = false,
+            psk_dhe_ke_offered: bool = false,
+            psk_ext: ?struct { body_offset: usize, len: usize } = null,
+
+            fn observe(ctx: *anyopaque, observation: tls_negotiation.ExtensionObservation) tls_negotiation.Error!void {
+                const self_obs: *@This() = @ptrCast(@alignCast(ctx));
+                switch (observation.id) {
+                    pre_shared_key.ext_psk_key_exchange_modes => {
+                        self_obs.psk_dhe_ke_offered = pre_shared_key.hasMode(observation.data, .psk_dhe_ke) catch
+                            return error.MalformedExtension;
+                        self_obs.psk_modes_seen = true;
+                    },
+                    pre_shared_key.ext_pre_shared_key => {
+                        if (!observation.is_last) return error.IllegalParameter;
+                        _ = pre_shared_key.OfferedPsks.parse(observation.data) catch |err| switch (err) {
+                            error.CountMismatch => return error.IllegalParameter,
+                            else => return error.MalformedExtension,
+                        };
+                        self_obs.psk_ext = .{
+                            .body_offset = observation.data_offset_in_body,
+                            .len = observation.data.len,
+                        };
+                    },
+                    else => if (self_obs.transport_extension_type) |expected_type| {
+                        if (expected_type == observation.id) self_obs.transport_params = observation.data;
+                    },
+                }
             }
-        }
-        if (!offers_tls13 or !offers_x25519_group) return error.MalformedHandshake;
-        if (psk_ext != null and !psk_modes_seen) return error.MissingExtension;
+        };
+
+        var observer = ClientHelloObserver{ .transport_extension_type = self.profile.extensionType() };
+        const parsed = tls_negotiation.parseClientHelloObserved(body, .{
+            .ctx = &observer,
+            .observeFn = ClientHelloObserver.observe,
+        }) catch |err| return mapNegotiationError(err);
+        const offers = parsed.offers;
+        const hello_selection = tls_negotiation.negotiateServerHello(self.policy, &offers) catch |err| return mapNegotiationError(err);
+        if (observer.psk_ext != null and !observer.psk_modes_seen) return error.MissingExtension;
         // signature_algorithms is required whenever the server authenticates
         // with a certificate (RFC 8446 §9.2). A missing or empty list is a
         // malformed/missing required *peer* extension — attribute it to the
         // peer (decode_error), not to local credential configuration.
-        if (!saw_signature_algorithms) return error.MissingExtension;
-        if (self.peer_sig_scheme_count == 0) return error.MalformedHandshake;
-        const client_share = peer_share orelse return error.MalformedHandshake;
+        if (offers.raw_signature_schemes_len == 0) return error.MissingExtension;
+        if (offers.raw_signature_schemes_len > self.peer_sig_schemes.len) return error.MalformedHandshake;
+        @memcpy(self.peer_sig_schemes[0..offers.raw_signature_schemes_len], offers.raw_signature_schemes[0..offers.raw_signature_schemes_len]);
+        self.peer_sig_scheme_count = offers.raw_signature_schemes_len;
+        if (hello_selection.key_share.len != X25519.public_length) return error.MalformedHandshake;
+        const client_share = hello_selection.key_share[0..X25519.public_length].*;
+        if (hello_selection.cipher_suite != .tls_aes_128_gcm_sha256 or
+            hello_selection.named_group != .x25519 or
+            hello_selection.version != .tls13)
+            return error.IllegalParameter;
+        self.negotiated_version = hello_selection.version;
+        self.negotiated_cipher_suite = hello_selection.cipher_suite;
+        self.negotiated_named_group = hello_selection.named_group;
 
-        if (selected_alpn) |protocol| {
-            self.setSelectedAlpn(protocol);
-        } else if (alpn_offered or !self.profile.allowAbsentAlpn()) {
+        if (hello_selection.alpn) |protocol| {
+            self.setSelectedAlpn(protocol.bytes);
+        } else if (!self.policy.allow_absent_alpn) {
             self.core.handshake_lifecycle = .failed;
             return error.AlpnMismatch;
         }
         if (self.profile.extensionType() != null) {
-            const extension = transport_params orelse return error.MissingTransportExtension;
+            const extension = observer.transport_params orelse return error.MissingTransportExtension;
             try self.capturePeerTransportExtension(extension);
+        }
+        if (hello_selection.server_name) |name| {
+            if (name.len > self.server_name.len) return error.IllegalParameter;
+            @memcpy(self.server_name[0..name.len], name);
+            self.server_name_len = name.len;
+            self.server_name_present = true;
         }
 
         // #362: the PSK-bearing ClientHello is captured only once every
@@ -2452,16 +2451,16 @@ pub const Tls13Backend = struct {
         // can never leave a captured bearer ticket identity sitting in
         // `client_hello_psk` past this call.
         self.clearClientHelloPsk();
-        if (psk_ext) |info| {
+        if (observer.psk_ext) |info| {
             var capture: ClientHelloPskCapture = .{};
             if (raw.len > capture.message.len) return error.MalformedHandshake;
             @memcpy(capture.message[0..raw.len], raw);
             capture.message_len = raw.len;
-            capture.ext_data_offset = info.offset;
+            capture.ext_data_offset = handshake_header_len + info.body_offset;
             capture.ext_data_len = info.len;
             self.client_hello_psk = capture;
             self.offered_psk_modes_seen = true;
-            self.offered_psk_dhe_ke = psk_dhe_ke_offered;
+            self.offered_psk_dhe_ke = observer.psk_dhe_ke_offered;
         }
         // Covers every synchronous failure from here on (a bad session_id,
         // a synchronous credential-selection failure); a no-op once
@@ -2470,7 +2469,7 @@ pub const Tls13Backend = struct {
         // — the capture must survive for the async resume.
         errdefer self.clearClientHelloPsk();
 
-        try self.beginServerSelection(session_id, client_share, sink);
+        try self.beginServerSelection(parsed.legacy_session_id, client_share, sink);
     }
 
     fn beginServerSelection(
@@ -2561,15 +2560,15 @@ pub const Tls13Backend = struct {
         try hello.bytes(&self.entropy.hello_random);
         try hello.u8_(@intCast(session_id.len)); // echo legacy_session_id
         try hello.bytes(session_id);
-        try hello.u16_(cipher_tls_aes_128_gcm_sha256);
+        try hello.u16_(self.negotiatedCipherCode());
         try hello.u8_(0);
         const hello_extensions = try hello.reserve(2);
         try hello.u16_(ext_supported_versions);
         try hello.u16_(2);
-        try hello.u16_(tls13_version);
+        try hello.u16_(self.negotiatedVersionCode());
         try hello.u16_(ext_key_share);
         try hello.u16_(2 + 2 + X25519.public_length);
-        try hello.u16_(group_x25519);
+        try hello.u16_(self.negotiatedGroupCode());
         try hello.u16_(X25519.public_length);
         try hello.bytes(&key_pair.public_key);
         if (psk_selected) |sel| {
@@ -2646,7 +2645,7 @@ pub const Tls13Backend = struct {
             if (!found) continue;
 
             const candidate_ctx: session.CandidateContext = .{
-                .cipher_suite = .tls_aes_128_gcm_sha256,
+                .cipher_suite = self.negotiated_cipher_suite,
                 .server_name = self.serverNameSlice(),
                 .application_protocol = self.selectedAlpn(),
                 .auth_binding = current_binding,
@@ -2801,10 +2800,11 @@ pub const Tls13Backend = struct {
             try w.u8_(0); // certificate_request_context<0..255>: empty
             const cr_exts = try w.reserve(2);
             try w.u16_(ext_signature_algorithms);
-            try w.u16_(2 + 2 * 2); // extension_data length
-            try w.u16_(2 * 2); // supported_signature_algorithms list length
-            try w.u16_(sigalg_ed25519);
-            try w.u16_(sigalg_ecdsa_secp256r1_sha256);
+            try w.u16_(@intCast(2 + 2 * self.policy.signature_schemes.len)); // extension_data length
+            try w.u16_(@intCast(2 * self.policy.signature_schemes.len)); // supported_signature_algorithms list length
+            for (self.policy.signature_schemes) |scheme| {
+                try w.u16_(@intFromEnum(scheme));
+            }
             w.patch(2, cr_exts);
             w.patch(3, cr_len);
             certificate_request = buf[cr_start..w.len];
@@ -3040,7 +3040,7 @@ pub const Tls13Backend = struct {
                 .credential => |c| return self.emitSelectedClientCertificate(c, sink),
                 // A selector that resolved to "no credential" declines with an
                 // empty Certificate, exactly like the synchronous path.
-                .no_credential => return self.emitClientCertificate(null, sink),
+                .no_credential => return self.emitClientCertificate(null, certificate_message_overhead, sink),
                 else => {
                     releaseCompletionCredentials(completion, null);
                     return self.failCredential(.invalid_callback_behavior);
@@ -3190,7 +3190,7 @@ pub const Tls13Backend = struct {
 
     fn resumptionContext(self: *const Tls13Backend) new_session_ticket.ConnectionResumptionContext {
         return .{
-            .cipher_suite = tls_algorithms.CipherSuite.tls_aes_128_gcm_sha256,
+            .cipher_suite = self.negotiated_cipher_suite,
             .server_name = if (self.server_name_present) self.server_name[0..self.server_name_len] else null,
             .application_protocol = self.selectedAlpn(),
             .auth_binding = self.effectiveAuthBinding(),
@@ -3224,6 +3224,14 @@ pub const Tls13Backend = struct {
         return self.connection_auth_binding orelse self.peerAuthBinding();
     }
 
+    pub const SelectedCredentialInfo = struct {
+        /// The exact encoded Certificate message length this chain would
+        /// produce (`certificate_message_overhead` + each entry's
+        /// `certificate_entry_overhead`-framed size) — reused by
+        /// flight emission preflight instead of recomputing it.
+        certificate_message_len: usize,
+    };
+
     /// Server (#362): validates the credential selection already performed
     /// for this ClientHello — the same checks `emitServerAuthFlight` applies
     /// before signing — and returns the binding for the server's *own*
@@ -3233,13 +3241,57 @@ pub const Tls13Backend = struct {
     /// peer chain.
     pub const SelectedServerCredentialInfo = struct {
         binding: session.AuthBinding,
-        /// The exact encoded Certificate message length this chain would
-        /// produce (`certificate_message_overhead` + each entry's
-        /// `certificate_entry_overhead`-framed size) — reused by
-        /// `emitServerAuthFlight`'s own flight-size preflight instead of
-        /// recomputing it.
         certificate_message_len: usize,
     };
+
+    fn leafSupportsSignatureScheme(der: []const u8, scheme: credentials.SignatureScheme) HandshakeError!bool {
+        const parsed = (Certificate{ .buffer = der, .index = 0 }).parse() catch
+            return error.MalformedHandshake;
+        return switch (scheme) {
+            .ed25519 => parsed.pub_key_algo == .curveEd25519,
+            .ecdsa_secp256r1_sha256 => switch (parsed.pub_key_algo) {
+                .X9_62_id_ecPublicKey => |curve| curve == .X9_62_prime256v1,
+                else => false,
+            },
+            else => false,
+        };
+    }
+
+    /// Complete local-provider contract validation for a selected credential,
+    /// shared by server authentication and handshake-time client authentication.
+    /// This runs before transcript mutation or output emission so callback
+    /// violations fail locally without sending a Certificate flight.
+    fn inspectSelectedCredential(
+        self: *Tls13Backend,
+        credential: credentials.SelectedCredential,
+    ) HandshakeError!SelectedCredentialInfo {
+        const selected = tls_algorithms.fromInt(tls_algorithms.SignatureScheme, credential.scheme.code()) orelse
+            return self.failCredential(.invalid_callback_behavior);
+        tls_negotiation.validateCredentialSignature(
+            self.policy,
+            self.peer_sig_schemes[0..self.peer_sig_scheme_count],
+            selected,
+        ) catch return self.failCredential(.invalid_callback_behavior);
+
+        const chain = credential.certificateChain();
+        if (chain.count() == 0 or chain.count() > credentials.max_chain_entries)
+            return self.failCredential(.malformed_credential_chain);
+        if (!(leafSupportsSignatureScheme(chain.entries[0], credential.scheme) catch
+            return self.failCredential(.malformed_credential_chain)))
+            return self.failCredential(.invalid_callback_behavior);
+
+        var certificate_message_len: usize = certificate_message_overhead;
+        for (chain.entries) |entry| {
+            if (entry.len == 0 or entry.len > max_certificate_len)
+                return self.failCredential(.malformed_credential_chain);
+            certificate_message_len = std.math.add(usize, certificate_message_len, entry.len + certificate_entry_overhead) catch
+                return self.failCredential(.malformed_credential_chain);
+            if (certificate_message_len > max_message_len)
+                return self.failCredential(.malformed_credential_chain);
+        }
+
+        return .{ .certificate_message_len = certificate_message_len };
+    }
 
     /// Complete validation of the credential selection already performed
     /// for this ClientHello — every chain entry, not just the leaf, and the
@@ -3252,26 +3304,11 @@ pub const Tls13Backend = struct {
         self: *Tls13Backend,
         credential: credentials.SelectedCredential,
     ) HandshakeError!SelectedServerCredentialInfo {
-        const selection = self.serverSelectionContext();
-        if (!selection.offersScheme(credential.scheme))
-            return self.failCredential(.invalid_callback_behavior);
+        const credential_info = try self.inspectSelectedCredential(credential);
         const chain = credential.certificateChain();
-        if (chain.count() == 0 or chain.count() > credentials.max_chain_entries)
-            return self.failCredential(.malformed_credential_chain);
-
-        var certificate_message_len: usize = certificate_message_overhead;
-        for (chain.entries) |entry| {
-            if (entry.len == 0 or entry.len > max_certificate_len)
-                return self.failCredential(.malformed_credential_chain);
-            certificate_message_len = std.math.add(usize, certificate_message_len, entry.len + certificate_entry_overhead) catch
-                return self.failCredential(.malformed_credential_chain);
-            if (certificate_message_len > max_message_len)
-                return self.failCredential(.malformed_credential_chain);
-        }
-
         return .{
             .binding = session.AuthBinding.fromLeafCertificateDer(chain.entries[0]),
-            .certificate_message_len = certificate_message_len,
+            .certificate_message_len = credential_info.certificate_message_len,
         };
     }
 
@@ -3519,7 +3556,7 @@ test "TLS-owned backend teardown clears transcript-adjacent and peer scratch" {
     var backend = Tls13Backend.initClient(
         .{ .hello_random = [_]u8{0x41} ** 32, .key_share_seed = [_]u8{0x42} ** 32 },
         .{ .pinned_certificate = testdata.certificate_der },
-        .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
+        .record,
     );
     backend.core.transcript.update("transcript-adjacent state");
     @memset(&backend.expected_client_verify, 0xa5);
@@ -3541,17 +3578,21 @@ test "TLS-owned backend teardown clears transcript-adjacent and peer scratch" {
 
 test "transport profile validation fails before lifecycle or transcript advance" {
     const entropy = Entropy{ .hello_random = [_]u8{0x41} ** 32, .key_share_seed = [_]u8{0x42} ** 32 };
-    const invalid_alpn_policies = [_]AlpnPolicy{
-        .{ .protocols = &.{""} },
-        .{ .protocols = &.{&([_]u8{'a'} ** 256)} },
-        .{ .protocols = &.{ "h2", "h2" } },
-        .{ .protocols = &.{} },
+    const oversized_alpn = [_]u8{'a'} ** 256;
+    const invalid_alpn_sets = [_][]const tls_algorithms.ProtocolName{
+        &.{.{ .bytes = "" }},
+        &.{.{ .bytes = &oversized_alpn }},
+        &.{ .{ .bytes = "h2" }, .{ .bytes = "h2" } },
+        &.{},
     };
-    for (invalid_alpn_policies) |alpn_policy| {
-        var backend = Tls13Backend.initClient(
+    for (invalid_alpn_sets) |alpns| {
+        var policy = tls_policy.Policy.recordH2Only();
+        policy.alpn_protocols = alpns;
+        var backend = Tls13Backend.initClientConfigured(
             entropy,
             .{ .pinned_certificate = testdata.certificate_der },
-            .{ .record = .{ .alpn = alpn_policy } },
+            recordConfig(policy),
+            .{},
         );
         var sink = EventSink{};
         defer sink.deinit();
@@ -3570,7 +3611,19 @@ test "transport profile validation fails before lifecycle or transcript advance"
         name[0] = @intCast(i);
         names[i] = name[0..];
     }
-    try std.testing.expectError(error.InvalidTransportProfile, (AlpnPolicy{ .protocols = &names }).validate());
+    var too_large_policy = tls_policy.Policy.recordDefault();
+    var too_large_alpns: [names.len]tls_algorithms.ProtocolName = undefined;
+    for (names, 0..) |name, i| too_large_alpns[i] = .{ .bytes = name };
+    too_large_policy.alpn_protocols = &too_large_alpns;
+    var too_large_backend = Tls13Backend.initClientConfigured(
+        entropy,
+        .{ .pinned_certificate = testdata.certificate_der },
+        recordConfig(too_large_policy),
+        .{},
+    );
+    var too_large_sink = EventSink{};
+    defer too_large_sink.deinit();
+    try std.testing.expectError(error.InvalidTransportProfile, too_large_backend.backend().start(.client, {}, &too_large_sink));
 
     var near_storage: [32][255]u8 = undefined;
     var near_names: [32][]const u8 = undefined;
@@ -3582,11 +3635,15 @@ test "transport profile validation fails before lifecycle or transcript advance"
     @memset(near_storage[31][0..], 'b');
     near_storage[31][0] = 'z';
     near_names[31] = near_storage[31][0..139];
-    try (AlpnPolicy{ .protocols = &near_names }).validate();
-    var near_backend = Tls13Backend.initClient(
+    var near_policy = tls_policy.Policy.recordDefault();
+    var near_alpns: [near_names.len]tls_algorithms.ProtocolName = undefined;
+    for (near_names, 0..) |name, i| near_alpns[i] = .{ .bytes = name };
+    near_policy.alpn_protocols = &near_alpns;
+    var near_backend = Tls13Backend.initClientConfigured(
         entropy,
         .{ .pinned_certificate = testdata.certificate_der },
-        .{ .record = .{ .alpn = .{ .protocols = &near_names } } },
+        recordConfig(near_policy),
+        .{},
     );
     var near_sink = EventSink{};
     defer near_sink.deinit();
@@ -3599,7 +3656,7 @@ test "transport profile validation fails before lifecycle or transcript advance"
     var extension_backend = Tls13Backend.initClient(
         entropy,
         .{ .pinned_certificate = testdata.certificate_der },
-        .{ .extension = .{ .alpn = "h3", .extension_type = 57, .local = &oversized } },
+        .{ .extension = .{ .extension_type = 57, .local = &oversized } },
     );
     var extension_sink = EventSink{};
     defer extension_sink.deinit();
@@ -3612,7 +3669,7 @@ test "transport profile validation fails before lifecycle or transcript advance"
     var collision_backend = Tls13Backend.initClient(
         entropy,
         .{ .pinned_certificate = testdata.certificate_der },
-        .{ .extension = .{ .alpn = "h3", .extension_type = ext_supported_versions, .local = "valid" } },
+        .{ .extension = .{ .extension_type = ext_supported_versions, .local = "valid" } },
     );
     var collision_sink = EventSink{};
     defer collision_sink.deinit();
@@ -3626,7 +3683,7 @@ test "client rejects malformed encrypted extensions ALPN framing" {
     var backend = Tls13Backend.initClient(
         Entropy{ .hello_random = [_]u8{0x51} ** 32, .key_share_seed = [_]u8{0x52} ** 32 },
         .{ .pinned_certificate = testdata.certificate_der },
-        .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
+        .record,
     );
     defer backend.deinit();
 
@@ -3684,7 +3741,7 @@ test "client NewSessionTicket callback receives owned state and lifetime zero is
     var backend = Tls13Backend.initClient(
         .{ .hello_random = [_]u8{0x41} ** 32, .key_share_seed = [_]u8{0x42} ** 32 },
         .{ .pinned_certificate = testdata.certificate_der },
-        .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
+        .record,
     );
     defer backend.deinit();
     try backend.setSessionTicketConsumer(std.testing.allocator, session.Limits.default, .{
@@ -3723,7 +3780,7 @@ test "client parses and drops NewSessionTicket when no consumer is configured" {
     var backend = Tls13Backend.initClient(
         .{ .hello_random = [_]u8{0x45} ** 32, .key_share_seed = [_]u8{0x46} ** 32 },
         .{ .pinned_certificate = testdata.certificate_der },
-        .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
+        .record,
     );
     defer backend.deinit();
     try backend.setPostHandshakeAllocator(std.testing.allocator);
@@ -3778,7 +3835,7 @@ test "server explicitly emits NewSessionTicket and returns recoverable state" {
     var server = Tls13Backend.initServer(
         .{ .hello_random = [_]u8{0x51} ** 32, .key_share_seed = [_]u8{0x52} ** 32 },
         try Identity.initPkcs8(testdata.certificate_der, testdata.private_key_pkcs8_der),
-        .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
+        .record,
     );
     defer server.deinit();
 
@@ -3821,7 +3878,7 @@ test "server ticket output failure is atomic and retryable" {
     var server = Tls13Backend.initServer(
         .{ .hello_random = [_]u8{0x61} ** 32, .key_share_seed = [_]u8{0x62} ** 32 },
         try Identity.initPkcs8(testdata.certificate_der, testdata.private_key_pkcs8_der),
-        .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
+        .record,
     );
     defer server.deinit();
     server.core.handshake_lifecycle = .complete;
@@ -3861,7 +3918,7 @@ test "server ticket emission allocation failures leave transcript and sink clean
         var server = Tls13Backend.initServer(
             .{ .hello_random = [_]u8{0x63} ** 32, .key_share_seed = [_]u8{0x64} ** 32 },
             try Identity.initPkcs8(testdata.certificate_der, testdata.private_key_pkcs8_der),
-            .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
+            .record,
         );
         server.core.handshake_lifecycle = .complete;
         try server.resumption_master_secret.replace(&([_]u8{0x33} ** hash_len));
@@ -3926,7 +3983,7 @@ test "large emitted ticket is delivered once after fragmented application receiv
     var server = Tls13Backend.initServer(
         .{ .hello_random = [_]u8{0x71} ** 32, .key_share_seed = [_]u8{0x72} ** 32 },
         try Identity.initPkcs8(testdata.certificate_der, testdata.private_key_pkcs8_der),
-        .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
+        .record,
     );
     defer server.deinit();
     server.core.handshake_lifecycle = .complete;
@@ -3935,7 +3992,7 @@ test "large emitted ticket is delivered once after fragmented application receiv
     var client = Tls13Backend.initClient(
         .{ .hello_random = [_]u8{0x73} ** 32, .key_share_seed = [_]u8{0x74} ** 32 },
         .{ .pinned_certificate = testdata.certificate_der },
-        .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
+        .record,
     );
     defer client.deinit();
     var capture = Capture{};
@@ -3974,7 +4031,7 @@ test "application reassembler accepts exact maximum ticket and rejects one byte 
     var client = Tls13Backend.initClient(
         .{ .hello_random = [_]u8{0x81} ** 32, .key_share_seed = [_]u8{0x82} ** 32 },
         .{ .pinned_certificate = testdata.certificate_der },
-        .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
+        .record,
     );
     defer client.deinit();
     try client.setPostHandshakeAllocator(std.testing.allocator);
@@ -3992,7 +4049,7 @@ test "application reassembler accepts exact maximum ticket and rejects one byte 
     var over_client = Tls13Backend.initClient(
         .{ .hello_random = [_]u8{0x83} ** 32, .key_share_seed = [_]u8{0x84} ** 32 },
         .{ .pinned_certificate = testdata.certificate_der },
-        .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
+        .record,
     );
     defer over_client.deinit();
     try over_client.setPostHandshakeAllocator(std.testing.allocator);
@@ -4009,7 +4066,7 @@ test "client cannot emit NewSessionTicket" {
     var client = Tls13Backend.initClient(
         .{ .hello_random = [_]u8{0x91} ** 32, .key_share_seed = [_]u8{0x92} ** 32 },
         .{ .pinned_certificate = testdata.certificate_der },
-        .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
+        .record,
     );
     defer client.deinit();
     client.core.handshake_lifecycle = .complete;
@@ -4030,7 +4087,7 @@ test "abandoned backend teardown wipes ephemeral and server identity storage" {
     var client = Tls13Backend.initClient(
         entropy,
         .{ .pinned_certificate = testdata.certificate_der },
-        .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
+        .record,
     );
     var sink = EventSink{};
     defer sink.deinit();
@@ -4044,7 +4101,7 @@ test "abandoned backend teardown wipes ephemeral and server identity storage" {
     var server = Tls13Backend.initServer(
         entropy,
         try Identity.initPkcs8(testdata.certificate_der, testdata.private_key_pkcs8_der),
-        .{ .record = .{ .alpn = recordAlpnPolicy("h2") } },
+        .record,
     );
     server.deinit();
     try std.testing.expect(!server.identity_present);

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -55,6 +55,14 @@ fn serverProvider() crypto.provider.CryptoProvider {
     return State.provider_state.cryptoProvider();
 }
 
+fn recordPolicyForNames(names: []const []const u8, allow_absent_alpn: bool) tls_core.policy.Policy {
+    if (names.len == 1 and std.mem.eql(u8, names[0], "h2")) return tls_core.policy.Policy.recordH2Only();
+    if (names.len == 1 and std.mem.eql(u8, names[0], "http/1.1")) return tls_core.policy.Policy.recordHttp1Only(allow_absent_alpn);
+    var policy = tls_core.policy.Policy.recordDefault();
+    policy.allow_absent_alpn = allow_absent_alpn;
+    return policy;
+}
+
 // ==========================================================================
 // Direct transport-neutral driver coverage. This keeps key derivation,
 // record sequencing, epoch discard, and teardown assertions at the engine
@@ -289,15 +297,15 @@ const DirectHarness = struct {
 
     fn init() DirectHarness {
         return initProfiles(
-            .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } },
-            .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } },
+            .record,
+            .record,
         );
     }
 
     fn initExtension() DirectHarness {
         return initProfiles(
-            .{ .extension = .{ .alpn = "h3", .extension_type = 57, .local = "client transport parameters" } },
-            .{ .extension = .{ .alpn = "h3", .extension_type = 57, .local = "server transport parameters" } },
+            .{ .extension = .{ .extension_type = 57, .local = "client transport parameters" } },
+            .{ .extension = .{ .extension_type = 57, .local = "server transport parameters" } },
         );
     }
 
@@ -1241,16 +1249,16 @@ const SocketHarness = struct {
 
         self.client_alpn_protocols = .{opts.client_alpn};
         self.server_alpn_protocols = .{opts.server_alpn};
-        const client_record_profile = tls_backend.TransportProfile{ .record = .{ .alpn = .{ .protocols = &self.client_alpn_protocols } } };
-        const server_record_profile = tls_backend.TransportProfile{ .record = .{ .alpn = .{ .protocols = &self.server_alpn_protocols } } };
+        const client_config = tls_backend.recordConfig(recordPolicyForNames(&self.client_alpn_protocols, false));
+        const server_config = tls_backend.recordConfig(recordPolicyForNames(&self.server_alpn_protocols, false));
         self.client_engine = if (opts.client_verifier) |verifier|
-            tls_backend.Tls13Backend.initClientWithVerifier(clientEntropy(), verifier, client_record_profile, opts.client_options)
+            tls_backend.Tls13Backend.initClientWithVerifierConfigured(clientEntropy(), verifier, client_config, opts.client_options)
         else
-            tls_backend.Tls13Backend.initClient(clientEntropy(), opts.client_trust, client_record_profile);
+            tls_backend.Tls13Backend.initClientConfigured(clientEntropy(), opts.client_trust, client_config, .{});
         self.server_engine = if (opts.server_provider) |provider|
-            tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), provider, server_record_profile)
+            tls_backend.Tls13Backend.initServerWithProviderConfigured(serverEntropy(), provider, server_config)
         else
-            tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), server_record_profile);
+            tls_backend.Tls13Backend.initServerConfigured(serverEntropy(), fixtureIdentity(), server_config);
         if (opts.client_post_handshake_allocator) |post_allocator| {
             try self.client_engine.setPostHandshakeAllocator(post_allocator);
         }
@@ -1840,11 +1848,11 @@ test "record engine pins selected SNI generation across provider reload" {
     var client = tls_backend.Tls13Backend.initClientWithVerifier(
         clientEntropy(),
         verifier.verifier(),
-        .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } },
+        .record,
         .{ .server_name = "pin.example.test", .policy = .{ .require_peer_authentication = true } },
     );
     defer client.deinit();
-    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), provider.provider(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), provider.provider(), .record);
     defer server.deinit();
     var client_sink = DirectSink{};
     defer client_sink.deinit();
@@ -1960,7 +1968,7 @@ test "unknown SNI fails before emitting ServerHello" {
     const config = sniIdentityConfig(&.{"known.example.test"}, chain[0..], true);
     try provider.reload(&.{config}, .{ .unknown_sni_policy = .fail_handshake });
 
-    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), provider.provider(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), provider.provider(), .record);
     defer server.deinit();
     var sink = DirectSink{};
     defer sink.deinit();
@@ -1982,7 +1990,7 @@ test "record stream SNI provider fails exact incompatible signature without wild
     };
     try provider.reload(&configs, .{});
 
-    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), provider.provider(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), provider.provider(), .record);
     defer server.deinit();
     var sink = DirectSink{};
     defer sink.deinit();
@@ -2211,6 +2219,7 @@ const ClientHelloOptions = struct {
     include_signature_algorithms: bool = true,
     sig_schemes: []const u16 = &.{ 0x0807, 0x0403 },
     alpn_protocols: ?[]const []const u8 = &.{"h2"},
+    duplicate_supported_versions: bool = false,
     /// The opaque transport extension (e.g. QUIC transport parameters) to
     /// offer, for driving an extension-profile (#392 HTTP/3) server through
     /// selection the same way a real QUIC client would.
@@ -2266,6 +2275,12 @@ fn buildClientHello(buf: []u8, opts: ClientHelloOptions) ![]const u8 {
     try w.u16_(3);
     try w.u8_(2);
     try w.u16_(0x0304);
+    if (opts.duplicate_supported_versions) {
+        try w.u16_(43);
+        try w.u16_(3);
+        try w.u8_(2);
+        try w.u16_(0x0304);
+    }
     // supported_groups
     try w.u16_(10);
     try w.u16_(4);
@@ -2447,10 +2462,10 @@ fn driveServerSelection(server: *tls_backend.Tls13Backend, opts: ClientHelloOpti
 }
 
 test "record ALPN policy uses server preference across a dual offer" {
-    var server = tls_backend.Tls13Backend.initServer(
+    var server = tls_backend.Tls13Backend.initServerConfigured(
         serverEntropy(),
         fixtureIdentity(),
-        .{ .record = .{ .alpn = .{ .protocols = &.{ "h2", "http/1.1" } } } },
+        tls_backend.recordConfig(tls_core.policy.Policy.recordDefault()),
     );
     defer server.deinit();
 
@@ -2459,31 +2474,49 @@ test "record ALPN policy uses server preference across a dual offer" {
 }
 
 test "record ALPN policy permits absent extension only when configured" {
-    var fallback = tls_backend.Tls13Backend.initServer(
+    var fallback = tls_backend.Tls13Backend.initServerConfigured(
         serverEntropy(),
         fixtureIdentity(),
-        .{ .record = .{ .alpn = .{ .protocols = &.{"http/1.1"}, .allow_absent = true } } },
+        tls_backend.recordConfig(tls_core.policy.Policy.recordHttp1Only(true)),
     );
     defer fallback.deinit();
 
     try driveServerSelection(&fallback, .{ .alpn_protocols = null });
     try std.testing.expect(fallback.selectedAlpn() == null);
 
-    var strict = tls_backend.Tls13Backend.initServer(
+    var strict = tls_backend.Tls13Backend.initServerConfigured(
         serverEntropy(),
         fixtureIdentity(),
-        .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("http/1.1") } },
+        tls_backend.recordConfig(tls_core.policy.Policy.recordHttp1Only(false)),
     );
     defer strict.deinit();
 
     try std.testing.expectError(error.AlpnMismatch, driveServerSelection(&strict, .{ .alpn_protocols = null }));
 }
 
+test "record ALPN fallback rejects present empty extension as malformed" {
+    var fallback = tls_backend.Tls13Backend.initServerConfigured(
+        serverEntropy(),
+        fixtureIdentity(),
+        tls_backend.recordConfig(tls_core.policy.Policy.recordHttp1Only(true)),
+    );
+    defer fallback.deinit();
+
+    try std.testing.expectError(error.MalformedHandshake, driveServerSelection(&fallback, .{ .alpn_protocols = &.{} }));
+}
+
+test "duplicate ClientHello extension maps to illegal_parameter" {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
+    defer server.deinit();
+
+    try expectServerReceiveError(&server, .{ .duplicate_supported_versions = true }, error.IllegalParameter);
+}
+
 test "record ALPN policy rejects no-overlap and malformed vectors" {
     var no_overlap = tls_backend.Tls13Backend.initServer(
         serverEntropy(),
         fixtureIdentity(),
-        .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } },
+        .record,
     );
     defer no_overlap.deinit();
 
@@ -2492,7 +2525,7 @@ test "record ALPN policy rejects no-overlap and malformed vectors" {
     var h2_only_absent = tls_backend.Tls13Backend.initServer(
         serverEntropy(),
         fixtureIdentity(),
-        .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } },
+        .record,
     );
     defer h2_only_absent.deinit();
 
@@ -2501,7 +2534,7 @@ test "record ALPN policy rejects no-overlap and malformed vectors" {
     var malformed = tls_backend.Tls13Backend.initServer(
         serverEntropy(),
         fixtureIdentity(),
-        .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } },
+        .record,
     );
     defer malformed.deinit();
 
@@ -2510,7 +2543,7 @@ test "record ALPN policy rejects no-overlap and malformed vectors" {
 
 test "exact SNI reaches credential selection through a mock provider" {
     var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
-    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .record);
     defer server.deinit();
 
     try driveServerSelection(&server, .{ .sni = "exact.example.test" });
@@ -2524,7 +2557,7 @@ test "exact SNI reaches credential selection through a mock provider" {
 
 test "absent SNI reaches selection deterministically as null" {
     var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
-    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .record);
     defer server.deinit();
 
     try driveServerSelection(&server, .{ .sni = null });
@@ -2535,14 +2568,14 @@ test "absent SNI reaches selection deterministically as null" {
 test "selection sees the peer's offered schemes and picks a compatible credential" {
     // Fixed Ed25519 identity; the peer offers ECDSA first then Ed25519. The
     // fixed provider still binds, proving order-independent compatibility.
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
     try driveServerSelection(&server, .{ .sig_schemes = &.{ 0x0403, 0x0807 } });
     try std.testing.expect(server.credentialFailure() == null);
 }
 
 test "no compatible signature algorithm fails with handshake_failure attribution" {
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
     var sink = DirectSink{};
     defer sink.deinit();
@@ -2561,7 +2594,7 @@ test "no compatible signature algorithm fails with handshake_failure attribution
 test "no credential available fails deterministically and preserves the failure" {
     var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
     mock.force_select_error = error.NoCredentialAvailable;
-    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .record);
     defer server.deinit();
     var sink = DirectSink{};
     defer sink.deinit();
@@ -2580,7 +2613,7 @@ test "no credential available fails deterministically and preserves the failure"
 test "an empty local credential chain is rejected before signing" {
     var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
     mock.empty_chain = true;
-    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .record);
     defer server.deinit();
     var sink = DirectSink{};
     defer sink.deinit();
@@ -2596,7 +2629,7 @@ test "an empty local credential chain is rejected before signing" {
 test "a signing provider failure maps to internal_error and releases the handle" {
     var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
     mock.force_sign_error = error.SigningProviderFailure;
-    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .record);
     defer server.deinit();
     var sink = DirectSink{};
     defer sink.deinit();
@@ -2612,7 +2645,7 @@ test "a signing provider failure maps to internal_error and releases the handle"
 test "an over-length reported signature is caught as a provider contract violation" {
     var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
     mock.force_sign_len = 4096; // far beyond the engine's bounded scratch
-    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .record);
     defer server.deinit();
     var sink = DirectSink{};
     defer sink.deinit();
@@ -2688,21 +2721,42 @@ test "a bad CertificateVerify signature fails proof of possession at the client"
     try std.testing.expectEqual(tls_backend.CredentialFailure.certificate_verify_invalid, h.client_engine.credentialFailure().?);
 }
 
-test "CertificateVerify with a supported but incompatible certificate key is decrypt_error" {
+test "server rejects provider-selected signature scheme incompatible with leaf key before flight" {
     var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
     mock.scheme_override = .ecdsa_secp256r1_sha256;
-    var verifier = credentials.MockVerifier.init(.accepted);
-    const h = try SocketHarness.create(.{ .server_provider = mock.provider(), .client_verifier = verifier.verifier() });
-    defer h.destroy();
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .record);
+    defer server.deinit();
 
-    const failures = driveUntilBothErrors(h);
-    try std.testing.expectEqual(@as(?anyerror, error.DecryptError), failures.client);
-    try std.testing.expectEqual(@as(?anyerror, error.PeerFatalAlert), failures.server);
-    try std.testing.expectEqual(tls_backend.CredentialFailure.certificate_verify_invalid, h.client_engine.credentialFailure().?);
-    try std.testing.expectEqual(
-        tls_core.alerts.AlertDescription.decrypt_error,
-        h.client_engine.credentialFailure().?.alert(),
-    );
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{});
+    try std.testing.expectError(error.CredentialProviderFailed, server.backend().receive(.initial, hello, &sink));
+    try std.testing.expectEqual(tls_backend.CredentialFailure.invalid_callback_behavior, server.credentialFailure().?);
+    try std.testing.expectEqual(@as(usize, 1), mock.release_count);
+    try std.testing.expectEqual(@as(usize, 0), countCryptoEvents(&sink, .initial));
+}
+
+test "async server selection rejects signature scheme incompatible with leaf key before flight" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.scheme_override = .ecdsa_secp256r1_sha256;
+    mock.async_select = true;
+    mock.pending_polls = 0;
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .record);
+    defer server.deinit();
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+    var buf: [1024]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{});
+    try server.backend().receive(.initial, hello, &sink);
+    try std.testing.expect(server.authPending());
+    try std.testing.expectError(error.CredentialProviderFailed, server.resumeAuth(&sink));
+    try std.testing.expectEqual(tls_backend.CredentialFailure.invalid_callback_behavior, server.credentialFailure().?);
+    try std.testing.expectEqual(@as(usize, 1), mock.release_count);
+    try std.testing.expectEqual(@as(usize, 0), countCryptoEvents(&sink, .initial));
 }
 
 fn malformedEd25519PublicKeyCertificate(out: *[tls_backend.testdata.certificate_der.len]u8) []const u8 {
@@ -2768,7 +2822,7 @@ test "provider and verifier mocks under allocation failure clean up" {
 // --------------------------------------------------------------------------
 
 fn serverWithProvider(mock: *credentials.MockCredentialProvider) tls_backend.Tls13Backend {
-    return tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    return tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .record);
 }
 
 fn expectServerReceiveError(server: *tls_backend.Tls13Backend, opts: ClientHelloOptions, want: anyerror) !void {
@@ -2811,7 +2865,7 @@ test "a compatible signature scheme past the legacy cap is still selected" {
     var schemes: [18]u16 = undefined;
     for (0..17) |i| schemes[i] = @intCast(0xfe00 + i);
     schemes[17] = 0x0807; // ed25519
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
     try driveServerSelection(&server, .{ .sig_schemes = &schemes });
     try std.testing.expect(server.credentialFailure() == null);
@@ -2820,19 +2874,19 @@ test "a compatible signature scheme past the legacy cap is still selected" {
 test "a signature_algorithms offer larger than the bound fails closed" {
     var schemes: [80]u16 = undefined;
     for (0..80) |i| schemes[i] = @intCast(0xfe00 + i);
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
     try expectServerReceiveError(&server, .{ .sig_schemes = &schemes }, error.MalformedHandshake);
 }
 
 test "an empty signature_algorithms list is a peer-attributed malformed ClientHello" {
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
     try expectServerReceiveError(&server, .{ .sig_schemes = &.{} }, error.MalformedHandshake);
 }
 
 test "an absent signature_algorithms extension maps to missing_extension" {
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
     try expectServerReceiveError(&server, .{ .include_signature_algorithms = false }, error.MissingExtension);
 }
@@ -2840,7 +2894,7 @@ test "an absent signature_algorithms extension maps to missing_extension" {
 test "malformed SNI is rejected rather than collapsed into the default path" {
     // Empty host_name.
     {
-        var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+        var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
         defer server.deinit();
         // ServerNameList<len=3>{ name_type=0, host_name<len=0> }
         const empty_host = [_]u8{ 0x00, 0x03, 0x00, 0x00, 0x00 };
@@ -2848,7 +2902,7 @@ test "malformed SNI is rejected rather than collapsed into the default path" {
     }
     // Duplicate host_name entries (RFC 6066 forbids a repeated name_type).
     {
-        var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+        var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
         defer server.deinit();
         // ServerNameList<len=8>{ {0,"a"}, {0,"b"} }
         const dup = [_]u8{ 0x00, 0x08, 0x00, 0x00, 0x01, 'a', 0x00, 0x00, 0x01, 'b' };
@@ -2858,7 +2912,7 @@ test "malformed SNI is rejected rather than collapsed into the default path" {
     // not silently treated as "no host_name present" and routed to the default
     // credential.
     {
-        var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+        var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
         defer server.deinit();
         const empty_list = [_]u8{ 0x00, 0x00 }; // ServerNameList<len=0>{}
         try expectServerReceiveError(&server, .{ .sni_raw = &empty_list }, error.IllegalParameter);
@@ -3224,7 +3278,7 @@ test "a transport-extension type colliding with a TLS-owned PSK extension is rej
         var client = tls_backend.Tls13Backend.initClient(
             clientEntropy(),
             .{ .pinned_certificate = tls_backend.testdata.certificate_der },
-            .{ .extension = .{ .alpn = "h3", .extension_type = colliding_type, .local = "x" } },
+            .{ .extension = .{ .extension_type = colliding_type, .local = "x" } },
         );
         defer client.deinit();
         var sink = DirectSink{};
@@ -3237,7 +3291,7 @@ test "a transport-extension type colliding with a TLS-owned PSK extension is rej
         var server = tls_backend.Tls13Backend.initServer(
             serverEntropy(),
             fixtureIdentity(),
-            .{ .extension = .{ .alpn = "h3", .extension_type = colliding_type, .local = "y" } },
+            .{ .extension = .{ .extension_type = colliding_type, .local = "y" } },
         );
         defer server.deinit();
         var server_sink = DirectSink{};
@@ -3248,7 +3302,7 @@ test "a transport-extension type colliding with a TLS-owned PSK extension is rej
 }
 
 test "setApplicationCompat copies the caller's bytes instead of borrowing them" {
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
 
     var scratch: [4]u8 = .{ 'o', 'l', 'd', '!' };
@@ -3267,7 +3321,7 @@ test "setApplicationCompat accepts a snapshot larger than the transport-extensio
     // transport-extension bound, silently rejecting an application
     // snapshot the shared session model itself allows up to 1024 bytes by
     // default (`session.Limits.default.max_application_compat_len`).
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
 
     var large: [session.Limits.default.max_application_compat_len]u8 = undefined;
@@ -3282,7 +3336,7 @@ test "PSK setters reject being called after start, leaving prior configuration u
     var client = tls_backend.Tls13Backend.initClient(
         clientEntropy(),
         .{ .pinned_certificate = tls_backend.testdata.certificate_der },
-        .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } },
+        .record,
     );
     defer client.deinit();
     var sink = DirectSink{};
@@ -3323,7 +3377,7 @@ test "PSK setters reject being called after start, leaving prior configuration u
 
     try std.testing.expectError(error.InvalidHandshakeState, client.setApplicationCompat(.{ .format_id = 1, .format_version = 1, .bytes = "x" }));
 
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
     var server_sink = DirectSink{};
     defer server_sink.deinit();
@@ -3339,7 +3393,7 @@ test "handshake-phase failure wipes PSK offer state before ServerHello even arri
     var client = tls_backend.Tls13Backend.initClient(
         clientEntropy(),
         .{ .pinned_certificate = tls_backend.testdata.certificate_der },
-        .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } },
+        .record,
     );
     defer client.deinit();
 
@@ -3408,7 +3462,7 @@ test "client selects a later (non-zero) identity when the server names it" {
     var client = tls_backend.Tls13Backend.initClient(
         clientEntropy(),
         .{ .pinned_certificate = tls_backend.testdata.certificate_der },
-        .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } },
+        .record,
     );
     defer client.deinit();
 
@@ -3445,7 +3499,7 @@ test "client rejects a selected_identity equal to or beyond the emitted offer co
         var client = tls_backend.Tls13Backend.initClient(
             clientEntropy(),
             .{ .pinned_certificate = tls_backend.testdata.certificate_der },
-            .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } },
+            .record,
         );
         defer client.deinit();
 
@@ -3478,7 +3532,7 @@ test "client rejects a forged selected_identity when no PSK was ever offered" {
     var client = tls_backend.Tls13Backend.initClient(
         clientEntropy(),
         .{ .pinned_certificate = tls_backend.testdata.certificate_der },
-        .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } },
+        .record,
     );
     defer client.deinit();
     try std.testing.expect(client.client_psk_offers.isEmpty());
@@ -3516,7 +3570,7 @@ test "a PSK-selected ServerHello with inconsistent suite/version/key-share is re
         var client = tls_backend.Tls13Backend.initClient(
             clientEntropy(),
             .{ .pinned_certificate = tls_backend.testdata.certificate_der },
-            .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } },
+            .record,
         );
         defer client.deinit();
 
@@ -3551,7 +3605,7 @@ test "a rejected ServerHello observably zeroes the client's offered PSK bytes, n
     var client = tls_backend.Tls13Backend.initClient(
         clientEntropy(),
         .{ .pinned_certificate = tls_backend.testdata.certificate_der },
-        .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } },
+        .record,
     );
     defer client.deinit();
 
@@ -3647,7 +3701,7 @@ test "takeSelectedServerPsk returns null before the client Finished commits the 
     // the client's Finished verifies. Handing the accepted session out any
     // earlier would let a caller retain it past a subsequent bad-Finished
     // failure, which `clearFailedHandshakeState` can then no longer reach.
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
 
     const psk = [_]u8{0x88} ** tls_backend.hash_len;
@@ -3684,7 +3738,7 @@ test "backend teardown observably zeroes the key schedule and selected PSK sessi
     // schedule — exactly the state selection leaves behind (see
     // `takeSelectedServerPsk returns null before the client Finished
     // commits the handshake`, above).
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
 
     const psk = [_]u8{0xcc} ** tls_backend.hash_len;
     var stored_state = pskStoredState(&psk);
@@ -3769,7 +3823,7 @@ test "takePskAgeSkew reports the exact signed observation and is one-shot" {
         .{ .apparent_age_ms = 1_000_000, .actual_elapsed_ms = 10, .expected_skew_ms = 999_990 }, // large skew, still 1-RTT
     };
     for (cases) |case| {
-        var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+        var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
         defer server.deinit();
 
         const psk = [_]u8{0x88} ** tls_backend.hash_len;
@@ -3805,7 +3859,7 @@ test "takePskAgeSkew reports the exact signed observation and is one-shot" {
 }
 
 test "a rejected or fallback candidate publishes no age-skew observation" {
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
 
     const psk = [_]u8{0x99} ** tls_backend.hash_len;
@@ -3829,7 +3883,7 @@ test "a rejected or fallback candidate publishes no age-skew observation" {
 }
 
 test "the accepted server session survives PSK selection with its early-data and metadata intact" {
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
 
     const psk = [_]u8{0x66} ** tls_backend.hash_len;
@@ -3876,7 +3930,7 @@ test "a bad client Finished after PSK selection clears the accepted session and 
     // The old `clearFailedHandshakeState` guard (`core.handshake_lifecycle
     // == .complete`) would therefore see `.complete` and skip cleanup
     // entirely on exactly this path.
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
 
     const psk = [_]u8{0x77} ** tls_backend.hash_len;
@@ -3964,7 +4018,7 @@ fn exerciseResolverCloneThroughBackend(
     stored: *session.ServerRecoverableState,
     psk: *const [tls_backend.hash_len]u8,
 ) !void {
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
     try server.setApplicationCompat(.{ .format_id = 2, .format_version = 1, .bytes = "application-snapshot" });
 
@@ -4022,7 +4076,7 @@ test "resolver candidate cloning is proven correct across every allocation-failu
 }
 
 test "resolver identity-resolution attempts are bounded to eight even when a ninth would succeed" {
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
 
     const psk = [_]u8{0x44} ** tls_backend.hash_len;
@@ -4048,7 +4102,7 @@ test "resolver identity-resolution attempts are bounded to eight even when a nin
 }
 
 test "resolver identity-resolution attempts stop at exactly eight when all eight are unusable" {
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
 
     const psk = [_]u8{0x55} ** tls_backend.hash_len;
@@ -4072,7 +4126,7 @@ test "resolver identity-resolution attempts stop at exactly eight when all eight
 }
 
 test "a resolver operational failure is fatal and distinct from an ordinary miss" {
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
 
     const FailingResolver = struct {
@@ -4104,7 +4158,7 @@ test "a resolver operational failure is fatal and distinct from an ordinary miss
 }
 
 test "a resolver that partially populates its output before failing leaves no residue" {
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
 
     const PartialResolver = struct {
@@ -4150,7 +4204,7 @@ test "a resolver that partially populates its output before failing leaves no re
 }
 
 test "server selects the first compatible identity: unknown first, valid second" {
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
 
     const psk = [_]u8{0x11} ** tls_backend.hash_len;
@@ -4174,7 +4228,7 @@ test "server selects the first compatible identity: unknown first, valid second"
 }
 
 test "a compatible candidate with a wrong binder is fatal and never probes a later identity" {
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
 
     const psk = [_]u8{0x22} ** tls_backend.hash_len;
@@ -4252,7 +4306,7 @@ test "a bad binder wipes the resolver's cloned candidate, including its compat b
     const clone_allocator = fba.allocator();
     const end_index_before_selection = fba.end_index;
 
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
 
     const marker = "candidate-compat-blob-marker";
@@ -4345,7 +4399,7 @@ const MalformedTailProvider = struct {
 
 test "a malformed non-leaf chain entry is rejected before PSK resolver/binder work, even though the leaf is valid" {
     var mock = MalformedTailProvider{ .entries = .{ tls_backend.testdata.certificate_der, "" } }; // entry 1: empty
-    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .record);
     defer server.deinit();
 
     const psk = [_]u8{0x99} ** tls_backend.hash_len;
@@ -4371,7 +4425,7 @@ test "a malformed non-leaf chain entry is rejected before PSK resolver/binder wo
 test "an oversized non-leaf chain entry is rejected before PSK resolver/binder work" {
     const oversized = [_]u8{0} ** (tls_backend.max_certificate_len + 1);
     var mock = MalformedTailProvider{ .entries = .{ tls_backend.testdata.certificate_der, &oversized } };
-    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), mock.provider(), .record);
     defer server.deinit();
 
     const psk = [_]u8{0xaa} ** tls_backend.hash_len;
@@ -4394,7 +4448,7 @@ test "an oversized non-leaf chain entry is rejected before PSK resolver/binder w
 }
 
 test "a ticket bound to a different server certificate falls back to a full handshake" {
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
 
     const psk = [_]u8{0x44} ** tls_backend.hash_len;
@@ -4420,7 +4474,7 @@ test "a ticket bound to a different server certificate falls back to a full hand
 }
 
 test "PSK offered without psk_key_exchange_modes is a missing_extension failure" {
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
     const psk = [_]u8{0x55} ** tls_backend.hash_len;
     try std.testing.expectError(error.MissingExtension, driveServerSelection(&server, .{ .psk = .{
@@ -4429,8 +4483,32 @@ test "PSK offered without psk_key_exchange_modes is a missing_extension failure"
     } }));
 }
 
+test "PSK identity and binder count mismatch is illegal_parameter" {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
+    defer server.deinit();
+
+    var raw_ext_data: [2 + (2 + 6 + 4) + 2 + 2 * (1 + tls_backend.hash_len)]u8 = undefined;
+    var w = HsWriter{ .buf = &raw_ext_data };
+    const identities_len = try w.reserve(2);
+    try w.u16_(6);
+    try w.bytes("ticket");
+    try w.bytes(&.{ 0, 0, 0, 0 });
+    w.patch(2, identities_len);
+    const binders_len = try w.reserve(2);
+    inline for (0..2) |_| {
+        try w.u8_(tls_backend.hash_len);
+        try w.bytes(&([_]u8{0xaa} ** tls_backend.hash_len));
+    }
+    w.patch(2, binders_len);
+
+    try std.testing.expectError(error.IllegalParameter, driveServerSelection(&server, .{ .psk = .{
+        .items = &.{},
+        .raw_ext_data = w.written(),
+    } }));
+}
+
 test "an SNI mismatch falls back to a full handshake instead of rejecting the connection" {
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
 
     const psk = [_]u8{0x66} ** tls_backend.hash_len;
@@ -4586,7 +4664,7 @@ test "resumeAuth is a safe no-op before any suspend and after completion" {
 /// cooperating fixed-identity server backend, so the client's peer verifier is
 /// exercised. Leaves the client parked if its verifier went async.
 fn driveClientThroughCertificateVerify(client: *tls_backend.Tls13Backend, client_sink: *DirectSink) !void {
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
     var server_sink = DirectSink{};
     defer server_sink.deinit();
@@ -4614,7 +4692,7 @@ test "an async peer verification suspends the client and resumes to acceptance" 
     var verifier = credentials.MockVerifier.init(.accepted);
     verifier.async_mode = true;
     verifier.pending_polls = 2;
-    var client = tls_backend.Tls13Backend.initClientWithVerifier(clientEntropy(), verifier.verifier(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } }, .{ .server_name = "tardigrade.test" });
+    var client = tls_backend.Tls13Backend.initClientWithVerifier(clientEntropy(), verifier.verifier(), .record, .{ .server_name = "tardigrade.test" });
     defer client.deinit();
     var sink = DirectSink{};
     defer sink.deinit();
@@ -4636,7 +4714,7 @@ test "a cancelled async peer verification cancels and releases the operation onc
     var verifier = credentials.MockVerifier.init(.accepted);
     verifier.async_mode = true;
     verifier.pending_polls = 5;
-    var client = tls_backend.Tls13Backend.initClientWithVerifier(clientEntropy(), verifier.verifier(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } }, .{});
+    var client = tls_backend.Tls13Backend.initClientWithVerifier(clientEntropy(), verifier.verifier(), .record, .{});
     var sink = DirectSink{};
     try driveClientThroughCertificateVerify(&client, &sink);
     try std.testing.expect(client.authPending());
@@ -4649,9 +4727,9 @@ test "a cancelled async peer verification cancels and releases the operation onc
 
 test "a client rejects trailing handshake bytes after the server Finished" {
     var verifier = credentials.MockVerifier.init(.accepted);
-    var client = tls_backend.Tls13Backend.initClientWithVerifier(clientEntropy(), verifier.verifier(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } }, .{});
+    var client = tls_backend.Tls13Backend.initClientWithVerifier(clientEntropy(), verifier.verifier(), .record, .{});
     defer client.deinit();
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
     var client_sink = DirectSink{};
     defer client_sink.deinit();
@@ -4679,9 +4757,9 @@ test "a client rejects trailing handshake bytes after the server Finished" {
 }
 
 test "a server rejects trailing handshake bytes after the client Finished" {
-    var client = tls_backend.Tls13Backend.initClient(clientEntropy(), .{ .pinned_certificate = tls_backend.testdata.certificate_der }, .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var client = tls_backend.Tls13Backend.initClient(clientEntropy(), .{ .pinned_certificate = tls_backend.testdata.certificate_der }, .record);
     defer client.deinit();
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     defer server.deinit();
     var client_sink = DirectSink{};
     defer client_sink.deinit();
@@ -4714,7 +4792,7 @@ fn clientWithLocalCredential(provider: credentials.CredentialProvider) tls_backe
     var client = tls_backend.Tls13Backend.initClient(
         clientEntropy(),
         .{ .pinned_certificate = tls_backend.testdata.certificate_der },
-        .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } },
+        .record,
     );
     client.setLocalCredentialProvider(provider);
     return client;
@@ -4776,10 +4854,88 @@ fn deliverClientFlightToServer(
     }
 }
 
+test "absent ALPN reaches server selector and client verifier as null" {
+    var provider = credentials.MockCredentialProvider.init(fixtureIdentity());
+    var verifier = credentials.MockVerifier.init(.accepted);
+    var client_policy = tls_core.policy.Policy.recordHttp1Only(true);
+    client_policy.alpn_protocols = &.{};
+    var client = tls_backend.Tls13Backend.initClientWithVerifierConfigured(
+        clientEntropy(),
+        verifier.verifier(),
+        tls_backend.recordConfig(client_policy),
+        .{},
+    );
+    defer client.deinit();
+    var server = tls_backend.Tls13Backend.initServerWithProviderConfigured(
+        serverEntropy(),
+        provider.provider(),
+        tls_backend.recordConfig(tls_core.policy.Policy.recordHttp1Only(true)),
+    );
+    defer server.deinit();
+
+    var client_sink = DirectSink{};
+    defer client_sink.deinit();
+    var server_sink = DirectSink{};
+    defer server_sink.deinit();
+
+    try deliverServerFlightToClient(&client, &server, &client_sink, &server_sink);
+    try std.testing.expectEqual(@as(usize, 1), provider.select_count);
+    try std.testing.expectEqual(@as(usize, 1), verifier.verify_count);
+    try std.testing.expect(provider.lastApplicationProtocol() == null);
+    try std.testing.expect(verifier.lastApplicationProtocol() == null);
+}
+
 fn serverRequestingClientAuth(mode: tls_backend.ClientAuthMode, verifier: credentials.PeerVerifier) tls_backend.Tls13Backend {
-    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
     server.requestClientAuthentication(mode, verifier);
     return server;
+}
+
+test "client rejects selected signature scheme incompatible with leaf key before Certificate flight" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.scheme_override = .ecdsa_secp256r1_sha256;
+    var client = clientWithLocalCredential(mock.provider());
+    defer client.deinit();
+    var verifier = credentials.MockVerifier.init(.accepted);
+    var server = serverRequestingClientAuth(.required, verifier.verifier());
+    defer server.deinit();
+
+    var client_sink = DirectSink{};
+    defer client_sink.deinit();
+    var server_sink = DirectSink{};
+    defer server_sink.deinit();
+
+    try std.testing.expectError(error.CredentialProviderFailed, deliverServerFlightToClient(&client, &server, &client_sink, &server_sink));
+    try std.testing.expectEqual(tls_backend.CredentialFailure.invalid_callback_behavior, client.credentialFailure().?);
+    try std.testing.expectEqual(@as(usize, 1), mock.release_count);
+    try std.testing.expectEqual(@as(usize, 0), mock.sign_count);
+    try std.testing.expectEqual(@as(usize, 0), countCryptoEvents(&client_sink, .handshake));
+}
+
+test "async client selection rejects signature scheme incompatible with leaf key before Certificate flight" {
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.scheme_override = .ecdsa_secp256r1_sha256;
+    mock.async_select = true;
+    mock.pending_polls = 0;
+    var client = clientWithLocalCredential(mock.provider());
+    defer client.deinit();
+    var verifier = credentials.MockVerifier.init(.accepted);
+    var server = serverRequestingClientAuth(.required, verifier.verifier());
+    defer server.deinit();
+
+    var client_sink = DirectSink{};
+    defer client_sink.deinit();
+    var server_sink = DirectSink{};
+    defer server_sink.deinit();
+
+    try deliverServerFlightToClient(&client, &server, &client_sink, &server_sink);
+    try std.testing.expect(client.authPending());
+    try std.testing.expectEqual(@as(usize, 0), countCryptoEvents(&client_sink, .handshake));
+    try std.testing.expectError(error.CredentialProviderFailed, client.resumeAuth(&client_sink));
+    try std.testing.expectEqual(tls_backend.CredentialFailure.invalid_callback_behavior, client.credentialFailure().?);
+    try std.testing.expectEqual(@as(usize, 1), mock.release_count);
+    try std.testing.expectEqual(@as(usize, 0), mock.sign_count);
+    try std.testing.expectEqual(@as(usize, 0), countCryptoEvents(&client_sink, .handshake));
 }
 
 test "async client credential selection suspends the client flight and resumes to mutual completion" {
@@ -5064,7 +5220,7 @@ test "an invalid configured server name is rejected at start rather than emitted
         var client = tls_backend.Tls13Backend.initClientWithVerifier(
             clientEntropy(),
             verifier.verifier(),
-            .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } },
+            .record,
             .{ .server_name = name },
         );
         defer client.deinit();
@@ -5087,10 +5243,20 @@ test "a ClientHello combining maximum ALPN, SNI, and transport extension seriali
     const max_alpn = [_]u8{'a'} ** 255;
     const max_sni = [_]u8{'s'} ** 256;
     var max_transport_ext = [_]u8{0xab} ** tls_backend.max_transport_extension_len;
-    var client = tls_backend.Tls13Backend.initClient(
+    const max_alpn_protocols = [_]tls_core.algorithms.ProtocolName{.{ .bytes = &max_alpn }};
+    const max_alpn_policy = tls_core.policy.Policy.fromCapabilities(
+        .quic,
+        tls_backend.native_capabilities,
+        &max_alpn_protocols,
+    );
+    var client = tls_backend.Tls13Backend.initClientConfigured(
         clientEntropy(),
         .{ .pinned_certificate = tls_backend.testdata.certificate_der },
-        .{ .extension = .{ .alpn = &max_alpn, .extension_type = 57, .local = &max_transport_ext } },
+        .{
+            .policy = max_alpn_policy,
+            .transport = .{ .extension = .{ .extension_type = 57, .local = &max_transport_ext } },
+        },
+        .{},
     );
     client.server_name_len = max_sni.len;
     @memcpy(client.server_name[0..max_sni.len], &max_sni);
@@ -5415,7 +5581,7 @@ test "the server flight preflight rejects a chain that fits entries but overflow
     // Four 2043-byte entries sum to exactly max_message_len once each entry's
     // 5-byte framing is added, but the Certificate message header pushes it over.
     var big = BigChainProvider{ .entry_len = 2043, .entry_count = 4 };
-    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), big.provider(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), big.provider(), .record);
     defer server.deinit();
     var sink = DirectSink{};
     defer sink.deinit();
@@ -5432,7 +5598,7 @@ test "the client flight preflight rejects a chain that overflows with the messag
     var client = tls_backend.Tls13Backend.initClient(
         clientEntropy(),
         .{ .pinned_certificate = tls_backend.testdata.certificate_der },
-        .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } },
+        .record,
     );
     client.setLocalCredentialProvider(big.provider());
     defer client.deinit();
@@ -5488,7 +5654,8 @@ const BigChainSigningProvider = struct {
     const cred_vtable = credentials.SelectedCredential.VTable{ .chain = chain, .sign = sign, .release = release };
     fn chain(handle: *anyopaque) credentials.CertificateChain {
         const self: *BigChainSigningProvider = @ptrCast(@alignCast(handle));
-        for (0..self.entry_count) |i| self.entries[i] = self.storage[0..self.entry_len];
+        if (self.entry_count > 0) self.entries[0] = self.identity.certificate_der;
+        for (1..self.entry_count) |i| self.entries[i] = self.storage[0..self.entry_len];
         return .{ .entries = self.entries[0..self.entry_count] };
     }
     fn sign(handle: *anyopaque, _: credentials.SignatureScheme, input: []const u8, out: []u8) credentials.SignError!credentials.Progress(usize) {
@@ -5518,7 +5685,7 @@ test "a chain at appliance's flight-size boundary serializes through the real re
     try std.testing.expect(entry_len <= tls_backend.max_certificate_len);
 
     var big = BigChainSigningProvider.init(entry_len, entry_count);
-    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), big.provider(), .{ .record = .{ .alpn = tls_backend.recordAlpnPolicy("h2") } });
+    var server = tls_backend.Tls13Backend.initServerWithProvider(serverEntropy(), big.provider(), .record);
     defer server.deinit();
     var sink = DirectSink{};
     defer sink.deinit();
@@ -5545,7 +5712,7 @@ test "a chain at appliance's flight-size boundary serializes through the real HT
     var server = tls_backend.Tls13Backend.initServerWithProvider(
         serverEntropy(),
         big.provider(),
-        .{ .extension = .{ .alpn = "h3", .extension_type = 57, .local = &local_transport_params } },
+        .{ .extension = .{ .extension_type = 57, .local = &local_transport_params } },
     );
     defer server.deinit();
     var sink = DirectSink{};

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -2454,10 +2454,10 @@ const PureZigTlsClient = struct {
         try setNonBlockingFd(self.stream.handle);
 
         self.crypto_provider_state = tls_core.production_crypto.Provider.init(self.entropy_source.entropy());
-        self.backend = tls_core.tls13_backend.Tls13Backend.initClientWithOptions(
+        self.backend = tls_core.tls13_backend.Tls13Backend.initClientConfigured(
             try tls_core.production_crypto.freshHandshakeEntropy(),
             .insecure_no_verification,
-            .{ .record = .{ .alpn = alpnPolicy(alpn) } },
+            tls_core.tls13_backend.recordConfig(alpnPolicy(alpn)),
             .{ .server_name = server_name },
         );
         self.record = try tls_core.encrypted_stream.PureZigRecordStream.initWithCarrierAndBackend(
@@ -2489,10 +2489,10 @@ const PureZigTlsClient = struct {
         try setNonBlockingFd(self.stream.handle);
 
         self.crypto_provider_state = tls_core.production_crypto.Provider.init(self.entropy_source.entropy());
-        self.backend = tls_core.tls13_backend.Tls13Backend.initClientWithOptions(
+        self.backend = tls_core.tls13_backend.Tls13Backend.initClientConfigured(
             try tls_core.production_crypto.freshHandshakeEntropy(),
             .insecure_no_verification,
-            .{ .record = .{ .alpn = alpnPolicy(alpn) } },
+            tls_core.tls13_backend.recordConfig(alpnPolicy(alpn)),
             .{ .server_name = server_name },
         );
         self.record = try tls_core.encrypted_stream.PureZigRecordStream.initWithCarrierAndBackend(
@@ -2671,11 +2671,17 @@ const PureZigTlsClient = struct {
     }
 };
 
-fn alpnPolicy(alpn: []const u8) tls_core.tls13_backend.AlpnPolicy {
-    if (std.mem.eql(u8, alpn, "h2")) return tls_core.tls13_backend.recordAlpnPolicy("h2");
-    if (std.mem.eql(u8, alpn, "http/1.1")) return tls_core.tls13_backend.recordAlpnPolicy("http/1.1");
-    if (std.mem.eql(u8, alpn, "tardigrade-test")) return tls_core.tls13_backend.recordAlpnPolicy("tardigrade-test");
-    return .{ .protocols = &.{} };
+const tardigrade_test_alpns = [_]tls_core.algorithms.ProtocolName{.{ .bytes = "tardigrade-test" }};
+
+fn alpnPolicy(alpn: []const u8) tls_core.policy.Policy {
+    if (std.mem.eql(u8, alpn, "h2")) return tls_core.policy.Policy.recordH2Only();
+    if (std.mem.eql(u8, alpn, "http/1.1")) return tls_core.policy.Policy.recordHttp1Only(false);
+    if (std.mem.eql(u8, alpn, "tardigrade-test")) {
+        return tls_core.policy.Policy.fromCapabilities(.record, tls_core.tls13_backend.native_capabilities, &tardigrade_test_alpns);
+    }
+    var policy = tls_core.policy.Policy.recordDefault();
+    policy.alpn_protocols = &.{};
+    return policy;
 }
 
 const Http2WireFrame = struct {


### PR DESCRIPTION
## Summary

- Add protocol-version and absent-ALPN fields to TLS policy, plus standard QUIC/record policy constructors.
- Extend shared negotiation parsing with observer metadata, raw signature-scheme preservation, hello-level selection, absent-ALPN handling, and credential-signature validation helpers.
- Wire the shared TLS 1.3 backend to validated policy for ClientHello offers, ServerHello validation, server hello selection, ALPN checks, and CertificateRequest/signature policy.
- Source QUIC transport-parameter extension ID from the TLS registry while keeping QUIC transport-parameter payload handling in the adapter.

Closes #386 after merge.

## Validation

- `zig fmt --check build.zig src/ tests/`
- `git diff --check`
- `zig build test-tls --summary all --error-style verbose`
- `zig build test-quic --summary all --error-style verbose`
- `zig build test-integration --summary all --error-style verbose`
- `zig build test --summary all --error-style verbose`
- `zig build test -Dtls-profile=appliance --summary all --error-style verbose`
