### PR TITLE
test: cover streamed Alt-Svc rollout paths

### DIFF
--- a/src/gateway_proxy_response.zig
+++ b/src/gateway_proxy_response.zig
@@ -439,5 +439,61 @@ test "writeBufferedUpstreamResponse strips upstream Alt-Svc and emits effective 
 
     const output = stream.getWritten();
     try std.testing.expect(std.mem.find(u8, output, "Alt-Svc: h3=\":443\"") == null);
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, output, "Alt-Svc:"));
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, output, "Alt-Svc: clear\r\n"));
     try std.testing.expect(std.mem.find(u8, output, "Alt-Svc: clear\r\n") != null);
+}
+
+test "writeStreamedUpstreamResponse emits effective Alt-Svc policy" {
+    var buf: [4096]u8 = undefined;
+    var stream = compat.fixedBufferStream(&buf);
+
+    try writeStreamedUpstreamResponse(
+        stream.writer(),
+        200,
+        "OK",
+        "text/plain",
+        null,
+        "req-stream-alt-svc",
+        &http.security_headers.SecurityHeaders.api,
+        "h3=\":8443\"; ma=120",
+        null,
+    );
+
+    const output = stream.getWritten();
+    try std.testing.expect(std.mem.find(u8, output, "Transfer-Encoding: chunked\r\n") != null);
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, output, "Alt-Svc:"));
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, output, "Alt-Svc: h3=\":8443\"; ma=120\r\n"));
+    try std.testing.expect(std.mem.find(u8, output, "Alt-Svc: h3=\":8443\"; ma=120\r\n") != null);
+    try std.testing.expect(std.mem.endsWith(u8, output, "\r\n\r\n"));
+}
+
+test "writeStreamedUpstreamResponseHeadFromHeaders strips upstream Alt-Svc and emits effective policy once" {
+    var upstream_headers = [_]TestUpstreamHeader{
+        .{ .name = "Content-Type", .value = "text/plain" },
+        .{ .name = "Alt-Svc", .value = "h3=\":443\"; ma=86400" },
+        .{ .name = "Server", .value = "origin" },
+    };
+    var buf: [4096]u8 = undefined;
+    var stream = compat.fixedBufferStream(&buf);
+
+    try writeStreamedUpstreamResponseHeadFromHeaders(
+        stream.writer(),
+        200,
+        "OK",
+        upstream_headers[0..],
+        true,
+        "req-stream-headers-alt-svc",
+        &http.security_headers.SecurityHeaders.api,
+        "clear",
+        null,
+    );
+
+    const output = stream.getWritten();
+    try std.testing.expect(std.mem.find(u8, output, "Alt-Svc: h3=\":443\"") == null);
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, output, "Alt-Svc:"));
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, output, "Alt-Svc: clear\r\n"));
+    try std.testing.expect(std.mem.find(u8, output, "Alt-Svc: clear\r\n") != null);
+    try std.testing.expect(std.mem.find(u8, output, "Server: origin\r\n") == null);
+    try std.testing.expect(std.mem.endsWith(u8, output, "\r\n\r\n"));
 }


### PR DESCRIPTION
## Summary
- Add regression coverage for streamed upstream responses emitting the gateway-owned effective Alt-Svc policy
- Add regression coverage for raw streamed upstream response heads stripping upstream Alt-Svc and Server while emitting a single effective Alt-Svc value

## Issue 257 reconciliation
Current main already contains the H3 rollout/lifecycle implementation for live-readiness-derived advertisement, restart-required listener-owned reload rejection, runtime drain hooks, effective-state metrics, and HTTP/3 rollout docs. This PR tightens the remaining response-path coverage for streamed proxy heads so the issue's Alt-Svc consistency contract is pinned alongside the existing buffered-path test.

## Validation
- zig build test --summary all
- zig build test-quic --summary all
- zig build test-integration --summary all

Refs #257