### PR TITLE
perf: [327-I] benchmark CryptoProvider and shared cryptographic machinery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,6 +434,51 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  # ── Crypto benchmark trend ────────────────────────────────────────────────────
+  # Reduced CI/trend profile for #378: reports CryptoProvider/record/
+  # ticket-protection measurements as a diffable JSON artifact. Correctness for
+  # every workload is already enforced by `test-crypto-bench` under the default
+  # `test` job above; this job never inspects the numbers or fails on them, so a
+  # noisy shared runner cannot make PR CI flaky (docs/CRYPTO_BENCHMARKS.md).
+  crypto-bench:
+    name: Crypto benchmark trend
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Zig
+        run: sh ./scripts/install-zig.sh 0.16.0
+
+      - name: Cache Zig build artifacts
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/zig
+            .zig-cache
+          key: zig-crypto-bench-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('build.zig') }}-${{ github.sha }}
+          restore-keys: |
+            zig-crypto-bench-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('build.zig') }}-
+            zig-crypto-bench-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Run crypto benchmark suite
+        run: |
+          mkdir -p "$RUNNER_TEMP/crypto-bench-artifacts"
+          zig build bench-crypto -Doptimize=ReleaseFast > "$RUNNER_TEMP/crypto-bench-artifacts/crypto-bench.json"
+
+      - name: Upload crypto benchmark results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: crypto-bench-results
+          path: ${{ runner.temp }}/crypto-bench-artifacts/crypto-bench.json
+          if-no-files-found: error
+          retention-days: 14
+
   # ── Security scanning ─────────────────────────────────────────────────────────
   # Secret detection, filesystem vulnerability scanning, and GitHub Actions
   # hardening checks. Results are uploaded to the Security tab as SARIF.

--- a/build.zig
+++ b/build.zig
@@ -10,6 +10,20 @@ const std = @import("std");
 /// `tardi version`. See docs/TLS_DEPENDENCY_POLICY.md.
 const TlsProfile = enum { general, appliance };
 
+/// Resolves the source revision embedded in benchmark/diagnostic metadata
+/// (e.g. `crypto_bench`'s `_meta.tardigrade_commit`, #378's benchmark
+/// contract). Runs `git rev-parse HEAD` at configure time and falls back to
+/// `"unknown"` rather than failing the build when there is no `.git`
+/// directory to inspect (a source archive, a shallow export, etc.) or `git`
+/// itself is unavailable.
+fn gitCommitSha(b: *std.Build) []const u8 {
+    var code: u8 = undefined;
+    const output = b.runAllowFail(&.{ "git", "rev-parse", "HEAD" }, &code, .ignore) catch return "unknown";
+    const trimmed = std.mem.trim(u8, output, " \t\r\n");
+    if (trimmed.len == 0) return "unknown";
+    return trimmed;
+}
+
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
@@ -17,6 +31,7 @@ pub fn build(b: *std.Build) void {
     const require_static_system_libs = b.option(bool, "require-static-system-libs", "Require static linking for system libraries") orelse false;
     const static_executable = b.option(bool, "static-executable", "Build the tardi executable as a static binary") orelse false;
     const app_version = b.option([]const u8, "version", "Version string embedded in the tardi binary") orelse "dev";
+    const commit_sha = b.option([]const u8, "commit", "Source commit SHA embedded in benchmark/diagnostic metadata (default: `git rev-parse HEAD`, or \"unknown\")") orelse gitCommitSha(b);
     const go_bin = b.option([]const u8, "go-bin", "Go command used to build the PKI crypto/x509 oracle") orelse "go";
     const quic_test_filter = b.option([]const u8, "quic-test-filter", "Filter tests run by the test-quic step");
     const quic_test_filters: []const []const u8 = if (quic_test_filter) |filter| &.{filter} else &.{};
@@ -31,6 +46,7 @@ pub fn build(b: *std.Build) void {
 
     const build_options = b.addOptions();
     build_options.addOption([]const u8, "version", app_version);
+    build_options.addOption([]const u8, "commit", commit_sha);
     build_options.addOption([]const u8, "tls_profile", @tagName(tls_profile));
     build_options.addOption(bool, "tls_openssl_adapter", link_openssl_adapter);
     const compat_mod = b.createModule(.{

--- a/build.zig
+++ b/build.zig
@@ -560,6 +560,39 @@ pub fn build(b: *std.Build) void {
     crypto_step.dependOn(&run_crypto_provider_fuzz_tests.step);
     test_step.dependOn(&run_crypto_provider_fuzz_tests.step);
 
+    // CryptoProvider/record/ticket-protection benchmark suite (#378, epic
+    // #327-I): reports latency, throughput, and allocation measurements for
+    // the shared crypto seam as JSON. `test-crypto-bench` runs every
+    // workload at a tiny iteration count purely as a correctness smoke check
+    // (crash/API-drift detection, not a timing signal), so it is safe to
+    // include in the default `zig build test`; `bench-crypto` runs the same
+    // suites at full iteration counts and prints the report.
+    const crypto_bench_mod = b.createModule(.{
+        .root_source_file = b.path("src/crypto_bench/root.zig"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    crypto_bench_mod.addImport("build_options", build_options.createModule());
+    crypto_bench_mod.addImport("zig_compat", compat_mod);
+    crypto_bench_mod.addImport("crypto", crypto_mod);
+    crypto_bench_mod.addImport("tls_core", tls_core_mod);
+
+    const crypto_bench_tests = b.addTest(.{ .root_module = crypto_bench_mod });
+    const run_crypto_bench_tests = b.addRunArtifact(crypto_bench_tests);
+    const crypto_bench_test_step = b.step("test-crypto-bench", "Run the CryptoProvider/record/ticket-protection benchmark suite as a correctness smoke check (#378)");
+    crypto_bench_test_step.dependOn(&run_crypto_bench_tests.step);
+    crypto_step.dependOn(&run_crypto_bench_tests.step);
+    test_step.dependOn(&run_crypto_bench_tests.step);
+
+    const crypto_bench_exe = b.addExecutable(.{
+        .name = "crypto_bench",
+        .root_module = crypto_bench_mod,
+    });
+    const run_crypto_bench = b.addRunArtifact(crypto_bench_exe);
+    const crypto_bench_step = b.step("bench-crypto", "Report CryptoProvider/record/ticket-protection benchmark measurements as JSON (#378)");
+    crypto_bench_step.dependOn(&run_crypto_bench.step);
+
     // A direct TLS-owned backend handshake through the record stack. This is a
     // standalone module because it uses socket-pair carriers and the concrete
     // pure-Zig crypto provider in addition to the reusable tls_core module.

--- a/docs/CRYPTO_BENCHMARKS.md
+++ b/docs/CRYPTO_BENCHMARKS.md
@@ -1,0 +1,132 @@
+# CryptoProvider / record / ticket-protection benchmarks (#378, epic #327-I)
+
+Repeatable component benchmarks for the shared cryptographic provider and
+crypto-facing machinery: enough to explain where larger-system performance
+comes from, without duplicating the end-to-end TLS/QUIC/PKI/HTTP benchmark
+work owned elsewhere (see "Ownership boundaries" below).
+
+Every workload drives `pure_zig.Provider` directly through
+`provider.CryptoProvider` — the same pattern
+`tests/crypto_provider_fuzz.zig` uses (own-stack-frame provider, never
+shared, never a protocol state machine) — or, for the record/ticket
+suites, the same `tls_core.record_protection` / `tls_core.ticket_protection`
+modules the native TLS stack calls in production.
+
+## Commands
+
+```bash
+# Fast correctness smoke check (tiny iteration counts; not a timing signal).
+# Part of the default `zig build test` and CI, so a broken workload or API
+# drift fails the build immediately rather than silently going stale.
+zig build test-crypto-bench --summary all --error-style verbose
+
+# Full benchmark run: prints one JSON report to stdout.
+zig build bench-crypto -Doptimize=ReleaseFast
+```
+
+`bench-crypto` is not wired into `zig build test` or `test_step` — like
+`bench-allocations`, it is a standalone report generator, not a pass/fail
+gate, so it never makes the default build flaky.
+
+## What is covered
+
+- **Hash / HKDF** — SHA-256/SHA-384 (provider-independent, explanatory
+  only), HKDF-Extract, HKDF-Expand-Label across representative
+  output/context sizes, and a repeated key+iv derivation pattern matching a
+  record-layer epoch change.
+- **AEAD** — AES-128-GCM, AES-256-GCM, ChaCha20-Poly1305: seal and open
+  measured separately across small/typical/near-max payload sizes, plus a
+  dedicated authentication-failure workload.
+- **Key exchange** — X25519 and secp256r1: key-share generation,
+  shared-secret derivation, and invalid-peer-key rejection.
+- **Signatures** — Ed25519, ECDSA-P256/SHA-256, RSA-PSS-RSAE/SHA-256: sign,
+  verify, and invalid-signature rejection, kept separate rather than
+  averaged.
+- **Secret-container/helper overhead** — `FixedSecret` replace+deinit,
+  `BoundedSecret` init+deinit (with allocation counts), `secureZero`, and
+  `constantTimeEqual` across representative sizes.
+- **TLS record cryptographic component** — traffic key/IV derivation,
+  record AEAD seal/open across all three cipher suites and record sizes, and
+  the authentication-failure path, through `record_protection`.
+- **Resumption/ticket cryptographic component** — `ServerRecoverableState`
+  codec encode/decode at small/medium/large sizes; for every ticket AEAD:
+  `Protector.seal` end to end, public envelope parse only, and complete
+  `Protector.resolve`; resolver-miss paths for malformed, unknown-key, and
+  invalid-tag identities; and keyring/nonce-lease overhead (snapshot build
+  at 1/2/4/8/16 keys, install with and without an in-flight reader,
+  active-snapshot acquire/release, and nonce reservation under real
+  multi-threaded contention).
+
+Not covered: a standalone "AEAD open with a pre-parsed envelope" step.
+`ticket_protection` does not expose its AAD-construction helper publicly,
+and issue #378 itself guards that bullet with "where the API permits it" —
+reimplementing private framing logic in the benchmark would risk silently
+drifting from the real implementation. `resolve` covers the combined
+parse+open+decode cost end to end instead.
+
+## Benchmark contract / metadata
+
+Every measurement in the JSON report carries `suite`, `name`, `algorithm`,
+`input_bytes`, `iterations`, `ns_total`/`ns_per_op`/`ops_per_sec`, and (where
+relevant) `allocations_per_op`/`bytes_allocated_per_op`. The report's
+`_meta` object carries the Tardigrade version, Zig version, OS/architecture,
+build mode, and provider kind — the environment facts issue #378's
+benchmark contract requires for comparability. No production secrets, keys,
+nonces, or ticket identities are logged; every workload uses fixed
+non-secret fixture material generated in-process.
+
+## Budgets
+
+Provider-primitive operations (HKDF, AEAD, key exchange, verify) are
+allocation-free **by construction**, not by runtime sampling:
+`primitives.assertProviderVtableIsAllocatorFree` is a compile-time check
+that no `CryptoProvider.VTable` method takes an `std.mem.Allocator`
+parameter, so no backend can allocate on that path regardless of
+implementation. Ticket/session-codec workloads, which do allocate, report
+actual allocation counts and bytes via a counting allocator instead.
+
+Latency/throughput budgets are advisory trend ceilings
+(`root.latency_budgets`) on a handful of core repeated workloads (AEAD
+seal, KEX shared-secret derivation, signature verify, ticket seal/resolve).
+They are deliberately generous — meant to catch a gross regression, not to
+gate CI on shared-hardware noise — and only print a warning to stderr when
+exceeded; they never fail `bench-crypto` or the build, matching issue
+#378's "budgets may be advisory/trend-based" allowance.
+
+A note on nanosecond-scale numbers: a few of the smallest leaf operations
+(`constantTimeEqual`, `FixedSecret` replace/deinit, `secureZero` on tiny
+buffers) are cheap enough, and simple enough for LLVM to fully inline, that
+naive benchmarking risks the optimizer proving the loop body invariant
+across iterations and collapsing thousands of iterations into one. Each of
+those workloads forces a memory-clobbering `std.mem.doNotOptimizeAway` on
+its input immediately before the operation under measurement (see the
+comments in `primitives.zig`) specifically to defeat that; treat any
+future addition of a similarly tiny, fully-inlinable workload as needing
+the same treatment.
+
+## Ownership boundaries (not duplicated here)
+
+Per issue #378: whole-TLS/PKI/QUIC/H3/HTTP application benchmarks, full
+handshake/resumption latency, encrypted-stream throughput, and generic HTTP
+server competitive benchmarks all belong to their owning protocol/perf
+stories (#323/#324/#325/#326/#369/#247/#149/#150 and the root
+`benchmarks/` HTTP suite), not to this component-benchmark suite.
+
+Two pieces are explicitly deferred, per the issue's own text:
+
+- **QUIC cryptographic component** (Initial secret/key derivation, packet
+  AEAD seal/open, header-protection mask, key-update derivation) — the
+  issue ties this to #490 reconciling provider ownership for QUIC's crypto
+  seam. Add it as a follow-on once that lands, following the same pattern
+  as `record.zig`.
+- **OpenSSL/reference comparison** — the issue frames this as optional
+  ("where a fair independent comparison is stable and useful"), and the
+  approved test/benchmark-only OpenSSL adapter path this would need is
+  worth its own follow-on rather than folding into the initial suite.
+
+## Closeout
+
+Per issue #378's closeout rule, this suite covers the *current* shared
+crypto/provider surface with repeatable component benchmarks and practical
+budgets. Future algorithm additions should extend the matrix here as part
+of their own owning implementation story rather than reopening #378.

--- a/docs/CRYPTO_BENCHMARKS.md
+++ b/docs/CRYPTO_BENCHMARKS.md
@@ -69,9 +69,15 @@ parse+open+decode cost end to end instead.
 Every measurement in the JSON report carries `suite`, `name`, `algorithm`,
 `input_bytes`, `iterations`, `ns_total`/`ns_per_op`/`ops_per_sec`, and (where
 relevant) `allocations_per_op`/`bytes_allocated_per_op`. The report's
-`_meta` object carries the Tardigrade version, Zig version, OS/architecture,
-build mode, and provider kind — the environment facts issue #378's
-benchmark contract requires for comparability. No production secrets, keys,
+`_meta` object carries the exact Tardigrade source commit (`git rev-parse
+HEAD` at build time, overridable with `-Dcommit`, or `"unknown"` for a
+non-git source tree — see `gitCommitSha` in `build.zig`) plus the
+Tardigrade version, Zig version, OS/architecture, build mode, and provider
+kind — the environment facts issue #378's benchmark contract requires for
+comparability. The commit is tracked separately from the version because a
+version string is not unique per commit; without it, two artifacts built
+from different commits of the same release would be indistinguishable. No
+production secrets, keys,
 nonces, or ticket identities are logged; every workload uses fixed
 non-secret fixture material generated in-process.
 

--- a/src/crypto_bench/harness.zig
+++ b/src/crypto_bench/harness.zig
@@ -1,0 +1,241 @@
+//! Shared measurement/report plumbing for the CryptoProvider benchmark suite
+//! (#378, epic #327-I). Every suite (`primitives.zig`, `record.zig`,
+//! `ticket.zig`) times its own workloads with `monotonicNs` and reports
+//! through the `Measurement`/`Report` types here so `root.zig` can print one
+//! consistent JSON document regardless of which suite produced a result.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const build_options = @import("build_options");
+const compat = @import("zig_compat");
+
+/// Zig 0.16 removed `std.time.Timer`; `std.Io.Clock.awake` is this
+/// toolchain's monotonic (not wall-clock/NTP-adjustable) clock, matching
+/// what `Timer` used to wrap. See the `Clock.awake` doc comment in
+/// `std.Io` and `zig_compat.sleepNs`'s identical choice.
+pub fn monotonicNs() i96 {
+    return std.Io.Clock.awake.now(compat.io()).toNanoseconds();
+}
+
+/// How hard each suite should push. `smoke` runs a handful of iterations so
+/// `zig build test-crypto-bench` finishes in well under a second per
+/// workload and is safe to run under the default `zig build test` — it
+/// exists to catch crashes/panics/API drift, not to produce trustworthy
+/// timings. `full` runs enough iterations for the printed ns/op to be
+/// meaningful and is what `zig build bench-crypto` uses.
+pub const Scale = enum {
+    smoke,
+    full,
+
+    pub fn iterations(self: Scale, full_iterations: usize) usize {
+        return switch (self) {
+            .smoke => @min(full_iterations, 5),
+            .full => full_iterations,
+        };
+    }
+};
+
+/// A minimal allocation counter, wrapping a child allocator to report how
+/// many allocations and bytes a workload performed. Only wired around calls
+/// that take an `std.mem.Allocator` in the first place — the `CryptoProvider`
+/// vtable (HKDF, AEAD, key exchange, verify) never does, so those workloads
+/// are allocation-free by construction rather than by runtime measurement
+/// (see `primitives.assertProviderVtableIsAllocatorFree` in primitives.zig).
+pub const CountingAllocator = struct {
+    child: std.mem.Allocator,
+    allocations: usize = 0,
+    frees: usize = 0,
+    bytes_allocated: usize = 0,
+
+    pub fn init(child: std.mem.Allocator) CountingAllocator {
+        return .{ .child = child };
+    }
+
+    pub fn allocator(self: *CountingAllocator) std.mem.Allocator {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    fn alloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ret_addr: usize) ?[*]u8 {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        const ptr = self.child.rawAlloc(len, alignment, ret_addr) orelse return null;
+        self.allocations += 1;
+        self.bytes_allocated += len;
+        return ptr;
+    }
+
+    fn resize(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ret_addr: usize) bool {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        return self.child.rawResize(memory, alignment, new_len, ret_addr);
+    }
+
+    fn remap(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ret_addr: usize) ?[*]u8 {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        return self.child.rawRemap(memory, alignment, new_len, ret_addr);
+    }
+
+    fn free(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, ret_addr: usize) void {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.frees += 1;
+        self.child.rawFree(memory, alignment, ret_addr);
+    }
+
+    const vtable = std.mem.Allocator.VTable{
+        .alloc = alloc,
+        .resize = resize,
+        .remap = remap,
+        .free = free,
+    };
+};
+
+/// One benchmarked workload's result. `suite` groups related workloads in
+/// the report (`hash`, `hkdf`, `aead`, `kex`, `signature`, `secret`,
+/// `record`, `ticket`); `name` identifies the specific workload within it.
+pub const Measurement = struct {
+    suite: []const u8,
+    name: []const u8,
+    algorithm: []const u8 = "",
+    input_bytes: usize = 0,
+    iterations: usize,
+    ns_total: u64,
+    allocations_per_op: f64 = 0,
+    bytes_allocated_per_op: f64 = 0,
+    note: []const u8 = "",
+
+    pub fn nsPerOp(self: Measurement) f64 {
+        return @as(f64, @floatFromInt(self.ns_total)) / @as(f64, @floatFromInt(self.iterations));
+    }
+
+    pub fn opsPerSec(self: Measurement) f64 {
+        const ns_per_op = self.nsPerOp();
+        if (ns_per_op <= 0) return 0;
+        return 1_000_000_000.0 / ns_per_op;
+    }
+};
+
+/// Times `iterations` calls to `step(context)`, discarding no work: callers
+/// are responsible for making sure the loop body cannot be optimised away
+/// (e.g. by folding a byte of real output into a `std.mem.doNotOptimizeAway`
+/// call), matching the pattern every workload in `primitives.zig`/
+/// `record.zig`/`ticket.zig` follows.
+pub fn timeLoop(
+    comptime Context: type,
+    context: *Context,
+    iterations: usize,
+    comptime step: fn (*Context) anyerror!void,
+) !u64 {
+    var i: usize = 0;
+    while (i < iterations) : (i += 1) try step(context);
+    const start = monotonicNs();
+    i = 0;
+    while (i < iterations) : (i += 1) try step(context);
+    const end = monotonicNs();
+    return @intCast(end - start);
+}
+
+/// Environment metadata every benchmark result must be comparable against
+/// (issue #378's "benchmark contract"): Tardigrade version, Zig version,
+/// OS/architecture, build mode, and provider kind. Deliberately excludes
+/// anything from the workloads themselves (keys, nonces, ticket identities)
+/// — only static build/environment facts belong here.
+pub const Metadata = struct {
+    tardigrade_version: []const u8,
+    zig_version: []const u8,
+    os: []const u8,
+    arch: []const u8,
+    optimize_mode: []const u8,
+    provider_kind: []const u8,
+
+    pub fn current() Metadata {
+        return .{
+            .tardigrade_version = build_options.version,
+            .zig_version = builtin.zig_version_string,
+            .os = @tagName(builtin.os.tag),
+            .arch = @tagName(builtin.cpu.arch),
+            .optimize_mode = @tagName(builtin.mode),
+            .provider_kind = "pure_zig",
+        };
+    }
+};
+
+/// Owns the growing measurement list so every suite function can just call
+/// `out.append(.{...})` without threading an `std.mem.Allocator` parameter
+/// through every workload function purely to satisfy Zig 0.16's unmanaged
+/// `std.ArrayList.append(allocator, value)` signature.
+pub const Reporter = struct {
+    allocator: std.mem.Allocator,
+    list: std.ArrayList(Measurement) = .empty,
+
+    pub fn append(self: *Reporter, measurement: Measurement) !void {
+        try self.list.append(self.allocator, measurement);
+    }
+
+    pub fn items(self: *const Reporter) []const Measurement {
+        return self.list.items;
+    }
+
+    pub fn deinit(self: *Reporter) void {
+        self.list.deinit(self.allocator);
+    }
+};
+
+pub fn writeJsonReport(writer: anytype, metadata: Metadata, measurements: []const Measurement) !void {
+    try writer.print(
+        "{{\n  \"_meta\": {{\"benchmark\":\"crypto-provider\",\"tardigrade_version\":\"{s}\",\"zig_version\":\"{s}\",\"os\":\"{s}\",\"arch\":\"{s}\",\"optimize_mode\":\"{s}\",\"provider_kind\":\"{s}\"}},\n  \"measurements\": [\n",
+        .{
+            metadata.tardigrade_version,
+            metadata.zig_version,
+            metadata.os,
+            metadata.arch,
+            metadata.optimize_mode,
+            metadata.provider_kind,
+        },
+    );
+    for (measurements, 0..) |m, i| {
+        try writer.print(
+            "    {{\"suite\":\"{s}\",\"name\":\"{s}\",\"algorithm\":\"{s}\",\"input_bytes\":{d},\"iterations\":{d},\"ns_total\":{d},\"ns_per_op\":{d:.1},\"ops_per_sec\":{d:.1},\"allocations_per_op\":{d:.2},\"bytes_allocated_per_op\":{d:.2},\"note\":\"{s}\"}}",
+            .{
+                m.suite,
+                m.name,
+                m.algorithm,
+                m.input_bytes,
+                m.iterations,
+                m.ns_total,
+                m.nsPerOp(),
+                m.opsPerSec(),
+                m.allocations_per_op,
+                m.bytes_allocated_per_op,
+                m.note,
+            },
+        );
+        try writer.writeAll(if (i + 1 < measurements.len) ",\n" else "\n");
+    }
+    try writer.writeAll("  ]\n}\n");
+}
+
+/// Advisory latency ceiling for one of the "core repeated workloads" issue
+/// #378 asks for a regression budget on. These are deliberately generous —
+/// meant to catch a gross regression (an accidental O(n^2), a lost
+/// fast-path), not to gate CI on shared-hardware noise. A workload that
+/// exceeds its ceiling prints a warning to stderr; it never fails the build
+/// or the test, matching the issue's "budgets may be advisory/trend-based"
+/// allowance.
+pub const LatencyBudget = struct {
+    suite: []const u8,
+    name: []const u8,
+    max_ns_per_op: f64,
+};
+
+pub fn checkLatencyBudgets(measurements: []const Measurement, budgets: []const LatencyBudget) void {
+    for (budgets) |budget| {
+        for (measurements) |m| {
+            if (!std.mem.eql(u8, m.suite, budget.suite) or !std.mem.eql(u8, m.name, budget.name)) continue;
+            const observed = m.nsPerOp();
+            if (observed > budget.max_ns_per_op) {
+                std.debug.print(
+                    "crypto-bench advisory: {s}/{s} took {d:.1} ns/op, over the {d:.1} ns/op trend ceiling (informational only, does not fail the build)\n",
+                    .{ budget.suite, budget.name, observed, budget.max_ns_per_op },
+                );
+            }
+        }
+    }
+}

--- a/src/crypto_bench/harness.zig
+++ b/src/crypto_bench/harness.zig
@@ -133,12 +133,20 @@ pub fn timeLoop(
 }
 
 /// Environment metadata every benchmark result must be comparable against
-/// (issue #378's "benchmark contract"): Tardigrade version, Zig version,
-/// OS/architecture, build mode, and provider kind. Deliberately excludes
-/// anything from the workloads themselves (keys, nonces, ticket identities)
-/// — only static build/environment facts belong here.
+/// (issue #378's "benchmark contract"): Tardigrade commit and version, Zig
+/// version, OS/architecture, build mode, and provider kind. Deliberately
+/// excludes anything from the workloads themselves (keys, nonces, ticket
+/// identities) — only static build/environment facts belong here.
+///
+/// `tardigrade_commit` is the exact source revision (`build.zig`'s
+/// `gitCommitSha`, embedded via `-Dcommit` / `git rev-parse HEAD`, or
+/// `"unknown"` for a non-git source tree) — distinct from
+/// `tardigrade_version`, which names a release and is not unique per
+/// commit, so two builds sharing a version string still produce
+/// distinguishable, attributable benchmark artifacts.
 pub const Metadata = struct {
     tardigrade_version: []const u8,
+    tardigrade_commit: []const u8,
     zig_version: []const u8,
     os: []const u8,
     arch: []const u8,
@@ -148,6 +156,7 @@ pub const Metadata = struct {
     pub fn current() Metadata {
         return .{
             .tardigrade_version = build_options.version,
+            .tardigrade_commit = build_options.commit,
             .zig_version = builtin.zig_version_string,
             .os = @tagName(builtin.os.tag),
             .arch = @tagName(builtin.cpu.arch),
@@ -180,9 +189,10 @@ pub const Reporter = struct {
 
 pub fn writeJsonReport(writer: anytype, metadata: Metadata, measurements: []const Measurement) !void {
     try writer.print(
-        "{{\n  \"_meta\": {{\"benchmark\":\"crypto-provider\",\"tardigrade_version\":\"{s}\",\"zig_version\":\"{s}\",\"os\":\"{s}\",\"arch\":\"{s}\",\"optimize_mode\":\"{s}\",\"provider_kind\":\"{s}\"}},\n  \"measurements\": [\n",
+        "{{\n  \"_meta\": {{\"benchmark\":\"crypto-provider\",\"tardigrade_version\":\"{s}\",\"tardigrade_commit\":\"{s}\",\"zig_version\":\"{s}\",\"os\":\"{s}\",\"arch\":\"{s}\",\"optimize_mode\":\"{s}\",\"provider_kind\":\"{s}\"}},\n  \"measurements\": [\n",
         .{
             metadata.tardigrade_version,
+            metadata.tardigrade_commit,
             metadata.zig_version,
             metadata.os,
             metadata.arch,

--- a/src/crypto_bench/primitives.zig
+++ b/src/crypto_bench/primitives.zig
@@ -1,0 +1,721 @@
+//! Provider primitive workloads for issue #378: hash/HKDF, AEAD, key
+//! exchange, signatures, and secret-container overhead. Every workload
+//! drives `pure_zig.Provider` directly through `provider.CryptoProvider` —
+//! the same "own-stack-frame provider, never shared, never a protocol state
+//! machine" pattern `tests/crypto_provider_fuzz.zig` uses — so a benchmark
+//! run measures exactly the seam native TLS/QUIC code calls through.
+
+const std = @import("std");
+const crypto = @import("crypto");
+const harness = @import("harness.zig");
+
+const provider = crypto.provider;
+const pure_zig = crypto.pure_zig;
+const secrets = crypto.secrets;
+const rsa = crypto.rsa;
+
+const Measurement = harness.Measurement;
+const Scale = harness.Scale;
+
+const Ed25519 = std.crypto.sign.Ed25519;
+const EcdsaP256Sha256 = std.crypto.sign.ecdsa.EcdsaP256Sha256;
+
+const message_len = 128;
+const max_plaintext_len = 16384;
+const payload_sizes = [_]usize{ 64, 1350, max_plaintext_len };
+/// RSA-PSS public keys (DER `RSAPublicKey`) are unrelated in size to
+/// `provider.max_public_key_len` (which bounds KEX public *values*, not
+/// signature-scheme public *keys*); size this independently for up to a
+/// 4096-bit RSA modulus.
+const max_verify_public_key_len = 600;
+
+fn testMessage() [message_len]u8 {
+    var buf: [message_len]u8 = undefined;
+    for (&buf, 0..) |*b, i| b.* = @truncate(i * 31 + 7);
+    return buf;
+}
+
+/// Container-scope (comptime-evaluated once) rather than a function-local:
+/// a nested `step` function inside a `Context` struct literal cannot close
+/// over an enclosing function's runtime locals in Zig, only over
+/// container-scope declarations and comptime parameters. Every signature
+/// workload below references this directly for that reason.
+const message: [message_len]u8 = testMessage();
+
+/// Every benchmark constructs its own `TestProvider` on its own stack frame
+/// and calls `init` on the already-addressed value — never build one in a
+/// helper and return it by value. `Provider.entropy` stores a raw pointer to
+/// `self.entropy`; a by-value return would leave that pointer aimed at a
+/// temporary that no longer exists once the helper returns (see the
+/// identical warning in `tests/crypto_provider_fuzz.zig`).
+const TestProvider = struct {
+    entropy: pure_zig.DeterministicEntropy,
+    instance: pure_zig.Provider,
+
+    fn init(self: *TestProvider, seed: u64) void {
+        self.entropy = pure_zig.DeterministicEntropy.init(seed);
+        self.instance = pure_zig.Provider.init(self.entropy.entropy());
+    }
+
+    fn cryptoProvider(self: *const TestProvider) provider.CryptoProvider {
+        return self.instance.cryptoProvider();
+    }
+};
+
+/// Structural regression guard for the "allocation-free by construction"
+/// claim the harness's `CountingAllocator` doc comment makes: every
+/// `CryptoProvider.VTable` operation takes no `std.mem.Allocator` parameter,
+/// so HKDF/AEAD/key-exchange/verify calls cannot allocate no matter which
+/// backend implements them.
+pub fn assertProviderVtableIsAllocatorFree() void {
+    const Vtable = provider.CryptoProvider.VTable;
+    inline for (@typeInfo(Vtable).@"struct".fields) |field| {
+        const fn_info = @typeInfo(@typeInfo(field.type).pointer.child).@"fn";
+        inline for (fn_info.params) |param| {
+            if (param.type) |t| {
+                if (t == std.mem.Allocator) @compileError("CryptoProvider.VTable." ++ field.name ++ " must not take an allocator");
+            }
+        }
+    }
+}
+
+pub fn run(allocator: std.mem.Allocator, out: *harness.Reporter, scale: Scale) !void {
+    comptime assertProviderVtableIsAllocatorFree();
+    try runHash(out, scale);
+    try runHkdf(out, scale);
+    try runAead(out, scale);
+    try runKeyExchange(out, scale);
+    try runSignatures(out, scale);
+    try runSecrets(allocator, out, scale);
+}
+
+// ---------------------------------------------------------------------------
+// Hash (provider-independent; explanatory only, per issue #378)
+// ---------------------------------------------------------------------------
+
+fn runHash(out: *harness.Reporter, scale: Scale) !void {
+    const sizes = [_]usize{ 64, 1350, max_plaintext_len };
+    inline for (.{ "sha256", "sha384" }) |name| {
+        for (sizes) |size| {
+            var input_buf: [max_plaintext_len]u8 = undefined;
+            for (input_buf[0..size], 0..) |*b, i| b.* = @truncate(i);
+            const Context = struct {
+                input: []const u8,
+                digest: [64]u8 = undefined,
+
+                fn step(self: *@This()) !void {
+                    // See `runFixedSecret`'s barrier comment: hashing a
+                    // fixed, never-mutated input is otherwise a loop
+                    // invariant a sufficiently aggressive inliner could hoist.
+                    std.mem.doNotOptimizeAway(self.input);
+                    if (comptime std.mem.eql(u8, name, "sha256")) {
+                        var h = std.crypto.hash.sha2.Sha256.init(.{});
+                        h.update(self.input);
+                        h.final(self.digest[0..32]);
+                    } else {
+                        var h = std.crypto.hash.sha2.Sha384.init(.{});
+                        h.update(self.input);
+                        h.final(self.digest[0..48]);
+                    }
+                    std.mem.doNotOptimizeAway(self.digest[0]);
+                }
+            };
+            var ctx = Context{ .input = input_buf[0..size] };
+            const iterations = scale.iterations(2000);
+            const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+            try out.append(.{
+                .suite = "hash",
+                .name = "digest",
+                .algorithm = name,
+                .input_bytes = size,
+                .iterations = iterations,
+                .ns_total = ns,
+                .note = "provider-independent std.crypto hash, benchmarked for explanatory context only",
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HKDF
+// ---------------------------------------------------------------------------
+
+fn runHkdf(out: *harness.Reporter, scale: Scale) !void {
+    inline for (.{ provider.Hash.sha256, provider.Hash.sha384 }) |hash| {
+        try runHkdfExtract(out, scale, hash);
+        try runHkdfExpandLabel(out, scale, hash);
+    }
+    try runRepeatedTrafficKeyDerivation(out, scale);
+}
+
+fn runHkdfExtract(out: *harness.Reporter, scale: Scale, comptime hash: provider.Hash) !void {
+    var tp: TestProvider = undefined;
+    tp.init(0x378_01);
+    const cp = tp.cryptoProvider();
+    const Context = struct {
+        cp: provider.CryptoProvider,
+        salt: [32]u8 = [_]u8{0x11} ** 32,
+        ikm: [40]u8 = [_]u8{0x22} ** 40,
+        prk: [hash.digestLength()]u8 = undefined,
+
+        fn step(self: *@This()) !void {
+            try self.cp.hkdfExtract(hash, &self.salt, &self.ikm, &self.prk);
+            std.mem.doNotOptimizeAway(self.prk[0]);
+        }
+    };
+    var ctx = Context{ .cp = cp };
+    const iterations = scale.iterations(5000);
+    const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+    try out.append(.{ .suite = "hkdf", .name = "extract", .algorithm = @tagName(hash), .iterations = iterations, .ns_total = ns });
+}
+
+fn runHkdfExpandLabel(out: *harness.Reporter, scale: Scale, comptime hash: provider.Hash) !void {
+    const output_lens = [_]usize{ 16, 32, 48, 64 };
+    const context_lens = [_]usize{ 0, 32, 48 };
+    for (output_lens) |out_len| {
+        for (context_lens) |ctx_len| {
+            var tp: TestProvider = undefined;
+            tp.init(0x378_02);
+            const cp = tp.cryptoProvider();
+            const Context = struct {
+                cp: provider.CryptoProvider,
+                secret: [hash.digestLength()]u8 = [_]u8{0x33} ** hash.digestLength(),
+                hash_context: [48]u8 = [_]u8{0x44} ** 48,
+                expanded: [64]u8 = undefined,
+                out_len: usize,
+                ctx_len: usize,
+
+                fn step(self: *@This()) !void {
+                    try self.cp.hkdfExpandLabel(hash, &self.secret, "traffic upd", self.hash_context[0..self.ctx_len], self.expanded[0..self.out_len]);
+                    std.mem.doNotOptimizeAway(self.expanded[0]);
+                }
+            };
+            var ctx = Context{ .cp = cp, .out_len = out_len, .ctx_len = ctx_len };
+            const iterations = scale.iterations(5000);
+            const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+            try out.append(.{
+                .suite = "hkdf",
+                .name = "expand_label",
+                .algorithm = @tagName(hash),
+                .input_bytes = out_len,
+                .iterations = iterations,
+                .ns_total = ns,
+                .note = "input_bytes is the derived-output length; hash_context length varies 0/32/48 across runs",
+            });
+        }
+    }
+}
+
+fn runRepeatedTrafficKeyDerivation(out: *harness.Reporter, scale: Scale) !void {
+    // Simulates the repeated key+iv derivation pattern the TLS 1.3 record
+    // layer performs on every epoch change (handshake, application, and any
+    // KeyUpdate), without depending on tls_core: two HKDF-Expand-Label calls
+    // ("key" then "iv") per iteration.
+    var tp: TestProvider = undefined;
+    tp.init(0x378_03);
+    const cp = tp.cryptoProvider();
+    const Context = struct {
+        cp: provider.CryptoProvider,
+        secret: [32]u8 = [_]u8{0x55} ** 32,
+        key: [16]u8 = undefined,
+        iv: [provider.aead_nonce_len]u8 = undefined,
+
+        fn step(self: *@This()) !void {
+            try self.cp.hkdfExpandLabel(.sha256, &self.secret, "key", "", &self.key);
+            try self.cp.hkdfExpandLabel(.sha256, &self.secret, "iv", "", &self.iv);
+            std.mem.doNotOptimizeAway(self.key[0]);
+        }
+    };
+    var ctx = Context{ .cp = cp };
+    const iterations = scale.iterations(3000);
+    const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+    try out.append(.{
+        .suite = "hkdf",
+        .name = "repeated_traffic_key_derivation",
+        .algorithm = "sha256",
+        .iterations = iterations,
+        .ns_total = ns,
+        .note = "one key + one iv HKDF-Expand-Label pair per iteration, matching a record-layer epoch change",
+    });
+}
+
+// ---------------------------------------------------------------------------
+// AEAD
+// ---------------------------------------------------------------------------
+
+fn runAead(out: *harness.Reporter, scale: Scale) !void {
+    inline for (.{ provider.Aead.aes_128_gcm, provider.Aead.aes_256_gcm, provider.Aead.chacha20_poly1305 }) |aead| {
+        for (payload_sizes) |size| {
+            try runAeadSeal(out, scale, aead, size);
+            try runAeadOpen(out, scale, aead, size);
+        }
+        try runAeadAuthFailure(out, scale, aead);
+    }
+}
+
+fn runAeadSeal(out: *harness.Reporter, scale: Scale, comptime aead: provider.Aead, size: usize) !void {
+    var tp: TestProvider = undefined;
+    tp.init(0x378_10);
+    const cp = tp.cryptoProvider();
+    const Context = struct {
+        cp: provider.CryptoProvider,
+        key: [aead.keyLength()]u8 = [_]u8{0x66} ** aead.keyLength(),
+        nonce: [provider.aead_nonce_len]u8 = [_]u8{0} ** provider.aead_nonce_len,
+        plaintext: [max_plaintext_len]u8 = [_]u8{0x77} ** max_plaintext_len,
+        ciphertext: [max_plaintext_len]u8 = undefined,
+        tag: [provider.aead_tag_len]u8 = undefined,
+        counter: u64 = 0,
+        size: usize,
+
+        fn step(self: *@This()) !void {
+            std.mem.writeInt(u64, self.nonce[4..12], self.counter, .big);
+            self.counter +%= 1;
+            try self.cp.aeadSeal(aead, &self.key, &self.nonce, "associated data", self.plaintext[0..self.size], self.ciphertext[0..self.size], &self.tag);
+            std.mem.doNotOptimizeAway(self.ciphertext[0]);
+        }
+    };
+    var ctx = Context{ .cp = cp, .size = size };
+    const iterations = scale.iterations(if (size >= max_plaintext_len) 500 else 3000);
+    const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+    try out.append(.{ .suite = "aead", .name = "seal", .algorithm = @tagName(aead), .input_bytes = size, .iterations = iterations, .ns_total = ns });
+}
+
+fn runAeadOpen(out: *harness.Reporter, scale: Scale, comptime aead: provider.Aead, size: usize) !void {
+    var tp: TestProvider = undefined;
+    tp.init(0x378_11);
+    const cp = tp.cryptoProvider();
+    const key = [_]u8{0x66} ** aead.keyLength();
+    const nonce = [_]u8{0x88} ** provider.aead_nonce_len;
+    var plaintext: [max_plaintext_len]u8 = [_]u8{0x77} ** max_plaintext_len;
+    var ciphertext: [max_plaintext_len]u8 = undefined;
+    var tag: [provider.aead_tag_len]u8 = undefined;
+    try cp.aeadSeal(aead, &key, &nonce, "associated data", plaintext[0..size], ciphertext[0..size], &tag);
+
+    const Context = struct {
+        cp: provider.CryptoProvider,
+        key: [aead.keyLength()]u8,
+        nonce: [provider.aead_nonce_len]u8,
+        ciphertext: [max_plaintext_len]u8,
+        tag: [provider.aead_tag_len]u8,
+        recovered: [max_plaintext_len]u8 = undefined,
+        size: usize,
+
+        fn step(self: *@This()) !void {
+            try self.cp.aeadOpen(aead, &self.key, &self.nonce, "associated data", self.ciphertext[0..self.size], &self.tag, self.recovered[0..self.size]);
+            std.mem.doNotOptimizeAway(self.recovered[0]);
+        }
+    };
+    var ctx = Context{ .cp = cp, .key = key, .nonce = nonce, .ciphertext = ciphertext, .tag = tag, .size = size };
+    const iterations = scale.iterations(if (size >= max_plaintext_len) 500 else 3000);
+    const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+    try out.append(.{ .suite = "aead", .name = "open", .algorithm = @tagName(aead), .input_bytes = size, .iterations = iterations, .ns_total = ns });
+}
+
+fn runAeadAuthFailure(out: *harness.Reporter, scale: Scale, comptime aead: provider.Aead) !void {
+    var tp: TestProvider = undefined;
+    tp.init(0x378_12);
+    const cp = tp.cryptoProvider();
+    const size = 1350;
+    const key = [_]u8{0x99} ** aead.keyLength();
+    const nonce = [_]u8{0xaa} ** provider.aead_nonce_len;
+    var plaintext: [size]u8 = [_]u8{0x77} ** size;
+    var ciphertext: [size]u8 = undefined;
+    var tag: [provider.aead_tag_len]u8 = undefined;
+    try cp.aeadSeal(aead, &key, &nonce, "associated data", &plaintext, &ciphertext, &tag);
+    ciphertext[0] ^= 0x01; // tamper: every open() below must reject, not just decode.
+
+    const Context = struct {
+        cp: provider.CryptoProvider,
+        key: [aead.keyLength()]u8,
+        nonce: [provider.aead_nonce_len]u8,
+        ciphertext: [size]u8,
+        tag: [provider.aead_tag_len]u8,
+        recovered: [size]u8 = undefined,
+
+        fn step(self: *@This()) !void {
+            const result = self.cp.aeadOpen(aead, &self.key, &self.nonce, "associated data", &self.ciphertext, &self.tag, &self.recovered);
+            if (result) |_| return error.ExpectedAuthenticationFailure else |err| {
+                if (err != error.AuthenticationFailed) return err;
+            }
+        }
+    };
+    var ctx = Context{ .cp = cp, .key = key, .nonce = nonce, .ciphertext = ciphertext, .tag = tag };
+    const iterations = scale.iterations(3000);
+    const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+    try out.append(.{ .suite = "aead", .name = "open_auth_failure", .algorithm = @tagName(aead), .input_bytes = size, .iterations = iterations, .ns_total = ns, .note = "tampered ciphertext; every call rejects" });
+}
+
+// ---------------------------------------------------------------------------
+// Key exchange
+// ---------------------------------------------------------------------------
+
+fn runKeyExchange(out: *harness.Reporter, scale: Scale) !void {
+    inline for (.{ provider.Group.x25519, provider.Group.secp256r1 }) |group| {
+        try runKeyShareGeneration(out, scale, group);
+        try runSharedSecretDerivation(out, scale, group);
+        try runInvalidPeerKeyRejection(out, scale, group);
+    }
+}
+
+fn runKeyShareGeneration(out: *harness.Reporter, scale: Scale, comptime group: provider.Group) !void {
+    var tp: TestProvider = undefined;
+    tp.init(0x378_20);
+    const cp = tp.cryptoProvider();
+    const Context = struct {
+        cp: provider.CryptoProvider,
+        public_key: [group.publicKeyLength()]u8 = undefined,
+        private_key: [provider.max_private_scalar_len]u8 = undefined,
+
+        fn step(self: *@This()) !void {
+            try self.cp.generateKeyShare(group, &self.public_key, &self.private_key);
+            std.mem.doNotOptimizeAway(self.public_key[0]);
+        }
+    };
+    var ctx = Context{ .cp = cp };
+    const iterations = scale.iterations(1000);
+    const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+    try out.append(.{ .suite = "kex", .name = "generate_key_share", .algorithm = @tagName(group), .iterations = iterations, .ns_total = ns });
+}
+
+fn runSharedSecretDerivation(out: *harness.Reporter, scale: Scale, comptime group: provider.Group) !void {
+    var tp: TestProvider = undefined;
+    tp.init(0x378_21);
+    const cp = tp.cryptoProvider();
+    var our_public: [group.publicKeyLength()]u8 = undefined;
+    var our_private: [provider.max_private_scalar_len]u8 = undefined;
+    try cp.generateKeyShare(group, &our_public, &our_private);
+    var peer_public: [group.publicKeyLength()]u8 = undefined;
+    var peer_private: [provider.max_private_scalar_len]u8 = undefined;
+    try cp.generateKeyShare(group, &peer_public, &peer_private);
+
+    const Context = struct {
+        cp: provider.CryptoProvider,
+        our_private: [provider.max_private_scalar_len]u8,
+        peer_public: [group.publicKeyLength()]u8,
+        shared: [group.sharedSecretLength()]u8 = undefined,
+
+        fn step(self: *@This()) !void {
+            try self.cp.deriveSharedSecret(group, &self.our_private, &self.peer_public, &self.shared);
+            std.mem.doNotOptimizeAway(self.shared[0]);
+        }
+    };
+    var ctx = Context{ .cp = cp, .our_private = our_private, .peer_public = peer_public };
+    const iterations = scale.iterations(1000);
+    const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+    try out.append(.{ .suite = "kex", .name = "derive_shared_secret", .algorithm = @tagName(group), .iterations = iterations, .ns_total = ns });
+}
+
+fn runInvalidPeerKeyRejection(out: *harness.Reporter, scale: Scale, comptime group: provider.Group) !void {
+    var tp: TestProvider = undefined;
+    tp.init(0x378_22);
+    const cp = tp.cryptoProvider();
+    var our_public: [group.publicKeyLength()]u8 = undefined;
+    var our_private: [provider.max_private_scalar_len]u8 = undefined;
+    try cp.generateKeyShare(group, &our_public, &our_private);
+
+    var invalid_peer: [group.publicKeyLength()]u8 = [_]u8{0} ** group.publicKeyLength();
+    if (group == .secp256r1) invalid_peer[0] = 0x00; // rejected before any curve math: not the 0x04 SEC1 prefix.
+
+    const Context = struct {
+        cp: provider.CryptoProvider,
+        our_private: [provider.max_private_scalar_len]u8,
+        invalid_peer: [group.publicKeyLength()]u8,
+        shared: [group.sharedSecretLength()]u8 = undefined,
+
+        fn step(self: *@This()) !void {
+            const result = self.cp.deriveSharedSecret(group, &self.our_private, &self.invalid_peer, &self.shared);
+            if (result) |_| return error.ExpectedInvalidInput else |err| {
+                if (err != error.InvalidInput) return err;
+            }
+        }
+    };
+    var ctx = Context{ .cp = cp, .our_private = our_private, .invalid_peer = invalid_peer };
+    const iterations = scale.iterations(1000);
+    const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+    try out.append(.{ .suite = "kex", .name = "reject_invalid_peer_key", .algorithm = @tagName(group), .iterations = iterations, .ns_total = ns, .note = "all-zero/malformed peer public value; every call rejects" });
+}
+
+// ---------------------------------------------------------------------------
+// Signatures
+// ---------------------------------------------------------------------------
+
+fn runSignatures(out: *harness.Reporter, scale: Scale) !void {
+    try runEd25519(out, scale);
+    try runEcdsaP256(out, scale);
+    try runRsaPss(out, scale);
+}
+
+fn runEd25519(out: *harness.Reporter, scale: Scale) !void {
+    var tp: TestProvider = undefined;
+    tp.init(0x378_30);
+    const cp = tp.cryptoProvider();
+
+    const seed: [Ed25519.KeyPair.seed_length]u8 = [_]u8{0xbb} ** Ed25519.KeyPair.seed_length;
+    var key = try pure_zig.SoftwareSigningKey.fromSeed(seed);
+    defer key.deinit();
+    const public_key = key.publicKey();
+
+    {
+        const Context = struct {
+            key: pure_zig.SoftwareSigningKey,
+            entropy: provider.Entropy,
+            signature: [provider.max_signature_len]u8 = undefined,
+
+            fn step(self: *@This()) !void {
+                const len = try self.key.signingKey().sign(&message, self.entropy, &self.signature);
+                std.mem.doNotOptimizeAway(self.signature[len - 1]);
+            }
+        };
+        var ctx = Context{ .key = try pure_zig.SoftwareSigningKey.fromSeed(seed), .entropy = cp.entropy };
+        defer ctx.key.deinit();
+        const iterations = scale.iterations(2000);
+        const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+        try out.append(.{ .suite = "signature", .name = "sign", .algorithm = "ed25519", .iterations = iterations, .ns_total = ns });
+    }
+
+    var signature: [provider.max_signature_len]u8 = undefined;
+    const sig_len = try key.signingKey().sign(&message, cp.entropy, &signature);
+
+    try runVerify(out, scale, .ed25519, &public_key, signature[0..sig_len]);
+    try runInvalidSignatureRejection(out, scale, .ed25519, &public_key, signature[0..sig_len]);
+}
+
+fn runEcdsaP256(out: *harness.Reporter, scale: Scale) !void {
+    var tp: TestProvider = undefined;
+    tp.init(0x378_31);
+    const cp = tp.cryptoProvider();
+
+    const seed: [EcdsaP256Sha256.KeyPair.seed_length]u8 = [_]u8{0xcc} ** EcdsaP256Sha256.KeyPair.seed_length;
+    var key = try pure_zig.SoftwareEcdsaP256SigningKey.fromSeed(seed);
+    defer key.deinit();
+    const public_key = key.publicKeySec1();
+
+    {
+        const Context = struct {
+            key: pure_zig.SoftwareEcdsaP256SigningKey,
+            entropy: provider.Entropy,
+            signature: [provider.max_signature_len]u8 = undefined,
+
+            fn step(self: *@This()) !void {
+                const len = try self.key.signingKey().sign(&message, self.entropy, &self.signature);
+                std.mem.doNotOptimizeAway(self.signature[len - 1]);
+            }
+        };
+        var ctx = Context{ .key = try pure_zig.SoftwareEcdsaP256SigningKey.fromSeed(seed), .entropy = cp.entropy };
+        defer ctx.key.deinit();
+        const iterations = scale.iterations(1000);
+        const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+        try out.append(.{ .suite = "signature", .name = "sign", .algorithm = "ecdsa_secp256r1_sha256", .iterations = iterations, .ns_total = ns });
+    }
+
+    var signature: [provider.max_signature_len]u8 = undefined;
+    const sig_len = try key.signingKey().sign(&message, cp.entropy, &signature);
+
+    try runVerify(out, scale, .ecdsa_secp256r1_sha256, &public_key, signature[0..sig_len]);
+    try runInvalidSignatureRejection(out, scale, .ecdsa_secp256r1_sha256, &public_key, signature[0..sig_len]);
+}
+
+fn runRsaPss(out: *harness.Reporter, scale: Scale) !void {
+    var tp: TestProvider = undefined;
+    tp.init(0x378_32);
+    const cp = tp.cryptoProvider();
+
+    var key = try pure_zig.SoftwareRsaSigningKey.fromDer(rsa.testdata.private_key_pkcs1_der, cp.entropy);
+    defer key.deinit();
+    const public_key = rsa.testdata.public_key_der;
+
+    var signature: [provider.max_signature_len]u8 = undefined;
+    var signature_len: usize = 0;
+    {
+        const Context = struct {
+            key: pure_zig.SoftwareRsaSigningKey,
+            entropy: provider.Entropy,
+            signature: [provider.max_signature_len]u8 = undefined,
+
+            fn step(self: *@This()) !void {
+                const len = try self.key.signingKey().sign(&message, self.entropy, &self.signature);
+                std.mem.doNotOptimizeAway(self.signature[len - 1]);
+            }
+        };
+        var key_copy = try pure_zig.SoftwareRsaSigningKey.fromDer(rsa.testdata.private_key_pkcs1_der, cp.entropy);
+        defer key_copy.deinit();
+        var ctx = Context{ .key = key_copy, .entropy = cp.entropy };
+        defer ctx.key.deinit();
+        const iterations = scale.iterations(50);
+        const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+        try out.append(.{ .suite = "signature", .name = "sign", .algorithm = "rsa_pss_rsae_sha256", .iterations = iterations, .ns_total = ns });
+        signature = ctx.signature;
+    }
+    signature_len = try key.signingKey().sign(&message, cp.entropy, &signature);
+
+    try runVerify(out, scale, .rsa_pss_rsae_sha256, public_key, signature[0..signature_len]);
+    try runInvalidSignatureRejection(out, scale, .rsa_pss_rsae_sha256, public_key, signature[0..signature_len]);
+}
+
+fn runVerify(out: *harness.Reporter, scale: Scale, comptime scheme: provider.SignatureScheme, public_key: []const u8, signature: []const u8) !void {
+    var tp: TestProvider = undefined;
+    tp.init(0x378_33);
+    const cp = tp.cryptoProvider();
+    const Context = struct {
+        cp: provider.CryptoProvider,
+        public_key: [max_verify_public_key_len]u8,
+        public_key_len: usize,
+        signature: [provider.max_signature_len]u8,
+        signature_len: usize,
+
+        fn step(self: *@This()) !void {
+            try self.cp.verify(scheme, self.public_key[0..self.public_key_len], &message, self.signature[0..self.signature_len]);
+        }
+    };
+    var public_key_buf: [max_verify_public_key_len]u8 = undefined;
+    @memcpy(public_key_buf[0..public_key.len], public_key);
+    var signature_buf: [provider.max_signature_len]u8 = undefined;
+    @memcpy(signature_buf[0..signature.len], signature);
+    var ctx = Context{ .cp = cp, .public_key = public_key_buf, .public_key_len = public_key.len, .signature = signature_buf, .signature_len = signature.len };
+    const iterations = scale.iterations(if (scheme == .rsa_pss_rsae_sha256) 200 else 2000);
+    const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+    try out.append(.{ .suite = "signature", .name = "verify", .algorithm = @tagName(scheme), .iterations = iterations, .ns_total = ns });
+}
+
+fn runInvalidSignatureRejection(out: *harness.Reporter, scale: Scale, comptime scheme: provider.SignatureScheme, public_key: []const u8, signature: []const u8) !void {
+    var tp: TestProvider = undefined;
+    tp.init(0x378_34);
+    const cp = tp.cryptoProvider();
+    var tampered: [provider.max_signature_len]u8 = undefined;
+    @memcpy(tampered[0..signature.len], signature);
+    tampered[signature.len - 1] ^= 0x01;
+
+    const Context = struct {
+        cp: provider.CryptoProvider,
+        public_key: [max_verify_public_key_len]u8,
+        public_key_len: usize,
+        signature: [provider.max_signature_len]u8,
+        signature_len: usize,
+
+        fn step(self: *@This()) !void {
+            const result = self.cp.verify(scheme, self.public_key[0..self.public_key_len], &message, self.signature[0..self.signature_len]);
+            if (result) |_| return error.ExpectedAuthenticationFailure else |err| {
+                if (err != error.AuthenticationFailed) return err;
+            }
+        }
+    };
+    var public_key_buf: [max_verify_public_key_len]u8 = undefined;
+    @memcpy(public_key_buf[0..public_key.len], public_key);
+    var ctx = Context{ .cp = cp, .public_key = public_key_buf, .public_key_len = public_key.len, .signature = tampered, .signature_len = signature.len };
+    const iterations = scale.iterations(if (scheme == .rsa_pss_rsae_sha256) 200 else 2000);
+    const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+    try out.append(.{ .suite = "signature", .name = "reject_invalid_signature", .algorithm = @tagName(scheme), .iterations = iterations, .ns_total = ns, .note = "tampered signature; every call rejects" });
+}
+
+// ---------------------------------------------------------------------------
+// Secret-container / helper overhead
+// ---------------------------------------------------------------------------
+
+fn runSecrets(allocator: std.mem.Allocator, out: *harness.Reporter, scale: Scale) !void {
+    try runFixedSecret(out, scale);
+    try runBoundedSecret(allocator, out, scale);
+    try runSecureZero(out, scale);
+    try runConstantTimeEqual(out, scale);
+}
+
+fn runFixedSecret(out: *harness.Reporter, scale: Scale) !void {
+    inline for (.{ 16, 32, 48 }) |capacity| {
+        const Secret = secrets.FixedSecret(capacity);
+        const Context = struct {
+            value: [capacity]u8 = [_]u8{0xdd} ** capacity,
+
+            fn step(self: *@This()) !void {
+                // `&self.value` is a memory-clobbering barrier (see
+                // `std.mem.doNotOptimizeAway`'s `.pointer` case), not just an
+                // "escape" hint: without it, this whole tiny/fully-inlinable
+                // operation over unchanging bytes is a textbook loop-invariant
+                // the optimizer can legally hoist out of the timed loop,
+                // collapsing thousands of iterations to one and reporting a
+                // meaningless near-zero cost.
+                std.mem.doNotOptimizeAway(&self.value);
+                var secret = try Secret.init(&self.value);
+                secret.deinit();
+            }
+        };
+        var ctx = Context{};
+        const iterations = scale.iterations(5000);
+        const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+        try out.append(.{ .suite = "secret", .name = "fixed_secret_replace_deinit", .algorithm = "FixedSecret", .input_bytes = capacity, .iterations = iterations, .ns_total = ns });
+    }
+}
+
+fn runBoundedSecret(allocator: std.mem.Allocator, out: *harness.Reporter, scale: Scale) !void {
+    inline for (.{ 64, 1024, 4096 }) |capacity| {
+        var value: [capacity]u8 = [_]u8{0xee} ** capacity;
+        const Context = struct {
+            allocator: std.mem.Allocator,
+            value: []const u8,
+
+            fn step(self: *@This()) !void {
+                var secret = secrets.BoundedSecret{};
+                try secret.init(self.allocator, capacity, self.value);
+                secret.deinit();
+            }
+        };
+        var counting = harness.CountingAllocator.init(allocator);
+        var ctx = Context{ .allocator = counting.allocator(), .value = &value };
+        const iterations = scale.iterations(2000);
+        const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+        try out.append(.{
+            .suite = "secret",
+            .name = "bounded_secret_init_deinit",
+            .algorithm = "BoundedSecret",
+            .input_bytes = capacity,
+            .iterations = iterations,
+            .ns_total = ns,
+            .allocations_per_op = @as(f64, @floatFromInt(counting.allocations)) / @as(f64, @floatFromInt(iterations)),
+            .bytes_allocated_per_op = @as(f64, @floatFromInt(counting.bytes_allocated)) / @as(f64, @floatFromInt(iterations)),
+        });
+    }
+}
+
+fn runSecureZero(out: *harness.Reporter, scale: Scale) !void {
+    inline for (.{ 16, 256, 4096 }) |size| {
+        const Context = struct {
+            buf: [size]u8 = [_]u8{0xff} ** size,
+
+            fn step(self: *@This()) !void {
+                // See the identical barrier in `runFixedSecret`: without
+                // forcing the compiler to treat `buf` as possibly changed
+                // since the last iteration, repeatedly zeroing an
+                // already-zero, never-read buffer is a loop-invariant the
+                // optimizer can legally collapse to one iteration.
+                std.mem.doNotOptimizeAway(&self.buf);
+                secrets.secureZero(&self.buf);
+            }
+        };
+        var ctx = Context{};
+        const iterations = scale.iterations(5000);
+        const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+        try out.append(.{ .suite = "secret", .name = "secure_zero", .algorithm = "secureZero", .input_bytes = size, .iterations = iterations, .ns_total = ns });
+    }
+}
+
+fn runConstantTimeEqual(out: *harness.Reporter, scale: Scale) !void {
+    inline for (.{ 16, 32, 48 }) |size| {
+        const Context = struct {
+            a: [size]u8 = [_]u8{0x12} ** size,
+            b: [size]u8 = [_]u8{0x12} ** size,
+            result: bool = false,
+
+            fn step(self: *@This()) !void {
+                // See the identical barrier in `runFixedSecret`: `a` and `b`
+                // are structurally always equal, so without this the
+                // optimizer can algebraically fold the whole comparison to
+                // `true` and hoist it out of the loop regardless of size.
+                std.mem.doNotOptimizeAway(&self.a);
+                std.mem.doNotOptimizeAway(&self.b);
+                self.result = secrets.constantTimeEqual(&self.a, &self.b);
+            }
+        };
+        var ctx = Context{};
+        const iterations = scale.iterations(20000);
+        const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+        try out.append(.{ .suite = "secret", .name = "constant_time_equal", .algorithm = "constantTimeEqual", .input_bytes = size, .iterations = iterations, .ns_total = ns, .note = "equal-value comparison (worst case: full length compared)" });
+    }
+}

--- a/src/crypto_bench/record.zig
+++ b/src/crypto_bench/record.zig
@@ -1,0 +1,249 @@
+//! TLS record cryptographic component workloads for issue #378: traffic
+//! key/IV derivation, record AEAD seal/open, and the authentication-failure
+//! path, through `tls_core.record_protection` — the same module the native
+//! TLS record layer uses. Whole-stream/HTTP throughput stays out of scope
+//! here per the issue's ownership boundaries (#325).
+
+const std = @import("std");
+const crypto = @import("crypto");
+const tls_core = @import("tls_core");
+const harness = @import("harness.zig");
+
+const provider = crypto.provider;
+const pure_zig = crypto.pure_zig;
+const algorithms = tls_core.algorithms;
+const record_protection = tls_core.record_protection;
+const record_codec = tls_core.record_codec;
+
+const Measurement = harness.Measurement;
+const Scale = harness.Scale;
+
+const cipher_suites = [_]algorithms.CipherSuite{
+    .tls_aes_128_gcm_sha256,
+    .tls_aes_256_gcm_sha384,
+    .tls_chacha20_poly1305_sha256,
+};
+const record_sizes = [_]usize{ 64, 1350, 16384 };
+
+/// See `primitives.TestProvider`'s doc comment: constructed and initialized
+/// on its own already-addressed stack frame, never returned by value.
+const TestProvider = struct {
+    entropy: pure_zig.DeterministicEntropy,
+    instance: pure_zig.Provider,
+
+    fn init(self: *TestProvider, seed: u64) void {
+        self.entropy = pure_zig.DeterministicEntropy.init(seed);
+        self.instance = pure_zig.Provider.init(self.entropy.entropy());
+    }
+
+    fn cryptoProvider(self: *const TestProvider) provider.CryptoProvider {
+        return self.instance.cryptoProvider();
+    }
+};
+
+fn trafficSecret(comptime hash: provider.Hash, fill: u8) [hash.digestLength()]u8 {
+    return [_]u8{fill} ** hash.digestLength();
+}
+
+pub fn run(out: *harness.Reporter, scale: Scale) !void {
+    for (cipher_suites) |suite| {
+        try runTrafficKeyDerivation(out, scale, suite);
+        for (record_sizes) |size| {
+            try runSeal(out, scale, suite, size);
+            try runOpen(out, scale, suite, size);
+        }
+        try runAuthFailure(out, scale, suite);
+    }
+}
+
+fn runTrafficKeyDerivation(out: *harness.Reporter, scale: Scale, suite: algorithms.CipherSuite) !void {
+    var tp: TestProvider = undefined;
+    tp.init(0x378_50);
+    const cp = tp.cryptoProvider();
+    const profile = record_protection.suiteProfile(suite);
+
+    const Context = struct {
+        cp: provider.CryptoProvider,
+        suite: algorithms.CipherSuite,
+        hash: provider.Hash,
+        secret_sha256: [32]u8,
+        secret_sha384: [48]u8,
+
+        fn step(self: *@This()) !void {
+            const secret: []const u8 = switch (self.hash) {
+                .sha256 => &self.secret_sha256,
+                .sha384 => &self.secret_sha384,
+            };
+            var keys = try record_protection.TrafficKeys.derive(self.cp, self.suite, secret);
+            keys.deinit();
+        }
+    };
+    var ctx = Context{
+        .cp = cp,
+        .suite = suite,
+        .hash = profile.hash,
+        .secret_sha256 = trafficSecret(.sha256, 0x11),
+        .secret_sha384 = trafficSecret(.sha384, 0x11),
+    };
+    const iterations = scale.iterations(3000);
+    const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+    try out.append(.{ .suite = "record", .name = "traffic_key_iv_derivation", .algorithm = @tagName(suite), .iterations = iterations, .ns_total = ns });
+}
+
+fn runSeal(out: *harness.Reporter, scale: Scale, suite: algorithms.CipherSuite, size: usize) !void {
+    var tp: TestProvider = undefined;
+    tp.init(0x378_51);
+    const cp = tp.cryptoProvider();
+    const profile = record_protection.suiteProfile(suite);
+    const secret_sha256 = trafficSecret(.sha256, 0x22);
+    const secret_sha384 = trafficSecret(.sha384, 0x22);
+    const secret: []const u8 = switch (profile.hash) {
+        .sha256 => &secret_sha256,
+        .sha384 => &secret_sha384,
+    };
+    const keys = try record_protection.TrafficKeys.derive(cp, suite, secret);
+
+    const Context = struct {
+        write: record_protection.WriteState,
+        plaintext: [16384]u8 = [_]u8{0x33} ** 16384,
+        out_buf: [16384 + 256]u8 = undefined,
+        size: usize,
+
+        fn step(self: *@This()) !void {
+            const sealed = try self.write.seal(.application_data, self.plaintext[0..self.size], 0, &self.out_buf);
+            std.mem.doNotOptimizeAway(sealed.len);
+        }
+    };
+    var ctx = Context{ .write = record_protection.WriteState.init(cp, keys), .size = size };
+    defer ctx.write.deinit();
+    const iterations = scale.iterations(if (size >= 16384) 500 else 3000);
+    const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+    try out.append(.{ .suite = "record", .name = "seal", .algorithm = @tagName(suite), .input_bytes = size, .iterations = iterations, .ns_total = ns });
+}
+
+fn runOpen(out: *harness.Reporter, scale: Scale, suite: algorithms.CipherSuite, size: usize) !void {
+    var tp: TestProvider = undefined;
+    tp.init(0x378_52);
+    const cp = tp.cryptoProvider();
+    const profile = record_protection.suiteProfile(suite);
+    const secret_sha256 = trafficSecret(.sha256, 0x44);
+    const secret_sha384 = trafficSecret(.sha384, 0x44);
+    const secret: []const u8 = switch (profile.hash) {
+        .sha256 => &secret_sha256,
+        .sha384 => &secret_sha384,
+    };
+
+    const write_keys = try record_protection.TrafficKeys.derive(cp, suite, secret);
+    var write = record_protection.WriteState.init(cp, write_keys);
+    var sealed_buf: [16384 + 256]u8 = undefined;
+    var plaintext: [16384]u8 = [_]u8{0x55} ** 16384;
+    const sealed = try write.seal(.application_data, plaintext[0..size], 0, &sealed_buf);
+    write.deinit();
+
+    const header = record_codec.parseHeader(sealed[0..record_codec.header_len], .ciphertext, .strict) catch unreachable;
+    var payload_buf: [16384 + 256]u8 = undefined;
+    const payload_len = sealed.len - record_codec.header_len;
+    @memcpy(payload_buf[0..payload_len], sealed[record_codec.header_len..]);
+
+    // Reads through one long-lived `ReadState`, resetting `sequence` to 0
+    // before each call (the same direct-field-reset pattern
+    // `record_protection.zig`'s own tests use) rather than re-deriving
+    // traffic keys every iteration, so this isolates AEAD-open cost from
+    // key-derivation cost (measured separately by `runTrafficKeyDerivation`).
+    const read_keys = try record_protection.TrafficKeys.derive(cp, suite, secret);
+    const Context = struct {
+        read: record_protection.ReadState,
+        content_type: record_codec.ContentType,
+        legacy_version: u16,
+        payload: [16384 + 256]u8,
+        payload_len: usize,
+        out_buf: [16384 + 256]u8 = undefined,
+
+        fn step(self: *@This()) !void {
+            self.read.sequence = 0;
+            self.read.exhausted = false;
+            const record: record_codec.TLSCiphertext = .{
+                .content_type = self.content_type,
+                .legacy_version = self.legacy_version,
+                .payload = self.payload[0..self.payload_len],
+            };
+            const inner = try self.read.open(record, &self.out_buf);
+            std.mem.doNotOptimizeAway(inner.content.len);
+        }
+    };
+    var ctx = Context{
+        .read = record_protection.ReadState.init(cp, read_keys),
+        .content_type = header.content_type,
+        .legacy_version = header.legacy_version,
+        .payload = payload_buf,
+        .payload_len = payload_len,
+    };
+    defer ctx.read.deinit();
+    const iterations = scale.iterations(if (size >= 16384) 500 else 3000);
+    const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+    try out.append(.{ .suite = "record", .name = "open", .algorithm = @tagName(suite), .input_bytes = size, .iterations = iterations, .ns_total = ns });
+}
+
+fn runAuthFailure(out: *harness.Reporter, scale: Scale, suite: algorithms.CipherSuite) !void {
+    var tp: TestProvider = undefined;
+    tp.init(0x378_53);
+    const cp = tp.cryptoProvider();
+    const profile = record_protection.suiteProfile(suite);
+    const secret_sha256 = trafficSecret(.sha256, 0x66);
+    const secret_sha384 = trafficSecret(.sha384, 0x66);
+    const secret: []const u8 = switch (profile.hash) {
+        .sha256 => &secret_sha256,
+        .sha384 => &secret_sha384,
+    };
+    const size = 1350;
+
+    const write_keys = try record_protection.TrafficKeys.derive(cp, suite, secret);
+    var write = record_protection.WriteState.init(cp, write_keys);
+    var sealed_buf: [size + 256]u8 = undefined;
+    var plaintext: [size]u8 = [_]u8{0x77} ** size;
+    const sealed = try write.seal(.application_data, &plaintext, 0, &sealed_buf);
+    write.deinit();
+    var tampered: [sealed_buf.len]u8 = undefined;
+    @memcpy(tampered[0..sealed.len], sealed);
+    tampered[sealed.len - 1] ^= 0x01; // tamper the AEAD tag's last byte.
+
+    const header = record_codec.parseHeader(tampered[0..record_codec.header_len], .ciphertext, .strict) catch unreachable;
+
+    const read_keys = try record_protection.TrafficKeys.derive(cp, suite, secret);
+    const Context = struct {
+        read: record_protection.ReadState,
+        payload: [size + 256]u8,
+        payload_len: usize,
+        content_type: record_codec.ContentType,
+        legacy_version: u16,
+        out_buf: [size + 256]u8 = undefined,
+
+        fn step(self: *@This()) !void {
+            self.read.sequence = 0;
+            self.read.exhausted = false;
+            const record: record_codec.TLSCiphertext = .{
+                .content_type = self.content_type,
+                .legacy_version = self.legacy_version,
+                .payload = self.payload[0..self.payload_len],
+            };
+            const result = self.read.open(record, &self.out_buf);
+            if (result) |_| return error.ExpectedAuthenticationFailure else |err| {
+                if (err != error.AuthenticationFailed) return err;
+            }
+        }
+    };
+    var payload_buf: [size + 256]u8 = undefined;
+    const payload_len = tampered.len - record_codec.header_len;
+    @memcpy(payload_buf[0..payload_len], tampered[record_codec.header_len..]);
+    var ctx = Context{
+        .read = record_protection.ReadState.init(cp, read_keys),
+        .payload = payload_buf,
+        .payload_len = payload_len,
+        .content_type = header.content_type,
+        .legacy_version = header.legacy_version,
+    };
+    defer ctx.read.deinit();
+    const iterations = scale.iterations(3000);
+    const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+    try out.append(.{ .suite = "record", .name = "open_auth_failure", .algorithm = @tagName(suite), .input_bytes = size, .iterations = iterations, .ns_total = ns, .note = "tampered ciphertext tag; every call rejects" });
+}

--- a/src/crypto_bench/root.zig
+++ b/src/crypto_bench/root.zig
@@ -1,0 +1,68 @@
+//! Entry point for the CryptoProvider/record/ticket-protection benchmark
+//! suite (#378, epic #327-I). `zig build bench-crypto` runs this as an
+//! executable and prints a JSON report; `zig build test-crypto-bench` runs
+//! the same suites at a tiny iteration count as a fast correctness smoke
+//! check (not a timing signal) that is safe under the default `zig build
+//! test`.
+//!
+//! Deliberately out of scope, per the issue's own ownership boundaries:
+//! QUIC packet-protection/header-protection benchmarks (blocked on #490
+//! reconciling provider ownership) and an OpenSSL reference comparison
+//! (optional — "where a fair independent comparison is stable and useful").
+//! See docs/CRYPTO_BENCHMARKS.md.
+
+const std = @import("std");
+const compat = @import("zig_compat");
+const harness = @import("harness.zig");
+const primitives = @import("primitives.zig");
+const record = @import("record.zig");
+const ticket = @import("ticket.zig");
+
+pub const Scale = harness.Scale;
+pub const Measurement = harness.Measurement;
+
+/// Advisory latency ceilings for a handful of "core repeated workloads"
+/// (issue #378's "budgets" section). Deliberately generous — see
+/// `harness.checkLatencyBudgets`'s doc comment for why these never fail the
+/// build.
+const latency_budgets = [_]harness.LatencyBudget{
+    .{ .suite = "aead", .name = "seal", .max_ns_per_op = 50_000 },
+    .{ .suite = "kex", .name = "derive_shared_secret", .max_ns_per_op = 2_000_000 },
+    .{ .suite = "signature", .name = "verify", .max_ns_per_op = 5_000_000 },
+    .{ .suite = "ticket", .name = "seal", .max_ns_per_op = 200_000 },
+    .{ .suite = "ticket", .name = "resolve", .max_ns_per_op = 200_000 },
+};
+
+pub fn collect(allocator: std.mem.Allocator, scale: Scale) !harness.Reporter {
+    var reporter = harness.Reporter{ .allocator = allocator };
+    errdefer reporter.deinit();
+    try primitives.run(allocator, &reporter, scale);
+    try record.run(&reporter, scale);
+    try ticket.run(allocator, &reporter, scale);
+    return reporter;
+}
+
+pub fn main() !void {
+    var debug: std.heap.DebugAllocator(.{}) = .init;
+    defer std.debug.assert(debug.deinit() == .ok);
+    const allocator = debug.allocator();
+
+    var reporter = try collect(allocator, .full);
+    defer reporter.deinit();
+
+    harness.checkLatencyBudgets(reporter.items(), &latency_budgets);
+
+    var stdout_buf: [8192]u8 = undefined;
+    var stdout = std.Io.File.stdout().writer(compat.io(), &stdout_buf);
+    try harness.writeJsonReport(&stdout.interface, harness.Metadata.current(), reporter.items());
+    try stdout.flush();
+}
+
+test "crypto-bench: every workload runs and reports at least one measurement" {
+    var reporter = try collect(std.testing.allocator, .smoke);
+    defer reporter.deinit();
+    try std.testing.expect(reporter.items().len > 0);
+    for (reporter.items()) |m| {
+        try std.testing.expect(m.iterations > 0);
+    }
+}

--- a/src/crypto_bench/ticket.zig
+++ b/src/crypto_bench/ticket.zig
@@ -615,29 +615,52 @@ fn runNonceReservationContended(out: *harness.Reporter, scale: Scale) !void {
     defer state.deinit();
     var protector = ticket_protection.Protector{ .provider = cp, .keyring = &keyring, .limits = session.Limits.default };
 
+    // A worker that hits a `Protector.seal` error (nonce-lease exhaustion,
+    // an unexpected keyring rejection, ...) must not be able to make this
+    // workload silently report success on partial work: nonce uniqueness is
+    // a security invariant issue #378 says benchmarks must not weaken, so a
+    // seal failure here has to fail the benchmark, not just end one thread
+    // early while the parent reports the full requested iteration count
+    // regardless.
+    const Shared = struct {
+        completed: std.atomic.Value(usize) = .init(0),
+        failed: std.atomic.Value(bool) = .init(false),
+    };
+
     const Worker = struct {
-        fn run(protector_ptr: *ticket_protection.Protector, state_ptr: *const session.ServerRecoverableState, iterations: usize) void {
+        fn run(shared: *Shared, protector_ptr: *ticket_protection.Protector, state_ptr: *const session.ServerRecoverableState, iterations: usize) void {
             var out_buf: [4096]u8 = undefined;
             var i: usize = 0;
             while (i < iterations) : (i += 1) {
-                _ = protector_ptr.seal(std.heap.page_allocator, state_ptr, 1500, &out_buf) catch return;
+                _ = protector_ptr.seal(std.heap.page_allocator, state_ptr, 1500, &out_buf) catch {
+                    shared.failed.store(true, .release);
+                    return;
+                };
+                _ = shared.completed.fetchAdd(1, .monotonic);
             }
         }
     };
 
+    var shared = Shared{};
     var threads: [thread_count]std.Thread = undefined;
     const start = harness.monotonicNs();
     for (&threads) |*t| {
-        t.* = try std.Thread.spawn(.{}, Worker.run, .{ &protector, &state, per_thread_iterations });
+        t.* = try std.Thread.spawn(.{}, Worker.run, .{ &shared, &protector, &state, per_thread_iterations });
     }
     for (&threads) |*t| t.join();
     const ns: u64 = @intCast(harness.monotonicNs() - start);
+
+    const expected = thread_count * per_thread_iterations;
+    const completed = shared.completed.load(.acquire);
+    if (shared.failed.load(.acquire) or completed != expected) {
+        return error.NonceReservationWorkerFailed;
+    }
 
     try out.append(.{
         .suite = "ticket",
         .name = "nonce_reservation_contended",
         .algorithm = "aes_128_gcm",
-        .iterations = thread_count * per_thread_iterations,
+        .iterations = completed,
         .ns_total = ns,
         .note = "4 threads sharing one nonce lease, each doing end-to-end Protector.seal",
     });

--- a/src/crypto_bench/ticket.zig
+++ b/src/crypto_bench/ticket.zig
@@ -1,0 +1,644 @@
+//! Resumption/ticket cryptographic-machinery workloads for issue #378:
+//! session-state codec size sweeps, stateless ticket seal/open/resolve
+//! through `tls_core.ticket_protection.Protector`, resolver-miss paths, and
+//! keyring/nonce-lease overhead. Whole resumed-handshake latency stays out
+//! of scope here per the issue's ownership boundaries (#326/#369).
+//!
+//! Not covered: a standalone "AEAD open with a pre-parsed envelope" step.
+//! `ticket_protection` does not expose the AAD-construction helper
+//! (`buildAad`) that step would need publicly, and issue #378 itself
+//! guards that bullet with "where the API permits it" — reimplementing
+//! private framing logic here would risk silently drifting from the real
+//! implementation. `runResolve` below covers the combined parse+open+decode
+//! cost end to end.
+
+const std = @import("std");
+const crypto = @import("crypto");
+const tls_core = @import("tls_core");
+const harness = @import("harness.zig");
+
+const provider = crypto.provider;
+const pure_zig = crypto.pure_zig;
+const session = tls_core.session;
+const ticket_protection = tls_core.ticket_protection;
+
+const Measurement = harness.Measurement;
+const Scale = harness.Scale;
+
+/// See `primitives.TestProvider`'s doc comment: constructed and initialized
+/// on its own already-addressed stack frame, never returned by value.
+const TestProvider = struct {
+    entropy: pure_zig.DeterministicEntropy,
+    instance: pure_zig.Provider,
+
+    fn init(self: *TestProvider, seed: u64) void {
+        self.entropy = pure_zig.DeterministicEntropy.init(seed);
+        self.instance = pure_zig.Provider.init(self.entropy.entropy());
+    }
+
+    fn cryptoProvider(self: *const TestProvider) provider.CryptoProvider {
+        return self.instance.cryptoProvider();
+    }
+};
+
+fn keyIdFor(byte: u8) ticket_protection.KeyId {
+    return [_]u8{byte} ** ticket_protection.key_id_len;
+}
+
+fn ticketCapabilities() provider.Capabilities {
+    var caps = provider.Capabilities{};
+    caps.aeads.insert(.aes_128_gcm);
+    caps.aeads.insert(.aes_256_gcm);
+    caps.aeads.insert(.chacha20_poly1305);
+    return caps;
+}
+
+const StateSize = enum { small, medium, large };
+
+fn buildServerState(allocator: std.mem.Allocator, comptime size: StateSize) !session.ServerRecoverableState {
+    var common: session.ResumableSessionCommon = .{};
+    switch (size) {
+        .small => try common.init(allocator, session.Limits.default, .{
+            .cipher_suite = .tls_aes_128_gcm_sha256,
+            .resumption_psk = &([_]u8{0xab} ** 32),
+            .auth_binding = session.AuthBinding.fromLeafCertificateDer("leaf-der-small"),
+            .issued_at_unix_ms = 1_000,
+            .lifetime_seconds = 3_600,
+        }),
+        .medium => try common.init(allocator, session.Limits.default, .{
+            .cipher_suite = .tls_aes_128_gcm_sha256,
+            .resumption_psk = &([_]u8{0xab} ** 32),
+            .server_name = "medium.example.test",
+            .application_protocol = "h3",
+            .auth_binding = session.AuthBinding.fromLeafCertificateDer("leaf-der-medium"),
+            .issued_at_unix_ms = 1_000,
+            .lifetime_seconds = 3_600,
+            .transport_compat = .{ .format_id = 1, .format_version = 1, .bytes = &([_]u8{0x5a} ** 256) },
+        }),
+        .large => try common.init(allocator, session.Limits.default, .{
+            .cipher_suite = .tls_aes_256_gcm_sha384,
+            .resumption_psk = &([_]u8{0xab} ** 48),
+            .server_name = "large.example.test",
+            .application_protocol = "h3",
+            .auth_binding = session.AuthBinding.fromLeafCertificateDer("leaf-der-large"),
+            .issued_at_unix_ms = 1_000,
+            .lifetime_seconds = 3_600,
+            .transport_compat = .{ .format_id = 1, .format_version = 1, .bytes = &([_]u8{0x5b} ** 900) },
+            .application_compat = .{ .format_id = 2, .format_version = 1, .bytes = &([_]u8{0x5c} ** 900) },
+        }),
+    }
+    var state: session.ServerRecoverableState = .{};
+    state.init(&common, 0x1122_3344);
+    return state;
+}
+
+pub fn run(allocator: std.mem.Allocator, out: *harness.Reporter, scale: Scale) !void {
+    try runCodecSize(allocator, out, scale, .small);
+    try runCodecSize(allocator, out, scale, .medium);
+    try runCodecSize(allocator, out, scale, .large);
+
+    inline for (.{ provider.Aead.aes_128_gcm, provider.Aead.aes_256_gcm, provider.Aead.chacha20_poly1305 }) |aead| {
+        try runSeal(allocator, out, scale, aead);
+        try runEnvelopeParseOnly(allocator, out, scale, aead);
+        try runResolve(allocator, out, scale, aead);
+    }
+    try runResolverMissMalformed(allocator, out, scale);
+    try runResolverMissUnknownKey(allocator, out, scale);
+    try runResolverMissInvalidTag(allocator, out, scale);
+
+    try runSnapshotBuild(allocator, out, scale);
+    try runInstallRotation(allocator, out, scale, false);
+    try runInstallRotation(allocator, out, scale, true);
+    try runAcquireRelease(allocator, out, scale);
+    try runNonceReservationContended(out, scale);
+}
+
+// ---------------------------------------------------------------------------
+// Session-state codec
+// ---------------------------------------------------------------------------
+
+fn runCodecSize(allocator: std.mem.Allocator, out: *harness.Reporter, scale: Scale, comptime size: StateSize) !void {
+    var state = try buildServerState(allocator, size);
+    defer state.deinit();
+
+    {
+        const Context = struct {
+            state: *const session.ServerRecoverableState,
+            buf: [4096]u8 = undefined,
+
+            fn step(self: *@This()) !void {
+                const encoded = try session.encodeServer(self.state, session.Limits.default, &self.buf);
+                std.mem.doNotOptimizeAway(encoded.len);
+            }
+        };
+        var ctx = Context{ .state = &state };
+        const iterations = scale.iterations(3000);
+        const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+        const encoded_len = try session.serverEncodedLenWithLimits(&state, session.Limits.default);
+        try out.append(.{ .suite = "ticket", .name = "state_encode", .algorithm = @tagName(size), .input_bytes = encoded_len, .iterations = iterations, .ns_total = ns });
+    }
+
+    var encode_buf: [4096]u8 = undefined;
+    const encoded = try session.encodeServer(&state, session.Limits.default, &encode_buf);
+    {
+        const Context = struct {
+            allocator: std.mem.Allocator,
+            encoded: []const u8,
+
+            fn step(self: *@This()) !void {
+                var decoded = try session.decode(self.allocator, session.Limits.default, self.encoded);
+                decoded.deinit();
+            }
+        };
+        var counting = harness.CountingAllocator.init(allocator);
+        var ctx = Context{ .allocator = counting.allocator(), .encoded = encoded };
+        const iterations = scale.iterations(3000);
+        const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+        try out.append(.{
+            .suite = "ticket",
+            .name = "state_decode",
+            .algorithm = @tagName(size),
+            .input_bytes = encoded.len,
+            .iterations = iterations,
+            .ns_total = ns,
+            .allocations_per_op = @as(f64, @floatFromInt(counting.allocations)) / @as(f64, @floatFromInt(iterations)),
+            .bytes_allocated_per_op = @as(f64, @floatFromInt(counting.bytes_allocated)) / @as(f64, @floatFromInt(iterations)),
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Stateless ticket seal / parse / resolve
+// ---------------------------------------------------------------------------
+
+fn runSeal(allocator: std.mem.Allocator, out: *harness.Reporter, scale: Scale, comptime aead: provider.Aead) !void {
+    var tp: TestProvider = undefined;
+    tp.init(0x378_60);
+    const cp = tp.cryptoProvider();
+
+    var keyring = ticket_protection.ReloadableKeyRing.init(allocator);
+    defer keyring.deinit();
+    const key_bytes = [_]u8{0x11} ** aead.keyLength();
+    const config = ticket_protection.KeyConfig{
+        .id = keyIdFor(0xA1),
+        .aead = aead,
+        .key_bytes = &key_bytes,
+        .not_before_unix_ms = 0,
+        .encrypt_until_unix_ms = 1_000_000_000,
+        .decrypt_until_unix_ms = 2_000_000_000,
+        .nonce_lease = .{ .prefix = .{ 0xA1, 0, 0, 0 }, .start = 0, .end_exclusive = 1_000_000 },
+    };
+    try keyring.install(try keyring.buildSnapshot(&.{config}, ticketCapabilities()));
+
+    var state = try buildServerState(allocator, .medium);
+    defer state.deinit();
+
+    const Context = struct {
+        protector: ticket_protection.Protector,
+        allocator: std.mem.Allocator,
+        state: *const session.ServerRecoverableState,
+        out_buf: [4096]u8 = undefined,
+
+        fn step(self: *@This()) !void {
+            const sealed = try self.protector.seal(self.allocator, self.state, 1500, &self.out_buf);
+            std.mem.doNotOptimizeAway(sealed.len);
+        }
+    };
+    var counting = harness.CountingAllocator.init(allocator);
+    var ctx = Context{
+        .protector = .{ .provider = cp, .keyring = &keyring, .limits = session.Limits.default },
+        .allocator = counting.allocator(),
+        .state = &state,
+    };
+    const iterations = scale.iterations(1000);
+    const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+    try out.append(.{
+        .suite = "ticket",
+        .name = "seal",
+        .algorithm = @tagName(aead),
+        .iterations = iterations,
+        .ns_total = ns,
+        .allocations_per_op = @as(f64, @floatFromInt(counting.allocations)) / @as(f64, @floatFromInt(iterations)),
+        .bytes_allocated_per_op = @as(f64, @floatFromInt(counting.bytes_allocated)) / @as(f64, @floatFromInt(iterations)),
+    });
+}
+
+fn runEnvelopeParseOnly(allocator: std.mem.Allocator, out: *harness.Reporter, scale: Scale, comptime aead: provider.Aead) !void {
+    var tp: TestProvider = undefined;
+    tp.init(0x378_61);
+    const cp = tp.cryptoProvider();
+
+    var keyring = ticket_protection.ReloadableKeyRing.init(allocator);
+    defer keyring.deinit();
+    const key_bytes = [_]u8{0x44} ** aead.keyLength();
+    const config = ticket_protection.KeyConfig{
+        .id = keyIdFor(0xF1),
+        .aead = aead,
+        .key_bytes = &key_bytes,
+        .not_before_unix_ms = 0,
+        .encrypt_until_unix_ms = 1_000_000_000,
+        .decrypt_until_unix_ms = 2_000_000_000,
+        .nonce_lease = .{ .prefix = .{ 0xF1, 0, 0, 0 }, .start = 0, .end_exclusive = 2 },
+    };
+    try keyring.install(try keyring.buildSnapshot(&.{config}, ticketCapabilities()));
+
+    var state = try buildServerState(allocator, .medium);
+    defer state.deinit();
+    var protector = ticket_protection.Protector{ .provider = cp, .keyring = &keyring, .limits = session.Limits.default };
+    var sealed_buf: [4096]u8 = undefined;
+    const identity = try protector.seal(allocator, &state, 1500, &sealed_buf);
+
+    const Context = struct {
+        identity: []const u8,
+
+        fn step(self: *@This()) !void {
+            const parsed = try ticket_protection.parseEnvelope(self.identity, session.Limits.default);
+            std.mem.doNotOptimizeAway(parsed.ciphertext.len);
+        }
+    };
+    var ctx = Context{ .identity = identity };
+    const iterations = scale.iterations(5000);
+    const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+    try out.append(.{ .suite = "ticket", .name = "envelope_parse_only", .algorithm = @tagName(aead), .input_bytes = identity.len, .iterations = iterations, .ns_total = ns });
+}
+
+fn runResolve(allocator: std.mem.Allocator, out: *harness.Reporter, scale: Scale, comptime aead: provider.Aead) !void {
+    var tp: TestProvider = undefined;
+    tp.init(0x378_62);
+    const cp = tp.cryptoProvider();
+
+    var keyring = ticket_protection.ReloadableKeyRing.init(allocator);
+    defer keyring.deinit();
+    const key_bytes = [_]u8{0x55} ** aead.keyLength();
+    const config = ticket_protection.KeyConfig{
+        .id = keyIdFor(0xF2),
+        .aead = aead,
+        .key_bytes = &key_bytes,
+        .not_before_unix_ms = 0,
+        .encrypt_until_unix_ms = 1_000_000_000,
+        .decrypt_until_unix_ms = 2_000_000_000,
+        .nonce_lease = .{ .prefix = .{ 0xF2, 0, 0, 0 }, .start = 0, .end_exclusive = 2 },
+    };
+    try keyring.install(try keyring.buildSnapshot(&.{config}, ticketCapabilities()));
+
+    var state = try buildServerState(allocator, .medium);
+    defer state.deinit();
+    var seal_protector = ticket_protection.Protector{ .provider = cp, .keyring = &keyring, .limits = session.Limits.default };
+    var sealed_buf: [4096]u8 = undefined;
+    const identity = try seal_protector.seal(allocator, &state, 1500, &sealed_buf);
+    var identity_buf: [4096]u8 = undefined;
+    @memcpy(identity_buf[0..identity.len], identity);
+
+    const Context = struct {
+        protector: ticket_protection.Protector,
+        allocator: std.mem.Allocator,
+        identity: [4096]u8,
+        identity_len: usize,
+
+        fn step(self: *@This()) !void {
+            var recovered: session.ServerRecoverableState = .{};
+            defer recovered.deinit();
+            const ok = try self.protector.resolve(self.allocator, self.identity[0..self.identity_len], 1500, &recovered);
+            if (!ok) return error.ExpectedResolveSuccess;
+        }
+    };
+    var counting = harness.CountingAllocator.init(allocator);
+    var ctx = Context{
+        .protector = .{ .provider = cp, .keyring = &keyring, .limits = session.Limits.default },
+        .allocator = counting.allocator(),
+        .identity = identity_buf,
+        .identity_len = identity.len,
+    };
+    const iterations = scale.iterations(1000);
+    const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+    try out.append(.{
+        .suite = "ticket",
+        .name = "resolve",
+        .algorithm = @tagName(aead),
+        .input_bytes = identity.len,
+        .iterations = iterations,
+        .ns_total = ns,
+        .allocations_per_op = @as(f64, @floatFromInt(counting.allocations)) / @as(f64, @floatFromInt(iterations)),
+        .bytes_allocated_per_op = @as(f64, @floatFromInt(counting.bytes_allocated)) / @as(f64, @floatFromInt(iterations)),
+        .note = "full resolve: envelope parse + AEAD open + state decode",
+    });
+}
+
+fn runResolverMissMalformed(allocator: std.mem.Allocator, out: *harness.Reporter, scale: Scale) !void {
+    var tp: TestProvider = undefined;
+    tp.init(0x378_63);
+    const cp = tp.cryptoProvider();
+    var keyring = ticket_protection.ReloadableKeyRing.init(allocator);
+    defer keyring.deinit();
+    const key_bytes = [_]u8{0x66} ** provider.Aead.aes_128_gcm.keyLength();
+    const config = ticket_protection.KeyConfig{
+        .id = keyIdFor(0xF3),
+        .aead = .aes_128_gcm,
+        .key_bytes = &key_bytes,
+        .not_before_unix_ms = 0,
+        .encrypt_until_unix_ms = 1_000_000_000,
+        .decrypt_until_unix_ms = 2_000_000_000,
+        .nonce_lease = null,
+    };
+    try keyring.install(try keyring.buildSnapshot(&.{config}, ticketCapabilities()));
+
+    const Context = struct {
+        protector: ticket_protection.Protector,
+        allocator: std.mem.Allocator,
+
+        fn step(self: *@This()) !void {
+            var recovered: session.ServerRecoverableState = .{};
+            defer recovered.deinit();
+            const ok = try self.protector.resolve(self.allocator, "not-a-valid-ticket-envelope-at-all", 1500, &recovered);
+            if (ok) return error.ExpectedResolveFailure;
+        }
+    };
+    var ctx = Context{ .protector = .{ .provider = cp, .keyring = &keyring, .limits = session.Limits.default }, .allocator = allocator };
+    const iterations = scale.iterations(5000);
+    const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+    try out.append(.{ .suite = "ticket", .name = "resolver_miss_malformed", .algorithm = "n/a", .iterations = iterations, .ns_total = ns, .note = "structurally invalid identity; rejected before any AEAD work" });
+}
+
+fn runResolverMissUnknownKey(allocator: std.mem.Allocator, out: *harness.Reporter, scale: Scale) !void {
+    var tp: TestProvider = undefined;
+    tp.init(0x378_64);
+    const cp = tp.cryptoProvider();
+
+    var keyring_a = ticket_protection.ReloadableKeyRing.init(allocator);
+    defer keyring_a.deinit();
+    const key_bytes_a = [_]u8{0x77} ** provider.Aead.aes_128_gcm.keyLength();
+    const config_a = ticket_protection.KeyConfig{
+        .id = keyIdFor(0xF4),
+        .aead = .aes_128_gcm,
+        .key_bytes = &key_bytes_a,
+        .not_before_unix_ms = 0,
+        .encrypt_until_unix_ms = 1_000_000_000,
+        .decrypt_until_unix_ms = 2_000_000_000,
+        .nonce_lease = .{ .prefix = .{ 0xF4, 0, 0, 0 }, .start = 0, .end_exclusive = 2 },
+    };
+    try keyring_a.install(try keyring_a.buildSnapshot(&.{config_a}, ticketCapabilities()));
+
+    var state = try buildServerState(allocator, .medium);
+    defer state.deinit();
+    var seal_protector = ticket_protection.Protector{ .provider = cp, .keyring = &keyring_a, .limits = session.Limits.default };
+    var sealed_buf: [4096]u8 = undefined;
+    const identity = try seal_protector.seal(allocator, &state, 1500, &sealed_buf);
+    var identity_buf: [4096]u8 = undefined;
+    @memcpy(identity_buf[0..identity.len], identity);
+
+    var keyring_b = ticket_protection.ReloadableKeyRing.init(allocator);
+    defer keyring_b.deinit();
+    const key_bytes_b = [_]u8{0x88} ** provider.Aead.aes_128_gcm.keyLength();
+    const config_b = ticket_protection.KeyConfig{
+        .id = keyIdFor(0xF5),
+        .aead = .aes_128_gcm,
+        .key_bytes = &key_bytes_b,
+        .not_before_unix_ms = 0,
+        .encrypt_until_unix_ms = 1_000_000_000,
+        .decrypt_until_unix_ms = 2_000_000_000,
+        .nonce_lease = null,
+    };
+    try keyring_b.install(try keyring_b.buildSnapshot(&.{config_b}, ticketCapabilities()));
+
+    const Context = struct {
+        protector: ticket_protection.Protector,
+        allocator: std.mem.Allocator,
+        identity: [4096]u8,
+        identity_len: usize,
+
+        fn step(self: *@This()) !void {
+            var recovered: session.ServerRecoverableState = .{};
+            defer recovered.deinit();
+            const ok = try self.protector.resolve(self.allocator, self.identity[0..self.identity_len], 1500, &recovered);
+            if (ok) return error.ExpectedResolveFailure;
+        }
+    };
+    var ctx = Context{
+        .protector = .{ .provider = cp, .keyring = &keyring_b, .limits = session.Limits.default },
+        .allocator = allocator,
+        .identity = identity_buf,
+        .identity_len = identity.len,
+    };
+    const iterations = scale.iterations(3000);
+    const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+    try out.append(.{ .suite = "ticket", .name = "resolver_miss_unknown_key", .algorithm = "aes_128_gcm", .input_bytes = identity.len, .iterations = iterations, .ns_total = ns, .note = "well-formed envelope; key id absent from the resolving keyring" });
+}
+
+fn runResolverMissInvalidTag(allocator: std.mem.Allocator, out: *harness.Reporter, scale: Scale) !void {
+    var tp: TestProvider = undefined;
+    tp.init(0x378_65);
+    const cp = tp.cryptoProvider();
+    var keyring = ticket_protection.ReloadableKeyRing.init(allocator);
+    defer keyring.deinit();
+    const key_bytes = [_]u8{0x99} ** provider.Aead.aes_128_gcm.keyLength();
+    const config = ticket_protection.KeyConfig{
+        .id = keyIdFor(0xF6),
+        .aead = .aes_128_gcm,
+        .key_bytes = &key_bytes,
+        .not_before_unix_ms = 0,
+        .encrypt_until_unix_ms = 1_000_000_000,
+        .decrypt_until_unix_ms = 2_000_000_000,
+        .nonce_lease = .{ .prefix = .{ 0xF6, 0, 0, 0 }, .start = 0, .end_exclusive = 2 },
+    };
+    try keyring.install(try keyring.buildSnapshot(&.{config}, ticketCapabilities()));
+
+    var state = try buildServerState(allocator, .medium);
+    defer state.deinit();
+    var seal_protector = ticket_protection.Protector{ .provider = cp, .keyring = &keyring, .limits = session.Limits.default };
+    var sealed_buf: [4096]u8 = undefined;
+    const identity = try seal_protector.seal(allocator, &state, 1500, &sealed_buf);
+    var tampered: [4096]u8 = undefined;
+    @memcpy(tampered[0..identity.len], identity);
+    tampered[identity.len - 1] ^= 0x01;
+
+    const Context = struct {
+        protector: ticket_protection.Protector,
+        allocator: std.mem.Allocator,
+        identity: [4096]u8,
+        identity_len: usize,
+
+        fn step(self: *@This()) !void {
+            var recovered: session.ServerRecoverableState = .{};
+            defer recovered.deinit();
+            const ok = try self.protector.resolve(self.allocator, self.identity[0..self.identity_len], 1500, &recovered);
+            if (ok) return error.ExpectedResolveFailure;
+        }
+    };
+    var ctx = Context{
+        .protector = .{ .provider = cp, .keyring = &keyring, .limits = session.Limits.default },
+        .allocator = allocator,
+        .identity = tampered,
+        .identity_len = identity.len,
+    };
+    const iterations = scale.iterations(3000);
+    const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+    try out.append(.{ .suite = "ticket", .name = "resolver_miss_invalid_tag", .algorithm = "aes_128_gcm", .input_bytes = identity.len, .iterations = iterations, .ns_total = ns, .note = "tampered AEAD tag byte; every call rejects" });
+}
+
+// ---------------------------------------------------------------------------
+// Keyring / nonce leases
+// ---------------------------------------------------------------------------
+
+fn runSnapshotBuild(allocator: std.mem.Allocator, out: *harness.Reporter, scale: Scale) !void {
+    inline for (.{ 1, 2, 4, 8, ticket_protection.max_keys }) |count| {
+        var key_bytes: [count][32]u8 = undefined;
+        var configs: [count]ticket_protection.KeyConfig = undefined;
+        for (0..count) |i| {
+            key_bytes[i] = [_]u8{@as(u8, @truncate(i + 1))} ** 32;
+            configs[i] = .{
+                .id = keyIdFor(@as(u8, @truncate(0xE0 + i))),
+                .aead = .aes_256_gcm,
+                .key_bytes = &key_bytes[i],
+                .not_before_unix_ms = 0,
+                .encrypt_until_unix_ms = 1_000_000_000,
+                .decrypt_until_unix_ms = 2_000_000_000,
+                .nonce_lease = null,
+            };
+        }
+        var keyring = ticket_protection.ReloadableKeyRing.init(allocator);
+        defer keyring.deinit();
+
+        const Context = struct {
+            keyring: *ticket_protection.ReloadableKeyRing,
+            configs: []const ticket_protection.KeyConfig,
+
+            fn step(self: *@This()) !void {
+                const snapshot = try self.keyring.buildSnapshot(self.configs, ticketCapabilities());
+                snapshot.release();
+            }
+        };
+        var ctx = Context{ .keyring = &keyring, .configs = &configs };
+        const iterations = scale.iterations(1000);
+        const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+        try out.append(.{ .suite = "ticket", .name = "snapshot_build", .algorithm = "ReloadableKeyRing", .input_bytes = count, .iterations = iterations, .ns_total = ns, .note = "input_bytes is the key count" });
+    }
+}
+
+fn runInstallRotation(allocator: std.mem.Allocator, out: *harness.Reporter, scale: Scale, comptime hold_inflight: bool) !void {
+    var keyring = ticket_protection.ReloadableKeyRing.init(allocator);
+    defer keyring.deinit();
+    const key_bytes = [_]u8{0x22} ** provider.Aead.aes_128_gcm.keyLength();
+    const config = ticket_protection.KeyConfig{
+        .id = keyIdFor(0xD0),
+        .aead = .aes_128_gcm,
+        .key_bytes = &key_bytes,
+        .not_before_unix_ms = 0,
+        .encrypt_until_unix_ms = 1_000_000_000,
+        .decrypt_until_unix_ms = 2_000_000_000,
+        .nonce_lease = null,
+    };
+    try keyring.install(try keyring.buildSnapshot(&.{config}, ticketCapabilities()));
+
+    const Context = struct {
+        keyring: *ticket_protection.ReloadableKeyRing,
+        config: ticket_protection.KeyConfig,
+
+        fn step(self: *@This()) !void {
+            var held: ?*ticket_protection.Snapshot = null;
+            if (hold_inflight) held = self.keyring.acquireCurrent();
+            const snapshot = try self.keyring.buildSnapshot(&.{self.config}, ticketCapabilities());
+            try self.keyring.install(snapshot);
+            if (held) |s| s.release();
+        }
+    };
+    var ctx = Context{ .keyring = &keyring, .config = config };
+    const iterations = scale.iterations(500);
+    const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+    try out.append(.{
+        .suite = "ticket",
+        .name = if (hold_inflight) "install_with_inflight_reader" else "install_no_inflight_reader",
+        .algorithm = "ReloadableKeyRing",
+        .iterations = iterations,
+        .ns_total = ns,
+        .note = "single-key snapshot rebuild+install per iteration, retiring the previous generation (repeated bounded rotation)",
+    });
+}
+
+fn runAcquireRelease(allocator: std.mem.Allocator, out: *harness.Reporter, scale: Scale) !void {
+    var keyring = ticket_protection.ReloadableKeyRing.init(allocator);
+    defer keyring.deinit();
+    const key_bytes = [_]u8{0x33} ** provider.Aead.aes_128_gcm.keyLength();
+    const config = ticket_protection.KeyConfig{
+        .id = keyIdFor(0xE9),
+        .aead = .aes_128_gcm,
+        .key_bytes = &key_bytes,
+        .not_before_unix_ms = 0,
+        .encrypt_until_unix_ms = 1_000_000_000,
+        .decrypt_until_unix_ms = 2_000_000_000,
+        .nonce_lease = null,
+    };
+    try keyring.install(try keyring.buildSnapshot(&.{config}, ticketCapabilities()));
+
+    const Context = struct {
+        keyring: *ticket_protection.ReloadableKeyRing,
+
+        fn step(self: *@This()) !void {
+            const snapshot = self.keyring.acquireCurrent() orelse return error.NoActiveSnapshot;
+            snapshot.release();
+        }
+    };
+    var ctx = Context{ .keyring = &keyring };
+    const iterations = scale.iterations(5000);
+    const ns = try harness.timeLoop(Context, &ctx, iterations, Context.step);
+    try out.append(.{ .suite = "ticket", .name = "acquire_active_snapshot", .algorithm = "ReloadableKeyRing", .iterations = iterations, .ns_total = ns });
+}
+
+fn runNonceReservationContended(out: *harness.Reporter, scale: Scale) !void {
+    var tp: TestProvider = undefined;
+    tp.init(0x378_70);
+    const cp = tp.cryptoProvider();
+
+    // Uses the OS-backed page allocator, not the harness's CountingAllocator:
+    // this workload's point is to exercise the atomic nonce-lease CAS under
+    // real concurrent writers, and a lock-free thread-safe allocator keeps
+    // that contention isolated to the lease itself rather than a shared
+    // counter inside the allocator.
+    const thread_allocator = std.heap.page_allocator;
+    var keyring = ticket_protection.ReloadableKeyRing.init(thread_allocator);
+    defer keyring.deinit();
+
+    const thread_count = 4;
+    const per_thread_iterations = scale.iterations(500);
+    const key_bytes = [_]u8{0x11} ** provider.Aead.aes_128_gcm.keyLength();
+    const config = ticket_protection.KeyConfig{
+        .id = keyIdFor(0xC1),
+        .aead = .aes_128_gcm,
+        .key_bytes = &key_bytes,
+        .not_before_unix_ms = 0,
+        .encrypt_until_unix_ms = 1_000_000_000,
+        .decrypt_until_unix_ms = 2_000_000_000,
+        .nonce_lease = .{ .prefix = .{ 0xC1, 0, 0, 0 }, .start = 0, .end_exclusive = @as(u64, thread_count * per_thread_iterations) + 1 },
+    };
+    try keyring.install(try keyring.buildSnapshot(&.{config}, ticketCapabilities()));
+
+    var state = try buildServerState(thread_allocator, .small);
+    defer state.deinit();
+    var protector = ticket_protection.Protector{ .provider = cp, .keyring = &keyring, .limits = session.Limits.default };
+
+    const Worker = struct {
+        fn run(protector_ptr: *ticket_protection.Protector, state_ptr: *const session.ServerRecoverableState, iterations: usize) void {
+            var out_buf: [4096]u8 = undefined;
+            var i: usize = 0;
+            while (i < iterations) : (i += 1) {
+                _ = protector_ptr.seal(std.heap.page_allocator, state_ptr, 1500, &out_buf) catch return;
+            }
+        }
+    };
+
+    var threads: [thread_count]std.Thread = undefined;
+    const start = harness.monotonicNs();
+    for (&threads) |*t| {
+        t.* = try std.Thread.spawn(.{}, Worker.run, .{ &protector, &state, per_thread_iterations });
+    }
+    for (&threads) |*t| t.join();
+    const ns: u64 = @intCast(harness.monotonicNs() - start);
+
+    try out.append(.{
+        .suite = "ticket",
+        .name = "nonce_reservation_contended",
+        .algorithm = "aes_128_gcm",
+        .iterations = thread_count * per_thread_iterations,
+        .ns_total = ns,
+        .note = "4 threads sharing one nonce lease, each doing end-to-end Protector.seal",
+    });
+}


### PR DESCRIPTION
## Summary

- Adds a repeatable Zig-native benchmark suite (`zig build bench-crypto`) for the shared `CryptoProvider` seam and its direct consumers, driving `pure_zig.Provider` the same own-stack-frame way `tests/crypto_provider_fuzz.zig` does — never a mock, never a protocol state machine.
- Covers: hash (explanatory)/HKDF, AEAD seal/open/auth-failure for all 3 suites, X25519/secp256r1 key exchange (including invalid-peer-key rejection), Ed25519/ECDSA-P256/RSA-PSS sign/verify/reject, `FixedSecret`/`BoundedSecret`/`secureZero`/`constantTimeEqual` overhead, TLS record-layer traffic-key derivation + seal/open + auth-failure via `record_protection`, and ticket/resumption codec size sweeps + `Protector.seal`/`resolve` + resolver-miss paths + keyring/nonce-lease overhead (including a real multi-threaded nonce-reservation contention workload) via `ticket_protection`.
- Every measurement reports Zig/OS/arch/build-mode/provider metadata as JSON, matching the issue's benchmark contract.
- Provider-primitive allocation-freedom is enforced **structurally** at compile time (`CryptoProvider.VTable` methods take no allocator param) rather than by fragile runtime sampling; a handful of core workloads carry generous advisory latency ceilings that warn but never fail the build, per the issue's "budgets may be advisory/trend-based" allowance.
- `test-crypto-bench` runs every workload at a tiny iteration count as a correctness/API-drift smoke check and is part of the default `zig build test`; `bench-crypto` runs full iteration counts and prints the real report.
- CI gains a non-blocking `crypto-bench` job that uploads the JSON report as a diffable trend artifact — it never inspects the numbers or fails on them.
- New doc: `docs/CRYPTO_BENCHMARKS.md`.

**Deliberately out of scope**, per the issue's own ownership boundaries:
- QUIC packet/header-protection crypto benchmarks — blocked on #490 reconciling QUIC provider ownership.
- An OpenSSL reference comparison — the issue frames this as optional ("where useful"); left as follow-on work.
- All whole-protocol (TLS/PKI/QUIC/H3/HTTP) end-to-end benchmarks, which stay with their owning stories (#323–#326/#369/#247/#149/#150 and the root `benchmarks/` HTTP suite).

## Test plan

- [x] `zig build test --summary all` — 3125/3126 passed (1 pre-existing unrelated skip), including the new `test-crypto-bench` smoke suite.
- [x] `zig build test -Dtls-profile=appliance --summary all` — 3094/3095 passed (1 pre-existing unrelated skip).
- [x] `zig fmt --check` on all new/changed `.zig` files and `build.zig`.
- [x] `zig build bench-crypto -Doptimize=ReleaseFast` — runs end to end (~14s) and prints a well-formed JSON report; spot-checked timings for plausibility (found and fixed a compiler loop-invariant-hoisting artifact in the tiniest leaf workloads — see `primitives.zig` comments and `docs/CRYPTO_BENCHMARKS.md`'s "A note on nanosecond-scale numbers").
- [x] `.github/workflows/ci.yml` validated with `python3 -c "import yaml; yaml.safe_load(...)"`.

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)