### PR TITLE
Issue #367 Slice 4: H2 deferral + early-data observability/docs

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -11,7 +11,18 @@ Runtime logs and access logs are JSON by default.
   `request_id` and `correlation_id`
 - access logs: `type`, `ts`, `request_id`, `correlation_id`, `method`, `path`,
   `status`, `latency_ms`, `client_ip`, `upstream_addr`, `upstream_status`,
-  `identity`, `bytes_sent`, `response_bytes`, and `error_category`
+  `identity`, `bytes_sent`, `response_bytes`, `error_category`,
+  `early_data_source`, `early_data_action`, `early_data_retry_result`, and
+  `early_data_replay_exposed`
+
+Early-data access-log fields are bounded enums/booleans only:
+
+- `early_data_source`: `none`, `transport`, `header`, `both`
+- `early_data_action`: `ordinary`, `accepted`, `forwarded`, `too_early`,
+  `deferred`, `retried`
+- `early_data_retry_result`: `none`, `success`, `too_early`, `failed`
+- `early_data_replay_exposed`: `true` when transport and/or header provenance
+  indicates replay exposure for this request
 
 Access logs are written through `src/http/access_log.zig`. Runtime component
 logs are written through `src/http/logger.zig`.
@@ -77,6 +88,15 @@ logs are written through `src/http/logger.zig`.
   eligibility. Upload and response eligibility are evaluated separately, so one
   request can contribute more than one fallback event.
 - reverse-proxy upstream TTFB summary: `tardigrade_proxy_ttfb_ms`
+- HTTP-level early-data counters (fixed labels only):
+  `tardigrade_http_early_data_requests_total{protocol,source}`,
+  `tardigrade_http_early_data_decisions_total{protocol,decision}`,
+  `tardigrade_http_early_data_upstream_425_total{action}`,
+  `tardigrade_http_early_data_retry_total{result}`,
+  and `tardigrade_http3_early_data_compat_total{decision}`
+
+Early-data metric label sets are intentionally bounded and never include
+high-cardinality request attributes (URL, request id, stream id, host, IP).
 
 The latency histogram is intentionally global rather than route-labeled to keep
 hot-path overhead predictable.

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -20,7 +20,7 @@ Early-data access-log fields are bounded enums/booleans only:
 - `early_data_source`: `none`, `transport`, `header`, `both`
 - `early_data_action`: `ordinary`, `accepted`, `forwarded`, `too_early`,
   `deferred`, `retried`
-- `early_data_retry_result`: `none`, `success`, `too_early`, `failed`
+- `early_data_retry_result`: `none`, `success`, `too_early`, `failure`
 - `early_data_replay_exposed`: `true` when transport and/or header provenance
   indicates replay exposure for this request
 

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -62,6 +62,7 @@ surfaces that should not be marketed as generic operator-facing capabilities.
 | --- | --- | --- | --- |
 | HTTP/2 | `tls_termination` HTTP/2 path, `hpack`, `http2_frame` | `experimental` | Present in-tree, but not documented or release-gated at the same level as the HTTP/1.1 core. |
 | HTTP/3 / QUIC | `http3_handler`, `http3_session`, `http3_runtime`, `quic`, `http3` | `experimental` | Served by the native Zig QUIC/H3 stack (no system libraries); enable at runtime with `--http3` and a QUIC-compatible TLS identity (Ed25519 or ECDSA P-256). ngtcp2/nghttp3 removed under #328; they remain out-of-process interop peers only. |
+| Early-data replay handling across H1/H2/H3 | `early_data`, `request_context`, `edge_gateway` H1/H2 preflight/deferral, `http3_runtime` compatibility gate | `experimental` | Current scope: #367 HTTP-level policy, H2 safe deferral, and bounded observability (metrics/access logs). Out of scope here: #366 transport-carrier internals and #368 anti-replay persistence/store. |
 | WebSocket, SSE, and mux realtime paths | `websocket`, `event_hub`, mux counters in `metrics` | `experimental` | Integration coverage exists, but the public operator docs are still example-scoped rather than Core v1. |
 | ACME automation | `acme_client` | `experimental` | Useful feature surface, but not part of the stable release/install promise yet. |
 | Auth and identity extensions | `auth`, `basic_auth`, `jwt`, `access_control` | `experimental` | Operators can use these paths, but they are not the defining Core v1 server contract. |

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -389,6 +389,8 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
             .max_datagram_size = cfg.http3_max_datagram_size,
             .request_handler = ghandlers.handleHttp3Request,
             .request_handler_ctx = &http3_dispatch_ctx,
+            .early_data_compat_metrics_ctx = &state,
+            .early_data_compat_metrics_cb = recordHttp3EarlyDataCompatFromRuntime,
         }) catch |err| blk: {
             state.logger.warn(null, "HTTP/3 listener failed to initialize: {s}", .{@errorName(err)});
             break :blk null;
@@ -1591,6 +1593,8 @@ const WaitingEncryptedHttpConnection = struct {
     tls_metrics: ?*http.metrics.Metrics = null,
     tls_metrics_mutex: ?*compat.Mutex = null,
     tls_metrics_state: ?*http.metrics.TlsBufferConnectionMetrics = null,
+    last_read_transport_early: bool = false,
+    handshake_complete_override: ?bool = null,
 
     fn init(
         inner: http.encrypted_stream_connection.EncryptedStreamHttpConnection,
@@ -1641,9 +1645,26 @@ const WaitingEncryptedHttpConnection = struct {
                 },
                 else => return err,
             };
+            self.last_read_transport_early = false;
             self.observeTlsBufferMetrics();
             return n;
         }
+    }
+
+    pub fn lastReadTransportEarly(self: *const WaitingEncryptedHttpConnection) bool {
+        return self.last_read_transport_early;
+    }
+
+    pub fn setLastReadTransportEarlyForTest(self: *WaitingEncryptedHttpConnection, early: bool) void {
+        self.last_read_transport_early = early;
+    }
+
+    pub fn downstreamHandshakeComplete(self: *const WaitingEncryptedHttpConnection) bool {
+        return self.handshake_complete_override orelse true;
+    }
+
+    pub fn setDownstreamHandshakeCompleteForTest(self: *WaitingEncryptedHttpConnection, complete: bool) void {
+        self.handshake_complete_override = complete;
     }
 
     pub fn write(self: *WaitingEncryptedHttpConnection, bytes: []const u8) !usize {
@@ -1857,6 +1878,105 @@ fn parkedConnectionCloseHook(raw_state: *anyopaque, fd: std.posix.fd_t) void {
     state.releaseConnectionSlot(fd);
 }
 
+fn recordHttp3EarlyDataCompatFromRuntime(
+    raw_state: *anyopaque,
+    decision: http.metrics.H3EarlyDataCompatDecision,
+) void {
+    const state: *GatewayState = @ptrCast(@alignCast(raw_state));
+    state.metricsRecordHttp3EarlyDataCompat(decision);
+}
+
+fn h2LastReadTransportEarly(conn: anytype) bool {
+    const T = @TypeOf(conn);
+    if (comptime std.meta.activeTag(@typeInfo(T)) == .pointer) {
+        const Child = std.meta.Child(T);
+        if (comptime @hasDecl(Child, "lastReadTransportEarly")) return conn.lastReadTransportEarly();
+    } else {
+        if (comptime @hasDecl(T, "lastReadTransportEarly")) return conn.lastReadTransportEarly();
+    }
+    return false;
+}
+
+fn h2DownstreamHandshakeComplete(conn: anytype) bool {
+    const T = @TypeOf(conn);
+    if (comptime std.meta.activeTag(@typeInfo(T)) == .pointer) {
+        const Child = std.meta.Child(T);
+        if (comptime @hasDecl(Child, "downstreamHandshakeComplete")) return conn.downstreamHandshakeComplete();
+    } else {
+        if (comptime @hasDecl(T, "downstreamHandshakeComplete")) return conn.downstreamHandshakeComplete();
+    }
+    return true;
+}
+
+fn h2AppendReadyStream(ready_streams: *std.array_list.Managed(u31), sid: u31) !void {
+    for (ready_streams.items) |existing| {
+        if (existing == sid) return;
+    }
+    try ready_streams.append(sid);
+}
+
+fn h2DispatchReadyStreams(
+    conn: anytype,
+    allocator: std.mem.Allocator,
+    state: *GatewayState,
+    cfg: *const edge_config.EdgeConfig,
+    pending: *std.AutoHashMap(u31, Http2PendingStream),
+    streams: *std.AutoHashMap(u31, http.http2_stream.Stream),
+    ready_streams: *std.array_list.Managed(u31),
+    next_server_stream_id: *u31,
+    conn_send_window: *i32,
+) !void {
+    if (ready_streams.items.len == 0) return;
+
+    const initial_ready = ready_streams.items.len;
+    var processed: usize = 0;
+    while (processed < initial_ready and ready_streams.items.len > 0) : (processed += 1) {
+        var best_idx: usize = 0;
+        var best_weight: u8 = 0;
+        for (ready_streams.items, 0..) |sid, idx| {
+            const w = if (streams.get(sid)) |s| s.priority_weight else 16;
+            if (w >= best_weight) {
+                best_weight = w;
+                best_idx = idx;
+            }
+        }
+
+        const sid = ready_streams.swapRemove(best_idx);
+        const stream_send = if (streams.get(sid)) |s| s.send_window else conn_send_window.*;
+        const ps = pending.getPtr(sid) orelse continue;
+        if (ps.dispatch_count > 0) continue;
+
+        if (ps.transport_early and !h2DownstreamHandshakeComplete(conn)) {
+            if (!ps.early_request_recorded) {
+                state.metricsRecordEarlyDataRequest(.h2, .transport);
+                ps.early_request_recorded = true;
+            }
+            if (!ps.deferred_recorded) {
+                state.metricsRecordEarlyDataDecision(.h2, .deferred);
+                ps.deferred_recorded = true;
+            }
+            try h2AppendReadyStream(ready_streams, sid);
+            continue;
+        }
+
+        if (ps.transport_early and !ps.early_request_recorded) {
+            state.metricsRecordEarlyDataRequest(.h2, .transport);
+            ps.early_request_recorded = true;
+        }
+        if (ps.transport_early) {
+            state.metricsRecordEarlyDataDecision(.h2, .accepted);
+        }
+
+        try respondHttp2Stream(conn.writer(), allocator, state, cfg, sid, ps, next_server_stream_id, conn_send_window, stream_send);
+        ps.dispatch_count += 1;
+        if (pending.fetchRemove(sid)) |removed| {
+            var tmp = removed.value;
+            tmp.deinit(allocator);
+        }
+        _ = streams.remove(sid);
+    }
+}
+
 fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const edge_config.EdgeConfig, state: *GatewayState, connection_ip: []const u8) !void {
     _ = session;
     _ = connection_ip;
@@ -1893,11 +2013,24 @@ fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const
     }
 
     while (!http.shutdown.isShutdownRequested() and !goaway_received) {
+        try h2DispatchReadyStreams(
+            conn,
+            allocator,
+            state,
+            cfg,
+            &pending,
+            &streams,
+            &ready_streams,
+            &next_server_stream_id,
+            &conn_send_window,
+        );
+
         var frame = http.http2_frame.readFrame(conn, allocator, HTTP2_MAX_FRAME_SIZE) catch |err| switch (err) {
             error.ConnectionClosed => return,
             else => return err,
         };
         defer http.http2_frame.deinitFrame(allocator, &frame);
+        const frame_transport_early = h2LastReadTransportEarly(conn);
 
         switch (frame.typ) {
             .settings => {
@@ -1924,6 +2057,7 @@ fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const
                 };
                 defer http.hpack.deinitDecoded(allocator, &decoded);
                 var ps = pending.get(frame.stream_id) orelse Http2PendingStream.init(allocator);
+                ps.transport_early = ps.transport_early or frame_transport_early;
                 if (streams.get(frame.stream_id)) |s| ps.priority_weight = s.priority_weight;
                 for (decoded.headers) |h| {
                     if (std.mem.eql(u8, h.name, ":method")) {
@@ -1939,7 +2073,7 @@ fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const
                 try pending.put(frame.stream_id, ps);
                 if ((frame.flags & http.http2_frame.Flags.END_STREAM) != 0) {
                     if (streams.getPtr(frame.stream_id)) |s| s.remoteEndStream() catch {};
-                    try ready_streams.append(frame.stream_id);
+                    try h2AppendReadyStream(&ready_streams, frame.stream_id);
                 }
             },
             .data => {
@@ -1947,6 +2081,7 @@ fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const
                 if (streams.getPtr(frame.stream_id)) |s| s.send_window -= @intCast(frame.payload.len);
                 conn_send_window -= @intCast(frame.payload.len);
                 if (pending.getPtr(frame.stream_id)) |ps| {
+                    ps.transport_early = ps.transport_early or frame_transport_early;
                     try ps.body.appendSlice(frame.payload);
                     try http.http2_frame.writeWindowUpdate(conn.writer(), frame.stream_id, @intCast(frame.payload.len));
                     try http.http2_frame.writeWindowUpdate(conn.writer(), 0, @intCast(frame.payload.len));
@@ -1954,7 +2089,7 @@ fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const
                     conn_send_window += @intCast(frame.payload.len);
                     if ((frame.flags & http.http2_frame.Flags.END_STREAM) != 0) {
                         if (streams.getPtr(frame.stream_id)) |s| s.remoteEndStream() catch {};
-                        try ready_streams.append(frame.stream_id);
+                        try h2AppendReadyStream(&ready_streams, frame.stream_id);
                     }
                 } else {
                     try http.http2_frame.writeGoaway(conn.writer(), frame.stream_id, 1);
@@ -1980,6 +2115,14 @@ fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const
                     tmp.deinit(allocator);
                 }
                 _ = streams.remove(frame.stream_id);
+                var idx: usize = 0;
+                while (idx < ready_streams.items.len) {
+                    if (ready_streams.items[idx] == frame.stream_id) {
+                        _ = ready_streams.swapRemove(idx);
+                        continue;
+                    }
+                    idx += 1;
+                }
             },
             .goaway => {
                 goaway_received = true;
@@ -1987,27 +2130,17 @@ fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const
             .continuation, .push_promise => {},
         }
 
-        while (ready_streams.items.len > 0) {
-            var best_idx: usize = 0;
-            var best_weight: u8 = 0;
-            for (ready_streams.items, 0..) |sid, idx| {
-                const w = if (streams.get(sid)) |s| s.priority_weight else 16;
-                if (w >= best_weight) {
-                    best_weight = w;
-                    best_idx = idx;
-                }
-            }
-            const sid = ready_streams.swapRemove(best_idx);
-            const stream_send = if (streams.get(sid)) |s| s.send_window else conn_send_window;
-            if (pending.getPtr(sid)) |ps| {
-                try respondHttp2Stream(conn.writer(), allocator, state, cfg, sid, ps, &next_server_stream_id, &conn_send_window, stream_send);
-            }
-            if (pending.fetchRemove(sid)) |removed| {
-                var tmp = removed.value;
-                tmp.deinit(allocator);
-            }
-            _ = streams.remove(sid);
-        }
+        try h2DispatchReadyStreams(
+            conn,
+            allocator,
+            state,
+            cfg,
+            &pending,
+            &streams,
+            &ready_streams,
+            &next_server_stream_id,
+            &conn_send_window,
+        );
     }
 }
 
@@ -2256,6 +2389,15 @@ fn earlyDataPreflightDecisionForH1(
     );
 }
 
+fn metricsEarlyDataSource(early_ctx: http.request_context.EarlyDataContext) ?http.metrics.EarlyDataSource {
+    return switch (early_ctx.source()) {
+        .none => null,
+        .transport => .transport,
+        .header => .header,
+        .both => .both,
+    };
+}
+
 const H1PreflightSideEffectProbe = struct {
     mirror_calls: usize = 0,
     auth_calls: usize = 0,
@@ -2370,9 +2512,26 @@ fn executeH1PostPreflightOrchestration(
     lifecycle: *http.request_lifecycle.RequestLifecycle,
     hooks: anytype,
 ) !H1PostPreflightOutcome {
-    switch (earlyDataPreflightDecisionForH1(cfg, ctx.early_data, request)) {
-        .ordinary, .execute_local, .forward_rfc8470 => {},
+    if (metricsEarlyDataSource(ctx.early_data)) |source| {
+        state.metricsRecordEarlyDataRequest(.h1, source);
+    }
+
+    const early_decision = earlyDataPreflightDecisionForH1(cfg, ctx.early_data, request);
+    switch (early_decision) {
+        .ordinary => {
+            ctx.early_data_action = .ordinary;
+        },
+        .execute_local => {
+            ctx.early_data_action = .accepted;
+            state.metricsRecordEarlyDataDecision(.h1, .accepted);
+        },
+        .forward_rfc8470 => {
+            ctx.early_data_action = .forwarded;
+            state.metricsRecordEarlyDataDecision(.h1, .forwarded);
+        },
         .too_early, .defer_until_handshake => {
+            ctx.early_data_action = if (early_decision == .defer_until_handshake) .deferred else .too_early;
+            state.metricsRecordEarlyDataDecision(.h1, if (ctx.early_data_action == .deferred) .deferred else .too_early);
             const status = try hooks.rejectEarly(allocator, writer, state, ctx, request, correlation_id, keep_alive.*);
             return .{ .terminal_status = status };
         },
@@ -2630,6 +2789,11 @@ fn handleConnection(conn: anytype, session: *ConnectionSession, cfg: *const edge
     // Reject before routing so no location block can accidentally serve it.
     if (traceRejectionStatus(request.method, ctx.early_data)) |trace_status| {
         if (trace_status == .too_early) {
+            if (metricsEarlyDataSource(ctx.early_data)) |source| {
+                state.metricsRecordEarlyDataRequest(.h1, source);
+            }
+            ctx.early_data_action = .too_early;
+            state.metricsRecordEarlyDataDecision(.h1, .too_early);
             const status = try ghandlers.writeTooEarlyResponse(allocator, writer, state, &ctx, correlation_id, keep_alive);
             ghandlers.logAccessForRequest(state, &ctx, &request, status);
             return;
@@ -2645,6 +2809,11 @@ fn handleConnection(conn: anytype, session: *ConnectionSession, cfg: *const edge
         std.mem.startsWith(u8, request.uri.path, acme_prefix))
     {
         if (ctx.early_data.replayExposed()) {
+            if (metricsEarlyDataSource(ctx.early_data)) |source| {
+                state.metricsRecordEarlyDataRequest(.h1, source);
+            }
+            ctx.early_data_action = .too_early;
+            state.metricsRecordEarlyDataDecision(.h1, .too_early);
             const status = try ghandlers.writeTooEarlyResponse(allocator, writer, state, &ctx, correlation_id, keep_alive);
             ghandlers.logAccessForRequest(state, &ctx, &request, status);
             return;
@@ -3037,6 +3206,8 @@ test "H1 early-data 425 preflight runs before side effects" {
     defer request.request.deinit();
     var effects = H1PreflightSideEffectProbe{};
     var state: GatewayState = undefined;
+    state.metrics_mutex = .{};
+    state.metrics = http.metrics.Metrics.init();
     var ctx = http.request_context.RequestContext.init(allocator, "req-early", "127.0.0.1");
     ctx.early_data.inbound_marker = true;
     var lifecycle = http.request_lifecycle.RequestLifecycle.init("req-early", 0);
@@ -3087,6 +3258,8 @@ test "H1 early proxy with origin capability off never reaches upstream side effe
     defer request.request.deinit();
     var effects = H1PreflightSideEffectProbe{};
     var state: GatewayState = undefined;
+    state.metrics_mutex = .{};
+    state.metrics = http.metrics.Metrics.init();
     var ctx = http.request_context.RequestContext.init(allocator, "req-off", "127.0.0.1");
     ctx.early_data.inbound_marker = true;
     var lifecycle = http.request_lifecycle.RequestLifecycle.init("req-off", 0);
@@ -3705,6 +3878,173 @@ test "waiting encrypted HTTP adapter records live HTTP/2 writer TLS metrics thro
     metrics_mutex.lock();
     defer metrics_mutex.unlock();
     try metrics.releaseTlsBufferSnapshot(&metrics_state);
+}
+
+const H2DispatchTestConn = struct {
+    allocator: std.mem.Allocator,
+    out: std.Io.Writer.Allocating,
+    handshake_complete: bool = true,
+
+    const Writer = struct {
+        conn: *H2DispatchTestConn,
+
+        pub fn write(self: Writer, bytes: []const u8) !usize {
+            return self.conn.out.writer.write(bytes);
+        }
+
+        pub fn writeAll(self: Writer, bytes: []const u8) !void {
+            try self.conn.out.writer.writeAll(bytes);
+        }
+    };
+
+    fn init(allocator: std.mem.Allocator) H2DispatchTestConn {
+        return .{
+            .allocator = allocator,
+            .out = .init(allocator),
+        };
+    }
+
+    fn deinit(self: *H2DispatchTestConn) void {
+        self.out.deinit();
+    }
+
+    fn writer(self: *H2DispatchTestConn) Writer {
+        return .{ .conn = self };
+    }
+
+    fn downstreamHandshakeComplete(self: *const H2DispatchTestConn) bool {
+        return self.handshake_complete;
+    }
+};
+
+test "H2 early stream defers dispatch until handshake completion then dispatches once" {
+    const allocator = std.testing.allocator;
+    var state: GatewayState = undefined;
+    state.metrics_mutex = .{};
+    state.add_headers = &.{};
+    state.metrics = http.metrics.Metrics.init();
+    var cfg = std.mem.zeroes(edge_config.EdgeConfig);
+
+    var pending = std.AutoHashMap(u31, Http2PendingStream).init(allocator);
+    defer {
+        var it = pending.iterator();
+        while (it.next()) |entry| {
+            var ps = entry.value_ptr.*;
+            ps.deinit(allocator);
+        }
+        pending.deinit();
+    }
+    var streams = std.AutoHashMap(u31, http.http2_stream.Stream).init(allocator);
+    defer streams.deinit();
+    var ready = std.array_list.Managed(u31).init(allocator);
+    defer ready.deinit();
+
+    var ps = Http2PendingStream.init(allocator);
+    ps.method = try allocator.dupe(u8, "GET");
+    ps.path = try allocator.dupe(u8, "/h2");
+    ps.transport_early = true;
+    try pending.put(1, ps);
+    try streams.put(1, http.http2_stream.Stream.init(1, 65_535));
+    try ready.append(1);
+
+    var conn = H2DispatchTestConn.init(allocator);
+    defer conn.deinit();
+    conn.handshake_complete = false;
+
+    var next_server_stream_id: u31 = 2;
+    var conn_send_window: i32 = 65_535;
+
+    try h2DispatchReadyStreams(
+        &conn,
+        allocator,
+        &state,
+        &cfg,
+        &pending,
+        &streams,
+        &ready,
+        &next_server_stream_id,
+        &conn_send_window,
+    );
+
+    try std.testing.expect(pending.contains(1));
+    try std.testing.expectEqual(@as(u8, 0), pending.get(1).?.dispatch_count);
+    try std.testing.expectEqual(@as(usize, 1), ready.items.len);
+    try std.testing.expectEqual(@as(u64, 0), state.metrics.total_requests);
+
+    conn.handshake_complete = true;
+    try h2DispatchReadyStreams(
+        &conn,
+        allocator,
+        &state,
+        &cfg,
+        &pending,
+        &streams,
+        &ready,
+        &next_server_stream_id,
+        &conn_send_window,
+    );
+
+    try std.testing.expect(!pending.contains(1));
+    try std.testing.expectEqual(@as(usize, 0), ready.items.len);
+    try std.testing.expectEqual(@as(u64, 1), state.metrics.total_requests);
+
+    const prom = try state.metrics.toPrometheus(allocator);
+    defer allocator.free(prom);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_requests_total{protocol=\"h2\",source=\"transport\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_decisions_total{protocol=\"h2\",decision=\"deferred\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_decisions_total{protocol=\"h2\",decision=\"accepted\"} 1") != null);
+}
+
+test "H2 ordinary stream dispatch remains unchanged" {
+    const allocator = std.testing.allocator;
+    var state: GatewayState = undefined;
+    state.metrics_mutex = .{};
+    state.add_headers = &.{};
+    state.metrics = http.metrics.Metrics.init();
+    var cfg = std.mem.zeroes(edge_config.EdgeConfig);
+
+    var pending = std.AutoHashMap(u31, Http2PendingStream).init(allocator);
+    defer {
+        var it = pending.iterator();
+        while (it.next()) |entry| {
+            var ps = entry.value_ptr.*;
+            ps.deinit(allocator);
+        }
+        pending.deinit();
+    }
+    var streams = std.AutoHashMap(u31, http.http2_stream.Stream).init(allocator);
+    defer streams.deinit();
+    var ready = std.array_list.Managed(u31).init(allocator);
+    defer ready.deinit();
+
+    var ps = Http2PendingStream.init(allocator);
+    ps.method = try allocator.dupe(u8, "GET");
+    ps.path = try allocator.dupe(u8, "/ordinary");
+    try pending.put(3, ps);
+    try streams.put(3, http.http2_stream.Stream.init(3, 65_535));
+    try ready.append(3);
+
+    var conn = H2DispatchTestConn.init(allocator);
+    defer conn.deinit();
+    conn.handshake_complete = false;
+
+    var next_server_stream_id: u31 = 2;
+    var conn_send_window: i32 = 65_535;
+    try h2DispatchReadyStreams(
+        &conn,
+        allocator,
+        &state,
+        &cfg,
+        &pending,
+        &streams,
+        &ready,
+        &next_server_stream_id,
+        &conn_send_window,
+    );
+
+    try std.testing.expect(!pending.contains(3));
+    try std.testing.expectEqual(@as(usize, 0), ready.items.len);
+    try std.testing.expectEqual(@as(u64, 1), state.metrics.total_requests);
 }
 
 fn gatewayTestSocketPair() ![2]std.posix.fd_t {

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -4274,10 +4274,10 @@ test "H2 frame provenance stays sticky when frame is fragmented across early the
     const wire = [_]u8{
         // length=4, type=DATA, flags=END_STREAM, stream_id=1
         0x00, 0x00, 0x04,
-        0x00,
-        0x01,
-        0x00, 0x00, 0x00, 0x01,
-        'a', 'b', 'c', 'd',
+        0x00, 0x01, 0x00,
+        0x00, 0x00, 0x01,
+        'a',  'b',  'c',
+        'd',
     };
 
     var harness = H2FrameReadProvenanceHarness{
@@ -4286,7 +4286,7 @@ test "H2 frame provenance stays sticky when frame is fragmented across early the
         .early_prefix_len = 11,
         .max_chunk = 2,
     };
-    var inner = http.encrypted_stream_connection.EncryptedStreamHttpConnection.initWithFdAndProvenance(
+    const inner = http.encrypted_stream_connection.EncryptedStreamHttpConnection.initWithFdAndProvenance(
         harness.stream(),
         -1,
         &harness,
@@ -4300,7 +4300,7 @@ test "H2 frame provenance stays sticky when frame is fragmented across early the
     defer http.http2_frame.deinitFrame(allocator, &frame);
 
     try std.testing.expect(h2LastReadTransportEarly(&conn));
-    try std.testing.expectEqual(http.http2_frame.FrameType.data, frame.typ);
+    try std.testing.expectEqual(http.http2_frame.Type.data, frame.typ);
     try std.testing.expectEqual(@as(u31, 1), frame.stream_id);
     try std.testing.expectEqualStrings("abcd", frame.payload);
 }

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -1593,8 +1593,7 @@ const WaitingEncryptedHttpConnection = struct {
     tls_metrics: ?*http.metrics.Metrics = null,
     tls_metrics_mutex: ?*compat.Mutex = null,
     tls_metrics_state: ?*http.metrics.TlsBufferConnectionMetrics = null,
-    last_read_transport_early: bool = false,
-    handshake_complete_override: ?bool = null,
+    read_scope_transport_early: bool = false,
 
     fn init(
         inner: http.encrypted_stream_connection.EncryptedStreamHttpConnection,
@@ -1645,26 +1644,43 @@ const WaitingEncryptedHttpConnection = struct {
                 },
                 else => return err,
             };
-            self.last_read_transport_early = false;
+            self.read_scope_transport_early = self.read_scope_transport_early or self.inner.currentReadTransportEarly();
             self.observeTlsBufferMetrics();
             return n;
         }
     }
 
-    pub fn lastReadTransportEarly(self: *const WaitingEncryptedHttpConnection) bool {
-        return self.last_read_transport_early;
+    pub fn beginReadScope(self: *WaitingEncryptedHttpConnection) void {
+        self.read_scope_transport_early = false;
     }
 
-    pub fn setLastReadTransportEarlyForTest(self: *WaitingEncryptedHttpConnection, early: bool) void {
-        self.last_read_transport_early = early;
+    pub fn takeReadScopeTransportEarly(self: *WaitingEncryptedHttpConnection) bool {
+        const early = self.read_scope_transport_early;
+        self.read_scope_transport_early = false;
+        return early;
     }
 
     pub fn downstreamHandshakeComplete(self: *const WaitingEncryptedHttpConnection) bool {
-        return self.handshake_complete_override orelse true;
+        return self.inner.downstreamHandshakeComplete();
     }
 
-    pub fn setDownstreamHandshakeCompleteForTest(self: *WaitingEncryptedHttpConnection, complete: bool) void {
-        self.handshake_complete_override = complete;
+    pub fn waitForHandshakeCompletionOrInput(self: *WaitingEncryptedHttpConnection) !void {
+        while (true) {
+            if (self.downstreamHandshakeComplete()) return;
+            if (self.pendingPlaintext() > 0) return;
+
+            const readiness = self.inner.readiness();
+            var requested = http.event_loop.Interest{ .read = true };
+            if (readiness.wants_write) requested.write = true;
+
+            self.observeTlsBufferMetrics();
+            try self.waitFor(requested, self.read_timeout_ms);
+            _ = self.inner.stream.drive() catch |err| switch (err) {
+                error.WouldBlock => continue,
+                else => return err,
+            };
+            self.observeTlsBufferMetrics();
+        }
     }
 
     pub fn write(self: *WaitingEncryptedHttpConnection, bytes: []const u8) !usize {
@@ -1890,11 +1906,27 @@ fn h2LastReadTransportEarly(conn: anytype) bool {
     const T = @TypeOf(conn);
     if (comptime std.meta.activeTag(@typeInfo(T)) == .pointer) {
         const Child = std.meta.Child(T);
-        if (comptime @hasDecl(Child, "lastReadTransportEarly")) return conn.lastReadTransportEarly();
+        if (comptime @hasDecl(Child, "takeReadScopeTransportEarly")) return conn.takeReadScopeTransportEarly();
     } else {
-        if (comptime @hasDecl(T, "lastReadTransportEarly")) return conn.lastReadTransportEarly();
+        if (comptime @hasDecl(T, "takeReadScopeTransportEarly")) return conn.takeReadScopeTransportEarly();
     }
     return false;
+}
+
+fn h2BeginReadScope(conn: anytype) void {
+    const T = @TypeOf(conn);
+    if (comptime std.meta.activeTag(@typeInfo(T)) == .pointer) {
+        const Child = std.meta.Child(T);
+        if (comptime @hasDecl(Child, "beginReadScope")) {
+            conn.beginReadScope();
+            return;
+        }
+    } else {
+        if (comptime @hasDecl(T, "beginReadScope")) {
+            conn.beginReadScope();
+            return;
+        }
+    }
 }
 
 fn h2DownstreamHandshakeComplete(conn: anytype) bool {
@@ -1906,6 +1938,28 @@ fn h2DownstreamHandshakeComplete(conn: anytype) bool {
         if (comptime @hasDecl(T, "downstreamHandshakeComplete")) return conn.downstreamHandshakeComplete();
     }
     return true;
+}
+
+fn h2WaitForHandshakeCompletionOrInput(conn: anytype) !void {
+    const T = @TypeOf(conn);
+    if (comptime std.meta.activeTag(@typeInfo(T)) == .pointer) {
+        const Child = std.meta.Child(T);
+        if (comptime @hasDecl(Child, "waitForHandshakeCompletionOrInput")) return conn.waitForHandshakeCompletionOrInput();
+    } else {
+        if (comptime @hasDecl(T, "waitForHandshakeCompletionOrInput")) return conn.waitForHandshakeCompletionOrInput();
+    }
+    return;
+}
+
+fn h2HasDeferredReadyStreams(
+    pending: *const std.AutoHashMap(u31, Http2PendingStream),
+    ready_streams: *const std.array_list.Managed(u31),
+) bool {
+    for (ready_streams.items) |sid| {
+        const ps = pending.get(sid) orelse continue;
+        if (ps.transport_early and ps.dispatch_count == 0) return true;
+    }
+    return false;
 }
 
 fn h2AppendReadyStream(ready_streams: *std.array_list.Managed(u31), sid: u31) !void {
@@ -2024,6 +2078,24 @@ fn handleHttp2Connection(conn: anytype, session: *ConnectionSession, cfg: *const
             &next_server_stream_id,
             &conn_send_window,
         );
+
+        if (h2HasDeferredReadyStreams(&pending, &ready_streams) and !h2DownstreamHandshakeComplete(conn)) {
+            try h2WaitForHandshakeCompletionOrInput(conn);
+            try h2DispatchReadyStreams(
+                conn,
+                allocator,
+                state,
+                cfg,
+                &pending,
+                &streams,
+                &ready_streams,
+                &next_server_stream_id,
+                &conn_send_window,
+            );
+            if (ready_streams.items.len == 0) continue;
+        }
+
+        h2BeginReadScope(conn);
 
         var frame = http.http2_frame.readFrame(conn, allocator, HTTP2_MAX_FRAME_SIZE) catch |err| switch (err) {
             error.ConnectionClosed => return,
@@ -3884,6 +3956,8 @@ const H2DispatchTestConn = struct {
     allocator: std.mem.Allocator,
     out: std.Io.Writer.Allocating,
     handshake_complete: bool = true,
+    handshake_completes_on_wait: bool = false,
+    wait_calls: usize = 0,
 
     const Writer = struct {
         conn: *H2DispatchTestConn,
@@ -3912,10 +3986,92 @@ const H2DispatchTestConn = struct {
         return .{ .conn = self };
     }
 
+    fn beginReadScope(_: *H2DispatchTestConn) void {}
+
+    fn takeReadScopeTransportEarly(_: *H2DispatchTestConn) bool {
+        return false;
+    }
+
     fn downstreamHandshakeComplete(self: *const H2DispatchTestConn) bool {
         return self.handshake_complete;
     }
+
+    fn waitForHandshakeCompletionOrInput(self: *H2DispatchTestConn) !void {
+        self.wait_calls += 1;
+        if (self.handshake_completes_on_wait) self.handshake_complete = true;
+    }
 };
+
+test "H2 deferred ready stream wakes on handshake completion without extra H2 frame" {
+    const allocator = std.testing.allocator;
+    var state: GatewayState = undefined;
+    state.metrics_mutex = .{};
+    state.add_headers = &.{};
+    state.metrics = http.metrics.Metrics.init();
+    var cfg = std.mem.zeroes(edge_config.EdgeConfig);
+
+    var pending = std.AutoHashMap(u31, Http2PendingStream).init(allocator);
+    defer {
+        var it = pending.iterator();
+        while (it.next()) |entry| {
+            var ps = entry.value_ptr.*;
+            ps.deinit(allocator);
+        }
+        pending.deinit();
+    }
+    var streams = std.AutoHashMap(u31, http.http2_stream.Stream).init(allocator);
+    defer streams.deinit();
+    var ready = std.array_list.Managed(u31).init(allocator);
+    defer ready.deinit();
+
+    var ps = Http2PendingStream.init(allocator);
+    ps.method = try allocator.dupe(u8, "GET");
+    ps.path = try allocator.dupe(u8, "/h2-wakeup");
+    ps.transport_early = true;
+    try pending.put(1, ps);
+    try streams.put(1, http.http2_stream.Stream.init(1, 65_535));
+    try ready.append(1);
+
+    var conn = H2DispatchTestConn.init(allocator);
+    defer conn.deinit();
+    conn.handshake_complete = false;
+    conn.handshake_completes_on_wait = true;
+
+    var next_server_stream_id: u31 = 2;
+    var conn_send_window: i32 = 65_535;
+
+    try h2DispatchReadyStreams(
+        &conn,
+        allocator,
+        &state,
+        &cfg,
+        &pending,
+        &streams,
+        &ready,
+        &next_server_stream_id,
+        &conn_send_window,
+    );
+    try std.testing.expect(pending.contains(1));
+    try std.testing.expectEqual(@as(u8, 0), pending.get(1).?.dispatch_count);
+
+    try h2WaitForHandshakeCompletionOrInput(&conn);
+    try h2DispatchReadyStreams(
+        &conn,
+        allocator,
+        &state,
+        &cfg,
+        &pending,
+        &streams,
+        &ready,
+        &next_server_stream_id,
+        &conn_send_window,
+    );
+
+    try std.testing.expectEqual(@as(usize, 1), conn.wait_calls);
+    try std.testing.expect(!pending.contains(1));
+    try std.testing.expectEqual(@as(usize, 0), ready.items.len);
+    try std.testing.expectEqual(@as(u64, 1), state.metrics.total_requests);
+}
 
 test "H2 early stream defers dispatch until handshake completion then dispatches once" {
     const allocator = std.testing.allocator;
@@ -4045,6 +4201,108 @@ test "H2 ordinary stream dispatch remains unchanged" {
     try std.testing.expect(!pending.contains(3));
     try std.testing.expectEqual(@as(usize, 0), ready.items.len);
     try std.testing.expectEqual(@as(u64, 1), state.metrics.total_requests);
+}
+
+const H2FrameReadProvenanceHarness = struct {
+    bytes: []const u8,
+    pos: usize = 0,
+    // Bytes in [0, early_prefix_len) are considered 0-RTT-origin.
+    early_prefix_len: usize,
+    max_chunk: usize,
+    last_read_early: bool = false,
+
+    fn stream(self: *H2FrameReadProvenanceHarness) tls_core.encrypted_stream.EncryptedStream {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    fn read(ptr: *anyopaque, out: []u8) tls_core.encrypted_stream.Error!usize {
+        const self: *H2FrameReadProvenanceHarness = @ptrCast(@alignCast(ptr));
+        if (self.pos >= self.bytes.len) return error.WouldBlock;
+        const n = @min(out.len, @min(self.max_chunk, self.bytes.len - self.pos));
+        self.last_read_early = self.pos < self.early_prefix_len;
+        @memcpy(out[0..n], self.bytes[self.pos .. self.pos + n]);
+        self.pos += n;
+        return n;
+    }
+
+    fn readiness(ptr: *anyopaque) tls_core.encrypted_stream.Readiness {
+        const self: *H2FrameReadProvenanceHarness = @ptrCast(@alignCast(ptr));
+        return .{ .can_read_plaintext = self.pos < self.bytes.len };
+    }
+
+    fn drive(ptr: *anyopaque) tls_core.encrypted_stream.Error!tls_core.encrypted_stream.DriveResult {
+        return .{ .made_progress = false, .readiness = readiness(ptr) };
+    }
+
+    fn backend(_: *anyopaque) tls_core.encrypted_stream.BackendKind {
+        return .pure_zig_record;
+    }
+
+    fn write(_: *anyopaque, _: []const u8) tls_core.encrypted_stream.Error!usize {
+        return error.WouldBlock;
+    }
+
+    fn close(_: *anyopaque) void {}
+
+    fn bufferSnapshot(_: *anyopaque) tls_core.encrypted_stream.BufferSnapshot {
+        return .{};
+    }
+
+    fn readTransportEarly(ptr: *anyopaque) bool {
+        const self: *H2FrameReadProvenanceHarness = @ptrCast(@alignCast(ptr));
+        return self.last_read_early;
+    }
+
+    fn handshakeComplete(_: *anyopaque) bool {
+        return true;
+    }
+
+    const vtable = tls_core.encrypted_stream.EncryptedStream.VTable{
+        .backendFn = backend,
+        .readFn = read,
+        .writeFn = write,
+        .closeFn = close,
+        .readinessFn = readiness,
+        .driveFn = drive,
+        .bufferSnapshotFn = bufferSnapshot,
+    };
+};
+
+test "H2 frame provenance stays sticky when frame is fragmented across early then 1-RTT reads" {
+    const allocator = std.testing.allocator;
+
+    const wire = [_]u8{
+        // length=4, type=DATA, flags=END_STREAM, stream_id=1
+        0x00, 0x00, 0x04,
+        0x00,
+        0x01,
+        0x00, 0x00, 0x00, 0x01,
+        'a', 'b', 'c', 'd',
+    };
+
+    var harness = H2FrameReadProvenanceHarness{
+        .bytes = wire[0..],
+        // Header + first two payload bytes come from early data; remainder is 1-RTT.
+        .early_prefix_len = 11,
+        .max_chunk = 2,
+    };
+    var inner = http.encrypted_stream_connection.EncryptedStreamHttpConnection.initWithFdAndProvenance(
+        harness.stream(),
+        -1,
+        &harness,
+        H2FrameReadProvenanceHarness.readTransportEarly,
+        H2FrameReadProvenanceHarness.handshakeComplete,
+    );
+    var conn = WaitingEncryptedHttpConnection.init(inner, 1, 1);
+
+    h2BeginReadScope(&conn);
+    var frame = try http.http2_frame.readFrame(&conn, allocator, HTTP2_MAX_FRAME_SIZE);
+    defer http.http2_frame.deinitFrame(allocator, &frame);
+
+    try std.testing.expect(h2LastReadTransportEarly(&conn));
+    try std.testing.expectEqual(http.http2_frame.FrameType.data, frame.typ);
+    try std.testing.expectEqual(@as(u31, 1), frame.stream_id);
+    try std.testing.expectEqualStrings("abcd", frame.payload);
 }
 
 fn gatewayTestSocketPair() ![2]std.posix.fd_t {

--- a/src/gateway_handlers.zig
+++ b/src/gateway_handlers.zig
@@ -2060,6 +2060,10 @@ pub fn logAccess(state: *GatewayState, ctx: *const http.request_context.RequestC
         .response_bytes = ctx.response_bytes,
         .error_category = classifyErrorCategory(status),
         .cancel_reason = cancel_reason,
+        .early_data_source = @tagName(ctx.early_data.source()),
+        .early_data_action = @tagName(ctx.early_data_action),
+        .early_data_retry_result = @tagName(ctx.early_data_retry_result),
+        .early_data_replay_exposed = ctx.early_data.replayExposed(),
     };
     entry.log();
 }

--- a/src/gateway_handlers.zig
+++ b/src/gateway_handlers.zig
@@ -500,6 +500,73 @@ fn minimalAuthConfig(blocks: []http.location_router.LocationBlock, token_hashes:
     return cfg;
 }
 
+fn minimalHttp3ProxyConfig(blocks: []http.location_router.LocationBlock) edge_config.EdgeConfig {
+    var cfg = minimalAuthConfig(blocks, &.{});
+    cfg.server_names = &.{};
+    cfg.server_blocks = &.{};
+    cfg.upstream_base_url = "";
+    cfg.upstream_tls_verify = false;
+    cfg.upstream_tls_ca_bundle = "";
+    cfg.upstream_tls_server_name = "";
+    cfg.upstream_tls_client_cert = "";
+    cfg.upstream_tls_client_key = "";
+    cfg.upstream_protocol = .http1;
+    cfg.upstream_timeout_ms = 5000;
+    cfg.upstream_connect_timeout_ms = 5000;
+    cfg.upstream_response_timeout_ms = 5000;
+    cfg.upstream_timeout_budget_ms = 0;
+    cfg.upstream_retry_attempts = 1;
+    cfg.upstream_retry_idempotent_only = true;
+    cfg.upstream_max_fails = 0;
+    cfg.upstream_fail_timeout_ms = 0;
+    cfg.upstream_active_health_interval_ms = 0;
+    cfg.upstream_slow_start_ms = 0;
+    cfg.max_buffered_upstream_response_bytes = 64 * 1024;
+    cfg.proxy_buffer_limits = .{
+        .per_stream_low_watermark = 256 * 1024,
+        .per_stream_high_watermark = 768 * 1024,
+        .per_stream_hard_limit = 1024 * 1024,
+        .per_origin_hard_limit = 0,
+        .global_hard_limit = 0,
+    };
+    cfg.upstream_pool_enabled = false;
+    cfg.upstream_pool_max_idle_per_host = 0;
+    cfg.upstream_pool_idle_timeout_ms = 0;
+    cfg.upstream_pool_max_lifetime_ms = 0;
+    cfg.upstream_pool_max_active_per_host = 0;
+    cfg.tls_cert_path = "";
+    cfg.tls_key_path = "";
+    cfg.add_headers = &.{};
+    return cfg;
+}
+
+fn initHttp3ProxyTestState(state: *GatewayState, allocator: std.mem.Allocator, add_headers: []const edge_config.EdgeConfig.HeaderPair) void {
+    initHandlerTestState(state, allocator, add_headers);
+    state.upstream_mutex = .{};
+    state.upstream_health = std.StringHashMap(gs.UpstreamHealth).init(allocator);
+    state.upstream_active_requests = std.StringHashMap(usize).init(allocator);
+    state.upstream_pool = http.upstream_pool.UpstreamPool.init(allocator, .{});
+    state.h2_pool = http.upstream_h2.H2ConnPool.init(allocator, .{});
+    state.proxy_buffer_limits = .{
+        .per_stream_low_watermark = 256 * 1024,
+        .per_stream_high_watermark = 768 * 1024,
+        .per_stream_hard_limit = 1024 * 1024,
+        .per_origin_hard_limit = 0,
+        .global_hard_limit = 0,
+    };
+}
+
+fn deinitHttp3ProxyTestState(state: *GatewayState) void {
+    state.upstream_pool.deinit();
+    state.h2_pool.deinit();
+    var active_it = state.upstream_active_requests.keyIterator();
+    while (active_it.next()) |key| state.allocator.free(key.*);
+    state.upstream_active_requests.deinit();
+    var health_it = state.upstream_health.keyIterator();
+    while (health_it.next()) |key| state.allocator.free(key.*);
+    state.upstream_health.deinit();
+}
+
 fn recordTestReturnMetrics(state: *GatewayState, result: ReturnResponseWriteResult) void {
     state.metricsRecord(result.status);
     if (result.error_code) |code| state.metricsRecordErrorCode(code);
@@ -1616,6 +1683,7 @@ fn executeSubrequest(allocator: std.mem.Allocator, url: []const u8, method: std.
 pub const Http3DispatchContext = struct {
     config_store: *ReloadableConfigStore,
     cfg: *const edge_config.EdgeConfig,
+    cfg_lease: ?*gs.ConfigLease = null,
     state: *GatewayState,
 };
 
@@ -1720,6 +1788,18 @@ fn rejectHttp3ProxyError(
     message: []const u8,
     correlation_id: []const u8,
 ) !void {
+    try rejectHttp3ProxyErrorWithState(allocator, response, ctx.state, status, code, message, correlation_id);
+}
+
+fn rejectHttp3ProxyErrorWithState(
+    allocator: std.mem.Allocator,
+    response: *http.Response,
+    state: *GatewayState,
+    status: http.Status,
+    code: []const u8,
+    message: []const u8,
+    correlation_id: []const u8,
+) !void {
     const payload = try buildApiErrorJson(allocator, code, message, correlation_id);
     _ = response
         .setStatus(status)
@@ -1727,14 +1807,36 @@ fn rejectHttp3ProxyError(
         .setContentType("application/json")
         .setHeader(http.correlation.HEADER_NAME, correlation_id);
     finalizeHttp3Response(response);
-    applyResponseHeaders(ctx.state, response);
-    ctx.state.metricsRecord(@intFromEnum(status));
-    ctx.state.metricsRecordErrorCode(code);
+    applyResponseHeaders(state, response);
+    state.metricsRecord(@intFromEnum(status));
+    state.metricsRecordErrorCode(code);
+}
+
+fn applyHttp3ProxyResponse(
+    allocator: std.mem.Allocator,
+    response: *http.Response,
+    state: *GatewayState,
+    upstream_response: *const gproxy_runtime.DataPlaneProxyResponse,
+    correlation_id: []const u8,
+) !void {
+    const buffered_response = upstream_response.boundedBufferedForCompatibility();
+
+    _ = response
+        .setStatus(@enumFromInt(buffered_response.status_code))
+        .setBodyOwned(try allocator.dupe(u8, buffered_response.body))
+        .setHeader(http.correlation.HEADER_NAME, correlation_id);
+    for (buffered_response.headers) |header| {
+        _ = response.setHeader(header.name, header.value);
+    }
+    finalizeHttp3Response(response);
+    applyResponseHeaders(state, response);
+    state.metricsRecord(upstream_response.statusCode());
 }
 
 const Http3BufferedProxyAttemptExecutor = struct {
     allocator: std.mem.Allocator,
     cfg: *const edge_config.EdgeConfig,
+    cfg_lease: ?*gs.ConfigLease,
     state: *GatewayState,
     request: *const http.http3_session.StreamRequest,
     upstream_url: []const u8,
@@ -1858,11 +1960,16 @@ const Http3BufferedProxyAttemptExecutor = struct {
         result: *gproxy_runtime.DataPlaneProxyResponse,
     ) !void {
         self.state.logger.debug(self.correlation_id, "h3 parking early-data upstream 425 retry until downstream handshake completion", .{});
-        self.request.parkEarly425Retry() catch |err| {
-            self.state.metricsReleaseProxyBufferedBytes(result.bodyLen());
-            result.deinit(self.allocator);
-            return err;
-        };
+        var plan = try Http3Early425ProxyContinuation.init(self.allocator, self);
+        errdefer {
+            plan.deinit(self.allocator);
+            self.allocator.destroy(plan);
+        }
+        try self.request.parkEarly425Retry(.{
+            .ctx = plan,
+            .resume_fn = Http3Early425ProxyContinuation.run,
+            .deinit_fn = Http3Early425ProxyContinuation.destroy,
+        });
         self.state.metricsReleaseProxyBufferedBytes(result.bodyLen());
         result.deinit(self.allocator);
     }
@@ -1884,6 +1991,181 @@ const Http3BufferedProxyAttemptExecutor = struct {
         self.state.logger.warn(self.correlation_id, "h3 proxy attempt {d}/{d} got {d}, retrying", .{ configured_attempt_index + 1, max_attempts, result.statusCode() });
         self.state.metricsReleaseProxyBufferedBytes(result.bodyLen());
         result.deinit(self.allocator);
+    }
+};
+
+const Http3Early425ProxyContinuation = struct {
+    config_lease: gs.ConfigLease,
+    cfg_snapshot: edge_config.EdgeConfig,
+    state: *GatewayState,
+    upstream_url: []u8,
+    unix_socket_path: ?[]const u8,
+    method: []u8,
+    headers: http.Headers,
+    body: []u8,
+    correlation_id: []u8,
+    client_ip: []u8,
+    forwarded_proto: []u8,
+    incoming_host: ?[]u8,
+    selection_base_url: []const u8,
+    budget_start_ms: u64,
+    last_attempt_start_ms: u64 = 0,
+    transport_early: bool,
+
+    fn init(
+        allocator: std.mem.Allocator,
+        executor: *const Http3BufferedProxyAttemptExecutor,
+    ) !*Http3Early425ProxyContinuation {
+        const plan = try allocator.create(Http3Early425ProxyContinuation);
+        errdefer allocator.destroy(plan);
+
+        const source_lease = executor.cfg_lease orelse return error.Http3Early425RetryCannotPark;
+        var retained_lease = source_lease.retain();
+        errdefer retained_lease.release();
+
+        const method = try allocator.dupe(u8, executor.method);
+        errdefer allocator.free(method);
+        var headers = http.Headers.init(allocator);
+        errdefer headers.deinit();
+        for (executor.headers.iterator()) |header| {
+            try headers.append(header.name, header.value);
+        }
+        const body = try allocator.dupe(u8, executor.body);
+        errdefer allocator.free(body);
+        const upstream_url = try allocator.dupe(u8, executor.upstream_url);
+        errdefer allocator.free(upstream_url);
+        const correlation_id = try allocator.dupe(u8, executor.correlation_id);
+        errdefer allocator.free(correlation_id);
+        const client_ip = try allocator.dupe(u8, executor.client_ip);
+        errdefer allocator.free(client_ip);
+        const forwarded_proto = try allocator.dupe(u8, executor.forwarded_proto);
+        errdefer allocator.free(forwarded_proto);
+        const incoming_host = if (executor.incoming_host) |value| try allocator.dupe(u8, value) else null;
+        errdefer if (incoming_host) |value| allocator.free(value);
+
+        plan.* = .{
+            .config_lease = retained_lease,
+            .cfg_snapshot = executor.cfg.*,
+            .state = executor.state,
+            .upstream_url = upstream_url,
+            .unix_socket_path = executor.unix_socket_path,
+            .method = method,
+            .headers = headers,
+            .body = body,
+            .correlation_id = correlation_id,
+            .client_ip = client_ip,
+            .forwarded_proto = forwarded_proto,
+            .incoming_host = incoming_host,
+            .selection_base_url = executor.selection_base_url,
+            .budget_start_ms = executor.budget_start_ms,
+            .transport_early = executor.request.transport_early,
+        };
+        return plan;
+    }
+
+    fn deinit(self: *Http3Early425ProxyContinuation, allocator: std.mem.Allocator) void {
+        self.config_lease.release();
+        allocator.free(self.upstream_url);
+        allocator.free(self.method);
+        self.headers.deinit();
+        allocator.free(self.body);
+        allocator.free(self.correlation_id);
+        allocator.free(self.client_ip);
+        allocator.free(self.forwarded_proto);
+        if (self.incoming_host) |value| allocator.free(value);
+        self.* = undefined;
+    }
+
+    fn destroy(ctx: *anyopaque, allocator: std.mem.Allocator) void {
+        const self: *Http3Early425ProxyContinuation = @ptrCast(@alignCast(ctx));
+        self.deinit(allocator);
+        allocator.destroy(self);
+    }
+
+    fn perAttemptTimeoutMs(self: *Http3Early425ProxyContinuation) !u32 {
+        if (self.cfg_snapshot.upstream_timeout_budget_ms == 0) return self.cfg_snapshot.upstream_timeout_ms;
+        const elapsed_ms = http.event_loop.monotonicMs() - self.budget_start_ms;
+        if (elapsed_ms >= self.cfg_snapshot.upstream_timeout_budget_ms) return error.ProxyBudgetExhausted;
+        const remaining = self.cfg_snapshot.upstream_timeout_budget_ms - elapsed_ms;
+        if (self.cfg_snapshot.upstream_timeout_ms == 0) {
+            return @intCast(@min(remaining, @as(u64, std.math.maxInt(u32))));
+        }
+        return @intCast(@min(@as(u64, self.cfg_snapshot.upstream_timeout_ms), remaining));
+    }
+
+    fn execute(self: *Http3Early425ProxyContinuation, per_attempt_timeout_ms: u32) !gproxy_runtime.DataPlaneProxyResponse {
+        self.state.recordUpstreamAttemptStart(self.selection_base_url);
+        self.last_attempt_start_ms = http.event_loop.monotonicMs();
+        const resp = executeBufferedDataPlaneProxyRequest(
+            self.headers.allocator,
+            &self.cfg_snapshot,
+            self.upstream_url,
+            self.unix_socket_path,
+            self.method,
+            &self.headers,
+            self.body,
+            self.correlation_id,
+            self.client_ip,
+            self.forwarded_proto,
+            self.incoming_host,
+            null,
+            null,
+            null,
+            null,
+            false,
+            per_attempt_timeout_ms,
+            self.cfg_snapshot.upstream_connect_timeout_ms,
+            self.cfg_snapshot.upstream_response_timeout_ms,
+            null,
+            &self.state.upstream_pool,
+            &self.state.h2_pool,
+        );
+        self.state.recordUpstreamAttemptEnd(self.selection_base_url);
+        return resp;
+    }
+
+    fn run(ctx: *anyopaque, allocator: std.mem.Allocator, response: *http.Response) !void {
+        const self: *Http3Early425ProxyContinuation = @ptrCast(@alignCast(ctx));
+        std.debug.assert(self.transport_early);
+        const per_attempt_timeout_ms = self.perAttemptTimeoutMs() catch |err| {
+            self.state.metricsRecordEarlyDataRetry(.failure);
+            if (err == error.OutOfMemory) return error.OutOfMemory;
+            try rejectHttp3ProxyErrorWithState(allocator, response, self.state, .gateway_timeout, "upstream_timeout", "Upstream request timed out", self.correlation_id);
+            return;
+        };
+        self.state.metricsRecordEarlyDataUpstream425(.retried);
+        var upstream_response = self.execute(per_attempt_timeout_ms) catch |err| {
+            self.state.metricsRecordEarlyDataRetry(.failure);
+            if (err == error.ProxyBudgetExhausted or err == error.RequestCancelled) {
+                try rejectHttp3ProxyErrorWithState(allocator, response, self.state, .gateway_timeout, "upstream_timeout", "Upstream request timed out", self.correlation_id);
+                return;
+            }
+            if (err == error.UpstreamAtCapacity) {
+                try rejectHttp3ProxyErrorWithState(allocator, response, self.state, .service_unavailable, "upstream_saturated", "Upstream connection limit reached", self.correlation_id);
+                return;
+            }
+            self.state.recordUpstreamFailure(&self.cfg_snapshot, self.selection_base_url);
+            if (err == error.OutOfMemory) return error.OutOfMemory;
+            const err_status: http.Status = switch (err) {
+                error.Timeout, error.TimedOut, error.WouldBlock => .gateway_timeout,
+                else => .bad_gateway,
+            };
+            const err_code = if (err_status == .gateway_timeout) "upstream_timeout" else "upstream_error";
+            const err_msg = if (err_status == .gateway_timeout) "Upstream request timed out" else "Upstream connection failed";
+            try rejectHttp3ProxyErrorWithState(allocator, response, self.state, err_status, err_code, err_msg, self.correlation_id);
+            return;
+        };
+        defer upstream_response.deinit(allocator);
+        const upstream_ttfb_ms = http.event_loop.monotonicMs() - self.last_attempt_start_ms;
+        self.state.metricsRecordProxyBufferedRequest(upstream_response.bodyLen(), upstream_ttfb_ms);
+        defer self.state.metricsReleaseProxyBufferedBytes(upstream_response.bodyLen());
+        if (upstream_response.statusCode() == @intFromEnum(http.Status.too_early)) {
+            self.state.metricsRecordEarlyDataUpstream425(.forwarded);
+            self.state.metricsRecordEarlyDataRetry(.too_early);
+        } else {
+            self.state.metricsRecordEarlyDataRetry(.success);
+        }
+        try applyHttp3ProxyResponse(allocator, response, self.state, &upstream_response, self.correlation_id);
     }
 };
 
@@ -1909,6 +2191,7 @@ fn handleHttp3LocationProxyPass(
     var attempt_executor = Http3BufferedProxyAttemptExecutor{
         .allocator = allocator,
         .cfg = ctx.cfg,
+        .cfg_lease = ctx.cfg_lease,
         .state = ctx.state,
         .request = request,
         .upstream_url = upstream_url.value,
@@ -1923,52 +2206,6 @@ fn handleHttp3LocationProxyPass(
         .selection_base_url = ctx.cfg.upstream_base_url,
         .budget_start_ms = http.event_loop.monotonicMs(),
     };
-
-    if (request.resume_early_425_retry) {
-        var upstream_response = attempt_executor.execute(0, false) catch |err| {
-            attempt_executor.recordEarlyRetryResult(.failure);
-            if (err == error.ProxyBudgetExhausted or err == error.RequestCancelled) {
-                try rejectHttp3ProxyError(allocator, response, ctx, .gateway_timeout, "upstream_timeout", "Upstream request timed out", correlation_id);
-                return;
-            }
-            if (err == error.UpstreamAtCapacity) {
-                try rejectHttp3ProxyError(allocator, response, ctx, .service_unavailable, "upstream_saturated", "Upstream connection limit reached", correlation_id);
-                return;
-            }
-            try attempt_executor.onTerminalAttemptError(err);
-            if (err == error.OutOfMemory) return error.OutOfMemory;
-            const err_status: http.Status = switch (err) {
-                error.Timeout, error.TimedOut, error.WouldBlock => .gateway_timeout,
-                else => .bad_gateway,
-            };
-            const err_code = if (err_status == .gateway_timeout) "upstream_timeout" else "upstream_error";
-            const err_msg = if (err_status == .gateway_timeout) "Upstream request timed out" else "Upstream connection failed";
-            try rejectHttp3ProxyError(allocator, response, ctx, err_status, err_code, err_msg, correlation_id);
-            return;
-        };
-        defer upstream_response.deinit(allocator);
-        try attempt_executor.onBufferedResponse(&upstream_response);
-        defer ctx.state.metricsReleaseProxyBufferedBytes(upstream_response.bodyLen());
-        if (upstream_response.statusCode() == @intFromEnum(http.Status.too_early)) {
-            attempt_executor.recordEarlyUpstream425Action(.forwarded);
-            attempt_executor.recordEarlyRetryResult(.too_early);
-        } else {
-            attempt_executor.recordEarlyRetryResult(.success);
-        }
-        const buffered_response = upstream_response.boundedBufferedForCompatibility();
-
-        _ = response
-            .setStatus(@enumFromInt(buffered_response.status_code))
-            .setBodyOwned(try allocator.dupe(u8, buffered_response.body))
-            .setHeader(http.correlation.HEADER_NAME, correlation_id);
-        for (buffered_response.headers) |header| {
-            _ = response.setHeader(header.name, header.value);
-        }
-        finalizeHttp3Response(response);
-        applyResponseHeaders(ctx.state, response);
-        ctx.state.metricsRecord(upstream_response.statusCode());
-        return;
-    }
 
     var upstream_response: gproxy_runtime.DataPlaneProxyResponse = switch (try gproxy_runtime.runBufferedProxyAttempts(
         early_ctx,
@@ -2004,18 +2241,7 @@ fn handleHttp3LocationProxyPass(
     };
     defer upstream_response.deinit(allocator);
     defer ctx.state.metricsReleaseProxyBufferedBytes(upstream_response.bodyLen());
-    const buffered_response = upstream_response.boundedBufferedForCompatibility();
-
-    _ = response
-        .setStatus(@enumFromInt(buffered_response.status_code))
-        .setBodyOwned(try allocator.dupe(u8, buffered_response.body))
-        .setHeader(http.correlation.HEADER_NAME, correlation_id);
-    for (buffered_response.headers) |header| {
-        _ = response.setHeader(header.name, header.value);
-    }
-    finalizeHttp3Response(response);
-    applyResponseHeaders(ctx.state, response);
-    ctx.state.metricsRecord(upstream_response.statusCode());
+    try applyHttp3ProxyResponse(allocator, response, ctx.state, &upstream_response, correlation_id);
 }
 
 fn handleHttp3StaticLocation(
@@ -2582,6 +2808,348 @@ test "routeHttp3Location replay-safe acceptance handles combined prior-hop and c
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_decisions_total{protocol=\"h3\",decision=\"accepted\"} 1") != null);
 }
 
+const H3ProxyOrigin = struct {
+    allocator: std.mem.Allocator,
+    listen_fd: std.posix.fd_t,
+    listen_port: u16,
+    thread: ?std.Thread = null,
+    statuses: []const u16,
+    mutex: compat.Mutex = .{},
+    requests: std.ArrayList([]u8) = .empty,
+
+    fn start(allocator: std.mem.Allocator, statuses: []const u16) !H3ProxyOrigin {
+        const listen_fd = std.c.socket(std.posix.AF.INET, std.posix.SOCK.STREAM, std.posix.IPPROTO.TCP);
+        try std.testing.expect(listen_fd >= 0);
+        _ = std.c.setsockopt(listen_fd, std.posix.SOL.SOCKET, std.posix.SO.REUSEADDR, std.mem.asBytes(&@as(c_int, 1)), @sizeOf(c_int));
+        var sin: std.c.sockaddr.in = .{
+            .family = std.posix.AF.INET,
+            .port = std.mem.nativeToBig(u16, 0),
+            .addr = std.mem.nativeToBig(u32, 0x7f000001),
+            .zero = [_]u8{0} ** 8,
+        };
+        try std.testing.expect(std.c.bind(listen_fd, @ptrCast(&sin), @sizeOf(std.c.sockaddr.in)) == 0);
+        try std.testing.expect(std.c.listen(listen_fd, 8) == 0);
+        var bound: std.c.sockaddr.in = undefined;
+        var bound_len: std.c.socklen_t = @sizeOf(std.c.sockaddr.in);
+        try std.testing.expect(std.c.getsockname(listen_fd, @ptrCast(&bound), &bound_len) == 0);
+        return .{
+            .allocator = allocator,
+            .listen_fd = listen_fd,
+            .listen_port = std.mem.bigToNative(u16, bound.port),
+            .statuses = statuses,
+        };
+    }
+
+    fn run(self: *H3ProxyOrigin) !void {
+        self.thread = try std.Thread.spawn(.{}, H3ProxyOrigin.threadMain, .{self});
+    }
+
+    fn stop(self: *H3ProxyOrigin) void {
+        if (self.thread) |_| {
+            if (compat.tcpConnectToHost(self.allocator, "127.0.0.1", self.port())) |stream| {
+                stream.close();
+            } else |_| {}
+        }
+        if (self.thread) |thread| thread.join();
+        _ = std.c.close(self.listen_fd);
+        self.mutex.lock();
+        for (self.requests.items) |raw| self.allocator.free(raw);
+        self.requests.deinit(self.allocator);
+        self.mutex.unlock();
+        self.* = undefined;
+    }
+
+    fn port(self: *const H3ProxyOrigin) u16 {
+        return self.listen_port;
+    }
+
+    fn requestCount(self: *H3ProxyOrigin) usize {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        return self.requests.items.len;
+    }
+
+    fn requestContains(self: *H3ProxyOrigin, index: usize, needle: []const u8) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (index >= self.requests.items.len) return false;
+        return std.mem.indexOf(u8, self.requests.items[index], needle) != null;
+    }
+
+    fn threadMain(self: *H3ProxyOrigin) void {
+        var idx: usize = 0;
+        while (idx < self.statuses.len) : (idx += 1) {
+            const fd = std.c.accept(self.listen_fd, null, null);
+            if (fd < 0) return;
+            defer _ = std.c.close(fd);
+            var raw = std.ArrayList(u8).empty;
+            defer raw.deinit(self.allocator);
+            var buf: [1024]u8 = undefined;
+            while (true) {
+                const n = std.c.read(fd, &buf, buf.len);
+                if (n == 0) return;
+                if (n < 0) return;
+                raw.appendSlice(self.allocator, buf[0..@intCast(n)]) catch return;
+                if (std.mem.indexOf(u8, raw.items, "\r\n\r\n") != null) break;
+            }
+            const owned = self.allocator.dupe(u8, raw.items) catch return;
+            self.mutex.lock();
+            self.requests.append(self.allocator, owned) catch {
+                self.mutex.unlock();
+                self.allocator.free(owned);
+                return;
+            };
+            self.mutex.unlock();
+            const body = if (self.statuses[idx] == 200) "ok" else "too early";
+            var response_buf: [256]u8 = undefined;
+            const response = std.fmt.bufPrint(&response_buf, "HTTP/1.1 {d} test\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n{s}", .{
+                self.statuses[idx], body.len, body,
+            }) catch return;
+            _ = std.c.write(fd, response.ptr, response.len);
+        }
+    }
+};
+
+const H3ParkCapture = struct {
+    parked: ?http.http3_session.StreamRequest.Early425RetryContinuation = null,
+
+    fn park(ctx: *anyopaque, continuation: http.http3_session.StreamRequest.Early425RetryContinuation) anyerror!void {
+        const self: *H3ParkCapture = @ptrCast(@alignCast(ctx));
+        if (self.parked != null) return error.TestDuplicatePark;
+        self.parked = continuation;
+    }
+
+    fn take(self: *H3ParkCapture) http.http3_session.StreamRequest.Early425RetryContinuation {
+        const parked = self.parked.?;
+        self.parked = null;
+        return parked;
+    }
+};
+
+const TestHttp3RequestHandshake = struct {
+    complete: bool = false,
+
+    fn isComplete(ctx: *anyopaque) bool {
+        const self: *TestHttp3RequestHandshake = @ptrCast(@alignCast(ctx));
+        return self.complete;
+    }
+
+    fn waitOrDrive(_: *anyopaque) anyerror!void {}
+
+    fn barrier(self: *TestHttp3RequestHandshake) http.request_context.DownstreamHandshakeBarrier {
+        return .{
+            .ctx = self,
+            .is_complete_fn = isComplete,
+            .wait_or_drive_fn = waitOrDrive,
+        };
+    }
+};
+
+test "h3 proxy early 425 parks and resumes exact ordinary continuation" {
+    const allocator = std.testing.allocator;
+    var origin = try H3ProxyOrigin.start(allocator, &.{ 425, 200 });
+    defer origin.stop();
+    try origin.run();
+
+    const target = try std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}", .{origin.port()});
+    defer allocator.free(target);
+    var blocks = [_]http.location_router.LocationBlock{.{
+        .match_type = .prefix,
+        .pattern = "/proxy/",
+        .priority = 0,
+        .action = .{ .proxy_pass = target },
+        .early_data = .replay_safe,
+        .proxy_early_data = .rfc8470,
+    }};
+    var cfg = minimalHttp3ProxyConfig(blocks[0..]);
+    var config_store = try ReloadableConfigStore.initBorrowed(allocator, &cfg);
+    defer config_store.deinit();
+    var state: GatewayState = undefined;
+    initHttp3ProxyTestState(&state, allocator, &.{});
+    defer deinitHttp3ProxyTestState(&state);
+    var dispatch_ctx = Http3DispatchContext{
+        .config_store = &config_store,
+        .cfg = &cfg,
+        .state = &state,
+    };
+    var barrier = TestHttp3RequestHandshake{ .complete = false };
+    var capture = H3ParkCapture{};
+    var request = http.http3_session.StreamRequest{
+        .allocator = allocator,
+        .stream_id = 7,
+        .method = try allocator.dupe(u8, "GET"),
+        .path = try allocator.dupe(u8, "/proxy/item"),
+        .authority = null,
+        .headers = http.Headers.init(allocator),
+        .body = try allocator.alloc(u8, 0),
+        .transport_early = true,
+        .downstream_handshake = barrier.barrier(),
+        .park_early_425_retry = .{ .ctx = &capture, .park_fn = H3ParkCapture.park },
+    };
+    defer request.deinit();
+    var first_response = http.Response.init(allocator);
+    defer first_response.deinit();
+
+    try std.testing.expectError(error.Http3RequestParked, handleHttp3Request(allocator, &request, &first_response, &dispatch_ctx));
+    try std.testing.expectEqual(@as(usize, 1), origin.requestCount());
+    try std.testing.expect(origin.requestContains(0, "\r\nEarly-Data: 1\r\n"));
+    try std.testing.expect(capture.parked != null);
+    try std.testing.expect(request.transport_early);
+
+    var continuation = capture.take();
+    defer continuation.deinit(allocator);
+    const plan: *Http3Early425ProxyContinuation = @ptrCast(@alignCast(continuation.ctx));
+    try std.testing.expect(plan.transport_early);
+    blocks[0].action = .{ .return_response = .{ .status = 418, .body = "reloaded" } };
+    blocks[0].early_data = .off;
+    var resumed_response = http.Response.init(allocator);
+    defer resumed_response.deinit();
+    try continuation.run(allocator, &resumed_response);
+
+    try std.testing.expectEqual(@as(usize, 2), origin.requestCount());
+    try std.testing.expect(!origin.requestContains(1, "\r\nEarly-Data: 1\r\n"));
+    try std.testing.expectEqual(@as(u16, 200), @intFromEnum(resumed_response.status));
+    try std.testing.expectEqualStrings("ok", resumed_response.body orelse "");
+
+    const prom = try state.metrics.toPrometheus(allocator);
+    defer allocator.free(prom);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_requests_total{protocol=\"h3\",source=\"transport\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_decisions_total{protocol=\"h3\",decision=\"forwarded\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_upstream_425_total{action=\"retried\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_retry_total{result=\"success\"} 1") != null);
+}
+
+test "h3 proxy parked early 425 forwards second 425 without third delivery" {
+    const allocator = std.testing.allocator;
+    var origin = try H3ProxyOrigin.start(allocator, &.{ 425, 425, 200 });
+    defer origin.stop();
+    try origin.run();
+
+    const target = try std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}", .{origin.port()});
+    defer allocator.free(target);
+    var blocks = [_]http.location_router.LocationBlock{.{
+        .match_type = .prefix,
+        .pattern = "/proxy/",
+        .priority = 0,
+        .action = .{ .proxy_pass = target },
+        .early_data = .replay_safe,
+        .proxy_early_data = .rfc8470,
+    }};
+    var cfg = minimalHttp3ProxyConfig(blocks[0..]);
+    var config_store = try ReloadableConfigStore.initBorrowed(allocator, &cfg);
+    defer config_store.deinit();
+    var state: GatewayState = undefined;
+    initHttp3ProxyTestState(&state, allocator, &.{});
+    defer deinitHttp3ProxyTestState(&state);
+    var dispatch_ctx = Http3DispatchContext{
+        .config_store = &config_store,
+        .cfg = &cfg,
+        .state = &state,
+    };
+    var barrier = TestHttp3RequestHandshake{ .complete = false };
+    var capture = H3ParkCapture{};
+    var request = http.http3_session.StreamRequest{
+        .allocator = allocator,
+        .stream_id = 9,
+        .method = try allocator.dupe(u8, "GET"),
+        .path = try allocator.dupe(u8, "/proxy/item"),
+        .authority = null,
+        .headers = http.Headers.init(allocator),
+        .body = try allocator.alloc(u8, 0),
+        .transport_early = true,
+        .downstream_handshake = barrier.barrier(),
+        .park_early_425_retry = .{ .ctx = &capture, .park_fn = H3ParkCapture.park },
+    };
+    defer request.deinit();
+    var first_response = http.Response.init(allocator);
+    defer first_response.deinit();
+
+    try std.testing.expectError(error.Http3RequestParked, handleHttp3Request(allocator, &request, &first_response, &dispatch_ctx));
+    try std.testing.expectEqual(@as(usize, 1), origin.requestCount());
+    try std.testing.expect(origin.requestContains(0, "\r\nEarly-Data: 1\r\n"));
+
+    var continuation = capture.take();
+    defer continuation.deinit(allocator);
+    var resumed_response = http.Response.init(allocator);
+    defer resumed_response.deinit();
+    try continuation.run(allocator, &resumed_response);
+
+    try std.testing.expectEqual(@as(usize, 2), origin.requestCount());
+    try std.testing.expect(!origin.requestContains(1, "\r\nEarly-Data: 1\r\n"));
+    try std.testing.expectEqual(@as(u16, 425), @intFromEnum(resumed_response.status));
+
+    const prom = try state.metrics.toPrometheus(allocator);
+    defer allocator.free(prom);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_upstream_425_total{action=\"retried\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_upstream_425_total{action=\"forwarded\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_retry_total{result=\"too_early\"} 1") != null);
+}
+
+test "h3 proxy parked early 425 fails without origin retry after budget expires" {
+    const allocator = std.testing.allocator;
+    var origin = try H3ProxyOrigin.start(allocator, &.{ 425, 200 });
+    defer origin.stop();
+    try origin.run();
+
+    const target = try std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}", .{origin.port()});
+    defer allocator.free(target);
+    var blocks = [_]http.location_router.LocationBlock{.{
+        .match_type = .prefix,
+        .pattern = "/proxy/",
+        .priority = 0,
+        .action = .{ .proxy_pass = target },
+        .early_data = .replay_safe,
+        .proxy_early_data = .rfc8470,
+    }};
+    var cfg = minimalHttp3ProxyConfig(blocks[0..]);
+    cfg.upstream_timeout_budget_ms = 1;
+    var config_store = try ReloadableConfigStore.initBorrowed(allocator, &cfg);
+    defer config_store.deinit();
+    var state: GatewayState = undefined;
+    initHttp3ProxyTestState(&state, allocator, &.{});
+    defer deinitHttp3ProxyTestState(&state);
+    var dispatch_ctx = Http3DispatchContext{
+        .config_store = &config_store,
+        .cfg = &cfg,
+        .state = &state,
+    };
+    var barrier = TestHttp3RequestHandshake{ .complete = false };
+    var capture = H3ParkCapture{};
+    var request = http.http3_session.StreamRequest{
+        .allocator = allocator,
+        .stream_id = 11,
+        .method = try allocator.dupe(u8, "GET"),
+        .path = try allocator.dupe(u8, "/proxy/item"),
+        .authority = null,
+        .headers = http.Headers.init(allocator),
+        .body = try allocator.alloc(u8, 0),
+        .transport_early = true,
+        .downstream_handshake = barrier.barrier(),
+        .park_early_425_retry = .{ .ctx = &capture, .park_fn = H3ParkCapture.park },
+    };
+    defer request.deinit();
+    var first_response = http.Response.init(allocator);
+    defer first_response.deinit();
+
+    try std.testing.expectError(error.Http3RequestParked, handleHttp3Request(allocator, &request, &first_response, &dispatch_ctx));
+    try std.testing.expectEqual(@as(usize, 1), origin.requestCount());
+    compat.sleepNs(3 * std.time.ns_per_ms);
+
+    var continuation = capture.take();
+    defer continuation.deinit(allocator);
+    var resumed_response = http.Response.init(allocator);
+    defer resumed_response.deinit();
+    try continuation.run(allocator, &resumed_response);
+
+    try std.testing.expectEqual(@as(usize, 1), origin.requestCount());
+    try std.testing.expectEqual(@as(u16, 504), @intFromEnum(resumed_response.status));
+
+    const prom = try state.metrics.toPrometheus(allocator);
+    defer allocator.free(prom);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_upstream_425_total{action=\"retried\"} 1") == null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_retry_total{result=\"failure\"} 1") != null);
+}
+
 fn handleHttp3Connection(
     allocator: std.mem.Allocator,
     request: *const http.http3_session.StreamRequest,
@@ -2660,6 +3228,7 @@ pub fn handleHttp3Request(
 
     var effective_ctx = ctx.*;
     effective_ctx.cfg = effective_cfg;
+    effective_ctx.cfg_lease = &cfg_lease;
     try handleHttp3Connection(allocator, request, response, &effective_ctx);
 }
 

--- a/src/gateway_handlers.zig
+++ b/src/gateway_handlers.zig
@@ -82,17 +82,13 @@ pub fn resolveRoutePath(
     return .unmatched;
 }
 
-fn methodEarlyDataSafe(method: http.Method) bool {
-    return http.early_data.methodSafe(method.toString());
-}
-
 fn routeReplaySafe(block: *const http.location_router.LocationBlock) bool {
     return block.early_data == .replay_safe;
 }
 
 fn locationEarlyDataDecision(
     early_ctx: http.request_context.EarlyDataContext,
-    method: http.Method,
+    method_safe: bool,
     block: *const http.location_router.LocationBlock,
 ) http.early_data.Decision {
     if (block.auth == .required) return .too_early;
@@ -101,7 +97,7 @@ fn locationEarlyDataDecision(
             .replay_exposed = early_ctx.replayExposed(),
             .transport_early = early_ctx.transport_early,
             .inbound_marker = early_ctx.inbound_marker,
-            .method_safe = methodEarlyDataSafe(method),
+            .method_safe = method_safe,
             .route_replay_safe = routeReplaySafe(block),
             .action_class = .local,
             .proxy_origin_rfc8470 = false,
@@ -110,7 +106,7 @@ fn locationEarlyDataDecision(
             .replay_exposed = early_ctx.replayExposed(),
             .transport_early = early_ctx.transport_early,
             .inbound_marker = early_ctx.inbound_marker,
-            .method_safe = methodEarlyDataSafe(method),
+            .method_safe = method_safe,
             .route_replay_safe = routeReplaySafe(block),
             .action_class = .proxy,
             .proxy_origin_rfc8470 = block.proxy_early_data == .rfc8470,
@@ -133,14 +129,24 @@ pub fn earlyDataDecisionForRequest(
     path: []const u8,
     has_body_framing: bool,
 ) http.early_data.Decision {
+    return earlyDataDecisionForRawMethod(cfg, early_ctx, method.toString(), path, has_body_framing);
+}
+
+pub fn earlyDataDecisionForRawMethod(
+    cfg: *const edge_config.EdgeConfig,
+    early_ctx: http.request_context.EarlyDataContext,
+    method: []const u8,
+    path: []const u8,
+    has_body_framing: bool,
+) http.early_data.Decision {
     if (!early_ctx.replayExposed()) return .ordinary;
     if (has_body_framing) return .too_early;
     if (isTranscriptRoutePath(path)) return .too_early;
-    if (hasMatchingMirrorRule(cfg.mirror_rules, method.toString(), path)) return .too_early;
+    if (hasMatchingMirrorRule(cfg.mirror_rules, method, path)) return .too_early;
 
     return switch (resolveRoutePath(cfg.metrics_path, cfg.location_blocks, path)) {
         .reload_status, .metrics, .unmatched => .too_early,
-        .location => |matched| locationEarlyDataDecision(early_ctx, method, matched.block),
+        .location => |matched| locationEarlyDataDecision(early_ctx, http.early_data.methodSafe(method), matched.block),
     };
 }
 
@@ -1699,6 +1705,7 @@ fn handleHttp3LocationProxyPass(
     request_query: ?[]const u8,
     target: []const u8,
     correlation_id: []const u8,
+    forward_early_data: bool,
 ) !void {
     const resolved = try resolveProxyTarget(allocator, ctx.cfg.upstream_base_url, target, proxySuffixPathForLocation(request_path, matched, ctx.cfg.location_blocks));
     defer allocator.free(resolved.url);
@@ -1721,7 +1728,7 @@ fn handleHttp3LocationProxyPass(
         null,
         null,
         null,
-        false,
+        forward_early_data,
         ctx.cfg.upstream_timeout_ms,
         ctx.cfg.upstream_connect_timeout_ms,
         ctx.cfg.upstream_response_timeout_ms,
@@ -1892,14 +1899,14 @@ fn routeHttp3Location(
         ctx.state.metricsRecordEarlyDataRequest(.h3, source);
     }
 
-    const method = http.Method.parse(request.method) orelse .GET;
-    const decision = earlyDataDecisionForRequest(
+    const decision = earlyDataDecisionForRawMethod(
         ctx.cfg,
         early_ctx,
-        method,
+        request.method,
         request_path,
         request.body.len != 0,
     );
+    const forward_early_data = decision == .forward_rfc8470;
     switch (decision) {
         .execute_local => {
             ctx.state.metricsRecordEarlyDataDecision(.h3, .accepted);
@@ -1933,7 +1940,7 @@ fn routeHttp3Location(
     }
     switch (matched.block.action) {
         .proxy_pass => |target| {
-            try handleHttp3LocationProxyPass(allocator, request, response, ctx, matched, request_path, request_query, target, correlation_id);
+            try handleHttp3LocationProxyPass(allocator, request, response, ctx, matched, request_path, request_query, target, correlation_id, forward_early_data);
             return .handled;
         },
         .return_response => |ret| {
@@ -2089,6 +2096,49 @@ test "routeHttp3Location accepts replay-safe current-hop transport provenance" {
     defer allocator.free(prom);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_requests_total{protocol=\"h3\",source=\"transport\"} 1") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_decisions_total{protocol=\"h3\",decision=\"accepted\"} 1") != null);
+}
+
+test "routeHttp3Location rejects unknown replay-exposed methods before action execution" {
+    const allocator = std.testing.allocator;
+    var state: GatewayState = undefined;
+    initHandlerTestState(&state, allocator, &.{});
+    var blocks = [_]http.location_router.LocationBlock{.{
+        .match_type = .exact,
+        .pattern = "/safe",
+        .priority = 0,
+        .action = .{ .return_response = .{ .status = 200, .body = "side-effect" } },
+        .early_data = .replay_safe,
+    }};
+    var token_hashes = [_][]const u8{};
+    var cfg = minimalAuthConfig(blocks[0..], token_hashes[0..]);
+    var config_store: ReloadableConfigStore = undefined;
+    var dispatch_ctx = Http3DispatchContext{
+        .config_store = &config_store,
+        .cfg = &cfg,
+        .state = &state,
+    };
+    var request = http.http3_session.StreamRequest{
+        .allocator = allocator,
+        .method = try allocator.dupe(u8, "FOO"),
+        .path = try allocator.dupe(u8, "/safe"),
+        .authority = null,
+        .headers = http.Headers.init(allocator),
+        .body = try allocator.alloc(u8, 0),
+        .transport_early = true,
+    };
+    defer request.deinit();
+    var response = http.Response.init(allocator);
+    defer response.deinit();
+
+    const outcome = try routeHttp3Location(allocator, &request, &response, &dispatch_ctx, "/safe", "h3-unknown-method");
+
+    try std.testing.expectEqual(std.meta.Tag(Http3LocationOutcome).handled, std.meta.activeTag(outcome));
+    try std.testing.expectEqual(@as(u16, 425), @intFromEnum(response.status));
+    try std.testing.expect(std.mem.indexOf(u8, response.body orelse "", "side-effect") == null);
+    try std.testing.expect(std.mem.indexOf(u8, response.body orelse "", "\"code\":\"too_early\"") != null);
+    const prom = try state.metrics.toPrometheus(allocator);
+    defer allocator.free(prom);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_decisions_total{protocol=\"h3\",decision=\"too_early\"} 1") != null);
 }
 
 test "routeHttp3Location replay-safe acceptance handles combined prior-hop and current-hop provenance" {

--- a/src/gateway_handlers.zig
+++ b/src/gateway_handlers.zig
@@ -2011,6 +2011,8 @@ const Http3Early425ProxyContinuation = struct {
     budget_start_ms: u64,
     last_attempt_start_ms: u64 = 0,
     transport_early: bool,
+    test_execute_ctx: ?*anyopaque = null,
+    test_execute_fn: ?*const fn (?*anyopaque, *Http3Early425ProxyContinuation, u32, bool) anyerror!gproxy_runtime.DataPlaneProxyResponse = null,
 
     fn init(
         allocator: std.mem.Allocator,
@@ -2093,7 +2095,10 @@ const Http3Early425ProxyContinuation = struct {
         return @intCast(@min(@as(u64, self.cfg_snapshot.upstream_timeout_ms), remaining));
     }
 
-    fn execute(self: *Http3Early425ProxyContinuation, per_attempt_timeout_ms: u32) !gproxy_runtime.DataPlaneProxyResponse {
+    fn execute(self: *Http3Early425ProxyContinuation, per_attempt_timeout_ms: u32, forward_early_data: bool) !gproxy_runtime.DataPlaneProxyResponse {
+        if (self.test_execute_fn) |test_execute| {
+            return test_execute(self.test_execute_ctx, self, per_attempt_timeout_ms, forward_early_data);
+        }
         self.state.recordUpstreamAttemptStart(self.selection_base_url);
         self.last_attempt_start_ms = http.event_loop.monotonicMs();
         const resp = executeBufferedDataPlaneProxyRequest(
@@ -2112,7 +2117,7 @@ const Http3Early425ProxyContinuation = struct {
             null,
             null,
             null,
-            false,
+            forward_early_data,
             per_attempt_timeout_ms,
             self.cfg_snapshot.upstream_connect_timeout_ms,
             self.cfg_snapshot.upstream_response_timeout_ms,
@@ -2127,45 +2132,59 @@ const Http3Early425ProxyContinuation = struct {
     fn run(ctx: *anyopaque, allocator: std.mem.Allocator, response: *http.Response) !void {
         const self: *Http3Early425ProxyContinuation = @ptrCast(@alignCast(ctx));
         std.debug.assert(self.transport_early);
-        const per_attempt_timeout_ms = self.perAttemptTimeoutMs() catch |err| {
-            self.state.metricsRecordEarlyDataRetry(.failure);
-            if (err == error.OutOfMemory) return error.OutOfMemory;
-            try rejectHttp3ProxyErrorWithState(allocator, response, self.state, .gateway_timeout, "upstream_timeout", "Upstream request timed out", self.correlation_id);
-            return;
-        };
-        self.state.metricsRecordEarlyDataUpstream425(.retried);
-        var upstream_response = self.execute(per_attempt_timeout_ms) catch |err| {
-            self.state.metricsRecordEarlyDataRetry(.failure);
-            if (err == error.ProxyBudgetExhausted or err == error.RequestCancelled) {
+        const max_stale_conn_retries: usize = 2;
+        var stale_conn_retries: usize = 0;
+        var retried_recorded = false;
+        while (true) {
+            const per_attempt_timeout_ms = self.perAttemptTimeoutMs() catch |err| {
+                self.state.metricsRecordEarlyDataRetry(.failure);
+                if (err == error.OutOfMemory) return error.OutOfMemory;
                 try rejectHttp3ProxyErrorWithState(allocator, response, self.state, .gateway_timeout, "upstream_timeout", "Upstream request timed out", self.correlation_id);
                 return;
-            }
-            if (err == error.UpstreamAtCapacity) {
-                try rejectHttp3ProxyErrorWithState(allocator, response, self.state, .service_unavailable, "upstream_saturated", "Upstream connection limit reached", self.correlation_id);
-                return;
-            }
-            self.state.recordUpstreamFailure(&self.cfg_snapshot, self.selection_base_url);
-            if (err == error.OutOfMemory) return error.OutOfMemory;
-            const err_status: http.Status = switch (err) {
-                error.Timeout, error.TimedOut, error.WouldBlock => .gateway_timeout,
-                else => .bad_gateway,
             };
-            const err_code = if (err_status == .gateway_timeout) "upstream_timeout" else "upstream_error";
-            const err_msg = if (err_status == .gateway_timeout) "Upstream request timed out" else "Upstream connection failed";
-            try rejectHttp3ProxyErrorWithState(allocator, response, self.state, err_status, err_code, err_msg, self.correlation_id);
+            if (!retried_recorded) {
+                self.state.metricsRecordEarlyDataUpstream425(.retried);
+                retried_recorded = true;
+            }
+            var upstream_response = self.execute(per_attempt_timeout_ms, false) catch |err| {
+                if (gproxy_runtime.shouldRetryStaleUpstreamConnection(err, self.method, stale_conn_retries, max_stale_conn_retries, true)) {
+                    stale_conn_retries += 1;
+                    self.state.logger.warn(self.correlation_id, "h3 parked proxy retrying on fresh connection after stale upstream keep-alive ({d}/{d})", .{ stale_conn_retries, max_stale_conn_retries });
+                    continue;
+                }
+                self.state.metricsRecordEarlyDataRetry(.failure);
+                if (err == error.ProxyBudgetExhausted or err == error.RequestCancelled) {
+                    try rejectHttp3ProxyErrorWithState(allocator, response, self.state, .gateway_timeout, "upstream_timeout", "Upstream request timed out", self.correlation_id);
+                    return;
+                }
+                if (err == error.UpstreamAtCapacity) {
+                    try rejectHttp3ProxyErrorWithState(allocator, response, self.state, .service_unavailable, "upstream_saturated", "Upstream connection limit reached", self.correlation_id);
+                    return;
+                }
+                self.state.recordUpstreamFailure(&self.cfg_snapshot, self.selection_base_url);
+                if (err == error.OutOfMemory) return error.OutOfMemory;
+                const err_status: http.Status = switch (err) {
+                    error.Timeout, error.TimedOut, error.WouldBlock => .gateway_timeout,
+                    else => .bad_gateway,
+                };
+                const err_code = if (err_status == .gateway_timeout) "upstream_timeout" else "upstream_error";
+                const err_msg = if (err_status == .gateway_timeout) "Upstream request timed out" else "Upstream connection failed";
+                try rejectHttp3ProxyErrorWithState(allocator, response, self.state, err_status, err_code, err_msg, self.correlation_id);
+                return;
+            };
+            defer upstream_response.deinit(allocator);
+            const upstream_ttfb_ms = http.event_loop.monotonicMs() - self.last_attempt_start_ms;
+            self.state.metricsRecordProxyBufferedRequest(upstream_response.bodyLen(), upstream_ttfb_ms);
+            defer self.state.metricsReleaseProxyBufferedBytes(upstream_response.bodyLen());
+            if (upstream_response.statusCode() == @intFromEnum(http.Status.too_early)) {
+                self.state.metricsRecordEarlyDataUpstream425(.forwarded);
+                self.state.metricsRecordEarlyDataRetry(.too_early);
+            } else {
+                self.state.metricsRecordEarlyDataRetry(.success);
+            }
+            try applyHttp3ProxyResponse(allocator, response, self.state, &upstream_response, self.correlation_id);
             return;
-        };
-        defer upstream_response.deinit(allocator);
-        const upstream_ttfb_ms = http.event_loop.monotonicMs() - self.last_attempt_start_ms;
-        self.state.metricsRecordProxyBufferedRequest(upstream_response.bodyLen(), upstream_ttfb_ms);
-        defer self.state.metricsReleaseProxyBufferedBytes(upstream_response.bodyLen());
-        if (upstream_response.statusCode() == @intFromEnum(http.Status.too_early)) {
-            self.state.metricsRecordEarlyDataUpstream425(.forwarded);
-            self.state.metricsRecordEarlyDataRetry(.too_early);
-        } else {
-            self.state.metricsRecordEarlyDataRetry(.success);
         }
-        try applyHttp3ProxyResponse(allocator, response, self.state, &upstream_response, self.correlation_id);
     }
 };
 
@@ -2945,6 +2964,52 @@ const TestHttp3RequestHandshake = struct {
     }
 };
 
+const H3ContinuationAttempt = union(enum) {
+    status: u16,
+    err: anyerror,
+};
+
+const H3ContinuationExecuteScript = struct {
+    allocator: std.mem.Allocator,
+    attempts: []const H3ContinuationAttempt,
+    calls: usize = 0,
+    forward_early_data: std.ArrayList(bool) = .empty,
+    timeouts_ms: std.ArrayList(u32) = .empty,
+
+    fn deinit(self: *H3ContinuationExecuteScript) void {
+        self.forward_early_data.deinit(self.allocator);
+        self.timeouts_ms.deinit(self.allocator);
+    }
+
+    fn execute(
+        ctx: ?*anyopaque,
+        continuation: *Http3Early425ProxyContinuation,
+        per_attempt_timeout_ms: u32,
+        forward_early_data: bool,
+    ) !gproxy_runtime.DataPlaneProxyResponse {
+        const self: *H3ContinuationExecuteScript = @ptrCast(@alignCast(ctx.?));
+        try self.forward_early_data.append(self.allocator, forward_early_data);
+        try self.timeouts_ms.append(self.allocator, per_attempt_timeout_ms);
+        continuation.last_attempt_start_ms = http.event_loop.monotonicMs();
+        const attempt = self.calls;
+        self.calls += 1;
+        if (attempt >= self.attempts.len) return error.TestMissingContinuationAttempt;
+        return switch (self.attempts[attempt]) {
+            .err => |err| err,
+            .status => |status| response: {
+                const body = if (status == 200) "ok" else "too early";
+                const raw = try std.fmt.allocPrint(
+                    self.allocator,
+                    "HTTP/1.1 {d} test\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n{s}",
+                    .{ status, body.len, body },
+                );
+                defer self.allocator.free(raw);
+                break :response .{ .bounded_buffered = try gp.parseBufferedUpstreamResponse(self.allocator, raw) };
+            },
+        };
+    }
+};
+
 test "h3 proxy early 425 parks and resumes exact ordinary continuation" {
     const allocator = std.testing.allocator;
     var origin = try H3ProxyOrigin.start(allocator, &.{ 425, 200 });
@@ -3083,6 +3148,174 @@ test "h3 proxy parked early 425 forwards second 425 without third delivery" {
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_upstream_425_total{action=\"retried\"} 1") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_upstream_425_total{action=\"forwarded\"} 1") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_retry_total{result=\"too_early\"} 1") != null);
+}
+
+test "h3 proxy parked early 425 treats stale ordinary retry as transparent" {
+    const allocator = std.testing.allocator;
+    var origin = try H3ProxyOrigin.start(allocator, &.{425});
+    defer origin.stop();
+    try origin.run();
+
+    const target = try std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}", .{origin.port()});
+    defer allocator.free(target);
+    var blocks = [_]http.location_router.LocationBlock{.{
+        .match_type = .prefix,
+        .pattern = "/proxy/",
+        .priority = 0,
+        .action = .{ .proxy_pass = target },
+        .early_data = .replay_safe,
+        .proxy_early_data = .rfc8470,
+    }};
+    var cfg = minimalHttp3ProxyConfig(blocks[0..]);
+    cfg.upstream_timeout_ms = 0;
+    cfg.upstream_timeout_budget_ms = 10_000;
+    cfg.upstream_max_fails = 1;
+    var config_store = try ReloadableConfigStore.initBorrowed(allocator, &cfg);
+    defer config_store.deinit();
+    var state: GatewayState = undefined;
+    initHttp3ProxyTestState(&state, allocator, &.{});
+    defer deinitHttp3ProxyTestState(&state);
+    var dispatch_ctx = Http3DispatchContext{
+        .config_store = &config_store,
+        .cfg = &cfg,
+        .state = &state,
+    };
+    var barrier = TestHttp3RequestHandshake{ .complete = false };
+    var capture = H3ParkCapture{};
+    var request = http.http3_session.StreamRequest{
+        .allocator = allocator,
+        .stream_id = 13,
+        .method = try allocator.dupe(u8, "GET"),
+        .path = try allocator.dupe(u8, "/proxy/item"),
+        .authority = null,
+        .headers = http.Headers.init(allocator),
+        .body = try allocator.alloc(u8, 0),
+        .transport_early = true,
+        .downstream_handshake = barrier.barrier(),
+        .park_early_425_retry = .{ .ctx = &capture, .park_fn = H3ParkCapture.park },
+    };
+    defer request.deinit();
+    var first_response = http.Response.init(allocator);
+    defer first_response.deinit();
+
+    try std.testing.expectError(error.Http3RequestParked, handleHttp3Request(allocator, &request, &first_response, &dispatch_ctx));
+    try std.testing.expectEqual(@as(usize, 1), origin.requestCount());
+    try std.testing.expect(origin.requestContains(0, "\r\nEarly-Data: 1\r\n"));
+
+    var continuation = capture.take();
+    defer continuation.deinit(allocator);
+    const plan: *Http3Early425ProxyContinuation = @ptrCast(@alignCast(continuation.ctx));
+    const original_budget_start_ms = plan.budget_start_ms;
+    const scripted = [_]H3ContinuationAttempt{
+        .{ .err = error.HttpConnectionClosing },
+        .{ .status = 200 },
+    };
+    var execute_script = H3ContinuationExecuteScript{
+        .allocator = allocator,
+        .attempts = &scripted,
+    };
+    defer execute_script.deinit();
+    plan.test_execute_ctx = &execute_script;
+    plan.test_execute_fn = H3ContinuationExecuteScript.execute;
+
+    var resumed_response = http.Response.init(allocator);
+    defer resumed_response.deinit();
+    try continuation.run(allocator, &resumed_response);
+
+    try std.testing.expectEqual(@as(u16, 200), @intFromEnum(resumed_response.status));
+    try std.testing.expectEqualStrings("ok", resumed_response.body orelse "");
+    try std.testing.expectEqual(@as(usize, 2), execute_script.calls);
+    try std.testing.expectEqualSlices(bool, &.{ false, false }, execute_script.forward_early_data.items);
+    try std.testing.expectEqual(@as(usize, 2), execute_script.timeouts_ms.items.len);
+    try std.testing.expect(execute_script.timeouts_ms.items[1] <= execute_script.timeouts_ms.items[0]);
+    try std.testing.expectEqual(original_budget_start_ms, plan.budget_start_ms);
+    try std.testing.expectEqual(@as(usize, 0), state.upstream_health.count());
+
+    const prom = try state.metrics.toPrometheus(allocator);
+    defer allocator.free(prom);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_upstream_425_total{action=\"retried\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_retry_total{result=\"success\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_retry_total{result=\"failure\"} 0") != null);
+}
+
+test "h3 proxy parked early 425 records failure after stale recovery exhausts" {
+    const allocator = std.testing.allocator;
+    var origin = try H3ProxyOrigin.start(allocator, &.{425});
+    defer origin.stop();
+    try origin.run();
+
+    const target = try std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}", .{origin.port()});
+    defer allocator.free(target);
+    var blocks = [_]http.location_router.LocationBlock{.{
+        .match_type = .prefix,
+        .pattern = "/proxy/",
+        .priority = 0,
+        .action = .{ .proxy_pass = target },
+        .early_data = .replay_safe,
+        .proxy_early_data = .rfc8470,
+    }};
+    var cfg = minimalHttp3ProxyConfig(blocks[0..]);
+    cfg.upstream_max_fails = 1;
+    var config_store = try ReloadableConfigStore.initBorrowed(allocator, &cfg);
+    defer config_store.deinit();
+    var state: GatewayState = undefined;
+    initHttp3ProxyTestState(&state, allocator, &.{});
+    defer deinitHttp3ProxyTestState(&state);
+    var dispatch_ctx = Http3DispatchContext{
+        .config_store = &config_store,
+        .cfg = &cfg,
+        .state = &state,
+    };
+    var barrier = TestHttp3RequestHandshake{ .complete = false };
+    var capture = H3ParkCapture{};
+    var request = http.http3_session.StreamRequest{
+        .allocator = allocator,
+        .stream_id = 15,
+        .method = try allocator.dupe(u8, "GET"),
+        .path = try allocator.dupe(u8, "/proxy/item"),
+        .authority = null,
+        .headers = http.Headers.init(allocator),
+        .body = try allocator.alloc(u8, 0),
+        .transport_early = true,
+        .downstream_handshake = barrier.barrier(),
+        .park_early_425_retry = .{ .ctx = &capture, .park_fn = H3ParkCapture.park },
+    };
+    defer request.deinit();
+    var first_response = http.Response.init(allocator);
+    defer first_response.deinit();
+
+    try std.testing.expectError(error.Http3RequestParked, handleHttp3Request(allocator, &request, &first_response, &dispatch_ctx));
+    try std.testing.expectEqual(@as(usize, 1), origin.requestCount());
+
+    var continuation = capture.take();
+    defer continuation.deinit(allocator);
+    const plan: *Http3Early425ProxyContinuation = @ptrCast(@alignCast(continuation.ctx));
+    const scripted = [_]H3ContinuationAttempt{
+        .{ .err = error.HttpConnectionClosing },
+        .{ .err = error.HttpConnectionClosing },
+        .{ .err = error.HttpConnectionClosing },
+    };
+    var execute_script = H3ContinuationExecuteScript{
+        .allocator = allocator,
+        .attempts = &scripted,
+    };
+    defer execute_script.deinit();
+    plan.test_execute_ctx = &execute_script;
+    plan.test_execute_fn = H3ContinuationExecuteScript.execute;
+
+    var resumed_response = http.Response.init(allocator);
+    defer resumed_response.deinit();
+    try continuation.run(allocator, &resumed_response);
+
+    try std.testing.expectEqual(@as(u16, 502), @intFromEnum(resumed_response.status));
+    try std.testing.expectEqual(@as(usize, 3), execute_script.calls);
+    try std.testing.expectEqualSlices(bool, &.{ false, false, false }, execute_script.forward_early_data.items);
+    try std.testing.expectEqual(@as(usize, 1), state.upstream_health.count());
+
+    const prom = try state.metrics.toPrometheus(allocator);
+    defer allocator.free(prom);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_upstream_425_total{action=\"retried\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_retry_total{result=\"failure\"} 1") != null);
 }
 
 test "h3 proxy parked early 425 fails without origin retry after budget expires" {

--- a/src/gateway_handlers.zig
+++ b/src/gateway_handlers.zig
@@ -157,6 +157,15 @@ fn hasMatchingMirrorRule(
     return false;
 }
 
+fn metricsEarlyDataSource(early_ctx: http.request_context.EarlyDataContext) ?http.metrics.EarlyDataSource {
+    return switch (early_ctx.source()) {
+        .none => null,
+        .transport => .transport,
+        .header => .header,
+        .both => .both,
+    };
+}
+
 pub fn writeTooEarlyResponse(
     allocator: std.mem.Allocator,
     writer: anytype,
@@ -1874,6 +1883,48 @@ fn routeHttp3Location(
         .location => |m| m,
         .reload_status, .metrics, .unmatched => return .not_handled,
     };
+
+    const early_ctx = http.request_context.EarlyDataContext{
+        .transport_early = request.transport_early,
+        .inbound_marker = request.headers.hasEarlyDataMarker(),
+    };
+    if (metricsEarlyDataSource(early_ctx)) |source| {
+        ctx.state.metricsRecordEarlyDataRequest(.h3, source);
+    }
+
+    const method = http.Method.parse(request.method) orelse .GET;
+    const decision = earlyDataDecisionForRequest(
+        ctx.cfg,
+        early_ctx,
+        method,
+        request_path,
+        request.body.len != 0,
+    );
+    switch (decision) {
+        .execute_local => {
+            ctx.state.metricsRecordEarlyDataDecision(.h3, .accepted);
+        },
+        .forward_rfc8470 => {
+            ctx.state.metricsRecordEarlyDataDecision(.h3, .forwarded);
+        },
+        .too_early, .defer_until_handshake => {
+            ctx.state.metricsRecordEarlyDataDecision(.h3, if (decision == .defer_until_handshake) .deferred else .too_early);
+            const payload = try buildApiErrorJson(allocator, "too_early", "Too Early", correlation_id);
+            _ = response
+                .setStatus(.too_early)
+                .setBodyOwned(payload)
+                .setContentType("application/json")
+                .setHeader("cache-control", "no-store")
+                .setHeader(http.correlation.HEADER_NAME, correlation_id);
+            finalizeHttp3Response(response);
+            applyResponseHeaders(ctx.state, response);
+            ctx.state.metricsRecord(425);
+            ctx.state.metricsRecordErrorCode("too_early");
+            return .handled;
+        },
+        .ordinary => {},
+    }
+
     const split = splitHttp3PathAndQuery(request.path);
     const request_query = split[1];
     if (matched.block.auth == .required) {
@@ -1949,6 +2000,138 @@ test "routeHttp3Location rejects auth-required locations before action execution
     try std.testing.expectEqual(@as(u64, 1), state.metrics.total_requests);
     try std.testing.expectEqual(@as(u64, 1), state.metrics.status_4xx);
     try std.testing.expectEqual(@as(u64, 1), state.metrics.err_unauthorized);
+}
+
+test "routeHttp3Location rejects prior-hop Early-Data on ordinary 1-RTT before auth side effects" {
+    const allocator = std.testing.allocator;
+    var state: GatewayState = undefined;
+    initHandlerTestState(&state, allocator, &.{});
+    var blocks = [_]http.location_router.LocationBlock{.{
+        .match_type = .exact,
+        .pattern = "/private",
+        .priority = 0,
+        .action = .{ .return_response = .{ .status = 200, .body = "secret" } },
+        .early_data = .replay_safe,
+        .auth = .required,
+    }};
+    var token_hashes = [_][]const u8{};
+    var cfg = minimalAuthConfig(blocks[0..], token_hashes[0..]);
+    var config_store: ReloadableConfigStore = undefined;
+    var dispatch_ctx = Http3DispatchContext{
+        .config_store = &config_store,
+        .cfg = &cfg,
+        .state = &state,
+    };
+    var request = http.http3_session.StreamRequest{
+        .allocator = allocator,
+        .method = try allocator.dupe(u8, "GET"),
+        .path = try allocator.dupe(u8, "/private"),
+        .authority = null,
+        .headers = http.Headers.init(allocator),
+        .body = try allocator.alloc(u8, 0),
+        .transport_early = false,
+    };
+    defer request.deinit();
+    try request.headers.append("Early-Data", "1");
+    var response = http.Response.init(allocator);
+    defer response.deinit();
+
+    const outcome = try routeHttp3Location(allocator, &request, &response, &dispatch_ctx, "/private", "h3-early-header");
+
+    try std.testing.expectEqual(std.meta.Tag(Http3LocationOutcome).handled, std.meta.activeTag(outcome));
+    try std.testing.expectEqual(@as(u16, 425), @intFromEnum(response.status));
+    try std.testing.expect(std.mem.indexOf(u8, response.body orelse "", "\"code\":\"too_early\"") != null);
+    try std.testing.expectEqual(@as(u64, 0), state.metrics.err_unauthorized);
+
+    const prom = try state.metrics.toPrometheus(allocator);
+    defer allocator.free(prom);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_requests_total{protocol=\"h3\",source=\"header\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_decisions_total{protocol=\"h3\",decision=\"too_early\"} 1") != null);
+}
+
+test "routeHttp3Location accepts replay-safe current-hop transport provenance" {
+    const allocator = std.testing.allocator;
+    var state: GatewayState = undefined;
+    initHandlerTestState(&state, allocator, &.{});
+    var blocks = [_]http.location_router.LocationBlock{.{
+        .match_type = .exact,
+        .pattern = "/safe",
+        .priority = 0,
+        .action = .{ .return_response = .{ .status = 200, .body = "ok" } },
+        .early_data = .replay_safe,
+    }};
+    var token_hashes = [_][]const u8{};
+    var cfg = minimalAuthConfig(blocks[0..], token_hashes[0..]);
+    var config_store: ReloadableConfigStore = undefined;
+    var dispatch_ctx = Http3DispatchContext{
+        .config_store = &config_store,
+        .cfg = &cfg,
+        .state = &state,
+    };
+    var request = http.http3_session.StreamRequest{
+        .allocator = allocator,
+        .method = try allocator.dupe(u8, "GET"),
+        .path = try allocator.dupe(u8, "/safe"),
+        .authority = null,
+        .headers = http.Headers.init(allocator),
+        .body = try allocator.alloc(u8, 0),
+        .transport_early = true,
+    };
+    defer request.deinit();
+    var response = http.Response.init(allocator);
+    defer response.deinit();
+
+    const outcome = try routeHttp3Location(allocator, &request, &response, &dispatch_ctx, "/safe", "h3-transport");
+
+    try std.testing.expectEqual(std.meta.Tag(Http3LocationOutcome).handled, std.meta.activeTag(outcome));
+    try std.testing.expectEqual(@as(u16, 200), @intFromEnum(response.status));
+    const prom = try state.metrics.toPrometheus(allocator);
+    defer allocator.free(prom);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_requests_total{protocol=\"h3\",source=\"transport\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_decisions_total{protocol=\"h3\",decision=\"accepted\"} 1") != null);
+}
+
+test "routeHttp3Location replay-safe acceptance handles combined prior-hop and current-hop provenance" {
+    const allocator = std.testing.allocator;
+    var state: GatewayState = undefined;
+    initHandlerTestState(&state, allocator, &.{});
+    var blocks = [_]http.location_router.LocationBlock{.{
+        .match_type = .exact,
+        .pattern = "/safe",
+        .priority = 0,
+        .action = .{ .return_response = .{ .status = 200, .body = "ok" } },
+        .early_data = .replay_safe,
+    }};
+    var token_hashes = [_][]const u8{};
+    var cfg = minimalAuthConfig(blocks[0..], token_hashes[0..]);
+    var config_store: ReloadableConfigStore = undefined;
+    var dispatch_ctx = Http3DispatchContext{
+        .config_store = &config_store,
+        .cfg = &cfg,
+        .state = &state,
+    };
+    var request = http.http3_session.StreamRequest{
+        .allocator = allocator,
+        .method = try allocator.dupe(u8, "GET"),
+        .path = try allocator.dupe(u8, "/safe"),
+        .authority = null,
+        .headers = http.Headers.init(allocator),
+        .body = try allocator.alloc(u8, 0),
+        .transport_early = true,
+    };
+    defer request.deinit();
+    try request.headers.append("Early-Data", "1");
+    var response = http.Response.init(allocator);
+    defer response.deinit();
+
+    const outcome = try routeHttp3Location(allocator, &request, &response, &dispatch_ctx, "/safe", "h3-both");
+
+    try std.testing.expectEqual(std.meta.Tag(Http3LocationOutcome).handled, std.meta.activeTag(outcome));
+    try std.testing.expectEqual(@as(u16, 200), @intFromEnum(response.status));
+    const prom = try state.metrics.toPrometheus(allocator);
+    defer allocator.free(prom);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_requests_total{protocol=\"h3\",source=\"both\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_decisions_total{protocol=\"h3\",decision=\"accepted\"} 1") != null);
 }
 
 fn handleHttp3Connection(

--- a/src/gateway_handlers.zig
+++ b/src/gateway_handlers.zig
@@ -172,6 +172,18 @@ fn metricsEarlyDataSource(early_ctx: http.request_context.EarlyDataContext) ?htt
     };
 }
 
+fn h3ForwardEarlyDataMarker(early_ctx: http.request_context.EarlyDataContext, decision: http.early_data.Decision) bool {
+    if (decision != .forward_rfc8470) return false;
+    return early_ctx.inbound_marker or (early_ctx.transport_early and early_ctx.downstreamHandshakeComplete() == false);
+}
+
+fn h3RequestHandshakeComplete(ctx: *anyopaque) bool {
+    const request: *const http.http3_session.StreamRequest = @ptrCast(@alignCast(ctx));
+    return request.downstream_handshake_complete;
+}
+
+fn h3RequestDriveHandshake(_: *anyopaque) anyerror!void {}
+
 pub fn writeTooEarlyResponse(
     allocator: std.mem.Allocator,
     writer: anytype,
@@ -1894,6 +1906,11 @@ fn routeHttp3Location(
     const early_ctx = http.request_context.EarlyDataContext{
         .transport_early = request.transport_early,
         .inbound_marker = request.headers.hasEarlyDataMarker(),
+        .downstream_handshake = .{
+            .ctx = @constCast(request),
+            .is_complete_fn = h3RequestHandshakeComplete,
+            .wait_or_drive_fn = h3RequestDriveHandshake,
+        },
     };
     if (metricsEarlyDataSource(early_ctx)) |source| {
         ctx.state.metricsRecordEarlyDataRequest(.h3, source);
@@ -1906,7 +1923,7 @@ fn routeHttp3Location(
         request_path,
         request.body.len != 0,
     );
-    const forward_early_data = decision == .forward_rfc8470;
+    const forward_early_data = h3ForwardEarlyDataMarker(early_ctx, decision);
     switch (decision) {
         .execute_local => {
             ctx.state.metricsRecordEarlyDataDecision(.h3, .accepted);
@@ -2096,6 +2113,27 @@ test "routeHttp3Location accepts replay-safe current-hop transport provenance" {
     defer allocator.free(prom);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_requests_total{protocol=\"h3\",source=\"transport\"} 1") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_decisions_total{protocol=\"h3\",decision=\"accepted\"} 1") != null);
+}
+
+test "h3 RFC8470 forwarding marker uses provenance and handshake state" {
+    var dummy: u8 = 0;
+    try std.testing.expect(h3ForwardEarlyDataMarker(.{ .inbound_marker = true }, .forward_rfc8470));
+    try std.testing.expect(h3ForwardEarlyDataMarker(.{
+        .transport_early = true,
+        .downstream_handshake = .{
+            .ctx = &dummy,
+            .is_complete_fn = struct {
+                fn incomplete(_: *anyopaque) bool {
+                    return false;
+                }
+            }.incomplete,
+            .wait_or_drive_fn = struct {
+                fn drive(_: *anyopaque) anyerror!void {}
+            }.drive,
+        },
+    }, .forward_rfc8470));
+    try std.testing.expect(!h3ForwardEarlyDataMarker(.{ .transport_early = true }, .forward_rfc8470));
+    try std.testing.expect(!h3ForwardEarlyDataMarker(.{}, .ordinary));
 }
 
 test "routeHttp3Location rejects unknown replay-exposed methods before action execution" {

--- a/src/gateway_handlers.zig
+++ b/src/gateway_handlers.zig
@@ -179,10 +179,14 @@ fn h3ForwardEarlyDataMarker(early_ctx: http.request_context.EarlyDataContext, de
 
 fn h3RequestHandshakeComplete(ctx: *anyopaque) bool {
     const request: *const http.http3_session.StreamRequest = @ptrCast(@alignCast(ctx));
+    if (request.downstream_handshake) |barrier| return barrier.isComplete();
     return request.downstream_handshake_complete;
 }
 
-fn h3RequestDriveHandshake(_: *anyopaque) anyerror!void {}
+fn h3RequestDriveHandshake(ctx: *anyopaque) anyerror!void {
+    const request: *const http.http3_session.StreamRequest = @ptrCast(@alignCast(ctx));
+    if (request.downstream_handshake) |barrier| try barrier.waitOrDrive();
+}
 
 pub fn writeTooEarlyResponse(
     allocator: std.mem.Allocator,
@@ -1707,6 +1711,167 @@ fn finalizeHttp3Response(response: *http.Response) void {
         .setContentLength(if (response.body) |body| body.len else 0);
 }
 
+fn rejectHttp3ProxyError(
+    allocator: std.mem.Allocator,
+    response: *http.Response,
+    ctx: *Http3DispatchContext,
+    status: http.Status,
+    code: []const u8,
+    message: []const u8,
+    correlation_id: []const u8,
+) !void {
+    const payload = try buildApiErrorJson(allocator, code, message, correlation_id);
+    _ = response
+        .setStatus(status)
+        .setBodyOwned(payload)
+        .setContentType("application/json")
+        .setHeader(http.correlation.HEADER_NAME, correlation_id);
+    finalizeHttp3Response(response);
+    applyResponseHeaders(ctx.state, response);
+    ctx.state.metricsRecord(@intFromEnum(status));
+    ctx.state.metricsRecordErrorCode(code);
+}
+
+const Http3BufferedProxyAttemptExecutor = struct {
+    allocator: std.mem.Allocator,
+    cfg: *const edge_config.EdgeConfig,
+    state: *GatewayState,
+    upstream_url: []const u8,
+    unix_socket_path: ?[]const u8,
+    method: []const u8,
+    headers: *const http.Headers,
+    body: []const u8,
+    correlation_id: []const u8,
+    client_ip: []const u8,
+    forwarded_proto: []const u8,
+    incoming_host: ?[]const u8,
+    selection_base_url: []const u8,
+    budget_start_ms: u64,
+    last_attempt_start_ms: u64 = 0,
+
+    pub fn recordEarlyUpstream425Action(
+        self: *Http3BufferedProxyAttemptExecutor,
+        action: http.metrics.EarlyDataUpstream425Action,
+    ) void {
+        self.state.metricsRecordEarlyDataUpstream425(action);
+    }
+
+    pub fn recordEarlyRetryResult(
+        self: *Http3BufferedProxyAttemptExecutor,
+        result: http.metrics.EarlyDataRetryResult,
+    ) void {
+        self.state.metricsRecordEarlyDataRetry(result);
+    }
+
+    pub fn perAttemptTimeoutMs(self: *Http3BufferedProxyAttemptExecutor) !u32 {
+        if (self.cfg.upstream_timeout_budget_ms == 0) return self.cfg.upstream_timeout_ms;
+        const elapsed_ms = http.event_loop.monotonicMs() - self.budget_start_ms;
+        if (elapsed_ms >= self.cfg.upstream_timeout_budget_ms) return error.ProxyBudgetExhausted;
+        const remaining = self.cfg.upstream_timeout_budget_ms - elapsed_ms;
+        if (self.cfg.upstream_timeout_ms == 0) {
+            return @intCast(@min(remaining, @as(u64, std.math.maxInt(u32))));
+        }
+        return @intCast(@min(@as(u64, self.cfg.upstream_timeout_ms), remaining));
+    }
+
+    pub fn execute(
+        self: *Http3BufferedProxyAttemptExecutor,
+        attempt: usize,
+        forward_early_data: bool,
+    ) !gproxy_runtime.DataPlaneProxyResponse {
+        _ = attempt;
+        const per_attempt_timeout_ms = try self.perAttemptTimeoutMs();
+        self.state.recordUpstreamAttemptStart(self.selection_base_url);
+        self.last_attempt_start_ms = http.event_loop.monotonicMs();
+        const resp = executeBufferedDataPlaneProxyRequest(
+            self.allocator,
+            self.cfg,
+            self.upstream_url,
+            self.unix_socket_path,
+            self.method,
+            self.headers,
+            self.body,
+            self.correlation_id,
+            self.client_ip,
+            self.forwarded_proto,
+            self.incoming_host,
+            null,
+            null,
+            null,
+            null,
+            forward_early_data,
+            per_attempt_timeout_ms,
+            self.cfg.upstream_connect_timeout_ms,
+            self.cfg.upstream_response_timeout_ms,
+            null,
+            &self.state.upstream_pool,
+            &self.state.h2_pool,
+        );
+        self.state.recordUpstreamAttemptEnd(self.selection_base_url);
+        return resp;
+    }
+
+    pub fn onBufferedResponse(
+        self: *Http3BufferedProxyAttemptExecutor,
+        result: *gproxy_runtime.DataPlaneProxyResponse,
+    ) !void {
+        const upstream_ttfb_ms = http.event_loop.monotonicMs() - self.last_attempt_start_ms;
+        self.state.metricsRecordProxyBufferedRequest(result.bodyLen(), upstream_ttfb_ms);
+    }
+
+    pub fn onStaleConnectionRetry(
+        self: *Http3BufferedProxyAttemptExecutor,
+        stale_conn_retries: usize,
+        max_stale_conn_retries: usize,
+    ) !void {
+        self.state.logger.warn(self.correlation_id, "h3 proxy retrying on fresh connection after stale upstream keep-alive ({d}/{d})", .{ stale_conn_retries, max_stale_conn_retries });
+    }
+
+    pub fn onTerminalAttemptError(
+        self: *Http3BufferedProxyAttemptExecutor,
+        _: anyerror,
+    ) !void {
+        self.state.recordUpstreamFailure(self.cfg, self.selection_base_url);
+    }
+
+    pub fn onConfiguredErrorRetry(
+        self: *Http3BufferedProxyAttemptExecutor,
+        configured_attempt_index: usize,
+        max_attempts: usize,
+        err: anyerror,
+    ) !void {
+        self.state.logger.warn(self.correlation_id, "h3 proxy attempt {d}/{d} failed: {}", .{ configured_attempt_index + 1, max_attempts, err });
+    }
+
+    pub fn onEarly425Retry(
+        self: *Http3BufferedProxyAttemptExecutor,
+        result: *gproxy_runtime.DataPlaneProxyResponse,
+    ) !void {
+        self.state.logger.debug(self.correlation_id, "h3 retrying early-data upstream 425 once after downstream handshake completion", .{});
+        self.state.metricsReleaseProxyBufferedBytes(result.bodyLen());
+        result.deinit(self.allocator);
+    }
+
+    pub fn onEarly425HandshakeFailure(
+        self: *Http3BufferedProxyAttemptExecutor,
+        err: anyerror,
+    ) !void {
+        self.state.logger.warn(self.correlation_id, "h3 could not complete downstream handshake before early-data 425 retry: {}", .{err});
+    }
+
+    pub fn onConfigured5xxRetry(
+        self: *Http3BufferedProxyAttemptExecutor,
+        configured_attempt_index: usize,
+        max_attempts: usize,
+        result: *gproxy_runtime.DataPlaneProxyResponse,
+    ) !void {
+        self.state.recordUpstreamFailure(self.cfg, self.selection_base_url);
+        self.state.logger.warn(self.correlation_id, "h3 proxy attempt {d}/{d} got {d}, retrying", .{ configured_attempt_index + 1, max_attempts, result.statusCode() });
+        self.state.metricsReleaseProxyBufferedBytes(result.bodyLen());
+        result.deinit(self.allocator);
+    }
+};
+
 fn handleHttp3LocationProxyPass(
     allocator: std.mem.Allocator,
     request: *const http.http3_session.StreamRequest,
@@ -1717,6 +1882,7 @@ fn handleHttp3LocationProxyPass(
     request_query: ?[]const u8,
     target: []const u8,
     correlation_id: []const u8,
+    early_ctx: *http.request_context.EarlyDataContext,
     forward_early_data: bool,
 ) !void {
     const resolved = try resolveProxyTarget(allocator, ctx.cfg.upstream_base_url, target, proxySuffixPathForLocation(request_path, matched, ctx.cfg.location_blocks));
@@ -1724,31 +1890,56 @@ fn handleHttp3LocationProxyPass(
     var upstream_url = try appendProxyQueryString(allocator, resolved.url, request_query);
     defer upstream_url.deinit(allocator);
 
-    var upstream_response = try executeBufferedDataPlaneProxyRequest(
-        allocator,
-        ctx.cfg,
-        upstream_url.value,
-        resolved.unix_socket_path,
-        request.method,
-        &request.headers,
-        request.body,
-        correlation_id,
-        request.headers.get("x-real-ip") orelse "unknown",
-        if (edge_config.hasTlsFiles(ctx.cfg)) "https" else "http",
-        request.headers.get(":authority") orelse request.headers.get("host"),
-        null,
-        null,
-        null,
-        null,
+    const max_attempts = gproxy_runtime.proxyRetryAttemptLimit(ctx.cfg.upstream_retry_attempts, ctx.cfg.upstream_retry_idempotent_only, request.method);
+    var attempt_executor = Http3BufferedProxyAttemptExecutor{
+        .allocator = allocator,
+        .cfg = ctx.cfg,
+        .state = ctx.state,
+        .upstream_url = upstream_url.value,
+        .unix_socket_path = resolved.unix_socket_path,
+        .method = request.method,
+        .headers = &request.headers,
+        .body = request.body,
+        .correlation_id = correlation_id,
+        .client_ip = request.headers.get("x-real-ip") orelse "unknown",
+        .forwarded_proto = if (edge_config.hasTlsFiles(ctx.cfg)) "https" else "http",
+        .incoming_host = request.headers.get(":authority") orelse request.headers.get("host"),
+        .selection_base_url = ctx.cfg.upstream_base_url,
+        .budget_start_ms = http.event_loop.monotonicMs(),
+    };
+    var upstream_response: gproxy_runtime.DataPlaneProxyResponse = switch (try gproxy_runtime.runBufferedProxyAttempts(
+        early_ctx,
         forward_early_data,
-        ctx.cfg.upstream_timeout_ms,
-        ctx.cfg.upstream_connect_timeout_ms,
-        ctx.cfg.upstream_response_timeout_ms,
-        null, // HTTP/3 path: no per-request lifecycle yet
-        &ctx.state.upstream_pool,
-        &ctx.state.h2_pool,
-    );
+        request.method,
+        matched.block,
+        max_attempts,
+        2,
+        ctx.cfg.upstream_retry_idempotent_only,
+        &attempt_executor,
+    )) {
+        .response => |upstream_response| upstream_response,
+        .upstream_at_capacity => {
+            try rejectHttp3ProxyError(allocator, response, ctx, .service_unavailable, "upstream_saturated", "Upstream connection limit reached", correlation_id);
+            return;
+        },
+        .request_cancelled, .retry_budget_exhausted => {
+            try rejectHttp3ProxyError(allocator, response, ctx, .gateway_timeout, "upstream_timeout", "Upstream request timed out", correlation_id);
+            return;
+        },
+        .terminal_error => |err| {
+            if (err == error.OutOfMemory) return error.OutOfMemory;
+            const err_status: http.Status = switch (err) {
+                error.Timeout, error.TimedOut, error.WouldBlock => .gateway_timeout,
+                else => .bad_gateway,
+            };
+            const err_code = if (err_status == .gateway_timeout) "upstream_timeout" else "upstream_error";
+            const err_msg = if (err_status == .gateway_timeout) "Upstream request timed out" else "Upstream connection failed";
+            try rejectHttp3ProxyError(allocator, response, ctx, err_status, err_code, err_msg, correlation_id);
+            return;
+        },
+    };
     defer upstream_response.deinit(allocator);
+    defer ctx.state.metricsReleaseProxyBufferedBytes(upstream_response.bodyLen());
     const buffered_response = upstream_response.boundedBufferedForCompatibility();
 
     _ = response
@@ -1898,12 +2089,9 @@ fn routeHttp3Location(
     // location routes today; the reload-status and metrics endpoints (which the
     // shared resolver ranks ahead of locations) fall through to the caller's 404
     // — h3 does not expose those operational endpoints yet.
-    const matched = switch (resolveRoutePath(ctx.cfg.metrics_path, ctx.cfg.location_blocks, request_path)) {
-        .location => |m| m,
-        .reload_status, .metrics, .unmatched => return .not_handled,
-    };
+    const route_decision = resolveRoutePath(ctx.cfg.metrics_path, ctx.cfg.location_blocks, request_path);
 
-    const early_ctx = http.request_context.EarlyDataContext{
+    var early_ctx = http.request_context.EarlyDataContext{
         .transport_early = request.transport_early,
         .inbound_marker = request.headers.hasEarlyDataMarker(),
         .downstream_handshake = .{
@@ -1949,6 +2137,11 @@ fn routeHttp3Location(
         .ordinary => {},
     }
 
+    const matched = switch (route_decision) {
+        .location => |m| m,
+        .reload_status, .metrics, .unmatched => return .not_handled,
+    };
+
     const split = splitHttp3PathAndQuery(request.path);
     const request_query = split[1];
     if (matched.block.auth == .required) {
@@ -1957,7 +2150,7 @@ fn routeHttp3Location(
     }
     switch (matched.block.action) {
         .proxy_pass => |target| {
-            try handleHttp3LocationProxyPass(allocator, request, response, ctx, matched, request_path, request_query, target, correlation_id, forward_early_data);
+            try handleHttp3LocationProxyPass(allocator, request, response, ctx, matched, request_path, request_query, target, correlation_id, &early_ctx, forward_early_data);
             return .handled;
         },
         .return_response => |ret| {
@@ -2177,6 +2370,109 @@ test "routeHttp3Location rejects unknown replay-exposed methods before action ex
     const prom = try state.metrics.toPrometheus(allocator);
     defer allocator.free(prom);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_decisions_total{protocol=\"h3\",decision=\"too_early\"} 1") != null);
+}
+
+test "routeHttp3Location preflights early data before unmatched routes fall through" {
+    const allocator = std.testing.allocator;
+    var state: GatewayState = undefined;
+    initHandlerTestState(&state, allocator, &.{});
+    var blocks = [_]http.location_router.LocationBlock{};
+    var token_hashes = [_][]const u8{};
+    var cfg = minimalAuthConfig(blocks[0..], token_hashes[0..]);
+    var config_store: ReloadableConfigStore = undefined;
+    var dispatch_ctx = Http3DispatchContext{
+        .config_store = &config_store,
+        .cfg = &cfg,
+        .state = &state,
+    };
+    var request = http.http3_session.StreamRequest{
+        .allocator = allocator,
+        .method = try allocator.dupe(u8, "GET"),
+        .path = try allocator.dupe(u8, "/missing"),
+        .authority = null,
+        .headers = http.Headers.init(allocator),
+        .body = try allocator.alloc(u8, 0),
+    };
+    defer request.deinit();
+    try request.headers.append("Early-Data", "1");
+    var response = http.Response.init(allocator);
+    defer response.deinit();
+
+    const outcome = try routeHttp3Location(allocator, &request, &response, &dispatch_ctx, "/missing", "h3-missing-early");
+
+    try std.testing.expectEqual(std.meta.Tag(Http3LocationOutcome).handled, std.meta.activeTag(outcome));
+    try std.testing.expectEqual(@as(u16, 425), @intFromEnum(response.status));
+    const prom = try state.metrics.toPrometheus(allocator);
+    defer allocator.free(prom);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_requests_total{protocol=\"h3\",source=\"header\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_decisions_total{protocol=\"h3\",decision=\"too_early\"} 1") != null);
+}
+
+test "routeHttp3Location preflights transport early data before operational routes fall through" {
+    const allocator = std.testing.allocator;
+    var state: GatewayState = undefined;
+    initHandlerTestState(&state, allocator, &.{});
+    var blocks = [_]http.location_router.LocationBlock{};
+    var token_hashes = [_][]const u8{};
+    var cfg = minimalAuthConfig(blocks[0..], token_hashes[0..]);
+    var config_store: ReloadableConfigStore = undefined;
+    var dispatch_ctx = Http3DispatchContext{
+        .config_store = &config_store,
+        .cfg = &cfg,
+        .state = &state,
+    };
+    var request = http.http3_session.StreamRequest{
+        .allocator = allocator,
+        .method = try allocator.dupe(u8, "GET"),
+        .path = try allocator.dupe(u8, cfg.metrics_path),
+        .authority = null,
+        .headers = http.Headers.init(allocator),
+        .body = try allocator.alloc(u8, 0),
+        .transport_early = true,
+    };
+    defer request.deinit();
+    var response = http.Response.init(allocator);
+    defer response.deinit();
+
+    const outcome = try routeHttp3Location(allocator, &request, &response, &dispatch_ctx, cfg.metrics_path, "h3-metrics-early");
+
+    try std.testing.expectEqual(std.meta.Tag(Http3LocationOutcome).handled, std.meta.activeTag(outcome));
+    try std.testing.expectEqual(@as(u16, 425), @intFromEnum(response.status));
+    const prom = try state.metrics.toPrometheus(allocator);
+    defer allocator.free(prom);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_requests_total{protocol=\"h3\",source=\"transport\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_decisions_total{protocol=\"h3\",decision=\"too_early\"} 1") != null);
+}
+
+test "routeHttp3Location preserves ordinary unmatched not-handled behavior" {
+    const allocator = std.testing.allocator;
+    var state: GatewayState = undefined;
+    initHandlerTestState(&state, allocator, &.{});
+    var blocks = [_]http.location_router.LocationBlock{};
+    var token_hashes = [_][]const u8{};
+    var cfg = minimalAuthConfig(blocks[0..], token_hashes[0..]);
+    var config_store: ReloadableConfigStore = undefined;
+    var dispatch_ctx = Http3DispatchContext{
+        .config_store = &config_store,
+        .cfg = &cfg,
+        .state = &state,
+    };
+    var request = http.http3_session.StreamRequest{
+        .allocator = allocator,
+        .method = try allocator.dupe(u8, "GET"),
+        .path = try allocator.dupe(u8, "/missing"),
+        .authority = null,
+        .headers = http.Headers.init(allocator),
+        .body = try allocator.alloc(u8, 0),
+    };
+    defer request.deinit();
+    var response = http.Response.init(allocator);
+    defer response.deinit();
+
+    const outcome = try routeHttp3Location(allocator, &request, &response, &dispatch_ctx, "/missing", "h3-missing-ordinary");
+
+    try std.testing.expectEqual(std.meta.Tag(Http3LocationOutcome).not_handled, std.meta.activeTag(outcome));
+    try std.testing.expectEqual(@as(u16, 200), @intFromEnum(response.status));
 }
 
 test "routeHttp3Location replay-safe acceptance handles combined prior-hop and current-hop provenance" {

--- a/src/gateway_handlers.zig
+++ b/src/gateway_handlers.zig
@@ -1736,6 +1736,7 @@ const Http3BufferedProxyAttemptExecutor = struct {
     allocator: std.mem.Allocator,
     cfg: *const edge_config.EdgeConfig,
     state: *GatewayState,
+    request: *const http.http3_session.StreamRequest,
     upstream_url: []const u8,
     unix_socket_path: ?[]const u8,
     method: []const u8,
@@ -1852,6 +1853,20 @@ const Http3BufferedProxyAttemptExecutor = struct {
         result.deinit(self.allocator);
     }
 
+    pub fn parkEarly425Retry(
+        self: *Http3BufferedProxyAttemptExecutor,
+        result: *gproxy_runtime.DataPlaneProxyResponse,
+    ) !void {
+        self.state.logger.debug(self.correlation_id, "h3 parking early-data upstream 425 retry until downstream handshake completion", .{});
+        self.request.parkEarly425Retry() catch |err| {
+            self.state.metricsReleaseProxyBufferedBytes(result.bodyLen());
+            result.deinit(self.allocator);
+            return err;
+        };
+        self.state.metricsReleaseProxyBufferedBytes(result.bodyLen());
+        result.deinit(self.allocator);
+    }
+
     pub fn onEarly425HandshakeFailure(
         self: *Http3BufferedProxyAttemptExecutor,
         err: anyerror,
@@ -1895,6 +1910,7 @@ fn handleHttp3LocationProxyPass(
         .allocator = allocator,
         .cfg = ctx.cfg,
         .state = ctx.state,
+        .request = request,
         .upstream_url = upstream_url.value,
         .unix_socket_path = resolved.unix_socket_path,
         .method = request.method,
@@ -1907,6 +1923,53 @@ fn handleHttp3LocationProxyPass(
         .selection_base_url = ctx.cfg.upstream_base_url,
         .budget_start_ms = http.event_loop.monotonicMs(),
     };
+
+    if (request.resume_early_425_retry) {
+        var upstream_response = attempt_executor.execute(0, false) catch |err| {
+            attempt_executor.recordEarlyRetryResult(.failure);
+            if (err == error.ProxyBudgetExhausted or err == error.RequestCancelled) {
+                try rejectHttp3ProxyError(allocator, response, ctx, .gateway_timeout, "upstream_timeout", "Upstream request timed out", correlation_id);
+                return;
+            }
+            if (err == error.UpstreamAtCapacity) {
+                try rejectHttp3ProxyError(allocator, response, ctx, .service_unavailable, "upstream_saturated", "Upstream connection limit reached", correlation_id);
+                return;
+            }
+            try attempt_executor.onTerminalAttemptError(err);
+            if (err == error.OutOfMemory) return error.OutOfMemory;
+            const err_status: http.Status = switch (err) {
+                error.Timeout, error.TimedOut, error.WouldBlock => .gateway_timeout,
+                else => .bad_gateway,
+            };
+            const err_code = if (err_status == .gateway_timeout) "upstream_timeout" else "upstream_error";
+            const err_msg = if (err_status == .gateway_timeout) "Upstream request timed out" else "Upstream connection failed";
+            try rejectHttp3ProxyError(allocator, response, ctx, err_status, err_code, err_msg, correlation_id);
+            return;
+        };
+        defer upstream_response.deinit(allocator);
+        try attempt_executor.onBufferedResponse(&upstream_response);
+        defer ctx.state.metricsReleaseProxyBufferedBytes(upstream_response.bodyLen());
+        if (upstream_response.statusCode() == @intFromEnum(http.Status.too_early)) {
+            attempt_executor.recordEarlyUpstream425Action(.forwarded);
+            attempt_executor.recordEarlyRetryResult(.too_early);
+        } else {
+            attempt_executor.recordEarlyRetryResult(.success);
+        }
+        const buffered_response = upstream_response.boundedBufferedForCompatibility();
+
+        _ = response
+            .setStatus(@enumFromInt(buffered_response.status_code))
+            .setBodyOwned(try allocator.dupe(u8, buffered_response.body))
+            .setHeader(http.correlation.HEADER_NAME, correlation_id);
+        for (buffered_response.headers) |header| {
+            _ = response.setHeader(header.name, header.value);
+        }
+        finalizeHttp3Response(response);
+        applyResponseHeaders(ctx.state, response);
+        ctx.state.metricsRecord(upstream_response.statusCode());
+        return;
+    }
+
     var upstream_response: gproxy_runtime.DataPlaneProxyResponse = switch (try gproxy_runtime.runBufferedProxyAttempts(
         early_ctx,
         forward_early_data,
@@ -1918,6 +1981,7 @@ fn handleHttp3LocationProxyPass(
         &attempt_executor,
     )) {
         .response => |upstream_response| upstream_response,
+        .early_425_retry_parked => return error.Http3RequestParked,
         .upstream_at_capacity => {
             try rejectHttp3ProxyError(allocator, response, ctx, .service_unavailable, "upstream_saturated", "Upstream connection limit reached", correlation_id);
             return;

--- a/src/gateway_proxy_runtime.zig
+++ b/src/gateway_proxy_runtime.zig
@@ -483,6 +483,10 @@ pub fn handleLocationProxyPass(
     matched_block: *const edge_config.EdgeConfig.LocationBlock,
     streaming_request_body: ?StreamingRequestBody,
 ) !u16 {
+    if (ctx.early_data.replayExposed()) {
+        ctx.early_data_action = .forwarded;
+    }
+
     const upstream_scope = .global;
     const upstream_pool = upstreamPoolForScope(cfg, upstream_scope);
     var proxy_temp_arena = std.heap.ArenaAllocator.init(allocator);
@@ -878,16 +882,27 @@ fn runBufferedProxyAttempts(
             method,
             matched_block,
         )) {
+            attempt_executor.recordEarlyUpstream425Action(.retried);
             early_ctx.waitOrDriveDownstreamHandshake() catch |err| {
+                attempt_executor.recordEarlyRetryResult(.failure);
                 try attempt_executor.onEarly425HandshakeFailure(err);
                 return .{ .response = result };
             };
             if (!early_ctx.downstreamHandshakeComplete()) {
+                attempt_executor.recordEarlyRetryResult(.failure);
                 return .{ .response = result };
             }
             retry_state.consumeEarly425Retry();
             try attempt_executor.onEarly425Retry(&result);
             continue;
+        }
+        if (result.statusCode() == @intFromEnum(http.Status.too_early)) {
+            attempt_executor.recordEarlyUpstream425Action(.forwarded);
+            if (retry_state.early_425_retry_used) {
+                attempt_executor.recordEarlyRetryResult(.too_early);
+            }
+        } else if (retry_state.early_425_retry_used) {
+            attempt_executor.recordEarlyRetryResult(.success);
         }
         if (result.statusCode() >= 500 and retry_state.hasConfiguredRetryRemaining(attempt, max_attempts)) {
             try attempt_executor.onConfigured5xxRetry(retry_state.configuredAttemptIndex(attempt), max_attempts, &result);
@@ -917,6 +932,28 @@ const ProductionBufferedProxyAttemptExecutor = struct {
     selection_base_url: []const u8,
     budget_start_ms: u64,
     last_attempt_start_ms: u64 = 0,
+
+    fn recordEarlyUpstream425Action(
+        self: *ProductionBufferedProxyAttemptExecutor,
+        action: http.metrics.EarlyDataUpstream425Action,
+    ) void {
+        self.state.metricsRecordEarlyDataUpstream425(action);
+    }
+
+    fn recordEarlyRetryResult(
+        self: *ProductionBufferedProxyAttemptExecutor,
+        result: http.metrics.EarlyDataRetryResult,
+    ) void {
+        self.state.metricsRecordEarlyDataRetry(result);
+        self.ctx.early_data_retry_result = switch (result) {
+            .success => .success,
+            .too_early => .too_early,
+            .failure => .failure,
+        };
+        if (result == .success) {
+            self.ctx.early_data_action = .retried;
+        }
+    }
 
     fn perAttemptTimeoutMs(self: *ProductionBufferedProxyAttemptExecutor) !u32 {
         if (self.cfg.upstream_timeout_budget_ms == 0) return self.cfg.upstream_timeout_ms;
@@ -1040,6 +1077,32 @@ const ScriptedBufferedAttemptExecutor = struct {
     deliveries: usize = 0,
     terminal_attempt_errors: usize = 0,
     handshake_failures: usize = 0,
+    early_425_forwarded: usize = 0,
+    early_425_retried: usize = 0,
+    early_retry_success: usize = 0,
+    early_retry_too_early: usize = 0,
+    early_retry_failure: usize = 0,
+
+    fn recordEarlyUpstream425Action(
+        self: *ScriptedBufferedAttemptExecutor,
+        action: http.metrics.EarlyDataUpstream425Action,
+    ) void {
+        switch (action) {
+            .forwarded => self.early_425_forwarded += 1,
+            .retried => self.early_425_retried += 1,
+        }
+    }
+
+    fn recordEarlyRetryResult(
+        self: *ScriptedBufferedAttemptExecutor,
+        result: http.metrics.EarlyDataRetryResult,
+    ) void {
+        switch (result) {
+            .success => self.early_retry_success += 1,
+            .too_early => self.early_retry_too_early += 1,
+            .failure => self.early_retry_failure += 1,
+        }
+    }
 
     fn execute(
         self: *ScriptedBufferedAttemptExecutor,
@@ -1125,6 +1188,22 @@ const ErrorBufferedAttemptExecutor = struct {
     execute_calls: usize = 0,
     terminal_attempt_errors: usize = 0,
     configured_error_retries: usize = 0,
+
+    fn recordEarlyUpstream425Action(
+        self: *ErrorBufferedAttemptExecutor,
+        action: http.metrics.EarlyDataUpstream425Action,
+    ) void {
+        _ = self;
+        _ = action;
+    }
+
+    fn recordEarlyRetryResult(
+        self: *ErrorBufferedAttemptExecutor,
+        result: http.metrics.EarlyDataRetryResult,
+    ) void {
+        _ = self;
+        _ = result;
+    }
 
     fn execute(
         self: *ErrorBufferedAttemptExecutor,

--- a/src/gateway_proxy_runtime.zig
+++ b/src/gateway_proxy_runtime.zig
@@ -772,7 +772,7 @@ pub fn isHttpMethodIdempotent(method: []const u8) bool {
 /// for any method when the operator has disabled the idempotent-only guard.
 /// The retry is bounded by `max_stale_conn_retries` so a persistently dead
 /// upstream still fails fast.
-fn shouldRetryStaleUpstreamConnection(
+pub fn shouldRetryStaleUpstreamConnection(
     err: anyerror,
     method: []const u8,
     stale_conn_retries: usize,

--- a/src/gateway_proxy_runtime.zig
+++ b/src/gateway_proxy_runtime.zig
@@ -802,6 +802,7 @@ fn shouldRetryEarlyUpstream425(
 
 const BufferedProxyRetryState = struct {
     early_425_retry_used: bool = false,
+    early_425_retry_result_pending: bool = false,
     early_425_extra_attempts: usize = 0,
     retry_as_ordinary: bool = false,
 
@@ -823,8 +824,19 @@ const BufferedProxyRetryState = struct {
 
     fn consumeEarly425Retry(self: *BufferedProxyRetryState) void {
         self.early_425_retry_used = true;
+        self.early_425_retry_result_pending = true;
         self.early_425_extra_attempts = 1;
         self.retry_as_ordinary = true;
+    }
+
+    fn recordEarly425RetryResultOnce(
+        self: *BufferedProxyRetryState,
+        attempt_executor: anytype,
+        result: http.metrics.EarlyDataRetryResult,
+    ) void {
+        if (!self.early_425_retry_result_pending) return;
+        self.early_425_retry_result_pending = false;
+        attempt_executor.recordEarlyRetryResult(result);
     }
 };
 
@@ -853,6 +865,7 @@ pub fn runBufferedProxyAttempts(
     var attempt: usize = 0;
     while (attempt < retry_state.loopBound(max_attempts, stale_conn_retries)) : (attempt += 1) {
         const resp = attempt_executor.execute(attempt, retry_state.forwardEarlyData(first_attempt_forward_early_data)) catch |err| {
+            retry_state.recordEarly425RetryResultOnce(attempt_executor, .failure);
             if (err == error.ProxyBudgetExhausted) return .retry_budget_exhausted;
             if (shouldRetryStaleUpstreamConnection(
                 err,
@@ -889,12 +902,14 @@ pub fn runBufferedProxyAttempts(
                     if (parked) return .early_425_retry_parked;
                 } else |err| {
                     attempt_executor.recordEarlyRetryResult(.failure);
+                    attempt_executor.recordEarlyUpstream425Action(.forwarded);
                     try attempt_executor.onEarly425HandshakeFailure(err);
                     return .{ .response = result };
                 }
             }
             early_ctx.waitOrDriveDownstreamHandshake() catch |err| {
                 attempt_executor.recordEarlyRetryResult(.failure);
+                attempt_executor.recordEarlyUpstream425Action(.forwarded);
                 try attempt_executor.onEarly425HandshakeFailure(err);
                 return .{ .response = result };
             };
@@ -903,10 +918,12 @@ pub fn runBufferedProxyAttempts(
                     if (parked) return .early_425_retry_parked;
                 } else |err| {
                     attempt_executor.recordEarlyRetryResult(.failure);
+                    attempt_executor.recordEarlyUpstream425Action(.forwarded);
                     try attempt_executor.onEarly425HandshakeFailure(err);
                     return .{ .response = result };
                 }
                 attempt_executor.recordEarlyRetryResult(.failure);
+                attempt_executor.recordEarlyUpstream425Action(.forwarded);
                 return .{ .response = result };
             }
             attempt_executor.recordEarlyUpstream425Action(.retried);
@@ -916,11 +933,9 @@ pub fn runBufferedProxyAttempts(
         }
         if (result.statusCode() == @intFromEnum(http.Status.too_early)) {
             attempt_executor.recordEarlyUpstream425Action(.forwarded);
-            if (retry_state.early_425_retry_used) {
-                attempt_executor.recordEarlyRetryResult(.too_early);
-            }
-        } else if (retry_state.early_425_retry_used) {
-            attempt_executor.recordEarlyRetryResult(.success);
+            retry_state.recordEarly425RetryResultOnce(attempt_executor, .too_early);
+        } else {
+            retry_state.recordEarly425RetryResultOnce(attempt_executor, .success);
         }
         if (result.statusCode() >= 500 and retry_state.hasConfiguredRetryRemaining(attempt, max_attempts)) {
             try attempt_executor.onConfigured5xxRetry(retry_state.configuredAttemptIndex(attempt), max_attempts, &result);
@@ -1094,13 +1109,21 @@ const Early425RetryHarnessResult = struct {
     downstream_status: u16,
     upstream_deliveries: usize,
     handshake_failures: usize = 0,
+    early_425_forwarded: usize = 0,
+    early_425_retried: usize = 0,
+    early_retry_success: usize = 0,
+    early_retry_too_early: usize = 0,
+    early_retry_failure: usize = 0,
 };
 
 const ScriptedBufferedAttemptExecutor = struct {
     allocator: std.mem.Allocator,
     upstream_statuses: []const u16,
     early_data_header_counts: *std.array_list.Managed(usize),
+    fail_attempt_index: ?usize = null,
+    fail_attempt_err: anyerror = error.TestRetryTransportFailed,
     deliveries: usize = 0,
+    execute_failures: usize = 0,
     terminal_attempt_errors: usize = 0,
     handshake_failures: usize = 0,
     early_425_forwarded: usize = 0,
@@ -1135,6 +1158,11 @@ const ScriptedBufferedAttemptExecutor = struct {
         attempt: usize,
         forward_early_data: bool,
     ) !DataPlaneProxyResponse {
+        if (self.fail_attempt_index == attempt) {
+            try recordCanonicalEarlyDataHeaderCount(self.allocator, self.early_data_header_counts, forward_early_data);
+            self.execute_failures += 1;
+            return self.fail_attempt_err;
+        }
         if (attempt >= self.upstream_statuses.len) return error.TestHarnessMissingStatus;
         try recordCanonicalEarlyDataHeaderCount(self.allocator, self.early_data_header_counts, forward_early_data);
         self.deliveries += 1;
@@ -1450,6 +1478,11 @@ fn runEarly425RetryHarness(
                 .downstream_status = mutable_response.statusCode(),
                 .upstream_deliveries = executor.deliveries,
                 .handshake_failures = executor.handshake_failures,
+                .early_425_forwarded = executor.early_425_forwarded,
+                .early_425_retried = executor.early_425_retried,
+                .early_retry_success = executor.early_retry_success,
+                .early_retry_too_early = executor.early_retry_too_early,
+                .early_retry_failure = executor.early_retry_failure,
             };
         },
         .early_425_retry_parked,
@@ -1577,6 +1610,8 @@ test "early upstream 425 retry sends marker once then retries ordinary to 200" {
     try std.testing.expectEqual(@as(u16, 200), result.downstream_status);
     try std.testing.expectEqual(@as(usize, 2), result.upstream_deliveries);
     try std.testing.expectEqual(@as(usize, 1), barrier.waits);
+    try std.testing.expectEqual(@as(usize, 1), result.early_425_retried);
+    try std.testing.expectEqual(@as(usize, 1), result.early_retry_success);
     try std.testing.expectEqualSlices(usize, &.{ 1, 0 }, header_counts.items);
 }
 
@@ -1648,6 +1683,7 @@ test "early upstream 425 parking failure forwards original response" {
     try std.testing.expectEqual(@as(usize, 1), executor.inner.deliveries);
     try std.testing.expectEqual(@as(usize, 0), executor.parked);
     try std.testing.expectEqual(@as(usize, 1), executor.inner.early_retry_failure);
+    try std.testing.expectEqual(@as(usize, 1), executor.inner.early_425_forwarded);
 }
 
 test "early upstream 425 retry forwards second 425 without third delivery" {
@@ -1670,6 +1706,45 @@ test "early upstream 425 retry forwards second 425 without third delivery" {
     try std.testing.expectEqual(@as(u16, 425), result.downstream_status);
     try std.testing.expectEqual(@as(usize, 2), result.upstream_deliveries);
     try std.testing.expectEqual(@as(usize, 1), barrier.waits);
+    try std.testing.expectEqual(@as(usize, 1), result.early_425_retried);
+    try std.testing.expectEqual(@as(usize, 1), result.early_425_forwarded);
+    try std.testing.expectEqual(@as(usize, 1), result.early_retry_too_early);
+    try std.testing.expectEqualSlices(usize, &.{ 1, 0 }, header_counts.items);
+}
+
+test "early upstream 425 ordinary retry transport failure records failure once" {
+    const allocator = std.testing.allocator;
+    const block = edge_config.EdgeConfig.LocationBlock{
+        .match_type = .prefix,
+        .pattern = "/",
+        .priority = 0,
+        .action = .{ .proxy_pass = "http://127.0.0.1:9001" },
+        .early_data = .replay_safe,
+        .proxy_early_data = .rfc8470,
+    };
+    var barrier = TestEarly425Barrier{};
+    var ctx = http.request_context.EarlyDataContext{ .transport_early = true, .downstream_handshake = barrier.barrier() };
+    var header_counts = std.array_list.Managed(usize).init(allocator);
+    defer header_counts.deinit();
+    var executor = ScriptedBufferedAttemptExecutor{
+        .allocator = allocator,
+        .upstream_statuses = &.{425},
+        .early_data_header_counts = &header_counts,
+        .fail_attempt_index = 1,
+        .fail_attempt_err = error.TestRetryTransportFailed,
+    };
+
+    const result = try runBufferedProxyAttempts(&ctx, true, "GET", &block, 1, 0, true, &executor);
+
+    switch (result) {
+        .terminal_error => |err| try std.testing.expectEqual(error.TestRetryTransportFailed, err),
+        else => return error.TestUnexpectedTerminalProxyResult,
+    }
+    try std.testing.expectEqual(@as(usize, 1), executor.deliveries);
+    try std.testing.expectEqual(@as(usize, 1), executor.execute_failures);
+    try std.testing.expectEqual(@as(usize, 1), executor.early_425_retried);
+    try std.testing.expectEqual(@as(usize, 1), executor.early_retry_failure);
+    try std.testing.expectEqual(@as(usize, 0), executor.early_retry_success);
     try std.testing.expectEqualSlices(usize, &.{ 1, 0 }, header_counts.items);
 }
 
@@ -1694,6 +1769,8 @@ test "early upstream 425 handshake failure forwards original 425" {
     try std.testing.expectEqual(@as(usize, 1), result.upstream_deliveries);
     try std.testing.expectEqual(@as(usize, 1), barrier.waits);
     try std.testing.expectEqual(@as(usize, 1), result.handshake_failures);
+    try std.testing.expectEqual(@as(usize, 1), result.early_425_forwarded);
+    try std.testing.expectEqual(@as(usize, 1), result.early_retry_failure);
     try std.testing.expectEqualSlices(usize, &.{1}, header_counts.items);
 }
 
@@ -1740,6 +1817,8 @@ test "semantic upstream 425 retry does not consume configured 5xx retry budget" 
     try std.testing.expectEqual(@as(u16, 200), result.downstream_status);
     try std.testing.expectEqual(@as(usize, 3), result.upstream_deliveries);
     try std.testing.expectEqual(@as(usize, 1), barrier.waits);
+    try std.testing.expectEqual(@as(usize, 1), result.early_425_retried);
+    try std.testing.expectEqual(@as(usize, 1), result.early_retry_success);
     try std.testing.expectEqualSlices(usize, &.{ 1, 0, 0 }, header_counts.items);
 }
 

--- a/src/gateway_proxy_runtime.zig
+++ b/src/gateway_proxy_runtime.zig
@@ -295,7 +295,7 @@ fn proxyPassTargetsDiffer(
     return !std.mem.eql(u8, matched_target, candidate_target);
 }
 
-fn proxyRetryAttemptLimit(configured_attempts: u32, idempotent_only: bool, method: []const u8) usize {
+pub fn proxyRetryAttemptLimit(configured_attempts: u32, idempotent_only: bool, method: []const u8) usize {
     const attempts: usize = @intCast(@max(configured_attempts, @as(u32, 1)));
     if (attempts <= 1) return 1;
     if (idempotent_only and !isHttpMethodIdempotent(method)) return 1;
@@ -827,7 +827,7 @@ const BufferedProxyRetryState = struct {
     }
 };
 
-const BufferedProxyAttemptsResult = union(enum) {
+pub const BufferedProxyAttemptsResult = union(enum) {
     response: DataPlaneProxyResponse,
     upstream_at_capacity,
     request_cancelled,
@@ -835,7 +835,7 @@ const BufferedProxyAttemptsResult = union(enum) {
     terminal_error: anyerror,
 };
 
-fn runBufferedProxyAttempts(
+pub fn runBufferedProxyAttempts(
     early_ctx: *http.request_context.EarlyDataContext,
     first_attempt_forward_early_data: bool,
     method: []const u8,

--- a/src/gateway_proxy_runtime.zig
+++ b/src/gateway_proxy_runtime.zig
@@ -676,6 +676,7 @@ pub fn handleLocationProxyPass(
         &attempt_executor,
     )) {
         .response => |response| response,
+        .early_425_retry_parked => unreachable,
         .upstream_at_capacity => {
             // Fail-fast at the per-origin active cap (#239): a local
             // saturation rejection, not an origin failure — do not count
@@ -829,6 +830,7 @@ const BufferedProxyRetryState = struct {
 
 pub const BufferedProxyAttemptsResult = union(enum) {
     response: DataPlaneProxyResponse,
+    early_425_retry_parked,
     upstream_at_capacity,
     request_cancelled,
     retry_budget_exhausted,
@@ -883,12 +885,18 @@ pub fn runBufferedProxyAttempts(
             matched_block,
         )) {
             attempt_executor.recordEarlyUpstream425Action(.retried);
+            if (!early_ctx.downstreamHandshakeComplete() and try maybeParkEarly425Retry(attempt_executor, &result)) {
+                return .early_425_retry_parked;
+            }
             early_ctx.waitOrDriveDownstreamHandshake() catch |err| {
                 attempt_executor.recordEarlyRetryResult(.failure);
                 try attempt_executor.onEarly425HandshakeFailure(err);
                 return .{ .response = result };
             };
             if (!early_ctx.downstreamHandshakeComplete()) {
+                if (try maybeParkEarly425Retry(attempt_executor, &result)) {
+                    return .early_425_retry_parked;
+                }
                 attempt_executor.recordEarlyRetryResult(.failure);
                 return .{ .response = result };
             }
@@ -911,6 +919,14 @@ pub fn runBufferedProxyAttempts(
         return .{ .response = result };
     }
     return error.UpstreamUnavailable;
+}
+
+fn maybeParkEarly425Retry(attempt_executor: anytype, result: *DataPlaneProxyResponse) !bool {
+    if (comptime @hasDecl(@TypeOf(attempt_executor.*), "parkEarly425Retry")) {
+        try attempt_executor.parkEarly425Retry(result);
+        return true;
+    }
+    return false;
 }
 
 const ProductionBufferedProxyAttemptExecutor = struct {
@@ -1183,6 +1199,95 @@ const ScriptedBufferedAttemptExecutor = struct {
     }
 };
 
+const ParkingBufferedAttemptExecutor = struct {
+    inner: ScriptedBufferedAttemptExecutor,
+    parked: usize = 0,
+
+    fn recordEarlyUpstream425Action(
+        self: *ParkingBufferedAttemptExecutor,
+        action: http.metrics.EarlyDataUpstream425Action,
+    ) void {
+        self.inner.recordEarlyUpstream425Action(action);
+    }
+
+    fn recordEarlyRetryResult(
+        self: *ParkingBufferedAttemptExecutor,
+        result: http.metrics.EarlyDataRetryResult,
+    ) void {
+        self.inner.recordEarlyRetryResult(result);
+    }
+
+    fn execute(
+        self: *ParkingBufferedAttemptExecutor,
+        attempt: usize,
+        forward_early_data: bool,
+    ) !DataPlaneProxyResponse {
+        return self.inner.execute(attempt, forward_early_data);
+    }
+
+    fn onBufferedResponse(
+        self: *ParkingBufferedAttemptExecutor,
+        result: *DataPlaneProxyResponse,
+    ) !void {
+        try self.inner.onBufferedResponse(result);
+    }
+
+    fn onEarly425HandshakeFailure(
+        self: *ParkingBufferedAttemptExecutor,
+        err: anyerror,
+    ) !void {
+        try self.inner.onEarly425HandshakeFailure(err);
+    }
+
+    fn onStaleConnectionRetry(
+        self: *ParkingBufferedAttemptExecutor,
+        stale_conn_retries: usize,
+        max_stale_conn_retries: usize,
+    ) !void {
+        try self.inner.onStaleConnectionRetry(stale_conn_retries, max_stale_conn_retries);
+    }
+
+    fn onTerminalAttemptError(
+        self: *ParkingBufferedAttemptExecutor,
+        err: anyerror,
+    ) !void {
+        try self.inner.onTerminalAttemptError(err);
+    }
+
+    fn onConfiguredErrorRetry(
+        self: *ParkingBufferedAttemptExecutor,
+        configured_attempt_index: usize,
+        max_attempts: usize,
+        err: anyerror,
+    ) !void {
+        try self.inner.onConfiguredErrorRetry(configured_attempt_index, max_attempts, err);
+    }
+
+    fn onEarly425Retry(
+        self: *ParkingBufferedAttemptExecutor,
+        result: *DataPlaneProxyResponse,
+    ) !void {
+        try self.inner.onEarly425Retry(result);
+    }
+
+    fn parkEarly425Retry(
+        self: *ParkingBufferedAttemptExecutor,
+        result: *DataPlaneProxyResponse,
+    ) !void {
+        self.parked += 1;
+        result.deinit(self.inner.allocator);
+    }
+
+    fn onConfigured5xxRetry(
+        self: *ParkingBufferedAttemptExecutor,
+        configured_attempt_index: usize,
+        max_attempts: usize,
+        result: *DataPlaneProxyResponse,
+    ) !void {
+        try self.inner.onConfigured5xxRetry(configured_attempt_index, max_attempts, result);
+    }
+};
+
 const ErrorBufferedAttemptExecutor = struct {
     err: anyerror,
     execute_calls: usize = 0,
@@ -1335,7 +1440,12 @@ fn runEarly425RetryHarness(
                 .handshake_failures = executor.handshake_failures,
             };
         },
-        .upstream_at_capacity, .request_cancelled, .retry_budget_exhausted, .terminal_error => error.TestUnexpectedTerminalProxyResult,
+        .early_425_retry_parked,
+        .upstream_at_capacity,
+        .request_cancelled,
+        .retry_budget_exhausted,
+        .terminal_error,
+        => error.TestUnexpectedTerminalProxyResult,
     };
 }
 
@@ -1456,6 +1566,38 @@ test "early upstream 425 retry sends marker once then retries ordinary to 200" {
     try std.testing.expectEqual(@as(usize, 2), result.upstream_deliveries);
     try std.testing.expectEqual(@as(usize, 1), barrier.waits);
     try std.testing.expectEqualSlices(usize, &.{ 1, 0 }, header_counts.items);
+}
+
+test "early upstream 425 can park retry until event-loop handshake completion" {
+    const allocator = std.testing.allocator;
+    const block = edge_config.EdgeConfig.LocationBlock{
+        .match_type = .prefix,
+        .pattern = "/",
+        .priority = 0,
+        .action = .{ .proxy_pass = "http://127.0.0.1:9001" },
+        .early_data = .replay_safe,
+        .proxy_early_data = .rfc8470,
+    };
+    var barrier = TestEarly425Barrier{};
+    var ctx = http.request_context.EarlyDataContext{ .transport_early = true, .downstream_handshake = barrier.barrier() };
+    var header_counts = std.array_list.Managed(usize).init(allocator);
+    defer header_counts.deinit();
+    var executor = ParkingBufferedAttemptExecutor{
+        .inner = .{
+            .allocator = allocator,
+            .upstream_statuses = &.{ 425, 200 },
+            .early_data_header_counts = &header_counts,
+        },
+    };
+
+    const result = try runBufferedProxyAttempts(&ctx, true, "GET", &block, 1, 0, true, &executor);
+
+    try std.testing.expectEqual(std.meta.Tag(BufferedProxyAttemptsResult).early_425_retry_parked, std.meta.activeTag(result));
+    try std.testing.expectEqual(@as(usize, 1), executor.inner.deliveries);
+    try std.testing.expectEqual(@as(usize, 0), barrier.waits);
+    try std.testing.expectEqual(@as(usize, 1), executor.parked);
+    try std.testing.expectEqual(@as(usize, 1), executor.inner.early_425_retried);
+    try std.testing.expectEqualSlices(usize, &.{1}, header_counts.items);
 }
 
 test "early upstream 425 retry forwards second 425 without third delivery" {

--- a/src/gateway_proxy_runtime.zig
+++ b/src/gateway_proxy_runtime.zig
@@ -810,12 +810,17 @@ const BufferedProxyRetryState = struct {
         return max_attempts + stale_conn_retries + self.early_425_extra_attempts;
     }
 
-    fn configuredAttemptIndex(self: BufferedProxyRetryState, attempt: usize) usize {
-        return attempt - @min(attempt, self.early_425_extra_attempts);
+    fn transparentAttempts(self: BufferedProxyRetryState, stale_conn_retries: usize) usize {
+        return self.early_425_extra_attempts + stale_conn_retries;
     }
 
-    fn hasConfiguredRetryRemaining(self: BufferedProxyRetryState, attempt: usize, max_attempts: usize) bool {
-        return self.configuredAttemptIndex(attempt) + 1 < max_attempts;
+    fn configuredAttemptIndex(self: BufferedProxyRetryState, attempt: usize, stale_conn_retries: usize) usize {
+        const transparent = self.transparentAttempts(stale_conn_retries);
+        return attempt - @min(attempt, transparent);
+    }
+
+    fn hasConfiguredRetryRemaining(self: BufferedProxyRetryState, attempt: usize, max_attempts: usize, stale_conn_retries: usize) bool {
+        return self.configuredAttemptIndex(attempt, stale_conn_retries) + 1 < max_attempts;
     }
 
     fn forwardEarlyData(self: BufferedProxyRetryState, first_attempt_forward_early_data: bool) bool {
@@ -865,8 +870,6 @@ pub fn runBufferedProxyAttempts(
     var attempt: usize = 0;
     while (attempt < retry_state.loopBound(max_attempts, stale_conn_retries)) : (attempt += 1) {
         const resp = attempt_executor.execute(attempt, retry_state.forwardEarlyData(first_attempt_forward_early_data)) catch |err| {
-            retry_state.recordEarly425RetryResultOnce(attempt_executor, .failure);
-            if (err == error.ProxyBudgetExhausted) return .retry_budget_exhausted;
             if (shouldRetryStaleUpstreamConnection(
                 err,
                 method,
@@ -878,11 +881,13 @@ pub fn runBufferedProxyAttempts(
                 try attempt_executor.onStaleConnectionRetry(stale_conn_retries, max_stale_conn_retries);
                 continue;
             }
+            retry_state.recordEarly425RetryResultOnce(attempt_executor, .failure);
+            if (err == error.ProxyBudgetExhausted) return .retry_budget_exhausted;
             if (err == error.UpstreamAtCapacity) return .upstream_at_capacity;
             try attempt_executor.onTerminalAttemptError(err);
             if (err == error.RequestCancelled) return .request_cancelled;
-            if (retry_state.hasConfiguredRetryRemaining(attempt, max_attempts)) {
-                try attempt_executor.onConfiguredErrorRetry(retry_state.configuredAttemptIndex(attempt), max_attempts, err);
+            if (retry_state.hasConfiguredRetryRemaining(attempt, max_attempts, stale_conn_retries)) {
+                try attempt_executor.onConfiguredErrorRetry(retry_state.configuredAttemptIndex(attempt, stale_conn_retries), max_attempts, err);
                 continue;
             }
             return .{ .terminal_error = err };
@@ -937,8 +942,8 @@ pub fn runBufferedProxyAttempts(
         } else {
             retry_state.recordEarly425RetryResultOnce(attempt_executor, .success);
         }
-        if (result.statusCode() >= 500 and retry_state.hasConfiguredRetryRemaining(attempt, max_attempts)) {
-            try attempt_executor.onConfigured5xxRetry(retry_state.configuredAttemptIndex(attempt), max_attempts, &result);
+        if (result.statusCode() >= 500 and retry_state.hasConfiguredRetryRemaining(attempt, max_attempts, stale_conn_retries)) {
+            try attempt_executor.onConfigured5xxRetry(retry_state.configuredAttemptIndex(attempt, stale_conn_retries), max_attempts, &result);
             continue;
         }
         return .{ .response = result };
@@ -979,6 +984,9 @@ const ProductionBufferedProxyAttemptExecutor = struct {
         action: http.metrics.EarlyDataUpstream425Action,
     ) void {
         self.state.metricsRecordEarlyDataUpstream425(action);
+        if (action == .retried) {
+            self.ctx.early_data_action = .retried;
+        }
     }
 
     fn recordEarlyRetryResult(
@@ -991,9 +999,6 @@ const ProductionBufferedProxyAttemptExecutor = struct {
             .too_early => .too_early,
             .failure => .failure,
         };
-        if (result == .success) {
-            self.ctx.early_data_action = .retried;
-        }
     }
 
     fn perAttemptTimeoutMs(self: *ProductionBufferedProxyAttemptExecutor) !u32 {
@@ -1120,6 +1125,7 @@ const ScriptedBufferedAttemptExecutor = struct {
     allocator: std.mem.Allocator,
     upstream_statuses: []const u16,
     early_data_header_counts: *std.array_list.Managed(usize),
+    request_ctx: ?*http.request_context.RequestContext = null,
     fail_attempt_index: ?usize = null,
     fail_attempt_err: anyerror = error.TestRetryTransportFailed,
     deliveries: usize = 0,
@@ -1140,6 +1146,9 @@ const ScriptedBufferedAttemptExecutor = struct {
             .forwarded => self.early_425_forwarded += 1,
             .retried => self.early_425_retried += 1,
         }
+        if (action == .retried) {
+            if (self.request_ctx) |ctx| ctx.early_data_action = .retried;
+        }
     }
 
     fn recordEarlyRetryResult(
@@ -1150,6 +1159,13 @@ const ScriptedBufferedAttemptExecutor = struct {
             .success => self.early_retry_success += 1,
             .too_early => self.early_retry_too_early += 1,
             .failure => self.early_retry_failure += 1,
+        }
+        if (self.request_ctx) |ctx| {
+            ctx.early_data_retry_result = switch (result) {
+                .success => .success,
+                .too_early => .too_early,
+                .failure => .failure,
+            };
         }
     }
 
@@ -1748,6 +1764,227 @@ test "early upstream 425 ordinary retry transport failure records failure once" 
     try std.testing.expectEqualSlices(usize, &.{ 1, 0 }, header_counts.items);
 }
 
+test "early upstream 425 retry success records retried action in request context" {
+    const allocator = std.testing.allocator;
+    const block = edge_config.EdgeConfig.LocationBlock{
+        .match_type = .prefix,
+        .pattern = "/",
+        .priority = 0,
+        .action = .{ .proxy_pass = "http://127.0.0.1:9001" },
+        .early_data = .replay_safe,
+        .proxy_early_data = .rfc8470,
+    };
+    var barrier = TestEarly425Barrier{};
+    var early_ctx = http.request_context.EarlyDataContext{ .transport_early = true, .downstream_handshake = barrier.barrier() };
+    var request_ctx = http.request_context.RequestContext.init(allocator, "req-early-success", "127.0.0.1");
+    request_ctx.early_data_action = .forwarded;
+    var header_counts = std.array_list.Managed(usize).init(allocator);
+    defer header_counts.deinit();
+    var executor = ScriptedBufferedAttemptExecutor{
+        .allocator = allocator,
+        .upstream_statuses = &.{ 425, 200 },
+        .early_data_header_counts = &header_counts,
+        .request_ctx = &request_ctx,
+    };
+
+    const result = try runBufferedProxyAttempts(&early_ctx, true, "GET", &block, 1, 0, true, &executor);
+    switch (result) {
+        .response => |response| {
+            var mutable = response;
+            defer mutable.deinit(allocator);
+            try std.testing.expectEqual(@as(u16, 200), mutable.statusCode());
+        },
+        else => return error.TestUnexpectedTerminalProxyResult,
+    }
+    try std.testing.expectEqual(http.request_context.EarlyDataAction.retried, request_ctx.early_data_action);
+    try std.testing.expectEqual(http.request_context.EarlyDataRetryResult.success, request_ctx.early_data_retry_result);
+}
+
+test "early upstream 425 retry second 425 records retried action in request context" {
+    const allocator = std.testing.allocator;
+    const block = edge_config.EdgeConfig.LocationBlock{
+        .match_type = .prefix,
+        .pattern = "/",
+        .priority = 0,
+        .action = .{ .proxy_pass = "http://127.0.0.1:9001" },
+        .early_data = .replay_safe,
+        .proxy_early_data = .rfc8470,
+    };
+    var barrier = TestEarly425Barrier{};
+    var early_ctx = http.request_context.EarlyDataContext{ .transport_early = true, .downstream_handshake = barrier.barrier() };
+    var request_ctx = http.request_context.RequestContext.init(allocator, "req-early-425", "127.0.0.1");
+    request_ctx.early_data_action = .forwarded;
+    var header_counts = std.array_list.Managed(usize).init(allocator);
+    defer header_counts.deinit();
+    var executor = ScriptedBufferedAttemptExecutor{
+        .allocator = allocator,
+        .upstream_statuses = &.{ 425, 425 },
+        .early_data_header_counts = &header_counts,
+        .request_ctx = &request_ctx,
+    };
+
+    const result = try runBufferedProxyAttempts(&early_ctx, true, "GET", &block, 1, 0, true, &executor);
+    switch (result) {
+        .response => |response| {
+            var mutable = response;
+            defer mutable.deinit(allocator);
+            try std.testing.expectEqual(@as(u16, 425), mutable.statusCode());
+        },
+        else => return error.TestUnexpectedTerminalProxyResult,
+    }
+    try std.testing.expectEqual(http.request_context.EarlyDataAction.retried, request_ctx.early_data_action);
+    try std.testing.expectEqual(http.request_context.EarlyDataRetryResult.too_early, request_ctx.early_data_retry_result);
+}
+
+test "early upstream 425 retry transport failure records retried action in request context" {
+    const allocator = std.testing.allocator;
+    const block = edge_config.EdgeConfig.LocationBlock{
+        .match_type = .prefix,
+        .pattern = "/",
+        .priority = 0,
+        .action = .{ .proxy_pass = "http://127.0.0.1:9001" },
+        .early_data = .replay_safe,
+        .proxy_early_data = .rfc8470,
+    };
+    var barrier = TestEarly425Barrier{};
+    var early_ctx = http.request_context.EarlyDataContext{ .transport_early = true, .downstream_handshake = barrier.barrier() };
+    var request_ctx = http.request_context.RequestContext.init(allocator, "req-early-failure", "127.0.0.1");
+    request_ctx.early_data_action = .forwarded;
+    var header_counts = std.array_list.Managed(usize).init(allocator);
+    defer header_counts.deinit();
+    var executor = ScriptedBufferedAttemptExecutor{
+        .allocator = allocator,
+        .upstream_statuses = &.{425},
+        .early_data_header_counts = &header_counts,
+        .request_ctx = &request_ctx,
+        .fail_attempt_index = 1,
+        .fail_attempt_err = error.TestRetryTransportFailed,
+    };
+
+    const result = try runBufferedProxyAttempts(&early_ctx, true, "GET", &block, 1, 0, true, &executor);
+    switch (result) {
+        .terminal_error => |err| try std.testing.expectEqual(error.TestRetryTransportFailed, err),
+        else => return error.TestUnexpectedTerminalProxyResult,
+    }
+    try std.testing.expectEqual(http.request_context.EarlyDataAction.retried, request_ctx.early_data_action);
+    try std.testing.expectEqual(http.request_context.EarlyDataRetryResult.failure, request_ctx.early_data_retry_result);
+}
+
+test "early upstream 425 handshake failure keeps forwarded action in request context" {
+    const allocator = std.testing.allocator;
+    const block = edge_config.EdgeConfig.LocationBlock{
+        .match_type = .prefix,
+        .pattern = "/",
+        .priority = 0,
+        .action = .{ .proxy_pass = "http://127.0.0.1:9001" },
+        .early_data = .replay_safe,
+        .proxy_early_data = .rfc8470,
+    };
+    var barrier = TestEarly425Barrier{ .fail_wait = true };
+    var early_ctx = http.request_context.EarlyDataContext{ .transport_early = true, .downstream_handshake = barrier.barrier() };
+    var request_ctx = http.request_context.RequestContext.init(allocator, "req-early-handshake-failure", "127.0.0.1");
+    request_ctx.early_data_action = .forwarded;
+    var header_counts = std.array_list.Managed(usize).init(allocator);
+    defer header_counts.deinit();
+    var executor = ScriptedBufferedAttemptExecutor{
+        .allocator = allocator,
+        .upstream_statuses = &.{425},
+        .early_data_header_counts = &header_counts,
+        .request_ctx = &request_ctx,
+    };
+
+    const result = try runBufferedProxyAttempts(&early_ctx, true, "GET", &block, 1, 0, true, &executor);
+    switch (result) {
+        .response => |response| {
+            var mutable = response;
+            defer mutable.deinit(allocator);
+            try std.testing.expectEqual(@as(u16, 425), mutable.statusCode());
+        },
+        else => return error.TestUnexpectedTerminalProxyResult,
+    }
+    try std.testing.expectEqual(http.request_context.EarlyDataAction.forwarded, request_ctx.early_data_action);
+    try std.testing.expectEqual(http.request_context.EarlyDataRetryResult.failure, request_ctx.early_data_retry_result);
+}
+
+test "early upstream 425 stale ordinary retry recovers without failure metric" {
+    const allocator = std.testing.allocator;
+    const block = edge_config.EdgeConfig.LocationBlock{
+        .match_type = .prefix,
+        .pattern = "/",
+        .priority = 0,
+        .action = .{ .proxy_pass = "http://127.0.0.1:9001" },
+        .early_data = .replay_safe,
+        .proxy_early_data = .rfc8470,
+    };
+    var barrier = TestEarly425Barrier{};
+    var ctx = http.request_context.EarlyDataContext{ .transport_early = true, .downstream_handshake = barrier.barrier() };
+    var header_counts = std.array_list.Managed(usize).init(allocator);
+    defer header_counts.deinit();
+    var executor = ScriptedBufferedAttemptExecutor{
+        .allocator = allocator,
+        .upstream_statuses = &.{ 425, 0, 200 },
+        .early_data_header_counts = &header_counts,
+        .fail_attempt_index = 1,
+        .fail_attempt_err = error.HttpConnectionClosing,
+    };
+
+    const result = try runBufferedProxyAttempts(&ctx, true, "GET", &block, 1, 1, true, &executor);
+
+    switch (result) {
+        .response => |response| {
+            var mutable = response;
+            defer mutable.deinit(allocator);
+            try std.testing.expectEqual(@as(u16, 200), mutable.statusCode());
+        },
+        else => return error.TestUnexpectedTerminalProxyResult,
+    }
+    try std.testing.expectEqual(@as(usize, 2), executor.deliveries);
+    try std.testing.expectEqual(@as(usize, 1), executor.execute_failures);
+    try std.testing.expectEqual(@as(usize, 1), executor.early_425_retried);
+    try std.testing.expectEqual(@as(usize, 1), executor.early_retry_success);
+    try std.testing.expectEqual(@as(usize, 0), executor.early_retry_failure);
+    try std.testing.expectEqualSlices(usize, &.{ 1, 0, 0 }, header_counts.items);
+}
+
+test "early upstream 425 stale retry does not consume configured retry budget" {
+    const allocator = std.testing.allocator;
+    const block = edge_config.EdgeConfig.LocationBlock{
+        .match_type = .prefix,
+        .pattern = "/",
+        .priority = 0,
+        .action = .{ .proxy_pass = "http://127.0.0.1:9001" },
+        .early_data = .replay_safe,
+        .proxy_early_data = .rfc8470,
+    };
+    var barrier = TestEarly425Barrier{};
+    var ctx = http.request_context.EarlyDataContext{ .transport_early = true, .downstream_handshake = barrier.barrier() };
+    var header_counts = std.array_list.Managed(usize).init(allocator);
+    defer header_counts.deinit();
+    var executor = ScriptedBufferedAttemptExecutor{
+        .allocator = allocator,
+        .upstream_statuses = &.{ 425, 0, 500, 200 },
+        .early_data_header_counts = &header_counts,
+        .fail_attempt_index = 1,
+        .fail_attempt_err = error.HttpConnectionClosing,
+    };
+
+    const result = try runBufferedProxyAttempts(&ctx, true, "GET", &block, 2, 1, true, &executor);
+
+    switch (result) {
+        .response => |response| {
+            var mutable = response;
+            defer mutable.deinit(allocator);
+            try std.testing.expectEqual(@as(u16, 200), mutable.statusCode());
+        },
+        else => return error.TestUnexpectedTerminalProxyResult,
+    }
+    try std.testing.expectEqual(@as(usize, 3), executor.deliveries);
+    try std.testing.expectEqual(@as(usize, 1), executor.execute_failures);
+    try std.testing.expectEqual(@as(usize, 1), executor.early_425_retried);
+    try std.testing.expectEqual(@as(usize, 1), executor.early_retry_success);
+    try std.testing.expectEqualSlices(usize, &.{ 1, 0, 0, 0 }, header_counts.items);
+}
+
 test "early upstream 425 handshake failure forwards original 425" {
     const allocator = std.testing.allocator;
     const block = edge_config.EdgeConfig.LocationBlock{
@@ -1820,6 +2057,43 @@ test "semantic upstream 425 retry does not consume configured 5xx retry budget" 
     try std.testing.expectEqual(@as(usize, 1), result.early_425_retried);
     try std.testing.expectEqual(@as(usize, 1), result.early_retry_success);
     try std.testing.expectEqualSlices(usize, &.{ 1, 0, 0 }, header_counts.items);
+}
+
+test "stale retry remains transparent to configured retry budget without early data" {
+    const allocator = std.testing.allocator;
+    const block = edge_config.EdgeConfig.LocationBlock{
+        .match_type = .prefix,
+        .pattern = "/",
+        .priority = 0,
+        .action = .{ .proxy_pass = "http://127.0.0.1:9001" },
+        .early_data = .replay_safe,
+        .proxy_early_data = .rfc8470,
+    };
+    var ctx = http.request_context.EarlyDataContext{};
+    var header_counts = std.array_list.Managed(usize).init(allocator);
+    defer header_counts.deinit();
+    var executor = ScriptedBufferedAttemptExecutor{
+        .allocator = allocator,
+        .upstream_statuses = &.{ 0, 500, 200 },
+        .early_data_header_counts = &header_counts,
+        .fail_attempt_index = 0,
+        .fail_attempt_err = error.HttpConnectionClosing,
+    };
+
+    const result = try runBufferedProxyAttempts(&ctx, false, "GET", &block, 2, 1, true, &executor);
+
+    switch (result) {
+        .response => |response| {
+            var mutable = response;
+            defer mutable.deinit(allocator);
+            try std.testing.expectEqual(@as(u16, 200), mutable.statusCode());
+        },
+        else => return error.TestUnexpectedTerminalProxyResult,
+    }
+    try std.testing.expectEqual(@as(usize, 2), executor.deliveries);
+    try std.testing.expectEqual(@as(usize, 1), executor.execute_failures);
+    try std.testing.expectEqual(@as(usize, 0), executor.early_425_retried);
+    try std.testing.expectEqualSlices(usize, &.{ 0, 0, 0 }, header_counts.items);
 }
 
 test "buffered proxy attempts record RequestCancelled as upstream failure before terminating" {

--- a/src/gateway_proxy_runtime.zig
+++ b/src/gateway_proxy_runtime.zig
@@ -884,9 +884,14 @@ pub fn runBufferedProxyAttempts(
             method,
             matched_block,
         )) {
-            attempt_executor.recordEarlyUpstream425Action(.retried);
-            if (!early_ctx.downstreamHandshakeComplete() and try maybeParkEarly425Retry(attempt_executor, &result)) {
-                return .early_425_retry_parked;
+            if (!early_ctx.downstreamHandshakeComplete()) {
+                if (maybeParkEarly425Retry(attempt_executor, &result)) |parked| {
+                    if (parked) return .early_425_retry_parked;
+                } else |err| {
+                    attempt_executor.recordEarlyRetryResult(.failure);
+                    try attempt_executor.onEarly425HandshakeFailure(err);
+                    return .{ .response = result };
+                }
             }
             early_ctx.waitOrDriveDownstreamHandshake() catch |err| {
                 attempt_executor.recordEarlyRetryResult(.failure);
@@ -894,12 +899,17 @@ pub fn runBufferedProxyAttempts(
                 return .{ .response = result };
             };
             if (!early_ctx.downstreamHandshakeComplete()) {
-                if (try maybeParkEarly425Retry(attempt_executor, &result)) {
-                    return .early_425_retry_parked;
+                if (maybeParkEarly425Retry(attempt_executor, &result)) |parked| {
+                    if (parked) return .early_425_retry_parked;
+                } else |err| {
+                    attempt_executor.recordEarlyRetryResult(.failure);
+                    try attempt_executor.onEarly425HandshakeFailure(err);
+                    return .{ .response = result };
                 }
                 attempt_executor.recordEarlyRetryResult(.failure);
                 return .{ .response = result };
             }
+            attempt_executor.recordEarlyUpstream425Action(.retried);
             retry_state.consumeEarly425Retry();
             try attempt_executor.onEarly425Retry(&result);
             continue;
@@ -1202,6 +1212,7 @@ const ScriptedBufferedAttemptExecutor = struct {
 const ParkingBufferedAttemptExecutor = struct {
     inner: ScriptedBufferedAttemptExecutor,
     parked: usize = 0,
+    fail_park: bool = false,
 
     fn recordEarlyUpstream425Action(
         self: *ParkingBufferedAttemptExecutor,
@@ -1274,6 +1285,7 @@ const ParkingBufferedAttemptExecutor = struct {
         self: *ParkingBufferedAttemptExecutor,
         result: *DataPlaneProxyResponse,
     ) !void {
+        if (self.fail_park) return error.TestParkingFailed;
         self.parked += 1;
         result.deinit(self.inner.allocator);
     }
@@ -1596,8 +1608,46 @@ test "early upstream 425 can park retry until event-loop handshake completion" {
     try std.testing.expectEqual(@as(usize, 1), executor.inner.deliveries);
     try std.testing.expectEqual(@as(usize, 0), barrier.waits);
     try std.testing.expectEqual(@as(usize, 1), executor.parked);
-    try std.testing.expectEqual(@as(usize, 1), executor.inner.early_425_retried);
+    try std.testing.expectEqual(@as(usize, 0), executor.inner.early_425_retried);
     try std.testing.expectEqualSlices(usize, &.{1}, header_counts.items);
+}
+
+test "early upstream 425 parking failure forwards original response" {
+    const allocator = std.testing.allocator;
+    const block = edge_config.EdgeConfig.LocationBlock{
+        .match_type = .prefix,
+        .pattern = "/",
+        .priority = 0,
+        .action = .{ .proxy_pass = "http://127.0.0.1:9001" },
+        .early_data = .replay_safe,
+        .proxy_early_data = .rfc8470,
+    };
+    var barrier = TestEarly425Barrier{};
+    var ctx = http.request_context.EarlyDataContext{ .transport_early = true, .downstream_handshake = barrier.barrier() };
+    var header_counts = std.array_list.Managed(usize).init(allocator);
+    defer header_counts.deinit();
+    var executor = ParkingBufferedAttemptExecutor{
+        .inner = .{
+            .allocator = allocator,
+            .upstream_statuses = &.{ 425, 200 },
+            .early_data_header_counts = &header_counts,
+        },
+        .fail_park = true,
+    };
+
+    const result = try runBufferedProxyAttempts(&ctx, true, "GET", &block, 1, 0, true, &executor);
+
+    switch (result) {
+        .response => |response| {
+            var mutable = response;
+            defer mutable.deinit(allocator);
+            try std.testing.expectEqual(@as(u16, 425), mutable.statusCode());
+        },
+        else => return error.TestUnexpectedTerminalProxyResult,
+    }
+    try std.testing.expectEqual(@as(usize, 1), executor.inner.deliveries);
+    try std.testing.expectEqual(@as(usize, 0), executor.parked);
+    try std.testing.expectEqual(@as(usize, 1), executor.inner.early_retry_failure);
 }
 
 test "early upstream 425 retry forwards second 425 without third delivery" {

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -33,6 +33,10 @@ pub const Http2PendingStream = struct {
     headers: http.Headers,
     body: std.array_list.Managed(u8),
     priority_weight: u8 = 16,
+    transport_early: bool = false,
+    dispatch_count: u8 = 0,
+    early_request_recorded: bool = false,
+    deferred_recorded: bool = false,
 
     pub fn init(allocator: std.mem.Allocator) Http2PendingStream {
         return .{
@@ -1377,6 +1381,36 @@ pub const GatewayState = struct {
         self.metrics_mutex.lock();
         defer self.metrics_mutex.unlock();
         self.metrics.recordErrorCode(code);
+    }
+
+    pub fn metricsRecordEarlyDataRequest(self: *GatewayState, protocol: http.metrics.HttpProtocol, source: http.metrics.EarlyDataSource) void {
+        self.metrics_mutex.lock();
+        defer self.metrics_mutex.unlock();
+        self.metrics.recordHttpEarlyDataRequest(protocol, source);
+    }
+
+    pub fn metricsRecordEarlyDataDecision(self: *GatewayState, protocol: http.metrics.HttpProtocol, decision: http.metrics.EarlyDataDecision) void {
+        self.metrics_mutex.lock();
+        defer self.metrics_mutex.unlock();
+        self.metrics.recordHttpEarlyDataDecision(protocol, decision);
+    }
+
+    pub fn metricsRecordEarlyDataUpstream425(self: *GatewayState, action: http.metrics.EarlyDataUpstream425Action) void {
+        self.metrics_mutex.lock();
+        defer self.metrics_mutex.unlock();
+        self.metrics.recordHttpEarlyDataUpstream425(action);
+    }
+
+    pub fn metricsRecordEarlyDataRetry(self: *GatewayState, result: http.metrics.EarlyDataRetryResult) void {
+        self.metrics_mutex.lock();
+        defer self.metrics_mutex.unlock();
+        self.metrics.recordHttpEarlyDataRetry(result);
+    }
+
+    pub fn metricsRecordHttp3EarlyDataCompat(self: *GatewayState, decision: http.metrics.H3EarlyDataCompatDecision) void {
+        self.metrics_mutex.lock();
+        defer self.metrics_mutex.unlock();
+        self.metrics.recordHttp3EarlyDataCompat(decision);
     }
 
     pub fn metricsRecordReloadAttempt(self: *GatewayState) void {

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -2708,6 +2708,10 @@ pub const ConfigLease = struct {
     version: *ManagedConfigVersion,
     cfg: *const edge_config.EdgeConfig,
 
+    pub fn retain(self: *ConfigLease) ConfigLease {
+        return self.store.retain(self.version);
+    }
+
     pub fn release(self: *ConfigLease) void {
         self.store.release(self.version);
         self.* = undefined;
@@ -2747,6 +2751,18 @@ pub const ReloadableConfigStore = struct {
             .store = self,
             .version = self.current,
             .cfg = self.current.cfg,
+        };
+    }
+
+    pub fn retain(self: *ReloadableConfigStore, version: *ManagedConfigVersion) ConfigLease {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        version.ref_count += 1;
+        return .{
+            .store = self,
+            .version = version,
+            .cfg = version.cfg,
         };
     }
 

--- a/src/http/access_log.zig
+++ b/src/http/access_log.zig
@@ -19,6 +19,14 @@ pub const AccessLogEntry = struct {
     /// Cancellation or timeout reason when the request was terminated early.
     /// Empty string when the request completed normally.
     cancel_reason: []const u8 = "",
+    /// Bounded replay-exposure source label.
+    early_data_source: []const u8 = "none",
+    /// Bounded early-data policy action label.
+    early_data_action: []const u8 = "ordinary",
+    /// Bounded upstream 425 retry result label.
+    early_data_retry_result: []const u8 = "none",
+    /// True when this request is replay-exposed by transport or prior-hop marker.
+    early_data_replay_exposed: bool = false,
 
     pub fn log(self: AccessLogEntry) void {
         emit(self);
@@ -188,7 +196,7 @@ fn appendEntry(allocator: std.mem.Allocator, out: *std.ArrayList(u8), cfg: Confi
     switch (cfg.format) {
         .json => try out.print(
             allocator,
-            "{{\"type\":\"access\",\"ts\":\"{s}\",\"request_id\":\"{s}\",\"correlation_id\":\"{s}\",\"method\":\"{s}\",\"path\":\"{s}\",\"status\":{d},\"latency_ms\":{d},\"client_ip\":\"{s}\",\"upstream_addr\":\"{s}\",\"upstream_status\":{s},\"identity\":\"{s}\",\"user_agent\":\"{s}\",\"bytes_sent\":{d},\"response_bytes\":{d},\"error_category\":\"{s}\",\"cancel_reason\":\"{s}\"}}\n",
+            "{{\"type\":\"access\",\"ts\":\"{s}\",\"request_id\":\"{s}\",\"correlation_id\":\"{s}\",\"method\":\"{s}\",\"path\":\"{s}\",\"status\":{d},\"latency_ms\":{d},\"client_ip\":\"{s}\",\"upstream_addr\":\"{s}\",\"upstream_status\":{s},\"identity\":\"{s}\",\"user_agent\":\"{s}\",\"bytes_sent\":{d},\"response_bytes\":{d},\"error_category\":\"{s}\",\"cancel_reason\":\"{s}\",\"early_data_source\":\"{s}\",\"early_data_action\":\"{s}\",\"early_data_retry_result\":\"{s}\",\"early_data_replay_exposed\":{s}}}\n",
             .{
                 ts,
                 entry.correlation_id,
@@ -206,19 +214,23 @@ fn appendEntry(allocator: std.mem.Allocator, out: *std.ArrayList(u8), cfg: Confi
                 entry.response_bytes,
                 entry.error_category,
                 entry.cancel_reason,
+                entry.early_data_source,
+                entry.early_data_action,
+                entry.early_data_retry_result,
+                if (entry.early_data_replay_exposed) "true" else "false",
             },
         ),
         .plain => if (entry.cancel_reason.len > 0)
             try out.print(
                 allocator,
-                "{s} {s} {d} {d}ms ip={s} req={s} upstream={s} upstream_status={?d} bytes={d} ua=\"{s}\" err={s} cancel={s}\n",
-                .{ entry.method, entry.path, entry.status, entry.latency_ms, entry.client_ip, entry.correlation_id, entry.upstream_addr, entry.upstream_status, entry.response_bytes, entry.user_agent, entry.error_category, entry.cancel_reason },
+                "{s} {s} {d} {d}ms ip={s} req={s} upstream={s} upstream_status={?d} bytes={d} ua=\"{s}\" err={s} cancel={s} early_source={s} early_action={s} early_retry={s} replay_exposed={}\n",
+                .{ entry.method, entry.path, entry.status, entry.latency_ms, entry.client_ip, entry.correlation_id, entry.upstream_addr, entry.upstream_status, entry.response_bytes, entry.user_agent, entry.error_category, entry.cancel_reason, entry.early_data_source, entry.early_data_action, entry.early_data_retry_result, entry.early_data_replay_exposed },
             )
         else
             try out.print(
                 allocator,
-                "{s} {s} {d} {d}ms ip={s} req={s} upstream={s} upstream_status={?d} bytes={d} ua=\"{s}\" err={s}\n",
-                .{ entry.method, entry.path, entry.status, entry.latency_ms, entry.client_ip, entry.correlation_id, entry.upstream_addr, entry.upstream_status, entry.response_bytes, entry.user_agent, entry.error_category },
+                "{s} {s} {d} {d}ms ip={s} req={s} upstream={s} upstream_status={?d} bytes={d} ua=\"{s}\" err={s} early_source={s} early_action={s} early_retry={s} replay_exposed={}\n",
+                .{ entry.method, entry.path, entry.status, entry.latency_ms, entry.client_ip, entry.correlation_id, entry.upstream_addr, entry.upstream_status, entry.response_bytes, entry.user_agent, entry.error_category, entry.early_data_source, entry.early_data_action, entry.early_data_retry_result, entry.early_data_replay_exposed },
             ),
         .custom => try appendTemplate(allocator, out, if (cfg.custom_template.len > 0) cfg.custom_template else "{method} {path} {status}", ts, entry),
     }
@@ -269,6 +281,14 @@ fn appendTemplate(allocator: std.mem.Allocator, out: *std.ArrayList(u8), templat
                     entry.error_category
                 else if (std.mem.eql(u8, key, "cancel_reason"))
                     entry.cancel_reason
+                else if (std.mem.eql(u8, key, "early_data_source"))
+                    entry.early_data_source
+                else if (std.mem.eql(u8, key, "early_data_action"))
+                    entry.early_data_action
+                else if (std.mem.eql(u8, key, "early_data_retry_result"))
+                    entry.early_data_retry_result
+                else if (std.mem.eql(u8, key, "early_data_replay_exposed"))
+                    if (entry.early_data_replay_exposed) "true" else "false"
                 else
                     "";
                 try out.appendSlice(allocator, replacement);
@@ -417,6 +437,10 @@ test "formatEntry json contains required fields" {
     try std.testing.expect(std.mem.find(u8, line, "\"identity\":\"user-1\"") != null);
     try std.testing.expect(std.mem.find(u8, line, "\"upstream_status\":200") != null);
     try std.testing.expect(std.mem.find(u8, line, "\"cancel_reason\":\"\"") != null);
+    try std.testing.expect(std.mem.find(u8, line, "\"early_data_source\":\"none\"") != null);
+    try std.testing.expect(std.mem.find(u8, line, "\"early_data_action\":\"ordinary\"") != null);
+    try std.testing.expect(std.mem.find(u8, line, "\"early_data_retry_result\":\"none\"") != null);
+    try std.testing.expect(std.mem.find(u8, line, "\"early_data_replay_exposed\":false") != null);
 }
 
 test "formatEntry json encodes null upstream_status as literal null" {

--- a/src/http/access_log.zig
+++ b/src/http/access_log.zig
@@ -443,6 +443,28 @@ test "formatEntry json contains required fields" {
     try std.testing.expect(std.mem.find(u8, line, "\"early_data_replay_exposed\":false") != null);
 }
 
+test "formatEntry json preserves early_data_retry_result failure label" {
+    const entry = AccessLogEntry{
+        .method = "GET",
+        .path = "/retry",
+        .status = 502,
+        .latency_ms = 7,
+        .client_ip = "127.0.0.1",
+        .correlation_id = "retry-failure",
+        .upstream_addr = "http://127.0.0.1:9001",
+        .upstream_status = 425,
+        .identity = "-",
+        .user_agent = "test",
+        .bytes_sent = 0,
+        .response_bytes = 0,
+        .error_category = "upstream_unavailable",
+        .early_data_retry_result = "failure",
+    };
+    const line = try formatEntry(std.testing.allocator, .{}, entry);
+    defer std.testing.allocator.free(line);
+    try std.testing.expect(std.mem.find(u8, line, "\"early_data_retry_result\":\"failure\"") != null);
+}
+
 test "formatEntry json encodes null upstream_status as literal null" {
     const entry = AccessLogEntry{
         .method = "GET",

--- a/src/http/encrypted_stream_connection.zig
+++ b/src/http/encrypted_stream_connection.zig
@@ -5,6 +5,9 @@ pub const EncryptedStreamHttpConnection = struct {
     stream: encrypted_stream.EncryptedStream,
     fd: std.posix.fd_t = -1,
     close_on_deinit: bool = false,
+    provenance_ctx: ?*anyopaque = null,
+    read_transport_early_fn: ?*const fn (*anyopaque) bool = null,
+    handshake_complete_fn: ?*const fn (*anyopaque) bool = null,
 
     pub fn init(stream: encrypted_stream.EncryptedStream) EncryptedStreamHttpConnection {
         return .{ .stream = stream };
@@ -12,6 +15,22 @@ pub const EncryptedStreamHttpConnection = struct {
 
     pub fn initWithFd(stream: encrypted_stream.EncryptedStream, fd: std.posix.fd_t) EncryptedStreamHttpConnection {
         return .{ .stream = stream, .fd = fd };
+    }
+
+    pub fn initWithFdAndProvenance(
+        stream: encrypted_stream.EncryptedStream,
+        fd: std.posix.fd_t,
+        provenance_ctx: *anyopaque,
+        read_transport_early_fn: *const fn (*anyopaque) bool,
+        handshake_complete_fn: *const fn (*anyopaque) bool,
+    ) EncryptedStreamHttpConnection {
+        return .{
+            .stream = stream,
+            .fd = fd,
+            .provenance_ctx = provenance_ctx,
+            .read_transport_early_fn = read_transport_early_fn,
+            .handshake_complete_fn = handshake_complete_fn,
+        };
     }
 
     pub fn deinit(self: *EncryptedStreamHttpConnection) void {
@@ -53,6 +72,18 @@ pub const EncryptedStreamHttpConnection = struct {
 
     pub fn rawFd(self: *const EncryptedStreamHttpConnection) std.posix.fd_t {
         return self.fd;
+    }
+
+    pub fn currentReadTransportEarly(self: *const EncryptedStreamHttpConnection) bool {
+        const ctx = self.provenance_ctx orelse return false;
+        const cb = self.read_transport_early_fn orelse return false;
+        return cb(ctx);
+    }
+
+    pub fn downstreamHandshakeComplete(self: *const EncryptedStreamHttpConnection) bool {
+        const ctx = self.provenance_ctx orelse return true;
+        const cb = self.handshake_complete_fn orelse return true;
+        return cb(ctx);
     }
 
     pub const Writer = struct {

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -21,6 +21,7 @@ const compat = @import("zig_compat");
 const std = @import("std");
 const http3_session = @import("http3_session.zig");
 const logger_mod = @import("logger.zig");
+const metrics_mod = @import("metrics.zig");
 const response_mod = @import("response.zig");
 const shutdown = @import("shutdown.zig");
 const stream_transport = @import("stream_transport");
@@ -67,6 +68,8 @@ pub const Config = struct {
     max_datagram_size: usize = 1350,
     request_handler: ?RequestHandler = null,
     request_handler_ctx: ?*anyopaque = null,
+    early_data_compat_metrics_ctx: ?*anyopaque = null,
+    early_data_compat_metrics_cb: ?*const fn (*anyopaque, metrics_mod.H3EarlyDataCompatDecision) void = null,
 };
 
 /// Half-open admission limits (#328 review). The native stack does not send
@@ -148,6 +151,8 @@ pub const Runtime = struct {
     h3_settings: http3.frame.Settings,
     h3_application_compat: [http3.early_data.encoded_snapshot_len]u8 = undefined,
     h3_application_compat_len: usize = 0,
+    early_data_compat_metrics_ctx: ?*anyopaque = null,
+    early_data_compat_metrics_cb: ?*const fn (*anyopaque, metrics_mod.H3EarlyDataCompatDecision) void = null,
     snapshot_mutex: compat.Mutex = .{},
     snapshot_state: Snapshot,
     stopping: std.atomic.Value(bool),
@@ -181,6 +186,8 @@ pub const Runtime = struct {
             .resumption_runtime = cfg.resumption_runtime,
             .quic_config = quicConfigFrom(cfg),
             .h3_settings = cfg.h3_settings,
+            .early_data_compat_metrics_ctx = cfg.early_data_compat_metrics_ctx,
+            .early_data_compat_metrics_cb = cfg.early_data_compat_metrics_cb,
             .snapshot_state = .{ .quic_port = cfg.quic_port },
             .stopping = std.atomic.Value(bool).init(false),
         };
@@ -662,15 +669,35 @@ pub const Runtime = struct {
 
     fn h3EarlyDataCompatibility(ctx: *anyopaque, candidate: tls_core.tls13_backend.EarlyDataCompatibilityCandidate) tls_core.tls13_backend.EarlyDataCompatibilityDecision {
         const self: *Runtime = @ptrCast(@alignCast(ctx));
-        const app = candidate.remembered_application orelse return .application_incompatible;
+        const app = candidate.remembered_application orelse {
+            self.recordH3EarlyDataCompat(.missing_state);
+            return .application_incompatible;
+        };
+
         return switch (http3.early_data.compatibility(.{
             .format_id = app.format_id,
             .format_version = app.format_version,
             .bytes = app.bytes,
         }, self.h3_settings)) {
-            .compatible => .compatible,
-            .missing_state, .malformed_state, .settings_incompatible => .application_incompatible,
+            .compatible => blk: {
+                self.recordH3EarlyDataCompat(.compatible);
+                break :blk .compatible;
+            },
+            .missing_state => blk: {
+                self.recordH3EarlyDataCompat(.missing_state);
+                break :blk .application_incompatible;
+            },
+            .malformed_state, .settings_incompatible => blk: {
+                self.recordH3EarlyDataCompat(.settings_incompatible);
+                break :blk .application_incompatible;
+            },
         };
+    }
+
+    fn recordH3EarlyDataCompat(self: *Runtime, decision: metrics_mod.H3EarlyDataCompatDecision) void {
+        const cb = self.early_data_compat_metrics_cb orelse return;
+        const cb_ctx = self.early_data_compat_metrics_ctx orelse return;
+        cb(cb_ctx, decision);
     }
 
     fn noteConnectionAccepted(self: *Runtime) void {

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -576,6 +576,7 @@ pub const Runtime = struct {
             return;
         };
         defer request.deinit();
+            request.transport_early = incoming.transport_early;
 
         var response = response_mod.Response.init(allocator);
         defer response.deinit();

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -84,10 +84,10 @@ const handshake_timeout_us: u64 = 10 * std.time.us_per_s;
 
 const ParkedH3Retry = struct {
     stream_id: u64,
-    request: http3_session.StreamRequest,
+    continuation: http3_session.StreamRequest.Early425RetryContinuation,
 
-    fn deinit(self: *ParkedH3Retry) void {
-        self.request.deinit();
+    fn deinit(self: *ParkedH3Retry, allocator: std.mem.Allocator) void {
+        self.continuation.deinit(allocator);
         self.* = undefined;
     }
 };
@@ -142,7 +142,7 @@ const ConnEntry = struct {
     parked_h3_retries: std.ArrayList(ParkedH3Retry) = .empty,
 
     fn deinit(self: *ConnEntry, allocator: std.mem.Allocator) void {
-        for (self.parked_h3_retries.items) |*parked| parked.deinit();
+        for (self.parked_h3_retries.items) |*parked| parked.deinit(allocator);
         self.parked_h3_retries.deinit(allocator);
         self.h3.deinit();
         self.conn.deinit();
@@ -619,21 +619,13 @@ pub const Runtime = struct {
     }
 
     fn resumeParkedH3Retries(self: *Runtime, entry: *ConnEntry) void {
-        const handler = self.request_handler orelse return;
         while (entry.parked_h3_retries.items.len != 0) {
             var parked = entry.parked_h3_retries.orderedRemove(0);
-            defer parked.deinit();
-            parked.request.downstream_handshake_complete = entry.conn.isEstablished();
-            parked.request.downstream_handshake = .{
-                .ctx = entry.conn,
-                .is_complete_fn = h3DownstreamHandshakeComplete,
-                .wait_or_drive_fn = h3DownstreamWaitOrDriveHandshake,
-            };
-            parked.request.park_early_425_retry = null;
+            defer parked.deinit(self.allocator);
 
             var response = response_mod.Response.init(self.allocator);
             defer response.deinit();
-            handler(self.allocator, &parked.request, &response, self.request_handler_ctx) catch |err| {
+            parked.continuation.run(self.allocator, &response) catch |err| {
                 self.logger.warn(null, "http3: parked request retry failed: {s}", .{@errorName(err)});
                 entry.h3.sendResponse(entry.conn, parked.stream_id, 500, &.{}, "") catch {};
                 return;
@@ -688,19 +680,11 @@ pub const Runtime = struct {
         stream_id: u64,
     };
 
-    fn parkH3Early425Retry(ctx: *anyopaque, request: *const http3_session.StreamRequest) anyerror!void {
+    fn parkH3Early425Retry(ctx: *anyopaque, continuation: http3_session.StreamRequest.Early425RetryContinuation) anyerror!void {
         const park_ctx: *H3ParkContext = @ptrCast(@alignCast(ctx));
-        var parked_request = try request.clone(park_ctx.runtime.allocator);
-        errdefer parked_request.deinit();
-        parked_request.stream_id = park_ctx.stream_id;
-        parked_request.transport_early = false;
-        parked_request.downstream_handshake_complete = false;
-        parked_request.downstream_handshake = null;
-        parked_request.resume_early_425_retry = true;
-        parked_request.park_early_425_retry = null;
         try park_ctx.entry.parked_h3_retries.append(park_ctx.runtime.allocator, .{
             .stream_id = park_ctx.stream_id,
-            .request = parked_request,
+            .continuation = continuation,
         });
     }
 

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -577,6 +577,7 @@ pub const Runtime = struct {
         };
         defer request.deinit();
         request.transport_early = incoming.transport_early;
+        request.downstream_handshake_complete = entry.conn.isEstablished();
 
         var response = response_mod.Response.init(allocator);
         defer response.deinit();

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -637,7 +637,7 @@ pub const Runtime = struct {
             parked.continuation.run(self.allocator, &response) catch |err| {
                 self.logger.warn(null, "http3: parked request retry failed: {s}", .{@errorName(err)});
                 self.sendInternalErrorResponse(entry, parked.stream_id);
-                return;
+                continue;
             };
             self.sendHandlerResponse(entry, parked.stream_id, &response);
         }
@@ -1108,6 +1108,8 @@ const TestH3ResumeConn = struct {
 
 const TestH3ResumeSession = struct {
     send_calls: usize = 0,
+    ok_sends: usize = 0,
+    internal_error_sends: usize = 0,
     finish_calls: usize = 0,
     send_fail: bool = false,
     last_status: u16 = 0,
@@ -1127,6 +1129,8 @@ const TestH3ResumeSession = struct {
         self.send_calls += 1;
         self.last_status = status;
         self.last_stream_id = stream_id;
+        if (status == 200) self.ok_sends += 1;
+        if (status == 500) self.internal_error_sends += 1;
         if (self.send_fail) return error.StreamBackpressure;
     }
 
@@ -1211,6 +1215,82 @@ test "parked H3 retry fallback send failure resets and finishes stream once" {
     try testing.expectEqual(@as(usize, 1), entry.h3.finish_calls);
     try testing.expectEqual(@as(u64, 13), conn.last_reset_stream_id);
     try testing.expectEqual(@as(u64, 13), entry.h3.last_stream_id);
+}
+
+test "failed parked H3 retry does not stop later parked retry" {
+    const allocator = testing.allocator;
+    var logger = logger_mod.Logger.init(.err, "http3-parked-drain-test");
+    var runtime = try Runtime.init(allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+    });
+    defer runtime.deinit();
+
+    var conn = TestH3ResumeConn{ .established = true };
+    var entry = TestH3ResumeEntry{ .conn = &conn };
+    defer entry.deinit(allocator);
+    var failed = TestParkedContinuationState{ .fail_run = true };
+    var resumed = TestParkedContinuationState{};
+    try entry.parked_h3_retries.append(allocator, .{
+        .stream_id = 21,
+        .continuation = failed.continuation(),
+    });
+    try entry.parked_h3_retries.append(allocator, .{
+        .stream_id = 23,
+        .continuation = resumed.continuation(),
+    });
+
+    runtime.resumeParkedH3RetriesForEntry(&entry);
+
+    try testing.expectEqual(@as(usize, 0), entry.parked_h3_retries.items.len);
+    try testing.expectEqual(@as(usize, 1), failed.run_calls);
+    try testing.expectEqual(@as(usize, 1), failed.deinit_calls);
+    try testing.expectEqual(@as(usize, 1), resumed.run_calls);
+    try testing.expectEqual(@as(usize, 1), resumed.deinit_calls);
+    try testing.expectEqual(@as(usize, 2), entry.h3.send_calls);
+    try testing.expectEqual(@as(usize, 1), entry.h3.internal_error_sends);
+    try testing.expectEqual(@as(usize, 1), entry.h3.ok_sends);
+    try testing.expectEqual(@as(usize, 0), conn.reset_calls);
+    try testing.expectEqual(@as(u64, 23), entry.h3.last_stream_id);
+}
+
+test "failed parked H3 retry reset path does not stop later parked retry" {
+    const allocator = testing.allocator;
+    var logger = logger_mod.Logger.init(.err, "http3-parked-reset-drain-test");
+    var runtime = try Runtime.init(allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+    });
+    defer runtime.deinit();
+
+    var conn = TestH3ResumeConn{ .established = true };
+    var entry = TestH3ResumeEntry{
+        .conn = &conn,
+        .h3 = .{ .send_fail = true },
+    };
+    defer entry.deinit(allocator);
+    var failed = TestParkedContinuationState{ .fail_run = true };
+    var resumed = TestParkedContinuationState{};
+    try entry.parked_h3_retries.append(allocator, .{
+        .stream_id = 31,
+        .continuation = failed.continuation(),
+    });
+    try entry.parked_h3_retries.append(allocator, .{
+        .stream_id = 33,
+        .continuation = resumed.continuation(),
+    });
+
+    runtime.resumeParkedH3RetriesForEntry(&entry);
+
+    try testing.expectEqual(@as(usize, 0), entry.parked_h3_retries.items.len);
+    try testing.expectEqual(@as(usize, 1), failed.run_calls);
+    try testing.expectEqual(@as(usize, 1), failed.deinit_calls);
+    try testing.expectEqual(@as(usize, 1), resumed.run_calls);
+    try testing.expectEqual(@as(usize, 1), resumed.deinit_calls);
+    try testing.expectEqual(@as(usize, 2), entry.h3.send_calls);
+    try testing.expectEqual(@as(usize, 2), conn.reset_calls);
+    try testing.expectEqual(@as(usize, 2), entry.h3.finish_calls);
+    try testing.expectEqual(@as(u64, 33), conn.last_reset_stream_id);
 }
 
 test "runtime borrows the credential provider and owns no key material" {

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -82,6 +82,16 @@ const max_connections: usize = 1024;
 const max_connections_per_source: u32 = 32;
 const handshake_timeout_us: u64 = 10 * std.time.us_per_s;
 
+const ParkedH3Retry = struct {
+    stream_id: u64,
+    request: http3_session.StreamRequest,
+
+    fn deinit(self: *ParkedH3Retry) void {
+        self.request.deinit();
+        self.* = undefined;
+    }
+};
+
 pub const Snapshot = struct {
     quic_port: u16 = 0,
     server_bootstrapped: bool = false,
@@ -129,8 +139,11 @@ const ConnEntry = struct {
     /// issuance (successfully or not) — issuance is best-effort and must
     /// never be retried on the same connection (#488).
     ticket_issue_attempted: bool = false,
+    parked_h3_retries: std.ArrayList(ParkedH3Retry) = .empty,
 
     fn deinit(self: *ConnEntry, allocator: std.mem.Allocator) void {
+        for (self.parked_h3_retries.items) |*parked| parked.deinit();
+        self.parked_h3_retries.deinit(allocator);
         self.h3.deinit();
         self.conn.deinit();
         allocator.destroy(self.backend);
@@ -554,6 +567,7 @@ pub const Runtime = struct {
             entry.conn.close(code, "h3 protocol error", now);
             return;
         };
+        self.resumeParkedH3Retries(entry);
         while (true) {
             const incoming = entry.h3.pollRequest() catch {
                 entry.conn.close(entry.h3.closeCode(), "h3 request error", now);
@@ -564,6 +578,7 @@ pub const Runtime = struct {
     }
 
     fn serveRequest(self: *Runtime, entry: *ConnEntry, incoming: H3.IncomingRequest, now: u64) void {
+        _ = now;
         const allocator = self.allocator;
         const handler = self.request_handler orelse {
             entry.h3.sendResponse(entry.conn, incoming.stream_id, 404, &.{}, "") catch {};
@@ -576,6 +591,7 @@ pub const Runtime = struct {
             return;
         };
         defer request.deinit();
+        request.stream_id = incoming.stream_id;
         request.transport_early = incoming.transport_early;
         request.downstream_handshake_complete = entry.conn.isEstablished();
         request.downstream_handshake = .{
@@ -583,16 +599,50 @@ pub const Runtime = struct {
             .is_complete_fn = h3DownstreamHandshakeComplete,
             .wait_or_drive_fn = h3DownstreamWaitOrDriveHandshake,
         };
+        var park_ctx = H3ParkContext{ .runtime = self, .entry = entry, .stream_id = incoming.stream_id };
+        request.park_early_425_retry = .{
+            .ctx = &park_ctx,
+            .park_fn = parkH3Early425Retry,
+        };
 
         var response = response_mod.Response.init(allocator);
         defer response.deinit();
         handler(allocator, &request, &response, self.request_handler_ctx) catch |err| {
+            if (err == error.Http3RequestParked) return;
             self.logger.warn(null, "http3: request handler failed: {s}", .{@errorName(err)});
             entry.h3.sendResponse(entry.conn, incoming.stream_id, 500, &.{}, "") catch {};
             entry.h3.finishRequest(incoming.stream_id);
             return;
         };
 
+        self.sendHandlerResponse(entry, incoming.stream_id, &response);
+    }
+
+    fn resumeParkedH3Retries(self: *Runtime, entry: *ConnEntry) void {
+        const handler = self.request_handler orelse return;
+        while (entry.parked_h3_retries.items.len != 0) {
+            var parked = entry.parked_h3_retries.orderedRemove(0);
+            defer parked.deinit();
+            parked.request.downstream_handshake_complete = entry.conn.isEstablished();
+            parked.request.downstream_handshake = .{
+                .ctx = entry.conn,
+                .is_complete_fn = h3DownstreamHandshakeComplete,
+                .wait_or_drive_fn = h3DownstreamWaitOrDriveHandshake,
+            };
+            parked.request.park_early_425_retry = null;
+
+            var response = response_mod.Response.init(self.allocator);
+            defer response.deinit();
+            handler(self.allocator, &parked.request, &response, self.request_handler_ctx) catch |err| {
+                self.logger.warn(null, "http3: parked request retry failed: {s}", .{@errorName(err)});
+                entry.h3.sendResponse(entry.conn, parked.stream_id, 500, &.{}, "") catch {};
+                return;
+            };
+            self.sendHandlerResponse(entry, parked.stream_id, &response);
+        }
+    }
+
+    fn sendHandlerResponse(self: *Runtime, entry: *ConnEntry, stream_id: u64, response: *const response_mod.Response) void {
         var headers_buf: [64]stream_transport.Header = undefined;
         var header_count: usize = 0;
         for (response.headers.iterator()) |header| {
@@ -602,17 +652,16 @@ pub const Runtime = struct {
         }
         entry.h3.sendResponse(
             entry.conn,
-            incoming.stream_id,
+            stream_id,
             response.status.code(),
             headers_buf[0..header_count],
             response.body orelse "",
         ) catch |err| {
             self.logger.warn(null, "http3: response send failed: {s}", .{@errorName(err)});
-            entry.conn.resetStream(incoming.stream_id, 0x0102) catch {}; // H3_INTERNAL_ERROR
-            entry.h3.finishRequest(incoming.stream_id);
+            entry.conn.resetStream(stream_id, 0x0102) catch {}; // H3_INTERNAL_ERROR
+            entry.h3.finishRequest(stream_id);
             return;
         };
-        _ = now;
         self.noteRequestCompleted();
     }
 
@@ -631,6 +680,28 @@ pub const Runtime = struct {
     fn h3DownstreamWaitOrDriveHandshake(ctx: *anyopaque) anyerror!void {
         const conn: *Connection = @ptrCast(@alignCast(ctx));
         conn.driveAuthentication(nowUs());
+    }
+
+    const H3ParkContext = struct {
+        runtime: *Runtime,
+        entry: *ConnEntry,
+        stream_id: u64,
+    };
+
+    fn parkH3Early425Retry(ctx: *anyopaque, request: *const http3_session.StreamRequest) anyerror!void {
+        const park_ctx: *H3ParkContext = @ptrCast(@alignCast(ctx));
+        var parked_request = try request.clone(park_ctx.runtime.allocator);
+        errdefer parked_request.deinit();
+        parked_request.stream_id = park_ctx.stream_id;
+        parked_request.transport_early = false;
+        parked_request.downstream_handshake_complete = false;
+        parked_request.downstream_handshake = null;
+        parked_request.resume_early_425_retry = true;
+        parked_request.park_early_425_retry = null;
+        try park_ctx.entry.parked_h3_retries.append(park_ctx.runtime.allocator, .{
+            .stream_id = park_ctx.stream_id,
+            .request = parked_request,
+        });
     }
 
     /// #488: best-effort, exactly-once post-handshake ticket issuance for

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -578,6 +578,11 @@ pub const Runtime = struct {
         defer request.deinit();
         request.transport_early = incoming.transport_early;
         request.downstream_handshake_complete = entry.conn.isEstablished();
+        request.downstream_handshake = .{
+            .ctx = entry.conn,
+            .is_complete_fn = h3DownstreamHandshakeComplete,
+            .wait_or_drive_fn = h3DownstreamWaitOrDriveHandshake,
+        };
 
         var response = response_mod.Response.init(allocator);
         defer response.deinit();
@@ -616,6 +621,16 @@ pub const Runtime = struct {
         if (sent >= 0 and @as(usize, @intCast(sent)) == datagram.len) {
             self.notePacketOut(datagram.len);
         }
+    }
+
+    fn h3DownstreamHandshakeComplete(ctx: *anyopaque) bool {
+        const conn: *Connection = @ptrCast(@alignCast(ctx));
+        return conn.isEstablished();
+    }
+
+    fn h3DownstreamWaitOrDriveHandshake(ctx: *anyopaque) anyerror!void {
+        const conn: *Connection = @ptrCast(@alignCast(ctx));
+        conn.driveAuthentication(nowUs());
     }
 
     /// #488: best-effort, exactly-once post-handshake ticket issuance for

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -619,6 +619,15 @@ pub const Runtime = struct {
     }
 
     fn resumeParkedH3Retries(self: *Runtime, entry: *ConnEntry) void {
+        self.resumeParkedH3RetriesForEntry(entry);
+    }
+
+    fn resumeParkedH3RetriesForEntry(self: *Runtime, entry: anytype) void {
+        if (!entry.conn.isEstablished()) return;
+        self.resumeEstablishedParkedH3Retries(entry);
+    }
+
+    fn resumeEstablishedParkedH3Retries(self: *Runtime, entry: anytype) void {
         while (entry.parked_h3_retries.items.len != 0) {
             var parked = entry.parked_h3_retries.orderedRemove(0);
             defer parked.deinit(self.allocator);
@@ -627,14 +636,14 @@ pub const Runtime = struct {
             defer response.deinit();
             parked.continuation.run(self.allocator, &response) catch |err| {
                 self.logger.warn(null, "http3: parked request retry failed: {s}", .{@errorName(err)});
-                entry.h3.sendResponse(entry.conn, parked.stream_id, 500, &.{}, "") catch {};
+                self.sendInternalErrorResponse(entry, parked.stream_id);
                 return;
             };
             self.sendHandlerResponse(entry, parked.stream_id, &response);
         }
     }
 
-    fn sendHandlerResponse(self: *Runtime, entry: *ConnEntry, stream_id: u64, response: *const response_mod.Response) void {
+    fn sendHandlerResponse(self: *Runtime, entry: anytype, stream_id: u64, response: *const response_mod.Response) void {
         var headers_buf: [64]stream_transport.Header = undefined;
         var header_count: usize = 0;
         for (response.headers.iterator()) |header| {
@@ -650,6 +659,16 @@ pub const Runtime = struct {
             response.body orelse "",
         ) catch |err| {
             self.logger.warn(null, "http3: response send failed: {s}", .{@errorName(err)});
+            entry.conn.resetStream(stream_id, 0x0102) catch {}; // H3_INTERNAL_ERROR
+            entry.h3.finishRequest(stream_id);
+            return;
+        };
+        self.noteRequestCompleted();
+    }
+
+    fn sendInternalErrorResponse(self: *Runtime, entry: anytype, stream_id: u64) void {
+        entry.h3.sendResponse(entry.conn, stream_id, 500, &.{}, "") catch |err| {
+            self.logger.warn(null, "http3: fallback response send failed: {s}", .{@errorName(err)});
             entry.conn.resetStream(stream_id, 0x0102) catch {}; // H3_INTERNAL_ERROR
             entry.h3.finishRequest(stream_id);
             return;
@@ -1041,6 +1060,157 @@ test "per-source admission counter increments and prunes to empty" {
     try testing.expect(per_ip.get(0x0100007f) == null);
     // Decrementing an unknown address is a no-op, not a crash.
     decPerIp(&per_ip, 0xdeadbeef);
+}
+
+const TestParkedContinuationState = struct {
+    run_calls: usize = 0,
+    deinit_calls: usize = 0,
+    fail_run: bool = false,
+
+    fn run(ctx: *anyopaque, allocator: std.mem.Allocator, response: *response_mod.Response) !void {
+        _ = allocator;
+        const self: *TestParkedContinuationState = @ptrCast(@alignCast(ctx));
+        self.run_calls += 1;
+        if (self.fail_run) return error.TestParkedContinuationFailed;
+        _ = response.setStatus(.ok).setBody("resumed");
+    }
+
+    fn deinit(ctx: *anyopaque, allocator: std.mem.Allocator) void {
+        _ = allocator;
+        const self: *TestParkedContinuationState = @ptrCast(@alignCast(ctx));
+        self.deinit_calls += 1;
+    }
+
+    fn continuation(self: *TestParkedContinuationState) http3_session.StreamRequest.Early425RetryContinuation {
+        return .{
+            .ctx = self,
+            .resume_fn = run,
+            .deinit_fn = deinit,
+        };
+    }
+};
+
+const TestH3ResumeConn = struct {
+    established: bool = false,
+    reset_calls: usize = 0,
+    last_reset_stream_id: u64 = 0,
+
+    fn isEstablished(self: *TestH3ResumeConn) bool {
+        return self.established;
+    }
+
+    fn resetStream(self: *TestH3ResumeConn, stream_id: u64, code: u64) !void {
+        _ = code;
+        self.reset_calls += 1;
+        self.last_reset_stream_id = stream_id;
+    }
+};
+
+const TestH3ResumeSession = struct {
+    send_calls: usize = 0,
+    finish_calls: usize = 0,
+    send_fail: bool = false,
+    last_status: u16 = 0,
+    last_stream_id: u64 = 0,
+
+    fn sendResponse(
+        self: *TestH3ResumeSession,
+        conn: *TestH3ResumeConn,
+        stream_id: u64,
+        status: u16,
+        headers: []const stream_transport.Header,
+        body: []const u8,
+    ) !void {
+        _ = conn;
+        _ = headers;
+        _ = body;
+        self.send_calls += 1;
+        self.last_status = status;
+        self.last_stream_id = stream_id;
+        if (self.send_fail) return error.StreamBackpressure;
+    }
+
+    fn finishRequest(self: *TestH3ResumeSession, stream_id: u64) void {
+        self.finish_calls += 1;
+        self.last_stream_id = stream_id;
+    }
+};
+
+const TestH3ResumeEntry = struct {
+    conn: *TestH3ResumeConn,
+    h3: TestH3ResumeSession = .{},
+    parked_h3_retries: std.ArrayList(ParkedH3Retry) = .empty,
+
+    fn deinit(self: *TestH3ResumeEntry, allocator: std.mem.Allocator) void {
+        for (self.parked_h3_retries.items) |*parked| parked.deinit(allocator);
+        self.parked_h3_retries.deinit(allocator);
+    }
+};
+
+test "parked H3 retry resumes only after connection establishment" {
+    const allocator = testing.allocator;
+    var logger = logger_mod.Logger.init(.err, "http3-parked-resume-test");
+    var runtime = try Runtime.init(allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+    });
+    defer runtime.deinit();
+
+    var conn = TestH3ResumeConn{};
+    var entry = TestH3ResumeEntry{ .conn = &conn };
+    defer entry.deinit(allocator);
+    var continuation = TestParkedContinuationState{};
+    try entry.parked_h3_retries.append(allocator, .{
+        .stream_id = 11,
+        .continuation = continuation.continuation(),
+    });
+
+    runtime.resumeParkedH3RetriesForEntry(&entry);
+    try testing.expectEqual(@as(usize, 1), entry.parked_h3_retries.items.len);
+    try testing.expectEqual(@as(usize, 0), continuation.run_calls);
+    try testing.expectEqual(@as(usize, 0), entry.h3.send_calls);
+
+    conn.established = true;
+    runtime.resumeParkedH3RetriesForEntry(&entry);
+    try testing.expectEqual(@as(usize, 0), entry.parked_h3_retries.items.len);
+    try testing.expectEqual(@as(usize, 1), continuation.run_calls);
+    try testing.expectEqual(@as(usize, 1), continuation.deinit_calls);
+    try testing.expectEqual(@as(usize, 1), entry.h3.send_calls);
+    try testing.expectEqual(@as(u16, 200), entry.h3.last_status);
+    try testing.expectEqual(@as(u64, 11), entry.h3.last_stream_id);
+}
+
+test "parked H3 retry fallback send failure resets and finishes stream once" {
+    const allocator = testing.allocator;
+    var logger = logger_mod.Logger.init(.err, "http3-parked-fallback-test");
+    var runtime = try Runtime.init(allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+    });
+    defer runtime.deinit();
+
+    var conn = TestH3ResumeConn{ .established = true };
+    var entry = TestH3ResumeEntry{
+        .conn = &conn,
+        .h3 = .{ .send_fail = true },
+    };
+    defer entry.deinit(allocator);
+    var continuation = TestParkedContinuationState{ .fail_run = true };
+    try entry.parked_h3_retries.append(allocator, .{
+        .stream_id = 13,
+        .continuation = continuation.continuation(),
+    });
+
+    runtime.resumeParkedH3RetriesForEntry(&entry);
+
+    try testing.expectEqual(@as(usize, 0), entry.parked_h3_retries.items.len);
+    try testing.expectEqual(@as(usize, 1), continuation.run_calls);
+    try testing.expectEqual(@as(usize, 1), continuation.deinit_calls);
+    try testing.expectEqual(@as(usize, 1), entry.h3.send_calls);
+    try testing.expectEqual(@as(usize, 1), conn.reset_calls);
+    try testing.expectEqual(@as(usize, 1), entry.h3.finish_calls);
+    try testing.expectEqual(@as(u64, 13), conn.last_reset_stream_id);
+    try testing.expectEqual(@as(u64, 13), entry.h3.last_stream_id);
 }
 
 test "runtime borrows the credential provider and owns no key material" {

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -576,7 +576,7 @@ pub const Runtime = struct {
             return;
         };
         defer request.deinit();
-            request.transport_early = incoming.transport_early;
+        request.transport_early = incoming.transport_early;
 
         var response = response_mod.Response.init(allocator);
         defer response.deinit();

--- a/src/http/http3_session.zig
+++ b/src/http/http3_session.zig
@@ -30,15 +30,28 @@ pub const StreamRequest = struct {
     transport_early: bool = false,
     downstream_handshake_complete: bool = true,
     downstream_handshake: ?request_context.DownstreamHandshakeBarrier = null,
-    resume_early_425_retry: bool = false,
     park_early_425_retry: ?ParkEarly425Retry = null,
+
+    pub const Early425RetryContinuation = struct {
+        ctx: *anyopaque,
+        resume_fn: *const fn (*anyopaque, std.mem.Allocator, *Response) anyerror!void,
+        deinit_fn: *const fn (*anyopaque, std.mem.Allocator) void,
+
+        pub fn run(self: Early425RetryContinuation, allocator: std.mem.Allocator, response: *Response) !void {
+            try self.resume_fn(self.ctx, allocator, response);
+        }
+
+        pub fn deinit(self: Early425RetryContinuation, allocator: std.mem.Allocator) void {
+            self.deinit_fn(self.ctx, allocator);
+        }
+    };
 
     pub const ParkEarly425Retry = struct {
         ctx: *anyopaque,
-        park_fn: *const fn (*anyopaque, *const StreamRequest) anyerror!void,
+        park_fn: *const fn (*anyopaque, Early425RetryContinuation) anyerror!void,
 
-        pub fn park(self: ParkEarly425Retry, request: *const StreamRequest) !void {
-            try self.park_fn(self.ctx, request);
+        pub fn park(self: ParkEarly425Retry, continuation: Early425RetryContinuation) !void {
+            try self.park_fn(self.ctx, continuation);
         }
     };
 
@@ -51,31 +64,9 @@ pub const StreamRequest = struct {
         self.* = undefined;
     }
 
-    pub fn clone(self: *const StreamRequest, allocator: std.mem.Allocator) !StreamRequest {
-        var headers = Headers.init(allocator);
-        errdefer headers.deinit();
-        for (self.headers.iterator()) |header| {
-            try headers.append(header.name, header.value);
-        }
-        return .{
-            .allocator = allocator,
-            .stream_id = self.stream_id,
-            .method = try allocator.dupe(u8, self.method),
-            .path = try allocator.dupe(u8, self.path),
-            .authority = if (self.authority) |authority| try allocator.dupe(u8, authority) else null,
-            .headers = headers,
-            .body = try allocator.dupe(u8, self.body),
-            .transport_early = self.transport_early,
-            .downstream_handshake_complete = self.downstream_handshake_complete,
-            .downstream_handshake = self.downstream_handshake,
-            .resume_early_425_retry = self.resume_early_425_retry,
-            .park_early_425_retry = self.park_early_425_retry,
-        };
-    }
-
-    pub fn parkEarly425Retry(self: *const StreamRequest) !void {
+    pub fn parkEarly425Retry(self: *const StreamRequest, continuation: Early425RetryContinuation) !void {
         const parker = self.park_early_425_retry orelse return error.Http3Early425RetryCannotPark;
-        try parker.park(self);
+        try parker.park(continuation);
     }
 };
 
@@ -151,7 +142,6 @@ pub const StreamAssembler = struct {
             .transport_early = false,
             .downstream_handshake_complete = true,
             .downstream_handshake = null,
-            .resume_early_425_retry = false,
             .park_early_425_retry = null,
         };
     }

--- a/src/http/http3_session.zig
+++ b/src/http/http3_session.zig
@@ -26,6 +26,7 @@ pub const StreamRequest = struct {
     headers: Headers,
     body: []u8,
     transport_early: bool = false,
+    downstream_handshake_complete: bool = true,
 
     pub fn deinit(self: *StreamRequest) void {
         self.allocator.free(self.method);
@@ -106,6 +107,7 @@ pub const StreamAssembler = struct {
             .headers = headers,
             .body = try self.body.toOwnedSlice(self.allocator),
             .transport_early = false,
+            .downstream_handshake_complete = true,
         };
     }
 };

--- a/src/http/http3_session.zig
+++ b/src/http/http3_session.zig
@@ -21,6 +21,7 @@ pub const EncodedHeaderBlock = struct {
 
 pub const StreamRequest = struct {
     allocator: std.mem.Allocator,
+    stream_id: ?u64 = null,
     method: []u8,
     path: []u8,
     authority: ?[]u8,
@@ -29,6 +30,17 @@ pub const StreamRequest = struct {
     transport_early: bool = false,
     downstream_handshake_complete: bool = true,
     downstream_handshake: ?request_context.DownstreamHandshakeBarrier = null,
+    resume_early_425_retry: bool = false,
+    park_early_425_retry: ?ParkEarly425Retry = null,
+
+    pub const ParkEarly425Retry = struct {
+        ctx: *anyopaque,
+        park_fn: *const fn (*anyopaque, *const StreamRequest) anyerror!void,
+
+        pub fn park(self: ParkEarly425Retry, request: *const StreamRequest) !void {
+            try self.park_fn(self.ctx, request);
+        }
+    };
 
     pub fn deinit(self: *StreamRequest) void {
         self.allocator.free(self.method);
@@ -37,6 +49,33 @@ pub const StreamRequest = struct {
         self.headers.deinit();
         self.allocator.free(self.body);
         self.* = undefined;
+    }
+
+    pub fn clone(self: *const StreamRequest, allocator: std.mem.Allocator) !StreamRequest {
+        var headers = Headers.init(allocator);
+        errdefer headers.deinit();
+        for (self.headers.iterator()) |header| {
+            try headers.append(header.name, header.value);
+        }
+        return .{
+            .allocator = allocator,
+            .stream_id = self.stream_id,
+            .method = try allocator.dupe(u8, self.method),
+            .path = try allocator.dupe(u8, self.path),
+            .authority = if (self.authority) |authority| try allocator.dupe(u8, authority) else null,
+            .headers = headers,
+            .body = try allocator.dupe(u8, self.body),
+            .transport_early = self.transport_early,
+            .downstream_handshake_complete = self.downstream_handshake_complete,
+            .downstream_handshake = self.downstream_handshake,
+            .resume_early_425_retry = self.resume_early_425_retry,
+            .park_early_425_retry = self.park_early_425_retry,
+        };
+    }
+
+    pub fn parkEarly425Retry(self: *const StreamRequest) !void {
+        const parker = self.park_early_425_retry orelse return error.Http3Early425RetryCannotPark;
+        try parker.park(self);
     }
 };
 
@@ -103,6 +142,7 @@ pub const StreamAssembler = struct {
 
         return .{
             .allocator = self.allocator,
+            .stream_id = null,
             .method = try self.allocator.dupe(u8, method),
             .path = try self.allocator.dupe(u8, path),
             .authority = if (self.authority) |authority| try self.allocator.dupe(u8, authority) else null,
@@ -111,6 +151,8 @@ pub const StreamAssembler = struct {
             .transport_early = false,
             .downstream_handshake_complete = true,
             .downstream_handshake = null,
+            .resume_early_425_retry = false,
+            .park_early_425_retry = null,
         };
     }
 };

--- a/src/http/http3_session.zig
+++ b/src/http/http3_session.zig
@@ -25,6 +25,7 @@ pub const StreamRequest = struct {
     authority: ?[]u8,
     headers: Headers,
     body: []u8,
+    transport_early: bool = false,
 
     pub fn deinit(self: *StreamRequest) void {
         self.allocator.free(self.method);
@@ -104,6 +105,7 @@ pub const StreamAssembler = struct {
             .authority = if (self.authority) |authority| try self.allocator.dupe(u8, authority) else null,
             .headers = headers,
             .body = try self.body.toOwnedSlice(self.allocator),
+            .transport_early = false,
         };
     }
 };

--- a/src/http/http3_session.zig
+++ b/src/http/http3_session.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const Headers = @import("headers.zig").Headers;
+const request_context = @import("request_context.zig");
 const Response = @import("response.zig").Response;
 
 pub const Http3SessionError = error{
@@ -27,6 +28,7 @@ pub const StreamRequest = struct {
     body: []u8,
     transport_early: bool = false,
     downstream_handshake_complete: bool = true,
+    downstream_handshake: ?request_context.DownstreamHandshakeBarrier = null,
 
     pub fn deinit(self: *StreamRequest) void {
         self.allocator.free(self.method);
@@ -108,6 +110,7 @@ pub const StreamAssembler = struct {
             .body = try self.body.toOwnedSlice(self.allocator),
             .transport_early = false,
             .downstream_handshake_complete = true,
+            .downstream_handshake = null,
         };
     }
 };

--- a/src/http/metrics.zig
+++ b/src/http/metrics.zig
@@ -26,10 +26,23 @@ pub const ResumptionOutcome = enum { accepted, full_handshake, incompatible, mis
 pub const ResumptionMode = enum { stateful, stateless, hybrid };
 pub const TicketResult = enum { success, rejected, failed };
 
+pub const HttpProtocol = enum { h1, h2, h3 };
+pub const EarlyDataSource = enum { transport, header, both };
+pub const EarlyDataDecision = enum { accepted, too_early, deferred, forwarded };
+pub const EarlyDataUpstream425Action = enum { forwarded, retried };
+pub const EarlyDataRetryResult = enum { success, too_early, failure };
+pub const H3EarlyDataCompatDecision = enum { compatible, transport_incompatible, settings_incompatible, missing_state };
+
 const resumption_transport_count = 2;
 const resumption_outcome_count = 5;
 const resumption_mode_count = 3;
 const ticket_result_count = 3;
+const http_protocol_count = 3;
+const early_data_source_count = 3;
+const early_data_decision_count = 4;
+const early_data_upstream_425_action_count = 2;
+const early_data_retry_result_count = 3;
+const h3_early_data_compat_decision_count = 4;
 
 /// Server-wide metrics counters.
 ///
@@ -169,6 +182,16 @@ pub const Metrics = struct {
     tls_ticket_store_total: [ticket_result_count]u64,
     /// #488: server-side ticket resolution attempts by mode and result.
     tls_ticket_resolve_total: [resumption_mode_count][ticket_result_count]u64,
+    /// HTTP early-data replay-exposed requests by protocol and source.
+    http_early_data_requests_total: [http_protocol_count][early_data_source_count]u64,
+    /// HTTP early-data decisions by protocol.
+    http_early_data_decisions_total: [http_protocol_count][early_data_decision_count]u64,
+    /// Upstream 425 handling actions (bounded RFC 8470 semantics only).
+    http_early_data_upstream_425_total: [early_data_upstream_425_action_count]u64,
+    /// Local one-shot upstream 425 retry outcomes.
+    http_early_data_retry_total: [early_data_retry_result_count]u64,
+    /// HTTP/3 early-data compatibility outcomes.
+    http3_early_data_compat_total: [h3_early_data_compat_decision_count]u64,
     /// Total graceful-shutdown drains started.
     drain_total: u64,
     /// Total drains that hit the configured drain timeout before work finished.
@@ -280,6 +303,11 @@ pub const Metrics = struct {
             .tls_ticket_issue_total = .{.{.{0} ** ticket_result_count} ** resumption_mode_count} ** resumption_transport_count,
             .tls_ticket_store_total = .{0} ** ticket_result_count,
             .tls_ticket_resolve_total = .{.{0} ** ticket_result_count} ** resumption_mode_count,
+            .http_early_data_requests_total = .{.{0} ** early_data_source_count} ** http_protocol_count,
+            .http_early_data_decisions_total = .{.{0} ** early_data_decision_count} ** http_protocol_count,
+            .http_early_data_upstream_425_total = .{0} ** early_data_upstream_425_action_count,
+            .http_early_data_retry_total = .{0} ** early_data_retry_result_count,
+            .http3_early_data_compat_total = .{0} ** h3_early_data_compat_decision_count,
             .drain_total = 0,
             .drain_timeouts_total = 0,
             .drain_forced_closes_total = 0,
@@ -357,6 +385,26 @@ pub const Metrics = struct {
     /// #488: record a server-side ticket/handle resolution attempt.
     pub fn recordTicketResolve(self: *Metrics, mode: ResumptionMode, result: TicketResult) void {
         self.tls_ticket_resolve_total[resumptionModeIndex(mode)][ticketResultIndex(result)] += 1;
+    }
+
+    pub fn recordHttpEarlyDataRequest(self: *Metrics, protocol: HttpProtocol, source: EarlyDataSource) void {
+        self.http_early_data_requests_total[httpProtocolIndex(protocol)][earlyDataSourceIndex(source)] += 1;
+    }
+
+    pub fn recordHttpEarlyDataDecision(self: *Metrics, protocol: HttpProtocol, decision: EarlyDataDecision) void {
+        self.http_early_data_decisions_total[httpProtocolIndex(protocol)][earlyDataDecisionIndex(decision)] += 1;
+    }
+
+    pub fn recordHttpEarlyDataUpstream425(self: *Metrics, action: EarlyDataUpstream425Action) void {
+        self.http_early_data_upstream_425_total[earlyDataUpstream425ActionIndex(action)] += 1;
+    }
+
+    pub fn recordHttpEarlyDataRetry(self: *Metrics, result: EarlyDataRetryResult) void {
+        self.http_early_data_retry_total[earlyDataRetryResultIndex(result)] += 1;
+    }
+
+    pub fn recordHttp3EarlyDataCompat(self: *Metrics, decision: H3EarlyDataCompatDecision) void {
+        self.http3_early_data_compat_total[h3EarlyDataCompatDecisionIndex(decision)] += 1;
     }
 
     /// Record the start of a config hot-reload attempt.
@@ -846,6 +894,7 @@ pub const Metrics = struct {
 
         try self.appendTlsBufferPrometheus(&out);
         try self.appendResumptionPrometheus(&out);
+        try self.appendHttpEarlyDataPrometheus(&out);
 
         try out.print(
             \\# HELP tardigrade_proxy_client_aborts_total Total proxied transfers aborted by downstream clients
@@ -1225,6 +1274,74 @@ pub const Metrics = struct {
         }
     }
 
+    fn appendHttpEarlyDataPrometheus(self: *const Metrics, out: *std.array_list.Managed(u8)) !void {
+        try out.appendSlice(
+            \\# HELP tardigrade_http_early_data_requests_total Replay-exposed HTTP requests by protocol and source
+            \\# TYPE tardigrade_http_early_data_requests_total counter
+            \\
+        );
+        inline for (.{ HttpProtocol.h1, HttpProtocol.h2, HttpProtocol.h3 }) |protocol| {
+            inline for (.{ EarlyDataSource.transport, EarlyDataSource.header, EarlyDataSource.both }) |source| {
+                try out.print("tardigrade_http_early_data_requests_total{{protocol=\"{s}\",source=\"{s}\"}} {d}\n", .{
+                    httpProtocolLabel(protocol),
+                    earlyDataSourceLabel(source),
+                    self.http_early_data_requests_total[httpProtocolIndex(protocol)][earlyDataSourceIndex(source)],
+                });
+            }
+        }
+
+        try out.appendSlice(
+            \\# HELP tardigrade_http_early_data_decisions_total Early-data policy decisions by protocol
+            \\# TYPE tardigrade_http_early_data_decisions_total counter
+            \\
+        );
+        inline for (.{ HttpProtocol.h1, HttpProtocol.h2, HttpProtocol.h3 }) |protocol| {
+            inline for (.{ EarlyDataDecision.accepted, EarlyDataDecision.too_early, EarlyDataDecision.deferred, EarlyDataDecision.forwarded }) |decision| {
+                try out.print("tardigrade_http_early_data_decisions_total{{protocol=\"{s}\",decision=\"{s}\"}} {d}\n", .{
+                    httpProtocolLabel(protocol),
+                    earlyDataDecisionLabel(decision),
+                    self.http_early_data_decisions_total[httpProtocolIndex(protocol)][earlyDataDecisionIndex(decision)],
+                });
+            }
+        }
+
+        try out.appendSlice(
+            \\# HELP tardigrade_http_early_data_upstream_425_total Upstream 425 handling actions
+            \\# TYPE tardigrade_http_early_data_upstream_425_total counter
+            \\
+        );
+        inline for (.{ EarlyDataUpstream425Action.forwarded, EarlyDataUpstream425Action.retried }) |action| {
+            try out.print("tardigrade_http_early_data_upstream_425_total{{action=\"{s}\"}} {d}\n", .{
+                earlyDataUpstream425ActionLabel(action),
+                self.http_early_data_upstream_425_total[earlyDataUpstream425ActionIndex(action)],
+            });
+        }
+
+        try out.appendSlice(
+            \\# HELP tardigrade_http_early_data_retry_total Bounded local upstream-425 retry outcomes
+            \\# TYPE tardigrade_http_early_data_retry_total counter
+            \\
+        );
+        inline for (.{ EarlyDataRetryResult.success, EarlyDataRetryResult.too_early, EarlyDataRetryResult.failure }) |result| {
+            try out.print("tardigrade_http_early_data_retry_total{{result=\"{s}\"}} {d}\n", .{
+                earlyDataRetryResultLabel(result),
+                self.http_early_data_retry_total[earlyDataRetryResultIndex(result)],
+            });
+        }
+
+        try out.appendSlice(
+            \\# HELP tardigrade_http3_early_data_compat_total HTTP/3 early-data compatibility outcomes
+            \\# TYPE tardigrade_http3_early_data_compat_total counter
+            \\
+        );
+        inline for (.{ H3EarlyDataCompatDecision.compatible, H3EarlyDataCompatDecision.transport_incompatible, H3EarlyDataCompatDecision.settings_incompatible, H3EarlyDataCompatDecision.missing_state }) |decision| {
+            try out.print("tardigrade_http3_early_data_compat_total{{decision=\"{s}\"}} {d}\n", .{
+                h3EarlyDataCompatDecisionLabel(decision),
+                self.http3_early_data_compat_total[h3EarlyDataCompatDecisionIndex(decision)],
+            });
+        }
+    }
+
     /// Format metrics as a JSON string.
     /// Caller owns the returned memory.
     pub fn toJson(self: *const Metrics, allocator: std.mem.Allocator) ![]u8 {
@@ -1411,6 +1528,104 @@ fn ticketResultLabel(result: TicketResult) []const u8 {
         .success => "success",
         .rejected => "rejected",
         .failed => "failed",
+    };
+}
+
+fn httpProtocolIndex(protocol: HttpProtocol) usize {
+    return switch (protocol) {
+        .h1 => 0,
+        .h2 => 1,
+        .h3 => 2,
+    };
+}
+
+fn earlyDataSourceIndex(source: EarlyDataSource) usize {
+    return switch (source) {
+        .transport => 0,
+        .header => 1,
+        .both => 2,
+    };
+}
+
+fn earlyDataDecisionIndex(decision: EarlyDataDecision) usize {
+    return switch (decision) {
+        .accepted => 0,
+        .too_early => 1,
+        .deferred => 2,
+        .forwarded => 3,
+    };
+}
+
+fn earlyDataUpstream425ActionIndex(action: EarlyDataUpstream425Action) usize {
+    return switch (action) {
+        .forwarded => 0,
+        .retried => 1,
+    };
+}
+
+fn earlyDataRetryResultIndex(result: EarlyDataRetryResult) usize {
+    return switch (result) {
+        .success => 0,
+        .too_early => 1,
+        .failure => 2,
+    };
+}
+
+fn h3EarlyDataCompatDecisionIndex(decision: H3EarlyDataCompatDecision) usize {
+    return switch (decision) {
+        .compatible => 0,
+        .transport_incompatible => 1,
+        .settings_incompatible => 2,
+        .missing_state => 3,
+    };
+}
+
+fn httpProtocolLabel(protocol: HttpProtocol) []const u8 {
+    return switch (protocol) {
+        .h1 => "h1",
+        .h2 => "h2",
+        .h3 => "h3",
+    };
+}
+
+fn earlyDataSourceLabel(source: EarlyDataSource) []const u8 {
+    return switch (source) {
+        .transport => "transport",
+        .header => "header",
+        .both => "both",
+    };
+}
+
+fn earlyDataDecisionLabel(decision: EarlyDataDecision) []const u8 {
+    return switch (decision) {
+        .accepted => "accepted",
+        .too_early => "too_early",
+        .deferred => "deferred",
+        .forwarded => "forwarded",
+    };
+}
+
+fn earlyDataUpstream425ActionLabel(action: EarlyDataUpstream425Action) []const u8 {
+    return switch (action) {
+        .forwarded => "forwarded",
+        .retried => "retried",
+    };
+}
+
+fn earlyDataRetryResultLabel(result: EarlyDataRetryResult) []const u8 {
+    return switch (result) {
+        .success => "success",
+        .too_early => "too_early",
+        .failure => "failure",
+    };
+}
+
+fn h3EarlyDataCompatDecisionLabel(decision: H3EarlyDataCompatDecision) []const u8 {
+    return switch (decision) {
+        .compatible => "compatible",
+        .transport_incompatible => "transport_incompatible",
+        .settings_incompatible => "settings_incompatible",
+        .missing_state => "missing_state",
     };
 }
 
@@ -1868,4 +2083,36 @@ test "worker queue wait histogram appears in Prometheus and JSON output (#136)" 
     defer allocator.free(json);
     try std.testing.expect(std.mem.find(u8, json, "\"worker_queue_wait_count\":1") != null);
     try std.testing.expect(std.mem.find(u8, json, "\"worker_queue_wait_sum_us\":500") != null);
+}
+
+test "early-data metrics record bounded labels and emit Prometheus series" {
+    const allocator = std.testing.allocator;
+    var m = Metrics.init();
+
+    m.recordHttpEarlyDataRequest(.h1, .header);
+    m.recordHttpEarlyDataRequest(.h2, .transport);
+    m.recordHttpEarlyDataDecision(.h1, .too_early);
+    m.recordHttpEarlyDataDecision(.h2, .deferred);
+    m.recordHttpEarlyDataDecision(.h3, .accepted);
+    m.recordHttpEarlyDataUpstream425(.forwarded);
+    m.recordHttpEarlyDataUpstream425(.retried);
+    m.recordHttpEarlyDataRetry(.success);
+    m.recordHttpEarlyDataRetry(.too_early);
+    m.recordHttp3EarlyDataCompat(.compatible);
+    m.recordHttp3EarlyDataCompat(.missing_state);
+
+    const prom = try m.toPrometheus(allocator);
+    defer allocator.free(prom);
+
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_requests_total{protocol=\"h1\",source=\"header\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_requests_total{protocol=\"h2\",source=\"transport\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_decisions_total{protocol=\"h1\",decision=\"too_early\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_decisions_total{protocol=\"h2\",decision=\"deferred\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_decisions_total{protocol=\"h3\",decision=\"accepted\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_upstream_425_total{action=\"forwarded\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_upstream_425_total{action=\"retried\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_retry_total{result=\"success\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_retry_total{result=\"too_early\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http3_early_data_compat_total{decision=\"compatible\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http3_early_data_compat_total{decision=\"missing_state\"} 1") != null);
 }

--- a/src/http/native_tls_connection.zig
+++ b/src/http/native_tls_connection.zig
@@ -261,9 +261,7 @@ pub const NativeTlsConnection = struct {
     }
 
     pub fn readTransportEarly(self: *const NativeTlsConnection) bool {
-        // #366 server-side provenance: accepted 0-RTT contributes replay
-        // exposure until the connection reaches authenticated application data.
-        return self.backend.earlyDataAccepted() and !self.record.applicationDataOpen();
+        return self.record.currentReadTransportEarly();
     }
 
     pub fn downstreamHandshakeComplete(self: *const NativeTlsConnection) bool {

--- a/src/http/native_tls_connection.zig
+++ b/src/http/native_tls_connection.zig
@@ -251,7 +251,23 @@ pub const NativeTlsConnection = struct {
     }
 
     pub fn httpConnection(self: *NativeTlsConnection) encrypted_stream_connection.EncryptedStreamHttpConnection {
-        return encrypted_stream_connection.EncryptedStreamHttpConnection.initWithFd(self.stream(), self.fd);
+        return encrypted_stream_connection.EncryptedStreamHttpConnection.initWithFdAndProvenance(
+            self.stream(),
+            self.fd,
+            self,
+            nativeReadTransportEarly,
+            nativeHandshakeComplete,
+        );
+    }
+
+    pub fn readTransportEarly(self: *const NativeTlsConnection) bool {
+        // #366 server-side provenance: accepted 0-RTT contributes replay
+        // exposure until the connection reaches authenticated application data.
+        return self.backend.earlyDataAccepted() and !self.record.applicationDataOpen();
+    }
+
+    pub fn downstreamHandshakeComplete(self: *const NativeTlsConnection) bool {
+        return self.record.applicationDataOpen();
     }
 
     pub fn rawFd(self: *const NativeTlsConnection) std.posix.fd_t {
@@ -355,6 +371,16 @@ pub const NativeTlsConnection = struct {
             .closeFn = carrierClose,
             .owns_handle = true,
         };
+    }
+
+    fn nativeReadTransportEarly(ptr: *anyopaque) bool {
+        const self: *NativeTlsConnection = @ptrCast(@alignCast(ptr));
+        return self.readTransportEarly();
+    }
+
+    fn nativeHandshakeComplete(ptr: *anyopaque) bool {
+        const self: *NativeTlsConnection = @ptrCast(@alignCast(ptr));
+        return self.downstreamHandshakeComplete();
     }
 
     fn carrierRead(ptr: *anyopaque, out: []u8) encrypted_stream.Error!usize {

--- a/src/http/request_context.zig
+++ b/src/http/request_context.zig
@@ -26,6 +26,40 @@ pub const EarlyDataContext = struct {
         const barrier = self.downstream_handshake orelse return;
         try barrier.waitOrDrive();
     }
+
+    pub fn source(self: EarlyDataContext) EarlyDataSource {
+        return if (self.transport_early and self.inbound_marker)
+            .both
+        else if (self.transport_early)
+            .transport
+        else if (self.inbound_marker)
+            .header
+        else
+            .none;
+    }
+};
+
+pub const EarlyDataSource = enum {
+    none,
+    transport,
+    header,
+    both,
+};
+
+pub const EarlyDataAction = enum {
+    ordinary,
+    accepted,
+    too_early,
+    forwarded,
+    retried,
+    deferred,
+};
+
+pub const EarlyDataRetryResult = enum {
+    none,
+    success,
+    too_early,
+    failure,
 };
 
 pub const DownstreamHandshakeBarrier = struct {
@@ -73,6 +107,10 @@ pub const RequestContext = struct {
     idempotency_key: ?[]const u8,
     /// HTTP early-data provenance for this request hop and prior hops.
     early_data: EarlyDataContext,
+    /// Bounded early-data action label for observability.
+    early_data_action: EarlyDataAction,
+    /// Bounded retry result label for upstream 425 retry observability.
+    early_data_retry_result: EarlyDataRetryResult,
     /// Upstream address selected for proxied requests.
     upstream_addr: ?[]const u8,
     /// Final upstream status observed for proxied requests.
@@ -98,6 +136,8 @@ pub const RequestContext = struct {
             .api_version = null,
             .idempotency_key = null,
             .early_data = .{},
+            .early_data_action = .ordinary,
+            .early_data_retry_result = .none,
             .upstream_addr = null,
             .upstream_status = null,
             .response_bytes = 0,

--- a/src/http3/conn.zig
+++ b/src/http3/conn.zig
@@ -109,7 +109,15 @@ pub fn Conn(comptime Transport: type) type {
         const ServerRequest = struct {
             stream: session.RequestStream,
             finished: bool = false,
+            transport_early: bool = false,
         };
+
+        fn transportStreamTransportEarly(transport: *Transport, stream_id: u64) bool {
+            if (comptime @hasDecl(Transport, "streamTransportEarly")) {
+                return transport.streamTransportEarly(stream_id);
+            }
+            return false;
+        }
 
         const ClientResponse = struct {
             buffer: std.ArrayList(u8) = .empty,
@@ -266,7 +274,10 @@ pub fn Conn(comptime Transport: type) type {
                     self.pending_uni.put(id, .{}) catch return error.OutOfMemory;
                 } else if (self.role == .server) {
                     const request = self.allocator.create(ServerRequest) catch return error.OutOfMemory;
-                    request.* = .{ .stream = session.RequestStream.init(self.allocator, id) };
+                    request.* = .{
+                        .stream = session.RequestStream.init(self.allocator, id),
+                        .transport_early = transportStreamTransportEarly(transport, id),
+                    };
                     self.requests.put(id, request) catch {
                         request.stream.deinit();
                         self.allocator.destroy(request);
@@ -518,6 +529,7 @@ pub fn Conn(comptime Transport: type) type {
         pub const IncomingRequest = struct {
             stream_id: u64,
             exchange: stream_transport.Exchange,
+            transport_early: bool,
         };
 
         /// Pop the next fully received request. The exchange borrows the
@@ -529,7 +541,11 @@ pub fn Conn(comptime Transport: type) type {
                 if (!request.finished or request.stream.finished) continue;
                 const exchange = request.stream.finish() catch return self.fail(.message_error);
                 self.metrics.requests_decoded += 1;
-                return .{ .stream_id = entry.key_ptr.*, .exchange = exchange };
+                return .{
+                    .stream_id = entry.key_ptr.*,
+                    .exchange = exchange,
+                    .transport_early = request.transport_early,
+                };
             }
             return null;
         }

--- a/src/http3/conn.zig
+++ b/src/http3/conn.zig
@@ -382,6 +382,7 @@ pub fn Conn(comptime Transport: type) type {
                 var qpack_scratch: [4096]u8 = undefined;
                 while (true) {
                     const result = transport.readStream(id, &buf) catch break;
+                    request.transport_early = request.transport_early or transportStreamTransportEarly(transport, id);
                     if (result.len > 0) {
                         _ = request.stream.ingestBytes(buf[0..result.len], &qpack_scratch) catch {
                             return self.fail(.message_error);

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -844,6 +844,13 @@ pub const Connection = struct {
                 self.handleRetry(bytes, parsed, now_us);
                 return;
             },
+            .zero_rtt => {
+                // #366 owns QUIC 0-RTT carrier acceptance. Until that gate can
+                // decide accepted vs rejected before recovery/ACK bookkeeping,
+                // fail closed and expose only the explicit sticky provenance seam.
+                self.dropPacket(.undecryptable, bytes.len);
+                return;
+            },
             else => {},
         }
         if (parsed.kind != .one_rtt and parsed.version != packet.quic_v1) {
@@ -858,7 +865,6 @@ pub const Connection = struct {
         const level: EncryptionLevel = switch (parsed.kind) {
             .initial => .initial,
             .handshake => .handshake,
-            .zero_rtt => .zero_rtt,
             .one_rtt => .application,
             else => unreachable,
         };
@@ -1016,7 +1022,7 @@ pub const Connection = struct {
                 self.afterHandshakeProgress(now_us);
             },
             .stream => |sf| {
-                if (level != .application and level != .zero_rtt) {
+                if (level != .application) {
                     self.startClose(.{ .error_code = error_protocol_violation, .is_application = false, .local = true }, "stream frame level", now_us);
                     return;
                 }
@@ -1029,9 +1035,6 @@ pub const Connection = struct {
                     self.closeOnStreamError(err, now_us);
                     return;
                 };
-                if (level == .zero_rtt) {
-                    try self.stream_transport_early.put(sf.id, {});
-                }
                 if (!known) {
                     try self.known_streams.put(sf.id, {});
                     if (quic_stream.streamInitiator(sf.id) != roleInitiator(self.role)) {
@@ -1827,6 +1830,10 @@ pub const Connection = struct {
 
     pub fn streamTransportEarly(self: *const Connection, id: StreamId) bool {
         return self.stream_transport_early.contains(id);
+    }
+
+    pub fn markStreamZeroRtt(self: *Connection, id: StreamId) !void {
+        try self.stream_transport_early.put(id, {});
     }
 
     pub fn resetStream(self: *Connection, id: StreamId, app_error_code: u64) !void {
@@ -2795,23 +2802,23 @@ test "driver: bidirectional stream data round-trips with FIN" {
     try testing.expectEqual(quic_stream.StreamState.closed, pair.server.streamState(id).?);
 }
 
-test "driver: accepted zero-rtt stream provenance stays sticky after one-rtt data" {
+test "driver: explicit zero-rtt stream provenance mark stays sticky after one-rtt data" {
     const allocator = testing.allocator;
     var pair = try TestPair.init(allocator);
     defer pair.deinit(allocator);
     try pair.pump();
 
     const id: StreamId = 0;
-    try pair.server.applyFrame(.zero_rtt, .{ .stream = .{ .id = id, .offset = 0, .data = "early" } }, pair.now_us);
+    try pair.server.markStreamZeroRtt(id);
     try testing.expect(pair.server.streamTransportEarly(id));
 
-    try pair.server.applyFrame(.application, .{ .stream = .{ .id = id, .offset = 5, .data = "-late", .fin = true } }, pair.now_us);
+    try pair.server.applyFrame(.application, .{ .stream = .{ .id = id, .offset = 0, .data = "late", .fin = true } }, pair.now_us);
     try testing.expect(pair.server.streamTransportEarly(id));
     try testing.expectEqual(@as(?StreamId, id), pair.server.acceptStream());
 
     var buf: [32]u8 = undefined;
     const request = try pair.server.readStream(id, &buf);
-    try testing.expectEqualStrings("early-late", buf[0..request.len]);
+    try testing.expectEqualStrings("late", buf[0..request.len]);
     try testing.expect(request.fin);
 }
 

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -1823,6 +1823,10 @@ pub const Connection = struct {
         return self.accept_queue.orderedRemove(0);
     }
 
+    pub fn streamTransportEarly(self: *const Connection, _: StreamId) bool {
+        return self.tls.earlyDataAccepted() and !self.handshake_complete;
+    }
+
     pub fn resetStream(self: *Connection, id: StreamId, app_error_code: u64) !void {
         var manager = self.streamManager() orelse return error.NotEstablished;
         const reset = try manager.sendResetStream(id, app_error_code);

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -565,6 +565,7 @@ pub const Connection = struct {
     streams: ?quic_stream.StreamManager = null,
     send_queues: std.AutoHashMap(StreamId, *SendQueue),
     known_streams: std.AutoHashMap(StreamId, void),
+    stream_transport_early: std.AutoHashMap(StreamId, void),
     accept_queue: std.ArrayList(StreamId) = .empty,
 
     crypto_tx: [3]CryptoTx = .{ .{}, .{}, .{} },
@@ -644,6 +645,7 @@ pub const Connection = struct {
             .peer_cids = quic_cid.PeerCidPool.init(params.active_connection_id_limit),
             .send_queues = std.AutoHashMap(StreamId, *SendQueue).init(allocator),
             .known_streams = std.AutoHashMap(StreamId, void).init(allocator),
+            .stream_transport_early = std.AutoHashMap(StreamId, void).init(allocator),
             .last_activity_us = options.now_us,
         };
         // Construct the handshake before `errdefer conn.deinitPartial()` is
@@ -722,6 +724,7 @@ pub const Connection = struct {
         }
         self.send_queues.deinit();
         self.known_streams.deinit();
+        self.stream_transport_early.deinit();
         self.accept_queue.deinit(self.allocator);
         for (&self.crypto_tx) |*tx| tx.deinit(self.allocator);
         self.sent_records.deinit(self.allocator);
@@ -841,11 +844,6 @@ pub const Connection = struct {
                 self.handleRetry(bytes, parsed, now_us);
                 return;
             },
-            .zero_rtt => {
-                // 0-RTT is disabled (config default); nothing can decrypt it.
-                self.dropPacket(.undecryptable, bytes.len);
-                return;
-            },
             else => {},
         }
         if (parsed.kind != .one_rtt and parsed.version != packet.quic_v1) {
@@ -860,6 +858,7 @@ pub const Connection = struct {
         const level: EncryptionLevel = switch (parsed.kind) {
             .initial => .initial,
             .handshake => .handshake,
+            .zero_rtt => .zero_rtt,
             .one_rtt => .application,
             else => unreachable,
         };
@@ -1017,7 +1016,7 @@ pub const Connection = struct {
                 self.afterHandshakeProgress(now_us);
             },
             .stream => |sf| {
-                if (level != .application) {
+                if (level != .application and level != .zero_rtt) {
                     self.startClose(.{ .error_code = error_protocol_violation, .is_application = false, .local = true }, "stream frame level", now_us);
                     return;
                 }
@@ -1030,6 +1029,9 @@ pub const Connection = struct {
                     self.closeOnStreamError(err, now_us);
                     return;
                 };
+                if (level == .zero_rtt) {
+                    try self.stream_transport_early.put(sf.id, {});
+                }
                 if (!known) {
                     try self.known_streams.put(sf.id, {});
                     if (quic_stream.streamInitiator(sf.id) != roleInitiator(self.role)) {
@@ -1823,8 +1825,8 @@ pub const Connection = struct {
         return self.accept_queue.orderedRemove(0);
     }
 
-    pub fn streamTransportEarly(self: *const Connection, _: StreamId) bool {
-        return self.tls.earlyDataAccepted() and !self.handshake_complete;
+    pub fn streamTransportEarly(self: *const Connection, id: StreamId) bool {
+        return self.stream_transport_early.contains(id);
     }
 
     pub fn resetStream(self: *Connection, id: StreamId, app_error_code: u64) !void {
@@ -2791,6 +2793,26 @@ test "driver: bidirectional stream data round-trips with FIN" {
 
     try testing.expectEqual(quic_stream.StreamState.closed, pair.client.streamState(id).?);
     try testing.expectEqual(quic_stream.StreamState.closed, pair.server.streamState(id).?);
+}
+
+test "driver: accepted zero-rtt stream provenance stays sticky after one-rtt data" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const id: StreamId = 0;
+    try pair.server.applyFrame(.zero_rtt, .{ .stream = .{ .id = id, .offset = 0, .data = "early" } }, pair.now_us);
+    try testing.expect(pair.server.streamTransportEarly(id));
+
+    try pair.server.applyFrame(.application, .{ .stream = .{ .id = id, .offset = 5, .data = "-late", .fin = true } }, pair.now_us);
+    try testing.expect(pair.server.streamTransportEarly(id));
+    try testing.expectEqual(@as(?StreamId, id), pair.server.acceptStream());
+
+    var buf: [32]u8 = undefined;
+    const request = try pair.server.readStream(id, &buf);
+    try testing.expectEqualStrings("early-late", buf[0..request.len]);
+    try testing.expect(request.fin);
 }
 
 test "driver: server NewSessionTicket uses application CRYPTO retransmission and stream traffic continues" {

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -282,7 +282,13 @@ pub const Tls13Backend = struct {
             .setServerPskResolverFn = setServerPskResolverVtable,
             .prepareNewSessionTicketFn = prepareNewSessionTicket,
             .emitPreparedNewSessionTicketFn = emitPreparedNewSessionTicket,
+            .earlyDataAcceptedFn = earlyDataAcceptedVtable,
         };
+    }
+
+    fn earlyDataAcceptedVtable(ptr: *anyopaque) bool {
+        const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
+        return self.engine.earlyDataAccepted();
     }
 
     fn authPending(ptr: *anyopaque) bool {

--- a/src/quic/tls_handshake.zig
+++ b/src/quic/tls_handshake.zig
@@ -104,6 +104,7 @@ pub const TlsBackend = struct {
         identity: []const u8,
         limits: tls_core.session.Limits,
     ) HandshakeError!void = null,
+    earlyDataAcceptedFn: ?*const fn (ptr: *anyopaque) bool = null,
 
     fn start(self: TlsBackend, role: Role, params: config.TransportParameters, sink: *EventSink) HandshakeError!void {
         return self.transport.start(role, params, sink);
@@ -170,6 +171,11 @@ pub const TlsBackend = struct {
     ) HandshakeError!void {
         const emit = self.emitPreparedNewSessionTicketFn orelse return error.InvalidHandshakeState;
         return emit(self.transport.ptr, allocator, sink, prepared, identity, limits);
+    }
+
+    pub fn earlyDataAccepted(self: TlsBackend) bool {
+        const cb = self.earlyDataAcceptedFn orelse return false;
+        return cb(self.transport.ptr);
     }
 
     pub fn deinit(self: TlsBackend) void {

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -530,6 +530,11 @@ pub const PureZigRecordStream = struct {
         return self.lifecycle == .open and self.bridge.handshake_complete;
     }
 
+    pub fn currentReadTransportEarly(self: *const PureZigRecordStream) bool {
+        _ = self;
+        return false;
+    }
+
     /// Require the peer to negotiate exactly `protocol`. Configure this before
     /// the handshake starts; the value is copied because caller storage need
     /// not outlive construction.


### PR DESCRIPTION
## Summary
Implements Issue #367 Slice 4 with scoped HTTP-level behavior and observability updates:

- Add H2 early-stream safe deferral behavior with single-dispatch guardrails.
- Add bounded early-data observability fields in request context and access logs.
- Add bounded HTTP early-data metrics families:
  - `tardigrade_http_early_data_requests_total{protocol,source}`
  - `tardigrade_http_early_data_decisions_total{protocol,decision}`
  - `tardigrade_http_early_data_upstream_425_total{action}`
  - `tardigrade_http_early_data_retry_total{result}`
  - `tardigrade_http3_early_data_compat_total{decision}`
- Wire HTTP/3 compatibility outcomes into gateway metrics via callback bridge.
- Update operator docs for observability and support boundaries.

## Scope Boundaries
- Includes #367 Slice 4 behavior (H2 deferral + observability/docs).
- Does **not** implement #366 transport-carrier internals.
- Does **not** implement #368 anti-replay persistence/store.

## Validation
- `zig fmt --check build.zig src/ tests/`
- `zig build test --summary all --error-style verbose`
- `zig build --summary all --error-style verbose`

All commands passed locally.
