### PR TITLE
quic: add path/Retry mechanical primitives and PathManager validate/promote split (#387 Slice 1)

### DIFF
--- a/src/quic/cid.zig
+++ b/src/quic/cid.zig
@@ -109,6 +109,14 @@ pub const CidRoutingTable = struct {
         return null;
     }
 
+    /// Whether `cid` already has a route, without touching hit/miss metrics.
+    /// Use this for a collision preflight before advertising a freshly
+    /// generated candidate CID; `lookup()` would otherwise count every
+    /// preflight as a routing hit or miss the operator never asked about.
+    pub fn contains(self: *const CidRoutingTable, cid: ConnectionId) bool {
+        return self.routes.contains(cid);
+    }
+
     /// Remove a retired CID; retired CIDs must no longer route.
     pub fn remove(self: *CidRoutingTable, cid: ConnectionId) void {
         _ = self.routes.remove(cid);
@@ -519,6 +527,18 @@ test "routing table routes by DCID independent of any address and counts misses"
     try testing.expectEqual(@as(?u64, null), table.lookup(""));
     try testing.expectEqual(@as(u64, 3), table.metrics.routing_hits);
     try testing.expectEqual(@as(u64, 2), table.metrics.routing_misses);
+}
+
+test "contains checks collisions without moving hit/miss metrics" {
+    var table = CidRoutingTable.init(testing.allocator);
+    defer table.deinit();
+    const cid_a = try ConnectionId.init(&.{ 5, 5, 5, 5 });
+    try table.insert(cid_a, 1);
+
+    try testing.expect(table.contains(cid_a));
+    try testing.expect(!table.contains(try ConnectionId.init(&.{ 6, 6, 6, 6 })));
+    try testing.expectEqual(@as(u64, 0), table.metrics.routing_hits);
+    try testing.expectEqual(@as(u64, 0), table.metrics.routing_misses);
 }
 
 test "retired local CIDs stop routing and unknown retire sequences are violations" {

--- a/src/quic/config.zig
+++ b/src/quic/config.zig
@@ -110,7 +110,10 @@ pub const Config = struct {
             .initial_max_stream_data_uni = self.initial_max_stream_data_uni,
             .initial_max_streams_bidi = self.initial_max_streams_bidi,
             .initial_max_streams_uni = self.initial_max_streams_uni,
-            .disable_active_migration = self.migration_policy == .disabled,
+            // Only `.full` advertises active migration support; `.disabled`
+            // and `.nat_rebinding_only` both disable it, since NAT rebinding
+            // is validated port-only traffic, not client-initiated migration.
+            .disable_active_migration = self.migration_policy != .full,
         };
     }
 };
@@ -200,6 +203,10 @@ test "QUIC config validation rejects unsafe combinations" {
 test "migration policy maps to transport parameter" {
     const disabled = try (Config{ .migration_policy = .disabled }).transportParameters();
     const rebinding = try (Config{ .migration_policy = .nat_rebinding_only }).transportParameters();
+    const full = try (Config{ .migration_policy = .full }).transportParameters();
+    // Only `.full` permits client-initiated migration; NAT rebinding is
+    // validated port-only traffic handled independently of this parameter.
     try std.testing.expect(disabled.disable_active_migration);
-    try std.testing.expect(!rebinding.disable_active_migration);
+    try std.testing.expect(rebinding.disable_active_migration);
+    try std.testing.expect(!full.disable_active_migration);
 }

--- a/src/quic/frame.zig
+++ b/src/quic/frame.zig
@@ -344,6 +344,12 @@ const FrameWriter = struct {
         @memcpy(self.buf[self.pos..][0..data.len], data);
         self.pos += data.len;
     }
+
+    fn byte(self: *FrameWriter, value: u8) EncodeError!void {
+        if (self.buf.len - self.pos < 1) return error.BufferTooShort;
+        self.buf[self.pos] = value;
+        self.pos += 1;
+    }
 };
 
 pub fn encodePing(buf: []u8) EncodeError!usize {
@@ -448,6 +454,21 @@ pub fn encodePathResponse(data: [path_data_len]u8, buf: []u8) EncodeError!usize 
     var w = FrameWriter{ .buf = buf };
     try w.int(frame_path_response);
     try w.bytes(&data);
+    return w.pos;
+}
+
+/// Encode a NEW_CONNECTION_ID frame (type 0x18, RFC 9000 §19.15): sequence,
+/// retire_prior_to, a length-prefixed CID (single byte, not a varint), and
+/// the 16-byte stateless reset token.
+pub fn encodeNewConnectionId(value: cid.NewConnectionIdFrame, buf: []u8) EncodeError!usize {
+    var w = FrameWriter{ .buf = buf };
+    try w.int(frame_new_connection_id);
+    try w.int(value.sequence);
+    try w.int(value.retire_prior_to);
+    const cid_bytes = value.cid.slice();
+    try w.byte(@intCast(cid_bytes.len));
+    try w.bytes(cid_bytes);
+    try w.bytes(&value.stateless_reset_token);
     return w.pos;
 }
 
@@ -624,6 +645,34 @@ test "NEW_CONNECTION_ID and RETIRE_CONNECTION_ID roundtrip" {
     var buf: [16]u8 = undefined;
     const len = try encodeRetireConnectionId(7, &buf);
     try testing.expectEqual(@as(u64, 7), (try roundtripOne(buf[0..len])).retire_connection_id.sequence);
+}
+
+test "encodeNewConnectionId round-trips through decodeFrame" {
+    var buf: [64]u8 = undefined;
+    const value = cid.NewConnectionIdFrame{
+        .sequence = 3,
+        .retire_prior_to = 1,
+        .cid = try cid.ConnectionId.init(&[_]u8{ 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88 }),
+        .stateless_reset_token = [_]u8{0xee} ** cid.stateless_reset_token_len,
+    };
+    const len = try encodeNewConnectionId(value, &buf);
+    const decoded = try roundtripOne(buf[0..len]);
+    const ncid = decoded.new_connection_id.frame;
+    try testing.expectEqual(@as(u64, 3), ncid.sequence);
+    try testing.expectEqual(@as(u64, 1), ncid.retire_prior_to);
+    try testing.expectEqualSlices(u8, value.cid.slice(), ncid.cid.slice());
+    try testing.expectEqualSlices(u8, &value.stateless_reset_token, &ncid.stateless_reset_token);
+}
+
+test "encodeNewConnectionId fails deterministically on a too-short buffer" {
+    const value = cid.NewConnectionIdFrame{
+        .sequence = 0,
+        .retire_prior_to = 0,
+        .cid = try cid.ConnectionId.init(&[_]u8{ 1, 2, 3, 4 }),
+        .stateless_reset_token = [_]u8{0} ** cid.stateless_reset_token_len,
+    };
+    var tiny: [4]u8 = undefined;
+    try testing.expectError(error.BufferTooShort, encodeNewConnectionId(value, &tiny));
 }
 
 test "NEW_CONNECTION_ID with retire_prior_to above sequence is malformed" {

--- a/src/quic/packet.zig
+++ b/src/quic/packet.zig
@@ -286,29 +286,83 @@ const retry_integrity_key_v1 = [16]u8{
 const retry_integrity_nonce_v1 = [12]u8{
     0x46, 0x15, 0x99, 0xd3, 0x5d, 0x63, 0x2b, 0xf2, 0x23, 0x98, 0x25, 0xbb,
 };
+/// Largest Retry body (header + token, excluding the tag) this module builds
+/// a pseudo-packet for.
+const max_retry_pseudo_body_len = 1500;
+
+/// Compute the RFC 9001 §5.8 Retry integrity tag over the pseudo-packet
+/// (`ODCID length || ODCID || Retry packet without tag`). Shared by
+/// `writeRetryV1` (compute) and `verifyRetryIntegrity` (compare), so there is
+/// exactly one implementation of the AAD construction.
+fn computeRetryIntegrityTag(original_dcid: []const u8, retry_body: []const u8) error{ InvalidConnectionId, RetryBodyTooLong }![retry_integrity_tag_len]u8 {
+    if (original_dcid.len > max_cid_len) return error.InvalidConnectionId;
+    if (retry_body.len > max_retry_pseudo_body_len) return error.RetryBodyTooLong;
+    const Aes128Gcm = std.crypto.aead.aes_gcm.Aes128Gcm;
+
+    var pseudo: [1 + max_cid_len + max_retry_pseudo_body_len]u8 = undefined;
+    pseudo[0] = @intCast(original_dcid.len);
+    @memcpy(pseudo[1..][0..original_dcid.len], original_dcid);
+    @memcpy(pseudo[1 + original_dcid.len ..][0..retry_body.len], retry_body);
+    const aad = pseudo[0 .. 1 + original_dcid.len + retry_body.len];
+
+    var tag: [retry_integrity_tag_len]u8 = undefined;
+    var empty_out: [0]u8 = undefined;
+    Aes128Gcm.encrypt(&empty_out, &tag, "", aad, retry_integrity_nonce_v1, retry_integrity_key_v1);
+    return tag;
+}
 
 /// Verify the integrity tag of a parsed Retry packet against the DCID the
 /// client sent in its first Initial (RFC 9001 §5.8). `retry_packet` is the
 /// full packet including the tag.
 pub fn verifyRetryIntegrity(retry_packet: []const u8, original_dcid: []const u8) bool {
     if (retry_packet.len < retry_integrity_tag_len) return false;
-    if (original_dcid.len > max_cid_len) return false;
-    const Aes128Gcm = std.crypto.aead.aes_gcm.Aes128Gcm;
-
-    // Retry pseudo-packet: ODCID length + ODCID + Retry packet without tag.
-    var pseudo: [1 + max_cid_len + 1500]u8 = undefined;
     const body_len = retry_packet.len - retry_integrity_tag_len;
-    if (1 + original_dcid.len + body_len > pseudo.len) return false;
-    pseudo[0] = @intCast(original_dcid.len);
-    @memcpy(pseudo[1..][0..original_dcid.len], original_dcid);
-    @memcpy(pseudo[1 + original_dcid.len ..][0..body_len], retry_packet[0..body_len]);
-    const aad = pseudo[0 .. 1 + original_dcid.len + body_len];
-
-    var expected: [retry_integrity_tag_len]u8 = undefined;
-    var empty_out: [0]u8 = undefined;
-    Aes128Gcm.encrypt(&empty_out, &expected, "", aad, retry_integrity_nonce_v1, retry_integrity_key_v1);
+    const expected = computeRetryIntegrityTag(original_dcid, retry_packet[0..body_len]) catch return false;
     const received = retry_packet[body_len..][0..retry_integrity_tag_len];
     return std.crypto.timing_safe.eql([retry_integrity_tag_len]u8, expected, received.*);
+}
+
+/// Write a complete QUIC v1 Retry packet (RFC 9000 §17.2.5): first byte, the
+/// fixed `version = 1`, the Retry packet's DCID (the client's Initial SCID)
+/// and SCID (the server-chosen Retry SCID), the opaque token, and the
+/// trailing RFC 9001 §5.8 integrity tag computed over `original_dcid` and
+/// everything written before the tag. Retry packets are never coalesced and
+/// carry no packet number.
+pub fn writeRetryV1(
+    original_dcid: []const u8,
+    client_scid: []const u8,
+    retry_scid: []const u8,
+    token: []const u8,
+    out: []u8,
+) error{ BufferTooShort, InvalidConnectionId, RetryBodyTooLong }![]const u8 {
+    if (client_scid.len > max_cid_len or retry_scid.len > max_cid_len) return error.InvalidConnectionId;
+
+    var pos: usize = 0;
+    const header_len = 1 + 4 + 1 + client_scid.len + 1 + retry_scid.len + token.len;
+    if (out.len < header_len + retry_integrity_tag_len) return error.BufferTooShort;
+
+    // Long header, fixed bit set, type = 0b11 (Retry); the low 4 bits are
+    // unused for Retry and may be any value on send (RFC 9000 §17.2.5).
+    out[pos] = 0x80 | 0x40 | (0b11 << 4);
+    pos += 1;
+    std.mem.writeInt(u32, out[pos..][0..4], quic_v1, .big);
+    pos += 4;
+    // Retry DCID = the client's Initial SCID; Retry SCID = our fresh CID.
+    out[pos] = @intCast(client_scid.len);
+    pos += 1;
+    @memcpy(out[pos..][0..client_scid.len], client_scid);
+    pos += client_scid.len;
+    out[pos] = @intCast(retry_scid.len);
+    pos += 1;
+    @memcpy(out[pos..][0..retry_scid.len], retry_scid);
+    pos += retry_scid.len;
+    @memcpy(out[pos..][0..token.len], token);
+    pos += token.len;
+
+    const tag = try computeRetryIntegrityTag(original_dcid, out[0..pos]);
+    @memcpy(out[pos..][0..retry_integrity_tag_len], &tag);
+    pos += retry_integrity_tag_len;
+    return out[0..pos];
 }
 
 const testing = std.testing;
@@ -439,6 +493,53 @@ test "Retry packet parses and RFC 9001 A.4 integrity tag verifies" {
     var tampered = retry;
     tampered[tampered.len - 1] ^= 1;
     try testing.expect(!verifyRetryIntegrity(&tampered, &odcid));
+}
+
+test "writeRetryV1 round-trips through parsePacket and verifyRetryIntegrity" {
+    const odcid = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08 };
+    const client_scid = [_]u8{ 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8 };
+    const retry_scid = [_]u8{ 0xa1, 0xa2, 0xa3, 0xa4 };
+    const token = "opaque-retry-token";
+
+    var buf: [128]u8 = undefined;
+    const written = try writeRetryV1(&odcid, &client_scid, &retry_scid, token, &buf);
+
+    const parsed = try parsePacket(written, 8);
+    try testing.expectEqual(PacketKind.retry, parsed.kind);
+    try testing.expectEqual(quic_v1, parsed.version);
+    try testing.expectEqualSlices(u8, &client_scid, parsed.dcid);
+    try testing.expectEqualSlices(u8, &retry_scid, parsed.scid);
+    try testing.expectEqualStrings(token, parsed.retry_token);
+    try testing.expect(verifyRetryIntegrity(written, &odcid));
+
+    // Wrong ODCID must fail integrity verification.
+    try testing.expect(!verifyRetryIntegrity(written, &client_scid));
+
+    // Any tamper to the written packet must fail integrity verification.
+    var tampered: [128]u8 = undefined;
+    @memcpy(tampered[0..written.len], written);
+    tampered[written.len - 1] ^= 0x01;
+    try testing.expect(!verifyRetryIntegrity(tampered[0..written.len], &odcid));
+}
+
+test "writeRetryV1 rejects oversized connection IDs and short output buffers" {
+    const odcid = [_]u8{0x01} ** 8;
+    const client_scid = [_]u8{0x02} ** 8;
+    const retry_scid = [_]u8{0x03} ** 8;
+    const oversized_cid = [_]u8{0xff} ** (max_cid_len + 1);
+
+    var buf: [128]u8 = undefined;
+    try testing.expectError(error.InvalidConnectionId, writeRetryV1(&odcid, &oversized_cid, &retry_scid, "tok", &buf));
+    try testing.expectError(error.InvalidConnectionId, writeRetryV1(&odcid, &client_scid, &oversized_cid, "tok", &buf));
+
+    // A zero-length CID pair still round-trips, but a too-small output buffer
+    // must fail deterministically rather than write a truncated packet.
+    var tiny: [8]u8 = undefined;
+    try testing.expectError(error.BufferTooShort, writeRetryV1(&odcid, &client_scid, &retry_scid, "tok", &tiny));
+
+    var exact: [1 + 4 + 1 + 8 + 1 + 8 + 3 + retry_integrity_tag_len]u8 = undefined;
+    const written = try writeRetryV1(&odcid, &client_scid, &retry_scid, "tok", &exact);
+    try testing.expectEqual(exact.len, written.len);
 }
 
 test "version negotiation packet exposes the version list" {

--- a/src/quic/packet.zig
+++ b/src/quic/packet.zig
@@ -334,8 +334,14 @@ pub fn writeRetryV1(
     retry_scid: []const u8,
     token: []const u8,
     out: []u8,
-) error{ BufferTooShort, InvalidConnectionId, RetryBodyTooLong }![]const u8 {
+) error{ BufferTooShort, InvalidConnectionId, RetryBodyTooLong, EmptyToken, RetryScidNotDistinct }![]const u8 {
     if (client_scid.len > max_cid_len or retry_scid.len > max_cid_len) return error.InvalidConnectionId;
+    // A Retry with no token defeats the point of Retry (there is nothing for
+    // a conforming client to echo back), and a Retry SCID equal to the
+    // client's original DCID is indistinguishable from "no Retry happened" —
+    // #387 requires a server-chosen SCID distinct from it.
+    if (token.len == 0) return error.EmptyToken;
+    if (std.mem.eql(u8, original_dcid, retry_scid)) return error.RetryScidNotDistinct;
 
     var pos: usize = 0;
     const header_len = 1 + 4 + 1 + client_scid.len + 1 + retry_scid.len + token.len;
@@ -520,6 +526,20 @@ test "writeRetryV1 round-trips through parsePacket and verifyRetryIntegrity" {
     @memcpy(tampered[0..written.len], written);
     tampered[written.len - 1] ^= 0x01;
     try testing.expect(!verifyRetryIntegrity(tampered[0..written.len], &odcid));
+}
+
+test "writeRetryV1 rejects an empty token and a Retry SCID matching the client's original DCID" {
+    const odcid = [_]u8{0x01} ** 8;
+    const client_scid = [_]u8{0x02} ** 8;
+    const retry_scid = [_]u8{0x03} ** 8;
+    var buf: [128]u8 = undefined;
+
+    // An empty token gives a conforming client nothing to echo back.
+    try testing.expectError(error.EmptyToken, writeRetryV1(&odcid, &client_scid, &retry_scid, "", &buf));
+
+    // A Retry SCID identical to the client's original DCID is indistinguishable
+    // from no Retry having happened at all — the server must choose a fresh one.
+    try testing.expectError(error.RetryScidNotDistinct, writeRetryV1(&odcid, &client_scid, &odcid, "tok", &buf));
 }
 
 test "writeRetryV1 rejects oversized connection IDs and short output buffers" {

--- a/src/quic/path.zig
+++ b/src/quic/path.zig
@@ -493,7 +493,18 @@ pub const PathState = enum {
     unvalidated,
     /// PATH_CHALLENGE outstanding.
     validating,
-    /// PATH_RESPONSE echoed the challenge; the path is usable.
+    /// PATH_RESPONSE echoed the challenge, but the path has not yet been
+    /// promoted to active (RFC 9000 §9.5: host migration must claim a fresh
+    /// peer CID first). Distinct from `.validated` so a later authenticated
+    /// datagram on this exact path cannot be mistaken for "previously active,
+    /// safe to trust indefinitely" and does not discard the completed
+    /// validation by re-probing.
+    validated_pending_promotion,
+    /// The path is (or was) promoted to active. RFC 9000 §9.3 permits
+    /// skipping validation for a previously validated address only when it
+    /// has been seen *recently*; this implementation tracks no recency, so a
+    /// non-active `.validated` path is re-probed like `.unvalidated`/`.failed`
+    /// rather than trusted forever.
     validated,
     /// The challenge expired unanswered.
     failed,
@@ -669,10 +680,15 @@ pub const PathManager = struct {
                 // Already validated but not yet promoted (e.g. blocked
                 // earlier on a fresh peer CID): keep the completed validation
                 // intact instead of discarding it for a fresh challenge.
-                .validated => return .validated_pending_promotion,
-                // Fresh traffic on a previously failed/unvalidated tuple:
-                // start a new probe.
-                .failed, .unvalidated => {},
+                .validated_pending_promotion => return .validated_pending_promotion,
+                // A previously-active/validated-but-now-non-active path has
+                // no tracked recency (RFC 9000 §9.3 permits skipping
+                // validation only for a *recently* seen address), and its
+                // stored `change` may be stale relative to the current active
+                // path. Treat it the same as unvalidated/failed: start a
+                // fresh, conservative probe rather than trusting it — and
+                // silently reusing a stale `change` — indefinitely.
+                .failed, .unvalidated, .validated => {},
             }
             path.state = .validating;
             path.change = change;
@@ -702,15 +718,18 @@ pub const PathManager = struct {
     }
 
     /// Validate a PATH_RESPONSE received from `key` without promoting it to
-    /// the active path. On a match the candidate becomes `.validated`; the
-    /// caller decides when (or whether) to call `promoteValidated` — host
-    /// migration must claim a fresh peer CID first (RFC 9000 §9.5), so
-    /// validation and promotion cannot be one atomic step. A response with no
-    /// matching outstanding challenge — wrong payload, wrong path, or expired
-    /// — is ignored (null) and counted in `path_response_mismatches`:
-    /// responses do not validate paths they were not sent on (RFC 9000
-    /// §8.2.3), but the probe itself keeps waiting (only expiry fails it
-    /// terminally).
+    /// the active path. On a match the candidate becomes
+    /// `.validated_pending_promotion` — distinct from `.validated`, which
+    /// means "is or was the active path" — so `onDatagram` cannot mistake it
+    /// for a previously-active path and re-probe it out from under a pending
+    /// promotion. The caller decides when (or whether) to call
+    /// `promoteValidated` — host migration must claim a fresh peer CID first
+    /// (RFC 9000 §9.5), so validation and promotion cannot be one atomic
+    /// step. A response with no matching outstanding challenge — wrong
+    /// payload, wrong path, or expired — is ignored (null) and counted in
+    /// `path_response_mismatches`: responses do not validate paths they were
+    /// not sent on (RFC 9000 §8.2.3), but the probe itself keeps waiting
+    /// (only expiry fails it terminally).
     pub fn validatePathResponse(
         self: *PathManager,
         key: PathKey,
@@ -735,23 +754,25 @@ pub const PathManager = struct {
             return null;
         }
 
-        candidate.state = .validated;
+        candidate.state = .validated_pending_promotion;
         self.metrics.path_validations_succeeded += 1;
         return .{ .path = key, .change = candidate.change };
     }
 
-    /// Promote a path already marked `.validated` by `validatePathResponse`
-    /// to the active path, lifting its anti-amplification limit. Returns null
-    /// if `key` is not a validated candidate. For a host migration the caller
-    /// must claim a fresh peer CID before calling this (RFC 9000 §9.5); if
-    /// none is available, call `recordMigrationBlockedNoPeerCid` instead and
-    /// leave the candidate `.validated` so a later retry can promote it
-    /// without a new challenge round trip.
+    /// Promote a path already marked `.validated_pending_promotion` by
+    /// `validatePathResponse` to the active path, transitioning it to
+    /// `.validated` and lifting its anti-amplification limit. Returns null if
+    /// `key` is not a pending-promotion candidate. For a host migration the
+    /// caller must claim a fresh peer CID before calling this (RFC 9000
+    /// §9.5); if none is available, call `recordMigrationBlockedNoPeerCid`
+    /// instead and leave the candidate `.validated_pending_promotion` so a
+    /// later retry can promote it without a new challenge round trip.
     pub fn promoteValidated(self: *PathManager, key: PathKey) ?MigrationOutcome {
         const index = self.find(key) orelse return null;
         const candidate = &self.paths[index].?;
-        if (candidate.state != .validated) return null;
+        if (candidate.state != .validated_pending_promotion) return null;
 
+        candidate.state = .validated;
         candidate.anti_amplification.markValidated();
         self.active = index;
         switch (candidate.change) {
@@ -1205,11 +1226,43 @@ test "a validated candidate blocked on a peer CID survives further datagrams ins
     try testing.expect(manager.activePath().key.eql(migrated));
 }
 
+test "a previously-active validated path is re-probed, not trusted indefinitely" {
+    const a = testKey(50_000);
+    const b = testKey(50_001); // same host, new port: NAT rebinding
+    var manager = PathManager.init(.full, a, true);
+
+    // B validates and is promoted; A is now a non-active `.validated` path.
+    _ = manager.onDatagram(b, 1_200, test_challenge, 0);
+    _ = manager.validatePathResponse(b, test_challenge, 10).?;
+    _ = manager.promoteValidated(b).?;
+    try testing.expect(manager.activePath().key.eql(b));
+
+    // Traffic later arrives back on A. A previously-active `.validated` path
+    // must not be mistaken for a pending-first-promotion candidate: it is
+    // re-probed like any unvalidated/failed path (RFC 9000 §9.3 permits
+    // skipping validation only for a *recently* seen address, which this
+    // implementation does not track).
+    const decision = manager.onDatagram(a, 1_200, test_challenge, 20);
+    try testing.expect(decision == .probe);
+
+    // The fresh probe recomputes `change` relative to the *current* active
+    // path (B), so a stale `.migration` value from A's original
+    // initialization cannot make a plain port rebind look like a host
+    // migration once it re-validates.
+    const echoed = PathManager.onPathChallenge(decision.probe);
+    const validated = manager.validatePathResponse(a, echoed, 30).?;
+    try testing.expectEqual(AddressChange.nat_rebinding, validated.change);
+    const outcome = manager.promoteValidated(a).?;
+    try testing.expectEqual(AddressChange.nat_rebinding, outcome.change);
+    try testing.expect(!outcome.reset_congestion);
+}
+
 test "promoteValidated is null for a path that never validated" {
     var manager = PathManager.init(.full, testKey(50_000), true);
     try testing.expectEqual(@as(?MigrationOutcome, null), manager.promoteValidated(testKey(50_001)));
     _ = manager.onDatagram(testKey(50_001), 1_200, test_challenge, 0);
-    // Still only .validating, not .validated: promotion must not skip validation.
+    // Still only .validating, not .validated_pending_promotion: promotion
+    // must not skip validation.
     try testing.expectEqual(@as(?MigrationOutcome, null), manager.promoteValidated(testKey(50_001)));
 }
 

--- a/src/quic/path.zig
+++ b/src/quic/path.zig
@@ -526,6 +526,11 @@ pub const PathDecision = union(enum) {
     probe: [path_challenge_len]u8,
     /// Probe already in flight for this tuple; nothing new to send.
     probing,
+    /// The tuple already validated (via `validatePathResponse`) but has not
+    /// been promoted yet — e.g. a host migration blocked earlier on a fresh
+    /// peer CID. No new challenge is needed; the completed validation stays
+    /// intact and the caller may retry `promoteValidated`.
+    validated_pending_promotion,
     /// Migration policy forbids this address change: the caller drops state
     /// changes for this tuple (packets themselves stay processed on the
     /// active path per RFC 9000 §9.1 server behavior for disabled migration).
@@ -586,15 +591,6 @@ pub const PathManager = struct {
         self.paths[self.active].?.anti_amplification.markValidated();
     }
 
-    /// Record datagram bytes authenticated on `path` against that path's own
-    /// anti-amplification ledger. The caller must only call this after packet
-    /// protection succeeds — an unauthenticated datagram must never buy
-    /// candidate-path send budget. A no-op if `path` is not tracked.
-    pub fn recordReceivedOnPath(self: *PathManager, path: PathKey, bytes: u64) void {
-        const index = self.find(path) orelse return;
-        self.paths[index].?.anti_amplification.recordReceived(bytes);
-    }
-
     /// Record bytes sent on `path` against that path's own ledger. A no-op if
     /// `path` is not tracked.
     pub fn recordSentOnPath(self: *PathManager, path: PathKey, bytes: u64) void {
@@ -623,16 +619,32 @@ pub const PathManager = struct {
         return earliest;
     }
 
-    /// Classify a datagram's tuple and drive path state. `challenge_entropy`
-    /// supplies the unpredictable PATH_CHALLENGE payload (RFC 9000 §8.2.1)
+    /// Classify a datagram's tuple, credit `authenticated_bytes` against that
+    /// path's own anti-amplification ledger, and drive path state — all as
+    /// one operation, so the very first datagram on a brand-new candidate
+    /// path is accounted atomically with the path's creation. There is no
+    /// separate "record received bytes" step a caller could invoke before
+    /// the path exists: classification and accounting happen together here,
+    /// satisfying the required ingress order (authenticate, then credit and
+    /// classify) without forcing a two-call sequence that only works once the
+    /// path has already been seen.
+    ///
+    /// The caller must only pass datagrams whose packet protection already
+    /// succeeded (RFC 9000 §8.2.1) — an unauthenticated datagram must never
+    /// create a path slot or buy candidate-path send budget.
+    /// `challenge_entropy` supplies the unpredictable PATH_CHALLENGE payload
     /// when a probe starts.
     pub fn onDatagram(
         self: *PathManager,
         key: PathKey,
+        authenticated_bytes: u64,
         challenge_entropy: [path_challenge_len]u8,
         now_us: u64,
     ) PathDecision {
-        if (key.eql(self.paths[self.active].?.key)) return .on_active_path;
+        if (key.eql(self.paths[self.active].?.key)) {
+            self.paths[self.active].?.anti_amplification.recordReceived(authenticated_bytes);
+            return .on_active_path;
+        }
 
         const change: AddressChange = if (key.remote.sameHost(self.paths[self.active].?.key.remote))
             .nat_rebinding
@@ -651,14 +663,16 @@ pub const PathManager = struct {
 
         if (self.find(key)) |index| {
             const path = &self.paths[index].?;
+            path.anti_amplification.recordReceived(authenticated_bytes);
             switch (path.state) {
                 .validating => return .probing,
+                // Already validated but not yet promoted (e.g. blocked
+                // earlier on a fresh peer CID): keep the completed validation
+                // intact instead of discarding it for a fresh challenge.
+                .validated => return .validated_pending_promotion,
                 // Fresh traffic on a previously failed/unvalidated tuple:
                 // start a new probe.
                 .failed, .unvalidated => {},
-                // A validated non-active path re-activates only through a new
-                // challenge round trip, keeping the switch deterministic.
-                .validated => {},
             }
             path.state = .validating;
             path.change = change;
@@ -676,6 +690,7 @@ pub const PathManager = struct {
             .challenge = challenge_entropy,
             .challenge_deadline_us = now_us + self.validation_timeout_us,
         };
+        self.paths[slot].?.anti_amplification.recordReceived(authenticated_bytes);
         self.metrics.path_challenges_sent += 1;
         return .{ .probe = challenge_entropy };
     }
@@ -988,7 +1003,7 @@ const test_challenge = [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 };
 
 test "datagrams on the active path require no action" {
     var manager = PathManager.init(.full, testKey(50_000), true);
-    try testing.expectEqual(PathDecision.on_active_path, manager.onDatagram(testKey(50_000), test_challenge, 0));
+    try testing.expectEqual(PathDecision.on_active_path, manager.onDatagram(testKey(50_000), 1_200, test_challenge, 0));
     try testing.expectEqual(PathState.validated, manager.activePath().state);
 }
 
@@ -996,17 +1011,32 @@ test "an unvalidated initial path keeps its amplification budget until markActiv
     var manager = PathManager.init(.full, testKey(50_000), false);
     try testing.expect(!manager.activePath().anti_amplification.validated);
     try testing.expectEqual(PathState.validated, manager.activePath().state);
-    manager.recordReceivedOnPath(testKey(50_000), 1_000);
+    _ = manager.onDatagram(testKey(50_000), 1_000, test_challenge, 0);
     try testing.expect(!manager.canSendOnPath(testKey(50_000), 3_001));
     manager.markActiveValidated();
     try testing.expect(manager.canSendOnPath(testKey(50_000), std.math.maxInt(u64)));
+}
+
+test "the first authenticated datagram on a new candidate path credits its own budget atomically" {
+    var manager = PathManager.init(.full, testKey(50_000), true);
+    const candidate = testKeyOtherHost(50_000);
+    // No path exists yet, so there is no pre-authentication budget at all —
+    // the candidate cannot have been credited before it was even classified.
+    try testing.expect(!manager.canSendOnPath(candidate, 1));
+
+    // A single onDatagram call both creates the path and credits it: there is
+    // no separate step where a caller could try (and silently fail) to
+    // record bytes on a path that does not exist yet.
+    _ = manager.onDatagram(candidate, 1_200, test_challenge, 0);
+    try testing.expect(manager.canSendOnPath(candidate, 3_600));
+    try testing.expect(!manager.canSendOnPath(candidate, 3_601));
 }
 
 test "path validation succeeds deterministically and switches the active path" {
     var manager = PathManager.init(.full, testKey(50_000), true);
     const rebound = testKey(50_001); // same host, new port: NAT rebinding
 
-    const decision = manager.onDatagram(rebound, test_challenge, 1_000);
+    const decision = manager.onDatagram(rebound, 1_200, test_challenge, 1_000);
     try testing.expectEqualSlices(u8, &test_challenge, &decision.probe);
     try testing.expectEqual(@as(u64, 1), manager.metrics.path_challenges_sent);
 
@@ -1030,7 +1060,7 @@ test "a real migration validates and requires congestion/RTT reset" {
     var manager = PathManager.init(.full, testKey(50_000), true);
     const migrated = testKeyOtherHost(50_000); // new host: real migration
 
-    _ = manager.onDatagram(migrated, test_challenge, 0);
+    _ = manager.onDatagram(migrated, 1_200, test_challenge, 0);
     const validated = manager.validatePathResponse(migrated, test_challenge, 100).?;
     try testing.expectEqual(AddressChange.migration, validated.change);
     const outcome = manager.promoteValidated(migrated).?;
@@ -1063,7 +1093,7 @@ test "a real migration validates and requires congestion/RTT reset" {
 test "a wrong PATH_RESPONSE payload does not validate the path" {
     var manager = PathManager.init(.full, testKey(50_000), true);
     const rebound = testKey(50_001);
-    _ = manager.onDatagram(rebound, test_challenge, 0);
+    _ = manager.onDatagram(rebound, 1_200, test_challenge, 0);
 
     const wrong = [_]u8{0xff} ** path_challenge_len;
     try testing.expectEqual(@as(?ValidatedCandidate, null), manager.validatePathResponse(rebound, wrong, 100));
@@ -1083,7 +1113,7 @@ test "path validation fails deterministically when the challenge expires" {
     var manager = PathManager.init(.full, testKey(50_000), true);
     manager.validation_timeout_us = 1_000;
     const rebound = testKey(50_001);
-    _ = manager.onDatagram(rebound, test_challenge, 0);
+    _ = manager.onDatagram(rebound, 1_200, test_challenge, 0);
     try testing.expectEqual(@as(?u64, 1_000), manager.nextValidationDeadlineUs());
 
     // Not yet expired: nothing fails.
@@ -1095,36 +1125,36 @@ test "path validation fails deterministically when the challenge expires" {
     // A late response for the failed probe is ignored.
     try testing.expectEqual(@as(?ValidatedCandidate, null), manager.validatePathResponse(rebound, test_challenge, 1_002));
     // New traffic from the tuple restarts a probe.
-    const retry = manager.onDatagram(rebound, test_challenge, 2_000);
+    const retry = manager.onDatagram(rebound, 1_200, test_challenge, 2_000);
     try testing.expectEqualSlices(u8, &test_challenge, &retry.probe);
 }
 
 test "migration policy gates rebinding and migration separately" {
     // disabled: even a port-only rebinding is blocked.
     var disabled = PathManager.init(.disabled, testKey(50_000), true);
-    try testing.expectEqual(PathDecision.blocked, disabled.onDatagram(testKey(50_001), test_challenge, 0));
+    try testing.expectEqual(PathDecision.blocked, disabled.onDatagram(testKey(50_001), 1_200, test_challenge, 0));
     try testing.expectEqual(@as(u64, 1), disabled.metrics.migrations_blocked);
 
     // nat_rebinding_only: port change probes, host change is blocked.
     var rebind_only = PathManager.init(.nat_rebinding_only, testKey(50_000), true);
-    const probe = rebind_only.onDatagram(testKey(50_001), test_challenge, 0);
+    const probe = rebind_only.onDatagram(testKey(50_001), 1_200, test_challenge, 0);
     try testing.expectEqualSlices(u8, &test_challenge, &probe.probe);
-    try testing.expectEqual(PathDecision.blocked, rebind_only.onDatagram(testKeyOtherHost(50_000), test_challenge, 0));
+    try testing.expectEqual(PathDecision.blocked, rebind_only.onDatagram(testKeyOtherHost(50_000), 1_200, test_challenge, 0));
     try testing.expectEqual(@as(u64, 1), rebind_only.metrics.migrations_blocked);
 
     // full: both probe.
     var full = PathManager.init(.full, testKey(50_000), true);
-    const rebinding_probe = full.onDatagram(testKey(50_001), test_challenge, 0);
+    const rebinding_probe = full.onDatagram(testKey(50_001), 1_200, test_challenge, 0);
     try testing.expectEqualSlices(u8, &test_challenge, &rebinding_probe.probe);
-    const migration_probe = full.onDatagram(testKeyOtherHost(50_000), test_challenge, 0);
+    const migration_probe = full.onDatagram(testKeyOtherHost(50_000), 1_200, test_challenge, 0);
     try testing.expectEqualSlices(u8, &test_challenge, &migration_probe.probe);
 }
 
 test "duplicate datagrams on a probing path do not restart the challenge" {
     var manager = PathManager.init(.full, testKey(50_000), true);
     const rebound = testKey(50_001);
-    _ = manager.onDatagram(rebound, test_challenge, 0);
-    const again = manager.onDatagram(rebound, [_]u8{0xee} ** path_challenge_len, 10);
+    _ = manager.onDatagram(rebound, 1_200, test_challenge, 0);
+    const again = manager.onDatagram(rebound, 1_200, [_]u8{0xee} ** path_challenge_len, 10);
     try testing.expectEqual(PathDecision.probing, again);
     try testing.expectEqual(@as(u64, 1), manager.metrics.path_challenges_sent);
     // The original challenge still validates.
@@ -1134,7 +1164,7 @@ test "duplicate datagrams on a probing path do not restart the challenge" {
 test "host migration validates without promoting until the caller secures a fresh peer CID" {
     var manager = PathManager.init(.full, testKey(50_000), true);
     const migrated = testKeyOtherHost(50_000);
-    _ = manager.onDatagram(migrated, test_challenge, 0);
+    _ = manager.onDatagram(migrated, 1_200, test_challenge, 0);
 
     const validated = manager.validatePathResponse(migrated, test_challenge, 100).?;
     try testing.expectEqual(AddressChange.migration, validated.change);
@@ -1152,20 +1182,42 @@ test "host migration validates without promoting until the caller secures a fres
     try testing.expectEqual(@as(u64, 1), manager.metrics.migrations);
 }
 
+test "a validated candidate blocked on a peer CID survives further datagrams instead of re-probing" {
+    var manager = PathManager.init(.full, testKey(50_000), true);
+    const migrated = testKeyOtherHost(50_000);
+    _ = manager.onDatagram(migrated, 1_200, test_challenge, 0);
+    _ = manager.validatePathResponse(migrated, test_challenge, 100).?;
+    manager.recordMigrationBlockedNoPeerCid();
+    try testing.expectEqual(@as(u64, 1), manager.metrics.migrations_blocked_no_peer_cid);
+    try testing.expectEqual(@as(u64, 1), manager.metrics.path_challenges_sent);
+
+    // Another authenticated datagram arrives on the same still-validated
+    // candidate path (for example, carrying the NEW_CONNECTION_ID that will
+    // unblock it). It must not discard the completed validation and start a
+    // fresh challenge round trip.
+    const decision = manager.onDatagram(migrated, 300, test_challenge, 200);
+    try testing.expectEqual(PathDecision.validated_pending_promotion, decision);
+    try testing.expectEqual(@as(u64, 1), manager.metrics.path_challenges_sent);
+
+    // The still-validated candidate promotes without ever re-probing.
+    const outcome = manager.promoteValidated(migrated).?;
+    try testing.expect(outcome.reset_congestion);
+    try testing.expect(manager.activePath().key.eql(migrated));
+}
+
 test "promoteValidated is null for a path that never validated" {
     var manager = PathManager.init(.full, testKey(50_000), true);
     try testing.expectEqual(@as(?MigrationOutcome, null), manager.promoteValidated(testKey(50_001)));
-    _ = manager.onDatagram(testKey(50_001), test_challenge, 0);
+    _ = manager.onDatagram(testKey(50_001), 1_200, test_challenge, 0);
     // Still only .validating, not .validated: promotion must not skip validation.
     try testing.expectEqual(@as(?MigrationOutcome, null), manager.promoteValidated(testKey(50_001)));
 }
 
 test "per-path anti-amplification accounting does not leak between paths" {
     var manager = PathManager.init(.full, testKey(50_000), false);
-    manager.recordReceivedOnPath(testKey(50_000), 1_200);
+    _ = manager.onDatagram(testKey(50_000), 1_200, test_challenge, 0);
     const candidate = testKeyOtherHost(50_000);
-    _ = manager.onDatagram(candidate, test_challenge, 0);
-    manager.recordReceivedOnPath(candidate, 100);
+    _ = manager.onDatagram(candidate, 100, test_challenge, 0);
 
     // The active (still unvalidated) path's budget reflects only its own bytes.
     try testing.expect(manager.canSendOnPath(testKey(50_000), 3_600));
@@ -1184,10 +1236,10 @@ test "probe storms recycle probe slots but never the active path" {
     // More new tuples than slots: the oldest probes are recycled.
     var port: u16 = 50_001;
     while (port < 50_001 + 2 * max_paths) : (port += 1) {
-        _ = manager.onDatagram(testKey(port), test_challenge, 0);
+        _ = manager.onDatagram(testKey(port), 1_200, test_challenge, 0);
     }
     // The active path survived the storm and still routes.
     try testing.expect(manager.activePath().key.eql(testKey(50_000)));
     try testing.expectEqual(PathState.validated, manager.activePath().state);
-    try testing.expectEqual(PathDecision.on_active_path, manager.onDatagram(testKey(50_000), test_challenge, 0));
+    try testing.expectEqual(PathDecision.on_active_path, manager.onDatagram(testKey(50_000), 1_200, test_challenge, 0));
 }

--- a/src/quic/path.zig
+++ b/src/quic/path.zig
@@ -92,14 +92,18 @@ pub const TokenKind = enum(u8) {
 };
 
 /// Fixed-size prefix of the token plaintext: `kind(1) + version(4) +
-/// issued_at(8) + odcid_len(1)`. The connection ID, address, and port follow.
+/// issued_at(8) + odcid_len(1)`. The connection ID, Retry SCID, address, and
+/// port follow.
 const token_header_len = 1 + 4 + 8 + 1;
 /// Variable address suffix: `family(1) + addr_len(1) + addr(4|16) +
 /// scope_id(4, IPv6 only) + port(2)`.
 const token_addr_min_len = 1 + 1 + 4 + 2; // IPv4
 const token_addr_max_len = 1 + 1 + 16 + 4 + 2; // IPv6, with scope id
-const token_min_plaintext_len = token_header_len + 0 + token_addr_min_len;
-const token_max_plaintext_len = token_header_len + udp.MaxConnectionIdLen + token_addr_max_len;
+/// `retry_scid_len(1)` plus the CID bytes it prefixes.
+const token_retry_scid_min_len = 1;
+const token_retry_scid_max_len = 1 + udp.MaxConnectionIdLen;
+const token_min_plaintext_len = token_header_len + 0 + token_retry_scid_min_len + token_addr_min_len;
+const token_max_plaintext_len = token_header_len + udp.MaxConnectionIdLen + token_retry_scid_max_len + token_addr_max_len;
 
 /// Largest possible encoded token (`key_id + nonce + plaintext + tag`).
 pub const max_token_len = 1 + token_nonce_len + token_max_plaintext_len + token_tag_len;
@@ -144,11 +148,13 @@ pub const RetryTokenKeyRing = struct {
 };
 
 /// Context recovered from a validated Retry token. The connection layer needs
-/// the original destination connection ID and QUIC version to validate the
-/// Retry flow and populate/verify the `original_destination_connection_id`
-/// transport parameter (RFC 9000 §7.3).
+/// the original destination connection ID and Retry source connection ID to
+/// validate the Retry flow and populate/verify the
+/// `original_destination_connection_id` / `retry_source_connection_id`
+/// transport parameters (RFC 9000 §7.3), plus the QUIC version.
 pub const RetryContext = struct {
     original_dcid: udp.ConnectionId,
+    retry_scid: udp.ConnectionId,
     quic_version: u32,
 };
 
@@ -163,13 +169,14 @@ pub const RetryTokens = struct {
     /// validator's clock. Tokens further in the future are rejected.
     allowed_clock_skew_us: u64 = 0,
 
-    /// Seal a Retry token binding `original_dcid` + `quic_version` + `address`,
-    /// stamped at `issued_at_us`. `nonce` must be unique per token under the
-    /// current key (the caller supplies it so the module stays deterministic and
-    /// free of ambient randomness).
+    /// Seal a Retry token binding `original_dcid` + `retry_scid` +
+    /// `quic_version` + `address`, stamped at `issued_at_us`. `nonce` must be
+    /// unique per token under the current key (the caller supplies it so the
+    /// module stays deterministic and free of ambient randomness).
     pub fn issueRetry(
         self: *const RetryTokens,
         original_dcid: []const u8,
+        retry_scid: []const u8,
         quic_version: u32,
         address: udp.Address,
         issued_at_us: u64,
@@ -177,10 +184,11 @@ pub const RetryTokens = struct {
         out: []u8,
     ) error{ OutputTooSmall, NoTokenKey, ConnectionIdTooLong }![]u8 {
         if (original_dcid.len > udp.MaxConnectionIdLen) return error.ConnectionIdTooLong;
+        if (retry_scid.len > udp.MaxConnectionIdLen) return error.ConnectionIdTooLong;
         const key = self.keys.get(self.keys.current) orelse return error.NoTokenKey;
 
         var plaintext: [token_max_plaintext_len]u8 = undefined;
-        const plaintext_len = encodeTokenPlaintext(.retry, quic_version, original_dcid, address, issued_at_us, &plaintext);
+        const plaintext_len = encodeTokenPlaintext(.retry, quic_version, original_dcid, retry_scid, address, issued_at_us, &plaintext);
         const total = 1 + token_nonce_len + plaintext_len + token_tag_len;
         if (out.len < total) return error.OutputTooSmall;
 
@@ -218,7 +226,11 @@ pub const RetryTokens = struct {
         // backwards clock jump cannot make a stale token look freshly issued.
         if (decoded.issued_at_us > now_us +| self.allowed_clock_skew_us) return error.TokenExpired;
         if ((now_us -| decoded.issued_at_us) > self.lifetime_us) return error.TokenExpired;
-        return .{ .original_dcid = decoded.original_dcid, .quic_version = decoded.quic_version };
+        return .{
+            .original_dcid = decoded.original_dcid,
+            .retry_scid = decoded.retry_scid,
+            .quic_version = decoded.quic_version,
+        };
     }
 };
 
@@ -227,6 +239,7 @@ const DecodedToken = struct {
     quic_version: u32,
     issued_at_us: u64,
     original_dcid: udp.ConnectionId,
+    retry_scid: udp.ConnectionId,
     address: udp.Address,
 };
 
@@ -234,6 +247,7 @@ fn encodeTokenPlaintext(
     kind: TokenKind,
     quic_version: u32,
     original_dcid: []const u8,
+    retry_scid: []const u8,
     address: udp.Address,
     issued_at_us: u64,
     out: *[token_max_plaintext_len]u8,
@@ -249,6 +263,10 @@ fn encodeTokenPlaintext(
     pos += 1;
     @memcpy(out[pos..][0..original_dcid.len], original_dcid);
     pos += original_dcid.len;
+    out[pos] = @intCast(retry_scid.len);
+    pos += 1;
+    @memcpy(out[pos..][0..retry_scid.len], retry_scid);
+    pos += retry_scid.len;
 
     out[pos] = @intFromEnum(address.family);
     pos += 1;
@@ -284,6 +302,15 @@ fn decodeTokenPlaintext(bytes: []const u8) error{MalformedToken}!DecodedToken {
     @memcpy(original_dcid.bytes[0..odcid_len], bytes[pos..][0..odcid_len]);
     pos += odcid_len;
 
+    if (bytes.len - pos < 1) return error.MalformedToken;
+    const retry_scid_len = bytes[pos];
+    pos += 1;
+    if (retry_scid_len > udp.MaxConnectionIdLen) return error.MalformedToken;
+    if (bytes.len - pos < retry_scid_len) return error.MalformedToken;
+    var retry_scid = udp.ConnectionId{ .len = retry_scid_len };
+    @memcpy(retry_scid.bytes[0..retry_scid_len], bytes[pos..][0..retry_scid_len]);
+    pos += retry_scid_len;
+
     if (bytes.len - pos < 2) return error.MalformedToken;
     const family = std.enums.fromInt(udp.AddressFamily, bytes[pos]) orelse return error.MalformedToken;
     pos += 1;
@@ -311,6 +338,7 @@ fn decodeTokenPlaintext(bytes: []const u8) error{MalformedToken}!DecodedToken {
         .quic_version = quic_version,
         .issued_at_us = issued_at_us,
         .original_dcid = original_dcid,
+        .retry_scid = retry_scid,
         .address = address,
     };
 }
@@ -402,6 +430,11 @@ pub const Metrics = struct {
     nat_rebindings: u64 = 0,
     migrations: u64 = 0,
     migrations_blocked: u64 = 0,
+    /// A host migration validated but could not promote because the peer had
+    /// no unused CID to migrate to (RFC 9000 §9.5). Kept separate from
+    /// `migrations_blocked` (policy denial before any probe) because this
+    /// path already spent a validation round trip.
+    migrations_blocked_no_peer_cid: u64 = 0,
 
     pub fn recordRetrySent(self: *Metrics) void {
         self.retry_packets_sent += 1;
@@ -499,6 +532,13 @@ pub const PathDecision = union(enum) {
     blocked,
 };
 
+/// A candidate path whose PATH_RESPONSE validated, returned by
+/// `validatePathResponse` before any active-path mutation.
+pub const ValidatedCandidate = struct {
+    path: PathKey,
+    change: AddressChange,
+};
+
 /// Result of a successful path validation switch.
 pub const MigrationOutcome = struct {
     change: AddressChange,
@@ -518,21 +558,69 @@ pub const PathManager = struct {
     active: usize = 0,
     metrics: Metrics = .{},
 
-    /// Start with the handshake path: it is validated by the handshake itself
-    /// (RFC 9000 §8.1).
-    pub fn init(policy: config.MigrationPolicy, handshake_path: PathKey) PathManager {
+    /// Start with the handshake path as the active routing path. Its
+    /// anti-amplification ledger is only marked validated when
+    /// `initial_address_validated` is true (RFC 9000 §8.1): a non-Retry
+    /// server's initial path stays amplification-limited until the handshake
+    /// completes; Retry-validated server paths and every client initial path
+    /// begin validated.
+    pub fn init(policy: config.MigrationPolicy, handshake_path: PathKey, initial_address_validated: bool) PathManager {
         var manager = PathManager{ .policy = policy };
         manager.paths[0] = .{
             .key = handshake_path,
             .state = .validated,
             .change = .migration,
         };
-        manager.paths[0].?.anti_amplification.markValidated();
+        if (initial_address_validated) manager.paths[0].?.anti_amplification.markValidated();
         return manager;
     }
 
     pub fn activePath(self: *const PathManager) *const Path {
         return &self.paths[self.active].?;
+    }
+
+    /// Lift the active path's anti-amplification limit once its address is
+    /// validated some other way (e.g. a non-Retry server's handshake
+    /// completed). Prefer this over reaching into a connection-wide ledger.
+    pub fn markActiveValidated(self: *PathManager) void {
+        self.paths[self.active].?.anti_amplification.markValidated();
+    }
+
+    /// Record datagram bytes authenticated on `path` against that path's own
+    /// anti-amplification ledger. The caller must only call this after packet
+    /// protection succeeds — an unauthenticated datagram must never buy
+    /// candidate-path send budget. A no-op if `path` is not tracked.
+    pub fn recordReceivedOnPath(self: *PathManager, path: PathKey, bytes: u64) void {
+        const index = self.find(path) orelse return;
+        self.paths[index].?.anti_amplification.recordReceived(bytes);
+    }
+
+    /// Record bytes sent on `path` against that path's own ledger. A no-op if
+    /// `path` is not tracked.
+    pub fn recordSentOnPath(self: *PathManager, path: PathKey, bytes: u64) void {
+        const index = self.find(path) orelse return;
+        self.paths[index].?.anti_amplification.recordSent(bytes);
+    }
+
+    /// Whether `bytes` may be sent on `path` right now without exceeding that
+    /// path's own anti-amplification budget. An untracked path has no budget.
+    pub fn canSendOnPath(self: *const PathManager, path: PathKey, bytes: u64) bool {
+        const index = self.find(path) orelse return false;
+        return self.paths[index].?.anti_amplification.canSend(bytes);
+    }
+
+    /// Earliest deadline among paths with an outstanding PATH_CHALLENGE, or
+    /// null when nothing is validating. Callers fold this into their own
+    /// timer wheel (e.g. `Connection.nextTimeoutUs()`) so `expireValidations`
+    /// runs promptly instead of only on the next unrelated timeout.
+    pub fn nextValidationDeadlineUs(self: *const PathManager) ?u64 {
+        var earliest: ?u64 = null;
+        for (self.paths) |slot| {
+            const path = slot orelse continue;
+            if (path.state != .validating) continue;
+            if (earliest == null or path.challenge_deadline_us < earliest.?) earliest = path.challenge_deadline_us;
+        }
+        return earliest;
     }
 
     /// Classify a datagram's tuple and drive path state. `challenge_entropy`
@@ -598,49 +686,73 @@ pub const PathManager = struct {
         return data;
     }
 
-    /// Apply a PATH_RESPONSE received from `key`. On a match the path becomes
-    /// validated and active, and the outcome says whether congestion/RTT
-    /// state must reset. A response with no matching outstanding challenge —
-    /// wrong payload, wrong path, or expired — is ignored (null) and counted
-    /// in `path_response_mismatches`: responses do not validate paths they
-    /// were not sent on (RFC 9000 §8.2.3), but the probe itself keeps waiting
-    /// (only expiry fails it terminally).
-    pub fn onPathResponse(
+    /// Validate a PATH_RESPONSE received from `key` without promoting it to
+    /// the active path. On a match the candidate becomes `.validated`; the
+    /// caller decides when (or whether) to call `promoteValidated` — host
+    /// migration must claim a fresh peer CID first (RFC 9000 §9.5), so
+    /// validation and promotion cannot be one atomic step. A response with no
+    /// matching outstanding challenge — wrong payload, wrong path, or expired
+    /// — is ignored (null) and counted in `path_response_mismatches`:
+    /// responses do not validate paths they were not sent on (RFC 9000
+    /// §8.2.3), but the probe itself keeps waiting (only expiry fails it
+    /// terminally).
+    pub fn validatePathResponse(
         self: *PathManager,
         key: PathKey,
         data: [path_challenge_len]u8,
         now_us: u64,
-    ) ?MigrationOutcome {
+    ) ?ValidatedCandidate {
         const index = self.find(key) orelse {
             self.metrics.path_response_mismatches += 1;
             return null;
         };
-        const path = &self.paths[index].?;
-        if (path.state != .validating) {
+        const candidate = &self.paths[index].?;
+        if (candidate.state != .validating) {
             self.metrics.path_response_mismatches += 1;
             return null;
         }
-        if (now_us > path.challenge_deadline_us) {
-            self.failValidation(path);
+        if (now_us > candidate.challenge_deadline_us) {
+            self.failValidation(candidate);
             return null;
         }
-        if (!std.crypto.timing_safe.eql([path_challenge_len]u8, path.challenge, data)) {
+        if (!std.crypto.timing_safe.eql([path_challenge_len]u8, candidate.challenge, data)) {
             self.metrics.path_response_mismatches += 1;
             return null;
         }
 
-        path.state = .validated;
-        path.anti_amplification.markValidated();
-        self.active = index;
+        candidate.state = .validated;
         self.metrics.path_validations_succeeded += 1;
-        switch (path.change) {
+        return .{ .path = key, .change = candidate.change };
+    }
+
+    /// Promote a path already marked `.validated` by `validatePathResponse`
+    /// to the active path, lifting its anti-amplification limit. Returns null
+    /// if `key` is not a validated candidate. For a host migration the caller
+    /// must claim a fresh peer CID before calling this (RFC 9000 §9.5); if
+    /// none is available, call `recordMigrationBlockedNoPeerCid` instead and
+    /// leave the candidate `.validated` so a later retry can promote it
+    /// without a new challenge round trip.
+    pub fn promoteValidated(self: *PathManager, key: PathKey) ?MigrationOutcome {
+        const index = self.find(key) orelse return null;
+        const candidate = &self.paths[index].?;
+        if (candidate.state != .validated) return null;
+
+        candidate.anti_amplification.markValidated();
+        self.active = index;
+        switch (candidate.change) {
             .nat_rebinding => self.metrics.nat_rebindings += 1,
             .migration => self.metrics.migrations += 1,
         }
         return .{
-            .change = path.change,
-            .reset_congestion = path.change == .migration,
+            .change = candidate.change,
+            .reset_congestion = candidate.change == .migration,
         };
+    }
+
+    /// Count a host migration that validated but could not promote because no
+    /// fresh peer CID was available. The previous active path stays active.
+    pub fn recordMigrationBlockedNoPeerCid(self: *PathManager) void {
+        self.metrics.migrations_blocked_no_peer_cid += 1;
     }
 
     /// Fail every probe whose challenge deadline has passed. Returns how many
@@ -722,17 +834,19 @@ test "anti-amplification accounting saturates instead of overflowing" {
 }
 
 const test_odcid = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08 };
+const test_retry_scid = [_]u8{ 0xa1, 0xb2, 0xc3, 0xd4, 0xe5, 0xf6, 0x07, 0x18 };
 const test_version: u32 = 0x0000_0001;
 
-test "retry token round-trips and recovers the original DCID and version" {
+test "retry token round-trips and recovers the original DCID, Retry SCID, and version" {
     var tokens = RetryTokens{ .lifetime_us = 10_000_000 };
     tokens.keys.install(0, [_]u8{0xa5} ** token_key_len);
 
     var buf: [max_token_len]u8 = undefined;
-    const token = try tokens.issueRetry(&test_odcid, test_version, loopbackV4(4433), 1_000_000, [_]u8{0x11} ** token_nonce_len, &buf);
+    const token = try tokens.issueRetry(&test_odcid, &test_retry_scid, test_version, loopbackV4(4433), 1_000_000, [_]u8{0x11} ** token_nonce_len, &buf);
 
     const ctx = try tokens.validateRetry(token, loopbackV4(4433), 1_500_000);
     try testing.expectEqualSlices(u8, &test_odcid, ctx.original_dcid.slice());
+    try testing.expectEqualSlices(u8, &test_retry_scid, ctx.retry_scid.slice());
     try testing.expectEqual(test_version, ctx.quic_version);
 
     // A different port or host is a different path.
@@ -746,7 +860,7 @@ test "retry token binds scoped IPv6 addresses including the scope id" {
 
     const scoped = udp.Address.ip6([_]u8{0xfe} ++ [_]u8{0x80} ++ [_]u8{0} ** 13 ++ [_]u8{0x01}, 4433, 7);
     var buf: [max_token_len]u8 = undefined;
-    const token = try tokens.issueRetry(&test_odcid, test_version, scoped, 1_000_000, [_]u8{0x66} ** token_nonce_len, &buf);
+    const token = try tokens.issueRetry(&test_odcid, &test_retry_scid, test_version, scoped, 1_000_000, [_]u8{0x66} ** token_nonce_len, &buf);
 
     // Same address including scope id validates; a different scope id does not.
     _ = try tokens.validateRetry(token, scoped, 1_500_000);
@@ -759,7 +873,7 @@ test "retry token expires after its lifetime" {
     tokens.keys.install(1, [_]u8{0x5a} ** token_key_len);
 
     var buf: [max_token_len]u8 = undefined;
-    const token = try tokens.issueRetry(&test_odcid, test_version, loopbackV4(443), 2_000_000, [_]u8{0x22} ** token_nonce_len, &buf);
+    const token = try tokens.issueRetry(&test_odcid, &test_retry_scid, test_version, loopbackV4(443), 2_000_000, [_]u8{0x22} ** token_nonce_len, &buf);
 
     _ = try tokens.validateRetry(token, loopbackV4(443), 7_000_000); // exactly at the limit
     try testing.expectError(error.TokenExpired, tokens.validateRetry(token, loopbackV4(443), 7_000_001));
@@ -770,7 +884,7 @@ test "retry token dated in the future is rejected" {
     tokens.keys.install(0, [_]u8{0x7a} ** token_key_len);
 
     var buf: [max_token_len]u8 = undefined;
-    const token = try tokens.issueRetry(&test_odcid, test_version, loopbackV4(443), 5_000_000, [_]u8{0x77} ** token_nonce_len, &buf);
+    const token = try tokens.issueRetry(&test_odcid, &test_retry_scid, test_version, loopbackV4(443), 5_000_000, [_]u8{0x77} ** token_nonce_len, &buf);
 
     // Within the allowed skew: accepted (age saturates to zero).
     _ = try tokens.validateRetry(token, loopbackV4(443), 4_999_500);
@@ -783,7 +897,7 @@ test "retry token rejects tampering and unknown keys" {
     tokens.keys.install(0, [_]u8{0x01} ** token_key_len);
 
     var buf: [max_token_len]u8 = undefined;
-    const token = try tokens.issueRetry(&test_odcid, test_version, loopbackV4(4433), 1_000_000, [_]u8{0x33} ** token_nonce_len, &buf);
+    const token = try tokens.issueRetry(&test_odcid, &test_retry_scid, test_version, loopbackV4(4433), 1_000_000, [_]u8{0x33} ** token_nonce_len, &buf);
 
     // Flip a ciphertext byte: AEAD authentication must fail.
     var tampered: [max_token_len]u8 = undefined;
@@ -806,7 +920,7 @@ test "retry token survives key rotation while a key is retained" {
     tokens.keys.install(0, [_]u8{0x01} ** token_key_len);
 
     var buf: [max_token_len]u8 = undefined;
-    const token = try tokens.issueRetry(&test_odcid, test_version, loopbackV4(4433), 1_000_000, [_]u8{0x44} ** token_nonce_len, &buf);
+    const token = try tokens.issueRetry(&test_odcid, &test_retry_scid, test_version, loopbackV4(4433), 1_000_000, [_]u8{0x44} ** token_nonce_len, &buf);
 
     // Rotate to a new current key; the old key still validates prior tokens.
     tokens.keys.install(1, [_]u8{0x02} ** token_key_len);
@@ -847,7 +961,7 @@ test "metrics distinguish invalid tokens from normal retry usage" {
     var metrics = Metrics{};
 
     var buf: [max_token_len]u8 = undefined;
-    const token = try tokens.issueRetry(&test_odcid, test_version, loopbackV4(4433), 1_000_000, [_]u8{0x55} ** token_nonce_len, &buf);
+    const token = try tokens.issueRetry(&test_odcid, &test_retry_scid, test_version, loopbackV4(4433), 1_000_000, [_]u8{0x55} ** token_nonce_len, &buf);
     metrics.recordRetrySent();
 
     metrics.recordTokenValidation(tokens.validateRetry(token, loopbackV4(4433), 1_500_000)); // valid
@@ -873,13 +987,23 @@ fn testKeyOtherHost(remote_port: u16) PathKey {
 const test_challenge = [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 };
 
 test "datagrams on the active path require no action" {
-    var manager = PathManager.init(.full, testKey(50_000));
+    var manager = PathManager.init(.full, testKey(50_000), true);
     try testing.expectEqual(PathDecision.on_active_path, manager.onDatagram(testKey(50_000), test_challenge, 0));
     try testing.expectEqual(PathState.validated, manager.activePath().state);
 }
 
+test "an unvalidated initial path keeps its amplification budget until markActiveValidated" {
+    var manager = PathManager.init(.full, testKey(50_000), false);
+    try testing.expect(!manager.activePath().anti_amplification.validated);
+    try testing.expectEqual(PathState.validated, manager.activePath().state);
+    manager.recordReceivedOnPath(testKey(50_000), 1_000);
+    try testing.expect(!manager.canSendOnPath(testKey(50_000), 3_001));
+    manager.markActiveValidated();
+    try testing.expect(manager.canSendOnPath(testKey(50_000), std.math.maxInt(u64)));
+}
+
 test "path validation succeeds deterministically and switches the active path" {
-    var manager = PathManager.init(.full, testKey(50_000));
+    var manager = PathManager.init(.full, testKey(50_000), true);
     const rebound = testKey(50_001); // same host, new port: NAT rebinding
 
     const decision = manager.onDatagram(rebound, test_challenge, 1_000);
@@ -888,7 +1012,12 @@ test "path validation succeeds deterministically and switches the active path" {
 
     // Peer echoes the challenge (PATH_RESPONSE semantics are a pure echo).
     const echoed = PathManager.onPathChallenge(test_challenge);
-    const outcome = manager.onPathResponse(rebound, echoed, 2_000).?;
+    const validated = manager.validatePathResponse(rebound, echoed, 2_000).?;
+    try testing.expectEqual(AddressChange.nat_rebinding, validated.change);
+    // Validation alone does not promote the candidate.
+    try testing.expect(manager.activePath().key.eql(testKey(50_000)));
+
+    const outcome = manager.promoteValidated(rebound).?;
     try testing.expectEqual(AddressChange.nat_rebinding, outcome.change);
     // Port-only rebinding: same underlying path, keep congestion/RTT state.
     try testing.expect(!outcome.reset_congestion);
@@ -898,11 +1027,13 @@ test "path validation succeeds deterministically and switches the active path" {
 }
 
 test "a real migration validates and requires congestion/RTT reset" {
-    var manager = PathManager.init(.full, testKey(50_000));
+    var manager = PathManager.init(.full, testKey(50_000), true);
     const migrated = testKeyOtherHost(50_000); // new host: real migration
 
     _ = manager.onDatagram(migrated, test_challenge, 0);
-    const outcome = manager.onPathResponse(migrated, test_challenge, 100).?;
+    const validated = manager.validatePathResponse(migrated, test_challenge, 100).?;
+    try testing.expectEqual(AddressChange.migration, validated.change);
+    const outcome = manager.promoteValidated(migrated).?;
     try testing.expectEqual(AddressChange.migration, outcome.change);
     try testing.expect(outcome.reset_congestion);
     try testing.expectEqual(@as(u64, 1), manager.metrics.migrations);
@@ -930,14 +1061,14 @@ test "a real migration validates and requires congestion/RTT reset" {
 }
 
 test "a wrong PATH_RESPONSE payload does not validate the path" {
-    var manager = PathManager.init(.full, testKey(50_000));
+    var manager = PathManager.init(.full, testKey(50_000), true);
     const rebound = testKey(50_001);
     _ = manager.onDatagram(rebound, test_challenge, 0);
 
     const wrong = [_]u8{0xff} ** path_challenge_len;
-    try testing.expectEqual(@as(?MigrationOutcome, null), manager.onPathResponse(rebound, wrong, 100));
+    try testing.expectEqual(@as(?ValidatedCandidate, null), manager.validatePathResponse(rebound, wrong, 100));
     // A response on a different tuple does not validate the probed one either.
-    try testing.expectEqual(@as(?MigrationOutcome, null), manager.onPathResponse(testKeyOtherHost(1), test_challenge, 100));
+    try testing.expectEqual(@as(?ValidatedCandidate, null), manager.validatePathResponse(testKeyOtherHost(1), test_challenge, 100));
     // Still probing; the active path is unchanged. Both bogus responses are
     // counted as mismatches, not as terminal validation failures — the probe
     // can still succeed.
@@ -945,22 +1076,24 @@ test "a wrong PATH_RESPONSE payload does not validate the path" {
     try testing.expectEqual(@as(u64, 0), manager.metrics.path_validations_succeeded);
     try testing.expectEqual(@as(u64, 0), manager.metrics.path_validations_failed);
     try testing.expectEqual(@as(u64, 2), manager.metrics.path_response_mismatches);
-    try testing.expect(manager.onPathResponse(rebound, test_challenge, 200) != null);
+    try testing.expect(manager.validatePathResponse(rebound, test_challenge, 200) != null);
 }
 
 test "path validation fails deterministically when the challenge expires" {
-    var manager = PathManager.init(.full, testKey(50_000));
+    var manager = PathManager.init(.full, testKey(50_000), true);
     manager.validation_timeout_us = 1_000;
     const rebound = testKey(50_001);
     _ = manager.onDatagram(rebound, test_challenge, 0);
+    try testing.expectEqual(@as(?u64, 1_000), manager.nextValidationDeadlineUs());
 
     // Not yet expired: nothing fails.
     try testing.expectEqual(@as(usize, 0), manager.expireValidations(1_000));
     // Past the deadline: the probe fails and is counted.
     try testing.expectEqual(@as(usize, 1), manager.expireValidations(1_001));
     try testing.expectEqual(@as(u64, 1), manager.metrics.path_validations_failed);
+    try testing.expectEqual(@as(?u64, null), manager.nextValidationDeadlineUs());
     // A late response for the failed probe is ignored.
-    try testing.expectEqual(@as(?MigrationOutcome, null), manager.onPathResponse(rebound, test_challenge, 1_002));
+    try testing.expectEqual(@as(?ValidatedCandidate, null), manager.validatePathResponse(rebound, test_challenge, 1_002));
     // New traffic from the tuple restarts a probe.
     const retry = manager.onDatagram(rebound, test_challenge, 2_000);
     try testing.expectEqualSlices(u8, &test_challenge, &retry.probe);
@@ -968,19 +1101,19 @@ test "path validation fails deterministically when the challenge expires" {
 
 test "migration policy gates rebinding and migration separately" {
     // disabled: even a port-only rebinding is blocked.
-    var disabled = PathManager.init(.disabled, testKey(50_000));
+    var disabled = PathManager.init(.disabled, testKey(50_000), true);
     try testing.expectEqual(PathDecision.blocked, disabled.onDatagram(testKey(50_001), test_challenge, 0));
     try testing.expectEqual(@as(u64, 1), disabled.metrics.migrations_blocked);
 
     // nat_rebinding_only: port change probes, host change is blocked.
-    var rebind_only = PathManager.init(.nat_rebinding_only, testKey(50_000));
+    var rebind_only = PathManager.init(.nat_rebinding_only, testKey(50_000), true);
     const probe = rebind_only.onDatagram(testKey(50_001), test_challenge, 0);
     try testing.expectEqualSlices(u8, &test_challenge, &probe.probe);
     try testing.expectEqual(PathDecision.blocked, rebind_only.onDatagram(testKeyOtherHost(50_000), test_challenge, 0));
     try testing.expectEqual(@as(u64, 1), rebind_only.metrics.migrations_blocked);
 
     // full: both probe.
-    var full = PathManager.init(.full, testKey(50_000));
+    var full = PathManager.init(.full, testKey(50_000), true);
     const rebinding_probe = full.onDatagram(testKey(50_001), test_challenge, 0);
     try testing.expectEqualSlices(u8, &test_challenge, &rebinding_probe.probe);
     const migration_probe = full.onDatagram(testKeyOtherHost(50_000), test_challenge, 0);
@@ -988,18 +1121,66 @@ test "migration policy gates rebinding and migration separately" {
 }
 
 test "duplicate datagrams on a probing path do not restart the challenge" {
-    var manager = PathManager.init(.full, testKey(50_000));
+    var manager = PathManager.init(.full, testKey(50_000), true);
     const rebound = testKey(50_001);
     _ = manager.onDatagram(rebound, test_challenge, 0);
     const again = manager.onDatagram(rebound, [_]u8{0xee} ** path_challenge_len, 10);
     try testing.expectEqual(PathDecision.probing, again);
     try testing.expectEqual(@as(u64, 1), manager.metrics.path_challenges_sent);
     // The original challenge still validates.
-    try testing.expect(manager.onPathResponse(rebound, test_challenge, 20) != null);
+    try testing.expect(manager.validatePathResponse(rebound, test_challenge, 20) != null);
+}
+
+test "host migration validates without promoting until the caller secures a fresh peer CID" {
+    var manager = PathManager.init(.full, testKey(50_000), true);
+    const migrated = testKeyOtherHost(50_000);
+    _ = manager.onDatagram(migrated, test_challenge, 0);
+
+    const validated = manager.validatePathResponse(migrated, test_challenge, 100).?;
+    try testing.expectEqual(AddressChange.migration, validated.change);
+    // No fresh peer CID: the caller does not promote, just counts the block.
+    manager.recordMigrationBlockedNoPeerCid();
+    try testing.expectEqual(@as(u64, 1), manager.metrics.migrations_blocked_no_peer_cid);
+    try testing.expectEqual(@as(u64, 0), manager.metrics.migrations);
+    try testing.expect(manager.activePath().key.eql(testKey(50_000)));
+
+    // The peer later issues a fresh CID: the already-validated candidate
+    // promotes without a new challenge round trip.
+    const outcome = manager.promoteValidated(migrated).?;
+    try testing.expect(outcome.reset_congestion);
+    try testing.expect(manager.activePath().key.eql(migrated));
+    try testing.expectEqual(@as(u64, 1), manager.metrics.migrations);
+}
+
+test "promoteValidated is null for a path that never validated" {
+    var manager = PathManager.init(.full, testKey(50_000), true);
+    try testing.expectEqual(@as(?MigrationOutcome, null), manager.promoteValidated(testKey(50_001)));
+    _ = manager.onDatagram(testKey(50_001), test_challenge, 0);
+    // Still only .validating, not .validated: promotion must not skip validation.
+    try testing.expectEqual(@as(?MigrationOutcome, null), manager.promoteValidated(testKey(50_001)));
+}
+
+test "per-path anti-amplification accounting does not leak between paths" {
+    var manager = PathManager.init(.full, testKey(50_000), false);
+    manager.recordReceivedOnPath(testKey(50_000), 1_200);
+    const candidate = testKeyOtherHost(50_000);
+    _ = manager.onDatagram(candidate, test_challenge, 0);
+    manager.recordReceivedOnPath(candidate, 100);
+
+    // The active (still unvalidated) path's budget reflects only its own bytes.
+    try testing.expect(manager.canSendOnPath(testKey(50_000), 3_600));
+    try testing.expect(!manager.canSendOnPath(testKey(50_000), 3_601));
+    // The candidate path has its own, much smaller budget.
+    try testing.expect(manager.canSendOnPath(candidate, 300));
+    try testing.expect(!manager.canSendOnPath(candidate, 301));
+    manager.recordSentOnPath(candidate, 300);
+    try testing.expect(!manager.canSendOnPath(candidate, 1));
+    // An untracked path has no budget at all.
+    try testing.expect(!manager.canSendOnPath(testKeyOtherHost(1), 1));
 }
 
 test "probe storms recycle probe slots but never the active path" {
-    var manager = PathManager.init(.full, testKey(50_000));
+    var manager = PathManager.init(.full, testKey(50_000), true);
     // More new tuples than slots: the oldest probes are recycled.
     var port: u16 = 50_001;
     while (port < 50_001 + 2 * max_paths) : (port += 1) {

--- a/src/quic/path.zig
+++ b/src/quic/path.zig
@@ -657,10 +657,7 @@ pub const PathManager = struct {
             return .on_active_path;
         }
 
-        const change: AddressChange = if (key.remote.sameHost(self.paths[self.active].?.key.remote))
-            .nat_rebinding
-        else
-            .migration;
+        const change = self.classifyAgainstActive(key);
 
         const allowed = switch (self.policy) {
             .disabled => false,
@@ -674,6 +671,14 @@ pub const PathManager = struct {
 
         if (self.find(key)) |index| {
             const path = &self.paths[index].?;
+            // A previously-active path being re-probed starts a genuinely
+            // fresh validation attempt: its old anti-amplification
+            // validation must not carry over, or canSendOnPath() would stay
+            // unlimited throughout the new attempt even though this code
+            // deliberately chose not to skip validation (RFC 9000 §9.3.1).
+            // A path still mid-validation or awaiting promotion keeps its
+            // ledger untouched — it either hasn't validated yet or just did.
+            if (path.state == .validated) path.anti_amplification = .{};
             path.anti_amplification.recordReceived(authenticated_bytes);
             switch (path.state) {
                 .validating => return .probing,
@@ -726,14 +731,19 @@ pub const PathManager = struct {
     /// 9000 §8.2.3: a successful PATH_RESPONSE permits sending beyond the 3x
     /// limit even before migration/promotion happens), so a host migration
     /// blocked later on a fresh peer CID is not also stuck amplification
-    /// limited. The caller decides when (or whether) to call
-    /// `promoteValidated` — host migration must claim a fresh peer CID first
-    /// (RFC 9000 §9.5), so validation and promotion cannot be one atomic
-    /// step. A response with no matching outstanding challenge — wrong
-    /// payload, wrong path, or expired — is ignored (null) and counted in
-    /// `path_response_mismatches`: responses do not validate paths they were
-    /// not sent on (RFC 9000 §8.2.3), but the probe itself keeps waiting
-    /// (only expiry fails it terminally).
+    /// limited. The returned (and stored) `change` is recomputed against the
+    /// active path *right now*, not the value captured when the challenge
+    /// started — another candidate can promote while this one's challenge was
+    /// outstanding, which changes what "migration" vs. "rebinding" means for
+    /// it. `promotionChange` covers the same staleness for a promotion
+    /// delayed *after* this call returns. The caller decides when (or
+    /// whether) to call `promoteValidated` — host migration must claim a
+    /// fresh peer CID first (RFC 9000 §9.5), so validation and promotion
+    /// cannot be one atomic step. A response with no matching outstanding
+    /// challenge — wrong payload, wrong path, or expired — is ignored (null)
+    /// and counted in `path_response_mismatches`: responses do not validate
+    /// paths they were not sent on (RFC 9000 §8.2.3), but the probe itself
+    /// keeps waiting (only expiry fails it terminally).
     pub fn validatePathResponse(
         self: *PathManager,
         key: PathKey,
@@ -760,6 +770,7 @@ pub const PathManager = struct {
 
         candidate.state = .validated_pending_promotion;
         candidate.anti_amplification.markValidated();
+        candidate.change = self.classifyAgainstActive(key);
         self.metrics.path_validations_succeeded += 1;
         return .{ .path = key, .change = candidate.change };
     }
@@ -767,10 +778,10 @@ pub const PathManager = struct {
     /// The current NAT-rebinding-vs-migration classification of a
     /// `.validated_pending_promotion` candidate, recomputed against
     /// `activePath()` right now rather than returning the (possibly stale)
-    /// classification stored from when the candidate was first probed.
-    /// `PathManager` allows several pending candidates at once; if a
-    /// different one is promoted first, an older candidate's relationship to
-    /// the *new* active path can differ from its stored `change` (e.g. two
+    /// classification stored from when the candidate was first probed or last
+    /// validated. `PathManager` allows several pending candidates at once; if
+    /// a different one is promoted first, an older candidate's relationship
+    /// to the *new* active path can differ from its stored `change` (e.g. two
     /// candidates on the same host: once one promotes, the other is only a
     /// port rebind relative to it). Call this immediately before deciding
     /// whether a fresh peer CID is required and before promoting. Returns
@@ -778,6 +789,14 @@ pub const PathManager = struct {
     pub fn promotionChange(self: *const PathManager, key: PathKey) ?AddressChange {
         const index = self.find(key) orelse return null;
         if (self.paths[index].?.state != .validated_pending_promotion) return null;
+        return self.classifyAgainstActive(key);
+    }
+
+    /// Classify `key` as a NAT rebinding or a host migration relative to the
+    /// *current* active path. The one implementation shared by `onDatagram`,
+    /// `validatePathResponse`, and `promotionChange`, so "recompute against
+    /// the active path right now" always means the same thing.
+    fn classifyAgainstActive(self: *const PathManager, key: PathKey) AddressChange {
         return if (key.remote.sameHost(self.activePath().key.remote))
             .nat_rebinding
         else
@@ -1300,6 +1319,61 @@ test "a pending candidate's promotion classification is recomputed against the c
     try testing.expect(manager.activePath().key.eql(b));
     try testing.expectEqual(@as(u64, 1), manager.metrics.nat_rebindings);
     try testing.expectEqual(@as(u64, 1), manager.metrics.migrations);
+}
+
+test "validatePathResponse returns the current classification, not the one captured when the challenge started" {
+    var manager = PathManager.init(.full, testKey(50_000), true); // A active
+    const b = testKeyOtherHost(50_001);
+    const c = testKeyOtherHost(50_002); // same host as B, different port
+
+    // B and C both start validating while A is active: both would classify
+    // as migrations relative to A.
+    _ = manager.onDatagram(b, 1_200, test_challenge, 0);
+    _ = manager.onDatagram(c, 1_200, test_challenge, 0);
+
+    // C's PATH_RESPONSE arrives first and promotes it before B's does.
+    _ = manager.validatePathResponse(c, test_challenge, 10).?;
+    _ = manager.promoteValidated(c).?;
+    try testing.expect(manager.activePath().key.eql(c));
+
+    // B's PATH_RESPONSE arrives only now, after C is already active. B
+    // shares C's host, so it must be reported as a NAT rebinding relative to
+    // the *current* active path — not the `.migration` its challenge started
+    // as — the instant validation succeeds, not only via a later
+    // `promotionChange` query.
+    const validated_b = manager.validatePathResponse(b, test_challenge, 20).?;
+    try testing.expectEqual(AddressChange.nat_rebinding, validated_b.change);
+
+    const outcome_b = manager.promoteValidated(b).?;
+    try testing.expectEqual(AddressChange.nat_rebinding, outcome_b.change);
+    try testing.expect(!outcome_b.reset_congestion);
+}
+
+test "re-probing a previously-active validated path resets its stale anti-amplification ledger" {
+    const a = testKey(50_000);
+    const b = testKeyOtherHost(50_001);
+    var manager = PathManager.init(.full, a, true);
+
+    // B validates and promotes; A becomes a non-active `.validated` path
+    // whose ledger was marked validated (unlimited) during its own tenure as
+    // the active path.
+    _ = manager.onDatagram(b, 1_200, test_challenge, 0);
+    _ = manager.validatePathResponse(b, test_challenge, 10).?;
+    _ = manager.promoteValidated(b).?;
+    try testing.expect(manager.activePath().key.eql(b));
+
+    // Traffic returns to A: it is re-probed (a previously-active path has no
+    // tracked recency), and its old "unlimited" ledger must not survive into
+    // the new validation attempt — the budget reflects only the fresh
+    // datagram's 100 bytes.
+    const decision = manager.onDatagram(a, 100, test_challenge, 20);
+    try testing.expect(decision == .probe);
+    try testing.expect(manager.canSendOnPath(a, 300));
+    try testing.expect(!manager.canSendOnPath(a, 301));
+
+    // Once A re-validates, its ledger is unlimited again.
+    _ = manager.validatePathResponse(a, test_challenge, 30).?;
+    try testing.expect(manager.canSendOnPath(a, std.math.maxInt(u64)));
 }
 
 test "a previously-active validated path is re-probed, not trusted indefinitely" {

--- a/src/quic/path.zig
+++ b/src/quic/path.zig
@@ -722,7 +722,11 @@ pub const PathManager = struct {
     /// `.validated_pending_promotion` — distinct from `.validated`, which
     /// means "is or was the active path" — so `onDatagram` cannot mistake it
     /// for a previously-active path and re-probe it out from under a pending
-    /// promotion. The caller decides when (or whether) to call
+    /// promotion. Its anti-amplification limit is lifted immediately (RFC
+    /// 9000 §8.2.3: a successful PATH_RESPONSE permits sending beyond the 3x
+    /// limit even before migration/promotion happens), so a host migration
+    /// blocked later on a fresh peer CID is not also stuck amplification
+    /// limited. The caller decides when (or whether) to call
     /// `promoteValidated` — host migration must claim a fresh peer CID first
     /// (RFC 9000 §9.5), so validation and promotion cannot be one atomic
     /// step. A response with no matching outstanding challenge — wrong
@@ -755,33 +759,56 @@ pub const PathManager = struct {
         }
 
         candidate.state = .validated_pending_promotion;
+        candidate.anti_amplification.markValidated();
         self.metrics.path_validations_succeeded += 1;
         return .{ .path = key, .change = candidate.change };
     }
 
+    /// The current NAT-rebinding-vs-migration classification of a
+    /// `.validated_pending_promotion` candidate, recomputed against
+    /// `activePath()` right now rather than returning the (possibly stale)
+    /// classification stored from when the candidate was first probed.
+    /// `PathManager` allows several pending candidates at once; if a
+    /// different one is promoted first, an older candidate's relationship to
+    /// the *new* active path can differ from its stored `change` (e.g. two
+    /// candidates on the same host: once one promotes, the other is only a
+    /// port rebind relative to it). Call this immediately before deciding
+    /// whether a fresh peer CID is required and before promoting. Returns
+    /// null if `key` is not a pending-promotion candidate.
+    pub fn promotionChange(self: *const PathManager, key: PathKey) ?AddressChange {
+        const index = self.find(key) orelse return null;
+        if (self.paths[index].?.state != .validated_pending_promotion) return null;
+        return if (key.remote.sameHost(self.activePath().key.remote))
+            .nat_rebinding
+        else
+            .migration;
+    }
+
     /// Promote a path already marked `.validated_pending_promotion` by
     /// `validatePathResponse` to the active path, transitioning it to
-    /// `.validated` and lifting its anti-amplification limit. Returns null if
-    /// `key` is not a pending-promotion candidate. For a host migration the
-    /// caller must claim a fresh peer CID before calling this (RFC 9000
-    /// §9.5); if none is available, call `recordMigrationBlockedNoPeerCid`
-    /// instead and leave the candidate `.validated_pending_promotion` so a
-    /// later retry can promote it without a new challenge round trip.
+    /// `.validated`. The returned outcome uses `promotionChange`'s current
+    /// classification, not the stored (possibly stale) one, since another
+    /// candidate may have promoted in the meantime. Returns null if `key` is
+    /// not a pending-promotion candidate. For a host migration the caller
+    /// must claim a fresh peer CID before calling this (RFC 9000 §9.5); if
+    /// none is available, call `recordMigrationBlockedNoPeerCid` instead and
+    /// leave the candidate `.validated_pending_promotion` so a later retry
+    /// can promote it without a new challenge round trip.
     pub fn promoteValidated(self: *PathManager, key: PathKey) ?MigrationOutcome {
-        const index = self.find(key) orelse return null;
+        const change = self.promotionChange(key) orelse return null;
+        const index = self.find(key).?;
         const candidate = &self.paths[index].?;
-        if (candidate.state != .validated_pending_promotion) return null;
 
         candidate.state = .validated;
-        candidate.anti_amplification.markValidated();
+        candidate.change = change;
         self.active = index;
-        switch (candidate.change) {
+        switch (change) {
             .nat_rebinding => self.metrics.nat_rebindings += 1,
             .migration => self.metrics.migrations += 1,
         }
         return .{
-            .change = candidate.change,
-            .reset_congestion = candidate.change == .migration,
+            .change = change,
+            .reset_congestion = change == .migration,
         };
     }
 
@@ -1224,6 +1251,55 @@ test "a validated candidate blocked on a peer CID survives further datagrams ins
     const outcome = manager.promoteValidated(migrated).?;
     try testing.expect(outcome.reset_congestion);
     try testing.expect(manager.activePath().key.eql(migrated));
+}
+
+test "validatePathResponse lifts the candidate's anti-amplification limit immediately, not only on promotion" {
+    var manager = PathManager.init(.full, testKey(50_000), true);
+    const migrated = testKeyOtherHost(50_000);
+    // A small receive credits only a small (3x) send budget.
+    _ = manager.onDatagram(migrated, 100, test_challenge, 0);
+    try testing.expect(manager.canSendOnPath(migrated, 300));
+    try testing.expect(!manager.canSendOnPath(migrated, 301));
+
+    _ = manager.validatePathResponse(migrated, test_challenge, 10).?;
+    // Validated but deliberately not promoted (e.g. still waiting on a fresh
+    // peer CID): RFC 9000 §8.2.3 already permits unlimited sends on this path.
+    try testing.expect(manager.canSendOnPath(migrated, std.math.maxInt(u64)));
+    // The old path is still active — validation alone does not promote.
+    try testing.expect(manager.activePath().key.eql(testKey(50_000)));
+}
+
+test "a pending candidate's promotion classification is recomputed against the current active path" {
+    var manager = PathManager.init(.full, testKey(50_000), true); // A active
+    const b = testKeyOtherHost(50_001);
+    const c = testKeyOtherHost(50_002); // same host as B, different port
+
+    // B validates while A is active: classified as a host migration.
+    _ = manager.onDatagram(b, 1_200, test_challenge, 0);
+    const validated_b = manager.validatePathResponse(b, test_challenge, 10).?;
+    try testing.expectEqual(AddressChange.migration, validated_b.change);
+    // No fresh peer CID for B yet: it stays pending.
+    manager.recordMigrationBlockedNoPeerCid();
+
+    // C also validates while A is still active (also a migration relative to
+    // A), and gets a fresh peer CID first, so it promotes.
+    _ = manager.onDatagram(c, 1_200, test_challenge, 20);
+    _ = manager.validatePathResponse(c, test_challenge, 30).?;
+    const outcome_c = manager.promoteValidated(c).?;
+    try testing.expectEqual(AddressChange.migration, outcome_c.change);
+    try testing.expect(manager.activePath().key.eql(c));
+
+    // B is still pending, and a fresh peer CID becomes available for it too.
+    // B and C share a host: relative to the now-active C, B is only a NAT
+    // rebinding, even though it was originally probed and validated as a
+    // migration relative to A.
+    try testing.expectEqual(AddressChange.nat_rebinding, manager.promotionChange(b).?);
+    const outcome_b = manager.promoteValidated(b).?;
+    try testing.expectEqual(AddressChange.nat_rebinding, outcome_b.change);
+    try testing.expect(!outcome_b.reset_congestion);
+    try testing.expect(manager.activePath().key.eql(b));
+    try testing.expectEqual(@as(u64, 1), manager.metrics.nat_rebindings);
+    try testing.expectEqual(@as(u64, 1), manager.metrics.migrations);
 }
 
 test "a previously-active validated path is re-probed, not trusted indefinitely" {

--- a/tests/quic_h3_smoke.zig
+++ b/tests/quic_h3_smoke.zig
@@ -405,9 +405,9 @@ const Endpoint = struct {
         try self.openAndProcess(received.bytes, path_key, outbound, received.received_at_us);
     }
 
-    fn handleAuthenticatedPath(self: *Endpoint, path_key: quic_path.PathKey, outbound: *DatagramQueue, now_us: u64) !void {
-        switch (self.paths.onDatagram(path_key, deterministicTestChallengeForPath(path_key), now_us)) {
-            .on_active_path, .probing => {},
+    fn handleAuthenticatedPath(self: *Endpoint, path_key: quic_path.PathKey, authenticated_bytes: usize, outbound: *DatagramQueue, now_us: u64) !void {
+        switch (self.paths.onDatagram(path_key, authenticated_bytes, deterministicTestChallengeForPath(path_key), now_us)) {
+            .on_active_path, .probing, .validated_pending_promotion => {},
             .blocked => {},
             .probe => |challenge| {
                 var frame_buf: [16]u8 = undefined;
@@ -497,7 +497,7 @@ const Endpoint = struct {
         if (self.largest_recv_pn[space] == null or pn > self.largest_recv_pn[space].?) {
             self.largest_recv_pn[space] = pn;
         }
-        if (level == .application) try self.handleAuthenticatedPath(path_key, outbound, now_us);
+        if (level == .application) try self.handleAuthenticatedPath(path_key, packet_end, outbound, now_us);
         try self.processFrames(level, frames, path_key, outbound, now_us);
     }
 

--- a/tests/quic_h3_smoke.zig
+++ b/tests/quic_h3_smoke.zig
@@ -564,8 +564,10 @@ const Endpoint = struct {
                     if (quic_path.path_challenge_len > frames.len - pos) return error.TruncatedFrame;
                     const response = frames[pos..][0..quic_path.path_challenge_len].*;
                     pos += quic_path.path_challenge_len;
-                    if (self.paths.onPathResponse(path_key, response, now_us)) |outcome| {
-                        if (outcome.reset_congestion) self.recovery.resetForPathMigration();
+                    if (self.paths.validatePathResponse(path_key, response, now_us)) |validated| {
+                        if (self.paths.promoteValidated(validated.path)) |outcome| {
+                            if (outcome.reset_congestion) self.recovery.resetForPathMigration();
+                        }
                     }
                 },
                 else => return error.UnexpectedFrameType,
@@ -681,7 +683,7 @@ const Smoke = struct {
                     .{ .pinned_certificate = tls_backend.testdata.certificate_der },
                 ),
                 .cid_routes = quic_cid.CidRoutingTable.init(allocator),
-                .paths = quic_path.PathManager.init(.full, .{ .local = client_addr, .remote = server_addr }),
+                .paths = quic_path.PathManager.init(.full, .{ .local = client_addr, .remote = server_addr }, true),
                 .recovery = client_recovery,
                 .local_params = params,
                 .local_cid = client_cid,
@@ -700,7 +702,7 @@ const Smoke = struct {
                     ),
                 ),
                 .cid_routes = quic_cid.CidRoutingTable.init(allocator),
-                .paths = quic_path.PathManager.init(.full, .{ .local = server_addr, .remote = client_addr }),
+                .paths = quic_path.PathManager.init(.full, .{ .local = server_addr, .remote = client_addr }, true),
                 .recovery = server_recovery,
                 .local_params = params,
                 .local_cid = server_cid,


### PR DESCRIPTION
## Summary

Slice 1 (Phases A+B) of #387's production-integration plan for wiring
authenticated path migration and Retry into the native HTTP/3 listener.
This slice lands the mechanical primitives and `PathManager` contract
changes the later `Connection`/HTTP-3-runtime integration slices depend
on. No runtime or operator-facing behavior changes yet — `migration_policy`
has no config wiring until a later slice, and `Connection` doesn't call
`PathManager` yet (confirmed via search — only the standalone
`tests/quic_h3_smoke.zig` harness does today).

- **`src/quic/config.zig`**: fix `disable_active_migration` mapping so both
  `.disabled` and `.nat_rebinding_only` advertise it; only `.full` doesn't.
- **`src/quic/path.zig`**:
  - Retry tokens / `RetryContext` now carry the Retry SCID alongside the
    original DCID (`issueRetry`/`validateRetry` signatures updated).
  - `PathManager.init()` takes an `initial_address_validated` bool so a
    non-Retry server's initial path starts amplification-limited until the
    handshake validates it; added `markActiveValidated()`.
  - Added per-path authenticated byte accounting:
    `recordReceivedOnPath`/`recordSentOnPath`/`canSendOnPath`, isolated per
    path so candidate-path bytes never inflate the active path's budget.
  - Added `nextValidationDeadlineUs()` so a connection driver can fold path
    validation deadlines into its own timer wheel.
  - Split `onPathResponse()` into `validatePathResponse()` +
    `promoteValidated()` so host migration can claim a fresh peer CID
    between validating a candidate and promoting it to active; added
    `recordMigrationBlockedNoPeerCid()` / `migrations_blocked_no_peer_cid`
    metric for the case where no fresh CID is available.
- **`src/quic/packet.zig`**: added `writeRetryV1()` (full QUIC v1 Retry
  packet writer), refactoring the RFC 9001 §5.8 integrity-tag computation
  into one shared helper used by both the writer and `verifyRetryIntegrity`.
- **`src/quic/frame.zig`**: added `encodeNewConnectionId()`.
- **`src/quic/cid.zig`**: added `CidRoutingTable.contains()` for a
  collision preflight that doesn't perturb routing hit/miss metrics.
- **`tests/quic_h3_smoke.zig`**: updated the two `PathManager` call sites
  for the new `init()`/`validatePathResponse`+`promoteValidated` APIs.

Remaining phases (Connection path-aware ingest/egress, CID lifecycle,
HTTP/3 runtime + Retry accept state machine, edge config/gateway wiring)
are tracked in #387 and will land as further slices.

## Test plan
- [x] `zig fmt --check build.zig src/ tests/`
- [x] `zig build test --summary all` — 2701/2702 passed (1 pre-existing skip)
- [x] `zig build test-quic --summary all` — 533/533 passed
- [x] New/updated tests cover: migration-policy transport-parameter mapping
      for all three policy values; Retry token round-trip with Retry SCID;
      `writeRetryV1` round-trip through `parsePacket`/`verifyRetryIntegrity`
      plus tamper/wrong-ODCID/oversized-CID/short-buffer cases;
      `encodeNewConnectionId` round-trip and short-buffer case;
      `CidRoutingTable.contains()` metric isolation; unvalidated-initial-path
      amplification gating; per-path byte-accounting isolation between
      active and candidate paths; `nextValidationDeadlineUs`;
      validate/promote split including the no-peer-CID-block-then-later-promote
      case and promotion-without-prior-validation rejection.

Refs #387 (Slice 1 of the production-integration plan; issue stays open
for the remaining phases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)