### PR TITLE
Add shared TLS protocol fuzz targets

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -51,6 +51,13 @@ pub fn build(b: *std.Build) void {
     // filter to select one target for a longer local run.
     const tls_resumption_test_filter = b.option([]const u8, "tls-resumption-test-filter", "Filter tests run by the test-tls-resumption-fuzz step (default: \"fuzz: TLS resumption:\", i.e. only the #494 session/PSK/ticket/resumption fuzz targets)") orelse "fuzz: TLS resumption:";
     const tls_resumption_test_filters: []const []const u8 = &.{tls_resumption_test_filter};
+    // Shared TLS protocol-engine fuzz targets (#491, epic #323-K):
+    // handshake message/extension codecs, policy negotiation, transcript/HRR
+    // state, and TLS-owned reassembly. Keep this namespace separate from
+    // #494's resumption targets so local coverage-guided runs can select the
+    // protocol boundary without also driving PSK/ticket/cache state.
+    const tls_protocol_test_filter = b.option([]const u8, "tls-protocol-test-filter", "Filter tests run by the test-tls-protocol-fuzz step (default: \"fuzz: TLS protocol:\", i.e. only #491 shared TLS handshake/negotiation/transcript/reassembly fuzz targets)") orelse "fuzz: TLS protocol:";
+    const tls_protocol_test_filters: []const []const u8 = &.{tls_protocol_test_filter};
     const tls_profile = b.option(
         TlsProfile,
         "tls-profile",
@@ -245,6 +252,11 @@ pub fn build(b: *std.Build) void {
     const run_tls_resumption_fuzz_tests = b.addRunArtifact(tls_resumption_fuzz_tests);
     const tls_resumption_fuzz_step = b.step("test-tls-resumption-fuzz", "Run TLS session/PSK/ticket/resumption fuzz targets (#494)");
     tls_resumption_fuzz_step.dependOn(&run_tls_resumption_fuzz_tests.step);
+
+    const tls_protocol_fuzz_tests = b.addTest(.{ .root_module = tls_core_mod, .filters = tls_protocol_test_filters });
+    const run_tls_protocol_fuzz_tests = b.addRunArtifact(tls_protocol_fuzz_tests);
+    const tls_protocol_fuzz_step = b.step("test-tls-protocol-fuzz", "Run shared TLS protocol-engine fuzz targets (#491)");
+    tls_protocol_fuzz_step.dependOn(&run_tls_protocol_fuzz_tests.step);
 
     const allocation_regression_mod = b.createModule(.{
         .root_source_file = b.path("src/allocation_regression.zig"),

--- a/docs/CRYPTO_FUZZ_CONTRACT.md
+++ b/docs/CRYPTO_FUZZ_CONTRACT.md
@@ -41,6 +41,9 @@ zig build test-crypto --summary all --error-style verbose
 # The standalone provider-boundary targets owned by this story:
 zig build test-crypto-provider-fuzz --summary all --error-style verbose
 
+# Shared TLS protocol-engine targets owned by #491:
+zig build test-tls-protocol-fuzz --summary all --error-style verbose
+
 # Longer local/scheduled coverage-guided runs:
 zig build test-crypto-provider-fuzz -Doptimize=ReleaseFast --fuzz=10M --summary all --error-style verbose
 zig build test-crypto-provider-fuzz -Doptimize=ReleaseFast -Dcrypto-test-filter="fuzz: AEAD open" --fuzz=10M --summary all --error-style verbose
@@ -49,6 +52,8 @@ zig build test-crypto-provider-fuzz -Doptimize=ReleaseFast -Dcrypto-test-filter=
 zig build test-crypto-provider-fuzz -Doptimize=ReleaseFast -Dcrypto-test-filter="fuzz: generateKeyShare" --fuzz=10M --summary all --error-style verbose
 zig build test-crypto-provider-fuzz -Doptimize=ReleaseFast -Dcrypto-test-filter="fuzz: FixedSecret" --fuzz=10M --summary all --error-style verbose
 zig build test-crypto-provider-fuzz -Doptimize=ReleaseFast -Dcrypto-test-filter="fuzz: BoundedSecret" --fuzz=10M --summary all --error-style verbose
+zig build test-tls-protocol-fuzz -Doptimize=ReleaseFast --fuzz=10M --summary all --error-style verbose
+zig build test-tls-protocol-fuzz -Doptimize=ReleaseFast -Dtls-protocol-test-filter="fuzz: TLS protocol: ClientHello parse" --fuzz=10M --summary all --error-style verbose
 ```
 
 `-Dcrypto-test-filter` (added alongside the existing `-Dquic-test-filter`)
@@ -57,6 +62,8 @@ gives explicit target selection for the `test-crypto-provider-fuzz` step; the
 scale it). #491–#494 should add their own protocol-scoped test steps and
 `-D<area>-test-filter` options following the same pattern rather than
 growing this one.
+`test-tls-protocol-fuzz` follows that convention with
+`-Dtls-protocol-test-filter` and the default `fuzz: TLS protocol:` namespace.
 
 ## Seed-corpus and regression update procedure
 

--- a/src/tls/engine.zig
+++ b/src/tls/engine.zig
@@ -563,16 +563,19 @@ fn fuzzHandshakeCoreAndDriver(_: void, smith: *std.testing.Smith) !void {
     } else {
         try std.testing.expect(backend.calls > before_calls);
         const repeated = driver.receiveOutcome(.handshake, command);
-        if (repeated.terminal_error) |err| {
-            const calls_after_failure = backend.calls;
-            const sink_len_after_failure = repeated.sink.len;
-            const sink_used_after_failure = repeated.sink.used;
-            const again = driver.receiveOutcome(.handshake, command);
-            try std.testing.expectEqual(err, again.terminal_error.?);
-            try std.testing.expectEqual(calls_after_failure, backend.calls);
-            try std.testing.expectEqual(sink_len_after_failure, again.sink.len);
-            try std.testing.expectEqual(sink_used_after_failure, again.sink.used);
-        }
+        const err = repeated.terminal_error orelse return error.TestExpectedError;
+        try std.testing.expectEqual(error.UnexpectedHandshakeMessage, err);
+
+        const calls_after_failure = backend.calls;
+        const state_after_failure = backend.core.handshake_state;
+        const sink_len_after_failure = repeated.sink.len;
+        const sink_used_after_failure = repeated.sink.used;
+        const again = driver.receiveOutcome(.handshake, command);
+        try std.testing.expectEqual(err, again.terminal_error.?);
+        try std.testing.expectEqual(calls_after_failure, backend.calls);
+        try std.testing.expectEqual(sink_len_after_failure, again.sink.len);
+        try std.testing.expectEqual(sink_used_after_failure, again.sink.used);
+        try std.testing.expectEqual(state_after_failure, backend.core.handshake_state);
     }
 }
 

--- a/src/tls/engine.zig
+++ b/src/tls/engine.zig
@@ -10,6 +10,7 @@ pub const state = @import("state.zig");
 pub const events = @import("events.zig");
 pub const handshake = @import("handshake.zig");
 pub const key_schedule = @import("key_schedule.zig");
+const messages = @import("messages.zig");
 pub const transcript = @import("transcript.zig");
 
 pub const EngineConfig = struct {
@@ -476,4 +477,147 @@ test "driver deinit is safe after a failed handshake" {
     try std.testing.expectError(error.TransportBufferOverflow, driver.start({}));
     driver.deinit();
     try std.testing.expectEqual(@as(usize, 0), driver.sink.used);
+}
+
+test "fuzz: TLS protocol: handshake core and driver reject malformed ordering with sticky terminal errors" {
+    try std.testing.fuzz({}, fuzzHandshakeCoreAndDriver, .{ .corpus = &.{
+        "",
+        &[_]u8{ 0, @intFromEnum(messages.MessageType.client_hello), 0, 0, 0 },
+        &[_]u8{ 1, @intFromEnum(messages.MessageType.finished), 0, 0, 0 },
+        &[_]u8{ 2, @intFromEnum(messages.MessageType.server_hello), 0, 0, 3, 'h', 'r', 'r' },
+        &([_]u8{0xff} ** 96),
+    } });
+}
+
+fn fuzzHandshakeCoreAndDriver(_: void, smith: *std.testing.Smith) !void {
+    try exerciseKnownValidHrrProgression(smith);
+
+    const DriverError = handshake.Error || error{TransportBufferOverflow};
+    const T = @import("transport.zig").Contract(void, enum { handshake }, DriverError);
+    const D = Driver(T);
+    const Backend = struct {
+        core: handshake.Core,
+        calls: usize = 0,
+
+        fn start(ptr: *anyopaque, role: state.Role, _: void, _: *T.EventSink) T.Error!void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.calls += 1;
+            self.core = handshake.Core.init(role);
+            try self.core.start();
+            self.core.transcript.selectFamily(.sha256);
+        }
+
+        fn receive(ptr: *anyopaque, _: T.EpochType, bytes: []const u8, _: *T.EventSink) T.Error!void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.calls += 1;
+            if (bytes.len == 0) return error.MalformedHandshake;
+            const op = bytes[0] % 6;
+            const raw = bytes[1..];
+            switch (op) {
+                0 => _ = try self.core.acceptReceived(raw),
+                1 => try self.core.recordSent(raw),
+                2 => _ = try self.core.acceptHelloRetryRequest(raw),
+                3 => try self.core.recordHelloRetryRequest(raw),
+                4 => try self.core.recordSecondClientHello(raw),
+                else => _ = try self.core.acceptSecondClientHello(raw),
+            }
+        }
+    };
+
+    var backend = Backend{ .core = handshake.Core.init(if (smith.index(2) == 0) .client else .server) };
+    var driver = D.init(if (smith.index(2) == 0) .client else .server, .{
+        .ptr = &backend,
+        .startFn = Backend.start,
+        .receiveFn = Backend.receive,
+    });
+    defer driver.deinit();
+
+    const start = driver.startOutcome({});
+    try std.testing.expectEqual(@as(?T.Error, null), start.terminal_error);
+    try std.testing.expectEqual(state.DriverState.in_progress, driver.state);
+
+    var frame_storage: [128]u8 = undefined;
+    const frame = try fuzzHandshakeFrame(smith, &frame_storage);
+    var command_storage: [129]u8 = undefined;
+    command_storage[0] = @intCast(smith.index(6));
+    @memcpy(command_storage[1..][0..frame.len], frame);
+    const command = command_storage[0 .. 1 + frame.len];
+
+    const before_calls = backend.calls;
+    const first = driver.receiveOutcome(.handshake, command);
+    if (first.terminal_error) |err| {
+        try std.testing.expectEqual(state.DriverState.failed, driver.state);
+        try std.testing.expectEqual(err, driver.failure().?);
+        const state_after_failure = backend.core.handshake_state;
+        const lifecycle_after_failure = backend.core.handshake_lifecycle;
+        const calls_after_failure = backend.calls;
+        const sink_len_after_failure = first.sink.len;
+        const sink_used_after_failure = first.sink.used;
+        const again = driver.receiveOutcome(.handshake, command);
+        try std.testing.expectEqual(err, again.terminal_error.?);
+        try std.testing.expectEqual(calls_after_failure, backend.calls);
+        try std.testing.expectEqual(sink_len_after_failure, again.sink.len);
+        try std.testing.expectEqual(sink_used_after_failure, again.sink.used);
+        try std.testing.expectEqual(state_after_failure, backend.core.handshake_state);
+        try std.testing.expectEqual(lifecycle_after_failure, backend.core.handshake_lifecycle);
+    } else {
+        try std.testing.expect(backend.calls > before_calls);
+        const repeated = driver.receiveOutcome(.handshake, command);
+        if (repeated.terminal_error) |err| {
+            const calls_after_failure = backend.calls;
+            const sink_len_after_failure = repeated.sink.len;
+            const sink_used_after_failure = repeated.sink.used;
+            const again = driver.receiveOutcome(.handshake, command);
+            try std.testing.expectEqual(err, again.terminal_error.?);
+            try std.testing.expectEqual(calls_after_failure, backend.calls);
+            try std.testing.expectEqual(sink_len_after_failure, again.sink.len);
+            try std.testing.expectEqual(sink_used_after_failure, again.sink.used);
+        }
+    }
+}
+
+fn exerciseKnownValidHrrProgression(smith: *std.testing.Smith) !void {
+    var client = handshake.Core.init(.client);
+    var server = handshake.Core.init(.server);
+    try client.start();
+    try server.start();
+    client.transcript.selectFamily(if (smith.index(2) == 0) .sha256 else .sha384);
+    server.transcript.selectFamily(client.transcript.family().?);
+
+    var ch1_buf: [32]u8 = undefined;
+    var hrr_buf: [32]u8 = undefined;
+    var ch2_buf: [32]u8 = undefined;
+    var sh_buf: [32]u8 = undefined;
+    const ch1 = try messages.encode(.client_hello, "one", &ch1_buf);
+    try client.recordSent(ch1);
+    _ = try server.acceptReceived(ch1);
+    const hrr = try messages.encode(.server_hello, "hrr", &hrr_buf);
+    try server.recordHelloRetryRequest(hrr);
+    _ = try client.acceptHelloRetryRequest(hrr);
+    const ch2 = try messages.encode(.client_hello, "two", &ch2_buf);
+    try client.recordSecondClientHello(ch2);
+    _ = try server.acceptSecondClientHello(ch2);
+    const sh = try messages.encode(.server_hello, "ok", &sh_buf);
+    try server.recordSent(sh);
+    _ = try client.acceptReceived(sh);
+
+    try std.testing.expectEqual(handshake.RetryState.hrr_received, client.retry_state);
+    try std.testing.expectEqual(handshake.RetryState.hrr_sent, server.retry_state);
+    try std.testing.expect(client.transcriptHash().eql(&server.transcriptHash()));
+}
+
+fn fuzzHandshakeFrame(smith: *std.testing.Smith, out: []u8) ![]const u8 {
+    const kinds = [_]messages.MessageType{ .client_hello, .server_hello, .encrypted_extensions, .certificate, .certificate_verify, .finished };
+    var body: [32]u8 = undefined;
+    const body_len = smith.index(body.len + 1);
+    smith.bytes(body[0..body_len]);
+    const frame = try messages.encode(kinds[smith.index(kinds.len)], body[0..body_len], out);
+    if (smith.index(4) == 0 and frame.len > 0) {
+        out[0] = 0xff;
+    } else if (smith.index(4) == 0 and frame.len >= 4) {
+        out[1] = 0xff;
+        out[2] = 0xff;
+        out[3] = 0xff;
+    }
+    return frame;
 }

--- a/src/tls/hello_retry.zig
+++ b/src/tls/hello_retry.zig
@@ -1010,3 +1010,107 @@ test "ClientHello2 validator rejects malformed PSK binder vectors" {
         }));
     }
 }
+
+test "fuzz: TLS protocol: HRR decode and ClientHello2 validation reject malformed ordering deterministically" {
+    try testing.fuzz({}, fuzzHrrAndClientHello2, .{ .corpus = &.{
+        "",
+        &[_]u8{ 3, 3 } ++ random ++ [_]u8{ 0, 0x13, 0x01, 0, 0, 0 },
+        &([_]u8{0xff} ** 128),
+    } });
+}
+
+fn fuzzHrrAndClientHello2(_: void, smith: *testing.Smith) !void {
+    var offers = try baseOffers();
+    if (smith.index(2) == 0) {
+        offers.key_shares[0] = .{ .group = .x25519, .key_exchange = "share" };
+        offers.key_shares_len = 1;
+    }
+    if (smith.index(2) == 0) offers.key_share_seen = false;
+
+    var raw_body: [384]u8 = undefined;
+    const raw_len = smith.index(raw_body.len + 1);
+    smith.bytes(raw_body[0..raw_len]);
+    if (decode(raw_body[0..raw_len], "sid", &offers)) |request| {
+        try testing.expectEqual(algorithms.ProtocolVersion.tls13, request.selected_version);
+        try testing.expect(containsEnum(algorithms.CipherSuite, offers.cipher_suites[0..offers.cipher_suites_len], request.cipher_suite));
+        if (request.selected_group) |group| {
+            try testing.expect(containsEnum(algorithms.NamedGroup, offers.supported_groups[0..offers.supported_groups_len], group));
+            try testing.expect(offers.keyShareFor(group) == null);
+        }
+        if (request.cookie) |cookie| try testing.expect(cookie.len > 0);
+    } else |err| switch (err) {
+        error.MalformedHandshake,
+        error.IllegalParameter,
+        error.UnexpectedHandshakeMessage,
+        error.MissingExtension,
+        error.UnsupportedExtension,
+        error.AlpnMismatch,
+        error.UnsupportedCertificate,
+        error.CertificateInvalid,
+        error.SecretExportFailed,
+        error.InvalidHandshakeState,
+        error.TicketTooLarge,
+        error.NoApplicableCredential,
+        error.CredentialProviderFailed,
+        error.ClientCertificateRequired,
+        error.DecryptError,
+        error.HandshakeBufferOverflow,
+        error.DuplicateExtension,
+        error.TooManyExtensions,
+        error.MessageTooLarge,
+        error.IncompleteHandshake,
+        => {},
+    }
+
+    const cookie_options = [_]?[]const u8{ null, "cookie", "other" };
+    const share_options = [_]?algorithms.NamedGroup{ null, .x25519, .secp256r1 };
+    const extra_options = [_]?ExtensionView{
+        null,
+        .{ .id = @intFromEnum(algorithms.ExtensionType.padding), .data = "" },
+        .{ .id = @intFromEnum(algorithms.ExtensionType.padding), .data = &.{ 0, 0, 0 } },
+        .{ .id = @intFromEnum(algorithms.ExtensionType.padding), .data = &.{ 0, 1 } },
+        .{ .id = @intFromEnum(algorithms.ExtensionType.early_data), .data = "" },
+    };
+
+    var first_buf: [768]u8 = undefined;
+    var second_buf: [768]u8 = undefined;
+    const first_share = share_options[smith.index(share_options.len)];
+    const second_share = share_options[smith.index(share_options.len)];
+    const first = try clientHello(&first_buf, @intCast(smith.index(256)), first_share, null, extra_options[smith.index(extra_options.len)]);
+    const second = try clientHello(
+        &second_buf,
+        if (smith.index(4) == 0) 0xbb else first[4],
+        second_share,
+        cookie_options[smith.index(cookie_options.len)],
+        extra_options[smith.index(extra_options.len)],
+    );
+    const request = Request{
+        .selected_version = .tls13,
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .selected_group = share_options[smith.index(share_options.len)],
+        .cookie = cookie_options[smith.index(cookie_options.len)],
+    };
+    validateSecondClientHello(first, second, request) catch |err| switch (err) {
+        error.MalformedHandshake,
+        error.IllegalParameter,
+        error.UnexpectedHandshakeMessage,
+        error.MissingExtension,
+        error.UnsupportedExtension,
+        error.AlpnMismatch,
+        error.UnsupportedCertificate,
+        error.CertificateInvalid,
+        error.SecretExportFailed,
+        error.InvalidHandshakeState,
+        error.TicketTooLarge,
+        error.NoApplicableCredential,
+        error.CredentialProviderFailed,
+        error.ClientCertificateRequired,
+        error.DecryptError,
+        error.HandshakeBufferOverflow,
+        error.DuplicateExtension,
+        error.TooManyExtensions,
+        error.MessageTooLarge,
+        error.IncompleteHandshake,
+        => {},
+    };
+}

--- a/src/tls/hello_retry.zig
+++ b/src/tls/hello_retry.zig
@@ -1062,35 +1062,100 @@ fn fuzzHrrAndClientHello2(_: void, smith: *testing.Smith) !void {
         => {},
     }
 
-    const cookie_options = [_]?[]const u8{ null, "cookie", "other" };
-    const share_options = [_]?algorithms.NamedGroup{ null, .x25519, .secp256r1 };
-    const extra_options = [_]?ExtensionView{
-        null,
-        .{ .id = @intFromEnum(algorithms.ExtensionType.padding), .data = "" },
-        .{ .id = @intFromEnum(algorithms.ExtensionType.padding), .data = &.{ 0, 0, 0 } },
-        .{ .id = @intFromEnum(algorithms.ExtensionType.padding), .data = &.{ 0, 1 } },
-        .{ .id = @intFromEnum(algorithms.ExtensionType.early_data), .data = "" },
-    };
-
     var first_buf: [768]u8 = undefined;
     var second_buf: [768]u8 = undefined;
-    const first_share = share_options[smith.index(share_options.len)];
-    const second_share = share_options[smith.index(share_options.len)];
-    const first = try clientHello(&first_buf, @intCast(smith.index(256)), first_share, null, extra_options[smith.index(extra_options.len)]);
-    const second = try clientHello(
-        &second_buf,
-        if (smith.index(4) == 0) 0xbb else first[4],
-        second_share,
-        cookie_options[smith.index(cookie_options.len)],
-        extra_options[smith.index(extra_options.len)],
-    );
-    const request = Request{
+    var mutated_buf: [768]u8 = undefined;
+    var psk_first_buf: [768]u8 = undefined;
+    var psk_buf: [256]u8 = undefined;
+
+    const first_random: u8 = @intCast(smith.index(256));
+    const second_cookie = "cookie";
+    const first = try clientHello(&first_buf, first_random, null, null, null);
+    const second = try clientHello(&second_buf, first_random, .x25519, second_cookie, null);
+    const valid_request = Request{
         .selected_version = .tls13,
         .cipher_suite = .tls_aes_128_gcm_sha256,
-        .selected_group = share_options[smith.index(share_options.len)],
-        .cookie = cookie_options[smith.index(cookie_options.len)],
+        .selected_group = .x25519,
+        .cookie = second_cookie,
     };
-    validateSecondClientHello(first, second, request) catch |err| switch (err) {
+    try validateSecondClientHello(first, second, valid_request);
+
+    switch (smith.index(8)) {
+        0 => {
+            const bad_random = try clientHello(&mutated_buf, first_random ^ 0xff, .x25519, second_cookie, null);
+            try testing.expectError(error.IllegalParameter, validateSecondClientHello(first, bad_random, valid_request));
+        },
+        1 => {
+            const missing_cookie = try clientHello(&mutated_buf, first_random, .x25519, null, null);
+            try testing.expectError(error.IllegalParameter, validateSecondClientHello(first, missing_cookie, valid_request));
+        },
+        2 => {
+            const wrong_cookie = try clientHello(&mutated_buf, first_random, .x25519, "other", null);
+            try testing.expectError(error.IllegalParameter, validateSecondClientHello(first, wrong_cookie, valid_request));
+        },
+        3 => {
+            const missing_share = try clientHello(&mutated_buf, first_random, null, second_cookie, null);
+            try testing.expectError(error.IllegalParameter, validateSecondClientHello(first, missing_share, valid_request));
+        },
+        4 => {
+            const early_data = try clientHello(
+                &mutated_buf,
+                first_random,
+                .x25519,
+                second_cookie,
+                .{ .id = @intFromEnum(algorithms.ExtensionType.early_data), .data = "" },
+            );
+            try testing.expectError(error.IllegalParameter, validateSecondClientHello(first, early_data, valid_request));
+        },
+        5 => {
+            const nonzero_padding = try clientHello(
+                &mutated_buf,
+                first_random,
+                .x25519,
+                second_cookie,
+                .{ .id = @intFromEnum(algorithms.ExtensionType.padding), .data = &.{ 0, @intCast(1 + smith.index(255)) } },
+            );
+            try testing.expectError(error.IllegalParameter, validateSecondClientHello(first, nonzero_padding, valid_request));
+        },
+        6 => {
+            const reordered_stable = try clientHelloWithReorderedStableExtensions(&mutated_buf, first_random, .x25519);
+            try testing.expectError(error.IllegalParameter, validateSecondClientHello(first, reordered_stable, .{
+                .selected_version = .tls13,
+                .cipher_suite = .tls_aes_128_gcm_sha256,
+                .selected_group = .x25519,
+                .cookie = null,
+            }));
+        },
+        else => {
+            const psk = try pskExtension(&psk_buf, "ticket-a", @intCast(smith.index(1024)), null, 0, @intCast(smith.index(256)));
+            const psk_ext = ExtensionView{ .id = @intFromEnum(algorithms.ExtensionType.pre_shared_key), .data = psk };
+            const cookie_ext = ExtensionView{ .id = @intFromEnum(algorithms.ExtensionType.cookie), .data = &.{ 0, 6, 'c', 'o', 'o', 'k', 'i', 'e' } };
+            const first_with_psk = try clientHelloWithExtensionList(&psk_first_buf, first_random, .x25519, &.{psk_ext});
+            const invalid_psk_order = try clientHelloWithExtensionList(&mutated_buf, first_random, .x25519, &.{ psk_ext, cookie_ext });
+            try testing.expectError(error.IllegalParameter, validateSecondClientHello(first_with_psk, invalid_psk_order, .{
+                .selected_version = .tls13,
+                .cipher_suite = .tls_aes_128_gcm_sha256,
+                .selected_group = null,
+                .cookie = second_cookie,
+            }));
+        },
+    }
+
+    const second_random = if (smith.index(4) == 0) first_random ^ 0xff else first_random;
+    const sampled_second = try clientHello(
+        &second_buf,
+        second_random,
+        if (smith.index(2) == 0) .x25519 else null,
+        if (smith.index(2) == 0) second_cookie else null,
+        null,
+    );
+    const sampled_request = Request{
+        .selected_version = .tls13,
+        .cipher_suite = .tls_aes_128_gcm_sha256,
+        .selected_group = .x25519,
+        .cookie = second_cookie,
+    };
+    validateSecondClientHello(first, sampled_second, sampled_request) catch |err| switch (err) {
         error.MalformedHandshake,
         error.IllegalParameter,
         error.UnexpectedHandshakeMessage,

--- a/src/tls/messages.zig
+++ b/src/tls/messages.zig
@@ -326,6 +326,10 @@ test "fuzz: TLS protocol: handshake framing extensions and reassembly preserve b
         &[_]u8{ @intFromEnum(MessageType.client_hello), 0, 0, 0 },
         &[_]u8{ @intFromEnum(MessageType.finished), 0, 0, 1, 0xaa },
         &[_]u8{ 0xff, 0, 0, 0 },
+        &[_]u8{ @intFromEnum(MessageType.client_hello), 0, 0, 0, @intFromEnum(MessageType.finished), 0, 0, 0 },
+        &[_]u8{ @intFromEnum(MessageType.finished), 0, 0xff, 0xff, 0xff },
+        &([_]u8{0xaa} ** 64),
+        &([_]u8{0xbb} ** 65),
         &[_]u8{ 0, 43, 0, 2, 3, 4, 0, 43, 0, 2, 3, 4 },
         &([_]u8{0xff} ** 128),
     } });
@@ -385,4 +389,52 @@ fn fuzzHandshakeCodecAndReassembly(_: void, smith: *testing.Smith) !void {
     try testing.expectEqualSlices(u8, encoded, reassembled.raw);
     try reassembler.discard(reassembled.raw.len);
     try testing.expectEqual(@as(usize, 0), reassembler.len);
+
+    var second_encoded_storage: [256]u8 = undefined;
+    var second_body_storage: [128]u8 = undefined;
+    const second_body_len = smith.index(second_body_storage.len + 1);
+    smith.bytes(second_body_storage[0..second_body_len]);
+    const second_encoded = try encode(kinds[smith.index(kinds.len)], second_body_storage[0..second_body_len], &second_encoded_storage);
+
+    var coalesced_storage: [512]u8 = undefined;
+    @memcpy(coalesced_storage[0..encoded.len], encoded);
+    @memcpy(coalesced_storage[encoded.len..][0..second_encoded.len], second_encoded);
+    const coalesced = coalesced_storage[0 .. encoded.len + second_encoded.len];
+    var coalesced_reassembler = Reassembler(512){};
+    var coalesced_cursor: usize = 0;
+    while (coalesced_cursor < coalesced.len) {
+        const remaining = coalesced.len - coalesced_cursor;
+        const chunk_len = 1 + smith.index(remaining);
+        try coalesced_reassembler.append(coalesced[coalesced_cursor..][0..chunk_len]);
+        coalesced_cursor += chunk_len;
+    }
+    for ([_][]const u8{ encoded, second_encoded }) |frame| {
+        const message = (try coalesced_reassembler.peek()).?;
+        try testing.expectEqualSlices(u8, frame, message.raw);
+        try coalesced_reassembler.discard(message.raw.len);
+    }
+    try testing.expectEqual(@as(usize, 0), coalesced_reassembler.len);
+
+    var raw_reassembler = Reassembler(64){};
+    const raw_before_len = raw_reassembler.len;
+    const append_result = raw_reassembler.append(raw);
+    if (append_result) |_| {
+        try testing.expectEqual(raw.len, raw_reassembler.len);
+        const peek_result = raw_reassembler.peek();
+        if (peek_result) |maybe_message| {
+            if (maybe_message) |message| {
+                try testing.expect(message.raw.len <= raw_reassembler.len);
+                try testing.expectEqualSlices(u8, raw_reassembler.data[0..message.raw.len], message.raw);
+                const bad_discard = message.raw.len + 1 + smith.index(raw_reassembler.len - message.raw.len + 1);
+                try testing.expectError(error.MalformedHandshake, raw_reassembler.discard(bad_discard));
+                try raw_reassembler.discard(message.raw.len);
+                try testing.expectEqual(raw.len - message.raw.len, raw_reassembler.len);
+            }
+        } else |err| switch (err) {
+            error.MalformedHandshake, error.MessageTooLarge, error.HandshakeBufferOverflow, error.DuplicateExtension, error.TooManyExtensions, error.IncompleteHandshake => {},
+        }
+    } else |err| switch (err) {
+        error.HandshakeBufferOverflow => try testing.expectEqual(raw_before_len, raw_reassembler.len),
+        error.MalformedHandshake, error.MessageTooLarge, error.DuplicateExtension, error.TooManyExtensions, error.IncompleteHandshake => {},
+    }
 }

--- a/src/tls/messages.zig
+++ b/src/tls/messages.zig
@@ -319,3 +319,70 @@ test "reader and writer enforce bounds" {
     try testing.expectEqual(@as(u8, 0), try r.u8_());
     try testing.expectError(error.MalformedHandshake, r.u8_());
 }
+
+test "fuzz: TLS protocol: handshake framing extensions and reassembly preserve bounded cursor invariants" {
+    try testing.fuzz({}, fuzzHandshakeCodecAndReassembly, .{ .corpus = &.{
+        "",
+        &[_]u8{ @intFromEnum(MessageType.client_hello), 0, 0, 0 },
+        &[_]u8{ @intFromEnum(MessageType.finished), 0, 0, 1, 0xaa },
+        &[_]u8{ 0xff, 0, 0, 0 },
+        &[_]u8{ 0, 43, 0, 2, 3, 4, 0, 43, 0, 2, 3, 4 },
+        &([_]u8{0xff} ** 128),
+    } });
+}
+
+fn fuzzHandshakeCodecAndReassembly(_: void, smith: *testing.Smith) !void {
+    var raw_buf: [256]u8 = undefined;
+    const raw_len = smith.index(raw_buf.len + 1);
+    smith.bytes(raw_buf[0..raw_len]);
+    const raw = raw_buf[0..raw_len];
+
+    if (decode(raw)) |message| {
+        try testing.expectEqual(raw.len, message.raw.len);
+        try testing.expectEqual(raw.len - 4, message.body.len);
+        try testing.expectEqual(raw.ptr, message.raw.ptr);
+        try testing.expectEqual(raw[4..].ptr, message.body.ptr);
+    } else |err| switch (err) {
+        error.MalformedHandshake, error.MessageTooLarge, error.DuplicateExtension, error.TooManyExtensions, error.HandshakeBufferOverflow, error.IncompleteHandshake => {},
+    }
+
+    var extensions = ExtensionIterator.init(raw);
+    var seen: [ExtensionGuard.max_extensions]u16 = undefined;
+    var seen_len: usize = 0;
+    while (extensions.next()) |maybe_extension| {
+        const extension = maybe_extension orelse break;
+        for (seen[0..seen_len]) |id| try testing.expect(id != extension.id);
+        try testing.expect(@intFromPtr(extension.data.ptr) >= @intFromPtr(raw.ptr));
+        try testing.expect(@intFromPtr(extension.data.ptr) + extension.data.len <= @intFromPtr(raw.ptr) + raw.len);
+        seen[seen_len] = extension.id;
+        seen_len += 1;
+    } else |err| switch (err) {
+        error.MalformedHandshake, error.DuplicateExtension, error.TooManyExtensions, error.HandshakeBufferOverflow, error.MessageTooLarge, error.IncompleteHandshake => {},
+    }
+
+    var encoded_storage: [256]u8 = undefined;
+    var body_storage: [128]u8 = undefined;
+    const body_len = smith.index(body_storage.len + 1);
+    smith.bytes(body_storage[0..body_len]);
+    const kinds = [_]MessageType{ .client_hello, .server_hello, .encrypted_extensions, .certificate, .finished, .message_hash };
+    const encoded = try encode(kinds[smith.index(kinds.len)], body_storage[0..body_len], &encoded_storage);
+    const decoded = try decode(encoded);
+    try testing.expectEqualSlices(u8, encoded, decoded.raw);
+    try testing.expectEqualSlices(u8, body_storage[0..body_len], decoded.body);
+
+    var reassembler = Reassembler(512){};
+    var cursor: usize = 0;
+    while (cursor < encoded.len) {
+        const remaining = encoded.len - cursor;
+        const chunk_len = 1 + smith.index(remaining);
+        try reassembler.append(encoded[cursor..][0..chunk_len]);
+        cursor += chunk_len;
+        if (cursor < encoded.len) {
+            try testing.expect((try reassembler.peek()) == null);
+        }
+    }
+    const reassembled = (try reassembler.peek()).?;
+    try testing.expectEqualSlices(u8, encoded, reassembled.raw);
+    try reassembler.discard(reassembled.raw.len);
+    try testing.expectEqual(@as(usize, 0), reassembler.len);
+}

--- a/src/tls/messages.zig
+++ b/src/tls/messages.zig
@@ -425,8 +425,10 @@ fn fuzzHandshakeCodecAndReassembly(_: void, smith: *testing.Smith) !void {
             if (maybe_message) |message| {
                 try testing.expect(message.raw.len <= raw_reassembler.len);
                 try testing.expectEqualSlices(u8, raw_reassembler.data[0..message.raw.len], message.raw);
-                const bad_discard = message.raw.len + 1 + smith.index(raw_reassembler.len - message.raw.len + 1);
+                const bad_discard = raw_reassembler.len + 1 + smith.index(8);
+                const before_bad_discard = raw_reassembler.len;
                 try testing.expectError(error.MalformedHandshake, raw_reassembler.discard(bad_discard));
+                try testing.expectEqual(before_bad_discard, raw_reassembler.len);
                 try raw_reassembler.discard(message.raw.len);
                 try testing.expectEqual(raw.len - message.raw.len, raw_reassembler.len);
             }

--- a/src/tls/negotiation.zig
+++ b/src/tls/negotiation.zig
@@ -847,7 +847,10 @@ fn assertNegotiationOutcomes(policy: policy_mod.Policy, parsed: *const ParsedCli
                 try testing.expect(parsed.offers.keyShareFor(group) == null);
             },
         }
-        if (selected.alpn) |alpn| try testing.expect(policy.containsAlpn(alpn.bytes));
+        if (selected.alpn) |alpn| {
+            try testing.expect(policy.containsAlpn(alpn.bytes));
+            try testing.expect(containsAlpn(parsed.offers.alpn_protocols[0..parsed.offers.alpn_protocols_len], alpn));
+        }
         try validateServerSelection(policy, .{
             .version = selected.version,
             .cipher_suite = selected.cipher_suite,
@@ -882,7 +885,11 @@ fn assertNegotiationOutcomes(policy: policy_mod.Policy, parsed: *const ParsedCli
         try testing.expect(policy.containsCipherSuite(selected.cipher_suite));
         try testing.expect(policy.containsNamedGroup(selected.named_group));
         try testing.expect(policy.containsSignatureScheme(selected.signature_scheme));
+        try testing.expect(containsEnum(algorithms.SignatureScheme, parsed.offers.signature_schemes[0..parsed.offers.signature_schemes_len], selected.signature_scheme));
         try testing.expect(policy.containsAlpn(selected.alpn.bytes));
+        try testing.expect(containsAlpn(parsed.offers.alpn_protocols[0..parsed.offers.alpn_protocols_len], selected.alpn));
+        try testing.expectEqualSlices(u8, parsed.offers.keyShareFor(selected.named_group).?, selected.key_share);
+        try testing.expectEqual(parsed.offers.server_name, selected.server_name);
     } else |err| switch (err) {
         error.UnsupportedProtocolVersion,
         error.MissingServerName,

--- a/src/tls/negotiation.zig
+++ b/src/tls/negotiation.zig
@@ -739,3 +739,170 @@ test "malformed required extensions fail deterministically" {
 
     try testing.expectError(error.MalformedHandshake, parseClientHello(w.written()));
 }
+
+test "fuzz: TLS protocol: ClientHello parse and policy negotiation stays within configured registry" {
+    try testing.fuzz({}, fuzzClientHelloAndPolicyNegotiation, .{ .corpus = &.{
+        "",
+        &[_]u8{ 3, 3 },
+        &[_]u8{ 3, 3 } ++ ([_]u8{0} ** 32) ++ [_]u8{ 0, 0, 2, 0x13, 0x01, 1, 0, 0, 0 },
+        &([_]u8{0xff} ** 128),
+    } });
+}
+
+fn fuzzClientHelloAndPolicyNegotiation(_: void, smith: *testing.Smith) !void {
+    var raw_body: [384]u8 = undefined;
+    const raw_len = smith.index(raw_body.len + 1);
+    smith.bytes(raw_body[0..raw_len]);
+    if (parseClientHelloObserved(raw_body[0..raw_len], null)) |parsed| {
+        try assertNegotiationOutcomes(policy_mod.Policy.recordDefault(), &parsed);
+        try assertNegotiationOutcomes(policy_mod.Policy.quicDefault(), &parsed);
+    } else |err| switch (err) {
+        error.MalformedHandshake,
+        error.MalformedExtension,
+        error.MissingSupportedVersions,
+        error.MissingExtension,
+        error.IllegalParameter,
+        error.UnsupportedProtocolVersion,
+        error.MissingCipherSuites,
+        error.NoMutualCipherSuite,
+        error.NoMutualNamedGroup,
+        error.MissingKeyShare,
+        error.NoMutualSignatureScheme,
+        error.NoMutualAlpn,
+        error.MissingServerName,
+        error.OfferVectorTooLarge,
+        error.DuplicateExtension,
+        error.TooManyExtensions,
+        error.HandshakeBufferOverflow,
+        error.MessageTooLarge,
+        error.IncompleteHandshake,
+        => {},
+    }
+
+    const offers = try generatedOffers(smith);
+    const generated = ParsedClientHello{ .offers = offers, .legacy_session_id = "", .offered_null_compression = true };
+    try assertNegotiationOutcomes(policy_mod.Policy.recordDefault(), &generated);
+    try assertNegotiationOutcomes(policy_mod.Policy.quicDefault(), &generated);
+
+    var require_sni_policy = policy_mod.Policy.recordDefault();
+    require_sni_policy.require_sni = smith.index(2) == 0;
+    try assertNegotiationOutcomes(require_sni_policy, &generated);
+}
+
+fn generatedOffers(smith: *testing.Smith) !ClientHelloOffers {
+    var offers = ClientHelloOffers{};
+    const versions = [_]?algorithms.ProtocolVersion{ .tls13, null };
+    const ciphers = [_]?algorithms.CipherSuite{ .tls_aes_128_gcm_sha256, .tls_aes_256_gcm_sha384, .tls_chacha20_poly1305_sha256, null };
+    const groups = [_]?algorithms.NamedGroup{ .x25519, .secp256r1, .secp384r1, null };
+    const signatures = [_]?algorithms.SignatureScheme{ .ed25519, .ecdsa_secp256r1_sha256, .rsa_pss_rsae_sha256, .rsa_pkcs1_sha256, null };
+    const alpns = [_]algorithms.ProtocolName{ algorithms.alpn.h2, algorithms.alpn.http_1_1, algorithms.alpn.h3, .{ .bytes = "unknown" } };
+
+    for (0..smith.index(12)) |_| {
+        if (versions[smith.index(versions.len)]) |version| try offers.appendVersion(version);
+    }
+    for (0..smith.index(12)) |_| {
+        if (ciphers[smith.index(ciphers.len)]) |cipher| try offers.appendCipherSuite(cipher);
+    }
+    for (0..smith.index(12)) |_| {
+        if (groups[smith.index(groups.len)]) |group| try offers.appendSupportedGroup(group);
+    }
+    for (0..smith.index(12)) |_| {
+        if (signatures[smith.index(signatures.len)]) |scheme| {
+            try offers.appendRawSignatureScheme(@intFromEnum(scheme));
+            try offers.appendSignatureScheme(scheme);
+        } else {
+            try offers.appendRawSignatureScheme(0xeeee);
+        }
+    }
+    for (0..smith.index(8)) |_| try offers.appendAlpn(alpns[smith.index(alpns.len)]);
+
+    offers.key_share_seen = smith.index(2) == 0;
+    const share_seeds = [_][]const u8{ "", "x25519 share", "p256 share", "oversized-but-bounded synthetic key share" };
+    const share_count = smith.index(share_seeds.len + 1);
+    for (0..share_count) |_| {
+        const group = groups[smith.index(groups.len)] orelse .x25519;
+        const seed = share_seeds[smith.index(share_seeds.len)];
+        try offers.appendKeyShare(.{ .group = group, .key_exchange = seed[0..smith.index(seed.len + 1)] });
+    }
+    if (smith.index(2) == 0) offers.server_name = if (smith.index(2) == 0) "example.test" else "";
+    return offers;
+}
+
+fn assertNegotiationOutcomes(policy: policy_mod.Policy, parsed: *const ParsedClientHello) !void {
+    if (negotiateServerHello(policy, &parsed.offers)) |selected| {
+        try testing.expect(policy.containsProtocolVersion(selected.version));
+        try testing.expect(parsed.offers.containsVersion(selected.version));
+        try testing.expect(policy.containsCipherSuite(selected.cipher_suite));
+        try testing.expect(containsEnum(algorithms.CipherSuite, parsed.offers.cipher_suites[0..parsed.offers.cipher_suites_len], selected.cipher_suite));
+        try testing.expect(policy.containsNamedGroup(selected.named_group));
+        try testing.expect(containsEnum(algorithms.NamedGroup, parsed.offers.supported_groups[0..parsed.offers.supported_groups_len], selected.named_group));
+        switch (selected.key_share) {
+            .use => |share| {
+                try testing.expectEqual(selected.named_group, share.group);
+                try testing.expect(parsed.offers.keyShareFor(selected.named_group) != null);
+            },
+            .retry => |group| {
+                try testing.expectEqual(selected.named_group, group);
+                try testing.expect(parsed.offers.key_share_seen);
+                try testing.expect(parsed.offers.keyShareFor(group) == null);
+            },
+        }
+        if (selected.alpn) |alpn| try testing.expect(policy.containsAlpn(alpn.bytes));
+        try validateServerSelection(policy, .{
+            .version = selected.version,
+            .cipher_suite = selected.cipher_suite,
+            .named_group = selected.named_group,
+            .alpn = selected.alpn,
+        });
+    } else |err| switch (err) {
+        error.UnsupportedProtocolVersion,
+        error.MissingServerName,
+        error.NoMutualCipherSuite,
+        error.NoMutualNamedGroup,
+        error.MissingExtension,
+        error.NoMutualAlpn,
+        error.MissingKeyShare,
+        error.NoMutualSignatureScheme,
+        error.MalformedHandshake,
+        error.MalformedExtension,
+        error.MissingSupportedVersions,
+        error.IllegalParameter,
+        error.MissingCipherSuites,
+        error.OfferVectorTooLarge,
+        error.DuplicateExtension,
+        error.TooManyExtensions,
+        error.HandshakeBufferOverflow,
+        error.MessageTooLarge,
+        error.IncompleteHandshake,
+        => {},
+    }
+
+    if (negotiateServer(policy, &parsed.offers)) |selected| {
+        try testing.expect(policy.containsProtocolVersion(selected.version));
+        try testing.expect(policy.containsCipherSuite(selected.cipher_suite));
+        try testing.expect(policy.containsNamedGroup(selected.named_group));
+        try testing.expect(policy.containsSignatureScheme(selected.signature_scheme));
+        try testing.expect(policy.containsAlpn(selected.alpn.bytes));
+    } else |err| switch (err) {
+        error.UnsupportedProtocolVersion,
+        error.MissingServerName,
+        error.NoMutualCipherSuite,
+        error.NoMutualNamedGroup,
+        error.MissingExtension,
+        error.NoMutualAlpn,
+        error.MissingKeyShare,
+        error.NoMutualSignatureScheme,
+        error.MalformedHandshake,
+        error.MalformedExtension,
+        error.MissingSupportedVersions,
+        error.IllegalParameter,
+        error.MissingCipherSuites,
+        error.OfferVectorTooLarge,
+        error.DuplicateExtension,
+        error.TooManyExtensions,
+        error.HandshakeBufferOverflow,
+        error.MessageTooLarge,
+        error.IncompleteHandshake,
+        => {},
+    }
+}

--- a/src/tls/transcript.zig
+++ b/src/tls/transcript.zig
@@ -347,3 +347,67 @@ test "an unselected transcript reports no family and a zero-length digest with a
     try testing.expectEqual(@as(usize, 0), digest.len);
     for (digest.bytes) |byte| try testing.expectEqual(@as(u8, 0), byte);
 }
+
+test "fuzz: TLS protocol: transcript update select and HRR rebind sequences are bounded and deterministic" {
+    try testing.fuzz({}, fuzzTranscriptSequences, .{ .corpus = &.{
+        "",
+        &[_]u8{ 0, 1, 2, 3, 4 },
+        &[_]u8{ 2, 0, 0, 1, 0xaa },
+        &([_]u8{0xff} ** 128),
+    } });
+}
+
+fn fuzzTranscriptSequences(_: void, smith: *testing.Smith) !void {
+    var transcript = Transcript{};
+    var mirrored = Transcript{};
+    var saw_deferred_rebind = false;
+
+    var chunk_storage: [96]u8 = undefined;
+    for (0..32) |_| {
+        switch (smith.index(5)) {
+            0 => {
+                const len = smith.index(chunk_storage.len + 1);
+                smith.bytes(chunk_storage[0..len]);
+                const before_pending_len = transcript.pending_len;
+                const update_result = transcript.update(chunk_storage[0..len]);
+                const mirror_result = mirrored.update(chunk_storage[0..len]);
+                if (update_result) |_| {
+                    try mirror_result;
+                } else |err| {
+                    try testing.expectEqual(error.TranscriptOverflow, err);
+                    try testing.expectError(error.TranscriptOverflow, mirror_result);
+                    try testing.expectEqual(before_pending_len, transcript.pending_len);
+                }
+            },
+            1 => {
+                const family: Hash = if (smith.index(2) == 0) .sha256 else .sha384;
+                transcript.selectFamily(family);
+                mirrored.selectFamily(family);
+                try testing.expectEqual(family, transcript.family().?);
+                try testing.expect(transcript.peek().eql(&mirrored.peek()));
+            },
+            2 => {
+                if (transcript.family() != null or !saw_deferred_rebind) {
+                    transcript.rebindClientHello();
+                    mirrored.rebindClientHello();
+                    if (transcript.family() == null) saw_deferred_rebind = true;
+                    try testing.expect(transcript.peek().eql(&mirrored.peek()));
+                }
+            },
+            3 => {
+                const len = smith.index(chunk_storage.len + 1);
+                smith.bytes(chunk_storage[0..len]);
+                const before = transcript.peek();
+                _ = transcript.peekWith(chunk_storage[0..len]);
+                try testing.expect(before.eql(&transcript.peek()));
+            },
+            else => {
+                if (transcript.family()) |family| {
+                    const before = transcript.peek();
+                    transcript.selectFamily(if (family == .sha256) .sha384 else .sha256);
+                    try testing.expect(before.eql(&transcript.peek()));
+                }
+            },
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a standalone `test-tls-protocol-fuzz` build step and `-Dtls-protocol-test-filter` namespace for #491
- add seed-backed fuzz targets for TLS handshake framing/extensions/reassembly, ClientHello policy negotiation, transcript HRR rebinding, and HRR/ClientHello2 validation
- document deterministic smoke and longer coverage-guided protocol fuzz commands

## Validation
- `zig build test-tls-protocol-fuzz --summary all --error-style verbose`
- `zig fmt --check build.zig src/ tests/`
- `zig build test-tls --summary all --error-style verbose`
- `zig build test --summary all --error-style verbose`

Refs #491