### PR TITLE
test: fuzz ticket snapshot config invariants

### DIFF
--- a/src/tls/ticket_protection.zig
+++ b/src/tls/ticket_protection.zig
@@ -5,6 +5,7 @@
 //! rotation scheduling, metrics export, and TLS PSK binder policy stay outside
 //! this module.
 
+const builtin = @import("builtin");
 const std = @import("std");
 const crypto = @import("crypto");
 const pre_shared_key = @import("pre_shared_key.zig");
@@ -37,7 +38,9 @@ const KeyDeinitProbe = struct {
         self.observed += 1;
     }
 };
-var test_key_deinit_probe: ?*KeyDeinitProbe = null;
+const TestKeyDeinitProbeStorage = if (builtin.is_test) struct {
+    threadlocal var probe: ?*KeyDeinitProbe = null;
+} else struct {};
 
 pub const ParseError = error{
     MalformedEnvelope,
@@ -282,7 +285,9 @@ const KeyRecord = struct {
     fn deinit(self: *KeyRecord) void {
         const key_len = self.key.len;
         self.key.deinit();
-        if (test_key_deinit_probe) |probe| probe.record(&self.key, key_len);
+        if (builtin.is_test) {
+            if (TestKeyDeinitProbeStorage.probe) |probe| probe.record(&self.key, key_len);
+        }
     }
 
     fn canEncryptAt(self: *const KeyRecord, now_unix_ms: i64) bool {
@@ -1554,7 +1559,6 @@ const LeaseState = struct {
 const LedgerState = struct {
     lease: LeaseState,
     aead: provider.Aead,
-    key_fingerprint: KeyFingerprint,
 };
 
 fn captureKeyringState(keyring: *ReloadableKeyRing) KeyringState {
@@ -1592,7 +1596,6 @@ fn captureKeyringState(keyring: *ReloadableKeyRing) KeyringState {
                 .has_lease = entry.has_lease,
             },
             .aead = entry.aead,
-            .key_fingerprint = entry.key_fingerprint,
         };
     }
     return state;
@@ -1646,7 +1649,6 @@ fn expectLedgerStateEqual(expected: LedgerState, entry: *const LeaseHighWater) !
         .has_lease = entry.has_lease,
     });
     try testing.expectEqual(expected.aead, entry.aead);
-    try testing.expectEqualSlices(u8, &expected.key_fingerprint, &entry.key_fingerprint);
 }
 
 fn expectLeaseStateEqual(expected: LeaseState, actual: LeaseState) !void {
@@ -1687,8 +1689,8 @@ fn expectPartialBuildWipesCopiedKey(input: []const u8) !void {
     if (expected_deinit_count == 0) return;
 
     var probe = KeyDeinitProbe{};
-    test_key_deinit_probe = &probe;
-    defer test_key_deinit_probe = null;
+    TestKeyDeinitProbeStorage.probe = &probe;
+    defer TestKeyDeinitProbeStorage.probe = null;
 
     const snapshot = Snapshot.build(testing.allocator, configs_slice, generation, caps) catch {
         try testing.expectEqual(expected_deinit_count, probe.observed);
@@ -1713,7 +1715,7 @@ fn initializedPrefixBeforeBuildFailure(configs: []const KeyConfig, caps: provide
         }
         initialized += 1;
     }
-    return 0;
+    return initialized;
 }
 
 fn byteAt(input: []const u8, idx: usize) u8 {
@@ -2031,6 +2033,20 @@ test "fuzz: ticket snapshot configs preserve bounded build invariants" {
     writeSnapshotSeedRecord(&partial_build_wipe, 0, .{ .aead = 0, .key_seed = 0x90, .id_seed = 0x90 });
     writeSnapshotSeedRecord(&partial_build_wipe, 1, .{ .aead = 1, .key_seed = 0xa0, .id_seed = 0xa0, .key_len_mode = 1 });
 
+    var ambiguous_windows = snapshotSeed(2, 0xff, 3, 0);
+    writeSnapshotSeedRecord(&ambiguous_windows, 0, .{
+        .aead = 0,
+        .key_seed = 0xd0,
+        .id_seed = 0xd0,
+        .lease_enabled = true,
+    });
+    writeSnapshotSeedRecord(&ambiguous_windows, 1, .{
+        .aead = 1,
+        .key_seed = 0xe0,
+        .id_seed = 0xe0,
+        .lease_enabled = true,
+    });
+
     var exact_max_keys = snapshotSeed(max_keys, 0xff, 3, 0);
     for (0..max_keys) |i| {
         writeSnapshotSeedRecord(&exact_max_keys, i, .{ .aead = @truncate(i % 3), .key_seed = @intCast(0x20 + i), .id_seed = @intCast(0x40 + i), .lease_enabled = false });
@@ -2072,6 +2088,7 @@ test "fuzz: ticket snapshot configs preserve bounded build invariants" {
     try expectSnapshotSeedOutcome(&invalid_window, .invalid_validity_window);
     try expectSnapshotSeedOutcome(&invalid_lease, .invalid_nonce_lease);
     try expectSnapshotSeedOutcome(&partial_build_wipe, .invalid_key_length);
+    try expectSnapshotSeedOutcome(&ambiguous_windows, .ambiguous_encryption_window);
     try expectSnapshotSeedOutcome(&exact_max_keys, .build_success);
     try expectSnapshotSeedOutcome(&max_plus_one_keys, .too_many_keys);
     try expectSnapshotSeedOutcome(&generation_overflow, .generation_overflow);
@@ -2089,6 +2106,7 @@ test "fuzz: ticket snapshot configs preserve bounded build invariants" {
         &invalid_window,
         &invalid_lease,
         &partial_build_wipe,
+        &ambiguous_windows,
         &exact_max_keys,
         &max_plus_one_keys,
         &generation_overflow,
@@ -2198,7 +2216,10 @@ fn expectSnapshotSeedOutcome(input: []const u8, outcome: SnapshotFuzzOutcome) !v
         .unsupported_capability => try testing.expectError(error.UnsupportedCapability, result),
         .invalid_validity_window => try testing.expectError(error.InvalidValidityWindow, result),
         .invalid_nonce_lease => try testing.expectError(error.InvalidNonceLease, result),
-        .ambiguous_encryption_window => try testing.expectError(error.AmbiguousEncryptionWindow, result),
+        .ambiguous_encryption_window => {
+            try testing.expectError(error.AmbiguousEncryptionWindow, result);
+            try expectPartialBuildWipesCopiedKey(input);
+        },
         .stale_generation, .generation_overflow, .non_overlapping_nonce_lease, .overlapping_nonce_lease => unreachable,
     }
 }

--- a/src/tls/ticket_protection.zig
+++ b/src/tls/ticket_protection.zig
@@ -42,6 +42,14 @@ const TestKeyDeinitProbeStorage = if (builtin.is_test) struct {
     threadlocal var probe: ?*KeyDeinitProbe = null;
 } else struct {};
 
+fn deinitTicketKey(key: *TicketKeySecret) void {
+    const key_len = key.len;
+    key.deinit();
+    if (builtin.is_test) {
+        if (TestKeyDeinitProbeStorage.probe) |probe| probe.record(key, key_len);
+    }
+}
+
 pub const ParseError = error{
     MalformedEnvelope,
     UnsupportedVersion,
@@ -264,7 +272,7 @@ const KeyRecord = struct {
             return error.InvalidValidityWindow;
 
         var key = TicketKeySecret.init(config.key_bytes) catch return error.InvalidKeyLength;
-        errdefer key.deinit();
+        errdefer deinitTicketKey(&key);
 
         const lease = if (config.nonce_lease) |lease_config|
             try NonceLease.init(lease_config)
@@ -283,11 +291,7 @@ const KeyRecord = struct {
     }
 
     fn deinit(self: *KeyRecord) void {
-        const key_len = self.key.len;
-        self.key.deinit();
-        if (builtin.is_test) {
-            if (TestKeyDeinitProbeStorage.probe) |probe| probe.record(&self.key, key_len);
-        }
+        deinitTicketKey(&self.key);
     }
 
     fn canEncryptAt(self: *const KeyRecord, now_unix_ms: i64) bool {
@@ -1700,6 +1704,7 @@ fn expectPartialBuildWipesCopiedKey(input: []const u8) !void {
 }
 
 fn initializedPrefixBeforeBuildFailure(configs: []const KeyConfig, caps: provider.Capabilities) usize {
+    if (configs.len == 0 or configs.len > max_keys) return 0;
     var initialized: usize = 0;
     for (configs, 0..) |config, i| {
         for (configs[0..i]) |prior| {
@@ -1711,7 +1716,7 @@ fn initializedPrefixBeforeBuildFailure(configs: []const KeyConfig, caps: provide
         if (!(config.not_before_unix_ms < config.encrypt_until_unix_ms and
             config.encrypt_until_unix_ms <= config.decrypt_until_unix_ms)) return initialized;
         if (config.nonce_lease) |lease| {
-            if (lease.start >= lease.end_exclusive) return initialized;
+            if (lease.start >= lease.end_exclusive) return initialized + 1;
         }
         initialized += 1;
     }
@@ -2052,6 +2057,9 @@ test "fuzz: ticket snapshot configs preserve bounded build invariants" {
         writeSnapshotSeedRecord(&exact_max_keys, i, .{ .aead = @truncate(i % 3), .key_seed = @intCast(0x20 + i), .id_seed = @intCast(0x40 + i), .lease_enabled = false });
     }
     var max_plus_one_keys = snapshotSeed(max_keys + 1, 0xff, 3, 0);
+    for (0..max_keys + 1) |i| {
+        writeSnapshotSeedRecord(&max_plus_one_keys, i, .{ .aead = @truncate(i % 3), .key_seed = @intCast(0x50 + i), .id_seed = @intCast(0x70 + i), .lease_enabled = false });
+    }
 
     var generation_overflow = snapshotSeed(1, 0xff, 3, 3);
     writeSnapshotSeedRecord(&generation_overflow, 0, .{ .aead = 0, .key_seed = 0xb0, .id_seed = 0xb0 });
@@ -2215,7 +2223,10 @@ fn expectSnapshotSeedOutcome(input: []const u8, outcome: SnapshotFuzzOutcome) !v
         },
         .unsupported_capability => try testing.expectError(error.UnsupportedCapability, result),
         .invalid_validity_window => try testing.expectError(error.InvalidValidityWindow, result),
-        .invalid_nonce_lease => try testing.expectError(error.InvalidNonceLease, result),
+        .invalid_nonce_lease => {
+            try testing.expectError(error.InvalidNonceLease, result);
+            try expectPartialBuildWipesCopiedKey(input);
+        },
         .ambiguous_encryption_window => {
             try testing.expectError(error.AmbiguousEncryptionWindow, result);
             try expectPartialBuildWipesCopiedKey(input);

--- a/src/tls/ticket_protection.zig
+++ b/src/tls/ticket_protection.zig
@@ -1335,13 +1335,64 @@ pub fn fuzzTicketIdentity(allocator: std.mem.Allocator, input: []const u8) !void
     }
 }
 
+const snapshot_fuzz_control_len = 4;
+const snapshot_fuzz_config_stride = 28;
+const SnapshotFuzzOutcome = enum {
+    build_success,
+    too_many_keys,
+    duplicate_key_id,
+    invalid_key_length,
+    unsupported_capability,
+    invalid_validity_window,
+    invalid_nonce_lease,
+    ambiguous_encryption_window,
+    generation_overflow,
+    overlapping_nonce_lease,
+};
+
 pub fn fuzzSnapshotConfig(allocator: std.mem.Allocator, input: []const u8) !void {
-    const config_count = if (input.len == 0) 0 else @as(usize, input[0] % (max_keys + 2));
     var key_storage: [max_keys + 1][provider.max_aead_key_len + 1]u8 = undefined;
     var configs: [max_keys + 1]KeyConfig = undefined;
+    const configs_slice = decodeSnapshotFuzzConfigs(input, &key_storage, &configs);
+    const caps = fuzzCapabilities(input);
+    const generation = fuzzGeneration(input);
+    const mode = fuzzMode(input);
 
-    for (configs[0..@min(config_count, configs.len)], 0..) |*config, i| {
-        const base = i * 13 + 1;
+    const snapshot = Snapshot.build(allocator, configs_slice, generation, caps) catch {
+        try expectPartialBuildWipesCopiedKey(input);
+        try expectBuildErrorLeavesPublicationUnchanged(allocator, configs_slice, generation, caps);
+        return;
+    };
+    defer snapshot.release();
+
+    try testing.expect(configs_slice.len >= 1 and configs_slice.len <= max_keys);
+    try testing.expectEqual(configs_slice.len, snapshot.keys.len);
+    for (snapshot.keys) |*key| {
+        try testing.expect(caps.supportsAead(key.aead));
+        try testing.expectEqual(key.aead.keyLength(), key.key.len);
+        try testing.expect(key.not_before_unix_ms < key.encrypt_until_unix_ms);
+        try testing.expect(key.encrypt_until_unix_ms <= key.decrypt_until_unix_ms);
+        if (key.nonce_lease) |*lease| {
+            try testing.expect(lease.next_counter.load(.acquire) < lease.currentEnd());
+        }
+    }
+
+    if (mode == 3 and configs_slice.len > 0 and configs_slice[0].nonce_lease != null) {
+        try exerciseReplacementInstall(allocator, configs_slice[0], generation, caps, false);
+    } else {
+        try exerciseCandidateDryRun(allocator, configs_slice, generation, caps);
+    }
+}
+
+fn decodeSnapshotFuzzConfigs(
+    input: []const u8,
+    key_storage: *[max_keys + 1][provider.max_aead_key_len + 1]u8,
+    configs: *[max_keys + 1]KeyConfig,
+) []KeyConfig {
+    const config_count = if (input.len == 0) 0 else @as(usize, input[0] % (max_keys + 2));
+    const bounded_count = @min(config_count, configs.len);
+    for (configs.*[0..bounded_count], 0..) |*config, i| {
+        const base = snapshot_fuzz_control_len + i * snapshot_fuzz_config_stride;
         const aead = fuzzAead(byteAt(input, base));
         const exact_len = aead.keyLength();
         const len = switch (byteAt(input, base + 1) % 5) {
@@ -1351,7 +1402,7 @@ pub fn fuzzSnapshotConfig(allocator: std.mem.Allocator, input: []const u8) !void
             3 => exact_len + 1,
             else => @min(provider.max_aead_key_len + 1, exact_len + (byteAt(input, base + 2) % 3)),
         };
-        for (key_storage[i][0..], 0..) |*byte, j| {
+        for (key_storage.*[i][0..], 0..) |*byte, j| {
             byte.* = @truncate(byteAt(input, base + 3) +% @as(u8, @truncate(i * 17 + j)));
         }
 
@@ -1364,9 +1415,9 @@ pub fn fuzzSnapshotConfig(allocator: std.mem.Allocator, input: []const u8) !void
             fuzzLease(input, base + 6);
 
         config.* = .{
-            .id = fuzzKeyId(input, base + 10, @intCast(i)),
+            .id = fuzzKeyId(input, base + 12, @intCast(i)),
             .aead = aead,
-            .key_bytes = key_storage[i][0..len],
+            .key_bytes = key_storage.*[i][0..len],
             .not_before_unix_ms = not_before,
             .encrypt_until_unix_ms = encrypt_until,
             .decrypt_until_unix_ms = decrypt_until,
@@ -1375,57 +1426,149 @@ pub fn fuzzSnapshotConfig(allocator: std.mem.Allocator, input: []const u8) !void
     }
 
     if (config_count > 1) {
-        switch (byteAt(input, 2) % 4) {
-            0 => configs[1].id = configs[0].id,
-            1 => configs[1].key_bytes = configs[0].key_bytes,
+        switch (fuzzMode(input)) {
+            0 => configs.*[1].id = configs.*[0].id,
+            1 => configs.*[1].key_bytes = configs.*[0].key_bytes,
             2 => {
-                configs[1].nonce_lease = configs[0].nonce_lease;
-                configs[1].not_before_unix_ms = configs[0].not_before_unix_ms;
-                configs[1].encrypt_until_unix_ms = configs[0].encrypt_until_unix_ms;
+                configs.*[1].nonce_lease = configs.*[0].nonce_lease;
+                configs.*[1].not_before_unix_ms = configs.*[0].not_before_unix_ms;
+                configs.*[1].encrypt_until_unix_ms = configs.*[0].encrypt_until_unix_ms;
             },
             else => {},
         }
     }
+    return configs.*[0..bounded_count];
+}
 
-    const caps = fuzzCapabilities(input);
-    const generation = fuzzGeneration(input);
-    const snapshot = Snapshot.build(allocator, configs[0..@min(config_count, configs.len)], generation, caps) catch {
-        try expectKeyringStillPublishesCurrent(allocator);
-        return;
-    };
-    defer snapshot.release();
-
-    try testing.expect(config_count >= 1 and config_count <= max_keys);
-    try testing.expectEqual(config_count, snapshot.keys.len);
-    for (snapshot.keys) |*key| {
-        try testing.expect(caps.supportsAead(key.aead));
-        try testing.expectEqual(key.aead.keyLength(), key.key.len);
-        try testing.expect(key.not_before_unix_ms < key.encrypt_until_unix_ms);
-        try testing.expect(key.encrypt_until_unix_ms <= key.decrypt_until_unix_ms);
-        if (key.nonce_lease) |*lease| {
-            try testing.expect(lease.next_counter.load(.acquire) < lease.currentEnd());
-        }
-    }
-
+fn exerciseCandidateDryRun(
+    allocator: std.mem.Allocator,
+    configs: []const KeyConfig,
+    generation: u64,
+    caps: provider.Capabilities,
+) !void {
     var keyring = ReloadableKeyRing.init(allocator);
     defer keyring.deinit();
     const current = sampleKeyConfigWithByte(keyId(0xee), .aes_128_gcm, .{ .prefix = .{ 0xee, 0, 0, 0 }, .start = 0, .end_exclusive = 4 }, 0x11);
     try keyring.install(try keyring.buildSnapshot(&.{current}, testCapabilities()));
-    const before_current = keyring.current.?;
-    const before_generation = before_current.generation;
-    const before_next_generation = keyring.next_generation;
-    const before_ledger_len = keyring.ledger.items.len;
+    const before = captureKeyringState(&keyring);
 
-    const candidate = Snapshot.build(allocator, configs[0..@min(config_count, configs.len)], generation, caps) catch return;
+    const candidate = Snapshot.build(allocator, configs, generation, caps) catch return;
     keyring.validateInstallCandidate(candidate) catch {
         candidate.release();
-        try testing.expectEqual(before_current, keyring.current.?);
-        try testing.expectEqual(before_generation, keyring.current.?.generation);
-        try testing.expectEqual(before_next_generation, keyring.next_generation);
-        try testing.expectEqual(before_ledger_len, keyring.ledger.items.len);
+        try expectKeyringStateEqual(before, &keyring);
         return;
     };
     candidate.release();
+}
+
+fn exerciseReplacementInstall(
+    allocator: std.mem.Allocator,
+    candidate_config: KeyConfig,
+    generation: u64,
+    caps: provider.Capabilities,
+    comptime expect_overlap: bool,
+) !void {
+    if (!caps.supportsAead(candidate_config.aead)) return;
+    if (candidate_config.key_bytes.len != candidate_config.aead.keyLength()) return;
+    const candidate_lease = candidate_config.nonce_lease orelse return;
+    if (candidate_lease.start >= candidate_lease.end_exclusive) return;
+
+    var keyring = ReloadableKeyRing.init(allocator);
+    defer keyring.deinit();
+
+    var baseline = candidate_config;
+    baseline.nonce_lease = .{
+        .prefix = candidate_lease.prefix,
+        .start = 0,
+        .end_exclusive = @max(candidate_lease.start + 1, candidate_lease.end_exclusive),
+    };
+    baseline.not_before_unix_ms = 0;
+    baseline.encrypt_until_unix_ms = 1_000;
+    baseline.decrypt_until_unix_ms = 20_000;
+    try keyring.install(try keyring.buildSnapshot(&.{baseline}, caps));
+    const before = captureKeyringState(&keyring);
+
+    const candidate = try Snapshot.build(allocator, &.{candidate_config}, generation, caps);
+    keyring.install(candidate) catch |err| {
+        if (expect_overlap) try testing.expectEqual(error.OverlappingNonceLease, err);
+        try expectKeyringStateEqual(before, &keyring);
+        return;
+    };
+    if (expect_overlap) return error.TestUnexpectedResult;
+}
+
+const KeyringState = struct {
+    current: ?*Snapshot,
+    current_generation: u64,
+    next_generation: u64,
+    ledger_len: usize,
+};
+
+fn captureKeyringState(keyring: *ReloadableKeyRing) KeyringState {
+    return .{
+        .current = keyring.current,
+        .current_generation = if (keyring.current) |current| current.generation else 0,
+        .next_generation = keyring.next_generation,
+        .ledger_len = keyring.ledger.items.len,
+    };
+}
+
+fn expectKeyringStateEqual(expected: KeyringState, keyring: *ReloadableKeyRing) !void {
+    try testing.expectEqual(expected.current, keyring.current);
+    try testing.expectEqual(expected.current_generation, if (keyring.current) |current| current.generation else 0);
+    try testing.expectEqual(expected.next_generation, keyring.next_generation);
+    try testing.expectEqual(expected.ledger_len, keyring.ledger.items.len);
+}
+
+fn expectBuildErrorLeavesPublicationUnchanged(
+    allocator: std.mem.Allocator,
+    configs: []const KeyConfig,
+    _: u64,
+    caps: provider.Capabilities,
+) !void {
+    var keyring = ReloadableKeyRing.init(allocator);
+    defer keyring.deinit();
+    const current = sampleKeyConfigWithByte(keyId(0xed), .aes_128_gcm, .{ .prefix = .{ 0xed, 0, 0, 0 }, .start = 0, .end_exclusive = 4 }, 0x11);
+    try keyring.install(try keyring.buildSnapshot(&.{current}, testCapabilities()));
+    const before = captureKeyringState(&keyring);
+
+    const candidate = keyring.buildSnapshot(configs, caps) catch {
+        try expectKeyringStateEqual(before, &keyring);
+        return;
+    };
+    candidate.release();
+    try expectKeyringStateEqual(before, &keyring);
+}
+
+fn expectPartialBuildWipesCopiedKey(input: []const u8) !void {
+    var backing = [_]u8{0xcc} ** 16384;
+    var fba = std.heap.FixedBufferAllocator.init(&backing);
+    var key_storage: [max_keys + 1][provider.max_aead_key_len + 1]u8 = undefined;
+    var configs: [max_keys + 1]KeyConfig = undefined;
+    const configs_slice = decodeSnapshotFuzzConfigs(input, &key_storage, &configs);
+    const caps = fuzzCapabilities(input);
+    const generation = fuzzGeneration(input);
+    const should_copy_first_key = configs_slice.len > 1 and firstConfigCopiesKey(configs_slice[0], caps);
+    const copied_key = if (should_copy_first_key) configs_slice[0].key_bytes else "";
+
+    const snapshot = Snapshot.build(fba.allocator(), configs_slice, generation, caps) catch {
+        if (should_copy_first_key) {
+            try testing.expect(std.mem.indexOf(u8, &backing, copied_key) == null);
+        }
+        return;
+    };
+    snapshot.release();
+}
+
+fn firstConfigCopiesKey(config: KeyConfig, caps: provider.Capabilities) bool {
+    if (!caps.supportsAead(config.aead)) return false;
+    if (config.key_bytes.len != config.aead.keyLength()) return false;
+    if (!(config.not_before_unix_ms < config.encrypt_until_unix_ms and
+        config.encrypt_until_unix_ms <= config.decrypt_until_unix_ms)) return false;
+    if (config.nonce_lease) |lease| {
+        if (lease.start >= lease.end_exclusive) return false;
+    }
+    return true;
 }
 
 fn byteAt(input: []const u8, idx: usize) u8 {
@@ -1490,6 +1633,10 @@ fn fuzzCapabilities(input: []const u8) provider.Capabilities {
     if (input.len > 1 and (input[1] & 0x04) != 0) caps.aeads.insert(.aes_256_gcm);
     if (input.len > 1 and (input[1] & 0x08) != 0) caps.aeads.insert(.chacha20_poly1305);
     return caps;
+}
+
+fn fuzzMode(input: []const u8) u8 {
+    return if (input.len > 2) input[2] % 4 else 3;
 }
 
 fn fuzzGeneration(input: []const u8) u64 {
@@ -1708,85 +1855,69 @@ test "fuzz helper preserves output on resolver allocation errors" {
 }
 
 test "fuzz: ticket snapshot configs preserve bounded build invariants" {
-    const empty_config_count = [_]u8{};
-    const exact_one_aes128 = [_]u8{
-        1,    0xff, 0xff, 0,
-        0,    2,    0x11, 1,
-        0,    1,    0x10, 0x10,
-        0x10, 0x10, 0x10, 0x10,
-        0x10, 0x10, 0x10, 0x10,
-        0x10, 0x10, 0x10, 0x10,
-        0x10, 0x10,
-    };
-    const exact_one_aes256 = [_]u8{
-        1,    0xff, 0xff, 0,
-        1,    2,    0x22, 1,
-        0,    1,    0x20, 0x20,
-        0x20, 0x20, 0x20, 0x20,
-        0x20, 0x20, 0x20, 0x20,
-        0x20, 0x20, 0x20, 0x20,
-        0x20, 0x20,
-    };
-    const exact_one_chacha = [_]u8{
-        1,    0xff, 0xff, 0,
-        2,    2,    0x33, 1,
-        0,    1,    0x30, 0x30,
-        0x30, 0x30, 0x30, 0x30,
-        0x30, 0x30, 0x30, 0x30,
-        0x30, 0x30, 0x30, 0x30,
-        0x30, 0x30,
-    };
-    const duplicate_id = [_]u8{
-        2,    0xff, 0,    0,
-        0,    2,    0x11, 1,
-        0,    1,    0xaa, 0xaa,
-        0xaa, 0xaa, 0xaa, 0xaa,
-        0xaa, 0xaa, 0xaa, 0xaa,
-        0xaa, 0xaa, 0xaa, 0xaa,
-        0xaa, 0xaa, 1,    2,
-        0x22, 1,    0,    1,
-        0xbb, 0xbb, 0xbb, 0xbb,
-        0xbb, 0xbb, 0xbb, 0xbb,
-        0xbb, 0xbb, 0xbb, 0xbb,
-        0xbb, 0xbb, 0xbb, 0xbb,
-    };
-    const unsupported_capability = [_]u8{
-        1,    0,    0xff, 0,
-        2,    2,    0x44, 1,
-        0,    1,    0x40, 0x40,
-        0x40, 0x40, 0x40, 0x40,
-        0x40, 0x40, 0x40, 0x40,
-        0x40, 0x40, 0x40, 0x40,
-        0x40, 0x40,
-    };
-    const invalid_window = [_]u8{
-        1,    0xff, 0xff, 0,
-        0,    2,    0x55, 2,
-        0,    1,    0x50, 0x50,
-        0x50, 0x50, 0x50, 0x50,
-        0x50, 0x50, 0x50, 0x50,
-        0x50, 0x50, 0x50, 0x50,
-        0x50, 0x50,
-    };
-    const invalid_lease = [_]u8{
-        1,    0xff, 0xff, 0,
-        0,    2,    0x66, 1,
-        1,    1,    0x60, 0x60,
-        0x60, 0x60, 0x60, 0x60,
-        0x60, 0x60, 0x60, 0x60,
-        0x60, 0x60, 0x60, 0x60,
-        0x60, 0x60,
-    };
-    const max_plus_one_keys = [_]u8{ max_keys + 1, 0xff, 0xff, 0 };
-    const generation_overflow = [_]u8{
-        1,    0xff, 0xff, 3,
-        0,    2,    0x77, 1,
-        0,    1,    0x70, 0x70,
-        0x70, 0x70, 0x70, 0x70,
-        0x70, 0x70, 0x70, 0x70,
-        0x70, 0x70, 0x70, 0x70,
-        0x70, 0x70,
-    };
+    var empty_config_count = snapshotSeed(0, 0xff, 3, 0);
+    var exact_one_aes128 = snapshotSeed(1, 0xff, 3, 0);
+    writeSnapshotSeedRecord(&exact_one_aes128, 0, .{ .aead = 0, .key_seed = 0x10, .id_seed = 0x10 });
+    var exact_one_aes256 = snapshotSeed(1, 0xff, 3, 0);
+    writeSnapshotSeedRecord(&exact_one_aes256, 0, .{ .aead = 1, .key_seed = 0x20, .id_seed = 0x20 });
+    var exact_one_chacha = snapshotSeed(1, 0xff, 3, 0);
+    writeSnapshotSeedRecord(&exact_one_chacha, 0, .{ .aead = 2, .key_seed = 0x30, .id_seed = 0x30 });
+
+    var duplicate_id = snapshotSeed(2, 0xff, 0, 0);
+    writeSnapshotSeedRecord(&duplicate_id, 0, .{ .aead = 0, .key_seed = 0x40, .id_seed = 0x40 });
+    writeSnapshotSeedRecord(&duplicate_id, 1, .{ .aead = 1, .key_seed = 0x50, .id_seed = 0x50 });
+
+    var unsupported_capability = snapshotSeed(1, 0x02, 3, 0);
+    writeSnapshotSeedRecord(&unsupported_capability, 0, .{ .aead = 2, .key_seed = 0x60, .id_seed = 0x60 });
+
+    var invalid_window = snapshotSeed(1, 0xff, 3, 0);
+    writeSnapshotSeedRecord(&invalid_window, 0, .{ .aead = 0, .key_seed = 0x70, .id_seed = 0x70, .time_case = 2 });
+
+    var invalid_lease = snapshotSeed(1, 0xff, 3, 0);
+    writeSnapshotSeedRecord(&invalid_lease, 0, .{
+        .aead = 0,
+        .key_seed = 0x80,
+        .id_seed = 0x80,
+        .lease_enabled = true,
+        .lease_case = 1,
+    });
+
+    var partial_build_wipe = snapshotSeed(2, 0xff, 3, 0);
+    writeSnapshotSeedRecord(&partial_build_wipe, 0, .{ .aead = 0, .key_seed = 0x90, .id_seed = 0x90 });
+    writeSnapshotSeedRecord(&partial_build_wipe, 1, .{ .aead = 1, .key_seed = 0xa0, .id_seed = 0xa0, .key_len_mode = 1 });
+
+    var exact_max_keys = snapshotSeed(max_keys, 0xff, 3, 0);
+    for (0..max_keys) |i| {
+        writeSnapshotSeedRecord(&exact_max_keys, i, .{ .aead = @truncate(i % 3), .key_seed = @intCast(0x20 + i), .id_seed = @intCast(0x40 + i), .lease_enabled = false });
+    }
+    var max_plus_one_keys = snapshotSeed(max_keys + 1, 0xff, 3, 0);
+
+    var generation_overflow = snapshotSeed(1, 0xff, 3, 3);
+    writeSnapshotSeedRecord(&generation_overflow, 0, .{ .aead = 0, .key_seed = 0xb0, .id_seed = 0xb0 });
+
+    var overlapping_replacement_lease = snapshotSeed(1, 0xff, 3, 0);
+    writeSnapshotSeedRecord(&overlapping_replacement_lease, 0, .{
+        .aead = 0,
+        .key_seed = 0xc0,
+        .id_seed = 0xc0,
+        .lease_enabled = true,
+        .lease_case = 6,
+        .lease_value = 1,
+    });
+
+    try expectSnapshotSeedOutcome(&empty_config_count, .too_many_keys);
+    try expectSnapshotSeedOutcome(&exact_one_aes128, .build_success);
+    try expectSnapshotSeedOutcome(&exact_one_aes256, .build_success);
+    try expectSnapshotSeedOutcome(&exact_one_chacha, .build_success);
+    try expectSnapshotSeedOutcome(&duplicate_id, .duplicate_key_id);
+    try expectSnapshotSeedOutcome(&unsupported_capability, .unsupported_capability);
+    try expectSnapshotSeedOutcome(&invalid_window, .invalid_validity_window);
+    try expectSnapshotSeedOutcome(&invalid_lease, .invalid_nonce_lease);
+    try expectSnapshotSeedOutcome(&partial_build_wipe, .invalid_key_length);
+    try expectSnapshotSeedOutcome(&exact_max_keys, .build_success);
+    try expectSnapshotSeedOutcome(&max_plus_one_keys, .too_many_keys);
+    try expectSnapshotSeedOutcome(&generation_overflow, .generation_overflow);
+    try expectSnapshotSeedOutcome(&overlapping_replacement_lease, .overlapping_nonce_lease);
 
     try testing.fuzz({}, fuzzTicketSnapshotConfigInput, .{ .corpus = &.{
         &empty_config_count,
@@ -1797,15 +1928,101 @@ test "fuzz: ticket snapshot configs preserve bounded build invariants" {
         &unsupported_capability,
         &invalid_window,
         &invalid_lease,
+        &partial_build_wipe,
+        &exact_max_keys,
         &max_plus_one_keys,
         &generation_overflow,
+        &overlapping_replacement_lease,
     } });
 }
 
 fn fuzzTicketSnapshotConfigInput(_: void, smith: *testing.Smith) !void {
-    var input_buf: [1 + (max_keys + 1) * 13]u8 = undefined;
+    var input_buf: [snapshot_fuzz_control_len + (max_keys + 1) * snapshot_fuzz_config_stride]u8 = undefined;
     const len = smith.slice(&input_buf);
     try fuzzSnapshotConfig(testing.allocator, input_buf[0..len]);
+}
+
+const SnapshotSeedRecord = struct {
+    aead: u8,
+    key_len_mode: u8 = 2,
+    key_seed: u8,
+    time_case: u8 = 1,
+    lease_enabled: bool = false,
+    lease_prefix: [4]u8 = .{ 0xaa, 0xbb, 0xcc, 0xdd },
+    lease_case: u8 = 0,
+    lease_value: u8 = 0,
+    id_seed: u8,
+};
+
+fn snapshotSeed(count: u8, caps: u8, mode: u8, generation_mode: u8) [snapshot_fuzz_control_len + (max_keys + 1) * snapshot_fuzz_config_stride]u8 {
+    var seed = [_]u8{0} ** (snapshot_fuzz_control_len + (max_keys + 1) * snapshot_fuzz_config_stride);
+    seed[0] = count;
+    seed[1] = caps;
+    seed[2] = mode;
+    seed[3] = generation_mode;
+    return seed;
+}
+
+fn writeSnapshotSeedRecord(
+    seed: *[snapshot_fuzz_control_len + (max_keys + 1) * snapshot_fuzz_config_stride]u8,
+    index: usize,
+    record: SnapshotSeedRecord,
+) void {
+    const base = snapshot_fuzz_control_len + index * snapshot_fuzz_config_stride;
+    seed[base] = record.aead;
+    seed[base + 1] = record.key_len_mode;
+    seed[base + 3] = record.key_seed;
+    seed[base + 4] = record.time_case;
+    seed[base + 5] = if (record.lease_enabled) 1 else 0;
+    seed[base + 6] = record.lease_prefix[0];
+    seed[base + 7] = record.lease_prefix[1];
+    seed[base + 8] = record.lease_prefix[2];
+    seed[base + 9] = record.lease_prefix[3];
+    seed[base + 10] = record.lease_case;
+    seed[base + 11] = record.lease_value;
+    @memset(seed[base + 12 .. base + 12 + key_id_len], record.id_seed);
+}
+
+fn expectSnapshotSeedOutcome(input: []const u8, outcome: SnapshotFuzzOutcome) !void {
+    var key_storage: [max_keys + 1][provider.max_aead_key_len + 1]u8 = undefined;
+    var configs: [max_keys + 1]KeyConfig = undefined;
+    const configs_slice = decodeSnapshotFuzzConfigs(input, &key_storage, &configs);
+    const caps = fuzzCapabilities(input);
+    const generation = fuzzGeneration(input);
+
+    if (outcome == .overlapping_nonce_lease) {
+        try testing.expect(configs_slice.len > 0);
+        try exerciseReplacementInstall(testing.allocator, configs_slice[0], generation, caps, true);
+        return;
+    }
+    if (outcome == .generation_overflow) {
+        const candidate = try Snapshot.build(testing.allocator, configs_slice, generation, caps);
+        var keyring = ReloadableKeyRing.init(testing.allocator);
+        defer keyring.deinit();
+        const before = captureKeyringState(&keyring);
+        try testing.expectError(error.GenerationOverflow, keyring.install(candidate));
+        try expectKeyringStateEqual(before, &keyring);
+        return;
+    }
+
+    const result = Snapshot.build(testing.allocator, configs_slice, generation, caps);
+    switch (outcome) {
+        .build_success => {
+            const snapshot = try result;
+            snapshot.release();
+        },
+        .too_many_keys => try testing.expectError(error.TooManyKeys, result),
+        .duplicate_key_id => try testing.expectError(error.DuplicateKeyId, result),
+        .invalid_key_length => {
+            try testing.expectError(error.InvalidKeyLength, result);
+            try expectPartialBuildWipesCopiedKey(input);
+        },
+        .unsupported_capability => try testing.expectError(error.UnsupportedCapability, result),
+        .invalid_validity_window => try testing.expectError(error.InvalidValidityWindow, result),
+        .invalid_nonce_lease => try testing.expectError(error.InvalidNonceLease, result),
+        .ambiguous_encryption_window => try testing.expectError(error.AmbiguousEncryptionWindow, result),
+        .generation_overflow, .overlapping_nonce_lease => unreachable,
+    }
 }
 
 test "protectedLen reserves envelope overhead exactly" {

--- a/src/tls/ticket_protection.zig
+++ b/src/tls/ticket_protection.zig
@@ -27,6 +27,17 @@ const key_fingerprint_domain = "tardigrade/tls-ticket/key-fingerprint/v1\x00";
 pub const KeyId = [key_id_len]u8;
 const TicketKeySecret = secrets.FixedSecret(provider.max_aead_key_len);
 const KeyFingerprint = [32]u8;
+const KeyDeinitProbe = struct {
+    observed: usize = 0,
+
+    fn record(self: *KeyDeinitProbe, key: *const TicketKeySecret, logical_len: usize) void {
+        for (key.bytes[0..logical_len]) |byte| {
+            if (byte != 0) @panic("ticket key was not zeroized before cleanup observation");
+        }
+        self.observed += 1;
+    }
+};
+var test_key_deinit_probe: ?*KeyDeinitProbe = null;
 
 pub const ParseError = error{
     MalformedEnvelope,
@@ -269,7 +280,9 @@ const KeyRecord = struct {
     }
 
     fn deinit(self: *KeyRecord) void {
+        const key_len = self.key.len;
         self.key.deinit();
+        if (test_key_deinit_probe) |probe| probe.record(&self.key, key_len);
     }
 
     fn canEncryptAt(self: *const KeyRecord, now_unix_ms: i64) bool {
@@ -1346,7 +1359,9 @@ const SnapshotFuzzOutcome = enum {
     invalid_validity_window,
     invalid_nonce_lease,
     ambiguous_encryption_window,
+    stale_generation,
     generation_overflow,
+    non_overlapping_nonce_lease,
     overlapping_nonce_lease,
 };
 
@@ -1472,15 +1487,23 @@ fn exerciseReplacementInstall(
     if (candidate_config.key_bytes.len != candidate_config.aead.keyLength()) return;
     const candidate_lease = candidate_config.nonce_lease orelse return;
     if (candidate_lease.start >= candidate_lease.end_exclusive) return;
+    if (!expect_overlap) {
+        if (candidate_lease.start == 0) return;
+        if (generation == 1 or generation == std.math.maxInt(u64)) return;
+    }
 
     var keyring = ReloadableKeyRing.init(allocator);
     defer keyring.deinit();
 
+    const baseline_end = if (expect_overlap)
+        candidate_lease.end_exclusive
+    else
+        candidate_lease.start;
     var baseline = candidate_config;
     baseline.nonce_lease = .{
         .prefix = candidate_lease.prefix,
         .start = 0,
-        .end_exclusive = @max(candidate_lease.start + 1, candidate_lease.end_exclusive),
+        .end_exclusive = baseline_end,
     };
     baseline.not_before_unix_ms = 0;
     baseline.encrypt_until_unix_ms = 1_000;
@@ -1495,6 +1518,9 @@ fn exerciseReplacementInstall(
         return;
     };
     if (expect_overlap) return error.TestUnexpectedResult;
+    try testing.expect(keyring.current != before.current);
+    try testing.expect(keyring.current != null);
+    try testing.expectEqual(candidate_config.id, keyring.current.?.keys[0].id);
 }
 
 const KeyringState = struct {
@@ -1502,15 +1528,74 @@ const KeyringState = struct {
     current_generation: u64,
     next_generation: u64,
     ledger_len: usize,
+    current_key_count: usize,
+    ledger_count: usize,
+    current_keys: [max_keys]KeyState = undefined,
+    ledger_entries: [max_keys + 4]LedgerState = undefined,
+};
+
+const KeyState = struct {
+    id: KeyId,
+    aead: provider.Aead,
+    not_before_unix_ms: i64,
+    encrypt_until_unix_ms: i64,
+    decrypt_until_unix_ms: i64,
+    lease: LeaseState,
+};
+
+const LeaseState = struct {
+    key_id: KeyId = [_]u8{0} ** key_id_len,
+    prefix: [4]u8 = [_]u8{0} ** 4,
+    next_counter: u64 = 0,
+    end_exclusive: u64 = 0,
+    has_lease: bool = false,
+};
+
+const LedgerState = struct {
+    lease: LeaseState,
+    aead: provider.Aead,
+    key_fingerprint: KeyFingerprint,
 };
 
 fn captureKeyringState(keyring: *ReloadableKeyRing) KeyringState {
-    return .{
+    var state = KeyringState{
         .current = keyring.current,
         .current_generation = if (keyring.current) |current| current.generation else 0,
         .next_generation = keyring.next_generation,
         .ledger_len = keyring.ledger.items.len,
+        .current_key_count = 0,
+        .ledger_count = 0,
     };
+    if (keyring.current) |current| {
+        std.debug.assert(current.keys.len <= state.current_keys.len);
+        state.current_key_count = current.keys.len;
+        for (current.keys, 0..) |*key, i| {
+            state.current_keys[i] = .{
+                .id = key.id,
+                .aead = key.aead,
+                .not_before_unix_ms = key.not_before_unix_ms,
+                .encrypt_until_unix_ms = key.encrypt_until_unix_ms,
+                .decrypt_until_unix_ms = key.decrypt_until_unix_ms,
+                .lease = leaseStateFromKey(key),
+            };
+        }
+    }
+    std.debug.assert(keyring.ledger.items.len <= state.ledger_entries.len);
+    state.ledger_count = keyring.ledger.items.len;
+    for (keyring.ledger.items, 0..) |entry, i| {
+        state.ledger_entries[i] = .{
+            .lease = .{
+                .key_id = entry.key_id,
+                .prefix = entry.prefix,
+                .next_counter = 0,
+                .end_exclusive = entry.end_exclusive,
+                .has_lease = entry.has_lease,
+            },
+            .aead = entry.aead,
+            .key_fingerprint = entry.key_fingerprint,
+        };
+    }
+    return state;
 }
 
 fn expectKeyringStateEqual(expected: KeyringState, keyring: *ReloadableKeyRing) !void {
@@ -1518,6 +1603,58 @@ fn expectKeyringStateEqual(expected: KeyringState, keyring: *ReloadableKeyRing) 
     try testing.expectEqual(expected.current_generation, if (keyring.current) |current| current.generation else 0);
     try testing.expectEqual(expected.next_generation, keyring.next_generation);
     try testing.expectEqual(expected.ledger_len, keyring.ledger.items.len);
+    try testing.expectEqual(expected.current_key_count, if (keyring.current) |current| current.keys.len else 0);
+    if (keyring.current) |current| {
+        for (current.keys, 0..) |*key, i| {
+            try expectKeyStateEqual(expected.current_keys[i], key);
+        }
+    }
+    try testing.expectEqual(expected.ledger_count, keyring.ledger.items.len);
+    for (keyring.ledger.items, 0..) |entry, i| {
+        try expectLedgerStateEqual(expected.ledger_entries[i], entry);
+    }
+}
+
+fn leaseStateFromKey(key: *const KeyRecord) LeaseState {
+    if (key.nonce_lease) |*lease| {
+        return .{
+            .key_id = key.id,
+            .prefix = lease.prefix,
+            .next_counter = lease.next_counter.load(.acquire),
+            .end_exclusive = lease.currentEnd(),
+            .has_lease = true,
+        };
+    }
+    return .{ .key_id = key.id };
+}
+
+fn expectKeyStateEqual(expected: KeyState, key: *const KeyRecord) !void {
+    try testing.expectEqualSlices(u8, &expected.id, &key.id);
+    try testing.expectEqual(expected.aead, key.aead);
+    try testing.expectEqual(expected.not_before_unix_ms, key.not_before_unix_ms);
+    try testing.expectEqual(expected.encrypt_until_unix_ms, key.encrypt_until_unix_ms);
+    try testing.expectEqual(expected.decrypt_until_unix_ms, key.decrypt_until_unix_ms);
+    try expectLeaseStateEqual(expected.lease, leaseStateFromKey(key));
+}
+
+fn expectLedgerStateEqual(expected: LedgerState, entry: *const LeaseHighWater) !void {
+    try expectLeaseStateEqual(expected.lease, .{
+        .key_id = entry.key_id,
+        .prefix = entry.prefix,
+        .next_counter = 0,
+        .end_exclusive = entry.end_exclusive,
+        .has_lease = entry.has_lease,
+    });
+    try testing.expectEqual(expected.aead, entry.aead);
+    try testing.expectEqualSlices(u8, &expected.key_fingerprint, &entry.key_fingerprint);
+}
+
+fn expectLeaseStateEqual(expected: LeaseState, actual: LeaseState) !void {
+    try testing.expectEqualSlices(u8, &expected.key_id, &actual.key_id);
+    try testing.expectEqualSlices(u8, &expected.prefix, &actual.prefix);
+    try testing.expectEqual(expected.next_counter, actual.next_counter);
+    try testing.expectEqual(expected.end_exclusive, actual.end_exclusive);
+    try testing.expectEqual(expected.has_lease, actual.has_lease);
 }
 
 fn expectBuildErrorLeavesPublicationUnchanged(
@@ -1541,34 +1678,42 @@ fn expectBuildErrorLeavesPublicationUnchanged(
 }
 
 fn expectPartialBuildWipesCopiedKey(input: []const u8) !void {
-    var backing = [_]u8{0xcc} ** 16384;
-    var fba = std.heap.FixedBufferAllocator.init(&backing);
     var key_storage: [max_keys + 1][provider.max_aead_key_len + 1]u8 = undefined;
     var configs: [max_keys + 1]KeyConfig = undefined;
     const configs_slice = decodeSnapshotFuzzConfigs(input, &key_storage, &configs);
     const caps = fuzzCapabilities(input);
     const generation = fuzzGeneration(input);
-    const should_copy_first_key = configs_slice.len > 1 and firstConfigCopiesKey(configs_slice[0], caps);
-    const copied_key = if (should_copy_first_key) configs_slice[0].key_bytes else "";
+    const expected_deinit_count = initializedPrefixBeforeBuildFailure(configs_slice, caps);
+    if (expected_deinit_count == 0) return;
 
-    const snapshot = Snapshot.build(fba.allocator(), configs_slice, generation, caps) catch {
-        if (should_copy_first_key) {
-            try testing.expect(std.mem.indexOf(u8, &backing, copied_key) == null);
-        }
+    var probe = KeyDeinitProbe{};
+    test_key_deinit_probe = &probe;
+    defer test_key_deinit_probe = null;
+
+    const snapshot = Snapshot.build(testing.allocator, configs_slice, generation, caps) catch {
+        try testing.expectEqual(expected_deinit_count, probe.observed);
         return;
     };
     snapshot.release();
 }
 
-fn firstConfigCopiesKey(config: KeyConfig, caps: provider.Capabilities) bool {
-    if (!caps.supportsAead(config.aead)) return false;
-    if (config.key_bytes.len != config.aead.keyLength()) return false;
-    if (!(config.not_before_unix_ms < config.encrypt_until_unix_ms and
-        config.encrypt_until_unix_ms <= config.decrypt_until_unix_ms)) return false;
-    if (config.nonce_lease) |lease| {
-        if (lease.start >= lease.end_exclusive) return false;
+fn initializedPrefixBeforeBuildFailure(configs: []const KeyConfig, caps: provider.Capabilities) usize {
+    var initialized: usize = 0;
+    for (configs, 0..) |config, i| {
+        for (configs[0..i]) |prior| {
+            if (std.mem.eql(u8, &prior.id, &config.id)) return initialized;
+            if (prior.aead == config.aead and std.mem.eql(u8, prior.key_bytes, config.key_bytes)) return initialized;
+        }
+        if (!caps.supportsAead(config.aead)) return initialized;
+        if (config.key_bytes.len != config.aead.keyLength()) return initialized;
+        if (!(config.not_before_unix_ms < config.encrypt_until_unix_ms and
+            config.encrypt_until_unix_ms <= config.decrypt_until_unix_ms)) return initialized;
+        if (config.nonce_lease) |lease| {
+            if (lease.start >= lease.end_exclusive) return initialized;
+        }
+        initialized += 1;
     }
-    return true;
+    return 0;
 }
 
 fn byteAt(input: []const u8, idx: usize) u8 {
@@ -1895,6 +2040,19 @@ test "fuzz: ticket snapshot configs preserve bounded build invariants" {
     var generation_overflow = snapshotSeed(1, 0xff, 3, 3);
     writeSnapshotSeedRecord(&generation_overflow, 0, .{ .aead = 0, .key_seed = 0xb0, .id_seed = 0xb0 });
 
+    var stale_generation = snapshotSeed(1, 0xff, 3, 1);
+    writeSnapshotSeedRecord(&stale_generation, 0, .{ .aead = 0, .key_seed = 0xb8, .id_seed = 0xb8 });
+
+    var non_overlapping_replacement_lease = snapshotSeed(1, 0xff, 3, 0);
+    writeSnapshotSeedRecord(&non_overlapping_replacement_lease, 0, .{
+        .aead = 0,
+        .key_seed = 0xbc,
+        .id_seed = 0xbc,
+        .lease_enabled = true,
+        .lease_case = 6,
+        .lease_value = 1,
+    });
+
     var overlapping_replacement_lease = snapshotSeed(1, 0xff, 3, 0);
     writeSnapshotSeedRecord(&overlapping_replacement_lease, 0, .{
         .aead = 0,
@@ -1917,6 +2075,8 @@ test "fuzz: ticket snapshot configs preserve bounded build invariants" {
     try expectSnapshotSeedOutcome(&exact_max_keys, .build_success);
     try expectSnapshotSeedOutcome(&max_plus_one_keys, .too_many_keys);
     try expectSnapshotSeedOutcome(&generation_overflow, .generation_overflow);
+    try expectSnapshotSeedOutcome(&stale_generation, .stale_generation);
+    try expectSnapshotSeedOutcome(&non_overlapping_replacement_lease, .non_overlapping_nonce_lease);
     try expectSnapshotSeedOutcome(&overlapping_replacement_lease, .overlapping_nonce_lease);
 
     try testing.fuzz({}, fuzzTicketSnapshotConfigInput, .{ .corpus = &.{
@@ -1932,6 +2092,8 @@ test "fuzz: ticket snapshot configs preserve bounded build invariants" {
         &exact_max_keys,
         &max_plus_one_keys,
         &generation_overflow,
+        &stale_generation,
+        &non_overlapping_replacement_lease,
         &overlapping_replacement_lease,
     } });
 }
@@ -1990,9 +2152,25 @@ fn expectSnapshotSeedOutcome(input: []const u8, outcome: SnapshotFuzzOutcome) !v
     const caps = fuzzCapabilities(input);
     const generation = fuzzGeneration(input);
 
+    if (outcome == .non_overlapping_nonce_lease) {
+        try testing.expect(configs_slice.len > 0);
+        try exerciseReplacementInstall(testing.allocator, configs_slice[0], generation, caps, false);
+        return;
+    }
     if (outcome == .overlapping_nonce_lease) {
         try testing.expect(configs_slice.len > 0);
         try exerciseReplacementInstall(testing.allocator, configs_slice[0], generation, caps, true);
+        return;
+    }
+    if (outcome == .stale_generation) {
+        const candidate = try Snapshot.build(testing.allocator, configs_slice, generation, caps);
+        var keyring = ReloadableKeyRing.init(testing.allocator);
+        defer keyring.deinit();
+        const current = sampleKeyConfigWithByte(keyId(0xd1), .aes_128_gcm, .{ .prefix = .{ 0xd1, 0, 0, 0 }, .start = 0, .end_exclusive = 4 }, 0x11);
+        try keyring.install(try keyring.buildSnapshot(&.{current}, testCapabilities()));
+        const before = captureKeyringState(&keyring);
+        try testing.expectError(error.StaleSnapshotGeneration, keyring.install(candidate));
+        try expectKeyringStateEqual(before, &keyring);
         return;
     }
     if (outcome == .generation_overflow) {
@@ -2021,7 +2199,7 @@ fn expectSnapshotSeedOutcome(input: []const u8, outcome: SnapshotFuzzOutcome) !v
         .invalid_validity_window => try testing.expectError(error.InvalidValidityWindow, result),
         .invalid_nonce_lease => try testing.expectError(error.InvalidNonceLease, result),
         .ambiguous_encryption_window => try testing.expectError(error.AmbiguousEncryptionWindow, result),
-        .generation_overflow, .overlapping_nonce_lease => unreachable,
+        .stale_generation, .generation_overflow, .non_overlapping_nonce_lease, .overlapping_nonce_lease => unreachable,
     }
 }
 

--- a/src/tls/ticket_protection.zig
+++ b/src/tls/ticket_protection.zig
@@ -1335,6 +1335,186 @@ pub fn fuzzTicketIdentity(allocator: std.mem.Allocator, input: []const u8) !void
     }
 }
 
+pub fn fuzzSnapshotConfig(allocator: std.mem.Allocator, input: []const u8) !void {
+    const config_count = if (input.len == 0) 0 else @as(usize, input[0] % (max_keys + 2));
+    var key_storage: [max_keys + 1][provider.max_aead_key_len + 1]u8 = undefined;
+    var configs: [max_keys + 1]KeyConfig = undefined;
+
+    for (configs[0..@min(config_count, configs.len)], 0..) |*config, i| {
+        const base = i * 13 + 1;
+        const aead = fuzzAead(byteAt(input, base));
+        const exact_len = aead.keyLength();
+        const len = switch (byteAt(input, base + 1) % 5) {
+            0 => 0,
+            1 => exact_len - 1,
+            2 => exact_len,
+            3 => exact_len + 1,
+            else => @min(provider.max_aead_key_len + 1, exact_len + (byteAt(input, base + 2) % 3)),
+        };
+        for (key_storage[i][0..], 0..) |*byte, j| {
+            byte.* = @truncate(byteAt(input, base + 3) +% @as(u8, @truncate(i * 17 + j)));
+        }
+
+        const time_case = byteAt(input, base + 4) % 8;
+        const not_before, const encrypt_until, const decrypt_until = fuzzWindows(time_case);
+
+        const lease = if ((byteAt(input, base + 5) & 0x01) == 0)
+            null
+        else
+            fuzzLease(input, base + 6);
+
+        config.* = .{
+            .id = fuzzKeyId(input, base + 10, @intCast(i)),
+            .aead = aead,
+            .key_bytes = key_storage[i][0..len],
+            .not_before_unix_ms = not_before,
+            .encrypt_until_unix_ms = encrypt_until,
+            .decrypt_until_unix_ms = decrypt_until,
+            .nonce_lease = lease,
+        };
+    }
+
+    if (config_count > 1) {
+        switch (byteAt(input, 2) % 4) {
+            0 => configs[1].id = configs[0].id,
+            1 => configs[1].key_bytes = configs[0].key_bytes,
+            2 => {
+                configs[1].nonce_lease = configs[0].nonce_lease;
+                configs[1].not_before_unix_ms = configs[0].not_before_unix_ms;
+                configs[1].encrypt_until_unix_ms = configs[0].encrypt_until_unix_ms;
+            },
+            else => {},
+        }
+    }
+
+    const caps = fuzzCapabilities(input);
+    const generation = fuzzGeneration(input);
+    const snapshot = Snapshot.build(allocator, configs[0..@min(config_count, configs.len)], generation, caps) catch {
+        try expectKeyringStillPublishesCurrent(allocator);
+        return;
+    };
+    defer snapshot.release();
+
+    try testing.expect(config_count >= 1 and config_count <= max_keys);
+    try testing.expectEqual(config_count, snapshot.keys.len);
+    for (snapshot.keys) |*key| {
+        try testing.expect(caps.supportsAead(key.aead));
+        try testing.expectEqual(key.aead.keyLength(), key.key.len);
+        try testing.expect(key.not_before_unix_ms < key.encrypt_until_unix_ms);
+        try testing.expect(key.encrypt_until_unix_ms <= key.decrypt_until_unix_ms);
+        if (key.nonce_lease) |*lease| {
+            try testing.expect(lease.next_counter.load(.acquire) < lease.currentEnd());
+        }
+    }
+
+    var keyring = ReloadableKeyRing.init(allocator);
+    defer keyring.deinit();
+    const current = sampleKeyConfigWithByte(keyId(0xee), .aes_128_gcm, .{ .prefix = .{ 0xee, 0, 0, 0 }, .start = 0, .end_exclusive = 4 }, 0x11);
+    try keyring.install(try keyring.buildSnapshot(&.{current}, testCapabilities()));
+    const before_current = keyring.current.?;
+    const before_generation = before_current.generation;
+    const before_next_generation = keyring.next_generation;
+    const before_ledger_len = keyring.ledger.items.len;
+
+    const candidate = Snapshot.build(allocator, configs[0..@min(config_count, configs.len)], generation, caps) catch return;
+    keyring.validateInstallCandidate(candidate) catch {
+        candidate.release();
+        try testing.expectEqual(before_current, keyring.current.?);
+        try testing.expectEqual(before_generation, keyring.current.?.generation);
+        try testing.expectEqual(before_next_generation, keyring.next_generation);
+        try testing.expectEqual(before_ledger_len, keyring.ledger.items.len);
+        return;
+    };
+    candidate.release();
+}
+
+fn byteAt(input: []const u8, idx: usize) u8 {
+    return if (idx < input.len) input[idx] else 0;
+}
+
+fn fuzzAead(byte: u8) provider.Aead {
+    return switch (byte % 3) {
+        0 => .aes_128_gcm,
+        1 => .aes_256_gcm,
+        else => .chacha20_poly1305,
+    };
+}
+
+fn fuzzKeyId(input: []const u8, offset: usize, fallback: u8) KeyId {
+    var id = [_]u8{fallback} ** key_id_len;
+    for (&id, 0..) |*byte, i| {
+        byte.* = byteAt(input, offset + i);
+    }
+    return id;
+}
+
+fn fuzzWindows(case: u8) struct { i64, i64, i64 } {
+    return switch (case) {
+        0 => .{ 0, 1, 1 },
+        1 => .{ 1_000, 5_000, 20_000 },
+        2 => .{ 5_000, 5_000, 20_000 },
+        3 => .{ 5_000, 4_999, 20_000 },
+        4 => .{ 1_000, 20_000, 19_999 },
+        5 => .{ std.math.minInt(i64), -1, 0 },
+        6 => .{ std.math.maxInt(i64) - 2, std.math.maxInt(i64) - 1, std.math.maxInt(i64) },
+        else => .{ 1_000, 5_000, 5_000 },
+    };
+}
+
+fn fuzzLease(input: []const u8, offset: usize) NonceLeaseConfig {
+    const start, const end = switch (byteAt(input, offset + 4) % 7) {
+        0 => .{ @as(u64, 0), @as(u64, 1) },
+        1 => .{ @as(u64, 0), @as(u64, 0) },
+        2 => .{ @as(u64, 2), @as(u64, 1) },
+        3 => .{ std.math.maxInt(u64) - 1, std.math.maxInt(u64) },
+        4 => .{ std.math.maxInt(u64), std.math.maxInt(u64) },
+        5 => .{ @as(u64, 65_534), @as(u64, 65_535) },
+        else => .{ @as(u64, byteAt(input, offset + 5)), @as(u64, byteAt(input, offset + 5)) + 2 },
+    };
+    return .{
+        .prefix = .{
+            byteAt(input, offset),
+            byteAt(input, offset + 1),
+            byteAt(input, offset + 2),
+            byteAt(input, offset + 3),
+        },
+        .start = start,
+        .end_exclusive = end,
+    };
+}
+
+fn fuzzCapabilities(input: []const u8) provider.Capabilities {
+    if (input.len > 1 and (input[1] & 0x01) != 0) return testCapabilities();
+    var caps = provider.Capabilities{};
+    if (input.len > 1 and (input[1] & 0x02) != 0) caps.aeads.insert(.aes_128_gcm);
+    if (input.len > 1 and (input[1] & 0x04) != 0) caps.aeads.insert(.aes_256_gcm);
+    if (input.len > 1 and (input[1] & 0x08) != 0) caps.aeads.insert(.chacha20_poly1305);
+    return caps;
+}
+
+fn fuzzGeneration(input: []const u8) u64 {
+    if (input.len < 4) return 0;
+    return switch (input[3] % 5) {
+        0 => 0,
+        1 => 1,
+        2 => std.math.maxInt(u64) - 1,
+        3 => std.math.maxInt(u64),
+        else => std.mem.readInt(u16, input[0..2], .big),
+    };
+}
+
+fn expectKeyringStillPublishesCurrent(allocator: std.mem.Allocator) !void {
+    var keyring = ReloadableKeyRing.init(allocator);
+    defer keyring.deinit();
+    const current = sampleKeyConfigWithByte(keyId(0xed), .aes_128_gcm, .{ .prefix = .{ 0xed, 0, 0, 0 }, .start = 0, .end_exclusive = 4 }, 0x11);
+    try keyring.install(try keyring.buildSnapshot(&.{current}, testCapabilities()));
+    const before_current = keyring.current.?;
+    const before_generation = before_current.generation;
+    try testing.expectError(error.TooManyKeys, keyring.buildSnapshot(&.{}, testCapabilities()));
+    try testing.expectEqual(before_current, keyring.current.?);
+    try testing.expectEqual(before_generation, keyring.current.?.generation);
+}
+
 const ConcurrentSealTask = struct {
     protector: *Protector,
     state: *const session.ServerRecoverableState,
@@ -1525,6 +1705,107 @@ test "fuzz helper preserves output on resolver allocation errors" {
     var decode_failing = testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 1 });
     try testing.expectError(error.OutOfMemory, protector.resolve(decode_failing.allocator(), ticket, 2_000, &out));
     try expectServerStateEqual(&expected, &out);
+}
+
+test "fuzz: ticket snapshot configs preserve bounded build invariants" {
+    const empty_config_count = [_]u8{};
+    const exact_one_aes128 = [_]u8{
+        1,    0xff, 0xff, 0,
+        0,    2,    0x11, 1,
+        0,    1,    0x10, 0x10,
+        0x10, 0x10, 0x10, 0x10,
+        0x10, 0x10, 0x10, 0x10,
+        0x10, 0x10, 0x10, 0x10,
+        0x10, 0x10,
+    };
+    const exact_one_aes256 = [_]u8{
+        1,    0xff, 0xff, 0,
+        1,    2,    0x22, 1,
+        0,    1,    0x20, 0x20,
+        0x20, 0x20, 0x20, 0x20,
+        0x20, 0x20, 0x20, 0x20,
+        0x20, 0x20, 0x20, 0x20,
+        0x20, 0x20,
+    };
+    const exact_one_chacha = [_]u8{
+        1,    0xff, 0xff, 0,
+        2,    2,    0x33, 1,
+        0,    1,    0x30, 0x30,
+        0x30, 0x30, 0x30, 0x30,
+        0x30, 0x30, 0x30, 0x30,
+        0x30, 0x30, 0x30, 0x30,
+        0x30, 0x30,
+    };
+    const duplicate_id = [_]u8{
+        2,    0xff, 0,    0,
+        0,    2,    0x11, 1,
+        0,    1,    0xaa, 0xaa,
+        0xaa, 0xaa, 0xaa, 0xaa,
+        0xaa, 0xaa, 0xaa, 0xaa,
+        0xaa, 0xaa, 0xaa, 0xaa,
+        0xaa, 0xaa, 1,    2,
+        0x22, 1,    0,    1,
+        0xbb, 0xbb, 0xbb, 0xbb,
+        0xbb, 0xbb, 0xbb, 0xbb,
+        0xbb, 0xbb, 0xbb, 0xbb,
+        0xbb, 0xbb, 0xbb, 0xbb,
+    };
+    const unsupported_capability = [_]u8{
+        1,    0,    0xff, 0,
+        2,    2,    0x44, 1,
+        0,    1,    0x40, 0x40,
+        0x40, 0x40, 0x40, 0x40,
+        0x40, 0x40, 0x40, 0x40,
+        0x40, 0x40, 0x40, 0x40,
+        0x40, 0x40,
+    };
+    const invalid_window = [_]u8{
+        1,    0xff, 0xff, 0,
+        0,    2,    0x55, 2,
+        0,    1,    0x50, 0x50,
+        0x50, 0x50, 0x50, 0x50,
+        0x50, 0x50, 0x50, 0x50,
+        0x50, 0x50, 0x50, 0x50,
+        0x50, 0x50,
+    };
+    const invalid_lease = [_]u8{
+        1,    0xff, 0xff, 0,
+        0,    2,    0x66, 1,
+        1,    1,    0x60, 0x60,
+        0x60, 0x60, 0x60, 0x60,
+        0x60, 0x60, 0x60, 0x60,
+        0x60, 0x60, 0x60, 0x60,
+        0x60, 0x60,
+    };
+    const max_plus_one_keys = [_]u8{ max_keys + 1, 0xff, 0xff, 0 };
+    const generation_overflow = [_]u8{
+        1,    0xff, 0xff, 3,
+        0,    2,    0x77, 1,
+        0,    1,    0x70, 0x70,
+        0x70, 0x70, 0x70, 0x70,
+        0x70, 0x70, 0x70, 0x70,
+        0x70, 0x70, 0x70, 0x70,
+        0x70, 0x70,
+    };
+
+    try testing.fuzz({}, fuzzTicketSnapshotConfigInput, .{ .corpus = &.{
+        &empty_config_count,
+        &exact_one_aes128,
+        &exact_one_aes256,
+        &exact_one_chacha,
+        &duplicate_id,
+        &unsupported_capability,
+        &invalid_window,
+        &invalid_lease,
+        &max_plus_one_keys,
+        &generation_overflow,
+    } });
+}
+
+fn fuzzTicketSnapshotConfigInput(_: void, smith: *testing.Smith) !void {
+    var input_buf: [1 + (max_keys + 1) * 13]u8 = undefined;
+    const len = smith.slice(&input_buf);
+    try fuzzSnapshotConfig(testing.allocator, input_buf[0..len]);
 }
 
 test "protectedLen reserves envelope overhead exactly" {


### PR DESCRIPTION
## Summary
- add a bounded ticket snapshot config fuzz helper for Snapshot.build inputs
- seed key count, duplicate id/key, AEAD capability, key length, validity window, nonce lease, generation boundary, stale-generation, ambiguous-window, and replacement overlap/non-overlap cases
- assert rejected snapshot/candidate/install paths leave the live keyring publication state unchanged, including current key nonce state and non-secret ledger contents
- verify partial Snapshot.build failures wipe every initialized copied key through a test-only thread-local cleanup probe, including temporary key cleanup before KeyRecord construction
- avoid copying or diagnosing secret-derived key fingerprints in publication-state assertions

Refs #376

## Tests
- zig fmt --check build.zig src/ tests/
- zig build test --summary all --error-style verbose