### PR TITLE
tls: [323-G3] make the shared TLS 1.3 handshake cipher/hash agile

### DIFF
--- a/docs/CRYPTO_PROVIDER.md
+++ b/docs/CRYPTO_PROVIDER.md
@@ -91,14 +91,18 @@ data, not prose:
   `EnumSet(ProductProfile)` (`.native_appliance`, `.general_purpose_openssl`):
   which product actually selects this capability. This is authored per row,
   not derived from `pure_zig_status`/`openssl_status` — primitive support
-  does not imply product selectability. AES-256-GCM and ChaCha20-Poly1305
-  both report `pure_zig_status = .supported` but neither is negotiated by the
-  native appliance, so neither claims `.native_appliance`; secp256r1 has
+  does not imply product selectability. secp256r1 is the standing example:
   `openssl_status = .provider_deferred` (no in-process OpenSSL
-  `CryptoProvider` yet) but the real general-purpose OpenSSL product supports
-  P-256 ECDH outside this seam, so it still claims `.general_purpose_openssl`.
-  See `profile.zig`'s "enabled product profiles are not a mechanical copy of
-  primitive support" test.
+  `CryptoProvider` yet), but the real general-purpose OpenSSL product
+  supports P-256 ECDH outside this seam, so it still claims
+  `.general_purpose_openssl` even though the pure-Zig backend does not
+  implement the group at all and can never claim `.native_appliance`.
+  AES-256-GCM and ChaCha20-Poly1305 used to illustrate the same asymmetry
+  (`pure_zig_status = .supported` but not negotiated by the native
+  appliance); since #564 made the native engine's handshake/transcript/key
+  schedule cipher/hash-agile, both are negotiated there too and now claim
+  `.native_appliance`. See `profile.zig`'s "enabled product profiles are not
+  a mechanical copy of primitive support" test.
 
 ## Supported profile matrix
 
@@ -110,12 +114,12 @@ lists only the consumers whose live runtime calls `CryptoProvider` today
 | Capability | Pure-Zig status | Pure-Zig implementation | OpenSSL status | Consumers | Live integration | Product profiles |
 | --- | --- | --- | --- | --- | --- | --- |
 | SHA-256 | supported | `std.crypto` | provider deferred | TLS transcript, HKDF, QUIC TLS bridge | none — unkeyed hashing has no `CryptoProvider` entry point by design | native appliance, general-purpose OpenSSL |
-| SHA-384 | supported | `std.crypto` | provider deferred | TLS transcript, HKDF | none — unkeyed hashing has no `CryptoProvider` entry point by design | general-purpose OpenSSL only (the native appliance's engine negotiates TLS_AES_128_GCM_SHA256 only, so SHA-384 is never selected there) |
+| SHA-384 | supported | `std.crypto` | provider deferred | TLS transcript, HKDF | none — unkeyed hashing has no `CryptoProvider` entry point by design | native appliance, general-purpose OpenSSL (the native engine's transcript/key schedule are cipher/hash-agile, #564; SHA-384 is live whenever TLS_AES_256_GCM_SHA384 is negotiated) |
 | HKDF-SHA256 | supported | `std.crypto` HMAC/TLS label code | provider deferred | TLS 1.3 key schedule, QUIC packet protection | live — QUIC packet protection, the QUIC/TLS secret bridge, and the TLS 1.3 key schedule (`src/tls/key_schedule.zig`) all call `CryptoProvider.hkdfExtract`/`.hkdfExpandLabel` | native appliance, general-purpose OpenSSL |
-| HKDF-SHA384 | supported | `std.crypto` HMAC/TLS label code | provider deferred | TLS 1.3 key schedule | not integrated — `src/tls/key_schedule.zig`'s generic resumption helpers correctly route `.sha384` through `CryptoProvider` when called with it, but no live native TLS path ever calls them that way: the native engine negotiates TLS_AES_128_GCM_SHA256 only, so its resumption/ticket flow always derives SHA-256 secrets | general-purpose OpenSSL only (the native appliance's engine negotiates TLS_AES_128_GCM_SHA256 only, so HKDF-SHA384 is never selected there) |
+| HKDF-SHA384 | supported | `std.crypto` HMAC/TLS label code | provider deferred | TLS 1.3 key schedule | live — `src/tls/key_schedule.zig` is hash-agile (#564): `KeySchedule` and every resumption/ticket helper derive their hash from the negotiated suite (`algorithms.transcriptHash`) and route it through `CryptoProvider`, so a native handshake negotiating TLS_AES_256_GCM_SHA384 really does derive under SHA-384 | native appliance, general-purpose OpenSSL |
 | AES-128-GCM | supported | `std.crypto` | provider deferred | TLS records, QUIC packet protection | both — TLS record protection and QUIC packet protection seal/open through `CryptoProvider` | native appliance, general-purpose OpenSSL |
-| AES-256-GCM | supported | `std.crypto` | provider deferred | TLS records; QUIC integration deferred | none — TLS_AES_256_GCM_SHA384 is not negotiated by the native appliance's engine | general-purpose OpenSSL only (negotiated there outside this seam) |
-| ChaCha20-Poly1305 | supported | `std.crypto` | provider deferred | protocol integration deferred | none | general-purpose OpenSSL only |
+| AES-256-GCM | supported | `std.crypto` | provider deferred | TLS records | live — the native engine now negotiates TLS_AES_256_GCM_SHA384 (#564) through the existing generic `record_protection.TrafficKeys.derive` path, the same CryptoProvider-routed seal/open every suite uses | native appliance, general-purpose OpenSSL |
+| ChaCha20-Poly1305 | supported | `std.crypto` | provider deferred | TLS records | live — the native engine now negotiates TLS_CHACHA20_POLY1305_SHA256 (#564) through the same generic record-protection path | native appliance, general-purpose OpenSSL |
 | QUIC AES-128 header protection | supported | `std.crypto` behind provider mask API | provider deferred | QUIC packet protection | live — every send/receive path in `src/quic/tls_adapter.zig` applies/removes header protection through `CryptoProvider` | native appliance only (QUIC-specific; the general-purpose backend is TLS-over-TCP) |
 | X25519 | supported | `std.crypto` | provider deferred | TLS key share, QUIC TLS bridge | live — `src/tls/tls13_backend.zig` generates its ephemeral key share and derives the shared secret through `CryptoProvider.generateKeyShare`/`.deriveSharedSecret` | native appliance, general-purpose OpenSSL |
 | secp256r1 / P-256 | provider deferred | unavailable | provider deferred | TLS key share, PKI | none | general-purpose OpenSSL only (P-256 ECDH outside this seam; not implemented in pure Zig at all) |

--- a/src/crypto/profile.zig
+++ b/src/crypto/profile.zig
@@ -140,12 +140,12 @@ pub const Row = struct {
 
 pub const rows = [_]Row{
     row(.{ .hash = .sha256 }, "SHA-256", .zig_std_crypto, .supported, .openssl_provider, .provider_deferred, "std.crypto cross-checks, transcript tests", .{ .{ .tls_handshake, .not_provider_routed }, .{ .quic_tls_bridge, .not_provider_routed } }, .{ .native_appliance, .general_purpose_openssl }, "Unkeyed transcript hashing never crosses the CryptoProvider vtable by design (no `hash` entry point exists); both product profiles use it for TLS transcripts regardless. Hash additions require transcript/HKDF vectors."),
-    row(.{ .hash = .sha384 }, "SHA-384", .zig_std_crypto, .supported, .openssl_provider, .provider_deferred, "provider capability and HKDF tests", .{.{ .tls_handshake, .not_provider_routed }}, .{.general_purpose_openssl}, "Unkeyed transcript hashing; the native appliance negotiates TLS_AES_128_GCM_SHA256 only, so SHA-384 is not selected there. Hash additions require TLS 1.3 suite mapping."),
+    row(.{ .hash = .sha384 }, "SHA-384", .zig_std_crypto, .supported, .openssl_provider, .provider_deferred, "provider capability and HKDF tests", .{.{ .tls_handshake, .not_provider_routed }}, .{ .native_appliance, .general_purpose_openssl }, "Unkeyed transcript hashing; the native appliance now negotiates TLS_AES_256_GCM_SHA384 (#564), so this hash is selected there whenever that suite is chosen. Never provider-routed by design, same as SHA-256 (see that row)."),
     row(.{ .hkdf = .sha256 }, "HKDF-SHA256", .zig_std_crypto, .supported, .openssl_provider, .provider_deferred, "RFC 5869/std.crypto and TLS expand-label parity", .{ .{ .tls_handshake, .live }, .{ .quic_tls_bridge, .live }, .{ .quic_packet_protection, .live } }, .{ .native_appliance, .general_purpose_openssl }, "QUIC Initial/Handshake/1-RTT key derivation in src/quic/tls_adapter.zig and the TLS 1.3 key schedule (src/tls/key_schedule.zig: HKDF-Extract, HKDF-Expand-Label, and Finished verify_data) both run through CryptoProvider (#490)."),
-    row(.{ .hkdf = .sha384 }, "HKDF-SHA384", .zig_std_crypto, .supported, .openssl_provider, .provider_deferred, "provider capability and expand-label tests", .{.{ .tls_handshake, .not_integrated }}, .{.general_purpose_openssl}, "The generic hash-parameterized helpers in src/tls/key_schedule.zig (deriveResumptionMasterSecret, resumptionPsk) accept and correctly route .sha384 through CryptoProvider when called with it (#490), but no live native TLS path ever calls them that way: the native engine negotiates TLS_AES_128_GCM_SHA256 only, so its own resumption/ticket flow always derives SHA-256 secrets, and the general-purpose OpenSSL backend that can negotiate SHA-384 runs entirely outside this CryptoProvider seam. Helper capability/testability is not the same as a live protocol path selecting it — stays not_integrated for tls_handshake until a native suite can actually select SHA-384."),
+    row(.{ .hkdf = .sha384 }, "HKDF-SHA384", .zig_std_crypto, .supported, .openssl_provider, .provider_deferred, "provider capability and expand-label tests", .{.{ .tls_handshake, .live }}, .{ .native_appliance, .general_purpose_openssl }, "The TLS 1.3 key schedule (src/tls/key_schedule.zig) is hash-agile (#564): `KeySchedule` and every resumption/ticket helper derive their hash from the negotiated cipher suite (`algorithms.transcriptHash`) and route it through CryptoProvider, so a native handshake that negotiates TLS_AES_256_GCM_SHA384 derives every handshake/application/resumption secret under SHA-384 live, not merely a capability the provider happens to support."),
     row(.{ .aead = .aes_128_gcm }, "AES-128-GCM", .zig_std_crypto, .supported, .openssl_provider, .provider_deferred, "seal/open round-trip, tamper rejection, AD mismatch", .{ .{ .tls_record, .live }, .{ .quic_packet_protection, .live } }, .{ .native_appliance, .general_purpose_openssl }, "TLS record protection and QUIC packet payload protection (TLS_AES_128_GCM_SHA256) both seal/open through CryptoProvider."),
-    row(.{ .aead = .aes_256_gcm }, "AES-256-GCM", .zig_std_crypto, .supported, .openssl_provider, .provider_deferred, "seal/open round-trip, tamper rejection, AD mismatch", .{.{ .tls_record, .not_integrated }}, .{.general_purpose_openssl}, "Provider primitive exists and the record layer is provider-routed generically, but TLS_AES_256_GCM_SHA384 is not negotiated by the native appliance's engine yet, so this AEAD is never selected there; the general-purpose OpenSSL backend negotiates it outside this seam."),
-    row(.{ .aead = .chacha20_poly1305 }, "ChaCha20-Poly1305", .zig_std_crypto, .supported, .openssl_provider, .provider_deferred, "seal/open round-trip, tamper rejection, AD mismatch", .{}, .{.general_purpose_openssl}, "Provider primitive exists; the native appliance does not negotiate this suite. The general-purpose OpenSSL backend negotiates it outside this seam."),
+    row(.{ .aead = .aes_256_gcm }, "AES-256-GCM", .zig_std_crypto, .supported, .openssl_provider, .provider_deferred, "seal/open round-trip, tamper rejection, AD mismatch", .{.{ .tls_record, .live }}, .{ .native_appliance, .general_purpose_openssl }, "The native appliance's engine now negotiates TLS_AES_256_GCM_SHA384 (#564) and reuses the existing generic `record_protection.TrafficKeys.derive` path for it — the same CryptoProvider-routed seal/open every other suite uses, not a second AES-256 implementation."),
+    row(.{ .aead = .chacha20_poly1305 }, "ChaCha20-Poly1305", .zig_std_crypto, .supported, .openssl_provider, .provider_deferred, "seal/open round-trip, tamper rejection, AD mismatch", .{.{ .tls_record, .live }}, .{ .native_appliance, .general_purpose_openssl }, "The native appliance's engine now negotiates TLS_CHACHA20_POLY1305_SHA256 (#564), through the same generic, CryptoProvider-routed record-protection path as the other two suites."),
     row(.{ .quic_header_protection = .aes_128 }, "QUIC AES-128 header protection", .zig_std_crypto, .supported, .openssl_provider, .provider_deferred, "RFC 9001 header-protection sample and provider mask parity", .{.{ .quic_packet_protection, .live }}, .{.native_appliance}, "src/quic/tls_adapter.zig applies and removes header protection through CryptoProvider on every send/receive path (#490); the direct Aes128.initEnc form remains only as differential test-vector fixtures. QUIC-specific: the general-purpose backend is TLS-over-TCP, not QUIC."),
     row(.{ .group = .x25519 }, "X25519", .zig_std_crypto, .supported, .openssl_provider, .provider_deferred, "std.crypto scalar multiplication parity, low-order rejection", .{ .{ .tls_handshake, .live }, .{ .quic_tls_bridge, .not_integrated } }, .{ .native_appliance, .general_purpose_openssl }, "src/tls/tls13_backend.zig generates its ephemeral key share and derives the shared secret through CryptoProvider.generateKeyShare/.deriveSharedSecret (#490); group additions require key-share and shared-secret vectors."),
     row(.{ .group = .secp256r1 }, "secp256r1 (P-256)", .unavailable, .provider_deferred, .openssl_provider, .provider_deferred, "capability rejection tests", .{ .{ .tls_handshake, .not_integrated }, .{ .quic_tls_bridge, .not_integrated }, .{ .pki, .not_integrated } }, .{.general_purpose_openssl}, "Not implemented in the pure-Zig backend at all, so unavailable to the native appliance regardless of CryptoProvider routing; the general-purpose OpenSSL backend supports P-256 ECDH outside this seam. P-256 support here requires explicit provider implementation and ECDH vectors."),
@@ -313,21 +313,23 @@ test "QUIC packet protection is live-integrated through CryptoProvider" {
     try expectIntegration(.{ .quic_header_protection = .aes_128 }, .quic_packet_protection, .live);
 }
 
-// Anchors the native TLS 1.3 engine claims this PR made true (#490): the
-// handshake's key schedule, key exchange, and CertificateVerify all call
-// CryptoProvider, not a parallel std.crypto path — and RSA-PSS and
-// HKDF-SHA384 both stay deliberately not_integrated for tls_handshake, since
-// the engine's CertificateVerify never negotiates RSA and its live protocol
-// path (TLS_AES_128_GCM_SHA256 only) never selects SHA-384, even though the
-// provider primitives exist, key_schedule.zig's generic helpers correctly
-// route .sha384 when called with it, and RSA's PKI integration is .live. A
-// helper being capable and tested is not the same as a live protocol path
-// selecting it. A future regression that quietly reintroduces a concrete
-// bypass, or over-claims support the live protocol path cannot execute, is
-// now a typed test failure, not just stale prose.
+// Anchors the native TLS 1.3 engine claims this PR made true (#490), updated
+// for #564's cipher/hash agility: the handshake's key schedule, key
+// exchange, and CertificateVerify all call CryptoProvider, not a parallel
+// std.crypto path. HKDF-SHA384 is now `.live` for tls_handshake — the key
+// schedule derives every secret's hash from the negotiated suite
+// (`algorithms.transcriptHash`), so a native handshake that selects
+// TLS_AES_256_GCM_SHA384 really does derive under SHA-384, not merely a
+// capability the provider happens to support. RSA-PSS stays deliberately
+// not_integrated: the engine's CertificateVerify still never negotiates RSA
+// (a separate, #564-independent suite/credential addition), even though the
+// provider primitive exists and RSA's PKI integration is `.live`. A future
+// regression that quietly reintroduces a concrete bypass, or over-claims
+// support the live protocol path cannot execute, is now a typed test
+// failure, not just stale prose.
 test "native TLS 1.3 handshake engine is live-integrated through CryptoProvider" {
     try expectIntegration(.{ .hkdf = .sha256 }, .tls_handshake, .live);
-    try expectIntegration(.{ .hkdf = .sha384 }, .tls_handshake, .not_integrated);
+    try expectIntegration(.{ .hkdf = .sha384 }, .tls_handshake, .live);
     try expectIntegration(.{ .group = .x25519 }, .tls_handshake, .live);
     try expectIntegration(.{ .signature = .ed25519 }, .tls_handshake, .live);
     try expectIntegration(.{ .signature = .ecdsa_secp256r1_sha256 }, .tls_handshake, .live);
@@ -356,21 +358,29 @@ fn enabledProfilesFor(algorithm: Algorithm) ProductProfileSet {
 
 // Anchors the exact distinction the profile previously collapsed (#490
 // second-pass review): primitive support (`pure_zig_status`) is not the same
-// thing as product-level selectability. AES-256-GCM and ChaCha20-Poly1305
-// both report `pure_zig_status = .supported` but neither is negotiated by
-// the native appliance, so neither may claim `.native_appliance` here even
-// though a purely mechanical derivation from `.supported` would grant it.
-// secp256r1 is the mirror case: `openssl_status` (the in-process OpenSSL
-// CryptoProvider column) is `.provider_deferred`, but the real
-// general-purpose OpenSSL product supports P-256 ECDH outside this seam, so
-// it must still claim `.general_purpose_openssl`.
+// thing as product-level selectability — a row's `enabled_product_profiles`
+// is a deliberate product-integration claim, not a mechanical copy of
+// `.supported`. AES-256-GCM and ChaCha20-Poly1305 illustrated this asymmetry
+// before #564 (both reported `pure_zig_status = .supported` but neither was
+// negotiated by the native appliance); now that the native engine's
+// handshake/transcript/key-schedule are cipher/hash-agile and negotiate all
+// three suites, both correctly claim `.native_appliance` too — the
+// assertions below were updated in lockstep with the profile rows, not
+// dropped, so a future regression that silently un-claims either is still
+// caught. secp256r1 remains the standing example of the asymmetry: the
+// pure-Zig backend does not implement P-256 ECDH at all, so it can never
+// claim `.native_appliance` regardless of any future CryptoProvider
+// wiring — `openssl_status` (`.provider_deferred`, the in-process OpenSSL
+// CryptoProvider column) is beside the point; the real general-purpose
+// OpenSSL product supports P-256 ECDH outside this seam, so it must still
+// claim `.general_purpose_openssl`.
 test "enabled product profiles are not a mechanical copy of primitive support" {
     const aes_256_profiles = enabledProfilesFor(.{ .aead = .aes_256_gcm });
-    try std.testing.expect(!aes_256_profiles.contains(.native_appliance));
+    try std.testing.expect(aes_256_profiles.contains(.native_appliance));
     try std.testing.expect(aes_256_profiles.contains(.general_purpose_openssl));
 
     const chacha_profiles = enabledProfilesFor(.{ .aead = .chacha20_poly1305 });
-    try std.testing.expect(!chacha_profiles.contains(.native_appliance));
+    try std.testing.expect(chacha_profiles.contains(.native_appliance));
     try std.testing.expect(chacha_profiles.contains(.general_purpose_openssl));
 
     const secp256r1_profiles = enabledProfilesFor(.{ .group = .secp256r1 });

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -589,6 +589,7 @@ fn translate(allocator: ?std.mem.Allocator, source: *RecordSink, destination: *E
                     try destination.emitOwnedHandshakeBytesCopy(explicit_allocator, toLevel(item.epoch), item.data);
                 }
             },
+            .negotiated_parameters => |params| try destination.emitNegotiatedParameters(params),
             .traffic_secret => |item| try destination.emitSecret(toLevel(item.epoch), item.direction, item.data),
             .peer_transport_parameters => {},
             .alpn => |protocol| try destination.emitAlpn(protocol),

--- a/src/quic/tls_handshake.zig
+++ b/src/quic/tls_handshake.zig
@@ -362,6 +362,11 @@ pub const Handshake = struct {
                     error.InvalidCryptoLevel => error.UnexpectedCryptoLevel,
                     error.CryptoBufferTooLarge => error.HandshakeBufferOverflow,
                 }),
+                // #564 scopes QUIC negotiated-suite packet/header protection
+                // as a separate child issue; this backend's own QUIC adapter
+                // still only negotiates TLS_AES_128_GCM_SHA256 (#335), so
+                // there is nothing for QUIC to do with this event yet.
+                .negotiated_parameters => {},
                 .traffic_secret => |s| {
                     const secret = Secret.init(s.epoch, s.direction, s.data) catch return self.fail(error.SecretExportFailed);
                     if (s.data.len != traffic_secret_len) return self.fail(error.SecretExportFailed);

--- a/src/tls/crypto_profile.zig
+++ b/src/tls/crypto_profile.zig
@@ -152,8 +152,13 @@ test "TLS policy capabilities are derived from provider support" {
 test "native appliance profile selects only what the live engine negotiates" {
     const caps = profile.capabilities(.pure_zig);
     const native = fromProfile(.native_appliance, caps);
-    try std.testing.expectEqual(@as(usize, 1), native.cipher_suites_len);
+    // #564: the native engine's handshake/transcript/key-schedule are
+    // cipher/hash-agile and negotiate all three checked-in suites now, not
+    // just the SHA-256 baseline.
+    try std.testing.expectEqual(@as(usize, 3), native.cipher_suites_len);
     try std.testing.expectEqual(policy_mod.CipherSuite.tls_aes_128_gcm_sha256, native.cipher_suites[0]);
+    try std.testing.expectEqual(policy_mod.CipherSuite.tls_aes_256_gcm_sha384, native.cipher_suites[1]);
+    try std.testing.expectEqual(policy_mod.CipherSuite.tls_chacha20_poly1305_sha256, native.cipher_suites[2]);
     try std.testing.expectEqual(@as(usize, 1), native.named_groups_len);
     try std.testing.expectEqual(policy_mod.NamedGroup.x25519, native.named_groups[0]);
     try std.testing.expectEqual(@as(usize, 2), native.signature_schemes_len);

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -1012,6 +1012,15 @@ pub const PureZigRecordStream = struct {
                 .handshake_bytes => |hb| {
                     self.emitHandshakeRecords(hb.epoch, hb.data) catch |err| return self.fail(err);
                 },
+                // #564: must be applied before this batch's own traffic
+                // secrets are installed below — `EventSink.emitNegotiatedParameters`'s
+                // contract guarantees the backend emits it first — so
+                // `self.bridge.installTrafficSecret` derives `TrafficKeys`
+                // for the suite this connection actually negotiated.
+                .negotiated_parameters => |params| {
+                    self.bridge.cipher_suite = algorithms.fromInt(algorithms.CipherSuite, params.cipher_suite) orelse
+                        return self.fail(error.MalformedHandshake);
+                },
                 .traffic_secret => |ts| {
                     self.bridge.installTrafficSecret(ts.epoch, ts.direction, ts.data) catch |err| return self.fail(err);
                     self.advanceEpochOnSecret(ts.epoch, ts.direction);

--- a/src/tls/engine.zig
+++ b/src/tls/engine.zig
@@ -10,6 +10,7 @@ pub const state = @import("state.zig");
 pub const events = @import("events.zig");
 pub const handshake = @import("handshake.zig");
 pub const key_schedule = @import("key_schedule.zig");
+pub const transcript = @import("transcript.zig");
 
 pub const EngineConfig = struct {
     role: state.Role,
@@ -44,7 +45,7 @@ pub const Engine = struct {
         return self.core.handshake_state;
     }
 
-    pub fn transcriptHash(self: *const Engine) [key_schedule.hash_len]u8 {
+    pub fn transcriptHash(self: *const Engine) transcript.Digest {
         return self.core.transcriptHash();
     }
 
@@ -203,6 +204,11 @@ test "core engine can be instantiated for record mode without record framing" {
 test "engine drives protocol-neutral handshake state" {
     var engine = Engine.init(.{ .role = .server, .transport_mode = .record });
     try engine.start();
+    // This shell is protocol-neutral and never selects a cipher suite on
+    // its own (#564) — select a family explicitly so `transcriptHash()`
+    // below reflects real hashed bytes rather than the empty pre-selection
+    // digest.
+    engine.core.transcript.selectFamily(.sha256);
 
     var buffer: [32]u8 = undefined;
     var writer = handshake.Writer{ .buf = &buffer };
@@ -212,7 +218,8 @@ test "engine drives protocol-neutral handshake state" {
     _ = try engine.receiveHandshake(writer.written());
     try std.testing.expectEqual(state.HandshakeState.server_hello, engine.handshakeState());
     const transcript_hash = engine.transcriptHash();
-    try std.testing.expect(!std.mem.eql(u8, &transcript_hash, &([_]u8{0} ** key_schedule.hash_len)));
+    try std.testing.expectEqual(@as(usize, 32), transcript_hash.len);
+    try std.testing.expect(!std.mem.allEqual(u8, transcript_hash.slice(), 0));
 }
 
 test "engine retains fragmented input and drains coalesced messages" {

--- a/src/tls/events.zig
+++ b/src/tls/events.zig
@@ -95,8 +95,29 @@ pub const HandshakeError = error{
     DecryptError,
 };
 
+/// The transcript/HKDF hash a negotiated cipher suite selects
+/// (`algorithms.transcriptHash`), re-exported here so a record or QUIC
+/// consumer can size/interpret traffic secrets without importing
+/// `algorithms.zig` or guessing from secret length alone (#564: two of the
+/// three negotiable suites share a hash, so length is not an implicit
+/// signal either way).
+pub const TranscriptHash = enum { sha256, sha384 };
+
+/// Negotiated cipher-suite metadata (#564), emitted exactly once per
+/// connection — for a full or a resumed handshake alike — before any
+/// `traffic_secret` event for the `handshake` epoch. `cipher_suite` is the
+/// wire code point (`algorithms.CipherSuite`'s backing `u16`); consumers
+/// that need the enum value convert it with `algorithms.fromInt`. This is
+/// the one canonical negotiated-parameters signal — transports must not
+/// infer the suite from secret length or any other side channel.
+pub const NegotiatedParameters = struct {
+    cipher_suite: u16,
+    transcript_hash: TranscriptHash,
+};
+
 pub const Event = union(enum) {
     handshake_bytes: struct { epoch: EncryptionEpoch, data: []const u8 },
+    negotiated_parameters: NegotiatedParameters,
     traffic_secret: struct { epoch: EncryptionEpoch, direction: SecretDirection, data: []const u8 },
     alpn: []const u8,
     certificate: CertificateState,
@@ -126,6 +147,14 @@ test "shared handshake errors include TLS-level failure cases" {
 
     const err: HandshakeError = error.MalformedHandshake;
     try std.testing.expectEqual(error.MalformedHandshake, err);
+}
+
+test "negotiated_parameters event carries the wire cipher suite and its transcript hash" {
+    const std = @import("std");
+
+    const event = Event{ .negotiated_parameters = .{ .cipher_suite = 0x1302, .transcript_hash = .sha384 } };
+    try std.testing.expectEqual(@as(u16, 0x1302), event.negotiated_parameters.cipher_suite);
+    try std.testing.expectEqual(TranscriptHash.sha384, event.negotiated_parameters.transcript_hash);
 }
 
 test "syntax, semantic, and ordering failures are distinct cases" {

--- a/src/tls/handshake.zig
+++ b/src/tls/handshake.zig
@@ -11,7 +11,7 @@ const messages = @import("messages.zig");
 const state = @import("state.zig");
 const transcript_mod = @import("transcript.zig");
 
-pub const Error = events.HandshakeError || messages.ReassemblerError;
+pub const Error = events.HandshakeError || messages.ReassemblerError || transcript_mod.Error;
 pub const Message = messages.HandshakeMessage;
 pub const MessageType = messages.MessageType;
 pub const Reader = messages.Reader;
@@ -153,7 +153,7 @@ pub const Core = struct {
         if (message.kind == .new_session_ticket) {
             if (self.handshake_lifecycle != .complete or self.role != .client)
                 return error.UnexpectedHandshakeMessage;
-            self.transcript.update(message.raw);
+            try self.transcript.update(message.raw);
             return message;
         }
         // A CertificateRequest (server->client, #334) is an optional message the
@@ -170,20 +170,20 @@ pub const Core = struct {
                 self.client_certificate_requested)
                 return error.UnexpectedHandshakeMessage;
             self.client_certificate_requested = true;
-            self.transcript.update(message.raw);
+            try self.transcript.update(message.raw);
             return message;
         }
         // Server inbound for the client's post-Finished certificate flight.
         if (self.client_auth_inbound != .inactive) {
             try self.checkClientAuthInbound(message.kind);
-            self.transcript.update(message.raw);
+            try self.transcript.update(message.raw);
             self.advanceClientAuthInbound(message.kind);
             return message;
         }
         if (message.kind == .end_of_early_data) {
             if (self.role != .server or self.handshake_state != .finished or self.expected_inbound != null or self.end_of_early_data_seen)
                 return error.UnexpectedHandshakeMessage;
-            self.transcript.update(message.raw);
+            try self.transcript.update(message.raw);
             self.end_of_early_data_seen = true;
             return message;
         }
@@ -191,7 +191,7 @@ pub const Core = struct {
             if (self.expected_inbound != message.kind)
                 return error.UnexpectedHandshakeMessage;
         }
-        self.transcript.update(message.raw);
+        try self.transcript.update(message.raw);
         self.advanceAfterReceive(message.kind);
         return message;
     }
@@ -228,7 +228,7 @@ pub const Core = struct {
         if (message.kind == .client_hello and self.retry_state == .hrr_received)
             return error.UnexpectedHandshakeMessage;
         if (!self.validOutbound(message.kind)) return error.UnexpectedHandshakeMessage;
-        self.transcript.update(message.raw);
+        try self.transcript.update(message.raw);
         self.advanceAfterSend(message.kind);
     }
 
@@ -242,7 +242,7 @@ pub const Core = struct {
         const message = messages.decode(raw) catch return error.MalformedHandshake;
         if (message.kind != .server_hello) return error.UnexpectedHandshakeMessage;
         self.transcript.rebindClientHello();
-        self.transcript.update(message.raw);
+        try self.transcript.update(message.raw);
         self.retry_state = .hrr_received;
         self.expected_inbound = null;
         return message;
@@ -257,7 +257,7 @@ pub const Core = struct {
         const message = messages.decode(raw) catch return error.MalformedHandshake;
         if (message.kind != .server_hello) return error.UnexpectedHandshakeMessage;
         self.transcript.rebindClientHello();
-        self.transcript.update(message.raw);
+        try self.transcript.update(message.raw);
         self.retry_state = .hrr_sent;
         self.handshake_state = .idle;
         self.expected_inbound = .client_hello;
@@ -271,7 +271,7 @@ pub const Core = struct {
             return error.UnexpectedHandshakeMessage;
         const message = messages.decode(raw) catch return error.MalformedHandshake;
         if (message.kind != .client_hello) return error.UnexpectedHandshakeMessage;
-        self.transcript.update(message.raw);
+        try self.transcript.update(message.raw);
         self.expected_inbound = .server_hello;
     }
 
@@ -283,7 +283,7 @@ pub const Core = struct {
             return error.UnexpectedHandshakeMessage;
         const message = messages.decode(raw) catch return error.MalformedHandshake;
         if (message.kind != .client_hello) return error.UnexpectedHandshakeMessage;
-        self.transcript.update(message.raw);
+        try self.transcript.update(message.raw);
         self.handshake_state = .server_hello;
         self.expected_inbound = null;
         return message;
@@ -293,7 +293,7 @@ pub const Core = struct {
         return self.acceptReceived(raw);
     }
 
-    pub fn transcriptHash(self: *const Core) [transcript_mod.digest_len]u8 {
+    pub fn transcriptHash(self: *const Core) transcript_mod.Digest {
         return self.transcript.peek();
     }
 
@@ -413,6 +413,8 @@ test "core records both directions of a client and server flight" {
     var server = Core.init(.server);
     try client.start();
     try server.start();
+    client.transcript.selectFamily(.sha256);
+    server.transcript.selectFamily(.sha256);
 
     var bytes: [8]u8 = undefined;
     const ch = try messages.encode(.client_hello, "", &bytes);
@@ -440,7 +442,7 @@ test "core records both directions of a client and server flight" {
     try std.testing.expectEqual(.complete, server.handshake_lifecycle);
     const client_hash = client.transcriptHash();
     const server_hash = server.transcriptHash();
-    try std.testing.expectEqualSlices(u8, &client_hash, &server_hash);
+    try std.testing.expect(client_hash.eql(&server_hash));
 }
 
 test "PSK-authenticated core skips Certificate/CertificateVerify and still completes both directions" {
@@ -448,6 +450,8 @@ test "PSK-authenticated core skips Certificate/CertificateVerify and still compl
     var server = Core.init(.server);
     try client.start();
     try server.start();
+    client.transcript.selectFamily(.sha256);
+    server.transcript.selectFamily(.sha256);
 
     var bytes: [8]u8 = undefined;
     const ch = try messages.encode(.client_hello, "", &bytes);
@@ -481,7 +485,7 @@ test "PSK-authenticated core skips Certificate/CertificateVerify and still compl
     try std.testing.expectEqual(.complete, server.handshake_lifecycle);
     const client_hash = client.transcriptHash();
     const server_hash = server.transcriptHash();
-    try std.testing.expectEqualSlices(u8, &client_hash, &server_hash);
+    try std.testing.expect(client_hash.eql(&server_hash));
 }
 
 test "core supports one HelloRetryRequest followed by ClientHello2" {
@@ -489,6 +493,8 @@ test "core supports one HelloRetryRequest followed by ClientHello2" {
     var server = Core.init(.server);
     try client.start();
     try server.start();
+    client.transcript.selectFamily(.sha256);
+    server.transcript.selectFamily(.sha256);
 
     var bytes: [16]u8 = undefined;
     const ch1 = try messages.encode(.client_hello, "one", &bytes);
@@ -511,7 +517,7 @@ test "core supports one HelloRetryRequest followed by ClientHello2" {
     try std.testing.expectEqual(RetryState.hrr_sent, server.retry_state);
     const client_hash = client.transcriptHash();
     const server_hash = server.transcriptHash();
-    try std.testing.expectEqualSlices(u8, &client_hash, &server_hash);
+    try std.testing.expect(client_hash.eql(&server_hash));
 }
 
 test "core rejects repeated HRR and ClientHello2 without retry state" {
@@ -543,7 +549,7 @@ test "core rejects HRR before ClientHello1 was recorded without rebinding transc
     const hrr = try messages.encode(.server_hello, "hrr", &bytes);
     try std.testing.expectError(error.UnexpectedHandshakeMessage, client.acceptHelloRetryRequest(hrr));
     const after = client.transcriptHash();
-    try std.testing.expectEqualSlices(u8, &before, &after);
+    try std.testing.expect(before.eql(&after));
     try std.testing.expectEqual(RetryState.none, client.retry_state);
 }
 
@@ -556,7 +562,7 @@ test "core rejects normal ServerHello before ClientHello1 was recorded" {
     const sh = try messages.encode(.server_hello, "sh", &bytes);
     try std.testing.expectError(error.UnexpectedHandshakeMessage, client.acceptReceived(sh));
     const after = client.transcriptHash();
-    try std.testing.expectEqualSlices(u8, &before, &after);
+    try std.testing.expect(before.eql(&after));
     try std.testing.expectEqual(state.HandshakeState.idle, client.handshake_state);
 }
 

--- a/src/tls/key_schedule.zig
+++ b/src/tls/key_schedule.zig
@@ -115,12 +115,17 @@ fn emptyTranscriptHashFor(hash: provider.Hash) [max_digest_len]u8 {
 }
 
 /// The "derived" early secret for the zero-PSK key-schedule chain, under
-/// whichever hash the negotiated suite selected. SHA-256 returns the
-/// precomputed public constant; every other hash derives it fresh through
-/// the provider (two HKDF calls, once per full handshake — not worth a
-/// second comptime/audit exemption).
-fn zeroPskDerivedEarlySecret(crypto_provider: provider.CryptoProvider, hash: provider.Hash) provider.HkdfError![max_digest_len]u8 {
-    var out: [max_digest_len]u8 = [_]u8{0} ** max_digest_len;
+/// whichever hash the negotiated suite selected, written into `out`
+/// (zeroed first so bytes beyond the active hash's digest length are never
+/// left uninitialized). SHA-256 copies the precomputed public constant;
+/// every other hash derives it fresh through the provider (two HKDF calls,
+/// once per full handshake — not worth a second comptime/audit exemption).
+/// Out-parameter style (#564 review), like every other retained-or-caller-
+/// owned secret in this file: writing directly into caller storage means
+/// there is never a separate successful-path local left unwiped after a
+/// by-value return.
+fn zeroPskDerivedEarlySecret(crypto_provider: provider.CryptoProvider, hash: provider.Hash, out: *[max_digest_len]u8) provider.HkdfError!void {
+    out.* = [_]u8{0} ** max_digest_len;
     switch (hash) {
         .sha256 => @memcpy(out[0..hash_len], &derived_early_secret_sha256),
         .sha384 => {
@@ -133,7 +138,6 @@ fn zeroPskDerivedEarlySecret(crypto_provider: provider.CryptoProvider, hash: pro
             try crypto_provider.hkdfExpandLabel(.sha384, &early_secret, "derived", empty_hash[0..n], out[0..n]);
         },
     }
-    return out;
 }
 
 pub const KeySchedule = struct {
@@ -156,12 +160,14 @@ pub const KeySchedule = struct {
         hash: provider.Hash,
         shared: []const u8,
         hello_transcript_hash: []const u8,
-    ) Error!KeySchedule {
+        out: *KeySchedule,
+    ) Error!void {
         const n = hash.digestLength();
         if (hello_transcript_hash.len != n) return error.InvalidSecretLength;
-        var derived_early = try zeroPskDerivedEarlySecret(crypto_provider, hash);
+        var derived_early: [max_digest_len]u8 = undefined;
         defer provider.secureZero(&derived_early);
-        return initFromEarlySecret(crypto_provider, hash, derived_early[0..n], shared, hello_transcript_hash);
+        try zeroPskDerivedEarlySecret(crypto_provider, hash, &derived_early);
+        try initFromEarlySecret(crypto_provider, hash, derived_early[0..n], shared, hello_transcript_hash, out);
     }
 
     /// PSK-resumed (`psk_dhe_ke`) handshake: the same key-schedule chain as
@@ -178,7 +184,8 @@ pub const KeySchedule = struct {
         psk: []const u8,
         shared: []const u8,
         hello_transcript_hash: []const u8,
-    ) Error!KeySchedule {
+        out: *KeySchedule,
+    ) Error!void {
         const n = hash.digestLength();
         if (psk.len != n) return error.InvalidSecretLength;
 
@@ -191,7 +198,7 @@ pub const KeySchedule = struct {
         const empty_hash = emptyTranscriptHashFor(hash);
         try crypto_provider.hkdfExpandLabel(hash, early_secret[0..n], "derived", empty_hash[0..n], derived_early[0..n]);
 
-        return initFromEarlySecret(crypto_provider, hash, derived_early[0..n], shared, hello_transcript_hash);
+        try initFromEarlySecret(crypto_provider, hash, derived_early[0..n], shared, hello_transcript_hash, out);
     }
 
     /// Shared continuation from a "derived" early secret (RFC 8446 §7.1)
@@ -204,47 +211,37 @@ pub const KeySchedule = struct {
         derived_early: []const u8,
         shared: []const u8,
         hello_transcript_hash: []const u8,
-    ) Error!KeySchedule {
+        out: *KeySchedule,
+    ) Error!void {
         const n = hash.digestLength();
         if (shared.len != shared_secret_len or derived_early.len != n or hello_transcript_hash.len != n)
             return error.InvalidSecretLength;
         const zeros = [_]u8{0} ** max_digest_len;
 
-        // handshake_secret, master_secret, client_handshake_traffic, and
-        // server_handshake_traffic are all retained in the returned
-        // KeySchedule on success, so each gets an errdefer (wipe only on
-        // failure) rather than an unconditional defer.
-        var handshake_secret: [max_digest_len]u8 = [_]u8{0} ** max_digest_len;
-        errdefer provider.secureZero(&handshake_secret);
-        try crypto_provider.hkdfExtract(hash, derived_early, shared, handshake_secret[0..n]);
+        // #564 review: every retained secret is derived directly into
+        // `out.*` — never a separate local later copied in by a by-value
+        // `return .{...}` — so there is no successful-path stack copy left
+        // unwiped once this returns. `out.*` is reset to its (zeroed)
+        // default field values first so a single `errdefer out.wipe()`,
+        // armed from that point on, covers every failure below uniformly,
+        // partial writes included.
+        out.* = .{ .provider = crypto_provider, .hash = hash };
+        errdefer out.wipe();
+
+        try crypto_provider.hkdfExtract(hash, derived_early, shared, out.handshake_secret[0..n]);
 
         // derived_handshake is purely transient — never retained — so it
         // always gets wiped, success or failure.
         var derived_handshake: [max_digest_len]u8 = [_]u8{0} ** max_digest_len;
         defer provider.secureZero(&derived_handshake);
         const empty_hash = emptyTranscriptHashFor(hash);
-        try crypto_provider.hkdfExpandLabel(hash, handshake_secret[0..n], "derived", empty_hash[0..n], derived_handshake[0..n]);
+        try crypto_provider.hkdfExpandLabel(hash, out.handshake_secret[0..n], "derived", empty_hash[0..n], derived_handshake[0..n]);
 
-        var master_secret: [max_digest_len]u8 = [_]u8{0} ** max_digest_len;
-        errdefer provider.secureZero(&master_secret);
-        try crypto_provider.hkdfExtract(hash, derived_handshake[0..n], zeros[0..n], master_secret[0..n]);
+        try crypto_provider.hkdfExtract(hash, derived_handshake[0..n], zeros[0..n], out.master_secret[0..n]);
 
-        var client_handshake_traffic: [max_digest_len]u8 = [_]u8{0} ** max_digest_len;
-        errdefer provider.secureZero(&client_handshake_traffic);
-        try crypto_provider.hkdfExpandLabel(hash, handshake_secret[0..n], "c hs traffic", hello_transcript_hash, client_handshake_traffic[0..n]);
+        try crypto_provider.hkdfExpandLabel(hash, out.handshake_secret[0..n], "c hs traffic", hello_transcript_hash, out.client_handshake_traffic[0..n]);
 
-        var server_handshake_traffic: [max_digest_len]u8 = [_]u8{0} ** max_digest_len;
-        errdefer provider.secureZero(&server_handshake_traffic);
-        try crypto_provider.hkdfExpandLabel(hash, handshake_secret[0..n], "s hs traffic", hello_transcript_hash, server_handshake_traffic[0..n]);
-
-        return .{
-            .provider = crypto_provider,
-            .hash = hash,
-            .handshake_secret = handshake_secret,
-            .master_secret = master_secret,
-            .client_handshake_traffic = client_handshake_traffic,
-            .server_handshake_traffic = server_handshake_traffic,
-        };
+        try crypto_provider.hkdfExpandLabel(hash, out.handshake_secret[0..n], "s hs traffic", hello_transcript_hash, out.server_handshake_traffic[0..n]);
     }
 
     pub const ApplicationSecrets = struct {
@@ -265,19 +262,16 @@ pub const KeySchedule = struct {
         }
     };
 
-    pub fn applicationSecrets(self: *const KeySchedule, finished_transcript_hash: []const u8) Error!ApplicationSecrets {
+    /// Out-parameter style (#564 review): both secrets are derived directly
+    /// into `out.*`, never a pair of locals copied in by a by-value return.
+    pub fn applicationSecrets(self: *const KeySchedule, finished_transcript_hash: []const u8, out: *ApplicationSecrets) Error!void {
         const n = self.digestLen();
         if (finished_transcript_hash.len != n) return error.InvalidSecretLength;
 
-        var client: [max_digest_len]u8 = [_]u8{0} ** max_digest_len;
-        errdefer provider.secureZero(&client);
-        try self.provider.hkdfExpandLabel(self.hash, self.master_secret[0..n], "c ap traffic", finished_transcript_hash, client[0..n]);
-
-        var server: [max_digest_len]u8 = [_]u8{0} ** max_digest_len;
-        errdefer provider.secureZero(&server);
-        try self.provider.hkdfExpandLabel(self.hash, self.master_secret[0..n], "s ap traffic", finished_transcript_hash, server[0..n]);
-
-        return .{ .client = client, .server = server, .len = n };
+        out.* = .{ .len = n };
+        errdefer out.wipe();
+        try self.provider.hkdfExpandLabel(self.hash, self.master_secret[0..n], "c ap traffic", finished_transcript_hash, out.client[0..n]);
+        try self.provider.hkdfExpandLabel(self.hash, self.master_secret[0..n], "s ap traffic", finished_transcript_hash, out.server[0..n]);
     }
 
     pub fn resumptionMasterSecret(

--- a/src/tls/key_schedule.zig
+++ b/src/tls/key_schedule.zig
@@ -1,4 +1,8 @@
-//! Protocol-neutral TLS 1.3 SHA-256 key schedule.
+//! Protocol-neutral TLS 1.3 key schedule, hash-agile across SHA-256 and
+//! SHA-384 (#564): every secret length and HKDF call follows the hash the
+//! caller names, which must always be `algorithms.transcriptHash(suite)` for
+//! the negotiated cipher suite — this module does not select or persist a
+//! hash of its own, so it can never disagree with the negotiated suite.
 //!
 //! This module has no QUIC, HTTP, socket, or record-layer types. QUIC and
 //! future TCP-record integrations both derive handshake/application traffic
@@ -9,19 +13,27 @@
 //! 5869 — see `verifyData`) crosses `crypto.provider.CryptoProvider`, the
 //! shared provider/security seam every other keyed TLS/QUIC operation uses
 //! (#490). The only crypto this module still performs directly is *unkeyed*
-//! transcript hashing (`Sha256.hash` for the comptime empty-transcript and
-//! all-zero-PSK constants below): that hash has no secret input, so it stays
-//! provider-independent by design, matching `docs/CRYPTO_PROVIDER_AUDIT.md`'s
-//! "unkeyed transcript hashing may remain provider-independent" disposition.
+//! transcript hashing (`Sha256.hash`/`Sha384.hash` for the comptime/runtime
+//! empty-transcript-hash constants below): that hash has no secret input, so
+//! it stays provider-independent by design, matching
+//! `docs/CRYPTO_PROVIDER_AUDIT.md`'s "unkeyed transcript hashing may remain
+//! provider-independent" disposition.
 //!
-//! `KeySchedule` holds the `CryptoProvider` it was constructed with (the same
-//! borrowed-value-type convention `QuicTlsAdapter` uses) so instance methods
-//! (`applicationSecrets`, `resumptionMasterSecret`) do not need it passed
-//! again; free functions that do not require a live `KeySchedule` instance
-//! (`resumptionPsk`, `deriveResumptionMasterSecret`, `clientEarlyTrafficSecret`,
-//! `finishedKey`, `verifyData`) take one explicitly, since resumption/ticket
-//! code (`new_session_ticket.zig`) and 0-RTT paths often need these before —
-//! or without ever constructing — a full `KeySchedule`.
+//! `KeySchedule` holds the `CryptoProvider` and the negotiated `Hash` it was
+//! constructed with (the same borrowed-value-type convention `QuicTlsAdapter`
+//! uses) so instance methods (`applicationSecrets`, `resumptionMasterSecret`)
+//! do not need either passed again; free functions that do not require a
+//! live `KeySchedule` instance (`resumptionPsk`, `deriveResumptionMasterSecret`,
+//! `clientEarlyTrafficSecret`, `finishedKey`, `verifyData`) take an explicit
+//! `hash: provider.Hash`, since resumption/ticket code (`new_session_ticket.zig`)
+//! and 0-RTT paths often need these before — or without ever constructing —
+//! a full `KeySchedule`, and a resumed ticket's own stored hash need not
+//! match whatever `KeySchedule` (if any) is live for the current connection.
+//!
+//! Every secret this module returns is bounded to `max_digest_len` (48
+//! bytes, SHA-384's output) with an explicit logical length rather than a
+//! hash-family-sized array — the caller-visible shape does not change with
+//! the negotiated suite, only how many of those bytes are meaningful.
 //!
 //! This is a production-only file: it has no test block of its own. Tests
 //! live in `key_schedule_tests.zig`, a separate file that `scripts/
@@ -40,9 +52,12 @@ const provider = @import("crypto").provider;
 
 const crypto = std.crypto;
 const Sha256 = crypto.hash.sha2.Sha256;
+const Sha384 = crypto.hash.sha2.Sha384;
 
-pub const TranscriptHash = Sha256;
-pub const hash_len = Sha256.digest_length;
+/// Largest secret this module produces or consumes (SHA-384's 48-byte
+/// digest/PRK length) — every bounded buffer below is sized to this, with
+/// callers slicing to the negotiated hash's actual `digestLength()`.
+pub const max_digest_len = provider.max_digest_len;
 /// X25519 shared-secret length (RFC 7748) — this module's only consumer of
 /// key-exchange output, not a key-exchange implementation itself.
 pub const shared_secret_len = 32;
@@ -52,6 +67,12 @@ pub const shared_secret_len = 32;
 /// exactly why a derivation failed rather than a single collapsed error.
 pub const Error = error{InvalidSecretLength} || provider.HkdfError;
 
+/// SHA-256's digest length — used only by the one documented comptime
+/// exception below (`derived_early_secret_sha256`); every other declaration
+/// in this file sizes its buffers to `max_digest_len` and slices to the
+/// negotiated hash's `digestLength()` instead of naming a fixed hash.
+const hash_len = Sha256.digest_length;
+
 const empty_transcript_hash: [hash_len]u8 = blk: {
     @setEvalBranchQuota(100_000);
     var out: [hash_len]u8 = undefined;
@@ -60,16 +81,20 @@ const empty_transcript_hash: [hash_len]u8 = blk: {
 };
 
 /// RFC 8446 §7.1's "derived" early secret for the zero-PSK (full handshake,
-/// non-resumed) key-schedule chain: `HKDF-Expand-Label(HKDF-Extract(0, 0),
-/// "derived", Hash(""), Hash.length)`. This is a fixed public constant — the
-/// early secret input is the all-zero PSK, not connection-specific secret
-/// material — so it is computed once at compile time directly, the same way
-/// `empty_transcript_hash` above is: there is no runtime provider available
-/// at comptime, and none is needed, since nothing here is a secret specific
-/// to any handshake. `scripts/audit_crypto_boundary.zig` allowlists the two
-/// lines below by exact text for exactly that reason (see
-/// `docs/CRYPTO_PROVIDER_AUDIT.md`).
-const derived_early_secret: [hash_len]u8 = blk: {
+/// non-resumed) key-schedule chain under SHA-256:
+/// `HKDF-Expand-Label(HKDF-Extract(0, 0), "derived", Hash(""), Hash.length)`.
+/// This is a fixed public constant — the early secret input is the all-zero
+/// PSK, not connection-specific secret material — so it is computed once at
+/// compile time directly, the same way `empty_transcript_hash` above is:
+/// there is no runtime provider available at comptime, and none is needed,
+/// since nothing here is a secret specific to any handshake.
+/// `scripts/audit_crypto_boundary.zig` allowlists the two lines below by
+/// exact text for exactly that reason (see `docs/CRYPTO_PROVIDER_AUDIT.md`).
+/// SHA-384's equivalent constant is not worth a second comptime block +
+/// audit exemption for a value computed at most once per full handshake:
+/// `zeroPskDerivedEarlySecret` below derives it through the provider at
+/// runtime instead, for every hash family other than this one fast path.
+const derived_early_secret_sha256: [hash_len]u8 = blk: {
     @setEvalBranchQuota(100_000);
     const HkdfSha256 = crypto.kdf.hkdf.HkdfSha256;
     const zeros = [_]u8{0} ** hash_len;
@@ -77,44 +102,96 @@ const derived_early_secret: [hash_len]u8 = blk: {
     break :blk crypto.tls.hkdfExpandLabel(HkdfSha256, early_secret, "derived", &empty_transcript_hash, hash_len);
 };
 
+/// Unkeyed `Hash("")` for `hash`, zero-padded to `max_digest_len` — never
+/// exposes uninitialized suffix bytes. Unkeyed transcript hashing stays
+/// provider-independent by design (see the module doc comment).
+fn emptyTranscriptHashFor(hash: provider.Hash) [max_digest_len]u8 {
+    var out: [max_digest_len]u8 = [_]u8{0} ** max_digest_len;
+    switch (hash) {
+        .sha256 => @memcpy(out[0..hash_len], &empty_transcript_hash),
+        .sha384 => Sha384.hash("", out[0..Sha384.digest_length], .{}),
+    }
+    return out;
+}
+
+/// The "derived" early secret for the zero-PSK key-schedule chain, under
+/// whichever hash the negotiated suite selected. SHA-256 returns the
+/// precomputed public constant; every other hash derives it fresh through
+/// the provider (two HKDF calls, once per full handshake — not worth a
+/// second comptime/audit exemption).
+fn zeroPskDerivedEarlySecret(crypto_provider: provider.CryptoProvider, hash: provider.Hash) provider.HkdfError![max_digest_len]u8 {
+    var out: [max_digest_len]u8 = [_]u8{0} ** max_digest_len;
+    switch (hash) {
+        .sha256 => @memcpy(out[0..hash_len], &derived_early_secret_sha256),
+        .sha384 => {
+            const n = Sha384.digest_length;
+            const zeros = [_]u8{0} ** n;
+            var early_secret: [n]u8 = undefined;
+            defer provider.secureZero(&early_secret);
+            try crypto_provider.hkdfExtract(.sha384, "", &zeros, &early_secret);
+            const empty_hash = emptyTranscriptHashFor(.sha384);
+            try crypto_provider.hkdfExpandLabel(.sha384, &early_secret, "derived", empty_hash[0..n], out[0..n]);
+        },
+    }
+    return out;
+}
+
 pub const KeySchedule = struct {
     provider: provider.CryptoProvider,
-    handshake_secret: [hash_len]u8,
-    master_secret: [hash_len]u8,
-    client_handshake_traffic: [hash_len]u8,
-    server_handshake_traffic: [hash_len]u8,
+    hash: provider.Hash,
+    handshake_secret: [max_digest_len]u8 = [_]u8{0} ** max_digest_len,
+    master_secret: [max_digest_len]u8 = [_]u8{0} ** max_digest_len,
+    client_handshake_traffic: [max_digest_len]u8 = [_]u8{0} ** max_digest_len,
+    server_handshake_traffic: [max_digest_len]u8 = [_]u8{0} ** max_digest_len,
+
+    /// This connection's negotiated transcript/HKDF digest length —
+    /// `self.hash.digestLength()`, exposed so callers never need to
+    /// re-derive it from the cipher suite once a schedule already exists.
+    pub fn digestLen(self: *const KeySchedule) usize {
+        return self.hash.digestLength();
+    }
 
     pub fn init(
         crypto_provider: provider.CryptoProvider,
-        shared: *const [shared_secret_len]u8,
-        hello_transcript_hash: [hash_len]u8,
-    ) provider.HkdfError!KeySchedule {
-        return initFromEarlySecret(crypto_provider, &derived_early_secret, shared, hello_transcript_hash);
+        hash: provider.Hash,
+        shared: []const u8,
+        hello_transcript_hash: []const u8,
+    ) Error!KeySchedule {
+        const n = hash.digestLength();
+        if (hello_transcript_hash.len != n) return error.InvalidSecretLength;
+        var derived_early = try zeroPskDerivedEarlySecret(crypto_provider, hash);
+        defer provider.secureZero(&derived_early);
+        return initFromEarlySecret(crypto_provider, hash, derived_early[0..n], shared, hello_transcript_hash);
     }
 
     /// PSK-resumed (`psk_dhe_ke`) handshake: the same key-schedule chain as
     /// `init`, but starting from a real early secret derived from the
-    /// resumption PSK (RFC 8446 §7.1) instead of the comptime all-zero-PSK
-    /// early secret `init` uses. `psk` must already be exactly `hash_len`
-    /// bytes (the SHA-256 resumption PSK produced by
-    /// `resumptionPsk`/`KeySchedule.resumptionPsk`, matching this module's
-    /// concrete SHA-256 schedule). X25519 key share remains mandatory in
-    /// this profile, so `shared` is still the ECDHE shared secret.
+    /// resumption PSK (RFC 8446 §7.1) instead of the all-zero-PSK early
+    /// secret `init` uses. `psk` must already be exactly `hash.digestLength()`
+    /// bytes (the resumption PSK produced by `resumptionPsk`, under the same
+    /// hash this ticket's own suite negotiated). X25519 key share remains
+    /// mandatory in this profile, so `shared` is still the ECDHE shared
+    /// secret.
     pub fn initWithPsk(
         crypto_provider: provider.CryptoProvider,
-        psk: *const [hash_len]u8,
-        shared: *const [shared_secret_len]u8,
-        hello_transcript_hash: [hash_len]u8,
-    ) provider.HkdfError!KeySchedule {
-        var early_secret: [hash_len]u8 = undefined;
+        hash: provider.Hash,
+        psk: []const u8,
+        shared: []const u8,
+        hello_transcript_hash: []const u8,
+    ) Error!KeySchedule {
+        const n = hash.digestLength();
+        if (psk.len != n) return error.InvalidSecretLength;
+
+        var early_secret: [max_digest_len]u8 = [_]u8{0} ** max_digest_len;
         defer provider.secureZero(&early_secret);
-        try crypto_provider.hkdfExtract(.sha256, "", psk, &early_secret);
+        try crypto_provider.hkdfExtract(hash, "", psk, early_secret[0..n]);
 
-        var derived_early: [hash_len]u8 = undefined;
+        var derived_early: [max_digest_len]u8 = [_]u8{0} ** max_digest_len;
         defer provider.secureZero(&derived_early);
-        try crypto_provider.hkdfExpandLabel(.sha256, &early_secret, "derived", &empty_transcript_hash, &derived_early);
+        const empty_hash = emptyTranscriptHashFor(hash);
+        try crypto_provider.hkdfExpandLabel(hash, early_secret[0..n], "derived", empty_hash[0..n], derived_early[0..n]);
 
-        return initFromEarlySecret(crypto_provider, &derived_early, shared, hello_transcript_hash);
+        return initFromEarlySecret(crypto_provider, hash, derived_early[0..n], shared, hello_transcript_hash);
     }
 
     /// Shared continuation from a "derived" early secret (RFC 8446 §7.1)
@@ -123,40 +200,46 @@ pub const KeySchedule = struct {
     /// points, which differ only in how `derived_early` was produced.
     fn initFromEarlySecret(
         crypto_provider: provider.CryptoProvider,
-        derived_early: *const [hash_len]u8,
-        shared: *const [shared_secret_len]u8,
-        hello_transcript_hash: [hash_len]u8,
-    ) provider.HkdfError!KeySchedule {
-        const zeros = [_]u8{0} ** hash_len;
+        hash: provider.Hash,
+        derived_early: []const u8,
+        shared: []const u8,
+        hello_transcript_hash: []const u8,
+    ) Error!KeySchedule {
+        const n = hash.digestLength();
+        if (shared.len != shared_secret_len or derived_early.len != n or hello_transcript_hash.len != n)
+            return error.InvalidSecretLength;
+        const zeros = [_]u8{0} ** max_digest_len;
 
         // handshake_secret, master_secret, client_handshake_traffic, and
         // server_handshake_traffic are all retained in the returned
         // KeySchedule on success, so each gets an errdefer (wipe only on
         // failure) rather than an unconditional defer.
-        var handshake_secret: [hash_len]u8 = undefined;
+        var handshake_secret: [max_digest_len]u8 = [_]u8{0} ** max_digest_len;
         errdefer provider.secureZero(&handshake_secret);
-        try crypto_provider.hkdfExtract(.sha256, derived_early, shared, &handshake_secret);
+        try crypto_provider.hkdfExtract(hash, derived_early, shared, handshake_secret[0..n]);
 
         // derived_handshake is purely transient — never retained — so it
         // always gets wiped, success or failure.
-        var derived_handshake: [hash_len]u8 = undefined;
+        var derived_handshake: [max_digest_len]u8 = [_]u8{0} ** max_digest_len;
         defer provider.secureZero(&derived_handshake);
-        try crypto_provider.hkdfExpandLabel(.sha256, &handshake_secret, "derived", &empty_transcript_hash, &derived_handshake);
+        const empty_hash = emptyTranscriptHashFor(hash);
+        try crypto_provider.hkdfExpandLabel(hash, handshake_secret[0..n], "derived", empty_hash[0..n], derived_handshake[0..n]);
 
-        var master_secret: [hash_len]u8 = undefined;
+        var master_secret: [max_digest_len]u8 = [_]u8{0} ** max_digest_len;
         errdefer provider.secureZero(&master_secret);
-        try crypto_provider.hkdfExtract(.sha256, &derived_handshake, &zeros, &master_secret);
+        try crypto_provider.hkdfExtract(hash, derived_handshake[0..n], zeros[0..n], master_secret[0..n]);
 
-        var client_handshake_traffic: [hash_len]u8 = undefined;
+        var client_handshake_traffic: [max_digest_len]u8 = [_]u8{0} ** max_digest_len;
         errdefer provider.secureZero(&client_handshake_traffic);
-        try crypto_provider.hkdfExpandLabel(.sha256, &handshake_secret, "c hs traffic", &hello_transcript_hash, &client_handshake_traffic);
+        try crypto_provider.hkdfExpandLabel(hash, handshake_secret[0..n], "c hs traffic", hello_transcript_hash, client_handshake_traffic[0..n]);
 
-        var server_handshake_traffic: [hash_len]u8 = undefined;
+        var server_handshake_traffic: [max_digest_len]u8 = [_]u8{0} ** max_digest_len;
         errdefer provider.secureZero(&server_handshake_traffic);
-        try crypto_provider.hkdfExpandLabel(.sha256, &handshake_secret, "s hs traffic", &hello_transcript_hash, &server_handshake_traffic);
+        try crypto_provider.hkdfExpandLabel(hash, handshake_secret[0..n], "s hs traffic", hello_transcript_hash, server_handshake_traffic[0..n]);
 
         return .{
             .provider = crypto_provider,
+            .hash = hash,
             .handshake_secret = handshake_secret,
             .master_secret = master_secret,
             .client_handshake_traffic = client_handshake_traffic,
@@ -165,24 +248,36 @@ pub const KeySchedule = struct {
     }
 
     pub const ApplicationSecrets = struct {
-        client: [hash_len]u8,
-        server: [hash_len]u8,
+        client: [max_digest_len]u8 = [_]u8{0} ** max_digest_len,
+        server: [max_digest_len]u8 = [_]u8{0} ** max_digest_len,
+        len: usize = 0,
+
+        pub fn clientSecret(self: *const ApplicationSecrets) []const u8 {
+            return self.client[0..self.len];
+        }
+
+        pub fn serverSecret(self: *const ApplicationSecrets) []const u8 {
+            return self.server[0..self.len];
+        }
 
         pub fn wipe(self: *ApplicationSecrets) void {
             provider.secureZero(std.mem.asBytes(self));
         }
     };
 
-    pub fn applicationSecrets(self: *const KeySchedule, finished_transcript_hash: [hash_len]u8) provider.HkdfError!ApplicationSecrets {
-        var client: [hash_len]u8 = undefined;
+    pub fn applicationSecrets(self: *const KeySchedule, finished_transcript_hash: []const u8) Error!ApplicationSecrets {
+        const n = self.digestLen();
+        if (finished_transcript_hash.len != n) return error.InvalidSecretLength;
+
+        var client: [max_digest_len]u8 = [_]u8{0} ** max_digest_len;
         errdefer provider.secureZero(&client);
-        try self.provider.hkdfExpandLabel(.sha256, &self.master_secret, "c ap traffic", &finished_transcript_hash, &client);
+        try self.provider.hkdfExpandLabel(self.hash, self.master_secret[0..n], "c ap traffic", finished_transcript_hash, client[0..n]);
 
-        var server: [hash_len]u8 = undefined;
+        var server: [max_digest_len]u8 = [_]u8{0} ** max_digest_len;
         errdefer provider.secureZero(&server);
-        try self.provider.hkdfExpandLabel(.sha256, &self.master_secret, "s ap traffic", &finished_transcript_hash, &server);
+        try self.provider.hkdfExpandLabel(self.hash, self.master_secret[0..n], "s ap traffic", finished_transcript_hash, server[0..n]);
 
-        return .{ .client = client, .server = server };
+        return .{ .client = client, .server = server, .len = n };
     }
 
     pub fn resumptionMasterSecret(
@@ -190,7 +285,8 @@ pub const KeySchedule = struct {
         handshake_complete_transcript_hash: []const u8,
         out: []u8,
     ) Error!void {
-        return deriveResumptionMasterSecret(self.provider, .sha256, &self.master_secret, handshake_complete_transcript_hash, out);
+        const n = self.digestLen();
+        return deriveResumptionMasterSecret(self.provider, self.hash, self.master_secret[0..n], handshake_complete_transcript_hash, out);
     }
 
     pub fn deriveResumptionMasterSecret(
@@ -231,29 +327,32 @@ pub const KeySchedule = struct {
     /// (including its real binders) — never the binder-truncated prefix
     /// used for binder computation itself. Independent of `KeySchedule`:
     /// unlike `initWithPsk`, early data has no ECDHE contribution and is
-    /// derived directly from the early secret, before `derived_early_secret`
-    /// folds in the (EC)DHE shared secret for the handshake/master chain.
+    /// derived directly from the early secret, before the "derived" early
+    /// secret folds in the (EC)DHE shared secret for the handshake/master
+    /// chain. `out` must be exactly `hash.digestLength()` bytes.
     pub fn clientEarlyTrafficSecret(
         crypto_provider: provider.CryptoProvider,
-        psk: *const [hash_len]u8,
-        client_hello_hash: [hash_len]u8,
-    ) provider.HkdfError![hash_len]u8 {
-        var early_secret: [hash_len]u8 = undefined;
+        hash: provider.Hash,
+        psk: []const u8,
+        client_hello_hash: []const u8,
+        out: []u8,
+    ) Error!void {
+        const n = hash.digestLength();
+        if (psk.len != n or client_hello_hash.len != n or out.len != n) return error.InvalidSecretLength;
+
+        var early_secret: [max_digest_len]u8 = [_]u8{0} ** max_digest_len;
         defer provider.secureZero(&early_secret);
-        try crypto_provider.hkdfExtract(.sha256, "", psk, &early_secret);
+        try crypto_provider.hkdfExtract(hash, "", psk, early_secret[0..n]);
 
-        var out: [hash_len]u8 = undefined;
-        errdefer provider.secureZero(&out);
-        try crypto_provider.hkdfExpandLabel(.sha256, &early_secret, "c e traffic", &client_hello_hash, &out);
-
-        return out;
+        errdefer provider.secureZero(out);
+        try crypto_provider.hkdfExpandLabel(hash, early_secret[0..n], "c e traffic", client_hello_hash, out);
     }
 
-    pub fn finishedKey(crypto_provider: provider.CryptoProvider, traffic_secret: *const [hash_len]u8) provider.HkdfError![hash_len]u8 {
-        var out: [hash_len]u8 = undefined;
-        errdefer provider.secureZero(&out);
-        try crypto_provider.hkdfExpandLabel(.sha256, traffic_secret, "finished", "", &out);
-        return out;
+    pub fn finishedKey(crypto_provider: provider.CryptoProvider, hash: provider.Hash, traffic_secret: []const u8, out: []u8) Error!void {
+        const n = hash.digestLength();
+        if (traffic_secret.len != n or out.len != n) return error.InvalidSecretLength;
+        errdefer provider.secureZero(out);
+        try crypto_provider.hkdfExpandLabel(hash, traffic_secret, "finished", "", out);
     }
 
     /// RFC 8446 §4.4.4: `verify_data = HMAC(finished_key, transcript_hash)`.
@@ -267,20 +366,24 @@ pub const KeySchedule = struct {
     /// `hkdfExtract` implementation (`src/crypto/pure_zig.zig`) confirms this:
     /// it calls `Hmac.create(out, ikm, salt)`, i.e. HMAC keyed by `salt` over
     /// `ikm`, matching this call shape bit for bit. `key_schedule_tests.zig`
-    /// cross-checks this against a direct HMAC-SHA256 computation.
+    /// cross-checks this against a direct HMAC computation for both hashes.
+    /// `out` must be exactly `hash.digestLength()` bytes.
     pub fn verifyData(
         crypto_provider: provider.CryptoProvider,
-        traffic_secret: *const [hash_len]u8,
-        transcript_hash: [hash_len]u8,
-    ) provider.HkdfError![hash_len]u8 {
-        var finished_key = try finishedKey(crypto_provider, traffic_secret);
+        hash: provider.Hash,
+        traffic_secret: []const u8,
+        transcript_hash: []const u8,
+        out: []u8,
+    ) Error!void {
+        const n = hash.digestLength();
+        if (traffic_secret.len != n or transcript_hash.len != n or out.len != n) return error.InvalidSecretLength;
+
+        var finished_key: [max_digest_len]u8 = [_]u8{0} ** max_digest_len;
         defer provider.secureZero(&finished_key);
+        try finishedKey(crypto_provider, hash, traffic_secret, finished_key[0..n]);
 
-        var mac: [hash_len]u8 = undefined;
-        errdefer provider.secureZero(&mac);
-        try crypto_provider.hkdfExtract(.sha256, &finished_key, &transcript_hash, &mac);
-
-        return mac;
+        errdefer provider.secureZero(out);
+        try crypto_provider.hkdfExtract(hash, finished_key[0..n], transcript_hash, out);
     }
 
     pub fn wipe(self: *KeySchedule) void {

--- a/src/tls/key_schedule_tests.zig
+++ b/src/tls/key_schedule_tests.zig
@@ -59,9 +59,11 @@ test "record-mode users can instantiate the protocol-neutral key schedule" {
 
     const shared = [_]u8{0x42} ** shared_secret_len;
     const transcript = [_]u8{0x24} ** hash_len;
-    var schedule = try KeySchedule.init(cp, .sha256, &shared, &transcript);
+    var schedule: KeySchedule = undefined;
+    try KeySchedule.init(cp, .sha256, &shared, &transcript, &schedule);
     defer schedule.wipe();
-    var app = try schedule.applicationSecrets(&transcript);
+    var app: KeySchedule.ApplicationSecrets = undefined;
+    try schedule.applicationSecrets(&transcript, &app);
     defer app.wipe();
     try testing.expect(!std.mem.eql(u8, app.clientSecret(), app.serverSecret()));
 }
@@ -73,7 +75,8 @@ test "shared TLS 1.3 key schedule matches the RFC 8448 simple 1-RTT trace" {
 
     const shared = hexBytes("8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d");
     const hello_hash = hexBytes("860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8");
-    var schedule = try KeySchedule.init(cp, .sha256, &shared, &hello_hash);
+    var schedule: KeySchedule = undefined;
+    try KeySchedule.init(cp, .sha256, &shared, &hello_hash, &schedule);
     defer schedule.wipe();
 
     try testing.expectEqualSlices(u8, &hexBytes("1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac"), schedule.handshake_secret[0..hash_len]);
@@ -82,7 +85,8 @@ test "shared TLS 1.3 key schedule matches the RFC 8448 simple 1-RTT trace" {
     try testing.expectEqualSlices(u8, &hexBytes("18df06843d13a08bf2a449844c5f8a478001bc4d4c627984d5a41da8d0402919"), schedule.master_secret[0..hash_len]);
 
     const finished_hash = hexBytes("9608102a0f1ccc6db6250b7b7e417b1a000eaada3daae4777a7686c9ff83df13");
-    var app = try schedule.applicationSecrets(&finished_hash);
+    var app: KeySchedule.ApplicationSecrets = undefined;
+    try schedule.applicationSecrets(&finished_hash, &app);
     defer app.wipe();
     try testing.expectEqualSlices(u8, &hexBytes("9e40646ce79a7f9dc05af8889bce6552875afa0b06df0087f792ebb7c17504a5"), app.clientSecret());
     try testing.expectEqualSlices(u8, &hexBytes("a11af9f05531f856ad47116b45a950328204b4f44bfb6b3a4b4f1f3fcb631643"), app.serverSecret());
@@ -117,7 +121,8 @@ test "SHA-384 key schedule matches an independently computed known-answer fixtur
 
     const shared = [_]u8{0x42} ** shared_secret_len;
     const transcript = [_]u8{0x24} ** hash_len_384;
-    var schedule = try KeySchedule.init(cp, .sha384, &shared, &transcript);
+    var schedule: KeySchedule = undefined;
+    try KeySchedule.init(cp, .sha384, &shared, &transcript, &schedule);
     defer schedule.wipe();
     try testing.expectEqual(provider.Hash.sha384, schedule.hash);
     try testing.expectEqual(@as(usize, hash_len_384), schedule.digestLen());
@@ -127,7 +132,8 @@ test "SHA-384 key schedule matches an independently computed known-answer fixtur
     try testing.expectEqualSlices(u8, &hexBytes("3ce66a169e12ab6927d5832cba1abaabb6c5237b1f129ff8e18e355c2e8f6f56e53ab195579da5131217e94aa57f18ac"), schedule.client_handshake_traffic[0..hash_len_384]);
     try testing.expectEqualSlices(u8, &hexBytes("062cc3bc2f786fd4d738bcf21d14ab173386513f5a98e99656b46865b373062768ff77f69b58467715667f56c7fd3353"), schedule.server_handshake_traffic[0..hash_len_384]);
 
-    var app = try schedule.applicationSecrets(&transcript);
+    var app: KeySchedule.ApplicationSecrets = undefined;
+    try schedule.applicationSecrets(&transcript, &app);
     defer app.wipe();
     try testing.expectEqual(@as(usize, hash_len_384), app.len);
     try testing.expectEqualSlices(u8, &hexBytes("8d2c41fc2f30630d9924bae6ff52df22d94939379fcd7de4b31f6bf7ceb0ec40c46c744a69ab217dc5c6e797ebebc291"), app.clientSecret());
@@ -156,7 +162,8 @@ test "SHA-384 initWithPsk matches an independently computed known-answer fixture
     const transcript = [_]u8{0x24} ** hash_len_384;
     const psk = [_]u8{0x99} ** hash_len_384;
 
-    var schedule = try KeySchedule.initWithPsk(cp, .sha384, &psk, &shared, &transcript);
+    var schedule: KeySchedule = undefined;
+    try KeySchedule.initWithPsk(cp, .sha384, &psk, &shared, &transcript, &schedule);
     defer schedule.wipe();
 
     try testing.expectEqualSlices(u8, &hexBytes("219ee43b44c170016081d9116317eab9b749cd4a6f3c7f0ba4f33594ba2889c3636f74b6ca205763519447a4fbb2bbd6"), schedule.handshake_secret[0..hash_len_384]);
@@ -185,15 +192,18 @@ test "SHA-384 KeySchedule.init and applicationSecrets reject SHA-256-sized input
 
     const shared = [_]u8{0x42} ** shared_secret_len;
     const wrong_transcript = [_]u8{0x24} ** hash_len;
-    try testing.expectError(error.InvalidSecretLength, KeySchedule.init(cp, .sha384, &shared, &wrong_transcript));
+    var scratch: KeySchedule = undefined;
+    try testing.expectError(error.InvalidSecretLength, KeySchedule.init(cp, .sha384, &shared, &wrong_transcript, &scratch));
 
     const transcript384 = [_]u8{0x24} ** hash_len_384;
-    var schedule = try KeySchedule.init(cp, .sha384, &shared, &transcript384);
+    var schedule: KeySchedule = undefined;
+    try KeySchedule.init(cp, .sha384, &shared, &transcript384, &schedule);
     defer schedule.wipe();
-    try testing.expectError(error.InvalidSecretLength, schedule.applicationSecrets(&wrong_transcript));
+    var scratch_app: KeySchedule.ApplicationSecrets = undefined;
+    try testing.expectError(error.InvalidSecretLength, schedule.applicationSecrets(&wrong_transcript, &scratch_app));
 
     const wrong_psk = [_]u8{0x99} ** hash_len;
-    try testing.expectError(error.InvalidSecretLength, KeySchedule.initWithPsk(cp, .sha384, &wrong_psk, &shared, &transcript384));
+    try testing.expectError(error.InvalidSecretLength, KeySchedule.initWithPsk(cp, .sha384, &wrong_psk, &shared, &transcript384, &scratch));
 }
 
 test "application traffic secret storage has explicit cleanup" {
@@ -203,9 +213,11 @@ test "application traffic secret storage has explicit cleanup" {
 
     const shared = [_]u8{0x42} ** shared_secret_len;
     const transcript = [_]u8{0x24} ** hash_len;
-    var schedule = try KeySchedule.init(cp, .sha256, &shared, &transcript);
+    var schedule: KeySchedule = undefined;
+    try KeySchedule.init(cp, .sha256, &shared, &transcript, &schedule);
     defer schedule.wipe();
-    var app = try schedule.applicationSecrets(&transcript);
+    var app: KeySchedule.ApplicationSecrets = undefined;
+    try schedule.applicationSecrets(&transcript, &app);
     try testing.expect(!std.mem.allEqual(u8, std.mem.asBytes(&app), 0));
     app.wipe();
     try testing.expect(std.mem.allEqual(u8, std.mem.asBytes(&app), 0));
@@ -226,7 +238,8 @@ test "KeySchedule.wipe zeroizes every derived secret" {
 
     const shared = [_]u8{0x77} ** shared_secret_len;
     const transcript = [_]u8{0x88} ** hash_len;
-    var schedule = try KeySchedule.init(cp, .sha256, &shared, &transcript);
+    var schedule: KeySchedule = undefined;
+    try KeySchedule.init(cp, .sha256, &shared, &transcript, &schedule);
     const bytes = std.mem.asBytes(&schedule);
     try testing.expect(!std.mem.allEqual(u8, bytes, 0));
     schedule.wipe();
@@ -240,7 +253,8 @@ test "resumption master secret and PSK derivation are deterministic" {
 
     const shared = hexBytes("8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d");
     const hello_hash = hexBytes("860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8");
-    var schedule = try KeySchedule.init(cp, .sha256, &shared, &hello_hash);
+    var schedule: KeySchedule = undefined;
+    try KeySchedule.init(cp, .sha256, &shared, &hello_hash, &schedule);
     defer schedule.wipe();
 
     const complete_hash = hexBytes("209145a96ee8e5751f3b7e74e573c01c384cff1b902e8ae503d6d3469c698d1c");
@@ -299,11 +313,14 @@ test "initWithPsk diverges from the zero-PSK schedule and is deterministic" {
     const transcript = [_]u8{0x24} ** hash_len;
     const psk = [_]u8{0x99} ** hash_len;
 
-    var zero_psk_schedule = try KeySchedule.init(cp, .sha256, &shared, &transcript);
+    var zero_psk_schedule: KeySchedule = undefined;
+    try KeySchedule.init(cp, .sha256, &shared, &transcript, &zero_psk_schedule);
     defer zero_psk_schedule.wipe();
-    var psk_schedule = try KeySchedule.initWithPsk(cp, .sha256, &psk, &shared, &transcript);
+    var psk_schedule: KeySchedule = undefined;
+    try KeySchedule.initWithPsk(cp, .sha256, &psk, &shared, &transcript, &psk_schedule);
     defer psk_schedule.wipe();
-    var psk_schedule_again = try KeySchedule.initWithPsk(cp, .sha256, &psk, &shared, &transcript);
+    var psk_schedule_again: KeySchedule = undefined;
+    try KeySchedule.initWithPsk(cp, .sha256, &psk, &shared, &transcript, &psk_schedule_again);
     defer psk_schedule_again.wipe();
 
     try testing.expect(!std.mem.eql(u8, &zero_psk_schedule.handshake_secret, &psk_schedule.handshake_secret));
@@ -312,7 +329,8 @@ test "initWithPsk diverges from the zero-PSK schedule and is deterministic" {
     try testing.expectEqualSlices(u8, &psk_schedule.master_secret, &psk_schedule_again.master_secret);
     try testing.expect(!std.mem.eql(u8, &psk_schedule.client_handshake_traffic, &psk_schedule.server_handshake_traffic));
 
-    var app = try psk_schedule.applicationSecrets(&transcript);
+    var app: KeySchedule.ApplicationSecrets = undefined;
+    try psk_schedule.applicationSecrets(&transcript, &app);
     defer app.wipe();
     try testing.expect(!std.mem.eql(u8, app.clientSecret(), app.serverSecret()));
 }
@@ -330,7 +348,8 @@ test "initWithPsk matches independently computed secrets" {
     const transcript = [_]u8{0x24} ** hash_len;
     const psk = [_]u8{0x99} ** hash_len;
 
-    var schedule = try KeySchedule.initWithPsk(cp, .sha256, &psk, &shared, &transcript);
+    var schedule: KeySchedule = undefined;
+    try KeySchedule.initWithPsk(cp, .sha256, &psk, &shared, &transcript, &schedule);
     defer schedule.wipe();
 
     try testing.expectEqualSlices(u8, &hexBytes("ab0803d6203c8feddfe8adc74f986c9d89b817b3d4132fc55c866a3522d9ff49"), schedule.handshake_secret[0..hash_len]);
@@ -338,7 +357,8 @@ test "initWithPsk matches independently computed secrets" {
     try testing.expectEqualSlices(u8, &hexBytes("739483d9d6a9508c73b4656de22fedd85a2a8d00e9a6ca1449d8cba678c94baf"), schedule.server_handshake_traffic[0..hash_len]);
     try testing.expectEqualSlices(u8, &hexBytes("abe96cce65361235f3126971c67760888b79d4c1724a6cb1e15f6d2ae128ff44"), schedule.master_secret[0..hash_len]);
 
-    var app = try schedule.applicationSecrets(&transcript);
+    var app: KeySchedule.ApplicationSecrets = undefined;
+    try schedule.applicationSecrets(&transcript, &app);
     defer app.wipe();
     try testing.expectEqualSlices(u8, &hexBytes("d1ba0b1be9862f1bd4c3bcc0d53b5a98c6a4951c4bad19243051237bc735031c"), app.clientSecret());
     try testing.expectEqualSlices(u8, &hexBytes("c7428c93109f1b656dcbf0971e5d1bad9c2d38b79420038b7e165a17c7f61fa1"), app.serverSecret());
@@ -354,9 +374,11 @@ test "a different resumption PSK produces a different PSK-resumed schedule" {
     const psk_a = [_]u8{0xaa} ** hash_len;
     const psk_b = [_]u8{0xbb} ** hash_len;
 
-    var schedule_a = try KeySchedule.initWithPsk(cp, .sha256, &psk_a, &shared, &transcript);
+    var schedule_a: KeySchedule = undefined;
+    try KeySchedule.initWithPsk(cp, .sha256, &psk_a, &shared, &transcript, &schedule_a);
     defer schedule_a.wipe();
-    var schedule_b = try KeySchedule.initWithPsk(cp, .sha256, &psk_b, &shared, &transcript);
+    var schedule_b: KeySchedule = undefined;
+    try KeySchedule.initWithPsk(cp, .sha256, &psk_b, &shared, &transcript, &schedule_b);
     defer schedule_b.wipe();
 
     try testing.expect(!std.mem.eql(u8, &schedule_a.master_secret, &schedule_b.master_secret));
@@ -489,10 +511,11 @@ test "init/initWithPsk/applicationSecrets propagate a typed provider error rathe
 
     const shared = [_]u8{0x42} ** shared_secret_len;
     const transcript = [_]u8{0x24} ** hash_len;
-    try testing.expectError(error.UnsupportedCapability, KeySchedule.init(cp, .sha256, &shared, &transcript));
+    var scratch: KeySchedule = undefined;
+    try testing.expectError(error.UnsupportedCapability, KeySchedule.init(cp, .sha256, &shared, &transcript, &scratch));
 
     const psk = [_]u8{0x99} ** hash_len;
-    try testing.expectError(error.UnsupportedCapability, KeySchedule.initWithPsk(cp, .sha256, &psk, &shared, &transcript));
+    try testing.expectError(error.UnsupportedCapability, KeySchedule.initWithPsk(cp, .sha256, &psk, &shared, &transcript, &scratch));
     var early: [hash_len]u8 = undefined;
     try testing.expectError(error.UnsupportedCapability, KeySchedule.clientEarlyTrafficSecret(cp, .sha256, &psk, &transcript, &early));
 
@@ -585,8 +608,9 @@ test "every fallible HKDF entry point wipes its own output buffer(s) when the pr
     const transcript = [_]u8{0x24} ** hash_len;
     const psk = [_]u8{0x99} ** hash_len;
 
-    try testing.expectError(error.UnsupportedCapability, KeySchedule.init(cp, .sha256, &shared, &transcript));
-    try testing.expectError(error.UnsupportedCapability, KeySchedule.initWithPsk(cp, .sha256, &psk, &shared, &transcript));
+    var scratch: KeySchedule = undefined;
+    try testing.expectError(error.UnsupportedCapability, KeySchedule.init(cp, .sha256, &shared, &transcript, &scratch));
+    try testing.expectError(error.UnsupportedCapability, KeySchedule.initWithPsk(cp, .sha256, &psk, &shared, &transcript, &scratch));
 
     // clientEarlyTrafficSecret and verifyData both fail at an earlier
     // *internal* HKDF call (into a local secret, not the caller's `out`)
@@ -615,10 +639,12 @@ test "every fallible HKDF entry point wipes its own output buffer(s) when the pr
     var real_det = pure_zig.DeterministicEntropy.init(20);
     var real_backing: pure_zig.Provider = undefined;
     const real_cp = testProvider(&real_det, &real_backing);
-    var schedule = try KeySchedule.init(real_cp, .sha256, &shared, &transcript);
+    var schedule: KeySchedule = undefined;
+    try KeySchedule.init(real_cp, .sha256, &shared, &transcript, &schedule);
     defer schedule.wipe();
     schedule.provider = cp;
-    try testing.expectError(error.UnsupportedCapability, schedule.applicationSecrets(&transcript));
+    var app_scratch: KeySchedule.ApplicationSecrets = undefined;
+    try testing.expectError(error.UnsupportedCapability, schedule.applicationSecrets(&transcript, &app_scratch));
 }
 
 fn hexBytes(comptime hex: []const u8) [hex.len / 2]u8 {

--- a/src/tls/key_schedule_tests.zig
+++ b/src/tls/key_schedule_tests.zig
@@ -2,9 +2,9 @@
 //!
 //! Kept in a separate file from the production module (#490 review): this
 //! file's own cross-check against a direct `std.crypto.auth.hmac.sha2.
-//! HmacSha256` computation, and its raw `CryptoProvider` vtable fixture for
-//! typed-error-propagation, are legitimate test-only direct-crypto use, but a
-//! textual "scan everything before this marker" boundary inside the
+//! HmacSha256`/`HmacSha384` computation, and its raw `CryptoProvider` vtable
+//! fixture for typed-error-propagation, are legitimate test-only direct-crypto
+//! use, but a textual "scan everything before this marker" boundary inside the
 //! production file is not a sound reachability proof — Zig declarations are
 //! order-independent, so a production function declared before such a marker
 //! could still call a private helper declared after it, and the scan would
@@ -13,6 +13,12 @@
 //! `tests/support/quic_crypto.zig` and `tests/crypto_vectors.zig` aren't
 //! scanned either) is the sound fix: `key_schedule.zig` itself now has zero
 //! test-only content and is scanned in full, with no marker.
+//!
+//! SHA-384 fixtures below (independent of the SHA-256 RFC 8448 trace) were
+//! computed with plain Python `hmac`/`hashlib` implementing RFC 8446's
+//! HKDF-Expand-Label directly — not by re-deriving with the helpers under
+//! test — matching this codebase's existing differential-fixture convention
+//! (see `record_protection.zig`'s AES-256-GCM/ChaCha20 known-answer tests).
 
 const std = @import("std");
 const testing = std.testing;
@@ -30,8 +36,12 @@ const pure_zig = @import("crypto").pure_zig;
 const key_schedule = @import("tls_core").key_schedule;
 
 const KeySchedule = key_schedule.KeySchedule;
-const hash_len = key_schedule.hash_len;
 const shared_secret_len = key_schedule.shared_secret_len;
+/// SHA-256's digest length, used throughout the SHA-256 fixtures below. Not
+/// re-exported by `key_schedule.zig` itself (#564): the production module no
+/// longer names a single fixed digest length, since it is hash-agile.
+const hash_len = 32;
+const hash_len_384 = 48;
 
 /// A fresh deterministic pure-Zig `CryptoProvider` for this module's own
 /// tests, built the same way `src/crypto/pure_zig.zig`'s own test block
@@ -49,11 +59,11 @@ test "record-mode users can instantiate the protocol-neutral key schedule" {
 
     const shared = [_]u8{0x42} ** shared_secret_len;
     const transcript = [_]u8{0x24} ** hash_len;
-    var schedule = try KeySchedule.init(cp, &shared, transcript);
+    var schedule = try KeySchedule.init(cp, .sha256, &shared, &transcript);
     defer schedule.wipe();
-    var app = try schedule.applicationSecrets(transcript);
+    var app = try schedule.applicationSecrets(&transcript);
     defer app.wipe();
-    try testing.expect(!std.mem.eql(u8, &app.client, &app.server));
+    try testing.expect(!std.mem.eql(u8, app.clientSecret(), app.serverSecret()));
 }
 
 test "shared TLS 1.3 key schedule matches the RFC 8448 simple 1-RTT trace" {
@@ -63,21 +73,23 @@ test "shared TLS 1.3 key schedule matches the RFC 8448 simple 1-RTT trace" {
 
     const shared = hexBytes("8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d");
     const hello_hash = hexBytes("860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8");
-    var schedule = try KeySchedule.init(cp, &shared, hello_hash);
+    var schedule = try KeySchedule.init(cp, .sha256, &shared, &hello_hash);
     defer schedule.wipe();
 
-    try testing.expectEqualSlices(u8, &hexBytes("1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac"), &schedule.handshake_secret);
-    try testing.expectEqualSlices(u8, &hexBytes("b3eddb126e067f35a780b3abf45e2d8f3b1a950738f52e9600746a0e27a55a21"), &schedule.client_handshake_traffic);
-    try testing.expectEqualSlices(u8, &hexBytes("b67b7d690cc16c4e75e54213cb2d37b4e9c912bcded9105d42befd59d391ad38"), &schedule.server_handshake_traffic);
-    try testing.expectEqualSlices(u8, &hexBytes("18df06843d13a08bf2a449844c5f8a478001bc4d4c627984d5a41da8d0402919"), &schedule.master_secret);
+    try testing.expectEqualSlices(u8, &hexBytes("1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac"), schedule.handshake_secret[0..hash_len]);
+    try testing.expectEqualSlices(u8, &hexBytes("b3eddb126e067f35a780b3abf45e2d8f3b1a950738f52e9600746a0e27a55a21"), schedule.client_handshake_traffic[0..hash_len]);
+    try testing.expectEqualSlices(u8, &hexBytes("b67b7d690cc16c4e75e54213cb2d37b4e9c912bcded9105d42befd59d391ad38"), schedule.server_handshake_traffic[0..hash_len]);
+    try testing.expectEqualSlices(u8, &hexBytes("18df06843d13a08bf2a449844c5f8a478001bc4d4c627984d5a41da8d0402919"), schedule.master_secret[0..hash_len]);
 
     const finished_hash = hexBytes("9608102a0f1ccc6db6250b7b7e417b1a000eaada3daae4777a7686c9ff83df13");
-    var app = try schedule.applicationSecrets(finished_hash);
+    var app = try schedule.applicationSecrets(&finished_hash);
     defer app.wipe();
-    try testing.expectEqualSlices(u8, &hexBytes("9e40646ce79a7f9dc05af8889bce6552875afa0b06df0087f792ebb7c17504a5"), &app.client);
-    try testing.expectEqualSlices(u8, &hexBytes("a11af9f05531f856ad47116b45a950328204b4f44bfb6b3a4b4f1f3fcb631643"), &app.server);
-    var finished_key = try KeySchedule.finishedKey(cp, &schedule.server_handshake_traffic);
+    try testing.expectEqualSlices(u8, &hexBytes("9e40646ce79a7f9dc05af8889bce6552875afa0b06df0087f792ebb7c17504a5"), app.clientSecret());
+    try testing.expectEqualSlices(u8, &hexBytes("a11af9f05531f856ad47116b45a950328204b4f44bfb6b3a4b4f1f3fcb631643"), app.serverSecret());
+
+    var finished_key: [hash_len]u8 = undefined;
     defer crypto.secureZero(u8, &finished_key);
+    try KeySchedule.finishedKey(cp, .sha256, schedule.server_handshake_traffic[0..hash_len], &finished_key);
     try testing.expectEqualSlices(u8, &hexBytes("008d3b66f816ea559f96b537e885c31fc068bf492c652f01f288a1d8cdc19fc8"), &finished_key);
 
     // The HKDF-Extract-as-HMAC verify_data trick documented on `verifyData`
@@ -89,8 +101,99 @@ test "shared TLS 1.3 key schedule matches the RFC 8448 simple 1-RTT trace" {
     const HmacSha256 = crypto.auth.hmac.sha2.HmacSha256;
     var direct_mac: [HmacSha256.mac_length]u8 = undefined;
     HmacSha256.create(&direct_mac, &finished_hash, &finished_key);
-    const verify_data = try KeySchedule.verifyData(cp, &schedule.server_handshake_traffic, finished_hash);
+    var verify_data: [hash_len]u8 = undefined;
+    try KeySchedule.verifyData(cp, .sha256, schedule.server_handshake_traffic[0..hash_len], &finished_hash, &verify_data);
     try testing.expectEqualSlices(u8, &direct_mac, &verify_data);
+}
+
+test "SHA-384 key schedule matches an independently computed known-answer fixture" {
+    // Checked-in literals computed independently of this module (plain
+    // Python hmac/hashlib implementing RFC 8446 HKDF-Expand-Label directly),
+    // for shared=0x42*32, transcript=0x24*48 — the SHA-384 analogue of the
+    // zero-PSK fixtures above.
+    var det = pure_zig.DeterministicEntropy.init(14);
+    var backing: pure_zig.Provider = undefined;
+    const cp = testProvider(&det, &backing);
+
+    const shared = [_]u8{0x42} ** shared_secret_len;
+    const transcript = [_]u8{0x24} ** hash_len_384;
+    var schedule = try KeySchedule.init(cp, .sha384, &shared, &transcript);
+    defer schedule.wipe();
+    try testing.expectEqual(provider.Hash.sha384, schedule.hash);
+    try testing.expectEqual(@as(usize, hash_len_384), schedule.digestLen());
+
+    try testing.expectEqualSlices(u8, &hexBytes("d6dc3f5d0217df1301fb9479d8aadd88e542306d6cdcf197913593658a5f2c50f526964fbaf5e4587be563272eda583d"), schedule.handshake_secret[0..hash_len_384]);
+    try testing.expectEqualSlices(u8, &hexBytes("8df0e42bc34170cf567790494d4fbb5b61538895bdaa2cf8a0ad2db0b588b46d52853504d8713db39e4c28f396cab7b0"), schedule.master_secret[0..hash_len_384]);
+    try testing.expectEqualSlices(u8, &hexBytes("3ce66a169e12ab6927d5832cba1abaabb6c5237b1f129ff8e18e355c2e8f6f56e53ab195579da5131217e94aa57f18ac"), schedule.client_handshake_traffic[0..hash_len_384]);
+    try testing.expectEqualSlices(u8, &hexBytes("062cc3bc2f786fd4d738bcf21d14ab173386513f5a98e99656b46865b373062768ff77f69b58467715667f56c7fd3353"), schedule.server_handshake_traffic[0..hash_len_384]);
+
+    var app = try schedule.applicationSecrets(&transcript);
+    defer app.wipe();
+    try testing.expectEqual(@as(usize, hash_len_384), app.len);
+    try testing.expectEqualSlices(u8, &hexBytes("8d2c41fc2f30630d9924bae6ff52df22d94939379fcd7de4b31f6bf7ceb0ec40c46c744a69ab217dc5c6e797ebebc291"), app.clientSecret());
+    try testing.expectEqualSlices(u8, &hexBytes("776852783850e21c01a86b5d5a861a7851f98a14189e6c58bfa941c9d99815317304e2deb0d74185ee97aa415ea74eb0"), app.serverSecret());
+
+    var finished_key: [hash_len_384]u8 = undefined;
+    defer crypto.secureZero(u8, &finished_key);
+    try KeySchedule.finishedKey(cp, .sha384, schedule.server_handshake_traffic[0..hash_len_384], &finished_key);
+    try testing.expectEqualSlices(u8, &hexBytes("0618d45ecd47b39463530464a6a91a50394c343442f3ec4491a8d0ecbcfb79ba24163c3a3a035676253e5c08ebe7b22e"), &finished_key);
+
+    const HmacSha384 = crypto.auth.hmac.sha2.HmacSha384;
+    var direct_mac: [HmacSha384.mac_length]u8 = undefined;
+    HmacSha384.create(&direct_mac, &transcript, &finished_key);
+    var verify_data: [hash_len_384]u8 = undefined;
+    try KeySchedule.verifyData(cp, .sha384, schedule.server_handshake_traffic[0..hash_len_384], &transcript, &verify_data);
+    try testing.expectEqualSlices(u8, &hexBytes("c9df95efc74c3e4ad63513ef86662693b2c52ceb0365773697c35d99a0ae7895a103993cad47021f0f55d0148d375daf"), &verify_data);
+    try testing.expectEqualSlices(u8, &direct_mac, &verify_data);
+}
+
+test "SHA-384 initWithPsk matches an independently computed known-answer fixture" {
+    var det = pure_zig.DeterministicEntropy.init(15);
+    var backing: pure_zig.Provider = undefined;
+    const cp = testProvider(&det, &backing);
+
+    const shared = [_]u8{0x42} ** shared_secret_len;
+    const transcript = [_]u8{0x24} ** hash_len_384;
+    const psk = [_]u8{0x99} ** hash_len_384;
+
+    var schedule = try KeySchedule.initWithPsk(cp, .sha384, &psk, &shared, &transcript);
+    defer schedule.wipe();
+
+    try testing.expectEqualSlices(u8, &hexBytes("219ee43b44c170016081d9116317eab9b749cd4a6f3c7f0ba4f33594ba2889c3636f74b6ca205763519447a4fbb2bbd6"), schedule.handshake_secret[0..hash_len_384]);
+    try testing.expectEqualSlices(u8, &hexBytes("c29de3d70cc9b39002b526cd3da32b39898e2b3a92fb167edfe18eb8df87da96a2ba26ba178b9062d6f2c85ea5d35bb6"), schedule.master_secret[0..hash_len_384]);
+    try testing.expectEqualSlices(u8, &hexBytes("f69664bafa4dff4ba0d22cb285225af79da35d46b7f2c5315fdb3479ebedfb612912473b798499cd6f69c61a201cabec"), schedule.client_handshake_traffic[0..hash_len_384]);
+    try testing.expectEqualSlices(u8, &hexBytes("f64f8f854a4fed3eb56a6f2587881b36c7b03ec941e611fee8a400fe3259a922110da51cde297e420f65a8fb47bee8c0"), schedule.server_handshake_traffic[0..hash_len_384]);
+}
+
+test "SHA-384 clientEarlyTrafficSecret matches an independently computed known-answer fixture" {
+    var det = pure_zig.DeterministicEntropy.init(16);
+    var backing: pure_zig.Provider = undefined;
+    const cp = testProvider(&det, &backing);
+
+    const psk = [_]u8{0x99} ** hash_len_384;
+    const hello_hash = [_]u8{0x24} ** hash_len_384;
+    var out: [hash_len_384]u8 = undefined;
+    defer crypto.secureZero(u8, &out);
+    try KeySchedule.clientEarlyTrafficSecret(cp, .sha384, &psk, &hello_hash, &out);
+    try testing.expectEqualSlices(u8, &hexBytes("c40401d9bf363b9677cc95cb7de19c7ce0bb56eac777b92d7b89235ef7c9c68947bba378116f1abcaf1e9bcb7211807c"), &out);
+}
+
+test "SHA-384 KeySchedule.init and applicationSecrets reject SHA-256-sized inputs" {
+    var det = pure_zig.DeterministicEntropy.init(17);
+    var backing: pure_zig.Provider = undefined;
+    const cp = testProvider(&det, &backing);
+
+    const shared = [_]u8{0x42} ** shared_secret_len;
+    const wrong_transcript = [_]u8{0x24} ** hash_len;
+    try testing.expectError(error.InvalidSecretLength, KeySchedule.init(cp, .sha384, &shared, &wrong_transcript));
+
+    const transcript384 = [_]u8{0x24} ** hash_len_384;
+    var schedule = try KeySchedule.init(cp, .sha384, &shared, &transcript384);
+    defer schedule.wipe();
+    try testing.expectError(error.InvalidSecretLength, schedule.applicationSecrets(&wrong_transcript));
+
+    const wrong_psk = [_]u8{0x99} ** hash_len;
+    try testing.expectError(error.InvalidSecretLength, KeySchedule.initWithPsk(cp, .sha384, &wrong_psk, &shared, &transcript384));
 }
 
 test "application traffic secret storage has explicit cleanup" {
@@ -100,9 +203,9 @@ test "application traffic secret storage has explicit cleanup" {
 
     const shared = [_]u8{0x42} ** shared_secret_len;
     const transcript = [_]u8{0x24} ** hash_len;
-    var schedule = try KeySchedule.init(cp, &shared, transcript);
+    var schedule = try KeySchedule.init(cp, .sha256, &shared, &transcript);
     defer schedule.wipe();
-    var app = try schedule.applicationSecrets(transcript);
+    var app = try schedule.applicationSecrets(&transcript);
     try testing.expect(!std.mem.allEqual(u8, std.mem.asBytes(&app), 0));
     app.wipe();
     try testing.expect(std.mem.allEqual(u8, std.mem.asBytes(&app), 0));
@@ -123,7 +226,7 @@ test "KeySchedule.wipe zeroizes every derived secret" {
 
     const shared = [_]u8{0x77} ** shared_secret_len;
     const transcript = [_]u8{0x88} ** hash_len;
-    var schedule = try KeySchedule.init(cp, &shared, transcript);
+    var schedule = try KeySchedule.init(cp, .sha256, &shared, &transcript);
     const bytes = std.mem.asBytes(&schedule);
     try testing.expect(!std.mem.allEqual(u8, bytes, 0));
     schedule.wipe();
@@ -137,7 +240,7 @@ test "resumption master secret and PSK derivation are deterministic" {
 
     const shared = hexBytes("8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d");
     const hello_hash = hexBytes("860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8");
-    var schedule = try KeySchedule.init(cp, &shared, hello_hash);
+    var schedule = try KeySchedule.init(cp, .sha256, &shared, &hello_hash);
     defer schedule.wipe();
 
     const complete_hash = hexBytes("209145a96ee8e5751f3b7e74e573c01c384cff1b902e8ae503d6d3469c698d1c");
@@ -196,11 +299,11 @@ test "initWithPsk diverges from the zero-PSK schedule and is deterministic" {
     const transcript = [_]u8{0x24} ** hash_len;
     const psk = [_]u8{0x99} ** hash_len;
 
-    var zero_psk_schedule = try KeySchedule.init(cp, &shared, transcript);
+    var zero_psk_schedule = try KeySchedule.init(cp, .sha256, &shared, &transcript);
     defer zero_psk_schedule.wipe();
-    var psk_schedule = try KeySchedule.initWithPsk(cp, &psk, &shared, transcript);
+    var psk_schedule = try KeySchedule.initWithPsk(cp, .sha256, &psk, &shared, &transcript);
     defer psk_schedule.wipe();
-    var psk_schedule_again = try KeySchedule.initWithPsk(cp, &psk, &shared, transcript);
+    var psk_schedule_again = try KeySchedule.initWithPsk(cp, .sha256, &psk, &shared, &transcript);
     defer psk_schedule_again.wipe();
 
     try testing.expect(!std.mem.eql(u8, &zero_psk_schedule.handshake_secret, &psk_schedule.handshake_secret));
@@ -209,9 +312,9 @@ test "initWithPsk diverges from the zero-PSK schedule and is deterministic" {
     try testing.expectEqualSlices(u8, &psk_schedule.master_secret, &psk_schedule_again.master_secret);
     try testing.expect(!std.mem.eql(u8, &psk_schedule.client_handshake_traffic, &psk_schedule.server_handshake_traffic));
 
-    var app = try psk_schedule.applicationSecrets(transcript);
+    var app = try psk_schedule.applicationSecrets(&transcript);
     defer app.wipe();
-    try testing.expect(!std.mem.eql(u8, &app.client, &app.server));
+    try testing.expect(!std.mem.eql(u8, app.clientSecret(), app.serverSecret()));
 }
 
 test "initWithPsk matches independently computed secrets" {
@@ -227,18 +330,18 @@ test "initWithPsk matches independently computed secrets" {
     const transcript = [_]u8{0x24} ** hash_len;
     const psk = [_]u8{0x99} ** hash_len;
 
-    var schedule = try KeySchedule.initWithPsk(cp, &psk, &shared, transcript);
+    var schedule = try KeySchedule.initWithPsk(cp, .sha256, &psk, &shared, &transcript);
     defer schedule.wipe();
 
-    try testing.expectEqualSlices(u8, &hexBytes("ab0803d6203c8feddfe8adc74f986c9d89b817b3d4132fc55c866a3522d9ff49"), &schedule.handshake_secret);
-    try testing.expectEqualSlices(u8, &hexBytes("e92139285417b6a9a54a7a9153f4b6dcce44b99cdc0937b83dfea5c79805c920"), &schedule.client_handshake_traffic);
-    try testing.expectEqualSlices(u8, &hexBytes("739483d9d6a9508c73b4656de22fedd85a2a8d00e9a6ca1449d8cba678c94baf"), &schedule.server_handshake_traffic);
-    try testing.expectEqualSlices(u8, &hexBytes("abe96cce65361235f3126971c67760888b79d4c1724a6cb1e15f6d2ae128ff44"), &schedule.master_secret);
+    try testing.expectEqualSlices(u8, &hexBytes("ab0803d6203c8feddfe8adc74f986c9d89b817b3d4132fc55c866a3522d9ff49"), schedule.handshake_secret[0..hash_len]);
+    try testing.expectEqualSlices(u8, &hexBytes("e92139285417b6a9a54a7a9153f4b6dcce44b99cdc0937b83dfea5c79805c920"), schedule.client_handshake_traffic[0..hash_len]);
+    try testing.expectEqualSlices(u8, &hexBytes("739483d9d6a9508c73b4656de22fedd85a2a8d00e9a6ca1449d8cba678c94baf"), schedule.server_handshake_traffic[0..hash_len]);
+    try testing.expectEqualSlices(u8, &hexBytes("abe96cce65361235f3126971c67760888b79d4c1724a6cb1e15f6d2ae128ff44"), schedule.master_secret[0..hash_len]);
 
-    var app = try schedule.applicationSecrets(transcript);
+    var app = try schedule.applicationSecrets(&transcript);
     defer app.wipe();
-    try testing.expectEqualSlices(u8, &hexBytes("d1ba0b1be9862f1bd4c3bcc0d53b5a98c6a4951c4bad19243051237bc735031c"), &app.client);
-    try testing.expectEqualSlices(u8, &hexBytes("c7428c93109f1b656dcbf0971e5d1bad9c2d38b79420038b7e165a17c7f61fa1"), &app.server);
+    try testing.expectEqualSlices(u8, &hexBytes("d1ba0b1be9862f1bd4c3bcc0d53b5a98c6a4951c4bad19243051237bc735031c"), app.clientSecret());
+    try testing.expectEqualSlices(u8, &hexBytes("c7428c93109f1b656dcbf0971e5d1bad9c2d38b79420038b7e165a17c7f61fa1"), app.serverSecret());
 }
 
 test "a different resumption PSK produces a different PSK-resumed schedule" {
@@ -251,9 +354,9 @@ test "a different resumption PSK produces a different PSK-resumed schedule" {
     const psk_a = [_]u8{0xaa} ** hash_len;
     const psk_b = [_]u8{0xbb} ** hash_len;
 
-    var schedule_a = try KeySchedule.initWithPsk(cp, &psk_a, &shared, transcript);
+    var schedule_a = try KeySchedule.initWithPsk(cp, .sha256, &psk_a, &shared, &transcript);
     defer schedule_a.wipe();
-    var schedule_b = try KeySchedule.initWithPsk(cp, &psk_b, &shared, transcript);
+    var schedule_b = try KeySchedule.initWithPsk(cp, .sha256, &psk_b, &shared, &transcript);
     defer schedule_b.wipe();
 
     try testing.expect(!std.mem.eql(u8, &schedule_a.master_secret, &schedule_b.master_secret));
@@ -270,7 +373,8 @@ test "clientEarlyTrafficSecret matches an independently computed known-answer fi
     const psk = [_]u8{0x99} ** hash_len;
     const hello_hash = [_]u8{0x24} ** hash_len;
 
-    const early = try KeySchedule.clientEarlyTrafficSecret(cp, &psk, hello_hash);
+    var early: [hash_len]u8 = undefined;
+    try KeySchedule.clientEarlyTrafficSecret(cp, .sha256, &psk, &hello_hash, &early);
     try testing.expectEqualSlices(u8, &hexBytes("16d133c56483399331d093c3389c265a9547962c6b494b215e02e4eb92900afd"), &early);
 }
 
@@ -284,8 +388,10 @@ test "clientEarlyTrafficSecret differs when the PSK differs" {
     const hello_hash_a = [_]u8{0x24} ** hash_len;
     const hello_hash_b = [_]u8{0x11} ** hash_len;
 
-    const early_a = try KeySchedule.clientEarlyTrafficSecret(cp, &psk_a, hello_hash_a);
-    const early_b = try KeySchedule.clientEarlyTrafficSecret(cp, &psk_b, hello_hash_b);
+    var early_a: [hash_len]u8 = undefined;
+    var early_b: [hash_len]u8 = undefined;
+    try KeySchedule.clientEarlyTrafficSecret(cp, .sha256, &psk_a, &hello_hash_a, &early_a);
+    try KeySchedule.clientEarlyTrafficSecret(cp, .sha256, &psk_b, &hello_hash_b, &early_b);
     try testing.expectEqualSlices(u8, &hexBytes("e69f3f7132880345ceda14cd7dcef6aeec62182cb3973d19a50371d75832f596"), &early_b);
     try testing.expect(!std.mem.eql(u8, &early_a, &early_b));
 }
@@ -301,7 +407,8 @@ test "clientEarlyTrafficSecret differs when only the ClientHello hash differs" {
     const psk = [_]u8{0x99} ** hash_len;
     const hello_hash = [_]u8{0x77} ** hash_len;
 
-    const early = try KeySchedule.clientEarlyTrafficSecret(cp, &psk, hello_hash);
+    var early: [hash_len]u8 = undefined;
+    try KeySchedule.clientEarlyTrafficSecret(cp, .sha256, &psk, &hello_hash, &early);
     try testing.expectEqualSlices(u8, &hexBytes("7d693eba9b582d3867e21784c2682d6ecef79deacbd28089a705e45ea8273310"), &early);
 }
 
@@ -382,11 +489,12 @@ test "init/initWithPsk/applicationSecrets propagate a typed provider error rathe
 
     const shared = [_]u8{0x42} ** shared_secret_len;
     const transcript = [_]u8{0x24} ** hash_len;
-    try testing.expectError(error.UnsupportedCapability, KeySchedule.init(cp, &shared, transcript));
+    try testing.expectError(error.UnsupportedCapability, KeySchedule.init(cp, .sha256, &shared, &transcript));
 
     const psk = [_]u8{0x99} ** hash_len;
-    try testing.expectError(error.UnsupportedCapability, KeySchedule.initWithPsk(cp, &psk, &shared, transcript));
-    try testing.expectError(error.UnsupportedCapability, KeySchedule.clientEarlyTrafficSecret(cp, &psk, transcript));
+    try testing.expectError(error.UnsupportedCapability, KeySchedule.initWithPsk(cp, .sha256, &psk, &shared, &transcript));
+    var early: [hash_len]u8 = undefined;
+    try testing.expectError(error.UnsupportedCapability, KeySchedule.clientEarlyTrafficSecret(cp, .sha256, &psk, &transcript, &early));
 
     var out: [hash_len]u8 = undefined;
     try testing.expectError(error.UnsupportedCapability, KeySchedule.resumptionPsk(cp, .sha256, &psk, "n", &out));
@@ -477,11 +585,23 @@ test "every fallible HKDF entry point wipes its own output buffer(s) when the pr
     const transcript = [_]u8{0x24} ** hash_len;
     const psk = [_]u8{0x99} ** hash_len;
 
-    try testing.expectError(error.UnsupportedCapability, KeySchedule.init(cp, &shared, transcript));
-    try testing.expectError(error.UnsupportedCapability, KeySchedule.initWithPsk(cp, &psk, &shared, transcript));
-    try testing.expectError(error.UnsupportedCapability, KeySchedule.clientEarlyTrafficSecret(cp, &psk, transcript));
-    try testing.expectError(error.UnsupportedCapability, KeySchedule.finishedKey(cp, &psk));
-    try testing.expectError(error.UnsupportedCapability, KeySchedule.verifyData(cp, &psk, transcript));
+    try testing.expectError(error.UnsupportedCapability, KeySchedule.init(cp, .sha256, &shared, &transcript));
+    try testing.expectError(error.UnsupportedCapability, KeySchedule.initWithPsk(cp, .sha256, &psk, &shared, &transcript));
+
+    // clientEarlyTrafficSecret and verifyData both fail at an earlier
+    // *internal* HKDF call (into a local secret, not the caller's `out`)
+    // before ever writing to `out` itself, so there is nothing to wipe
+    // there — only `expectError` applies. finishedKey passes `out` directly
+    // to its one HKDF call, so its own `errdefer` wipe is checked below.
+    var early: [hash_len]u8 = undefined;
+    try testing.expectError(error.UnsupportedCapability, KeySchedule.clientEarlyTrafficSecret(cp, .sha256, &psk, &transcript, &early));
+
+    var fkey: [hash_len]u8 = undefined;
+    try testing.expectError(error.UnsupportedCapability, KeySchedule.finishedKey(cp, .sha256, &psk, &fkey));
+    try testing.expect(std.mem.allEqual(u8, &fkey, 0));
+
+    var vdata: [hash_len]u8 = undefined;
+    try testing.expectError(error.UnsupportedCapability, KeySchedule.verifyData(cp, .sha256, &psk, &transcript, &vdata));
 
     var out: [hash_len]u8 = undefined;
     try testing.expectError(error.UnsupportedCapability, KeySchedule.resumptionPsk(cp, .sha256, &psk, "n", &out));
@@ -495,10 +615,10 @@ test "every fallible HKDF entry point wipes its own output buffer(s) when the pr
     var real_det = pure_zig.DeterministicEntropy.init(20);
     var real_backing: pure_zig.Provider = undefined;
     const real_cp = testProvider(&real_det, &real_backing);
-    var schedule = try KeySchedule.init(real_cp, &shared, transcript);
+    var schedule = try KeySchedule.init(real_cp, .sha256, &shared, &transcript);
     defer schedule.wipe();
     schedule.provider = cp;
-    try testing.expectError(error.UnsupportedCapability, schedule.applicationSecrets(transcript));
+    try testing.expectError(error.UnsupportedCapability, schedule.applicationSecrets(&transcript));
 }
 
 fn hexBytes(comptime hex: []const u8) [hex.len / 2]u8 {

--- a/src/tls/record_epoch_bridge.zig
+++ b/src/tls/record_epoch_bridge.zig
@@ -85,6 +85,14 @@ pub const Bridge = struct {
     pub fn applyEvent(self: *Bridge, event: events.Event, out: []u8) Error!?[]const u8 {
         switch (event) {
             .handshake_bytes => |bytes| return try self.sealHandshake(bytes.epoch, bytes.data, out),
+            // #564: the negotiated suite arrives before any handshake-epoch
+            // traffic secret (the contract `EventSink.emitNegotiatedParameters`
+            // documents), so updating `cipher_suite` here — rather than only
+            // ever accepting the constructor's fixed value — is what lets
+            // `installTrafficSecret` derive the right `TrafficKeys` for
+            // whichever suite this connection actually negotiated.
+            .negotiated_parameters => |params| self.cipher_suite = algorithms.fromInt(algorithms.CipherSuite, params.cipher_suite) orelse
+                return error.UnsupportedRecordEpoch,
             .traffic_secret => |traffic_secret| try self.installTrafficSecret(traffic_secret.epoch, traffic_secret.direction, traffic_secret.data),
             .discard_epoch => |epoch| try self.discardEpoch(epoch),
             .handshake_complete => try self.markHandshakeComplete(),
@@ -968,6 +976,10 @@ test "record epoch bridge shuttles protocol-neutral driver events through record
                         var scratch: [1]u8 = undefined;
                         _ = try sender_bridge.applyEvent(.handshake_complete, &scratch);
                         sender_driver.complete();
+                    },
+                    .negotiated_parameters => |params| {
+                        var scratch: [1]u8 = undefined;
+                        _ = try sender_bridge.applyEvent(.{ .negotiated_parameters = params }, &scratch);
                     },
                     .peer_transport_parameters,
                     .alpn,

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -1855,6 +1855,18 @@ pub const Tls13Backend = struct {
         // advance rather than emitting SNI for a truncated (wrong) host.
         if (self.server_name_overflow) return error.InvalidHandshakeState;
         if (self.role == .client) {
+            // #568 review: this must run before `planPskOffer`/
+            // `planEarlyDataAttempt` (which prune/commit offer-lease state)
+            // and `core.start()` (which advances the handshake lifecycle) —
+            // previously this same check lived inside `sendClientHello`,
+            // after all of that had already run, so a capability gap
+            // aborted with partially-consumed offer state and a
+            // lifecycle already advanced past `.idle`, instead of behaving
+            // like every other local startup preflight above (profile,
+            // policy, server-name overflow): fail closed before any of
+            // this call's state is touched at all.
+            var suites_storage: [native_cipher_suites.len]tls_algorithms.CipherSuite = undefined;
+            if (self.effectiveCipherSuites(&suites_storage).len == 0) return error.IllegalParameter;
             const base_len = try self.clientHelloEncodedLen();
             if (base_len > max_message_len) return error.InvalidTransportProfile;
             // #362: decide which offered tickets fit — and in what wire
@@ -2327,14 +2339,12 @@ pub const Tls13Backend = struct {
         // ordinary no-mutual-suite path.
         var suites_storage: [native_cipher_suites.len]tls_algorithms.CipherSuite = undefined;
         const offered_suites = self.effectiveCipherSuites(&suites_storage);
-        // #568 review: an empty intersection must fail locally, before any
-        // byte reaches the wire — otherwise this would emit a ClientHello
-        // with a zero-length `cipher_suites` vector, which is not a legal
-        // offer RFC 8446 §4.1.2 permits a peer to answer at all. Reported as
-        // the same `IllegalParameter` the server-side no-mutual-suite path
-        // (`mapNegotiationError`) surfaces, since this is exactly that
-        // failure discovered one step earlier — a local capability gap, not
-        // a distinct capability error.
+        // #568 review: `startImpl` already fails closed on an empty
+        // intersection before any lifecycle/offer-lease state is touched
+        // (see its matching comment), so this is unreachable in practice —
+        // kept as a backstop so this function can never itself encode a
+        // zero-length `cipher_suites` vector onto the wire, which is not a
+        // legal offer RFC 8446 §4.1.2 permits a peer to answer at all.
         if (offered_suites.len == 0) return error.IllegalParameter;
         try w.u16_(@intCast(2 * offered_suites.len)); // cipher_suites
         for (offered_suites) |cipher_suite| {

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -38,6 +38,7 @@ const tls_transcript = @import("transcript.zig");
 const crypto = std.crypto;
 const Certificate = crypto.Certificate;
 const Sha256 = crypto.hash.sha2.Sha256;
+const Sha384 = crypto.hash.sha2.Sha384;
 const crypto_provider_pkg = crypto_pkg.provider;
 
 /// The one key-exchange group this profile negotiates. Key-share generation
@@ -76,7 +77,21 @@ const MessageType = tls_handshake_codec.MessageType;
 const Reader = tls_handshake_codec.Reader;
 const Writer = tls_handshake_codec.Writer;
 
-pub const hash_len = tls_key_schedule.hash_len;
+/// Largest transcript/HKDF digest this engine's negotiable suites can
+/// select (SHA-384, #564) — the bound every per-connection digest buffer
+/// below is sized to; the negotiated suite's actual `provider.Hash.
+/// digestLength()` (via `negotiatedHash`/`negotiatedDigestLen`) says how
+/// much of it is meaningful for a given connection.
+const max_digest_len = crypto_provider_pkg.max_digest_len;
+/// SHA-256's digest length (`TLS_AES_128_GCM_SHA256`/
+/// `TLS_CHACHA20_POLY1305_SHA256`'s transcript/HKDF hash) — the fixed
+/// digest length QUIC's single-suite adapter (`quic/tls_backend.zig`,
+/// `quic/connection.zig`) and other callers that never negotiate anything
+/// but the SHA-256 baseline still use. Never the right constant for
+/// suite-agile record-mode code in *this* file (#564): use
+/// `negotiatedHash()`/`negotiatedDigestLen()` there instead, since a live
+/// connection's own digest length can also be SHA-384's 48 bytes.
+pub const hash_len = 32;
 /// Largest framed handshake message we accept during the main handshake.
 pub const max_message_len = 8 * 1024;
 /// Largest framed post-handshake NewSessionTicket message: a 65535-byte opaque
@@ -221,7 +236,18 @@ const ext_cookie: u16 = @intFromEnum(tls_algorithms.ExtensionType.cookie);
 pub const max_transport_extension_len = 512;
 
 const native_protocol_versions = [_]tls_algorithms.ProtocolVersion{.tls13};
-const native_cipher_suites = [_]tls_algorithms.CipherSuite{.tls_aes_128_gcm_sha256};
+/// #564: every cipher suite this engine's handshake/transcript/key-schedule
+/// logic can now negotiate natively. Whether a given product actually
+/// offers all three (versus just the SHA-256 baseline) is a product-profile
+/// decision, not this engine's — see `crypto_profile.zig`'s
+/// `enabled_product_profiles` and `TlsCapabilities.fromProfile`, which
+/// intersect this protocol-level capability with what the live
+/// `CryptoProvider` and the product's checked-in profile actually enable.
+const native_cipher_suites = [_]tls_algorithms.CipherSuite{
+    .tls_aes_128_gcm_sha256,
+    .tls_aes_256_gcm_sha384,
+    .tls_chacha20_poly1305_sha256,
+};
 const native_named_groups = [_]tls_algorithms.NamedGroup{.x25519};
 const native_signature_schemes = [_]tls_algorithms.SignatureScheme{ .ed25519, .ecdsa_secp256r1_sha256 };
 
@@ -622,7 +648,7 @@ pub const Tls13Backend = struct {
     session_ticket_consumer: ?ConfiguredSessionTicketConsumer = null,
     /// The client Finished verify_data the server expects (computed when its
     /// own flight is sent).
-    expected_client_verify: [hash_len]u8 = undefined,
+    expected_client_verify: [max_digest_len]u8 = undefined,
     /// Reassembled-but-unparsed handshake bytes per transport epoch; a message
     /// may arrive split across TLS records or QUIC CRYPTO frames.
     initial_input: tls_handshake_codec.Reassembler(max_message_len + 4) = .{},
@@ -784,7 +810,7 @@ pub const Tls13Backend = struct {
 
     const Slice = struct { start: usize, len: usize };
     const PendingStage = enum { server_select, server_sign, client_select, client_sign, peer_verify };
-    const PskSelected = struct { index: usize, psk: [hash_len]u8, early_data: EarlyDataDecision = .not_attempted };
+    const PskSelected = struct { index: usize, psk: [max_digest_len]u8, early_data: EarlyDataDecision = .not_attempted };
     pub const ResumptionDecision = enum { accepted, miss, incompatible, full_handshake, fatal };
 
     pub const ResumptionDecisionObserver = struct {
@@ -832,7 +858,7 @@ pub const Tls13Backend = struct {
         /// left `undefined` for the transient ClientHello1-retention-only
         /// capture `emitHelloRetryRequest` writes on the `.retry` path,
         /// which is always cleared before any offer capture reads it.
-        binder_transcript_hash: [hash_len]u8 = undefined,
+        binder_transcript_hash: [max_digest_len]u8 = undefined,
 
         /// Zeroizes the captured bytes in place. Exposed (`pub`) so its
         /// zeroing behavior can be proven directly, on a plain value, in
@@ -1542,6 +1568,33 @@ pub const Tls13Backend = struct {
         return @intFromEnum(self.negotiated_cipher_suite);
     }
 
+    /// The transcript/HKDF hash `self.negotiated_cipher_suite` selects
+    /// (`algorithms.transcriptHash`) — the single source of truth every
+    /// hash-agile call site in this file derives its digest length from.
+    /// Never re-derived independently, so it can never disagree with the
+    /// negotiated suite (#564).
+    fn negotiatedHash(self: *const Tls13Backend) crypto_provider_pkg.Hash {
+        return tls_algorithms.transcriptHash(self.negotiated_cipher_suite);
+    }
+
+    fn negotiatedDigestLen(self: *const Tls13Backend) usize {
+        return self.negotiatedHash().digestLength();
+    }
+
+    /// #564: confirm the injected `CryptoProvider` can actually perform the
+    /// negotiated suite's complete tuple (AEAD + transcript hash + HKDF)
+    /// before this side ever derives a secret under it. Ordinary policy
+    /// negotiation (`negotiation.zig`) already restricts both sides to
+    /// suites present in `self.policy.cipher_suites`; this is the
+    /// belt-and-braces check that the live provider backing that policy
+    /// actually agrees, so a provider/policy mismatch fails closed right at
+    /// selection instead of surfacing later as an opaque HKDF capability
+    /// error deep in the key schedule.
+    fn validateNegotiatedSuiteCapability(self: *const Tls13Backend) HandshakeError!void {
+        const caps = self.crypto_provider.capabilities();
+        if (!tls_crypto_profile.supportsCipherSuite(caps, self.negotiated_cipher_suite)) return error.SecretExportFailed;
+    }
+
     fn negotiatedGroupCode(self: *const Tls13Backend) u16 {
         return @intFromEnum(self.negotiated_named_group);
     }
@@ -1806,7 +1859,7 @@ pub const Tls13Backend = struct {
             if (containsEnum(tls_algorithms.ProtocolVersion, self.policy.protocol_versions[0..i], version)) return error.InvalidTransportProfile;
         }
         for (self.policy.cipher_suites, 0..) |cipher, i| {
-            if (cipher != .tls_aes_128_gcm_sha256) return error.InvalidTransportProfile;
+            if (!containsEnum(tls_algorithms.CipherSuite, &native_cipher_suites, cipher)) return error.InvalidTransportProfile;
             if (containsEnum(tls_algorithms.CipherSuite, self.policy.cipher_suites[0..i], cipher)) return error.InvalidTransportProfile;
         }
         for (self.policy.named_groups, 0..) |group, i| {
@@ -2043,6 +2096,12 @@ pub const Tls13Backend = struct {
             error.TooManyExtensions,
             => error.MalformedHandshake,
             error.HandshakeBufferOverflow => error.HandshakeBufferOverflow,
+            // #564: a peer whose ServerHello/HRR never lets a hash family
+            // resolve (or a stray extra message reaching the transcript
+            // before one does) is bounded by `Transcript.max_pending_len`
+            // — the same buffer-exhaustion class as any other framing
+            // overflow.
+            error.TranscriptOverflow => error.HandshakeBufferOverflow,
             error.IllegalParameter => error.IllegalParameter,
             error.UnexpectedHandshakeMessage => error.UnexpectedHandshakeMessage,
             error.MissingExtension => error.MissingExtension,
@@ -2094,7 +2153,7 @@ pub const Tls13Backend = struct {
         self: *Tls13Backend,
         message: tls_handshake_codec.Message,
         level: EncryptionLevel,
-        transcript_before: [hash_len]u8,
+        transcript_before: tls_transcript.Digest,
         is_hello_retry_request: bool,
         ch2_transcript_snapshot: ?tls_transcript.Transcript,
         sink: *EventSink,
@@ -2122,7 +2181,7 @@ pub const Tls13Backend = struct {
         switch (kind) {
             .client_hello => try self.onClientHello(message.raw, ch2_transcript_snapshot, sink),
             .server_hello => if (is_hello_retry_request)
-                try self.onHelloRetryRequest(body, sink)
+                try self.onHelloRetryRequest(message.raw, body, sink)
             else
                 try self.onServerHello(body, sink),
             .encrypted_extensions => try self.onEncryptedExtensions(body, sink),
@@ -2288,8 +2347,15 @@ pub const Tls13Backend = struct {
         // wire index aligned with `onServerHello`'s `selected_identity`.
         // RFC 8446 §4.2.11's "last extension" rule is what puts this block
         // after every other extension above and before the length patches.
-        var psk_secrets: [pre_shared_key.max_offered_identities][hash_len]u8 = undefined;
+        // #564: each offered ticket's binder hash follows *that ticket's
+        // own* negotiated suite (`ticket.common.cipher_suite`), fixed when
+        // the ticket was issued — never `self.negotiated_cipher_suite`,
+        // which is not yet chosen at ClientHello time on this (offering)
+        // side. Distinct tickets may legally carry distinct hashes, so
+        // `psk_hashes` tracks one per offered identity alongside its secret.
+        var psk_secrets: [pre_shared_key.max_offered_identities][max_digest_len]u8 = undefined;
         defer crypto.secureZero(u8, std.mem.asBytes(&psk_secrets));
+        var psk_hashes: [pre_shared_key.max_offered_identities]crypto_provider_pkg.Hash = undefined;
         var psk_count: usize = 0;
         var psk_offer_write: ?pre_shared_key.ClientOfferWrite = null;
         const active_offers = self.constClientPskOffers();
@@ -2297,11 +2363,14 @@ pub const Tls13Backend = struct {
             const now_ms = self.psk_now_fn.?(self.psk_now_ctx.?);
             var psk_items: [pre_shared_key.max_offered_identities]pre_shared_key.OfferItem = undefined;
             for (active_offers.constSlice()) |*ticket| {
-                @memcpy(&psk_secrets[psk_count], ticket.common.resumption_psk.slice());
+                const ticket_hash = tls_algorithms.transcriptHash(ticket.common.cipher_suite);
+                const psk_slice = ticket.common.resumption_psk.slice();
+                @memcpy(psk_secrets[psk_count][0..psk_slice.len], psk_slice);
+                psk_hashes[psk_count] = ticket_hash;
                 psk_items[psk_count] = .{
                     .identity = ticket.ticket.slice(),
                     .obfuscated_ticket_age = pre_shared_key.obfuscateTicketAge(ticket.ageMillis(now_ms), ticket.ticket_age_add),
-                    .digest_len = hash_len,
+                    .digest_len = ticket_hash.digestLength(),
                 };
                 psk_count += 1;
             }
@@ -2341,11 +2410,12 @@ pub const Tls13Backend = struct {
         if (psk_offer_write) |offer| {
             const prefix = buf[0..offer.truncated_len];
             for (0..psk_count) |i| {
-                var binder: [hash_len]u8 = undefined;
+                const n = psk_hashes[i].digestLength();
+                var binder: [max_digest_len]u8 = undefined;
                 defer crypto.secureZero(u8, &binder);
-                pre_shared_key.deriveBinder(.sha256, &psk_secrets[i], prefix, &binder) catch return error.SecretExportFailed;
+                pre_shared_key.deriveBinder(psk_hashes[i], psk_secrets[i][0..n], prefix, binder[0..n]) catch return error.SecretExportFailed;
                 const slot = offer.slots[i];
-                @memcpy(buf[slot.offset..][0..slot.len], &binder);
+                @memcpy(buf[slot.offset..][0..slot.len], binder[0..n]);
             }
         }
 
@@ -2357,14 +2427,21 @@ pub const Tls13Backend = struct {
         // is identity 0's PSK (the only identity 0-RTT may use), matching
         // `planEarlyDataAttempt`'s "first surviving offer only" rule.
         if (self.client_early_data_attempted) {
-            var client_hello_hash: [hash_len]u8 = undefined;
-            Sha256.hash(message, &client_hello_hash, .{});
+            // #564: identity 0's own hash, not the not-yet-negotiated
+            // suite — the server has not even seen this ClientHello yet.
+            const n0 = psk_hashes[0].digestLength();
+            var client_hello_hash: [max_digest_len]u8 = undefined;
+            switch (psk_hashes[0]) {
+                .sha256 => Sha256.hash(message, client_hello_hash[0..Sha256.digest_length], .{}),
+                .sha384 => Sha384.hash(message, client_hello_hash[0..Sha384.digest_length], .{}),
+            }
 
-            var early = KeySchedule.clientEarlyTrafficSecret(self.crypto_provider, &psk_secrets[0], client_hello_hash) catch
-                return error.SecretExportFailed;
+            var early: [max_digest_len]u8 = undefined;
             defer crypto.secureZero(u8, &early);
+            KeySchedule.clientEarlyTrafficSecret(self.crypto_provider, psk_hashes[0], psk_secrets[0][0..n0], client_hello_hash[0..n0], early[0..n0]) catch
+                return error.SecretExportFailed;
 
-            try self.emitSecret(sink, .zero_rtt, .write, &early);
+            try self.emitSecret(sink, .zero_rtt, .write, early[0..n0]);
         }
 
         // #484: retained (reusing `client_hello_psk`'s storage — see
@@ -2413,7 +2490,8 @@ pub const Tls13Backend = struct {
                         keep = false;
                     } else {
                         const entry_len = try checkedAdd(try checkedAdd(2, identity_len), 4);
-                        var candidate_total = try checkedAdd(try checkedAdd(total, entry_len), 1 + hash_len);
+                        const ticket_digest_len = tls_algorithms.transcriptHash(ticket.common.cipher_suite).digestLength();
+                        var candidate_total = try checkedAdd(try checkedAdd(total, entry_len), 1 + ticket_digest_len);
                         if (kept == 0 and self.clientEarlyDataBudget(ticket) != null)
                             candidate_total = try checkedAdd(candidate_total, 4);
                         if (candidate_total > max_message_len) {
@@ -2451,7 +2529,8 @@ pub const Tls13Backend = struct {
             if (identity_len == 0 or identity_len > std.math.maxInt(u16)) continue;
             // identity: 2 len + bytes + 4 age; binder: 1 len + digest.
             const entry_len = try checkedAdd(try checkedAdd(2, identity_len), 4);
-            var candidate_total = try checkedAdd(try checkedAdd(total, entry_len), 1 + hash_len);
+            const ticket_digest_len = tls_algorithms.transcriptHash(ticket.common.cipher_suite).digestLength();
+            var candidate_total = try checkedAdd(try checkedAdd(total, entry_len), 1 + ticket_digest_len);
             if (emitted.len == 0 and self.clientEarlyDataBudget(ticket) != null)
                 candidate_total = try checkedAdd(candidate_total, 4);
             if (candidate_total > max_message_len) break; // does not fit: stop, in offer order
@@ -2503,7 +2582,7 @@ pub const Tls13Backend = struct {
         const common = &ticket.common;
         if (common.isExpired(now_ms) or common.isNotYetValid(now_ms)) return false;
         if (!self.policy.containsCipherSuite(common.cipher_suite)) return false;
-        if (common.resumption_psk.slice().len != hash_len) return false;
+        if (common.resumption_psk.slice().len != tls_algorithms.transcriptHash(common.cipher_suite).digestLength()) return false;
         if (common.server_name) |*stored| {
             const intended = self.serverNameSlice() orelse return false;
             if (!stored.eqlIgnoreCase(intended)) return false;
@@ -2655,7 +2734,7 @@ pub const Tls13Backend = struct {
             .named_group = named_group,
             .alpn = null,
         }) catch |err| return mapNegotiationError(err);
-        if (selected_cipher != .tls_aes_128_gcm_sha256 or named_group != .x25519 or protocol_version != .tls13) return error.IllegalParameter;
+        if (named_group != .x25519 or protocol_version != .tls13) return error.IllegalParameter;
         // #484: the final ServerHello must remain consistent with what this
         // connection's HelloRetryRequest actually selected — a check on top
         // of (not a substitute for) the ordinary policy-tuple check above,
@@ -2671,6 +2750,11 @@ pub const Tls13Backend = struct {
         self.negotiated_version = protocol_version;
         self.negotiated_cipher_suite = selected_cipher;
         self.negotiated_named_group = named_group;
+        // #564: idempotent once an HRR already selected the family (checked
+        // consistent with it above); the one-and-only selection point for a
+        // connection that never retried.
+        try self.validateNegotiatedSuiteCapability();
+        self.core.transcript.selectFamily(self.negotiatedHash());
         const share = peer_share orelse return error.MalformedHandshake;
 
         // A low-order/identity peer share is a well-formed 32-byte field with an
@@ -2696,7 +2780,7 @@ pub const Tls13Backend = struct {
         // it against the negotiated context and carried its `auth_binding`
         // forward. Every other offer is wiped here, on every path (selected
         // or not, malformed or not).
-        var psk_secret: ?[hash_len]u8 = null;
+        var psk_secret: ?[max_digest_len]u8 = null;
         const active_offers = self.mutableClientPskOffers();
         // #366: retained regardless of `idx`'s value so
         // `onEncryptedExtensions` can check an accepted `early_data`
@@ -2709,10 +2793,16 @@ pub const Tls13Backend = struct {
             self.client_offer_lease = .{};
             self.selected_client_psk_present = true;
             const psk_slice = self.selected_client_psk.common.resumption_psk.slice();
-            if (psk_slice.len != hash_len) return error.IllegalParameter;
-            var buf: [hash_len]u8 = undefined;
+            // #564: a well-behaved server only ever selects an identity
+            // whose own suite matches the one it just negotiated (this
+            // engine's own `selectPsk`/`session.evaluateCompatibility`
+            // enforce exactly that on the server side); defensively check
+            // it here too rather than deriving a schedule from a
+            // wrong-length secret.
+            if (psk_slice.len != self.negotiatedDigestLen()) return error.IllegalParameter;
+            var buf: [max_digest_len]u8 = undefined;
             defer crypto.secureZero(u8, &buf);
-            @memcpy(&buf, psk_slice);
+            @memcpy(buf[0..psk_slice.len], psk_slice);
             psk_secret = buf;
         } else {
             if (self.client_offer_lease.active) {
@@ -2737,11 +2827,12 @@ pub const Tls13Backend = struct {
             // ticket's PSK — so the client may treat the peer as
             // equivalently authenticated without a fresh Certificate flight.
             try sink.emitCertificate(.valid);
-            self.schedule = KeySchedule.initWithPsk(self.crypto_provider, psk, &shared, self.core.transcriptHash()) catch
+            const n = self.negotiatedDigestLen();
+            self.schedule = KeySchedule.initWithPsk(self.crypto_provider, self.negotiatedHash(), psk[0..n], &shared, self.core.transcriptHash().slice()) catch
                 return error.SecretExportFailed;
             crypto.secureZero(u8, psk);
         } else {
-            self.schedule = KeySchedule.init(self.crypto_provider, &shared, self.core.transcriptHash()) catch
+            self.schedule = KeySchedule.init(self.crypto_provider, self.negotiatedHash(), &shared, self.core.transcriptHash().slice()) catch
                 return error.SecretExportFailed;
         }
         try self.emitHandshakeSecrets(sink);
@@ -2756,7 +2847,7 @@ pub const Tls13Backend = struct {
     /// Builds and emits ClientHello2 from the retained ClientHello1; never
     /// derives, installs, or discards a traffic secret — Initial stays live
     /// through both messages.
-    fn onHelloRetryRequest(self: *Tls13Backend, body: []const u8, sink: *EventSink) HandshakeError!void {
+    fn onHelloRetryRequest(self: *Tls13Backend, hrr_raw: []const u8, body: []const u8, sink: *EventSink) HandshakeError!void {
         // #484: reuses `client_hello_psk`'s storage — see `RetryContext`'s
         // doc comment; this field is otherwise never touched by the client
         // role, so it can only ever hold `sendClientHello`'s retry capture.
@@ -2784,6 +2875,16 @@ pub const Tls13Backend = struct {
             .cipher_suite = request.cipher_suite,
             .selected_group = request.selected_group,
         };
+        // #564: commit the suite the moment it is known from the HRR body,
+        // before anything below reads the live transcript (the PSK binder
+        // rebind further down, and `recordSecondClientHello`'s own hashing
+        // of ClientHello2). `Core.acceptHelloRetryRequest` already rebound/
+        // buffered ClientHello1 and this HRR under an unresolved family;
+        // `selectFamily` replays exactly those bytes now that the family is
+        // known, losing nothing.
+        self.negotiated_cipher_suite = request.cipher_suite;
+        try self.validateNegotiatedSuiteCapability();
+        self.core.transcript.selectFamily(self.negotiatedHash());
 
         var buf: [max_message_len]u8 = undefined;
         defer crypto.secureZero(u8, &buf);
@@ -2901,8 +3002,11 @@ pub const Tls13Backend = struct {
         // `error.HandshakeBufferOverflow` (propagated to the caller, which
         // wipes all retained PSK state via `clearFailedHandshakeState`)
         // rather than silently narrowing the offer.
-        var psk_secrets: [pre_shared_key.max_offered_identities][hash_len]u8 = undefined;
+        // #564: same per-ticket-hash reasoning as `sendClientHello`'s
+        // ClientHello1 offer — see its comment on `psk_hashes`.
+        var psk_secrets: [pre_shared_key.max_offered_identities][max_digest_len]u8 = undefined;
         defer crypto.secureZero(u8, std.mem.asBytes(&psk_secrets));
+        var psk_hashes: [pre_shared_key.max_offered_identities]crypto_provider_pkg.Hash = undefined;
         var psk_count: usize = 0;
         var psk_offer_write: ?pre_shared_key.ClientOfferWrite = null;
         const active_offers = self.constClientPskOffers();
@@ -2910,11 +3014,14 @@ pub const Tls13Backend = struct {
             const now_ms = self.psk_now_fn.?(self.psk_now_ctx.?);
             var psk_items: [pre_shared_key.max_offered_identities]pre_shared_key.OfferItem = undefined;
             for (active_offers.constSlice()) |*ticket| {
-                @memcpy(&psk_secrets[psk_count], ticket.common.resumption_psk.slice());
+                const ticket_hash = tls_algorithms.transcriptHash(ticket.common.cipher_suite);
+                const psk_slice = ticket.common.resumption_psk.slice();
+                @memcpy(psk_secrets[psk_count][0..psk_slice.len], psk_slice);
+                psk_hashes[psk_count] = ticket_hash;
                 psk_items[psk_count] = .{
                     .identity = ticket.ticket.slice(),
                     .obfuscated_ticket_age = pre_shared_key.obfuscateTicketAge(ticket.ageMillis(now_ms), ticket.ticket_age_add),
-                    .digest_len = hash_len,
+                    .digest_len = ticket_hash.digestLength(),
                 };
                 psk_count += 1;
             }
@@ -2955,16 +3062,44 @@ pub const Tls13Backend = struct {
         // the live transcript (already exactly `message_hash(Hash(CH1)) ||
         // HRR` at this point, since ClientHello2 itself has not been
         // recorded yet) without mutating it.
+        //
+        // #564: `peekWith` reads the live transcript, which is hashed under
+        // this connection's *negotiated* suite — correct for any ticket
+        // whose own hash matches it. A ticket offered under a different
+        // hash (a rarer case: distinct past connections can issue tickets
+        // under distinct suites) needs the same `message_hash(Hash(CH1)) ||
+        // HRR` prefix rehashed under *its* hash instead; a fresh throwaway
+        // `Transcript` reproduces exactly that from the still-retained raw
+        // ClientHello1/HRR bytes. Either way the resulting binder is
+        // correct wire framing; a ticket whose hash cannot match the
+        // negotiated suite can never actually be selected regardless
+        // (`session.evaluateCompatibility`'s `cipher_suite_mismatch` gate),
+        // so getting its binder's cryptographic content exactly right
+        // matters only for not corrupting the wire message, not for
+        // security.
         if (psk_offer_write) |offer| {
             const prefix = buf[0..offer.truncated_len];
-            const rebound_transcript_hash = self.core.transcript.peekWith(prefix);
+            const negotiated_hash = self.negotiatedHash();
+            const negotiated_rebound = self.core.transcript.peekWith(prefix);
             for (0..psk_count) |i| {
-                var binder: [hash_len]u8 = undefined;
+                const n = psk_hashes[i].digestLength();
+                var binder: [max_digest_len]u8 = undefined;
                 defer crypto.secureZero(u8, &binder);
-                pre_shared_key.deriveBinderFromTranscriptHash(.sha256, &psk_secrets[i], &rebound_transcript_hash, &binder) catch
-                    return error.SecretExportFailed;
+                if (psk_hashes[i] == negotiated_hash) {
+                    pre_shared_key.deriveBinderFromTranscriptHash(psk_hashes[i], psk_secrets[i][0..n], negotiated_rebound.slice(), binder[0..n]) catch
+                        return error.SecretExportFailed;
+                } else {
+                    var rehash = tls_transcript.Transcript{};
+                    rehash.selectFamily(psk_hashes[i]);
+                    rehash.update(ch1) catch return error.SecretExportFailed;
+                    rehash.rebindClientHello();
+                    rehash.update(hrr_raw) catch return error.SecretExportFailed;
+                    const rebound = rehash.peekWith(prefix);
+                    pre_shared_key.deriveBinderFromTranscriptHash(psk_hashes[i], psk_secrets[i][0..n], rebound.slice(), binder[0..n]) catch
+                        return error.SecretExportFailed;
+                }
                 const slot = offer.slots[i];
-                @memcpy(buf[slot.offset..][0..slot.len], &binder);
+                @memcpy(buf[slot.offset..][0..slot.len], binder[0..n]);
             }
         }
 
@@ -3225,7 +3360,7 @@ pub const Tls13Backend = struct {
         return if (self.server_name_present) self.server_name[0..self.server_name_len] else null;
     }
 
-    fn onCertificateVerify(self: *Tls13Backend, transcript_before: [hash_len]u8, body: []const u8, sink: *EventSink) HandshakeError!void {
+    fn onCertificateVerify(self: *Tls13Backend, transcript_before: tls_transcript.Digest, body: []const u8, sink: *EventSink) HandshakeError!void {
         var r = Reader{ .bytes = body };
         const algorithm = try r.u16_();
         const signature = try r.slice(try r.u16_());
@@ -3400,20 +3535,22 @@ pub const Tls13Backend = struct {
         return .valid;
     }
 
-    fn onServerFinished(self: *Tls13Backend, transcript_before: [hash_len]u8, body: []const u8, sink: *EventSink) HandshakeError!void {
+    fn onServerFinished(self: *Tls13Backend, transcript_before: tls_transcript.Digest, body: []const u8, sink: *EventSink) HandshakeError!void {
         const schedule = &self.schedule.?;
-        if (body.len != hash_len) return error.MalformedHandshake;
-        var expected = KeySchedule.verifyData(schedule.provider, &schedule.server_handshake_traffic, transcript_before) catch return error.SecretExportFailed;
-        defer crypto.secureZero(u8, &expected);
-        if (!crypto_pkg.provider.constantTimeEqual(&expected, body[0..hash_len])) return error.DecryptError;
+        const n = schedule.digestLen();
+        if (body.len != n) return error.MalformedHandshake;
+        var expected: [max_digest_len]u8 = undefined;
+        KeySchedule.verifyData(schedule.provider, schedule.hash, schedule.server_handshake_traffic[0..n], transcript_before.slice(), expected[0..n]) catch return error.SecretExportFailed;
+        defer crypto.secureZero(u8, expected[0..n]);
+        if (!crypto_pkg.provider.constantTimeEqual(expected[0..n], body[0..n])) return error.DecryptError;
 
         // 1-RTT secrets exist from the transcript through server Finished,
         // independent of any client certificate flight that follows.
         const finished_hash = self.core.transcriptHash();
-        var app = schedule.applicationSecrets(finished_hash) catch return error.SecretExportFailed;
+        var app = schedule.applicationSecrets(finished_hash.slice()) catch return error.SecretExportFailed;
         defer app.wipe();
-        try self.emitSecret(sink, .application, .write, &app.client);
-        try self.emitSecret(sink, .application, .read, &app.server);
+        try self.emitSecret(sink, .application, .write, app.clientSecret());
+        try self.emitSecret(sink, .application, .read, app.serverSecret());
 
         // When the server requested handshake-time client authentication
         // (#334) the client answers with Certificate, an optional
@@ -3430,8 +3567,9 @@ pub const Tls13Backend = struct {
 
     /// Emit a lone client Finished (no client authentication) covering the
     /// transcript through the server Finished.
-    fn sendClientFinished(self: *Tls13Backend, transcript_hash: [hash_len]u8, sink: *EventSink) HandshakeError!void {
+    fn sendClientFinished(self: *Tls13Backend, transcript_hash: tls_transcript.Digest, sink: *EventSink) HandshakeError!void {
         const schedule = &self.schedule.?;
+        const n = schedule.digestLen();
         var finished_transcript_hash = transcript_hash;
         if (self.profile == .record and self.early_data_accepted) {
             var ebuf: [handshake_header_len]u8 = undefined;
@@ -3445,13 +3583,14 @@ pub const Tls13Backend = struct {
             try self.emitDiscardKeys(sink, .zero_rtt);
             finished_transcript_hash = self.core.transcriptHash();
         }
-        var buf: [4 + hash_len]u8 = undefined;
+        var buf: [4 + max_digest_len]u8 = undefined;
         var w = Writer{ .buf = &buf };
         try w.u8_(@intFromEnum(MessageType.finished));
         const message_len = try w.reserve(3);
-        var client_verify = KeySchedule.verifyData(schedule.provider, &schedule.client_handshake_traffic, finished_transcript_hash) catch return error.SecretExportFailed;
-        defer crypto.secureZero(u8, &client_verify);
-        try w.bytes(&client_verify);
+        var client_verify: [max_digest_len]u8 = undefined;
+        KeySchedule.verifyData(schedule.provider, schedule.hash, schedule.client_handshake_traffic[0..n], finished_transcript_hash.slice(), client_verify[0..n]) catch return error.SecretExportFailed;
+        defer crypto.secureZero(u8, client_verify[0..n]);
+        try w.bytes(client_verify[0..n]);
         w.patch(3, message_len);
         const message = buf[0..w.len];
         self.core.recordSent(message) catch |err| return mapCoreError(err);
@@ -3610,9 +3749,11 @@ pub const Tls13Backend = struct {
         const finished_start = w.len;
         try w.u8_(@intFromEnum(MessageType.finished));
         const finished_len = try w.reserve(3);
-        var client_verify = KeySchedule.verifyData(schedule.provider, &schedule.client_handshake_traffic, self.core.transcriptHash()) catch return error.SecretExportFailed;
-        defer crypto.secureZero(u8, &client_verify);
-        try w.bytes(&client_verify);
+        const n = schedule.digestLen();
+        var client_verify: [max_digest_len]u8 = undefined;
+        KeySchedule.verifyData(schedule.provider, schedule.hash, schedule.client_handshake_traffic[0..n], self.core.transcriptHash().slice(), client_verify[0..n]) catch return error.SecretExportFailed;
+        defer crypto.secureZero(u8, client_verify[0..n]);
+        try w.bytes(client_verify[0..n]);
         w.patch(3, finished_len);
         self.core.recordSent(buf[finished_start..w.len]) catch |err| return mapCoreError(err);
         // Emit CertificateVerify (when present) and Finished together; the
@@ -3702,6 +3843,21 @@ pub const Tls13Backend = struct {
             self.retry.wipe();
         }
         const hello_selection = tls_negotiation.negotiateServerHello(self.policy, &offers) catch |err| return mapNegotiationError(err);
+        if (hello_selection.version != .tls13 or hello_selection.named_group != .x25519) return error.IllegalParameter;
+        // #564: commit the negotiated suite — and select the transcript's
+        // hash family accordingly — as soon as it is known, before any
+        // possible HelloRetryRequest: `Core.acceptReceived` has already fed
+        // this ClientHello's raw bytes to the transcript with the family
+        // still unresolved (buffered), and `emitHelloRetryRequest` below
+        // would otherwise rebind/hash the HRR itself under an unresolved
+        // family. Re-negotiating ClientHello2 after a retry reaches this
+        // same point and re-selects the identical suite; `selectFamily` is
+        // a no-op once already selected.
+        self.negotiated_version = hello_selection.version;
+        self.negotiated_cipher_suite = hello_selection.cipher_suite;
+        self.negotiated_named_group = hello_selection.named_group;
+        try self.validateNegotiatedSuiteCapability();
+        self.core.transcript.selectFamily(self.negotiatedHash());
         if (observer.psk_ext != null and !observer.psk_modes_seen) return error.MissingExtension;
         // #366: early_data without an accompanying PSK offer is malformed —
         // 0-RTT is only meaningful alongside a resumption attempt.
@@ -3742,13 +3898,6 @@ pub const Tls13Backend = struct {
         };
         if (selected_key_share.len != key_share_public_len) return error.MalformedHandshake;
         const client_share = selected_key_share[0..key_share_public_len].*;
-        if (hello_selection.cipher_suite != .tls_aes_128_gcm_sha256 or
-            hello_selection.named_group != .x25519 or
-            hello_selection.version != .tls13)
-            return error.IllegalParameter;
-        self.negotiated_version = hello_selection.version;
-        self.negotiated_cipher_suite = hello_selection.cipher_suite;
-        self.negotiated_named_group = hello_selection.named_group;
 
         if (hello_selection.alpn) |protocol| {
             self.setSelectedAlpn(protocol.bytes);
@@ -3796,9 +3945,14 @@ pub const Tls13Backend = struct {
                 // transcript `message_hash(Hash(CH1)) || HRR ||
                 // Truncate(CH2)` — never `Hash(Truncate(CH2))` alone.
                 const snapshot = ch2_transcript_snapshot orelse return error.InvalidHandshakeState;
-                capture.binder_transcript_hash = snapshot.peekWith(truncated_prefix);
+                capture.binder_transcript_hash = snapshot.peekWith(truncated_prefix).bytes;
             } else {
-                Sha256.hash(truncated_prefix, &capture.binder_transcript_hash, .{});
+                // #564: the negotiated suite's hash — committed above,
+                // before this ClientHello's PSK offer is ever captured.
+                switch (self.negotiatedHash()) {
+                    .sha256 => Sha256.hash(truncated_prefix, capture.binder_transcript_hash[0..Sha256.digest_length], .{}),
+                    .sha384 => Sha384.hash(truncated_prefix, capture.binder_transcript_hash[0..Sha384.digest_length], .{}),
+                }
             }
 
             self.client_hello_psk = capture;
@@ -4008,10 +4162,11 @@ pub const Tls13Backend = struct {
         if (self.selectedAlpn()) |protocol| try sink.emitAlpn(protocol);
 
         if (psk_selected) |*sel| {
-            self.schedule = KeySchedule.initWithPsk(self.crypto_provider, &sel.psk, &shared, self.core.transcriptHash()) catch
+            const n = self.negotiatedDigestLen();
+            self.schedule = KeySchedule.initWithPsk(self.crypto_provider, self.negotiatedHash(), sel.psk[0..n], &shared, self.core.transcriptHash().slice()) catch
                 return error.SecretExportFailed;
         } else {
-            self.schedule = KeySchedule.init(self.crypto_provider, &shared, self.core.transcriptHash()) catch
+            self.schedule = KeySchedule.init(self.crypto_provider, self.negotiatedHash(), &shared, self.core.transcriptHash().slice()) catch
                 return error.SecretExportFailed;
         }
         try self.emitHandshakeSecrets(sink);
@@ -4096,18 +4251,25 @@ pub const Tls13Backend = struct {
                 continue;
             }
 
+            // #564: `evaluateCompatibility` above already enforced
+            // `hit.state.common.cipher_suite == self.negotiated_cipher_suite`
+            // (its `cipher_suite_mismatch` eligibility check) for any
+            // candidate reaching this point, so the negotiated suite's own
+            // hash is provably this candidate's PSK hash too — never a
+            // guess independent of that check.
+            const n = self.negotiatedDigestLen();
             const psk_slice = hit.state.common.resumption_psk.slice();
-            if (psk_slice.len != hash_len) return error.InvalidHandshakeState;
-            var psk_buf: [hash_len]u8 = undefined;
+            if (psk_slice.len != n) return error.InvalidHandshakeState;
+            var psk_buf: [max_digest_len]u8 = undefined;
             defer crypto.secureZero(u8, &psk_buf);
-            @memcpy(&psk_buf, psk_slice);
+            @memcpy(psk_buf[0..n], psk_slice);
 
             // #485: verify against the digest captured at parse time
             // (`Hash(Truncate(CH1))`, or after a HelloRetryRequest
             // `Hash(message_hash(Hash(CH1)) || HRR || Truncate(CH2))`) —
             // never re-hash the truncated message in isolation, which would
             // silently accept a pre-#485-shaped binder after a retry.
-            const ok = pre_shared_key.verifyBinderFromTranscriptHash(.sha256, &psk_buf, &capture.binder_transcript_hash, pair.binder) catch
+            const ok = pre_shared_key.verifyBinderFromTranscriptHash(self.negotiatedHash(), psk_buf[0..n], capture.binder_transcript_hash[0..n], pair.binder) catch
                 return error.InvalidHandshakeState;
             if (!ok) {
                 self.resumption_decision_observer.notify(.fatal);
@@ -4129,7 +4291,11 @@ pub const Tls13Backend = struct {
             // first-flight data) and only after binder verification, so an
             // early-data rejection never rejects an otherwise-valid PSK
             // resumption.
-            var identity_fingerprint: [hash_len]u8 = undefined;
+            // Always SHA-256 regardless of the negotiated suite: an
+            // internal replay-cache key over the opaque ticket identity
+            // bytes, never a TLS wire value — see
+            // `EarlyDataReplayCandidate.ticket_identity_fingerprint`.
+            var identity_fingerprint: [32]u8 = undefined;
             Sha256.hash(pair.identity.identity, &identity_fingerprint, .{});
             // #368 Slice 2: the replay store's retention window, derived
             // here (not re-derived from `obfuscated_ticket_age` by the
@@ -4173,16 +4339,20 @@ pub const Tls13Backend = struct {
             else
                 0;
             if (early_decision == .accepted) {
-                var client_hello_hash: [hash_len]u8 = undefined;
-                Sha256.hash(capture.message[0..capture.message_len], &client_hello_hash, .{});
+                var client_hello_hash: [max_digest_len]u8 = undefined;
+                switch (self.negotiatedHash()) {
+                    .sha256 => Sha256.hash(capture.message[0..capture.message_len], client_hello_hash[0..Sha256.digest_length], .{}),
+                    .sha384 => Sha384.hash(capture.message[0..capture.message_len], client_hello_hash[0..Sha384.digest_length], .{}),
+                }
 
-                var early = KeySchedule.clientEarlyTrafficSecret(self.crypto_provider, &psk_buf, client_hello_hash) catch
-                    return error.SecretExportFailed;
+                var early: [max_digest_len]u8 = undefined;
                 defer crypto.secureZero(u8, &early);
+                KeySchedule.clientEarlyTrafficSecret(self.crypto_provider, self.negotiatedHash(), psk_buf[0..n], client_hello_hash[0..n], early[0..n]) catch
+                    return error.SecretExportFailed;
 
                 // The server never emits a 0-RTT *write* key; server
                 // responses always use 1-RTT keys.
-                try self.emitSecret(sink, .zero_rtt, .read, &early);
+                try self.emitSecret(sink, .zero_rtt, .read, early[0..n]);
             }
 
             if (hit.on_selected) |hook| hook.complete();
@@ -4317,23 +4487,25 @@ pub const Tls13Backend = struct {
         try sink.emitCrypto(.handshake, buf[0..w.len]);
 
         const schedule = &self.schedule.?;
-        var fbuf: [handshake_header_len + hash_len]u8 = undefined;
+        const n = schedule.digestLen();
+        var fbuf: [handshake_header_len + max_digest_len]u8 = undefined;
         var fw = Writer{ .buf = &fbuf };
         try fw.u8_(@intFromEnum(MessageType.finished));
         const finished_len = try fw.reserve(3);
-        var server_verify = KeySchedule.verifyData(schedule.provider, &schedule.server_handshake_traffic, self.core.transcriptHash()) catch return error.SecretExportFailed;
-        defer crypto.secureZero(u8, &server_verify);
-        try fw.bytes(&server_verify);
+        var server_verify: [max_digest_len]u8 = undefined;
+        KeySchedule.verifyData(schedule.provider, schedule.hash, schedule.server_handshake_traffic[0..n], self.core.transcriptHash().slice(), server_verify[0..n]) catch return error.SecretExportFailed;
+        defer crypto.secureZero(u8, server_verify[0..n]);
+        try fw.bytes(server_verify[0..n]);
         fw.patch(3, finished_len);
         const finished = fbuf[0..fw.len];
         self.core.recordSent(finished) catch |err| return mapCoreError(err);
         try sink.emitCrypto(.handshake, finished);
 
         const finished_hash = self.core.transcriptHash();
-        var app = schedule.applicationSecrets(finished_hash) catch return error.SecretExportFailed;
+        var app = schedule.applicationSecrets(finished_hash.slice()) catch return error.SecretExportFailed;
         defer app.wipe();
-        try self.emitSecret(sink, .application, .read, &app.client);
-        try self.emitSecret(sink, .application, .write, &app.server);
+        try self.emitSecret(sink, .application, .read, app.clientSecret());
+        try self.emitSecret(sink, .application, .write, app.serverSecret());
     }
 
     /// Validate the selected credential, emit EncryptedExtensions+Certificate,
@@ -4486,9 +4658,11 @@ pub const Tls13Backend = struct {
         const finished_start = w.len;
         try w.u8_(@intFromEnum(MessageType.finished));
         const finished_len = try w.reserve(3);
-        var server_verify = KeySchedule.verifyData(schedule.provider, &schedule.server_handshake_traffic, self.core.transcriptHash()) catch return error.SecretExportFailed;
-        defer crypto.secureZero(u8, &server_verify);
-        try w.bytes(&server_verify);
+        const n = schedule.digestLen();
+        var server_verify: [max_digest_len]u8 = undefined;
+        KeySchedule.verifyData(schedule.provider, schedule.hash, schedule.server_handshake_traffic[0..n], self.core.transcriptHash().slice(), server_verify[0..n]) catch return error.SecretExportFailed;
+        defer crypto.secureZero(u8, server_verify[0..n]);
+        try w.bytes(server_verify[0..n]);
         w.patch(3, finished_len);
         const finished = buf[finished_start..w.len];
         self.core.recordSent(finished) catch |err| return mapCoreError(err);
@@ -4499,10 +4673,10 @@ pub const Tls13Backend = struct {
         // 1-RTT secrets from the transcript through server Finished; the
         // client Finished we will require is fixed by the same hash.
         const finished_hash = self.core.transcriptHash();
-        var app = schedule.applicationSecrets(finished_hash) catch return error.SecretExportFailed;
+        var app = schedule.applicationSecrets(finished_hash.slice()) catch return error.SecretExportFailed;
         defer app.wipe();
-        try self.emitSecret(sink, .application, .read, &app.client);
-        try self.emitSecret(sink, .application, .write, &app.server);
+        try self.emitSecret(sink, .application, .read, app.clientSecret());
+        try self.emitSecret(sink, .application, .write, app.serverSecret());
         // The client Finished MAC is (re)computed when the client Finished
         // arrives, over the transcript actually preceding it — which, under
         // handshake-time client authentication, includes the client's own
@@ -4707,18 +4881,20 @@ pub const Tls13Backend = struct {
         }
     }
 
-    fn onClientFinished(self: *Tls13Backend, transcript_before: [hash_len]u8, body: []const u8, sink: *EventSink) HandshakeError!void {
+    fn onClientFinished(self: *Tls13Backend, transcript_before: tls_transcript.Digest, body: []const u8, sink: *EventSink) HandshakeError!void {
         const schedule = &self.schedule.?;
+        const n = schedule.digestLen();
         if (self.profile == .record and self.early_data_accepted and !self.core.end_of_early_data_seen)
             return error.UnexpectedHandshakeMessage;
-        if (body.len != hash_len) return error.MalformedHandshake;
+        if (body.len != n) return error.MalformedHandshake;
         // Recompute over the transcript that actually precedes this Finished:
         // with handshake-time client authentication it includes the client's
         // Certificate and CertificateVerify, so the MAC cannot be fixed when the
         // server flight was sent.
-        var expected = KeySchedule.verifyData(schedule.provider, &schedule.client_handshake_traffic, transcript_before) catch return error.SecretExportFailed;
-        defer crypto.secureZero(u8, &expected);
-        if (!crypto_pkg.provider.constantTimeEqual(&expected, body[0..hash_len])) return error.DecryptError;
+        var expected: [max_digest_len]u8 = undefined;
+        KeySchedule.verifyData(schedule.provider, schedule.hash, schedule.client_handshake_traffic[0..n], transcript_before.slice(), expected[0..n]) catch return error.SecretExportFailed;
+        defer crypto.secureZero(u8, expected[0..n]);
+        if (!crypto_pkg.provider.constantTimeEqual(expected[0..n], body[0..n])) return error.DecryptError;
         // Client Finished confirms the handshake for the server (RFC 8446 §4.4.4).
         try self.captureResumptionMasterSecret();
         try self.emitDiscardKeys(sink, .handshake);
@@ -4735,14 +4911,26 @@ pub const Tls13Backend = struct {
 
     fn emitHandshakeSecrets(self: *Tls13Backend, sink: *EventSink) HandshakeError!void {
         const schedule = &self.schedule.?;
+        const n = schedule.digestLen();
+        // #564: the one canonical point both roles' full and resumed
+        // handshakes alike reach right after constructing `self.schedule`
+        // and before either handshake traffic secret below — satisfying
+        // `EventSink.emitNegotiatedParameters`'s ordering contract.
+        try sink.emitNegotiatedParameters(.{
+            .cipher_suite = self.negotiatedCipherCode(),
+            .transcript_hash = switch (self.negotiated_cipher_suite) {
+                .tls_aes_128_gcm_sha256, .tls_chacha20_poly1305_sha256 => .sha256,
+                .tls_aes_256_gcm_sha384 => .sha384,
+            },
+        });
         switch (self.role) {
             .client => {
-                try self.emitSecret(sink, .handshake, .write, &schedule.client_handshake_traffic);
-                try self.emitSecret(sink, .handshake, .read, &schedule.server_handshake_traffic);
+                try self.emitSecret(sink, .handshake, .write, schedule.client_handshake_traffic[0..n]);
+                try self.emitSecret(sink, .handshake, .read, schedule.server_handshake_traffic[0..n]);
             },
             .server => {
-                try self.emitSecret(sink, .handshake, .read, &schedule.client_handshake_traffic);
-                try self.emitSecret(sink, .handshake, .write, &schedule.server_handshake_traffic);
+                try self.emitSecret(sink, .handshake, .read, schedule.client_handshake_traffic[0..n]);
+                try self.emitSecret(sink, .handshake, .write, schedule.server_handshake_traffic[0..n]);
             },
         }
     }
@@ -4777,10 +4965,11 @@ pub const Tls13Backend = struct {
     fn captureResumptionMasterSecret(self: *Tls13Backend) HandshakeError!void {
         if (self.resumption_master_secret.slice().len != 0) return error.InvalidHandshakeState;
         const schedule = &(self.schedule orelse return error.InvalidHandshakeState);
-        var rms: [hash_len]u8 = undefined;
-        defer crypto.secureZero(u8, &rms);
-        schedule.resumptionMasterSecret(&self.core.transcriptHash(), &rms) catch return error.SecretExportFailed;
-        self.resumption_master_secret.replace(&rms) catch return error.SecretExportFailed;
+        const n = schedule.digestLen();
+        var rms: [max_digest_len]u8 = undefined;
+        defer crypto.secureZero(u8, rms[0..n]);
+        schedule.resumptionMasterSecret(self.core.transcriptHash().slice(), rms[0..n]) catch return error.SecretExportFailed;
+        self.resumption_master_secret.replace(rms[0..n]) catch return error.SecretExportFailed;
     }
 
     fn resumptionContext(self: *const Tls13Backend) new_session_ticket.ConnectionResumptionContext {
@@ -5047,7 +5236,7 @@ pub const Tls13Backend = struct {
         w.patch(3, body_len_index);
         const message = buf[0..w.len];
         try sink.emitOwnedCrypto(allocator, .application, message);
-        self.core.transcript.update(message);
+        self.core.transcript.update(message) catch return error.HandshakeBufferOverflow;
     }
 
     /// Single-phase issuance, retained for callers (and tests) that already
@@ -5274,7 +5463,7 @@ fn mapTicketBuildClientError(err: new_session_ticket.BuildError) HandshakeError!
 /// RFC 8446 §4.4.3 CertificateVerify content: 64 spaces, context string,
 /// separator, transcript hash.
 const CertificateVerifyContent = struct {
-    buf: [64 + 64 + 1 + hash_len]u8,
+    buf: [64 + 64 + 1 + max_digest_len]u8,
     len: usize,
 
     fn slice(self: *const CertificateVerifyContent) []const u8 {
@@ -5282,7 +5471,7 @@ const CertificateVerifyContent = struct {
     }
 };
 
-fn certificateVerifyContent(signer: Role, transcript_hash: [hash_len]u8) CertificateVerifyContent {
+fn certificateVerifyContent(signer: Role, transcript_hash: tls_transcript.Digest) CertificateVerifyContent {
     const context = switch (signer) {
         .server => "TLS 1.3, server CertificateVerify",
         .client => "TLS 1.3, client CertificateVerify",
@@ -5295,8 +5484,8 @@ fn certificateVerifyContent(signer: Role, transcript_hash: [hash_len]u8) Certifi
     len += context.len;
     content.buf[len] = 0x00;
     len += 1;
-    @memcpy(content.buf[len..][0..hash_len], &transcript_hash);
-    len += hash_len;
+    @memcpy(content.buf[len..][0..transcript_hash.len], transcript_hash.slice());
+    len += transcript_hash.len;
     content.len = len;
     return content;
 }
@@ -5377,7 +5566,14 @@ const TestProviderStorage = struct {
 const test_crypto_provider_seed: u64 = 0x71357_490;
 
 test "TLS-owned backend does not embed maximum ticket storage" {
-    try std.testing.expect(@sizeOf(Tls13Backend) < 64 * 1024);
+    // #564: the budget grew from 64 KiB to accommodate exactly one framed
+    // handshake message's worth of transcript pre-selection buffering
+    // (`transcript.max_pending_len`) — see that constant's doc comment for
+    // why a client cannot hash its own ClientHello until the negotiated
+    // suite (learned only from the server's response) is known. This is
+    // still nowhere near `max_new_session_ticket_message_len`, checked
+    // below, so ticket storage itself remains unaffected.
+    try std.testing.expect(@sizeOf(Tls13Backend) < 96 * 1024);
     try std.testing.expect(@sizeOf(Tls13Backend) + EventSink.max_bytes < max_new_session_ticket_message_len);
 }
 
@@ -5389,7 +5585,7 @@ test "TLS-owned backend teardown clears transcript-adjacent and peer scratch" {
         .{ .pinned_certificate = testdata.certificate_der },
         .record,
     );
-    backend.core.transcript.update("transcript-adjacent state");
+    try backend.core.transcript.update("transcript-adjacent state");
     @memset(&backend.expected_client_verify, 0xa5);
     @memset(&backend.peer_chain, 0x5a);
     backend.peer_chain_entries[0] = .{ .start = 0, .len = 32 };
@@ -5598,6 +5794,7 @@ test "client NewSessionTicket callback receives owned state and lifetime zero is
         .onTicketFn = TicketCapture.onTicket,
     });
     backend.core.handshake_lifecycle = .complete;
+    backend.core.transcript.selectFamily(.sha256);
     try backend.resumption_master_secret.replace(&([_]u8{0x42} ** hash_len));
 
     var body_buf: [128]u8 = undefined;
@@ -5635,6 +5832,7 @@ test "client parses and drops NewSessionTicket when no consumer is configured" {
     defer backend.deinit();
     try backend.setPostHandshakeAllocator(std.testing.allocator);
     backend.core.handshake_lifecycle = .complete;
+    backend.core.transcript.selectFamily(.sha256);
 
     var body_buf: [128]u8 = undefined;
     const body = try new_session_ticket.encode(.{
@@ -5702,6 +5900,7 @@ test "server explicitly emits NewSessionTicket and returns recoverable state" {
     }, session.Limits.default));
 
     server.core.handshake_lifecycle = .complete;
+    server.core.transcript.selectFamily(.sha256);
     try server.resumption_master_secret.replace(&([_]u8{0x33} ** hash_len));
     var state = try server.emitNewSessionTicket(std.testing.allocator, &sink, .{
         .ticket_lifetime = 60,
@@ -5736,6 +5935,7 @@ test "prepare/emit two-phase ticket issuance matches single-phase wire output" {
     );
     defer server.deinit();
     server.core.handshake_lifecycle = .complete;
+    server.core.transcript.selectFamily(.sha256);
     try server.resumption_master_secret.replace(&([_]u8{0x33} ** hash_len));
 
     var sink = EventSink{};
@@ -5773,6 +5973,7 @@ test "emitPreparedNewSessionTicket rejects an empty or oversized identity" {
     );
     defer server.deinit();
     server.core.handshake_lifecycle = .complete;
+    server.core.transcript.selectFamily(.sha256);
     try server.resumption_master_secret.replace(&([_]u8{0x33} ** hash_len));
 
     var sink = EventSink{};
@@ -5802,6 +6003,7 @@ test "server ticket output failure is atomic and retryable" {
     );
     defer server.deinit();
     server.core.handshake_lifecycle = .complete;
+    server.core.transcript.selectFamily(.sha256);
     try server.resumption_master_secret.replace(&([_]u8{0x33} ** hash_len));
 
     var full_sink = EventSink{};
@@ -5815,7 +6017,7 @@ test "server ticket output failure is atomic and retryable" {
         .opaque_ticket = "ticket",
         .issued_at_unix_ms = 10,
     }, session.Limits.default));
-    try std.testing.expectEqualSlices(u8, &before, &server.core.transcriptHash());
+    try std.testing.expectEqualSlices(u8, before.slice(), server.core.transcriptHash().slice());
 
     full_sink.reset();
     var state = try server.emitNewSessionTicket(std.testing.allocator, &full_sink, .{
@@ -5843,6 +6045,7 @@ test "server ticket emission allocation failures leave transcript and sink clean
             .record,
         );
         server.core.handshake_lifecycle = .complete;
+        server.core.transcript.selectFamily(.sha256);
         try server.resumption_master_secret.replace(&([_]u8{0x33} ** hash_len));
         var sink = EventSink{};
         const before = server.core.transcriptHash();
@@ -5858,7 +6061,7 @@ test "server ticket emission allocation failures leave transcript and sink clean
             if (!failing.has_induced_failure) return err;
             saw_injected_failure = true;
             try std.testing.expectEqual(error.CredentialProviderFailed, err);
-            try std.testing.expectEqualSlices(u8, &before, &server.core.transcriptHash());
+            try std.testing.expectEqualSlices(u8, before.slice(), server.core.transcriptHash().slice());
             try std.testing.expectEqual(@as(usize, 0), sink.len);
             sink.deinit();
             server.deinit();
@@ -5912,6 +6115,7 @@ test "large emitted ticket is delivered once after fragmented application receiv
     );
     defer server.deinit();
     server.core.handshake_lifecycle = .complete;
+    server.core.transcript.selectFamily(.sha256);
     try server.resumption_master_secret.replace(&([_]u8{0x44} ** hash_len));
 
     var client = Tls13Backend.initClient(
@@ -5928,6 +6132,7 @@ test "large emitted ticket is delivered once after fragmented application receiv
         .onTicketFn = Capture.onTicket,
     });
     client.core.handshake_lifecycle = .complete;
+    client.core.transcript.selectFamily(.sha256);
     try client.resumption_master_secret.replace(&([_]u8{0x44} ** hash_len));
 
     var sink = EventSink{};
@@ -5965,6 +6170,7 @@ test "application reassembler accepts exact maximum ticket and rejects one byte 
     defer client.deinit();
     try client.setPostHandshakeAllocator(std.testing.allocator);
     client.core.handshake_lifecycle = .complete;
+    client.core.transcript.selectFamily(.sha256);
 
     const max_message = try buildMaxNewSessionTicketMessage(std.testing.allocator);
     defer std.testing.allocator.free(max_message);
@@ -5984,6 +6190,7 @@ test "application reassembler accepts exact maximum ticket and rejects one byte 
     defer over_client.deinit();
     try over_client.setPostHandshakeAllocator(std.testing.allocator);
     over_client.core.handshake_lifecycle = .complete;
+    over_client.core.transcript.selectFamily(.sha256);
     const over = try std.testing.allocator.alloc(u8, max_new_session_ticket_message_len + 1);
     defer std.testing.allocator.free(over);
     // Non-zero filler: only the header this test explicitly overwrites
@@ -6007,6 +6214,7 @@ test "client cannot emit NewSessionTicket" {
     );
     defer client.deinit();
     client.core.handshake_lifecycle = .complete;
+    client.core.transcript.selectFamily(.sha256);
     try client.resumption_master_secret.replace(&([_]u8{0x44} ** hash_len));
     var sink = EventSink{};
     defer sink.deinit();

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -2327,6 +2327,15 @@ pub const Tls13Backend = struct {
         // ordinary no-mutual-suite path.
         var suites_storage: [native_cipher_suites.len]tls_algorithms.CipherSuite = undefined;
         const offered_suites = self.effectiveCipherSuites(&suites_storage);
+        // #568 review: an empty intersection must fail locally, before any
+        // byte reaches the wire — otherwise this would emit a ClientHello
+        // with a zero-length `cipher_suites` vector, which is not a legal
+        // offer RFC 8446 §4.1.2 permits a peer to answer at all. Reported as
+        // the same `IllegalParameter` the server-side no-mutual-suite path
+        // (`mapNegotiationError`) surfaces, since this is exactly that
+        // failure discovered one step earlier — a local capability gap, not
+        // a distinct capability error.
+        if (offered_suites.len == 0) return error.IllegalParameter;
         try w.u16_(@intCast(2 * offered_suites.len)); // cipher_suites
         for (offered_suites) |cipher_suite| {
             try w.u16_(@intFromEnum(cipher_suite));
@@ -2666,6 +2675,14 @@ pub const Tls13Backend = struct {
         const common = &ticket.common;
         if (common.isExpired(now_ms) or common.isNotYetValid(now_ms)) return false;
         if (!self.policy.containsCipherSuite(common.cipher_suite)) return false;
+        // #568 review: policy membership alone is not enough — a ticket
+        // whose suite the *live* provider cannot actually perform (e.g.
+        // SHA-384 support withdrawn at runtime while policy still lists it)
+        // must be dropped here too, or `sendClientHello`'s binder
+        // derivation reaches an unsupported HKDF call and fails the whole
+        // ClientHello with `SecretExportFailed` instead of quietly falling
+        // back to a full handshake or another, capability-supported ticket.
+        if (!tls_crypto_profile.supportsCipherSuite(self.crypto_provider.capabilities(), common.cipher_suite)) return false;
         if (common.resumption_psk.slice().len != tls_algorithms.transcriptHash(common.cipher_suite).digestLength()) return false;
         if (common.server_name) |*stored| {
             const intended = self.serverNameSlice() orelse return false;
@@ -2984,6 +3001,11 @@ pub const Tls13Backend = struct {
         // ever computed differently between the two calls.
         var suites_storage: [native_cipher_suites.len]tls_algorithms.CipherSuite = undefined;
         const offered_suites = self.effectiveCipherSuites(&suites_storage);
+        // #568 review: same local fail-closed guard as `sendClientHello` —
+        // ClientHello1 already proved this list non-empty, so this is only
+        // reachable if capability changed mid-handshake, but it must still
+        // never encode a zero-length `cipher_suites` vector onto the wire.
+        if (offered_suites.len == 0) return error.IllegalParameter;
         try w.u16_(@intCast(2 * offered_suites.len));
         for (offered_suites) |cipher_suite| {
             try w.u16_(@intFromEnum(cipher_suite));

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -1595,6 +1595,43 @@ pub const Tls13Backend = struct {
         if (!tls_crypto_profile.supportsCipherSuite(caps, self.negotiated_cipher_suite)) return error.SecretExportFailed;
     }
 
+    /// #564 review: `self.policy.cipher_suites` in preference order,
+    /// intersected with what the live `CryptoProvider` can actually
+    /// perform (AEAD + transcript hash + HKDF, via
+    /// `crypto_profile.supportsCipherSuite`). Both roles negotiate from
+    /// *this* list, never `self.policy.cipher_suites` directly — capability
+    /// absence must remove a suite from consideration before ServerHello,
+    /// so a provider that only partially supports the configured policy
+    /// still negotiates a mutually usable suite instead of selecting an
+    /// unsupported one and failing closed afterward with
+    /// `SecretExportFailed` (`validateNegotiatedSuiteCapability` above
+    /// stays as a belt-and-braces backstop, not the primary mechanism).
+    /// Order is preserved, so preference is unaffected; an empty result
+    /// means every configured suite is unsupported, which negotiation
+    /// reports as the ordinary `NoMutualCipherSuite`/no-mutual-suite
+    /// failure, not a capability error.
+    fn effectiveCipherSuites(self: *const Tls13Backend, out: *[native_cipher_suites.len]tls_algorithms.CipherSuite) []const tls_algorithms.CipherSuite {
+        const caps = self.crypto_provider.capabilities();
+        var len: usize = 0;
+        for (self.policy.cipher_suites) |suite| {
+            if (tls_crypto_profile.supportsCipherSuite(caps, suite)) {
+                out[len] = suite;
+                len += 1;
+            }
+        }
+        return out[0..len];
+    }
+
+    /// `self.policy` with `cipher_suites` replaced by `effectiveCipherSuites`
+    /// — for callers (`tls_negotiation.negotiateServerHello`,
+    /// `hello_retry` validation) that take a whole `Policy` rather than a
+    /// bare suite list. `suites_storage` must outlive the returned value.
+    fn effectivePolicy(self: *const Tls13Backend, suites_storage: *[native_cipher_suites.len]tls_algorithms.CipherSuite) tls_policy.Policy {
+        var policy = self.policy;
+        policy.cipher_suites = self.effectiveCipherSuites(suites_storage);
+        return policy;
+    }
+
     fn negotiatedGroupCode(self: *const Tls13Backend) u16 {
         return @intFromEnum(self.negotiated_named_group);
     }
@@ -1965,6 +2002,25 @@ pub const Tls13Backend = struct {
         }
     }
 
+    /// #564: a lightweight, non-authoritative read of a ServerHello/HRR's
+    /// `cipher_suite` field straight off the wire — `legacy_version`(2) +
+    /// `random`(32) + `legacy_session_id`(1-byte length + data) +
+    /// `cipher_suite`(2). Used only to resolve the transcript's hash family
+    /// as early as possible (see `drainInput`); every field this reads is
+    /// re-read and fully validated moments later by `onServerHello`/
+    /// `onHelloRetryRequest`, so a wrong or malformed value here never
+    /// reaches a security decision — it just leaves the family unresolved,
+    /// same as if this peek did not exist at all.
+    fn peekServerHelloCipherSuite(body: []const u8) ?tls_algorithms.CipherSuite {
+        var r = Reader{ .bytes = body };
+        _ = r.u16_() catch return null;
+        _ = r.slice(32) catch return null;
+        const session_id_len = r.u8_() catch return null;
+        _ = r.slice(session_id_len) catch return null;
+        const raw_suite = r.u16_() catch return null;
+        return tls_algorithms.fromInt(tls_algorithms.CipherSuite, raw_suite);
+    }
+
     /// Consume whole handshake messages from a reassembly buffer, dispatching
     /// each. Stops early when an async authentication operation parks (so the
     /// suspend point is never crossed) or when the handshake completes or fails.
@@ -2015,6 +2071,27 @@ pub const Tls13Backend = struct {
             // size budget.
             const ch2_transcript_snapshot: ?tls_transcript.Transcript =
                 if (is_second_client_hello) self.core.transcript else null;
+            // #564 review: the client is the one role that can still reach
+            // this point with the transcript's hash family unresolved (the
+            // server always resolves it synchronously while processing
+            // ClientHello1, before `onClientHello` returns). Left
+            // unresolved, `Core.acceptReceived`/`acceptHelloRetryRequest`
+            // below would buffer *this* message too — on top of the
+            // client's own already-buffered ClientHello1 — needing two
+            // messages' worth of pre-selection storage instead of one.
+            // Peeking the wire `cipher_suite` field here, before either
+            // Core function ever mutates the transcript, resolves the
+            // family from ClientHello1 alone in the common case; a
+            // malformed/unrecognized field is simply left unresolved and
+            // falls through to `onServerHello`/`onHelloRetryRequest`'s own
+            // parse, which rejects it the same way it always did (at the
+            // cost of needing the second message's buffering, but that
+            // path was going to fail closed regardless).
+            if (self.role == .client and message.kind == .server_hello and self.core.transcript.family() == null) {
+                if (peekServerHelloCipherSuite(message.body)) |suite| {
+                    self.core.transcript.selectFamily(tls_algorithms.transcriptHash(suite));
+                }
+            }
             if (is_hello_retry_request) {
                 try self.validateHelloRetryRequest(message.body);
                 _ = self.core.acceptHelloRetryRequest(message.raw) catch |err| return mapCoreError(err);
@@ -2243,8 +2320,15 @@ pub const Tls13Backend = struct {
         try w.u16_(legacy_version);
         try w.bytes(&self.entropy.hello_random);
         try w.u8_(0); // legacy_session_id: this profile does not use compatibility mode
-        try w.u16_(@intCast(2 * self.policy.cipher_suites.len)); // cipher_suites
-        for (self.policy.cipher_suites) |cipher_suite| {
+        // #564 review: offer only what the live provider can actually
+        // perform — see `effectiveCipherSuites`. A capability-unsupported
+        // suite must never reach the wire, or the server could select it
+        // and this side would fail closed after ServerHello instead of the
+        // ordinary no-mutual-suite path.
+        var suites_storage: [native_cipher_suites.len]tls_algorithms.CipherSuite = undefined;
+        const offered_suites = self.effectiveCipherSuites(&suites_storage);
+        try w.u16_(@intCast(2 * offered_suites.len)); // cipher_suites
+        for (offered_suites) |cipher_suite| {
             try w.u16_(@intFromEnum(cipher_suite));
         }
         try w.u8_(1); // legacy_compression_methods
@@ -2828,12 +2912,10 @@ pub const Tls13Backend = struct {
             // equivalently authenticated without a fresh Certificate flight.
             try sink.emitCertificate(.valid);
             const n = self.negotiatedDigestLen();
-            self.schedule = KeySchedule.initWithPsk(self.crypto_provider, self.negotiatedHash(), psk[0..n], &shared, self.core.transcriptHash().slice()) catch
-                return error.SecretExportFailed;
+            try self.installScheduleWithPsk(psk[0..n], &shared, self.core.transcriptHash().slice());
             crypto.secureZero(u8, psk);
         } else {
-            self.schedule = KeySchedule.init(self.crypto_provider, self.negotiatedHash(), &shared, self.core.transcriptHash().slice()) catch
-                return error.SecretExportFailed;
+            try self.installSchedule(&shared, self.core.transcriptHash().slice());
         }
         try self.emitHandshakeSecrets(sink);
         try sink.emitDiscardKeys(.initial);
@@ -2894,8 +2976,16 @@ pub const Tls13Backend = struct {
         try w.u16_(legacy_version);
         try w.bytes(&self.entropy.hello_random);
         try w.u8_(0); // legacy_session_id: unchanged from ClientHello1
-        try w.u16_(@intCast(2 * self.policy.cipher_suites.len));
-        for (self.policy.cipher_suites) |cipher_suite| {
+        // #564 review: must reoffer exactly the same (capability-filtered)
+        // list ClientHello1 did — see `sendClientHello`'s matching comment
+        // — so ClientHello2 remains a legal mutation of ClientHello1
+        // (`hello_retry.validateSecondClientHello` requires an identical
+        // cipher_suites vector) rather than drifting if capabilities were
+        // ever computed differently between the two calls.
+        var suites_storage: [native_cipher_suites.len]tls_algorithms.CipherSuite = undefined;
+        const offered_suites = self.effectiveCipherSuites(&suites_storage);
+        try w.u16_(@intCast(2 * offered_suites.len));
+        for (offered_suites) |cipher_suite| {
             try w.u16_(@intFromEnum(cipher_suite));
         }
         try w.u8_(1);
@@ -3547,8 +3637,9 @@ pub const Tls13Backend = struct {
         // 1-RTT secrets exist from the transcript through server Finished,
         // independent of any client certificate flight that follows.
         const finished_hash = self.core.transcriptHash();
-        var app = schedule.applicationSecrets(finished_hash.slice()) catch return error.SecretExportFailed;
+        var app: KeySchedule.ApplicationSecrets = undefined;
         defer app.wipe();
+        schedule.applicationSecrets(finished_hash.slice(), &app) catch return error.SecretExportFailed;
         try self.emitSecret(sink, .application, .write, app.clientSecret());
         try self.emitSecret(sink, .application, .read, app.serverSecret());
 
@@ -3842,7 +3933,15 @@ pub const Tls13Backend = struct {
             self.clearClientHelloPsk();
             self.retry.wipe();
         }
-        const hello_selection = tls_negotiation.negotiateServerHello(self.policy, &offers) catch |err| return mapNegotiationError(err);
+        // #564 review: select only from what the live provider can
+        // actually perform — see `effectiveCipherSuites`/`effectivePolicy`.
+        // A capability-unsupported suite must never be selected in the
+        // first place, or a mutually usable suite further down the offered
+        // preference list would be missed and this side would fail closed
+        // afterward with `SecretExportFailed` instead of negotiating the
+        // fallback.
+        var suites_storage: [native_cipher_suites.len]tls_algorithms.CipherSuite = undefined;
+        const hello_selection = tls_negotiation.negotiateServerHello(self.effectivePolicy(&suites_storage), &offers) catch |err| return mapNegotiationError(err);
         if (hello_selection.version != .tls13 or hello_selection.named_group != .x25519) return error.IllegalParameter;
         // #564: commit the negotiated suite — and select the transcript's
         // hash family accordingly — as soon as it is known, before any
@@ -4163,11 +4262,9 @@ pub const Tls13Backend = struct {
 
         if (psk_selected) |*sel| {
             const n = self.negotiatedDigestLen();
-            self.schedule = KeySchedule.initWithPsk(self.crypto_provider, self.negotiatedHash(), sel.psk[0..n], &shared, self.core.transcriptHash().slice()) catch
-                return error.SecretExportFailed;
+            try self.installScheduleWithPsk(sel.psk[0..n], &shared, self.core.transcriptHash().slice());
         } else {
-            self.schedule = KeySchedule.init(self.crypto_provider, self.negotiatedHash(), &shared, self.core.transcriptHash().slice()) catch
-                return error.SecretExportFailed;
+            try self.installSchedule(&shared, self.core.transcriptHash().slice());
         }
         try self.emitHandshakeSecrets(sink);
         try sink.emitDiscardKeys(.initial);
@@ -4502,8 +4599,9 @@ pub const Tls13Backend = struct {
         try sink.emitCrypto(.handshake, finished);
 
         const finished_hash = self.core.transcriptHash();
-        var app = schedule.applicationSecrets(finished_hash.slice()) catch return error.SecretExportFailed;
+        var app: KeySchedule.ApplicationSecrets = undefined;
         defer app.wipe();
+        schedule.applicationSecrets(finished_hash.slice(), &app) catch return error.SecretExportFailed;
         try self.emitSecret(sink, .application, .read, app.clientSecret());
         try self.emitSecret(sink, .application, .write, app.serverSecret());
     }
@@ -4673,8 +4771,9 @@ pub const Tls13Backend = struct {
         // 1-RTT secrets from the transcript through server Finished; the
         // client Finished we will require is fixed by the same hash.
         const finished_hash = self.core.transcriptHash();
-        var app = schedule.applicationSecrets(finished_hash.slice()) catch return error.SecretExportFailed;
+        var app: KeySchedule.ApplicationSecrets = undefined;
         defer app.wipe();
+        schedule.applicationSecrets(finished_hash.slice(), &app) catch return error.SecretExportFailed;
         try self.emitSecret(sink, .application, .read, app.clientSecret());
         try self.emitSecret(sink, .application, .write, app.serverSecret());
         // The client Finished MAC is (re)computed when the client Finished
@@ -4908,6 +5007,33 @@ pub const Tls13Backend = struct {
     // -----------------------------------------------------------------------
     // Shared helpers.
     // -----------------------------------------------------------------------
+
+    /// #564 review: constructs `self.schedule` in place through
+    /// `KeySchedule`'s out-parameter API — no separate stack-local
+    /// `KeySchedule` is ever created and then copied in by value, so there
+    /// is no successful-path stack copy left unwiped. Preserves the
+    /// original null-on-failure contract (`self.schedule` reverts to
+    /// `null` if derivation fails), exactly as when `KeySchedule.init`
+    /// returned by value and was only assigned to `self.schedule` on the
+    /// success path.
+    fn installSchedule(self: *Tls13Backend, shared: []const u8, hello_transcript_hash: []const u8) HandshakeError!void {
+        const hash = self.negotiatedHash();
+        self.schedule = KeySchedule{ .provider = self.crypto_provider, .hash = hash };
+        KeySchedule.init(self.crypto_provider, hash, shared, hello_transcript_hash, &self.schedule.?) catch {
+            self.schedule = null;
+            return error.SecretExportFailed;
+        };
+    }
+
+    /// PSK-resumed counterpart of `installSchedule` — see its doc comment.
+    fn installScheduleWithPsk(self: *Tls13Backend, psk: []const u8, shared: []const u8, hello_transcript_hash: []const u8) HandshakeError!void {
+        const hash = self.negotiatedHash();
+        self.schedule = KeySchedule{ .provider = self.crypto_provider, .hash = hash };
+        KeySchedule.initWithPsk(self.crypto_provider, hash, psk, shared, hello_transcript_hash, &self.schedule.?) catch {
+            self.schedule = null;
+            return error.SecretExportFailed;
+        };
+    }
 
     fn emitHandshakeSecrets(self: *Tls13Backend, sink: *EventSink) HandshakeError!void {
         const schedule = &self.schedule.?;

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -74,6 +74,19 @@ const CapabilityOverrideProvider = struct {
         return .{ .backing = backing, .caps = caps };
     }
 
+    /// #564: models a provider that never grew AES-256-GCM/SHA-384 support
+    /// (e.g. an embedded build without the wider AEAD/hash set) — used to
+    /// prove `effectiveCipherSuites`/`effectivePolicy` (tls13_backend.zig)
+    /// silently drop `tls_aes_256_gcm_sha384` from the server's own
+    /// candidate list before negotiation, rather than selecting it and
+    /// failing later at `SecretExportFailed`.
+    fn initWithoutSha384(backing: crypto.provider.CryptoProvider) CapabilityOverrideProvider {
+        var caps = backing.capabilities();
+        caps.hashes.remove(.sha384);
+        caps.aeads.remove(.aes_256_gcm);
+        return .{ .backing = backing, .caps = caps };
+    }
+
     fn provider(self: *CapabilityOverrideProvider) crypto.provider.CryptoProvider {
         return .{ .context = self, .vtable = &vtable, .entropy = self.backing.entropy };
     }
@@ -760,6 +773,123 @@ test "PSK round trip: an offered, resolved, and verified ticket resumes the hand
     try std.testing.expectEqualStrings("resumed request", opened_request.inner.content);
 }
 
+test "#564 PSK round trip resumes under AES-256-GCM/SHA-384, including a 48-byte resumption PSK" {
+    // Mirrors "PSK round trip: an offered, resolved, and verified ticket
+    // resumes the handshake" above, but restricted to the SHA-384 suite on
+    // both the issuing and resuming connections — the resumption master
+    // secret, binder, and PSK-path Finished all follow the negotiated
+    // suite's hash per #564, not just the SHA-256 baseline that test covers.
+    var harness: DirectHarness = undefined;
+    directHarnessWithCipherSuite(&harness, .tls_aes_256_gcm_sha384);
+    defer harness.deinit();
+
+    const TicketCapture = struct {
+        ticket: session.ClientTicketState = .{},
+        fn now(_: *anyopaque) i64 {
+            return 1000;
+        }
+        fn onTicket(ctx: *anyopaque, ticket: *const session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            ticket.cloneInto(std.testing.allocator, &self.ticket) catch unreachable;
+        }
+    };
+    var capture = TicketCapture{};
+    defer capture.ticket.deinit();
+    const limits = session.Limits.default;
+    try harness.client_backend.setSessionTicketConsumer(std.testing.allocator, limits, .{
+        .ctx = &capture,
+        .nowUnixMsFn = TicketCapture.now,
+        .onTicketFn = TicketCapture.onTicket,
+    });
+    try harness.run();
+    try std.testing.expect(harness.client_driver.isComplete());
+    try std.testing.expect(harness.server_driver.isComplete());
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    var server_state = try harness.server_backend.emitNewSessionTicket(std.testing.allocator, &sink, .{
+        .ticket_lifetime = 3600,
+        .ticket_age_add = 500,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = "opaque-psk-ticket-384",
+        .issued_at_unix_ms = 1000,
+    }, limits);
+    defer server_state.deinit();
+    try std.testing.expectEqual(@as(usize, 1), sink.len);
+
+    const ticket_event = sink.items[0].handshake_bytes;
+    var protected: [record_codec.max_ciphertext_record_len * 2]u8 = undefined;
+    const records = (try harness.server_bridge.applyEvent(.{ .handshake_bytes = .{
+        .epoch = ticket_event.epoch,
+        .data = ticket_event.data,
+    } }, &protected)).?;
+    var parser = record_codec.Parser.init(.ciphertext);
+    var record_sink = record_codec.RecordSink(8, record_codec.max_ciphertext_fragment_len * 8){};
+    try parser.feed(records, &record_sink);
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    for (record_sink.items[0..record_sink.len]) |record| {
+        const opened = try harness.client_bridge.openHandshake(.application, record, &plaintext);
+        _ = try harness.client_driver.receive(.application, opened.inner.content);
+    }
+    try std.testing.expect(capture.ticket.ticket.slice().len > 0);
+    // The resumption PSK is exactly the negotiated suite's digest length
+    // (48 for SHA-384), not silently truncated/padded to the SHA-256
+    // baseline's 32.
+    try std.testing.expectEqual(@as(usize, 48), capture.ticket.common.resumption_psk.slice().len);
+    try std.testing.expectEqualSlices(u8, server_state.common.resumption_psk.slice(), capture.ticket.common.resumption_psk.slice());
+
+    var resumed: DirectHarness = undefined;
+    directHarnessWithCipherSuite(&resumed, .tls_aes_256_gcm_sha384);
+    defer resumed.deinit();
+
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&capture.ticket);
+    var clock_dummy: u8 = 0;
+    const Clock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 2000;
+        }
+    };
+    try resumed.client_backend.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+
+    const Resolver = struct {
+        state: *session.ServerRecoverableState,
+        resolve_calls: usize = 0,
+
+        fn now(_: *anyopaque) i64 {
+            return 2000;
+        }
+        fn resolve(ctx: *anyopaque, identity: []const u8) pre_shared_key.ResolveError!pre_shared_key.ServerPskResolveResult {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.resolve_calls += 1;
+            if (!std.mem.eql(u8, identity, "opaque-psk-ticket-384")) return .miss;
+            return clonedResolveHit(self.state, std.testing.allocator);
+        }
+    };
+    var resolver_state: Resolver = .{ .state = &server_state };
+    try resumed.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = Resolver.now,
+        .resolveFn = Resolver.resolve,
+    });
+
+    try resumed.run();
+
+    try std.testing.expect(resumed.client_driver.isComplete());
+    try std.testing.expect(resumed.server_driver.isComplete());
+    try std.testing.expectEqual(@as(usize, 1), resolver_state.resolve_calls);
+    try std.testing.expect(resumed.client_backend.core.psk_authenticated);
+    try std.testing.expect(resumed.server_backend.core.psk_authenticated);
+    try std.testing.expectEqual(tls_core.algorithms.CipherSuite.tls_aes_256_gcm_sha384, resumed.client_backend.negotiated_cipher_suite);
+    try std.testing.expectEqual(tls_core.algorithms.CipherSuite.tls_aes_256_gcm_sha384, resumed.server_backend.negotiated_cipher_suite);
+
+    var protected2: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext2: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    const request = try resumed.client_bridge.sealApplicationData("resumed request 384", &protected2);
+    const opened_request = try resumed.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, request), &plaintext2);
+    try std.testing.expectEqualStrings("resumed request 384", opened_request.inner.content);
+}
+
 // ==========================================================================
 // #366: 0-RTT policy gate — TLS vocabulary/negotiation slice.
 //
@@ -798,6 +928,72 @@ fn issueEarlyCapableTicketProfile(profile: EarlyTicketProfile, max_early_data_si
         .record => harness.init(),
         .extension => harness.initExtension(),
     }
+    defer harness.deinit();
+
+    const TicketCapture = struct {
+        ticket: session.ClientTicketState = .{},
+        fn now(_: *anyopaque) i64 {
+            return 1000;
+        }
+        fn onTicket(ctx: *anyopaque, ticket: *const session.ClientTicketState) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            ticket.cloneInto(std.testing.allocator, &self.ticket) catch unreachable;
+        }
+    };
+    var capture = TicketCapture{};
+    errdefer capture.ticket.deinit();
+    const limits = session.Limits.default;
+    try harness.client_backend.setSessionTicketConsumer(std.testing.allocator, limits, .{
+        .ctx = &capture,
+        .nowUnixMsFn = TicketCapture.now,
+        .onTicketFn = TicketCapture.onTicket,
+    });
+    try harness.run();
+    try std.testing.expect(harness.client_driver.isComplete());
+    try std.testing.expect(harness.server_driver.isComplete());
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    var server_state = try harness.server_backend.emitNewSessionTicket(std.testing.allocator, &sink, .{
+        .ticket_lifetime = 3600,
+        .ticket_age_add = 500,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = "opaque-early-ticket",
+        .max_early_data_size = max_early_data_size,
+        .issued_at_unix_ms = 1000,
+    }, limits);
+    errdefer server_state.deinit();
+    try std.testing.expectEqual(@as(usize, 1), sink.len);
+
+    const ticket_event = sink.items[0].handshake_bytes;
+    var protected: [record_codec.max_ciphertext_record_len * 2]u8 = undefined;
+    const records = (try harness.server_bridge.applyEvent(.{ .handshake_bytes = .{
+        .epoch = ticket_event.epoch,
+        .data = ticket_event.data,
+    } }, &protected)).?;
+    var parser = record_codec.Parser.init(.ciphertext);
+    var record_sink = record_codec.RecordSink(8, record_codec.max_ciphertext_fragment_len * 8){};
+    try parser.feed(records, &record_sink);
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    for (record_sink.items[0..record_sink.len]) |record| {
+        const opened = try harness.client_bridge.openHandshake(.application, record, &plaintext);
+        _ = try harness.client_driver.receive(.application, opened.inner.content);
+    }
+    try std.testing.expect(capture.ticket.ticket.slice().len > 0);
+
+    var result = IssuedEarlyTicket{};
+    result.ticket.moveFrom(&capture.ticket);
+    result.server_state.moveFrom(&server_state);
+    return result;
+}
+
+/// #564: `issueEarlyCapableTicketProfile`, restricted to a single native
+/// cipher suite on the issuing connection — so a resumed 0-RTT attempt can
+/// be driven under AES-256-GCM/SHA-384 rather than only the SHA-256
+/// baseline.
+fn issueEarlyCapableTicketWithCipherSuite(comptime cipher_suite: tls_core.algorithms.CipherSuite, max_early_data_size: ?u32) !IssuedEarlyTicket {
+    var harness: DirectHarness = undefined;
+    directHarnessWithCipherSuite(&harness, cipher_suite);
     defer harness.deinit();
 
     const TicketCapture = struct {
@@ -1021,6 +1217,65 @@ test "0-RTT round trip: an early-capable ticket, matching policy, and an allowin
     const request = try resumed.client_bridge.sealApplicationData("resumed request", &protected2);
     const opened_request = try resumed.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, request), &plaintext2);
     try std.testing.expectEqualStrings("resumed request", opened_request.inner.content);
+}
+
+test "#564 0-RTT round trip is accepted end to end under AES-256-GCM/SHA-384, not only the SHA-256 baseline" {
+    var issued = try issueEarlyCapableTicketWithCipherSuite(.tls_aes_256_gcm_sha384, 32);
+    defer issued.deinit();
+
+    var resumed: DirectHarness = undefined;
+    directHarnessWithCipherSuite(&resumed, .tls_aes_256_gcm_sha384);
+    defer resumed.deinit();
+
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&issued.ticket);
+    var clock_dummy: u8 = 0;
+    try resumed.client_backend.setClientPskOffers(&offers, &clock_dummy, earlyDataResumedClientClock);
+
+    var resolver_state = IdentityResolver{ .state = &issued.server_state };
+    try resumed.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = IdentityResolver.now,
+        .resolveFn = IdentityResolver.resolve,
+    });
+
+    try resumed.client_backend.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 16384 });
+    try resumed.server_backend.setServerEarlyDataPolicy(.{ .enabled = true, .age_skew_tolerance_ms = 60_000 });
+    var replay_ctx: u8 = 0;
+    try resumed.server_backend.setEarlyDataReplayGate(.{ .ctx = &replay_ctx, .decideFn = AllowReplayGate.decide });
+
+    try resumed.run();
+
+    try std.testing.expect(resumed.client_driver.isComplete());
+    try std.testing.expect(resumed.server_driver.isComplete());
+    try std.testing.expect(resumed.client_backend.core.psk_authenticated);
+    try std.testing.expect(resumed.server_backend.core.psk_authenticated);
+    try std.testing.expectEqual(tls_core.algorithms.CipherSuite.tls_aes_256_gcm_sha384, resumed.client_backend.negotiated_cipher_suite);
+    try std.testing.expectEqual(tls_core.algorithms.CipherSuite.tls_aes_256_gcm_sha384, resumed.server_backend.negotiated_cipher_suite);
+
+    try std.testing.expect(resumed.client_backend.earlyDataAttempted());
+    try std.testing.expect(resumed.client_backend.earlyDataAccepted());
+    try std.testing.expectEqual(tls_backend.EarlyDataDecision.accepted, resumed.client_backend.earlyDataDecision());
+    try std.testing.expect(resumed.server_backend.earlyDataAttempted());
+    try std.testing.expect(resumed.server_backend.earlyDataAccepted());
+    try std.testing.expectEqual(tls_backend.EarlyDataDecision.accepted, resumed.server_backend.earlyDataDecision());
+
+    // The client's `c e traffic` secret and the server's own independent
+    // derivation of it must be byte-identical — the 48-byte SHA-384 early
+    // secret path (`KeySchedule.clientEarlyTrafficSecret`), not just the
+    // 32-byte SHA-256 one the baseline test above exercises.
+    try std.testing.expectEqual(@as(usize, 48), resumed.observed.zero_rtt_secret[0].?.slice().len);
+    try std.testing.expectEqualSlices(
+        u8,
+        resumed.observed.zero_rtt_secret[0].?.slice(),
+        resumed.observed.zero_rtt_secret[1].?.slice(),
+    );
+
+    var protected2: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext2: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    const request = try resumed.client_bridge.sealApplicationData("resumed request 384", &protected2);
+    const opened_request = try resumed.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, request), &plaintext2);
+    try std.testing.expectEqualStrings("resumed request 384", opened_request.inner.content);
 }
 
 test "0-RTT is rejected without ever consulting the replay gate when the retention deadline overflows" {
@@ -2748,10 +3003,14 @@ fn directHarnessWithClientKeyShareMode(
 /// and transcript/HKDF hash end to end, through the same generic
 /// `record_protection`/key-schedule paths the SHA-256 baseline already
 /// exercises elsewhere in this file. `client_bridge`/`server_bridge` are
-/// still constructed with the SHA-256 baseline as their placeholder initial
-/// suite — `pumpDirect` forwards the backend's `negotiated_parameters`
-/// event to `Bridge.applyEvent`, which corrects it before either bridge
-/// ever derives a traffic key (see `record_epoch_bridge.Bridge.applyEvent`).
+/// constructed already pinned to `cipher_suite` (not the SHA-256 baseline
+/// placeholder `DirectHarness.initProfiles` uses): a 0-RTT attempt derives
+/// and installs its `zero_rtt` write secret from the *offered PSK's own*
+/// suite immediately after the ClientHello is sent, before any
+/// `negotiated_parameters` event exists to correct a wrong placeholder (see
+/// `record_epoch_bridge.Bridge.applyEvent`) — for every other secret,
+/// `pumpDirect` still forwards that event and this pin is simply confirmed
+/// as a no-op.
 fn directHarnessWithCipherSuite(self: *DirectHarness, comptime cipher_suite: tls_core.algorithms.CipherSuite) void {
     const client_crypto_provider = self.client_provider_storage.init(client_provider_seed);
     const server_crypto_provider = self.server_provider_storage.init(server_provider_seed);
@@ -2783,6 +3042,70 @@ fn directHarnessWithCipherSuite(self: *DirectHarness, comptime cipher_suite: tls
             fixtureIdentity(),
             tls_backend.recordConfig(policy),
         ),
+        .client_bridge = Bridge.init(client_bridge_crypto_provider, cipher_suite),
+        .server_bridge = Bridge.init(server_bridge_crypto_provider, cipher_suite),
+    };
+}
+
+/// #564: `directHarnessWithCipherSuite`, plus an empty initial client key
+/// share — combines suite restriction with #484's HRR trigger so the
+/// non-baseline suites get their own HelloRetryRequest coverage, not only
+/// SHA-256's.
+fn directHarnessWithCipherSuiteAndEmptyKeyShare(self: *DirectHarness, comptime cipher_suite: tls_core.algorithms.CipherSuite) void {
+    const client_crypto_provider = self.client_provider_storage.init(client_provider_seed);
+    const server_crypto_provider = self.server_provider_storage.init(server_provider_seed);
+    const client_bridge_crypto_provider = self.client_bridge_provider_storage.init(client_provider_seed);
+    const server_bridge_crypto_provider = self.server_bridge_provider_storage.init(server_provider_seed);
+    const suites = [_]tls_core.algorithms.CipherSuite{cipher_suite};
+    const alpns = [_]tls_core.algorithms.ProtocolName{tls_core.algorithms.alpn.h2};
+    const policy = tls_core.policy.Policy.fromCapabilities(.record, .{ .cipher_suites = &suites }, &alpns);
+    self.* = .{
+        .client_provider_storage = self.client_provider_storage,
+        .server_provider_storage = self.server_provider_storage,
+        .client_bridge_provider_storage = self.client_bridge_provider_storage,
+        .server_bridge_provider_storage = self.server_bridge_provider_storage,
+        .client_backend = tls_backend.Tls13Backend.initClientConfigured(
+            clientEntropy(),
+            client_crypto_provider,
+            .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+            tls_backend.recordConfig(policy),
+            .{ .initial_key_share_mode = .empty },
+        ),
+        .server_backend = tls_backend.Tls13Backend.initServerConfigured(
+            serverEntropy(),
+            server_crypto_provider,
+            fixtureIdentity(),
+            tls_backend.recordConfig(policy),
+        ),
+        .client_bridge = Bridge.init(client_bridge_crypto_provider, cipher_suite),
+        .server_bridge = Bridge.init(server_bridge_crypto_provider, cipher_suite),
+    };
+}
+
+/// #564: wires the harness's server to a caller-supplied provider (e.g. a
+/// `CapabilityOverrideProvider` withdrawing a suite's crypto support)
+/// instead of the harness's own deterministic storage, while the client
+/// keeps the harness's normal provider and the default (all-native-suites)
+/// policy. `server_crypto_provider` must stay valid for the harness's whole
+/// lifetime, so callers own its storage in the test function itself (see
+/// `ProviderStorage`'s doc comment).
+fn directHarnessWithServerProvider(self: *DirectHarness, server_crypto_provider: crypto.provider.CryptoProvider) void {
+    const client_crypto_provider = self.client_provider_storage.init(client_provider_seed);
+    _ = self.server_provider_storage.init(server_provider_seed);
+    const client_bridge_crypto_provider = self.client_bridge_provider_storage.init(client_provider_seed);
+    const server_bridge_crypto_provider = self.server_bridge_provider_storage.init(server_provider_seed);
+    self.* = .{
+        .client_provider_storage = self.client_provider_storage,
+        .server_provider_storage = self.server_provider_storage,
+        .client_bridge_provider_storage = self.client_bridge_provider_storage,
+        .server_bridge_provider_storage = self.server_bridge_provider_storage,
+        .client_backend = tls_backend.Tls13Backend.initClient(
+            clientEntropy(),
+            client_crypto_provider,
+            .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+            .record,
+        ),
+        .server_backend = tls_backend.Tls13Backend.initServer(serverEntropy(), server_crypto_provider, fixtureIdentity(), .record),
         .client_bridge = Bridge.init(client_bridge_crypto_provider, .tls_aes_128_gcm_sha256),
         .server_bridge = Bridge.init(server_bridge_crypto_provider, .tls_aes_128_gcm_sha256),
     };
@@ -2839,6 +3162,32 @@ test "#564 native record-mode loopback still negotiates the AES-128-GCM/SHA-256 
     try expectNativeSuiteLoopback(.tls_aes_128_gcm_sha256, 32);
 }
 
+test "#564 a server whose provider lacks SHA-384/AES-256-GCM drops that suite from negotiation instead of failing" {
+    var harness: DirectHarness = undefined;
+    var server_provider_storage: ProviderStorage = .{};
+    var server_capability_override = CapabilityOverrideProvider.initWithoutSha384(server_provider_storage.init(server_provider_seed));
+    directHarnessWithServerProvider(&harness, server_capability_override.provider());
+    defer harness.deinit();
+    try harness.run();
+
+    try std.testing.expect(harness.client_driver.isComplete());
+    try std.testing.expect(harness.server_driver.isComplete());
+    // The server's own preference list still lists AES-256-GCM/SHA-384 (the
+    // default `.record` policy offers all three native suites) — capability
+    // filtering must have quietly removed it from `effectiveCipherSuites`
+    // before negotiation, landing on one of the two suites the provider can
+    // actually perform, rather than selecting SHA-384 and only discovering
+    // the gap later at `SecretExportFailed`.
+    try std.testing.expect(harness.server_backend.negotiated_cipher_suite != .tls_aes_256_gcm_sha384);
+    try std.testing.expectEqual(harness.client_backend.negotiated_cipher_suite, harness.server_backend.negotiated_cipher_suite);
+
+    var client_out: [64]u8 = undefined;
+    const client_record_bytes = try harness.client_bridge.sealApplicationData("still usable", &client_out);
+    var server_in: [64]u8 = undefined;
+    const from_client = try harness.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, client_record_bytes), &server_in);
+    try std.testing.expectEqualStrings("still usable", from_client.inner.content);
+}
+
 fn expectHrrRetryStateCleared(backend: *const tls_backend.Tls13Backend) !void {
     try std.testing.expect(backend.client_hello_psk == null);
     try std.testing.expect(backend.retry.request == null);
@@ -2872,6 +3221,31 @@ test "#484 HRR round trip: record client with an empty key share completes via n
     try std.testing.expect(harness.observed.application_write_secret[1] != null);
     try std.testing.expect(harness.observed.initial_discarded[0]);
     try std.testing.expect(harness.observed.initial_discarded[1]);
+
+    try expectHrrRetryStateCleared(&harness.client_backend);
+    try expectHrrRetryStateCleared(&harness.server_backend);
+}
+
+test "#564 HRR round trip completes end to end under AES-256-GCM/SHA-384, not only the SHA-256 baseline" {
+    var harness: DirectHarness = undefined;
+    directHarnessWithCipherSuiteAndEmptyKeyShare(&harness, .tls_aes_256_gcm_sha384);
+    defer harness.deinit();
+    try harness.run();
+
+    try std.testing.expect(harness.client_driver.isComplete());
+    try std.testing.expect(harness.server_driver.isComplete());
+    try std.testing.expectEqual(tls_core.handshake.RetryState.hrr_received, harness.client_backend.core.retry_state);
+    try std.testing.expectEqual(tls_core.handshake.RetryState.hrr_sent, harness.server_backend.core.retry_state);
+    try std.testing.expectEqual(tls_core.algorithms.CipherSuite.tls_aes_256_gcm_sha384, harness.client_backend.negotiated_cipher_suite);
+    try std.testing.expectEqual(tls_core.algorithms.CipherSuite.tls_aes_256_gcm_sha384, harness.server_backend.negotiated_cipher_suite);
+
+    // The rebound `message_hash(ClientHello1)` at the retry boundary must
+    // itself be folded under SHA-384 (not silently pinned to SHA-256's
+    // length/algorithm) for both sides to land on the same 48-byte digest.
+    const client_hash = harness.client_backend.core.transcriptHash();
+    const server_hash = harness.server_backend.core.transcriptHash();
+    try std.testing.expectEqual(@as(usize, 48), client_hash.len);
+    try std.testing.expectEqualSlices(u8, client_hash.slice(), server_hash.slice());
 
     try expectHrrRetryStateCleared(&harness.client_backend);
     try expectHrrRetryStateCleared(&harness.server_backend);
@@ -3136,6 +3510,100 @@ test "#485 an oversized ClientHello2 PSK offer fails locally and wipes all retai
     try std.testing.expect(client.client_hello_psk == null);
     try std.testing.expect(client.retry.request == null);
     try std.testing.expectEqual(tls_core.handshake.HandshakeLifecycle.failed, client.core.handshake_lifecycle);
+}
+
+/// #564 review: eight offered identities, sized (as in the oversized-CH2
+/// test above) so ClientHello1 alone sits close to `max_message_len` —
+/// close enough that buffering it plus any nontrivial second message would
+/// overflow the transcript's single-message pre-selection bound if the
+/// family were not resolved from the wire `cipher_suite` field before that
+/// second message is ever recorded (see `peekServerHelloCipherSuite`).
+fn offerNearMaxClientHello(client: *tls_backend.Tls13Backend, item_len: usize) !void {
+    const item_identity = try std.testing.allocator.alloc(u8, item_len);
+    defer std.testing.allocator.free(item_identity);
+    @memset(item_identity, 'x');
+    var tickets: [pre_shared_key.max_offered_identities]session.ClientTicketState = undefined;
+    for (&tickets) |*t| t.* = try makeCacheTicket(&([_]u8{0x5a} ** tls_backend.hash_len), item_identity);
+    defer for (&tickets) |*t| t.deinit();
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    for (&tickets) |*t| try offers.push(t);
+    const Clock = struct {
+        fn now(_: *anyopaque) i64 {
+            return 5_000;
+        }
+    };
+    var clock_dummy: u8 = 0;
+    try client.setClientPskOffers(&offers, &clock_dummy, Clock.now);
+}
+
+test "#564 a near-max-size ClientHello1 followed by an ordinary ServerHello does not overflow the transcript" {
+    var client_provider_storage: ProviderStorage = .{};
+    var client = tls_backend.Tls13Backend.initClient(
+        clientEntropy(),
+        client_provider_storage.init(client_provider_seed),
+        .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+        .record,
+    );
+    defer client.deinit();
+    // Same 950-byte/8-identity shape the oversized-CH2 regression above
+    // uses, which that test's own comment establishes packs ClientHello1
+    // close to `max_message_len` (8 KiB).
+    try offerNearMaxClientHello(&client, 950);
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try client.backend().start(.client, {}, &sink);
+    try std.testing.expectEqual(@as(usize, 1), countCryptoEvents(&sink, .initial));
+
+    // An ordinary full-handshake ServerHello (no PSK identity selected):
+    // legal, unremarkable, and — before this fix — the second
+    // transcript-affecting message buffered on top of the already-buffered
+    // near-max ClientHello1, which overflowed the single-message bound.
+    var buf: [512]u8 = undefined;
+    const hello = try buildServerHello(&buf, .{});
+    try client.backend().receive(.initial, hello, &sink);
+
+    // The transcript actually absorbed both messages under a resolved
+    // family, rather than never reaching `update` at all.
+    try std.testing.expect(client.core.transcript.family() != null);
+}
+
+test "#564 a near-max-size ClientHello1 followed by a HelloRetryRequest does not overflow the transcript" {
+    var client_provider_storage: ProviderStorage = .{};
+    var client = tls_backend.Tls13Backend.initClientWithOptions(
+        clientEntropy(),
+        client_provider_storage.init(client_provider_seed),
+        .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+        .record,
+        .{ .initial_key_share_mode = .empty },
+    );
+    defer client.deinit();
+    // Smaller than the ordinary-ServerHello case above: ClientHello2 must
+    // re-offer the same identities *plus* a real key share, so this leaves
+    // enough headroom for that regrowth to still fit under
+    // `max_message_len` — this test is about the transcript's buffering
+    // bound, not the unrelated ClientHello2 local size guard the
+    // oversized-CH2 regression exercises deliberately.
+    try offerNearMaxClientHello(&client, 900);
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try client.backend().start(.client, {}, &sink);
+    try std.testing.expectEqual(@as(usize, 1), countCryptoEvents(&sink, .initial));
+
+    var hrr_buf: [128]u8 = undefined;
+    const hrr_raw = try tls_core.hello_retry.encode(.{
+        .legacy_session_id_echo = "",
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .selected_group = .x25519,
+    }, &hrr_buf);
+    try client.backend().receive(.initial, hrr_raw, &sink);
+
+    // ClientHello2 was actually emitted — the HRR was accepted, not
+    // rejected, and the transcript survived buffering both ClientHello1
+    // and the HRR before the family was resolved.
+    try std.testing.expectEqual(@as(usize, 2), countCryptoEvents(&sink, .initial));
+    try std.testing.expect(client.core.transcript.family() != null);
 }
 
 fn hexBytes(comptime hex: []const u8) [hex.len / 2]u8 {
@@ -4288,7 +4756,13 @@ test "#484 client rejects an invalid HelloRetryRequest without committing it int
     var sink = DirectSink{};
     defer sink.deinit();
     try client.backend().start(.client, {}, &sink);
-    const transcript_before = client.core.transcriptHash();
+    var client_hello: ?[]const u8 = null;
+    for (sink.items[0..sink.len]) |event| {
+        if (event == .handshake_bytes) client_hello = event.handshake_bytes.data;
+    }
+    const ch1 = client_hello orelse return error.TestExpectedEqual;
+    var independent_ch1_hash: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(ch1, &independent_ch1_hash, .{});
 
     // This client uses `.normal` mode, so ClientHello1 already offers an
     // x25519 share — an HRR requesting that same group is illegal per RFC
@@ -4303,9 +4777,16 @@ test "#484 client rejects an invalid HelloRetryRequest without committing it int
     try std.testing.expectError(error.IllegalParameter, client.backend().receive(.initial, hrr, &sink));
 
     // `drainInput`'s preflight rejected it *before* `Core.acceptHelloRetryRequest`
-    // ever rebound/updated the transcript — the running hash is exactly
-    // what it was right after ClientHello1, and no retry was recorded.
-    try std.testing.expectEqualSlices(u8, transcript_before.slice(), client.core.transcriptHash().slice());
+    // ever rebound/updated the transcript with the HRR's own bytes, and no
+    // retry was recorded. #564: `drainInput` may still have opportunistically
+    // resolved the transcript's hash family from this same (rejected)
+    // message's wire `cipher_suite` field before the rejection ran (see
+    // `peekServerHelloCipherSuite`) — harmless, since that only flushes the
+    // already-legitimate buffered ClientHello1 bytes into a real hash and
+    // never incorporates the HRR itself. Check the property that actually
+    // matters: the running hash is exactly `Hash(ClientHello1)`, computed
+    // independently, not `Hash(ClientHello1) || <the rejected HRR>`.
+    try std.testing.expectEqualSlices(u8, &independent_ch1_hash, client.core.transcriptHash().slice());
     try std.testing.expectEqual(tls_core.handshake.RetryState.none, client.core.retry_state);
 }
 
@@ -4363,6 +4844,30 @@ test "required client authentication completes with a valid client certificate" 
     const request = try harness.client_bridge.sealApplicationData("mutually authenticated", &protected);
     const opened = try harness.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, request), &plaintext);
     try std.testing.expectEqualStrings("mutually authenticated", opened.inner.content);
+}
+
+test "#564 required client authentication completes end to end under AES-256-GCM/SHA-384, not only the SHA-256 baseline" {
+    // The client's Certificate/CertificateVerify/Finished flight is signed
+    // and MAC'd over a transcript hashed under the negotiated suite — this
+    // proves that path is hash-agile too, not only the server-authenticated
+    // handshakes `expectNativeSuiteLoopback` already covers.
+    var harness: DirectHarness = undefined;
+    directHarnessWithCipherSuite(&harness, .tls_aes_256_gcm_sha384);
+    defer harness.deinit();
+    harness.configureClientAuth(.required, true, .{ .pinned_certificate = tls_backend.testdata.certificate_der });
+    try harness.run();
+
+    try std.testing.expect(harness.client_driver.isComplete());
+    try std.testing.expect(harness.server_driver.isComplete());
+    try std.testing.expectEqual(tls_core.algorithms.CipherSuite.tls_aes_256_gcm_sha384, harness.client_backend.negotiated_cipher_suite);
+    try std.testing.expectEqual(tls_core.algorithms.CipherSuite.tls_aes_256_gcm_sha384, harness.server_backend.negotiated_cipher_suite);
+    try std.testing.expectEqual(events.CertificateState.valid, harness.observed.certificate_state.?);
+
+    var protected: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    const request = try harness.client_bridge.sealApplicationData("mutually authenticated 384", &protected);
+    const opened = try harness.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, request), &plaintext);
+    try std.testing.expectEqualStrings("mutually authenticated 384", opened.inner.content);
 }
 
 test "optional client authentication completes when the client declines" {
@@ -8197,6 +8702,71 @@ test "a bad client Finished after PSK selection clears the accepted session and 
     var taken: session.ServerRecoverableState = .{};
     try std.testing.expectEqual(@as(?u16, null), server.takeSelectedServerPsk(&taken));
     try std.testing.expectEqual(@as(?pre_shared_key.AgeSkew, null), server.takePskAgeSkew());
+}
+
+test "#564 a bad client Finished after a full AES-256-GCM/SHA-384 handshake clears the accepted session and secret state" {
+    // Mirrors the PSK-path test above, but for a full certificate handshake
+    // driven under SHA-384 end to end, up to the server's own Finished
+    // verification — the negotiated suite's Finished key/verify_data are
+    // 48 bytes, not the SHA-256 baseline's 32, so this exercises a distinct
+    // code path through `KeySchedule.finishedKey`/`verifyData`. Driven at
+    // the `backend().receive`/`.start` layer directly (bypassing
+    // `record_epoch_bridge.Bridge`, exactly like the PSK-path test above),
+    // since that layer already operates on decrypted handshake-message
+    // bytes and the record/AEAD round trip itself is proven elsewhere
+    // (`expectNativeSuiteLoopback`).
+    var harness: DirectHarness = undefined;
+    directHarnessWithCipherSuite(&harness, .tls_aes_256_gcm_sha384);
+    defer harness.deinit();
+
+    var start_sink = DirectSink{};
+    defer start_sink.deinit();
+    try harness.client_backend.backend().start(.client, {}, &start_sink);
+    var client_hello: ?[]const u8 = null;
+    for (start_sink.items[0..start_sink.len]) |event| {
+        if (event == .handshake_bytes) client_hello = event.handshake_bytes.data;
+    }
+    const ch = client_hello orelse return error.TestExpectedEqual;
+
+    var server_flight_sink = DirectSink{};
+    defer server_flight_sink.deinit();
+    try harness.server_backend.backend().start(.server, {}, &server_flight_sink);
+    try harness.server_backend.backend().receive(.initial, ch, &server_flight_sink);
+
+    // Feed the server's flight (ServerHello, EncryptedExtensions,
+    // Certificate, CertificateVerify, Finished) to the client one message
+    // at a time, exactly as `pumpDirect` would — only the last one (its own
+    // Finished) provokes a response, which is captured immediately (each
+    // per-message sink is wiped by its own `deinit` before the next
+    // iteration, so nothing outlives its own step as a dangling slice).
+    var client_finished_buf: [256]u8 = undefined;
+    var client_finished_len: usize = 0;
+    for (server_flight_sink.items[0..server_flight_sink.len]) |event| {
+        if (event != .handshake_bytes) continue;
+        var client_step_sink = DirectSink{};
+        defer client_step_sink.deinit();
+        try harness.client_backend.backend().receive(event.handshake_bytes.epoch, event.handshake_bytes.data, &client_step_sink);
+        for (client_step_sink.items[0..client_step_sink.len]) |client_event| {
+            if (client_event != .handshake_bytes) continue;
+            const data = client_event.handshake_bytes.data;
+            @memcpy(client_finished_buf[0..data.len], data);
+            client_finished_len = data.len;
+        }
+    }
+    try std.testing.expect(client_finished_len > 0);
+
+    var corrupted = client_finished_buf;
+    corrupted[client_finished_len - 1] ^= 0x01;
+
+    var final_sink = DirectSink{};
+    defer final_sink.deinit();
+    try std.testing.expectError(
+        error.DecryptError,
+        harness.server_backend.backend().receive(.handshake, corrupted[0..client_finished_len], &final_sink),
+    );
+
+    try std.testing.expectEqual(.failed, harness.server_backend.core.handshake_lifecycle);
+    try std.testing.expect(harness.server_backend.schedule == null);
 }
 
 /// Writes a raw `pre_shared_key` extension_data with `count` identities

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -87,6 +87,17 @@ const CapabilityOverrideProvider = struct {
         return .{ .backing = backing, .caps = caps };
     }
 
+    /// #568 review: models a provider that cannot perform AES-128-GCM/SHA-256
+    /// — the *only* suite the plain `.record` transport default
+    /// (`Policy.recordH2Only`) configures — so `effectiveCipherSuites`
+    /// resolves to the empty list for a client using that default policy,
+    /// without needing to strip every native suite one at a time.
+    fn initWithoutAes128Gcm(backing: crypto.provider.CryptoProvider) CapabilityOverrideProvider {
+        var caps = backing.capabilities();
+        caps.aeads.remove(.aes_128_gcm);
+        return .{ .backing = backing, .caps = caps };
+    }
+
     fn provider(self: *CapabilityOverrideProvider) crypto.provider.CryptoProvider {
         return .{ .context = self, .vtable = &vtable, .entropy = self.backing.entropy };
     }
@@ -3047,6 +3058,44 @@ fn directHarnessWithCipherSuite(self: *DirectHarness, comptime cipher_suite: tls
     };
 }
 
+/// #568 review: `directHarnessWithCipherSuite`, but the server authenticates
+/// with the ECDSA-P256 fixture identity (`tls_backend.testdata.p256Identity`)
+/// instead of the file's usual Ed25519 one, and the client pins the
+/// matching P-256 certificate — every other SHA-384 loopback/HRR/resumption
+/// test in this file happens to exercise only Ed25519 CertificateVerify,
+/// leaving the ECDSA-P256 signature path's own transcript-hash-under-SHA-384
+/// dependency unexercised.
+fn directHarnessWithCipherSuiteAndP256Identity(self: *DirectHarness, comptime cipher_suite: tls_core.algorithms.CipherSuite) void {
+    const client_crypto_provider = self.client_provider_storage.init(client_provider_seed);
+    const server_crypto_provider = self.server_provider_storage.init(server_provider_seed);
+    const client_bridge_crypto_provider = self.client_bridge_provider_storage.init(client_provider_seed);
+    const server_bridge_crypto_provider = self.server_bridge_provider_storage.init(server_provider_seed);
+    const suites = [_]tls_core.algorithms.CipherSuite{cipher_suite};
+    const alpns = [_]tls_core.algorithms.ProtocolName{tls_core.algorithms.alpn.h2};
+    const policy = tls_core.policy.Policy.fromCapabilities(.record, .{ .cipher_suites = &suites }, &alpns);
+    self.* = .{
+        .client_provider_storage = self.client_provider_storage,
+        .server_provider_storage = self.server_provider_storage,
+        .client_bridge_provider_storage = self.client_bridge_provider_storage,
+        .server_bridge_provider_storage = self.server_bridge_provider_storage,
+        .client_backend = tls_backend.Tls13Backend.initClientConfigured(
+            clientEntropy(),
+            client_crypto_provider,
+            .{ .pinned_certificate = tls_backend.testdata.p256_certificate_der },
+            tls_backend.recordConfig(policy),
+            .{},
+        ),
+        .server_backend = tls_backend.Tls13Backend.initServerConfigured(
+            serverEntropy(),
+            server_crypto_provider,
+            tls_backend.testdata.p256Identity(),
+            tls_backend.recordConfig(policy),
+        ),
+        .client_bridge = Bridge.init(client_bridge_crypto_provider, cipher_suite),
+        .server_bridge = Bridge.init(server_bridge_crypto_provider, cipher_suite),
+    };
+}
+
 /// #564: `directHarnessWithCipherSuite`, plus an empty initial client key
 /// share — combines suite restriction with #484's HRR trigger so the
 /// non-baseline suites get their own HelloRetryRequest coverage, not only
@@ -3082,30 +3131,94 @@ fn directHarnessWithCipherSuiteAndEmptyKeyShare(self: *DirectHarness, comptime c
     };
 }
 
-/// #564: wires the harness's server to a caller-supplied provider (e.g. a
-/// `CapabilityOverrideProvider` withdrawing a suite's crypto support)
-/// instead of the harness's own deterministic storage, while the client
-/// keeps the harness's normal provider and the default (all-native-suites)
-/// policy. `server_crypto_provider` must stay valid for the harness's whole
-/// lifetime, so callers own its storage in the test function itself (see
-/// `ProviderStorage`'s doc comment).
-fn directHarnessWithServerProvider(self: *DirectHarness, server_crypto_provider: crypto.provider.CryptoProvider) void {
+/// #568 review: wires the harness's server to a caller-supplied provider
+/// (e.g. a `CapabilityOverrideProvider` withdrawing a suite's crypto
+/// support). Both roles get an explicit multi-suite policy instead of the
+/// plain `.record` transport
+/// default — which, contrary to this file's other helpers' assumption,
+/// resolves through `defaultConfigForTransport`/`Policy.recordH2Only` to
+/// *one* suite (AES-128-GCM/SHA-256 only, see `policy.zig`'s
+/// `default_cipher_suites`), not all three native suites. Without an
+/// explicit policy here, a capability override removing SHA-384 would be a
+/// no-op against a server that never offered SHA-384 in the first place —
+/// exactly the gap the second-pass review flagged. The server always gets
+/// the full native preference order (`tls_backend.native_capabilities`,
+/// AES-128 first); the client's own policy is restricted to exactly
+/// `client_suites` (in that preference order), so callers can force a case
+/// where the server's capability-filtered suite is genuinely the one that
+/// would otherwise have been selected. `client_suites` must stay valid for
+/// the harness's whole lifetime — declare it as a local in the test
+/// function itself, matching `ProviderStorage`'s doc comment.
+fn directHarnessWithClientCipherSuitesAndServerProvider(
+    self: *DirectHarness,
+    client_suites: []const tls_core.algorithms.CipherSuite,
+    server_crypto_provider: crypto.provider.CryptoProvider,
+) void {
     const client_crypto_provider = self.client_provider_storage.init(client_provider_seed);
     _ = self.server_provider_storage.init(server_provider_seed);
     const client_bridge_crypto_provider = self.client_bridge_provider_storage.init(client_provider_seed);
     const server_bridge_crypto_provider = self.server_bridge_provider_storage.init(server_provider_seed);
+    const alpns = [_]tls_core.algorithms.ProtocolName{tls_core.algorithms.alpn.h2};
+    const client_policy = tls_core.policy.Policy.fromCapabilities(.record, .{ .cipher_suites = client_suites }, &alpns);
+    const server_policy = tls_core.policy.Policy.fromCapabilities(.record, tls_backend.native_capabilities, &alpns);
     self.* = .{
         .client_provider_storage = self.client_provider_storage,
         .server_provider_storage = self.server_provider_storage,
         .client_bridge_provider_storage = self.client_bridge_provider_storage,
         .server_bridge_provider_storage = self.server_bridge_provider_storage,
-        .client_backend = tls_backend.Tls13Backend.initClient(
+        .client_backend = tls_backend.Tls13Backend.initClientConfigured(
             clientEntropy(),
             client_crypto_provider,
             .{ .pinned_certificate = tls_backend.testdata.certificate_der },
-            .record,
+            tls_backend.recordConfig(client_policy),
+            .{},
         ),
-        .server_backend = tls_backend.Tls13Backend.initServer(serverEntropy(), server_crypto_provider, fixtureIdentity(), .record),
+        .server_backend = tls_backend.Tls13Backend.initServerConfigured(
+            serverEntropy(),
+            server_crypto_provider,
+            fixtureIdentity(),
+            tls_backend.recordConfig(server_policy),
+        ),
+        .client_bridge = Bridge.init(client_bridge_crypto_provider, .tls_aes_128_gcm_sha256),
+        .server_bridge = Bridge.init(server_bridge_crypto_provider, .tls_aes_128_gcm_sha256),
+    };
+}
+
+/// #568 review: wires the harness's *client* to a caller-supplied provider
+/// (e.g. a `CapabilityOverrideProvider` withdrawing a suite's crypto
+/// support) with the full native multi-suite policy — the client-side
+/// mirror of `directHarnessWithClientCipherSuitesAndServerProvider`, needed
+/// to prove `ticketEligibleToOffer` drops a PSK ticket whose suite the
+/// client's own live provider cannot perform, even though the ticket's
+/// suite is still listed in policy. The server keeps the harness's normal
+/// (full-capability) provider. `client_crypto_provider` must stay valid for
+/// the harness's whole lifetime, so callers own its storage in the test
+/// function itself (see `ProviderStorage`'s doc comment).
+fn directHarnessWithClientProvider(self: *DirectHarness, client_crypto_provider: crypto.provider.CryptoProvider) void {
+    _ = self.client_provider_storage.init(client_provider_seed);
+    const server_crypto_provider = self.server_provider_storage.init(server_provider_seed);
+    const client_bridge_crypto_provider = self.client_bridge_provider_storage.init(client_provider_seed);
+    const server_bridge_crypto_provider = self.server_bridge_provider_storage.init(server_provider_seed);
+    const alpns = [_]tls_core.algorithms.ProtocolName{tls_core.algorithms.alpn.h2};
+    const policy = tls_core.policy.Policy.fromCapabilities(.record, tls_backend.native_capabilities, &alpns);
+    self.* = .{
+        .client_provider_storage = self.client_provider_storage,
+        .server_provider_storage = self.server_provider_storage,
+        .client_bridge_provider_storage = self.client_bridge_provider_storage,
+        .server_bridge_provider_storage = self.server_bridge_provider_storage,
+        .client_backend = tls_backend.Tls13Backend.initClientConfigured(
+            clientEntropy(),
+            client_crypto_provider,
+            .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+            tls_backend.recordConfig(policy),
+            .{},
+        ),
+        .server_backend = tls_backend.Tls13Backend.initServerConfigured(
+            serverEntropy(),
+            server_crypto_provider,
+            fixtureIdentity(),
+            tls_backend.recordConfig(policy),
+        ),
         .client_bridge = Bridge.init(client_bridge_crypto_provider, .tls_aes_128_gcm_sha256),
         .server_bridge = Bridge.init(server_bridge_crypto_provider, .tls_aes_128_gcm_sha256),
     };
@@ -3162,30 +3275,150 @@ test "#564 native record-mode loopback still negotiates the AES-128-GCM/SHA-256 
     try expectNativeSuiteLoopback(.tls_aes_128_gcm_sha256, 32);
 }
 
-test "#564 a server whose provider lacks SHA-384/AES-256-GCM drops that suite from negotiation instead of failing" {
+test "#568 native record-mode loopback negotiates AES-256-GCM/SHA-384 with an ECDSA-P256 CertificateVerify, not only Ed25519" {
+    // #568 second-pass review: every other SHA-384 test in this file
+    // authenticates with the fixture Ed25519 identity, so the ECDSA-P256
+    // CertificateVerify path — its own signature over the SHA-384
+    // transcript hash, distinct code from Ed25519's — was never exercised
+    // under a non-baseline hash.
     var harness: DirectHarness = undefined;
-    var server_provider_storage: ProviderStorage = .{};
-    var server_capability_override = CapabilityOverrideProvider.initWithoutSha384(server_provider_storage.init(server_provider_seed));
-    directHarnessWithServerProvider(&harness, server_capability_override.provider());
+    directHarnessWithCipherSuiteAndP256Identity(&harness, .tls_aes_256_gcm_sha384);
     defer harness.deinit();
     try harness.run();
 
     try std.testing.expect(harness.client_driver.isComplete());
     try std.testing.expect(harness.server_driver.isComplete());
-    // The server's own preference list still lists AES-256-GCM/SHA-384 (the
-    // default `.record` policy offers all three native suites) — capability
-    // filtering must have quietly removed it from `effectiveCipherSuites`
-    // before negotiation, landing on one of the two suites the provider can
-    // actually perform, rather than selecting SHA-384 and only discovering
-    // the gap later at `SecretExportFailed`.
-    try std.testing.expect(harness.server_backend.negotiated_cipher_suite != .tls_aes_256_gcm_sha384);
-    try std.testing.expectEqual(harness.client_backend.negotiated_cipher_suite, harness.server_backend.negotiated_cipher_suite);
+    try std.testing.expectEqual(tls_core.algorithms.CipherSuite.tls_aes_256_gcm_sha384, harness.client_backend.negotiated_cipher_suite);
+    try std.testing.expectEqual(tls_core.algorithms.CipherSuite.tls_aes_256_gcm_sha384, harness.server_backend.negotiated_cipher_suite);
+    try std.testing.expectEqual(events.CertificateState.valid, harness.observed.certificate_state.?);
+
+    const client_hash = harness.client_backend.core.transcriptHash();
+    const server_hash = harness.server_backend.core.transcriptHash();
+    try std.testing.expectEqual(@as(usize, 48), client_hash.len);
+    try std.testing.expectEqualSlices(u8, client_hash.slice(), server_hash.slice());
+
+    var client_out: [64]u8 = undefined;
+    const client_record_bytes = try harness.client_bridge.sealApplicationData("ecdsa p256 sha384", &client_out);
+    var server_in: [64]u8 = undefined;
+    const from_client = try harness.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, client_record_bytes), &server_in);
+    try std.testing.expectEqualStrings("ecdsa p256 sha384", from_client.inner.content);
+}
+
+test "#568 a server whose provider lacks SHA-384/AES-256-GCM falls back past it to a suite the client did not prefer first" {
+    // #568 second-pass review: the previous version of this test left the
+    // client on the harness default (all 3 suites, AES-128 first), so the
+    // server's *unfiltered* preference order (also AES-128 first) would
+    // have landed on the same AES-128 selection with or without
+    // `effectiveCipherSuites` ever running — it did not actually prove the
+    // filtering did anything. Restricting the client to [SHA-384, ChaCha]
+    // (no AES-128) forces a real fork: without filtering, the server's
+    // unfiltered preference order would still try AES-256-GCM/SHA-384
+    // first, the client offered it, so it would be *selected* — and only
+    // then fail closed at `SecretExportFailed` once the (capability-absent)
+    // provider is asked to actually derive under it. With filtering, the
+    // server's effective candidate list drops AES-256-GCM/SHA-384 before
+    // selection ever runs, so negotiation continues past it to ChaCha20-
+    // Poly1305/SHA-256 — the first suite both sides can actually execute —
+    // and the handshake completes normally instead of failing at all.
+    var harness: DirectHarness = undefined;
+    var server_provider_storage: ProviderStorage = .{};
+    var server_capability_override = CapabilityOverrideProvider.initWithoutSha384(server_provider_storage.init(server_provider_seed));
+    const client_suites = [_]tls_core.algorithms.CipherSuite{ .tls_aes_256_gcm_sha384, .tls_chacha20_poly1305_sha256 };
+    directHarnessWithClientCipherSuitesAndServerProvider(&harness, &client_suites, server_capability_override.provider());
+    defer harness.deinit();
+    try harness.run();
+
+    try std.testing.expect(harness.client_driver.isComplete());
+    try std.testing.expect(harness.server_driver.isComplete());
+    try std.testing.expectEqual(tls_core.algorithms.CipherSuite.tls_chacha20_poly1305_sha256, harness.client_backend.negotiated_cipher_suite);
+    try std.testing.expectEqual(tls_core.algorithms.CipherSuite.tls_chacha20_poly1305_sha256, harness.server_backend.negotiated_cipher_suite);
 
     var client_out: [64]u8 = undefined;
     const client_record_bytes = try harness.client_bridge.sealApplicationData("still usable", &client_out);
     var server_in: [64]u8 = undefined;
     const from_client = try harness.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, client_record_bytes), &server_in);
     try std.testing.expectEqualStrings("still usable", from_client.inner.content);
+}
+
+test "#568 a server whose provider lacks SHA-384/AES-256-GCM fails the ordinary no-mutual-suite way when that is all the client offers" {
+    // The true no-overlap case #568's second-pass review asked for,
+    // distinct from the fallback case above: the client offers *only*
+    // AES-256-GCM/SHA-384, which the server's capability-filtered
+    // candidate list no longer contains at all, so there is no suite left
+    // to fall back to. This must fail during negotiation itself — the
+    // ordinary `NoMutualCipherSuite`/`IllegalParameter` path — not reach
+    // key-schedule installation and fail there as `SecretExportFailed`.
+    var harness: DirectHarness = undefined;
+    var server_provider_storage: ProviderStorage = .{};
+    var server_capability_override = CapabilityOverrideProvider.initWithoutSha384(server_provider_storage.init(server_provider_seed));
+    const client_suites = [_]tls_core.algorithms.CipherSuite{.tls_aes_256_gcm_sha384};
+    directHarnessWithClientCipherSuitesAndServerProvider(&harness, &client_suites, server_capability_override.provider());
+    defer harness.deinit();
+    try std.testing.expectError(error.IllegalParameter, harness.run());
+    try std.testing.expect(harness.server_backend.schedule == null);
+}
+
+test "#568 a client whose provider lacks SHA-384 drops a SHA-384 ticket from its PSK offer and falls back to a full handshake" {
+    // #568 second-pass review: `ticketEligibleToOffer` used to filter a
+    // stored ticket against policy membership alone. A ticket whose suite
+    // the *live* provider cannot perform (capability withdrawn at runtime,
+    // policy unchanged) used to survive that filter, reach
+    // `sendClientHello`'s binder derivation, and fail the whole ClientHello
+    // with `SecretExportFailed` — aborting startup instead of quietly
+    // falling back to a full handshake, which is what should happen here:
+    // the ticket is dropped before it is ever offered, and the connection
+    // completes normally without PSK authentication.
+    var issued = try issueEarlyCapableTicketWithCipherSuite(.tls_aes_256_gcm_sha384, null);
+    defer issued.deinit();
+
+    var harness: DirectHarness = undefined;
+    var client_provider_storage: ProviderStorage = .{};
+    var client_capability_override = CapabilityOverrideProvider.initWithoutSha384(client_provider_storage.init(client_provider_seed));
+    directHarnessWithClientProvider(&harness, client_capability_override.provider());
+    defer harness.deinit();
+
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&issued.ticket);
+    var clock_dummy: u8 = 0;
+    try harness.client_backend.setClientPskOffers(&offers, &clock_dummy, earlyDataResumedClientClock);
+
+    var resolver_state = IdentityResolver{ .state = &issued.server_state };
+    try harness.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = IdentityResolver.now,
+        .resolveFn = IdentityResolver.resolve,
+    });
+
+    try harness.run();
+
+    try std.testing.expect(harness.client_driver.isComplete());
+    try std.testing.expect(harness.server_driver.isComplete());
+    try std.testing.expect(!harness.client_backend.core.psk_authenticated);
+    try std.testing.expect(!harness.server_backend.core.psk_authenticated);
+    try std.testing.expect(harness.client_backend.negotiated_cipher_suite != .tls_aes_256_gcm_sha384);
+    try std.testing.expectEqual(events.CertificateState.valid, harness.observed.certificate_state.?);
+}
+
+test "#568 a client whose provider cannot perform any policy-configured suite fails locally instead of emitting an empty cipher_suites vector" {
+    // #568 second-pass review: an empty `effectiveCipherSuites` result used
+    // to still be encoded onto the wire as a zero-length `cipher_suites`
+    // vector — not a ClientHello any RFC 8446 peer could legally answer.
+    // `sendClientHello` must instead fail closed, locally, before any byte
+    // is ever emitted.
+    var client_provider_storage: ProviderStorage = .{};
+    var client_capability_override = CapabilityOverrideProvider.initWithoutAes128Gcm(client_provider_storage.init(client_provider_seed));
+    var client = tls_backend.Tls13Backend.initClient(
+        clientEntropy(),
+        client_capability_override.provider(),
+        .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+        .record,
+    );
+    defer client.deinit();
+
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try std.testing.expectError(error.IllegalParameter, client.backend().start(.client, {}, &sink));
+    try std.testing.expectEqual(@as(usize, 0), sink.len);
 }
 
 fn expectHrrRetryStateCleared(backend: *const tls_backend.Tls13Backend) !void {
@@ -3227,25 +3460,75 @@ test "#484 HRR round trip: record client with an empty key share completes via n
 }
 
 test "#564 HRR round trip completes end to end under AES-256-GCM/SHA-384, not only the SHA-256 baseline" {
+    // #568 second-pass review: comparing `client_hash` to `server_hash`
+    // alone proves the two sides *agree*, not that either is *correct* —
+    // both are computed by the same production `Transcript` code, so a
+    // shared bug (e.g. the rebind hash silently using SHA-256 length/
+    // algorithm on both sides) would still make that comparison pass. This
+    // drives the handshake manually (bypassing `harness.run()`/
+    // `record_epoch_bridge.Bridge`, the same `backend().receive`-direct
+    // style the `#485 KAT` test above uses) so every message's raw wire
+    // bytes can be captured and independently rehashed through
+    // `std.crypto.hash.sha2.Sha384` — mirroring `reboundTranscriptHashFixture`'s
+    // exact RFC 8446 §4.4.1 `message_hash`-rebinding algorithm, but for
+    // SHA-384 instead of that fixture's hardcoded SHA-256.
     var harness: DirectHarness = undefined;
     directHarnessWithCipherSuiteAndEmptyKeyShare(&harness, .tls_aes_256_gcm_sha384);
     defer harness.deinit();
-    try harness.run();
 
-    try std.testing.expect(harness.client_driver.isComplete());
-    try std.testing.expect(harness.server_driver.isComplete());
+    var client_sink = DirectSink{};
+    defer client_sink.deinit();
+    var server_sink = DirectSink{};
+    defer server_sink.deinit();
+
+    try harness.client_backend.backend().start(.client, {}, &client_sink);
+    const ch1_raw = nthInitialCryptoBytes(&client_sink, 0);
+
+    try harness.server_backend.backend().start(.server, {}, &server_sink);
+    try harness.server_backend.backend().receive(.initial, ch1_raw, &server_sink);
+    const hrr_raw = nthInitialCryptoBytes(&server_sink, 0);
+
+    try harness.client_backend.backend().receive(.initial, hrr_raw, &client_sink);
+    const ch2_raw = nthInitialCryptoBytes(&client_sink, 1);
+
+    try harness.server_backend.backend().receive(.initial, ch2_raw, &server_sink);
+    const server_hello_raw = nthInitialCryptoBytes(&server_sink, 1);
+    var ee_finished_buf: [4096]u8 = undefined;
+    const ee_finished_raw = collectHandshakeCrypto(&server_sink, &ee_finished_buf);
+
+    try harness.client_backend.backend().receive(.initial, server_hello_raw, &client_sink);
+    try harness.client_backend.backend().receive(.handshake, ee_finished_raw, &client_sink);
+    var client_finished_buf: [512]u8 = undefined;
+    const client_finished_raw = collectHandshakeCrypto(&client_sink, &client_finished_buf);
+
+    try harness.server_backend.backend().receive(.handshake, client_finished_raw, &server_sink);
+
+    try std.testing.expectEqual(tls_core.handshake.HandshakeLifecycle.complete, harness.client_backend.core.handshake_lifecycle);
+    try std.testing.expectEqual(tls_core.handshake.HandshakeLifecycle.complete, harness.server_backend.core.handshake_lifecycle);
     try std.testing.expectEqual(tls_core.handshake.RetryState.hrr_received, harness.client_backend.core.retry_state);
     try std.testing.expectEqual(tls_core.handshake.RetryState.hrr_sent, harness.server_backend.core.retry_state);
     try std.testing.expectEqual(tls_core.algorithms.CipherSuite.tls_aes_256_gcm_sha384, harness.client_backend.negotiated_cipher_suite);
     try std.testing.expectEqual(tls_core.algorithms.CipherSuite.tls_aes_256_gcm_sha384, harness.server_backend.negotiated_cipher_suite);
 
-    // The rebound `message_hash(ClientHello1)` at the retry boundary must
-    // itself be folded under SHA-384 (not silently pinned to SHA-256's
-    // length/algorithm) for both sides to land on the same 48-byte digest.
-    const client_hash = harness.client_backend.core.transcriptHash();
-    const server_hash = harness.server_backend.core.transcriptHash();
-    try std.testing.expectEqual(@as(usize, 48), client_hash.len);
-    try std.testing.expectEqualSlices(u8, client_hash.slice(), server_hash.slice());
+    var ch1_hash: [48]u8 = undefined;
+    std.crypto.hash.sha2.Sha384.hash(ch1_raw, &ch1_hash, .{});
+    var msg_hash_record: [4 + 48]u8 = undefined;
+    msg_hash_record[0] = @intFromEnum(tls_core.messages.MessageType.message_hash);
+    std.mem.writeInt(u24, msg_hash_record[1..4], 48, .big);
+    @memcpy(msg_hash_record[4..], &ch1_hash);
+
+    var hasher = std.crypto.hash.sha2.Sha384.init(.{});
+    hasher.update(&msg_hash_record);
+    hasher.update(hrr_raw);
+    hasher.update(ch2_raw);
+    hasher.update(server_hello_raw);
+    hasher.update(ee_finished_raw);
+    hasher.update(client_finished_raw);
+    var expected: [48]u8 = undefined;
+    hasher.final(&expected);
+
+    try std.testing.expectEqualSlices(u8, &expected, harness.client_backend.core.transcriptHash().slice());
+    try std.testing.expectEqualSlices(u8, &expected, harness.server_backend.core.transcriptHash().slice());
 
     try expectHrrRetryStateCleared(&harness.client_backend);
     try expectHrrRetryStateCleared(&harness.server_backend);
@@ -8763,6 +9046,60 @@ test "#564 a bad client Finished after a full AES-256-GCM/SHA-384 handshake clea
     try std.testing.expectError(
         error.DecryptError,
         harness.server_backend.backend().receive(.handshake, corrupted[0..client_finished_len], &final_sink),
+    );
+
+    try std.testing.expectEqual(.failed, harness.server_backend.core.handshake_lifecycle);
+    try std.testing.expect(harness.server_backend.schedule == null);
+}
+
+test "#568 a wrong-length client Finished under SHA-384 is rejected as malformed, not as a MAC mismatch" {
+    // #568 second-pass review: the tamper test above corrupts a
+    // *correctly-sized* Finished's content, exercising the MAC-comparison
+    // (`DecryptError`) branch of `onClientFinished`. This instead sends a
+    // well-framed Finished whose `verify_data` is the SHA-256 baseline's
+    // 32 bytes rather than the negotiated SHA-384 suite's 48 — exercising
+    // `onClientFinished`'s separate `if (body.len != n) return
+    // error.MalformedHandshake` guard, which must reject the wrong length
+    // itself rather than reading/comparing past the too-short buffer or
+    // silently truncating the expected 48-byte MAC to compare only 32.
+    var harness: DirectHarness = undefined;
+    directHarnessWithCipherSuite(&harness, .tls_aes_256_gcm_sha384);
+    defer harness.deinit();
+
+    var start_sink = DirectSink{};
+    defer start_sink.deinit();
+    try harness.client_backend.backend().start(.client, {}, &start_sink);
+    var client_hello: ?[]const u8 = null;
+    for (start_sink.items[0..start_sink.len]) |event| {
+        if (event == .handshake_bytes) client_hello = event.handshake_bytes.data;
+    }
+    const ch = client_hello orelse return error.TestExpectedEqual;
+
+    var server_flight_sink = DirectSink{};
+    defer server_flight_sink.deinit();
+    try harness.server_backend.backend().start(.server, {}, &server_flight_sink);
+    try harness.server_backend.backend().receive(.initial, ch, &server_flight_sink);
+
+    // Drive the client through the server's flight so the server reaches a
+    // real, negotiated-under-SHA-384 state (schedule installed, digest
+    // length 48) before it is asked to verify a Finished — the client's own
+    // resulting Finished bytes are unused, since this test replaces them
+    // with a deliberately wrong-length one.
+    for (server_flight_sink.items[0..server_flight_sink.len]) |event| {
+        if (event != .handshake_bytes) continue;
+        var client_step_sink = DirectSink{};
+        defer client_step_sink.deinit();
+        try harness.client_backend.backend().receive(event.handshake_bytes.epoch, event.handshake_bytes.data, &client_step_sink);
+    }
+
+    var wrong_length_buf: [4 + 32]u8 = undefined;
+    const wrong_length_finished = try tls_core.messages.encode(.finished, &([_]u8{0xaa} ** 32), &wrong_length_buf);
+
+    var final_sink = DirectSink{};
+    defer final_sink.deinit();
+    try std.testing.expectError(
+        error.MalformedHandshake,
+        harness.server_backend.backend().receive(.handshake, wrong_length_finished, &final_sink),
     );
 
     try std.testing.expectEqual(.failed, harness.server_backend.core.handshake_lifecycle);

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -9052,16 +9052,39 @@ test "#564 a bad client Finished after a full AES-256-GCM/SHA-384 handshake clea
     try std.testing.expect(harness.server_backend.schedule == null);
 }
 
-test "#568 a wrong-length client Finished under SHA-384 is rejected as malformed, not as a MAC mismatch" {
-    // #568 second-pass review: the tamper test above corrupts a
-    // *correctly-sized* Finished's content, exercising the MAC-comparison
-    // (`DecryptError`) branch of `onClientFinished`. This instead sends a
-    // well-framed Finished whose `verify_data` is the SHA-256 baseline's
-    // 32 bytes rather than the negotiated SHA-384 suite's 48 — exercising
-    // `onClientFinished`'s separate `if (body.len != n) return
-    // error.MalformedHandshake` guard, which must reject the wrong length
-    // itself rather than reading/comparing past the too-short buffer or
-    // silently truncating the expected 48-byte MAC to compare only 32.
+/// Splits a buffer of one or more concatenated, framed TLS handshake
+/// messages (1-byte type + 3-byte big-endian length + body, repeated) into
+/// everything before the last message and the last message alone. Used to
+/// isolate a trailing Finished from whatever the backend bundled ahead of
+/// it in the same emitted buffer (e.g. Certificate + CertificateVerify).
+fn splitOffLastHandshakeMessage(blob: []const u8) struct { prefix: []const u8, last: []const u8 } {
+    var offset: usize = 0;
+    var last_start: usize = 0;
+    while (offset < blob.len) {
+        last_start = offset;
+        const body_len = std.mem.readInt(u24, blob[offset + 1 ..][0..3], .big);
+        offset += 4 + body_len;
+    }
+    std.debug.assert(offset == blob.len);
+    return .{ .prefix = blob[0..last_start], .last = blob[last_start..] };
+}
+
+/// #568 review (third pass): the previous version of this test sent a
+/// wrong-length *client* Finished to the server — but by the time the
+/// server verifies the client's Finished, it has already derived and
+/// emitted its own application secrets (`onServerFinished` does that before
+/// the client ever gets a chance to answer), so that ordering can never be
+/// proven wrong-length-safe from the server side. `onServerFinished`
+/// (`src/tls/tls13_backend.zig`) is the function that actually gates
+/// application-secret installation on Finished verification — its own
+/// `if (body.len != n) return error.MalformedHandshake` runs first, before
+/// any `applicationSecrets`/`emitSecret` call — so this drives the
+/// *client* through a real SHA-384 handshake up to the server's Finished,
+/// replaces just that message with a `wrong_len`-byte `verify_data`, and
+/// confirms both the correct error and that nothing was emitted for that
+/// call (proving the length check really did run first, not merely that
+/// the overall handshake ended up failed).
+fn expectWrongLengthServerFinishedRejected(comptime wrong_len: usize) !void {
     var harness: DirectHarness = undefined;
     directHarnessWithCipherSuite(&harness, .tls_aes_256_gcm_sha384);
     defer harness.deinit();
@@ -9080,30 +9103,65 @@ test "#568 a wrong-length client Finished under SHA-384 is rejected as malformed
     try harness.server_backend.backend().start(.server, {}, &server_flight_sink);
     try harness.server_backend.backend().receive(.initial, ch, &server_flight_sink);
 
-    // Drive the client through the server's flight so the server reaches a
-    // real, negotiated-under-SHA-384 state (schedule installed, digest
-    // length 48) before it is asked to verify a Finished — the client's own
-    // resulting Finished bytes are unused, since this test replaces them
-    // with a deliberately wrong-length one.
+    // The server's own Finished is the last `handshake_bytes` event in its
+    // flight (RFC 8446 §4.4: ServerHello, EncryptedExtensions, Certificate,
+    // CertificateVerify, Finished, in that order) — feed every earlier
+    // message to the client normally, then replace only that last one with
+    // a deliberately wrong-length `verify_data`.
+    var handshake_event_count: usize = 0;
+    for (server_flight_sink.items[0..server_flight_sink.len]) |event| {
+        if (event == .handshake_bytes) handshake_event_count += 1;
+    }
+    try std.testing.expect(handshake_event_count > 0);
+
+    var seen: usize = 0;
     for (server_flight_sink.items[0..server_flight_sink.len]) |event| {
         if (event != .handshake_bytes) continue;
-        var client_step_sink = DirectSink{};
-        defer client_step_sink.deinit();
-        try harness.client_backend.backend().receive(event.handshake_bytes.epoch, event.handshake_bytes.data, &client_step_sink);
+        seen += 1;
+        if (seen < handshake_event_count) {
+            var client_step_sink = DirectSink{};
+            defer client_step_sink.deinit();
+            try harness.client_backend.backend().receive(event.handshake_bytes.epoch, event.handshake_bytes.data, &client_step_sink);
+        } else {
+            // The last `.handshake_bytes` event may bundle more than one
+            // message (e.g. Certificate + CertificateVerify + Finished all
+            // written into the same buffer before being emitted together) —
+            // Finished is always the flight's trailing message (RFC 8446
+            // §4.4), so feed everything *before* it normally and leave only
+            // the trailing Finished itself to be replaced below.
+            const split = splitOffLastHandshakeMessage(event.handshake_bytes.data);
+            if (split.prefix.len > 0) {
+                var prefix_sink = DirectSink{};
+                defer prefix_sink.deinit();
+                try harness.client_backend.backend().receive(event.handshake_bytes.epoch, split.prefix, &prefix_sink);
+            }
+        }
     }
 
-    var wrong_length_buf: [4 + 32]u8 = undefined;
-    const wrong_length_finished = try tls_core.messages.encode(.finished, &([_]u8{0xaa} ** 32), &wrong_length_buf);
+    var wrong_length_buf: [4 + wrong_len]u8 = undefined;
+    const wrong_length_finished = try tls_core.messages.encode(.finished, &([_]u8{0xaa} ** wrong_len), &wrong_length_buf);
 
     var final_sink = DirectSink{};
     defer final_sink.deinit();
     try std.testing.expectError(
         error.MalformedHandshake,
-        harness.server_backend.backend().receive(.handshake, wrong_length_finished, &final_sink),
+        harness.client_backend.backend().receive(.handshake, wrong_length_finished, &final_sink),
     );
 
-    try std.testing.expectEqual(.failed, harness.server_backend.core.handshake_lifecycle);
-    try std.testing.expect(harness.server_backend.schedule == null);
+    // Nothing was emitted for this call at all — not just no *application*
+    // secret event specifically — confirming the length guard is the very
+    // first thing `onServerFinished` does, before any state-changing work.
+    try std.testing.expectEqual(@as(usize, 0), final_sink.len);
+    try std.testing.expectEqual(.failed, harness.client_backend.core.handshake_lifecycle);
+    try std.testing.expect(harness.client_backend.schedule == null);
+}
+
+test "#568 a too-short (SHA-256-length) server Finished under SHA-384 is rejected before application secrets are installed" {
+    try expectWrongLengthServerFinishedRejected(32);
+}
+
+test "#568 a too-long server Finished under SHA-384 is rejected before application secrets are installed" {
+    try expectWrongLengthServerFinishedRejected(64);
 }
 
 /// Writes a raw `pre_shared_key` extension_data with `count` identities

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -193,11 +193,21 @@ const KeySnapshot = struct {
 };
 
 const SecretSnapshot = struct {
-    bytes: [tls_backend.hash_len]u8,
+    // #564: sized for the largest negotiable suite's digest (SHA-384), not
+    // just the SHA-256 baseline `tls_backend.hash_len` — a snapshot taken
+    // during an AES-256-GCM/SHA-384 handshake is 48 bytes.
+    bytes: [tls_core.key_schedule.max_digest_len]u8 = undefined,
+    len: usize,
 
     fn capture(secret: []const u8) SecretSnapshot {
-        std.debug.assert(secret.len == tls_backend.hash_len);
-        return .{ .bytes = secret[0..tls_backend.hash_len].* };
+        std.debug.assert(secret.len <= tls_core.key_schedule.max_digest_len);
+        var out = SecretSnapshot{ .len = secret.len };
+        @memcpy(out.bytes[0..secret.len], secret);
+        return out;
+    }
+
+    fn slice(self: *const SecretSnapshot) []const u8 {
+        return self.bytes[0..self.len];
     }
 };
 
@@ -341,6 +351,10 @@ fn pumpDirect(
             var scratch: [1]u8 = undefined;
             _ = try sender_bridge.applyEvent(.handshake_complete, &scratch);
             sender_driver.complete();
+        },
+        .negotiated_parameters => |params| {
+            var scratch: [1]u8 = undefined;
+            _ = try sender_bridge.applyEvent(.{ .negotiated_parameters = params }, &scratch);
         },
         .peer_transport_parameters => {},
         .alpn => |protocol| observed.noteAlpn(protocol),
@@ -996,8 +1010,8 @@ test "0-RTT round trip: an early-capable ticket, matching policy, and an allowin
     // `KeySchedule.clientEarlyTrafficSecret` independently.
     try std.testing.expectEqualSlices(
         u8,
-        &resumed.observed.zero_rtt_secret[0].?.bytes,
-        &resumed.observed.zero_rtt_secret[1].?.bytes,
+        resumed.observed.zero_rtt_secret[0].?.slice(),
+        resumed.observed.zero_rtt_secret[1].?.slice(),
     );
 
     // The resumed 1-RTT connection remains usable afterward regardless of
@@ -2664,16 +2678,16 @@ test "record and extension profiles preserve independent traffic-secret goldens"
         secretGolden("262f66c237c5ff9cf867b242fa37ba707b2dcd06d0188ce3b3c60a069f05588b"),
     };
     const record_actual = [_][tls_backend.hash_len]u8{
-        record.observed.handshake_write_secret[0].?.bytes,
-        record.observed.handshake_write_secret[1].?.bytes,
-        record.observed.application_write_secret[0].?.bytes,
-        record.observed.application_write_secret[1].?.bytes,
+        record.observed.handshake_write_secret[0].?.bytes[0..tls_backend.hash_len].*,
+        record.observed.handshake_write_secret[1].?.bytes[0..tls_backend.hash_len].*,
+        record.observed.application_write_secret[0].?.bytes[0..tls_backend.hash_len].*,
+        record.observed.application_write_secret[1].?.bytes[0..tls_backend.hash_len].*,
     };
     const extension_actual = [_][tls_backend.hash_len]u8{
-        extension.observed.handshake_write_secret[0].?.bytes,
-        extension.observed.handshake_write_secret[1].?.bytes,
-        extension.observed.application_write_secret[0].?.bytes,
-        extension.observed.application_write_secret[1].?.bytes,
+        extension.observed.handshake_write_secret[0].?.bytes[0..tls_backend.hash_len].*,
+        extension.observed.handshake_write_secret[1].?.bytes[0..tls_backend.hash_len].*,
+        extension.observed.application_write_secret[0].?.bytes[0..tls_backend.hash_len].*,
+        extension.observed.application_write_secret[1].?.bytes[0..tls_backend.hash_len].*,
     };
     for (record_goldens, record_actual) |expected, actual| {
         try std.testing.expectEqualSlices(u8, &expected, &actual);
@@ -2728,6 +2742,103 @@ fn directHarnessWithClientKeyShareMode(
     };
 }
 
+/// #564: out-parameter style (see `DirectHarness.initProfiles`'s doc
+/// comment) — both roles are configured with a policy offering only
+/// `suite`, so the native engine must negotiate exactly that suite's AEAD
+/// and transcript/HKDF hash end to end, through the same generic
+/// `record_protection`/key-schedule paths the SHA-256 baseline already
+/// exercises elsewhere in this file. `client_bridge`/`server_bridge` are
+/// still constructed with the SHA-256 baseline as their placeholder initial
+/// suite — `pumpDirect` forwards the backend's `negotiated_parameters`
+/// event to `Bridge.applyEvent`, which corrects it before either bridge
+/// ever derives a traffic key (see `record_epoch_bridge.Bridge.applyEvent`).
+fn directHarnessWithCipherSuite(self: *DirectHarness, comptime cipher_suite: tls_core.algorithms.CipherSuite) void {
+    const client_crypto_provider = self.client_provider_storage.init(client_provider_seed);
+    const server_crypto_provider = self.server_provider_storage.init(server_provider_seed);
+    const client_bridge_crypto_provider = self.client_bridge_provider_storage.init(client_provider_seed);
+    const server_bridge_crypto_provider = self.server_bridge_provider_storage.init(server_provider_seed);
+    // `comptime cipher_suite` (not a runtime parameter) so these arrays get
+    // static storage duration: `Policy.cipher_suites`/`.alpn_protocols` are
+    // borrowed slices retained inside both backends for the life of the
+    // harness, well past this function returning — a runtime-local array
+    // here would dangle the moment it did.
+    const suites = [_]tls_core.algorithms.CipherSuite{cipher_suite};
+    const alpns = [_]tls_core.algorithms.ProtocolName{tls_core.algorithms.alpn.h2};
+    const policy = tls_core.policy.Policy.fromCapabilities(.record, .{ .cipher_suites = &suites }, &alpns);
+    self.* = .{
+        .client_provider_storage = self.client_provider_storage,
+        .server_provider_storage = self.server_provider_storage,
+        .client_bridge_provider_storage = self.client_bridge_provider_storage,
+        .server_bridge_provider_storage = self.server_bridge_provider_storage,
+        .client_backend = tls_backend.Tls13Backend.initClientConfigured(
+            clientEntropy(),
+            client_crypto_provider,
+            .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+            tls_backend.recordConfig(policy),
+            .{},
+        ),
+        .server_backend = tls_backend.Tls13Backend.initServerConfigured(
+            serverEntropy(),
+            server_crypto_provider,
+            fixtureIdentity(),
+            tls_backend.recordConfig(policy),
+        ),
+        .client_bridge = Bridge.init(client_bridge_crypto_provider, .tls_aes_128_gcm_sha256),
+        .server_bridge = Bridge.init(server_bridge_crypto_provider, .tls_aes_128_gcm_sha256),
+    };
+}
+
+fn expectNativeSuiteLoopback(comptime cipher_suite: tls_core.algorithms.CipherSuite, expected_digest_len: usize) !void {
+    var harness: DirectHarness = undefined;
+    directHarnessWithCipherSuite(&harness, cipher_suite);
+    defer harness.deinit();
+    try harness.run();
+
+    try std.testing.expect(harness.client_driver.isComplete());
+    try std.testing.expect(harness.server_driver.isComplete());
+    try std.testing.expectEqual(cipher_suite, harness.client_backend.negotiated_cipher_suite);
+    try std.testing.expectEqual(cipher_suite, harness.server_backend.negotiated_cipher_suite);
+
+    // Both sides end up with byte-identical transcripts under the
+    // negotiated suite's own hash — the same cross-role invariant the
+    // SHA-256 baseline tests above check, now for a suite whose transcript
+    // hash may differ in length from SHA-256's.
+    const client_hash = harness.client_backend.core.transcriptHash();
+    const server_hash = harness.server_backend.core.transcriptHash();
+    try std.testing.expectEqual(expected_digest_len, client_hash.len);
+    try std.testing.expectEqualSlices(u8, client_hash.slice(), server_hash.slice());
+
+    // Application data actually round-trips under the negotiated suite's
+    // AEAD, proving `record_protection.TrafficKeys.derive` was driven with
+    // the right suite (not silently defaulted to AES-128-GCM) on both
+    // directions and both bridges.
+    var client_out: [64]u8 = undefined;
+    const client_record_bytes = try harness.client_bridge.sealApplicationData("hello from client", &client_out);
+    const client_record = try parseSingleRecord(.ciphertext, client_record_bytes);
+    var server_in: [64]u8 = undefined;
+    const from_client = try harness.server_bridge.openApplicationData(client_record, &server_in);
+    try std.testing.expectEqualStrings("hello from client", from_client.inner.content);
+
+    var server_out: [64]u8 = undefined;
+    const server_record_bytes = try harness.server_bridge.sealApplicationData("hello from server", &server_out);
+    const server_record = try parseSingleRecord(.ciphertext, server_record_bytes);
+    var client_in: [64]u8 = undefined;
+    const from_server = try harness.client_bridge.openApplicationData(server_record, &client_in);
+    try std.testing.expectEqualStrings("hello from server", from_server.inner.content);
+}
+
+test "#564 native record-mode loopback negotiates AES-256-GCM/SHA-384 end to end" {
+    try expectNativeSuiteLoopback(.tls_aes_256_gcm_sha384, 48);
+}
+
+test "#564 native record-mode loopback negotiates ChaCha20-Poly1305/SHA-256 end to end" {
+    try expectNativeSuiteLoopback(.tls_chacha20_poly1305_sha256, 32);
+}
+
+test "#564 native record-mode loopback still negotiates the AES-128-GCM/SHA-256 baseline end to end" {
+    try expectNativeSuiteLoopback(.tls_aes_128_gcm_sha256, 32);
+}
+
 fn expectHrrRetryStateCleared(backend: *const tls_backend.Tls13Backend) !void {
     try std.testing.expect(backend.client_hello_psk == null);
     try std.testing.expect(backend.retry.request == null);
@@ -2749,7 +2860,7 @@ test "#484 HRR round trip: record client with an empty key share completes via n
     // real HRR, ClientHello2, and the rest of the flight through Finished.
     const client_hash = harness.client_backend.core.transcriptHash();
     const server_hash = harness.server_backend.core.transcriptHash();
-    try std.testing.expectEqualSlices(u8, &client_hash, &server_hash);
+    try std.testing.expectEqualSlices(u8, client_hash.slice(), server_hash.slice());
 
     // Traffic secrets were derived exactly once, from the final
     // ServerHello — `DirectObserved.captureSecret` never records anything
@@ -2783,7 +2894,7 @@ test "#484 HRR round trip completes over the extension (QUIC-style) profile too"
     try std.testing.expectEqual(tls_core.handshake.RetryState.hrr_sent, harness.server_backend.core.retry_state);
     const client_hash = harness.client_backend.core.transcriptHash();
     const server_hash = harness.server_backend.core.transcriptHash();
-    try std.testing.expectEqualSlices(u8, &client_hash, &server_hash);
+    try std.testing.expectEqualSlices(u8, client_hash.slice(), server_hash.slice());
 
     // The local transport-extension payload contract survives HelloRetryRequest
     // and ClientHello2 unchanged, on both sides.
@@ -3089,7 +3200,7 @@ test "#485 PSK resumption completes through one HelloRetryRequest, with matching
     // internally without it showing up here.
     const client_hash = harness.client_backend.core.transcriptHash();
     const server_hash = harness.server_backend.core.transcriptHash();
-    try std.testing.expectEqualSlices(u8, &client_hash, &server_hash);
+    try std.testing.expectEqualSlices(u8, client_hash.slice(), server_hash.slice());
 
     // No traffic secret was derived at the HRR itself, only after the final
     // ServerHello — same assertions as the non-PSK #484 HRR round trip.
@@ -4194,7 +4305,7 @@ test "#484 client rejects an invalid HelloRetryRequest without committing it int
     // `drainInput`'s preflight rejected it *before* `Core.acceptHelloRetryRequest`
     // ever rebound/updated the transcript — the running hash is exactly
     // what it was right after ClientHello1, and no retry was recorded.
-    try std.testing.expectEqualSlices(u8, &transcript_before, &client.core.transcriptHash());
+    try std.testing.expectEqualSlices(u8, transcript_before.slice(), client.core.transcriptHash().slice());
     try std.testing.expectEqual(tls_core.handshake.RetryState.none, client.core.retry_state);
 }
 
@@ -4222,7 +4333,7 @@ test "#484 server rejects an invalid ClientHello2 mutation without committing it
     // `drainInput`'s preflight rejected it *before* `Core.acceptSecondClientHello`
     // ever updated the transcript or advanced `handshake_state` — both are
     // exactly what they were right after the HRR was recorded.
-    try std.testing.expectEqualSlices(u8, &transcript_before, &server.core.transcriptHash());
+    try std.testing.expectEqualSlices(u8, transcript_before.slice(), server.core.transcriptHash().slice());
     try std.testing.expectEqual(tls_core.handshake.RetryState.hrr_sent, server.core.retry_state);
 }
 
@@ -7802,10 +7913,12 @@ test "cache-backed client offer filtering preserves selected index token mapping
 /// these server-only tests.
 fn feedValidClientFinished(server: *tls_backend.Tls13Backend) !void {
     const schedule = &server.schedule.?;
-    var client_verify = try tls_backend.KeySchedule.verifyData(schedule.provider, &schedule.client_handshake_traffic, server.core.transcriptHash());
-    defer std.crypto.secureZero(u8, &client_verify);
-    var finished_buf: [4 + tls_backend.hash_len]u8 = undefined;
-    const finished = try tls_core.messages.encode(.finished, &client_verify, &finished_buf);
+    const n = schedule.digestLen();
+    var client_verify: [tls_core.key_schedule.max_digest_len]u8 = undefined;
+    try tls_backend.KeySchedule.verifyData(schedule.provider, schedule.hash, schedule.client_handshake_traffic[0..n], server.core.transcriptHash().slice(), client_verify[0..n]);
+    defer std.crypto.secureZero(u8, client_verify[0..n]);
+    var finished_buf: [4 + tls_core.key_schedule.max_digest_len]u8 = undefined;
+    const finished = try tls_core.messages.encode(.finished, client_verify[0..n], &finished_buf);
     var sink = DirectSink{};
     defer sink.deinit();
     try server.backend().receive(.handshake, finished, &sink);

--- a/src/tls/transcript.zig
+++ b/src/tls/transcript.zig
@@ -1,49 +1,224 @@
 //! TLS 1.3 transcript hash helper.
 //!
-//! The transcript is transport-neutral: callers update it with exact handshake
+//! The transcript is transport-neutral and hash-agile: it supports SHA-256
+//! and SHA-384 (the two transcript/HKDF hashes `algorithms.transcriptHash`
+//! maps the negotiated cipher suites to — #564), selected once per
+//! connection via `selectFamily`. Callers update it with exact handshake
 //! message bytes as emitted by `messages.HandshakeMessage.raw`.
+//!
+//! ## Why selection is deferred
+//!
+//! The negotiated cipher suite — and therefore the transcript's hash family
+//! — is not known when the very first transcript-affecting bytes arrive:
+//!
+//!   - The server learns the suite while parsing ClientHello, but `Core`
+//!     (`handshake.zig`) already feeds ClientHello's raw bytes to the
+//!     transcript before that parse ever runs.
+//!   - The client sends its own ClientHello before it knows anything the
+//!     server will pick, and then `Core` feeds the ServerHello/
+//!     HelloRetryRequest's raw bytes to the transcript (and, for an HRR,
+//!     rebinds ClientHello1 into `message_hash` form) *before* the backend
+//!     has parsed that message's `cipher_suite` field out of its body.
+//!
+//! So `update`/`rebindClientHello` transparently buffer bytes (and record a
+//! rebind boundary) until `selectFamily` runs, then replay them into the
+//! real hash in order — no ClientHello bytes are lost and no message is
+//! ever hashed under the wrong family. Once a family is selected every
+//! subsequent `update`/`rebindClientHello` call hashes live; `selectFamily`
+//! itself becomes a no-op (the negotiated suite is authoritative and is not
+//! re-derived here — callers must not call it with a different hash for the
+//! same connection).
+//!
+//! ## Bounding the pre-selection buffer
+//!
+//! `max_pending_len` holds exactly one framed handshake message, not two:
+//! a well-behaved peer only ever requires buffering ClientHello1 (the
+//! server resolves the family from it synchronously, before any other
+//! message is processed) or, on the client, a single incoming ServerHello/
+//! HelloRetryRequest (the transport layer resolves the family from that
+//! message's own `cipher_suite` field before handing it to `update`/
+//! `rebindClientHello` at all — see `tls13_backend.zig`'s `drainInput`).
+//! Buffering more than one message's worth before a family is ever selected
+//! is a caller bug (or a peer so malformed the connection was going to fail
+//! closed anyway), and `update` reports it as `error.TranscriptOverflow`
+//! rather than overrunning `pending` — this type never panics on
+//! attacker-controlled input.
 
 const std = @import("std");
-const key_schedule = @import("key_schedule.zig");
+const provider = @import("crypto").provider;
 const messages = @import("messages.zig");
 
-pub const Hash = key_schedule.TranscriptHash;
-pub const digest_len = key_schedule.hash_len;
+pub const Hash = provider.Hash;
+/// Largest digest this transcript can hold (SHA-384 = 48 bytes).
+pub const max_digest_len = provider.max_digest_len;
+
+/// One framed handshake message's worth of pre-selection buffering — see
+/// "Bounding the pre-selection buffer" above. Exactly
+/// `tls13_backend.max_message_len` (8 KiB) plus its 4-byte handshake
+/// header — the same bound the reassembler already admits a single
+/// handshake message up to, so a legitimate ClientHello the engine accepts
+/// can never itself overflow this buffer before its suite is known.
+pub const max_pending_len: usize = 8 * 1024 + 4;
+
+pub const Error = error{TranscriptOverflow};
+
+const Sha256 = std.crypto.hash.sha2.Sha256;
+const Sha384 = std.crypto.hash.sha2.Sha384;
+
+/// A transcript digest: `bytes[0..len]` is the hash under whatever family
+/// was selected (or active at capture time); `bytes[len..]` is always zero,
+/// never uninitialized — so a caller that mistakenly reads past `len` sees
+/// deterministic zero bytes, not stack garbage.
+pub const Digest = struct {
+    bytes: [max_digest_len]u8 = [_]u8{0} ** max_digest_len,
+    len: usize = 0,
+
+    pub fn slice(self: *const Digest) []const u8 {
+        return self.bytes[0..self.len];
+    }
+
+    pub fn eql(self: *const Digest, other: *const Digest) bool {
+        return self.len == other.len and std.mem.eql(u8, self.slice(), other.slice());
+    }
+};
+
+const HashState = union(Hash) {
+    sha256: Sha256,
+    sha384: Sha384,
+
+    fn init(hash: Hash) HashState {
+        return switch (hash) {
+            .sha256 => .{ .sha256 = Sha256.init(.{}) },
+            .sha384 => .{ .sha384 = Sha384.init(.{}) },
+        };
+    }
+
+    fn update(self: *HashState, bytes: []const u8) void {
+        switch (self.*) {
+            inline else => |*h| h.update(bytes),
+        }
+    }
+
+    fn digest(self: *const HashState) Digest {
+        var copy = self.*;
+        var out = Digest{};
+        switch (copy) {
+            inline else => |*h| {
+                const n = @TypeOf(h.*).digest_length;
+                out.len = n;
+                h.final(out.bytes[0..n]);
+            },
+        }
+        return out;
+    }
+
+    fn family(self: HashState) Hash {
+        return std.meta.activeTag(self);
+    }
+};
 
 pub const Transcript = struct {
-    hash: Hash = Hash.init(.{}),
+    /// Bytes already hashed into `state`, when a family has been selected;
+    /// otherwise unused (everything so far lives in `pending`).
+    state: ?HashState = null,
+    pending: [max_pending_len]u8 = undefined,
+    pending_len: usize = 0,
+    /// Set by a `rebindClientHello` that ran before a family was selected:
+    /// the offset in `pending` where the HRR `message_hash` synthetic
+    /// message must be substituted for everything before it. At most one
+    /// HRR may occur per connection (RFC 8446), and only the client can
+    /// ever reach a rebind before its own suite is known, so a single
+    /// optional offset is sufficient — never a list.
+    rebind_at: ?usize = null,
 
-    pub fn update(self: *Transcript, bytes: []const u8) void {
-        self.hash.update(bytes);
+    /// Commit this transcript to `hash`, the negotiated cipher suite's
+    /// transcript/HKDF hash (`algorithms.transcriptHash`). Replays any
+    /// buffered bytes (and rebind boundary) into a real hash of that
+    /// family. A no-op once a family is already active — the negotiated
+    /// suite is selected exactly once per connection and every call after
+    /// the first is expected to name the same hash.
+    pub fn selectFamily(self: *Transcript, hash: Hash) void {
+        if (self.state != null) return;
+        var h = HashState.init(hash);
+        if (self.rebind_at) |at| {
+            var pre = HashState.init(hash);
+            pre.update(self.pending[0..at]);
+            const pre_digest = pre.digest();
+            var synthetic: [4 + max_digest_len]u8 = undefined;
+            synthetic[0] = @intFromEnum(messages.MessageType.message_hash);
+            std.mem.writeInt(u24, synthetic[1..4], @intCast(pre_digest.len), .big);
+            @memcpy(synthetic[4..][0..pre_digest.len], pre_digest.slice());
+            h.update(synthetic[0 .. 4 + pre_digest.len]);
+            h.update(self.pending[at..self.pending_len]);
+        } else {
+            h.update(self.pending[0..self.pending_len]);
+        }
+        self.state = h;
+        std.crypto.secureZero(u8, self.pending[0..self.pending_len]);
+        self.pending_len = 0;
+        self.rebind_at = null;
     }
 
-    pub fn peek(self: *const Transcript) [digest_len]u8 {
-        var copy = self.hash;
-        var out: [digest_len]u8 = undefined;
-        copy.final(&out);
-        return out;
+    /// The negotiated hash family, once selected.
+    pub fn family(self: *const Transcript) ?Hash {
+        if (self.state) |s| return s.family();
+        return null;
     }
 
-    pub fn peekWith(self: *const Transcript, bytes: []const u8) [digest_len]u8 {
-        var copy = self.hash;
-        copy.update(bytes);
-        var out: [digest_len]u8 = undefined;
-        copy.final(&out);
-        return out;
+    pub fn update(self: *Transcript, bytes: []const u8) Error!void {
+        if (self.state) |*s| {
+            s.update(bytes);
+            return;
+        }
+        // Buffering: the family is not known yet — see "Bounding the
+        // pre-selection buffer" above. A caller on attacker-reachable input
+        // must be able to fail the connection here rather than crash.
+        if (self.pending_len + bytes.len > self.pending.len) return error.TranscriptOverflow;
+        @memcpy(self.pending[self.pending_len..][0..bytes.len], bytes);
+        self.pending_len += bytes.len;
     }
 
+    pub fn peek(self: *const Transcript) Digest {
+        if (self.state) |s| return s.digest();
+        return .{};
+    }
+
+    pub fn peekWith(self: *const Transcript, bytes: []const u8) Digest {
+        if (self.state) |s| {
+            var copy = s;
+            copy.update(bytes);
+            return copy.digest();
+        }
+        return .{};
+    }
+
+    /// RFC 8446 §4.4.1: replace the transcript-so-far with the synthetic
+    /// `message_hash(Hash(ClientHello1))` message ahead of a
+    /// HelloRetryRequest. When the hash family is already known this hashes
+    /// immediately, exactly as before; when it is not yet known (the
+    /// client's own HRR-shaped ServerHello, received before its body has
+    /// been parsed) this only records where the rebind boundary falls in
+    /// the pending buffer — `selectFamily` performs the actual rebind once
+    /// the family is learned, still over exactly the same bytes.
     pub fn rebindClientHello(self: *Transcript) void {
-        self.replace(self.peek());
+        if (self.state != null) {
+            self.replace(self.peek());
+            return;
+        }
+        std.debug.assert(self.rebind_at == null);
+        self.rebind_at = self.pending_len;
     }
 
-    pub fn replace(self: *Transcript, digest: [digest_len]u8) void {
-        var synthetic: [4 + digest_len]u8 = undefined;
+    pub fn replace(self: *Transcript, digest: Digest) void {
+        std.debug.assert(self.state != null);
+        var synthetic: [4 + max_digest_len]u8 = undefined;
         synthetic[0] = @intFromEnum(messages.MessageType.message_hash);
-        std.mem.writeInt(u24, synthetic[1..4], digest_len, .big);
-        @memcpy(synthetic[4..], &digest);
+        std.mem.writeInt(u24, synthetic[1..4], @intCast(digest.len), .big);
+        @memcpy(synthetic[4..][0..digest.len], digest.slice());
 
-        self.hash = Hash.init(.{});
-        self.hash.update(&synthetic);
+        const hash = self.state.?.family();
+        self.state = HashState.init(hash);
+        self.state.?.update(synthetic[0 .. 4 + digest.len]);
     }
 };
 
@@ -51,59 +226,124 @@ const testing = std.testing;
 
 test "transcript hash matches direct SHA-256 and supports HRR-style replacement" {
     var transcript = Transcript{};
-    transcript.update("client hello");
+    transcript.selectFamily(.sha256);
+    try transcript.update("client hello");
 
-    var expected: [digest_len]u8 = undefined;
-    Hash.hash("client hello", &expected, .{});
-    try testing.expectEqualSlices(u8, &expected, &transcript.peek());
+    var expected: [Sha256.digest_length]u8 = undefined;
+    Sha256.hash("client hello", &expected, .{});
+    try testing.expectEqualSlices(u8, &expected, transcript.peek().slice());
 
-    transcript.replace(expected);
-    var rebound_expected: [digest_len]u8 = undefined;
-    const synthetic = [_]u8{ 254, 0, 0, digest_len } ++ expected;
-    Hash.hash(&synthetic, &rebound_expected, .{});
-    try testing.expectEqualSlices(u8, &rebound_expected, &transcript.peek());
+    transcript.replace(transcript.peek());
+    var rebound_expected: [Sha256.digest_length]u8 = undefined;
+    const synthetic = [_]u8{ 254, 0, 0, Sha256.digest_length } ++ expected;
+    Sha256.hash(&synthetic, &rebound_expected, .{});
+    try testing.expectEqualSlices(u8, &rebound_expected, transcript.peek().slice());
+}
+
+test "transcript hash matches direct SHA-384" {
+    var transcript = Transcript{};
+    transcript.selectFamily(.sha384);
+    try transcript.update("client hello");
+
+    var expected: [Sha384.digest_length]u8 = undefined;
+    Sha384.hash("client hello", &expected, .{});
+    const digest = transcript.peek();
+    try testing.expectEqual(@as(usize, Sha384.digest_length), digest.len);
+    try testing.expectEqualSlices(u8, &expected, digest.slice());
 }
 
 test "peekWith does not mutate transcript state" {
     var transcript = Transcript{};
-    transcript.update("client hello");
+    transcript.selectFamily(.sha256);
+    try transcript.update("client hello");
     const before = transcript.peek();
 
-    var expected = Hash.init(.{});
+    var expected = Sha256.init(.{});
     expected.update("client hello");
     expected.update("hello retry request");
-    var expected_digest: [digest_len]u8 = undefined;
+    var expected_digest: [Sha256.digest_length]u8 = undefined;
     expected.final(&expected_digest);
 
-    try testing.expectEqualSlices(u8, &expected_digest, &transcript.peekWith("hello retry request"));
-    try testing.expectEqualSlices(u8, &before, &transcript.peek());
+    try testing.expectEqualSlices(u8, &expected_digest, transcript.peekWith("hello retry request").slice());
+    try testing.expectEqualSlices(u8, before.slice(), transcript.peek().slice());
 }
 
-test "rebindClientHello produces deterministic HRR transcript fixture" {
+test "rebindClientHello produces deterministic HRR transcript fixture when the family is already known" {
     const client_hello_1 = [_]u8{ 1, 0, 0, 3, 0x01, 0x02, 0x03 };
     const hello_retry_request = [_]u8{ 2, 0, 0, 2, 0x04, 0x05 };
     const client_hello_2 = [_]u8{ 1, 0, 0, 4, 0x06, 0x07, 0x08, 0x09 };
 
     var transcript = Transcript{};
-    transcript.update(&client_hello_1);
+    transcript.selectFamily(.sha256);
+    try transcript.update(&client_hello_1);
     transcript.rebindClientHello();
-    transcript.update(&hello_retry_request);
-    transcript.update(&client_hello_2);
+    try transcript.update(&hello_retry_request);
+    try transcript.update(&client_hello_2);
 
-    var independent_ch1_hash: [digest_len]u8 = undefined;
-    Hash.hash(&client_hello_1, &independent_ch1_hash, .{});
+    var independent_ch1_hash: [Sha256.digest_length]u8 = undefined;
+    Sha256.hash(&client_hello_1, &independent_ch1_hash, .{});
 
-    var synthetic: [4 + digest_len]u8 = undefined;
+    var synthetic: [4 + Sha256.digest_length]u8 = undefined;
     synthetic[0] = @intFromEnum(messages.MessageType.message_hash);
-    std.mem.writeInt(u24, synthetic[1..4], digest_len, .big);
+    std.mem.writeInt(u24, synthetic[1..4], Sha256.digest_length, .big);
     @memcpy(synthetic[4..], &independent_ch1_hash);
 
-    var direct = Hash.init(.{});
+    var direct = Sha256.init(.{});
     direct.update(&synthetic);
     direct.update(&hello_retry_request);
     direct.update(&client_hello_2);
-    var expected: [digest_len]u8 = undefined;
+    var expected: [Sha256.digest_length]u8 = undefined;
     direct.final(&expected);
 
-    try testing.expectEqualSlices(u8, &expected, &transcript.peek());
+    try testing.expectEqualSlices(u8, &expected, transcript.peek().slice());
+}
+
+test "rebindClientHello buffers the rebind boundary until selectFamily runs, matching the live-family path byte for byte" {
+    const client_hello_1 = [_]u8{ 1, 0, 0, 3, 0x01, 0x02, 0x03 };
+    const hello_retry_request = [_]u8{ 2, 0, 0, 2, 0x04, 0x05 };
+    const client_hello_2 = [_]u8{ 1, 0, 0, 4, 0x06, 0x07, 0x08, 0x09 };
+
+    // Deferred: the family is only learned after both ClientHello1 and the
+    // HelloRetryRequest have already been fed to the transcript — exactly
+    // the client-role ordering `drainInput`/`Core.acceptHelloRetryRequest`
+    // impose in the real engine.
+    var deferred = Transcript{};
+    try deferred.update(&client_hello_1);
+    deferred.rebindClientHello();
+    try deferred.update(&hello_retry_request);
+    try testing.expectEqual(@as(?Hash, null), deferred.family());
+    deferred.selectFamily(.sha384);
+    try deferred.update(&client_hello_2);
+
+    // Live: the family is selected up front, so every call hashes
+    // immediately — the baseline this deferred path must reproduce.
+    var live = Transcript{};
+    live.selectFamily(.sha384);
+    try live.update(&client_hello_1);
+    live.rebindClientHello();
+    try live.update(&hello_retry_request);
+    try live.update(&client_hello_2);
+
+    try testing.expect(deferred.peek().eql(&live.peek()));
+    try testing.expectEqual(@as(usize, Sha384.digest_length), deferred.peek().len);
+}
+
+test "selectFamily is idempotent once a family is active" {
+    var transcript = Transcript{};
+    transcript.selectFamily(.sha256);
+    try transcript.update("client hello");
+    const before = transcript.peek();
+
+    // A later call (e.g. the final ServerHello after an HRR already
+    // selected the family) must not reset or re-hash anything.
+    transcript.selectFamily(.sha256);
+    try testing.expect(before.eql(&transcript.peek()));
+}
+
+test "an unselected transcript reports no family and a zero-length digest with a zeroed tail" {
+    const transcript = Transcript{};
+    try testing.expectEqual(@as(?Hash, null), transcript.family());
+    const digest = transcript.peek();
+    try testing.expectEqual(@as(usize, 0), digest.len);
+    for (digest.bytes) |byte| try testing.expectEqual(@as(u8, 0), byte);
 }

--- a/src/tls/transport.zig
+++ b/src/tls/transport.zig
@@ -63,6 +63,12 @@ pub fn ContractWithOptions(
         pub const Event = union(enum) {
             /// Raw TLS handshake bytes to send at `epoch`.
             handshake_bytes: struct { epoch: Epoch, data: []const u8 },
+            /// The negotiated cipher suite and its transcript hash (#564),
+            /// emitted exactly once per connection before any
+            /// `traffic_secret` event for the `handshake` epoch — the one
+            /// canonical way a record or QUIC consumer learns the suite,
+            /// never inferred from secret length.
+            negotiated_parameters: events.NegotiatedParameters,
             /// A traffic secret to install for `epoch`/`direction`.
             traffic_secret: struct { epoch: Epoch, direction: events.SecretDirection, data: []const u8 },
             /// Transport-owned peer parameters carried by the TLS handshake.
@@ -212,6 +218,15 @@ pub fn ContractWithOptions(
 
             pub fn emitOwnedCrypto(self: *EventSink, allocator: std.mem.Allocator, epoch: Epoch, data: []u8) ErrorSet!void {
                 try self.emitOwnedHandshakeBytes(allocator, epoch, data);
+            }
+
+            /// Emit the negotiated cipher-suite metadata. Callers must emit
+            /// this before the first `emitSecret` for the `handshake`
+            /// epoch, on every path (full or resumed handshake alike) —
+            /// see `Event.negotiated_parameters`.
+            pub fn emitNegotiatedParameters(self: *EventSink, params: events.NegotiatedParameters) ErrorSet!void {
+                try self.reserve(0);
+                self.pushUnchecked(.{ .negotiated_parameters = params });
             }
 
             pub fn emitSecret(self: *EventSink, epoch: Epoch, direction: events.SecretDirection, data: []const u8) ErrorSet!void {

--- a/tests/crypto_openssl_diff.zig
+++ b/tests/crypto_openssl_diff.zig
@@ -1162,7 +1162,7 @@ fn runTlsKeySchedule(allocator: std.mem.Allocator) !void {
     const cp = cryptoProvider();
     const shared = hexBytes("8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d");
     const hello_hash = hexBytes("860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8");
-    var schedule = try KeySchedule.init(cp, &shared, hello_hash);
+    var schedule = try KeySchedule.init(cp, .sha256, &shared, &hello_hash);
     defer schedule.wipe();
 
     const zero = [_]u8{0} ** provider.Hash.sha256.digestLength();
@@ -1173,31 +1173,31 @@ fn runTlsKeySchedule(allocator: std.mem.Allocator) !void {
     defer allocator.free(derived_from_early);
     const handshake_secret = try opensslHkdfExtract(allocator, "tls13 handshake secret", .sha256, derived_from_early, &shared);
     defer allocator.free(handshake_secret);
-    try expectStage("tls13 handshake secret", &schedule.handshake_secret, handshake_secret);
+    try expectStage("tls13 handshake secret", schedule.handshake_secret[0..32], handshake_secret);
 
     const client_hs = try opensslHkdfExpandLabel(allocator, "tls13 client handshake traffic secret", .sha256, handshake_secret, "c hs traffic", &hello_hash, provider.Hash.sha256.digestLength());
     defer allocator.free(client_hs);
-    try expectStage("tls13 client handshake traffic secret", &schedule.client_handshake_traffic, client_hs);
+    try expectStage("tls13 client handshake traffic secret", schedule.client_handshake_traffic[0..32], client_hs);
 
     const server_hs = try opensslHkdfExpandLabel(allocator, "tls13 server handshake traffic secret", .sha256, handshake_secret, "s hs traffic", &hello_hash, provider.Hash.sha256.digestLength());
     defer allocator.free(server_hs);
-    try expectStage("tls13 server handshake traffic secret", &schedule.server_handshake_traffic, server_hs);
+    try expectStage("tls13 server handshake traffic secret", schedule.server_handshake_traffic[0..32], server_hs);
 
     const derived_from_handshake = try opensslHkdfExpandLabel(allocator, "tls13 derived handshake secret", .sha256, handshake_secret, "derived", &empty_hash, provider.Hash.sha256.digestLength());
     defer allocator.free(derived_from_handshake);
     const master_secret = try opensslHkdfExtract(allocator, "tls13 master secret", .sha256, derived_from_handshake, &zero);
     defer allocator.free(master_secret);
-    try expectStage("tls13 master secret", &schedule.master_secret, master_secret);
+    try expectStage("tls13 master secret", schedule.master_secret[0..32], master_secret);
 
     const finished_hash = hexBytes("9608102a0f1ccc6db6250b7b7e417b1a000eaada3daae4777a7686c9ff83df13");
-    var app = try schedule.applicationSecrets(finished_hash);
+    var app = try schedule.applicationSecrets(&finished_hash);
     defer app.wipe();
     const client_app = try opensslHkdfExpandLabel(allocator, "tls13 client application traffic secret", .sha256, master_secret, "c ap traffic", &finished_hash, provider.Hash.sha256.digestLength());
     defer allocator.free(client_app);
-    try expectStage("tls13 client application traffic secret", &app.client, client_app);
+    try expectStage("tls13 client application traffic secret", app.clientSecret(), client_app);
     const server_app = try opensslHkdfExpandLabel(allocator, "tls13 server application traffic secret", .sha256, master_secret, "s ap traffic", &finished_hash, provider.Hash.sha256.digestLength());
     defer allocator.free(server_app);
-    try expectStage("tls13 server application traffic secret", &app.server, server_app);
+    try expectStage("tls13 server application traffic secret", app.serverSecret(), server_app);
 }
 
 fn fillPattern(out: []u8, seed: u8) void {
@@ -1856,16 +1856,18 @@ test "OpenSSL HKDF oracle matches QUIC production initial derivation" {
     try runQuicInitial(testing.allocator);
 }
 
+const sha256_digest_len = provider.Hash.sha256.digestLength();
+
 fn fillSyntheticHrr(
     out: []u8,
-    ch1_hash: *const [tls_core.transcript.digest_len]u8,
+    ch1_hash: *const [sha256_digest_len]u8,
     hello_retry_request: []const u8,
     client_hello_2: []const u8,
 ) void {
     out[0] = 0xfe;
-    std.mem.writeInt(u24, out[1..4], tls_core.transcript.digest_len, .big);
-    @memcpy(out[4..][0..tls_core.transcript.digest_len], ch1_hash);
-    var offset: usize = 4 + tls_core.transcript.digest_len;
+    std.mem.writeInt(u24, out[1..4], sha256_digest_len, .big);
+    @memcpy(out[4..][0..sha256_digest_len], ch1_hash);
+    var offset: usize = 4 + sha256_digest_len;
     @memcpy(out[offset..][0..hello_retry_request.len], hello_retry_request);
     offset += hello_retry_request.len;
     @memcpy(out[offset..][0..client_hello_2.len], client_hello_2);
@@ -1885,30 +1887,34 @@ fn runTranscriptAndFinished(allocator: std.mem.Allocator) !void {
     defer allocator.free(client_hello_path);
 
     var transcript = tls_core.transcript.Transcript{};
-    transcript.update(&client_hello_1);
-    const zig_ch1_hash = transcript.peek();
-    try expectOpenSslSha256File(allocator, "tls transcript ClientHello1 hash", &zig_ch1_hash, client_hello_path);
+    transcript.selectFamily(.sha256);
+    try transcript.update(&client_hello_1);
+    const zig_ch1_digest = transcript.peek();
+    const zig_ch1_hash = zig_ch1_digest.bytes[0..sha256_digest_len].*;
+    try expectOpenSslSha256File(allocator, "tls transcript ClientHello1 hash", zig_ch1_digest.slice(), client_hello_path);
 
     const hello_retry_request = hexBytes("02000002cf21");
     var client_hello_2 = hexBytes("01000002ddee");
-    transcript.replace(zig_ch1_hash);
-    transcript.update(&hello_retry_request);
-    transcript.update(&client_hello_2);
-    const zig_hrr_hash = transcript.peek();
+    transcript.replace(zig_ch1_digest);
+    try transcript.update(&hello_retry_request);
+    try transcript.update(&client_hello_2);
+    const zig_hrr_digest = transcript.peek();
+    const zig_hrr_hash = zig_hrr_digest.bytes[0..sha256_digest_len].*;
 
-    var synthetic_and_hrr: [4 + tls_core.transcript.digest_len + hello_retry_request.len + client_hello_2.len]u8 = undefined;
+    var synthetic_and_hrr: [4 + sha256_digest_len + hello_retry_request.len + client_hello_2.len]u8 = undefined;
     fillSyntheticHrr(&synthetic_and_hrr, &zig_ch1_hash, &hello_retry_request, &client_hello_2);
     try tmp.dir.writeFile(io, .{ .sub_path = "synthetic_hrr.bin", .data = &synthetic_and_hrr });
     const synthetic_hrr_path = try tmp.dir.realPathFileAlloc(io, "synthetic_hrr.bin", allocator);
     defer allocator.free(synthetic_hrr_path);
-    try expectOpenSslSha256File(allocator, "tls transcript HRR hash", &zig_hrr_hash, synthetic_hrr_path);
+    try expectOpenSslSha256File(allocator, "tls transcript HRR hash", zig_hrr_digest.slice(), synthetic_hrr_path);
 
     const traffic_secret = hexBytes("b67b7d690cc16c4e75e54213cb2d37b4e9c912bcded9105d42befd59d391ad38");
     try tmp.dir.writeFile(io, .{ .sub_path = "finished_hash.bin", .data = &zig_hrr_hash });
     const finished_hash_path = try tmp.dir.realPathFileAlloc(io, "finished_hash.bin", allocator);
     defer allocator.free(finished_hash_path);
 
-    var zig_finished_key = try KeySchedule.finishedKey(cp, &traffic_secret);
+    var zig_finished_key: [sha256_digest_len]u8 = undefined;
+    try KeySchedule.finishedKey(cp, .sha256, &traffic_secret, &zig_finished_key);
     defer std.crypto.secureZero(u8, &zig_finished_key);
     const openssl_finished_key = try opensslHkdfExpandLabel(allocator, "tls13 server Finished key", .sha256, &traffic_secret, "finished", "", provider.Hash.sha256.digestLength());
     defer allocator.free(openssl_finished_key);
@@ -1916,35 +1922,41 @@ fn runTranscriptAndFinished(allocator: std.mem.Allocator) !void {
 
     const openssl_verify_data = try opensslHmacSha256File(allocator, "tls13 server Finished verify_data", openssl_finished_key, finished_hash_path);
     defer allocator.free(openssl_verify_data);
-    var zig_verify_data = try KeySchedule.verifyData(cp, &traffic_secret, zig_hrr_hash);
+    var zig_verify_data: [sha256_digest_len]u8 = undefined;
+    try KeySchedule.verifyData(cp, .sha256, &traffic_secret, &zig_hrr_hash, &zig_verify_data);
     defer std.crypto.secureZero(u8, &zig_verify_data);
     try expectStage("tls13 server Finished verify_data", &zig_verify_data, openssl_verify_data);
 
     client_hello_2[client_hello_2.len - 1] ^= 0x01;
     var mutated_transcript = tls_core.transcript.Transcript{};
-    mutated_transcript.update(&client_hello_1);
-    const mutated_ch1_hash = mutated_transcript.peek();
+    mutated_transcript.selectFamily(.sha256);
+    try mutated_transcript.update(&client_hello_1);
+    const mutated_ch1_digest = mutated_transcript.peek();
+    const mutated_ch1_hash = mutated_ch1_digest.bytes[0..sha256_digest_len].*;
     try expectStage("tls transcript mutated ClientHello1 stable hash", &zig_ch1_hash, &mutated_ch1_hash);
-    mutated_transcript.replace(mutated_ch1_hash);
-    mutated_transcript.update(&hello_retry_request);
-    mutated_transcript.update(&client_hello_2);
-    const zig_mutated_hrr_hash = mutated_transcript.peek();
+    mutated_transcript.replace(mutated_ch1_digest);
+    try mutated_transcript.update(&hello_retry_request);
+    try mutated_transcript.update(&client_hello_2);
+    const zig_mutated_hrr_digest = mutated_transcript.peek();
+    const zig_mutated_hrr_hash = zig_mutated_hrr_digest.bytes[0..sha256_digest_len].*;
 
     fillSyntheticHrr(&synthetic_and_hrr, &zig_ch1_hash, &hello_retry_request, &client_hello_2);
     try tmp.dir.writeFile(io, .{ .sub_path = "synthetic_hrr_mutated.bin", .data = &synthetic_and_hrr });
     const synthetic_hrr_mutated_path = try tmp.dir.realPathFileAlloc(io, "synthetic_hrr_mutated.bin", allocator);
     defer allocator.free(synthetic_hrr_mutated_path);
-    try expectOpenSslSha256File(allocator, "tls transcript HRR mutated hash", &zig_mutated_hrr_hash, synthetic_hrr_mutated_path);
+    try expectOpenSslSha256File(allocator, "tls transcript HRR mutated hash", zig_mutated_hrr_digest.slice(), synthetic_hrr_mutated_path);
 
     try tmp.dir.writeFile(io, .{ .sub_path = "finished_hash_mutated.bin", .data = &zig_mutated_hrr_hash });
     const finished_hash_mutated_path = try tmp.dir.realPathFileAlloc(io, "finished_hash_mutated.bin", allocator);
     defer allocator.free(finished_hash_mutated_path);
     const openssl_mutated_verify_data = try opensslHmacSha256File(allocator, "tls13 server Finished mutated verify_data", openssl_finished_key, finished_hash_mutated_path);
     defer allocator.free(openssl_mutated_verify_data);
-    var zig_mutated_verify_data = try KeySchedule.verifyData(cp, &traffic_secret, zig_mutated_hrr_hash);
+    var zig_mutated_verify_data: [sha256_digest_len]u8 = undefined;
+    try KeySchedule.verifyData(cp, .sha256, &traffic_secret, &zig_mutated_hrr_hash, &zig_mutated_verify_data);
     defer std.crypto.secureZero(u8, &zig_mutated_verify_data);
     try expectStage("tls13 server Finished mutated verify_data", &zig_mutated_verify_data, openssl_mutated_verify_data);
-    var stable_verify_data = try KeySchedule.verifyData(cp, &traffic_secret, zig_hrr_hash);
+    var stable_verify_data: [sha256_digest_len]u8 = undefined;
+    try KeySchedule.verifyData(cp, .sha256, &traffic_secret, &zig_hrr_hash, &stable_verify_data);
     defer std.crypto.secureZero(u8, &stable_verify_data);
     try testing.expect(!std.mem.eql(u8, &stable_verify_data, &zig_mutated_verify_data));
 }

--- a/tests/crypto_openssl_diff.zig
+++ b/tests/crypto_openssl_diff.zig
@@ -1162,7 +1162,8 @@ fn runTlsKeySchedule(allocator: std.mem.Allocator) !void {
     const cp = cryptoProvider();
     const shared = hexBytes("8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d");
     const hello_hash = hexBytes("860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8");
-    var schedule = try KeySchedule.init(cp, .sha256, &shared, &hello_hash);
+    var schedule: KeySchedule = undefined;
+    try KeySchedule.init(cp, .sha256, &shared, &hello_hash, &schedule);
     defer schedule.wipe();
 
     const zero = [_]u8{0} ** provider.Hash.sha256.digestLength();
@@ -1190,7 +1191,8 @@ fn runTlsKeySchedule(allocator: std.mem.Allocator) !void {
     try expectStage("tls13 master secret", schedule.master_secret[0..32], master_secret);
 
     const finished_hash = hexBytes("9608102a0f1ccc6db6250b7b7e417b1a000eaada3daae4777a7686c9ff83df13");
-    var app = try schedule.applicationSecrets(&finished_hash);
+    var app: KeySchedule.ApplicationSecrets = undefined;
+    try schedule.applicationSecrets(&finished_hash, &app);
     defer app.wipe();
     const client_app = try opensslHkdfExpandLabel(allocator, "tls13 client application traffic secret", .sha256, master_secret, "c ap traffic", &finished_hash, provider.Hash.sha256.digestLength());
     defer allocator.free(client_app);

--- a/tests/crypto_vectors.zig
+++ b/tests/crypto_vectors.zig
@@ -303,7 +303,8 @@ fn runTlsKeyScheduleVector(log: *ExecutionLog) !void {
 
     const shared = hexBytes("8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d");
     const hello_hash = hexBytes("860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8");
-    var schedule = try KeySchedule.init(cp, .sha256, &shared, &hello_hash);
+    var schedule: KeySchedule = undefined;
+    try KeySchedule.init(cp, .sha256, &shared, &hello_hash, &schedule);
     defer schedule.wipe();
 
     try expectStage("tls13 handshake secret / RFC 8448", &hexBytes("1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac"), schedule.handshake_secret[0..32]);
@@ -312,7 +313,8 @@ fn runTlsKeyScheduleVector(log: *ExecutionLog) !void {
     try expectStage("tls13 master secret / RFC 8448", &hexBytes("18df06843d13a08bf2a449844c5f8a478001bc4d4c627984d5a41da8d0402919"), schedule.master_secret[0..32]);
 
     const finished_hash = hexBytes("9608102a0f1ccc6db6250b7b7e417b1a000eaada3daae4777a7686c9ff83df13");
-    var app = try schedule.applicationSecrets(&finished_hash);
+    var app: KeySchedule.ApplicationSecrets = undefined;
+    try schedule.applicationSecrets(&finished_hash, &app);
     defer app.wipe();
     try expectStage("tls13 client application traffic secret / RFC 8448", &hexBytes("9e40646ce79a7f9dc05af8889bce6552875afa0b06df0087f792ebb7c17504a5"), app.clientSecret());
     try expectStage("tls13 server application traffic secret / RFC 8448", &hexBytes("a11af9f05531f856ad47116b45a950328204b4f44bfb6b3a4b4f1f3fcb631643"), app.serverSecret());

--- a/tests/crypto_vectors.zig
+++ b/tests/crypto_vectors.zig
@@ -303,23 +303,25 @@ fn runTlsKeyScheduleVector(log: *ExecutionLog) !void {
 
     const shared = hexBytes("8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d");
     const hello_hash = hexBytes("860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8");
-    var schedule = try KeySchedule.init(cp, &shared, hello_hash);
+    var schedule = try KeySchedule.init(cp, .sha256, &shared, &hello_hash);
     defer schedule.wipe();
 
-    try expectStage("tls13 handshake secret / RFC 8448", &hexBytes("1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac"), &schedule.handshake_secret);
-    try expectStage("tls13 client handshake traffic secret / RFC 8448", &hexBytes("b3eddb126e067f35a780b3abf45e2d8f3b1a950738f52e9600746a0e27a55a21"), &schedule.client_handshake_traffic);
-    try expectStage("tls13 server handshake traffic secret / RFC 8448", &hexBytes("b67b7d690cc16c4e75e54213cb2d37b4e9c912bcded9105d42befd59d391ad38"), &schedule.server_handshake_traffic);
-    try expectStage("tls13 master secret / RFC 8448", &hexBytes("18df06843d13a08bf2a449844c5f8a478001bc4d4c627984d5a41da8d0402919"), &schedule.master_secret);
+    try expectStage("tls13 handshake secret / RFC 8448", &hexBytes("1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac"), schedule.handshake_secret[0..32]);
+    try expectStage("tls13 client handshake traffic secret / RFC 8448", &hexBytes("b3eddb126e067f35a780b3abf45e2d8f3b1a950738f52e9600746a0e27a55a21"), schedule.client_handshake_traffic[0..32]);
+    try expectStage("tls13 server handshake traffic secret / RFC 8448", &hexBytes("b67b7d690cc16c4e75e54213cb2d37b4e9c912bcded9105d42befd59d391ad38"), schedule.server_handshake_traffic[0..32]);
+    try expectStage("tls13 master secret / RFC 8448", &hexBytes("18df06843d13a08bf2a449844c5f8a478001bc4d4c627984d5a41da8d0402919"), schedule.master_secret[0..32]);
 
     const finished_hash = hexBytes("9608102a0f1ccc6db6250b7b7e417b1a000eaada3daae4777a7686c9ff83df13");
-    var app = try schedule.applicationSecrets(finished_hash);
+    var app = try schedule.applicationSecrets(&finished_hash);
     defer app.wipe();
-    try expectStage("tls13 client application traffic secret / RFC 8448", &hexBytes("9e40646ce79a7f9dc05af8889bce6552875afa0b06df0087f792ebb7c17504a5"), &app.client);
-    try expectStage("tls13 server application traffic secret / RFC 8448", &hexBytes("a11af9f05531f856ad47116b45a950328204b4f44bfb6b3a4b4f1f3fcb631643"), &app.server);
-    var finished_key = try KeySchedule.finishedKey(cp, &schedule.server_handshake_traffic);
+    try expectStage("tls13 client application traffic secret / RFC 8448", &hexBytes("9e40646ce79a7f9dc05af8889bce6552875afa0b06df0087f792ebb7c17504a5"), app.clientSecret());
+    try expectStage("tls13 server application traffic secret / RFC 8448", &hexBytes("a11af9f05531f856ad47116b45a950328204b4f44bfb6b3a4b4f1f3fcb631643"), app.serverSecret());
+    var finished_key: [32]u8 = undefined;
+    try KeySchedule.finishedKey(cp, .sha256, schedule.server_handshake_traffic[0..32], &finished_key);
     defer std.crypto.secureZero(u8, &finished_key);
     try expectStage("tls13 server Finished key / RFC 8448", &hexBytes("008d3b66f816ea559f96b537e885c31fc068bf492c652f01f288a1d8cdc19fc8"), &finished_key);
-    var verify_data = try KeySchedule.verifyData(cp, &schedule.server_handshake_traffic, finished_hash);
+    var verify_data: [32]u8 = undefined;
+    try KeySchedule.verifyData(cp, .sha256, schedule.server_handshake_traffic[0..32], &finished_hash, &verify_data);
     defer std.crypto.secureZero(u8, &verify_data);
     try expectStage("tls13 server Finished verify_data / RFC 8448", &hexBytes("c5486af1426697c43c18dab6a79ef816a2188023ea743133b7e3b15a2c05c955"), &verify_data);
 }
@@ -333,18 +335,22 @@ fn runTranscriptVector(log: *ExecutionLog) !void {
     const client_hello_2 = hexBytes("01000002ddee");
 
     var transcript = Transcript{};
-    transcript.update(&client_hello_1);
+    transcript.selectFamily(.sha256);
+    try transcript.update(&client_hello_1);
     const ch1_hash = hexBytes("93e26e55d8fd5b5236e00556a269142fc88e0d9616836ca9b8607841ac0287a0");
-    try expectStage("tls transcript ClientHello1 hash", &ch1_hash, &transcript.peek());
+    try expectStage("tls transcript ClientHello1 hash", &ch1_hash, transcript.peek().slice());
 
-    transcript.replace(ch1_hash);
-    try expectStage("tls transcript HRR synthetic message_hash", &hexBytes("42a5f8938f2b4f45f63df268cf67218045831c80b841bdb54f46afefceee6218"), &transcript.peek());
+    var ch1_digest = tls_core.transcript.Digest{};
+    ch1_digest.len = ch1_hash.len;
+    @memcpy(ch1_digest.bytes[0..ch1_hash.len], &ch1_hash);
+    transcript.replace(ch1_digest);
+    try expectStage("tls transcript HRR synthetic message_hash", &hexBytes("42a5f8938f2b4f45f63df268cf67218045831c80b841bdb54f46afefceee6218"), transcript.peek().slice());
 
-    transcript.update(&hello_retry_request);
-    try expectStage("tls transcript after HelloRetryRequest", &hexBytes("cb0a3fbd3c60144a08852ceb18f319fd65f5b352026cb23036f568a209d6a036"), &transcript.peek());
+    try transcript.update(&hello_retry_request);
+    try expectStage("tls transcript after HelloRetryRequest", &hexBytes("cb0a3fbd3c60144a08852ceb18f319fd65f5b352026cb23036f568a209d6a036"), transcript.peek().slice());
 
-    transcript.update(&client_hello_2);
-    try expectStage("tls transcript after ClientHello2", &hexBytes("7ec9461d8bac7434b8ae63e99899d1ef75ce0b716c9ee12aadd5f5837e51d182"), &transcript.peek());
+    try transcript.update(&client_hello_2);
+    try expectStage("tls transcript after ClientHello2", &hexBytes("7ec9461d8bac7434b8ae63e99899d1ef75ce0b716c9ee12aadd5f5837e51d182"), transcript.peek().slice());
 }
 
 fn runTlsRecordVector(log: *ExecutionLog) !void {


### PR DESCRIPTION
## Summary

Makes the transport-neutral TLS 1.3 handshake, transcript, key schedule, PSK/Finished path, and secret-export contract follow the negotiated cipher suite's hash family, so the native engine can complete record-mode handshakes for `TLS_AES_256_GCM_SHA384` and `TLS_CHACHA20_POLY1305_SHA256` in addition to the existing `TLS_AES_128_GCM_SHA256` baseline — without duplicating protocol state machines. QUIC packet/header protection is out of scope (separate child issue per #335), and X25519 remains the only key-exchange group (per #563).

- **`transcript.zig`**: replaced the fixed-SHA-256 `Transcript` with a hash-agile one (SHA-256/SHA-384). The negotiated hash isn't known when the very first transcript bytes arrive (server learns it while parsing ClientHello; client learns it only from the server's response, after `Core` has already fed those bytes in) — `update`/`rebindClientHello` transparently buffer at most one framed handshake message until `selectFamily` runs, then replay it into the real hash. Never panics on attacker-controlled input (`error.TranscriptOverflow` instead of an assert).
- **`key_schedule.zig`**: `KeySchedule` and its Finished/early-traffic-secret helpers now take an explicit `provider.Hash` and use `max_digest_len`-bounded storage instead of a fixed 32-byte schedule. The SHA-256 zero-PSK comptime fast path is preserved byte-for-byte (and stays within `scripts/audit_crypto_boundary.zig`'s exact-text allowlist); SHA-384 derives the same value through the provider at runtime.
- **`events.zig` / `transport.zig`**: new `negotiated_parameters` event (cipher suite + transcript hash), emitted exactly once per connection before any `handshake`-epoch traffic secret, on both full and resumed handshakes. `record_epoch_bridge.Bridge` consumes it to pick the right AEAD for `record_protection.TrafficKeys.derive` — no second AES-256/ChaCha record implementation.
- **`tls13_backend.zig`**: negotiates all three suites, validates the live `CryptoProvider`'s capability for the full suite tuple (AEAD + hash + HKDF) before selection, and threads the negotiated hash through every Finished/CertificateVerify/PSK-binder/resumption call site (including per-ticket hash for offered PSKs, since a resumption ticket's own hash can differ from the suite about to be negotiated).
- **`crypto/profile.zig`, `tls/crypto_profile.zig`, `docs/CRYPTO_PROVIDER.md`**: updated to reflect that AES-256-GCM, ChaCha20-Poly1305, SHA-384, and HKDF-SHA384 are now live (not just provider-capable) for the native appliance product profile.

## Test plan

- [x] `zig build test` — full suite passes, including new SHA-384 key-schedule/transcript known-answer vectors (computed independently via Python, not the code under test) and 3 new native record-mode client/server loopback tests (AES-128-GCM/SHA-256 baseline, AES-256-GCM/SHA-384, ChaCha20-Poly1305/SHA-256) verifying negotiated suite/hash, matching transcripts across roles, and successful encrypted application-data round trips.
- [x] `zig build audit-crypto-boundary` — passes; no new direct keyed-crypto call sites outside the provider seam.
- [x] Existing HRR, resumption, 0-RTT, and client-auth coverage in `tls13_backend_tests.zig` still passes unmodified (aside from mechanical `Digest`/`SecretSnapshot` API updates for the now-variable digest length).

Closes #564