### PR TITLE
security: build shared crypto fuzzing contract and provider targets (327-G4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable user-facing changes to Tardigrade are documented here.
 
 ## [Unreleased]
 
+### Testing
+- **Shared crypto fuzzing contract and CryptoProvider fuzz targets (#376,
+  epic #327-G)** — adds `docs/CRYPTO_FUZZ_CONTRACT.md`, the shared
+  deterministic-reproduction/bounded-work/arithmetic-safety/lifetime/secret-
+  diagnostics/regression-minimization contract that #491–#494's future
+  protocol-level fuzzing stories consume, plus standalone `std.testing.Smith`
+  fuzz targets and deterministic regressions in
+  `tests/crypto_provider_fuzz.zig` for the `CryptoProvider` boundary itself:
+  AEAD seal/open (wrong-length fields, tamper/zeroization-on-auth-failure,
+  zero/bounded-max plaintext), key exchange (`generateKeyShare`/
+  `deriveSharedSecret` wrong-length and output-buffer fuzzing for X25519 and
+  secp256r1), signature verification (malformed key/signature encodings,
+  tampered signatures, wrong message/key for Ed25519, ECDSA-P256/SHA-256, and
+  RSA-PSS-RSAE/SHA-256), the software signing-key boundary (undersized output
+  buffers, `deinit` zeroization), and the shared `FixedSecret`/`BoundedSecret`
+  containers (including allocator-failure injection via
+  `std.testing.FailingAllocator`). Wired into `zig build test` via the new
+  `test-crypto-provider-fuzz` step and a `-Dcrypto-test-filter` build option
+  for targeted longer coverage-guided runs.
+
 ### Features
 - **QUIC negotiated TLS suite packet protection (#566)** — Handshake, 0-RTT,
   and 1-RTT packet protection now follows the TLS 1.3 cipher suite negotiated

--- a/build.zig
+++ b/build.zig
@@ -20,6 +20,8 @@ pub fn build(b: *std.Build) void {
     const go_bin = b.option([]const u8, "go-bin", "Go command used to build the PKI crypto/x509 oracle") orelse "go";
     const quic_test_filter = b.option([]const u8, "quic-test-filter", "Filter tests run by the test-quic step");
     const quic_test_filters: []const []const u8 = if (quic_test_filter) |filter| &.{filter} else &.{};
+    const crypto_test_filter = b.option([]const u8, "crypto-test-filter", "Filter tests run by the test-crypto-provider-fuzz step");
+    const crypto_test_filters: []const []const u8 = if (crypto_test_filter) |filter| &.{filter} else &.{};
     const tls_profile = b.option(
         TlsProfile,
         "tls-profile",
@@ -538,6 +540,25 @@ pub fn build(b: *std.Build) void {
     crypto_corpus_step.dependOn(&run_crypto_corpus_tests.step);
     crypto_step.dependOn(&run_crypto_corpus_tests.step);
     test_step.dependOn(&run_crypto_corpus_tests.step);
+
+    // Standalone CryptoProvider fuzz targets (#376, epic #327-G): AEAD,
+    // key exchange, signature verification, signing-key boundary, and
+    // shared secret container properties, following the shared fuzz
+    // contract in docs/CRYPTO_FUZZ_CONTRACT.md. Deterministic seed-corpus
+    // replay runs by default; `-Doptimize=ReleaseFast --fuzz=<N>` drives
+    // real coverage-guided exploration, matching docs/QUIC_H3_FUZZ_MATRIX.md.
+    const crypto_provider_fuzz_mod = b.createModule(.{
+        .root_source_file = b.path("tests/crypto_provider_fuzz.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    crypto_provider_fuzz_mod.addImport("crypto", crypto_mod);
+    const crypto_provider_fuzz_tests = b.addTest(.{ .root_module = crypto_provider_fuzz_mod, .filters = crypto_test_filters });
+    const run_crypto_provider_fuzz_tests = b.addRunArtifact(crypto_provider_fuzz_tests);
+    const crypto_provider_fuzz_step = b.step("test-crypto-provider-fuzz", "Run standalone CryptoProvider AEAD/KEX/verify/signing-key/secret-helper fuzz targets (#376)");
+    crypto_provider_fuzz_step.dependOn(&run_crypto_provider_fuzz_tests.step);
+    crypto_step.dependOn(&run_crypto_provider_fuzz_tests.step);
+    test_step.dependOn(&run_crypto_provider_fuzz_tests.step);
 
     // A direct TLS-owned backend handshake through the record stack. This is a
     // standalone module because it uses socket-pair carriers and the concrete

--- a/docs/CRYPTO_FUZZ_CONTRACT.md
+++ b/docs/CRYPTO_FUZZ_CONTRACT.md
@@ -63,45 +63,82 @@ growing this one.
 This is the concrete workflow #491–#494 should follow too, rather than each
 inventing their own.
 
-1. **Reproduce and identify the case.** A `--fuzz=<N>` run that finds a
-   failure fails the `zig build` step and prints the panic/error and Zig's
-   own `test "fuzz: <name>"` name plus its run count in the `FUZZING
-   REPORT` block — that name is the target's deterministic case ID
-   (`Deterministic reproduction` above). Re-run the exact same command
-   (same target, same `-Dcrypto-test-filter`, same `-Doptimize`) to confirm
-   the failure reproduces; Zig's fuzz engine is deterministic given the same
-   binary and inputs.
-2. **Choose the minimization form.**
-   - **Prefer a named deterministic `test` block** next to the fuzz target
-     when the failure has clear structure (a specific field's wrong length,
-     a specific tamper, a specific boundary value) — this is what every
-     deterministic regression in `tests/crypto_provider_fuzz.zig` already
-     is, and it stays reviewable years later the way a raw byte blob does
-     not.
-   - **Add a raw entry to the target's `.corpus = &.{...}` array** only when
-     the failure is genuinely opaque (no clean semantic story) and the exact
-     bytes matter. To capture those bytes: temporarily add a
-     `std.debug.print` of the sampled lengths/enum choice/raw slices
-     immediately before the failing `CryptoProvider` (or `secrets`) call
-     inside the target, re-run the same failing case to trigger the print,
-     copy the reported values, then remove the temporary print. Encode the
-     captured bytes as a Zig string literal using `\xNN` escapes for any
-     non-printable byte (see the existing corpus entries in this file for
-     the style) and add it to `.corpus`.
-3. **Never store real secret material.** Every target in this file
+1. **Capture the exact crash input, not a description of it.** A `--fuzz=<N>`
+   run that finds a failure persists the exact failing `Smith` byte input
+   through Zig's own fuzz engine (the memory-mapped/corpus-backed input the
+   coverage-guided runner uses to recover crashing values, per the [Zig
+   0.16 release notes' fuzzer
+   section](https://ziglang.org/download/0.16.0/release-notes.html#Fuzzer)).
+   The `test "fuzz: <name>"` name Zig prints identifies the *target*, and a
+   `FUZZING REPORT` run count is not a stable case ID — re-running the same
+   coverage-guided command is exploration, not an exact replay. Do not
+   substitute a `std.debug.print` of the *values sampled from* the Smith
+   stream (lengths, enum choices, etc.): those are derived data, not the
+   input itself, and cannot be fed back into `.corpus` to reproduce the
+   same run deterministically. Copy the crash input file Zig's fuzzer
+   reports into a stable checked-in fixture instead:
+   `tests/vectors/fuzz/crypto/<target-slug>/<sha256-of-the-file>.bin`, where
+   `<target-slug>` is a short slug for the target (e.g. `aead-open`,
+   `derive-shared-secret`, `verify`, `fixed-secret`, `bounded-secret`). The
+   SHA-256 digest is both the filename and the deterministic case ID/
+   provenance record — identical bytes always hash to the same fixture name,
+   so a duplicate find is a no-op rather than a second copy.
+2. **Wire it back in with `@embedFile`, always.** Every checked-in crash
+   fixture is added to its target's `.corpus` as `@embedFile`, never
+   hand-transcribed as a string literal (transcription is exactly the kind
+   of lossy transcription step 1 rules out):
+   ```zig
+   try std.testing.fuzz({}, fuzzAeadOpen, .{ .corpus = &.{
+       "",
+       // Found 2026-08-04, zig build test-crypto-provider-fuzz
+       // -Doptimize=ReleaseFast -Dcrypto-test-filter="fuzz: AEAD open ..." --fuzz=50M
+       @embedFile("vectors/fuzz/crypto/aead-open/1f3c9a7e...bin"),
+   } });
+   ```
+   Replay it immediately with the *same* target's filtered non-`--fuzz`
+   command (below) to confirm it reproduces deterministically before doing
+   anything else with it.
+3. **Minimize, then decide what to keep.** Reduce the fixture by repeatedly
+   trimming/simplifying its bytes and re-running the same filtered replay
+   command until it stops reproducing the failure, keeping the last input
+   that still did (manual delta-debugging; Zig 0.16 does not ship an
+   automatic minimizer for this workflow). Once the minimal failing input is
+   understood:
+   - If it has a clean semantic story (a specific field's wrong length, a
+     specific tamper, a specific boundary value), translate it into a named
+     deterministic `test` block next to the target — this is what every
+     regression in `tests/crypto_provider_fuzz.zig` already is, and it
+     stays reviewable in a way a byte blob does not. Only remove the raw
+     `.corpus`/`@embedFile` fixture once that named regression has been
+     confirmed to fail against the pre-fix code and pass against the fix
+     (i.e. it exercises the same defect, not a superficially similar one).
+   - If it has no clean semantic story (the exact bytes matter and cannot be
+     reduced to a short description), keep the minimized fixture itself as
+     the permanent regression via `@embedFile`, re-hashing and renaming the
+     file to match its minimized content.
+4. **Never store real secret material.** Every target in this file
    synthesizes or derives its own key material per case from injected
    deterministic entropy — callers never hand it a real production secret —
-   so captured bytes are inherently synthetic/malformed wire-shaped input,
-   never a real private key, certificate, or traffic capture. Corpus entries
-   and regression fixtures must stay that way: hand-crafted or fuzzer-found
-   malformed input only, never copied from a real deployment.
-4. **Record provenance.** Add a one-line comment directly above the new
-   corpus entry or regression test noting when it was found and which
-   command found it (e.g. `-Doptimize=ReleaseFast --fuzz=10M`), so a future
-   reader can tell a hand-written edge case from a fuzzer-discovered one.
-5. **Verify before committing.** Both must pass:
+   so a captured fixture is inherently synthetic/malformed wire-shaped
+   input, never a real private key, certificate, or traffic capture. Corpus
+   fixtures and regression tests must stay that way: hand-crafted or
+   fuzzer-found malformed input only, never copied from a real deployment.
+5. **Record provenance.** Add a one-line comment directly above the new
+   `.corpus`/`@embedFile` entry or regression test (see the example in step
+   2) noting when it was found and which command found it, so a future
+   reader can tell a hand-written edge case from a fuzzer-discovered one;
+   the SHA-256 filename itself is the immutable half of that record.
+6. **Verify before committing, and pick the right command for the artifact.**
+   A raw `.corpus`/`@embedFile` fixture is replayed by the *fuzz test's own*
+   filter; a named deterministic regression is a separate `test` and needs
+   its *own* name filtered instead (or the whole step, unfiltered) — the
+   fuzz-target filter will not run it:
    ```bash
+   # Corpus/@embedFile fixture: filter on the fuzz target that owns it.
    zig build test-crypto-provider-fuzz -Dcrypto-test-filter="fuzz: <exact target name>" --summary all --error-style verbose
+   # Named deterministic regression: filter on the regression's own name.
+   zig build test-crypto-provider-fuzz -Dcrypto-test-filter="<exact regression test name>" --summary all --error-style verbose
+   # Always, regardless of artifact type:
    zig build test --summary all --error-style verbose
    ```
    The first confirms the new corpus entry or regression reproduces
@@ -119,13 +156,15 @@ Every target under epic #327-G — this story's provider targets and
 Every failure must identify:
 
 - the target name (the `test "fuzz: ..."` name Zig's runner already prints);
-- a deterministic seed/case ID (the minimized input Zig's fuzz runner
-  reports, or the checked-in corpus entry index);
+- a deterministic case ID — the SHA-256 digest of the checked-in
+  `@embedFile` fixture, or the named regression `test`'s own name; a
+  `FUZZING REPORT` run count is not one (see "Seed-corpus and regression
+  update procedure" above);
 - input length;
 - a typed stage/failure class (which operation and which error variant, not
   a bare panic message);
-- the exact local reproduction command (the commands above, optionally with
-  `-Dcrypto-test-filter` narrowed to the failing test name).
+- the exact local reproduction command (the filtered commands in "Seed-corpus
+  and regression update procedure" above, chosen by artifact type).
 
 Identical input/configuration must produce identical target behavior unless
 the target explicitly injects a deterministic clock/entropy stream. Every
@@ -234,13 +273,19 @@ posture (`docs/CRYPTO_SECURITY_AUDIT.md`).
 
 Every deterministic crash, panic, invariant violation, lifetime failure, or
 semantic bug this story's targets find is checked in as a permanent
-deterministic `test` block next to the fuzz target in
-`tests/crypto_provider_fuzz.zig` (inline regression, the same pattern
-`docs/QUIC_H3_FUZZ_MATRIX.md` uses — there is no generic top-level
-`regression/` directory in this repo; PKI's `tests/vectors/pki/reduced/`
-manifest pattern is the one exception, reserved for #492's semantic
-certificate corpus). Do not fix a reproducible deterministic failure by
-adding a skip; fix the defect or the test's understanding of the contract.
+regression, in the form the "Seed-corpus and regression update procedure"
+above prefers for it: normally an inline deterministic `test` block next to
+the fuzz target in `tests/crypto_provider_fuzz.zig` (the same pattern
+`docs/QUIC_H3_FUZZ_MATRIX.md` uses), or — only when the failure has no clean
+semantic story and the exact bytes matter — a checked-in
+`tests/vectors/fuzz/crypto/<target-slug>/<sha256>.bin` fixture wired back in
+through `@embedFile`. There is no generic top-level `regression/` directory
+in this repo; `tests/vectors/fuzz/crypto/` and PKI's
+`tests/vectors/pki/reduced/` manifest pattern (reserved for #492's semantic
+certificate corpus) are the two directory-backed exceptions to the
+inline-`test`-block default. Do not fix a reproducible deterministic failure
+by adding a skip; fix the defect or the test's understanding of the
+contract.
 
 ## Provider targets owned here
 

--- a/docs/CRYPTO_FUZZ_CONTRACT.md
+++ b/docs/CRYPTO_FUZZ_CONTRACT.md
@@ -1,0 +1,239 @@
+# Shared crypto fuzzing contract and provider targets (#376, epic #327-G)
+
+This is the shared fuzzing contract for the native TLS program's crypto
+surfaces. It defines the rules every fuzz target under epic #327-G must
+follow, and owns the standalone targets for the `CryptoProvider` boundary
+itself (AEAD, key exchange, signature verification, signing keys, and the
+shared secret containers). Protocol-specific fuzzing is owned by the epics
+that own those protocol surfaces and must consume this contract rather than
+inventing incompatible rules:
+
+- #491 — shared TLS handshake / negotiation / transcript / reassembly (#323)
+- #492 — DER / PEM / X.509 / path validation (#324)
+- #493 — TLS record / protection / encrypted-stream (#325)
+- #494 — session / PSK / ticket / resumption state (#326)
+- #247 — QUIC/H3 packet/frame/transport/QPACK/H3 validation
+
+This story does not re-implement those targets. Its own targets stop at the
+provider seam (`src/crypto/provider.zig`, `src/crypto/pure_zig.zig`,
+`src/crypto/rsa.zig`, `src/crypto/secrets.zig`): malformed input that can
+reach `CryptoProvider` directly, without needing a protocol state machine.
+
+## Existing fuzzing pattern in this repo
+
+There is no separate `fuzz/` tree. Fuzzing is inline `test "fuzz: ..."`
+blocks using Zig 0.16's built-in `std.testing.fuzz`/`std.testing.Smith`,
+next to the code they exercise or in a focused `tests/*.zig` file, each with
+a checked-in seed corpus passed as `.corpus = &.{...}`. Under a normal
+`zig build test` this deterministically replays only the seed corpus; under
+`zig build <step> -Doptimize=ReleaseFast --fuzz=<N>` it becomes real
+coverage-guided mutation. This mirrors `docs/QUIC_H3_FUZZ_MATRIX.md`'s
+program for QUIC/H3 (#247/#537); this document is the equivalent for the
+shared crypto surfaces.
+
+## Commands
+
+```bash
+# Deterministic smoke coverage (seed corpus replay only) — part of the
+# default `zig build test` and CI.
+zig build test-crypto --summary all --error-style verbose
+
+# The standalone provider-boundary targets owned by this story:
+zig build test-crypto-provider-fuzz --summary all --error-style verbose
+
+# Longer local/scheduled coverage-guided runs:
+zig build test-crypto-provider-fuzz -Doptimize=ReleaseFast --fuzz=10M --summary all --error-style verbose
+zig build test-crypto-provider-fuzz -Doptimize=ReleaseFast -Dcrypto-test-filter="fuzz: AEAD open" --fuzz=10M --summary all --error-style verbose
+zig build test-crypto-provider-fuzz -Doptimize=ReleaseFast -Dcrypto-test-filter="fuzz: deriveSharedSecret" --fuzz=10M --summary all --error-style verbose
+zig build test-crypto-provider-fuzz -Doptimize=ReleaseFast -Dcrypto-test-filter="fuzz: verify" --fuzz=10M --summary all --error-style verbose
+zig build test-crypto-provider-fuzz -Doptimize=ReleaseFast -Dcrypto-test-filter="fuzz: generateKeyShare" --fuzz=10M --summary all --error-style verbose
+zig build test-crypto-provider-fuzz -Doptimize=ReleaseFast -Dcrypto-test-filter="fuzz: FixedSecret" --fuzz=10M --summary all --error-style verbose
+zig build test-crypto-provider-fuzz -Doptimize=ReleaseFast -Dcrypto-test-filter="fuzz: BoundedSecret" --fuzz=10M --summary all --error-style verbose
+```
+
+`-Dcrypto-test-filter` (added alongside the existing `-Dquic-test-filter`)
+gives explicit target selection for the `test-crypto-provider-fuzz` step; the
+`--fuzz=<runs>` limit keeps scheduled runs bounded (`K`/`M`/`G` suffixes
+scale it). #491–#494 should add their own protocol-scoped test steps and
+`-D<area>-test-filter` options following the same pattern rather than
+growing this one.
+
+## The shared contract
+
+Every target under epic #327-G — this story's provider targets and
+#491–#494's protocol targets alike — must satisfy the following.
+
+### Deterministic reproduction
+
+Every failure must identify:
+
+- the target name (the `test "fuzz: ..."` name Zig's runner already prints);
+- a deterministic seed/case ID (the minimized input Zig's fuzz runner
+  reports, or the checked-in corpus entry index);
+- input length;
+- a typed stage/failure class (which operation and which error variant, not
+  a bare panic message);
+- the exact local reproduction command (the commands above, optionally with
+  `-Dcrypto-test-filter` narrowed to the failing test name).
+
+Identical input/configuration must produce identical target behavior unless
+the target explicitly injects a deterministic clock/entropy stream. Every
+target in this file drives `pure_zig.Provider` through the injected
+`provider.Entropy` seam only (`pure_zig.DeterministicEntropy` in tests) —
+never ambient randomness — so this holds by construction.
+
+### Bounded work
+
+Every target defines explicit limits for the dimensions it can amplify. For
+the provider targets in this file that means: input bytes are read from
+`std.testing.Smith` into fixed-capacity stack buffers (never an unbounded
+`ArrayList`), so a target cannot be driven into an unbounded allocation by
+attacker-controlled length fields. There is no nesting/recursion, no graph
+exploration, and no allocation inside the hot path of AEAD/KEX/verify calls
+— the provider's own contract keeps those operations O(input length). The
+`BoundedSecret` property targets are the one place with real allocation, and
+they bound capacity to a small fixed maximum (see the test file) and always
+`deinit` before the next iteration.
+
+### Arithmetic safety
+
+Provider inputs are lengths and byte buffers, not wire-encoded variable-width
+integers, so most of the classic overflow-adjacent boundaries reduce to
+buffer-length boundaries. Targets and their deterministic regressions cover:
+
+- zero-length keys/nonces/tags/AD/plaintext/ciphertext and zero-length
+  signatures/public keys;
+- exact, one-under, and one-over the algorithm's required length for every
+  fixed-size field (AEAD key/nonce/tag, key-exchange public value/private
+  scalar/shared secret, fixed-length signature encodings);
+- a harness-chosen bounded "maximum" plaintext/message length, since AEAD and
+  signing have no wire-defined upper bound the way a DER length or QUIC
+  varint does.
+
+Checked add/subtract/multiply around offsets, padding, and record/ticket/DER
+lengths belongs to #491–#494 and #492 (those are the modules that actually
+compute such offsets); this file's targets never perform that arithmetic —
+`CryptoProvider` calls take already-sliced buffers.
+
+### Lifetime / borrowed-slice safety
+
+The provider boundary is explicit about this in its own doc comment
+(`src/crypto/provider.zig`, "Secrets are borrowed, never retained"): every
+slice a caller hands in is valid only for the call's duration, and the sole
+provider-owned secret is the opaque `SigningKey` handle. This file's targets
+exercise that contract:
+
+- `deinit`/destruction after both success and failure leaves no usable
+  private key: `SoftwareSigningKey`/`SoftwareEcdsaP256SigningKey` wipe
+  `key_pair.secret_key` in place (stack-resident, directly inspectable after
+  `deinit`); `SoftwareRsaSigningKey`/`rsa.PrivateKey` route through
+  `secrets.secureZeroAndFree` (heap-resident, inspected via a
+  `FixedBufferAllocator` the same way `src/crypto/secrets.zig`'s own
+  `BoundedSecret` tests do);
+- owned results (a returned shared secret, a returned signature) remain
+  stable in the caller's buffer after the call returns — nothing the
+  provider does later can invalidate them, because the provider retains no
+  pointer into caller-owned output;
+- borrowed results are never used outside their owner's lifetime — this is
+  structurally enforced here because every provider operation is a single
+  synchronous call with no retained borrow, not a stateful handle;
+  `SigningKey` is the one exception and it is the type these `deinit` tests
+  target;
+- allocation-failure and early-return cleanup: the `BoundedSecret` property
+  target injects allocator failure at random points via
+  `std.testing.FailingAllocator` and asserts no leak (`std.testing.allocator`
+  wraps every non-injecting path) and no partially-initialized secret escapes
+  a failed `init`;
+- partial outputs are not retained after a failed transactional operation:
+  AEAD `open` never leaves usable plaintext after `error.AuthenticationFailed`
+  (see below), and every `SigningKey.sign` implementation checks the output
+  buffer length *before* drawing entropy or computing anything, so a rejected
+  call never partially fills `out`.
+
+### Read/write/reentrancy separation
+
+Not applicable to this story's own targets: every `CryptoProvider` operation
+is a single synchronous, non-reentrant call with no network I/O, no output
+event carrier, and no partial-progress state to resume. State machines with
+this shape (TLS transcript, QUIC CRYPTO reassembly, H3 request state) are
+owned by #491/#493/#494/#247, which must apply this rule themselves.
+
+### Secret-safe diagnostics
+
+No target in this file ever formats or logs a `SigningKey`, `FixedSecret`,
+`BoundedSecret`, private scalar, or shared secret — `format` is a compile
+error on every secret-bearing type already (`@compileError("secret values
+must not be formatted or logged")` in `secrets.zig` and each
+`Software*SigningKey`), so a target that tried would fail to compile, not
+just fail to review-catch. Failure output uses case IDs, public lengths,
+algorithm/scheme names, and typed error variants, matching #375's audit
+posture (`docs/CRYPTO_SECURITY_AUDIT.md`).
+
+### Regression minimization
+
+Every deterministic crash, panic, invariant violation, lifetime failure, or
+semantic bug this story's targets find is checked in as a permanent
+deterministic `test` block next to the fuzz target in
+`tests/crypto_provider_fuzz.zig` (inline regression, the same pattern
+`docs/QUIC_H3_FUZZ_MATRIX.md` uses — there is no generic top-level
+`regression/` directory in this repo; PKI's `tests/vectors/pki/reduced/`
+manifest pattern is the one exception, reserved for #492's semantic
+certificate corpus). Do not fix a reproducible deterministic failure by
+adding a skip; fix the defect or the test's understanding of the contract.
+
+## Provider targets owned here
+
+`tests/crypto_provider_fuzz.zig` drives the real `pure_zig.Provider` (never a
+mock) through `provider.CryptoProvider`, following the same three-tier shape
+`tests/security/request_parser_corpus.zig` established: deterministic
+regression tests for named edge cases, plus a `std.testing.Smith`-driven
+generative `fuzz:` target with a seed corpus for each surface below. It
+complements rather than duplicates the deep existing deterministic coverage
+already in `src/crypto/pure_zig.zig`, `src/crypto/rsa.zig`, and
+`src/crypto/secrets.zig` (key-share buffer sizing, ECDSA/RSA entropy-failure
+and malformed-scalar rejection, `BoundedSecret` allocator-observable
+zeroization, etc.) — this file adds the pieces that were missing: the
+generative fuzz harnesses themselves, plus a small number of genuine
+deterministic gaps identified while wiring them up.
+
+| Area | Target | Properties covered | Open follow-up |
+| --- | --- | --- | --- |
+| AEAD seal/open | `tests/crypto_provider_fuzz.zig` `fuzz: AEAD open never leaves unauthenticated plaintext on arbitrary key/nonce/tag/ciphertext/AD`; deterministic wrong-length, tamper-zeroization, and zero/max-length regressions | Wrong key/nonce/tag length, ciphertext/plaintext length mismatch, truncated/mutated ciphertext/tag/AD rejected as `AuthenticationFailed` with the plaintext buffer fully zeroed, zero-length and harness-bounded maximum-length plaintext round-trip, for all three supported AEADs. | Overlap/alias behavior between `ciphertext` and `plaintext` buffers is not part of the documented provider contract today (`provider.zig`'s `aeadSeal`/`aeadOpen` doc comments are silent on aliasing); add coverage once that contract is decided rather than asserting undocumented behavior. |
+| Key exchange | `tests/crypto_provider_fuzz.zig` `fuzz: deriveSharedSecret never panics on arbitrary scalar and peer-public bytes`; `fuzz: generateKeyShare never panics on arbitrary output-buffer lengths`; deterministic wrong-length and output-buffer-bound regressions | Wrong-length private scalars, peer public keys, and output buffers rejected as `InvalidInput` for X25519 and secp256r1; output-buffer-length fuzzing for key-share generation. Complements the existing low-order/all-zero-point and malformed-scalar coverage already in `pure_zig.zig`. | Positive round-trip and deterministic/failing-entropy-during-keygen coverage already exists in `pure_zig.zig` (`"X25519 key shares agree..."`, `"secp256r1 key-share generation rejects bad buffers before entropy and handles entropy failure"`); not duplicated here. |
+| Signature verification | `tests/crypto_provider_fuzz.zig` `fuzz: verify never panics on arbitrary public key, message, and signature bytes`; deterministic malformed-key, malformed-signature, tampered-signature, and wrong-message/key regressions | Malformed public-key and signature encodings, structurally-valid single-bit-modified signatures, wrong message, and wrong key rejected without panic for Ed25519, ECDSA-P256/SHA-256, and RSA-PSS-RSAE/SHA-256, using `rsa.testdata`'s fixed RSA-2048 fixture as seed/provenance material rather than re-deriving key material. | None for the current provider `verify` surface. |
+| Signing-key boundary | `tests/crypto_provider_fuzz.zig` deterministic undersized-output-buffer and deinit-wipe regressions for all three software signing-key types | Undersized output buffers rejected before any entropy draw or computation, output buffer left untouched, for Ed25519 (new — the ECDSA/RSA equivalents already existed in `pure_zig.zig`); `deinit` wipes the retained private key bytes for `SoftwareSigningKey` and `SoftwareEcdsaP256SigningKey` (RSA's equivalent already exists as `rsa.zig`'s `"PrivateKey.deinit wipes the retained private exponent"`). | Malformed constructor/import input and entropy-failure coverage already exists per-type in `pure_zig.zig`/`rsa.zig`; not duplicated here. |
+| Shared secret helpers | `tests/crypto_provider_fuzz.zig` `fuzz: FixedSecret replace/eql/deinit preserve invariants under arbitrary overlapping and non-overlapping input`; `fuzz: BoundedSecret replace/eql/deinit preserve invariants under arbitrary capacity and allocator-failure injection` | `FixedSecret`/`BoundedSecret` `replace`/`copy`/`eql`/`deinit` across randomized capacities, content, and self-overlapping slices; `BoundedSecret` allocation-failure injection via `std.testing.FailingAllocator` with no leak under `std.testing.allocator` and no partially-initialized secret escaping a failed `init`. | `constantTimeEqual`'s functional behavior (equal/unequal/length-mismatch) and the `format`-is-a-compile-error guard are already covered deterministically in `secrets.zig` and `provider.zig`; not duplicated here. |
+
+## Ownership boundaries
+
+Same boundaries as the parent issue, restated for anyone landing on this
+document directly:
+
+- **#491** owns handshake message/extensions, canonical negotiation/policy,
+  transcript/HRR/ClientHello2 state, and shared TLS reassembly.
+- **#492** owns DER/PEM/X.509 semantic parsing, path building/validation,
+  graph/resource bounds, and hostile certificate seed reuse.
+- **#493** owns record codec/protection, epoch lifecycle, encrypted-stream
+  buffering/progression, partial I/O, and authentication-failure record
+  behavior.
+- **#494** owns `NewSessionTicket`, PSK/binder handling, session
+  codecs/cache, protected ticket envelopes/keyrings, resolver/runtime
+  selection, and resumption state lifetime.
+- **#247** owns QUIC packet/frame/transport-parameter/token/CRYPTO/ACK/
+  stream/QPACK/H3 transport fuzzing and related interop/benchmark harnesses.
+
+Do not pull those concerns back into this story merely because their
+implementation consumes cryptography, and do not have this story re-fuzz a
+protocol module's own state machine — call `CryptoProvider` directly instead.
+
+## CI model
+
+`zig build test` (and therefore every CI job that runs it, per
+`.github/workflows/ci.yml`) already includes `test-crypto-provider-fuzz`'s
+deterministic seed-corpus replay — no separate CI job was added. Longer
+coverage-guided runs use the `-Doptimize=ReleaseFast --fuzz=<N>` commands
+above as scheduled or manual local runs, the same model
+`docs/QUIC_H3_FUZZ_MATRIX.md` uses; they are not wired into required PR CI
+because they are unbounded by design. Coordinate future OSS-Fuzz/OpenSSF
+onboarding with #121 rather than making external service integration a
+blocker here.

--- a/docs/CRYPTO_FUZZ_CONTRACT.md
+++ b/docs/CRYPTO_FUZZ_CONTRACT.md
@@ -58,6 +58,57 @@ scale it). #491–#494 should add their own protocol-scoped test steps and
 `-D<area>-test-filter` options following the same pattern rather than
 growing this one.
 
+## Seed-corpus and regression update procedure
+
+This is the concrete workflow #491–#494 should follow too, rather than each
+inventing their own.
+
+1. **Reproduce and identify the case.** A `--fuzz=<N>` run that finds a
+   failure fails the `zig build` step and prints the panic/error and Zig's
+   own `test "fuzz: <name>"` name plus its run count in the `FUZZING
+   REPORT` block — that name is the target's deterministic case ID
+   (`Deterministic reproduction` above). Re-run the exact same command
+   (same target, same `-Dcrypto-test-filter`, same `-Doptimize`) to confirm
+   the failure reproduces; Zig's fuzz engine is deterministic given the same
+   binary and inputs.
+2. **Choose the minimization form.**
+   - **Prefer a named deterministic `test` block** next to the fuzz target
+     when the failure has clear structure (a specific field's wrong length,
+     a specific tamper, a specific boundary value) — this is what every
+     deterministic regression in `tests/crypto_provider_fuzz.zig` already
+     is, and it stays reviewable years later the way a raw byte blob does
+     not.
+   - **Add a raw entry to the target's `.corpus = &.{...}` array** only when
+     the failure is genuinely opaque (no clean semantic story) and the exact
+     bytes matter. To capture those bytes: temporarily add a
+     `std.debug.print` of the sampled lengths/enum choice/raw slices
+     immediately before the failing `CryptoProvider` (or `secrets`) call
+     inside the target, re-run the same failing case to trigger the print,
+     copy the reported values, then remove the temporary print. Encode the
+     captured bytes as a Zig string literal using `\xNN` escapes for any
+     non-printable byte (see the existing corpus entries in this file for
+     the style) and add it to `.corpus`.
+3. **Never store real secret material.** Every target in this file
+   synthesizes or derives its own key material per case from injected
+   deterministic entropy — callers never hand it a real production secret —
+   so captured bytes are inherently synthetic/malformed wire-shaped input,
+   never a real private key, certificate, or traffic capture. Corpus entries
+   and regression fixtures must stay that way: hand-crafted or fuzzer-found
+   malformed input only, never copied from a real deployment.
+4. **Record provenance.** Add a one-line comment directly above the new
+   corpus entry or regression test noting when it was found and which
+   command found it (e.g. `-Doptimize=ReleaseFast --fuzz=10M`), so a future
+   reader can tell a hand-written edge case from a fuzzer-discovered one.
+5. **Verify before committing.** Both must pass:
+   ```bash
+   zig build test-crypto-provider-fuzz -Dcrypto-test-filter="fuzz: <exact target name>" --summary all --error-style verbose
+   zig build test --summary all --error-style verbose
+   ```
+   The first confirms the new corpus entry or regression reproduces
+   deterministically under plain (non-`--fuzz`) replay; the second confirms
+   no other target regressed. Run `zig fmt --check build.zig src/ tests/`
+   too, matching every other change in this repo.
+
 ## The shared contract
 
 Every target under epic #327-G — this story's provider targets and
@@ -80,7 +131,17 @@ Identical input/configuration must produce identical target behavior unless
 the target explicitly injects a deterministic clock/entropy stream. Every
 target in this file drives `pure_zig.Provider` through the injected
 `provider.Entropy` seam only (`pure_zig.DeterministicEntropy` in tests) —
-never ambient randomness — so this holds by construction.
+never ambient randomness. Case isolation matters as much as determinism
+here: each test and each fuzz callback constructs its own
+`DeterministicEntropy`/`Provider` pair on its own stack frame (the
+`TestProvider` helper in `tests/crypto_provider_fuzz.zig`) rather than
+sharing one process-global instance. A shared stream would advance
+differently depending on how many earlier cases already ran in the same
+process, so a case minimized during a full run and later replayed alone
+(e.g. via `-Dcrypto-test-filter`) would see a different entropy position
+than it had during discovery — reproducible in aggregate, but not
+per-case. Constructing fresh state per case removes that dependency
+entirely.
 
 ### Bounded work
 

--- a/tests/crypto_provider_fuzz.zig
+++ b/tests/crypto_provider_fuzz.zig
@@ -25,13 +25,29 @@ const secrets = crypto_pkg.secrets;
 const Ed25519 = std.crypto.sign.Ed25519;
 const EcdsaP256Sha256 = std.crypto.sign.ecdsa.EcdsaP256Sha256;
 
-fn cryptoProvider() provider.CryptoProvider {
-    const Holder = struct {
-        var entropy = pure_zig.DeterministicEntropy.init(0x376);
-        var provider_instance = pure_zig.Provider.init(entropy.entropy());
-    };
-    return Holder.provider_instance.cryptoProvider();
-}
+/// Every test/fuzz case constructs its own `TestProvider` value on its own
+/// stack frame rather than sharing one process-global instance: a shared
+/// `DeterministicEntropy` stream would advance differently depending on how
+/// many earlier cases already ran in the same process, so a minimized case
+/// replayed alone (e.g. via `-Dcrypto-test-filter`) would not see the same
+/// entropy a full run gave it, breaking case-isolated deterministic
+/// reproduction. `init` must be called on an already-addressed `self` (never
+/// have a helper build one and return it by value) because `Provider.entropy`
+/// stores a raw pointer to `self.entropy`; a by-value return would leave that
+/// pointer aimed at a temporary.
+const TestProvider = struct {
+    entropy: pure_zig.DeterministicEntropy,
+    instance: pure_zig.Provider,
+
+    fn init(self: *TestProvider, seed: u64) void {
+        self.entropy = pure_zig.DeterministicEntropy.init(seed);
+        self.instance = pure_zig.Provider.init(self.entropy.entropy());
+    }
+
+    fn cryptoProvider(self: *const TestProvider) provider.CryptoProvider {
+        return self.instance.cryptoProvider();
+    }
+};
 
 fn ed25519SigningKey(seed_byte: u8) !pure_zig.SoftwareSigningKey {
     var seed: [Ed25519.KeyPair.seed_length]u8 = undefined;
@@ -50,7 +66,9 @@ fn ecdsaSigningKey(seed_byte: u8) !pure_zig.SoftwareEcdsaP256SigningKey {
 // ---------------------------------------------------------------------------
 
 test "AEAD seal/open reject wrong-length key, nonce, tag, and mismatched ciphertext/plaintext lengths for every supported AEAD" {
-    const cp = cryptoProvider();
+    var tp: TestProvider = undefined;
+    tp.init(0x376);
+    const cp = tp.cryptoProvider();
     const aeads = [_]provider.Aead{ .aes_128_gcm, .aes_256_gcm, .chacha20_poly1305 };
     for (aeads) |aead| {
         const key_len = aead.keyLength();
@@ -83,7 +101,9 @@ test "AEAD seal/open reject wrong-length key, nonce, tag, and mismatched ciphert
 }
 
 test "AEAD open zeroes the plaintext buffer on authentication failure from ciphertext, tag, or associated-data mutation" {
-    const cp = cryptoProvider();
+    var tp: TestProvider = undefined;
+    tp.init(0x376);
+    const cp = tp.cryptoProvider();
     const aeads = [_]provider.Aead{ .aes_128_gcm, .aes_256_gcm, .chacha20_poly1305 };
     for (aeads) |aead| {
         const key = [_]u8{0xAB} ** provider.max_aead_key_len;
@@ -117,7 +137,9 @@ test "AEAD open zeroes the plaintext buffer on authentication failure from ciphe
 }
 
 test "AEAD seal/open round-trip zero-length and a harness-bounded maximum-length plaintext" {
-    const cp = cryptoProvider();
+    var tp: TestProvider = undefined;
+    tp.init(0x376);
+    const cp = tp.cryptoProvider();
     const aeads = [_]provider.Aead{ .aes_128_gcm, .aes_256_gcm, .chacha20_poly1305 };
     // Harness-chosen bound: AEAD itself has no wire-defined maximum plaintext
     // length the way a DER or QUIC varint length does (see the fuzz
@@ -149,7 +171,9 @@ test "AEAD seal/open round-trip zero-length and a harness-bounded maximum-length
 }
 
 fn fuzzAeadOpen(_: void, smith: *std.testing.Smith) anyerror!void {
-    const cp = cryptoProvider();
+    var tp: TestProvider = undefined;
+    tp.init(0x376);
+    const cp = tp.cryptoProvider();
     const aeads = [_]provider.Aead{ .aes_128_gcm, .aes_256_gcm, .chacha20_poly1305 };
     const aead = aeads[smith.index(aeads.len)];
 
@@ -180,18 +204,22 @@ fn fuzzAeadOpen(_: void, smith: *std.testing.Smith) anyerror!void {
         ct_buf[0..ct_len],
         tag_buf[0..tag_len],
         pt_buf[0..ct_len],
-    ) catch |err| {
-        // AuthenticationFailed carries the security-relevant contract this
-        // target exists to check: no unauthenticated plaintext survives.
-        // Any other rejection (InvalidInput for a wrong-length field) means
-        // the provider never wrote to `pt_buf` at all, so the sentinel is
-        // still there -- also fine, just not the interesting case.
-        if (err == error.AuthenticationFailed) {
+    ) catch |err| switch (err) {
+        // A wrong-length field is an expected, benign rejection: the
+        // provider never wrote to `pt_buf`, so nothing to check.
+        error.InvalidInput => return,
+        // The security-relevant contract this target exists to check: no
+        // unauthenticated plaintext survives a failed authentication.
+        error.AuthenticationFailed => {
             for (pt_buf[0..ct_len]) |b| {
                 if (b != 0) return error.TestUnexpectedResult;
             }
-        }
-        return;
+            return;
+        },
+        // `aead` is always one of the three variants this provider
+        // advertises support for; seeing this means the provider-contract
+        // itself regressed, not that the fuzz input was malformed.
+        error.UnsupportedCapability => return err,
     };
 }
 
@@ -209,7 +237,9 @@ test "fuzz: AEAD open never leaves unauthenticated plaintext on arbitrary key/no
 // ---------------------------------------------------------------------------
 
 test "deriveSharedSecret rejects wrong-length private scalars, peer public keys, and output buffers for every supported group" {
-    const cp = cryptoProvider();
+    var tp: TestProvider = undefined;
+    tp.init(0x376);
+    const cp = tp.cryptoProvider();
     const Case = struct { group: provider.Group, scalar_len: usize, peer_len: usize, out_len: usize };
     const cases = [_]Case{
         .{ .group = .x25519, .scalar_len = 32, .peer_len = 32, .out_len = 32 },
@@ -228,7 +258,9 @@ test "deriveSharedSecret rejects wrong-length private scalars, peer public keys,
 }
 
 fn fuzzDeriveSharedSecret(_: void, smith: *std.testing.Smith) anyerror!void {
-    const cp = cryptoProvider();
+    var tp: TestProvider = undefined;
+    tp.init(0x376);
+    const cp = tp.cryptoProvider();
     const groups = [_]provider.Group{ .x25519, .secp256r1 };
     const group = groups[smith.index(groups.len)];
 
@@ -242,7 +274,11 @@ fn fuzzDeriveSharedSecret(_: void, smith: *std.testing.Smith) anyerror!void {
     smith.bytes(peer_buf[0..peer_len]);
     const out_len = smith.index(out_buf.len + 1);
 
-    cp.deriveSharedSecret(group, scalar_buf[0..scalar_len], peer_buf[0..peer_len], out_buf[0..out_len]) catch return;
+    cp.deriveSharedSecret(group, scalar_buf[0..scalar_len], peer_buf[0..peer_len], out_buf[0..out_len]) catch |err| switch (err) {
+        error.InvalidInput => return,
+        // `group` is always one of the two variants this provider supports.
+        error.UnsupportedCapability => return err,
+    };
 }
 
 test "fuzz: deriveSharedSecret never panics on arbitrary scalar and peer-public bytes" {
@@ -254,7 +290,9 @@ test "fuzz: deriveSharedSecret never panics on arbitrary scalar and peer-public 
 }
 
 fn fuzzGenerateKeyShare(_: void, smith: *std.testing.Smith) anyerror!void {
-    const cp = cryptoProvider();
+    var tp: TestProvider = undefined;
+    tp.init(0x376);
+    const cp = tp.cryptoProvider();
     const groups = [_]provider.Group{ .x25519, .secp256r1 };
     const group = groups[smith.index(groups.len)];
 
@@ -264,7 +302,13 @@ fn fuzzGenerateKeyShare(_: void, smith: *std.testing.Smith) anyerror!void {
     const public_len = smith.index(public_buf.len + 1);
     const private_len = smith.index(private_buf.len + 1);
 
-    cp.generateKeyShare(group, public_buf[0..public_len], private_buf[0..private_len]) catch return;
+    cp.generateKeyShare(group, public_buf[0..public_len], private_buf[0..private_len]) catch |err| switch (err) {
+        error.InvalidInput => return,
+        // `group` is always supported and `tp`'s `DeterministicEntropy`
+        // never fails, so an entropy/provider/capability failure here means
+        // a real regression, not a benign fuzz outcome.
+        error.UnsupportedCapability, error.EntropyFailure, error.ProviderFailure => return err,
+    };
 }
 
 test "fuzz: generateKeyShare never panics on arbitrary output-buffer lengths" {
@@ -281,7 +325,9 @@ test "fuzz: generateKeyShare never panics on arbitrary output-buffer lengths" {
 // ---------------------------------------------------------------------------
 
 test "verify rejects malformed public key encodings for every supported scheme" {
-    const cp = cryptoProvider();
+    var tp: TestProvider = undefined;
+    tp.init(0x376);
+    const cp = tp.cryptoProvider();
     const message = "certificate verify transcript";
 
     {
@@ -324,7 +370,9 @@ test "verify rejects malformed public key encodings for every supported scheme" 
 }
 
 test "verify treats a malformed signature encoding as AuthenticationFailed for every supported scheme" {
-    const cp = cryptoProvider();
+    var tp: TestProvider = undefined;
+    tp.init(0x376);
+    const cp = tp.cryptoProvider();
     const message = "certificate verify transcript";
 
     {
@@ -355,7 +403,9 @@ test "verify treats a malformed signature encoding as AuthenticationFailed for e
 }
 
 test "verify rejects a structurally valid but single-bit-modified signature for every supported scheme" {
-    const cp = cryptoProvider();
+    var tp: TestProvider = undefined;
+    tp.init(0x376);
+    const cp = tp.cryptoProvider();
     const message = "certificate verify transcript";
 
     {
@@ -392,7 +442,9 @@ test "verify rejects a structurally valid but single-bit-modified signature for 
 }
 
 test "verify rejects the correct signature under the wrong message for every supported scheme" {
-    const cp = cryptoProvider();
+    var tp: TestProvider = undefined;
+    tp.init(0x376);
+    const cp = tp.cryptoProvider();
     const message = "certificate verify transcript";
     const wrong_message = "a completely different transcript";
 
@@ -430,7 +482,9 @@ test "verify rejects the correct signature under the wrong message for every sup
 }
 
 test "verify rejects the correct signature under an unrelated key for Ed25519 and ECDSA-P256" {
-    const cp = cryptoProvider();
+    var tp: TestProvider = undefined;
+    tp.init(0x376);
+    const cp = tp.cryptoProvider();
     const message = "certificate verify transcript";
 
     {
@@ -459,7 +513,9 @@ test "verify rejects the correct signature under an unrelated key for Ed25519 an
 }
 
 fn fuzzVerify(_: void, smith: *std.testing.Smith) anyerror!void {
-    const cp = cryptoProvider();
+    var tp: TestProvider = undefined;
+    tp.init(0x376);
+    const cp = tp.cryptoProvider();
     const schemes = [_]provider.SignatureScheme{ .ed25519, .ecdsa_secp256r1_sha256, .rsa_pss_rsae_sha256 };
     const scheme = schemes[smith.index(schemes.len)];
 
@@ -474,7 +530,12 @@ fn fuzzVerify(_: void, smith: *std.testing.Smith) anyerror!void {
     const sig_len = smith.index(sig_buf.len + 1);
     smith.bytes(sig_buf[0..sig_len]);
 
-    cp.verify(scheme, pk_buf[0..pk_len], msg_buf[0..msg_len], sig_buf[0..sig_len]) catch return;
+    cp.verify(scheme, pk_buf[0..pk_len], msg_buf[0..msg_len], sig_buf[0..sig_len]) catch |err| switch (err) {
+        error.InvalidInput, error.AuthenticationFailed => return,
+        // `scheme` is always one of the three variants this provider
+        // supports.
+        error.UnsupportedCapability => return err,
+    };
 }
 
 test "fuzz: verify never panics on arbitrary public key, message, and signature bytes" {
@@ -491,7 +552,9 @@ test "fuzz: verify never panics on arbitrary public key, message, and signature 
 // ---------------------------------------------------------------------------
 
 test "SigningKey.sign rejects an undersized output buffer without writing to it, for Ed25519" {
-    const cp = cryptoProvider();
+    var tp: TestProvider = undefined;
+    tp.init(0x376);
+    const cp = tp.cryptoProvider();
     var key = try ed25519SigningKey(13);
     defer key.deinit();
     const signer = key.signingKey();
@@ -530,11 +593,15 @@ fn fuzzFixedSecret(_: void, smith: *std.testing.Smith) anyerror!void {
         if (use_self_overlap) {
             const start = smith.index(secret.len);
             const take = smith.index(secret.len - start + 1);
-            secret.replace(secret.slice()[start..][0..take]) catch continue;
+            secret.replace(secret.slice()[start..][0..take]) catch |err| switch (err) {
+                error.SecretTooLarge => unreachable, // a self-slice cannot exceed capacity
+            };
         } else {
             const len = smith.index(scratch.len + 1);
             smith.bytes(scratch[0..len]);
-            secret.replace(scratch[0..len]) catch continue;
+            secret.replace(scratch[0..len]) catch |err| switch (err) {
+                error.SecretTooLarge => continue, // len may exceed the 32-byte capacity
+            };
         }
 
         if (secret.len > secret.bytes.len) return error.TestUnexpectedResult;
@@ -556,33 +623,124 @@ test "fuzz: FixedSecret replace/eql/deinit preserve invariants under arbitrary o
 }
 
 fn fuzzBoundedSecret(_: void, smith: *std.testing.Smith) anyerror!void {
+    const capacity = smith.index(64) + 1;
+    var scratch: [64]u8 = undefined;
+    const first_len = smith.index(capacity + 1);
+    smith.bytes(scratch[0..first_len]);
+
+    // Allocation-failure and leak-freedom path: `std.testing.allocator`'s
+    // own leak checker, wrapped so we can inject an occasional failure on
+    // `BoundedSecret`'s single capacity allocation and confirm no
+    // partially-initialized secret escapes it or leaks. Biased toward
+    // succeeding so most cases still reach the richer property loop below.
+    {
+        const should_fail = smith.boolWeighted(4, 1);
+        const fail_index: usize = if (should_fail) 0 else 1;
+        var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = fail_index });
+        var leak_secret = secrets.BoundedSecret{};
+        leak_secret.init(failing.allocator(), capacity, scratch[0..first_len]) catch |err| switch (err) {
+            error.OutOfMemory => {
+                leak_secret.deinit(); // must stay a safe no-op: nothing was allocated.
+                return;
+            },
+            error.SecretTooLarge => unreachable, // first_len <= capacity by construction
+        };
+        leak_secret.deinit(); // std.testing.allocator's own leak checker asserts this ran.
+    }
+
+    // Byte-inspection path: replace/self-overlap/oversized/eql/deinit
+    // properties against a `FixedBufferAllocator` so zeroization is directly
+    // observable in backing memory, mirroring `src/crypto/secrets.zig`'s own
+    // deterministic `BoundedSecret` tests. Every allocation below is freed
+    // in strict LIFO order (nested `defer`s inside each sub-block, `secret`
+    // itself only at the very end), so this backing buffer's bump pointer
+    // never grows past 3 concurrent `capacity`-sized allocations regardless
+    // of iteration count.
     var backing: [512]u8 align(8) = undefined;
     var fba = std.heap.FixedBufferAllocator.init(&backing);
-
-    const capacity = smith.index(96) + 1;
-    var scratch: [96]u8 = undefined;
-    const value_len = smith.index(capacity + 1);
-    smith.bytes(scratch[0..value_len]);
-
-    // fail_index in {0, 1}: 0 injects failure on BoundedSecret's single
-    // capacity allocation; 1 lets it succeed, exercising the ordinary path.
-    const fail_index = smith.index(2);
-    var failing = std.testing.FailingAllocator.init(fba.allocator(), .{ .fail_index = fail_index });
-
     var secret = secrets.BoundedSecret{};
-    secret.init(failing.allocator(), capacity, scratch[0..value_len]) catch |err| switch (err) {
-        error.OutOfMemory => return, // injected failure: nothing further to verify
-        error.SecretTooLarge => unreachable, // value_len <= capacity by construction
-    };
-    defer secret.deinit();
+    try secret.init(fba.allocator(), capacity, scratch[0..first_len]);
 
-    if (secret.len != value_len) return error.TestUnexpectedResult;
-    if (!std.mem.eql(u8, secret.slice(), scratch[0..value_len])) return error.TestUnexpectedResult;
+    var oversized_buf: [96]u8 = undefined;
+    var iterations: usize = 0;
+    while (iterations < 8 and !smith.eos()) : (iterations += 1) {
+        const before_len = secret.len;
+        var before_value: [64]u8 = undefined;
+        @memcpy(before_value[0..before_len], secret.slice());
 
-    var mirror = secrets.BoundedSecret{};
-    try mirror.init(fba.allocator(), capacity, secret.slice());
-    defer mirror.deinit();
-    if (!secret.eql(&mirror)) return error.TestUnexpectedResult;
+        const use_self_overlap = secret.len > 0 and smith.boolWeighted(1, 3);
+        if (use_self_overlap) {
+            const start = smith.index(secret.len);
+            const take = smith.index(secret.len - start + 1);
+            secret.replace(secret.slice()[start..][0..take]) catch |err| switch (err) {
+                error.SecretTooLarge => unreachable, // a self-slice cannot exceed capacity
+            };
+        } else if (smith.boolWeighted(3, 1)) {
+            // Oversized replacement: must always be rejected and must leave
+            // the prior value completely untouched.
+            const len = capacity + 1 + smith.index(oversized_buf.len - capacity);
+            smith.bytes(oversized_buf[0..len]);
+            secret.replace(oversized_buf[0..len]) catch |err| switch (err) {
+                error.SecretTooLarge => {
+                    if (secret.len != before_len) return error.TestUnexpectedResult;
+                    if (!std.mem.eql(u8, secret.slice(), before_value[0..before_len])) return error.TestUnexpectedResult;
+                    continue;
+                },
+            };
+            return error.TestUnexpectedResult; // an oversized replace must never succeed
+        } else {
+            const len = smith.index(capacity + 1);
+            smith.bytes(scratch[0..len]);
+            secret.replace(scratch[0..len]) catch |err| switch (err) {
+                error.SecretTooLarge => unreachable, // len <= capacity by construction
+            };
+        }
+
+        // Replacement-tail clearing: every byte beyond the new length, up to
+        // the full allocated capacity, must be zero in backing storage.
+        if (secret.len > capacity) return error.TestUnexpectedResult;
+        for (secret.bytes[secret.len..]) |b| {
+            if (b != 0) return error.TestUnexpectedResult;
+        }
+
+        // Equal comparison.
+        var mirror = secrets.BoundedSecret{};
+        try mirror.init(fba.allocator(), capacity, secret.slice());
+        defer mirror.deinit();
+        if (!secret.eql(&mirror)) return error.TestUnexpectedResult;
+
+        // Unequal (same-length, differing content) comparison.
+        if (secret.len > 0) {
+            var unequal = secrets.BoundedSecret{};
+            var tweaked: [64]u8 = undefined;
+            @memcpy(tweaked[0..secret.len], secret.slice());
+            tweaked[0] +%= 1;
+            try unequal.init(fba.allocator(), capacity, tweaked[0..secret.len]);
+            defer unequal.deinit();
+            if (secret.eql(&unequal)) return error.TestUnexpectedResult;
+        }
+
+        // Length-mismatched comparison.
+        if (secret.len < capacity) {
+            var longer = secrets.BoundedSecret{};
+            var longer_buf: [64]u8 = undefined;
+            @memcpy(longer_buf[0..secret.len], secret.slice());
+            longer_buf[secret.len] = 0;
+            try longer.init(fba.allocator(), capacity, longer_buf[0 .. secret.len + 1]);
+            defer longer.deinit();
+            if (secret.eql(&longer)) return error.TestUnexpectedResult;
+        }
+    }
+
+    secret.deinit();
+    if (secret.len != 0) return error.TestUnexpectedResult;
+    // `deinit` hands the allocator genuinely zeroed bytes, not
+    // `Allocator.free`'s undefined-poison -- inspect the FBA-backed bytes
+    // directly (they are `secret`'s original, first-from-this-arena
+    // allocation, so they sit at `backing[0..capacity]`).
+    for (backing[0..capacity]) |b| {
+        if (b != 0) return error.TestUnexpectedResult;
+    }
 }
 
 test "fuzz: BoundedSecret replace/eql/deinit preserve invariants under arbitrary capacity and allocator-failure injection" {

--- a/tests/crypto_provider_fuzz.zig
+++ b/tests/crypto_provider_fuzz.zig
@@ -1,0 +1,594 @@
+//! Standalone fuzz targets for the shared `CryptoProvider` boundary (#376,
+//! epic #327-G). See `docs/CRYPTO_FUZZ_CONTRACT.md` for the shared contract
+//! these targets (and the ones #491-494 own for their own protocol
+//! surfaces) follow.
+//!
+//! Every target here drives the real `pure_zig.Provider` directly through
+//! `provider.CryptoProvider` -- never a mock and never a protocol state
+//! machine (TLS/QUIC/PKI fuzzing belongs to #491-494/#247/#492) -- covering
+//! AEAD seal/open, key exchange, signature verification, the software
+//! signing-key boundary, and the shared secret containers. This
+//! complements, rather than duplicates, the deep deterministic coverage
+//! already in `src/crypto/pure_zig.zig`, `src/crypto/rsa.zig`, and
+//! `src/crypto/secrets.zig`; see the fuzz contract doc's matrix for exactly
+//! which properties are covered where.
+
+const std = @import("std");
+const crypto_pkg = @import("crypto");
+const testing = std.testing;
+
+const provider = crypto_pkg.provider;
+const pure_zig = crypto_pkg.pure_zig;
+const rsa = crypto_pkg.rsa;
+const secrets = crypto_pkg.secrets;
+
+const Ed25519 = std.crypto.sign.Ed25519;
+const EcdsaP256Sha256 = std.crypto.sign.ecdsa.EcdsaP256Sha256;
+
+fn cryptoProvider() provider.CryptoProvider {
+    const Holder = struct {
+        var entropy = pure_zig.DeterministicEntropy.init(0x376);
+        var provider_instance = pure_zig.Provider.init(entropy.entropy());
+    };
+    return Holder.provider_instance.cryptoProvider();
+}
+
+fn ed25519SigningKey(seed_byte: u8) !pure_zig.SoftwareSigningKey {
+    var seed: [Ed25519.KeyPair.seed_length]u8 = undefined;
+    @memset(&seed, seed_byte);
+    return pure_zig.SoftwareSigningKey.fromSeed(seed);
+}
+
+fn ecdsaSigningKey(seed_byte: u8) !pure_zig.SoftwareEcdsaP256SigningKey {
+    var seed: [EcdsaP256Sha256.KeyPair.seed_length]u8 = undefined;
+    @memset(&seed, seed_byte);
+    return pure_zig.SoftwareEcdsaP256SigningKey.fromSeed(seed);
+}
+
+// ---------------------------------------------------------------------------
+// AEAD seal/open
+// ---------------------------------------------------------------------------
+
+test "AEAD seal/open reject wrong-length key, nonce, tag, and mismatched ciphertext/plaintext lengths for every supported AEAD" {
+    const cp = cryptoProvider();
+    const aeads = [_]provider.Aead{ .aes_128_gcm, .aes_256_gcm, .chacha20_poly1305 };
+    for (aeads) |aead| {
+        const key_len = aead.keyLength();
+        const key_buf = [_]u8{0x11} ** provider.max_aead_key_len;
+        const nonce_buf = [_]u8{0x22} ** provider.aead_nonce_len;
+        const tag_buf = [_]u8{0x33} ** provider.aead_tag_len;
+        const plaintext = [_]u8{0x44} ** 8;
+        var ciphertext: [8]u8 = undefined;
+        var tag_out: [provider.aead_tag_len]u8 = undefined;
+        var recovered: [8]u8 = undefined;
+
+        // Wrong-length key.
+        try testing.expectError(error.InvalidInput, cp.aeadSeal(aead, key_buf[0 .. key_len - 1], &nonce_buf, "", &plaintext, &ciphertext, &tag_out));
+        try testing.expectError(error.InvalidInput, cp.aeadOpen(aead, key_buf[0 .. key_len - 1], &nonce_buf, "", &plaintext, &tag_buf, &recovered));
+
+        // Wrong-length nonce.
+        try testing.expectError(error.InvalidInput, cp.aeadSeal(aead, key_buf[0..key_len], nonce_buf[0 .. provider.aead_nonce_len - 1], "", &plaintext, &ciphertext, &tag_out));
+        try testing.expectError(error.InvalidInput, cp.aeadOpen(aead, key_buf[0..key_len], nonce_buf[0 .. provider.aead_nonce_len - 1], "", &plaintext, &tag_buf, &recovered));
+
+        // Wrong-length tag.
+        try testing.expectError(error.InvalidInput, cp.aeadOpen(aead, key_buf[0..key_len], &nonce_buf, "", &plaintext, tag_buf[0 .. provider.aead_tag_len - 1], &recovered));
+        var short_tag_out: [provider.aead_tag_len - 1]u8 = undefined;
+        try testing.expectError(error.InvalidInput, cp.aeadSeal(aead, key_buf[0..key_len], &nonce_buf, "", &plaintext, &ciphertext, &short_tag_out));
+
+        // Ciphertext/plaintext length mismatch.
+        var short_out: [4]u8 = undefined;
+        try testing.expectError(error.InvalidInput, cp.aeadSeal(aead, key_buf[0..key_len], &nonce_buf, "", &plaintext, &short_out, &tag_out));
+        try testing.expectError(error.InvalidInput, cp.aeadOpen(aead, key_buf[0..key_len], &nonce_buf, "", &plaintext, &tag_buf, &short_out));
+    }
+}
+
+test "AEAD open zeroes the plaintext buffer on authentication failure from ciphertext, tag, or associated-data mutation" {
+    const cp = cryptoProvider();
+    const aeads = [_]provider.Aead{ .aes_128_gcm, .aes_256_gcm, .chacha20_poly1305 };
+    for (aeads) |aead| {
+        const key = [_]u8{0xAB} ** provider.max_aead_key_len;
+        const nonce = [_]u8{0xCD} ** provider.aead_nonce_len;
+        const ad = "associated data";
+        const plaintext = "the quick brown fox jumps";
+        var ciphertext: [plaintext.len]u8 = undefined;
+        var tag: [provider.aead_tag_len]u8 = undefined;
+        try cp.aeadSeal(aead, key[0..aead.keyLength()], &nonce, ad, plaintext, &ciphertext, &tag);
+
+        {
+            var bad_ct = ciphertext;
+            bad_ct[0] ^= 0x01;
+            var recovered: [plaintext.len]u8 = [_]u8{0xAA} ** plaintext.len;
+            try testing.expectError(error.AuthenticationFailed, cp.aeadOpen(aead, key[0..aead.keyLength()], &nonce, ad, &bad_ct, &tag, &recovered));
+            for (recovered) |b| try testing.expectEqual(@as(u8, 0), b);
+        }
+        {
+            var bad_tag = tag;
+            bad_tag[0] ^= 0x01;
+            var recovered: [plaintext.len]u8 = [_]u8{0xAA} ** plaintext.len;
+            try testing.expectError(error.AuthenticationFailed, cp.aeadOpen(aead, key[0..aead.keyLength()], &nonce, ad, &ciphertext, &bad_tag, &recovered));
+            for (recovered) |b| try testing.expectEqual(@as(u8, 0), b);
+        }
+        {
+            var recovered: [plaintext.len]u8 = [_]u8{0xAA} ** plaintext.len;
+            try testing.expectError(error.AuthenticationFailed, cp.aeadOpen(aead, key[0..aead.keyLength()], &nonce, "different associated data", &ciphertext, &tag, &recovered));
+            for (recovered) |b| try testing.expectEqual(@as(u8, 0), b);
+        }
+    }
+}
+
+test "AEAD seal/open round-trip zero-length and a harness-bounded maximum-length plaintext" {
+    const cp = cryptoProvider();
+    const aeads = [_]provider.Aead{ .aes_128_gcm, .aes_256_gcm, .chacha20_poly1305 };
+    // Harness-chosen bound: AEAD itself has no wire-defined maximum plaintext
+    // length the way a DER or QUIC varint length does (see the fuzz
+    // contract's "Arithmetic safety" section).
+    const max_len = 8192;
+    for (aeads) |aead| {
+        const key = [_]u8{0x5A} ** provider.max_aead_key_len;
+        const nonce = [_]u8{0xA5} ** provider.aead_nonce_len;
+
+        {
+            var ciphertext: [0]u8 = undefined;
+            var tag: [provider.aead_tag_len]u8 = undefined;
+            try cp.aeadSeal(aead, key[0..aead.keyLength()], &nonce, "", "", &ciphertext, &tag);
+            var recovered: [0]u8 = undefined;
+            try cp.aeadOpen(aead, key[0..aead.keyLength()], &nonce, "", &ciphertext, &tag, &recovered);
+        }
+
+        {
+            var plaintext: [max_len]u8 = undefined;
+            for (&plaintext, 0..) |*b, i| b.* = @truncate(i);
+            var ciphertext: [max_len]u8 = undefined;
+            var tag: [provider.aead_tag_len]u8 = undefined;
+            try cp.aeadSeal(aead, key[0..aead.keyLength()], &nonce, "ad", &plaintext, &ciphertext, &tag);
+            var recovered: [max_len]u8 = undefined;
+            try cp.aeadOpen(aead, key[0..aead.keyLength()], &nonce, "ad", &ciphertext, &tag, &recovered);
+            try testing.expectEqualSlices(u8, &plaintext, &recovered);
+        }
+    }
+}
+
+fn fuzzAeadOpen(_: void, smith: *std.testing.Smith) anyerror!void {
+    const cp = cryptoProvider();
+    const aeads = [_]provider.Aead{ .aes_128_gcm, .aes_256_gcm, .chacha20_poly1305 };
+    const aead = aeads[smith.index(aeads.len)];
+
+    var key_buf: [64]u8 = undefined;
+    var nonce_buf: [32]u8 = undefined;
+    var tag_buf: [32]u8 = undefined;
+    var ad_buf: [128]u8 = undefined;
+    var ct_buf: [256]u8 = undefined;
+    var pt_buf: [256]u8 = undefined;
+
+    const key_len = smith.index(key_buf.len + 1);
+    smith.bytes(key_buf[0..key_len]);
+    const nonce_len = smith.index(nonce_buf.len + 1);
+    smith.bytes(nonce_buf[0..nonce_len]);
+    const tag_len = smith.index(tag_buf.len + 1);
+    smith.bytes(tag_buf[0..tag_len]);
+    const ad_len = smith.index(ad_buf.len + 1);
+    smith.bytes(ad_buf[0..ad_len]);
+    const ct_len = smith.index(ct_buf.len + 1);
+    smith.bytes(ct_buf[0..ct_len]);
+
+    @memset(&pt_buf, 0xAA);
+    cp.aeadOpen(
+        aead,
+        key_buf[0..key_len],
+        nonce_buf[0..nonce_len],
+        ad_buf[0..ad_len],
+        ct_buf[0..ct_len],
+        tag_buf[0..tag_len],
+        pt_buf[0..ct_len],
+    ) catch |err| {
+        // AuthenticationFailed carries the security-relevant contract this
+        // target exists to check: no unauthenticated plaintext survives.
+        // Any other rejection (InvalidInput for a wrong-length field) means
+        // the provider never wrote to `pt_buf` at all, so the sentinel is
+        // still there -- also fine, just not the interesting case.
+        if (err == error.AuthenticationFailed) {
+            for (pt_buf[0..ct_len]) |b| {
+                if (b != 0) return error.TestUnexpectedResult;
+            }
+        }
+        return;
+    };
+}
+
+test "fuzz: AEAD open never leaves unauthenticated plaintext on arbitrary key/nonce/tag/ciphertext/AD" {
+    try std.testing.fuzz({}, fuzzAeadOpen, .{ .corpus = &.{
+        "",
+        "\x00" ** 32,
+        "\xff" ** 32,
+        "\x00" ** 16 ++ "\xff" ** 16,
+    } });
+}
+
+// ---------------------------------------------------------------------------
+// Key exchange
+// ---------------------------------------------------------------------------
+
+test "deriveSharedSecret rejects wrong-length private scalars, peer public keys, and output buffers for every supported group" {
+    const cp = cryptoProvider();
+    const Case = struct { group: provider.Group, scalar_len: usize, peer_len: usize, out_len: usize };
+    const cases = [_]Case{
+        .{ .group = .x25519, .scalar_len = 32, .peer_len = 32, .out_len = 32 },
+        .{ .group = .secp256r1, .scalar_len = provider.max_private_scalar_len, .peer_len = 65, .out_len = 32 },
+    };
+    const scalar_buf = [_]u8{0x01} ** provider.max_private_scalar_len;
+    var peer_buf = [_]u8{0x04} ** provider.max_public_key_len;
+    peer_buf[0] = 0x04;
+    var out_buf: [provider.max_shared_secret_len]u8 = undefined;
+
+    for (cases) |case| {
+        try testing.expectError(error.InvalidInput, cp.deriveSharedSecret(case.group, scalar_buf[0 .. case.scalar_len - 1], peer_buf[0..case.peer_len], out_buf[0..case.out_len]));
+        try testing.expectError(error.InvalidInput, cp.deriveSharedSecret(case.group, scalar_buf[0..case.scalar_len], peer_buf[0 .. case.peer_len - 1], out_buf[0..case.out_len]));
+        try testing.expectError(error.InvalidInput, cp.deriveSharedSecret(case.group, scalar_buf[0..case.scalar_len], peer_buf[0..case.peer_len], out_buf[0 .. case.out_len - 1]));
+    }
+}
+
+fn fuzzDeriveSharedSecret(_: void, smith: *std.testing.Smith) anyerror!void {
+    const cp = cryptoProvider();
+    const groups = [_]provider.Group{ .x25519, .secp256r1 };
+    const group = groups[smith.index(groups.len)];
+
+    var scalar_buf: [96]u8 = undefined;
+    var peer_buf: [96]u8 = undefined;
+    var out_buf: [96]u8 = undefined;
+
+    const scalar_len = smith.index(scalar_buf.len + 1);
+    smith.bytes(scalar_buf[0..scalar_len]);
+    const peer_len = smith.index(peer_buf.len + 1);
+    smith.bytes(peer_buf[0..peer_len]);
+    const out_len = smith.index(out_buf.len + 1);
+
+    cp.deriveSharedSecret(group, scalar_buf[0..scalar_len], peer_buf[0..peer_len], out_buf[0..out_len]) catch return;
+}
+
+test "fuzz: deriveSharedSecret never panics on arbitrary scalar and peer-public bytes" {
+    try std.testing.fuzz({}, fuzzDeriveSharedSecret, .{ .corpus = &.{
+        "",
+        "\x00" ** 32,
+        "\x04" ++ "\xff" ** 64,
+    } });
+}
+
+fn fuzzGenerateKeyShare(_: void, smith: *std.testing.Smith) anyerror!void {
+    const cp = cryptoProvider();
+    const groups = [_]provider.Group{ .x25519, .secp256r1 };
+    const group = groups[smith.index(groups.len)];
+
+    var public_buf: [96]u8 = undefined;
+    var private_buf: [96]u8 = undefined;
+
+    const public_len = smith.index(public_buf.len + 1);
+    const private_len = smith.index(private_buf.len + 1);
+
+    cp.generateKeyShare(group, public_buf[0..public_len], private_buf[0..private_len]) catch return;
+}
+
+test "fuzz: generateKeyShare never panics on arbitrary output-buffer lengths" {
+    try std.testing.fuzz({}, fuzzGenerateKeyShare, .{ .corpus = &.{
+        "",
+        "\x00",
+        "\x20\x20",
+        "\x41\x41",
+    } });
+}
+
+// ---------------------------------------------------------------------------
+// Signature verification
+// ---------------------------------------------------------------------------
+
+test "verify rejects malformed public key encodings for every supported scheme" {
+    const cp = cryptoProvider();
+    const message = "certificate verify transcript";
+
+    {
+        var key = try ed25519SigningKey(1);
+        defer key.deinit();
+        const signer = key.signingKey();
+        var sig: [Ed25519.Signature.encoded_length]u8 = undefined;
+        _ = try signer.sign(message, cp.entropy, &sig);
+
+        const short_key = [_]u8{0} ** 31;
+        try testing.expectError(error.InvalidInput, cp.verify(.ed25519, &short_key, message, &sig));
+        const non_canonical = [_]u8{0xff} ** Ed25519.PublicKey.encoded_length;
+        try testing.expectError(error.InvalidInput, cp.verify(.ed25519, &non_canonical, message, &sig));
+    }
+
+    {
+        var key = try ecdsaSigningKey(2);
+        defer key.deinit();
+        const signer = key.signingKey();
+        var sig_buf: [EcdsaP256Sha256.Signature.der_encoded_length_max]u8 = undefined;
+        const sig_len = try signer.sign(message, cp.entropy, &sig_buf);
+
+        const short_key = [_]u8{0} ** 10;
+        try testing.expectError(error.InvalidInput, cp.verify(.ecdsa_secp256r1_sha256, &short_key, message, sig_buf[0..sig_len]));
+        var bad_tag = key.publicKeySec1();
+        bad_tag[0] = 0x00; // not a valid SEC1 point tag (0x02/0x03/0x04)
+        try testing.expectError(error.InvalidInput, cp.verify(.ecdsa_secp256r1_sha256, &bad_tag, message, sig_buf[0..sig_len]));
+    }
+
+    {
+        var key = try pure_zig.SoftwareRsaSigningKey.fromDer(rsa.testdata.private_key_pkcs1_der, cp.entropy);
+        defer key.deinit();
+        const signer = key.signingKey();
+        var sig_buf: [provider.max_signature_len]u8 = undefined;
+        const sig_len = try signer.sign(message, cp.entropy, &sig_buf);
+
+        const short_key = [_]u8{0} ** 10;
+        try testing.expectError(error.InvalidInput, cp.verify(.rsa_pss_rsae_sha256, &short_key, message, sig_buf[0..sig_len]));
+    }
+}
+
+test "verify treats a malformed signature encoding as AuthenticationFailed for every supported scheme" {
+    const cp = cryptoProvider();
+    const message = "certificate verify transcript";
+
+    {
+        var key = try ed25519SigningKey(3);
+        defer key.deinit();
+        const public_key = key.publicKey();
+        const short_sig = [_]u8{0x01} ** (Ed25519.Signature.encoded_length - 1);
+        try testing.expectError(error.AuthenticationFailed, cp.verify(.ed25519, &public_key, message, &short_sig));
+    }
+
+    {
+        var key = try ecdsaSigningKey(4);
+        defer key.deinit();
+        const public_key = key.publicKeySec1();
+        const not_der = [_]u8{0xff} ** 8; // not a valid DER SEQUENCE
+        try testing.expectError(error.AuthenticationFailed, cp.verify(.ecdsa_secp256r1_sha256, &public_key, message, &not_der));
+    }
+
+    {
+        // A correct-length signature (matches the 2048-bit test modulus) but
+        // out-of-range as an integer is `AuthenticationFailed`, not
+        // `InvalidInput` -- unlike a wrong-*length* signature, which
+        // `rsa.verifyPssSha256` rejects as `InvalidInput` before it ever
+        // reaches this classification (see `src/crypto/rsa.zig`).
+        const garbage_sig = [_]u8{0} ** 256;
+        try testing.expectError(error.AuthenticationFailed, cp.verify(.rsa_pss_rsae_sha256, rsa.testdata.public_key_der, message, &garbage_sig));
+    }
+}
+
+test "verify rejects a structurally valid but single-bit-modified signature for every supported scheme" {
+    const cp = cryptoProvider();
+    const message = "certificate verify transcript";
+
+    {
+        var key = try ed25519SigningKey(5);
+        defer key.deinit();
+        const signer = key.signingKey();
+        var sig: [Ed25519.Signature.encoded_length]u8 = undefined;
+        _ = try signer.sign(message, cp.entropy, &sig);
+        sig[sig.len / 2] ^= 0x01;
+        const public_key = key.publicKey();
+        try testing.expectError(error.AuthenticationFailed, cp.verify(.ed25519, &public_key, message, &sig));
+    }
+
+    {
+        var key = try ecdsaSigningKey(6);
+        defer key.deinit();
+        const signer = key.signingKey();
+        var sig_buf: [EcdsaP256Sha256.Signature.der_encoded_length_max]u8 = undefined;
+        const sig_len = try signer.sign(message, cp.entropy, &sig_buf);
+        sig_buf[sig_len / 2] ^= 0x01;
+        const public_key = key.publicKeySec1();
+        try testing.expectError(error.AuthenticationFailed, cp.verify(.ecdsa_secp256r1_sha256, &public_key, message, sig_buf[0..sig_len]));
+    }
+
+    {
+        var key = try pure_zig.SoftwareRsaSigningKey.fromDer(rsa.testdata.private_key_pkcs1_der, cp.entropy);
+        defer key.deinit();
+        const signer = key.signingKey();
+        var sig_buf: [provider.max_signature_len]u8 = undefined;
+        const sig_len = try signer.sign(message, cp.entropy, &sig_buf);
+        sig_buf[sig_len / 2] ^= 0x01;
+        try testing.expectError(error.AuthenticationFailed, cp.verify(.rsa_pss_rsae_sha256, rsa.testdata.public_key_der, message, sig_buf[0..sig_len]));
+    }
+}
+
+test "verify rejects the correct signature under the wrong message for every supported scheme" {
+    const cp = cryptoProvider();
+    const message = "certificate verify transcript";
+    const wrong_message = "a completely different transcript";
+
+    {
+        var key = try ed25519SigningKey(7);
+        defer key.deinit();
+        const signer = key.signingKey();
+        var sig: [Ed25519.Signature.encoded_length]u8 = undefined;
+        _ = try signer.sign(message, cp.entropy, &sig);
+        const public_key = key.publicKey();
+        try testing.expectError(error.AuthenticationFailed, cp.verify(.ed25519, &public_key, wrong_message, &sig));
+    }
+
+    {
+        var key = try ecdsaSigningKey(8);
+        defer key.deinit();
+        const signer = key.signingKey();
+        var sig_buf: [EcdsaP256Sha256.Signature.der_encoded_length_max]u8 = undefined;
+        const sig_len = try signer.sign(message, cp.entropy, &sig_buf);
+        const public_key = key.publicKeySec1();
+        try testing.expectError(error.AuthenticationFailed, cp.verify(.ecdsa_secp256r1_sha256, &public_key, wrong_message, sig_buf[0..sig_len]));
+    }
+
+    {
+        // No independent second RSA fixture exists in this repo (RSA
+        // key-generation is out of scope for the provider); the wrong-key
+        // sub-case above is exercised for Ed25519/ECDSA only.
+        var key = try pure_zig.SoftwareRsaSigningKey.fromDer(rsa.testdata.private_key_pkcs1_der, cp.entropy);
+        defer key.deinit();
+        const signer = key.signingKey();
+        var sig_buf: [provider.max_signature_len]u8 = undefined;
+        const sig_len = try signer.sign(message, cp.entropy, &sig_buf);
+        try testing.expectError(error.AuthenticationFailed, cp.verify(.rsa_pss_rsae_sha256, rsa.testdata.public_key_der, wrong_message, sig_buf[0..sig_len]));
+    }
+}
+
+test "verify rejects the correct signature under an unrelated key for Ed25519 and ECDSA-P256" {
+    const cp = cryptoProvider();
+    const message = "certificate verify transcript";
+
+    {
+        var key = try ed25519SigningKey(9);
+        defer key.deinit();
+        var other = try ed25519SigningKey(10);
+        defer other.deinit();
+        const signer = key.signingKey();
+        var sig: [Ed25519.Signature.encoded_length]u8 = undefined;
+        _ = try signer.sign(message, cp.entropy, &sig);
+        const other_public = other.publicKey();
+        try testing.expectError(error.AuthenticationFailed, cp.verify(.ed25519, &other_public, message, &sig));
+    }
+
+    {
+        var key = try ecdsaSigningKey(11);
+        defer key.deinit();
+        var other = try ecdsaSigningKey(12);
+        defer other.deinit();
+        const signer = key.signingKey();
+        var sig_buf: [EcdsaP256Sha256.Signature.der_encoded_length_max]u8 = undefined;
+        const sig_len = try signer.sign(message, cp.entropy, &sig_buf);
+        const other_public = other.publicKeySec1();
+        try testing.expectError(error.AuthenticationFailed, cp.verify(.ecdsa_secp256r1_sha256, &other_public, message, sig_buf[0..sig_len]));
+    }
+}
+
+fn fuzzVerify(_: void, smith: *std.testing.Smith) anyerror!void {
+    const cp = cryptoProvider();
+    const schemes = [_]provider.SignatureScheme{ .ed25519, .ecdsa_secp256r1_sha256, .rsa_pss_rsae_sha256 };
+    const scheme = schemes[smith.index(schemes.len)];
+
+    var pk_buf: [600]u8 = undefined;
+    var msg_buf: [128]u8 = undefined;
+    var sig_buf: [600]u8 = undefined;
+
+    const pk_len = smith.index(pk_buf.len + 1);
+    smith.bytes(pk_buf[0..pk_len]);
+    const msg_len = smith.index(msg_buf.len + 1);
+    smith.bytes(msg_buf[0..msg_len]);
+    const sig_len = smith.index(sig_buf.len + 1);
+    smith.bytes(sig_buf[0..sig_len]);
+
+    cp.verify(scheme, pk_buf[0..pk_len], msg_buf[0..msg_len], sig_buf[0..sig_len]) catch return;
+}
+
+test "fuzz: verify never panics on arbitrary public key, message, and signature bytes" {
+    try std.testing.fuzz({}, fuzzVerify, .{ .corpus = &.{
+        "",
+        "\x00" ** 32,
+        "\x04" ++ "\xff" ** 64,
+        rsa.testdata.public_key_der,
+    } });
+}
+
+// ---------------------------------------------------------------------------
+// Signing-key boundary
+// ---------------------------------------------------------------------------
+
+test "SigningKey.sign rejects an undersized output buffer without writing to it, for Ed25519" {
+    const cp = cryptoProvider();
+    var key = try ed25519SigningKey(13);
+    defer key.deinit();
+    const signer = key.signingKey();
+
+    var out: [Ed25519.Signature.encoded_length - 1]u8 = [_]u8{0xEE} ** (Ed25519.Signature.encoded_length - 1);
+    const before = out;
+    try testing.expectError(error.InvalidInput, signer.sign("message", cp.entropy, &out));
+    try testing.expectEqualSlices(u8, &before, &out);
+}
+
+test "SoftwareSigningKey.deinit wipes the retained Ed25519 private key bytes" {
+    var key = try ed25519SigningKey(14);
+    key.deinit();
+    for (key.key_pair.secret_key.bytes) |b| try testing.expectEqual(@as(u8, 0), b);
+}
+
+test "SoftwareEcdsaP256SigningKey.deinit wipes the retained private key bytes" {
+    var key = try ecdsaSigningKey(15);
+    key.deinit();
+    for (key.key_pair.secret_key.bytes) |b| try testing.expectEqual(@as(u8, 0), b);
+}
+
+// ---------------------------------------------------------------------------
+// Shared secret helpers
+// ---------------------------------------------------------------------------
+
+fn fuzzFixedSecret(_: void, smith: *std.testing.Smith) anyerror!void {
+    const Secret = secrets.FixedSecret(32);
+    var secret = Secret{};
+    defer secret.deinit();
+
+    var scratch: [64]u8 = undefined;
+    var iterations: usize = 0;
+    while (iterations < 8 and !smith.eos()) : (iterations += 1) {
+        const use_self_overlap = secret.len > 0 and smith.boolWeighted(1, 3);
+        if (use_self_overlap) {
+            const start = smith.index(secret.len);
+            const take = smith.index(secret.len - start + 1);
+            secret.replace(secret.slice()[start..][0..take]) catch continue;
+        } else {
+            const len = smith.index(scratch.len + 1);
+            smith.bytes(scratch[0..len]);
+            secret.replace(scratch[0..len]) catch continue;
+        }
+
+        if (secret.len > secret.bytes.len) return error.TestUnexpectedResult;
+        for (secret.bytes[secret.len..]) |b| {
+            if (b != 0) return error.TestUnexpectedResult;
+        }
+        var mirror = secret.copy();
+        defer mirror.deinit();
+        if (!secret.eql(&mirror)) return error.TestUnexpectedResult;
+    }
+}
+
+test "fuzz: FixedSecret replace/eql/deinit preserve invariants under arbitrary overlapping and non-overlapping input" {
+    try std.testing.fuzz({}, fuzzFixedSecret, .{ .corpus = &.{
+        "",
+        "\x00" ** 8,
+        "\xff" ** 40,
+    } });
+}
+
+fn fuzzBoundedSecret(_: void, smith: *std.testing.Smith) anyerror!void {
+    var backing: [512]u8 align(8) = undefined;
+    var fba = std.heap.FixedBufferAllocator.init(&backing);
+
+    const capacity = smith.index(96) + 1;
+    var scratch: [96]u8 = undefined;
+    const value_len = smith.index(capacity + 1);
+    smith.bytes(scratch[0..value_len]);
+
+    // fail_index in {0, 1}: 0 injects failure on BoundedSecret's single
+    // capacity allocation; 1 lets it succeed, exercising the ordinary path.
+    const fail_index = smith.index(2);
+    var failing = std.testing.FailingAllocator.init(fba.allocator(), .{ .fail_index = fail_index });
+
+    var secret = secrets.BoundedSecret{};
+    secret.init(failing.allocator(), capacity, scratch[0..value_len]) catch |err| switch (err) {
+        error.OutOfMemory => return, // injected failure: nothing further to verify
+        error.SecretTooLarge => unreachable, // value_len <= capacity by construction
+    };
+    defer secret.deinit();
+
+    if (secret.len != value_len) return error.TestUnexpectedResult;
+    if (!std.mem.eql(u8, secret.slice(), scratch[0..value_len])) return error.TestUnexpectedResult;
+
+    var mirror = secrets.BoundedSecret{};
+    try mirror.init(fba.allocator(), capacity, secret.slice());
+    defer mirror.deinit();
+    if (!secret.eql(&mirror)) return error.TestUnexpectedResult;
+}
+
+test "fuzz: BoundedSecret replace/eql/deinit preserve invariants under arbitrary capacity and allocator-failure injection" {
+    try std.testing.fuzz({}, fuzzBoundedSecret, .{ .corpus = &.{
+        "",
+        "\x00" ** 8,
+        "\xff" ** 40,
+    } });
+}


### PR DESCRIPTION
## Summary

Issue #376 is a large research story (`327-G`) whose full scope spans a
shared fuzzing contract, harness support, standalone `CryptoProvider`
targets, and CI wiring, with protocol-specific fuzzing explicitly split out
to sibling stories (#491–#494, #247). This PR implements the story's own
scope: the shared contract and the provider-boundary targets it owns.

- Adds `docs/CRYPTO_FUZZ_CONTRACT.md`: the shared fuzzing contract —
  deterministic reproduction, bounded work, arithmetic safety,
  lifetime/borrowed-slice safety, secret-safe diagnostics, and regression
  minimization — that #491–#494's future protocol-level fuzzing stories are
  expected to consume, following the same pattern established by
  `docs/QUIC_H3_FUZZ_MATRIX.md` for #247.
- Adds `tests/crypto_provider_fuzz.zig`: standalone `std.testing.Smith`
  generative fuzz targets plus deterministic regression tests driving the
  real `pure_zig.Provider` directly through `provider.CryptoProvider` (never
  a mock, never a protocol state machine):
  - **AEAD seal/open** — wrong-length key/nonce/tag/output, mismatched
    ciphertext/plaintext lengths, tampered ciphertext/tag/AD mapped to
    `AuthenticationFailed` with the plaintext buffer fully zeroed, and
    zero-length/harness-bounded-maximum plaintext round-trips, for all three
    supported AEADs.
  - **Key exchange** — wrong-length private scalars/peer public
    keys/output buffers for X25519 and secp256r1, plus generative fuzzing of
    `deriveSharedSecret` and `generateKeyShare`.
  - **Signature verification** — malformed public-key and signature
    encodings, structurally-valid single-bit-modified signatures, and
    wrong-message/wrong-key rejection for Ed25519, ECDSA-P256/SHA-256, and
    RSA-PSS-RSAE/SHA-256 (using the existing `rsa.testdata` fixture rather
    than re-deriving key material).
  - **Signing-key boundary** — undersized-output-buffer rejection and
    `deinit` zeroization verification, filling the specific gaps not already
    covered by `src/crypto/pure_zig.zig`'s existing deep per-scheme coverage.
  - **Shared secret helpers** — `FixedSecret`/`BoundedSecret`
    `replace`/`copy`/`eql`/`deinit` property fuzzing across randomized
    capacities and self-overlapping input, including allocator-failure
    injection via `std.testing.FailingAllocator`.
- Wires a new `test-crypto-provider-fuzz` build step and a
  `-Dcrypto-test-filter` option into `build.zig`, added to both
  `test-crypto` and the default `zig build test` (so it runs in existing CI
  with no workflow changes needed), mirroring the QUIC program's
  `-Dquic-test-filter` convention.
- `CHANGELOG.md` entry under a new `### Testing` section.

This intentionally does **not** re-implement TLS handshake/negotiation
(#491), DER/PEM/X.509 (#492), TLS record (#493), resumption/ticket (#494), or
QUIC/H3 (#247) fuzzing — the issue is explicit that #376 owns only the
contract and the provider seam. It also avoids duplicating the substantial
existing deterministic coverage already in `pure_zig.zig`/`rsa.zig`/
`secrets.zig` (documented per-target in the contract doc's matrix), adding
only the missing generative harnesses and a small number of genuine gaps.

## Test plan

- [x] `zig build test-crypto-provider-fuzz --summary all --error-style
      verbose` — 18/18 new tests pass.
- [x] `zig build test-crypto-provider-fuzz -Doptimize=ReleaseFast
      --fuzz=20000` — real coverage-guided fuzzing run (132k+ runs) with no
      crashes.
- [x] `zig build test --summary all --error-style verbose` — full suite,
      3124/3125 passing (1 pre-existing unrelated skip), no regressions.
- [x] `zig fmt --check build.zig src/ tests/` — clean.

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)