### PR TITLE
fix: harden secret lifecycle cleanup paths

### DIFF
--- a/scripts/audit_crypto_boundary.zig
+++ b/scripts/audit_crypto_boundary.zig
@@ -265,7 +265,7 @@ const file_checks_with_exceptions = [_]FileCheckWithExceptions{
         // anywhere else in the file would pass (#490 fifth-pass review).
         .forbidden = &(full_forbidden ++ [_][]const u8{"HmacSha256."}),
         .exempt_exact = &.{"const HmacSha256 = std.crypto.auth.hmac.sha2.HmacSha256;"},
-        .exempt_functions = &.{"statelessResetToken"},
+        .exempt_functions = &.{ "statelessResetToken", "statelessResetTokenInto" },
         .rationale = "Connection-ID/stateless-reset-token derivation (RFC 9000 §10.3.1) is a documented HMAC-SHA256 exception under a static process-lifetime key (docs/CRYPTO_PROVIDER_AUDIT.md), not TLS/QUIC-negotiated packet protection; no AEAD, ECDH, signature, KDF, or AES header-protection shortcuts, and no other HmacSha256 use, may be added here.",
     },
     .{

--- a/scripts/audit_crypto_boundary.zig
+++ b/scripts/audit_crypto_boundary.zig
@@ -265,7 +265,7 @@ const file_checks_with_exceptions = [_]FileCheckWithExceptions{
         // anywhere else in the file would pass (#490 fifth-pass review).
         .forbidden = &(full_forbidden ++ [_][]const u8{"HmacSha256."}),
         .exempt_exact = &.{"const HmacSha256 = std.crypto.auth.hmac.sha2.HmacSha256;"},
-        .exempt_functions = &.{ "statelessResetToken", "statelessResetTokenInto" },
+        .exempt_functions = &.{"statelessResetTokenInto"},
         .rationale = "Connection-ID/stateless-reset-token derivation (RFC 9000 §10.3.1) is a documented HMAC-SHA256 exception under a static process-lifetime key (docs/CRYPTO_PROVIDER_AUDIT.md), not TLS/QUIC-negotiated packet protection; no AEAD, ECDH, signature, KDF, or AES header-protection shortcuts, and no other HmacSha256 use, may be added here.",
     },
     .{

--- a/src/crypto/secrets.zig
+++ b/src/crypto/secrets.zig
@@ -17,6 +17,25 @@ pub fn constantTimeEqual(a: []const u8, b: []const u8) bool {
     return std.crypto.timing_safe.compare(u8, a, b, .big) == .eq;
 }
 
+/// Wipes a secret-bearing heap allocation and returns it to `allocator`,
+/// guaranteeing the bytes the backing allocator observes are zero rather
+/// than whatever `std.mem.Allocator.free` would otherwise leave behind.
+///
+/// `Allocator.free` runs `@memset(bytes, undefined)` before dispatching to
+/// the backing implementation. In safety builds that fills the buffer with a
+/// poison pattern *after* any zeroing we've already done, which trips
+/// allocator-level "was this zeroized before free" assertions; in
+/// ReleaseFast, "undefined" carries no required bit pattern so the compiler
+/// is free to emit no write at all, meaning the plain `free()` path is not
+/// actually guaranteed to scrub secrets in a production build. Bypassing the
+/// wrapper and calling `rawFree` directly ensures the zeroed bytes are what
+/// the allocator (and anything that reuses the memory next) actually sees.
+pub fn secureZeroAndFree(allocator: std.mem.Allocator, buffer: []u8) void {
+    if (buffer.len == 0) return;
+    secureZero(buffer);
+    allocator.rawFree(buffer, .fromByteUnits(@alignOf(u8)), @returnAddress());
+}
+
 pub fn FixedSecret(comptime capacity: usize) type {
     return struct {
         bytes: [capacity]u8 = [_]u8{0} ** capacity,
@@ -238,6 +257,26 @@ test "bounded secret replace handles self-overlapping input" {
     try secret.replace(secret.slice()[1..4]);
     try testing.expectEqualStrings("bcd", secret.slice());
     try testing.expectEqual(@as(u8, 0), secret.bytes[3]);
+}
+
+test "secureZeroAndFree hands the allocator zeroed bytes, not Allocator.free's undefined-poison" {
+    var backing = [_]u8{0xcc} ** 64;
+    var fba = std.heap.FixedBufferAllocator.init(&backing);
+    const buf = try fba.allocator().alloc(u8, 16);
+    @memset(buf, 0xab);
+
+    secureZeroAndFree(fba.allocator(), buf);
+
+    // A plain `allocator.free(buf)` would have run `@memset(buf, undefined)`
+    // first in safety builds, leaving poison bytes rather than zeros.
+    try testing.expect(std.mem.indexOfScalar(u8, &backing, 0xab) == null);
+    for (backing[0..16]) |byte| try testing.expectEqual(@as(u8, 0), byte);
+}
+
+test "secureZeroAndFree tolerates an empty buffer" {
+    var backing = [_]u8{0xcc} ** 8;
+    var fba = std.heap.FixedBufferAllocator.init(&backing);
+    secureZeroAndFree(fba.allocator(), &.{});
 }
 
 test "secret helpers expose non-formatting APIs" {

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -338,7 +338,7 @@ pub const Runtime = struct {
         runtime.crypto_provider_state = tls_core.production_crypto.Provider.init(runtime.crypto_provider_entropy.entropy());
         var retry_key: [quic.path.token_key_len]u8 = undefined;
         compat.randomBytes(&retry_key);
-        runtime.secrets.retry_tokens.keys.install(0, retry_key);
+        runtime.secrets.retry_tokens.keys.install(0, &retry_key);
         crypto_pkg.secrets.secureZero(&retry_key);
         compat.randomBytes(&runtime.secrets.stateless_reset_key);
         errdefer runtime.secrets.deinit();
@@ -694,7 +694,7 @@ pub const Runtime = struct {
             .now_us = now,
             .initial_path = .{ .local = self.local_address, .remote = addressFromSockaddrIn(peer) },
             .initial_address_validated = retry_context != null,
-            .stateless_reset_key = self.secrets.stateless_reset_key,
+            .stateless_reset_key = &self.secrets.stateless_reset_key,
             .events = .{ .context = self, .emitFn = quicConnectionEvent },
         }) catch {
             allocator.destroy(backend);
@@ -1678,7 +1678,7 @@ const RuntimeCidHarness = struct {
             .crypto_provider = test_quic_crypto.testDefaultProvider(),
             .now_us = self.now_us,
             .initial_path = server_path,
-            .stateless_reset_key = [_]u8{0x44} ** 32,
+            .stateless_reset_key = &([_]u8{0x44} ** 32),
         });
         entry.* = .{
             .backend = server_backend,

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -322,7 +322,9 @@ pub const Runtime = struct {
         var retry_key: [quic.path.token_key_len]u8 = undefined;
         compat.randomBytes(&retry_key);
         runtime.retry_tokens.keys.install(0, retry_key);
+        crypto_pkg.secrets.secureZero(&retry_key);
         compat.randomBytes(&runtime.stateless_reset_key);
+        errdefer runtime.wipeSecrets();
         http3.frame.validateLocallySupportedSettings(runtime.h3_settings) catch return error.InvalidH3Settings;
         runtime.h3_application_compat_len = (http3.early_data.encodeSettingsSnapshot(
             runtime.h3_settings,
@@ -354,7 +356,20 @@ pub const Runtime = struct {
         self.stopping.store(true, .release);
         if (self.thread) |thread| thread.join();
         _ = std.c.close(self.socket_fd);
+        self.wipeSecrets();
         self.* = undefined;
+    }
+
+    /// Wipe the Retry token key ring and the stateless-reset key. Factored
+    /// out of `deinit` (rather than inlined before its trailing
+    /// `self.* = undefined`) so it stays independently callable — including
+    /// from tests, which would otherwise be unable to observe the wipe at
+    /// all: safety-checked builds poison-fill a whole struct on `= undefined`,
+    /// which would overwrite the very zero bytes a post-`deinit` byte-level
+    /// assertion is trying to verify.
+    fn wipeSecrets(self: *Runtime) void {
+        self.retry_tokens.keys.deinit();
+        crypto_pkg.secrets.secureZero(&self.stateless_reset_key);
     }
 
     pub fn snapshot(self: *Runtime) Snapshot {
@@ -2043,6 +2058,45 @@ test "runtime init rejects unsupported local H3 setting h3_datagram" {
 
 test "runtime init rejects unsupported local H3 setting max_field_section_size" {
     try expectInvalidH3SettingsAtRuntimeInit(.{ .max_field_section_size = 1024 });
+}
+
+test "Runtime.deinit wipes the retry token key ring and the stateless reset key" {
+    var logger = logger_mod.Logger.init(.err, "http3-runtime-deinit-wipe-test");
+    var runtime = try Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+    });
+    // `deinit()` ends with `self.* = undefined`, and safety-checked builds
+    // poison-fill the *whole* struct on that assignment — which would
+    // overwrite our zeroed bytes with poison before a post-`deinit` byte
+    // check ever ran, making the wipe unobservable either way. Call
+    // `wipeSecrets()` (the exact cleanup `deinit()` delegates to) directly
+    // instead, on this real `Runtime.init`-produced key material, and close
+    // the socket by hand since we're bypassing `deinit()`.
+    defer _ = std.c.close(runtime.socket_fd);
+
+    // Capture raw pointers into the still-installed key storage before the
+    // wipe: asserting only that lookups fail afterward would also pass an
+    // implementation that just cleared option tags without ever touching
+    // the key bytes.
+    const key0_ptr: *const [quic.path.token_key_len]u8 = &(runtime.retry_tokens.keys.keys[0].?);
+    const reset_key_ptr = &runtime.stateless_reset_key;
+
+    var saw_key_nonzero = false;
+    for (key0_ptr) |b| {
+        if (b != 0) saw_key_nonzero = true;
+    }
+    try testing.expect(saw_key_nonzero);
+    var saw_reset_nonzero = false;
+    for (reset_key_ptr) |b| {
+        if (b != 0) saw_reset_nonzero = true;
+    }
+    try testing.expect(saw_reset_nonzero);
+
+    runtime.wipeSecrets();
+
+    for (key0_ptr) |byte| try testing.expectEqual(@as(u8, 0), byte);
+    for (reset_key_ptr) |byte| try testing.expectEqual(@as(u8, 0), byte);
 }
 
 test "admissionAllowed enforces global and per-source caps at the boundary" {

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -206,6 +206,25 @@ const ConnEntry = struct {
     }
 };
 
+/// The Retry token key ring and the process stateless-reset key are the
+/// only long-lived secrets `Runtime` owns. Grouping them here makes their
+/// lifecycle (installed at `init`, wiped on teardown or a later init
+/// failure) independently testable via `deinit` — including calling the
+/// exact cleanup the production owner uses — without fighting
+/// `Runtime.deinit`'s own trailing `self.* = undefined`, which
+/// safety-checked builds use to poison-fill the *entire* enclosing struct
+/// and would otherwise make any post-deinit byte-level assertion on these
+/// fields meaningless.
+const RuntimeSecrets = struct {
+    retry_tokens: quic.path.RetryTokens = .{},
+    stateless_reset_key: [32]u8 = [_]u8{0} ** 32,
+
+    fn deinit(self: *RuntimeSecrets) void {
+        self.retry_tokens.keys.deinit();
+        crypto_pkg.secrets.secureZero(&self.stateless_reset_key);
+    }
+};
+
 pub const Runtime = struct {
     allocator: std.mem.Allocator,
     socket_fd: std.c.fd_t,
@@ -228,8 +247,7 @@ pub const Runtime = struct {
     /// early-data policy on new connections' TLS backends.
     zero_rtt_enabled: bool,
     retry_policy: quic.config.RetryPolicy,
-    retry_tokens: quic.path.RetryTokens,
-    stateless_reset_key: [32]u8,
+    secrets: RuntimeSecrets,
     quic_config: quic.config.Config,
     h3_settings: http3.frame.Settings,
     h3_application_compat: [http3.early_data.encoded_snapshot_len]u8 = undefined,
@@ -302,8 +320,7 @@ pub const Runtime = struct {
             .early_data_replay_gate = cfg.early_data_replay_gate,
             .zero_rtt_enabled = zeroRttCarrierEnabled(cfg),
             .retry_policy = cfg.retry_policy,
-            .retry_tokens = .{},
-            .stateless_reset_key = undefined,
+            .secrets = .{},
             .quic_config = quicConfigFrom(cfg),
             .h3_settings = cfg.h3_settings,
             .early_data_compat_metrics_ctx = cfg.early_data_compat_metrics_ctx,
@@ -321,10 +338,10 @@ pub const Runtime = struct {
         runtime.crypto_provider_state = tls_core.production_crypto.Provider.init(runtime.crypto_provider_entropy.entropy());
         var retry_key: [quic.path.token_key_len]u8 = undefined;
         compat.randomBytes(&retry_key);
-        runtime.retry_tokens.keys.install(0, retry_key);
+        runtime.secrets.retry_tokens.keys.install(0, retry_key);
         crypto_pkg.secrets.secureZero(&retry_key);
-        compat.randomBytes(&runtime.stateless_reset_key);
-        errdefer runtime.wipeSecrets();
+        compat.randomBytes(&runtime.secrets.stateless_reset_key);
+        errdefer runtime.secrets.deinit();
         http3.frame.validateLocallySupportedSettings(runtime.h3_settings) catch return error.InvalidH3Settings;
         runtime.h3_application_compat_len = (http3.early_data.encodeSettingsSnapshot(
             runtime.h3_settings,
@@ -356,20 +373,8 @@ pub const Runtime = struct {
         self.stopping.store(true, .release);
         if (self.thread) |thread| thread.join();
         _ = std.c.close(self.socket_fd);
-        self.wipeSecrets();
+        self.secrets.deinit();
         self.* = undefined;
-    }
-
-    /// Wipe the Retry token key ring and the stateless-reset key. Factored
-    /// out of `deinit` (rather than inlined before its trailing
-    /// `self.* = undefined`) so it stays independently callable — including
-    /// from tests, which would otherwise be unable to observe the wipe at
-    /// all: safety-checked builds poison-fill a whole struct on `= undefined`,
-    /// which would overwrite the very zero bytes a post-`deinit` byte-level
-    /// assertion is trying to verify.
-    fn wipeSecrets(self: *Runtime) void {
-        self.retry_tokens.keys.deinit();
-        crypto_pkg.secrets.secureZero(&self.stateless_reset_key);
     }
 
     pub fn snapshot(self: *Runtime) Snapshot {
@@ -689,7 +694,7 @@ pub const Runtime = struct {
             .now_us = now,
             .initial_path = .{ .local = self.local_address, .remote = addressFromSockaddrIn(peer) },
             .initial_address_validated = retry_context != null,
-            .stateless_reset_key = self.stateless_reset_key,
+            .stateless_reset_key = self.secrets.stateless_reset_key,
             .events = .{ .context = self, .emitFn = quicConnectionEvent },
         }) catch {
             allocator.destroy(backend);
@@ -767,7 +772,7 @@ pub const Runtime = struct {
             self.issueRetry(routes, parsed, peer, remote, now);
             return .drop;
         }
-        const ctx = self.retry_tokens.validateRetry(parsed.token, remote, now) catch {
+        const ctx = self.secrets.retry_tokens.validateRetry(parsed.token, remote, now) catch {
             self.noteInvalidToken();
             return .drop;
         };
@@ -790,7 +795,7 @@ pub const Runtime = struct {
         var nonce: [quic.path.token_nonce_len]u8 = undefined;
         compat.randomBytes(&nonce);
         var token_buf: [quic.path.max_token_len]u8 = undefined;
-        const token = self.retry_tokens.issueRetry(parsed.dcid, retry_scid.slice(), parsed.version, remote, now, nonce, &token_buf) catch return;
+        const token = self.secrets.retry_tokens.issueRetry(parsed.dcid, retry_scid.slice(), parsed.version, remote, now, nonce, &token_buf) catch return;
         var retry_buf: [512]u8 = undefined;
         const retry = quic.packet.writeRetryV1(parsed.dcid, parsed.scid, retry_scid.slice(), token, &retry_buf) catch return;
         self.sendDatagram(peer, retry);
@@ -2060,27 +2065,29 @@ test "runtime init rejects unsupported local H3 setting max_field_section_size" 
     try expectInvalidH3SettingsAtRuntimeInit(.{ .max_field_section_size = 1024 });
 }
 
-test "Runtime.deinit wipes the retry token key ring and the stateless reset key" {
+test "RuntimeSecrets.deinit wipes the retry token key ring and the stateless reset key" {
     var logger = logger_mod.Logger.init(.err, "http3-runtime-deinit-wipe-test");
     var runtime = try Runtime.init(testing.allocator, &logger, .{
         .listen_host = "127.0.0.1",
         .quic_port = 0,
     });
-    // `deinit()` ends with `self.* = undefined`, and safety-checked builds
-    // poison-fill the *whole* struct on that assignment — which would
-    // overwrite our zeroed bytes with poison before a post-`deinit` byte
-    // check ever ran, making the wipe unobservable either way. Call
-    // `wipeSecrets()` (the exact cleanup `deinit()` delegates to) directly
-    // instead, on this real `Runtime.init`-produced key material, and close
-    // the socket by hand since we're bypassing `deinit()`.
+    // Exercise `RuntimeSecrets.deinit()` directly — the exact cleanup
+    // `Runtime.deinit()` delegates to via `self.secrets.deinit()` — rather
+    // than the full `Runtime.deinit()`, whose trailing `self.* = undefined`
+    // poison-fills the *whole* struct in safety-checked builds. That would
+    // overwrite these zeroed bytes with poison before any post-deinit byte
+    // check ran, making the wipe unobservable regardless of whether it
+    // happened. `RuntimeSecrets` has no such trailing assignment, so its
+    // fields stay genuinely inspectable after `deinit()`. Close the socket
+    // by hand since we're bypassing `Runtime.deinit()`.
     defer _ = std.c.close(runtime.socket_fd);
 
     // Capture raw pointers into the still-installed key storage before the
     // wipe: asserting only that lookups fail afterward would also pass an
-    // implementation that just cleared option tags without ever touching
-    // the key bytes.
-    const key0_ptr: *const [quic.path.token_key_len]u8 = &(runtime.retry_tokens.keys.keys[0].?);
-    const reset_key_ptr = &runtime.stateless_reset_key;
+    // implementation that never touched the key bytes, only an occupancy
+    // flag/length.
+    const key0_ptr: *const [quic.path.token_key_len]u8 = &runtime.secrets.retry_tokens.keys.keys[0].bytes;
+    const reset_key_ptr = &runtime.secrets.stateless_reset_key;
 
     var saw_key_nonzero = false;
     for (key0_ptr) |b| {
@@ -2093,7 +2100,7 @@ test "Runtime.deinit wipes the retry token key ring and the stateless reset key"
     }
     try testing.expect(saw_reset_nonzero);
 
-    runtime.wipeSecrets();
+    runtime.secrets.deinit();
 
     for (key0_ptr) |byte| try testing.expectEqual(@as(u8, 0), byte);
     for (reset_key_ptr) |byte| try testing.expectEqual(@as(u8, 0), byte);
@@ -4119,7 +4126,7 @@ test "http3 runtime Retry accepts validated tokens with split CID roles and vali
     const client_scid = [_]u8{0x22} ** 8;
     const peer = testPeerSockaddr(44_332);
     var token_buf: [quic.path.max_token_len]u8 = undefined;
-    const token = try runtime.retry_tokens.issueRetry(
+    const token = try runtime.secrets.retry_tokens.issueRetry(
         &odcid,
         &retry_scid,
         quic.packet.quic_v1,
@@ -4181,7 +4188,7 @@ test "http3 runtime Retry rejects valid tokens replayed with the wrong Retry SCI
     const client_scid = [_]u8{0x22} ** 8;
     const peer = testPeerSockaddr(44_333);
     var token_buf: [quic.path.max_token_len]u8 = undefined;
-    const token = try runtime.retry_tokens.issueRetry(
+    const token = try runtime.secrets.retry_tokens.issueRetry(
         &odcid,
         &retry_scid,
         quic.packet.quic_v1,
@@ -4235,7 +4242,7 @@ test "http3 runtime Retry counts valid tokens replayed with the wrong QUIC versi
     const client_scid = [_]u8{0x22} ** 8;
     const peer = testPeerSockaddr(44_334);
     var token_buf: [quic.path.max_token_len]u8 = undefined;
-    const token = try runtime.retry_tokens.issueRetry(
+    const token = try runtime.secrets.retry_tokens.issueRetry(
         &odcid,
         &retry_scid,
         quic.packet.quic_v1,

--- a/src/quic/cid.zig
+++ b/src/quic/cid.zig
@@ -654,9 +654,50 @@ test "local registry deinit clears issued entries" {
     _ = try registry.issue(&entropy, 8);
     try testing.expect(registry.activeCount() > 0);
 
+    // Capture raw pointers into the still-populated storage before deinit:
+    // `activeCount() == 0` and `reset_token_key.len == 0` alone would also
+    // pass an implementation that only flips the `?Entry` option tags
+    // without ever touching the token/key payload bytes.
+    var token_ptrs: [max_local_active_cids]?*const [stateless_reset_token_len]u8 = .{null} ** max_local_active_cids;
+    for (&registry.entries, 0..) |*slot, i| {
+        if (slot.*) |*entry| token_ptrs[i] = &entry.stateless_reset_token;
+    }
+    try testing.expect(token_ptrs[0] != null);
+    const key_ptr = &registry.reset_token_key.bytes;
+
     registry.deinit();
     try testing.expectEqual(@as(usize, 0), registry.activeCount());
     try testing.expectEqual(@as(usize, 0), registry.reset_token_key.len);
+    for (token_ptrs) |maybe_ptr| {
+        const ptr = maybe_ptr orelse continue;
+        for (ptr) |byte| try testing.expectEqual(@as(u8, 0), byte);
+    }
+    for (key_ptr) |byte| try testing.expectEqual(@as(u8, 0), byte);
+}
+
+test "retire wipes the stateless reset token bytes, not just the entry slot" {
+    var registry = LocalCidRegistry.init(4, [_]u8{0x66} ** 32);
+    defer registry.deinit();
+    _ = try registry.registerInitial(try ConnectionId.init(&.{ 9, 9, 9, 9 }));
+    var entropy = [_]u8{0x77} ** 8;
+    const issued = try registry.issue(&entropy, 8);
+    try registry.markAdvertised(issued.sequence);
+
+    var token_ptr: ?*const [stateless_reset_token_len]u8 = null;
+    for (&registry.entries) |*slot| {
+        if (slot.*) |*entry| {
+            if (entry.sequence == issued.sequence) token_ptr = &entry.stateless_reset_token;
+        }
+    }
+    const token = token_ptr orelse return error.TestUnexpectedResult;
+    var saw_nonzero = false;
+    for (token) |byte| {
+        if (byte != 0) saw_nonzero = true;
+    }
+    try testing.expect(saw_nonzero);
+
+    _ = try registry.retire(.{ .sequence = issued.sequence });
+    for (token) |byte| try testing.expectEqual(@as(u8, 0), byte);
 }
 
 test "peer pool validates NEW_CONNECTION_ID and sweeps retire_prior_to" {

--- a/src/quic/cid.zig
+++ b/src/quic/cid.zig
@@ -190,12 +190,15 @@ pub const LocalCidRegistry = struct {
     }
 
     /// Register the CID chosen during the handshake as sequence 0
-    /// (RFC 9000 §5.1.1). Call once, before any `issue`.
-    pub fn registerInitial(self: *LocalCidRegistry, cid: ConnectionId) error{ CidLimitExceeded, DuplicateCid }!Entry {
+    /// (RFC 9000 §5.1.1). Call once, before any `issue`. Returns only the
+    /// (public, wire-visible) CID rather than the full `Entry`, so the
+    /// registry's copy of the derived reset token is never duplicated onto
+    /// the caller's stack.
+    pub fn registerInitial(self: *LocalCidRegistry, cid: ConnectionId) error{ CidLimitExceeded, DuplicateCid }!ConnectionId {
         std.debug.assert(self.next_sequence == 0);
         const entry = try self.store(cid);
         self.largest_advertised_sequence = entry.sequence;
-        return entry;
+        return entry.cid;
     }
 
     /// Issue a fresh CID from caller-supplied entropy and return the
@@ -207,13 +210,16 @@ pub const LocalCidRegistry = struct {
         return try self.issueCid(cid);
     }
 
-    /// Issue a caller-generated CID. Production endpoints use this
-    /// transactional form so a route table entry can be reserved before the
-    /// exact CID is queued in a NEW_CONNECTION_ID frame.
-    pub fn issueCid(self: *LocalCidRegistry, cid: ConnectionId) error{ CidLimitExceeded, DuplicateCid }!NewConnectionIdFrame {
+    /// Issue a caller-generated CID, writing the NEW_CONNECTION_ID frame
+    /// model directly into `out`. Production endpoints use this
+    /// destination-oriented form so the reset token is copied exactly once,
+    /// from the registry's owned entry into the caller's owned destination
+    /// (e.g. a queue slot), instead of round-tripping through an
+    /// intermediate by-value return.
+    pub fn issueCidInto(self: *LocalCidRegistry, cid: ConnectionId, out: *NewConnectionIdFrame) error{ CidLimitExceeded, DuplicateCid }!void {
         const entry = try self.store(cid);
         self.metrics.cids_issued += 1;
-        return .{
+        out.* = .{
             .sequence = entry.sequence,
             .retire_prior_to = 0,
             .cid = entry.cid,
@@ -221,7 +227,18 @@ pub const LocalCidRegistry = struct {
         };
     }
 
-    fn store(self: *LocalCidRegistry, cid: ConnectionId) error{ CidLimitExceeded, DuplicateCid }!Entry {
+    /// Convenience wrapper over `issueCidInto` for callers (mostly tests)
+    /// that want an owned return value rather than a destination pointer.
+    pub fn issueCid(self: *LocalCidRegistry, cid: ConnectionId) error{ CidLimitExceeded, DuplicateCid }!NewConnectionIdFrame {
+        var out: NewConnectionIdFrame = undefined;
+        try self.issueCidInto(cid, &out);
+        return out;
+    }
+
+    /// Reserve and populate a fresh entry for `cid`, returning a pointer into
+    /// the registry's own storage. Callers must not retain the pointer past
+    /// their next mutating call into the registry.
+    fn store(self: *LocalCidRegistry, cid: ConnectionId) error{ CidLimitExceeded, DuplicateCid }!*Entry {
         if (self.activeCount() >= self.active_limit) return error.CidLimitExceeded;
         // Repeated caller entropy must not mint the same CID twice under
         // different sequence numbers.
@@ -231,12 +248,13 @@ pub const LocalCidRegistry = struct {
         const slot_idx = for (self.occupied, 0..) |occupied, i| {
             if (!occupied) break i;
         } else return error.CidLimitExceeded;
-        const entry = Entry{
+        const entry = &self.entries[slot_idx];
+        entry.* = .{
             .sequence = self.next_sequence,
             .cid = cid,
-            .stateless_reset_token = statelessResetToken(self.reset_token_key.slice(), cid.slice()),
+            .stateless_reset_token = [_]u8{0} ** stateless_reset_token_len,
         };
-        self.entries[slot_idx] = entry;
+        statelessResetTokenInto(&entry.stateless_reset_token, self.reset_token_key.slice(), cid.slice());
         self.occupied[slot_idx] = true;
         self.next_sequence += 1;
         return entry;
@@ -462,12 +480,20 @@ pub const stateless_reset_token_len = 16;
 /// HMAC-SHA256(static_key, connection_id); it MUST be hard to guess, so the
 /// static key must be secret and stable across the connection's lifetime.
 pub fn statelessResetToken(static_key: []const u8, connection_id: []const u8) [stateless_reset_token_len]u8 {
+    var token: [stateless_reset_token_len]u8 = undefined;
+    statelessResetTokenInto(&token, static_key, connection_id);
+    return token;
+}
+
+/// Same derivation as `statelessResetToken`, writing directly into `out`
+/// instead of returning by value. Production issuance paths use this so the
+/// token is written once into its final owner, rather than materializing an
+/// extra by-value stack copy that a caller then copies again.
+fn statelessResetTokenInto(out: *[stateless_reset_token_len]u8, static_key: []const u8, connection_id: []const u8) void {
     var mac: [HmacSha256.mac_length]u8 = undefined;
     defer secrets.secureZero(&mac);
     HmacSha256.create(&mac, connection_id, static_key);
-    var token: [stateless_reset_token_len]u8 = undefined;
-    @memcpy(&token, mac[0..stateless_reset_token_len]);
-    return token;
+    @memcpy(out, mac[0..stateless_reset_token_len]);
 }
 
 /// Emission rules and packet construction for stateless resets (RFC 9000 §10.3).
@@ -615,8 +641,8 @@ test "retired local CIDs stop routing and unknown retire sequences are violation
     var registry = LocalCidRegistry.init(4, [_]u8{0xab} ** 32);
 
     const initial = try ConnectionId.init(&.{ 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa });
-    const initial_entry = try registry.registerInitial(initial);
-    try table.insert(initial_entry.cid, 1);
+    const initial_cid = try registry.registerInitial(initial);
+    try table.insert(initial_cid, 1);
 
     var entropy = [_]u8{0x10} ** 8;
     const issued = try registry.issue(&entropy, 8);

--- a/src/quic/cid.zig
+++ b/src/quic/cid.zig
@@ -173,7 +173,13 @@ pub const LocalCidRegistry = struct {
         out.reset_token_key.replace(reset_key) catch unreachable;
     }
 
-    pub fn init(peer_active_connection_id_limit: u64, reset_token_key: [32]u8) LocalCidRegistry {
+    /// Return-by-value convenience for tests only. `initInto` is the only
+    /// production-facing constructor: a by-value parameter plus a
+    /// return-by-value result both leave an unowned semantic copy of the
+    /// secret, and this is not one of the compile-time-known-safe call
+    /// sites (a test literal wiped by nothing) that would make that
+    /// acceptable in production.
+    fn init(peer_active_connection_id_limit: u64, reset_token_key: [32]u8) LocalCidRegistry {
         var out: LocalCidRegistry = undefined;
         initInto(&out, peer_active_connection_id_limit, &reset_token_key);
         return out;
@@ -201,11 +207,17 @@ pub const LocalCidRegistry = struct {
         return entry.cid;
     }
 
-    /// Issue a fresh CID from caller-supplied entropy and return the
-    /// NEW_CONNECTION_ID frame model to send. Fails when the peer's active
-    /// CID limit is reached (RFC 9000 §5.1.1: an endpoint MUST NOT provide
-    /// more CIDs than the peer's limit).
-    pub fn issue(self: *LocalCidRegistry, entropy: []const u8, cid_len: u8) !NewConnectionIdFrame {
+    /// Issue a fresh CID from caller-supplied entropy, writing the
+    /// NEW_CONNECTION_ID frame model directly into `out`. Production
+    /// entry point mirroring `issueCidInto` for callers that generate the
+    /// CID from entropy rather than supplying one directly.
+    pub fn issueInto(self: *LocalCidRegistry, entropy: []const u8, cid_len: u8, out: *NewConnectionIdFrame) !void {
+        const cid = try generateCid(entropy, cid_len);
+        try self.issueCidInto(cid, out);
+    }
+
+    /// Return-by-value convenience for tests only; see `issueCidInto`.
+    fn issue(self: *LocalCidRegistry, entropy: []const u8, cid_len: u8) !NewConnectionIdFrame {
         const cid = try generateCid(entropy, cid_len);
         return try self.issueCid(cid);
     }
@@ -227,9 +239,11 @@ pub const LocalCidRegistry = struct {
         };
     }
 
-    /// Convenience wrapper over `issueCidInto` for callers (mostly tests)
-    /// that want an owned return value rather than a destination pointer.
-    pub fn issueCid(self: *LocalCidRegistry, cid: ConnectionId) error{ CidLimitExceeded, DuplicateCid }!NewConnectionIdFrame {
+    /// Return-by-value convenience for tests only. `issueCidInto` is the
+    /// only production-facing form: a caller with a real queue/record
+    /// destination should write into it directly rather than round-tripping
+    /// the reset token through an intermediate by-value return.
+    fn issueCid(self: *LocalCidRegistry, cid: ConnectionId) error{ CidLimitExceeded, DuplicateCid }!NewConnectionIdFrame {
         var out: NewConnectionIdFrame = undefined;
         try self.issueCidInto(cid, &out);
         return out;
@@ -299,8 +313,12 @@ pub const LocalCidRegistry = struct {
         return active;
     }
 
-    pub fn get(self: *const LocalCidRegistry, sequence: u64) ?Entry {
-        for (self.entries, self.occupied) |entry, occupied| {
+    /// Returns a pointer into the registry's own storage rather than a
+    /// by-value `Entry`, so a caller cannot walk away with an unowned copy
+    /// of the reset token. Callers must not retain the pointer past their
+    /// next mutating call into the registry.
+    pub fn get(self: *const LocalCidRegistry, sequence: u64) ?*const Entry {
+        for (&self.entries, self.occupied) |*entry, occupied| {
             if (occupied and entry.sequence == sequence) return entry;
         }
         return null;
@@ -489,7 +507,7 @@ pub fn statelessResetToken(static_key: []const u8, connection_id: []const u8) [s
 /// instead of returning by value. Production issuance paths use this so the
 /// token is written once into its final owner, rather than materializing an
 /// extra by-value stack copy that a caller then copies again.
-fn statelessResetTokenInto(out: *[stateless_reset_token_len]u8, static_key: []const u8, connection_id: []const u8) void {
+pub fn statelessResetTokenInto(out: *[stateless_reset_token_len]u8, static_key: []const u8, connection_id: []const u8) void {
     var mac: [HmacSha256.mac_length]u8 = undefined;
     defer secrets.secureZero(&mac);
     HmacSha256.create(&mac, connection_id, static_key);

--- a/src/quic/cid.zig
+++ b/src/quic/cid.zig
@@ -138,35 +138,51 @@ pub const max_local_active_cids = 8;
 
 pub const LocalCidRegistry = struct {
     pub const Entry = struct {
-        sequence: u64,
-        cid: ConnectionId,
-        stateless_reset_token: [stateless_reset_token_len]u8,
+        sequence: u64 = 0,
+        cid: ConnectionId = .{},
+        stateless_reset_token: [stateless_reset_token_len]u8 = [_]u8{0} ** stateless_reset_token_len,
     };
 
     /// min(peer's active_connection_id_limit, local storage bound).
-    active_limit: u64,
+    active_limit: u64 = 0,
     /// Static secret for stateless-reset token derivation (RFC 9000 §10.3.1).
-    reset_token_key: secrets.FixedSecret(32),
-    entries: [max_local_active_cids]?Entry = [_]?Entry{null} ** max_local_active_cids,
+    reset_token_key: secrets.FixedSecret(32) = .{},
+    /// Always-live entry storage; `occupied` tracks which slots hold a live
+    /// CID rather than wrapping each entry in `?Entry`. An optional wrapper
+    /// would make a retired (or never-issued) slot's payload logically
+    /// inactive, and safety-checked builds are free to poison-fill an
+    /// inactive optional payload — observably so on Linux x64 — which would
+    /// make it impossible to assert the token bytes were actually zeroed
+    /// rather than merely tagged absent.
+    entries: [max_local_active_cids]Entry = [_]Entry{.{}} ** max_local_active_cids,
+    occupied: [max_local_active_cids]bool = [_]bool{false} ** max_local_active_cids,
     next_sequence: u64 = 0,
     largest_advertised_sequence: ?u64 = null,
     metrics: Metrics = .{},
 
-    pub fn init(peer_active_connection_id_limit: u64, reset_token_key: [32]u8) LocalCidRegistry {
-        var key = secrets.FixedSecret(32){};
-        key.replace(&reset_token_key) catch unreachable;
-        return .{
+    /// Construct the registry in place, borrowing `reset_key` rather than
+    /// taking it by value. `init` (below) is convenient for tests, but a
+    /// by-value `[32]u8` parameter plus a return-by-value result both leave
+    /// an extra semantic copy of the secret that the compiler is not
+    /// guaranteed to elide — the production owner (`Connection`) uses this
+    /// instead.
+    pub fn initInto(out: *LocalCidRegistry, peer_active_connection_id_limit: u64, reset_key: []const u8) void {
+        out.* = .{
             .active_limit = @min(peer_active_connection_id_limit, max_local_active_cids),
-            .reset_token_key = key,
         };
+        out.reset_token_key.replace(reset_key) catch unreachable;
+    }
+
+    pub fn init(peer_active_connection_id_limit: u64, reset_token_key: [32]u8) LocalCidRegistry {
+        var out: LocalCidRegistry = undefined;
+        initInto(&out, peer_active_connection_id_limit, &reset_token_key);
+        return out;
     }
 
     pub fn deinit(self: *LocalCidRegistry) void {
-        for (&self.entries) |*slot| {
-            if (slot.*) |*entry| {
-                secrets.secureZero(&entry.stateless_reset_token);
-            }
-            slot.* = null;
+        for (&self.entries, &self.occupied) |*entry, *occupied| {
+            if (occupied.*) secrets.secureZero(&entry.stateless_reset_token);
+            occupied.* = false;
         }
         self.reset_token_key.deinit();
         self.next_sequence = 0;
@@ -209,20 +225,19 @@ pub const LocalCidRegistry = struct {
         if (self.activeCount() >= self.active_limit) return error.CidLimitExceeded;
         // Repeated caller entropy must not mint the same CID twice under
         // different sequence numbers.
-        for (self.entries) |existing| {
-            if (existing) |entry| {
-                if (std.mem.eql(u8, entry.cid.slice(), cid.slice())) return error.DuplicateCid;
-            }
+        for (self.entries, self.occupied) |entry, occupied| {
+            if (occupied and std.mem.eql(u8, entry.cid.slice(), cid.slice())) return error.DuplicateCid;
         }
-        const slot = for (&self.entries) |*entry| {
-            if (entry.* == null) break entry;
+        const slot_idx = for (self.occupied, 0..) |occupied, i| {
+            if (!occupied) break i;
         } else return error.CidLimitExceeded;
         const entry = Entry{
             .sequence = self.next_sequence,
             .cid = cid,
             .stateless_reset_token = statelessResetToken(self.reset_token_key.slice(), cid.slice()),
         };
-        slot.* = entry;
+        self.entries[slot_idx] = entry;
+        self.occupied[slot_idx] = true;
         self.next_sequence += 1;
         return entry;
     }
@@ -234,12 +249,12 @@ pub const LocalCidRegistry = struct {
     pub fn retire(self: *LocalCidRegistry, frame: RetireConnectionIdFrame) error{ProtocolViolation}!?ConnectionId {
         const largest = self.largest_advertised_sequence orelse return error.ProtocolViolation;
         if (frame.sequence > largest) return error.ProtocolViolation;
-        for (&self.entries) |*slot| {
-            const entry = &(slot.* orelse continue);
+        for (&self.entries, &self.occupied) |*entry, *occupied| {
+            if (!occupied.*) continue;
             if (entry.sequence != frame.sequence) continue;
             const cid = entry.cid;
             secrets.secureZero(&entry.stateless_reset_token);
-            slot.* = null;
+            occupied.* = false;
             self.metrics.local_cids_retired += 1;
             return cid;
         }
@@ -260,35 +275,29 @@ pub const LocalCidRegistry = struct {
 
     pub fn activeCount(self: *const LocalCidRegistry) usize {
         var active: usize = 0;
-        for (self.entries) |entry| {
-            if (entry != null) active += 1;
+        for (self.occupied) |occupied| {
+            if (occupied) active += 1;
         }
         return active;
     }
 
     pub fn get(self: *const LocalCidRegistry, sequence: u64) ?Entry {
-        for (self.entries) |entry| {
-            if (entry) |value| {
-                if (value.sequence == sequence) return value;
-            }
+        for (self.entries, self.occupied) |entry, occupied| {
+            if (occupied and entry.sequence == sequence) return entry;
         }
         return null;
     }
 
     pub fn containsCid(self: *const LocalCidRegistry, cid: ConnectionId) bool {
-        for (self.entries) |entry| {
-            if (entry) |value| {
-                if (std.mem.eql(u8, value.cid.slice(), cid.slice())) return true;
-            }
+        for (self.entries, self.occupied) |entry, occupied| {
+            if (occupied and std.mem.eql(u8, entry.cid.slice(), cid.slice())) return true;
         }
         return false;
     }
 
     pub fn sequenceForCid(self: *const LocalCidRegistry, cid: ConnectionId) ?u64 {
-        for (self.entries) |entry| {
-            if (entry) |value| {
-                if (std.mem.eql(u8, value.cid.slice(), cid.slice())) return value.sequence;
-            }
+        for (self.entries, self.occupied) |entry, occupied| {
+            if (occupied and std.mem.eql(u8, entry.cid.slice(), cid.slice())) return entry.sequence;
         }
         return null;
     }
@@ -654,23 +663,23 @@ test "local registry deinit clears issued entries" {
     _ = try registry.issue(&entropy, 8);
     try testing.expect(registry.activeCount() > 0);
 
-    // Capture raw pointers into the still-populated storage before deinit:
+    // Capture raw pointers into the always-live entry storage before deinit:
     // `activeCount() == 0` and `reset_token_key.len == 0` alone would also
-    // pass an implementation that only flips the `?Entry` option tags
-    // without ever touching the token/key payload bytes.
-    var token_ptrs: [max_local_active_cids]?*const [stateless_reset_token_len]u8 = .{null} ** max_local_active_cids;
-    for (&registry.entries, 0..) |*slot, i| {
-        if (slot.*) |*entry| token_ptrs[i] = &entry.stateless_reset_token;
-    }
-    try testing.expect(token_ptrs[0] != null);
+    // pass an implementation that only flipped `occupied` without ever
+    // touching the token/key payload bytes. `entries[i].stateless_reset_token`
+    // stays addressable regardless of `occupied[i]`, so this read is
+    // well-defined even after the slot is cleared.
+    var was_occupied: [max_local_active_cids]bool = undefined;
+    for (&was_occupied, registry.occupied) |*w, occupied| w.* = occupied;
+    try testing.expect(was_occupied[0]);
     const key_ptr = &registry.reset_token_key.bytes;
 
     registry.deinit();
     try testing.expectEqual(@as(usize, 0), registry.activeCount());
     try testing.expectEqual(@as(usize, 0), registry.reset_token_key.len);
-    for (token_ptrs) |maybe_ptr| {
-        const ptr = maybe_ptr orelse continue;
-        for (ptr) |byte| try testing.expectEqual(@as(u8, 0), byte);
+    for (registry.entries, was_occupied) |entry, occupied| {
+        if (!occupied) continue;
+        for (entry.stateless_reset_token) |byte| try testing.expectEqual(@as(u8, 0), byte);
     }
     for (key_ptr) |byte| try testing.expectEqual(@as(u8, 0), byte);
 }
@@ -683,13 +692,15 @@ test "retire wipes the stateless reset token bytes, not just the entry slot" {
     const issued = try registry.issue(&entropy, 8);
     try registry.markAdvertised(issued.sequence);
 
-    var token_ptr: ?*const [stateless_reset_token_len]u8 = null;
-    for (&registry.entries) |*slot| {
-        if (slot.*) |*entry| {
-            if (entry.sequence == issued.sequence) token_ptr = &entry.stateless_reset_token;
-        }
+    var slot_idx: ?usize = null;
+    for (registry.entries, registry.occupied, 0..) |entry, occupied, i| {
+        if (occupied and entry.sequence == issued.sequence) slot_idx = i;
     }
-    const token = token_ptr orelse return error.TestUnexpectedResult;
+    const idx = slot_idx orelse return error.TestUnexpectedResult;
+    // `entries[idx].stateless_reset_token` stays addressable regardless of
+    // `occupied[idx]`, so reading it after `retire()` clears the slot below
+    // is well-defined — unlike reading through a dead `?Entry` payload.
+    const token = &registry.entries[idx].stateless_reset_token;
     var saw_nonzero = false;
     for (token) |byte| {
         if (byte != 0) saw_nonzero = true;

--- a/src/quic/cid.zig
+++ b/src/quic/cid.zig
@@ -13,6 +13,7 @@
 
 const std = @import("std");
 const udp = @import("udp.zig");
+const secrets = @import("crypto_secrets");
 
 const HmacSha256 = std.crypto.auth.hmac.sha2.HmacSha256;
 
@@ -145,17 +146,31 @@ pub const LocalCidRegistry = struct {
     /// min(peer's active_connection_id_limit, local storage bound).
     active_limit: u64,
     /// Static secret for stateless-reset token derivation (RFC 9000 §10.3.1).
-    reset_token_key: [32]u8,
+    reset_token_key: secrets.FixedSecret(32),
     entries: [max_local_active_cids]?Entry = [_]?Entry{null} ** max_local_active_cids,
     next_sequence: u64 = 0,
     largest_advertised_sequence: ?u64 = null,
     metrics: Metrics = .{},
 
     pub fn init(peer_active_connection_id_limit: u64, reset_token_key: [32]u8) LocalCidRegistry {
+        var key = secrets.FixedSecret(32){};
+        key.replace(&reset_token_key) catch unreachable;
         return .{
             .active_limit = @min(peer_active_connection_id_limit, max_local_active_cids),
-            .reset_token_key = reset_token_key,
+            .reset_token_key = key,
         };
+    }
+
+    pub fn deinit(self: *LocalCidRegistry) void {
+        for (&self.entries) |*slot| {
+            if (slot.*) |*entry| {
+                secrets.secureZero(&entry.stateless_reset_token);
+            }
+            slot.* = null;
+        }
+        self.reset_token_key.deinit();
+        self.next_sequence = 0;
+        self.largest_advertised_sequence = null;
     }
 
     /// Register the CID chosen during the handshake as sequence 0
@@ -205,7 +220,7 @@ pub const LocalCidRegistry = struct {
         const entry = Entry{
             .sequence = self.next_sequence,
             .cid = cid,
-            .stateless_reset_token = statelessResetToken(self.reset_token_key, cid.slice()),
+            .stateless_reset_token = statelessResetToken(self.reset_token_key.slice(), cid.slice()),
         };
         slot.* = entry;
         self.next_sequence += 1;
@@ -223,6 +238,7 @@ pub const LocalCidRegistry = struct {
             const entry = &(slot.* orelse continue);
             if (entry.sequence != frame.sequence) continue;
             const cid = entry.cid;
+            secrets.secureZero(&entry.stateless_reset_token);
             slot.* = null;
             self.metrics.local_cids_retired += 1;
             return cid;
@@ -436,10 +452,13 @@ pub const stateless_reset_token_len = 16;
 /// static server key (RFC 9000 §10.3.1). The token is the first 16 bytes of
 /// HMAC-SHA256(static_key, connection_id); it MUST be hard to guess, so the
 /// static key must be secret and stable across the connection's lifetime.
-pub fn statelessResetToken(static_key: [32]u8, connection_id: []const u8) [stateless_reset_token_len]u8 {
+pub fn statelessResetToken(static_key: []const u8, connection_id: []const u8) [stateless_reset_token_len]u8 {
     var mac: [HmacSha256.mac_length]u8 = undefined;
-    HmacSha256.create(&mac, connection_id, &static_key);
-    return mac[0..stateless_reset_token_len].*;
+    defer secrets.secureZero(&mac);
+    HmacSha256.create(&mac, connection_id, static_key);
+    var token: [stateless_reset_token_len]u8 = undefined;
+    @memcpy(&token, mac[0..stateless_reset_token_len]);
+    return token;
 }
 
 /// Emission rules and packet construction for stateless resets (RFC 9000 §10.3).
@@ -491,15 +510,15 @@ test "stateless reset token is a stable function of the connection ID" {
     const key = [_]u8{0xab} ** 32;
     const cid = [_]u8{ 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
 
-    const token = statelessResetToken(key, &cid);
+    const token = statelessResetToken(key[0..], &cid);
     // Deterministic for a given key + CID.
-    try testing.expectEqualSlices(u8, &token, &statelessResetToken(key, &cid));
+    try testing.expectEqualSlices(u8, &token, &statelessResetToken(key[0..], &cid));
 
     // A different CID or key yields a different token.
     const other_cid = [_]u8{ 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x09 };
-    try testing.expect(!std.mem.eql(u8, &token, &statelessResetToken(key, &other_cid)));
+    try testing.expect(!std.mem.eql(u8, &token, &statelessResetToken(key[0..], &other_cid)));
     const other_key = [_]u8{0xcd} ** 32;
-    try testing.expect(!std.mem.eql(u8, &token, &statelessResetToken(other_key, &cid)));
+    try testing.expect(!std.mem.eql(u8, &token, &statelessResetToken(other_key[0..], &cid)));
 }
 
 test "stateless reset is only emitted for packets large enough to answer safely" {
@@ -618,7 +637,7 @@ test "local registry enforces the peer's active CID limit and derives reset toke
     const issued = try registry.issue(&entropy, 8);
     try registry.markAdvertised(issued.sequence);
     // The frame's token matches the RFC 9000 §10.3.1 derivation for the CID.
-    try testing.expectEqualSlices(u8, &statelessResetToken(key, issued.cid.slice()), &issued.stateless_reset_token);
+    try testing.expectEqualSlices(u8, &statelessResetToken(key[0..], issued.cid.slice()), &issued.stateless_reset_token);
 
     // Limit of 2 is reached: further issuance must fail until one retires.
     var more_entropy = [_]u8{0x30} ** 8;
@@ -626,6 +645,18 @@ test "local registry enforces the peer's active CID limit and derives reset toke
     _ = try registry.retire(.{ .sequence = issued.sequence });
     _ = try registry.issue(&more_entropy, 8);
     try testing.expectEqual(@as(usize, 2), registry.activeCount());
+}
+
+test "local registry deinit clears issued entries" {
+    var registry = LocalCidRegistry.init(4, [_]u8{0x55} ** 32);
+    _ = try registry.registerInitial(try ConnectionId.init(&.{ 1, 2, 3, 4 }));
+    var entropy = [_]u8{0x42} ** 8;
+    _ = try registry.issue(&entropy, 8);
+    try testing.expect(registry.activeCount() > 0);
+
+    registry.deinit();
+    try testing.expectEqual(@as(usize, 0), registry.activeCount());
+    try testing.expectEqual(@as(usize, 0), registry.reset_token_key.len);
 }
 
 test "peer pool validates NEW_CONNECTION_ID and sweeps retire_prior_to" {

--- a/src/quic/cid.zig
+++ b/src/quic/cid.zig
@@ -39,10 +39,10 @@ pub fn generateCid(entropy: []const u8, len: u8) error{ InvalidCidLength, NotEno
 // ---------------------------------------------------------------------------
 
 pub const NewConnectionIdFrame = struct {
-    sequence: u64,
-    retire_prior_to: u64,
-    cid: ConnectionId,
-    stateless_reset_token: [stateless_reset_token_len]u8,
+    sequence: u64 = 0,
+    retire_prior_to: u64 = 0,
+    cid: ConnectionId = .{},
+    stateless_reset_token: [stateless_reset_token_len]u8 = [_]u8{0} ** stateless_reset_token_len,
 };
 
 pub const RetireConnectionIdFrame = struct {

--- a/src/quic/config.zig
+++ b/src/quic/config.zig
@@ -6,6 +6,7 @@
 //! defaults until benchmarks or interop require public knobs.
 
 const std = @import("std");
+const secrets = @import("crypto_secrets");
 
 pub const QuicVersion = enum(u32) {
     v1 = 0x00000001,
@@ -176,6 +177,13 @@ pub const CidBinding = struct {
     retry_source_connection_id: ?CidValue = null,
     /// Server only.
     stateless_reset_token: ?[16]u8 = null,
+
+    /// Wipes the only secret-bearing field before this binding (a local, a
+    /// retained backend copy, or a peer-supplied copy) is discarded.
+    pub fn deinit(self: *CidBinding) void {
+        if (self.stateless_reset_token) |*token| secrets.secureZero(token);
+        self.stateless_reset_token = null;
+    }
 };
 
 test "default QUIC config maps to conservative transport parameters" {

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -734,27 +734,31 @@ fn wipeSentRecordTokens(records: []SentRecord) void {
 }
 
 /// `std.ArrayList.swapRemove` moves the last live element into the removed
-/// slot but only assigns `undefined` (a no-op at runtime, not a real write)
-/// to the vacated tail slot, so a byte-for-byte duplicate of whatever
-/// occupied that tail position survives at `items.ptr[items.len]` — within
-/// the backing allocation, just past the shrunk `.items` slice — until the
-/// allocator reuses it. Call this immediately after every
-/// `sent_records.swapRemove(...)` to scrub that residue.
+/// slot, then assigns `undefined` to the vacated tail slot — which is a
+/// real poison-fill in safety-checked builds (not a no-op) and may be no
+/// write at all in `ReleaseFast`. Either way, that slot is no longer a
+/// validly-typed `SentRecord`: its optional tags may be garbage. Call this
+/// immediately after every `sent_records.swapRemove(...)` — it scrubs the
+/// vacated slot as raw bytes only, never interpreting any field, so it
+/// cannot read an undefined optional tag the way pattern-matching
+/// `carried_new_connection_id` on that slot would. Callers must wipe the
+/// *live* element's own token (via `wipeSentRecordToken`) before calling
+/// `swapRemove`, since this only cleans up the residue the swap leaves
+/// behind, not the record being removed.
 fn wipeSentRecordsSwapRemoveResidue(records: *std.ArrayList(SentRecord)) void {
-    wipeSentRecordToken(&records.allocatedSlice()[records.items.len]);
+    crypto_secrets.secureZero(std.mem.asBytes(&records.allocatedSlice()[records.items.len]));
 }
 
 fn wipePendingNewConnectionIdTokens(frames: []quic_cid.NewConnectionIdFrame) void {
     for (frames) |*ncid| crypto_secrets.secureZero(&ncid.stateless_reset_token);
 }
 
-/// Same residue as `wipeSentRecordsSwapRemoveResidue`, but for
-/// `pending_new_connection_ids.orderedRemove(0)`: `replaceRangeAssumeCapacity`
-/// shifts the remaining frames down and marks the vacated tail slot
-/// `undefined`, which is not guaranteed to actually clear the bytes in every
-/// build mode. Scrub it explicitly.
+/// Same hazard as `wipeSentRecordsSwapRemoveResidue`, but for
+/// `pending_new_connection_ids.orderedRemove(0)`: scrub the vacated slot as
+/// raw bytes rather than selecting a field from a `NewConnectionIdFrame`
+/// whose representation is no longer guaranteed valid.
 fn wipePendingNewConnectionIdsOrderedRemoveResidue(frames: *std.ArrayList(quic_cid.NewConnectionIdFrame)) void {
-    crypto_secrets.secureZero(&frames.allocatedSlice()[frames.items.len].stateless_reset_token);
+    crypto_secrets.secureZero(std.mem.asBytes(&frames.allocatedSlice()[frames.items.len]));
 }
 
 /// A candidate path (RFC 9000 §9.3/§9.5) we are validating: the
@@ -922,6 +926,20 @@ pub const Connection = struct {
         conn.paths = quic_path.PathManager.init(conn.cfg.migration_policy, options.initial_path, initial_validated);
         errdefer conn.deinitPartial();
 
+        // Reserve the full capacity these two collections can ever need,
+        // before any locally-generated stateless-reset token is queued into
+        // them: `sent_records` cannot exceed `recovery.max_tracked_packets`
+        // (every append is gated by a successful recovery-tracker insert,
+        // itself bounded there), and `pending_new_connection_ids` cannot
+        // exceed `quic_cid.max_local_active_cids` (the local CID registry's
+        // own issuance limit). With capacity reserved up front, later
+        // `append`/`ensureUnusedCapacity` calls never trigger `std.ArrayList`'s
+        // grow-and-free-the-old-backing-unwiped path, which would otherwise
+        // copy a live reset token into a new allocation and free the old one
+        // without scrubbing it.
+        try conn.sent_records.ensureTotalCapacityPrecise(allocator, recovery.max_tracked_packets);
+        try conn.pending_new_connection_ids.ensureTotalCapacityPrecise(allocator, quic_cid.max_local_active_cids);
+
         // RFC 9000 §7.3 binding: commit our CIDs into the TLS transport
         // parameters before the first flight.
         var binding = config.CidBinding{
@@ -1052,10 +1070,10 @@ pub const Connection = struct {
     pub fn copyActiveLocalCids(self: *const Connection, out: []quic_cid.ConnectionId) usize {
         var count: usize = 0;
         if (self.local_cids) |registry| {
-            for (registry.entries) |entry| {
-                if (entry) |value| {
+            for (registry.entries, registry.occupied) |entry, occupied| {
+                if (occupied) {
                     if (count == out.len) return count;
-                    out[count] = value.cid;
+                    out[count] = entry.cid;
                     count += 1;
                 }
             }
@@ -1634,7 +1652,7 @@ pub const Connection = struct {
         // comes from the largest acked packet (RFC 9002 §5.1).
         var index: usize = 0;
         while (index < self.sent_records.items.len) {
-            const record = self.sent_records.items[index];
+            const record = &self.sent_records.items[index];
             if (record.space != space or !ack.ranges.contains(record.packet_number)) {
                 index += 1;
                 continue;
@@ -1646,6 +1664,14 @@ pub const Connection = struct {
                 }
             }
             self.onRecordAcked(record);
+            // Delivery is confirmed: any reset token this record carried
+            // has done its job (the registry keeps the durable copy for as
+            // long as the CID stays active) and is now redundant. Wipe it
+            // here, on the still-live, validly-typed element, before
+            // `swapRemove` — the vacated slot the swap leaves behind gets a
+            // separate raw-byte wipe below, since it is no longer safe to
+            // interpret as a typed `SentRecord`.
+            wipeSentRecordToken(record);
             _ = self.sent_records.swapRemove(index);
             wipeSentRecordsSwapRemoveResidue(&self.sent_records);
         }
@@ -1655,7 +1681,7 @@ pub const Connection = struct {
         self.detectAndRequeueLost(space, now_us);
     }
 
-    fn onRecordAcked(self: *Connection, record: SentRecord) void {
+    fn onRecordAcked(self: *Connection, record: *const SentRecord) void {
         if (record.carried_handshake_done) self.handshake_done_acked = true;
         if (record.crypto) |range| {
             if (record.space == .application) self.crypto_tx[2].markAcked(self.allocator, range);
@@ -1678,13 +1704,18 @@ pub const Connection = struct {
         var index: usize = 0;
         var lost_count: u64 = 0;
         while (index < self.sent_records.items.len) {
-            const record = self.sent_records.items[index];
+            const record = &self.sent_records.items[index];
             if (record.space != space or self.trackerContains(space, record.packet_number)) {
                 index += 1;
                 continue;
             }
             lost_count += 1;
+            // Read the live element to requeue its content (a fresh copy of
+            // any carried reset token lands in `pending_new_connection_ids`
+            // via `requeueRecord`) before wiping this now-redundant copy and
+            // removing the record.
             self.requeueRecord(record);
+            wipeSentRecordToken(record);
             _ = self.sent_records.swapRemove(index);
             wipeSentRecordsSwapRemoveResidue(&self.sent_records);
         }
@@ -1702,7 +1733,7 @@ pub const Connection = struct {
     }
 
     /// Requeue everything a lost packet carried.
-    fn requeueRecord(self: *Connection, record: SentRecord) void {
+    fn requeueRecord(self: *Connection, record: *const SentRecord) void {
         if (record.crypto) |range| {
             const tx = switch (record.space) {
                 .initial => &self.crypto_tx[0],
@@ -1736,7 +1767,9 @@ pub const Connection = struct {
         if (record.carried_stop_sending) |stop| {
             self.pending_stop_sending.append(self.allocator, stop) catch {};
         }
-        if (record.carried_new_connection_id) |ncid| {
+        if (record.carried_new_connection_id) |ncid_value| {
+            var ncid = ncid_value;
+            defer crypto_secrets.secureZero(&ncid.stateless_reset_token);
             self.pending_new_connection_ids.append(self.allocator, ncid) catch {};
         }
         if (record.carried_path_challenge_path) |path| {
@@ -1868,6 +1901,11 @@ pub const Connection = struct {
         var index: usize = 0;
         while (index < self.sent_records.items.len) {
             if (self.sent_records.items[index].space == .initial) {
+                // NEW_CONNECTION_ID frames are only ever attached to
+                // `.application`-space records, so this is a no-op in
+                // practice; wipe defensively so that invariant is never
+                // load-bearing for correctness here.
+                wipeSentRecordToken(&self.sent_records.items[index]);
                 _ = self.sent_records.swapRemove(index);
                 wipeSentRecordsSwapRemoveResidue(&self.sent_records);
             } else index += 1;
@@ -2066,13 +2104,15 @@ pub const Connection = struct {
             return;
         };
         if (self.local_cids == null) {
-            // Construct the registry directly in `self.local_cids` rather
-            // than through a stack-local intermediate: the latter would
-            // leave a second, never-wiped copy of the reset-token key
-            // behind in this frame after the assignment below. Once the
-            // registry holds its own copy, `self.stateless_reset_key` is
-            // redundant and gets wiped immediately.
-            self.local_cids = quic_cid.LocalCidRegistry.init(peer_params.active_connection_id_limit, self.stateless_reset_key);
+            // Construct the registry in place via `initInto`, which borrows
+            // `self.stateless_reset_key` instead of taking it by value: a
+            // by-value parameter (or a return-by-value constructor) would
+            // leave an extra semantic copy of the secret that the compiler
+            // is not guaranteed to elide. Once the registry holds its own
+            // copy, `self.stateless_reset_key` is redundant and gets wiped
+            // immediately.
+            self.local_cids = .{};
+            quic_cid.LocalCidRegistry.initInto(&self.local_cids.?, peer_params.active_connection_id_limit, &self.stateless_reset_key);
             crypto_secrets.secureZero(&self.stateless_reset_key);
             const registry = &self.local_cids.?;
             const initial = quic_cid.ConnectionId.init(self.local_cid.slice()) catch {
@@ -2182,6 +2222,9 @@ pub const Connection = struct {
         var index: usize = 0;
         while (index < self.sent_records.items.len) {
             if (self.sent_records.items[index].space == space) {
+                // Defensive, as above: NEW_CONNECTION_ID frames only ever
+                // ride `.application`-space records.
+                wipeSentRecordToken(&self.sent_records.items[index]);
                 _ = self.sent_records.swapRemove(index);
                 wipeSentRecordsSwapRemoveResidue(&self.sent_records);
             } else index += 1;
@@ -2357,7 +2400,7 @@ pub const Connection = struct {
                 oldest = i;
             }
         }
-        if (oldest) |i| self.requeueRecord(self.sent_records.items[i]);
+        if (oldest) |i| self.requeueRecord(&self.sent_records.items[i]);
     }
 
     fn armIdle(self: *Connection, now_us: u64) void {
@@ -2867,6 +2910,13 @@ pub const Connection = struct {
             .packet_number = pn,
             .ack_eliciting = false,
         };
+        // `record` may pick up a dequeued NEW_CONNECTION_ID's reset token
+        // below; `self.sent_records.append` (if reached) copies it into the
+        // owned, tracked record, but this local stays around until every
+        // return path below (including early failures after the token was
+        // already dequeued and encoded) unwinds. Wipe it unconditionally on
+        // the way out — a no-op when no token was ever attached.
+        defer wipeSentRecordToken(&record);
 
         // 1) ACK
         if (want_ack) {
@@ -3104,11 +3154,15 @@ pub const Connection = struct {
             _ = self.pending_retires.orderedRemove(0);
         }
         if (self.pending_new_connection_ids.items.len > 0) {
-            const ncid = self.pending_new_connection_ids.items[0];
-            if (frame.encodeNewConnectionId(ncid, plain[plain_len..budget])) |n| {
+            // Encode and assign directly from the queued element rather
+            // than through an intermediate `const ncid = ...` local: that
+            // would leave a third, unwiped stack copy of the reset token
+            // (beyond the queue's own copy and the one `record` ends up
+            // owning) sitting around for the rest of this function.
+            if (frame.encodeNewConnectionId(self.pending_new_connection_ids.items[0], plain[plain_len..budget])) |n| {
                 plain_len += n;
                 record.ack_eliciting = true;
-                record.carried_new_connection_id = ncid;
+                record.carried_new_connection_id = self.pending_new_connection_ids.items[0];
                 _ = self.pending_new_connection_ids.orderedRemove(0);
                 wipePendingNewConnectionIdsOrderedRemoveResidue(&self.pending_new_connection_ids);
             } else |_| {}
@@ -4889,7 +4943,7 @@ test "driver: server NewSessionTicket uses application CRYPTO retransmission and
     const sent = pair.server.sent_records.items[pair.server.sent_records.items.len - 1];
     try testing.expectEqual(PacketNumberSpace.application, sent.space);
     try testing.expect(sent.crypto != null);
-    pair.server.requeueRecord(sent);
+    pair.server.requeueRecord(&sent);
 
     try pair.pump();
     try testing.expectEqual(@as(usize, 1), capture.count);
@@ -4947,7 +5001,7 @@ test "driver: two-phase prepare/emit NewSessionTicket delivers over application 
     const sent = pair.server.sent_records.items[pair.server.sent_records.items.len - 1];
     try testing.expectEqual(PacketNumberSpace.application, sent.space);
     try testing.expect(sent.crypto != null);
-    pair.server.requeueRecord(sent);
+    pair.server.requeueRecord(&sent);
 
     try pair.pump();
     try testing.expectEqual(@as(usize, 1), capture.count);
@@ -6852,7 +6906,7 @@ test "connection: lost NEW_CONNECTION_ID retransmits the same frame identity" {
     try testing.expectEqual(@as(u64, 1), first.sequence);
     try testing.expectEqualSlices(u8, spare.slice(), first.cid.slice());
 
-    pair.server.requeueRecord(first_record);
+    pair.server.requeueRecord(&first_record);
     _ = pair.server.pollTransmitOnPath(&out, pair.now_us + 1_000) orelse return error.TestExpectedEqual;
     const second_record = pair.server.sent_records.items[pair.server.sent_records.items.len - 1];
     const second = second_record.carried_new_connection_id orelse return error.TestExpectedEqual;
@@ -6915,7 +6969,7 @@ test "connection: losing one NEW_CONNECTION_ID leaves all queued CID identities 
     try testing.expectEqual(@as(usize, 1), pair.server.pending_new_connection_ids.items.len);
     try testing.expectEqualSlices(u8, second_cid.slice(), pair.server.pending_new_connection_ids.items[0].cid.slice());
 
-    pair.server.requeueRecord(sent);
+    pair.server.requeueRecord(&sent);
     try testing.expectEqual(@as(usize, 2), pair.server.pending_new_connection_ids.items.len);
     var saw_first = false;
     var saw_second = false;
@@ -6930,6 +6984,86 @@ test "connection: losing one NEW_CONNECTION_ID leaves all queued CID identities 
     }
     try testing.expect(saw_first);
     try testing.expect(saw_second);
+}
+
+test "wipeSentRecordsSwapRemoveResidue zeroes the vacated slot regardless of its prior byte pattern" {
+    var records: std.ArrayList(SentRecord) = .empty;
+    defer records.deinit(testing.allocator);
+    try records.ensureTotalCapacityPrecise(testing.allocator, 4);
+    records.appendAssumeCapacity(.{ .space = .application, .packet_number = 1, .ack_eliciting = false });
+    records.appendAssumeCapacity(.{ .space = .application, .packet_number = 2, .ack_eliciting = false });
+
+    _ = records.swapRemove(0);
+    // Simulate whatever a safety-checked build's poison-fill (or a
+    // `ReleaseFast` build's leftover live data) might put in the vacated
+    // slot: an arbitrary, non-zero byte pattern that would be an invalid
+    // `?NewConnectionIdFrame` tag if ever misinterpreted as a typed
+    // `SentRecord` rather than treated as opaque bytes.
+    const ghost = std.mem.asBytes(&records.allocatedSlice()[records.items.len]);
+    @memset(ghost, 0xaa);
+
+    wipeSentRecordsSwapRemoveResidue(&records);
+    for (ghost) |byte| try testing.expectEqual(@as(u8, 0), byte);
+}
+
+test "wipePendingNewConnectionIdsOrderedRemoveResidue zeroes the vacated slot regardless of its prior byte pattern" {
+    var frames: std.ArrayList(quic_cid.NewConnectionIdFrame) = .empty;
+    defer frames.deinit(testing.allocator);
+    try frames.ensureTotalCapacityPrecise(testing.allocator, 4);
+    frames.appendAssumeCapacity(.{
+        .sequence = 1,
+        .retire_prior_to = 0,
+        .cid = try quic_cid.ConnectionId.init(&.{ 1, 2, 3, 4 }),
+        .stateless_reset_token = [_]u8{0xcd} ** quic_cid.stateless_reset_token_len,
+    });
+    frames.appendAssumeCapacity(.{
+        .sequence = 2,
+        .retire_prior_to = 0,
+        .cid = try quic_cid.ConnectionId.init(&.{ 5, 6, 7, 8 }),
+        .stateless_reset_token = [_]u8{0xef} ** quic_cid.stateless_reset_token_len,
+    });
+
+    _ = frames.orderedRemove(0);
+    const ghost = std.mem.asBytes(&frames.allocatedSlice()[frames.items.len]);
+    @memset(ghost, 0xaa);
+
+    wipePendingNewConnectionIdsOrderedRemoveResidue(&frames);
+    for (ghost) |byte| try testing.expectEqual(@as(u8, 0), byte);
+}
+
+test "connection: sent_records and pending_new_connection_ids reserve capacity once and never regrow" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+
+    // `Connection.init` reserves the full protocol-bounded capacity for
+    // both collections before either can ever hold a locally-generated
+    // reset token.
+    try testing.expect(pair.server.sent_records.capacity >= recovery.max_tracked_packets);
+    try testing.expect(pair.server.pending_new_connection_ids.capacity >= quic_cid.max_local_active_cids);
+
+    const sent_records_backing = pair.server.sent_records.items.ptr;
+    const pending_backing = pair.server.pending_new_connection_ids.items.ptr;
+
+    // Push `sent_records` all the way to the protocol bound directly
+    // (bypassing the recovery-tracker gate, which is exactly what keeps it
+    // under that bound in production): if capacity were not already
+    // reserved, appends anywhere in this loop would trigger
+    // `std.ArrayList`'s grow-and-free-the-old-backing-unwiped path. The
+    // backing pointer staying fixed throughout proves that never happens.
+    var i: usize = 0;
+    while (i < recovery.max_tracked_packets) : (i += 1) {
+        try pair.server.sent_records.append(pair.server.allocator, .{
+            .space = .application,
+            .packet_number = i,
+            .ack_eliciting = false,
+        });
+    }
+    try testing.expectEqual(sent_records_backing, pair.server.sent_records.items.ptr);
+    try testing.expectEqual(@as(usize, recovery.max_tracked_packets), pair.server.sent_records.capacity);
+
+    try pair.pump();
+    try testing.expectEqual(pending_backing, pair.server.pending_new_connection_ids.items.ptr);
 }
 
 test "connection: teardown scrubs a still-pending and an in-flight NEW_CONNECTION_ID's reset token" {

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -720,6 +720,43 @@ const SentRecord = struct {
     };
 };
 
+/// Wipe a `SentRecord`'s carried stateless-reset token copy in place. A
+/// `NewConnectionIdFrame` embeds the token by value, so every place that
+/// copies, requeues, or discards a `SentRecord` mints or drops an
+/// independent copy of it; each of those copies must be scrubbed once it is
+/// no longer needed rather than left for the allocator to reclaim unwiped.
+fn wipeSentRecordToken(record: *SentRecord) void {
+    if (record.carried_new_connection_id) |*ncid| crypto_secrets.secureZero(&ncid.stateless_reset_token);
+}
+
+fn wipeSentRecordTokens(records: []SentRecord) void {
+    for (records) |*record| wipeSentRecordToken(record);
+}
+
+/// `std.ArrayList.swapRemove` moves the last live element into the removed
+/// slot but only assigns `undefined` (a no-op at runtime, not a real write)
+/// to the vacated tail slot, so a byte-for-byte duplicate of whatever
+/// occupied that tail position survives at `items.ptr[items.len]` — within
+/// the backing allocation, just past the shrunk `.items` slice — until the
+/// allocator reuses it. Call this immediately after every
+/// `sent_records.swapRemove(...)` to scrub that residue.
+fn wipeSentRecordsSwapRemoveResidue(records: *std.ArrayList(SentRecord)) void {
+    wipeSentRecordToken(&records.allocatedSlice()[records.items.len]);
+}
+
+fn wipePendingNewConnectionIdTokens(frames: []quic_cid.NewConnectionIdFrame) void {
+    for (frames) |*ncid| crypto_secrets.secureZero(&ncid.stateless_reset_token);
+}
+
+/// Same residue as `wipeSentRecordsSwapRemoveResidue`, but for
+/// `pending_new_connection_ids.orderedRemove(0)`: `replaceRangeAssumeCapacity`
+/// shifts the remaining frames down and marks the vacated tail slot
+/// `undefined`, which is not guaranteed to actually clear the bytes in every
+/// build mode. Scrub it explicitly.
+fn wipePendingNewConnectionIdsOrderedRemoveResidue(frames: *std.ArrayList(quic_cid.NewConnectionIdFrame)) void {
+    crypto_secrets.secureZero(&frames.allocatedSlice()[frames.items.len].stateless_reset_token);
+}
+
 /// A candidate path (RFC 9000 §9.3/§9.5) we are validating: the
 /// `PathManager`-issued PATH_CHALLENGE payload and whether the packet
 /// carrying it still needs to go out (initially, and again after loss —
@@ -950,11 +987,17 @@ pub const Connection = struct {
         self.stream_transport_early.deinit();
         self.accept_queue.deinit(self.allocator);
         for (&self.crypto_tx) |*tx| tx.deinit(self.allocator);
+        // Any still-outstanding (unacked/unlost) or still-queued
+        // NEW_CONNECTION_ID carries a stateless-reset token copy; teardown
+        // must scrub those before the backing allocations are freed, not
+        // just the registry's own copy below.
+        wipeSentRecordTokens(self.sent_records.items);
         self.sent_records.deinit(self.allocator);
         self.pending_max_stream_data.deinit(self.allocator);
         self.pending_resets.deinit(self.allocator);
         self.pending_stop_sending.deinit(self.allocator);
         self.pending_retires.deinit(self.allocator);
+        wipePendingNewConnectionIdTokens(self.pending_new_connection_ids.items);
         self.pending_new_connection_ids.deinit(self.allocator);
         self.pending_path_responses.deinit(self.allocator);
         self.candidate_challenges.deinit(self.allocator);
@@ -1604,6 +1647,7 @@ pub const Connection = struct {
             }
             self.onRecordAcked(record);
             _ = self.sent_records.swapRemove(index);
+            wipeSentRecordsSwapRemoveResidue(&self.sent_records);
         }
         // A validated ACK ends the current PTO backoff episode.
         self.pto_count = 0;
@@ -1642,6 +1686,7 @@ pub const Connection = struct {
             lost_count += 1;
             self.requeueRecord(record);
             _ = self.sent_records.swapRemove(index);
+            wipeSentRecordsSwapRemoveResidue(&self.sent_records);
         }
         if (lost_count > 0) {
             self.metrics.packets_lost += lost_count;
@@ -1824,6 +1869,7 @@ pub const Connection = struct {
         while (index < self.sent_records.items.len) {
             if (self.sent_records.items[index].space == .initial) {
                 _ = self.sent_records.swapRemove(index);
+                wipeSentRecordsSwapRemoveResidue(&self.sent_records);
             } else index += 1;
         }
         const tx = &self.crypto_tx[0];
@@ -2020,16 +2066,27 @@ pub const Connection = struct {
             return;
         };
         if (self.local_cids == null) {
-            var registry = quic_cid.LocalCidRegistry.init(peer_params.active_connection_id_limit, self.stateless_reset_key);
+            // Construct the registry directly in `self.local_cids` rather
+            // than through a stack-local intermediate: the latter would
+            // leave a second, never-wiped copy of the reset-token key
+            // behind in this frame after the assignment below. Once the
+            // registry holds its own copy, `self.stateless_reset_key` is
+            // redundant and gets wiped immediately.
+            self.local_cids = quic_cid.LocalCidRegistry.init(peer_params.active_connection_id_limit, self.stateless_reset_key);
+            crypto_secrets.secureZero(&self.stateless_reset_key);
+            const registry = &self.local_cids.?;
             const initial = quic_cid.ConnectionId.init(self.local_cid.slice()) catch {
+                registry.deinit();
+                self.local_cids = null;
                 self.startClose(.{ .error_code = error_internal, .is_application = false, .local = true }, "local cid registry", now_us);
                 return;
             };
             _ = registry.registerInitial(initial) catch {
+                registry.deinit();
+                self.local_cids = null;
                 self.startClose(.{ .error_code = error_internal, .is_application = false, .local = true }, "local cid registry", now_us);
                 return;
             };
-            self.local_cids = registry;
         }
         if (self.streams) |*manager| {
             // 0-RTT already brought the stream layer up early with a
@@ -2126,6 +2183,7 @@ pub const Connection = struct {
         while (index < self.sent_records.items.len) {
             if (self.sent_records.items[index].space == space) {
                 _ = self.sent_records.swapRemove(index);
+                wipeSentRecordsSwapRemoveResidue(&self.sent_records);
             } else index += 1;
         }
         self.ack_needed[spaceIndex(space)] = false;
@@ -3052,6 +3110,7 @@ pub const Connection = struct {
                 record.ack_eliciting = true;
                 record.carried_new_connection_id = ncid;
                 _ = self.pending_new_connection_ids.orderedRemove(0);
+                wipePendingNewConnectionIdsOrderedRemoveResidue(&self.pending_new_connection_ids);
             } else |_| {}
         }
         // Only a PATH_RESPONSE queued for the active path rides along with
@@ -6871,6 +6930,56 @@ test "connection: losing one NEW_CONNECTION_ID leaves all queued CID identities 
     }
     try testing.expect(saw_first);
     try testing.expect(saw_second);
+}
+
+test "connection: teardown scrubs a still-pending and an in-flight NEW_CONNECTION_ID's reset token" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const first_cid = try quic_cid.ConnectionId.init(&.{ 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28 });
+    const second_cid = try quic_cid.ConnectionId.init(&.{ 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38 });
+    try pair.server.advertiseLocalCid(first_cid);
+    try pair.server.advertiseLocalCid(second_cid);
+    try testing.expectEqual(@as(usize, 2), pair.server.pending_new_connection_ids.items.len);
+
+    // Dequeue only the first NEW_CONNECTION_ID into an in-flight sent
+    // record; the second stays queued in `pending_new_connection_ids`.
+    var out: [2048]u8 = undefined;
+    _ = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
+    try testing.expectEqual(@as(usize, 1), pair.server.pending_new_connection_ids.items.len);
+    const sent_index = pair.server.sent_records.items.len - 1;
+    try testing.expect(pair.server.sent_records.items[sent_index].carried_new_connection_id != null);
+
+    var in_flight_nonzero = false;
+    for (pair.server.sent_records.items[sent_index].carried_new_connection_id.?.stateless_reset_token) |b| {
+        if (b != 0) in_flight_nonzero = true;
+    }
+    try testing.expect(in_flight_nonzero);
+    var pending_nonzero = false;
+    for (pair.server.pending_new_connection_ids.items[0].stateless_reset_token) |b| {
+        if (b != 0) pending_nonzero = true;
+    }
+    try testing.expect(pending_nonzero);
+
+    // `std.ArrayList.deinit` runs the freed buffer through `Allocator.free`,
+    // which does its own `@memset(bytes, undefined)` poison-fill before the
+    // real free — so bytes read back *after* a full `Connection.deinit()`
+    // reflect that poison, not whether our own wipe ran (see
+    // `secureZeroAndFree` in crypto/secrets.zig for the same issue). Call
+    // the exact scrub helpers `deinitPartial` calls, directly on this
+    // connection's real pending/in-flight state, and assert what they are
+    // responsible for zeroing.
+    wipeSentRecordTokens(pair.server.sent_records.items);
+    wipePendingNewConnectionIdTokens(pair.server.pending_new_connection_ids.items);
+
+    for (pair.server.sent_records.items[sent_index].carried_new_connection_id.?.stateless_reset_token) |byte| {
+        try testing.expectEqual(@as(u8, 0), byte);
+    }
+    for (pair.server.pending_new_connection_ids.items[0].stateless_reset_token) |byte| {
+        try testing.expectEqual(@as(u8, 0), byte);
+    }
 }
 
 test "driver: idle timeout closes silently" {

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -1126,9 +1126,17 @@ pub const Connection = struct {
         return registry.activeCount() < target;
     }
 
-    pub fn advertiseLocalCid(self: *Connection, cid_value: quic_cid.ConnectionId) error{ CidLimitExceeded, DuplicateCid, OutOfMemory }!void {
-        try self.pending_new_connection_ids.ensureUnusedCapacity(self.allocator, 1);
+    pub fn advertiseLocalCid(self: *Connection, cid_value: quic_cid.ConnectionId) error{ CidLimitExceeded, DuplicateCid }!void {
         const registry = if (self.local_cids) |*registry| registry else return error.CidLimitExceeded;
+        // The queue was deliberately preallocated to its hard bound
+        // (`quic_cid.max_local_active_cids`) in `init()`, so this path must
+        // never call a grow-capable API — not even to discover afterward
+        // that the registry would have rejected the CID. Reject here, before
+        // ever touching the queue, rather than letting `ensureUnusedCapacity`
+        // grow-and-free the backing allocation unwiped first.
+        if (self.pending_new_connection_ids.items.len == self.pending_new_connection_ids.capacity) {
+            return error.CidLimitExceeded;
+        }
         // Write the issued frame directly into the reserved queue slot: the
         // registry entry is the only prior owner of the reset token, so this
         // is its single copy into caller-owned storage, rather than a
@@ -2190,8 +2198,13 @@ pub const Connection = struct {
         self.events.emit(.handshake_complete);
 
         // RFC 9000 §7.3: validate the peer's authenticated CID binding
-        // against what we actually observed on the wire.
-        const peer_binding = self.tls.peerCidBinding();
+        // against what we actually observed on the wire. `peerCidBinding()`
+        // borrows the backend's retained copy rather than returning one by
+        // value; a backend without binding support (the in-memory test
+        // backend) has no hook installed and returns null, equivalent to an
+        // empty binding.
+        const empty_peer_binding = config.CidBinding{};
+        const peer_binding = self.tls.peerCidBinding() orelse &empty_peer_binding;
         if (!self.validateCidBinding(peer_binding)) {
             self.startClose(.{ .error_code = error_transport_parameter, .is_application = false, .local = true }, "cid binding mismatch", now_us);
             return;
@@ -2269,7 +2282,7 @@ pub const Connection = struct {
         }
     }
 
-    fn validateCidBinding(self: *const Connection, peer_binding: config.CidBinding) bool {
+    fn validateCidBinding(self: *const Connection, peer_binding: *const config.CidBinding) bool {
         // Backends without binding support (the in-memory test backend)
         // return an empty binding; there is nothing to check.
         const peer_initial_scid = peer_binding.initial_source_connection_id orelse {
@@ -7044,6 +7057,96 @@ test "connection: advertised local CID can be retired from another active CID" {
     try testing.expectEqual(State.established, pair.server.state());
     try testing.expectEqual(@as(?u64, null), pair.server.localCidSequence(spare.slice()));
     try testing.expect(pair.server.needsLocalCid());
+}
+
+test "connection: RETIRE_CONNECTION_ID cancels a queued and an in-flight copy of the same sequence and neither is ever resurrected" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    // 1) Issue sequence 1 and send it, so it becomes an in-flight sent
+    // record; then manually requeue that same record — mirroring exactly
+    // what a PTO does without removing the record it requeues from — so a
+    // second, pending copy of sequence 1 also exists simultaneously.
+    const spare = try quic_cid.ConnectionId.init(&.{ 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8 });
+    try pair.server.advertiseLocalCid(spare);
+    var out: [2048]u8 = undefined;
+    _ = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
+    const sent_index = pair.server.sent_records.items.len - 1;
+    const in_flight = pair.server.sent_records.items[sent_index].carried_new_connection_id orelse return error.TestExpectedEqual;
+    try testing.expectEqual(@as(u64, 1), in_flight.sequence);
+    // Captured while still live, not read back through the optional after
+    // it is nulled below: safety-checked builds poison-fill an optional's
+    // payload on that transition, so a pointer captured beforehand would
+    // observe poison, not proof of a real wipe.
+    const original_token = in_flight.stateless_reset_token;
+
+    const sent_copy = pair.server.sent_records.items[sent_index];
+    pair.server.requeueRecord(&sent_copy);
+    try testing.expectEqual(@as(usize, 1), pair.server.pending_new_connection_ids.items.len);
+    try testing.expectEqual(@as(u64, 1), pair.server.pending_new_connection_ids.items[0].sequence);
+
+    // 2) The peer retires sequence 1 from a packet bound to a still-active
+    // local CID (sequence 0, the handshake-issued one) — not the sequence
+    // being retired.
+    try pair.server.applyFrame(.application, .{ .retire_connection_id = .{ .sequence = 1 } }, TestPair.server_path, 0, pair.now_us);
+    try testing.expectEqual(State.established, pair.server.state());
+
+    // 3) Both the pending and the in-flight copy are gone. The sent
+    // record's storage no longer contains the original token bytes
+    // anywhere, proven via a raw byte scan rather than reading the
+    // optional's payload after it has been nulled.
+    try testing.expectEqual(@as(usize, 0), pair.server.pending_new_connection_ids.items.len);
+    try testing.expectEqual(@as(?quic_cid.NewConnectionIdFrame, null), pair.server.sent_records.items[sent_index].carried_new_connection_id);
+    const record_bytes = std.mem.asBytes(&pair.server.sent_records.items[sent_index]);
+    try testing.expect(std.mem.indexOf(u8, record_bytes, &original_token) == null);
+
+    // 4) Neither a repeated PTO nor another manual requeue (loss
+    // processing's own primitive) resurrects the retired sequence: the
+    // record that would have carried it forward no longer does.
+    pair.server.firePto(.application);
+    pair.server.firePto(.application);
+    pair.server.requeueRecord(&pair.server.sent_records.items[sent_index]);
+    try testing.expectEqual(@as(usize, 0), pair.server.pending_new_connection_ids.items.len);
+    for (pair.server.pending_new_connection_ids.items) |queued| {
+        try testing.expect(queued.sequence != 1);
+    }
+}
+
+test "connection: issue/send/retire cycling past the active-CID count never regrows pending_new_connection_ids" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const pending_backing = pair.server.pending_new_connection_ids.items.ptr;
+    const pending_capacity = pair.server.pending_new_connection_ids.capacity;
+
+    // More cycles than `max_local_active_cids`: each cycle issues, sends,
+    // and immediately retires one CID, so `next_sequence` climbs well past
+    // 8 while `activeCount()` never exceeds 1 beyond the handshake CID.
+    // If retirement ever stopped canceling in-flight/queued copies, this
+    // would eventually exceed the queue's reserved capacity and force the
+    // unwiped-growth path back open.
+    var out: [2048]u8 = undefined;
+    var i: u8 = 0;
+    while (i < quic_cid.max_local_active_cids + 2) : (i += 1) {
+        const cid = try quic_cid.ConnectionId.init(&[_]u8{ 0xd0, i, i, i, i, i, i, i });
+        try pair.server.advertiseLocalCid(cid);
+        _ = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
+        try pair.server.applyFrame(
+            .application,
+            .{ .retire_connection_id = .{ .sequence = @as(u64, i) + 1 } },
+            TestPair.server_path,
+            0,
+            pair.now_us,
+        );
+        try testing.expectEqual(State.established, pair.server.state());
+    }
+
+    try testing.expectEqual(pending_backing, pair.server.pending_new_connection_ids.items.ptr);
+    try testing.expectEqual(pending_capacity, pair.server.pending_new_connection_ids.capacity);
 }
 
 test "connection: losing one NEW_CONNECTION_ID leaves all queued CID identities pending" {

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -284,7 +284,10 @@ pub const Options = struct {
     initial_address_validated: bool = false,
     /// Process-lifetime stateless reset secret supplied by the runtime. The
     /// transport derives a token for every locally issued CID from this key.
-    stateless_reset_key: [32]u8 = [_]u8{0} ** 32,
+    /// Borrowed rather than taken by value so the caller's owned key is
+    /// never duplicated through this struct or through `Connection.init`'s
+    /// by-value `options` parameter.
+    stateless_reset_key: *const [32]u8 = &([_]u8{0} ** 32),
 };
 
 // ---------------------------------------------------------------------------
@@ -900,7 +903,7 @@ pub const Connection = struct {
                 try config.CidValue.init(retry_source)
             else
                 null,
-            .stateless_reset_key = options.stateless_reset_key,
+            .stateless_reset_key = options.stateless_reset_key.*,
             .peer_cids = quic_cid.PeerCidPool.init(params.active_connection_id_limit),
             .send_queues = std.AutoHashMap(StreamId, *SendQueue).init(allocator),
             .known_streams = std.AutoHashMap(StreamId, void).init(allocator),
@@ -1096,11 +1099,18 @@ pub const Connection = struct {
     pub fn advertiseLocalCid(self: *Connection, cid_value: quic_cid.ConnectionId) error{ CidLimitExceeded, DuplicateCid, OutOfMemory }!void {
         try self.pending_new_connection_ids.ensureUnusedCapacity(self.allocator, 1);
         const registry = if (self.local_cids) |*registry| registry else return error.CidLimitExceeded;
-        const ncid = registry.issueCid(cid_value) catch |err| switch (err) {
-            error.CidLimitExceeded => return error.CidLimitExceeded,
-            error.DuplicateCid => return error.DuplicateCid,
+        // Write the issued frame directly into the reserved queue slot: the
+        // registry entry is the only prior owner of the reset token, so this
+        // is its single copy into caller-owned storage, rather than a
+        // separate local plus a second copy into the queue.
+        const dst = self.pending_new_connection_ids.addOneAssumeCapacity();
+        registry.issueCidInto(cid_value, dst) catch |err| {
+            self.pending_new_connection_ids.shrinkRetainingCapacity(self.pending_new_connection_ids.items.len - 1);
+            switch (err) {
+                error.CidLimitExceeded => return error.CidLimitExceeded,
+                error.DuplicateCid => return error.DuplicateCid,
+            }
         };
-        self.pending_new_connection_ids.appendAssumeCapacity(ncid);
     }
 
     fn setState(self: *Connection, next: State) void {
@@ -1770,7 +1780,7 @@ pub const Connection = struct {
         if (record.carried_new_connection_id) |ncid_value| {
             var ncid = ncid_value;
             defer crypto_secrets.secureZero(&ncid.stateless_reset_token);
-            self.pending_new_connection_ids.append(self.allocator, ncid) catch {};
+            self.queueNewConnectionId(&ncid);
         }
         if (record.carried_path_challenge_path) |path| {
             for (self.candidate_challenges.items) |*candidate| {
@@ -1780,6 +1790,21 @@ pub const Connection = struct {
                 }
             }
         }
+    }
+
+    /// Queue `source` for (re)transmission, deduplicating by sequence.
+    /// `firePto` can requeue the same in-flight sent record more than once
+    /// before it is finally acked or declared lost (it does not remove the
+    /// record it requeues from), so without this guard a repeated PTO would
+    /// append duplicate copies of the same NEW_CONNECTION_ID frame — pushing
+    /// `pending_new_connection_ids` past the capacity `init()` reserves once
+    /// up front and reopening the unwiped-growth path that reservation
+    /// exists to close.
+    fn queueNewConnectionId(self: *Connection, source: *const quic_cid.NewConnectionIdFrame) void {
+        for (self.pending_new_connection_ids.items) |*queued| {
+            if (queued.sequence == source.sequence) return;
+        }
+        self.pending_new_connection_ids.append(self.allocator, source.*) catch {};
     }
 
     fn queueMaxDataUpdate(self: *Connection) void {
@@ -3159,7 +3184,7 @@ pub const Connection = struct {
             // would leave a third, unwiped stack copy of the reset token
             // (beyond the queue's own copy and the one `record` ends up
             // owning) sitting around for the rest of this function.
-            if (frame.encodeNewConnectionId(self.pending_new_connection_ids.items[0], plain[plain_len..budget])) |n| {
+            if (frame.encodeNewConnectionId(&self.pending_new_connection_ids.items[0], plain[plain_len..budget])) |n| {
                 plain_len += n;
                 record.ack_eliciting = true;
                 record.carried_new_connection_id = self.pending_new_connection_ids.items[0];

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -736,6 +736,29 @@ fn wipeSentRecordTokens(records: []SentRecord) void {
     for (records) |*record| wipeSentRecordToken(record);
 }
 
+/// Publish `source` (a function-local `SentRecord` about to be sealed and
+/// sent) into `self.sent_records` by writing directly into the reserved
+/// destination slot, rather than passing it by value into
+/// `ArrayList.append` — which would create an unowned intermediate copy of
+/// any carried reset token. Capacity is always available here: every call
+/// site only reaches this after `self.recovery.onPacketSent` accepted the
+/// packet, and that tracker is itself bounded by `recovery.max_tracked_packets`
+/// — the same bound `init()` reserves `sent_records`' capacity to once, up
+/// front.
+fn publishSentRecord(self: *Connection, source: *const SentRecord) void {
+    // Real traffic can never exceed capacity here: `sent_records` only ever
+    // grows in lockstep with `self.recovery.tracker` (both gated by
+    // `onPacketSent`) and shrinks in lockstep with it (ACK/loss processing
+    // remove from both together), and the tracker is bounded by the same
+    // `recovery.max_tracked_packets` this reserves capacity to. If that ever
+    // desyncs, degrade to an untracked send — like recovery-tracker
+    // exhaustion itself, just above — rather than growing the backing
+    // allocation and reopening the unwiped-growth path capacity reservation
+    // exists to close.
+    if (self.sent_records.items.len == self.sent_records.capacity) return;
+    self.sent_records.addOneAssumeCapacity().* = source.*;
+}
+
 /// `std.ArrayList.swapRemove` moves the last live element into the removed
 /// slot, then assigns `undefined` to the vacated tail slot — which is a
 /// real poison-fill in safety-checked builds (not a no-op) and may be no
@@ -944,16 +967,23 @@ pub const Connection = struct {
         try conn.pending_new_connection_ids.ensureTotalCapacityPrecise(allocator, quic_cid.max_local_active_cids);
 
         // RFC 9000 §7.3 binding: commit our CIDs into the TLS transport
-        // parameters before the first flight.
+        // parameters before the first flight. `binding` is a local, owned
+        // copy; `setCidBinding` borrows it so the retained backend copy is
+        // the only further duplicate, and that copy is wiped in the
+        // backend's own `deinit()`. `defer binding.deinit()` wipes this
+        // local's token on every path out of `init`, including the early
+        // handshake-construction failures below.
         var binding = config.CidBinding{
             .initial_source_connection_id = conn.local_cid,
         };
+        defer binding.deinit();
         if (options.role == .server) {
             binding.original_destination_connection_id = conn.original_dcid;
             if (conn.retry_scid) |retry_source| binding.retry_source_connection_id = retry_source;
-            binding.stateless_reset_token = quic_cid.statelessResetToken(options.stateless_reset_key[0..], conn.local_cid.slice());
+            binding.stateless_reset_token = [_]u8{0} ** quic_cid.stateless_reset_token_len;
+            quic_cid.statelessResetTokenInto(&binding.stateless_reset_token.?, options.stateless_reset_key[0..], conn.local_cid.slice());
         }
-        options.tls.setCidBinding(binding);
+        options.tls.setCidBinding(&binding);
 
         if (options.role == .client and conn.peer_cid.len == 0) {
             conn.peer_cid = conn.original_dcid;
@@ -1583,11 +1613,16 @@ pub const Connection = struct {
                     self.startClose(.{ .error_code = error_protocol_violation, .is_application = false, .local = true }, "RETIRE_CONNECTION_ID", now_us);
                     return;
                 };
-                const retired = registry.retire(retire) catch {
+                _ = registry.retire(retire) catch {
                     self.startClose(.{ .error_code = error_protocol_violation, .is_application = false, .local = true }, "RETIRE_CONNECTION_ID", now_us);
                     return;
                 };
-                _ = retired;
+                // Cancel every owned copy of this sequence's frame, not only
+                // the registry entry `retire()` already wiped — including on
+                // an idempotent repeated retire, since a duplicate
+                // RETIRE_CONNECTION_ID for an already-retired sequence still
+                // means no in-flight copy of it should survive.
+                self.cancelLocalCidFrameCopies(retire.sequence);
             },
             .path_challenge => |data| {
                 // Echo on the exact path the challenge arrived on (RFC 9000
@@ -1777,10 +1812,8 @@ pub const Connection = struct {
         if (record.carried_stop_sending) |stop| {
             self.pending_stop_sending.append(self.allocator, stop) catch {};
         }
-        if (record.carried_new_connection_id) |ncid_value| {
-            var ncid = ncid_value;
-            defer crypto_secrets.secureZero(&ncid.stateless_reset_token);
-            self.queueNewConnectionId(&ncid);
+        if (record.carried_new_connection_id) |*ncid| {
+            self.queueNewConnectionId(ncid);
         }
         if (record.carried_path_challenge_path) |path| {
             for (self.candidate_challenges.items) |*candidate| {
@@ -1804,7 +1837,47 @@ pub const Connection = struct {
         for (self.pending_new_connection_ids.items) |*queued| {
             if (queued.sequence == source.sequence) return;
         }
-        self.pending_new_connection_ids.append(self.allocator, source.*) catch {};
+        // `cancelLocalCidFrameCopies` removes every queued/in-flight copy of
+        // a sequence the instant it is retired, so the registry's
+        // `max_local_active_cids` bound on simultaneously issued-and-not-
+        // yet-retired sequences also bounds this queue — exactly the
+        // capacity `init()` reserves once up front. If that invariant is
+        // ever wrong, drop the requeue rather than growing the backing
+        // allocation and reopening the unwiped-growth path the reservation
+        // exists to close.
+        if (self.pending_new_connection_ids.items.len == self.pending_new_connection_ids.capacity) return;
+        const dst = self.pending_new_connection_ids.addOneAssumeCapacity();
+        dst.* = source.*;
+    }
+
+    /// A peer's RETIRE_CONNECTION_ID only tells `LocalCidRegistry.retire()`
+    /// to wipe its own entry; it says nothing about copies of that
+    /// sequence's NEW_CONNECTION_ID frame already queued or in flight.
+    /// Without also canceling those: a later PTO/loss could retransmit a
+    /// frame for a sequence the peer already retired, and retiring frees a
+    /// registry slot that `needsLocalCid()` may immediately reuse while the
+    /// old sequence's copies are still live, silently reopening the
+    /// capacity bound `queueNewConnectionId` depends on staying fixed.
+    /// Called for every valid retire, including an idempotent repeat of an
+    /// already-retired sequence.
+    fn cancelLocalCidFrameCopies(self: *Connection, sequence: u64) void {
+        var i: usize = 0;
+        while (i < self.pending_new_connection_ids.items.len) {
+            if (self.pending_new_connection_ids.items[i].sequence != sequence) {
+                i += 1;
+                continue;
+            }
+            crypto_secrets.secureZero(&self.pending_new_connection_ids.items[i].stateless_reset_token);
+            _ = self.pending_new_connection_ids.orderedRemove(i);
+            wipePendingNewConnectionIdsOrderedRemoveResidue(&self.pending_new_connection_ids);
+        }
+        for (self.sent_records.items) |*record| {
+            if (record.carried_new_connection_id) |*ncid| {
+                if (ncid.sequence != sequence) continue;
+                crypto_secrets.secureZero(&ncid.stateless_reset_token);
+                record.carried_new_connection_id = null;
+            }
+        }
     }
 
     fn queueMaxDataUpdate(self: *Connection) void {
@@ -2836,7 +2909,7 @@ pub const Connection = struct {
                 tracked = false;
             };
             self.last_ack_eliciting_sent_us[space_idx] = now_us;
-            if (tracked) self.sent_records.append(self.allocator, record) catch {};
+            if (tracked) publishSentRecord(self, &record);
         }
         self.paths.recordSentOnPath(path, total);
         self.metrics.packets_sent += 1;
@@ -3077,7 +3150,7 @@ pub const Connection = struct {
                 tracked = false;
             };
             self.last_ack_eliciting_sent_us[space_idx] = now_us;
-            if (tracked) self.sent_records.append(self.allocator, record) catch {};
+            if (tracked) publishSentRecord(self, &record);
         }
         if (record.carried_new_connection_id) |ncid| {
             if (self.local_cids) |*registry| registry.markAdvertised(ncid.sequence) catch {};

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -705,7 +705,15 @@ const SentRecord = struct {
     carried_handshake_done: bool = false,
     carried_reset_stream: ?quic_stream.ResetStreamFrame = null,
     carried_stop_sending: ?quic_stream.StopSendingFrame = null,
-    carried_new_connection_id: ?quic_cid.NewConnectionIdFrame = null,
+    /// Always-live payload; `has_new_connection_id` tracks whether it holds
+    /// a real, currently-carried frame. An `?NewConnectionIdFrame` would
+    /// make the payload logically inactive the moment it is cleared, and
+    /// safety-checked builds are free to poison-fill an inactive optional
+    /// payload on that very transition — which would make it impossible for
+    /// a test (or any code) to tell "wiped, then cleared" apart from "just
+    /// cleared" by inspecting the bytes afterward.
+    carried_new_connection_id: quic_cid.NewConnectionIdFrame = .{},
+    has_new_connection_id: bool = false,
     /// PATH_CHALLENGE re-arms on loss; PATH_RESPONSE does not (the peer
     /// re-challenges, RFC 9000 §8.2.2). Both force datagram expansion.
     /// Non-null when this record carried a PATH_CHALLENGE for the given
@@ -729,7 +737,7 @@ const SentRecord = struct {
 /// independent copy of it; each of those copies must be scrubbed once it is
 /// no longer needed rather than left for the allocator to reclaim unwiped.
 fn wipeSentRecordToken(record: *SentRecord) void {
-    if (record.carried_new_connection_id) |*ncid| crypto_secrets.secureZero(&ncid.stateless_reset_token);
+    if (record.has_new_connection_id) crypto_secrets.secureZero(&record.carried_new_connection_id.stateless_reset_token);
 }
 
 fn wipeSentRecordTokens(records: []SentRecord) void {
@@ -1820,8 +1828,8 @@ pub const Connection = struct {
         if (record.carried_stop_sending) |stop| {
             self.pending_stop_sending.append(self.allocator, stop) catch {};
         }
-        if (record.carried_new_connection_id) |*ncid| {
-            self.queueNewConnectionId(ncid);
+        if (record.has_new_connection_id) {
+            self.queueNewConnectionId(&record.carried_new_connection_id);
         }
         if (record.carried_path_challenge_path) |path| {
             for (self.candidate_challenges.items) |*candidate| {
@@ -1880,11 +1888,10 @@ pub const Connection = struct {
             wipePendingNewConnectionIdsOrderedRemoveResidue(&self.pending_new_connection_ids);
         }
         for (self.sent_records.items) |*record| {
-            if (record.carried_new_connection_id) |*ncid| {
-                if (ncid.sequence != sequence) continue;
-                crypto_secrets.secureZero(&ncid.stateless_reset_token);
-                record.carried_new_connection_id = null;
-            }
+            if (!record.has_new_connection_id) continue;
+            if (record.carried_new_connection_id.sequence != sequence) continue;
+            crypto_secrets.secureZero(&record.carried_new_connection_id.stateless_reset_token);
+            record.has_new_connection_id = false;
         }
     }
 
@@ -3165,8 +3172,8 @@ pub const Connection = struct {
             self.last_ack_eliciting_sent_us[space_idx] = now_us;
             if (tracked) publishSentRecord(self, &record);
         }
-        if (record.carried_new_connection_id) |ncid| {
-            if (self.local_cids) |*registry| registry.markAdvertised(ncid.sequence) catch {};
+        if (record.has_new_connection_id) {
+            if (self.local_cids) |*registry| registry.markAdvertised(record.carried_new_connection_id.sequence) catch {};
         }
         self.metrics.packets_sent += 1;
         self.events.emit(.{ .packet_sent = .{
@@ -3274,6 +3281,7 @@ pub const Connection = struct {
                 plain_len += n;
                 record.ack_eliciting = true;
                 record.carried_new_connection_id = self.pending_new_connection_ids.items[0];
+                record.has_new_connection_id = true;
                 _ = self.pending_new_connection_ids.orderedRemove(0);
                 wipePendingNewConnectionIdsOrderedRemoveResidue(&self.pending_new_connection_ids);
             } else |_| {}
@@ -7013,14 +7021,16 @@ test "connection: lost NEW_CONNECTION_ID retransmits the same frame identity" {
     var out: [2048]u8 = undefined;
     _ = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
     const first_record = pair.server.sent_records.items[pair.server.sent_records.items.len - 1];
-    const first = first_record.carried_new_connection_id orelse return error.TestExpectedEqual;
+    try testing.expect(first_record.has_new_connection_id);
+    const first = first_record.carried_new_connection_id;
     try testing.expectEqual(@as(u64, 1), first.sequence);
     try testing.expectEqualSlices(u8, spare.slice(), first.cid.slice());
 
     pair.server.requeueRecord(&first_record);
     _ = pair.server.pollTransmitOnPath(&out, pair.now_us + 1_000) orelse return error.TestExpectedEqual;
     const second_record = pair.server.sent_records.items[pair.server.sent_records.items.len - 1];
-    const second = second_record.carried_new_connection_id orelse return error.TestExpectedEqual;
+    try testing.expect(second_record.has_new_connection_id);
+    const second = second_record.carried_new_connection_id;
     try testing.expectEqual(first.sequence, second.sequence);
     try testing.expectEqual(first.retire_prior_to, second.retire_prior_to);
     try testing.expectEqualSlices(u8, first.cid.slice(), second.cid.slice());
@@ -7066,7 +7076,7 @@ test "connection: RETIRE_CONNECTION_ID cancels a queued and an in-flight copy of
     try pair.pump();
 
     // 1) Issue sequence 1 and send it, so it becomes an in-flight sent
-    // record; then manually requeue that same record — mirroring exactly
+    // record; then requeue that exact record in place — mirroring exactly
     // what a PTO does without removing the record it requeues from — so a
     // second, pending copy of sequence 1 also exists simultaneously.
     const spare = try quic_cid.ConnectionId.init(&.{ 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8 });
@@ -7074,18 +7084,13 @@ test "connection: RETIRE_CONNECTION_ID cancels a queued and an in-flight copy of
     var out: [2048]u8 = undefined;
     _ = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
     const sent_index = pair.server.sent_records.items.len - 1;
-    const in_flight = pair.server.sent_records.items[sent_index].carried_new_connection_id orelse return error.TestExpectedEqual;
-    try testing.expectEqual(@as(u64, 1), in_flight.sequence);
-    // Captured while still live, not read back through the optional after
-    // it is nulled below: safety-checked builds poison-fill an optional's
-    // payload on that transition, so a pointer captured beforehand would
-    // observe poison, not proof of a real wipe.
-    const original_token = in_flight.stateless_reset_token;
+    try testing.expect(pair.server.sent_records.items[sent_index].has_new_connection_id);
+    try testing.expectEqual(@as(u64, 1), pair.server.sent_records.items[sent_index].carried_new_connection_id.sequence);
 
-    const sent_copy = pair.server.sent_records.items[sent_index];
-    pair.server.requeueRecord(&sent_copy);
+    pair.server.requeueRecord(&pair.server.sent_records.items[sent_index]);
     try testing.expectEqual(@as(usize, 1), pair.server.pending_new_connection_ids.items.len);
     try testing.expectEqual(@as(u64, 1), pair.server.pending_new_connection_ids.items[0].sequence);
+    const pending_backing = pair.server.pending_new_connection_ids.items.ptr;
 
     // 2) The peer retires sequence 1 from a packet bound to a still-active
     // local CID (sequence 0, the handshake-issued one) — not the sequence
@@ -7093,18 +7098,29 @@ test "connection: RETIRE_CONNECTION_ID cancels a queued and an in-flight copy of
     try pair.server.applyFrame(.application, .{ .retire_connection_id = .{ .sequence = 1 } }, TestPair.server_path, 0, pair.now_us);
     try testing.expectEqual(State.established, pair.server.state());
 
-    // 3) Both the pending and the in-flight copy are gone. The sent
-    // record's storage no longer contains the original token bytes
-    // anywhere, proven via a raw byte scan rather than reading the
-    // optional's payload after it has been nulled.
+    // 3) The pending copy is gone — including its raw vacated backing
+    // slot, not just the logical length dropping — and the in-flight
+    // copy's flag and token bytes are both cleared. Every check reads the
+    // always-live payload directly, never through an optional whose own
+    // tag transition a safety-checked build is free to poison-fill: that
+    // representation change is exactly what makes these assertions prove
+    // a real wipe happened, rather than merely being consistent with one.
     try testing.expectEqual(@as(usize, 0), pair.server.pending_new_connection_ids.items.len);
-    try testing.expectEqual(@as(?quic_cid.NewConnectionIdFrame, null), pair.server.sent_records.items[sent_index].carried_new_connection_id);
-    const record_bytes = std.mem.asBytes(&pair.server.sent_records.items[sent_index]);
-    try testing.expect(std.mem.indexOf(u8, record_bytes, &original_token) == null);
+    try testing.expectEqual(pending_backing, pair.server.pending_new_connection_ids.items.ptr);
+    const vacated_pending_slot = std.mem.asBytes(
+        &pair.server.pending_new_connection_ids.allocatedSlice()[pair.server.pending_new_connection_ids.items.len],
+    );
+    for (vacated_pending_slot) |byte| try testing.expectEqual(@as(u8, 0), byte);
 
-    // 4) Neither a repeated PTO nor another manual requeue (loss
-    // processing's own primitive) resurrects the retired sequence: the
-    // record that would have carried it forward no longer does.
+    try testing.expect(!pair.server.sent_records.items[sent_index].has_new_connection_id);
+    for (pair.server.sent_records.items[sent_index].carried_new_connection_id.stateless_reset_token) |byte| {
+        try testing.expectEqual(@as(u8, 0), byte);
+    }
+
+    // 4) Neither a repeated PTO nor another direct requeue (loss
+    // processing's own primitive) resurrects the retired sequence: both
+    // consult the same `has_new_connection_id` flag on this record, and it
+    // is now false.
     pair.server.firePto(.application);
     pair.server.firePto(.application);
     pair.server.requeueRecord(&pair.server.sent_records.items[sent_index]);
@@ -7126,15 +7142,19 @@ test "connection: issue/send/retire cycling past the active-CID count never regr
     // More cycles than `max_local_active_cids`: each cycle issues, sends,
     // and immediately retires one CID, so `next_sequence` climbs well past
     // 8 while `activeCount()` never exceeds 1 beyond the handshake CID.
-    // If retirement ever stopped canceling in-flight/queued copies, this
-    // would eventually exceed the queue's reserved capacity and force the
-    // unwiped-growth path back open.
+    // Each cycle also directly requeues the exact record that just carried
+    // the now-retired sequence: a retirement that failed to cancel that
+    // in-flight copy would resurrect it right here, re-queued and counted
+    // against the very capacity this test bounds. Without driving that
+    // retransmission after every retire, a stale copy could accumulate
+    // silently across cycles without this test ever observing it.
     var out: [2048]u8 = undefined;
     var i: u8 = 0;
     while (i < quic_cid.max_local_active_cids + 2) : (i += 1) {
         const cid = try quic_cid.ConnectionId.init(&[_]u8{ 0xd0, i, i, i, i, i, i, i });
         try pair.server.advertiseLocalCid(cid);
         _ = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
+        const sent_index = pair.server.sent_records.items.len - 1;
         try pair.server.applyFrame(
             .application,
             .{ .retire_connection_id = .{ .sequence = @as(u64, i) + 1 } },
@@ -7143,6 +7163,8 @@ test "connection: issue/send/retire cycling past the active-CID count never regr
             pair.now_us,
         );
         try testing.expectEqual(State.established, pair.server.state());
+        pair.server.requeueRecord(&pair.server.sent_records.items[sent_index]);
+        try testing.expectEqual(@as(usize, 0), pair.server.pending_new_connection_ids.items.len);
     }
 
     try testing.expectEqual(pending_backing, pair.server.pending_new_connection_ids.items.ptr);
@@ -7164,7 +7186,8 @@ test "connection: losing one NEW_CONNECTION_ID leaves all queued CID identities 
     var out: [2048]u8 = undefined;
     _ = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
     const sent = pair.server.sent_records.items[pair.server.sent_records.items.len - 1];
-    const first = sent.carried_new_connection_id orelse return error.TestExpectedEqual;
+    try testing.expect(sent.has_new_connection_id);
+    const first = sent.carried_new_connection_id;
     try testing.expectEqual(@as(u64, 1), first.sequence);
     try testing.expectEqualSlices(u8, first_cid.slice(), first.cid.slice());
     try testing.expectEqual(@as(usize, 1), pair.server.pending_new_connection_ids.items.len);
@@ -7285,10 +7308,10 @@ test "connection: teardown scrubs a still-pending and an in-flight NEW_CONNECTIO
     _ = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
     try testing.expectEqual(@as(usize, 1), pair.server.pending_new_connection_ids.items.len);
     const sent_index = pair.server.sent_records.items.len - 1;
-    try testing.expect(pair.server.sent_records.items[sent_index].carried_new_connection_id != null);
+    try testing.expect(pair.server.sent_records.items[sent_index].has_new_connection_id);
 
     var in_flight_nonzero = false;
-    for (pair.server.sent_records.items[sent_index].carried_new_connection_id.?.stateless_reset_token) |b| {
+    for (pair.server.sent_records.items[sent_index].carried_new_connection_id.stateless_reset_token) |b| {
         if (b != 0) in_flight_nonzero = true;
     }
     try testing.expect(in_flight_nonzero);
@@ -7309,7 +7332,7 @@ test "connection: teardown scrubs a still-pending and an in-flight NEW_CONNECTIO
     wipeSentRecordTokens(pair.server.sent_records.items);
     wipePendingNewConnectionIdTokens(pair.server.pending_new_connection_ids.items);
 
-    for (pair.server.sent_records.items[sent_index].carried_new_connection_id.?.stateless_reset_token) |byte| {
+    for (pair.server.sent_records.items[sent_index].carried_new_connection_id.stateless_reset_token) |byte| {
         try testing.expectEqual(@as(u8, 0), byte);
     }
     for (pair.server.pending_new_connection_ids.items[0].stateless_reset_token) |byte| {

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -893,7 +893,7 @@ pub const Connection = struct {
         if (options.role == .server) {
             binding.original_destination_connection_id = conn.original_dcid;
             if (conn.retry_scid) |retry_source| binding.retry_source_connection_id = retry_source;
-            binding.stateless_reset_token = quic_cid.statelessResetToken(options.stateless_reset_key, conn.local_cid.slice());
+            binding.stateless_reset_token = quic_cid.statelessResetToken(options.stateless_reset_key[0..], conn.local_cid.slice());
         }
         options.tls.setCidBinding(binding);
 
@@ -959,6 +959,9 @@ pub const Connection = struct {
         self.pending_path_responses.deinit(self.allocator);
         self.candidate_challenges.deinit(self.allocator);
         self.retry_token.deinit(self.allocator);
+        if (self.local_cids) |*registry| registry.deinit();
+        self.local_cids = null;
+        crypto_secrets.secureZero(&self.stateless_reset_key);
     }
 
     pub fn deinit(self: *Connection) void {

--- a/src/quic/frame.zig
+++ b/src/quic/frame.zig
@@ -460,7 +460,7 @@ pub fn encodePathResponse(data: [path_data_len]u8, buf: []u8) EncodeError!usize 
 /// Encode a NEW_CONNECTION_ID frame (type 0x18, RFC 9000 §19.15): sequence,
 /// retire_prior_to, a length-prefixed CID (single byte, not a varint), and
 /// the 16-byte stateless reset token.
-pub fn encodeNewConnectionId(value: cid.NewConnectionIdFrame, buf: []u8) EncodeError!usize {
+pub fn encodeNewConnectionId(value: *const cid.NewConnectionIdFrame, buf: []u8) EncodeError!usize {
     var w = FrameWriter{ .buf = buf };
     try w.int(frame_new_connection_id);
     try w.int(value.sequence);
@@ -655,7 +655,7 @@ test "encodeNewConnectionId round-trips through decodeFrame" {
         .cid = try cid.ConnectionId.init(&[_]u8{ 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88 }),
         .stateless_reset_token = [_]u8{0xee} ** cid.stateless_reset_token_len,
     };
-    const len = try encodeNewConnectionId(value, &buf);
+    const len = try encodeNewConnectionId(&value, &buf);
     const decoded = try roundtripOne(buf[0..len]);
     const ncid = decoded.new_connection_id.frame;
     try testing.expectEqual(@as(u64, 3), ncid.sequence);
@@ -672,7 +672,7 @@ test "encodeNewConnectionId fails deterministically on a too-short buffer" {
         .stateless_reset_token = [_]u8{0} ** cid.stateless_reset_token_len,
     };
     var tiny: [4]u8 = undefined;
-    try testing.expectError(error.BufferTooShort, encodeNewConnectionId(value, &tiny));
+    try testing.expectError(error.BufferTooShort, encodeNewConnectionId(&value, &tiny));
 }
 
 test "NEW_CONNECTION_ID with retire_prior_to above sequence is malformed" {
@@ -952,7 +952,7 @@ fn fuzzCanonicalFrameRoundTrip(_: void, smith: *testing.Smith) !void {
                 .cid = try cid.ConnectionId.init(&cid_bytes),
                 .stateless_reset_token = [_]u8{smith.value(u8)} ** cid.stateless_reset_token_len,
             };
-            const frame = try roundtripOne(buf[0..try encodeNewConnectionId(value, &buf)]);
+            const frame = try roundtripOne(buf[0..try encodeNewConnectionId(&value, &buf)]);
             const decoded = frame.new_connection_id.frame;
             try testing.expectEqual(value.sequence, decoded.sequence);
             try testing.expectEqual(value.retire_prior_to, decoded.retire_prior_to);

--- a/src/quic/path.zig
+++ b/src/quic/path.zig
@@ -1110,16 +1110,53 @@ test "retry token survives key rotation while a key is retained" {
     try testing.expectError(error.UnknownTokenKey, tokens.validateRetry(token, loopbackV4(4433), 1_000_000));
 }
 
-test "retry token key ring deinit clears installed keys" {
+test "retry token key ring deinit clears installed keys down to the byte level" {
     var ring = RetryTokenKeyRing{};
     ring.install(0, [_]u8{0x9c} ** token_key_len);
     ring.install(1, [_]u8{0x8d} ** token_key_len);
     try testing.expect(ring.get(0) != null);
     try testing.expect(ring.get(1) != null);
 
+    // Capture raw pointers into the still-installed key storage before
+    // deinit: asserting only `get(id) == null` afterward would also pass an
+    // implementation that just flips the `?[N]u8` option tag without ever
+    // touching the key bytes.
+    const key0_ptr: *const [token_key_len]u8 = &(ring.keys[0].?);
+    const key1_ptr: *const [token_key_len]u8 = &(ring.keys[1].?);
+
     ring.deinit();
     try testing.expect(ring.get(0) == null);
     try testing.expect(ring.get(1) == null);
+    for (key0_ptr) |byte| try testing.expectEqual(@as(u8, 0), byte);
+    for (key1_ptr) |byte| try testing.expectEqual(@as(u8, 0), byte);
+}
+
+test "retry token key ring retire wipes the retired key, not just its slot tag" {
+    var ring = RetryTokenKeyRing{};
+    defer ring.deinit();
+    ring.install(0, [_]u8{0x9c} ** token_key_len);
+    const key0_ptr: *const [token_key_len]u8 = &(ring.keys[0].?);
+    var saw_nonzero = false;
+    for (key0_ptr) |byte| {
+        if (byte != 0) saw_nonzero = true;
+    }
+    try testing.expect(saw_nonzero);
+
+    ring.retire(0);
+    try testing.expect(ring.get(0) == null);
+    for (key0_ptr) |byte| try testing.expectEqual(@as(u8, 0), byte);
+}
+
+test "retry token key ring install wipes a replaced key before the new one takes over" {
+    var ring = RetryTokenKeyRing{};
+    defer ring.deinit();
+    ring.install(0, [_]u8{0xaa} ** token_key_len);
+    const key0_ptr: *const [token_key_len]u8 = &(ring.keys[0].?);
+
+    ring.install(0, [_]u8{0xbb} ** token_key_len);
+    // The old 0xaa key must not survive anywhere in the slot's storage —
+    // only the new key's bytes.
+    for (key0_ptr) |byte| try testing.expectEqual(@as(u8, 0xbb), byte);
 }
 
 test "retry token deterministic boundary matrix rejects malformed public input" {

--- a/src/quic/path.zig
+++ b/src/quic/path.zig
@@ -20,6 +20,7 @@
 const std = @import("std");
 const config = @import("config.zig");
 const udp = @import("udp.zig");
+const secrets = @import("crypto_secrets");
 
 const Aes128Gcm = std.crypto.aead.aes_gcm.Aes128Gcm;
 
@@ -133,17 +134,30 @@ pub const RetryTokenKeyRing = struct {
 
     pub fn install(self: *RetryTokenKeyRing, key_id: u8, key: [token_key_len]u8) void {
         std.debug.assert(key_id < max_token_keys);
+        if (self.keys[key_id]) |*slot| secrets.secureZero(slot);
         self.keys[key_id] = key;
         self.current = key_id;
     }
 
     pub fn retire(self: *RetryTokenKeyRing, key_id: u8) void {
-        if (key_id < max_token_keys) self.keys[key_id] = null;
+        if (key_id >= max_token_keys) return;
+        if (self.keys[key_id]) |*slot| secrets.secureZero(slot);
+        self.keys[key_id] = null;
     }
 
-    fn get(self: *const RetryTokenKeyRing, key_id: u8) ?[token_key_len]u8 {
+    pub fn deinit(self: *RetryTokenKeyRing) void {
+        for (&self.keys) |*entry| {
+            if (entry.*) |*slot| secrets.secureZero(slot);
+            entry.* = null;
+        }
+        self.current = 0;
+    }
+
+    fn get(self: *const RetryTokenKeyRing, key_id: u8) ?*const [token_key_len]u8 {
         if (key_id >= max_token_keys) return null;
-        return self.keys[key_id];
+        const entry = &self.keys[key_id];
+        if (entry.*) |*slot| return slot;
+        return null;
     }
 };
 
@@ -196,7 +210,7 @@ pub const RetryTokens = struct {
         @memcpy(out[1..][0..token_nonce_len], &nonce);
         const cipher = out[1 + token_nonce_len ..][0..plaintext_len];
         var tag: [token_tag_len]u8 = undefined;
-        Aes128Gcm.encrypt(cipher, &tag, plaintext[0..plaintext_len], &.{}, nonce, key);
+        Aes128Gcm.encrypt(cipher, &tag, plaintext[0..plaintext_len], &.{}, nonce, key.*);
         @memcpy(out[1 + token_nonce_len + plaintext_len ..][0..token_tag_len], &tag);
         return out[0..total];
     }
@@ -217,7 +231,7 @@ pub const RetryTokens = struct {
         @memcpy(&tag, token[1 + token_nonce_len + plaintext_len ..][0..token_tag_len]);
 
         var plaintext: [token_max_plaintext_len]u8 = undefined;
-        Aes128Gcm.decrypt(plaintext[0..plaintext_len], cipher, tag, &.{}, nonce, key) catch return error.TokenAuthenticationFailed;
+        Aes128Gcm.decrypt(plaintext[0..plaintext_len], cipher, tag, &.{}, nonce, key.*) catch return error.TokenAuthenticationFailed;
 
         const decoded = decodeTokenPlaintext(plaintext[0..plaintext_len]) catch return error.MalformedToken;
         if (decoded.kind != .retry) return error.UnexpectedTokenKind;
@@ -1096,6 +1110,18 @@ test "retry token survives key rotation while a key is retained" {
     try testing.expectError(error.UnknownTokenKey, tokens.validateRetry(token, loopbackV4(4433), 1_000_000));
 }
 
+test "retry token key ring deinit clears installed keys" {
+    var ring = RetryTokenKeyRing{};
+    ring.install(0, [_]u8{0x9c} ** token_key_len);
+    ring.install(1, [_]u8{0x8d} ** token_key_len);
+    try testing.expect(ring.get(0) != null);
+    try testing.expect(ring.get(1) != null);
+
+    ring.deinit();
+    try testing.expect(ring.get(0) == null);
+    try testing.expect(ring.get(1) == null);
+}
+
 test "retry token deterministic boundary matrix rejects malformed public input" {
     var tokens = RetryTokens{ .lifetime_us = 1_000_000 };
     tokens.keys.install(0, [_]u8{0x31} ** token_key_len);
@@ -1206,7 +1232,7 @@ fn sealTokenPlaintextForTest(
     @memcpy(out[1..][0..token_nonce_len], &nonce);
     const cipher = out[1 + token_nonce_len ..][0..plaintext.len];
     var tag: [token_tag_len]u8 = undefined;
-    Aes128Gcm.encrypt(cipher, &tag, plaintext, &.{}, nonce, key);
+    Aes128Gcm.encrypt(cipher, &tag, plaintext, &.{}, nonce, key.*);
     @memcpy(out[1 + token_nonce_len + plaintext.len ..][0..token_tag_len], &tag);
     return out[0..total];
 }

--- a/src/quic/path.zig
+++ b/src/quic/path.zig
@@ -140,9 +140,9 @@ pub const RetryTokenKeyRing = struct {
     keys: [max_token_keys]secrets.FixedSecret(token_key_len) = [_]secrets.FixedSecret(token_key_len){secrets.FixedSecret(token_key_len){}} ** max_token_keys,
     current: u8 = 0,
 
-    pub fn install(self: *RetryTokenKeyRing, key_id: u8, key: [token_key_len]u8) void {
+    pub fn install(self: *RetryTokenKeyRing, key_id: u8, key: *const [token_key_len]u8) void {
         std.debug.assert(key_id < max_token_keys);
-        self.keys[key_id].replace(&key) catch unreachable;
+        self.keys[key_id].replace(key) catch unreachable;
         self.current = key_id;
     }
 
@@ -1020,7 +1020,7 @@ const test_version: u32 = 0x0000_0001;
 
 test "retry token round-trips and recovers the original DCID, Retry SCID, and version" {
     var tokens = RetryTokens{ .lifetime_us = 10_000_000 };
-    tokens.keys.install(0, [_]u8{0xa5} ** token_key_len);
+    tokens.keys.install(0, &([_]u8{0xa5} ** token_key_len));
 
     var buf: [max_token_len]u8 = undefined;
     const token = try tokens.issueRetry(&test_odcid, &test_retry_scid, test_version, loopbackV4(4433), 1_000_000, [_]u8{0x11} ** token_nonce_len, &buf);
@@ -1037,7 +1037,7 @@ test "retry token round-trips and recovers the original DCID, Retry SCID, and ve
 
 test "retry token binds scoped IPv6 addresses including the scope id" {
     var tokens = RetryTokens{ .lifetime_us = 10_000_000 };
-    tokens.keys.install(0, [_]u8{0xa5} ** token_key_len);
+    tokens.keys.install(0, &([_]u8{0xa5} ** token_key_len));
 
     const scoped = udp.Address.ip6([_]u8{0xfe} ++ [_]u8{0x80} ++ [_]u8{0} ** 13 ++ [_]u8{0x01}, 4433, 7);
     var buf: [max_token_len]u8 = undefined;
@@ -1051,7 +1051,7 @@ test "retry token binds scoped IPv6 addresses including the scope id" {
 
 test "retry token expires after its lifetime" {
     var tokens = RetryTokens{ .lifetime_us = 5_000_000 };
-    tokens.keys.install(1, [_]u8{0x5a} ** token_key_len);
+    tokens.keys.install(1, &([_]u8{0x5a} ** token_key_len));
 
     var buf: [max_token_len]u8 = undefined;
     const token = try tokens.issueRetry(&test_odcid, &test_retry_scid, test_version, loopbackV4(443), 2_000_000, [_]u8{0x22} ** token_nonce_len, &buf);
@@ -1062,7 +1062,7 @@ test "retry token expires after its lifetime" {
 
 test "retry token dated in the future is rejected" {
     var tokens = RetryTokens{ .lifetime_us = 5_000_000, .allowed_clock_skew_us = 1_000 };
-    tokens.keys.install(0, [_]u8{0x7a} ** token_key_len);
+    tokens.keys.install(0, &([_]u8{0x7a} ** token_key_len));
 
     var buf: [max_token_len]u8 = undefined;
     const token = try tokens.issueRetry(&test_odcid, &test_retry_scid, test_version, loopbackV4(443), 5_000_000, [_]u8{0x77} ** token_nonce_len, &buf);
@@ -1075,7 +1075,7 @@ test "retry token dated in the future is rejected" {
 
 test "retry token rejects tampering and unknown keys" {
     var tokens = RetryTokens{ .lifetime_us = 10_000_000 };
-    tokens.keys.install(0, [_]u8{0x01} ** token_key_len);
+    tokens.keys.install(0, &([_]u8{0x01} ** token_key_len));
 
     var buf: [max_token_len]u8 = undefined;
     const token = try tokens.issueRetry(&test_odcid, &test_retry_scid, test_version, loopbackV4(4433), 1_000_000, [_]u8{0x33} ** token_nonce_len, &buf);
@@ -1098,13 +1098,13 @@ test "retry token rejects tampering and unknown keys" {
 
 test "retry token survives key rotation while a key is retained" {
     var tokens = RetryTokens{ .lifetime_us = 10_000_000 };
-    tokens.keys.install(0, [_]u8{0x01} ** token_key_len);
+    tokens.keys.install(0, &([_]u8{0x01} ** token_key_len));
 
     var buf: [max_token_len]u8 = undefined;
     const token = try tokens.issueRetry(&test_odcid, &test_retry_scid, test_version, loopbackV4(4433), 1_000_000, [_]u8{0x44} ** token_nonce_len, &buf);
 
     // Rotate to a new current key; the old key still validates prior tokens.
-    tokens.keys.install(1, [_]u8{0x02} ** token_key_len);
+    tokens.keys.install(1, &([_]u8{0x02} ** token_key_len));
     _ = try tokens.validateRetry(token, loopbackV4(4433), 1_000_000);
 
     // Retiring the issuing key invalidates its tokens.
@@ -1114,8 +1114,8 @@ test "retry token survives key rotation while a key is retained" {
 
 test "retry token key ring deinit clears installed keys down to the byte level" {
     var ring = RetryTokenKeyRing{};
-    ring.install(0, [_]u8{0x9c} ** token_key_len);
-    ring.install(1, [_]u8{0x8d} ** token_key_len);
+    ring.install(0, &([_]u8{0x9c} ** token_key_len));
+    ring.install(1, &([_]u8{0x8d} ** token_key_len));
     try testing.expect(ring.get(0) != null);
     try testing.expect(ring.get(1) != null);
 
@@ -1137,7 +1137,7 @@ test "retry token key ring deinit clears installed keys down to the byte level" 
 test "retry token key ring retire wipes the retired key, not just its slot tag" {
     var ring = RetryTokenKeyRing{};
     defer ring.deinit();
-    ring.install(0, [_]u8{0x9c} ** token_key_len);
+    ring.install(0, &([_]u8{0x9c} ** token_key_len));
     const key0_ptr: *const [token_key_len]u8 = &ring.keys[0].bytes;
     var saw_nonzero = false;
     for (key0_ptr) |byte| {
@@ -1153,10 +1153,10 @@ test "retry token key ring retire wipes the retired key, not just its slot tag" 
 test "retry token key ring install wipes a replaced key before the new one takes over" {
     var ring = RetryTokenKeyRing{};
     defer ring.deinit();
-    ring.install(0, [_]u8{0xaa} ** token_key_len);
+    ring.install(0, &([_]u8{0xaa} ** token_key_len));
     const key0_ptr: *const [token_key_len]u8 = &ring.keys[0].bytes;
 
-    ring.install(0, [_]u8{0xbb} ** token_key_len);
+    ring.install(0, &([_]u8{0xbb} ** token_key_len));
     // The old 0xaa key must not survive anywhere in the slot's storage —
     // only the new key's bytes.
     for (key0_ptr) |byte| try testing.expectEqual(@as(u8, 0xbb), byte);
@@ -1164,7 +1164,7 @@ test "retry token key ring install wipes a replaced key before the new one takes
 
 test "retry token deterministic boundary matrix rejects malformed public input" {
     var tokens = RetryTokens{ .lifetime_us = 1_000_000 };
-    tokens.keys.install(0, [_]u8{0x31} ** token_key_len);
+    tokens.keys.install(0, &([_]u8{0x31} ** token_key_len));
 
     try testing.expectError(error.MalformedToken, tokens.validateRetry(&([_]u8{0xaa} ** (1 + token_nonce_len + token_min_plaintext_len + token_tag_len - 1)), loopbackV4(4433), 0));
     try testing.expectError(error.MalformedToken, tokens.validateRetry(&([_]u8{0xaa} ** (max_token_len + 1)), loopbackV4(4433), 0));
@@ -1195,7 +1195,7 @@ test "retry token deterministic boundary matrix rejects malformed public input" 
 
 test "retry token validates exact time boundaries and u64 saturation" {
     var tokens = RetryTokens{ .lifetime_us = 5_000, .allowed_clock_skew_us = 100 };
-    tokens.keys.install(0, [_]u8{0x41} ** token_key_len);
+    tokens.keys.install(0, &([_]u8{0x41} ** token_key_len));
 
     var buf: [max_token_len]u8 = undefined;
     var token = try tokens.issueRetry(&test_odcid, &test_retry_scid, test_version, loopbackV4(4433), 10_000, [_]u8{0x42} ** token_nonce_len, &buf);
@@ -1214,7 +1214,7 @@ test "retry token validates exact time boundaries and u64 saturation" {
 
 test "retry token authenticated malformed plaintext maps to public rejection classes" {
     var tokens = RetryTokens{ .lifetime_us = 1_000_000 };
-    tokens.keys.install(0, [_]u8{0x51} ** token_key_len);
+    tokens.keys.install(0, &([_]u8{0x51} ** token_key_len));
     const nonce = [_]u8{0x52} ** token_nonce_len;
     const address = loopbackV4(4433);
     var plaintext: [token_max_plaintext_len]u8 = undefined;
@@ -1282,8 +1282,8 @@ fn fuzzRetryTokenIssueValidate(_: void, smith: *testing.Smith) !void {
         .lifetime_us = 1 + @as(u64, smith.value(u16)),
         .allowed_clock_skew_us = @as(u64, smith.value(u8)),
     };
-    tokens.keys.install(0, [_]u8{0x61} ** token_key_len);
-    tokens.keys.install(1, [_]u8{0x62} ** token_key_len);
+    tokens.keys.install(0, &([_]u8{0x61} ** token_key_len));
+    tokens.keys.install(1, &([_]u8{0x62} ** token_key_len));
 
     var odcid_storage: [udp.MaxConnectionIdLen]u8 = undefined;
     var retry_scid_storage: [udp.MaxConnectionIdLen]u8 = undefined;
@@ -1310,7 +1310,7 @@ fn fuzzRetryTokenIssueValidate(_: void, smith: *testing.Smith) !void {
     try testing.expectEqualSlices(u8, retry_scid, ctx.retry_scid.slice());
     try testing.expectEqual(version, ctx.quic_version);
 
-    tokens.keys.install(2, [_]u8{0x63} ** token_key_len);
+    tokens.keys.install(2, &([_]u8{0x63} ** token_key_len));
     _ = try tokens.validateRetry(token, address, issued_at);
 
     var mutated: [max_token_len]u8 = undefined;
@@ -1388,7 +1388,7 @@ test "retry integrity tag matches the RFC 9001 Appendix A.4 vector" {
 
 test "metrics distinguish invalid tokens from normal retry usage" {
     var tokens = RetryTokens{ .lifetime_us = 1_000_000 };
-    tokens.keys.install(0, [_]u8{0x09} ** token_key_len);
+    tokens.keys.install(0, &([_]u8{0x09} ** token_key_len));
     var metrics = Metrics{};
 
     var buf: [max_token_len]u8 = undefined;

--- a/src/quic/path.zig
+++ b/src/quic/path.zig
@@ -129,35 +129,37 @@ pub const TokenError = error{
 /// Installing a key makes it current; older keys remain valid for verification
 /// until explicitly retired, so tokens issued before a rotation still validate.
 pub const RetryTokenKeyRing = struct {
-    keys: [max_token_keys]?[token_key_len]u8 = .{null} ** max_token_keys,
+    /// `FixedSecret` keeps each slot's byte storage live for the ring's
+    /// entire lifetime — installed/retired is tracked by `.len` (0 vs
+    /// `token_key_len`), never by wrapping the array in an outer
+    /// `?[N]u8`. An optional wrapper would make the payload logically
+    /// inactive the moment a key is retired, and safety-checked builds are
+    /// free to poison-fill an inactive optional payload — observably so on
+    /// Linux x64 — which would make it impossible to assert the bytes were
+    /// actually zeroed rather than merely tagged absent.
+    keys: [max_token_keys]secrets.FixedSecret(token_key_len) = [_]secrets.FixedSecret(token_key_len){secrets.FixedSecret(token_key_len){}} ** max_token_keys,
     current: u8 = 0,
 
     pub fn install(self: *RetryTokenKeyRing, key_id: u8, key: [token_key_len]u8) void {
         std.debug.assert(key_id < max_token_keys);
-        if (self.keys[key_id]) |*slot| secrets.secureZero(slot);
-        self.keys[key_id] = key;
+        self.keys[key_id].replace(&key) catch unreachable;
         self.current = key_id;
     }
 
     pub fn retire(self: *RetryTokenKeyRing, key_id: u8) void {
         if (key_id >= max_token_keys) return;
-        if (self.keys[key_id]) |*slot| secrets.secureZero(slot);
-        self.keys[key_id] = null;
+        self.keys[key_id].deinit();
     }
 
     pub fn deinit(self: *RetryTokenKeyRing) void {
-        for (&self.keys) |*entry| {
-            if (entry.*) |*slot| secrets.secureZero(slot);
-            entry.* = null;
-        }
+        for (&self.keys) |*slot| slot.deinit();
         self.current = 0;
     }
 
     fn get(self: *const RetryTokenKeyRing, key_id: u8) ?*const [token_key_len]u8 {
         if (key_id >= max_token_keys) return null;
-        const entry = &self.keys[key_id];
-        if (entry.*) |*slot| return slot;
-        return null;
+        if (self.keys[key_id].len == 0) return null;
+        return &self.keys[key_id].bytes;
     }
 };
 
@@ -1117,12 +1119,13 @@ test "retry token key ring deinit clears installed keys down to the byte level" 
     try testing.expect(ring.get(0) != null);
     try testing.expect(ring.get(1) != null);
 
-    // Capture raw pointers into the still-installed key storage before
-    // deinit: asserting only `get(id) == null` afterward would also pass an
-    // implementation that just flips the `?[N]u8` option tag without ever
-    // touching the key bytes.
-    const key0_ptr: *const [token_key_len]u8 = &(ring.keys[0].?);
-    const key1_ptr: *const [token_key_len]u8 = &(ring.keys[1].?);
+    // Capture raw pointers into the always-live key storage before deinit:
+    // asserting only `get(id) == null` afterward would also pass an
+    // implementation that never actually touched the key bytes, only the
+    // occupancy length. `.bytes` stays addressable regardless of `.len`, so
+    // this read is well-defined even after the slot is cleared.
+    const key0_ptr: *const [token_key_len]u8 = &ring.keys[0].bytes;
+    const key1_ptr: *const [token_key_len]u8 = &ring.keys[1].bytes;
 
     ring.deinit();
     try testing.expect(ring.get(0) == null);
@@ -1135,7 +1138,7 @@ test "retry token key ring retire wipes the retired key, not just its slot tag" 
     var ring = RetryTokenKeyRing{};
     defer ring.deinit();
     ring.install(0, [_]u8{0x9c} ** token_key_len);
-    const key0_ptr: *const [token_key_len]u8 = &(ring.keys[0].?);
+    const key0_ptr: *const [token_key_len]u8 = &ring.keys[0].bytes;
     var saw_nonzero = false;
     for (key0_ptr) |byte| {
         if (byte != 0) saw_nonzero = true;
@@ -1151,7 +1154,7 @@ test "retry token key ring install wipes a replaced key before the new one takes
     var ring = RetryTokenKeyRing{};
     defer ring.deinit();
     ring.install(0, [_]u8{0xaa} ** token_key_len);
-    const key0_ptr: *const [token_key_len]u8 = &(ring.keys[0].?);
+    const key0_ptr: *const [token_key_len]u8 = &ring.keys[0].bytes;
 
     ring.install(0, [_]u8{0xbb} ** token_key_len);
     // The old 0xaa key must not survive anywhere in the slot's storage —

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -61,12 +61,12 @@ const tp_retry_source_connection_id: u64 = 0x10;
 pub const max_transport_parameters_len = 11 * (2 + 1 + 8) + 3 + 3 * (2 + 1 + config.max_cid_len) + (2 + 1 + 16);
 
 pub fn encodeTransportParameters(params: config.TransportParameters, buf: []u8) HandshakeError![]const u8 {
-    return encodeTransportParametersBound(params, .{}, buf);
+    return encodeTransportParametersBound(params, &.{}, buf);
 }
 
 pub fn encodeTransportParametersBound(
     params: config.TransportParameters,
-    binding: config.CidBinding,
+    binding: *const config.CidBinding,
     buf: []u8,
 ) HandshakeError![]const u8 {
     if (params.initial_max_streams_bidi > config.max_initial_streams_transport_parameter or
@@ -408,6 +408,8 @@ pub const Tls13Backend = struct {
         self.scratch.deinit();
         self.engine.deinit();
         std.crypto.secureZero(u8, &self.local_transport_parameters);
+        self.cid_binding.deinit();
+        self.peer_cid_binding.deinit();
     }
 
     fn deinitImpl(ptr: *anyopaque) void {
@@ -415,9 +417,9 @@ pub const Tls13Backend = struct {
         self.deinit();
     }
 
-    fn setCidBinding(ptr: *anyopaque, binding: config.CidBinding) void {
+    fn setCidBinding(ptr: *anyopaque, binding: *const config.CidBinding) void {
         const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
-        self.cid_binding = binding;
+        self.cid_binding = binding.*;
     }
 
     fn peerCidBinding(ptr: *anyopaque) config.CidBinding {
@@ -536,7 +538,7 @@ pub const Tls13Backend = struct {
 
     fn start(ptr: *anyopaque, role: tls_handshake.Role, params: config.TransportParameters, sink: *EventSink) HandshakeError!void {
         const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
-        const encoded = try encodeTransportParametersBound(params, self.cid_binding, &self.local_transport_parameters);
+        const encoded = try encodeTransportParametersBound(params, &self.cid_binding, &self.local_transport_parameters);
         self.engine.profile = .{ .extension = .{
             .extension_type = ext_quic_transport_parameters,
             .local = encoded,
@@ -663,7 +665,7 @@ test "QUIC adapter owns CID binding round trip" {
         .stateless_reset_token = [_]u8{0xa5} ** 16,
     };
     var buf: [max_transport_parameters_len]u8 = undefined;
-    const encoded = try encodeTransportParametersBound(params, local, &buf);
+    const encoded = try encodeTransportParametersBound(params, &local, &buf);
     var peer = config.CidBinding{};
     _ = try decodeTransportParametersBound(encoded, &peer);
     try std.testing.expectEqualDeep(local, peer);
@@ -915,7 +917,7 @@ fn fuzzTransportParameterRoundTrip(_: void, smith: *std.testing.Smith) !void {
     };
 
     var encoded: [max_transport_parameters_len]u8 = undefined;
-    const bytes = try encodeTransportParametersBound(params, binding, &encoded);
+    const bytes = try encodeTransportParametersBound(params, &binding, &encoded);
     var decoded_binding = config.CidBinding{};
     const decoded = try decodeTransportParametersBound(bytes, &decoded_binding);
     try std.testing.expectEqualDeep(params, decoded);

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -112,11 +112,11 @@ pub fn encodeTransportParametersBound(
         @memcpy(buf[len..][0..value.len], value.slice());
         len += value.len;
     }
-    if (binding.stateless_reset_token) |token| {
+    if (binding.stateless_reset_token) |*token| {
         len += varint.encode(tp_stateless_reset_token, buf[len..]) catch return error.HandshakeBufferOverflow;
         len += varint.encode(token.len, buf[len..]) catch return error.HandshakeBufferOverflow;
         if (token.len > buf.len - len) return error.HandshakeBufferOverflow;
-        @memcpy(buf[len..][0..token.len], &token);
+        @memcpy(buf[len..][0..token.len], token);
         len += token.len;
     }
     return buf[0..len];
@@ -126,6 +126,7 @@ pub const max_tracked_unknown_transport_parameters = 64;
 
 pub fn decodeTransportParameters(bytes: []const u8) HandshakeError!config.TransportParameters {
     var binding = config.CidBinding{};
+    defer binding.deinit();
     return decodeTransportParametersBound(bytes, &binding);
 }
 
@@ -419,12 +420,17 @@ pub const Tls13Backend = struct {
 
     fn setCidBinding(ptr: *anyopaque, binding: *const config.CidBinding) void {
         const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
+        // Wipe the prior owner before replacing it: if this hook is ever
+        // called more than once, assigning straight over a binding whose
+        // token is `Some` would otherwise leave the old payload bytes
+        // resident until final teardown instead of only until replacement.
+        self.cid_binding.deinit();
         self.cid_binding = binding.*;
     }
 
-    fn peerCidBinding(ptr: *anyopaque) config.CidBinding {
+    fn peerCidBinding(ptr: *anyopaque) *const config.CidBinding {
         const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
-        return self.peer_cid_binding;
+        return &self.peer_cid_binding;
     }
 
     fn setPostHandshakeAllocator(ptr: *anyopaque, allocator: std.mem.Allocator) HandshakeError!void {

--- a/src/quic/tls_handshake.zig
+++ b/src/quic/tls_handshake.zig
@@ -71,7 +71,7 @@ pub const TlsBackend = struct {
     /// carries connection IDs in its transport parameters implements both; the
     /// in-memory test backend leaves them null.
     setCidBindingFn: ?*const fn (ptr: *anyopaque, binding: *const config.CidBinding) void = null,
-    peerCidBindingFn: ?*const fn (ptr: *anyopaque) config.CidBinding = null,
+    peerCidBindingFn: ?*const fn (ptr: *anyopaque) *const config.CidBinding = null,
     setPostHandshakeAllocatorFn: ?*const fn (ptr: *anyopaque, allocator: std.mem.Allocator) HandshakeError!void = null,
     setEarlyDataApplicationCompatFn: ?*const fn (
         ptr: *anyopaque,
@@ -126,9 +126,15 @@ pub const TlsBackend = struct {
         if (self.setCidBindingFn) |set| set(self.transport.ptr, binding);
     }
 
-    pub fn peerCidBinding(self: TlsBackend) config.CidBinding {
-        if (self.peerCidBindingFn) |get| return get(self.transport.ptr);
-        return .{};
+    /// Borrows the backend's retained peer binding rather than returning a
+    /// copy: the binding may carry the peer's stateless-reset token, and a
+    /// by-value return would leave an unowned, never-wiped stack copy at
+    /// every layer between here and the eventual caller. `null` means no
+    /// backend hook is installed (equivalent to the prior default-`CidBinding`
+    /// behavior, just without a copy to hand back).
+    pub fn peerCidBinding(self: TlsBackend) ?*const config.CidBinding {
+        const get = self.peerCidBindingFn orelse return null;
+        return get(self.transport.ptr);
     }
 
     pub fn setPostHandshakeAllocator(self: TlsBackend, allocator: std.mem.Allocator) HandshakeError!void {

--- a/src/quic/tls_handshake.zig
+++ b/src/quic/tls_handshake.zig
@@ -70,7 +70,7 @@ pub const TlsBackend = struct {
     /// Optional RFC 9000 §7.3 authentication-binding hooks. A backend that
     /// carries connection IDs in its transport parameters implements both; the
     /// in-memory test backend leaves them null.
-    setCidBindingFn: ?*const fn (ptr: *anyopaque, binding: config.CidBinding) void = null,
+    setCidBindingFn: ?*const fn (ptr: *anyopaque, binding: *const config.CidBinding) void = null,
     peerCidBindingFn: ?*const fn (ptr: *anyopaque) config.CidBinding = null,
     setPostHandshakeAllocatorFn: ?*const fn (ptr: *anyopaque, allocator: std.mem.Allocator) HandshakeError!void = null,
     setEarlyDataApplicationCompatFn: ?*const fn (
@@ -122,7 +122,7 @@ pub const TlsBackend = struct {
         return self.transport.receive(level, bytes, sink);
     }
 
-    pub fn setCidBinding(self: TlsBackend, binding: config.CidBinding) void {
+    pub fn setCidBinding(self: TlsBackend, binding: *const config.CidBinding) void {
         if (self.setCidBindingFn) |set| set(self.transport.ptr, binding);
     }
 

--- a/src/tls/identity_loader.zig
+++ b/src/tls/identity_loader.zig
@@ -61,7 +61,10 @@ pub fn readSmallFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
     defer _ = std.c.close(fd);
 
     var out: std.ArrayList(u8) = .empty;
-    errdefer out.deinit(allocator);
+    errdefer {
+        secrets.secureZero(out.items);
+        out.deinit(allocator);
+    }
     var buf: [4096]u8 = undefined;
     defer secrets.secureZero(&buf);
     while (true) {
@@ -186,6 +189,27 @@ test "PEM certificate chain decoding preserves every certificate block in order"
     try std.testing.expectEqual(@as(usize, 2), chain.len);
     try std.testing.expectEqualSlices(u8, &[_]u8{ 0x30, 0x03, 0x02, 0x01, 0x00 }, chain[0]);
     try std.testing.expectEqualSlices(u8, &[_]u8{ 0x30, 0x03, 0x02, 0x01, 0x01 }, chain[1]);
+}
+
+test "readSmallFile wipes the accumulated buffer when the size limit trips" {
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const data = try std.testing.allocator.alloc(u8, 256 * 1024 + 4096);
+    defer std.testing.allocator.free(data);
+    @memset(data, 0xab);
+    try tmp.dir.writeFile(io, .{ .sub_path = "big.key", .data = data });
+
+    const path = try tmp.dir.realPathFileAlloc(io, "big.key", std.testing.allocator);
+    defer std.testing.allocator.free(path);
+
+    const backing = try std.testing.allocator.alloc(u8, 4 * 1024 * 1024);
+    defer std.testing.allocator.free(backing);
+    var fba = std.heap.FixedBufferAllocator.init(backing);
+
+    try std.testing.expectError(error.FileTooBig, readSmallFile(fba.allocator(), path));
+    try std.testing.expect(std.mem.indexOfScalar(u8, backing, 0xab) == null);
 }
 
 test "PEM certificate chain decoding rejects truncated trailing certificate" {

--- a/src/tls/identity_loader.zig
+++ b/src/tls/identity_loader.zig
@@ -56,24 +56,73 @@ pub fn loadIdentity(
     };
 }
 
+const read_small_file_max_len = 256 * 1024;
+
+/// Reads `path` into a freshly allocated, exactly-sized buffer, bounded by
+/// `read_small_file_max_len`. The file may contain private-key bytes, so
+/// every intermediate allocation this function creates — not just the one it
+/// finally returns — must be wiped before it is freed. `std.ArrayList`'s
+/// grow-and-copy and `toOwnedSlice`'s final move both free a retired
+/// backing allocation through `Allocator.free`, which only `@memset`s it
+/// with `undefined` (a no-op in ReleaseFast); using one for accumulation
+/// would leave earlier chunks of the file recoverable in freed heap memory.
+/// This manages its own growth instead, so every allocation this function
+/// retires is explicitly zeroed via `secrets.secureZeroAndFree` first.
 pub fn readSmallFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
     const fd = try std.posix.openat(std.posix.AT.FDCWD, path, .{}, 0);
     defer _ = std.c.close(fd);
 
-    var out: std.ArrayList(u8) = .empty;
-    errdefer {
-        secrets.secureZero(out.items);
-        out.deinit(allocator);
-    }
-    var buf: [4096]u8 = undefined;
-    defer secrets.secureZero(&buf);
+    var capacity: usize = 4096;
+    var buf = try allocator.alloc(u8, capacity);
+    errdefer secrets.secureZeroAndFree(allocator, buf);
+    var len: usize = 0;
     while (true) {
-        const n = try std.posix.read(fd, &buf);
+        if (len == capacity) {
+            if (capacity >= read_small_file_max_len) {
+                // Confirm there is really more data before failing: the
+                // file may be exactly `read_small_file_max_len` bytes, in
+                // which case the next read legitimately returns EOF.
+                var probe: [1]u8 = undefined;
+                defer secrets.secureZero(&probe);
+                if (try std.posix.read(fd, &probe) == 0) break;
+                return error.FileTooBig;
+            }
+            const grown = @min(capacity * 2, read_small_file_max_len);
+            buf = try growSecretBuffer(allocator, buf, grown);
+            capacity = grown;
+        }
+        const n = try std.posix.read(fd, buf[len..capacity]);
         if (n == 0) break;
-        if (out.items.len + n > 256 * 1024) return error.FileTooBig;
-        try out.appendSlice(allocator, buf[0..n]);
+        len += n;
     }
-    return out.toOwnedSlice(allocator);
+    return shrinkSecretBufferToExact(allocator, buf, len);
+}
+
+/// Grows `buf` to `new_capacity`, in place when the allocator permits it, or
+/// via copy-then-wipe-then-free of the retired allocation otherwise.
+fn growSecretBuffer(allocator: std.mem.Allocator, buf: []u8, new_capacity: usize) ![]u8 {
+    if (allocator.resize(buf, new_capacity)) return buf.ptr[0..new_capacity];
+    const grown = try allocator.alloc(u8, new_capacity);
+    @memcpy(grown[0..buf.len], buf);
+    secrets.secureZeroAndFree(allocator, buf);
+    return grown;
+}
+
+/// Shrinks `buf` down to its live `len` bytes, in place when the allocator
+/// permits it, or via copy-then-wipe-then-free of the retired allocation
+/// otherwise. This is the buffer's final owner-to-owner transfer, mirroring
+/// what `toOwnedSlice` would otherwise do without wiping.
+fn shrinkSecretBufferToExact(allocator: std.mem.Allocator, buf: []u8, len: usize) ![]u8 {
+    if (buf.len == len) return buf;
+    if (len == 0) {
+        secrets.secureZeroAndFree(allocator, buf);
+        return &.{};
+    }
+    if (allocator.resize(buf, len)) return buf.ptr[0..len];
+    const exact = try allocator.alloc(u8, len);
+    @memcpy(exact, buf[0..len]);
+    secrets.secureZeroAndFree(allocator, buf);
+    return exact;
 }
 
 pub fn derFromPemOrDer(allocator: std.mem.Allocator, raw: []const u8, block_name: []const u8) ![]u8 {
@@ -189,6 +238,92 @@ test "PEM certificate chain decoding preserves every certificate block in order"
     try std.testing.expectEqual(@as(usize, 2), chain.len);
     try std.testing.expectEqualSlices(u8, &[_]u8{ 0x30, 0x03, 0x02, 0x01, 0x00 }, chain[0]);
     try std.testing.expectEqualSlices(u8, &[_]u8{ 0x30, 0x03, 0x02, 0x01, 0x01 }, chain[1]);
+}
+
+/// Test-only allocator wrapper that always refuses in-place `resize`,
+/// forcing every grow (and the final shrink-to-exact) through the
+/// alloc-copy-free path. Real allocators sometimes resize in place, which
+/// would let a broken implementation skip the wipe-before-free step
+/// entirely and still pass; this proves the wipe happens even when a move
+/// is unavoidable.
+const ForceMoveAllocator = struct {
+    backing: std.mem.Allocator,
+    moved_allocations: usize = 0,
+    saw_nonzero_at_free: bool = false,
+
+    fn allocator(self: *ForceMoveAllocator) std.mem.Allocator {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    const vtable: std.mem.Allocator.VTable = .{
+        .alloc = vtableAlloc,
+        .resize = vtableResize,
+        .remap = vtableRemap,
+        .free = vtableFree,
+    };
+
+    fn vtableAlloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ret_addr: usize) ?[*]u8 {
+        const self: *ForceMoveAllocator = @ptrCast(@alignCast(ctx));
+        return self.backing.rawAlloc(len, alignment, ret_addr);
+    }
+
+    fn vtableResize(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ret_addr: usize) bool {
+        _ = memory;
+        _ = alignment;
+        _ = new_len;
+        _ = ret_addr;
+        const self: *ForceMoveAllocator = @ptrCast(@alignCast(ctx));
+        self.moved_allocations += 1;
+        return false;
+    }
+
+    fn vtableRemap(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ret_addr: usize) ?[*]u8 {
+        _ = ctx;
+        _ = memory;
+        _ = alignment;
+        _ = new_len;
+        _ = ret_addr;
+        return null;
+    }
+
+    fn vtableFree(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, ret_addr: usize) void {
+        const self: *ForceMoveAllocator = @ptrCast(@alignCast(ctx));
+        for (memory) |b| {
+            if (b != 0) {
+                self.saw_nonzero_at_free = true;
+                break;
+            }
+        }
+        self.backing.rawFree(memory, alignment, ret_addr);
+    }
+};
+
+test "readSmallFile scrubs every allocation retired during growth, not just the final one" {
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // Larger than the function's initial 4096-byte capacity so at least one
+    // grow-and-copy cycle happens; well under the size cap so the read
+    // succeeds and the buffer's final shrink-to-exact also moves.
+    const data = try std.testing.allocator.alloc(u8, 20 * 1024);
+    defer std.testing.allocator.free(data);
+    @memset(data, 0xcd);
+    try tmp.dir.writeFile(io, .{ .sub_path = "medium.key", .data = data });
+
+    const path = try tmp.dir.realPathFileAlloc(io, "medium.key", std.testing.allocator);
+    defer std.testing.allocator.free(path);
+
+    var forced = ForceMoveAllocator{ .backing = std.testing.allocator };
+    const out = try readSmallFile(forced.allocator(), path);
+    defer std.testing.allocator.free(out);
+
+    try std.testing.expectEqualSlices(u8, data, out);
+    // Every grow step and the final shrink asked to resize in place and was
+    // refused, so this only passes if the wipe-then-copy-then-free path ran
+    // more than once.
+    try std.testing.expect(forced.moved_allocations > 1);
+    try std.testing.expect(!forced.saw_nonzero_at_free);
 }
 
 test "readSmallFile wipes the accumulated buffer when the size limit trips" {

--- a/src/tls/identity_loader.zig
+++ b/src/tls/identity_loader.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const credentials = @import("credentials.zig");
+const secrets = @import("crypto_secrets");
 
 pub const LoadedIdentity = struct {
     allocator: std.mem.Allocator,
@@ -8,12 +9,15 @@ pub const LoadedIdentity = struct {
     identity: credentials.Identity,
 
     pub fn deinit(self: *LoadedIdentity) void {
-        std.crypto.secureZero(u8, std.mem.asBytes(&self.identity.key));
+        secrets.secureZero(std.mem.asBytes(&self.identity.key));
         for (self.cert_chain) |cert_der| {
             if (cert_der.len > 0) self.allocator.free(cert_der);
         }
         if (self.cert_chain.len > 0) self.allocator.free(self.cert_chain);
-        if (self.key_der.len > 0) self.allocator.free(self.key_der);
+        if (self.key_der.len > 0) {
+            secrets.secureZero(self.key_der);
+            self.allocator.free(self.key_der);
+        }
         self.* = undefined;
     }
 };
@@ -24,14 +28,23 @@ pub fn loadIdentity(
     key_path: []const u8,
 ) !LoadedIdentity {
     const cert_raw = try readSmallFile(allocator, cert_path);
-    defer allocator.free(cert_raw);
+    defer {
+        secrets.secureZero(cert_raw);
+        allocator.free(cert_raw);
+    }
     const key_raw = try readSmallFile(allocator, key_path);
-    defer allocator.free(key_raw);
+    defer {
+        secrets.secureZero(key_raw);
+        allocator.free(key_raw);
+    }
 
     const cert_chain = try certChainFromPemOrDer(allocator, cert_raw);
     errdefer freeCertChain(allocator, cert_chain);
     const key_der = try keyDerFromPemOrDer(allocator, key_raw);
-    errdefer allocator.free(key_der);
+    errdefer {
+        secrets.secureZero(key_der);
+        allocator.free(key_der);
+    }
 
     if (cert_chain.len == 0) return error.PemBlockNotFound;
     const identity = try credentials.Identity.initPkcs8(cert_chain[0], key_der);
@@ -50,6 +63,7 @@ pub fn readSmallFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
     var out: std.ArrayList(u8) = .empty;
     errdefer out.deinit(allocator);
     var buf: [4096]u8 = undefined;
+    defer secrets.secureZero(&buf);
     while (true) {
         const n = try std.posix.read(fd, &buf);
         if (n == 0) break;
@@ -121,7 +135,10 @@ fn pemBlockToDerFrom(allocator: std.mem.Allocator, pem: []const u8, block_name: 
     const body = pem[body_start..end_at];
 
     var compact = try allocator.alloc(u8, body.len);
-    defer allocator.free(compact);
+    defer {
+        secrets.secureZero(compact);
+        allocator.free(compact);
+    }
     var len: usize = 0;
     for (body) |char| {
         if (char == '\n' or char == '\r' or char == ' ' or char == '\t') continue;
@@ -131,7 +148,10 @@ fn pemBlockToDerFrom(allocator: std.mem.Allocator, pem: []const u8, block_name: 
     const decoder = std.base64.standard.Decoder;
     const der_len = try decoder.calcSizeForSlice(compact[0..len]);
     const der = try allocator.alloc(u8, der_len);
-    errdefer allocator.free(der);
+    errdefer {
+        secrets.secureZero(der);
+        allocator.free(der);
+    }
     try decoder.decode(der, compact[0..len]);
     return der;
 }

--- a/src/tls/ticket_protection.zig
+++ b/src/tls/ticket_protection.zig
@@ -406,20 +406,44 @@ const LeaseHighWater = struct {
     aead: provider.Aead,
     key_fingerprint: KeyFingerprint,
 
-    fn init(record: *const KeyRecord) LeaseHighWater {
-        return .{
-            .key_id = record.id,
-            .prefix = if (record.nonce_lease) |*value| value.prefix else [_]u8{0} ** 4,
-            .end_exclusive = if (record.nonce_lease) |*value| value.currentEnd() else 0,
-            .has_lease = record.nonce_lease != null,
-            .aead = record.aead,
-            .key_fingerprint = fingerprintKey(record.aead, record.key.slice()),
-        };
+    /// Initialize `out` in place rather than returning a `LeaseHighWater` by
+    /// value: a return-by-value constructor would copy the fingerprint
+    /// through an unwiped stack temporary as part of copying the whole
+    /// struct into its final (heap-allocated) home. The one remaining
+    /// fingerprint temporary here is explicitly wiped once copied in.
+    fn initInto(out: *LeaseHighWater, record: *const KeyRecord) void {
+        out.key_id = record.id;
+        out.prefix = if (record.nonce_lease) |*value| value.prefix else [_]u8{0} ** 4;
+        out.end_exclusive = if (record.nonce_lease) |*value| value.currentEnd() else 0;
+        out.has_lease = record.nonce_lease != null;
+        out.aead = record.aead;
+        var fingerprint = fingerprintKey(record.aead, record.key.slice());
+        defer secrets.secureZero(&fingerprint);
+        out.key_fingerprint = fingerprint;
     }
 
     fn deinit(self: *LeaseHighWater) void {
         secrets.secureZero(&self.key_fingerprint);
         self.* = undefined;
+    }
+};
+
+/// Entries allocated while validating a replacement snapshot, held here
+/// until the whole validation pass succeeds. `validateReplacementLocked`
+/// allocates every ledger entry a replacement needs *before* `install()`
+/// mutates `self.current`, so an allocation failure anywhere in validation
+/// rejects the whole install — it can no longer commit a key while silently
+/// omitting its ledger fingerprint/nonce high-water mark.
+const PendingLedgerEntries = struct {
+    entries: [max_keys]*LeaseHighWater = undefined,
+    count: usize = 0,
+
+    fn destroyAll(self: *PendingLedgerEntries, allocator: std.mem.Allocator) void {
+        for (self.entries[0..self.count]) |entry| {
+            entry.deinit();
+            allocator.destroy(entry);
+        }
+        self.count = 0;
     }
 };
 
@@ -494,7 +518,8 @@ pub const ReloadableKeyRing = struct {
             return error.GenerationOverflow;
         }
 
-        self.validateReplacementLocked(replacement) catch |err| {
+        var pending: PendingLedgerEntries = .{};
+        self.validateReplacementLocked(replacement, &pending) catch |err| {
             self.mutex.unlock();
             replacement.release();
             self.record(.{ .snapshot_rejected = snapshotReason(err) });
@@ -503,6 +528,7 @@ pub const ReloadableKeyRing = struct {
         if (replacement.generation == 0) {
             if (self.next_generation == std.math.maxInt(u64)) {
                 self.mutex.unlock();
+                pending.destroyAll(self.allocator);
                 replacement.release();
                 self.record(.{ .snapshot_rejected = .generation_overflow });
                 return error.GenerationOverflow;
@@ -516,7 +542,9 @@ pub const ReloadableKeyRing = struct {
         const retired_key_count = if (retired) |snapshot| retiredKeyCount(snapshot, replacement) else 0;
         self.current = replacement;
         self.next_generation = @max(self.next_generation, replacement.generation + 1);
-        self.updateLedgerLocked(replacement);
+        // Every entry `updateLedgerLocked` needs was already allocated (and
+        // validated) above, so publication from here on is infallible.
+        self.updateLedgerLocked(replacement, &pending);
         self.mutex.unlock();
 
         self.record(.{ .snapshot_installed = installed_generation });
@@ -540,7 +568,13 @@ pub const ReloadableKeyRing = struct {
             self.record(.{ .snapshot_rejected = .generation_overflow });
             return error.GenerationOverflow;
         }
-        self.validateReplacementLocked(replacement) catch |err| {
+        // This is a dry run — it never installs `replacement` — so any
+        // ledger entries `validateReplacementLocked` allocates for it must
+        // be destroyed here regardless of outcome; nothing else will ever
+        // consume them.
+        var pending: PendingLedgerEntries = .{};
+        defer pending.destroyAll(self.allocator);
+        self.validateReplacementLocked(replacement, &pending) catch |err| {
             self.mutex.unlock();
             self.record(.{ .snapshot_rejected = snapshotReason(err) });
             return err;
@@ -561,8 +595,8 @@ pub const ReloadableKeyRing = struct {
         return snapshot;
     }
 
-    fn validateReplacementLocked(self: *ReloadableKeyRing, replacement: *Snapshot) SnapshotError!void {
-        var new_ledger_entries: usize = 0;
+    fn validateReplacementLocked(self: *ReloadableKeyRing, replacement: *Snapshot, pending: *PendingLedgerEntries) SnapshotError!void {
+        errdefer pending.destroyAll(self.allocator);
         for (replacement.keys, 0..) |*key, i| {
             for (replacement.keys[0..i]) |*prior| {
                 if (prior.aead == key.aead and prior.key.eql(&key.key)) return error.DuplicateKeyId;
@@ -573,10 +607,22 @@ pub const ReloadableKeyRing = struct {
             if (self.findLedger(&key.id)) |entry| {
                 if (entry.aead != key.aead or !secrets.constantTimeEqual(&entry.key_fingerprint, &key_fingerprint)) return error.DuplicateKeyId;
             } else {
+                var duplicate = false;
                 for (self.ledger.items) |entry| {
-                    if (entry.aead == key.aead and secrets.constantTimeEqual(&entry.key_fingerprint, &key_fingerprint)) return error.DuplicateKeyId;
+                    if (entry.aead == key.aead and secrets.constantTimeEqual(&entry.key_fingerprint, &key_fingerprint)) {
+                        duplicate = true;
+                        break;
+                    }
                 }
-                new_ledger_entries += 1;
+                if (duplicate) return error.DuplicateKeyId;
+                // Allocate and initialize the entry now, before any state is
+                // committed: if this fails, the whole install is rejected
+                // rather than later silently omitting this key's ledger
+                // fingerprint after `self.current` has already moved.
+                const entry = self.allocator.create(LeaseHighWater) catch return error.OutOfMemory;
+                LeaseHighWater.initInto(entry, key);
+                pending.entries[pending.count] = entry;
+                pending.count += 1;
             }
 
             if (key.nonce_lease) |*lease| {
@@ -602,10 +648,16 @@ pub const ReloadableKeyRing = struct {
                 }
             }
         }
-        self.ledger.ensureUnusedCapacity(self.allocator, new_ledger_entries) catch return error.OutOfMemory;
+        self.ledger.ensureUnusedCapacity(self.allocator, pending.count) catch return error.OutOfMemory;
     }
 
-    fn updateLedgerLocked(self: *ReloadableKeyRing, snapshot: *Snapshot) void {
+    /// Publish `pending`'s entries into the ledger. Every entry this needs
+    /// was already allocated and validated by `validateReplacementLocked`
+    /// (which reserved ledger pointer-array capacity for exactly
+    /// `pending.count` entries too), so this cannot fail — publication after
+    /// `self.current` has moved must be infallible.
+    fn updateLedgerLocked(self: *ReloadableKeyRing, snapshot: *Snapshot, pending: *PendingLedgerEntries) void {
+        var pending_idx: usize = 0;
         for (snapshot.keys) |*key| {
             if (self.findLedgerIndex(&key.id)) |idx| {
                 if (key.nonce_lease) |*lease| {
@@ -615,15 +667,13 @@ pub const ReloadableKeyRing = struct {
                     entry.end_exclusive = @max(entry.end_exclusive, lease.currentEnd());
                 }
             } else {
-                // `validateReplacementLocked` already reserved pointer-array
-                // capacity for every entry counted here, so only the
-                // individual entry allocation can fail; skip on OOM rather
-                // than leaving the ledger inconsistent post-commit.
-                const entry = self.allocator.create(LeaseHighWater) catch continue;
-                entry.* = LeaseHighWater.init(key);
+                const entry = pending.entries[pending_idx];
+                pending_idx += 1;
                 self.ledger.appendAssumeCapacity(entry);
             }
         }
+        // Ownership of every entry moved into `self.ledger` above.
+        pending.count = 0;
     }
 
     fn findLedger(self: *const ReloadableKeyRing, key_id: *const KeyId) ?*const LeaseHighWater {

--- a/src/tls/ticket_protection.zig
+++ b/src/tls/ticket_protection.zig
@@ -908,7 +908,8 @@ fn zeroAndFree(allocator: std.mem.Allocator, buffer: []u8) void {
         const volatile_byte: *volatile u8 = @ptrCast(byte);
         volatile_byte.* = 0;
     }
-    allocator.free(buffer);
+    for (buffer) |byte| std.debug.assert(byte == 0);
+    allocator.rawFree(buffer, .fromByteUnits(@alignOf(u8)), @returnAddress());
 }
 
 fn ticketExpiresWithinKey(state: *const session.ServerRecoverableState, key_decrypt_until_unix_ms: i64) bool {

--- a/src/tls/ticket_protection.zig
+++ b/src/tls/ticket_protection.zig
@@ -416,6 +416,11 @@ const LeaseHighWater = struct {
             .key_fingerprint = fingerprintKey(record.aead, record.key.slice()),
         };
     }
+
+    fn deinit(self: *LeaseHighWater) void {
+        secrets.secureZero(&self.key_fingerprint);
+        self.* = undefined;
+    }
 };
 
 pub const ReloadableKeyRing = struct {
@@ -439,6 +444,7 @@ pub const ReloadableKeyRing = struct {
         self.mutex.unlock();
         if (retired) |snapshot| snapshot.release();
         var mutable_ledger = ledger;
+        for (mutable_ledger.items) |*entry| entry.deinit();
         mutable_ledger.deinit(self.allocator);
     }
 
@@ -554,7 +560,8 @@ pub const ReloadableKeyRing = struct {
                 if (prior.aead == key.aead and prior.key.eql(&key.key)) return error.DuplicateKeyId;
             }
 
-            const key_fingerprint = fingerprintKey(key.aead, key.key.slice());
+            var key_fingerprint = fingerprintKey(key.aead, key.key.slice());
+            defer secrets.secureZero(&key_fingerprint);
             if (self.findLedger(&key.id)) |entry| {
                 if (entry.aead != key.aead or !std.mem.eql(u8, &entry.key_fingerprint, &key_fingerprint)) return error.DuplicateKeyId;
             } else {
@@ -893,12 +900,15 @@ fn checkedProtectedLen(plaintext_len: usize, limits: session.Limits) SealError!u
 }
 
 fn zeroAndFree(allocator: std.mem.Allocator, buffer: []u8) void {
+    if (buffer.len == 0) return;
+    secrets.secureZero(buffer);
+    // Keep an explicit volatile clear so test allocators that inspect bytes
+    // before free observe deterministic zeroized memory.
     for (buffer) |*byte| {
         const volatile_byte: *volatile u8 = @ptrCast(byte);
         volatile_byte.* = 0;
     }
-    for (buffer) |byte| std.debug.assert(byte == 0);
-    allocator.rawFree(buffer, .fromByteUnits(@alignOf(u8)), @returnAddress());
+    allocator.free(buffer);
 }
 
 fn ticketExpiresWithinKey(state: *const session.ServerRecoverableState, key_decrypt_until_unix_ms: i64) bool {

--- a/src/tls/ticket_protection.zig
+++ b/src/tls/ticket_protection.zig
@@ -428,7 +428,12 @@ pub const ReloadableKeyRing = struct {
     mutex: SpinMutex = .{},
     current: ?*Snapshot = null,
     next_generation: u64 = 1,
-    ledger: std.ArrayList(LeaseHighWater) = .empty,
+    // Entries are individually heap-allocated (rather than stored by value in
+    // this list) so that growing the list never copies a `key_fingerprint`
+    // through an intermediate allocation that gets freed unwiped: only the
+    // pointers move, and the fingerprint bytes stay in one stable allocation
+    // until `LeaseHighWater.deinit()` wipes it before the entry is destroyed.
+    ledger: std.ArrayList(*LeaseHighWater) = .empty,
     observer: ?Observer = null,
 
     pub fn init(allocator: std.mem.Allocator) ReloadableKeyRing {
@@ -444,7 +449,10 @@ pub const ReloadableKeyRing = struct {
         self.mutex.unlock();
         if (retired) |snapshot| snapshot.release();
         var mutable_ledger = ledger;
-        for (mutable_ledger.items) |*entry| entry.deinit();
+        for (mutable_ledger.items) |entry| {
+            entry.deinit();
+            self.allocator.destroy(entry);
+        }
         mutable_ledger.deinit(self.allocator);
     }
 
@@ -563,10 +571,10 @@ pub const ReloadableKeyRing = struct {
             var key_fingerprint = fingerprintKey(key.aead, key.key.slice());
             defer secrets.secureZero(&key_fingerprint);
             if (self.findLedger(&key.id)) |entry| {
-                if (entry.aead != key.aead or !std.mem.eql(u8, &entry.key_fingerprint, &key_fingerprint)) return error.DuplicateKeyId;
+                if (entry.aead != key.aead or !secrets.constantTimeEqual(&entry.key_fingerprint, &key_fingerprint)) return error.DuplicateKeyId;
             } else {
-                for (self.ledger.items) |*entry| {
-                    if (entry.aead == key.aead and std.mem.eql(u8, &entry.key_fingerprint, &key_fingerprint)) return error.DuplicateKeyId;
+                for (self.ledger.items) |entry| {
+                    if (entry.aead == key.aead and secrets.constantTimeEqual(&entry.key_fingerprint, &key_fingerprint)) return error.DuplicateKeyId;
                 }
                 new_ledger_entries += 1;
             }
@@ -601,18 +609,25 @@ pub const ReloadableKeyRing = struct {
         for (snapshot.keys) |*key| {
             if (self.findLedgerIndex(&key.id)) |idx| {
                 if (key.nonce_lease) |*lease| {
-                    self.ledger.items[idx].has_lease = true;
-                    self.ledger.items[idx].prefix = lease.prefix;
-                    self.ledger.items[idx].end_exclusive = @max(self.ledger.items[idx].end_exclusive, lease.currentEnd());
+                    const entry = self.ledger.items[idx];
+                    entry.has_lease = true;
+                    entry.prefix = lease.prefix;
+                    entry.end_exclusive = @max(entry.end_exclusive, lease.currentEnd());
                 }
             } else {
-                self.ledger.appendAssumeCapacity(LeaseHighWater.init(key));
+                // `validateReplacementLocked` already reserved pointer-array
+                // capacity for every entry counted here, so only the
+                // individual entry allocation can fail; skip on OOM rather
+                // than leaving the ledger inconsistent post-commit.
+                const entry = self.allocator.create(LeaseHighWater) catch continue;
+                entry.* = LeaseHighWater.init(key);
+                self.ledger.appendAssumeCapacity(entry);
             }
         }
     }
 
     fn findLedger(self: *const ReloadableKeyRing, key_id: *const KeyId) ?*const LeaseHighWater {
-        if (self.findLedgerIndex(key_id)) |idx| return &self.ledger.items[idx];
+        if (self.findLedgerIndex(key_id)) |idx| return self.ledger.items[idx];
         return null;
     }
 
@@ -900,16 +915,7 @@ fn checkedProtectedLen(plaintext_len: usize, limits: session.Limits) SealError!u
 }
 
 fn zeroAndFree(allocator: std.mem.Allocator, buffer: []u8) void {
-    if (buffer.len == 0) return;
-    secrets.secureZero(buffer);
-    // Keep an explicit volatile clear so test allocators that inspect bytes
-    // before free observe deterministic zeroized memory.
-    for (buffer) |*byte| {
-        const volatile_byte: *volatile u8 = @ptrCast(byte);
-        volatile_byte.* = 0;
-    }
-    for (buffer) |byte| std.debug.assert(byte == 0);
-    allocator.rawFree(buffer, .fromByteUnits(@alignOf(u8)), @returnAddress());
+    secrets.secureZeroAndFree(allocator, buffer);
 }
 
 fn ticketExpiresWithinKey(state: *const session.ServerRecoverableState, key_decrypt_until_unix_ms: i64) bool {
@@ -2058,6 +2064,99 @@ test "nonce ledger supports more than fixed live-snapshot rotations" {
         try keyring.install(try keyring.buildSnapshot(&.{config}, testCapabilities()));
     }
     try testing.expectEqual(@as(usize, 70), keyring.ledger.items.len);
+}
+
+test "ledger growth across many installs never leaves a stale fingerprint copy behind" {
+    // Each `LeaseHighWater` is individually heap-allocated and the ledger
+    // stores pointers to them, so growing the pointer array (which this
+    // loop forces several times over) only ever moves pointers, never the
+    // fingerprint bytes themselves. A regression to storing entries by
+    // value in the growable list would leave old, unwiped fingerprint
+    // copies behind at each prior backing allocation.
+    var backing = [_]u8{0xcc} ** (64 * 1024);
+    var fba = std.heap.FixedBufferAllocator.init(&backing);
+    const allocator = fba.allocator();
+    var keyring = ReloadableKeyRing.init(allocator);
+    defer keyring.deinit();
+
+    var key_storage: [40][16]u8 = undefined;
+    for (&key_storage, 0..) |*bytes, i| {
+        @memset(bytes, @intCast(i + 1));
+        const config = KeyConfig{
+            .id = keyId(@intCast(i + 100)),
+            .aead = .aes_128_gcm,
+            .key_bytes = bytes,
+            .not_before_unix_ms = 1_000,
+            .encrypt_until_unix_ms = 5_000,
+            .decrypt_until_unix_ms = 20_000,
+            .nonce_lease = .{ .prefix = .{ 9, 0, 0, @intCast(i) }, .start = 0, .end_exclusive = 10 },
+        };
+        try keyring.install(try keyring.buildSnapshot(&.{config}, testCapabilities()));
+    }
+    try testing.expectEqual(@as(usize, 40), keyring.ledger.items.len);
+
+    for (keyring.ledger.items) |entry| {
+        try testing.expectEqual(@as(usize, 1), std.mem.count(u8, &backing, &entry.key_fingerprint));
+    }
+}
+
+test "ledger fingerprint check catches a mismatch at the first, middle, or last byte" {
+    const allocator = testing.allocator;
+    var keyring = ReloadableKeyRing.init(allocator);
+    defer keyring.deinit();
+
+    const retiring_id = keyId(200);
+    var base_key = [_]u8{0xaa} ** 16;
+    const base = KeyConfig{
+        .id = retiring_id,
+        .aead = .aes_128_gcm,
+        .key_bytes = &base_key,
+        .not_before_unix_ms = 1_000,
+        .encrypt_until_unix_ms = 5_000,
+        .decrypt_until_unix_ms = 20_000,
+        .nonce_lease = .{ .prefix = .{ 9, 9, 0, 0 }, .start = 0, .end_exclusive = 10 },
+    };
+    try keyring.install(try keyring.buildSnapshot(&.{base}, testCapabilities()));
+
+    // Rotate `retiring_id` out of the current snapshot entirely, so only
+    // the ledger (not `current.findKey`) remembers its fingerprint.
+    const other = sampleKeyConfig(keyId(201), .aes_128_gcm, .{ .prefix = .{ 9, 9, 1, 0 }, .start = 0, .end_exclusive = 10 });
+    try keyring.install(try keyring.buildSnapshot(&.{other}, testCapabilities()));
+
+    // Each variant replaces `current` outright (a single-key snapshot), so
+    // only the ledger's memory of `retiring_id` — not `current.findKey` —
+    // can be catching the mismatch.
+    const mismatch_positions = [_]usize{ 0, 8, 15 };
+    for (mismatch_positions) |pos| {
+        var variant_key = base_key;
+        variant_key[pos] ^= 0x01;
+        const variant = KeyConfig{
+            .id = retiring_id,
+            .aead = .aes_128_gcm,
+            .key_bytes = &variant_key,
+            .not_before_unix_ms = 1_000,
+            .encrypt_until_unix_ms = 5_000,
+            .decrypt_until_unix_ms = 20_000,
+            .nonce_lease = null,
+        };
+        try testing.expectError(
+            error.DuplicateKeyId,
+            keyring.install(try keyring.buildSnapshot(&.{variant}, testCapabilities())),
+        );
+    }
+
+    // Reasserting the exact same key bytes under the retired id is not a
+    // conflict — only the ledger fingerprint has to agree.
+    const same = KeyConfig{
+        .id = retiring_id,
+        .aead = .aes_128_gcm,
+        .key_bytes = &base_key,
+        .not_before_unix_ms = 1_000,
+        .encrypt_until_unix_ms = 5_000,
+        .decrypt_until_unix_ms = 20_000,
+        .nonce_lease = null,
+    };
+    try keyring.install(try keyring.buildSnapshot(&.{same}, testCapabilities()));
 }
 
 test "invalid issuance limits fail before reserving a nonce" {

--- a/tests/quic_h3_udp_smoke.zig
+++ b/tests/quic_h3_udp_smoke.zig
@@ -655,7 +655,7 @@ test "udp smoke: HTTP/3 runtime Retry rejects invalid token matrix without alloc
     const wrong_retry_scid = [_]u8{ 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8 };
     const client_scid = [_]u8{ 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8 };
     var token_buf: [quic.path.max_token_len]u8 = undefined;
-    const fresh_token = try runtime.retry_tokens.issueRetry(
+    const fresh_token = try runtime.secrets.retry_tokens.issueRetry(
         &odcid,
         &retry_scid,
         quic.packet.quic_v1,
@@ -670,7 +670,7 @@ test "udp smoke: HTTP/3 runtime Retry rejects invalid token matrix without alloc
     tampered_storage[fresh_token.len - 1] ^= 0x01;
 
     var expired_buf: [quic.path.max_token_len]u8 = undefined;
-    const expired_token = try runtime.retry_tokens.issueRetry(
+    const expired_token = try runtime.secrets.retry_tokens.issueRetry(
         &odcid,
         &retry_scid,
         quic.packet.quic_v1,


### PR DESCRIPTION
## Summary
- harden QUIC Retry key-ring lifecycle by wiping keys on overwrite/retire/deinit and avoiding by-value key retrieval from the ring
- harden local CID stateless-reset handling with owned secret-key storage, explicit registry deinit, token wipe-on-retire, and borrowed-key token derivation
- route TLS identity-loader key-material cleanup through canonical secret helpers and wipe PEM/base64/decode scratch + retained DER on cleanup paths
- tighten ticket-protection lifecycle cleanup by wiping ledger fingerprints on deinit, wiping temporary fingerprints after validation, and using canonical secure-zero in ticket plaintext free path while preserving deterministic zero-before-free behavior
- ensure QUIC connection teardown deinitializes local CID registry and wipes stateless reset key material

## Validation
- `ZIG_GLOBAL_CACHE_DIR="$TMPDIR/zig-global-cache" ZIG_LOCAL_CACHE_DIR="$TMPDIR/zig-local-cache" zig build test` (pass)
- VS Code diagnostics: no errors in touched files

## Issue
- Refs #375
