### PR TITLE
tls: add focused HRR interop smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,6 +548,11 @@ jobs:
           H3_INTEROP_CLIENT_PATH: ${{ steps.build-h3-peer.outputs.client_path }}
         run: zig build test-integration-resumption-interop -Dtls-profile=general --summary all --error-style verbose
 
+      - name: Run focused H3 HRR peer matrix
+        env:
+          H3_PEER_EXAMPLES_DIR: ${{ steps.build-h3-peer.outputs.examples_dir }}
+        run: ./scripts/interop/run-h3-peer-ci.sh
+
   # ── Integration tests ─────────────────────────────────────────────────────────
   # Runs on push to main only (not PRs). Failures block the workflow.
   integration-test:

--- a/scripts/interop/README.md
+++ b/scripts/interop/README.md
@@ -21,6 +21,93 @@ Matrix (`run-interop.sh`):
 | 4 | quiche `http3-client` | native `h3_interop_tool` | yes |
 | 5 | native `h3_interop_tool` | aioquic             | optional |
 | 6 | aioquic               | native `h3_interop_tool` | optional |
+| 7 | native HRR client (`h3_interop_tool --empty-initial-key-share`) | ngtcp2 `gtlsserver` | #333 closure |
+| 8 | ngtcp2 HRR `gtlsclient` (`--groups=-GROUP-ALL:+GROUP-SECP256R1:+GROUP-X25519:%NO_SHUFFLE_EXTENSIONS`) | native `h3_interop_tool --expect-hrr` | #333 closure |
+
+## #333: focused HelloRetryRequest smoke evidence
+
+The matrix includes two bounded, out-of-process HRR smokes that close the
+remaining #333 evidence gap without expanding this script into #338's broad
+conformance suite:
+
+- `#333 native HRR client -> ngtcp2 gtlsserver` runs the native client with
+  `--empty-initial-key-share`. The ClientHello still advertises X25519, but
+  carries an empty initial key-share vector, so the external GnuTLS server must
+  send HelloRetryRequest before the HTTP/3 request can complete. The native
+  tool asserts `--expect-hrr` by checking its TLS retry state and logs
+  `tls retry_state=hrr_received`.
+- `#333 ngtcp2 HRR gtlsclient -> native server` runs the external GnuTLS
+  client with
+  `--groups=-GROUP-ALL:+GROUP-SECP256R1:+GROUP-X25519:%NO_SHUFFLE_EXTENSIONS`
+  and the `GNUTLS_KEY_SHARE_TOP` / `%NO_SHUFFLE_EXTENSIONS` patches applied by
+  `build-h3-peer-ci.sh`. That keeps X25519 advertised while sending only the
+  first P-256 key share in ClientHello1, and keeps ClientHello2 extension order
+  deterministic; the native server supports/selects X25519, emits
+  HelloRetryRequest, accepts ClientHello2, and completes the HTTP/3 exchange.
+  The native server asserts `--expect-hrr` and logs
+  `tls hello_retry_request=true`.
+
+Prerequisites are the pinned nghttp3 `v1.18.0` and ngtcp2 `v1.25.0`
+GnuTLS example builds documented below, built with a GnuTLS version that
+supports `GNUTLS_KEY_SHARE_TOP` (CI uses Ubuntu 24.04's GnuTLS 3.8.x
+package). The easiest reproducible build path is:
+
+```sh
+scripts/interop/install-h3-peer-deps-ci.sh
+H3_PEER_WORKDIR=/tmp/tardigrade-h3-peer scripts/interop/build-h3-peer-ci.sh
+gnutls-cli --version
+```
+
+Then run the normal matrix command:
+
+```sh
+zig build build-h3-interop
+NGTCP2_EXAMPLES_DIR=/tmp/tardigrade-h3-peer/client/build/examples \
+  scripts/interop/run-interop.sh
+```
+
+The exact single-case commands are:
+
+```sh
+# native HRR client against external server
+mkdir -p /tmp/tardi-hrr/certs /tmp/tardi-hrr/docroot
+scripts/interop/gen-certs.sh /tmp/tardi-hrr/certs
+printf '%s\n' hello-from-ngtcp2-hrr >/tmp/tardi-hrr/docroot/hrr.txt
+/path/to/ngtcp2/build/examples/gtlsserver 127.0.0.1 24434 \
+  /tmp/tardi-hrr/certs/ed25519-key.pem \
+  /tmp/tardi-hrr/certs/ed25519-cert.pem \
+  -d /tmp/tardi-hrr/docroot --quiet \
+  >/tmp/tardi-hrr/gtlsserver-hrr.log 2>&1 &
+server_pid=$!
+trap 'kill "$server_pid" 2>/dev/null || true' EXIT
+sleep 1.5
+zig-out/bin/h3_interop_tool client --host 127.0.0.1 --port 24434 \
+  --authority tardigrade.test --path /hrr.txt --insecure \
+  --empty-initial-key-share --expect-hrr --timeout-ms 10000
+kill "$server_pid" 2>/dev/null || true
+wait "$server_pid" 2>/dev/null || true
+trap - EXIT
+
+# external HRR client against native server
+zig-out/bin/h3_interop_tool server --port 24435 \
+  --cert /tmp/tardi-hrr/certs/ed25519-cert.der \
+  --key /tmp/tardi-hrr/certs/ed25519-key.pkcs8.der \
+  --expect-hrr --timeout-ms 15000 \
+  >/tmp/tardi-hrr/native-server-hrr.log 2>&1 &
+server_pid=$!
+trap 'kill "$server_pid" 2>/dev/null || true' EXIT
+sleep 1.5
+/path/to/ngtcp2/build/examples/gtlsclient \
+  --groups=-GROUP-ALL:+GROUP-SECP256R1:+GROUP-X25519:%NO_SHUFFLE_EXTENSIONS \
+  127.0.0.1 24435 https://tardigrade.test/from-ngtcp2-hrr \
+  --exit-on-first-stream-close
+wait "$server_pid"
+trap - EXIT
+```
+
+The matrix logs stdout/stderr for each side under the printed `logs:` path.
+They contain request/response status and the explicit HRR assertion lines
+above, but no keylog output or secret material.
 
 ## #522: production resumption/0-RTT interop
 
@@ -50,8 +137,18 @@ H3_INTEROP_CLIENT_PATH=/path/to/ngtcp2/build/examples/gtlsclient \
 
 CI runs `scripts/interop/install-h3-peer-deps-ci.sh` then
 `scripts/interop/build-h3-peer-ci.sh` to build the pinned ngtcp2/nghttp3
-GnuTLS examples and exports `H3_INTEROP_CLIENT_PATH` before running the same
-target with `-Dtls-profile=general`. Both scripts live under
+GnuTLS examples. It exports `H3_INTEROP_CLIENT_PATH` before running the same
+target with `-Dtls-profile=general`, then passes the peer-neutral
+`H3_PEER_EXAMPLES_DIR` output to `scripts/interop/run-h3-peer-ci.sh`. That
+wrapper runs the bounded external-peer matrix and asserts both #333 HRR lines
+are present as `PASS`:
+
+```text
+#333 native HRR client -> ngtcp2 gtlsserver PASS
+#333 ngtcp2 HRR gtlsclient -> native server PASS
+```
+
+Both scripts live under
 `scripts/interop/` specifically because that directory is the policy-exempt
 external-peer boundary the dependency audit (`scripts/audit-dependencies.sh`)
 excludes -- the peer's actual repository/library names would otherwise trip
@@ -133,16 +230,18 @@ Everything below stays outside the Tardigrade build graph.
 
 ### ngtcp2 / nghttp3 (GnuTLS example client/server)
 
-Needs `libgnutls28-dev` (>= 3.7.2), `libev-dev`, cmake, and a C++23 compiler
-(g++ >= 14 for `<print>`):
+Needs `libgnutls28-dev` (>= 3.7.2), `gnutls-bin`, `libev-dev`, cmake, and a
+C++23 compiler (clang >= 19 or gcc >= 15 for `<print>`):
 
 ```sh
-git clone --depth 1 https://github.com/ngtcp2/nghttp3 && cd nghttp3
+git clone --depth 1 --branch v1.18.0 https://github.com/ngtcp2/nghttp3 && cd nghttp3
 cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$PREFIX -DENABLE_LIB_ONLY=ON
 make -C build install
 cd ../
-git clone --depth 1 https://github.com/ngtcp2/ngtcp2 && cd ngtcp2
-PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig CC=gcc-14 CXX=g++-14 \
+git clone --depth 1 --branch v1.25.0 https://github.com/ngtcp2/ngtcp2 && cd ngtcp2
+perl -0pi -e 's/GNUTLS_CLIENT \| GNUTLS_ENABLE_EARLY_DATA \|\n\s+GNUTLS_NO_END_OF_EARLY_DATA/GNUTLS_CLIENT | GNUTLS_ENABLE_EARLY_DATA |\n                                 GNUTLS_NO_END_OF_EARLY_DATA |\n                                 GNUTLS_KEY_SHARE_TOP/' examples/tls_client_session_gnutls.cc
+gnutls-cli --version
+PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig CC=clang-19 CXX=clang++-19 \
   cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$PREFIX \
   -DENABLE_GNUTLS=ON -DENABLE_OPENSSL=OFF
 make -C build

--- a/scripts/interop/README.md
+++ b/scripts/interop/README.md
@@ -48,9 +48,9 @@ conformance suite:
   `tls hello_retry_request=true`.
 
 Prerequisites are the pinned nghttp3 `v1.18.0` and ngtcp2 `v1.25.0`
-GnuTLS example builds documented below, built with a GnuTLS version that
-supports `GNUTLS_KEY_SHARE_TOP` (CI uses Ubuntu 24.04's GnuTLS 3.8.x
-package). The easiest reproducible build path is:
+GnuTLS example builds documented below, built with GnuTLS >= 3.8.1,
+supporting both `GNUTLS_KEY_SHARE_TOP` and `%NO_SHUFFLE_EXTENSIONS`
+(CI currently uses 3.8.3). The easiest reproducible build path is:
 
 ```sh
 scripts/interop/install-h3-peer-deps-ci.sh
@@ -230,8 +230,9 @@ Everything below stays outside the Tardigrade build graph.
 
 ### ngtcp2 / nghttp3 (GnuTLS example client/server)
 
-Needs `libgnutls28-dev` (>= 3.7.2), `gnutls-bin`, `libev-dev`, cmake, and a
-C++23 compiler (clang >= 19 or gcc >= 15 for `<print>`):
+Needs `libgnutls28-dev` (GnuTLS >= 3.8.1; CI tested with 3.8.3),
+`gnutls-bin`, `libev-dev`, cmake, and a C++23 compiler (clang >= 19 or
+gcc >= 15 for `<print>`):
 
 ```sh
 git clone --depth 1 --branch v1.18.0 https://github.com/ngtcp2/nghttp3 && cd nghttp3

--- a/scripts/interop/build-h3-peer-ci.sh
+++ b/scripts/interop/build-h3-peer-ci.sh
@@ -10,8 +10,9 @@
 #
 # usage: build-h3-peer-ci.sh
 #
-# Writes the built client binary's path to $GITHUB_OUTPUT as `client_path`
-# (or prints it to stdout when GITHUB_OUTPUT isn't set, e.g. run locally).
+# Writes the built client binary's path to $GITHUB_OUTPUT as `client_path` and
+# the peer-neutral examples directory as `examples_dir` (or prints both when
+# GITHUB_OUTPUT isn't set, e.g. run locally).
 set -euo pipefail
 
 # Pinned release tags, not HEAD: tests/integration.zig's h3interop.quic.*
@@ -51,6 +52,33 @@ fi
 # consumes an object library built from a submodule there).
 git -C "$root/client" submodule update --init --depth 1
 
+# #333 HRR smoke: force the GnuTLS example client to send only the top
+# configured group's key share in ClientHello1. With
+# `--groups=-GROUP-ALL:+GROUP-SECP256R1:+GROUP-X25519`, P-256 is then present
+# as the first share while X25519 remains advertised but shareless, so the
+# native X25519-only server must emit HelloRetryRequest.
+gtls_client_source="$root/client/examples/tls_client_session_gnutls.cc"
+if ! grep -q "GNUTLS_KEY_SHARE_TOP" "$gtls_client_source"; then
+  perl -0pi -e 's/GNUTLS_CLIENT \| GNUTLS_ENABLE_EARLY_DATA \|\n\s+GNUTLS_NO_END_OF_EARLY_DATA/GNUTLS_CLIENT | GNUTLS_ENABLE_EARLY_DATA |\n                                 GNUTLS_NO_END_OF_EARLY_DATA |\n                                 GNUTLS_KEY_SHARE_TOP/' "$gtls_client_source"
+fi
+grep -q "GNUTLS_KEY_SHARE_TOP" "$gtls_client_source" || {
+  echo "build-h3-peer-ci.sh: failed to apply GnuTLS key-share-top patch" >&2
+  exit 1
+}
+# GnuTLS shuffles ClientHello extensions by default for fingerprinting
+# resistance. Disable that in the pinned interop peer so ClientHello2 remains
+# conforming to RFC 8446 §4.1.2's stable-extension-order requirement.
+if ! grep -q "%NO_SHUFFLE_EXTENSIONS" "$gtls_client_source"; then
+  perl -0pi -e 's/%DISABLE_TLS13_COMPAT_MODE:/%DISABLE_TLS13_COMPAT_MODE:%NO_SHUFFLE_EXTENSIONS:/' "$gtls_client_source"
+fi
+grep -q "%NO_SHUFFLE_EXTENSIONS" "$gtls_client_source" || {
+  echo "build-h3-peer-ci.sh: failed to apply GnuTLS no-shuffle patch" >&2
+  exit 1
+}
+if command -v gnutls-cli >/dev/null 2>&1; then
+  gnutls-cli --version | head -n 1
+fi
+
 export PKG_CONFIG_PATH="$prefix/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
 export CMAKE_PREFIX_PATH="$prefix${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
 
@@ -74,13 +102,18 @@ cmake -S "$root/client" -B "$root/client/build" \
   -DCMAKE_PREFIX_PATH="$prefix" \
   -DENABLE_GNUTLS=ON \
   -DENABLE_OPENSSL=OFF
-cmake --build "$root/client/build" --parallel "$jobs" --target gtlsclient
+cmake --build "$root/client/build" --parallel "$jobs" --target gtlsclient gtlsserver
 
 client_path="$root/client/build/examples/gtlsclient"
+server_path="$root/client/build/examples/gtlsserver"
+examples_dir="$root/client/build/examples"
 test -x "$client_path"
+test -x "$server_path"
 
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
   printf 'client_path=%s\n' "$client_path" >> "$GITHUB_OUTPUT"
+  printf 'examples_dir=%s\n' "$examples_dir" >> "$GITHUB_OUTPUT"
 else
-  printf '%s\n' "$client_path"
+  printf 'client_path=%s\n' "$client_path"
+  printf 'examples_dir=%s\n' "$examples_dir"
 fi

--- a/scripts/interop/install-h3-peer-deps-ci.sh
+++ b/scripts/interop/install-h3-peer-deps-ci.sh
@@ -28,4 +28,4 @@ fi
 # headers are present too.
 sudo apt-get install -y libstdc++-14-dev
 
-sudo apt-get install -y libgnutls28-dev
+sudo apt-get install -y libgnutls28-dev gnutls-bin

--- a/scripts/interop/run-h3-peer-ci.sh
+++ b/scripts/interop/run-h3-peer-ci.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Runs the pinned external H3 peer matrix entries that CI builds in
+# build-h3-peer-ci.sh. This wrapper keeps peer-specific environment names
+# inside scripts/interop/, the dependency-audit external-peer boundary.
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+examples_dir="${H3_PEER_EXAMPLES_DIR:?set H3_PEER_EXAMPLES_DIR to the built examples directory}"
+workdir="${INTEROP_WORKDIR:-${RUNNER_TEMP:-/tmp}/tardigrade-h3-peer-interop}"
+output="${INTEROP_OUTPUT_LOG:-$workdir/matrix.log}"
+
+mkdir -p "$workdir" "$(dirname "$output")"
+
+dump_hrr_logs() {
+  for log in \
+    "$workdir/logs/333-1-native-client-hrr.log" \
+    "$workdir/logs/333-1-gtlsserver-hrr.log" \
+    "$workdir/logs/333-2-native-server-hrr.log" \
+    "$workdir/logs/333-2-gtlsclient-hrr.log"
+  do
+    if [ -f "$log" ]; then
+      printf '\n--- %s ---\n' "$log"
+      sed -n '1,420p' "$log"
+    fi
+  done
+}
+
+set +e
+INTEROP_WORKDIR="$workdir" NGTCP2_EXAMPLES_DIR="$examples_dir" "$here/run-interop.sh" | tee "$output"
+matrix_rc=${PIPESTATUS[0]}
+set -e
+
+if [ "$matrix_rc" -ne 0 ]; then
+  dump_hrr_logs
+  exit "$matrix_rc"
+fi
+
+grep -q "#333 native HRR client -> ngtcp2 gtlsserver[[:space:]]*PASS" "$output"
+grep -q "#333 ngtcp2 HRR gtlsclient -> native server[[:space:]]*PASS" "$output"
+
+grep "tls retry_state=hrr_received" "$workdir/logs/333-1-native-client-hrr.log"
+grep "tls hello_retry_request=true" "$workdir/logs/333-2-native-server-hrr.log"

--- a/scripts/interop/run-interop.sh
+++ b/scripts/interop/run-interop.sh
@@ -9,6 +9,8 @@
 #   4. quiche http3-client -> native server
 #   5. native client -> aioquic server        (optional)
 #   6. aioquic client -> native server        (optional)
+#   7. native HRR client -> ngtcp2/nghttp3 server
+#   8. ngtcp2/nghttp3 HRR client -> native server
 #
 # Peer discovery via environment variables (unset peers are skipped, but
 # ngtcp2 and quiche are required for the #328 gate):
@@ -99,6 +101,54 @@ if [ -n "${NGTCP2_EXAMPLES_DIR:-}" ] && [ -x "$NGTCP2_EXAMPLES_DIR/gtlsclient" ]
   fi
 else
   result "ngtcp2 gtlsclient -> native server" SKIP
+fi
+
+# --- 333-1. native HRR client -> ngtcp2 gtlsserver ------------------------
+next_port
+if [ -n "${NGTCP2_EXAMPLES_DIR:-}" ] && [ -x "$NGTCP2_EXAMPLES_DIR/gtlsserver" ]; then
+  mkdir -p "$workdir/hrr-docroot"
+  echo "hello-from-ngtcp2-hrr" >"$workdir/hrr-docroot/hrr.txt"
+  "$NGTCP2_EXAMPLES_DIR/gtlsserver" 127.0.0.1 "$port" "$certs/ed25519-key.pem" "$certs/ed25519-cert.pem" \
+    -d "$workdir/hrr-docroot" --quiet >"$logs/333-1-gtlsserver-hrr.log" 2>&1 &
+  peer=$!
+  wait_udp_listen
+  if "$tool" client --host 127.0.0.1 --port "$port" --authority tardigrade.test \
+    --path /hrr.txt --insecure --empty-initial-key-share --expect-hrr --timeout-ms 10000 \
+    >"$logs/333-1-native-client-hrr.log" 2>&1 &&
+    grep -q "hello-from-ngtcp2-hrr" "$logs/333-1-native-client-hrr.log" &&
+    grep -q "tls retry_state=hrr_received" "$logs/333-1-native-client-hrr.log"; then
+    result "#333 native HRR client -> ngtcp2 gtlsserver" PASS
+  else
+    result "#333 native HRR client -> ngtcp2 gtlsserver" FAIL
+  fi
+  kill "$peer" 2>/dev/null
+  wait "$peer" 2>/dev/null
+else
+  result "#333 native HRR client -> ngtcp2 gtlsserver" SKIP
+fi
+
+# --- 333-2. ngtcp2 HRR gtlsclient -> native server ------------------------
+next_port
+if [ -n "${NGTCP2_EXAMPLES_DIR:-}" ] && [ -x "$NGTCP2_EXAMPLES_DIR/gtlsclient" ]; then
+  "$tool" server --port "$port" --cert "$certs/ed25519-cert.der" --key "$certs/ed25519-key.pkcs8.der" \
+    --expect-hrr --verbose --timeout-ms 15000 >"$logs/333-2-native-server-hrr.log" 2>&1 &
+  peer=$!
+  wait_udp_listen
+  "$NGTCP2_EXAMPLES_DIR/gtlsclient" --groups=-GROUP-ALL:+GROUP-SECP256R1:+GROUP-X25519:%NO_SHUFFLE_EXTENSIONS \
+    127.0.0.1 "$port" "https://tardigrade.test/from-ngtcp2-hrr" \
+    --exit-on-first-stream-close >"$logs/333-2-gtlsclient-hrr.log" 2>&1
+  client_rc=$?
+  wait "$peer"
+  server_rc=$?
+  if [ "$client_rc" -eq 0 ] && [ "$server_rc" -eq 0 ] &&
+    grep -q "server ok, served=1" "$logs/333-2-native-server-hrr.log" &&
+    grep -q "tls hello_retry_request=true" "$logs/333-2-native-server-hrr.log"; then
+    result "#333 ngtcp2 HRR gtlsclient -> native server" PASS
+  else
+    result "#333 ngtcp2 HRR gtlsclient -> native server" FAIL
+  fi
+else
+  result "#333 ngtcp2 HRR gtlsclient -> native server" SKIP
 fi
 
 # --- 3. native client -> quiche http3-server ------------------------------

--- a/src/tls/hello_retry.zig
+++ b/src/tls/hello_retry.zig
@@ -214,25 +214,18 @@ const ClientHelloView = struct {
 };
 
 fn compareExtensions(first: []const ExtensionView, second: []const ExtensionView, request: Request) Error!void {
-    var first_index: usize = 0;
-    var second_index: usize = 0;
+    try compareStableExtensionOrder(first, second);
 
-    while (true) {
-        first_index = nextComparable(first, first_index, false);
-        second_index = nextComparable(second, second_index, true);
-        if (first_index == first.len or second_index == second.len) break;
-
-        const lhs = first[first_index];
-        const rhs = second[second_index];
-        if (lhs.id != rhs.id) return error.IllegalParameter;
+    for (first) |lhs| {
+        if (!isComparable(lhs.id, false)) continue;
+        const rhs = findComparable(second, lhs.id, true) orelse return error.IllegalParameter;
         try compareExtensionPayload(lhs, rhs, request);
-        first_index += 1;
-        second_index += 1;
     }
 
-    if (nextComparable(first, first_index, false) != first.len or
-        nextComparable(second, second_index, true) != second.len)
-        return error.IllegalParameter;
+    for (second) |rhs| {
+        if (!isComparable(rhs.id, true)) continue;
+        _ = findComparable(first, rhs.id, false) orelse return error.IllegalParameter;
+    }
 
     if (findExtension(second, @intFromEnum(algorithms.ExtensionType.early_data)) != null)
         return error.IllegalParameter;
@@ -245,17 +238,42 @@ fn compareExtensions(first: []const ExtensionView, second: []const ExtensionView
     }
 }
 
-fn nextComparable(extensions: []const ExtensionView, start: usize, skip_cookie: bool) usize {
-    var index = start;
-    while (index < extensions.len) : (index += 1) {
-        const id = extensions[index].id;
-        if (id == @intFromEnum(algorithms.ExtensionType.padding) or
-            id == @intFromEnum(algorithms.ExtensionType.early_data) or
-            (skip_cookie and id == @intFromEnum(algorithms.ExtensionType.cookie)))
-            continue;
-        return index;
+fn compareStableExtensionOrder(first: []const ExtensionView, second: []const ExtensionView) Error!void {
+    var i: usize = 0;
+    var j: usize = 0;
+    while (true) {
+        while (i < first.len and !isOrderStable(first[i].id)) : (i += 1) {}
+        while (j < second.len and !isOrderStable(second[j].id)) : (j += 1) {}
+        if (i == first.len or j == second.len) break;
+        if (first[i].id != second[j].id) return error.IllegalParameter;
+        i += 1;
+        j += 1;
     }
-    return index;
+    while (i < first.len and !isOrderStable(first[i].id)) : (i += 1) {}
+    while (j < second.len and !isOrderStable(second[j].id)) : (j += 1) {}
+    if (i != first.len or j != second.len) return error.IllegalParameter;
+}
+
+fn isOrderStable(id: u16) bool {
+    return id != @intFromEnum(algorithms.ExtensionType.padding) and
+        id != @intFromEnum(algorithms.ExtensionType.early_data) and
+        id != @intFromEnum(algorithms.ExtensionType.cookie) and
+        id != @intFromEnum(algorithms.ExtensionType.key_share) and
+        id != @intFromEnum(algorithms.ExtensionType.pre_shared_key);
+}
+
+fn isComparable(id: u16, skip_cookie: bool) bool {
+    return id != @intFromEnum(algorithms.ExtensionType.padding) and
+        id != @intFromEnum(algorithms.ExtensionType.early_data) and
+        !(skip_cookie and id == @intFromEnum(algorithms.ExtensionType.cookie));
+}
+
+fn findComparable(extensions: []const ExtensionView, id: u16, skip_cookie: bool) ?ExtensionView {
+    for (extensions) |extension| {
+        if (!isComparable(extension.id, skip_cookie)) continue;
+        if (extension.id == id) return extension;
+    }
+    return null;
 }
 
 fn compareExtensionPayload(lhs: ExtensionView, rhs: ExtensionView, request: Request) Error!void {
@@ -642,6 +660,78 @@ fn clientHelloWithExtensionList(
     return messages.encode(.client_hello, w.written(), out);
 }
 
+fn clientHelloWithReorderedExtensions(
+    out: []u8,
+    random_byte: u8,
+    key_share_group: algorithms.NamedGroup,
+) ![]const u8 {
+    var body: [512]u8 = undefined;
+    var w = messages.Writer{ .buf = &body };
+    try w.u16_(algorithms.legacy_version);
+    try w.bytes(&([_]u8{random_byte} ** 32));
+    try w.u8_(3);
+    try w.bytes("sid");
+    try w.u16_(2);
+    try w.u16_(@intFromEnum(algorithms.CipherSuite.tls_aes_128_gcm_sha256));
+    try w.u8_(1);
+    try w.u8_(0);
+    const extensions_len = try w.reserve(2);
+    try w.u16_(@intFromEnum(algorithms.ExtensionType.supported_versions));
+    try w.u16_(3);
+    try w.u8_(2);
+    try w.u16_(@intFromEnum(algorithms.ProtocolVersion.tls13));
+    try w.u16_(@intFromEnum(algorithms.ExtensionType.key_share));
+    const key_share_ext = try w.reserve(2);
+    const key_shares = try w.reserve(2);
+    try w.u16_(@intFromEnum(key_share_group));
+    try w.u16_(5);
+    try w.bytes("share");
+    w.patch(2, key_shares);
+    w.patch(2, key_share_ext);
+    try w.u16_(@intFromEnum(algorithms.ExtensionType.supported_groups));
+    try w.u16_(4);
+    try w.u16_(2);
+    try w.u16_(@intFromEnum(algorithms.NamedGroup.x25519));
+    w.patch(2, extensions_len);
+    return messages.encode(.client_hello, w.written(), out);
+}
+
+fn clientHelloWithReorderedStableExtensions(
+    out: []u8,
+    random_byte: u8,
+    key_share_group: algorithms.NamedGroup,
+) ![]const u8 {
+    var body: [512]u8 = undefined;
+    var w = messages.Writer{ .buf = &body };
+    try w.u16_(algorithms.legacy_version);
+    try w.bytes(&([_]u8{random_byte} ** 32));
+    try w.u8_(3);
+    try w.bytes("sid");
+    try w.u16_(2);
+    try w.u16_(@intFromEnum(algorithms.CipherSuite.tls_aes_128_gcm_sha256));
+    try w.u8_(1);
+    try w.u8_(0);
+    const extensions_len = try w.reserve(2);
+    try w.u16_(@intFromEnum(algorithms.ExtensionType.supported_groups));
+    try w.u16_(4);
+    try w.u16_(2);
+    try w.u16_(@intFromEnum(algorithms.NamedGroup.x25519));
+    try w.u16_(@intFromEnum(algorithms.ExtensionType.supported_versions));
+    try w.u16_(3);
+    try w.u8_(2);
+    try w.u16_(@intFromEnum(algorithms.ProtocolVersion.tls13));
+    try w.u16_(@intFromEnum(algorithms.ExtensionType.key_share));
+    const key_share_ext = try w.reserve(2);
+    const key_shares = try w.reserve(2);
+    try w.u16_(@intFromEnum(key_share_group));
+    try w.u16_(5);
+    try w.bytes("share");
+    w.patch(2, key_shares);
+    w.patch(2, key_share_ext);
+    w.patch(2, extensions_len);
+    return messages.encode(.client_hello, w.written(), out);
+}
+
 fn pskExtension(
     out: []u8,
     identity_a: []const u8,
@@ -686,6 +776,32 @@ test "ClientHello2 validator permits requested key share and cookie" {
         .selected_group = .x25519,
         .cookie = "cookie",
     });
+}
+
+test "ClientHello2 validator permits key_share relocation" {
+    var first_buf: [768]u8 = undefined;
+    var second_buf: [768]u8 = undefined;
+    const first = try clientHello(&first_buf, 0xaa, null, null, null);
+    const second = try clientHelloWithReorderedExtensions(&second_buf, 0xaa, .x25519);
+    try validateSecondClientHello(first, second, .{
+        .selected_version = .tls13,
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .selected_group = .x25519,
+        .cookie = null,
+    });
+}
+
+test "ClientHello2 validator rejects reordered unaffected extensions" {
+    var first_buf: [768]u8 = undefined;
+    var second_buf: [768]u8 = undefined;
+    const first = try clientHello(&first_buf, 0xaa, null, null, null);
+    const second = try clientHelloWithReorderedStableExtensions(&second_buf, 0xaa, .x25519);
+    try testing.expectError(error.IllegalParameter, validateSecondClientHello(first, second, .{
+        .selected_version = .tls13,
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .selected_group = .x25519,
+        .cookie = null,
+    }));
 }
 
 test "ClientHello2 validator rejects changed random and cookie" {

--- a/tests/h3_interop_tool.zig
+++ b/tests/h3_interop_tool.zig
@@ -7,9 +7,10 @@
 //!
 //! Usage:
 //!   h3_interop_tool server --port N --cert cert.der --key key.pkcs8.der \
-//!       [--response-body STR] [--requests N] [--verbose]
+//!       [--response-body STR] [--requests N] [--expect-hrr] [--verbose]
 //!   h3_interop_tool client --host A.B.C.D --port N --authority NAME \
-//!       --path /p [--body STR] [--insecure | --pin cert.der] [--verbose]
+//!       --path /p [--body STR] [--empty-initial-key-share] \
+//!       [--expect-hrr] [--insecure | --pin cert.der] [--verbose]
 //!
 //! The client exits 0 once it has received a complete response (status and
 //! body are printed to stdout). The server exits 0 after serving --requests
@@ -88,6 +89,8 @@ const Args = struct {
     response_body: []const u8 = "hello from tardigrade native h3\n",
     requests: usize = 1,
     timeout_ms: u64 = 15_000,
+    empty_initial_key_share: bool = false,
+    expect_hrr: bool = false,
 };
 
 fn parseArgs(allocator: std.mem.Allocator, init_args: std.process.Args) !Args {
@@ -102,6 +105,10 @@ fn parseArgs(allocator: std.mem.Allocator, init_args: std.process.Args) !Args {
             verbose = true;
         } else if (std.mem.eql(u8, arg, "--insecure")) {
             args.insecure = true;
+        } else if (std.mem.eql(u8, arg, "--empty-initial-key-share")) {
+            args.empty_initial_key_share = true;
+        } else if (std.mem.eql(u8, arg, "--expect-hrr")) {
+            args.expect_hrr = true;
         } else if (std.mem.eql(u8, arg, "--host")) {
             args.host = try allocator.dupe(u8, it.next() orelse return error.MissingValue);
         } else if (std.mem.eql(u8, arg, "--port")) {
@@ -255,8 +262,8 @@ pub fn main(init: std.process.Init.Minimal) !void {
     const args = parseArgs(allocator, init.args) catch |err| {
         std.debug.print(
             "h3-interop: bad arguments ({s})\n" ++
-                "usage: h3_interop_tool server --port N --cert cert.der --key key.pkcs8.der [--requests N]\n" ++
-                "       h3_interop_tool client --host IP --port N --authority NAME --path /p [--insecure|--pin cert.der]\n",
+                "usage: h3_interop_tool server --port N --cert cert.der --key key.pkcs8.der [--requests N] [--expect-hrr]\n" ++
+                "       h3_interop_tool client --host IP --port N --authority NAME --path /p [--empty-initial-key-share] [--expect-hrr] [--insecure|--pin cert.der]\n",
             .{@errorName(err)},
         );
         std.process.exit(2);
@@ -291,7 +298,10 @@ fn runClient(allocator: std.mem.Allocator, args: Args) !void {
         .local = addressFromSockaddrIn(socket.local),
         .remote = addressFromSockaddrIn(peer_addr),
     };
-    var backend = tls_backend.Tls13Backend.initClient(randomEntropy(), trust);
+    const client_options = tls_backend.ClientOptions{
+        .initial_key_share_mode = if (args.empty_initial_key_share) .empty else .normal,
+    };
+    var backend = tls_backend.Tls13Backend.initClientWithOptions(randomEntropy(), trust, client_options);
     const client = try Connection.init(allocator, .{
         .role = .client,
         .local_cid = &local_cid,
@@ -364,6 +374,12 @@ fn runClient(allocator: std.mem.Allocator, args: Args) !void {
         });
         std.process.exit(1);
     }
+    const saw_hrr = backend.engine.core.retry_state == .hrr_received;
+    std.debug.print("h3-interop: tls retry_state={s}\n", .{@tagName(backend.engine.core.retry_state)});
+    if (args.expect_hrr and !saw_hrr) {
+        std.debug.print("h3-interop: expected HelloRetryRequest but none was observed\n", .{});
+        std.process.exit(1);
+    }
     // Orderly close.
     client.close(0, "done", nowUs());
     var out: [2048]u8 = undefined;
@@ -390,6 +406,7 @@ fn runServer(allocator: std.mem.Allocator, args: Args) !void {
 
     var served: usize = 0;
     const deadline = nowUs() + args.timeout_ms * 1_000;
+    var saw_hrr = false;
 
     // One connection at a time: enough for focused interop runs, and each
     // connection exercises the full accept path.
@@ -451,9 +468,11 @@ fn runServer(allocator: std.mem.Allocator, args: Args) !void {
 
             switch (server.state()) {
                 .closed, .draining, .closing => {
-                    std.debug.print("h3-interop: connection ended state={s} served={d}\n", .{
+                    saw_hrr = saw_hrr or backend.engine.core.retry_state == .hrr_sent;
+                    std.debug.print("h3-interop: connection ended state={s} served={d} handshake_error={any}\n", .{
                         @tagName(server.state()),
                         served,
+                        server.handshakeFailure(),
                     });
                     if (served >= args.requests) break :accept_loop;
                     continue :accept_loop;
@@ -486,10 +505,16 @@ fn runServer(allocator: std.mem.Allocator, args: Args) !void {
                 }
             }
         }
+        saw_hrr = saw_hrr or backend.engine.core.retry_state == .hrr_sent;
     }
 
     if (served < args.requests) {
         std.debug.print("h3-interop: server timed out with served={d}/{d}\n", .{ served, args.requests });
+        std.process.exit(1);
+    }
+    std.debug.print("h3-interop: tls hello_retry_request={}\n", .{saw_hrr});
+    if (args.expect_hrr and !saw_hrr) {
+        std.debug.print("h3-interop: expected HelloRetryRequest but none was observed\n", .{});
         std.process.exit(1);
     }
     std.debug.print("h3-interop: server ok, served={d}\n", .{served});

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -14844,7 +14844,7 @@ test "native TLS listener dispatches ALPN http/1.1 through keepalive requests" {
     const second_raw = try client.readPlainToEnd(allocator, 64 * 1024, 5_000);
     defer allocator.free(second_raw);
 
-    try waitForUpstreamCount(&upstream, 2, 2_000);
+    try waitForUpstreamCount(&upstream, 2, 5_000);
     try std.testing.expectEqual(@as(usize, 1), countOccurrences(second_raw, "HTTP/1.1 200 OK"));
     try assertContains(second_raw, "native-h1-second");
 }

--- a/tests/quic_h3_udp_smoke.zig
+++ b/tests/quic_h3_udp_smoke.zig
@@ -920,6 +920,9 @@ test "udp smoke: HTTP/3 runtime drain lets admitted work finish and rejects new 
                 else => return err,
             };
             request_b_sent = request_b != null;
+            while (client.pollTransmitOnPath(&out, nowUs())) |t| {
+                try client_socket.sendTo(sockaddrInFromAddress(t.path.remote), t.bytes);
+            }
         }
 
         const snapshot = runtime.snapshot();


### PR DESCRIPTION
## Summary

- add `h3_interop_tool` flags to force an empty initial client key share and assert observed HelloRetryRequest state
- add two focused #333 HRR smokes to `scripts/interop/run-interop.sh` using the existing ngtcp2/GnuTLS external peer boundary
- patch the pinned ngtcp2/GnuTLS CI peer build with `GNUTLS_KEY_SHARE_TOP`, so `SECP256R1:X25519` ordering sends only a P-256 first share while still advertising X25519
- document exact pinned peer tags, GnuTLS prerequisite/version capture, copy/paste-safe single-case commands, and bounded HRR assertion logs in `scripts/interop/README.md`
- relax the macOS-sensitive native TLS keepalive integration wait to match the existing 5s response-read budget

Closes #333

## Validation

- `zig build build-h3-interop --summary all --error-style verbose`
- `scripts/interop/run-interop.sh` without external peer env vars: 0 passed, 0 failed, 8 skipped
- native-to-native HRR smoke with `--empty-initial-key-share --expect-hrr`: client/server both exited 0; client logged `tls retry_state=hrr_received`; server logged `tls hello_retry_request=true`
- verified the `GNUTLS_KEY_SHARE_TOP` patch expression against ngtcp2 `v1.25.0`'s `examples/tls_client_session_gnutls.cc`
- `bash -n scripts/interop/build-h3-peer-ci.sh scripts/interop/install-h3-peer-deps-ci.sh scripts/interop/run-interop.sh`
- `zig build test --summary all --error-style verbose`: 43/43 steps succeeded; 2927/2928 tests passed (1 skipped)
- `zig build test -Dtls-profile=appliance --summary all --error-style verbose`: 41/41 steps succeeded; 2898/2899 tests passed (1 skipped)
- `zig build test-integration-native-tls -Dtls-profile=appliance --summary all --error-style verbose`: 8/8 steps succeeded; 9/9 tests passed
- `zig fmt --check build.zig src/ tests/`
- `git diff --check`
- `scripts/audit-dependencies.sh`
