### PR TITLE
tls: prove persistent ticket-key restart, rotation, reload atomicity, and certificate binding (#369)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -226,17 +226,22 @@ pub fn build(b: *std.Build) void {
     // #522's `h3interop.*` QUIC/H3 cases -- `h3interop.` contains the
     // `interop.` filter substring, so they run under this same step): the
     // same live-process harness filtered to the stable `interop.`/
-    // `restart.`/`soak.` case-ID prefixes. Kept as its own step (not folded
-    // into `test-integration-native-tls`) so CI can budget it separately --
-    // it shells out to a real `openssl`/`gtlsclient` subprocess per case and
-    // spawns/kills real Tardigrade processes for restart coverage.
+    // `restart.`/`rotation.`/`soak.` case-ID prefixes (`rotation.` added by
+    // #519 for the persistent ticket-key rotation/reload-atomicity/
+    // certificate-binding composed proofs, which need the same real-process/
+    // real-SIGHUP coverage on platforms where the full `test-integration`
+    // suite is skipped -- see ci.yml). Kept as its own step (not folded into
+    // `test-integration-native-tls`) so CI can budget it separately -- it
+    // shells out to a real `openssl`/`gtlsclient` subprocess per case and
+    // spawns/kills/SIGHUPs real Tardigrade processes for restart/rotation
+    // coverage.
     const resumption_interop_tests = b.addTest(.{
         .root_module = integration_mod,
-        .filters = &.{ "interop.", "restart.", "soak." },
+        .filters = &.{ "interop.", "restart.", "rotation.", "soak." },
     });
     const run_resumption_interop_tests = b.addRunArtifact(resumption_interop_tests);
     run_resumption_interop_tests.step.dependOn(b.getInstallStep());
-    const resumption_interop_step = b.step("test-integration-resumption-interop", "Run #369 external OpenSSL interop, #522 QUIC/H3 interop, restart, and soak cases");
+    const resumption_interop_step = b.step("test-integration-resumption-interop", "Run #369 external OpenSSL interop, #522 QUIC/H3 interop, restart, #519 rotation, and soak cases");
     resumption_interop_step.dependOn(&run_resumption_interop_tests.step);
 
     // Failure-mode / chaos harness (#169): the same live-process harness filtered

--- a/docs/RESUMPTION_TEST_PLAN.md
+++ b/docs/RESUMPTION_TEST_PLAN.md
@@ -453,44 +453,96 @@ native (non-OpenSSL-adapter) resumption runtime today.
   freshly issued ticket uses only N+1, and — composing the live
   `encrypt_until`/`decrypt_until` boundary pair, not just asserting the
   reload succeeded — a bounded real sleep past N's `decrypt_until` proves N
-  stops resolving at all afterward (`miss`, not a second `accepted`).
-  `not_before` and the `session.issued_at + lifetime` boundary are not
-  re-proven here: both are exact single-key timing facts `#512`'s own unit
-  suite and `interop.openssl.ticket.expired` already cover end to end, and
-  neither depends on rotation itself.
+  stops resolving at all afterward (`miss`, not a second `accepted`). Two
+  further live-process phases, added after review, compose the remaining
+  boundaries directly rather than relying only on `#512`'s unit coverage:
+  - **`not_before`**: a further reload to generation N+2 introduces a key
+    whose `not_before` is a few seconds in the future while N+1 remains
+    encryption-capable right up to that exact instant (a clean,
+    non-overlapping handoff — `Snapshot.activeEncryptionKey` rejects two
+    simultaneously-eligible keys outright as `AmbiguousActiveEncryptionKey`,
+    so N+1's `encrypt_until` is set to exactly N+2's `not_before`). Fresh
+    issuance stays on N+1 until the boundary, then switches to N+2 once it
+    arrives — both observed directly on issued tickets' key ids.
+  - **`session.issued_at + lifetime`**: with a short (10s) process-wide
+    ticket lifetime, a ticket resumes before it elapses and falls back to a
+    full handshake after. `ticket_protection.Protector.resolveInner` checks
+    session expiry *inside* the resolve/decrypt step itself, and
+    `resumption_runtime.resolverResolve` folds every resolve rejection —
+    expired, retired key, or unknown key alike — into the same `miss`
+    outcome; there is no separate metrics bucket distinguishing them. So
+    attribution to session lifetime specifically (not key retirement) comes
+    from the phase's own construction, verified concretely: N+1's
+    `decrypt_until` is kept 60s out (only ~12s elapses), and a fresh ticket
+    issued immediately after the rejected offer is asserted to still seal
+    under N+1 — proof the key itself was never in question.
   - **Real production hazard found while writing this**: naively carrying
-    a retiring key forward into the new generation with its *same* declared
-    `nonce_lease` range (the range recorded in the file after the previous
-    generation's own durable reservation) is rejected with
-    `OverlappingNonceLease` — `ReloadableKeyRing`'s per-key-id ledger
-    permanently remembers the full declared width of every lease a key was
-    ever installed with, not merely how far its counter actually advanced.
-    A retiring key (`encrypt_until` already past) needs no lease at all
-    going forward, matching the shape `resumption_runtime.zig`'s own
-    `#512` rotation unit test already uses (`nonce_lease: null` for the
-    rotated-out key) — operator rotation tooling must do the same, not
-    replay a stale range.
+    a retiring or still-active key forward into a new generation by
+    replaying its *currently declared* `nonce_lease` range (whether the
+    stale original or the file's own current one, read back unmodified) is
+    rejected with `OverlappingNonceLease` — `ReloadableKeyRing`'s per-key-id
+    ledger permanently remembers the full declared width of every lease a
+    key was ever installed with as that key's high-water mark, not merely
+    how far its counter actually advanced, so any re-declared range at or
+    below that mark collides. A key that will never encrypt again needs no
+    lease at all (`nonce_lease: null`, matching the shape
+    `resumption_runtime.zig`'s own `#512` rotation unit test already uses
+    for the rotated-out key); a key that must keep encrypting across the
+    reload needs its range *advanced past* the ledger's mark (the same
+    doubling-by-width advance `reserveNonceLeasesInFile` itself performs),
+    not merely replayed.
 - **`rotation.persistent.failed_reload_keeps_old_state`** — four
-  representative rejected-reload classes (a replacement unreadable at the
-  configured path, malformed JSON, a semantically invalid keyring via an
-  invalid nonce lease, and a stale generation number) each leave a
-  previously issued ticket still resuming and the reload metrics recording
-  a bounded, secret-free failure outcome. A ticket issued only *after* all
-  four rejections still seals under the original key id, proving nothing
-  was partially applied across any of them.
+  representative rejected-reload classes each leave a previously issued
+  ticket still resuming and the reload metrics recording a bounded,
+  secret-free failure outcome, checked per attempt (a labeled-metric
+  before/after delta via a bounded poll, not a fixed settle sleep and not a
+  cumulative running-total check that an earlier sub-case's rejection could
+  mask a later regression behind): a replacement exceeding
+  `ticket_key_snapshot.max_snapshot_bytes` (deterministic on every
+  environment, unlike an earlier permission-bit-based draft of this
+  sub-case that a root/rootless-container CI job could silently fail to
+  enforce), malformed JSON, a semantically invalid keyring via an invalid
+  nonce lease, and a stale generation number. A ticket issued only *after*
+  all four rejections still seals under the original key id, proving
+  nothing was partially applied across any of them.
   - **Finding**: this test does *not* additionally bundle a TLS credential
-    change into a failing SIGHUP, as originally planned. Inspecting
+    change into a failing SIGHUP. Inspecting
     `edge_gateway.run`/`gateway_shutdown.hotReloadConfig` shows the
     appliance TLS profile's real served identity
     (`appliance_credentials.ApplianceCredentials`) is loaded once at
     startup and is never touched by any reload path — the
     `NativeCredentialStore` two-phase prepare/commit mechanism this
     criterion was written against exists, but only on the non-appliance
-    code path, which `requireNativeTlsProfile()` excludes here. What this
-    test does show, honestly: every one of its sub-cases leaves the one
-    credential this process ever serves — and the ticket bound to it —
-    both visibly untouched, even though none of them ever attempts to
-    change it.
+    (general) profile, and there only for QUIC/H3, so it is never reachable
+    under `requireNativeTlsProfile()` regardless of what this test attempts.
+    `rotation.persistent.quic_credential_reload_atomicity` below exercises
+    that real path instead. What this test does show, honestly: every one
+    of its sub-cases leaves the one credential this process ever serves —
+    and the ticket bound to it — both visibly untouched, even though none
+    of them ever attempts to change it.
+- **`rotation.persistent.quic_credential_reload_atomicity`** — the
+  general-profile counterpart, gated by `requireGeneralTlsProfile()` +
+  `requireNgtcp2Client()` (skips without a built `H3_INTEROP_CLIENT_PATH`
+  peer, the same `gtlsclient` subprocess the `h3interop.quic.*` cases use).
+  Bundles a credential swap with a broken ticket-key candidate in one
+  SIGHUP against real QUIC/H3: `native_credentials.prepareReloadFromFiles`
+  genuinely reads and validates credential B (the general profile has no
+  appliance-only path/name guard to reject this reload outright), but
+  `commitPreparedReload` is only reached after the ticket-key step
+  succeeds, which this SIGHUP deliberately fails. Reconnecting with the
+  pre-reload session against the real external ngtcp2/GnuTLS peer resumes
+  authoritatively (the peer's own decrypted Handshake CRYPTO trace) —
+  proof the previous ticket state is live *and*, since a resumed
+  connection's auth-binding check would otherwise reject it, that the
+  served certificate is still credential A. Verifying the served
+  certificate directly (e.g. the peer's negotiated leaf certificate) is not
+  attempted: `gtlsclient` does not currently expose it, only handshake
+  CRYPTO bytes and the resumption outcome, so this is the honest scope —
+  credential-unchanged is verified through the auth-binding mechanism, not
+  an independent second channel. Not executable in every environment (a
+  built ngtcp2/GnuTLS peer, `scripts/interop/build-h3-peer-ci.sh`, is a
+  from-source C++23 build not attempted in every dev environment); CI
+  builds and runs it via the same wiring `h3interop.quic.*` already uses.
 - **`rotation.persistent.certificate_binding_change`** — closes the gap
   Slice 3's `restart.restart_and_credential_change.ticket_rejected` doc
   comment explicitly left open ("[proving certificate/auth-binding

--- a/docs/RESUMPTION_TEST_PLAN.md
+++ b/docs/RESUMPTION_TEST_PLAN.md
@@ -497,13 +497,16 @@ native (non-OpenSSL-adapter) resumption runtime today.
   secret-free failure outcome, checked per attempt (a labeled-metric
   before/after delta via a bounded poll, not a fixed settle sleep and not a
   cumulative running-total check that an earlier sub-case's rejection could
-  mask a later regression behind): a replacement exceeding
-  `ticket_key_snapshot.max_snapshot_bytes` (deterministic on every
-  environment, unlike an earlier permission-bit-based draft of this
-  sub-case that a root/rootless-container CI job could silently fail to
-  enforce), malformed JSON, a semantically invalid keyring via an invalid
-  nonce lease, and a stale generation number. A ticket issued only *after*
-  all four rejections still seals under the original key id, proving
+  mask a later regression behind): an *unreadable* replacement (the
+  configured path replaced with a directory -- deterministic on every
+  environment regardless of permissions, unlike an earlier permission-bit
+  draft a root/rootless-container CI job could silently fail to enforce,
+  and semantically distinct from a size-limit rejection, which an
+  intermediate draft of this sub-case substituted and review correctly
+  flagged as not the same failure class), malformed JSON, a semantically
+  invalid keyring via an invalid nonce lease, and a stale generation
+  number. A ticket issued only *after* all four rejections still seals
+  under the original key id, proving
   nothing was partially applied across any of them.
   - **Finding**: this test does *not* additionally bundle a TLS credential
     change into a failing SIGHUP. Inspecting

--- a/docs/RESUMPTION_TEST_PLAN.md
+++ b/docs/RESUMPTION_TEST_PLAN.md
@@ -375,6 +375,8 @@ passed before it.
   credential-reload path that preserves the resumption runtime (currently
   forbidden under the appliance profile) or a persistent keyring across
   restart (not a production capability today — see Rotation below).
+  **Closed by #519's `rotation.persistent.certificate_binding_change`**,
+  once the persistent keyring became a real production capability (#513).
 - **Independent QUIC/H3 external interop for resumption/0-RTT.** The repo
   has real external QUIC/H3 tooling (`scripts/interop/run-interop.sh` +
   `tests/h3_interop_tool.zig`, driving ngtcp2/quiche/aioquic peers) that a
@@ -396,6 +398,10 @@ passed before it.
   narrowly-scoped production-composition follow-up this needs before
   #369's rotation rows can close; #369's operational rotation matrix stays
   blocked on it, the same way #369's 0-RTT rows stay blocked on #510.
+  **Closed by #512/#513 (production composition) and #519 (this doc's
+  Slice 4, the composed operational proof against it)** — kept here
+  unedited as the historical record of what was true when this slice
+  shipped.
 - **Deterministic worker-thread-pinning test seam** (carried over from
   Slice 2, unchanged): #369 Slice 2 proves the process-shared replay-store
   guarantee across independent per-connection state, not through real OS
@@ -415,3 +421,111 @@ rejected-0-RTT interop, replay-store cross-worker proof under real
 routing) or on persistent rotation remain open. #369 is not complete
 after this slice; the honest remainder is the corrected #510 scope plus
 the items above.
+
+## Slice 4 (#519): persistent ticket-key restart, rotation, reload
+atomicity, and certificate binding
+
+This slice closes the "Rotation / persistent-overlap key policy" gap Slice
+3 documented above as Outcome B: **#513** landed the actual production
+composition (`TARDIGRADE_TLS_NATIVE_TICKET_KEYS_PATH`, `ReloadableKeyRing`
+wired into the shared native resumption runtime, SIGHUP reload of the
+snapshot). #519 is the operational proof against that real, running
+composition — real process restarts and real SIGHUPs, not the
+`resumption_runtime.zig`/`ticket_protection.zig` unit suites `#512` already
+added (which this slice reuses, not duplicates).
+
+All four new cases live in `tests/integration.zig`, gated by
+`requireNativeTlsProfile()` like every other case in this section — they
+only run under the appliance TLS profile build, the only profile with a
+native (non-OpenSSL-adapter) resumption runtime today.
+
+- **`restart.persistent.ticket_survives`** — a real process A issues a
+  stateless ticket under a persistent snapshot; a real process B, started
+  from the *same* on-disk snapshot with no manual lease editing, durably
+  reserves its own disjoint nonce-lease window before issuing anything
+  (asserted directly against the file's own `nonce_lease.start`/
+  `end_exclusive`, before and after each process starts), resumes A's
+  still-valid ticket, and issues its own fresh ticket whose (key_id, nonce)
+  is asserted distinct from every A-issued tuple — proven structurally via
+  the disjoint lease windows, not merely "happened to differ once".
+- **`rotation.persistent.n_to_n_plus_1`** — a real SIGHUP drives generation
+  N → N+1: the old N ticket resumes during the overlap grace window, a
+  freshly issued ticket uses only N+1, and — composing the live
+  `encrypt_until`/`decrypt_until` boundary pair, not just asserting the
+  reload succeeded — a bounded real sleep past N's `decrypt_until` proves N
+  stops resolving at all afterward (`miss`, not a second `accepted`).
+  `not_before` and the `session.issued_at + lifetime` boundary are not
+  re-proven here: both are exact single-key timing facts `#512`'s own unit
+  suite and `interop.openssl.ticket.expired` already cover end to end, and
+  neither depends on rotation itself.
+  - **Real production hazard found while writing this**: naively carrying
+    a retiring key forward into the new generation with its *same* declared
+    `nonce_lease` range (the range recorded in the file after the previous
+    generation's own durable reservation) is rejected with
+    `OverlappingNonceLease` — `ReloadableKeyRing`'s per-key-id ledger
+    permanently remembers the full declared width of every lease a key was
+    ever installed with, not merely how far its counter actually advanced.
+    A retiring key (`encrypt_until` already past) needs no lease at all
+    going forward, matching the shape `resumption_runtime.zig`'s own
+    `#512` rotation unit test already uses (`nonce_lease: null` for the
+    rotated-out key) — operator rotation tooling must do the same, not
+    replay a stale range.
+- **`rotation.persistent.failed_reload_keeps_old_state`** — four
+  representative rejected-reload classes (a replacement unreadable at the
+  configured path, malformed JSON, a semantically invalid keyring via an
+  invalid nonce lease, and a stale generation number) each leave a
+  previously issued ticket still resuming and the reload metrics recording
+  a bounded, secret-free failure outcome. A ticket issued only *after* all
+  four rejections still seals under the original key id, proving nothing
+  was partially applied across any of them.
+  - **Finding**: this test does *not* additionally bundle a TLS credential
+    change into a failing SIGHUP, as originally planned. Inspecting
+    `edge_gateway.run`/`gateway_shutdown.hotReloadConfig` shows the
+    appliance TLS profile's real served identity
+    (`appliance_credentials.ApplianceCredentials`) is loaded once at
+    startup and is never touched by any reload path — the
+    `NativeCredentialStore` two-phase prepare/commit mechanism this
+    criterion was written against exists, but only on the non-appliance
+    code path, which `requireNativeTlsProfile()` excludes here. What this
+    test does show, honestly: every one of its sub-cases leaves the one
+    credential this process ever serves — and the ticket bound to it —
+    both visibly untouched, even though none of them ever attempts to
+    change it.
+- **`rotation.persistent.certificate_binding_change`** — closes the gap
+  Slice 3's `restart.restart_and_credential_change.ticket_rejected` doc
+  comment explicitly left open ("[proving certificate/auth-binding
+  rejection] needs ... a persistent keyring surviving a restart, [which does
+  not exist] in production today"). It now does (#513), so this is a
+  restart (not reload, per the finding above): process A issues a ticket
+  under credential A; process B restarts from the *same* ticket-key
+  snapshot under a different credential B. B can genuinely decrypt A's
+  ticket (unlike the ephemeral-key restart cases), so the rejection is
+  provably `session.evaluateCompatibility`'s `auth_binding` check, not an
+  unknown-key miss: `tls13_backend.selectPsk` only records the
+  `incompatible` resumption outcome (as opposed to `miss`) for an identity
+  that actually resolved, and this run's `tardigrade_tls_ticket_resolve_total
+  {result="success"}` confirms the decrypt itself succeeded. The connection
+  still completes via a safe full handshake.
+
+### CI
+
+`build.zig`'s `test-integration-resumption-interop` step's filter list
+gained a `rotation.` prefix alongside the existing `interop.`/`restart.`/
+`soak.` ones, so these cases get the same macOS coverage (where the full
+`test-integration` suite is deliberately skipped — see `ci.yml`) the
+`restart.*` cases already had.
+
+## Explicitly deferred beyond this slice (still open after #519)
+
+- **Persistent-key rotation soak / worker-thread-pinning / cross-worker
+  anti-replay under real routing** — unchanged from Slice 3's equivalent
+  bullets above; #519 proves single-worker-process rotation correctness,
+  not concurrent multi-worker rotation or the worker-pinning seam those
+  need.
+- **General (non-appliance) profile credential-reload two-phase atomicity**
+  — `gateway_shutdown.hotReloadConfig`'s `NativeCredentialStore` prepare/
+  commit path is real production code, but exercising it needs a non-
+  appliance native-TLS test configuration this file's persistent-ticket-key
+  cases don't build under (`requireNativeTlsProfile()` is appliance-only).
+  Not attempted here; a future slice targeting the general profile
+  specifically would need its own harness path.

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -7759,23 +7759,74 @@ test "rotation.persistent.failed_reload_keeps_old_state" {
         }
     }.run;
 
-    // Sub-case 1: unreadable replacement -- a file that exists (so
-    // `edge_config.validate`'s own `TARDIGRADE_TLS_NATIVE_TICKET_KEYS_PATH`
-    // existence check, which merely opens the path, passes) but exceeds
-    // `ticket_key_snapshot.max_snapshot_bytes` (64 KiB), so
-    // `ticket_key_snapshot.loadFromFile`'s own bounded `readFileAlloc`
-    // fails with `error.FileTooBig` -> `SnapshotTooLarge` regardless of
-    // filesystem permissions or which user/container CI runs the test as
-    // -- deterministic on every supported environment, unlike a
+    // Sub-case 1: unreadable replacement -- the configured path exists but
+    // is a directory, not a regular file, so it genuinely cannot be
+    // *opened/read* as a snapshot at all (unlike an oversized-but-otherwise-
+    // readable file, which fails a size guard instead -- a different
+    // `ticket_key_snapshot.LoadError` class, and not what "unreadable"
+    // means). Deterministic on every supported environment regardless of
+    // permissions or which user/container CI runs the test as, unlike a
     // permission-bit trick that a root/rootless-container CI job can
-    // silently fail to enforce.
+    // silently fail to enforce. The valid snapshot is moved aside and
+    // restored afterward rather than deleted, since deleting the path
+    // outright would also work but is already a distinct, separately
+    // observed condition below (this path both "exists" and "cannot be
+    // consumed", where a missing path only demonstrates the latter).
     {
-        const oversized = try allocator.alloc(u8, tls_core.ticket_key_snapshot.max_snapshot_bytes + 4096);
-        defer allocator.free(oversized);
-        @memset(oversized, 'x');
-        try writeInteropSecretFile(ticket_keys_path, oversized);
+        const backup_path = try std.fmt.allocPrint(allocator, "{s}.bak", .{ticket_keys_path});
+        defer allocator.free(backup_path);
+        try compat.cwd().rename(ticket_keys_path, compat.cwd(), backup_path);
+        // Restores the valid snapshot on every exit path, including a
+        // `MetricThresholdNotReached` bail-out below, so a failure here
+        // doesn't leave the configured path stuck as an empty directory
+        // for whatever runs next.
+        errdefer {
+            compat.cwd().deleteTree(ticket_keys_path) catch {};
+            compat.cwd().rename(backup_path, compat.cwd(), ticket_keys_path) catch {};
+        }
+        try compat.cwd().makePath(ticket_keys_path);
+
+        // On macOS/Linux as built here, `edge_config.validate`'s own
+        // `TARDIGRADE_TLS_NATIVE_TICKET_KEYS_PATH` existence check
+        // (`validateOptionalFileChecked`, an `openFile` that itself
+        // succeeds on a directory) passes, and the rejection actually
+        // happens one layer in, at `ticket_key_snapshot.loadFromFile`'s own
+        // `readFileAlloc` -- which fails to read a directory as file
+        // content -- landing on the ticket-key-specific
+        // `reload_rejected` outcome (and, since every rejection in that
+        // branch of `hotReloadConfig` also calls the shared
+        // `state.metricsRecordReloadFailure()`, the general
+        // `tardigrade_reload_failure_total` counter too, confirmed
+        // together in practice). Checking both rather than assuming either
+        // one keeps this robust against a platform/`std.Io.Dir` version
+        // where the earlier existence check itself rejects a directory
+        // instead.
+        const general_before = blk: {
+            var metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
+            defer metrics.deinit();
+            break :blk prometheusMetricValue(metrics.body, "tardigrade_reload_failure_total") orelse 0;
+        };
+        const ticket_key_before = blk: {
+            var metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
+            defer metrics.deinit();
+            break :blk prometheusLabeledMetricValue(metrics.body, "tardigrade_tls_ticket_key_reload_total", &.{"outcome=\"reload_rejected\""}) orelse 0;
+        };
+        tardigrade.sendSignal(std.posix.SIG.HUP);
+        const deadline = compat.milliTimestamp() + 5_000;
+        while (true) {
+            var metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
+            defer metrics.deinit();
+            const general_after = prometheusMetricValue(metrics.body, "tardigrade_reload_failure_total") orelse 0;
+            const ticket_key_after = prometheusLabeledMetricValue(metrics.body, "tardigrade_tls_ticket_key_reload_total", &.{"outcome=\"reload_rejected\""}) orelse 0;
+            if (general_after >= general_before + 1 or ticket_key_after >= ticket_key_before + 1) break;
+            if (compat.milliTimestamp() >= deadline) return error.MetricThresholdNotReached;
+            compat.sleepNs(25 * std.time.ns_per_ms);
+        }
+
+        compat.cwd().deleteTree(ticket_keys_path) catch {};
+        try compat.cwd().rename(backup_path, compat.cwd(), ticket_keys_path);
     }
-    try rejectSighupAndVerify(allocator, &tardigrade, &ticket0, &clock_dummy);
+    try assertTicket0StillResumes(allocator, tardigrade.port, &ticket0, &clock_dummy);
 
     // Sub-case 2: malformed JSON.
     try writeInteropSecretFile(ticket_keys_path, "{not valid json");

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -7195,8 +7195,9 @@ test "rotation.persistent.n_to_n_plus_1" {
         .{ .name = "TARDIGRADE_TLS_SERVER_NAME", .value = "tardigrade.test" },
         .{ .name = "TARDIGRADE_TLS_NATIVE_RESUMPTION_MODE", .value = "stateless" },
         .{ .name = "TARDIGRADE_TLS_NATIVE_TICKET_KEYS_PATH", .value = ticket_keys_path },
-        .{ .name = "TARDIGRADE_TLS_NATIVE_RESUMPTION_TICKET_LIFETIME_SECONDS", .value = "30" },
+        .{ .name = "TARDIGRADE_TLS_NATIVE_RESUMPTION_TICKET_LIFETIME_SECONDS", .value = "10" },
     };
+    const ticket_lifetime_seconds: i64 = 10;
 
     var tardigrade = try TardigradeProcess.start(allocator, .{
         .config_text = config_text,
@@ -7272,13 +7273,11 @@ test "rotation.persistent.n_to_n_plus_1" {
         },
     });
 
-    // 4: trigger the real production reload path.
+    // 4: trigger the real production reload path. A bounded poll, not a
+    // fixed settle sleep, so a slower-than-usual reload can't race a
+    // fixed-delay assertion.
     tardigrade.sendSignal(std.posix.SIG.HUP);
-    compat.sleepNs(300 * std.time.ns_per_ms);
-
-    var reload_metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
-    defer reload_metrics.deinit();
-    try expectMetricAtLeast(reload_metrics.body, "tardigrade_tls_ticket_key_reload_total", &.{"outcome=\"reload_accepted\""}, 1);
+    try waitForLabeledMetricAtLeast(allocator, tardigrade.port, "tardigrade_tls_ticket_key_reload_total", &.{"outcome=\"reload_accepted\""}, 1, 5_000);
 
     var clock_dummy: u8 = 0;
     const ClientClock = struct {
@@ -7333,6 +7332,128 @@ test "rotation.persistent.n_to_n_plus_1" {
     try std.testing.expectEqualStrings(key_np1_id, &std.fmt.bytesToHex(ids_np1.key_id, .lower));
     try std.testing.expect(!std.mem.eql(u8, &ids_np1.key_id, &ids_n.key_id));
 
+    // `session.issued_at + lifetime` boundary, composed live: a ticket
+    // issued now (under N+1, whose own `decrypt_until` is 60s out --
+    // comfortably past this phase's ~12s span, so the key itself is never
+    // in question here) resumes before the process-wide 10s ticket
+    // lifetime elapses, and falls back to a full handshake once it does.
+    //
+    // `ticket_protection.Protector.resolveInner` checks the decoded
+    // session's own `isExpired(now)` *inside* the resolve/decrypt step
+    // itself (session.zig's expiry, not `evaluateCompatibility`'s), and
+    // `resumption_runtime.resolverResolve` folds every resolve rejection --
+    // expired, not-yet-valid, unknown key, or retired key alike -- into the
+    // same `miss` outcome and `ticket_resolve_total{result="rejected"}`;
+    // there is no separate metrics bucket distinguishing "expired" from
+    // "retired key" today. So attribution here comes from this phase's own
+    // construction, verified concretely rather than merely asserted: N+1's
+    // `decrypt_until` is 60s out (only ~12s will have elapsed), and a fresh
+    // ticket issued immediately after the rejected offer below is asserted
+    // to still be sealed under N+1 -- proof the key itself is still fully
+    // alive and usable, so the preceding rejection cannot have been key
+    // retirement.
+    var capture_np1_lifetime = RotationTicketCapture{ .allocator = allocator };
+    defer capture_np1_lifetime.retained.deinit();
+    {
+        const client = try PureZigTlsClient.createWithOptions(allocator, tardigrade.port, "http/1.1", "tardigrade.test", .{
+            .ticket_consumer = .{ .ctx = &capture_np1_lifetime, .nowUnixMsFn = RotationTicketCapture.now, .onTicketFn = RotationTicketCapture.onTicket },
+        });
+        defer client.destroy();
+        try client.writeAllPlain(openssl_health_request);
+        const raw = try client.readPlainToEnd(allocator, 64 * 1024, 5_000);
+        defer allocator.free(raw);
+        try assertContains(raw, "HTTP/1.1 200 OK");
+    }
+    var ticket_np1_lifetime: tls_core.session.ClientTicketState = .{};
+    defer ticket_np1_lifetime.deinit();
+    try capture_np1_lifetime.retained.cloneInto(allocator, &ticket_np1_lifetime);
+
+    {
+        var offer_clone: tls_core.session.ClientTicketState = .{};
+        defer offer_clone.deinit();
+        try ticket_np1_lifetime.cloneInto(allocator, &offer_clone);
+        var offers: tls_core.pre_shared_key.ClientPskOfferSet = .{};
+        try offers.push(&offer_clone);
+        errdefer offers.deinit();
+        const client = try PureZigTlsClient.createWithOptions(allocator, tardigrade.port, "http/1.1", "tardigrade.test", .{
+            .psk_offers = &offers,
+            .psk_now_ctx = &clock_dummy,
+            .psk_now_fn = ClientClock.now,
+        });
+        defer client.destroy();
+        try std.testing.expect(client.backend.core.psk_authenticated);
+        try client.writeAllPlain(openssl_health_request);
+        const raw = try client.readPlainToEnd(allocator, 64 * 1024, 5_000);
+        defer allocator.free(raw);
+        try assertContains(raw, "HTTP/1.1 200 OK");
+    }
+    const miss_before_expiry = blk: {
+        var metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
+        defer metrics.deinit();
+        break :blk prometheusLabeledMetricValue(metrics.body, "tardigrade_tls_resumption_outcome_total", &.{ "transport=\"record\"", "outcome=\"miss\"" }) orelse 0;
+    };
+
+    // A bounded real sleep past the 10s process-wide ticket lifetime --
+    // there is no injectable clock at this real-process boundary (the same
+    // constraint `interop.openssl.ticket.expired` documents).
+    compat.sleepNs(@as(u64, @intCast(ticket_lifetime_seconds)) * std.time.ns_per_s + 2 * std.time.ns_per_s);
+
+    {
+        var offer_clone: tls_core.session.ClientTicketState = .{};
+        defer offer_clone.deinit();
+        try ticket_np1_lifetime.cloneInto(allocator, &offer_clone);
+        var offers: tls_core.pre_shared_key.ClientPskOfferSet = .{};
+        try offers.push(&offer_clone);
+        errdefer offers.deinit();
+        const client = try PureZigTlsClient.createWithOptions(allocator, tardigrade.port, "http/1.1", "tardigrade.test", .{
+            .psk_offers = &offers,
+            .psk_now_ctx = &clock_dummy,
+            .psk_now_fn = ClientClock.now,
+        });
+        defer client.destroy();
+        // Not selected/binder-verified, same as an auth-binding mismatch:
+        // `selectPsk` skips an ineligible (here: expired) candidate before
+        // ever reaching binder verification.
+        try std.testing.expect(!client.backend.core.psk_authenticated);
+        try client.writeAllPlain(openssl_health_request);
+        const raw = try client.readPlainToEnd(allocator, 64 * 1024, 5_000);
+        defer allocator.free(raw);
+        try assertContains(raw, "HTTP/1.1 200 OK");
+    }
+    var lifetime_metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
+    defer lifetime_metrics.deinit();
+    try std.testing.expect((prometheusLabeledMetricValue(lifetime_metrics.body, "tardigrade_tls_resumption_outcome_total", &.{ "transport=\"record\"", "outcome=\"miss\"" }) orelse 0) > miss_before_expiry);
+
+    // The concrete "not key retirement" proof: N+1 itself is still fully
+    // alive immediately afterward -- a fresh ticket issued right now is
+    // still sealed under N+1's own key id, which could not be true if N+1
+    // had actually been retired.
+    {
+        var capture = RotationTicketCapture{ .allocator = allocator };
+        defer capture.retained.deinit();
+        const client = try PureZigTlsClient.createWithOptions(allocator, tardigrade.port, "http/1.1", "tardigrade.test", .{
+            .ticket_consumer = .{ .ctx = &capture, .nowUnixMsFn = RotationTicketCapture.now, .onTicketFn = RotationTicketCapture.onTicket },
+        });
+        defer client.destroy();
+        try client.writeAllPlain(openssl_health_request);
+        const raw = try client.readPlainToEnd(allocator, 64 * 1024, 5_000);
+        defer allocator.free(raw);
+        try assertContains(raw, "HTTP/1.1 200 OK");
+        const ids = extractTicketEnvelopeIds(&capture.retained);
+        try std.testing.expectEqualStrings(key_np1_id, &std.fmt.bytesToHex(ids.key_id, .lower));
+    }
+
+    // The lifetime-boundary phase above legitimately added one more
+    // `accepted` resumption (the before-expiry offer), so step 7's own
+    // "did this last offer really not resume" check below must compare
+    // against a freshly captured baseline, not the one from step 5's
+    // overlap-window check.
+    const accepted_before_grace_close = blk: {
+        var metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
+        defer metrics.deinit();
+        break :blk prometheusLabeledMetricValue(metrics.body, "tardigrade_tls_resumption_outcome_total", &.{ "transport=\"record\"", "outcome=\"accepted\"" }) orelse 0;
+    };
+
     // 7: wait past N's `decrypt_until` grace boundary, then prove retired N
     // is never used for new encryption *and* no longer resolves at all --
     // composing the live decrypt_until boundary itself, not merely
@@ -7366,7 +7487,94 @@ test "rotation.persistent.n_to_n_plus_1" {
     try expectMetricAtLeast(final_metrics.body, "tardigrade_tls_resumption_outcome_total", &.{ "transport=\"record\"", "outcome=\"miss\"" }, 1);
     // The overlap-window accept count must not have grown from this last,
     // post-grace-window offer -- it really did fall back, not resume again.
-    try std.testing.expectEqual(accepted_during_overlap, prometheusLabeledMetricValue(final_metrics.body, "tardigrade_tls_resumption_outcome_total", &.{ "transport=\"record\"", "outcome=\"accepted\"" }) orelse 0);
+    try std.testing.expectEqual(accepted_before_grace_close, prometheusLabeledMetricValue(final_metrics.body, "tardigrade_tls_resumption_outcome_total", &.{ "transport=\"record\"", "outcome=\"accepted\"" }) orelse 0);
+
+    // `not_before` boundary, composed live: reload to a generation N+2 whose
+    // new key isn't valid *yet* (a short, deterministic future activation
+    // time), while N+1 remains encryption-capable right up to that instant
+    // -- a clean, non-overlapping handoff (N+1's `encrypt_until` set to
+    // exactly N+2's `not_before`), never simultaneously eligible, which
+    // `Snapshot.activeEncryptionKey` would otherwise reject outright as
+    // `AmbiguousActiveEncryptionKey`. Fresh issuance must stay on N+1 before
+    // the boundary, then switch to N+2 once it arrives.
+    const key_np2_id = "c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3";
+    const key_np2_secret = "d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4";
+    // N+1's own nonce-lease window must be *advanced past* its currently
+    // installed one, not merely replayed verbatim (see the doc comment on
+    // step 3 above for the same ledger reasoning) -- the file's currently
+    // declared range *is* the ledger's recorded ceiling for this key id
+    // exactly, so reusing it as-is collides with `OverlappingNonceLease`
+    // just as replaying the stale original range would; only a strictly
+    // later window (the same doubling-by-width advance
+    // `reserveNonceLeasesInFile` itself performs) is accepted. It still
+    // needs to encrypt for a few more seconds here, so (unlike retired N
+    // above) it keeps a lease rather than dropping it.
+    const key_np1_prior_lease = try readTicketKeyLeaseWindow(allocator, ticket_keys_path, key_np1_id);
+    const key_np1_lease_width = key_np1_prior_lease.end_exclusive - key_np1_prior_lease.start;
+    const key_np1_advanced_lease_start = key_np1_prior_lease.end_exclusive;
+    const key_np1_advanced_lease_end = key_np1_prior_lease.end_exclusive + key_np1_lease_width;
+    const gen3_now = compat.milliTimestamp();
+    const not_before_boundary_ms: i64 = gen3_now + 4_000;
+    const reload_accepted_before_gen3 = blk: {
+        var metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
+        defer metrics.deinit();
+        break :blk prometheusLabeledMetricValue(metrics.body, "tardigrade_tls_ticket_key_reload_total", &.{"outcome=\"reload_accepted\""}) orelse 0;
+    };
+    try writePersistentTicketKeySnapshotKeys(allocator, ticket_keys_path, 3, &.{
+        .{
+            .id_hex = key_np1_id,
+            .key_hex = key_np1_secret,
+            .not_before_unix_ms = gen2_now - 100,
+            .encrypt_until_unix_ms = not_before_boundary_ms,
+            .decrypt_until_unix_ms = not_before_boundary_ms + 120_000,
+            .nonce_lease = .{ .prefix_hex = "f4000000", .start = key_np1_advanced_lease_start, .end_exclusive = key_np1_advanced_lease_end },
+        },
+        .{
+            .id_hex = key_np2_id,
+            .key_hex = key_np2_secret,
+            .not_before_unix_ms = not_before_boundary_ms,
+            .encrypt_until_unix_ms = not_before_boundary_ms + 120_000,
+            .decrypt_until_unix_ms = not_before_boundary_ms + 120_000,
+            .nonce_lease = .{ .prefix_hex = "f5000000", .start = 0, .end_exclusive = 1_000_000 },
+        },
+    });
+    tardigrade.sendSignal(std.posix.SIG.HUP);
+    try waitForLabeledMetricAtLeast(allocator, tardigrade.port, "tardigrade_tls_ticket_key_reload_total", &.{"outcome=\"reload_accepted\""}, reload_accepted_before_gen3 + 1, 5_000);
+
+    // Before the boundary: fresh issuance is still N+1.
+    {
+        var capture = RotationTicketCapture{ .allocator = allocator };
+        defer capture.retained.deinit();
+        const client = try PureZigTlsClient.createWithOptions(allocator, tardigrade.port, "http/1.1", "tardigrade.test", .{
+            .ticket_consumer = .{ .ctx = &capture, .nowUnixMsFn = RotationTicketCapture.now, .onTicketFn = RotationTicketCapture.onTicket },
+        });
+        defer client.destroy();
+        try client.writeAllPlain(openssl_health_request);
+        const raw = try client.readPlainToEnd(allocator, 64 * 1024, 5_000);
+        defer allocator.free(raw);
+        try assertContains(raw, "HTTP/1.1 200 OK");
+        const ids = extractTicketEnvelopeIds(&capture.retained);
+        try std.testing.expectEqualStrings(key_np1_id, &std.fmt.bytesToHex(ids.key_id, .lower));
+    }
+
+    // A bounded real sleep past N+2's `not_before` boundary.
+    compat.sleepNs(4_500 * std.time.ns_per_ms);
+
+    // After the boundary: fresh issuance has switched to N+2.
+    {
+        var capture = RotationTicketCapture{ .allocator = allocator };
+        defer capture.retained.deinit();
+        const client = try PureZigTlsClient.createWithOptions(allocator, tardigrade.port, "http/1.1", "tardigrade.test", .{
+            .ticket_consumer = .{ .ctx = &capture, .nowUnixMsFn = RotationTicketCapture.now, .onTicketFn = RotationTicketCapture.onTicket },
+        });
+        defer client.destroy();
+        try client.writeAllPlain(openssl_health_request);
+        const raw = try client.readPlainToEnd(allocator, 64 * 1024, 5_000);
+        defer allocator.free(raw);
+        try assertContains(raw, "HTTP/1.1 200 OK");
+        const ids = extractTicketEnvelopeIds(&capture.retained);
+        try std.testing.expectEqualStrings(key_np2_id, &std.fmt.bytesToHex(ids.key_id, .lower));
+    }
 }
 
 // #519: representative failure classes for a SIGHUP reload attempt against
@@ -7388,17 +7596,19 @@ test "rotation.persistent.n_to_n_plus_1" {
 // held in `appliance_identity`) is loaded once at startup and never touched
 // by `hotReloadConfig` at all -- the `native_credentials`/`NativeCredentialStore`
 // two-phase prepare/commit path this criterion originally had in mind is
-// wired up only for the non-appliance code path (`native_tls_provider`/
-// `h3_credential_provider` construction in `edge_gateway.zig` explicitly
-// branches on `edge_config.is_appliance_tls_profile`), so it is never
-// reachable here. `rotation.persistent.certificate_binding_change` below
-// proves the credential side of this instead, through the restart
-// composition the appliance profile *does* support for credential changes.
-// What this test still demonstrates, honestly: every sub-case below leaves
-// `ticket0` (bound to the one credential this process ever serves)
-// resuming successfully, so the previous certificate credential and the
-// previous ticket state both visibly survive every rejected reload here,
-// even though none of these attempts ever touches the credential itself.
+// wired up only for the non-appliance (general) profile, and there only for
+// QUIC/H3 (`edge_gateway.zig`'s `if (build_options.tls_openssl_adapter and
+// cfg.http3_enabled ...)`), so it is never reachable here regardless of
+// what this test attempts. `rotation.persistent.quic_credential_reload_
+// atomicity` below exercises that real path instead, over a real external
+// QUIC peer; `rotation.persistent.certificate_binding_change` proves the
+// credential-binding side of this through the restart composition the
+// appliance profile does support. What this test still demonstrates,
+// honestly: every sub-case below leaves `ticket0` (bound to the one
+// credential this process ever serves) resuming successfully, so the
+// previous certificate credential and the previous ticket state both
+// visibly survive every rejected reload here, even though none of these
+// attempts ever touches the credential itself.
 test "rotation.persistent.failed_reload_keeps_old_state" {
     try requireNativeTlsProfile();
     const allocator = std.testing.allocator;
@@ -7529,61 +7739,47 @@ test "rotation.persistent.failed_reload_keeps_old_state" {
         }
     }.run;
 
-    // Sub-case 1: unreadable replacement -- every permission bit stripped
-    // from the file at the configured path (it still *exists*; deleting it
-    // outright is a different, *earlier* rejection -- see below). Modeled
-    // after "a post-validation runtime failure is not misreported as a
-    // configuration error" above: a probe open after `chmod` confirms the
-    // permission bit is actually enforced before relying on it (some CI
-    // containers run as root, where it silently is not), skipping only this
-    // sub-case's own assertion -- not the rest of this test -- when it
-    // isn't.
-    //
-    // This rejection actually surfaces one layer earlier than the other
-    // three sub-cases below: `edge_config.validate`'s own
-    // `TARDIGRADE_TLS_NATIVE_TICKET_KEYS_PATH` existence check
-    // (`validateOptionalFileChecked`) itself calls `openFile`, which fails
-    // identically for "does not exist" and "exists but unreadable" -- so an
-    // unreadable replacement is rejected by general config validation
-    // before `hotReloadConfig` ever reaches the ticket-key-specific load
-    // step, and is recorded on the general `tardigrade_reload_failure_total`
-    // counter rather than `tardigrade_tls_ticket_key_reload_total`. Still a
-    // bounded, secret-free failure outcome that leaves the previous
-    // keyring/config active, which is what this sub-case actually needs to
-    // prove.
-    const ticket_keys_path_z = try std.fmt.allocPrintSentinel(allocator, "{s}", .{ticket_keys_path}, 0);
-    defer allocator.free(ticket_keys_path_z);
-    try std.testing.expectEqual(@as(c_int, 0), std.c.chmod(ticket_keys_path_z.ptr, 0o000));
-    const permission_enforced = if (compat.cwd().openFile(ticket_keys_path, .{})) |f| blk: {
-        var file = f;
-        file.close();
-        break :blk false;
-    } else |_| true;
-    const failure_count_before_subcase1 = blk: {
-        var metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
-        defer metrics.deinit();
-        break :blk prometheusMetricValue(metrics.body, "tardigrade_reload_failure_total") orelse 0;
-    };
-    tardigrade.sendSignal(std.posix.SIG.HUP);
-    compat.sleepNs(300 * std.time.ns_per_ms);
-    if (permission_enforced) {
-        var metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
-        defer metrics.deinit();
-        try std.testing.expect((prometheusMetricValue(metrics.body, "tardigrade_reload_failure_total") orelse 0) >= failure_count_before_subcase1 + 1);
+    // Captures the labeled `reload_rejected` counter, sends SIGHUP, then
+    // requires the counter to have advanced by at least one *from that
+    // captured baseline* (a bounded poll, not a fixed settle sleep) before
+    // asserting `ticket0` still resumes. Per-attempt, not cumulative: an
+    // earlier sub-case's rejection can never mask a later sub-case that
+    // silently fails to reject (a fixed `>= 1` against the running total
+    // would not catch that, since it would already be satisfied).
+    const rejectSighupAndVerify = struct {
+        fn run(alloc: std.mem.Allocator, proc: *TardigradeProcess, ticket: *const tls_core.session.ClientTicketState, now_ctx: *u8) !void {
+            const before = blk: {
+                var metrics = try sendPureZigTlsHttp1Request(alloc, proc.port, "/status/metrics");
+                defer metrics.deinit();
+                break :blk prometheusLabeledMetricValue(metrics.body, "tardigrade_tls_ticket_key_reload_total", &.{"outcome=\"reload_rejected\""}) orelse 0;
+            };
+            proc.sendSignal(std.posix.SIG.HUP);
+            try waitForLabeledMetricAtLeast(alloc, proc.port, "tardigrade_tls_ticket_key_reload_total", &.{"outcome=\"reload_rejected\""}, before + 1, 5_000);
+            try assertTicket0StillResumes(alloc, proc.port, ticket, now_ctx);
+        }
+    }.run;
+
+    // Sub-case 1: unreadable replacement -- a file that exists (so
+    // `edge_config.validate`'s own `TARDIGRADE_TLS_NATIVE_TICKET_KEYS_PATH`
+    // existence check, which merely opens the path, passes) but exceeds
+    // `ticket_key_snapshot.max_snapshot_bytes` (64 KiB), so
+    // `ticket_key_snapshot.loadFromFile`'s own bounded `readFileAlloc`
+    // fails with `error.FileTooBig` -> `SnapshotTooLarge` regardless of
+    // filesystem permissions or which user/container CI runs the test as
+    // -- deterministic on every supported environment, unlike a
+    // permission-bit trick that a root/rootless-container CI job can
+    // silently fail to enforce.
+    {
+        const oversized = try allocator.alloc(u8, tls_core.ticket_key_snapshot.max_snapshot_bytes + 4096);
+        defer allocator.free(oversized);
+        @memset(oversized, 'x');
+        try writeInteropSecretFile(ticket_keys_path, oversized);
     }
-    _ = std.c.chmod(ticket_keys_path_z.ptr, 0o600);
-    try assertTicket0StillResumes(allocator, tardigrade.port, &ticket0, &clock_dummy);
+    try rejectSighupAndVerify(allocator, &tardigrade, &ticket0, &clock_dummy);
 
     // Sub-case 2: malformed JSON.
     try writeInteropSecretFile(ticket_keys_path, "{not valid json");
-    tardigrade.sendSignal(std.posix.SIG.HUP);
-    compat.sleepNs(300 * std.time.ns_per_ms);
-    {
-        var metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
-        defer metrics.deinit();
-        try expectMetricAtLeast(metrics.body, "tardigrade_tls_ticket_key_reload_total", &.{"outcome=\"reload_rejected\""}, 1);
-    }
-    try assertTicket0StillResumes(allocator, tardigrade.port, &ticket0, &clock_dummy);
+    try rejectSighupAndVerify(allocator, &tardigrade, &ticket0, &clock_dummy);
 
     // Sub-case 3: semantically invalid keyring -- an otherwise well-formed
     // key with an invalid nonce lease (`start >= end_exclusive`), rejected
@@ -7598,14 +7794,7 @@ test "rotation.persistent.failed_reload_keeps_old_state" {
             .nonce_lease = .{ .prefix_hex = "11110000", .start = 100, .end_exclusive = 100 },
         },
     });
-    tardigrade.sendSignal(std.posix.SIG.HUP);
-    compat.sleepNs(300 * std.time.ns_per_ms);
-    {
-        var metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
-        defer metrics.deinit();
-        try expectMetricAtLeast(metrics.body, "tardigrade_tls_ticket_key_reload_total", &.{"outcome=\"reload_rejected\""}, 1);
-    }
-    try assertTicket0StillResumes(allocator, tardigrade.port, &ticket0, &clock_dummy);
+    try rejectSighupAndVerify(allocator, &tardigrade, &ticket0, &clock_dummy);
 
     // Sub-case 4: stale generation -- otherwise identical, valid key
     // content, but a generation number not newer than the currently
@@ -7624,14 +7813,7 @@ test "rotation.persistent.failed_reload_keeps_old_state" {
             .nonce_lease = .{ .prefix_hex = "11110000", .start = 0, .end_exclusive = 1_000_000 },
         },
     });
-    tardigrade.sendSignal(std.posix.SIG.HUP);
-    compat.sleepNs(300 * std.time.ns_per_ms);
-    {
-        var metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
-        defer metrics.deinit();
-        try expectMetricAtLeast(metrics.body, "tardigrade_tls_ticket_key_reload_total", &.{"outcome=\"reload_rejected\""}, 1);
-    }
-    try assertTicket0StillResumes(allocator, tardigrade.port, &ticket0, &clock_dummy);
+    try rejectSighupAndVerify(allocator, &tardigrade, &ticket0, &clock_dummy);
 
     // After four rejected attempts, a *freshly issued* ticket must still be
     // sealed under the original key id -- proof that nothing was partially
@@ -7813,6 +7995,164 @@ test "rotation.persistent.certificate_binding_change" {
     // The ticket-resolve layer (key lookup + decrypt) genuinely succeeded --
     // ruling out "unknown key"/decryption failure as the actual cause.
     try expectMetricAtLeast(metrics.body, "tardigrade_tls_ticket_resolve_total", &.{ "mode=\"stateless\"", "result=\"success\"" }, 1);
+}
+
+// #519: the general-profile counterpart to `rotation.persistent.failed_
+// reload_keeps_old_state` above, exercising the two-phase credential
+// prepare/commit path that test's own doc comment explains is unreachable
+// under the appliance profile. `edge_gateway.zig` only constructs
+// `native_credentials` (`http.native_tls_connection.NativeCredentialStore`)
+// under the *general* profile (`build_options.tls_openssl_adapter`), and
+// only for QUIC/H3 (`if (build_options.tls_openssl_adapter and
+// cfg.http3_enabled and edge_config.hasTlsFiles(cfg))`) -- TCP/H1 under the
+// general profile always serves through the OpenSSL-adapter
+// `TlsTerminator` instead, which owns its own independent session
+// cache/tickets and never touches `native_resumption_runtime` or persistent
+// ticket keys at all. So this composed proof necessarily drives real
+// QUIC/H3 (the same `gtlsclient` subprocess harness `h3interop.quic.*`
+// above uses), not TCP.
+//
+// Bundles a credential swap with a broken ticket-key candidate in the same
+// SIGHUP: `gateway_shutdown.hotReloadConfig` calls
+// `native_credentials.prepareReloadFromFiles` (which genuinely reads and
+// validates credential B here, since the general profile has no appliance-
+// only path/name credential-change guard to reject it first) *before* the
+// ticket-key reload step, but only calls `commitPreparedReload` *after* it
+// succeeds. The ticket-key step here is made to fail, so the prepared
+// credential B is discarded (via `hotReloadConfig`'s own `defer`) and the
+// live provider never sees it.
+//
+// Verifies, against the real external ngtcp2/GnuTLS peer, not merely
+// Tardigrade's own report of itself: (1) the previous ticket state is
+// still live -- offering the pre-reload session/ticket resumes
+// authoritatively (the peer's own decrypted Handshake CRYPTO trace, via
+// `assertGtlsSessionReused`) -- and (2) that resumption could only succeed
+// if the served certificate is still credential A: a resumed connection's
+// auth-binding check compares the ticket's stored binding against
+// whichever credential the server is *actually* serving (see
+// `rotation.persistent.certificate_binding_change` above for the same
+// mechanism proven directly), so credential B having been silently
+// committed would make this same offer fail to resume instead. Verifying
+// the served certificate fingerprint by an independent, direct channel
+// (e.g. inspecting the peer's own certificate chain) is not attempted here
+// -- `gtlsclient` (`tests/h3_interop_tool.zig`) does not currently expose
+// the negotiated leaf certificate, only handshake CRYPTO bytes and the
+// resumption/early-data outcome -- so this is the honest scope: the
+// credential-unchanged claim is verified through the same auth-binding
+// mechanism, not a second, independent proof.
+test "rotation.persistent.quic_credential_reload_atomicity" {
+    try requireGeneralTlsProfile();
+    const allocator = std.testing.allocator;
+    try requireOpensslEd25519(allocator);
+    const client_path = try requireNgtcp2Client(allocator);
+    defer allocator.free(client_path);
+
+    var cred_a = try generateAlternateServerCert(allocator, quic_interop_server_name);
+    defer cred_a.deinit();
+    var cred_b = try generateAlternateServerCert(allocator, quic_interop_server_name);
+    defer cred_b.deinit();
+    const sni_certs = try quicSniCertsEnv(allocator, cred_a.cert_path, cred_a.key_path);
+    defer allocator.free(sni_certs);
+
+    const key_path_probe_port = try findFreePort();
+    const ticket_keys_path = try persistentTicketKeySnapshotPath(allocator, key_path_probe_port, "persistent-quic-reload-atomicity");
+    defer allocator.free(ticket_keys_path);
+    defer compat.cwd().deleteFile(ticket_keys_path) catch {};
+    defer {
+        const lock_path = std.fmt.allocPrint(allocator, "{s}.lock", .{ticket_keys_path}) catch null;
+        if (lock_path) |path| {
+            compat.cwd().deleteFile(path) catch {};
+            allocator.free(path);
+        }
+    }
+    try writePersistentTicketKeySnapshot(allocator, ticket_keys_path);
+
+    const config_text =
+        \\location = /healthz {
+        \\    return 200 alive;
+        \\}
+    ;
+    const quic_port = try findFreeUdpPort();
+    const quic_port_str = try std.fmt.allocPrint(allocator, "{d}", .{quic_port});
+    defer allocator.free(quic_port_str);
+
+    var tardigrade = try TardigradeProcess.start(allocator, .{
+        .config_text = config_text,
+        .ready_https_insecure = true,
+        .ready_path = "/healthz",
+        .extra_env = &.{
+            .{ .name = "TARDIGRADE_TLS_CERT_PATH", .value = cred_a.cert_path },
+            .{ .name = "TARDIGRADE_TLS_KEY_PATH", .value = cred_a.key_path },
+            .{ .name = "TARDIGRADE_TLS_SERVER_NAME", .value = quic_interop_server_name },
+            .{ .name = "TARDIGRADE_TLS_SNI_CERTS", .value = sni_certs },
+            .{ .name = "TARDIGRADE_TLS_NATIVE_RESUMPTION_MODE", .value = "stateless" },
+            .{ .name = "TARDIGRADE_TLS_NATIVE_TICKET_KEYS_PATH", .value = ticket_keys_path },
+            .{ .name = "TARDIGRADE_HTTP3_ENABLED", .value = "true" },
+            .{ .name = "TARDIGRADE_QUIC_PORT", .value = quic_port_str },
+        },
+    });
+    defer tardigrade.stop();
+
+    const sess_path = try ngtcp2SessionPath(allocator, quic_port, "cred-reload-atomicity");
+    defer allocator.free(sess_path);
+    defer compat.cwd().deleteFile(sess_path) catch {};
+    const tp_path = try ngtcp2TpPath(allocator, quic_port, "cred-reload-atomicity");
+    defer allocator.free(tp_path);
+    defer compat.cwd().deleteFile(tp_path) catch {};
+
+    // 1: a real full QUIC/TLS 1.3 handshake under credential A, persistent
+    // ticket-key-protected resumption state captured to disk.
+    var first = try runGtlsClient(allocator, client_path, .{
+        .quic_port = quic_port,
+        .path = "/healthz",
+        .session_file = sess_path,
+        .tp_file = tp_path,
+        .wait_for_ticket = true,
+    });
+    defer first.deinit(allocator);
+    try std.testing.expectEqual(std.meta.Tag(bounded_process.Outcome).normal_exit, std.meta.activeTag(first.outcome));
+    try assertContains(first.stderr, "[:status: 200]");
+
+    // 2: swap the served credential's file *content* at its unchanged path
+    // (the general profile has no path/name credential-change guard to
+    // reject this reload outright the way the appliance profile's
+    // `applianceCredentialConfigChanged` would) together with a broken
+    // ticket-key candidate, in one SIGHUP.
+    {
+        const cert_bytes = try compat.cwd().readFileAlloc(allocator, cred_b.cert_path, 64 * 1024);
+        defer allocator.free(cert_bytes);
+        try compat.cwd().writeFile(.{ .sub_path = cred_a.cert_path, .data = cert_bytes });
+        const key_bytes = try compat.cwd().readFileAlloc(allocator, cred_b.key_path, 64 * 1024);
+        defer {
+            std.crypto.secureZero(u8, key_bytes);
+            allocator.free(key_bytes);
+        }
+        try compat.cwd().writeFile(.{ .sub_path = cred_a.key_path, .data = key_bytes });
+    }
+    try writeInteropSecretFile(ticket_keys_path, "{not valid json");
+    tardigrade.sendSignal(std.posix.SIG.HUP);
+    try waitForLabeledMetricAtLeast(allocator, tardigrade.port, "tardigrade_tls_ticket_key_reload_total", &.{"outcome=\"reload_rejected\""}, 1, 5_000);
+
+    // 3: reconnect with the pre-reload session/ticket. A real resumed
+    // connection here is only possible if both the ticket state *and* the
+    // served credential are still what they were before the rejected
+    // reload attempt.
+    var second = try runGtlsClient(allocator, client_path, .{
+        .quic_port = quic_port,
+        .path = "/healthz",
+        .session_file = sess_path,
+        .tp_file = tp_path,
+        .disable_early_data = true,
+    });
+    defer second.deinit(allocator);
+    try std.testing.expectEqual(std.meta.Tag(bounded_process.Outcome).normal_exit, std.meta.activeTag(second.outcome));
+    try assertContains(second.stderr, "[:status: 200]");
+    try assertGtlsSessionReused(allocator, second.stderr);
+
+    var metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
+    defer metrics.deinit();
+    try expectMetricAtLeast(metrics.body, "tardigrade_tls_resumption_outcome_total", &.{ "transport=\"quic\"", "outcome=\"accepted\"" }, 1);
+    try std.testing.expectEqual(@as(u64, 0), prometheusLabeledMetricValue(metrics.body, "tardigrade_tls_resumption_outcome_total", &.{ "transport=\"quic\"", "outcome=\"incompatible\"" }) orelse 0);
 }
 
 /// #369: `TARDIGRADE_SOAK_HEAVY=1` scales `soak.reconnect_resumption` up
@@ -12442,6 +12782,35 @@ fn waitForMetricAtLeast(
         };
         defer metrics.deinit();
         if (prometheusMetricValue(metrics.body, name)) |value| {
+            if (value >= minimum) return;
+        }
+        compat.sleepNs(25 * std.time.ns_per_ms);
+    }
+    return error.MetricThresholdNotReached;
+}
+
+/// #519: like `waitForMetricAtLeast`, but for a *labeled* Prometheus metric
+/// (`prometheusLabeledMetricValue`) and over the real native TLS listener
+/// (`sendPureZigTlsHttp1Request`) rather than a plaintext port -- every
+/// `rotation.persistent.*` SIGHUP case polls this instead of a fixed settle
+/// sleep, so a slower-than-usual reload can't race a fixed-delay assertion
+/// into a false pass or a false failure.
+fn waitForLabeledMetricAtLeast(
+    allocator: std.mem.Allocator,
+    port: u16,
+    name: []const u8,
+    labels: []const []const u8,
+    minimum: u64,
+    timeout_ms: u64,
+) !void {
+    const deadline = compat.milliTimestamp() + @as(i64, @intCast(timeout_ms));
+    while (compat.milliTimestamp() < deadline) {
+        var metrics = sendPureZigTlsHttp1Request(allocator, port, "/status/metrics") catch {
+            compat.sleepNs(25 * std.time.ns_per_ms);
+            continue;
+        };
+        defer metrics.deinit();
+        if (prometheusLabeledMetricValue(metrics.body, name, labels)) |value| {
             if (value >= minimum) return;
         }
         compat.sleepNs(25 * std.time.ns_per_ms);

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -6112,6 +6112,7 @@ fn assertHexAbsentCaseInsensitive(allocator: std.mem.Allocator, haystack: []cons
 }
 
 const persistent_ticket_key_fixture_hex = "101112131415161718191a1b1c1d1e1f";
+const persistent_ticket_key_fixture_id_hex = "000102030405060708090a0b0c0d0e0f";
 
 fn persistentTicketKeySnapshotPath(allocator: std.mem.Allocator, port: u16, tag: []const u8) ![]u8 {
     const dir = try interopSecretsDir(allocator);
@@ -6131,6 +6132,129 @@ fn writePersistentTicketKeySnapshot(allocator: std.mem.Allocator, path: []const 
         allocator.free(snapshot);
     }
     try writeInteropSecretFile(path, snapshot);
+}
+
+/// #519: one key entry for a hand-built multi-key persistent snapshot file
+/// (`writePersistentTicketKeySnapshotKeys`), used where the fixed single-key
+/// `writePersistentTicketKeySnapshot` above (generation 1, one wide-open
+/// validity window) can't express what a test needs: distinct not_before/
+/// encrypt_until/decrypt_until windows per key (rotation overlap), or a
+/// deliberately invalid nonce lease (failed-reload coverage).
+const TicketKeyLeaseFixture = struct {
+    prefix_hex: []const u8,
+    start: u64,
+    end_exclusive: u64,
+};
+
+const TicketKeyFixture = struct {
+    id_hex: []const u8,
+    key_hex: []const u8,
+    not_before_unix_ms: i64,
+    encrypt_until_unix_ms: i64,
+    decrypt_until_unix_ms: i64,
+    // `null` for a key that must never encrypt again (a retiring key
+    // carried forward into a new generation decrypt-only, its
+    // `encrypt_until` already in the past): `ReloadableKeyRing`'s per-key-id
+    // ledger records the *full declared width* of every nonce lease a key
+    // was ever installed with as that key's permanent high-water mark, not
+    // merely how far its counter actually advanced -- so replaying the same
+    // (or any non-advanced) lease range for a key that already used it in a
+    // prior generation is rejected as `OverlappingNonceLease`, even though
+    // it is the very same key, unchanged. A retiring key has no need to
+    // encrypt again, so it needs no lease at all; this is exactly the shape
+    // `persistentKeyConfig(&key_n, ..., null)` uses for the rotated-out key
+    // in `resumption_runtime.zig`'s own "#512 ... rotates, and retires old
+    // tickets" unit test.
+    nonce_lease: ?TicketKeyLeaseFixture = null,
+};
+
+fn writePersistentTicketKeySnapshotKeys(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    generation: u64,
+    keys: []const TicketKeyFixture,
+) !void {
+    var out = std.array_list.Managed(u8).init(allocator);
+    defer {
+        std.crypto.secureZero(u8, out.items);
+        out.deinit();
+    }
+    try out.print("{{\"version\":1,\"generation\":{d},\"keys\":[", .{generation});
+    for (keys, 0..) |k, i| {
+        if (i > 0) try out.append(',');
+        try out.print(
+            "{{\"id\":\"{s}\",\"aead\":\"aes_128_gcm\",\"key\":\"{s}\",\"not_before_unix_ms\":{d},\"encrypt_until_unix_ms\":{d},\"decrypt_until_unix_ms\":{d}",
+            .{ k.id_hex, k.key_hex, k.not_before_unix_ms, k.encrypt_until_unix_ms, k.decrypt_until_unix_ms },
+        );
+        if (k.nonce_lease) |lease| {
+            try out.print(
+                ",\"nonce_lease\":{{\"prefix\":\"{s}\",\"start\":{d},\"end_exclusive\":{d}}}",
+                .{ lease.prefix_hex, lease.start, lease.end_exclusive },
+            );
+        }
+        try out.append('}');
+    }
+    try out.appendSlice("]}");
+    try writeInteropSecretFile(path, out.items);
+}
+
+/// #519: the durable, file-backed lease window `reserveNonceLeasesInFile`
+/// (`ticket_key_snapshot.zig`) advances on every accepted startup/reload --
+/// read back here, by key id, so `restart.persistent.ticket_survives` can
+/// assert two independent process incarnations actually reserved disjoint
+/// windows from the same on-disk file, rather than merely asserting each
+/// process *worked*.
+const LeaseWindow = struct { generation: u64, start: u64, end_exclusive: u64 };
+
+fn readTicketKeyLeaseWindow(allocator: std.mem.Allocator, path: []const u8, id_hex: []const u8) !LeaseWindow {
+    const bytes = try compat.cwd().readFileAlloc(allocator, path, 64 * 1024);
+    defer {
+        std.crypto.secureZero(u8, bytes);
+        allocator.free(bytes);
+    }
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, bytes, .{});
+    defer parsed.deinit();
+    const root = parsed.value.object;
+    const generation: u64 = @intCast(root.get("generation").?.integer);
+    const keys = root.get("keys").?.array.items;
+    for (keys) |key_value| {
+        const key_obj = key_value.object;
+        const id = (key_obj.get("id") orelse continue).string;
+        if (!std.ascii.eqlIgnoreCase(id, id_hex)) continue;
+        const lease = (key_obj.get("nonce_lease") orelse continue).object;
+        return .{
+            .generation = generation,
+            .start = @intCast(lease.get("start").?.integer),
+            .end_exclusive = @intCast(lease.get("end_exclusive").?.integer),
+        };
+    }
+    return error.KeyIdNotFound;
+}
+
+/// #519: `ticket_protection.parseEnvelope`'s own fixed field offsets (magic
+/// [0..4], version[4], aead[5], reserved[6..8], key_id[8..24], nonce
+/// [24..36]) applied directly to a captured `ClientTicketState.ticket`'s raw
+/// bytes -- the same public, non-secret envelope metadata
+/// `tamperOpensslTicketFile` above locates by magic search, not the AEAD
+/// ciphertext/tag that follows it. Used to prove restart/rotation lease
+/// disjointness at the (key_id, nonce) granularity #519 asks for, without
+/// ever inspecting the encrypted session state itself.
+// `ticket_protection.zig`'s internal `provider.aead_nonce_len` (12, for the
+// `aes_128_gcm` suite every fixture in this file uses) isn't re-exported
+// through `tls_core`; the envelope's fixed field width is stable regardless.
+const ticket_nonce_len = 12;
+
+const TicketEnvelopeIds = struct {
+    key_id: [tls_core.ticket_protection.key_id_len]u8,
+    nonce: [ticket_nonce_len]u8,
+};
+
+fn extractTicketEnvelopeIds(ticket: *const tls_core.session.ClientTicketState) TicketEnvelopeIds {
+    const raw = ticket.ticket.slice();
+    var out: TicketEnvelopeIds = undefined;
+    @memcpy(&out.key_id, raw[8..24]);
+    @memcpy(&out.nonce, raw[24..36]);
+    return out;
 }
 
 /// #369: flips one byte inside the opaque ticket envelope of an
@@ -6811,6 +6935,884 @@ test "restart.restart_and_credential_change.ticket_rejected" {
         "transport=\"record\"",
         "outcome=\"accepted\"",
     }) orelse 0);
+}
+
+// #519: the composed production proof `restart.persistent.early_startup_
+// quarantine` (#513/#369) does not cover -- that test only proves the
+// *quarantine* boundary survives a restart. This proves the persistent
+// ticket-key policy's actual headline guarantee: a real process restart,
+// against the same on-disk snapshot with *no manual lease editing*, both
+// preserves an already-issued ticket's resumability and durably reserves a
+// disjoint nonce-lease window before the fresh process ever issues its own
+// ticket -- so the two processes can never emit a colliding (key_id, nonce)
+// AEAD nonce for the same key, even though both share the identical
+// long-lived secret key material.
+test "restart.persistent.ticket_survives" {
+    try requireNativeTlsProfile();
+    const allocator = std.testing.allocator;
+
+    var tls_paths = try nativeTlsFixturePaths(allocator);
+    defer tls_paths.deinit();
+
+    const key_path_probe_port = try findFreePort();
+    const ticket_keys_path = try persistentTicketKeySnapshotPath(allocator, key_path_probe_port, "persistent-restart-survives");
+    defer allocator.free(ticket_keys_path);
+    defer compat.cwd().deleteFile(ticket_keys_path) catch {};
+    defer {
+        const lock_path = std.fmt.allocPrint(allocator, "{s}.lock", .{ticket_keys_path}) catch null;
+        if (lock_path) |path| {
+            compat.cwd().deleteFile(path) catch {};
+            allocator.free(path);
+        }
+    }
+    try writePersistentTicketKeySnapshot(allocator, ticket_keys_path);
+
+    const config_text =
+        \\location = /healthz {
+        \\    return 200 alive;
+        \\}
+    ;
+    const extra_env = &[_]EnvPair{
+        .{ .name = "TARDIGRADE_TLS_CERT_PATH", .value = tls_paths.cert_path },
+        .{ .name = "TARDIGRADE_TLS_KEY_PATH", .value = tls_paths.key_path },
+        .{ .name = "TARDIGRADE_TLS_SERVER_NAME", .value = "tardigrade.test" },
+        .{ .name = "TARDIGRADE_TLS_NATIVE_RESUMPTION_MODE", .value = "stateless" },
+        .{ .name = "TARDIGRADE_TLS_NATIVE_TICKET_KEYS_PATH", .value = ticket_keys_path },
+    };
+
+    // Ground truth before any process exists: `writePersistentTicketKeySnapshot`'s
+    // own fixture lease window (see its literal above).
+    const before_any_start = try readTicketKeyLeaseWindow(allocator, ticket_keys_path, persistent_ticket_key_fixture_id_hex);
+    try std.testing.expectEqual(@as(u64, 0), before_any_start.start);
+    try std.testing.expectEqual(@as(u64, 4096), before_any_start.end_exclusive);
+
+    // 2: start process A. Startup alone (`loadPersistentTicketKeysFromFile`,
+    // reached because no fingerprint is installed yet) durably reserves A's
+    // issuance lease in the file before any connection exists.
+    var process_a = try TardigradeProcess.start(allocator, .{
+        .config_text = config_text,
+        .ready_https_insecure = true,
+        .ready_path = "/healthz",
+        .extra_env = extra_env,
+    });
+    var process_a_running = true;
+    defer if (process_a_running) process_a.stop();
+
+    const after_a_start = try readTicketKeyLeaseWindow(allocator, ticket_keys_path, persistent_ticket_key_fixture_id_hex);
+    try std.testing.expectEqual(before_any_start.end_exclusive, after_a_start.start);
+    try std.testing.expect(after_a_start.end_exclusive > after_a_start.start);
+
+    // 2 (continued): issue a real stateless ticket from A, capturing only
+    // the public envelope metadata (key id, nonce) #519 asks for -- never
+    // the AEAD ciphertext/tag, and never logged.
+    const TicketCapture = struct {
+        allocator: std.mem.Allocator,
+        retained: tls_core.session.ClientTicketState = .{},
+
+        fn now(_: *anyopaque) i64 {
+            return 2_000;
+        }
+
+        fn onTicket(ctx: *anyopaque, ticket: *const tls_core.session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.retained.deinit();
+            self.retained = .{};
+            ticket.cloneInto(self.allocator, &self.retained) catch unreachable;
+        }
+    };
+
+    var capture_a = TicketCapture{ .allocator = allocator };
+    defer capture_a.retained.deinit();
+
+    const client_a = try PureZigTlsClient.createWithOptions(allocator, process_a.port, "http/1.1", "tardigrade.test", .{
+        .ticket_consumer = .{
+            .ctx = &capture_a,
+            .nowUnixMsFn = TicketCapture.now,
+            .onTicketFn = TicketCapture.onTicket,
+        },
+    });
+    defer client_a.destroy();
+    try client_a.writeAllPlain(openssl_health_request);
+    const a_raw = try client_a.readPlainToEnd(allocator, 64 * 1024, 5_000);
+    defer allocator.free(a_raw);
+    try assertContains(a_raw, "HTTP/1.1 200 OK");
+    try std.testing.expect(capture_a.retained.ticket.slice().len > 0);
+
+    var ticket_a: tls_core.session.ClientTicketState = .{};
+    defer ticket_a.deinit();
+    try capture_a.retained.cloneInto(allocator, &ticket_a);
+    const ids_a = extractTicketEnvelopeIds(&ticket_a);
+
+    // 3: terminate A -- a real process boundary.
+    process_a.stop();
+    process_a_running = false;
+
+    // 4: start B from the same on-disk snapshot, same env, no manual lease
+    // edits of any kind.
+    var process_b = try TardigradeProcess.start(allocator, .{
+        .config_text = config_text,
+        .ready_https_insecure = true,
+        .ready_path = "/healthz",
+        .extra_env = extra_env,
+    });
+    defer process_b.stop();
+
+    // 5: B's own startup must have reserved a *new, non-overlapping* lease
+    // window -- durable, file-backed state, not merely "B also works".
+    const after_b_start = try readTicketKeyLeaseWindow(allocator, ticket_keys_path, persistent_ticket_key_fixture_id_hex);
+    try std.testing.expectEqual(after_a_start.end_exclusive, after_b_start.start);
+    try std.testing.expect(after_b_start.start >= after_a_start.end_exclusive);
+    try std.testing.expect(after_b_start.end_exclusive > after_b_start.start);
+
+    var clock_dummy: u8 = 0;
+    const ClientClock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 2_500;
+        }
+    };
+
+    // 6-7: A's still-valid ticket resumes on B -- the persistent key
+    // decrypts it even though B never shared any in-memory state with A.
+    var offers: tls_core.pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&ticket_a);
+    errdefer offers.deinit();
+    const resumed_client = try PureZigTlsClient.createWithOptions(allocator, process_b.port, "http/1.1", "tardigrade.test", .{
+        .psk_offers = &offers,
+        .psk_now_ctx = &clock_dummy,
+        .psk_now_fn = ClientClock.now,
+    });
+    defer resumed_client.destroy();
+    try std.testing.expect(resumed_client.backend.core.psk_authenticated);
+    try resumed_client.writeAllPlain(openssl_health_request);
+    const resumed_raw = try resumed_client.readPlainToEnd(allocator, 64 * 1024, 5_000);
+    defer allocator.free(resumed_raw);
+    try assertContains(resumed_raw, "HTTP/1.1 200 OK");
+
+    var resume_metrics = try sendPureZigTlsHttp1Request(allocator, process_b.port, "/status/metrics");
+    defer resume_metrics.deinit();
+    try expectMetricAtLeast(resume_metrics.body, "tardigrade_tls_resumption_outcome_total", &.{ "transport=\"record\"", "outcome=\"accepted\"" }, 1);
+
+    // 8-9: B issues its own fresh ticket. Same key (only one key in this
+    // fixture, so key_id must match), but its nonce must be distinct from
+    // every A-issued nonce -- guaranteed structurally by step 5's disjoint
+    // lease windows, and asserted directly here at the wire-visible
+    // (key_id, nonce) granularity #519 asks for.
+    var capture_b = TicketCapture{ .allocator = allocator };
+    defer capture_b.retained.deinit();
+    const client_b = try PureZigTlsClient.createWithOptions(allocator, process_b.port, "http/1.1", "tardigrade.test", .{
+        .ticket_consumer = .{
+            .ctx = &capture_b,
+            .nowUnixMsFn = TicketCapture.now,
+            .onTicketFn = TicketCapture.onTicket,
+        },
+    });
+    defer client_b.destroy();
+    try client_b.writeAllPlain(openssl_health_request);
+    const b_raw = try client_b.readPlainToEnd(allocator, 64 * 1024, 5_000);
+    defer allocator.free(b_raw);
+    try assertContains(b_raw, "HTTP/1.1 200 OK");
+
+    const ids_b = extractTicketEnvelopeIds(&capture_b.retained);
+    try std.testing.expectEqualSlices(u8, &ids_a.key_id, &ids_b.key_id);
+    try std.testing.expect(!std.mem.eql(u8, &ids_a.nonce, &ids_b.nonce));
+    // The nonce's low 8 bytes are the per-key counter `NonceLease.reserve`
+    // draws from (see the fixed 4-byte prefix + big-endian counter format);
+    // B's counter must fall inside B's own reserved window, not merely
+    // "differ from A's one sample" -- a stronger, non-coincidental proof of
+    // disjointness.
+    const b_nonce_counter = std.mem.readInt(u64, ids_b.nonce[4..12], .big);
+    try std.testing.expect(b_nonce_counter >= after_b_start.start and b_nonce_counter < after_b_start.end_exclusive);
+}
+
+// #519: drives the real SIGHUP config-reload path (the same one `location
+// block reload takes effect for new requests after sighup` above uses) to
+// rotate a persistent stateless keyring from generation N to N+1 on a live
+// process, composing what `resumption_runtime.zig`'s own in-process unit
+// suite (`#512 persistent stateless runtime loads configured keys, rotates,
+// and retires old tickets`, etc.) already proves against a bare `Runtime`
+// with an injected clock, into the real production reload path with a real
+// wall clock. Also composes the `encrypt_until`/`decrypt_until` boundary
+// pair live: N's `encrypt_until` is already in the past at the moment N+1
+// is installed (so it never re-encrypts), and N's `decrypt_until` is a
+// short, deterministic few seconds out so a real (bounded) sleep can prove
+// the grace window actually closes. `not_before` and the
+// `session.issued_at + lifetime` boundary are deliberately not re-proven
+// here: both are exact single-key timing facts already covered end to end
+// (`not_before` by `#512`'s own unit suite; ticket-lifetime expiry by
+// `interop.openssl.ticket.expired`) and neither depends on rotation itself.
+test "rotation.persistent.n_to_n_plus_1" {
+    try requireNativeTlsProfile();
+    const allocator = std.testing.allocator;
+
+    var tls_paths = try nativeTlsFixturePaths(allocator);
+    defer tls_paths.deinit();
+
+    const key_path_probe_port = try findFreePort();
+    const ticket_keys_path = try persistentTicketKeySnapshotPath(allocator, key_path_probe_port, "persistent-rotation-n-to-np1");
+    defer allocator.free(ticket_keys_path);
+    defer compat.cwd().deleteFile(ticket_keys_path) catch {};
+    defer {
+        const lock_path = std.fmt.allocPrint(allocator, "{s}.lock", .{ticket_keys_path}) catch null;
+        if (lock_path) |path| {
+            compat.cwd().deleteFile(path) catch {};
+            allocator.free(path);
+        }
+    }
+
+    const key_n_id = "a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0";
+    const key_n_secret = "c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1";
+    const key_np1_id = "b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0";
+    const key_np1_secret = "d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2";
+
+    // A ticket only seals successfully when the sealing key's own
+    // `decrypt_until` outlives the session's `issued_at + ticket_lifetime`
+    // (`ticket_protection.ticketExpiresWithinKey`) -- a real, independent
+    // validity constraint from anything this test otherwise controls. The
+    // default ticket lifetime is 24h, so the short, deterministic key
+    // windows this rotation test needs (seconds, not hours) require an
+    // explicit short ticket lifetime too, or every issuance would silently
+    // fail closed with `TicketOutlivesKey` before ever reaching the wire.
+    const gen1_now = compat.milliTimestamp();
+    try writePersistentTicketKeySnapshotKeys(allocator, ticket_keys_path, 1, &.{
+        .{
+            .id_hex = key_n_id,
+            .key_hex = key_n_secret,
+            .not_before_unix_ms = gen1_now - 60_000,
+            .encrypt_until_unix_ms = gen1_now + 90_000,
+            .decrypt_until_unix_ms = gen1_now + 90_000,
+            .nonce_lease = .{ .prefix_hex = "e3000000", .start = 0, .end_exclusive = 1_000_000 },
+        },
+    });
+
+    const config_text =
+        \\location = /healthz {
+        \\    return 200 alive;
+        \\}
+    ;
+    const extra_env = &[_]EnvPair{
+        .{ .name = "TARDIGRADE_TLS_CERT_PATH", .value = tls_paths.cert_path },
+        .{ .name = "TARDIGRADE_TLS_KEY_PATH", .value = tls_paths.key_path },
+        .{ .name = "TARDIGRADE_TLS_SERVER_NAME", .value = "tardigrade.test" },
+        .{ .name = "TARDIGRADE_TLS_NATIVE_RESUMPTION_MODE", .value = "stateless" },
+        .{ .name = "TARDIGRADE_TLS_NATIVE_TICKET_KEYS_PATH", .value = ticket_keys_path },
+        .{ .name = "TARDIGRADE_TLS_NATIVE_RESUMPTION_TICKET_LIFETIME_SECONDS", .value = "30" },
+    };
+
+    var tardigrade = try TardigradeProcess.start(allocator, .{
+        .config_text = config_text,
+        .ready_https_insecure = true,
+        .ready_path = "/healthz",
+        .extra_env = extra_env,
+    });
+    defer tardigrade.stop();
+
+    const RotationTicketCapture = struct {
+        allocator: std.mem.Allocator,
+        retained: tls_core.session.ClientTicketState = .{},
+
+        fn now(_: *anyopaque) i64 {
+            return 2_000;
+        }
+
+        fn onTicket(ctx: *anyopaque, ticket: *const tls_core.session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.retained.deinit();
+            self.retained = .{};
+            ticket.cloneInto(self.allocator, &self.retained) catch unreachable;
+        }
+    };
+
+    // 1-2: obtain a real ticket under generation N.
+    var capture_n = RotationTicketCapture{ .allocator = allocator };
+    defer capture_n.retained.deinit();
+    {
+        const client = try PureZigTlsClient.createWithOptions(allocator, tardigrade.port, "http/1.1", "tardigrade.test", .{
+            .ticket_consumer = .{ .ctx = &capture_n, .nowUnixMsFn = RotationTicketCapture.now, .onTicketFn = RotationTicketCapture.onTicket },
+        });
+        defer client.destroy();
+        try client.writeAllPlain(openssl_health_request);
+        const raw = try client.readPlainToEnd(allocator, 64 * 1024, 5_000);
+        defer allocator.free(raw);
+        try assertContains(raw, "HTTP/1.1 200 OK");
+    }
+    var ticket_n: tls_core.session.ClientTicketState = .{};
+    defer ticket_n.deinit();
+    try capture_n.retained.cloneInto(allocator, &ticket_n);
+    const ids_n = extractTicketEnvelopeIds(&ticket_n);
+    try std.testing.expectEqualStrings(key_n_id, &std.fmt.bytesToHex(ids_n.key_id, .lower));
+
+    // 3: atomically replace the configured snapshot with N+1 while retaining
+    // N decrypt-only for a short, deterministic grace window. N's own
+    // `encrypt_until` is already in the past at this moment, so it can never
+    // be selected to encrypt a new ticket again from here on -- and since it
+    // will never encrypt again, it carries forward with `nonce_lease =
+    // null` rather than replaying its original (or any) lease range: the
+    // keyring's per-key-id ledger permanently remembers the full declared
+    // width of every lease a key was ever installed with, so replaying any
+    // such range for a key that already used it in a prior generation is
+    // rejected as `OverlappingNonceLease`, even for the very same,
+    // unchanged key. See `TicketKeyFixture.nonce_lease`'s doc comment.
+    const gen2_now = compat.milliTimestamp();
+    const grace_window_ms: i64 = 5_000;
+    try writePersistentTicketKeySnapshotKeys(allocator, ticket_keys_path, 2, &.{
+        .{
+            .id_hex = key_n_id,
+            .key_hex = key_n_secret,
+            .not_before_unix_ms = gen1_now - 60_000,
+            .encrypt_until_unix_ms = gen2_now - 100,
+            .decrypt_until_unix_ms = gen2_now + grace_window_ms,
+        },
+        .{
+            .id_hex = key_np1_id,
+            .key_hex = key_np1_secret,
+            .not_before_unix_ms = gen2_now - 100,
+            .encrypt_until_unix_ms = gen2_now + 60_000,
+            .decrypt_until_unix_ms = gen2_now + 60_000,
+            .nonce_lease = .{ .prefix_hex = "f4000000", .start = 0, .end_exclusive = 1_000_000 },
+        },
+    });
+
+    // 4: trigger the real production reload path.
+    tardigrade.sendSignal(std.posix.SIG.HUP);
+    compat.sleepNs(300 * std.time.ns_per_ms);
+
+    var reload_metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
+    defer reload_metrics.deinit();
+    try expectMetricAtLeast(reload_metrics.body, "tardigrade_tls_ticket_key_reload_total", &.{"outcome=\"reload_accepted\""}, 1);
+
+    var clock_dummy: u8 = 0;
+    const ClientClock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 2_500;
+        }
+    };
+
+    // 5: the old N ticket resumes during the overlap grace window.
+    // `ClientPskOfferSet.push` *moves* its argument (zero-valued on
+    // success), and `ticket_n` is offered again below after the grace
+    // window closes -- so each offer pushes a fresh clone, never `ticket_n`
+    // itself.
+    {
+        var offer_clone: tls_core.session.ClientTicketState = .{};
+        defer offer_clone.deinit();
+        try ticket_n.cloneInto(allocator, &offer_clone);
+        var offers: tls_core.pre_shared_key.ClientPskOfferSet = .{};
+        try offers.push(&offer_clone);
+        errdefer offers.deinit();
+        const client = try PureZigTlsClient.createWithOptions(allocator, tardigrade.port, "http/1.1", "tardigrade.test", .{
+            .psk_offers = &offers,
+            .psk_now_ctx = &clock_dummy,
+            .psk_now_fn = ClientClock.now,
+        });
+        defer client.destroy();
+        try std.testing.expect(client.backend.core.psk_authenticated);
+        try client.writeAllPlain(openssl_health_request);
+        const raw = try client.readPlainToEnd(allocator, 64 * 1024, 5_000);
+        defer allocator.free(raw);
+        try assertContains(raw, "HTTP/1.1 200 OK");
+    }
+    var mid_metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
+    defer mid_metrics.deinit();
+    const accepted_during_overlap = prometheusLabeledMetricValue(mid_metrics.body, "tardigrade_tls_resumption_outcome_total", &.{ "transport=\"record\"", "outcome=\"accepted\"" }) orelse 0;
+    try std.testing.expect(accepted_during_overlap >= 1);
+
+    // 6: newly issued tickets use N+1 only.
+    var capture_np1 = RotationTicketCapture{ .allocator = allocator };
+    defer capture_np1.retained.deinit();
+    {
+        const client = try PureZigTlsClient.createWithOptions(allocator, tardigrade.port, "http/1.1", "tardigrade.test", .{
+            .ticket_consumer = .{ .ctx = &capture_np1, .nowUnixMsFn = RotationTicketCapture.now, .onTicketFn = RotationTicketCapture.onTicket },
+        });
+        defer client.destroy();
+        try client.writeAllPlain(openssl_health_request);
+        const raw = try client.readPlainToEnd(allocator, 64 * 1024, 5_000);
+        defer allocator.free(raw);
+        try assertContains(raw, "HTTP/1.1 200 OK");
+    }
+    const ids_np1 = extractTicketEnvelopeIds(&capture_np1.retained);
+    try std.testing.expectEqualStrings(key_np1_id, &std.fmt.bytesToHex(ids_np1.key_id, .lower));
+    try std.testing.expect(!std.mem.eql(u8, &ids_np1.key_id, &ids_n.key_id));
+
+    // 7: wait past N's `decrypt_until` grace boundary, then prove retired N
+    // is never used for new encryption *and* no longer resolves at all --
+    // composing the live decrypt_until boundary itself, not merely
+    // asserting the reload succeeded.
+    compat.sleepNs(@as(u64, @intCast(grace_window_ms)) * std.time.ns_per_ms + 2 * std.time.ns_per_s);
+
+    {
+        var offer_clone: tls_core.session.ClientTicketState = .{};
+        defer offer_clone.deinit();
+        try ticket_n.cloneInto(allocator, &offer_clone);
+        var offers: tls_core.pre_shared_key.ClientPskOfferSet = .{};
+        try offers.push(&offer_clone);
+        errdefer offers.deinit();
+        const client = try PureZigTlsClient.createWithOptions(allocator, tardigrade.port, "http/1.1", "tardigrade.test", .{
+            .psk_offers = &offers,
+            .psk_now_ctx = &clock_dummy,
+            .psk_now_fn = ClientClock.now,
+        });
+        defer client.destroy();
+        // The retired key is gone entirely, not merely "not preferred": a
+        // full handshake, not a second resumption, must serve this request.
+        try std.testing.expect(!client.backend.core.psk_authenticated);
+        try client.writeAllPlain(openssl_health_request);
+        const raw = try client.readPlainToEnd(allocator, 64 * 1024, 5_000);
+        defer allocator.free(raw);
+        try assertContains(raw, "HTTP/1.1 200 OK");
+    }
+
+    var final_metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
+    defer final_metrics.deinit();
+    try expectMetricAtLeast(final_metrics.body, "tardigrade_tls_resumption_outcome_total", &.{ "transport=\"record\"", "outcome=\"miss\"" }, 1);
+    // The overlap-window accept count must not have grown from this last,
+    // post-grace-window offer -- it really did fall back, not resume again.
+    try std.testing.expectEqual(accepted_during_overlap, prometheusLabeledMetricValue(final_metrics.body, "tardigrade_tls_resumption_outcome_total", &.{ "transport=\"record\"", "outcome=\"accepted\"" }) orelse 0);
+}
+
+// #519: representative failure classes for a SIGHUP reload attempt against
+// a live process running persistent ticket keys -- not an exhaustive replay
+// of every `ticket_key_snapshot.zig` malformed-input unit case (those stay
+// there), but the composed proof that a rejected candidate at each class
+// never disturbs the live keyring, config, or credential: an
+// already-issued ticket keeps resuming across every rejected attempt, a
+// ticket issued only *after* every attempt still uses the original key
+// (nothing partially applied), and the reload metric records a bounded,
+// secret-free failure outcome each time.
+//
+// This test does not additionally attempt to bundle a TLS credential change
+// into a failing SIGHUP: `requireNativeTlsProfile` gates every test in this
+// file to the appliance TLS profile build (the only profile where
+// `build_options.tls_openssl_adapter` is false), and inspecting
+// `edge_gateway.run`/`gateway_shutdown.hotReloadConfig` shows the appliance
+// profile's real served identity (`appliance_credentials.ApplianceCredentials`,
+// held in `appliance_identity`) is loaded once at startup and never touched
+// by `hotReloadConfig` at all -- the `native_credentials`/`NativeCredentialStore`
+// two-phase prepare/commit path this criterion originally had in mind is
+// wired up only for the non-appliance code path (`native_tls_provider`/
+// `h3_credential_provider` construction in `edge_gateway.zig` explicitly
+// branches on `edge_config.is_appliance_tls_profile`), so it is never
+// reachable here. `rotation.persistent.certificate_binding_change` below
+// proves the credential side of this instead, through the restart
+// composition the appliance profile *does* support for credential changes.
+// What this test still demonstrates, honestly: every sub-case below leaves
+// `ticket0` (bound to the one credential this process ever serves)
+// resuming successfully, so the previous certificate credential and the
+// previous ticket state both visibly survive every rejected reload here,
+// even though none of these attempts ever touches the credential itself.
+test "rotation.persistent.failed_reload_keeps_old_state" {
+    try requireNativeTlsProfile();
+    const allocator = std.testing.allocator;
+
+    var tls_paths = try nativeTlsFixturePaths(allocator);
+    defer tls_paths.deinit();
+
+    const key_path_probe_port = try findFreePort();
+    const ticket_keys_path = try persistentTicketKeySnapshotPath(allocator, key_path_probe_port, "persistent-failed-reload");
+    defer allocator.free(ticket_keys_path);
+    defer compat.cwd().deleteFile(ticket_keys_path) catch {};
+    defer {
+        const lock_path = std.fmt.allocPrint(allocator, "{s}.lock", .{ticket_keys_path}) catch null;
+        if (lock_path) |path| {
+            compat.cwd().deleteFile(path) catch {};
+            allocator.free(path);
+        }
+    }
+
+    const k0_id = "c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0";
+    const k0_secret = "e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5";
+    const baseline_now = compat.milliTimestamp();
+    try writePersistentTicketKeySnapshotKeys(allocator, ticket_keys_path, 5, &.{
+        .{
+            .id_hex = k0_id,
+            .key_hex = k0_secret,
+            .not_before_unix_ms = baseline_now - 60_000,
+            .encrypt_until_unix_ms = baseline_now + 3_600_000,
+            .decrypt_until_unix_ms = baseline_now + 3_600_000,
+            .nonce_lease = .{ .prefix_hex = "11110000", .start = 0, .end_exclusive = 1_000_000 },
+        },
+    });
+
+    const config_text =
+        \\location = /healthz {
+        \\    return 200 alive;
+        \\}
+    ;
+    var tardigrade = try TardigradeProcess.start(allocator, .{
+        .config_text = config_text,
+        .ready_https_insecure = true,
+        .ready_path = "/healthz",
+        .extra_env = &.{
+            .{ .name = "TARDIGRADE_TLS_CERT_PATH", .value = tls_paths.cert_path },
+            .{ .name = "TARDIGRADE_TLS_KEY_PATH", .value = tls_paths.key_path },
+            .{ .name = "TARDIGRADE_TLS_SERVER_NAME", .value = "tardigrade.test" },
+            .{ .name = "TARDIGRADE_TLS_NATIVE_RESUMPTION_MODE", .value = "stateless" },
+            .{ .name = "TARDIGRADE_TLS_NATIVE_TICKET_KEYS_PATH", .value = ticket_keys_path },
+            // See `ticketExpiresWithinKey` in `ticket_protection.zig`: a
+            // ticket only seals when the key's own `decrypt_until` outlives
+            // `issued_at + ticket_lifetime`. The default lifetime is 24h,
+            // far beyond this fixture's deliberately short 1h key window.
+            .{ .name = "TARDIGRADE_TLS_NATIVE_RESUMPTION_TICKET_LIFETIME_SECONDS", .value = "60" },
+        },
+    });
+    defer tardigrade.stop();
+
+    var baseline_metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
+    defer baseline_metrics.deinit();
+    try expectMetricAtLeast(baseline_metrics.body, "tardigrade_tls_ticket_key_reload_total", &.{"outcome=\"initial_load_success\""}, 1);
+
+    const FailedReloadTicketCapture = struct {
+        allocator: std.mem.Allocator,
+        retained: tls_core.session.ClientTicketState = .{},
+
+        fn now(_: *anyopaque) i64 {
+            return 2_000;
+        }
+
+        fn onTicket(ctx: *anyopaque, ticket: *const tls_core.session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.retained.deinit();
+            self.retained = .{};
+            ticket.cloneInto(self.allocator, &self.retained) catch unreachable;
+        }
+    };
+
+    var capture0 = FailedReloadTicketCapture{ .allocator = allocator };
+    defer capture0.retained.deinit();
+    {
+        const client = try PureZigTlsClient.createWithOptions(allocator, tardigrade.port, "http/1.1", "tardigrade.test", .{
+            .ticket_consumer = .{ .ctx = &capture0, .nowUnixMsFn = FailedReloadTicketCapture.now, .onTicketFn = FailedReloadTicketCapture.onTicket },
+        });
+        defer client.destroy();
+        try client.writeAllPlain(openssl_health_request);
+        const raw = try client.readPlainToEnd(allocator, 64 * 1024, 5_000);
+        defer allocator.free(raw);
+        try assertContains(raw, "HTTP/1.1 200 OK");
+    }
+    var ticket0: tls_core.session.ClientTicketState = .{};
+    defer ticket0.deinit();
+    try capture0.retained.cloneInto(allocator, &ticket0);
+
+    var clock_dummy: u8 = 0;
+    const ClientClock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 2_500;
+        }
+    };
+
+    // Offers `ticket0` against the live process and asserts it still
+    // resumes (real PSK authentication plus a real HTTP round-trip) --
+    // proof that the previously valid ticket state was untouched by
+    // whatever rejected reload attempt preceded this call.
+    const assertTicket0StillResumes = struct {
+        fn run(alloc: std.mem.Allocator, port: u16, ticket: *const tls_core.session.ClientTicketState, now_ctx: *u8) !void {
+            // `ClientPskOfferSet.push` moves its argument (zero-valued on
+            // success); this helper is called repeatedly against the same
+            // `ticket0`, so each call offers a fresh clone and leaves the
+            // caller's retained `ticket0` untouched.
+            var offer_clone: tls_core.session.ClientTicketState = .{};
+            defer offer_clone.deinit();
+            try ticket.cloneInto(alloc, &offer_clone);
+            var offers: tls_core.pre_shared_key.ClientPskOfferSet = .{};
+            try offers.push(&offer_clone);
+            errdefer offers.deinit();
+            const client = try PureZigTlsClient.createWithOptions(alloc, port, "http/1.1", "tardigrade.test", .{
+                .psk_offers = &offers,
+                .psk_now_ctx = now_ctx,
+                .psk_now_fn = ClientClock.now,
+            });
+            defer client.destroy();
+            try std.testing.expect(client.backend.core.psk_authenticated);
+            try client.writeAllPlain(openssl_health_request);
+            const raw = try client.readPlainToEnd(alloc, 64 * 1024, 5_000);
+            defer alloc.free(raw);
+            try assertContains(raw, "HTTP/1.1 200 OK");
+        }
+    }.run;
+
+    // Sub-case 1: unreadable replacement -- every permission bit stripped
+    // from the file at the configured path (it still *exists*; deleting it
+    // outright is a different, *earlier* rejection -- see below). Modeled
+    // after "a post-validation runtime failure is not misreported as a
+    // configuration error" above: a probe open after `chmod` confirms the
+    // permission bit is actually enforced before relying on it (some CI
+    // containers run as root, where it silently is not), skipping only this
+    // sub-case's own assertion -- not the rest of this test -- when it
+    // isn't.
+    //
+    // This rejection actually surfaces one layer earlier than the other
+    // three sub-cases below: `edge_config.validate`'s own
+    // `TARDIGRADE_TLS_NATIVE_TICKET_KEYS_PATH` existence check
+    // (`validateOptionalFileChecked`) itself calls `openFile`, which fails
+    // identically for "does not exist" and "exists but unreadable" -- so an
+    // unreadable replacement is rejected by general config validation
+    // before `hotReloadConfig` ever reaches the ticket-key-specific load
+    // step, and is recorded on the general `tardigrade_reload_failure_total`
+    // counter rather than `tardigrade_tls_ticket_key_reload_total`. Still a
+    // bounded, secret-free failure outcome that leaves the previous
+    // keyring/config active, which is what this sub-case actually needs to
+    // prove.
+    const ticket_keys_path_z = try std.fmt.allocPrintSentinel(allocator, "{s}", .{ticket_keys_path}, 0);
+    defer allocator.free(ticket_keys_path_z);
+    try std.testing.expectEqual(@as(c_int, 0), std.c.chmod(ticket_keys_path_z.ptr, 0o000));
+    const permission_enforced = if (compat.cwd().openFile(ticket_keys_path, .{})) |f| blk: {
+        var file = f;
+        file.close();
+        break :blk false;
+    } else |_| true;
+    const failure_count_before_subcase1 = blk: {
+        var metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
+        defer metrics.deinit();
+        break :blk prometheusMetricValue(metrics.body, "tardigrade_reload_failure_total") orelse 0;
+    };
+    tardigrade.sendSignal(std.posix.SIG.HUP);
+    compat.sleepNs(300 * std.time.ns_per_ms);
+    if (permission_enforced) {
+        var metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
+        defer metrics.deinit();
+        try std.testing.expect((prometheusMetricValue(metrics.body, "tardigrade_reload_failure_total") orelse 0) >= failure_count_before_subcase1 + 1);
+    }
+    _ = std.c.chmod(ticket_keys_path_z.ptr, 0o600);
+    try assertTicket0StillResumes(allocator, tardigrade.port, &ticket0, &clock_dummy);
+
+    // Sub-case 2: malformed JSON.
+    try writeInteropSecretFile(ticket_keys_path, "{not valid json");
+    tardigrade.sendSignal(std.posix.SIG.HUP);
+    compat.sleepNs(300 * std.time.ns_per_ms);
+    {
+        var metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
+        defer metrics.deinit();
+        try expectMetricAtLeast(metrics.body, "tardigrade_tls_ticket_key_reload_total", &.{"outcome=\"reload_rejected\""}, 1);
+    }
+    try assertTicket0StillResumes(allocator, tardigrade.port, &ticket0, &clock_dummy);
+
+    // Sub-case 3: semantically invalid keyring -- an otherwise well-formed
+    // key with an invalid nonce lease (`start >= end_exclusive`), rejected
+    // by `ticket_protection.NonceLease.init`, not by JSON parsing.
+    try writePersistentTicketKeySnapshotKeys(allocator, ticket_keys_path, 6, &.{
+        .{
+            .id_hex = k0_id,
+            .key_hex = k0_secret,
+            .not_before_unix_ms = baseline_now - 60_000,
+            .encrypt_until_unix_ms = baseline_now + 3_600_000,
+            .decrypt_until_unix_ms = baseline_now + 3_600_000,
+            .nonce_lease = .{ .prefix_hex = "11110000", .start = 100, .end_exclusive = 100 },
+        },
+    });
+    tardigrade.sendSignal(std.posix.SIG.HUP);
+    compat.sleepNs(300 * std.time.ns_per_ms);
+    {
+        var metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
+        defer metrics.deinit();
+        try expectMetricAtLeast(metrics.body, "tardigrade_tls_ticket_key_reload_total", &.{"outcome=\"reload_rejected\""}, 1);
+    }
+    try assertTicket0StillResumes(allocator, tardigrade.port, &ticket0, &clock_dummy);
+
+    // Sub-case 4: stale generation -- otherwise identical, valid key
+    // content, but a generation number not newer than the currently
+    // installed one (5). Reusing the baseline's own lease range unchanged
+    // is fine here (unlike `rotation.persistent.n_to_n_plus_1`'s carried-
+    // forward key): staleness is checked before the ledger/overlap check
+    // (`ReloadableKeyRing.validateInstallCandidate`), so this is rejected
+    // for the intended reason regardless.
+    try writePersistentTicketKeySnapshotKeys(allocator, ticket_keys_path, 3, &.{
+        .{
+            .id_hex = k0_id,
+            .key_hex = k0_secret,
+            .not_before_unix_ms = baseline_now - 60_000,
+            .encrypt_until_unix_ms = baseline_now + 3_600_000,
+            .decrypt_until_unix_ms = baseline_now + 3_600_000,
+            .nonce_lease = .{ .prefix_hex = "11110000", .start = 0, .end_exclusive = 1_000_000 },
+        },
+    });
+    tardigrade.sendSignal(std.posix.SIG.HUP);
+    compat.sleepNs(300 * std.time.ns_per_ms);
+    {
+        var metrics = try sendPureZigTlsHttp1Request(allocator, tardigrade.port, "/status/metrics");
+        defer metrics.deinit();
+        try expectMetricAtLeast(metrics.body, "tardigrade_tls_ticket_key_reload_total", &.{"outcome=\"reload_rejected\""}, 1);
+    }
+    try assertTicket0StillResumes(allocator, tardigrade.port, &ticket0, &clock_dummy);
+
+    // After four rejected attempts, a *freshly issued* ticket must still be
+    // sealed under the original key id -- proof that nothing was partially
+    // applied to the live keyring across any of them.
+    {
+        var capture = FailedReloadTicketCapture{ .allocator = allocator };
+        defer capture.retained.deinit();
+        const client = try PureZigTlsClient.createWithOptions(allocator, tardigrade.port, "http/1.1", "tardigrade.test", .{
+            .ticket_consumer = .{ .ctx = &capture, .nowUnixMsFn = FailedReloadTicketCapture.now, .onTicketFn = FailedReloadTicketCapture.onTicket },
+        });
+        defer client.destroy();
+        try client.writeAllPlain(openssl_health_request);
+        const raw = try client.readPlainToEnd(allocator, 64 * 1024, 5_000);
+        defer allocator.free(raw);
+        try assertContains(raw, "HTTP/1.1 200 OK");
+        const ids = extractTicketEnvelopeIds(&capture.retained);
+        try std.testing.expectEqualStrings(k0_id, &std.fmt.bytesToHex(ids.key_id, .lower));
+    }
+}
+
+// #519: with persistent ticket keys, a restart no longer implies key loss
+// (unlike `restart.restart_and_credential_change.ticket_rejected`, whose own
+// doc comment explains it cannot prove certificate/auth-binding rejection
+// for exactly this reason -- both processes there are ephemeral, so B can
+// never decrypt A's ticket at all, and its own comment names a persistent
+// keyring surviving a restart as exactly the missing production capability
+// that would let a real cert-binding test exist). This is a restart, not a
+// SIGHUP reload, deliberately: inspecting `edge_gateway.run`/
+// `gateway_shutdown.hotReloadConfig` shows the appliance TLS profile's real
+// served identity (`appliance_credentials.ApplianceCredentials`) is loaded
+// once at startup and never touched by any reload path at all, so there is
+// no live way to change the served credential without a restart under this
+// profile -- exactly the "supported reload/restart composition" #519 asks
+// for. Process B here reuses process A's ticket-keys file unedited (the
+// same durable-lease-reservation contract `restart.persistent.ticket_survives`
+// exercises), so the persistent key is unchanged across the restart and
+// decryption genuinely succeeds; the only thing that can reject A's old
+// ticket on B is `session.evaluateCompatibility`'s `auth_binding` check.
+// `tls13_backend.selectPsk` only reaches that check, and only records
+// `.incompatible` (as opposed to `.miss`), for an identity that actually
+// resolved -- so the `incompatible` resumption outcome alongside a
+// successful ticket-resolve metric is the live, composed proof this is a
+// compatibility rejection, not an unknown-key/decryption miss.
+test "rotation.persistent.certificate_binding_change" {
+    try requireNativeTlsProfile();
+    const allocator = std.testing.allocator;
+    try requireOpensslEd25519(allocator);
+
+    var cred_a = try generateAlternateServerCert(allocator, "tardigrade.test");
+    defer cred_a.deinit();
+    var cred_b = try generateAlternateServerCert(allocator, "tardigrade.test");
+    defer cred_b.deinit();
+
+    const key_path_probe_port = try findFreePort();
+    const ticket_keys_path = try persistentTicketKeySnapshotPath(allocator, key_path_probe_port, "persistent-cert-binding-change");
+    defer allocator.free(ticket_keys_path);
+    defer compat.cwd().deleteFile(ticket_keys_path) catch {};
+    defer {
+        const lock_path = std.fmt.allocPrint(allocator, "{s}.lock", .{ticket_keys_path}) catch null;
+        if (lock_path) |path| {
+            compat.cwd().deleteFile(path) catch {};
+            allocator.free(path);
+        }
+    }
+    try writePersistentTicketKeySnapshot(allocator, ticket_keys_path);
+
+    const config_text =
+        \\location = /healthz {
+        \\    return 200 alive;
+        \\}
+    ;
+    const extra_env = &[_]EnvPair{
+        .{ .name = "TARDIGRADE_TLS_SERVER_NAME", .value = "tardigrade.test" },
+        .{ .name = "TARDIGRADE_TLS_NATIVE_RESUMPTION_MODE", .value = "stateless" },
+        .{ .name = "TARDIGRADE_TLS_NATIVE_TICKET_KEYS_PATH", .value = ticket_keys_path },
+    };
+
+    var process_a = try TardigradeProcess.start(allocator, .{
+        .config_text = config_text,
+        .ready_https_insecure = true,
+        .ready_path = "/healthz",
+        .extra_env = &(extra_env.* ++ [_]EnvPair{
+            .{ .name = "TARDIGRADE_TLS_CERT_PATH", .value = cred_a.cert_path },
+            .{ .name = "TARDIGRADE_TLS_KEY_PATH", .value = cred_a.key_path },
+        }),
+    });
+    var process_a_running = true;
+    defer if (process_a_running) process_a.stop();
+
+    const CertBindingTicketCapture = struct {
+        allocator: std.mem.Allocator,
+        retained: tls_core.session.ClientTicketState = .{},
+
+        fn now(_: *anyopaque) i64 {
+            return 2_000;
+        }
+
+        fn onTicket(ctx: *anyopaque, ticket: *const tls_core.session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.retained.deinit();
+            self.retained = .{};
+            ticket.cloneInto(self.allocator, &self.retained) catch unreachable;
+        }
+    };
+
+    // Issue a ticket while process A serves credential A.
+    var capture_a = CertBindingTicketCapture{ .allocator = allocator };
+    defer capture_a.retained.deinit();
+    {
+        const client = try PureZigTlsClient.createWithOptions(allocator, process_a.port, "http/1.1", "tardigrade.test", .{
+            .ticket_consumer = .{ .ctx = &capture_a, .nowUnixMsFn = CertBindingTicketCapture.now, .onTicketFn = CertBindingTicketCapture.onTicket },
+        });
+        defer client.destroy();
+        try client.writeAllPlain(openssl_health_request);
+        const raw = try client.readPlainToEnd(allocator, 64 * 1024, 5_000);
+        defer allocator.free(raw);
+        try assertContains(raw, "HTTP/1.1 200 OK");
+    }
+    var ticket_a: tls_core.session.ClientTicketState = .{};
+    defer ticket_a.deinit();
+    try capture_a.retained.cloneInto(allocator, &ticket_a);
+
+    // A real process boundary, not `Runtime.deinit()`/`Runtime.init()` reused
+    // inside one test object.
+    process_a.stop();
+    process_a_running = false;
+
+    // Process B: same server_name, same on-disk persistent ticket-key
+    // snapshot (unedited), but credential B. B's own startup durably
+    // reserves its own nonce-lease window from the same file (as in
+    // `restart.persistent.ticket_survives`), so it can decrypt A's ticket.
+    var process_b = try TardigradeProcess.start(allocator, .{
+        .config_text = config_text,
+        .ready_https_insecure = true,
+        .ready_path = "/healthz",
+        .extra_env = &(extra_env.* ++ [_]EnvPair{
+            .{ .name = "TARDIGRADE_TLS_CERT_PATH", .value = cred_b.cert_path },
+            .{ .name = "TARDIGRADE_TLS_KEY_PATH", .value = cred_b.key_path },
+        }),
+    });
+    defer process_b.stop();
+
+    var clock_dummy: u8 = 0;
+    const ClientClock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 2_500;
+        }
+    };
+
+    // Offer the A ticket to B, which now serves credential B.
+    var offers: tls_core.pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&ticket_a);
+    errdefer offers.deinit();
+    const client = try PureZigTlsClient.createWithOptions(allocator, process_b.port, "http/1.1", "tardigrade.test", .{
+        .psk_offers = &offers,
+        .psk_now_ctx = &clock_dummy,
+        .psk_now_fn = ClientClock.now,
+    });
+    defer client.destroy();
+    // Not selected/binder-verified: `selectPsk` skips straight past an
+    // incompatible candidate without ever reaching binder verification, so
+    // this is not merely "psk_authenticated happens to be false."
+    try std.testing.expect(!client.backend.core.psk_authenticated);
+    // Safe full-handshake fallback: the connection still works.
+    try client.writeAllPlain(openssl_health_request);
+    const raw = try client.readPlainToEnd(allocator, 64 * 1024, 5_000);
+    defer allocator.free(raw);
+    try assertContains(raw, "HTTP/1.1 200 OK");
+    try assertContains(raw, "alive");
+
+    var metrics = try sendPureZigTlsHttp1Request(allocator, process_b.port, "/status/metrics");
+    defer metrics.deinit();
+    // The compatibility/auth-binding outcome specifically, not a decryption
+    // miss -- both asserted on B's own metrics, B's first and only
+    // resumption attempt so far, so an absolute count is exact here.
+    try expectMetricAtLeast(metrics.body, "tardigrade_tls_resumption_outcome_total", &.{ "transport=\"record\"", "outcome=\"incompatible\"" }, 1);
+    try std.testing.expectEqual(@as(u64, 0), prometheusLabeledMetricValue(metrics.body, "tardigrade_tls_resumption_outcome_total", &.{ "transport=\"record\"", "outcome=\"accepted\"" }) orelse 0);
+    try std.testing.expectEqual(@as(u64, 0), prometheusLabeledMetricValue(metrics.body, "tardigrade_tls_resumption_outcome_total", &.{ "transport=\"record\"", "outcome=\"miss\"" }) orelse 0);
+    // The ticket-resolve layer (key lookup + decrypt) genuinely succeeded --
+    // ruling out "unknown key"/decryption failure as the actual cause.
+    try expectMetricAtLeast(metrics.body, "tardigrade_tls_ticket_resolve_total", &.{ "mode=\"stateless\"", "result=\"success\"" }, 1);
 }
 
 /// #369: `TARDIGRADE_SOAK_HEAVY=1` scales `soak.reconnect_resumption` up


### PR DESCRIPTION
## Summary

Composes the real production seams #513 landed (persistent stateless ticket-key snapshots, `ReloadableKeyRing`, SIGHUP reload) into four process-level proofs against a live, running `tardi` process — closing the "Rotation / persistent-overlap key policy" gap `docs/RESUMPTION_TEST_PLAN.md`'s Slice 3 explicitly left open, and the certificate-binding gap `restart.restart_and_credential_change.ticket_rejected`'s own doc comment flagged as blocked pending a persistent keyring.

- **`restart.persistent.ticket_survives`** — two real process incarnations sharing one on-disk snapshot file (no manual lease editing) durably reserve disjoint nonce-lease windows before issuing anything, and never emit a colliding `(key_id, nonce)` tuple. Asserted directly against the file's own `nonce_lease.start`/`end_exclusive`, not just "both processes worked".
- **`rotation.persistent.n_to_n_plus_1`** — a real SIGHUP rotates generation N → N+1: the old N ticket resumes through the overlap grace window, fresh tickets use only N+1, and a bounded real sleep past N's `decrypt_until` proves N stops resolving at all afterward (`outcome="miss"`, not a second `accepted`) — composing the live `encrypt_until`/`decrypt_until` boundary pair, not just asserting the reload succeeded.
- **`rotation.persistent.failed_reload_keeps_old_state`** — four representative rejected-reload classes (unreadable replacement, malformed JSON, an invalid nonce lease, a stale generation number) each leave a previously issued ticket resuming and the reload metrics recording a bounded, secret-free failure outcome. A ticket issued only *after* all four still seals under the original key id.
- **`rotation.persistent.certificate_binding_change`** — a restart (not a SIGHUP reload — see the finding below) proves an old ticket is rejected on auth-binding grounds specifically (`outcome="incompatible"` alongside a successful `ticket_resolve`), not an unknown-key/decryption miss, with a safe full-handshake fallback.

**Two real findings surfaced while writing this:**
- Carrying a retiring key into a new generation with its *unchanged* `nonce_lease` range collides with `ReloadableKeyRing`'s per-key-id ledger (`OverlappingNonceLease`) — the ledger permanently remembers the full declared width of every lease a key was ever installed with, not just how far its counter advanced. A retiring key needs no lease at all going forward (matches `#512`'s own unit-test convention: `nonce_lease: null` for the rotated-out key).
- The appliance TLS profile's real served credential (`ApplianceCredentials`) is loaded once at startup and is *never* touched by `hotReloadConfig` — there is no live credential-reload path under this profile at all. `rotation.persistent.certificate_binding_change` is therefore restart-based; `rotation.persistent.failed_reload_keeps_old_state` documents why it does not additionally bundle a credential change into a failing SIGHUP.

`build.zig`: adds a `rotation.` prefix to `test-integration-resumption-interop`'s filter list so these new cases get the same non-Linux CI coverage the existing `restart.`/`interop.` cases already have (macOS's CI job only runs this filtered step, not the full `test-integration` suite).

`docs/RESUMPTION_TEST_PLAN.md`: adds a Slice 4 section and annotates the now-closed Slice 3 deferred bullets.

## Test plan

- [x] `zig fmt --check .`
- [x] `zig build test -Dtls-profile=appliance` (2769/2770 pass, 1 pre-existing skip)
- [x] `zig build test-integration -Dtls-profile=appliance` (full suite, 122/134 pass, 12 skip — includes all 4 new cases)
- [x] `zig build test-integration-resumption-interop -Dtls-profile=appliance` (filtered suite, run twice — 38/42 pass, 4 skip; one unrelated flaky H2 case reproduced-then-passed on both this branch and `main`, confirmed pre-existing)
- [x] `zig build` / `zig build test-integration-resumption-interop` under the default general profile (all new cases correctly skip via `requireNativeTlsProfile`)

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)