### PR TITLE
http3: finish rollout advertisement and drain lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ operate without guessing which config file or pid file is active.
 | Topic | Location |
 | --- | --- |
 | Core v1 support matrix | [docs/SUPPORT_MATRIX.md](docs/SUPPORT_MATRIX.md) |
+| HTTP/3 rollout and lifecycle | [docs/HTTP3_ROLLOUT.md](docs/HTTP3_ROLLOUT.md) |
 | Concurrency & hot-path audit | [docs/CONCURRENCY.md](docs/CONCURRENCY.md) |
 | Observability | [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) |
 | Proxy security | [docs/PROXY_SECURITY.md](docs/PROXY_SECURITY.md) |

--- a/docs/HTTP3_ROLLOUT.md
+++ b/docs/HTTP3_ROLLOUT.md
@@ -1,0 +1,66 @@
+# HTTP/3 rollout and lifecycle
+
+HTTP/3 uses QUIC over UDP on `TARDIGRADE_QUIC_PORT`; HTTP/1.1 and HTTP/2 remain
+on the configured TCP listener. Firewalls, security groups, and load balancers
+must explicitly permit UDP to the QUIC port. Allowing TCP/443 does not make
+HTTP/3 reachable.
+
+The supported v1 deployment model is one Tardigrade process owning one UDP
+runtime and one in-process Destination Connection ID routing table. NAT
+rebinding and the configured migration policy are handled inside that process.
+Multi-process `SO_REUSEPORT`, eBPF, or external DCID steering is not part of the
+current support promise.
+
+## Advertisement
+
+`TARDIGRADE_HTTP3_ENABLED=true` starts the native listener when TLS credentials
+are available and the UDP socket can bind. It does not advertise HTTP/3 by
+itself.
+
+`TARDIGRADE_HTTP3_ALT_SVC=auto` advertises only while the runtime is actually
+ready to accept QUIC/H3 connections. `TARDIGRADE_HTTP3_ALT_SVC=off` keeps the
+listener running without emitting an active `Alt-Svc` alternative, which allows
+staged rollout and rollback.
+
+`TARDIGRADE_HTTP3_ALT_SVC_MAX_AGE_SECONDS` controls the bounded `ma` value
+emitted with active advertisements. Values above 86400 are rejected.
+
+During drain or rollback withdrawal, eligible TCP responses emit
+`Alt-Svc: clear` so clients can discard cached alternatives. Tardigrade strips
+upstream `Alt-Svc` response headers and emits at most one gateway-owned
+`Alt-Svc` value.
+
+## Reload
+
+Advertisement-only knobs can hot reload:
+
+- `TARDIGRADE_HTTP3_ALT_SVC`
+- `TARDIGRADE_HTTP3_ALT_SVC_MAX_AGE_SECONDS`
+
+Listener-owned HTTP/3 knobs require a process restart because the current
+runtime does not atomically replace a live UDP socket and QUIC connection table:
+
+- `TARDIGRADE_HTTP3_ENABLED`
+- `TARDIGRADE_QUIC_PORT`
+- `TARDIGRADE_HTTP3_CONNECTION_MIGRATION`
+- `TARDIGRADE_HTTP3_RETRY_POLICY`
+- `TARDIGRADE_HTTP3_ENABLE_0RTT`
+- `TARDIGRADE_HTTP3_MAX_DATAGRAM_SIZE`
+
+A reload that changes one of those fields is rejected before publication. The
+old config, old runtime, and old effective advertisement remain active.
+
+## Drain and rollback
+
+Graceful rollback order is:
+
+1. Withdraw advertisement (`Alt-Svc: clear`).
+2. Begin H3 drain; the runtime sends HTTP/3 GOAWAY and refuses new work.
+3. Let admitted streams finish until `TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS`.
+4. Close remaining QUIC connections, remove CID routes, then stop or restart
+   the listener.
+
+`TARDIGRADE_HTTP3_RETRY_POLICY=address_validation` enables stateless QUIC Retry
+before connection allocation. `off` is the default. `TARDIGRADE_HTTP3_CONNECTION_MIGRATION=false`
+allows the hardened NAT-rebinding behavior; enabling migration broadens that
+policy and is restart-required.

--- a/docs/HTTP3_ROLLOUT.md
+++ b/docs/HTTP3_ROLLOUT.md
@@ -19,8 +19,9 @@ itself.
 
 `TARDIGRADE_HTTP3_ALT_SVC=auto` advertises only while the runtime is actually
 ready to accept QUIC/H3 connections. `TARDIGRADE_HTTP3_ALT_SVC=off` keeps the
-listener running without emitting an active `Alt-Svc` alternative, which allows
-staged rollout and rollback.
+listener running without emitting an active `Alt-Svc` alternative. When a hot
+reload changes an actively advertised listener from `auto` to `off`, TCP
+responses emit `Alt-Svc: clear` to withdraw cached alternatives.
 
 `TARDIGRADE_HTTP3_ALT_SVC_MAX_AGE_SECONDS` controls the bounded `ma` value
 emitted with active advertisements. Values above 86400 are rejected.

--- a/src/edge_config.zig
+++ b/src/edge_config.zig
@@ -270,6 +270,8 @@ pub const EdgeConfig = struct {
     upstream_tls_client_key: []const u8,
     http3_enabled: bool,
     quic_port: u16,
+    http3_alt_svc: http.http3_handler.AltSvcMode,
+    http3_alt_svc_max_age_seconds: u32,
     http3_enable_0rtt: bool,
     http3_connection_migration: bool,
     http3_retry_policy: http.quic.config.RetryPolicy,
@@ -895,6 +897,10 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
     const quic_port_str = envOrDefault(allocator, "TARDIGRADE_QUIC_PORT", "443") catch unreachable;
     defer allocator.free(quic_port_str);
     const quic_port = try parseConfigPort("quic_port", quic_port_str);
+    const http3_alt_svc_str = envOrDefault(allocator, "TARDIGRADE_HTTP3_ALT_SVC", "off") catch unreachable;
+    defer allocator.free(http3_alt_svc_str);
+    const http3_alt_svc = try parseHttp3AltSvcConfig(http3_alt_svc_str);
+    const http3_alt_svc_max_age_seconds = parseIntEnv(u32, allocator, "TARDIGRADE_HTTP3_ALT_SVC_MAX_AGE_SECONDS", 300);
     const http3_enable_0rtt = parseBoolEnv(allocator, "TARDIGRADE_HTTP3_ENABLE_0RTT", false);
     const http3_connection_migration = parseBoolEnv(allocator, "TARDIGRADE_HTTP3_CONNECTION_MIGRATION", false);
     const http3_retry_policy_str = envOrDefault(allocator, "TARDIGRADE_HTTP3_RETRY_POLICY", "off") catch unreachable;
@@ -1560,6 +1566,8 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
         .upstream_tls_client_key = upstream_tls_client_key,
         .http3_enabled = http3_enabled,
         .quic_port = quic_port,
+        .http3_alt_svc = http3_alt_svc,
+        .http3_alt_svc_max_age_seconds = http3_alt_svc_max_age_seconds,
         .http3_enable_0rtt = http3_enable_0rtt,
         .http3_connection_migration = http3_connection_migration,
         .http3_retry_policy = http3_retry_policy,
@@ -1934,6 +1942,14 @@ fn parseHttp3RetryPolicyConfig(raw: []const u8) !http.quic.config.RetryPolicy {
     if (std.ascii.eqlIgnoreCase(value, "address_validation") or std.ascii.eqlIgnoreCase(value, "address-validation")) return .address_validation;
     logConfigDiagnostic("config validation failed: http3_retry_policy must be one of off, address_validation", .{});
     return error.InvalidConfigValue;
+}
+
+fn parseHttp3AltSvcConfig(raw: []const u8) !http.http3_handler.AltSvcMode {
+    const value = std.mem.trim(u8, raw, " \t\r\n");
+    return http.http3_handler.AltSvcMode.parse(value) orelse {
+        logConfigDiagnostic("config validation failed: http3_alt_svc must be one of off, auto", .{});
+        return error.InvalidConfigValue;
+    };
 }
 
 fn parseEarlyDataReplayModeConfig(raw: []const u8) !EarlyDataReplayMode {
@@ -2928,6 +2944,10 @@ pub fn validate(cfg: *const EdgeConfig) !void {
     if (cfg.http3_enabled and cfg.quic_port == 0) {
         std.log.err("config validation failed: quic_port must be between 1 and 65535 when HTTP/3 is enabled", .{});
         return error.InvalidConfigPort;
+    }
+    if (cfg.http3_alt_svc_max_age_seconds > 86_400) {
+        std.log.err("config validation failed: http3_alt_svc_max_age_seconds must be <= 86400", .{});
+        return error.InvalidConfigValue;
     }
     try validateListenerProtocolPolicy(cfg.http1_enabled, cfg.http2_enabled, hasTlsFiles(cfg), true);
 

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -77,7 +77,8 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
         },
         .hsts_value = initial_hsts,
         .add_headers = cfg.add_headers,
-        .http3_alt_svc = if (cfg.http3_enabled) http.http3_handler.formatAltSvc(state_allocator, cfg.quic_port) catch null else null,
+        .http3_alt_svc = null,
+        .http3_advertisement_state = if (cfg.http3_enabled) .configured_unavailable else .disabled,
         .http3_runtime = null,
         .session_store = if (cfg.session_ttl_seconds > 0)
             http.session.SessionStore.init(state_allocator, cfg.session_ttl_seconds, cfg.session_max)
@@ -467,6 +468,7 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
             break :blk null;
         };
         if (http3_runtime) |*runtime| runtime.start();
+        updateHttp3Advertisement(&state, cfg, if (http3_runtime) |*runtime| runtime else null, .steady);
     }
     state.http3_runtime = if (http3_runtime) |*runtime| runtime else null;
     defer if (http3_runtime) |*runtime| runtime.deinit();
@@ -847,12 +849,57 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
         break :blk state.active_connections_total;
     };
     state.logger.info(null, "Shutdown requested; draining active connection work (timeout={}ms active_connections={d})", .{ cfg.shutdown_drain_timeout_ms, active_at_drain_start });
+    const h3_deadline_us = http.http3_runtime.Runtime.nowUsPublic() + cfg.shutdown_drain_timeout_ms * std.time.us_per_ms;
+    if (http3_runtime) |*runtime| {
+        updateHttp3Advertisement(&state, cfg, runtime, .draining);
+        runtime.beginDrain(h3_deadline_us);
+    }
     const drain_result = worker_pool.shutdownAndJoin(cfg.shutdown_drain_timeout_ms);
+    if (http3_runtime) |*runtime| {
+        while (!runtime.isDrained() and http.http3_runtime.Runtime.nowUsPublic() < h3_deadline_us) {
+            std.Io.sleep(compat.io(), .fromMilliseconds(10), .awake) catch {};
+        }
+    }
     state.metricsRecordDrain(drain_result.timed_out, drain_result.forced_closes);
     if (drain_result.timed_out) {
         state.logger.warn(null, "drain timeout elapsed; force-closed {d} queued connection(s)", .{drain_result.forced_closes});
     }
     state.logger.info(null, "Graceful shutdown complete (forced_closes={d} drain_timed_out={})", .{ drain_result.forced_closes, drain_result.timed_out });
+}
+
+const Http3AdvertisementPhase = enum {
+    steady,
+    draining,
+};
+
+fn updateHttp3Advertisement(
+    state: *GatewayState,
+    cfg: *const edge_config.EdgeConfig,
+    runtime: ?*http.http3_runtime.Runtime,
+    phase: Http3AdvertisementPhase,
+) void {
+    const runtime_ready = if (runtime) |rt| rt.snapshot().server_bootstrapped else false;
+    const advertisement: http.http3_handler.Advertisement = blk: {
+        if (!cfg.http3_enabled) break :blk .disabled;
+        if (phase == .draining) break :blk .clear;
+        if (!runtime_ready) break :blk .disabled;
+        if (cfg.http3_alt_svc == .off) break :blk .disabled;
+        break :blk .{ .active = .{
+            .port = if (runtime) |rt| rt.snapshot().quic_port else cfg.quic_port,
+            .max_age_seconds = cfg.http3_alt_svc_max_age_seconds,
+        } };
+    };
+    const effective = http.http3_handler.formatAdvertisement(state.allocator, advertisement) catch null;
+    state.runtime_mutex.lock();
+    if (state.http3_alt_svc) |old| state.allocator.free(old);
+    state.http3_alt_svc = effective;
+    state.http3_advertisement_state = switch (advertisement) {
+        .disabled => if (!cfg.http3_enabled) .disabled else if (!runtime_ready) .configured_unavailable else .ready_advertisement_disabled,
+        .clear => .clearing,
+        .active => .advertising,
+    };
+    if (phase == .draining) state.http3_advertisement_state = .draining;
+    state.runtime_mutex.unlock();
 }
 
 fn nativeResumptionMetricsObserver(state: *GatewayState) tls_core.resumption_runtime.Observer {

--- a/src/gateway_control_plane_proxy.zig
+++ b/src/gateway_control_plane_proxy.zig
@@ -538,6 +538,7 @@ fn executeBoundedControlPlaneJsonProxyAttempt(
                 upstream_content_disposition,
                 correlation_id,
                 &state.security_headers,
+                state.http3_alt_svc,
                 sticky_set_cookie,
             );
             if (buffered_resp.body.len > 0) {

--- a/src/gateway_handlers.zig
+++ b/src/gateway_handlers.zig
@@ -483,6 +483,8 @@ fn initHandlerTestState(state: *GatewayState, allocator: std.mem.Allocator, add_
     };
     state.add_headers = add_headers;
     state.http3_alt_svc = null;
+    state.http3_advertisement_state = .disabled;
+    state.http3_runtime = null;
     state.session_store = null;
 }
 

--- a/src/gateway_proxy.zig
+++ b/src/gateway_proxy.zig
@@ -698,6 +698,7 @@ fn streamViaH2Pool(
     downstream_conn: anytype,
     downstream_writer: anytype,
     security: *const http.security_headers.SecurityHeaders,
+    alt_svc: ?[]const u8,
     sticky_set_cookie: ?[]const u8,
     correlation_id: []const u8,
     connect_timeout_ms: u32,
@@ -730,7 +731,7 @@ fn streamViaH2Pool(
                 if (h1_pool) |p| p.recordProtocol(false);
                 const start_ms = http.event_loop.monotonicMs();
                 var wrote_downstream = false;
-                const res = try streamProxyOverTransport(allocator, tls_ptr, tls_ptr.fd, read_buf, uri, method, extra_headers, buffered_body, streaming_body, downstream_conn, downstream_writer, security, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, &wrote_downstream, proxy_buffer_limits, proxy_buffer_observer);
+                const res = try streamProxyOverTransport(allocator, tls_ptr, tls_ptr.fd, read_buf, uri, method, extra_headers, buffered_body, streaming_body, downstream_conn, downstream_writer, security, alt_svc, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, &wrote_downstream, proxy_buffer_limits, proxy_buffer_observer);
                 if (h1_pool) |p| p.recordRequestLatency(false, http.event_loop.monotonicMs() - start_ms);
                 return res.result;
             },
@@ -858,6 +859,7 @@ fn streamViaH2Pool(
                     body_allowed,
                     correlation_id,
                     security,
+                    alt_svc,
                     sticky_set_cookie,
                 ) catch {
                     conn.finishStreaming(stream); // resets the unfinished stream
@@ -1755,6 +1757,7 @@ fn streamProxyOverTransport(
     downstream_conn: anytype,
     downstream_writer: anytype,
     security: *const http.security_headers.SecurityHeaders,
+    alt_svc: ?[]const u8,
     sticky_set_cookie: ?[]const u8,
     correlation_id: []const u8,
     connect_timeout_ms: u32,
@@ -1804,6 +1807,7 @@ fn streamProxyOverTransport(
         body_allowed,
         correlation_id,
         security,
+        alt_svc,
         sticky_set_cookie,
     ) catch return error.ClientAborted;
     wrote_downstream.* = true;
@@ -1861,6 +1865,7 @@ pub fn executeStreamingHttpProxyRequest(
     auth_device_id: ?[]const u8,
     auth_scopes: ?[]const u8,
     security: *const http.security_headers.SecurityHeaders,
+    alt_svc: ?[]const u8,
     sticky_set_cookie: ?[]const u8,
     cancel_token: ?*const CancellationToken,
     proxy_buffer_observer: proxy_buffer_account.Observer,
@@ -1926,7 +1931,7 @@ pub fn executeStreamingHttpProxyRequest(
     if (stream_h2) {
         if (h2_pool) |hp| {
             const h2_opts: ?http.tls_termination.UpstreamTlsOptions = if (is_https) tls_options.? else null;
-            return streamViaH2Pool(allocator, hp, pool, host, port, h2_opts, uri, method, extra_headers.items, buffered_body, streaming_body, read_buf, downstream_conn, downstream_writer, security, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, cfg.proxy_buffer_limits, proxy_buffer_observer);
+            return streamViaH2Pool(allocator, hp, pool, host, port, h2_opts, uri, method, extra_headers.items, buffered_body, streaming_body, read_buf, downstream_conn, downstream_writer, security, alt_svc, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, cfg.proxy_buffer_limits, proxy_buffer_observer);
         }
         if (streaming_body != null) {
             if (pool) |p| p.recordH2StreamingUploadFallback();
@@ -1995,9 +2000,9 @@ pub fn executeStreamingHttpProxyRequest(
         const exchange_start_ms = http.event_loop.monotonicMs();
         const fd = conn.stream.handle;
         const res = (if (conn.tls) |tls|
-            streamProxyOverTransport(allocator, tls, fd, read_buf, uri, method, extra_headers.items, buffered_body, streaming_body, downstream_conn, downstream_writer, security, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, &wrote_downstream, cfg.proxy_buffer_limits, proxy_buffer_observer)
+            streamProxyOverTransport(allocator, tls, fd, read_buf, uri, method, extra_headers.items, buffered_body, streaming_body, downstream_conn, downstream_writer, security, alt_svc, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, &wrote_downstream, cfg.proxy_buffer_limits, proxy_buffer_observer)
         else
-            streamProxyOverTransport(allocator, compat.netStreamFromFd(fd), fd, read_buf, uri, method, extra_headers.items, buffered_body, streaming_body, downstream_conn, downstream_writer, security, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, &wrote_downstream, cfg.proxy_buffer_limits, proxy_buffer_observer)) catch |err| {
+            streamProxyOverTransport(allocator, compat.netStreamFromFd(fd), fd, read_buf, uri, method, extra_headers.items, buffered_body, streaming_body, downstream_conn, downstream_writer, security, alt_svc, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, &wrote_downstream, cfg.proxy_buffer_limits, proxy_buffer_observer)) catch |err| {
             // Tear down the connection (release handles active-- and close).
             if (active_pool) |p| {
                 p.release(key, conn, false, http.event_loop.monotonicMs());

--- a/src/gateway_proxy_headers.zig
+++ b/src/gateway_proxy_headers.zig
@@ -71,6 +71,7 @@ pub fn shouldSkipUpstreamResponseHeader(name: []const u8) bool {
         std.ascii.eqlIgnoreCase(name, "trailer") or
         std.ascii.eqlIgnoreCase(name, "transfer-encoding") or
         std.ascii.eqlIgnoreCase(name, "upgrade") or
+        std.ascii.eqlIgnoreCase(name, "alt-svc") or
         // Strip upstream technology-disclosure headers. Tardigrade emits its
         // own Server header; leaking the upstream value exposes backend stack
         // details to external clients (WSTG-INFO-02, ASVS-14.3.3).

--- a/src/gateway_proxy_response.zig
+++ b/src/gateway_proxy_response.zig
@@ -36,6 +36,7 @@ pub fn writeStreamedUpstreamResponse(
     content_disposition: ?[]const u8,
     correlation_id: []const u8,
     security: *const http.security_headers.SecurityHeaders,
+    alt_svc: ?[]const u8,
     sticky_set_cookie: ?[]const u8,
 ) !void {
     var header_buf: [4096]u8 = undefined;
@@ -48,6 +49,7 @@ pub fn writeStreamedUpstreamResponse(
         content_disposition,
         correlation_id,
         security,
+        alt_svc,
         sticky_set_cookie,
     ) catch {
         try writeStreamedUpstreamResponseHead(
@@ -58,6 +60,7 @@ pub fn writeStreamedUpstreamResponse(
             content_disposition,
             correlation_id,
             security,
+            alt_svc,
             sticky_set_cookie,
         );
         return;
@@ -73,6 +76,7 @@ pub fn writeStreamedUpstreamResponseHead(
     content_disposition: ?[]const u8,
     correlation_id: []const u8,
     security: *const http.security_headers.SecurityHeaders,
+    alt_svc: ?[]const u8,
     sticky_set_cookie: ?[]const u8,
 ) !void {
     const phrase = if (reason.len > 0)
@@ -94,6 +98,7 @@ pub fn writeStreamedUpstreamResponseHead(
     }
 
     try writeSecurityHeaders(writer, security);
+    if (alt_svc) |value| try writer.print("Alt-Svc: {s}\r\n", .{value});
     try writer.writeAll("\r\n");
 }
 
@@ -105,6 +110,7 @@ pub fn writeStreamedUpstreamResponseHeadFromHeaders(
     body_allowed: bool,
     correlation_id: []const u8,
     security: *const http.security_headers.SecurityHeaders,
+    alt_svc: ?[]const u8,
     sticky_set_cookie: ?[]const u8,
 ) !void {
     const phrase = if (reason.len > 0)
@@ -125,6 +131,7 @@ pub fn writeStreamedUpstreamResponseHeadFromHeaders(
         try writer.print("Set-Cookie: {s}\r\n", .{cookie});
     }
     try writeSecurityHeadersFiltered(writer, security, upstream_headers);
+    if (alt_svc) |value| try writer.print("Alt-Svc: {s}\r\n", .{value});
     try writer.writeAll("\r\n");
 }
 
@@ -134,6 +141,7 @@ pub fn writeBufferedUpstreamResponse(
     keep_alive: bool,
     correlation_id: []const u8,
     security: *const http.security_headers.SecurityHeaders,
+    alt_svc: ?[]const u8,
     sticky_set_cookie: ?[]const u8,
 ) !void {
     var response_buf: [8192]u8 = undefined;
@@ -144,6 +152,7 @@ pub fn writeBufferedUpstreamResponse(
         keep_alive,
         correlation_id,
         security,
+        alt_svc,
         sticky_set_cookie,
     ) catch {
         try writeBufferedUpstreamResponseHead(
@@ -152,6 +161,7 @@ pub fn writeBufferedUpstreamResponse(
             keep_alive,
             correlation_id,
             security,
+            alt_svc,
             sticky_set_cookie,
         );
         if (upstream_response.body.len > 0) try writer.writeAll(upstream_response.body);
@@ -176,6 +186,7 @@ pub fn writeBufferedUpstreamResponseHead(
     keep_alive: bool,
     correlation_id: []const u8,
     security: *const http.security_headers.SecurityHeaders,
+    alt_svc: ?[]const u8,
     sticky_set_cookie: ?[]const u8,
 ) !void {
     const phrase = if (upstream_response.reason.len > 0)
@@ -201,6 +212,7 @@ pub fn writeBufferedUpstreamResponseHead(
     // Only inject security headers that the upstream did not already supply,
     // preventing duplicate / conflicting headers (e.g. double CSP).
     try writeSecurityHeadersFiltered(writer, security, upstream_response.headers);
+    if (alt_svc) |value| try writer.print("Alt-Svc: {s}\r\n", .{value});
     try writer.writeAll("\r\n");
 }
 
@@ -342,6 +354,7 @@ test "writeBufferedUpstreamResponse preserves oversized body bytes exactly" {
         "req-large-body",
         &http.security_headers.SecurityHeaders.api,
         null,
+        null,
     );
 
     const raw = output.written();
@@ -376,6 +389,7 @@ test "writeBufferedUpstreamResponse serializes a single forwarded response head"
         true,
         "tg-1778460305668-bfebecb410803023",
         &http.security_headers.SecurityHeaders.api,
+        null,
         "tg_sticky=proxy",
     );
 
@@ -392,4 +406,38 @@ test "writeBufferedUpstreamResponse serializes a single forwarded response head"
     try std.testing.expect(std.mem.find(u8, output, "X-Correlation-ID: tg-1778460305668-bfebecb410803023\r\n") != null);
     try std.testing.expect(std.mem.find(u8, output, "Server: python\r\n") == null);
     try std.testing.expect(std.mem.endsWith(u8, output, "\r\n\r\npong"));
+}
+
+test "writeBufferedUpstreamResponse strips upstream Alt-Svc and emits effective policy once" {
+    const allocator = std.testing.allocator;
+    const body = try allocator.dupe(u8, "pong");
+    var upstream_headers = [_]TestUpstreamHeader{
+        .{ .name = "Content-Type", .value = "text/plain" },
+        .{ .name = "Alt-Svc", .value = "h3=\":443\"; ma=86400" },
+    };
+
+    var response = TestBufferedUpstreamResponse{
+        .metadata_arena = std.heap.ArenaAllocator.init(allocator),
+        .status_code = 200,
+        .reason = "OK",
+        .headers = upstream_headers[0..],
+        .body = body,
+    };
+    defer response.deinit(allocator);
+
+    var buf: [4096]u8 = undefined;
+    var stream = compat.fixedBufferStream(&buf);
+    try writeBufferedUpstreamResponse(
+        stream.writer(),
+        &response,
+        true,
+        "req-alt-svc",
+        &http.security_headers.SecurityHeaders.api,
+        "clear",
+        null,
+    );
+
+    const output = stream.getWritten();
+    try std.testing.expect(std.mem.find(u8, output, "Alt-Svc: h3=\":443\"") == null);
+    try std.testing.expect(std.mem.find(u8, output, "Alt-Svc: clear\r\n") != null);
 }

--- a/src/gateway_proxy_runtime.zig
+++ b/src/gateway_proxy_runtime.zig
@@ -115,11 +115,12 @@ pub const DataPlaneProxyResponse = union(enum) {
         keep_alive: bool,
         correlation_id: []const u8,
         security: *const http.security_headers.SecurityHeaders,
+        alt_svc: ?[]const u8,
         sticky_set_cookie: ?[]const u8,
     ) !void {
         switch (self.*) {
             .bounded_buffered => |*response| {
-                try writeBufferedUpstreamResponse(writer, response, keep_alive, correlation_id, security, sticky_set_cookie);
+                try writeBufferedUpstreamResponse(writer, response, keep_alive, correlation_id, security, alt_svc, sticky_set_cookie);
             },
         }
     }
@@ -558,6 +559,7 @@ pub fn handleLocationProxyPass(
                 auth_device_id,
                 auth_scopes,
                 &state.security_headers,
+                state.http3_alt_svc,
                 sticky_set_cookie,
                 if (ctx.lifecycle) |lc| &lc.token else null,
                 proxy_buffer_observer,
@@ -740,7 +742,7 @@ pub fn handleLocationProxyPass(
         }
     }
     ctx.setUpstreamResult(resolved.upstream_host, upstream_response.statusCode(), upstream_response.bodyLen());
-    try upstream_response.writeHttp1(writer, keep_alive, correlation_id, &state.security_headers, sticky_set_cookie);
+    try upstream_response.writeHttp1(writer, keep_alive, correlation_id, &state.security_headers, state.http3_alt_svc, sticky_set_cookie);
     const status_code = upstream_response.statusCode();
     state.metricsRecord(status_code);
     return status_code;

--- a/src/gateway_shutdown.zig
+++ b/src/gateway_shutdown.zig
@@ -380,6 +380,27 @@ test "http3ListenerConfigChanged permits advertisement-only reloads" {
     try std.testing.expect(http3ListenerConfigChanged(&base, &proposed));
 }
 
+test "computeReloadedHttp3Advertisement withdraws active auto advertisement when reloaded off" {
+    const allocator = std.testing.allocator;
+    var cfg = try edge_config.loadFromEnv(allocator);
+    defer cfg.deinit(allocator);
+
+    cfg.http3_enabled = true;
+    cfg.http3_alt_svc = .off;
+    cfg.http3_alt_svc_max_age_seconds = 60;
+
+    const withdrawal = computeReloadedHttp3Advertisement(&cfg, true, 8443, .advertising);
+    try std.testing.expectEqual(http.http3_handler.Advertisement.clear, withdrawal);
+    try std.testing.expectEqual(http.http3_runtime.EffectiveAdvertisementState.clearing, stateForHttp3Advertisement(true, true, withdrawal));
+
+    const already_off = computeReloadedHttp3Advertisement(&cfg, true, 8443, .ready_advertisement_disabled);
+    try std.testing.expectEqual(http.http3_handler.Advertisement.disabled, already_off);
+
+    cfg.http3_alt_svc = .auto;
+    const active = computeReloadedHttp3Advertisement(&cfg, true, 8443, .clearing);
+    try std.testing.expectEqualDeep(http.http3_handler.Advertisement{ .active = .{ .port = 8443, .max_age_seconds = 60 } }, active);
+}
+
 extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
 extern "c" fn unsetenv(name: [*:0]const u8) c_int;
 
@@ -582,21 +603,17 @@ pub fn applyReloadedRuntimeConfig(cfg: *const edge_config.EdgeConfig, state: *Ga
 
     state.runtime_mutex.lock();
     state.add_headers = cfg.add_headers;
+    const previous_h3_advertisement_state = state.http3_advertisement_state;
     if (state.http3_alt_svc) |value| state.allocator.free(value);
     const runtime_ready = if (state.http3_runtime) |runtime| runtime.snapshot().server_bootstrapped else false;
-    const advertisement: http.http3_handler.Advertisement = if (!cfg.http3_enabled or !runtime_ready or cfg.http3_alt_svc == .off)
-        .disabled
-    else
-        .{ .active = .{
-            .port = if (state.http3_runtime) |runtime| runtime.snapshot().quic_port else cfg.quic_port,
-            .max_age_seconds = cfg.http3_alt_svc_max_age_seconds,
-        } };
+    const advertisement = computeReloadedHttp3Advertisement(
+        cfg,
+        runtime_ready,
+        if (state.http3_runtime) |runtime| runtime.snapshot().quic_port else cfg.quic_port,
+        previous_h3_advertisement_state,
+    );
     state.http3_alt_svc = http.http3_handler.formatAdvertisement(state.allocator, advertisement) catch null;
-    state.http3_advertisement_state = switch (advertisement) {
-        .disabled => if (!cfg.http3_enabled) .disabled else if (!runtime_ready) .configured_unavailable else .ready_advertisement_disabled,
-        .clear => .clearing,
-        .active => .advertising,
-    };
+    state.http3_advertisement_state = stateForHttp3Advertisement(cfg.http3_enabled, runtime_ready, advertisement);
     if (state.hsts_value.len > 0) state.allocator.free(state.hsts_value);
     state.hsts_value = computeHstsValue(state.allocator, cfg) catch &.{};
     state.security_headers = blk: {
@@ -622,6 +639,37 @@ pub fn applyReloadedRuntimeConfig(cfg: *const edge_config.EdgeConfig, state: *Ga
     };
     state.logger.min_level = cfg.log_level;
     state.runtime_mutex.unlock();
+}
+
+fn computeReloadedHttp3Advertisement(
+    cfg: *const edge_config.EdgeConfig,
+    runtime_ready: bool,
+    runtime_port: u16,
+    previous_state: http.http3_runtime.EffectiveAdvertisementState,
+) http.http3_handler.Advertisement {
+    if (!cfg.http3_enabled or !runtime_ready) return .disabled;
+    if (cfg.http3_alt_svc == .off) {
+        return switch (previous_state) {
+            .advertising, .clearing, .draining => .clear,
+            else => .disabled,
+        };
+    }
+    return .{ .active = .{
+        .port = runtime_port,
+        .max_age_seconds = cfg.http3_alt_svc_max_age_seconds,
+    } };
+}
+
+fn stateForHttp3Advertisement(
+    http3_enabled: bool,
+    runtime_ready: bool,
+    advertisement: http.http3_handler.Advertisement,
+) http.http3_runtime.EffectiveAdvertisementState {
+    return switch (advertisement) {
+        .disabled => if (!http3_enabled) .disabled else if (!runtime_ready) .configured_unavailable else .ready_advertisement_disabled,
+        .clear => .clearing,
+        .active => .advertising,
+    };
 }
 
 pub fn reopenErrorLog(cfg: *const edge_config.EdgeConfig) !void {

--- a/src/gateway_shutdown.zig
+++ b/src/gateway_shutdown.zig
@@ -115,6 +115,23 @@ pub fn hotReloadConfig(
     }
     {
         var current_lease = worker_ctx.config_store.acquire();
+        const h3_listener_config_changed = http3ListenerConfigChanged(current_lease.cfg, cfg_ptr);
+        current_lease.release();
+        if (h3_listener_config_changed) {
+            worker_ctx.config_store.destroyVersion(prepared_version);
+            const msg = std.fmt.bufPrint(&state.last_reload_error, "HTTP/3 listener configuration changed; restart required", .{}) catch "HTTP/3 listener configuration changed";
+            state.reload_mutex.lock();
+            state.last_reload_ok = false;
+            state.last_reload_at_ms = now_ms;
+            state.last_reload_error_len = msg.len;
+            state.reload_mutex.unlock();
+            state.metricsRecordReloadFailure();
+            state.logger.warn(null, "config reload rejected: HTTP/3 listener-owned configuration changed; restart the process to change http3_enabled, quic_port, migration, Retry, 0-RTT, or datagram sizing", .{});
+            return;
+        }
+    }
+    {
+        var current_lease = worker_ctx.config_store.acquire();
         const source_changed = (current_lease.cfg.tls_native_ticket_keys_path.len == 0) != (cfg_ptr.tls_native_ticket_keys_path.len == 0);
         current_lease.release();
         if (source_changed or (cfg_ptr.tls_native_ticket_keys_path.len > 0 and worker_ctx.resumption_runtime == null)) {
@@ -302,6 +319,18 @@ pub fn earlyDataReplayConfigChanged(
         current.tls_native_early_data_replay_max_entries != proposed.tls_native_early_data_replay_max_entries;
 }
 
+pub fn http3ListenerConfigChanged(
+    current: *const edge_config.EdgeConfig,
+    proposed: *const edge_config.EdgeConfig,
+) bool {
+    return current.http3_enabled != proposed.http3_enabled or
+        current.quic_port != proposed.quic_port or
+        current.http3_enable_0rtt != proposed.http3_enable_0rtt or
+        current.http3_connection_migration != proposed.http3_connection_migration or
+        current.http3_retry_policy != proposed.http3_retry_policy or
+        current.http3_max_datagram_size != proposed.http3_max_datagram_size;
+}
+
 test "earlyDataReplayConfigChanged detects mode and capacity changes independently" {
     const allocator = std.testing.allocator;
     var base = try edge_config.loadFromEnv(allocator);
@@ -328,6 +357,27 @@ test "earlyDataReplayConfigChanged detects mode and capacity changes independent
     try std.testing.expect(earlyDataReplayConfigChanged(&base, &proposed));
     proposed.tls_native_early_data_replay_max_entries = base.tls_native_early_data_replay_max_entries;
     try std.testing.expect(!earlyDataReplayConfigChanged(&base, &proposed));
+}
+
+test "http3ListenerConfigChanged permits advertisement-only reloads" {
+    const allocator = std.testing.allocator;
+    var base = try edge_config.loadFromEnv(allocator);
+    defer base.deinit(allocator);
+    var proposed = try edge_config.loadFromEnv(allocator);
+    defer proposed.deinit(allocator);
+
+    base.http3_enabled = true;
+    proposed.http3_enabled = true;
+    proposed.http3_alt_svc = .auto;
+    proposed.http3_alt_svc_max_age_seconds = base.http3_alt_svc_max_age_seconds + 1;
+    try std.testing.expect(!http3ListenerConfigChanged(&base, &proposed));
+
+    proposed.quic_port = base.quic_port + 1;
+    try std.testing.expect(http3ListenerConfigChanged(&base, &proposed));
+    proposed.quic_port = base.quic_port;
+
+    proposed.http3_retry_policy = .address_validation;
+    try std.testing.expect(http3ListenerConfigChanged(&base, &proposed));
 }
 
 extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
@@ -533,7 +583,20 @@ pub fn applyReloadedRuntimeConfig(cfg: *const edge_config.EdgeConfig, state: *Ga
     state.runtime_mutex.lock();
     state.add_headers = cfg.add_headers;
     if (state.http3_alt_svc) |value| state.allocator.free(value);
-    state.http3_alt_svc = if (cfg.http3_enabled) http.http3_handler.formatAltSvc(state.allocator, cfg.quic_port) catch null else null;
+    const runtime_ready = if (state.http3_runtime) |runtime| runtime.snapshot().server_bootstrapped else false;
+    const advertisement: http.http3_handler.Advertisement = if (!cfg.http3_enabled or !runtime_ready or cfg.http3_alt_svc == .off)
+        .disabled
+    else
+        .{ .active = .{
+            .port = if (state.http3_runtime) |runtime| runtime.snapshot().quic_port else cfg.quic_port,
+            .max_age_seconds = cfg.http3_alt_svc_max_age_seconds,
+        } };
+    state.http3_alt_svc = http.http3_handler.formatAdvertisement(state.allocator, advertisement) catch null;
+    state.http3_advertisement_state = switch (advertisement) {
+        .disabled => if (!cfg.http3_enabled) .disabled else if (!runtime_ready) .configured_unavailable else .ready_advertisement_disabled,
+        .clear => .clearing,
+        .active => .advertising,
+    };
     if (state.hsts_value.len > 0) state.allocator.free(state.hsts_value);
     state.hsts_value = computeHstsValue(state.allocator, cfg) catch &.{};
     state.security_headers = blk: {
@@ -613,6 +676,8 @@ test "applyReloadedRuntimeConfig updates exported proxy buffer limits" {
     state.metrics = http.metrics.Metrics.init();
     state.add_headers = &.{};
     state.http3_alt_svc = null;
+    state.http3_advertisement_state = .disabled;
+    state.http3_runtime = null;
     state.hsts_value = "";
     state.security_headers = http.security_headers.SecurityHeaders.api;
     state.max_connections_per_ip = 0;

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -3531,6 +3531,7 @@ fn initMetricsJsonTestState(gs: *GatewayState, allocator: std.mem.Allocator) voi
     // counters, so the pool must be a valid (empty) instance here.
     gs.upstream_pool = http.upstream_pool.UpstreamPool.init(allocator, .{});
     gs.h2_pool = http.upstream_h2.H2ConnPool.init(allocator, .{});
+    gs.http3_advertisement_state = .disabled;
     gs.proxy_buffer_limits = .{
         .per_stream_low_watermark = 256 * 1024,
         .per_stream_high_watermark = 768 * 1024,
@@ -3594,6 +3595,7 @@ test "served Prometheus metrics expose h2 streaming upload fallback counter" {
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_upstream_h2_streaming_upload_fallback_total 1\n") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_config_limit_bytes{direction=\"upstream_to_downstream\",scope=\"stream\",limit=\"high\"} 786432\n") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_tls_buffer_config_limit_bytes{queue=\"outbound_ciphertext\",limit=\"hard\"}") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http3_effective_state{state=\"disabled\"} 1\n") != null);
 }
 
 test "served Prometheus metrics reflect updated proxy buffer limit snapshot" {

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -434,7 +434,8 @@ pub const GatewayState = struct {
     /// configured. Heap-owned; re-derived (old value freed) on reload. [runtime_mutex]
     hsts_value: []u8 = &.{},
     add_headers: []const edge_config.EdgeConfig.HeaderPair, // borrowed from cfg; rebound on reload [runtime_mutex]
-    http3_alt_svc: ?[]u8, // owned; re-derived (old freed) on reload [runtime_mutex]
+    http3_alt_svc: ?[]u8, // owned effective advertisement; re-derived (old freed) on reload [runtime_mutex]
+    http3_advertisement_state: http.http3_runtime.EffectiveAdvertisementState, // cfg/runtime-derived [runtime_mutex]
     http3_runtime: ?*http.http3_runtime.Runtime, // owned pointer; main-event-loop-only
     session_store: ?http.session.SessionStore, // owned [session_mutex]
     session_store_path: []const u8, // borrowed from startup cfg; restart-only (warns on change at reload)
@@ -1758,9 +1759,16 @@ pub const GatewayState = struct {
         self.runtime_mutex.lock();
         const proxy_buffer_limits = self.proxy_buffer_limits;
         const tls_buffer_limits = self.tls_buffer_limits;
+        const http3_advertisement_state = self.http3_advertisement_state;
         self.runtime_mutex.unlock();
         try appendProxyBufferConfigPrometheus(&combined, proxy_buffer_limits);
         try appendTlsBufferConfigPrometheus(&combined, tls_buffer_limits);
+        try combined.appendSlice(
+            \\# HELP tardigrade_http3_effective_state HTTP/3 effective listener and advertisement state
+            \\# TYPE tardigrade_http3_effective_state gauge
+            \\
+        );
+        try combined.print("tardigrade_http3_effective_state{{state=\"{s}\"}} 1\n", .{@tagName(http3_advertisement_state)});
         if (mux_snapshot.device_counts.len > 0) {
             try combined.appendSlice(
                 \\# HELP tardigrade_mux_device_channels Current active mux channels by device

--- a/src/http/http3_handler.zig
+++ b/src/http/http3_handler.zig
@@ -4,8 +4,36 @@
 
 const std = @import("std");
 
-pub fn formatAltSvc(allocator: std.mem.Allocator, https_port: u16) ![]u8 {
-    return std.fmt.allocPrint(allocator, "h3=\":{d}\"", .{https_port});
+pub const AltSvcMode = enum {
+    off,
+    auto,
+
+    pub fn parse(value: []const u8) ?AltSvcMode {
+        if (std.ascii.eqlIgnoreCase(value, "off")) return .off;
+        if (std.ascii.eqlIgnoreCase(value, "auto")) return .auto;
+        return null;
+    }
+};
+
+pub const Advertisement = union(enum) {
+    disabled,
+    clear,
+    active: struct {
+        port: u16,
+        max_age_seconds: u32,
+    },
+};
+
+pub fn formatAltSvc(allocator: std.mem.Allocator, https_port: u16, max_age_seconds: u32) ![]u8 {
+    return std.fmt.allocPrint(allocator, "h3=\":{d}\"; ma={d}", .{ https_port, max_age_seconds });
+}
+
+pub fn formatAdvertisement(allocator: std.mem.Allocator, advertisement: Advertisement) !?[]u8 {
+    return switch (advertisement) {
+        .disabled => null,
+        .clear => try allocator.dupe(u8, "clear"),
+        .active => |active| try formatAltSvc(allocator, active.port, active.max_age_seconds),
+    };
 }
 
 pub fn configurationStatus(http3_enabled: bool, tls_ready: bool) []const u8 {
@@ -15,9 +43,22 @@ pub fn configurationStatus(http3_enabled: bool, tls_ready: bool) []const u8 {
 }
 
 test "http3 handler alt-svc formatting" {
-    const value = try formatAltSvc(std.testing.allocator, 443);
+    const value = try formatAltSvc(std.testing.allocator, 443, 300);
     defer std.testing.allocator.free(value);
-    try std.testing.expectEqualStrings("h3=\":443\"", value);
+    try std.testing.expectEqualStrings("h3=\":443\"; ma=300", value);
+}
+
+test "http3 handler formats advertisement states" {
+    const disabled = try formatAdvertisement(std.testing.allocator, .disabled);
+    try std.testing.expectEqual(@as(?[]u8, null), disabled);
+
+    const clear = try formatAdvertisement(std.testing.allocator, .clear);
+    defer std.testing.allocator.free(clear.?);
+    try std.testing.expectEqualStrings("clear", clear.?);
+
+    const active = try formatAdvertisement(std.testing.allocator, .{ .active = .{ .port = 8443, .max_age_seconds = 60 } });
+    defer std.testing.allocator.free(active.?);
+    try std.testing.expectEqualStrings("h3=\":8443\"; ma=60", active.?);
 }
 
 test "http3 handler configuration status reports expected states" {

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -188,6 +188,8 @@ const ConnEntry = struct {
     /// never be retried on the same connection (#488).
     ticket_issue_attempted: bool = false,
     drain_goaway_sent: bool = false,
+    highest_admitted_request_stream_id: ?u64 = null,
+    drain_goaway_boundary: ?u64 = null,
     last_path_metrics: quic.path.Metrics = .{},
     parked_h3_retries: std.ArrayList(ParkedH3Retry) = .empty,
 
@@ -460,7 +462,6 @@ pub const Runtime = struct {
                 if (n == 0) continue;
                 const datagram = buf[0..@intCast(n)];
                 if (from.family != posix.AF.INET) continue;
-                if (draining) continue;
                 const peer: *const std.c.sockaddr.in = @ptrCast(&from);
                 self.ingest(&connections, &routes, &per_ip, &next_handle, datagram, peer.*, nowUs());
             }
@@ -570,6 +571,7 @@ pub const Runtime = struct {
         peer: std.c.sockaddr.in,
         now: u64,
     ) ?u64 {
+        if (self.drain_requested.load(.acquire)) return null;
         const credential_provider = self.credential_provider orelse return null;
         if (parsed.dcid.len < 8 or parsed.scid.len == 0) return null;
         const retry_context: ?quic.path.RetryContext = switch (self.classifyRetry(routes, parsed, peer, now)) {
@@ -881,9 +883,13 @@ pub const Runtime = struct {
                 return;
             } orelse break;
             if (self.drain_requested.load(.acquire)) {
-                entry.conn.resetStream(incoming.stream_id, 0x0107) catch {}; // H3_REQUEST_REJECTED
-                entry.h3.finishRequest(incoming.stream_id);
-                continue;
+                const boundary = entry.drain_goaway_boundary orelse drainBoundaryAfter(entry.highest_admitted_request_stream_id);
+                entry.drain_goaway_boundary = boundary;
+                if (requestRejectedByDrainBoundary(incoming.stream_id, boundary)) {
+                    entry.conn.resetStream(incoming.stream_id, 0x010b) catch {}; // H3_REQUEST_REJECTED
+                    entry.h3.finishRequest(incoming.stream_id);
+                    continue;
+                }
             }
             self.serveRequest(entry, incoming, now);
         }
@@ -891,7 +897,9 @@ pub const Runtime = struct {
 
     fn sendDrainGoaway(self: *Runtime, entry: *ConnEntry) void {
         if (!entry.conn.isEstablished() or !entry.h3_started) return;
-        entry.h3.sendGoaway(entry.conn, 0) catch |err| {
+        const boundary = entry.drain_goaway_boundary orelse drainBoundaryAfter(entry.highest_admitted_request_stream_id);
+        entry.drain_goaway_boundary = boundary;
+        entry.h3.sendGoaway(entry.conn, boundary) catch |err| {
             self.logger.warn(null, "http3: failed to queue GOAWAY during drain: {s}", .{@errorName(err)});
             return;
         };
@@ -900,6 +908,7 @@ pub const Runtime = struct {
 
     fn serveRequest(self: *Runtime, entry: *ConnEntry, incoming: H3.IncomingRequest, now: u64) void {
         _ = now;
+        entry.highest_admitted_request_stream_id = maxOptional(entry.highest_admitted_request_stream_id, incoming.stream_id);
         entry.conn.setStreamSchedulingHint(incoming.stream_id, .{
             .urgency = incoming.priority.urgency,
             .incremental = incoming.priority.incremental,
@@ -1446,6 +1455,19 @@ fn admissionAllowed(total: usize, per_source: u32) bool {
     return total < max_connections and per_source < max_connections_per_source;
 }
 
+fn maxOptional(current: ?u64, candidate: u64) u64 {
+    return if (current) |value| @max(value, candidate) else candidate;
+}
+
+fn drainBoundaryAfter(highest_admitted_request_stream_id: ?u64) u64 {
+    const highest = highest_admitted_request_stream_id orelse return 0;
+    return highest +| 4;
+}
+
+fn requestRejectedByDrainBoundary(stream_id: u64, boundary: u64) bool {
+    return stream_id >= boundary;
+}
+
 /// What to do with a tracked connection after ingesting a datagram, decided
 /// purely from whether the datagram authenticated (the post-AEAD
 /// `packets_received` delta), whether the connection was just accepted for this
@@ -1962,6 +1984,16 @@ test "admissionAllowed enforces global and per-source caps at the boundary" {
     try testing.expect(!admissionAllowed(0, max_connections_per_source + 1));
     // Either cap alone is sufficient to reject.
     try testing.expect(!admissionAllowed(max_connections, max_connections_per_source));
+}
+
+test "drainBoundaryAfter permits admitted client-bidi streams" {
+    try testing.expectEqual(@as(u64, 0), drainBoundaryAfter(null));
+    try testing.expectEqual(@as(u64, 4), drainBoundaryAfter(0));
+    try testing.expectEqual(@as(u64, 12), drainBoundaryAfter(8));
+
+    try testing.expect(!requestRejectedByDrainBoundary(0, 4));
+    try testing.expect(requestRejectedByDrainBoundary(4, 4));
+    try testing.expect(requestRejectedByDrainBoundary(8, 4));
 }
 
 test "classifyIngest routes spoofed Initials, migration, and normal traffic" {

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -24,7 +24,6 @@ const http3_session = @import("http3_session.zig");
 const logger_mod = @import("logger.zig");
 const metrics_mod = @import("metrics.zig");
 const response_mod = @import("response.zig");
-const shutdown = @import("shutdown.zig");
 const stream_transport = @import("stream_transport");
 const quic = @import("quic");
 const http3 = @import("http3");
@@ -155,6 +154,9 @@ pub const Snapshot = struct {
     migrations_blocked_no_peer_cid: usize = 0,
     last_error_code: i32 = 0,
     draining: bool = false,
+    h3_goaway_sent: usize = 0,
+    h3_drain_request_rejections: usize = 0,
+    active_cid_routes: usize = 0,
 
     pub fn handshakeState(self: Snapshot) []const u8 {
         if (!self.server_bootstrapped) return "bootstrap_incomplete";
@@ -393,7 +395,7 @@ pub const Runtime = struct {
 
         while (!self.stopping.load(.acquire)) {
             const now = nowUs();
-            const draining = self.drain_requested.load(.acquire) or shutdown.isShutdownRequested();
+            const draining = self.drain_requested.load(.acquire);
             const drain_deadline = self.drain_deadline_us.load(.acquire);
             const drain_expired = draining and drain_deadline != 0 and now >= drain_deadline;
 
@@ -690,8 +692,10 @@ pub const Runtime = struct {
             allocator.destroy(entry);
             return null;
         };
+        self.noteCidRouteCount(routes.count());
         connections.put(handle, entry) catch {
             routes.remove(cid);
+            self.noteCidRouteCount(routes.count());
             entry.deinit(allocator);
             allocator.destroy(entry);
             return null;
@@ -699,6 +703,7 @@ pub const Runtime = struct {
         incPerIp(per_ip, peer.addr) catch {
             _ = connections.remove(handle);
             routes.remove(cid);
+            self.noteCidRouteCount(routes.count());
             entry.deinit(allocator);
             allocator.destroy(entry);
             return null;
@@ -784,6 +789,7 @@ pub const Runtime = struct {
     ) void {
         if (connections.fetchRemove(handle)) |kv| {
             for (kv.value.owned_cids[0..kv.value.owned_cid_count]) |cid| routes.remove(cid);
+            self.noteCidRouteCount(routes.count());
             decPerIp(per_ip, kv.value.admission_source_ip);
             kv.value.deinit(self.allocator);
             self.allocator.destroy(kv.value);
@@ -792,13 +798,13 @@ pub const Runtime = struct {
     }
 
     fn syncCidRoutes(self: *Runtime, entry: *ConnEntry, routes: *quic.cid.CidRoutingTable) void {
-        _ = self;
         var active: [quic.cid.max_local_active_cids]quic.cid.ConnectionId = undefined;
         const active_count = entry.conn.copyActiveLocalCids(&active);
         var i: usize = 0;
         while (i < entry.owned_cid_count) {
             if (!cidSliceContains(active[0..active_count], entry.owned_cids[i])) {
                 routes.remove(entry.owned_cids[i]);
+                self.noteCidRouteCount(routes.count());
                 entry.owned_cids[i] = entry.owned_cids[entry.owned_cid_count - 1];
                 entry.owned_cid_count -= 1;
                 continue;
@@ -808,7 +814,6 @@ pub const Runtime = struct {
     }
 
     fn maintainLocalCidRoutes(self: *Runtime, entry: *ConnEntry, handle: u64, routes: *quic.cid.CidRoutingTable) void {
-        _ = self;
         while (entry.conn.needsLocalCid() and entry.owned_cid_count < entry.owned_cids.len) {
             var cid_value: ?quic.cid.ConnectionId = null;
             var entropy: [quic.udp.MaxConnectionIdLen]u8 = undefined;
@@ -821,7 +826,7 @@ pub const Runtime = struct {
             }
             const cid = cid_value orelse return;
             switch (registerLocalCidRoute(entry, handle, routes, cid)) {
-                .registered => {},
+                .registered => self.noteCidRouteCount(routes.count()),
                 .collision => continue,
                 .queue_failed => return,
             }
@@ -888,6 +893,7 @@ pub const Runtime = struct {
                 if (requestRejectedByDrainBoundary(incoming.stream_id, boundary)) {
                     entry.conn.resetStream(incoming.stream_id, 0x010b) catch {}; // H3_REQUEST_REJECTED
                     entry.h3.finishRequest(incoming.stream_id);
+                    self.noteDrainRequestRejected();
                     continue;
                 }
             }
@@ -904,6 +910,7 @@ pub const Runtime = struct {
             return;
         };
         entry.drain_goaway_sent = true;
+        self.noteDrainGoawaySent();
     }
 
     fn serveRequest(self: *Runtime, entry: *ConnEntry, incoming: H3.IncomingRequest, now: u64) void {
@@ -1261,6 +1268,24 @@ pub const Runtime = struct {
         self.snapshot_state.native_connections -|= 1;
         self.snapshot_state.tracked_connections -|= 1;
         if (self.snapshot_state.tracked_connections == 0) self.snapshot_state.draining = false;
+    }
+
+    fn noteCidRouteCount(self: *Runtime, count: usize) void {
+        self.snapshot_mutex.lock();
+        defer self.snapshot_mutex.unlock();
+        self.snapshot_state.active_cid_routes = count;
+    }
+
+    fn noteDrainGoawaySent(self: *Runtime) void {
+        self.snapshot_mutex.lock();
+        defer self.snapshot_mutex.unlock();
+        self.snapshot_state.h3_goaway_sent += 1;
+    }
+
+    fn noteDrainRequestRejected(self: *Runtime) void {
+        self.snapshot_mutex.lock();
+        defer self.snapshot_mutex.unlock();
+        self.snapshot_state.h3_drain_request_rejections += 1;
     }
 
     fn noteHandshakeComplete(self: *Runtime) void {

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -38,6 +38,15 @@ pub const StreamRequest = http3_session.StreamRequest;
 pub const Response = response_mod.Response;
 pub const Logger = logger_mod.Logger;
 
+pub const EffectiveAdvertisementState = enum {
+    disabled,
+    configured_unavailable,
+    ready_advertisement_disabled,
+    advertising,
+    clearing,
+    draining,
+};
+
 pub const Http3RuntimeError = error{
     OutOfMemory,
     DependencyUnavailable,
@@ -145,6 +154,7 @@ pub const Snapshot = struct {
     migrations_blocked: usize = 0,
     migrations_blocked_no_peer_cid: usize = 0,
     last_error_code: i32 = 0,
+    draining: bool = false,
 
     pub fn handshakeState(self: Snapshot) []const u8 {
         if (!self.server_bootstrapped) return "bootstrap_incomplete";
@@ -177,6 +187,7 @@ const ConnEntry = struct {
     /// issuance (successfully or not) — issuance is best-effort and must
     /// never be retried on the same connection (#488).
     ticket_issue_attempted: bool = false,
+    drain_goaway_sent: bool = false,
     last_path_metrics: quic.path.Metrics = .{},
     parked_h3_retries: std.ArrayList(ParkedH3Retry) = .empty,
 
@@ -226,6 +237,8 @@ pub const Runtime = struct {
     snapshot_mutex: compat.Mutex = .{},
     snapshot_state: Snapshot,
     stopping: std.atomic.Value(bool),
+    drain_requested: std.atomic.Value(bool),
+    drain_deadline_us: std.atomic.Value(u64),
 
     pub fn init(allocator: std.mem.Allocator, logger: *logger_mod.Logger, cfg: Config) Http3RuntimeError!Runtime {
         const address = compat.parseIpAddress(cfg.listen_host, cfg.quic_port) catch |err| {
@@ -281,6 +294,8 @@ pub const Runtime = struct {
             .quic_zero_rtt_packet_metrics_cb = cfg.quic_zero_rtt_packet_metrics_cb,
             .snapshot_state = .{ .quic_port = cfg.quic_port },
             .stopping = std.atomic.Value(bool).init(false),
+            .drain_requested = std.atomic.Value(bool).init(false),
+            .drain_deadline_us = std.atomic.Value(u64).init(0),
         };
         var retry_key: [quic.path.token_key_len]u8 = undefined;
         compat.randomBytes(&retry_key);
@@ -326,10 +341,28 @@ pub const Runtime = struct {
         return self.snapshot_state;
     }
 
+    pub fn beginDrain(self: *Runtime, deadline_us: u64) void {
+        if (self.drain_requested.swap(true, .acq_rel)) return;
+        self.drain_deadline_us.store(deadline_us, .release);
+        self.snapshot_mutex.lock();
+        self.snapshot_state.draining = true;
+        self.snapshot_mutex.unlock();
+        self.logger.info(null, "http3: graceful drain started deadline_us={d}", .{deadline_us});
+    }
+
+    pub fn isDrained(self: *Runtime) bool {
+        const snap = self.snapshot();
+        return snap.tracked_connections == 0;
+    }
+
     fn nowUs() u64 {
         var ts: std.c.timespec = undefined;
         _ = std.c.clock_gettime(.MONOTONIC, &ts);
         return @as(u64, @intCast(ts.sec)) * 1_000_000 + @as(u64, @intCast(ts.nsec)) / 1_000;
+    }
+
+    pub fn nowUsPublic() u64 {
+        return nowUs();
     }
 
     fn loopMain(self: *Runtime) void {
@@ -356,8 +389,11 @@ pub const Runtime = struct {
             per_ip.deinit();
         }
 
-        while (!self.stopping.load(.acquire) and !shutdown.isShutdownRequested()) {
+        while (!self.stopping.load(.acquire)) {
             const now = nowUs();
+            const draining = self.drain_requested.load(.acquire) or shutdown.isShutdownRequested();
+            const drain_deadline = self.drain_deadline_us.load(.acquire);
+            const drain_expired = draining and drain_deadline != 0 and now >= drain_deadline;
 
             // 1) Timers and transmission for every connection.
             var wake_us: u64 = now + 100_000;
@@ -372,10 +408,15 @@ pub const Runtime = struct {
                     self.syncCidRoutes(entry, &routes);
                     self.maintainLocalCidRoutes(entry, kv.key_ptr.*, &routes);
                     self.foldPathMetrics(entry);
+                    if (draining and !entry.drain_goaway_sent) self.sendDrainGoaway(entry);
                     while (entry.conn.pollTransmitOnPath(&out, now)) |t| {
                         self.sendDatagram(sockaddrInFromAddress(t.path.remote), t.bytes);
                     }
-                    self.pumpH3(entry, now);
+                    if (drain_expired) {
+                        entry.conn.close(0x0100, "h3 drain deadline", now);
+                    } else {
+                        self.pumpH3(entry, now);
+                    }
                     while (entry.conn.pollTransmitOnPath(&out, now)) |t| {
                         self.sendDatagram(sockaddrInFromAddress(t.path.remote), t.bytes);
                     }
@@ -395,6 +436,7 @@ pub const Runtime = struct {
                     self.removeConnection(&connections, &routes, &per_ip, handle);
                 }
             }
+            if (draining and connections.count() == 0) break;
 
             // 2) Sleep until the earliest deadline or socket readability.
             const timeout_ms: i32 = @intCast(@min((wake_us -| nowUs()) / 1_000 + 1, 100));
@@ -418,6 +460,7 @@ pub const Runtime = struct {
                 if (n == 0) continue;
                 const datagram = buf[0..@intCast(n)];
                 if (from.family != posix.AF.INET) continue;
+                if (draining) continue;
                 const peer: *const std.c.sockaddr.in = @ptrCast(&from);
                 self.ingest(&connections, &routes, &per_ip, &next_handle, datagram, peer.*, nowUs());
             }
@@ -837,8 +880,22 @@ pub const Runtime = struct {
                 entry.conn.close(entry.h3.closeCode(), "h3 request error", now);
                 return;
             } orelse break;
+            if (self.drain_requested.load(.acquire)) {
+                entry.conn.resetStream(incoming.stream_id, 0x0107) catch {}; // H3_REQUEST_REJECTED
+                entry.h3.finishRequest(incoming.stream_id);
+                continue;
+            }
             self.serveRequest(entry, incoming, now);
         }
+    }
+
+    fn sendDrainGoaway(self: *Runtime, entry: *ConnEntry) void {
+        if (!entry.conn.isEstablished() or !entry.h3_started) return;
+        entry.h3.sendGoaway(entry.conn, 0) catch |err| {
+            self.logger.warn(null, "http3: failed to queue GOAWAY during drain: {s}", .{@errorName(err)});
+            return;
+        };
+        entry.drain_goaway_sent = true;
     }
 
     fn serveRequest(self: *Runtime, entry: *ConnEntry, incoming: H3.IncomingRequest, now: u64) void {
@@ -1194,6 +1251,7 @@ pub const Runtime = struct {
         defer self.snapshot_mutex.unlock();
         self.snapshot_state.native_connections -|= 1;
         self.snapshot_state.tracked_connections -|= 1;
+        if (self.snapshot_state.tracked_connections == 0) self.snapshot_state.draining = false;
     }
 
     fn noteHandshakeComplete(self: *Runtime) void {

--- a/src/http3/conn.zig
+++ b/src/http3/conn.zig
@@ -19,6 +19,7 @@ const priority = @import("priority.zig");
 const qpack = @import("qpack.zig");
 const session = @import("session.zig");
 const stream_transport = @import("stream_transport");
+const varint = @import("quic_varint");
 
 pub const Role = enum { client, server };
 
@@ -927,6 +928,37 @@ test "H3 conn: SETTINGS exchange and request/response over a mock transport" {
     try testing.expectEqualStrings("pong", response.body);
     try testing.expectEqualStrings("server", response.headers[0].name);
     client.releaseResponse(id);
+}
+
+test "H3 conn: sendGoaway writes the selected request boundary on the control stream" {
+    const allocator = testing.allocator;
+    var client_transport = MockTransport.init(allocator, true);
+    defer client_transport.deinit();
+    var server_transport = MockTransport.init(allocator, false);
+    defer server_transport.deinit();
+    client_transport.peer = &server_transport;
+    server_transport.peer = &client_transport;
+
+    const H3 = Conn(MockTransport);
+    var server = H3.init(allocator, .server);
+    defer server.deinit();
+
+    try server.start(&server_transport);
+    try server.sendGoaway(&server_transport, 4);
+
+    const control_id = server.control_out.?;
+    const stream = client_transport.streams.get(control_id).?;
+    const bytes = stream.data.items;
+    const stream_type = try frame.decodeStreamType(bytes);
+    try testing.expectEqual(frame.StreamType.control, stream_type.typ);
+
+    const settings = try frame.decodeFrame(bytes[stream_type.len..]);
+    try testing.expectEqual(frame.FrameType.settings, settings.typ);
+
+    const goaway = try frame.decodeFrame(bytes[stream_type.len + settings.len ..]);
+    try testing.expectEqual(frame.FrameType.goaway, goaway.typ);
+    const boundary = try varint.decode(goaway.payload);
+    try testing.expectEqual(@as(u64, 4), boundary.value);
 }
 
 test "H3 conn: polls completed requests by urgency and reports priority" {

--- a/src/http3/conn.zig
+++ b/src/http3/conn.zig
@@ -728,6 +728,13 @@ pub fn Conn(comptime Transport: type) type {
             self.finishRequest(stream_id);
         }
 
+        pub fn sendGoaway(self: *Self, transport: *Transport, stream_id: u64) !void {
+            const control = self.control_out orelse return error.MissingControlStream;
+            var wire: [32]u8 = undefined;
+            const goaway = try session.ResponseEncoder.encodeGoaway(stream_id, &wire);
+            try self.writeAll(transport, control, goaway, false);
+        }
+
         fn writeAll(self: *Self, transport: *Transport, stream_id: u64, bytes: []const u8, fin: bool) !void {
             _ = self;
             // The transport records FIN only when it accepts the whole slice

--- a/tests/quic_h3_udp_smoke.zig
+++ b/tests/quic_h3_udp_smoke.zig
@@ -799,6 +799,166 @@ test "udp smoke: HTTP/3 runtime Retry round trip completes a native H3 request" 
     try testing.expect(snapshot.nat_rebindings > before_rebind.nat_rebindings);
 }
 
+test "udp smoke: HTTP/3 runtime drain lets admitted work finish and rejects new work" {
+    const allocator = testing.allocator;
+    var fixed = tls_core.credentials.FixedCredentialProvider.init(tls_core.credentials.testdata.identity());
+    defer fixed.deinit();
+    var logger = http3_runtime.Logger.init(.err, "udp-runtime-drain-lifecycle-test");
+    var handler_state = RuntimeHandlerState{};
+    var runtime = try http3_runtime.Runtime.init(allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+        .credential_provider = fixed.provider(),
+        .request_handler = runtimeSmokeHandler,
+        .request_handler_ctx = &handler_state,
+    });
+    defer runtime.deinit();
+    runtime.start();
+
+    var client_socket = try UdpSocket.open();
+    defer client_socket.close();
+
+    const client_cid = [_]u8{ 0xe1, 0xe2, 0xe3, 0xe4, 0xe5, 0xe6, 0xe7, 0xe8 };
+    const odcid = [_]u8{ 0xa3, 0xa4, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08 };
+    const client_path = quic.path.PathKey{
+        .local = addressFromSockaddrIn(client_socket.addr),
+        .remote = runtime.local_address,
+    };
+    var client_backend = tls_backend.Tls13Backend.initClient(
+        .{ .hello_random = [_]u8{0xe1} ** 32, .key_share_seed = [_]u8{0x41} ** 32, .retry_key_share_seed = [_]u8{0x41} ** 32 },
+        .{ .pinned_certificate = tls_core.credentials.testdata.certificate_der },
+    );
+    const client = try Connection.init(allocator, .{
+        .role = .client,
+        .local_cid = &client_cid,
+        .original_destination_cid = &odcid,
+        .initial_secret_dcid = &odcid,
+        .tls = client_backend.backend(),
+        .now_us = nowUs(),
+        .initial_path = client_path,
+    });
+    defer client.deinit();
+    var client_h3 = H3.init(allocator, .client);
+    defer client_h3.deinit();
+
+    var h3_started = false;
+    var request_a: ?u64 = null;
+    var request_a_done = false;
+    var request_b: ?u64 = null;
+    var request_b_sent = false;
+    var drain_started = false;
+    var sent_new_initial = false;
+    var new_initial_seen = false;
+    var new_conn_socket = try UdpSocket.open();
+    defer new_conn_socket.close();
+    var tracked_at_new_initial: usize = 0;
+    var datagrams_before_new_initial: usize = 0;
+
+    const deadline = nowUs() + 10_000_000;
+    var iterations: usize = 0;
+    while (nowUs() < deadline and !new_initial_seen) : (iterations += 1) {
+        try testing.expect(iterations < 5_000);
+        const now = nowUs();
+
+        var out: [2048]u8 = undefined;
+        while (client.pollTransmitOnPath(&out, now)) |t| {
+            try client_socket.sendTo(sockaddrInFromAddress(t.path.remote), t.bytes);
+        }
+
+        var next: u64 = now + 50_000;
+        if (client.nextTimeoutUs()) |t| next = @min(next, t);
+        const timeout_ms: i32 = @intCast(@min((next -| now) / 1_000 + 1, 50));
+        var fds = [_]posix.pollfd{.{ .fd = client_socket.fd, .events = posix.POLL.IN, .revents = 0 }};
+        _ = try posix.poll(&fds, timeout_ms);
+
+        var in: [2048]u8 = undefined;
+        while (try client_socket.recv(&in)) |datagram| {
+            try client.ingestOnPath(datagram, client_path, test_challenge_entropy, nowUs());
+        }
+        client.onTimeout(nowUs());
+
+        if (!h3_started and client.isEstablished()) {
+            try client_h3.start(client);
+            h3_started = true;
+        }
+        if (h3_started and request_a == null) {
+            request_a = try client_h3.sendRequest(client, .{
+                .authority = "tardigrade.test",
+                .path = "/runtime-retry",
+                .body = "runtime-drain-admitted",
+            });
+        }
+        try client_h3.pump(client);
+
+        if (!drain_started and handler_state.requests.load(.monotonic) == 1) {
+            runtime.beginDrain(http3_runtime.Runtime.nowUsPublic() + 5_000_000);
+            drain_started = true;
+        }
+
+        if (request_a) |id| {
+            if (!request_a_done) {
+                if (try client_h3.pollResponse(id)) |response| {
+                    try testing.expectEqual(@as(u16, 200), response.status);
+                    try testing.expectEqualStrings("runtime-retry-response", response.body);
+                    request_a_done = true;
+                    client_h3.releaseResponse(id);
+                }
+            }
+        }
+
+        if (drain_started and request_a_done and request_b == null) {
+            request_b = try client_h3.sendRequest(client, .{
+                .authority = "tardigrade.test",
+                .path = "/runtime-retry",
+                .body = "runtime-drain-rejected",
+            });
+            request_b_sent = true;
+        }
+
+        const snapshot = runtime.snapshot();
+        if (request_b_sent and snapshot.h3_drain_request_rejections >= 1 and !sent_new_initial) {
+            tracked_at_new_initial = snapshot.tracked_connections;
+            datagrams_before_new_initial = snapshot.datagrams_seen;
+            var initial_buf: [128]u8 = undefined;
+            const new_initial = try writeSyntheticInitial(
+                quic.packet.quic_v1,
+                &[_]u8{ 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8 },
+                &[_]u8{ 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8 },
+                "",
+                &initial_buf,
+            );
+            try new_conn_socket.sendTo(sockaddrInFromAddress(runtime.local_address), new_initial);
+            sent_new_initial = true;
+        }
+        if (sent_new_initial) {
+            const after_new = runtime.snapshot();
+            if (after_new.datagrams_seen > datagrams_before_new_initial) {
+                try testing.expectEqual(tracked_at_new_initial, after_new.tracked_connections);
+                new_initial_seen = true;
+            }
+        }
+    }
+
+    try testing.expect(drain_started);
+    try testing.expect(request_a_done);
+    try testing.expect(request_b_sent);
+    try testing.expect(new_initial_seen);
+    try testing.expectEqual(@as(usize, 1), handler_state.requests.load(.monotonic));
+    const drained_snapshot = runtime.snapshot();
+    try testing.expect(drained_snapshot.h3_goaway_sent >= 1);
+    try testing.expect(drained_snapshot.h3_drain_request_rejections >= 1);
+
+    client.close(0, "runtime-drain-done", nowUs());
+    var close_out: [2048]u8 = undefined;
+    while (client.pollTransmitOnPath(&close_out, nowUs())) |t| {
+        try client_socket.sendTo(sockaddrInFromAddress(t.path.remote), t.bytes);
+    }
+    const final_snapshot = try waitRuntimeSnapshot(&runtime, hasNoTrackedConnections);
+    try testing.expectEqual(@as(usize, 0), final_snapshot.tracked_connections);
+    try testing.expectEqual(@as(usize, 0), final_snapshot.active_cid_routes);
+    try testing.expect(runtime.isDrained());
+}
+
 // ---------------------------------------------------------------------------
 // Appliance credential provider over native QUIC (#392): the same strict
 // Ed25519 owner that authenticates native TCP TLS drives a real loopback QUIC


### PR DESCRIPTION
Claims #257

## Summary
- make HTTP/3 Alt-Svc an explicit effective rollout state with `off|auto`, bounded `ma`, and `clear` support
- advertise only after the runtime is actually bootstrapped; reject listener-owned H3 reload changes as restart-required while allowing advertisement-only reloads
- add runtime H3 drain API with GOAWAY, no-new-work admission, deadline close, CID cleanup, and effective-state metrics
- apply the gateway-owned Alt-Svc policy consistently across buffered, streamed, and error response paths, stripping upstream Alt-Svc
- document the v1 UDP/LB/reload/drain rollout contract

## Validation
- `zig build test`
- `zig build`