### PR TITLE
security: [494-A] fuzz NewSessionTicket, session codec, PSK, and ticket-envelope parsing

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -37,6 +37,15 @@ pub fn build(b: *std.Build) void {
     const quic_test_filters: []const []const u8 = if (quic_test_filter) |filter| &.{filter} else &.{};
     const crypto_test_filter = b.option([]const u8, "crypto-test-filter", "Filter tests run by the test-crypto-provider-fuzz step");
     const crypto_test_filters: []const []const u8 = if (crypto_test_filter) |filter| &.{filter} else &.{};
+    // #494: unlike the crypto/QUIC provider-fuzz steps, this step's root
+    // module (tls_core_mod) is the *entire* pure-Zig TLS suite -- also run
+    // unfiltered by `test-tls`/`test` -- not a dedicated fuzz-only root
+    // file, so an unfiltered default here would just re-run the whole
+    // suite under a second name. Default to the "fuzz: " test-name prefix
+    // every #494 target above uses, scoping the step to just those targets;
+    // pass an explicit filter to select one target for a longer local run.
+    const tls_resumption_test_filter = b.option([]const u8, "tls-resumption-test-filter", "Filter tests run by the test-tls-resumption-fuzz step (default: \"fuzz: \", i.e. only the #494 session/PSK/ticket/resumption fuzz targets)") orelse "fuzz: ";
+    const tls_resumption_test_filters: []const []const u8 = &.{tls_resumption_test_filter};
     const tls_profile = b.option(
         TlsProfile,
         "tls-profile",
@@ -217,6 +226,20 @@ pub fn build(b: *std.Build) void {
     const tls_step = b.step("test-tls", "Run pure-Zig TLS core unit tests");
     tls_step.dependOn(&run_tls_core_tests.step);
     test_step.dependOn(&run_tls_core_tests.step);
+
+    // Session/PSK/ticket/resumption fuzz targets (#494, epic #326-K),
+    // following the shared contract in docs/CRYPTO_FUZZ_CONTRACT.md and
+    // #376's test-crypto-provider-fuzz naming pattern. The targets
+    // themselves are inline `test "fuzz: ..."` blocks next to the code
+    // they exercise (new_session_ticket.zig, session.zig,
+    // pre_shared_key.zig, ticket_protection.zig) and already replay their
+    // deterministic seed corpus under plain `test-tls`/`test`; this step
+    // exists to give them a stable, individually filterable/long-runnable
+    // name, matching #376's `-Dcrypto-test-filter` shape.
+    const tls_resumption_fuzz_tests = b.addTest(.{ .root_module = tls_core_mod, .filters = tls_resumption_test_filters });
+    const run_tls_resumption_fuzz_tests = b.addRunArtifact(tls_resumption_fuzz_tests);
+    const tls_resumption_fuzz_step = b.step("test-tls-resumption-fuzz", "Run TLS session/PSK/ticket/resumption fuzz targets (#494)");
+    tls_resumption_fuzz_step.dependOn(&run_tls_resumption_fuzz_tests.step);
 
     const allocation_regression_mod = b.createModule(.{
         .root_source_file = b.path("src/allocation_regression.zig"),

--- a/build.zig
+++ b/build.zig
@@ -41,10 +41,15 @@ pub fn build(b: *std.Build) void {
     // module (tls_core_mod) is the *entire* pure-Zig TLS suite -- also run
     // unfiltered by `test-tls`/`test` -- not a dedicated fuzz-only root
     // file, so an unfiltered default here would just re-run the whole
-    // suite under a second name. Default to the "fuzz: " test-name prefix
-    // every #494 target above uses, scoping the step to just those targets;
-    // pass an explicit filter to select one target for a longer local run.
-    const tls_resumption_test_filter = b.option([]const u8, "tls-resumption-test-filter", "Filter tests run by the test-tls-resumption-fuzz step (default: \"fuzz: \", i.e. only the #494 session/PSK/ticket/resumption fuzz targets)") orelse "fuzz: ";
+    // suite under a second name. `tls_core_mod` also already contains
+    // unrelated pre-existing "fuzz: ..." tests (sni_provider.zig,
+    // ticket_key_snapshot.zig, ticket_protection.zig's own combined
+    // identity/resolve target), so a bare "fuzz: " prefix would silently
+    // pull those in too. Every #494-A target below is therefore named
+    // "fuzz: TLS resumption: ..." and this defaults to that exact
+    // namespace, scoping the step to only those targets; pass an explicit
+    // filter to select one target for a longer local run.
+    const tls_resumption_test_filter = b.option([]const u8, "tls-resumption-test-filter", "Filter tests run by the test-tls-resumption-fuzz step (default: \"fuzz: TLS resumption:\", i.e. only the #494 session/PSK/ticket/resumption fuzz targets)") orelse "fuzz: TLS resumption:";
     const tls_resumption_test_filters: []const []const u8 = &.{tls_resumption_test_filter};
     const tls_profile = b.option(
         TlsProfile,

--- a/docs/CRYPTO_FUZZ_CONTRACT.md
+++ b/docs/CRYPTO_FUZZ_CONTRACT.md
@@ -366,30 +366,41 @@ individually filterable/long-runnable name, the same shape as
 
 ```bash
 # Deterministic smoke coverage for every #494 fuzz target (seed corpus
-# replay only, "fuzz: " test-name prefix) — also covered by plain
-# `zig build test-tls` / `zig build test` since tls_core's test binary
-# already includes these files.
+# replay only, "fuzz: TLS resumption:" test-name namespace) — also
+# covered by plain `zig build test-tls` / `zig build test` since
+# tls_core's test binary already includes these files. The namespace is
+# deliberately more specific than a bare "fuzz: " prefix: `tls_core_mod`
+# also contains unrelated pre-existing "fuzz: ..." tests
+# (sni_provider.zig, ticket_key_snapshot.zig, and ticket_protection.zig's
+# own combined identity/resolve target), which a bare prefix would pull
+# into this step too.
 zig build test-tls-resumption-fuzz --summary all --error-style verbose
 
 # Longer local/scheduled coverage-guided runs, one target at a time:
 zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast --fuzz=10M --summary all --error-style verbose
-zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: NewSessionTicket wire decode and owned-state construction never panic or corrupt output" --fuzz=10M --summary all --error-style verbose
-zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: session codec raw decode never panics and owns its decoded state" --fuzz=10M --summary all --error-style verbose
-zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: session codec generated client/server records round-trip and reject cross-kind decode" --fuzz=10M --summary all --error-style verbose
-zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: PSK wire codec" --fuzz=10M --summary all --error-style verbose
-zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: PSK binder derivation" --fuzz=10M --summary all --error-style verbose
-zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: parseEnvelope is allocation-free" --fuzz=10M --summary all --error-style verbose
-zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: parseEnvelope single-field mutation" --fuzz=10M --summary all --error-style verbose
+zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: TLS resumption: NewSessionTicket wire decode and owned-state construction never panic or corrupt output" --fuzz=10M --summary all --error-style verbose
+zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: TLS resumption: session codec raw decode never panics and owns its decoded state" --fuzz=10M --summary all --error-style verbose
+zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: TLS resumption: session codec generated client/server records round-trip and reject cross-kind decode" --fuzz=10M --summary all --error-style verbose
+zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: TLS resumption: PSK wire codec" --fuzz=10M --summary all --error-style verbose
+zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: TLS resumption: PSK binder derivation" --fuzz=10M --summary all --error-style verbose
+zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: TLS resumption: parseEnvelope is allocation-free" --fuzz=10M --summary all --error-style verbose
+zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: TLS resumption: parseEnvelope single-field mutation" --fuzz=10M --summary all --error-style verbose
+
+# Named deterministic regressions (not fuzz-tagged, so outside the
+# default "fuzz: TLS resumption:" namespace — filter on their own name):
+zig build test-tls-resumption-fuzz -Dtls-resumption-test-filter="parseEnvelope rejects every truncated prefix of a valid envelope below the minimum length" --summary all --error-style verbose
 ```
 
-`-Dtls-resumption-test-filter` defaults to `"fuzz: "` (every #494 target,
-none of the much larger surrounding deterministic TLS suite); pass an
-exact `test "fuzz: ..."` name to scope a long `--fuzz=<N>` run to one
-target, matching the reproduction-command shape "Seed-corpus and
-regression update procedure" above requires. #494-A (this pass) covers
-`NewSessionTicket` wire/owned-state construction, the session client/
-server codec, PSK modes/`OfferedPsks`/binder primitives, and allocation-
-free ticket-envelope parsing (`parseEnvelope`); authenticated ticket open,
-key-snapshot/keyring publication, session-cache/lease state machines, and
-backend/runtime composition follow in #494-B/C/D per the issue's PR
-decomposition.
+`-Dtls-resumption-test-filter` defaults to `"fuzz: TLS resumption:"` (every
+#494 target, none of the much larger surrounding deterministic TLS suite
+or the unrelated pre-existing `sni_provider.zig`/`ticket_key_snapshot.zig`/
+`ticket_protection.zig` fuzz targets that also happen to start with
+`"fuzz: "`); pass an exact `test "fuzz: ..."` name to scope a long
+`--fuzz=<N>` run to one target, matching the reproduction-command shape
+"Seed-corpus and regression update procedure" above requires. #494-A (this
+pass) covers `NewSessionTicket` wire/owned-state construction, the session
+client/server codec, PSK modes/`OfferedPsks`/binder primitives, and
+allocation-free ticket-envelope parsing (`parseEnvelope`); authenticated
+ticket open, key-snapshot/keyring publication, session-cache/lease state
+machines, and backend/runtime composition follow in #494-B/C/D per the
+issue's PR decomposition.

--- a/docs/CRYPTO_FUZZ_CONTRACT.md
+++ b/docs/CRYPTO_FUZZ_CONTRACT.md
@@ -389,6 +389,7 @@ zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-
 # Named deterministic regressions (not fuzz-tagged, so outside the
 # default "fuzz: TLS resumption:" namespace — filter on their own name):
 zig build test-tls-resumption-fuzz -Dtls-resumption-test-filter="parseEnvelope rejects every truncated prefix of a valid envelope below the minimum length" --summary all --error-style verbose
+zig build test-tls-resumption-fuzz -Dtls-resumption-test-filter="earlyDataCapableFromRaw never overflows at the u32 boundary" --summary all --error-style verbose
 ```
 
 `-Dtls-resumption-test-filter` defaults to `"fuzz: TLS resumption:"` (every

--- a/docs/CRYPTO_FUZZ_CONTRACT.md
+++ b/docs/CRYPTO_FUZZ_CONTRACT.md
@@ -343,3 +343,53 @@ above as scheduled or manual local runs, the same model
 because they are unbounded by design. Coordinate future OSS-Fuzz/OpenSSF
 onboarding with #121 rather than making external service integration a
 blocker here.
+
+## Protocol-scoped fuzz steps built on this contract
+
+Per the "Commands" section above, #491–#494 do not grow this file's own
+`test-crypto-provider-fuzz` step; each adds its own protocol-scoped step
+and `-D<area>-test-filter` option instead. This section records the
+stable step/filter names as those stories land, so a reader here does not
+have to go hunting through `build.zig`.
+
+### #494 — session / PSK / ticket / resumption state (epic #326-K)
+
+Unlike this file's own targets, #494's targets are inline `test "fuzz:
+..."` blocks inside the production modules themselves
+(`src/tls/new_session_ticket.zig`, `src/tls/session.zig`,
+`src/tls/pre_shared_key.zig`, `src/tls/ticket_protection.zig`) — not a
+separate `tests/*.zig` root — so they already replay their deterministic
+seed corpus under plain `zig build test-tls` / `zig build test`. The
+`test-tls-resumption-fuzz` step exists to give them a stable,
+individually filterable/long-runnable name, the same shape as
+`-Dcrypto-test-filter` above:
+
+```bash
+# Deterministic smoke coverage for every #494 fuzz target (seed corpus
+# replay only, "fuzz: " test-name prefix) — also covered by plain
+# `zig build test-tls` / `zig build test` since tls_core's test binary
+# already includes these files.
+zig build test-tls-resumption-fuzz --summary all --error-style verbose
+
+# Longer local/scheduled coverage-guided runs, one target at a time:
+zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast --fuzz=10M --summary all --error-style verbose
+zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: NewSessionTicket wire decode and owned-state construction never panic or corrupt output" --fuzz=10M --summary all --error-style verbose
+zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: session codec raw decode never panics and owns its decoded state" --fuzz=10M --summary all --error-style verbose
+zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: session codec generated client/server records round-trip and reject cross-kind decode" --fuzz=10M --summary all --error-style verbose
+zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: PSK wire codec" --fuzz=10M --summary all --error-style verbose
+zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: PSK binder derivation" --fuzz=10M --summary all --error-style verbose
+zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: parseEnvelope is allocation-free" --fuzz=10M --summary all --error-style verbose
+zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: parseEnvelope single-field mutation" --fuzz=10M --summary all --error-style verbose
+```
+
+`-Dtls-resumption-test-filter` defaults to `"fuzz: "` (every #494 target,
+none of the much larger surrounding deterministic TLS suite); pass an
+exact `test "fuzz: ..."` name to scope a long `--fuzz=<N>` run to one
+target, matching the reproduction-command shape "Seed-corpus and
+regression update procedure" above requires. #494-A (this pass) covers
+`NewSessionTicket` wire/owned-state construction, the session client/
+server codec, PSK modes/`OfferedPsks`/binder primitives, and allocation-
+free ticket-envelope parsing (`parseEnvelope`); authenticated ticket open,
+key-snapshot/keyring publication, session-cache/lease state machines, and
+backend/runtime composition follow in #494-B/C/D per the issue's PR
+decomposition.

--- a/src/tls/new_session_ticket.zig
+++ b/src/tls/new_session_ticket.zig
@@ -1009,14 +1009,20 @@ pub fn fuzzNewSessionTicket(allocator: std.mem.Allocator, smith: *std.testing.Sm
     // structural round trips and owned-state construction. Fields are
     // bounded by construction (buffer sizes / modulo) rather than
     // allowing arbitrary unbounded values, per the #376 contract.
+    // `ticket_buf` reaches exactly `session.Limits.default.max_ticket_len`
+    // so generated cases exercise the configured default boundary, not
+    // only small tickets; the absolute wire maximum
+    // (`absolute_ticket_wire_max`) is already deterministically covered
+    // by "server recoverable state honors caller ticket limits" above.
     const direction = smith.index(2);
     const suite = fuzz_cipher_suites[smith.index(fuzz_cipher_suites.len)];
+    const digest_len = algorithms.transcriptHash(suite).digestLength();
 
     var nonce_buf: [max_ticket_nonce_len]u8 = undefined;
     const nonce_len = smith.index(nonce_buf.len + 1);
     smith.bytes(nonce_buf[0..nonce_len]);
 
-    var ticket_buf: [1024]u8 = undefined;
+    var ticket_buf: [session.Limits.default.max_ticket_len]u8 = undefined;
     const ticket_len = 1 + smith.index(ticket_buf.len);
     smith.bytes(ticket_buf[0..ticket_len]);
 
@@ -1041,11 +1047,15 @@ pub fn fuzzNewSessionTicket(allocator: std.mem.Allocator, smith: *std.testing.Sm
         .max_early_data_size = max_early_data_size,
     };
 
-    var encode_buf: [2048]u8 = undefined;
+    // Comfortably above the worst-case encoded length for the generated
+    // shapes above (up to 4096-byte ticket + 255-byte nonce + extension +
+    // fixed fields), so a non-trivial `encode_cap` routinely succeeds
+    // instead of `OutputTooSmall` dominating every large-ticket case.
+    var encode_buf: [8192]u8 = undefined;
     const encode_cap = smith.index(encode_buf.len + 1);
     const scratch = encode_buf[0..encode_cap];
     @memset(scratch, 0xa5);
-    var before_buf: [2048]u8 = undefined;
+    var before_buf: [8192]u8 = undefined;
     @memcpy(before_buf[0..encode_cap], scratch);
 
     const encoded = encode(params, scratch) catch {
@@ -1054,6 +1064,7 @@ pub fn fuzzNewSessionTicket(allocator: std.mem.Allocator, smith: *std.testing.Sm
         try std.testing.expectEqualSlices(u8, before_buf[0..encode_cap], scratch);
         return;
     };
+    try std.testing.expectEqual(try encodedLen(params), encoded.len);
     const round = try decode(encoded);
     try std.testing.expectEqual(params.ticket_lifetime, round.ticket_lifetime);
     try std.testing.expectEqual(params.ticket_age_add, round.ticket_age_add);
@@ -1062,9 +1073,14 @@ pub fn fuzzNewSessionTicket(allocator: std.mem.Allocator, smith: *std.testing.Sm
     try std.testing.expectEqual(params.max_early_data_size, round.max_early_data_size);
 
     // 3. Owned-state construction from the round-tripped `Parsed` value,
-    // exercising both client and server construction directions.
+    // exercising both client and server construction directions. `rms` is
+    // sized to exactly the selected suite's transcript-hash digest length
+    // (`KeySchedule.resumptionPsk` requires an exact match); a fixed
+    // 48-byte slice would make both SHA-256 suites always fail with
+    // `InvalidSecretLength`, silently skipping owned-state construction
+    // for two of the three suites.
     var rms: [session.max_psk_len]u8 = undefined;
-    smith.bytes(&rms);
+    smith.bytes(rms[0..digest_len]);
     var limits_control: [1]u8 = undefined;
     smith.bytes(&limits_control);
     const limits = fuzzLimits(limits_control[0]);
@@ -1078,24 +1094,48 @@ pub fn fuzzNewSessionTicket(allocator: std.mem.Allocator, smith: *std.testing.Sm
     smith.bytes(&received_at_bytes);
     const received_at_unix_ms: i64 = @bitCast(std.mem.readInt(u64, &received_at_bytes, .big));
 
+    // Fresh per-case deterministic entropy/provider pair, on this call's
+    // own stack frame: the #376 contract forbids sharing one
+    // process-global entropy stream across cases (unlike
+    // `testCryptoProvider()` above, which this file's *deterministic*
+    // tests intentionally share).
+    const pure_zig = @import("crypto").pure_zig;
+    var fuzz_entropy = pure_zig.DeterministicEntropy.init(0x1cec_5);
+    var fuzz_provider = pure_zig.Provider.init(fuzz_entropy.entropy());
+    const crypto_provider = fuzz_provider.cryptoProvider();
+
     if (direction == 0) {
-        var maybe_state = buildClientTicketState(
+        const build_result = buildClientTicketState(
             allocator,
-            testCryptoProvider(),
+            crypto_provider,
             round,
             context,
-            &rms,
+            rms[0..digest_len],
             received_at_unix_ms,
             limits,
-        ) catch return;
-        if (maybe_state) |*state| {
-            defer state.deinit();
-            try std.testing.expectEqual(round.ticket.len, state.ticket.slice().len);
+        );
+        if (round.ticket_lifetime == 0) {
+            // `buildClientTicketState` returns `null` (not an error) for a
+            // zero lifetime, before the ticket-size check below ever runs.
+            try std.testing.expectEqual(@as(?session.ClientTicketState, null), try build_result);
+            return;
         }
+        if (round.ticket.len > limits.max_ticket_len) {
+            try std.testing.expectError(error.TicketTooLarge, build_result);
+            return;
+        }
+        var state = (try build_result).?;
+        defer state.deinit();
+        // The state must own its ticket/nonce bytes, not borrow `round`'s
+        // view into `scratch`: poison `scratch` after construction and
+        // confirm the state's content survives.
+        @memset(scratch, 0xee);
+        try std.testing.expectEqualSlices(u8, params.ticket, state.ticket.slice());
+        try std.testing.expectEqualSlices(u8, params.ticket_nonce, state.ticket_nonce.slice());
     } else {
-        var state = buildServerRecoverableStateNoIdentity(
+        const build_result = buildServerRecoverableStateNoIdentity(
             allocator,
-            testCryptoProvider(),
+            crypto_provider,
             .{
                 .ticket_lifetime = round.ticket_lifetime,
                 .ticket_age_add = round.ticket_age_add,
@@ -1103,15 +1143,24 @@ pub fn fuzzNewSessionTicket(allocator: std.mem.Allocator, smith: *std.testing.Sm
                 .max_early_data_size = round.max_early_data_size,
             },
             context,
-            &rms,
+            rms[0..digest_len],
             received_at_unix_ms,
             limits,
-        ) catch return;
+        );
+        if (round.ticket_lifetime == 0) {
+            // Unlike the client path, a zero lifetime is a hard error here
+            // (no opaque bearer identity yet to fall back to `null` for).
+            try std.testing.expectError(error.InvalidLifetime, build_result);
+            return;
+        }
+        var state = try build_result;
         defer state.deinit();
+        @memset(scratch, 0xee);
+        try std.testing.expectEqual(round.ticket_age_add, state.ticket_age_add);
     }
 }
 
-test "fuzz: NewSessionTicket wire decode and owned-state construction never panic or corrupt output" {
+test "fuzz: TLS resumption: NewSessionTicket wire decode and owned-state construction never panic or corrupt output" {
     try std.testing.fuzz({}, fuzzNewSessionTicketInput, .{ .corpus = &.{
         "",
         &[_]u8{ 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 'x', 0, 0 },

--- a/src/tls/new_session_ticket.zig
+++ b/src/tls/new_session_ticket.zig
@@ -949,3 +949,183 @@ fn appendExtension(list: *std.ArrayList(u8), ext_type: u16, payload: []const u8)
     try list.appendSlice(allocator, &encoded);
     try list.appendSlice(allocator, payload);
 }
+
+// -----------------------------------------------------------------------
+// Fuzz target (#494): NewSessionTicket wire codec and owned-state
+// construction.
+//
+// This complements the deterministic truncation/extension/limit coverage
+// above (not duplicated here) with continuous mutation of the raw wire
+// body plus control-derived owned-state construction through the real
+// `buildClientTicketState`/`buildServerRecoverableStateNoIdentity` APIs.
+// `std.testing.checkAllAllocationFailures` in
+// "ticket owned state builders and clone are allocation-failure clean"
+// above already sweeps `FailingAllocator` over a fixed representative
+// shape; this target drives fuzzer-chosen shapes through the same APIs at
+// `std.testing.allocator` rather than re-adding a second sweep.
+// -----------------------------------------------------------------------
+
+const fuzz_cipher_suites = [_]algorithms.CipherSuite{
+    .tls_aes_128_gcm_sha256,
+    .tls_aes_256_gcm_sha384,
+    .tls_chacha20_poly1305_sha256,
+};
+
+/// True when `inner` is empty or is wholly contained within `outer`'s
+/// backing bytes (pointer-range containment, not content equality) — the
+/// #494 borrowed-slice-safety property for `decode`'s `ticket_nonce`/
+/// `ticket` fields.
+fn withinBounds(outer: []const u8, inner: []const u8) bool {
+    if (inner.len == 0) return true;
+    const outer_start = @intFromPtr(outer.ptr);
+    const outer_end = outer_start + outer.len;
+    const inner_start = @intFromPtr(inner.ptr);
+    const inner_end = inner_start + inner.len;
+    return inner_start >= outer_start and inner_end <= outer_end and inner_end >= inner_start;
+}
+
+fn fuzzLimits(control: u8) session.Limits {
+    return switch (control % 4) {
+        0 => .default,
+        1 => .{ .max_ticket_len = 1 },
+        2 => .{ .max_ticket_len = absolute_ticket_wire_max },
+        else => .{ .max_ticket_len = @as(usize, control) + 1 },
+    };
+}
+
+pub fn fuzzNewSessionTicket(allocator: std.mem.Allocator, smith: *std.testing.Smith) !void {
+    // 1. Raw wire decode: bounded stack buffer, no allocator, matching the
+    // real allocation-free `decode` contract.
+    var wire_buf: [4096]u8 = undefined;
+    const wire_len = smith.slice(&wire_buf);
+    const wire = wire_buf[0..wire_len];
+
+    if (decode(wire)) |parsed| {
+        try std.testing.expect(withinBounds(wire, parsed.ticket_nonce));
+        try std.testing.expect(withinBounds(wire, parsed.ticket));
+    } else |_| {}
+
+    // 2. Control-derived valid `EmitParams`, driving encode -> decode
+    // structural round trips and owned-state construction. Fields are
+    // bounded by construction (buffer sizes / modulo) rather than
+    // allowing arbitrary unbounded values, per the #376 contract.
+    const direction = smith.index(2);
+    const suite = fuzz_cipher_suites[smith.index(fuzz_cipher_suites.len)];
+
+    var nonce_buf: [max_ticket_nonce_len]u8 = undefined;
+    const nonce_len = smith.index(nonce_buf.len + 1);
+    smith.bytes(nonce_buf[0..nonce_len]);
+
+    var ticket_buf: [1024]u8 = undefined;
+    const ticket_len = 1 + smith.index(ticket_buf.len);
+    smith.bytes(ticket_buf[0..ticket_len]);
+
+    const has_early_data = smith.index(2) == 1;
+    var early_data_bytes: [4]u8 = undefined;
+    smith.bytes(&early_data_bytes);
+    const max_early_data_size: ?u32 = if (has_early_data) std.mem.readInt(u32, &early_data_bytes, .big) else null;
+
+    var lifetime_bytes: [4]u8 = undefined;
+    smith.bytes(&lifetime_bytes);
+    const ticket_lifetime = std.mem.readInt(u32, &lifetime_bytes, .big) % (max_lifetime_seconds + 1);
+
+    var age_add_bytes: [4]u8 = undefined;
+    smith.bytes(&age_add_bytes);
+    const ticket_age_add = std.mem.readInt(u32, &age_add_bytes, .big);
+
+    const params = EmitParams{
+        .ticket_lifetime = ticket_lifetime,
+        .ticket_age_add = ticket_age_add,
+        .ticket_nonce = nonce_buf[0..nonce_len],
+        .ticket = ticket_buf[0..ticket_len],
+        .max_early_data_size = max_early_data_size,
+    };
+
+    var encode_buf: [2048]u8 = undefined;
+    const encode_cap = smith.index(encode_buf.len + 1);
+    const scratch = encode_buf[0..encode_cap];
+    @memset(scratch, 0xa5);
+    var before_buf: [2048]u8 = undefined;
+    @memcpy(before_buf[0..encode_cap], scratch);
+
+    const encoded = encode(params, scratch) catch {
+        // `OutputTooSmall`/`IllegalParameter`/`LengthOverflow` must never
+        // partially write the destination buffer.
+        try std.testing.expectEqualSlices(u8, before_buf[0..encode_cap], scratch);
+        return;
+    };
+    const round = try decode(encoded);
+    try std.testing.expectEqual(params.ticket_lifetime, round.ticket_lifetime);
+    try std.testing.expectEqual(params.ticket_age_add, round.ticket_age_add);
+    try std.testing.expectEqualSlices(u8, params.ticket_nonce, round.ticket_nonce);
+    try std.testing.expectEqualSlices(u8, params.ticket, round.ticket);
+    try std.testing.expectEqual(params.max_early_data_size, round.max_early_data_size);
+
+    // 3. Owned-state construction from the round-tripped `Parsed` value,
+    // exercising both client and server construction directions.
+    var rms: [session.max_psk_len]u8 = undefined;
+    smith.bytes(&rms);
+    var limits_control: [1]u8 = undefined;
+    smith.bytes(&limits_control);
+    const limits = fuzzLimits(limits_control[0]);
+
+    const context = ConnectionResumptionContext{
+        .cipher_suite = suite,
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer("fuzz-leaf"),
+    };
+
+    var received_at_bytes: [8]u8 = undefined;
+    smith.bytes(&received_at_bytes);
+    const received_at_unix_ms: i64 = @bitCast(std.mem.readInt(u64, &received_at_bytes, .big));
+
+    if (direction == 0) {
+        var maybe_state = buildClientTicketState(
+            allocator,
+            testCryptoProvider(),
+            round,
+            context,
+            &rms,
+            received_at_unix_ms,
+            limits,
+        ) catch return;
+        if (maybe_state) |*state| {
+            defer state.deinit();
+            try std.testing.expectEqual(round.ticket.len, state.ticket.slice().len);
+        }
+    } else {
+        var state = buildServerRecoverableStateNoIdentity(
+            allocator,
+            testCryptoProvider(),
+            .{
+                .ticket_lifetime = round.ticket_lifetime,
+                .ticket_age_add = round.ticket_age_add,
+                .ticket_nonce = round.ticket_nonce,
+                .max_early_data_size = round.max_early_data_size,
+            },
+            context,
+            &rms,
+            received_at_unix_ms,
+            limits,
+        ) catch return;
+        defer state.deinit();
+    }
+}
+
+test "fuzz: NewSessionTicket wire decode and owned-state construction never panic or corrupt output" {
+    try std.testing.fuzz({}, fuzzNewSessionTicketInput, .{ .corpus = &.{
+        "",
+        &[_]u8{ 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 'x', 0, 0 },
+        &[_]u8{ 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 'x', 0, 8, 0, 42, 0, 4, 0, 0, 0, 0x20 },
+        &[_]u8{ 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 1, 'x', 0, 4, 0x12, 0x34, 0, 0 },
+        &[_]u8{ 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 'x', 0, 8, 0x12, 0x34, 0, 0, 0x12, 0x34, 0, 0 },
+        &[_]u8{ 0, 0, 0, 1, 0, 0, 0, 0 },
+        &([_]u8{ 0, 0, 0, 1, 0, 0, 0, 0, 255 } ++ ([_]u8{1} ** 255) ++ [_]u8{ 0, 1, 'x', 0, 0 }),
+        &[_]u8{ 0x00, 0x09, 0x3a, 0x80, 0, 0, 0, 0, 0, 0, 1, 'x', 0, 0 },
+        &[_]u8{ 0x00, 0x09, 0x3a, 0x81, 0, 0, 0, 0, 0, 0, 1, 'x', 0, 0 },
+        &([_]u8{0xff} ** 128),
+    } });
+}
+
+fn fuzzNewSessionTicketInput(_: void, smith: *std.testing.Smith) !void {
+    try fuzzNewSessionTicket(std.testing.allocator, smith);
+}

--- a/src/tls/pre_shared_key.zig
+++ b/src/tls/pre_shared_key.zig
@@ -1587,6 +1587,28 @@ pub fn fuzzPskBinderAndAge(smith: *std.testing.Smith) !void {
         try std.testing.expect(!wrong_length_matches);
     }
 
+    // #494-A also requires one-bit *identity* mutations not to verify.
+    // `deriveBinder`/`verifyBinder` compute the transcript hash over a
+    // full truncated-ClientHello-shaped prefix themselves (matching real
+    // usage), rather than taking a precomputed digest the way
+    // `*FromTranscriptHash` above does; flipping a bit inside a distinct
+    // identity sub-region of that prefix proves the identity bytes are
+    // actually included in the transcript at the correct boundary --
+    // otherwise indistinguishable from the binder/PSK/digest mutations
+    // already covered above.
+    var prefix: [128]u8 = undefined;
+    smith.bytes(&prefix);
+    const identity_len = 1 + smith.index(prefix.len - 1);
+    const identity_offset = smith.index(prefix.len - identity_len + 1);
+    const identity = prefix[identity_offset .. identity_offset + identity_len];
+
+    var identity_binder: [provider.max_digest_len]u8 = undefined;
+    try deriveBinder(hash, psk_buf[0..digest_len], &prefix, identity_binder[0..digest_len]);
+    try std.testing.expect(try verifyBinder(hash, psk_buf[0..digest_len], &prefix, identity_binder[0..digest_len]));
+
+    identity[smith.index(identity.len)] ^= @as(u8, 1) << @intCast(smith.index(8));
+    try std.testing.expect(!try verifyBinder(hash, psk_buf[0..digest_len], &prefix, identity_binder[0..digest_len]));
+
     var age_bytes: [8]u8 = undefined;
     smith.bytes(&age_bytes);
     const age_ms = std.mem.readInt(u64, &age_bytes, .big);

--- a/src/tls/pre_shared_key.zig
+++ b/src/tls/pre_shared_key.zig
@@ -1443,6 +1443,28 @@ pub fn fuzzPskWireAndOffer(smith: *std.testing.Smith) !void {
         }
     } else |_| {}
 
+    // `writeModes`: structurally valid (1..255 modes) and invalid (0 or
+    // 256+ modes) generated lists, with the same len+bytes transactional
+    // property as `writeOffer` below.
+    const mode_choices = [_]PskKeyExchangeMode{ .psk_ke, .psk_dhe_ke };
+    const requested_mode_count = smith.index(258);
+    var modes_buf: [257]PskKeyExchangeMode = undefined;
+    for (modes_buf[0..@min(requested_mode_count, modes_buf.len)]) |*m| {
+        m.* = mode_choices[smith.index(mode_choices.len)];
+    }
+    const modes = modes_buf[0..@min(requested_mode_count, modes_buf.len)];
+
+    var modes_write_buf: [1024]u8 = undefined;
+    @memset(&modes_write_buf, 0xa5);
+    const modes_before = modes_write_buf;
+    var modes_w = messages.Writer{ .buf = &modes_write_buf };
+    if (writeModes(&modes_w, modes)) |_| {
+        try std.testing.expect(modes.len >= 1 and modes.len <= 255);
+    } else |_| {
+        try std.testing.expectEqual(@as(usize, 0), modes_w.len);
+        try std.testing.expectEqualSlices(u8, &modes_before, &modes_write_buf);
+    }
+
     const item_count = smith.index(max_offered_identities + 2);
     var items_buf: [max_offered_identities + 1]OfferItem = undefined;
     var identity_storage: [max_offered_identities + 1][64]u8 = undefined;
@@ -1461,9 +1483,15 @@ pub fn fuzzPskWireAndOffer(smith: *std.testing.Smith) !void {
     const items = items_buf[0..item_count];
 
     var write_buf: [8192]u8 = undefined;
+    @memset(&write_buf, 0xa5);
+    const before = write_buf;
     var w = messages.Writer{ .buf = &write_buf };
     const offer = writeOffer(&w, items) catch {
+        // Rejection must be fully transactional: not just `w.len`
+        // unchanged, but every byte of the destination buffer too — a
+        // regression could write bytes and then reset the logical length.
         try std.testing.expectEqual(@as(usize, 0), w.len);
+        try std.testing.expectEqualSlices(u8, &before, &write_buf);
         return;
     };
     try std.testing.expectEqual(items.len, offer.count);
@@ -1481,7 +1509,7 @@ pub fn fuzzPskWireAndOffer(smith: *std.testing.Smith) !void {
     try std.testing.expectEqual(@as(?OfferedPsks.PairIterator.Pair, null), try offer_it.next());
 }
 
-test "fuzz: PSK wire codec — modes, OfferedPsks parse, and writeOffer round trip never panic or escape bounds" {
+test "fuzz: TLS resumption: PSK wire codec — modes, OfferedPsks parse, and writeOffer round trip never panic or escape bounds" {
     try testing.fuzz({}, fuzzPskWireAndOfferInput, .{ .corpus = &.{
         "",
         &[_]u8{0},
@@ -1497,6 +1525,22 @@ fn fuzzPskWireAndOfferInput(_: void, smith: *std.testing.Smith) !void {
     try fuzzPskWireAndOffer(smith);
 }
 
+/// One of `{base-1 (saturating), base, base+1}`, used to independently vary
+/// the PSK/transcript-hash/output/candidate lengths passed to
+/// `deriveBinderFromTranscriptHash`/`verifyBinderFromTranscriptHash` around
+/// the selected hash's digest length. `base+1` is always representable in
+/// the caller's `provider.max_digest_len + 1`-sized buffers, so this
+/// actually produces a one-over case for SHA-384 too (`digest_len ==
+/// provider.max_digest_len`, where `@min(base + 1, provider.max_digest_len)`
+/// would silently collapse back to a valid length).
+fn chooseLenAround(base: usize, smith: *std.testing.Smith) usize {
+    return switch (smith.index(3)) {
+        0 => base -| 1,
+        1 => base,
+        else => base + 1,
+    };
+}
+
 /// Drives `deriveBinderFromTranscriptHash`/`verifyBinderFromTranscriptHash`
 /// across both supported hashes with Smith-controlled lengths and one-bit
 /// mutations, plus `obfuscateTicketAge`/`deobfuscateTicketAge`/
@@ -1505,30 +1549,23 @@ pub fn fuzzPskBinderAndAge(smith: *std.testing.Smith) !void {
     const hash: provider.Hash = if (smith.index(2) == 0) .sha256 else .sha384;
     const digest_len = hash.digestLength();
 
-    var psk_buf: [provider.max_digest_len]u8 = undefined;
+    var psk_buf: [provider.max_digest_len + 1]u8 = undefined;
     smith.bytes(&psk_buf);
-    var transcript_buf: [provider.max_digest_len]u8 = undefined;
+    var transcript_buf: [provider.max_digest_len + 1]u8 = undefined;
     smith.bytes(&transcript_buf);
+    var out_buf: [provider.max_digest_len + 1]u8 = undefined;
 
-    const psk_len = switch (smith.index(3)) {
-        0 => digest_len,
-        1 => digest_len -| 1,
-        else => @min(digest_len + 1, psk_buf.len),
-    };
-    var out_buf: [provider.max_digest_len]u8 = undefined;
-    const out_len = switch (smith.index(3)) {
-        0 => digest_len,
-        1 => digest_len -| 1,
-        else => @min(digest_len + 1, out_buf.len),
-    };
+    const psk_len = chooseLenAround(digest_len, smith);
+    const transcript_len = chooseLenAround(digest_len, smith);
+    const out_len = chooseLenAround(digest_len, smith);
 
-    const derive_result = deriveBinderFromTranscriptHash(hash, psk_buf[0..psk_len], transcript_buf[0..digest_len], out_buf[0..out_len]);
-    if (psk_len != digest_len or out_len != digest_len) {
+    const derive_result = deriveBinderFromTranscriptHash(hash, psk_buf[0..psk_len], transcript_buf[0..transcript_len], out_buf[0..out_len]);
+    if (psk_len != digest_len or transcript_len != digest_len or out_len != digest_len) {
         try std.testing.expectError(error.InvalidSecretLength, derive_result);
     } else {
         try derive_result;
 
-        var out2: [provider.max_digest_len]u8 = undefined;
+        var out2: [provider.max_digest_len + 1]u8 = undefined;
         try deriveBinderFromTranscriptHash(hash, psk_buf[0..digest_len], transcript_buf[0..digest_len], out2[0..digest_len]);
         try std.testing.expectEqualSlices(u8, out_buf[0..digest_len], out2[0..digest_len]);
 
@@ -1569,7 +1606,7 @@ pub fn fuzzPskBinderAndAge(smith: *std.testing.Smith) !void {
     try std.testing.expectEqual(actual_age_ms, skew.actual_age_ms);
 }
 
-test "fuzz: PSK binder derivation/verification and ticket-age arithmetic are deterministic and bounded" {
+test "fuzz: TLS resumption: PSK binder derivation/verification and ticket-age arithmetic are deterministic and bounded" {
     try testing.fuzz({}, fuzzPskBinderAndAgeInput, .{ .corpus = &.{
         "",
         &([_]u8{0} ** 32),

--- a/src/tls/pre_shared_key.zig
+++ b/src/tls/pre_shared_key.zig
@@ -1395,3 +1395,189 @@ fn hexBytes(comptime hex: []const u8) [hex.len / 2]u8 {
     _ = std.fmt.hexToBytes(&bytes, hex) catch unreachable;
     return bytes;
 }
+
+// -----------------------------------------------------------------------
+// Fuzz targets (#494): PSK modes/`OfferedPsks`/binder primitives.
+//
+// The deterministic tests above already exhaustively cover exact binder
+// truncation, fixture-derived boundaries, and offer/lease ownership; these
+// targets add continuous Smith-driven mutation of the raw wire bytes,
+// generated valid offers, and binder/age arithmetic across both supported
+// hashes. Backend selected-identity/bad-binder semantics (#494 item 4) are
+// out of scope here — see `tls13_backend.zig`.
+// -----------------------------------------------------------------------
+
+/// True when `inner` is empty or wholly contained within `outer`'s backing
+/// bytes — the #494 borrowed-slice-safety property for `OfferedPsks.parse`.
+fn pskWithinBounds(outer: []const u8, inner: []const u8) bool {
+    if (inner.len == 0) return true;
+    const outer_start = @intFromPtr(outer.ptr);
+    const outer_end = outer_start + outer.len;
+    const inner_start = @intFromPtr(inner.ptr);
+    const inner_end = inner_start + inner.len;
+    return inner_start >= outer_start and inner_end <= outer_end and inner_end >= inner_start;
+}
+
+/// Drives `hasMode` and `OfferedPsks.parse` on Smith-mutated raw bytes (no
+/// allocator, small fixed buffers), then a control-derived `writeOffer` ->
+/// `OfferedPsks.parse` round trip. The writer buffer (8192 bytes) is sized
+/// well above anything the bounded generated items below can produce, so
+/// any `writeOffer` error is guaranteed to be one of the up-front
+/// structural-validation errors (never a buffer-capacity `bytes` failure
+/// partway through writing) — the single case the "never touches `w`
+/// before validating" contract actually promises.
+pub fn fuzzPskWireAndOffer(smith: *std.testing.Smith) !void {
+    var mode_buf: [64]u8 = undefined;
+    const mode_len = smith.slice(&mode_buf);
+    const mode: PskKeyExchangeMode = if (smith.index(2) == 0) .psk_ke else .psk_dhe_ke;
+    _ = hasMode(mode_buf[0..mode_len], mode) catch {};
+
+    var ext_buf: [2048]u8 = undefined;
+    const ext_len = smith.slice(&ext_buf);
+    const ext_data = ext_buf[0..ext_len];
+    if (OfferedPsks.parse(ext_data)) |parsed| {
+        var it = parsed.pairs();
+        while (try it.next()) |pair| {
+            try std.testing.expect(pskWithinBounds(ext_data, pair.identity.identity));
+            try std.testing.expect(pskWithinBounds(ext_data, pair.binder));
+        }
+    } else |_| {}
+
+    const item_count = smith.index(max_offered_identities + 2);
+    var items_buf: [max_offered_identities + 1]OfferItem = undefined;
+    var identity_storage: [max_offered_identities + 1][64]u8 = undefined;
+    const digest_choices = [_]usize{ min_binder_len - 1, min_binder_len, 48, max_binder_len, @as(usize, max_binder_len) + 1 };
+    for (items_buf[0..item_count], 0..) |*item, i| {
+        const id_len = smith.index(identity_storage[i].len + 1);
+        smith.bytes(identity_storage[i][0..id_len]);
+        var age_bytes: [4]u8 = undefined;
+        smith.bytes(&age_bytes);
+        item.* = .{
+            .identity = identity_storage[i][0..id_len],
+            .obfuscated_ticket_age = std.mem.readInt(u32, &age_bytes, .big),
+            .digest_len = digest_choices[smith.index(digest_choices.len)],
+        };
+    }
+    const items = items_buf[0..item_count];
+
+    var write_buf: [8192]u8 = undefined;
+    var w = messages.Writer{ .buf = &write_buf };
+    const offer = writeOffer(&w, items) catch {
+        try std.testing.expectEqual(@as(usize, 0), w.len);
+        return;
+    };
+    try std.testing.expectEqual(items.len, offer.count);
+
+    // ext_id(2) + ext_len(2) precede the region writeOffer wrote.
+    var parsed_offer = try OfferedPsks.parse(w.written()[4..]);
+    try std.testing.expectEqual(items.len, parsed_offer.count);
+    var offer_it = parsed_offer.pairs();
+    for (items) |item| {
+        const pair = (try offer_it.next()).?;
+        try std.testing.expectEqualSlices(u8, item.identity, pair.identity.identity);
+        try std.testing.expectEqual(item.obfuscated_ticket_age, pair.identity.obfuscated_ticket_age);
+        try std.testing.expectEqual(item.digest_len, pair.binder.len);
+    }
+    try std.testing.expectEqual(@as(?OfferedPsks.PairIterator.Pair, null), try offer_it.next());
+}
+
+test "fuzz: PSK wire codec — modes, OfferedPsks parse, and writeOffer round trip never panic or escape bounds" {
+    try testing.fuzz({}, fuzzPskWireAndOfferInput, .{ .corpus = &.{
+        "",
+        &[_]u8{0},
+        &[_]u8{ 0, 0 },
+        &[_]u8{ 1, 1 },
+        &[_]u8{ 0, 4, 'a', 'b', 'c', 'd', 0, 0, 0, 0 },
+        &([_]u8{0xff} ** 128),
+        &([_]u8{0x00} ** 128),
+    } });
+}
+
+fn fuzzPskWireAndOfferInput(_: void, smith: *std.testing.Smith) !void {
+    try fuzzPskWireAndOffer(smith);
+}
+
+/// Drives `deriveBinderFromTranscriptHash`/`verifyBinderFromTranscriptHash`
+/// across both supported hashes with Smith-controlled lengths and one-bit
+/// mutations, plus `obfuscateTicketAge`/`deobfuscateTicketAge`/
+/// `observeAgeSkew` arithmetic.
+pub fn fuzzPskBinderAndAge(smith: *std.testing.Smith) !void {
+    const hash: provider.Hash = if (smith.index(2) == 0) .sha256 else .sha384;
+    const digest_len = hash.digestLength();
+
+    var psk_buf: [provider.max_digest_len]u8 = undefined;
+    smith.bytes(&psk_buf);
+    var transcript_buf: [provider.max_digest_len]u8 = undefined;
+    smith.bytes(&transcript_buf);
+
+    const psk_len = switch (smith.index(3)) {
+        0 => digest_len,
+        1 => digest_len -| 1,
+        else => @min(digest_len + 1, psk_buf.len),
+    };
+    var out_buf: [provider.max_digest_len]u8 = undefined;
+    const out_len = switch (smith.index(3)) {
+        0 => digest_len,
+        1 => digest_len -| 1,
+        else => @min(digest_len + 1, out_buf.len),
+    };
+
+    const derive_result = deriveBinderFromTranscriptHash(hash, psk_buf[0..psk_len], transcript_buf[0..digest_len], out_buf[0..out_len]);
+    if (psk_len != digest_len or out_len != digest_len) {
+        try std.testing.expectError(error.InvalidSecretLength, derive_result);
+    } else {
+        try derive_result;
+
+        var out2: [provider.max_digest_len]u8 = undefined;
+        try deriveBinderFromTranscriptHash(hash, psk_buf[0..digest_len], transcript_buf[0..digest_len], out2[0..digest_len]);
+        try std.testing.expectEqualSlices(u8, out_buf[0..digest_len], out2[0..digest_len]);
+
+        try std.testing.expect(try verifyBinderFromTranscriptHash(hash, psk_buf[0..digest_len], transcript_buf[0..digest_len], out_buf[0..digest_len]));
+
+        var mutated_binder = out_buf;
+        var mutated_psk = psk_buf;
+        var mutated_transcript = transcript_buf;
+        const bit_index = smith.index(digest_len * 8);
+        switch (smith.index(3)) {
+            0 => mutated_binder[bit_index / 8] ^= @as(u8, 1) << @intCast(bit_index % 8),
+            1 => mutated_psk[bit_index / 8] ^= @as(u8, 1) << @intCast(bit_index % 8),
+            else => mutated_transcript[bit_index / 8] ^= @as(u8, 1) << @intCast(bit_index % 8),
+        }
+        const still_matches = try verifyBinderFromTranscriptHash(hash, mutated_psk[0..digest_len], mutated_transcript[0..digest_len], mutated_binder[0..digest_len]);
+        try std.testing.expect(!still_matches);
+
+        const wrong_length_matches = try verifyBinderFromTranscriptHash(hash, psk_buf[0..digest_len], transcript_buf[0..digest_len], out_buf[0 .. digest_len - 1]);
+        try std.testing.expect(!wrong_length_matches);
+    }
+
+    var age_bytes: [8]u8 = undefined;
+    smith.bytes(&age_bytes);
+    const age_ms = std.mem.readInt(u64, &age_bytes, .big);
+    var add_bytes: [4]u8 = undefined;
+    smith.bytes(&add_bytes);
+    const ticket_age_add = std.mem.readInt(u32, &add_bytes, .big);
+
+    const obfuscated = obfuscateTicketAge(age_ms, ticket_age_add);
+    const recovered = deobfuscateTicketAge(obfuscated, ticket_age_add);
+    try std.testing.expectEqual(@as(u32, @truncate(age_ms)), recovered);
+
+    var actual_bytes: [8]u8 = undefined;
+    smith.bytes(&actual_bytes);
+    const actual_age_ms = std.mem.readInt(u64, &actual_bytes, .big);
+    const skew = observeAgeSkew(obfuscated, ticket_age_add, actual_age_ms);
+    try std.testing.expectEqual(recovered, skew.apparent_age_ms);
+    try std.testing.expectEqual(actual_age_ms, skew.actual_age_ms);
+}
+
+test "fuzz: PSK binder derivation/verification and ticket-age arithmetic are deterministic and bounded" {
+    try testing.fuzz({}, fuzzPskBinderAndAgeInput, .{ .corpus = &.{
+        "",
+        &([_]u8{0} ** 32),
+        &([_]u8{0xab} ** 48),
+        &([_]u8{0xff} ** 96),
+    } });
+}
+
+fn fuzzPskBinderAndAgeInput(_: void, smith: *std.testing.Smith) !void {
+    try fuzzPskBinderAndAge(smith);
+}

--- a/src/tls/session.zig
+++ b/src/tls/session.zig
@@ -3565,3 +3565,255 @@ test "a failed CompatSnapshot.init replacement leaves the live destination compl
     try testing.expectEqual(@as(u16, 1), snap.format_id);
     try testing.expectEqualStrings("original-live-value", snap.slice());
 }
+
+// -----------------------------------------------------------------------
+// Fuzz targets (#494): bounded versioned session-state codec.
+//
+// The deterministic tests above already give this codec unusually deep
+// boundary coverage (every field mutation, truncation, duplicate/missing/
+// unknown field, allocation-failure sweep, byte-stability). These targets
+// add continuous Smith-driven mutation of the raw wire body, synthetic
+// `Limits` boundaries, and generated-record round trips; they do not
+// re-walk the deterministic matrix above.
+// -----------------------------------------------------------------------
+
+fn fuzzSessionLimits(control: u8) Limits {
+    return switch (control % 6) {
+        0 => .default,
+        1 => .{ .max_fields = 1 },
+        2 => .{ .max_fields = hard_max_fields },
+        3 => .{ .max_serialized_len = header_len },
+        4 => .{ .max_serialized_len = hard_max_serialized_len },
+        else => .{
+            .max_fields = 1 + @as(usize, control) % hard_max_fields,
+            .max_ticket_len = 1 + (@as(usize, control) * 37) % absolute_ticket_wire_max,
+            .max_transport_compat_len = (@as(usize, control) * 13) % (hard_max_compat_len + 1),
+            .max_application_compat_len = (@as(usize, control) * 41) % (hard_max_compat_len + 1),
+            .max_serialized_len = 64 + (@as(usize, control) * 91) % hard_max_serialized_len,
+        },
+    };
+}
+
+/// True when `inner` is empty or wholly disjoint from `outer`'s backing
+/// bytes — the #494 ownership property that a successful `decode` never
+/// retains a borrow into the `bytes` it was decoded from.
+fn disjointFromInput(outer: []const u8, inner: []const u8) bool {
+    if (inner.len == 0 or outer.len == 0) return true;
+    const outer_start = @intFromPtr(outer.ptr);
+    const outer_end = outer_start + outer.len;
+    const inner_start = @intFromPtr(inner.ptr);
+    const inner_end = inner_start + inner.len;
+    return inner_end <= outer_start or inner_start >= outer_end;
+}
+
+fn expectDecodedOwnership(raw: []const u8, decoded: *const DecodedRecord) !void {
+    const common = switch (decoded.*) {
+        .client => |*c| blk: {
+            try testing.expect(disjointFromInput(raw, c.ticket.slice()));
+            try testing.expect(disjointFromInput(raw, c.ticket_nonce.slice()));
+            break :blk &c.common;
+        },
+        .server => |*s| &s.common,
+    };
+    try testing.expect(disjointFromInput(raw, common.resumption_psk.slice()));
+    if (common.server_name) |*s| try testing.expect(disjointFromInput(raw, s.slice()));
+    if (common.application_protocol) |*a| try testing.expect(disjointFromInput(raw, a.slice()));
+    if (common.transport_compat) |*snap| try testing.expect(disjointFromInput(raw, snap.slice()));
+    if (common.application_compat) |*snap| try testing.expect(disjointFromInput(raw, snap.slice()));
+    if (common.early_data_transport_compat) |*snap| try testing.expect(disjointFromInput(raw, snap.slice()));
+    if (common.early_data_application_compat) |*snap| try testing.expect(disjointFromInput(raw, snap.slice()));
+}
+
+/// Drives `decode` directly on Smith-mutated bytes and synthetic `Limits`:
+/// malformed TLV/header/length input must never panic, wrap, or escape the
+/// cursor, and any successful decode must own its state (checked via
+/// pointer disjointness from the buffer it was decoded from, not by
+/// snapshot/poison, since ownership is exactly non-aliasing).
+pub fn fuzzSessionRawDecode(allocator: std.mem.Allocator, smith: *std.testing.Smith) !void {
+    var limits_control: [1]u8 = undefined;
+    smith.bytes(&limits_control);
+    const limits = fuzzSessionLimits(limits_control[0]);
+    limits.validate() catch return;
+
+    var raw_buf: [8192]u8 = undefined;
+    const raw_len = smith.slice(&raw_buf);
+    const raw = raw_buf[0..raw_len];
+
+    var decoded = decode(allocator, limits, raw) catch return;
+    defer decoded.deinit();
+    try expectDecodedOwnership(raw, &decoded);
+}
+
+test "fuzz: session codec raw decode never panics and owns its decoded state" {
+    try testing.fuzz({}, fuzzSessionRawDecodeInput, .{ .corpus = &.{
+        "",
+        &magic,
+        &(magic ++ [_]u8{ format_version, 1, 0, 0, 0, 0 }),
+        &client_fixture,
+        &server_fixture,
+        &([_]u8{0xff} ** 256),
+        &([_]u8{0x00} ** header_len),
+    } });
+}
+
+fn fuzzSessionRawDecodeInput(_: void, smith: *std.testing.Smith) !void {
+    try fuzzSessionRawDecode(testing.allocator, smith);
+}
+
+const fuzz_session_cipher_suites = [_]algorithms.CipherSuite{
+    .tls_aes_128_gcm_sha256,
+    .tls_aes_256_gcm_sha384,
+    .tls_chacha20_poly1305_sha256,
+};
+
+/// Builds a control-derived valid `ResumableSessionCommon`: presence/
+/// content of optional fields is fuzzed, but `server_name` is a fixed
+/// valid hostname when present (SNI charset/label rules are already
+/// exhaustively fuzzed by `sni_provider.zig`'s own "fuzz:" targets and
+/// deterministically boundary-tested above; this target's own value is
+/// the record-level round trip, not re-deriving DNS-name validity).
+fn fuzzSessionCommon(allocator: std.mem.Allocator, smith: *std.testing.Smith, suite: algorithms.CipherSuite) !ResumableSessionCommon {
+    const digest_len = algorithms.transcriptHash(suite).digestLength();
+    var psk_buf: [max_psk_len]u8 = undefined;
+    smith.bytes(&psk_buf);
+
+    const has_sni = smith.index(2) == 1;
+    const has_alpn = smith.index(2) == 1;
+    var auth_der: [16]u8 = undefined;
+    smith.bytes(&auth_der);
+
+    var issued_bytes: [8]u8 = undefined;
+    smith.bytes(&issued_bytes);
+    const issued_at_unix_ms: i64 = @bitCast(std.mem.readInt(u64, &issued_bytes, .big));
+
+    var lifetime_bytes: [4]u8 = undefined;
+    smith.bytes(&lifetime_bytes);
+    const lifetime_seconds = 1 + std.mem.readInt(u32, &lifetime_bytes, .big) % max_lifetime_seconds;
+
+    var early_max_bytes: [4]u8 = undefined;
+    smith.bytes(&early_max_bytes);
+    const early_data: EarlyDataPolicy = if (smith.index(2) == 1)
+        .{ .early_data_capable = 1 + std.mem.readInt(u32, &early_max_bytes, .big) }
+    else
+        .resume_only;
+
+    const has_transport_compat = smith.index(2) == 1;
+    const has_application_compat = smith.index(2) == 1;
+    var transport_bytes: [32]u8 = undefined;
+    smith.bytes(&transport_bytes);
+    var application_bytes: [32]u8 = undefined;
+    smith.bytes(&application_bytes);
+
+    var common: ResumableSessionCommon = .{};
+    try common.init(allocator, Limits.default, .{
+        .cipher_suite = suite,
+        .resumption_psk = psk_buf[0..digest_len],
+        .server_name = if (has_sni) "fuzz.example.test" else null,
+        .application_protocol = if (has_alpn) "h3" else null,
+        .auth_binding = AuthBinding.fromLeafCertificateDer(&auth_der),
+        .issued_at_unix_ms = issued_at_unix_ms,
+        .lifetime_seconds = lifetime_seconds,
+        .early_data = early_data,
+        .transport_compat = if (has_transport_compat) .{ .format_id = 1, .format_version = 1, .bytes = &transport_bytes } else null,
+        .application_compat = if (has_application_compat) .{ .format_id = 2, .format_version = 1, .bytes = &application_bytes } else null,
+    });
+    return common;
+}
+
+/// Builds a generated, control-derived valid client or server record,
+/// encodes it, decodes the encoding, and asserts the round trip is
+/// canonical and preserves record kind; also flips the header's record-
+/// kind byte on the valid encoding and asserts decode never accepts a
+/// client-shaped record as a server record or vice versa (a client record
+/// always carries the client-only mandatory `ticket` field, which the
+/// server decoder treats as an unknown *critical* field, and a server
+/// record is always missing the client-only mandatory fields).
+pub fn fuzzSessionRoundTrip(allocator: std.mem.Allocator, smith: *std.testing.Smith) !void {
+    const suite = fuzz_session_cipher_suites[smith.index(fuzz_session_cipher_suites.len)];
+    const as_client = smith.index(2) == 0;
+
+    var common = fuzzSessionCommon(allocator, smith, suite) catch return;
+    errdefer common.deinit();
+
+    var encode_buf: [4096]u8 = undefined;
+    const encode_cap = smith.index(encode_buf.len + 1);
+
+    if (as_client) {
+        var ticket_buf: [256]u8 = undefined;
+        const ticket_len = 1 + smith.index(ticket_buf.len);
+        smith.bytes(ticket_buf[0..ticket_len]);
+        var nonce_buf: [max_ticket_nonce_len]u8 = undefined;
+        const nonce_len = smith.index(nonce_buf.len + 1);
+        smith.bytes(nonce_buf[0..nonce_len]);
+        var age_bytes: [4]u8 = undefined;
+        smith.bytes(&age_bytes);
+        var received_bytes: [8]u8 = undefined;
+        smith.bytes(&received_bytes);
+
+        var state: ClientTicketState = .{};
+        // `errdefer common.deinit()` above already covers failure here per
+        // `ClientTicketState.init`'s documented contract (`common.*` is
+        // left completely untouched on failure); a second explicit
+        // `common.deinit()` in a `catch` here would double-free it.
+        try state.init(allocator, Limits.default, &common, .{
+            .ticket = ticket_buf[0..ticket_len],
+            .ticket_age_add = std.mem.readInt(u32, &age_bytes, .big),
+            .ticket_nonce = nonce_buf[0..nonce_len],
+            .received_at_unix_ms = @bitCast(std.mem.readInt(u64, &received_bytes, .big)),
+        });
+        defer state.deinit();
+
+        const encoded = encodeClient(&state, Limits.default, encode_buf[0..encode_cap]) catch return;
+        var decoded = try decode(allocator, Limits.default, encoded);
+        defer decoded.deinit();
+        try testing.expect(decoded == .client);
+        try testing.expectEqualSlices(u8, state.ticket.slice(), decoded.client.ticket.slice());
+        try testing.expectEqualSlices(u8, state.ticket_nonce.slice(), decoded.client.ticket_nonce.slice());
+        try testing.expectEqual(state.common.cipher_suite, decoded.client.common.cipher_suite);
+        try testing.expectEqual(state.common.lifetime_seconds, decoded.client.common.lifetime_seconds);
+
+        try expectCrossKindRejected(allocator, encoded);
+    } else {
+        var age_bytes: [4]u8 = undefined;
+        smith.bytes(&age_bytes);
+
+        var state: ServerRecoverableState = .{};
+        state.init(&common, std.mem.readInt(u32, &age_bytes, .big));
+        defer state.deinit();
+
+        const encoded = encodeServer(&state, Limits.default, encode_buf[0..encode_cap]) catch return;
+        var decoded = try decode(allocator, Limits.default, encoded);
+        defer decoded.deinit();
+        try testing.expect(decoded == .server);
+        try testing.expectEqual(state.common.cipher_suite, decoded.server.common.cipher_suite);
+        try testing.expectEqual(state.ticket_age_add, decoded.server.ticket_age_add);
+
+        try expectCrossKindRejected(allocator, encoded);
+    }
+}
+
+/// `encoded` must be a valid encoding produced by `encodeClient`/
+/// `encodeServer` above. Flipping the record-kind byte (offset 5, per
+/// `writeHeader`) must never let `decode` accept it as the other kind.
+fn expectCrossKindRejected(allocator: std.mem.Allocator, encoded: []const u8) !void {
+    var flipped: [4096]u8 = undefined;
+    @memcpy(flipped[0..encoded.len], encoded);
+    flipped[5] = if (flipped[5] == @intFromEnum(RecordType.client)) @intFromEnum(RecordType.server) else @intFromEnum(RecordType.client);
+    if (decode(allocator, Limits.default, flipped[0..encoded.len])) |mismatched| {
+        var m = mismatched;
+        defer m.deinit();
+        return error.CrossKindRecordWronglyAccepted;
+    } else |_| {}
+}
+
+test "fuzz: session codec generated client/server records round-trip and reject cross-kind decode" {
+    try testing.fuzz({}, fuzzSessionRoundTripInput, .{ .corpus = &.{
+        "",
+        &([_]u8{0} ** 64),
+        &([_]u8{0xff} ** 64),
+    } });
+}
+
+fn fuzzSessionRoundTripInput(_: void, smith: *std.testing.Smith) !void {
+    try fuzzSessionRoundTrip(testing.allocator, smith);
+}

--- a/src/tls/session.zig
+++ b/src/tls/session.zig
@@ -3577,19 +3577,38 @@ test "a failed CompatSnapshot.init replacement leaves the live destination compl
 // re-walk the deterministic matrix above.
 // -----------------------------------------------------------------------
 
+/// Explicit zero/one-under/exact/one-over/`0xffff` boundary matrix for
+/// every `Limits` field, including deliberately *invalid* values (zero
+/// `max_fields`/`max_ticket_len`/`max_serialized_len`, one-over every hard
+/// cap): `fuzzSessionRawDecode` below must see these, not silently drop
+/// them, to prove `decode` rejects an invalid caller `Limits` with
+/// `error.InvalidLimits`.
 fn fuzzSessionLimits(control: u8) Limits {
-    return switch (control % 6) {
+    return switch (control % 19) {
         0 => .default,
-        1 => .{ .max_fields = 1 },
-        2 => .{ .max_fields = hard_max_fields },
-        3 => .{ .max_serialized_len = header_len },
-        4 => .{ .max_serialized_len = hard_max_serialized_len },
+        1 => .{ .max_fields = 0 }, // invalid: zero
+        2 => .{ .max_fields = 1 }, // exact minimum
+        3 => .{ .max_fields = hard_max_fields - 1 }, // one-under maximum
+        4 => .{ .max_fields = hard_max_fields }, // exact maximum
+        5 => .{ .max_fields = hard_max_fields + 1 }, // invalid: one-over maximum
+        6 => .{ .max_ticket_len = 0 }, // invalid: zero
+        7 => .{ .max_ticket_len = 1 }, // exact minimum
+        8 => .{ .max_ticket_len = 0xfffe }, // one-under the 0xffff/absolute maximum
+        9 => .{ .max_ticket_len = 0xffff }, // exact maximum (absolute_ticket_wire_max == 0xffff)
+        10 => .{ .max_ticket_len = absolute_ticket_wire_max + 1 }, // invalid: one-over maximum
+        11 => .{ .max_serialized_len = 0 }, // invalid: zero
+        12 => .{ .max_serialized_len = header_len }, // near-minimum, still valid
+        13 => .{ .max_serialized_len = hard_max_serialized_len - 1 }, // one-under maximum
+        14 => .{ .max_serialized_len = hard_max_serialized_len }, // exact maximum
+        15 => .{ .max_serialized_len = hard_max_serialized_len + 1 }, // invalid: one-over maximum
+        16 => .{ .max_transport_compat_len = hard_max_compat_len + 1 }, // invalid: one-over maximum
+        17 => .{ .max_application_compat_len = hard_max_compat_len + 1 }, // invalid: one-over maximum
         else => .{
-            .max_fields = 1 + @as(usize, control) % hard_max_fields,
-            .max_ticket_len = 1 + (@as(usize, control) * 37) % absolute_ticket_wire_max,
-            .max_transport_compat_len = (@as(usize, control) * 13) % (hard_max_compat_len + 1),
-            .max_application_compat_len = (@as(usize, control) * 41) % (hard_max_compat_len + 1),
-            .max_serialized_len = 64 + (@as(usize, control) * 91) % hard_max_serialized_len,
+            .max_fields = 1 + @as(usize, control) % (hard_max_fields + 2),
+            .max_ticket_len = 1 + (@as(usize, control) * 37) % (absolute_ticket_wire_max + 2),
+            .max_transport_compat_len = (@as(usize, control) * 13) % (hard_max_compat_len + 2),
+            .max_application_compat_len = (@as(usize, control) * 41) % (hard_max_compat_len + 2),
+            .max_serialized_len = 1 + (@as(usize, control) * 91) % (hard_max_serialized_len + 2),
         },
     };
 }
@@ -3633,18 +3652,27 @@ pub fn fuzzSessionRawDecode(allocator: std.mem.Allocator, smith: *std.testing.Sm
     var limits_control: [1]u8 = undefined;
     smith.bytes(&limits_control);
     const limits = fuzzSessionLimits(limits_control[0]);
-    limits.validate() catch return;
 
     var raw_buf: [8192]u8 = undefined;
     const raw_len = smith.slice(&raw_buf);
     const raw = raw_buf[0..raw_len];
 
-    var decoded = decode(allocator, limits, raw) catch return;
-    defer decoded.deinit();
-    try expectDecodedOwnership(raw, &decoded);
+    // `limits` may itself be invalid (see `fuzzSessionLimits`): `decode`
+    // must see it, not have it filtered out beforehand, so this proves
+    // the #494 requirement that an invalid caller `Limits` fails
+    // deterministically with `error.InvalidLimits` rather than becoming a
+    // silent no-op fuzz input.
+    const result = decode(allocator, limits, raw);
+    if (limits.validate()) |_| {
+        var decoded = result catch return;
+        defer decoded.deinit();
+        try expectDecodedOwnership(raw, &decoded);
+    } else |_| {
+        try testing.expectError(error.InvalidLimits, result);
+    }
 }
 
-test "fuzz: session codec raw decode never panics and owns its decoded state" {
+test "fuzz: TLS resumption: session codec raw decode never panics and owns its decoded state" {
     try testing.fuzz({}, fuzzSessionRawDecodeInput, .{ .corpus = &.{
         "",
         &magic,
@@ -3665,6 +3693,24 @@ const fuzz_session_cipher_suites = [_]algorithms.CipherSuite{
     .tls_aes_256_gcm_sha384,
     .tls_chacha20_poly1305_sha256,
 };
+
+/// Maps an arbitrary `u32` into the non-zero `u32` domain
+/// `EarlyDataPolicy.early_data_capable` requires, without `1 +
+/// std.math.maxInt(u32)` overflowing/trapping when `raw ==
+/// 0xffffffff` (safety-build panic; the fuzz harness itself would then
+/// violate the target's own no-panic property).
+fn earlyDataCapableFromRaw(raw: u32) u32 {
+    return (raw % std.math.maxInt(u32)) + 1;
+}
+
+test "fuzz: TLS resumption: earlyDataCapableFromRaw never overflows at the u32 boundary" {
+    // Regression for a fix to fuzzSessionCommon's early-data generation:
+    // `1 + raw` previously trapped when `raw == 0xffffffff`.
+    try testing.expectEqual(@as(u32, 1), earlyDataCapableFromRaw(std.math.maxInt(u32)));
+    try testing.expectEqual(@as(u32, std.math.maxInt(u32)), earlyDataCapableFromRaw(std.math.maxInt(u32) - 1));
+    try testing.expectEqual(@as(u32, 1), earlyDataCapableFromRaw(0));
+    try testing.expectEqual(@as(u32, 2), earlyDataCapableFromRaw(1));
+}
 
 /// Builds a control-derived valid `ResumableSessionCommon`: presence/
 /// content of optional fields is fuzzed, but `server_name` is a fixed
@@ -3693,7 +3739,7 @@ fn fuzzSessionCommon(allocator: std.mem.Allocator, smith: *std.testing.Smith, su
     var early_max_bytes: [4]u8 = undefined;
     smith.bytes(&early_max_bytes);
     const early_data: EarlyDataPolicy = if (smith.index(2) == 1)
-        .{ .early_data_capable = 1 + std.mem.readInt(u32, &early_max_bytes, .big) }
+        .{ .early_data_capable = earlyDataCapableFromRaw(std.mem.readInt(u32, &early_max_bytes, .big)) }
     else
         .resume_only;
 
@@ -3720,14 +3766,38 @@ fn fuzzSessionCommon(allocator: std.mem.Allocator, smith: *std.testing.Smith, su
     return common;
 }
 
+/// Asserts `evaluateCompatibility` reports the record itself as eligible
+/// when the candidate context exactly matches every field `common` holds:
+/// proves `evaluateCompatibility` is actually driven by this target
+/// (#494-A acceptance gap) rather than only being available at compile
+/// time.
+fn expectSelfCompatible(common: *const ResumableSessionCommon) !void {
+    const candidate: CandidateContext = .{
+        .cipher_suite = common.cipher_suite,
+        .server_name = if (common.server_name) |*s| s.slice() else null,
+        .application_protocol = if (common.application_protocol) |*a| a.slice() else null,
+        .auth_binding = common.auth_binding,
+        .transport_compat = if (common.transport_compat) |*snap| .{ .format_id = snap.format_id, .format_version = snap.format_version, .bytes = snap.slice() } else null,
+        .application_compat = if (common.application_compat) |*snap| .{ .format_id = snap.format_id, .format_version = snap.format_version, .bytes = snap.slice() } else null,
+    };
+    const decision = evaluateCompatibility(common, candidate, common.issued_at_unix_ms);
+    try testing.expect(decision.resumption == .eligible);
+}
+
 /// Builds a generated, control-derived valid client or server record,
-/// encodes it, decodes the encoding, and asserts the round trip is
-/// canonical and preserves record kind; also flips the header's record-
-/// kind byte on the valid encoding and asserts decode never accepts a
-/// client-shaped record as a server record or vice versa (a client record
-/// always carries the client-only mandatory `ticket` field, which the
-/// server decoder treats as an unknown *critical* field, and a server
-/// record is always missing the client-only mandatory fields).
+/// encodes it, decodes the encoding, and asserts the round trip is fully
+/// canonical: `clientEncodedLenWithLimits`/`serverEncodedLenWithLimits`
+/// matches the actual encoded length, and re-encoding the *decoded*
+/// record reproduces the original encoding byte-for-byte — proving every
+/// field (PSK, SNI, ALPN, auth binding, timestamps, early-data policy,
+/// every compatibility snapshot), not just the handful spot-checked
+/// individually, survives the round trip. Also drives
+/// `evaluateCompatibility` against a matching candidate, and flips the
+/// header's record-kind byte on the valid encoding to assert decode never
+/// accepts a client-shaped record as a server record or vice versa (a
+/// client record always carries the client-only mandatory `ticket` field,
+/// which the server decoder treats as an unknown *critical* field, and a
+/// server record is always missing the client-only mandatory fields).
 pub fn fuzzSessionRoundTrip(allocator: std.mem.Allocator, smith: *std.testing.Smith) !void {
     const suite = fuzz_session_cipher_suites[smith.index(fuzz_session_cipher_suites.len)];
     const as_client = smith.index(2) == 0;
@@ -3764,13 +3834,17 @@ pub fn fuzzSessionRoundTrip(allocator: std.mem.Allocator, smith: *std.testing.Sm
         defer state.deinit();
 
         const encoded = encodeClient(&state, Limits.default, encode_buf[0..encode_cap]) catch return;
+        const needed = try clientEncodedLenWithLimits(&state, Limits.default);
+        try testing.expectEqual(needed, encoded.len);
+
         var decoded = try decode(allocator, Limits.default, encoded);
         defer decoded.deinit();
         try testing.expect(decoded == .client);
-        try testing.expectEqualSlices(u8, state.ticket.slice(), decoded.client.ticket.slice());
-        try testing.expectEqualSlices(u8, state.ticket_nonce.slice(), decoded.client.ticket_nonce.slice());
-        try testing.expectEqual(state.common.cipher_suite, decoded.client.common.cipher_suite);
-        try testing.expectEqual(state.common.lifetime_seconds, decoded.client.common.lifetime_seconds);
+
+        var canonical_buf: [4096]u8 = undefined;
+        const canonical = try encodeClient(&decoded.client, Limits.default, &canonical_buf);
+        try testing.expectEqualSlices(u8, encoded, canonical);
+        try expectSelfCompatible(&decoded.client.common);
 
         try expectCrossKindRejected(allocator, encoded);
     } else {
@@ -3782,11 +3856,17 @@ pub fn fuzzSessionRoundTrip(allocator: std.mem.Allocator, smith: *std.testing.Sm
         defer state.deinit();
 
         const encoded = encodeServer(&state, Limits.default, encode_buf[0..encode_cap]) catch return;
+        const needed = try serverEncodedLenWithLimits(&state, Limits.default);
+        try testing.expectEqual(needed, encoded.len);
+
         var decoded = try decode(allocator, Limits.default, encoded);
         defer decoded.deinit();
         try testing.expect(decoded == .server);
-        try testing.expectEqual(state.common.cipher_suite, decoded.server.common.cipher_suite);
-        try testing.expectEqual(state.ticket_age_add, decoded.server.ticket_age_add);
+
+        var canonical_buf: [4096]u8 = undefined;
+        const canonical = try encodeServer(&decoded.server, Limits.default, &canonical_buf);
+        try testing.expectEqualSlices(u8, encoded, canonical);
+        try expectSelfCompatible(&decoded.server.common);
 
         try expectCrossKindRejected(allocator, encoded);
     }
@@ -3806,7 +3886,7 @@ fn expectCrossKindRejected(allocator: std.mem.Allocator, encoded: []const u8) !v
     } else |_| {}
 }
 
-test "fuzz: session codec generated client/server records round-trip and reject cross-kind decode" {
+test "fuzz: TLS resumption: session codec generated client/server records round-trip and reject cross-kind decode" {
     try testing.fuzz({}, fuzzSessionRoundTripInput, .{ .corpus = &.{
         "",
         &([_]u8{0} ** 64),

--- a/src/tls/session.zig
+++ b/src/tls/session.zig
@@ -3584,7 +3584,7 @@ test "a failed CompatSnapshot.init replacement leaves the live destination compl
 /// them, to prove `decode` rejects an invalid caller `Limits` with
 /// `error.InvalidLimits`.
 fn fuzzSessionLimits(control: u8) Limits {
-    return switch (control % 19) {
+    return switch (control % 27) {
         0 => .default,
         1 => .{ .max_fields = 0 }, // invalid: zero
         2 => .{ .max_fields = 1 }, // exact minimum
@@ -3601,8 +3601,18 @@ fn fuzzSessionLimits(control: u8) Limits {
         13 => .{ .max_serialized_len = hard_max_serialized_len - 1 }, // one-under maximum
         14 => .{ .max_serialized_len = hard_max_serialized_len }, // exact maximum
         15 => .{ .max_serialized_len = hard_max_serialized_len + 1 }, // invalid: one-over maximum
-        16 => .{ .max_transport_compat_len = hard_max_compat_len + 1 }, // invalid: one-over maximum
-        17 => .{ .max_application_compat_len = hard_max_compat_len + 1 }, // invalid: one-over maximum
+        // Zero is *valid* for both compat-length fields (it means "no
+        // compat snapshot accepted"), so it must reach `decode` as a
+        // meaningful tight limit, not only exercise invalid-limit
+        // rejection.
+        16 => .{ .max_transport_compat_len = 0 }, // valid: zero
+        17 => .{ .max_transport_compat_len = hard_max_compat_len - 1 }, // one-under maximum
+        18 => .{ .max_transport_compat_len = hard_max_compat_len }, // exact maximum
+        19 => .{ .max_transport_compat_len = hard_max_compat_len + 1 }, // invalid: one-over maximum
+        20 => .{ .max_application_compat_len = 0 }, // valid: zero
+        21 => .{ .max_application_compat_len = hard_max_compat_len - 1 }, // one-under maximum
+        22 => .{ .max_application_compat_len = hard_max_compat_len }, // exact maximum
+        23 => .{ .max_application_compat_len = hard_max_compat_len + 1 }, // invalid: one-over maximum
         else => .{
             .max_fields = 1 + @as(usize, control) % (hard_max_fields + 2),
             .max_ticket_len = 1 + (@as(usize, control) * 37) % (absolute_ticket_wire_max + 2),
@@ -3703,9 +3713,15 @@ fn earlyDataCapableFromRaw(raw: u32) u32 {
     return (raw % std.math.maxInt(u32)) + 1;
 }
 
-test "fuzz: TLS resumption: earlyDataCapableFromRaw never overflows at the u32 boundary" {
-    // Regression for a fix to fuzzSessionCommon's early-data generation:
-    // `1 + raw` previously trapped when `raw == 0xffffffff`.
+test "earlyDataCapableFromRaw never overflows at the u32 boundary" {
+    // Named deterministic regression, not a fuzz target (no
+    // `std.testing.fuzz` call, no corpus): kept outside the
+    // "fuzz: TLS resumption:" namespace per #376's target/regression
+    // convention, and selected by its own name --
+    // `-Dtls-resumption-test-filter="earlyDataCapableFromRaw never
+    // overflows at the u32 boundary"`. Regression for a fix to
+    // fuzzSessionCommon's early-data generation: `1 + raw` previously
+    // trapped when `raw == 0xffffffff`.
     try testing.expectEqual(@as(u32, 1), earlyDataCapableFromRaw(std.math.maxInt(u32)));
     try testing.expectEqual(@as(u32, std.math.maxInt(u32)), earlyDataCapableFromRaw(std.math.maxInt(u32) - 1));
     try testing.expectEqual(@as(u32, 1), earlyDataCapableFromRaw(0));

--- a/src/tls/ticket_protection.zig
+++ b/src/tls/ticket_protection.zig
@@ -3198,6 +3198,29 @@ fn envelopeWithinBounds(outer: []const u8, inner: []const u8) bool {
     return inner_start >= outer_start and inner_end <= outer_end and inner_end >= inner_start;
 }
 
+test "parseEnvelope rejects every truncated prefix of a valid envelope below the minimum length" {
+    var identity: [fixed_header_len + 32 + tag_len]u8 = undefined;
+    writeHeader(identity[0..fixed_header_len], .aes_128_gcm, &keyId(9), &([_]u8{0x77} ** provider.aead_nonce_len));
+    const ciphertext_len = 32;
+    @memset(identity[fixed_header_len..][0..ciphertext_len], 0x22);
+    @memset(identity[fixed_header_len + ciphertext_len ..][0..tag_len], 0x33);
+    const full = identity[0 .. fixed_header_len + ciphertext_len + tag_len];
+
+    // Below the minimum (`fixed_header_len + 1 + tag_len`), `parseEnvelope`
+    // rejects on length alone before ever inspecting magic/version/AEAD
+    // content, so every one of these prefixes fails identically.
+    const minimum = fixed_header_len + 1 + tag_len;
+    var cut: usize = 0;
+    while (cut < minimum) : (cut += 1) {
+        try testing.expectError(error.MalformedEnvelope, parseEnvelope(full[0..cut], session.Limits.default));
+    }
+    // At and above the minimum, the full fixed header is always intact
+    // (`minimum > fixed_header_len`), so every remaining prefix parses.
+    while (cut <= full.len) : (cut += 1) {
+        _ = try parseEnvelope(full[0..cut], session.Limits.default);
+    }
+}
+
 fn fuzzEnvelopeLimits(control: u8) session.Limits {
     return switch (control % 6) {
         0 => .default,
@@ -3234,15 +3257,21 @@ pub fn fuzzParseEnvelope(smith: *std.testing.Smith) !void {
         try testing.expectEqual(@intFromPtr(parsed.header.ptr) + parsed.header.len, @intFromPtr(parsed.ciphertext.ptr));
         try testing.expectEqual(@intFromPtr(parsed.ciphertext.ptr) + parsed.ciphertext.len, @intFromPtr(parsed.tag.ptr));
         try testing.expectEqual(@intFromPtr(parsed.tag.ptr) + parsed.tag.len, @intFromPtr(identity.ptr) + identity.len);
+        // Every field of the two parses must agree, not just a subset:
+        // identical bytes/limits must produce a byte-for-byte identical
+        // `ParsedEnvelope`.
         try testing.expectEqual(parsed.aead, parsed2.aead);
         try testing.expectEqualSlices(u8, &parsed.key_id, &parsed2.key_id);
         try testing.expectEqualSlices(u8, &parsed.nonce, &parsed2.nonce);
+        try testing.expectEqualSlices(u8, parsed.header, parsed2.header);
+        try testing.expectEqualSlices(u8, parsed.ciphertext, parsed2.ciphertext);
+        try testing.expectEqualSlices(u8, parsed.tag, parsed2.tag);
     } else |err| {
         try testing.expectError(err, second);
     }
 }
 
-test "fuzz: parseEnvelope is allocation-free, deterministic, and returns an ordered non-overlapping view" {
+test "fuzz: TLS resumption: parseEnvelope is allocation-free, deterministic, and returns an ordered non-overlapping view" {
     try testing.fuzz({}, fuzzParseEnvelopeInput, .{ .corpus = &.{
         "",
         "TDTK",
@@ -3256,14 +3285,31 @@ fn fuzzParseEnvelopeInput(_: void, smith: *std.testing.Smith) !void {
     try fuzzParseEnvelope(smith);
 }
 
+fn expectEnvelopeGeometry(identity: []const u8, parsed: ParsedEnvelope) !void {
+    try testing.expect(envelopeWithinBounds(identity, parsed.header));
+    try testing.expect(envelopeWithinBounds(identity, parsed.ciphertext));
+    try testing.expect(envelopeWithinBounds(identity, parsed.tag));
+}
+
 /// Builds a control-derived *valid* envelope via `writeHeader`, confirms
 /// the baseline parses, then applies one Smith-selected single-field
-/// mutation (magic, version, AEAD id, reserved flags, key id, nonce,
-/// ciphertext, or tag) and a synthetic `Limits` sweep. Any post-mutation
-/// success must still satisfy the ordered/non-overlapping/within-bounds
-/// view contract; this never asserts a specific rejection, since some
-/// mutations (e.g. a still-valid AEAD id byte) do not actually break
-/// structural validity.
+/// mutation and asserts the exact typed outcome for that field class:
+///
+/// - magic/reserved-flags: the fixture always starts at the required
+///   value (`magic`/zero), so XOR-by-`0xff` on one byte deterministically
+///   breaks it -- always `error.MalformedEnvelope`.
+/// - version: the fixture always starts at `format_version`; `+%= 1`
+///   always produces a different, unsupported value -- always
+///   `error.UnsupportedVersion`.
+/// - AEAD id: guarantees an actual mutation first (a same-value
+///   reassignment would silently skip this branch), then asserts by
+///   class -- a still-valid stable id parses to a *different* AEAD than
+///   the baseline, an invalid one is `error.UnsupportedAeadId`.
+/// - key id/nonce/ciphertext/tag: opaque until authenticated open, so
+///   *any* mutation must still parse successfully with the ordered/
+///   non-overlapping/within-bounds view contract intact -- a future
+///   regression that starts rejecting or interpreting these bytes must
+///   fail this target, not silently pass via a blanket `catch {}`.
 pub fn fuzzParseEnvelopeMutation(smith: *std.testing.Smith) !void {
     var ciphertext_buf: [64]u8 = undefined;
     const ciphertext_len = 1 + smith.index(ciphertext_buf.len);
@@ -3289,21 +3335,51 @@ pub fn fuzzParseEnvelopeMutation(smith: *std.testing.Smith) !void {
     try testing.expectEqual(aead, baseline.aead);
 
     switch (smith.index(8)) {
-        0 => identity[smith.index(4)] ^= 0xff, // magic
-        1 => identity[4] +%= 1, // version
-        2 => identity[5] = @intCast(smith.index(256)), // AEAD id
-        3 => identity[6 + smith.index(2)] ^= 0xff, // reserved flags
-        4 => identity[8 + smith.index(key_id_len)] ^= 0xff, // key id
-        5 => identity[24 + smith.index(provider.aead_nonce_len)] ^= 0xff, // nonce
-        6 => identity[fixed_header_len + smith.index(ciphertext_len)] ^= 0xff, // ciphertext
-        else => identity[identity.len - 1 - smith.index(tag_len)] ^= 0xff, // tag
+        0 => {
+            identity[smith.index(4)] ^= 0xff; // magic
+            try testing.expectError(error.MalformedEnvelope, parseEnvelope(identity, session.Limits.default));
+        },
+        1 => {
+            identity[4] +%= 1; // version
+            try testing.expectError(error.UnsupportedVersion, parseEnvelope(identity, session.Limits.default));
+        },
+        2 => {
+            const original = identity[5];
+            var new_id = smith.index(256);
+            if (new_id == original) new_id = (new_id + 1) % 256;
+            identity[5] = @intCast(new_id); // AEAD id, guaranteed changed
+            if (decodeAeadId(@intCast(new_id))) |_| {
+                const mutated = try parseEnvelope(identity, session.Limits.default);
+                try testing.expect(mutated.aead != baseline.aead);
+            } else |_| {
+                try testing.expectError(error.UnsupportedAeadId, parseEnvelope(identity, session.Limits.default));
+            }
+        },
+        3 => {
+            identity[6 + smith.index(2)] ^= 0xff; // reserved flags
+            try testing.expectError(error.MalformedEnvelope, parseEnvelope(identity, session.Limits.default));
+        },
+        4 => {
+            identity[8 + smith.index(key_id_len)] ^= 0xff; // key id
+            const mutated = try parseEnvelope(identity, session.Limits.default);
+            try expectEnvelopeGeometry(identity, mutated);
+        },
+        5 => {
+            identity[24 + smith.index(provider.aead_nonce_len)] ^= 0xff; // nonce
+            const mutated = try parseEnvelope(identity, session.Limits.default);
+            try expectEnvelopeGeometry(identity, mutated);
+        },
+        6 => {
+            identity[fixed_header_len + smith.index(ciphertext_len)] ^= 0xff; // ciphertext
+            const mutated = try parseEnvelope(identity, session.Limits.default);
+            try expectEnvelopeGeometry(identity, mutated);
+        },
+        else => {
+            identity[identity.len - 1 - smith.index(tag_len)] ^= 0xff; // tag
+            const mutated = try parseEnvelope(identity, session.Limits.default);
+            try expectEnvelopeGeometry(identity, mutated);
+        },
     }
-
-    if (parseEnvelope(identity, session.Limits.default)) |mutated| {
-        try testing.expect(envelopeWithinBounds(identity, mutated.header));
-        try testing.expect(envelopeWithinBounds(identity, mutated.ciphertext));
-        try testing.expect(envelopeWithinBounds(identity, mutated.tag));
-    } else |_| {}
 
     var limits_control: [1]u8 = undefined;
     smith.bytes(&limits_control);
@@ -3311,7 +3387,7 @@ pub fn fuzzParseEnvelopeMutation(smith: *std.testing.Smith) !void {
     _ = parseEnvelope(identity, limits) catch {};
 }
 
-test "fuzz: parseEnvelope single-field mutation and Limits boundaries never panic" {
+test "fuzz: TLS resumption: parseEnvelope single-field mutation and Limits boundaries never panic" {
     try testing.fuzz({}, fuzzParseEnvelopeMutationInput, .{ .corpus = &.{
         "",
         &([_]u8{0} ** 16),

--- a/src/tls/ticket_protection.zig
+++ b/src/tls/ticket_protection.zig
@@ -3172,3 +3172,153 @@ test "key windows and ticket lifetime are enforced" {
     state.common.lifetime_seconds = 20;
     try testing.expectError(error.TicketOutlivesKey, protector.seal(allocator, &state, 2_000, &ticket_buf));
 }
+
+// -----------------------------------------------------------------------
+// Fuzz targets (#494 item 5): allocation-free public ticket-envelope
+// parsing.
+//
+// "fuzz: ticket identity parsing and miss resolution never panic or
+// mutate output" above already drives `parseEnvelope` as part of the
+// combined authenticated `Protector.resolve` path (item 6's scope). These
+// targets touch ONLY `parseEnvelope`: no allocator, provider, keyring, or
+// clock is constructed anywhere in them.
+// -----------------------------------------------------------------------
+
+const fuzz_minimal_valid_envelope: [fixed_header_len + 1 + tag_len]u8 =
+    magic ++ [_]u8{ format_version, 1, 0, 0 } ++ ([_]u8{0} ** (key_id_len + provider.aead_nonce_len)) ++ [_]u8{0xab} ++ ([_]u8{0} ** tag_len);
+
+/// True when `inner` is empty or wholly contained within `outer`'s backing
+/// bytes.
+fn envelopeWithinBounds(outer: []const u8, inner: []const u8) bool {
+    if (inner.len == 0) return true;
+    const outer_start = @intFromPtr(outer.ptr);
+    const outer_end = outer_start + outer.len;
+    const inner_start = @intFromPtr(inner.ptr);
+    const inner_end = inner_start + inner.len;
+    return inner_start >= outer_start and inner_end <= outer_end and inner_end >= inner_start;
+}
+
+fn fuzzEnvelopeLimits(control: u8) session.Limits {
+    return switch (control % 6) {
+        0 => .default,
+        1 => .{ .max_ticket_len = fixed_header_len + tag_len }, // below the minimum (no ciphertext room)
+        2 => .{ .max_ticket_len = fixed_header_len + 1 + tag_len }, // exact minimum
+        3 => .{ .max_ticket_len = session.absolute_ticket_wire_max },
+        4 => .{ .max_ticket_len = 1 },
+        else => .{ .max_ticket_len = 1 + @as(usize, control) },
+    };
+}
+
+/// Drives `parseEnvelope` directly on Smith-mutated raw bytes and
+/// synthetic `Limits`: never panics, is deterministic for identical
+/// inputs, and a successful parse's `header`/`ciphertext`/`tag` views are
+/// ordered, non-overlapping, and wholly inside `identity`.
+pub fn fuzzParseEnvelope(smith: *std.testing.Smith) !void {
+    var limits_control: [1]u8 = undefined;
+    smith.bytes(&limits_control);
+    const limits = fuzzEnvelopeLimits(limits_control[0]);
+
+    var identity_buf: [session.absolute_ticket_wire_max + 16]u8 = undefined;
+    const identity_len = smith.slice(&identity_buf);
+    const identity = identity_buf[0..identity_len];
+
+    const first = parseEnvelope(identity, limits);
+    const second = parseEnvelope(identity, limits);
+    if (first) |parsed| {
+        const parsed2 = second catch return error.NondeterministicParseEnvelope;
+        try testing.expect(envelopeWithinBounds(identity, parsed.header));
+        try testing.expect(envelopeWithinBounds(identity, parsed.ciphertext));
+        try testing.expect(envelopeWithinBounds(identity, parsed.tag));
+        try testing.expectEqual(@as(usize, fixed_header_len), parsed.header.len);
+        try testing.expectEqual(@as(usize, tag_len), parsed.tag.len);
+        try testing.expectEqual(@intFromPtr(parsed.header.ptr) + parsed.header.len, @intFromPtr(parsed.ciphertext.ptr));
+        try testing.expectEqual(@intFromPtr(parsed.ciphertext.ptr) + parsed.ciphertext.len, @intFromPtr(parsed.tag.ptr));
+        try testing.expectEqual(@intFromPtr(parsed.tag.ptr) + parsed.tag.len, @intFromPtr(identity.ptr) + identity.len);
+        try testing.expectEqual(parsed.aead, parsed2.aead);
+        try testing.expectEqualSlices(u8, &parsed.key_id, &parsed2.key_id);
+        try testing.expectEqualSlices(u8, &parsed.nonce, &parsed2.nonce);
+    } else |err| {
+        try testing.expectError(err, second);
+    }
+}
+
+test "fuzz: parseEnvelope is allocation-free, deterministic, and returns an ordered non-overlapping view" {
+    try testing.fuzz({}, fuzzParseEnvelopeInput, .{ .corpus = &.{
+        "",
+        "TDTK",
+        &fuzz_minimal_valid_envelope,
+        &([_]u8{0} ** (fixed_header_len + tag_len)),
+        &([_]u8{0xff} ** 256),
+    } });
+}
+
+fn fuzzParseEnvelopeInput(_: void, smith: *std.testing.Smith) !void {
+    try fuzzParseEnvelope(smith);
+}
+
+/// Builds a control-derived *valid* envelope via `writeHeader`, confirms
+/// the baseline parses, then applies one Smith-selected single-field
+/// mutation (magic, version, AEAD id, reserved flags, key id, nonce,
+/// ciphertext, or tag) and a synthetic `Limits` sweep. Any post-mutation
+/// success must still satisfy the ordered/non-overlapping/within-bounds
+/// view contract; this never asserts a specific rejection, since some
+/// mutations (e.g. a still-valid AEAD id byte) do not actually break
+/// structural validity.
+pub fn fuzzParseEnvelopeMutation(smith: *std.testing.Smith) !void {
+    var ciphertext_buf: [64]u8 = undefined;
+    const ciphertext_len = 1 + smith.index(ciphertext_buf.len);
+    smith.bytes(ciphertext_buf[0..ciphertext_len]);
+
+    var identity_buf: [fixed_header_len + 64 + tag_len]u8 = undefined;
+    const total_len = fixed_header_len + ciphertext_len + tag_len;
+    const identity = identity_buf[0..total_len];
+
+    const aead_choices = [_]provider.Aead{ .aes_128_gcm, .aes_256_gcm, .chacha20_poly1305 };
+    const aead = aead_choices[smith.index(aead_choices.len)];
+    var kid_bytes: KeyId = undefined;
+    smith.bytes(&kid_bytes);
+    var nonce_bytes: [provider.aead_nonce_len]u8 = undefined;
+    smith.bytes(&nonce_bytes);
+    writeHeader(identity[0..fixed_header_len], aead, &kid_bytes, &nonce_bytes);
+    @memcpy(identity[fixed_header_len..][0..ciphertext_len], ciphertext_buf[0..ciphertext_len]);
+    var tag_bytes: [tag_len]u8 = undefined;
+    smith.bytes(&tag_bytes);
+    @memcpy(identity[fixed_header_len + ciphertext_len ..][0..tag_len], &tag_bytes);
+
+    const baseline = try parseEnvelope(identity, session.Limits.default);
+    try testing.expectEqual(aead, baseline.aead);
+
+    switch (smith.index(8)) {
+        0 => identity[smith.index(4)] ^= 0xff, // magic
+        1 => identity[4] +%= 1, // version
+        2 => identity[5] = @intCast(smith.index(256)), // AEAD id
+        3 => identity[6 + smith.index(2)] ^= 0xff, // reserved flags
+        4 => identity[8 + smith.index(key_id_len)] ^= 0xff, // key id
+        5 => identity[24 + smith.index(provider.aead_nonce_len)] ^= 0xff, // nonce
+        6 => identity[fixed_header_len + smith.index(ciphertext_len)] ^= 0xff, // ciphertext
+        else => identity[identity.len - 1 - smith.index(tag_len)] ^= 0xff, // tag
+    }
+
+    if (parseEnvelope(identity, session.Limits.default)) |mutated| {
+        try testing.expect(envelopeWithinBounds(identity, mutated.header));
+        try testing.expect(envelopeWithinBounds(identity, mutated.ciphertext));
+        try testing.expect(envelopeWithinBounds(identity, mutated.tag));
+    } else |_| {}
+
+    var limits_control: [1]u8 = undefined;
+    smith.bytes(&limits_control);
+    const limits = fuzzEnvelopeLimits(limits_control[0]);
+    _ = parseEnvelope(identity, limits) catch {};
+}
+
+test "fuzz: parseEnvelope single-field mutation and Limits boundaries never panic" {
+    try testing.fuzz({}, fuzzParseEnvelopeMutationInput, .{ .corpus = &.{
+        "",
+        &([_]u8{0} ** 16),
+        &([_]u8{0xff} ** 16),
+    } });
+}
+
+fn fuzzParseEnvelopeMutationInput(_: void, smith: *std.testing.Smith) !void {
+    try fuzzParseEnvelopeMutation(smith);
+}


### PR DESCRIPTION
## Summary

First slice (#494-A, per the issue's own recommended PR decomposition) of #494's fuzz/property coverage for the pure-Zig TLS resumption stack: codecs and allocation-free parsing. Follows the shared contract in `docs/CRYPTO_FUZZ_CONTRACT.md` and #376's `std.testing.fuzz`/`Smith` pattern (already used by `ticket_key_snapshot.zig`/`sni_provider.zig`).

- **`NewSessionTicket` wire codec + owned-state construction** (`src/tls/new_session_ticket.zig`): `decode` never panics or retains a borrow past its input buffer; `encode`/`decode` structurally round-trips generated valid params (`encodedLen(params) == encoded.len` asserted directly); `OutputTooSmall` never partially writes the destination; drives `buildClientTicketState`/`buildServerRecoverableStateNoIdentity` from the round-tripped value with a fresh per-case provider and an RMS sized to the selected suite's digest length, poisoning the source after construction to prove the resulting state owns its ticket/nonce bytes, and asserting the exact `TicketTooLarge`/`InvalidLifetime` outcome when the generated shape should fail.
- **Session-state codec** (`src/tls/session.zig`): raw `decode` never panics on arbitrary bytes and synthetic `Limits` (an explicit zero/one-under/exact/one-over/`0xffff` boundary matrix for every `Limits` field, including deliberately invalid values, which must fail with `error.InvalidLimits`), and a successful decode owns its state (verified via pointer-disjointness from the input, not snapshot/poison); generated client/server records round-trip fully canonically (`clientEncodedLenWithLimits`/`serverEncodedLenWithLimits` match, and re-encoding the *decoded* record reproduces the original bytes exactly, not just a handful of spot-checked fields) and drive `evaluateCompatibility`; a valid client record can never be accepted as a server record or vice versa (flipped record-kind byte).
- **PSK modes/`OfferedPsks`/binder primitives** (`src/tls/pre_shared_key.zig`): `hasMode`/`OfferedPsks.parse` never panic on raw bytes and parsed slices stay within the input; `writeModes`/`writeOffer`'s pre-write structural validation is fully transactional (writer length *and* every output byte unchanged on rejection); generated valid offers round-trip through `parse`; `deriveBinderFromTranscriptHash`/`verifyBinderFromTranscriptHash` are deterministic across both SHA-256 and SHA-384 with PSK/transcript-hash/output/candidate lengths chosen independently around the digest length (so SHA-384's one-over case and wrong-length transcript hashes are actually exercised, not silently collapsed back to a valid length); `deriveBinder`/`verifyBinder` reject one-bit mutations of the transcript hash, PSK, binder, *and* identity bytes (proving the identity is actually included in the transcript at the correct boundary); `obfuscateTicketAge`/`deobfuscateTicketAge`/`observeAgeSkew` arithmetic never panics.
- **Allocation-free ticket-envelope parsing** (`src/tls/ticket_protection.zig`): a *dedicated* `parseEnvelope`-only target (no allocator/provider/keyring/clock — distinct from the existing combined `fuzzTicketIdentity` target, which also drives authenticated `Protector.resolve` and is #494-B's scope) proving every field of `ParsedEnvelope` is deterministic and returns ordered, non-overlapping `header`/`ciphertext`/`tag` views under raw-byte mutation; a single-field-mutation target that asserts by class (typed errors for magic/version/reserved-flags, a guaranteed-changed AEAD id, and required continued success for key-id/nonce/ciphertext/tag mutations, which are opaque until authenticated open) plus synthetic `Limits` boundaries; a deterministic regression exhaustively covering every truncation boundary of a valid envelope.

Wires a dedicated `zig build test-tls-resumption-fuzz` step with `-Dtls-resumption-test-filter` (defaults to the `"fuzz: TLS resumption:"` namespace — not a bare `"fuzz: "` prefix, which would also pull in unrelated pre-existing fuzz targets already living in `tls_core_mod`: `sni_provider.zig`'s two targets, `ticket_key_snapshot.zig`'s, and `ticket_protection.zig`'s own combined identity/resolve target) and documents the step/example reproduction commands, including the named deterministic regressions selected by their own name, in `CRYPTO_FUZZ_CONTRACT.md`.

Existing deep deterministic coverage in each module (truncation matrices, field mutation, allocation-failure sweeps, byte-stability fixtures, etc.) is preserved, not duplicated or weakened — these targets add continuous mutation, cross-operation round trips, and ownership/lifetime invariants on top of it.

Authenticated ticket open/keyring publication, session-cache/lease state machines, and backend/runtime composition remain #494-B/C/D per the issue's own PR decomposition.

## Test plan

- [x] `zig fmt --check build.zig src/ tests/`
- [x] `zig build test-tls-resumption-fuzz --summary all --error-style verbose` (9/9 pass)
- [x] `zig build test-tls --summary all --error-style verbose` (883/883 pass)
- [x] `zig build test --summary all --error-style verbose` (3144/3145 pass, 1 pre-existing skip)
- [x] `zig build test -Dtls-profile=appliance --summary all --error-style verbose` (3113/3114 pass, 1 pre-existing skip)
- [x] `-Dtls-resumption-test-filter` spot-checked to select individual fuzz targets and individual named deterministic regressions

Closes part of #494 (this PR covers only the #494-A slice; #494-B/C/D remain open per the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
