### PR TITLE
http3: count post-GOAWAY stream rejections and deflake UDP drain smoke

### DIFF
--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -890,7 +890,20 @@ pub const Runtime = struct {
         // any response `serveRequest` queues still can't reach the wire
         // until `.application` packet building unlocks at establishment.
         if (!established and !self.zero_rtt_enabled) return;
-        entry.h3.pump(entry.conn) catch |err| {
+        // #546: a peer request stream that arrives at/above `local_goaway_id`
+        // is rejected by `entry.h3.pump()` itself, during admission, before
+        // it can ever become a `pollRequest()`-visible `IncomingRequest` —
+        // the boundary-rejection branch below never sees it. That's a
+        // distinct, mutually-exclusive rejection owner from this one, so
+        // fold its delta into the same snapshot counter here, unconditionally
+        // (a result-first shape, not inside the `catch`) so an unrelated
+        // protocol error from this same `pump()` call can't suppress an
+        // already-real rejection that happened earlier in the same call.
+        const rejected_before = entry.h3.metrics.goaway_request_rejections;
+        const pump_result = entry.h3.pump(entry.conn);
+        const rejected_after = entry.h3.metrics.goaway_request_rejections;
+        self.noteDrainRequestRejections(@intCast(rejected_after - rejected_before));
+        pump_result catch |err| {
             // An H3-level protocol error closes the connection with the
             // specific RFC 9114 §8.1 code the session layer recorded.
             const code = entry.h3.closeCode();
@@ -910,7 +923,7 @@ pub const Runtime = struct {
                 if (requestRejectedByDrainBoundary(incoming.stream_id, boundary)) {
                     entry.conn.resetStream(incoming.stream_id, 0x010b) catch {}; // H3_REQUEST_REJECTED
                     entry.h3.finishRequest(incoming.stream_id);
-                    self.noteDrainRequestRejected();
+                    self.noteDrainRequestRejections(1);
                     continue;
                 }
             }
@@ -1299,10 +1312,11 @@ pub const Runtime = struct {
         self.snapshot_state.h3_goaway_sent += 1;
     }
 
-    fn noteDrainRequestRejected(self: *Runtime) void {
+    fn noteDrainRequestRejections(self: *Runtime, count: usize) void {
+        if (count == 0) return;
         self.snapshot_mutex.lock();
         defer self.snapshot_mutex.unlock();
-        self.snapshot_state.h3_drain_request_rejections += 1;
+        self.snapshot_state.h3_drain_request_rejections += count;
     }
 
     fn noteHandshakeComplete(self: *Runtime) void {
@@ -2053,6 +2067,44 @@ test "drainBoundaryAfter permits admitted client-bidi streams" {
     try testing.expect(!requestRejectedByDrainBoundary(0, 4));
     try testing.expect(requestRejectedByDrainBoundary(4, 4));
     try testing.expect(requestRejectedByDrainBoundary(8, 4));
+}
+
+test "http3 runtime (#546): a request stream rejected by Conn.pump() at local_goaway_id folds into Snapshot.h3_drain_request_rejections" {
+    var fixed = tls_core.credentials.FixedCredentialProvider.init(tls_core.credentials.testdata.identity());
+    defer fixed.deinit();
+    var logger = logger_mod.Logger.init(.err, "http3-goaway-admission-fold-test");
+    var runtime = try Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+        .credential_provider = fixed.provider(),
+    });
+    defer runtime.deinit();
+    var harness = try RuntimeCidHarness.init(testing.allocator, fixed.provider());
+    defer harness.deinit(testing.allocator);
+
+    // Install the local GOAWAY boundary directly on the H3 session, exactly
+    // as the "H3 conn: sent GOAWAY rejects boundary..." unit test does in
+    // conn.zig — this isolates the admission-time rejection path from the
+    // full drain/GOAWAY-frame machinery, which is covered separately by the
+    // `drain_requested` branch this test does not touch.
+    harness.entry.h3.local_goaway_id = 0;
+
+    // The client's first bidi stream (id 0) lands exactly at that boundary,
+    // so `entry.h3.pump()` rejects it during admission before it can ever
+    // reach `pollRequest()` — the ordering this issue's UDP smoke flake
+    // depended on being observable.
+    var request_bytes: [128]u8 = undefined;
+    const bytes = buildH3RequestBytesForTest("GET", "/after-goaway", "example.com", &request_bytes);
+    const stream_id = try harness.client.openStream(.bidi);
+    try testing.expectEqual(@as(u64, 0), stream_id);
+    _ = try harness.client.writeStream(stream_id, bytes, true);
+    try harness.pump();
+
+    runtime.pumpH3(harness.entry, harness.now_us);
+
+    try testing.expectEqual(@as(u64, 1), harness.entry.h3.metrics.goaway_request_rejections);
+    try testing.expectEqual(@as(u32, 0), harness.entry.h3.requests.count());
+    try testing.expectEqual(@as(usize, 1), runtime.snapshot().h3_drain_request_rejections);
 }
 
 test "classifyIngest routes spoofed Initials, migration, and normal traffic" {

--- a/src/http3/conn.zig
+++ b/src/http3/conn.zig
@@ -115,6 +115,12 @@ pub fn Conn(comptime Transport: type) type {
             priority_duplicate_parameters: u64 = 0,
             priority_updates_buffered: u64 = 0,
             goaway_received: u64 = 0,
+            /// Peer request streams rejected directly by `pump()` because
+            /// they arrived at or above `local_goaway_id` — never surfaced
+            /// as an `IncomingRequest`, so `Runtime` cannot observe them via
+            /// `pollRequest()`. See `Metrics.goaway_request_rejections` at
+            /// the call site in `pump()`.
+            goaway_request_rejections: u64 = 0,
         };
 
         const max_pending_priority_updates: usize = 64;
@@ -307,6 +313,7 @@ pub fn Conn(comptime Transport: type) type {
                     if (self.local_goaway_id) |limit| {
                         if (id >= limit) {
                             rejectRequestStream(transport, id);
+                            self.metrics.goaway_request_rejections += 1;
                             continue;
                         }
                     }
@@ -1103,6 +1110,11 @@ test "H3 conn: sent GOAWAY rejects boundary and later peer requests without clos
     try testing.expectEqual(@as(?ErrorCode, null), server.close_code);
     try testing.expect((try server_transport.stream(first_rejected)).reset);
     try testing.expect((try server_transport.stream(second_rejected)).reset);
+    // #546: both peer request streams landed at/above `local_goaway_id`
+    // directly during `pump()`'s admission check, never becoming an
+    // `IncomingRequest` — this is the only place that observes them, so the
+    // runtime-level `h3_drain_request_rejections` fold depends on this count.
+    try testing.expectEqual(@as(u64, 2), server.metrics.goaway_request_rejections);
 }
 
 test "H3 conn: polls completed requests by urgency and reports priority" {

--- a/tests/quic_h3_udp_smoke.zig
+++ b/tests/quic_h3_udp_smoke.zig
@@ -990,6 +990,16 @@ test "udp smoke: HTTP/3 runtime drain lets admitted work finish and rejects new 
     try testing.expect(drain_started);
     try testing.expect(request_a_done);
     try testing.expect(request_b_sent or request_b_rejected_by_goaway);
+    // #546: split what used to be a single `new_initial_seen` assertion into
+    // two, so a future failure here tells apart the two very different
+    // causes: `sent_new_initial == false` means the drain rejection (via
+    // either the client-side GoawayReceived race or the server-side
+    // `h3_drain_request_rejections` counter — see the loop above) was never
+    // observed within the deadline, while `sent_new_initial == true` but
+    // `new_initial_seen == false` means the rejection *was* observed and the
+    // synthetic unknown-DCID Initial was sent, but the runtime never
+    // ingested it.
+    try testing.expect(sent_new_initial);
     try testing.expect(new_initial_seen);
     try testing.expectEqual(@as(usize, 1), handler_state.requests.load(.monotonic));
     const drained_snapshot = runtime.snapshot();


### PR DESCRIPTION
## Summary
- A request stream rejected directly by `http3.Conn.pump()` at `local_goaway_id` never became an `IncomingRequest`, so `Runtime` had no way to observe it — the runtime-level boundary rejection only counted requests that survived to `pollRequest()`. When the server installed GOAWAY before the client observed it, `Snapshot.h3_drain_request_rejections` stayed at zero, and `tests/quic_h3_udp_smoke.zig`'s drain smoke could time out waiting for `new_initial_seen` depending on which side won that race.
- Add `Metrics.goaway_request_rejections` to `http3.Conn` and increment it exactly at the admission-rejection site in `pump()` (`src/http3/conn.zig`).
- Fold that counter's delta into `Runtime`'s `Snapshot.h3_drain_request_rejections` around every `entry.h3.pump()` call, using a result-first shape so an unrelated `pump()` error from the same call can't suppress an already-real rejection (`src/http/http3_runtime.zig`). The existing runtime-level boundary-rejection path (for requests admitted before drain but rejected later) is unchanged and remains mutually exclusive with this one.
- Extend the existing `H3 conn: sent GOAWAY rejects boundary...` unit test with an assertion on the new counter, and add a new runtime-level test proving the H3 metric delta folds into the snapshot.
- Split the UDP smoke test's single `new_initial_seen` assertion into two (`sent_new_initial` first), so a future failure distinguishes "the drain rejection was never observed" from "the synthetic Initial was sent but never ingested."

## Test plan
- [x] `zig build test` — full suite green
- [x] `zig build test -Dtls-profile=appliance --seed 0x811b55b0` — reproduces the original CI shape, green (2708/2709, 1 pre-existing skip)
- [x] `zig build test-quic -Dquic-test-filter="udp smoke: HTTP/3 runtime drain lets admitted work finish and rejects new work" --seed 0x811b55b0` — the exact CI-failing seed, passes
- [x] Same focused test repeated with 6+ additional randomized seeds — all pass

Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)