### PR TITLE
security: [494-B] fuzz authenticated ticket open and keyring publication

### DIFF
--- a/docs/CRYPTO_FUZZ_CONTRACT.md
+++ b/docs/CRYPTO_FUZZ_CONTRACT.md
@@ -411,32 +411,50 @@ free on every path -- exercised across all three required AEADs, each fuzz
 case constructing its own fresh `pure_zig.DeterministicEntropy`-backed
 provider rather than sharing static state. The rejection matrix includes
 several classes that require successfully authenticating first:
-`not_yet_valid`/`expired` (forged timestamps), and `invalid_plaintext` via
-an authenticated-but-malformed `TRS1` record covering both the shared
-header (magic/version/record-type/section-length) and field-level TLV
-boundaries (duplicate field, missing mandatory field, exact-width field
-length above/below its true size) -- the latter reusing
+`not_yet_valid`/`expired` (forged timestamps); an authenticated state
+extended with an unknown *optional* field, which must still accept and
+round-trip (proving forward compatibility, not just rejection); and
+`invalid_plaintext` via an authenticated-but-malformed `TRS1` record
+covering the shared header (magic/version/record-type/section-length),
+field-level TLV boundaries (duplicate field, missing mandatory field,
+exact-width field length one-under/zero/one-over, an unknown *critical*
+field, PSK length across zero/one/one-over/the largest supported digest
+length, and a field whose declared length vastly exceeds the bytes the
+section actually has left -- a declaration-only truncation, not a 64 KiB
+allocation). The known-field mutations reuse
 `session.fixtureWithFieldRemoved`/`fixtureWithFieldDuplicated`/
 `withTlvLengthOverride`/`originalTlvLen`, promoted `pub` from session.zig's
-own codec fuzz/test suite rather than re-derived here. `protector.limits`
-is varied around both the envelope-length boundary (`max_ticket_len`) and
-the decoded-state boundary (`max_serialized_len`). It also adds an
+own codec fuzz/test suite rather than re-derived here (that promotion also
+fixed `withTlvLengthOverride` to zero-fill a one-over declared length's
+excess bytes instead of leaving them as whatever was in the caller's
+scratch buffer, so every caller's mutation is deterministic by
+construction). `protector.limits` is varied around both the envelope-length
+boundary (`max_ticket_len`) and the decoded-state boundary
+(`max_serialized_len`). It also adds an
 in-memory `Snapshot`/`ReloadableKeyRing` publication target: a bounded
 *sequence* of build/install/dry-run-validate/acquire/explicit-retain/
 release/`seal` operations (rather than the single-call property fuzzing
-`fuzzSnapshotConfig` already covered) asserting generation monotonicity,
-ledger growth, nonce uniqueness and deterministic exhaustion (including
-right at the `maxInt(u64)` boundary via an occasional near-wrap lease
-window), that a failed seal still consumes its reserved nonce (via a
-per-case fault-injecting provider that always fails `aeadSeal` after
-`NonceLease.reserve()` has already committed), that a retained old
-snapshot's key material and lease state stay exactly frozen once it stops
-being `keyring.current` (compared via the same constant-time key
-fingerprint the keyring's own ledger uses) for as long as it is held, that
-every modeled reference -- acquired or explicitly retained, including any
-left outstanding when a bounded program ends -- wipes the snapshot exactly
-once when the last one is released, and that injected allocation failure
-during build/install leaves publication state unchanged. The existing
+`fuzzSnapshotConfig` already covered), driving its own fresh per-case
+`pure_zig.DeterministicEntropy`-backed provider (not the shared static
+`testProvider()` every ordinary deterministic test in this file uses) for
+both the normal seal path and the fault-injecting wrapper below, and
+asserting generation monotonicity, ledger growth, nonce uniqueness and
+deterministic exhaustion (including right at the `maxInt(u64)` boundary via
+an occasional near-wrap lease window), that a failed seal still consumes
+its reserved nonce (via a per-case `FaultingSealProvider` that always fails
+`aeadSeal` after `NonceLease.reserve()` has already committed), that a
+retained old snapshot's key material and lease state stay exactly frozen
+once it stops being `keyring.current` (compared via the same constant-time
+key fingerprint the keyring's own ledger uses) for as long as it is held,
+and that injected allocation failure during build/install leaves
+publication state unchanged. Every modeled reference -- acquired or
+explicitly retained -- wipes the snapshot exactly once when the last one is
+released, and this holds even for a bounded program that ends mid-sequence
+with references still outstanding: end-of-case cleanup drains them, tears
+the keyring down, and only then asserts the snapshot deinitialized exactly
+once and wipes the stored fingerprint, with the zeroization probe kept
+installed through both steps (not disabled first) so it can observe
+whichever one performs the true final release. The existing
 `ticket_key_snapshot.zig` persistent-JSON-snapshot fuzz target is unrelated
 (on-disk snapshot file parsing, not the in-memory keyring) and is preserved
 as-is, per the issue's "existing coverage to preserve, not recreate" list.

--- a/docs/CRYPTO_FUZZ_CONTRACT.md
+++ b/docs/CRYPTO_FUZZ_CONTRACT.md
@@ -404,24 +404,41 @@ or the unrelated pre-existing `sni_provider.zig`/`ticket_key_snapshot.zig`/
 `NewSessionTicket` wire/owned-state construction, the session client/server
 codec, PSK modes/`OfferedPsks`/binder primitives, and allocation-free
 ticket-envelope parsing (`parseEnvelope`). #494-B adds authenticated
-`Protector.resolve` -- accept, every typed rejection reason (including the
-ones that require successfully authenticating first: `invalid_plaintext`,
-`not_yet_valid`, `expired`), and a full allocation-failure sweep over every
-reachable allocation point, all under `ZeroCheckingAllocator` to prove the
-temporary plaintext is wiped before free on every path -- exercised across
-all three required AEADs, each fuzz case constructing its own fresh
-`pure_zig.DeterministicEntropy`-backed provider rather than sharing static
-state. It also adds an in-memory `Snapshot`/`ReloadableKeyRing` publication
-target: a bounded *sequence* of build/install/dry-run-validate/acquire/
-explicit-retain/release/`seal` operations (rather than the single-call
-property fuzzing `fuzzSnapshotConfig` already covered) asserting generation
-monotonicity, ledger growth, nonce uniqueness/exhaustion, that a retained
-old snapshot's key/lease state stays byte-identical and unfreed for as long
-as it is held across replacement, that it wipes exactly once when the last
-reference is released, and that injected allocation failure during
-build/install leaves publication state unchanged. The
-existing `ticket_key_snapshot.zig` persistent-JSON-snapshot fuzz target is
-unrelated (on-disk snapshot file parsing, not the in-memory keyring) and is
-preserved as-is, per the issue's "existing coverage to preserve, not
-recreate" list. Session-cache/lease state machines and backend/runtime
-composition follow in #494-C/D per the issue's PR decomposition.
+`Protector.resolve` -- accept, every typed rejection reason, and a full
+allocation-failure sweep over every reachable allocation point, all under
+`ZeroCheckingAllocator` to prove the temporary plaintext is wiped before
+free on every path -- exercised across all three required AEADs, each fuzz
+case constructing its own fresh `pure_zig.DeterministicEntropy`-backed
+provider rather than sharing static state. The rejection matrix includes
+several classes that require successfully authenticating first:
+`not_yet_valid`/`expired` (forged timestamps), and `invalid_plaintext` via
+an authenticated-but-malformed `TRS1` record covering both the shared
+header (magic/version/record-type/section-length) and field-level TLV
+boundaries (duplicate field, missing mandatory field, exact-width field
+length above/below its true size) -- the latter reusing
+`session.fixtureWithFieldRemoved`/`fixtureWithFieldDuplicated`/
+`withTlvLengthOverride`/`originalTlvLen`, promoted `pub` from session.zig's
+own codec fuzz/test suite rather than re-derived here. `protector.limits`
+is varied around both the envelope-length boundary (`max_ticket_len`) and
+the decoded-state boundary (`max_serialized_len`). It also adds an
+in-memory `Snapshot`/`ReloadableKeyRing` publication target: a bounded
+*sequence* of build/install/dry-run-validate/acquire/explicit-retain/
+release/`seal` operations (rather than the single-call property fuzzing
+`fuzzSnapshotConfig` already covered) asserting generation monotonicity,
+ledger growth, nonce uniqueness and deterministic exhaustion (including
+right at the `maxInt(u64)` boundary via an occasional near-wrap lease
+window), that a failed seal still consumes its reserved nonce (via a
+per-case fault-injecting provider that always fails `aeadSeal` after
+`NonceLease.reserve()` has already committed), that a retained old
+snapshot's key material and lease state stay exactly frozen once it stops
+being `keyring.current` (compared via the same constant-time key
+fingerprint the keyring's own ledger uses) for as long as it is held, that
+every modeled reference -- acquired or explicitly retained, including any
+left outstanding when a bounded program ends -- wipes the snapshot exactly
+once when the last one is released, and that injected allocation failure
+during build/install leaves publication state unchanged. The existing
+`ticket_key_snapshot.zig` persistent-JSON-snapshot fuzz target is unrelated
+(on-disk snapshot file parsing, not the in-memory keyring) and is preserved
+as-is, per the issue's "existing coverage to preserve, not recreate" list.
+Session-cache/lease state machines and backend/runtime composition follow
+in #494-C/D per the issue's PR decomposition.

--- a/docs/CRYPTO_FUZZ_CONTRACT.md
+++ b/docs/CRYPTO_FUZZ_CONTRACT.md
@@ -413,15 +413,21 @@ provider rather than sharing static state. The rejection matrix includes
 several classes that require successfully authenticating first:
 `not_yet_valid`/`expired` (forged timestamps); an authenticated state
 extended with an unknown *optional* field, which must still accept and
-round-trip (proving forward compatibility, not just rejection); and
+round-trip (proving forward compatibility, not just rejection); a
+supported SHA-384 suite id paired with the 48-byte PSK it requires, which
+must also accept and round-trip (contrasted against the mismatched
+pairings below, so acceptance is proven, not just assumed); and
 `invalid_plaintext` via an authenticated-but-malformed `TRS1` record
 covering the shared header (magic/version/record-type/section-length),
 field-level TLV boundaries (duplicate field, missing mandatory field,
 exact-width field length one-under/zero/one-over, an unknown *critical*
 field, PSK length across zero/one/one-over/the largest supported digest
-length, and a field whose declared length vastly exceeds the bytes the
-section actually has left -- a declaration-only truncation, not a 64 KiB
-allocation). The known-field mutations reuse
+length, a field whose declared length vastly exceeds the bytes the section
+actually has left -- a declaration-only truncation, not a 64 KiB
+allocation -- an unknown/unassigned cipher-suite wire value, and a
+*supported* suite id whose transcript-hash length disagrees with the
+unchanged, authenticated PSK bytes that follow it). The known-field
+mutations reuse
 `session.fixtureWithFieldRemoved`/`fixtureWithFieldDuplicated`/
 `withTlvLengthOverride`/`originalTlvLen`, promoted `pub` from session.zig's
 own codec fuzz/test suite rather than re-derived here (that promotion also
@@ -449,12 +455,22 @@ key fingerprint the keyring's own ledger uses) for as long as it is held,
 and that injected allocation failure during build/install leaves
 publication state unchanged. Every modeled reference -- acquired or
 explicitly retained -- wipes the snapshot exactly once when the last one is
-released, and this holds even for a bounded program that ends mid-sequence
-with references still outstanding: end-of-case cleanup drains them, tears
-the keyring down, and only then asserts the snapshot deinitialized exactly
-once and wipes the stored fingerprint, with the zeroization probe kept
-installed through both steps (not disabled first) so it can observe
-whichever one performs the true final release. The existing
+released, and this holds for every bounded program, not just ones where
+opcode 4 happens to run again before the sequence ends: a `tracked_snapshot`
+flag (set once, on the first acquire, and never reset -- unlike `held`,
+which opcode 4 nulls out the moment its own modeled reference count reaches
+zero even when the snapshot is still `keyring.current` and therefore not
+actually freed yet) drives real end-of-case cleanup code -- not a bare
+`defer`, since the final check needs `try testing.expectEqual` rather than
+`std.debug.assert` (which lowers through `unreachable` and is therefore not
+a reliable runtime check under the documented `-Doptimize=ReleaseFast
+--fuzz` configuration) -- that drains every outstanding reference, tears the
+keyring down, and only then asserts the snapshot deinitialized exactly once
+and unconditionally wipes the stored fingerprint, with the zeroization
+probe kept installed through both steps so it can observe whichever one
+performs the true final release; a separate `errdefer` covers only the
+leak-prevention side of the same cleanup for an early error return elsewhere
+in the opcode loop, without a redundant assertion. The existing
 `ticket_key_snapshot.zig` persistent-JSON-snapshot fuzz target is unrelated
 (on-disk snapshot file parsing, not the in-memory keyring) and is preserved
 as-is, per the issue's "existing coverage to preserve, not recreate" list.

--- a/docs/CRYPTO_FUZZ_CONTRACT.md
+++ b/docs/CRYPTO_FUZZ_CONTRACT.md
@@ -385,6 +385,8 @@ zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-
 zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: TLS resumption: PSK binder derivation" --fuzz=10M --summary all --error-style verbose
 zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: TLS resumption: parseEnvelope is allocation-free" --fuzz=10M --summary all --error-style verbose
 zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: TLS resumption: parseEnvelope single-field mutation" --fuzz=10M --summary all --error-style verbose
+zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: TLS resumption: Protector.resolve authenticates" --fuzz=10M --summary all --error-style verbose
+zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: TLS resumption: ticket keyring install/validate/acquire/retain/release sequence" --fuzz=10M --summary all --error-style verbose
 
 # Named deterministic regressions (not fuzz-tagged, so outside the
 # default "fuzz: TLS resumption:" namespace — filter on their own name):
@@ -398,10 +400,20 @@ or the unrelated pre-existing `sni_provider.zig`/`ticket_key_snapshot.zig`/
 `ticket_protection.zig` fuzz targets that also happen to start with
 `"fuzz: "`); pass an exact `test "fuzz: ..."` name to scope a long
 `--fuzz=<N>` run to one target, matching the reproduction-command shape
-"Seed-corpus and regression update procedure" above requires. #494-A (this
-pass) covers `NewSessionTicket` wire/owned-state construction, the session
-client/server codec, PSK modes/`OfferedPsks`/binder primitives, and
-allocation-free ticket-envelope parsing (`parseEnvelope`); authenticated
-ticket open, key-snapshot/keyring publication, session-cache/lease state
-machines, and backend/runtime composition follow in #494-B/C/D per the
-issue's PR decomposition.
+"Seed-corpus and regression update procedure" above requires. #494-A covers
+`NewSessionTicket` wire/owned-state construction, the session client/server
+codec, PSK modes/`OfferedPsks`/binder primitives, and allocation-free
+ticket-envelope parsing (`parseEnvelope`). #494-B adds authenticated
+`Protector.resolve` (accept, every typed rejection reason, and a bounded
+allocation-failure sweep, all under `ZeroCheckingAllocator` to prove the
+temporary plaintext is wiped before free on every path) and an in-memory
+`Snapshot`/`ReloadableKeyRing` publication target: a bounded *sequence* of
+build/install/dry-run-validate/acquire/retain/release operations (rather
+than the single-call property fuzzing `fuzzSnapshotConfig` already covered)
+asserting generation monotonicity, ledger growth, and that a retained old
+snapshot stays intact for as long as it is held across replacement. The
+existing `ticket_key_snapshot.zig` persistent-JSON-snapshot fuzz target is
+unrelated (on-disk snapshot file parsing, not the in-memory keyring) and is
+preserved as-is, per the issue's "existing coverage to preserve, not
+recreate" list. Session-cache/lease state machines and backend/runtime
+composition follow in #494-C/D per the issue's PR decomposition.

--- a/docs/CRYPTO_FUZZ_CONTRACT.md
+++ b/docs/CRYPTO_FUZZ_CONTRACT.md
@@ -386,7 +386,7 @@ zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-
 zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: TLS resumption: parseEnvelope is allocation-free" --fuzz=10M --summary all --error-style verbose
 zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: TLS resumption: parseEnvelope single-field mutation" --fuzz=10M --summary all --error-style verbose
 zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: TLS resumption: Protector.resolve authenticates" --fuzz=10M --summary all --error-style verbose
-zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: TLS resumption: ticket keyring install/validate/acquire/retain/release sequence" --fuzz=10M --summary all --error-style verbose
+zig build test-tls-resumption-fuzz -Doptimize=ReleaseFast -Dtls-resumption-test-filter="fuzz: TLS resumption: ticket keyring install/validate/acquire/retain/release/seal sequence" --fuzz=10M --summary all --error-style verbose
 
 # Named deterministic regressions (not fuzz-tagged, so outside the
 # default "fuzz: TLS resumption:" namespace — filter on their own name):
@@ -404,14 +404,22 @@ or the unrelated pre-existing `sni_provider.zig`/`ticket_key_snapshot.zig`/
 `NewSessionTicket` wire/owned-state construction, the session client/server
 codec, PSK modes/`OfferedPsks`/binder primitives, and allocation-free
 ticket-envelope parsing (`parseEnvelope`). #494-B adds authenticated
-`Protector.resolve` (accept, every typed rejection reason, and a bounded
-allocation-failure sweep, all under `ZeroCheckingAllocator` to prove the
-temporary plaintext is wiped before free on every path) and an in-memory
-`Snapshot`/`ReloadableKeyRing` publication target: a bounded *sequence* of
-build/install/dry-run-validate/acquire/retain/release operations (rather
-than the single-call property fuzzing `fuzzSnapshotConfig` already covered)
-asserting generation monotonicity, ledger growth, and that a retained old
-snapshot stays intact for as long as it is held across replacement. The
+`Protector.resolve` -- accept, every typed rejection reason (including the
+ones that require successfully authenticating first: `invalid_plaintext`,
+`not_yet_valid`, `expired`), and a full allocation-failure sweep over every
+reachable allocation point, all under `ZeroCheckingAllocator` to prove the
+temporary plaintext is wiped before free on every path -- exercised across
+all three required AEADs, each fuzz case constructing its own fresh
+`pure_zig.DeterministicEntropy`-backed provider rather than sharing static
+state. It also adds an in-memory `Snapshot`/`ReloadableKeyRing` publication
+target: a bounded *sequence* of build/install/dry-run-validate/acquire/
+explicit-retain/release/`seal` operations (rather than the single-call
+property fuzzing `fuzzSnapshotConfig` already covered) asserting generation
+monotonicity, ledger growth, nonce uniqueness/exhaustion, that a retained
+old snapshot's key/lease state stays byte-identical and unfreed for as long
+as it is held across replacement, that it wipes exactly once when the last
+reference is released, and that injected allocation failure during
+build/install leaves publication state unchanged. The
 existing `ticket_key_snapshot.zig` persistent-JSON-snapshot fuzz target is
 unrelated (on-disk snapshot file parsing, not the in-memory keyring) and is
 preserved as-is, per the issue's "existing coverage to preserve, not

--- a/src/tls/session.zig
+++ b/src/tls/session.zig
@@ -3181,11 +3181,18 @@ test "decode rejects both literal fixtures truncated at every byte boundary" {
 
 /// Rebuilds `fixture` with the TLV whose field id is `field_id` given a new
 /// declared length (`new_length`), copying as much of its original value as
-/// fits and leaving any excess unspecified. Every other TLV is copied
-/// unchanged. `out` must have at least `fixture.len + 8` bytes of room.
-/// Exposed for #494-B's authenticated-plaintext mutation matrix; see
-/// `header_len`'s doc comment.
-pub fn withTlvLengthOverride(fixture: []const u8, field_id: u16, new_length: u16, out: []u8) usize {
+/// fits and zero-filling any excess (for deterministic reproduction; see
+/// the comment on the zero-fill below). Every other TLV is copied
+/// unchanged. `out` must have at least `fixture.len - old_len + new_length`
+/// bytes of room, where `old_len` is the field's original length (checked
+/// against `out.len` below, rather than merely documented, since this is a
+/// `pub` helper a caller can rely on without inspecting the
+/// implementation). Exposed for #494-B's authenticated-plaintext mutation
+/// matrix; see `header_len`'s doc comment.
+pub fn withTlvLengthOverride(fixture: []const u8, field_id: u16, new_length: u16, out: []u8) error{ FieldNotFound, BufferTooSmall }!usize {
+    const old_len = originalTlvLen(fixture, field_id) orelse return error.FieldNotFound;
+    const required = fixture.len - old_len + new_length;
+    if (out.len < required) return error.BufferTooSmall;
     @memcpy(out[0..header_len], fixture[0..header_len]);
     var pos: usize = header_len;
     var offset: usize = header_len;
@@ -3235,16 +3242,16 @@ test "decode rejects zero-length and one-over-length mutations for exact-width f
         const original = originalTlvLen(&client_fixture, field_id).?;
 
         var zero_buf: [client_fixture.len + 8]u8 = undefined;
-        const zero_len = withTlvLengthOverride(&client_fixture, field_id, 0, &zero_buf);
+        const zero_len = try withTlvLengthOverride(&client_fixture, field_id, 0, &zero_buf);
         try expectDecodeFailsWithoutLeaking(zero_buf[0..zero_len]);
 
         var over_buf: [client_fixture.len + 8]u8 = undefined;
-        const over_len = withTlvLengthOverride(&client_fixture, field_id, original + 1, &over_buf);
+        const over_len = try withTlvLengthOverride(&client_fixture, field_id, original + 1, &over_buf);
         try expectDecodeFailsWithoutLeaking(over_buf[0..over_len]);
 
         if (original > 0) {
             var under_buf: [client_fixture.len + 8]u8 = undefined;
-            const under_len = withTlvLengthOverride(&client_fixture, field_id, original - 1, &under_buf);
+            const under_len = try withTlvLengthOverride(&client_fixture, field_id, original - 1, &under_buf);
             try expectDecodeFailsWithoutLeaking(under_buf[0..under_len]);
         }
     }
@@ -3257,7 +3264,7 @@ test "decode rejects zero-length mutations for fields required to be non-empty" 
     };
     for (must_be_nonempty_ids) |field_id| {
         var zero_buf: [client_fixture.len + 8]u8 = undefined;
-        const zero_len = withTlvLengthOverride(&client_fixture, field_id, 0, &zero_buf);
+        const zero_len = try withTlvLengthOverride(&client_fixture, field_id, 0, &zero_buf);
         try expectDecodeFailsWithoutLeaking(zero_buf[0..zero_len]);
 
         // Widening by one byte has no upper semantic constraint here
@@ -3265,7 +3272,7 @@ test "decode rejects zero-length mutations for fields required to be non-empty" 
         // leak, without asserting a specific success/failure outcome.
         const original = originalTlvLen(&client_fixture, field_id).?;
         var over_buf: [client_fixture.len + 8]u8 = undefined;
-        const over_len = withTlvLengthOverride(&client_fixture, field_id, original + 1, &over_buf);
+        const over_len = try withTlvLengthOverride(&client_fixture, field_id, original + 1, &over_buf);
         try expectDecodeDoesNotPanicOrLeak(over_buf[0..over_len]);
     }
 }
@@ -3277,11 +3284,11 @@ test "decode never panics or leaks on any length mutation of ticket_nonce" {
     const original = originalTlvLen(&client_fixture, field_ticket_nonce).?;
 
     var zero_buf: [client_fixture.len + 8]u8 = undefined;
-    const zero_len = withTlvLengthOverride(&client_fixture, field_ticket_nonce, 0, &zero_buf);
+    const zero_len = try withTlvLengthOverride(&client_fixture, field_ticket_nonce, 0, &zero_buf);
     try expectDecodeDoesNotPanicOrLeak(zero_buf[0..zero_len]);
 
     var over_buf: [client_fixture.len + 8]u8 = undefined;
-    const over_len = withTlvLengthOverride(&client_fixture, field_ticket_nonce, original + 1, &over_buf);
+    const over_len = try withTlvLengthOverride(&client_fixture, field_ticket_nonce, original + 1, &over_buf);
     try expectDecodeDoesNotPanicOrLeak(over_buf[0..over_len]);
 }
 

--- a/src/tls/session.zig
+++ b/src/tls/session.zig
@@ -3189,9 +3189,23 @@ test "decode rejects both literal fixtures truncated at every byte boundary" {
 /// `pub` helper a caller can rely on without inspecting the
 /// implementation). Exposed for #494-B's authenticated-plaintext mutation
 /// matrix; see `header_len`'s doc comment.
-pub fn withTlvLengthOverride(fixture: []const u8, field_id: u16, new_length: u16, out: []u8) error{ FieldNotFound, BufferTooSmall }!usize {
-    const old_len = originalTlvLen(fixture, field_id) orelse return error.FieldNotFound;
-    const required = fixture.len - old_len + new_length;
+pub fn withTlvLengthOverride(fixture: []const u8, field_id: u16, new_length: u16, out: []u8) error{ FieldNotFound, DuplicateField, BufferTooSmall }!usize {
+    // Every TLV whose id is `field_id` gets rewritten below (not just the
+    // first), so the required-capacity math only holds for a canonical
+    // record with exactly one occurrence -- the precondition this helper
+    // has always implicitly assumed (matching `originalTlvLen`, which only
+    // ever reports the first occurrence's length). Reject a duplicate
+    // explicitly rather than silently underestimating `required` for it.
+    var old_len: ?u16 = null;
+    {
+        var offset: usize = header_len;
+        while ((nextTlv(fixture, &offset) catch unreachable)) |tlv| {
+            if (tlv.field_id != field_id) continue;
+            if (old_len != null) return error.DuplicateField;
+            old_len = @intCast(tlv.value.len);
+        }
+    }
+    const required = fixture.len - (old_len orelse return error.FieldNotFound) + new_length;
     if (out.len < required) return error.BufferTooSmall;
     @memcpy(out[0..header_len], fixture[0..header_len]);
     var pos: usize = header_len;

--- a/src/tls/session.zig
+++ b/src/tls/session.zig
@@ -3195,6 +3195,15 @@ pub fn withTlvLengthOverride(fixture: []const u8, field_id: u16, new_length: u16
             std.mem.writeInt(u16, out[pos + 2 ..][0..2], new_length, .big);
             const copy_len = @min(new_length, tlv.value.len);
             @memcpy(out[pos + 4 ..][0..copy_len], tlv.value[0..copy_len]);
+            // `out` is caller-provided and may be `undefined`-backed
+            // scratch space (as every #494-B fuzz caller uses): a
+            // one-over `new_length` leaves `copy_len` short of the
+            // declared length, so the excess must be zero-filled here
+            // rather than left as whatever was already in `out`, or a
+            // "one-over" mutation would authenticate and encrypt
+            // uninitialized bytes into the ciphertext, breaking
+            // deterministic reproduction.
+            @memset(out[pos + 4 + copy_len ..][0 .. new_length - copy_len], 0);
             pos += 4 + @as(usize, new_length);
         } else {
             writeTlv(out, &pos, tlv.field_id, tlv.value);

--- a/src/tls/session.zig
+++ b/src/tls/session.zig
@@ -3244,6 +3244,52 @@ pub fn originalTlvLen(fixture: []const u8, field_id: u16) ?u16 {
     return null;
 }
 
+test "withTlvLengthOverride rejects a duplicate target transactionally" {
+    var duplicate_buf: [client_fixture.len + 8]u8 = undefined;
+    const duplicate_len = fixtureWithFieldDuplicated(
+        &client_fixture,
+        field_cipher_suite,
+        &duplicate_buf,
+    );
+
+    var out = [_]u8{0xa5} ** (client_fixture.len + 16);
+    const before = out;
+    try testing.expectError(
+        error.DuplicateField,
+        withTlvLengthOverride(
+            duplicate_buf[0..duplicate_len],
+            field_cipher_suite,
+            3,
+            &out,
+        ),
+    );
+    try testing.expectEqualSlices(u8, &before, &out);
+}
+
+test "withTlvLengthOverride enforces exact grown capacity" {
+    var exact: [client_fixture.len + 1]u8 = undefined;
+    const len = try withTlvLengthOverride(
+        &client_fixture,
+        field_cipher_suite,
+        3,
+        &exact,
+    );
+    try testing.expectEqual(client_fixture.len + 1, len);
+
+    var short = [_]u8{0xa5} ** client_fixture.len;
+    const before = short;
+    try testing.expectError(
+        error.BufferTooSmall,
+        withTlvLengthOverride(
+            &client_fixture,
+            field_cipher_suite,
+            3,
+            &short,
+        ),
+    );
+    try testing.expectEqualSlices(u8, &before, &short);
+}
+
 test "decode rejects zero-length and one-over-length mutations for exact-width fields" {
     // These fields require an exact byte count (2/32/8/4/4/8, or the {1,5}
     // early-data set); any other declared length must always fail.

--- a/src/tls/session.zig
+++ b/src/tls/session.zig
@@ -848,25 +848,32 @@ pub const format_version: u8 = 1;
 pub const magic: [4]u8 = .{ 'T', 'R', 'S', '1' };
 
 /// `magic(4) | major(1) | kind(1) | field_section_len(4)`.
-const header_len: usize = magic.len + 1 + 1 + 4;
+/// #494-B's `Protector.resolve` fuzz target (`src/tls/ticket_protection.zig`)
+/// reuses this alongside the fixture-mutation helpers below rather than
+/// re-deriving the wire header shape, so an authenticated malformed-plaintext
+/// mutation always lands on a real TLV boundary.
+pub const header_len: usize = magic.len + 1 + 1 + 4;
 
 const optional_field_mask: u16 = 0x8000;
 
-const field_cipher_suite: u16 = 0x0001;
-const field_resumption_psk: u16 = 0x0002;
+/// Exposed for #494-B's authenticated-plaintext mutation matrix (see
+/// `header_len`'s doc comment); the rest stay module-private since only
+/// these are driven from outside this file today.
+pub const field_cipher_suite: u16 = 0x0001;
+pub const field_resumption_psk: u16 = 0x0002;
 const field_server_name: u16 = 0x0003;
 const field_application_protocol: u16 = 0x0004;
-const field_auth_binding: u16 = 0x0005;
-const field_issued_at: u16 = 0x0006;
-const field_lifetime_seconds: u16 = 0x0007;
-const field_early_data: u16 = 0x0008;
+pub const field_auth_binding: u16 = 0x0005;
+pub const field_issued_at: u16 = 0x0006;
+pub const field_lifetime_seconds: u16 = 0x0007;
+pub const field_early_data: u16 = 0x0008;
 const field_transport_compat: u16 = 0x8001;
 const field_application_compat: u16 = 0x8002;
 const field_early_data_transport_compat: u16 = 0x8003;
 const field_early_data_application_compat: u16 = 0x8004;
 
 const field_ticket: u16 = 0x0010;
-const field_ticket_age_add: u16 = 0x0011;
+pub const field_ticket_age_add: u16 = 0x0011;
 const field_ticket_nonce: u16 = 0x0012;
 const field_received_at: u16 = 0x0013;
 
@@ -3000,8 +3007,9 @@ test "current encoder output exactly equals the checked-in fixtures" {
 }
 
 /// Rebuilds `fixture` with every TLV whose field id is `field_id_to_remove`
-/// dropped, patching the section length to match.
-fn fixtureWithFieldRemoved(fixture: []const u8, field_id_to_remove: u16, out: []u8) usize {
+/// dropped, patching the section length to match. Exposed for #494-B's
+/// authenticated-plaintext mutation matrix; see `header_len`'s doc comment.
+pub fn fixtureWithFieldRemoved(fixture: []const u8, field_id_to_remove: u16, out: []u8) usize {
     @memcpy(out[0..header_len], fixture[0..header_len]);
     var pos: usize = header_len;
     var offset: usize = header_len;
@@ -3015,8 +3023,9 @@ fn fixtureWithFieldRemoved(fixture: []const u8, field_id_to_remove: u16, out: []
 
 /// Rebuilds `fixture` with an extra copy of the first TLV whose field id is
 /// `field_id_to_duplicate` appended at the end, patching the section length
-/// to match.
-fn fixtureWithFieldDuplicated(fixture: []const u8, field_id_to_duplicate: u16, out: []u8) usize {
+/// to match. Exposed for #494-B's authenticated-plaintext mutation matrix;
+/// see `header_len`'s doc comment.
+pub fn fixtureWithFieldDuplicated(fixture: []const u8, field_id_to_duplicate: u16, out: []u8) usize {
     @memcpy(out[0..fixture.len], fixture);
     var pos: usize = fixture.len;
     var offset: usize = header_len;
@@ -3174,7 +3183,9 @@ test "decode rejects both literal fixtures truncated at every byte boundary" {
 /// declared length (`new_length`), copying as much of its original value as
 /// fits and leaving any excess unspecified. Every other TLV is copied
 /// unchanged. `out` must have at least `fixture.len + 8` bytes of room.
-fn withTlvLengthOverride(fixture: []const u8, field_id: u16, new_length: u16, out: []u8) usize {
+/// Exposed for #494-B's authenticated-plaintext mutation matrix; see
+/// `header_len`'s doc comment.
+pub fn withTlvLengthOverride(fixture: []const u8, field_id: u16, new_length: u16, out: []u8) usize {
     @memcpy(out[0..header_len], fixture[0..header_len]);
     var pos: usize = header_len;
     var offset: usize = header_len;
@@ -3193,7 +3204,9 @@ fn withTlvLengthOverride(fixture: []const u8, field_id: u16, new_length: u16, ou
     return pos;
 }
 
-fn originalTlvLen(fixture: []const u8, field_id: u16) ?u16 {
+/// Exposed for #494-B's authenticated-plaintext mutation matrix; see
+/// `header_len`'s doc comment.
+pub fn originalTlvLen(fixture: []const u8, field_id: u16) ?u16 {
     var offset: usize = header_len;
     while ((nextTlv(fixture, &offset) catch unreachable)) |tlv| {
         if (tlv.field_id == field_id) return @intCast(tlv.value.len);

--- a/src/tls/ticket_protection.zig
+++ b/src/tls/ticket_protection.zig
@@ -3524,6 +3524,20 @@ fn withCipherSuiteValue(fixture: []const u8, new_suite_wire_value: u16, out: []u
     return appendTlv(without_suite_buf[0..without_suite_len], session.field_cipher_suite, &value_bytes, out);
 }
 
+/// Same composition as `withCipherSuiteValue`, for `field_lifetime_seconds`
+/// (a 4-byte big-endian `u32`). Used to authenticate raw wire values
+/// `session.ResumableSessionCommon.init` itself would reject at
+/// construction time (zero, or above `session.max_lifetime_seconds`), so
+/// those boundaries can only be exercised through a post-encode mutation
+/// like this one.
+fn withLifetimeSecondsValue(fixture: []const u8, new_value: u32, out: []u8) usize {
+    var without_field_buf: [2048 + 256]u8 = undefined;
+    const without_field_len = session.fixtureWithFieldRemoved(fixture, session.field_lifetime_seconds, &without_field_buf);
+    var value_bytes: [4]u8 = undefined;
+    std.mem.writeInt(u32, &value_bytes, new_value, .big);
+    return appendTlv(without_field_buf[0..without_field_len], session.field_lifetime_seconds, &value_bytes, out);
+}
+
 /// #494-B: authenticated `Protector.resolve` under key-state, envelope, and
 /// authenticated-plaintext mutation. Complements `fuzzTicketIdentity` above
 /// (which only proves miss paths never panic or mutate output against
@@ -3830,29 +3844,88 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
             try observer.expectOnly(.resolve_succeeded);
         },
         9 => {
-            // `issued_at_unix_ms` strictly after `resolve_now_unix_ms`.
-            var timed_state = try buildTimedServerState(allocator, resolve_now_unix_ms + 5_000, 10);
+            // Exact `isNotYetValid` boundary (`now < issued_at` is the
+            // rejection condition): `issued_at == now` must accept and
+            // `issued_at == now + 1` must reject, proving the boundary is
+            // `<`, not `<=` or some other off-by-one -- a comfortably
+            // inside-the-region case like the old fixed `now + 5_000`
+            // could not catch a regression at the boundary itself.
+            const at_boundary = smith.index(2) == 0;
+            var timed_state = try buildTimedServerState(allocator, if (at_boundary) resolve_now_unix_ms else resolve_now_unix_ms + 1, 10);
             defer timed_state.deinit();
             var plaintext_buf: [2048]u8 = undefined;
             const plaintext = try session.encodeServer(&timed_state, session.Limits.default, &plaintext_buf);
             var envelope_buf: [2048]u8 = undefined;
             const nonce = [_]u8{0xcd} ** provider.aead_nonce_len;
             const envelope = try sealPlaintextWithProvider(fresh_provider, &envelope_buf, selected_aead, active_id, active_key, nonce, plaintext);
-            try expectResolveFalseUnchanged(&protector, zero_alloc.allocator(), envelope, resolve_now_unix_ms);
-            try observer.expectOnly(.{ .resolve_rejected = .not_yet_valid });
+            if (at_boundary) {
+                try expectRoundTrip(&protector, zero_alloc.allocator(), &timed_state, envelope, resolve_now_unix_ms);
+                try observer.expectOnly(.resolve_succeeded);
+            } else {
+                try expectResolveFalseUnchanged(&protector, zero_alloc.allocator(), envelope, resolve_now_unix_ms);
+                try observer.expectOnly(.{ .resolve_rejected = .not_yet_valid });
+            }
         },
-        else => {
-            // `issued_at_unix_ms + lifetime_seconds` strictly before
-            // `resolve_now_unix_ms`.
-            var timed_state = try buildTimedServerState(allocator, 1, 1);
-            defer timed_state.deinit();
-            var plaintext_buf: [2048]u8 = undefined;
-            const plaintext = try session.encodeServer(&timed_state, session.Limits.default, &plaintext_buf);
-            var envelope_buf: [2048]u8 = undefined;
-            const nonce = [_]u8{0xef} ** provider.aead_nonce_len;
-            const envelope = try sealPlaintextWithProvider(fresh_provider, &envelope_buf, selected_aead, active_id, active_key, nonce, plaintext);
-            try expectResolveFalseUnchanged(&protector, zero_alloc.allocator(), envelope, resolve_now_unix_ms);
-            try observer.expectOnly(.{ .resolve_rejected = .expired });
+        else => switch (smith.index(4)) {
+            0 => {
+                // Exact `isExpired` boundary for `lifetime_seconds = 1`
+                // (1000ms): `age == 999` must accept.
+                var timed_state = try buildTimedServerState(allocator, resolve_now_unix_ms - 999, 1);
+                defer timed_state.deinit();
+                var plaintext_buf: [2048]u8 = undefined;
+                const plaintext = try session.encodeServer(&timed_state, session.Limits.default, &plaintext_buf);
+                var envelope_buf: [2048]u8 = undefined;
+                const nonce = [_]u8{0xef} ** provider.aead_nonce_len;
+                const envelope = try sealPlaintextWithProvider(fresh_provider, &envelope_buf, selected_aead, active_id, active_key, nonce, plaintext);
+                try expectRoundTrip(&protector, zero_alloc.allocator(), &timed_state, envelope, resolve_now_unix_ms);
+                try observer.expectOnly(.resolve_succeeded);
+            },
+            1 => {
+                // ...and `age == 1000` (the exact boundary) must reject,
+                // proving `age >= lifetime` is the real condition, not
+                // `age > lifetime` or some other off-by-one.
+                var timed_state = try buildTimedServerState(allocator, resolve_now_unix_ms - 1_000, 1);
+                defer timed_state.deinit();
+                var plaintext_buf: [2048]u8 = undefined;
+                const plaintext = try session.encodeServer(&timed_state, session.Limits.default, &plaintext_buf);
+                var envelope_buf: [2048]u8 = undefined;
+                const nonce = [_]u8{0xfa} ** provider.aead_nonce_len;
+                const envelope = try sealPlaintextWithProvider(fresh_provider, &envelope_buf, selected_aead, active_id, active_key, nonce, plaintext);
+                try expectResolveFalseUnchanged(&protector, zero_alloc.allocator(), envelope, resolve_now_unix_ms);
+                try observer.expectOnly(.{ .resolve_rejected = .expired });
+            },
+            2 => {
+                // Raw-TLV `lifetime_seconds` boundary: zero is below the
+                // valid `(0, max_lifetime_seconds]` range.
+                // `ResumableSessionCommon.init` itself already rejects
+                // this at construction time, so it can only be reached
+                // through a post-encode authenticated mutation like this
+                // one -- proving `resolveInner` still normalizes it to
+                // the public `invalid_plaintext` contract with the
+                // destination unchanged, the same as every other decode
+                // failure class.
+                var plaintext_buf: [2048]u8 = undefined;
+                const plaintext = try session.encodeServer(&state, session.Limits.default, &plaintext_buf);
+                var mutated_buf: [2048 + 64]u8 = undefined;
+                const mutated = mutated_buf[0..withLifetimeSecondsValue(plaintext, 0, &mutated_buf)];
+                var envelope_buf: [2048 + 64]u8 = undefined;
+                const nonce = [_]u8{0xfb} ** provider.aead_nonce_len;
+                const envelope = try sealPlaintextWithProvider(fresh_provider, &envelope_buf, selected_aead, active_id, active_key, nonce, mutated);
+                try expectResolveFalseUnchanged(&protector, zero_alloc.allocator(), envelope, resolve_now_unix_ms);
+                try observer.expectOnly(.{ .resolve_rejected = .invalid_plaintext });
+            },
+            else => {
+                // ...and one past `max_lifetime_seconds` is above it.
+                var plaintext_buf: [2048]u8 = undefined;
+                const plaintext = try session.encodeServer(&state, session.Limits.default, &plaintext_buf);
+                var mutated_buf: [2048 + 64]u8 = undefined;
+                const mutated = mutated_buf[0..withLifetimeSecondsValue(plaintext, session.max_lifetime_seconds + 1, &mutated_buf)];
+                var envelope_buf: [2048 + 64]u8 = undefined;
+                const nonce = [_]u8{0xfc} ** provider.aead_nonce_len;
+                const envelope = try sealPlaintextWithProvider(fresh_provider, &envelope_buf, selected_aead, active_id, active_key, nonce, mutated);
+                try expectResolveFalseUnchanged(&protector, zero_alloc.allocator(), envelope, resolve_now_unix_ms);
+                try observer.expectOnly(.{ .resolve_rejected = .invalid_plaintext });
+            },
         },
     }
 
@@ -4398,38 +4471,43 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
     // Normal-path end-of-case cleanup, reached only once the whole opcode
     // program above completed without an earlier failure (the `errdefer`
     // near the top of this function is the safety net for that other
-    // case): drain every modeled reference, tear the keyring down --
-    // releasing its own reference too, if the instrumented snapshot is
-    // still `keyring.current` -- and only *then* assert, as a real fuzz
-    // failure via `testing.expectEqual` rather than a `std.debug.assert`
-    // (which lowers through `unreachable` and so is not a reliable runtime
-    // check under `-Doptimize=ReleaseFast`), that it deinitialized exactly
-    // once (`Snapshot.deinit` fired) *and* wiped its key exactly once (the
-    // `key_probe` delta): never zero (a leak) and never more than one (a
-    // double free/wipe). `tracked_snapshot and !tracked_finalized` -- the
-    // latter set at whichever single operation (opcode 4's inline release,
-    // or the install-replacement bracket above) already observed and
-    // verified the tracked snapshot's true final reference drop -- covers
-    // the remaining case: it is still `keyring.current` with no further
-    // install ever having replaced it, so this `keyring.deinit()` call is
-    // the one that finally performs (and here verifies) that release. When
-    // `tracked_finalized` is already true, the earlier bracket already
-    // proved the wipe, so this deliberately does not re-check: a *later*,
-    // untracked snapshot may be whatever `keyring.deinit()` frees here, and
-    // attributing its key-wipe delta to the original tracked snapshot would
-    // be a false attribution, not a real verification.
+    // case): drain every modeled reference, tear the keyring down, and
+    // assert -- as a real fuzz failure via `testing.expectEqual` rather
+    // than a `std.debug.assert` (which lowers through `unreachable` and so
+    // is not a reliable runtime check under `-Doptimize=ReleaseFast`) --
+    // that the tracked snapshot deinitialized exactly once and wiped its
+    // key exactly once. The `key_probe` delta bracket has to sit around
+    // whichever operation is the tracked snapshot's *own* true final
+    // release, not merely "whatever runs after the drain loop": if
+    // `held_outlived_current` is already true when the drain below runs,
+    // draining the last modeled reference *is* that final release (the
+    // snapshot stopped being `keyring.current` earlier in the loop, so
+    // nothing else still owns a reference to it) -- capturing the baseline
+    // only after draining would let `keyring.deinit()`'s unrelated wipe of
+    // the *current* (untracked) snapshot satisfy the delta instead,
+    // falsely "proving" the tracked one was wiped. Only when the tracked
+    // snapshot is still `keyring.current` at this point (never outlived,
+    // never finalized by opcode 4 or the install bracket above) does
+    // `keyring.deinit()` itself perform and verify the release.
     if (held) |snap| {
+        const wipes_before = key_probe.observed;
         while (held_refs != 0) {
             held_refs -= 1;
             snap.release();
         }
+        if (held_outlived_current) {
+            try testing.expectEqual(@as(usize, 1), held_deinit_count.load(.monotonic));
+            try testing.expectEqual(@as(usize, 1), key_probe.observed - wipes_before);
+            tracked_finalized = true;
+        }
     }
-    const watching = tracked_snapshot and !tracked_finalized;
-    const wipes_before = if (watching) key_probe.observed else 0;
-    keyring.deinit();
-    if (watching) {
+    if (tracked_snapshot and !tracked_finalized) {
+        const wipes_before = key_probe.observed;
+        keyring.deinit();
         try testing.expectEqual(@as(usize, 1), held_deinit_count.load(.monotonic));
         try testing.expectEqual(@as(usize, 1), key_probe.observed - wipes_before);
+    } else {
+        keyring.deinit();
     }
     secrets.secureZero(&held_key_fingerprint);
     TestKeyDeinitProbeStorage.probe = null;

--- a/src/tls/ticket_protection.zig
+++ b/src/tls/ticket_protection.zig
@@ -50,6 +50,26 @@ fn deinitTicketKey(key: *TicketKeySecret) void {
     }
 }
 
+/// Mirrors `KeyDeinitProbe` for `LeaseHighWater.key_fingerprint`: the
+/// ledger's fingerprint is a separate secret-derived value from the
+/// `KeyRecord` it was computed from (kept alive independently, including
+/// across a key's own retirement -- see `validateReplacementLocked`), so
+/// its wipe-on-cleanup needs its own passive observation rather than
+/// assuming `KeyDeinitProbe` already covers it.
+const FingerprintDeinitProbe = struct {
+    observed: usize = 0,
+
+    fn record(self: *FingerprintDeinitProbe, value: *const KeyFingerprint) void {
+        for (value.*) |byte| {
+            if (byte != 0) @panic("ledger fingerprint was not zeroized before cleanup observation");
+        }
+        self.observed += 1;
+    }
+};
+const TestFingerprintDeinitProbeStorage = if (builtin.is_test) struct {
+    threadlocal var probe: ?*FingerprintDeinitProbe = null;
+} else struct {};
+
 pub const ParseError = error{
     MalformedEnvelope,
     UnsupportedVersion,
@@ -446,6 +466,9 @@ const LeaseHighWater = struct {
 
     fn deinit(self: *LeaseHighWater) void {
         secrets.secureZero(&self.key_fingerprint);
+        if (builtin.is_test) {
+            if (TestFingerprintDeinitProbeStorage.probe) |probe| probe.record(&self.key_fingerprint);
+        }
         self.* = undefined;
     }
 };
@@ -1622,6 +1645,65 @@ fn expectKeyringStateEqual(expected: KeyringState, keyring: *ReloadableKeyRing) 
     }
 }
 
+/// `KeyringState`/`expectKeyringStateEqual` above capture and compare every
+/// *public* field of a keyring's publication state, but neither one
+/// touches the two secret-bearing pieces: `KeyRecord.key` (the current
+/// snapshot's actual key material) and `LeaseHighWater.key_fingerprint`
+/// (the ledger's retained fingerprints, including for keys already
+/// retired out of `current`). A "no mutation happened" assertion built
+/// only from `KeyringState` would therefore still pass if a bug corrupted
+/// or wiped either one early -- this captures and compares them
+/// separately, via the same constant-time fingerprint comparison the
+/// keyring's own duplicate-detection uses, without ever exposing a raw
+/// secret byte to a test assertion. `captureInto`/`deinit` take a pointer
+/// so the fingerprints live in exactly one place (never copied through an
+/// intermediate return value) and so `deinit` can wipe them explicitly
+/// rather than leaving that to whenever the stack frame happens to be
+/// reused.
+const KeyringSecretState = struct {
+    current_count: usize = 0,
+    current: [max_keys]KeyFingerprint = undefined,
+    ledger_count: usize = 0,
+    ledger: [max_keys + 4]KeyFingerprint = undefined,
+
+    fn captureInto(self: *KeyringSecretState, keyring: *const ReloadableKeyRing) void {
+        self.current_count = 0;
+        if (keyring.current) |snapshot| {
+            self.current_count = snapshot.keys.len;
+            for (snapshot.keys, 0..) |*key, i| {
+                self.current[i] = fingerprintKey(key.aead, key.key.slice());
+            }
+        }
+        self.ledger_count = keyring.ledger.items.len;
+        for (keyring.ledger.items, 0..) |entry, i| {
+            self.ledger[i] = entry.key_fingerprint;
+        }
+    }
+
+    fn expectEqual(self: *const KeyringSecretState, keyring: *const ReloadableKeyRing) !void {
+        const current_count = if (keyring.current) |snapshot| snapshot.keys.len else 0;
+        try testing.expectEqual(self.current_count, current_count);
+        if (keyring.current) |snapshot| {
+            for (snapshot.keys, 0..) |*key, i| {
+                var actual = fingerprintKey(key.aead, key.key.slice());
+                defer secrets.secureZero(&actual);
+                try testing.expect(secrets.constantTimeEqual(&self.current[i], &actual));
+            }
+        }
+        try testing.expectEqual(self.ledger_count, keyring.ledger.items.len);
+        for (keyring.ledger.items, 0..) |entry, i| {
+            try testing.expect(secrets.constantTimeEqual(&self.ledger[i], &entry.key_fingerprint));
+        }
+    }
+
+    fn deinit(self: *KeyringSecretState) void {
+        for (self.current[0..self.current_count]) |*fingerprint| secrets.secureZero(fingerprint);
+        for (self.ledger[0..self.ledger_count]) |*fingerprint| secrets.secureZero(fingerprint);
+        self.current_count = 0;
+        self.ledger_count = 0;
+    }
+};
+
 fn leaseStateFromKey(key: *const KeyRecord) LeaseState {
     if (key.nonce_lease) |*lease| {
         return .{
@@ -2624,6 +2706,35 @@ test "candidate validation rejection observer may reenter keyring" {
 
     try testing.expectError(error.StaleSnapshotGeneration, keyring.validateInstallCandidate(candidate));
     try testing.expectEqual(@as(usize, 1), observer.rejected_events);
+}
+
+test "candidate validation OOM wipes pending ledger fingerprints" {
+    var fingerprint_probe = FingerprintDeinitProbe{};
+    TestFingerprintDeinitProbeStorage.probe = &fingerprint_probe;
+    defer TestFingerprintDeinitProbeStorage.probe = null;
+
+    // Allocation order: baseline snapshot/create/ledger/capacity = 0..3;
+    // candidate snapshot+keys = 4..5; first pending entry = 6;
+    // second pending entry allocation fails at 7 and must clean entry 6.
+    var failing = testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 7 });
+    var keyring = ReloadableKeyRing.init(failing.allocator());
+    defer keyring.deinit();
+
+    const baseline = sampleKeyConfigWithByte(keyId(0xc1), .aes_128_gcm, .{ .prefix = .{ 0xc1, 0, 0, 0 }, .start = 0, .end_exclusive = 3 }, 0x11);
+    try keyring.install(try keyring.buildSnapshot(&.{baseline}, testCapabilities()));
+
+    const candidates = [_]KeyConfig{
+        sampleKeyConfigWithByte(keyId(0xc2), .aes_256_gcm, null, 0x22),
+        sampleKeyConfigWithByte(keyId(0xc3), .chacha20_poly1305, null, 0x33),
+    };
+    const candidate = try keyring.buildSnapshot(&candidates, testCapabilities());
+    defer candidate.release();
+
+    const before = captureKeyringState(&keyring);
+    const wipes_before = fingerprint_probe.observed;
+    try testing.expectError(error.OutOfMemory, keyring.validateInstallCandidate(candidate));
+    try expectKeyringStateEqual(before, &keyring);
+    try testing.expectEqual(@as(usize, 1), fingerprint_probe.observed - wipes_before);
 }
 
 test "ambiguous encryption windows are rejected before publication" {
@@ -3645,6 +3756,24 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
     const resolve_now_unix_ms: i64 = 10_000;
     const valid_envelope = try protector.seal(allocator, &state, seal_now_unix_ms, &seal_buf);
 
+    // #494-B requires current/active, future, retained, retired, and
+    // unknown key states. Every scenario below resolves at
+    // `resolve_now_unix_ms` (inside `active_id`'s decrypt-only grace
+    // window, i.e. `retained`), so without this the active/current state
+    // itself would never be authenticated through `Protector.resolve` at
+    // all -- prove it here, once, before the Smith-selected scenario
+    // switch (and its own observer) takes over, so this runs identically
+    // for every selected AEAD without perturbing the corpus call order.
+    {
+        var active_observer = TestObserver{};
+        defer active_observer.deinit(allocator);
+        var active_protector = protector;
+        active_protector.observer = active_observer.observer();
+        var active_zero = ZeroCheckingAllocator.init(allocator);
+        try expectRoundTrip(&active_protector, active_zero.allocator(), &state, valid_envelope, seal_now_unix_ms);
+        try active_observer.expectOnly(.resolve_succeeded);
+    }
+
     var observer = TestObserver{};
     defer observer.deinit(allocator);
     protector.observer = observer.observer();
@@ -4076,6 +4205,41 @@ const resolve_lifetime_max = smithCorpusWords(&.{ 0, 10, 2, 0 });
 const resolve_lifetime_zero = smithCorpusWords(&.{ 0, 10, 3, 0 });
 const resolve_lifetime_over = smithCorpusWords(&.{ 0, 10, 4, 0 });
 
+// Envelope authentication regions (scenario 5's own `region` selection:
+// 0 = nonce, already covered by `resolve_tampered_nonce` above; 1 =
+// ciphertext; 2 = tag).
+const resolve_tampered_ciphertext = smithCorpusWords(&.{ 0, 5, 1, 0, 0 });
+const resolve_tampered_tag = smithCorpusWords(&.{ 0, 5, 2, 0, 0 });
+
+// Authenticated malformed `TRS1` records (scenario 6): word[2] keeps the
+// truncation gate nonzero (`resolve_truncated_ffff` above already covers
+// the gate-zero arm), word[3] selects the inner mutation switch, and any
+// further words are that mutation's own nested selections in call order.
+const resolve_bad_magic = smithCorpusWords(&.{ 0, 6, 1, 0, 0, 0 });
+const resolve_bad_version = smithCorpusWords(&.{ 0, 6, 1, 1, 0 });
+const resolve_bad_record_type = smithCorpusWords(&.{ 0, 6, 1, 2, 0 });
+const resolve_bad_section_length = smithCorpusWords(&.{ 0, 6, 1, 3, 0 });
+const resolve_duplicate_required = smithCorpusWords(&.{ 0, 6, 1, 4, 0, 0 });
+const resolve_missing_required = smithCorpusWords(&.{ 0, 6, 1, 5, 0, 0 });
+const resolve_length_one_under = smithCorpusWords(&.{ 0, 6, 1, 6, 0, 0, 0 });
+const resolve_length_zero = smithCorpusWords(&.{ 0, 6, 1, 6, 0, 1, 0 });
+const resolve_length_one_over = smithCorpusWords(&.{ 0, 6, 1, 6, 0, 2, 0 });
+const resolve_unknown_critical = smithCorpusWords(&.{ 0, 6, 1, 7, 0 });
+const resolve_psk_zero = smithCorpusWords(&.{ 0, 6, 1, 8, 0, 0 });
+const resolve_psk_one = smithCorpusWords(&.{ 0, 6, 1, 8, 1, 0 });
+const resolve_psk_one_over = smithCorpusWords(&.{ 0, 6, 1, 8, 2, 0 });
+const resolve_psk_max_digest = smithCorpusWords(&.{ 0, 6, 1, 8, 3, 0 });
+const resolve_unknown_suite = smithCorpusWords(&.{ 0, 6, 1, 9, 0 });
+const resolve_suite_psk_mismatch = smithCorpusWords(&.{ 0, 6, 1, 10, 0 });
+
+// The post-scenario `protector.limits` probe (`switch (smith.index(5))`
+// after the main scenario switch), forced on top of the baseline accept
+// scenario (word[1] = 0).
+const resolve_ticket_limit_exact = smithCorpusWords(&.{ 0, 0, 1 });
+const resolve_ticket_limit_one_under = smithCorpusWords(&.{ 0, 0, 2 });
+const resolve_state_limit_exact = smithCorpusWords(&.{ 0, 0, 3 });
+const resolve_state_limit_one_under = smithCorpusWords(&.{ 0, 0, 4 });
+
 test "fuzz: TLS resumption: Protector.resolve authenticates, rejects, and never leaks plaintext under key-state and envelope mutation" {
     try testing.fuzz({}, fuzzProtectorResolveInput, .{
         .corpus = &.{
@@ -4097,6 +4261,28 @@ test "fuzz: TLS resumption: Protector.resolve authenticates, rejects, and never 
             &resolve_lifetime_max,
             &resolve_lifetime_zero,
             &resolve_lifetime_over,
+            &resolve_tampered_ciphertext,
+            &resolve_tampered_tag,
+            &resolve_bad_magic,
+            &resolve_bad_version,
+            &resolve_bad_record_type,
+            &resolve_bad_section_length,
+            &resolve_duplicate_required,
+            &resolve_missing_required,
+            &resolve_length_one_under,
+            &resolve_length_zero,
+            &resolve_length_one_over,
+            &resolve_unknown_critical,
+            &resolve_psk_zero,
+            &resolve_psk_one,
+            &resolve_psk_one_over,
+            &resolve_psk_max_digest,
+            &resolve_unknown_suite,
+            &resolve_suite_psk_mismatch,
+            &resolve_ticket_limit_exact,
+            &resolve_ticket_limit_one_under,
+            &resolve_state_limit_exact,
+            &resolve_state_limit_one_under,
         },
     });
 }
@@ -4221,6 +4407,13 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
     var key_probe = KeyDeinitProbe{};
     TestKeyDeinitProbeStorage.probe = &key_probe;
 
+    // Mirrors `key_probe` above, but for `LeaseHighWater.key_fingerprint`
+    // (see `FingerprintDeinitProbe`'s doc comment): proves pending ledger
+    // fingerprints are actually zeroized before being freed, not merely
+    // that the enclosing allocation was cleaned up.
+    var fingerprint_probe = FingerprintDeinitProbe{};
+    TestFingerprintDeinitProbeStorage.probe = &fingerprint_probe;
+
     var held: ?*Snapshot = null;
     var held_refs: usize = 0;
     var held_deinit_count = std.atomic.Value(usize).init(0);
@@ -4277,6 +4470,7 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
         keyring.deinit();
         secrets.secureZero(&held_key_fingerprint);
         TestKeyDeinitProbeStorage.probe = null;
+        TestFingerprintDeinitProbeStorage.probe = null;
     }
 
     var last_generation: u64 = 0;
@@ -4304,7 +4498,7 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
     const op_count = 1 + smith.index(8);
     for (0..op_count) |_| {
         switch (smith.index(6)) {
-            0 => { // (re)install the active key with an advanced, non-overlapping lease window
+            0 => install_op: { // (re)install the active key with an advanced, non-overlapping lease window
                 // Occasionally install a lease window pinned at the very
                 // top of the `u64` counter space instead of the normal
                 // small advancing range, so the "seal" opcode below gets a
@@ -4317,7 +4511,8 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
                 // install of the same id deterministically (and correctly)
                 // rejects as `OverlappingNonceLease` for the rest of this
                 // bounded program -- already handled by the same
-                // catch/continue every other install rejection uses below.
+                // catch/rollback-assertion every other install rejection
+                // uses below.
                 const near_wrap = smith.index(8) == 0;
                 const start: u64 = if (near_wrap) std.math.maxInt(u64) - 1 else next_lease_start;
                 const end: u64 = if (near_wrap) std.math.maxInt(u64) else start + lease_chunk;
@@ -4332,6 +4527,9 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
                     .nonce_lease = .{ .prefix = .{ 0xc1, 0, 0, 0 }, .start = start, .end_exclusive = end },
                 };
                 const before = captureKeyringState(&keyring);
+                var secret_before: KeyringSecretState = undefined;
+                secret_before.captureInto(&keyring);
+                defer secret_before.deinit();
                 // If the tracked snapshot is currently unheld (no modeled
                 // owner) and still `keyring.current`, this install -- if it
                 // succeeds -- performs its true final release (a fresh
@@ -4345,11 +4543,13 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
                 const wipes_before = if (watching) key_probe.observed else 0;
                 const snapshot = keyring.buildSnapshot(&.{config}, testCapabilities()) catch {
                     try expectKeyringStateEqual(before, &keyring);
-                    continue;
+                    try secret_before.expectEqual(&keyring);
+                    break :install_op;
                 };
                 keyring.install(snapshot) catch {
                     try expectKeyringStateEqual(before, &keyring);
-                    continue;
+                    try secret_before.expectEqual(&keyring);
+                    break :install_op;
                 };
                 try testing.expect(keyring.current.?.generation > last_generation);
                 last_generation = keyring.current.?.generation;
@@ -4359,16 +4559,21 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
                     tracked_finalized = true;
                 }
             },
-            1 => { // dry-run validate must never mutate published state
+            1 => validate_op: { // dry-run validate must never mutate published state
                 const config = sampleKeyConfigWithByte(keyId(0xc2), .aes_256_gcm, null, 0x22);
                 const before = captureKeyringState(&keyring);
+                var secret_before: KeyringSecretState = undefined;
+                secret_before.captureInto(&keyring);
+                defer secret_before.deinit();
                 const candidate = keyring.buildSnapshot(&.{config}, testCapabilities()) catch {
                     try expectKeyringStateEqual(before, &keyring);
-                    continue;
+                    try secret_before.expectEqual(&keyring);
+                    break :validate_op;
                 };
                 defer candidate.release();
                 keyring.validateInstallCandidate(candidate) catch {};
                 try expectKeyringStateEqual(before, &keyring);
+                try secret_before.expectEqual(&keyring);
             },
             2 => { // acquire current, hold across subsequent ops -- at most once per program
                 // Instrumenting a *second* snapshot would repoint
@@ -4432,10 +4637,13 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
                     }
                 }
             },
-            else => { // reserve a nonce: uniqueness, deterministic exhaustion (including near-wrap), and the post-reservation provider-fault contract
+            else => seal_op: { // reserve a nonce: uniqueness, deterministic exhaustion (including near-wrap), and the post-reservation provider-fault contract
                 const before = captureKeyringState(&keyring);
+                var secret_before: KeyringSecretState = undefined;
+                secret_before.captureInto(&keyring);
+                defer secret_before.deinit();
                 const ticket = keyring.current != null and keyring.current.?.keys[0].nonce_lease != null;
-                if (!ticket) continue;
+                if (!ticket) break :seal_op;
                 const counter_before = keyring.current.?.keys[0].nonce_lease.?.next_counter.load(.acquire);
                 const has_room = counter_before < keyring.current.?.keys[0].nonce_lease.?.currentEnd();
 
@@ -4468,7 +4676,8 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
                     var expected_after = before;
                     expected_after.current_keys[0].lease.next_counter = counter_before + 1;
                     try expectKeyringStateEqual(expected_after, &keyring);
-                    continue;
+                    try secret_before.expectEqual(&keyring);
+                    break :seal_op;
                 }
 
                 var ticket_buf: [512]u8 = undefined;
@@ -4487,6 +4696,7 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
                     var expected_after = before;
                     expected_after.current_keys[0].lease.next_counter = counter_before + 1;
                     try expectKeyringStateEqual(expected_after, &keyring);
+                    try secret_before.expectEqual(&keyring);
 
                     var expected_nonce: [provider.aead_nonce_len]u8 = undefined;
                     @memcpy(expected_nonce[0..4], &before.current_keys[0].lease.prefix);
@@ -4511,6 +4721,7 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
                     // regression instead of failing loudly.
                     try testing.expectEqual(error.NonceLeaseExhausted, err);
                     try expectKeyringStateEqual(before, &keyring);
+                    try secret_before.expectEqual(&keyring);
                 }
             },
         }
@@ -4607,6 +4818,7 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
     }
     secrets.secureZero(&held_key_fingerprint);
     TestKeyDeinitProbeStorage.probe = null;
+    TestFingerprintDeinitProbeStorage.probe = null;
 }
 
 // Word[0] is the `FailingAllocator` fail index (`smith.index(24)`); word[1]

--- a/src/tls/ticket_protection.zig
+++ b/src/tls/ticket_protection.zig
@@ -3398,3 +3398,258 @@ test "fuzz: TLS resumption: parseEnvelope single-field mutation and Limits bound
 fn fuzzParseEnvelopeMutationInput(_: void, smith: *std.testing.Smith) !void {
     try fuzzParseEnvelopeMutation(smith);
 }
+
+/// #494-B: authenticated `Protector.resolve` under key-state and envelope
+/// mutation. Complements `fuzzTicketIdentity` above (which only proves miss
+/// paths never panic or mutate output against arbitrary bytes) by driving
+/// the accept path, every typed rejection reason, and an allocator-failure
+/// sweep against a *structurally valid* envelope, so mutation has a
+/// meaningful chance of landing on the authenticated-open boundary rather
+/// than being rejected by `parseEnvelope` before any key/AEAD work happens.
+/// Every scenario runs through `ZeroCheckingAllocator` to prove the
+/// temporary plaintext buffer is wiped before free on every path (accept,
+/// reject, and allocation failure alike), not just the miss path the
+/// existing deterministic "...zeroize plaintext before free" test names.
+fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith) !void {
+    const active_id = keyId(0xa1);
+    const future_id = keyId(0xa2);
+    const retired_id = keyId(0xa3);
+    const other_aead_id = keyId(0xa4);
+    const unknown_id = keyId(0xff);
+
+    var keyring = ReloadableKeyRing.init(allocator);
+    defer keyring.deinit();
+    const configs = [_]KeyConfig{
+        // The only key with a nonce lease, so `seal` picks it unambiguously.
+        sampleKeyConfigWithByte(active_id, .aes_128_gcm, .{ .prefix = .{ 0xa1, 0, 0, 0 }, .start = 0, .end_exclusive = 8 }, 0x11),
+        .{
+            .id = future_id,
+            .aead = .aes_128_gcm,
+            .key_bytes = testKeyBytes(.aes_128_gcm, 0x13),
+            .not_before_unix_ms = 15_000,
+            .encrypt_until_unix_ms = 20_000,
+            .decrypt_until_unix_ms = 30_000,
+        },
+        .{
+            .id = retired_id,
+            .aead = .aes_128_gcm,
+            .key_bytes = testKeyBytes(.aes_128_gcm, 0x10),
+            .not_before_unix_ms = 0,
+            .encrypt_until_unix_ms = 500,
+            .decrypt_until_unix_ms = 1_000,
+        },
+        .{
+            .id = other_aead_id,
+            .aead = .aes_256_gcm,
+            .key_bytes = testKeyBytes(.aes_256_gcm, 0x22),
+            .not_before_unix_ms = 0,
+            .encrypt_until_unix_ms = 20_000,
+            .decrypt_until_unix_ms = 30_000,
+        },
+    };
+    try keyring.install(try keyring.buildSnapshot(&configs, testCapabilities()));
+
+    var state = try sampleServerState(allocator);
+    defer state.deinit();
+    var protector = Protector{ .provider = testProvider(), .keyring = &keyring, .limits = session.Limits.default };
+    var seal_buf: [1024]u8 = undefined;
+    // `active_id`'s window is `sampleKeyConfigWithByte`'s fixed
+    // `[1_000, 5_000)` encrypt / `[1_000, 20_000)` decrypt range, so sealing
+    // and resolving must use different instants: seal while the lease can
+    // still mint nonces, resolve later during the decrypt-only grace
+    // window (still `retained`, not `retired`) so the accept/round-trip
+    // scenario exercises the same grace-window path
+    // `"rotation: a resolve against a decrypt-only grace-window key..."`
+    // covers deterministically, but under Smith-driven envelope/key-state
+    // mutation instead of a single hand-picked case.
+    const seal_now_unix_ms: i64 = 2_000;
+    const now_unix_ms: i64 = 10_000;
+    const valid_envelope = try protector.seal(allocator, &state, seal_now_unix_ms, &seal_buf);
+
+    var observer = TestObserver{};
+    defer observer.deinit(allocator);
+    protector.observer = observer.observer();
+
+    var zero_alloc = ZeroCheckingAllocator.init(allocator);
+    switch (smith.index(6)) {
+        0 => {
+            try expectRoundTrip(&protector, zero_alloc.allocator(), &state, valid_envelope, now_unix_ms);
+            try observer.expectOnly(.resolve_succeeded);
+        },
+        1, 2, 3, 4 => |case| {
+            var tampered_buf: [1024]u8 = undefined;
+            const tampered = tampered_buf[0..valid_envelope.len];
+            @memcpy(tampered, valid_envelope);
+            const substituted = switch (case) {
+                1 => unknown_id,
+                2 => future_id,
+                3 => retired_id,
+                else => other_aead_id,
+            };
+            @memcpy(tampered[8..24], &substituted);
+            try expectResolveFalseUnchanged(&protector, zero_alloc.allocator(), tampered, now_unix_ms);
+            const expected_reason: ResolveRejectReason = switch (case) {
+                1 => .unknown_key,
+                2 => .future_key,
+                3 => .retired_key,
+                else => .authentication_failed,
+            };
+            try observer.expectOnly(.{ .resolve_rejected = expected_reason });
+        },
+        else => {
+            var tampered_buf: [1024]u8 = undefined;
+            const tampered = tampered_buf[0..valid_envelope.len];
+            @memcpy(tampered, valid_envelope);
+            const region = smith.index(3);
+            const offset = switch (region) {
+                0 => 24 + smith.index(provider.aead_nonce_len), // nonce (authenticated via AAD)
+                1 => fixed_header_len + smith.index(tampered.len - fixed_header_len - tag_len), // ciphertext
+                else => tampered.len - tag_len + smith.index(tag_len), // tag
+            };
+            tampered[offset] ^= 0xff;
+            try expectResolveFalseUnchanged(&protector, zero_alloc.allocator(), tampered, now_unix_ms);
+            try observer.expectOnly(.{ .resolve_rejected = .authentication_failed });
+        },
+    }
+
+    // Bounded allocation-failure sweep against the unmodified valid
+    // envelope: every reachable allocation point must leave `out` either
+    // fully owned (fail_index landed after the last allocation `resolve`
+    // needed) or byte-identical to its pristine sentinel (fail_index landed
+    // on or before one), never a partially-populated state either way.
+    var sweep_zero = ZeroCheckingAllocator.init(allocator);
+    var failing = testing.FailingAllocator.init(sweep_zero.allocator(), .{ .fail_index = smith.index(6) });
+    var out: session.ServerRecoverableState = .{};
+    defer out.deinit();
+    if (protector.resolve(failing.allocator(), valid_envelope, now_unix_ms, &out)) |found| {
+        if (found) {
+            try expectServerStateEqual(&state, &out);
+        } else {
+            try testing.expectEqual(@as(usize, 0), out.common.resumption_psk.len);
+        }
+    } else |err| {
+        try testing.expectEqual(error.OutOfMemory, err);
+        try testing.expectEqual(@as(usize, 0), out.common.resumption_psk.len);
+    }
+}
+
+test "fuzz: TLS resumption: Protector.resolve authenticates, rejects, and never leaks plaintext under key-state and envelope mutation" {
+    try testing.fuzz({}, fuzzProtectorResolveInput, .{ .corpus = &.{
+        "",
+        &[_]u8{0},
+        &[_]u8{ 0, 1, 2, 3, 4, 5 },
+        &([_]u8{0xff} ** 6),
+    } });
+}
+
+fn fuzzProtectorResolveInput(_: void, smith: *testing.Smith) !void {
+    try fuzzProtectorResolve(testing.allocator, smith);
+}
+
+/// #494-B: bounded operation-sequence target over `Snapshot.build`,
+/// `ReloadableKeyRing.install`/`validateInstallCandidate`/`acquireCurrent`,
+/// and `Snapshot.retain`/`release`. `fuzzSnapshotConfig` above already
+/// exhaustively fuzzes the *static* properties of a single build/install
+/// call (every rejection reason, boundary window, and key count); this
+/// target instead fuzzes a short *program* of such calls interleaved with
+/// acquire/retain/release, asserting after every step that generation is
+/// monotonic, the ledger never shrinks, and a retained old snapshot stays
+/// fully intact (unwiped, unfreed) for as long as it is held, even across
+/// installs that replace it as `keyring.current` -- the temporal invariant
+/// the single-call target cannot exercise.
+fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Smith) !void {
+    var keyring = ReloadableKeyRing.init(allocator);
+    defer keyring.deinit();
+
+    var held: ?*Snapshot = null;
+    var held_deinit_count = std.atomic.Value(usize).init(0);
+    var held_generation: u64 = 0;
+    defer if (held) |snap| snap.release();
+
+    var last_generation: u64 = 0;
+    var last_ledger_len: usize = 0;
+    var next_id_byte: u8 = 0xb0;
+
+    const op_count = 1 + smith.index(8);
+    for (0..op_count) |_| {
+        switch (smith.index(5)) {
+            0 => { // install a fresh key, occasionally reusing a prior id
+                const aead = fuzzAead(@intCast(smith.index(3)));
+                const reuse_prior = next_id_byte > 0xb0 and smith.index(3) == 0;
+                const id_byte = if (reuse_prior) next_id_byte -% 1 else next_id_byte;
+                if (!reuse_prior) next_id_byte +%= 1;
+                const key_byte: u8 = if (aead == .aes_128_gcm) 0x11 else 0x22;
+                const config = sampleKeyConfigWithByte(keyId(id_byte), aead, .{ .prefix = .{ id_byte, 0, 0, 0 }, .start = 0, .end_exclusive = 4 }, key_byte);
+                const before = captureKeyringState(&keyring);
+                const snapshot = keyring.buildSnapshot(&.{config}, testCapabilities()) catch continue;
+                keyring.install(snapshot) catch {
+                    try expectKeyringStateEqual(before, &keyring);
+                    continue;
+                };
+                try testing.expect(keyring.current.?.generation > last_generation);
+                last_generation = keyring.current.?.generation;
+            },
+            1 => { // dry-run validate must never mutate published state
+                const config = sampleKeyConfigWithByte(keyId(next_id_byte), .aes_256_gcm, null, 0x22);
+                const before = captureKeyringState(&keyring);
+                const candidate = keyring.buildSnapshot(&.{config}, testCapabilities()) catch continue;
+                defer candidate.release();
+                keyring.validateInstallCandidate(candidate) catch {};
+                try expectKeyringStateEqual(before, &keyring);
+            },
+            2 => { // acquire + retain current, hold across subsequent ops
+                if (held == null) {
+                    if (keyring.acquireCurrent()) |snap| {
+                        held_deinit_count = std.atomic.Value(usize).init(0);
+                        snap.deinit_count = &held_deinit_count;
+                        held_generation = snap.generation;
+                        held = snap;
+                    }
+                }
+            },
+            3 => { // release the held snapshot
+                if (held) |snap| {
+                    try testing.expectEqual(@as(usize, 0), held_deinit_count.load(.monotonic));
+                    snap.release();
+                    held = null;
+                }
+            },
+            else => { // explicit generation control: exercise stale/overflow rejection
+                const config = sampleKeyConfigWithByte(keyId(next_id_byte), .aes_128_gcm, null, 0x33);
+                const generation: u64 = switch (smith.index(3)) {
+                    0 => 0,
+                    1 => if (last_generation > 0) last_generation else 1,
+                    else => std.math.maxInt(u64),
+                };
+                const before = captureKeyringState(&keyring);
+                const candidate = Snapshot.build(allocator, &.{config}, generation, testCapabilities()) catch continue;
+                keyring.install(candidate) catch {
+                    try expectKeyringStateEqual(before, &keyring);
+                    continue;
+                };
+                try testing.expect(keyring.current.?.generation > last_generation);
+                last_generation = keyring.current.?.generation;
+            },
+        }
+
+        try testing.expect(keyring.ledger.items.len >= last_ledger_len);
+        last_ledger_len = keyring.ledger.items.len;
+        if (held) |snap| {
+            try testing.expectEqual(held_generation, snap.generation);
+            try testing.expectEqual(@as(usize, 0), held_deinit_count.load(.monotonic));
+        }
+    }
+}
+
+test "fuzz: TLS resumption: ticket keyring install/validate/acquire/retain/release sequence preserves generation, ledger, and reference invariants" {
+    try testing.fuzz({}, fuzzKeyringOperationSequenceInput, .{ .corpus = &.{
+        "",
+        &([_]u8{0} ** 8),
+        &([_]u8{0xff} ** 8),
+        &[_]u8{ 0, 2, 3, 0, 2, 0, 3, 1 },
+    } });
+}
+
+fn fuzzKeyringOperationSequenceInput(_: void, smith: *testing.Smith) !void {
+    try fuzzKeyringOperationSequence(testing.allocator, smith);
+}

--- a/src/tls/ticket_protection.zig
+++ b/src/tls/ticket_protection.zig
@@ -3779,7 +3779,7 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
     protector.observer = observer.observer();
 
     var zero_alloc = ZeroCheckingAllocator.init(allocator);
-    switch (smith.index(11)) {
+    switch (smith.index(13)) {
         0 => {
             try expectRoundTrip(&protector, zero_alloc.allocator(), &state, valid_envelope, resolve_now_unix_ms);
             try observer.expectOnly(.resolve_succeeded);
@@ -3995,7 +3995,7 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
                 try observer.expectOnly(.{ .resolve_rejected = .not_yet_valid });
             }
         },
-        else => switch (smith.index(5)) {
+        10 => switch (smith.index(5)) {
             0 => {
                 // Exact `isExpired` boundary for `lifetime_seconds = 1`
                 // (1000ms): `age == 999` must accept.
@@ -4073,6 +4073,54 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
                 try expectResolveFalseUnchanged(&protector, zero_alloc.allocator(), envelope, resolve_now_unix_ms);
                 try observer.expectOnly(.{ .resolve_rejected = .invalid_plaintext });
             },
+        },
+        11 => {
+            // A local provider fault distinct from a peer-controlled
+            // authentication failure: `aeadOpen` itself reports the active
+            // key's AEAD as unsupported. This must escape `resolve()`
+            // as-is (not normalize to a miss) and be attributed as
+            // `.unsupported_capability`, proving the resolver's
+            // peer-vs-local error split covers `aeadOpen`, not just
+            // allocation and `Limits`.
+            var faulting = FaultingAeadProvider{ .inner = fresh_provider, .fault = .open_unsupported_capability };
+            var faulting_protector = protector;
+            faulting_protector.provider = faulting.cryptoProvider();
+
+            var out = try sentinelServerState(allocator);
+            defer out.deinit();
+            var expected: session.ServerRecoverableState = .{};
+            try out.cloneInto(allocator, &expected);
+            defer expected.deinit();
+
+            try testing.expectError(
+                error.UnsupportedCapability,
+                faulting_protector.resolve(zero_alloc.allocator(), valid_envelope, resolve_now_unix_ms, &out),
+            );
+            try expectServerStateEqual(&expected, &out);
+            try observer.expectOnly(.{ .resolve_rejected = .unsupported_capability });
+        },
+        else => {
+            // The companion local-fault case: `aeadOpen` reports a
+            // configuration/input error, which must normalize to
+            // `error.InvalidInternalState` (not silently become a peer
+            // miss), leave `out` untouched, and attribute
+            // `.invalid_internal_state`.
+            var faulting = FaultingAeadProvider{ .inner = fresh_provider, .fault = .open_invalid_input };
+            var faulting_protector = protector;
+            faulting_protector.provider = faulting.cryptoProvider();
+
+            var out = try sentinelServerState(allocator);
+            defer out.deinit();
+            var expected: session.ServerRecoverableState = .{};
+            try out.cloneInto(allocator, &expected);
+            defer expected.deinit();
+
+            try testing.expectError(
+                error.InvalidInternalState,
+                faulting_protector.resolve(zero_alloc.allocator(), valid_envelope, resolve_now_unix_ms, &out),
+            );
+            try expectServerStateEqual(&expected, &out);
+            try observer.expectOnly(.{ .resolve_rejected = .invalid_internal_state });
         },
     }
 
@@ -4175,7 +4223,7 @@ fn smithCorpusWords(comptime words: []const u64) [words.len * 8]u8 {
 
 // Word[0] selects the AEAD (0/1/2 = AES-128-GCM/AES-256-GCM/ChaCha20-
 // Poly1305); word[1] selects the top-level scenario (`switch
-// (smith.index(11))` in `fuzzProtectorResolve`); the trailing word on every
+// (smith.index(13))` in `fuzzProtectorResolve`); the trailing word on every
 // entry is always the post-switch `protector.limits` probe selector
 // (`switch (smith.index(5))`, kept at its default/no-change value here so
 // each seed forces exactly the scenario it names). Words in between are
@@ -4197,13 +4245,19 @@ const resolve_sha384_pair = smithCorpusWords(&.{ 0, 8, 0 });
 // `at_boundary == true` (issued_at == now) / `false` (== now + 1).
 const resolve_issued_exact = smithCorpusWords(&.{ 0, 9, 0, 0 });
 const resolve_issued_plus_one = smithCorpusWords(&.{ 0, 9, 1, 0 });
-// The lifetime/expiry matrix (`else` branch, i.e. any value >= 10 in range)
-// selects among its own five cases via one more word.
+// The lifetime/expiry matrix (case 10) selects among its own five cases via
+// one more word.
 const resolve_expiry_999 = smithCorpusWords(&.{ 0, 10, 0, 0 });
 const resolve_expiry_1000 = smithCorpusWords(&.{ 0, 10, 1, 0 });
 const resolve_lifetime_max = smithCorpusWords(&.{ 0, 10, 2, 0 });
 const resolve_lifetime_zero = smithCorpusWords(&.{ 0, 10, 3, 0 });
 const resolve_lifetime_over = smithCorpusWords(&.{ 0, 10, 4, 0 });
+
+// Local provider faults (cases 11/12), distinct from every peer-controlled
+// rejection above: `aeadOpen` itself reports `UnsupportedCapability` /
+// `InvalidInput`, which must escape `resolve()` untranslated into a miss.
+const resolve_provider_unsupported = smithCorpusWords(&.{ 0, 11, 0 });
+const resolve_provider_invalid_input = smithCorpusWords(&.{ 0, 12, 0 });
 
 // Envelope authentication regions (scenario 5's own `region` selection:
 // 0 = nonce, already covered by `resolve_tampered_nonce` above; 1 =
@@ -4279,6 +4333,8 @@ test "fuzz: TLS resumption: Protector.resolve authenticates, rejects, and never 
             &resolve_psk_max_digest,
             &resolve_unknown_suite,
             &resolve_suite_psk_mismatch,
+            &resolve_provider_unsupported,
+            &resolve_provider_invalid_input,
             &resolve_ticket_limit_exact,
             &resolve_ticket_limit_one_under,
             &resolve_state_limit_exact,
@@ -4291,59 +4347,75 @@ fn fuzzProtectorResolveInput(_: void, smith: *testing.Smith) !void {
     try fuzzProtectorResolve(testing.allocator, smith);
 }
 
-/// Wraps a real `CryptoProvider` but always fails `aeadSeal`, so
-/// `fuzzKeyringOperationSequence`'s "seal" opcode can drive the
-/// post-nonce-reservation failure contract: `NonceLease.reserve()` commits
-/// the nonce *before* `Protector.sealInner` calls `aeadSeal`, so a local
-/// provider fault after that point must still leave the nonce consumed
-/// (never reused or rolled back), even though the ticket itself is never
-/// produced. Every other operation delegates unchanged to the wrapped
-/// provider so this stays a true "one operation faults" injection rather
-/// than a stub.
-const FaultingSealProvider = struct {
+/// Which single AEAD operation `FaultingAeadProvider` injects a fault into,
+/// and how: `seal_invalid_input` drives `fuzzKeyringOperationSequence`'s
+/// "seal" opcode's post-nonce-reservation failure contract (see below), and
+/// the two `open_*` variants drive `fuzzProtectorResolve`'s local-fault
+/// scenarios (#494-B requires proving `error.UnsupportedCapability` and
+/// `error.InvalidInput` from `aeadOpen` are distinct, non-normalized-to-miss
+/// operational errors, not folded into the peer-controlled
+/// `authentication_failed` path every tampered-ciphertext case above already
+/// covers).
+const AeadFault = enum {
+    seal_invalid_input,
+    open_unsupported_capability,
+    open_invalid_input,
+};
+
+/// Wraps a real `CryptoProvider` but injects exactly one `AeadFault` into
+/// the corresponding AEAD operation; every other operation (including the
+/// *other* AEAD direction -- `aeadSeal` under an `open_*` fault, `aeadOpen`
+/// under `seal_invalid_input`) delegates unchanged to the wrapped provider,
+/// so this stays a true "one operation faults" injection rather than a stub.
+/// `seal_invalid_input` in particular backs `fuzzKeyringOperationSequence`'s
+/// "seal" opcode's post-nonce-reservation failure contract:
+/// `NonceLease.reserve()` commits the nonce *before* `Protector.sealInner`
+/// calls `aeadSeal`, so a local provider fault after that point must still
+/// leave the nonce consumed (never reused or rolled back), even though the
+/// ticket itself is never produced.
+const FaultingAeadProvider = struct {
     inner: provider.CryptoProvider,
+    fault: AeadFault,
 
     fn capabilities(ctx: *anyopaque) provider.Capabilities {
-        const self: *FaultingSealProvider = @ptrCast(@alignCast(ctx));
+        const self: *FaultingAeadProvider = @ptrCast(@alignCast(ctx));
         return self.inner.capabilities();
     }
     fn hkdfExtract(ctx: *anyopaque, hash: provider.Hash, salt: []const u8, ikm: []const u8, out: []u8) provider.HkdfError!void {
-        const self: *FaultingSealProvider = @ptrCast(@alignCast(ctx));
+        const self: *FaultingAeadProvider = @ptrCast(@alignCast(ctx));
         return self.inner.vtable.hkdfExtract(self.inner.context, hash, salt, ikm, out);
     }
     fn hkdfExpandLabel(ctx: *anyopaque, hash: provider.Hash, secret: []const u8, label: []const u8, hash_context: []const u8, out: []u8) provider.HkdfError!void {
-        const self: *FaultingSealProvider = @ptrCast(@alignCast(ctx));
+        const self: *FaultingAeadProvider = @ptrCast(@alignCast(ctx));
         return self.inner.vtable.hkdfExpandLabel(self.inner.context, hash, secret, label, hash_context, out);
     }
     fn aeadSeal(ctx: *anyopaque, aead: provider.Aead, key: []const u8, nonce: []const u8, associated_data: []const u8, plaintext: []const u8, ciphertext: []u8, tag: []u8) provider.SealError!void {
-        _ = ctx;
-        _ = aead;
-        _ = key;
-        _ = nonce;
-        _ = associated_data;
-        _ = plaintext;
-        _ = ciphertext;
-        _ = tag;
-        return error.InvalidInput;
+        const self: *FaultingAeadProvider = @ptrCast(@alignCast(ctx));
+        if (self.fault == .seal_invalid_input) return error.InvalidInput;
+        return self.inner.vtable.aeadSeal(self.inner.context, aead, key, nonce, associated_data, plaintext, ciphertext, tag);
     }
     fn aeadOpen(ctx: *anyopaque, aead: provider.Aead, key: []const u8, nonce: []const u8, associated_data: []const u8, ciphertext: []const u8, tag: []const u8, plaintext: []u8) provider.OpenError!void {
-        const self: *FaultingSealProvider = @ptrCast(@alignCast(ctx));
-        return self.inner.vtable.aeadOpen(self.inner.context, aead, key, nonce, associated_data, ciphertext, tag, plaintext);
+        const self: *FaultingAeadProvider = @ptrCast(@alignCast(ctx));
+        return switch (self.fault) {
+            .seal_invalid_input => self.inner.vtable.aeadOpen(self.inner.context, aead, key, nonce, associated_data, ciphertext, tag, plaintext),
+            .open_unsupported_capability => error.UnsupportedCapability,
+            .open_invalid_input => error.InvalidInput,
+        };
     }
     fn quicHeaderProtectionMask(ctx: *anyopaque, hp: provider.QuicHeaderProtection, key: []const u8, sample: []const u8, mask: []u8) provider.QuicHeaderProtectionError!void {
-        const self: *FaultingSealProvider = @ptrCast(@alignCast(ctx));
+        const self: *FaultingAeadProvider = @ptrCast(@alignCast(ctx));
         return self.inner.vtable.quicHeaderProtectionMask(self.inner.context, hp, key, sample, mask);
     }
     fn generateKeyShare(ctx: *anyopaque, group: provider.Group, public_out: []u8, private_out: []u8) provider.KeyShareError!void {
-        const self: *FaultingSealProvider = @ptrCast(@alignCast(ctx));
+        const self: *FaultingAeadProvider = @ptrCast(@alignCast(ctx));
         return self.inner.vtable.generateKeyShare(self.inner.context, group, public_out, private_out);
     }
     fn deriveSharedSecret(ctx: *anyopaque, group: provider.Group, private_scalar: []const u8, peer_public: []const u8, out: []u8) provider.DeriveError!void {
-        const self: *FaultingSealProvider = @ptrCast(@alignCast(ctx));
+        const self: *FaultingAeadProvider = @ptrCast(@alignCast(ctx));
         return self.inner.vtable.deriveSharedSecret(self.inner.context, group, private_scalar, peer_public, out);
     }
     fn verify(ctx: *anyopaque, scheme: provider.SignatureScheme, public_key: []const u8, message: []const u8, signature: []const u8) provider.VerifyError!void {
-        const self: *FaultingSealProvider = @ptrCast(@alignCast(ctx));
+        const self: *FaultingAeadProvider = @ptrCast(@alignCast(ctx));
         return self.inner.vtable.verify(self.inner.context, scheme, public_key, message, signature);
     }
 
@@ -4359,7 +4431,7 @@ const FaultingSealProvider = struct {
         .verify = verify,
     };
 
-    fn cryptoProvider(self: *FaultingSealProvider) provider.CryptoProvider {
+    fn cryptoProvider(self: *FaultingAeadProvider) provider.CryptoProvider {
         return .{ .context = self, .vtable = &vtable, .entropy = self.inner.entropy };
     }
 };
@@ -4657,7 +4729,7 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
                     // (`seal` never writes to the ledger on any path). A
                     // fresh per-case fault-injecting provider, not the
                     // shared static `testProvider()`, drives this.
-                    var faulting = FaultingSealProvider{ .inner = seal_provider };
+                    var faulting = FaultingAeadProvider{ .inner = seal_provider, .fault = .seal_invalid_input };
                     var faulting_protector = Protector{ .provider = faulting.cryptoProvider(), .keyring = &keyring, .limits = session.Limits.default };
                     var ticket_buf: [512]u8 = undefined;
                     try testing.expectError(error.InvalidInternalState, faulting_protector.seal(allocator, &state, seal_now_unix_ms, &ticket_buf));

--- a/src/tls/ticket_protection.zig
+++ b/src/tls/ticket_protection.zig
@@ -3866,7 +3866,7 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
                 try observer.expectOnly(.{ .resolve_rejected = .not_yet_valid });
             }
         },
-        else => switch (smith.index(4)) {
+        else => switch (smith.index(5)) {
             0 => {
                 // Exact `isExpired` boundary for `lifetime_seconds = 1`
                 // (1000ms): `age == 999` must accept.
@@ -3895,6 +3895,24 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
                 try observer.expectOnly(.{ .resolve_rejected = .expired });
             },
             2 => {
+                // Exact upper endpoint of the valid `(0,
+                // max_lifetime_seconds]` interval must round-trip:
+                // #494-B's boundary matrix requires zero / exact maximum /
+                // max-plus-one, and only this branch proves the *valid*
+                // maximum is actually accepted through the authenticated
+                // resolver rather than assuming it from
+                // `ResumableSessionCommon.init`'s own constructor tests.
+                var timed_state = try buildTimedServerState(allocator, resolve_now_unix_ms, session.max_lifetime_seconds);
+                defer timed_state.deinit();
+                var plaintext_buf: [2048]u8 = undefined;
+                const plaintext = try session.encodeServer(&timed_state, session.Limits.default, &plaintext_buf);
+                var envelope_buf: [2048]u8 = undefined;
+                const nonce = [_]u8{0xfd} ** provider.aead_nonce_len;
+                const envelope = try sealPlaintextWithProvider(fresh_provider, &envelope_buf, selected_aead, active_id, active_key, nonce, plaintext);
+                try expectRoundTrip(&protector, zero_alloc.allocator(), &timed_state, envelope, resolve_now_unix_ms);
+                try observer.expectOnly(.resolve_succeeded);
+            },
+            3 => {
                 // Raw-TLV `lifetime_seconds` boundary: zero is below the
                 // valid `(0, max_lifetime_seconds]` range.
                 // `ResumableSessionCommon.init` itself already rejects
@@ -4007,34 +4025,78 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
     try testing.expectEqual(@as(usize, 0), current_deinit_count.load(.monotonic));
 }
 
+/// Builds a corpus-replay entry for `std.testing.Smith` from explicit
+/// `index()`/`indexWithHash()` selections rather than opaque bytes.
+/// `Smith`'s corpus-replay contract (`valueWeightedWithHashInner` in Zig
+/// 0.16's `Smith.zig`) reads the *next* 8 bytes of the entry as a
+/// little-endian `u64` per call and uses it verbatim when it already falls
+/// in the call's valid range (defaulting to 0 once the entry runs out or a
+/// word falls outside that range) -- so a plain one- or nine-byte seed only
+/// ever supplies its *first* `index()` call before every later one defaults
+/// to 0, silently failing to force the AEAD/scenario/opcode matrix its own
+/// name and comment claim to cover. Every word here is one `index()`
+/// selection, in the exact call order the target itself makes.
+fn smithCorpusWords(comptime words: []const u64) [words.len * 8]u8 {
+    var out = [_]u8{0} ** (words.len * 8);
+    inline for (words, 0..) |word, i| {
+        std.mem.writeInt(u64, out[i * 8 ..][0..8], word, .little);
+    }
+    return out;
+}
+
+// Word[0] selects the AEAD (0/1/2 = AES-128-GCM/AES-256-GCM/ChaCha20-
+// Poly1305); word[1] selects the top-level scenario (`switch
+// (smith.index(11))` in `fuzzProtectorResolve`); the trailing word on every
+// entry is always the post-switch `protector.limits` probe selector
+// (`switch (smith.index(5))`, kept at its default/no-change value here so
+// each seed forces exactly the scenario it names). Words in between are
+// that scenario's own nested selections, in call order.
+const resolve_aes128_accept = smithCorpusWords(&.{ 0, 0, 0 });
+const resolve_aes256_accept = smithCorpusWords(&.{ 1, 0, 0 });
+const resolve_chacha_accept = smithCorpusWords(&.{ 2, 0, 0 });
+const resolve_unknown_key = smithCorpusWords(&.{ 0, 1, 0 });
+const resolve_future_key = smithCorpusWords(&.{ 0, 2, 0 });
+const resolve_retired_key = smithCorpusWords(&.{ 0, 3, 0 });
+const resolve_cross_aead = smithCorpusWords(&.{ 0, 4, 0 });
+// Region = 0 (nonce), byte-offset selector = 0.
+const resolve_tampered_nonce = smithCorpusWords(&.{ 0, 5, 0, 0, 0 });
+// The truncation gate (`smith.index(4) == 0`) inside case 6, then a valid
+// field-id index.
+const resolve_truncated_ffff = smithCorpusWords(&.{ 0, 6, 0, 0, 0 });
+const resolve_optional_field = smithCorpusWords(&.{ 0, 7, 0 });
+const resolve_sha384_pair = smithCorpusWords(&.{ 0, 8, 0 });
+// `at_boundary == true` (issued_at == now) / `false` (== now + 1).
+const resolve_issued_exact = smithCorpusWords(&.{ 0, 9, 0, 0 });
+const resolve_issued_plus_one = smithCorpusWords(&.{ 0, 9, 1, 0 });
+// The lifetime/expiry matrix (`else` branch, i.e. any value >= 10 in range)
+// selects among its own five cases via one more word.
+const resolve_expiry_999 = smithCorpusWords(&.{ 0, 10, 0, 0 });
+const resolve_expiry_1000 = smithCorpusWords(&.{ 0, 10, 1, 0 });
+const resolve_lifetime_max = smithCorpusWords(&.{ 0, 10, 2, 0 });
+const resolve_lifetime_zero = smithCorpusWords(&.{ 0, 10, 3, 0 });
+const resolve_lifetime_over = smithCorpusWords(&.{ 0, 10, 4, 0 });
+
 test "fuzz: TLS resumption: Protector.resolve authenticates, rejects, and never leaks plaintext under key-state and envelope mutation" {
     try testing.fuzz({}, fuzzProtectorResolveInput, .{
         .corpus = &.{
-            "",
-            &[_]u8{0},
-            &[_]u8{1},
-            &[_]u8{2},
-            &[_]u8{ 0, 1, 2, 3, 4, 5, 6, 7, 8 },
-            &([_]u8{0xff} ** 9),
-            // Deterministically forces the declaration-only-truncation arm of
-            // case 6's mutation matrix (`if (smith.index(4) == 0)`), rather
-            // than relying on a coverage-guided run to stumble onto it. Hand-
-            // derived from `std.testing.Smith`'s corpus-replay contract
-            // (`valueWeightedWithHashInner` in Zig 0.16's `Smith.zig`): each
-            // `index(n)` call under replay reads the *next* 8 bytes of the
-            // corpus entry as a little-endian `u64` and uses it verbatim if it
-            // already falls in `[0, n)` (defaulting to 0 once the bytes run
-            // out or fall outside that range), so this is four consecutive
-            // 8-byte little-endian words -- `1` (any valid AEAD index), `6`
-            // (the case-6 scenario, i.e. `invalid_plaintext`'s authenticated
-            // mutation matrix), `0` (the truncation gate), `0` (any valid
-            // field-id index) -- not an opaque fuzzer-minimized blob.
-            &[_]u8{
-                1, 0, 0, 0, 0, 0, 0, 0,
-                6, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0,
-            },
+            &resolve_aes128_accept,
+            &resolve_aes256_accept,
+            &resolve_chacha_accept,
+            &resolve_unknown_key,
+            &resolve_future_key,
+            &resolve_retired_key,
+            &resolve_cross_aead,
+            &resolve_tampered_nonce,
+            &resolve_truncated_ffff,
+            &resolve_optional_field,
+            &resolve_sha384_pair,
+            &resolve_issued_exact,
+            &resolve_issued_plus_one,
+            &resolve_expiry_999,
+            &resolve_expiry_1000,
+            &resolve_lifetime_max,
+            &resolve_lifetime_zero,
+            &resolve_lifetime_over,
         },
     });
 }
@@ -4281,7 +4343,10 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
                 const watching = tracked_snapshot and !tracked_finalized and held == null and
                     before.current != null and before.current_generation == tracked_generation;
                 const wipes_before = if (watching) key_probe.observed else 0;
-                const snapshot = keyring.buildSnapshot(&.{config}, testCapabilities()) catch continue;
+                const snapshot = keyring.buildSnapshot(&.{config}, testCapabilities()) catch {
+                    try expectKeyringStateEqual(before, &keyring);
+                    continue;
+                };
                 keyring.install(snapshot) catch {
                     try expectKeyringStateEqual(before, &keyring);
                     continue;
@@ -4297,7 +4362,10 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
             1 => { // dry-run validate must never mutate published state
                 const config = sampleKeyConfigWithByte(keyId(0xc2), .aes_256_gcm, null, 0x22);
                 const before = captureKeyringState(&keyring);
-                const candidate = keyring.buildSnapshot(&.{config}, testCapabilities()) catch continue;
+                const candidate = keyring.buildSnapshot(&.{config}, testCapabilities()) catch {
+                    try expectKeyringStateEqual(before, &keyring);
+                    continue;
+                };
                 defer candidate.release();
                 keyring.validateInstallCandidate(candidate) catch {};
                 try expectKeyringStateEqual(before, &keyring);
@@ -4385,25 +4453,53 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
                     var faulting_protector = Protector{ .provider = faulting.cryptoProvider(), .keyring = &keyring, .limits = session.Limits.default };
                     var ticket_buf: [512]u8 = undefined;
                     try testing.expectError(error.InvalidInternalState, faulting_protector.seal(allocator, &state, seal_now_unix_ms, &ticket_buf));
+                    // The sole allowed change from a faulted seal is the
+                    // reserved-and-consumed lease counter: everything else
+                    // in the publication snapshot -- key records,
+                    // generation/next-generation, every ledger entry, lease
+                    // prefix/end -- must be byte-identical to `before`.
+                    // `captureKeyringState`/`expectKeyringStateEqual`
+                    // already capture and compare all of that; a pointer/
+                    // ledger-length subset cannot catch a regression that
+                    // corrupts anything else this operation must leave
+                    // alone.
                     const counter_after = keyring.current.?.keys[0].nonce_lease.?.next_counter.load(.acquire);
                     try testing.expectEqual(counter_before + 1, counter_after);
-                    try testing.expectEqual(before.current, keyring.current);
-                    try testing.expectEqual(before.ledger_len, keyring.ledger.items.len);
+                    var expected_after = before;
+                    expected_after.current_keys[0].lease.next_counter = counter_before + 1;
+                    try expectKeyringStateEqual(expected_after, &keyring);
                     continue;
                 }
 
                 var ticket_buf: [512]u8 = undefined;
                 var protector = Protector{ .provider = seal_provider, .keyring = &keyring, .limits = session.Limits.default };
                 if (protector.seal(allocator, &state, seal_now_unix_ms, &ticket_buf)) |sealed| {
+                    // Same full-publication-state invariant as the faulted
+                    // path above, plus the exact emitted nonce: the
+                    // reserved counter, encoded big-endian after the
+                    // lease's 4-byte prefix, is public wire format
+                    // (`writeHeader`), not an implementation detail, so
+                    // asserting it exactly (not just its uniqueness) proves
+                    // `seal` really did consume `counter_before` and not
+                    // some other value.
+                    const counter_after = keyring.current.?.keys[0].nonce_lease.?.next_counter.load(.acquire);
+                    try testing.expectEqual(counter_before + 1, counter_after);
+                    var expected_after = before;
+                    expected_after.current_keys[0].lease.next_counter = counter_before + 1;
+                    try expectKeyringStateEqual(expected_after, &keyring);
+
+                    var expected_nonce: [provider.aead_nonce_len]u8 = undefined;
+                    @memcpy(expected_nonce[0..4], &before.current_keys[0].lease.prefix);
+                    std.mem.writeInt(u64, expected_nonce[4..12], counter_before, .big);
+                    try testing.expectEqualSlices(u8, &expected_nonce, sealed[24..36]);
+
                     var nonce: [provider.aead_nonce_len]u8 = undefined;
                     @memcpy(&nonce, sealed[24..36]);
                     for (seen_nonces[0..seen_nonce_count]) |prior| {
                         try testing.expect(!std.mem.eql(u8, &prior, &nonce));
                     }
-                    if (seen_nonce_count < seen_nonces.len) {
-                        seen_nonces[seen_nonce_count] = nonce;
-                        seen_nonce_count += 1;
-                    }
+                    seen_nonces[seen_nonce_count] = nonce;
+                    seen_nonce_count += 1;
                 } else |err| {
                     // With this fixture (a single key whose time window
                     // always covers `seal_now_unix_ms`, guarded above by
@@ -4513,13 +4609,83 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
     TestKeyDeinitProbeStorage.probe = null;
 }
 
+// Word[0] is the `FailingAllocator` fail index (`smith.index(24)`); word[1]
+// is `op_count - 1` (`smith.index(8)`); every word after that is one
+// opcode selection (`smith.index(6)`: 0=install, 1=dry-run validate,
+// 2=acquire, 3=retain, 4=release, 5=seal) or that opcode's own nested
+// selection, in call order. Opcode 0 (install) is always followed by its
+// near-wrap selector (`smith.index(8)`, 0 = near-`maxInt(u64)` window,
+// anything else = the normal small advancing range). Opcode 5 (seal) is
+// followed by its fault-mode selector (`smith.index(5)`, 0 = inject a
+// provider fault after the nonce is reserved) *only when* a nonce is
+// actually available to reserve (`has_room`) -- `and` short-circuits that
+// call otherwise, so an exhaustion-producing seal consumes no extra word.
+const keyring_oom_first_allocation = smithCorpusWords(&.{ 0, 0, 0, 1 });
+// install(normal range) -> acquire -> install(replaces while still held,
+// i.e. `held_outlived_current` becomes true with `held_refs > 0`) -> end:
+// teardown must drain the retained old snapshot and verify its wipe there,
+// not via the install-replacement bracket (which only fires when the
+// tracked snapshot is unheld at the moment it is replaced).
+const keyring_replace_while_held = smithCorpusWords(&.{
+    23, 2,
+    0,  1,
+    2,  0,
+    1,
+});
+// install -> acquire -> retain (a second modeled owner) -> install
+// (replaces while held) -> release -> release (the final modeled
+// reference, with the snapshot already outlived): exercises explicit
+// `Snapshot.retain()` plus the exact-final-release assertion under it.
+const keyring_explicit_retain_release = smithCorpusWords(&.{
+    23, 5,
+    0,  1,
+    2,  3,
+    0,  1,
+    4,  4,
+});
+// install -> seal, immediately faulted after the nonce is reserved.
+const keyring_fault_after_reserve = smithCorpusWords(&.{
+    23, 1,
+    0,  1,
+    5,  0,
+});
+// install(normal range, capacity 3) -> three successful reservations ->
+// a fourth seal that finds no room left and hits exact exhaustion.
+const keyring_success_and_exhaustion = smithCorpusWords(&.{
+    23, 4,
+    0,  1,
+    5,  1,
+    5,  1,
+    5,  1,
+    5,
+});
+// install a lease pinned at `[maxInt(u64) - 1, maxInt(u64))` -> the one
+// nonce it can ever issue -> a second seal that hits exhaustion exactly at
+// the `u64` boundary, proving no wraparound.
+const keyring_near_wrap = smithCorpusWords(&.{
+    23, 2,
+    0,  0,
+    5,  1,
+    5,
+});
+// install -> dry-run validate against an already-populated keyring (not
+// the empty initial state), proving the "never mutates published state"
+// invariant holds once there is real state to protect.
+const keyring_validate_dry_run = smithCorpusWords(&.{
+    23, 1,
+    0,  1,
+    1,
+});
+
 test "fuzz: TLS resumption: ticket keyring install/validate/acquire/retain/release/seal sequence preserves generation, ledger, nonce, and reference invariants" {
     try testing.fuzz({}, fuzzKeyringOperationSequenceInput, .{ .corpus = &.{
-        "",
-        &([_]u8{0} ** 8),
-        &([_]u8{0xff} ** 8),
-        &[_]u8{ 0, 2, 3, 5, 0, 4, 5, 4 },
-        &[_]u8{ 0, 0, 0, 5, 5, 5, 5 },
+        &keyring_oom_first_allocation,
+        &keyring_replace_while_held,
+        &keyring_explicit_retain_release,
+        &keyring_fault_after_reserve,
+        &keyring_success_and_exhaustion,
+        &keyring_near_wrap,
+        &keyring_validate_dry_run,
     } });
 }
 

--- a/src/tls/ticket_protection.zig
+++ b/src/tls/ticket_protection.zig
@@ -3447,6 +3447,40 @@ fn buildTimedServerState(allocator: std.mem.Allocator, issued_at_unix_ms: i64, l
     return state;
 }
 
+/// Appends one real TLV (`field_id`/`value`) to `fixture` and patches the
+/// section length to match, for authenticating a state extended with an
+/// unknown field. `out` must have at least `fixture.len + 4 + value.len`
+/// bytes of room.
+fn appendTlv(fixture: []const u8, field_id: u16, value: []const u8, out: []u8) usize {
+    @memcpy(out[0..fixture.len], fixture);
+    var pos: usize = fixture.len;
+    std.mem.writeInt(u16, out[pos..][0..2], field_id, .big);
+    std.mem.writeInt(u16, out[pos + 2 ..][0..2], @intCast(value.len), .big);
+    @memcpy(out[pos + 4 ..][0..value.len], value);
+    pos += 4 + value.len;
+    std.mem.writeInt(u32, out[6..10], @intCast(pos - session.header_len), .big);
+    return pos;
+}
+
+/// Appends only a TLV *header* (`field_id` plus a `declared_length` that is
+/// never backed by that many real bytes) to `fixture` and patches the
+/// section length to the true, short byte count -- a "declaration-only"
+/// truncation that proves `session.decode`'s per-field length check
+/// rejects a field claiming far more bytes than the section actually has
+/// left, without needing an output buffer sized to `declared_length`
+/// itself (unlike `session.withTlvLengthOverride`, which always backs the
+/// declared length with real bytes). `out` must have at least
+/// `fixture.len + 4` bytes of room.
+fn appendTruncatedTlvHeader(fixture: []const u8, field_id: u16, declared_length: u16, out: []u8) usize {
+    @memcpy(out[0..fixture.len], fixture);
+    var pos: usize = fixture.len;
+    std.mem.writeInt(u16, out[pos..][0..2], field_id, .big);
+    std.mem.writeInt(u16, out[pos + 2 ..][0..2], declared_length, .big);
+    pos += 4;
+    std.mem.writeInt(u32, out[6..10], @intCast(pos - session.header_len), .big);
+    return pos;
+}
+
 /// #494-B: authenticated `Protector.resolve` under key-state, envelope, and
 /// authenticated-plaintext mutation. Complements `fuzzTicketIdentity` above
 /// (which only proves miss paths never panic or mutate output against
@@ -3559,7 +3593,7 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
     protector.observer = observer.observer();
 
     var zero_alloc = ZeroCheckingAllocator.init(allocator);
-    switch (smith.index(9)) {
+    switch (smith.index(10)) {
         0 => {
             try expectRoundTrip(&protector, zero_alloc.allocator(), &state, valid_envelope, resolve_now_unix_ms);
             try observer.expectOnly(.resolve_succeeded);
@@ -3631,7 +3665,7 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
 
             var mutated_buf: [2048 + 256]u8 = undefined;
             var mutated: []u8 = undefined;
-            switch (smith.index(7)) {
+            switch (smith.index(9)) {
                 0 => {
                     mutated = mutated_buf[0..plaintext.len];
                     @memcpy(mutated, plaintext);
@@ -3662,11 +3696,34 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
                     const field_id = duplicate_or_missing_ids[smith.index(duplicate_or_missing_ids.len)];
                     mutated = mutated_buf[0..session.fixtureWithFieldRemoved(plaintext, field_id, &mutated_buf)];
                 },
-                else => { // suite/PSK/lifetime/etc. exact-width field: 0 or one-over its true length
+                6 => { // suite/lifetime/etc. exact-width field: one-under, zero, or one-over its true length
                     const field_id = exact_width_ids[smith.index(exact_width_ids.len)];
                     const original_len = session.originalTlvLen(plaintext, field_id).?;
-                    const new_length: u16 = if (smith.index(2) == 0) 0 else original_len + 1;
+                    const new_length: u16 = switch (smith.index(3)) {
+                        0 => original_len - 1,
+                        1 => 0,
+                        else => original_len + 1,
+                    };
                     mutated = mutated_buf[0..session.withTlvLengthOverride(plaintext, field_id, new_length, &mutated_buf)];
+                },
+                7 => { // unknown *critical* field (high bit clear) -- always `error.UnknownCriticalField`
+                    mutated = mutated_buf[0..appendTlv(plaintext, 0x00ff, "unrecognized-critical-data", &mutated_buf)];
+                },
+                8 => { // PSK length boundary: zero, one, one-over, or the largest supported digest length
+                    const original_len = session.originalTlvLen(plaintext, session.field_resumption_psk).?;
+                    const new_length: u16 = switch (smith.index(4)) {
+                        0 => 0,
+                        1 => 1,
+                        2 => original_len + 1,
+                        else => provider.max_digest_len,
+                    };
+                    mutated = mutated_buf[0..session.withTlvLengthOverride(plaintext, session.field_resumption_psk, new_length, &mutated_buf)];
+                },
+                else => { // declared length far exceeds the bytes actually provided -- a truncation, not a 64 KiB allocation
+                    const field_id = duplicate_or_missing_ids[smith.index(duplicate_or_missing_ids.len)];
+                    var without_field_buf: [2048 + 256]u8 = undefined;
+                    const without_field_len = session.fixtureWithFieldRemoved(plaintext, field_id, &without_field_buf);
+                    mutated = mutated_buf[0..appendTruncatedTlvHeader(without_field_buf[0..without_field_len], field_id, 0xffff, &mutated_buf)];
                 },
             }
 
@@ -3677,6 +3734,25 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
             try observer.expectOnly(.{ .resolve_rejected = .invalid_plaintext });
         },
         7 => {
+            // An unknown *optional* field (high bit 0x8000 set) must be
+            // silently skipped by `session.decode`, not rejected -- the
+            // resolver should still accept and round-trip to the same
+            // state, proving the accept path is forward-compatible with a
+            // future optional extension the same way session.zig's own
+            // deterministic "unknown optional fields are skipped, unknown
+            // critical fields are rejected" test already proves for the
+            // raw codec (same field id, `0x9abc`, reused here).
+            var plaintext_buf: [2048]u8 = undefined;
+            const plaintext = try session.encodeServer(&state, session.Limits.default, &plaintext_buf);
+            var extended_buf: [2048 + 64]u8 = undefined;
+            const extended = extended_buf[0..appendTlv(plaintext, 0x9abc, "future-extension-data", &extended_buf)];
+            var envelope_buf: [2048 + 64]u8 = undefined;
+            const nonce = [_]u8{0x91} ** provider.aead_nonce_len;
+            const envelope = try sealPlaintextWithProvider(fresh_provider, &envelope_buf, selected_aead, active_id, active_key, nonce, extended);
+            try expectRoundTrip(&protector, zero_alloc.allocator(), &state, envelope, resolve_now_unix_ms);
+            try observer.expectOnly(.resolve_succeeded);
+        },
+        8 => {
             // `issued_at_unix_ms` strictly after `resolve_now_unix_ms`.
             var timed_state = try buildTimedServerState(allocator, resolve_now_unix_ms + 5_000, 10);
             defer timed_state.deinit();
@@ -3902,7 +3978,6 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
     // keyring's.
     var failing_keyring_alloc = testing.FailingAllocator.init(allocator, .{ .fail_index = smith.index(24) });
     var keyring = ReloadableKeyRing.init(failing_keyring_alloc.allocator());
-    defer keyring.deinit();
 
     // A passive zeroization safety net for the whole sequence:
     // `KeyDeinitProbe.record` (already used by `expectPartialBuildWipesCopiedKey`
@@ -3912,7 +3987,6 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
     // injected allocation failure.
     var key_probe = KeyDeinitProbe{};
     TestKeyDeinitProbeStorage.probe = &key_probe;
-    defer TestKeyDeinitProbeStorage.probe = null;
 
     var held: ?*Snapshot = null;
     var held_refs: usize = 0;
@@ -3920,20 +3994,42 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
     var held_fixture: KeyState = undefined;
     var held_key_fingerprint: KeyFingerprint = undefined;
     var held_outlived_current = false;
-    // A bounded program can terminate with more than one modeled owner
+    // A bounded program can terminate mid-sequence with modeled owners
     // still outstanding (e.g. install -> acquire -> retain -> end, leaving
-    // `held_refs == 2`): drain every one of them here, not just a single
-    // reference, so the "every reference is released exactly once"
-    // invariant holds even for an unfinished opcode stream. This runs
-    // before the `TestKeyDeinitProbeStorage.probe = null` defer above
-    // (Zig defers unwind LIFO), so the zeroization probe is still active
-    // to observe these final releases too.
-    defer if (held) |snap| {
-        while (held_refs != 0) {
-            held_refs -= 1;
-            snap.release();
+    // `held_refs == 2`) or with the held snapshot still `keyring.current`
+    // (never replaced), so this end-of-case cleanup has to prove the final
+    // wipe, not just avoid a leak:
+    //
+    // 1. Drain every modeled reference (`held_refs` down to 0).
+    // 2. *Then* tear the keyring down, releasing its own reference if the
+    //    held snapshot is still `keyring.current` -- whichever of these two
+    //    steps holds the true last reference performs the actual free.
+    // 3. Only once both have run, assert the snapshot deinitialized
+    //    exactly once (never zero -- a leak -- and never more than one --
+    //    a double free) and unconditionally wipe the stored fingerprint,
+    //    matching `secureZero`'s use everywhere else in this file rather
+    //    than relying on opcode 4 happening to run again.
+    // 4. Disable the zeroization probe last, so it stays installed through
+    //    both step 1 and step 2 -- with the original per-defer ordering
+    //    (probe disabled before `keyring.deinit()`) the probe missed
+    //    exactly the case where the held snapshot was still current at
+    //    teardown, since that path's true final release happens inside
+    //    `keyring.deinit()`.
+    defer {
+        const was_held = held != null;
+        if (held) |snap| {
+            while (held_refs != 0) {
+                held_refs -= 1;
+                snap.release();
+            }
         }
-    };
+        keyring.deinit();
+        if (was_held) {
+            std.debug.assert(held_deinit_count.load(.monotonic) == 1);
+            secrets.secureZero(&held_key_fingerprint);
+        }
+        TestKeyDeinitProbeStorage.probe = null;
+    }
 
     var last_generation: u64 = 0;
     var last_ledger_len: usize = 0;
@@ -3945,6 +4041,17 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
     var seen_nonces: [16][provider.aead_nonce_len]u8 = undefined;
     var seen_nonce_count: usize = 0;
     const seal_now_unix_ms: i64 = 500;
+
+    // A fresh per-case provider, per #376/#494's case-isolation contract:
+    // the shared static `testProvider()` is process-global state shared
+    // across every ordinary deterministic test in this file, and this
+    // target must not fold its result into that stream (even though these
+    // particular AEAD calls never draw entropy today, a future provider
+    // change should not be able to silently make this fuzz result order-
+    // dependent on whatever else happened to run first).
+    var seal_entropy = crypto.pure_zig.DeterministicEntropy.init(0x4b657972696e67);
+    var seal_provider_state = crypto.pure_zig.Provider.init(seal_entropy.entropy());
+    const seal_provider = seal_provider_state.cryptoProvider();
 
     const op_count = 1 + smith.index(8);
     for (0..op_count) |_| {
@@ -4063,7 +4170,7 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
                     // (`seal` never writes to the ledger on any path). A
                     // fresh per-case fault-injecting provider, not the
                     // shared static `testProvider()`, drives this.
-                    var faulting = FaultingSealProvider{ .inner = testProvider() };
+                    var faulting = FaultingSealProvider{ .inner = seal_provider };
                     var faulting_protector = Protector{ .provider = faulting.cryptoProvider(), .keyring = &keyring, .limits = session.Limits.default };
                     var ticket_buf: [512]u8 = undefined;
                     try testing.expectError(error.InvalidInternalState, faulting_protector.seal(allocator, &state, seal_now_unix_ms, &ticket_buf));
@@ -4075,7 +4182,7 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
                 }
 
                 var ticket_buf: [512]u8 = undefined;
-                var protector = Protector{ .provider = testProvider(), .keyring = &keyring, .limits = session.Limits.default };
+                var protector = Protector{ .provider = seal_provider, .keyring = &keyring, .limits = session.Limits.default };
                 if (protector.seal(allocator, &state, seal_now_unix_ms, &ticket_buf)) |sealed| {
                     var nonce: [provider.aead_nonce_len]u8 = undefined;
                     @memcpy(&nonce, sealed[24..36]);

--- a/src/tls/ticket_protection.zig
+++ b/src/tls/ticket_protection.zig
@@ -3600,27 +3600,77 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
         },
         6 => {
             // Authenticate a structurally corrupted `TRS1` record: encode a
-            // valid state, mutate its shared record header (magic/version/
-            // record-type/field-section-length), and re-seal the mutated
-            // bytes with the real key so AEAD authentication succeeds and
+            // valid state, mutate it, and re-seal the mutated bytes with
+            // the real key so AEAD authentication succeeds and
             // `resolveInner` reaches `session.decode`, which must reject it
-            // deterministically as `invalid_plaintext`.
+            // deterministically as `invalid_plaintext`. Covers the shared
+            // record header (magic/version/record-type/field-section-
+            // length) plus field-level TLV boundaries (duplicate/missing
+            // field, exact-width length under/over) via the promoted
+            // session-codec fixture-mutation helpers -- the same ones
+            // `session.zig`'s own deterministic suite already proves
+            // deterministically reject for every field in these sets, so
+            // reusing them here (rather than re-deriving the TLV shape)
+            // keeps this target's own job scoped to proving the
+            // *integration* boundary: that an authenticated malformed
+            // record of any of these classes reaches the resolver's public
+            // `invalid_plaintext` contract, not to re-litigating which
+            // classes are malformed.
             var plaintext_buf: [2048]u8 = undefined;
             const plaintext = try session.encodeServer(&state, session.Limits.default, &plaintext_buf);
-            var mutated_buf: [2048]u8 = undefined;
-            const mutated = mutated_buf[0..plaintext.len];
-            @memcpy(mutated, plaintext);
-            switch (smith.index(4)) {
-                0 => mutated[smith.index(4)] ^= 0xff, // magic
-                1 => mutated[4] +%= 1, // format_version
-                2 => mutated[5] = 0xff, // record_type: not a valid client(1)/server(2) tag
-                else => { // field_section_len off by one from the true remaining length
-                    var section_len = std.mem.readInt(u32, mutated[6..10], .big);
+
+            const duplicate_or_missing_ids = [_]u16{
+                session.field_cipher_suite,   session.field_resumption_psk,   session.field_auth_binding,
+                session.field_issued_at,      session.field_lifetime_seconds, session.field_early_data,
+                session.field_ticket_age_add,
+            };
+            const exact_width_ids = [_]u16{
+                session.field_cipher_suite,     session.field_auth_binding, session.field_issued_at,
+                session.field_lifetime_seconds, session.field_early_data,   session.field_ticket_age_add,
+            };
+
+            var mutated_buf: [2048 + 256]u8 = undefined;
+            var mutated: []u8 = undefined;
+            switch (smith.index(7)) {
+                0 => {
+                    mutated = mutated_buf[0..plaintext.len];
+                    @memcpy(mutated, plaintext);
+                    mutated[smith.index(4)] ^= 0xff; // magic
+                },
+                1 => {
+                    mutated = mutated_buf[0..plaintext.len];
+                    @memcpy(mutated, plaintext);
+                    mutated[4] +%= 1; // format_version
+                },
+                2 => {
+                    mutated = mutated_buf[0..plaintext.len];
+                    @memcpy(mutated, plaintext);
+                    mutated[5] = 0xff; // record_type: not a valid client(1)/server(2) tag
+                },
+                3 => {
+                    mutated = mutated_buf[0..plaintext.len];
+                    @memcpy(mutated, plaintext);
+                    var section_len = std.mem.readInt(u32, mutated[6..10], .big); // field_section_len off by one
                     section_len +%= 1;
                     std.mem.writeInt(u32, mutated[6..10], section_len, .big);
                 },
+                4 => { // duplicate a known field -- always `error.DuplicateField`
+                    const field_id = duplicate_or_missing_ids[smith.index(duplicate_or_missing_ids.len)];
+                    mutated = mutated_buf[0..session.fixtureWithFieldDuplicated(plaintext, field_id, &mutated_buf)];
+                },
+                5 => { // remove a mandatory field -- always `error.MissingField`
+                    const field_id = duplicate_or_missing_ids[smith.index(duplicate_or_missing_ids.len)];
+                    mutated = mutated_buf[0..session.fixtureWithFieldRemoved(plaintext, field_id, &mutated_buf)];
+                },
+                else => { // suite/PSK/lifetime/etc. exact-width field: 0 or one-over its true length
+                    const field_id = exact_width_ids[smith.index(exact_width_ids.len)];
+                    const original_len = session.originalTlvLen(plaintext, field_id).?;
+                    const new_length: u16 = if (smith.index(2) == 0) 0 else original_len + 1;
+                    mutated = mutated_buf[0..session.withTlvLengthOverride(plaintext, field_id, new_length, &mutated_buf)];
+                },
             }
-            var envelope_buf: [2048]u8 = undefined;
+
+            var envelope_buf: [2048 + 256]u8 = undefined;
             const nonce = [_]u8{0xab} ** provider.aead_nonce_len;
             const envelope = try sealPlaintextWithProvider(fresh_provider, &envelope_buf, selected_aead, active_id, active_key, nonce, mutated);
             try expectResolveFalseUnchanged(&protector, zero_alloc.allocator(), envelope, resolve_now_unix_ms);
@@ -3653,21 +3703,37 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
         },
     }
 
-    // Vary `protector.limits` around the exact envelope-length boundary.
-    // The raw `parseEnvelope` boundary is already exhaustively fuzzed at
-    // the parse layer by `fuzzParseEnvelopeMutation` (#494-A); this proves
-    // the same boundary integrates correctly through the full `resolve`
-    // path (`self.limits.validate()` then `parseEnvelope(identity,
-    // self.limits)`).
+    // Vary `protector.limits` around the exact envelope-length boundary
+    // (`parseEnvelope`, checked before authentication) and the exact
+    // decoded-state boundary (`session.decode`'s own `max_serialized_len`
+    // check, reached only *after* authentication succeeds). Both raw
+    // boundaries are already exhaustively fuzzed at their own parse/codec
+    // layers by `fuzzParseEnvelopeMutation` (#494-A) and session.zig's own
+    // codec target; this proves both integrate correctly through the full
+    // `resolve` path (`self.limits.validate()`, then `parseEnvelope`, then
+    // `session.decode(allocator, self.limits, plaintext)`).
     {
         var limits_probe = session.Limits.default;
-        switch (smith.index(3)) {
+        // `valid_envelope.len - envelope_overhead` is the exact plaintext
+        // length `state` encodes to, derived from the already-sealed
+        // envelope rather than re-deriving it.
+        const plaintext_len = valid_envelope.len - envelope_overhead;
+        var expect_rejected = false;
+        switch (smith.index(5)) {
             0 => {},
             1 => limits_probe.max_ticket_len = valid_envelope.len,
-            else => limits_probe.max_ticket_len = valid_envelope.len - 1,
+            2 => {
+                limits_probe.max_ticket_len = valid_envelope.len - 1;
+                expect_rejected = true;
+            },
+            3 => limits_probe.max_serialized_len = plaintext_len,
+            else => {
+                limits_probe.max_serialized_len = plaintext_len - 1;
+                expect_rejected = true;
+            },
         }
         var probe_protector = Protector{ .provider = fresh_provider, .keyring = &keyring, .limits = limits_probe };
-        if (limits_probe.max_ticket_len < valid_envelope.len) {
+        if (expect_rejected) {
             try expectResolveFalseUnchanged(&probe_protector, zero_alloc.allocator(), valid_envelope, resolve_now_unix_ms);
         } else {
             try expectRoundTrip(&probe_protector, zero_alloc.allocator(), &state, valid_envelope, resolve_now_unix_ms);
@@ -3730,6 +3796,79 @@ fn fuzzProtectorResolveInput(_: void, smith: *testing.Smith) !void {
     try fuzzProtectorResolve(testing.allocator, smith);
 }
 
+/// Wraps a real `CryptoProvider` but always fails `aeadSeal`, so
+/// `fuzzKeyringOperationSequence`'s "seal" opcode can drive the
+/// post-nonce-reservation failure contract: `NonceLease.reserve()` commits
+/// the nonce *before* `Protector.sealInner` calls `aeadSeal`, so a local
+/// provider fault after that point must still leave the nonce consumed
+/// (never reused or rolled back), even though the ticket itself is never
+/// produced. Every other operation delegates unchanged to the wrapped
+/// provider so this stays a true "one operation faults" injection rather
+/// than a stub.
+const FaultingSealProvider = struct {
+    inner: provider.CryptoProvider,
+
+    fn capabilities(ctx: *anyopaque) provider.Capabilities {
+        const self: *FaultingSealProvider = @ptrCast(@alignCast(ctx));
+        return self.inner.capabilities();
+    }
+    fn hkdfExtract(ctx: *anyopaque, hash: provider.Hash, salt: []const u8, ikm: []const u8, out: []u8) provider.HkdfError!void {
+        const self: *FaultingSealProvider = @ptrCast(@alignCast(ctx));
+        return self.inner.vtable.hkdfExtract(self.inner.context, hash, salt, ikm, out);
+    }
+    fn hkdfExpandLabel(ctx: *anyopaque, hash: provider.Hash, secret: []const u8, label: []const u8, hash_context: []const u8, out: []u8) provider.HkdfError!void {
+        const self: *FaultingSealProvider = @ptrCast(@alignCast(ctx));
+        return self.inner.vtable.hkdfExpandLabel(self.inner.context, hash, secret, label, hash_context, out);
+    }
+    fn aeadSeal(ctx: *anyopaque, aead: provider.Aead, key: []const u8, nonce: []const u8, associated_data: []const u8, plaintext: []const u8, ciphertext: []u8, tag: []u8) provider.SealError!void {
+        _ = ctx;
+        _ = aead;
+        _ = key;
+        _ = nonce;
+        _ = associated_data;
+        _ = plaintext;
+        _ = ciphertext;
+        _ = tag;
+        return error.InvalidInput;
+    }
+    fn aeadOpen(ctx: *anyopaque, aead: provider.Aead, key: []const u8, nonce: []const u8, associated_data: []const u8, ciphertext: []const u8, tag: []const u8, plaintext: []u8) provider.OpenError!void {
+        const self: *FaultingSealProvider = @ptrCast(@alignCast(ctx));
+        return self.inner.vtable.aeadOpen(self.inner.context, aead, key, nonce, associated_data, ciphertext, tag, plaintext);
+    }
+    fn quicHeaderProtectionMask(ctx: *anyopaque, hp: provider.QuicHeaderProtection, key: []const u8, sample: []const u8, mask: []u8) provider.QuicHeaderProtectionError!void {
+        const self: *FaultingSealProvider = @ptrCast(@alignCast(ctx));
+        return self.inner.vtable.quicHeaderProtectionMask(self.inner.context, hp, key, sample, mask);
+    }
+    fn generateKeyShare(ctx: *anyopaque, group: provider.Group, public_out: []u8, private_out: []u8) provider.KeyShareError!void {
+        const self: *FaultingSealProvider = @ptrCast(@alignCast(ctx));
+        return self.inner.vtable.generateKeyShare(self.inner.context, group, public_out, private_out);
+    }
+    fn deriveSharedSecret(ctx: *anyopaque, group: provider.Group, private_scalar: []const u8, peer_public: []const u8, out: []u8) provider.DeriveError!void {
+        const self: *FaultingSealProvider = @ptrCast(@alignCast(ctx));
+        return self.inner.vtable.deriveSharedSecret(self.inner.context, group, private_scalar, peer_public, out);
+    }
+    fn verify(ctx: *anyopaque, scheme: provider.SignatureScheme, public_key: []const u8, message: []const u8, signature: []const u8) provider.VerifyError!void {
+        const self: *FaultingSealProvider = @ptrCast(@alignCast(ctx));
+        return self.inner.vtable.verify(self.inner.context, scheme, public_key, message, signature);
+    }
+
+    const vtable = provider.CryptoProvider.VTable{
+        .capabilities = capabilities,
+        .hkdfExtract = hkdfExtract,
+        .hkdfExpandLabel = hkdfExpandLabel,
+        .aeadSeal = aeadSeal,
+        .aeadOpen = aeadOpen,
+        .quicHeaderProtectionMask = quicHeaderProtectionMask,
+        .generateKeyShare = generateKeyShare,
+        .deriveSharedSecret = deriveSharedSecret,
+        .verify = verify,
+    };
+
+    fn cryptoProvider(self: *FaultingSealProvider) provider.CryptoProvider {
+        return .{ .context = self, .vtable = &vtable, .entropy = self.inner.entropy };
+    }
+};
+
 /// #494-B: bounded operation-sequence target over `Snapshot.build`,
 /// `ReloadableKeyRing.install`/`validateInstallCandidate`/`acquireCurrent`,
 /// `Snapshot.retain`/`release`, and `Protector.seal`. `fuzzSnapshotConfig`
@@ -3779,8 +3918,22 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
     var held_refs: usize = 0;
     var held_deinit_count = std.atomic.Value(usize).init(0);
     var held_fixture: KeyState = undefined;
+    var held_key_fingerprint: KeyFingerprint = undefined;
     var held_outlived_current = false;
-    defer if (held) |snap| snap.release();
+    // A bounded program can terminate with more than one modeled owner
+    // still outstanding (e.g. install -> acquire -> retain -> end, leaving
+    // `held_refs == 2`): drain every one of them here, not just a single
+    // reference, so the "every reference is released exactly once"
+    // invariant holds even for an unfinished opcode stream. This runs
+    // before the `TestKeyDeinitProbeStorage.probe = null` defer above
+    // (Zig defers unwind LIFO), so the zeroization probe is still active
+    // to observe these final releases too.
+    defer if (held) |snap| {
+        while (held_refs != 0) {
+            held_refs -= 1;
+            snap.release();
+        }
+    };
 
     var last_generation: u64 = 0;
     var last_ledger_len: usize = 0;
@@ -3797,9 +3950,23 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
     for (0..op_count) |_| {
         switch (smith.index(6)) {
             0 => { // (re)install the active key with an advanced, non-overlapping lease window
-                const start = next_lease_start;
-                const end = start + lease_chunk;
-                next_lease_start = end;
+                // Occasionally install a lease window pinned at the very
+                // top of the `u64` counter space instead of the normal
+                // small advancing range, so the "seal" opcode below gets a
+                // chance to exercise the exact boundary `reserve()` guards
+                // against wraparound at (`current == maxInt(u64)`, and the
+                // one-nonce-then-exhausted transition it produces, not just
+                // the small-integer exhaustion the advancing range already
+                // covers. This permanently high-waters this id's ledger
+                // entry to `maxInt(u64)`, so any later ordinary-range
+                // install of the same id deterministically (and correctly)
+                // rejects as `OverlappingNonceLease` for the rest of this
+                // bounded program -- already handled by the same
+                // catch/continue every other install rejection uses below.
+                const near_wrap = smith.index(8) == 0;
+                const start: u64 = if (near_wrap) std.math.maxInt(u64) - 1 else next_lease_start;
+                const end: u64 = if (near_wrap) std.math.maxInt(u64) else start + lease_chunk;
+                if (!near_wrap) next_lease_start = end;
                 const config = KeyConfig{
                     .id = keyId(0xc1),
                     .aead = .aes_128_gcm,
@@ -3842,6 +4009,7 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
                             .decrypt_until_unix_ms = snap.keys[0].decrypt_until_unix_ms,
                             .lease = leaseStateFromKey(&snap.keys[0]),
                         };
+                        held_key_fingerprint = fingerprintKey(snap.keys[0].aead, snap.keys[0].key.slice());
                     }
                 }
             },
@@ -3853,6 +4021,7 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
             },
             4 => { // release one modeled reference
                 if (held) |snap| {
+                    const key_wipes_before = key_probe.observed;
                     snap.release();
                     held_refs -= 1;
                     if (held_refs == 0) {
@@ -3860,15 +4029,52 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
                             @as(usize, if (held_outlived_current) 1 else 0),
                             held_deinit_count.load(.monotonic),
                         );
+                        // Only the *final* modeled reference actually frees
+                        // the snapshot (and, since this fixture is always a
+                        // single-key snapshot, wipes exactly one key
+                        // record): if this was the last owner, the
+                        // zeroization probe must have fired exactly once
+                        // for this release, never zero (a leaked/never-wiped
+                        // key) and never more than one (a double free/wipe).
+                        if (held_outlived_current) {
+                            try testing.expectEqual(@as(usize, 1), key_probe.observed - key_wipes_before);
+                        } else {
+                            try testing.expectEqual(key_wipes_before, key_probe.observed);
+                        }
                         held = null;
+                        secrets.secureZero(&held_key_fingerprint);
                     }
                 }
             },
-            else => { // reserve a nonce; expect deterministic exhaustion once the lease window is spent
-                var ticket_buf: [512]u8 = undefined;
+            else => { // reserve a nonce: uniqueness, deterministic exhaustion (including near-wrap), and the post-reservation provider-fault contract
                 const before = captureKeyringState(&keyring);
                 const ticket = keyring.current != null and keyring.current.?.keys[0].nonce_lease != null;
                 if (!ticket) continue;
+                const counter_before = keyring.current.?.keys[0].nonce_lease.?.next_counter.load(.acquire);
+                const has_room = counter_before < keyring.current.?.keys[0].nonce_lease.?.currentEnd();
+
+                if (has_room and smith.index(5) == 0) {
+                    // `NonceLease.reserve()` commits the nonce *before*
+                    // `Protector.sealInner` ever calls `aeadSeal`, so a
+                    // local provider fault at that point must still leave
+                    // the counter advanced by exactly one -- the documented
+                    // "never reuse a nonce, even on local failure" contract
+                    // -- and must not touch any other publication state
+                    // (`seal` never writes to the ledger on any path). A
+                    // fresh per-case fault-injecting provider, not the
+                    // shared static `testProvider()`, drives this.
+                    var faulting = FaultingSealProvider{ .inner = testProvider() };
+                    var faulting_protector = Protector{ .provider = faulting.cryptoProvider(), .keyring = &keyring, .limits = session.Limits.default };
+                    var ticket_buf: [512]u8 = undefined;
+                    try testing.expectError(error.InvalidInternalState, faulting_protector.seal(allocator, &state, seal_now_unix_ms, &ticket_buf));
+                    const counter_after = keyring.current.?.keys[0].nonce_lease.?.next_counter.load(.acquire);
+                    try testing.expectEqual(counter_before + 1, counter_after);
+                    try testing.expectEqual(before.current, keyring.current);
+                    try testing.expectEqual(before.ledger_len, keyring.ledger.items.len);
+                    continue;
+                }
+
+                var ticket_buf: [512]u8 = undefined;
                 var protector = Protector{ .provider = testProvider(), .keyring = &keyring, .limits = session.Limits.default };
                 if (protector.seal(allocator, &state, seal_now_unix_ms, &ticket_buf)) |sealed| {
                     var nonce: [provider.aead_nonce_len]u8 = undefined;
@@ -3881,7 +4087,15 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
                         seen_nonce_count += 1;
                     }
                 } else |err| {
-                    try testing.expect(err == error.NonceLeaseExhausted or err == error.NoActiveEncryptionKey or err == error.AmbiguousActiveEncryptionKey);
+                    // With this fixture (a single key whose time window
+                    // always covers `seal_now_unix_ms`, guarded above by
+                    // `ticket`), the only normal terminal failure is lease
+                    // exhaustion, including right at the `maxInt(u64)`
+                    // boundary the near-wrap install above sometimes
+                    // produces -- accepting the other two errors here would
+                    // silently mask an unexpected active-key-selection
+                    // regression instead of failing loudly.
+                    try testing.expectEqual(error.NonceLeaseExhausted, err);
                     try expectKeyringStateEqual(before, &keyring);
                 }
             },
@@ -3890,32 +4104,48 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
         try testing.expect(keyring.ledger.items.len >= last_ledger_len);
         last_ledger_len = keyring.ledger.items.len;
         if (held) |snap| {
-            if (keyring.current != snap) held_outlived_current = true;
+            // The moment `keyring.current` first moves away from `snap`,
+            // this is still a single-threaded sequence and no later
+            // `Protector.seal` can legally reach `snap`'s lease anymore
+            // (`seal` always reserves against `acquireCurrent()`, which now
+            // returns a different snapshot) -- so the lease's `next_counter`
+            // stops moving on its own from this exact point on. Capture
+            // that stopping value right here, once, rather than comparing
+            // against the original acquire-time value: `seal` calls issued
+            // *before* this transition legitimately advanced the counter
+            // while `snap` was still current, so only the value at the
+            // transition itself is the correct freeze point.
+            const key = &snap.keys[0];
+            if (keyring.current != snap and !held_outlived_current) {
+                held_outlived_current = true;
+                if (key.nonce_lease) |*lease| held_fixture.lease.next_counter = lease.next_counter.load(.acquire);
+            }
             try testing.expectEqual(@as(usize, 0), held_deinit_count.load(.monotonic));
             // Every field of the held key record is frozen -- it belongs to
             // a published, immutable `Snapshot` that is never mutated in
-            // place -- *except* its nonce lease's `next_counter`, which is
-            // a live atomic that legitimately keeps advancing via `seal`
-            // for as long as this snapshot is still `keyring.current`
-            // (`seal` always reserves against `acquireCurrent()`, not
-            // `held`); it stops moving on its own once a replacing install
-            // takes `keyring.current` elsewhere, since no later `seal` can
-            // reach it, but there is no single "value at the moment of
-            // transition" to freeze to here -- the fixture was captured once
-            // at acquire time, so the only invariant that holds for every
-            // observation in between is monotonic non-decrease against that
-            // original value (never a reset/decrease), not exact equality.
-            const key = &snap.keys[0];
+            // place -- including the secret key material itself, compared
+            // here via the same constant-time fingerprint the keyring's own
+            // ledger uses, so a premature wipe or corruption while retained
+            // is caught immediately rather than only at final release
+            // (`KeyDeinitProbe` only proves bytes are zero *at* deinit, not
+            // that they were still live a moment before it).
             try testing.expectEqualSlices(u8, &held_fixture.id, &key.id);
             try testing.expectEqual(held_fixture.aead, key.aead);
             try testing.expectEqual(held_fixture.not_before_unix_ms, key.not_before_unix_ms);
             try testing.expectEqual(held_fixture.encrypt_until_unix_ms, key.encrypt_until_unix_ms);
             try testing.expectEqual(held_fixture.decrypt_until_unix_ms, key.decrypt_until_unix_ms);
+            var current_fingerprint = fingerprintKey(key.aead, key.key.slice());
+            defer secrets.secureZero(&current_fingerprint);
+            try testing.expect(secrets.constantTimeEqual(&held_key_fingerprint, &current_fingerprint));
             try testing.expectEqual(held_fixture.lease.has_lease, key.nonce_lease != null);
             if (key.nonce_lease) |*lease| {
                 try testing.expectEqualSlices(u8, &held_fixture.lease.prefix, &lease.prefix);
                 try testing.expectEqual(held_fixture.lease.end_exclusive, lease.currentEnd());
-                try testing.expect(lease.next_counter.load(.acquire) >= held_fixture.lease.next_counter);
+                if (held_outlived_current) {
+                    try testing.expectEqual(held_fixture.lease.next_counter, lease.next_counter.load(.acquire));
+                } else {
+                    try testing.expect(lease.next_counter.load(.acquire) >= held_fixture.lease.next_counter);
+                }
             }
         }
     }

--- a/src/tls/ticket_protection.zig
+++ b/src/tls/ticket_protection.zig
@@ -3708,7 +3708,21 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
 
             var mutated_buf: [2048 + 256]u8 = undefined;
             var mutated: []u8 = undefined;
-            switch (smith.index(11)) {
+            // The declaration-only-truncation case is deliberately gated by
+            // its own small, independent choice rather than folded in as
+            // one value of a large N-way switch: a low-cardinality gate is
+            // both easier for a coverage-guided fuzzer to reach quickly and
+            // easier to force with a short, checked-in deterministic
+            // corpus entry (see the seed list below) than hoping a single
+            // wide `smith.index` call happens to land on one specific high
+            // value among many.
+            if (smith.index(4) == 0) {
+                // declared length far exceeds the bytes actually provided -- a truncation, not a 64 KiB allocation
+                const field_id = duplicate_or_missing_ids[smith.index(duplicate_or_missing_ids.len)];
+                var without_field_buf: [2048 + 256]u8 = undefined;
+                const without_field_len = session.fixtureWithFieldRemoved(plaintext, field_id, &without_field_buf);
+                mutated = mutated_buf[0..appendTruncatedTlvHeader(without_field_buf[0..without_field_len], field_id, 0xffff, &mutated_buf)];
+            } else switch (smith.index(11)) {
                 0 => {
                     mutated = mutated_buf[0..plaintext.len];
                     @memcpy(mutated, plaintext);
@@ -3747,7 +3761,7 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
                         1 => 0,
                         else => original_len + 1,
                     };
-                    mutated = mutated_buf[0..session.withTlvLengthOverride(plaintext, field_id, new_length, &mutated_buf)];
+                    mutated = mutated_buf[0..try session.withTlvLengthOverride(plaintext, field_id, new_length, &mutated_buf)];
                 },
                 7 => { // unknown *critical* field (high bit clear) -- always `error.UnknownCriticalField`
                     mutated = mutated_buf[0..appendTlv(plaintext, 0x00ff, "unrecognized-critical-data", &mutated_buf)];
@@ -3760,24 +3774,18 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
                         2 => original_len + 1,
                         else => provider.max_digest_len,
                     };
-                    mutated = mutated_buf[0..session.withTlvLengthOverride(plaintext, session.field_resumption_psk, new_length, &mutated_buf)];
+                    mutated = mutated_buf[0..try session.withTlvLengthOverride(plaintext, session.field_resumption_psk, new_length, &mutated_buf)];
                 },
                 9 => { // unknown (unassigned) cipher-suite wire value -- always `error.InvalidCipherSuite`
                     mutated = mutated_buf[0..withCipherSuiteValue(plaintext, 0x9999, &mutated_buf)];
                 },
-                10 => { // a *supported* suite id whose transcript-hash length disagrees with the
+                else => { // a *supported* suite id whose transcript-hash length disagrees with the
                     // unchanged, authenticated PSK bytes that follow it -- `state`'s own SHA-256
                     // suite paired with the SHA-384 suite id -- always `error.InvalidPskLength`.
                     // The reverse pairing (SHA-256 suite against a wrong-length PSK) is exercised
                     // by the PSK length boundary case above; scenario 8 in the outer switch proves
                     // the *accepted* SHA-384-suite/48-byte-PSK pairing this contrasts against.
                     mutated = mutated_buf[0..withCipherSuiteValue(plaintext, 0x1302, &mutated_buf)];
-                },
-                else => { // declared length far exceeds the bytes actually provided -- a truncation, not a 64 KiB allocation
-                    const field_id = duplicate_or_missing_ids[smith.index(duplicate_or_missing_ids.len)];
-                    var without_field_buf: [2048 + 256]u8 = undefined;
-                    const without_field_len = session.fixtureWithFieldRemoved(plaintext, field_id, &without_field_buf);
-                    mutated = mutated_buf[0..appendTruncatedTlvHeader(without_field_buf[0..without_field_len], field_id, 0xffff, &mutated_buf)];
                 },
             }
 
@@ -3927,14 +3935,35 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
 }
 
 test "fuzz: TLS resumption: Protector.resolve authenticates, rejects, and never leaks plaintext under key-state and envelope mutation" {
-    try testing.fuzz({}, fuzzProtectorResolveInput, .{ .corpus = &.{
-        "",
-        &[_]u8{0},
-        &[_]u8{1},
-        &[_]u8{2},
-        &[_]u8{ 0, 1, 2, 3, 4, 5, 6, 7, 8 },
-        &([_]u8{0xff} ** 9),
-    } });
+    try testing.fuzz({}, fuzzProtectorResolveInput, .{
+        .corpus = &.{
+            "",
+            &[_]u8{0},
+            &[_]u8{1},
+            &[_]u8{2},
+            &[_]u8{ 0, 1, 2, 3, 4, 5, 6, 7, 8 },
+            &([_]u8{0xff} ** 9),
+            // Deterministically forces the declaration-only-truncation arm of
+            // case 6's mutation matrix (`if (smith.index(4) == 0)`), rather
+            // than relying on a coverage-guided run to stumble onto it. Hand-
+            // derived from `std.testing.Smith`'s corpus-replay contract
+            // (`valueWeightedWithHashInner` in Zig 0.16's `Smith.zig`): each
+            // `index(n)` call under replay reads the *next* 8 bytes of the
+            // corpus entry as a little-endian `u64` and uses it verbatim if it
+            // already falls in `[0, n)` (defaulting to 0 once the bytes run
+            // out or fall outside that range), so this is four consecutive
+            // 8-byte little-endian words -- `1` (any valid AEAD index), `6`
+            // (the case-6 scenario, i.e. `invalid_plaintext`'s authenticated
+            // mutation matrix), `0` (the truncation gate), `0` (any valid
+            // field-id index) -- not an opaque fuzzer-minimized blob.
+            &[_]u8{
+                1, 0, 0, 0, 0, 0, 0, 0,
+                6, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+            },
+        },
+    });
 }
 
 fn fuzzProtectorResolveInput(_: void, smith: *testing.Smith) !void {
@@ -4062,6 +4091,7 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
     var held_deinit_count = std.atomic.Value(usize).init(0);
     var held_fixture: KeyState = undefined;
     var held_key_fingerprint: KeyFingerprint = undefined;
+    var tracked_generation: u64 = undefined;
     var held_outlived_current = false;
     // Set once, on the *first* successful acquire, and never reset --
     // unlike `held`, which opcode 4 sets back to `null` the moment the
@@ -4071,8 +4101,20 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
     // assertion below on `held != null` at teardown would miss exactly
     // that case; this flag means "a snapshot was instrumented and its
     // eventual wipe still needs proving," independent of whether a modeled
-    // owner happens to still be outstanding right now.
+    // owner happens to still be outstanding right now. Also makes opcode 2
+    // a one-shot acquire (see below), so `held_deinit_count`/
+    // `held_key_fingerprint` are only ever wired to a single snapshot for
+    // the whole program -- never repointed at a second one mid-run, which
+    // would silently erase whatever the first snapshot's final release had
+    // or had not yet proven.
     var tracked_snapshot = false;
+    // Set at the exact operation that observes the tracked snapshot's true
+    // final reference drop (opcode 4 releasing while already outlived, or
+    // the install-replacement bracket below), so the teardown code neither
+    // re-checks an already-verified release nor mis-attributes a *later*,
+    // untracked snapshot's key-wipe delta to the one this program
+    // instrumented.
+    var tracked_finalized = false;
     // A bounded program can terminate mid-sequence with modeled owners
     // still outstanding (e.g. install -> acquire -> retain -> end) or with
     // the held snapshot still `keyring.current` (never replaced), so
@@ -4155,6 +4197,17 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
                     .nonce_lease = .{ .prefix = .{ 0xc1, 0, 0, 0 }, .start = start, .end_exclusive = end },
                 };
                 const before = captureKeyringState(&keyring);
+                // If the tracked snapshot is currently unheld (no modeled
+                // owner) and still `keyring.current`, this install -- if it
+                // succeeds -- performs its true final release (a fresh
+                // `Snapshot.build` always produces a new pointer/generation,
+                // so a successful install always replaces `before.current`).
+                // Bracket the key-wipe delta around exactly that operation
+                // rather than leaving it for teardown to (mis)attribute
+                // later, once other installs may have moved on further.
+                const watching = tracked_snapshot and !tracked_finalized and held == null and
+                    before.current != null and before.current_generation == tracked_generation;
+                const wipes_before = if (watching) key_probe.observed else 0;
                 const snapshot = keyring.buildSnapshot(&.{config}, testCapabilities()) catch continue;
                 keyring.install(snapshot) catch {
                     try expectKeyringStateEqual(before, &keyring);
@@ -4162,6 +4215,11 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
                 };
                 try testing.expect(keyring.current.?.generation > last_generation);
                 last_generation = keyring.current.?.generation;
+                if (watching) {
+                    try testing.expectEqual(@as(usize, 1), held_deinit_count.load(.monotonic));
+                    try testing.expectEqual(@as(usize, 1), key_probe.observed - wipes_before);
+                    tracked_finalized = true;
+                }
             },
             1 => { // dry-run validate must never mutate published state
                 const config = sampleKeyConfigWithByte(keyId(0xc2), .aes_256_gcm, null, 0x22);
@@ -4171,8 +4229,14 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
                 keyring.validateInstallCandidate(candidate) catch {};
                 try expectKeyringStateEqual(before, &keyring);
             },
-            2 => { // acquire current, hold across subsequent ops
-                if (held == null) {
+            2 => { // acquire current, hold across subsequent ops -- at most once per program
+                // Instrumenting a *second* snapshot would repoint
+                // `snap.deinit_count`/re-seed `held_key_fingerprint` at the
+                // new one, silently erasing whatever the first snapshot's
+                // final release had (or had not yet) proven; `!tracked_snapshot`
+                // (never reset, unlike `held`) makes this a one-shot
+                // acquire per program instead.
+                if (!tracked_snapshot) {
                     if (keyring.acquireCurrent()) |snap| {
                         held_deinit_count = std.atomic.Value(usize).init(0);
                         snap.deinit_count = &held_deinit_count;
@@ -4189,6 +4253,7 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
                             .lease = leaseStateFromKey(&snap.keys[0]),
                         };
                         held_key_fingerprint = fingerprintKey(snap.keys[0].aead, snap.keys[0].key.slice());
+                        tracked_generation = snap.generation;
                     }
                 }
             },
@@ -4217,6 +4282,7 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
                         // key) and never more than one (a double free/wipe).
                         if (held_outlived_current) {
                             try testing.expectEqual(@as(usize, 1), key_probe.observed - key_wipes_before);
+                            tracked_finalized = true;
                         } else {
                             try testing.expectEqual(key_wipes_before, key_probe.observed);
                         }
@@ -4338,24 +4404,32 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
     // failure via `testing.expectEqual` rather than a `std.debug.assert`
     // (which lowers through `unreachable` and so is not a reliable runtime
     // check under `-Doptimize=ReleaseFast`), that it deinitialized exactly
-    // once: never zero (a leak) and never more than one (a double free).
-    // `tracked_snapshot` -- true from the first successful acquire, never
-    // reset -- covers this even when opcode 4 already dropped the last
-    // modeled reference earlier in the loop while the snapshot was still
-    // `keyring.current` (that inline release correctly observed
-    // `deinit_count == 0` and set `held = null`, since the snapshot was
-    // not actually freed yet; its true final release happens right here,
-    // inside `keyring.deinit()`, so gating this assertion on `held != null`
-    // at this point would silently skip verifying it).
+    // once (`Snapshot.deinit` fired) *and* wiped its key exactly once (the
+    // `key_probe` delta): never zero (a leak) and never more than one (a
+    // double free/wipe). `tracked_snapshot and !tracked_finalized` -- the
+    // latter set at whichever single operation (opcode 4's inline release,
+    // or the install-replacement bracket above) already observed and
+    // verified the tracked snapshot's true final reference drop -- covers
+    // the remaining case: it is still `keyring.current` with no further
+    // install ever having replaced it, so this `keyring.deinit()` call is
+    // the one that finally performs (and here verifies) that release. When
+    // `tracked_finalized` is already true, the earlier bracket already
+    // proved the wipe, so this deliberately does not re-check: a *later*,
+    // untracked snapshot may be whatever `keyring.deinit()` frees here, and
+    // attributing its key-wipe delta to the original tracked snapshot would
+    // be a false attribution, not a real verification.
     if (held) |snap| {
         while (held_refs != 0) {
             held_refs -= 1;
             snap.release();
         }
     }
+    const watching = tracked_snapshot and !tracked_finalized;
+    const wipes_before = if (watching) key_probe.observed else 0;
     keyring.deinit();
-    if (tracked_snapshot) {
+    if (watching) {
         try testing.expectEqual(@as(usize, 1), held_deinit_count.load(.monotonic));
+        try testing.expectEqual(@as(usize, 1), key_probe.observed - wipes_before);
     }
     secrets.secureZero(&held_key_fingerprint);
     TestKeyDeinitProbeStorage.probe = null;

--- a/src/tls/ticket_protection.zig
+++ b/src/tls/ticket_protection.zig
@@ -3447,6 +3447,29 @@ fn buildTimedServerState(allocator: std.mem.Allocator, issued_at_unix_ms: i64, l
     return state;
 }
 
+/// A valid `.tls_aes_256_gcm_sha384` state with the SHA-384-length (48
+/// byte) PSK that suite requires, proving the accepted-pairing side of
+/// #494-B's suite/PSK routing requirement: `state`/`sentinelServerState`
+/// elsewhere in this file are always the SHA-256 suite, so every
+/// mismatched-pairing rejection case needs a genuine SHA-384 acceptance to
+/// contrast against, not just another rejection.
+fn buildSha384ServerState(allocator: std.mem.Allocator) !session.ServerRecoverableState {
+    var common: session.ResumableSessionCommon = .{};
+    try common.init(allocator, session.Limits.default, .{
+        .cipher_suite = .tls_aes_256_gcm_sha384,
+        .resumption_psk = &([_]u8{0x55} ** 48),
+        .server_name = "sha384.example.test",
+        .application_protocol = "h3",
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer("sha384-leaf"),
+        .issued_at_unix_ms = 1_000,
+        .lifetime_seconds = 10,
+        .early_data = .resume_only,
+    });
+    var state: session.ServerRecoverableState = .{};
+    state.init(&common, 0x53484133);
+    return state;
+}
+
 /// Appends one real TLV (`field_id`/`value`) to `fixture` and patches the
 /// section length to match, for authenticating a state extended with an
 /// unknown field. `out` must have at least `fixture.len + 4 + value.len`
@@ -3479,6 +3502,26 @@ fn appendTruncatedTlvHeader(fixture: []const u8, field_id: u16, declared_length:
     pos += 4;
     std.mem.writeInt(u32, out[6..10], @intCast(pos - session.header_len), .big);
     return pos;
+}
+
+/// Replaces `fixture`'s `field_cipher_suite` TLV with one declaring the
+/// same field id but a caller-chosen raw wire value, composed from the two
+/// promoted helpers above (`fixtureWithFieldRemoved` then `appendTlv`)
+/// rather than needing a third "overwrite this field's value in place"
+/// primitive: field order is not semantically significant to `decode`
+/// (proved by session.zig's own "fields in different order" round-trip
+/// test), so moving the field to the end of the section is equivalent to
+/// mutating it in place. Drives #494-B's suite/PSK routing requirement:
+/// an unknown suite id, or a supported suite id whose transcript-hash
+/// length disagrees with the (unchanged) authenticated PSK bytes that
+/// follow it, both through the full authenticated resolver boundary
+/// rather than only the raw codec.
+fn withCipherSuiteValue(fixture: []const u8, new_suite_wire_value: u16, out: []u8) usize {
+    var without_suite_buf: [2048 + 256]u8 = undefined;
+    const without_suite_len = session.fixtureWithFieldRemoved(fixture, session.field_cipher_suite, &without_suite_buf);
+    var value_bytes: [2]u8 = undefined;
+    std.mem.writeInt(u16, &value_bytes, new_suite_wire_value, .big);
+    return appendTlv(without_suite_buf[0..without_suite_len], session.field_cipher_suite, &value_bytes, out);
 }
 
 /// #494-B: authenticated `Protector.resolve` under key-state, envelope, and
@@ -3593,7 +3636,7 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
     protector.observer = observer.observer();
 
     var zero_alloc = ZeroCheckingAllocator.init(allocator);
-    switch (smith.index(10)) {
+    switch (smith.index(11)) {
         0 => {
             try expectRoundTrip(&protector, zero_alloc.allocator(), &state, valid_envelope, resolve_now_unix_ms);
             try observer.expectOnly(.resolve_succeeded);
@@ -3665,7 +3708,7 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
 
             var mutated_buf: [2048 + 256]u8 = undefined;
             var mutated: []u8 = undefined;
-            switch (smith.index(9)) {
+            switch (smith.index(11)) {
                 0 => {
                     mutated = mutated_buf[0..plaintext.len];
                     @memcpy(mutated, plaintext);
@@ -3719,6 +3762,17 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
                     };
                     mutated = mutated_buf[0..session.withTlvLengthOverride(plaintext, session.field_resumption_psk, new_length, &mutated_buf)];
                 },
+                9 => { // unknown (unassigned) cipher-suite wire value -- always `error.InvalidCipherSuite`
+                    mutated = mutated_buf[0..withCipherSuiteValue(plaintext, 0x9999, &mutated_buf)];
+                },
+                10 => { // a *supported* suite id whose transcript-hash length disagrees with the
+                    // unchanged, authenticated PSK bytes that follow it -- `state`'s own SHA-256
+                    // suite paired with the SHA-384 suite id -- always `error.InvalidPskLength`.
+                    // The reverse pairing (SHA-256 suite against a wrong-length PSK) is exercised
+                    // by the PSK length boundary case above; scenario 8 in the outer switch proves
+                    // the *accepted* SHA-384-suite/48-byte-PSK pairing this contrasts against.
+                    mutated = mutated_buf[0..withCipherSuiteValue(plaintext, 0x1302, &mutated_buf)];
+                },
                 else => { // declared length far exceeds the bytes actually provided -- a truncation, not a 64 KiB allocation
                     const field_id = duplicate_or_missing_ids[smith.index(duplicate_or_missing_ids.len)];
                     var without_field_buf: [2048 + 256]u8 = undefined;
@@ -3753,6 +3807,21 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
             try observer.expectOnly(.resolve_succeeded);
         },
         8 => {
+            // The accepted-pairing side of the suite/PSK routing matrix
+            // below: a supported SHA-384 suite id with the 48-byte PSK it
+            // requires must authenticate, decode, and round-trip
+            // end-to-end through the resolver, not just fail to reject.
+            var sha384_state = try buildSha384ServerState(allocator);
+            defer sha384_state.deinit();
+            var plaintext_buf: [2048]u8 = undefined;
+            const plaintext = try session.encodeServer(&sha384_state, session.Limits.default, &plaintext_buf);
+            var envelope_buf: [2048]u8 = undefined;
+            const nonce = [_]u8{0x84} ** provider.aead_nonce_len;
+            const envelope = try sealPlaintextWithProvider(fresh_provider, &envelope_buf, selected_aead, active_id, active_key, nonce, plaintext);
+            try expectRoundTrip(&protector, zero_alloc.allocator(), &sha384_state, envelope, resolve_now_unix_ms);
+            try observer.expectOnly(.resolve_succeeded);
+        },
+        9 => {
             // `issued_at_unix_ms` strictly after `resolve_now_unix_ms`.
             var timed_state = try buildTimedServerState(allocator, resolve_now_unix_ms + 5_000, 10);
             defer timed_state.deinit();
@@ -3994,29 +4063,34 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
     var held_fixture: KeyState = undefined;
     var held_key_fingerprint: KeyFingerprint = undefined;
     var held_outlived_current = false;
+    // Set once, on the *first* successful acquire, and never reset --
+    // unlike `held`, which opcode 4 sets back to `null` the moment the
+    // last modeled reference is released even when the snapshot is still
+    // `keyring.current` and therefore not actually freed yet (that free
+    // happens later, inside `keyring.deinit()`). Gating the final-release
+    // assertion below on `held != null` at teardown would miss exactly
+    // that case; this flag means "a snapshot was instrumented and its
+    // eventual wipe still needs proving," independent of whether a modeled
+    // owner happens to still be outstanding right now.
+    var tracked_snapshot = false;
     // A bounded program can terminate mid-sequence with modeled owners
-    // still outstanding (e.g. install -> acquire -> retain -> end, leaving
-    // `held_refs == 2`) or with the held snapshot still `keyring.current`
-    // (never replaced), so this end-of-case cleanup has to prove the final
-    // wipe, not just avoid a leak:
-    //
-    // 1. Drain every modeled reference (`held_refs` down to 0).
-    // 2. *Then* tear the keyring down, releasing its own reference if the
-    //    held snapshot is still `keyring.current` -- whichever of these two
-    //    steps holds the true last reference performs the actual free.
-    // 3. Only once both have run, assert the snapshot deinitialized
-    //    exactly once (never zero -- a leak -- and never more than one --
-    //    a double free) and unconditionally wipe the stored fingerprint,
-    //    matching `secureZero`'s use everywhere else in this file rather
-    //    than relying on opcode 4 happening to run again.
-    // 4. Disable the zeroization probe last, so it stays installed through
-    //    both step 1 and step 2 -- with the original per-defer ordering
-    //    (probe disabled before `keyring.deinit()`) the probe missed
-    //    exactly the case where the held snapshot was still current at
-    //    teardown, since that path's true final release happens inside
-    //    `keyring.deinit()`.
-    defer {
-        const was_held = held != null;
+    // still outstanding (e.g. install -> acquire -> retain -> end) or with
+    // the held snapshot still `keyring.current` (never replaced), so
+    // end-of-case cleanup has to prove the final wipe, not just avoid a
+    // leak -- see the plain code after the opcode loop below, which drains,
+    // tears the keyring down, and only then asserts. That assertion needs
+    // `try testing.expectEqual` (a `std.debug.assert` lowers through
+    // `unreachable` under the documented `-Doptimize=ReleaseFast --fuzz`
+    // configuration, so the optimizer may treat it as an assumption to
+    // build on rather than a runtime check to report), which cannot run
+    // inside a bare `defer` block. This `errdefer` is therefore only the
+    // leak-prevention safety net for an early error return partway through
+    // the opcode loop (e.g. an invariant assertion elsewhere already
+    // failing) -- cleanup only, no redundant assertion, since the earlier
+    // failure is already this case's primary signal, and this never runs
+    // on the normal path (where the code below already tears everything
+    // down once).
+    errdefer {
         if (held) |snap| {
             while (held_refs != 0) {
                 held_refs -= 1;
@@ -4024,10 +4098,7 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
             }
         }
         keyring.deinit();
-        if (was_held) {
-            std.debug.assert(held_deinit_count.load(.monotonic) == 1);
-            secrets.secureZero(&held_key_fingerprint);
-        }
+        secrets.secureZero(&held_key_fingerprint);
         TestKeyDeinitProbeStorage.probe = null;
     }
 
@@ -4108,6 +4179,7 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
                         held = snap;
                         held_refs = 1;
                         held_outlived_current = false;
+                        tracked_snapshot = true;
                         held_fixture = .{
                             .id = snap.keys[0].id,
                             .aead = snap.keys[0].aead,
@@ -4256,6 +4328,37 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
             }
         }
     }
+
+    // Normal-path end-of-case cleanup, reached only once the whole opcode
+    // program above completed without an earlier failure (the `errdefer`
+    // near the top of this function is the safety net for that other
+    // case): drain every modeled reference, tear the keyring down --
+    // releasing its own reference too, if the instrumented snapshot is
+    // still `keyring.current` -- and only *then* assert, as a real fuzz
+    // failure via `testing.expectEqual` rather than a `std.debug.assert`
+    // (which lowers through `unreachable` and so is not a reliable runtime
+    // check under `-Doptimize=ReleaseFast`), that it deinitialized exactly
+    // once: never zero (a leak) and never more than one (a double free).
+    // `tracked_snapshot` -- true from the first successful acquire, never
+    // reset -- covers this even when opcode 4 already dropped the last
+    // modeled reference earlier in the loop while the snapshot was still
+    // `keyring.current` (that inline release correctly observed
+    // `deinit_count == 0` and set `held = null`, since the snapshot was
+    // not actually freed yet; its true final release happens right here,
+    // inside `keyring.deinit()`, so gating this assertion on `held != null`
+    // at this point would silently skip verifying it).
+    if (held) |snap| {
+        while (held_refs != 0) {
+            held_refs -= 1;
+            snap.release();
+        }
+    }
+    keyring.deinit();
+    if (tracked_snapshot) {
+        try testing.expectEqual(@as(usize, 1), held_deinit_count.load(.monotonic));
+    }
+    secrets.secureZero(&held_key_fingerprint);
+    TestKeyDeinitProbeStorage.probe = null;
 }
 
 test "fuzz: TLS resumption: ticket keyring install/validate/acquire/retain/release/seal sequence preserves generation, ledger, nonce, and reference invariants" {

--- a/src/tls/ticket_protection.zig
+++ b/src/tls/ticket_protection.zig
@@ -3399,71 +3399,159 @@ fn fuzzParseEnvelopeMutationInput(_: void, smith: *std.testing.Smith) !void {
     try fuzzParseEnvelopeMutation(smith);
 }
 
-/// #494-B: authenticated `Protector.resolve` under key-state and envelope
-/// mutation. Complements `fuzzTicketIdentity` above (which only proves miss
-/// paths never panic or mutate output against arbitrary bytes) by driving
-/// the accept path, every typed rejection reason, and an allocator-failure
-/// sweep against a *structurally valid* envelope, so mutation has a
-/// meaningful chance of landing on the authenticated-open boundary rather
-/// than being rejected by `parseEnvelope` before any key/AEAD work happens.
-/// Every scenario runs through `ZeroCheckingAllocator` to prove the
-/// temporary plaintext buffer is wiped before free on every path (accept,
-/// reject, and allocation failure alike), not just the miss path the
-/// existing deterministic "...zeroize plaintext before free" test names.
+/// Like `buildAuthenticatedEnvelope`, but takes an explicit provider
+/// instead of the shared static `testProvider()`, so `fuzzProtectorResolve`
+/// can forge authenticated envelopes under the same per-case
+/// `DeterministicEntropy`-backed provider it uses for `Protector.seal`/
+/// `resolve`, rather than mixing two separate provider instances within one
+/// fuzz case.
+fn sealPlaintextWithProvider(
+    provider_in: provider.CryptoProvider,
+    out: []u8,
+    aead: provider.Aead,
+    key_id: KeyId,
+    key: []const u8,
+    nonce: [provider.aead_nonce_len]u8,
+    plaintext: []const u8,
+) ![]const u8 {
+    const protected_len = envelope_overhead + plaintext.len;
+    if (out.len < protected_len) return error.BufferTooSmall;
+    writeHeader(out[0..fixed_header_len], aead, &key_id, &nonce);
+    var aad: [aad_prefix.len + fixed_header_len]u8 = undefined;
+    buildAad(out[0..fixed_header_len], &aad);
+    const ciphertext = out[fixed_header_len .. fixed_header_len + plaintext.len];
+    const tag = out[fixed_header_len + plaintext.len .. protected_len];
+    try provider_in.aeadSeal(aead, key, &nonce, &aad, plaintext, ciphertext, tag);
+    return out[0..protected_len];
+}
+
+/// A `ServerRecoverableState` with caller-controlled `issued_at`/`lifetime`,
+/// for forging authenticated tickets that land on `Protector.resolveInner`'s
+/// `isNotYetValid`/`isExpired` checks (which run after authenticated decode,
+/// not at the envelope/key layer, so they need a real encoded+resealed
+/// plaintext rather than a raw byte mutation).
+fn buildTimedServerState(allocator: std.mem.Allocator, issued_at_unix_ms: i64, lifetime_seconds: u32) !session.ServerRecoverableState {
+    var common: session.ResumableSessionCommon = .{};
+    try common.init(allocator, session.Limits.default, .{
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .resumption_psk = &([_]u8{0x77} ** 32),
+        .server_name = "timed.example.test",
+        .application_protocol = "h3",
+        .auth_binding = session.AuthBinding.fromLeafCertificateDer("timed-leaf"),
+        .issued_at_unix_ms = issued_at_unix_ms,
+        .lifetime_seconds = lifetime_seconds,
+        .early_data = .resume_only,
+    });
+    var state: session.ServerRecoverableState = .{};
+    state.init(&common, 0xdeadbeef);
+    return state;
+}
+
+/// #494-B: authenticated `Protector.resolve` under key-state, envelope, and
+/// authenticated-plaintext mutation. Complements `fuzzTicketIdentity` above
+/// (which only proves miss paths never panic or mutate output against
+/// arbitrary bytes) by driving the accept path, every typed rejection
+/// reason -- including the ones that require successfully authenticating
+/// first (`invalid_plaintext`, `not_yet_valid`, `expired`) -- and a full
+/// allocation-failure sweep, against structurally valid envelopes for all
+/// three required AEADs, each fuzz case using its own freshly constructed
+/// `pure_zig.DeterministicEntropy`-backed provider rather than the shared
+/// static `testProvider()`. Every scenario runs through
+/// `ZeroCheckingAllocator` to prove the temporary plaintext buffer is wiped
+/// before free on every path (accept, reject, and allocation failure
+/// alike), not just the miss path the existing deterministic "...zeroize
+/// plaintext before free" test names.
 fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith) !void {
+    const aead_choices = [_]provider.Aead{ .aes_128_gcm, .aes_256_gcm, .chacha20_poly1305 };
+    const selected_aead = aead_choices[smith.index(aead_choices.len)];
+    const cross_aead: provider.Aead = switch (selected_aead) {
+        .aes_128_gcm => .aes_256_gcm,
+        .aes_256_gcm => .chacha20_poly1305,
+        .chacha20_poly1305 => .aes_128_gcm,
+    };
+
+    // A fresh provider per case, per the #494-B contract: nothing in this
+    // target's actual code path draws entropy (AEAD seal/open are pure
+    // functions of key/nonce/aad/plaintext, and nonces come from the
+    // keyring's counter-based lease, not the provider), but constructing
+    // fresh state here rather than reaching for the shared static
+    // `testProvider()` keeps every target in this file honoring the same
+    // case-isolation discipline regardless of whether a given target
+    // happens to touch entropy today.
+    var entropy = crypto.pure_zig.DeterministicEntropy.init(0x494b2094);
+    var provider_state = crypto.pure_zig.Provider.init(entropy.entropy());
+    const fresh_provider = provider_state.cryptoProvider();
+
     const active_id = keyId(0xa1);
     const future_id = keyId(0xa2);
     const retired_id = keyId(0xa3);
     const other_aead_id = keyId(0xa4);
     const unknown_id = keyId(0xff);
 
+    var key_storage: [4][provider.max_aead_key_len]u8 = undefined;
+    for (&key_storage, [_]u8{ 0x11, 0x13, 0x10, 0x22 }) |*buf, tag| @memset(buf, tag);
+    const active_key = key_storage[0][0..selected_aead.keyLength()];
+
     var keyring = ReloadableKeyRing.init(allocator);
     defer keyring.deinit();
     const configs = [_]KeyConfig{
         // The only key with a nonce lease, so `seal` picks it unambiguously.
-        sampleKeyConfigWithByte(active_id, .aes_128_gcm, .{ .prefix = .{ 0xa1, 0, 0, 0 }, .start = 0, .end_exclusive = 8 }, 0x11),
+        // `decrypt_until_unix_ms` is generous (well beyond `resolve_now`
+        // below) so the forged not_yet_valid/expired tickets, whose
+        // `lifetime_seconds` pushes their nominal expiry far past the
+        // window `sampleKeyConfigWithByte`'s fixed windows would allow,
+        // stay inside the *key's* decrypt window -- only the *ticket's*
+        // own timestamps should trigger those two rejections.
+        .{
+            .id = active_id,
+            .aead = selected_aead,
+            .key_bytes = active_key,
+            .not_before_unix_ms = 0,
+            .encrypt_until_unix_ms = 5_000,
+            .decrypt_until_unix_ms = 5_000_000,
+            .nonce_lease = .{ .prefix = .{ 0xa1, 0, 0, 0 }, .start = 0, .end_exclusive = 64 },
+        },
         .{
             .id = future_id,
-            .aead = .aes_128_gcm,
-            .key_bytes = testKeyBytes(.aes_128_gcm, 0x13),
-            .not_before_unix_ms = 15_000,
-            .encrypt_until_unix_ms = 20_000,
-            .decrypt_until_unix_ms = 30_000,
+            .aead = selected_aead,
+            .key_bytes = key_storage[1][0..selected_aead.keyLength()],
+            .not_before_unix_ms = 50_000,
+            .encrypt_until_unix_ms = 60_000,
+            .decrypt_until_unix_ms = 5_000_000,
         },
         .{
             .id = retired_id,
-            .aead = .aes_128_gcm,
-            .key_bytes = testKeyBytes(.aes_128_gcm, 0x10),
+            .aead = selected_aead,
+            .key_bytes = key_storage[2][0..selected_aead.keyLength()],
             .not_before_unix_ms = 0,
             .encrypt_until_unix_ms = 500,
             .decrypt_until_unix_ms = 1_000,
         },
         .{
             .id = other_aead_id,
-            .aead = .aes_256_gcm,
-            .key_bytes = testKeyBytes(.aes_256_gcm, 0x22),
+            .aead = cross_aead,
+            .key_bytes = key_storage[3][0..cross_aead.keyLength()],
             .not_before_unix_ms = 0,
-            .encrypt_until_unix_ms = 20_000,
-            .decrypt_until_unix_ms = 30_000,
+            .encrypt_until_unix_ms = 5_000,
+            .decrypt_until_unix_ms = 5_000_000,
         },
     };
     try keyring.install(try keyring.buildSnapshot(&configs, testCapabilities()));
 
-    var state = try sampleServerState(allocator);
+    var state = try sentinelServerState(allocator);
     defer state.deinit();
-    var protector = Protector{ .provider = testProvider(), .keyring = &keyring, .limits = session.Limits.default };
-    var seal_buf: [1024]u8 = undefined;
-    // `active_id`'s window is `sampleKeyConfigWithByte`'s fixed
-    // `[1_000, 5_000)` encrypt / `[1_000, 20_000)` decrypt range, so sealing
-    // and resolving must use different instants: seal while the lease can
-    // still mint nonces, resolve later during the decrypt-only grace
-    // window (still `retained`, not `retired`) so the accept/round-trip
-    // scenario exercises the same grace-window path
+    var protector = Protector{ .provider = fresh_provider, .keyring = &keyring, .limits = session.Limits.default };
+    var seal_buf: [2048]u8 = undefined;
+    // `active_id`'s window is `[0, 5_000)` encrypt / `[0, 5_000_000)`
+    // decrypt, so sealing and resolving use different instants: seal
+    // while the lease can still mint nonces, resolve later during the
+    // decrypt-only grace window (still `retained`, not `retired`) so the
+    // accept/round-trip scenario exercises the same grace-window path
     // `"rotation: a resolve against a decrypt-only grace-window key..."`
-    // covers deterministically, but under Smith-driven envelope/key-state
-    // mutation instead of a single hand-picked case.
+    // covers deterministically, but under Smith-driven mutation across
+    // all three AEADs instead of a single hand-picked AES-128-GCM case.
     const seal_now_unix_ms: i64 = 2_000;
-    const now_unix_ms: i64 = 10_000;
+    const resolve_now_unix_ms: i64 = 10_000;
     const valid_envelope = try protector.seal(allocator, &state, seal_now_unix_ms, &seal_buf);
 
     var observer = TestObserver{};
@@ -3471,13 +3559,13 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
     protector.observer = observer.observer();
 
     var zero_alloc = ZeroCheckingAllocator.init(allocator);
-    switch (smith.index(6)) {
+    switch (smith.index(9)) {
         0 => {
-            try expectRoundTrip(&protector, zero_alloc.allocator(), &state, valid_envelope, now_unix_ms);
+            try expectRoundTrip(&protector, zero_alloc.allocator(), &state, valid_envelope, resolve_now_unix_ms);
             try observer.expectOnly(.resolve_succeeded);
         },
         1, 2, 3, 4 => |case| {
-            var tampered_buf: [1024]u8 = undefined;
+            var tampered_buf: [2048]u8 = undefined;
             const tampered = tampered_buf[0..valid_envelope.len];
             @memcpy(tampered, valid_envelope);
             const substituted = switch (case) {
@@ -3487,7 +3575,7 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
                 else => other_aead_id,
             };
             @memcpy(tampered[8..24], &substituted);
-            try expectResolveFalseUnchanged(&protector, zero_alloc.allocator(), tampered, now_unix_ms);
+            try expectResolveFalseUnchanged(&protector, zero_alloc.allocator(), tampered, resolve_now_unix_ms);
             const expected_reason: ResolveRejectReason = switch (case) {
                 1 => .unknown_key,
                 2 => .future_key,
@@ -3496,8 +3584,8 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
             };
             try observer.expectOnly(.{ .resolve_rejected = expected_reason });
         },
-        else => {
-            var tampered_buf: [1024]u8 = undefined;
+        5 => {
+            var tampered_buf: [2048]u8 = undefined;
             const tampered = tampered_buf[0..valid_envelope.len];
             @memcpy(tampered, valid_envelope);
             const region = smith.index(3);
@@ -3507,38 +3595,134 @@ fn fuzzProtectorResolve(allocator: std.mem.Allocator, smith: *std.testing.Smith)
                 else => tampered.len - tag_len + smith.index(tag_len), // tag
             };
             tampered[offset] ^= 0xff;
-            try expectResolveFalseUnchanged(&protector, zero_alloc.allocator(), tampered, now_unix_ms);
+            try expectResolveFalseUnchanged(&protector, zero_alloc.allocator(), tampered, resolve_now_unix_ms);
             try observer.expectOnly(.{ .resolve_rejected = .authentication_failed });
+        },
+        6 => {
+            // Authenticate a structurally corrupted `TRS1` record: encode a
+            // valid state, mutate its shared record header (magic/version/
+            // record-type/field-section-length), and re-seal the mutated
+            // bytes with the real key so AEAD authentication succeeds and
+            // `resolveInner` reaches `session.decode`, which must reject it
+            // deterministically as `invalid_plaintext`.
+            var plaintext_buf: [2048]u8 = undefined;
+            const plaintext = try session.encodeServer(&state, session.Limits.default, &plaintext_buf);
+            var mutated_buf: [2048]u8 = undefined;
+            const mutated = mutated_buf[0..plaintext.len];
+            @memcpy(mutated, plaintext);
+            switch (smith.index(4)) {
+                0 => mutated[smith.index(4)] ^= 0xff, // magic
+                1 => mutated[4] +%= 1, // format_version
+                2 => mutated[5] = 0xff, // record_type: not a valid client(1)/server(2) tag
+                else => { // field_section_len off by one from the true remaining length
+                    var section_len = std.mem.readInt(u32, mutated[6..10], .big);
+                    section_len +%= 1;
+                    std.mem.writeInt(u32, mutated[6..10], section_len, .big);
+                },
+            }
+            var envelope_buf: [2048]u8 = undefined;
+            const nonce = [_]u8{0xab} ** provider.aead_nonce_len;
+            const envelope = try sealPlaintextWithProvider(fresh_provider, &envelope_buf, selected_aead, active_id, active_key, nonce, mutated);
+            try expectResolveFalseUnchanged(&protector, zero_alloc.allocator(), envelope, resolve_now_unix_ms);
+            try observer.expectOnly(.{ .resolve_rejected = .invalid_plaintext });
+        },
+        7 => {
+            // `issued_at_unix_ms` strictly after `resolve_now_unix_ms`.
+            var timed_state = try buildTimedServerState(allocator, resolve_now_unix_ms + 5_000, 10);
+            defer timed_state.deinit();
+            var plaintext_buf: [2048]u8 = undefined;
+            const plaintext = try session.encodeServer(&timed_state, session.Limits.default, &plaintext_buf);
+            var envelope_buf: [2048]u8 = undefined;
+            const nonce = [_]u8{0xcd} ** provider.aead_nonce_len;
+            const envelope = try sealPlaintextWithProvider(fresh_provider, &envelope_buf, selected_aead, active_id, active_key, nonce, plaintext);
+            try expectResolveFalseUnchanged(&protector, zero_alloc.allocator(), envelope, resolve_now_unix_ms);
+            try observer.expectOnly(.{ .resolve_rejected = .not_yet_valid });
+        },
+        else => {
+            // `issued_at_unix_ms + lifetime_seconds` strictly before
+            // `resolve_now_unix_ms`.
+            var timed_state = try buildTimedServerState(allocator, 1, 1);
+            defer timed_state.deinit();
+            var plaintext_buf: [2048]u8 = undefined;
+            const plaintext = try session.encodeServer(&timed_state, session.Limits.default, &plaintext_buf);
+            var envelope_buf: [2048]u8 = undefined;
+            const nonce = [_]u8{0xef} ** provider.aead_nonce_len;
+            const envelope = try sealPlaintextWithProvider(fresh_provider, &envelope_buf, selected_aead, active_id, active_key, nonce, plaintext);
+            try expectResolveFalseUnchanged(&protector, zero_alloc.allocator(), envelope, resolve_now_unix_ms);
+            try observer.expectOnly(.{ .resolve_rejected = .expired });
         },
     }
 
-    // Bounded allocation-failure sweep against the unmodified valid
-    // envelope: every reachable allocation point must leave `out` either
-    // fully owned (fail_index landed after the last allocation `resolve`
-    // needed) or byte-identical to its pristine sentinel (fail_index landed
-    // on or before one), never a partially-populated state either way.
-    var sweep_zero = ZeroCheckingAllocator.init(allocator);
-    var failing = testing.FailingAllocator.init(sweep_zero.allocator(), .{ .fail_index = smith.index(6) });
-    var out: session.ServerRecoverableState = .{};
-    defer out.deinit();
-    if (protector.resolve(failing.allocator(), valid_envelope, now_unix_ms, &out)) |found| {
-        if (found) {
-            try expectServerStateEqual(&state, &out);
-        } else {
-            try testing.expectEqual(@as(usize, 0), out.common.resumption_psk.len);
+    // Vary `protector.limits` around the exact envelope-length boundary.
+    // The raw `parseEnvelope` boundary is already exhaustively fuzzed at
+    // the parse layer by `fuzzParseEnvelopeMutation` (#494-A); this proves
+    // the same boundary integrates correctly through the full `resolve`
+    // path (`self.limits.validate()` then `parseEnvelope(identity,
+    // self.limits)`).
+    {
+        var limits_probe = session.Limits.default;
+        switch (smith.index(3)) {
+            0 => {},
+            1 => limits_probe.max_ticket_len = valid_envelope.len,
+            else => limits_probe.max_ticket_len = valid_envelope.len - 1,
         }
-    } else |err| {
-        try testing.expectEqual(error.OutOfMemory, err);
-        try testing.expectEqual(@as(usize, 0), out.common.resumption_psk.len);
+        var probe_protector = Protector{ .provider = fresh_provider, .keyring = &keyring, .limits = limits_probe };
+        if (limits_probe.max_ticket_len < valid_envelope.len) {
+            try expectResolveFalseUnchanged(&probe_protector, zero_alloc.allocator(), valid_envelope, resolve_now_unix_ms);
+        } else {
+            try expectRoundTrip(&probe_protector, zero_alloc.allocator(), &state, valid_envelope, resolve_now_unix_ms);
+        }
     }
+
+    // A real transactional allocation-failure sweep: every reachable
+    // allocation point in `resolveInner` (measured at 5 for a fully
+    // populated `ServerRecoverableState` via a one-off local probe; 8
+    // leaves headroom for future fields) must leave `out` either fully
+    // owned (fail_index landed after the last allocation `resolve`
+    // needed) or byte-identical to a *non-empty* sentinel it started
+    // from -- proving no field (not just `resumption_psk`) was partially
+    // populated -- on every miss/error. A `deinit_count` probe on the
+    // keyring's live current snapshot proves the `acquireCurrent`/
+    // `release` pair inside `resolveInner` stays balanced under every
+    // injected failure: it must never reach zero here, since the keyring
+    // itself still holds its own reference throughout.
+    const max_resolve_fail_index: usize = 8;
+    var current_deinit_count = std.atomic.Value(usize).init(0);
+    if (keyring.acquireCurrent()) |snap| {
+        snap.deinit_count = &current_deinit_count;
+        snap.release();
+    }
+    for (0..max_resolve_fail_index + 1) |fail_index| {
+        var out = try sentinelServerState(allocator);
+        defer out.deinit();
+        var expected: session.ServerRecoverableState = .{};
+        try out.cloneInto(allocator, &expected);
+        defer expected.deinit();
+
+        var sweep_zero = ZeroCheckingAllocator.init(allocator);
+        var failing = testing.FailingAllocator.init(sweep_zero.allocator(), .{ .fail_index = fail_index });
+        if (protector.resolve(failing.allocator(), valid_envelope, resolve_now_unix_ms, &out)) |found| {
+            if (found) {
+                try expectServerStateEqual(&state, &out);
+            } else {
+                try expectServerStateEqual(&expected, &out);
+            }
+        } else |err| {
+            try testing.expectEqual(error.OutOfMemory, err);
+            try expectServerStateEqual(&expected, &out);
+        }
+    }
+    try testing.expectEqual(@as(usize, 0), current_deinit_count.load(.monotonic));
 }
 
 test "fuzz: TLS resumption: Protector.resolve authenticates, rejects, and never leaks plaintext under key-state and envelope mutation" {
     try testing.fuzz({}, fuzzProtectorResolveInput, .{ .corpus = &.{
         "",
         &[_]u8{0},
-        &[_]u8{ 0, 1, 2, 3, 4, 5 },
-        &([_]u8{0xff} ** 6),
+        &[_]u8{1},
+        &[_]u8{2},
+        &[_]u8{ 0, 1, 2, 3, 4, 5, 6, 7, 8 },
+        &([_]u8{0xff} ** 9),
     } });
 }
 
@@ -3548,38 +3732,83 @@ fn fuzzProtectorResolveInput(_: void, smith: *testing.Smith) !void {
 
 /// #494-B: bounded operation-sequence target over `Snapshot.build`,
 /// `ReloadableKeyRing.install`/`validateInstallCandidate`/`acquireCurrent`,
-/// and `Snapshot.retain`/`release`. `fuzzSnapshotConfig` above already
-/// exhaustively fuzzes the *static* properties of a single build/install
-/// call (every rejection reason, boundary window, and key count); this
-/// target instead fuzzes a short *program* of such calls interleaved with
-/// acquire/retain/release, asserting after every step that generation is
-/// monotonic, the ledger never shrinks, and a retained old snapshot stays
-/// fully intact (unwiped, unfreed) for as long as it is held, even across
-/// installs that replace it as `keyring.current` -- the temporal invariant
-/// the single-call target cannot exercise.
+/// `Snapshot.retain`/`release`, and `Protector.seal`. `fuzzSnapshotConfig`
+/// above already exhaustively fuzzes the *static* properties of a single
+/// build/install call (every rejection reason, boundary window, and key
+/// count); this target instead fuzzes a short *program* of such calls
+/// interleaved with acquire/retain/release and nonce-reserving seals,
+/// asserting after every step that generation is monotonic, the ledger
+/// never shrinks, nonces are never reused or reissued, a retained old
+/// snapshot's key/lease state stays byte-identical and unfreed for as long
+/// as it is held (even across installs that replace it as
+/// `keyring.current`), and it is wiped exactly once when the last
+/// reference -- acquired or explicitly retained -- is finally released.
 fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Smith) !void {
-    var keyring = ReloadableKeyRing.init(allocator);
+    // #494-B also requires OOM during `Snapshot.build`/ledger allocation/
+    // `validateInstallCandidate`/`install` to exercise copied-key/
+    // fingerprint cleanup and publication rollback. `ReloadableKeyRing`'s
+    // allocator is fixed at construction and reused for every internal
+    // allocation over the ring's whole lifetime -- there is no per-call
+    // override -- so the only way to inject a failure at an arbitrary
+    // point across a *sequence* of build/install/validate calls is to back
+    // the ring itself with a `FailingAllocator` whose `fail_index` Smith
+    // chooses once, up front: every allocation up to that point across the
+    // whole bounded program succeeds, and (per `FailingAllocator`'s "fails
+    // after N allocations" contract) every one from that point on fails
+    // deterministically, so the rest of the program keeps exercising the
+    // rejection/rollback path repeatedly rather than needing a separate
+    // one-shot opcode. `Protector.seal`'s own plaintext-buffer allocation
+    // uses the unwrapped `allocator` parameter directly (see the `seal`
+    // opcode below), so its allocation budget is independent of the
+    // keyring's.
+    var failing_keyring_alloc = testing.FailingAllocator.init(allocator, .{ .fail_index = smith.index(24) });
+    var keyring = ReloadableKeyRing.init(failing_keyring_alloc.allocator());
     defer keyring.deinit();
 
+    // A passive zeroization safety net for the whole sequence:
+    // `KeyDeinitProbe.record` (already used by `expectPartialBuildWipesCopiedKey`
+    // above) panics if any retained key byte is nonzero when a `KeyRecord`
+    // is wiped, whether that wipe comes from an ordinary replacement or
+    // from `Snapshot.build`'s partial-construction cleanup after an
+    // injected allocation failure.
+    var key_probe = KeyDeinitProbe{};
+    TestKeyDeinitProbeStorage.probe = &key_probe;
+    defer TestKeyDeinitProbeStorage.probe = null;
+
     var held: ?*Snapshot = null;
+    var held_refs: usize = 0;
     var held_deinit_count = std.atomic.Value(usize).init(0);
-    var held_generation: u64 = 0;
+    var held_fixture: KeyState = undefined;
+    var held_outlived_current = false;
     defer if (held) |snap| snap.release();
 
     var last_generation: u64 = 0;
     var last_ledger_len: usize = 0;
-    var next_id_byte: u8 = 0xb0;
+    var next_lease_start: u64 = 0;
+    const lease_chunk: u64 = 3;
+
+    var state = try sampleServerState(allocator);
+    defer state.deinit();
+    var seen_nonces: [16][provider.aead_nonce_len]u8 = undefined;
+    var seen_nonce_count: usize = 0;
+    const seal_now_unix_ms: i64 = 500;
 
     const op_count = 1 + smith.index(8);
     for (0..op_count) |_| {
-        switch (smith.index(5)) {
-            0 => { // install a fresh key, occasionally reusing a prior id
-                const aead = fuzzAead(@intCast(smith.index(3)));
-                const reuse_prior = next_id_byte > 0xb0 and smith.index(3) == 0;
-                const id_byte = if (reuse_prior) next_id_byte -% 1 else next_id_byte;
-                if (!reuse_prior) next_id_byte +%= 1;
-                const key_byte: u8 = if (aead == .aes_128_gcm) 0x11 else 0x22;
-                const config = sampleKeyConfigWithByte(keyId(id_byte), aead, .{ .prefix = .{ id_byte, 0, 0, 0 }, .start = 0, .end_exclusive = 4 }, key_byte);
+        switch (smith.index(6)) {
+            0 => { // (re)install the active key with an advanced, non-overlapping lease window
+                const start = next_lease_start;
+                const end = start + lease_chunk;
+                next_lease_start = end;
+                const config = KeyConfig{
+                    .id = keyId(0xc1),
+                    .aead = .aes_128_gcm,
+                    .key_bytes = testKeyBytes(.aes_128_gcm, 0x11),
+                    .not_before_unix_ms = 0,
+                    .encrypt_until_unix_ms = 1_000_000,
+                    .decrypt_until_unix_ms = 2_000_000,
+                    .nonce_lease = .{ .prefix = .{ 0xc1, 0, 0, 0 }, .start = start, .end_exclusive = end },
+                };
                 const before = captureKeyringState(&keyring);
                 const snapshot = keyring.buildSnapshot(&.{config}, testCapabilities()) catch continue;
                 keyring.install(snapshot) catch {
@@ -3590,63 +3819,115 @@ fn fuzzKeyringOperationSequence(allocator: std.mem.Allocator, smith: *testing.Sm
                 last_generation = keyring.current.?.generation;
             },
             1 => { // dry-run validate must never mutate published state
-                const config = sampleKeyConfigWithByte(keyId(next_id_byte), .aes_256_gcm, null, 0x22);
+                const config = sampleKeyConfigWithByte(keyId(0xc2), .aes_256_gcm, null, 0x22);
                 const before = captureKeyringState(&keyring);
                 const candidate = keyring.buildSnapshot(&.{config}, testCapabilities()) catch continue;
                 defer candidate.release();
                 keyring.validateInstallCandidate(candidate) catch {};
                 try expectKeyringStateEqual(before, &keyring);
             },
-            2 => { // acquire + retain current, hold across subsequent ops
+            2 => { // acquire current, hold across subsequent ops
                 if (held == null) {
                     if (keyring.acquireCurrent()) |snap| {
                         held_deinit_count = std.atomic.Value(usize).init(0);
                         snap.deinit_count = &held_deinit_count;
-                        held_generation = snap.generation;
                         held = snap;
+                        held_refs = 1;
+                        held_outlived_current = false;
+                        held_fixture = .{
+                            .id = snap.keys[0].id,
+                            .aead = snap.keys[0].aead,
+                            .not_before_unix_ms = snap.keys[0].not_before_unix_ms,
+                            .encrypt_until_unix_ms = snap.keys[0].encrypt_until_unix_ms,
+                            .decrypt_until_unix_ms = snap.keys[0].decrypt_until_unix_ms,
+                            .lease = leaseStateFromKey(&snap.keys[0]),
+                        };
                     }
                 }
             },
-            3 => { // release the held snapshot
+            3 => { // explicit Snapshot.retain(), a second modeled owner
                 if (held) |snap| {
-                    try testing.expectEqual(@as(usize, 0), held_deinit_count.load(.monotonic));
-                    snap.release();
-                    held = null;
+                    snap.retain();
+                    held_refs += 1;
                 }
             },
-            else => { // explicit generation control: exercise stale/overflow rejection
-                const config = sampleKeyConfigWithByte(keyId(next_id_byte), .aes_128_gcm, null, 0x33);
-                const generation: u64 = switch (smith.index(3)) {
-                    0 => 0,
-                    1 => if (last_generation > 0) last_generation else 1,
-                    else => std.math.maxInt(u64),
-                };
+            4 => { // release one modeled reference
+                if (held) |snap| {
+                    snap.release();
+                    held_refs -= 1;
+                    if (held_refs == 0) {
+                        try testing.expectEqual(
+                            @as(usize, if (held_outlived_current) 1 else 0),
+                            held_deinit_count.load(.monotonic),
+                        );
+                        held = null;
+                    }
+                }
+            },
+            else => { // reserve a nonce; expect deterministic exhaustion once the lease window is spent
+                var ticket_buf: [512]u8 = undefined;
                 const before = captureKeyringState(&keyring);
-                const candidate = Snapshot.build(allocator, &.{config}, generation, testCapabilities()) catch continue;
-                keyring.install(candidate) catch {
+                const ticket = keyring.current != null and keyring.current.?.keys[0].nonce_lease != null;
+                if (!ticket) continue;
+                var protector = Protector{ .provider = testProvider(), .keyring = &keyring, .limits = session.Limits.default };
+                if (protector.seal(allocator, &state, seal_now_unix_ms, &ticket_buf)) |sealed| {
+                    var nonce: [provider.aead_nonce_len]u8 = undefined;
+                    @memcpy(&nonce, sealed[24..36]);
+                    for (seen_nonces[0..seen_nonce_count]) |prior| {
+                        try testing.expect(!std.mem.eql(u8, &prior, &nonce));
+                    }
+                    if (seen_nonce_count < seen_nonces.len) {
+                        seen_nonces[seen_nonce_count] = nonce;
+                        seen_nonce_count += 1;
+                    }
+                } else |err| {
+                    try testing.expect(err == error.NonceLeaseExhausted or err == error.NoActiveEncryptionKey or err == error.AmbiguousActiveEncryptionKey);
                     try expectKeyringStateEqual(before, &keyring);
-                    continue;
-                };
-                try testing.expect(keyring.current.?.generation > last_generation);
-                last_generation = keyring.current.?.generation;
+                }
             },
         }
 
         try testing.expect(keyring.ledger.items.len >= last_ledger_len);
         last_ledger_len = keyring.ledger.items.len;
         if (held) |snap| {
-            try testing.expectEqual(held_generation, snap.generation);
+            if (keyring.current != snap) held_outlived_current = true;
             try testing.expectEqual(@as(usize, 0), held_deinit_count.load(.monotonic));
+            // Every field of the held key record is frozen -- it belongs to
+            // a published, immutable `Snapshot` that is never mutated in
+            // place -- *except* its nonce lease's `next_counter`, which is
+            // a live atomic that legitimately keeps advancing via `seal`
+            // for as long as this snapshot is still `keyring.current`
+            // (`seal` always reserves against `acquireCurrent()`, not
+            // `held`); it stops moving on its own once a replacing install
+            // takes `keyring.current` elsewhere, since no later `seal` can
+            // reach it, but there is no single "value at the moment of
+            // transition" to freeze to here -- the fixture was captured once
+            // at acquire time, so the only invariant that holds for every
+            // observation in between is monotonic non-decrease against that
+            // original value (never a reset/decrease), not exact equality.
+            const key = &snap.keys[0];
+            try testing.expectEqualSlices(u8, &held_fixture.id, &key.id);
+            try testing.expectEqual(held_fixture.aead, key.aead);
+            try testing.expectEqual(held_fixture.not_before_unix_ms, key.not_before_unix_ms);
+            try testing.expectEqual(held_fixture.encrypt_until_unix_ms, key.encrypt_until_unix_ms);
+            try testing.expectEqual(held_fixture.decrypt_until_unix_ms, key.decrypt_until_unix_ms);
+            try testing.expectEqual(held_fixture.lease.has_lease, key.nonce_lease != null);
+            if (key.nonce_lease) |*lease| {
+                try testing.expectEqualSlices(u8, &held_fixture.lease.prefix, &lease.prefix);
+                try testing.expectEqual(held_fixture.lease.end_exclusive, lease.currentEnd());
+                try testing.expect(lease.next_counter.load(.acquire) >= held_fixture.lease.next_counter);
+            }
         }
     }
 }
 
-test "fuzz: TLS resumption: ticket keyring install/validate/acquire/retain/release sequence preserves generation, ledger, and reference invariants" {
+test "fuzz: TLS resumption: ticket keyring install/validate/acquire/retain/release/seal sequence preserves generation, ledger, nonce, and reference invariants" {
     try testing.fuzz({}, fuzzKeyringOperationSequenceInput, .{ .corpus = &.{
         "",
         &([_]u8{0} ** 8),
         &([_]u8{0xff} ** 8),
-        &[_]u8{ 0, 2, 3, 0, 2, 0, 3, 1 },
+        &[_]u8{ 0, 2, 3, 5, 0, 4, 5, 4 },
+        &[_]u8{ 0, 0, 0, 5, 5, 5, 5 },
     } });
 }
 


### PR DESCRIPTION
## Summary

Second PR of #494's recommended decomposition (#494-B: "ticket security and key publication"). Adds two new `fuzz: TLS resumption: ...` targets to `src/tls/ticket_protection.zig`, following the pattern #494-A (#574) established for `NewSessionTicket`/session codec/PSK/`parseEnvelope`.

- **Authenticated `Protector.resolve` target** — drives the accept path, every typed `ResolveRejectReason` (`unknown_key`, `future_key`, `retired_key`, cross-AEAD `authentication_failed`, and tampered-nonce/ciphertext/tag `authentication_failed`), and a bounded allocation-failure sweep against a structurally valid sealed envelope. Every scenario runs through the file's existing `ZeroCheckingAllocator` to prove the temporary plaintext buffer is wiped before free on the **accept** path too, not just the miss path the existing deterministic `"seal and invalid-plaintext resolve zeroize plaintext before free"` test names.
- **Keyring/snapshot publication operation-sequence target** — a bounded program of `Snapshot.build`/`ReloadableKeyRing.install`/`validateInstallCandidate`/`acquireCurrent`/`Snapshot.retain`/`release` calls, asserting after every step that generation is monotonic, the ledger never shrinks, and a retained old snapshot stays fully intact for as long as it is held — even across installs that replace it as `keyring.current`. The existing `fuzzSnapshotConfig` target already exhaustively fuzzes the *static* properties of a single build/install call; this closes the *temporal* gap a single-call target can't reach.

The existing `ticket_key_snapshot.zig` persistent-JSON-snapshot fuzz target (on-disk snapshot parsing, unrelated to the in-memory `ReloadableKeyRing`) is untouched, per the issue's "existing coverage to preserve, not recreate" list.

`docs/CRYPTO_FUZZ_CONTRACT.md`'s `#494` section is updated with the two new target names/commands and an updated status note (no `build.zig` changes needed — the `test-tls-resumption-fuzz` step already filters generically on the `"fuzz: TLS resumption:"` prefix from #494-A).

## Test plan

- [x] `zig fmt --check build.zig src/ tests/`
- [x] `zig build test-tls-resumption-fuzz --summary all --error-style verbose` (11/11 pass, deterministic seed-corpus replay)
- [x] `zig build test-tls --summary all --error-style verbose` (885/885 pass)
- [x] `zig build test --summary all --error-style verbose` (3146/3147 pass, 1 pre-existing unrelated skip)
- [x] `zig build test -Dtls-profile=appliance --summary all --error-style verbose` (3115/3116 pass, same pre-existing skip)
- [x] Local bounded coverage-guided smoke run for both new targets (`-Doptimize=ReleaseFast --fuzz=2M`, ~800k-2M iterations each) — no crashes or findings

Progresses #494 (PR 2 of 4 — #494-C/D follow for session-cache/lease state machines and backend/runtime composition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)