### PR TITLE
tls: add resumption/0-RTT scenario tests (#369 Slice 1)

### DIFF
--- a/docs/RESUMPTION_TEST_PLAN.md
+++ b/docs/RESUMPTION_TEST_PLAN.md
@@ -83,14 +83,16 @@ real OpenSSL/QUIC peer, no CI/soak changes.
   - Drive a real 425 early-retry through an upstream request-execution
     counter and prove it lands at exactly one execution, through the actual
     proxy path rather than a scripted attempt executor.
-  - Validate the store's documented scope directly: it is process-local
-    (each worker/process anti-replay state is independent), and it is
-    *not* cluster-wide — #368 explicitly scoped out a real distributed
-    backend (Redis/etcd/similar) as out of contract for this epic, so that
-    remains this repo's committed behavior, not a gap to close. This slice
-    should validate the process-local/multi-worker guarantee and the
-    documented non-cluster-wide limitation, not require implementing a
-    distributed backend.
+  - Validate the store's documented scope directly: all workers/transports
+    inside one process share one authoritative replay store (a replay
+    accepted by worker A is rejected by worker B in the same process);
+    separate Tardigrade processes are independent, so the guarantee is
+    process-local, not cluster-wide — #368 explicitly scoped out a real
+    distributed backend (Redis/etcd/similar) as out of contract for this
+    epic, so that remains this repo's committed behavior, not a gap to
+    close. This slice should validate the process-shared/multi-worker
+    guarantee and the documented non-cluster-wide limitation, not require
+    implementing a distributed backend.
 - **Soak scenarios**: repeated reconnect/rotation loops with memory/metrics
   checks over long runs.
 - **CI wiring**: a smoke subset plus an optional nightly/soak job.

--- a/docs/RESUMPTION_TEST_PLAN.md
+++ b/docs/RESUMPTION_TEST_PLAN.md
@@ -1,0 +1,67 @@
+# Resumption / 0-RTT Test Plan
+
+Tracks test coverage for the session-resumption and 0-RTT epic (#326) against
+the validation scope in issue #369 (326-J). #369 itself is XL and spans
+external interop, restart/rotation soak runs, and CI wiring — too large for
+one PR, so it is being landed in slices. This doc records what each slice
+covers so gaps are visible instead of implied.
+
+## Slice 1 (this PR): in-repo scenario tests
+
+Fast, deterministic, single-process Zig tests exercising the resumption/
+0-RTT/anti-replay code already landed by #365–#368. No external process, no
+real OpenSSL/QUIC peer, no CI/soak changes.
+
+- **Ticket expiry**: `src/tls/tls13_backend_tests.zig` — `"a ticket past its
+  lifetime is rejected and falls back to a full handshake (#369)"` drives a
+  real ClientHello/PSK-offer against a resolved-but-expired ticket end to
+  end. (Pure-logic expiry boundaries were already covered by
+  `src/tls/session.zig` and `src/tls/ticket_protection.zig`.)
+- **Key rotation**: `src/tls/ticket_protection.zig` —
+  `"rotation: a resolve against a decrypt-only grace-window key still
+  succeeds, and new seals use the new key (#369)"` and `"rotation: a fully
+  removed key rejects old tickets with unknown_key instead of crashing
+  (#369)"` cover both the grace-window and full-removal rotation shapes
+  against `ReloadableKeyRing`/`Protector` directly.
+- **Process restart / lost cache**: `src/tls/resumption_runtime.zig` —
+  `"restart: a stateless identity issued by one process is unresolvable by a
+  fresh process with no shared state (#369)"` and the stateful-cache
+  equivalent construct two independent `Runtime`s to model a real restart
+  (no shared ephemeral key or cache), not just a resolver returning miss.
+- **ALPN / cipher-suite mismatch on resumption**: `src/tls/
+  tls13_backend_tests.zig` — `"an ALPN mismatch falls back..."` and `"a
+  cipher-suite mismatch falls back..."`, alongside the pre-existing SNI-
+  mismatch and certificate-change tests, so every `session.ResumeMismatch`
+  variant now has an end-to-end (not just unit-level) regression.
+- **0-RTT replay rejection, anti-replay capacity, fallback to 1-RTT/full
+  handshake, and no-double-execution on 425 retry**: already extensively
+  covered by #368/#367's own test suites
+  (`src/tls/early_data_replay.zig`, `src/tls/tls13_backend_tests.zig`,
+  `src/gateway_proxy_runtime.zig`, `src/gateway_handlers.zig`,
+  `src/edge_gateway.zig`). No new tests added here in this slice — see the
+  file-level docs on those tests for the existing matrix.
+
+## Explicitly deferred to a later slice
+
+- **External interop** with OpenSSL (`s_client`/`s_server` ticket
+  round-trips) and an independent QUIC peer for H3 resumption/0-RTT. Needs
+  subprocess-driven test harnesses, not covered here.
+- **A real distributed anti-replay backend.** `src/tls/
+  early_data_replay.zig`'s `Store` contract (`GateAdapter`) is proven against
+  `LocalStore` and a scripted single-threaded fake
+  (`FakeDistributedOutcome`) only — see that file's module doc. True
+  cross-node atomicity, network partition/timeout handling, and TTL honoring
+  require an actual backend (Redis/etcd/similar) and are unimplemented, not
+  just untested.
+- **Soak scenarios**: repeated reconnect/rotation loops with memory/metrics
+  checks over long runs.
+- **CI wiring**: a smoke subset plus an optional nightly/soak job.
+- **QUIC-transport-specific 0-RTT-rejection-falls-back-to-1-RTT variant.**
+  The record-transport matrix is thoroughly covered
+  (`src/tls/tls13_backend_tests.zig`); an equivalent pass explicitly over
+  `Transport.quic` has not been added yet.
+
+Acceptance criteria for #369 as a whole (interop reliability, safe
+fallback/rejection under mismatch, no double execution, bounded soak
+memory/cache growth, reproducible artifacts without leaking ticket keys)
+remain open until the deferred items above land in follow-up slices.

--- a/docs/RESUMPTION_TEST_PLAN.md
+++ b/docs/RESUMPTION_TEST_PLAN.md
@@ -23,36 +23,74 @@ real OpenSSL/QUIC peer, no CI/soak changes.
   removed key rejects old tickets with unknown_key instead of crashing
   (#369)"` cover both the grace-window and full-removal rotation shapes
   against `ReloadableKeyRing`/`Protector` directly.
-- **Process restart / lost cache**: `src/tls/resumption_runtime.zig` —
+- **Process restart / lost cache (in-process/unit coverage only — not
+  #369's full restart obligation)**: `src/tls/resumption_runtime.zig` —
   `"restart: a stateless identity issued by one process is unresolvable by a
   fresh process with no shared state (#369)"` and the stateful-cache
-  equivalent construct two independent `Runtime`s to model a real restart
-  (no shared ephemeral key or cache), not just a resolver returning miss.
+  equivalent construct two independent `Runtime`s as a deterministic *model*
+  of lost ephemeral state (no shared ephemeral key or cache). This proves
+  the resolve-side fail-closed behavior in isolation; it does not exercise
+  an actual process restart, composition re-init, or the operational
+  lifecycle #369 owns — see the deferred restart/rotation matrix below.
 - **ALPN / cipher-suite mismatch on resumption**: `src/tls/
   tls13_backend_tests.zig` — `"an ALPN mismatch falls back..."` and `"a
   cipher-suite mismatch falls back..."`, alongside the pre-existing SNI-
   mismatch and certificate-change tests, so every `session.ResumeMismatch`
   variant now has an end-to-end (not just unit-level) regression.
 - **0-RTT replay rejection, anti-replay capacity, fallback to 1-RTT/full
-  handshake, and no-double-execution on 425 retry**: already extensively
-  covered by #368/#367's own test suites
+  handshake, and no-double-execution on 425 retry (unit/integration
+  coverage only — not #369's process-level assurance)**: already
+  extensively covered by #368/#367's own test suites
   (`src/tls/early_data_replay.zig`, `src/tls/tls13_backend_tests.zig`,
   `src/gateway_proxy_runtime.zig`, `src/gateway_handlers.zig`,
   `src/edge_gateway.zig`). No new tests added here in this slice — see the
-  file-level docs on those tests for the existing matrix.
+  file-level docs on those tests for the existing matrix. #326 assigns the
+  cross-layer, process-level version of this assurance to #369, which those
+  predecessor suites do not exercise — see the deferred matrix below.
 
 ## Explicitly deferred to a later slice
 
 - **External interop** with OpenSSL (`s_client`/`s_server` ticket
   round-trips) and an independent QUIC peer for H3 resumption/0-RTT. Needs
   subprocess-driven test harnesses, not covered here.
-- **A real distributed anti-replay backend.** `src/tls/
-  early_data_replay.zig`'s `Store` contract (`GateAdapter`) is proven against
-  `LocalStore` and a scripted single-threaded fake
-  (`FakeDistributedOutcome`) only — see that file's module doc. True
-  cross-node atomicity, network partition/timeout handling, and TTL honoring
-  require an actual backend (Redis/etcd/similar) and are unimplemented, not
-  just untested.
+- **Operational restart/rotation matrix** (the part of #369's restart
+  obligation the in-process `Runtime` model above does not reach):
+  - Old ticket issued → actual process restart / composition re-init →
+    resolver miss on the old ticket → connection still completes as a
+    usable full handshake → fresh ticket issuance succeeds with bounded
+    metrics recorded for the miss and the reissue.
+  - A persistent-overlap restart: generation N retained decrypt-only
+    alongside a newly current generation N+1 (or, for the stateless
+    keyring, a fresh non-overlapping nonce lease on reload), proving live
+    traffic straddling the reload never double-uses a nonce or drops a
+    still-valid ticket.
+  - Exact lifecycle boundaries (not-yet-active, active, decrypt-only grace,
+    fully retired) driven through a real reload/composition path rather
+    than direct `ReloadableKeyRing` calls.
+  - A failed reload retains the prior snapshot rather than leaving the
+    runtime with no usable key.
+  - Concurrent / cross-worker restart and rotation cases.
+- **Process-level 0-RTT/replay/425 matrix** (the cross-layer assurance #326
+  assigns to #369, distinct from the unit/integration tests #367/#368
+  already carry):
+  - Drive the real gateway/native TLS or H3 path end to end with a
+    `process_local` (in-process, not distributed) anti-replay store; prove
+    a duplicate 0-RTT claim is rejected while the underlying PSK connection
+    still completes as ordinary 1-RTT.
+  - Prove anti-replay capacity exhaustion and startup-quarantine both
+    reject only the early-data attempt, never the resumed/full-handshake
+    connection.
+  - Drive a real 425 early-retry through an upstream request-execution
+    counter and prove it lands at exactly one execution, through the actual
+    proxy path rather than a scripted attempt executor.
+  - Validate the store's documented scope directly: it is process-local
+    (each worker/process anti-replay state is independent), and it is
+    *not* cluster-wide — #368 explicitly scoped out a real distributed
+    backend (Redis/etcd/similar) as out of contract for this epic, so that
+    remains this repo's committed behavior, not a gap to close. This slice
+    should validate the process-local/multi-worker guarantee and the
+    documented non-cluster-wide limitation, not require implementing a
+    distributed backend.
 - **Soak scenarios**: repeated reconnect/rotation loops with memory/metrics
   checks over long runs.
 - **CI wiring**: a smoke subset plus an optional nightly/soak job.

--- a/src/tls/resumption_runtime.zig
+++ b/src/tls/resumption_runtime.zig
@@ -1008,3 +1008,76 @@ test "createIdentity disabled runtime reports typed stateful refusal" {
     defer state.deinit();
     try std.testing.expectError(error.StatefulCapacityRefused, runtime.createIdentity(&state, clock.now_ms, &.{}));
 }
+
+test "restart: a stateless identity issued by one process is unresolvable by a fresh process with no shared state (#369)" {
+    var clock = TestClock{};
+
+    var entropy_a = TestEntropy{ .byte = 0x10 };
+    var provider_a = crypto.pure_zig.Provider.init(entropy_a.entropy());
+    var runtime_a = try Runtime.init(
+        std.testing.allocator,
+        .{ .mode = .stateless },
+        clock.clock(),
+        provider_a.cryptoProvider(),
+    );
+    defer runtime_a.deinit();
+
+    var state = try sampleServerState(std.testing.allocator, "restart-stateless.test");
+    defer state.deinit();
+    var scratch: [1024]u8 = undefined;
+    const identity = try runtime_a.createIdentity(&state, clock.now_ms, &scratch);
+
+    // A fresh process: an independent entropy source feeding an independent
+    // `Runtime.init` call, so its ephemeral stateless key
+    // (`installEphemeralStatelessKey`) shares no key material with
+    // `runtime_a`'s — exactly what a real restart looks like.
+    var entropy_b = TestEntropy{ .byte = 0x99 };
+    var provider_b = crypto.pure_zig.Provider.init(entropy_b.entropy());
+    var runtime_b = try Runtime.init(
+        std.testing.allocator,
+        .{ .mode = .stateless },
+        clock.clock(),
+        provider_b.cryptoProvider(),
+    );
+    defer runtime_b.deinit();
+
+    const resolver = runtime_b.serverResolver().?;
+    var miss = try resolver.resolve(identity.slice());
+    defer miss.deinit();
+    try std.testing.expect(miss == .miss);
+}
+
+test "restart: a stateful handle issued by one process is unresolvable by a fresh process with an empty cache (#369)" {
+    var clock = TestClock{};
+
+    var entropy_a = TestEntropy{ .byte = 0x21 };
+    var provider_a = crypto.pure_zig.Provider.init(entropy_a.entropy());
+    var runtime_a = try Runtime.init(
+        std.testing.allocator,
+        .{ .mode = .stateful },
+        clock.clock(),
+        provider_a.cryptoProvider(),
+    );
+    defer runtime_a.deinit();
+
+    var state = try sampleServerState(std.testing.allocator, "restart-stateful.test");
+    const identity = try runtime_a.createIdentity(&state, clock.now_ms, &.{});
+    state.deinit();
+
+    // A fresh process with its own empty stateful cache — no knowledge of
+    // any handle `runtime_a` ever issued.
+    var entropy_b = TestEntropy{ .byte = 0x88 };
+    var provider_b = crypto.pure_zig.Provider.init(entropy_b.entropy());
+    var runtime_b = try Runtime.init(
+        std.testing.allocator,
+        .{ .mode = .stateful },
+        clock.clock(),
+        provider_b.cryptoProvider(),
+    );
+    defer runtime_b.deinit();
+
+    const resolver = runtime_b.serverResolver().?;
+    var miss = try resolver.resolve(identity.slice());
+    defer miss.deinit();
+    try std.testing.expect(miss == .miss);
+}

--- a/src/tls/ticket_protection.zig
+++ b/src/tls/ticket_protection.zig
@@ -1688,6 +1688,80 @@ test "nonce ledger persists through decrypt-only and removed snapshots" {
     try testing.expectError(error.OverlappingNonceLease, keyring.install(try keyring.buildSnapshot(&.{reintroduced}, testCapabilities())));
 }
 
+test "rotation: a resolve against a decrypt-only grace-window key still succeeds, and new seals use the new key (#369)" {
+    const allocator = testing.allocator;
+    var keyring = ReloadableKeyRing.init(allocator);
+    defer keyring.deinit();
+
+    const old_id = keyId(60);
+    const new_id = keyId(61);
+    const active_old = sampleKeyConfig(old_id, .aes_128_gcm, .{ .prefix = .{ 6, 0, 0, 0 }, .start = 0, .end_exclusive = 10 });
+    try keyring.install(try keyring.buildSnapshot(&.{active_old}, testCapabilities()));
+
+    var protector = Protector{ .provider = testProvider(), .keyring = &keyring, .limits = session.Limits.default };
+    var state = try sampleServerState(allocator);
+    defer state.deinit();
+    var old_ticket_buf: [1024]u8 = undefined;
+    const old_ticket = try protector.seal(allocator, &state, 1_000, &old_ticket_buf);
+    const old_parsed = try parseEnvelope(old_ticket, session.Limits.default);
+    try testing.expectEqualSlices(u8, &old_id, &old_parsed.key_id);
+
+    // Rotate: retire `old_id` to decrypt-only (grace window) and bring up
+    // `new_id` as the sole active encryption key, mirroring an operator
+    // pushing a new key config without yet removing the old one.
+    var decrypt_only_old = active_old;
+    decrypt_only_old.nonce_lease = null;
+    decrypt_only_old.encrypt_until_unix_ms = 1_500;
+    decrypt_only_old.decrypt_until_unix_ms = 20_000;
+    const active_new = sampleKeyConfigWithByte(new_id, .aes_128_gcm, .{ .prefix = .{ 6, 1, 0, 0 }, .start = 0, .end_exclusive = 10 }, 0x13);
+    try keyring.install(try keyring.buildSnapshot(&.{ decrypt_only_old, active_new }, testCapabilities()));
+
+    // The ticket sealed under `old_id` before rotation still decrypts
+    // during the grace window.
+    var recovered: session.ServerRecoverableState = .{};
+    defer recovered.deinit();
+    try testing.expect(try protector.resolve(allocator, old_ticket, 2_000, &recovered));
+
+    // A ticket sealed after rotation is bound to the new key, not the
+    // retired one.
+    var new_ticket_buf: [1024]u8 = undefined;
+    const new_ticket = try protector.seal(allocator, &state, 2_000, &new_ticket_buf);
+    const new_parsed = try parseEnvelope(new_ticket, session.Limits.default);
+    try testing.expectEqualSlices(u8, &new_id, &new_parsed.key_id);
+}
+
+test "rotation: a fully removed key rejects old tickets with unknown_key instead of crashing (#369)" {
+    const allocator = testing.allocator;
+    var keyring = ReloadableKeyRing.init(allocator);
+    defer keyring.deinit();
+
+    const old_id = keyId(70);
+    const new_id = keyId(71);
+    const active_old = sampleKeyConfig(old_id, .aes_128_gcm, .{ .prefix = .{ 7, 0, 0, 0 }, .start = 0, .end_exclusive = 10 });
+    try keyring.install(try keyring.buildSnapshot(&.{active_old}, testCapabilities()));
+
+    var protector = Protector{ .provider = testProvider(), .keyring = &keyring, .limits = session.Limits.default };
+    var state = try sampleServerState(allocator);
+    defer state.deinit();
+    var old_ticket_buf: [1024]u8 = undefined;
+    const old_ticket = try protector.seal(allocator, &state, 1_000, &old_ticket_buf);
+
+    // Rotate: install a replacement snapshot that no longer contains
+    // `old_id` at all (a full key removal, not a grace-window retirement).
+    const active_new = sampleKeyConfigWithByte(new_id, .aes_128_gcm, .{ .prefix = .{ 7, 1, 0, 0 }, .start = 0, .end_exclusive = 10 }, 0x13);
+    try keyring.install(try keyring.buildSnapshot(&.{active_new}, testCapabilities()));
+
+    var observer = TestObserver{};
+    defer observer.deinit(allocator);
+    protector.observer = observer.observer();
+
+    var recovered: session.ServerRecoverableState = .{};
+    defer recovered.deinit();
+    const accepted = try protector.resolve(allocator, old_ticket, 2_000, &recovered);
+    try testing.expect(!accepted);
+    try observer.expectOnly(.{ .resolve_rejected = .unknown_key });
+}
+
 test "nonce ledger rejects same key under a different id" {
     const allocator = testing.allocator;
     var keyring = ReloadableKeyRing.init(allocator);

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -4674,9 +4674,16 @@ const CountingResolver = struct {
     state: *session.ServerRecoverableState,
     identity: []const u8,
     calls: usize = 0,
+    /// The clock the server sees when evaluating resumption eligibility
+    /// (`session.evaluateCompatibility`'s `now_unix_ms`) — defaults to 0 to
+    /// match every existing call site's fixed-at-issuance tickets; set it
+    /// past a ticket's `issued_at_unix_ms + lifetime_seconds` to model
+    /// resolving an already-expired ticket.
+    now_ms: i64 = 0,
 
-    fn now(_: *anyopaque) i64 {
-        return 0;
+    fn now(ctx: *anyopaque) i64 {
+        const self: *@This() = @ptrCast(@alignCast(ctx));
+        return self.now_ms;
     }
     fn resolve(ctx: *anyopaque, identity: []const u8) pre_shared_key.ResolveError!pre_shared_key.ServerPskResolveResult {
         const self: *@This() = @ptrCast(@alignCast(ctx));
@@ -6763,6 +6770,124 @@ test "an SNI mismatch falls back to a full handshake instead of rejecting the co
 
     try std.testing.expectEqual(@as(usize, 1), resolver_state.calls);
     try std.testing.expect(!server.core.psk_authenticated);
+    try std.testing.expect(server.credentialFailure() == null);
+}
+
+test "a ticket past its lifetime is rejected and falls back to a full handshake (#369)" {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
+    defer server.deinit();
+
+    const psk = [_]u8{0x77} ** tls_backend.hash_len;
+    var common: session.ResumableSessionCommon = .{};
+    try common.init(std.testing.allocator, session.Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = &psk,
+        .application_protocol = "h2",
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer(tls_backend.testdata.certificate_der),
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 3600,
+    });
+    var stored_state: session.ServerRecoverableState = .{};
+    stored_state.init(&common, 0);
+    defer stored_state.deinit();
+    // Resolved well past `issued_at_unix_ms + lifetime_seconds * 1000`.
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "expired-ticket", .now_ms = 3_600_001 };
+    try server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+
+    try driveServerSelection(&server, .{
+        .psk = .{ .items = &.{.{ .identity = "expired-ticket", .binder_psk = &psk }} },
+    });
+
+    try std.testing.expectEqual(@as(usize, 1), resolver_state.calls);
+    try std.testing.expect(!server.core.psk_authenticated);
+    // Falls back to the ordinary full-certificate flight rather than
+    // failing the connection outright.
+    try std.testing.expectEqual(.running, server.core.handshake_lifecycle);
+    try std.testing.expect(server.credentialFailure() == null);
+}
+
+test "an ALPN mismatch falls back to a full handshake instead of rejecting the connection (#369)" {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
+    defer server.deinit();
+
+    const psk = [_]u8{0x88} ** tls_backend.hash_len;
+    var common: session.ResumableSessionCommon = .{};
+    try common.init(std.testing.allocator, session.Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = &psk,
+        // The ticket was issued for a connection negotiated as "h3"; the
+        // resuming ClientHello below only offers/negotiates "h2".
+        .application_protocol = "h3",
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer(tls_backend.testdata.certificate_der),
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 3600,
+    });
+    var stored_state: session.ServerRecoverableState = .{};
+    stored_state.init(&common, 0);
+    defer stored_state.deinit();
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "alpn-ticket" };
+    try server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+
+    try driveServerSelection(&server, .{
+        .alpn_protocols = &.{"h2"},
+        .psk = .{ .items = &.{.{ .identity = "alpn-ticket", .binder_psk = &psk }} },
+    });
+
+    try std.testing.expectEqual(@as(usize, 1), resolver_state.calls);
+    try std.testing.expect(!server.core.psk_authenticated);
+    try std.testing.expectEqual(.running, server.core.handshake_lifecycle);
+    try std.testing.expect(server.credentialFailure() == null);
+}
+
+test "a cipher-suite mismatch falls back to a full handshake instead of rejecting the connection (#369)" {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
+    defer server.deinit();
+
+    // The wire binder key (what the resuming ClientHello actually offers)
+    // stays at `hash_len` (sha256, since `buildClientHello` always derives
+    // binders with sha256) — it is never reached for this scenario, since
+    // the cipher-suite mismatch is caught before binder verification.
+    const psk = [_]u8{0x99} ** tls_backend.hash_len;
+    // The stored ticket's own PSK must match its declared cipher suite's
+    // hash length (sha384 => 48 bytes) for `common.init` to accept it.
+    const ticket_psk = [_]u8{0x99} ** 48;
+    var common: session.ResumableSessionCommon = .{};
+    try common.init(std.testing.allocator, session.Limits.default, .{
+        // The ticket was bound to AES-256-GCM; `buildClientHello` only ever
+        // offers (and this server only ever negotiates) AES-128-GCM, so the
+        // resuming connection's negotiated cipher suite can never match.
+        .cipher_suite = .tls_aes_256_gcm_sha384,
+        .resumption_psk = &ticket_psk,
+        .application_protocol = "h2",
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer(tls_backend.testdata.certificate_der),
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 3600,
+    });
+    var stored_state: session.ServerRecoverableState = .{};
+    stored_state.init(&common, 0);
+    defer stored_state.deinit();
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "cipher-ticket" };
+    try server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+
+    try driveServerSelection(&server, .{
+        .psk = .{ .items = &.{.{ .identity = "cipher-ticket", .binder_psk = &psk }} },
+    });
+
+    try std.testing.expectEqual(@as(usize, 1), resolver_state.calls);
+    try std.testing.expect(!server.core.psk_authenticated);
+    try std.testing.expectEqual(.running, server.core.handshake_lifecycle);
     try std.testing.expect(server.credentialFailure() == null);
 }
 


### PR DESCRIPTION
## Summary

Slice 1 of #369 (326-J), the resumption/0-RTT interop + restart + soak
validation epic. #369 is XL — external OpenSSL/QUIC-peer interop, restart/
rotation soak runs, and CI wiring — too large for one PR, so it's being
split into slices the way #367/#368 were.

This slice adds in-repo, deterministic Zig test coverage for what's
testable in-process against the resumption/0-RTT/anti-replay code already
landed by #365–#368:

- **Ticket expiry**: an end-to-end (real ClientHello/PSK-offer) test that an
  expired ticket falls back to a full handshake, not just the pre-existing
  pure-logic boundary tests.
- **Key rotation**: `ReloadableKeyRing`/`Protector` tests for both the
  grace-window shape (old key decrypt-only, still resolves) and the full-
  removal shape (old key gone, resolves as `unknown_key`, no crash).
- **Process restart / lost cache (in-process model only)**: two independent
  `Runtime` instances (stateless and stateful) modeling lost ephemeral
  state with no shared key or cache — the closest existing test only used a
  resolver hardcoded to miss. This proves the resolve-side fail-closed
  behavior in isolation; it is not the full operational restart assurance
  #369 owns (see deferred items below).
- **ALPN / cipher-suite mismatch**: end-to-end fallback-to-full-handshake
  tests alongside the pre-existing SNI-mismatch and cert-change tests, so
  every `session.ResumeMismatch` variant now has integration coverage.

Anti-replay rejection, 0-RTT-reject-falls-back-to-1-RTT, and no-double-
execution-on-425-retry were already extensively covered by #367/#368's own
suites (25+ tests across `early_data_replay.zig`, `tls13_backend_tests.zig`,
`gateway_proxy_runtime.zig`, `gateway_handlers.zig`, `edge_gateway.zig`), so
no new tests were added there — duplicating them would be noise, not signal.
That existing coverage is unit/integration-level, not the process-level
cross-layer assurance #369 owns (see deferred items below).

`docs/RESUMPTION_TEST_PLAN.md` records what this slice covers and what's
explicitly deferred to later slices:
- External OpenSSL/QUIC-peer interop.
- The operational restart/rotation matrix (actual restart/composition
  re-init, generation-overlap reloads, lifecycle boundaries, failed-reload
  retention, concurrent/cross-worker cases).
- The process-level 0-RTT/replay/425 matrix (real gateway/native path,
  duplicate-0RTT-rejected-while-1RTT-continues, capacity/quarantine
  rejecting only early data, a real 425 retry through an upstream
  execution counter) — including validating the anti-replay store's actual
  documented scope: all workers/transports in one process share one
  authoritative store, while separate processes are independent, so the
  guarantee is process-local, not cluster-wide. A real distributed backend
  (Redis/etcd/similar) was explicitly scoped out of #368's contract and is
  not required to close #369 either.
- Soak runs and CI wiring.
- A QUIC-transport-specific variant of the 0-RTT-fallback matrix.

## Test plan

- [x] `zig build test` — 2678/2679 passing (1 skipped: the known UDP smoke
      test that fails under socket-blocking sandboxes)
- [x] All new tests fail without the fix under test / pass with it (verified
      incrementally while writing each one — see the cipher-suite-mismatch
      test's PSK-length fixup in this branch's history)

Refs #369
