### PR TITLE
quic: implement native QUIC/H3 0-RTT packet acceptance and early-data delivery

### DIFF
--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -455,6 +455,10 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
             .request_handler_ctx = &http3_dispatch_ctx,
             .early_data_compat_metrics_ctx = &state,
             .early_data_compat_metrics_cb = recordHttp3EarlyDataCompatFromRuntime,
+            .quic_early_data_decision_metrics_ctx = &state,
+            .quic_early_data_decision_metrics_cb = recordQuicEarlyDataDecisionFromRuntime,
+            .quic_zero_rtt_packet_metrics_ctx = &state,
+            .quic_zero_rtt_packet_metrics_cb = recordQuicZeroRttPacketFromRuntime,
         }) catch |err| blk: {
             state.logger.warn(null, "HTTP/3 listener failed to initialize: {s}", .{@errorName(err)});
             break :blk null;
@@ -2117,6 +2121,22 @@ fn recordHttp3EarlyDataCompatFromRuntime(
 ) void {
     const state: *GatewayState = @ptrCast(@alignCast(raw_state));
     state.metricsRecordHttp3EarlyDataCompat(decision);
+}
+
+fn recordQuicEarlyDataDecisionFromRuntime(
+    raw_state: *anyopaque,
+    decision: http.metrics.QuicEarlyDataDecision,
+) void {
+    const state: *GatewayState = @ptrCast(@alignCast(raw_state));
+    state.metricsRecordQuicEarlyDataDecision(decision);
+}
+
+fn recordQuicZeroRttPacketFromRuntime(
+    raw_state: *anyopaque,
+    outcome: http.metrics.QuicZeroRttPacketOutcome,
+) void {
+    const state: *GatewayState = @ptrCast(@alignCast(raw_state));
+    state.metricsRecordQuicZeroRttPacket(outcome);
 }
 
 fn h2LastReadEarlyPrefixLen(conn: anytype) usize {

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -1413,6 +1413,20 @@ pub const GatewayState = struct {
         self.metrics.recordHttp3EarlyDataCompat(decision);
     }
 
+    /// #523: the QUIC/H3 server's authoritative 0-RTT accept/reject decision.
+    pub fn metricsRecordQuicEarlyDataDecision(self: *GatewayState, decision: http.metrics.QuicEarlyDataDecision) void {
+        self.metrics_mutex.lock();
+        defer self.metrics_mutex.unlock();
+        self.metrics.recordQuicEarlyDataDecision(decision);
+    }
+
+    /// #523: a single 0-RTT packet's authentication/admission outcome.
+    pub fn metricsRecordQuicZeroRttPacket(self: *GatewayState, outcome: http.metrics.QuicZeroRttPacketOutcome) void {
+        self.metrics_mutex.lock();
+        defer self.metrics_mutex.unlock();
+        self.metrics.recordQuicZeroRttPacket(outcome);
+    }
+
     pub fn metricsRecordReloadAttempt(self: *GatewayState) void {
         self.metrics_mutex.lock();
         defer self.metrics_mutex.unlock();

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -616,11 +616,25 @@ pub const Runtime = struct {
     }
 
     fn pumpH3(self: *Runtime, entry: *ConnEntry, now: u64) void {
-        if (!entry.conn.isEstablished()) return;
-        if (!entry.h3_started) {
+        const established = entry.conn.isEstablished();
+        // The control stream/SETTINGS flight only ever goes out once
+        // established — QUIC packet building itself already refuses to
+        // transmit any `.application`-space frame before `self.state_ ==
+        // .established` (see `buildPacket`), so this is establishment-only
+        // by construction, not just by this early return.
+        if (established and !entry.h3_started) {
             entry.h3.start(entry.conn) catch return;
             entry.h3_started = true;
         }
+        // #523: accepted 0-RTT STREAM bytes must reach H3 during the
+        // early-data window, not sit unread until the handshake completes —
+        // otherwise the replay-safe/425 request-safety decision never runs
+        // as early data at all. Safe to pump pre-establishment even for an
+        // ordinary (non-0-RTT) connection: `acceptStream`/`readStream` are
+        // no-ops until something actually populated the stream layer, and
+        // any response `serveRequest` queues still can't reach the wire
+        // until `.application` packet building unlocks at establishment.
+        if (!established and !self.zero_rtt_enabled) return;
         entry.h3.pump(entry.conn) catch |err| {
             // An H3-level protocol error closes the connection with the
             // specific RFC 9114 §8.1 code the session layer recorded.
@@ -803,6 +817,14 @@ pub const Runtime = struct {
             .ticket_age_add = ticket_age_add,
             .ticket_nonce = &ticket_nonce,
             .issued_at_unix_ms = now_unix_ms,
+            // RFC 9001 §4.6.1: a QUIC NewSessionTicket that advertises 0-RTT
+            // capability carries the fixed sentinel 0xffffffff — QUIC early
+            // data isn't bounded by this TLS-record byte cap (that's the
+            // job of QUIC flow control and `ServerEarlyDataPolicy`), and
+            // the field must be omitted (`null`) entirely when the carrier
+            // isn't actually composed, or a client would offer 0-RTT the
+            // server can never accept.
+            .max_early_data_size = if (self.zero_rtt_enabled) std.math.maxInt(u32) else null,
         }, limits);
         defer prepared.deinit();
 
@@ -822,6 +844,36 @@ pub const Runtime = struct {
 
     fn h3EarlyDataCompatibility(ctx: *anyopaque, candidate: tls_core.tls13_backend.EarlyDataCompatibilityCandidate) tls_core.tls13_backend.EarlyDataCompatibilityDecision {
         const self: *Runtime = @ptrCast(@alignCast(ctx));
+
+        // #523: the early-specific gate — deliberately independent of
+        // `ResumeCompatibilityPolicy` (`accept()` sets `.transport = .ignore`
+        // there so *ordinary* 1-RTT resumption never depends on transport
+        // parameters) — is the only owner that may reject *early data
+        // specifically* for a remembered QUIC transport snapshot that no
+        // longer holds. RFC 9001 §4.6.1: an endpoint that accepts 0-RTT must
+        // not have reduced any limit the client's early data would rely on
+        // below what was remembered.
+        const transport = candidate.remembered_transport orelse {
+            self.recordH3EarlyDataCompat(.missing_state);
+            return .transport_incompatible;
+        };
+        if (transport.format_id != quic_transport_parameters_extension_type) {
+            self.recordH3EarlyDataCompat(.transport_incompatible);
+            return .transport_incompatible;
+        }
+        const remembered_transport = quic.tls_backend.decodeTransportParameters(transport.bytes) catch {
+            self.recordH3EarlyDataCompat(.transport_incompatible);
+            return .transport_incompatible;
+        };
+        const current_transport = self.quic_config.transportParameters() catch {
+            self.recordH3EarlyDataCompat(.transport_incompatible);
+            return .transport_incompatible;
+        };
+        if (!quicEarlyDataTransportCompatible(remembered_transport, current_transport)) {
+            self.recordH3EarlyDataCompat(.transport_incompatible);
+            return .transport_incompatible;
+        }
+
         const app = candidate.remembered_application orelse {
             self.recordH3EarlyDataCompat(.missing_state);
             return .application_incompatible;
@@ -949,8 +1001,39 @@ fn quicConfigFrom(cfg: Config) quic.config.Config {
 /// default gate fails closed (`.unavailable`) for every attempt anyway, so
 /// gating here keeps that fail-closed behavior visible instead of quietly
 /// letting every 0-RTT attempt dead-end downstream.
+/// TLS extension type carrying the QUIC transport-parameters extension —
+/// matches what `quic.tls_backend` stamps as the remembered/current
+/// transport-compat snapshot's `format_id`, without needing that internal
+/// constant exported.
+const quic_transport_parameters_extension_type: u16 = @intFromEnum(tls_core.algorithms.ExtensionType.quic_transport_parameters);
+
+/// RFC 9001 §4.6.1: a 0-RTT attempt is only transport-compatible if none of
+/// the limits governing what the client may send early have been reduced
+/// since the ticket was issued. `initial_max_stream_data_bidi_local` is
+/// deliberately excluded — it governs the server's own outbound budget on
+/// server-initiated streams, which is never relevant to data the client
+/// sends (the server never sends 0-RTT).
+fn quicEarlyDataTransportCompatible(remembered: quic.config.TransportParameters, current: quic.config.TransportParameters) bool {
+    return current.initial_max_data >= remembered.initial_max_data and
+        current.initial_max_stream_data_bidi_remote >= remembered.initial_max_stream_data_bidi_remote and
+        current.initial_max_stream_data_uni >= remembered.initial_max_stream_data_uni and
+        current.initial_max_streams_bidi >= remembered.initial_max_streams_bidi and
+        current.initial_max_streams_uni >= remembered.initial_max_streams_uni;
+}
+
 fn zeroRttCarrierEnabled(cfg: Config) bool {
-    return cfg.enable_0rtt and cfg.resumption_runtime != null and cfg.early_data_replay_gate != null;
+    if (!cfg.enable_0rtt) return false;
+    // A non-null dependency isn't necessarily a *usable* one: a resumption
+    // runtime constructed with `.mode = .disabled` still exists but yields
+    // no PSK resolver, and a default-constructed `EarlyDataReplayGate`
+    // (`decideFn == null`) exists but fails closed on every attempt. Either
+    // would leave `accept()` composing a carrier that can never actually
+    // accept 0-RTT — check the thing that matters, not just presence.
+    const runtime = cfg.resumption_runtime orelse return false;
+    if (runtime.serverResolver() == null) return false;
+    const gate = cfg.early_data_replay_gate orelse return false;
+    if (gate.decideFn == null) return false;
+    return true;
 }
 
 /// Convert a source/destination IPv4 `sockaddr_in` into the protocol-neutral
@@ -1595,6 +1678,236 @@ test "runtime (#523): enable_0rtt enables the carrier only with complete composi
     defer complete.deinit();
     try testing.expect(complete.zero_rtt_enabled);
     try testing.expect(complete.quic_config.zero_rtt_enabled);
+}
+
+test "runtime (#523): a present-but-unusable resumption runtime or replay gate still fails closed" {
+    var fixed = tls_core.credentials.FixedCredentialProvider.init(tls_core.credentials.testdata.identity());
+    defer fixed.deinit();
+    var logger = logger_mod.Logger.init(.err, "http3-0rtt-usability-test");
+
+    var entropy = tls_core.production_crypto.OsEntropy{};
+    var provider_state = tls_core.production_crypto.Provider.init(entropy.entropy());
+
+    // A `.mode = .disabled` resumption runtime is non-null but yields no PSK
+    // resolver (`serverResolver() == null`) — `accept()` would install no
+    // resolver at all, so the carrier must not report itself enabled.
+    var disabled_mode_resumption = try tls_core.resumption_runtime.Runtime.init(
+        testing.allocator,
+        .{ .mode = .disabled },
+        .{ .ctx = undefined, .nowUnixMsFn = fixedNowUnixMsForTest },
+        provider_state.cryptoProvider(),
+    );
+    defer disabled_mode_resumption.deinit();
+
+    var store = try tls_core.early_data_replay.LocalStore.init(testing.allocator, .{}, 0, 0);
+    defer store.deinit();
+    var gate_adapter = tls_core.early_data_replay.GateAdapter.init(store.store());
+    const usable_gate = gate_adapter.gate();
+
+    var disabled_mode = try Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+        .credential_provider = fixed.provider(),
+        .resumption_runtime = &disabled_mode_resumption,
+        .early_data_replay_gate = usable_gate,
+        .enable_0rtt = true,
+    });
+    defer disabled_mode.deinit();
+    try testing.expect(!disabled_mode.zero_rtt_enabled);
+
+    // A default-constructed `EarlyDataReplayGate` (`decideFn == null`) is
+    // non-null but fails closed (`.unavailable`) for every attempt on its
+    // own — installing it doesn't make the carrier usable either.
+    var usable_resumption = try tls_core.resumption_runtime.Runtime.init(
+        testing.allocator,
+        .{ .mode = .stateful },
+        .{ .ctx = undefined, .nowUnixMsFn = fixedNowUnixMsForTest },
+        provider_state.cryptoProvider(),
+    );
+    defer usable_resumption.deinit();
+
+    var unconfigured_gate = try Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+        .credential_provider = fixed.provider(),
+        .resumption_runtime = &usable_resumption,
+        .early_data_replay_gate = .{},
+        .enable_0rtt = true,
+    });
+    defer unconfigured_gate.deinit();
+    try testing.expect(!unconfigured_gate.zero_rtt_enabled);
+
+    // Sanity: both dependencies actually usable enables it, confirming the
+    // two cases above are real negatives and not an over-broad check.
+    var usable = try Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+        .credential_provider = fixed.provider(),
+        .resumption_runtime = &usable_resumption,
+        .early_data_replay_gate = usable_gate,
+        .enable_0rtt = true,
+    });
+    defer usable.deinit();
+    try testing.expect(usable.zero_rtt_enabled);
+}
+
+test "issueSessionTicket (#523): the production issuer advertises QUIC 0-RTT capability only when the carrier is enabled" {
+    const allocator = testing.allocator;
+    var fixed = tls_core.credentials.FixedCredentialProvider.init(tls_core.credentials.testdata.identity());
+    defer fixed.deinit();
+    var logger = logger_mod.Logger.init(.err, "http3-ticket-issuance-test");
+
+    var entropy = tls_core.production_crypto.OsEntropy{};
+    var provider_state = tls_core.production_crypto.Provider.init(entropy.entropy());
+    var resumption = try tls_core.resumption_runtime.Runtime.init(
+        testing.allocator,
+        .{ .mode = .stateful },
+        .{ .ctx = undefined, .nowUnixMsFn = fixedNowUnixMsForTest },
+        provider_state.cryptoProvider(),
+    );
+    defer resumption.deinit();
+
+    var store = try tls_core.early_data_replay.LocalStore.init(testing.allocator, .{}, 0, 0);
+    defer store.deinit();
+    var gate_adapter = tls_core.early_data_replay.GateAdapter.init(store.store());
+    const gate = gate_adapter.gate();
+
+    var runtime = try Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+        .credential_provider = fixed.provider(),
+        .resumption_runtime = &resumption,
+        .early_data_replay_gate = gate,
+        .enable_0rtt = true,
+    });
+    defer runtime.deinit();
+    try testing.expect(runtime.zero_rtt_enabled);
+
+    // Build a real, established client/server QUIC pair directly (not via
+    // `runtime.accept()`, which needs a real UDP round trip) —
+    // `prepareNewSessionTicket` requires a genuine post-handshake
+    // resumption master secret, so there is no shortcut around a real
+    // handshake. This mirrors `quic.connection`'s own private `TestPair`,
+    // which isn't reachable from this file.
+    const client_cid = [_]u8{ 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8 };
+    const odcid = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08 };
+    const client_path = quic.path.PathKey{
+        .local = quic.udp.Address.ip4(.{ 127, 0, 0, 1 }, 41_200),
+        .remote = quic.udp.Address.ip4(.{ 127, 0, 0, 1 }, 41_201),
+    };
+    const server_path = quic.path.PathKey{
+        .local = quic.udp.Address.ip4(.{ 127, 0, 0, 1 }, 41_201),
+        .remote = quic.udp.Address.ip4(.{ 127, 0, 0, 1 }, 41_200),
+    };
+    const no_challenge = [_]u8{0} ** quic.path.path_challenge_len;
+
+    var client_backend = try quic.tls_backend.Tls13Backend.initClientWithAllocator(
+        allocator,
+        .{ .hello_random = [_]u8{0xc1} ** 32, .key_share_seed = [_]u8{0x11} ** 32 },
+        .{ .pinned_certificate = tls_core.credentials.testdata.certificate_der },
+    );
+
+    const Capture = struct {
+        retained: tls_core.session.ClientTicketState = .{},
+        count: usize = 0,
+
+        fn now(_: *anyopaque) i64 {
+            return 1000;
+        }
+        fn onTicket(ctx: *anyopaque, ticket: *const tls_core.session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            ticket.cloneInto(testing.allocator, &self.retained) catch unreachable;
+            self.count += 1;
+        }
+    };
+    var capture = Capture{};
+    defer capture.retained.deinit();
+    try client_backend.engine.setSessionTicketConsumer(allocator, tls_core.session.Limits.default, .{
+        .ctx = &capture,
+        .nowUnixMsFn = Capture.now,
+        .onTicketFn = Capture.onTicket,
+    });
+
+    const backend = try allocator.create(quic.tls_backend.Tls13Backend);
+    backend.* = quic.tls_backend.Tls13Backend.initServerWithProvider(
+        .{ .hello_random = [_]u8{0x51} ** 32, .key_share_seed = [_]u8{0x22} ** 32 },
+        fixed.provider(),
+    );
+
+    const client = try Connection.init(allocator, .{
+        .role = .client,
+        .local_cid = &client_cid,
+        .original_dcid = &odcid,
+        .peer_cid = &odcid,
+        .tls = client_backend.backend(),
+        .now_us = 1_000_000,
+        .initial_path = client_path,
+    });
+    defer client.deinit();
+    const server_conn = try Connection.init(allocator, .{
+        .role = .server,
+        .local_cid = &odcid,
+        .original_dcid = &odcid,
+        .peer_cid = &client_cid,
+        .tls = backend.backend(),
+        .now_us = 1_000_000,
+        .initial_path = server_path,
+    });
+
+    var entry = ConnEntry{
+        .backend = backend,
+        .conn = server_conn,
+        .h3 = H3.initWithSettings(allocator, .server, .{}),
+        .admission_source_ip = 0,
+        .cid_len = odcid.len,
+        .accepted_at_us = 1_000_000,
+    };
+    defer entry.deinit(allocator);
+
+    var rounds: usize = 0;
+    while (rounds < 64) : (rounds += 1) {
+        var progressed = false;
+        var buf: [2048]u8 = undefined;
+        while (client.pollTransmitOnPath(&buf, 1_000_000)) |t| {
+            try entry.conn.ingestOnPath(t.bytes, server_path, no_challenge, 1_000_000);
+            progressed = true;
+        }
+        while (entry.conn.pollTransmitOnPath(&buf, 1_000_000)) |t| {
+            try client.ingestOnPath(t.bytes, client_path, no_challenge, 1_000_000);
+            progressed = true;
+        }
+        if (!progressed) break;
+    }
+    try testing.expect(client.isEstablished());
+    try testing.expect(entry.conn.isEstablished());
+
+    try runtime.issueSessionTicket(&entry, &resumption);
+
+    // Deliver the queued NewSessionTicket CRYPTO data to the client.
+    var rounds2: usize = 0;
+    while (rounds2 < 16) : (rounds2 += 1) {
+        var progressed = false;
+        var buf: [2048]u8 = undefined;
+        while (entry.conn.pollTransmitOnPath(&buf, 1_000_000)) |t| {
+            try client.ingestOnPath(t.bytes, client_path, no_challenge, 1_000_000);
+            progressed = true;
+        }
+        while (client.pollTransmitOnPath(&buf, 1_000_000)) |t| {
+            try entry.conn.ingestOnPath(t.bytes, server_path, no_challenge, 1_000_000);
+            progressed = true;
+        }
+        if (!progressed) break;
+    }
+
+    try testing.expectEqual(@as(usize, 1), capture.count);
+    // #523: the production issuer must advertise QUIC 0-RTT capability with
+    // the RFC 9001 §4.6.1 sentinel now that the carrier is actually
+    // enabled — a ticket a resumed client can genuinely attempt 0-RTT with,
+    // not one silently limited to resume-only.
+    try testing.expectEqual(
+        tls_core.session.EarlyDataPolicy{ .early_data_capable = std.math.maxInt(u32) },
+        capture.retained.common.early_data,
+    );
 }
 
 test "runtime resolves the actual bound local address, including an OS-assigned port, from quic_port = 0" {

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -19,6 +19,7 @@
 
 const compat = @import("zig_compat");
 const std = @import("std");
+const early_data_policy = @import("early_data.zig");
 const http3_session = @import("http3_session.zig");
 const logger_mod = @import("logger.zig");
 const metrics_mod = @import("metrics.zig");
@@ -857,7 +858,9 @@ pub const Runtime = struct {
             self.recordH3EarlyDataCompat(.missing_state);
             return .transport_incompatible;
         };
-        if (transport.format_id != quic_transport_parameters_extension_type) {
+        if (transport.format_id != quic_transport_parameters_extension_type or
+            transport.format_version != quic_transport_parameters_compat_format_version)
+        {
             self.recordH3EarlyDataCompat(.transport_incompatible);
             return .transport_incompatible;
         }
@@ -1007,18 +1010,31 @@ fn quicConfigFrom(cfg: Config) quic.config.Config {
 /// constant exported.
 const quic_transport_parameters_extension_type: u16 = @intFromEnum(tls_core.algorithms.ExtensionType.quic_transport_parameters);
 
-/// RFC 9001 §4.6.1: a 0-RTT attempt is only transport-compatible if none of
-/// the limits governing what the client may send early have been reduced
-/// since the ticket was issued. `initial_max_stream_data_bidi_local` is
-/// deliberately excluded — it governs the server's own outbound budget on
-/// server-initiated streams, which is never relevant to data the client
-/// sends (the server never sends 0-RTT).
+/// The snapshot format version `quic.tls_backend.localTransportCompat` /
+/// `peerTransportCompat` stamp on every remembered-transport `CompatView`
+/// (hardcoded `1` there) — validated here before decoding so a
+/// version-mismatched snapshot from a future encoding change fails closed
+/// as `.transport_incompatible` rather than being decoded under the wrong
+/// assumptions.
+const quic_transport_parameters_compat_format_version: u16 = 1;
+
+/// RFC 9000 §7.4.1 / RFC 9001 §4.6.1's no-reduction set: a 0-RTT attempt is
+/// only transport-compatible if none of the limits it depends on — or that
+/// the client otherwise remembers as a standing guarantee from the prior
+/// connection — have been reduced since the ticket was issued.
+/// `initial_max_stream_data_bidi_local` and `active_connection_id_limit`
+/// are included even though they don't gate the early-data window itself
+/// (server never sends 0-RTT, and CIDs aren't consumed by 0-RTT admission):
+/// RFC 9000 §7.4.1 requires the full remembered parameter set to hold, not
+/// just the ones 0-RTT immediately exercises.
 fn quicEarlyDataTransportCompatible(remembered: quic.config.TransportParameters, current: quic.config.TransportParameters) bool {
     return current.initial_max_data >= remembered.initial_max_data and
+        current.initial_max_stream_data_bidi_local >= remembered.initial_max_stream_data_bidi_local and
         current.initial_max_stream_data_bidi_remote >= remembered.initial_max_stream_data_bidi_remote and
         current.initial_max_stream_data_uni >= remembered.initial_max_stream_data_uni and
         current.initial_max_streams_bidi >= remembered.initial_max_streams_bidi and
-        current.initial_max_streams_uni >= remembered.initial_max_streams_uni;
+        current.initial_max_streams_uni >= remembered.initial_max_streams_uni and
+        current.active_connection_id_limit >= remembered.active_connection_id_limit;
 }
 
 fn zeroRttCarrierEnabled(cfg: Config) bool {
@@ -1155,6 +1171,107 @@ test "quicConfigFrom clamps datagram size into the work-buffer range" {
     const mid = quicConfigFrom(.{ .listen_host = "::", .quic_port = 443, .max_datagram_size = 1350 });
     try testing.expectEqual(@as(u64, 1350), mid.max_udp_payload_size);
     try testing.expectEqual(quic.config.MigrationPolicy.disabled, mid.migration_policy);
+}
+
+test "quicEarlyDataTransportCompatible (#523): rejects any reduced limit in the full RFC 9000 §7.4.1 set" {
+    const base = quic.config.TransportParameters{
+        .max_idle_timeout_ms = 1000,
+        .active_connection_id_limit = 4,
+        .max_udp_payload_size = 1200,
+        .initial_max_data = 100,
+        .initial_max_stream_data_bidi_local = 50,
+        .initial_max_stream_data_bidi_remote = 50,
+        .initial_max_stream_data_uni = 25,
+        .initial_max_streams_bidi = 10,
+        .initial_max_streams_uni = 5,
+        .disable_active_migration = true,
+    };
+
+    // Identical parameters are always compatible.
+    try testing.expect(quicEarlyDataTransportCompatible(base, base));
+
+    // Raising every limit (including the two the second-pass review added)
+    // stays compatible.
+    var raised = base;
+    raised.initial_max_data += 1;
+    raised.active_connection_id_limit += 1;
+    raised.initial_max_stream_data_bidi_local += 1;
+    try testing.expect(quicEarlyDataTransportCompatible(base, raised));
+
+    // Reducing `active_connection_id_limit` alone is rejected.
+    var reduced_cid = base;
+    reduced_cid.active_connection_id_limit -= 1;
+    try testing.expect(!quicEarlyDataTransportCompatible(base, reduced_cid));
+
+    // Reducing `initial_max_stream_data_bidi_local` alone is rejected.
+    var reduced_bidi_local = base;
+    reduced_bidi_local.initial_max_stream_data_bidi_local -= 1;
+    try testing.expect(!quicEarlyDataTransportCompatible(base, reduced_bidi_local));
+}
+
+test "h3EarlyDataCompatibility (#523): rejects a remembered snapshot with the wrong format_version before decoding" {
+    var fixed = tls_core.credentials.FixedCredentialProvider.init(tls_core.credentials.testdata.identity());
+    defer fixed.deinit();
+    var logger = logger_mod.Logger.init(.err, "http3-transport-version-test");
+    var runtime = try Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+        .credential_provider = fixed.provider(),
+    });
+    defer runtime.deinit();
+
+    const candidate: tls_core.tls13_backend.EarlyDataCompatibilityCandidate = .{
+        .remembered_transport = .{
+            .format_id = quic_transport_parameters_extension_type,
+            .format_version = quic_transport_parameters_compat_format_version + 1,
+            .bytes = "not even valid transport parameter bytes",
+        },
+    };
+    try testing.expectEqual(
+        tls_core.tls13_backend.EarlyDataCompatibilityDecision.transport_incompatible,
+        Runtime.h3EarlyDataCompatibility(@ptrCast(&runtime), candidate),
+    );
+}
+
+test "h3EarlyDataCompatibility (#523): rejects a live QUIC transport limit reduced below the remembered snapshot" {
+    var fixed = tls_core.credentials.FixedCredentialProvider.init(tls_core.credentials.testdata.identity());
+    defer fixed.deinit();
+    var logger = logger_mod.Logger.init(.err, "http3-transport-reduced-test");
+    var runtime = try Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+        .credential_provider = fixed.provider(),
+    });
+    defer runtime.deinit();
+
+    const remembered_params = try runtime.quic_config.transportParameters();
+    var encoded: [quic.tls_backend.max_transport_parameters_len]u8 = undefined;
+    const encoded_bytes = try quic.tls_backend.encodeTransportParameters(remembered_params, &encoded);
+
+    const candidate: tls_core.tls13_backend.EarlyDataCompatibilityCandidate = .{
+        .remembered_transport = .{
+            .format_id = quic_transport_parameters_extension_type,
+            .format_version = quic_transport_parameters_compat_format_version,
+            .bytes = encoded_bytes,
+        },
+    };
+
+    // Identical to the live configuration: transport-compatible, so the
+    // decision falls through to the application/H3-SETTINGS check next —
+    // which fails closed as `.application_incompatible` here since this
+    // candidate supplies no `remembered_application` at all. That's the
+    // proof the transport check itself passed, not a transport rejection.
+    try testing.expectEqual(
+        tls_core.tls13_backend.EarlyDataCompatibilityDecision.application_incompatible,
+        Runtime.h3EarlyDataCompatibility(@ptrCast(&runtime), candidate),
+    );
+
+    // Reduce a live limit below what was remembered.
+    runtime.quic_config.initial_max_streams_bidi -= 1;
+    try testing.expectEqual(
+        tls_core.tls13_backend.EarlyDataCompatibilityDecision.transport_incompatible,
+        Runtime.h3EarlyDataCompatibility(@ptrCast(&runtime), candidate),
+    );
 }
 
 test "quicConfigFrom (#523): enable_0rtt alone never enables the 0-RTT carrier" {
@@ -1908,6 +2025,458 @@ test "issueSessionTicket (#523): the production issuer advertises QUIC 0-RTT cap
         tls_core.session.EarlyDataPolicy{ .early_data_capable = std.math.maxInt(u32) },
         capture.retained.common.early_data,
     );
+}
+
+/// #523 test-only: seal a 0-RTT wire packet exactly the way a real client
+/// sender would, mirroring `quic.connection`'s private `sealTestZeroRttPacket`
+/// (not reachable from this file). Key derivation depends only on the
+/// secret bytes, so a receiver with the same bytes installed at
+/// `.zero_rtt read` genuinely decrypts this.
+fn sealZeroRttPacketForTest(
+    dcid: []const u8,
+    scid: []const u8,
+    secret: [quic.tls_adapter.traffic_secret_len]u8,
+    pn: u64,
+    plaintext: []const u8,
+    out: []u8,
+) []u8 {
+    var sender = quic.tls_adapter.QuicTlsAdapter{};
+    sender.setZeroRttEnabled(true);
+    sender.installSecret(quic.tls_adapter.Secret.init(.zero_rtt, .write, &secret) catch unreachable);
+
+    const pn_len: u3 = quic.packet.packetNumberLength(pn, null);
+    const written = quic.packet.writeLongHeader(.zero_rtt, quic.packet.quic_v1, dcid, scid, "", pn_len, out) catch unreachable;
+    const pn_offset = written.pn_offset;
+
+    var padded: [1024]u8 = undefined;
+    const sample_min = (4 - @as(usize, pn_len)) + quic.tls_adapter.header_protection_sample_len - quic.tls_adapter.packet_protection_tag_len;
+    const padded_len = @max(plaintext.len, sample_min);
+    @memcpy(padded[0..plaintext.len], plaintext);
+    @memset(padded[plaintext.len..padded_len], 0);
+
+    // The Length field precedes `pn_offset` and is covered by the AEAD
+    // associated data, so it must be patched before sealing.
+    quic.packet.patchLongHeaderLength(out, written.length_offset, pn_len + padded_len + quic.tls_adapter.packet_protection_tag_len);
+
+    const truncated = quic.packet.truncatePacketNumber(pn, pn_len);
+    var pn_bytes: [4]u8 = undefined;
+    std.mem.writeInt(u32, &pn_bytes, truncated, .big);
+    @memcpy(out[pn_offset..][0..pn_len], pn_bytes[4 - @as(usize, pn_len) ..][0..pn_len]);
+
+    const header = out[0 .. pn_offset + pn_len];
+    const keys = sender.protectionKeys(.zero_rtt, .write).?;
+    _ = sender.sealPacketPayload(.zero_rtt, .write, pn, header, padded[0..padded_len], out[pn_offset + pn_len ..]) catch unreachable;
+
+    var sample: [quic.tls_adapter.header_protection_sample_len]u8 = undefined;
+    @memcpy(&sample, out[pn_offset + 4 ..][0..quic.tls_adapter.header_protection_sample_len]);
+    keys.applyHeaderProtection(&out[0], out[pn_offset..][0..pn_len], sample);
+
+    return out[0 .. pn_offset + pn_len + padded_len + quic.tls_adapter.packet_protection_tag_len];
+}
+
+/// #523 test-only: encode a real HTTP/3 request (QPACK HEADERS frame, no
+/// body) — the same primitives `http3.conn.Conn.sendRequest` uses — so the
+/// production H3 request parser genuinely has to decode this, not a
+/// synthetic shortcut.
+fn buildH3RequestBytesForTest(method: []const u8, path: []const u8, authority: []const u8, out: []u8) []const u8 {
+    var fields = [_]http3.qpack.HeaderField{
+        .{ .name = ":method", .value = method },
+        .{ .name = ":scheme", .value = "https" },
+        .{ .name = ":authority", .value = authority },
+        .{ .name = ":path", .value = path },
+    };
+    var block: [256]u8 = undefined;
+    const header_block = http3.qpack.encode(&fields, &block) catch unreachable;
+    return http3.frame.encodeKnownFrame(.headers, header_block, out) catch unreachable;
+}
+
+/// #523 test-only: an embedder-shaped request handler using the actual
+/// shared, transport-neutral early-data policy (`http.early_data.decide`,
+/// the same primitive `gateway_handlers.zig`'s production routing uses) —
+/// not a second, test-invented safety layer. `action_class = .local`
+/// mirrors an origin server (not a reverse proxy), the shape
+/// `http3_runtime.Config.request_handler` is meant for.
+const TestEarlyDataHandlerState = struct {
+    executed_local: usize = 0,
+    rejected_too_early: usize = 0,
+    last_method_buf: [8]u8 = undefined,
+    last_method_len: usize = 0,
+};
+
+fn testEarlyDataAwareHandler(
+    _: std.mem.Allocator,
+    request: *const http3_session.StreamRequest,
+    response: *response_mod.Response,
+    user_data: ?*anyopaque,
+) anyerror!void {
+    const state: *TestEarlyDataHandlerState = @ptrCast(@alignCast(user_data.?));
+    const decision = early_data_policy.decide(.{
+        .replay_exposed = request.transport_early,
+        .transport_early = request.transport_early,
+        .inbound_marker = false,
+        .method_safe = early_data_policy.methodSafe(request.method),
+        .route_replay_safe = true,
+        .action_class = .local,
+        .proxy_origin_rfc8470 = false,
+    });
+    switch (decision) {
+        .too_early => {
+            state.rejected_too_early += 1;
+            response.status = .too_early;
+        },
+        .ordinary, .execute_local => {
+            state.executed_local += 1;
+            const len = @min(request.method.len, state.last_method_buf.len);
+            @memcpy(state.last_method_buf[0..len], request.method[0..len]);
+            state.last_method_len = len;
+            response.status = .ok;
+        },
+        .forward_rfc8470, .defer_until_handshake => unreachable, // action_class = .local never yields these
+    }
+}
+
+test "http3 (#523): a replay-safe early request reaches the local handler exactly once; an unsafe one is rejected without dispatch; ordinary post-handshake requests still work" {
+    const allocator = testing.allocator;
+    var fixed = tls_core.credentials.FixedCredentialProvider.init(tls_core.credentials.testdata.identity());
+    defer fixed.deinit();
+    var logger = logger_mod.Logger.init(.err, "http3-early-request-matrix-test");
+
+    var server_entropy = tls_core.production_crypto.OsEntropy{};
+    var server_provider_state = tls_core.production_crypto.Provider.init(server_entropy.entropy());
+    var resumption = try tls_core.resumption_runtime.Runtime.init(
+        testing.allocator,
+        .{ .mode = .stateful },
+        .{ .ctx = undefined, .nowUnixMsFn = fixedNowUnixMsForTest },
+        server_provider_state.cryptoProvider(),
+    );
+    defer resumption.deinit();
+
+    // A separate client-side runtime instance for storing/looking up the
+    // client's own tickets — the server-side `resumption` above and this
+    // one play distinct roles, exactly as they would across two real
+    // processes, matching the pattern the #488 connection-level tests use.
+    var client_entropy = tls_core.production_crypto.OsEntropy{};
+    var client_provider_state = tls_core.production_crypto.Provider.init(client_entropy.entropy());
+    var client_resumption = try tls_core.resumption_runtime.Runtime.init(
+        testing.allocator,
+        .{ .mode = .stateful },
+        .{ .ctx = undefined, .nowUnixMsFn = fixedNowUnixMsForTest },
+        client_provider_state.cryptoProvider(),
+    );
+    defer client_resumption.deinit();
+
+    // `LocalStore`'s real `claim()` path reads real wall-clock time
+    // (`trampolineClaim` → `zig_compat.milliTimestamp()`), while this
+    // test's resumption clock is a small fixed value for determinism —
+    // those would never agree on a retention window. An always-allow gate
+    // still installs through the exact same `EarlyDataReplayGate` seam
+    // production composition uses (proving that seam, not a second policy
+    // layer); `LocalStore`'s own real-clock claim behavior has its own
+    // dedicated test coverage elsewhere.
+    const AlwaysAllow = struct {
+        fn decide(_: *anyopaque, _: tls_core.tls13_backend.EarlyDataReplayCandidate) tls_core.tls13_backend.EarlyDataReplayDecision {
+            return .allow;
+        }
+    };
+    var replay_ctx: u8 = 0;
+    const gate: tls_core.tls13_backend.EarlyDataReplayGate = .{ .ctx = &replay_ctx, .decideFn = AlwaysAllow.decide };
+
+    var handler_state = TestEarlyDataHandlerState{};
+    var runtime = try Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+        .credential_provider = fixed.provider(),
+        .resumption_runtime = &resumption,
+        .early_data_replay_gate = gate,
+        .enable_0rtt = true,
+        .request_handler = testEarlyDataAwareHandler,
+        .request_handler_ctx = &handler_state,
+    });
+    defer runtime.deinit();
+    try testing.expect(runtime.zero_rtt_enabled);
+
+    // Phase 1: a real handshake, then a real ticket obtained from the
+    // production issuance path (`runtime.issueSessionTicket`), not a
+    // manually-constructed one.
+    const client_cid = [_]u8{ 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8 };
+    const odcid = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08 };
+    const client_path = quic.path.PathKey{
+        .local = quic.udp.Address.ip4(.{ 127, 0, 0, 1 }, 41_300),
+        .remote = quic.udp.Address.ip4(.{ 127, 0, 0, 1 }, 41_301),
+    };
+    const server_path = quic.path.PathKey{
+        .local = quic.udp.Address.ip4(.{ 127, 0, 0, 1 }, 41_301),
+        .remote = quic.udp.Address.ip4(.{ 127, 0, 0, 1 }, 41_300),
+    };
+    const no_challenge = [_]u8{0} ** quic.path.path_challenge_len;
+
+    var client_backend = try quic.tls_backend.Tls13Backend.initClientWithAllocator(
+        allocator,
+        .{ .hello_random = [_]u8{0xc1} ** 32, .key_share_seed = [_]u8{0x11} ** 32 },
+        .{ .pinned_certificate = tls_core.credentials.testdata.certificate_der },
+    );
+
+    const Capture = struct {
+        runtime: *tls_core.resumption_runtime.Runtime,
+        retained: tls_core.session.ClientTicketState = .{},
+        stored: tls_core.session_cache.StoreResult = undefined,
+        count: usize = 0,
+        fn now(_: *anyopaque) i64 {
+            return 1000;
+        }
+        fn onTicket(ctx: *anyopaque, ticket: *const tls_core.session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            ticket.cloneInto(testing.allocator, &self.retained) catch unreachable;
+            self.stored = self.runtime.storeClientTicket(ticket);
+            self.count += 1;
+        }
+    };
+    var capture = Capture{ .runtime = &client_resumption };
+    defer capture.retained.deinit();
+    try client_backend.engine.setSessionTicketConsumer(allocator, tls_core.session.Limits.default, .{
+        .ctx = &capture,
+        .nowUnixMsFn = Capture.now,
+        .onTicketFn = Capture.onTicket,
+    });
+
+    const backend1 = try allocator.create(quic.tls_backend.Tls13Backend);
+    backend1.* = quic.tls_backend.Tls13Backend.initServerWithProvider(
+        .{ .hello_random = [_]u8{0x51} ** 32, .key_share_seed = [_]u8{0x22} ** 32 },
+        fixed.provider(),
+    );
+    // Native QUIC 1-RTT resumption deliberately ignores connection-specific
+    // transport/application snapshots for *ordinary* resumption matching
+    // (mirrors `accept()`'s own `.transport = .ignore` — see
+    // `h3EarlyDataCompatibility`'s doc comment) — without this, the ticket's
+    // `common.transport_compat` gets stamped non-null and the phase-2
+    // candidate lookup below (which intentionally supplies no
+    // transport/application compat context) would miss on origin-digest
+    // mismatch rather than genuinely testing 0-RTT compatibility.
+    const resume_policy: tls_core.tls13_backend.Tls13Backend.ResumeCompatibilityPolicy = .{ .transport = .ignore, .application = .ignore };
+    try client_backend.setResumeCompatibilityPolicy(resume_policy);
+    try backend1.setResumeCompatibilityPolicy(resume_policy);
+
+    const client1 = try Connection.init(allocator, .{
+        .role = .client,
+        .local_cid = &client_cid,
+        .original_dcid = &odcid,
+        .peer_cid = &odcid,
+        .tls = client_backend.backend(),
+        .now_us = 1_000_000,
+        .initial_path = client_path,
+    });
+    defer client1.deinit();
+    const server_conn1 = try Connection.init(allocator, .{
+        .role = .server,
+        .local_cid = &odcid,
+        .original_dcid = &odcid,
+        .peer_cid = &client_cid,
+        .tls = backend1.backend(),
+        .now_us = 1_000_000,
+        .initial_path = server_path,
+    });
+
+    var entry1 = ConnEntry{
+        .backend = backend1,
+        .conn = server_conn1,
+        .h3 = H3.initWithSettings(allocator, .server, .{}),
+        .admission_source_ip = 0,
+        .cid_len = odcid.len,
+        .accepted_at_us = 1_000_000,
+    };
+    defer entry1.deinit(allocator);
+
+    {
+        var rounds: usize = 0;
+        while (rounds < 64) : (rounds += 1) {
+            var progressed = false;
+            var buf: [2048]u8 = undefined;
+            while (client1.pollTransmitOnPath(&buf, 1_000_000)) |t| {
+                try entry1.conn.ingestOnPath(t.bytes, server_path, no_challenge, 1_000_000);
+                progressed = true;
+            }
+            while (entry1.conn.pollTransmitOnPath(&buf, 1_000_000)) |t| {
+                try client1.ingestOnPath(t.bytes, client_path, no_challenge, 1_000_000);
+                progressed = true;
+            }
+            if (!progressed) break;
+        }
+    }
+    try testing.expect(client1.isEstablished());
+    try testing.expect(entry1.conn.isEstablished());
+
+    try runtime.issueSessionTicket(&entry1, &resumption);
+    {
+        var rounds: usize = 0;
+        while (rounds < 16) : (rounds += 1) {
+            var progressed = false;
+            var buf: [2048]u8 = undefined;
+            while (entry1.conn.pollTransmitOnPath(&buf, 1_000_000)) |t| {
+                try client1.ingestOnPath(t.bytes, client_path, no_challenge, 1_000_000);
+                progressed = true;
+            }
+            while (client1.pollTransmitOnPath(&buf, 1_000_000)) |t| {
+                try entry1.conn.ingestOnPath(t.bytes, server_path, no_challenge, 1_000_000);
+                progressed = true;
+            }
+            if (!progressed) break;
+        }
+    }
+    try testing.expectEqual(@as(usize, 1), capture.count);
+    try testing.expectEqual(tls_core.session_cache.StoreResult.stored, capture.stored);
+
+    // Phase 2: a fresh resumed connection actually attempting/accepting
+    // 0-RTT, composed exactly the way `accept()` wires it in production.
+    const candidate: tls_core.session.CandidateContext = .{
+        .cipher_suite = capture.retained.common.cipher_suite,
+        .server_name = if (capture.retained.common.server_name) |*s| s.slice() else null,
+        .application_protocol = if (capture.retained.common.application_protocol) |*a| a.slice() else null,
+        .auth_binding = capture.retained.common.auth_binding,
+        .transport_compat = null,
+        .application_compat = null,
+    };
+    var lookup = client_resumption.lookupClientOffers(candidate);
+    defer lookup.deinit();
+    try testing.expect(lookup == .hit);
+
+    var client_backend2 = quic.tls_backend.Tls13Backend.initClient(
+        .{ .hello_random = [_]u8{0xe1} ** 32, .key_share_seed = [_]u8{0x41} ** 32 },
+        .{ .pinned_certificate = tls_core.credentials.testdata.certificate_der },
+    );
+    var clock_dummy: u8 = 0;
+    const ClientClock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 2000;
+        }
+    };
+    try client_backend2.engine.setClientPskOfferLease(&lookup.hit, &clock_dummy, ClientClock.now);
+    try client_backend2.setResumeCompatibilityPolicy(.{ .transport = .ignore, .application = .ignore });
+    try client_backend2.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 65536 });
+
+    const backend2 = try allocator.create(quic.tls_backend.Tls13Backend);
+    backend2.* = quic.tls_backend.Tls13Backend.initServerWithProvider(
+        .{ .hello_random = [_]u8{0xe2} ** 32, .key_share_seed = [_]u8{0x42} ** 32 },
+        fixed.provider(),
+    );
+    try backend2.setResumeCompatibilityPolicy(.{ .transport = .ignore, .application = .ignore });
+    try backend2.setServerPskResolver(resumption.serverResolver().?);
+    try backend2.setEarlyDataReplayGate(gate);
+    try backend2.setServerEarlyDataPolicy(.{ .enabled = true });
+
+    const client2 = try Connection.init(allocator, .{
+        .role = .client,
+        .config = .{ .zero_rtt_enabled = true },
+        .local_cid = &client_cid,
+        .original_dcid = &odcid,
+        .peer_cid = &odcid,
+        .tls = client_backend2.backend(),
+        .now_us = 2_000_000,
+        .initial_path = client_path,
+    });
+    defer client2.deinit();
+    const server_conn2 = try Connection.init(allocator, .{
+        .role = .server,
+        .config = .{ .zero_rtt_enabled = true },
+        .local_cid = &odcid,
+        .original_dcid = &odcid,
+        .peer_cid = &client_cid,
+        .tls = backend2.backend(),
+        .now_us = 2_000_000,
+        .initial_path = server_path,
+    });
+
+    var entry2 = ConnEntry{
+        .backend = backend2,
+        .conn = server_conn2,
+        .h3 = H3.initWithSettings(allocator, .server, .{}),
+        .admission_source_ip = 0,
+        .cid_len = odcid.len,
+        .accepted_at_us = 2_000_000,
+    };
+    defer entry2.deinit(allocator);
+
+    // Drive only the client's first flight so the server accepts 0-RTT and
+    // installs its read key, but is not yet established — the actual
+    // early-data window this test targets.
+    {
+        var buf: [2048]u8 = undefined;
+        while (client2.pollTransmitOnPath(&buf, 2_000_000)) |t| {
+            try entry2.conn.ingestOnPath(t.bytes, server_path, no_challenge, 2_000_000);
+        }
+    }
+    try testing.expect(!entry2.conn.isEstablished());
+    try testing.expect(entry2.conn.adapter.protectionKeys(.zero_rtt, .read) != null);
+
+    const real_secret = entry2.conn.adapter.secret(.zero_rtt, .read).?.slice()[0..quic.tls_adapter.traffic_secret_len].*;
+
+    // Two real, QPACK-encoded 0-RTT H3 requests on distinct stream ids
+    // (40/44, staying clear of the ids the client's own stream manager will
+    // naturally hand out later for the ordinary post-handshake request) —
+    // a replay-safe GET and a replay-unsafe POST.
+    var get_h3: [128]u8 = undefined;
+    const get_bytes = buildH3RequestBytesForTest("GET", "/safe", "example.com", &get_h3);
+    var get_frame_buf: [160]u8 = undefined;
+    const get_frame_len = try quic.frame.encodeStream(40, 0, get_bytes, true, &get_frame_buf);
+    var get_wire: [512]u8 = undefined;
+    const get_datagram = sealZeroRttPacketForTest(&odcid, &client_cid, real_secret, 0, get_frame_buf[0..get_frame_len], &get_wire);
+    try entry2.conn.ingestOnPath(get_datagram, server_path, no_challenge, 2_000_000);
+
+    var post_h3: [128]u8 = undefined;
+    const post_bytes = buildH3RequestBytesForTest("POST", "/unsafe", "example.com", &post_h3);
+    var post_frame_buf: [160]u8 = undefined;
+    const post_frame_len = try quic.frame.encodeStream(44, 0, post_bytes, true, &post_frame_buf);
+    var post_wire: [512]u8 = undefined;
+    const post_datagram = sealZeroRttPacketForTest(&odcid, &client_cid, real_secret, 1, post_frame_buf[0..post_frame_len], &post_wire);
+    try entry2.conn.ingestOnPath(post_datagram, server_path, no_challenge, 2_000_000);
+
+    // Drive H3 during the early-data window — before establishment. This is
+    // exactly `pumpH3`, the function the second-pass review's finding #2
+    // required to work pre-establishment.
+    runtime.pumpH3(&entry2, 2_000_000);
+
+    // The safe GET reached the local-execution path exactly once; the
+    // unsafe POST was rejected by the shared early-data policy without
+    // ever reaching that path — proving the safety decision, not just
+    // QUIC-level STREAM delivery.
+    try testing.expectEqual(@as(usize, 1), handler_state.executed_local);
+    try testing.expectEqualStrings("GET", handler_state.last_method_buf[0..handler_state.last_method_len]);
+    try testing.expectEqual(@as(usize, 1), handler_state.rejected_too_early);
+
+    // Ordinary (non-early) request post-handshake: even an otherwise-unsafe
+    // method dispatches normally once the connection is fully established,
+    // proving the 425 above was strictly an early-data-window decision, not
+    // a permanent rejection of that route. Reuses phase 1's already-
+    // established `client1`/`entry1` pair rather than continuing to drive
+    // `client2`/`entry2`: the fabricated 0-RTT packets above were sealed
+    // with a throwaway sender adapter that shares no packet-number state
+    // with `client2`'s own counters, so letting `client2` go on to send
+    // real application-space packets of its own would collide with the
+    // packet numbers (0 and 1) those fabricated packets already consumed in
+    // the space 0-RTT and 1-RTT share.
+    const ordinary_id = try client1.openStream(.bidi);
+    var ordinary_h3: [128]u8 = undefined;
+    const ordinary_bytes = buildH3RequestBytesForTest("POST", "/ordinary", "example.com", &ordinary_h3);
+    _ = try client1.writeStream(ordinary_id, ordinary_bytes, true);
+    {
+        var rounds: usize = 0;
+        while (rounds < 32) : (rounds += 1) {
+            var progressed = false;
+            var buf: [2048]u8 = undefined;
+            while (client1.pollTransmitOnPath(&buf, 1_000_000)) |t| {
+                try entry1.conn.ingestOnPath(t.bytes, server_path, no_challenge, 1_000_000);
+                progressed = true;
+            }
+            while (entry1.conn.pollTransmitOnPath(&buf, 1_000_000)) |t| {
+                try client1.ingestOnPath(t.bytes, client_path, no_challenge, 1_000_000);
+                progressed = true;
+            }
+            runtime.pumpH3(&entry1, 1_000_000);
+            if (!progressed) break;
+        }
+    }
+    try testing.expectEqual(@as(usize, 2), handler_state.executed_local);
+    try testing.expectEqualStrings("POST", handler_state.last_method_buf[0..handler_state.last_method_len]);
+    try testing.expectEqual(@as(usize, 1), handler_state.rejected_too_early);
 }
 
 test "runtime resolves the actual bound local address, including an OS-assigned port, from quic_port = 0" {

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -2620,11 +2620,62 @@ test "http3 (#523): a replay-safe early request reaches the local handler exactl
     try testing.expectEqual(@as(usize, 2), handler_state.executed_local);
     try testing.expectEqualStrings("POST", handler_state.last_method_buf[0..handler_state.last_method_len]);
     try testing.expectEqual(@as(usize, 1), handler_state.rejected_too_early);
+
+    // Handler counters only prove the local dispatch/rejection decision —
+    // decode the actual bytes `client2` received on the wire to prove the
+    // responses themselves were transmitted: the safe GET's 200 on stream
+    // 40, and — the specific proof this review round required — the
+    // unsafe POST's 425 on stream 44, showing the queued early-rejection
+    // response genuinely reached the client once 1-RTT became
+    // send-capable, not just that a counter was incremented server-side.
+    try expectH3ResponseStatusForTest(client2, 40, "200");
+    try expectH3ResponseStatusForTest(client2, 44, "425");
+}
+
+/// #523 test-only: read a stream to EOF-of-buffer and decode its first H3
+/// frame as a QPACK HEADERS block, asserting `:status` matches `expected`.
+fn expectH3ResponseStatusForTest(conn: *Connection, stream_id: quic.stream.StreamId, expected_status: []const u8) !void {
+    var buf: [512]u8 = undefined;
+    const result = try conn.readStream(stream_id, &buf);
+    const raw = try http3.frame.decodeFrame(buf[0..result.len]);
+    try testing.expectEqual(http3.frame.FrameType.headers, raw.typ);
+
+    var fields: [8]http3.qpack.HeaderField = undefined;
+    var scratch: [256]u8 = undefined;
+    const count = try http3.qpack.decode(raw.payload, &fields, &scratch);
+    for (fields[0..count]) |field| {
+        if (std.mem.eql(u8, field.name, ":status")) {
+            try testing.expectEqualStrings(expected_status, field.value);
+            return;
+        }
+    }
+    return error.MissingStatusField;
 }
 
 const H3EarlyDataRejectionScenario = struct {
-    replay_gate: ?tls_core.tls13_backend.EarlyDataReplayGate,
+    // Always an installed, decideFn-non-null gate — never absent. Production
+    // `accept()` always wires a real gate (`zeroRttCarrierEnabled` refuses
+    // to enable 0-RTT at all otherwise); modeling "the replay store is
+    // unavailable" as literally no gate installed would test a composition
+    // that can never occur in production. An operationally-unavailable
+    // store is instead a real, installed gate whose `decide` always returns
+    // `.unavailable` (see the replay-store-unavailable test below).
+    replay_gate: tls_core.tls13_backend.EarlyDataReplayGate,
     mutate: *const fn (*Runtime) void,
+    // The H3 SETTINGS snapshot `backend1` remembers into the ticket at
+    // issuance time. Defaults to `.{}`, matching the runtime's own (always
+    // default — see below) live `h3_settings` exactly, so every scenario
+    // except the application-incompatible one is fully app-compatible and
+    // isolates its own specific rejection reason. The application-
+    // incompatible scenario overrides this to a *stricter remembered*
+    // value instead of reducing the runtime's *live* settings: phase 2's
+    // H3 session is initialized with `runtime.h3_settings` (mirroring
+    // `accept()`), and that must stay within
+    // `validateLocallySupportedSettings`'s bounds or the H3 session never
+    // starts at all (see "H3 conn: start rejects unsupported
+    // max_field_section_size" in `src/http3/conn.zig`) — silently breaking
+    // the same-connection 1-RTT fallback this whole matrix is proving.
+    remembered_app_settings: http3.frame.Settings = .{},
     expect_decision: metrics_mod.QuicEarlyDataDecision,
 };
 
@@ -2632,22 +2683,6 @@ fn h3EarlyDataRejectionNoMutation(_: *Runtime) void {}
 
 fn h3EarlyDataRejectionReduceTransportLimit(runtime: *Runtime) void {
     runtime.quic_config.initial_max_streams_bidi -= 1;
-}
-
-fn h3EarlyDataRejectionReduceSettingsLimit(runtime: *Runtime) void {
-    // `remembered` (baked into the ticket at issuance, when this field was
-    // still `null`) vs `current` (this, read live at gate-consult time):
-    // `early_data.limitCompatible` requires a null-remembered limit to stay
-    // null — introducing one where none existed before is itself the
-    // "incompatible" transition (see `src/http3/early_data.zig`). All of
-    // this codebase's *other* H3 SETTINGS fields default to `0`/`false`,
-    // which `early_data.zig`'s own compatibility rules for those fields
-    // treat as vacuously compatible (`qpackMaxTableCompatible` short-
-    // circuits `remembered == 0`; `qpack_blocked_streams`/booleans only
-    // reject a *regression* from a already-nonzero/true remembered value) —
-    // so this is the only field that can actually produce
-    // `.settings_incompatible` from this runtime's always-default settings.
-    runtime.h3_settings.max_field_section_size = 1024;
 }
 
 /// Shared production-shaped scaffold for #523's "0-RTT rejected -> same
@@ -2700,6 +2735,17 @@ fn expectH3EarlyDataRejectionFallsBackToRealRequest(scenario: H3EarlyDataRejecti
     };
     var decision_capture = DecisionCapture{};
 
+    const PacketCapture = struct {
+        count: usize = 0,
+        last: ?metrics_mod.QuicZeroRttPacketOutcome = null,
+        fn onPacket(ctx: *anyopaque, outcome: metrics_mod.QuicZeroRttPacketOutcome) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.count += 1;
+            self.last = outcome;
+        }
+    };
+    var packet_capture = PacketCapture{};
+
     // `quicConfigFrom`/`zeroRttCarrierEnabled` require a replay gate present
     // on the *runtime's own* config before they'll consider 0-RTT usable at
     // all (see the "enable_0rtt alone never enables the 0-RTT carrier" unit
@@ -2724,6 +2770,8 @@ fn expectH3EarlyDataRejectionFallsBackToRealRequest(scenario: H3EarlyDataRejecti
         .request_handler_ctx = &handler_state,
         .quic_early_data_decision_metrics_ctx = &decision_capture,
         .quic_early_data_decision_metrics_cb = DecisionCapture.onDecision,
+        .quic_zero_rtt_packet_metrics_ctx = &packet_capture,
+        .quic_zero_rtt_packet_metrics_cb = PacketCapture.onPacket,
     });
     defer runtime.deinit();
     try testing.expect(runtime.zero_rtt_enabled);
@@ -2784,15 +2832,23 @@ fn expectH3EarlyDataRejectionFallsBackToRealRequest(scenario: H3EarlyDataRejecti
     try client_backend.setResumeCompatibilityPolicy(resume_policy);
     try backend1.setResumeCompatibilityPolicy(resume_policy);
     // Mirror production `accept()`'s installation of the H3 application
-    // compat snapshot at ticket-issuance time using the runtime's own
-    // precomputed bytes — without this, the ticket has no remembered
-    // application state at all, and a scenario meant to isolate one
-    // specific rejection reason could actually be passing for a different
-    // one (`application_incompatible` via `missing_state`) instead.
+    // compat snapshot at ticket-issuance time — without this, the ticket
+    // has no remembered application state at all, and a scenario meant to
+    // isolate one specific rejection reason could actually be passing for a
+    // different one (`application_incompatible` via `missing_state`)
+    // instead. Encoded fresh from `scenario.remembered_app_settings` rather
+    // than reusing `runtime.h3_application_compat` directly: every scenario
+    // but the application-incompatible one leaves this at `.{}`, which
+    // encodes identically to the runtime's own default `h3_settings`, so
+    // this is a distinction without a difference for them — but the
+    // application-incompatible scenario needs a *stricter remembered*
+    // snapshot than the (always locally-supported-default) live settings.
+    var remembered_app_compat_buf: [http3.early_data.encoded_snapshot_len]u8 = undefined;
+    const remembered_app_compat_bytes = try http3.early_data.encodeSettingsSnapshot(scenario.remembered_app_settings, &remembered_app_compat_buf);
     try backend1.setEarlyDataApplicationCompat(.{
         .format_id = http3.early_data.format_id,
         .format_version = http3.early_data.format_version,
-        .bytes = runtime.h3_application_compat[0..runtime.h3_application_compat_len],
+        .bytes = remembered_app_compat_bytes,
     });
 
     const client1 = try Connection.init(allocator, .{
@@ -2908,10 +2964,7 @@ fn expectH3EarlyDataRejectionFallsBackToRealRequest(scenario: H3EarlyDataRejecti
     );
     try backend2.setResumeCompatibilityPolicy(.{ .transport = .ignore, .application = .ignore });
     try backend2.setServerPskResolver(resumption.serverResolver().?);
-    // `null` deliberately leaves no replay gate installed at all — the
-    // backend's own default gate fails closed (`.replay_unavailable`) for
-    // every attempt, exercising that fail-closed default itself.
-    if (scenario.replay_gate) |gate| try backend2.setEarlyDataReplayGate(gate);
+    try backend2.setEarlyDataReplayGate(scenario.replay_gate);
     try backend2.setServerEarlyDataPolicy(.{ .enabled = true });
     try backend2.setEarlyDataCompatibilityGate(.{ .ctx = &runtime, .decideFn = Runtime.h3EarlyDataCompatibility });
 
@@ -2941,7 +2994,11 @@ fn expectH3EarlyDataRejectionFallsBackToRealRequest(scenario: H3EarlyDataRejecti
     var entry2 = ConnEntry{
         .backend = backend2,
         .conn = server_conn2,
-        .h3 = H3.initWithSettings(allocator, .server, .{}),
+        // Mirrors `accept()`'s `self.h3_settings` (line ~585) — for the
+        // application-incompatible scenario, `scenario.mutate` just changed
+        // this live value, so phase 2's actual H3 session must run under
+        // those same (mutated) SETTINGS, not silently fall back to defaults.
+        .h3 = H3.initWithSettings(allocator, .server, runtime.h3_settings),
         .admission_source_ip = 0,
         .cid_len = odcid.len,
         .accepted_at_us = 2_000_000,
@@ -2962,6 +3019,31 @@ fn expectH3EarlyDataRejectionFallsBackToRealRequest(scenario: H3EarlyDataRejecti
     try testing.expect(entry2.conn.adapter.protectionKeys(.zero_rtt, .read) == null);
     try testing.expectEqual(@as(usize, 1), decision_capture.count);
     try testing.expectEqual(scenario.expect_decision, decision_capture.last.?);
+
+    // Prove rejection actually suppresses early delivery, not just that no
+    // read key exists: the client's own TLS engine still derives and would
+    // use a real 0-RTT write secret regardless of what the server's gate
+    // decides (it can't know the decision in advance) — extract that real
+    // secret and seal a genuine QPACK-encoded H3 GET as an early 0-RTT
+    // packet, exactly as a real client attempting (and having rejected)
+    // early data would send. The server can't have a matching read key (see
+    // above), so this must be dropped as `keys_unavailable` before ever
+    // reaching the frame/H3 layer — not merely "no packet was sent".
+    {
+        const client_write_secret = client2.adapter.secret(.zero_rtt, .write).?.slice()[0..quic.tls_adapter.traffic_secret_len].*;
+        var early_h3: [128]u8 = undefined;
+        const early_bytes = buildH3RequestBytesForTest("GET", "/early-after-rejection", "example.com", &early_h3);
+        var early_frame_buf: [160]u8 = undefined;
+        const early_frame_len = try quic.frame.encodeStream(40, 0, early_bytes, true, &early_frame_buf);
+        var early_wire: [512]u8 = undefined;
+        const early_datagram = sealZeroRttPacketForTest(&odcid, &client_cid, client_write_secret, 0, early_frame_buf[0..early_frame_len], &early_wire);
+        try entry2.conn.ingestOnPath(early_datagram, server_path, no_challenge, 2_000_000);
+        runtime.pumpH3(&entry2, 2_000_000);
+    }
+    try testing.expectEqual(@as(usize, 1), packet_capture.count);
+    try testing.expectEqual(metrics_mod.QuicZeroRttPacketOutcome.keys_unavailable, packet_capture.last.?);
+    try testing.expectEqual(@as(usize, 0), handler_state.executed_local);
+    try testing.expectEqual(@as(usize, 0), handler_state.rejected_too_early);
 
     // The rest of the handshake completes normally as ordinary 1-RTT
     // resumption on this *same* connection — rejection is strictly an
@@ -3029,8 +3111,19 @@ test "http3 (#523): replay-rejected 0-RTT falls back to a real H3 request over 1
 }
 
 test "http3 (#523): replay-store-unavailable 0-RTT falls back to a real H3 request over 1-RTT, same connection" {
+    // Models an operationally-unavailable replay store (e.g. the process
+    // shared store failing open a lookup) as a real, installed gate whose
+    // `decide` always reports `.unavailable` — not the absence of a gate,
+    // which `zeroRttCarrierEnabled` never lets a production composition
+    // reach in the first place.
+    const AlwaysUnavailable = struct {
+        fn decide(_: *anyopaque, _: tls_core.tls13_backend.EarlyDataReplayCandidate) tls_core.tls13_backend.EarlyDataReplayDecision {
+            return .unavailable;
+        }
+    };
+    var replay_ctx: u8 = 0;
     try expectH3EarlyDataRejectionFallsBackToRealRequest(.{
-        .replay_gate = null,
+        .replay_gate = .{ .ctx = &replay_ctx, .decideFn = AlwaysUnavailable.decide },
         .mutate = h3EarlyDataRejectionNoMutation,
         .expect_decision = .replay_unavailable,
     });
@@ -3059,7 +3152,15 @@ test "http3 (#523): application-incompatible (H3 SETTINGS) 0-RTT rejected by the
     var replay_ctx: u8 = 0;
     try expectH3EarlyDataRejectionFallsBackToRealRequest(.{
         .replay_gate = .{ .ctx = &replay_ctx, .decideFn = AlwaysAllow.decide },
-        .mutate = h3EarlyDataRejectionReduceSettingsLimit,
+        .mutate = h3EarlyDataRejectionNoMutation,
+        // A stricter *remembered* QPACK dynamic-table capacity than the
+        // live (always-default, `qpack_max_table_capacity == 0`) settings
+        // phase 2 actually runs under: `qpackMaxTableCompatible` treats
+        // `remembered == 0` as vacuously compatible, so this field can only
+        // ever produce `.settings_incompatible` by remembering *more* than
+        // the always-zero live default — never by reducing the live side
+        // (see `H3EarlyDataRejectionScenario.remembered_app_settings`).
+        .remembered_app_settings = .{ .qpack_max_table_capacity = 4096 },
         .expect_decision = .application_incompatible,
     });
 }

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -78,6 +78,16 @@ pub const Config = struct {
     request_handler_ctx: ?*anyopaque = null,
     early_data_compat_metrics_ctx: ?*anyopaque = null,
     early_data_compat_metrics_cb: ?*const fn (*anyopaque, metrics_mod.H3EarlyDataCompatDecision) void = null,
+    /// #523: the QUIC/H3 server's authoritative 0-RTT accept/reject decision
+    /// (`quic.connection.Event.early_data_decision`), bridged out of every
+    /// accepted connection's `EventSink`. `null` (the default) leaves the
+    /// event unobserved — never silently required.
+    quic_early_data_decision_metrics_ctx: ?*anyopaque = null,
+    quic_early_data_decision_metrics_cb: ?*const fn (*anyopaque, metrics_mod.QuicEarlyDataDecision) void = null,
+    /// #523: per-packet 0-RTT authentication/admission outcomes
+    /// (`quic.connection.Event.zero_rtt_packet`), bridged the same way.
+    quic_zero_rtt_packet_metrics_ctx: ?*anyopaque = null,
+    quic_zero_rtt_packet_metrics_cb: ?*const fn (*anyopaque, metrics_mod.QuicZeroRttPacketOutcome) void = null,
 };
 
 /// Half-open admission limits (#328 review). The native stack does not send
@@ -186,6 +196,10 @@ pub const Runtime = struct {
     h3_application_compat_len: usize = 0,
     early_data_compat_metrics_ctx: ?*anyopaque = null,
     early_data_compat_metrics_cb: ?*const fn (*anyopaque, metrics_mod.H3EarlyDataCompatDecision) void = null,
+    quic_early_data_decision_metrics_ctx: ?*anyopaque = null,
+    quic_early_data_decision_metrics_cb: ?*const fn (*anyopaque, metrics_mod.QuicEarlyDataDecision) void = null,
+    quic_zero_rtt_packet_metrics_ctx: ?*anyopaque = null,
+    quic_zero_rtt_packet_metrics_cb: ?*const fn (*anyopaque, metrics_mod.QuicZeroRttPacketOutcome) void = null,
     snapshot_mutex: compat.Mutex = .{},
     snapshot_state: Snapshot,
     stopping: std.atomic.Value(bool),
@@ -235,6 +249,10 @@ pub const Runtime = struct {
             .h3_settings = cfg.h3_settings,
             .early_data_compat_metrics_ctx = cfg.early_data_compat_metrics_ctx,
             .early_data_compat_metrics_cb = cfg.early_data_compat_metrics_cb,
+            .quic_early_data_decision_metrics_ctx = cfg.quic_early_data_decision_metrics_ctx,
+            .quic_early_data_decision_metrics_cb = cfg.quic_early_data_decision_metrics_cb,
+            .quic_zero_rtt_packet_metrics_ctx = cfg.quic_zero_rtt_packet_metrics_ctx,
+            .quic_zero_rtt_packet_metrics_cb = cfg.quic_zero_rtt_packet_metrics_cb,
             .snapshot_state = .{ .quic_port = cfg.quic_port },
             .stopping = std.atomic.Value(bool).init(false),
         };
@@ -550,6 +568,7 @@ pub const Runtime = struct {
             .tls = backend.backend(),
             .now_us = now,
             .initial_path = .{ .local = self.local_address, .remote = addressFromSockaddrIn(peer) },
+            .events = .{ .context = self, .emitFn = quicConnectionEvent },
         }) catch {
             allocator.destroy(backend);
             return null;
@@ -906,6 +925,59 @@ pub const Runtime = struct {
         const cb = self.early_data_compat_metrics_cb orelse return;
         const cb_ctx = self.early_data_compat_metrics_ctx orelse return;
         cb(cb_ctx, decision);
+    }
+
+    fn recordQuicEarlyDataDecision(self: *Runtime, decision: metrics_mod.QuicEarlyDataDecision) void {
+        const cb = self.quic_early_data_decision_metrics_cb orelse return;
+        const cb_ctx = self.quic_early_data_decision_metrics_ctx orelse return;
+        cb(cb_ctx, decision);
+    }
+
+    fn recordQuicZeroRttPacket(self: *Runtime, outcome: metrics_mod.QuicZeroRttPacketOutcome) void {
+        const cb = self.quic_zero_rtt_packet_metrics_cb orelse return;
+        const cb_ctx = self.quic_zero_rtt_packet_metrics_ctx orelse return;
+        cb(cb_ctx, outcome);
+    }
+
+    /// #523: bridges `quic.connection.Event`s from every accepted
+    /// connection into the composition root's metrics — without this,
+    /// `accept()` would construct connections with no `EventSink` at all
+    /// and the typed TLS decision / per-packet 0-RTT outcomes would be
+    /// silently discarded. Only forwards the two 0-RTT-specific event
+    /// variants; every other `Connection.Event` (packet_received,
+    /// handshake_complete, path_validated, ...) is intentionally not this
+    /// function's concern.
+    fn quicConnectionEvent(ctx: ?*anyopaque, event: quic.connection.Event) void {
+        const self: *Runtime = @ptrCast(@alignCast(ctx.?));
+        switch (event) {
+            .early_data_decision => |decision| {
+                const mapped: metrics_mod.QuicEarlyDataDecision = switch (decision) {
+                    .not_attempted => return,
+                    .accepted => .accepted,
+                    .disabled => .disabled,
+                    .ticket_not_capable => .ticket_not_capable,
+                    .selected_identity_not_zero => .selected_identity_not_zero,
+                    .age_skew => .age_skew,
+                    .transport_incompatible => .transport_incompatible,
+                    .application_incompatible => .application_incompatible,
+                    .replay_rejected => .replay_rejected,
+                    .replay_unavailable => .replay_unavailable,
+                    .resource_limited => .resource_limited,
+                };
+                self.recordQuicEarlyDataDecision(mapped);
+            },
+            .zero_rtt_packet => |packet| {
+                const mapped: metrics_mod.QuicZeroRttPacketOutcome = switch (packet.outcome) {
+                    .accepted => .accepted,
+                    .keys_unavailable => .keys_unavailable,
+                    .authentication_failed => .authentication_failed,
+                    .duplicate => .duplicate,
+                    .malformed => .malformed,
+                };
+                self.recordQuicZeroRttPacket(mapped);
+            },
+            else => {},
+        }
     }
 
     fn noteConnectionAccepted(self: *Runtime) void {
@@ -2477,6 +2549,77 @@ test "http3 (#523): a replay-safe early request reaches the local handler exactl
     try testing.expectEqual(@as(usize, 2), handler_state.executed_local);
     try testing.expectEqualStrings("POST", handler_state.last_method_buf[0..handler_state.last_method_len]);
     try testing.expectEqual(@as(usize, 1), handler_state.rejected_too_early);
+}
+
+test "accept() (#523): wires an EventSink into every accepted connection so 0-RTT events reach metrics instead of being silently discarded" {
+    var fixed = tls_core.credentials.FixedCredentialProvider.init(tls_core.credentials.testdata.identity());
+    defer fixed.deinit();
+    var logger = logger_mod.Logger.init(.err, "http3-event-wiring-test");
+
+    const Capture = struct {
+        decisions: usize = 0,
+        packets: usize = 0,
+
+        fn onDecision(ctx: *anyopaque, _: metrics_mod.QuicEarlyDataDecision) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.decisions += 1;
+        }
+        fn onPacket(ctx: *anyopaque, _: metrics_mod.QuicZeroRttPacketOutcome) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.packets += 1;
+        }
+    };
+    var capture = Capture{};
+
+    var runtime = try Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+        .credential_provider = fixed.provider(),
+        .quic_early_data_decision_metrics_ctx = &capture,
+        .quic_early_data_decision_metrics_cb = Capture.onDecision,
+        .quic_zero_rtt_packet_metrics_ctx = &capture,
+        .quic_zero_rtt_packet_metrics_cb = Capture.onPacket,
+    });
+    defer runtime.deinit();
+
+    var connections = std.AutoHashMap(u64, *ConnEntry).init(testing.allocator);
+    defer {
+        var it = connections.valueIterator();
+        while (it.next()) |entry| {
+            entry.*.deinit(testing.allocator);
+            testing.allocator.destroy(entry.*);
+        }
+        connections.deinit();
+    }
+    var routes = quic.cid.CidRoutingTable.init(testing.allocator);
+    defer routes.deinit();
+    var per_ip = std.AutoHashMap(u32, u32).init(testing.allocator);
+    defer per_ip.deinit();
+    var next_handle: u64 = 1;
+
+    const dcid = [_]u8{0x11} ** 8;
+    const scid = [_]u8{0x22} ** 8;
+    const parsed = quic.packet.ParsedPacket{
+        .kind = .initial,
+        .version = quic.packet.quic_v1,
+        .dcid = &dcid,
+        .scid = &scid,
+    };
+    const peer = std.c.sockaddr.in{ .family = posix.AF.INET, .port = 0, .addr = 0, .zero = [_]u8{0} ** 8 };
+
+    const handle = runtime.accept(&connections, &routes, &per_ip, &next_handle, parsed, peer, 1_000_000);
+    try testing.expect(handle != null);
+    const entry = connections.get(handle.?).?;
+
+    // Prove `accept()` genuinely attached a non-default `EventSink` (not
+    // just left it at its `.{}` no-op default) by emitting directly through
+    // it — this is what a real handshake's `Event.early_data_decision` /
+    // `Event.zero_rtt_packet` emissions from inside `Connection` would
+    // otherwise reach and, before this fix, never did.
+    entry.conn.events.emit(.{ .early_data_decision = .disabled });
+    entry.conn.events.emit(.{ .zero_rtt_packet = .{ .outcome = .keys_unavailable, .size = 0 } });
+    try testing.expectEqual(@as(usize, 1), capture.decisions);
+    try testing.expectEqual(@as(usize, 1), capture.packets);
 }
 
 test "runtime resolves the actual bound local address, including an OS-assigned port, from quic_port = 0" {

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -2446,6 +2446,38 @@ test "http3 (#523): a replay-safe early request reaches the local handler exactl
         .initial_path = client_path,
     });
     defer client2.deinit();
+
+    // There is no production client-side 0-RTT transmit path — the two
+    // fabricated 0-RTT packets below are sealed by a throwaway sender
+    // adapter operating entirely outside `client2`'s own connection state
+    // (see `sealZeroRttPacketForTest`) — so without this, `client2`'s own
+    // `StreamManager` would have no record of stream ids 40/44 at all. Once
+    // established, the server refreshes send credit for every stream it
+    // knows about (`StreamManager.refreshPeerParams`) and each early
+    // request's H3 response travels back on that same bidi stream id, both
+    // of which `client2` would otherwise reject as `error.UnknownStream`,
+    // aborting the connection before it could ever serve a later request.
+    // Bring `client2`'s stream layer up early — mirroring
+    // `Connection.ensureEarlyStreamManager`, which never runs client-side
+    // since a client never receives a `.zero_rtt`-level packet itself — and
+    // seed it with placeholder `Stream` entries at exactly those two ids,
+    // standing in for the state a real client would already have from
+    // having opened them itself before transmitting its own early data.
+    client2.streams = quic.stream.StreamManager.init(allocator, .client, client2.local_params, client2.local_params);
+    inline for (.{ @as(quic.stream.StreamId, 40), @as(quic.stream.StreamId, 44) }) |placeholder_id| {
+        const placeholder = try allocator.create(quic.stream.Stream);
+        placeholder.* = .{
+            .id = placeholder_id,
+            .role = .client,
+            .typ = .bidi,
+            .init = .client,
+            .initial_recv_window = client2.local_params.initial_max_stream_data_bidi_local,
+            .max_recv_data = client2.local_params.initial_max_stream_data_bidi_local,
+            .max_send_data = 0,
+        };
+        try client2.streams.?.streams.put(placeholder_id, placeholder);
+    }
+
     const server_conn2 = try Connection.init(allocator, .{
         .role = .server,
         .config = .{ .zero_rtt_enabled = true },
@@ -2501,6 +2533,20 @@ test "http3 (#523): a replay-safe early request reaches the local handler exactl
     const post_datagram = sealZeroRttPacketForTest(&odcid, &client_cid, real_secret, 1, post_frame_buf[0..post_frame_len], &post_wire);
     try entry2.conn.ingestOnPath(post_datagram, server_path, no_challenge, 2_000_000);
 
+    // The two fabricated 0-RTT packets above used application-space packet
+    // numbers 0 and 1 through a throwaway sender adapter alongside (not
+    // through) `client2`'s own transmit path — there is no real client
+    // 0-RTT transmit path to drive instead (see `sealZeroRttPacketForTest`).
+    // The server's ACKs for those packet numbers raise `client2`'s own
+    // `largest_peer_acked` for this space once received; advance `client2`'s
+    // own send counter to match what the server has already recorded as
+    // used, so `client2`'s later real packets don't collide with (and get
+    // authenticated as duplicates of, or worse — encoded with a packet
+    // number `packetNumberLength` asserts is impossible relative to an
+    // already-higher acked value — see RFC 9000 §17.1) those already-
+    // consumed numbers.
+    client2.next_pn[@intFromEnum(quic.recovery.PacketNumberSpace.application)] = 2;
+
     // Drive H3 during the early-data window — before establishment. This is
     // exactly `pumpH3`, the function the second-pass review's finding #2
     // required to work pre-establishment.
@@ -2514,44 +2560,60 @@ test "http3 (#523): a replay-safe early request reaches the local handler exactl
     try testing.expectEqualStrings("GET", handler_state.last_method_buf[0..handler_state.last_method_len]);
     try testing.expectEqual(@as(usize, 1), handler_state.rejected_too_early);
 
-    // Ordinary (non-early) request post-handshake: even an otherwise-unsafe
-    // method dispatches normally once the connection is fully established,
-    // proving the 425 above was strictly an early-data-window decision, not
-    // a permanent rejection of that route. This deliberately reuses phase
-    // 1's already-established `client1`/`entry1` pair rather than
-    // continuing to drive `client2`/`entry2`: the fabricated 0-RTT packets
-    // above were sealed with a throwaway sender adapter operating entirely
-    // outside `client2`'s own connection state (there is no real client
-    // 0-RTT transmit path — see `sealZeroRttPacketForTest`), so the server
-    // now believes streams 40/44 exist and have received bytes that
-    // `client2`'s own `StreamManager` has no record of at all. Letting
-    // `client2` continue would need the server to never reference those
-    // stream ids again (e.g. via MAX_STREAM_DATA credit renewal, which H3
-    // request assembly triggers naturally) — and there is no way to
-    // pre-register matching stream state on `client2` first, since its
-    // `StreamManager` does not exist until *after* the handshake completes,
-    // which is exactly the step this would need to happen before. The
-    // dedicated same-connection rejection-fallback test below avoids this
-    // entirely: 0-RTT rejection never installs `.zero_rtt` read keys, so no
-    // fabricated packet — and no such divergent state — exists at all.
-    const ordinary_id = try client1.openStream(.bidi);
+    // The rest of the handshake completes normally on the *same* connection
+    // that just attempted 0-RTT — accepted/rejected early requests don't
+    // derail ordinary 1-RTT completion. This is where the queued 425 for
+    // the unsafe POST above (and the 200 for the safe GET) actually reach
+    // the wire: the placeholder streams seeded above let `client2` accept
+    // the server's MAX_STREAM_DATA credit renewal and each response's
+    // STREAM frames on ids 40/44 without erroring `UnknownStream`.
+    {
+        var rounds: usize = 0;
+        while (rounds < 64) : (rounds += 1) {
+            var progressed = false;
+            var buf: [2048]u8 = undefined;
+            while (client2.pollTransmitOnPath(&buf, 2_000_000)) |t| {
+                try entry2.conn.ingestOnPath(t.bytes, server_path, no_challenge, 2_000_000);
+                progressed = true;
+            }
+            while (entry2.conn.pollTransmitOnPath(&buf, 2_000_000)) |t| {
+                try client2.ingestOnPath(t.bytes, client_path, no_challenge, 2_000_000);
+                progressed = true;
+            }
+            runtime.pumpH3(&entry2, 2_000_000);
+            if (!progressed) break;
+        }
+    }
+    try testing.expect(client2.isEstablished());
+    try testing.expect(entry2.conn.isEstablished());
+
+    // Ordinary (non-early) request post-handshake, on that *same*
+    // connection: even an otherwise-unsafe method dispatches normally once
+    // established, proving the 425 above was strictly an early-data-window
+    // decision, not a permanent rejection of that route — and proving the
+    // connection that attempted 0-RTT is itself genuinely usable
+    // afterward, not just some other, cleaner connection. `openStream`
+    // hands out id 0 (the first *real* client-opened bidi stream — the
+    // placeholder ids 40/44 above bypassed `openLocal`'s counter entirely),
+    // so there is no collision with the fabricated early streams.
+    const ordinary_id = try client2.openStream(.bidi);
     var ordinary_h3: [128]u8 = undefined;
     const ordinary_bytes = buildH3RequestBytesForTest("POST", "/ordinary", "example.com", &ordinary_h3);
-    _ = try client1.writeStream(ordinary_id, ordinary_bytes, true);
+    _ = try client2.writeStream(ordinary_id, ordinary_bytes, true);
     {
         var rounds: usize = 0;
         while (rounds < 32) : (rounds += 1) {
             var progressed = false;
             var buf: [2048]u8 = undefined;
-            while (client1.pollTransmitOnPath(&buf, 1_000_000)) |t| {
-                try entry1.conn.ingestOnPath(t.bytes, server_path, no_challenge, 1_000_000);
+            while (client2.pollTransmitOnPath(&buf, 2_000_000)) |t| {
+                try entry2.conn.ingestOnPath(t.bytes, server_path, no_challenge, 2_000_000);
                 progressed = true;
             }
-            while (entry1.conn.pollTransmitOnPath(&buf, 1_000_000)) |t| {
-                try client1.ingestOnPath(t.bytes, client_path, no_challenge, 1_000_000);
+            while (entry2.conn.pollTransmitOnPath(&buf, 2_000_000)) |t| {
+                try client2.ingestOnPath(t.bytes, client_path, no_challenge, 2_000_000);
                 progressed = true;
             }
-            runtime.pumpH3(&entry1, 1_000_000);
+            runtime.pumpH3(&entry2, 2_000_000);
             if (!progressed) break;
         }
     }
@@ -2560,11 +2622,50 @@ test "http3 (#523): a replay-safe early request reaches the local handler exactl
     try testing.expectEqual(@as(usize, 1), handler_state.rejected_too_early);
 }
 
-test "http3 (#523): 0-RTT rejected by the real Runtime.h3EarlyDataCompatibility gate still serves a real H3 request over 1-RTT, same connection" {
+const H3EarlyDataRejectionScenario = struct {
+    replay_gate: ?tls_core.tls13_backend.EarlyDataReplayGate,
+    mutate: *const fn (*Runtime) void,
+    expect_decision: metrics_mod.QuicEarlyDataDecision,
+};
+
+fn h3EarlyDataRejectionNoMutation(_: *Runtime) void {}
+
+fn h3EarlyDataRejectionReduceTransportLimit(runtime: *Runtime) void {
+    runtime.quic_config.initial_max_streams_bidi -= 1;
+}
+
+fn h3EarlyDataRejectionReduceSettingsLimit(runtime: *Runtime) void {
+    // `remembered` (baked into the ticket at issuance, when this field was
+    // still `null`) vs `current` (this, read live at gate-consult time):
+    // `early_data.limitCompatible` requires a null-remembered limit to stay
+    // null — introducing one where none existed before is itself the
+    // "incompatible" transition (see `src/http3/early_data.zig`). All of
+    // this codebase's *other* H3 SETTINGS fields default to `0`/`false`,
+    // which `early_data.zig`'s own compatibility rules for those fields
+    // treat as vacuously compatible (`qpackMaxTableCompatible` short-
+    // circuits `remembered == 0`; `qpack_blocked_streams`/booleans only
+    // reject a *regression* from a already-nonzero/true remembered value) —
+    // so this is the only field that can actually produce
+    // `.settings_incompatible` from this runtime's always-default settings.
+    runtime.h3_settings.max_field_section_size = 1024;
+}
+
+/// Shared production-shaped scaffold for #523's "0-RTT rejected -> same
+/// resumed connection still serves a real H3 request over 1-RTT" matrix.
+/// Phase 1 mirrors `accept()`'s exact composition (including the H3
+/// application-compat snapshot installed at ticket-issuance time — omitting
+/// it left a prior version of this test able to pass for the wrong
+/// rejection reason, since a ticket with no remembered application state at
+/// all resolves to `.application_incompatible` regardless of the transport
+/// snapshot). Phase 2 wires the *real* `Runtime.h3EarlyDataCompatibility`
+/// gate and the *real* `Runtime.quicConnectionEvent` bridge production uses,
+/// so the typed early-data decision this asserts on is the one that would
+/// actually reach metrics in production, not a synthetic stand-in.
+fn expectH3EarlyDataRejectionFallsBackToRealRequest(scenario: H3EarlyDataRejectionScenario) !void {
     const allocator = testing.allocator;
     var fixed = tls_core.credentials.FixedCredentialProvider.init(tls_core.credentials.testdata.identity());
     defer fixed.deinit();
-    var logger = logger_mod.Logger.init(.err, "http3-early-request-real-gate-rejection-test");
+    var logger = logger_mod.Logger.init(.err, "http3-early-request-rejection-matrix-test");
 
     var server_entropy = tls_core.production_crypto.OsEntropy{};
     var server_provider_state = tls_core.production_crypto.Provider.init(server_entropy.entropy());
@@ -2586,35 +2687,53 @@ test "http3 (#523): 0-RTT rejected by the real Runtime.h3EarlyDataCompatibility 
     );
     defer client_resumption.deinit();
 
-    const AlwaysAllow = struct {
+    var handler_state = TestEarlyDataHandlerState{};
+
+    const DecisionCapture = struct {
+        count: usize = 0,
+        last: ?metrics_mod.QuicEarlyDataDecision = null,
+        fn onDecision(ctx: *anyopaque, decision: metrics_mod.QuicEarlyDataDecision) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.count += 1;
+            self.last = decision;
+        }
+    };
+    var decision_capture = DecisionCapture{};
+
+    // `quicConfigFrom`/`zeroRttCarrierEnabled` require a replay gate present
+    // on the *runtime's own* config before they'll consider 0-RTT usable at
+    // all (see the "enable_0rtt alone never enables the 0-RTT carrier" unit
+    // test above) — this placeholder is otherwise inert here, since
+    // `backend2` below is wired with `scenario.replay_gate` directly rather
+    // than going through `runtime.accept()`.
+    const RuntimeLevelAlwaysAllow = struct {
         fn decide(_: *anyopaque, _: tls_core.tls13_backend.EarlyDataReplayCandidate) tls_core.tls13_backend.EarlyDataReplayDecision {
             return .allow;
         }
     };
-    var replay_ctx: u8 = 0;
-    const gate: tls_core.tls13_backend.EarlyDataReplayGate = .{ .ctx = &replay_ctx, .decideFn = AlwaysAllow.decide };
+    var runtime_replay_ctx: u8 = 0;
 
-    var handler_state = TestEarlyDataHandlerState{};
     var runtime = try Runtime.init(testing.allocator, &logger, .{
         .listen_host = "127.0.0.1",
         .quic_port = 0,
         .credential_provider = fixed.provider(),
         .resumption_runtime = &resumption,
-        .early_data_replay_gate = gate,
+        .early_data_replay_gate = .{ .ctx = &runtime_replay_ctx, .decideFn = RuntimeLevelAlwaysAllow.decide },
         .enable_0rtt = true,
         .request_handler = testEarlyDataAwareHandler,
         .request_handler_ctx = &handler_state,
+        .quic_early_data_decision_metrics_ctx = &decision_capture,
+        .quic_early_data_decision_metrics_cb = DecisionCapture.onDecision,
     });
     defer runtime.deinit();
     try testing.expect(runtime.zero_rtt_enabled);
 
     // Phase 1: a real handshake, then a real ticket obtained from the
-    // production issuance path — identical setup to the accepted-case test
-    // above, except `server_conn1` is explicitly constructed with the
-    // runtime's own live `quic_config` (mirrors `accept()`'s
-    // `.config = self.quic_config`) so the transport-parameters snapshot the
-    // ticket remembers is exactly what `Runtime.h3EarlyDataCompatibility`
-    // will later compare a *reduced* live config against.
+    // production issuance path. `server_conn1` is explicitly constructed
+    // with the runtime's own live `quic_config` (mirrors `accept()`'s
+    // `.config = self.quic_config`) so the transport-parameters snapshot
+    // the ticket remembers is exactly what `Runtime.h3EarlyDataCompatibility`
+    // will later compare a possibly-mutated live config against.
     const client_cid = [_]u8{ 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8 };
     const odcid = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08 };
     const client_path = quic.path.PathKey{
@@ -2664,6 +2783,17 @@ test "http3 (#523): 0-RTT rejected by the real Runtime.h3EarlyDataCompatibility 
     const resume_policy: tls_core.tls13_backend.Tls13Backend.ResumeCompatibilityPolicy = .{ .transport = .ignore, .application = .ignore };
     try client_backend.setResumeCompatibilityPolicy(resume_policy);
     try backend1.setResumeCompatibilityPolicy(resume_policy);
+    // Mirror production `accept()`'s installation of the H3 application
+    // compat snapshot at ticket-issuance time using the runtime's own
+    // precomputed bytes — without this, the ticket has no remembered
+    // application state at all, and a scenario meant to isolate one
+    // specific rejection reason could actually be passing for a different
+    // one (`application_incompatible` via `missing_state`) instead.
+    try backend1.setEarlyDataApplicationCompat(.{
+        .format_id = http3.early_data.format_id,
+        .format_version = http3.early_data.format_version,
+        .bytes = runtime.h3_application_compat[0..runtime.h3_application_compat_len],
+    });
 
     const client1 = try Connection.init(allocator, .{
         .role = .client,
@@ -2735,20 +2865,16 @@ test "http3 (#523): 0-RTT rejected by the real Runtime.h3EarlyDataCompatibility 
     try testing.expectEqual(@as(usize, 1), capture.count);
     try testing.expectEqual(tls_core.session_cache.StoreResult.stored, capture.stored);
 
-    // The genuine incompatibility: reduce a *live* QUIC transport limit
-    // below what the ticket above just remembered — the same mutation the
-    // unit test "h3EarlyDataCompatibility (#523): rejects a live QUIC
-    // transport limit reduced below the remembered snapshot" above proves
-    // in isolation, but here driven through a real resumed handshake rather
-    // than a hand-built candidate.
-    runtime.quic_config.initial_max_streams_bidi -= 1;
+    // The scenario's specific mutation, applied only now — so the ticket
+    // just issued above remembered the *pre*-mutation state.
+    scenario.mutate(&runtime);
 
     // Phase 2: a fresh resumed connection attempting 0-RTT, wired with the
-    // *real* `Runtime.h3EarlyDataCompatibility` gate exactly as production's
-    // `accept()` does — unlike the accepted-case test above, which bypasses
-    // the compatibility gate entirely (its `backend2` never calls
-    // `setEarlyDataCompatibilityGate`, so the TLS layer's default
-    // always-compatible gate is what applies there).
+    // *real* `Runtime.h3EarlyDataCompatibility` gate and the *real*
+    // `Runtime.quicConnectionEvent` bridge exactly as production's
+    // `accept()` composes them — unlike the accepted-case test below, which
+    // intentionally bypasses both (its `backend2` never installs either),
+    // this proves the actual typed decision that would reach metrics.
     const candidate: tls_core.session.CandidateContext = .{
         .cipher_suite = capture.retained.common.cipher_suite,
         .server_name = if (capture.retained.common.server_name) |*s| s.slice() else null,
@@ -2782,7 +2908,10 @@ test "http3 (#523): 0-RTT rejected by the real Runtime.h3EarlyDataCompatibility 
     );
     try backend2.setResumeCompatibilityPolicy(.{ .transport = .ignore, .application = .ignore });
     try backend2.setServerPskResolver(resumption.serverResolver().?);
-    try backend2.setEarlyDataReplayGate(gate);
+    // `null` deliberately leaves no replay gate installed at all — the
+    // backend's own default gate fails closed (`.replay_unavailable`) for
+    // every attempt, exercising that fail-closed default itself.
+    if (scenario.replay_gate) |gate| try backend2.setEarlyDataReplayGate(gate);
     try backend2.setServerEarlyDataPolicy(.{ .enabled = true });
     try backend2.setEarlyDataCompatibilityGate(.{ .ctx = &runtime, .decideFn = Runtime.h3EarlyDataCompatibility });
 
@@ -2806,6 +2935,7 @@ test "http3 (#523): 0-RTT rejected by the real Runtime.h3EarlyDataCompatibility 
         .tls = backend2.backend(),
         .now_us = 2_000_000,
         .initial_path = server_path,
+        .events = .{ .context = &runtime, .emitFn = Runtime.quicConnectionEvent },
     });
 
     var entry2 = ConnEntry{
@@ -2820,9 +2950,9 @@ test "http3 (#523): 0-RTT rejected by the real Runtime.h3EarlyDataCompatibility 
 
     // Drive only the client's first flight — enough for the server to run
     // the resumption/early-data decision — then confirm 0-RTT was genuinely
-    // rejected: no `.zero_rtt` read key is ever installed, so there is
-    // nothing to decrypt early data with (and consequently no fabricated
-    // 0-RTT packet to inject at all, unlike the accepted-case test above).
+    // rejected (no `.zero_rtt` read key installed) and that the *specific*
+    // typed decision this scenario is testing is exactly what was recorded,
+    // through the same production metrics bridge `accept()` uses.
     {
         var buf: [2048]u8 = undefined;
         while (client2.pollTransmitOnPath(&buf, 2_000_000)) |t| {
@@ -2830,11 +2960,12 @@ test "http3 (#523): 0-RTT rejected by the real Runtime.h3EarlyDataCompatibility 
         }
     }
     try testing.expect(entry2.conn.adapter.protectionKeys(.zero_rtt, .read) == null);
+    try testing.expectEqual(@as(usize, 1), decision_capture.count);
+    try testing.expectEqual(scenario.expect_decision, decision_capture.last.?);
 
     // The rest of the handshake completes normally as ordinary 1-RTT
-    // resumption on this *same* connection — the real compatibility gate's
-    // rejection is strictly an early-data-window decision, not a rejection
-    // of the resumed connection itself.
+    // resumption on this *same* connection — rejection is strictly an
+    // early-data-window decision, not a rejection of the connection itself.
     {
         var rounds: usize = 0;
         while (rounds < 64) : (rounds += 1) {
@@ -2855,9 +2986,8 @@ test "http3 (#523): 0-RTT rejected by the real Runtime.h3EarlyDataCompatibility 
     try testing.expect(entry2.conn.isEstablished());
 
     // A real H3 request over 1-RTT, on this *same* connection that just had
-    // its 0-RTT attempt rejected by the real, production compatibility
-    // gate — the same-connection fallback proof the review asked for, using
-    // `Runtime.h3EarlyDataCompatibility` itself rather than a synthetic gate.
+    // its 0-RTT attempt rejected — the same-connection fallback proof the
+    // review asked for, through `Runtime.pumpH3` and the shared handler.
     const request_id = try client2.openStream(.bidi);
     var request_h3: [128]u8 = undefined;
     const request_bytes = buildH3RequestBytesForTest("GET", "/after-rejection", "example.com", &request_h3);
@@ -2882,6 +3012,56 @@ test "http3 (#523): 0-RTT rejected by the real Runtime.h3EarlyDataCompatibility 
     try testing.expectEqual(@as(usize, 1), handler_state.executed_local);
     try testing.expectEqualStrings("GET", handler_state.last_method_buf[0..handler_state.last_method_len]);
     try testing.expectEqual(@as(usize, 0), handler_state.rejected_too_early);
+}
+
+test "http3 (#523): replay-rejected 0-RTT falls back to a real H3 request over 1-RTT, same connection" {
+    const AlwaysReplay = struct {
+        fn decide(_: *anyopaque, _: tls_core.tls13_backend.EarlyDataReplayCandidate) tls_core.tls13_backend.EarlyDataReplayDecision {
+            return .replay;
+        }
+    };
+    var replay_ctx: u8 = 0;
+    try expectH3EarlyDataRejectionFallsBackToRealRequest(.{
+        .replay_gate = .{ .ctx = &replay_ctx, .decideFn = AlwaysReplay.decide },
+        .mutate = h3EarlyDataRejectionNoMutation,
+        .expect_decision = .replay_rejected,
+    });
+}
+
+test "http3 (#523): replay-store-unavailable 0-RTT falls back to a real H3 request over 1-RTT, same connection" {
+    try expectH3EarlyDataRejectionFallsBackToRealRequest(.{
+        .replay_gate = null,
+        .mutate = h3EarlyDataRejectionNoMutation,
+        .expect_decision = .replay_unavailable,
+    });
+}
+
+test "http3 (#523): transport-incompatible 0-RTT rejected by the real Runtime.h3EarlyDataCompatibility gate falls back to a real H3 request over 1-RTT, same connection" {
+    const AlwaysAllow = struct {
+        fn decide(_: *anyopaque, _: tls_core.tls13_backend.EarlyDataReplayCandidate) tls_core.tls13_backend.EarlyDataReplayDecision {
+            return .allow;
+        }
+    };
+    var replay_ctx: u8 = 0;
+    try expectH3EarlyDataRejectionFallsBackToRealRequest(.{
+        .replay_gate = .{ .ctx = &replay_ctx, .decideFn = AlwaysAllow.decide },
+        .mutate = h3EarlyDataRejectionReduceTransportLimit,
+        .expect_decision = .transport_incompatible,
+    });
+}
+
+test "http3 (#523): application-incompatible (H3 SETTINGS) 0-RTT rejected by the real Runtime.h3EarlyDataCompatibility gate falls back to a real H3 request over 1-RTT, same connection" {
+    const AlwaysAllow = struct {
+        fn decide(_: *anyopaque, _: tls_core.tls13_backend.EarlyDataReplayCandidate) tls_core.tls13_backend.EarlyDataReplayDecision {
+            return .allow;
+        }
+    };
+    var replay_ctx: u8 = 0;
+    try expectH3EarlyDataRejectionFallsBackToRealRequest(.{
+        .replay_gate = .{ .ctx = &replay_ctx, .decideFn = AlwaysAllow.decide },
+        .mutate = h3EarlyDataRejectionReduceSettingsLimit,
+        .expect_decision = .application_incompatible,
+    });
 }
 
 test "accept() (#523): wires an EventSink into every accepted connection so 0-RTT events reach metrics instead of being silently discarded" {

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -174,6 +174,11 @@ pub const Runtime = struct {
     credential_provider: ?tls_core.credentials.CredentialProvider,
     resumption_runtime: ?*tls_core.resumption_runtime.Runtime,
     early_data_replay_gate: ?tls_core.tls13_backend.EarlyDataReplayGate,
+    /// #523: whether the native QUIC 0-RTT carrier is actually composed and
+    /// enabled — see `zeroRttCarrierEnabled`. Drives both `quic_config`'s
+    /// `zero_rtt_enabled` gate and whether `accept()` installs a server
+    /// early-data policy on new connections' TLS backends.
+    zero_rtt_enabled: bool,
     quic_config: quic.config.Config,
     h3_settings: http3.frame.Settings,
     h3_application_compat: [http3.early_data.encoded_snapshot_len]u8 = undefined,
@@ -224,6 +229,7 @@ pub const Runtime = struct {
             .credential_provider = cfg.credential_provider,
             .resumption_runtime = cfg.resumption_runtime,
             .early_data_replay_gate = cfg.early_data_replay_gate,
+            .zero_rtt_enabled = zeroRttCarrierEnabled(cfg),
             .quic_config = quicConfigFrom(cfg),
             .h3_settings = cfg.h3_settings,
             .early_data_compat_metrics_ctx = cfg.early_data_compat_metrics_ctx,
@@ -237,8 +243,8 @@ pub const Runtime = struct {
             &runtime.h3_application_compat,
         ) catch return error.InvalidH3Settings).len;
 
-        if (cfg.enable_0rtt) {
-            logger.warn(null, "http3: 0-RTT is not supported by the native QUIC stack; continuing without it", .{});
+        if (cfg.enable_0rtt and !runtime.zero_rtt_enabled) {
+            logger.warn(null, "http3: enable_0rtt requires both resumption_runtime and early_data_replay_gate to be configured; continuing with 0-RTT disabled", .{});
         }
         if (cfg.connection_migration) {
             logger.warn(null, "http3: connection migration is not supported by the native QUIC stack; disable_active_migration stays advertised", .{});
@@ -522,6 +528,16 @@ pub const Runtime = struct {
                 allocator.destroy(backend);
                 return null;
             };
+            // #523: only actually enable the server's early-data accept path
+            // once composition confirmed a resumption runtime, replay gate,
+            // and the QUIC carrier are all present (`zeroRttCarrierEnabled`)
+            // — mirrors `native_tls_connection.zig`'s identical gate for TCP.
+            if (self.zero_rtt_enabled) {
+                backend.setServerEarlyDataPolicy(.{ .enabled = true }) catch {
+                    allocator.destroy(backend);
+                    return null;
+                };
+            }
         }
 
         const conn = Connection.init(allocator, .{
@@ -916,13 +932,25 @@ fn buildStreamRequest(allocator: std.mem.Allocator, exchange: stream_transport.E
 }
 
 /// Map the operator-facing runtime config onto the native QUIC transport
-/// config. Only `max_datagram_size` is honored today (clamped to the range the
-/// 2048-byte work buffers can carry); the remaining transport knobs keep their
-/// conservative defaults, including `migration_policy = .disabled`.
+/// config. Only `max_datagram_size` and `zero_rtt_enabled` are honored today;
+/// the remaining transport knobs keep their conservative defaults, including
+/// `migration_policy = .disabled`.
 fn quicConfigFrom(cfg: Config) quic.config.Config {
     return .{
         .max_udp_payload_size = std.math.clamp(cfg.max_datagram_size, 1200, 2048),
+        .zero_rtt_enabled = zeroRttCarrierEnabled(cfg),
     };
+}
+
+/// #523: the QUIC 0-RTT carrier may only be enabled once every dependency it
+/// relies on is actually present — `enable_0rtt` alone must never install a
+/// usable early-data path. Without a resumption runtime there is no PSK
+/// resolver to select a session, and without the replay gate the backend's
+/// default gate fails closed (`.unavailable`) for every attempt anyway, so
+/// gating here keeps that fail-closed behavior visible instead of quietly
+/// letting every 0-RTT attempt dead-end downstream.
+fn zeroRttCarrierEnabled(cfg: Config) bool {
+    return cfg.enable_0rtt and cfg.resumption_runtime != null and cfg.early_data_replay_gate != null;
 }
 
 /// Convert a source/destination IPv4 `sockaddr_in` into the protocol-neutral
@@ -1044,6 +1072,55 @@ test "quicConfigFrom clamps datagram size into the work-buffer range" {
     const mid = quicConfigFrom(.{ .listen_host = "::", .quic_port = 443, .max_datagram_size = 1350 });
     try testing.expectEqual(@as(u64, 1350), mid.max_udp_payload_size);
     try testing.expectEqual(quic.config.MigrationPolicy.disabled, mid.migration_policy);
+}
+
+test "quicConfigFrom (#523): enable_0rtt alone never enables the 0-RTT carrier" {
+    var entropy = tls_core.production_crypto.OsEntropy{};
+    var provider_state = tls_core.production_crypto.Provider.init(entropy.entropy());
+    var resumption = try tls_core.resumption_runtime.Runtime.init(
+        testing.allocator,
+        .{ .mode = .stateful },
+        .{ .ctx = undefined, .nowUnixMsFn = fixedNowUnixMsForTest },
+        provider_state.cryptoProvider(),
+    );
+    defer resumption.deinit();
+
+    var store = try tls_core.early_data_replay.LocalStore.init(testing.allocator, .{}, 0, 0);
+    defer store.deinit();
+    var gate_adapter = tls_core.early_data_replay.GateAdapter.init(store.store());
+    const gate = gate_adapter.gate();
+
+    // No dependencies at all.
+    try testing.expect(!quicConfigFrom(.{ .listen_host = "::", .quic_port = 443, .enable_0rtt = true }).zero_rtt_enabled);
+    // Only a resumption runtime.
+    try testing.expect(!quicConfigFrom(.{
+        .listen_host = "::",
+        .quic_port = 443,
+        .enable_0rtt = true,
+        .resumption_runtime = &resumption,
+    }).zero_rtt_enabled);
+    // Only a replay gate.
+    try testing.expect(!quicConfigFrom(.{
+        .listen_host = "::",
+        .quic_port = 443,
+        .enable_0rtt = true,
+        .early_data_replay_gate = gate,
+    }).zero_rtt_enabled);
+    // Both dependencies present but `enable_0rtt` false (the default): still disabled.
+    try testing.expect(!quicConfigFrom(.{
+        .listen_host = "::",
+        .quic_port = 443,
+        .resumption_runtime = &resumption,
+        .early_data_replay_gate = gate,
+    }).zero_rtt_enabled);
+    // Every dependency present: the carrier actually enables.
+    try testing.expect(quicConfigFrom(.{
+        .listen_host = "::",
+        .quic_port = 443,
+        .enable_0rtt = true,
+        .resumption_runtime = &resumption,
+        .early_data_replay_gate = gate,
+    }).zero_rtt_enabled);
 }
 
 fn expectInvalidH3SettingsAtRuntimeInit(settings: http3.frame.Settings) !void {
@@ -1458,6 +1535,66 @@ test "runtime borrows the early-data replay gate independently of the resumption
     const installed = runtime.early_data_replay_gate orelse return error.TestExpectedEqual;
     try testing.expectEqual(gate.ctx, installed.ctx);
     try testing.expectEqual(gate.decideFn, installed.decideFn);
+}
+
+test "runtime (#523): enable_0rtt enables the carrier only with complete composition, fails closed otherwise" {
+    var fixed = tls_core.credentials.FixedCredentialProvider.init(tls_core.credentials.testdata.identity());
+    defer fixed.deinit();
+    var logger = logger_mod.Logger.init(.err, "http3-0rtt-composition-test");
+
+    var entropy = tls_core.production_crypto.OsEntropy{};
+    var provider_state = tls_core.production_crypto.Provider.init(entropy.entropy());
+    var resumption = try tls_core.resumption_runtime.Runtime.init(
+        testing.allocator,
+        .{ .mode = .stateful },
+        .{ .ctx = undefined, .nowUnixMsFn = fixedNowUnixMsForTest },
+        provider_state.cryptoProvider(),
+    );
+    defer resumption.deinit();
+
+    var store = try tls_core.early_data_replay.LocalStore.init(testing.allocator, .{}, 0, 0);
+    defer store.deinit();
+    var gate_adapter = tls_core.early_data_replay.GateAdapter.init(store.store());
+    const gate = gate_adapter.gate();
+
+    // enable_0rtt requested but the replay gate is missing: fails closed.
+    var incomplete = try Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+        .credential_provider = fixed.provider(),
+        .resumption_runtime = &resumption,
+        .enable_0rtt = true,
+    });
+    defer incomplete.deinit();
+    try testing.expect(!incomplete.zero_rtt_enabled);
+    try testing.expect(!incomplete.quic_config.zero_rtt_enabled);
+
+    // `enable_0rtt = false` (the default) stays disabled even with full
+    // composition otherwise present.
+    var disabled = try Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+        .credential_provider = fixed.provider(),
+        .resumption_runtime = &resumption,
+        .early_data_replay_gate = gate,
+    });
+    defer disabled.deinit();
+    try testing.expect(!disabled.zero_rtt_enabled);
+
+    // Every dependency present: the carrier actually enables, and that same
+    // decision reaches the QUIC transport config `accept()` hands every new
+    // connection.
+    var complete = try Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+        .credential_provider = fixed.provider(),
+        .resumption_runtime = &resumption,
+        .early_data_replay_gate = gate,
+        .enable_0rtt = true,
+    });
+    defer complete.deinit();
+    try testing.expect(complete.zero_rtt_enabled);
+    try testing.expect(complete.quic_config.zero_rtt_enabled);
 }
 
 test "runtime resolves the actual bound local address, including an OS-assigned port, from quic_port = 0" {

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -2517,14 +2517,23 @@ test "http3 (#523): a replay-safe early request reaches the local handler exactl
     // Ordinary (non-early) request post-handshake: even an otherwise-unsafe
     // method dispatches normally once the connection is fully established,
     // proving the 425 above was strictly an early-data-window decision, not
-    // a permanent rejection of that route. Reuses phase 1's already-
-    // established `client1`/`entry1` pair rather than continuing to drive
-    // `client2`/`entry2`: the fabricated 0-RTT packets above were sealed
-    // with a throwaway sender adapter that shares no packet-number state
-    // with `client2`'s own counters, so letting `client2` go on to send
-    // real application-space packets of its own would collide with the
-    // packet numbers (0 and 1) those fabricated packets already consumed in
-    // the space 0-RTT and 1-RTT share.
+    // a permanent rejection of that route. This deliberately reuses phase
+    // 1's already-established `client1`/`entry1` pair rather than
+    // continuing to drive `client2`/`entry2`: the fabricated 0-RTT packets
+    // above were sealed with a throwaway sender adapter operating entirely
+    // outside `client2`'s own connection state (there is no real client
+    // 0-RTT transmit path — see `sealZeroRttPacketForTest`), so the server
+    // now believes streams 40/44 exist and have received bytes that
+    // `client2`'s own `StreamManager` has no record of at all. Letting
+    // `client2` continue would need the server to never reference those
+    // stream ids again (e.g. via MAX_STREAM_DATA credit renewal, which H3
+    // request assembly triggers naturally) — and there is no way to
+    // pre-register matching stream state on `client2` first, since its
+    // `StreamManager` does not exist until *after* the handshake completes,
+    // which is exactly the step this would need to happen before. The
+    // dedicated same-connection rejection-fallback test below avoids this
+    // entirely: 0-RTT rejection never installs `.zero_rtt` read keys, so no
+    // fabricated packet — and no such divergent state — exists at all.
     const ordinary_id = try client1.openStream(.bidi);
     var ordinary_h3: [128]u8 = undefined;
     const ordinary_bytes = buildH3RequestBytesForTest("POST", "/ordinary", "example.com", &ordinary_h3);
@@ -2549,6 +2558,330 @@ test "http3 (#523): a replay-safe early request reaches the local handler exactl
     try testing.expectEqual(@as(usize, 2), handler_state.executed_local);
     try testing.expectEqualStrings("POST", handler_state.last_method_buf[0..handler_state.last_method_len]);
     try testing.expectEqual(@as(usize, 1), handler_state.rejected_too_early);
+}
+
+test "http3 (#523): 0-RTT rejected by the real Runtime.h3EarlyDataCompatibility gate still serves a real H3 request over 1-RTT, same connection" {
+    const allocator = testing.allocator;
+    var fixed = tls_core.credentials.FixedCredentialProvider.init(tls_core.credentials.testdata.identity());
+    defer fixed.deinit();
+    var logger = logger_mod.Logger.init(.err, "http3-early-request-real-gate-rejection-test");
+
+    var server_entropy = tls_core.production_crypto.OsEntropy{};
+    var server_provider_state = tls_core.production_crypto.Provider.init(server_entropy.entropy());
+    var resumption = try tls_core.resumption_runtime.Runtime.init(
+        testing.allocator,
+        .{ .mode = .stateful },
+        .{ .ctx = undefined, .nowUnixMsFn = fixedNowUnixMsForTest },
+        server_provider_state.cryptoProvider(),
+    );
+    defer resumption.deinit();
+
+    var client_entropy = tls_core.production_crypto.OsEntropy{};
+    var client_provider_state = tls_core.production_crypto.Provider.init(client_entropy.entropy());
+    var client_resumption = try tls_core.resumption_runtime.Runtime.init(
+        testing.allocator,
+        .{ .mode = .stateful },
+        .{ .ctx = undefined, .nowUnixMsFn = fixedNowUnixMsForTest },
+        client_provider_state.cryptoProvider(),
+    );
+    defer client_resumption.deinit();
+
+    const AlwaysAllow = struct {
+        fn decide(_: *anyopaque, _: tls_core.tls13_backend.EarlyDataReplayCandidate) tls_core.tls13_backend.EarlyDataReplayDecision {
+            return .allow;
+        }
+    };
+    var replay_ctx: u8 = 0;
+    const gate: tls_core.tls13_backend.EarlyDataReplayGate = .{ .ctx = &replay_ctx, .decideFn = AlwaysAllow.decide };
+
+    var handler_state = TestEarlyDataHandlerState{};
+    var runtime = try Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+        .credential_provider = fixed.provider(),
+        .resumption_runtime = &resumption,
+        .early_data_replay_gate = gate,
+        .enable_0rtt = true,
+        .request_handler = testEarlyDataAwareHandler,
+        .request_handler_ctx = &handler_state,
+    });
+    defer runtime.deinit();
+    try testing.expect(runtime.zero_rtt_enabled);
+
+    // Phase 1: a real handshake, then a real ticket obtained from the
+    // production issuance path — identical setup to the accepted-case test
+    // above, except `server_conn1` is explicitly constructed with the
+    // runtime's own live `quic_config` (mirrors `accept()`'s
+    // `.config = self.quic_config`) so the transport-parameters snapshot the
+    // ticket remembers is exactly what `Runtime.h3EarlyDataCompatibility`
+    // will later compare a *reduced* live config against.
+    const client_cid = [_]u8{ 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8 };
+    const odcid = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08 };
+    const client_path = quic.path.PathKey{
+        .local = quic.udp.Address.ip4(.{ 127, 0, 0, 1 }, 41_310),
+        .remote = quic.udp.Address.ip4(.{ 127, 0, 0, 1 }, 41_311),
+    };
+    const server_path = quic.path.PathKey{
+        .local = quic.udp.Address.ip4(.{ 127, 0, 0, 1 }, 41_311),
+        .remote = quic.udp.Address.ip4(.{ 127, 0, 0, 1 }, 41_310),
+    };
+    const no_challenge = [_]u8{0} ** quic.path.path_challenge_len;
+
+    var client_backend = try quic.tls_backend.Tls13Backend.initClientWithAllocator(
+        allocator,
+        .{ .hello_random = [_]u8{0xc1} ** 32, .key_share_seed = [_]u8{0x11} ** 32 },
+        .{ .pinned_certificate = tls_core.credentials.testdata.certificate_der },
+    );
+
+    const Capture = struct {
+        runtime: *tls_core.resumption_runtime.Runtime,
+        retained: tls_core.session.ClientTicketState = .{},
+        stored: tls_core.session_cache.StoreResult = undefined,
+        count: usize = 0,
+        fn now(_: *anyopaque) i64 {
+            return 1000;
+        }
+        fn onTicket(ctx: *anyopaque, ticket: *const tls_core.session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            ticket.cloneInto(testing.allocator, &self.retained) catch unreachable;
+            self.stored = self.runtime.storeClientTicket(ticket);
+            self.count += 1;
+        }
+    };
+    var capture = Capture{ .runtime = &client_resumption };
+    defer capture.retained.deinit();
+    try client_backend.engine.setSessionTicketConsumer(allocator, tls_core.session.Limits.default, .{
+        .ctx = &capture,
+        .nowUnixMsFn = Capture.now,
+        .onTicketFn = Capture.onTicket,
+    });
+
+    const backend1 = try allocator.create(quic.tls_backend.Tls13Backend);
+    backend1.* = quic.tls_backend.Tls13Backend.initServerWithProvider(
+        .{ .hello_random = [_]u8{0x51} ** 32, .key_share_seed = [_]u8{0x22} ** 32 },
+        fixed.provider(),
+    );
+    const resume_policy: tls_core.tls13_backend.Tls13Backend.ResumeCompatibilityPolicy = .{ .transport = .ignore, .application = .ignore };
+    try client_backend.setResumeCompatibilityPolicy(resume_policy);
+    try backend1.setResumeCompatibilityPolicy(resume_policy);
+
+    const client1 = try Connection.init(allocator, .{
+        .role = .client,
+        .local_cid = &client_cid,
+        .original_dcid = &odcid,
+        .peer_cid = &odcid,
+        .tls = client_backend.backend(),
+        .now_us = 1_000_000,
+        .initial_path = client_path,
+    });
+    defer client1.deinit();
+    const server_conn1 = try Connection.init(allocator, .{
+        .role = .server,
+        .config = runtime.quic_config,
+        .local_cid = &odcid,
+        .original_dcid = &odcid,
+        .peer_cid = &client_cid,
+        .tls = backend1.backend(),
+        .now_us = 1_000_000,
+        .initial_path = server_path,
+    });
+
+    var entry1 = ConnEntry{
+        .backend = backend1,
+        .conn = server_conn1,
+        .h3 = H3.initWithSettings(allocator, .server, .{}),
+        .admission_source_ip = 0,
+        .cid_len = odcid.len,
+        .accepted_at_us = 1_000_000,
+    };
+    defer entry1.deinit(allocator);
+
+    {
+        var rounds: usize = 0;
+        while (rounds < 64) : (rounds += 1) {
+            var progressed = false;
+            var buf: [2048]u8 = undefined;
+            while (client1.pollTransmitOnPath(&buf, 1_000_000)) |t| {
+                try entry1.conn.ingestOnPath(t.bytes, server_path, no_challenge, 1_000_000);
+                progressed = true;
+            }
+            while (entry1.conn.pollTransmitOnPath(&buf, 1_000_000)) |t| {
+                try client1.ingestOnPath(t.bytes, client_path, no_challenge, 1_000_000);
+                progressed = true;
+            }
+            if (!progressed) break;
+        }
+    }
+    try testing.expect(client1.isEstablished());
+    try testing.expect(entry1.conn.isEstablished());
+
+    try runtime.issueSessionTicket(&entry1, &resumption);
+    {
+        var rounds: usize = 0;
+        while (rounds < 16) : (rounds += 1) {
+            var progressed = false;
+            var buf: [2048]u8 = undefined;
+            while (entry1.conn.pollTransmitOnPath(&buf, 1_000_000)) |t| {
+                try client1.ingestOnPath(t.bytes, client_path, no_challenge, 1_000_000);
+                progressed = true;
+            }
+            while (client1.pollTransmitOnPath(&buf, 1_000_000)) |t| {
+                try entry1.conn.ingestOnPath(t.bytes, server_path, no_challenge, 1_000_000);
+                progressed = true;
+            }
+            if (!progressed) break;
+        }
+    }
+    try testing.expectEqual(@as(usize, 1), capture.count);
+    try testing.expectEqual(tls_core.session_cache.StoreResult.stored, capture.stored);
+
+    // The genuine incompatibility: reduce a *live* QUIC transport limit
+    // below what the ticket above just remembered — the same mutation the
+    // unit test "h3EarlyDataCompatibility (#523): rejects a live QUIC
+    // transport limit reduced below the remembered snapshot" above proves
+    // in isolation, but here driven through a real resumed handshake rather
+    // than a hand-built candidate.
+    runtime.quic_config.initial_max_streams_bidi -= 1;
+
+    // Phase 2: a fresh resumed connection attempting 0-RTT, wired with the
+    // *real* `Runtime.h3EarlyDataCompatibility` gate exactly as production's
+    // `accept()` does — unlike the accepted-case test above, which bypasses
+    // the compatibility gate entirely (its `backend2` never calls
+    // `setEarlyDataCompatibilityGate`, so the TLS layer's default
+    // always-compatible gate is what applies there).
+    const candidate: tls_core.session.CandidateContext = .{
+        .cipher_suite = capture.retained.common.cipher_suite,
+        .server_name = if (capture.retained.common.server_name) |*s| s.slice() else null,
+        .application_protocol = if (capture.retained.common.application_protocol) |*a| a.slice() else null,
+        .auth_binding = capture.retained.common.auth_binding,
+        .transport_compat = null,
+        .application_compat = null,
+    };
+    var lookup = client_resumption.lookupClientOffers(candidate);
+    defer lookup.deinit();
+    try testing.expect(lookup == .hit);
+
+    var client_backend2 = quic.tls_backend.Tls13Backend.initClient(
+        .{ .hello_random = [_]u8{0xe1} ** 32, .key_share_seed = [_]u8{0x41} ** 32 },
+        .{ .pinned_certificate = tls_core.credentials.testdata.certificate_der },
+    );
+    var clock_dummy: u8 = 0;
+    const ClientClock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 2000;
+        }
+    };
+    try client_backend2.engine.setClientPskOfferLease(&lookup.hit, &clock_dummy, ClientClock.now);
+    try client_backend2.setResumeCompatibilityPolicy(.{ .transport = .ignore, .application = .ignore });
+    try client_backend2.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 65536 });
+
+    const backend2 = try allocator.create(quic.tls_backend.Tls13Backend);
+    backend2.* = quic.tls_backend.Tls13Backend.initServerWithProvider(
+        .{ .hello_random = [_]u8{0xe2} ** 32, .key_share_seed = [_]u8{0x42} ** 32 },
+        fixed.provider(),
+    );
+    try backend2.setResumeCompatibilityPolicy(.{ .transport = .ignore, .application = .ignore });
+    try backend2.setServerPskResolver(resumption.serverResolver().?);
+    try backend2.setEarlyDataReplayGate(gate);
+    try backend2.setServerEarlyDataPolicy(.{ .enabled = true });
+    try backend2.setEarlyDataCompatibilityGate(.{ .ctx = &runtime, .decideFn = Runtime.h3EarlyDataCompatibility });
+
+    const client2 = try Connection.init(allocator, .{
+        .role = .client,
+        .config = .{ .zero_rtt_enabled = true },
+        .local_cid = &client_cid,
+        .original_dcid = &odcid,
+        .peer_cid = &odcid,
+        .tls = client_backend2.backend(),
+        .now_us = 2_000_000,
+        .initial_path = client_path,
+    });
+    defer client2.deinit();
+    const server_conn2 = try Connection.init(allocator, .{
+        .role = .server,
+        .config = runtime.quic_config,
+        .local_cid = &odcid,
+        .original_dcid = &odcid,
+        .peer_cid = &client_cid,
+        .tls = backend2.backend(),
+        .now_us = 2_000_000,
+        .initial_path = server_path,
+    });
+
+    var entry2 = ConnEntry{
+        .backend = backend2,
+        .conn = server_conn2,
+        .h3 = H3.initWithSettings(allocator, .server, .{}),
+        .admission_source_ip = 0,
+        .cid_len = odcid.len,
+        .accepted_at_us = 2_000_000,
+    };
+    defer entry2.deinit(allocator);
+
+    // Drive only the client's first flight — enough for the server to run
+    // the resumption/early-data decision — then confirm 0-RTT was genuinely
+    // rejected: no `.zero_rtt` read key is ever installed, so there is
+    // nothing to decrypt early data with (and consequently no fabricated
+    // 0-RTT packet to inject at all, unlike the accepted-case test above).
+    {
+        var buf: [2048]u8 = undefined;
+        while (client2.pollTransmitOnPath(&buf, 2_000_000)) |t| {
+            try entry2.conn.ingestOnPath(t.bytes, server_path, no_challenge, 2_000_000);
+        }
+    }
+    try testing.expect(entry2.conn.adapter.protectionKeys(.zero_rtt, .read) == null);
+
+    // The rest of the handshake completes normally as ordinary 1-RTT
+    // resumption on this *same* connection — the real compatibility gate's
+    // rejection is strictly an early-data-window decision, not a rejection
+    // of the resumed connection itself.
+    {
+        var rounds: usize = 0;
+        while (rounds < 64) : (rounds += 1) {
+            var progressed = false;
+            var buf: [2048]u8 = undefined;
+            while (client2.pollTransmitOnPath(&buf, 2_000_000)) |t| {
+                try entry2.conn.ingestOnPath(t.bytes, server_path, no_challenge, 2_000_000);
+                progressed = true;
+            }
+            while (entry2.conn.pollTransmitOnPath(&buf, 2_000_000)) |t| {
+                try client2.ingestOnPath(t.bytes, client_path, no_challenge, 2_000_000);
+                progressed = true;
+            }
+            if (!progressed) break;
+        }
+    }
+    try testing.expect(client2.isEstablished());
+    try testing.expect(entry2.conn.isEstablished());
+
+    // A real H3 request over 1-RTT, on this *same* connection that just had
+    // its 0-RTT attempt rejected by the real, production compatibility
+    // gate — the same-connection fallback proof the review asked for, using
+    // `Runtime.h3EarlyDataCompatibility` itself rather than a synthetic gate.
+    const request_id = try client2.openStream(.bidi);
+    var request_h3: [128]u8 = undefined;
+    const request_bytes = buildH3RequestBytesForTest("GET", "/after-rejection", "example.com", &request_h3);
+    _ = try client2.writeStream(request_id, request_bytes, true);
+    {
+        var rounds: usize = 0;
+        while (rounds < 32) : (rounds += 1) {
+            var progressed = false;
+            var buf: [2048]u8 = undefined;
+            while (client2.pollTransmitOnPath(&buf, 2_000_000)) |t| {
+                try entry2.conn.ingestOnPath(t.bytes, server_path, no_challenge, 2_000_000);
+                progressed = true;
+            }
+            while (entry2.conn.pollTransmitOnPath(&buf, 2_000_000)) |t| {
+                try client2.ingestOnPath(t.bytes, client_path, no_challenge, 2_000_000);
+                progressed = true;
+            }
+            runtime.pumpH3(&entry2, 2_000_000);
+            if (!progressed) break;
+        }
+    }
+    try testing.expectEqual(@as(usize, 1), handler_state.executed_local);
+    try testing.expectEqualStrings("GET", handler_state.last_method_buf[0..handler_state.last_method_len]);
+    try testing.expectEqual(@as(usize, 0), handler_state.rejected_too_early);
 }
 
 test "accept() (#523): wires an EventSink into every accepted connection so 0-RTT events reach metrics instead of being silently discarded" {

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -2746,25 +2746,18 @@ fn expectH3EarlyDataRejectionFallsBackToRealRequest(scenario: H3EarlyDataRejecti
     };
     var packet_capture = PacketCapture{};
 
-    // `quicConfigFrom`/`zeroRttCarrierEnabled` require a replay gate present
-    // on the *runtime's own* config before they'll consider 0-RTT usable at
-    // all (see the "enable_0rtt alone never enables the 0-RTT carrier" unit
-    // test above) — this placeholder is otherwise inert here, since
-    // `backend2` below is wired with `scenario.replay_gate` directly rather
-    // than going through `runtime.accept()`.
-    const RuntimeLevelAlwaysAllow = struct {
-        fn decide(_: *anyopaque, _: tls_core.tls13_backend.EarlyDataReplayCandidate) tls_core.tls13_backend.EarlyDataReplayDecision {
-            return .allow;
-        }
-    };
-    var runtime_replay_ctx: u8 = 0;
-
+    // The scenario's gate is the *runtime's own* configured gate — not a
+    // separate placeholder — so this proves the full production ownership
+    // chain: the process-shared gate configured on `Runtime` (what
+    // `accept()` actually reads) is the one driving the TLS decision, not
+    // just that some TLS backend behaves correctly with a gate handed to it
+    // directly.
     var runtime = try Runtime.init(testing.allocator, &logger, .{
         .listen_host = "127.0.0.1",
         .quic_port = 0,
         .credential_provider = fixed.provider(),
         .resumption_runtime = &resumption,
-        .early_data_replay_gate = .{ .ctx = &runtime_replay_ctx, .decideFn = RuntimeLevelAlwaysAllow.decide },
+        .early_data_replay_gate = scenario.replay_gate,
         .enable_0rtt = true,
         .request_handler = testEarlyDataAwareHandler,
         .request_handler_ctx = &handler_state,
@@ -2964,7 +2957,9 @@ fn expectH3EarlyDataRejectionFallsBackToRealRequest(scenario: H3EarlyDataRejecti
     );
     try backend2.setResumeCompatibilityPolicy(.{ .transport = .ignore, .application = .ignore });
     try backend2.setServerPskResolver(resumption.serverResolver().?);
-    try backend2.setEarlyDataReplayGate(scenario.replay_gate);
+    // Sourced from `runtime.early_data_replay_gate`, not `scenario.replay_gate`
+    // directly — the same process-shared value `accept()` reads.
+    try backend2.setEarlyDataReplayGate(runtime.early_data_replay_gate.?);
     try backend2.setServerEarlyDataPolicy(.{ .enabled = true });
     try backend2.setEarlyDataCompatibilityGate(.{ .ctx = &runtime, .decideFn = Runtime.h3EarlyDataCompatibility });
 

--- a/src/http/metrics.zig
+++ b/src/http/metrics.zig
@@ -42,6 +42,38 @@ pub const H3EarlyDataCompatDecision = enum { compatible, transport_incompatible,
 /// request path, user ID, PSK, or binder.
 pub const EarlyDataReplayOutcome = enum { accepted, duplicate, capacity_rejected, expired, unavailable, startup_quarantine };
 
+/// #523: mirrors `tls_core.tls13_backend.EarlyDataDecision` one-for-one
+/// (bridged in `http3_runtime.zig`'s `accept()` `EventSink`) — the QUIC/H3
+/// server's authoritative 0-RTT accept/reject decision, made once per
+/// connection as soon as the ClientHello is processed, independent of
+/// whether any `.zero_rtt` packet ever actually arrives. `not_attempted`
+/// is deliberately excluded: that's the vast majority of ordinary
+/// connections and isn't itself an outcome worth counting.
+pub const QuicEarlyDataDecision = enum {
+    accepted,
+    disabled,
+    ticket_not_capable,
+    selected_identity_not_zero,
+    age_skew,
+    transport_incompatible,
+    application_incompatible,
+    replay_rejected,
+    replay_unavailable,
+    resource_limited,
+};
+
+/// #523: mirrors `quic.connection.ZeroRttPacketOutcome` one-for-one
+/// (bridged the same way) — per-packet 0-RTT authentication/admission
+/// outcomes, distinguishing policy/keys-unavailable from a genuine AEAD
+/// authentication failure and from an authenticated duplicate.
+pub const QuicZeroRttPacketOutcome = enum {
+    accepted,
+    keys_unavailable,
+    authentication_failed,
+    duplicate,
+    malformed,
+};
+
 const resumption_transport_count = 2;
 const resumption_outcome_count = 5;
 const resumption_mode_count = 3;
@@ -54,6 +86,8 @@ const early_data_upstream_425_action_count = 2;
 const early_data_retry_result_count = 3;
 const h3_early_data_compat_decision_count = 4;
 const early_data_replay_outcome_count = 6;
+const quic_early_data_decision_count = 10;
+const quic_zero_rtt_packet_outcome_count = 5;
 
 /// Server-wide metrics counters.
 ///
@@ -210,6 +244,12 @@ pub const Metrics = struct {
     /// #368 Slice 3: process-local anti-replay store outcomes by bounded,
     /// closed-enum outcome. See `EarlyDataReplayOutcome`.
     tls_early_data_replay_total: [early_data_replay_outcome_count]u64,
+    /// #523: the QUIC/H3 server's authoritative 0-RTT accept/reject
+    /// decision by outcome. See `QuicEarlyDataDecision`.
+    quic_early_data_decision_total: [quic_early_data_decision_count]u64,
+    /// #523: per-packet 0-RTT authentication/admission outcomes. See
+    /// `QuicZeroRttPacketOutcome`.
+    quic_zero_rtt_packet_total: [quic_zero_rtt_packet_outcome_count]u64,
     /// Total graceful-shutdown drains started.
     drain_total: u64,
     /// Total drains that hit the configured drain timeout before work finished.
@@ -328,6 +368,8 @@ pub const Metrics = struct {
             .http_early_data_retry_total = .{0} ** early_data_retry_result_count,
             .http3_early_data_compat_total = .{0} ** h3_early_data_compat_decision_count,
             .tls_early_data_replay_total = .{0} ** early_data_replay_outcome_count,
+            .quic_early_data_decision_total = .{0} ** quic_early_data_decision_count,
+            .quic_zero_rtt_packet_total = .{0} ** quic_zero_rtt_packet_outcome_count,
             .drain_total = 0,
             .drain_timeouts_total = 0,
             .drain_forced_closes_total = 0,
@@ -434,6 +476,17 @@ pub const Metrics = struct {
     /// #368 Slice 3: record a process-local anti-replay store outcome.
     pub fn recordEarlyDataReplay(self: *Metrics, outcome: EarlyDataReplayOutcome) void {
         self.tls_early_data_replay_total[earlyDataReplayOutcomeIndex(outcome)] += 1;
+    }
+
+    /// #523: record the QUIC/H3 server's authoritative 0-RTT accept/reject
+    /// decision for one connection.
+    pub fn recordQuicEarlyDataDecision(self: *Metrics, decision: QuicEarlyDataDecision) void {
+        self.quic_early_data_decision_total[quicEarlyDataDecisionIndex(decision)] += 1;
+    }
+
+    /// #523: record one 0-RTT packet's authentication/admission outcome.
+    pub fn recordQuicZeroRttPacket(self: *Metrics, outcome: QuicZeroRttPacketOutcome) void {
+        self.quic_zero_rtt_packet_total[quicZeroRttPacketOutcomeIndex(outcome)] += 1;
     }
 
     /// Record the start of a config hot-reload attempt.
@@ -1382,6 +1435,47 @@ pub const Metrics = struct {
                 self.http3_early_data_compat_total[h3EarlyDataCompatDecisionIndex(decision)],
             });
         }
+
+        try out.appendSlice(
+            \\# HELP tardigrade_quic_early_data_decision_total QUIC/H3 server authoritative 0-RTT accept/reject decisions
+            \\# TYPE tardigrade_quic_early_data_decision_total counter
+            \\
+        );
+        inline for (.{
+            QuicEarlyDataDecision.accepted,
+            QuicEarlyDataDecision.disabled,
+            QuicEarlyDataDecision.ticket_not_capable,
+            QuicEarlyDataDecision.selected_identity_not_zero,
+            QuicEarlyDataDecision.age_skew,
+            QuicEarlyDataDecision.transport_incompatible,
+            QuicEarlyDataDecision.application_incompatible,
+            QuicEarlyDataDecision.replay_rejected,
+            QuicEarlyDataDecision.replay_unavailable,
+            QuicEarlyDataDecision.resource_limited,
+        }) |decision| {
+            try out.print("tardigrade_quic_early_data_decision_total{{decision=\"{s}\"}} {d}\n", .{
+                quicEarlyDataDecisionLabel(decision),
+                self.quic_early_data_decision_total[quicEarlyDataDecisionIndex(decision)],
+            });
+        }
+
+        try out.appendSlice(
+            \\# HELP tardigrade_quic_zero_rtt_packet_total Per-packet 0-RTT authentication/admission outcomes
+            \\# TYPE tardigrade_quic_zero_rtt_packet_total counter
+            \\
+        );
+        inline for (.{
+            QuicZeroRttPacketOutcome.accepted,
+            QuicZeroRttPacketOutcome.keys_unavailable,
+            QuicZeroRttPacketOutcome.authentication_failed,
+            QuicZeroRttPacketOutcome.duplicate,
+            QuicZeroRttPacketOutcome.malformed,
+        }) |outcome| {
+            try out.print("tardigrade_quic_zero_rtt_packet_total{{outcome=\"{s}\"}} {d}\n", .{
+                quicZeroRttPacketOutcomeLabel(outcome),
+                self.quic_zero_rtt_packet_total[quicZeroRttPacketOutcomeIndex(outcome)],
+            });
+        }
     }
 
     /// #368 Slice 3: process-local anti-replay store outcomes. Every label
@@ -1658,6 +1752,31 @@ fn earlyDataReplayOutcomeIndex(outcome: EarlyDataReplayOutcome) usize {
     };
 }
 
+fn quicEarlyDataDecisionIndex(decision: QuicEarlyDataDecision) usize {
+    return switch (decision) {
+        .accepted => 0,
+        .disabled => 1,
+        .ticket_not_capable => 2,
+        .selected_identity_not_zero => 3,
+        .age_skew => 4,
+        .transport_incompatible => 5,
+        .application_incompatible => 6,
+        .replay_rejected => 7,
+        .replay_unavailable => 8,
+        .resource_limited => 9,
+    };
+}
+
+fn quicZeroRttPacketOutcomeIndex(outcome: QuicZeroRttPacketOutcome) usize {
+    return switch (outcome) {
+        .accepted => 0,
+        .keys_unavailable => 1,
+        .authentication_failed => 2,
+        .duplicate => 3,
+        .malformed => 4,
+    };
+}
+
 fn ticketKeyReloadOutcomeIndex(outcome: TicketKeyReloadOutcome) usize {
     return switch (outcome) {
         .initial_load_success => 0,
@@ -1724,6 +1843,31 @@ fn earlyDataReplayOutcomeLabel(outcome: EarlyDataReplayOutcome) []const u8 {
         .expired => "expired",
         .unavailable => "unavailable",
         .startup_quarantine => "startup_quarantine",
+    };
+}
+
+fn quicEarlyDataDecisionLabel(decision: QuicEarlyDataDecision) []const u8 {
+    return switch (decision) {
+        .accepted => "accepted",
+        .disabled => "disabled",
+        .ticket_not_capable => "ticket_not_capable",
+        .selected_identity_not_zero => "selected_identity_not_zero",
+        .age_skew => "age_skew",
+        .transport_incompatible => "transport_incompatible",
+        .application_incompatible => "application_incompatible",
+        .replay_rejected => "replay_rejected",
+        .replay_unavailable => "replay_unavailable",
+        .resource_limited => "resource_limited",
+    };
+}
+
+fn quicZeroRttPacketOutcomeLabel(outcome: QuicZeroRttPacketOutcome) []const u8 {
+    return switch (outcome) {
+        .accepted => "accepted",
+        .keys_unavailable => "keys_unavailable",
+        .authentication_failed => "authentication_failed",
+        .duplicate => "duplicate",
+        .malformed => "malformed",
     };
 }
 

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -130,6 +130,32 @@ pub const Event = union(enum) {
     /// A candidate path validated and was promoted to active (RFC 9000
     /// §8.2.3/§9.5): a NAT rebinding or a host migration, per `change`.
     path_validated: PathValidatedEvent,
+    /// #523: a typed outcome for every `.zero_rtt` packet this connection
+    /// processes, distinguishing "policy/keys unavailable" from a genuine
+    /// AEAD authentication failure and from an authenticated duplicate —
+    /// `packet_received`/`packet_dropped` above collapse all of these into
+    /// generic application-space bookkeeping. Never carries ticket
+    /// identities, PSKs, traffic secrets, or other decrypted session state.
+    zero_rtt_packet: struct { outcome: ZeroRttPacketOutcome, size: usize },
+};
+
+/// See `Event.zero_rtt_packet`.
+pub const ZeroRttPacketOutcome = enum {
+    /// Authenticated and, if it carried a STREAM frame, delivered.
+    accepted,
+    /// No installed/enabled `.zero_rtt` read secret — the ordinary shape of
+    /// "TLS never authorized this attempt" (not attempted, rejected by
+    /// policy/replay/compatibility, or the carrier is simply disabled): all
+    /// of these leave the same observable state at this layer.
+    keys_unavailable,
+    /// A read secret was installed, but AEAD authentication failed —
+    /// tampered or spoofed, distinct from `keys_unavailable`.
+    authentication_failed,
+    /// Authenticated, but this packet number was already processed in the
+    /// application space; its frame effects were not reapplied.
+    duplicate,
+    /// Too short to remove header protection / locate the payload.
+    malformed,
 };
 
 pub const PathValidatedEvent = struct {
@@ -962,11 +988,13 @@ pub const Connection = struct {
         var work: [2048]u8 = undefined;
         if (bytes.len > work.len) {
             self.dropPacket(.malformed, bytes.len);
+            self.emitZeroRttOutcome(level, .malformed, bytes.len);
             return;
         }
         @memcpy(work[0..bytes.len], bytes);
         if (parsed.packet_len < parsed.pn_offset + 4 + sample_len) {
             self.dropPacket(.malformed, bytes.len);
+            self.emitZeroRttOutcome(level, .malformed, bytes.len);
             return;
         }
 
@@ -976,6 +1004,7 @@ pub const Connection = struct {
             // accepted the PSK attempt, or the carrier is disabled) rather
             // than an authentication failure, so it gets its own reason.
             self.dropPacket(if (level == .zero_rtt) .keys_unavailable else .undecryptable, bytes.len);
+            self.emitZeroRttOutcome(level, .keys_unavailable, bytes.len);
             return;
         };
         var sample: [sample_len]u8 = undefined;
@@ -1011,11 +1040,24 @@ pub const Connection = struct {
         const payload = keys.openPayload(pn, header, ciphertext, &plain) catch {
             self.adapter.metrics.deprotection_failures += 1;
             self.dropPacket(.undecryptable, bytes.len);
+            self.emitZeroRttOutcome(level, .authentication_failed, bytes.len);
             return;
         };
         self.adapter.metrics.packets_deprotected += 1;
 
         if (level == .zero_rtt) self.ensureEarlyStreamManager();
+
+        // RFC 9001 §4.9.3: a server retires its 0-RTT read key once it has
+        // received a 1-RTT packet — the client's Finished (and any coalesced
+        // 1-RTT application data) proves it has moved on, so a 0-RTT key can
+        // no longer be legitimately used. This wipes only the `.zero_rtt`
+        // secret slot; 0-RTT and 1-RTT share the application packet-number
+        // and recovery state, which is untouched. `discardSecrets` is a
+        // no-op once already discarded, so this needs no "first time only"
+        // guard.
+        if (self.role == .server and level == .application) {
+            self.adapter.discardSecrets(.zero_rtt);
+        }
 
         if (used_next_keys) {
             self.adapter.commitApplicationReadKeyUpdate() catch {};
@@ -1028,6 +1070,16 @@ pub const Connection = struct {
         if (self.largest_recv_pn[space_idx] == null or pn > self.largest_recv_pn[space_idx].?) {
             self.largest_recv_pn[space_idx] = pn;
         }
+        // An authenticated duplicate (same packet number already recorded in
+        // this space — query *before* recording this one) must never have
+        // its frame effects re-applied: 0-RTT and 1-RTT share the
+        // application space, so this is also what stops a replayed 0-RTT
+        // packet from re-crediting stream/connection state a second time.
+        // Path-validation/ACK-range bookkeeping below still runs regardless:
+        // a duplicate still proves current possession of the keys and the
+        // path, and its packet number still belongs in the next ACK.
+        const already_received = self.recovery.wasReceived(space, pn);
+        self.emitZeroRttOutcome(level, if (already_received) .duplicate else .accepted, bytes.len);
         self.recovery.onPacketReceived(space, pn) catch {
             // Pathological ACK-range fragmentation; close rather than lose ACK state.
             self.startClose(.{ .error_code = error_internal, .is_application = false, .local = true }, "ack range overflow", now_us);
@@ -1075,17 +1127,19 @@ pub const Connection = struct {
         }
 
         var ack_eliciting = false;
-        var parser = frame.Parser.init(payload);
-        while (true) {
-            const decoded = parser.next() catch {
-                self.startClose(.{ .error_code = error_frame_encoding, .is_application = false, .local = true }, "frame decode", now_us);
-                return;
-            };
-            const f = decoded orelse break;
-            if (f.isAckEliciting()) ack_eliciting = true;
-            try self.applyFrame(level, f, ingress_path, now_us);
-            if (self.state_ == .closed or self.state_ == .draining) return;
-            if (self.state_ == .closing) break;
+        if (!already_received) {
+            var parser = frame.Parser.init(payload);
+            while (true) {
+                const decoded = parser.next() catch {
+                    self.startClose(.{ .error_code = error_frame_encoding, .is_application = false, .local = true }, "frame decode", now_us);
+                    return;
+                };
+                const f = decoded orelse break;
+                if (f.isAckEliciting()) ack_eliciting = true;
+                try self.applyFrame(level, f, ingress_path, now_us);
+                if (self.state_ == .closed or self.state_ == .draining) return;
+                if (self.state_ == .closing) break;
+            }
         }
 
         if (ack_eliciting) {
@@ -1104,6 +1158,10 @@ pub const Connection = struct {
     }
 
     fn applyFrame(self: *Connection, level: EncryptionLevel, f: frame.Frame, ingress_path: quic_path.PathKey, now_us: u64) IngestError!void {
+        if (!frameAllowedAtLevel(level, f)) {
+            self.startClose(.{ .error_code = error_protocol_violation, .is_application = false, .local = true }, "0-rtt frame level", now_us);
+            return;
+        }
         const space = spaceForLevel(level);
         switch (f) {
             .padding, .ping => {},
@@ -1231,7 +1289,11 @@ pub const Connection = struct {
                 // Echo on the exact path the challenge arrived on (RFC 9000
                 // §8.2.2) — never the active path by default, since the
                 // challenge may have come from a peer address probing us.
-                if (level == .application) {
+                // Legal in 0-RTT as well as 1-RTT (RFC 9000 §12.5); the
+                // response itself always transmits under 1-RTT keys since
+                // the server never sends 0-RTT (queued the same way either
+                // way — only the trigger's level differs).
+                if (level == .application or level == .zero_rtt) {
                     try self.pending_path_responses.append(self.allocator, .{ .path = ingress_path, .data = data });
                 }
             },
@@ -1264,6 +1326,20 @@ pub const Connection = struct {
                 }
             },
         }
+    }
+
+    /// RFC 9000 §12.5 (frame types permitted per packet type): ACK, CRYPTO,
+    /// NEW_TOKEN, RETIRE_CONNECTION_ID, PATH_RESPONSE, and HANDSHAKE_DONE are
+    /// never legal in a 0-RTT packet. Checked once, before any frame-specific
+    /// side effect, so an authenticated 0-RTT packet carrying one of these
+    /// can never mutate sent/recovery/congestion state, hand bytes to the
+    /// TLS engine, or otherwise act as if it were an ordinary 1-RTT packet.
+    fn frameAllowedAtLevel(level: EncryptionLevel, f: frame.Frame) bool {
+        if (level != .zero_rtt) return true;
+        return switch (f) {
+            .ack, .crypto, .new_token, .retire_connection_id, .path_response, .handshake_done => false,
+            else => true,
+        };
     }
 
     fn processAck(self: *Connection, space: PacketNumberSpace, ack: frame.Ack, now_us: u64) void {
@@ -1425,6 +1501,14 @@ pub const Connection = struct {
     fn dropPacket(self: *Connection, reason: DropReason, size: usize) void {
         self.metrics.packets_dropped += 1;
         self.events.emit(.{ .packet_dropped = .{ .reason = reason, .size = size } });
+    }
+
+    /// See `Event.zero_rtt_packet` — a no-op for every level but `.zero_rtt`,
+    /// so call sites shared with every other level don't need their own
+    /// level check.
+    fn emitZeroRttOutcome(self: *Connection, level: EncryptionLevel, outcome: ZeroRttPacketOutcome, size: usize) void {
+        if (level != .zero_rtt) return;
+        self.events.emit(.{ .zero_rtt_packet = .{ .outcome = outcome, .size = size } });
     }
 
     fn roleInitiator(role: Role) quic_stream.Initiator {
@@ -3400,10 +3484,11 @@ test "driver: 0-RTT stream provenance survives reassembly, duplicate delivery, a
     try testing.expect(pair.server.streamTransportEarly(0));
 
     // Duplicate delivery of an already-processed 0-RTT packet re-authenticates
-    // (packet numbers aren't deduplicated pre-application — the same as any
-    // other space), but must not duplicate the bytes the application
-    // eventually reads: stream-offset dedup (pre-existing, generic to every
-    // level) is what actually suppresses it.
+    // (AEAD has no memory of prior packets), but `wasReceived`/the
+    // already-recorded application-space packet number stop its frames from
+    // ever reaching `applyFrame` a second time — see the dedicated
+    // frame-effect regression test below for the case where that actually
+    // matters (STREAM offset dedup alone would otherwise mask it).
     try pair.server.ingestOnPath(datagram_1, TestPair.server_path, TestPair.test_challenge_entropy, pair.now_us);
 
     try testing.expectEqual(@as(?StreamId, 0), pair.server.acceptStream());
@@ -3419,6 +3504,133 @@ test "driver: 0-RTT stream provenance survives reassembly, duplicate delivery, a
     const late_read = try pair.server.readStream(0, &buf);
     try testing.expectEqualStrings("!", buf[0..late_read.len]);
     try testing.expect(late_read.fin);
+}
+
+test "driver: authenticated duplicate 0-RTT packet does not re-apply a state-mutating frame" {
+    // STREAM-offset dedup happens to hide a replayed STREAM frame regardless
+    // of packet-level dedup, so it can't prove frame effects aren't
+    // reapplied. PATH_CHALLENGE has no such built-in idempotency —
+    // `applyFrame` unconditionally appends a pending response — making it a
+    // frame type where a real regression (replaying an authenticated
+    // duplicate packet re-dispatching its frames) is directly observable.
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+
+    const secret = [_]u8{0x63} ** tls_adapter.traffic_secret_len;
+    pair.server.adapter.setZeroRttEnabled(true);
+    pair.server.adapter.installSecret(try tls_adapter.Secret.init(.zero_rtt, .read, &secret));
+
+    var frame_buf: [16]u8 = undefined;
+    const challenge_data = [_]u8{0xab} ** frame.path_data_len;
+    const frame_len = try frame.encodePathChallenge(challenge_data, &frame_buf);
+    var wire: [256]u8 = undefined;
+    const datagram = sealTestZeroRttPacket(&TestPair.odcid, &TestPair.client_cid, secret, 0, frame_buf[0..frame_len], &wire);
+
+    try pair.server.ingestOnPath(datagram, TestPair.server_path, TestPair.test_challenge_entropy, pair.now_us);
+    try testing.expectEqual(@as(usize, 1), pair.server.pending_path_responses.items.len);
+
+    // Replay the identical authenticated packet.
+    try pair.server.ingestOnPath(datagram, TestPair.server_path, TestPair.test_challenge_entropy, pair.now_us);
+    try testing.expectEqual(@as(usize, 1), pair.server.pending_path_responses.items.len);
+}
+
+test "driver: frames illegal in 0-RTT close the connection instead of taking effect (RFC 9000 §12.5)" {
+    const allocator = testing.allocator;
+
+    // ACK is the sharpest case: without the level gate this frame is
+    // silently accepted by `processAck` (mutating sent/recovery/congestion
+    // state) rather than erroring, so a close happening here specifically
+    // proves the gate ran — not some unrelated pre-existing failure path.
+    {
+        var pair = try TestPair.init(allocator);
+        defer pair.deinit(allocator);
+        try pair.server.applyFrame(.zero_rtt, .{ .ack = .{
+            .ranges = .{},
+            .ack_delay_raw = 0,
+            .largest_acknowledged = 0,
+        } }, TestPair.server_path, pair.now_us);
+        try testing.expectEqual(State.closing, pair.server.state());
+        try testing.expectEqual(error_protocol_violation, pair.server.close_info.?.error_code);
+    }
+
+    // CRYPTO: without the gate, `Handshake.onCrypto(.zero_rtt, ...)` would
+    // also fail (0-RTT never carries CRYPTO — `cryptoStreamIndex` rejects
+    // it), but through a different, CRYPTO_ERROR-shaped close. Asserting the
+    // plain `error_protocol_violation` code here proves the level gate
+    // itself rejected it before any TLS-engine call, not that TLS happened
+    // to reject it independently.
+    {
+        var pair = try TestPair.init(allocator);
+        defer pair.deinit(allocator);
+        try pair.server.applyFrame(.zero_rtt, .{ .crypto = .{ .offset = 0, .data = "x" } }, TestPair.server_path, pair.now_us);
+        try testing.expectEqual(State.closing, pair.server.state());
+        try testing.expectEqual(error_protocol_violation, pair.server.close_info.?.error_code);
+    }
+
+    {
+        var pair = try TestPair.init(allocator);
+        defer pair.deinit(allocator);
+        try pair.server.applyFrame(.zero_rtt, .{ .new_token = .{ .token = "t" } }, TestPair.server_path, pair.now_us);
+        try testing.expectEqual(State.closing, pair.server.state());
+        try testing.expectEqual(error_protocol_violation, pair.server.close_info.?.error_code);
+    }
+
+    {
+        var pair = try TestPair.init(allocator);
+        defer pair.deinit(allocator);
+        try pair.server.applyFrame(.zero_rtt, .{ .retire_connection_id = .{ .sequence = 0 } }, TestPair.server_path, pair.now_us);
+        try testing.expectEqual(State.closing, pair.server.state());
+        try testing.expectEqual(error_protocol_violation, pair.server.close_info.?.error_code);
+    }
+
+    {
+        var pair = try TestPair.init(allocator);
+        defer pair.deinit(allocator);
+        try pair.server.applyFrame(.zero_rtt, .{ .path_response = [_]u8{0} ** frame.path_data_len }, TestPair.server_path, pair.now_us);
+        try testing.expectEqual(State.closing, pair.server.state());
+        try testing.expectEqual(error_protocol_violation, pair.server.close_info.?.error_code);
+    }
+
+    {
+        var pair = try TestPair.init(allocator);
+        defer pair.deinit(allocator);
+        try pair.server.applyFrame(.zero_rtt, .handshake_done, TestPair.server_path, pair.now_us);
+        try testing.expectEqual(State.closing, pair.server.state());
+        try testing.expectEqual(error_protocol_violation, pair.server.close_info.?.error_code);
+    }
+}
+
+test "driver: server retires its 0-RTT read secret once it authenticates a 1-RTT packet (RFC 9001 §4.9.3)" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const secret = [_]u8{0x11} ** tls_adapter.traffic_secret_len;
+    pair.server.adapter.setZeroRttEnabled(true);
+    pair.server.adapter.installSecret(try tls_adapter.Secret.init(.zero_rtt, .read, &secret));
+    try testing.expect(pair.server.adapter.protectionKeys(.zero_rtt, .read) != null);
+
+    // Force a genuine ack-eliciting `.application` exchange the server must
+    // authenticate — a delayed/unforced ACK alone might never actually
+    // transmit within a single `pump()`.
+    const id = try pair.client.openStream(.bidi);
+    _ = try pair.client.writeStream(id, "hi", true);
+    try pair.pump();
+
+    // The server has now authenticated a real 1-RTT packet; its 0-RTT read
+    // secret must be retired.
+    try testing.expect(pair.server.adapter.protectionKeys(.zero_rtt, .read) == null);
+
+    // Retirement wipes only the `.zero_rtt` secret-store slot — the
+    // application packet-number/recovery state 0-RTT and 1-RTT share is
+    // untouched, so the stream data is still intact and readable.
+    try testing.expectEqual(@as(?StreamId, id), pair.server.acceptStream());
+    var buf: [8]u8 = undefined;
+    const request = try pair.server.readStream(id, &buf);
+    try testing.expectEqualStrings("hi", buf[0..request.len]);
+    try testing.expect(request.fin);
 }
 
 test "driver: server NewSessionTicket uses application CRYPTO retransmission and stream traffic continues" {
@@ -3789,7 +4001,10 @@ test "#523: real TLS accept decision installs a usable QUIC 0-RTT read key end t
         .ticket_age_add = 500,
         .ticket_nonce = "\x01",
         .issued_at_unix_ms = 1000,
-        .max_early_data_size = 4096,
+        // RFC 9001 §4.6.1: a QUIC ticket advertises 0-RTT capability with
+        // the fixed sentinel, not a small TLS-record-style byte cap — this
+        // is the value `http3_runtime.zig`'s production issuer uses too.
+        .max_early_data_size = std.math.maxInt(u32),
     }, tls_core.session.Limits.default);
     defer prepared.deinit();
     var scratch: [256]u8 = undefined;
@@ -3878,23 +4093,35 @@ test "#523: real TLS accept decision installs a usable QUIC 0-RTT read key end t
     });
     defer resumed.server.deinit();
 
-    try resumed.pump();
+    // Drive only the client's first flight (Initial, carrying the
+    // PSK-resumed ClientHello) into the server. The server's accept/reject
+    // decision — and any resulting `.zero_rtt` read-key installation —
+    // happens synchronously while processing that ClientHello, strictly
+    // before the server sends anything back and long before either side is
+    // anywhere close to established. Draining every pending client
+    // datagram (not just one) is robust to the ClientHello spanning more
+    // than one Initial packet.
+    {
+        var buf: [2048]u8 = undefined;
+        while (resumed.client.pollTransmitOnPath(&buf, resumed.now_us)) |t| {
+            try resumed.server.ingestOnPath(t.bytes, TestPair.server_path, TestPair.test_challenge_entropy, resumed.now_us);
+        }
+    }
 
-    try testing.expect(resumed.client.isEstablished());
-    try testing.expect(resumed.server.isEstablished());
-    try testing.expect(resumed.client_backend.engine.core.psk_authenticated);
-    try testing.expect(resumed.server_backend.engine.core.psk_authenticated);
-
-    // The real TLS decision actually accepted 0-RTT (not just "resumed")...
+    // The real TLS decision already accepted 0-RTT (not just "will resume")
+    // — and did so before the handshake is anywhere close to complete...
+    try testing.expect(!resumed.server.isEstablished());
     try testing.expect(resumed.server_backend.engine.earlyDataAccepted());
-    // ...and that acceptance actually installed a usable QUIC 0-RTT read key
+    // ...and that acceptance already installed a usable QUIC 0-RTT read key
     // through the ordinary secret-event pipeline (#523 requirement 1) — with
     // `zero_rtt_enabled` honored via `Connection.init`'s `setZeroRttEnabled`.
     try testing.expect(resumed.server.adapter.protectionKeys(.zero_rtt, .read) != null);
 
     // That real, TLS-derived key genuinely decrypts a 0-RTT wire packet
-    // through the ordinary driver path, with correct early-data provenance —
-    // proving the pipeline end to end, not just its two halves in isolation.
+    // through the ordinary driver path *during the early-data window*, with
+    // correct early-data provenance — proving the pipeline end to end and
+    // at the actual production timing, not just its two halves in
+    // isolation after the fact.
     const real_secret = resumed.server.adapter.secret(.zero_rtt, .read).?.slice()[0..tls_adapter.traffic_secret_len].*;
     var frame_buf: [32]u8 = undefined;
     const frame_len = try frame.encodeStream(4, 0, "real early data", true, &frame_buf);
@@ -3908,6 +4135,14 @@ test "#523: real TLS accept decision installs a usable QUIC 0-RTT read key end t
     const request = try resumed.server.readStream(4, &buf);
     try testing.expectEqualStrings("real early data", buf[0..request.len]);
     try testing.expect(request.fin);
+
+    // The rest of the handshake now completes normally — accepted 0-RTT
+    // does not derail ordinary 1-RTT completion.
+    try resumed.pump();
+    try testing.expect(resumed.client.isEstablished());
+    try testing.expect(resumed.server.isEstablished());
+    try testing.expect(resumed.client_backend.engine.core.psk_authenticated);
+    try testing.expect(resumed.server_backend.engine.core.psk_authenticated);
 }
 
 test "driver: maximum NewSessionTicket survives real loss reordering PTO and ACK cleanup" {

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -1646,6 +1646,14 @@ pub const Connection = struct {
         // (unexpected type, malformed, failed integrity check) is a
         // never-processed/dropped packet and correctly does not reach here.
         self.armIdle(now_us);
+        // The client handshake anti-deadlock PTO (`nextTimeoutUs`/`onTimeout`,
+        // ~line 2002/2060) bases its deadline on `last_activity_us` whenever
+        // nothing is in flight. This Retry just cleared the Initial
+        // recovery/sent state above, so without updating it here too, that
+        // deadline would still reflect pre-Retry activity and could fire
+        // before the replacement Initial (queued via `tx.pending` above) is
+        // even emitted.
+        self.last_activity_us = now_us;
     }
 
     /// Drain queued TLS output into the per-level retransmission buffers.
@@ -3663,6 +3671,12 @@ test "driver: a validated, successfully processed Retry still refreshes the idle
 
     try testing.expect(pair.client.got_retry);
     try testing.expect(pair.client.idle_deadline_us.? > before.?);
+    // The client handshake anti-deadlock PTO (`nextTimeoutUs`/`onTimeout`)
+    // bases its deadline on `last_activity_us` whenever nothing is in
+    // flight; `handleRetry` clears the Initial recovery/sent state, so this
+    // must move forward too or that deadline could still fire based on
+    // pre-Retry activity before the replacement Initial goes out.
+    try testing.expectEqual(later, pair.client.last_activity_us);
 }
 
 test "driver: replayed duplicate packet from a different source address does not create or credit candidate-path state" {

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -1605,7 +1605,6 @@ pub const Connection = struct {
     // -- retry / handshake progress -------------------------------------------
 
     fn handleRetry(self: *Connection, bytes: []const u8, parsed: packet.ParsedPacket, now_us: u64) void {
-        _ = now_us;
         // RFC 9000 §17.2.5.2: only clients accept Retry, only before any
         // Initial packet from the server, and only once.
         if (self.role != .client or self.got_retry or self.initial_packet_processed) {
@@ -1640,6 +1639,13 @@ pub const Connection = struct {
         tx.pending.items.clearRetainingCapacity();
         tx.pending.insert(self.allocator, .{ .start = 0, .end = tx.data.items.len }) catch {};
         self.largest_recv_pn[0] = null;
+        // RFC 9000 §10.1: a successfully validated and processed Retry is a
+        // legitimate packet from the peer just like any other — the idle
+        // timer must restart here too, not only from the protected-packet
+        // path in `ingestPacket`. Every early return above this point
+        // (unexpected type, malformed, failed integrity check) is a
+        // never-processed/dropped packet and correctly does not reach here.
+        self.armIdle(now_us);
     }
 
     /// Drain queued TLS output into the per-level retransmission buffers.
@@ -3628,6 +3634,35 @@ test "driver: the idle timer does not refresh on a duplicate or an undecryptable
     const datagram_2 = sealTestZeroRttPacket(&TestPair.odcid, &TestPair.client_cid, secret, 1, frame_buf_2[0..frame_len_2], &wire_2);
     try pair.server.ingestOnPath(datagram_2, TestPair.server_path, TestPair.test_challenge_entropy, later);
     try testing.expect(pair.server.idle_deadline_us.? > deadline_after_fresh.?);
+}
+
+test "driver: a validated, successfully processed Retry still refreshes the idle timer (RFC 9000 §10.1)" {
+    // Fixing the duplicate/dropped-datagram idle-timer regression must not
+    // regress the legitimate Retry path: `handleRetry` returns before
+    // `ingestPacket`'s own protected-packet refresh point, so it needs its
+    // own `armIdle` call once the Retry is validated and processed.
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+
+    // RFC 9001 Appendix A.4 sample Retry packet for ODCID
+    // 0x8394c8f03e515708 — the same value `TestPair.odcid` uses, so a fresh
+    // client (which hasn't processed any Initial exchange yet, matching
+    // `TestPair.init`'s just-constructed state) validates it as genuine.
+    const retry = [_]u8{
+        0xff, 0x00, 0x00, 0x00, 0x01, 0x00, 0x08, 0xf0, 0x67, 0xa5, 0x50, 0x2a,
+        0x42, 0x62, 0xb5, 0x74, 0x6f, 0x6b, 0x65, 0x6e, 0x04, 0xa2, 0x65, 0xba,
+        0x2e, 0xff, 0x4d, 0x82, 0x90, 0x58, 0xfb, 0x3f, 0x0f, 0x24, 0x96, 0xba,
+    };
+
+    const before = pair.client.idle_deadline_us;
+    try testing.expect(before != null);
+    const later = pair.now_us + 5 * std.time.us_per_s;
+
+    try pair.client.ingestOnPath(&retry, TestPair.client_path, TestPair.test_challenge_entropy, later);
+
+    try testing.expect(pair.client.got_retry);
+    try testing.expect(pair.client.idle_deadline_us.? > before.?);
 }
 
 test "driver: replayed duplicate packet from a different source address does not create or credit candidate-path state" {

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -137,6 +137,16 @@ pub const Event = union(enum) {
     /// generic application-space bookkeeping. Never carries ticket
     /// identities, PSKs, traffic secrets, or other decrypted session state.
     zero_rtt_packet: struct { outcome: ZeroRttPacketOutcome, size: usize },
+    /// #523: the authoritative TLS-layer 0-RTT decision, bridged once per
+    /// connection as soon as the server has processed the ClientHello —
+    /// independent of whether any `.zero_rtt` packet ever actually arrives
+    /// on the wire (`zero_rtt_packet` above only exists if one does).
+    /// Distinguishes *why* early data was unavailable (disabled, ticket not
+    /// capable, replay, transport/application incompatibility, age skew,
+    /// ...) rather than collapsing every reason into one bucket. Never
+    /// carries ticket identities, PSKs, or other decrypted session state —
+    /// `EarlyDataDecision` is a closed, non-secret enum.
+    early_data_decision: tls_core.tls13_backend.EarlyDataDecision,
 };
 
 /// See `Event.zero_rtt_packet`.
@@ -694,6 +704,11 @@ pub const Connection = struct {
     /// First Handshake-level packet sent (client Initial-key discard trigger).
     sent_handshake_packet: bool = false,
     processed_handshake_packet: bool = false,
+    /// #523: whether `Event.early_data_decision` has already been reported
+    /// for this connection — emitted at most once, as soon as the TLS layer
+    /// has made a real decision, regardless of whether a `.zero_rtt` packet
+    /// ever arrives.
+    early_data_decision_reported: bool = false,
 
     pending_max_data: ?u64 = null,
     pending_max_stream_data: std.ArrayList(struct { id: StreamId, limit: u64 }) = .empty,
@@ -1071,21 +1086,27 @@ pub const Connection = struct {
             self.largest_recv_pn[space_idx] = pn;
         }
         // An authenticated duplicate (same packet number already recorded in
-        // this space — query *before* recording this one) must never have
-        // its frame effects re-applied: 0-RTT and 1-RTT share the
-        // application space, so this is also what stops a replayed 0-RTT
-        // packet from re-crediting stream/connection state a second time.
-        // Path-validation/ACK-range bookkeeping below still runs regardless:
-        // a duplicate still proves current possession of the keys and the
-        // path, and its packet number still belongs in the next ACK.
+        // this space — query *before* recording this one) must be inert
+        // beyond the fact that it authenticated: no re-applied frame
+        // effects (0-RTT and 1-RTT share the application space, so this is
+        // also what stops a replayed 0-RTT packet from re-crediting
+        // stream/connection state), no idle-timer refresh, no ACK-range
+        // insertion (already covered — the insert would be a no-op merge
+        // anyway), and critically no path classification / anti-
+        // amplification crediting: a captured-and-replayed packet resent
+        // from a *different* (possibly spoofed) source address must not be
+        // able to create or credit candidate-path state for that address
+        // just because its packet number already authenticated once.
         const already_received = self.recovery.wasReceived(space, pn);
         self.emitZeroRttOutcome(level, if (already_received) .duplicate else .accepted, bytes.len);
-        self.recovery.onPacketReceived(space, pn) catch {
-            // Pathological ACK-range fragmentation; close rather than lose ACK state.
-            self.startClose(.{ .error_code = error_internal, .is_application = false, .local = true }, "ack range overflow", now_us);
-            return;
-        };
-        self.last_activity_us = now_us;
+        if (!already_received) {
+            self.recovery.onPacketReceived(space, pn) catch {
+                // Pathological ACK-range fragmentation; close rather than lose ACK state.
+                self.startClose(.{ .error_code = error_internal, .is_application = false, .local = true }, "ack range overflow", now_us);
+                return;
+            };
+            self.last_activity_us = now_us;
+        }
 
         if (self.role == .client and parsed.kind == .initial and !self.peer_cid_adopted) {
             // RFC 9000 §7.2: the client adopts the server's SCID.
@@ -1105,25 +1126,30 @@ pub const Connection = struct {
         }
 
         // Authenticated path state (#251/#515): only a packet whose AEAD open
-        // just succeeded (we are past that point now) may create path state,
-        // credit anti-amplification budget, or start/continue a candidate
-        // validation. This never moves the active path or an outbound
-        // destination by itself — only `tryPromote` (driven by a validated
-        // PATH_RESPONSE) does that. A new validation attempt uses the #387
-        // contract for its timeout: max(default, 3x application-space PTO).
-        self.paths.validation_timeout_us = @max(quic_path.default_validation_timeout_us, 3 * self.recovery.rtt.ptoDuration(.application));
-        switch (self.paths.onDatagram(ingress_path, bytes.len, challenge_entropy, now_us)) {
-            .probe => |data| self.queueCandidateChallenge(ingress_path, data),
-            .on_active_path, .probing, .validated_pending_promotion, .blocked => {},
-        }
-        if (level == .handshake and self.role == .server) {
-            // RFC 9001 §4.9.1 / RFC 9000 §8.1: receiving an authenticated
-            // Handshake packet proves the client owns the exact address it
-            // arrived on — never implicitly "whatever path is currently
-            // active". `onDatagram` above has already classified/tracked
-            // `ingress_path` (creating it as a candidate if it differs from
-            // the active path), so this lifts only that path's limit.
-            self.paths.markValidatedOnPath(ingress_path);
+        // just succeeded (we are past that point now) *and* is not an
+        // already-processed duplicate may create path state, credit
+        // anti-amplification budget, or start/continue a candidate
+        // validation — see the comment above `already_received` for why a
+        // duplicate must not reach here. This never moves the active path
+        // or an outbound destination by itself — only `tryPromote` (driven
+        // by a validated PATH_RESPONSE) does that. A new validation attempt
+        // uses the #387 contract for its timeout: max(default, 3x
+        // application-space PTO).
+        if (!already_received) {
+            self.paths.validation_timeout_us = @max(quic_path.default_validation_timeout_us, 3 * self.recovery.rtt.ptoDuration(.application));
+            switch (self.paths.onDatagram(ingress_path, bytes.len, challenge_entropy, now_us)) {
+                .probe => |data| self.queueCandidateChallenge(ingress_path, data),
+                .on_active_path, .probing, .validated_pending_promotion, .blocked => {},
+            }
+            if (level == .handshake and self.role == .server) {
+                // RFC 9001 §4.9.1 / RFC 9000 §8.1: receiving an authenticated
+                // Handshake packet proves the client owns the exact address it
+                // arrived on — never implicitly "whatever path is currently
+                // active". `onDatagram` above has already classified/tracked
+                // `ingress_path` (creating it as a candidate if it differs from
+                // the active path), so this lifts only that path's limit.
+                self.paths.markValidatedOnPath(ingress_path);
+            }
         }
 
         var ack_eliciting = false;
@@ -1186,6 +1212,7 @@ pub const Connection = struct {
                     self.startClose(.{ .error_code = error_crypto_buffer_exceeded, .is_application = false, .local = true }, "crypto buffer", now_us);
                     return;
                 };
+                self.reportEarlyDataDecisionOnce();
                 self.afterHandshakeProgress(ingress_path, now_us);
             },
             .stream => |sf| {
@@ -1509,6 +1536,21 @@ pub const Connection = struct {
     fn emitZeroRttOutcome(self: *Connection, level: EncryptionLevel, outcome: ZeroRttPacketOutcome, size: usize) void {
         if (level != .zero_rtt) return;
         self.events.emit(.{ .zero_rtt_packet = .{ .outcome = outcome, .size = size } });
+    }
+
+    /// See `Event.early_data_decision`. Only the server ever makes this
+    /// decision (RFC 9001 §4.6.1); a client polling its own backend would
+    /// only ever see `.not_attempted`, so this is a no-op there. Emitted at
+    /// most once per connection, as soon as the decision is no longer
+    /// `.not_attempted` — CRYPTO frames arrive in order, so once the
+    /// server's transcript covers the full ClientHello, every later
+    /// `.crypto` frame observes a stable, final decision.
+    fn reportEarlyDataDecisionOnce(self: *Connection) void {
+        if (self.role != .server or self.early_data_decision_reported) return;
+        const decision = self.tls.earlyDataDecision();
+        if (decision == .not_attempted) return;
+        self.early_data_decision_reported = true;
+        self.events.emit(.{ .early_data_decision = decision });
     }
 
     fn roleInitiator(role: Role) quic_stream.Initiator {
@@ -3535,6 +3577,40 @@ test "driver: authenticated duplicate 0-RTT packet does not re-apply a state-mut
     try testing.expectEqual(@as(usize, 1), pair.server.pending_path_responses.items.len);
 }
 
+test "driver: replayed duplicate packet from a different source address does not create or credit candidate-path state" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+
+    const secret = [_]u8{0x37} ** tls_adapter.traffic_secret_len;
+    pair.server.adapter.setZeroRttEnabled(true);
+    pair.server.adapter.installSecret(try tls_adapter.Secret.init(.zero_rtt, .read, &secret));
+
+    var frame_buf: [16]u8 = undefined;
+    const frame_len = try frame.encodeStream(0, 0, "hi", true, &frame_buf);
+    var wire: [256]u8 = undefined;
+    const datagram = sealTestZeroRttPacket(&TestPair.odcid, &TestPair.client_cid, secret, 0, frame_buf[0..frame_len], &wire);
+
+    // First delivery: authenticates and is processed on the server's actual
+    // (handshake) active path, as usual.
+    try pair.server.ingestOnPath(datagram, TestPair.server_path, TestPair.test_challenge_entropy, pair.now_us);
+
+    // Replay the byte-identical datagram, but claim it arrived from a
+    // different (spoofed or off-path-captured-and-resent) source address.
+    const spoofed_path = quic_path.PathKey{
+        .local = TestPair.server_path.local,
+        .remote = quic_udp.Address.ip4(.{ 203, 0, 113, 7 }, 9999),
+    };
+    try testing.expectEqual(@as(?quic_path.PathState, null), pair.server.paths.stateOf(spoofed_path));
+    try pair.server.ingestOnPath(datagram, spoofed_path, TestPair.test_challenge_entropy, pair.now_us);
+
+    // The replay authenticates (it's the same packet number, already
+    // processed once) but must not have created a candidate path or
+    // credited that address's anti-amplification ledger merely because the
+    // bytes happened to decrypt.
+    try testing.expectEqual(@as(?quic_path.PathState, null), pair.server.paths.stateOf(spoofed_path));
+}
+
 test "driver: frames illegal in 0-RTT close the connection instead of taking effect (RFC 9000 §12.5)" {
     const allocator = testing.allocator;
 
@@ -4143,6 +4219,183 @@ test "#523: real TLS accept decision installs a usable QUIC 0-RTT read key end t
     try testing.expect(resumed.server.isEstablished());
     try testing.expect(resumed.client_backend.engine.core.psk_authenticated);
     try testing.expect(resumed.server_backend.engine.core.psk_authenticated);
+}
+
+test "#523: Event.early_data_decision surfaces the real TLS decision once, even when the carrier is disabled" {
+    const resumption_runtime = tls_core.resumption_runtime;
+    const allocator = testing.allocator;
+
+    var server_entropy = tls_core.production_crypto.OsEntropy{};
+    var server_provider = tls_core.production_crypto.Provider.init(server_entropy.entropy());
+    var server_runtime = try resumption_runtime.Runtime.init(
+        allocator,
+        .{ .mode = .stateful },
+        .{ .ctx = undefined, .nowUnixMsFn = struct {
+            fn now(_: *anyopaque) i64 {
+                return 1000;
+            }
+        }.now },
+        server_provider.cryptoProvider(),
+    );
+    defer server_runtime.deinit();
+
+    var client_entropy = tls_core.production_crypto.OsEntropy{};
+    var client_provider = tls_core.production_crypto.Provider.init(client_entropy.entropy());
+    var client_runtime = try resumption_runtime.Runtime.init(
+        allocator,
+        .{ .mode = .stateful },
+        .{ .ctx = undefined, .nowUnixMsFn = struct {
+            fn now(_: *anyopaque) i64 {
+                return 2000;
+            }
+        }.now },
+        client_provider.cryptoProvider(),
+    );
+    defer client_runtime.deinit();
+
+    // Phase 1: same shape as the previous test — an early-data-capable
+    // ticket, issued and captured.
+    const CaptureImpl = struct {
+        runtime: *resumption_runtime.Runtime,
+        stored: tls_core.session_cache.StoreResult = undefined,
+        retained: tls_core.session.ClientTicketState = .{},
+
+        fn now(_: *anyopaque) i64 {
+            return 1000;
+        }
+        fn onTicket(ctx: *anyopaque, ticket: *const tls_core.session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            ticket.cloneInto(testing.allocator, &self.retained) catch unreachable;
+            self.stored = self.runtime.storeClientTicket(ticket);
+        }
+    };
+    var capture = CaptureImpl{ .runtime = &client_runtime };
+    defer capture.retained.deinit();
+    const resume_policy: tls_core.tls13_backend.Tls13Backend.ResumeCompatibilityPolicy = .{
+        .transport = .ignore,
+        .application = .ignore,
+    };
+    var pair = try TestPair.initWithTicketConsumerAndResumePolicy(allocator, tls_core.session.Limits.default, .{
+        .ctx = &capture,
+        .nowUnixMsFn = CaptureImpl.now,
+        .onTicketFn = CaptureImpl.onTicket,
+    }, resume_policy);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    var prepared = try pair.server.prepareNewSessionTicket(allocator, .{
+        .ticket_lifetime = 3600,
+        .ticket_age_add = 500,
+        .ticket_nonce = "\x01",
+        .issued_at_unix_ms = 1000,
+        .max_early_data_size = std.math.maxInt(u32),
+    }, tls_core.session.Limits.default);
+    defer prepared.deinit();
+    var scratch: [256]u8 = undefined;
+    var identity = try server_runtime.createIdentity(&prepared.state, 1000, &scratch);
+    try testing.expect(identity == .stateful);
+    try pair.server.emitPreparedNewSessionTicket(&prepared, identity.slice(), tls_core.session.Limits.default);
+    try pair.pump();
+    try testing.expectEqual(tls_core.session_cache.StoreResult.stored, capture.stored);
+
+    const candidate: tls_core.session.CandidateContext = .{
+        .cipher_suite = capture.retained.common.cipher_suite,
+        .server_name = if (capture.retained.common.server_name) |*s| s.slice() else null,
+        .application_protocol = if (capture.retained.common.application_protocol) |*a| a.slice() else null,
+        .auth_binding = capture.retained.common.auth_binding,
+        .transport_compat = null,
+        .application_compat = null,
+    };
+    var lookup = client_runtime.lookupClientOffers(candidate);
+    defer lookup.deinit();
+    try testing.expect(lookup == .hit);
+
+    // Phase 2: the client attempts 0-RTT with a genuinely early-data-capable
+    // ticket, but the server never enables `ServerEarlyDataPolicy` — the
+    // carrier stays off. `decideServerEarlyData` still runs (the ClientHello
+    // did request early data) and must report `.disabled`, not silently
+    // produce nothing just because no `.zero_rtt` packet will ever be sent.
+    const EventCapture = struct {
+        decision: ?tls_core.tls13_backend.EarlyDataDecision = null,
+        count: usize = 0,
+
+        fn onEvent(ctx: ?*anyopaque, event: Event) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx.?));
+            switch (event) {
+                .early_data_decision => |d| {
+                    self.decision = d;
+                    self.count += 1;
+                },
+                else => {},
+            }
+        }
+    };
+    var event_capture = EventCapture{};
+
+    const resumed = try allocator.create(TestPair);
+    defer allocator.destroy(resumed);
+    resumed.* = .{
+        .client_backend = tls_backend_mod.Tls13Backend.initClient(
+            .{ .hello_random = [_]u8{0xf1} ** 32, .key_share_seed = [_]u8{0x51} ** 32 },
+            .{ .pinned_certificate = tls_backend_mod.testdata.certificate_der },
+        ),
+        .server_backend = tls_backend_mod.Tls13Backend.initServer(
+            .{ .hello_random = [_]u8{0xf2} ** 32, .key_share_seed = [_]u8{0x52} ** 32 },
+            try tls_backend_mod.Identity.initPkcs8(
+                tls_backend_mod.testdata.certificate_der,
+                tls_backend_mod.testdata.private_key_pkcs8_der,
+            ),
+        ),
+    };
+    var clock_dummy: u8 = 0;
+    const ClientClock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 2000;
+        }
+    };
+    try resumed.client_backend.engine.setClientPskOfferLease(&lookup.hit, &clock_dummy, ClientClock.now);
+    try resumed.client_backend.setResumeCompatibilityPolicy(resume_policy);
+    try resumed.client_backend.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 4096 });
+    try resumed.server_backend.setServerPskResolver(server_runtime.serverResolver().?);
+    try resumed.server_backend.setResumeCompatibilityPolicy(resume_policy);
+    // Deliberately not called: `resumed.server_backend.setServerEarlyDataPolicy(...)`.
+
+    resumed.client = try Connection.init(allocator, .{
+        .role = .client,
+        .config = .{ .zero_rtt_enabled = true },
+        .local_cid = &TestPair.client_cid,
+        .original_dcid = &TestPair.odcid,
+        .peer_cid = &TestPair.odcid,
+        .tls = resumed.client_backend.backend(),
+        .now_us = resumed.now_us,
+        .initial_path = TestPair.client_path,
+    });
+    defer resumed.client.deinit();
+    resumed.server = try Connection.init(allocator, .{
+        .role = .server,
+        .config = .{ .zero_rtt_enabled = true },
+        .local_cid = &TestPair.odcid,
+        .original_dcid = &TestPair.odcid,
+        .peer_cid = &TestPair.client_cid,
+        .tls = resumed.server_backend.backend(),
+        .now_us = resumed.now_us,
+        .initial_path = TestPair.server_path,
+        .events = .{ .context = &event_capture, .emitFn = EventCapture.onEvent },
+    });
+    defer resumed.server.deinit();
+
+    try resumed.pump();
+
+    try testing.expect(resumed.client.isEstablished());
+    try testing.expect(resumed.server.isEstablished());
+    // The PSK still resumed (ordinary 1-RTT is unaffected by the disabled
+    // carrier)...
+    try testing.expect(resumed.server_backend.engine.core.psk_authenticated);
+    // ...but the typed decision correctly distinguishes "disabled" from
+    // "accepted", reported exactly once regardless of how many further
+    // CRYPTO/application packets the rest of the handshake exchanges.
+    try testing.expectEqual(@as(usize, 1), event_capture.count);
+    try testing.expectEqual(tls_core.tls13_backend.EarlyDataDecision.disabled, event_capture.decision.?);
 }
 
 test "driver: maximum NewSessionTicket survives real loss reordering PTO and ACK cleanup" {

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -949,7 +949,10 @@ pub const Connection = struct {
             // Everything after a short-header packet is part of it.
             if (parsed.kind == .one_rtt) break;
         }
-        self.armIdle(now_us);
+        // Idle-timer refresh happens inside `ingestPacket`, only for a
+        // packet that authenticated and was not a duplicate (RFC 9000
+        // §10.1) — never unconditionally per datagram here, or a replayed
+        // or undecryptable datagram could keep the connection alive.
     }
 
     fn ingestPacket(
@@ -1106,6 +1109,15 @@ pub const Connection = struct {
                 return;
             };
             self.last_activity_us = now_us;
+            // RFC 9000 §10.1: the idle timer restarts only when a packet is
+            // received *and processed successfully* — a duplicate (or a
+            // dropped/undecryptable packet, which never reaches this point
+            // at all) must not keep the connection alive. This must live
+            // here, not as an unconditional call in `ingestOnPath` after the
+            // packet loop — that would refresh the deadline for every
+            // datagram regardless of whether anything in it actually
+            // authenticated.
+            self.armIdle(now_us);
         }
 
         if (self.role == .client and parsed.kind == .initial and !self.peer_cid_adopted) {
@@ -3577,6 +3589,47 @@ test "driver: authenticated duplicate 0-RTT packet does not re-apply a state-mut
     try testing.expectEqual(@as(usize, 1), pair.server.pending_path_responses.items.len);
 }
 
+test "driver: the idle timer does not refresh on a duplicate or an undecryptable datagram (RFC 9000 §10.1)" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+
+    const secret = [_]u8{0x29} ** tls_adapter.traffic_secret_len;
+    pair.server.adapter.setZeroRttEnabled(true);
+    pair.server.adapter.installSecret(try tls_adapter.Secret.init(.zero_rtt, .read, &secret));
+
+    var frame_buf: [16]u8 = undefined;
+    const frame_len = try frame.encodeStream(0, 0, "hi", true, &frame_buf);
+    var wire: [256]u8 = undefined;
+    const datagram = sealTestZeroRttPacket(&TestPair.odcid, &TestPair.client_cid, secret, 0, frame_buf[0..frame_len], &wire);
+
+    try pair.server.ingestOnPath(datagram, TestPair.server_path, TestPair.test_challenge_entropy, pair.now_us);
+    const deadline_after_fresh = pair.server.idle_deadline_us;
+    try testing.expect(deadline_after_fresh != null);
+
+    const later = pair.now_us + 10 * std.time.us_per_s;
+
+    // Replaying the identical (now-duplicate) packet much later must not
+    // move the idle deadline out to reflect that later time.
+    try pair.server.ingestOnPath(datagram, TestPair.server_path, TestPair.test_challenge_entropy, later);
+    try testing.expectEqual(deadline_after_fresh, pair.server.idle_deadline_us);
+
+    // Neither must a tampered (undecryptable) datagram at that later time.
+    var tampered: [256]u8 = undefined;
+    @memcpy(tampered[0..datagram.len], datagram);
+    tampered[datagram.len - 1] ^= 0x01;
+    try pair.server.ingestOnPath(tampered[0..datagram.len], TestPair.server_path, TestPair.test_challenge_entropy, later);
+    try testing.expectEqual(deadline_after_fresh, pair.server.idle_deadline_us);
+
+    // A genuinely fresh authenticated packet still does refresh it.
+    var frame_buf_2: [16]u8 = undefined;
+    const frame_len_2 = try frame.encodeStream(4, 0, "bye", true, &frame_buf_2);
+    var wire_2: [256]u8 = undefined;
+    const datagram_2 = sealTestZeroRttPacket(&TestPair.odcid, &TestPair.client_cid, secret, 1, frame_buf_2[0..frame_len_2], &wire_2);
+    try pair.server.ingestOnPath(datagram_2, TestPair.server_path, TestPair.test_challenge_entropy, later);
+    try testing.expect(pair.server.idle_deadline_us.? > deadline_after_fresh.?);
+}
+
 test "driver: replayed duplicate packet from a different source address does not create or credit candidate-path state" {
     const allocator = testing.allocator;
     var pair = try TestPair.init(allocator);
@@ -4396,6 +4449,267 @@ test "#523: Event.early_data_decision surfaces the real TLS decision once, even 
     // CRYPTO/application packets the rest of the handshake exchanges.
     try testing.expectEqual(@as(usize, 1), event_capture.count);
     try testing.expectEqual(tls_core.tls13_backend.EarlyDataDecision.disabled, event_capture.decision.?);
+}
+
+/// #523 third-pass review: proves that when 0-RTT is rejected — for any of
+/// several distinct reasons, not just "disabled" — the *same* resumed PSK
+/// connection (not a fallback to a different one) still completes its
+/// handshake and serves a real request over ordinary 1-RTT afterward.
+/// Shared by the reason-specific tests below; only the server's early-data
+/// composition (and the expected `EarlyDataDecision`) varies per caller.
+const RejectedEarlyDataFallback = struct {
+    server_early_data_policy: tls_core.tls13_backend.ServerEarlyDataPolicy,
+    replay_gate: ?tls_core.tls13_backend.EarlyDataReplayGate,
+    compat_gate: ?tls_core.tls13_backend.EarlyDataCompatibilityGate,
+    expect_decision: tls_core.tls13_backend.EarlyDataDecision,
+};
+
+fn expectRejectedEarlyDataFallsBackOnSameConnection(scenario: RejectedEarlyDataFallback) !void {
+    const resumption_runtime = tls_core.resumption_runtime;
+    const allocator = testing.allocator;
+
+    var server_entropy = tls_core.production_crypto.OsEntropy{};
+    var server_provider = tls_core.production_crypto.Provider.init(server_entropy.entropy());
+    var server_runtime = try resumption_runtime.Runtime.init(
+        allocator,
+        .{ .mode = .stateful },
+        .{ .ctx = undefined, .nowUnixMsFn = struct {
+            fn now(_: *anyopaque) i64 {
+                return 1000;
+            }
+        }.now },
+        server_provider.cryptoProvider(),
+    );
+    defer server_runtime.deinit();
+
+    var client_entropy = tls_core.production_crypto.OsEntropy{};
+    var client_provider = tls_core.production_crypto.Provider.init(client_entropy.entropy());
+    var client_runtime = try resumption_runtime.Runtime.init(
+        allocator,
+        .{ .mode = .stateful },
+        .{ .ctx = undefined, .nowUnixMsFn = struct {
+            fn now(_: *anyopaque) i64 {
+                return 2000;
+            }
+        }.now },
+        client_provider.cryptoProvider(),
+    );
+    defer client_runtime.deinit();
+
+    const CaptureImpl = struct {
+        runtime: *resumption_runtime.Runtime,
+        stored: tls_core.session_cache.StoreResult = undefined,
+        retained: tls_core.session.ClientTicketState = .{},
+
+        fn now(_: *anyopaque) i64 {
+            return 1000;
+        }
+        fn onTicket(ctx: *anyopaque, ticket: *const tls_core.session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            ticket.cloneInto(testing.allocator, &self.retained) catch unreachable;
+            self.stored = self.runtime.storeClientTicket(ticket);
+        }
+    };
+    var capture = CaptureImpl{ .runtime = &client_runtime };
+    defer capture.retained.deinit();
+    const resume_policy: tls_core.tls13_backend.Tls13Backend.ResumeCompatibilityPolicy = .{
+        .transport = .ignore,
+        .application = .ignore,
+    };
+    var pair = try TestPair.initWithTicketConsumerAndResumePolicy(allocator, tls_core.session.Limits.default, .{
+        .ctx = &capture,
+        .nowUnixMsFn = CaptureImpl.now,
+        .onTicketFn = CaptureImpl.onTicket,
+    }, resume_policy);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    var prepared = try pair.server.prepareNewSessionTicket(allocator, .{
+        .ticket_lifetime = 3600,
+        .ticket_age_add = 500,
+        .ticket_nonce = "\x01",
+        .issued_at_unix_ms = 1000,
+        .max_early_data_size = std.math.maxInt(u32),
+    }, tls_core.session.Limits.default);
+    defer prepared.deinit();
+    var scratch: [256]u8 = undefined;
+    var identity = try server_runtime.createIdentity(&prepared.state, 1000, &scratch);
+    try testing.expect(identity == .stateful);
+    try pair.server.emitPreparedNewSessionTicket(&prepared, identity.slice(), tls_core.session.Limits.default);
+    try pair.pump();
+    try testing.expectEqual(tls_core.session_cache.StoreResult.stored, capture.stored);
+
+    const candidate: tls_core.session.CandidateContext = .{
+        .cipher_suite = capture.retained.common.cipher_suite,
+        .server_name = if (capture.retained.common.server_name) |*s| s.slice() else null,
+        .application_protocol = if (capture.retained.common.application_protocol) |*a| a.slice() else null,
+        .auth_binding = capture.retained.common.auth_binding,
+        .transport_compat = null,
+        .application_compat = null,
+    };
+    var lookup = client_runtime.lookupClientOffers(candidate);
+    defer lookup.deinit();
+    try testing.expect(lookup == .hit);
+
+    const EventCapture = struct {
+        decision: ?tls_core.tls13_backend.EarlyDataDecision = null,
+        count: usize = 0,
+
+        fn onEvent(ctx: ?*anyopaque, event: Event) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx.?));
+            switch (event) {
+                .early_data_decision => |d| {
+                    self.decision = d;
+                    self.count += 1;
+                },
+                else => {},
+            }
+        }
+    };
+    var event_capture = EventCapture{};
+
+    const resumed = try allocator.create(TestPair);
+    defer allocator.destroy(resumed);
+    resumed.* = .{
+        .client_backend = tls_backend_mod.Tls13Backend.initClient(
+            .{ .hello_random = [_]u8{0xa1} ** 32, .key_share_seed = [_]u8{0x61} ** 32 },
+            .{ .pinned_certificate = tls_backend_mod.testdata.certificate_der },
+        ),
+        .server_backend = tls_backend_mod.Tls13Backend.initServer(
+            .{ .hello_random = [_]u8{0xa2} ** 32, .key_share_seed = [_]u8{0x62} ** 32 },
+            try tls_backend_mod.Identity.initPkcs8(
+                tls_backend_mod.testdata.certificate_der,
+                tls_backend_mod.testdata.private_key_pkcs8_der,
+            ),
+        ),
+    };
+    var clock_dummy: u8 = 0;
+    const ClientClock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 2000;
+        }
+    };
+    try resumed.client_backend.engine.setClientPskOfferLease(&lookup.hit, &clock_dummy, ClientClock.now);
+    try resumed.client_backend.setResumeCompatibilityPolicy(resume_policy);
+    try resumed.client_backend.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 4096 });
+    try resumed.server_backend.setServerPskResolver(server_runtime.serverResolver().?);
+    try resumed.server_backend.setResumeCompatibilityPolicy(resume_policy);
+    if (scenario.replay_gate) |gate| try resumed.server_backend.setEarlyDataReplayGate(gate);
+    if (scenario.compat_gate) |gate| try resumed.server_backend.setEarlyDataCompatibilityGate(gate);
+    try resumed.server_backend.setServerEarlyDataPolicy(scenario.server_early_data_policy);
+
+    resumed.client = try Connection.init(allocator, .{
+        .role = .client,
+        .config = .{ .zero_rtt_enabled = true },
+        .local_cid = &TestPair.client_cid,
+        .original_dcid = &TestPair.odcid,
+        .peer_cid = &TestPair.odcid,
+        .tls = resumed.client_backend.backend(),
+        .now_us = resumed.now_us,
+        .initial_path = TestPair.client_path,
+    });
+    defer resumed.client.deinit();
+    resumed.server = try Connection.init(allocator, .{
+        .role = .server,
+        .config = .{ .zero_rtt_enabled = true },
+        .local_cid = &TestPair.odcid,
+        .original_dcid = &TestPair.odcid,
+        .peer_cid = &TestPair.client_cid,
+        .tls = resumed.server_backend.backend(),
+        .now_us = resumed.now_us,
+        .initial_path = TestPair.server_path,
+        .events = .{ .context = &event_capture, .emitFn = EventCapture.onEvent },
+    });
+    defer resumed.server.deinit();
+
+    try resumed.pump();
+
+    try testing.expect(resumed.client.isEstablished());
+    try testing.expect(resumed.server.isEstablished());
+    try testing.expect(resumed.client_backend.engine.core.psk_authenticated);
+    try testing.expect(resumed.server_backend.engine.core.psk_authenticated);
+    try testing.expect(resumed.server.adapter.protectionKeys(.zero_rtt, .read) == null);
+    try testing.expectEqual(@as(usize, 1), event_capture.count);
+    try testing.expectEqual(scenario.expect_decision, event_capture.decision.?);
+
+    // The same connection — not a different, cleaner one — genuinely serves
+    // a real request over ordinary 1-RTT afterward.
+    const id = try resumed.client.openStream(.bidi);
+    _ = try resumed.client.writeStream(id, "hello", true);
+    try resumed.pump();
+    try testing.expectEqual(@as(?StreamId, id), resumed.server.acceptStream());
+    var buf: [16]u8 = undefined;
+    const request = try resumed.server.readStream(id, &buf);
+    try testing.expectEqualStrings("hello", buf[0..request.len]);
+}
+
+test "#523: replay-rejected 0-RTT falls back to a working 1-RTT connection, same connection" {
+    const AlwaysReplay = struct {
+        fn decide(_: *anyopaque, _: tls_backend_mod.EarlyDataReplayCandidate) tls_backend_mod.EarlyDataReplayDecision {
+            return .replay;
+        }
+    };
+    var ctx: u8 = 0;
+    try expectRejectedEarlyDataFallsBackOnSameConnection(.{
+        .server_early_data_policy = .{ .enabled = true },
+        .replay_gate = .{ .ctx = &ctx, .decideFn = AlwaysReplay.decide },
+        .compat_gate = null,
+        .expect_decision = .replay_rejected,
+    });
+}
+
+test "#523: replay-store-unavailable 0-RTT falls back to a working 1-RTT connection, same connection" {
+    // No replay gate installed at all: the backend's own default gate fails
+    // closed (`.unavailable`) for every attempt — proving the fail-closed
+    // default itself still leaves ordinary resumption usable.
+    try expectRejectedEarlyDataFallsBackOnSameConnection(.{
+        .server_early_data_policy = .{ .enabled = true },
+        .replay_gate = null,
+        .compat_gate = null,
+        .expect_decision = .replay_unavailable,
+    });
+}
+
+test "#523: transport-incompatible 0-RTT falls back to a working 1-RTT connection, same connection" {
+    const AlwaysTransportIncompatible = struct {
+        fn decide(_: *anyopaque, _: tls_backend_mod.EarlyDataCompatibilityCandidate) tls_backend_mod.EarlyDataCompatibilityDecision {
+            return .transport_incompatible;
+        }
+    };
+    const AlwaysAllow = struct {
+        fn decide(_: *anyopaque, _: tls_backend_mod.EarlyDataReplayCandidate) tls_backend_mod.EarlyDataReplayDecision {
+            return .allow;
+        }
+    };
+    var replay_ctx: u8 = 0;
+    var compat_ctx: u8 = 0;
+    try expectRejectedEarlyDataFallsBackOnSameConnection(.{
+        .server_early_data_policy = .{ .enabled = true },
+        .replay_gate = .{ .ctx = &replay_ctx, .decideFn = AlwaysAllow.decide },
+        .compat_gate = .{ .ctx = &compat_ctx, .decideFn = AlwaysTransportIncompatible.decide },
+        .expect_decision = .transport_incompatible,
+    });
+}
+
+test "#523: application-incompatible (H3 SETTINGS) 0-RTT falls back to a working 1-RTT connection, same connection" {
+    const AlwaysApplicationIncompatible = struct {
+        fn decide(_: *anyopaque, _: tls_backend_mod.EarlyDataCompatibilityCandidate) tls_backend_mod.EarlyDataCompatibilityDecision {
+            return .application_incompatible;
+        }
+    };
+    const AlwaysAllow = struct {
+        fn decide(_: *anyopaque, _: tls_backend_mod.EarlyDataReplayCandidate) tls_backend_mod.EarlyDataReplayDecision {
+            return .allow;
+        }
+    };
+    var replay_ctx: u8 = 0;
+    var compat_ctx: u8 = 0;
+    try expectRejectedEarlyDataFallsBackOnSameConnection(.{
+        .server_early_data_policy = .{ .enabled = true },
+        .replay_gate = .{ .ctx = &replay_ctx, .decideFn = AlwaysAllow.decide },
+        .compat_gate = .{ .ctx = &compat_ctx, .decideFn = AlwaysApplicationIncompatible.decide },
+        .expect_decision = .application_incompatible,
+    });
 }
 
 test "driver: maximum NewSessionTicket survives real loss reordering PTO and ACK cleanup" {

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -93,6 +93,25 @@ const h3_early_data_format_id: u16 = 0x6833;
 const h3_early_data_format_version: u16 = 1;
 const h3_default_settings_snapshot = [_]u8{0} ** 25;
 
+/// Zero-credit stand-in for the peer's transport parameters, used only to
+/// bring the stream layer up early for 0-RTT admission (`ensureEarlyStreamManager`)
+/// before the real peer parameters are authenticated. Grants no send credit
+/// of any kind, so it can never be more permissive than whatever the real
+/// peer eventually authorizes — `StreamManager.refreshPeerParams` only ever
+/// raises limits once the authenticated values land.
+const zero_send_credit_params: config.TransportParameters = .{
+    .max_idle_timeout_ms = 0,
+    .active_connection_id_limit = 0,
+    .max_udp_payload_size = 0,
+    .initial_max_data = 0,
+    .initial_max_stream_data_bidi_local = 0,
+    .initial_max_stream_data_bidi_remote = 0,
+    .initial_max_stream_data_uni = 0,
+    .initial_max_streams_bidi = 0,
+    .initial_max_streams_uni = 0,
+    .disable_active_migration = false,
+};
+
 pub const IngestError = error{OutOfMemory};
 
 pub const Event = union(enum) {
@@ -696,6 +715,7 @@ pub const Connection = struct {
             .stream_transport_early = std.AutoHashMap(StreamId, void).init(allocator),
             .last_activity_us = options.now_us,
         };
+        conn.adapter.setZeroRttEnabled(conn.cfg.zero_rtt_enabled);
         // Construct the handshake before `errdefer conn.deinitPartial()` is
         // installed: deinitPartial() unconditionally calls
         // `self.handshake.deinit()`, so any fallible operation between the
@@ -914,13 +934,6 @@ pub const Connection = struct {
                 self.handleRetry(bytes, parsed, now_us);
                 return;
             },
-            .zero_rtt => {
-                // #366 owns QUIC 0-RTT carrier acceptance. Until that gate can
-                // decide accepted vs rejected before recovery/ACK bookkeeping,
-                // fail closed and expose only the explicit sticky provenance seam.
-                self.dropPacket(.undecryptable, bytes.len);
-                return;
-            },
             else => {},
         }
         if (parsed.kind != .one_rtt and parsed.version != packet.quic_v1) {
@@ -935,6 +948,7 @@ pub const Connection = struct {
         const level: EncryptionLevel = switch (parsed.kind) {
             .initial => .initial,
             .handshake => .handshake,
+            .zero_rtt => .zero_rtt,
             .one_rtt => .application,
             else => unreachable,
         };
@@ -957,7 +971,11 @@ pub const Connection = struct {
         }
 
         var keys = self.adapter.protectionKeys(level, .read) orelse {
-            self.dropPacket(.undecryptable, bytes.len);
+            // No installed/enabled read secret at this level. For 0-RTT this
+            // is the ordinary "early data not authorized yet" case (TLS never
+            // accepted the PSK attempt, or the carrier is disabled) rather
+            // than an authentication failure, so it gets its own reason.
+            self.dropPacket(if (level == .zero_rtt) .keys_unavailable else .undecryptable, bytes.len);
             return;
         };
         var sample: [sample_len]u8 = undefined;
@@ -996,6 +1014,8 @@ pub const Connection = struct {
             return;
         };
         self.adapter.metrics.packets_deprotected += 1;
+
+        if (level == .zero_rtt) self.ensureEarlyStreamManager();
 
         if (used_next_keys) {
             self.adapter.commitApplicationReadKeyUpdate() catch {};
@@ -1111,7 +1131,7 @@ pub const Connection = struct {
                 self.afterHandshakeProgress(ingress_path, now_us);
             },
             .stream => |sf| {
-                if (level != .application) {
+                if (level != .application and level != .zero_rtt) {
                     self.startClose(.{ .error_code = error_protocol_violation, .is_application = false, .local = true }, "stream frame level", now_us);
                     return;
                 }
@@ -1129,6 +1149,12 @@ pub const Connection = struct {
                     if (quic_stream.streamInitiator(sf.id) != roleInitiator(self.role)) {
                         try self.accept_queue.append(self.allocator, sf.id);
                     }
+                }
+                if (level == .zero_rtt) {
+                    // Sticky provenance (#523): bytes delivered while this
+                    // packet was 0-RTT stay marked early even once later
+                    // 1-RTT bytes land on the same stream.
+                    try self.markStreamZeroRtt(sf.id);
                 }
             },
             .reset_stream => |rs| {
@@ -1413,6 +1439,31 @@ pub const Connection = struct {
         return null;
     }
 
+    /// Bring the stream layer up early so an authenticated 0-RTT STREAM frame
+    /// has somewhere to land. `afterHandshakeProgress` normally waits for the
+    /// peer's transport parameters to be authenticated (full handshake done)
+    /// before creating `self.streams`, but 0-RTT data is by definition
+    /// received before that point. This is safe to do early because inbound
+    /// admission (`StreamManager.receiveStreamFrame` / `ensurePeerStreamAllowed`
+    /// / `initialRecvWindow`) is governed entirely by `local` transport
+    /// parameters — our own fixed configuration, known before any handshake
+    /// byte arrives — never by the peer's. The peer side is seeded with
+    /// `zero_send_credit_params` (grants no send credit) until
+    /// `afterHandshakeProgress` calls `refreshPeerParams` with the real,
+    /// authenticated peer parameters.
+    fn ensureEarlyStreamManager(self: *Connection) void {
+        if (self.streams != null) return;
+        self.streams = quic_stream.StreamManager.init(
+            self.allocator,
+            switch (self.role) {
+                .client => .client,
+                .server => .server,
+            },
+            self.local_params,
+            zero_send_credit_params,
+        );
+    }
+
     // -- retry / handshake progress -------------------------------------------
 
     fn handleRetry(self: *Connection, bytes: []const u8, parsed: packet.ParsedPacket, now_us: u64) void {
@@ -1625,15 +1676,25 @@ pub const Connection = struct {
             self.startClose(.{ .error_code = error_transport_parameter, .is_application = false, .local = true }, "missing peer params", now_us);
             return;
         };
-        self.streams = quic_stream.StreamManager.init(
-            self.allocator,
-            switch (self.role) {
-                .client => .client,
-                .server => .server,
-            },
-            self.local_params,
-            peer_params,
-        );
+        if (self.streams) |*manager| {
+            // 0-RTT already brought the stream layer up early with a
+            // zero-send-credit placeholder peer side (see
+            // `ensureEarlyStreamManager`) — swap in the now-authenticated
+            // real peer parameters in place rather than reinitializing,
+            // which would silently discard any stream state/data buffered
+            // from accepted 0-RTT packets.
+            manager.refreshPeerParams(peer_params);
+        } else {
+            self.streams = quic_stream.StreamManager.init(
+                self.allocator,
+                switch (self.role) {
+                    .client => .client,
+                    .server => .server,
+                },
+                self.local_params,
+                peer_params,
+            );
+        }
         self.setState(.established);
 
         if (self.role == .server) {
@@ -3174,6 +3235,192 @@ test "driver: explicit zero-rtt stream provenance mark stays sticky after one-rt
     try testing.expect(request.fin);
 }
 
+/// Test-only helper (#523): seal a 0-RTT wire packet exactly the way a real
+/// client sender would, via an independent throwaway adapter installed with
+/// `secret` at the `.zero_rtt write` slot. Key derivation
+/// (`deriveAes128GcmKeys`) depends only on the secret bytes, not on which
+/// side calls it "read" vs "write", so a receiver with the same bytes
+/// installed at `.zero_rtt read` genuinely decrypts this — it exercises the
+/// real AEAD-seal/header-protection codepath `buildPacket` uses for every
+/// other level, not a synthetic shortcut.
+fn sealTestZeroRttPacket(
+    dcid: []const u8,
+    scid: []const u8,
+    secret: [tls_adapter.traffic_secret_len]u8,
+    pn: u64,
+    plaintext: []const u8,
+    out: []u8,
+) []u8 {
+    var sender = tls_adapter.QuicTlsAdapter{};
+    sender.setZeroRttEnabled(true);
+    sender.installSecret(tls_adapter.Secret.init(.zero_rtt, .write, &secret) catch unreachable);
+
+    const pn_len: u3 = packet.packetNumberLength(pn, null);
+    const written = packet.writeLongHeader(.zero_rtt, packet.quic_v1, dcid, scid, "", pn_len, out) catch unreachable;
+    const pn_offset = written.pn_offset;
+
+    // Pad so the sealed ciphertext is long enough to sample for header
+    // protection, mirroring `buildPacket`'s own padding step.
+    var padded: [128]u8 = undefined;
+    const sample_min = (4 - @as(usize, pn_len)) + sample_len - aead_tag_len;
+    const padded_len = @max(plaintext.len, sample_min);
+    @memcpy(padded[0..plaintext.len], plaintext);
+    @memset(padded[plaintext.len..padded_len], 0);
+
+    // The Length field precedes `pn_offset` and is covered by the AEAD
+    // associated data (the "header" slice below), so it must be patched to
+    // its final value *before* sealing — sealing after would authenticate a
+    // different header than what ends up on the wire.
+    packet.patchLongHeaderLength(out, written.length_offset, pn_len + padded_len + aead_tag_len);
+
+    const truncated = packet.truncatePacketNumber(pn, pn_len);
+    var pn_bytes: [4]u8 = undefined;
+    std.mem.writeInt(u32, &pn_bytes, truncated, .big);
+    @memcpy(out[pn_offset..][0..pn_len], pn_bytes[4 - @as(usize, pn_len) ..][0..pn_len]);
+
+    const header = out[0 .. pn_offset + pn_len];
+    const keys = sender.protectionKeys(.zero_rtt, .write).?;
+    _ = sender.sealPacketPayload(.zero_rtt, .write, pn, header, padded[0..padded_len], out[pn_offset + pn_len ..]) catch unreachable;
+
+    var sample: [sample_len]u8 = undefined;
+    @memcpy(&sample, out[pn_offset + 4 ..][0..sample_len]);
+    keys.applyHeaderProtection(&out[0], out[pn_offset..][0..pn_len], sample);
+
+    return out[0 .. pn_offset + pn_len + padded_len + aead_tag_len];
+}
+
+test "driver: accepted 0-RTT packet with installed read keys decrypts and delivers stream data" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+
+    const secret = [_]u8{0x42} ** tls_adapter.traffic_secret_len;
+    pair.server.adapter.setZeroRttEnabled(true);
+    pair.server.adapter.installSecret(try tls_adapter.Secret.init(.zero_rtt, .read, &secret));
+
+    var frame_buf: [32]u8 = undefined;
+    const frame_len = try frame.encodeStream(0, 0, "hello 0-rtt", true, &frame_buf);
+
+    var wire: [256]u8 = undefined;
+    const datagram = sealTestZeroRttPacket(&TestPair.odcid, &TestPair.client_cid, secret, 0, frame_buf[0..frame_len], &wire);
+
+    const before_received = pair.server.metrics.packets_received;
+    try pair.server.ingestOnPath(datagram, TestPair.server_path, TestPair.test_challenge_entropy, pair.now_us);
+
+    try testing.expectEqual(before_received + 1, pair.server.metrics.packets_received);
+    try testing.expect(pair.server.streamTransportEarly(0));
+    try testing.expectEqual(@as(?StreamId, 0), pair.server.acceptStream());
+    var buf: [32]u8 = undefined;
+    const request = try pair.server.readStream(0, &buf);
+    try testing.expectEqualStrings("hello 0-rtt", buf[0..request.len]);
+    try testing.expect(request.fin);
+}
+
+test "driver: 0-RTT packet without an installed read key is dropped, not delivered" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+
+    // Server never received/authorized a zero_rtt read secret — the same
+    // observable state as "not attempted", "rejected by policy", "replay",
+    // or "incompatible": whatever the reason, the TLS layer simply never
+    // installs a usable key, and the QUIC carrier must fail closed on that
+    // alone without needing to know which reason applied.
+    const secret = [_]u8{0x77} ** tls_adapter.traffic_secret_len;
+    var frame_buf: [32]u8 = undefined;
+    const frame_len = try frame.encodeStream(0, 0, "should not land", true, &frame_buf);
+    var wire: [256]u8 = undefined;
+    const datagram = sealTestZeroRttPacket(&TestPair.odcid, &TestPair.client_cid, secret, 0, frame_buf[0..frame_len], &wire);
+
+    const before_received = pair.server.metrics.packets_received;
+    const before_dropped = pair.server.metrics.packets_dropped;
+    try pair.server.ingestOnPath(datagram, TestPair.server_path, TestPair.test_challenge_entropy, pair.now_us);
+
+    try testing.expectEqual(before_received, pair.server.metrics.packets_received);
+    try testing.expectEqual(before_dropped + 1, pair.server.metrics.packets_dropped);
+    try testing.expect(!pair.server.streamTransportEarly(0));
+    try testing.expectEqual(@as(?StreamId, null), pair.server.acceptStream());
+
+    // The ordinary (non-early) handshake is entirely unaffected by the
+    // rejected/unavailable 0-RTT attempt.
+    try pair.pump();
+    try testing.expect(pair.client.isEstablished());
+    try testing.expect(pair.server.isEstablished());
+}
+
+test "driver: tampered 0-RTT packet is dropped and not delivered" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+
+    const secret = [_]u8{0x99} ** tls_adapter.traffic_secret_len;
+    pair.server.adapter.setZeroRttEnabled(true);
+    pair.server.adapter.installSecret(try tls_adapter.Secret.init(.zero_rtt, .read, &secret));
+
+    var frame_buf: [32]u8 = undefined;
+    const frame_len = try frame.encodeStream(0, 0, "tampered", true, &frame_buf);
+    var wire: [256]u8 = undefined;
+    const datagram = sealTestZeroRttPacket(&TestPair.odcid, &TestPair.client_cid, secret, 0, frame_buf[0..frame_len], &wire);
+    // Flip a bit well past the header so header protection removal still
+    // succeeds but AEAD authentication fails.
+    datagram[datagram.len - 1] ^= 0x01;
+
+    const before_received = pair.server.metrics.packets_received;
+    const before_dropped = pair.server.metrics.packets_dropped;
+    try pair.server.ingestOnPath(datagram, TestPair.server_path, TestPair.test_challenge_entropy, pair.now_us);
+
+    try testing.expectEqual(before_received, pair.server.metrics.packets_received);
+    try testing.expectEqual(before_dropped + 1, pair.server.metrics.packets_dropped);
+    try testing.expect(!pair.server.streamTransportEarly(0));
+    try testing.expectEqual(@as(?StreamId, null), pair.server.acceptStream());
+}
+
+test "driver: 0-RTT stream provenance survives reassembly, duplicate delivery, and later 1-RTT bytes" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+
+    const secret = [_]u8{0x5a} ** tls_adapter.traffic_secret_len;
+    pair.server.adapter.setZeroRttEnabled(true);
+    pair.server.adapter.installSecret(try tls_adapter.Secret.init(.zero_rtt, .read, &secret));
+
+    var frame_buf_1: [32]u8 = undefined;
+    const frame_len_1 = try frame.encodeStream(0, 0, "hel", false, &frame_buf_1);
+    var wire_1: [256]u8 = undefined;
+    const datagram_1 = sealTestZeroRttPacket(&TestPair.odcid, &TestPair.client_cid, secret, 0, frame_buf_1[0..frame_len_1], &wire_1);
+
+    var frame_buf_2: [32]u8 = undefined;
+    const frame_len_2 = try frame.encodeStream(0, 3, "lo", false, &frame_buf_2);
+    var wire_2: [256]u8 = undefined;
+    const datagram_2 = sealTestZeroRttPacket(&TestPair.odcid, &TestPair.client_cid, secret, 1, frame_buf_2[0..frame_len_2], &wire_2);
+
+    // Reassembly across two 0-RTT packets.
+    try pair.server.ingestOnPath(datagram_1, TestPair.server_path, TestPair.test_challenge_entropy, pair.now_us);
+    try pair.server.ingestOnPath(datagram_2, TestPair.server_path, TestPair.test_challenge_entropy, pair.now_us);
+    try testing.expect(pair.server.streamTransportEarly(0));
+
+    // Duplicate delivery of an already-processed 0-RTT packet re-authenticates
+    // (packet numbers aren't deduplicated pre-application — the same as any
+    // other space), but must not duplicate the bytes the application
+    // eventually reads: stream-offset dedup (pre-existing, generic to every
+    // level) is what actually suppresses it.
+    try pair.server.ingestOnPath(datagram_1, TestPair.server_path, TestPair.test_challenge_entropy, pair.now_us);
+
+    try testing.expectEqual(@as(?StreamId, 0), pair.server.acceptStream());
+    var buf: [32]u8 = undefined;
+    const early_read = try pair.server.readStream(0, &buf);
+    try testing.expectEqualStrings("hello", buf[0..early_read.len]);
+    try testing.expect(!early_read.fin);
+
+    // Later 1-RTT bytes on the same stream must not retroactively lose the
+    // sticky early marking, and read correctly alongside the early bytes.
+    try pair.server.applyFrame(.application, .{ .stream = .{ .id = 0, .offset = 5, .data = "!", .fin = true } }, TestPair.server_path, pair.now_us);
+    try testing.expect(pair.server.streamTransportEarly(0));
+    const late_read = try pair.server.readStream(0, &buf);
+    try testing.expectEqualStrings("!", buf[0..late_read.len]);
+    try testing.expect(late_read.fin);
+}
+
 test "driver: server NewSessionTicket uses application CRYPTO retransmission and stream traffic continues" {
     const Capture = struct {
         count: usize = 0,
@@ -3471,6 +3718,196 @@ test "#488: resumption_runtime.Runtime drives a genuine resumed QUIC handshake v
     var buf: [16]u8 = undefined;
     const request = try resumed.server.readStream(id, &buf);
     try testing.expectEqualStrings("hello", buf[0..request.len]);
+}
+
+test "#523: real TLS accept decision installs a usable QUIC 0-RTT read key end to end" {
+    const resumption_runtime = tls_core.resumption_runtime;
+    const allocator = testing.allocator;
+
+    var server_entropy = tls_core.production_crypto.OsEntropy{};
+    var server_provider = tls_core.production_crypto.Provider.init(server_entropy.entropy());
+    var server_runtime = try resumption_runtime.Runtime.init(
+        allocator,
+        .{ .mode = .stateful },
+        .{ .ctx = undefined, .nowUnixMsFn = struct {
+            fn now(_: *anyopaque) i64 {
+                return 1000;
+            }
+        }.now },
+        server_provider.cryptoProvider(),
+    );
+    defer server_runtime.deinit();
+
+    var client_entropy = tls_core.production_crypto.OsEntropy{};
+    var client_provider = tls_core.production_crypto.Provider.init(client_entropy.entropy());
+    var client_runtime = try resumption_runtime.Runtime.init(
+        allocator,
+        .{ .mode = .stateful },
+        .{ .ctx = undefined, .nowUnixMsFn = struct {
+            fn now(_: *anyopaque) i64 {
+                return 2000;
+            }
+        }.now },
+        client_provider.cryptoProvider(),
+    );
+    defer client_runtime.deinit();
+
+    // Phase 1: an ordinary full handshake, then an early-data-capable ticket
+    // (#523: `max_early_data_size` set) issued through the #488 two-phase API
+    // and captured into the client's own runtime — same shape as the #488
+    // test above, plus early-data capability on the ticket.
+    const CaptureImpl = struct {
+        runtime: *resumption_runtime.Runtime,
+        stored: tls_core.session_cache.StoreResult = undefined,
+        retained: tls_core.session.ClientTicketState = .{},
+
+        fn now(_: *anyopaque) i64 {
+            return 1000;
+        }
+        fn onTicket(ctx: *anyopaque, ticket: *const tls_core.session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            ticket.cloneInto(testing.allocator, &self.retained) catch unreachable;
+            self.stored = self.runtime.storeClientTicket(ticket);
+        }
+    };
+    var capture = CaptureImpl{ .runtime = &client_runtime };
+    defer capture.retained.deinit();
+    const resume_policy: tls_core.tls13_backend.Tls13Backend.ResumeCompatibilityPolicy = .{
+        .transport = .ignore,
+        .application = .ignore,
+    };
+    var pair = try TestPair.initWithTicketConsumerAndResumePolicy(allocator, tls_core.session.Limits.default, .{
+        .ctx = &capture,
+        .nowUnixMsFn = CaptureImpl.now,
+        .onTicketFn = CaptureImpl.onTicket,
+    }, resume_policy);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    var prepared = try pair.server.prepareNewSessionTicket(allocator, .{
+        .ticket_lifetime = 3600,
+        .ticket_age_add = 500,
+        .ticket_nonce = "\x01",
+        .issued_at_unix_ms = 1000,
+        .max_early_data_size = 4096,
+    }, tls_core.session.Limits.default);
+    defer prepared.deinit();
+    var scratch: [256]u8 = undefined;
+    var identity = try server_runtime.createIdentity(&prepared.state, 1000, &scratch);
+    try testing.expect(identity == .stateful);
+    try pair.server.emitPreparedNewSessionTicket(&prepared, identity.slice(), tls_core.session.Limits.default);
+    try pair.pump();
+    try testing.expectEqual(tls_core.session_cache.StoreResult.stored, capture.stored);
+
+    // Phase 2: a fresh QUIC connection pair, resuming with the client
+    // actually attempting 0-RTT and the server actually configured to accept
+    // it — the full #523 composition (`setClientEarlyDataIntent`,
+    // `setServerEarlyDataPolicy`, an allow replay gate, `zero_rtt_enabled` on
+    // both `Connection.init` configs) that `http3_runtime.zig` wires for
+    // production.
+    const candidate: tls_core.session.CandidateContext = .{
+        .cipher_suite = capture.retained.common.cipher_suite,
+        .server_name = if (capture.retained.common.server_name) |*s| s.slice() else null,
+        .application_protocol = if (capture.retained.common.application_protocol) |*a| a.slice() else null,
+        .auth_binding = capture.retained.common.auth_binding,
+        .transport_compat = null,
+        .application_compat = null,
+    };
+    var lookup = client_runtime.lookupClientOffers(candidate);
+    defer lookup.deinit();
+    try testing.expect(lookup == .hit);
+
+    const resumed = try allocator.create(TestPair);
+    defer allocator.destroy(resumed);
+    resumed.* = .{
+        .client_backend = tls_backend_mod.Tls13Backend.initClient(
+            .{ .hello_random = [_]u8{0xe1} ** 32, .key_share_seed = [_]u8{0x41} ** 32 },
+            .{ .pinned_certificate = tls_backend_mod.testdata.certificate_der },
+        ),
+        .server_backend = tls_backend_mod.Tls13Backend.initServer(
+            .{ .hello_random = [_]u8{0xe2} ** 32, .key_share_seed = [_]u8{0x42} ** 32 },
+            try tls_backend_mod.Identity.initPkcs8(
+                tls_backend_mod.testdata.certificate_der,
+                tls_backend_mod.testdata.private_key_pkcs8_der,
+            ),
+        ),
+    };
+    var clock_dummy: u8 = 0;
+    const ClientClock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 2000;
+        }
+    };
+    try resumed.client_backend.engine.setClientPskOfferLease(&lookup.hit, &clock_dummy, ClientClock.now);
+    try resumed.client_backend.setResumeCompatibilityPolicy(resume_policy);
+    try resumed.client_backend.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 4096 });
+    try resumed.server_backend.setServerPskResolver(server_runtime.serverResolver().?);
+    try resumed.server_backend.setResumeCompatibilityPolicy(resume_policy);
+
+    // Always-allow replay gate: proves the #368 seam is what the QUIC/H3
+    // composition installs, not a QUIC-local replay mechanism.
+    const AlwaysAllow = struct {
+        fn decide(_: *anyopaque, _: tls_backend_mod.EarlyDataReplayCandidate) tls_backend_mod.EarlyDataReplayDecision {
+            return .allow;
+        }
+    };
+    var replay_ctx: u8 = 0;
+    try resumed.server_backend.setEarlyDataReplayGate(.{ .ctx = &replay_ctx, .decideFn = AlwaysAllow.decide });
+    try resumed.server_backend.setServerEarlyDataPolicy(.{ .enabled = true });
+
+    resumed.client = try Connection.init(allocator, .{
+        .role = .client,
+        .config = .{ .zero_rtt_enabled = true },
+        .local_cid = &TestPair.client_cid,
+        .original_dcid = &TestPair.odcid,
+        .peer_cid = &TestPair.odcid,
+        .tls = resumed.client_backend.backend(),
+        .now_us = resumed.now_us,
+        .initial_path = TestPair.client_path,
+    });
+    defer resumed.client.deinit();
+    resumed.server = try Connection.init(allocator, .{
+        .role = .server,
+        .config = .{ .zero_rtt_enabled = true },
+        .local_cid = &TestPair.odcid,
+        .original_dcid = &TestPair.odcid,
+        .peer_cid = &TestPair.client_cid,
+        .tls = resumed.server_backend.backend(),
+        .now_us = resumed.now_us,
+        .initial_path = TestPair.server_path,
+    });
+    defer resumed.server.deinit();
+
+    try resumed.pump();
+
+    try testing.expect(resumed.client.isEstablished());
+    try testing.expect(resumed.server.isEstablished());
+    try testing.expect(resumed.client_backend.engine.core.psk_authenticated);
+    try testing.expect(resumed.server_backend.engine.core.psk_authenticated);
+
+    // The real TLS decision actually accepted 0-RTT (not just "resumed")...
+    try testing.expect(resumed.server_backend.engine.earlyDataAccepted());
+    // ...and that acceptance actually installed a usable QUIC 0-RTT read key
+    // through the ordinary secret-event pipeline (#523 requirement 1) — with
+    // `zero_rtt_enabled` honored via `Connection.init`'s `setZeroRttEnabled`.
+    try testing.expect(resumed.server.adapter.protectionKeys(.zero_rtt, .read) != null);
+
+    // That real, TLS-derived key genuinely decrypts a 0-RTT wire packet
+    // through the ordinary driver path, with correct early-data provenance —
+    // proving the pipeline end to end, not just its two halves in isolation.
+    const real_secret = resumed.server.adapter.secret(.zero_rtt, .read).?.slice()[0..tls_adapter.traffic_secret_len].*;
+    var frame_buf: [32]u8 = undefined;
+    const frame_len = try frame.encodeStream(4, 0, "real early data", true, &frame_buf);
+    var wire: [256]u8 = undefined;
+    const datagram = sealTestZeroRttPacket(&TestPair.odcid, &TestPair.client_cid, real_secret, 0, frame_buf[0..frame_len], &wire);
+    try resumed.server.ingestOnPath(datagram, TestPair.server_path, TestPair.test_challenge_entropy, resumed.now_us);
+
+    try testing.expect(resumed.server.streamTransportEarly(4));
+    try testing.expectEqual(@as(?StreamId, 4), resumed.server.acceptStream());
+    var buf: [32]u8 = undefined;
+    const request = try resumed.server.readStream(4, &buf);
+    try testing.expectEqualStrings("real early data", buf[0..request.len]);
+    try testing.expect(request.fin);
 }
 
 test "driver: maximum NewSessionTicket survives real loss reordering PTO and ACK cleanup" {

--- a/src/quic/recovery.zig
+++ b/src/quic/recovery.zig
@@ -422,8 +422,12 @@ pub const RecoveryController = struct {
     /// Whether `packet_number` has already been authenticated in `space` —
     /// query *before* `onPacketReceived` records it. An authenticated
     /// duplicate (distinct from an undecryptable one, which never reaches
-    /// this point) must still count for ACK/path bookkeeping but must never
-    /// have its frame effects re-applied.
+    /// this point) must be inert: the driver (`connection.zig`) uses this to
+    /// skip re-applying its frame effects, refreshing the idle timer, and
+    /// crediting path/anti-amplification state for it — a duplicate proves
+    /// nothing new about the peer or the path. Its packet number is already
+    /// recorded from the prior `onPacketReceived` call that first saw it, so
+    /// it's already covered by the next ACK regardless.
     pub fn wasReceived(self: *const RecoveryController, space: PacketNumberSpace, packet_number: u64) bool {
         return self.ack_ranges[spaceIndex(space)].contains(packet_number);
     }

--- a/src/quic/recovery.zig
+++ b/src/quic/recovery.zig
@@ -419,6 +419,15 @@ pub const RecoveryController = struct {
         self.events.emit(.{ .kind = .ack_range_inserted, .space = space, .packet_number = packet_number });
     }
 
+    /// Whether `packet_number` has already been authenticated in `space` —
+    /// query *before* `onPacketReceived` records it. An authenticated
+    /// duplicate (distinct from an undecryptable one, which never reaches
+    /// this point) must still count for ACK/path bookkeeping but must never
+    /// have its frame effects re-applied.
+    pub fn wasReceived(self: *const RecoveryController, space: PacketNumberSpace, packet_number: u64) bool {
+        return self.ack_ranges[spaceIndex(space)].contains(packet_number);
+    }
+
     pub fn ackFrameForSpace(self: *const RecoveryController, space: PacketNumberSpace, ack_delay_us: u64) ?AckFrameModel {
         return self.ack_ranges[spaceIndex(space)].toAckFrame(ack_delay_us);
     }

--- a/src/quic/stream.zig
+++ b/src/quic/stream.zig
@@ -556,6 +556,25 @@ pub const StreamManager = struct {
         if (limit > stream.max_send_data) stream.max_send_data = limit;
     }
 
+    /// Swap in the peer's authenticated transport parameters once the
+    /// handshake completes, for a manager that was brought up early (before
+    /// authentication) to admit 0-RTT stream data. Only ever raises existing
+    /// send-side limits, mirroring `applyMaxData`/`applyMaxStreamData` — the
+    /// placeholder parameters used during 0-RTT are never more permissive
+    /// than what the real peer eventually grants, since nothing may be sent
+    /// through this manager until this call has already happened.
+    pub fn refreshPeerParams(self: *StreamManager, peer_params: config.TransportParameters) void {
+        self.peer = peer_params;
+        self.applyMaxData(peer_params.initial_max_data);
+        var it = self.streams.iterator();
+        while (it.next()) |entry| {
+            const id = entry.key_ptr.*;
+            const stream = entry.value_ptr.*;
+            const limit = streamDataLimit(peer_params, peerRole(self.role), id);
+            if (limit > stream.max_send_data) stream.max_send_data = limit;
+        }
+    }
+
     pub fn applyMaxStreams(self: *StreamManager, typ: StreamType, limit: u64) void {
         switch (typ) {
             .bidi => self.peer.initial_max_streams_bidi = @max(self.peer.initial_max_streams_bidi, limit),

--- a/src/quic/stream.zig
+++ b/src/quic/stream.zig
@@ -564,7 +564,17 @@ pub const StreamManager = struct {
     /// than what the real peer eventually grants, since nothing may be sent
     /// through this manager until this call has already happened.
     pub fn refreshPeerParams(self: *StreamManager, peer_params: config.TransportParameters) void {
+        // MAX_STREAMS received during 0-RTT (`applyMaxStreams`, monotonic)
+        // already raised `self.peer.initial_max_streams_{bidi,uni}` above
+        // whatever the placeholder started at — preserve that credit rather
+        // than overwriting it with the peer's un-raised initial value below.
+        const max_bidi = @max(self.peer.initial_max_streams_bidi, peer_params.initial_max_streams_bidi);
+        const max_uni = @max(self.peer.initial_max_streams_uni, peer_params.initial_max_streams_uni);
+
         self.peer = peer_params;
+        self.peer.initial_max_streams_bidi = max_bidi;
+        self.peer.initial_max_streams_uni = max_uni;
+
         self.applyMaxData(peer_params.initial_max_data);
         var it = self.streams.iterator();
         while (it.next()) |entry| {
@@ -752,6 +762,29 @@ test "local stream limits produce blocked accounting" {
     try std.testing.expectEqual(@as(StreamId, 0), try manager.openLocal(.bidi));
     try std.testing.expectError(error.StreamLimitExceeded, manager.openLocal(.bidi));
     try std.testing.expectEqual(@as(u64, 1), manager.metrics.streams_blocked_events);
+}
+
+test "refreshPeerParams (#523) preserves MAX_STREAMS credit granted during 0-RTT instead of rolling it back" {
+    var manager = StreamManager.init(std.testing.allocator, .server, testParams(), testParams());
+    defer manager.deinit();
+
+    // Simulate an accepted 0-RTT MAX_STREAMS frame raising bidi credit well
+    // above `testParams()`'s initial value (2).
+    manager.applyMaxStreams(.bidi, 500);
+    try std.testing.expectEqual(@as(u64, 500), manager.peer.initial_max_streams_bidi);
+
+    // The handshake completes; the authenticated peer parameters only ever
+    // granted `testParams()`'s smaller initial value. Refreshing must not
+    // roll the already-raised credit back down to it.
+    manager.refreshPeerParams(testParams());
+    try std.testing.expectEqual(@as(u64, 500), manager.peer.initial_max_streams_bidi);
+
+    // And that credit is genuinely usable: opening more local bidi streams
+    // than `testParams()`'s own limit (2) would ever allow succeeds.
+    var opened: usize = 0;
+    while (opened < 5) : (opened += 1) {
+        _ = try manager.openLocal(.bidi);
+    }
 }
 
 test "send path enforces stream and connection flow control" {

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -34,6 +34,8 @@ pub const EarlyDataCompatibilityGate = shared.EarlyDataCompatibilityGate;
 pub const EarlyDataReplayCandidate = shared.EarlyDataReplayCandidate;
 pub const EarlyDataReplayDecision = shared.EarlyDataReplayDecision;
 pub const EarlyDataReplayGate = shared.EarlyDataReplayGate;
+pub const ServerEarlyDataPolicy = shared.ServerEarlyDataPolicy;
+pub const ClientEarlyDataIntent = shared.ClientEarlyDataIntent;
 
 const ext_quic_transport_parameters: u16 = @intFromEnum(tls_core.algorithms.ExtensionType.quic_transport_parameters);
 const tp_max_idle_timeout: u64 = 0x01;
@@ -406,6 +408,21 @@ pub const Tls13Backend = struct {
     /// fall back to worker-local replay bookkeeping.
     pub fn setEarlyDataReplayGate(self: *Tls13Backend, gate: EarlyDataReplayGate) HandshakeError!void {
         self.engine.setEarlyDataReplayGate(gate) catch |err| return mapError(err);
+    }
+
+    /// #523: forwarding seam only — the accept/reject decision (PSK identity,
+    /// replay, compatibility, age skew) stays entirely in the shared engine.
+    /// Must be called before the handshake starts, matching every other
+    /// early-data setter here.
+    pub fn setServerEarlyDataPolicy(self: *Tls13Backend, policy: ServerEarlyDataPolicy) HandshakeError!void {
+        self.engine.setServerEarlyDataPolicy(policy) catch |err| return mapError(err);
+    }
+
+    /// #523: forwarding seam only — offer/binder selection and the resulting
+    /// early-traffic-secret export stay entirely in the shared engine. Must
+    /// be called before the handshake starts.
+    pub fn setClientEarlyDataIntent(self: *Tls13Backend, intent: ClientEarlyDataIntent) HandshakeError!void {
+        self.engine.setClientEarlyDataIntent(intent) catch |err| return mapError(err);
     }
 
     pub fn setResumptionDecisionObserver(self: *Tls13Backend, observer: shared.Tls13Backend.ResumptionDecisionObserver) HandshakeError!void {

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -291,12 +291,18 @@ pub const Tls13Backend = struct {
             .prepareNewSessionTicketFn = prepareNewSessionTicket,
             .emitPreparedNewSessionTicketFn = emitPreparedNewSessionTicket,
             .earlyDataAcceptedFn = earlyDataAcceptedVtable,
+            .earlyDataDecisionFn = earlyDataDecisionVtable,
         };
     }
 
     fn earlyDataAcceptedVtable(ptr: *anyopaque) bool {
         const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
         return self.engine.earlyDataAccepted();
+    }
+
+    fn earlyDataDecisionVtable(ptr: *anyopaque) shared.EarlyDataDecision {
+        const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
+        return self.engine.earlyDataDecision();
     }
 
     fn earlyDataAttempted(ptr: *anyopaque) bool {

--- a/src/quic/tls_handshake.zig
+++ b/src/quic/tls_handshake.zig
@@ -105,6 +105,13 @@ pub const TlsBackend = struct {
         limits: tls_core.session.Limits,
     ) HandshakeError!void = null,
     earlyDataAcceptedFn: ?*const fn (ptr: *anyopaque) bool = null,
+    /// #523: the authoritative TLS-layer 0-RTT decision (not just the
+    /// accepted/not-accepted bool above) — surfaces *why* early data was
+    /// rejected (policy disabled, ticket not capable, replay, transport/
+    /// application incompatibility, ...), available as soon as the server
+    /// has processed the ClientHello, independent of whether any `.zero_rtt`
+    /// packet ever actually arrives on the wire.
+    earlyDataDecisionFn: ?*const fn (ptr: *anyopaque) tls_core.tls13_backend.EarlyDataDecision = null,
 
     fn start(self: TlsBackend, role: Role, params: config.TransportParameters, sink: *EventSink) HandshakeError!void {
         return self.transport.start(role, params, sink);
@@ -175,6 +182,11 @@ pub const TlsBackend = struct {
 
     pub fn earlyDataAccepted(self: TlsBackend) bool {
         const cb = self.earlyDataAcceptedFn orelse return false;
+        return cb(self.transport.ptr);
+    }
+
+    pub fn earlyDataDecision(self: TlsBackend) tls_core.tls13_backend.EarlyDataDecision {
+        const cb = self.earlyDataDecisionFn orelse return .not_attempted;
         return cb(self.transport.ptr);
     }
 


### PR DESCRIPTION
## Summary

Implements the missing native QUIC/H3 0-RTT carrier: the QUIC connection driver previously dropped every `.zero_rtt` packet unconditionally (`src/quic/connection.zig`'s `ingestPacket`), and `http3_runtime.zig` logged "0-RTT is not supported" whenever `enable_0rtt` was set. Most of the surrounding TLS-side machinery (PSK/resumption decision, replay gate, H3 SETTINGS compatibility, ticket issuance) already existed from #366/#367/#368/#488/#513 — this closes the QUIC-carrier gap beneath it, reusing that machinery rather than reimplementing any of it.

- **`src/quic/connection.zig`**
  - `ingestPacket`: map `.zero_rtt` through the same decrypt / packet-number-space / recovery / ACK path as every other level, gated entirely on `adapter.protectionKeys(.zero_rtt, .read)` — which already refuses to hand back keys for an unauthorized/disabled 0-RTT attempt, so "no keys installed" naturally becomes the fail-closed drop case with no new decision logic.
  - `applyFrame`: relax the STREAM-frame level check to accept `.zero_rtt`, and mark accepted 0-RTT streams via the existing (previously unused) `markStreamZeroRtt` provenance seam.
  - `Connection.init`: wire `adapter.setZeroRttEnabled(cfg.zero_rtt_enabled)` — the adapter's own gate existed but nothing ever called it.
  - **`ensureEarlyStreamManager`** (the non-obvious part): the stream/flow-control layer was only ever created once the *full* handshake completed and peer transport parameters were authenticated — strictly after 0-RTT data arrives, which would have closed the connection on the first accepted 0-RTT STREAM frame (`stream before handshake`). Brings the stream layer up early on the first authenticated 0-RTT packet, using local transport parameters (receive-side admission depends only on those, confirmed via `stream.zig`) and a zero-send-credit placeholder for the peer side, since nothing can be sent before the handshake completes anyway. `afterHandshakeProgress` now refreshes (`StreamManager.refreshPeerParams`, monotonic raise-only, mirroring `applyMaxData`/`applyMaxStreamData`) rather than reinitializing — reinitializing would silently discard any stream state buffered from accepted 0-RTT packets.
- **`src/quic/tls_backend.zig`**: forward `setServerEarlyDataPolicy` and `setClientEarlyDataIntent` to the shared TLS engine — both existed on the shared engine but had no QUIC-profile forwarding seam.
- **`src/http/http3_runtime.zig`**: `enable_0rtt` now composes with `resumption_runtime` and `early_data_replay_gate` (`zeroRttCarrierEnabled`) so the carrier only activates with complete dependencies present — never silently from the boolean alone. `accept()` installs the server early-data policy, mirroring `native_tls_connection.zig`'s identical gate for native TCP.

## Test plan
- [x] `zig build test` — full suite (2775 tests) passes.
- [x] `zig fmt --check` on all touched files.
- [x] New deterministic driver-level tests in `connection.zig`: accepted 0-RTT packet decrypts/delivers with correct packet-number-space bookkeeping; packet dropped fail-closed when no read key is installed (covers not-attempted/rejected/replay/incompatible, which are observably identical at this layer); tampered 0-RTT packet dropped, not delivered; stream provenance survives reassembly across two 0-RTT packets, duplicate packet delivery, and later 1-RTT bytes on the same stream (sticky).
- [x] New end-to-end test extending the existing `#488` two-phase resumption pattern: drives a *real* TLS accept decision (real ticket, real PSK resumption, real `ServerEarlyDataPolicy`/replay gate) and proves it installs a genuinely usable QUIC 0-RTT read key, which then decrypts and delivers a real 0-RTT wire packet through the ordinary driver path.
- [x] New `http3_runtime.zig` composition tests: `enable_0rtt=false` stays disabled; `enable_0rtt=true` with incomplete dependencies fails closed; `enable_0rtt=true` with complete dependencies enables the carrier end-to-end into `quic_config.zero_rtt_enabled`.

Closes #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)