### PR TITLE
tls: add native H1 early-data interop coverage

### DIFF
--- a/src/edge_config.zig
+++ b/src/edge_config.zig
@@ -2897,10 +2897,6 @@ fn validateApplianceTlsProfile(cfg: *const EdgeConfig) !void {
         logConfigDiagnostic("config validation failed: the appliance TLS profile does not support TARDIGRADE_TLS_DYNAMIC_RELOAD_INTERVAL_MS (no filesystem credential watcher)", .{});
         return error.UnsupportedApplianceConfiguration;
     }
-    if (cfg.tls_native_ticket_keys_path.len != 0) {
-        logConfigDiagnostic("config validation failed: the appliance TLS profile does not support TARDIGRADE_TLS_NATIVE_TICKET_KEYS_PATH (filesystem-backed ticket-key reload)", .{});
-        return error.UnsupportedApplianceConfiguration;
-    }
     if (cfg.proxy_protocol_mode != .off) {
         logConfigDiagnostic("config validation failed: the appliance TLS profile does not support TARDIGRADE_PROXY_PROTOCOL; the native TLS path closes every connection before the handshake when a PROXY preface is expected", .{});
         return error.UnsupportedApplianceConfiguration;
@@ -4156,11 +4152,6 @@ test "appliance profile rejects PROXY protocol, credential watching, and OCSP au
     {
         var cfg = base;
         cfg.proxy_protocol_mode = .v1;
-        try std.testing.expectError(error.UnsupportedApplianceConfiguration, validateApplianceTlsProfile(&cfg));
-    }
-    {
-        var cfg = base;
-        cfg.tls_native_ticket_keys_path = "ticket-keys.json";
         try std.testing.expectError(error.UnsupportedApplianceConfiguration, validateApplianceTlsProfile(&cfg));
     }
     {

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -1596,11 +1596,13 @@ fn nativeTcpServerEarlyDataPolicy(
     return if (gate != null) .{ .enabled = true } else .{};
 }
 
+const native_persistent_ticket_max: usize = 16 * 1024;
+
 fn nativeResumptionSessionLimits(cfg: *const edge_config.EdgeConfig) tls_core.session.Limits {
     var limits = tls_core.session.Limits.default;
     if (cfg.tls_native_ticket_keys_path.len > 0) {
-        limits.max_ticket_len = tls_core.session.absolute_ticket_wire_max;
-        limits.max_serialized_len = tls_core.session.hard_max_serialized_len;
+        limits.max_ticket_len = native_persistent_ticket_max;
+        limits.max_serialized_len = native_persistent_ticket_max - tls_core.ticket_protection.envelope_overhead;
     }
     return limits;
 }
@@ -4102,6 +4104,49 @@ test "#510 process-local composition enables native TCP server early-data policy
 
     try std.testing.expect(native.backend.server_early_data_policy.enabled);
     try std.testing.expectEqual(composition.early_data_replay_gate.?.ctx, native.backend.early_data_replay_gate.ctx);
+}
+
+test "#518 persistent native resumption uses bounded stateless ticket limits" {
+    var cfg: edge_config.EdgeConfig = undefined;
+    cfg.tls_native_ticket_keys_path = "";
+    var limits = nativeResumptionSessionLimits(&cfg);
+    try std.testing.expectEqual(tls_core.session.Limits.default.max_ticket_len, limits.max_ticket_len);
+    try std.testing.expectEqual(tls_core.session.Limits.default.max_serialized_len, limits.max_serialized_len);
+
+    cfg.tls_native_ticket_keys_path = "ticket-keys.json";
+    limits = nativeResumptionSessionLimits(&cfg);
+    try std.testing.expectEqual(@as(usize, native_persistent_ticket_max), limits.max_ticket_len);
+    try std.testing.expectEqual(@as(usize, native_persistent_ticket_max - tls_core.ticket_protection.envelope_overhead), limits.max_serialized_len);
+    try std.testing.expect(limits.max_ticket_len < tls_core.session.absolute_ticket_wire_max);
+    try std.testing.expect(limits.max_serialized_len < tls_core.session.hard_max_serialized_len);
+
+    const max_transport = tls_core.session.Limits.default.max_transport_compat_len;
+    const max_application = tls_core.session.Limits.default.max_application_compat_len;
+    const transport_compat = [_]u8{0xa5} ** max_transport;
+    const application_compat = [_]u8{0x5a} ** max_application;
+    var common: tls_core.session.ResumableSessionCommon = .{};
+    defer common.deinit();
+    try common.init(std.testing.allocator, limits, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = &([_]u8{0x42} ** 32),
+        .server_name = "tardigrade.test",
+        .application_protocol = "http/1.1",
+        .auth_binding = tls_core.session.AuthBinding.fromLeafCertificateDer("native-h1-fixture-leaf"),
+        .issued_at_unix_ms = 2_000,
+        .lifetime_seconds = 24 * 60 * 60,
+        .early_data = .{ .early_data_capable = 16 * 1024 },
+        .transport_compat = .{ .format_id = 1, .format_version = 1, .bytes = &transport_compat },
+        .application_compat = .{ .format_id = 2, .format_version = 1, .bytes = &application_compat },
+        .early_data_transport_compat = .{ .format_id = 3, .format_version = 1, .bytes = &transport_compat },
+        .early_data_application_compat = .{ .format_id = 4, .format_version = 1, .bytes = &application_compat },
+    });
+
+    var state: tls_core.session.ServerRecoverableState = .{};
+    defer state.deinit();
+    state.init(&common, 0x01020304);
+    const encoded_len = try tls_core.session.serverEncodedLenWithLimits(&state, limits);
+    try std.testing.expect(encoded_len <= limits.max_serialized_len);
+    try std.testing.expect(encoded_len + tls_core.ticket_protection.envelope_overhead <= limits.max_ticket_len);
 }
 
 test "return_response method enforcement — non-GET/HEAD rejected on static returns" {

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -271,6 +271,7 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
                 .mode = edge_config.nativeResumptionMode(cfg),
                 .ticket_lifetime_seconds = cfg.tls_native_resumption_ticket_lifetime_seconds,
                 .usage = edge_config.nativeResumptionTicketUsage(cfg),
+                .session_limits = nativeResumptionSessionLimits(cfg),
                 .stateless_ticket_key_source = if (cfg.tls_native_ticket_keys_path.len > 0) .persistent else .ephemeral,
             },
             .{ .ctx = undefined, .nowUnixMsFn = systemNowUnixMs },
@@ -1593,6 +1594,15 @@ fn nativeTcpServerEarlyDataPolicy(
     gate: ?tls_core.tls13_backend.EarlyDataReplayGate,
 ) tls_core.tls13_backend.ServerEarlyDataPolicy {
     return if (gate != null) .{ .enabled = true } else .{};
+}
+
+fn nativeResumptionSessionLimits(cfg: *const edge_config.EdgeConfig) tls_core.session.Limits {
+    var limits = tls_core.session.Limits.default;
+    if (cfg.tls_native_ticket_keys_path.len > 0) {
+        limits.max_ticket_len = tls_core.session.absolute_ticket_wire_max;
+        limits.max_serialized_len = tls_core.session.hard_max_serialized_len;
+    }
+    return limits;
 }
 
 fn reapActiveConnections(

--- a/src/http/native_tls_connection.zig
+++ b/src/http/native_tls_connection.zig
@@ -193,6 +193,7 @@ pub const NativeTlsConnection = struct {
     entropy_source: production_crypto.OsEntropy = .{},
     crypto_provider_state: production_crypto.Provider = undefined,
     resumption_runtime: ?*tls.resumption_runtime.Runtime = null,
+    server_early_data_policy: tls_backend.ServerEarlyDataPolicy = .{},
     /// Set exactly once this connection has attempted post-handshake ticket
     /// issuance (successfully or not) — issuance is best-effort and must
     /// never be retried on the same connection (#488).
@@ -266,6 +267,7 @@ pub const NativeTlsConnection = struct {
             .record = record,
             .policy = policy,
             .resumption_runtime = options.resumption_runtime,
+            .server_early_data_policy = if (options.early_data_replay_gate != null and options.resumption_runtime != null) options.server_early_data_policy else .{},
         };
         self.crypto_provider_state = production_crypto.Provider.init(self.entropy_source.entropy());
         record.* = try encrypted_stream.PureZigRecordStream.initWithCarrierBackendAndLimits(
@@ -376,7 +378,7 @@ pub const NativeTlsConnection = struct {
             .ticket_age_add = ticket_age_add,
             .ticket_nonce = &ticket_nonce,
             .issued_at_unix_ms = now_unix_ms,
-            .max_early_data_size = if (self.backend.server_early_data_policy.enabled) self.backend.server_early_data_policy.max_early_data_size else null,
+            .max_early_data_size = if (self.server_early_data_policy.enabled) self.server_early_data_policy.max_early_data_size else null,
         }, limits);
         defer prepared.deinit();
 

--- a/tests/bounded_process.zig
+++ b/tests/bounded_process.zig
@@ -193,7 +193,11 @@ pub fn run(allocator: std.mem.Allocator, options: Options) std.mem.Allocator.Err
     }
 
     multi_reader.checkAnyError() catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
+        error.OutOfMemory => {
+            reapProcessGroup(&child, pgid);
+            reaped = true;
+            return error.OutOfMemory;
+        },
         else => return killedResult(
             allocator,
             &child,
@@ -373,6 +377,8 @@ fn killedResult(
 fn reapProcessGroup(child: *std.process.Child, pgid: std.posix.pid_t) void {
     terminateProcessGroup(pgid);
     child.kill(compat.io());
+    terminateProcessGroup(pgid);
+    waitForProcessGroupGone(pgid);
 }
 
 fn terminateProcessGroup(pid: std.posix.pid_t) void {
@@ -381,6 +387,22 @@ fn terminateProcessGroup(pid: std.posix.pid_t) void {
         error.PermissionDenied => {},
         else => {},
     };
+}
+
+fn waitForProcessGroupGone(pgid: std.posix.pid_t) void {
+    for (0..20) |_| {
+        if (!processGroupExists(pgid)) return;
+        compat.sleepNs(50 * std.time.ns_per_ms);
+    }
+}
+
+fn processGroupExists(pgid: std.posix.pid_t) bool {
+    std.posix.kill(-pgid, @enumFromInt(0)) catch |err| switch (err) {
+        error.ProcessNotFound => return false,
+        error.PermissionDenied => return true,
+        else => return true,
+    };
+    return true;
 }
 
 fn failureFromBuffered(

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -2700,9 +2700,11 @@ test "interop.openssl.h1.early.accepted" {
     try assertContains(first.stdout, "New, TLSv1.3");
     try assertContains(first.stdout, "HTTP/1.1 200 OK");
 
-    const fingerprint = try opensslSessionFileMaterialSample(allocator, sess_path);
-    var fingerprint_hex: [64]u8 = undefined;
-    const fingerprint_hex_slice = std.fmt.bufPrint(&fingerprint_hex, "{x}", .{fingerprint}) catch unreachable;
+    const resumption_psk_hex = try opensslSessionResumptionPskHex(allocator, sess_path);
+    defer allocator.free(resumption_psk_hex);
+    const resumption_psk_hex_lower = try allocator.dupe(u8, resumption_psk_hex);
+    defer allocator.free(resumption_psk_hex_lower);
+    _ = std.ascii.lowerString(resumption_psk_hex_lower, resumption_psk_hex_lower);
     try upstream.resetCapture();
 
     var early = try runOpenssl(allocator, &.{
@@ -2725,7 +2727,8 @@ test "interop.openssl.h1.early.accepted" {
 
     const log = try compat.cwd().readFileAlloc(allocator, tardigrade.log_path, 4 * 1024 * 1024);
     defer allocator.free(log);
-    try std.testing.expect(!containsSubstring(log, fingerprint_hex_slice));
+    try std.testing.expect(!containsSubstring(log, resumption_psk_hex));
+    try std.testing.expect(!containsSubstring(log, resumption_psk_hex_lower));
 }
 
 test "interop.openssl.h1.early.unsafe_425" {
@@ -3353,13 +3356,23 @@ fn opensslSessionTicketFingerprint(allocator: std.mem.Allocator, path: []const u
     return fingerprint;
 }
 
-fn opensslSessionFileMaterialSample(allocator: std.mem.Allocator, path: []const u8) ![32]u8 {
-    const raw = try decodeOpensslSessionFile(allocator, path);
-    defer allocator.free(raw);
-    if (raw.len < 32) return error.SessionFileTooShortToSample;
-    var sample: [32]u8 = undefined;
-    @memcpy(&sample, raw[raw.len - 32 ..]);
-    return sample;
+fn opensslSessionResumptionPskHex(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    var result = try runOpenssl(allocator, &.{
+        "sess_id", "-in", path, "-text", "-noout",
+    }, null, 10_000);
+    defer result.deinit(allocator);
+    try std.testing.expectEqual(std.meta.Tag(bounded_process.Outcome).normal_exit, std.meta.activeTag(result.outcome));
+
+    const marker = "Resumption PSK:";
+    const marker_start = std.mem.indexOf(u8, result.stdout, marker) orelse return error.ResumptionPskNotFound;
+    const value_start = marker_start + marker.len;
+    const line_end = std.mem.indexOfScalarPos(u8, result.stdout, value_start, '\n') orelse result.stdout.len;
+    const raw = std.mem.trim(u8, result.stdout[value_start..line_end], " \t\r");
+    if (raw.len < 32 or raw.len % 2 != 0) return error.ResumptionPskMalformed;
+    for (raw) |c| {
+        if (!std.ascii.isHex(c)) return error.ResumptionPskMalformed;
+    }
+    return allocator.dupe(u8, raw);
 }
 
 fn persistentTicketKeySnapshotPath(allocator: std.mem.Allocator, port: u16, tag: []const u8) ![]u8 {
@@ -3373,7 +3386,7 @@ fn writePersistentTicketKeySnapshot(allocator: std.mem.Allocator, path: []const 
     const snapshot = try std.fmt.allocPrint(
         allocator,
         "{{\"version\":1,\"generation\":1,\"keys\":[{{\"id\":\"000102030405060708090a0b0c0d0e0f\",\"aead\":\"aes_128_gcm\",\"key\":\"101112131415161718191a1b1c1d1e1f\",\"not_before_unix_ms\":{d},\"encrypt_until_unix_ms\":{d},\"decrypt_until_unix_ms\":{d},\"nonce_lease\":{{\"prefix\":\"51800000\",\"start\":0,\"end_exclusive\":4096}}}}]}}",
-        .{ now - 60_000, now + 60 * 60 * 1000, now + 2 * 60 * 60 * 1000 },
+        .{ now - 60_000, now + 25 * 60 * 60 * 1000, now + 26 * 60 * 60 * 1000 },
     );
     defer {
         std.crypto.secureZero(u8, snapshot);
@@ -3806,6 +3819,7 @@ test "restart.persistent.early_startup_quarantine" {
         allocator: std.mem.Allocator,
         runtime: *tls_core.resumption_runtime.Runtime,
         retained: tls_core.session.ClientTicketState = .{},
+        count: usize = 0,
 
         fn now(_: *anyopaque) i64 {
             return 2_000;
@@ -3817,6 +3831,7 @@ test "restart.persistent.early_startup_quarantine" {
             self.retained = .{};
             ticket.cloneInto(self.allocator, &self.retained) catch unreachable;
             _ = self.runtime.storeClientTicket(ticket);
+            self.count += 1;
         }
     };
 
@@ -3835,7 +3850,7 @@ test "restart.persistent.early_startup_quarantine" {
     const first_raw = try first_client.readPlainToEnd(allocator, 64 * 1024, 5_000);
     defer allocator.free(first_raw);
     try assertContains(first_raw, "HTTP/1.1 200 OK");
-    if (capture.retained.common.early_data == .resume_only) return error.SkipZigTest;
+    try std.testing.expect(capture.count > 0);
     try std.testing.expectEqual(tls_core.session.EarlyDataPolicy{ .early_data_capable = 16 * 1024 }, capture.retained.common.early_data);
 
     var ordinary_ticket: tls_core.session.ClientTicketState = .{};

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -2700,11 +2700,8 @@ test "interop.openssl.h1.early.accepted" {
     try assertContains(first.stdout, "New, TLSv1.3");
     try assertContains(first.stdout, "HTTP/1.1 200 OK");
 
-    const resumption_psk_hex = try opensslSessionResumptionPskHex(allocator, sess_path);
-    defer allocator.free(resumption_psk_hex);
-    const resumption_psk_hex_lower = try allocator.dupe(u8, resumption_psk_hex);
-    defer allocator.free(resumption_psk_hex_lower);
-    _ = std.ascii.lowerString(resumption_psk_hex_lower, resumption_psk_hex_lower);
+    var session_secrets = try opensslSessionSecrets(allocator, sess_path);
+    defer session_secrets.deinit();
     try upstream.resetCapture();
 
     var early = try runOpenssl(allocator, &.{
@@ -2727,8 +2724,8 @@ test "interop.openssl.h1.early.accepted" {
 
     const log = try compat.cwd().readFileAlloc(allocator, tardigrade.log_path, 4 * 1024 * 1024);
     defer allocator.free(log);
-    try std.testing.expect(!containsSubstring(log, resumption_psk_hex));
-    try std.testing.expect(!containsSubstring(log, resumption_psk_hex_lower));
+    try assertHexAbsentCaseInsensitive(allocator, log, session_secrets.resumption_psk_hex);
+    try assertHexAbsentCaseInsensitive(allocator, log, session_secrets.ticket_hex);
 }
 
 test "interop.openssl.h1.early.unsafe_425" {
@@ -3356,24 +3353,107 @@ fn opensslSessionTicketFingerprint(allocator: std.mem.Allocator, path: []const u
     return fingerprint;
 }
 
-fn opensslSessionResumptionPskHex(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+const OpenSslSessionSecrets = struct {
+    allocator: std.mem.Allocator,
+    resumption_psk_hex: []u8,
+    ticket_hex: []u8,
+
+    fn deinit(self: *OpenSslSessionSecrets) void {
+        self.allocator.free(self.resumption_psk_hex);
+        self.allocator.free(self.ticket_hex);
+        self.* = undefined;
+    }
+};
+
+fn opensslSessionSecrets(allocator: std.mem.Allocator, path: []const u8) !OpenSslSessionSecrets {
     var result = try runOpenssl(allocator, &.{
         "sess_id", "-in", path, "-text", "-noout",
     }, null, 10_000);
     defer result.deinit(allocator);
     try std.testing.expectEqual(std.meta.Tag(bounded_process.Outcome).normal_exit, std.meta.activeTag(result.outcome));
 
-    const marker = "Resumption PSK:";
-    const marker_start = std.mem.indexOf(u8, result.stdout, marker) orelse return error.ResumptionPskNotFound;
+    const resumption_psk_hex = try opensslSessionLineHex(allocator, result.stdout, "Resumption PSK:");
+    errdefer allocator.free(resumption_psk_hex);
+    const ticket_hex = try opensslSessionTicketHexBlock(allocator, result.stdout);
+    errdefer allocator.free(ticket_hex);
+
+    return .{
+        .allocator = allocator,
+        .resumption_psk_hex = resumption_psk_hex,
+        .ticket_hex = ticket_hex,
+    };
+}
+
+fn opensslSessionLineHex(allocator: std.mem.Allocator, text: []const u8, marker: []const u8) ![]u8 {
+    const marker_start = std.mem.indexOf(u8, text, marker) orelse return error.SessionSecretNotFound;
     const value_start = marker_start + marker.len;
-    const line_end = std.mem.indexOfScalarPos(u8, result.stdout, value_start, '\n') orelse result.stdout.len;
-    const raw = std.mem.trim(u8, result.stdout[value_start..line_end], " \t\r");
-    if (raw.len < 32 or raw.len % 2 != 0) return error.ResumptionPskMalformed;
-    for (raw) |c| {
-        if (!std.ascii.isHex(c)) return error.ResumptionPskMalformed;
-    }
+    const line_end = std.mem.indexOfScalarPos(u8, text, value_start, '\n') orelse text.len;
+    const raw = std.mem.trim(u8, text[value_start..line_end], " \t\r");
+    try validateHexSecret(raw);
     return allocator.dupe(u8, raw);
 }
+
+fn opensslSessionTicketHexBlock(allocator: std.mem.Allocator, text: []const u8) ![]u8 {
+    const marker = "TLS session ticket:";
+    const marker_start = std.mem.indexOf(u8, text, marker) orelse return error.SessionTicketNotFound;
+    var lines = std.mem.splitScalar(u8, text[marker_start + marker.len ..], '\n');
+    var hex = std.array_list.Managed(u8).init(allocator);
+    errdefer hex.deinit();
+
+    while (lines.next()) |line_raw| {
+        const line = compat.trimRight(u8, line_raw, " \t\r");
+        if (line.len == 0) {
+            if (hex.items.len > 0) break;
+            continue;
+        }
+        if (line[0] != ' ' and line[0] != '\t') {
+            if (hex.items.len > 0) break;
+            continue;
+        }
+        const dash = std.mem.indexOfScalar(u8, line, '-') orelse {
+            if (hex.items.len > 0) break;
+            continue;
+        };
+        const bytes_text = std.mem.trim(u8, line[dash + 1 ..], " \t");
+        var consumed = false;
+        var i: usize = 0;
+        while (i < bytes_text.len) {
+            const c = bytes_text[i];
+            if (std.ascii.isHex(c)) {
+                try hex.append(c);
+                consumed = true;
+            } else if (c == ' ' or c == '\t') {
+                // OpenSSL separates hex byte pairs with spaces.
+            } else {
+                break;
+            }
+            i += 1;
+        }
+        if (!consumed and hex.items.len > 0) break;
+    }
+
+    try validateHexSecret(hex.items);
+    return hex.toOwnedSlice();
+}
+
+fn validateHexSecret(raw: []const u8) !void {
+    if (raw.len < 32 or raw.len % 2 != 0) return error.SessionSecretMalformed;
+    for (raw) |c| {
+        if (!std.ascii.isHex(c)) return error.SessionSecretMalformed;
+    }
+}
+
+fn assertHexAbsentCaseInsensitive(allocator: std.mem.Allocator, haystack: []const u8, hex: []const u8) !void {
+    const haystack_lower = try allocator.dupe(u8, haystack);
+    defer allocator.free(haystack_lower);
+    _ = std.ascii.lowerString(haystack_lower, haystack_lower);
+    const hex_lower = try allocator.dupe(u8, hex);
+    defer allocator.free(hex_lower);
+    _ = std.ascii.lowerString(hex_lower, hex_lower);
+    try std.testing.expect(!containsSubstring(haystack_lower, hex_lower));
+}
+
+const persistent_ticket_key_fixture_hex = "101112131415161718191a1b1c1d1e1f";
 
 fn persistentTicketKeySnapshotPath(allocator: std.mem.Allocator, port: u16, tag: []const u8) ![]u8 {
     const dir = try interopSecretsDir(allocator);
@@ -3860,6 +3940,8 @@ test "restart.persistent.early_startup_quarantine" {
     defer early_ticket.deinit();
     try capture.retained.cloneInto(allocator, &early_ticket);
 
+    const log_a_path = try allocator.dupe(u8, process_a.log_path);
+    defer allocator.free(log_a_path);
     process_a.stop();
     process_a_running = false;
 
@@ -3946,6 +4028,13 @@ test "restart.persistent.early_startup_quarantine" {
     try expectMetricAtLeast(metrics.body, "tardigrade_tls_resumption_outcome_total", &.{ "transport=\"record\"", "outcome=\"accepted\"" }, 1);
     try expectMetricAtLeast(metrics.body, "tardigrade_tls_early_data_replay_total", &.{"outcome=\"startup_quarantine\""}, 1);
     try std.testing.expectEqual(@as(u64, 0), prometheusLabeledMetricValue(metrics.body, "tardigrade_tls_early_data_replay_total", &.{"outcome=\"accepted\""}) orelse 0);
+
+    const log_a = try compat.cwd().readFileAlloc(allocator, log_a_path, 4 * 1024 * 1024);
+    defer allocator.free(log_a);
+    const log_b = try compat.cwd().readFileAlloc(allocator, process_b.log_path, 4 * 1024 * 1024);
+    defer allocator.free(log_b);
+    try assertHexAbsentCaseInsensitive(allocator, log_a, persistent_ticket_key_fixture_hex);
+    try assertHexAbsentCaseInsensitive(allocator, log_b, persistent_ticket_key_fixture_hex);
 }
 
 // Named `restart_and_credential_change`, not `cert_change`: process A and

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -2494,7 +2494,7 @@ fn runOpenssl(allocator: std.mem.Allocator, args: []const []const u8, stdin_data
         // the instant the write returns races that ticket into arriving
         // too late for `-sess_out` to capture it; this bounded pause (not a
         // blind test-level sleep) gives it a chance to land first.
-        .stdin_close_delay_ms = if (stdin_data != null) 400 else 0,
+        .stdin_close_delay_ms = if (stdin_data != null) 1_000 else 0,
         .stdout_limit = 256 * 1024,
         .stderr_limit = 256 * 1024,
         .deadline_ms = deadline_ms,
@@ -2540,6 +2540,26 @@ fn opensslSessionPath(allocator: std.mem.Allocator, port: u16, tag: []const u8) 
     const dir = try interopSecretsDir(allocator);
     defer allocator.free(dir);
     return std.fmt.allocPrint(allocator, "{s}/interop-{s}-{d}.sess", .{ dir, tag, port });
+}
+
+fn opensslEarlyDataPath(allocator: std.mem.Allocator, port: u16, tag: []const u8) ![]u8 {
+    const dir = try interopSecretsDir(allocator);
+    defer allocator.free(dir);
+    return std.fmt.allocPrint(allocator, "{s}/interop-{s}-{d}.early", .{ dir, tag, port });
+}
+
+fn writeInteropSecretFile(path: []const u8, data: []const u8) !void {
+    var file = try compat.cwd().createFile(path, .{
+        .truncate = true,
+        .permissions = .fromMode(0o600),
+    });
+    defer file.close();
+    try file.writeAll(data);
+    try file.flush();
+}
+
+fn expectMetricAtLeast(body: []const u8, name: []const u8, labels: []const []const u8, expected: u64) !void {
+    try std.testing.expect((prometheusLabeledMetricValue(body, name, labels) orelse 0) >= expected);
 }
 
 const openssl_health_request = "GET /healthz HTTP/1.1\r\nHost: tardigrade.test\r\nConnection: close\r\n\r\n";
@@ -2617,6 +2637,272 @@ test "interop.openssl.h1.resume" {
         "transport=\"record\"",
         "outcome=\"accepted\"",
     }) orelse 0) >= 1);
+}
+
+test "interop.openssl.h1.early.accepted" {
+    try requireNativeTlsProfile();
+    const allocator = std.testing.allocator;
+    try requireOpenssl(allocator);
+
+    var tls_paths = try nativeTlsFixturePaths(allocator);
+    defer tls_paths.deinit();
+
+    var upstream = try UpstreamServer.start(allocator, &.{
+        .{ .body = "readiness", .connection_header = "close" },
+        .{ .body = "ticket-bootstrap", .connection_header = "close" },
+        .{ .body = "safe-early", .connection_header = "close" },
+    });
+    defer upstream.stop();
+    try upstream.run();
+
+    const config_text = try std.fmt.allocPrint(allocator,
+        \\location / {{
+        \\    proxy_pass http://{s}:{d};
+        \\    early_data replay_safe;
+        \\    proxy_early_data rfc8470;
+        \\}}
+    , .{ test_host, upstream.port() });
+    defer allocator.free(config_text);
+
+    var tardigrade = try TardigradeProcess.start(allocator, .{
+        .config_text = config_text,
+        .ready_https_insecure = true,
+        .ready_path = "/safe",
+        .extra_env = &.{
+            .{ .name = "TARDIGRADE_TLS_CERT_PATH", .value = tls_paths.cert_path },
+            .{ .name = "TARDIGRADE_TLS_KEY_PATH", .value = tls_paths.key_path },
+            .{ .name = "TARDIGRADE_TLS_SERVER_NAME", .value = "tardigrade.test" },
+            .{ .name = "TARDIGRADE_HTTP2_ENABLED", .value = "false" },
+            .{ .name = "TARDIGRADE_TLS_NATIVE_RESUMPTION_MODE", .value = "stateful" },
+            .{ .name = "TARDIGRADE_TLS_NATIVE_EARLY_DATA_REPLAY_MODE", .value = "process_local" },
+        },
+    });
+    defer tardigrade.stop();
+
+    const connect_arg = try opensslConnectArg(allocator, tardigrade.port);
+    defer allocator.free(connect_arg);
+    const sess_path = try opensslSessionPath(allocator, tardigrade.port, "h1-early-accepted");
+    defer allocator.free(sess_path);
+    defer compat.cwd().deleteFile(sess_path) catch {};
+    const early_path = try opensslEarlyDataPath(allocator, tardigrade.port, "h1-early-accepted");
+    defer allocator.free(early_path);
+    defer compat.cwd().deleteFile(early_path) catch {};
+    try writeInteropSecretFile(early_path, "GET /safe HTTP/1.1\r\nHost: tardigrade.test\r\nConnection: close\r\n\r\n");
+
+    var first = try runOpenssl(allocator, &.{
+        "s_client",        "-connect", connect_arg,
+        "-alpn",           "http/1.1", "-servername",
+        "tardigrade.test", "-tls1_3",  "-sess_out",
+        sess_path,
+    }, "GET /safe HTTP/1.1\r\nHost: tardigrade.test\r\nConnection: close\r\n\r\n", 10_000);
+    defer first.deinit(allocator);
+    try std.testing.expectEqual(std.meta.Tag(bounded_process.Outcome).normal_exit, std.meta.activeTag(first.outcome));
+    try assertContains(first.stdout, "New, TLSv1.3");
+    try assertContains(first.stdout, "HTTP/1.1 200 OK");
+
+    const fingerprint = try opensslSessionFileMaterialSample(allocator, sess_path);
+    var fingerprint_hex: [64]u8 = undefined;
+    const fingerprint_hex_slice = std.fmt.bufPrint(&fingerprint_hex, "{x}", .{fingerprint}) catch unreachable;
+    try upstream.resetCapture();
+
+    var early = try runOpenssl(allocator, &.{
+        "s_client",        "-connect",    connect_arg,
+        "-alpn",           "http/1.1",    "-servername",
+        "tardigrade.test", "-tls1_3",     "-sess_in",
+        sess_path,         "-early_data", early_path,
+    }, "", 10_000);
+    defer early.deinit(allocator);
+    try std.testing.expectEqual(std.meta.Tag(bounded_process.Outcome).normal_exit, std.meta.activeTag(early.outcome));
+    try assertContains(early.stdout, "Reused, TLSv1.3");
+    try assertContains(early.stdout, "HTTP/1.1 200 OK");
+    try assertContains(early.stdout, "safe-early");
+    try std.testing.expectEqual(@as(u32, 1), upstream.requestCount());
+
+    var metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
+    defer metrics.deinit();
+    try expectMetricAtLeast(metrics.body, "tardigrade_tls_early_data_replay_total", &.{"outcome=\"accepted\""}, 1);
+    try expectMetricAtLeast(metrics.body, "tardigrade_http_early_data_decisions_total", &.{ "protocol=\"h1\"", "decision=\"forwarded\"" }, 1);
+
+    const log = try compat.cwd().readFileAlloc(allocator, tardigrade.log_path, 4 * 1024 * 1024);
+    defer allocator.free(log);
+    try std.testing.expect(!containsSubstring(log, fingerprint_hex_slice));
+}
+
+test "interop.openssl.h1.early.unsafe_425" {
+    try requireNativeTlsProfile();
+    const allocator = std.testing.allocator;
+    try requireOpenssl(allocator);
+
+    var tls_paths = try nativeTlsFixturePaths(allocator);
+    defer tls_paths.deinit();
+
+    var upstream = try UpstreamServer.start(allocator, &.{
+        .{ .body = "readiness", .connection_header = "close" },
+        .{ .body = "ticket-bootstrap", .connection_header = "close" },
+    });
+    defer upstream.stop();
+    try upstream.run();
+
+    const config_text = try std.fmt.allocPrint(allocator,
+        \\location / {{
+        \\    proxy_pass http://{s}:{d};
+        \\    early_data replay_safe;
+        \\    proxy_early_data rfc8470;
+        \\}}
+    , .{ test_host, upstream.port() });
+    defer allocator.free(config_text);
+
+    var tardigrade = try TardigradeProcess.start(allocator, .{
+        .config_text = config_text,
+        .ready_https_insecure = true,
+        .ready_path = "/safe",
+        .extra_env = &.{
+            .{ .name = "TARDIGRADE_TLS_CERT_PATH", .value = tls_paths.cert_path },
+            .{ .name = "TARDIGRADE_TLS_KEY_PATH", .value = tls_paths.key_path },
+            .{ .name = "TARDIGRADE_TLS_SERVER_NAME", .value = "tardigrade.test" },
+            .{ .name = "TARDIGRADE_HTTP2_ENABLED", .value = "false" },
+            .{ .name = "TARDIGRADE_TLS_NATIVE_RESUMPTION_MODE", .value = "stateful" },
+            .{ .name = "TARDIGRADE_TLS_NATIVE_EARLY_DATA_REPLAY_MODE", .value = "process_local" },
+        },
+    });
+    defer tardigrade.stop();
+
+    const connect_arg = try opensslConnectArg(allocator, tardigrade.port);
+    defer allocator.free(connect_arg);
+    const sess_path = try opensslSessionPath(allocator, tardigrade.port, "h1-early-unsafe");
+    defer allocator.free(sess_path);
+    defer compat.cwd().deleteFile(sess_path) catch {};
+    const early_path = try opensslEarlyDataPath(allocator, tardigrade.port, "h1-early-unsafe");
+    defer allocator.free(early_path);
+    defer compat.cwd().deleteFile(early_path) catch {};
+    try writeInteropSecretFile(early_path, "POST /work HTTP/1.1\r\nHost: tardigrade.test\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+
+    var first = try runOpenssl(allocator, &.{
+        "s_client",        "-connect", connect_arg,
+        "-alpn",           "http/1.1", "-servername",
+        "tardigrade.test", "-tls1_3",  "-sess_out",
+        sess_path,
+    }, "GET /safe HTTP/1.1\r\nHost: tardigrade.test\r\nConnection: close\r\n\r\n", 10_000);
+    defer first.deinit(allocator);
+    try std.testing.expectEqual(std.meta.Tag(bounded_process.Outcome).normal_exit, std.meta.activeTag(first.outcome));
+    try upstream.resetCapture();
+
+    var early = try runOpenssl(allocator, &.{
+        "s_client",        "-connect",    connect_arg,
+        "-alpn",           "http/1.1",    "-servername",
+        "tardigrade.test", "-tls1_3",     "-sess_in",
+        sess_path,         "-early_data", early_path,
+    }, "", 10_000);
+    defer early.deinit(allocator);
+    try std.testing.expectEqual(std.meta.Tag(bounded_process.Outcome).normal_exit, std.meta.activeTag(early.outcome));
+    try assertContains(early.stdout, "Reused, TLSv1.3");
+    try assertContains(early.stdout, "HTTP/1.1 425 Too Early");
+    try std.testing.expectEqual(@as(u32, 0), upstream.requestCount());
+
+    var metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
+    defer metrics.deinit();
+    try expectMetricAtLeast(metrics.body, "tardigrade_tls_early_data_replay_total", &.{"outcome=\"accepted\""}, 1);
+    try std.testing.expectEqual(@as(u64, 0), prometheusLabeledMetricValue(metrics.body, "tardigrade_tls_early_data_replay_total", &.{"outcome=\"duplicate\""}) orelse 0);
+    try expectMetricAtLeast(metrics.body, "tardigrade_http_early_data_decisions_total", &.{ "protocol=\"h1\"", "decision=\"too_early\"" }, 1);
+}
+
+test "interop.openssl.h1.early.replay_fallback" {
+    try requireNativeTlsProfile();
+    const allocator = std.testing.allocator;
+    try requireOpenssl(allocator);
+
+    var tls_paths = try nativeTlsFixturePaths(allocator);
+    defer tls_paths.deinit();
+
+    var upstream = try UpstreamServer.start(allocator, &.{
+        .{ .body = "readiness", .connection_header = "close" },
+        .{ .body = "ticket-bootstrap", .connection_header = "close" },
+        .{ .body = "safe-early", .connection_header = "close" },
+        .{ .body = "after-replay", .connection_header = "close" },
+    });
+    defer upstream.stop();
+    try upstream.run();
+
+    const config_text = try std.fmt.allocPrint(allocator,
+        \\location / {{
+        \\    proxy_pass http://{s}:{d};
+        \\    early_data replay_safe;
+        \\    proxy_early_data rfc8470;
+        \\}}
+    , .{ test_host, upstream.port() });
+    defer allocator.free(config_text);
+
+    var tardigrade = try TardigradeProcess.start(allocator, .{
+        .config_text = config_text,
+        .ready_https_insecure = true,
+        .ready_path = "/early",
+        .extra_env = &.{
+            .{ .name = "TARDIGRADE_TLS_CERT_PATH", .value = tls_paths.cert_path },
+            .{ .name = "TARDIGRADE_TLS_KEY_PATH", .value = tls_paths.key_path },
+            .{ .name = "TARDIGRADE_TLS_SERVER_NAME", .value = "tardigrade.test" },
+            .{ .name = "TARDIGRADE_HTTP2_ENABLED", .value = "false" },
+            .{ .name = "TARDIGRADE_TLS_NATIVE_RESUMPTION_MODE", .value = "stateful" },
+            .{ .name = "TARDIGRADE_TLS_NATIVE_EARLY_DATA_REPLAY_MODE", .value = "process_local" },
+        },
+    });
+    defer tardigrade.stop();
+
+    const connect_arg = try opensslConnectArg(allocator, tardigrade.port);
+    defer allocator.free(connect_arg);
+    const sess_path = try opensslSessionPath(allocator, tardigrade.port, "h1-early-replay");
+    defer allocator.free(sess_path);
+    defer compat.cwd().deleteFile(sess_path) catch {};
+    const early_path = try opensslEarlyDataPath(allocator, tardigrade.port, "h1-early-replay");
+    defer allocator.free(early_path);
+    defer compat.cwd().deleteFile(early_path) catch {};
+    try writeInteropSecretFile(early_path, "GET /early HTTP/1.1\r\nHost: tardigrade.test\r\nConnection: keep-alive\r\n\r\n");
+
+    var first = try runOpenssl(allocator, &.{
+        "s_client",        "-connect", connect_arg,
+        "-alpn",           "http/1.1", "-servername",
+        "tardigrade.test", "-tls1_3",  "-sess_out",
+        sess_path,
+    }, "GET /early HTTP/1.1\r\nHost: tardigrade.test\r\nConnection: close\r\n\r\n", 10_000);
+    defer first.deinit(allocator);
+    try std.testing.expectEqual(std.meta.Tag(bounded_process.Outcome).normal_exit, std.meta.activeTag(first.outcome));
+    try upstream.resetCapture();
+
+    var accepted = try runOpenssl(allocator, &.{
+        "s_client",        "-connect",    connect_arg,
+        "-alpn",           "http/1.1",    "-servername",
+        "tardigrade.test", "-tls1_3",     "-sess_in",
+        sess_path,         "-early_data", early_path,
+    }, "", 10_000);
+    defer accepted.deinit(allocator);
+    try std.testing.expectEqual(std.meta.Tag(bounded_process.Outcome).normal_exit, std.meta.activeTag(accepted.outcome));
+    try assertContains(accepted.stdout, "HTTP/1.1 200 OK");
+    try assertContains(accepted.stdout, "safe-early");
+    try std.testing.expectEqual(@as(u32, 1), upstream.requestCount());
+
+    var replay = try runOpenssl(allocator, &.{
+        "s_client",        "-connect",    connect_arg,
+        "-alpn",           "http/1.1",    "-servername",
+        "tardigrade.test", "-tls1_3",     "-sess_in",
+        sess_path,         "-early_data", early_path,
+    }, "GET /after HTTP/1.1\r\nHost: tardigrade.test\r\nConnection: close\r\n\r\n", 10_000);
+    defer replay.deinit(allocator);
+    try std.testing.expectEqual(std.meta.Tag(bounded_process.Outcome).normal_exit, std.meta.activeTag(replay.outcome));
+    try assertContains(replay.stdout, "Reused, TLSv1.3");
+    try assertContains(replay.stdout, "HTTP/1.1 200 OK");
+    try assertContains(replay.stdout, "after-replay");
+    try std.testing.expectEqual(@as(u32, 2), upstream.requestCount());
+    const first_path = try upstream.capturedPathHistoryAt(allocator, 0);
+    defer allocator.free(first_path);
+    const second_path = try upstream.capturedPathHistoryAt(allocator, 1);
+    defer allocator.free(second_path);
+    try std.testing.expectEqualStrings("/early", first_path);
+    try std.testing.expectEqualStrings("/after", second_path);
+
+    var metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
+    defer metrics.deinit();
+    try expectMetricAtLeast(metrics.body, "tardigrade_tls_early_data_replay_total", &.{"outcome=\"accepted\""}, 1);
+    try expectMetricAtLeast(metrics.body, "tardigrade_tls_early_data_replay_total", &.{"outcome=\"duplicate\""}, 1);
+    try expectMetricAtLeast(metrics.body, "tardigrade_tls_resumption_outcome_total", &.{ "transport=\"record\"", "outcome=\"accepted\"" }, 2);
 }
 
 // Named `h2.tls_resume`, not `h2.resume`: this proves TLS-layer PSK
@@ -3067,6 +3353,35 @@ fn opensslSessionTicketFingerprint(allocator: std.mem.Allocator, path: []const u
     return fingerprint;
 }
 
+fn opensslSessionFileMaterialSample(allocator: std.mem.Allocator, path: []const u8) ![32]u8 {
+    const raw = try decodeOpensslSessionFile(allocator, path);
+    defer allocator.free(raw);
+    if (raw.len < 32) return error.SessionFileTooShortToSample;
+    var sample: [32]u8 = undefined;
+    @memcpy(&sample, raw[raw.len - 32 ..]);
+    return sample;
+}
+
+fn persistentTicketKeySnapshotPath(allocator: std.mem.Allocator, port: u16, tag: []const u8) ![]u8 {
+    const dir = try interopSecretsDir(allocator);
+    defer allocator.free(dir);
+    return std.fmt.allocPrint(allocator, "{s}/interop-{s}-{d}-ticket-keys.json", .{ dir, tag, port });
+}
+
+fn writePersistentTicketKeySnapshot(allocator: std.mem.Allocator, path: []const u8) !void {
+    const now = compat.milliTimestamp();
+    const snapshot = try std.fmt.allocPrint(
+        allocator,
+        "{{\"version\":1,\"generation\":1,\"keys\":[{{\"id\":\"000102030405060708090a0b0c0d0e0f\",\"aead\":\"aes_128_gcm\",\"key\":\"101112131415161718191a1b1c1d1e1f\",\"not_before_unix_ms\":{d},\"encrypt_until_unix_ms\":{d},\"decrypt_until_unix_ms\":{d},\"nonce_lease\":{{\"prefix\":\"51800000\",\"start\":0,\"end_exclusive\":4096}}}}]}}",
+        .{ now - 60_000, now + 60 * 60 * 1000, now + 2 * 60 * 60 * 1000 },
+    );
+    defer {
+        std.crypto.secureZero(u8, snapshot);
+        allocator.free(snapshot);
+    }
+    try writeInteropSecretFile(path, snapshot);
+}
+
 /// #369: flips one byte inside the opaque ticket envelope of an
 /// OpenSSL-managed `-sess_out` PEM file, in place. Locates
 /// `ticket_protection`'s public, non-secret magic (`"TDTK"`) with a plain
@@ -3416,6 +3731,206 @@ test "restart.ephemeral.ticket_miss and restart.ephemeral.fresh_ticket" {
     defer allocator.free(log_b);
     try std.testing.expect(!containsSubstring(log_a, fingerprint_hex_slice));
     try std.testing.expect(!containsSubstring(log_b, fingerprint_hex_slice));
+}
+
+test "restart.persistent.early_startup_quarantine" {
+    try requireNativeTlsProfile();
+    const allocator = std.testing.allocator;
+    try requireOpenssl(allocator);
+
+    var tls_paths = try nativeTlsFixturePaths(allocator);
+    defer tls_paths.deinit();
+
+    const key_path_probe_port = try findFreePort();
+    const ticket_keys_path = try persistentTicketKeySnapshotPath(allocator, key_path_probe_port, "persistent-early-quarantine");
+    defer allocator.free(ticket_keys_path);
+    defer compat.cwd().deleteFile(ticket_keys_path) catch {};
+    defer {
+        const lock_path = std.fmt.allocPrint(allocator, "{s}.lock", .{ticket_keys_path}) catch null;
+        if (lock_path) |path| {
+            compat.cwd().deleteFile(path) catch {};
+            allocator.free(path);
+        }
+    }
+    try writePersistentTicketKeySnapshot(allocator, ticket_keys_path);
+
+    var upstream_a = try UpstreamServer.start(allocator, &.{
+        .{ .body = "a-readiness", .connection_header = "close" },
+        .{ .body = "a-ticket", .connection_header = "close" },
+    });
+    defer upstream_a.stop();
+    try upstream_a.run();
+    const config_a = try std.fmt.allocPrint(allocator,
+        \\location / {{
+        \\    proxy_pass http://{s}:{d};
+        \\    early_data replay_safe;
+        \\    proxy_early_data rfc8470;
+        \\}}
+    , .{ test_host, upstream_a.port() });
+    defer allocator.free(config_a);
+
+    var process_a = try TardigradeProcess.start(allocator, .{
+        .config_text = config_a,
+        .ready_https_insecure = true,
+        .ready_path = "/healthz",
+        .extra_env = &.{
+            .{ .name = "TARDIGRADE_TLS_CERT_PATH", .value = tls_paths.cert_path },
+            .{ .name = "TARDIGRADE_TLS_KEY_PATH", .value = tls_paths.key_path },
+            .{ .name = "TARDIGRADE_TLS_SERVER_NAME", .value = "tardigrade.test" },
+            .{ .name = "TARDIGRADE_HTTP2_ENABLED", .value = "false" },
+            .{ .name = "TARDIGRADE_TLS_NATIVE_RESUMPTION_MODE", .value = "stateless" },
+            .{ .name = "TARDIGRADE_TLS_NATIVE_TICKET_KEYS_PATH", .value = ticket_keys_path },
+            .{ .name = "TARDIGRADE_TLS_NATIVE_EARLY_DATA_REPLAY_MODE", .value = "process_local" },
+        },
+    });
+    var process_a_running = true;
+    defer if (process_a_running) process_a.stop();
+
+    compat.sleepNs(61 * std.time.ns_per_s);
+
+    var client_entropy = tls_core.production_crypto.OsEntropy{};
+    var client_provider = tls_core.production_crypto.Provider.init(client_entropy.entropy());
+    var client_runtime = try tls_core.resumption_runtime.Runtime.init(
+        allocator,
+        .{ .mode = .stateful },
+        .{ .ctx = undefined, .nowUnixMsFn = struct {
+            fn now(_: *anyopaque) i64 {
+                return 2_000;
+            }
+        }.now },
+        client_provider.cryptoProvider(),
+    );
+    defer client_runtime.deinit();
+
+    const TicketCapture = struct {
+        allocator: std.mem.Allocator,
+        runtime: *tls_core.resumption_runtime.Runtime,
+        retained: tls_core.session.ClientTicketState = .{},
+
+        fn now(_: *anyopaque) i64 {
+            return 2_000;
+        }
+
+        fn onTicket(ctx: *anyopaque, ticket: *const tls_core.session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.retained.deinit();
+            self.retained = .{};
+            ticket.cloneInto(self.allocator, &self.retained) catch unreachable;
+            _ = self.runtime.storeClientTicket(ticket);
+        }
+    };
+
+    var capture = TicketCapture{ .allocator = allocator, .runtime = &client_runtime };
+    defer capture.retained.deinit();
+
+    const first_client = try PureZigTlsClient.createWithOptions(allocator, process_a.port, "http/1.1", "tardigrade.test", .{
+        .ticket_consumer = .{
+            .ctx = &capture,
+            .nowUnixMsFn = TicketCapture.now,
+            .onTicketFn = TicketCapture.onTicket,
+        },
+    });
+    defer first_client.destroy();
+    try first_client.writeAllPlain("GET /ticket HTTP/1.1\r\nHost: tardigrade.test\r\nConnection: close\r\n\r\n");
+    const first_raw = try first_client.readPlainToEnd(allocator, 64 * 1024, 5_000);
+    defer allocator.free(first_raw);
+    try assertContains(first_raw, "HTTP/1.1 200 OK");
+    if (capture.retained.common.early_data == .resume_only) return error.SkipZigTest;
+    try std.testing.expectEqual(tls_core.session.EarlyDataPolicy{ .early_data_capable = 16 * 1024 }, capture.retained.common.early_data);
+
+    var ordinary_ticket: tls_core.session.ClientTicketState = .{};
+    defer ordinary_ticket.deinit();
+    try capture.retained.cloneInto(allocator, &ordinary_ticket);
+    var early_ticket: tls_core.session.ClientTicketState = .{};
+    defer early_ticket.deinit();
+    try capture.retained.cloneInto(allocator, &early_ticket);
+
+    process_a.stop();
+    process_a_running = false;
+
+    var upstream_b = try UpstreamServer.start(allocator, &.{
+        .{ .body = "b-readiness", .connection_header = "close" },
+        .{ .body = "ordinary-after-quarantine", .connection_header = "close" },
+    });
+    defer upstream_b.stop();
+    try upstream_b.run();
+    const config_b = try std.fmt.allocPrint(allocator,
+        \\location / {{
+        \\    proxy_pass http://{s}:{d};
+        \\    early_data replay_safe;
+        \\    proxy_early_data rfc8470;
+        \\}}
+    , .{ test_host, upstream_b.port() });
+    defer allocator.free(config_b);
+
+    var process_b = try TardigradeProcess.start(allocator, .{
+        .config_text = config_b,
+        .ready_https_insecure = true,
+        .ready_path = "/healthz",
+        .extra_env = &.{
+            .{ .name = "TARDIGRADE_TLS_CERT_PATH", .value = tls_paths.cert_path },
+            .{ .name = "TARDIGRADE_TLS_KEY_PATH", .value = tls_paths.key_path },
+            .{ .name = "TARDIGRADE_TLS_SERVER_NAME", .value = "tardigrade.test" },
+            .{ .name = "TARDIGRADE_HTTP2_ENABLED", .value = "false" },
+            .{ .name = "TARDIGRADE_TLS_NATIVE_RESUMPTION_MODE", .value = "stateless" },
+            .{ .name = "TARDIGRADE_TLS_NATIVE_TICKET_KEYS_PATH", .value = ticket_keys_path },
+            .{ .name = "TARDIGRADE_TLS_NATIVE_EARLY_DATA_REPLAY_MODE", .value = "process_local" },
+        },
+    });
+    defer process_b.stop();
+
+    try upstream_b.resetCapture();
+
+    var clock_dummy: u8 = 0;
+    const ClientClock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 2_500;
+        }
+    };
+
+    var ordinary_offers: tls_core.pre_shared_key.ClientPskOfferSet = .{};
+    try ordinary_offers.push(&ordinary_ticket);
+    errdefer ordinary_offers.deinit();
+    const ordinary_client = try PureZigTlsClient.createWithOptions(allocator, process_b.port, "http/1.1", "tardigrade.test", .{
+        .psk_offers = &ordinary_offers,
+        .psk_now_ctx = &clock_dummy,
+        .psk_now_fn = ClientClock.now,
+    });
+    defer ordinary_client.destroy();
+    try std.testing.expect(ordinary_client.backend.core.psk_authenticated);
+    try ordinary_client.writeAllPlain("GET /ordinary HTTP/1.1\r\nHost: tardigrade.test\r\nConnection: close\r\n\r\n");
+    const ordinary_raw = try ordinary_client.readPlainToEnd(allocator, 64 * 1024, 5_000);
+    defer allocator.free(ordinary_raw);
+    try assertContains(ordinary_raw, "HTTP/1.1 200 OK");
+    try assertContains(ordinary_raw, "ordinary-after-quarantine");
+    try std.testing.expectEqual(@as(u32, 1), upstream_b.requestCount());
+    const path = try upstream_b.capturedPathHistoryAt(allocator, 0);
+    defer allocator.free(path);
+    try std.testing.expectEqualStrings("/ordinary", path);
+    try upstream_b.resetCapture();
+
+    var early_offers: tls_core.pre_shared_key.ClientPskOfferSet = .{};
+    try early_offers.push(&early_ticket);
+    errdefer early_offers.deinit();
+    const early_client = try PureZigTlsClient.createWithOptions(allocator, process_b.port, "http/1.1", "tardigrade.test", .{
+        .psk_offers = &early_offers,
+        .psk_now_ctx = &clock_dummy,
+        .psk_now_fn = ClientClock.now,
+        .early_data_intent = .{ .enabled = true, .max_bytes = 4096 },
+        .return_after_early_data_ready = true,
+    });
+    defer early_client.destroy();
+    try early_client.writeAllPlain("GET /early HTTP/1.1\r\nHost: tardigrade.test\r\nConnection: close\r\n\r\n");
+    try early_client.driveUntilOpen(5_000);
+    try std.testing.expectEqual(@as(u32, 0), upstream_b.requestCount());
+
+    var metrics = try sendPureZigTlsHttp1Request(allocator, process_b.port, "/status/metrics");
+    defer metrics.deinit();
+    try expectMetricAtLeast(metrics.body, "tardigrade_tls_ticket_key_reload_total", &.{"outcome=\"initial_load_success\""}, 1);
+    try expectMetricAtLeast(metrics.body, "tardigrade_tls_ticket_resolve_total", &.{ "mode=\"stateless\"", "result=\"success\"" }, 1);
+    try expectMetricAtLeast(metrics.body, "tardigrade_tls_resumption_outcome_total", &.{ "transport=\"record\"", "outcome=\"accepted\"" }, 1);
+    try expectMetricAtLeast(metrics.body, "tardigrade_tls_early_data_replay_total", &.{"outcome=\"startup_quarantine\""}, 1);
+    try std.testing.expectEqual(@as(u64, 0), prometheusLabeledMetricValue(metrics.body, "tardigrade_tls_early_data_replay_total", &.{"outcome=\"accepted\""}) orelse 0);
 }
 
 // Named `restart_and_credential_change`, not `cert_change`: process A and


### PR DESCRIPTION
## Summary
- add external OpenSSL H1 0-RTT coverage for accepted replay-safe early data, unsafe 425 rejection, and replay fallback usability
- assert typed TLS/HTTP early-data metrics and upstream execution counts for those paths
- allow the appliance profile to load the production persistent native ticket-key path and retain native server early-data policy for ticket issuance
- add a persistent restart quarantine test scaffold that skips when the current production persistent stateless ticket remains resume-only

## Validation
- zig build test -Dtls-profile=appliance
- zig build test-integration-resumption-interop -Dtls-profile=appliance

Refs #518