### PR TITLE
tls: make PSK binders HelloRetryRequest-aware

### DIFF
--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -3605,6 +3605,212 @@ test "driver: HelloRetryRequest completes through real QUIC Initial CRYPTO data"
     }
 }
 
+// #485: a genuine two-`Connection` loopback proving PSK resumption itself
+// (not just the non-PSK HRR retry mechanics the #484 test above covers)
+// survives a real HelloRetryRequest over the QUIC adapter — the client's
+// retained offer is re-emitted in ClientHello2 with a binder derived from
+// the rebound transcript, and the server verifies it against that same
+// digest, exactly as `src/tls/tls13_backend_tests.zig`'s direct-harness
+// tests prove at the TLS-backend level.
+test "driver: PSK resumption completes through a real HelloRetryRequest over QUIC" {
+    const allocator = testing.allocator;
+
+    const LoggedEvent = union(enum) { packet_sent: PacketNumberSpace, keys_discarded: PacketNumberSpace };
+    const EventCapture = struct {
+        log: [64]LoggedEvent = undefined,
+        len: usize = 0,
+
+        fn onEvent(ctx: ?*anyopaque, event: Event) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx.?));
+            const logged: LoggedEvent = switch (event) {
+                .packet_sent => |p| .{ .packet_sent = p.space },
+                .keys_discarded => |space| .{ .keys_discarded = space },
+                else => return,
+            };
+            if (self.len == self.log.len) return;
+            self.log[self.len] = logged;
+            self.len += 1;
+        }
+
+        fn initialPacketsSentBeforeInitialDiscard(self: *const @This()) usize {
+            var count: usize = 0;
+            for (self.log[0..self.len]) |entry| {
+                switch (entry) {
+                    .packet_sent => |space| if (space == .initial) {
+                        count += 1;
+                    },
+                    .keys_discarded => |space| if (space == .initial) return count,
+                }
+            }
+            return count;
+        }
+    };
+    var client_capture = EventCapture{};
+    var server_capture = EventCapture{};
+
+    const psk = [_]u8{0x64} ** tls_core.tls13_backend.hash_len;
+    var common: tls_core.session.ResumableSessionCommon = .{};
+    try common.init(allocator, tls_core.session.Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = &psk,
+        // QUIC negotiates "h3", not the record profile's "h2" — must match
+        // what `onEncryptedExtensions` actually negotiates or the resumed
+        // connection is fatally rejected as an ALPN mismatch, not merely
+        // falling back to a full handshake.
+        .application_protocol = "h3",
+        .auth_binding = tls_core.session.AuthBinding.fromLeafCertificateDer(tls_backend_mod.testdata.certificate_der),
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 3600,
+    });
+    var ticket: tls_core.session.ClientTicketState = .{};
+    try ticket.init(allocator, tls_core.session.Limits.default, &common, .{
+        .ticket = "quic-hrr-resumption-ticket",
+        .ticket_age_add = 0,
+        .ticket_nonce = "n",
+        .received_at_unix_ms = 0,
+    });
+    var offers: tls_core.pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&ticket);
+    var clock_dummy: u8 = 0;
+    const Clock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 5_000;
+        }
+    };
+
+    var stored_common: tls_core.session.ResumableSessionCommon = .{};
+    try stored_common.init(allocator, tls_core.session.Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = &psk,
+        .application_protocol = "h3",
+        .auth_binding = tls_core.session.AuthBinding.fromLeafCertificateDer(tls_backend_mod.testdata.certificate_der),
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 3600,
+    });
+    var stored_state: tls_core.session.ServerRecoverableState = .{};
+    stored_state.init(&stored_common, 0);
+    defer stored_state.deinit();
+
+    const Resolver = struct {
+        state: *tls_core.session.ServerRecoverableState,
+        calls: usize = 0,
+
+        fn now(_: *anyopaque) i64 {
+            return 0;
+        }
+        fn resolve(ctx: *anyopaque, identity: []const u8) tls_core.pre_shared_key.ResolveError!tls_core.pre_shared_key.ServerPskResolveResult {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.calls += 1;
+            if (!std.mem.eql(u8, identity, "quic-hrr-resumption-ticket")) return .miss;
+            var out: tls_core.session.ServerRecoverableState = .{};
+            self.state.cloneInto(testing.allocator, &out) catch return error.ResolverFailed;
+            return .{ .hit = .{ .state = out, .lease = tls_core.pre_shared_key.ServerPskLease.initNoop() } };
+        }
+    };
+    var resolver_state = Resolver{ .state = &stored_state };
+    const DecisionProbe = struct {
+        count: usize = 0,
+        last: ?tls_core.tls13_backend.Tls13Backend.ResumptionDecision = null,
+        fn onDecision(ctx: *anyopaque, decision: tls_core.tls13_backend.Tls13Backend.ResumptionDecision) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.count += 1;
+            self.last = decision;
+        }
+    };
+    var decision_probe = DecisionProbe{};
+
+    const pair = try allocator.create(TestPair);
+    errdefer allocator.destroy(pair);
+    pair.* = .{
+        .client_backend = try tls_backend_mod.Tls13Backend.initClientWithAllocatorAndOptions(
+            allocator,
+            .{ .hello_random = [_]u8{0xc1} ** 32, .key_share_seed = [_]u8{0x11} ** 32, .retry_key_share_seed = [_]u8{0x13} ** 32 },
+            .{ .pinned_certificate = tls_backend_mod.testdata.certificate_der },
+            .{ .initial_key_share_mode = .empty },
+        ),
+        .server_backend = tls_backend_mod.Tls13Backend.initServerWithAllocator(
+            allocator,
+            .{ .hello_random = [_]u8{0x51} ** 32, .key_share_seed = [_]u8{0x22} ** 32, .retry_key_share_seed = [_]u8{0x23} ** 32 },
+            try tls_backend_mod.Identity.initPkcs8(
+                tls_backend_mod.testdata.certificate_der,
+                tls_backend_mod.testdata.private_key_pkcs8_der,
+            ),
+        ),
+    };
+    // Native QUIC 1-RTT resumption deliberately ignores connection-specific
+    // transport/application snapshots (matching the runtime-composition PSK
+    // tests elsewhere in this file) — a hand-built stored ticket has no
+    // transport_compat of its own to match against this fresh connection's.
+    const resume_policy: tls_core.tls13_backend.Tls13Backend.ResumeCompatibilityPolicy = .{
+        .transport = .ignore,
+        .application = .ignore,
+    };
+    try pair.client_backend.engine.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+    try pair.client_backend.setResumeCompatibilityPolicy(resume_policy);
+    try pair.server_backend.setResumeCompatibilityPolicy(resume_policy);
+    try pair.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = Resolver.now,
+        .resolveFn = Resolver.resolve,
+    });
+    try pair.server_backend.setResumptionDecisionObserver(.{ .ctx = &decision_probe, .onDecisionFn = DecisionProbe.onDecision });
+
+    pair.client = try Connection.init(allocator, .{
+        .role = .client,
+        .local_cid = &TestPair.client_cid,
+        .original_dcid = &TestPair.odcid,
+        .peer_cid = &TestPair.odcid,
+        .tls = pair.client_backend.backend(),
+        .now_us = pair.now_us,
+        .initial_path = TestPair.client_path,
+        .events = .{ .context = &client_capture, .emitFn = EventCapture.onEvent },
+    });
+    errdefer pair.client.deinit();
+    pair.server = try Connection.init(allocator, .{
+        .role = .server,
+        .local_cid = &TestPair.odcid,
+        .original_dcid = &TestPair.odcid,
+        .peer_cid = &TestPair.client_cid,
+        .tls = pair.server_backend.backend(),
+        .now_us = pair.now_us,
+        .initial_path = TestPair.server_path,
+        .events = .{ .context = &server_capture, .emitFn = EventCapture.onEvent },
+    });
+    defer pair.deinit(allocator);
+
+    try pair.pump();
+
+    try testing.expectEqual(State.established, pair.client.state());
+    try testing.expectEqual(State.established, pair.server.state());
+
+    // The resumption itself actually succeeded (not merely a plain HRR
+    // retry that happened to fall back to a full handshake), and it went
+    // through exactly one HelloRetryRequest.
+    try testing.expectEqual(@as(usize, 1), resolver_state.calls);
+    try testing.expectEqual(@as(usize, 1), decision_probe.count);
+    try testing.expectEqual(tls_core.tls13_backend.Tls13Backend.ResumptionDecision.accepted, decision_probe.last.?);
+    try testing.expect(pair.client_backend.engine.core.psk_authenticated);
+    try testing.expect(pair.server_backend.engine.core.psk_authenticated);
+    try testing.expectEqual(tls_core.handshake.RetryState.hrr_received, pair.client_backend.engine.core.retry_state);
+    try testing.expectEqual(tls_core.handshake.RetryState.hrr_sent, pair.server_backend.engine.core.retry_state);
+
+    // HRR and ClientHello2 (like the non-PSK #484 case) stayed at the
+    // Initial epoch, and Initial keys were not discarded before both of a
+    // side's Initial-space flight packets had already gone out.
+    try testing.expect(server_capture.initialPacketsSentBeforeInitialDiscard() >= 2);
+    try testing.expect(client_capture.initialPacketsSentBeforeInitialDiscard() >= 2);
+
+    // The resumed connection is genuinely usable under the post-HRR,
+    // PSK-derived keys.
+    const id = try pair.client.openStream(.bidi);
+    try testing.expectEqual(@as(usize, 5), try pair.client.writeStream(id, "hello", true));
+    try pair.pump();
+    try testing.expectEqual(@as(?StreamId, id), pair.server.acceptStream());
+    var buf: [16]u8 = undefined;
+    const request = try pair.server.readStream(id, &buf);
+    try testing.expectEqualStrings("hello", buf[0..request.len]);
+}
+
 test "driver: bidirectional stream data round-trips with FIN" {
     const allocator = testing.allocator;
     var pair = try TestPair.init(allocator);

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -3758,7 +3758,8 @@ test "driver: PSK resumption completes through a real HelloRetryRequest over QUI
     pair.client = try Connection.init(allocator, .{
         .role = .client,
         .local_cid = &TestPair.client_cid,
-        .original_dcid = &TestPair.odcid,
+        .original_destination_cid = &TestPair.odcid,
+        .initial_secret_dcid = &TestPair.odcid,
         .peer_cid = &TestPair.odcid,
         .tls = pair.client_backend.backend(),
         .now_us = pair.now_us,
@@ -3769,7 +3770,8 @@ test "driver: PSK resumption completes through a real HelloRetryRequest over QUI
     pair.server = try Connection.init(allocator, .{
         .role = .server,
         .local_cid = &TestPair.odcid,
-        .original_dcid = &TestPair.odcid,
+        .original_destination_cid = &TestPair.odcid,
+        .initial_secret_dcid = &TestPair.odcid,
         .peer_cid = &TestPair.client_cid,
         .tls = pair.server_backend.backend(),
         .now_us = pair.now_us,

--- a/src/tls/pre_shared_key.zig
+++ b/src/tls/pre_shared_key.zig
@@ -292,23 +292,33 @@ pub fn writeOffer(w: *messages.Writer, items: []const OfferItem) WriteError!Clie
 //   early_secret  = HKDF-Extract(0, PSK)
 //   binder_key    = Derive-Secret(early_secret, "res binder", "")
 //   finished_key  = HKDF-Expand-Label(binder_key, "finished", "", L)
-//   binder        = HMAC(finished_key, Hash(truncated ClientHello))
+//   binder        = HMAC(finished_key, transcript_hash)
+//
+// `transcript_hash` is ordinarily `Hash(truncated ClientHello)`; after a
+// HelloRetryRequest it is instead `Hash(message_hash(Hash(ClientHello1)) ||
+// HelloRetryRequest || Truncate(ClientHello2))` (#485) — the caller supplies
+// this precomputed digest so this module never has to know which case it is.
 // -----------------------------------------------------------------------
 
 /// Derives the resumption binder for `psk` (already exactly
 /// `hash.digestLength()` bytes — the caller derives it via
-/// `key_schedule.KeySchedule.resumptionPsk`) over `truncated_client_hello`
-/// (the exact framed-message prefix ending just before the binders
-/// vector's own length field) into `out` (must be exactly
-/// `hash.digestLength()` bytes).
-pub fn deriveBinder(
+/// `key_schedule.KeySchedule.resumptionPsk`) over a precomputed
+/// `transcript_hash` (exactly `hash.digestLength()` bytes: either
+/// `Hash(Truncate(ClientHello1))` or, after a HelloRetryRequest,
+/// `Hash(message_hash(Hash(ClientHello1)) || HelloRetryRequest ||
+/// Truncate(ClientHello2))`) into `out` (must be exactly
+/// `hash.digestLength()` bytes). Never touches the live transcript itself —
+/// obtaining `transcript_hash` without mutating it is the caller's
+/// responsibility (see `transcript.Transcript.peekWith`).
+pub fn deriveBinderFromTranscriptHash(
     hash: provider.Hash,
     psk: []const u8,
-    truncated_client_hello: []const u8,
+    transcript_hash: []const u8,
     out: []u8,
 ) BinderError!void {
     const expected_len = hash.digestLength();
-    if (psk.len != expected_len or out.len != expected_len) return error.InvalidSecretLength;
+    if (psk.len != expected_len or out.len != expected_len or transcript_hash.len != expected_len)
+        return error.InvalidSecretLength;
     switch (hash) {
         .sha256 => {
             var empty_hash: [Sha256.digest_length]u8 = undefined;
@@ -325,10 +335,8 @@ pub fn deriveBinder(
             var finished_key = tls.hkdfExpandLabel(HkdfSha256, binder_key, "finished", "", Sha256.digest_length);
             defer crypto.secureZero(u8, &finished_key);
 
-            var transcript_hash: [Sha256.digest_length]u8 = undefined;
-            Sha256.hash(truncated_client_hello, &transcript_hash, .{});
             var mac: [HmacSha256.mac_length]u8 = undefined;
-            HmacSha256.create(&mac, &transcript_hash, &finished_key);
+            HmacSha256.create(&mac, transcript_hash[0..Sha256.digest_length], &finished_key);
             @memcpy(out, &mac);
         },
         .sha384 => {
@@ -346,36 +354,72 @@ pub fn deriveBinder(
             var finished_key = tls.hkdfExpandLabel(HkdfSha384, binder_key, "finished", "", HmacSha384.mac_length);
             defer crypto.secureZero(u8, &finished_key);
 
-            var transcript_hash: [Sha384.digest_length]u8 = undefined;
-            Sha384.hash(truncated_client_hello, &transcript_hash, .{});
             var mac: [HmacSha384.mac_length]u8 = undefined;
-            HmacSha384.create(&mac, &transcript_hash, &finished_key);
+            HmacSha384.create(&mac, transcript_hash[0..Sha384.digest_length], &finished_key);
             @memcpy(out, &mac);
         },
     }
 }
 
-/// Constant-time binder verification: derives the expected binder for `psk`
-/// over `truncated_client_hello` and compares it against `candidate_binder`
-/// without early-exiting on a byte mismatch. A length mismatch (the binder
-/// on the wire is not `hash.digestLength()` bytes) is reported as a
-/// non-match, not an error — a wrong-length binder is simply wrong.
-pub fn verifyBinder(
+/// Constant-time binder verification against a precomputed `transcript_hash`
+/// (see `deriveBinderFromTranscriptHash`): derives the expected binder for
+/// `psk` and compares it against `candidate_binder` without early-exiting on
+/// a byte mismatch. A length mismatch (the binder on the wire is not
+/// `hash.digestLength()` bytes) is reported as a non-match, not an error —
+/// a wrong-length binder is simply wrong.
+pub fn verifyBinderFromTranscriptHash(
     hash: provider.Hash,
     psk: []const u8,
-    truncated_client_hello: []const u8,
+    transcript_hash: []const u8,
     candidate_binder: []const u8,
 ) BinderError!bool {
     var computed: [provider.max_digest_len]u8 = undefined;
     const out = computed[0..hash.digestLength()];
     defer crypto.secureZero(u8, out);
-    try deriveBinder(hash, psk, truncated_client_hello, out);
+    try deriveBinderFromTranscriptHash(hash, psk, transcript_hash, out);
     if (out.len != candidate_binder.len) return false;
     return switch (out.len) {
         32 => crypto.timing_safe.eql([32]u8, out[0..32].*, candidate_binder[0..32].*),
         48 => crypto.timing_safe.eql([48]u8, out[0..48].*, candidate_binder[0..48].*),
         else => false,
     };
+}
+
+/// Ordinary (non-HRR) ClientHello wrapper: hashes `truncated_client_hello`
+/// (the exact framed-message prefix ending just before the binders vector's
+/// own length field) with `hash` and derives the binder over that digest via
+/// `deriveBinderFromTranscriptHash`.
+pub fn deriveBinder(
+    hash: provider.Hash,
+    psk: []const u8,
+    truncated_client_hello: []const u8,
+    out: []u8,
+) BinderError!void {
+    var transcript_hash_buf: [provider.max_digest_len]u8 = undefined;
+    const transcript_hash = transcript_hash_buf[0..hash.digestLength()];
+    switch (hash) {
+        .sha256 => Sha256.hash(truncated_client_hello, transcript_hash[0..Sha256.digest_length], .{}),
+        .sha384 => Sha384.hash(truncated_client_hello, transcript_hash[0..Sha384.digest_length], .{}),
+    }
+    return deriveBinderFromTranscriptHash(hash, psk, transcript_hash, out);
+}
+
+/// Ordinary (non-HRR) ClientHello wrapper around
+/// `verifyBinderFromTranscriptHash` — see `deriveBinder` for the digest
+/// computed over `truncated_client_hello`.
+pub fn verifyBinder(
+    hash: provider.Hash,
+    psk: []const u8,
+    truncated_client_hello: []const u8,
+    candidate_binder: []const u8,
+) BinderError!bool {
+    var transcript_hash_buf: [provider.max_digest_len]u8 = undefined;
+    const transcript_hash = transcript_hash_buf[0..hash.digestLength()];
+    switch (hash) {
+        .sha256 => Sha256.hash(truncated_client_hello, transcript_hash[0..Sha256.digest_length], .{}),
+        .sha384 => Sha384.hash(truncated_client_hello, transcript_hash[0..Sha384.digest_length], .{}),
+    }
+    return verifyBinderFromTranscriptHash(hash, psk, transcript_hash, candidate_binder);
 }
 
 // -----------------------------------------------------------------------
@@ -1163,6 +1207,100 @@ test "verifyBinder rejects a wrong-length candidate without erroring" {
     var binder: [32]u8 = undefined;
     try deriveBinder(.sha256, &psk, "prefix", &binder);
     try testing.expect(!try verifyBinder(.sha256, &psk, "prefix", binder[0..31]));
+}
+
+test "the ordinary ClientHello wrapper matches direct deriveBinderFromTranscriptHash output" {
+    const psk = [_]u8{0x42} ** 32;
+    const truncated_client_hello = "an arbitrary truncated ClientHello prefix";
+
+    var expected_via_wrapper: [32]u8 = undefined;
+    try deriveBinder(.sha256, &psk, truncated_client_hello, &expected_via_wrapper);
+
+    var transcript_hash: [32]u8 = undefined;
+    Sha256.hash(truncated_client_hello, &transcript_hash, .{});
+    var direct: [32]u8 = undefined;
+    try deriveBinderFromTranscriptHash(.sha256, &psk, &transcript_hash, &direct);
+
+    try testing.expectEqualSlices(u8, &expected_via_wrapper, &direct);
+    try testing.expect(try verifyBinderFromTranscriptHash(.sha256, &psk, &transcript_hash, &direct));
+
+    const psk384 = [_]u8{0x99} ** 48;
+    var expected_via_wrapper384: [48]u8 = undefined;
+    try deriveBinder(.sha384, &psk384, truncated_client_hello, &expected_via_wrapper384);
+    var transcript_hash384: [48]u8 = undefined;
+    Sha384.hash(truncated_client_hello, &transcript_hash384, .{});
+    var direct384: [48]u8 = undefined;
+    try deriveBinderFromTranscriptHash(.sha384, &psk384, &transcript_hash384, &direct384);
+    try testing.expectEqualSlices(u8, &expected_via_wrapper384, &direct384);
+}
+
+test "a deterministic HRR fixture matches an independently computed rebound binder" {
+    // Independently computed (Python hashlib/hmac, not this module's own
+    // `std.crypto.tls.hkdfExpandLabel`/transcript code) over
+    // `Hash(message_hash(Hash(CH1)) || HRR || Truncate(CH2))` — the exact
+    // #485 rebound-transcript binder input RFC 8446 §4.2.11.2 requires after
+    // a HelloRetryRequest. `ch1`/`hrr`/`ch2_truncated` are arbitrary
+    // fixed-shape "framed message" byte strings (only their bytes matter to
+    // the hash, not real TLS semantics).
+    const psk = [_]u8{0x5a} ** 32;
+    const ch1 = [_]u8{ 1, 0, 0, 3, 0xAA, 0xBB, 0xCC };
+    const hrr = [_]u8{ 2, 0, 0, 2, 0xDD, 0xEE };
+    const ch2_truncated = [_]u8{ 1, 0, 0, 4, 0x11, 0x22, 0x33, 0x44 };
+
+    var ch1_hash: [32]u8 = undefined;
+    Sha256.hash(&ch1, &ch1_hash, .{});
+
+    // message_hash record: type 254, 3-byte length (32), then the digest —
+    // matching `transcript.Transcript.rebindClientHello`'s synthetic record.
+    var msg_hash_record: [4 + 32]u8 = undefined;
+    msg_hash_record[0] = 254;
+    std.mem.writeInt(u24, msg_hash_record[1..4], 32, .big);
+    @memcpy(msg_hash_record[4..], &ch1_hash);
+
+    var rebound_input: [msg_hash_record.len + hrr.len + ch2_truncated.len]u8 = undefined;
+    @memcpy(rebound_input[0..msg_hash_record.len], &msg_hash_record);
+    @memcpy(rebound_input[msg_hash_record.len..][0..hrr.len], &hrr);
+    @memcpy(rebound_input[msg_hash_record.len + hrr.len ..], &ch2_truncated);
+
+    var transcript_hash: [32]u8 = undefined;
+    Sha256.hash(&rebound_input, &transcript_hash, .{});
+    const expected_transcript_hash = hexBytes("bf7ceeb56705cefb2742d47a3914c98ebe0c873c594107cd25a727a10fc2cba8");
+    try testing.expectEqualSlices(u8, &expected_transcript_hash, &transcript_hash);
+
+    var binder: [32]u8 = undefined;
+    try deriveBinderFromTranscriptHash(.sha256, &psk, &transcript_hash, &binder);
+    const expected_binder = hexBytes("70ba04b488fd16cec6afb692457754c26e577cfcdcaee4811c254baa10ffc4a5");
+    try testing.expectEqualSlices(u8, &expected_binder, &binder);
+    try testing.expect(try verifyBinderFromTranscriptHash(.sha256, &psk, &transcript_hash, &binder));
+
+    // A binder computed as `Hash(Truncate(CH2))` in isolation — the
+    // pre-#485, non-HRR-aware mistake — must not accidentally match.
+    var isolated_transcript_hash: [32]u8 = undefined;
+    Sha256.hash(&ch2_truncated, &isolated_transcript_hash, .{});
+    try testing.expect(!std.mem.eql(u8, &isolated_transcript_hash, &transcript_hash));
+    try testing.expect(!try verifyBinderFromTranscriptHash(.sha256, &psk, &isolated_transcript_hash, &binder));
+}
+
+test "deriveBinderFromTranscriptHash rejects malformed secret/digest lengths without partial output" {
+    const psk = [_]u8{0x11} ** 32;
+    var transcript_hash: [32]u8 = undefined;
+    Sha256.hash("prefix", &transcript_hash, .{});
+
+    var out: [32]u8 = undefined;
+    // Wrong PSK length.
+    try testing.expectError(error.InvalidSecretLength, deriveBinderFromTranscriptHash(.sha256, psk[0..31], &transcript_hash, &out));
+    // Wrong transcript-hash length.
+    try testing.expectError(error.InvalidSecretLength, deriveBinderFromTranscriptHash(.sha256, &psk, transcript_hash[0..31], &out));
+    // Wrong output length.
+    var short_out: [31]u8 = undefined;
+    try testing.expectError(error.InvalidSecretLength, deriveBinderFromTranscriptHash(.sha256, &psk, &transcript_hash, &short_out));
+
+    // A SHA-384 transcript hash/PSK against the SHA-256 primitive is also a
+    // length mismatch, not silently truncated/extended.
+    const psk384 = [_]u8{0x22} ** 48;
+    var transcript_hash384: [48]u8 = undefined;
+    Sha384.hash("prefix", &transcript_hash384, .{});
+    try testing.expectError(error.InvalidSecretLength, deriveBinderFromTranscriptHash(.sha256, &psk384, &transcript_hash384, &out));
 }
 
 test "obfuscated ticket age round-trips including u32 wraparound" {

--- a/src/tls/pre_shared_key.zig
+++ b/src/tls/pre_shared_key.zig
@@ -336,6 +336,7 @@ pub fn deriveBinderFromTranscriptHash(
             defer crypto.secureZero(u8, &finished_key);
 
             var mac: [HmacSha256.mac_length]u8 = undefined;
+            defer crypto.secureZero(u8, &mac);
             HmacSha256.create(&mac, transcript_hash[0..Sha256.digest_length], &finished_key);
             @memcpy(out, &mac);
         },
@@ -355,6 +356,7 @@ pub fn deriveBinderFromTranscriptHash(
             defer crypto.secureZero(u8, &finished_key);
 
             var mac: [HmacSha384.mac_length]u8 = undefined;
+            defer crypto.secureZero(u8, &mac);
             HmacSha384.create(&mac, transcript_hash[0..Sha384.digest_length], &finished_key);
             @memcpy(out, &mac);
         },

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -32,6 +32,7 @@ const pre_shared_key = @import("pre_shared_key.zig");
 const session = @import("session.zig");
 const tls_state = @import("state.zig");
 const tls13_transport = @import("tls13_transport.zig");
+const tls_transcript = @import("transcript.zig");
 
 const crypto = std.crypto;
 const X25519 = crypto.dh.X25519;
@@ -789,6 +790,19 @@ pub const Tls13Backend = struct {
         /// within `message`.
         ext_data_offset: usize = 0,
         ext_data_len: usize = 0,
+        /// #485: the exact transcript digest this capture's offered
+        /// binder(s) must be verified against — `Hash(Truncate(CH1))` for
+        /// an ordinary capture, or `Hash(message_hash(Hash(CH1)) || HRR ||
+        /// Truncate(CH2))` for a post-retry capture. Computed once at
+        /// capture time (`onClientHello`), so `selectPsk` — including
+        /// across an asynchronous credential/PSK resolution suspend — never
+        /// needs to re-hash the truncated message or touch the live
+        /// (by-then further advanced) handshake transcript. Only meaningful
+        /// when this capture actually carries a `pre_shared_key` offer;
+        /// left `undefined` for the transient ClientHello1-retention-only
+        /// capture `emitHelloRetryRequest` writes on the `.retry` path,
+        /// which is always cleared before any offer capture reads it.
+        binder_transcript_hash: [hash_len]u8 = undefined,
 
         /// Zeroizes the captured bytes in place. Exposed (`pub`) so its
         /// zeroing behavior can be proven directly, on a plain value, in
@@ -801,6 +815,7 @@ pub const Tls13Backend = struct {
         pub fn wipe(self: *ClientHelloPskCapture) void {
             crypto.secureZero(u8, self.message[0..self.message_len]);
             self.message_len = 0;
+            crypto.secureZero(u8, &self.binder_transcript_hash);
         }
     };
 
@@ -1866,6 +1881,19 @@ pub const Tls13Backend = struct {
             // HRR, or an illegal ClientHello2 mutation, must be rejected
             // *before* either mutation ever runs, not only afterward by
             // `onHelloRetryRequest`/`onClientHello`.
+            // #485: for a second ClientHello, freeze the pre-ClientHello2
+            // transcript state (`message_hash(Hash(CH1)) || HRR`) as a
+            // plain stack value *before* `Core.acceptSecondClientHello`
+            // mutates it below — `onClientHello`'s PSK capture uses this
+            // snapshot's `peekWith(Truncate(ClientHello2))` to compute the
+            // rebound binder transcript digest, since by the time it runs
+            // the live transcript has already moved on to include the
+            // complete ClientHello2. Threaded through as a call argument
+            // (like `transcript_before` below), never stored on the
+            // backend, so it costs nothing in `Tls13Backend`'s own
+            // size budget.
+            const ch2_transcript_snapshot: ?tls_transcript.Transcript =
+                if (is_second_client_hello) self.core.transcript else null;
             if (is_hello_retry_request) {
                 try self.validateHelloRetryRequest(message.body);
                 _ = self.core.acceptHelloRetryRequest(message.raw) catch |err| return mapCoreError(err);
@@ -1875,7 +1903,7 @@ pub const Tls13Backend = struct {
             } else {
                 _ = self.core.acceptReceived(message.raw) catch |err| return mapCoreError(err);
             }
-            try self.onMessage(message, level, transcript_before, is_hello_retry_request, sink);
+            try self.onMessage(message, level, transcript_before, is_hello_retry_request, ch2_transcript_snapshot, sink);
             input.discard(message.raw.len) catch |err| return mapCoreError(err);
             // A parked async authentication operation suspends the handshake:
             // stop consuming buffered messages until the driver resumes it (any
@@ -2000,6 +2028,7 @@ pub const Tls13Backend = struct {
         level: EncryptionLevel,
         transcript_before: [hash_len]u8,
         is_hello_retry_request: bool,
+        ch2_transcript_snapshot: ?tls_transcript.Transcript,
         sink: *EventSink,
     ) HandshakeError!void {
         // Enforce the transport epoch each message belongs to before anything
@@ -2023,7 +2052,7 @@ pub const Tls13Backend = struct {
         // Dispatch the shared TLS semantics; transport extension contents stay
         // opaque and are consumed by the owning adapter.
         switch (kind) {
-            .client_hello => try self.onClientHello(message.raw, sink),
+            .client_hello => try self.onClientHello(message.raw, ch2_transcript_snapshot, sink),
             .server_hello => if (is_hello_retry_request)
                 try self.onHelloRetryRequest(body, sink)
             else
@@ -2777,8 +2806,87 @@ pub const Tls13Backend = struct {
             try w.bytes(cookie);
         }
 
+        // #485: retain the original PSK offer set across the retry and
+        // re-emit it verbatim (same identities, same wire order as
+        // ClientHello1 — `self.client_offer_lease.offers` is untouched
+        // since `onServerHello` is what eventually consumes it) with a
+        // freshly recomputed `obfuscated_ticket_age` per identity and
+        // placeholder binders sized to each identity's digest length. Must
+        // be the last extension (RFC 8446 §4.2.11), so this goes after
+        // every other extension above (including a requested cookie) and
+        // right before the outer length patches. Identities are never
+        // dropped to make room for the cookie: if the retained set no
+        // longer fits, the fixed-size `buf` write below fails with
+        // `error.HandshakeBufferOverflow` (propagated to the caller, which
+        // wipes all retained PSK state via `clearFailedHandshakeState`)
+        // rather than silently narrowing the offer.
+        var psk_secrets: [pre_shared_key.max_offered_identities][hash_len]u8 = undefined;
+        defer crypto.secureZero(u8, std.mem.asBytes(&psk_secrets));
+        var psk_count: usize = 0;
+        var psk_offer_write: ?pre_shared_key.ClientOfferWrite = null;
+        const active_offers = self.constClientPskOffers();
+        if (!active_offers.isEmpty()) {
+            const now_ms = self.psk_now_fn.?(self.psk_now_ctx.?);
+            var psk_items: [pre_shared_key.max_offered_identities]pre_shared_key.OfferItem = undefined;
+            for (active_offers.constSlice()) |*ticket| {
+                @memcpy(&psk_secrets[psk_count], ticket.common.resumption_psk.slice());
+                psk_items[psk_count] = .{
+                    .identity = ticket.ticket.slice(),
+                    .obfuscated_ticket_age = pre_shared_key.obfuscateTicketAge(ticket.ageMillis(now_ms), ticket.ticket_age_add),
+                    .digest_len = hash_len,
+                };
+                psk_count += 1;
+            }
+            try w.u16_(pre_shared_key.ext_psk_key_exchange_modes);
+            const modes_ext_len = try w.reserve(2);
+            pre_shared_key.writeModes(&w, &.{.psk_dhe_ke}) catch |err| switch (err) {
+                error.EmptyModes, error.TooManyModes => unreachable,
+                error.HandshakeBufferOverflow => return error.HandshakeBufferOverflow,
+            };
+            w.patch(2, modes_ext_len);
+            psk_offer_write = pre_shared_key.writeOffer(&w, psk_items[0..psk_count]) catch |err| switch (err) {
+                error.TooManyIdentities => unreachable, // bounded by ClientPskOfferSet's own capacity
+                // Every retained ticket already survived `planPskOffer`'s
+                // identity-shape checks (non-empty, wire-representable) when
+                // ClientHello1 was built — none of these are reachable
+                // through this concrete backend.
+                error.EmptyIdentity,
+                error.IdentityTooLarge,
+                error.IdentitiesVectorTooLarge,
+                error.InvalidBinderLength,
+                error.BindersVectorTooLarge,
+                error.ExtensionTooLarge,
+                => unreachable,
+                error.HandshakeBufferOverflow => return error.HandshakeBufferOverflow,
+            };
+        }
+
         w.patch(2, extensions_len);
         w.patch(3, message_len);
+
+        // #485: every enclosing length field (message, extensions block, the
+        // PSK extension itself, identities, binders) is now patched to its
+        // final value, so `buf[0..offer.truncated_len]` is exactly
+        // `Truncate(ClientHello2)`. Each binder is derived not from
+        // `Hash(Truncate(ClientHello2))` in isolation, but from the rebound
+        // transcript `message_hash(Hash(ClientHello1)) || HelloRetryRequest
+        // || Truncate(ClientHello2)` — obtained via `peekWith`, which reads
+        // the live transcript (already exactly `message_hash(Hash(CH1)) ||
+        // HRR` at this point, since ClientHello2 itself has not been
+        // recorded yet) without mutating it.
+        if (psk_offer_write) |offer| {
+            const prefix = buf[0..offer.truncated_len];
+            const rebound_transcript_hash = self.core.transcript.peekWith(prefix);
+            for (0..psk_count) |i| {
+                var binder: [hash_len]u8 = undefined;
+                defer crypto.secureZero(u8, &binder);
+                pre_shared_key.deriveBinderFromTranscriptHash(.sha256, &psk_secrets[i], &rebound_transcript_hash, &binder) catch
+                    return error.SecretExportFailed;
+                const slot = offer.slots[i];
+                @memcpy(buf[slot.offset..][0..slot.len], &binder);
+            }
+        }
+
         const message = buf[0..w.len];
 
         // Self-check before emission: proves this ClientHello2 is a legal
@@ -3393,7 +3501,12 @@ pub const Tls13Backend = struct {
     // Server flight.
     // -----------------------------------------------------------------------
 
-    fn onClientHello(self: *Tls13Backend, raw: []const u8, sink: *EventSink) HandshakeError!void {
+    fn onClientHello(
+        self: *Tls13Backend,
+        raw: []const u8,
+        ch2_transcript_snapshot: ?tls_transcript.Transcript,
+        sink: *EventSink,
+    ) HandshakeError!void {
         const body = raw[handshake_header_len..];
         // A server needs a credential source: the fixed identity or an external
         // provider. Which signature scheme is usable is decided later by
@@ -3543,6 +3656,26 @@ pub const Tls13Backend = struct {
             capture.message_len = raw.len;
             capture.ext_data_offset = handshake_header_len + info.body_offset;
             capture.ext_data_len = info.len;
+
+            // #485: compute the exact transcript digest this ClientHello's
+            // binder(s) must verify against, once, at capture time. The
+            // observer callback above already validated this same
+            // `ext_data` via `OfferedPsks.parse`, so re-parsing it here
+            // cannot fail.
+            const ext_data = capture.message[capture.ext_data_offset..][0..capture.ext_data_len];
+            const offered_for_capture = pre_shared_key.OfferedPsks.parse(ext_data) catch unreachable;
+            const truncated_len = capture.ext_data_offset + offered_for_capture.binder_vector_offset;
+            const truncated_prefix = capture.message[0..truncated_len];
+            if (self.core.retry_state == .hrr_sent) {
+                // Post-retry: binders must verify only against the rebound
+                // transcript `message_hash(Hash(CH1)) || HRR ||
+                // Truncate(CH2)` — never `Hash(Truncate(CH2))` alone.
+                const snapshot = ch2_transcript_snapshot orelse return error.InvalidHandshakeState;
+                capture.binder_transcript_hash = snapshot.peekWith(truncated_prefix);
+            } else {
+                Sha256.hash(truncated_prefix, &capture.binder_transcript_hash, .{});
+            }
+
             self.client_hello_psk = capture;
             self.offered_psk_modes_seen = true;
             self.offered_psk_dhe_ke = observer.psk_dhe_ke_offered;
@@ -3791,8 +3924,6 @@ pub const Tls13Backend = struct {
             self.resumption_decision_observer.notify(.fatal);
             return null;
         };
-        const truncated_len = capture.ext_data_offset + offered.binder_vector_offset;
-        const truncated_prefix = capture.message[0..truncated_len];
         const now = resolver.nowUnixMs();
 
         var it = offered.pairs();
@@ -3835,7 +3966,12 @@ pub const Tls13Backend = struct {
             defer crypto.secureZero(u8, &psk_buf);
             @memcpy(&psk_buf, psk_slice);
 
-            const ok = pre_shared_key.verifyBinder(.sha256, &psk_buf, truncated_prefix, pair.binder) catch
+            // #485: verify against the digest captured at parse time
+            // (`Hash(Truncate(CH1))`, or after a HelloRetryRequest
+            // `Hash(message_hash(Hash(CH1)) || HRR || Truncate(CH2))`) —
+            // never re-hash the truncated message in isolation, which would
+            // silently accept a pre-#485-shaped binder after a retry.
+            const ok = pre_shared_key.verifyBinderFromTranscriptHash(.sha256, &psk_buf, &capture.binder_transcript_hash, pair.binder) catch
                 return error.InvalidHandshakeState;
             if (!ok) {
                 self.resumption_decision_observer.notify(.fatal);

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -2705,18 +2705,39 @@ test "#485 client re-offers PSK identities across HelloRetryRequest with binders
     try offers.push(&ticket_a);
     try offers.push(&ticket_b);
 
-    var clock_dummy: u8 = 0;
+    // Mutable clock: CH1 and the HRR/CH2 must be observed at genuinely
+    // different times, or a test that merely echoes ClientHello1's own age
+    // would pass just as easily as one that actually recomputes it.
     const Clock = struct {
-        fn now(_: *anyopaque) i64 {
-            return 5_000;
+        now_ms: i64,
+        fn now(ctx: *anyopaque) i64 {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            return self.now_ms;
         }
     };
-    try client.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+    var clock = Clock{ .now_ms = 5_000 };
+    try client.setClientPskOffers(&offers, &clock, Clock.now);
 
     var sink = DirectSink{};
     defer sink.deinit();
     try client.backend().start(.client, {}, &sink);
     const ch1_raw = nthInitialCryptoBytes(&sink, 0);
+
+    const ch1_message = try tls_core.messages.decode(ch1_raw);
+    var ch1_observer = PskExtensionObserver{};
+    _ = try tls_core.negotiation.parseClientHelloObserved(ch1_message.body, .{ .ctx = &ch1_observer, .observeFn = PskExtensionObserver.observe });
+    var ch1_offered = try pre_shared_key.OfferedPsks.parse(ch1_observer.psk_ext orelse return error.TestUnexpectedResult);
+    var ch1_it = ch1_offered.pairs();
+    const ch1_first = (try ch1_it.next()).?;
+    const ch1_second = (try ch1_it.next()).?;
+    // Both tickets were received at `received_at_unix_ms = 0` with
+    // `ticket_age_add = 0`, so ClientHello1's age is exactly `now_ms`.
+    try std.testing.expectEqual(@as(u32, 5_000), ch1_first.identity.obfuscated_ticket_age);
+    try std.testing.expectEqual(@as(u32, 5_000), ch1_second.identity.obfuscated_ticket_age);
+
+    // Advance the clock before the HRR arrives, so ClientHello2's
+    // recomputed age must differ from ClientHello1's by exactly this delta.
+    clock.now_ms = 6_250;
 
     // A cookie-bearing, group-requesting HRR — proving both "PSK stays the
     // last extension even once a cookie is inserted" and correct binder
@@ -2747,11 +2768,13 @@ test "#485 client re-offers PSK identities across HelloRetryRequest with binders
     const second = (try it.next()).?;
     try std.testing.expectEqualStrings("ticket-a", first.identity.identity);
     try std.testing.expectEqualStrings("ticket-b", second.identity.identity);
-    // Ages were recomputed at ClientHello2 emission time (`now = 5000`,
-    // ticket `received_at_unix_ms = 0`), not merely echoed from
-    // ClientHello1's ticket_age_add of 0.
-    try std.testing.expectEqual(@as(u32, 5_000), first.identity.obfuscated_ticket_age);
-    try std.testing.expectEqual(@as(u32, 5_000), second.identity.obfuscated_ticket_age);
+    // Ages were genuinely recomputed at ClientHello2 emission time — each
+    // changed by exactly the clock advance since ClientHello1, not merely
+    // echoed from ClientHello1's own age.
+    try std.testing.expectEqual(@as(u32, 6_250), first.identity.obfuscated_ticket_age);
+    try std.testing.expectEqual(@as(u32, 6_250), second.identity.obfuscated_ticket_age);
+    try std.testing.expectEqual(ch1_first.identity.obfuscated_ticket_age + 1_250, first.identity.obfuscated_ticket_age);
+    try std.testing.expectEqual(ch1_second.identity.obfuscated_ticket_age + 1_250, second.identity.obfuscated_ticket_age);
 
     // Each binder verifies only against the rebound transcript.
     const ext_data_offset_in_ch2 = @intFromPtr(ext_data.ptr) - @intFromPtr(ch2_raw.ptr);
@@ -2825,6 +2848,12 @@ test "#485 an oversized ClientHello2 PSK offer fails locally and wipes all retai
     try std.testing.expect(client.client_hello_psk == null);
     try std.testing.expect(client.retry.request == null);
     try std.testing.expectEqual(tls_core.handshake.HandshakeLifecycle.failed, client.core.handshake_lifecycle);
+}
+
+fn hexBytes(comptime hex: []const u8) [hex.len / 2]u8 {
+    var bytes: [hex.len / 2]u8 = undefined;
+    _ = std.fmt.hexToBytes(&bytes, hex) catch unreachable;
+    return bytes;
 }
 
 fn nthInitialCryptoBytes(sink: *const DirectSink, index: usize) []const u8 {
@@ -2903,6 +2932,135 @@ test "#485 PSK resumption completes through one HelloRetryRequest, with matching
     const request = try harness.client_bridge.sealApplicationData("resumed after hrr", &protected);
     const opened_request = try harness.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, request), &plaintext);
     try std.testing.expectEqualStrings("resumed after hrr", opened_request.inner.content);
+}
+
+fn findSecretEvent(sink: *const DirectSink, epoch: events.EncryptionEpoch, direction: events.SecretDirection) []const u8 {
+    for (sink.items[0..sink.len]) |event| switch (event) {
+        .traffic_secret => |ts| if (ts.epoch == epoch and ts.direction == direction) return ts.data,
+        else => {},
+    };
+    unreachable;
+}
+
+/// Independently generated (Python `cryptography` X25519 + hashlib/hmac
+/// HKDF, not this codebase's own `std.crypto.tls.hkdfExpandLabel` or
+/// `transcript.zig`) known-answer values for the "#485 KAT" test below, over
+/// the exact wire bytes that fixed test's fixed entropy
+/// (`clientEntropy().retry_key_share_seed = 0x13*32`,
+/// `serverEntropy().key_share_seed = 0x22*32`) and PSK (`0x64*32`) produce:
+/// the rebound binder-transcript hash and ClientHello2's own PSK binder
+/// (cross-checking the full CH1-rebind/HRR/Truncate(CH2) chain the same way
+/// the pre_shared_key.zig primitive fixture does), the post-ServerHello
+/// handshake traffic secrets, and the post-server-Finished application
+/// traffic secrets (RFC 8446 §7.1's Derive-Secret/HKDF-Expand-Label chain
+/// from PSK-derived early_secret through ECDHE-derived handshake_secret to
+/// master_secret). The independent script also recomputed the client
+/// Finished `verify_data` from these same secrets/transcript and confirmed
+/// it matches the wire bytes, cross-checking that the whole transcript
+/// chain (not just the isolated HKDF calls) is threaded correctly.
+const kat_rebound_transcript_hash = "74bcded7fdd3c4c74e2825fa5d9b07862dbc83157fd5bc8448b6ec4330a45ee3";
+const kat_ch2_binder = "d5f5ca74be00bec75fb93a09ee3465a81240833bd20221e70ee97ed3f1543a3c";
+const kat_client_hs_traffic = "e314b50f3740ee9bfc9a73f46aaf73cdd5e5194a3b3fef0e35ecc08980910a41";
+const kat_server_hs_traffic = "28a14344d5e36f0dc876d5aaaa57496f5d5da86e5a11ac77335df56a5194d9ca";
+const kat_client_ap_traffic = "ed507f15754fcab4e0a4603ecb04ffebcffc21390b20de367196c0d3613e1a52";
+const kat_server_ap_traffic = "632f7e12de3c8853a19c91436cb487b61dd50ce2a6edad93d30628d5723a14bd";
+
+test "#485 KAT: PSK-resumed HRR handshake/application secrets match an independently computed RFC 8446 key schedule" {
+    var client = tls_backend.Tls13Backend.initClientWithOptions(
+        clientEntropy(),
+        .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+        .record,
+        .{ .initial_key_share_mode = .empty },
+    );
+    defer client.deinit();
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
+    defer server.deinit();
+
+    const psk = [_]u8{0x64} ** tls_backend.hash_len;
+    var ticket = try makeH2CacheTicket(&psk, "kat-resumption-ticket");
+    defer ticket.deinit();
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&ticket);
+    var clock_dummy: u8 = 0;
+    const Clock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 5_000;
+        }
+    };
+    try client.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+
+    var stored_state = pskStoredState(&psk);
+    defer stored_state.deinit();
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "kat-resumption-ticket" };
+    try server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+
+    var client_sink = DirectSink{};
+    defer client_sink.deinit();
+    var server_sink = DirectSink{};
+    defer server_sink.deinit();
+
+    try client.backend().start(.client, {}, &client_sink);
+    const ch1_raw = nthInitialCryptoBytes(&client_sink, 0);
+
+    try server.backend().start(.server, {}, &server_sink);
+    try server.backend().receive(.initial, ch1_raw, &server_sink);
+    const hrr_raw = nthInitialCryptoBytes(&server_sink, 0);
+
+    try client.backend().receive(.initial, hrr_raw, &client_sink);
+    const ch2_raw = nthInitialCryptoBytes(&client_sink, 1);
+
+    // The rebound binder-transcript digest and ClientHello2's own PSK
+    // binder, checked against the independent KAT before the handshake is
+    // even allowed to proceed to the server.
+    const ch2_message = try tls_core.messages.decode(ch2_raw);
+    var psk_observer = PskExtensionObserver{};
+    _ = try tls_core.negotiation.parseClientHelloObserved(ch2_message.body, .{ .ctx = &psk_observer, .observeFn = PskExtensionObserver.observe });
+    const ext_data = psk_observer.psk_ext orelse return error.TestUnexpectedResult;
+    const offered = try pre_shared_key.OfferedPsks.parse(ext_data);
+    var pairs = offered.pairs();
+    const pair = (try pairs.next()).?;
+    const ext_data_offset_in_ch2 = @intFromPtr(ext_data.ptr) - @intFromPtr(ch2_raw.ptr);
+    const truncated_ch2 = ch2_raw[0 .. ext_data_offset_in_ch2 + offered.binder_vector_offset];
+    const rebound_hash = reboundTranscriptHashFixture(ch1_raw, hrr_raw, truncated_ch2);
+    try std.testing.expectEqualSlices(u8, &hexBytes(kat_rebound_transcript_hash), &rebound_hash);
+    try std.testing.expectEqualSlices(u8, &hexBytes(kat_ch2_binder), pair.binder);
+
+    try server.backend().receive(.initial, ch2_raw, &server_sink);
+    const server_hello_raw = nthInitialCryptoBytes(&server_sink, 1);
+    var ee_finished_buf: [4096]u8 = undefined;
+    const ee_finished_raw = collectHandshakeCrypto(&server_sink, &ee_finished_buf);
+
+    try client.backend().receive(.initial, server_hello_raw, &client_sink);
+    try client.backend().receive(.handshake, ee_finished_raw, &client_sink);
+    var client_finished_buf: [512]u8 = undefined;
+    const client_finished_raw = collectHandshakeCrypto(&client_sink, &client_finished_buf);
+
+    try server.backend().receive(.handshake, client_finished_raw, &server_sink);
+
+    try std.testing.expectEqual(tls_core.handshake.HandshakeLifecycle.complete, client.core.handshake_lifecycle);
+    try std.testing.expectEqual(tls_core.handshake.HandshakeLifecycle.complete, server.core.handshake_lifecycle);
+    try std.testing.expect(client.core.psk_authenticated);
+    try std.testing.expect(server.core.psk_authenticated);
+
+    // Client-observed secrets, checked against the independent KAT.
+    // "hs_write"/"ap_write" are the client's own direction (matches
+    // `client_hs_traffic`/`client_ap_traffic` in the independent script);
+    // "hs_read"/"ap_read" are the server's direction as seen by the client.
+    try std.testing.expectEqualSlices(u8, &hexBytes(kat_client_hs_traffic), findSecretEvent(&client_sink, .handshake, .write));
+    try std.testing.expectEqualSlices(u8, &hexBytes(kat_server_hs_traffic), findSecretEvent(&client_sink, .handshake, .read));
+    try std.testing.expectEqualSlices(u8, &hexBytes(kat_client_ap_traffic), findSecretEvent(&client_sink, .application, .write));
+    try std.testing.expectEqualSlices(u8, &hexBytes(kat_server_ap_traffic), findSecretEvent(&client_sink, .application, .read));
+
+    // The server's own view of each secret must be the identical bytes —
+    // both sides agree with the independent KAT, not merely with each other.
+    try std.testing.expectEqualSlices(u8, &hexBytes(kat_client_hs_traffic), findSecretEvent(&server_sink, .handshake, .read));
+    try std.testing.expectEqualSlices(u8, &hexBytes(kat_server_hs_traffic), findSecretEvent(&server_sink, .handshake, .write));
+    try std.testing.expectEqualSlices(u8, &hexBytes(kat_client_ap_traffic), findSecretEvent(&server_sink, .application, .read));
+    try std.testing.expectEqualSlices(u8, &hexBytes(kat_server_ap_traffic), findSecretEvent(&server_sink, .application, .write));
 }
 
 test "#485 server rejects a ClientHello2 PSK binder computed only over Hash(Truncate(CH2)), requiring the rebound transcript instead" {
@@ -3027,6 +3185,167 @@ test "#485 asynchronous PSK resolution after a HelloRetryRequest uses the captur
     try std.testing.expect(server.core.psk_authenticated);
     try std.testing.expect(server.credentialFailure() == null);
     try std.testing.expect(server.client_hello_psk == null);
+}
+
+// --------------------------------------------------------------------------
+// #485: ordinary fallback/cleanup semantics must survive a HelloRetryRequest
+// unchanged. #536 changed what `onClientHello` retains for ClientHello2's
+// binder capture — these prove that change never leaks into the paths where
+// `selectPsk` declines to resume and the connection falls back to full
+// certificate authentication.
+// --------------------------------------------------------------------------
+
+test "#485 an unknown PSK identity through HelloRetryRequest falls back to a full certificate handshake" {
+    var harness = directHarnessWithClientKeyShareMode(.record, .record, .empty);
+    defer harness.deinit();
+
+    const psk = [_]u8{0x91} ** tls_backend.hash_len;
+    var ticket = try makeH2CacheTicket(&psk, "unknown-after-hrr-ticket");
+    defer ticket.deinit();
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&ticket);
+    var clock_dummy: u8 = 0;
+    const Clock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 5_000;
+        }
+    };
+    try harness.client_backend.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+
+    // The server has never heard of this identity: every resolve attempt is
+    // a miss.
+    const Resolver = struct {
+        calls: usize = 0,
+        fn now(_: *anyopaque) i64 {
+            return 0;
+        }
+        fn resolve(ctx: *anyopaque, _: []const u8) pre_shared_key.ResolveError!pre_shared_key.ServerPskResolveResult {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.calls += 1;
+            return .miss;
+        }
+    };
+    var resolver_state = Resolver{};
+    try harness.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = Resolver.now,
+        .resolveFn = Resolver.resolve,
+    });
+    var decisions = DecisionProbe{};
+    try harness.server_backend.setResumptionDecisionObserver(decisions.observer());
+
+    try harness.run();
+
+    try std.testing.expect(harness.client_driver.isComplete());
+    try std.testing.expect(harness.server_driver.isComplete());
+    try std.testing.expectEqual(tls_core.handshake.RetryState.hrr_received, harness.client_backend.core.retry_state);
+    try std.testing.expectEqual(tls_core.handshake.RetryState.hrr_sent, harness.server_backend.core.retry_state);
+    try std.testing.expectEqual(@as(usize, 1), resolver_state.calls);
+    try std.testing.expect(!harness.client_backend.core.psk_authenticated);
+    try std.testing.expect(!harness.server_backend.core.psk_authenticated);
+    try std.testing.expectEqual(@as(usize, 1), decisions.count);
+    try std.testing.expectEqual(tls_backend.Tls13Backend.ResumptionDecision.miss, decisions.last.?);
+    // The full certificate flight actually ran and was trusted.
+    try std.testing.expectEqual(events.CertificateState.valid, harness.observed.certificate_state.?);
+
+    try expectHrrRetryStateCleared(&harness.client_backend);
+    try expectHrrRetryStateCleared(&harness.server_backend);
+}
+
+test "#485 an incompatible PSK identity through HelloRetryRequest falls back to a full certificate handshake" {
+    var harness = directHarnessWithClientKeyShareMode(.record, .record, .empty);
+    defer harness.deinit();
+
+    const psk = [_]u8{0x92} ** tls_backend.hash_len;
+    var ticket = try makeH2CacheTicket(&psk, "incompatible-after-hrr-ticket");
+    defer ticket.deinit();
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&ticket);
+    var clock_dummy: u8 = 0;
+    const Clock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 5_000;
+        }
+    };
+    try harness.client_backend.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+
+    // Resolves, but the stored ticket was issued under a different leaf
+    // certificate than the server's current identity — incompatible, not a
+    // miss.
+    var incompatible_state = pskStoredStateWithBinding(&psk, session.AuthBinding.fromLeafCertificateDer("different-leaf"));
+    defer incompatible_state.deinit();
+    var resolver_state = CountingResolver{ .state = &incompatible_state, .identity = "incompatible-after-hrr-ticket" };
+    try harness.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+    var decisions = DecisionProbe{};
+    try harness.server_backend.setResumptionDecisionObserver(decisions.observer());
+
+    try harness.run();
+
+    try std.testing.expect(harness.client_driver.isComplete());
+    try std.testing.expect(harness.server_driver.isComplete());
+    try std.testing.expectEqual(tls_core.handshake.RetryState.hrr_received, harness.client_backend.core.retry_state);
+    try std.testing.expectEqual(tls_core.handshake.RetryState.hrr_sent, harness.server_backend.core.retry_state);
+    try std.testing.expectEqual(@as(usize, 1), resolver_state.calls);
+    try std.testing.expect(!harness.client_backend.core.psk_authenticated);
+    try std.testing.expect(!harness.server_backend.core.psk_authenticated);
+    try std.testing.expectEqual(@as(usize, 1), decisions.count);
+    try std.testing.expectEqual(tls_backend.Tls13Backend.ResumptionDecision.incompatible, decisions.last.?);
+    try std.testing.expectEqual(events.CertificateState.valid, harness.observed.certificate_state.?);
+
+    try expectHrrRetryStateCleared(&harness.client_backend);
+    try expectHrrRetryStateCleared(&harness.server_backend);
+}
+
+test "#485 handshake-time client authentication forces a full handshake through HelloRetryRequest even when a PSK is offered" {
+    var harness = directHarnessWithClientKeyShareMode(.record, .record, .empty);
+    defer harness.deinit();
+    harness.configureClientAuth(.required, true, .{ .pinned_certificate = tls_backend.testdata.certificate_der });
+
+    const psk = [_]u8{0x93} ** tls_backend.hash_len;
+    var ticket = try makeH2CacheTicket(&psk, "client-auth-after-hrr-ticket");
+    defer ticket.deinit();
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&ticket);
+    var clock_dummy: u8 = 0;
+    const Clock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 5_000;
+        }
+    };
+    try harness.client_backend.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+
+    var stored_state = pskStoredState(&psk);
+    defer stored_state.deinit();
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "client-auth-after-hrr-ticket" };
+    try harness.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+    var decisions = DecisionProbe{};
+    try harness.server_backend.setResumptionDecisionObserver(decisions.observer());
+
+    try harness.run();
+
+    try std.testing.expect(harness.client_driver.isComplete());
+    try std.testing.expect(harness.server_driver.isComplete());
+    try std.testing.expectEqual(tls_core.handshake.RetryState.hrr_received, harness.client_backend.core.retry_state);
+    try std.testing.expectEqual(tls_core.handshake.RetryState.hrr_sent, harness.server_backend.core.retry_state);
+    try std.testing.expect(!harness.client_backend.core.psk_authenticated);
+    try std.testing.expect(!harness.server_backend.core.psk_authenticated);
+    // The resolver is never even consulted: client_auth forces the full
+    // fallback before PSK selection begins, exactly as it does without HRR.
+    try std.testing.expectEqual(@as(usize, 0), resolver_state.calls);
+    try std.testing.expectEqual(@as(usize, 1), decisions.count);
+    try std.testing.expectEqual(tls_backend.Tls13Backend.ResumptionDecision.full_handshake, decisions.last.?);
+    try std.testing.expectEqual(events.CertificateState.valid, harness.observed.certificate_state.?);
+
+    try expectHrrRetryStateCleared(&harness.client_backend);
+    try expectHrrRetryStateCleared(&harness.server_backend);
 }
 
 test "#484 server emits exactly one HelloRetryRequest for an external-style ClientHello1 with a present, empty key_share" {

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -3300,6 +3300,68 @@ test "#485 an incompatible PSK identity through HelloRetryRequest falls back to 
     try expectHrrRetryStateCleared(&harness.server_backend);
 }
 
+test "#485 an expired PSK identity through HelloRetryRequest falls back to a full certificate handshake" {
+    var harness = directHarnessWithClientKeyShareMode(.record, .record, .empty);
+    defer harness.deinit();
+
+    const psk = [_]u8{0x94} ** tls_backend.hash_len;
+    // The client's own local record of this ticket is generously live —
+    // this offer must actually reach the wire (not be filtered by the
+    // client's own `ticketEligibleToOffer` recheck) so the server's
+    // compatibility/fallback path is what's actually exercised.
+    var ticket = try makeH2CacheTicket(&psk, "expired-after-hrr-ticket");
+    defer ticket.deinit();
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&ticket);
+    var clock_dummy: u8 = 0;
+    const Clock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 5_000;
+        }
+    };
+    try harness.client_backend.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+
+    // The server's own authoritative recovered session disagrees: issued at
+    // 0 with only a 1-second lifetime, observed at the resolver's clock of
+    // 5000ms — already well past expiry.
+    var expired_common: session.ResumableSessionCommon = .{};
+    try expired_common.init(std.testing.allocator, session.Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = &psk,
+        .application_protocol = "h2",
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer(tls_backend.testdata.certificate_der),
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 1,
+    });
+    var expired_state: session.ServerRecoverableState = .{};
+    expired_state.init(&expired_common, 0);
+    defer expired_state.deinit();
+    var resolver_state = CountingResolver{ .state = &expired_state, .identity = "expired-after-hrr-ticket", .now_ms = 5_000 };
+    try harness.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+    var decisions = DecisionProbe{};
+    try harness.server_backend.setResumptionDecisionObserver(decisions.observer());
+
+    try harness.run();
+
+    try std.testing.expect(harness.client_driver.isComplete());
+    try std.testing.expect(harness.server_driver.isComplete());
+    try std.testing.expectEqual(tls_core.handshake.RetryState.hrr_received, harness.client_backend.core.retry_state);
+    try std.testing.expectEqual(tls_core.handshake.RetryState.hrr_sent, harness.server_backend.core.retry_state);
+    try std.testing.expectEqual(@as(usize, 1), resolver_state.calls);
+    try std.testing.expect(!harness.client_backend.core.psk_authenticated);
+    try std.testing.expect(!harness.server_backend.core.psk_authenticated);
+    try std.testing.expectEqual(@as(usize, 1), decisions.count);
+    try std.testing.expectEqual(tls_backend.Tls13Backend.ResumptionDecision.incompatible, decisions.last.?);
+    try std.testing.expectEqual(events.CertificateState.valid, harness.observed.certificate_state.?);
+
+    try expectHrrRetryStateCleared(&harness.client_backend);
+    try expectHrrRetryStateCleared(&harness.server_backend);
+}
+
 test "#485 handshake-time client authentication forces a full handshake through HelloRetryRequest even when a PSK is offered" {
     var harness = directHarnessWithClientKeyShareMode(.record, .record, .empty);
     defer harness.deinit();

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -2621,6 +2621,212 @@ test "#484 HRR round trip completes over the extension (QUIC-style) profile too"
     try expectHrrRetryStateCleared(&harness.server_backend);
 }
 
+// ==========================================================================
+// #485: PSK binders become HelloRetryRequest-aware — ClientHello2 carries
+// the retained PSK offer with binders derived from the rebound transcript
+// (`message_hash(Hash(CH1)) || HRR || Truncate(CH2)`), not
+// `Hash(Truncate(CH2))` alone.
+// ==========================================================================
+
+/// Independently reconstructs the #485 rebound binder-transcript digest from
+/// raw wire bytes: `Hash(message_hash(Hash(ch1_raw)) || hrr_raw ||
+/// truncated_ch2)`. Mirrors `transcript.Transcript.rebindClientHello`'s
+/// synthetic `message_hash` record, built by hand here (not by calling that
+/// method) so this actually cross-checks the production transcript/binder
+/// code rather than assuming it.
+fn reboundTranscriptHashFixture(ch1_raw: []const u8, hrr_raw: []const u8, truncated_ch2: []const u8) [tls_backend.hash_len]u8 {
+    var ch1_hash: [tls_backend.hash_len]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(ch1_raw, &ch1_hash, .{});
+
+    var msg_hash_record: [4 + tls_backend.hash_len]u8 = undefined;
+    msg_hash_record[0] = @intFromEnum(tls_core.messages.MessageType.message_hash);
+    std.mem.writeInt(u24, msg_hash_record[1..4], tls_backend.hash_len, .big);
+    @memcpy(msg_hash_record[4..], &ch1_hash);
+
+    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+    hasher.update(&msg_hash_record);
+    hasher.update(hrr_raw);
+    hasher.update(truncated_ch2);
+    var out: [tls_backend.hash_len]u8 = undefined;
+    hasher.final(&out);
+    return out;
+}
+
+/// Like `makeCacheTicket`, but stamped with the "h2" ALPN both
+/// `directHarnessWithClientKeyShareMode`'s default record policy and
+/// `pskStoredState`'s server-side state expect — required for any test that
+/// drives the connection through a real `onEncryptedExtensions`, which
+/// checks the selected ticket's stored ALPN against the just-negotiated one.
+fn makeH2CacheTicket(psk: []const u8, ticket: []const u8) !session.ClientTicketState {
+    var common: session.ResumableSessionCommon = .{};
+    try common.init(std.testing.allocator, session.Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = psk,
+        .application_protocol = "h2",
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer(tls_backend.testdata.certificate_der),
+        .issued_at_unix_ms = 0,
+        .lifetime_seconds = 3600,
+    });
+    var state: session.ClientTicketState = .{};
+    try state.init(std.testing.allocator, session.Limits.default, &common, .{
+        .ticket = ticket,
+        .ticket_age_add = 0,
+        .ticket_nonce = "n",
+        .received_at_unix_ms = 0,
+    });
+    return state;
+}
+
+const PskExtensionObserver = struct {
+    psk_ext: ?[]const u8 = null,
+
+    fn observe(ctx: *anyopaque, observation: tls_core.negotiation.ExtensionObservation) tls_core.negotiation.Error!void {
+        const self: *@This() = @ptrCast(@alignCast(ctx));
+        if (observation.id == pre_shared_key.ext_pre_shared_key) self.psk_ext = observation.data;
+    }
+};
+
+test "#485 client re-offers PSK identities across HelloRetryRequest with binders derived from the rebound transcript, preserving order and updating ages" {
+    var client = tls_backend.Tls13Backend.initClientWithOptions(
+        clientEntropy(),
+        .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+        .record,
+        .{ .initial_key_share_mode = .empty },
+    );
+    defer client.deinit();
+
+    const psk_a = [_]u8{0x5a} ** tls_backend.hash_len;
+    const psk_b = [_]u8{0x6b} ** tls_backend.hash_len;
+    var ticket_a = try makeCacheTicket(&psk_a, "ticket-a");
+    defer ticket_a.deinit();
+    var ticket_b = try makeCacheTicket(&psk_b, "ticket-b");
+    defer ticket_b.deinit();
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&ticket_a);
+    try offers.push(&ticket_b);
+
+    var clock_dummy: u8 = 0;
+    const Clock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 5_000;
+        }
+    };
+    try client.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try client.backend().start(.client, {}, &sink);
+    const ch1_raw = nthInitialCryptoBytes(&sink, 0);
+
+    // A cookie-bearing, group-requesting HRR — proving both "PSK stays the
+    // last extension even once a cookie is inserted" and correct binder
+    // derivation through a non-trivial rebound transcript in one exchange.
+    const cookie = "hrr-cookie-fixture";
+    var hrr_buf: [256]u8 = undefined;
+    const hrr_raw = try tls_core.hello_retry.encode(.{
+        .legacy_session_id_echo = "",
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .selected_group = .x25519,
+        .cookie = cookie,
+    }, &hrr_buf);
+    try client.backend().receive(.initial, hrr_raw, &sink);
+    try std.testing.expectEqual(tls_core.handshake.RetryState.hrr_received, client.core.retry_state);
+    const ch2_raw = nthInitialCryptoBytes(&sink, 1);
+
+    const ch2_message = try tls_core.messages.decode(ch2_raw);
+    var observer = PskExtensionObserver{};
+    _ = try tls_core.negotiation.parseClientHelloObserved(ch2_message.body, .{ .ctx = &observer, .observeFn = PskExtensionObserver.observe });
+    const ext_data = observer.psk_ext orelse return error.TestUnexpectedResult;
+
+    var offered = try pre_shared_key.OfferedPsks.parse(ext_data);
+    try std.testing.expectEqual(@as(usize, 2), offered.count);
+
+    // Identity order preserved from ClientHello1's own wire order.
+    var it = offered.pairs();
+    const first = (try it.next()).?;
+    const second = (try it.next()).?;
+    try std.testing.expectEqualStrings("ticket-a", first.identity.identity);
+    try std.testing.expectEqualStrings("ticket-b", second.identity.identity);
+    // Ages were recomputed at ClientHello2 emission time (`now = 5000`,
+    // ticket `received_at_unix_ms = 0`), not merely echoed from
+    // ClientHello1's ticket_age_add of 0.
+    try std.testing.expectEqual(@as(u32, 5_000), first.identity.obfuscated_ticket_age);
+    try std.testing.expectEqual(@as(u32, 5_000), second.identity.obfuscated_ticket_age);
+
+    // Each binder verifies only against the rebound transcript.
+    const ext_data_offset_in_ch2 = @intFromPtr(ext_data.ptr) - @intFromPtr(ch2_raw.ptr);
+    const truncated_len = ext_data_offset_in_ch2 + offered.binder_vector_offset;
+    const truncated_ch2 = ch2_raw[0..truncated_len];
+    const rebound_hash = reboundTranscriptHashFixture(ch1_raw, hrr_raw, truncated_ch2);
+
+    try std.testing.expect(try pre_shared_key.verifyBinderFromTranscriptHash(.sha256, &psk_a, &rebound_hash, first.binder));
+    try std.testing.expect(try pre_shared_key.verifyBinderFromTranscriptHash(.sha256, &psk_b, &rebound_hash, second.binder));
+
+    // A binder over `Hash(Truncate(ClientHello2))` alone — the pre-#485
+    // shape — must not accidentally verify.
+    var isolated_hash: [tls_backend.hash_len]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(truncated_ch2, &isolated_hash, .{});
+    try std.testing.expect(!try pre_shared_key.verifyBinderFromTranscriptHash(.sha256, &psk_a, &isolated_hash, first.binder));
+
+    try expectHrrRetryStateCleared(&client);
+}
+
+test "#485 an oversized ClientHello2 PSK offer fails locally and wipes all retained PSK/retry state" {
+    var client = tls_backend.Tls13Backend.initClientWithOptions(
+        clientEntropy(),
+        .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+        .record,
+        .{ .initial_key_share_mode = .empty },
+    );
+    defer client.deinit();
+
+    // Eight identities (the offer-set maximum), each well under
+    // `session.Limits.default.max_ticket_len` individually, but packed close
+    // enough to `max_message_len` in total that ClientHello1 still fits
+    // while ClientHello2 — the same offer plus a real key share and a large
+    // HRR cookie — no longer does.
+    const item_identity = [_]u8{'x'} ** 950;
+    var tickets: [pre_shared_key.max_offered_identities]session.ClientTicketState = undefined;
+    for (&tickets) |*t| t.* = try makeCacheTicket(&([_]u8{0x5a} ** tls_backend.hash_len), &item_identity);
+    defer for (&tickets) |*t| t.deinit();
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    for (&tickets) |*t| try offers.push(t);
+    var clock_dummy: u8 = 0;
+    const Clock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 5_000;
+        }
+    };
+    try client.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try client.backend().start(.client, {}, &sink);
+    try std.testing.expectEqual(@as(usize, 1), countCryptoEvents(&sink, .initial));
+
+    const big_cookie = [_]u8{0xcc} ** 440;
+    var hrr_buf: [768]u8 = undefined;
+    const hrr_raw = try tls_core.hello_retry.encode(.{
+        .legacy_session_id_echo = "",
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .selected_group = .x25519,
+        .cookie = &big_cookie,
+    }, &hrr_buf);
+
+    // Fails locally — the retained identity is never silently dropped to
+    // make room for the cookie.
+    try std.testing.expectError(error.HandshakeBufferOverflow, client.backend().receive(.initial, hrr_raw, &sink));
+
+    // No ClientHello2 was ever emitted...
+    try std.testing.expectEqual(@as(usize, 1), countCryptoEvents(&sink, .initial));
+    // ...and every retained PSK/retry field was wiped by
+    // `clearFailedHandshakeState`, not left half-consumed.
+    try std.testing.expect(client.client_offer_lease.offers.isEmpty());
+    try std.testing.expect(client.client_hello_psk == null);
+    try std.testing.expect(client.retry.request == null);
+    try std.testing.expectEqual(tls_core.handshake.HandshakeLifecycle.failed, client.core.handshake_lifecycle);
+}
+
 fn nthInitialCryptoBytes(sink: *const DirectSink, index: usize) []const u8 {
     var seen: usize = 0;
     for (sink.items[0..sink.len]) |event| switch (event) {
@@ -2633,6 +2839,194 @@ fn nthInitialCryptoBytes(sink: *const DirectSink, index: usize) []const u8 {
         else => {},
     };
     unreachable;
+}
+
+test "#485 PSK resumption completes through one HelloRetryRequest, with matching transcripts and traffic secrets on both sides" {
+    var harness = directHarnessWithClientKeyShareMode(.record, .record, .empty);
+    defer harness.deinit();
+
+    const psk = [_]u8{0x64} ** tls_backend.hash_len;
+    var ticket = try makeH2CacheTicket(&psk, "hrr-resumption-ticket");
+    defer ticket.deinit();
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&ticket);
+    var clock_dummy: u8 = 0;
+    const Clock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 5_000;
+        }
+    };
+    try harness.client_backend.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+
+    var stored_state = pskStoredState(&psk);
+    defer stored_state.deinit();
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "hrr-resumption-ticket" };
+    try harness.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+
+    try harness.run();
+
+    try std.testing.expect(harness.client_driver.isComplete());
+    try std.testing.expect(harness.server_driver.isComplete());
+    try std.testing.expectEqual(tls_core.handshake.RetryState.hrr_received, harness.client_backend.core.retry_state);
+    try std.testing.expectEqual(tls_core.handshake.RetryState.hrr_sent, harness.server_backend.core.retry_state);
+    try std.testing.expectEqual(@as(usize, 1), resolver_state.calls);
+    try std.testing.expect(harness.client_backend.core.psk_authenticated);
+    try std.testing.expect(harness.server_backend.core.psk_authenticated);
+
+    // Both sides derived the same transcript hash, so no side used a
+    // divergent (e.g. isolated `Hash(Truncate(CH2))`) binder transcript
+    // internally without it showing up here.
+    const client_hash = harness.client_backend.core.transcriptHash();
+    const server_hash = harness.server_backend.core.transcriptHash();
+    try std.testing.expectEqualSlices(u8, &client_hash, &server_hash);
+
+    // No traffic secret was derived at the HRR itself, only after the final
+    // ServerHello — same assertions as the non-PSK #484 HRR round trip.
+    try std.testing.expect(harness.observed.handshake_write_secret[0] != null);
+    try std.testing.expect(harness.observed.handshake_write_secret[1] != null);
+    try std.testing.expect(harness.observed.application_write_secret[0] != null);
+    try std.testing.expect(harness.observed.application_write_secret[1] != null);
+    try std.testing.expect(harness.observed.initial_discarded[0]);
+    try std.testing.expect(harness.observed.initial_discarded[1]);
+
+    try expectHrrRetryStateCleared(&harness.client_backend);
+    try expectHrrRetryStateCleared(&harness.server_backend);
+
+    // Genuinely usable: application data flows both ways under the
+    // PSK-resumed, post-HRR keys.
+    var protected: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    const request = try harness.client_bridge.sealApplicationData("resumed after hrr", &protected);
+    const opened_request = try harness.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, request), &plaintext);
+    try std.testing.expectEqualStrings("resumed after hrr", opened_request.inner.content);
+}
+
+test "#485 server rejects a ClientHello2 PSK binder computed only over Hash(Truncate(CH2)), requiring the rebound transcript instead" {
+    var server = tls_backend.Tls13Backend.initServer(serverEntropy(), fixtureIdentity(), .record);
+    defer server.deinit();
+
+    const psk = [_]u8{0x77} ** tls_backend.hash_len;
+    var stored_state = pskStoredState(&psk);
+    defer stored_state.deinit();
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "ticket-1" };
+    try server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+
+    // ClientHello1: an empty key share (forces `.retry`) with the same PSK
+    // offer CH2 will also carry — CH2 must mutate CH1 only in permitted
+    // ways, so the two extension sets must match.
+    var buf1: [2048]u8 = undefined;
+    const ch1 = try buildClientHello(&buf1, .{
+        .empty_key_share = true,
+        .psk = .{ .items = &.{.{ .identity = "ticket-1", .binder_psk = &psk }} },
+    });
+    try server.backend().receive(.initial, ch1, &sink);
+    try std.testing.expectEqual(tls_core.handshake.RetryState.hrr_sent, server.core.retry_state);
+    // The `.retry` decision returns before PSK selection ever runs.
+    try std.testing.expectEqual(@as(usize, 0), resolver_state.calls);
+
+    // ClientHello2: a real key share this time, and `buildClientHello`'s own
+    // binder helper — which computes `Hash(Truncate(this message))` in
+    // isolation, the pre-#485 shape — is deliberately reused unmodified
+    // here (not patched to the rebound-transcript binder) to prove that
+    // shape is now rejected.
+    var buf2: [2048]u8 = undefined;
+    const ch2 = try buildClientHello(&buf2, .{
+        .psk = .{ .items = &.{.{ .identity = "ticket-1", .binder_psk = &psk }} },
+    });
+    try std.testing.expectError(error.DecryptError, server.backend().receive(.initial, ch2, &sink));
+
+    // The candidate was resolved (compatible) but its binder was fatally
+    // wrong — never silently treated as a miss/fallback.
+    try std.testing.expectEqual(@as(usize, 1), resolver_state.calls);
+    try std.testing.expect(!server.selected_server_psk_present);
+    try std.testing.expect(!server.core.psk_authenticated);
+    // Every retained PSK/retry field was wiped on this failure path too.
+    try std.testing.expect(server.client_hello_psk == null);
+    try std.testing.expect(server.retry.request == null);
+}
+
+test "#485 asynchronous PSK resolution after a HelloRetryRequest uses the captured rebound-transcript binder, not a re-hash" {
+    var client = tls_backend.Tls13Backend.initClientWithOptions(
+        clientEntropy(),
+        .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+        .record,
+        .{ .initial_key_share_mode = .empty },
+    );
+    defer client.deinit();
+
+    const psk = [_]u8{0x5a} ** tls_backend.hash_len;
+    var ticket = try makeH2CacheTicket(&psk, "retry-async-ticket");
+    defer ticket.deinit();
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&ticket);
+    var clock_dummy: u8 = 0;
+    const Clock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 5_000;
+        }
+    };
+    try client.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+
+    var mock = credentials.MockCredentialProvider.init(fixtureIdentity());
+    mock.async_select = true;
+    mock.pending_polls = 2;
+    var server = serverWithProvider(&mock);
+    defer server.deinit();
+
+    var stored_state = pskStoredState(&psk);
+    defer stored_state.deinit();
+    var resolver_state = CountingResolver{ .state = &stored_state, .identity = "retry-async-ticket" };
+    try server.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = CountingResolver.now,
+        .resolveFn = CountingResolver.resolve,
+    });
+
+    var client_sink = DirectSink{};
+    defer client_sink.deinit();
+    var server_sink = DirectSink{};
+    defer server_sink.deinit();
+
+    try client.backend().start(.client, {}, &client_sink);
+    const ch1_raw = nthInitialCryptoBytes(&client_sink, 0);
+
+    try server.backend().start(.server, {}, &server_sink);
+    try server.backend().receive(.initial, ch1_raw, &server_sink);
+    try std.testing.expectEqual(tls_core.handshake.RetryState.hrr_sent, server.core.retry_state);
+    const hrr_raw = nthInitialCryptoBytes(&server_sink, 0);
+
+    try client.backend().receive(.initial, hrr_raw, &client_sink);
+    try std.testing.expectEqual(tls_core.handshake.RetryState.hrr_received, client.core.retry_state);
+    const ch2_raw = nthInitialCryptoBytes(&client_sink, 1);
+
+    try server.backend().receive(.initial, ch2_raw, &server_sink);
+    // Parked awaiting the async credential selection: PSK selection (and
+    // therefore binder verification against the captured rebound-transcript
+    // digest) has not run yet.
+    try std.testing.expect(server.authPending());
+    try std.testing.expectEqual(@as(usize, 0), resolver_state.calls);
+
+    try server.resumeAuth(&server_sink); // poll #1: still pending
+    try server.resumeAuth(&server_sink); // poll #2: still pending
+    try server.resumeAuth(&server_sink); // poll #3: completes, runs PSK selection
+    try std.testing.expect(!server.authPending());
+
+    try std.testing.expectEqual(@as(usize, 1), resolver_state.calls);
+    try std.testing.expect(server.core.psk_authenticated);
+    try std.testing.expect(server.credentialFailure() == null);
+    try std.testing.expect(server.client_hello_psk == null);
 }
 
 test "#484 server emits exactly one HelloRetryRequest for an external-style ClientHello1 with a present, empty key_share" {


### PR DESCRIPTION
## Summary
- Complete the PSK/resumption portion of TLS 1.3 HelloRetryRequest: ClientHello2 binders are now generated and verified over the rebound transcript (`message_hash(Hash(CH1)) || HRR || Truncate(CH2)`), not `Hash(Truncate(CH2))` in isolation.
- `src/tls/pre_shared_key.zig`: refactor around new `deriveBinderFromTranscriptHash` / `verifyBinderFromTranscriptHash` primitives that take a precomputed transcript digest; the existing `deriveBinder`/`verifyBinder` ClientHello wrappers become thin callers that hash the truncated message first.
- Client (`onHelloRetryRequest`): retains the PSK offer set across the retry and re-emits it in ClientHello2 — same identity order, freshly recomputed obfuscated ticket ages, binders derived from the rebound transcript via `Transcript.peekWith` (never mutating the live transcript), `pre_shared_key` still last. Identities are never silently dropped to fit; an oversized retry ClientHello fails locally (`HandshakeBufferOverflow`) and all retained PSK/retry state is wiped on that path.
- Server (`onClientHello` / `selectPsk`): captures the exact transcript digest each ClientHello's binder must verify against at parse time. For ClientHello2 this requires the transcript state as it existed *before* `Core.acceptSecondClientHello` appends the full message — threaded through `drainInput`/`onMessage` as a plain call argument (never stored on the backend) so `Tls13Backend` stays under its 64 KiB size budget. `selectPsk` now verifies against the captured digest instead of re-hashing the truncated message.
- `hello_retry.zig`'s ClientHello2 mutation validator already enforced PSK identity ordering and `pre_shared_key`-last from the #484 foundation — untouched here.

## Test plan
- [x] `zig build test` — full suite green (2843 tests), including the new binder-primitive, client-retry, server-retry, async-resolution, and full record-loopback PSK+HRR resumption tests.
- [x] `zig fmt --check` on all changed files.
- [x] Existing non-HRR resumption and #484 non-PSK HRR tests remain green (no regressions).

Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)