### PR TITLE
tls: finish native 1-RTT resumption runtime integration

### DIFF
--- a/src/edge_config.zig
+++ b/src/edge_config.zig
@@ -181,6 +181,18 @@ pub const EdgeConfig = struct {
     tls_session_cache_size: u32,
     tls_session_timeout_seconds: u32,
     tls_session_tickets_enabled: bool,
+    /// #488: native (pure-Zig) TLS/QUIC resumption runtime configuration.
+    /// Deliberately distinct from the `tls_session_*`/`tls_session_tickets_*`
+    /// fields above, which remain OpenSSL-facing only — native settings
+    /// affect only the native TLS-over-TCP and QUIC/H3 engines and must
+    /// never be conflated with the OpenSSL terminator's own session config.
+    /// One of "disabled" (default), "stateful", "stateless", "hybrid"; see
+    /// `nativeResumptionMode`.
+    tls_native_resumption_mode: []const u8,
+    tls_native_resumption_ticket_lifetime_seconds: u32,
+    /// One of "reusable" (default) or "single_use"; see
+    /// `nativeResumptionTicketUsage`.
+    tls_native_resumption_ticket_usage: []const u8,
     tls_ocsp_stapling_enabled: bool,
     tls_ocsp_response_path: []const u8,
     tls_ocsp_auto_refresh: bool,
@@ -560,6 +572,8 @@ pub const EdgeConfig = struct {
             allocator.free(sc.key_path);
         }
         allocator.free(self.tls_sni_certs);
+        allocator.free(self.tls_native_resumption_mode);
+        allocator.free(self.tls_native_resumption_ticket_usage);
         allocator.free(self.tls_ocsp_response_path);
         allocator.free(self.tls_acme_directory_url);
         for (self.tls_acme_domains) |d| allocator.free(d);
@@ -765,6 +779,15 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
     const tls_session_cache_size = parseIntEnv(u32, allocator, "TARDIGRADE_TLS_SESSION_CACHE_SIZE", 20_480);
     const tls_session_timeout_seconds = parseIntEnv(u32, allocator, "TARDIGRADE_TLS_SESSION_TIMEOUT_SECONDS", 300);
     const tls_session_tickets_enabled = parseBoolEnv(allocator, "TARDIGRADE_TLS_SESSION_TICKETS", !is_appliance_tls_profile);
+    // #488: native resumption defaults to disabled/safe regardless of TLS
+    // profile — this is a distinct opt-in surface from the OpenSSL-facing
+    // `tls_session_*` settings above and is validated deterministically in
+    // `validate()`, not silently coerced here.
+    const tls_native_resumption_mode = envOrDefault(allocator, "TARDIGRADE_TLS_NATIVE_RESUMPTION_MODE", "disabled") catch unreachable;
+    errdefer allocator.free(tls_native_resumption_mode);
+    const tls_native_resumption_ticket_lifetime_seconds = parseIntEnv(u32, allocator, "TARDIGRADE_TLS_NATIVE_RESUMPTION_TICKET_LIFETIME_SECONDS", 86_400);
+    const tls_native_resumption_ticket_usage = envOrDefault(allocator, "TARDIGRADE_TLS_NATIVE_RESUMPTION_TICKET_USAGE", "reusable") catch unreachable;
+    errdefer allocator.free(tls_native_resumption_ticket_usage);
     const tls_ocsp_stapling_enabled = parseBoolEnv(allocator, "TARDIGRADE_TLS_OCSP_STAPLING", false);
     const tls_ocsp_response_path = envOrDefault(allocator, "TARDIGRADE_TLS_OCSP_RESPONSE_PATH", "") catch unreachable;
     errdefer allocator.free(tls_ocsp_response_path);
@@ -1447,6 +1470,9 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
         .tls_session_cache_size = tls_session_cache_size,
         .tls_session_timeout_seconds = tls_session_timeout_seconds,
         .tls_session_tickets_enabled = tls_session_tickets_enabled,
+        .tls_native_resumption_mode = tls_native_resumption_mode,
+        .tls_native_resumption_ticket_lifetime_seconds = tls_native_resumption_ticket_lifetime_seconds,
+        .tls_native_resumption_ticket_usage = tls_native_resumption_ticket_usage,
         .tls_ocsp_stapling_enabled = tls_ocsp_stapling_enabled,
         .tls_ocsp_response_path = tls_ocsp_response_path,
         .tls_ocsp_auto_refresh = tls_ocsp_auto_refresh,
@@ -2591,6 +2617,54 @@ pub fn hasTlsFiles(cfg: *const EdgeConfig) bool {
 pub const is_appliance_tls_profile =
     std.mem.eql(u8, build_options.tls_profile, "appliance");
 
+/// #488: native (pure-Zig) resumption mode this config resolves to. Callers
+/// must only rely on this after `validate()` has succeeded — an unrecognized
+/// raw string falls back to `.disabled`, the safe default, rather than
+/// silently picking some other mode.
+pub fn nativeResumptionMode(cfg: *const EdgeConfig) tls_core.resumption_runtime.Mode {
+    if (std.mem.eql(u8, cfg.tls_native_resumption_mode, "stateful")) return .stateful;
+    if (std.mem.eql(u8, cfg.tls_native_resumption_mode, "stateless")) return .stateless;
+    if (std.mem.eql(u8, cfg.tls_native_resumption_mode, "hybrid")) return .hybrid;
+    return .disabled;
+}
+
+/// #488: native ticket usage policy this config resolves to. See
+/// `nativeResumptionMode` for the same "only valid after `validate()`"
+/// caveat.
+pub fn nativeResumptionTicketUsage(cfg: *const EdgeConfig) tls_core.resumption_runtime.TicketUsage {
+    if (std.mem.eql(u8, cfg.tls_native_resumption_ticket_usage, "single_use")) return .single_use;
+    return .reusable;
+}
+
+/// #488: native resumption settings are a distinct configuration boundary
+/// from the OpenSSL-facing `tls_session_*` fields — validated deterministically
+/// here rather than silently coerced at load time, so an invalid mode,
+/// usage, or ticket lifetime fails startup/reload instead of falling back.
+/// Pure and logless (like `validateOtelSampleRate`); `validate()` logs the
+/// specific reason at its call site.
+fn validateNativeResumptionConfig(cfg: *const EdgeConfig) !void {
+    const mode = cfg.tls_native_resumption_mode;
+    if (!std.mem.eql(u8, mode, "disabled") and
+        !std.mem.eql(u8, mode, "stateful") and
+        !std.mem.eql(u8, mode, "stateless") and
+        !std.mem.eql(u8, mode, "hybrid"))
+    {
+        return error.InvalidConfigValue;
+    }
+
+    const usage = cfg.tls_native_resumption_ticket_usage;
+    if (!std.mem.eql(u8, usage, "reusable") and !std.mem.eql(u8, usage, "single_use")) {
+        return error.InvalidConfigValue;
+    }
+
+    if (!std.mem.eql(u8, mode, "disabled")) {
+        const lifetime = cfg.tls_native_resumption_ticket_lifetime_seconds;
+        if (lifetime == 0 or lifetime > tls_core.session.max_lifetime_seconds) {
+            return error.InvalidConfigValue;
+        }
+    }
+}
+
 /// Server-name policy for the downstream TLS identity (#392). A configured
 /// name must always be one valid, non-wildcard DNS host name. The appliance
 /// profile additionally requires exactly one identity: a server name must be
@@ -2738,6 +2812,13 @@ pub fn validate(cfg: *const EdgeConfig) !void {
     }
     try validateOptionalFile(cfg.tls_cert_path, "tls_cert_path");
     try validateOptionalFile(cfg.tls_key_path, "tls_key_path");
+    validateNativeResumptionConfig(cfg) catch {
+        std.log.err(
+            "config validation failed: TARDIGRADE_TLS_NATIVE_RESUMPTION_MODE must be one of disabled/stateful/stateless/hybrid, TARDIGRADE_TLS_NATIVE_RESUMPTION_TICKET_USAGE must be reusable/single_use, and (once enabled) TARDIGRADE_TLS_NATIVE_RESUMPTION_TICKET_LIFETIME_SECONDS must be nonzero and <= {d} (mode='{s}' usage='{s}' lifetime={d})",
+            .{ tls_core.session.max_lifetime_seconds, cfg.tls_native_resumption_mode, cfg.tls_native_resumption_ticket_usage, cfg.tls_native_resumption_ticket_lifetime_seconds },
+        );
+        return error.InvalidConfigValue;
+    };
     try validateTlsServerNamePolicy(cfg);
     try validateApplianceTlsProfile(cfg);
     for (cfg.tls_sni_certs) |entry| {
@@ -3633,6 +3714,77 @@ test "validate TLS cert/key pair rejects mismatched presence" {
     try validateTlsCertKeyPair("/cert.pem", "/key.pem");
     try std.testing.expectError(error.InvalidConfigPath, validateTlsCertKeyPair("/cert.pem", ""));
     try std.testing.expectError(error.InvalidConfigPath, validateTlsCertKeyPair("", "/key.pem"));
+}
+
+test "native resumption config defaults to disabled and validates cleanly" {
+    const allocator = std.testing.allocator;
+    var cfg = try loadFromEnv(allocator);
+    defer cfg.deinit(allocator);
+
+    try std.testing.expectEqualStrings("disabled", cfg.tls_native_resumption_mode);
+    try std.testing.expectEqualStrings("reusable", cfg.tls_native_resumption_ticket_usage);
+    try std.testing.expectEqual(tls_core.resumption_runtime.Mode.disabled, nativeResumptionMode(&cfg));
+    try std.testing.expectEqual(tls_core.resumption_runtime.TicketUsage.reusable, nativeResumptionTicketUsage(&cfg));
+    try validateNativeResumptionConfig(&cfg);
+}
+
+test "native resumption config rejects an unrecognized mode or ticket usage" {
+    const allocator = std.testing.allocator;
+    var cfg = try loadFromEnv(allocator);
+    defer cfg.deinit(allocator);
+
+    allocator.free(cfg.tls_native_resumption_mode);
+    cfg.tls_native_resumption_mode = try allocator.dupe(u8, "bogus");
+    try std.testing.expectError(error.InvalidConfigValue, validateNativeResumptionConfig(&cfg));
+    // An unrecognized mode falls back to the safe default rather than
+    // panicking or picking an arbitrary other mode.
+    try std.testing.expectEqual(tls_core.resumption_runtime.Mode.disabled, nativeResumptionMode(&cfg));
+
+    allocator.free(cfg.tls_native_resumption_mode);
+    cfg.tls_native_resumption_mode = try allocator.dupe(u8, "stateful");
+    try validateNativeResumptionConfig(&cfg);
+
+    allocator.free(cfg.tls_native_resumption_ticket_usage);
+    cfg.tls_native_resumption_ticket_usage = try allocator.dupe(u8, "bogus");
+    try std.testing.expectError(error.InvalidConfigValue, validateNativeResumptionConfig(&cfg));
+}
+
+test "native resumption ticket lifetime must be nonzero and within the ceiling, only once enabled" {
+    const allocator = std.testing.allocator;
+    var cfg = try loadFromEnv(allocator);
+    defer cfg.deinit(allocator);
+
+    // A zero/oversized lifetime is harmless while resumption stays disabled.
+    cfg.tls_native_resumption_ticket_lifetime_seconds = 0;
+    try validateNativeResumptionConfig(&cfg);
+
+    allocator.free(cfg.tls_native_resumption_mode);
+    cfg.tls_native_resumption_mode = try allocator.dupe(u8, "hybrid");
+    try std.testing.expectError(error.InvalidConfigValue, validateNativeResumptionConfig(&cfg));
+
+    cfg.tls_native_resumption_ticket_lifetime_seconds = tls_core.session.max_lifetime_seconds + 1;
+    try std.testing.expectError(error.InvalidConfigValue, validateNativeResumptionConfig(&cfg));
+
+    cfg.tls_native_resumption_ticket_lifetime_seconds = tls_core.session.max_lifetime_seconds;
+    try validateNativeResumptionConfig(&cfg);
+}
+
+test "nativeResumptionMode and nativeResumptionTicketUsage cover every recognized value" {
+    const allocator = std.testing.allocator;
+    var cfg = try loadFromEnv(allocator);
+    defer cfg.deinit(allocator);
+
+    const modes = [_][]const u8{ "disabled", "stateful", "stateless", "hybrid" };
+    const expected_modes = [_]tls_core.resumption_runtime.Mode{ .disabled, .stateful, .stateless, .hybrid };
+    for (modes, expected_modes) |raw, expected| {
+        allocator.free(cfg.tls_native_resumption_mode);
+        cfg.tls_native_resumption_mode = try allocator.dupe(u8, raw);
+        try std.testing.expectEqual(expected, nativeResumptionMode(&cfg));
+    }
+
+    allocator.free(cfg.tls_native_resumption_ticket_usage);
+    cfg.tls_native_resumption_ticket_usage = try allocator.dupe(u8, "single_use");
+    try std.testing.expectEqual(tls_core.resumption_runtime.TicketUsage.single_use, nativeResumptionTicketUsage(&cfg));
 }
 
 test "appliance profile defaults never trip validateApplianceTlsProfile" {

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -253,6 +253,33 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
     var http3_runtime: ?http.http3_runtime.Runtime = null;
     var tls_terminator: ?http.tls_termination.TlsTerminator = null;
     var native_credentials: ?http.native_tls_connection.NativeCredentialStore = null;
+    // #488: one process-scoped native resumption runtime, shared by every
+    // native TCP connection and by the QUIC/H3 runtime — never by the
+    // OpenSSL terminator, which owns its own independent session cache
+    // (`tls_terminator`/`tls_session_*` above). Declared and deferred here,
+    // ahead of every borrower below, so its teardown runs last: after
+    // `http3_runtime`, the active/parked connection registries, and every
+    // dynamically accepted native connection have already torn down.
+    var native_resumption_entropy: tls_core.production_crypto.OsEntropy = .{};
+    var native_resumption_provider: tls_core.production_crypto.Provider = undefined;
+    var native_resumption_runtime: ?tls_core.resumption_runtime.Runtime = null;
+    if (edge_config.nativeResumptionMode(cfg) != .disabled) {
+        native_resumption_provider = tls_core.production_crypto.Provider.init(native_resumption_entropy.entropy());
+        native_resumption_runtime = tls_core.resumption_runtime.Runtime.init(
+            state_allocator,
+            .{
+                .mode = edge_config.nativeResumptionMode(cfg),
+                .ticket_lifetime_seconds = cfg.tls_native_resumption_ticket_lifetime_seconds,
+                .usage = edge_config.nativeResumptionTicketUsage(cfg),
+            },
+            .{ .ctx = undefined, .nowUnixMsFn = systemNowUnixMs },
+            native_resumption_provider.cryptoProvider(),
+        ) catch |err| blk: {
+            state.logger.warn(null, "native TLS/QUIC resumption runtime failed to initialize: {s}; continuing without native resumption", .{@errorName(err)});
+            break :blk null;
+        };
+    }
+    defer if (native_resumption_runtime) |*rt| rt.deinit();
     var http3_dispatch_ctx = ghandlers.Http3DispatchContext{
         .config_store = &config_store,
         .cfg = cfg,
@@ -353,6 +380,7 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
             .listen_host = cfg.listen_host,
             .quic_port = cfg.quic_port,
             .credential_provider = h3_credential_provider,
+            .resumption_runtime = if (native_resumption_runtime) |*rt| rt else null,
             .tls_min_version = "1.3",
             .tls_max_version = "1.3",
             .enable_0rtt = cfg.http3_enable_0rtt,
@@ -390,6 +418,7 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
         .tls = if (tls_terminator) |*tls| tls else null,
         .native_credentials = if (native_credentials) |*store| store else null,
         .native_tls_provider = native_tls_provider,
+        .resumption_runtime = if (native_resumption_runtime) |*rt| rt else null,
         .session_pool = undefined,
         .event_loop = &event_loop,
         .active = undefined,
@@ -1050,7 +1079,7 @@ fn startNewConnection(ctx: *WorkerContext, client_fd: std.posix.fd_t) void {
             client_fd,
             tls_protocol_policy,
             native_provider,
-            .{ .buffer_limits = cfg.tls_buffer_limits },
+            .{ .buffer_limits = cfg.tls_buffer_limits, .resumption_runtime = ctx.resumption_runtime },
         ) catch |err| {
             ctx.state.logger.warn(null, "native tls connection setup failed: {}", .{err});
             return;
@@ -1268,6 +1297,13 @@ fn activeConnectionCloseHook(raw_state: *anyopaque, fd: std.posix.fd_t) void {
 
 fn deadlineFromNow(now_ms: u64, timeout_ms: u32) u64 {
     return if (timeout_ms == 0) 0 else now_ms + @as(u64, timeout_ms);
+}
+
+/// Wall-clock source for the process-scoped native resumption runtime
+/// (#488): ticket lifetime/age bookkeeping needs real wall-clock time, not
+/// the monotonic clock the event loop otherwise uses.
+fn systemNowUnixMs(_: *anyopaque) i64 {
+    return compat.milliTimestamp();
 }
 
 fn reapActiveConnections(

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -274,9 +274,9 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
             },
             .{ .ctx = undefined, .nowUnixMsFn = systemNowUnixMs },
             native_resumption_provider.cryptoProvider(),
-        ) catch |err| blk: {
-            state.logger.warn(null, "native TLS/QUIC resumption runtime failed to initialize: {s}; continuing without native resumption", .{@errorName(err)});
-            break :blk null;
+        ) catch |err| {
+            state.logger.err(null, "native TLS/QUIC resumption initialization failed ({s}); refusing to start", .{@errorName(err)});
+            return err;
         };
         if (native_resumption_runtime) |*rt| rt.setObserver(nativeResumptionMetricsObserver(&state));
     }
@@ -818,6 +818,8 @@ fn nativeResumptionOutcomeValue(outcome: tls_core.resumption_runtime.ResumptionO
     return switch (outcome) {
         .accepted => .accepted,
         .full_handshake => .full_handshake,
+        .incompatible => .incompatible,
+        .miss => .miss,
         .fatal => .fatal,
     };
 }

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -278,6 +278,7 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
             state.logger.warn(null, "native TLS/QUIC resumption runtime failed to initialize: {s}; continuing without native resumption", .{@errorName(err)});
             break :blk null;
         };
+        if (native_resumption_runtime) |*rt| rt.setObserver(nativeResumptionMetricsObserver(&state));
     }
     defer if (native_resumption_runtime) |*rt| rt.deinit();
     var http3_dispatch_ctx = ghandlers.Http3DispatchContext{
@@ -777,6 +778,83 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
         state.logger.warn(null, "drain timeout elapsed; force-closed {d} queued connection(s)", .{drain_result.forced_closes});
     }
     state.logger.info(null, "Graceful shutdown complete (forced_closes={d} drain_timed_out={})", .{ drain_result.forced_closes, drain_result.timed_out });
+}
+
+fn nativeResumptionMetricsObserver(state: *GatewayState) tls_core.resumption_runtime.Observer {
+    return .{
+        .ctx = state,
+        .onTicketIssueFn = nativeResumptionTicketIssue,
+        .onTicketStoreFn = nativeResumptionTicketStore,
+        .onTicketResolveFn = nativeResumptionTicketResolve,
+        .onResumptionAttemptFn = nativeResumptionAttempt,
+        .onResumptionOutcomeFn = nativeResumptionOutcome,
+    };
+}
+
+fn nativeResumptionTransport(transport: tls_core.resumption_runtime.Transport) http.metrics.ResumptionTransport {
+    return switch (transport) {
+        .record => .record,
+        .quic => .quic,
+    };
+}
+
+fn nativeResumptionMode(mode: tls_core.resumption_runtime.Mode) http.metrics.ResumptionMode {
+    return switch (mode) {
+        .disabled, .stateful => .stateful,
+        .stateless => .stateless,
+        .hybrid => .hybrid,
+    };
+}
+
+fn nativeTicketResult(result: tls_core.resumption_runtime.TicketResult) http.metrics.TicketResult {
+    return switch (result) {
+        .success => .success,
+        .rejected => .rejected,
+        .failed => .failed,
+    };
+}
+
+fn nativeResumptionOutcomeValue(outcome: tls_core.resumption_runtime.ResumptionOutcome) http.metrics.ResumptionOutcome {
+    return switch (outcome) {
+        .accepted => .accepted,
+        .full_handshake => .full_handshake,
+        .fatal => .fatal,
+    };
+}
+
+fn nativeResumptionTicketIssue(ctx: *anyopaque, transport: tls_core.resumption_runtime.Transport, mode: tls_core.resumption_runtime.Mode, result: tls_core.resumption_runtime.TicketResult) void {
+    const state: *GatewayState = @ptrCast(@alignCast(ctx));
+    state.metrics_mutex.lock();
+    defer state.metrics_mutex.unlock();
+    state.metrics.recordTicketIssue(nativeResumptionTransport(transport), nativeResumptionMode(mode), nativeTicketResult(result));
+}
+
+fn nativeResumptionTicketStore(ctx: *anyopaque, result: tls_core.resumption_runtime.TicketResult) void {
+    const state: *GatewayState = @ptrCast(@alignCast(ctx));
+    state.metrics_mutex.lock();
+    defer state.metrics_mutex.unlock();
+    state.metrics.recordTicketStore(nativeTicketResult(result));
+}
+
+fn nativeResumptionTicketResolve(ctx: *anyopaque, mode: tls_core.resumption_runtime.Mode, result: tls_core.resumption_runtime.TicketResult) void {
+    const state: *GatewayState = @ptrCast(@alignCast(ctx));
+    state.metrics_mutex.lock();
+    defer state.metrics_mutex.unlock();
+    state.metrics.recordTicketResolve(nativeResumptionMode(mode), nativeTicketResult(result));
+}
+
+fn nativeResumptionAttempt(ctx: *anyopaque, transport: tls_core.resumption_runtime.Transport) void {
+    const state: *GatewayState = @ptrCast(@alignCast(ctx));
+    state.metrics_mutex.lock();
+    defer state.metrics_mutex.unlock();
+    state.metrics.recordResumptionAttempt(nativeResumptionTransport(transport));
+}
+
+fn nativeResumptionOutcome(ctx: *anyopaque, transport: tls_core.resumption_runtime.Transport, outcome: tls_core.resumption_runtime.ResumptionOutcome) void {
+    const state: *GatewayState = @ptrCast(@alignCast(ctx));
+    state.metrics_mutex.lock();
+    defer state.metrics_mutex.unlock();
+    state.metrics.recordResumptionOutcome(nativeResumptionTransport(transport), nativeResumptionOutcomeValue(outcome));
 }
 
 fn applyRuntimeIdentity(cfg: *const edge_config.EdgeConfig, logger: *const http.logger.Logger) !void {

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -2641,6 +2641,11 @@ pub const WorkerContext = struct {
     /// Appliance profile: borrowed from the `ApplianceCredentials` owner.
     /// Otherwise: borrowed from the generic native credential store.
     native_tls_provider: ?tls_core.credentials.CredentialProvider = null,
+    /// #488: process-shared native TLS/QUIC resumption runtime, borrowed
+    /// for the lifetime of every native TCP connection this worker accepts.
+    /// `null` when native resumption is disabled (the default) or the
+    /// downstream path is not native TLS.
+    resumption_runtime: ?*tls_core.resumption_runtime.Runtime = null,
     session_pool: *ConnectionSessionPool,
     /// Event loop used to (un)watch idle keepalive connections (#138). A worker
     /// re-arms a parked fd here; the loop thread dispatches it back on readiness.

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -124,6 +124,7 @@ const ConnEntry = struct {
     /// issuance (successfully or not) — issuance is best-effort and must
     /// never be retried on the same connection (#488).
     ticket_issue_attempted: bool = false,
+    resumption_outcome_recorded: bool = false,
 
     fn deinit(self: *ConnEntry, allocator: std.mem.Allocator) void {
         self.h3.deinit();
@@ -378,6 +379,7 @@ pub const Runtime = struct {
 
         if (!was_established and entry.conn.isEstablished()) {
             self.noteHandshakeComplete();
+            self.recordResumptionOutcome(entry);
         }
         self.maybeIssueSessionTicket(entry);
 
@@ -583,7 +585,23 @@ pub const Runtime = struct {
         const runtime = self.resumption_runtime orelse return;
         if (!entry.conn.isEstablished()) return;
         entry.ticket_issue_attempted = true;
-        self.issueSessionTicket(entry, runtime) catch {};
+        self.issueSessionTicket(entry, runtime) catch |err| {
+            runtime.observer.ticketIssue(.quic, runtime.config.mode, switch (err) {
+                error.StatefulCapacityRefused => .rejected,
+                else => .failed,
+            });
+            return;
+        };
+        runtime.observer.ticketIssue(.quic, runtime.config.mode, .success);
+    }
+
+    fn recordResumptionOutcome(self: *Runtime, entry: *ConnEntry) void {
+        if (entry.resumption_outcome_recorded) return;
+        const runtime = self.resumption_runtime orelse return;
+        if (!entry.backend.engine.core.psk_authenticated) return;
+        entry.resumption_outcome_recorded = true;
+        runtime.observer.resumptionAttempt(.quic);
+        runtime.observer.resumptionOutcome(.quic, .accepted);
     }
 
     fn issueSessionTicket(self: *Runtime, entry: *ConnEntry, runtime: *tls_core.resumption_runtime.Runtime) !void {
@@ -606,8 +624,12 @@ pub const Runtime = struct {
         defer prepared.deinit();
 
         const scratch = try allocator.alloc(u8, runtime.maxIdentityLen());
-        defer allocator.free(scratch);
+        defer {
+            std.crypto.secureZero(u8, scratch);
+            allocator.free(scratch);
+        }
         var identity = try runtime.createIdentity(&prepared.state, now_unix_ms, scratch);
+        defer identity.deinit();
 
         entry.conn.emitPreparedNewSessionTicket(&prepared, identity.slice(), limits) catch |err| {
             runtime.rollbackIdentity(&identity);

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -124,7 +124,6 @@ const ConnEntry = struct {
     /// issuance (successfully or not) — issuance is best-effort and must
     /// never be retried on the same connection (#488).
     ticket_issue_attempted: bool = false,
-    resumption_outcome_recorded: bool = false,
 
     fn deinit(self: *ConnEntry, allocator: std.mem.Allocator) void {
         self.h3.deinit();
@@ -379,7 +378,6 @@ pub const Runtime = struct {
 
         if (!was_established and entry.conn.isEstablished()) {
             self.noteHandshakeComplete();
-            self.recordResumptionOutcome(entry);
         }
         self.maybeIssueSessionTicket(entry);
 
@@ -419,6 +417,14 @@ pub const Runtime = struct {
         // native TCP, before the handshake can start — `Connection.init`
         // below arms the responder.
         if (self.resumption_runtime) |runtime| {
+            backend.setResumeCompatibilityPolicy(.{ .transport = .ignore, .application = .ignore }) catch {
+                allocator.destroy(backend);
+                return null;
+            };
+            backend.setResumptionDecisionObserver(runtime.backendDecisionObserver(.quic)) catch {
+                allocator.destroy(backend);
+                return null;
+            };
             if (runtime.serverResolver()) |resolver| {
                 backend.setServerPskResolver(resolver) catch {
                     allocator.destroy(backend);
@@ -593,15 +599,6 @@ pub const Runtime = struct {
             return;
         };
         runtime.observer.ticketIssue(.quic, runtime.config.mode, .success);
-    }
-
-    fn recordResumptionOutcome(self: *Runtime, entry: *ConnEntry) void {
-        if (entry.resumption_outcome_recorded) return;
-        const runtime = self.resumption_runtime orelse return;
-        if (!entry.backend.engine.core.psk_authenticated) return;
-        entry.resumption_outcome_recorded = true;
-        runtime.observer.resumptionAttempt(.quic);
-        runtime.observer.resumptionOutcome(.quic, .accepted);
     }
 
     fn issueSessionTicket(self: *Runtime, entry: *ConnEntry, runtime: *tls_core.resumption_runtime.Runtime) !void {

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -53,6 +53,11 @@ pub const Config = struct {
     /// Borrowed local credential provider shared with the TCP TLS path. The
     /// owner must outlive this runtime and every QUIC connection it accepts.
     credential_provider: ?tls_core.credentials.CredentialProvider = null,
+    /// #488: borrowed process-shared native resumption runtime, shared with
+    /// the native TCP TLS path. `null` (the default) leaves resumption
+    /// fully disabled for QUIC/H3: no resolver is installed on any accepted
+    /// connection and no ticket is ever issued.
+    resumption_runtime: ?*tls_core.resumption_runtime.Runtime = null,
     tls_min_version: []const u8 = "1.3",
     tls_max_version: []const u8 = "1.3",
     enable_0rtt: bool = false,
@@ -115,6 +120,10 @@ const ConnEntry = struct {
     /// Monotonic microseconds when the connection was accepted; used to reap
     /// connections that never complete the handshake.
     accepted_at_us: u64,
+    /// Set exactly once this connection has attempted post-handshake ticket
+    /// issuance (successfully or not) — issuance is best-effort and must
+    /// never be retried on the same connection (#488).
+    ticket_issue_attempted: bool = false,
 
     fn deinit(self: *ConnEntry, allocator: std.mem.Allocator) void {
         self.h3.deinit();
@@ -132,6 +141,7 @@ pub const Runtime = struct {
     request_handler: ?RequestHandler,
     request_handler_ctx: ?*anyopaque,
     credential_provider: ?tls_core.credentials.CredentialProvider,
+    resumption_runtime: ?*tls_core.resumption_runtime.Runtime,
     quic_config: quic.config.Config,
     snapshot_mutex: compat.Mutex = .{},
     snapshot_state: Snapshot,
@@ -163,6 +173,7 @@ pub const Runtime = struct {
             .request_handler = cfg.request_handler,
             .request_handler_ctx = cfg.request_handler_ctx,
             .credential_provider = cfg.credential_provider,
+            .resumption_runtime = cfg.resumption_runtime,
             .quic_config = quicConfigFrom(cfg),
             .snapshot_state = .{ .quic_port = cfg.quic_port },
             .stopping = std.atomic.Value(bool).init(false),
@@ -368,6 +379,7 @@ pub const Runtime = struct {
         if (!was_established and entry.conn.isEstablished()) {
             self.noteHandshakeComplete();
         }
+        self.maybeIssueSessionTicket(entry);
 
         var out: [2048]u8 = undefined;
         while (entry.conn.pollTransmit(&out, now)) |response_datagram| {
@@ -401,6 +413,17 @@ pub const Runtime = struct {
         compat.randomBytes(&entropy.hello_random);
         compat.randomBytes(&entropy.key_share_seed);
         backend.* = quic.tls_backend.Tls13Backend.initServerWithProvider(entropy, credential_provider);
+        // #488: install the same process-shared server resolver used by
+        // native TCP, before the handshake can start — `Connection.init`
+        // below arms the responder.
+        if (self.resumption_runtime) |runtime| {
+            if (runtime.serverResolver()) |resolver| {
+                backend.setServerPskResolver(resolver) catch {
+                    allocator.destroy(backend);
+                    return null;
+                };
+            }
+        }
 
         const conn = Connection.init(allocator, .{
             .role = .server,
@@ -550,6 +573,46 @@ pub const Runtime = struct {
         if (sent >= 0 and @as(usize, @intCast(sent)) == datagram.len) {
             self.notePacketOut(datagram.len);
         }
+    }
+
+    /// #488: best-effort, exactly-once post-handshake ticket issuance for
+    /// this connection. A failure here is swallowed rather than tearing
+    /// down an otherwise usable connection — never retried afterward.
+    fn maybeIssueSessionTicket(self: *Runtime, entry: *ConnEntry) void {
+        if (entry.ticket_issue_attempted) return;
+        const runtime = self.resumption_runtime orelse return;
+        if (!entry.conn.isEstablished()) return;
+        entry.ticket_issue_attempted = true;
+        self.issueSessionTicket(entry, runtime) catch {};
+    }
+
+    fn issueSessionTicket(self: *Runtime, entry: *ConnEntry, runtime: *tls_core.resumption_runtime.Runtime) !void {
+        const allocator = self.allocator;
+        const now_unix_ms = runtime.nowUnixMs();
+
+        var ticket_nonce: [8]u8 = undefined;
+        try runtime.provider.randomBytes(&ticket_nonce);
+        var age_add_bytes: [4]u8 = undefined;
+        try runtime.provider.randomBytes(&age_add_bytes);
+        const ticket_age_add = std.mem.readInt(u32, &age_add_bytes, .big);
+
+        const limits = runtime.config.session_limits;
+        var prepared = try entry.conn.prepareNewSessionTicket(allocator, .{
+            .ticket_lifetime = runtime.config.ticket_lifetime_seconds,
+            .ticket_age_add = ticket_age_add,
+            .ticket_nonce = &ticket_nonce,
+            .issued_at_unix_ms = now_unix_ms,
+        }, limits);
+        defer prepared.deinit();
+
+        const scratch = try allocator.alloc(u8, runtime.maxIdentityLen());
+        defer allocator.free(scratch);
+        var identity = try runtime.createIdentity(&prepared.state, now_unix_ms, scratch);
+
+        entry.conn.emitPreparedNewSessionTicket(&prepared, identity.slice(), limits) catch |err| {
+            runtime.rollbackIdentity(&identity);
+            return err;
+        };
     }
 
     fn noteConnectionAccepted(self: *Runtime) void {
@@ -839,6 +902,36 @@ test "runtime borrows the credential provider and owns no key material" {
     });
     try testing.expect(!unbootstrapped.snapshot().server_bootstrapped);
     unbootstrapped.deinit();
+}
+
+fn fixedNowUnixMsForTest(_: *anyopaque) i64 {
+    return 1000;
+}
+
+test "runtime borrows the resumption runtime and installs it per accepted connection" {
+    var fixed = tls_core.credentials.FixedCredentialProvider.init(tls_core.credentials.testdata.identity());
+    defer fixed.deinit();
+    var logger = logger_mod.Logger.init(.err, "http3-resumption-test");
+
+    var entropy = tls_core.production_crypto.OsEntropy{};
+    var provider_state = tls_core.production_crypto.Provider.init(entropy.entropy());
+    var resumption = try tls_core.resumption_runtime.Runtime.init(
+        testing.allocator,
+        .{ .mode = .stateful },
+        .{ .ctx = undefined, .nowUnixMsFn = fixedNowUnixMsForTest },
+        provider_state.cryptoProvider(),
+    );
+    defer resumption.deinit();
+
+    var runtime = try Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+        .credential_provider = fixed.provider(),
+        .resumption_runtime = &resumption,
+    });
+    defer runtime.deinit();
+
+    try testing.expectEqual(@as(?*tls_core.resumption_runtime.Runtime, &resumption), runtime.resumption_runtime);
 }
 
 test {

--- a/src/http/metrics.zig
+++ b/src/http/metrics.zig
@@ -17,6 +17,20 @@ const tls_direction_count = 2;
 const TlsQueue = enum { inbound_ciphertext, inbound_plaintext, outbound_ciphertext, handshake };
 const TlsDirection = enum { carrier_read, plaintext_write };
 
+/// #488: native TLS/QUIC resumption metric labels. Every label here is a
+/// fixed, closed enum — never a raw ticket, PSK, identity, handle, SNI/ALPN
+/// value, certificate byte, key ID, ciphertext, decrypted state, filesystem
+/// path, or arbitrary error string.
+pub const ResumptionTransport = enum { record, quic };
+pub const ResumptionOutcome = enum { accepted, full_handshake, incompatible, miss, fatal };
+pub const ResumptionMode = enum { stateful, stateless, hybrid };
+pub const TicketResult = enum { success, rejected, failed };
+
+const resumption_transport_count = 2;
+const resumption_outcome_count = 5;
+const resumption_mode_count = 3;
+const ticket_result_count = 3;
+
 /// Server-wide metrics counters.
 ///
 /// Tracks request counts, status code distribution, and uptime.
@@ -145,6 +159,16 @@ pub const Metrics = struct {
     /// Total config hot-reloads rejected (load/validation/bookkeeping failure); the
     /// previous config stays active.
     reload_failure_total: u64,
+    /// #488: native TLS/QUIC resumption attempts by transport.
+    tls_resumption_attempt_total: [resumption_transport_count]u64,
+    /// #488: native resumption outcomes by transport and outcome.
+    tls_resumption_outcome_total: [resumption_transport_count][resumption_outcome_count]u64,
+    /// #488: server-side ticket issuance attempts by transport, mode, result.
+    tls_ticket_issue_total: [resumption_transport_count][resumption_mode_count][ticket_result_count]u64,
+    /// #488: client-side ticket storage attempts by result.
+    tls_ticket_store_total: [ticket_result_count]u64,
+    /// #488: server-side ticket resolution attempts by mode and result.
+    tls_ticket_resolve_total: [resumption_mode_count][ticket_result_count]u64,
     /// Total graceful-shutdown drains started.
     drain_total: u64,
     /// Total drains that hit the configured drain timeout before work finished.
@@ -251,6 +275,11 @@ pub const Metrics = struct {
             .reload_attempts_total = 0,
             .reload_success_total = 0,
             .reload_failure_total = 0,
+            .tls_resumption_attempt_total = .{0} ** resumption_transport_count,
+            .tls_resumption_outcome_total = .{.{0} ** resumption_outcome_count} ** resumption_transport_count,
+            .tls_ticket_issue_total = .{.{.{0} ** ticket_result_count} ** resumption_mode_count} ** resumption_transport_count,
+            .tls_ticket_store_total = .{0} ** ticket_result_count,
+            .tls_ticket_resolve_total = .{.{0} ** ticket_result_count} ** resumption_mode_count,
             .drain_total = 0,
             .drain_timeouts_total = 0,
             .drain_forced_closes_total = 0,
@@ -302,6 +331,32 @@ pub const Metrics = struct {
 
     pub fn recordHealthProbeRun(self: *Metrics) void {
         self.health_probe_runs += 1;
+    }
+
+    /// #488: record one native TLS/QUIC resumption attempt (a connection
+    /// where a PSK-bearing ClientHello was offered/resolved).
+    pub fn recordResumptionAttempt(self: *Metrics, transport: ResumptionTransport) void {
+        self.tls_resumption_attempt_total[resumptionTransportIndex(transport)] += 1;
+    }
+
+    /// #488: record the resolved outcome of a resumption attempt.
+    pub fn recordResumptionOutcome(self: *Metrics, transport: ResumptionTransport, outcome: ResumptionOutcome) void {
+        self.tls_resumption_outcome_total[resumptionTransportIndex(transport)][resumptionOutcomeIndex(outcome)] += 1;
+    }
+
+    /// #488: record a server-side post-handshake ticket issuance attempt.
+    pub fn recordTicketIssue(self: *Metrics, transport: ResumptionTransport, mode: ResumptionMode, result: TicketResult) void {
+        self.tls_ticket_issue_total[resumptionTransportIndex(transport)][resumptionModeIndex(mode)][ticketResultIndex(result)] += 1;
+    }
+
+    /// #488: record a client-side ticket storage attempt.
+    pub fn recordTicketStore(self: *Metrics, result: TicketResult) void {
+        self.tls_ticket_store_total[ticketResultIndex(result)] += 1;
+    }
+
+    /// #488: record a server-side ticket/handle resolution attempt.
+    pub fn recordTicketResolve(self: *Metrics, mode: ResumptionMode, result: TicketResult) void {
+        self.tls_ticket_resolve_total[resumptionModeIndex(mode)][ticketResultIndex(result)] += 1;
     }
 
     /// Record the start of a config hot-reload attempt.
@@ -790,6 +845,7 @@ pub const Metrics = struct {
         });
 
         try self.appendTlsBufferPrometheus(&out);
+        try self.appendResumptionPrometheus(&out);
 
         try out.print(
             \\# HELP tardigrade_proxy_client_aborts_total Total proxied transfers aborted by downstream clients
@@ -1092,6 +1148,83 @@ pub const Metrics = struct {
         }
     }
 
+    /// #488: native TLS/QUIC resumption and ticket counters. Every label
+    /// rendered here comes from a fixed, closed enum (`resumption*Label`/
+    /// `ticketResultLabel`) — never a raw secret or high-cardinality value.
+    fn appendResumptionPrometheus(self: *const Metrics, out: *std.array_list.Managed(u8)) !void {
+        try out.appendSlice(
+            \\# HELP tardigrade_tls_resumption_attempt_total Native TLS/QUIC resumption attempts by transport
+            \\# TYPE tardigrade_tls_resumption_attempt_total counter
+            \\
+        );
+        inline for (.{ ResumptionTransport.record, ResumptionTransport.quic }) |transport| {
+            try out.print("tardigrade_tls_resumption_attempt_total{{transport=\"{s}\"}} {d}\n", .{
+                resumptionTransportLabel(transport),
+                self.tls_resumption_attempt_total[resumptionTransportIndex(transport)],
+            });
+        }
+
+        try out.appendSlice(
+            \\# HELP tardigrade_tls_resumption_outcome_total Native TLS/QUIC resumption outcomes by transport and outcome
+            \\# TYPE tardigrade_tls_resumption_outcome_total counter
+            \\
+        );
+        inline for (.{ ResumptionTransport.record, ResumptionTransport.quic }) |transport| {
+            inline for (.{ ResumptionOutcome.accepted, ResumptionOutcome.full_handshake, ResumptionOutcome.incompatible, ResumptionOutcome.miss, ResumptionOutcome.fatal }) |outcome| {
+                try out.print("tardigrade_tls_resumption_outcome_total{{transport=\"{s}\",outcome=\"{s}\"}} {d}\n", .{
+                    resumptionTransportLabel(transport),
+                    resumptionOutcomeLabel(outcome),
+                    self.tls_resumption_outcome_total[resumptionTransportIndex(transport)][resumptionOutcomeIndex(outcome)],
+                });
+            }
+        }
+
+        try out.appendSlice(
+            \\# HELP tardigrade_tls_ticket_issue_total Server-side ticket issuance attempts by transport, mode, and result
+            \\# TYPE tardigrade_tls_ticket_issue_total counter
+            \\
+        );
+        inline for (.{ ResumptionTransport.record, ResumptionTransport.quic }) |transport| {
+            inline for (.{ ResumptionMode.stateful, ResumptionMode.stateless, ResumptionMode.hybrid }) |mode| {
+                inline for (.{ TicketResult.success, TicketResult.rejected, TicketResult.failed }) |result| {
+                    try out.print("tardigrade_tls_ticket_issue_total{{transport=\"{s}\",mode=\"{s}\",result=\"{s}\"}} {d}\n", .{
+                        resumptionTransportLabel(transport),
+                        resumptionModeLabel(mode),
+                        ticketResultLabel(result),
+                        self.tls_ticket_issue_total[resumptionTransportIndex(transport)][resumptionModeIndex(mode)][ticketResultIndex(result)],
+                    });
+                }
+            }
+        }
+
+        try out.appendSlice(
+            \\# HELP tardigrade_tls_ticket_store_total Client-side ticket storage attempts by result
+            \\# TYPE tardigrade_tls_ticket_store_total counter
+            \\
+        );
+        inline for (.{ TicketResult.success, TicketResult.rejected, TicketResult.failed }) |result| {
+            try out.print("tardigrade_tls_ticket_store_total{{result=\"{s}\"}} {d}\n", .{
+                ticketResultLabel(result),
+                self.tls_ticket_store_total[ticketResultIndex(result)],
+            });
+        }
+
+        try out.appendSlice(
+            \\# HELP tardigrade_tls_ticket_resolve_total Server-side ticket/handle resolution attempts by mode and result
+            \\# TYPE tardigrade_tls_ticket_resolve_total counter
+            \\
+        );
+        inline for (.{ ResumptionMode.stateful, ResumptionMode.stateless, ResumptionMode.hybrid }) |mode| {
+            inline for (.{ TicketResult.success, TicketResult.rejected, TicketResult.failed }) |result| {
+                try out.print("tardigrade_tls_ticket_resolve_total{{mode=\"{s}\",result=\"{s}\"}} {d}\n", .{
+                    resumptionModeLabel(mode),
+                    ticketResultLabel(result),
+                    self.tls_ticket_resolve_total[resumptionModeIndex(mode)][ticketResultIndex(result)],
+                });
+            }
+        }
+    }
+
     /// Format metrics as a JSON string.
     /// Caller owns the returned memory.
     pub fn toJson(self: *const Metrics, allocator: std.mem.Allocator) ![]u8 {
@@ -1212,6 +1345,72 @@ fn tlsDirectionLabel(direction: TlsDirection) []const u8 {
     return switch (direction) {
         .carrier_read => "carrier_read",
         .plaintext_write => "plaintext_write",
+    };
+}
+
+fn resumptionTransportIndex(transport: ResumptionTransport) usize {
+    return switch (transport) {
+        .record => 0,
+        .quic => 1,
+    };
+}
+
+fn resumptionOutcomeIndex(outcome: ResumptionOutcome) usize {
+    return switch (outcome) {
+        .accepted => 0,
+        .full_handshake => 1,
+        .incompatible => 2,
+        .miss => 3,
+        .fatal => 4,
+    };
+}
+
+fn resumptionModeIndex(mode: ResumptionMode) usize {
+    return switch (mode) {
+        .stateful => 0,
+        .stateless => 1,
+        .hybrid => 2,
+    };
+}
+
+fn ticketResultIndex(result: TicketResult) usize {
+    return switch (result) {
+        .success => 0,
+        .rejected => 1,
+        .failed => 2,
+    };
+}
+
+fn resumptionTransportLabel(transport: ResumptionTransport) []const u8 {
+    return switch (transport) {
+        .record => "record",
+        .quic => "quic",
+    };
+}
+
+fn resumptionOutcomeLabel(outcome: ResumptionOutcome) []const u8 {
+    return switch (outcome) {
+        .accepted => "accepted",
+        .full_handshake => "full_handshake",
+        .incompatible => "incompatible",
+        .miss => "miss",
+        .fatal => "fatal",
+    };
+}
+
+fn resumptionModeLabel(mode: ResumptionMode) []const u8 {
+    return switch (mode) {
+        .stateful => "stateful",
+        .stateless => "stateless",
+        .hybrid => "hybrid",
+    };
+}
+
+fn ticketResultLabel(result: TicketResult) []const u8 {
+    return switch (result) {
+        .success => "success",
+        .rejected => "rejected",
+        .failed => "failed",
     };
 }
 
@@ -1486,6 +1685,59 @@ test "Metrics toPrometheus produces valid Prometheus text" {
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_error_invalid_request_total") != null);
     try std.testing.expect(std.mem.find(u8, prom, "# TYPE tardigrade_requests_total counter") != null);
     try std.testing.expect(std.mem.find(u8, prom, "# TYPE tardigrade_uptime_seconds gauge") != null);
+}
+
+test "resumption and ticket counters default to zero and record by label (#488)" {
+    var m = Metrics.init();
+    try std.testing.expectEqual(@as(u64, 0), m.tls_resumption_attempt_total[resumptionTransportIndex(.record)]);
+    try std.testing.expectEqual(@as(u64, 0), m.tls_resumption_attempt_total[resumptionTransportIndex(.quic)]);
+
+    m.recordResumptionAttempt(.record);
+    m.recordResumptionAttempt(.record);
+    m.recordResumptionAttempt(.quic);
+    try std.testing.expectEqual(@as(u64, 2), m.tls_resumption_attempt_total[resumptionTransportIndex(.record)]);
+    try std.testing.expectEqual(@as(u64, 1), m.tls_resumption_attempt_total[resumptionTransportIndex(.quic)]);
+
+    m.recordResumptionOutcome(.record, .accepted);
+    m.recordResumptionOutcome(.quic, .full_handshake);
+    m.recordResumptionOutcome(.quic, .fatal);
+    try std.testing.expectEqual(@as(u64, 1), m.tls_resumption_outcome_total[resumptionTransportIndex(.record)][resumptionOutcomeIndex(.accepted)]);
+    try std.testing.expectEqual(@as(u64, 1), m.tls_resumption_outcome_total[resumptionTransportIndex(.quic)][resumptionOutcomeIndex(.full_handshake)]);
+    try std.testing.expectEqual(@as(u64, 1), m.tls_resumption_outcome_total[resumptionTransportIndex(.quic)][resumptionOutcomeIndex(.fatal)]);
+
+    m.recordTicketIssue(.record, .stateful, .success);
+    m.recordTicketIssue(.quic, .hybrid, .failed);
+    try std.testing.expectEqual(@as(u64, 1), m.tls_ticket_issue_total[resumptionTransportIndex(.record)][resumptionModeIndex(.stateful)][ticketResultIndex(.success)]);
+    try std.testing.expectEqual(@as(u64, 1), m.tls_ticket_issue_total[resumptionTransportIndex(.quic)][resumptionModeIndex(.hybrid)][ticketResultIndex(.failed)]);
+
+    m.recordTicketStore(.success);
+    m.recordTicketStore(.rejected);
+    m.recordTicketStore(.rejected);
+    try std.testing.expectEqual(@as(u64, 1), m.tls_ticket_store_total[ticketResultIndex(.success)]);
+    try std.testing.expectEqual(@as(u64, 2), m.tls_ticket_store_total[ticketResultIndex(.rejected)]);
+
+    m.recordTicketResolve(.stateless, .success);
+    m.recordTicketResolve(.stateless, .failed);
+    try std.testing.expectEqual(@as(u64, 1), m.tls_ticket_resolve_total[resumptionModeIndex(.stateless)][ticketResultIndex(.success)]);
+    try std.testing.expectEqual(@as(u64, 1), m.tls_ticket_resolve_total[resumptionModeIndex(.stateless)][ticketResultIndex(.failed)]);
+}
+
+test "resumption and ticket counters appear in Prometheus output with closed-enum labels only (#488)" {
+    const allocator = std.testing.allocator;
+    var m = Metrics.init();
+    m.recordResumptionAttempt(.quic);
+    m.recordResumptionOutcome(.quic, .accepted);
+    m.recordTicketIssue(.record, .stateful, .success);
+    m.recordTicketStore(.success);
+    m.recordTicketResolve(.hybrid, .success);
+
+    const prom = try m.toPrometheus(allocator);
+    defer allocator.free(prom);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_tls_resumption_attempt_total{transport=\"quic\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_tls_resumption_outcome_total{transport=\"quic\",outcome=\"accepted\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_tls_ticket_issue_total{transport=\"record\",mode=\"stateful\",result=\"success\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_tls_ticket_store_total{result=\"success\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_tls_ticket_resolve_total{mode=\"hybrid\",result=\"success\"} 1") != null);
 }
 
 test "Metrics records proxy streaming fallback reasons" {

--- a/src/http/native_tls_connection.zig
+++ b/src/http/native_tls_connection.zig
@@ -138,6 +138,11 @@ fn keyKindForScheme(scheme: credentials.SignatureScheme) sni_provider.KeyKind {
 pub const NativeTlsConnection = struct {
     pub const Options = struct {
         buffer_limits: encrypted_stream.BufferLimits = encrypted_stream.BufferLimits.defaults(),
+        /// #488: process-shared native resumption runtime, borrowed for the
+        /// lifetime of this connection. `null` (the default) leaves
+        /// resumption fully disabled: no resolver is installed and no
+        /// ticket is ever issued.
+        resumption_runtime: ?*tls.resumption_runtime.Runtime = null,
     };
 
     allocator: std.mem.Allocator,
@@ -148,6 +153,11 @@ pub const NativeTlsConnection = struct {
     negotiated: ?NegotiatedProtocol = null,
     entropy_source: production_crypto.OsEntropy = .{},
     crypto_provider_state: production_crypto.Provider = undefined,
+    resumption_runtime: ?*tls.resumption_runtime.Runtime = null,
+    /// Set exactly once this connection has attempted post-handshake ticket
+    /// issuance (successfully or not) — issuance is best-effort and must
+    /// never be retried on the same connection (#488).
+    ticket_issue_attempted: bool = false,
 
     pub fn create(
         allocator: std.mem.Allocator,
@@ -187,6 +197,14 @@ pub const NativeTlsConnection = struct {
                 .transport = .record,
             },
         );
+        // #488: install the process-shared server resolver before the
+        // handshake can start — `setServerPskResolver` itself refuses once
+        // the backend has left `.idle`.
+        if (options.resumption_runtime) |runtime| {
+            if (runtime.serverResolver()) |resolver| {
+                backend.setServerPskResolver(resolver) catch unreachable;
+            }
+        }
 
         const record = try allocator.create(encrypted_stream.PureZigRecordStream);
         errdefer allocator.destroy(record);
@@ -197,6 +215,7 @@ pub const NativeTlsConnection = struct {
             .backend = backend,
             .record = record,
             .policy = policy,
+            .resumption_runtime = options.resumption_runtime,
         };
         self.crypto_provider_state = production_crypto.Provider.init(self.entropy_source.entropy());
         record.* = try encrypted_stream.PureZigRecordStream.initWithCarrierBackendAndLimits(
@@ -246,7 +265,62 @@ pub const NativeTlsConnection = struct {
     }
 
     pub fn drive(self: *NativeTlsConnection) encrypted_stream.Error!encrypted_stream.DriveResult {
-        return self.record.drive();
+        const result = try self.record.drive();
+        self.maybeIssueSessionTicket();
+        return result;
+    }
+
+    /// #488: best-effort, exactly-once post-handshake ticket issuance. Only
+    /// attempted once authenticated application data has actually opened,
+    /// and never retried on this connection regardless of outcome — a
+    /// failure here is swallowed rather than tearing down an otherwise
+    /// usable connection.
+    fn maybeIssueSessionTicket(self: *NativeTlsConnection) void {
+        if (self.ticket_issue_attempted) return;
+        const runtime = self.resumption_runtime orelse return;
+        if (self.backend.role != .server) return;
+        if (!self.record.applicationDataOpen()) return;
+        self.ticket_issue_attempted = true;
+        self.issueSessionTicket(runtime) catch {};
+    }
+
+    fn issueSessionTicket(self: *NativeTlsConnection, runtime: *tls.resumption_runtime.Runtime) !void {
+        const now_unix_ms = runtime.nowUnixMs();
+        const crypto_provider = self.crypto_provider_state.cryptoProvider();
+
+        var ticket_nonce: [8]u8 = undefined;
+        try crypto_provider.randomBytes(&ticket_nonce);
+        var age_add_bytes: [4]u8 = undefined;
+        try crypto_provider.randomBytes(&age_add_bytes);
+        const ticket_age_add = std.mem.readInt(u32, &age_add_bytes, .big);
+
+        const limits = runtime.config.session_limits;
+        var prepared = try self.backend.prepareNewSessionTicket(self.allocator, .{
+            .ticket_lifetime = runtime.config.ticket_lifetime_seconds,
+            .ticket_age_add = ticket_age_add,
+            .ticket_nonce = &ticket_nonce,
+            .issued_at_unix_ms = now_unix_ms,
+        }, limits);
+        defer prepared.deinit();
+
+        const scratch = try self.allocator.alloc(u8, runtime.maxIdentityLen());
+        defer self.allocator.free(scratch);
+        var identity = try runtime.createIdentity(&prepared.state, now_unix_ms, scratch);
+
+        var sink = tls.tls13_transport.EventSink{};
+        defer sink.deinit();
+        self.backend.emitPreparedNewSessionTicket(self.allocator, &sink, &prepared, identity.slice(), limits) catch |err| {
+            runtime.rollbackIdentity(&identity);
+            return err;
+        };
+
+        for (sink.items[0..sink.len]) |event| switch (event) {
+            .handshake_bytes => |hb| self.record.applyEvent(.{ .handshake_bytes = .{ .epoch = hb.epoch, .data = hb.data } }) catch |err| {
+                runtime.rollbackIdentity(&identity);
+                return err;
+            },
+            else => {},
+        };
     }
 
     pub fn validatedNegotiatedProtocol(self: *NativeTlsConnection) negotiated_dispatch.Error!NegotiatedProtocol {
@@ -442,6 +516,85 @@ test "native TLS createWithOptions applies validated buffer limits" {
     const snapshot = conn.stream().bufferSnapshot();
     try std.testing.expect(snapshot.limits_enforced);
     try std.testing.expectEqual(limits.outbound_ciphertext.high, snapshot.limits.?.outbound_ciphertext.high);
+}
+
+fn fixedNowUnixMs(_: *anyopaque) i64 {
+    return 1000;
+}
+
+fn testResumptionRuntime(allocator: std.mem.Allocator) !tls.resumption_runtime.Runtime {
+    var entropy = production_crypto.OsEntropy{};
+    var provider_state = production_crypto.Provider.init(entropy.entropy());
+    return tls.resumption_runtime.Runtime.init(
+        allocator,
+        .{ .mode = .stateful },
+        .{ .ctx = undefined, .nowUnixMsFn = fixedNowUnixMs },
+        provider_state.cryptoProvider(),
+    );
+}
+
+test "native TLS createWithOptions installs the shared server resolver when configured" {
+    var fixed = credentials.FixedCredentialProvider.init(credentials.testdata.identity());
+    defer fixed.deinit();
+    const fds = try testSocketPair();
+    defer closeFd(fds[1]);
+
+    var runtime = try testResumptionRuntime(std.testing.allocator);
+    defer runtime.deinit();
+
+    const conn = try NativeTlsConnection.createWithOptions(
+        std.testing.allocator,
+        fds[0],
+        .{ .http1_enabled = true, .http2_enabled = true },
+        fixed.provider(),
+        .{ .resumption_runtime = &runtime },
+    );
+    defer conn.destroy();
+
+    try std.testing.expect(conn.backend.psk_resolver != null);
+    try std.testing.expectEqual(@as(?*tls.resumption_runtime.Runtime, &runtime), conn.resumption_runtime);
+}
+
+test "native TLS without a resumption runtime never attempts ticket issuance" {
+    var fixed = credentials.FixedCredentialProvider.init(credentials.testdata.identity());
+    defer fixed.deinit();
+    const fds = try testSocketPair();
+    defer closeFd(fds[1]);
+
+    const conn = try NativeTlsConnection.create(
+        std.testing.allocator,
+        fds[0],
+        .{ .http1_enabled = true, .http2_enabled = true },
+        fixed.provider(),
+    );
+    defer conn.destroy();
+
+    try std.testing.expect(conn.backend.psk_resolver == null);
+    conn.maybeIssueSessionTicket();
+    try std.testing.expect(!conn.ticket_issue_attempted);
+}
+
+test "native TLS never attempts ticket issuance before application data opens" {
+    var fixed = credentials.FixedCredentialProvider.init(credentials.testdata.identity());
+    defer fixed.deinit();
+    const fds = try testSocketPair();
+    defer closeFd(fds[1]);
+
+    var runtime = try testResumptionRuntime(std.testing.allocator);
+    defer runtime.deinit();
+
+    const conn = try NativeTlsConnection.createWithOptions(
+        std.testing.allocator,
+        fds[0],
+        .{ .http1_enabled = true, .http2_enabled = true },
+        fixed.provider(),
+        .{ .resumption_runtime = &runtime },
+    );
+    defer conn.destroy();
+
+    try std.testing.expect(!conn.record.applicationDataOpen());
+    conn.maybeIssueSessionTicket();
+    try std.testing.expect(!conn.ticket_issue_attempted);
 }
 
 test "native TLS negotiated protocol is unavailable before application data opens" {

--- a/src/http/native_tls_connection.zig
+++ b/src/http/native_tls_connection.zig
@@ -158,7 +158,6 @@ pub const NativeTlsConnection = struct {
     /// issuance (successfully or not) — issuance is best-effort and must
     /// never be retried on the same connection (#488).
     ticket_issue_attempted: bool = false,
-    resumption_outcome_recorded: bool = false,
 
     pub fn create(
         allocator: std.mem.Allocator,
@@ -198,11 +197,12 @@ pub const NativeTlsConnection = struct {
                 .transport = .record,
             },
         );
-        backend.setResumeCompatibilityPolicy(.{ .transport = .ignore, .application = .ignore }) catch unreachable;
         // #488: install the process-shared server resolver before the
         // handshake can start — `setServerPskResolver` itself refuses once
         // the backend has left `.idle`.
         if (options.resumption_runtime) |runtime| {
+            backend.setResumeCompatibilityPolicy(.{ .transport = .ignore, .application = .ignore }) catch unreachable;
+            backend.setResumptionDecisionObserver(runtime.backendDecisionObserver(.record)) catch unreachable;
             if (runtime.serverResolver()) |resolver| {
                 backend.setServerPskResolver(resolver) catch unreachable;
             }
@@ -268,19 +268,8 @@ pub const NativeTlsConnection = struct {
 
     pub fn drive(self: *NativeTlsConnection) encrypted_stream.Error!encrypted_stream.DriveResult {
         const result = try self.record.drive();
-        self.maybeRecordResumptionOutcome();
         self.maybeIssueSessionTicket();
         return result;
-    }
-
-    fn maybeRecordResumptionOutcome(self: *NativeTlsConnection) void {
-        if (self.resumption_outcome_recorded) return;
-        const runtime = self.resumption_runtime orelse return;
-        if (!self.record.applicationDataOpen()) return;
-        if (!self.backend.core.psk_authenticated) return;
-        self.resumption_outcome_recorded = true;
-        runtime.observer.resumptionAttempt(.record);
-        runtime.observer.resumptionOutcome(.record, .accepted);
     }
 
     /// #488: best-effort, exactly-once post-handshake ticket issuance. Only

--- a/src/http/native_tls_connection.zig
+++ b/src/http/native_tls_connection.zig
@@ -158,6 +158,7 @@ pub const NativeTlsConnection = struct {
     /// issuance (successfully or not) — issuance is best-effort and must
     /// never be retried on the same connection (#488).
     ticket_issue_attempted: bool = false,
+    resumption_outcome_recorded: bool = false,
 
     pub fn create(
         allocator: std.mem.Allocator,
@@ -197,6 +198,7 @@ pub const NativeTlsConnection = struct {
                 .transport = .record,
             },
         );
+        backend.setResumeCompatibilityPolicy(.{ .transport = .ignore, .application = .ignore }) catch unreachable;
         // #488: install the process-shared server resolver before the
         // handshake can start — `setServerPskResolver` itself refuses once
         // the backend has left `.idle`.
@@ -266,8 +268,19 @@ pub const NativeTlsConnection = struct {
 
     pub fn drive(self: *NativeTlsConnection) encrypted_stream.Error!encrypted_stream.DriveResult {
         const result = try self.record.drive();
+        self.maybeRecordResumptionOutcome();
         self.maybeIssueSessionTicket();
         return result;
+    }
+
+    fn maybeRecordResumptionOutcome(self: *NativeTlsConnection) void {
+        if (self.resumption_outcome_recorded) return;
+        const runtime = self.resumption_runtime orelse return;
+        if (!self.record.applicationDataOpen()) return;
+        if (!self.backend.core.psk_authenticated) return;
+        self.resumption_outcome_recorded = true;
+        runtime.observer.resumptionAttempt(.record);
+        runtime.observer.resumptionOutcome(.record, .accepted);
     }
 
     /// #488: best-effort, exactly-once post-handshake ticket issuance. Only
@@ -281,7 +294,14 @@ pub const NativeTlsConnection = struct {
         if (self.backend.role != .server) return;
         if (!self.record.applicationDataOpen()) return;
         self.ticket_issue_attempted = true;
-        self.issueSessionTicket(runtime) catch {};
+        self.issueSessionTicket(runtime) catch |err| {
+            runtime.observer.ticketIssue(.record, runtime.config.mode, switch (err) {
+                error.StatefulCapacityRefused => .rejected,
+                else => .failed,
+            });
+            return;
+        };
+        runtime.observer.ticketIssue(.record, runtime.config.mode, .success);
     }
 
     fn issueSessionTicket(self: *NativeTlsConnection, runtime: *tls.resumption_runtime.Runtime) !void {
@@ -304,8 +324,12 @@ pub const NativeTlsConnection = struct {
         defer prepared.deinit();
 
         const scratch = try self.allocator.alloc(u8, runtime.maxIdentityLen());
-        defer self.allocator.free(scratch);
+        defer {
+            std.crypto.secureZero(u8, scratch);
+            self.allocator.free(scratch);
+        }
         var identity = try runtime.createIdentity(&prepared.state, now_unix_ms, scratch);
+        defer identity.deinit();
 
         var sink = tls.tls13_transport.EventSink{};
         defer sink.deinit();
@@ -315,7 +339,7 @@ pub const NativeTlsConnection = struct {
         };
 
         for (sink.items[0..sink.len]) |event| switch (event) {
-            .handshake_bytes => |hb| self.record.applyEvent(.{ .handshake_bytes = .{ .epoch = hb.epoch, .data = hb.data } }) catch |err| {
+            .handshake_bytes => |hb| self.record.tryQueuePostHandshake(.{ .handshake_bytes = .{ .epoch = hb.epoch, .data = hb.data } }) catch |err| {
                 runtime.rollbackIdentity(&identity);
                 return err;
             },

--- a/src/http/native_tls_connection.zig
+++ b/src/http/native_tls_connection.zig
@@ -573,6 +573,19 @@ const TicketIssueProbe = struct {
     }
 };
 
+const CacheEventProbe = struct {
+    stored: usize = 0,
+
+    fn observer(self: *CacheEventProbe) tls.session_cache.Observer {
+        return .{ .ctx = self, .onEventFn = onEvent };
+    }
+
+    fn onEvent(ctx: *anyopaque, event: tls.session_cache.CacheEvent) void {
+        const self: *CacheEventProbe = @ptrCast(@alignCast(ctx));
+        if (event == .stored) self.stored += 1;
+    }
+};
+
 test "native TLS createWithOptions installs the shared server resolver when configured" {
     var fixed = credentials.FixedCredentialProvider.init(credentials.testdata.identity());
     defer fixed.deinit();
@@ -647,6 +660,60 @@ test "native TLS failed post-handshake issuance notifies the runtime observer on
 
     conn.maybeIssueSessionTicket();
     try std.testing.expectEqual(@as(usize, 1), probe.count);
+}
+
+test "native TLS post-handshake queue pressure rolls back inserted stateful handle and keeps stream open" {
+    var fixed = credentials.FixedCredentialProvider.init(credentials.testdata.identity());
+    defer fixed.deinit();
+    const fds = try testSocketPair();
+    defer closeFd(fds[1]);
+
+    var runtime = try testResumptionRuntime(std.testing.allocator);
+    defer runtime.deinit();
+    var issue_probe = TicketIssueProbe{};
+    runtime.setObserver(issue_probe.observer());
+    var cache_probe = CacheEventProbe{};
+    runtime.server_cache.?.setObserver(cache_probe.observer());
+
+    const conn = try NativeTlsConnection.createWithOptions(
+        std.testing.allocator,
+        fds[0],
+        .{ .http1_enabled = true, .http2_enabled = true },
+        fixed.provider(),
+        .{ .resumption_runtime = &runtime },
+    );
+    defer conn.destroy();
+
+    const hs_read = [_]u8{0x21} ** 32;
+    const hs_write = [_]u8{0x22} ** 32;
+    const app_read = [_]u8{0x23} ** 32;
+    const app_write = [_]u8{0x24} ** 32;
+    try conn.record.applyEvent(.{ .traffic_secret = .{ .epoch = .handshake, .direction = .read, .data = &hs_read } });
+    try conn.record.applyEvent(.{ .traffic_secret = .{ .epoch = .handshake, .direction = .write, .data = &hs_write } });
+    try conn.record.applyEvent(.{ .traffic_secret = .{ .epoch = .application, .direction = .read, .data = &app_read } });
+    try conn.record.applyEvent(.{ .traffic_secret = .{ .epoch = .application, .direction = .write, .data = &app_write } });
+    try conn.record.applyEvent(.{ .discard_epoch = .initial });
+    try conn.record.applyEvent(.{ .discard_epoch = .handshake });
+    try conn.record.applyEvent(.handshake_complete);
+    conn.backend.core.handshake_lifecycle = .complete;
+    try conn.backend.resumption_master_secret.replace(&([_]u8{0x42} ** tls.tls13_backend.hash_len));
+
+    try std.testing.expectEqual(@as(usize, 0), runtime.server_cache.?.count());
+    conn.record.outbound_ciphertext.len = encrypted_stream.PureZigRecordStream.max_ciphertext_queue - 1;
+    conn.maybeIssueSessionTicket();
+
+    try std.testing.expect(conn.ticket_issue_attempted);
+    try std.testing.expectEqual(@as(usize, 1), cache_probe.stored);
+    try std.testing.expectEqual(@as(usize, 0), runtime.server_cache.?.count());
+    try std.testing.expectEqual(@as(usize, 1), issue_probe.count);
+    try std.testing.expectEqual(tls.resumption_runtime.TicketResult.failed, issue_probe.result);
+    try std.testing.expect(conn.record.lifecycle == .open);
+    try std.testing.expect(conn.record.failed == null);
+
+    conn.record.outbound_ciphertext.len = 0;
+    const written = try conn.record.stream().write("still-open");
+    try std.testing.expectEqual(@as(usize, "still-open".len), written);
+    try std.testing.expect(conn.record.queuedCiphertextLen() > 0);
 }
 
 test "native TLS never attempts ticket issuance before application data opens" {

--- a/src/http/native_tls_connection.zig
+++ b/src/http/native_tls_connection.zig
@@ -546,6 +546,33 @@ fn testResumptionRuntime(allocator: std.mem.Allocator) !tls.resumption_runtime.R
     );
 }
 
+const TicketIssueProbe = struct {
+    count: usize = 0,
+    transport: tls.resumption_runtime.Transport = undefined,
+    mode: tls.resumption_runtime.Mode = undefined,
+    result: tls.resumption_runtime.TicketResult = undefined,
+
+    fn observer(self: *TicketIssueProbe) tls.resumption_runtime.Observer {
+        return .{
+            .ctx = self,
+            .onTicketIssueFn = onTicketIssue,
+        };
+    }
+
+    fn onTicketIssue(
+        ctx: *anyopaque,
+        transport: tls.resumption_runtime.Transport,
+        mode: tls.resumption_runtime.Mode,
+        result: tls.resumption_runtime.TicketResult,
+    ) void {
+        const self: *TicketIssueProbe = @ptrCast(@alignCast(ctx));
+        self.count += 1;
+        self.transport = transport;
+        self.mode = mode;
+        self.result = result;
+    }
+};
+
 test "native TLS createWithOptions installs the shared server resolver when configured" {
     var fixed = credentials.FixedCredentialProvider.init(credentials.testdata.identity());
     defer fixed.deinit();
@@ -585,6 +612,41 @@ test "native TLS without a resumption runtime never attempts ticket issuance" {
     try std.testing.expect(conn.backend.psk_resolver == null);
     conn.maybeIssueSessionTicket();
     try std.testing.expect(!conn.ticket_issue_attempted);
+}
+
+test "native TLS failed post-handshake issuance notifies the runtime observer once" {
+    var fixed = credentials.FixedCredentialProvider.init(credentials.testdata.identity());
+    defer fixed.deinit();
+    const fds = try testSocketPair();
+    defer closeFd(fds[1]);
+
+    var runtime = try testResumptionRuntime(std.testing.allocator);
+    defer runtime.deinit();
+    var probe = TicketIssueProbe{};
+    runtime.setObserver(probe.observer());
+
+    const conn = try NativeTlsConnection.createWithOptions(
+        std.testing.allocator,
+        fds[0],
+        .{ .http1_enabled = true, .http2_enabled = true },
+        fixed.provider(),
+        .{ .resumption_runtime = &runtime },
+    );
+    defer conn.destroy();
+
+    conn.record.lifecycle = .open;
+    conn.record.bridge.handshake_complete = true;
+    runtime.config.ticket_lifetime_seconds = 0;
+
+    conn.maybeIssueSessionTicket();
+    try std.testing.expect(conn.ticket_issue_attempted);
+    try std.testing.expectEqual(@as(usize, 1), probe.count);
+    try std.testing.expectEqual(tls.resumption_runtime.Transport.record, probe.transport);
+    try std.testing.expectEqual(tls.resumption_runtime.Mode.stateful, probe.mode);
+    try std.testing.expectEqual(tls.resumption_runtime.TicketResult.failed, probe.result);
+
+    conn.maybeIssueSessionTicket();
+    try std.testing.expectEqual(@as(usize, 1), probe.count);
 }
 
 test "native TLS never attempts ticket issuance before application data opens" {

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -1411,6 +1411,59 @@ pub const Connection = struct {
         return ticket_state;
     }
 
+    /// #488: install the process-shared server resolver. Must be called
+    /// before the handshake starts, matching the shared engine's own
+    /// precondition — the same contract native TLS-over-TCP uses.
+    pub fn setServerPskResolver(self: *Connection, resolver: tls_core.pre_shared_key.ServerPskResolver) tls_handshake.HandshakeError!void {
+        try self.tls.setServerPskResolver(resolver);
+    }
+
+    /// #488 two-phase issuance, step 1 (QUIC): derives the RMS-bound PSK and
+    /// the exact `ServerRecoverableState` a stateful insertion or stateless
+    /// seal will consume. See `tls_core.tls13_backend.Tls13Backend.prepareNewSessionTicket`.
+    pub fn prepareNewSessionTicket(
+        self: *Connection,
+        allocator: std.mem.Allocator,
+        params: tls_handshake.PrepareNewSessionTicketParams,
+        limits: tls_core.session.Limits,
+    ) tls_handshake.HandshakeError!tls_handshake.PreparedNewSessionTicket {
+        if (self.state_ != .established or self.role != .server) return error.InvalidHandshakeState;
+        limits.validate() catch return error.IllegalParameter;
+        return self.tls.prepareNewSessionTicket(allocator, params, limits);
+    }
+
+    /// #488 two-phase issuance, step 2 (QUIC): queues the `NewSessionTicket`
+    /// carrying `identity` through the same reserved application-CRYPTO path
+    /// as single-phase `emitNewSessionTicket`, so retransmission/ordering
+    /// bookkeeping is never duplicated.
+    pub fn emitPreparedNewSessionTicket(
+        self: *Connection,
+        prepared: *const tls_handshake.PreparedNewSessionTicket,
+        identity: []const u8,
+        limits: tls_core.session.Limits,
+    ) tls_handshake.HandshakeError!void {
+        if (self.state_ != .established or self.role != .server) return error.InvalidHandshakeState;
+        if (identity.len == 0 or identity.len > limits.max_ticket_len) return error.TicketTooLarge;
+        const emit_params: tls_core.new_session_ticket.EmitParams = .{
+            .ticket_lifetime = prepared.ticket_lifetime,
+            .ticket_age_add = prepared.ticket_age_add,
+            .ticket_nonce = prepared.ticketNonce(),
+            .ticket = identity,
+            .max_early_data_size = prepared.max_early_data_size,
+        };
+        const body_len = tls_core.new_session_ticket.encodedLen(emit_params) catch return error.IllegalParameter;
+        const message_len = 4 + body_len;
+        const tx = &self.crypto_tx[2];
+        var reservation = tx.prepareAppend(self.allocator, message_len, max_application_crypto_outstanding) catch return error.HandshakeBufferOverflow;
+        defer reservation.deinit();
+
+        var sink = tls_handshake.EventSink{};
+        defer sink.deinit();
+        try self.tls.emitPreparedNewSessionTicket(self.allocator, &sink, prepared, identity, limits);
+        tx.commitReservation(&reservation);
+        try self.queueApplicationCryptoEventsReserved(&sink, message_len);
+    }
+
     fn queueApplicationCryptoEventsReserved(self: *Connection, sink: *tls_handshake.EventSink, expected_bytes: usize) tls_handshake.HandshakeError!void {
         var appended: usize = 0;
         for (sink.items[0..sink.len]) |event| {
@@ -2756,6 +2809,244 @@ test "driver: server NewSessionTicket uses application CRYPTO retransmission and
     var buf: [16]u8 = undefined;
     const request = try pair.server.readStream(id, &buf);
     try testing.expectEqualStrings("after", buf[0..request.len]);
+}
+
+test "driver: two-phase prepare/emit NewSessionTicket delivers over application CRYPTO" {
+    const CaptureImpl = struct {
+        count: usize = 0,
+        ticket_len: usize = 0,
+
+        fn now(_: *anyopaque) i64 {
+            return 10;
+        }
+
+        fn onTicket(ctx: *anyopaque, ticket: *const tls_core.session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.count += 1;
+            self.ticket_len = ticket.ticket.slice().len;
+        }
+    };
+
+    const allocator = testing.allocator;
+    var capture = CaptureImpl{};
+    var pair = try TestPair.initWithTicketConsumer(allocator, tls_core.session.Limits.default, .{
+        .ctx = &capture,
+        .nowUnixMsFn = CaptureImpl.now,
+        .onTicketFn = CaptureImpl.onTicket,
+    });
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    var prepared = try pair.server.prepareNewSessionTicket(allocator, .{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .issued_at_unix_ms = 10,
+    }, tls_core.session.Limits.default);
+    defer prepared.deinit();
+    try testing.expect(!std.mem.allEqual(u8, prepared.state.common.resumption_psk.slice(), 0));
+
+    try pair.server.emitPreparedNewSessionTicket(&prepared, "two-phase-ticket", tls_core.session.Limits.default);
+
+    var datagram: [2048]u8 = undefined;
+    const dropped = pair.server.pollTransmit(&datagram, pair.now_us) orelse return error.TestExpectedEqual;
+    try testing.expect(dropped.len > 0);
+    const sent = pair.server.sent_records.items[pair.server.sent_records.items.len - 1];
+    try testing.expectEqual(PacketNumberSpace.application, sent.space);
+    try testing.expect(sent.crypto != null);
+    pair.server.requeueRecord(sent);
+
+    try pair.pump();
+    try testing.expectEqual(@as(usize, 1), capture.count);
+    try testing.expectEqual(@as(usize, "two-phase-ticket".len), capture.ticket_len);
+}
+
+test "driver: prepareNewSessionTicket and emitPreparedNewSessionTicket require an established server connection" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+
+    try testing.expectError(error.InvalidHandshakeState, pair.server.prepareNewSessionTicket(allocator, .{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .issued_at_unix_ms = 10,
+    }, tls_core.session.Limits.default));
+
+    try pair.pump();
+    var prepared = try pair.server.prepareNewSessionTicket(allocator, .{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .issued_at_unix_ms = 10,
+    }, tls_core.session.Limits.default);
+    defer prepared.deinit();
+
+    // A client connection can never prepare or emit a ticket.
+    try testing.expectError(error.InvalidHandshakeState, pair.client.prepareNewSessionTicket(allocator, .{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .issued_at_unix_ms = 10,
+    }, tls_core.session.Limits.default));
+    try testing.expectError(error.TicketTooLarge, pair.server.emitPreparedNewSessionTicket(&prepared, "", tls_core.session.Limits.default));
+}
+
+test "#488: resumption_runtime.Runtime drives a genuine resumed QUIC handshake via two-phase issuance" {
+    const resumption_runtime = tls_core.resumption_runtime;
+    const allocator = testing.allocator;
+
+    var server_entropy = tls_core.production_crypto.OsEntropy{};
+    var server_provider = tls_core.production_crypto.Provider.init(server_entropy.entropy());
+    var server_runtime = try resumption_runtime.Runtime.init(
+        allocator,
+        .{ .mode = .stateful },
+        .{ .ctx = undefined, .nowUnixMsFn = struct {
+            fn now(_: *anyopaque) i64 {
+                return 1000;
+            }
+        }.now },
+        server_provider.cryptoProvider(),
+    );
+    defer server_runtime.deinit();
+
+    var client_entropy = tls_core.production_crypto.OsEntropy{};
+    var client_provider = tls_core.production_crypto.Provider.init(client_entropy.entropy());
+    var client_runtime = try resumption_runtime.Runtime.init(
+        allocator,
+        .{ .mode = .stateful },
+        .{ .ctx = undefined, .nowUnixMsFn = struct {
+            fn now(_: *anyopaque) i64 {
+                return 2000;
+            }
+        }.now },
+        client_provider.cryptoProvider(),
+    );
+    defer client_runtime.deinit();
+
+    // Phase 1: a full QUIC handshake. The server issues a ticket through the
+    // #488 two-phase API and the client captures it into its own runtime.
+    const CaptureImpl = struct {
+        runtime: *resumption_runtime.Runtime,
+        stored: tls_core.session_cache.StoreResult = undefined,
+        retained: tls_core.session.ClientTicketState = .{},
+
+        fn now(_: *anyopaque) i64 {
+            return 1000;
+        }
+        fn onTicket(ctx: *anyopaque, ticket: *const tls_core.session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            ticket.cloneInto(testing.allocator, &self.retained) catch unreachable;
+            self.stored = self.runtime.storeClientTicket(ticket);
+        }
+    };
+    var capture = CaptureImpl{ .runtime = &client_runtime };
+    defer capture.retained.deinit();
+    var pair = try TestPair.initWithTicketConsumer(allocator, tls_core.session.Limits.default, .{
+        .ctx = &capture,
+        .nowUnixMsFn = CaptureImpl.now,
+        .onTicketFn = CaptureImpl.onTicket,
+    });
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    var prepared = try pair.server.prepareNewSessionTicket(allocator, .{
+        .ticket_lifetime = 3600,
+        .ticket_age_add = 500,
+        .ticket_nonce = "\x01",
+        .issued_at_unix_ms = 1000,
+    }, tls_core.session.Limits.default);
+    defer prepared.deinit();
+    var scratch: [256]u8 = undefined;
+    var identity = try server_runtime.createIdentity(&prepared.state, 1000, &scratch);
+    try testing.expect(identity == .stateful);
+    try pair.server.emitPreparedNewSessionTicket(&prepared, identity.slice(), tls_core.session.Limits.default);
+    try pair.pump();
+    try testing.expectEqual(tls_core.session_cache.StoreResult.stored, capture.stored);
+
+    // Phase 2: a fresh QUIC connection pair. The client looks its offer up
+    // through the client runtime; the server installs the *same* server
+    // runtime's resolver before the handshake starts — proving the runtime's
+    // cache/resolver composition (not a hand-rolled resolver) drives a real
+    // abbreviated QUIC handshake.
+    // Built from the retained ticket's own fields rather than guessed
+    // constants: QUIC connections carry their negotiated transport
+    // parameters as `transport_compat`, which is part of the origin the
+    // ticket was actually issued under (unlike the plain record profile).
+    const candidate: tls_core.session.CandidateContext = .{
+        .cipher_suite = capture.retained.common.cipher_suite,
+        .server_name = if (capture.retained.common.server_name) |*s| s.slice() else null,
+        .application_protocol = if (capture.retained.common.application_protocol) |*a| a.slice() else null,
+        .auth_binding = capture.retained.common.auth_binding,
+        .transport_compat = if (capture.retained.common.transport_compat) |*snap| .{
+            .format_id = snap.format_id,
+            .format_version = snap.format_version,
+            .bytes = snap.slice(),
+        } else null,
+    };
+    var lookup = client_runtime.lookupClientOffers(candidate);
+    defer lookup.deinit();
+    try testing.expect(lookup == .hit);
+    try testing.expectEqual(@as(usize, 1), lookup.hit.offers.len);
+
+    const resumed = try allocator.create(TestPair);
+    defer allocator.destroy(resumed);
+    resumed.* = .{
+        .client_backend = tls_backend_mod.Tls13Backend.initClient(
+            .{ .hello_random = [_]u8{0xd1} ** 32, .key_share_seed = [_]u8{0x31} ** 32 },
+            .{ .pinned_certificate = tls_backend_mod.testdata.certificate_der },
+        ),
+        .server_backend = tls_backend_mod.Tls13Backend.initServer(
+            .{ .hello_random = [_]u8{0xd2} ** 32, .key_share_seed = [_]u8{0x32} ** 32 },
+            try tls_backend_mod.Identity.initPkcs8(
+                tls_backend_mod.testdata.certificate_der,
+                tls_backend_mod.testdata.private_key_pkcs8_der,
+            ),
+        ),
+    };
+    var clock_dummy: u8 = 0;
+    const ClientClock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 2000;
+        }
+    };
+    try resumed.client_backend.engine.setClientPskOfferLease(&lookup.hit, &clock_dummy, ClientClock.now);
+    try resumed.server_backend.setServerPskResolver(server_runtime.serverResolver().?);
+
+    resumed.client = try Connection.init(allocator, .{
+        .role = .client,
+        .local_cid = &TestPair.client_cid,
+        .original_dcid = &TestPair.odcid,
+        .peer_cid = &TestPair.odcid,
+        .tls = resumed.client_backend.backend(),
+        .now_us = resumed.now_us,
+    });
+    defer resumed.client.deinit();
+    resumed.server = try Connection.init(allocator, .{
+        .role = .server,
+        .local_cid = &TestPair.odcid,
+        .original_dcid = &TestPair.odcid,
+        .peer_cid = &TestPair.client_cid,
+        .tls = resumed.server_backend.backend(),
+        .now_us = resumed.now_us,
+    });
+    defer resumed.server.deinit();
+
+    try resumed.pump();
+
+    try testing.expect(resumed.client.isEstablished());
+    try testing.expect(resumed.server.isEstablished());
+    try testing.expect(resumed.client_backend.engine.core.psk_authenticated);
+    try testing.expect(resumed.server_backend.engine.core.psk_authenticated);
+
+    // The resumed connection is genuinely usable: application data flows.
+    const id = try resumed.client.openStream(.bidi);
+    try testing.expectEqual(@as(usize, 5), try resumed.client.writeStream(id, "hello", true));
+    try resumed.pump();
+    try testing.expectEqual(@as(?StreamId, id), resumed.server.acceptStream());
+    var buf: [16]u8 = undefined;
+    const request = try resumed.server.readStream(id, &buf);
+    try testing.expectEqualStrings("hello", buf[0..request.len]);
 }
 
 test "driver: maximum NewSessionTicket survives real loss reordering PTO and ACK cleanup" {

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -2577,6 +2577,15 @@ const TestPair = struct {
         limits: tls_core.session.Limits,
         consumer: tls_core.tls13_backend.Tls13Backend.SessionTicketConsumer,
     ) !*TestPair {
+        return initWithTicketConsumerAndResumePolicy(allocator, limits, consumer, null);
+    }
+
+    fn initWithTicketConsumerAndResumePolicy(
+        allocator: std.mem.Allocator,
+        limits: tls_core.session.Limits,
+        consumer: tls_core.tls13_backend.Tls13Backend.SessionTicketConsumer,
+        resume_compat: ?tls_core.tls13_backend.Tls13Backend.ResumeCompatibilityPolicy,
+    ) !*TestPair {
         const pair = try allocator.create(TestPair);
         pair.* = .{
             .client_backend = try tls_backend_mod.Tls13Backend.initClientWithAllocator(
@@ -2594,6 +2603,10 @@ const TestPair = struct {
             ),
         };
         errdefer allocator.destroy(pair);
+        if (resume_compat) |policy| {
+            try pair.client_backend.setResumeCompatibilityPolicy(policy);
+            try pair.server_backend.setResumeCompatibilityPolicy(policy);
+        }
         try pair.client_backend.engine.setSessionTicketConsumer(allocator, limits, consumer);
         pair.client = try Connection.init(allocator, .{
             .role = .client,
@@ -2942,11 +2955,15 @@ test "#488: resumption_runtime.Runtime drives a genuine resumed QUIC handshake v
     };
     var capture = CaptureImpl{ .runtime = &client_runtime };
     defer capture.retained.deinit();
-    var pair = try TestPair.initWithTicketConsumer(allocator, tls_core.session.Limits.default, .{
+    const resume_policy: tls_core.tls13_backend.Tls13Backend.ResumeCompatibilityPolicy = .{
+        .transport = .ignore,
+        .application = .ignore,
+    };
+    var pair = try TestPair.initWithTicketConsumerAndResumePolicy(allocator, tls_core.session.Limits.default, .{
         .ctx = &capture,
         .nowUnixMsFn = CaptureImpl.now,
         .onTicketFn = CaptureImpl.onTicket,
-    });
+    }, resume_policy);
     defer pair.deinit(allocator);
     try pair.pump();
 
@@ -2969,20 +2986,17 @@ test "#488: resumption_runtime.Runtime drives a genuine resumed QUIC handshake v
     // runtime's resolver before the handshake starts — proving the runtime's
     // cache/resolver composition (not a hand-rolled resolver) drives a real
     // abbreviated QUIC handshake.
-    // Built from the retained ticket's own fields rather than guessed
-    // constants: QUIC connections carry their negotiated transport
-    // parameters as `transport_compat`, which is part of the origin the
-    // ticket was actually issued under (unlike the plain record profile).
+    // Native QUIC 1-RTT resumption deliberately ignores connection-specific
+    // transport/application snapshots. Do not feed the old ticket snapshot
+    // back as the current candidate; doing so would only prove exact-match
+    // behavior and would mask valid reconnects with changed transport params.
     const candidate: tls_core.session.CandidateContext = .{
         .cipher_suite = capture.retained.common.cipher_suite,
         .server_name = if (capture.retained.common.server_name) |*s| s.slice() else null,
         .application_protocol = if (capture.retained.common.application_protocol) |*a| a.slice() else null,
         .auth_binding = capture.retained.common.auth_binding,
-        .transport_compat = if (capture.retained.common.transport_compat) |*snap| .{
-            .format_id = snap.format_id,
-            .format_version = snap.format_version,
-            .bytes = snap.slice(),
-        } else null,
+        .transport_compat = null,
+        .application_compat = null,
     };
     var lookup = client_runtime.lookupClientOffers(candidate);
     defer lookup.deinit();
@@ -3011,7 +3025,9 @@ test "#488: resumption_runtime.Runtime drives a genuine resumed QUIC handshake v
         }
     };
     try resumed.client_backend.engine.setClientPskOfferLease(&lookup.hit, &clock_dummy, ClientClock.now);
+    try resumed.client_backend.setResumeCompatibilityPolicy(resume_policy);
     try resumed.server_backend.setServerPskResolver(server_runtime.serverResolver().?);
+    try resumed.server_backend.setResumeCompatibilityPolicy(resume_policy);
 
     resumed.client = try Connection.init(allocator, .{
         .role = .client,

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -206,15 +206,13 @@ pub const Tls13Backend = struct {
     }
 
     pub fn initClientWithOptions(entropy: Entropy, trust: Trust, options: ClientOptions) Tls13Backend {
-        var self = Tls13Backend{ .engine = shared.Tls13Backend.initClientConfigured(entropy, trust, .{
+        return .{ .engine = shared.Tls13Backend.initClientConfigured(entropy, trust, .{
             .policy = tls_core.policy.Policy.quicDefault(),
             .transport = .{ .extension = .{
                 .extension_type = ext_quic_transport_parameters,
                 .local = "",
             } },
         }, options) };
-        self.engine.setResumeCompatibilityPolicy(.{ .transport = .ignore, .application = .ignore }) catch unreachable;
-        return self;
     }
 
     pub fn initClientWithAllocator(allocator: std.mem.Allocator, entropy: Entropy, trust: Trust) HandshakeError!Tls13Backend {
@@ -229,15 +227,13 @@ pub const Tls13Backend = struct {
     }
 
     pub fn initServer(entropy: Entropy, identity: Identity) Tls13Backend {
-        var self = Tls13Backend{ .engine = shared.Tls13Backend.initServerConfigured(entropy, identity, .{
+        return .{ .engine = shared.Tls13Backend.initServerConfigured(entropy, identity, .{
             .policy = tls_core.policy.Policy.quicDefault(),
             .transport = .{ .extension = .{
                 .extension_type = ext_quic_transport_parameters,
                 .local = "",
             } },
         }) };
-        self.engine.setResumeCompatibilityPolicy(.{ .transport = .ignore, .application = .ignore }) catch unreachable;
-        return self;
     }
 
     pub fn initServerWithAllocator(allocator: std.mem.Allocator, entropy: Entropy, identity: Identity) Tls13Backend {
@@ -247,15 +243,13 @@ pub const Tls13Backend = struct {
     }
 
     pub fn initServerWithProvider(entropy: Entropy, provider: CredentialProvider) Tls13Backend {
-        var self = Tls13Backend{ .engine = shared.Tls13Backend.initServerWithProviderConfigured(entropy, provider, .{
+        return .{ .engine = shared.Tls13Backend.initServerWithProviderConfigured(entropy, provider, .{
             .policy = tls_core.policy.Policy.quicDefault(),
             .transport = .{ .extension = .{
                 .extension_type = ext_quic_transport_parameters,
                 .local = "",
             } },
         }) };
-        self.engine.setResumeCompatibilityPolicy(.{ .transport = .ignore, .application = .ignore }) catch unreachable;
-        return self;
     }
 
     pub fn initServerWithAllocatorAndProvider(allocator: std.mem.Allocator, entropy: Entropy, provider: CredentialProvider) Tls13Backend {
@@ -353,6 +347,14 @@ pub const Tls13Backend = struct {
     /// arms the responder), matching the shared engine's own precondition.
     pub fn setServerPskResolver(self: *Tls13Backend, resolver: tls_core.pre_shared_key.ServerPskResolver) HandshakeError!void {
         self.engine.setServerPskResolver(resolver) catch |err| return mapError(err);
+    }
+
+    pub fn setResumeCompatibilityPolicy(self: *Tls13Backend, policy: shared.Tls13Backend.ResumeCompatibilityPolicy) HandshakeError!void {
+        self.engine.setResumeCompatibilityPolicy(policy) catch |err| return mapError(err);
+    }
+
+    pub fn setResumptionDecisionObserver(self: *Tls13Backend, observer: shared.Tls13Backend.ResumptionDecisionObserver) HandshakeError!void {
+        self.engine.setResumptionDecisionObserver(observer) catch |err| return mapError(err);
     }
 
     fn setServerPskResolverVtable(ptr: *anyopaque, resolver: tls_core.pre_shared_key.ServerPskResolver) HandshakeError!void {

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -275,6 +275,9 @@ pub const Tls13Backend = struct {
             .peerCidBindingFn = peerCidBinding,
             .setPostHandshakeAllocatorFn = setPostHandshakeAllocator,
             .emitNewSessionTicketFn = emitNewSessionTicket,
+            .setServerPskResolverFn = setServerPskResolverVtable,
+            .prepareNewSessionTicketFn = prepareNewSessionTicket,
+            .emitPreparedNewSessionTicketFn = emitPreparedNewSessionTicket,
         };
     }
 
@@ -336,6 +339,43 @@ pub const Tls13Backend = struct {
         errdefer state.deinit();
         try translate(self.allocator, &self.scratch, sink);
         return state;
+    }
+
+    /// #488: forwarding seam only — resolver selection, binder verification,
+    /// and the PSK+DHE key schedule all stay in the shared engine. Must be
+    /// called before the handshake starts (before `Connection.init`, which
+    /// arms the responder), matching the shared engine's own precondition.
+    pub fn setServerPskResolver(self: *Tls13Backend, resolver: tls_core.pre_shared_key.ServerPskResolver) HandshakeError!void {
+        self.engine.setServerPskResolver(resolver) catch |err| return mapError(err);
+    }
+
+    fn setServerPskResolverVtable(ptr: *anyopaque, resolver: tls_core.pre_shared_key.ServerPskResolver) HandshakeError!void {
+        const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
+        try self.setServerPskResolver(resolver);
+    }
+
+    fn prepareNewSessionTicket(
+        ptr: *anyopaque,
+        allocator: std.mem.Allocator,
+        params: tls_handshake.PrepareNewSessionTicketParams,
+        limits: tls_core.session.Limits,
+    ) HandshakeError!tls_handshake.PreparedNewSessionTicket {
+        const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
+        return self.engine.prepareNewSessionTicket(allocator, params, limits) catch |err| return mapError(err);
+    }
+
+    fn emitPreparedNewSessionTicket(
+        ptr: *anyopaque,
+        allocator: std.mem.Allocator,
+        sink: *EventSink,
+        prepared: *const tls_handshake.PreparedNewSessionTicket,
+        identity: []const u8,
+        limits: tls_core.session.Limits,
+    ) HandshakeError!void {
+        const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
+        self.scratch.reset();
+        self.engine.emitPreparedNewSessionTicket(allocator, &self.scratch, prepared, identity, limits) catch |err| return mapError(err);
+        try translate(self.allocator, &self.scratch, sink);
     }
 
     fn start(ptr: *anyopaque, role: tls_handshake.Role, params: config.TransportParameters, sink: *EventSink) HandshakeError!void {

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -206,13 +206,15 @@ pub const Tls13Backend = struct {
     }
 
     pub fn initClientWithOptions(entropy: Entropy, trust: Trust, options: ClientOptions) Tls13Backend {
-        return .{ .engine = shared.Tls13Backend.initClientConfigured(entropy, trust, .{
+        var self = Tls13Backend{ .engine = shared.Tls13Backend.initClientConfigured(entropy, trust, .{
             .policy = tls_core.policy.Policy.quicDefault(),
             .transport = .{ .extension = .{
                 .extension_type = ext_quic_transport_parameters,
                 .local = "",
             } },
         }, options) };
+        self.engine.setResumeCompatibilityPolicy(.{ .transport = .ignore, .application = .ignore }) catch unreachable;
+        return self;
     }
 
     pub fn initClientWithAllocator(allocator: std.mem.Allocator, entropy: Entropy, trust: Trust) HandshakeError!Tls13Backend {
@@ -227,13 +229,15 @@ pub const Tls13Backend = struct {
     }
 
     pub fn initServer(entropy: Entropy, identity: Identity) Tls13Backend {
-        return .{ .engine = shared.Tls13Backend.initServerConfigured(entropy, identity, .{
+        var self = Tls13Backend{ .engine = shared.Tls13Backend.initServerConfigured(entropy, identity, .{
             .policy = tls_core.policy.Policy.quicDefault(),
             .transport = .{ .extension = .{
                 .extension_type = ext_quic_transport_parameters,
                 .local = "",
             } },
         }) };
+        self.engine.setResumeCompatibilityPolicy(.{ .transport = .ignore, .application = .ignore }) catch unreachable;
+        return self;
     }
 
     pub fn initServerWithAllocator(allocator: std.mem.Allocator, entropy: Entropy, identity: Identity) Tls13Backend {
@@ -243,13 +247,15 @@ pub const Tls13Backend = struct {
     }
 
     pub fn initServerWithProvider(entropy: Entropy, provider: CredentialProvider) Tls13Backend {
-        return .{ .engine = shared.Tls13Backend.initServerWithProviderConfigured(entropy, provider, .{
+        var self = Tls13Backend{ .engine = shared.Tls13Backend.initServerWithProviderConfigured(entropy, provider, .{
             .policy = tls_core.policy.Policy.quicDefault(),
             .transport = .{ .extension = .{
                 .extension_type = ext_quic_transport_parameters,
                 .local = "",
             } },
         }) };
+        self.engine.setResumeCompatibilityPolicy(.{ .transport = .ignore, .application = .ignore }) catch unreachable;
+        return self;
     }
 
     pub fn initServerWithAllocatorAndProvider(allocator: std.mem.Allocator, entropy: Entropy, provider: CredentialProvider) Tls13Backend {

--- a/src/quic/tls_handshake.zig
+++ b/src/quic/tls_handshake.zig
@@ -56,6 +56,8 @@ pub const EventSink = TransportContract.EventSink;
 pub const TlsTransportBackend = TransportContract.Backend;
 pub const CoreDriver = tls_core.engine.Driver(TransportContract);
 pub const EmitNewSessionTicketParams = tls_core.tls13_backend.Tls13Backend.EmitNewSessionTicketParams;
+pub const PrepareNewSessionTicketParams = tls_core.tls13_backend.Tls13Backend.PrepareNewSessionTicketParams;
+pub const PreparedNewSessionTicket = tls_core.tls13_backend.Tls13Backend.PreparedNewSessionTicket;
 
 /// Runtime interface to a concrete TLS 1.3 engine. The engine consumes and
 /// produces raw handshake bytes and reports keying material / negotiation
@@ -77,6 +79,27 @@ pub const TlsBackend = struct {
         params: EmitNewSessionTicketParams,
         limits: tls_core.session.Limits,
     ) HandshakeError!tls_core.session.ServerRecoverableState = null,
+    /// #488: install the process-shared server resolver before `start`. QUIC
+    /// mirrors the record-mode contract exactly — no duplicate PSK parsing,
+    /// binder verification, or key schedule lives here or in `Connection`.
+    setServerPskResolverFn: ?*const fn (
+        ptr: *anyopaque,
+        resolver: tls_core.pre_shared_key.ServerPskResolver,
+    ) HandshakeError!void = null,
+    prepareNewSessionTicketFn: ?*const fn (
+        ptr: *anyopaque,
+        allocator: std.mem.Allocator,
+        params: PrepareNewSessionTicketParams,
+        limits: tls_core.session.Limits,
+    ) HandshakeError!PreparedNewSessionTicket = null,
+    emitPreparedNewSessionTicketFn: ?*const fn (
+        ptr: *anyopaque,
+        allocator: std.mem.Allocator,
+        sink: *EventSink,
+        prepared: *const PreparedNewSessionTicket,
+        identity: []const u8,
+        limits: tls_core.session.Limits,
+    ) HandshakeError!void = null,
 
     fn start(self: TlsBackend, role: Role, params: config.TransportParameters, sink: *EventSink) HandshakeError!void {
         return self.transport.start(role, params, sink);
@@ -108,6 +131,36 @@ pub const TlsBackend = struct {
     ) HandshakeError!tls_core.session.ServerRecoverableState {
         const emit = self.emitNewSessionTicketFn orelse return error.InvalidHandshakeState;
         return emit(self.transport.ptr, allocator, sink, params, limits);
+    }
+
+    /// Must be called before `start`, matching the shared engine's own
+    /// precondition (#488): a backend without this hook (e.g. the in-memory
+    /// test backend) never offers or accepts PSK resumption.
+    pub fn setServerPskResolver(self: TlsBackend, resolver: tls_core.pre_shared_key.ServerPskResolver) HandshakeError!void {
+        const set = self.setServerPskResolverFn orelse return error.InvalidHandshakeState;
+        try set(self.transport.ptr, resolver);
+    }
+
+    pub fn prepareNewSessionTicket(
+        self: TlsBackend,
+        allocator: std.mem.Allocator,
+        params: PrepareNewSessionTicketParams,
+        limits: tls_core.session.Limits,
+    ) HandshakeError!PreparedNewSessionTicket {
+        const prepare = self.prepareNewSessionTicketFn orelse return error.InvalidHandshakeState;
+        return prepare(self.transport.ptr, allocator, params, limits);
+    }
+
+    pub fn emitPreparedNewSessionTicket(
+        self: TlsBackend,
+        allocator: std.mem.Allocator,
+        sink: *EventSink,
+        prepared: *const PreparedNewSessionTicket,
+        identity: []const u8,
+        limits: tls_core.session.Limits,
+    ) HandshakeError!void {
+        const emit = self.emitPreparedNewSessionTicketFn orelse return error.InvalidHandshakeState;
+        return emit(self.transport.ptr, allocator, sink, prepared, identity, limits);
     }
 
     pub fn deinit(self: TlsBackend) void {

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -826,6 +826,28 @@ pub const PureZigRecordStream = struct {
         if (event == .handshake_complete) self.lifecycle = .open;
     }
 
+    /// Best-effort established-connection post-handshake queueing. Unlike
+    /// `applyEvent`, queue or sealing failure is reported to the caller without
+    /// calling `fail()` and without closing an otherwise usable connection.
+    pub fn tryQueuePostHandshake(self: *PureZigRecordStream, event: events.Event) Error!void {
+        if (self.failed) |err| return err;
+        if (self.lifecycle == .closed or self.lifecycle == .failed or self.lifecycle == .closing) return error.StreamClosed;
+        if (!self.applicationDataOpen()) return error.HandshakeNotComplete;
+        if (event != .handshake_bytes or event.handshake_bytes.epoch != .application) return error.InvalidHandshakeState;
+        const needed = try self.bridge.sealedHandshakeLen(event.handshake_bytes.epoch, event.handshake_bytes.data.len);
+        if (!self.hasHardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, needed)) return self.rejectHardLimit(.outbound_ciphertext, error.WouldBlock);
+        if (self.outbound_ciphertext.available() < needed) return error.WouldBlock;
+
+        var offset: usize = 0;
+        while (offset < event.handshake_bytes.data.len) {
+            const take = @min(record_codec.max_plaintext_fragment_len, event.handshake_bytes.data.len - offset);
+            var record_buf: [record_codec.max_ciphertext_record_len]u8 = undefined;
+            const record = try self.bridge.sealHandshake(.application, event.handshake_bytes.data[offset..][0..take], &record_buf);
+            try self.appendOutboundCiphertext(record);
+            offset += take;
+        }
+    }
+
     /// The record-layer side effects of an epoch discard, shared by the manual
     /// `applyEvent` path and the driver-owned path (`applyDriverOutcome`).
     fn applyDiscardSideEffects(self: *PureZigRecordStream, epoch: events.EncryptionEpoch) Error!void {

--- a/src/tls/new_session_ticket.zig
+++ b/src/tls/new_session_ticket.zig
@@ -190,18 +190,37 @@ pub fn buildClientTicketState(
     return state;
 }
 
-pub fn buildServerRecoverableState(
+/// Ticket-identity-free subset of `EmitParams` for #488's two-phase
+/// preparation: the opaque bearer identity (stateful handle or stateless
+/// envelope) is only known *after* `ServerRecoverableState` is derived
+/// (stateful issuance derives the handle from inserting the state itself;
+/// stateless issuance seals the state to produce it), so preparation cannot
+/// require it up front the way single-phase `buildServerRecoverableState`
+/// does.
+pub const PrepareParams = struct {
+    ticket_lifetime: u32,
+    ticket_age_add: u32,
+    ticket_nonce: []const u8,
+    max_early_data_size: ?u32 = null,
+};
+
+/// Derives the per-ticket PSK and builds the exact `ServerRecoverableState`
+/// a later stateful insertion or stateless seal will consume, without
+/// requiring the opaque bearer identity that only exists once one of those
+/// two issuance paths has run. Callers that already know the final identity
+/// should use `buildServerRecoverableState` instead.
+pub fn buildServerRecoverableStateNoIdentity(
     allocator: std.mem.Allocator,
-    params: EmitParams,
+    params: PrepareParams,
     connection: ConnectionResumptionContext,
     resumption_master_secret: []const u8,
     issued_at_unix_ms: i64,
     limits: session.Limits,
 ) BuildServerError!session.ServerRecoverableState {
     try limits.validate();
-    validateEmitParams(params) catch return error.IllegalParameter;
+    if (params.ticket_lifetime > max_lifetime_seconds) return error.IllegalParameter;
+    if (params.ticket_nonce.len > max_ticket_nonce_len) return error.IllegalParameter;
     if (params.ticket_lifetime == 0) return error.InvalidLifetime;
-    if (params.ticket.len == 0 or params.ticket.len > limits.max_ticket_len) return error.TicketTooLarge;
     const hash = algorithms.transcriptHash(connection.cipher_suite);
     var psk: [session.max_psk_len]u8 = undefined;
     defer crypto.secureZero(u8, &psk);
@@ -230,6 +249,24 @@ pub fn buildServerRecoverableState(
     var state: session.ServerRecoverableState = .{};
     state.init(&common, params.ticket_age_add);
     return state;
+}
+
+pub fn buildServerRecoverableState(
+    allocator: std.mem.Allocator,
+    params: EmitParams,
+    connection: ConnectionResumptionContext,
+    resumption_master_secret: []const u8,
+    issued_at_unix_ms: i64,
+    limits: session.Limits,
+) BuildServerError!session.ServerRecoverableState {
+    validateEmitParams(params) catch return error.IllegalParameter;
+    if (params.ticket.len == 0 or params.ticket.len > limits.max_ticket_len) return error.TicketTooLarge;
+    return buildServerRecoverableStateNoIdentity(allocator, .{
+        .ticket_lifetime = params.ticket_lifetime,
+        .ticket_age_add = params.ticket_age_add,
+        .ticket_nonce = params.ticket_nonce,
+        .max_early_data_size = params.max_early_data_size,
+    }, connection, resumption_master_secret, issued_at_unix_ms, limits);
 }
 
 fn earlyDataPolicy(max_early_data_size: ?u32) session.EarlyDataPolicy {

--- a/src/tls/resumption_runtime.zig
+++ b/src/tls/resumption_runtime.zig
@@ -128,6 +128,118 @@ pub const Runtime = struct {
         return .rejected_capacity;
     }
 
+    /// Safe upper bound on the wire length of an identity this runtime can
+    /// produce (stateful handle or stateless envelope), for callers that
+    /// need to size a scratch buffer before `createIdentity`. `0` while
+    /// disabled.
+    pub fn maxIdentityLen(self: *const Runtime) usize {
+        var max: usize = 0;
+        if (self.config.mode == .stateful or self.config.mode == .hybrid)
+            max = @max(max, session_cache.stateful_identity_len);
+        if (self.config.mode == .stateless or self.config.mode == .hybrid)
+            max = @max(max, @min(
+                self.config.session_limits.max_serialized_len + ticket_protection.envelope_overhead,
+                self.config.session_limits.max_ticket_len,
+            ));
+        return max;
+    }
+
+    pub const IdentityMode = enum { stateful, stateless };
+
+    /// The opaque bearer identity produced by `createIdentity`. `stateless`
+    /// borrows the caller-supplied `scratch` buffer passed to
+    /// `createIdentity`; `stateful` owns its bytes inline. Either way,
+    /// `slice()` stays valid exactly as long as the `Identity` value (and,
+    /// for `stateless`, its backing `scratch` buffer) does.
+    pub const Identity = union(IdentityMode) {
+        stateful: [session_cache.stateful_identity_len]u8,
+        stateless: struct { buf: []u8, len: usize },
+
+        pub fn slice(self: *const Identity) []const u8 {
+            return switch (self.*) {
+                .stateful => |*handle| handle[0..],
+                .stateless => |s| s.buf[0..s.len],
+            };
+        }
+    };
+
+    pub const CreateIdentityError = error{ StorageUnavailable, SealFailed };
+
+    /// Consumes `state` — the exact prepared `ServerRecoverableState` from
+    /// `Tls13Backend.prepareNewSessionTicket` — into this runtime's
+    /// configured issuance storage and returns the resulting bearer
+    /// identity. Stateful mode moves `state` into the server cache
+    /// (`state.*` becomes zero-valued on success, so the caller's later
+    /// unconditional `deinit` is then a no-op); stateless mode only reads
+    /// `state` to seal it into `scratch` and leaves it fully owned by the
+    /// caller either way. Hybrid prefers stateful issuance and falls back
+    /// to stateless only for ordinary stateful capacity/storage refusal —
+    /// never for a hard internal error.
+    ///
+    /// On any failure, `state.*` is left completely unchanged (never
+    /// partially consumed), and no identity is left resolvable: the caller
+    /// need not roll anything back.
+    pub fn createIdentity(
+        self: *Runtime,
+        state: *session.ServerRecoverableState,
+        now_unix_ms: i64,
+        scratch: []u8,
+    ) CreateIdentityError!Identity {
+        return switch (self.config.mode) {
+            .disabled => error.StorageUnavailable,
+            .stateful => self.createStatefulIdentity(state, now_unix_ms),
+            .stateless => self.createStatelessIdentity(state, now_unix_ms, scratch),
+            .hybrid => self.createStatefulIdentity(state, now_unix_ms) catch |err| switch (err) {
+                error.StorageUnavailable => self.createStatelessIdentity(state, now_unix_ms, scratch),
+                error.SealFailed => err,
+            },
+        };
+    }
+
+    fn createStatefulIdentity(
+        self: *Runtime,
+        state: *session.ServerRecoverableState,
+        now_unix_ms: i64,
+    ) CreateIdentityError!Identity {
+        const cache = if (self.server_cache) |*cache| cache else return error.StorageUnavailable;
+        var handle: [session_cache.stateful_identity_len]u8 = undefined;
+        const result = cache.insertMove(state, now_unix_ms, usagePolicy(self.config.usage), &handle);
+        return switch (result) {
+            .stored => .{ .stateful = handle },
+            .rejected_capacity, .storage_failed, .rejected_handle_generation_failed => error.StorageUnavailable,
+            .replaced, .rejected_unsupported_usage => unreachable,
+        };
+    }
+
+    fn createStatelessIdentity(
+        self: *Runtime,
+        state: *const session.ServerRecoverableState,
+        now_unix_ms: i64,
+        scratch: []u8,
+    ) CreateIdentityError!Identity {
+        const keyring = if (self.keyring) |*keyring| keyring else return error.StorageUnavailable;
+        var protector = ticket_protection.Protector{
+            .provider = self.provider,
+            .keyring = keyring,
+            .limits = self.config.session_limits,
+        };
+        const sealed = protector.seal(self.allocator, state, now_unix_ms, scratch) catch return error.SealFailed;
+        return .{ .stateless = .{ .buf = scratch, .len = sealed.len } };
+    }
+
+    /// Rolls back an identity `createIdentity` produced but that never
+    /// actually reached the peer (e.g. `NewSessionTicket` emission or
+    /// queueing failed afterward): revokes a stateful handle from storage
+    /// so it can never be offered back; a no-op for a stateless envelope
+    /// (nothing was stored — the caller's own `scratch`/message buffers are
+    /// the only copies, and wiping those remains the caller's concern).
+    pub fn rollbackIdentity(self: *Runtime, identity: *const Identity) void {
+        switch (identity.*) {
+            .stateful => |*handle| if (self.server_cache) |*cache| cache.revokeHandle(handle),
+            .stateless => {},
+        }
+    }
+
     fn resolverNow(ctx: *anyopaque) i64 {
         const self: *Runtime = @ptrCast(@alignCast(ctx));
         return self.nowUnixMs();
@@ -533,4 +645,153 @@ test "stateless runtime initialization fails without AES-128-GCM capability" {
         clock.clock(),
         unsupported.cryptoProvider(),
     ));
+}
+
+test "createIdentity stateful issues a resolvable handle and consumes state" {
+    var clock = TestClock{};
+    var entropy_ctx = TestEntropy{};
+    var provider_impl = crypto.pure_zig.Provider.init(entropy_ctx.entropy());
+    var runtime = try Runtime.init(
+        std.testing.allocator,
+        .{ .mode = .stateful },
+        clock.clock(),
+        provider_impl.cryptoProvider(),
+    );
+    defer runtime.deinit();
+
+    var state = try sampleServerState(std.testing.allocator, "createidentity.test");
+    var identity = try runtime.createIdentity(&state, clock.now_ms, &.{});
+    // Successful stateful issuance moves `state` away; the caller's later
+    // unconditional `deinit` must be a safe no-op rather than a double-free.
+    state.deinit();
+
+    const resolver = runtime.serverResolver().?;
+    var hit = try resolver.resolve(identity.slice());
+    defer hit.deinit();
+    try std.testing.expect(hit == .hit);
+    try std.testing.expectEqualStrings("createidentity.test", hit.hit.state.common.server_name.?.slice());
+}
+
+test "createIdentity stateless seals into caller scratch and does not consume state" {
+    var clock = TestClock{};
+    var entropy_ctx = TestEntropy{};
+    var provider_impl = crypto.pure_zig.Provider.init(entropy_ctx.entropy());
+    var runtime = try Runtime.init(
+        std.testing.allocator,
+        .{ .mode = .stateless },
+        clock.clock(),
+        provider_impl.cryptoProvider(),
+    );
+    defer runtime.deinit();
+
+    var state = try sampleServerState(std.testing.allocator, "stateless-identity.test");
+    defer state.deinit();
+    var scratch: [1024]u8 = undefined;
+    var identity = try runtime.createIdentity(&state, clock.now_ms, &scratch);
+
+    // Stateless issuance only reads `state` to seal it: it must remain
+    // fully owned (and independently deinit-able) by the caller.
+    try std.testing.expect(!std.mem.allEqual(u8, state.common.resumption_psk.slice(), 0));
+
+    const resolver = runtime.serverResolver().?;
+    var hit = try resolver.resolve(identity.slice());
+    defer hit.deinit();
+    try std.testing.expect(hit == .hit);
+}
+
+test "createIdentity hybrid falls back to stateless on ordinary stateful capacity refusal" {
+    var clock = TestClock{};
+    var entropy_ctx = TestEntropy{};
+    var provider_impl = crypto.pure_zig.Provider.init(entropy_ctx.entropy());
+    var runtime = try Runtime.init(
+        std.testing.allocator,
+        .{ .mode = .hybrid, .server_cache_limits = .{
+            .max_entries = 4,
+            .max_origins = 4,
+            .max_entries_per_origin = 4,
+            .max_entry_bytes = 1,
+            .max_total_bytes = 1024,
+        } },
+        clock.clock(),
+        provider_impl.cryptoProvider(),
+    );
+    defer runtime.deinit();
+
+    var state = try sampleServerState(std.testing.allocator, "hybrid-fallback.test");
+    defer state.deinit();
+    var scratch: [1024]u8 = undefined;
+    var identity = try runtime.createIdentity(&state, clock.now_ms, &scratch);
+    try std.testing.expect(identity == .stateless);
+
+    const resolver = runtime.serverResolver().?;
+    var hit = try resolver.resolve(identity.slice());
+    defer hit.deinit();
+    try std.testing.expect(hit == .hit);
+}
+
+test "rollbackIdentity revokes a stateful handle so it no longer resolves" {
+    var clock = TestClock{};
+    var entropy_ctx = TestEntropy{};
+    var provider_impl = crypto.pure_zig.Provider.init(entropy_ctx.entropy());
+    var runtime = try Runtime.init(
+        std.testing.allocator,
+        .{ .mode = .stateful },
+        clock.clock(),
+        provider_impl.cryptoProvider(),
+    );
+    defer runtime.deinit();
+
+    var state = try sampleServerState(std.testing.allocator, "rollback.test");
+    var identity = try runtime.createIdentity(&state, clock.now_ms, &.{});
+    state.deinit();
+
+    runtime.rollbackIdentity(&identity);
+
+    const resolver = runtime.serverResolver().?;
+    var miss = try resolver.resolve(identity.slice());
+    defer miss.deinit();
+    try std.testing.expect(miss == .miss);
+}
+
+test "rollbackIdentity is a no-op for a stateless envelope" {
+    var clock = TestClock{};
+    var entropy_ctx = TestEntropy{};
+    var provider_impl = crypto.pure_zig.Provider.init(entropy_ctx.entropy());
+    var runtime = try Runtime.init(
+        std.testing.allocator,
+        .{ .mode = .stateless },
+        clock.clock(),
+        provider_impl.cryptoProvider(),
+    );
+    defer runtime.deinit();
+
+    var state = try sampleServerState(std.testing.allocator, "stateless-rollback.test");
+    defer state.deinit();
+    var scratch: [1024]u8 = undefined;
+    var identity = try runtime.createIdentity(&state, clock.now_ms, &scratch);
+    runtime.rollbackIdentity(&identity);
+
+    // Stateless issuance never stored anything server-side, so the exact
+    // same envelope must still resolve after "rollback".
+    const resolver = runtime.serverResolver().?;
+    var hit = try resolver.resolve(identity.slice());
+    defer hit.deinit();
+    try std.testing.expect(hit == .hit);
+}
+
+test "createIdentity disabled runtime always reports storage unavailable" {
+    var clock = TestClock{};
+    var entropy_ctx = TestEntropy{};
+    var provider_impl = crypto.pure_zig.Provider.init(entropy_ctx.entropy());
+    var runtime = try Runtime.init(
+        std.testing.allocator,
+        .{},
+        clock.clock(),
+        provider_impl.cryptoProvider(),
+    );
+    defer runtime.deinit();
+
+    var state = try sampleServerState(std.testing.allocator, "disabled.test");
+    defer state.deinit();
+    try std.testing.expectError(error.StorageUnavailable, runtime.createIdentity(&state, clock.now_ms, &.{}));
 }

--- a/src/tls/resumption_runtime.zig
+++ b/src/tls/resumption_runtime.zig
@@ -18,6 +18,40 @@ const provider = crypto.provider;
 
 pub const Mode = enum { disabled, stateful, stateless, hybrid };
 pub const TicketUsage = enum { reusable, single_use };
+pub const Transport = enum { record, quic };
+pub const TicketResult = enum { success, rejected, failed };
+pub const ResumptionOutcome = enum { accepted, full_handshake, fatal };
+
+pub const Observer = struct {
+    ctx: *anyopaque = @ptrCast(@constCast(&empty_observer_dummy)),
+    onTicketIssueFn: ?*const fn (*anyopaque, Transport, Mode, TicketResult) void = null,
+    onTicketStoreFn: ?*const fn (*anyopaque, TicketResult) void = null,
+    onTicketResolveFn: ?*const fn (*anyopaque, Mode, TicketResult) void = null,
+    onResumptionAttemptFn: ?*const fn (*anyopaque, Transport) void = null,
+    onResumptionOutcomeFn: ?*const fn (*anyopaque, Transport, ResumptionOutcome) void = null,
+
+    pub fn ticketIssue(self: Observer, transport: Transport, mode: Mode, result: TicketResult) void {
+        if (self.onTicketIssueFn) |f| f(self.ctx, transport, mode, result);
+    }
+
+    pub fn ticketStore(self: Observer, result: TicketResult) void {
+        if (self.onTicketStoreFn) |f| f(self.ctx, result);
+    }
+
+    pub fn ticketResolve(self: Observer, mode: Mode, result: TicketResult) void {
+        if (self.onTicketResolveFn) |f| f(self.ctx, mode, result);
+    }
+
+    pub fn resumptionAttempt(self: Observer, transport: Transport) void {
+        if (self.onResumptionAttemptFn) |f| f(self.ctx, transport);
+    }
+
+    pub fn resumptionOutcome(self: Observer, transport: Transport, outcome: ResumptionOutcome) void {
+        if (self.onResumptionOutcomeFn) |f| f(self.ctx, transport, outcome);
+    }
+};
+
+var empty_observer_dummy: u8 = 0;
 
 pub const Clock = struct {
     ctx: *anyopaque,
@@ -58,6 +92,7 @@ pub const Runtime = struct {
     client_cache: ?session_cache.ClientSessionCache = null,
     server_cache: ?session_cache.StatefulServerCache = null,
     keyring: ?ticket_protection.ReloadableKeyRing = null,
+    observer: Observer = .{},
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -123,9 +158,16 @@ pub const Runtime = struct {
     }
 
     pub fn storeClientTicket(self: *Runtime, ticket: *const session.ClientTicketState) session_cache.StoreResult {
-        if (self.client_cache) |*cache|
-            return cache.storeClone(ticket, self.nowUnixMs(), usagePolicy(self.config.usage));
-        return .rejected_capacity;
+        const result = if (self.client_cache) |*cache|
+            cache.storeClone(ticket, self.nowUnixMs(), usagePolicy(self.config.usage))
+        else
+            .rejected_capacity;
+        self.observer.ticketStore(storeResultToTicketResult(result));
+        return result;
+    }
+
+    pub fn setObserver(self: *Runtime, observer: Observer) void {
+        self.observer = observer;
     }
 
     /// Safe upper bound on the wire length of an identity this runtime can
@@ -161,9 +203,22 @@ pub const Runtime = struct {
                 .stateless => |s| s.buf[0..s.len],
             };
         }
+
+        pub fn deinit(self: *Identity) void {
+            switch (self.*) {
+                .stateful => |*handle| crypto.secrets.secureZero(handle[0..]),
+                .stateless => |s| crypto.secrets.secureZero(s.buf[0..s.len]),
+            }
+            self.* = undefined;
+        }
     };
 
-    pub const CreateIdentityError = error{ StorageUnavailable, SealFailed };
+    pub const CreateIdentityError = error{
+        StatefulCapacityRefused,
+        StatefulStorageFailed,
+        HandleGenerationFailed,
+        SealFailed,
+    };
 
     /// Consumes `state` — the exact prepared `ServerRecoverableState` from
     /// `Tls13Backend.prepareNewSessionTicket` — into this runtime's
@@ -186,12 +241,12 @@ pub const Runtime = struct {
         scratch: []u8,
     ) CreateIdentityError!Identity {
         return switch (self.config.mode) {
-            .disabled => error.StorageUnavailable,
+            .disabled => error.StatefulCapacityRefused,
             .stateful => self.createStatefulIdentity(state, now_unix_ms),
             .stateless => self.createStatelessIdentity(state, now_unix_ms, scratch),
             .hybrid => self.createStatefulIdentity(state, now_unix_ms) catch |err| switch (err) {
-                error.StorageUnavailable => self.createStatelessIdentity(state, now_unix_ms, scratch),
-                error.SealFailed => err,
+                error.StatefulCapacityRefused => self.createStatelessIdentity(state, now_unix_ms, scratch),
+                else => err,
             },
         };
     }
@@ -201,12 +256,15 @@ pub const Runtime = struct {
         state: *session.ServerRecoverableState,
         now_unix_ms: i64,
     ) CreateIdentityError!Identity {
-        const cache = if (self.server_cache) |*cache| cache else return error.StorageUnavailable;
+        const cache = if (self.server_cache) |*cache| cache else return error.StatefulCapacityRefused;
         var handle: [session_cache.stateful_identity_len]u8 = undefined;
+        defer crypto.secrets.secureZero(handle[0..]);
         const result = cache.insertMove(state, now_unix_ms, usagePolicy(self.config.usage), &handle);
         return switch (result) {
             .stored => .{ .stateful = handle },
-            .rejected_capacity, .storage_failed, .rejected_handle_generation_failed => error.StorageUnavailable,
+            .rejected_capacity => error.StatefulCapacityRefused,
+            .storage_failed => error.StatefulStorageFailed,
+            .rejected_handle_generation_failed => error.HandleGenerationFailed,
             .replaced, .rejected_unsupported_usage => unreachable,
         };
     }
@@ -217,7 +275,7 @@ pub const Runtime = struct {
         now_unix_ms: i64,
         scratch: []u8,
     ) CreateIdentityError!Identity {
-        const keyring = if (self.keyring) |*keyring| keyring else return error.StorageUnavailable;
+        const keyring = if (self.keyring) |*keyring| keyring else return error.StatefulCapacityRefused;
         var protector = ticket_protection.Protector{
             .provider = self.provider,
             .keyring = keyring,
@@ -250,8 +308,15 @@ pub const Runtime = struct {
         const now = self.nowUnixMs();
 
         if (session_cache.isValidStatefulHandleShape(identity)) {
-            if (self.server_cache) |*cache|
-                return session_cache.resolveStatefulServerPsk(cache, self.allocator, identity, now);
+            if (self.server_cache) |*cache| {
+                const result = session_cache.resolveStatefulServerPsk(cache, self.allocator, identity, now) catch |err| {
+                    self.observer.ticketResolve(.stateful, .failed);
+                    return err;
+                };
+                self.observer.ticketResolve(.stateful, if (result == .hit) .success else .rejected);
+                return result;
+            }
+            self.observer.ticketResolve(.stateful, .rejected);
             return .miss;
         }
 
@@ -263,11 +328,19 @@ pub const Runtime = struct {
                 .limits = self.config.session_limits,
             };
             var state: session.ServerRecoverableState = .{};
-            const found = protector.resolve(self.allocator, identity, now, &state) catch return error.ResolverFailed;
-            if (!found) return .miss;
+            const found = protector.resolve(self.allocator, identity, now, &state) catch {
+                self.observer.ticketResolve(.stateless, .failed);
+                return error.ResolverFailed;
+            };
+            if (!found) {
+                self.observer.ticketResolve(.stateless, .rejected);
+                return .miss;
+            }
+            self.observer.ticketResolve(.stateless, .success);
             return .{ .hit = .{ .state = state, .lease = pre_shared_key.ServerPskLease.initNoop() } };
         }
 
+        self.observer.ticketResolve(self.config.mode, .rejected);
         return .miss;
     }
 
@@ -306,6 +379,14 @@ fn usagePolicy(usage: TicketUsage) session_cache.UsagePolicy {
     return switch (usage) {
         .reusable => .reusable,
         .single_use => .single_use,
+    };
+}
+
+pub fn storeResultToTicketResult(result: session_cache.StoreResult) TicketResult {
+    return switch (result) {
+        .stored, .replaced => .success,
+        .rejected_capacity, .rejected_unsupported_usage => .rejected,
+        .storage_failed, .rejected_handle_generation_failed => .failed,
     };
 }
 
@@ -350,6 +431,16 @@ const TestEntropy = struct {
         if (self.fail) return error.EntropyFailure;
         @memset(buffer, self.byte);
         self.byte +%= 1;
+    }
+};
+
+const FailingHandleRandom = struct {
+    fn source() session_cache.RandomSource {
+        return .{ .ctx = @ptrCast(@constCast(&empty_observer_dummy)), .fillFn = fill };
+    }
+
+    fn fill(_: *anyopaque, _: []u8) error{EntropyFailure}!void {
+        return error.EntropyFailure;
     }
 };
 
@@ -729,6 +820,53 @@ test "createIdentity hybrid falls back to stateless on ordinary stateful capacit
     try std.testing.expect(hit == .hit);
 }
 
+test "createIdentity hybrid does not fall back on stateful storage failure" {
+    var clock = TestClock{};
+    var entropy_ctx = TestEntropy{};
+    var provider_impl = crypto.pure_zig.Provider.init(entropy_ctx.entropy());
+    var runtime = try Runtime.init(
+        std.testing.allocator,
+        .{ .mode = .hybrid },
+        clock.clock(),
+        provider_impl.cryptoProvider(),
+    );
+    defer runtime.deinit();
+
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
+    const original_allocator = runtime.server_cache.?.allocator;
+    runtime.server_cache.?.allocator = failing.allocator();
+    defer {
+        runtime.server_cache.?.allocator = original_allocator;
+    }
+
+    var state = try sampleServerState(std.testing.allocator, "hybrid-storage-failed.test");
+    defer state.deinit();
+    var scratch = [_]u8{0} ** 1024;
+    try std.testing.expectError(error.StatefulStorageFailed, runtime.createIdentity(&state, clock.now_ms, &scratch));
+    try std.testing.expect(!std.mem.startsWith(u8, &scratch, &ticket_protection.magic));
+}
+
+test "createIdentity hybrid does not fall back on stateful handle generation failure" {
+    var clock = TestClock{};
+    var entropy_ctx = TestEntropy{};
+    var provider_impl = crypto.pure_zig.Provider.init(entropy_ctx.entropy());
+    var runtime = try Runtime.init(
+        std.testing.allocator,
+        .{ .mode = .hybrid },
+        clock.clock(),
+        provider_impl.cryptoProvider(),
+    );
+    defer runtime.deinit();
+
+    runtime.server_cache.?.random = FailingHandleRandom.source();
+
+    var state = try sampleServerState(std.testing.allocator, "hybrid-handle-failed.test");
+    defer state.deinit();
+    var scratch = [_]u8{0} ** 1024;
+    try std.testing.expectError(error.HandleGenerationFailed, runtime.createIdentity(&state, clock.now_ms, &scratch));
+    try std.testing.expect(!std.mem.startsWith(u8, &scratch, &ticket_protection.magic));
+}
+
 test "rollbackIdentity revokes a stateful handle so it no longer resolves" {
     var clock = TestClock{};
     var entropy_ctx = TestEntropy{};
@@ -779,7 +917,7 @@ test "rollbackIdentity is a no-op for a stateless envelope" {
     try std.testing.expect(hit == .hit);
 }
 
-test "createIdentity disabled runtime always reports storage unavailable" {
+test "createIdentity disabled runtime reports typed stateful refusal" {
     var clock = TestClock{};
     var entropy_ctx = TestEntropy{};
     var provider_impl = crypto.pure_zig.Provider.init(entropy_ctx.entropy());
@@ -793,5 +931,5 @@ test "createIdentity disabled runtime always reports storage unavailable" {
 
     var state = try sampleServerState(std.testing.allocator, "disabled.test");
     defer state.deinit();
-    try std.testing.expectError(error.StorageUnavailable, runtime.createIdentity(&state, clock.now_ms, &.{}));
+    try std.testing.expectError(error.StatefulCapacityRefused, runtime.createIdentity(&state, clock.now_ms, &.{}));
 }

--- a/src/tls/resumption_runtime.zig
+++ b/src/tls/resumption_runtime.zig
@@ -13,6 +13,7 @@ const pre_shared_key = @import("pre_shared_key.zig");
 const session = @import("session.zig");
 const session_cache = @import("session_cache.zig");
 const ticket_protection = @import("ticket_protection.zig");
+const tls13_backend = @import("tls13_backend.zig");
 
 const provider = crypto.provider;
 
@@ -20,7 +21,7 @@ pub const Mode = enum { disabled, stateful, stateless, hybrid };
 pub const TicketUsage = enum { reusable, single_use };
 pub const Transport = enum { record, quic };
 pub const TicketResult = enum { success, rejected, failed };
-pub const ResumptionOutcome = enum { accepted, full_handshake, fatal };
+pub const ResumptionOutcome = enum { accepted, full_handshake, incompatible, miss, fatal };
 
 pub const Observer = struct {
     ctx: *anyopaque = @ptrCast(@constCast(&empty_observer_dummy)),
@@ -168,6 +169,13 @@ pub const Runtime = struct {
 
     pub fn setObserver(self: *Runtime, observer: Observer) void {
         self.observer = observer;
+    }
+
+    pub fn backendDecisionObserver(self: *Runtime, transport: Transport) tls13_backend.Tls13Backend.ResumptionDecisionObserver {
+        return switch (transport) {
+            .record => .{ .ctx = self, .onDecisionFn = backendRecordDecision },
+            .quic => .{ .ctx = self, .onDecisionFn = backendQuicDecision },
+        };
     }
 
     /// Safe upper bound on the wire length of an identity this runtime can
@@ -372,6 +380,26 @@ pub const Runtime = struct {
             error.OutOfMemory => return error.OutOfMemory,
             else => return error.InvalidConfig,
         };
+    }
+
+    fn backendRecordDecision(ctx: *anyopaque, decision: tls13_backend.Tls13Backend.ResumptionDecision) void {
+        backendDecision(ctx, .record, decision);
+    }
+
+    fn backendQuicDecision(ctx: *anyopaque, decision: tls13_backend.Tls13Backend.ResumptionDecision) void {
+        backendDecision(ctx, .quic, decision);
+    }
+
+    fn backendDecision(ctx: *anyopaque, transport: Transport, decision: tls13_backend.Tls13Backend.ResumptionDecision) void {
+        const self: *Runtime = @ptrCast(@alignCast(ctx));
+        self.observer.resumptionAttempt(transport);
+        self.observer.resumptionOutcome(transport, switch (decision) {
+            .accepted => .accepted,
+            .miss => .miss,
+            .incompatible => .incompatible,
+            .full_handshake => .full_handshake,
+            .fatal => .fatal,
+        });
     }
 };
 

--- a/src/tls/session_cache.zig
+++ b/src/tls/session_cache.zig
@@ -2407,6 +2407,23 @@ pub const StatefulServerCache = struct {
         }
     }
 
+    /// Unconditionally removes and wipes a just-inserted entry by its
+    /// bearer handle, regardless of lease/expiry state (#488 issuance
+    /// rollback: a handle `insertMove` already committed to storage but
+    /// whose `NewSessionTicket` never reached the peer — e.g. post-
+    /// handshake emission/queueing failed — must not remain resolvable, or
+    /// a client could never plausibly have received; a peer can never
+    /// legitimately offer it). Ordinary consumption after successful
+    /// delivery goes through `resolveLease`/`ServerLease`, never this. A
+    /// handle that is not present (already rolled back, evicted, or never
+    /// stored) is a silent no-op.
+    pub fn revokeHandle(self: *StatefulServerCache, handle: *const [stateful_identity_len]u8) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const entry_id = self.handle_index.get(digestHandle(handle)) orelse return;
+        self.removeEntryLocked(entry_id);
+    }
+
     /// Removes and wipes a stored entry by its stable `entry_id`,
     /// unindexing its handle and updating (and, if now empty, removing) its
     /// origin bucket.

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -1871,6 +1871,18 @@ pub const Tls13Backend = struct {
         self.wipeEphemeral();
         if (psk_secret) |*psk| {
             self.core.enterPskAuthenticated();
+            // #488: a PSK-resumed handshake never sends a Certificate
+            // message (RFC 8446 SS4.2.11), so `certificate_state` would
+            // otherwise stay `.not_checked` forever — which every transport
+            // completion policy (record `completionPolicyError`, QUIC
+            // `Handshake.complete`) treats as a fatal `CertificateInvalid`
+            // for the client role. The resumed identity's trust is not
+            // reestablished here: it was already proven once, at the
+            // original full handshake that issued this ticket, and the
+            // binder just confirmed the client and server share that same
+            // ticket's PSK — so the client may treat the peer as
+            // equivalently authenticated without a fresh Certificate flight.
+            try sink.emitCertificate(.valid);
             self.schedule = KeySchedule.initWithPsk(psk, &shared, self.core.transcriptHash());
             crypto.secureZero(u8, psk);
         } else {
@@ -3395,39 +3407,110 @@ pub const Tls13Backend = struct {
         };
     }
 
-    pub fn emitNewSessionTicket(
+    /// #488 two-phase issuance, step 1: derives the RMS-bound PSK and the
+    /// exact `ServerRecoverableState` a stateful insertion or stateless seal
+    /// will consume, without requiring the opaque bearer identity that only
+    /// exists once one of those two issuance paths has actually run.
+    /// Runtime code must not rederive the PSK from this connection a second
+    /// time — call `emitPreparedNewSessionTicket` with the resulting
+    /// identity to finish issuance, then `prepared.deinit()` unconditionally.
+    pub const PreparedNewSessionTicket = struct {
+        state: session.ServerRecoverableState = .{},
+        ticket_lifetime: u32 = 0,
+        ticket_age_add: u32 = 0,
+        ticket_nonce_buf: [new_session_ticket.max_ticket_nonce_len]u8 = undefined,
+        ticket_nonce_len: u8 = 0,
+        max_early_data_size: ?u32 = null,
+
+        pub fn ticketNonce(self: *const PreparedNewSessionTicket) []const u8 {
+            return self.ticket_nonce_buf[0..self.ticket_nonce_len];
+        }
+
+        /// Safe to call unconditionally, including after a successful
+        /// `emitPreparedNewSessionTicket` whose stateful path already moved
+        /// `state` away (leaving it zero-valued and this a no-op).
+        pub fn deinit(self: *PreparedNewSessionTicket) void {
+            self.state.deinit();
+            crypto.secureZero(u8, &self.ticket_nonce_buf);
+            self.* = undefined;
+        }
+    };
+
+    pub const PrepareNewSessionTicketParams = struct {
+        ticket_lifetime: u32,
+        ticket_age_add: u32,
+        ticket_nonce: []const u8,
+        max_early_data_size: ?u32 = null,
+        issued_at_unix_ms: i64,
+    };
+
+    pub fn prepareNewSessionTicket(
         self: *Tls13Backend,
         allocator: std.mem.Allocator,
-        sink: *EventSink,
-        params: EmitNewSessionTicketParams,
+        params: PrepareNewSessionTicketParams,
         limits: session.Limits,
-    ) HandshakeError!session.ServerRecoverableState {
+    ) HandshakeError!PreparedNewSessionTicket {
         if (self.role != .server or self.core.handshake_lifecycle != .complete)
             return error.InvalidHandshakeState;
         if (self.resumption_master_secret.slice().len == 0)
             return error.InvalidHandshakeState;
         limits.validate() catch return error.InvalidTransportProfile;
+        if (params.ticket_nonce.len > new_session_ticket.max_ticket_nonce_len)
+            return error.IllegalParameter;
 
-        const emit_params: new_session_ticket.EmitParams = .{
-            .ticket_lifetime = params.ticket_lifetime,
-            .ticket_age_add = params.ticket_age_add,
-            .ticket_nonce = params.ticket_nonce,
-            .ticket = params.opaque_ticket,
-            .max_early_data_size = params.max_early_data_size,
-        };
-        const body_len = new_session_ticket.encodedLen(emit_params) catch |err| return mapTicketEncodeError(err);
-        if (body_len > max_new_session_ticket_message_len - 4) return error.TransportBufferOverflow;
-        const message_len = handshake_header_len + body_len;
-
-        var state = new_session_ticket.buildServerRecoverableState(
+        const state = new_session_ticket.buildServerRecoverableStateNoIdentity(
             allocator,
-            emit_params,
+            .{
+                .ticket_lifetime = params.ticket_lifetime,
+                .ticket_age_add = params.ticket_age_add,
+                .ticket_nonce = params.ticket_nonce,
+                .max_early_data_size = params.max_early_data_size,
+            },
             self.resumptionContext(),
             self.resumption_master_secret.slice(),
             params.issued_at_unix_ms,
             limits,
         ) catch |err| return mapTicketBuildServerError(err);
-        errdefer state.deinit();
+
+        var prepared: PreparedNewSessionTicket = .{
+            .state = state,
+            .ticket_lifetime = params.ticket_lifetime,
+            .ticket_age_add = params.ticket_age_add,
+            .max_early_data_size = params.max_early_data_size,
+        };
+        prepared.ticket_nonce_len = @intCast(params.ticket_nonce.len);
+        @memcpy(prepared.ticket_nonce_buf[0..prepared.ticket_nonce_len], params.ticket_nonce);
+        return prepared;
+    }
+
+    /// #488 two-phase issuance, step 2: encodes and emits the
+    /// `NewSessionTicket` message carrying `identity` — the exact bearer
+    /// identity (stateful handle or stateless envelope) produced from
+    /// `prepared.state` — through the existing application-epoch record
+    /// path. Does not consume or clear `prepared`; the caller still owns it
+    /// and must `deinit` it afterward regardless of outcome.
+    pub fn emitPreparedNewSessionTicket(
+        self: *Tls13Backend,
+        allocator: std.mem.Allocator,
+        sink: *EventSink,
+        prepared: *const PreparedNewSessionTicket,
+        identity: []const u8,
+        limits: session.Limits,
+    ) HandshakeError!void {
+        if (self.role != .server or self.core.handshake_lifecycle != .complete)
+            return error.InvalidHandshakeState;
+        if (identity.len == 0 or identity.len > limits.max_ticket_len) return error.TicketTooLarge;
+
+        const emit_params: new_session_ticket.EmitParams = .{
+            .ticket_lifetime = prepared.ticket_lifetime,
+            .ticket_age_add = prepared.ticket_age_add,
+            .ticket_nonce = prepared.ticketNonce(),
+            .ticket = identity,
+            .max_early_data_size = prepared.max_early_data_size,
+        };
+        const body_len = new_session_ticket.encodedLen(emit_params) catch |err| return mapTicketEncodeError(err);
+        if (body_len > max_new_session_ticket_message_len - 4) return error.TransportBufferOverflow;
+        const message_len = handshake_header_len + body_len;
 
         const buf = allocator.alloc(u8, message_len) catch return error.CredentialProviderFailed;
         errdefer {
@@ -3443,7 +3526,30 @@ pub const Tls13Backend = struct {
         const message = buf[0..w.len];
         try sink.emitOwnedCrypto(allocator, .application, message);
         self.core.transcript.update(message);
-        return state;
+    }
+
+    /// Single-phase issuance, retained for callers (and tests) that already
+    /// know the final bearer identity before deriving connection state.
+    /// New production issuance paths should prefer `prepareNewSessionTicket`
+    /// / `emitPreparedNewSessionTicket` (#488) so the identity can be
+    /// derived from the exact state this produces.
+    pub fn emitNewSessionTicket(
+        self: *Tls13Backend,
+        allocator: std.mem.Allocator,
+        sink: *EventSink,
+        params: EmitNewSessionTicketParams,
+        limits: session.Limits,
+    ) HandshakeError!session.ServerRecoverableState {
+        var prepared = try self.prepareNewSessionTicket(allocator, .{
+            .ticket_lifetime = params.ticket_lifetime,
+            .ticket_age_add = params.ticket_age_add,
+            .ticket_nonce = params.ticket_nonce,
+            .max_early_data_size = params.max_early_data_size,
+            .issued_at_unix_ms = params.issued_at_unix_ms,
+        }, limits);
+        errdefer prepared.deinit();
+        try self.emitPreparedNewSessionTicket(allocator, sink, &prepared, params.opaque_ticket, limits);
+        return prepared.state;
     }
 
     /// The handshake is over: the transport sink owns every exported live
@@ -3945,6 +4051,68 @@ test "server explicitly emits NewSessionTicket and returns recoverable state" {
     try std.testing.expectEqual(@as(u32, 60), state.common.lifetime_seconds);
     try std.testing.expectEqual(session.EarlyDataPolicy{ .early_data_capable = 32 }, state.common.early_data);
     try std.testing.expect(!std.mem.allEqual(u8, state.common.resumption_psk.slice(), 0));
+}
+
+test "prepare/emit two-phase ticket issuance matches single-phase wire output" {
+    var server = Tls13Backend.initServer(
+        .{ .hello_random = [_]u8{0x51} ** 32, .key_share_seed = [_]u8{0x52} ** 32 },
+        try Identity.initPkcs8(testdata.certificate_der, testdata.private_key_pkcs8_der),
+        .record,
+    );
+    defer server.deinit();
+    server.core.handshake_lifecycle = .complete;
+    try server.resumption_master_secret.replace(&([_]u8{0x33} ** hash_len));
+
+    var sink = EventSink{};
+    defer sink.deinit();
+    var prepared = try server.prepareNewSessionTicket(std.testing.allocator, .{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .max_early_data_size = 32,
+        .issued_at_unix_ms = 10,
+    }, session.Limits.default);
+    defer prepared.deinit();
+
+    try std.testing.expect(!std.mem.allEqual(u8, prepared.state.common.resumption_psk.slice(), 0));
+    try std.testing.expectEqual(@as(usize, 0), sink.len);
+
+    try server.emitPreparedNewSessionTicket(std.testing.allocator, &sink, &prepared, "identity-bytes", session.Limits.default);
+
+    try std.testing.expectEqual(@as(usize, 1), sink.len);
+    const message = try tls_handshake_codec.decode(sink.items[0].handshake_bytes.data);
+    try std.testing.expectEqual(MessageType.new_session_ticket, message.kind);
+    const parsed = try new_session_ticket.decode(message.body);
+    try std.testing.expectEqual(@as(u32, 60), parsed.ticket_lifetime);
+    try std.testing.expectEqualSlices(u8, "identity-bytes", parsed.ticket);
+    try std.testing.expectEqual(@as(?u32, 32), parsed.max_early_data_size);
+}
+
+test "emitPreparedNewSessionTicket rejects an empty or oversized identity" {
+    var server = Tls13Backend.initServer(
+        .{ .hello_random = [_]u8{0x53} ** 32, .key_share_seed = [_]u8{0x54} ** 32 },
+        try Identity.initPkcs8(testdata.certificate_der, testdata.private_key_pkcs8_der),
+        .record,
+    );
+    defer server.deinit();
+    server.core.handshake_lifecycle = .complete;
+    try server.resumption_master_secret.replace(&([_]u8{0x33} ** hash_len));
+
+    var sink = EventSink{};
+    defer sink.deinit();
+    var prepared = try server.prepareNewSessionTicket(std.testing.allocator, .{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .issued_at_unix_ms = 10,
+    }, session.Limits.default);
+    defer prepared.deinit();
+
+    try std.testing.expectError(error.TicketTooLarge, server.emitPreparedNewSessionTicket(std.testing.allocator, &sink, &prepared, "", session.Limits.default));
+    var too_large: [session.Limits.default.max_ticket_len + 1]u8 = undefined;
+    @memset(&too_large, 0xa5);
+    try std.testing.expectError(error.TicketTooLarge, server.emitPreparedNewSessionTicket(std.testing.allocator, &sink, &prepared, &too_large, session.Limits.default));
+    try std.testing.expectEqual(@as(usize, 0), sink.len);
 }
 
 test "server ticket output failure is atomic and retryable" {

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -2740,9 +2740,15 @@ pub const Tls13Backend = struct {
     /// not configured/offered/eligible, or no candidate is acceptable.
     fn selectPsk(self: *Tls13Backend, current_binding: session.AuthBinding) HandshakeError!?PskSelected {
         const resolver = self.psk_resolver orelse return null;
-        if (self.client_auth != .disabled) return null;
-        if (!self.offered_psk_modes_seen or !self.offered_psk_dhe_ke) return null;
         const capture = self.client_hello_psk orelse return null;
+        if (self.client_auth != .disabled) {
+            self.resumption_decision_observer.notify(.full_handshake);
+            return null;
+        }
+        if (!self.offered_psk_modes_seen or !self.offered_psk_dhe_ke) {
+            self.resumption_decision_observer.notify(.full_handshake);
+            return null;
+        }
         const ext_data = capture.message[capture.ext_data_offset..][0..capture.ext_data_len];
         // Already validated once in `onClientHello`; re-parsing the same
         // captured bytes cannot fail.

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -55,6 +55,7 @@ pub const max_message_len = 8 * 1024;
 /// ticket identity plus its handshake header and small fixed/vector fields.
 pub const max_new_session_ticket_message_len = tls13_transport.max_new_session_ticket_message_len;
 const handshake_header_len = 4;
+var empty_observer_dummy: u8 = 0;
 
 const PostHandshakeInput = struct {
     allocator: ?std.mem.Allocator = null,
@@ -484,6 +485,7 @@ pub const Tls13Backend = struct {
     /// `null` means this server never offers PSK resumption.
     psk_resolver: ?pre_shared_key.ServerPskResolver = null,
     resume_compat: ResumeCompatibilityPolicy = .{},
+    resumption_decision_observer: ResumptionDecisionObserver = .{},
     offered_psk_modes_seen: bool = false,
     offered_psk_dhe_ke: bool = false,
     /// Server: a captured copy of the just-parsed ClientHello, kept only
@@ -525,6 +527,16 @@ pub const Tls13Backend = struct {
     const Slice = struct { start: usize, len: usize };
     const PendingStage = enum { server_select, server_sign, client_select, client_sign, peer_verify };
     const PskSelected = struct { index: usize, psk: [hash_len]u8 };
+    pub const ResumptionDecision = enum { accepted, miss, incompatible, full_handshake, fatal };
+
+    pub const ResumptionDecisionObserver = struct {
+        ctx: *anyopaque = @ptrCast(@constCast(&empty_observer_dummy)),
+        onDecisionFn: ?*const fn (*anyopaque, ResumptionDecision) void = null,
+
+        pub fn notify(self: ResumptionDecisionObserver, decision: ResumptionDecision) void {
+            if (self.onDecisionFn) |f| f(self.ctx, decision);
+        }
+    };
 
     /// Server (#362): the accepted `ServerRecoverableState` a successful PSK
     /// selection moves into backend ownership — not only the derived PSK
@@ -795,6 +807,11 @@ pub const Tls13Backend = struct {
     pub fn setResumeCompatibilityPolicy(self: *Tls13Backend, policy: ResumeCompatibilityPolicy) HandshakeError!void {
         if (self.core.handshake_lifecycle != .idle) return error.InvalidHandshakeState;
         self.resume_compat = policy;
+    }
+
+    pub fn setResumptionDecisionObserver(self: *Tls13Backend, observer: ResumptionDecisionObserver) HandshakeError!void {
+        if (self.core.handshake_lifecycle != .idle) return error.InvalidHandshakeState;
+        self.resumption_decision_observer = observer;
     }
 
     /// #362/#365: configure this connection's application-layer
@@ -2729,19 +2746,27 @@ pub const Tls13Backend = struct {
         const ext_data = capture.message[capture.ext_data_offset..][0..capture.ext_data_len];
         // Already validated once in `onClientHello`; re-parsing the same
         // captured bytes cannot fail.
-        const offered = pre_shared_key.OfferedPsks.parse(ext_data) catch return null;
+        const offered = pre_shared_key.OfferedPsks.parse(ext_data) catch {
+            self.resumption_decision_observer.notify(.fatal);
+            return null;
+        };
         const truncated_len = capture.ext_data_offset + offered.binder_vector_offset;
         const truncated_prefix = capture.message[0..truncated_len];
         const now = resolver.nowUnixMs();
 
         var it = offered.pairs();
         var attempts: usize = 0;
+        var saw_resolved = false;
+        var saw_incompatible = false;
         while (attempts < pre_shared_key.max_offered_identities) : (attempts += 1) {
             const pair = (it.next() catch return null) orelse break;
-            var resolved = resolver.resolve(pair.identity.identity) catch
+            var resolved = resolver.resolve(pair.identity.identity) catch {
+                self.resumption_decision_observer.notify(.fatal);
                 return self.failCredential(.provider_internal_failure);
+            };
             defer resolved.deinit();
             if (resolved == .miss) continue;
+            saw_resolved = true;
             var hit = &resolved.hit;
 
             const candidate_ctx: session.CandidateContext = .{
@@ -2753,7 +2778,10 @@ pub const Tls13Backend = struct {
                 .application_compat = if (self.resume_compat.application == .exact) self.candidateApplicationCompat() else null,
             };
             const decision = session.evaluateCompatibility(&hit.state.common, candidate_ctx, now);
-            if (decision.resumption != .eligible) continue;
+            if (decision.resumption != .eligible) {
+                saw_incompatible = true;
+                continue;
+            }
 
             const psk_slice = hit.state.common.resumption_psk.slice();
             if (psk_slice.len != hash_len) return error.InvalidHandshakeState;
@@ -2763,7 +2791,10 @@ pub const Tls13Backend = struct {
 
             const ok = pre_shared_key.verifyBinder(.sha256, &psk_buf, truncated_prefix, pair.binder) catch
                 return error.InvalidHandshakeState;
-            if (!ok) return error.DecryptError; // fatal: never probe a later identity
+            if (!ok) {
+                self.resumption_decision_observer.notify(.fatal);
+                return error.DecryptError; // fatal: never probe a later identity
+            }
 
             // #362: surface the ticket-age skew observation for #366 — skew
             // alone never rejects this 1-RTT resumption.
@@ -2777,7 +2808,16 @@ pub const Tls13Backend = struct {
             self.selected_server_psk.state.moveFrom(&hit.state);
             self.selected_server_psk.index = @intCast(attempts);
             self.selected_server_psk_present = true;
+            self.resumption_decision_observer.notify(.accepted);
             return .{ .index = attempts, .psk = psk_buf };
+        }
+        if (attempts > 0) {
+            self.resumption_decision_observer.notify(if (saw_incompatible)
+                .incompatible
+            else if (saw_resolved)
+                .full_handshake
+            else
+                .miss);
         }
         return null;
     }

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -483,6 +483,7 @@ pub const Tls13Backend = struct {
     /// Server (#362): the configured stateful/stateless identity resolver.
     /// `null` means this server never offers PSK resumption.
     psk_resolver: ?pre_shared_key.ServerPskResolver = null,
+    resume_compat: ResumeCompatibilityPolicy = .{},
     offered_psk_modes_seen: bool = false,
     offered_psk_dhe_ke: bool = false,
     /// Server: a captured copy of the just-parsed ClientHello, kept only
@@ -782,6 +783,18 @@ pub const Tls13Backend = struct {
         if (self.role != .server) return error.InvalidHandshakeState;
         if (self.core.handshake_lifecycle != .idle) return error.InvalidHandshakeState;
         self.psk_resolver = resolver;
+    }
+
+    pub const SnapshotResumePolicy = enum { exact, ignore };
+
+    pub const ResumeCompatibilityPolicy = struct {
+        transport: SnapshotResumePolicy = .exact,
+        application: SnapshotResumePolicy = .exact,
+    };
+
+    pub fn setResumeCompatibilityPolicy(self: *Tls13Backend, policy: ResumeCompatibilityPolicy) HandshakeError!void {
+        if (self.core.handshake_lifecycle != .idle) return error.InvalidHandshakeState;
+        self.resume_compat = policy;
     }
 
     /// #362/#365: configure this connection's application-layer
@@ -1970,8 +1983,8 @@ pub const Tls13Backend = struct {
                 .{ .format_id = blob.format_id, .format_version = blob.format_version, .bytes = blob.bytes }
             else
                 null;
-            if (!compatCompatible(stored.transport_compat, received_transport)) return error.IllegalParameter;
-            if (!compatCompatible(stored.application_compat, self.candidateApplicationCompat())) return error.IllegalParameter;
+            if (self.resume_compat.transport == .exact and !compatCompatible(stored.transport_compat, received_transport)) return error.IllegalParameter;
+            if (self.resume_compat.application == .exact and !compatCompatible(stored.application_compat, self.candidateApplicationCompat())) return error.IllegalParameter;
 
             self.connection_auth_binding = stored.auth_binding;
         }
@@ -2736,8 +2749,8 @@ pub const Tls13Backend = struct {
                 .server_name = self.serverNameSlice(),
                 .application_protocol = self.selectedAlpn(),
                 .auth_binding = current_binding,
-                .transport_compat = self.candidateTransportCompat(),
-                .application_compat = self.candidateApplicationCompat(),
+                .transport_compat = if (self.resume_compat.transport == .exact) self.candidateTransportCompat() else null,
+                .application_compat = if (self.resume_compat.application == .exact) self.candidateApplicationCompat() else null,
             };
             const decision = session.evaluateCompatibility(&hit.state.common, candidate_ctx, now);
             if (decision.resumption != .eligible) continue;
@@ -3279,8 +3292,8 @@ pub const Tls13Backend = struct {
             .server_name = if (self.server_name_present) self.server_name[0..self.server_name_len] else null,
             .application_protocol = self.selectedAlpn(),
             .auth_binding = self.effectiveAuthBinding(),
-            .transport_compat = self.peerTransportCompat(),
-            .application_compat = self.ownedApplicationCompat(),
+            .transport_compat = if (self.resume_compat.transport == .exact) self.peerTransportCompat() else null,
+            .application_compat = if (self.resume_compat.application == .exact) self.ownedApplicationCompat() else null,
         };
     }
 

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -620,7 +620,11 @@ test "PSK round trip: an offered, resolved, and verified ticket resumes the hand
     try std.testing.expectEqualStrings("resumed request", opened_request.inner.content);
 }
 
-test "#488: resumption_runtime.Runtime drives a genuine end-to-end resumed handshake via two-phase issuance" {
+fn expectRuntimeResumedRecordHandshake(
+    server_config: tls_core.resumption_runtime.Config,
+    client_config: tls_core.resumption_runtime.Config,
+    expected_identity: tls_core.resumption_runtime.Runtime.IdentityMode,
+) !void {
     const resumption_runtime = tls_core.resumption_runtime;
 
     // Phase 1: a full handshake. The server issues a ticket through the new
@@ -632,7 +636,7 @@ test "#488: resumption_runtime.Runtime drives a genuine end-to-end resumed hands
 
     var server_runtime = try resumption_runtime.Runtime.init(
         std.testing.allocator,
-        .{ .mode = .stateful },
+        server_config,
         .{ .ctx = undefined, .nowUnixMsFn = struct {
             fn now(_: *anyopaque) i64 {
                 return 1000;
@@ -644,7 +648,7 @@ test "#488: resumption_runtime.Runtime drives a genuine end-to-end resumed hands
 
     var client_runtime = try resumption_runtime.Runtime.init(
         std.testing.allocator,
-        .{ .mode = .stateful },
+        client_config,
         .{ .ctx = undefined, .nowUnixMsFn = struct {
             fn now(_: *anyopaque) i64 {
                 return 2000;
@@ -686,9 +690,10 @@ test "#488: resumption_runtime.Runtime drives a genuine end-to-end resumed hands
         .issued_at_unix_ms = 1000,
     }, limits);
     defer prepared.deinit();
-    var scratch: [256]u8 = undefined;
+    var scratch: [session.absolute_ticket_wire_max]u8 = undefined;
     var identity = try server_runtime.createIdentity(&prepared.state, 1000, &scratch);
-    try std.testing.expect(identity == .stateful);
+    defer identity.deinit();
+    try std.testing.expectEqual(expected_identity, std.meta.activeTag(identity));
     try harness.server_backend.emitPreparedNewSessionTicket(std.testing.allocator, &sink, &prepared, identity.slice(), limits);
     try std.testing.expectEqual(@as(usize, 1), sink.len);
 
@@ -761,6 +766,36 @@ test "#488: resumption_runtime.Runtime drives a genuine end-to-end resumed hands
     const request = try resumed.client_bridge.sealApplicationData("resumed request", &protected2);
     const opened_request = try resumed.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, request), &plaintext2);
     try std.testing.expectEqualStrings("resumed request", opened_request.inner.content);
+}
+
+test "#488: stateful runtime drives a genuine end-to-end resumed handshake via two-phase issuance" {
+    try expectRuntimeResumedRecordHandshake(
+        .{ .mode = .stateful },
+        .{ .mode = .stateful },
+        .stateful,
+    );
+}
+
+test "#488: stateless runtime drives a genuine end-to-end resumed handshake via two-phase issuance" {
+    try expectRuntimeResumedRecordHandshake(
+        .{ .mode = .stateless },
+        .{ .mode = .stateless },
+        .stateless,
+    );
+}
+
+test "#488: hybrid runtime falls back to stateless issuance and reconnects successfully" {
+    try expectRuntimeResumedRecordHandshake(
+        .{ .mode = .hybrid, .server_cache_limits = .{
+            .max_entries = 4,
+            .max_origins = 4,
+            .max_total_bytes = 1,
+            .max_entry_bytes = 1,
+            .max_entries_per_origin = 4,
+        } },
+        .{ .mode = .hybrid },
+        .stateless,
+    );
 }
 
 test "PSK round trip resumes over the extension (QUIC-style) profile with asymmetric client/server transport payloads" {
@@ -1003,7 +1038,6 @@ test "an ineligible offered ticket is filtered without desyncing the wire index 
         .nowUnixMsFn = CountingResolver.now,
         .resolveFn = CountingResolver.resolve,
     });
-
     try harness.run();
 
     try std.testing.expect(harness.client_driver.isComplete());
@@ -1055,6 +1089,8 @@ test "handshake-time client authentication forces a full handshake even when a P
         .nowUnixMsFn = CountingResolver.now,
         .resolveFn = CountingResolver.resolve,
     });
+    var decisions = DecisionProbe{};
+    try harness.server_backend.setResumptionDecisionObserver(decisions.observer());
 
     try harness.run();
 
@@ -1065,6 +1101,8 @@ test "handshake-time client authentication forces a full handshake even when a P
     // The resolver is never even consulted: client_auth forces the full
     // fallback before PSK selection begins.
     try std.testing.expectEqual(@as(usize, 0), resolver_state.calls);
+    try std.testing.expectEqual(@as(usize, 1), decisions.count);
+    try std.testing.expectEqual(tls_backend.Tls13Backend.ResumptionDecision.full_handshake, decisions.last.?);
     try std.testing.expectEqual(events.CertificateState.valid, harness.observed.certificate_state.?);
 }
 
@@ -2385,6 +2423,7 @@ const PskOfferOptions = struct {
     /// Skip writing `psk_key_exchange_modes` — for the missing-extension
     /// malformed-input test.
     omit_modes: bool = false,
+    modes: []const pre_shared_key.PskKeyExchangeMode = &.{.psk_dhe_ke},
     /// When set, write this literal `pre_shared_key` extension_data
     /// verbatim instead of building it from `items` — bypasses
     /// `pre_shared_key.writeOffer`'s own `max_offered_identities` cap, for
@@ -2489,7 +2528,7 @@ fn buildClientHello(buf: []u8, opts: ClientHelloOptions) ![]const u8 {
         if (!psk_opt.omit_modes) {
             try w.u16_(pre_shared_key.ext_psk_key_exchange_modes);
             const modes_ext_len = try w.reserve(2);
-            try pre_shared_key.writeModes(&w, &.{.psk_dhe_ke});
+            try pre_shared_key.writeModes(&w, psk_opt.modes);
             w.patch(2, modes_ext_len);
         }
         if (psk_opt.raw_ext_data) |raw| {
@@ -4806,6 +4845,33 @@ test "resolver incompatibility reports incompatible full-handshake fallback" {
     try std.testing.expect(!server.core.psk_authenticated);
     try std.testing.expectEqual(@as(usize, 1), decisions.count);
     try std.testing.expectEqual(tls_backend.Tls13Backend.ResumptionDecision.incompatible, decisions.last.?);
+}
+
+test "unsupported PSK key-exchange mode reports full-handshake fallback" {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
+    defer server.deinit();
+
+    const psk = [_]u8{0xb4} ** tls_backend.hash_len;
+    var stored_state = pskStoredState(&psk);
+    defer stored_state.deinit();
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "psk-ke-only-ticket" };
+    try server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+    var decisions = DecisionProbe{};
+    try server.setResumptionDecisionObserver(decisions.observer());
+
+    try driveServerSelection(&server, .{ .psk = .{
+        .modes = &.{.psk_ke},
+        .items = &.{.{ .identity = "psk-ke-only-ticket", .binder_psk = &psk }},
+    } });
+
+    try std.testing.expectEqual(@as(usize, 0), resolver_state.calls);
+    try std.testing.expect(!server.core.psk_authenticated);
+    try std.testing.expectEqual(@as(usize, 1), decisions.count);
+    try std.testing.expectEqual(tls_backend.Tls13Backend.ResumptionDecision.full_handshake, decisions.last.?);
 }
 
 test "resolver lease releases bad-binder candidate before fatal failure and probes no later identity" {

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -3296,6 +3296,21 @@ const CountingResolver = struct {
     }
 };
 
+const DecisionProbe = struct {
+    count: usize = 0,
+    last: ?tls_backend.Tls13Backend.ResumptionDecision = null,
+
+    fn observer(self: *DecisionProbe) tls_backend.Tls13Backend.ResumptionDecisionObserver {
+        return .{ .ctx = self, .onDecisionFn = onDecision };
+    }
+
+    fn onDecision(ctx: *anyopaque, decision: tls_backend.Tls13Backend.ResumptionDecision) void {
+        const self: *@This() = @ptrCast(@alignCast(ctx));
+        self.count += 1;
+        self.last = decision;
+    }
+};
+
 const LeaseProbe = struct {
     commit_count: usize = 0,
     release_count: usize = 0,
@@ -3370,6 +3385,8 @@ test "async credential selection resumes PSK selection identically to the synchr
         .nowUnixMsFn = CountingResolver.now,
         .resolveFn = CountingResolver.resolve,
     });
+    var decisions = DecisionProbe{};
+    try server.setResumptionDecisionObserver(decisions.observer());
 
     var sink = DirectSink{};
     defer sink.deinit();
@@ -4544,6 +4561,8 @@ test "resolver identity-resolution attempts are bounded to eight even when a nin
         .nowUnixMsFn = CountingResolver.now,
         .resolveFn = CountingResolver.resolve,
     });
+    var decisions = DecisionProbe{};
+    try server.setResumptionDecisionObserver(decisions.observer());
 
     var ext_buf: [512]u8 = undefined;
     const raw_ext_data = try buildRawOfferedPsks(&ext_buf, 9);
@@ -4554,6 +4573,8 @@ test "resolver identity-resolution attempts are bounded to eight even when a nin
 
     try std.testing.expectEqual(@as(usize, 8), resolver_state.calls);
     try std.testing.expect(!server.core.psk_authenticated);
+    try std.testing.expectEqual(@as(usize, 1), decisions.count);
+    try std.testing.expectEqual(tls_backend.Tls13Backend.ResumptionDecision.miss, decisions.last.?);
 }
 
 test "resolver identity-resolution attempts stop at exactly eight when all eight are unusable" {
@@ -4601,6 +4622,8 @@ test "a resolver operational failure is fatal and distinct from an ordinary miss
         .nowUnixMsFn = FailingResolver.now,
         .resolveFn = FailingResolver.resolve,
     });
+    var decisions = DecisionProbe{};
+    try server.setResumptionDecisionObserver(decisions.observer());
 
     const psk = [_]u8{0x66} ** tls_backend.hash_len;
     try std.testing.expectError(error.CredentialProviderFailed, driveServerSelection(&server, .{
@@ -4610,6 +4633,8 @@ test "a resolver operational failure is fatal and distinct from an ordinary miss
     // identity, unlike an ordinary "unknown" miss.
     try std.testing.expectEqual(@as(usize, 1), resolver_state.calls);
     try std.testing.expectEqual(tls_backend.CredentialFailure.provider_internal_failure, server.credentialFailure().?);
+    try std.testing.expectEqual(@as(usize, 1), decisions.count);
+    try std.testing.expectEqual(tls_backend.Tls13Backend.ResumptionDecision.fatal, decisions.last.?);
 }
 
 test "a resolver that partially populates its output before failing leaves no residue" {
@@ -4657,6 +4682,8 @@ test "server selects the first compatible identity: unknown first, valid second"
         .nowUnixMsFn = CountingResolver.now,
         .resolveFn = CountingResolver.resolve,
     });
+    var decisions = DecisionProbe{};
+    try server.setResumptionDecisionObserver(decisions.observer());
 
     try driveServerSelection(&server, .{ .psk = .{ .items = &.{
         .{ .identity = "unknown-ticket", .binder_psk = &psk },
@@ -4666,6 +4693,8 @@ test "server selects the first compatible identity: unknown first, valid second"
     try std.testing.expectEqual(@as(usize, 2), resolver_state.calls);
     try std.testing.expect(server.core.psk_authenticated);
     try std.testing.expect(server.credentialFailure() == null);
+    try std.testing.expectEqual(@as(usize, 1), decisions.count);
+    try std.testing.expectEqual(tls_backend.Tls13Backend.ResumptionDecision.accepted, decisions.last.?);
 }
 
 test "a compatible candidate with a wrong binder is fatal and never probes a later identity" {
@@ -4682,6 +4711,8 @@ test "a compatible candidate with a wrong binder is fatal and never probes a lat
         .nowUnixMsFn = CountingResolver.now,
         .resolveFn = CountingResolver.resolve,
     });
+    var decisions = DecisionProbe{};
+    try server.setResumptionDecisionObserver(decisions.observer());
 
     var sink = DirectSink{};
     defer sink.deinit();
@@ -4703,6 +4734,8 @@ test "a compatible candidate with a wrong binder is fatal and never probes a lat
     // failed selection: the fatal binder mismatch is caught before
     // anything is written to the wire.
     try std.testing.expectEqual(events_before_client_hello, sink.len);
+    try std.testing.expectEqual(@as(usize, 1), decisions.count);
+    try std.testing.expectEqual(tls_backend.Tls13Backend.ResumptionDecision.fatal, decisions.last.?);
 }
 
 test "resolver lease releases incompatible candidate and commits later selected identity" {
@@ -4729,6 +4762,8 @@ test "resolver lease releases incompatible candidate and commits later selected 
         .nowUnixMsFn = TwoIdentityLeaseResolver.now,
         .resolveFn = TwoIdentityLeaseResolver.resolve,
     });
+    var decisions = DecisionProbe{};
+    try server.setResumptionDecisionObserver(decisions.observer());
 
     try driveServerSelection(&server, .{ .psk = .{ .items = &.{
         .{ .identity = "incompatible-ticket", .binder_psk = &psk },
@@ -4743,6 +4778,34 @@ test "resolver lease releases incompatible candidate and commits later selected 
     try std.testing.expectEqual(@as(usize, 0), compatible_lease.release_count);
     try std.testing.expectEqual(@as(usize, 1), compatible_lease.deinit_count);
     try std.testing.expect(server.core.psk_authenticated);
+    try std.testing.expectEqual(@as(usize, 1), decisions.count);
+    try std.testing.expectEqual(tls_backend.Tls13Backend.ResumptionDecision.accepted, decisions.last.?);
+}
+
+test "resolver incompatibility reports incompatible full-handshake fallback" {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
+    defer server.deinit();
+
+    const psk = [_]u8{0xa1} ** tls_backend.hash_len;
+    var incompatible_state = pskStoredStateWithBinding(&psk, session.AuthBinding.fromLeafCertificateDer("different-leaf"));
+    defer incompatible_state.deinit();
+    var resolver_state = CountingResolver{ .state = &incompatible_state, .identity = "incompatible-ticket" };
+    try server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+    var decisions = DecisionProbe{};
+    try server.setResumptionDecisionObserver(decisions.observer());
+
+    try driveServerSelection(&server, .{ .psk = .{ .items = &.{
+        .{ .identity = "incompatible-ticket", .binder_psk = &psk },
+    } } });
+
+    try std.testing.expectEqual(@as(usize, 1), resolver_state.calls);
+    try std.testing.expect(!server.core.psk_authenticated);
+    try std.testing.expectEqual(@as(usize, 1), decisions.count);
+    try std.testing.expectEqual(tls_backend.Tls13Backend.ResumptionDecision.incompatible, decisions.last.?);
 }
 
 test "resolver lease releases bad-binder candidate before fatal failure and probes no later identity" {

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -603,7 +603,156 @@ test "PSK round trip: an offered, resolved, and verified ticket resumes the hand
     try std.testing.expect(resumed.client_backend.core.psk_authenticated);
     try std.testing.expect(resumed.server_backend.core.psk_authenticated);
     // No certificate flight: the fixed server identity was never consumed.
-    try std.testing.expect(resumed.observed.certificate_state == null);
+    // `certificate_state` reports `.valid` anyway (#488) — a PSK-resumed
+    // handshake never sends Certificate, so the completion policy that
+    // requires a valid peer certificate for the client role would otherwise
+    // treat every resumed connection as fatally unauthenticated; the client
+    // instead inherits trust from the original full handshake that issued
+    // this ticket, confirmed here by the binder.
+    try std.testing.expectEqual(events.CertificateState.valid, resumed.observed.certificate_state.?);
+
+    // The resumed connection is genuinely usable: application data flows
+    // both ways under the PSK-derived keys.
+    var protected2: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext2: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    const request = try resumed.client_bridge.sealApplicationData("resumed request", &protected2);
+    const opened_request = try resumed.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, request), &plaintext2);
+    try std.testing.expectEqualStrings("resumed request", opened_request.inner.content);
+}
+
+test "#488: resumption_runtime.Runtime drives a genuine end-to-end resumed handshake via two-phase issuance" {
+    const resumption_runtime = tls_core.resumption_runtime;
+
+    // Phase 1: a full handshake. The server issues a ticket through the new
+    // #488 two-phase API (prepare -> Runtime.createIdentity -> emit) instead
+    // of the single-phase `emitNewSessionTicket`, and the client captures the
+    // resulting ClientTicketState into its own process-shared runtime.
+    var harness = DirectHarness.init();
+    defer harness.deinit();
+
+    var server_runtime = try resumption_runtime.Runtime.init(
+        std.testing.allocator,
+        .{ .mode = .stateful },
+        .{ .ctx = undefined, .nowUnixMsFn = struct {
+            fn now(_: *anyopaque) i64 {
+                return 1000;
+            }
+        }.now },
+        serverProvider(),
+    );
+    defer server_runtime.deinit();
+
+    var client_runtime = try resumption_runtime.Runtime.init(
+        std.testing.allocator,
+        .{ .mode = .stateful },
+        .{ .ctx = undefined, .nowUnixMsFn = struct {
+            fn now(_: *anyopaque) i64 {
+                return 2000;
+            }
+        }.now },
+        clientProvider(),
+    );
+    defer client_runtime.deinit();
+
+    const TicketCapture = struct {
+        runtime: *resumption_runtime.Runtime,
+        stored: session_cache.StoreResult = undefined,
+
+        fn now(_: *anyopaque) i64 {
+            return 1000;
+        }
+        fn onTicket(ctx: *anyopaque, ticket: *const session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.stored = self.runtime.storeClientTicket(ticket);
+        }
+    };
+    var capture = TicketCapture{ .runtime = &client_runtime };
+    const limits = session.Limits.default;
+    try harness.client_backend.setSessionTicketConsumer(std.testing.allocator, limits, .{
+        .ctx = &capture,
+        .nowUnixMsFn = TicketCapture.now,
+        .onTicketFn = TicketCapture.onTicket,
+    });
+    try harness.run();
+    try std.testing.expect(harness.client_driver.isComplete());
+    try std.testing.expect(harness.server_driver.isComplete());
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    var prepared = try harness.server_backend.prepareNewSessionTicket(std.testing.allocator, .{
+        .ticket_lifetime = 3600,
+        .ticket_age_add = 500,
+        .ticket_nonce = "\x01",
+        .issued_at_unix_ms = 1000,
+    }, limits);
+    defer prepared.deinit();
+    var scratch: [256]u8 = undefined;
+    var identity = try server_runtime.createIdentity(&prepared.state, 1000, &scratch);
+    try std.testing.expect(identity == .stateful);
+    try harness.server_backend.emitPreparedNewSessionTicket(std.testing.allocator, &sink, &prepared, identity.slice(), limits);
+    try std.testing.expectEqual(@as(usize, 1), sink.len);
+
+    // Deliver the ticket to the client over the (encrypted) application
+    // channel, exactly as a real deployment would.
+    const ticket_event = sink.items[0].handshake_bytes;
+    var protected: [record_codec.max_ciphertext_record_len * 2]u8 = undefined;
+    const records = (try harness.server_bridge.applyEvent(.{ .handshake_bytes = .{
+        .epoch = ticket_event.epoch,
+        .data = ticket_event.data,
+    } }, &protected)).?;
+    var parser = record_codec.Parser.init(.ciphertext);
+    var record_sink = record_codec.RecordSink(8, record_codec.max_ciphertext_fragment_len * 8){};
+    try parser.feed(records, &record_sink);
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    for (record_sink.items[0..record_sink.len]) |record| {
+        const opened = try harness.client_bridge.openHandshake(.application, record, &plaintext);
+        _ = try harness.client_driver.receive(.application, opened.inner.content);
+    }
+    try std.testing.expectEqual(session_cache.StoreResult.stored, capture.stored);
+
+    // Phase 2: a fresh connection looks its offer up through the client
+    // runtime and the server resolves it through the *same* server runtime
+    // that issued it — proving the runtime's cache/resolver composition (not
+    // hand-rolled test stand-ins) drives a real abbreviated handshake.
+    var resumed = DirectHarness.init();
+    defer resumed.deinit();
+
+    const candidate: session.CandidateContext = .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .server_name = null,
+        // The `DirectHarness` backends negotiate ALPN `h2` by default even
+        // without an explicit policy override; the candidate must match the
+        // exact origin the ticket was actually issued under.
+        .application_protocol = "h2",
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer(tls_backend.testdata.certificate_der),
+    };
+    var lookup = client_runtime.lookupClientOffers(candidate);
+    defer lookup.deinit();
+    try std.testing.expect(lookup == .hit);
+    try std.testing.expectEqual(@as(usize, 1), lookup.hit.offers.len);
+
+    var clock_dummy: u8 = 0;
+    const ClientClock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 2000;
+        }
+    };
+    try resumed.client_backend.setClientPskOfferLease(&lookup.hit, &clock_dummy, ClientClock.now);
+    try resumed.server_backend.setServerPskResolver(server_runtime.serverResolver().?);
+
+    try resumed.run();
+
+    try std.testing.expect(resumed.client_driver.isComplete());
+    try std.testing.expect(resumed.server_driver.isComplete());
+    try std.testing.expect(resumed.client_backend.core.psk_authenticated);
+    try std.testing.expect(resumed.server_backend.core.psk_authenticated);
+    // No certificate flight: this is a genuine PSK-abbreviated handshake, not
+    // merely a second successful full handshake. `certificate_state` reports
+    // `.valid` anyway (#488): the client inherits trust from the original
+    // full handshake that issued this ticket, confirmed here by the binder,
+    // since every transport completion policy otherwise requires a valid
+    // peer certificate for the client role.
+    try std.testing.expectEqual(events.CertificateState.valid, resumed.observed.certificate_state.?);
 
     // The resumed connection is genuinely usable: application data flows
     // both ways under the PSK-derived keys.

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -2432,6 +2432,14 @@ fn requireNativeTlsProfile() !void {
 }
 
 const PureZigTlsClient = struct {
+    const Options = struct {
+        ticket_consumer: ?tls_core.tls13_backend.Tls13Backend.SessionTicketConsumer = null,
+        ticket_limits: tls_core.session.Limits = tls_core.session.Limits.default,
+        psk_lease: ?*tls_core.pre_shared_key.ClientOfferLease = null,
+        psk_now_ctx: ?*anyopaque = null,
+        psk_now_fn: ?*const fn (*anyopaque) i64 = null,
+    };
+
     allocator: std.mem.Allocator,
     stream: compat.NetStream,
     entropy_source: tls_core.production_crypto.OsEntropy = .{},
@@ -2444,6 +2452,10 @@ const PureZigTlsClient = struct {
     }
 
     fn createWithServerName(allocator: std.mem.Allocator, port: u16, alpn: []const u8, server_name: ?[]const u8) !*PureZigTlsClient {
+        return createWithOptions(allocator, port, alpn, server_name, .{});
+    }
+
+    fn createWithOptions(allocator: std.mem.Allocator, port: u16, alpn: []const u8, server_name: ?[]const u8, options: Options) !*PureZigTlsClient {
         const self = try allocator.create(PureZigTlsClient);
         errdefer allocator.destroy(self);
         self.* = .{
@@ -2460,6 +2472,19 @@ const PureZigTlsClient = struct {
             tls_core.tls13_backend.recordConfig(alpnPolicy(alpn)),
             .{ .server_name = server_name },
         );
+        if (options.ticket_consumer != null or options.psk_lease != null) {
+            try self.backend.setResumeCompatibilityPolicy(.{ .transport = .ignore, .application = .ignore });
+        }
+        if (options.ticket_consumer) |consumer| {
+            try self.backend.setSessionTicketConsumer(allocator, options.ticket_limits, consumer);
+        }
+        if (options.psk_lease) |lease| {
+            try self.backend.setClientPskOfferLease(
+                lease,
+                options.psk_now_ctx orelse return error.InvalidTestSetup,
+                options.psk_now_fn orelse return error.InvalidTestSetup,
+            );
+        }
         self.record = try tls_core.encrypted_stream.PureZigRecordStream.initWithCarrierAndBackend(
             allocator,
             .client,
@@ -2866,6 +2891,28 @@ fn prometheusMetricValue(body: []const u8, name: []const u8) ?u64 {
         if (line.len == name.len) continue;
         if (line[name.len] != ' ') continue;
         return std.fmt.parseInt(u64, std.mem.trim(u8, line[name.len + 1 ..], " \t"), 10) catch null;
+    }
+    return null;
+}
+
+fn prometheusLabeledMetricValue(body: []const u8, name: []const u8, labels: []const []const u8) ?u64 {
+    var lines = std.mem.splitScalar(u8, body, '\n');
+    while (lines.next()) |line_raw| {
+        const line = std.mem.trim(u8, line_raw, " \t\r");
+        if (!std.mem.startsWith(u8, line, name)) continue;
+        if (line.len == name.len or line[name.len] != '{') continue;
+        const end_labels = std.mem.indexOfScalarPos(u8, line, name.len, '}') orelse continue;
+        const label_text = line[name.len + 1 .. end_labels];
+        var matched = true;
+        for (labels) |label| {
+            if (std.mem.indexOf(u8, label_text, label) == null) {
+                matched = false;
+                break;
+            }
+        }
+        if (!matched) continue;
+        const value_text = std.mem.trim(u8, line[end_labels + 1 ..], " \t");
+        return std.fmt.parseInt(u64, value_text, 10) catch null;
     }
     return null;
 }
@@ -7331,6 +7378,137 @@ test "native TLS listener appliance identity serves the exact configured SNI" {
     defer allocator.free(raw);
     try std.testing.expectEqual(@as(usize, 1), countOccurrences(raw, "HTTP/1.1 200 OK"));
     try assertContains(raw, "alive");
+}
+
+test "#488: native TLS listener resumes and serves HTTP traffic with production metrics" {
+    try requireNativeTlsProfile();
+    const allocator = std.testing.allocator;
+
+    var tls_paths = try nativeTlsFixturePaths(allocator);
+    defer tls_paths.deinit();
+
+    var tardigrade = try TardigradeProcess.start(allocator, .{
+        .config_text =
+        \\location = /healthz {
+        \\    return 200 alive;
+        \\}
+        ,
+        .ready_https_insecure = true,
+        .ready_path = "/healthz",
+        .extra_env = &.{
+            .{ .name = "TARDIGRADE_TLS_CERT_PATH", .value = tls_paths.cert_path },
+            .{ .name = "TARDIGRADE_TLS_KEY_PATH", .value = tls_paths.key_path },
+            .{ .name = "TARDIGRADE_TLS_SERVER_NAME", .value = "tardigrade.test" },
+            .{ .name = "TARDIGRADE_HTTP2_ENABLED", .value = "false" },
+            .{ .name = "TARDIGRADE_TLS_NATIVE_RESUMPTION_MODE", .value = "stateful" },
+        },
+    });
+    defer tardigrade.stop();
+
+    var client_entropy = tls_core.production_crypto.OsEntropy{};
+    var client_provider = tls_core.production_crypto.Provider.init(client_entropy.entropy());
+    var client_runtime = try tls_core.resumption_runtime.Runtime.init(
+        allocator,
+        .{ .mode = .stateful },
+        .{ .ctx = undefined, .nowUnixMsFn = struct {
+            fn now(_: *anyopaque) i64 {
+                return 2_000;
+            }
+        }.now },
+        client_provider.cryptoProvider(),
+    );
+    defer client_runtime.deinit();
+
+    const TicketCapture = struct {
+        allocator: std.mem.Allocator,
+        runtime: *tls_core.resumption_runtime.Runtime,
+        retained: tls_core.session.ClientTicketState = .{},
+        stored: tls_core.session_cache.StoreResult = undefined,
+        count: usize = 0,
+
+        fn now(_: *anyopaque) i64 {
+            return 2_000;
+        }
+
+        fn onTicket(ctx: *anyopaque, ticket: *const tls_core.session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.retained.deinit();
+            self.retained = .{};
+            ticket.cloneInto(self.allocator, &self.retained) catch unreachable;
+            self.stored = self.runtime.storeClientTicket(ticket);
+            self.count += 1;
+        }
+    };
+    var capture = TicketCapture{ .allocator = allocator, .runtime = &client_runtime };
+    defer capture.retained.deinit();
+
+    const first_client = try PureZigTlsClient.createWithOptions(allocator, tardigrade.port, "http/1.1", "tardigrade.test", .{
+        .ticket_consumer = .{
+            .ctx = &capture,
+            .nowUnixMsFn = TicketCapture.now,
+            .onTicketFn = TicketCapture.onTicket,
+        },
+    });
+    defer first_client.destroy();
+    try first_client.writeAllPlain("GET /healthz HTTP/1.1\r\nHost: tardigrade.test\r\nConnection: close\r\n\r\n");
+    const first_raw = try first_client.readPlainToEnd(allocator, 64 * 1024, 5_000);
+    defer allocator.free(first_raw);
+    try std.testing.expectEqual(@as(usize, 1), countOccurrences(first_raw, "HTTP/1.1 200 OK"));
+    try assertContains(first_raw, "alive");
+    try std.testing.expect(capture.count > 0);
+    try std.testing.expectEqual(tls_core.session_cache.StoreResult.stored, capture.stored);
+
+    const candidate: tls_core.session.CandidateContext = .{
+        .cipher_suite = capture.retained.common.cipher_suite,
+        .server_name = if (capture.retained.common.server_name) |*s| s.slice() else null,
+        .application_protocol = if (capture.retained.common.application_protocol) |*a| a.slice() else null,
+        .auth_binding = capture.retained.common.auth_binding,
+        .transport_compat = null,
+        .application_compat = null,
+    };
+    var lookup = client_runtime.lookupClientOffers(candidate);
+    defer lookup.deinit();
+    try std.testing.expect(lookup == .hit);
+    try std.testing.expectEqual(@as(usize, 1), lookup.hit.offers.len);
+
+    var clock_dummy: u8 = 0;
+    const ClientClock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 2_500;
+        }
+    };
+    const resumed_client = try PureZigTlsClient.createWithOptions(allocator, tardigrade.port, "http/1.1", "tardigrade.test", .{
+        .psk_lease = &lookup.hit,
+        .psk_now_ctx = &clock_dummy,
+        .psk_now_fn = ClientClock.now,
+    });
+    defer resumed_client.destroy();
+    try std.testing.expect(resumed_client.backend.core.psk_authenticated);
+    try resumed_client.writeAllPlain("GET /healthz HTTP/1.1\r\nHost: tardigrade.test\r\nConnection: close\r\n\r\n");
+    const resumed_raw = try resumed_client.readPlainToEnd(allocator, 64 * 1024, 5_000);
+    defer allocator.free(resumed_raw);
+    try std.testing.expectEqual(@as(usize, 1), countOccurrences(resumed_raw, "HTTP/1.1 200 OK"));
+    try assertContains(resumed_raw, "alive");
+
+    var metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
+    defer metrics.deinit();
+    try std.testing.expectEqual(@as(u16, 200), metrics.status_code);
+    try std.testing.expect((prometheusLabeledMetricValue(metrics.body, "tardigrade_tls_ticket_issue_total", &.{
+        "transport=\"record\"",
+        "mode=\"stateful\"",
+        "result=\"success\"",
+    }) orelse 0) >= 1);
+    try std.testing.expect((prometheusLabeledMetricValue(metrics.body, "tardigrade_tls_ticket_resolve_total", &.{
+        "mode=\"stateful\"",
+        "result=\"success\"",
+    }) orelse 0) >= 1);
+    try std.testing.expect((prometheusLabeledMetricValue(metrics.body, "tardigrade_tls_resumption_attempt_total", &.{
+        "transport=\"record\"",
+    }) orelse 0) >= 1);
+    try std.testing.expect((prometheusLabeledMetricValue(metrics.body, "tardigrade_tls_resumption_outcome_total", &.{
+        "transport=\"record\"",
+        "outcome=\"accepted\"",
+    }) orelse 0) >= 1);
 }
 
 test "native TLS listener appliance rejects unknown SNI before HTTP dispatch" {

--- a/tests/quic_h3_e2e.zig
+++ b/tests/quic_h3_e2e.zig
@@ -21,6 +21,7 @@
 const std = @import("std");
 const quic = @import("quic");
 const http3 = @import("http3");
+const tls_core = quic.tls_core;
 
 const connection = quic.connection;
 const tls_backend = quic.tls_backend;
@@ -239,8 +240,16 @@ const Sim = struct {
         to_server: Rules = .{},
         to_client: Rules = .{},
         quic: quic.config.Config = .{},
+        server_quic: ?quic.config.Config = null,
         limits: Limits = .{},
         log_failures: bool = true,
+        ticket_consumer: ?tls_core.tls13_backend.Tls13Backend.SessionTicketConsumer = null,
+        ticket_limits: tls_core.session.Limits = tls_core.session.Limits.default,
+        client_psk_lease: ?*tls_core.pre_shared_key.ClientOfferLease = null,
+        psk_now_ctx: ?*anyopaque = null,
+        psk_now_fn: ?*const fn (*anyopaque) i64 = null,
+        server_psk_resolver: ?tls_core.pre_shared_key.ServerPskResolver = null,
+        resume_compat: ?tls_core.tls13_backend.Tls13Backend.ResumeCompatibilityPolicy = null,
     };
 
     const FailureSnapshot = struct {
@@ -299,6 +308,23 @@ const Sim = struct {
                 .limits = sim_config.limits,
             },
         };
+        if (sim_config.resume_compat) |policy| {
+            try sim.client_backend.setResumeCompatibilityPolicy(policy);
+            try sim.server_backend.setResumeCompatibilityPolicy(policy);
+        }
+        if (sim_config.ticket_consumer) |consumer| {
+            try sim.client_backend.engine.setSessionTicketConsumer(allocator, sim_config.ticket_limits, consumer);
+        }
+        if (sim_config.client_psk_lease) |lease| {
+            try sim.client_backend.engine.setClientPskOfferLease(
+                lease,
+                sim_config.psk_now_ctx orelse return error.InvalidTestSetup,
+                sim_config.psk_now_fn orelse return error.InvalidTestSetup,
+            );
+        }
+        if (sim_config.server_psk_resolver) |resolver| {
+            try sim.server_backend.setServerPskResolver(resolver);
+        }
         sim.client = try Connection.init(allocator, .{
             .role = .client,
             .config = sim_config.quic,
@@ -310,7 +336,7 @@ const Sim = struct {
         errdefer sim.client.deinit();
         sim.server = try Connection.init(allocator, .{
             .role = .server,
-            .config = sim_config.quic,
+            .config = sim_config.server_quic orelse sim_config.quic,
             .local_cid = &odcid,
             .original_dcid = &odcid,
             .peer_cid = &client_cid,
@@ -546,6 +572,161 @@ test "e2e: lossless handshake, SETTINGS, request/response, clean close" {
     const info = sim.server.closeInfo().?;
     try testing.expect(info.is_application);
     try testing.expect(!info.local);
+}
+
+test "#488: runtime-backed resumed QUIC connection exchanges HTTP/3 after transport params change" {
+    const allocator = testing.allocator;
+    const runtime = tls_core.resumption_runtime;
+    const resume_policy: tls_core.tls13_backend.Tls13Backend.ResumeCompatibilityPolicy = .{
+        .transport = .ignore,
+        .application = .ignore,
+    };
+
+    var server_entropy = tls_core.production_crypto.OsEntropy{};
+    var server_provider = tls_core.production_crypto.Provider.init(server_entropy.entropy());
+    var server_runtime = try runtime.Runtime.init(
+        allocator,
+        .{ .mode = .stateful },
+        .{ .ctx = undefined, .nowUnixMsFn = struct {
+            fn now(_: *anyopaque) i64 {
+                return 1_000;
+            }
+        }.now },
+        server_provider.cryptoProvider(),
+    );
+    defer server_runtime.deinit();
+
+    var client_entropy = tls_core.production_crypto.OsEntropy{};
+    var client_provider = tls_core.production_crypto.Provider.init(client_entropy.entropy());
+    var client_runtime = try runtime.Runtime.init(
+        allocator,
+        .{ .mode = .stateful },
+        .{ .ctx = undefined, .nowUnixMsFn = struct {
+            fn now(_: *anyopaque) i64 {
+                return 2_000;
+            }
+        }.now },
+        client_provider.cryptoProvider(),
+    );
+    defer client_runtime.deinit();
+
+    const Capture = struct {
+        allocator: std.mem.Allocator,
+        runtime: *runtime.Runtime,
+        retained: tls_core.session.ClientTicketState = .{},
+        stored: tls_core.session_cache.StoreResult = undefined,
+        count: usize = 0,
+
+        fn now(_: *anyopaque) i64 {
+            return 2_000;
+        }
+
+        fn onTicket(ctx: *anyopaque, ticket: *const tls_core.session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.retained.deinit();
+            self.retained = .{};
+            ticket.cloneInto(self.allocator, &self.retained) catch unreachable;
+            self.stored = self.runtime.storeClientTicket(ticket);
+            self.count += 1;
+        }
+    };
+    var capture = Capture{ .allocator = allocator, .runtime = &client_runtime };
+    defer capture.retained.deinit();
+
+    const issue_quic: quic.config.Config = .{
+        .initial_max_data = 32 * 1024,
+        .initial_max_stream_data_bidi_local = 8 * 1024,
+        .initial_max_stream_data_bidi_remote = 8 * 1024,
+        .initial_max_stream_data_uni = 4 * 1024,
+        .initial_max_streams_bidi = 12,
+        .initial_max_streams_uni = 6,
+    };
+    var first = try Sim.init(allocator, .{
+        .scenario = "resumption-issue-h3",
+        .quic = issue_quic,
+        .server_quic = issue_quic,
+        .ticket_consumer = .{
+            .ctx = &capture,
+            .nowUnixMsFn = Capture.now,
+            .onTicketFn = Capture.onTicket,
+        },
+        .resume_compat = resume_policy,
+    });
+    defer first.deinit();
+    errdefer |err| first.recordFailure(err);
+    try runH3Exchange(first);
+
+    var prepared = try first.server.prepareNewSessionTicket(allocator, .{
+        .ticket_lifetime = 3600,
+        .ticket_age_add = 500,
+        .ticket_nonce = "\x01",
+        .issued_at_unix_ms = 1_000,
+    }, tls_core.session.Limits.default);
+    defer prepared.deinit();
+    var scratch: [256]u8 = undefined;
+    var identity = try server_runtime.createIdentity(&prepared.state, 1_000, &scratch);
+    defer identity.deinit();
+    try first.server.emitPreparedNewSessionTicket(&prepared, identity.slice(), tls_core.session.Limits.default);
+    const ticket_deadline = first.now_us + 30_000_000;
+    while (capture.count == 0 and first.now_us < ticket_deadline) {
+        if (!try first.step()) break;
+    }
+    try testing.expect(capture.count > 0);
+    try testing.expectEqual(tls_core.session_cache.StoreResult.stored, capture.stored);
+
+    const candidate: tls_core.session.CandidateContext = .{
+        .cipher_suite = capture.retained.common.cipher_suite,
+        .server_name = if (capture.retained.common.server_name) |*s| s.slice() else null,
+        .application_protocol = if (capture.retained.common.application_protocol) |*a| a.slice() else null,
+        .auth_binding = capture.retained.common.auth_binding,
+        .transport_compat = null,
+        .application_compat = null,
+    };
+    var lookup = client_runtime.lookupClientOffers(candidate);
+    defer lookup.deinit();
+    try testing.expect(lookup == .hit);
+
+    var clock_dummy: u8 = 0;
+    const ClientClock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 2_500;
+        }
+    };
+    const resume_client_quic: quic.config.Config = .{
+        .idle_timeout_ms = 20_000,
+        .active_connection_id_limit = 5,
+        .initial_max_data = 64 * 1024,
+        .initial_max_stream_data_bidi_local = 12 * 1024,
+        .initial_max_stream_data_bidi_remote = 12 * 1024,
+        .initial_max_stream_data_uni = 6 * 1024,
+        .initial_max_streams_bidi = 20,
+        .initial_max_streams_uni = 8,
+    };
+    const resume_server_quic: quic.config.Config = .{
+        .idle_timeout_ms = 45_000,
+        .active_connection_id_limit = 6,
+        .initial_max_data = 96 * 1024,
+        .initial_max_stream_data_bidi_local = 16 * 1024,
+        .initial_max_stream_data_bidi_remote = 16 * 1024,
+        .initial_max_stream_data_uni = 8 * 1024,
+        .initial_max_streams_bidi = 24,
+        .initial_max_streams_uni = 10,
+    };
+    var resumed = try Sim.init(allocator, .{
+        .scenario = "resumed-h3-changed-transport",
+        .quic = resume_client_quic,
+        .server_quic = resume_server_quic,
+        .client_psk_lease = &lookup.hit,
+        .psk_now_ctx = &clock_dummy,
+        .psk_now_fn = ClientClock.now,
+        .server_psk_resolver = server_runtime.serverResolver().?,
+        .resume_compat = resume_policy,
+    });
+    defer resumed.deinit();
+    errdefer |err| resumed.recordFailure(err);
+    try runH3Exchange(resumed);
+    try testing.expect(resumed.client_backend.engine.core.psk_authenticated);
+    try testing.expect(resumed.server_backend.engine.core.psk_authenticated);
 }
 
 test "e2e: lost client Initial recovers via PTO" {


### PR DESCRIPTION
## Summary

Completes the production integration work intentionally left after PR #486 (per the issue): the process-shared native TLS 1.3 resumption runtime (`tls.resumption_runtime.Runtime`) is now actually used end to end by native TLS-over-TCP and native QUIC/HTTP/3, rather than existing only as unused foundation.

- **Two-phase server ticket issuance** (`src/tls/tls13_backend.zig`, `src/tls/new_session_ticket.zig`, `src/tls/resumption_runtime.zig`): `prepareNewSessionTicket` → `Runtime.createIdentity` → `emitPreparedNewSessionTicket`, so the opaque bearer identity is derived from the exact prepared `ServerRecoverableState` instead of being invented by the caller. Stateful/stateless/hybrid dispatch, hybrid fallback on ordinary capacity refusal, and rollback (`rollbackIdentity`, backed by a new `StatefulServerCache.revokeHandle`) if emission fails after storage succeeded. The old one-phase `emitNewSessionTicket` is kept as a thin wrapper for existing callers.
- **Native TLS-over-TCP wiring** (`src/http/native_tls_connection.zig`): `Options.resumption_runtime` installs the shared server resolver before handshake start and triggers ticket issuance exactly once after application data opens, queued through the existing application-epoch record path (`PureZigRecordStream.applyEvent`) — no raw bytes written to the socket, no duplicate queue-limit logic.
- **Native QUIC/HTTP3 wiring** (`src/quic/tls_handshake.zig`, `src/quic/tls_backend.zig`, `src/quic/connection.zig`, `src/http/http3_runtime.zig`): thin forwarding seams (`setServerPskResolver`/`prepareNewSessionTicket`/`emitPreparedNewSessionTicket`) mirroring the TCP contract; `http3_runtime.Runtime` installs the same resolver per accepted connection and issues a ticket once established, through the existing application-CRYPTO reservation path. `enable_0rtt` stays false; no QUIC 0-RTT keys are touched.
- **Process composition root** (`src/edge_gateway.zig`, `src/gateway_state.zig`): one `resumption_runtime.Runtime` constructed per process when enabled, shared by every native TCP connection (via `WorkerContext`) and by `http3_runtime.Runtime`, torn down after its borrowers (defer ordering fires it last). When TCP uses OpenSSL, the runtime is only ever handed to HTTP/3 — no OpenSSL/native ticket interchange.
- **Native config boundary** (`src/edge_config.zig`): `TARDIGRADE_TLS_NATIVE_RESUMPTION_MODE` / `..._TICKET_LIFETIME_SECONDS` / `..._TICKET_USAGE`, distinct from the OpenSSL-facing `tls_session_*` fields, validated deterministically (invalid values fail `validate()`) and defaulting to disabled/safe.
- **Metrics** (`src/http/metrics.zig`): bounded, closed-enum counters — `tls_resumption_attempt_total`, `tls_resumption_outcome_total`, `tls_ticket_issue_total`, `tls_ticket_store_total`, `tls_ticket_resolve_total` — no secret or high-cardinality labels.
- **Bug fix surfaced by the new integration tests**: a PSK-resumed handshake never sends a Certificate message (by design), but both transports' completion policy (`encrypted_stream.zig`'s `completionPolicyError`, `tls_handshake.zig`'s `Handshake.complete`) unconditionally required a valid client-side peer certificate, which would have made every resumed connection fail closed with `CertificateInvalid` in production. Fixed by having the engine emit a synthetic `.certificate = .valid` event once the PSK binder confirms selection, since the client is inheriting trust already established at the original full handshake that issued the ticket.

## Scope notes

- Client-side native resumption wiring targets the codebase's current in-process test/deterministic-client usage; there is no production native TLS *client* connection type in this repo to wire (the issue explicitly says not to add one for this story).
- Metrics counters/schema are complete and tested, but not yet wired into every production call site (native TCP/QUIC issuance, client-side store) — a natural, low-risk follow-up.

## Test plan

- [x] `zig fmt --check build.zig src/ tests/`
- [x] `zig build test-session-cache --summary all` — 436/436
- [x] `zig build test-tls --summary all --error-style verbose` — 670/670 (includes new end-to-end resumed record-mode handshake test)
- [x] `zig build test-quic --summary all --error-style verbose` — 475/475 (includes new end-to-end resumed QUIC handshake test)
- [x] `zig build test-integration --summary all --error-style verbose`
- [x] `zig build test --summary all --error-style verbose` — 2482/2483 (1 known sandbox-only skip)
- [x] `zig build test -Dtls-profile=appliance --summary all --error-style verbose` — 2453/2454
- [x] `zig build -Doptimize=ReleaseFast --summary all --error-style verbose`
- [x] New focused integration tests prove genuine abbreviated handshakes (no Certificate flight, `psk_authenticated`, application data flows) for both record and QUIC, driven through `resumption_runtime.Runtime`'s cache/resolver composition rather than hand-rolled test stand-ins.

Closes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)