### PR TITLE
tls: add process-level 0-RTT replay and 425 assurance (#369 Slice 2)

### DIFF
--- a/docs/RESUMPTION_TEST_PLAN.md
+++ b/docs/RESUMPTION_TEST_PLAN.md
@@ -48,6 +48,94 @@ real OpenSSL/QUIC peer, no CI/soak changes.
   cross-layer, process-level version of this assurance to #369, which those
   predecessor suites do not exercise — see the deferred matrix below.
 
+## Slice 2 (this PR): process-level 0-RTT replay / anti-replay / 425 assurance
+
+Moves assurance one layer outward from Slice 1: exercises the real
+production TLS/replay-store/HTTP-early-data/gateway-retry code composed
+together, rather than each layer's own unit tests in isolation. Two new
+test areas, both reusing existing production code and harness patterns
+rather than scripted stand-ins:
+
+- **`src/tls/tls13_backend_tests.zig`** (real `DirectHarness`
+  ClientHello/PSK-offer/binder handshakes, a real
+  `tls_core.early_data_replay.LocalStore`/`GateAdapter`, and an atomic
+  "application executed" counter driven strictly by the real
+  `earlyDataAccepted()` outcome — not a re-derivation of the TLS decision
+  itself):
+  - `rt0.accept.first_use` — accepted 0-RTT records the replay claim,
+    executes the application exactly once, and a diagnostic-formatting
+    check confirms the raw ticket identity never appears in what a log
+    line would show (the candidate type has no PSK field at all, so that
+    leak is impossible by construction, not merely untested).
+  - `rt0.reject.duplicate` — an exact-duplicate claim on a second,
+    independent connection never executes the application; the resumed
+    connection remains usable and a later, distinct 1-RTT request executes
+    normally (total: one execution for the accept, one more for the
+    intentionally distinct later request).
+  - `rt0.reject.capacity` — a store configured with one live slot rejects a
+    second, otherwise-valid claim with the typed capacity outcome, no
+    application side effect, occupancy stays bounded, and a later request
+    on the same connection still succeeds.
+  - `rt0.reject.startup_quarantine` — a fresh store (modeling lost replay
+    history after a restart) rejects early execution during quarantine
+    without any application side effect, and the connection remains usable
+    for an ordinary request; the exact quarantine boundary is exercised
+    against #368's existing (exclusive-end) semantics
+    (`now < quarantine_end` rejects, `now == quarantine_end` is ordinary
+    eligibility) with a deterministic injected clock, not a sleep.
+  - `rt0.reject.cross_worker_duplicate` — two independent per-connection
+    `DirectHarness` instances ("worker A"/"worker B") share one real
+    `LocalStore`; worker A's accepted claim executes once, and worker B's
+    replay of the same identity is rejected and never executes. See the
+    "true OS-thread/worker-routing seam" note below.
+- **`src/process_early_data_integration_tests.zig`** (new file, wired into
+  `zig build test` via `edge_gateway.zig`'s existing `test { _ = @import(...) }`
+  aggregator pattern):
+  - `rt0.retry.425_exactly_once` — drives the real
+    `gateway_proxy_runtime.runBufferedProxyAttempts` retry/425 state
+    machine and the real production TCP HTTP client
+    (`executeBufferedDataPlaneProxyRequest`) against an actual loopback
+    upstream test server with an atomic execution counter that itself
+    returns a real `425 Too Early` whenever it sees a real `Early-Data: 1`
+    header. Proves: the retried request no longer carries the header, the
+    upstream executes exactly once total, the response returned to the
+    caller is the successful retry, and real
+    `http.metrics.Metrics.recordHttpEarlyDataUpstream425`/
+    `recordHttpEarlyDataRetry` deltas distinguish the initial 425 from the
+    successful retry — no parallel test-only metrics model.
+  - `rt0.reject.unsafe_request` — an unsafe method (POST) with current-hop
+    early data is rejected by the real, `pub`
+    `gateway_handlers.earlyDataDecisionForRequest` (the same function
+    `edge_gateway.zig`'s H1 dispatch calls) before any upstream dispatch is
+    attempted at all — the configured `proxy_pass` target is deliberately
+    nothing that listens, so the only way the test can pass is by the real
+    gateway decision short-circuiting before any network I/O, not by
+    racing a responder thread.
+  - `rt0.reject.store_unavailable` — ties two independently-proven facts
+    together: `edge_config.loadFromEnv`'s default configuration leaves
+    native 0-RTT replay mode `disabled` and defines no location routes at
+    all, and `tls13_backend.EarlyDataReplayGate`'s default (no gate
+    configured) fails closed to `.unavailable` for 0-RTT while leaving
+    ordinary 1-RTT resumption untouched (both already proven individually
+    by `edge_config.zig`'s and `tls13_backend_tests.zig`'s own suites) — so
+    a freshly started process with no operator configuration cannot accept
+    0-RTT anywhere, without needing any replay backend present.
+
+### Known gap: no deterministic worker-thread-routing test seam
+
+The cross-worker test above proves the process-shared-store guarantee
+using two independent per-connection state instances (the same object
+`edge_gateway.zig`'s real composition actually shares by reference across
+every native TCP worker and QUIC/H3 — see `initNativeEarlyDataReplayStore`/
+`GateAdapter.init` there), not two real OS worker threads. There is
+currently no API to pin a connection to a specific worker thread
+deterministically for testing, so a stronger proof (issue the accepted
+claim through worker thread A, replay it through worker thread B) is not
+available today. A future slice could add a small, explicit worker-id test
+seam to `WorkerContext` to close this gap; until then this is a
+documented, intentional limitation of this slice's assurance, not a
+weakening of the "workers share one store" guarantee itself.
+
 ## Explicitly deferred to a later slice
 
 - **External interop** with OpenSSL (`s_client`/`s_server` ticket
@@ -70,29 +158,11 @@ real OpenSSL/QUIC peer, no CI/soak changes.
   - A failed reload retains the prior snapshot rather than leaving the
     runtime with no usable key.
   - Concurrent / cross-worker restart and rotation cases.
-- **Process-level 0-RTT/replay/425 matrix** (the cross-layer assurance #326
-  assigns to #369, distinct from the unit/integration tests #367/#368
-  already carry):
-  - Drive the real gateway/native TLS or H3 path end to end with a
-    `process_local` (in-process, not distributed) anti-replay store; prove
-    a duplicate 0-RTT claim is rejected while the underlying PSK connection
-    still completes as ordinary 1-RTT.
-  - Prove anti-replay capacity exhaustion and startup-quarantine both
-    reject only the early-data attempt, never the resumed/full-handshake
-    connection.
-  - Drive a real 425 early-retry through an upstream request-execution
-    counter and prove it lands at exactly one execution, through the actual
-    proxy path rather than a scripted attempt executor.
-  - Validate the store's documented scope directly: all workers/transports
-    inside one process share one authoritative replay store (a replay
-    accepted by worker A is rejected by worker B in the same process);
-    separate Tardigrade processes are independent, so the guarantee is
-    process-local, not cluster-wide — #368 explicitly scoped out a real
-    distributed backend (Redis/etcd/similar) as out of contract for this
-    epic, so that remains this repo's committed behavior, not a gap to
-    close. This slice should validate the process-shared/multi-worker
-    guarantee and the documented non-cluster-wide limitation, not require
-    implementing a distributed backend.
+- **Deterministic worker-thread-pinning test seam** — see "Known gap"
+  above. #369 Slice 2 proves process-shared-store sharing across
+  independent per-connection state; it does not drive that proof through
+  real OS worker threads, because no seam exists yet to pin a connection to
+  one deterministically.
 - **Soak scenarios**: repeated reconnect/rotation loops with memory/metrics
   checks over long runs.
 - **CI wiring**: a smoke subset plus an optional nightly/soak job.
@@ -104,4 +174,5 @@ real OpenSSL/QUIC peer, no CI/soak changes.
 Acceptance criteria for #369 as a whole (interop reliability, safe
 fallback/rejection under mismatch, no double execution, bounded soak
 memory/cache growth, reproducible artifacts without leaking ticket keys)
-remain open until the deferred items above land in follow-up slices.
+remain open until the deferred items above land in follow-up slices. #369
+is not complete after this slice.

--- a/docs/RESUMPTION_TEST_PLAN.md
+++ b/docs/RESUMPTION_TEST_PLAN.md
@@ -52,45 +52,81 @@ real OpenSSL/QUIC peer, no CI/soak changes.
 
 Moves assurance one layer outward from Slice 1: exercises the real
 production TLS/replay-store/HTTP-early-data/gateway-retry code composed
-together, rather than each layer's own unit tests in isolation. Two new
-test areas, both reusing existing production code and harness patterns
-rather than scripted stand-ins:
+together, rather than each layer's own unit tests in isolation, and rather
+than scripted stand-ins where production code was reachable.
 
-- **`src/tls/tls13_backend_tests.zig`** (real `DirectHarness`
-  ClientHello/PSK-offer/binder handshakes, a real
-  `tls_core.early_data_replay.LocalStore`/`GateAdapter`, and an atomic
-  "application executed" counter driven strictly by the real
-  `earlyDataAccepted()` outcome — not a re-derivation of the TLS decision
-  itself):
-  - `rt0.accept.first_use` — accepted 0-RTT records the replay claim,
-    executes the application exactly once, and a diagnostic-formatting
-    check confirms the raw ticket identity never appears in what a log
-    line would show (the candidate type has no PSK field at all, so that
-    leak is impossible by construction, not merely untested).
+A review pass on the first draft of this slice found that its TLS-layer
+tests paired each real TLS/replay decision with a same-process "application
+executed" counter incremented directly from that same decision
+(`server_backend.earlyDataAccepted()`) — tautological, since it could never
+catch the actual cross-layer bug #369 cares about (HTTP/gateway dispatch
+ignoring a correct TLS decision), and, worse, unfalsifiable for the native
+TCP/H1 transport today: see "Confirmed production gap" below. The review
+also found a real test-only deadlock risk (an unbounded `accept()` a
+regression could block on forever, joined in the wrong order relative to
+socket teardown) and a test that special-cased itself around a decision
+function without actually invoking any dispatch path. All of these are
+fixed in the current state of this slice, described below.
+
+- **`src/tls/tls13_backend_tests.zig`** — TLS / replay-store layer only
+  (real `DirectHarness` ClientHello/PSK-offer/binder handshakes and a real
+  `tls_core.early_data_replay.LocalStore`/`GateAdapter`, each scenario
+  additionally asserting a real `Observer`/`Event` delta — the same
+  observer seam production composition installs
+  (`nativeEarlyDataReplayMetricsObserver`), asserted directly on the closed
+  `Event` vocabulary since this module has no dependency on `http.metrics`):
+  - `rt0.accept.first_use` — accepted 0-RTT records the replay claim, emits
+    exactly one real `.accepted` event, and a diagnostic-formatting check
+    confirms the raw ticket identity never appears in what a log line
+    would show (the candidate type has no PSK field at all, so that leak
+    is impossible by construction, not merely untested).
   - `rt0.reject.duplicate` — an exact-duplicate claim on a second,
-    independent connection never executes the application; the resumed
-    connection remains usable and a later, distinct 1-RTT request executes
-    normally (total: one execution for the accept, one more for the
-    intentionally distinct later request).
-  - `rt0.reject.capacity` — a store configured with one live slot rejects a
-    second, otherwise-valid claim with the typed capacity outcome, no
-    application side effect, occupancy stays bounded, and a later request
-    on the same connection still succeeds.
+    independent connection emits a real `.duplicate` event (not a second
+    `.accepted`); the resumed connection remains usable and a later,
+    distinct 1-RTT request round-trips real application data.
+  - `rt0.reject.capacity` — a store configured with one live slot emits a
+    real `.capacity_rejected` event for a second, otherwise-valid claim,
+    occupancy stays bounded, and a later request on the same connection
+    still succeeds.
   - `rt0.reject.startup_quarantine` — a fresh store (modeling lost replay
-    history after a restart) rejects early execution during quarantine
-    without any application side effect, and the connection remains usable
-    for an ordinary request; the exact quarantine boundary is exercised
-    against #368's existing (exclusive-end) semantics
-    (`now < quarantine_end` rejects, `now == quarantine_end` is ordinary
-    eligibility) with a deterministic injected clock, not a sleep.
+    history after a restart) emits a real `.startup_quarantine` event
+    (distinguishable from `.duplicate`) during quarantine, and the
+    connection remains usable for an ordinary request; the exact
+    quarantine boundary is exercised against #368's existing
+    (exclusive-end) semantics (`now < quarantine_end` rejects,
+    `now == quarantine_end` is ordinary eligibility, and does emit a real
+    `.accepted` event) with a deterministic injected clock, not a sleep.
   - `rt0.reject.cross_worker_duplicate` — two independent per-connection
     `DirectHarness` instances ("worker A"/"worker B") share one real
-    `LocalStore`; worker A's accepted claim executes once, and worker B's
-    replay of the same identity is rejected and never executes. See the
-    "true OS-thread/worker-routing seam" note below.
+    `LocalStore`; worker A's claim emits `.accepted`, and worker B's replay
+    of the same identity emits `.duplicate`. See the "true OS-thread/
+    worker-routing seam" note below.
+- **`src/edge_gateway.zig`** (two new tests alongside its existing H1
+  dispatch tests, reusing the same `executeH1PostPreflightOrchestration` +
+  probe-hooks and composition-decision seams those tests already use —
+  reachable only from this file, since both are private to it):
+  - `rt0.reject.unsafe_request` — an unsafe method (POST) with current-hop
+    early data is driven through the real, private
+    `executeH1PostPreflightOrchestration` orchestration (the same function
+    production H1 dispatch calls) with the existing
+    `H1CountingPostPreflightHooks` probe; asserts the probe's route hook —
+    where any upstream dispatch would originate — never runs. Isolates the
+    method-safety gate specifically, distinct from the file's pre-existing
+    mirror-rule and origin-capability-off tests.
+  - `rt0.reject.store_unavailable` — forces `tls_native_early_data_replay_mode
+    = .disabled` on an explicit, deterministic config (not ambient
+    `TARDIGRADE_*` env vars), confirms the real
+    `nativeEarlyDataReplayStoreEnabled` composition-decision function
+    withholds the store even though a native path otherwise exists, then
+    builds a real `NativeTlsConnection` exactly as `run()` would in this
+    configuration (no `.early_data_replay_gate` option) and asserts its
+    real `Tls13Backend.early_data_replay_gate.decideFn == null` — tying the
+    config decision to the real composition-built object, not just to two
+    independently-true facts asserted side by side.
 - **`src/process_early_data_integration_tests.zig`** (new file, wired into
   `zig build test` via `edge_gateway.zig`'s existing `test { _ = @import(...) }`
-  aggregator pattern):
+  aggregator pattern) — the one scenario that needs neither module's
+  private internals:
   - `rt0.retry.425_exactly_once` — drives the real
     `gateway_proxy_runtime.runBufferedProxyAttempts` retry/425 state
     machine and the real production TCP HTTP client
@@ -102,24 +138,43 @@ rather than scripted stand-ins:
     caller is the successful retry, and real
     `http.metrics.Metrics.recordHttpEarlyDataUpstream425`/
     `recordHttpEarlyDataRetry` deltas distinguish the initial 425 from the
-    successful retry — no parallel test-only metrics model.
-  - `rt0.reject.unsafe_request` — an unsafe method (POST) with current-hop
-    early data is rejected by the real, `pub`
-    `gateway_handlers.earlyDataDecisionForRequest` (the same function
-    `edge_gateway.zig`'s H1 dispatch calls) before any upstream dispatch is
-    attempted at all — the configured `proxy_pass` target is deliberately
-    nothing that listens, so the only way the test can pass is by the real
-    gateway decision short-circuiting before any network I/O, not by
-    racing a responder thread.
-  - `rt0.reject.store_unavailable` — ties two independently-proven facts
-    together: `edge_config.loadFromEnv`'s default configuration leaves
-    native 0-RTT replay mode `disabled` and defines no location routes at
-    all, and `tls13_backend.EarlyDataReplayGate`'s default (no gate
-    configured) fails closed to `.unavailable` for 0-RTT while leaving
-    ordinary 1-RTT resumption untouched (both already proven individually
-    by `edge_config.zig`'s and `tls13_backend_tests.zig`'s own suites) — so
-    a freshly started process with no operator configuration cannot accept
-    0-RTT anywhere, without needing any replay backend present.
+    successful retry — no parallel test-only metrics model. Every wait in
+    the loopback origin (`acceptBounded`/`readRequestHeadBounded`) is
+    poll-bounded rather than a raw blocking `accept()`/`read()`, and the
+    responder thread is joined (establishing a real happens-before
+    relationship) before any of its observations are read, so a regression
+    in the retry logic fails the test with a useful assertion instead of
+    hanging the test binary.
+
+### Confirmed production gap: native TCP/H1 does not yet wire `Tls13Backend.earlyDataAccepted()` into HTTP dispatch
+
+While addressing review feedback, inspection of `edge_gateway.zig`'s
+request-context setup found this existing comment and hardcoded value:
+
+```zig
+// #367 slice 2 keeps this as request-scoped handoff state. The production
+// #366 H1 record provenance carrier is not present on this branch yet, so
+// H1 transport provenance stays false rather than using connection state.
+ctx.early_data.transport_early = false;
+```
+
+That is: for the native record/TCP transport, **no production code path
+today reads the real TLS backend's `earlyDataAccepted()`/`earlyDataDecision()`
+and forwards it into `ctx.early_data.transport_early`** for the H1 request
+that follows. `transport_early` only ever becomes `true` for H1 in
+production via this hardcoded-`false` assignment (i.e. never); the only
+other `.transport_early = true` assignments in `edge_gateway.zig` are
+either H2 frame-provenance propagation (already set from elsewhere, not
+derived from the TLS backend) or test-only fixtures. Wiring this is a
+`#366`/`#367` follow-up, not this slice's scope — but it means no test,
+here or otherwise, can currently prove "an accepted real 0-RTT record over
+TCP results in a real early HTTP dispatch," because that composition does
+not exist in production yet to prove. This slice's tests are scoped
+accordingly: the TLS/replay-store decision is proven with real production
+code, and the *given an early context, does dispatch correctly gate on
+it* question is proven with a directly-constructed `EarlyDataContext` (the
+shape the real wiring would eventually produce), not by claiming to
+exercise the (currently nonexistent) wiring itself.
 
 ### Known gap: no deterministic worker-thread-routing test seam
 

--- a/docs/RESUMPTION_TEST_PLAN.md
+++ b/docs/RESUMPTION_TEST_PLAN.md
@@ -113,16 +113,17 @@ fixed in the current state of this slice, described below.
     where any upstream dispatch would originate — never runs. Isolates the
     method-safety gate specifically, distinct from the file's pre-existing
     mirror-rule and origin-capability-off tests.
-  - `rt0.reject.store_unavailable` — forces `tls_native_early_data_replay_mode
-    = .disabled` on an explicit, deterministic config (not ambient
-    `TARDIGRADE_*` env vars), confirms the real
-    `nativeEarlyDataReplayStoreEnabled` composition-decision function
-    withholds the store even though a native path otherwise exists, then
-    builds a real `NativeTlsConnection` exactly as `run()` would in this
-    configuration (no `.early_data_replay_gate` option) and asserts its
-    real `Tls13Backend.early_data_replay_gate.decideFn == null` — tying the
-    config decision to the real composition-built object, not just to two
-    independently-true facts asserted side by side.
+  - `rt0.reject.store_unavailable` — drives the same
+    `nativeEarlyDataReplayComposition` helper used by `run()` with explicit,
+    deterministic inputs: replay mode disabled, native resumption present,
+    and a native TCP provider present. The helper withholds both store and
+    gate options even though a native path otherwise exists, and a real
+    `NativeTlsConnection` built with that returned option retains
+    `Tls13Backend`'s fail-closed default
+    (`early_data_replay_gate.decideFn == null`). This proves the disabled
+    helper/default-backend boundary without depending on ambient
+    `TARDIGRADE_*` env vars; true record-TLS → H1 provenance → safety-gate
+    process coverage remains deferred below and is tracked by #510.
 - **`src/process_early_data_integration_tests.zig`** (new file, wired into
   `zig build test` via `edge_gateway.zig`'s existing `test { _ = @import(...) }`
   aggregator pattern) — the one scenario that needs neither module's
@@ -165,8 +166,8 @@ that follows. `transport_early` only ever becomes `true` for H1 in
 production via this hardcoded-`false` assignment (i.e. never); the only
 other `.transport_early = true` assignments in `edge_gateway.zig` are
 either H2 frame-provenance propagation (already set from elsewhere, not
-derived from the TLS backend) or test-only fixtures. Wiring this is a
-`#366`/`#367` follow-up, not this slice's scope — but it means no test,
+derived from the TLS backend) or test-only fixtures. Wiring this is tracked
+by #510 as a `#366`/`#367` follow-up, not this slice's scope — but it means no test,
 here or otherwise, can currently prove "an accepted real 0-RTT record over
 TCP results in a real early HTTP dispatch," because that composition does
 not exist in production yet to prove. This slice's tests are scoped
@@ -225,6 +226,13 @@ weakening of the "workers share one store" guarantee itself.
   The record-transport matrix is thoroughly covered
   (`src/tls/tls13_backend_tests.zig`); an equivalent pass explicitly over
   `Transport.quic` has not been added yet.
+- **True end-to-end native TCP/H1 record-provenance dispatch coverage**
+  (#510): a real accepted/rejected TLS 0-RTT record must flow through
+  native TCP/H1 request parsing into `RequestContext.early_data` and the
+  production H1 safety gate before #369's process-level H1 path is complete.
+  The current slice proves the TLS/replay-store decision and the constructed
+  H1 dispatch context on either side of that gap; it does not close the
+  missing production handoff itself.
 
 Acceptance criteria for #369 as a whole (interop reliability, safe
 fallback/rejection under mismatch, no double execution, bounded soak

--- a/docs/RESUMPTION_TEST_PLAN.md
+++ b/docs/RESUMPTION_TEST_PLAN.md
@@ -147,10 +147,11 @@ fixed in the current state of this slice, described below.
     in the retry logic fails the test with a useful assertion instead of
     hanging the test binary.
 
-### Confirmed production gap: native TCP/H1 does not yet wire `Tls13Backend.earlyDataAccepted()` into HTTP dispatch
+### Confirmed production gap: native TCP/H1 is not yet production-enabled end to end for real 0-RTT dispatch
 
 While addressing review feedback, inspection of `edge_gateway.zig`'s
-request-context setup found this existing comment and hardcoded value:
+request-context setup found one visible gap in this existing comment and
+hardcoded value:
 
 ```zig
 // #367 slice 2 keeps this as request-scoped handoff state. The production
@@ -159,23 +160,29 @@ request-context setup found this existing comment and hardcoded value:
 ctx.early_data.transport_early = false;
 ```
 
-That is: for the native record/TCP transport, **no production code path
-today reads the real TLS backend's `earlyDataAccepted()`/`earlyDataDecision()`
-and forwards it into `ctx.early_data.transport_early`** for the H1 request
-that follows. `transport_early` only ever becomes `true` for H1 in
-production via this hardcoded-`false` assignment (i.e. never); the only
-other `.transport_early = true` assignments in `edge_gateway.zig` are
-either H2 frame-provenance propagation (already set from elsewhere, not
-derived from the TLS backend) or test-only fixtures. Wiring this is tracked
-by #510 as a `#366`/`#367` follow-up, not this slice's scope — but it means no test,
-here or otherwise, can currently prove "an accepted real 0-RTT record over
-TCP results in a real early HTTP dispatch," because that composition does
-not exist in production yet to prove. This slice's tests are scoped
-accordingly: the TLS/replay-store decision is proven with real production
-code, and the *given an early context, does dispatch correctly gate on
-it* question is proven with a directly-constructed `EarlyDataContext` (the
-shape the real wiring would eventually produce), not by claiming to
-exercise the (currently nonexistent) wiring itself.
+That final H1 handoff is not the only missing production wiring. Native TCP
+also does not yet advertise early-capable tickets from production
+`NativeTlsConnection.issueSessionTicket()` because its
+`prepareNewSessionTicket(...)` call does not pass `max_early_data_size`, and
+`NativeTlsConnection.createWithOptions()` does not install an enabled
+`Tls13Backend.ServerEarlyDataPolicy` (whose default is disabled). Together,
+those gaps mean a production native TCP client cannot currently receive a
+server-issued early-capable ticket, have the server accept a real
+`early_data` attempt, and then carry that record-read provenance into H1
+dispatch.
+
+Wiring those prerequisites and the final `ctx.early_data.transport_early`
+handoff is tracked by #510 as a `#366`/`#367` follow-up, not this slice's
+scope. This means no test here or otherwise can currently prove "a
+production-issued native TCP ticket leads to accepted real 0-RTT records
+whose provenance gates H1 dispatch," because that composition does not
+exist in production yet to prove. This slice's tests are scoped accordingly:
+the TLS/replay-store decision is proven with real production code, and the
+*given an early context, does dispatch correctly gate on it* question is
+proven with a directly-constructed `EarlyDataContext` (the shape the real
+wiring would eventually produce), not by claiming to exercise the
+currently nonexistent production-issued-ticket → server-policy →
+record-provenance → H1-safety-gate chain.
 
 ### Known gap: no deterministic worker-thread-routing test seam
 
@@ -226,13 +233,17 @@ weakening of the "workers share one store" guarantee itself.
   The record-transport matrix is thoroughly covered
   (`src/tls/tls13_backend_tests.zig`); an equivalent pass explicitly over
   `Transport.quic` has not been added yet.
-- **True end-to-end native TCP/H1 record-provenance dispatch coverage**
-  (#510): a real accepted/rejected TLS 0-RTT record must flow through
-  native TCP/H1 request parsing into `RequestContext.early_data` and the
-  production H1 safety gate before #369's process-level H1 path is complete.
-  The current slice proves the TLS/replay-store decision and the constructed
-  H1 dispatch context on either side of that gap; it does not close the
-  missing production handoff itself.
+- **True end-to-end native TCP/H1 production 0-RTT dispatch coverage**
+  (#510): the E2E must start from a production-issued early-capable native
+  TCP ticket (`max_early_data_size` advertised by the production ticket
+  path), use production server composition to enable
+  `Tls13Backend.ServerEarlyDataPolicy` only when replay protection
+  prerequisites are satisfied, then carry accepted/rejected TLS 0-RTT
+  record provenance through native TCP/H1 request parsing into
+  `RequestContext.early_data` and the production H1 safety gate. The
+  current slice proves the TLS/replay-store decision and the constructed H1
+  dispatch context on either side of that wider gap; it does not close the
+  missing production enablement or provenance handoff itself.
 
 Acceptance criteria for #369 as a whole (interop reliability, safe
 fallback/rejection under mismatch, no double execution, bounded soak

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -4693,4 +4693,5 @@ test "#368 Slice 2: one process-scoped early-data replay store is shared by nati
 test {
     _ = @import("gateway_handlers.zig");
     _ = @import("gateway_shutdown.zig");
+    _ = @import("process_early_data_integration_tests.zig");
 }

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -389,13 +389,15 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
     }
     defer if (native_credentials) |*store| store.deinit();
     defer if (tls_terminator) |*tls| tls.deinit();
-    if (nativeEarlyDataReplayStoreEnabled(
+    const native_early_data_replay_composition = nativeEarlyDataReplayComposition(
         cfg.tls_native_early_data_replay_mode,
         native_resumption_runtime != null,
         native_tls_provider != null,
         cfg.http3_enabled,
         h3_credential_provider != null,
-    )) {
+        null,
+    );
+    if (native_early_data_replay_composition.store_enabled) {
         // A configured `process_local` mode must never silently fall back to
         // an unprotected/disabled implementation if store initialization
         // fails — refusing to start (like `native_resumption_runtime` above)
@@ -412,7 +414,14 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
     }
     if (native_early_data_replay_store) |*store| {
         native_early_data_replay_gate_adapter = tls_core.early_data_replay.GateAdapter.init(store.store());
-        native_early_data_replay_gate = native_early_data_replay_gate_adapter.gate();
+        native_early_data_replay_gate = nativeEarlyDataReplayComposition(
+            cfg.tls_native_early_data_replay_mode,
+            native_resumption_runtime != null,
+            native_tls_provider != null,
+            cfg.http3_enabled,
+            h3_credential_provider != null,
+            native_early_data_replay_gate_adapter.gate(),
+        ).early_data_replay_gate;
     }
     if (cfg.http3_enabled) {
         if (!edge_config.hasTlsFiles(cfg)) {
@@ -1533,6 +1542,37 @@ fn nativeEarlyDataReplayStoreEnabled(
         http3_enabled,
         h3_credential_provider_present,
     );
+}
+
+const NativeEarlyDataReplayComposition = struct {
+    store_enabled: bool,
+    early_data_replay_gate: ?tls_core.tls13_backend.EarlyDataReplayGate,
+};
+
+/// Selects the replay-store/gate options shared by `run()`'s native TCP and
+/// H3 composition. The optional gate is installed only when the same decision
+/// says the process-scoped store is enabled; disabled mode therefore flows
+/// into `NativeTlsConnection.createWithOptions` as a null gate rather than an
+/// independently reconstructed test expectation.
+fn nativeEarlyDataReplayComposition(
+    replay_mode: edge_config.EarlyDataReplayMode,
+    native_resumption_runtime_enabled: bool,
+    native_tls_provider_present: bool,
+    http3_enabled: bool,
+    h3_credential_provider_present: bool,
+    gate: ?tls_core.tls13_backend.EarlyDataReplayGate,
+) NativeEarlyDataReplayComposition {
+    const store_enabled = nativeEarlyDataReplayStoreEnabled(
+        replay_mode,
+        native_resumption_runtime_enabled,
+        native_tls_provider_present,
+        http3_enabled,
+        h3_credential_provider_present,
+    );
+    return .{
+        .store_enabled = store_enabled,
+        .early_data_replay_gate = if (store_enabled) gate else null,
+    };
 }
 
 fn reapActiveConnections(
@@ -3567,34 +3607,29 @@ test "#369 Slice 2 rt0.reject.unsafe_request: an unsafe method carrying current-
     try std.testing.expectEqual(@as(usize, 0), effects.handler_calls);
 }
 
-test "#369 Slice 2 rt0.reject.store_unavailable: the disabled-mode composition decision installs no replay gate on the real native TLS connection, matching Tls13Backend's fail-closed default" {
-    // Deterministic, explicit config rather than depending on ambient
-    // TARDIGRADE_* env vars — forces the exact decision `run()` makes.
-    var cfg = try edge_config.loadFromEnv(std.testing.allocator);
-    defer cfg.deinit(std.testing.allocator);
-    cfg.tls_native_early_data_replay_mode = .disabled;
-
-    // Native resumption and a native TCP provider both "exist" here (so a
-    // native PSK/early-data path genuinely could exist), isolating that
-    // `.disabled` replay mode alone — not merely "no eligible path" — is
-    // what withholds the store/gate. This is the exact decision `run()`
-    // makes via `nativeEarlyDataReplayStoreEnabled` before ever deciding
-    // whether to call `initNativeEarlyDataReplayStore`.
-    try std.testing.expect(!nativeEarlyDataReplayStoreEnabled(
-        cfg.tls_native_early_data_replay_mode,
+test "#369 Slice 2 rt0.reject.store_unavailable: disabled-mode composition passes no replay gate to the real native TLS connection" {
+    // Deterministic, explicit inputs: native resumption and a native TCP
+    // provider both "exist" here, isolating `.disabled` replay mode alone
+    // as the reason `run()` withholds the process-scoped store/gate.
+    const disabled_composition = nativeEarlyDataReplayComposition(
+        .disabled,
         true, // native_resumption_runtime_enabled
         true, // native_tls_provider_present
         false,
         false,
-    ));
+        .{ .ctx = undefined, .decideFn = struct {
+            fn decide(_: *anyopaque, _: tls_core.tls13_backend.EarlyDataReplayCandidate) tls_core.tls13_backend.EarlyDataReplayDecision {
+                return .allow;
+            }
+        }.decide },
+    );
+    try std.testing.expect(!disabled_composition.store_enabled);
+    try std.testing.expect(disabled_composition.early_data_replay_gate == null);
 
-    // Exactly the production composition pattern from "#368 Slice 2: one
-    // process-scoped early-data replay store is shared by native TCP and
-    // QUIC/H3" above: `run()` only calls `initNativeEarlyDataReplayStore`/
-    // installs a gate when `nativeEarlyDataReplayStoreEnabled` is true.
-    // Since it is not here, `run()` builds `NativeTlsConnection` exactly as
-    // it would in this configuration: with no `.early_data_replay_gate`
-    // option at all.
+    // This is the production option-selection helper `run()` uses before
+    // constructing native TCP/H3 runtimes, not a parallel reproduction of
+    // its branch. Since the helper returns null here, the real native TLS
+    // connection receives the backend default gate.
     var fixed = tls_core.credentials.FixedCredentialProvider.init(tls_core.credentials.testdata.identity());
     defer fixed.deinit();
     const fds = try gatewayTestSocketPair();
@@ -3605,7 +3640,7 @@ test "#369 Slice 2 rt0.reject.store_unavailable: the disabled-mode composition d
         fds[0],
         .{ .http1_enabled = true, .http2_enabled = true },
         fixed.provider(),
-        .{}, // no early_data_replay_gate — matches the `.disabled` composition decision above
+        .{ .early_data_replay_gate = disabled_composition.early_data_replay_gate },
     );
     defer native.destroy();
 
@@ -3616,11 +3651,6 @@ test "#369 Slice 2 rt0.reject.store_unavailable: the disabled-mode composition d
     // so any 0-RTT attempt on it fails closed to `.unavailable` while
     // ordinary 1-RTT resumption is untouched.
     try std.testing.expect(native.backend.early_data_replay_gate.decideFn == null);
-
-    // The default configuration also defines no location routes at all —
-    // native 0-RTT is not merely rejected but structurally unreachable.
-    try std.testing.expectEqual(edge_config.EarlyDataReplayMode.disabled, cfg.tls_native_early_data_replay_mode);
-    try std.testing.expectEqual(@as(usize, 0), cfg.location_blocks.len);
 }
 
 test "return_response method enforcement — non-GET/HEAD rejected on static returns" {

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -3505,6 +3505,124 @@ test "H1 early proxy with origin capability off never reaches upstream side effe
     try std.testing.expectEqual(@as(usize, 0), effects.upstream_calls);
 }
 
+test "#369 Slice 2 rt0.reject.unsafe_request: an unsafe method carrying current-hop early data is rejected by the real H1 orchestration before any route dispatch" {
+    // Drives the real, private `executeH1PostPreflightOrchestration` this
+    // file's own dispatch uses in production (see `H1ProductionPostPreflightHooks`
+    // above), with the same probe-hooks pattern the two tests directly
+    // above already use — so "the route hook never runs" is proven by the
+    // real orchestration's control flow, not merely inferred from calling
+    // the decision function in isolation. Distinct from those two tests:
+    // this isolates the *method-safety* gate in `http.early_data.decide()`
+    // specifically (no mirror rule, `proxy_early_data: rfc8470`, so an
+    // unsafe method is the only thing that can produce `.too_early` here),
+    // whereas the existing tests isolate a mirror-rule match and an
+    // origin-capability-off route respectively.
+    const allocator = std.testing.allocator;
+    var blocks = [_]edge_config.EdgeConfig.LocationBlock{
+        .{
+            .match_type = .prefix,
+            .pattern = "/",
+            .priority = 0,
+            .action = .{ .proxy_pass = "http://127.0.0.1:1" },
+            .early_data = .replay_safe,
+            .proxy_early_data = .rfc8470,
+        },
+    };
+    var cfg: edge_config.EdgeConfig = undefined;
+    cfg.metrics_path = "/status/metrics";
+    cfg.location_blocks = blocks[0..];
+    cfg.mirror_rules = &.{};
+    var request = try http.Request.parseHead(allocator, "POST /work HTTP/1.1\r\nHost: example.test\r\nContent-Length: 0\r\n\r\n", MAX_REQUEST_SIZE);
+    defer request.request.deinit();
+    var effects = H1PreflightSideEffectProbe{};
+    var state: GatewayState = undefined;
+    state.metrics_mutex = .{};
+    state.metrics = http.metrics.Metrics.init();
+    var ctx = http.request_context.RequestContext.init(allocator, "req-post-early", "127.0.0.1");
+    ctx.early_data.transport_early = true;
+    var lifecycle = http.request_lifecycle.RequestLifecycle.init("req-post-early", 0);
+    var keep_alive = false;
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    defer output.deinit();
+    const outcome = try executeH1PostPreflightOrchestration(
+        {},
+        allocator,
+        &output.writer,
+        &cfg,
+        &state,
+        &ctx,
+        &request.request,
+        "req-post-early",
+        &keep_alive,
+        "127.0.0.1",
+        null,
+        &lifecycle,
+        H1CountingPostPreflightHooks{ .effects = &effects },
+    );
+
+    try std.testing.expectEqual(@as(u16, @intFromEnum(http.Status.too_early)), outcome.terminal_status);
+    // The route hook — which is where any upstream dispatch, real or
+    // otherwise, would originate — never ran.
+    try std.testing.expectEqual(@as(usize, 0), effects.upstream_calls);
+    try std.testing.expectEqual(@as(usize, 0), effects.handler_calls);
+}
+
+test "#369 Slice 2 rt0.reject.store_unavailable: the disabled-mode composition decision installs no replay gate on the real native TLS connection, matching Tls13Backend's fail-closed default" {
+    // Deterministic, explicit config rather than depending on ambient
+    // TARDIGRADE_* env vars — forces the exact decision `run()` makes.
+    var cfg = try edge_config.loadFromEnv(std.testing.allocator);
+    defer cfg.deinit(std.testing.allocator);
+    cfg.tls_native_early_data_replay_mode = .disabled;
+
+    // Native resumption and a native TCP provider both "exist" here (so a
+    // native PSK/early-data path genuinely could exist), isolating that
+    // `.disabled` replay mode alone — not merely "no eligible path" — is
+    // what withholds the store/gate. This is the exact decision `run()`
+    // makes via `nativeEarlyDataReplayStoreEnabled` before ever deciding
+    // whether to call `initNativeEarlyDataReplayStore`.
+    try std.testing.expect(!nativeEarlyDataReplayStoreEnabled(
+        cfg.tls_native_early_data_replay_mode,
+        true, // native_resumption_runtime_enabled
+        true, // native_tls_provider_present
+        false,
+        false,
+    ));
+
+    // Exactly the production composition pattern from "#368 Slice 2: one
+    // process-scoped early-data replay store is shared by native TCP and
+    // QUIC/H3" above: `run()` only calls `initNativeEarlyDataReplayStore`/
+    // installs a gate when `nativeEarlyDataReplayStoreEnabled` is true.
+    // Since it is not here, `run()` builds `NativeTlsConnection` exactly as
+    // it would in this configuration: with no `.early_data_replay_gate`
+    // option at all.
+    var fixed = tls_core.credentials.FixedCredentialProvider.init(tls_core.credentials.testdata.identity());
+    defer fixed.deinit();
+    const fds = try gatewayTestSocketPair();
+    defer gatewayTestCloseFd(fds[0]);
+    defer gatewayTestCloseFd(fds[1]);
+    const native = try http.native_tls_connection.NativeTlsConnection.createWithOptions(
+        std.testing.allocator,
+        fds[0],
+        .{ .http1_enabled = true, .http2_enabled = true },
+        fixed.provider(),
+        .{}, // no early_data_replay_gate — matches the `.disabled` composition decision above
+    );
+    defer native.destroy();
+
+    // `Tls13Backend`'s own default (proven end-to-end in
+    // `tls13_backend_tests.zig`'s "0-RTT anti-replay defaults to
+    // unavailable (fails closed) when no gate is configured" test) applies
+    // to this real, composition-built connection: no callback installed,
+    // so any 0-RTT attempt on it fails closed to `.unavailable` while
+    // ordinary 1-RTT resumption is untouched.
+    try std.testing.expect(native.backend.early_data_replay_gate.decideFn == null);
+
+    // The default configuration also defines no location routes at all —
+    // native 0-RTT is not merely rejected but structurally unreachable.
+    try std.testing.expectEqual(edge_config.EarlyDataReplayMode.disabled, cfg.tls_native_early_data_replay_mode);
+    try std.testing.expectEqual(@as(usize, 0), cfg.location_blocks.len);
+}
+
 test "return_response method enforcement — non-GET/HEAD rejected on static returns" {
     // ASVS-14.5.1: static return directives (non-redirect) must reject anything
     // other than GET and HEAD to prevent silent success on destructive methods

--- a/src/process_early_data_integration_tests.zig
+++ b/src/process_early_data_integration_tests.zig
@@ -1,0 +1,422 @@
+//! #369 Slice 2: process-level 0-RTT replay / anti-replay / 425 assurance —
+//! the gateway/HTTP-dispatch half. `src/tls/tls13_backend_tests.zig` proves
+//! the TLS/replay-store layer (accept, duplicate, capacity, quarantine,
+//! cross-worker sharing, no-gate-configured) with real production TLS and
+//! replay-store code. This file goes one layer further: it drives the real
+//! `gateway_proxy_runtime.runBufferedProxyAttempts` retry/425 state machine
+//! and the real production TCP HTTP client
+//! (`gateway_proxy_runtime.executeBufferedDataPlaneProxyRequest`) against
+//! an actual loopback upstream test server with an atomic execution
+//! counter — not a scripted attempt executor — so a real `425 Too Early`
+//! response and a real retry are what get proven, not a stand-in.
+//!
+//! `ProductionBufferedProxyAttemptExecutor` in `gateway_proxy_runtime.zig`
+//! is the real production executor, but it is wired to a full
+//! `GatewayState` (upstream health/circuit-breaker/logger/security headers/
+//! transcript store/...). Reconstructing all of that machinery merely to
+//! reach the two fields (`state.upstream_pool`, `state.h2_pool`) the
+//! executor actually threads through to the real HTTP client would be a
+//! large, brittle test-only reimplementation of `GatewayState` itself.
+//! `LoopbackAttemptExecutor` below is the smaller seam: it implements the
+//! same `attempt_executor` contract `runBufferedProxyAttempts` requires,
+//! but calls the *same* public, production
+//! `executeBufferedDataPlaneProxyRequest` function directly against a real
+//! `http.upstream_pool.UpstreamPool` and a real `http.metrics.Metrics`
+//! instance, so the retry/425 policy under test
+//! (`runBufferedProxyAttempts`/`shouldRetryEarlyUpstream425`) and the
+//! upstream transport are both genuine production code; only the
+//! observability plumbing that would otherwise live on `GatewayState` is
+//! test-local.
+
+const std = @import("std");
+const tls_core = @import("tls_core");
+const http = @import("http.zig");
+const edge_config = @import("edge_config.zig");
+const gproxy_runtime = @import("gateway_proxy_runtime.zig");
+const ghandlers = @import("gateway_handlers.zig");
+
+const testing = std.testing;
+
+// ---------------------------------------------------------------------
+// A real loopback upstream test server with an atomic execution counter.
+// Mirrors the raw blocking-listener fixture already used by
+// `gateway_proxy.zig`'s "connectBlockingTcp + exchange round-trips a real
+// TCP origin" test (bind on an ephemeral port, accept on a thread), rather
+// than inventing a new one.
+// ---------------------------------------------------------------------
+
+const EphemeralListener = struct {
+    fd: std.posix.fd_t,
+    port: u16,
+};
+
+fn bindEphemeralLoopbackListener() !EphemeralListener {
+    const listen_fd = std.c.socket(std.posix.AF.INET, std.posix.SOCK.STREAM, std.posix.IPPROTO.TCP);
+    try testing.expect(listen_fd >= 0);
+    errdefer _ = std.c.close(listen_fd);
+    _ = std.c.setsockopt(listen_fd, std.posix.SOL.SOCKET, std.posix.SO.REUSEADDR, std.mem.asBytes(&@as(c_int, 1)), @sizeOf(c_int));
+
+    const sin: std.c.sockaddr.in = .{
+        .family = std.posix.AF.INET,
+        .port = std.mem.nativeToBig(u16, 0),
+        .addr = @bitCast([4]u8{ 127, 0, 0, 1 }),
+        .zero = [8]u8{ 0, 0, 0, 0, 0, 0, 0, 0 },
+    };
+    try testing.expect(std.c.bind(listen_fd, @ptrCast(&sin), @sizeOf(std.c.sockaddr.in)) == 0);
+    try testing.expect(std.c.listen(listen_fd, 8) == 0);
+
+    var bound: std.c.sockaddr.in = undefined;
+    var bound_len: std.posix.socklen_t = @sizeOf(std.c.sockaddr.in);
+    try testing.expect(std.c.getsockname(listen_fd, @ptrCast(&bound), &bound_len) == 0);
+    const port = std.mem.bigToNative(u16, bound.port);
+    try testing.expect(port != 0);
+    return .{ .fd = listen_fd, .port = port };
+}
+
+/// Bounded, non-secret record of what the real origin observed per
+/// connection — case ID, execution count, and whether each request carried
+/// the real `Early-Data: 1` header — never request bodies or ticket/PSK
+/// material (there is none here to leak).
+const OriginState = struct {
+    executed: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+    connections_seen: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+    early_header_seen: [4]bool = .{ false, false, false, false },
+};
+
+fn requestHasEarlyDataHeader(raw: []const u8) bool {
+    var lower_buf: [4096]u8 = undefined;
+    const n = @min(raw.len, lower_buf.len);
+    for (raw[0..n], 0..) |c, i| lower_buf[i] = std.ascii.toLower(c);
+    return std.mem.indexOf(u8, lower_buf[0..n], "early-data: 1") != null;
+}
+
+/// Real blocking origin: accepts up to `max_connections` sequential
+/// connections (the buffered HTTP client always sends `Connection: close`
+/// bound responses here, so each attempt is a fresh TCP connection). Any
+/// request that actually carries `Early-Data: 1` is answered with a real
+/// `425 Too Early` and does **not** increment `executed` — modeling an
+/// origin that itself enforces RFC 8470 and refuses to treat early data as
+/// a safe side-effecting request. Any other request executes normally.
+fn earlyRejectingOriginResponder(listen_fd: std.posix.fd_t, state: *OriginState, max_connections: usize) void {
+    var handled: usize = 0;
+    while (handled < max_connections) : (handled += 1) {
+        const conn = std.c.accept(listen_fd, null, null);
+        if (conn < 0) return;
+        defer _ = std.c.close(conn);
+        var buf: [4096]u8 = undefined;
+        const got = std.c.read(conn, &buf, buf.len);
+        if (got <= 0) return;
+        const n: usize = @intCast(got);
+        const has_early = requestHasEarlyDataHeader(buf[0..n]);
+        const idx = state.connections_seen.fetchAdd(1, .monotonic);
+        if (idx < state.early_header_seen.len) state.early_header_seen[idx] = has_early;
+
+        if (has_early) {
+            const response = "HTTP/1.1 425 Too Early\r\nContent-Type: text/plain\r\nContent-Length: 9\r\nConnection: close\r\n\r\ntoo early";
+            _ = std.c.write(conn, response.ptr, response.len);
+        } else {
+            _ = state.executed.fetchAdd(1, .monotonic);
+            const response = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok";
+            _ = std.c.write(conn, response.ptr, response.len);
+        }
+    }
+}
+
+/// Real `runBufferedProxyAttempts` attempt executor driving the genuine
+/// production upstream TCP client. See the module doc for why this exists
+/// instead of reusing `ProductionBufferedProxyAttemptExecutor` directly.
+const LoopbackAttemptExecutor = struct {
+    allocator: std.mem.Allocator,
+    cfg: *const edge_config.EdgeConfig,
+    request: *const http.Request,
+    upstream_url: []const u8,
+    correlation_id: []const u8,
+    pool: *http.upstream_pool.UpstreamPool,
+    metrics: *http.metrics.Metrics,
+
+    pub fn execute(
+        self: *LoopbackAttemptExecutor,
+        attempt: usize,
+        forward_early_data: bool,
+    ) !gproxy_runtime.DataPlaneProxyResponse {
+        _ = attempt;
+        return gproxy_runtime.executeBufferedDataPlaneProxyRequest(
+            self.allocator,
+            self.cfg,
+            self.upstream_url,
+            null,
+            self.request.method.toString(),
+            &self.request.headers,
+            self.request.body orelse "",
+            self.correlation_id,
+            "127.0.0.1",
+            "http",
+            self.request.headers.get("host"),
+            null,
+            null,
+            null,
+            null,
+            forward_early_data,
+            2_000,
+            2_000,
+            2_000,
+            null,
+            self.pool,
+            null,
+        );
+    }
+
+    pub fn onBufferedResponse(self: *LoopbackAttemptExecutor, result: *gproxy_runtime.DataPlaneProxyResponse) !void {
+        _ = self;
+        _ = result;
+    }
+
+    pub fn onStaleConnectionRetry(self: *LoopbackAttemptExecutor, stale_conn_retries: usize, max_stale_conn_retries: usize) !void {
+        _ = self;
+        _ = stale_conn_retries;
+        _ = max_stale_conn_retries;
+    }
+
+    pub fn onTerminalAttemptError(self: *LoopbackAttemptExecutor, _: anyerror) !void {
+        _ = self;
+    }
+
+    pub fn onConfiguredErrorRetry(self: *LoopbackAttemptExecutor, configured_attempt_index: usize, max_attempts: usize, _: anyerror) !void {
+        _ = self;
+        _ = configured_attempt_index;
+        _ = max_attempts;
+    }
+
+    pub fn onEarly425Retry(self: *LoopbackAttemptExecutor, result: *gproxy_runtime.DataPlaneProxyResponse) !void {
+        result.deinit(self.allocator);
+    }
+
+    pub fn onEarly425HandshakeFailure(self: *LoopbackAttemptExecutor, _: anyerror) !void {
+        _ = self;
+    }
+
+    pub fn onConfigured5xxRetry(self: *LoopbackAttemptExecutor, configured_attempt_index: usize, max_attempts: usize, result: *gproxy_runtime.DataPlaneProxyResponse) !void {
+        _ = configured_attempt_index;
+        _ = max_attempts;
+        result.deinit(self.allocator);
+    }
+
+    pub fn recordEarlyUpstream425Action(self: *LoopbackAttemptExecutor, action: http.metrics.EarlyDataUpstream425Action) void {
+        self.metrics.recordHttpEarlyDataUpstream425(action);
+    }
+
+    pub fn recordEarlyRetryResult(self: *LoopbackAttemptExecutor, result: http.metrics.EarlyDataRetryResult) void {
+        self.metrics.recordHttpEarlyDataRetry(result);
+    }
+};
+
+/// Deterministic downstream-handshake barrier, matching the
+/// `TestEarly425Barrier` pattern already used by
+/// `gateway_proxy_runtime.zig`'s own "early upstream 425 retry..." test:
+/// starts incomplete (modeling a connection still mid-handshake when the
+/// early request arrived — the actual condition current-hop early data
+/// requires) and completes when `runBufferedProxyAttempts` drives it while
+/// waiting to retry after a 425. A `null` barrier instead means "already
+/// complete", which would make this current-hop-early scenario
+/// indistinguishable from an ordinary post-handshake request.
+const TestDownstreamHandshakeBarrier = struct {
+    complete: bool = false,
+    waits: usize = 0,
+
+    fn isComplete(ptr: *anyopaque) bool {
+        const self: *TestDownstreamHandshakeBarrier = @ptrCast(@alignCast(ptr));
+        return self.complete;
+    }
+
+    fn waitOrDrive(ptr: *anyopaque) anyerror!void {
+        const self: *TestDownstreamHandshakeBarrier = @ptrCast(@alignCast(ptr));
+        self.waits += 1;
+        self.complete = true;
+    }
+
+    fn barrier(self: *TestDownstreamHandshakeBarrier) http.request_context.DownstreamHandshakeBarrier {
+        return .{
+            .ctx = self,
+            .is_complete_fn = isComplete,
+            .wait_or_drive_fn = waitOrDrive,
+        };
+    }
+};
+
+test "#369 Slice 2 rt0.retry.425_exactly_once: a real early-data 425 from a real upstream retries exactly once, and the upstream executes exactly once" {
+    const allocator = testing.allocator;
+
+    var cfg = try edge_config.loadFromEnv(allocator);
+    defer cfg.deinit(allocator);
+
+    const listener = try bindEphemeralLoopbackListener();
+    defer _ = std.c.close(listener.fd);
+
+    var origin = OriginState{};
+    const responder = try std.Thread.spawn(.{}, earlyRejectingOriginResponder, .{ listener.fd, &origin, @as(usize, 2) });
+    defer responder.join();
+
+    var url_buf: [64]u8 = undefined;
+    const upstream_url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/work", .{listener.port});
+
+    const block = edge_config.EdgeConfig.LocationBlock{
+        .match_type = .prefix,
+        .pattern = "/",
+        .priority = 0,
+        .action = .{ .proxy_pass = upstream_url },
+        .early_data = .replay_safe,
+        .proxy_early_data = .rfc8470,
+    };
+
+    var parsed = try http.Request.parseHead(allocator, "GET /work HTTP/1.1\r\nHost: example.test\r\n\r\n", 1 << 20);
+    defer parsed.request.deinit();
+
+    var pool = http.upstream_pool.UpstreamPool.init(allocator, .{});
+    defer pool.deinit();
+    var metrics = http.metrics.Metrics.init();
+
+    var executor = LoopbackAttemptExecutor{
+        .allocator = allocator,
+        .cfg = &cfg,
+        .request = &parsed.request,
+        .upstream_url = upstream_url,
+        .correlation_id = "req-425",
+        .pool = &pool,
+        .metrics = &metrics,
+    };
+
+    // Current-hop 0-RTT early data, no prior-hop `Early-Data` marker, and a
+    // downstream handshake that has not yet completed (the actual
+    // condition current-hop early data implies) — this is the shape #367's
+    // contract allows exactly one transparent retry for, on a replay-safe
+    // GET to an RFC-8470-aware origin.
+    var handshake_barrier = TestDownstreamHandshakeBarrier{};
+    var early_ctx = http.request_context.EarlyDataContext{
+        .transport_early = true,
+        .downstream_handshake = handshake_barrier.barrier(),
+    };
+    const first_attempt_forward_early_data = early_ctx.inbound_marker or
+        (early_ctx.transport_early and !early_ctx.downstreamHandshakeComplete());
+    try testing.expect(first_attempt_forward_early_data);
+
+    const before_retried = metrics.http_early_data_upstream_425_total[@intFromEnum(http.metrics.EarlyDataUpstream425Action.retried)];
+    const before_success = metrics.http_early_data_retry_total[@intFromEnum(http.metrics.EarlyDataRetryResult.success)];
+
+    const outcome = try gproxy_runtime.runBufferedProxyAttempts(
+        &early_ctx,
+        first_attempt_forward_early_data,
+        "GET",
+        &block,
+        1,
+        0,
+        cfg.upstream_retry_idempotent_only,
+        &executor,
+    );
+
+    var response = switch (outcome) {
+        .response => |r| r,
+        else => return error.TestUnexpectedResult,
+    };
+    defer response.deinit(allocator);
+
+    // The response returned to the caller is the successful retry response.
+    try testing.expectEqual(@as(u16, 200), response.statusCode());
+
+    // Real origin, real bytes: first connection carried Early-Data: 1 and
+    // was rejected; the retried connection did not carry it.
+    try testing.expectEqual(@as(usize, 2), origin.connections_seen.load(.monotonic));
+    try testing.expect(origin.early_header_seen[0]);
+    try testing.expect(!origin.early_header_seen[1]);
+
+    // Exactly one real upstream execution across both attempts.
+    try testing.expectEqual(@as(usize, 1), origin.executed.load(.monotonic));
+
+    // Retry occurred at most once (exactly once here), per the #367
+    // contract; metrics distinguish the initial 425 from the successful
+    // retry.
+    try testing.expectEqual(before_retried + 1, metrics.http_early_data_upstream_425_total[@intFromEnum(http.metrics.EarlyDataUpstream425Action.retried)]);
+    try testing.expectEqual(before_success + 1, metrics.http_early_data_retry_total[@intFromEnum(http.metrics.EarlyDataRetryResult.success)]);
+    // The retry genuinely waited on the downstream handshake barrier
+    // exactly once before retrying as ordinary.
+    try testing.expectEqual(@as(usize, 1), handshake_barrier.waits);
+}
+
+test "#369 Slice 2 rt0.reject.unsafe_request: an unsafe method carrying current-hop early data is rejected by the real gateway decision before any upstream dispatch is even attempted" {
+    // Matches the minimal-`undefined`-`EdgeConfig` pattern already used by
+    // `edge_gateway.zig`'s own "H1 early-data 425 preflight..." tests: only
+    // the fields `earlyDataDecisionForRequest` actually reads are set, and
+    // (unlike `edge_config.loadFromEnv`) nothing here is heap-allocated, so
+    // there is no `cfg.deinit` to call and no risk of freeing
+    // literal-backed `LocationBlock`/slice memory a real `loadFromEnv`
+    // config would expect to own.
+    var cfg: edge_config.EdgeConfig = undefined;
+    cfg.metrics_path = "/status/metrics";
+
+    // Deliberately not bound by anything: if the real gateway path were to
+    // (incorrectly) attempt to dispatch this request as early data, this
+    // test would need a live responder to get a 2xx/425 back at all. Using
+    // an address nothing listens on means the only way this test can pass
+    // is by never attempting the dispatch in the first place — no thread,
+    // no sleep-based synchronization needed to prove non-contact.
+    var blocks = [_]edge_config.EdgeConfig.LocationBlock{.{
+        .match_type = .prefix,
+        .pattern = "/",
+        .priority = 0,
+        .action = .{ .proxy_pass = "http://127.0.0.1:1" },
+        .early_data = .replay_safe,
+        .proxy_early_data = .rfc8470,
+    }};
+    cfg.location_blocks = blocks[0..];
+    cfg.mirror_rules = &.{};
+
+    // POST is not method-safe (#366/#367 policy): even though the route
+    // itself is configured replay-safe and RFC-8470-aware, an unsafe
+    // method must never be admitted as early data. This is the same real,
+    // `pub` production decision function `edge_gateway.zig`'s H1 dispatch
+    // calls (via `earlyDataPreflightDecisionForH1`) before ever reaching
+    // `hooks.route`/`gproxy_runtime.handleLocationProxyPass` — see
+    // `executeH1PostPreflightOrchestration` in `edge_gateway.zig`, whose
+    // `.too_early` branch calls `hooks.rejectEarly` and returns without
+    // calling `hooks.route` at all.
+    const early_ctx = http.request_context.EarlyDataContext{ .transport_early = true };
+    const decision = ghandlers.earlyDataDecisionForRequest(&cfg, early_ctx, .POST, "/work", false);
+    try testing.expectEqual(http.early_data.Decision.too_early, decision);
+
+    // The real gateway path never reaches `runBufferedProxyAttempts` for a
+    // `.too_early` decision, so nothing here calls it — that omission is
+    // itself the proof: no upstream dispatch, real or otherwise, is even
+    // attempted for this request shape, and therefore no unsafe side
+    // effect and no double execution from any fallback/retry path either.
+}
+
+test "#369 Slice 2 rt0.reject.store_unavailable: the default configuration neither enables native 0-RTT nor accidentally accepts it — 1-RTT-equivalent policy stays available" {
+    // Cross-layer proof, tying two independently-tested facts together:
+    //  1. `edge_config.loadFromEnv`'s default configuration (no env
+    //     overrides) leaves native 0-RTT anti-replay disabled and defines
+    //     no location routes at all, so nothing could be routed as early
+    //     data even if a peer attempted it (already directly asserted in
+    //     `edge_config.zig`'s own "#368 Slice 3: early-data replay config
+    //     defaults to disabled..." test — not re-asserted in isolation
+    //     here, only combined with fact 2).
+    //  2. `tls_core.tls13_backend.EarlyDataReplayGate`'s default
+    //     (`decideFn == null`, i.e. exactly what composition leaves wired
+    //     when the operator has not configured `process_local` mode) maps
+    //     every 0-RTT attempt to `.unavailable` — fail closed — while
+    //     never touching ordinary 1-RTT resumption (already directly
+    //     proven end-to-end in `tls13_backend_tests.zig`'s "0-RTT
+    //     anti-replay defaults to unavailable (fails closed) when no gate
+    //     is configured" test).
+    //
+    // Together: a freshly started process with no operator configuration
+    // cannot accept 0-RTT anywhere, by construction, without needing a
+    // distributed or even a local replay backend to be present.
+    const allocator = testing.allocator;
+    var cfg = try edge_config.loadFromEnv(allocator);
+    defer cfg.deinit(allocator);
+
+    try testing.expectEqual(edge_config.EarlyDataReplayMode.disabled, cfg.tls_native_early_data_replay_mode);
+    try testing.expectEqual(@as(usize, 0), cfg.location_blocks.len);
+
+    const default_gate = tls_core.tls13_backend.EarlyDataReplayGate{};
+    try testing.expect(default_gate.decideFn == null);
+}

--- a/src/process_early_data_integration_tests.zig
+++ b/src/process_early_data_integration_tests.zig
@@ -1,14 +1,16 @@
-//! #369 Slice 2: process-level 0-RTT replay / anti-replay / 425 assurance —
-//! the gateway/HTTP-dispatch half. `src/tls/tls13_backend_tests.zig` proves
-//! the TLS/replay-store layer (accept, duplicate, capacity, quarantine,
-//! cross-worker sharing, no-gate-configured) with real production TLS and
-//! replay-store code. This file goes one layer further: it drives the real
-//! `gateway_proxy_runtime.runBufferedProxyAttempts` retry/425 state machine
-//! and the real production TCP HTTP client
-//! (`gateway_proxy_runtime.executeBufferedDataPlaneProxyRequest`) against
-//! an actual loopback upstream test server with an atomic execution
-//! counter — not a scripted attempt executor — so a real `425 Too Early`
-//! response and a real retry are what get proven, not a stand-in.
+//! #369 Slice 2: process-level 0-RTT replay / 425 assurance — the real
+//! upstream-retry half. `src/tls/tls13_backend_tests.zig` proves the TLS/
+//! replay-store layer with real production TLS and replay-store code, and
+//! `edge_gateway.zig` proves the real H1 orchestration/dispatch-gating and
+//! composition-decision scenarios (both need production code these files
+//! cannot see — orchestration internals and the replay-store composition
+//! helpers are private to `edge_gateway.zig`). This file's scenario needs
+//! neither: it drives the real `gateway_proxy_runtime.runBufferedProxyAttempts`
+//! retry/425 state machine and the real production TCP HTTP client
+//! (`gateway_proxy_runtime.executeBufferedDataPlaneProxyRequest`) against an
+//! actual loopback upstream test server with an atomic execution counter —
+//! not a scripted attempt executor — so a real `425 Too Early` response and
+//! a real retry are what get proven, not a stand-in.
 //!
 //! `ProductionBufferedProxyAttemptExecutor` in `gateway_proxy_runtime.zig`
 //! is the real production executor, but it is wired to a full
@@ -29,11 +31,9 @@
 //! test-local.
 
 const std = @import("std");
-const tls_core = @import("tls_core");
 const http = @import("http.zig");
 const edge_config = @import("edge_config.zig");
 const gproxy_runtime = @import("gateway_proxy_runtime.zig");
-const ghandlers = @import("gateway_handlers.zig");
 
 const testing = std.testing;
 
@@ -41,8 +41,10 @@ const testing = std.testing;
 // A real loopback upstream test server with an atomic execution counter.
 // Mirrors the raw blocking-listener fixture already used by
 // `gateway_proxy.zig`'s "connectBlockingTcp + exchange round-trips a real
-// TCP origin" test (bind on an ephemeral port, accept on a thread), rather
-// than inventing a new one.
+// TCP origin" test (bind on an ephemeral port, accept on a thread), but
+// bounded throughout with `poll` so a regression that this test is meant
+// to catch (e.g. the retry never happening) makes the *test* fail with a
+// useful assertion instead of hanging `zig build test`/CI forever.
 // ---------------------------------------------------------------------
 
 const EphemeralListener = struct {
@@ -73,14 +75,29 @@ fn bindEphemeralLoopbackListener() !EphemeralListener {
     return .{ .fd = listen_fd, .port = port };
 }
 
+/// Polls `fd` for readability with a bounded timeout. Never blocks forever:
+/// returns `false` on timeout or a poll error, both of which the caller
+/// must treat as "give up", not "keep waiting".
+fn pollReadable(fd: std.posix.fd_t, timeout_ms: i32) bool {
+    var fds = [_]std.posix.pollfd{.{ .fd = fd, .events = std.posix.POLL.IN, .revents = 0 }};
+    const n = std.posix.poll(&fds, timeout_ms) catch return false;
+    return n > 0 and (fds[0].revents & std.posix.POLL.IN) != 0;
+}
+
 /// Bounded, non-secret record of what the real origin observed per
 /// connection — case ID, execution count, and whether each request carried
 /// the real `Early-Data: 1` header — never request bodies or ticket/PSK
-/// material (there is none here to leak).
+/// material (there is none here to leak). Only `stop` is written from the
+/// main test thread; everything else is written by the responder thread
+/// and must only be read by the main thread *after* `Thread.join` has
+/// returned, which is the real happens-before relationship this file
+/// relies on (see the test below) rather than relying on these fields
+/// being atomic.
 const OriginState = struct {
     executed: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
     connections_seen: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
     early_header_seen: [4]bool = .{ false, false, false, false },
+    stop: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
 };
 
 fn requestHasEarlyDataHeader(raw: []const u8) bool {
@@ -90,24 +107,64 @@ fn requestHasEarlyDataHeader(raw: []const u8) bool {
     return std.mem.indexOf(u8, lower_buf[0..n], "early-data: 1") != null;
 }
 
-/// Real blocking origin: accepts up to `max_connections` sequential
-/// connections (the buffered HTTP client always sends `Connection: close`
-/// bound responses here, so each attempt is a fresh TCP connection). Any
-/// request that actually carries `Early-Data: 1` is answered with a real
-/// `425 Too Early` and does **not** increment `executed` — modeling an
-/// origin that itself enforces RFC 8470 and refuses to treat early data as
-/// a safe side-effecting request. Any other request executes normally.
+/// Bounded wait for one inbound connection: polls in small slices, checking
+/// `state.stop` between them, up to `max_wait_ms` total. Returns `null`
+/// (never blocks indefinitely) if `stop` is requested or the deadline
+/// passes without a peer connecting — the caller must treat that as "no
+/// more connections are coming," not retry forever.
+fn acceptBounded(listen_fd: std.posix.fd_t, state: *OriginState, max_wait_ms: i64) ?std.posix.fd_t {
+    const poll_slice_ms = 25;
+    var waited_ms: i64 = 0;
+    while (waited_ms < max_wait_ms) : (waited_ms += poll_slice_ms) {
+        if (state.stop.load(.acquire)) return null;
+        if (pollReadable(listen_fd, poll_slice_ms)) {
+            const conn = std.c.accept(listen_fd, null, null);
+            if (conn < 0) return null;
+            return conn;
+        }
+    }
+    return null;
+}
+
+/// Reads one HTTP request head from `conn`, bounded both in time (via
+/// `pollReadable`) and in size (`buf.len`). Returns the bytes read so far
+/// on any of: seeing the `\r\n\r\n` head terminator, a read timeout, EOF,
+/// or a full buffer — never blocks indefinitely on a peer that stops
+/// sending mid-request.
+fn readRequestHeadBounded(conn: std.posix.fd_t, buf: []u8) []const u8 {
+    var total: usize = 0;
+    while (total < buf.len) {
+        if (!pollReadable(conn, 2_000)) break;
+        const got = std.c.read(conn, buf[total..].ptr, buf.len - total);
+        if (got <= 0) break;
+        total += @intCast(got);
+        if (std.mem.indexOf(u8, buf[0..total], "\r\n\r\n") != null) break;
+    }
+    return buf[0..total];
+}
+
+/// Real blocking-but-bounded origin: accepts up to `max_connections`
+/// sequential connections (the buffered HTTP client always sends
+/// `Connection: close` bound responses here, so each attempt is a fresh
+/// TCP connection). Any request that actually carries `Early-Data: 1` is
+/// answered with a real `425 Too Early` and does **not** increment
+/// `executed` — modeling an origin that itself enforces RFC 8470 and
+/// refuses to treat early data as a safe side-effecting request. Any other
+/// request executes normally. Every wait in this function is bounded (see
+/// `acceptBounded`/`readRequestHeadBounded`), so a regression this test is
+/// meant to catch (e.g. the client never retrying) makes this function
+/// return promptly instead of blocking the test process forever.
 fn earlyRejectingOriginResponder(listen_fd: std.posix.fd_t, state: *OriginState, max_connections: usize) void {
     var handled: usize = 0;
     while (handled < max_connections) : (handled += 1) {
-        const conn = std.c.accept(listen_fd, null, null);
-        if (conn < 0) return;
+        const conn = acceptBounded(listen_fd, state, 5_000) orelse return;
         defer _ = std.c.close(conn);
+
         var buf: [4096]u8 = undefined;
-        const got = std.c.read(conn, &buf, buf.len);
-        if (got <= 0) return;
-        const n: usize = @intCast(got);
-        const has_early = requestHasEarlyDataHeader(buf[0..n]);
+        const request_head = readRequestHeadBounded(conn, &buf);
+        if (request_head.len == 0) return;
+
+        const has_early = requestHasEarlyDataHeader(request_head);
         const idx = state.connections_seen.fetchAdd(1, .monotonic);
         if (idx < state.early_header_seen.len) state.early_header_seen[idx] = has_early;
 
@@ -254,7 +311,16 @@ test "#369 Slice 2 rt0.retry.425_exactly_once: a real early-data 425 from a real
 
     var origin = OriginState{};
     const responder = try std.Thread.spawn(.{}, earlyRejectingOriginResponder, .{ listener.fd, &origin, @as(usize, 2) });
-    defer responder.join();
+    // Belt-and-suspenders for every early-return path between here and the
+    // explicit join below (e.g. an allocation failure building the request/
+    // URL): request a bounded shutdown and join at most once. `joined`
+    // guards against the double-join UB that would result from both this
+    // defer and the explicit join below running.
+    var joined = false;
+    defer if (!joined) {
+        origin.stop.store(true, .release);
+        responder.join();
+    };
 
     var url_buf: [64]u8 = undefined;
     const upstream_url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/work", .{listener.port});
@@ -302,7 +368,7 @@ test "#369 Slice 2 rt0.retry.425_exactly_once: a real early-data 425 from a real
     const before_retried = metrics.http_early_data_upstream_425_total[@intFromEnum(http.metrics.EarlyDataUpstream425Action.retried)];
     const before_success = metrics.http_early_data_retry_total[@intFromEnum(http.metrics.EarlyDataRetryResult.success)];
 
-    const outcome = try gproxy_runtime.runBufferedProxyAttempts(
+    const outcome_result = gproxy_runtime.runBufferedProxyAttempts(
         &early_ctx,
         first_attempt_forward_early_data,
         "GET",
@@ -313,7 +379,16 @@ test "#369 Slice 2 rt0.retry.425_exactly_once: a real early-data 425 from a real
         &executor,
     );
 
-    var response = switch (outcome) {
+    // Establish a real happens-before relationship with the responder
+    // thread *before* reading any of its (non-atomic) observations below —
+    // `Thread.join` synchronizes-with the thread's completion. This must
+    // run whether `outcome_result` is a value or an error, and before the
+    // `try` that would otherwise skip straight to the deferred cleanup.
+    origin.stop.store(true, .release);
+    responder.join();
+    joined = true;
+
+    var response = switch (try outcome_result) {
         .response => |r| r,
         else => return error.TestUnexpectedResult,
     };
@@ -339,84 +414,4 @@ test "#369 Slice 2 rt0.retry.425_exactly_once: a real early-data 425 from a real
     // The retry genuinely waited on the downstream handshake barrier
     // exactly once before retrying as ordinary.
     try testing.expectEqual(@as(usize, 1), handshake_barrier.waits);
-}
-
-test "#369 Slice 2 rt0.reject.unsafe_request: an unsafe method carrying current-hop early data is rejected by the real gateway decision before any upstream dispatch is even attempted" {
-    // Matches the minimal-`undefined`-`EdgeConfig` pattern already used by
-    // `edge_gateway.zig`'s own "H1 early-data 425 preflight..." tests: only
-    // the fields `earlyDataDecisionForRequest` actually reads are set, and
-    // (unlike `edge_config.loadFromEnv`) nothing here is heap-allocated, so
-    // there is no `cfg.deinit` to call and no risk of freeing
-    // literal-backed `LocationBlock`/slice memory a real `loadFromEnv`
-    // config would expect to own.
-    var cfg: edge_config.EdgeConfig = undefined;
-    cfg.metrics_path = "/status/metrics";
-
-    // Deliberately not bound by anything: if the real gateway path were to
-    // (incorrectly) attempt to dispatch this request as early data, this
-    // test would need a live responder to get a 2xx/425 back at all. Using
-    // an address nothing listens on means the only way this test can pass
-    // is by never attempting the dispatch in the first place — no thread,
-    // no sleep-based synchronization needed to prove non-contact.
-    var blocks = [_]edge_config.EdgeConfig.LocationBlock{.{
-        .match_type = .prefix,
-        .pattern = "/",
-        .priority = 0,
-        .action = .{ .proxy_pass = "http://127.0.0.1:1" },
-        .early_data = .replay_safe,
-        .proxy_early_data = .rfc8470,
-    }};
-    cfg.location_blocks = blocks[0..];
-    cfg.mirror_rules = &.{};
-
-    // POST is not method-safe (#366/#367 policy): even though the route
-    // itself is configured replay-safe and RFC-8470-aware, an unsafe
-    // method must never be admitted as early data. This is the same real,
-    // `pub` production decision function `edge_gateway.zig`'s H1 dispatch
-    // calls (via `earlyDataPreflightDecisionForH1`) before ever reaching
-    // `hooks.route`/`gproxy_runtime.handleLocationProxyPass` — see
-    // `executeH1PostPreflightOrchestration` in `edge_gateway.zig`, whose
-    // `.too_early` branch calls `hooks.rejectEarly` and returns without
-    // calling `hooks.route` at all.
-    const early_ctx = http.request_context.EarlyDataContext{ .transport_early = true };
-    const decision = ghandlers.earlyDataDecisionForRequest(&cfg, early_ctx, .POST, "/work", false);
-    try testing.expectEqual(http.early_data.Decision.too_early, decision);
-
-    // The real gateway path never reaches `runBufferedProxyAttempts` for a
-    // `.too_early` decision, so nothing here calls it — that omission is
-    // itself the proof: no upstream dispatch, real or otherwise, is even
-    // attempted for this request shape, and therefore no unsafe side
-    // effect and no double execution from any fallback/retry path either.
-}
-
-test "#369 Slice 2 rt0.reject.store_unavailable: the default configuration neither enables native 0-RTT nor accidentally accepts it — 1-RTT-equivalent policy stays available" {
-    // Cross-layer proof, tying two independently-tested facts together:
-    //  1. `edge_config.loadFromEnv`'s default configuration (no env
-    //     overrides) leaves native 0-RTT anti-replay disabled and defines
-    //     no location routes at all, so nothing could be routed as early
-    //     data even if a peer attempted it (already directly asserted in
-    //     `edge_config.zig`'s own "#368 Slice 3: early-data replay config
-    //     defaults to disabled..." test — not re-asserted in isolation
-    //     here, only combined with fact 2).
-    //  2. `tls_core.tls13_backend.EarlyDataReplayGate`'s default
-    //     (`decideFn == null`, i.e. exactly what composition leaves wired
-    //     when the operator has not configured `process_local` mode) maps
-    //     every 0-RTT attempt to `.unavailable` — fail closed — while
-    //     never touching ordinary 1-RTT resumption (already directly
-    //     proven end-to-end in `tls13_backend_tests.zig`'s "0-RTT
-    //     anti-replay defaults to unavailable (fails closed) when no gate
-    //     is configured" test).
-    //
-    // Together: a freshly started process with no operator configuration
-    // cannot accept 0-RTT anywhere, by construction, without needing a
-    // distributed or even a local replay backend to be present.
-    const allocator = testing.allocator;
-    var cfg = try edge_config.loadFromEnv(allocator);
-    defer cfg.deinit(allocator);
-
-    try testing.expectEqual(edge_config.EarlyDataReplayMode.disabled, cfg.tls_native_early_data_replay_mode);
-    try testing.expectEqual(@as(usize, 0), cfg.location_blocks.len);
-
-    const default_gate = tls_core.tls13_backend.EarlyDataReplayGate{};
-    try testing.expect(default_gate.decideFn == null);
 }

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -8124,3 +8124,367 @@ test "record mode delivers a fatal alert to the client when required client auth
     try std.testing.expect(!h.server.bridge.handshake_complete);
     try std.testing.expectEqual(tls_backend.CredentialFailure.client_certificate_required, h.server_engine.credentialFailure().?);
 }
+
+// ---------------------------------------------------------------------
+// #369 Slice 2: process-level 0-RTT replay / anti-replay assurance.
+//
+// The tests above (#366/#367/#368) already prove the TLS-layer decision
+// (`EarlyDataDecision`) is correct for every accept/duplicate/capacity/
+// quarantine/no-gate-configured case, including two independent backends
+// sharing one real `LocalStore` (see "#368 Slice 2: a real process-scoped
+// LocalStore shared across two independent backends..." above). What none
+// of them prove is the security invariant #369 (326-J) actually owns: that
+// the *decision* correctly gates an *application-level side effect* —
+// exactly one execution for an accepted claim, zero for every rejected one
+// — and that a rejected claim never turns a valid session into a fatal
+// resumption failure. These tests reuse the exact same production harness
+// helpers (`DirectHarness`, `issueEarlyCapableTicket`, `IdentityResolver`, a
+// real `tls_core.early_data_replay.LocalStore`/`GateAdapter`) and add an
+// atomic "application executed" counter driven strictly by
+// `server_backend.earlyDataAccepted()`, rather than re-deriving the TLS
+// decision logic itself.
+//
+// True OS-thread/worker-routing determinism is not exposed as a test seam
+// in this codebase today — no API pins a connection to a specific worker
+// thread for deterministic testing. The strongest available proof, and the
+// one that actually matches what `edge_gateway.zig`'s real composition
+// shares (one process-scoped `LocalStore`/`GateAdapter`, built once in
+// `initNativeEarlyDataReplayStore`/`GateAdapter.init` and installed by
+// reference into every native TCP worker and QUIC/H3 — see
+// "#368 Slice 2: one process-scoped early-data replay store is shared by
+// native TCP and QUIC/H3" in edge_gateway.zig), is two independent
+// per-connection `DirectHarness` instances sharing one real `LocalStore`,
+// used below in the cross-worker test. A future slice could add a
+// deterministic worker-pinning seam (e.g. an explicit worker id threaded
+// through `WorkerContext`) to drive this through real OS threads instead.
+// ---------------------------------------------------------------------
+
+const early_data_replay = tls_core.early_data_replay;
+
+/// Deterministic `Store` wrapper around a real `LocalStore` that takes an
+/// explicit `now_unix_ms` instead of reading wall-clock time, matching this
+/// suite's fixed test clocks (`IdentityResolver.now`/
+/// `earlyDataResumedClientClock` both return `2000`) — the same pattern as
+/// `DeterministicStore` in the #368 Slice 2 cross-worker test above, kept
+/// as an independent type here so each #369 test owns its own store
+/// lifetime.
+const DeterministicNowStore = struct {
+    backing: *early_data_replay.LocalStore,
+    now_unix_ms: u64,
+
+    fn asStore(self: *@This()) early_data_replay.Store {
+        return .{ .ctx = self, .claimFn = claimTrampoline };
+    }
+
+    fn claimTrampoline(ctx: *anyopaque, c: early_data_replay.Claim) early_data_replay.ClaimResult {
+        const self: *@This() = @ptrCast(@alignCast(ctx));
+        return self.backing.claim(c, self.now_unix_ms);
+    }
+};
+
+/// Runs one resumed "connection" (a fresh `DirectHarness`) offering a clone
+/// of `ticket` against `state`, with `gate` installed as the server's
+/// anti-replay gate, and — only on a real `EarlyDataDecision.accepted`
+/// outcome — increments `application_executions` exactly once. This models
+/// the production invariant (`http/early_data.zig`'s `decide()`: only
+/// `.execute_local`/`.forward_rfc8470`, which require an accepted
+/// TLS/replay decision, ever reach an application/upstream handler) without
+/// re-deriving it: the TLS decision itself is genuine production output,
+/// only the "did the application run" bookkeeping is test-local.
+fn runResumedConnectionCountingExecutions(
+    state: *session.ServerRecoverableState,
+    ticket: *const session.ClientTicketState,
+    gate: tls_backend.EarlyDataReplayGate,
+    application_executions: *usize,
+) !*DirectHarness {
+    const harness = try std.testing.allocator.create(DirectHarness);
+    harness.* = DirectHarness.init();
+    errdefer {
+        harness.deinit();
+        std.testing.allocator.destroy(harness);
+    }
+
+    // `ClientPskOfferSet.push` moves ownership out of its argument, so
+    // offering the same ticket to independent connections needs an
+    // independent clone each time.
+    var ticket_clone: session.ClientTicketState = .{};
+    try ticket.cloneInto(std.testing.allocator, &ticket_clone);
+    errdefer ticket_clone.deinit();
+
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&ticket_clone);
+    var clock_dummy: u8 = 0;
+    try harness.client_backend.setClientPskOffers(&offers, &clock_dummy, earlyDataResumedClientClock);
+
+    var resolver_state = IdentityResolver{ .state = state };
+    try harness.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = IdentityResolver.now,
+        .resolveFn = IdentityResolver.resolve,
+    });
+
+    try harness.client_backend.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 16384 });
+    try harness.server_backend.setServerEarlyDataPolicy(.{ .enabled = true, .age_skew_tolerance_ms = 60_000 });
+    try harness.server_backend.setEarlyDataReplayGate(gate);
+
+    try harness.run();
+
+    if (harness.server_backend.earlyDataAccepted()) application_executions.* += 1;
+    return harness;
+}
+
+fn destroyResumedConnection(harness: *DirectHarness) void {
+    harness.deinit();
+    std.testing.allocator.destroy(harness);
+}
+
+/// Formats an `EarlyDataReplayCandidate` the way a diagnostic log line
+/// might and asserts the raw ticket identity never appears in it — only the
+/// one-way fingerprint and a plain integer deadline should ever be
+/// observable this way. `EarlyDataReplayCandidate` structurally has no PSK
+/// field at all, so a PSK leak through this seam is impossible by
+/// construction rather than merely untested.
+fn assertNoRawTicketInDiagnostic(candidate: tls_backend.EarlyDataReplayCandidate, raw_ticket: []const u8) !void {
+    var buf: [512]u8 = undefined;
+    const diagnostic = try std.fmt.bufPrint(&buf, "candidate={any}", .{candidate});
+    try std.testing.expect(std.mem.indexOf(u8, diagnostic, raw_ticket) == null);
+}
+
+test "#369 Slice 2 rt0.accept.first_use: accepted 0-RTT records the replay claim, executes the application exactly once, and leaks no raw ticket identity in diagnostics" {
+    var issued = try issueEarlyCapableTicket(32);
+    defer issued.deinit();
+
+    var store = try early_data_replay.LocalStore.init(std.testing.allocator, .{}, 0, 0);
+    defer store.deinit();
+    var det_store = DeterministicNowStore{ .backing = &store, .now_unix_ms = 2_000 };
+    var adapter = early_data_replay.GateAdapter.init(det_store.asStore());
+    const inner_gate = adapter.gate();
+
+    const CapturingGate = struct {
+        inner: tls_backend.EarlyDataReplayGate,
+        seen: ?tls_backend.EarlyDataReplayCandidate = null,
+
+        fn decide(ctx: *anyopaque, candidate: tls_backend.EarlyDataReplayCandidate) tls_backend.EarlyDataReplayDecision {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.seen = candidate;
+            return self.inner.decideFn.?(self.inner.ctx, candidate);
+        }
+    };
+    var capturing = CapturingGate{ .inner = inner_gate };
+    const gate = tls_backend.EarlyDataReplayGate{ .ctx = &capturing, .decideFn = CapturingGate.decide };
+
+    var executions: usize = 0;
+    const harness = try runResumedConnectionCountingExecutions(&issued.server_state, &issued.ticket, gate, &executions);
+    defer destroyResumedConnection(harness);
+
+    try std.testing.expect(harness.server_backend.core.psk_authenticated);
+    try std.testing.expectEqual(tls_backend.EarlyDataDecision.accepted, harness.server_backend.earlyDataDecision());
+    try std.testing.expectEqual(@as(usize, 1), executions);
+    // The replay claim was actually recorded — the store, not just the TLS
+    // decision, now has one live entry for this ticket's replay key.
+    try std.testing.expectEqual(@as(usize, 1), store.count());
+
+    const seen = capturing.seen orelse return error.TestExpectedEqual;
+    try assertNoRawTicketInDiagnostic(seen, "opaque-early-ticket");
+}
+
+test "#369 Slice 2 rt0.reject.duplicate: an exact-duplicate 0-RTT claim never executes the application, and the connection stays usable for a later distinct 1-RTT request" {
+    var issued = try issueEarlyCapableTicket(32);
+    defer issued.deinit();
+
+    var store = try early_data_replay.LocalStore.init(std.testing.allocator, .{}, 0, 0);
+    defer store.deinit();
+    var det_store = DeterministicNowStore{ .backing = &store, .now_unix_ms = 2_000 };
+    var adapter = early_data_replay.GateAdapter.init(det_store.asStore());
+    const gate = adapter.gate();
+
+    var executions: usize = 0;
+
+    // First attempt: claim -> accepted, application executes once.
+    const first = try runResumedConnectionCountingExecutions(&issued.server_state, &issued.ticket, gate, &executions);
+    defer destroyResumedConnection(first);
+    try std.testing.expectEqual(tls_backend.EarlyDataDecision.accepted, first.server_backend.earlyDataDecision());
+    try std.testing.expectEqual(@as(usize, 1), executions);
+
+    // Second attempt: the exact same logical replay identity (a clone of
+    // the same ticket) reused on an independent connection -> claim ->
+    // duplicate, early request must NOT execute.
+    const second = try runResumedConnectionCountingExecutions(&issued.server_state, &issued.ticket, gate, &executions);
+    defer destroyResumedConnection(second);
+    try std.testing.expectEqual(tls_backend.EarlyDataDecision.replay_rejected, second.server_backend.earlyDataDecision());
+    try std.testing.expect(!second.server_backend.earlyDataAccepted());
+    // Total application executions across both attempts remain exactly one.
+    try std.testing.expectEqual(@as(usize, 1), executions);
+    // The PSK/session is otherwise valid: the resumed handshake completed
+    // as ordinary 1-RTT rather than becoming a fatal TLS failure.
+    try std.testing.expect(second.client_driver.isComplete());
+    try std.testing.expect(second.server_driver.isComplete());
+    try std.testing.expect(second.server_backend.core.psk_authenticated);
+
+    // The surviving connection is actually usable: a distinct, later 1-RTT
+    // request round-trips real application data.
+    var protected: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    const request = try second.client_bridge.sealApplicationData("distinct 1-RTT request", &protected);
+    const opened = try second.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, request), &plaintext);
+    try std.testing.expectEqualStrings("distinct 1-RTT request", opened.inner.content);
+    // That distinct, intentionally-sent request is a genuine execution in
+    // its own right — bringing the total to two.
+    executions += 1;
+    try std.testing.expectEqual(@as(usize, 2), executions);
+
+    // Only one replay key was ever recorded; the duplicate never created a
+    // second entry.
+    try std.testing.expectEqual(@as(usize, 1), store.count());
+}
+
+test "#369 Slice 2 rt0.reject.capacity: capacity exhaustion rejects only early execution and ordinary resumption continues" {
+    var issued = try issueEarlyCapableTicket(32);
+    defer issued.deinit();
+
+    // Deliberately small capacity: exactly one live entry fits.
+    var store = try early_data_replay.LocalStore.init(std.testing.allocator, .{ .max_entries = 1 }, 0, 0);
+    defer store.deinit();
+
+    // Fill the store's one slot with a distinct, valid replay claim first —
+    // `issueEarlyCapableTicket` always mints the fixed identity
+    // "opaque-early-ticket" (see `issueEarlyCapableTicketProfile` above), so
+    // a second real ticket would collide as a *duplicate* of the same key
+    // rather than exercising capacity at all. A directly-claimed synthetic
+    // key models "some other distinct valid replay claim already occupying
+    // the store" without that collision, while the claim under test below
+    // is still a genuine production TLS/replay decision.
+    const filler_key: early_data_replay.Key = [_]u8{0xaa} ** 32;
+    try std.testing.expectEqual(early_data_replay.ClaimResult.accepted, store.claim(.{ .key = filler_key, .retain_until_unix_ms = std.math.maxInt(u64) }, 2_000));
+
+    var det_store = DeterministicNowStore{ .backing = &store, .now_unix_ms = 2_000 };
+    var adapter = early_data_replay.GateAdapter.init(det_store.asStore());
+    const gate = adapter.gate();
+
+    var executions: usize = 0;
+
+    // A real, otherwise-valid 0-RTT request finds the store full: rejected
+    // with the typed capacity outcome, no application side effect, but the
+    // valid PSK connection still continues as ordinary 1-RTT.
+    const rejected = try runResumedConnectionCountingExecutions(&issued.server_state, &issued.ticket, gate, &executions);
+    defer destroyResumedConnection(rejected);
+    try std.testing.expectEqual(tls_backend.EarlyDataDecision.replay_unavailable, rejected.server_backend.earlyDataDecision());
+    try std.testing.expect(!rejected.server_backend.earlyDataAccepted());
+    try std.testing.expectEqual(@as(usize, 0), executions);
+    try std.testing.expect(rejected.client_driver.isComplete());
+    try std.testing.expect(rejected.server_driver.isComplete());
+    try std.testing.expect(rejected.server_backend.core.psk_authenticated);
+
+    // A later normal request over that connection succeeds exactly once.
+    var protected: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    const request = try rejected.client_bridge.sealApplicationData("after capacity rejection", &protected);
+    const opened = try rejected.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, request), &plaintext);
+    try std.testing.expectEqualStrings("after capacity rejection", opened.inner.content);
+    executions += 1;
+    try std.testing.expectEqual(@as(usize, 1), executions);
+
+    // Occupancy stays bounded at the configured capacity — the rejected
+    // claim was never recorded.
+    try std.testing.expectEqual(@as(usize, 1), store.count());
+}
+
+test "#369 Slice 2 rt0.reject.startup_quarantine: lost replay history after restart rejects early execution, and the exact quarantine boundary matches #368's documented (exclusive-end) semantics" {
+    var issued = try issueEarlyCapableTicket(32);
+    defer issued.deinit();
+
+    // A 60_000ms quarantine window starting at the same fixed clock this
+    // suite's ticket/skew fixtures use (2_000), so `now == 2_000` is deep
+    // inside quarantine and `now == 62_000` is exactly at (and therefore
+    // past, per #368's `now_unix_ms < quarantine_until_unix_ms` exclusive
+    // check) the boundary.
+    var store = try early_data_replay.LocalStore.init(std.testing.allocator, .{}, 60_000, 2_000);
+    defer store.deinit();
+
+    // now < quarantine_end -> reject early data (the "restart" case: a
+    // fresh store with no shared history from the process that issued the
+    // ticket must not blindly accept 0-RTT).
+    {
+        var det_store = DeterministicNowStore{ .backing = &store, .now_unix_ms = 2_000 };
+        var adapter = early_data_replay.GateAdapter.init(det_store.asStore());
+        var executions: usize = 0;
+        const harness = try runResumedConnectionCountingExecutions(&issued.server_state, &issued.ticket, adapter.gate(), &executions);
+        defer destroyResumedConnection(harness);
+        try std.testing.expectEqual(tls_backend.EarlyDataDecision.replay_unavailable, harness.server_backend.earlyDataDecision());
+        try std.testing.expect(!harness.server_backend.earlyDataAccepted());
+        try std.testing.expectEqual(@as(usize, 0), executions);
+        // The rejection reason is distinguishable from an ordinary
+        // duplicate at the store's own typed-outcome layer: nothing was
+        // recorded (a duplicate would imply a live entry), and the
+        // underlying valid resumption/full handshake continues normally.
+        try std.testing.expectEqual(@as(usize, 0), store.count());
+        try std.testing.expect(harness.client_driver.isComplete());
+        try std.testing.expect(harness.server_driver.isComplete());
+        try std.testing.expect(harness.server_backend.core.psk_authenticated);
+
+        // The connection remains usable for a subsequent 1-RTT request.
+        var protected: [record_codec.max_ciphertext_record_len]u8 = undefined;
+        var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+        const request = try harness.client_bridge.sealApplicationData("during quarantine", &protected);
+        const opened = try harness.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, request), &plaintext);
+        try std.testing.expectEqualStrings("during quarantine", opened.inner.content);
+    }
+
+    // now == quarantine_end (62_000) -> per #368's existing boundary
+    // semantics (`now_unix_ms < quarantine_until_unix_ms`), this is no
+    // longer quarantined and ordinary replay-store eligibility applies: a
+    // fresh, otherwise-valid claim is accepted.
+    {
+        var fresh_issued = try issueEarlyCapableTicket(32);
+        defer fresh_issued.deinit();
+        var det_store = DeterministicNowStore{ .backing = &store, .now_unix_ms = 62_000 };
+        var adapter = early_data_replay.GateAdapter.init(det_store.asStore());
+        var executions: usize = 0;
+        const harness = try runResumedConnectionCountingExecutions(&fresh_issued.server_state, &fresh_issued.ticket, adapter.gate(), &executions);
+        defer destroyResumedConnection(harness);
+        try std.testing.expectEqual(tls_backend.EarlyDataDecision.accepted, harness.server_backend.earlyDataDecision());
+        try std.testing.expectEqual(@as(usize, 1), executions);
+    }
+}
+
+test "#369 Slice 2 rt0.reject.cross_worker_duplicate: worker A's accepted claim executes once; the same replay identity replayed through worker B never executes, over a real process-shared LocalStore" {
+    // Models exactly what `edge_gateway.zig`'s composition actually shares
+    // (one process-scoped `LocalStore`/`GateAdapter` handed by reference to
+    // every native TCP worker and QUIC/H3 — see
+    // `initNativeEarlyDataReplayStore`) as two independent per-connection
+    // `DirectHarness` "workers". See the module-doc note above this section
+    // for why real OS-thread pinning is not an available test seam today.
+    var issued = try issueEarlyCapableTicket(32);
+    defer issued.deinit();
+
+    var store = try early_data_replay.LocalStore.init(std.testing.allocator, .{}, 0, 0);
+    defer store.deinit();
+    var det_store = DeterministicNowStore{ .backing = &store, .now_unix_ms = 2_000 };
+    var adapter = early_data_replay.GateAdapter.init(det_store.asStore());
+    const shared_gate = adapter.gate();
+
+    var worker_a_executions: usize = 0;
+    var worker_b_executions: usize = 0;
+
+    // Worker A: first claim of this ticket's replay key anywhere in the
+    // (simulated) process — accepted, application executes exactly once.
+    const worker_a = try runResumedConnectionCountingExecutions(&issued.server_state, &issued.ticket, shared_gate, &worker_a_executions);
+    defer destroyResumedConnection(worker_a);
+    try std.testing.expectEqual(tls_backend.EarlyDataDecision.accepted, worker_a.server_backend.earlyDataDecision());
+    try std.testing.expectEqual(@as(usize, 1), worker_a_executions);
+
+    // Worker B: an independent backend instance — a different native TCP
+    // worker/connection in production — offering the very same ticket. The
+    // process-shared store must reject worker B's early execution; it must
+    // never execute.
+    const worker_b = try runResumedConnectionCountingExecutions(&issued.server_state, &issued.ticket, shared_gate, &worker_b_executions);
+    defer destroyResumedConnection(worker_b);
+    try std.testing.expectEqual(tls_backend.EarlyDataDecision.replay_rejected, worker_b.server_backend.earlyDataDecision());
+    try std.testing.expect(!worker_b.server_backend.earlyDataAccepted());
+    try std.testing.expectEqual(@as(usize, 0), worker_b_executions);
+    try std.testing.expect(worker_b.client_driver.isComplete());
+    try std.testing.expect(worker_b.server_driver.isComplete());
+    try std.testing.expect(worker_b.server_backend.core.psk_authenticated);
+
+    try std.testing.expectEqual(@as(usize, 1), store.count());
+}

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -8126,23 +8126,42 @@ test "record mode delivers a fatal alert to the client when required client auth
 }
 
 // ---------------------------------------------------------------------
-// #369 Slice 2: process-level 0-RTT replay / anti-replay assurance.
+// #369 Slice 2: TLS / replay-store layer assurance.
 //
 // The tests above (#366/#367/#368) already prove the TLS-layer decision
 // (`EarlyDataDecision`) is correct for every accept/duplicate/capacity/
 // quarantine/no-gate-configured case, including two independent backends
 // sharing one real `LocalStore` (see "#368 Slice 2: a real process-scoped
-// LocalStore shared across two independent backends..." above). What none
-// of them prove is the security invariant #369 (326-J) actually owns: that
-// the *decision* correctly gates an *application-level side effect* —
-// exactly one execution for an accepted claim, zero for every rejected one
-// — and that a rejected claim never turns a valid session into a fatal
-// resumption failure. These tests reuse the exact same production harness
-// helpers (`DirectHarness`, `issueEarlyCapableTicket`, `IdentityResolver`, a
-// real `tls_core.early_data_replay.LocalStore`/`GateAdapter`) and add an
-// atomic "application executed" counter driven strictly by
-// `server_backend.earlyDataAccepted()`, rather than re-deriving the TLS
-// decision logic itself.
+// LocalStore shared across two independent backends..." above). The tests
+// below reuse the exact same production harness helpers (`DirectHarness`,
+// `issueEarlyCapableTicket`, `IdentityResolver`, a real
+// `tls_core.early_data_replay.LocalStore`/`GateAdapter`) and add a real,
+// non-secret `Observer`/`Event` delta assertion for each scenario — the
+// same observer seam `edge_gateway.zig`'s composition installs on the
+// process-scoped store (`nativeEarlyDataReplayMetricsObserver`), just
+// asserted directly on the closed `Event` vocabulary here rather than
+// through `http.metrics`, which this module does not depend on.
+//
+// Scope note, corrected after review: an earlier version of these tests
+// paired each TLS decision with a same-process "application executed"
+// counter incremented directly from `server_backend.earlyDataAccepted()`.
+// That counter was tautological — derived from the exact decision under
+// test, so it could not catch a real cross-layer bug where HTTP/gateway
+// dispatch ignored the TLS decision. Worse, for the native TCP/H1 record
+// transport that bug is not even reachable to test today: `edge_gateway.zig`
+// currently hardcodes `ctx.early_data.transport_early = false` for every H1
+// request (see its own comment: "The production #366 H1 record provenance
+// carrier is not present on this branch yet"), i.e. **no production code
+// path yet wires `Tls13Backend.earlyDataAccepted()` into the HTTP
+// dispatch layer for this transport**. No test — here or anywhere — can
+// honestly claim to prove that wiring is correct until it exists; wiring it
+// is out of this slice's scope (a #366/#367 follow-up), so this file limits
+// itself to what real production code actually does today: the TLS/replay-
+// store decision and its observable `Event`s. The one place in this PR
+// where a real dispatch decision genuinely gates a real, non-tautological
+// execution/rejection is `rt0.reject.unsafe_request` in `edge_gateway.zig`,
+// which drives the real `executeH1PostPreflightOrchestration` orchestration
+// with a probe route hook.
 //
 // True OS-thread/worker-routing determinism is not exposed as a test seam
 // in this codebase today — no API pins a connection to a specific worker
@@ -8182,20 +8201,46 @@ const DeterministicNowStore = struct {
     }
 };
 
+/// Counts each closed `early_data_replay.Event` variant, installed via the
+/// real `LocalStore.setObserver` seam production composition uses (see
+/// `edge_gateway.zig`'s `nativeEarlyDataReplayMetricsObserver`). Never
+/// records anything beyond the bounded event tag itself.
+const EventRecorder = struct {
+    counts: [6]usize = .{0} ** 6,
+
+    fn indexOf(event: early_data_replay.Event) usize {
+        return switch (event) {
+            .accepted => 0,
+            .duplicate => 1,
+            .capacity_rejected => 2,
+            .expired => 3,
+            .unavailable => 4,
+            .startup_quarantine => 5,
+        };
+    }
+
+    fn count(self: *const EventRecorder, event: early_data_replay.Event) usize {
+        return self.counts[indexOf(event)];
+    }
+
+    fn onEvent(ctx: *anyopaque, event: early_data_replay.Event) void {
+        const self: *EventRecorder = @ptrCast(@alignCast(ctx));
+        self.counts[indexOf(event)] += 1;
+    }
+
+    fn observer(self: *EventRecorder) early_data_replay.Observer {
+        return .{ .ctx = self, .onEventFn = onEvent };
+    }
+};
+
 /// Runs one resumed "connection" (a fresh `DirectHarness`) offering a clone
 /// of `ticket` against `state`, with `gate` installed as the server's
-/// anti-replay gate, and — only on a real `EarlyDataDecision.accepted`
-/// outcome — increments `application_executions` exactly once. This models
-/// the production invariant (`http/early_data.zig`'s `decide()`: only
-/// `.execute_local`/`.forward_rfc8470`, which require an accepted
-/// TLS/replay decision, ever reach an application/upstream handler) without
-/// re-deriving it: the TLS decision itself is genuine production output,
-/// only the "did the application run" bookkeeping is test-local.
-fn runResumedConnectionCountingExecutions(
+/// anti-replay gate. Returns the harness so callers can assert on the real
+/// `EarlyDataDecision`, PSK/resumption state, and store occupancy.
+fn runResumedConnection(
     state: *session.ServerRecoverableState,
     ticket: *const session.ClientTicketState,
     gate: tls_backend.EarlyDataReplayGate,
-    application_executions: *usize,
 ) !*DirectHarness {
     const harness = try std.testing.allocator.create(DirectHarness);
     harness.* = DirectHarness.init();
@@ -8228,8 +8273,6 @@ fn runResumedConnectionCountingExecutions(
     try harness.server_backend.setEarlyDataReplayGate(gate);
 
     try harness.run();
-
-    if (harness.server_backend.earlyDataAccepted()) application_executions.* += 1;
     return harness;
 }
 
@@ -8250,12 +8293,14 @@ fn assertNoRawTicketInDiagnostic(candidate: tls_backend.EarlyDataReplayCandidate
     try std.testing.expect(std.mem.indexOf(u8, diagnostic, raw_ticket) == null);
 }
 
-test "#369 Slice 2 rt0.accept.first_use: accepted 0-RTT records the replay claim, executes the application exactly once, and leaks no raw ticket identity in diagnostics" {
+test "#369 Slice 2 rt0.accept.first_use: accepted 0-RTT records the replay claim, emits exactly one real accepted Event, and leaks no raw ticket identity in diagnostics" {
     var issued = try issueEarlyCapableTicket(32);
     defer issued.deinit();
 
     var store = try early_data_replay.LocalStore.init(std.testing.allocator, .{}, 0, 0);
     defer store.deinit();
+    var recorder = EventRecorder{};
+    store.setObserver(recorder.observer());
     var det_store = DeterministicNowStore{ .backing = &store, .now_unix_ms = 2_000 };
     var adapter = early_data_replay.GateAdapter.init(det_store.asStore());
     const inner_gate = adapter.gate();
@@ -8273,48 +8318,50 @@ test "#369 Slice 2 rt0.accept.first_use: accepted 0-RTT records the replay claim
     var capturing = CapturingGate{ .inner = inner_gate };
     const gate = tls_backend.EarlyDataReplayGate{ .ctx = &capturing, .decideFn = CapturingGate.decide };
 
-    var executions: usize = 0;
-    const harness = try runResumedConnectionCountingExecutions(&issued.server_state, &issued.ticket, gate, &executions);
+    const harness = try runResumedConnection(&issued.server_state, &issued.ticket, gate);
     defer destroyResumedConnection(harness);
 
     try std.testing.expect(harness.server_backend.core.psk_authenticated);
     try std.testing.expectEqual(tls_backend.EarlyDataDecision.accepted, harness.server_backend.earlyDataDecision());
-    try std.testing.expectEqual(@as(usize, 1), executions);
     // The replay claim was actually recorded — the store, not just the TLS
-    // decision, now has one live entry for this ticket's replay key.
+    // decision, now has one live entry for this ticket's replay key — and
+    // the real observer seam saw exactly one `.accepted` event.
     try std.testing.expectEqual(@as(usize, 1), store.count());
+    try std.testing.expectEqual(@as(usize, 1), recorder.count(.accepted));
+    try std.testing.expectEqual(@as(usize, 0), recorder.count(.duplicate));
 
     const seen = capturing.seen orelse return error.TestExpectedEqual;
     try assertNoRawTicketInDiagnostic(seen, "opaque-early-ticket");
 }
 
-test "#369 Slice 2 rt0.reject.duplicate: an exact-duplicate 0-RTT claim never executes the application, and the connection stays usable for a later distinct 1-RTT request" {
+test "#369 Slice 2 rt0.reject.duplicate: an exact-duplicate 0-RTT claim emits a real duplicate Event and never re-records the claim, and the connection stays usable for a later distinct 1-RTT request" {
     var issued = try issueEarlyCapableTicket(32);
     defer issued.deinit();
 
     var store = try early_data_replay.LocalStore.init(std.testing.allocator, .{}, 0, 0);
     defer store.deinit();
+    var recorder = EventRecorder{};
+    store.setObserver(recorder.observer());
     var det_store = DeterministicNowStore{ .backing = &store, .now_unix_ms = 2_000 };
     var adapter = early_data_replay.GateAdapter.init(det_store.asStore());
     const gate = adapter.gate();
 
-    var executions: usize = 0;
-
-    // First attempt: claim -> accepted, application executes once.
-    const first = try runResumedConnectionCountingExecutions(&issued.server_state, &issued.ticket, gate, &executions);
+    // First attempt: claim -> accepted.
+    const first = try runResumedConnection(&issued.server_state, &issued.ticket, gate);
     defer destroyResumedConnection(first);
     try std.testing.expectEqual(tls_backend.EarlyDataDecision.accepted, first.server_backend.earlyDataDecision());
-    try std.testing.expectEqual(@as(usize, 1), executions);
+    try std.testing.expectEqual(@as(usize, 1), recorder.count(.accepted));
 
     // Second attempt: the exact same logical replay identity (a clone of
     // the same ticket) reused on an independent connection -> claim ->
-    // duplicate, early request must NOT execute.
-    const second = try runResumedConnectionCountingExecutions(&issued.server_state, &issued.ticket, gate, &executions);
+    // duplicate.
+    const second = try runResumedConnection(&issued.server_state, &issued.ticket, gate);
     defer destroyResumedConnection(second);
     try std.testing.expectEqual(tls_backend.EarlyDataDecision.replay_rejected, second.server_backend.earlyDataDecision());
     try std.testing.expect(!second.server_backend.earlyDataAccepted());
-    // Total application executions across both attempts remain exactly one.
-    try std.testing.expectEqual(@as(usize, 1), executions);
+    try std.testing.expectEqual(@as(usize, 1), recorder.count(.duplicate));
+    // The accepted count never grows from the duplicate.
+    try std.testing.expectEqual(@as(usize, 1), recorder.count(.accepted));
     // The PSK/session is otherwise valid: the resumed handshake completed
     // as ordinary 1-RTT rather than becoming a fatal TLS failure.
     try std.testing.expect(second.client_driver.isComplete());
@@ -8328,23 +8375,21 @@ test "#369 Slice 2 rt0.reject.duplicate: an exact-duplicate 0-RTT claim never ex
     const request = try second.client_bridge.sealApplicationData("distinct 1-RTT request", &protected);
     const opened = try second.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, request), &plaintext);
     try std.testing.expectEqualStrings("distinct 1-RTT request", opened.inner.content);
-    // That distinct, intentionally-sent request is a genuine execution in
-    // its own right — bringing the total to two.
-    executions += 1;
-    try std.testing.expectEqual(@as(usize, 2), executions);
 
     // Only one replay key was ever recorded; the duplicate never created a
     // second entry.
     try std.testing.expectEqual(@as(usize, 1), store.count());
 }
 
-test "#369 Slice 2 rt0.reject.capacity: capacity exhaustion rejects only early execution and ordinary resumption continues" {
+test "#369 Slice 2 rt0.reject.capacity: capacity exhaustion emits a real capacity_rejected Event and ordinary resumption continues" {
     var issued = try issueEarlyCapableTicket(32);
     defer issued.deinit();
 
     // Deliberately small capacity: exactly one live entry fits.
     var store = try early_data_replay.LocalStore.init(std.testing.allocator, .{ .max_entries = 1 }, 0, 0);
     defer store.deinit();
+    var recorder = EventRecorder{};
+    store.setObserver(recorder.observer());
 
     // Fill the store's one slot with a distinct, valid replay claim first —
     // `issueEarlyCapableTicket` always mints the fixed identity
@@ -8356,40 +8401,39 @@ test "#369 Slice 2 rt0.reject.capacity: capacity exhaustion rejects only early e
     // is still a genuine production TLS/replay decision.
     const filler_key: early_data_replay.Key = [_]u8{0xaa} ** 32;
     try std.testing.expectEqual(early_data_replay.ClaimResult.accepted, store.claim(.{ .key = filler_key, .retain_until_unix_ms = std.math.maxInt(u64) }, 2_000));
+    try std.testing.expectEqual(@as(usize, 1), recorder.count(.accepted));
 
     var det_store = DeterministicNowStore{ .backing = &store, .now_unix_ms = 2_000 };
     var adapter = early_data_replay.GateAdapter.init(det_store.asStore());
     const gate = adapter.gate();
 
-    var executions: usize = 0;
-
     // A real, otherwise-valid 0-RTT request finds the store full: rejected
-    // with the typed capacity outcome, no application side effect, but the
-    // valid PSK connection still continues as ordinary 1-RTT.
-    const rejected = try runResumedConnectionCountingExecutions(&issued.server_state, &issued.ticket, gate, &executions);
+    // with the typed capacity outcome, but the valid PSK connection still
+    // continues as ordinary 1-RTT.
+    const rejected = try runResumedConnection(&issued.server_state, &issued.ticket, gate);
     defer destroyResumedConnection(rejected);
     try std.testing.expectEqual(tls_backend.EarlyDataDecision.replay_unavailable, rejected.server_backend.earlyDataDecision());
     try std.testing.expect(!rejected.server_backend.earlyDataAccepted());
-    try std.testing.expectEqual(@as(usize, 0), executions);
+    try std.testing.expectEqual(@as(usize, 1), recorder.count(.capacity_rejected));
+    // The filler's accept is the only accept ever recorded.
+    try std.testing.expectEqual(@as(usize, 1), recorder.count(.accepted));
     try std.testing.expect(rejected.client_driver.isComplete());
     try std.testing.expect(rejected.server_driver.isComplete());
     try std.testing.expect(rejected.server_backend.core.psk_authenticated);
 
-    // A later normal request over that connection succeeds exactly once.
+    // A later normal request over that connection succeeds.
     var protected: [record_codec.max_ciphertext_record_len]u8 = undefined;
     var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
     const request = try rejected.client_bridge.sealApplicationData("after capacity rejection", &protected);
     const opened = try rejected.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, request), &plaintext);
     try std.testing.expectEqualStrings("after capacity rejection", opened.inner.content);
-    executions += 1;
-    try std.testing.expectEqual(@as(usize, 1), executions);
 
     // Occupancy stays bounded at the configured capacity — the rejected
     // claim was never recorded.
     try std.testing.expectEqual(@as(usize, 1), store.count());
 }
 
-test "#369 Slice 2 rt0.reject.startup_quarantine: lost replay history after restart rejects early execution, and the exact quarantine boundary matches #368's documented (exclusive-end) semantics" {
+test "#369 Slice 2 rt0.reject.startup_quarantine: lost replay history after restart emits a real startup_quarantine Event distinguishable from duplicate, and the exact quarantine boundary matches #368's documented (exclusive-end) semantics" {
     var issued = try issueEarlyCapableTicket(32);
     defer issued.deinit();
 
@@ -8400,6 +8444,8 @@ test "#369 Slice 2 rt0.reject.startup_quarantine: lost replay history after rest
     // check) the boundary.
     var store = try early_data_replay.LocalStore.init(std.testing.allocator, .{}, 60_000, 2_000);
     defer store.deinit();
+    var recorder = EventRecorder{};
+    store.setObserver(recorder.observer());
 
     // now < quarantine_end -> reject early data (the "restart" case: a
     // fresh store with no shared history from the process that issued the
@@ -8407,16 +8453,16 @@ test "#369 Slice 2 rt0.reject.startup_quarantine: lost replay history after rest
     {
         var det_store = DeterministicNowStore{ .backing = &store, .now_unix_ms = 2_000 };
         var adapter = early_data_replay.GateAdapter.init(det_store.asStore());
-        var executions: usize = 0;
-        const harness = try runResumedConnectionCountingExecutions(&issued.server_state, &issued.ticket, adapter.gate(), &executions);
+        const harness = try runResumedConnection(&issued.server_state, &issued.ticket, adapter.gate());
         defer destroyResumedConnection(harness);
         try std.testing.expectEqual(tls_backend.EarlyDataDecision.replay_unavailable, harness.server_backend.earlyDataDecision());
         try std.testing.expect(!harness.server_backend.earlyDataAccepted());
-        try std.testing.expectEqual(@as(usize, 0), executions);
-        // The rejection reason is distinguishable from an ordinary
-        // duplicate at the store's own typed-outcome layer: nothing was
-        // recorded (a duplicate would imply a live entry), and the
-        // underlying valid resumption/full handshake continues normally.
+        // The real observer distinguishes startup quarantine from an
+        // ordinary duplicate: nothing was recorded (a duplicate would
+        // imply a live entry), and the underlying valid resumption/full
+        // handshake continues normally.
+        try std.testing.expectEqual(@as(usize, 1), recorder.count(.startup_quarantine));
+        try std.testing.expectEqual(@as(usize, 0), recorder.count(.duplicate));
         try std.testing.expectEqual(@as(usize, 0), store.count());
         try std.testing.expect(harness.client_driver.isComplete());
         try std.testing.expect(harness.server_driver.isComplete());
@@ -8439,15 +8485,14 @@ test "#369 Slice 2 rt0.reject.startup_quarantine: lost replay history after rest
         defer fresh_issued.deinit();
         var det_store = DeterministicNowStore{ .backing = &store, .now_unix_ms = 62_000 };
         var adapter = early_data_replay.GateAdapter.init(det_store.asStore());
-        var executions: usize = 0;
-        const harness = try runResumedConnectionCountingExecutions(&fresh_issued.server_state, &fresh_issued.ticket, adapter.gate(), &executions);
+        const harness = try runResumedConnection(&fresh_issued.server_state, &fresh_issued.ticket, adapter.gate());
         defer destroyResumedConnection(harness);
         try std.testing.expectEqual(tls_backend.EarlyDataDecision.accepted, harness.server_backend.earlyDataDecision());
-        try std.testing.expectEqual(@as(usize, 1), executions);
+        try std.testing.expectEqual(@as(usize, 1), recorder.count(.accepted));
     }
 }
 
-test "#369 Slice 2 rt0.reject.cross_worker_duplicate: worker A's accepted claim executes once; the same replay identity replayed through worker B never executes, over a real process-shared LocalStore" {
+test "#369 Slice 2 rt0.reject.cross_worker_duplicate: worker A's accepted claim emits one real accepted Event; the same replay identity replayed through worker B emits a real duplicate Event, over a real process-shared LocalStore" {
     // Models exactly what `edge_gateway.zig`'s composition actually shares
     // (one process-scoped `LocalStore`/`GateAdapter` handed by reference to
     // every native TCP worker and QUIC/H3 — see
@@ -8459,29 +8504,29 @@ test "#369 Slice 2 rt0.reject.cross_worker_duplicate: worker A's accepted claim 
 
     var store = try early_data_replay.LocalStore.init(std.testing.allocator, .{}, 0, 0);
     defer store.deinit();
+    var recorder = EventRecorder{};
+    store.setObserver(recorder.observer());
     var det_store = DeterministicNowStore{ .backing = &store, .now_unix_ms = 2_000 };
     var adapter = early_data_replay.GateAdapter.init(det_store.asStore());
     const shared_gate = adapter.gate();
 
-    var worker_a_executions: usize = 0;
-    var worker_b_executions: usize = 0;
-
     // Worker A: first claim of this ticket's replay key anywhere in the
-    // (simulated) process — accepted, application executes exactly once.
-    const worker_a = try runResumedConnectionCountingExecutions(&issued.server_state, &issued.ticket, shared_gate, &worker_a_executions);
+    // (simulated) process — accepted.
+    const worker_a = try runResumedConnection(&issued.server_state, &issued.ticket, shared_gate);
     defer destroyResumedConnection(worker_a);
     try std.testing.expectEqual(tls_backend.EarlyDataDecision.accepted, worker_a.server_backend.earlyDataDecision());
-    try std.testing.expectEqual(@as(usize, 1), worker_a_executions);
+    try std.testing.expectEqual(@as(usize, 1), recorder.count(.accepted));
 
     // Worker B: an independent backend instance — a different native TCP
     // worker/connection in production — offering the very same ticket. The
-    // process-shared store must reject worker B's early execution; it must
-    // never execute.
-    const worker_b = try runResumedConnectionCountingExecutions(&issued.server_state, &issued.ticket, shared_gate, &worker_b_executions);
+    // process-shared store must reject worker B's claim as a real
+    // duplicate, not merely a different in-memory decision.
+    const worker_b = try runResumedConnection(&issued.server_state, &issued.ticket, shared_gate);
     defer destroyResumedConnection(worker_b);
     try std.testing.expectEqual(tls_backend.EarlyDataDecision.replay_rejected, worker_b.server_backend.earlyDataDecision());
     try std.testing.expect(!worker_b.server_backend.earlyDataAccepted());
-    try std.testing.expectEqual(@as(usize, 0), worker_b_executions);
+    try std.testing.expectEqual(@as(usize, 1), recorder.count(.duplicate));
+    try std.testing.expectEqual(@as(usize, 1), recorder.count(.accepted));
     try std.testing.expect(worker_b.client_driver.isComplete());
     try std.testing.expect(worker_b.server_driver.isComplete());
     try std.testing.expect(worker_b.server_backend.core.psk_authenticated);


### PR DESCRIPTION
## Summary

Slice 2 of #369 (326-J). Slice 1 (#508) added deterministic in-process resumption scenario tests plus `docs/RESUMPTION_TEST_PLAN.md`. This slice moves assurance outward across the production TLS/replay-store/H1 early-data/retry surfaces that are currently wired, while explicitly leaving the remaining native TCP/H1 production 0-RTT enablement and provenance path tracked in #510.

Central invariant under test: a replay or anti-replay-store failure may reject early execution, but must never destroy an otherwise-valid PSK-resumed connection, and retry behavior must never execute an application request twice.

**#369 stays open** — this slice does not close it. Several scenarios remain explicitly deferred in `docs/RESUMPTION_TEST_PLAN.md`, including true end-to-end native TCP/H1 0-RTT dispatch from a production-issued early-capable ticket through production server policy, record provenance, and the H1 safety gate (#510).

### TLS / replay-store layer

`src/tls/tls13_backend_tests.zig` reuses the existing production TLS harness and a real `tls_core.early_data_replay.LocalStore`/`GateAdapter`. The tests now assert real observer/event metric deltas for accepted, duplicate, capacity-rejected, and startup-quarantine outcomes instead of deriving any application-execution counter from `earlyDataAccepted()` itself.

Covered scenarios:

- `rt0.accept.first_use`
- `rt0.reject.duplicate`
- `rt0.reject.capacity`
- `rt0.reject.startup_quarantine`
- `rt0.reject.cross_worker_duplicate`

### H1 dispatch / gateway composition

`src/edge_gateway.zig` adds tests next to the private production H1 orchestration and native replay composition helpers:

- `rt0.reject.unsafe_request` drives the real `executeH1PostPreflightOrchestration` with counting hooks and proves an unsafe early POST returns 425 before route/upstream dispatch.
- `rt0.reject.store_unavailable` drives the same `nativeEarlyDataReplayComposition` helper used by `run()` with deterministic inputs, proves disabled mode withholds store/gate options even when a native path exists, and builds a real `NativeTlsConnection` with the returned null replay gate so `Tls13Backend` retains its fail-closed default.

### Process-level retry

`src/process_early_data_integration_tests.zig` drives the real `gateway_proxy_runtime.runBufferedProxyAttempts` retry/425 state machine and the real production TCP HTTP client against a loopback upstream server. The responder uses bounded accept/read loops, reads headers through `\r\n\r\n`, joins before shared-state inspection, and verifies the first request carries `Early-Data: 1`, the retry drops it, the upstream executes exactly once, and real metrics distinguish the upstream 425 from the retry.

### Docs and follow-up

`docs/RESUMPTION_TEST_PLAN.md` records the slice coverage, documents the worker-thread-pinning test seam gap, and explicitly defers external interop, operational restart/rotation, soak/CI, QUIC-specific rejection fallback, and the true native TCP/H1 production 0-RTT path. #510 now owns the remaining native TCP production prerequisites: early-capable ticket advertisement, server early-data policy composition, record-read provenance propagation, and H1 safety-gate dispatch.

## Test plan

- [x] `zig fmt --check .`
- [x] `zig build test`

Refs #369
Refs #510