### PR TITLE
quic: wire local CID lifecycle into H3 runtime

### DIFF
--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -99,6 +99,7 @@ pub const Config = struct {
 const max_connections: usize = 1024;
 const max_connections_per_source: u32 = 32;
 const handshake_timeout_us: u64 = 10 * std.time.us_per_s;
+const cid_generation_retries: usize = 16;
 
 const ParkedH3Retry = struct {
     stream_id: u64,
@@ -154,6 +155,8 @@ const ConnEntry = struct {
     /// Monotonic microseconds when the connection was accepted; used to reap
     /// connections that never complete the handshake.
     accepted_at_us: u64,
+    owned_cids: [quic.cid.max_local_active_cids]quic.cid.ConnectionId = undefined,
+    owned_cid_count: usize = 0,
     /// Set exactly once this connection has attempted post-handshake ticket
     /// issuance (successfully or not) — issuance is best-effort and must
     /// never be retried on the same connection (#488).
@@ -190,6 +193,7 @@ pub const Runtime = struct {
     /// `zero_rtt_enabled` gate and whether `accept()` installs a server
     /// early-data policy on new connections' TLS backends.
     zero_rtt_enabled: bool,
+    stateless_reset_key: [32]u8,
     quic_config: quic.config.Config,
     h3_settings: http3.frame.Settings,
     h3_application_compat: [http3.early_data.encoded_snapshot_len]u8 = undefined,
@@ -245,6 +249,7 @@ pub const Runtime = struct {
             .resumption_runtime = cfg.resumption_runtime,
             .early_data_replay_gate = cfg.early_data_replay_gate,
             .zero_rtt_enabled = zeroRttCarrierEnabled(cfg),
+            .stateless_reset_key = undefined,
             .quic_config = quicConfigFrom(cfg),
             .h3_settings = cfg.h3_settings,
             .early_data_compat_metrics_ctx = cfg.early_data_compat_metrics_ctx,
@@ -256,6 +261,7 @@ pub const Runtime = struct {
             .snapshot_state = .{ .quic_port = cfg.quic_port },
             .stopping = std.atomic.Value(bool).init(false),
         };
+        compat.randomBytes(&runtime.stateless_reset_key);
         http3.frame.validateLocallySupportedSettings(runtime.h3_settings) catch return error.InvalidH3Settings;
         runtime.h3_application_compat_len = (http3.early_data.encodeSettingsSnapshot(
             runtime.h3_settings,
@@ -339,6 +345,8 @@ pub const Runtime = struct {
                 while (it.next()) |kv| {
                     const entry = kv.value_ptr.*;
                     entry.conn.onTimeout(now);
+                    self.syncCidRoutes(entry, &routes);
+                    self.maintainLocalCidRoutes(entry, kv.key_ptr.*, &routes);
                     while (entry.conn.pollTransmitOnPath(&out, now)) |t| {
                         self.sendDatagram(sockaddrInFromAddress(t.path.remote), t.bytes);
                     }
@@ -451,6 +459,8 @@ pub const Runtime = struct {
             if (freshly_accepted) self.removeConnection(connections, routes, per_ip, found);
             return;
         };
+        self.syncCidRoutes(entry, routes);
+        self.maintainLocalCidRoutes(entry, found, routes);
         const authenticated = entry.conn.metrics.packets_received > packets_before;
         switch (classifyIngest(freshly_accepted, authenticated, !active_before.remote.eql(ingress_remote))) {
             // A just-accepted connection whose first datagram authenticates
@@ -568,6 +578,7 @@ pub const Runtime = struct {
             .tls = backend.backend(),
             .now_us = now,
             .initial_path = .{ .local = self.local_address, .remote = addressFromSockaddrIn(peer) },
+            .stateless_reset_key = self.stateless_reset_key,
             .events = .{ .context = self, .emitFn = quicConnectionEvent },
         }) catch {
             allocator.destroy(backend);
@@ -595,6 +606,8 @@ pub const Runtime = struct {
             allocator.destroy(entry);
             return null;
         };
+        entry.owned_cids[0] = cid;
+        entry.owned_cid_count = 1;
         routes.insert(cid, handle) catch {
             entry.deinit(allocator);
             allocator.destroy(entry);
@@ -627,11 +640,50 @@ pub const Runtime = struct {
         handle: u64,
     ) void {
         if (connections.fetchRemove(handle)) |kv| {
-            routes.remove(quic.cid.ConnectionId.init(kv.value.conn.localCid()) catch unreachable);
+            for (kv.value.owned_cids[0..kv.value.owned_cid_count]) |cid| routes.remove(cid);
             decPerIp(per_ip, kv.value.admission_source_ip);
             kv.value.deinit(self.allocator);
             self.allocator.destroy(kv.value);
             self.noteConnectionClosed();
+        }
+    }
+
+    fn syncCidRoutes(self: *Runtime, entry: *ConnEntry, routes: *quic.cid.CidRoutingTable) void {
+        _ = self;
+        var active: [quic.cid.max_local_active_cids]quic.cid.ConnectionId = undefined;
+        const active_count = entry.conn.copyActiveLocalCids(&active);
+        var i: usize = 0;
+        while (i < entry.owned_cid_count) {
+            if (!cidSliceContains(active[0..active_count], entry.owned_cids[i])) {
+                routes.remove(entry.owned_cids[i]);
+                entry.owned_cids[i] = entry.owned_cids[entry.owned_cid_count - 1];
+                entry.owned_cid_count -= 1;
+                continue;
+            }
+            i += 1;
+        }
+    }
+
+    fn maintainLocalCidRoutes(self: *Runtime, entry: *ConnEntry, handle: u64, routes: *quic.cid.CidRoutingTable) void {
+        _ = self;
+        while (entry.conn.needsLocalCid() and entry.owned_cid_count < entry.owned_cids.len) {
+            var cid_value: ?quic.cid.ConnectionId = null;
+            var entropy: [quic.udp.MaxConnectionIdLen]u8 = undefined;
+            for (0..cid_generation_retries) |_| {
+                compat.randomBytes(&entropy);
+                const candidate = quic.cid.generateCid(&entropy, @intCast(entry.cid_len)) catch return;
+                if (routes.contains(candidate)) continue;
+                cid_value = candidate;
+                break;
+            }
+            const cid = cid_value orelse return;
+            routes.insert(cid, handle) catch return;
+            entry.conn.advertiseLocalCid(cid) catch {
+                routes.remove(cid);
+                return;
+            };
+            entry.owned_cids[entry.owned_cid_count] = cid;
+            entry.owned_cid_count += 1;
         }
     }
 
@@ -1186,6 +1238,13 @@ fn decPerIp(per_ip: *std.AutoHashMap(u32, u32), addr: u32) void {
         count.* -= 1;
         if (count.* == 0) _ = per_ip.remove(addr);
     }
+}
+
+fn cidSliceContains(cids: []const quic.cid.ConnectionId, needle: quic.cid.ConnectionId) bool {
+    for (cids) |cid| {
+        if (std.mem.eql(u8, cid.slice(), needle.slice())) return true;
+    }
+    return false;
 }
 
 /// Create a non-blocking, close-on-exec UDP socket for `sa_family`. Returns a

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -677,14 +677,32 @@ pub const Runtime = struct {
                 break;
             }
             const cid = cid_value orelse return;
-            routes.insert(cid, handle) catch return;
-            entry.conn.advertiseLocalCid(cid) catch {
-                routes.remove(cid);
-                return;
-            };
-            entry.owned_cids[entry.owned_cid_count] = cid;
-            entry.owned_cid_count += 1;
+            switch (registerLocalCidRoute(entry, handle, routes, cid)) {
+                .registered => {},
+                .collision => continue,
+                .queue_failed => return,
+            }
         }
+    }
+
+    const RegisterLocalCidRouteResult = enum {
+        registered,
+        collision,
+        queue_failed,
+    };
+
+    fn registerLocalCidRoute(entry: *ConnEntry, handle: u64, routes: *quic.cid.CidRoutingTable, cid: quic.cid.ConnectionId) RegisterLocalCidRouteResult {
+        routes.insert(cid, handle) catch |err| switch (err) {
+            error.CidCollision => return .collision,
+            error.OutOfMemory => return .queue_failed,
+        };
+        entry.conn.advertiseLocalCid(cid) catch {
+            routes.remove(cid);
+            return .queue_failed;
+        };
+        entry.owned_cids[entry.owned_cid_count] = cid;
+        entry.owned_cid_count += 1;
+        return .registered;
     }
 
     fn pumpH3(self: *Runtime, entry: *ConnEntry, now: u64) void {
@@ -1264,6 +1282,108 @@ fn openUdpSocket(sa_family: u32) std.c.fd_t {
 
 const testing = std.testing;
 
+const RuntimeCidHarness = struct {
+    client_backend: quic.tls_backend.Tls13Backend,
+    server_backend: *quic.tls_backend.Tls13Backend,
+    client: *Connection,
+    entry: *ConnEntry,
+    now_us: u64 = 1_000_000,
+
+    const client_cid = [_]u8{ 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8 };
+    const odcid = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08 };
+    const client_path = quic.path.PathKey{
+        .local = quic.udp.Address.ip4(.{ 127, 0, 0, 1 }, 42_000),
+        .remote = quic.udp.Address.ip4(.{ 127, 0, 0, 1 }, 42_001),
+    };
+    const server_path = quic.path.PathKey{
+        .local = quic.udp.Address.ip4(.{ 127, 0, 0, 1 }, 42_001),
+        .remote = quic.udp.Address.ip4(.{ 127, 0, 0, 1 }, 42_000),
+    };
+    const no_challenge = [_]u8{0} ** quic.path.path_challenge_len;
+
+    fn init(allocator: std.mem.Allocator, credential_provider: tls_core.credentials.CredentialProvider) !*RuntimeCidHarness {
+        const self = try allocator.create(RuntimeCidHarness);
+        errdefer allocator.destroy(self);
+        const server_backend = try allocator.create(quic.tls_backend.Tls13Backend);
+        errdefer allocator.destroy(server_backend);
+        const entry = try allocator.create(ConnEntry);
+        errdefer allocator.destroy(entry);
+        server_backend.* = quic.tls_backend.Tls13Backend.initServerWithProvider(
+            .{ .hello_random = [_]u8{0x51} ** 32, .key_share_seed = [_]u8{0x22} ** 32 },
+            credential_provider,
+        );
+        self.* = .{
+            .client_backend = quic.tls_backend.Tls13Backend.initClient(
+                .{ .hello_random = [_]u8{0xc1} ** 32, .key_share_seed = [_]u8{0x11} ** 32 },
+                .{ .pinned_certificate = tls_core.credentials.testdata.certificate_der },
+            ),
+            .server_backend = server_backend,
+            .client = undefined,
+            .entry = entry,
+        };
+        self.client = try Connection.init(allocator, .{
+            .role = .client,
+            .local_cid = &client_cid,
+            .original_dcid = &odcid,
+            .peer_cid = &odcid,
+            .tls = self.client_backend.backend(),
+            .now_us = self.now_us,
+            .initial_path = client_path,
+        });
+        errdefer self.client.deinit();
+        const server = try Connection.init(allocator, .{
+            .role = .server,
+            .local_cid = &odcid,
+            .original_dcid = &odcid,
+            .peer_cid = &client_cid,
+            .tls = server_backend.backend(),
+            .now_us = self.now_us,
+            .initial_path = server_path,
+            .stateless_reset_key = [_]u8{0x44} ** 32,
+        });
+        entry.* = .{
+            .backend = server_backend,
+            .conn = server,
+            .h3 = H3.initWithSettings(allocator, .server, .{}),
+            .admission_source_ip = 0x0100007f,
+            .cid_len = odcid.len,
+            .accepted_at_us = self.now_us,
+        };
+        entry.owned_cids[0] = try quic.cid.ConnectionId.init(&odcid);
+        entry.owned_cid_count = 1;
+        try self.pump();
+        return self;
+    }
+
+    fn deinit(self: *RuntimeCidHarness, allocator: std.mem.Allocator) void {
+        self.client.deinit();
+        self.entry.deinit(allocator);
+        allocator.destroy(self.entry);
+        allocator.destroy(self);
+    }
+
+    fn pump(self: *RuntimeCidHarness) !void {
+        var rounds: usize = 0;
+        while (rounds < 64) : (rounds += 1) {
+            var progressed = false;
+            var buf: [2048]u8 = undefined;
+            while (self.client.pollTransmitOnPath(&buf, self.now_us)) |t| {
+                try self.entry.conn.ingestOnPath(t.bytes, server_path, no_challenge, self.now_us);
+                progressed = true;
+                self.now_us += 500;
+            }
+            while (self.entry.conn.pollTransmitOnPath(&buf, self.now_us)) |t| {
+                try self.client.ingestOnPath(t.bytes, client_path, no_challenge, self.now_us);
+                progressed = true;
+                self.now_us += 500;
+            }
+            if (!progressed) break;
+        }
+        try testing.expect(self.client.isEstablished());
+        try testing.expect(self.entry.conn.isEstablished());
+    }
+};
+
 test "stream request bridge maps exchange fields and Host" {
     const allocator = testing.allocator;
     var request = try buildStreamRequest(allocator, .{
@@ -1302,6 +1422,117 @@ test "quicConfigFrom clamps datagram size into the work-buffer range" {
     const mid = quicConfigFrom(.{ .listen_host = "::", .quic_port = 443, .max_datagram_size = 1350 });
     try testing.expectEqual(@as(u64, 1350), mid.max_udp_payload_size);
     try testing.expectEqual(quic.config.MigrationPolicy.disabled, mid.migration_policy);
+}
+
+test "http3 runtime: spare CID route is registered before NEW_CONNECTION_ID is pollable" {
+    var fixed = tls_core.credentials.FixedCredentialProvider.init(tls_core.credentials.testdata.identity());
+    defer fixed.deinit();
+    var logger = logger_mod.Logger.init(.err, "http3-cid-route-order-test");
+    var runtime = try Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+        .credential_provider = fixed.provider(),
+    });
+    defer runtime.deinit();
+    var harness = try RuntimeCidHarness.init(testing.allocator, fixed.provider());
+    defer harness.deinit(testing.allocator);
+
+    var routes = quic.cid.CidRoutingTable.init(testing.allocator);
+    defer routes.deinit();
+    const handle: u64 = 7;
+    const initial = harness.entry.owned_cids[0];
+    try routes.insert(initial, handle);
+    try testing.expect(routes.contains(initial));
+    try testing.expectEqual(@as(usize, 1), harness.entry.owned_cid_count);
+    try testing.expectEqual(@as(usize, 0), harness.entry.conn.pending_new_connection_ids.items.len);
+
+    runtime.maintainLocalCidRoutes(harness.entry, handle, &routes);
+    try testing.expectEqual(@as(usize, 2), harness.entry.owned_cid_count);
+    try testing.expectEqual(@as(usize, 1), harness.entry.conn.pending_new_connection_ids.items.len);
+    const spare = harness.entry.owned_cids[1];
+    try testing.expect(routes.contains(spare));
+
+    var out: [2048]u8 = undefined;
+    _ = harness.entry.conn.pollTransmitOnPath(&out, harness.now_us) orelse return error.TestExpectedEqual;
+    try testing.expectEqual(@as(usize, 0), harness.entry.conn.pending_new_connection_ids.items.len);
+}
+
+test "http3 runtime: CID route collision rolls back without stealing an existing route" {
+    var fixed = tls_core.credentials.FixedCredentialProvider.init(tls_core.credentials.testdata.identity());
+    defer fixed.deinit();
+    var harness = try RuntimeCidHarness.init(testing.allocator, fixed.provider());
+    defer harness.deinit(testing.allocator);
+
+    var routes = quic.cid.CidRoutingTable.init(testing.allocator);
+    defer routes.deinit();
+    const handle: u64 = 7;
+    const collision_owner: u64 = 99;
+    const candidate = try quic.cid.ConnectionId.init(&.{ 9, 8, 7, 6, 5, 4, 3, 2 });
+    try routes.insert(harness.entry.owned_cids[0], handle);
+    try routes.insert(candidate, collision_owner);
+
+    const before_routes = routes.count();
+    const before_owned = harness.entry.owned_cid_count;
+    const before_pending = harness.entry.conn.pending_new_connection_ids.items.len;
+    try testing.expectEqual(Runtime.RegisterLocalCidRouteResult.collision, Runtime.registerLocalCidRoute(harness.entry, handle, &routes, candidate));
+    try testing.expectEqual(before_routes, routes.count());
+    try testing.expectEqual(before_owned, harness.entry.owned_cid_count);
+    try testing.expectEqual(before_pending, harness.entry.conn.pending_new_connection_ids.items.len);
+    try testing.expectEqual(@as(?u64, collision_owner), routes.lookup(candidate.slice()));
+}
+
+test "http3 runtime: retired CIDs stop routing, replenish, and teardown removes every route" {
+    var fixed = tls_core.credentials.FixedCredentialProvider.init(tls_core.credentials.testdata.identity());
+    defer fixed.deinit();
+    var logger = logger_mod.Logger.init(.err, "http3-cid-teardown-test");
+    var runtime = try Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+        .credential_provider = fixed.provider(),
+    });
+    defer runtime.deinit();
+    var harness = try RuntimeCidHarness.init(testing.allocator, fixed.provider());
+    defer {
+        harness.client.deinit();
+        testing.allocator.destroy(harness);
+    }
+
+    var routes = quic.cid.CidRoutingTable.init(testing.allocator);
+    defer routes.deinit();
+    const handle: u64 = 7;
+    const initial = harness.entry.owned_cids[0];
+    try routes.insert(initial, handle);
+    runtime.maintainLocalCidRoutes(harness.entry, handle, &routes);
+    const spare = harness.entry.owned_cids[1];
+    try testing.expect(routes.contains(spare));
+
+    var out: [2048]u8 = undefined;
+    _ = harness.entry.conn.pollTransmitOnPath(&out, harness.now_us) orelse return error.TestExpectedEqual;
+    _ = try harness.entry.conn.local_cids.?.retire(.{ .sequence = 1 });
+    runtime.syncCidRoutes(harness.entry, &routes);
+    try testing.expect(!routes.contains(spare));
+    try testing.expectEqual(@as(?u64, null), routes.lookup(spare.slice()));
+
+    runtime.maintainLocalCidRoutes(harness.entry, handle, &routes);
+    try testing.expectEqual(@as(usize, 2), harness.entry.owned_cid_count);
+    try testing.expect(routes.contains(initial));
+    const replacement = for (harness.entry.owned_cids[0..harness.entry.owned_cid_count]) |cid| {
+        if (!std.mem.eql(u8, cid.slice(), initial.slice())) break cid;
+    } else return error.TestExpectedEqual;
+    try testing.expect(!std.mem.eql(u8, replacement.slice(), spare.slice()));
+    try testing.expect(routes.contains(replacement));
+
+    var connections = std.AutoHashMap(u64, *ConnEntry).init(testing.allocator);
+    defer connections.deinit();
+    var per_ip = std.AutoHashMap(u32, u32).init(testing.allocator);
+    defer per_ip.deinit();
+    const admission_ip = harness.entry.admission_source_ip;
+    try connections.put(handle, harness.entry);
+    try incPerIp(&per_ip, admission_ip);
+    runtime.removeConnection(&connections, &routes, &per_ip, handle);
+    try testing.expectEqual(@as(usize, 0), connections.count());
+    try testing.expectEqual(@as(usize, 0), routes.count());
+    try testing.expectEqual(@as(?u32, null), per_ip.get(admission_ip));
 }
 
 test "quicEarlyDataTransportCompatible (#523): rejects any reduced limit in the full RFC 9000 §7.4.1 set" {

--- a/src/quic/cid.zig
+++ b/src/quic/cid.zig
@@ -148,6 +148,7 @@ pub const LocalCidRegistry = struct {
     reset_token_key: [32]u8,
     entries: [max_local_active_cids]?Entry = [_]?Entry{null} ** max_local_active_cids,
     next_sequence: u64 = 0,
+    largest_advertised_sequence: ?u64 = null,
     metrics: Metrics = .{},
 
     pub fn init(peer_active_connection_id_limit: u64, reset_token_key: [32]u8) LocalCidRegistry {
@@ -161,7 +162,9 @@ pub const LocalCidRegistry = struct {
     /// (RFC 9000 §5.1.1). Call once, before any `issue`.
     pub fn registerInitial(self: *LocalCidRegistry, cid: ConnectionId) error{ CidLimitExceeded, DuplicateCid }!Entry {
         std.debug.assert(self.next_sequence == 0);
-        return self.store(cid);
+        const entry = try self.store(cid);
+        self.largest_advertised_sequence = entry.sequence;
+        return entry;
     }
 
     /// Issue a fresh CID from caller-supplied entropy and return the
@@ -214,7 +217,8 @@ pub const LocalCidRegistry = struct {
     /// permitted retransmit of an already-retired sequence. A sequence this
     /// endpoint never issued is a protocol violation (RFC 9000 §19.16).
     pub fn retire(self: *LocalCidRegistry, frame: RetireConnectionIdFrame) error{ProtocolViolation}!?ConnectionId {
-        if (frame.sequence >= self.next_sequence) return error.ProtocolViolation;
+        const largest = self.largest_advertised_sequence orelse return error.ProtocolViolation;
+        if (frame.sequence > largest) return error.ProtocolViolation;
         for (&self.entries) |*slot| {
             const entry = &(slot.* orelse continue);
             if (entry.sequence != frame.sequence) continue;
@@ -225,6 +229,17 @@ pub const LocalCidRegistry = struct {
         }
         // Issued in the past and already retired: a permitted retransmit.
         return null;
+    }
+
+    pub fn markAdvertised(self: *LocalCidRegistry, sequence: u64) error{ProtocolViolation}!void {
+        if (sequence >= self.next_sequence) return error.ProtocolViolation;
+        if (self.largest_advertised_sequence) |largest| {
+            if (sequence <= largest) return;
+            if (sequence != largest + 1) return error.ProtocolViolation;
+        } else if (sequence != 0) {
+            return error.ProtocolViolation;
+        }
+        self.largest_advertised_sequence = sequence;
     }
 
     pub fn activeCount(self: *const LocalCidRegistry) usize {
@@ -578,6 +593,7 @@ test "retired local CIDs stop routing and unknown retire sequences are violation
     var entropy = [_]u8{0x10} ** 8;
     const issued = try registry.issue(&entropy, 8);
     try table.insert(issued.cid, 1);
+    try registry.markAdvertised(issued.sequence);
     try testing.expectEqual(@as(u64, 1), issued.sequence);
     try testing.expectEqual(@as(?u64, 1), table.lookup(issued.cid.slice()));
 
@@ -600,6 +616,7 @@ test "local registry enforces the peer's active CID limit and derives reset toke
 
     var entropy = [_]u8{0x20} ** 8;
     const issued = try registry.issue(&entropy, 8);
+    try registry.markAdvertised(issued.sequence);
     // The frame's token matches the RFC 9000 §10.3.1 derivation for the CID.
     try testing.expectEqualSlices(u8, &statelessResetToken(key, issued.cid.slice()), &issued.stateless_reset_token);
 
@@ -739,6 +756,7 @@ test "CID issue/retire churn does not leak routing table entries" {
         std.mem.writeInt(u64, &entropy, iteration + 1, .big);
         const issued = try registry.issue(&entropy, 8);
         try table.insert(issued.cid, 1);
+        try registry.markAdvertised(issued.sequence);
         if (try registry.retire(.{ .sequence = previous_sequence })) |retired| {
             table.remove(retired);
         }

--- a/src/quic/cid.zig
+++ b/src/quic/cid.zig
@@ -170,6 +170,13 @@ pub const LocalCidRegistry = struct {
     /// more CIDs than the peer's limit).
     pub fn issue(self: *LocalCidRegistry, entropy: []const u8, cid_len: u8) !NewConnectionIdFrame {
         const cid = try generateCid(entropy, cid_len);
+        return try self.issueCid(cid);
+    }
+
+    /// Issue a caller-generated CID. Production endpoints use this
+    /// transactional form so a route table entry can be reserved before the
+    /// exact CID is queued in a NEW_CONNECTION_ID frame.
+    pub fn issueCid(self: *LocalCidRegistry, cid: ConnectionId) error{ CidLimitExceeded, DuplicateCid }!NewConnectionIdFrame {
         const entry = try self.store(cid);
         self.metrics.cids_issued += 1;
         return .{
@@ -232,6 +239,24 @@ pub const LocalCidRegistry = struct {
         for (self.entries) |entry| {
             if (entry) |value| {
                 if (value.sequence == sequence) return value;
+            }
+        }
+        return null;
+    }
+
+    pub fn containsCid(self: *const LocalCidRegistry, cid: ConnectionId) bool {
+        for (self.entries) |entry| {
+            if (entry) |value| {
+                if (std.mem.eql(u8, value.cid.slice(), cid.slice())) return true;
+            }
+        }
+        return false;
+    }
+
+    pub fn sequenceForCid(self: *const LocalCidRegistry, cid: ConnectionId) ?u64 {
+        for (self.entries) |entry| {
+            if (entry) |value| {
+                if (std.mem.eql(u8, value.cid.slice(), cid.slice())) return value.sequence;
             }
         }
         return null;

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -248,6 +248,9 @@ pub const Options = struct {
     /// server's initial path stays amplification-limited until the
     /// handshake completes unless this is true.
     initial_address_validated: bool = false,
+    /// Process-lifetime stateless reset secret supplied by the runtime. The
+    /// transport derives a token for every locally issued CID from this key.
+    stateless_reset_key: [32]u8 = [_]u8{0} ** 32,
 };
 
 // ---------------------------------------------------------------------------
@@ -603,6 +606,7 @@ const SentRecord = struct {
     carried_handshake_done: bool = false,
     carried_reset_stream: ?quic_stream.ResetStreamFrame = null,
     carried_stop_sending: ?quic_stream.StopSendingFrame = null,
+    carried_new_connection_id: ?quic_cid.NewConnectionIdFrame = null,
     /// PATH_CHALLENGE re-arms on loss; PATH_RESPONSE does not (the peer
     /// re-challenges, RFC 9000 §8.2.2). Both force datagram expansion.
     /// Non-null when this record carried a PATH_CHALLENGE for the given
@@ -666,6 +670,8 @@ pub const Connection = struct {
     original_dcid: config.CidValue,
     retry_scid: ?config.CidValue = null,
     retry_token: std.ArrayList(u8) = .empty,
+    local_cids: ?quic_cid.LocalCidRegistry = null,
+    stateless_reset_key: [32]u8,
     peer_cids: quic_cid.PeerCidPool,
 
     streams: ?quic_stream.StreamManager = null,
@@ -715,6 +721,7 @@ pub const Connection = struct {
     pending_resets: std.ArrayList(quic_stream.ResetStreamFrame) = .empty,
     pending_stop_sending: std.ArrayList(quic_stream.StopSendingFrame) = .empty,
     pending_retires: std.ArrayList(u64) = .empty,
+    pending_new_connection_ids: std.ArrayList(quic_cid.NewConnectionIdFrame) = .empty,
     pending_path_responses: std.ArrayList(PendingPathResponse) = .empty,
     /// Candidate paths currently being validated (RFC 9000 §8.2), keyed by
     /// path so multiple concurrent probes (bounded by `quic_path.max_paths`)
@@ -750,6 +757,7 @@ pub const Connection = struct {
             else
                 .{},
             .original_dcid = try config.CidValue.init(options.original_dcid),
+            .stateless_reset_key = options.stateless_reset_key,
             .peer_cids = quic_cid.PeerCidPool.init(params.active_connection_id_limit),
             .send_queues = std.AutoHashMap(StreamId, *SendQueue).init(allocator),
             .known_streams = std.AutoHashMap(StreamId, void).init(allocator),
@@ -782,6 +790,7 @@ pub const Connection = struct {
         };
         if (options.role == .server) {
             binding.original_destination_connection_id = conn.original_dcid;
+            binding.stateless_reset_token = quic_cid.statelessResetToken(options.stateless_reset_key, conn.local_cid.slice());
         }
         options.tls.setCidBinding(binding);
 
@@ -843,6 +852,7 @@ pub const Connection = struct {
         self.pending_resets.deinit(self.allocator);
         self.pending_stop_sending.deinit(self.allocator);
         self.pending_retires.deinit(self.allocator);
+        self.pending_new_connection_ids.deinit(self.allocator);
         self.pending_path_responses.deinit(self.allocator);
         self.candidate_challenges.deinit(self.allocator);
         self.retry_token.deinit(self.allocator);
@@ -883,6 +893,47 @@ pub const Connection = struct {
     /// The connection ID the peer routes to us with (for endpoint routing).
     pub fn localCid(self: *const Connection) []const u8 {
         return self.local_cid.slice();
+    }
+
+    pub fn activeLocalCidCount(self: *const Connection) usize {
+        if (self.local_cids) |registry| return registry.activeCount();
+        return 1;
+    }
+
+    pub fn copyActiveLocalCids(self: *const Connection, out: []quic_cid.ConnectionId) usize {
+        var count: usize = 0;
+        if (self.local_cids) |registry| {
+            for (registry.entries) |entry| {
+                if (entry) |value| {
+                    if (count == out.len) return count;
+                    out[count] = value.cid;
+                    count += 1;
+                }
+            }
+            return count;
+        }
+        if (out.len > 0) {
+            out[0] = quic_cid.ConnectionId.init(self.local_cid.slice()) catch return 0;
+            return 1;
+        }
+        return 0;
+    }
+
+    pub fn needsLocalCid(self: *const Connection) bool {
+        if (self.state_ != .established) return false;
+        const registry = if (self.local_cids) |*registry| registry else return false;
+        const target = @min(@as(usize, 2), @as(usize, @intCast(registry.active_limit)));
+        return registry.activeCount() < target;
+    }
+
+    pub fn advertiseLocalCid(self: *Connection, cid_value: quic_cid.ConnectionId) error{ CidLimitExceeded, DuplicateCid, OutOfMemory }!void {
+        const registry = if (self.local_cids) |*registry| registry else return error.CidLimitExceeded;
+        const ncid = registry.issueCid(cid_value) catch |err| switch (err) {
+            error.CidLimitExceeded => return error.CidLimitExceeded,
+            error.DuplicateCid => return error.DuplicateCid,
+        };
+        errdefer _ = registry.retire(.{ .sequence = ncid.sequence }) catch null;
+        try self.pending_new_connection_ids.append(self.allocator, ncid);
     }
 
     fn setState(self: *Connection, next: State) void {
@@ -984,10 +1035,10 @@ pub const Connection = struct {
             self.dropPacket(.unsupported_version, bytes.len);
             return;
         }
-        if (!std.mem.eql(u8, parsed.dcid, self.local_cid.slice())) {
+        const local_cid_sequence = self.localCidSequence(parsed.dcid) orelse {
             self.dropPacket(.unknown_cid, bytes.len);
             return;
-        }
+        };
 
         const level: EncryptionLevel = switch (parsed.kind) {
             .initial => .initial,
@@ -1174,7 +1225,7 @@ pub const Connection = struct {
                 };
                 const f = decoded orelse break;
                 if (f.isAckEliciting()) ack_eliciting = true;
-                try self.applyFrame(level, f, ingress_path, now_us);
+                try self.applyFrame(level, f, ingress_path, local_cid_sequence, now_us);
                 if (self.state_ == .closed or self.state_ == .draining) return;
                 if (self.state_ == .closing) break;
             }
@@ -1195,7 +1246,14 @@ pub const Connection = struct {
         }
     }
 
-    fn applyFrame(self: *Connection, level: EncryptionLevel, f: frame.Frame, ingress_path: quic_path.PathKey, now_us: u64) IngestError!void {
+    fn localCidSequence(self: *const Connection, dcid: []const u8) ?u64 {
+        const parsed = quic_cid.ConnectionId.init(dcid) catch return null;
+        if (self.local_cids) |registry| return registry.sequenceForCid(parsed);
+        if (std.mem.eql(u8, dcid, self.local_cid.slice())) return 0;
+        return null;
+    }
+
+    fn applyFrame(self: *Connection, level: EncryptionLevel, f: frame.Frame, ingress_path: quic_path.PathKey, local_cid_sequence: u64, now_us: u64) IngestError!void {
         if (!frameAllowedAtLevel(level, f)) {
             self.startClose(.{ .error_code = error_protocol_violation, .is_application = false, .local = true }, "0-rtt frame level", now_us);
             return;
@@ -1320,9 +1378,21 @@ pub const Connection = struct {
                 // waiting for another challenge round trip.
                 if (self.paths.pendingPromotionCandidate()) |candidate| self.tryPromote(candidate);
             },
-            .retire_connection_id => {
-                // We never issue additional CIDs, so there is nothing to
-                // retire; tolerate the frame (it can only name sequence 0).
+            .retire_connection_id => |retire| {
+                if (retire.sequence == local_cid_sequence) {
+                    self.startClose(.{ .error_code = error_protocol_violation, .is_application = false, .local = true }, "retire active cid", now_us);
+                    return;
+                }
+                const registry = if (self.local_cids) |*registry| registry else {
+                    if (retire.sequence == 0) return;
+                    self.startClose(.{ .error_code = error_protocol_violation, .is_application = false, .local = true }, "RETIRE_CONNECTION_ID", now_us);
+                    return;
+                };
+                const retired = registry.retire(retire) catch {
+                    self.startClose(.{ .error_code = error_protocol_violation, .is_application = false, .local = true }, "RETIRE_CONNECTION_ID", now_us);
+                    return;
+                };
+                _ = retired;
             },
             .path_challenge => |data| {
                 // Echo on the exact path the challenge arrived on (RFC 9000
@@ -1502,6 +1572,9 @@ pub const Connection = struct {
         }
         if (record.carried_stop_sending) |stop| {
             self.pending_stop_sending.append(self.allocator, stop) catch {};
+        }
+        if (record.carried_new_connection_id) |ncid| {
+            self.pending_new_connection_ids.append(self.allocator, ncid) catch {};
         }
         if (record.carried_path_challenge_path) |path| {
             for (self.candidate_challenges.items) |*candidate| {
@@ -1828,6 +1901,18 @@ pub const Connection = struct {
             self.startClose(.{ .error_code = error_transport_parameter, .is_application = false, .local = true }, "missing peer params", now_us);
             return;
         };
+        if (self.local_cids == null) {
+            var registry = quic_cid.LocalCidRegistry.init(peer_params.active_connection_id_limit, self.stateless_reset_key);
+            const initial = quic_cid.ConnectionId.init(self.local_cid.slice()) catch {
+                self.startClose(.{ .error_code = error_internal, .is_application = false, .local = true }, "local cid registry", now_us);
+                return;
+            };
+            _ = registry.registerInitial(initial) catch {
+                self.startClose(.{ .error_code = error_internal, .is_application = false, .local = true }, "local cid registry", now_us);
+                return;
+            };
+            self.local_cids = registry;
+        }
         if (self.streams) |*manager| {
             // 0-RTT already brought the stream layer up early with a
             // zero-send-credit placeholder peer side (see
@@ -2760,6 +2845,7 @@ pub const Connection = struct {
         if (self.pending_resets.items.len > 0) return true;
         if (self.pending_stop_sending.items.len > 0) return true;
         if (self.pending_retires.items.len > 0) return true;
+        if (self.pending_new_connection_ids.items.len > 0) return true;
         if (self.hasActivePathResponsePending()) return true;
         var it = self.send_queues.iterator();
         while (it.next()) |entry| {
@@ -2825,6 +2911,14 @@ pub const Connection = struct {
             plain_len += n;
             record.ack_eliciting = true;
             _ = self.pending_retires.orderedRemove(0);
+        }
+        while (self.pending_new_connection_ids.items.len > 0) {
+            const ncid = self.pending_new_connection_ids.items[0];
+            const n = frame.encodeNewConnectionId(ncid, plain[plain_len..budget]) catch break;
+            plain_len += n;
+            record.ack_eliciting = true;
+            record.carried_new_connection_id = ncid;
+            _ = self.pending_new_connection_ids.orderedRemove(0);
         }
         // Only a PATH_RESPONSE queued for the active path rides along with
         // ordinary content; one queued for a candidate path is sent in
@@ -3377,7 +3471,7 @@ test "driver: explicit zero-rtt stream provenance mark stays sticky after one-rt
     try pair.server.markStreamZeroRtt(id);
     try testing.expect(pair.server.streamTransportEarly(id));
 
-    try pair.server.applyFrame(.application, .{ .stream = .{ .id = id, .offset = 0, .data = "late", .fin = true } }, TestPair.server_path, pair.now_us);
+    try pair.server.applyFrame(.application, .{ .stream = .{ .id = id, .offset = 0, .data = "late", .fin = true } }, TestPair.server_path, 0, pair.now_us);
     try testing.expect(pair.server.streamTransportEarly(id));
     try testing.expectEqual(@as(?StreamId, id), pair.server.acceptStream());
 
@@ -3567,7 +3661,7 @@ test "driver: 0-RTT stream provenance survives reassembly, duplicate delivery, a
 
     // Later 1-RTT bytes on the same stream must not retroactively lose the
     // sticky early marking, and read correctly alongside the early bytes.
-    try pair.server.applyFrame(.application, .{ .stream = .{ .id = 0, .offset = 5, .data = "!", .fin = true } }, TestPair.server_path, pair.now_us);
+    try pair.server.applyFrame(.application, .{ .stream = .{ .id = 0, .offset = 5, .data = "!", .fin = true } }, TestPair.server_path, 0, pair.now_us);
     try testing.expect(pair.server.streamTransportEarly(0));
     const late_read = try pair.server.readStream(0, &buf);
     try testing.expectEqualStrings("!", buf[0..late_read.len]);
@@ -3727,7 +3821,7 @@ test "driver: frames illegal in 0-RTT close the connection instead of taking eff
             .ranges = .{},
             .ack_delay_raw = 0,
             .largest_acknowledged = 0,
-        } }, TestPair.server_path, pair.now_us);
+        } }, TestPair.server_path, 0, pair.now_us);
         try testing.expectEqual(State.closing, pair.server.state());
         try testing.expectEqual(error_protocol_violation, pair.server.close_info.?.error_code);
     }
@@ -3741,7 +3835,7 @@ test "driver: frames illegal in 0-RTT close the connection instead of taking eff
     {
         var pair = try TestPair.init(allocator);
         defer pair.deinit(allocator);
-        try pair.server.applyFrame(.zero_rtt, .{ .crypto = .{ .offset = 0, .data = "x" } }, TestPair.server_path, pair.now_us);
+        try pair.server.applyFrame(.zero_rtt, .{ .crypto = .{ .offset = 0, .data = "x" } }, TestPair.server_path, 0, pair.now_us);
         try testing.expectEqual(State.closing, pair.server.state());
         try testing.expectEqual(error_protocol_violation, pair.server.close_info.?.error_code);
     }
@@ -3749,7 +3843,7 @@ test "driver: frames illegal in 0-RTT close the connection instead of taking eff
     {
         var pair = try TestPair.init(allocator);
         defer pair.deinit(allocator);
-        try pair.server.applyFrame(.zero_rtt, .{ .new_token = .{ .token = "t" } }, TestPair.server_path, pair.now_us);
+        try pair.server.applyFrame(.zero_rtt, .{ .new_token = .{ .token = "t" } }, TestPair.server_path, 0, pair.now_us);
         try testing.expectEqual(State.closing, pair.server.state());
         try testing.expectEqual(error_protocol_violation, pair.server.close_info.?.error_code);
     }
@@ -3757,7 +3851,7 @@ test "driver: frames illegal in 0-RTT close the connection instead of taking eff
     {
         var pair = try TestPair.init(allocator);
         defer pair.deinit(allocator);
-        try pair.server.applyFrame(.zero_rtt, .{ .retire_connection_id = .{ .sequence = 0 } }, TestPair.server_path, pair.now_us);
+        try pair.server.applyFrame(.zero_rtt, .{ .retire_connection_id = .{ .sequence = 0 } }, TestPair.server_path, 0, pair.now_us);
         try testing.expectEqual(State.closing, pair.server.state());
         try testing.expectEqual(error_protocol_violation, pair.server.close_info.?.error_code);
     }
@@ -3765,7 +3859,7 @@ test "driver: frames illegal in 0-RTT close the connection instead of taking eff
     {
         var pair = try TestPair.init(allocator);
         defer pair.deinit(allocator);
-        try pair.server.applyFrame(.zero_rtt, .{ .path_response = [_]u8{0} ** frame.path_data_len }, TestPair.server_path, pair.now_us);
+        try pair.server.applyFrame(.zero_rtt, .{ .path_response = [_]u8{0} ** frame.path_data_len }, TestPair.server_path, 0, pair.now_us);
         try testing.expectEqual(State.closing, pair.server.state());
         try testing.expectEqual(error_protocol_violation, pair.server.close_info.?.error_code);
     }
@@ -3773,7 +3867,7 @@ test "driver: frames illegal in 0-RTT close the connection instead of taking eff
     {
         var pair = try TestPair.init(allocator);
         defer pair.deinit(allocator);
-        try pair.server.applyFrame(.zero_rtt, .handshake_done, TestPair.server_path, pair.now_us);
+        try pair.server.applyFrame(.zero_rtt, .handshake_done, TestPair.server_path, 0, pair.now_us);
         try testing.expectEqual(State.closing, pair.server.state());
         try testing.expectEqual(error_protocol_violation, pair.server.close_info.?.error_code);
     }
@@ -5711,6 +5805,58 @@ test "connection: a path validation deadline is folded into nextTimeoutUs and ex
     try testing.expectEqual(quic_path.PathState.failed, pair.server.paths.stateOf(rebind_candidate).?);
 }
 
+test "connection: local CID registry maintains a spare and accepts packets addressed to it" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    try testing.expect(pair.server.needsLocalCid());
+    const spare = try quic_cid.ConnectionId.init(&.{ 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8 });
+    try pair.server.advertiseLocalCid(spare);
+    try testing.expect(!pair.server.needsLocalCid());
+    try testing.expectEqual(@as(?u64, 1), pair.server.localCidSequence(spare.slice()));
+
+    pair.client.peer_cid = try config.CidValue.init(spare.slice());
+    const id = try pair.client.openStream(.bidi);
+    try testing.expectEqual(@as(usize, 5), try pair.client.writeStream(id, "spare", false));
+
+    var out: [2048]u8 = undefined;
+    const t = pair.client.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
+    const parsed = packet.parsePacket(t.bytes, spare.len) catch return error.TestUnexpectedResult;
+    try testing.expectEqualSlices(u8, spare.slice(), parsed.dcid);
+
+    const before = pair.server.metrics.packets_received;
+    try pair.server.ingestOnPath(t.bytes, TestPair.server_path, TestPair.test_challenge_entropy, pair.now_us);
+    try testing.expect(pair.server.metrics.packets_received > before);
+}
+
+test "connection: lost NEW_CONNECTION_ID retransmits the same frame identity" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const spare = try quic_cid.ConnectionId.init(&.{ 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8 });
+    try pair.server.advertiseLocalCid(spare);
+
+    var out: [2048]u8 = undefined;
+    _ = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
+    const first_record = pair.server.sent_records.items[pair.server.sent_records.items.len - 1];
+    const first = first_record.carried_new_connection_id orelse return error.TestExpectedEqual;
+    try testing.expectEqual(@as(u64, 1), first.sequence);
+    try testing.expectEqualSlices(u8, spare.slice(), first.cid.slice());
+
+    pair.server.requeueRecord(first_record);
+    _ = pair.server.pollTransmitOnPath(&out, pair.now_us + 1_000) orelse return error.TestExpectedEqual;
+    const second_record = pair.server.sent_records.items[pair.server.sent_records.items.len - 1];
+    const second = second_record.carried_new_connection_id orelse return error.TestExpectedEqual;
+    try testing.expectEqual(first.sequence, second.sequence);
+    try testing.expectEqual(first.retire_prior_to, second.retire_prior_to);
+    try testing.expectEqualSlices(u8, first.cid.slice(), second.cid.slice());
+    try testing.expectEqualSlices(u8, &first.stateless_reset_token, &second.stateless_reset_token);
+}
+
 test "driver: idle timeout closes silently" {
     const allocator = testing.allocator;
     var pair = try TestPair.init(allocator);
@@ -5794,7 +5940,7 @@ fn expectConnectionRejectsExtraCryptoWhileClientAuthPending(async_sign: bool) !v
     const stray = [_]u8{@intFromEnum(tls_core.handshake.MessageType.finished)};
     const handshake_index = @intFromEnum(EncryptionLevel.handshake);
     const offset = pair.client.adapter.reassembler.streams[handshake_index].consumed_offset;
-    try pair.client.applyFrame(.handshake, .{ .crypto = .{ .offset = offset, .data = &stray } }, TestPair.client_path, pair.now_us);
+    try pair.client.applyFrame(.handshake, .{ .crypto = .{ .offset = offset, .data = &stray } }, TestPair.client_path, 0, pair.now_us);
 
     try testing.expect(!pair.client.authPending());
     try testing.expectEqual(tls_handshake.HandshakeError.UnexpectedHandshakeMessage, pair.client.handshakeFailure().?);

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -927,13 +927,13 @@ pub const Connection = struct {
     }
 
     pub fn advertiseLocalCid(self: *Connection, cid_value: quic_cid.ConnectionId) error{ CidLimitExceeded, DuplicateCid, OutOfMemory }!void {
+        try self.pending_new_connection_ids.ensureUnusedCapacity(self.allocator, 1);
         const registry = if (self.local_cids) |*registry| registry else return error.CidLimitExceeded;
         const ncid = registry.issueCid(cid_value) catch |err| switch (err) {
             error.CidLimitExceeded => return error.CidLimitExceeded,
             error.DuplicateCid => return error.DuplicateCid,
         };
-        errdefer _ = registry.retire(.{ .sequence = ncid.sequence }) catch null;
-        try self.pending_new_connection_ids.append(self.allocator, ncid);
+        self.pending_new_connection_ids.appendAssumeCapacity(ncid);
     }
 
     fn setState(self: *Connection, next: State) void {
@@ -2816,6 +2816,9 @@ pub const Connection = struct {
             self.last_ack_eliciting_sent_us[space_idx] = now_us;
             if (tracked) self.sent_records.append(self.allocator, record) catch {};
         }
+        if (record.carried_new_connection_id) |ncid| {
+            if (self.local_cids) |*registry| registry.markAdvertised(ncid.sequence) catch {};
+        }
         self.metrics.packets_sent += 1;
         self.events.emit(.{ .packet_sent = .{
             .space = space,
@@ -2912,13 +2915,14 @@ pub const Connection = struct {
             record.ack_eliciting = true;
             _ = self.pending_retires.orderedRemove(0);
         }
-        while (self.pending_new_connection_ids.items.len > 0) {
+        if (self.pending_new_connection_ids.items.len > 0) {
             const ncid = self.pending_new_connection_ids.items[0];
-            const n = frame.encodeNewConnectionId(ncid, plain[plain_len..budget]) catch break;
-            plain_len += n;
-            record.ack_eliciting = true;
-            record.carried_new_connection_id = ncid;
-            _ = self.pending_new_connection_ids.orderedRemove(0);
+            if (frame.encodeNewConnectionId(ncid, plain[plain_len..budget])) |n| {
+                plain_len += n;
+                record.ack_eliciting = true;
+                record.carried_new_connection_id = ncid;
+                _ = self.pending_new_connection_ids.orderedRemove(0);
+            } else |_| {}
         }
         // Only a PATH_RESPONSE queued for the active path rides along with
         // ordinary content; one queued for a candidate path is sent in
@@ -5855,6 +5859,76 @@ test "connection: lost NEW_CONNECTION_ID retransmits the same frame identity" {
     try testing.expectEqual(first.retire_prior_to, second.retire_prior_to);
     try testing.expectEqualSlices(u8, first.cid.slice(), second.cid.slice());
     try testing.expectEqualSlices(u8, &first.stateless_reset_token, &second.stateless_reset_token);
+}
+
+test "connection: unadvertised local CID retirement is a protocol violation" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const spare = try quic_cid.ConnectionId.init(&.{ 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8 });
+    try pair.server.advertiseLocalCid(spare);
+    try testing.expectEqual(@as(usize, 1), pair.server.pending_new_connection_ids.items.len);
+
+    try pair.server.applyFrame(.application, .{ .retire_connection_id = .{ .sequence = 1 } }, TestPair.server_path, 0, pair.now_us);
+    try testing.expectEqual(State.closing, pair.server.state());
+    try testing.expectEqual(error_protocol_violation, pair.server.close_info.?.error_code);
+}
+
+test "connection: advertised local CID can be retired from another active CID" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const spare = try quic_cid.ConnectionId.init(&.{ 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8 });
+    try pair.server.advertiseLocalCid(spare);
+    var out: [2048]u8 = undefined;
+    _ = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
+
+    try pair.server.applyFrame(.application, .{ .retire_connection_id = .{ .sequence = 1 } }, TestPair.server_path, 0, pair.now_us);
+    try testing.expectEqual(State.established, pair.server.state());
+    try testing.expectEqual(@as(?u64, null), pair.server.localCidSequence(spare.slice()));
+    try testing.expect(pair.server.needsLocalCid());
+}
+
+test "connection: losing one NEW_CONNECTION_ID leaves all queued CID identities pending" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const first_cid = try quic_cid.ConnectionId.init(&.{ 0xe1, 0xe2, 0xe3, 0xe4, 0xe5, 0xe6, 0xe7, 0xe8 });
+    const second_cid = try quic_cid.ConnectionId.init(&.{ 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8 });
+    try pair.server.advertiseLocalCid(first_cid);
+    try pair.server.advertiseLocalCid(second_cid);
+    try testing.expectEqual(@as(usize, 2), pair.server.pending_new_connection_ids.items.len);
+
+    var out: [2048]u8 = undefined;
+    _ = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
+    const sent = pair.server.sent_records.items[pair.server.sent_records.items.len - 1];
+    const first = sent.carried_new_connection_id orelse return error.TestExpectedEqual;
+    try testing.expectEqual(@as(u64, 1), first.sequence);
+    try testing.expectEqualSlices(u8, first_cid.slice(), first.cid.slice());
+    try testing.expectEqual(@as(usize, 1), pair.server.pending_new_connection_ids.items.len);
+    try testing.expectEqualSlices(u8, second_cid.slice(), pair.server.pending_new_connection_ids.items[0].cid.slice());
+
+    pair.server.requeueRecord(sent);
+    try testing.expectEqual(@as(usize, 2), pair.server.pending_new_connection_ids.items.len);
+    var saw_first = false;
+    var saw_second = false;
+    for (pair.server.pending_new_connection_ids.items) |pending| {
+        if (pending.sequence == 1 and std.mem.eql(u8, pending.cid.slice(), first_cid.slice())) {
+            try testing.expectEqualSlices(u8, &first.stateless_reset_token, &pending.stateless_reset_token);
+            saw_first = true;
+        }
+        if (pending.sequence == 2 and std.mem.eql(u8, pending.cid.slice(), second_cid.slice())) {
+            saw_second = true;
+        }
+    }
+    try testing.expect(saw_first);
+    try testing.expect(saw_second);
 }
 
 test "driver: idle timeout closes silently" {


### PR DESCRIPTION
## Summary

Refs #387. Implements the Slice 3 local-CID lifecycle integration for the native QUIC/H3 runtime.

- add transactional caller-generated local CID issuance so runtime routing is reserved before NEW_CONNECTION_ID can be emitted
- let Connection own active local CID state after handshake, accept all active local DCIDs, process RETIRE_CONNECTION_ID, and retransmit the same NEW_CONNECTION_ID frame identity on loss
- track every runtime-owned CID route per connection, reconcile retired CIDs, and remove all owned routes on teardown

## Validation

- zig fmt --check build.zig src/ tests/
- zig build test-quic --summary all --error-style verbose
- zig build test --summary all --error-style verbose

## Notes

This intentionally does not close #387. Remaining slices still need production Retry admission, CID-role split for Retry, operator retry/migration policy wiring, metrics, docs, and the broader UDP acceptance tests.