### PR TITLE
test(h2): eliminate macOS flake in connection WINDOW_UPDATE overflow GOAWAY regression

### DIFF
--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -5219,21 +5219,44 @@ test "interop.h2.window_update_connection_overflow_sends_goaway" {
     try client.writeAllPlain("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n");
     try client.writeHttp2Frame(0x4, 0, 0, &.{}); // client SETTINGS
 
+    // Finish the initial SETTINGS/ACK handshake before injecting the
+    // overflowing WINDOW_UPDATE. Interleaving the two races the server's
+    // GOAWAY-triggered teardown against the client's own SETTINGS ACK: on
+    // some schedules the connection closes before the ACK write lands,
+    // which the test would otherwise misreport as a harness socket error
+    // rather than as evidence about the (already-correct) GOAWAY behavior.
+    var saw_server_settings = false;
+    var saw_client_settings_ack = false;
+    var setup_frame_count: usize = 0;
+    while ((!saw_server_settings or !saw_client_settings_ack) and setup_frame_count < 16) : (setup_frame_count += 1) {
+        var frame = try client.readHttp2Frame(allocator, 16 * 1024, 5_000);
+        defer frame.deinit(allocator);
+        if (frame.typ != 0x4) continue;
+        if ((frame.flags & 0x1) != 0) {
+            saw_client_settings_ack = true;
+        } else {
+            saw_server_settings = true;
+            try client.writeHttp2Frame(0x4, 0x1, 0, &.{});
+        }
+    }
+    try std.testing.expect(saw_server_settings);
+    try std.testing.expect(saw_client_settings_ack);
+
     // The connection-level window starts at 65,535; this legal 31-bit
     // increment alone pushes it past 2^31-1.
     var inc: [4]u8 = undefined;
     std.mem.writeInt(u32, inc[0..4], 0x7FFFFFFF, .big);
     try client.writeHttp2Frame(0x8, 0, 0, inc[0..]);
 
+    // Past this point the client sends nothing further: it only waits for
+    // and validates the server's GOAWAY. Sending a SETTINGS ACK here would
+    // reopen the same teardown race this test exists to close.
     var saw_goaway = false;
     var frame_count: usize = 0;
     while (frame_count < 16 and !saw_goaway) : (frame_count += 1) {
         var frame = try client.readHttp2Frame(allocator, 16 * 1024, 5_000);
         defer frame.deinit(allocator);
         switch (frame.typ) {
-            0x4 => {
-                if ((frame.flags & 0x1) == 0) try client.writeHttp2Frame(0x4, 0x1, 0, &.{});
-            },
             0x7 => { // GOAWAY
                 try std.testing.expect(frame.payload.len >= 8);
                 const err_code = std.mem.readInt(u32, frame.payload[4..8], .big);


### PR DESCRIPTION
## Summary
- `interop.h2.window_update_connection_overflow_sends_goaway` sent the connection-level overflowing `WINDOW_UPDATE` back-to-back with the client preface/`SETTINGS`, before ever reading server frames. This let the server's `GOAWAY`-triggered teardown race the client's own pending `SETTINGS` ACK — most visibly on macOS, where the non-Linux `readFdNonblocking()` path collapses any terminal `read()` errno into `SocketReadFailed`, hiding what actually happened.
- The test now completes the initial `SETTINGS`/ACK exchange first, then sends the overflowing `WINDOW_UPDATE` and only reads (never writes again) while waiting for the expected `GOAWAY(FLOW_CONTROL_ERROR)`. This removes the teardown race without weakening the assertion — `SocketReadFailed`/`ConnectionResetByPeer`/EOF are still not accepted as a substitute for a real `GOAWAY`.
- Production `edge_gateway.zig` connection-level flow-control/`GOAWAY` behavior is unchanged — this is purely a test-harness ordering fix, per the issue's diagnosis.
- Darwin errno diagnostics in `readFdNonblocking()` were left as-is: the synchronized test did not flake in local verification, so per the issue's acceptance criteria that follow-up wasn't needed.

## Test plan
- [x] Ran the isolated `interop.h2.window_update_connection_overflow_sends_goaway` test 40 consecutive times on macOS (via a temporary local build-filter, reverted before commit) — 0 failures.
- [x] `zig build test-integration-resumption-interop -Dtls-profile=appliance` on macOS — `41 pass, 5 skip (46 total)`, 0 failures.
- [ ] Linux CI run of the same suite (not run locally on this machine).

Closes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)