### PR TITLE
http: add early-data policy primitives

### DIFF
--- a/src/edge_config.zig
+++ b/src/edge_config.zig
@@ -2352,16 +2352,20 @@ fn parseLocationBlocks(allocator: std.mem.Allocator, raw: []const u8) ![]EdgeCon
         if (pattern.len == 0 or action_kind.len == 0) return error.InvalidLocationBlockFormat;
 
         var action: http.location_router.Action = undefined;
+        var action_owned = false;
+        errdefer if (action_owned) action.deinit(allocator);
         if (std.ascii.eqlIgnoreCase(action_kind, "proxy_pass")) {
             const target_raw = fields.next() orelse return error.InvalidLocationBlockFormat;
             const target = std.mem.trim(u8, target_raw, " \t\r\n");
             if (target.len == 0) return error.InvalidLocationBlockFormat;
             action = .{ .proxy_pass = try allocator.dupe(u8, target) };
+            action_owned = true;
         } else if (std.ascii.eqlIgnoreCase(action_kind, "fastcgi_pass")) {
             const target_raw = fields.next() orelse return error.InvalidLocationBlockFormat;
             const target = std.mem.trim(u8, target_raw, " \t\r\n");
             if (target.len == 0) return error.InvalidLocationBlockFormat;
             action = .{ .fastcgi_pass = try allocator.dupe(u8, target) };
+            action_owned = true;
         } else if (std.ascii.eqlIgnoreCase(action_kind, "return")) {
             const status_raw = fields.next() orelse return error.InvalidLocationBlockFormat;
             const body_raw = fields.next() orelse return error.InvalidLocationBlockFormat;
@@ -2370,6 +2374,7 @@ fn parseLocationBlocks(allocator: std.mem.Allocator, raw: []const u8) ![]EdgeCon
                 .status = status,
                 .body = try allocator.dupe(u8, std.mem.trim(u8, body_raw, " \t\r\n")),
             } };
+            action_owned = true;
         } else if (std.ascii.eqlIgnoreCase(action_kind, "rewrite")) {
             const replacement_raw = fields.next() orelse return error.InvalidLocationBlockFormat;
             const flag_raw = fields.next() orelse return error.InvalidLocationBlockFormat;
@@ -2380,6 +2385,7 @@ fn parseLocationBlocks(allocator: std.mem.Allocator, raw: []const u8) ![]EdgeCon
                 .replacement = try allocator.dupe(u8, replacement),
                 .flag = flag,
             } };
+            action_owned = true;
         } else if (std.ascii.eqlIgnoreCase(action_kind, "static_root")) {
             const root_raw = fields.next() orelse return error.InvalidLocationBlockFormat;
             const alias_raw = fields.next() orelse return error.InvalidLocationBlockFormat;
@@ -2397,22 +2403,33 @@ fn parseLocationBlocks(allocator: std.mem.Allocator, raw: []const u8) ![]EdgeCon
                 .index = try allocator.dupe(u8, std.mem.trim(u8, index_raw, " \t\r\n")),
                 .try_files = try allocator.dupe(u8, std.mem.trim(u8, try_files_raw, " \t\r\n")),
             } };
+            action_owned = true;
         } else {
             return error.InvalidLocationBlockFormat;
         }
 
         var auth: http.location_router.AuthMode = .off;
         var proxy_streaming_policy: http.location_router.ProxyStreamingPolicy = .inherit;
+        var early_data: http.location_router.EarlyDataPolicy = .off;
+        var proxy_early_data: http.location_router.ProxyEarlyDataPolicy = .off;
         while (fields.next()) |option_raw| {
             const option = std.mem.trim(u8, option_raw, " \t\r\n");
             if (std.mem.startsWith(u8, option, "auth:")) {
                 auth = http.location_router.AuthMode.parse(option["auth:".len..]) orelse return error.InvalidLocationBlockFormat;
             } else if (std.mem.startsWith(u8, option, "stream:")) {
                 proxy_streaming_policy = http.location_router.ProxyStreamingPolicy.parse(option["stream:".len..]) orelse return error.InvalidLocationBlockFormat;
+            } else if (std.mem.startsWith(u8, option, "early_data:")) {
+                early_data = http.location_router.EarlyDataPolicy.parse(option["early_data:".len..]) orelse return error.InvalidLocationBlockFormat;
+            } else if (std.mem.startsWith(u8, option, "proxy_early_data:")) {
+                proxy_early_data = http.location_router.ProxyEarlyDataPolicy.parse(option["proxy_early_data:".len..]) orelse return error.InvalidLocationBlockFormat;
             } else {
                 return error.InvalidLocationBlockFormat;
             }
         }
+        if (proxy_early_data == .rfc8470) switch (action) {
+            .proxy_pass => {},
+            else => return error.InvalidLocationBlockFormat,
+        };
 
         try out.append(allocator, .{
             .match_type = match_type,
@@ -2422,7 +2439,10 @@ fn parseLocationBlocks(allocator: std.mem.Allocator, raw: []const u8) ![]EdgeCon
             .error_pages = &.{},
             .auth = auth,
             .proxy_streaming_policy = proxy_streaming_policy,
+            .early_data = early_data,
+            .proxy_early_data = proxy_early_data,
         });
+        action_owned = false;
     }
 
     return out.toOwnedSlice(allocator);
@@ -2863,7 +2883,7 @@ pub fn validate(cfg: *const EdgeConfig) !void {
         switch (block.action) {
             .proxy_pass => |target| if (isAbsoluteHttpUrl(target) or isUnixEndpoint(target)) try validateOptionalUpstreamBaseUrl(target, "location.proxy_pass"),
             .fastcgi_pass => |target| try validateOptionalSocketEndpoint(target, "location.fastcgi_pass"),
-            else => {},
+            else => if (block.proxy_early_data == .rfc8470) return error.InvalidConfigValue,
         }
     }
 
@@ -3614,6 +3634,33 @@ test "parse location blocks include route streaming policy option" {
     try std.testing.expectEqual(http.location_router.ProxyStreamingPolicy.off, blocks[0].proxy_streaming_policy);
     try std.testing.expectEqual(http.location_router.ProxyStreamingPolicy.full, blocks[1].proxy_streaming_policy);
     try std.testing.expectEqual(http.location_router.AuthMode.required, blocks[1].auth);
+}
+
+test "parse location blocks include early data policy options" {
+    const allocator = std.testing.allocator;
+    const blocks = try parseLocationBlocks(
+        allocator,
+        "prefix|/safe/|return|200|ok|early_data:replay_safe;prefix|/proxy/|proxy_pass|http://127.0.0.1:9002|early_data:replay_safe|proxy_early_data:rfc8470",
+    );
+    defer {
+        for (blocks) |*block| {
+            block.deinit(allocator);
+        }
+        allocator.free(blocks);
+    }
+
+    try std.testing.expectEqual(@as(usize, 2), blocks.len);
+    try std.testing.expectEqual(http.location_router.EarlyDataPolicy.replay_safe, blocks[0].early_data);
+    try std.testing.expectEqual(http.location_router.ProxyEarlyDataPolicy.off, blocks[0].proxy_early_data);
+    try std.testing.expectEqual(http.location_router.EarlyDataPolicy.replay_safe, blocks[1].early_data);
+    try std.testing.expectEqual(http.location_router.ProxyEarlyDataPolicy.rfc8470, blocks[1].proxy_early_data);
+}
+
+test "parse location blocks reject proxy early data on non proxy action" {
+    try std.testing.expectError(
+        error.InvalidLocationBlockFormat,
+        parseLocationBlocks(std.testing.allocator, "prefix|/local/|return|200|ok|proxy_early_data:rfc8470"),
+    );
 }
 
 test "apply location error pages csv" {

--- a/src/gateway_proxy_headers.zig
+++ b/src/gateway_proxy_headers.zig
@@ -30,6 +30,8 @@ pub fn shouldSkipUpstreamRequestHeader(name: []const u8, connection_header: ?[]c
         std.ascii.eqlIgnoreCase(name[0..tardigrade_prefix.len], tardigrade_prefix))
         return true;
 
+    if (std.ascii.eqlIgnoreCase(name, http.early_data.HEADER_NAME)) return true;
+
     if (connectionHeaderReferencesHeader(connection_header, name)) return true;
 
     return std.ascii.eqlIgnoreCase(name, "accept-encoding") or
@@ -61,6 +63,7 @@ pub fn shouldSkipUpstreamRequestHeader(name: []const u8, connection_header: ?[]c
 pub fn shouldSkipUpstreamResponseHeader(name: []const u8) bool {
     return std.ascii.eqlIgnoreCase(name, "connection") or
         std.ascii.eqlIgnoreCase(name, "content-encoding") or
+        std.ascii.eqlIgnoreCase(name, http.early_data.HEADER_NAME) or
         std.ascii.eqlIgnoreCase(name, "content-length") or
         std.ascii.eqlIgnoreCase(name, "keep-alive") or
         std.ascii.eqlIgnoreCase(name, "proxy-connection") or
@@ -102,6 +105,11 @@ pub fn appendProxyRequestHeaders(
         if (shouldSkipUpstreamRequestHeader(header.name, connection_header)) continue;
         try extra_headers.append(.{ .name = header.name, .value = header.value });
     }
+}
+
+pub fn appendCanonicalEarlyDataHeader(extra_headers: *std.array_list.Managed(std.http.Header), enabled: bool) !void {
+    if (!enabled) return;
+    try extra_headers.append(.{ .name = http.early_data.HEADER_NAME, .value = http.early_data.HEADER_VALUE });
 }
 
 // ---------------------------------------------------------------------------
@@ -316,6 +324,11 @@ test "shouldSkipUpstreamRequestHeader strips standard hop-by-hop headers" {
     try std.testing.expect(shouldSkipUpstreamRequestHeader("Upgrade", null));
 }
 
+test "shouldSkipUpstreamRequestHeader strips raw Early-Data before canonical append" {
+    try std.testing.expect(shouldSkipUpstreamRequestHeader("Early-Data", null));
+    try std.testing.expect(shouldSkipUpstreamRequestHeader("early-data", "Early-Data"));
+}
+
 test "shouldSkipUpstreamRequestHeader strips headers named by Connection" {
     const connection_header = "X-Test-Hop, keep-alive, Another-Hop";
     try std.testing.expect(shouldSkipUpstreamRequestHeader("X-Test-Hop", connection_header));
@@ -369,6 +382,45 @@ test "shouldSkipUpstreamResponseHeader strips stale content-encoding" {
     try std.testing.expect(shouldSkipUpstreamResponseHeader("Content-Encoding"));
     try std.testing.expect(shouldSkipUpstreamResponseHeader("content-encoding"));
     try std.testing.expect(!shouldSkipUpstreamResponseHeader("Content-Type"));
+}
+
+test "shouldSkipUpstreamResponseHeader strips Early-Data response headers" {
+    try std.testing.expect(shouldSkipUpstreamResponseHeader("Early-Data"));
+    try std.testing.expect(shouldSkipUpstreamResponseHeader("early-data"));
+}
+
+test "appendCanonicalEarlyDataHeader emits exactly one RFC 8470 marker when enabled" {
+    var headers = std.array_list.Managed(std.http.Header).init(std.testing.allocator);
+    defer headers.deinit();
+
+    try appendCanonicalEarlyDataHeader(&headers, false);
+    try std.testing.expectEqual(@as(usize, 0), headers.items.len);
+
+    try appendCanonicalEarlyDataHeader(&headers, true);
+    try std.testing.expectEqual(@as(usize, 1), headers.items.len);
+    try std.testing.expectEqualStrings("Early-Data", headers.items[0].name);
+    try std.testing.expectEqualStrings("1", headers.items[0].value);
+}
+
+test "appendProxyRequestHeaders normalizes duplicate inbound Early-Data through canonical helper" {
+    var request_headers = http.Headers.init(std.testing.allocator);
+    defer request_headers.deinit();
+    try request_headers.append("Connection", "Early-Data");
+    try request_headers.append("Early-Data", "0");
+    try request_headers.append("early-data", "garbage");
+    try request_headers.append("X-Application", "kept");
+
+    var extra_headers = std.array_list.Managed(std.http.Header).init(std.testing.allocator);
+    defer extra_headers.deinit();
+
+    try appendProxyRequestHeaders(&extra_headers, &request_headers);
+    try appendCanonicalEarlyDataHeader(&extra_headers, true);
+
+    try std.testing.expectEqual(@as(usize, 2), extra_headers.items.len);
+    try std.testing.expectEqualStrings("x-application", extra_headers.items[0].name);
+    try std.testing.expectEqualStrings("kept", extra_headers.items[0].value);
+    try std.testing.expectEqualStrings("Early-Data", extra_headers.items[1].name);
+    try std.testing.expectEqualStrings("1", extra_headers.items[1].value);
 }
 
 test "shouldSkipUpstreamResponseHeader strips upstream Server and X-Powered-By" {

--- a/src/http.zig
+++ b/src/http.zig
@@ -37,6 +37,7 @@ pub const jwt = @import("http/jwt.zig");
 pub const logger = @import("http/logger.zig");
 pub const cache_control = @import("http/cache_control.zig");
 pub const compression = @import("http/compression.zig");
+pub const early_data = @import("http/early_data.zig");
 pub const metrics = @import("http/metrics.zig");
 pub const shutdown = @import("http/shutdown.zig");
 pub const health_checker = @import("http/health_checker.zig");

--- a/src/http/config_file.zig
+++ b/src/http/config_file.zig
@@ -81,6 +81,8 @@ const LocationBlockBuilder = struct {
     rewrite_flag: ?[]u8 = null,
     auth: ?[]u8 = null,
     proxy_streaming: ?[]u8 = null,
+    early_data: ?[]u8 = null,
+    proxy_early_data: ?[]u8 = null,
     error_pages: std.ArrayList(ErrorPageBuilder) = .empty,
 
     fn actionKind(self: *const LocationBlockBuilder) ?[]const u8 {
@@ -110,6 +112,8 @@ const LocationBlockBuilder = struct {
         if (self.rewrite_flag) |value| allocator.free(value);
         if (self.auth) |value| allocator.free(value);
         if (self.proxy_streaming) |value| allocator.free(value);
+        if (self.early_data) |value| allocator.free(value);
+        if (self.proxy_early_data) |value| allocator.free(value);
         for (self.error_pages.items) |entry| {
             allocator.free(entry.status_codes_csv);
             allocator.free(entry.target);
@@ -803,6 +807,22 @@ fn parseLocationStatement(
         try replaceOptionalOwned(allocator, &builder.proxy_streaming, value_interp);
         return;
     }
+    if (std.ascii.eqlIgnoreCase(directive, "early_data")) {
+        if (!isLocationEarlyDataPolicy(value_interp)) {
+            std.log.err("config syntax error at {s}:{d}: early_data must be one of off, replay_safe", .{ file_path, line_no });
+            return error.InvalidConfigSyntax;
+        }
+        try replaceOptionalOwned(allocator, &builder.early_data, value_interp);
+        return;
+    }
+    if (std.ascii.eqlIgnoreCase(directive, "proxy_early_data")) {
+        if (!isLocationProxyEarlyDataPolicy(value_interp)) {
+            std.log.err("config syntax error at {s}:{d}: proxy_early_data must be one of off, rfc8470", .{ file_path, line_no });
+            return error.InvalidConfigSyntax;
+        }
+        try replaceOptionalOwned(allocator, &builder.proxy_early_data, value_interp);
+        return;
+    }
 }
 
 fn isLocationProxyStreamingPolicy(value: []const u8) bool {
@@ -814,6 +834,18 @@ fn isLocationProxyStreamingPolicy(value: []const u8) bool {
         std.ascii.eqlIgnoreCase(value, "full") or
         std.ascii.eqlIgnoreCase(value, "request_response") or
         std.ascii.eqlIgnoreCase(value, "request-response");
+}
+
+fn isLocationEarlyDataPolicy(value: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(value, "off") or
+        std.ascii.eqlIgnoreCase(value, "replay_safe") or
+        std.ascii.eqlIgnoreCase(value, "replay-safe");
+}
+
+fn isLocationProxyEarlyDataPolicy(value: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(value, "off") or
+        std.ascii.eqlIgnoreCase(value, "rfc8470") or
+        std.ascii.eqlIgnoreCase(value, "rfc-8470");
 }
 
 fn ensureLocationActionAllowed(
@@ -886,6 +918,24 @@ fn buildLocationBlockEntry(allocator: std.mem.Allocator, builder: *LocationBlock
             const with_stream_policy = try std.fmt.allocPrint(allocator, "{s}|stream:{s}", .{ entry, mode });
             allocator.free(entry);
             entry = with_stream_policy;
+        }
+    }
+    if (builder.early_data) |policy| {
+        if (!std.ascii.eqlIgnoreCase(policy, "off")) {
+            const with_early_data = try std.fmt.allocPrint(allocator, "{s}|early_data:{s}", .{ entry, policy });
+            allocator.free(entry);
+            entry = with_early_data;
+        }
+    }
+    if (builder.proxy_early_data) |policy| {
+        if (!std.ascii.eqlIgnoreCase(policy, "off")) {
+            if (builder.proxy_pass == null) {
+                allocator.free(entry);
+                return error.InvalidConfigSyntax;
+            }
+            const with_proxy_early_data = try std.fmt.allocPrint(allocator, "{s}|proxy_early_data:{s}", .{ entry, policy });
+            allocator.free(entry);
+            entry = with_proxy_early_data;
         }
     }
     return entry;
@@ -1311,6 +1361,76 @@ test "location block serializes proxy streaming policy" {
         "prefix|/bulk/|proxy_pass|http://127.0.0.1:9001|stream:full;prefix|/compat/|proxy_pass|http://127.0.0.1:9002|stream:off",
         overrides.map.get("TARDIGRADE_LOCATION_BLOCKS").?,
     );
+}
+
+test "location block serializes early data policies" {
+    const allocator = std.testing.allocator;
+    var cfg_dir = std.testing.tmpDir(.{});
+    defer cfg_dir.cleanup();
+
+    try compat.wrapDir(cfg_dir.dir).writeFile(.{
+        .sub_path = "location-early-data.conf",
+        .data =
+        \\location /submit/ {
+        \\    proxy_pass http://127.0.0.1:9001;
+        \\    early_data replay_safe;
+        \\    proxy_early_data rfc8470;
+        \\}
+        ,
+    });
+
+    const absolute = try compat.wrapDir(cfg_dir.dir).realpathAlloc(allocator, "location-early-data.conf");
+    defer allocator.free(absolute);
+
+    var overrides = Overrides.init(allocator);
+    defer overrides.deinit(allocator);
+    var vars = std.StringHashMap([]const u8).init(allocator);
+    defer vars.deinit();
+    var visited = std.StringHashMap(void).init(allocator);
+    defer {
+        var it = visited.iterator();
+        while (it.next()) |entry| allocator.free(entry.key_ptr.*);
+        visited.deinit();
+    }
+
+    try parseFile(allocator, absolute, &overrides, &vars, &visited);
+
+    try std.testing.expectEqualStrings(
+        "prefix|/submit/|proxy_pass|http://127.0.0.1:9001|early_data:replay_safe|proxy_early_data:rfc8470",
+        overrides.map.get("TARDIGRADE_LOCATION_BLOCKS").?,
+    );
+}
+
+test "location block rejects proxy early data on non proxy action" {
+    const allocator = std.testing.allocator;
+    var cfg_dir = std.testing.tmpDir(.{});
+    defer cfg_dir.cleanup();
+
+    try compat.wrapDir(cfg_dir.dir).writeFile(.{
+        .sub_path = "location-early-data-invalid.conf",
+        .data =
+        \\location /local/ {
+        \\    return 200 ok;
+        \\    proxy_early_data rfc8470;
+        \\}
+        ,
+    });
+
+    const absolute = try compat.wrapDir(cfg_dir.dir).realpathAlloc(allocator, "location-early-data-invalid.conf");
+    defer allocator.free(absolute);
+
+    var overrides = Overrides.init(allocator);
+    defer overrides.deinit(allocator);
+    var vars = std.StringHashMap([]const u8).init(allocator);
+    defer vars.deinit();
+    var visited = std.StringHashMap(void).init(allocator);
+    defer {
+        var it = visited.iterator();
+        while (it.next()) |entry| allocator.free(entry.key_ptr.*);
+        visited.deinit();
+    }
+
+    try std.testing.expectError(error.InvalidConfigSyntax, parseFile(allocator, absolute, &overrides, &vars, &visited));
 }
 
 test "location block supports alias and fastcgi pass serialization" {

--- a/src/http/early_data.zig
+++ b/src/http/early_data.zig
@@ -38,15 +38,17 @@ pub fn decide(inputs: Inputs) Decision {
     const exposed = inputs.replay_exposed or inputs.transport_early or inputs.inbound_marker;
     if (!exposed) return .ordinary;
 
-    if (inputs.action_class == .defer_until_handshake) return .defer_until_handshake;
+    if (inputs.action_class == .defer_until_handshake and inputs.transport_early and !inputs.inbound_marker) {
+        return .defer_until_handshake;
+    }
 
-    const replay_safe = inputs.method_safe or inputs.route_replay_safe;
-    if (!replay_safe) return .too_early;
+    if (!inputs.method_safe) return .too_early;
+    if (!inputs.route_replay_safe) return .too_early;
 
     return switch (inputs.action_class) {
         .local => .execute_local,
         .proxy => if (inputs.proxy_origin_rfc8470) .forward_rfc8470 else .too_early,
-        .defer_until_handshake => unreachable,
+        .defer_until_handshake => .too_early,
     };
 }
 
@@ -56,9 +58,7 @@ pub fn tooEarlyPlan() TooEarlyPlan {
 
 pub fn methodSafe(method: []const u8) bool {
     return std.ascii.eqlIgnoreCase(method, "GET") or
-        std.ascii.eqlIgnoreCase(method, "HEAD") or
-        std.ascii.eqlIgnoreCase(method, "OPTIONS") or
-        std.ascii.eqlIgnoreCase(method, "TRACE");
+        std.ascii.eqlIgnoreCase(method, "HEAD");
 }
 
 test "early data decision treats unexposed requests as ordinary" {
@@ -90,7 +90,7 @@ test "early data decision executes replay-safe local work" {
         .replay_exposed = false,
         .transport_early = true,
         .inbound_marker = false,
-        .method_safe = false,
+        .method_safe = true,
         .route_replay_safe = true,
         .action_class = .local,
         .proxy_origin_rfc8470 = false,
@@ -103,7 +103,7 @@ test "early data decision forwards only to RFC 8470 aware proxy origins" {
         .transport_early = false,
         .inbound_marker = true,
         .method_safe = true,
-        .route_replay_safe = false,
+        .route_replay_safe = true,
         .action_class = .proxy,
         .proxy_origin_rfc8470 = false,
     };
@@ -112,6 +112,27 @@ test "early data decision forwards only to RFC 8470 aware proxy origins" {
     var aware = base;
     aware.proxy_origin_rfc8470 = true;
     try std.testing.expectEqual(Decision.forward_rfc8470, decide(aware));
+}
+
+test "early data decision requires both method and route replay-safety gates" {
+    try std.testing.expectEqual(Decision.too_early, decide(.{
+        .replay_exposed = true,
+        .transport_early = false,
+        .inbound_marker = false,
+        .method_safe = false,
+        .route_replay_safe = true,
+        .action_class = .local,
+        .proxy_origin_rfc8470 = false,
+    }));
+    try std.testing.expectEqual(Decision.too_early, decide(.{
+        .replay_exposed = false,
+        .transport_early = false,
+        .inbound_marker = true,
+        .method_safe = true,
+        .route_replay_safe = false,
+        .action_class = .proxy,
+        .proxy_origin_rfc8470 = true,
+    }));
 }
 
 test "early data decision supports explicit handshake deferral" {
@@ -126,10 +147,26 @@ test "early data decision supports explicit handshake deferral" {
     }));
 }
 
-test "early data method safety follows HTTP safe methods" {
+test "early data decision does not defer prior-hop exposure" {
+    try std.testing.expectEqual(Decision.too_early, decide(.{
+        .replay_exposed = false,
+        .transport_early = false,
+        .inbound_marker = true,
+        .method_safe = true,
+        .route_replay_safe = true,
+        .action_class = .defer_until_handshake,
+        .proxy_origin_rfc8470 = false,
+    }));
+}
+
+test "early data method safety is limited to GET and HEAD" {
     try std.testing.expect(methodSafe("GET"));
     try std.testing.expect(methodSafe("head"));
-    try std.testing.expect(methodSafe("OPTIONS"));
-    try std.testing.expect(methodSafe("TRACE"));
+    try std.testing.expect(!methodSafe("OPTIONS"));
+    try std.testing.expect(!methodSafe("TRACE"));
     try std.testing.expect(!methodSafe("POST"));
+    try std.testing.expect(!methodSafe("PUT"));
+    try std.testing.expect(!methodSafe("PATCH"));
+    try std.testing.expect(!methodSafe("DELETE"));
+    try std.testing.expect(!methodSafe("CONNECT"));
 }

--- a/src/http/early_data.zig
+++ b/src/http/early_data.zig
@@ -1,0 +1,135 @@
+const std = @import("std");
+const status = @import("status.zig");
+
+pub const HEADER_NAME = "Early-Data";
+pub const HEADER_VALUE = "1";
+
+pub const ActionClass = enum {
+    local,
+    proxy,
+    defer_until_handshake,
+};
+
+pub const Decision = enum {
+    ordinary,
+    execute_local,
+    forward_rfc8470,
+    too_early,
+    defer_until_handshake,
+};
+
+pub const Inputs = struct {
+    replay_exposed: bool,
+    transport_early: bool,
+    inbound_marker: bool,
+    method_safe: bool,
+    route_replay_safe: bool,
+    action_class: ActionClass,
+    proxy_origin_rfc8470: bool,
+};
+
+pub const TooEarlyPlan = struct {
+    status: status.Status = .too_early,
+    code: []const u8 = "too_early",
+    message: []const u8 = "Request rejected because it was sent in early data and the route is not replay safe.",
+};
+
+pub fn decide(inputs: Inputs) Decision {
+    const exposed = inputs.replay_exposed or inputs.transport_early or inputs.inbound_marker;
+    if (!exposed) return .ordinary;
+
+    if (inputs.action_class == .defer_until_handshake) return .defer_until_handshake;
+
+    const replay_safe = inputs.method_safe or inputs.route_replay_safe;
+    if (!replay_safe) return .too_early;
+
+    return switch (inputs.action_class) {
+        .local => .execute_local,
+        .proxy => if (inputs.proxy_origin_rfc8470) .forward_rfc8470 else .too_early,
+        .defer_until_handshake => unreachable,
+    };
+}
+
+pub fn tooEarlyPlan() TooEarlyPlan {
+    return .{};
+}
+
+pub fn methodSafe(method: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(method, "GET") or
+        std.ascii.eqlIgnoreCase(method, "HEAD") or
+        std.ascii.eqlIgnoreCase(method, "OPTIONS") or
+        std.ascii.eqlIgnoreCase(method, "TRACE");
+}
+
+test "early data decision treats unexposed requests as ordinary" {
+    try std.testing.expectEqual(Decision.ordinary, decide(.{
+        .replay_exposed = false,
+        .transport_early = false,
+        .inbound_marker = false,
+        .method_safe = false,
+        .route_replay_safe = false,
+        .action_class = .proxy,
+        .proxy_origin_rfc8470 = false,
+    }));
+}
+
+test "early data decision rejects unsafe replay-exposed work" {
+    try std.testing.expectEqual(Decision.too_early, decide(.{
+        .replay_exposed = true,
+        .transport_early = false,
+        .inbound_marker = false,
+        .method_safe = false,
+        .route_replay_safe = false,
+        .action_class = .local,
+        .proxy_origin_rfc8470 = false,
+    }));
+}
+
+test "early data decision executes replay-safe local work" {
+    try std.testing.expectEqual(Decision.execute_local, decide(.{
+        .replay_exposed = false,
+        .transport_early = true,
+        .inbound_marker = false,
+        .method_safe = false,
+        .route_replay_safe = true,
+        .action_class = .local,
+        .proxy_origin_rfc8470 = false,
+    }));
+}
+
+test "early data decision forwards only to RFC 8470 aware proxy origins" {
+    const base = Inputs{
+        .replay_exposed = false,
+        .transport_early = false,
+        .inbound_marker = true,
+        .method_safe = true,
+        .route_replay_safe = false,
+        .action_class = .proxy,
+        .proxy_origin_rfc8470 = false,
+    };
+
+    try std.testing.expectEqual(Decision.too_early, decide(base));
+    var aware = base;
+    aware.proxy_origin_rfc8470 = true;
+    try std.testing.expectEqual(Decision.forward_rfc8470, decide(aware));
+}
+
+test "early data decision supports explicit handshake deferral" {
+    try std.testing.expectEqual(Decision.defer_until_handshake, decide(.{
+        .replay_exposed = false,
+        .transport_early = true,
+        .inbound_marker = false,
+        .method_safe = true,
+        .route_replay_safe = false,
+        .action_class = .defer_until_handshake,
+        .proxy_origin_rfc8470 = false,
+    }));
+}
+
+test "early data method safety follows HTTP safe methods" {
+    try std.testing.expect(methodSafe("GET"));
+    try std.testing.expect(methodSafe("head"));
+    try std.testing.expect(methodSafe("OPTIONS"));
+    try std.testing.expect(methodSafe("TRACE"));
+    try std.testing.expect(!methodSafe("POST"));
+}

--- a/src/http/headers.zig
+++ b/src/http/headers.zig
@@ -111,6 +111,11 @@ pub const Headers = struct {
         return self.get(name) != null;
     }
 
+    /// RFC 8470 marker detection is based on field presence, not value.
+    pub fn hasEarlyDataMarker(self: *const Headers) bool {
+        return self.countByName("early-data") > 0;
+    }
+
     /// Count how many times a header name appears.
     pub fn countByName(self: *const Headers, name: []const u8) usize {
         var lower_buf: [256]u8 = undefined;
@@ -297,6 +302,21 @@ test "missing header returns null" {
     try testing.expect(headers.get("X-Missing") == null);
     try testing.expect(!headers.contains("X-Missing"));
     try testing.expect(headers.contains("Host"));
+}
+
+test "early data marker uses presence regardless of value" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var headers = Headers.init(allocator);
+    defer headers.deinit();
+
+    try testing.expect(!headers.hasEarlyDataMarker());
+    try headers.append("Early-Data", "0");
+    try testing.expect(headers.hasEarlyDataMarker());
+    try headers.append("early-data", "not-one");
+    try testing.expect(headers.hasEarlyDataMarker());
+    try testing.expectEqual(@as(usize, 2), headers.countByName("Early-Data"));
 }
 
 test "invalid header - no colon" {

--- a/src/http/location_router.zig
+++ b/src/http/location_router.zig
@@ -106,6 +106,28 @@ pub const ProxyStreamingPolicy = enum {
     }
 };
 
+pub const EarlyDataPolicy = enum {
+    off,
+    replay_safe,
+
+    pub fn parse(value: []const u8) ?EarlyDataPolicy {
+        if (std.ascii.eqlIgnoreCase(value, "off")) return .off;
+        if (std.ascii.eqlIgnoreCase(value, "replay_safe") or std.ascii.eqlIgnoreCase(value, "replay-safe")) return .replay_safe;
+        return null;
+    }
+};
+
+pub const ProxyEarlyDataPolicy = enum {
+    off,
+    rfc8470,
+
+    pub fn parse(value: []const u8) ?ProxyEarlyDataPolicy {
+        if (std.ascii.eqlIgnoreCase(value, "off")) return .off;
+        if (std.ascii.eqlIgnoreCase(value, "rfc8470") or std.ascii.eqlIgnoreCase(value, "rfc-8470")) return .rfc8470;
+        return null;
+    }
+};
+
 pub const LocationBlock = struct {
     match_type: MatchType,
     pattern: []const u8,
@@ -114,6 +136,8 @@ pub const LocationBlock = struct {
     error_pages: []ErrorPageRule = &.{},
     auth: AuthMode = .off,
     proxy_streaming_policy: ProxyStreamingPolicy = .inherit,
+    early_data: EarlyDataPolicy = .off,
+    proxy_early_data: ProxyEarlyDataPolicy = .off,
 
     pub fn deinit(self: *LocationBlock, allocator: std.mem.Allocator) void {
         allocator.free(self.pattern);
@@ -206,6 +230,13 @@ fn normalizeRequestPath(request_uri: []const u8) []const u8 {
     const query_start = std.mem.findScalar(u8, request_uri, '?') orelse request_uri.len;
     const fragment_start = std.mem.findScalar(u8, request_uri[0..query_start], '#') orelse query_start;
     return request_uri[0..fragment_start];
+}
+
+test "early data route policy parsers accept canonical and dashed values" {
+    try std.testing.expectEqual(EarlyDataPolicy.off, EarlyDataPolicy.parse("off").?);
+    try std.testing.expectEqual(EarlyDataPolicy.replay_safe, EarlyDataPolicy.parse("replay-safe").?);
+    try std.testing.expectEqual(ProxyEarlyDataPolicy.rfc8470, ProxyEarlyDataPolicy.parse("rfc-8470").?);
+    try std.testing.expect(ProxyEarlyDataPolicy.parse("yes") == null);
 }
 
 test "exact match beats prefix match" {

--- a/src/http/request_context.zig
+++ b/src/http/request_context.zig
@@ -4,6 +4,19 @@ const Allocator = std.mem.Allocator;
 const Request = @import("request.zig").Request;
 const RequestLifecycle = @import("request_lifecycle.zig").RequestLifecycle;
 
+pub const EarlyDataContext = struct {
+    transport_early: bool = false,
+    inbound_marker: bool = false,
+
+    pub fn replayExposed(self: EarlyDataContext) bool {
+        return self.transport_early or self.inbound_marker;
+    }
+
+    pub fn mayRetryUpstream425(self: EarlyDataContext) bool {
+        return self.inbound_marker and !self.transport_early;
+    }
+};
+
 /// Per-request context propagated through the middleware pipeline.
 ///
 /// Captures identity, timing, and metadata so downstream handlers
@@ -33,6 +46,8 @@ pub const RequestContext = struct {
     api_version: ?u16,
     /// Idempotency key if provided.
     idempotency_key: ?[]const u8,
+    /// HTTP early-data provenance for this request hop and prior hops.
+    early_data: EarlyDataContext,
     /// Upstream address selected for proxied requests.
     upstream_addr: ?[]const u8,
     /// Final upstream status observed for proxied requests.
@@ -57,6 +72,7 @@ pub const RequestContext = struct {
             .client_ip = client_ip,
             .api_version = null,
             .idempotency_key = null,
+            .early_data = .{},
             .upstream_addr = null,
             .upstream_status = null,
             .response_bytes = 0,
@@ -184,6 +200,14 @@ test "RequestContext setApiVersion and setIdempotencyKey" {
     try std.testing.expect(ctx.idempotency_key == null);
     ctx.setIdempotencyKey("idem-xyz");
     try std.testing.expectEqualStrings("idem-xyz", ctx.idempotency_key.?);
+}
+
+test "EarlyDataContext tracks current and prior hop exposure" {
+    try std.testing.expect(!(@as(EarlyDataContext, .{}).replayExposed()));
+    try std.testing.expect((@as(EarlyDataContext, .{ .transport_early = true })).replayExposed());
+    try std.testing.expect((@as(EarlyDataContext, .{ .inbound_marker = true })).replayExposed());
+    try std.testing.expect((@as(EarlyDataContext, .{ .inbound_marker = true })).mayRetryUpstream425());
+    try std.testing.expect(!(@as(EarlyDataContext, .{ .transport_early = true, .inbound_marker = true })).mayRetryUpstream425());
 }
 
 test "extractClientIp prefers X-Forwarded-For" {

--- a/src/http/request_context.zig
+++ b/src/http/request_context.zig
@@ -13,7 +13,7 @@ pub const EarlyDataContext = struct {
     }
 
     pub fn mayRetryUpstream425(self: EarlyDataContext) bool {
-        return self.inbound_marker and !self.transport_early;
+        return self.transport_early and !self.inbound_marker;
     }
 };
 
@@ -206,7 +206,12 @@ test "EarlyDataContext tracks current and prior hop exposure" {
     try std.testing.expect(!(@as(EarlyDataContext, .{}).replayExposed()));
     try std.testing.expect((@as(EarlyDataContext, .{ .transport_early = true })).replayExposed());
     try std.testing.expect((@as(EarlyDataContext, .{ .inbound_marker = true })).replayExposed());
-    try std.testing.expect((@as(EarlyDataContext, .{ .inbound_marker = true })).mayRetryUpstream425());
+}
+
+test "EarlyDataContext retries upstream 425 only for current-hop early data" {
+    try std.testing.expect(!(@as(EarlyDataContext, .{})).mayRetryUpstream425());
+    try std.testing.expect((@as(EarlyDataContext, .{ .transport_early = true })).mayRetryUpstream425());
+    try std.testing.expect(!(@as(EarlyDataContext, .{ .inbound_marker = true })).mayRetryUpstream425());
     try std.testing.expect(!(@as(EarlyDataContext, .{ .transport_early = true, .inbound_marker = true })).mayRetryUpstream425());
 }
 


### PR DESCRIPTION
## Summary
- add protocol-neutral HTTP early-data provenance, decision, and 425 planning primitives
- add route/config policy parsing for `early_data replay_safe` and `proxy_early_data rfc8470`
- normalize RFC 8470 proxy header handling by stripping inbound `Early-Data` and appending one canonical marker when enabled

Refs #367

## Testing
- `zig fmt --check build.zig src/ tests/`
- `zig build test --summary all --error-style verbose`

Note: this is slice 1 for #367 and intentionally does not close the umbrella issue.