### PR TITLE
tls: wire early-data replay store into TLS/composition (#368 Slice 2)

### DIFF
--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -282,18 +282,19 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
     }
     defer if (native_resumption_runtime) |*rt| rt.deinit();
     // #368 Slice 2: one process-scoped anti-replay store, shared by every
-    // native TCP worker and the QUIC/H3 runtime — independent of whether
-    // native resumption is enabled above, since Slice 3 owns the switch
-    // that actually lets native 0-RTT be attempted. Declared ahead of
-    // every borrower below for the same teardown-ordering reason as
+    // native TCP worker and the QUIC/H3 runtime — but constructed only once
+    // a native PSK/early-data path can actually exist (below, once
+    // `native_tls_provider`/`h3_credential_provider` are known), so plain
+    // HTTP, OpenSSL-only, or resumption-disabled deployments never pay the
+    // default 65,536-entry reservation or gain a new startup-failure path
+    // for a security feature they cannot use. Declared (but not yet
+    // constructed) here, ahead of every borrower below, so its teardown —
+    // once present — runs last, for the same reason as
     // `native_resumption_runtime`.
-    var native_early_data_replay_store = initNativeEarlyDataReplayStore(state_allocator, @intCast(compat.milliTimestamp())) catch |err| {
-        state.logger.err(null, "native TLS/QUIC early-data replay store initialization failed ({s}); refusing to start", .{@errorName(err)});
-        return err;
-    };
-    defer native_early_data_replay_store.deinit();
-    var native_early_data_replay_gate_adapter = tls_core.early_data_replay.GateAdapter.init(native_early_data_replay_store.store());
-    const native_early_data_replay_gate = native_early_data_replay_gate_adapter.gate();
+    var native_early_data_replay_store: ?tls_core.early_data_replay.LocalStore = null;
+    defer if (native_early_data_replay_store) |*store| store.deinit();
+    var native_early_data_replay_gate_adapter: tls_core.early_data_replay.GateAdapter = undefined;
+    var native_early_data_replay_gate: ?tls_core.tls13_backend.EarlyDataReplayGate = null;
     var http3_dispatch_ctx = ghandlers.Http3DispatchContext{
         .config_store = &config_store,
         .cfg = cfg,
@@ -386,6 +387,21 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
     }
     defer if (native_credentials) |*store| store.deinit();
     defer if (tls_terminator) |*tls| tls.deinit();
+    if (nativeEarlyDataReplayStoreNeeded(
+        native_resumption_runtime != null,
+        native_tls_provider != null,
+        cfg.http3_enabled,
+        h3_credential_provider != null,
+    )) {
+        native_early_data_replay_store = initNativeEarlyDataReplayStore(state_allocator, @intCast(compat.milliTimestamp())) catch |err| {
+            state.logger.err(null, "native TLS/QUIC early-data replay store initialization failed ({s}); refusing to start", .{@errorName(err)});
+            return err;
+        };
+    }
+    if (native_early_data_replay_store) |*store| {
+        native_early_data_replay_gate_adapter = tls_core.early_data_replay.GateAdapter.init(store.store());
+        native_early_data_replay_gate = native_early_data_replay_gate_adapter.gate();
+    }
     if (cfg.http3_enabled) {
         if (!edge_config.hasTlsFiles(cfg)) {
             state.logger.warn(null, "HTTP/3 requested without TLS cert/key; QUIC bootstrap will remain incomplete", .{});
@@ -1425,6 +1441,27 @@ fn initNativeEarlyDataReplayStore(
         (tls_core.tls13_backend.ServerEarlyDataPolicy{}).age_skew_tolerance_ms,
         now_unix_ms,
     );
+}
+
+/// #368 Slice 2: whether a native PSK/early-data path can actually exist
+/// for this composition, and therefore whether `run()` should pay for
+/// constructing the process-scoped replay store at all. Native resumption
+/// being enabled is necessary but not sufficient — a native (non-OpenSSL)
+/// TLS backend that could ever accept early data must also be configured:
+/// native TCP (`native_tls_provider`) or, when HTTP/3 is enabled, native
+/// QUIC/H3 (`h3_credential_provider`). The OpenSSL terminator owns its own
+/// independent session cache and never consults this seam at all, so plain
+/// HTTP, OpenSSL-only, or resumption-disabled deployments must never gain
+/// the default 65,536-entry allocation or a new startup-failure path for a
+/// security feature they cannot use.
+fn nativeEarlyDataReplayStoreNeeded(
+    native_resumption_runtime_enabled: bool,
+    native_tls_provider_present: bool,
+    http3_enabled: bool,
+    h3_credential_provider_present: bool,
+) bool {
+    return native_resumption_runtime_enabled and
+        (native_tls_provider_present or (http3_enabled and h3_credential_provider_present));
 }
 
 fn reapActiveConnections(
@@ -4418,6 +4455,30 @@ fn gatewayTestWriteFd(fd: std.posix.fd_t, bytes: []const u8) tls_core.encrypted_
         return error.SocketWriteFailed;
     }
     return @intCast(rc);
+}
+
+test "#368 Slice 2: nativeEarlyDataReplayStoreNeeded is false for every configuration without a native PSK/early-data path" {
+    // Plain HTTP or resumption-disabled: no native resumption at all.
+    try std.testing.expect(!nativeEarlyDataReplayStoreNeeded(false, false, false, false));
+    try std.testing.expect(!nativeEarlyDataReplayStoreNeeded(false, true, false, false));
+    try std.testing.expect(!nativeEarlyDataReplayStoreNeeded(false, false, true, true));
+    // OpenSSL-only TCP with HTTP/3 disabled: native resumption enabled, but
+    // neither a native TCP provider nor an eligible H3 path exists.
+    try std.testing.expect(!nativeEarlyDataReplayStoreNeeded(true, false, false, false));
+    // HTTP/3 enabled but no native H3 credential provider actually bootstrapped
+    // (e.g. TLS files missing), and no native TCP provider either.
+    try std.testing.expect(!nativeEarlyDataReplayStoreNeeded(true, false, true, false));
+    // A native TCP provider exists, but native resumption itself is disabled.
+    try std.testing.expect(!nativeEarlyDataReplayStoreNeeded(false, true, true, true));
+}
+
+test "#368 Slice 2: nativeEarlyDataReplayStoreNeeded is true once native resumption and a native TCP or QUIC/H3 path both exist" {
+    try std.testing.expect(nativeEarlyDataReplayStoreNeeded(true, true, false, false));
+    try std.testing.expect(nativeEarlyDataReplayStoreNeeded(true, false, true, true));
+    try std.testing.expect(nativeEarlyDataReplayStoreNeeded(true, true, true, true));
+    // HTTP/3 disabled entirely: the H3 credential-provider flag alone must
+    // not be enough without `http3_enabled` also true.
+    try std.testing.expect(!nativeEarlyDataReplayStoreNeeded(true, false, false, true));
 }
 
 test "#368 Slice 2: initNativeEarlyDataReplayStore rejects 0-RTT for the startup quarantine window then accepts fresh claims" {

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -281,6 +281,19 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
         if (native_resumption_runtime) |*rt| rt.setObserver(nativeResumptionMetricsObserver(&state));
     }
     defer if (native_resumption_runtime) |*rt| rt.deinit();
+    // #368 Slice 2: one process-scoped anti-replay store, shared by every
+    // native TCP worker and the QUIC/H3 runtime — independent of whether
+    // native resumption is enabled above, since Slice 3 owns the switch
+    // that actually lets native 0-RTT be attempted. Declared ahead of
+    // every borrower below for the same teardown-ordering reason as
+    // `native_resumption_runtime`.
+    var native_early_data_replay_store = initNativeEarlyDataReplayStore(state_allocator, @intCast(compat.milliTimestamp())) catch |err| {
+        state.logger.err(null, "native TLS/QUIC early-data replay store initialization failed ({s}); refusing to start", .{@errorName(err)});
+        return err;
+    };
+    defer native_early_data_replay_store.deinit();
+    var native_early_data_replay_gate_adapter = tls_core.early_data_replay.GateAdapter.init(native_early_data_replay_store.store());
+    const native_early_data_replay_gate = native_early_data_replay_gate_adapter.gate();
     var http3_dispatch_ctx = ghandlers.Http3DispatchContext{
         .config_store = &config_store,
         .cfg = cfg,
@@ -382,6 +395,7 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
             .quic_port = cfg.quic_port,
             .credential_provider = h3_credential_provider,
             .resumption_runtime = if (native_resumption_runtime) |*rt| rt else null,
+            .early_data_replay_gate = native_early_data_replay_gate,
             .tls_min_version = "1.3",
             .tls_max_version = "1.3",
             .enable_0rtt = cfg.http3_enable_0rtt,
@@ -422,6 +436,7 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
         .native_credentials = if (native_credentials) |*store| store else null,
         .native_tls_provider = native_tls_provider,
         .resumption_runtime = if (native_resumption_runtime) |*rt| rt else null,
+        .early_data_replay_gate = native_early_data_replay_gate,
         .session_pool = undefined,
         .event_loop = &event_loop,
         .active = undefined,
@@ -1161,7 +1176,11 @@ fn startNewConnection(ctx: *WorkerContext, client_fd: std.posix.fd_t) void {
             client_fd,
             tls_protocol_policy,
             native_provider,
-            .{ .buffer_limits = cfg.tls_buffer_limits, .resumption_runtime = ctx.resumption_runtime },
+            .{
+                .buffer_limits = cfg.tls_buffer_limits,
+                .resumption_runtime = ctx.resumption_runtime,
+                .early_data_replay_gate = ctx.early_data_replay_gate,
+            },
         ) catch |err| {
             ctx.state.logger.warn(null, "native tls connection setup failed: {}", .{err});
             return;
@@ -1386,6 +1405,26 @@ fn deadlineFromNow(now_ms: u64, timeout_ms: u32) u64 {
 /// the monotonic clock the event loop otherwise uses.
 fn systemNowUnixMs(_: *anyopaque) i64 {
     return compat.milliTimestamp();
+}
+
+/// #368 Slice 2: constructs the single process-scoped replay store `run`
+/// installs into every native TLS backend that can accept early data.
+/// Bounded defaults only (`Limits{}`) — mode/max-entries configuration and
+/// metrics are Slice 3. The startup-quarantine window reuses
+/// `ServerEarlyDataPolicy`'s default age-skew tolerance so it is never
+/// shorter than the freshness window Slice 3's eventually-configured policy
+/// will use (RFC 9846 §8.2: the recording window must not overlap startup
+/// history the store no longer has).
+fn initNativeEarlyDataReplayStore(
+    allocator: std.mem.Allocator,
+    now_unix_ms: u64,
+) tls_core.early_data_replay.LocalStore.InitError!tls_core.early_data_replay.LocalStore {
+    return tls_core.early_data_replay.LocalStore.init(
+        allocator,
+        .{},
+        (tls_core.tls13_backend.ServerEarlyDataPolicy{}).age_skew_tolerance_ms,
+        now_unix_ms,
+    );
 }
 
 fn reapActiveConnections(
@@ -4379,6 +4418,82 @@ fn gatewayTestWriteFd(fd: std.posix.fd_t, bytes: []const u8) tls_core.encrypted_
         return error.SocketWriteFailed;
     }
     return @intCast(rc);
+}
+
+test "#368 Slice 2: initNativeEarlyDataReplayStore rejects 0-RTT for the startup quarantine window then accepts fresh claims" {
+    // Exercises the exact helper `run()` calls to build the process-scoped
+    // replay store, proving the production composition path — not a
+    // reimplementation of it — rejects 0-RTT while the recording window
+    // still overlaps startup and accepts a genuinely fresh claim afterward.
+    const start_unix_ms: u64 = 1_000_000;
+    var store = try initNativeEarlyDataReplayStore(std.testing.allocator, start_unix_ms);
+    defer store.deinit();
+
+    const quarantine_duration_ms = (tls_core.tls13_backend.ServerEarlyDataPolicy{}).age_skew_tolerance_ms;
+    var key: tls_core.early_data_replay.Key = [_]u8{0} ** 32;
+    key[0] = 7;
+
+    try std.testing.expectEqual(
+        tls_core.early_data_replay.ClaimResult.unavailable,
+        store.claim(.{ .key = key, .retain_until_unix_ms = start_unix_ms + quarantine_duration_ms + 60_000 }, start_unix_ms),
+    );
+    try std.testing.expectEqual(@as(usize, 0), store.count());
+
+    try std.testing.expectEqual(
+        tls_core.early_data_replay.ClaimResult.accepted,
+        store.claim(
+            .{ .key = key, .retain_until_unix_ms = start_unix_ms + quarantine_duration_ms + 60_000 },
+            start_unix_ms + quarantine_duration_ms,
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 1), store.count());
+}
+
+test "#368 Slice 2: one process-scoped early-data replay store is shared by native TCP and QUIC/H3" {
+    // Proves the exact composition-root pattern `run()` uses: one
+    // `LocalStore`/`GateAdapter` pair, its `.gate()` installed into both a
+    // native TCP `NativeTlsConnection` and an `http3_runtime.Runtime` — the
+    // same store instance, not a worker-local or protocol-local copy.
+    var store = try initNativeEarlyDataReplayStore(std.testing.allocator, 0);
+    defer store.deinit();
+    var adapter = tls_core.early_data_replay.GateAdapter.init(store.store());
+    const gate = adapter.gate();
+
+    var fixed = tls_core.credentials.FixedCredentialProvider.init(tls_core.credentials.testdata.identity());
+    defer fixed.deinit();
+
+    const fds = try gatewayTestSocketPair();
+    defer gatewayTestCloseFd(fds[0]);
+    defer gatewayTestCloseFd(fds[1]);
+    const native = try http.native_tls_connection.NativeTlsConnection.createWithOptions(
+        std.testing.allocator,
+        fds[0],
+        .{ .http1_enabled = true, .http2_enabled = true },
+        fixed.provider(),
+        .{ .early_data_replay_gate = gate },
+    );
+    defer native.destroy();
+
+    var logger = http.logger.Logger.init(.err, "replay-store-shared-test");
+    var h3_runtime = try http.http3_runtime.Runtime.init(std.testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+        .credential_provider = fixed.provider(),
+        .early_data_replay_gate = gate,
+    });
+    defer h3_runtime.deinit();
+
+    try std.testing.expectEqual(gate.ctx, native.backend.early_data_replay_gate.ctx);
+    const h3_installed = h3_runtime.early_data_replay_gate orelse return error.TestExpectedEqual;
+    try std.testing.expectEqual(gate.ctx, h3_installed.ctx);
+    // Same underlying `LocalStore`, proven behaviorally too: a claim made
+    // through the TCP-installed gate is visible to the H3-installed one.
+    const candidate: tls_core.tls13_backend.EarlyDataReplayCandidate = .{
+        .ticket_identity_fingerprint = [_]u8{5} ** 32,
+        .retain_until_unix_ms = std.math.maxInt(u64),
+    };
+    try std.testing.expectEqual(tls_core.tls13_backend.EarlyDataReplayDecision.allow, native.backend.early_data_replay_gate.decideFn.?(native.backend.early_data_replay_gate.ctx, candidate));
+    try std.testing.expectEqual(tls_core.tls13_backend.EarlyDataReplayDecision.replay, h3_installed.decideFn.?(h3_installed.ctx, candidate));
 }
 
 // Pull gateway_handlers (and its transitive imports, including

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -2680,6 +2680,12 @@ pub const WorkerContext = struct {
     /// `null` when native resumption is disabled (the default) or the
     /// downstream path is not native TLS.
     resumption_runtime: ?*tls_core.resumption_runtime.Runtime = null,
+    /// #368 Slice 2: process-shared anti-replay gate, borrowed for the
+    /// lifetime of every native TCP connection this worker accepts — the
+    /// same store instance shared with native QUIC/H3, so worker-local
+    /// duplicate 0-RTT acceptance is impossible. `null` leaves each
+    /// backend's own default gate in place (fail-closed `.unavailable`).
+    early_data_replay_gate: ?tls_core.tls13_backend.EarlyDataReplayGate = null,
     session_pool: *ConnectionSessionPool,
     /// Event loop used to (un)watch idle keepalive connections (#138). A worker
     /// re-arms a parked fd here; the loop thread dispatches it back on readiness.

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -60,6 +60,13 @@ pub const Config = struct {
     /// fully disabled for QUIC/H3: no resolver is installed on any accepted
     /// connection and no ticket is ever issued.
     resumption_runtime: ?*tls_core.resumption_runtime.Runtime = null,
+    /// #368 Slice 2: borrowed process-shared anti-replay gate, the same
+    /// instance shared with the native TCP TLS path — installed
+    /// independently of `resumption_runtime` on every accepted connection's
+    /// backend so QUIC/H3 can never fall back to worker-local replay
+    /// bookkeeping. `null` (the default) leaves the backend's own default
+    /// gate in place, which fails closed (`.unavailable`) for 0-RTT.
+    early_data_replay_gate: ?tls_core.tls13_backend.EarlyDataReplayGate = null,
     tls_min_version: []const u8 = "1.3",
     tls_max_version: []const u8 = "1.3",
     enable_0rtt: bool = false,
@@ -160,6 +167,7 @@ pub const Runtime = struct {
     request_handler_ctx: ?*anyopaque,
     credential_provider: ?tls_core.credentials.CredentialProvider,
     resumption_runtime: ?*tls_core.resumption_runtime.Runtime,
+    early_data_replay_gate: ?tls_core.tls13_backend.EarlyDataReplayGate,
     quic_config: quic.config.Config,
     h3_settings: http3.frame.Settings,
     h3_application_compat: [http3.early_data.encoded_snapshot_len]u8 = undefined,
@@ -197,6 +205,7 @@ pub const Runtime = struct {
             .request_handler_ctx = cfg.request_handler_ctx,
             .credential_provider = cfg.credential_provider,
             .resumption_runtime = cfg.resumption_runtime,
+            .early_data_replay_gate = cfg.early_data_replay_gate,
             .quic_config = quicConfigFrom(cfg),
             .h3_settings = cfg.h3_settings,
             .early_data_compat_metrics_ctx = cfg.early_data_compat_metrics_ctx,
@@ -477,6 +486,15 @@ pub const Runtime = struct {
                     return null;
                 };
             }
+        }
+        // #368 Slice 2: independent of `resumption_runtime` above — the
+        // same process-scoped replay store shared with every native TCP
+        // worker, not a per-connection or per-protocol concern.
+        if (self.early_data_replay_gate) |gate| {
+            backend.setEarlyDataReplayGate(gate) catch {
+                allocator.destroy(backend);
+                return null;
+            };
         }
 
         const conn = Connection.init(allocator, .{
@@ -1368,6 +1386,31 @@ test "runtime borrows the resumption runtime and installs it per accepted connec
     defer runtime.deinit();
 
     try testing.expectEqual(@as(?*tls_core.resumption_runtime.Runtime, &resumption), runtime.resumption_runtime);
+}
+
+test "runtime borrows the early-data replay gate independently of the resumption runtime" {
+    var fixed = tls_core.credentials.FixedCredentialProvider.init(tls_core.credentials.testdata.identity());
+    defer fixed.deinit();
+    var logger = logger_mod.Logger.init(.err, "http3-replay-gate-test");
+
+    var store = try tls_core.early_data_replay.LocalStore.init(testing.allocator, .{}, 0, 0);
+    defer store.deinit();
+    var adapter = tls_core.early_data_replay.GateAdapter.init(store.store());
+    const gate = adapter.gate();
+
+    // No `resumption_runtime` supplied: the replay gate must still install,
+    // proving it is not gated on resumption plumbing.
+    var runtime = try Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+        .credential_provider = fixed.provider(),
+        .early_data_replay_gate = gate,
+    });
+    defer runtime.deinit();
+
+    const installed = runtime.early_data_replay_gate orelse return error.TestExpectedEqual;
+    try testing.expectEqual(gate.ctx, installed.ctx);
+    try testing.expectEqual(gate.decideFn, installed.decideFn);
 }
 
 test {

--- a/src/http/native_tls_connection.zig
+++ b/src/http/native_tls_connection.zig
@@ -143,6 +143,14 @@ pub const NativeTlsConnection = struct {
         /// resumption fully disabled: no resolver is installed and no
         /// ticket is ever issued.
         resumption_runtime: ?*tls.resumption_runtime.Runtime = null,
+        /// #368 Slice 2: process-shared anti-replay gate, borrowed for the
+        /// lifetime of this connection and installed independently of
+        /// `resumption_runtime` — without a PSK resolver early data can
+        /// never be attempted anyway, but installing this gate does not
+        /// itself depend on that. `null` (the default) leaves the backend's
+        /// own default gate in place, which fails closed (`.unavailable`)
+        /// for any 0-RTT attempt.
+        early_data_replay_gate: ?tls_backend.EarlyDataReplayGate = null,
     };
 
     allocator: std.mem.Allocator,
@@ -206,6 +214,12 @@ pub const NativeTlsConnection = struct {
             if (runtime.serverResolver()) |resolver| {
                 backend.setServerPskResolver(resolver) catch unreachable;
             }
+        }
+        // #368 Slice 2: independent of `resumption_runtime` above — this is
+        // the same process-scoped store shared with every other native TCP
+        // worker and QUIC/H3, not a per-connection concern.
+        if (options.early_data_replay_gate) |gate| {
+            backend.setEarlyDataReplayGate(gate) catch unreachable;
         }
 
         const record = try allocator.create(encrypted_stream.PureZigRecordStream);
@@ -630,6 +644,32 @@ test "native TLS createWithOptions installs the shared server resolver when conf
 
     try std.testing.expect(conn.backend.psk_resolver != null);
     try std.testing.expectEqual(@as(?*tls.resumption_runtime.Runtime, &runtime), conn.resumption_runtime);
+}
+
+test "native TLS createWithOptions installs the shared early-data replay gate independently of the resumption runtime" {
+    var fixed = credentials.FixedCredentialProvider.init(credentials.testdata.identity());
+    defer fixed.deinit();
+    const fds = try testSocketPair();
+    defer closeFd(fds[1]);
+
+    var store = try tls.early_data_replay.LocalStore.init(std.testing.allocator, .{}, 0, 0);
+    defer store.deinit();
+    var adapter = tls.early_data_replay.GateAdapter.init(store.store());
+    const gate = adapter.gate();
+
+    // No `resumption_runtime` supplied: the replay gate must still install,
+    // proving it is not gated on resumption plumbing.
+    const conn = try NativeTlsConnection.createWithOptions(
+        std.testing.allocator,
+        fds[0],
+        .{ .http1_enabled = true, .http2_enabled = true },
+        fixed.provider(),
+        .{ .early_data_replay_gate = gate },
+    );
+    defer conn.destroy();
+
+    try std.testing.expectEqual(gate.ctx, conn.backend.early_data_replay_gate.ctx);
+    try std.testing.expectEqual(gate.decideFn, conn.backend.early_data_replay_gate.decideFn);
 }
 
 test "native TLS without a resumption runtime never attempts ticket issuance" {

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -31,6 +31,9 @@ pub const testdata = shared.testdata;
 pub const EarlyDataCompatibilityCandidate = shared.EarlyDataCompatibilityCandidate;
 pub const EarlyDataCompatibilityDecision = shared.EarlyDataCompatibilityDecision;
 pub const EarlyDataCompatibilityGate = shared.EarlyDataCompatibilityGate;
+pub const EarlyDataReplayCandidate = shared.EarlyDataReplayCandidate;
+pub const EarlyDataReplayDecision = shared.EarlyDataReplayDecision;
+pub const EarlyDataReplayGate = shared.EarlyDataReplayGate;
 
 const ext_quic_transport_parameters: u16 = @intFromEnum(tls_core.algorithms.ExtensionType.quic_transport_parameters);
 const tp_max_idle_timeout: u64 = 0x01;
@@ -378,6 +381,13 @@ pub const Tls13Backend = struct {
 
     pub fn setEarlyDataCompatibilityGate(self: *Tls13Backend, gate: EarlyDataCompatibilityGate) HandshakeError!void {
         self.engine.setEarlyDataCompatibilityGate(gate) catch |err| return mapError(err);
+    }
+
+    /// #368 Slice 2: installs the process-shared anti-replay gate on the
+    /// shared engine — the same seam native TCP uses — so QUIC/H3 can never
+    /// fall back to worker-local replay bookkeeping.
+    pub fn setEarlyDataReplayGate(self: *Tls13Backend, gate: EarlyDataReplayGate) HandshakeError!void {
+        self.engine.setEarlyDataReplayGate(gate) catch |err| return mapError(err);
     }
 
     pub fn setResumptionDecisionObserver(self: *Tls13Backend, observer: shared.Tls13Backend.ResumptionDecisionObserver) HandshakeError!void {

--- a/src/tls/early_data_replay.zig
+++ b/src/tls/early_data_replay.zig
@@ -1,9 +1,9 @@
 //! Process-local anti-replay store for accepted native TLS/QUIC 0-RTT early
-//! data (#368, Slice 1). This module owns replay-key storage, atomic claim
-//! semantics, recording-window retention/expiration, capacity behavior, and
-//! startup quarantine — it does not touch the #366/#497 `EarlyDataReplayGate`
-//! seam in `tls13_backend.zig`, and replay state is deliberately kept out of
-//! `resumption_runtime.zig` (wiring this store into the gate is Slice 2).
+//! data (#368). Slice 1 landed replay-key storage, atomic claim semantics,
+//! recording-window retention/expiration, capacity behavior, and startup
+//! quarantine. Slice 2 (`GateAdapter` below) wires a `Store` into the
+//! #366/#497 `EarlyDataReplayGate` seam in `tls13_backend.zig` — replay
+//! state itself stays deliberately out of `resumption_runtime.zig`.
 //!
 //! Normative reference: RFC 9846 §8. The guarantee this store implements a
 //! single-process instance of: after a replay key is successfully claimed,
@@ -19,6 +19,7 @@
 
 const std = @import("std");
 const zig_compat = @import("zig_compat");
+const tls13_backend = @import("tls13_backend.zig");
 
 /// One-way digest of an offered ticket's opaque wire identity — the
 /// existing `tls13_backend.EarlyDataReplayCandidate.ticket_identity_fingerprint`
@@ -98,6 +99,47 @@ pub const Store = struct {
 
     pub fn claim(self: Store, c: Claim) ClaimResult {
         return self.claimFn(self.ctx, c);
+    }
+};
+
+/// Maps a `Store`'s outcome vocabulary onto the TLS-layer decision
+/// `tls13_backend.EarlyDataReplayGate` expects: only `.duplicate` is a
+/// proven replay (`.replay`); a genuinely unavailable store, startup
+/// quarantine, and capacity exhaustion are all "this store cannot vouch for
+/// 0-RTT right now" (`.unavailable`) — every one of these rejects only
+/// early data, never an otherwise-valid PSK/session resumption.
+fn mapClaimResult(result: ClaimResult) tls13_backend.EarlyDataReplayDecision {
+    return switch (result) {
+        .accepted => .allow,
+        .duplicate => .replay,
+        .rejected_capacity, .unavailable => .unavailable,
+    };
+}
+
+/// Adapts any `Store` implementation — the bounded `LocalStore` today, a
+/// future distributed backend eventually — to the
+/// `tls13_backend.EarlyDataReplayGate` seam (#368 Slice 2). Composition owns
+/// exactly one `Store` and wraps it in exactly one `GateAdapter`, then
+/// installs the resulting gate into every native TLS backend that can
+/// accept early data (native TCP and QUIC/H3), so worker-local duplicate
+/// acceptance is impossible.
+pub const GateAdapter = struct {
+    backing: Store,
+
+    pub fn init(backing: Store) GateAdapter {
+        return .{ .backing = backing };
+    }
+
+    pub fn gate(self: *GateAdapter) tls13_backend.EarlyDataReplayGate {
+        return .{ .ctx = self, .decideFn = decide };
+    }
+
+    fn decide(ctx: *anyopaque, candidate: tls13_backend.EarlyDataReplayCandidate) tls13_backend.EarlyDataReplayDecision {
+        const self: *GateAdapter = @ptrCast(@alignCast(ctx));
+        return mapClaimResult(self.backing.claim(.{
+            .key = candidate.ticket_identity_fingerprint,
+            .retain_until_unix_ms = candidate.retain_until_unix_ms,
+        }));
     }
 };
 
@@ -632,4 +674,70 @@ test "capacity and expiration events are observable through the closed Event voc
     try testing.expectEqual(Event.capacity_rejected, recorder.events[1]);
     try testing.expectEqual(Event.expired, recorder.events[2]);
     try testing.expectEqual(Event.accepted, recorder.events[3]);
+}
+
+// ---------------------------------------------------------------------
+// #368 Slice 2: `GateAdapter` — adapting `Store` to the TLS-layer
+// `EarlyDataReplayGate` seam.
+// ---------------------------------------------------------------------
+
+test "mapClaimResult: only duplicate maps to replay; capacity and unavailable both fail closed to unavailable" {
+    try testing.expectEqual(tls13_backend.EarlyDataReplayDecision.allow, mapClaimResult(.accepted));
+    try testing.expectEqual(tls13_backend.EarlyDataReplayDecision.replay, mapClaimResult(.duplicate));
+    try testing.expectEqual(tls13_backend.EarlyDataReplayDecision.unavailable, mapClaimResult(.rejected_capacity));
+    try testing.expectEqual(tls13_backend.EarlyDataReplayDecision.unavailable, mapClaimResult(.unavailable));
+}
+
+test "GateAdapter.gate() drives a real LocalStore: allow, then replay, preserving the candidate's key/deadline" {
+    var store = try LocalStore.init(testing.allocator, testLimits(4), 0, 1_000);
+    defer store.deinit();
+    var adapter = GateAdapter.init(store.store());
+    const gate = adapter.gate();
+
+    const candidate: tls13_backend.EarlyDataReplayCandidate = .{
+        .ticket_identity_fingerprint = keyOf(9),
+        .retain_until_unix_ms = std.math.maxInt(u64),
+    };
+    try testing.expectEqual(tls13_backend.EarlyDataReplayDecision.allow, gate.decideFn.?(gate.ctx, candidate));
+    try testing.expectEqual(tls13_backend.EarlyDataReplayDecision.replay, gate.decideFn.?(gate.ctx, candidate));
+    try testing.expectEqual(@as(usize, 1), store.count());
+}
+
+test "GateAdapter.gate() surfaces startup quarantine as unavailable, never as replay" {
+    // `Store.claim` (unlike `LocalStore.claim` called directly) reads real
+    // wall-clock time at the trampoline boundary — see `store()`'s doc
+    // comment — so the store must be seeded from that same clock for a
+    // quarantine window to still be open moments later in this test.
+    var store = try LocalStore.init(testing.allocator, testLimits(4), 60_000, @intCast(zig_compat.milliTimestamp()));
+    defer store.deinit();
+    var adapter = GateAdapter.init(store.store());
+    const gate = adapter.gate();
+
+    const candidate: tls13_backend.EarlyDataReplayCandidate = .{
+        .ticket_identity_fingerprint = keyOf(1),
+        .retain_until_unix_ms = 5_000,
+    };
+    try testing.expectEqual(tls13_backend.EarlyDataReplayDecision.unavailable, gate.decideFn.?(gate.ctx, candidate));
+    try testing.expectEqual(@as(usize, 0), store.count());
+}
+
+test "GateAdapter.gate() surfaces capacity exhaustion as unavailable without evicting the live entry" {
+    var store = try LocalStore.init(testing.allocator, testLimits(1), 0, 1_000);
+    defer store.deinit();
+    var adapter = GateAdapter.init(store.store());
+    const gate = adapter.gate();
+
+    const first: tls13_backend.EarlyDataReplayCandidate = .{
+        .ticket_identity_fingerprint = keyOf(1),
+        .retain_until_unix_ms = std.math.maxInt(u64),
+    };
+    const second: tls13_backend.EarlyDataReplayCandidate = .{
+        .ticket_identity_fingerprint = keyOf(2),
+        .retain_until_unix_ms = std.math.maxInt(u64),
+    };
+    try testing.expectEqual(tls13_backend.EarlyDataReplayDecision.allow, gate.decideFn.?(gate.ctx, first));
+    try testing.expectEqual(tls13_backend.EarlyDataReplayDecision.unavailable, gate.decideFn.?(gate.ctx, second));
+    // The first key must still be protected — capacity exhaustion never
+    // evicts a live entry to admit a new one.
+    try testing.expectEqual(tls13_backend.EarlyDataReplayDecision.replay, gate.decideFn.?(gate.ctx, first));
 }

--- a/src/tls/early_data_replay.zig
+++ b/src/tls/early_data_replay.zig
@@ -281,6 +281,21 @@ pub const LocalStore = struct {
             expired_removed.* += 1;
         }
 
+        // The caller (`tls13_backend.zig`) derived `c.retain_until_unix_ms`
+        // from an earlier wall-clock read at TLS-freshness-check time;
+        // `Store.claim`'s trampoline takes a *second*, later wall-clock
+        // reading for `now_unix_ms`. At the exact accepted negative-skew
+        // boundary those two reads can straddle `retain_until_unix_ms`
+        // itself. Inserting a claim whose own deadline has already passed
+        // relative to `now_unix_ms` would record an entry that looks
+        // already-expired to every subsequent claim of the same key —
+        // silently reopening the exact replay window #368 requires closed.
+        // Fail closed instead of recording anything.
+        if (now_unix_ms > c.retain_until_unix_ms) {
+            event.* = .unavailable;
+            return .unavailable;
+        }
+
         if (self.entries.count() < self.limits.max_entries) {
             return self.insertLocked(c, event);
         }
@@ -408,6 +423,42 @@ test "claim after the deadline expires the old entry and a new claim can be acce
     defer store.deinit();
     try testing.expectEqual(ClaimResult.accepted, store.claim(.{ .key = keyOf(1), .retain_until_unix_ms = 2_000 }, 1_000));
     try testing.expectEqual(ClaimResult.accepted, store.claim(.{ .key = keyOf(1), .retain_until_unix_ms = 5_000 }, 2_001));
+}
+
+test "a claim whose own deadline has already passed relative to now fails closed instead of recording an already-expired entry" {
+    // Guards the exact clock-boundary gap between the TLS-layer's earlier
+    // freshness-check read (which produced `retain_until_unix_ms = T`) and
+    // `Store.claim`'s later wall-clock read (`now_unix_ms = T + 1`):
+    // inserting anyway would record a key that looks already-expired to
+    // every subsequent claimant, letting a second concurrent replay of the
+    // same key also be accepted once it, too, observes the entry as
+    // expired and reclaims it.
+    var store = try LocalStore.init(testing.allocator, testLimits(4), 0, 1_000);
+    defer store.deinit();
+    try testing.expectEqual(ClaimResult.unavailable, store.claim(.{ .key = keyOf(1), .retain_until_unix_ms = 1_000 }, 1_001));
+    try testing.expectEqual(@as(usize, 0), store.count());
+
+    // A second "concurrent" claim of the same key, at the same stale
+    // `now`, must not be recorded either — nothing was ever inserted for
+    // the first claim to protect against replay of the second.
+    try testing.expectEqual(ClaimResult.unavailable, store.claim(.{ .key = keyOf(1), .retain_until_unix_ms = 1_000 }, 1_001));
+    try testing.expectEqual(@as(usize, 0), store.count());
+
+    // A fresh claim whose deadline has not yet passed still succeeds
+    // normally — this only guards claims that are stale on arrival.
+    try testing.expectEqual(ClaimResult.accepted, store.claim(.{ .key = keyOf(1), .retain_until_unix_ms = 1_001 }, 1_001));
+}
+
+test "an already-stale claim also fails closed against a live entry it would otherwise expire and replace" {
+    // Same boundary gap, but with a *prior* live entry for the same key
+    // already present: the duplicate check must still win first (the key
+    // remains claimed), rather than the stale-deadline guard tearing down
+    // protection that was already established.
+    var store = try LocalStore.init(testing.allocator, testLimits(4), 0, 1_000);
+    defer store.deinit();
+    try testing.expectEqual(ClaimResult.accepted, store.claim(.{ .key = keyOf(1), .retain_until_unix_ms = 5_000 }, 1_000));
+    try testing.expectEqual(ClaimResult.duplicate, store.claim(.{ .key = keyOf(1), .retain_until_unix_ms = 1_000 }, 1_001));
+    try testing.expectEqual(@as(usize, 1), store.count());
 }
 
 test "two different keys are independent" {

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -360,6 +360,16 @@ pub const EarlyDataReplayDecision = enum { allow, replay, unavailable };
 pub const EarlyDataReplayCandidate = struct {
     ticket_identity_fingerprint: [32]u8 = [_]u8{0} ** 32,
     obfuscated_ticket_age: u32 = 0,
+    /// #368 Slice 2: the authoritative anti-replay retention deadline for
+    /// this candidate, derived by `computeReplayRetainUntilUnixMs` from the
+    /// already-validated ticket issuance time, apparent ticket age, and
+    /// age-skew tolerance — never re-derived by the replay store itself.
+    /// Only meaningful when the candidate actually reaches
+    /// `EarlyDataReplayGate.decide`; a deadline that cannot be computed
+    /// (overflow/impossible timing) short-circuits to `.replay_unavailable`
+    /// before the gate is ever consulted, so this field stays `0` in that
+    /// case.
+    retain_until_unix_ms: u64 = 0,
 };
 
 /// Server (#366/#368 seam): injectable anti-replay decision for an
@@ -3246,6 +3256,18 @@ pub const Tls13Backend = struct {
             // resumption.
             var identity_fingerprint: [hash_len]u8 = undefined;
             Sha256.hash(pair.identity.identity, &identity_fingerprint, .{});
+            // #368 Slice 2: the replay store's retention window, derived
+            // here (not re-derived from `obfuscated_ticket_age` by the
+            // store) from the same validated ticket-age observation used
+            // for the `.age_skew` freshness check above. `null` means the
+            // arithmetic overflowed or the timing is impossible — fail
+            // closed for 0-RTT below rather than silently shortening
+            // retention.
+            const replay_retain_until_unix_ms = computeReplayRetainUntilUnixMs(
+                hit.state.common.issued_at_unix_ms,
+                age_skew.apparent_age_ms,
+                self.server_early_data_policy.age_skew_tolerance_ms,
+            );
             const early_decision = self.decideServerEarlyData(.{
                 .selected_index = attempts,
                 .compatibility = decision.early_data,
@@ -3258,6 +3280,7 @@ pub const Tls13Backend = struct {
                     .ticket_identity_fingerprint = identity_fingerprint,
                     .obfuscated_ticket_age = pair.identity.obfuscated_ticket_age,
                 },
+                .replay_retain_until_unix_ms = replay_retain_until_unix_ms,
             });
             self.early_data_decision = early_decision;
             self.early_data_accepted = early_decision == .accepted;
@@ -3302,6 +3325,12 @@ pub const Tls13Backend = struct {
         age_skew: pre_shared_key.AgeSkew,
         compat_candidate: EarlyDataCompatibilityCandidate,
         replay_candidate: EarlyDataReplayCandidate,
+        /// #368 Slice 2: the replay-store retention deadline computed by
+        /// `computeReplayRetainUntilUnixMs` for `replay_candidate`, or
+        /// `null` on overflow/impossible timing — `decideServerEarlyData`
+        /// fails closed to `.replay_unavailable` without ever consulting
+        /// the replay gate in that case.
+        replay_retain_until_unix_ms: ?u64,
     };
 
     /// #366: the server's live 0-RTT decision for the just-selected,
@@ -3335,7 +3364,14 @@ pub const Tls13Backend = struct {
         }
         if (!skewWithinTolerance(inputs.age_skew.skew_ms, self.server_early_data_policy.age_skew_tolerance_ms))
             return .age_skew;
-        return switch (self.early_data_replay_gate.decide(inputs.replay_candidate)) {
+        // #368 Slice 2: a deadline that couldn't be computed (overflow or
+        // impossible ticket timing) never reaches the replay gate at all —
+        // fail closed rather than let the store record a bogus, silently
+        // shortened retention window.
+        const retain_until_unix_ms = inputs.replay_retain_until_unix_ms orelse return .replay_unavailable;
+        var candidate = inputs.replay_candidate;
+        candidate.retain_until_unix_ms = retain_until_unix_ms;
+        return switch (self.early_data_replay_gate.decide(candidate)) {
             .allow => .accepted,
             .replay => .replay_rejected,
             .unavailable => .replay_unavailable,
@@ -4209,6 +4245,63 @@ test "skewWithinTolerance handles minInt(i64) without trapping" {
 test "skewWithinTolerance handles maxInt(i64) at the u64 tolerance boundary" {
     try std.testing.expect(skewWithinTolerance(std.math.maxInt(i64), @as(u64, std.math.maxInt(i64))));
     try std.testing.expect(!skewWithinTolerance(std.math.maxInt(i64), @as(u64, std.math.maxInt(i64)) - 1));
+}
+
+/// #368 Slice 2: the authoritative anti-replay retention deadline for an
+/// accepted 0-RTT candidate — `expected_arrival_time = ticket_issued_at +
+/// apparent_ticket_age`, `retain_until = expected_arrival_time +
+/// age_skew_tolerance` (RFC 9846 §8.2/§8.3). The replay store must not
+/// reverse-engineer this from `obfuscated_ticket_age` itself, so it is
+/// derived once here from the already-validated inputs the `.age_skew`
+/// freshness check already used. Checked arithmetic throughout: a negative
+/// issuance time (never produced by legitimate ticket issuance, but not a
+/// type-level impossibility) or any addition overflow returns `null`, which
+/// the caller treats as fail-closed for 0-RTT — never a silently shortened
+/// retention window.
+fn computeReplayRetainUntilUnixMs(issued_at_unix_ms: i64, apparent_age_ms: u32, age_skew_tolerance_ms: u64) ?u64 {
+    if (issued_at_unix_ms < 0) return null;
+    const issued_at: u64 = @intCast(issued_at_unix_ms);
+    const expected_arrival = std.math.add(u64, issued_at, apparent_age_ms) catch return null;
+    return std.math.add(u64, expected_arrival, age_skew_tolerance_ms) catch return null;
+}
+
+test "computeReplayRetainUntilUnixMs sums issuance, apparent age, and tolerance" {
+    try std.testing.expectEqual(@as(?u64, 1_000 + 2_000 + 60_000), computeReplayRetainUntilUnixMs(1_000, 2_000, 60_000));
+    try std.testing.expectEqual(@as(?u64, 0), computeReplayRetainUntilUnixMs(0, 0, 0));
+}
+
+test "computeReplayRetainUntilUnixMs rejects a negative issuance time" {
+    try std.testing.expectEqual(@as(?u64, null), computeReplayRetainUntilUnixMs(-1, 0, 0));
+}
+
+test "computeReplayRetainUntilUnixMs fails closed when the tolerance addition overflows" {
+    // `issued_at_unix_ms` (`i64`) plus `apparent_age_ms` (`u32`) can never
+    // overflow `u64` on its own — the tolerance addition is where a
+    // caller-controlled `u64` can actually push the sum past `maxInt(u64)`.
+    try std.testing.expectEqual(
+        @as(?u64, null),
+        computeReplayRetainUntilUnixMs(std.math.maxInt(i64), std.math.maxInt(u32), std.math.maxInt(u64)),
+    );
+    try std.testing.expectEqual(
+        @as(?u64, null),
+        computeReplayRetainUntilUnixMs(1_000, 0, std.math.maxInt(u64)),
+    );
+}
+
+test "computeReplayRetainUntilUnixMs accepts the exact boundary before overflow" {
+    // `issued_at_unix_ms` is `i64`, so the largest representable issuance
+    // time is `maxInt(i64)` — well short of `maxInt(u64)`. Push the
+    // remaining headroom into the tolerance term to land exactly on the
+    // `maxInt(u64)` boundary without either input overflowing its own type.
+    const headroom: u64 = std.math.maxInt(u64) - @as(u64, std.math.maxInt(i64));
+    try std.testing.expectEqual(
+        @as(?u64, std.math.maxInt(u64)),
+        computeReplayRetainUntilUnixMs(std.math.maxInt(i64), 0, headroom),
+    );
+    try std.testing.expectEqual(
+        @as(?u64, null),
+        computeReplayRetainUntilUnixMs(std.math.maxInt(i64), 0, headroom + 1),
+    );
 }
 
 /// Symmetric optional equality for a stored `CompatSnapshot` against a

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -947,6 +947,83 @@ test "0-RTT is rejected without ever consulting the replay gate when the retenti
     try std.testing.expectEqual(@as(?tls_backend.EarlyDataReplayCandidate, null), replay_gate.seen);
 }
 
+test "0-RTT is rejected, not accepted, when the replay store's own clock read lands past the TLS-validated retention deadline; 1-RTT resumption still completes" {
+    // The exact clock-boundary gap flagged in review: `tls13_backend.zig`
+    // derives `retain_until_unix_ms` from an earlier wall-clock read (the
+    // resolver's `now`, fixed here via `IdentityResolver.now`/
+    // `earlyDataResumedClientClock`); `Store.claim`'s trampoline then takes
+    // a *second*, later wall-clock read for its own `now_unix_ms`. If that
+    // second read lands even one millisecond past the deadline the first
+    // read produced, a naive store would insert an already-expired record
+    // and report `.accepted` — letting a second, concurrent replay of the
+    // same key also be accepted once it observes that record as expired.
+    // `LocalStore.claimLocked`'s stale-claim guard (see `early_data_replay.zig`)
+    // must fail closed here instead.
+    var issued = try issueEarlyCapableTicket(32);
+    defer issued.deinit();
+
+    var resumed = DirectHarness.init();
+    defer resumed.deinit();
+
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&issued.ticket);
+    var clock_dummy: u8 = 0;
+    try resumed.client_backend.setClientPskOffers(&offers, &clock_dummy, earlyDataResumedClientClock);
+
+    var resolver_state = IdentityResolver{ .state = &issued.server_state };
+    try resumed.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = IdentityResolver.now,
+        .resolveFn = IdentityResolver.resolve,
+    });
+
+    try resumed.client_backend.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 16384 });
+    try resumed.server_backend.setServerEarlyDataPolicy(.{ .enabled = true, .age_skew_tolerance_ms = 60_000 });
+
+    // A real `LocalStore`, driven through a gate that simulates the
+    // replay-store clock reading exactly one millisecond past the
+    // TLS-validated deadline it is handed — rather than depending on real
+    // wall-clock timing (non-deterministic and effectively unreachable in
+    // a fast unit test), this test controls that later read directly so
+    // the boundary is hit deterministically every run.
+    var store = try tls_core.early_data_replay.LocalStore.init(std.testing.allocator, .{}, 0, 0);
+    defer store.deinit();
+    const RaceGate = struct {
+        store: *tls_core.early_data_replay.LocalStore,
+
+        fn decide(ctx: *anyopaque, candidate: tls_backend.EarlyDataReplayCandidate) tls_backend.EarlyDataReplayDecision {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            const result = self.store.claim(
+                .{ .key = candidate.ticket_identity_fingerprint, .retain_until_unix_ms = candidate.retain_until_unix_ms },
+                candidate.retain_until_unix_ms + 1,
+            );
+            return switch (result) {
+                .accepted => .allow,
+                .duplicate => .replay,
+                .rejected_capacity, .unavailable => .unavailable,
+            };
+        }
+    };
+    var race_gate = RaceGate{ .store = &store };
+    try resumed.server_backend.setEarlyDataReplayGate(.{ .ctx = &race_gate, .decideFn = RaceGate.decide });
+
+    try resumed.run();
+
+    try std.testing.expect(resumed.client_driver.isComplete());
+    try std.testing.expect(resumed.server_driver.isComplete());
+    // Resumption itself is unaffected by the store's clock-boundary
+    // rejection — only the 0-RTT attempt is rejected.
+    try std.testing.expect(resumed.client_backend.core.psk_authenticated);
+    try std.testing.expect(resumed.server_backend.core.psk_authenticated);
+
+    try std.testing.expectEqual(tls_backend.EarlyDataDecision.replay_unavailable, resumed.server_backend.earlyDataDecision());
+    try std.testing.expect(!resumed.server_backend.earlyDataAccepted());
+    // Nothing was recorded: a concurrent replay racing the same boundary
+    // must not find a live entry to duplicate against, nor an
+    // already-expired one it could silently reclaim and get accepted for.
+    try std.testing.expectEqual(@as(usize, 0), store.count());
+}
+
 test "#368 Slice 2: a real process-scoped LocalStore shared across two independent backends rejects the second worker's duplicate 0-RTT claim while both preserve 1-RTT resumption" {
     var issued = try issueEarlyCapableTicket(32);
     defer issued.deinit();

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -862,6 +862,16 @@ test "0-RTT round trip: an early-capable ticket, matching policy, and an allowin
     try std.testing.expectEqualSlices(u8, &expected_fingerprint, &seen_candidate.ticket_identity_fingerprint);
     try std.testing.expect(!std.mem.allEqual(u8, &seen_candidate.ticket_identity_fingerprint, 0));
 
+    // #368 Slice 2: the candidate the replay gate receives also carries the
+    // authoritative retention deadline — `ticket_issued_at (1000, from
+    // `issueEarlyCapableTicketProfile`) + apparent_ticket_age +
+    // age_skew_tolerance_ms (60_000, set above)` — derived once by
+    // `tls13_backend.zig` from the same validated age-skew observation the
+    // freshness check already used, not re-derived by the replay store.
+    const age_skew = resumed.server_backend.takePskAgeSkew() orelse return error.TestExpectedEqual;
+    const expected_retain_until_unix_ms: u64 = @intCast(@as(i64, 1000) + @as(i64, age_skew.apparent_age_ms) + 60_000);
+    try std.testing.expectEqual(expected_retain_until_unix_ms, seen_candidate.retain_until_unix_ms);
+
     // The client's `c e traffic` secret (derived from the final ClientHello
     // it sent) and the server's own derivation (from the same ClientHello,
     // captured pre-binder-verification) must be byte-identical — a real
@@ -880,6 +890,169 @@ test "0-RTT round trip: an early-capable ticket, matching policy, and an allowin
     const request = try resumed.client_bridge.sealApplicationData("resumed request", &protected2);
     const opened_request = try resumed.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, request), &plaintext2);
     try std.testing.expectEqualStrings("resumed request", opened_request.inner.content);
+}
+
+test "0-RTT is rejected without ever consulting the replay gate when the retention deadline overflows" {
+    var issued = try issueEarlyCapableTicket(32);
+    defer issued.deinit();
+
+    var resumed = DirectHarness.init();
+    defer resumed.deinit();
+
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&issued.ticket);
+    var clock_dummy: u8 = 0;
+    try resumed.client_backend.setClientPskOffers(&offers, &clock_dummy, earlyDataResumedClientClock);
+
+    var resolver_state = IdentityResolver{ .state = &issued.server_state };
+    try resumed.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = IdentityResolver.now,
+        .resolveFn = IdentityResolver.resolve,
+    });
+
+    try resumed.client_backend.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 16384 });
+    // An enormous tolerance still passes the `skewWithinTolerance` freshness
+    // check (any real skew is trivially within it), but overflows
+    // `computeReplayRetainUntilUnixMs`'s final addition — #368 Slice 2 must
+    // fail closed for 0-RTT there rather than hand the store a silently
+    // shortened/wrapped deadline.
+    try resumed.server_backend.setServerEarlyDataPolicy(.{ .enabled = true, .age_skew_tolerance_ms = std.math.maxInt(u64) });
+
+    const CapturingReplayGate = struct {
+        seen: ?tls_backend.EarlyDataReplayCandidate = null,
+
+        fn decide(ctx: *anyopaque, candidate: tls_backend.EarlyDataReplayCandidate) tls_backend.EarlyDataReplayDecision {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.seen = candidate;
+            return .allow;
+        }
+    };
+    var replay_gate = CapturingReplayGate{};
+    try resumed.server_backend.setEarlyDataReplayGate(.{
+        .ctx = &replay_gate,
+        .decideFn = CapturingReplayGate.decide,
+    });
+
+    try resumed.run();
+
+    try std.testing.expect(resumed.client_driver.isComplete());
+    try std.testing.expect(resumed.server_driver.isComplete());
+    // Resumption itself is unaffected by the deadline-overflow rejection.
+    try std.testing.expect(resumed.client_backend.core.psk_authenticated);
+    try std.testing.expect(resumed.server_backend.core.psk_authenticated);
+
+    try std.testing.expectEqual(tls_backend.EarlyDataDecision.replay_unavailable, resumed.server_backend.earlyDataDecision());
+    try std.testing.expect(!resumed.server_backend.earlyDataAccepted());
+    try std.testing.expectEqual(@as(?tls_backend.EarlyDataReplayCandidate, null), replay_gate.seen);
+}
+
+test "#368 Slice 2: a real process-scoped LocalStore shared across two independent backends rejects the second worker's duplicate 0-RTT claim while both preserve 1-RTT resumption" {
+    var issued = try issueEarlyCapableTicket(32);
+    defer issued.deinit();
+
+    // One process-scoped store, one gate adapter — exactly the composition
+    // pattern `edge_gateway.zig` installs into every native TCP worker and
+    // QUIC/H3, proven here against two independent `Tls13Backend`
+    // "workers" sharing it. `LocalStore.store()`'s adapter reads real
+    // wall-clock time at the trampoline boundary (see its doc comment), but
+    // `DirectHarness`'s ticket/skew clocks are fixed test values, so this
+    // wraps the same `LocalStore` in a small deterministic `Store` instead
+    // — matching this suite's "no sleeping tests, deterministic injected
+    // clocks" convention while still exercising the real claim semantics.
+    const DeterministicStore = struct {
+        backing: *tls_core.early_data_replay.LocalStore,
+        now_unix_ms: u64,
+
+        fn asStore(self: *@This()) tls_core.early_data_replay.Store {
+            return .{ .ctx = self, .claimFn = claimTrampoline };
+        }
+
+        fn claimTrampoline(ctx: *anyopaque, c: tls_core.early_data_replay.Claim) tls_core.early_data_replay.ClaimResult {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            return self.backing.claim(c, self.now_unix_ms);
+        }
+    };
+
+    var store = try tls_core.early_data_replay.LocalStore.init(std.testing.allocator, .{}, 0, 0);
+    defer store.deinit();
+    // Matches `IdentityResolver.now`/the server's freshness-check clock
+    // above, so the retention deadline `tls13_backend.zig` computes from
+    // the (equally fixed) ticket issuance time is measured against the same
+    // clock the store sees.
+    var det_store = DeterministicStore{ .backing = &store, .now_unix_ms = 2_000 };
+    var adapter = tls_core.early_data_replay.GateAdapter.init(det_store.asStore());
+    const shared_gate = adapter.gate();
+
+    const RunWorker = struct {
+        fn run(state: *session.ServerRecoverableState, ticket: *const session.ClientTicketState, gate: tls_backend.EarlyDataReplayGate) !*DirectHarness {
+            const harness = try std.testing.allocator.create(DirectHarness);
+            harness.* = DirectHarness.init();
+            errdefer {
+                harness.deinit();
+                std.testing.allocator.destroy(harness);
+            }
+
+            // `ClientPskOfferSet.push` moves ownership out of its argument
+            // (zero-valuing it) — offering the same ticket to two
+            // independent "worker" harnesses needs an independent clone
+            // each time, not the one shared `issued.ticket`.
+            var ticket_clone: session.ClientTicketState = .{};
+            try ticket.cloneInto(std.testing.allocator, &ticket_clone);
+            errdefer ticket_clone.deinit();
+
+            var offers: pre_shared_key.ClientPskOfferSet = .{};
+            try offers.push(&ticket_clone);
+            var clock_dummy: u8 = 0;
+            try harness.client_backend.setClientPskOffers(&offers, &clock_dummy, earlyDataResumedClientClock);
+
+            var resolver_state = IdentityResolver{ .state = state };
+            try harness.server_backend.setServerPskResolver(.{
+                .ctx = &resolver_state,
+                .nowUnixMsFn = IdentityResolver.now,
+                .resolveFn = IdentityResolver.resolve,
+            });
+
+            try harness.client_backend.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 16384 });
+            try harness.server_backend.setServerEarlyDataPolicy(.{ .enabled = true, .age_skew_tolerance_ms = 60_000 });
+            try harness.server_backend.setEarlyDataReplayGate(gate);
+
+            try harness.run();
+            return harness;
+        }
+    };
+
+    // Worker A: the first claim of this ticket's replay key anywhere in the
+    // (simulated) process — accepted.
+    const worker_a = try RunWorker.run(&issued.server_state, &issued.ticket, shared_gate);
+    defer {
+        worker_a.deinit();
+        std.testing.allocator.destroy(worker_a);
+    }
+    try std.testing.expect(worker_a.client_driver.isComplete());
+    try std.testing.expect(worker_a.server_driver.isComplete());
+    try std.testing.expect(worker_a.client_backend.core.psk_authenticated);
+    try std.testing.expect(worker_a.server_backend.core.psk_authenticated);
+    try std.testing.expectEqual(tls_backend.EarlyDataDecision.accepted, worker_a.server_backend.earlyDataDecision());
+
+    // Worker B: an independent backend instance (a different native TCP
+    // worker/connection in production) offering the very same ticket. The
+    // shared store — not a worker-local one — must recognize the replay key
+    // is already claimed and reject only the 0-RTT attempt; resumption
+    // itself still succeeds.
+    const worker_b = try RunWorker.run(&issued.server_state, &issued.ticket, shared_gate);
+    defer {
+        worker_b.deinit();
+        std.testing.allocator.destroy(worker_b);
+    }
+    try std.testing.expect(worker_b.client_driver.isComplete());
+    try std.testing.expect(worker_b.server_driver.isComplete());
+    try std.testing.expect(worker_b.client_backend.core.psk_authenticated);
+    try std.testing.expect(worker_b.server_backend.core.psk_authenticated);
+    try std.testing.expectEqual(tls_backend.EarlyDataDecision.replay_rejected, worker_b.server_backend.earlyDataDecision());
+    try std.testing.expect(!worker_b.server_backend.earlyDataAccepted());
+
+    try std.testing.expectEqual(@as(usize, 1), store.count());
 }
 
 test "0-RTT is never attempted for a resume-only ticket even with client intent enabled" {


### PR DESCRIPTION
## Summary

Slice 2 of #368 — TLS/composition integration for the process-local anti-replay store landed in Slice 1 (#505).

- Extends `tls13_backend.EarlyDataReplayCandidate` with an authoritative `retain_until_unix_ms` deadline: `expected_arrival_time = ticket_issued_at + apparent_ticket_age`, `retain_until = expected_arrival_time + age_skew_tolerance`, computed via checked arithmetic from the already-validated ticket-age/freshness inputs. Overflow or impossible timing fails closed for 0-RTT (`.replay_unavailable`) *before* the replay gate is ever consulted — never a silently shortened retention window.
- Adds `early_data_replay.GateAdapter`, adapting any `Store` implementation (the bounded `LocalStore` today, a future distributed backend later) to the `EarlyDataReplayGate` seam. Maps `accepted -> allow`, `duplicate -> replay`, and `rejected_capacity`/`unavailable` -> `unavailable` — only a proven duplicate is reported as replay; everything else fails closed without touching 1-RTT resumption.
- `edge_gateway.zig` constructs exactly one process-scoped `LocalStore`/`GateAdapter` pair at the composition root (mirroring #488's `resumption_runtime` ownership pattern) and installs the resulting gate into every native TCP worker (`native_tls_connection.zig`) and the QUIC/H3 runtime (`http3_runtime.zig`, via a new `quic.tls_backend.Tls13Backend.setEarlyDataReplayGate` passthrough) — independent of whether native resumption itself is wired for a given connection, so worker-local duplicate 0-RTT acceptance is architecturally impossible.
- No config, metrics, deployment docs, or real distributed backend — that's Slice 3. No replay state added to `resumption_runtime.zig`.

## Test plan

- [x] `computeReplayRetainUntilUnixMs`: deadline arithmetic and boundary/overflow fail-closed (inline unit tests in `tls13_backend.zig`)
- [x] `GateAdapter`/`mapClaimResult`: allow/duplicate/unavailable mapping, including capacity exhaustion and startup quarantine (`early_data_replay.zig`)
- [x] Full handshake: replay gate receives the computed retention deadline; deadline overflow rejects 0-RTT without ever consulting the gate, preserving 1-RTT resumption (`tls13_backend_tests.zig`)
- [x] Two independent `Tls13Backend` "workers" sharing one real `LocalStore` reject the second worker's duplicate 0-RTT claim while both complete ordinary resumption (`tls13_backend_tests.zig`)
- [x] Native TCP (`NativeTlsConnection`) and QUIC/H3 (`http3_runtime.Runtime`) each install the shared gate independently of the resumption runtime (`native_tls_connection.zig`, `http3_runtime.zig`)
- [x] One process-scoped store is shared by native TCP and QUIC/H3 through the actual composition-root wiring; startup quarantine is exercised through the exact helper `run()` calls (`edge_gateway.zig`)
- [x] `zig fmt --check` on all changed files
- [x] Full suite: `zig build test` — 2647/2648 passing (1 pre-existing unrelated skip)

Part of #368 (Slice 2 of 3 — config/metrics/docs and the distributed seam proof remain in Slice 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)