### PR TITLE
tls: add 0-RTT client/server negotiation and early secret derivation

### DIFF
--- a/src/tls/key_schedule.zig
+++ b/src/tls/key_schedule.zig
@@ -185,6 +185,22 @@ pub const KeySchedule = struct {
         }
     }
 
+    /// RFC 8446 §7.1/§4.2.10: the client's 0-RTT traffic secret, derived
+    /// from a resumption PSK and the hash of the *complete* ClientHello
+    /// (including its real binders) — never the binder-truncated prefix
+    /// used for binder computation itself. Independent of `KeySchedule`:
+    /// unlike `initWithPsk`, early data has no ECDHE contribution and is
+    /// derived directly from the early secret, before `derived_early_secret`
+    /// folds in the (EC)DHE shared secret for the handshake/master chain.
+    pub fn clientEarlyTrafficSecret(
+        psk: *const [hash_len]u8,
+        client_hello_hash: [hash_len]u8,
+    ) [hash_len]u8 {
+        var early_secret = HkdfSha256.extract("", psk);
+        defer crypto.secureZero(u8, &early_secret);
+        return tls.hkdfExpandLabel(HkdfSha256, early_secret, "c e traffic", &client_hello_hash, hash_len);
+    }
+
     pub fn finishedKey(traffic_secret: *const [hash_len]u8) [hash_len]u8 {
         return tls.hkdfExpandLabel(HkdfSha256, traffic_secret.*, "finished", "", hash_len);
     }
@@ -365,6 +381,40 @@ test "a different resumption PSK produces a different PSK-resumed schedule" {
     defer schedule_b.wipe();
 
     try std.testing.expect(!std.mem.eql(u8, &schedule_a.master_secret, &schedule_b.master_secret));
+}
+
+test "clientEarlyTrafficSecret matches an independently computed known-answer fixture" {
+    // Checked-in literals computed independently of this module (plain
+    // Python hmac/hashlib HKDF-Extract + RFC 8446 HKDF-Expand-Label), not by
+    // re-deriving with the helper under test.
+    const psk = [_]u8{0x99} ** hash_len;
+    const hello_hash = [_]u8{0x24} ** hash_len;
+
+    const early = KeySchedule.clientEarlyTrafficSecret(&psk, hello_hash);
+    try std.testing.expectEqualSlices(u8, &hexBytes("16d133c56483399331d093c3389c265a9547962c6b494b215e02e4eb92900afd"), &early);
+}
+
+test "clientEarlyTrafficSecret differs when the PSK differs" {
+    const psk_a = [_]u8{0x99} ** hash_len;
+    const psk_b = [_]u8{0xaa} ** hash_len;
+    const hello_hash_a = [_]u8{0x24} ** hash_len;
+    const hello_hash_b = [_]u8{0x11} ** hash_len;
+
+    const early_a = KeySchedule.clientEarlyTrafficSecret(&psk_a, hello_hash_a);
+    const early_b = KeySchedule.clientEarlyTrafficSecret(&psk_b, hello_hash_b);
+    try std.testing.expectEqualSlices(u8, &hexBytes("e69f3f7132880345ceda14cd7dcef6aeec62182cb3973d19a50371d75832f596"), &early_b);
+    try std.testing.expect(!std.mem.eql(u8, &early_a, &early_b));
+}
+
+test "clientEarlyTrafficSecret differs when only the ClientHello hash differs" {
+    // Same PSK as the first fixture above, but a different (complete)
+    // ClientHello hash: the early secret must bind to the exact transcript,
+    // not just the PSK, so this must differ from `early_a`.
+    const psk = [_]u8{0x99} ** hash_len;
+    const hello_hash = [_]u8{0x77} ** hash_len;
+
+    const early = KeySchedule.clientEarlyTrafficSecret(&psk, hello_hash);
+    try std.testing.expectEqualSlices(u8, &hexBytes("7d693eba9b582d3867e21784c2682d6ecef79deacbd28089a705e45ea8273310"), &early);
 }
 
 fn hexBytes(comptime hex: []const u8) [hex.len / 2]u8 {

--- a/src/tls/new_session_ticket.zig
+++ b/src/tls/new_session_ticket.zig
@@ -176,8 +176,9 @@ pub fn buildClientTicketState(
         .issued_at_unix_ms = received_at_unix_ms,
         .lifetime_seconds = parsed.ticket_lifetime,
         .early_data = earlyDataPolicy(parsed.max_early_data_size),
-        .transport_compat = connection.transport_compat,
+        .transport_compat = if (parsed.max_early_data_size == null) connection.transport_compat else null,
         .application_compat = connection.application_compat,
+        .early_data_transport_compat = if (parsed.max_early_data_size != null) connection.transport_compat else null,
     });
 
     var state: session.ClientTicketState = .{};
@@ -242,8 +243,9 @@ pub fn buildServerRecoverableStateNoIdentity(
         .issued_at_unix_ms = issued_at_unix_ms,
         .lifetime_seconds = params.ticket_lifetime,
         .early_data = earlyDataPolicy(params.max_early_data_size),
-        .transport_compat = connection.transport_compat,
+        .transport_compat = if (params.max_early_data_size == null) connection.transport_compat else null,
         .application_compat = connection.application_compat,
+        .early_data_transport_compat = if (params.max_early_data_size != null) connection.transport_compat else null,
     });
 
     var state: session.ServerRecoverableState = .{};
@@ -822,7 +824,8 @@ fn exerciseClientTicketBuild(allocator: std.mem.Allocator) !void {
     try std.testing.expectEqualSlices(u8, "\x01\x02", state.ticket_nonce.slice());
     try std.testing.expectEqualStrings("example.com", state.common.server_name.?.slice());
     try std.testing.expectEqualStrings("h2", state.common.application_protocol.?.slice());
-    try std.testing.expect(state.common.transport_compat != null);
+    try std.testing.expect(state.common.transport_compat == null);
+    try std.testing.expect(state.common.early_data_transport_compat != null);
     try std.testing.expect(state.common.application_compat != null);
 }
 
@@ -845,7 +848,8 @@ fn exerciseServerTicketBuild(allocator: std.mem.Allocator) !void {
     defer state.deinit();
     try std.testing.expectEqualStrings("example.com", state.common.server_name.?.slice());
     try std.testing.expectEqualStrings("h2", state.common.application_protocol.?.slice());
-    try std.testing.expect(state.common.transport_compat != null);
+    try std.testing.expect(state.common.transport_compat == null);
+    try std.testing.expect(state.common.early_data_transport_compat != null);
     try std.testing.expect(state.common.application_compat != null);
 }
 

--- a/src/tls/new_session_ticket.zig
+++ b/src/tls/new_session_ticket.zig
@@ -41,6 +41,8 @@ pub const ConnectionResumptionContext = struct {
     auth_binding: session.AuthBinding,
     transport_compat: ?CompatBlob = null,
     application_compat: ?CompatBlob = null,
+    early_data_transport_compat: ?CompatBlob = null,
+    early_data_application_compat: ?CompatBlob = null,
 };
 
 pub const EncodeError = error{
@@ -176,9 +178,10 @@ pub fn buildClientTicketState(
         .issued_at_unix_ms = received_at_unix_ms,
         .lifetime_seconds = parsed.ticket_lifetime,
         .early_data = earlyDataPolicy(parsed.max_early_data_size),
-        .transport_compat = if (parsed.max_early_data_size == null) connection.transport_compat else null,
+        .transport_compat = connection.transport_compat,
         .application_compat = connection.application_compat,
-        .early_data_transport_compat = if (parsed.max_early_data_size != null) connection.transport_compat else null,
+        .early_data_transport_compat = connection.early_data_transport_compat,
+        .early_data_application_compat = connection.early_data_application_compat,
     });
 
     var state: session.ClientTicketState = .{};
@@ -243,9 +246,10 @@ pub fn buildServerRecoverableStateNoIdentity(
         .issued_at_unix_ms = issued_at_unix_ms,
         .lifetime_seconds = params.ticket_lifetime,
         .early_data = earlyDataPolicy(params.max_early_data_size),
-        .transport_compat = if (params.max_early_data_size == null) connection.transport_compat else null,
+        .transport_compat = connection.transport_compat,
         .application_compat = connection.application_compat,
-        .early_data_transport_compat = if (params.max_early_data_size != null) connection.transport_compat else null,
+        .early_data_transport_compat = connection.early_data_transport_compat,
+        .early_data_application_compat = connection.early_data_application_compat,
     });
 
     var state: session.ServerRecoverableState = .{};
@@ -800,6 +804,8 @@ fn allocationSweepContext() ConnectionResumptionContext {
         .auth_binding = session.AuthBinding.fromLeafCertificateDer("leaf"),
         .transport_compat = .{ .format_id = 1, .format_version = 1, .bytes = "transport-compat" },
         .application_compat = .{ .format_id = 2, .format_version = 1, .bytes = "application-compat" },
+        .early_data_transport_compat = .{ .format_id = 3, .format_version = 1, .bytes = "early-transport-compat" },
+        .early_data_application_compat = .{ .format_id = 4, .format_version = 1, .bytes = "early-application-compat" },
     };
 }
 
@@ -824,9 +830,10 @@ fn exerciseClientTicketBuild(allocator: std.mem.Allocator) !void {
     try std.testing.expectEqualSlices(u8, "\x01\x02", state.ticket_nonce.slice());
     try std.testing.expectEqualStrings("example.com", state.common.server_name.?.slice());
     try std.testing.expectEqualStrings("h2", state.common.application_protocol.?.slice());
-    try std.testing.expect(state.common.transport_compat == null);
+    try std.testing.expect(state.common.transport_compat != null);
     try std.testing.expect(state.common.early_data_transport_compat != null);
     try std.testing.expect(state.common.application_compat != null);
+    try std.testing.expect(state.common.early_data_application_compat != null);
 }
 
 fn exerciseServerTicketBuild(allocator: std.mem.Allocator) !void {
@@ -848,9 +855,10 @@ fn exerciseServerTicketBuild(allocator: std.mem.Allocator) !void {
     defer state.deinit();
     try std.testing.expectEqualStrings("example.com", state.common.server_name.?.slice());
     try std.testing.expectEqualStrings("h2", state.common.application_protocol.?.slice());
-    try std.testing.expect(state.common.transport_compat == null);
+    try std.testing.expect(state.common.transport_compat != null);
     try std.testing.expect(state.common.early_data_transport_compat != null);
     try std.testing.expect(state.common.application_compat != null);
+    try std.testing.expect(state.common.early_data_application_compat != null);
 }
 
 fn exerciseClientTicketClone(allocator: std.mem.Allocator) !void {

--- a/src/tls/resumption_runtime.zig
+++ b/src/tls/resumption_runtime.zig
@@ -488,6 +488,25 @@ fn sampleServerState(allocator: std.mem.Allocator, sni: []const u8) !session.Ser
     return state;
 }
 
+fn sampleEarlyDataServerState(allocator: std.mem.Allocator, sni: []const u8) !session.ServerRecoverableState {
+    var common: session.ResumableSessionCommon = .{};
+    try common.init(allocator, session.Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = &([_]u8{0x43} ** 32),
+        .server_name = sni,
+        .application_protocol = "h3",
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer("leaf"),
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 86_400,
+        .early_data = .{ .early_data_capable = 32 },
+        .transport_compat = .{ .format_id = 1, .format_version = 1, .bytes = "ordinary-transport" },
+        .early_data_transport_compat = .{ .format_id = 57, .format_version = 1, .bytes = "remembered-server-transport" },
+    });
+    var state: session.ServerRecoverableState = .{};
+    state.init(&common, 7);
+    return state;
+}
+
 fn sampleClientTicket(allocator: std.mem.Allocator, ticket: []const u8, sni: []const u8) !session.ClientTicketState {
     var common: session.ResumableSessionCommon = .{};
     try common.init(allocator, session.Limits.default, .{
@@ -816,6 +835,34 @@ test "createIdentity stateless seals into caller scratch and does not consume st
     var hit = try resolver.resolve(identity.slice());
     defer hit.deinit();
     try std.testing.expect(hit == .hit);
+}
+
+test "createIdentity stateless preserves early-data transport compatibility" {
+    var clock = TestClock{};
+    var entropy_ctx = TestEntropy{};
+    var provider_impl = crypto.pure_zig.Provider.init(entropy_ctx.entropy());
+    var runtime = try Runtime.init(
+        std.testing.allocator,
+        .{ .mode = .stateless },
+        clock.clock(),
+        provider_impl.cryptoProvider(),
+    );
+    defer runtime.deinit();
+
+    var state = try sampleEarlyDataServerState(std.testing.allocator, "early-stateless.test");
+    defer state.deinit();
+    var scratch: [2048]u8 = undefined;
+    var identity = try runtime.createIdentity(&state, clock.now_ms, &scratch);
+
+    const resolver = runtime.serverResolver().?;
+    var hit = try resolver.resolve(identity.slice());
+    defer hit.deinit();
+    try std.testing.expect(hit == .hit);
+    try std.testing.expectEqualStrings("ordinary-transport", hit.hit.state.common.transport_compat.?.slice());
+    const early_transport = hit.hit.state.common.early_data_transport_compat orelse return error.TestExpectedEqual;
+    try std.testing.expectEqual(@as(u16, 57), early_transport.format_id);
+    try std.testing.expectEqual(@as(u16, 1), early_transport.format_version);
+    try std.testing.expectEqualStrings("remembered-server-transport", early_transport.slice());
 }
 
 test "createIdentity hybrid falls back to stateless on ordinary stateful capacity refusal" {

--- a/src/tls/session.zig
+++ b/src/tls/session.zig
@@ -307,6 +307,8 @@ pub const ResumableSessionCommon = struct {
     early_data: EarlyDataPolicy = .resume_only,
     transport_compat: ?CompatSnapshot = null,
     application_compat: ?CompatSnapshot = null,
+    early_data_transport_compat: ?CompatSnapshot = null,
+    early_data_application_compat: ?CompatSnapshot = null,
 
     pub const CompatBlobParams = struct {
         format_id: u16,
@@ -325,6 +327,8 @@ pub const ResumableSessionCommon = struct {
         early_data: EarlyDataPolicy = .resume_only,
         transport_compat: ?CompatBlobParams = null,
         application_compat: ?CompatBlobParams = null,
+        early_data_transport_compat: ?CompatBlobParams = null,
+        early_data_application_compat: ?CompatBlobParams = null,
     };
 
     pub const InitError = error{
@@ -394,6 +398,16 @@ pub const ResumableSessionCommon = struct {
             try snap.init(allocator, blob.format_id, blob.format_version, blob.bytes, limits.max_application_compat_len);
             next.application_compat = snap;
         }
+        if (params.early_data_transport_compat) |blob| {
+            var snap: CompatSnapshot = .{};
+            try snap.init(allocator, blob.format_id, blob.format_version, blob.bytes, limits.max_transport_compat_len);
+            next.early_data_transport_compat = snap;
+        }
+        if (params.early_data_application_compat) |blob| {
+            var snap: CompatSnapshot = .{};
+            try snap.init(allocator, blob.format_id, blob.format_version, blob.bytes, limits.max_application_compat_len);
+            next.early_data_application_compat = snap;
+        }
 
         self.moveFrom(&next);
     }
@@ -402,8 +416,12 @@ pub const ResumableSessionCommon = struct {
         self.resumption_psk.deinit();
         if (self.transport_compat) |*snap| snap.deinit();
         if (self.application_compat) |*snap| snap.deinit();
+        if (self.early_data_transport_compat) |*snap| snap.deinit();
+        if (self.early_data_application_compat) |*snap| snap.deinit();
         self.transport_compat = null;
         self.application_compat = null;
+        self.early_data_transport_compat = null;
+        self.early_data_application_compat = null;
     }
 
     /// `out` must be zero-valued or a previously-initialized, live value —
@@ -438,6 +456,16 @@ pub const ResumableSessionCommon = struct {
             var cloned: CompatSnapshot = .{};
             try snap.cloneInto(allocator, &cloned);
             next.application_compat = cloned;
+        }
+        if (self.early_data_transport_compat) |*snap| {
+            var cloned: CompatSnapshot = .{};
+            try snap.cloneInto(allocator, &cloned);
+            next.early_data_transport_compat = cloned;
+        }
+        if (self.early_data_application_compat) |*snap| {
+            var cloned: CompatSnapshot = .{};
+            try snap.cloneInto(allocator, &cloned);
+            next.early_data_application_compat = cloned;
         }
 
         out.moveFrom(&next);

--- a/src/tls/session.zig
+++ b/src/tls/session.zig
@@ -862,6 +862,8 @@ const field_lifetime_seconds: u16 = 0x0007;
 const field_early_data: u16 = 0x0008;
 const field_transport_compat: u16 = 0x8001;
 const field_application_compat: u16 = 0x8002;
+const field_early_data_transport_compat: u16 = 0x8003;
+const field_early_data_application_compat: u16 = 0x8004;
 
 const field_ticket: u16 = 0x0010;
 const field_ticket_age_add: u16 = 0x0011;
@@ -929,6 +931,8 @@ fn commonEncodedLen(common: *const ResumableSessionCommon) usize {
     total += tlvLen(earlyDataFieldLen(common.early_data));
     if (common.transport_compat) |*snap| total += tlvLen(4 + snap.slice().len);
     if (common.application_compat) |*snap| total += tlvLen(4 + snap.slice().len);
+    if (common.early_data_transport_compat) |*snap| total += tlvLen(4 + snap.slice().len);
+    if (common.early_data_application_compat) |*snap| total += tlvLen(4 + snap.slice().len);
     return total;
 }
 
@@ -953,6 +957,8 @@ fn commonFieldCount(common: *const ResumableSessionCommon) usize {
     if (common.application_protocol != null) count += 1;
     if (common.transport_compat != null) count += 1;
     if (common.application_compat != null) count += 1;
+    if (common.early_data_transport_compat != null) count += 1;
+    if (common.early_data_application_compat != null) count += 1;
     return count;
 }
 
@@ -964,6 +970,12 @@ fn checkCommonAgainstLimits(common: *const ResumableSessionCommon, limits: Limit
         if (snap.slice().len > limits.max_transport_compat_len) return error.FieldTooLarge;
     }
     if (common.application_compat) |*snap| {
+        if (snap.slice().len > limits.max_application_compat_len) return error.FieldTooLarge;
+    }
+    if (common.early_data_transport_compat) |*snap| {
+        if (snap.slice().len > limits.max_transport_compat_len) return error.FieldTooLarge;
+    }
+    if (common.early_data_application_compat) |*snap| {
         if (snap.slice().len > limits.max_application_compat_len) return error.FieldTooLarge;
     }
 }
@@ -1010,6 +1022,12 @@ fn validateCommonForEncoding(common: *const ResumableSessionCommon) EncodeError!
         if (snap.blob.len > snap.blob.bytes.len) return error.InvalidState;
     }
     if (common.application_compat) |*snap| {
+        if (snap.blob.len > snap.blob.bytes.len) return error.InvalidState;
+    }
+    if (common.early_data_transport_compat) |*snap| {
+        if (snap.blob.len > snap.blob.bytes.len) return error.InvalidState;
+    }
+    if (common.early_data_application_compat) |*snap| {
         if (snap.blob.len > snap.blob.bytes.len) return error.InvalidState;
     }
 }
@@ -1099,6 +1117,10 @@ fn writeCommon(out: []u8, pos: *usize, common: *const ResumableSessionCommon, co
     if (common.transport_compat) |*snap| writeCompatSnapshot(out, pos, field_transport_compat, snap, compat_scratch);
     if (common.application_compat) |*snap|
         writeCompatSnapshot(out, pos, field_application_compat, snap, compat_scratch);
+    if (common.early_data_transport_compat) |*snap|
+        writeCompatSnapshot(out, pos, field_early_data_transport_compat, snap, compat_scratch);
+    if (common.early_data_application_compat) |*snap|
+        writeCompatSnapshot(out, pos, field_early_data_application_compat, snap, compat_scratch);
 }
 
 fn writeHeader(out: []u8, kind: RecordType, field_section_len: u32) void {
@@ -1186,6 +1208,8 @@ const CommonFields = struct {
     early_data: ?EarlyDataPolicy = null,
     transport_compat: ?RawCompat = null,
     application_compat: ?RawCompat = null,
+    early_data_transport_compat: ?RawCompat = null,
+    early_data_application_compat: ?RawCompat = null,
 };
 
 const RawCompat = struct {
@@ -1290,6 +1314,14 @@ fn parseSharedField(builder: *CommonFields, limits: Limits, field_id: u16, value
             builder.application_compat = try decodeRawCompat(value, limits.max_application_compat_len);
             return true;
         },
+        field_early_data_transport_compat => {
+            builder.early_data_transport_compat = try decodeRawCompat(value, limits.max_transport_compat_len);
+            return true;
+        },
+        field_early_data_application_compat => {
+            builder.early_data_application_compat = try decodeRawCompat(value, limits.max_application_compat_len);
+            return true;
+        },
         else => return false,
     }
 }
@@ -1313,6 +1345,12 @@ fn buildCommon(
     var application_compat: ?ResumableSessionCommon.CompatBlobParams = null;
     if (fields.application_compat) |raw|
         application_compat = .{ .format_id = raw.format_id, .format_version = raw.format_version, .bytes = raw.bytes };
+    var early_data_transport_compat: ?ResumableSessionCommon.CompatBlobParams = null;
+    if (fields.early_data_transport_compat) |raw|
+        early_data_transport_compat = .{ .format_id = raw.format_id, .format_version = raw.format_version, .bytes = raw.bytes };
+    var early_data_application_compat: ?ResumableSessionCommon.CompatBlobParams = null;
+    if (fields.early_data_application_compat) |raw|
+        early_data_application_compat = .{ .format_id = raw.format_id, .format_version = raw.format_version, .bytes = raw.bytes };
 
     out.init(allocator, limits, .{
         .cipher_suite = cipher_suite,
@@ -1325,6 +1363,8 @@ fn buildCommon(
         .early_data = early_data,
         .transport_compat = transport_compat,
         .application_compat = application_compat,
+        .early_data_transport_compat = early_data_transport_compat,
+        .early_data_application_compat = early_data_application_compat,
     }) catch |err| switch (err) {
         error.InvalidDnsName => return error.InvalidSni,
         error.EmptyServerName => return error.EmptyServerName,
@@ -2282,6 +2322,77 @@ test "encode enforces max_application_compat_len symmetrically with decode" {
     // Decoding the same bytes under the tighter application-compat limit
     // must also fail, proving encode and decode agree on every limit.
     try testing.expectError(error.FieldTooLarge, decode(testing.allocator, tight_application, encoded));
+}
+
+test "client encode decode preserves early-data compatibility snapshots" {
+    var common: ResumableSessionCommon = .{};
+    try common.init(testing.allocator, Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = &([_]u8{0xab} ** 32),
+        .auth_binding = AuthBinding.fromLeafCertificateDer("leaf"),
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 100,
+        .early_data = .{ .early_data_capable = 32 },
+        .transport_compat = .{ .format_id = 1, .format_version = 1, .bytes = "ordinary-transport" },
+        .application_compat = .{ .format_id = 2, .format_version = 1, .bytes = "ordinary-application" },
+        .early_data_transport_compat = .{ .format_id = 3, .format_version = 7, .bytes = "early-transport" },
+        .early_data_application_compat = .{ .format_id = 4, .format_version = 8, .bytes = "early-application" },
+    });
+    var state: ClientTicketState = .{};
+    try state.init(testing.allocator, Limits.default, &common, .{
+        .ticket = "ticket",
+        .ticket_age_add = 1,
+        .ticket_nonce = "n",
+        .received_at_unix_ms = 0,
+    });
+    defer state.deinit();
+
+    var buf: [4096]u8 = undefined;
+    const encoded = try encodeClient(&state, Limits.default, &buf);
+    var decoded = try decode(testing.allocator, Limits.default, encoded);
+    defer decoded.deinit();
+
+    try testing.expectEqualStrings("ordinary-transport", decoded.client.common.transport_compat.?.slice());
+    try testing.expectEqualStrings("ordinary-application", decoded.client.common.application_compat.?.slice());
+    try testing.expectEqual(@as(u16, 3), decoded.client.common.early_data_transport_compat.?.format_id);
+    try testing.expectEqual(@as(u16, 7), decoded.client.common.early_data_transport_compat.?.format_version);
+    try testing.expectEqualStrings("early-transport", decoded.client.common.early_data_transport_compat.?.slice());
+    try testing.expectEqual(@as(u16, 4), decoded.client.common.early_data_application_compat.?.format_id);
+    try testing.expectEqual(@as(u16, 8), decoded.client.common.early_data_application_compat.?.format_version);
+    try testing.expectEqualStrings("early-application", decoded.client.common.early_data_application_compat.?.slice());
+}
+
+test "server encode decode preserves early-data compatibility snapshots" {
+    var common: ResumableSessionCommon = .{};
+    try common.init(testing.allocator, Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = &([_]u8{0xcd} ** 32),
+        .auth_binding = AuthBinding.fromLeafCertificateDer("leaf"),
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 100,
+        .early_data = .{ .early_data_capable = 64 },
+        .transport_compat = .{ .format_id = 1, .format_version = 1, .bytes = "ordinary-transport" },
+        .application_compat = .{ .format_id = 2, .format_version = 1, .bytes = "ordinary-application" },
+        .early_data_transport_compat = .{ .format_id = 5, .format_version = 9, .bytes = "server-early-transport" },
+        .early_data_application_compat = .{ .format_id = 6, .format_version = 10, .bytes = "server-early-application" },
+    });
+    var state: ServerRecoverableState = .{};
+    state.init(&common, 7);
+    defer state.deinit();
+
+    var buf: [4096]u8 = undefined;
+    const encoded = try encodeServer(&state, Limits.default, &buf);
+    var decoded = try decode(testing.allocator, Limits.default, encoded);
+    defer decoded.deinit();
+
+    try testing.expectEqualStrings("ordinary-transport", decoded.server.common.transport_compat.?.slice());
+    try testing.expectEqualStrings("ordinary-application", decoded.server.common.application_compat.?.slice());
+    try testing.expectEqual(@as(u16, 5), decoded.server.common.early_data_transport_compat.?.format_id);
+    try testing.expectEqual(@as(u16, 9), decoded.server.common.early_data_transport_compat.?.format_version);
+    try testing.expectEqualStrings("server-early-transport", decoded.server.common.early_data_transport_compat.?.slice());
+    try testing.expectEqual(@as(u16, 6), decoded.server.common.early_data_application_compat.?.format_id);
+    try testing.expectEqual(@as(u16, 10), decoded.server.common.early_data_application_compat.?.format_version);
+    try testing.expectEqualStrings("server-early-application", decoded.server.common.early_data_application_compat.?.slice());
 }
 
 test "encode enforces max_fields symmetrically with decode" {

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -389,16 +389,19 @@ pub const EarlyDataReplayGate = struct {
 /// until a transport-specific check is wired in.
 pub const EarlyDataCompatibilityDecision = enum { compatible, transport_incompatible, application_incompatible };
 
-/// Bounded, non-secret compatibility inputs: the ticket's stored
-/// transport/application snapshots against the current connection's
-/// candidate snapshots — the same shape `session.CandidateCompat` /
-/// `CompatSnapshot` already carry, flattened to slices so this seam does not
-/// need to import ownership/allocator-bearing session types.
+/// Bounded, non-secret compatibility input view that preserves the snapshot
+/// discriminator alongside the bytes. The gate's owner supplies the current
+/// local transport/application state in `ctx`; these fields are only the
+/// remembered values the selected ticket carries for early-data admission.
+pub const CompatView = struct {
+    format_id: u16,
+    format_version: u16,
+    bytes: []const u8,
+};
+
 pub const EarlyDataCompatibilityCandidate = struct {
-    stored_transport_compat: ?[]const u8 = null,
-    candidate_transport_compat: ?[]const u8 = null,
-    stored_application_compat: ?[]const u8 = null,
-    candidate_application_compat: ?[]const u8 = null,
+    remembered_transport: ?CompatView = null,
+    remembered_application: ?CompatView = null,
 };
 
 /// Server (#366): injectable early-data-specific compatibility gate,
@@ -683,11 +686,10 @@ pub const Tls13Backend = struct {
     /// RFC 8446 does not tell a client *why* the server omitted the
     /// extension when it did not accept.
     early_data_decision: EarlyDataDecision = .not_attempted,
-    /// Server: the ticket's advertised early-data byte allowance, captured
-    /// only when `early_data_decision == .accepted` — otherwise `0`. Exposed
-    /// via `earlyDataMaxBytes()` so the record/QUIC carrier slice knows how
-    /// much early-data plaintext it may accept while 0-RTT is live, instead
-    /// of discarding the ticket's own advertised limit.
+    /// Client: effective send allowance for the planned 0-RTT attempt
+    /// (`min(ticket allowance, configured max)`) while waiting for
+    /// EncryptedExtensions. Server: ticket allowance for an accepted attempt.
+    /// Cleared to zero when no early-data attempt is live/accepted.
     early_data_max_bytes: u32 = 0,
 
     const Slice = struct { start: usize, len: usize };
@@ -1045,9 +1047,10 @@ pub const Tls13Backend = struct {
         return self.early_data_decision;
     }
 
-    /// Server: the ticket's advertised early-data byte allowance, valid only
-    /// when `earlyDataAccepted()` is true (`0` otherwise). The record/QUIC
-    /// carrier bounds accepted early-data plaintext to this value.
+    /// Role-neutral early-data byte allowance. Client: maximum bytes this
+    /// attempt may send before EncryptedExtensions arrives. Server: maximum
+    /// bytes this accepted attempt may receive. Returns `0` when no such
+    /// allowance is currently live.
     pub fn earlyDataMaxBytes(self: *const Tls13Backend) u32 {
         return self.early_data_max_bytes;
     }
@@ -1715,7 +1718,7 @@ pub const Tls13Backend = struct {
         var state = new_session_ticket.buildClientTicketState(
             configured.allocator,
             parsed,
-            self.resumptionContext(),
+            self.resumptionContextForTicket(parsed.max_early_data_size != null),
             self.resumption_master_secret.slice(),
             received_at,
             configured.limits,
@@ -1933,6 +1936,7 @@ pub const Tls13Backend = struct {
 
         if (self.client_offer_lease.active) {
             var total = try checkedAdd(base_len, 6 + 8);
+            var kept: usize = 0;
             var i: usize = 0;
             while (i < self.client_offer_lease.offers.len) {
                 const ticket = &self.client_offer_lease.offers.tickets[i];
@@ -1944,7 +1948,9 @@ pub const Tls13Backend = struct {
                         keep = false;
                     } else {
                         const entry_len = try checkedAdd(try checkedAdd(2, identity_len), 4);
-                        const candidate_total = try checkedAdd(try checkedAdd(total, entry_len), 1 + hash_len);
+                        var candidate_total = try checkedAdd(try checkedAdd(total, entry_len), 1 + hash_len);
+                        if (kept == 0 and self.clientEarlyDataBudget(ticket) != null)
+                            candidate_total = try checkedAdd(candidate_total, 4);
                         if (candidate_total > max_message_len) {
                             keep = false;
                             stop = true;
@@ -1959,6 +1965,7 @@ pub const Tls13Backend = struct {
                     }
                     continue;
                 }
+                kept += 1;
                 i += 1;
             }
             if (self.client_offer_lease.offers.isEmpty()) self.client_offer_lease.finish(.not_selected);
@@ -1979,7 +1986,9 @@ pub const Tls13Backend = struct {
             if (identity_len == 0 or identity_len > std.math.maxInt(u16)) continue;
             // identity: 2 len + bytes + 4 age; binder: 1 len + digest.
             const entry_len = try checkedAdd(try checkedAdd(2, identity_len), 4);
-            const candidate_total = try checkedAdd(try checkedAdd(total, entry_len), 1 + hash_len);
+            var candidate_total = try checkedAdd(try checkedAdd(total, entry_len), 1 + hash_len);
+            if (emitted.len == 0 and self.clientEarlyDataBudget(ticket) != null)
+                candidate_total = try checkedAdd(candidate_total, 4);
             if (candidate_total > max_message_len) break; // does not fit: stop, in offer order
             total = candidate_total;
             emitted.push(ticket) catch break; // bounded by the loop guard above
@@ -1997,18 +2006,26 @@ pub const Tls13Backend = struct {
     /// `self.client_offer_lease.offers` to exactly the wire-emitted subset.
     fn planEarlyDataAttempt(self: *Tls13Backend) void {
         self.client_early_data_attempted = false;
+        self.early_data_max_bytes = 0;
         if (!self.client_early_data_intent.enabled) return;
 
         const offers = self.constClientPskOffers();
         if (offers.isEmpty()) return;
 
-        const max = switch (offers.constSlice()[0].common.early_data) {
-            .resume_only => return,
-            .early_data_capable => |n| n,
-        };
-        if (max == 0 or self.client_early_data_intent.max_bytes == 0) return;
+        const effective = self.clientEarlyDataBudget(&offers.constSlice()[0]) orelse return;
 
         self.client_early_data_attempted = true;
+        self.early_data_max_bytes = effective;
+    }
+
+    fn clientEarlyDataBudget(self: *const Tls13Backend, ticket: *const session.ClientTicketState) ?u32 {
+        if (!self.client_early_data_intent.enabled) return null;
+        const ticket_max = switch (ticket.common.early_data) {
+            .resume_only => return null,
+            .early_data_capable => |n| n,
+        };
+        const effective = @min(ticket_max, self.client_early_data_intent.max_bytes);
+        return if (effective == 0) null else effective;
     }
 
     /// Whether `ticket` is still safe and compatible to offer *now*: not
@@ -2076,16 +2093,6 @@ pub const Tls13Backend = struct {
         if (self.profile.extensionType() != null) {
             const payload = self.profile.localExtension() orelse return error.MissingTransportExtension;
             len = try checkedAdd(len, 2 + 2 + payload.len);
-        }
-        // #366: reserved whenever the client has opted in, regardless of
-        // whether `planEarlyDataAttempt` (which runs later, after this
-        // budget is used by `planPskOffer`'s own ticket-fitting arithmetic)
-        // ends up actually attempting 0-RTT — so a too-large PSK offer is
-        // rejected/trimmed by `planPskOffer` itself instead of the
-        // 4-byte `early_data` extension silently pushing `sendClientHello`'s
-        // fixed-capacity buffer past `max_message_len`.
-        if (self.client_early_data_intent.enabled) {
-            len = try checkedAdd(len, 4); // early_data: type(2) + length(2), empty body
         }
         return len;
     }
@@ -2345,6 +2352,8 @@ pub const Tls13Backend = struct {
             if (early_data_seen) {
                 self.early_data_accepted = true;
                 self.early_data_decision = .accepted;
+            } else {
+                self.early_data_max_bytes = 0;
             }
 
             self.connection_auth_binding = stored.auth_binding;
@@ -3185,10 +3194,8 @@ pub const Tls13Backend = struct {
                 .compatibility = decision.early_data,
                 .age_skew = age_skew,
                 .compat_candidate = .{
-                    .stored_transport_compat = if (hit.state.common.transport_compat) |*snap| snap.slice() else null,
-                    .candidate_transport_compat = if (self.candidateTransportCompat()) |c| c.bytes else null,
-                    .stored_application_compat = if (hit.state.common.application_compat) |*snap| snap.slice() else null,
-                    .candidate_application_compat = if (self.candidateApplicationCompat()) |c| c.bytes else null,
+                    .remembered_transport = compatView(hit.state.common.early_data_transport_compat),
+                    .remembered_application = compatView(hit.state.common.early_data_application_compat),
                 },
                 .replay_candidate = .{
                     .ticket_identity_fingerprint = identity_fingerprint,
@@ -3286,6 +3293,12 @@ pub const Tls13Backend = struct {
             .format_version = 1,
             .bytes = self.peer_transport_extension[0..self.peer_transport_extension_len],
         };
+    }
+
+    fn localTransportCompat(self: *const Tls13Backend) ?new_session_ticket.CompatBlob {
+        const bytes = self.profile.localExtension() orelse return null;
+        const ext_type = self.profile.extensionType() orelse return null;
+        return .{ .format_id = ext_type, .format_version = 1, .bytes = bytes };
     }
 
     /// PSK-resumed server flight: EncryptedExtensions straight to Finished —
@@ -3801,6 +3814,17 @@ pub const Tls13Backend = struct {
         };
     }
 
+    fn resumptionContextForTicket(self: *const Tls13Backend, early_data_capable: bool) new_session_ticket.ConnectionResumptionContext {
+        var ctx = self.resumptionContext();
+        if (early_data_capable) {
+            ctx.transport_compat = switch (self.role) {
+                .client => self.peerTransportCompat(),
+                .server => self.localTransportCompat(),
+            };
+        }
+        return ctx;
+    }
+
     fn peerAuthBinding(self: *const Tls13Backend) session.AuthBinding {
         if (self.peer_chain_count == 0) return session.AuthBinding.fromLeafCertificateDer("");
         const leaf = self.peer_chain_entries[0];
@@ -3983,7 +4007,7 @@ pub const Tls13Backend = struct {
                 .ticket_nonce = params.ticket_nonce,
                 .max_early_data_size = params.max_early_data_size,
             },
-            self.resumptionContext(),
+            self.resumptionContextForTicket(params.max_early_data_size != null),
             self.resumption_master_secret.slice(),
             params.issued_at_unix_ms,
             limits,
@@ -4139,6 +4163,11 @@ fn compatCompatible(stored: ?session.CompatSnapshot, candidate: ?session.Candida
         return s.format_id == c.format_id and s.format_version == c.format_version and std.mem.eql(u8, s.slice(), c.bytes);
     }
     return candidate == null;
+}
+
+fn compatView(stored: ?session.CompatSnapshot) ?CompatView {
+    const s = stored orelse return null;
+    return .{ .format_id = s.format_id, .format_version = s.format_version, .bytes = s.slice() };
 }
 
 fn mapPskReadError(err: pre_shared_key.ReadError) HandshakeError {

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -3817,7 +3817,7 @@ pub const Tls13Backend = struct {
     fn resumptionContextForTicket(self: *const Tls13Backend, early_data_capable: bool) new_session_ticket.ConnectionResumptionContext {
         var ctx = self.resumptionContext();
         if (early_data_capable) {
-            ctx.transport_compat = switch (self.role) {
+            ctx.early_data_transport_compat = switch (self.role) {
                 .client => self.peerTransportCompat(),
                 .server => self.localTransportCompat(),
             };

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -346,8 +346,20 @@ pub const EarlyDataReplayDecision = enum { allow, replay, unavailable };
 /// Bounded, non-secret metadata about an early-data attempt handed to the
 /// anti-replay gate — never the raw ticket, PSK, or binder. #368 owns the
 /// actual replay store; this is only the seam.
+///
+/// `selected_identity` alone (the field this type originally carried) is
+/// always `0` for every acceptable 0-RTT attempt — every candidate that
+/// reaches this gate has already passed `selected_identity_not_zero` — so it
+/// cannot distinguish one ticket/attempt from another. `ticket_identity_fingerprint`
+/// is what a real store keys on: a one-way digest of the offered ticket's
+/// opaque wire identity, so #368 can recognize "this exact ticket instance
+/// was already used for 0-RTT" without ever being handed the bearer ticket
+/// itself. `obfuscated_ticket_age` is the client's wire-visible (already
+/// obfuscated, already transmitted in the clear) ticket age, useful as
+/// auxiliary replay-window bookkeeping.
 pub const EarlyDataReplayCandidate = struct {
-    selected_identity: u16 = 0,
+    ticket_identity_fingerprint: [32]u8 = [_]u8{0} ** 32,
+    obfuscated_ticket_age: u32 = 0,
 };
 
 /// Server (#366/#368 seam): injectable anti-replay decision for an
@@ -361,6 +373,45 @@ pub const EarlyDataReplayGate = struct {
 
     fn decide(self: EarlyDataReplayGate, candidate: EarlyDataReplayCandidate) EarlyDataReplayDecision {
         const f = self.decideFn orelse return .unavailable;
+        return f(self.ctx, candidate);
+    }
+};
+
+/// #366: the outcome of an early-data-*specific* compatibility check,
+/// deliberately independent of `Tls13Backend.ResumeCompatibilityPolicy` /
+/// `session.evaluateCompatibility`'s resumption-eligibility gate — so a
+/// future transport-parameter check (e.g. QUIC's "remembered limits must
+/// not be reduced", #366 letter S) can reject *only* early data while
+/// ordinary 1-RTT resumption still succeeds even when `resume_compat` is
+/// configured to `.ignore` transport/application snapshots for resumption
+/// itself. The default gate (see `EarlyDataCompatibilityGate`) never
+/// produces anything but `.compatible`, so this is a pure extension seam
+/// until a transport-specific check is wired in.
+pub const EarlyDataCompatibilityDecision = enum { compatible, transport_incompatible, application_incompatible };
+
+/// Bounded, non-secret compatibility inputs: the ticket's stored
+/// transport/application snapshots against the current connection's
+/// candidate snapshots — the same shape `session.CandidateCompat` /
+/// `CompatSnapshot` already carry, flattened to slices so this seam does not
+/// need to import ownership/allocator-bearing session types.
+pub const EarlyDataCompatibilityCandidate = struct {
+    stored_transport_compat: ?[]const u8 = null,
+    candidate_transport_compat: ?[]const u8 = null,
+    stored_application_compat: ?[]const u8 = null,
+    candidate_application_compat: ?[]const u8 = null,
+};
+
+/// Server (#366): injectable early-data-specific compatibility gate,
+/// consulted independently of (in addition to) ordinary resumption
+/// eligibility. Defaults to always-compatible: no additional restriction
+/// beyond what `session.evaluateCompatibility` already required for
+/// resumption.
+pub const EarlyDataCompatibilityGate = struct {
+    ctx: *anyopaque = @ptrCast(@constCast(&empty_observer_dummy)),
+    decideFn: ?*const fn (*anyopaque, EarlyDataCompatibilityCandidate) EarlyDataCompatibilityDecision = null,
+
+    fn decide(self: EarlyDataCompatibilityGate, candidate: EarlyDataCompatibilityCandidate) EarlyDataCompatibilityDecision {
+        const f = self.decideFn orelse return .compatible;
         return f(self.ctx, candidate);
     }
 };
@@ -618,15 +669,26 @@ pub const Tls13Backend = struct {
     /// via `setEarlyDataReplayGate` before `start`. Defaults to
     /// `.unavailable`, which rejects only early data.
     early_data_replay_gate: EarlyDataReplayGate = .{},
+    /// Server (#366): injectable early-data-specific compatibility gate,
+    /// configured via `setEarlyDataCompatibilityGate` before `start`.
+    /// Defaults to always-compatible.
+    early_data_compat_gate: EarlyDataCompatibilityGate = .{},
     /// Whether 0-RTT was accepted for this connection — mirrors
     /// `early_data_decision == .accepted`, kept separately for cheap
     /// boolean access from record/QUIC carriers.
     early_data_accepted: bool = false,
     /// Server: authoritative reason `decideServerEarlyData` reached for the
-    /// selected candidate. Client: only ever observes `.accepted` (RFC 8446
-    /// does not tell a client *why* the server omitted the extension), so
-    /// this stays `.not_attempted` on the client except when accepted.
+    /// selected candidate. Client: mirrors `early_data_accepted` — `.accepted`
+    /// when the server signaled acceptance, `.not_attempted` otherwise, since
+    /// RFC 8446 does not tell a client *why* the server omitted the
+    /// extension when it did not accept.
     early_data_decision: EarlyDataDecision = .not_attempted,
+    /// Server: the ticket's advertised early-data byte allowance, captured
+    /// only when `early_data_decision == .accepted` — otherwise `0`. Exposed
+    /// via `earlyDataMaxBytes()` so the record/QUIC carrier slice knows how
+    /// much early-data plaintext it may accept while 0-RTT is live, instead
+    /// of discarding the ticket's own advertised limit.
+    early_data_max_bytes: u32 = 0,
 
     const Slice = struct { start: usize, len: usize };
     const PendingStage = enum { server_select, server_sign, client_select, client_sign, peer_verify };
@@ -947,10 +1009,27 @@ pub const Tls13Backend = struct {
         self.early_data_replay_gate = gate;
     }
 
-    /// Client: whether the ClientHello just sent actually attempted 0-RTT.
-    /// Independent of acceptance — see `earlyDataAccepted`.
+    /// Server (#366): configure the early-data-specific compatibility gate,
+    /// consulted independently of ordinary resumption eligibility. Must be
+    /// called before `start`; the default gate always reports `.compatible`.
+    pub fn setEarlyDataCompatibilityGate(self: *Tls13Backend, gate: EarlyDataCompatibilityGate) HandshakeError!void {
+        if (self.role != .server) return error.InvalidHandshakeState;
+        if (self.core.handshake_lifecycle != .idle) return error.InvalidHandshakeState;
+        self.early_data_compat_gate = gate;
+    }
+
+    /// Whether 0-RTT was attempted on this connection. Client: whether the
+    /// ClientHello just sent carried `early_data` (independent of
+    /// acceptance — see `earlyDataAccepted`). Server: whether the peer's
+    /// ClientHello carried `early_data`, regardless of whether this
+    /// connection went on to accept it — the later record/QUIC carrier
+    /// needs this even for an attempted-but-rejected connection (e.g. to
+    /// still expect and boundedly discard skipped first-flight ciphertext).
     pub fn earlyDataAttempted(self: *const Tls13Backend) bool {
-        return self.client_early_data_attempted;
+        return switch (self.role) {
+            .client => self.client_early_data_attempted,
+            .server => self.client_hello_early_data_seen,
+        };
     }
 
     /// Whether 0-RTT was accepted for this connection.
@@ -964,6 +1043,13 @@ pub const Tls13Backend = struct {
     /// (RFC 8446 EncryptedExtensions simply omits the extension).
     pub fn earlyDataDecision(self: *const Tls13Backend) EarlyDataDecision {
         return self.early_data_decision;
+    }
+
+    /// Server: the ticket's advertised early-data byte allowance, valid only
+    /// when `earlyDataAccepted()` is true (`0` otherwise). The record/QUIC
+    /// carrier bounds accepted early-data plaintext to this value.
+    pub fn earlyDataMaxBytes(self: *const Tls13Backend) u32 {
+        return self.early_data_max_bytes;
     }
 
     /// #362/#365: configure this connection's application-layer
@@ -1187,8 +1273,10 @@ pub const Tls13Backend = struct {
         self.client_hello_early_data_seen = false;
         self.server_early_data_policy = .{};
         self.early_data_replay_gate = .{};
+        self.early_data_compat_gate = .{};
         self.early_data_accepted = false;
         self.early_data_decision = .not_attempted;
+        self.early_data_max_bytes = 0;
         self.selected_client_psk.deinit();
         self.selected_client_psk_present = false;
         self.selected_server_psk.deinit();
@@ -1298,6 +1386,7 @@ pub const Tls13Backend = struct {
         self.client_hello_early_data_seen = false;
         self.early_data_accepted = false;
         self.early_data_decision = .not_attempted;
+        self.early_data_max_bytes = 0;
         self.clearClientHelloPsk();
         if (self.schedule) |*schedule| schedule.wipe();
         self.schedule = null;
@@ -1988,6 +2077,16 @@ pub const Tls13Backend = struct {
             const payload = self.profile.localExtension() orelse return error.MissingTransportExtension;
             len = try checkedAdd(len, 2 + 2 + payload.len);
         }
+        // #366: reserved whenever the client has opted in, regardless of
+        // whether `planEarlyDataAttempt` (which runs later, after this
+        // budget is used by `planPskOffer`'s own ticket-fitting arithmetic)
+        // ends up actually attempting 0-RTT — so a too-large PSK offer is
+        // rejected/trimmed by `planPskOffer` itself instead of the
+        // 4-byte `early_data` extension silently pushing `sendClientHello`'s
+        // fixed-capacity buffer past `max_message_len`.
+        if (self.client_early_data_intent.enabled) {
+            len = try checkedAdd(len, 4); // early_data: type(2) + length(2), empty body
+        }
         return len;
     }
 
@@ -2243,7 +2342,10 @@ pub const Tls13Backend = struct {
             // accepted `early_data` extension, regardless of what the
             // client attempted.
             if (early_data_seen and stored.early_data == .resume_only) return error.IllegalParameter;
-            if (early_data_seen) self.early_data_accepted = true;
+            if (early_data_seen) {
+                self.early_data_accepted = true;
+                self.early_data_decision = .accepted;
+            }
 
             self.connection_auth_binding = stored.auth_binding;
         }
@@ -3076,13 +3178,29 @@ pub const Tls13Backend = struct {
             // first-flight data) and only after binder verification, so an
             // early-data rejection never rejects an otherwise-valid PSK
             // resumption.
+            var identity_fingerprint: [hash_len]u8 = undefined;
+            Sha256.hash(pair.identity.identity, &identity_fingerprint, .{});
             const early_decision = self.decideServerEarlyData(.{
                 .selected_index = attempts,
                 .compatibility = decision.early_data,
                 .age_skew = age_skew,
+                .compat_candidate = .{
+                    .stored_transport_compat = if (hit.state.common.transport_compat) |*snap| snap.slice() else null,
+                    .candidate_transport_compat = if (self.candidateTransportCompat()) |c| c.bytes else null,
+                    .stored_application_compat = if (hit.state.common.application_compat) |*snap| snap.slice() else null,
+                    .candidate_application_compat = if (self.candidateApplicationCompat()) |c| c.bytes else null,
+                },
+                .replay_candidate = .{
+                    .ticket_identity_fingerprint = identity_fingerprint,
+                    .obfuscated_ticket_age = pair.identity.obfuscated_ticket_age,
+                },
             });
             self.early_data_decision = early_decision;
             self.early_data_accepted = early_decision == .accepted;
+            self.early_data_max_bytes = if (early_decision == .accepted) switch (decision.early_data) {
+                .allowed => |max| max,
+                .disabled, .incompatible => 0,
+            } else 0;
             if (early_decision == .accepted) {
                 var client_hello_hash: [hash_len]u8 = undefined;
                 Sha256.hash(capture.message[0..capture.message_len], &client_hello_hash, .{});
@@ -3118,12 +3236,18 @@ pub const Tls13Backend = struct {
         selected_index: usize,
         compatibility: session.EarlyDataEligibility,
         age_skew: pre_shared_key.AgeSkew,
+        compat_candidate: EarlyDataCompatibilityCandidate,
+        replay_candidate: EarlyDataReplayCandidate,
     };
 
     /// #366: the server's live 0-RTT decision for the just-selected,
     /// binder-verified candidate. `inputs.compatibility` already reflects
     /// `client_hello_early_data_seen`/identity-0/ticket-capability via
-    /// `session.evaluateCompatibility`'s `want_early_data`; resource
+    /// `session.evaluateCompatibility`'s `want_early_data`; the early-data-
+    /// specific compatibility gate (`early_data_compat_gate`) runs
+    /// independently of that resumption-level check, so it can reject only
+    /// early data even when `resume_compat` is configured to `.ignore`
+    /// transport/application snapshots for ordinary resumption. Resource
     /// admission (byte/request caps) is a composition-root concern layered
     /// on top of this backend and is never produced here.
     fn decideServerEarlyData(self: *Tls13Backend, inputs: ServerEarlyDataInputs) EarlyDataDecision {
@@ -3140,9 +3264,14 @@ pub const Tls13Backend = struct {
             .disabled, .incompatible => return .ticket_not_capable,
             .allowed => {},
         }
+        switch (self.early_data_compat_gate.decide(inputs.compat_candidate)) {
+            .transport_incompatible => return .transport_incompatible,
+            .application_incompatible => return .application_incompatible,
+            .compatible => {},
+        }
         if (!skewWithinTolerance(inputs.age_skew.skew_ms, self.server_early_data_policy.age_skew_tolerance_ms))
             return .age_skew;
-        return switch (self.early_data_replay_gate.decide(.{ .selected_identity = @intCast(inputs.selected_index) })) {
+        return switch (self.early_data_replay_gate.decide(inputs.replay_candidate)) {
             .allow => .accepted,
             .replay => .replay_rejected,
             .unavailable => .replay_unavailable,
@@ -3967,6 +4096,37 @@ fn skewWithinTolerance(skew_ms: i64, tolerance_ms: u64) bool {
     else
         @intCast(skew_ms);
     return magnitude <= tolerance_ms;
+}
+
+test "skewWithinTolerance accepts exact positive and negative boundaries" {
+    try std.testing.expect(skewWithinTolerance(1000, 1000));
+    try std.testing.expect(skewWithinTolerance(-1000, 1000));
+}
+
+test "skewWithinTolerance rejects one past either boundary" {
+    try std.testing.expect(!skewWithinTolerance(1001, 1000));
+    try std.testing.expect(!skewWithinTolerance(-1001, 1000));
+}
+
+test "skewWithinTolerance treats exact zero skew and zero tolerance consistently" {
+    try std.testing.expect(skewWithinTolerance(0, 0));
+    try std.testing.expect(!skewWithinTolerance(1, 0));
+    try std.testing.expect(!skewWithinTolerance(-1, 0));
+}
+
+test "skewWithinTolerance handles minInt(i64) without trapping" {
+    // `-minInt(i64)` overflows `i64` itself (its magnitude is exactly
+    // `2^63`, one past `maxInt(i64)`); the `i128` promotion inside
+    // `skewWithinTolerance` is what makes this representable at all rather
+    // than trapping.
+    const magnitude_of_min_i64: u64 = @as(u64, 1) << 63;
+    try std.testing.expect(skewWithinTolerance(std.math.minInt(i64), magnitude_of_min_i64));
+    try std.testing.expect(!skewWithinTolerance(std.math.minInt(i64), magnitude_of_min_i64 - 1));
+}
+
+test "skewWithinTolerance handles maxInt(i64) at the u64 tolerance boundary" {
+    try std.testing.expect(skewWithinTolerance(std.math.maxInt(i64), @as(u64, std.math.maxInt(i64))));
+    try std.testing.expect(!skewWithinTolerance(std.math.maxInt(i64), @as(u64, std.math.maxInt(i64)) - 1));
 }
 
 /// Symmetric optional equality for a stored `CompatSnapshot` against a

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -37,6 +37,7 @@ const X25519 = crypto.dh.X25519;
 const Ed25519 = crypto.sign.Ed25519;
 const EcdsaP256 = crypto.sign.ecdsa.EcdsaP256Sha256;
 const Certificate = crypto.Certificate;
+const Sha256 = crypto.hash.sha2.Sha256;
 
 const EncryptionLevel = events.EncryptionEpoch;
 const CertificateState = events.CertificateState;
@@ -192,6 +193,7 @@ const ext_signature_algorithms: u16 = @intFromEnum(tls_algorithms.ExtensionType.
 const ext_alpn: u16 = @intFromEnum(tls_algorithms.ExtensionType.application_layer_protocol_negotiation);
 const ext_supported_versions: u16 = @intFromEnum(tls_algorithms.ExtensionType.supported_versions);
 const ext_key_share: u16 = @intFromEnum(tls_algorithms.ExtensionType.key_share);
+const ext_early_data: u16 = @intFromEnum(tls_algorithms.ExtensionType.early_data);
 pub const max_transport_extension_len = 512;
 
 const native_protocol_versions = [_]tls_algorithms.ProtocolVersion{.tls13};
@@ -291,6 +293,77 @@ const hello_retry_request_random = [32]u8{
 // ===========================================================================
 
 pub const KeySchedule = tls_key_schedule.KeySchedule;
+
+// ===========================================================================
+// 0-RTT / early-data vocabulary (#366).
+//
+// Native TLS 1.3/QUIC 0-RTT mechanics: explicit client opt-in, a server-side
+// identity-0/skew/replay decision made inside the existing `selectPsk`
+// selection, and EncryptedExtensions acceptance signaling. Ticket
+// advertisement, record/QUIC key installation, and HTTP-level request-safety
+// gating are separate follow-up slices (#366's own suggested PR breakdown);
+// this backend owns only the TLS-layer negotiation and secret derivation.
+// ===========================================================================
+
+/// Client: explicit application opt-in to attempt 0-RTT on this connection.
+/// Disabled by default — configured before `start` via
+/// `setClientEarlyDataIntent`.
+pub const ClientEarlyDataIntent = struct {
+    enabled: bool = false,
+    max_bytes: u32 = 0,
+};
+
+/// Why (or whether) 0-RTT was accepted for this connection. Distinct from
+/// the boolean `earlyDataAccepted()`/`earlyDataAttempted()` accessors: this
+/// is the closed set of reasons a caller can log/meter without ever
+/// exposing secret or attacker-controlled values.
+pub const EarlyDataDecision = enum {
+    not_attempted,
+    accepted,
+    disabled,
+    ticket_not_capable,
+    selected_identity_not_zero,
+    age_skew,
+    transport_incompatible,
+    application_incompatible,
+    replay_rejected,
+    replay_unavailable,
+    resource_limited,
+};
+
+/// Server: enablement/tolerance for accepting 0-RTT. Disabled by default;
+/// configured before `start` via `setServerEarlyDataPolicy`. Resource
+/// admission (`EarlyDataDecision.resource_limited`) is a composition-root
+/// concern (concurrent-request/byte caps) layered on top of this backend,
+/// not decided here.
+pub const ServerEarlyDataPolicy = struct {
+    enabled: bool = false,
+    age_skew_tolerance_ms: u64 = 60_000,
+};
+
+pub const EarlyDataReplayDecision = enum { allow, replay, unavailable };
+
+/// Bounded, non-secret metadata about an early-data attempt handed to the
+/// anti-replay gate — never the raw ticket, PSK, or binder. #368 owns the
+/// actual replay store; this is only the seam.
+pub const EarlyDataReplayCandidate = struct {
+    selected_identity: u16 = 0,
+};
+
+/// Server (#366/#368 seam): injectable anti-replay decision for an
+/// otherwise-acceptable 0-RTT attempt. The default (`decideFn == null`)
+/// reports `.unavailable`, which rejects only early data and preserves
+/// ordinary 1-RTT resumption — production is safe with no replay store
+/// configured at all.
+pub const EarlyDataReplayGate = struct {
+    ctx: *anyopaque = @ptrCast(@constCast(&empty_observer_dummy)),
+    decideFn: ?*const fn (*anyopaque, EarlyDataReplayCandidate) EarlyDataReplayDecision = null,
+
+    fn decide(self: EarlyDataReplayGate, candidate: EarlyDataReplayCandidate) EarlyDataReplayDecision {
+        const f = self.decideFn orelse return .unavailable;
+        return f(self.ctx, candidate);
+    }
+};
 
 const ExtensionGuard = struct {
     pub const max_extensions = 64;
@@ -523,10 +596,41 @@ pub const Tls13Backend = struct {
     /// never rejects ordinary 1-RTT resumption; #366 is the intended
     /// consumer (e.g. to gate early-data acceptance).
     last_psk_age_skew: ?pre_shared_key.AgeSkew = null,
+    /// Client (#366): explicit opt-in to attempt 0-RTT, configured via
+    /// `setClientEarlyDataIntent` before `start`.
+    client_early_data_intent: ClientEarlyDataIntent = .{},
+    /// Client: whether the ClientHello just sent actually carried the
+    /// `early_data` extension (decided by `planEarlyDataAttempt` from the
+    /// first surviving PSK offer — #487's wire-index/lease semantics are
+    /// never reordered to find an early-capable ticket).
+    client_early_data_attempted: bool = false,
+    /// Client: the wire index of the identity ServerHello selected (if
+    /// any), retained so `onEncryptedExtensions` can check an accepted
+    /// `early_data` extension applies only to identity 0.
+    selected_client_psk_index: ?u16 = null,
+    /// Server: whether the just-parsed ClientHello carried the (empty)
+    /// `early_data` extension.
+    client_hello_early_data_seen: bool = false,
+    /// Server (#366): enablement/tolerance for accepting 0-RTT, configured
+    /// via `setServerEarlyDataPolicy` before `start`.
+    server_early_data_policy: ServerEarlyDataPolicy = .{},
+    /// Server (#366/#368 seam): injectable anti-replay decision, configured
+    /// via `setEarlyDataReplayGate` before `start`. Defaults to
+    /// `.unavailable`, which rejects only early data.
+    early_data_replay_gate: EarlyDataReplayGate = .{},
+    /// Whether 0-RTT was accepted for this connection — mirrors
+    /// `early_data_decision == .accepted`, kept separately for cheap
+    /// boolean access from record/QUIC carriers.
+    early_data_accepted: bool = false,
+    /// Server: authoritative reason `decideServerEarlyData` reached for the
+    /// selected candidate. Client: only ever observes `.accepted` (RFC 8446
+    /// does not tell a client *why* the server omitted the extension), so
+    /// this stays `.not_attempted` on the client except when accepted.
+    early_data_decision: EarlyDataDecision = .not_attempted,
 
     const Slice = struct { start: usize, len: usize };
     const PendingStage = enum { server_select, server_sign, client_select, client_sign, peer_verify };
-    const PskSelected = struct { index: usize, psk: [hash_len]u8 };
+    const PskSelected = struct { index: usize, psk: [hash_len]u8, early_data: EarlyDataDecision = .not_attempted };
     pub const ResumptionDecision = enum { accepted, miss, incompatible, full_handshake, fatal };
 
     pub const ResumptionDecisionObserver = struct {
@@ -814,6 +918,54 @@ pub const Tls13Backend = struct {
         self.resumption_decision_observer = observer;
     }
 
+    /// Client (#366): opt in to attempting 0-RTT on this connection. Must
+    /// be called before `start`; disabled (the default) means the client
+    /// never emits `early_data` even when an early-capable ticket is
+    /// offered.
+    pub fn setClientEarlyDataIntent(self: *Tls13Backend, intent: ClientEarlyDataIntent) HandshakeError!void {
+        if (self.role != .client) return error.InvalidHandshakeState;
+        if (self.core.handshake_lifecycle != .idle) return error.InvalidHandshakeState;
+        self.client_early_data_intent = intent;
+    }
+
+    /// Server (#366): configure whether/how tolerantly this connection
+    /// accepts 0-RTT. Must be called before `start`; disabled (the
+    /// default) means this connection never accepts early data even from
+    /// an early-capable ticket.
+    pub fn setServerEarlyDataPolicy(self: *Tls13Backend, policy: ServerEarlyDataPolicy) HandshakeError!void {
+        if (self.role != .server) return error.InvalidHandshakeState;
+        if (self.core.handshake_lifecycle != .idle) return error.InvalidHandshakeState;
+        self.server_early_data_policy = policy;
+    }
+
+    /// Server (#366/#368 seam): configure the anti-replay decision hook
+    /// consulted for an otherwise-acceptable 0-RTT attempt. Must be called
+    /// before `start`; the default gate reports `.unavailable`.
+    pub fn setEarlyDataReplayGate(self: *Tls13Backend, gate: EarlyDataReplayGate) HandshakeError!void {
+        if (self.role != .server) return error.InvalidHandshakeState;
+        if (self.core.handshake_lifecycle != .idle) return error.InvalidHandshakeState;
+        self.early_data_replay_gate = gate;
+    }
+
+    /// Client: whether the ClientHello just sent actually attempted 0-RTT.
+    /// Independent of acceptance — see `earlyDataAccepted`.
+    pub fn earlyDataAttempted(self: *const Tls13Backend) bool {
+        return self.client_early_data_attempted;
+    }
+
+    /// Whether 0-RTT was accepted for this connection.
+    pub fn earlyDataAccepted(self: *const Tls13Backend) bool {
+        return self.early_data_accepted;
+    }
+
+    /// The authoritative server-side reason 0-RTT was or was not accepted
+    /// (see `EarlyDataDecision`). On the client this only ever reaches
+    /// `.accepted`; a client-observed rejection carries no reason
+    /// (RFC 8446 EncryptedExtensions simply omits the extension).
+    pub fn earlyDataDecision(self: *const Tls13Backend) EarlyDataDecision {
+        return self.early_data_decision;
+    }
+
     /// #362/#365: configure this connection's application-layer
     /// compatibility snapshot (e.g. HTTP/3 settings), compared against a
     /// candidate PSK's stored value on the server and used to recheck an
@@ -1029,6 +1181,14 @@ pub const Tls13Backend = struct {
         self.application_compat_present = false;
         self.application_compat_len = 0;
         self.last_psk_age_skew = null;
+        self.client_early_data_intent = .{};
+        self.client_early_data_attempted = false;
+        self.selected_client_psk_index = null;
+        self.client_hello_early_data_seen = false;
+        self.server_early_data_policy = .{};
+        self.early_data_replay_gate = .{};
+        self.early_data_accepted = false;
+        self.early_data_decision = .not_attempted;
         self.selected_client_psk.deinit();
         self.selected_client_psk_present = false;
         self.selected_server_psk.deinit();
@@ -1131,6 +1291,13 @@ pub const Tls13Backend = struct {
         self.selected_server_psk.deinit();
         self.selected_server_psk_present = false;
         self.last_psk_age_skew = null;
+        // #366: a failed handshake must never leave a stale 0-RTT
+        // acceptance bit visible to a carrier.
+        self.client_early_data_attempted = false;
+        self.selected_client_psk_index = null;
+        self.client_hello_early_data_seen = false;
+        self.early_data_accepted = false;
+        self.early_data_decision = .not_attempted;
         self.clearClientHelloPsk();
         if (self.schedule) |*schedule| schedule.wipe();
         self.schedule = null;
@@ -1162,6 +1329,10 @@ pub const Tls13Backend = struct {
             // order — before any lifecycle/key-pair state is mutated below,
             // so a too-large offer never partially advances the handshake.
             _ = try self.planPskOffer(base_len);
+            // #366: decide whether to attempt 0-RTT from the (now final)
+            // first surviving offer, after offer planning but still before
+            // any lifecycle/key-pair state is mutated.
+            self.planEarlyDataAttempt();
         }
         self.core.start() catch |err| return mapCoreError(err);
         switch (self.role) {
@@ -1556,6 +1727,15 @@ pub const Tls13Backend = struct {
             try w.bytes(payload);
         }
 
+        // early_data (#366): an empty extension announcing a 0-RTT attempt.
+        // Order relative to `pre_shared_key` doesn't matter under RFC
+        // 8446 §4.2.11 (only `pre_shared_key` itself must be last), so this
+        // is placed before the PSK block below for wire-format stability.
+        if (self.client_early_data_attempted) {
+            try w.u16_(ext_early_data);
+            try w.u16_(0);
+        }
+
         // pre_shared_key (#362/#487): `self.client_offer_lease.offers` was already
         // compacted to exactly the eligible, size-fitting, wire-ordered
         // subset by `planPskOffer` (called from `startImpl` before
@@ -1626,6 +1806,22 @@ pub const Tls13Backend = struct {
         }
 
         const message = buf[0..w.len];
+
+        // #366: the client 0-RTT traffic secret is derived from the hash of
+        // this *complete* ClientHello (patched lengths, real binders) —
+        // never the binder-truncated prefix used just above. `psk_secrets[0]`
+        // is identity 0's PSK (the only identity 0-RTT may use), matching
+        // `planEarlyDataAttempt`'s "first surviving offer only" rule.
+        if (self.client_early_data_attempted) {
+            var client_hello_hash: [hash_len]u8 = undefined;
+            Sha256.hash(message, &client_hello_hash, .{});
+
+            var early = KeySchedule.clientEarlyTrafficSecret(&psk_secrets[0], client_hello_hash);
+            defer crypto.secureZero(u8, &early);
+
+            try self.emitSecret(sink, .zero_rtt, .write, &early);
+        }
+
         self.core.recordSent(message) catch |err| return mapCoreError(err);
         try sink.emitCrypto(.initial, message);
     }
@@ -1702,6 +1898,28 @@ pub const Tls13Backend = struct {
 
         raw_offers.deinit(); // whatever was ineligible or did not fit
         raw_offers.moveFrom(&emitted);
+    }
+
+    /// #366: decide whether to attempt 0-RTT, from the first surviving wire
+    /// offer only — tickets are never reordered to find an early-capable
+    /// one, which both preserves #487's wire-index/lease semantics and
+    /// naturally enforces the TLS "selected identity must be 0" requirement
+    /// for early data. Called after `planPskOffer` has already compacted
+    /// `self.client_offer_lease.offers` to exactly the wire-emitted subset.
+    fn planEarlyDataAttempt(self: *Tls13Backend) void {
+        self.client_early_data_attempted = false;
+        if (!self.client_early_data_intent.enabled) return;
+
+        const offers = self.constClientPskOffers();
+        if (offers.isEmpty()) return;
+
+        const max = switch (offers.constSlice()[0].common.early_data) {
+            .resume_only => return,
+            .early_data_capable => |n| n,
+        };
+        if (max == 0 or self.client_early_data_intent.max_bytes == 0) return;
+
+        self.client_early_data_attempted = true;
     }
 
     /// Whether `ticket` is still safe and compatible to offer *now*: not
@@ -1878,6 +2096,10 @@ pub const Tls13Backend = struct {
         // or not, malformed or not).
         var psk_secret: ?[hash_len]u8 = null;
         const active_offers = self.mutableClientPskOffers();
+        // #366: retained regardless of `idx`'s value so
+        // `onEncryptedExtensions` can check an accepted `early_data`
+        // extension applies only to identity 0.
+        self.selected_client_psk_index = selected_identity;
         if (selected_identity) |idx| {
             if (idx >= active_offers.len) return error.IllegalParameter;
             if (self.client_offer_lease.active) self.client_offer_lease.finishPins(.{ .selected = idx });
@@ -1934,6 +2156,7 @@ pub const Tls13Backend = struct {
         var guard = ExtensionGuard{};
         var transport_extension_seen = false;
         var alpn_seen = false;
+        var early_data_seen = false;
         var extensions = Reader{ .bytes = try r.slice(try r.u16_()) };
         try r.expectEnd();
         while (extensions.remaining() > 0) {
@@ -1956,6 +2179,12 @@ pub const Tls13Backend = struct {
                     alpn_seen = true;
                     try sink.emitAlpn(name);
                 },
+                // #366: RFC 8446 §4.2.10 defines this extension's
+                // EncryptedExtensions form as empty too.
+                ext_early_data => {
+                    try ext.expectEnd();
+                    early_data_seen = true;
+                },
                 else => {
                     if (self.profile.extensionType()) |expected_type| {
                         if (expected_type == ext_id) {
@@ -1967,6 +2196,13 @@ pub const Tls13Backend = struct {
             }
         }
         if (!alpn_seen and !self.policy.allow_absent_alpn) return error.AlpnMismatch;
+        // #366: an EncryptedExtensions `early_data` the client never
+        // attempted, or applying to a non-zero selected identity, is a
+        // protocol violation — not merely "not accepted".
+        if (early_data_seen) {
+            if (!self.client_early_data_attempted) return error.IllegalParameter;
+            if ((self.selected_client_psk_index orelse return error.IllegalParameter) != 0) return error.IllegalParameter;
+        }
         tls_negotiation.validateServerSelection(self.policy, .{
             .version = self.negotiated_version,
             .cipher_suite = self.negotiated_cipher_suite,
@@ -2002,6 +2238,12 @@ pub const Tls13Backend = struct {
                 null;
             if (self.resume_compat.transport == .exact and !compatCompatible(stored.transport_compat, received_transport)) return error.IllegalParameter;
             if (self.resume_compat.application == .exact and !compatCompatible(stored.application_compat, self.candidateApplicationCompat())) return error.IllegalParameter;
+
+            // #366: a resume-only ticket can never be the basis for an
+            // accepted `early_data` extension, regardless of what the
+            // client attempted.
+            if (early_data_seen and stored.early_data == .resume_only) return error.IllegalParameter;
+            if (early_data_seen) self.early_data_accepted = true;
 
             self.connection_auth_binding = stored.auth_binding;
         }
@@ -2485,6 +2727,7 @@ pub const Tls13Backend = struct {
         self.peer_sig_scheme_count = 0;
         self.server_name_present = false;
         self.server_name_len = 0;
+        self.client_hello_early_data_seen = false;
 
         const ClientHelloObserver = struct {
             transport_extension_type: ?u16,
@@ -2492,6 +2735,7 @@ pub const Tls13Backend = struct {
             psk_modes_seen: bool = false,
             psk_dhe_ke_offered: bool = false,
             psk_ext: ?struct { body_offset: usize, len: usize } = null,
+            early_data_seen: bool = false,
 
             fn observe(ctx: *anyopaque, observation: tls_negotiation.ExtensionObservation) tls_negotiation.Error!void {
                 const self_obs: *@This() = @ptrCast(@alignCast(ctx));
@@ -2512,6 +2756,12 @@ pub const Tls13Backend = struct {
                             .len = observation.data.len,
                         };
                     },
+                    // #366: RFC 8446 §4.2.10 defines this extension's
+                    // ClientHello form as empty; anything else is malformed.
+                    ext_early_data => {
+                        if (observation.data.len != 0) return error.MalformedExtension;
+                        self_obs.early_data_seen = true;
+                    },
                     else => if (self_obs.transport_extension_type) |expected_type| {
                         if (expected_type == observation.id) self_obs.transport_params = observation.data;
                     },
@@ -2527,6 +2777,10 @@ pub const Tls13Backend = struct {
         const offers = parsed.offers;
         const hello_selection = tls_negotiation.negotiateServerHello(self.policy, &offers) catch |err| return mapNegotiationError(err);
         if (observer.psk_ext != null and !observer.psk_modes_seen) return error.MissingExtension;
+        // #366: early_data without an accompanying PSK offer is malformed —
+        // 0-RTT is only meaningful alongside a resumption attempt.
+        if (observer.early_data_seen and observer.psk_ext == null) return error.MissingExtension;
+        self.client_hello_early_data_seen = observer.early_data_seen;
         // signature_algorithms is required whenever the server authenticates
         // with a certificate (RFC 8446 §9.2). A missing or empty list is a
         // malformed/missing required *peer* extension — attribute it to the
@@ -2669,7 +2923,7 @@ pub const Tls13Backend = struct {
         defer self.clearClientHelloPsk();
         const credential_info = try self.inspectSelectedServerCredential(credential);
         self.connection_auth_binding = credential_info.binding;
-        var psk_selected = try self.selectPsk(credential_info.binding);
+        var psk_selected = try self.selectPsk(credential_info.binding, sink);
         defer if (psk_selected) |*sel| crypto.secureZero(u8, &sel.psk);
 
         // ServerHello (Initial level).
@@ -2738,7 +2992,7 @@ pub const Tls13Backend = struct {
     /// continues to the next offered identity. Returns `null` — meaning
     /// "continue with the existing full-certificate flow" — whenever PSK is
     /// not configured/offered/eligible, or no candidate is acceptable.
-    fn selectPsk(self: *Tls13Backend, current_binding: session.AuthBinding) HandshakeError!?PskSelected {
+    fn selectPsk(self: *Tls13Backend, current_binding: session.AuthBinding, sink: *EventSink) HandshakeError!?PskSelected {
         const resolver = self.psk_resolver orelse return null;
         const capture = self.client_hello_psk orelse return null;
         if (self.client_auth != .disabled) {
@@ -2775,6 +3029,10 @@ pub const Tls13Backend = struct {
             saw_resolved = true;
             var hit = &resolved.hit;
 
+            // #366: 0-RTT may only be attempted against the first offered
+            // identity (wire index 0) — never reordered/probed for a later
+            // early-capable identity.
+            const wants_early = self.client_hello_early_data_seen and attempts == 0;
             const candidate_ctx: session.CandidateContext = .{
                 .cipher_suite = self.negotiated_cipher_suite,
                 .server_name = self.serverNameSlice(),
@@ -2782,6 +3040,7 @@ pub const Tls13Backend = struct {
                 .auth_binding = current_binding,
                 .transport_compat = if (self.resume_compat.transport == .exact) self.candidateTransportCompat() else null,
                 .application_compat = if (self.resume_compat.application == .exact) self.candidateApplicationCompat() else null,
+                .want_early_data = wants_early,
             };
             const decision = session.evaluateCompatibility(&hit.state.common, candidate_ctx, now);
             if (decision.resumption != .eligible) {
@@ -2804,18 +3063,45 @@ pub const Tls13Backend = struct {
 
             // #362: surface the ticket-age skew observation for #366 — skew
             // alone never rejects this 1-RTT resumption.
-            self.last_psk_age_skew = pre_shared_key.observeAgeSkew(
+            const age_skew = pre_shared_key.observeAgeSkew(
                 pair.identity.obfuscated_ticket_age,
                 hit.state.ticket_age_add,
                 elapsedMillis(now, hit.state.common.issued_at_unix_ms),
             );
+            self.last_psk_age_skew = age_skew;
+
+            // #366: the live 0-RTT decision, made here (not from
+            // `takePskAgeSkew`/`takeSelectedServerPsk`, which intentionally
+            // release state only after handshake commit — too late for
+            // first-flight data) and only after binder verification, so an
+            // early-data rejection never rejects an otherwise-valid PSK
+            // resumption.
+            const early_decision = self.decideServerEarlyData(.{
+                .selected_index = attempts,
+                .compatibility = decision.early_data,
+                .age_skew = age_skew,
+            });
+            self.early_data_decision = early_decision;
+            self.early_data_accepted = early_decision == .accepted;
+            if (early_decision == .accepted) {
+                var client_hello_hash: [hash_len]u8 = undefined;
+                Sha256.hash(capture.message[0..capture.message_len], &client_hello_hash, .{});
+
+                var early = KeySchedule.clientEarlyTrafficSecret(&psk_buf, client_hello_hash);
+                defer crypto.secureZero(u8, &early);
+
+                // The server never emits a 0-RTT *write* key; server
+                // responses always use 1-RTT keys.
+                try self.emitSecret(sink, .zero_rtt, .read, &early);
+            }
+
             if (hit.on_selected) |hook| hook.complete();
             hit.lease.commit();
             self.selected_server_psk.state.moveFrom(&hit.state);
             self.selected_server_psk.index = @intCast(attempts);
             self.selected_server_psk_present = true;
             self.resumption_decision_observer.notify(.accepted);
-            return .{ .index = attempts, .psk = psk_buf };
+            return .{ .index = attempts, .psk = psk_buf, .early_data = early_decision };
         }
         if (attempts > 0) {
             self.resumption_decision_observer.notify(if (saw_incompatible)
@@ -2826,6 +3112,41 @@ pub const Tls13Backend = struct {
                 .miss);
         }
         return null;
+    }
+
+    const ServerEarlyDataInputs = struct {
+        selected_index: usize,
+        compatibility: session.EarlyDataEligibility,
+        age_skew: pre_shared_key.AgeSkew,
+    };
+
+    /// #366: the server's live 0-RTT decision for the just-selected,
+    /// binder-verified candidate. `inputs.compatibility` already reflects
+    /// `client_hello_early_data_seen`/identity-0/ticket-capability via
+    /// `session.evaluateCompatibility`'s `want_early_data`; resource
+    /// admission (byte/request caps) is a composition-root concern layered
+    /// on top of this backend and is never produced here.
+    fn decideServerEarlyData(self: *Tls13Backend, inputs: ServerEarlyDataInputs) EarlyDataDecision {
+        if (!self.client_hello_early_data_seen) return .not_attempted;
+        if (!self.server_early_data_policy.enabled) return .disabled;
+        if (inputs.selected_index != 0) return .selected_identity_not_zero;
+        switch (inputs.compatibility) {
+            // Reached only for the selected (already resumption-eligible)
+            // candidate, so `.incompatible` (which `evaluateCompatibility`
+            // only produces when resumption itself is ineligible) cannot
+            // actually occur here; `.disabled` is the real "ticket is
+            // resume-only" case for an identity-0, early_data-requesting
+            // candidate.
+            .disabled, .incompatible => return .ticket_not_capable,
+            .allowed => {},
+        }
+        if (!skewWithinTolerance(inputs.age_skew.skew_ms, self.server_early_data_policy.age_skew_tolerance_ms))
+            return .age_skew;
+        return switch (self.early_data_replay_gate.decide(.{ .selected_identity = @intCast(inputs.selected_index) })) {
+            .allow => .accepted,
+            .replay => .replay_rejected,
+            .unavailable => .replay_unavailable,
+        };
     }
 
     fn candidateTransportCompat(self: *const Tls13Backend) ?session.CandidateCompat {
@@ -2861,6 +3182,14 @@ pub const Tls13Backend = struct {
             try w.u16_(extension_type);
             try w.u16_(@intCast(payload.len));
             try w.bytes(payload);
+        }
+        // #366: signal 0-RTT acceptance with an empty `early_data`
+        // extension — omitted (not merely absent-with-a-flag) for a
+        // PSK-resumed but early-rejected connection, so the client's
+        // omission-based rejection check has something concrete to check.
+        if (self.early_data_decision == .accepted) {
+            try w.u16_(ext_early_data);
+            try w.u16_(0);
         }
         w.patch(2, ee_extensions);
         w.patch(3, ee_len);
@@ -3628,6 +3957,16 @@ fn elapsedMillis(now_ms: i64, issued_ms: i64) u64 {
     const delta: i128 = @as(i128, now_ms) - @as(i128, issued_ms);
     if (delta <= 0) return 0;
     return @intCast(@min(delta, @as(i128, std.math.maxInt(u64))));
+}
+
+/// #366: overflow-safe `|skew_ms| <= tolerance_ms`. The `i128` promotion is
+/// deliberate: `-minInt(i64)` must not trap.
+fn skewWithinTolerance(skew_ms: i64, tolerance_ms: u64) bool {
+    const magnitude: u64 = if (skew_ms < 0)
+        @intCast(-@as(i128, skew_ms))
+    else
+        @intCast(skew_ms);
+    return magnitude <= tolerance_ms;
 }
 
 /// Symmetric optional equality for a stored `CompatSnapshot` against a

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -658,7 +658,16 @@ const IssuedEarlyTicket = struct {
 /// server's recoverable state (for a `resumed` connection's resolver) with
 /// ownership moved out for the caller to `deinit`.
 fn issueEarlyCapableTicket(max_early_data_size: ?u32) !IssuedEarlyTicket {
-    var harness = DirectHarness.init();
+    return issueEarlyCapableTicketProfile(.record, max_early_data_size);
+}
+
+const EarlyTicketProfile = enum { record, extension };
+
+fn issueEarlyCapableTicketProfile(profile: EarlyTicketProfile, max_early_data_size: ?u32) !IssuedEarlyTicket {
+    var harness = switch (profile) {
+        .record => DirectHarness.init(),
+        .extension => DirectHarness.initExtension(),
+    };
     defer harness.deinit();
 
     const TicketCapture = struct {
@@ -801,6 +810,7 @@ test "0-RTT round trip: an early-capable ticket, matching policy, and an allowin
     // The ticket's own advertised allowance (32, from `issueEarlyCapableTicket`
     // above) survives into the accepted decision for the next carrier slice,
     // rather than being discarded at `.allowed => {}`.
+    try std.testing.expectEqual(@as(u32, 32), resumed.client_backend.earlyDataMaxBytes());
     try std.testing.expectEqual(@as(u32, 32), resumed.server_backend.earlyDataMaxBytes());
 
     const seen_candidate = replay_gate.seen orelse return error.TestExpectedEqual;
@@ -857,6 +867,7 @@ test "0-RTT is never attempted for a resume-only ticket even with client intent 
     try std.testing.expect(resumed.client_backend.core.psk_authenticated);
     try std.testing.expect(!resumed.client_backend.earlyDataAttempted());
     try std.testing.expect(!resumed.client_backend.earlyDataAccepted());
+    try std.testing.expectEqual(@as(u32, 0), resumed.client_backend.earlyDataMaxBytes());
     try std.testing.expect(!resumed.server_backend.earlyDataAccepted());
     try std.testing.expectEqual(@as(?SecretSnapshot, null), resumed.observed.zero_rtt_secret[0]);
     try std.testing.expectEqual(@as(?SecretSnapshot, null), resumed.observed.zero_rtt_secret[1]);
@@ -1043,11 +1054,11 @@ test "0-RTT anti-replay defaults to unavailable (fails closed) when no gate is c
     try std.testing.expectEqual(tls_backend.EarlyDataDecision.replay_unavailable, resumed.server_backend.earlyDataDecision());
 }
 
-test "an early-data-specific compatibility gate can reject only 0-RTT while resumption still completes" {
-    var issued = try issueEarlyCapableTicket(32);
+test "an early-data-specific compatibility gate sees remembered transport metadata and rejects only 0-RTT" {
+    var issued = try issueEarlyCapableTicketProfile(.extension, 32);
     defer issued.deinit();
 
-    var resumed = DirectHarness.init();
+    var resumed = DirectHarness.initExtension();
     defer resumed.deinit();
 
     var offers: pre_shared_key.ClientPskOfferSet = .{};
@@ -1060,21 +1071,29 @@ test "an early-data-specific compatibility gate can reject only 0-RTT while resu
         .nowUnixMsFn = IdentityResolver.now,
         .resolveFn = IdentityResolver.resolve,
     });
+    try resumed.client_backend.setResumeCompatibilityPolicy(.{ .transport = .ignore, .application = .ignore });
+    try resumed.server_backend.setResumeCompatibilityPolicy(.{ .transport = .ignore, .application = .ignore });
     try resumed.client_backend.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 16384 });
     try resumed.server_backend.setServerEarlyDataPolicy(.{ .enabled = true, .age_skew_tolerance_ms = 60_000 });
 
-    // A gate that always reports a transport mismatch — modeling a future
-    // QUIC-owned "remembered transport parameters were reduced" check
-    // (#366 letter S) — deliberately independent of `resume_compat`
-    // (never configured `.exact` here), proving early data and ordinary
-    // resumption are no longer coupled through the same compatibility path.
+    const CapturingCompatGate = struct {
+        seen: ?tls_backend.EarlyDataCompatibilityCandidate = null,
+
+        fn decide(ctx: *anyopaque, candidate: tls_backend.EarlyDataCompatibilityCandidate) tls_backend.EarlyDataCompatibilityDecision {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.seen = candidate;
+            return .transport_incompatible;
+        }
+    };
+    var compat_gate = CapturingCompatGate{};
+    // A gate that reports a transport mismatch — modeling a future QUIC-owned
+    // "remembered transport parameters were reduced" check (#366 letter S) —
+    // deliberately independent of `resume_compat` (never configured `.exact`
+    // here), proving early data and ordinary resumption are no longer coupled
+    // through the same compatibility path.
     try resumed.server_backend.setEarlyDataCompatibilityGate(.{
-        .ctx = undefined,
-        .decideFn = struct {
-            fn decide(_: *anyopaque, _: tls_backend.EarlyDataCompatibilityCandidate) tls_backend.EarlyDataCompatibilityDecision {
-                return .transport_incompatible;
-            }
-        }.decide,
+        .ctx = &compat_gate,
+        .decideFn = CapturingCompatGate.decide,
     });
 
     try resumed.run();
@@ -1088,6 +1107,11 @@ test "an early-data-specific compatibility gate can reject only 0-RTT while resu
     try std.testing.expect(!resumed.server_backend.earlyDataAccepted());
     try std.testing.expectEqual(tls_backend.EarlyDataDecision.transport_incompatible, resumed.server_backend.earlyDataDecision());
     try std.testing.expectEqual(@as(u32, 0), resumed.server_backend.earlyDataMaxBytes());
+    const remembered = (compat_gate.seen orelse return error.TestExpectedEqual).remembered_transport orelse
+        return error.TestExpectedEqual;
+    try std.testing.expectEqual(@as(u16, 57), remembered.format_id);
+    try std.testing.expectEqual(@as(u16, 1), remembered.format_version);
+    try std.testing.expectEqualStrings("server transport parameters", remembered.bytes);
 }
 
 test "0-RTT is rejected when the server selects an identity other than 0, even though the client attempted it" {
@@ -1199,6 +1223,69 @@ test "the ClientHello wire-encodes early_data before pre_shared_key only when 0-
     // beyond the harness's own `deinit`, which only runs the drivers'
     // `deinit` when `drivers_ready` — already true here.
     resumed.server_driver = DirectDriver.init(.server, resumed.server_backend.backend());
+}
+
+test "early-data intent does not trim a later 1-RTT PSK when identity 0 is resume-only at the ClientHello boundary" {
+    const first_psk = [_]u8{0x41} ** tls_backend.hash_len;
+    const second_psk = [_]u8{0x42} ** tls_backend.hash_len;
+    const one_byte_ticket = [_]u8{'a'};
+    const max_ticket = [_]u8{'b'} ** session.Limits.default.max_ticket_len;
+
+    var long_names: [16][255]u8 = undefined;
+    var alpns: [16]tls_core.policy.ProtocolName = undefined;
+    for (long_names[0..15], 0..) |*name, i| {
+        @memset(name, @intCast(i + 1));
+        alpns[i] = .{ .bytes = name[0..255] };
+    }
+
+    var found_boundary = false;
+    var trial_len: usize = 1;
+    while (trial_len <= 255 and !found_boundary) : (trial_len += 1) {
+        @memset(&long_names[15], 0xaa);
+        alpns[15] = .{ .bytes = long_names[15][0..trial_len] };
+
+        var policy = tls_core.policy.Policy.recordDefault();
+        policy.alpn_protocols = &alpns;
+        var client = tls_backend.Tls13Backend.initClientConfigured(
+            clientEntropy(),
+            .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+            tls_backend.recordConfig(policy),
+            .{},
+        );
+        defer client.deinit();
+
+        var offers: pre_shared_key.ClientPskOfferSet = .{};
+        try pushTestTicketWithEarlyPolicy(&offers, &first_psk, &one_byte_ticket, .resume_only);
+        try pushTestTicketWithEarlyPolicy(&offers, &second_psk, &max_ticket, .resume_only);
+        var clock_dummy: u8 = 0;
+        const Clock = struct {
+            fn now(_: *anyopaque) i64 {
+                return 0;
+            }
+        };
+        try client.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+        try client.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 16_384 });
+
+        var sink = DirectSink{};
+        defer sink.deinit();
+        try client.backend().start(.client, {}, &sink);
+
+        var client_hello: ?[]const u8 = null;
+        for (sink.items[0..sink.len]) |event| {
+            if (event == .handshake_bytes) client_hello = event.handshake_bytes.data;
+        }
+        const ch = client_hello orelse return error.TestExpectedEqual;
+        if (ch.len <= tls_backend.max_message_len - 4) continue;
+
+        found_boundary = true;
+        try std.testing.expectEqual(@as(usize, 2), client.client_offer_lease.offers.len);
+        try std.testing.expect(!client.earlyDataAttempted());
+        try std.testing.expectEqual(@as(u32, 0), client.earlyDataMaxBytes());
+        const early_data_ext: u16 = @intFromEnum(tls_core.algorithms.ExtensionType.early_data);
+        try std.testing.expect(std.mem.indexOf(u8, ch, &std.mem.toBytes(std.mem.nativeToBig(u16, early_data_ext))) == null);
+    }
+
+    try std.testing.expect(found_boundary);
 }
 
 fn expectRuntimeResumedRecordHandshake(
@@ -4297,6 +4384,15 @@ test "handshake-phase failure wipes PSK offer state before ServerHello even arri
 }
 
 fn pushTestTicket(offers: *pre_shared_key.ClientPskOfferSet, psk: []const u8, ticket: []const u8) !void {
+    try pushTestTicketWithEarlyPolicy(offers, psk, ticket, .resume_only);
+}
+
+fn pushTestTicketWithEarlyPolicy(
+    offers: *pre_shared_key.ClientPskOfferSet,
+    psk: []const u8,
+    ticket: []const u8,
+    early_data: session.EarlyDataPolicy,
+) !void {
     var common: session.ResumableSessionCommon = .{};
     try common.init(std.testing.allocator, session.Limits.default, .{
         .cipher_suite = .tls_aes_128_gcm_sha256,
@@ -4304,6 +4400,7 @@ fn pushTestTicket(offers: *pre_shared_key.ClientPskOfferSet, psk: []const u8, ti
         .auth_binding = session.AuthBinding.fromLeafCertificateDer(""),
         .issued_at_unix_ms = 0,
         .lifetime_seconds = 3600,
+        .early_data = early_data,
     });
     var state: session.ClientTicketState = .{};
     try state.init(std.testing.allocator, session.Limits.default, &common, .{

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -764,14 +764,25 @@ test "0-RTT round trip: an early-capable ticket, matching policy, and an allowin
 
     try resumed.client_backend.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 16384 });
     try resumed.server_backend.setServerEarlyDataPolicy(.{ .enabled = true, .age_skew_tolerance_ms = 60_000 });
-    var replay_gate_ctx: u8 = 0;
+
+    // A capturing replay gate: proves the candidate the gate receives
+    // actually distinguishes this specific ticket (a real, non-zero
+    // fingerprint of its opaque wire identity), not just "identity 0" —
+    // the fingerprint alone (the previous, sole field) can never do that,
+    // since 0-RTT is only ever attempted against wire identity 0.
+    const CapturingReplayGate = struct {
+        seen: ?tls_backend.EarlyDataReplayCandidate = null,
+
+        fn decide(ctx: *anyopaque, candidate: tls_backend.EarlyDataReplayCandidate) tls_backend.EarlyDataReplayDecision {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.seen = candidate;
+            return .allow;
+        }
+    };
+    var replay_gate = CapturingReplayGate{};
     try resumed.server_backend.setEarlyDataReplayGate(.{
-        .ctx = &replay_gate_ctx,
-        .decideFn = struct {
-            fn decide(_: *anyopaque, _: tls_backend.EarlyDataReplayCandidate) tls_backend.EarlyDataReplayDecision {
-                return .allow;
-            }
-        }.decide,
+        .ctx = &replay_gate,
+        .decideFn = CapturingReplayGate.decide,
     });
 
     try resumed.run();
@@ -783,8 +794,20 @@ test "0-RTT round trip: an early-capable ticket, matching policy, and an allowin
 
     try std.testing.expect(resumed.client_backend.earlyDataAttempted());
     try std.testing.expect(resumed.client_backend.earlyDataAccepted());
+    try std.testing.expectEqual(tls_backend.EarlyDataDecision.accepted, resumed.client_backend.earlyDataDecision());
+    try std.testing.expect(resumed.server_backend.earlyDataAttempted());
     try std.testing.expect(resumed.server_backend.earlyDataAccepted());
     try std.testing.expectEqual(tls_backend.EarlyDataDecision.accepted, resumed.server_backend.earlyDataDecision());
+    // The ticket's own advertised allowance (32, from `issueEarlyCapableTicket`
+    // above) survives into the accepted decision for the next carrier slice,
+    // rather than being discarded at `.allowed => {}`.
+    try std.testing.expectEqual(@as(u32, 32), resumed.server_backend.earlyDataMaxBytes());
+
+    const seen_candidate = replay_gate.seen orelse return error.TestExpectedEqual;
+    var expected_fingerprint: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash("opaque-early-ticket", &expected_fingerprint, .{});
+    try std.testing.expectEqualSlices(u8, &expected_fingerprint, &seen_candidate.ticket_identity_fingerprint);
+    try std.testing.expect(!std.mem.allEqual(u8, &seen_candidate.ticket_identity_fingerprint, 0));
 
     // The client's `c e traffic` secret (derived from the final ClientHello
     // it sent) and the server's own derivation (from the same ClientHello,
@@ -864,6 +887,9 @@ test "0-RTT is never attempted when the client never opts in, even for an early-
     try std.testing.expect(resumed.client_driver.isComplete());
     try std.testing.expect(resumed.server_driver.isComplete());
     try std.testing.expect(!resumed.client_backend.earlyDataAttempted());
+    // The server's role-aware `earlyDataAttempted()` correctly reports
+    // false too: the peer's ClientHello genuinely never carried `early_data`.
+    try std.testing.expect(!resumed.server_backend.earlyDataAttempted());
     try std.testing.expect(!resumed.server_backend.earlyDataAccepted());
     try std.testing.expectEqual(tls_backend.EarlyDataDecision.not_attempted, resumed.server_backend.earlyDataDecision());
 }
@@ -898,8 +924,14 @@ test "0-RTT is attempted but rejected when the server's early-data policy is dis
 
     try std.testing.expect(resumed.client_backend.earlyDataAttempted());
     try std.testing.expect(!resumed.client_backend.earlyDataAccepted());
+    // `earlyDataAttempted()` is role-aware: the server side must also
+    // report the peer's attempt (regardless of rejection), since the later
+    // record/QUIC carrier needs to know to expect and boundedly discard
+    // skipped first-flight ciphertext even on this rejected path.
+    try std.testing.expect(resumed.server_backend.earlyDataAttempted());
     try std.testing.expect(!resumed.server_backend.earlyDataAccepted());
     try std.testing.expectEqual(tls_backend.EarlyDataDecision.disabled, resumed.server_backend.earlyDataDecision());
+    try std.testing.expectEqual(@as(u32, 0), resumed.server_backend.earlyDataMaxBytes());
     // The client still derived and emitted its own 0-RTT write secret (the
     // attempt itself always happens locally); only the server never emits
     // a matching read secret, since it never reached `.accepted`.
@@ -1009,6 +1041,53 @@ test "0-RTT anti-replay defaults to unavailable (fails closed) when no gate is c
     try std.testing.expect(resumed.server_backend.core.psk_authenticated);
     try std.testing.expect(!resumed.server_backend.earlyDataAccepted());
     try std.testing.expectEqual(tls_backend.EarlyDataDecision.replay_unavailable, resumed.server_backend.earlyDataDecision());
+}
+
+test "an early-data-specific compatibility gate can reject only 0-RTT while resumption still completes" {
+    var issued = try issueEarlyCapableTicket(32);
+    defer issued.deinit();
+
+    var resumed = DirectHarness.init();
+    defer resumed.deinit();
+
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&issued.ticket);
+    var clock_dummy: u8 = 0;
+    try resumed.client_backend.setClientPskOffers(&offers, &clock_dummy, earlyDataResumedClientClock);
+    var resolver_state = IdentityResolver{ .state = &issued.server_state };
+    try resumed.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = IdentityResolver.now,
+        .resolveFn = IdentityResolver.resolve,
+    });
+    try resumed.client_backend.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 16384 });
+    try resumed.server_backend.setServerEarlyDataPolicy(.{ .enabled = true, .age_skew_tolerance_ms = 60_000 });
+
+    // A gate that always reports a transport mismatch — modeling a future
+    // QUIC-owned "remembered transport parameters were reduced" check
+    // (#366 letter S) — deliberately independent of `resume_compat`
+    // (never configured `.exact` here), proving early data and ordinary
+    // resumption are no longer coupled through the same compatibility path.
+    try resumed.server_backend.setEarlyDataCompatibilityGate(.{
+        .ctx = undefined,
+        .decideFn = struct {
+            fn decide(_: *anyopaque, _: tls_backend.EarlyDataCompatibilityCandidate) tls_backend.EarlyDataCompatibilityDecision {
+                return .transport_incompatible;
+            }
+        }.decide,
+    });
+
+    try resumed.run();
+
+    try std.testing.expect(resumed.client_driver.isComplete());
+    try std.testing.expect(resumed.server_driver.isComplete());
+    // Resumption itself is unaffected by the early-data-specific rejection.
+    try std.testing.expect(resumed.client_backend.core.psk_authenticated);
+    try std.testing.expect(resumed.server_backend.core.psk_authenticated);
+
+    try std.testing.expect(!resumed.server_backend.earlyDataAccepted());
+    try std.testing.expectEqual(tls_backend.EarlyDataDecision.transport_incompatible, resumed.server_backend.earlyDataDecision());
+    try std.testing.expectEqual(@as(u32, 0), resumed.server_backend.earlyDataMaxBytes());
 }
 
 test "0-RTT is rejected when the server selects an identity other than 0, even though the client attempted it" {

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -127,6 +127,13 @@ const DirectObserved = struct {
     application_read: [2]?KeySnapshot = .{ null, null },
     handshake_write_secret: [2]?SecretSnapshot = .{ null, null },
     application_write_secret: [2]?SecretSnapshot = .{ null, null },
+    // #366: record/QUIC 0-RTT key installation is a follow-up slice, so
+    // `record_epoch_bridge.Bridge` deliberately does not support the
+    // `.zero_rtt` epoch yet. `pumpDirect` below captures a `.zero_rtt`
+    // secret event directly (client write / server read) instead of
+    // routing it through the bridge, so 0-RTT tests can still drive a real
+    // end-to-end handshake through this harness.
+    zero_rtt_secret: [2]?SecretSnapshot = .{ null, null },
     handshake_write_seq_after_first_record: [2]?u64 = .{ null, null },
     alpn: [32]u8 = undefined,
     alpn_len: usize = 0,
@@ -219,6 +226,10 @@ fn pumpDirect(
             }
         },
         .traffic_secret => |traffic_secret| {
+            if (traffic_secret.epoch == .zero_rtt) {
+                observed.zero_rtt_secret[@intFromEnum(sender_side)] = SecretSnapshot.capture(traffic_secret.data);
+                continue;
+            }
             var scratch: [1]u8 = undefined;
             _ = try sender_bridge.applyEvent(.{ .traffic_secret = .{
                 .epoch = traffic_secret.epoch,
@@ -618,6 +629,497 @@ test "PSK round trip: an offered, resolved, and verified ticket resumes the hand
     const request = try resumed.client_bridge.sealApplicationData("resumed request", &protected2);
     const opened_request = try resumed.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, request), &plaintext2);
     try std.testing.expectEqualStrings("resumed request", opened_request.inner.content);
+}
+
+// ==========================================================================
+// #366: 0-RTT policy gate — TLS vocabulary/negotiation slice.
+//
+// Record/QUIC key installation and the HTTP-level request-safety gate are
+// separate follow-up slices; these tests only prove the TLS-layer
+// negotiation (ClientHello/EncryptedExtensions `early_data`, the server's
+// live identity-0/skew/replay decision, and the derived early secret)
+// through the real backend and driver, via `DirectHarness`'s `zero_rtt`
+// secret capture (see `pumpDirect`).
+// ==========================================================================
+
+const IssuedEarlyTicket = struct {
+    ticket: session.ClientTicketState = .{},
+    server_state: session.ServerRecoverableState = .{},
+
+    fn deinit(self: *IssuedEarlyTicket) void {
+        self.ticket.deinit();
+        self.server_state.deinit();
+    }
+};
+
+/// Runs a full handshake and has the server issue a ticket advertising
+/// `max_early_data_size`, delivering it to the client exactly as `PSK round
+/// trip` above does, then returns the client's captured ticket and the
+/// server's recoverable state (for a `resumed` connection's resolver) with
+/// ownership moved out for the caller to `deinit`.
+fn issueEarlyCapableTicket(max_early_data_size: ?u32) !IssuedEarlyTicket {
+    var harness = DirectHarness.init();
+    defer harness.deinit();
+
+    const TicketCapture = struct {
+        ticket: session.ClientTicketState = .{},
+        fn now(_: *anyopaque) i64 {
+            return 1000;
+        }
+        fn onTicket(ctx: *anyopaque, ticket: *const session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            ticket.cloneInto(std.testing.allocator, &self.ticket) catch unreachable;
+        }
+    };
+    var capture = TicketCapture{};
+    errdefer capture.ticket.deinit();
+    const limits = session.Limits.default;
+    try harness.client_backend.setSessionTicketConsumer(std.testing.allocator, limits, .{
+        .ctx = &capture,
+        .nowUnixMsFn = TicketCapture.now,
+        .onTicketFn = TicketCapture.onTicket,
+    });
+    try harness.run();
+    try std.testing.expect(harness.client_driver.isComplete());
+    try std.testing.expect(harness.server_driver.isComplete());
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    var server_state = try harness.server_backend.emitNewSessionTicket(std.testing.allocator, &sink, .{
+        .ticket_lifetime = 3600,
+        .ticket_age_add = 500,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = "opaque-early-ticket",
+        .max_early_data_size = max_early_data_size,
+        .issued_at_unix_ms = 1000,
+    }, limits);
+    errdefer server_state.deinit();
+    try std.testing.expectEqual(@as(usize, 1), sink.len);
+
+    const ticket_event = sink.items[0].handshake_bytes;
+    var protected: [record_codec.max_ciphertext_record_len * 2]u8 = undefined;
+    const records = (try harness.server_bridge.applyEvent(.{ .handshake_bytes = .{
+        .epoch = ticket_event.epoch,
+        .data = ticket_event.data,
+    } }, &protected)).?;
+    var parser = record_codec.Parser.init(.ciphertext);
+    var record_sink = record_codec.RecordSink(8, record_codec.max_ciphertext_fragment_len * 8){};
+    try parser.feed(records, &record_sink);
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    for (record_sink.items[0..record_sink.len]) |record| {
+        const opened = try harness.client_bridge.openHandshake(.application, record, &plaintext);
+        _ = try harness.client_driver.receive(.application, opened.inner.content);
+    }
+    try std.testing.expect(capture.ticket.ticket.slice().len > 0);
+
+    var result = IssuedEarlyTicket{};
+    result.ticket.moveFrom(&capture.ticket);
+    result.server_state.moveFrom(&server_state);
+    return result;
+}
+
+/// Wires a fresh `resumed` `DirectHarness` to offer `issued.ticket` and
+/// resolve it back to `issued.server_state`, but does not configure any
+/// 0-RTT policy — callers set `client_early_data_intent`/
+/// `server_early_data_policy`/the replay gate afterward.
+/// A resolver keyed on exact identity match, mirroring `Resolver` in `PSK
+/// round trip` above — an instance (not a file-scope var) so its state
+/// safely outlives the setup call that wires it into
+/// `resumed.server_backend`, for the whole life of the test.
+const IdentityResolver = struct {
+    state: *session.ServerRecoverableState,
+
+    fn now(_: *anyopaque) i64 {
+        return 2000;
+    }
+    fn resolve(ctx: *anyopaque, identity: []const u8) pre_shared_key.ResolveError!pre_shared_key.ServerPskResolveResult {
+        const self: *@This() = @ptrCast(@alignCast(ctx));
+        if (!std.mem.eql(u8, identity, "opaque-early-ticket")) return .miss;
+        return clonedResolveHit(self.state, std.testing.allocator);
+    }
+};
+
+fn earlyDataResumedClientClock(_: *anyopaque) i64 {
+    return 2000;
+}
+
+test "0-RTT round trip: an early-capable ticket, matching policy, and an allowing replay gate is accepted by both sides" {
+    var issued = try issueEarlyCapableTicket(32);
+    defer issued.deinit();
+
+    var resumed = DirectHarness.init();
+    defer resumed.deinit();
+
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&issued.ticket);
+    var clock_dummy: u8 = 0;
+    try resumed.client_backend.setClientPskOffers(&offers, &clock_dummy, earlyDataResumedClientClock);
+
+    var resolver_state = IdentityResolver{ .state = &issued.server_state };
+    try resumed.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = IdentityResolver.now,
+        .resolveFn = IdentityResolver.resolve,
+    });
+
+    try resumed.client_backend.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 16384 });
+    try resumed.server_backend.setServerEarlyDataPolicy(.{ .enabled = true, .age_skew_tolerance_ms = 60_000 });
+    var replay_gate_ctx: u8 = 0;
+    try resumed.server_backend.setEarlyDataReplayGate(.{
+        .ctx = &replay_gate_ctx,
+        .decideFn = struct {
+            fn decide(_: *anyopaque, _: tls_backend.EarlyDataReplayCandidate) tls_backend.EarlyDataReplayDecision {
+                return .allow;
+            }
+        }.decide,
+    });
+
+    try resumed.run();
+
+    try std.testing.expect(resumed.client_driver.isComplete());
+    try std.testing.expect(resumed.server_driver.isComplete());
+    try std.testing.expect(resumed.client_backend.core.psk_authenticated);
+    try std.testing.expect(resumed.server_backend.core.psk_authenticated);
+
+    try std.testing.expect(resumed.client_backend.earlyDataAttempted());
+    try std.testing.expect(resumed.client_backend.earlyDataAccepted());
+    try std.testing.expect(resumed.server_backend.earlyDataAccepted());
+    try std.testing.expectEqual(tls_backend.EarlyDataDecision.accepted, resumed.server_backend.earlyDataDecision());
+
+    // The client's `c e traffic` secret (derived from the final ClientHello
+    // it sent) and the server's own derivation (from the same ClientHello,
+    // captured pre-binder-verification) must be byte-identical — a real
+    // cross-check, not a tautology, since each side runs
+    // `KeySchedule.clientEarlyTrafficSecret` independently.
+    try std.testing.expectEqualSlices(
+        u8,
+        &resumed.observed.zero_rtt_secret[0].?.bytes,
+        &resumed.observed.zero_rtt_secret[1].?.bytes,
+    );
+
+    // The resumed 1-RTT connection remains usable afterward regardless of
+    // the 0-RTT outcome (record/QUIC 0-RTT delivery is a follow-up slice).
+    var protected2: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext2: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    const request = try resumed.client_bridge.sealApplicationData("resumed request", &protected2);
+    const opened_request = try resumed.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, request), &plaintext2);
+    try std.testing.expectEqualStrings("resumed request", opened_request.inner.content);
+}
+
+test "0-RTT is never attempted for a resume-only ticket even with client intent enabled" {
+    var issued = try issueEarlyCapableTicket(null); // resume_only: no max_early_data_size
+    defer issued.deinit();
+
+    var resumed = DirectHarness.init();
+    defer resumed.deinit();
+
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&issued.ticket);
+    var clock_dummy: u8 = 0;
+    try resumed.client_backend.setClientPskOffers(&offers, &clock_dummy, earlyDataResumedClientClock);
+    var resolver_state = IdentityResolver{ .state = &issued.server_state };
+    try resumed.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = IdentityResolver.now,
+        .resolveFn = IdentityResolver.resolve,
+    });
+
+    try resumed.client_backend.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 16384 });
+    try resumed.server_backend.setServerEarlyDataPolicy(.{ .enabled = true, .age_skew_tolerance_ms = 60_000 });
+
+    try resumed.run();
+
+    try std.testing.expect(resumed.client_driver.isComplete());
+    try std.testing.expect(resumed.server_driver.isComplete());
+    try std.testing.expect(resumed.client_backend.core.psk_authenticated);
+    try std.testing.expect(!resumed.client_backend.earlyDataAttempted());
+    try std.testing.expect(!resumed.client_backend.earlyDataAccepted());
+    try std.testing.expect(!resumed.server_backend.earlyDataAccepted());
+    try std.testing.expectEqual(@as(?SecretSnapshot, null), resumed.observed.zero_rtt_secret[0]);
+    try std.testing.expectEqual(@as(?SecretSnapshot, null), resumed.observed.zero_rtt_secret[1]);
+}
+
+test "0-RTT is never attempted when the client never opts in, even for an early-capable ticket" {
+    var issued = try issueEarlyCapableTicket(32);
+    defer issued.deinit();
+
+    var resumed = DirectHarness.init();
+    defer resumed.deinit();
+
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&issued.ticket);
+    var clock_dummy: u8 = 0;
+    try resumed.client_backend.setClientPskOffers(&offers, &clock_dummy, earlyDataResumedClientClock);
+    var resolver_state = IdentityResolver{ .state = &issued.server_state };
+    try resumed.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = IdentityResolver.now,
+        .resolveFn = IdentityResolver.resolve,
+    });
+    // Client intent left at its disabled default.
+    try resumed.server_backend.setServerEarlyDataPolicy(.{ .enabled = true, .age_skew_tolerance_ms = 60_000 });
+
+    try resumed.run();
+
+    try std.testing.expect(resumed.client_driver.isComplete());
+    try std.testing.expect(resumed.server_driver.isComplete());
+    try std.testing.expect(!resumed.client_backend.earlyDataAttempted());
+    try std.testing.expect(!resumed.server_backend.earlyDataAccepted());
+    try std.testing.expectEqual(tls_backend.EarlyDataDecision.not_attempted, resumed.server_backend.earlyDataDecision());
+}
+
+test "0-RTT is attempted but rejected when the server's early-data policy is disabled (the default)" {
+    var issued = try issueEarlyCapableTicket(32);
+    defer issued.deinit();
+
+    var resumed = DirectHarness.init();
+    defer resumed.deinit();
+
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&issued.ticket);
+    var clock_dummy: u8 = 0;
+    try resumed.client_backend.setClientPskOffers(&offers, &clock_dummy, earlyDataResumedClientClock);
+    var resolver_state = IdentityResolver{ .state = &issued.server_state };
+    try resumed.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = IdentityResolver.now,
+        .resolveFn = IdentityResolver.resolve,
+    });
+    try resumed.client_backend.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 16384 });
+    // Server early-data policy left at its disabled default.
+
+    try resumed.run();
+
+    try std.testing.expect(resumed.client_driver.isComplete());
+    try std.testing.expect(resumed.server_driver.isComplete());
+    // Resumption itself is unaffected by the rejected early-data attempt.
+    try std.testing.expect(resumed.client_backend.core.psk_authenticated);
+    try std.testing.expect(resumed.server_backend.core.psk_authenticated);
+
+    try std.testing.expect(resumed.client_backend.earlyDataAttempted());
+    try std.testing.expect(!resumed.client_backend.earlyDataAccepted());
+    try std.testing.expect(!resumed.server_backend.earlyDataAccepted());
+    try std.testing.expectEqual(tls_backend.EarlyDataDecision.disabled, resumed.server_backend.earlyDataDecision());
+    // The client still derived and emitted its own 0-RTT write secret (the
+    // attempt itself always happens locally); only the server never emits
+    // a matching read secret, since it never reached `.accepted`.
+    try std.testing.expect(resumed.observed.zero_rtt_secret[0] != null);
+    try std.testing.expectEqual(@as(?SecretSnapshot, null), resumed.observed.zero_rtt_secret[1]);
+}
+
+fn earlyDataSkewedClientClock(_: *anyopaque) i64 {
+    // The ticket was issued and received at simulated t=1000 (see
+    // `issueEarlyCapableTicket`'s `TicketCapture.now`); the server's own
+    // resolver clock (`IdentityResolver.now`) reports t=2000, for a genuine
+    // 1000ms server-observed age. Reporting a much larger "now" here makes
+    // the *client's* apparent ticket age diverge sharply from that — real
+    // clock skew, not merely two different-but-consistent clocks.
+    return 6000;
+}
+
+test "0-RTT is rejected for a ticket-age skew outside the configured tolerance" {
+    var issued = try issueEarlyCapableTicket(32);
+    defer issued.deinit();
+
+    var resumed = DirectHarness.init();
+    defer resumed.deinit();
+
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&issued.ticket);
+    var clock_dummy: u8 = 0;
+    try resumed.client_backend.setClientPskOffers(&offers, &clock_dummy, earlyDataSkewedClientClock);
+    var resolver_state = IdentityResolver{ .state = &issued.server_state };
+    try resumed.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = IdentityResolver.now,
+        .resolveFn = IdentityResolver.resolve,
+    });
+    try resumed.client_backend.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 16384 });
+    try resumed.server_backend.setServerEarlyDataPolicy(.{ .enabled = true, .age_skew_tolerance_ms = 10 });
+
+    try resumed.run();
+
+    try std.testing.expect(resumed.client_driver.isComplete());
+    try std.testing.expect(resumed.server_driver.isComplete());
+    try std.testing.expect(resumed.server_backend.core.psk_authenticated);
+    try std.testing.expect(!resumed.server_backend.earlyDataAccepted());
+    try std.testing.expectEqual(tls_backend.EarlyDataDecision.age_skew, resumed.server_backend.earlyDataDecision());
+}
+
+test "0-RTT is rejected when the anti-replay gate reports replay, without affecting resumption" {
+    var issued = try issueEarlyCapableTicket(32);
+    defer issued.deinit();
+
+    var resumed = DirectHarness.init();
+    defer resumed.deinit();
+
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&issued.ticket);
+    var clock_dummy: u8 = 0;
+    try resumed.client_backend.setClientPskOffers(&offers, &clock_dummy, earlyDataResumedClientClock);
+    var resolver_state = IdentityResolver{ .state = &issued.server_state };
+    try resumed.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = IdentityResolver.now,
+        .resolveFn = IdentityResolver.resolve,
+    });
+    try resumed.client_backend.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 16384 });
+    try resumed.server_backend.setServerEarlyDataPolicy(.{ .enabled = true, .age_skew_tolerance_ms = 60_000 });
+    var replay_gate_ctx: u8 = 0;
+    try resumed.server_backend.setEarlyDataReplayGate(.{
+        .ctx = &replay_gate_ctx,
+        .decideFn = struct {
+            fn decide(_: *anyopaque, _: tls_backend.EarlyDataReplayCandidate) tls_backend.EarlyDataReplayDecision {
+                return .replay;
+            }
+        }.decide,
+    });
+
+    try resumed.run();
+
+    try std.testing.expect(resumed.server_backend.core.psk_authenticated);
+    try std.testing.expect(!resumed.server_backend.earlyDataAccepted());
+    try std.testing.expectEqual(tls_backend.EarlyDataDecision.replay_rejected, resumed.server_backend.earlyDataDecision());
+}
+
+test "0-RTT anti-replay defaults to unavailable (fails closed) when no gate is configured" {
+    var issued = try issueEarlyCapableTicket(32);
+    defer issued.deinit();
+
+    var resumed = DirectHarness.init();
+    defer resumed.deinit();
+
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&issued.ticket);
+    var clock_dummy: u8 = 0;
+    try resumed.client_backend.setClientPskOffers(&offers, &clock_dummy, earlyDataResumedClientClock);
+    var resolver_state = IdentityResolver{ .state = &issued.server_state };
+    try resumed.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = IdentityResolver.now,
+        .resolveFn = IdentityResolver.resolve,
+    });
+    try resumed.client_backend.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 16384 });
+    try resumed.server_backend.setServerEarlyDataPolicy(.{ .enabled = true, .age_skew_tolerance_ms = 60_000 });
+    // No `setEarlyDataReplayGate` call: production is safe with no replay
+    // store configured at all.
+
+    try resumed.run();
+
+    try std.testing.expect(resumed.server_backend.core.psk_authenticated);
+    try std.testing.expect(!resumed.server_backend.earlyDataAccepted());
+    try std.testing.expectEqual(tls_backend.EarlyDataDecision.replay_unavailable, resumed.server_backend.earlyDataDecision());
+}
+
+test "0-RTT is rejected when the server selects an identity other than 0, even though the client attempted it" {
+    var issued = try issueEarlyCapableTicket(32);
+    defer issued.deinit();
+    // A second, ordinary (non-early-capable) ticket that the resolver will
+    // actually select, offered *after* the early-capable one so wire index
+    // 0 stays the early-capable ticket the client attempted 0-RTT against.
+    var second_issued = try issueEarlyCapableTicket(null);
+    defer second_issued.deinit();
+
+    var resumed = DirectHarness.init();
+    defer resumed.deinit();
+
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&issued.ticket);
+    try offers.push(&second_issued.ticket);
+    const Clock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 2000;
+        }
+    };
+    var clock_dummy: u8 = 0;
+    try resumed.client_backend.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+    try resumed.client_backend.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 16384 });
+
+    // The resolver misses identity 0 (forcing selection of identity 1),
+    // regardless of which ticket's opaque identity it actually is —
+    // `issueEarlyCapableTicket` gives both the same opaque identity string,
+    // so the resolver is keyed on call count instead.
+    const CallCountResolver = struct {
+        state: *session.ServerRecoverableState,
+        calls: usize = 0,
+
+        fn now(_: *anyopaque) i64 {
+            return 2000;
+        }
+        fn resolve(ctx: *anyopaque, _: []const u8) pre_shared_key.ResolveError!pre_shared_key.ServerPskResolveResult {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.calls += 1;
+            if (self.calls == 1) return .miss;
+            return clonedResolveHit(self.state, std.testing.allocator);
+        }
+    };
+    var resolver_state = CallCountResolver{ .state = &second_issued.server_state };
+    try resumed.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CallCountResolver.now,
+        .resolveFn = CallCountResolver.resolve,
+    });
+    try resumed.server_backend.setServerEarlyDataPolicy(.{ .enabled = true, .age_skew_tolerance_ms = 60_000 });
+
+    try resumed.run();
+
+    try std.testing.expect(resumed.client_driver.isComplete());
+    try std.testing.expect(resumed.server_driver.isComplete());
+    try std.testing.expect(resumed.server_backend.core.psk_authenticated);
+    try std.testing.expectEqual(@as(usize, 2), resolver_state.calls);
+    try std.testing.expect(!resumed.server_backend.earlyDataAccepted());
+    try std.testing.expectEqual(tls_backend.EarlyDataDecision.selected_identity_not_zero, resumed.server_backend.earlyDataDecision());
+}
+
+test "the ClientHello wire-encodes early_data before pre_shared_key only when 0-RTT is attempted" {
+    var issued = try issueEarlyCapableTicket(32);
+    defer issued.deinit();
+
+    var resumed = DirectHarness.init();
+    defer resumed.deinit();
+
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&issued.ticket);
+    var clock_dummy: u8 = 0;
+    try resumed.client_backend.setClientPskOffers(&offers, &clock_dummy, earlyDataResumedClientClock);
+    var resolver_state = IdentityResolver{ .state = &issued.server_state };
+    try resumed.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = IdentityResolver.now,
+        .resolveFn = IdentityResolver.resolve,
+    });
+    try resumed.client_backend.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 16384 });
+
+    resumed.client_driver = DirectDriver.init(.client, resumed.client_backend.backend());
+    resumed.drivers_ready = true;
+    const initial_sink = try resumed.client_driver.start({});
+    // Attempting 0-RTT means `sendClientHello` also emits its own
+    // `.zero_rtt`/`.write` secret event (see `tls13_backend.zig`), ahead of
+    // the ClientHello's `handshake_bytes` event — find the ClientHello
+    // itself rather than assuming its position.
+    var client_hello: ?[]const u8 = null;
+    for (initial_sink.items[0..initial_sink.len]) |event| {
+        if (event == .handshake_bytes) client_hello = event.handshake_bytes.data;
+    }
+    const ch = client_hello orelse return error.TestExpectedEqual;
+
+    const early_data_ext: u16 = @intFromEnum(tls_core.algorithms.ExtensionType.early_data);
+    const psk_ext: u16 = pre_shared_key.ext_pre_shared_key;
+    const early_data_pos = std.mem.indexOf(u8, ch, &std.mem.toBytes(std.mem.nativeToBig(u16, early_data_ext))) orelse
+        return error.TestExpectedEqual;
+    // `pre_shared_key`'s own 2-byte type also appears inside the extension
+    // as the identities/binders vector lengths never happen to collide
+    // with the exact 2-byte pattern `0029` (41) at a *type* position for
+    // this fixed, small ClientHello — found from the end so the match is
+    // unambiguous even so.
+    const psk_ext_pos = std.mem.lastIndexOf(u8, ch, &std.mem.toBytes(std.mem.nativeToBig(u16, psk_ext))) orelse
+        return error.TestExpectedEqual;
+    try std.testing.expect(early_data_pos < psk_ext_pos);
+
+    // Server never started (no `harness.run()`): nothing to tear down
+    // beyond the harness's own `deinit`, which only runs the drivers'
+    // `deinit` when `drivers_ready` — already true here.
+    resumed.server_driver = DirectDriver.init(.server, resumed.server_backend.backend());
 }
 
 fn expectRuntimeResumedRecordHandshake(

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -1071,8 +1071,6 @@ test "an early-data-specific compatibility gate sees remembered transport metada
         .nowUnixMsFn = IdentityResolver.now,
         .resolveFn = IdentityResolver.resolve,
     });
-    try resumed.client_backend.setResumeCompatibilityPolicy(.{ .transport = .ignore, .application = .ignore });
-    try resumed.server_backend.setResumeCompatibilityPolicy(.{ .transport = .ignore, .application = .ignore });
     try resumed.client_backend.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 16384 });
     try resumed.server_backend.setServerEarlyDataPolicy(.{ .enabled = true, .age_skew_tolerance_ms = 60_000 });
 
@@ -1088,9 +1086,9 @@ test "an early-data-specific compatibility gate sees remembered transport metada
     var compat_gate = CapturingCompatGate{};
     // A gate that reports a transport mismatch — modeling a future QUIC-owned
     // "remembered transport parameters were reduced" check (#366 letter S) —
-    // deliberately independent of `resume_compat` (never configured `.exact`
-    // here), proving early data and ordinary resumption are no longer coupled
-    // through the same compatibility path.
+    // while the default ordinary `.exact` transport compatibility still
+    // succeeds, proving early data and ordinary resumption are no longer
+    // coupled through the same compatibility path.
     try resumed.server_backend.setEarlyDataCompatibilityGate(.{
         .ctx = &compat_gate,
         .decideFn = CapturingCompatGate.decide,


### PR DESCRIPTION
## Summary

Issue #366 ("[326-G] add 0-RTT policy gate and request-safety filter") is
XL-complexity and its own description lays out 5 suggested PR slices. This
PR implements **slice 1 only** (TLS vocabulary + early secret + server
decision + EE signaling), scoped to `src/tls/tls13_backend.zig` and
`src/tls/key_schedule.zig` as the issue itself suggests for that slice.

- Adds `ClientEarlyDataIntent` / `ServerEarlyDataPolicy` / `EarlyDataDecision`
  / `EarlyDataReplayGate` vocabulary, all disabled/unavailable by default.
- Client: `setClientEarlyDataIntent`, `planEarlyDataAttempt` (attempts 0-RTT
  only against the *first surviving* PSK offer — never reordered, preserving
  #487's wire-index/lease semantics), emits the empty `early_data` ClientHello
  extension before `pre_shared_key`, and derives `client_early_traffic_secret`
  from the hash of the *complete* ClientHello (real binders, not the
  binder-truncated prefix).
- Server: `setServerEarlyDataPolicy`, `setEarlyDataReplayGate`, and a new
  `decideServerEarlyData` decision made live inside the existing `selectPsk`
  selection (identity-0 → ticket-capability → age-skew → anti-replay), after
  binder verification — so an early-data rejection never rejects an
  otherwise-valid PSK resumption. Anti-replay is only a seam (#368 owns the
  actual store) and defaults to `.unavailable`, which fails 0-RTT closed
  without affecting ordinary 1-RTT.
- `EncryptedExtensions` signals acceptance with an empty `early_data`
  extension; the client validates it (attempted, identity 0, non-resume-only
  ticket) before trusting it.
- New public accessors: `earlyDataAttempted()`, `earlyDataAccepted()`,
  `earlyDataDecision()`.

**Out of scope for this PR** (separate follow-up slices, per #366's own
breakdown): ticket `max_early_data_size` advertisement at the #495 issuance
call sites, record/QUIC 0-RTT key installation and EndOfEarlyData, and the
HTTP-level request-safety gate. This PR does not close #366.

## Test plan
- [x] `zig build test-tls` / `zig build test` — full suite green, including
      8 new tests: an accepted round trip with matching independently-derived
      client/server secrets, resume-only tickets never attempting 0-RTT,
      client opt-out, server-policy-disabled rejection, age-skew rejection,
      explicit replay rejection, default (unavailable) replay rejection,
      non-zero selected-identity rejection, and ClientHello wire-ordering
      (`early_data` before `pre_shared_key`).
- [x] `key_schedule.zig` gets 3 new `clientEarlyTrafficSecret` KAT tests
      against an independently computed (plain Python HKDF) fixture.
- [x] `zig fmt --check` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)