### PR TITLE
http3: add remembered SETTINGS early-data compatibility

### DIFF
--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -38,6 +38,7 @@ pub const Http3RuntimeError = error{
     NotYetImplemented,
     BindFailed,
     TlsBootstrapFailed,
+    InvalidH3Settings,
 };
 
 pub const RequestHandler = *const fn (
@@ -186,7 +187,7 @@ pub const Runtime = struct {
         runtime.h3_application_compat_len = (http3.early_data.encodeSettingsSnapshot(
             runtime.h3_settings,
             &runtime.h3_application_compat,
-        ) catch unreachable).len;
+        ) catch return error.InvalidH3Settings).len;
 
         if (cfg.enable_0rtt) {
             logger.warn(null, "http3: 0-RTT is not supported by the native QUIC stack; continuing without it", .{});
@@ -430,7 +431,7 @@ pub const Runtime = struct {
                 allocator.destroy(backend);
                 return null;
             };
-            backend.setApplicationCompat(.{
+            backend.setEarlyDataApplicationCompat(.{
                 .format_id = http3.early_data.format_id,
                 .format_version = http3.early_data.format_version,
                 .bytes = self.h3_application_compat[0..self.h3_application_compat_len],

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -61,6 +61,7 @@ pub const Config = struct {
     tls_min_version: []const u8 = "1.3",
     tls_max_version: []const u8 = "1.3",
     enable_0rtt: bool = false,
+    h3_settings: http3.frame.Settings = .{},
     connection_migration: bool = false,
     max_datagram_size: usize = 1350,
     request_handler: ?RequestHandler = null,
@@ -143,6 +144,9 @@ pub const Runtime = struct {
     credential_provider: ?tls_core.credentials.CredentialProvider,
     resumption_runtime: ?*tls_core.resumption_runtime.Runtime,
     quic_config: quic.config.Config,
+    h3_settings: http3.frame.Settings,
+    h3_application_compat: [http3.early_data.encoded_snapshot_len]u8 = undefined,
+    h3_application_compat_len: usize = 0,
     snapshot_mutex: compat.Mutex = .{},
     snapshot_state: Snapshot,
     stopping: std.atomic.Value(bool),
@@ -175,9 +179,14 @@ pub const Runtime = struct {
             .credential_provider = cfg.credential_provider,
             .resumption_runtime = cfg.resumption_runtime,
             .quic_config = quicConfigFrom(cfg),
+            .h3_settings = cfg.h3_settings,
             .snapshot_state = .{ .quic_port = cfg.quic_port },
             .stopping = std.atomic.Value(bool).init(false),
         };
+        runtime.h3_application_compat_len = (http3.early_data.encodeSettingsSnapshot(
+            runtime.h3_settings,
+            &runtime.h3_application_compat,
+        ) catch unreachable).len;
 
         if (cfg.enable_0rtt) {
             logger.warn(null, "http3: 0-RTT is not supported by the native QUIC stack; continuing without it", .{});
@@ -421,6 +430,21 @@ pub const Runtime = struct {
                 allocator.destroy(backend);
                 return null;
             };
+            backend.setApplicationCompat(.{
+                .format_id = http3.early_data.format_id,
+                .format_version = http3.early_data.format_version,
+                .bytes = self.h3_application_compat[0..self.h3_application_compat_len],
+            }) catch {
+                allocator.destroy(backend);
+                return null;
+            };
+            backend.setEarlyDataCompatibilityGate(.{
+                .ctx = self,
+                .decideFn = h3EarlyDataCompatibility,
+            }) catch {
+                allocator.destroy(backend);
+                return null;
+            };
             backend.setResumptionDecisionObserver(runtime.backendDecisionObserver(.quic)) catch {
                 allocator.destroy(backend);
                 return null;
@@ -454,7 +478,7 @@ pub const Runtime = struct {
         entry.* = .{
             .backend = backend,
             .conn = conn,
-            .h3 = H3.init(allocator, .server),
+            .h3 = H3.initWithSettings(allocator, .server, self.h3_settings),
             .peer = peer,
             .cid_len = parsed.dcid.len,
             .accepted_at_us = now,
@@ -631,6 +655,19 @@ pub const Runtime = struct {
         entry.conn.emitPreparedNewSessionTicket(&prepared, identity.slice(), limits) catch |err| {
             runtime.rollbackIdentity(&identity);
             return err;
+        };
+    }
+
+    fn h3EarlyDataCompatibility(ctx: *anyopaque, candidate: tls_core.tls13_backend.EarlyDataCompatibilityCandidate) tls_core.tls13_backend.EarlyDataCompatibilityDecision {
+        const self: *Runtime = @ptrCast(@alignCast(ctx));
+        const app = candidate.remembered_application orelse return .application_incompatible;
+        return switch (http3.early_data.compatibility(.{
+            .format_id = app.format_id,
+            .format_version = app.format_version,
+            .bytes = app.bytes,
+        }, self.h3_settings)) {
+            .compatible => .compatible,
+            .missing_state, .malformed_state, .settings_incompatible => .application_incompatible,
         };
     }
 

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -184,6 +184,7 @@ pub const Runtime = struct {
             .snapshot_state = .{ .quic_port = cfg.quic_port },
             .stopping = std.atomic.Value(bool).init(false),
         };
+        http3.frame.validateLocallySupportedSettings(runtime.h3_settings) catch return error.InvalidH3Settings;
         runtime.h3_application_compat_len = (http3.early_data.encodeSettingsSnapshot(
             runtime.h3_settings,
             &runtime.h3_application_compat,
@@ -860,6 +861,35 @@ test "quicConfigFrom clamps datagram size into the work-buffer range" {
     const mid = quicConfigFrom(.{ .listen_host = "::", .quic_port = 443, .max_datagram_size = 1350 });
     try testing.expectEqual(@as(u64, 1350), mid.max_udp_payload_size);
     try testing.expectEqual(quic.config.MigrationPolicy.disabled, mid.migration_policy);
+}
+
+fn expectInvalidH3SettingsAtRuntimeInit(settings: http3.frame.Settings) !void {
+    var logger = logger_mod.Logger.init(.err, "http3-invalid-settings-test");
+    try testing.expectError(error.InvalidH3Settings, Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+        .h3_settings = settings,
+    }));
+}
+
+test "runtime init rejects unsupported local H3 setting qpack_max_table_capacity" {
+    try expectInvalidH3SettingsAtRuntimeInit(.{ .qpack_max_table_capacity = 1 });
+}
+
+test "runtime init rejects unsupported local H3 setting qpack_blocked_streams" {
+    try expectInvalidH3SettingsAtRuntimeInit(.{ .qpack_blocked_streams = 1 });
+}
+
+test "runtime init rejects unsupported local H3 setting enable_connect_protocol" {
+    try expectInvalidH3SettingsAtRuntimeInit(.{ .enable_connect_protocol = true });
+}
+
+test "runtime init rejects unsupported local H3 setting h3_datagram" {
+    try expectInvalidH3SettingsAtRuntimeInit(.{ .h3_datagram = true });
+}
+
+test "runtime init rejects unsupported local H3 setting max_field_section_size" {
+    try expectInvalidH3SettingsAtRuntimeInit(.{ .max_field_section_size = 1024 });
 }
 
 test "admissionAllowed enforces global and per-source caps at the boundary" {

--- a/src/http3/conn.zig
+++ b/src/http3/conn.zig
@@ -78,6 +78,7 @@ pub fn Conn(comptime Transport: type) type {
         peer_qpack_encoder: ?u64 = null,
         peer_qpack_decoder: ?u64 = null,
         peer_control_view: frame.ControlStream = .{},
+        local_settings: frame.Settings = .{},
         /// Peer uni streams whose type varint has not fully arrived yet, and
         /// unknown-type streams we drain and ignore.
         pending_uni: std.AutoHashMap(u64, PendingUni),
@@ -116,9 +117,14 @@ pub fn Conn(comptime Transport: type) type {
         };
 
         pub fn init(allocator: std.mem.Allocator, role: Role) Self {
+            return initWithSettings(allocator, role, .{});
+        }
+
+        pub fn initWithSettings(allocator: std.mem.Allocator, role: Role, settings: frame.Settings) Self {
             return .{
                 .allocator = allocator,
                 .role = role,
+                .local_settings = settings,
                 .pending_uni = std.AutoHashMap(u64, PendingUni).init(allocator),
                 .requests = std.AutoHashMap(u64, *ServerRequest).init(allocator),
                 .responses = std.AutoHashMap(u64, *ClientResponse).init(allocator),
@@ -190,13 +196,37 @@ pub fn Conn(comptime Transport: type) type {
             var bytes: [64]u8 = undefined;
             var len: usize = 0;
             len += (try frame.encodeStreamType(.control, bytes[len..])).len;
-            var settings_payload: [16]u8 = undefined;
-            // Static-table-only QPACK: all our SETTINGS are the RFC defaults,
-            // so the frame is legitimately empty.
-            const settings = try frame.encodeSettings(&.{}, &settings_payload);
+            var settings_payload: [64]u8 = undefined;
+            var settings_entries: [5]frame.Setting = undefined;
+            const settings = try encodeLocalSettings(self.local_settings, &settings_entries, &settings_payload);
             len += (try frame.encodeKnownFrame(.settings, settings, bytes[len..])).len;
             _ = try transport.writeStream(control, bytes[0..len], false);
             self.control_out = control;
+        }
+
+        fn encodeLocalSettings(settings: frame.Settings, entries: *[5]frame.Setting, out: []u8) ![]u8 {
+            var count: usize = 0;
+            if (settings.qpack_max_table_capacity != 0) {
+                entries[count] = .{ .id = .qpack_max_table_capacity, .id_value = 0x01, .value = settings.qpack_max_table_capacity };
+                count += 1;
+            }
+            if (settings.max_field_section_size) |max| {
+                entries[count] = .{ .id = .max_field_section_size, .id_value = 0x06, .value = max };
+                count += 1;
+            }
+            if (settings.qpack_blocked_streams != 0) {
+                entries[count] = .{ .id = .qpack_blocked_streams, .id_value = 0x07, .value = settings.qpack_blocked_streams };
+                count += 1;
+            }
+            if (settings.enable_connect_protocol) {
+                entries[count] = .{ .id = .enable_connect_protocol, .id_value = 0x08, .value = 1 };
+                count += 1;
+            }
+            if (settings.h3_datagram) {
+                entries[count] = .{ .id = .h3_datagram, .id_value = 0x33, .value = 1 };
+                count += 1;
+            }
+            return frame.encodeSettings(entries[0..count], out);
         }
 
         /// Drain newly accepted and readable peer streams. Call after every
@@ -655,6 +685,37 @@ test "H3 conn: SETTINGS exchange and request/response over a mock transport" {
     try testing.expectEqualStrings("pong", response.body);
     try testing.expectEqualStrings("server", response.headers[0].name);
     client.releaseResponse(id);
+}
+
+test "H3 conn: start emits configured non-default SETTINGS" {
+    const allocator = testing.allocator;
+    var client_transport = MockTransport.init(allocator, true);
+    defer client_transport.deinit();
+    var server_transport = MockTransport.init(allocator, false);
+    defer server_transport.deinit();
+    client_transport.peer = &server_transport;
+    server_transport.peer = &client_transport;
+
+    const H3 = Conn(MockTransport);
+    var server = H3.initWithSettings(allocator, .server, .{
+        .qpack_max_table_capacity = 1024,
+        .qpack_blocked_streams = 2,
+        .max_field_section_size = 4096,
+        .enable_connect_protocol = true,
+    });
+    defer server.deinit();
+
+    try server.start(&server_transport);
+    try testing.expectEqual(@as(?u64, 3), server.control_out);
+    const stream = client_transport.streams.get(3) orelse return error.TestExpectedEqual;
+    var control = frame.ControlStream{};
+    defer control.deinit(allocator);
+    try testing.expectEqual(stream.data.items.len, try control.ingest(allocator, stream.data.items));
+    try testing.expect(control.saw_settings);
+    try testing.expectEqual(@as(u64, 1024), control.settings.qpack_max_table_capacity);
+    try testing.expectEqual(@as(u64, 2), control.settings.qpack_blocked_streams);
+    try testing.expectEqual(@as(?u64, 4096), control.settings.max_field_section_size);
+    try testing.expect(control.settings.enable_connect_protocol);
 }
 
 test "H3 conn: duplicate QPACK encoder stream is a stream creation error" {

--- a/src/http3/conn.zig
+++ b/src/http3/conn.zig
@@ -13,6 +13,7 @@
 //! rejected per RFC 9114 §7.2.3 (we never send MAX_PUSH_ID).
 
 const std = @import("std");
+const early_data = @import("early_data.zig");
 const frame = @import("frame.zig");
 const qpack = @import("qpack.zig");
 const session = @import("session.zig");
@@ -153,6 +154,19 @@ pub fn Conn(comptime Transport: type) type {
         pub fn closeCode(self: *const Self) u64 {
             const code = self.close_code orelse ErrorCode.general_protocol_error;
             return code.wire();
+        }
+
+        pub fn peerSettings(self: *const Self) ?frame.Settings {
+            if (!self.peer_control_view.saw_settings) return null;
+            return self.peer_control_view.settings;
+        }
+
+        /// Client-side #367 handoff: before SETTINGS arrives, H3 0-RTT uses
+        /// RFC defaults; after the peer control stream is decoded,
+        /// subsequently received tickets inherit the remembered server
+        /// SETTINGS snapshot.
+        pub fn encodePeerSettingsForEarlyDataTicket(self: *const Self, out: []u8) early_data.SnapshotError![]const u8 {
+            return early_data.encodeSettingsSnapshot(self.peerSettings() orelse .{}, out);
         }
 
         /// Record the wire close code (first failure wins) and produce the
@@ -716,6 +730,38 @@ test "H3 conn: start emits configured non-default SETTINGS" {
     try testing.expectEqual(@as(u64, 2), control.settings.qpack_blocked_streams);
     try testing.expectEqual(@as(?u64, 4096), control.settings.max_field_section_size);
     try testing.expect(control.settings.enable_connect_protocol);
+}
+
+test "H3 conn: early ticket snapshot uses defaults until peer SETTINGS arrive" {
+    const allocator = testing.allocator;
+    var client_transport = MockTransport.init(allocator, true);
+    defer client_transport.deinit();
+    var server_transport = MockTransport.init(allocator, false);
+    defer server_transport.deinit();
+    client_transport.peer = &server_transport;
+    server_transport.peer = &client_transport;
+
+    const H3 = Conn(MockTransport);
+    var client = H3.init(allocator, .client);
+    defer client.deinit();
+    var snapshot: [early_data.encoded_snapshot_len]u8 = undefined;
+    const defaults = try client.encodePeerSettingsForEarlyDataTicket(&snapshot);
+    try testing.expectEqual(frame.Settings{}, try early_data.decodeSettingsSnapshot(defaults));
+
+    var server = H3.initWithSettings(allocator, .server, .{
+        .qpack_blocked_streams = 3,
+        .max_field_section_size = 8192,
+        .enable_connect_protocol = true,
+    });
+    defer server.deinit();
+    try server.start(&server_transport);
+    try client.pump(&client_transport);
+    const remembered = try client.encodePeerSettingsForEarlyDataTicket(&snapshot);
+    try testing.expectEqual(frame.Settings{
+        .qpack_blocked_streams = 3,
+        .max_field_section_size = 8192,
+        .enable_connect_protocol = true,
+    }, try early_data.decodeSettingsSnapshot(remembered));
 }
 
 test "H3 conn: duplicate QPACK encoder stream is a stream creation error" {

--- a/src/http3/conn.zig
+++ b/src/http3/conn.zig
@@ -26,6 +26,7 @@ pub const H3Error = error{
     ProtocolError,
     ResponseTooLarge,
     UnknownStream,
+    UnsupportedH3Setting,
 };
 
 /// HTTP/3 wire error codes (RFC 9114 §8.1). Zig errors carry no payload, so
@@ -206,6 +207,7 @@ pub fn Conn(comptime Transport: type) type {
         /// connection is established.
         pub fn start(self: *Self, transport: *Transport) !void {
             if (self.control_out != null) return;
+            frame.validateLocallySupportedSettings(self.local_settings) catch return error.UnsupportedH3Setting;
             const control = try transport.openStream(.uni);
             var bytes: [64]u8 = undefined;
             var len: usize = 0;
@@ -216,6 +218,18 @@ pub fn Conn(comptime Transport: type) type {
             len += (try frame.encodeKnownFrame(.settings, settings, bytes[len..])).len;
             _ = try transport.writeStream(control, bytes[0..len], false);
             self.control_out = control;
+            if (self.role == .client) try self.publishEarlyTicketSnapshot(transport);
+        }
+
+        fn publishEarlyTicketSnapshot(self: *const Self, transport: *Transport) H3Error!void {
+            if (!@hasDecl(Transport, "setEarlyDataApplicationCompat")) return;
+            var snapshot: [early_data.encoded_snapshot_len]u8 = undefined;
+            const encoded = self.encodePeerSettingsForEarlyDataTicket(&snapshot) catch return error.ProtocolError;
+            transport.setEarlyDataApplicationCompat(.{
+                .format_id = early_data.format_id,
+                .format_version = early_data.format_version,
+                .bytes = encoded,
+            }) catch return error.ProtocolError;
         }
 
         fn encodeLocalSettings(settings: frame.Settings, entries: *[5]frame.Setting, out: []u8) ![]u8 {
@@ -324,10 +338,14 @@ pub fn Conn(comptime Transport: type) type {
                         }
                     }
                     if (bytes.len > 0 and state.typ == .control) {
+                        const had_settings = self.peer_control_view.saw_settings;
                         _ = self.peer_control_view.ingest(self.allocator, bytes) catch |err| {
                             return self.failControl(err);
                         };
                         if (self.peer_control_view.saw_settings) self.metrics.settings_received = true;
+                        if (self.role == .client and !had_settings and self.peer_control_view.saw_settings) {
+                            try self.publishEarlyTicketSnapshot(transport);
+                        }
                     }
                     // QPACK encoder/decoder instructions: with a zero-capacity
                     // dynamic table the peer sends none that affect state;
@@ -701,7 +719,7 @@ test "H3 conn: SETTINGS exchange and request/response over a mock transport" {
     client.releaseResponse(id);
 }
 
-test "H3 conn: start emits configured non-default SETTINGS" {
+test "H3 conn: start emits default SETTINGS" {
     const allocator = testing.allocator;
     var client_transport = MockTransport.init(allocator, true);
     defer client_transport.deinit();
@@ -711,12 +729,7 @@ test "H3 conn: start emits configured non-default SETTINGS" {
     server_transport.peer = &client_transport;
 
     const H3 = Conn(MockTransport);
-    var server = H3.initWithSettings(allocator, .server, .{
-        .qpack_max_table_capacity = 1024,
-        .qpack_blocked_streams = 2,
-        .max_field_section_size = 4096,
-        .enable_connect_protocol = true,
-    });
+    var server = H3.initWithSettings(allocator, .server, .{});
     defer server.deinit();
 
     try server.start(&server_transport);
@@ -726,10 +739,67 @@ test "H3 conn: start emits configured non-default SETTINGS" {
     defer control.deinit(allocator);
     try testing.expectEqual(stream.data.items.len, try control.ingest(allocator, stream.data.items));
     try testing.expect(control.saw_settings);
-    try testing.expectEqual(@as(u64, 1024), control.settings.qpack_max_table_capacity);
-    try testing.expectEqual(@as(u64, 2), control.settings.qpack_blocked_streams);
-    try testing.expectEqual(@as(?u64, 4096), control.settings.max_field_section_size);
-    try testing.expect(control.settings.enable_connect_protocol);
+    try testing.expectEqual(frame.Settings{}, control.settings);
+}
+
+test "H3 conn: start rejects unsupported qpack_max_table_capacity" {
+    const allocator = testing.allocator;
+    var server_transport = MockTransport.init(allocator, false);
+    defer server_transport.deinit();
+
+    const H3 = Conn(MockTransport);
+    var server = H3.initWithSettings(allocator, .server, .{ .qpack_max_table_capacity = 1 });
+    defer server.deinit();
+
+    try testing.expectError(error.UnsupportedH3Setting, server.start(&server_transport));
+}
+
+test "H3 conn: start rejects unsupported qpack_blocked_streams" {
+    const allocator = testing.allocator;
+    var server_transport = MockTransport.init(allocator, false);
+    defer server_transport.deinit();
+
+    const H3 = Conn(MockTransport);
+    var server = H3.initWithSettings(allocator, .server, .{ .qpack_blocked_streams = 1 });
+    defer server.deinit();
+
+    try testing.expectError(error.UnsupportedH3Setting, server.start(&server_transport));
+}
+
+test "H3 conn: start rejects unsupported enable_connect_protocol" {
+    const allocator = testing.allocator;
+    var server_transport = MockTransport.init(allocator, false);
+    defer server_transport.deinit();
+
+    const H3 = Conn(MockTransport);
+    var server = H3.initWithSettings(allocator, .server, .{ .enable_connect_protocol = true });
+    defer server.deinit();
+
+    try testing.expectError(error.UnsupportedH3Setting, server.start(&server_transport));
+}
+
+test "H3 conn: start rejects unsupported h3_datagram" {
+    const allocator = testing.allocator;
+    var server_transport = MockTransport.init(allocator, false);
+    defer server_transport.deinit();
+
+    const H3 = Conn(MockTransport);
+    var server = H3.initWithSettings(allocator, .server, .{ .h3_datagram = true });
+    defer server.deinit();
+
+    try testing.expectError(error.UnsupportedH3Setting, server.start(&server_transport));
+}
+
+test "H3 conn: start rejects unsupported max_field_section_size" {
+    const allocator = testing.allocator;
+    var server_transport = MockTransport.init(allocator, false);
+    defer server_transport.deinit();
+
+    const H3 = Conn(MockTransport);
+    var server = H3.initWithSettings(allocator, .server, .{ .max_field_section_size = 1024 });
+    defer server.deinit();
+
+    try testing.expectError(error.UnsupportedH3Setting, server.start(&server_transport));
 }
 
 test "H3 conn: early ticket snapshot uses defaults until peer SETTINGS arrive" {
@@ -748,13 +818,19 @@ test "H3 conn: early ticket snapshot uses defaults until peer SETTINGS arrive" {
     const defaults = try client.encodePeerSettingsForEarlyDataTicket(&snapshot);
     try testing.expectEqual(frame.Settings{}, try early_data.decodeSettingsSnapshot(defaults));
 
-    var server = H3.initWithSettings(allocator, .server, .{
-        .qpack_blocked_streams = 3,
-        .max_field_section_size = 8192,
-        .enable_connect_protocol = true,
-    });
-    defer server.deinit();
-    try server.start(&server_transport);
+    const control_id = try server_transport.openStream(.uni);
+    var settings_payload_buf: [64]u8 = undefined;
+    const settings_payload = try frame.encodeSettings(&.{
+        .{ .id = .qpack_blocked_streams, .id_value = 0x07, .value = 3 },
+        .{ .id = .max_field_section_size, .id_value = 0x06, .value = 8192 },
+        .{ .id = .enable_connect_protocol, .id_value = 0x08, .value = 1 },
+    }, &settings_payload_buf);
+    var control_buf: [128]u8 = undefined;
+    var control_len: usize = 0;
+    control_len += (try frame.encodeStreamType(.control, control_buf[control_len..])).len;
+    control_len += (try frame.encodeKnownFrame(.settings, settings_payload, control_buf[control_len..])).len;
+    _ = try server_transport.writeStream(control_id, control_buf[0..control_len], false);
+
     try client.pump(&client_transport);
     const remembered = try client.encodePeerSettingsForEarlyDataTicket(&snapshot);
     try testing.expectEqual(frame.Settings{

--- a/src/http3/early_data.zig
+++ b/src/http3/early_data.zig
@@ -1,0 +1,176 @@
+//! HTTP/3 0-RTT remembered SETTINGS support (RFC 9114 §7.2.4.2).
+//!
+//! TLS session tickets carry this module's opaque bytes as
+//! `early_data_application_compat`; the TLS layer keeps the blob opaque and
+//! H3 owns the directional compatibility rules.
+
+const std = @import("std");
+const frame = @import("frame.zig");
+
+pub const format_id: u16 = 0x6833; // "h3"
+pub const format_version: u16 = 1;
+
+pub const encoded_snapshot_len: usize = 25;
+const flag_max_field_section_size_present: u8 = 1 << 0;
+const flag_enable_connect_protocol: u8 = 1 << 1;
+const flag_h3_datagram: u8 = 1 << 2;
+const known_flags: u8 = flag_max_field_section_size_present |
+    flag_enable_connect_protocol |
+    flag_h3_datagram;
+
+pub const SnapshotError = error{
+    OutputTooSmall,
+    MalformedSnapshot,
+    FormatMismatch,
+};
+
+pub const Compatibility = enum {
+    compatible,
+    missing_state,
+    malformed_state,
+    settings_incompatible,
+};
+
+pub const CompatView = struct {
+    format_id: u16,
+    format_version: u16,
+    bytes: []const u8,
+};
+
+pub fn encodeSettingsSnapshot(settings: frame.Settings, out: []u8) SnapshotError![]const u8 {
+    if (out.len < encoded_snapshot_len) return error.OutputTooSmall;
+    var flags: u8 = 0;
+    if (settings.max_field_section_size != null) flags |= flag_max_field_section_size_present;
+    if (settings.enable_connect_protocol) flags |= flag_enable_connect_protocol;
+    if (settings.h3_datagram) flags |= flag_h3_datagram;
+
+    out[0] = flags;
+    std.mem.writeInt(u64, out[1..9], settings.qpack_max_table_capacity, .big);
+    std.mem.writeInt(u64, out[9..17], settings.qpack_blocked_streams, .big);
+    std.mem.writeInt(u64, out[17..25], settings.max_field_section_size orelse 0, .big);
+    return out[0..encoded_snapshot_len];
+}
+
+pub fn decodeSettingsSnapshot(bytes: []const u8) SnapshotError!frame.Settings {
+    if (bytes.len != encoded_snapshot_len) return error.MalformedSnapshot;
+    const flags = bytes[0];
+    if (flags & ~known_flags != 0) return error.MalformedSnapshot;
+    return .{
+        .qpack_max_table_capacity = std.mem.readInt(u64, bytes[1..9], .big),
+        .qpack_blocked_streams = std.mem.readInt(u64, bytes[9..17], .big),
+        .max_field_section_size = if (flags & flag_max_field_section_size_present != 0)
+            std.mem.readInt(u64, bytes[17..25], .big)
+        else
+            null,
+        .enable_connect_protocol = flags & flag_enable_connect_protocol != 0,
+        .h3_datagram = flags & flag_h3_datagram != 0,
+    };
+}
+
+pub fn decodeCompatView(view: CompatView) SnapshotError!frame.Settings {
+    if (view.format_id != format_id or view.format_version != format_version) return error.FormatMismatch;
+    return decodeSettingsSnapshot(view.bytes);
+}
+
+pub fn rememberedSettingsCompatible(remembered: frame.Settings, current: frame.Settings) bool {
+    if (current.qpack_max_table_capacity < remembered.qpack_max_table_capacity) return false;
+    if (current.qpack_blocked_streams < remembered.qpack_blocked_streams) return false;
+    if (!limitCompatible(remembered.max_field_section_size, current.max_field_section_size)) return false;
+    if (remembered.enable_connect_protocol and !current.enable_connect_protocol) return false;
+    if (remembered.h3_datagram and !current.h3_datagram) return false;
+    return true;
+}
+
+pub fn compatibility(remembered: ?CompatView, current: frame.Settings) Compatibility {
+    const view = remembered orelse return .missing_state;
+    const decoded = decodeCompatView(view) catch |err| return switch (err) {
+        error.FormatMismatch => .malformed_state,
+        error.MalformedSnapshot => .malformed_state,
+        error.OutputTooSmall => unreachable,
+    };
+    return if (rememberedSettingsCompatible(decoded, current)) .compatible else .settings_incompatible;
+}
+
+fn limitCompatible(remembered: ?u64, current: ?u64) bool {
+    if (remembered) |old| {
+        if (current) |now| return now >= old;
+        return true;
+    }
+    return current == null;
+}
+
+const testing = std.testing;
+
+test "H3 early data SETTINGS snapshot round trips defaults and non-defaults" {
+    var buf: [encoded_snapshot_len]u8 = undefined;
+    const defaults = try encodeSettingsSnapshot(.{}, &buf);
+    try testing.expectEqual(frame.Settings{}, try decodeSettingsSnapshot(defaults));
+
+    const settings: frame.Settings = .{
+        .qpack_max_table_capacity = 4096,
+        .qpack_blocked_streams = 8,
+        .max_field_section_size = 16 * 1024,
+        .enable_connect_protocol = true,
+        .h3_datagram = true,
+    };
+    const encoded = try encodeSettingsSnapshot(settings, &buf);
+    try testing.expectEqual(settings, try decodeSettingsSnapshot(encoded));
+}
+
+test "H3 early data SETTINGS snapshot rejects malformed state" {
+    var buf: [encoded_snapshot_len]u8 = undefined;
+    const encoded = try encodeSettingsSnapshot(.{}, &buf);
+    try testing.expectError(error.MalformedSnapshot, decodeSettingsSnapshot(encoded[0 .. encoded.len - 1]));
+    buf[0] = 0x80;
+    try testing.expectError(error.MalformedSnapshot, decodeSettingsSnapshot(&buf));
+    try testing.expectError(error.FormatMismatch, decodeCompatView(.{
+        .format_id = format_id + 1,
+        .format_version = format_version,
+        .bytes = encoded,
+    }));
+}
+
+test "H3 early data SETTINGS compatibility is directional" {
+    const remembered: frame.Settings = .{
+        .qpack_max_table_capacity = 32,
+        .qpack_blocked_streams = 4,
+        .max_field_section_size = 128,
+        .enable_connect_protocol = false,
+    };
+    try testing.expect(rememberedSettingsCompatible(remembered, .{
+        .qpack_max_table_capacity = 64,
+        .qpack_blocked_streams = 4,
+        .max_field_section_size = null,
+        .enable_connect_protocol = true,
+    }));
+    try testing.expect(!rememberedSettingsCompatible(remembered, .{
+        .qpack_max_table_capacity = 31,
+        .qpack_blocked_streams = 4,
+        .max_field_section_size = 128,
+    }));
+    try testing.expect(!rememberedSettingsCompatible(.{ .max_field_section_size = null }, .{ .max_field_section_size = 1024 }));
+    try testing.expect(rememberedSettingsCompatible(.{ .max_field_section_size = 1024 }, .{ .max_field_section_size = null }));
+    try testing.expect(!rememberedSettingsCompatible(.{ .enable_connect_protocol = true }, .{ .enable_connect_protocol = false }));
+    try testing.expect(rememberedSettingsCompatible(.{ .enable_connect_protocol = false }, .{ .enable_connect_protocol = true }));
+}
+
+test "H3 early data SETTINGS compatibility classifies missing and malformed remembered state" {
+    var buf: [encoded_snapshot_len]u8 = undefined;
+    const encoded = try encodeSettingsSnapshot(.{ .qpack_blocked_streams = 2 }, &buf);
+    try testing.expectEqual(Compatibility.compatible, compatibility(.{
+        .format_id = format_id,
+        .format_version = format_version,
+        .bytes = encoded,
+    }, .{ .qpack_blocked_streams = 2 }));
+    try testing.expectEqual(Compatibility.settings_incompatible, compatibility(.{
+        .format_id = format_id,
+        .format_version = format_version,
+        .bytes = encoded,
+    }, .{ .qpack_blocked_streams = 1 }));
+    try testing.expectEqual(Compatibility.missing_state, compatibility(null, .{}));
+    try testing.expectEqual(Compatibility.malformed_state, compatibility(.{
+        .format_id = format_id,
+        .format_version = format_version + 1,
+        .bytes = encoded,
+    }, .{}));
+}

--- a/src/http3/early_data.zig
+++ b/src/http3/early_data.zig
@@ -6,6 +6,7 @@
 
 const std = @import("std");
 const frame = @import("frame.zig");
+const varint = @import("quic_varint");
 
 pub const format_id: u16 = 0x6833; // "h3"
 pub const format_version: u16 = 1;
@@ -22,6 +23,7 @@ pub const SnapshotError = error{
     OutputTooSmall,
     MalformedSnapshot,
     FormatMismatch,
+    InvalidSettingsDomain,
 };
 
 pub const Compatibility = enum {
@@ -39,6 +41,7 @@ pub const CompatView = struct {
 
 pub fn encodeSettingsSnapshot(settings: frame.Settings, out: []u8) SnapshotError![]const u8 {
     if (out.len < encoded_snapshot_len) return error.OutputTooSmall;
+    if (!settingsDomainValid(settings)) return error.InvalidSettingsDomain;
     var flags: u8 = 0;
     if (settings.max_field_section_size != null) flags |= flag_max_field_section_size_present;
     if (settings.enable_connect_protocol) flags |= flag_enable_connect_protocol;
@@ -55,7 +58,7 @@ pub fn decodeSettingsSnapshot(bytes: []const u8) SnapshotError!frame.Settings {
     if (bytes.len != encoded_snapshot_len) return error.MalformedSnapshot;
     const flags = bytes[0];
     if (flags & ~known_flags != 0) return error.MalformedSnapshot;
-    return .{
+    const settings: frame.Settings = .{
         .qpack_max_table_capacity = std.mem.readInt(u64, bytes[1..9], .big),
         .qpack_blocked_streams = std.mem.readInt(u64, bytes[9..17], .big),
         .max_field_section_size = if (flags & flag_max_field_section_size_present != 0)
@@ -65,6 +68,8 @@ pub fn decodeSettingsSnapshot(bytes: []const u8) SnapshotError!frame.Settings {
         .enable_connect_protocol = flags & flag_enable_connect_protocol != 0,
         .h3_datagram = flags & flag_h3_datagram != 0,
     };
+    if (!settingsDomainValid(settings)) return error.InvalidSettingsDomain;
+    return settings;
 }
 
 pub fn decodeCompatView(view: CompatView) SnapshotError!frame.Settings {
@@ -73,7 +78,7 @@ pub fn decodeCompatView(view: CompatView) SnapshotError!frame.Settings {
 }
 
 pub fn rememberedSettingsCompatible(remembered: frame.Settings, current: frame.Settings) bool {
-    if (current.qpack_max_table_capacity < remembered.qpack_max_table_capacity) return false;
+    if (!qpackMaxTableCompatible(remembered.qpack_max_table_capacity, current.qpack_max_table_capacity)) return false;
     if (current.qpack_blocked_streams < remembered.qpack_blocked_streams) return false;
     if (!limitCompatible(remembered.max_field_section_size, current.max_field_section_size)) return false;
     if (remembered.enable_connect_protocol and !current.enable_connect_protocol) return false;
@@ -86,9 +91,24 @@ pub fn compatibility(remembered: ?CompatView, current: frame.Settings) Compatibi
     const decoded = decodeCompatView(view) catch |err| return switch (err) {
         error.FormatMismatch => .malformed_state,
         error.MalformedSnapshot => .malformed_state,
+        error.InvalidSettingsDomain => .malformed_state,
         error.OutputTooSmall => unreachable,
     };
     return if (rememberedSettingsCompatible(decoded, current)) .compatible else .settings_incompatible;
+}
+
+pub fn settingsDomainValid(settings: frame.Settings) bool {
+    if (settings.qpack_max_table_capacity > varint.max_value) return false;
+    if (settings.qpack_blocked_streams > varint.max_value) return false;
+    if (settings.max_field_section_size) |v| {
+        if (v > varint.max_value) return false;
+    }
+    return true;
+}
+
+fn qpackMaxTableCompatible(remembered: u64, current: u64) bool {
+    if (remembered == 0) return true;
+    return current == remembered;
 }
 
 fn limitCompatible(remembered: ?u64, current: ?u64) bool {
@@ -138,20 +158,56 @@ test "H3 early data SETTINGS compatibility is directional" {
         .enable_connect_protocol = false,
     };
     try testing.expect(rememberedSettingsCompatible(remembered, .{
-        .qpack_max_table_capacity = 64,
+        .qpack_max_table_capacity = 32,
         .qpack_blocked_streams = 4,
         .max_field_section_size = null,
         .enable_connect_protocol = true,
     }));
     try testing.expect(!rememberedSettingsCompatible(remembered, .{
-        .qpack_max_table_capacity = 31,
+        .qpack_max_table_capacity = 32,
         .qpack_blocked_streams = 4,
-        .max_field_section_size = 128,
+        .max_field_section_size = 127,
     }));
     try testing.expect(!rememberedSettingsCompatible(.{ .max_field_section_size = null }, .{ .max_field_section_size = 1024 }));
     try testing.expect(rememberedSettingsCompatible(.{ .max_field_section_size = 1024 }, .{ .max_field_section_size = null }));
     try testing.expect(!rememberedSettingsCompatible(.{ .enable_connect_protocol = true }, .{ .enable_connect_protocol = false }));
     try testing.expect(rememberedSettingsCompatible(.{ .enable_connect_protocol = false }, .{ .enable_connect_protocol = true }));
+}
+
+test "H3 early data SETTINGS snapshot validates QUIC varint domains" {
+    var buf: [encoded_snapshot_len]u8 = undefined;
+    _ = try encodeSettingsSnapshot(.{
+        .qpack_max_table_capacity = varint.max_value,
+        .qpack_blocked_streams = varint.max_value,
+        .max_field_section_size = varint.max_value,
+    }, &buf);
+    try testing.expectError(error.InvalidSettingsDomain, encodeSettingsSnapshot(.{
+        .qpack_max_table_capacity = varint.max_value + 1,
+    }, &buf));
+    try testing.expectError(error.InvalidSettingsDomain, encodeSettingsSnapshot(.{
+        .qpack_blocked_streams = varint.max_value + 1,
+    }, &buf));
+    try testing.expectError(error.InvalidSettingsDomain, encodeSettingsSnapshot(.{
+        .max_field_section_size = varint.max_value + 1,
+    }, &buf));
+
+    std.mem.writeInt(u64, buf[1..9], varint.max_value + 1, .big);
+    try testing.expectError(error.InvalidSettingsDomain, decodeSettingsSnapshot(&buf));
+    std.mem.writeInt(u64, buf[1..9], 0, .big);
+    std.mem.writeInt(u64, buf[9..17], varint.max_value + 1, .big);
+    try testing.expectError(error.InvalidSettingsDomain, decodeSettingsSnapshot(&buf));
+    std.mem.writeInt(u64, buf[9..17], 0, .big);
+    buf[0] = flag_max_field_section_size_present;
+    std.mem.writeInt(u64, buf[17..25], varint.max_value + 1, .big);
+    try testing.expectError(error.InvalidSettingsDomain, decodeSettingsSnapshot(&buf));
+}
+
+test "H3 early data QPACK max table follows RFC 9204 0-RTT rule" {
+    try testing.expect(rememberedSettingsCompatible(.{ .qpack_max_table_capacity = 0 }, .{ .qpack_max_table_capacity = 0 }));
+    try testing.expect(rememberedSettingsCompatible(.{ .qpack_max_table_capacity = 0 }, .{ .qpack_max_table_capacity = 4096 }));
+    try testing.expect(rememberedSettingsCompatible(.{ .qpack_max_table_capacity = 4096 }, .{ .qpack_max_table_capacity = 4096 }));
+    try testing.expect(!rememberedSettingsCompatible(.{ .qpack_max_table_capacity = 4096 }, .{ .qpack_max_table_capacity = 2048 }));
+    try testing.expect(!rememberedSettingsCompatible(.{ .qpack_max_table_capacity = 4096 }, .{ .qpack_max_table_capacity = 8192 }));
 }
 
 test "H3 early data SETTINGS compatibility classifies missing and malformed remembered state" {

--- a/src/http3/frame.zig
+++ b/src/http3/frame.zig
@@ -180,6 +180,18 @@ pub const Settings = struct {
     h3_datagram: bool = false,
 };
 
+pub const LocalSettingsValidationError = error{UnsupportedH3Setting};
+
+/// Fail closed for features this static/basic H3 path cannot honor yet.
+pub fn validateLocallySupportedSettings(settings: Settings) LocalSettingsValidationError!void {
+    if (settings.qpack_max_table_capacity != 0) return error.UnsupportedH3Setting;
+    if (settings.qpack_blocked_streams != 0) return error.UnsupportedH3Setting;
+    if (settings.enable_connect_protocol) return error.UnsupportedH3Setting;
+    if (settings.h3_datagram) return error.UnsupportedH3Setting;
+    // Current request/session path does not enforce this bound yet.
+    if (settings.max_field_section_size != null) return error.UnsupportedH3Setting;
+}
+
 pub fn encodeSettings(settings: []const Setting, out: []u8) EncodeError![]u8 {
     var pos: usize = 0;
     for (settings) |setting| {

--- a/src/http3/root.zig
+++ b/src/http3/root.zig
@@ -10,6 +10,7 @@ pub const session = @import("session.zig");
 pub const conn = @import("conn.zig");
 pub const qlog = @import("qlog.zig");
 pub const priority = @import("priority.zig");
+pub const early_data = @import("early_data.zig");
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -88,6 +88,10 @@ pub const error_key_update: u64 = 0x0e;
 /// CRYPTO_ERROR base (0x0100–0x01ff carries the TLS alert).
 pub const error_crypto_base: u64 = 0x0100;
 
+const h3_early_data_format_id: u16 = 0x6833;
+const h3_early_data_format_version: u16 = 1;
+const h3_default_settings_snapshot = [_]u8{0} ** 25;
+
 pub const IngestError = error{OutOfMemory};
 
 pub const Event = union(enum) {
@@ -682,6 +686,14 @@ pub const Connection = struct {
         conn.handshake.manual_key_discard = true;
         conn.handshake.allow_unverified_certificate = options.allow_unverified_certificate;
         if (options.role == .client) {
+            options.tls.setEarlyDataApplicationCompat(.{
+                .format_id = h3_early_data_format_id,
+                .format_version = h3_early_data_format_version,
+                .bytes = &h3_default_settings_snapshot,
+            }) catch |err| {
+                conn.failHandshake(err);
+                return conn;
+            };
             options.tls.setPostHandshakeAllocator(allocator) catch |err| {
                 conn.failHandshake(err);
                 return conn;

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -1418,6 +1418,15 @@ pub const Connection = struct {
         try self.tls.setServerPskResolver(resolver);
     }
 
+    /// #367: update the application snapshot that will be stamped into
+    /// subsequently issued early-capable NewSessionTickets.
+    pub fn setEarlyDataApplicationCompat(
+        self: *Connection,
+        blob: ?tls_core.new_session_ticket.CompatBlob,
+    ) tls_handshake.HandshakeError!void {
+        try self.tls.setEarlyDataApplicationCompat(blob);
+    }
+
     /// #488 two-phase issuance, step 1 (QUIC): derives the RMS-bound PSK and
     /// the exact `ServerRecoverableState` a stateful insertion or stateless
     /// seal will consume. See `tls_core.tls13_backend.Tls13Backend.prepareNewSessionTicket`.

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -360,6 +360,10 @@ pub const Tls13Backend = struct {
         self.engine.setApplicationCompat(blob) catch |err| return mapError(err);
     }
 
+    pub fn setEarlyDataApplicationCompat(self: *Tls13Backend, blob: ?tls_core.new_session_ticket.CompatBlob) HandshakeError!void {
+        self.engine.setEarlyDataApplicationCompat(blob) catch |err| return mapError(err);
+    }
+
     pub fn setEarlyDataCompatibilityGate(self: *Tls13Backend, gate: EarlyDataCompatibilityGate) HandshakeError!void {
         self.engine.setEarlyDataCompatibilityGate(gate) catch |err| return mapError(err);
     }

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -277,6 +277,7 @@ pub const Tls13Backend = struct {
             .setCidBindingFn = setCidBinding,
             .peerCidBindingFn = peerCidBinding,
             .setPostHandshakeAllocatorFn = setPostHandshakeAllocator,
+            .setEarlyDataApplicationCompatFn = setEarlyDataApplicationCompatVtable,
             .emitNewSessionTicketFn = emitNewSessionTicket,
             .setServerPskResolverFn = setServerPskResolverVtable,
             .prepareNewSessionTicketFn = prepareNewSessionTicket,
@@ -362,6 +363,11 @@ pub const Tls13Backend = struct {
 
     pub fn setEarlyDataApplicationCompat(self: *Tls13Backend, blob: ?tls_core.new_session_ticket.CompatBlob) HandshakeError!void {
         self.engine.setEarlyDataApplicationCompat(blob) catch |err| return mapError(err);
+    }
+
+    fn setEarlyDataApplicationCompatVtable(ptr: *anyopaque, blob: ?tls_core.new_session_ticket.CompatBlob) HandshakeError!void {
+        const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
+        try self.setEarlyDataApplicationCompat(blob);
     }
 
     pub fn setEarlyDataCompatibilityGate(self: *Tls13Backend, gate: EarlyDataCompatibilityGate) HandshakeError!void {

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -28,6 +28,9 @@ pub const hash_len = shared.hash_len;
 pub const max_message_len = shared.max_message_len;
 pub const max_certificate_len = shared.max_certificate_len;
 pub const testdata = shared.testdata;
+pub const EarlyDataCompatibilityCandidate = shared.EarlyDataCompatibilityCandidate;
+pub const EarlyDataCompatibilityDecision = shared.EarlyDataCompatibilityDecision;
+pub const EarlyDataCompatibilityGate = shared.EarlyDataCompatibilityGate;
 
 const ext_quic_transport_parameters: u16 = @intFromEnum(tls_core.algorithms.ExtensionType.quic_transport_parameters);
 const tp_max_idle_timeout: u64 = 0x01;
@@ -351,6 +354,14 @@ pub const Tls13Backend = struct {
 
     pub fn setResumeCompatibilityPolicy(self: *Tls13Backend, policy: shared.Tls13Backend.ResumeCompatibilityPolicy) HandshakeError!void {
         self.engine.setResumeCompatibilityPolicy(policy) catch |err| return mapError(err);
+    }
+
+    pub fn setApplicationCompat(self: *Tls13Backend, blob: ?tls_core.new_session_ticket.CompatBlob) HandshakeError!void {
+        self.engine.setApplicationCompat(blob) catch |err| return mapError(err);
+    }
+
+    pub fn setEarlyDataCompatibilityGate(self: *Tls13Backend, gate: EarlyDataCompatibilityGate) HandshakeError!void {
+        self.engine.setEarlyDataCompatibilityGate(gate) catch |err| return mapError(err);
     }
 
     pub fn setResumptionDecisionObserver(self: *Tls13Backend, observer: shared.Tls13Backend.ResumptionDecisionObserver) HandshakeError!void {

--- a/src/quic/tls_handshake.zig
+++ b/src/quic/tls_handshake.zig
@@ -127,7 +127,7 @@ pub const TlsBackend = struct {
     }
 
     pub fn setEarlyDataApplicationCompat(self: TlsBackend, blob: ?tls_core.new_session_ticket.CompatBlob) HandshakeError!void {
-        const set = self.setEarlyDataApplicationCompatFn orelse return error.InvalidHandshakeState;
+        const set = self.setEarlyDataApplicationCompatFn orelse return;
         try set(self.transport.ptr, blob);
     }
 

--- a/src/quic/tls_handshake.zig
+++ b/src/quic/tls_handshake.zig
@@ -72,6 +72,10 @@ pub const TlsBackend = struct {
     setCidBindingFn: ?*const fn (ptr: *anyopaque, binding: config.CidBinding) void = null,
     peerCidBindingFn: ?*const fn (ptr: *anyopaque) config.CidBinding = null,
     setPostHandshakeAllocatorFn: ?*const fn (ptr: *anyopaque, allocator: std.mem.Allocator) HandshakeError!void = null,
+    setEarlyDataApplicationCompatFn: ?*const fn (
+        ptr: *anyopaque,
+        blob: ?tls_core.new_session_ticket.CompatBlob,
+    ) HandshakeError!void = null,
     emitNewSessionTicketFn: ?*const fn (
         ptr: *anyopaque,
         allocator: std.mem.Allocator,
@@ -120,6 +124,11 @@ pub const TlsBackend = struct {
 
     pub fn setPostHandshakeAllocator(self: TlsBackend, allocator: std.mem.Allocator) HandshakeError!void {
         if (self.setPostHandshakeAllocatorFn) |set| try set(self.transport.ptr, allocator);
+    }
+
+    pub fn setEarlyDataApplicationCompat(self: TlsBackend, blob: ?tls_core.new_session_ticket.CompatBlob) HandshakeError!void {
+        const set = self.setEarlyDataApplicationCompatFn orelse return error.InvalidHandshakeState;
+        try set(self.transport.ptr, blob);
     }
 
     pub fn emitNewSessionTicket(

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -419,6 +419,8 @@ pub const EarlyDataCompatibilityGate = struct {
     }
 };
 
+const max_early_application_compat_len = session.Limits.default.max_application_compat_len;
+
 const ExtensionGuard = struct {
     pub const max_extensions = 64;
 
@@ -644,6 +646,14 @@ pub const Tls13Backend = struct {
     application_compat_bytes: [session.hard_max_compat_len]u8 = undefined,
     application_compat_len: usize = 0,
     application_compat_present: bool = false,
+    /// #367: application compatibility snapshot used only for early-capable
+    /// tickets. HTTP/3 updates this across the NST lifecycle independently of
+    /// ordinary 1-RTT resumption's `application_compat`.
+    early_application_compat_format_id: u16 = 0,
+    early_application_compat_format_version: u16 = 0,
+    early_application_compat_bytes: [max_early_application_compat_len]u8 = undefined,
+    early_application_compat_len: usize = 0,
+    early_application_compat_present: bool = false,
     /// #362: the most recent successful PSK selection's ticket-age skew
     /// observation (apparent vs. actual elapsed time since issuance), taken
     /// exactly once by `takePskAgeSkew`. Informational only — skew alone
@@ -1103,6 +1113,38 @@ pub const Tls13Backend = struct {
         };
     }
 
+    /// #367: configure the application snapshot stamped only into
+    /// early-capable tickets. Unlike `setApplicationCompat`, this may be
+    /// called after handshake completion so an H3 client can seed RFC default
+    /// SETTINGS before `start()` and update to decoded peer SETTINGS before
+    /// later NewSessionTickets arrive.
+    pub fn setEarlyDataApplicationCompat(self: *Tls13Backend, blob: ?new_session_ticket.CompatBlob) HandshakeError!void {
+        switch (self.core.handshake_lifecycle) {
+            .idle, .complete => {},
+            .running, .failed => return error.InvalidHandshakeState,
+        }
+        if (blob) |b| {
+            if (b.bytes.len > self.early_application_compat_bytes.len) return error.TransportBufferOverflow;
+            self.early_application_compat_format_id = b.format_id;
+            self.early_application_compat_format_version = b.format_version;
+            @memcpy(self.early_application_compat_bytes[0..b.bytes.len], b.bytes);
+            self.early_application_compat_len = b.bytes.len;
+            self.early_application_compat_present = true;
+        } else {
+            self.early_application_compat_present = false;
+            self.early_application_compat_len = 0;
+        }
+    }
+
+    pub fn ownedEarlyDataApplicationCompat(self: *const Tls13Backend) ?new_session_ticket.CompatBlob {
+        if (!self.early_application_compat_present) return null;
+        return .{
+            .format_id = self.early_application_compat_format_id,
+            .format_version = self.early_application_compat_format_version,
+            .bytes = self.early_application_compat_bytes[0..self.early_application_compat_len],
+        };
+    }
+
     /// #362: takes (clears) the most recent successful PSK selection's
     /// ticket-age skew observation, if any — a one-shot accessor for #366.
     pub fn takePskAgeSkew(self: *Tls13Backend) ?pre_shared_key.AgeSkew {
@@ -1281,6 +1323,9 @@ pub const Tls13Backend = struct {
         crypto.secureZero(u8, &self.application_compat_bytes);
         self.application_compat_present = false;
         self.application_compat_len = 0;
+        crypto.secureZero(u8, &self.early_application_compat_bytes);
+        self.early_application_compat_present = false;
+        self.early_application_compat_len = 0;
         self.last_psk_age_skew = null;
         self.client_early_data_intent = .{};
         self.client_early_data_attempted = false;
@@ -3833,7 +3878,7 @@ pub const Tls13Backend = struct {
                 .client => self.peerTransportCompat(),
                 .server => self.localTransportCompat(),
             };
-            ctx.early_data_application_compat = self.ownedApplicationCompat();
+            ctx.early_data_application_compat = self.ownedEarlyDataApplicationCompat();
         }
         return ctx;
     }

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -1055,6 +1055,18 @@ pub const Tls13Backend = struct {
         return self.early_data_max_bytes;
     }
 
+    /// Client (#367): the remembered application-level compatibility state
+    /// carried by the same first surviving ticket that produced
+    /// `earlyDataAttempted()` / `earlyDataMaxBytes()`. HTTP/3 uses this
+    /// before EncryptedExtensions to decide which remembered SETTINGS govern
+    /// client-side 0-RTT; `null` means RFC defaults.
+    pub fn clientEarlyDataApplicationCompat(self: *const Tls13Backend) ?CompatView {
+        if (self.role != .client or !self.client_early_data_attempted) return null;
+        const offers = self.constClientPskOffers();
+        if (offers.isEmpty()) return null;
+        return compatView(offers.constSlice()[0].common.early_data_application_compat);
+    }
+
     /// #362/#365: configure this connection's application-layer
     /// compatibility snapshot (e.g. HTTP/3 settings), compared against a
     /// candidate PSK's stored value on the server and used to recheck an
@@ -3821,6 +3833,7 @@ pub const Tls13Backend = struct {
                 .client => self.peerTransportCompat(),
                 .server => self.localTransportCompat(),
             };
+            ctx.early_data_application_compat = self.ownedApplicationCompat();
         }
         return ctx;
     }

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -960,6 +960,127 @@ fn earlyDataSkewedClientClock(_: *anyopaque) i64 {
     return 6000;
 }
 
+test "early-capable tickets stamp early application compatibility snapshot" {
+    var harness = DirectHarness.init();
+    defer harness.deinit();
+    const app_snapshot = "h3-settings-snapshot";
+    try harness.server_backend.setApplicationCompat(.{
+        .format_id = 0x6833,
+        .format_version = 1,
+        .bytes = app_snapshot,
+    });
+    try harness.client_backend.setApplicationCompat(.{
+        .format_id = 0x6833,
+        .format_version = 1,
+        .bytes = app_snapshot,
+    });
+
+    const TicketCapture = struct {
+        ticket: session.ClientTicketState = .{},
+        fn now(_: *anyopaque) i64 {
+            return 1000;
+        }
+        fn onTicket(ctx: *anyopaque, ticket: *const session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            ticket.cloneInto(std.testing.allocator, &self.ticket) catch unreachable;
+        }
+    };
+    var capture = TicketCapture{};
+    defer capture.ticket.deinit();
+    const limits = session.Limits.default;
+    try harness.client_backend.setSessionTicketConsumer(std.testing.allocator, limits, .{
+        .ctx = &capture,
+        .nowUnixMsFn = TicketCapture.now,
+        .onTicketFn = TicketCapture.onTicket,
+    });
+    try harness.run();
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    var server_state = try harness.server_backend.emitNewSessionTicket(std.testing.allocator, &sink, .{
+        .ticket_lifetime = 3600,
+        .ticket_age_add = 500,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = "early-app-compat-ticket",
+        .max_early_data_size = 32,
+        .issued_at_unix_ms = 1000,
+    }, limits);
+    defer server_state.deinit();
+    try std.testing.expectEqualStrings(app_snapshot, server_state.common.early_data_application_compat.?.slice());
+    try std.testing.expectEqual(@as(u16, 0x6833), server_state.common.early_data_application_compat.?.format_id);
+
+    const ticket_event = sink.items[0].handshake_bytes;
+    var protected: [record_codec.max_ciphertext_record_len * 2]u8 = undefined;
+    const records = (try harness.server_bridge.applyEvent(.{ .handshake_bytes = .{
+        .epoch = ticket_event.epoch,
+        .data = ticket_event.data,
+    } }, &protected)).?;
+    var parser = record_codec.Parser.init(.ciphertext);
+    var record_sink = record_codec.RecordSink(8, record_codec.max_ciphertext_fragment_len * 8){};
+    try parser.feed(records, &record_sink);
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    for (record_sink.items[0..record_sink.len]) |record| {
+        const opened = try harness.client_bridge.openHandshake(.application, record, &plaintext);
+        _ = try harness.client_driver.receive(.application, opened.inner.content);
+    }
+    try std.testing.expectEqualStrings(app_snapshot, capture.ticket.common.early_data_application_compat.?.slice());
+    try std.testing.expectEqual(@as(u16, 1), capture.ticket.common.early_data_application_compat.?.format_version);
+}
+
+test "client early application compat follows the planned identity-0 early attempt" {
+    var client = tls_backend.Tls13Backend.initClient(
+        clientEntropy(),
+        .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+        .record,
+    );
+    defer client.deinit();
+
+    const psk = [_]u8{0x42} ** tls_backend.hash_len;
+    var common: session.ResumableSessionCommon = .{};
+    try common.init(std.testing.allocator, session.Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = &psk,
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer(""),
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 3600,
+        .early_data = .{ .early_data_capable = 64 },
+        .early_data_application_compat = .{
+            .format_id = 0x6833,
+            .format_version = 1,
+            .bytes = "remembered-h3-settings",
+        },
+    });
+    defer common.deinit();
+    var ticket: session.ClientTicketState = .{};
+    try ticket.init(std.testing.allocator, session.Limits.default, &common, .{
+        .ticket = "identity-0",
+        .ticket_age_add = 0,
+        .ticket_nonce = "n",
+        .received_at_unix_ms = 0,
+    });
+    defer ticket.deinit();
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&ticket);
+    var clock_dummy: u8 = 0;
+    const Clock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 0;
+        }
+    };
+    try client.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+    try client.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 16 });
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try client.backend().start(.client, {}, &sink);
+    try std.testing.expect(client.earlyDataAttempted());
+    try std.testing.expectEqual(@as(u32, 16), client.earlyDataMaxBytes());
+    const remembered = client.clientEarlyDataApplicationCompat() orelse return error.TestExpectedEqual;
+    try std.testing.expectEqual(@as(u16, 0x6833), remembered.format_id);
+    try std.testing.expectEqual(@as(u16, 1), remembered.format_version);
+    try std.testing.expectEqualStrings("remembered-h3-settings", remembered.bytes);
+}
+
 test "0-RTT is rejected for a ticket-age skew outside the configured tolerance" {
     var issued = try issueEarlyCapableTicket(32);
     defer issued.deinit();

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -752,6 +752,49 @@ fn earlyDataResumedClientClock(_: *anyopaque) i64 {
     return 2000;
 }
 
+fn deliverApplicationTicket(harness: *DirectHarness, handshake_bytes: []const u8) !void {
+    var protected: [record_codec.max_ciphertext_record_len * 2]u8 = undefined;
+    const records = (try harness.server_bridge.applyEvent(.{ .handshake_bytes = .{
+        .epoch = .application,
+        .data = handshake_bytes,
+    } }, &protected)).?;
+    var parser = record_codec.Parser.init(.ciphertext);
+    var record_sink = record_codec.RecordSink(8, record_codec.max_ciphertext_fragment_len * 8){};
+    try parser.feed(records, &record_sink);
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    for (record_sink.items[0..record_sink.len]) |record| {
+        const opened = try harness.client_bridge.openHandshake(.application, record, &plaintext);
+        _ = try harness.client_driver.receive(.application, opened.inner.content);
+    }
+}
+
+fn replaceEarlyApplicationCompat(common: *session.ResumableSessionCommon, bytes: []const u8) !void {
+    if (common.early_data_application_compat) |*existing| existing.deinit();
+    common.early_data_application_compat = null;
+    var snap: session.CompatSnapshot = .{};
+    try snap.init(std.testing.allocator, 0x6833, 1, bytes, session.Limits.default.max_application_compat_len);
+    common.early_data_application_compat = snap;
+    snap = .{};
+}
+
+const AllowReplayGate = struct {
+    fn decide(_: *anyopaque, _: tls_backend.EarlyDataReplayCandidate) tls_backend.EarlyDataReplayDecision {
+        return .allow;
+    }
+};
+
+const H3ApplicationCompatGate = struct {
+    compatible_bytes: []const u8,
+
+    fn decide(ctx: *anyopaque, candidate: tls_backend.EarlyDataCompatibilityCandidate) tls_backend.EarlyDataCompatibilityDecision {
+        const self: *@This() = @ptrCast(@alignCast(ctx));
+        const app = candidate.remembered_application orelse return .application_incompatible;
+        if (app.format_id != 0x6833 or app.format_version != 1) return .application_incompatible;
+        if (!std.mem.eql(u8, app.bytes, self.compatible_bytes)) return .application_incompatible;
+        return .compatible;
+    }
+};
+
 test "0-RTT round trip: an early-capable ticket, matching policy, and an allowing replay gate is accepted by both sides" {
     var issued = try issueEarlyCapableTicket(32);
     defer issued.deinit();
@@ -960,16 +1003,95 @@ fn earlyDataSkewedClientClock(_: *anyopaque) i64 {
     return 6000;
 }
 
+test "H3 application incompatibility rejects only 0-RTT while PSK resumption succeeds" {
+    var issued = try issueEarlyCapableTicket(32);
+    defer issued.deinit();
+    try replaceEarlyApplicationCompat(&issued.ticket.common, "malformed-h3-settings");
+    try replaceEarlyApplicationCompat(&issued.server_state.common, "malformed-h3-settings");
+
+    var resumed = DirectHarness.init();
+    defer resumed.deinit();
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&issued.ticket);
+    var clock_dummy: u8 = 0;
+    try resumed.client_backend.setClientPskOffers(&offers, &clock_dummy, earlyDataResumedClientClock);
+    var resolver_state = IdentityResolver{ .state = &issued.server_state };
+    try resumed.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = IdentityResolver.now,
+        .resolveFn = IdentityResolver.resolve,
+    });
+    try resumed.client_backend.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 16_384 });
+    try resumed.server_backend.setServerEarlyDataPolicy(.{ .enabled = true, .age_skew_tolerance_ms = 60_000 });
+    var replay_ctx: u8 = 0;
+    try resumed.server_backend.setEarlyDataReplayGate(.{ .ctx = &replay_ctx, .decideFn = AllowReplayGate.decide });
+    var compat_gate = H3ApplicationCompatGate{ .compatible_bytes = "compatible-h3-settings" };
+    try resumed.server_backend.setEarlyDataCompatibilityGate(.{ .ctx = &compat_gate, .decideFn = H3ApplicationCompatGate.decide });
+
+    try resumed.run();
+
+    try std.testing.expect(resumed.client_backend.core.psk_authenticated);
+    try std.testing.expect(resumed.server_backend.core.psk_authenticated);
+    try std.testing.expect(resumed.client_backend.earlyDataAttempted());
+    try std.testing.expect(!resumed.server_backend.earlyDataAccepted());
+    try std.testing.expectEqual(tls_backend.EarlyDataDecision.application_incompatible, resumed.server_backend.earlyDataDecision());
+}
+
+test "H3 application compatibility allows 0-RTT when replay gate allows" {
+    var issued = try issueEarlyCapableTicket(32);
+    defer issued.deinit();
+    try replaceEarlyApplicationCompat(&issued.ticket.common, "compatible-h3-settings");
+    try replaceEarlyApplicationCompat(&issued.server_state.common, "compatible-h3-settings");
+
+    var resumed = DirectHarness.init();
+    defer resumed.deinit();
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&issued.ticket);
+    var clock_dummy: u8 = 0;
+    try resumed.client_backend.setClientPskOffers(&offers, &clock_dummy, earlyDataResumedClientClock);
+    var resolver_state = IdentityResolver{ .state = &issued.server_state };
+    try resumed.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = IdentityResolver.now,
+        .resolveFn = IdentityResolver.resolve,
+    });
+    try resumed.client_backend.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 16_384 });
+    try resumed.server_backend.setServerEarlyDataPolicy(.{ .enabled = true, .age_skew_tolerance_ms = 60_000 });
+    var replay_ctx: u8 = 0;
+    try resumed.server_backend.setEarlyDataReplayGate(.{ .ctx = &replay_ctx, .decideFn = AllowReplayGate.decide });
+    var compat_gate = H3ApplicationCompatGate{ .compatible_bytes = "compatible-h3-settings" };
+    try resumed.server_backend.setEarlyDataCompatibilityGate(.{ .ctx = &compat_gate, .decideFn = H3ApplicationCompatGate.decide });
+
+    try resumed.run();
+
+    try std.testing.expect(resumed.client_backend.core.psk_authenticated);
+    try std.testing.expect(resumed.server_backend.core.psk_authenticated);
+    try std.testing.expect(resumed.client_backend.earlyDataAttempted());
+    try std.testing.expect(resumed.server_backend.earlyDataAccepted());
+    try std.testing.expectEqual(tls_backend.EarlyDataDecision.accepted, resumed.server_backend.earlyDataDecision());
+    try std.testing.expectEqual(@as(u32, 32), resumed.server_backend.earlyDataMaxBytes());
+}
+
 test "early-capable tickets stamp early application compatibility snapshot" {
     var harness = DirectHarness.init();
     defer harness.deinit();
     const app_snapshot = "h3-settings-snapshot";
     try harness.server_backend.setApplicationCompat(.{
+        .format_id = 9,
+        .format_version = 1,
+        .bytes = "ordinary-application-compat",
+    });
+    try harness.client_backend.setApplicationCompat(.{
+        .format_id = 9,
+        .format_version = 1,
+        .bytes = "ordinary-application-compat",
+    });
+    try harness.server_backend.setEarlyDataApplicationCompat(.{
         .format_id = 0x6833,
         .format_version = 1,
         .bytes = app_snapshot,
     });
-    try harness.client_backend.setApplicationCompat(.{
+    try harness.client_backend.setEarlyDataApplicationCompat(.{
         .format_id = 0x6833,
         .format_version = 1,
         .bytes = app_snapshot,
@@ -1008,6 +1130,7 @@ test "early-capable tickets stamp early application compatibility snapshot" {
     defer server_state.deinit();
     try std.testing.expectEqualStrings(app_snapshot, server_state.common.early_data_application_compat.?.slice());
     try std.testing.expectEqual(@as(u16, 0x6833), server_state.common.early_data_application_compat.?.format_id);
+    try std.testing.expectEqualStrings("ordinary-application-compat", server_state.common.application_compat.?.slice());
 
     const ticket_event = sink.items[0].handshake_bytes;
     var protected: [record_codec.max_ciphertext_record_len * 2]u8 = undefined;
@@ -1025,6 +1148,78 @@ test "early-capable tickets stamp early application compatibility snapshot" {
     }
     try std.testing.expectEqualStrings(app_snapshot, capture.ticket.common.early_data_application_compat.?.slice());
     try std.testing.expectEqual(@as(u16, 1), capture.ticket.common.early_data_application_compat.?.format_version);
+}
+
+test "early application compat can update after handshake for later NSTs only" {
+    var harness = DirectHarness.init();
+    defer harness.deinit();
+    const defaults = "default-h3-settings";
+    const decoded_settings = "decoded-peer-h3-settings";
+    try harness.client_backend.setEarlyDataApplicationCompat(.{
+        .format_id = 0x6833,
+        .format_version = 1,
+        .bytes = defaults,
+    });
+
+    const TicketCapture = struct {
+        tickets: [2]session.ClientTicketState = .{ .{}, .{} },
+        count: usize = 0,
+        fn now(_: *anyopaque) i64 {
+            return 1000;
+        }
+        fn onTicket(ctx: *anyopaque, ticket: *const session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            if (self.count >= self.tickets.len) unreachable;
+            ticket.cloneInto(std.testing.allocator, &self.tickets[self.count]) catch unreachable;
+            self.count += 1;
+        }
+    };
+    var capture = TicketCapture{};
+    defer {
+        for (&capture.tickets) |*ticket| ticket.deinit();
+    }
+    const limits = session.Limits.default;
+    try harness.client_backend.setSessionTicketConsumer(std.testing.allocator, limits, .{
+        .ctx = &capture,
+        .nowUnixMsFn = TicketCapture.now,
+        .onTicketFn = TicketCapture.onTicket,
+    });
+    try harness.run();
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    var first_state = try harness.server_backend.emitNewSessionTicket(std.testing.allocator, &sink, .{
+        .ticket_lifetime = 3600,
+        .ticket_age_add = 500,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = "first-ticket",
+        .max_early_data_size = 32,
+        .issued_at_unix_ms = 1000,
+    }, limits);
+    defer first_state.deinit();
+    try deliverApplicationTicket(&harness, sink.items[0].handshake_bytes.data);
+    try std.testing.expectEqual(@as(usize, 1), capture.count);
+    try std.testing.expectEqualStrings(defaults, capture.tickets[0].common.early_data_application_compat.?.slice());
+
+    try harness.client_backend.setEarlyDataApplicationCompat(.{
+        .format_id = 0x6833,
+        .format_version = 1,
+        .bytes = decoded_settings,
+    });
+    sink.reset();
+    var second_state = try harness.server_backend.emitNewSessionTicket(std.testing.allocator, &sink, .{
+        .ticket_lifetime = 3600,
+        .ticket_age_add = 501,
+        .ticket_nonce = "\x02",
+        .opaque_ticket = "second-ticket",
+        .max_early_data_size = 32,
+        .issued_at_unix_ms = 1000,
+    }, limits);
+    defer second_state.deinit();
+    try deliverApplicationTicket(&harness, sink.items[0].handshake_bytes.data);
+    try std.testing.expectEqual(@as(usize, 2), capture.count);
+    try std.testing.expectEqualStrings(defaults, capture.tickets[0].common.early_data_application_compat.?.slice());
+    try std.testing.expectEqualStrings(decoded_settings, capture.tickets[1].common.early_data_application_compat.?.slice());
 }
 
 test "client early application compat follows the planned identity-0 early attempt" {

--- a/tests/quic_h3_e2e.zig
+++ b/tests/quic_h3_e2e.zig
@@ -553,6 +553,143 @@ fn runH3Exchange(sim: *Sim) !void {
     try testing.expect(sim.network.max_observed_bytes <= sim.limits.max_queued_bytes);
 }
 
+test "#367 slice3: client ticket snapshots move from defaults to decoded peer SETTINGS without mutating earlier ticket" {
+    const allocator = testing.allocator;
+
+    const Capture = struct {
+        tickets: [2]tls_core.session.ClientTicketState = .{ .{}, .{} },
+        count: usize = 0,
+
+        fn deinit(self: *@This()) void {
+            for (&self.tickets) |*ticket| ticket.deinit();
+        }
+
+        fn now(_: *anyopaque) i64 {
+            return 2_000;
+        }
+
+        fn onTicket(ctx: *anyopaque, ticket: *const tls_core.session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            if (self.count >= self.tickets.len) return;
+            self.tickets[self.count].deinit();
+            self.tickets[self.count] = .{};
+            ticket.cloneInto(testing.allocator, &self.tickets[self.count]) catch unreachable;
+            self.count += 1;
+        }
+    };
+
+    const issueEarlyCapableTicket = struct {
+        fn issue(sim: *Sim, nonce: u8, ticket_id: u8, issued_at_unix_ms: i64) !void {
+            var opaque_ticket = [1]u8{ticket_id};
+            var ticket_state = try sim.server.emitNewSessionTicket(.{
+                .ticket_lifetime = 3600,
+                .ticket_age_add = 100 + ticket_id,
+                .ticket_nonce = &[_]u8{nonce},
+                .opaque_ticket = &opaque_ticket,
+                .max_early_data_size = 4096,
+                .issued_at_unix_ms = issued_at_unix_ms,
+            }, tls_core.session.Limits.default);
+            defer ticket_state.deinit();
+        }
+    }.issue;
+
+    var capture = Capture{};
+    defer capture.deinit();
+
+    var sim = try Sim.init(allocator, .{
+        .scenario = "slice3-remembered-settings-lifecycle",
+        .ticket_consumer = .{
+            .ctx = &capture,
+            .nowUnixMsFn = Capture.now,
+            .onTicketFn = Capture.onTicket,
+        },
+        .resume_compat = .{ .transport = .ignore, .application = .ignore },
+    });
+    defer sim.deinit();
+    errdefer |err| sim.recordFailure(err);
+
+    try sim.runUntil(Sim.bothEstablished, 30_000_000);
+
+    var client_h3 = H3.init(allocator, .client);
+    defer client_h3.deinit();
+    try client_h3.start(sim.client);
+
+    // Ticket #1 arrives before client has observed peer SETTINGS.
+    try issueEarlyCapableTicket(sim, 0x01, 0x41, 1_000);
+    const first_ticket_deadline = sim.now_us + 20_000_000;
+    while (capture.count < 1 and sim.now_us < first_ticket_deadline) {
+        if (!try sim.step()) break;
+    }
+    try testing.expectEqual(@as(usize, 1), capture.count);
+
+    const ticket1_compat = capture.tickets[0].common.early_data_application_compat orelse return error.TestExpectedEqual;
+    const ticket1_settings = try http3.early_data.decodeCompatView(.{
+        .format_id = ticket1_compat.format_id,
+        .format_version = ticket1_compat.format_version,
+        .bytes = ticket1_compat.slice(),
+    });
+    try testing.expectEqual(http3.frame.Settings{}, ticket1_settings);
+
+    // Now the client observes the peer SETTINGS frame with non-default values.
+    const control_id = try sim.server.openStream(.uni);
+    var settings_payload_buf: [64]u8 = undefined;
+    const settings_payload = try http3.frame.encodeSettings(&.{
+        .{ .id = .qpack_blocked_streams, .id_value = 0x07, .value = 3 },
+        .{ .id = .max_field_section_size, .id_value = 0x06, .value = 8192 },
+        .{ .id = .enable_connect_protocol, .id_value = 0x08, .value = 1 },
+    }, &settings_payload_buf);
+    var control_buf: [128]u8 = undefined;
+    var control_len: usize = 0;
+    control_len += (try http3.frame.encodeStreamType(.control, control_buf[control_len..])).len;
+    control_len += (try http3.frame.encodeKnownFrame(.settings, settings_payload, control_buf[control_len..])).len;
+
+    var written: usize = 0;
+    while (written < control_len) {
+        const n = try sim.server.writeStream(control_id, control_buf[written..control_len], false);
+        if (n == 0) {
+            _ = try sim.step();
+            continue;
+        }
+        written += n;
+    }
+
+    const settings_seen_deadline = sim.now_us + 20_000_000;
+    while (!client_h3.metrics.settings_received and sim.now_us < settings_seen_deadline) {
+        _ = try sim.step();
+        try client_h3.pump(sim.client);
+    }
+    try testing.expect(client_h3.metrics.settings_received);
+
+    // Ticket #2 arrives after peer SETTINGS was decoded by the H3 client.
+    try issueEarlyCapableTicket(sim, 0x02, 0x42, 1_500);
+    const second_ticket_deadline = sim.now_us + 20_000_000;
+    while (capture.count < 2 and sim.now_us < second_ticket_deadline) {
+        _ = try sim.step();
+        try client_h3.pump(sim.client);
+    }
+    try testing.expectEqual(@as(usize, 2), capture.count);
+
+    const ticket2_compat = capture.tickets[1].common.early_data_application_compat orelse return error.TestExpectedEqual;
+    const ticket2_settings = try http3.early_data.decodeCompatView(.{
+        .format_id = ticket2_compat.format_id,
+        .format_version = ticket2_compat.format_version,
+        .bytes = ticket2_compat.slice(),
+    });
+    try testing.expectEqual(http3.frame.Settings{
+        .qpack_blocked_streams = 3,
+        .max_field_section_size = 8192,
+        .enable_connect_protocol = true,
+    }, ticket2_settings);
+
+    // Earlier ingested ticket remains unchanged.
+    const ticket1_settings_after = try http3.early_data.decodeCompatView(.{
+        .format_id = ticket1_compat.format_id,
+        .format_version = ticket1_compat.format_version,
+        .bytes = ticket1_compat.slice(),
+    });
+    try testing.expectEqual(http3.frame.Settings{}, ticket1_settings_after);
+}
+
 test "e2e: lossless handshake, SETTINGS, request/response, clean close" {
     var sim = try Sim.init(testing.allocator, .{ .scenario = "lossless" });
     defer sim.deinit();

--- a/tests/quic_h3_e2e.zig
+++ b/tests/quic_h3_e2e.zig
@@ -610,11 +610,9 @@ test "#367 slice3: client ticket snapshots move from defaults to decoded peer SE
 
     try sim.runUntil(Sim.bothEstablished, 30_000_000);
 
-    var client_h3 = H3.init(allocator, .client);
-    defer client_h3.deinit();
-    try client_h3.start(sim.client);
-
     // Ticket #1 arrives before client has observed peer SETTINGS.
+    // This is also before H3.start(), so defaults must have been installed
+    // at connection initialization time.
     try issueEarlyCapableTicket(sim, 0x01, 0x41, 1_000);
     const first_ticket_deadline = sim.now_us + 20_000_000;
     while (capture.count < 1 and sim.now_us < first_ticket_deadline) {
@@ -629,6 +627,10 @@ test "#367 slice3: client ticket snapshots move from defaults to decoded peer SE
         .bytes = ticket1_compat.slice(),
     });
     try testing.expectEqual(http3.frame.Settings{}, ticket1_settings);
+
+    var client_h3 = H3.init(allocator, .client);
+    defer client_h3.deinit();
+    try client_h3.start(sim.client);
 
     // Now the client observes the peer SETTINGS frame with non-default values.
     const control_id = try sim.server.openStream(.uni);


### PR DESCRIPTION
## Summary
- add canonical HTTP/3 remembered SETTINGS snapshot encode/decode and directional 0-RTT compatibility checks
- stamp early-capable tickets with H3 application compatibility and expose the client-side remembered application snapshot for the planned identity-0 early-data attempt
- wire native H3 runtime SETTINGS emission/application compatibility into the QUIC TLS backend wrapper

## Validation
- zig fmt --check build.zig src/ tests/
- zig build test --summary all --error-style verbose
- zig build --summary all --error-style verbose

Part of #367 slice 3.