### PR TITLE
security: [493-A] fuzz TLS record codec and inner-plaintext framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,13 +28,22 @@ All notable user-facing changes to Tardigrade are documented here.
   `src/tls/record_codec.zig` following the `docs/CRYPTO_FUZZ_CONTRACT.md`
   contract: `codec fragmentation, coalescing, and sink saturation preserve
   exact consumption` drives fuzzer-generated valid record streams through
-  `Parser.feedOne` against a single-record-capacity sink, asserting exact
-  per-record byte consumption, correct saturation/`drainReady`/`finish`
+  `Parser.feedOne` using fuzzer-chosen offered fragment sizes (so partial
+  headers/bodies stay buffered across call boundaries), covers the
+  legal/illegal initial-ClientHello `0x0301` compatibility window as part of
+  the generated case, drives record-size boundaries up to the exact
+  plaintext/ciphertext maxima plus a declared maximum-plus-one, and asserts
+  exact per-record byte consumption, correct saturation/`drainReady`/`finish`
   backpressure semantics, and that arbitrary malformed bytes never panic;
   `inner plaintext framing, padding, and bounds remain transactional` fuzzes
   `encodeInnerPlaintext`/`decodeInnerPlaintext` round trips and raw-byte
-  decoding against an independent oracle, asserting transactional output on
-  every rejected encode. Also converts record-length-only arithmetic
+  decoding against independent oracles over content/padding/output-capacity
+  boundary matrices, asserting the exact expected typed error (computed
+  before each call) and transactional output on every rejection. Also adds
+  named deterministic companions pinning every `encodeInnerPlaintext`
+  rejection stage and every `feedOne` header/payload split point, for the
+  arms a seed-corpus replay cannot reliably reach. Also converts
+  record-length-only arithmetic
   reachable from fuzzer-chosen scalar lengths (`record_codec.Parser`'s
   pending-bytes-needed helpers, `record_epoch_bridge.zig`'s handshake
   chunk/record-length helpers, `encrypted_stream.zig`'s

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,26 @@ All notable user-facing changes to Tardigrade are documented here.
   `std.testing.FailingAllocator`). Wired into `zig build test` via the new
   `test-crypto-provider-fuzz` step and a `-Dcrypto-test-filter` build option
   for targeted longer coverage-guided runs.
+- **TLS record codec and inner-plaintext fuzz targets (#493-A, epic
+  #325-K)** — adds two `std.testing.Smith` fuzz targets in
+  `src/tls/record_codec.zig` following the `docs/CRYPTO_FUZZ_CONTRACT.md`
+  contract: `codec fragmentation, coalescing, and sink saturation preserve
+  exact consumption` drives fuzzer-generated valid record streams through
+  `Parser.feedOne` against a single-record-capacity sink, asserting exact
+  per-record byte consumption, correct saturation/`drainReady`/`finish`
+  backpressure semantics, and that arbitrary malformed bytes never panic;
+  `inner plaintext framing, padding, and bounds remain transactional` fuzzes
+  `encodeInnerPlaintext`/`decodeInnerPlaintext` round trips and raw-byte
+  decoding against an independent oracle, asserting transactional output on
+  every rejected encode. Also converts record-length-only arithmetic
+  reachable from fuzzer-chosen scalar lengths (`record_codec.Parser`'s
+  pending-bytes-needed helpers, `record_epoch_bridge.zig`'s handshake
+  chunk/record-length helpers, `encrypted_stream.zig`'s
+  `handshakeRecordCount`) to checked `std.math`-based arithmetic instead of
+  idioms that could wrap on a synthetic near-`usize`-max input. Wired into
+  `zig build test`/`zig build test-tls` (already run deterministically) via
+  the new `test-tls-record-fuzz` step and `-Dtls-record-test-filter` build
+  option for targeted longer coverage-guided runs.
 
 ### Features
 - **QUIC negotiated TLS suite packet protection (#566)** — Handshake, 0-RTT,

--- a/build.zig
+++ b/build.zig
@@ -58,6 +58,16 @@ pub fn build(b: *std.Build) void {
     // protocol boundary without also driving PSK/ticket/cache state.
     const tls_protocol_test_filter = b.option([]const u8, "tls-protocol-test-filter", "Filter tests run by the test-tls-protocol-fuzz step (default: \"fuzz: TLS protocol:\", i.e. only #491 shared TLS handshake/negotiation/transcript/reassembly fuzz targets)") orelse "fuzz: TLS protocol:";
     const tls_protocol_test_filters: []const []const u8 = &.{tls_protocol_test_filter};
+    // TLS record / protection / epoch / encrypted-stream fuzz targets (#493,
+    // epic #325-K). Same shape as #491/#494 above: a dedicated namespace so
+    // local coverage-guided runs can select this boundary without also
+    // driving the shared protocol engine or resumption state.
+    const tls_record_test_filter = b.option(
+        []const u8,
+        "tls-record-test-filter",
+        "Filter tests run by the test-tls-record-fuzz step (default: \"fuzz: TLS record:\", i.e. only #493 record/protection/epoch/encrypted-stream fuzz targets)",
+    ) orelse "fuzz: TLS record:";
+    const tls_record_test_filters: []const []const u8 = &.{tls_record_test_filter};
     const tls_profile = b.option(
         TlsProfile,
         "tls-profile",
@@ -257,6 +267,18 @@ pub fn build(b: *std.Build) void {
     const run_tls_protocol_fuzz_tests = b.addRunArtifact(tls_protocol_fuzz_tests);
     const tls_protocol_fuzz_step = b.step("test-tls-protocol-fuzz", "Run shared TLS protocol-engine fuzz targets (#491)");
     tls_protocol_fuzz_step.dependOn(&run_tls_protocol_fuzz_tests.step);
+
+    // Record codec, protection, epoch/key lifecycle, and encrypted-stream
+    // fuzz targets (#493, epic #325-K). Like #494/#491 above, these are
+    // inline `test "fuzz: ..."` blocks next to the code they exercise
+    // (record_codec.zig, record_protection.zig, record_epoch_bridge.zig,
+    // encrypted_stream.zig) and already replay their deterministic seed
+    // corpus under plain `test-tls`/`test`; this step gives them a stable,
+    // individually filterable/long-runnable name.
+    const tls_record_fuzz_tests = b.addTest(.{ .root_module = tls_core_mod, .filters = tls_record_test_filters });
+    const run_tls_record_fuzz_tests = b.addRunArtifact(tls_record_fuzz_tests);
+    const tls_record_fuzz_step = b.step("test-tls-record-fuzz", "Run TLS record/protection/epoch/encrypted-stream fuzz targets (#493)");
+    tls_record_fuzz_step.dependOn(&run_tls_record_fuzz_tests.step);
 
     const allocation_regression_mod = b.createModule(.{
         .root_source_file = b.path("src/allocation_regression.zig"),

--- a/docs/CRYPTO_FUZZ_CONTRACT.md
+++ b/docs/CRYPTO_FUZZ_CONTRACT.md
@@ -44,6 +44,9 @@ zig build test-crypto-provider-fuzz --summary all --error-style verbose
 # Shared TLS protocol-engine targets owned by #491:
 zig build test-tls-protocol-fuzz --summary all --error-style verbose
 
+# Record/protection/epoch/encrypted-stream targets owned by #493:
+zig build test-tls-record-fuzz --summary all --error-style verbose
+
 # Longer local/scheduled coverage-guided runs:
 zig build test-crypto-provider-fuzz -Doptimize=ReleaseFast --fuzz=10M --summary all --error-style verbose
 zig build test-crypto-provider-fuzz -Doptimize=ReleaseFast -Dcrypto-test-filter="fuzz: AEAD open" --fuzz=10M --summary all --error-style verbose
@@ -498,3 +501,92 @@ lease oracles, per-op invariant checks, bounded operation-scoped
 zeroization/destruction probes for entries and public lease boxes.
 Backend/runtime composition follows in #494-D per the issue's PR
 decomposition.
+
+### #493 — TLS record / protection / epoch / encrypted-stream state (epic #325-K)
+
+Like #494's targets, #493's are inline `test "fuzz: ..."` blocks inside the
+production modules themselves (`src/tls/record_codec.zig`,
+`src/tls/record_protection.zig`, `src/tls/record_epoch_bridge.zig`,
+`src/tls/encrypted_stream.zig`) rather than a separate `tests/*.zig` root,
+so they already replay their deterministic seed corpus under plain
+`zig build test-tls` / `zig build test`. The `test-tls-record-fuzz` step
+gives them a stable, individually filterable/long-runnable name, matching
+`-Dtls-resumption-test-filter`/`-Dtls-protocol-test-filter` above:
+
+```bash
+# Deterministic smoke coverage for every #493 fuzz target landed so far
+# (seed corpus replay only, "fuzz: TLS record:" namespace) — also covered
+# by plain `zig build test-tls` / `zig build test`.
+zig build test-tls-record-fuzz --summary all --error-style verbose
+
+# Longer local/scheduled coverage-guided runs, one target at a time:
+zig build test-tls-record-fuzz -Doptimize=ReleaseFast --fuzz=10M --summary all --error-style verbose
+zig build test-tls-record-fuzz -Doptimize=ReleaseFast -Dtls-record-test-filter="fuzz: TLS record: codec fragmentation, coalescing, and sink saturation preserve exact consumption" --fuzz=10M --summary all --error-style verbose
+zig build test-tls-record-fuzz -Doptimize=ReleaseFast -Dtls-record-test-filter="fuzz: TLS record: inner plaintext framing, padding, and bounds remain transactional" --fuzz=10M --summary all --error-style verbose
+```
+
+`-Dtls-record-test-filter` defaults to `"fuzz: TLS record:"` (every #493
+target; scoped narrower than a bare `"fuzz: "` prefix for the same reason
+as `-Dtls-resumption-test-filter` above). This story is being delivered in
+three PRs to keep agent context and review scope manageable, per the
+issue's implementation-plan comment:
+
+- **#493-A** (this slice) — build wiring (`test-tls-record-fuzz`,
+  `-Dtls-record-test-filter`) and the two `record_codec.zig` targets:
+  `codec fragmentation, coalescing, and sink saturation preserve exact
+  consumption` drives a bounded oracle stream of generated valid records
+  through `Parser.feedOne` against a single-record-capacity `RecordSink`,
+  asserting exact per-record consumption, that an undrained/saturated sink
+  yields `consumed == 0` with parser and stale-sink state untouched, that
+  `drainReady` publishes an already-buffered complete record without new
+  input, that `finish()` only accepts a fully-drained parser, and that
+  arbitrary bytes into a fresh parser never panic or exceed the fixed
+  pending-buffer bound; `inner plaintext framing, padding, and bounds
+  remain transactional` drives `encodeInnerPlaintext`/`decodeInnerPlaintext`
+  round trips plus an independent last-nonzero-byte oracle for raw-byte
+  decoding, asserting transactional output on every rejected encode and
+  borrowed-slice containment on every accepted decode. Both targets also
+  exercise a synthetic near-`usize`-max length at least once per case (an
+  overflow-adjacent case an actual allocation could never represent) against
+  the checked scalar arithmetic helpers below.
+- Per the issue's "harden synthetic length arithmetic" requirement, this
+  slice also converts the record-length-only calculations reachable from
+  fuzzer-chosen scalar lengths to checked arithmetic returning a typed
+  `RecordTooLarge` rather than wrapping: `record_codec.Parser`'s
+  `checkedOwnedLen`/`checkedRecordLen` (backing
+  `pendingRecordBytesNeededWith`/`pendingRecordPayloadLenWith`),
+  `record_epoch_bridge.zig`'s `chunkCount`/`plaintextHandshakeRecordLen`/
+  `protectedHandshakeRecordLen`/`sealHandshakeFragments`/
+  `sealedHandshakeLen`, and `encrypted_stream.zig`'s `handshakeRecordCount`.
+  Each of these (following `record_codec.encodeInnerPlaintext`'s existing
+  precedent) now uses `std.math.add`/`std.math.mul`/`std.math.divCeil`
+  instead of the `a + b - 1` / `a + b` idioms that can silently wrap for a
+  synthetic scalar input near the `usize` boundary — a case fuzzing can
+  drive directly as a bare length but never as a real allocation. Each
+  helper has its own named deterministic boundary test in addition to the
+  fuzz corpus; several (`chunkCount`, `handshakeRecordCount`) turn out to be
+  overflow-safe *by construction* once expressed via `std.math.divCeil`
+  (its `@divFloor(numerator - 1, denominator) + 1` form cannot itself
+  overflow for a positive numerator/denominator), so their boundary tests
+  assert exact agreement with `std.math.divCeil` at a synthetic near-max
+  input rather than an error — the actual overflow these targets guard
+  against surfaces one step later, in the callers that add `bytes_len` back
+  on top of the chunk overhead.
+- **#493-B** (record protection and epoch/key lifecycle) and **#493-C**
+  (scripted in-memory carrier, encrypted-stream progression, docs
+  closeout) are tracked as follow-on slices of the same issue and will
+  extend this section and the `-Dtls-record-test-filter` namespace when
+  they land, rather than duplicating this contract.
+
+Ownership stays exactly as scoped above and in the issue: shared TLS
+message/negotiation/transcript fuzzing is #491; PKI fuzzing is #492;
+resumption/PSK/ticket/cache fuzzing is #494; provider primitive
+malformed-input fuzzing is this file's own #376 targets; HTTP parsing and
+external TLS-over-TCP interop are out of scope entirely. #408's
+foundation-layer fixes (exact parser consumption, sink retry behavior,
+legal initial-ClientHello `0x0301`, explicit epoch discard, sequence
+exhaustion, key cleanup, independent record-protection vectors) are treated
+as regression seeds/properties here, not reimplemented — the extensive
+pre-existing deterministic `record_codec.zig` test suite already pins most
+of them by name, and the #493-A property targets extend that coverage with
+randomization rather than duplicating it.

--- a/docs/CRYPTO_FUZZ_CONTRACT.md
+++ b/docs/CRYPTO_FUZZ_CONTRACT.md
@@ -532,23 +532,70 @@ three PRs to keep agent context and review scope manageable, per the
 issue's implementation-plan comment:
 
 - **#493-A** (this slice) — build wiring (`test-tls-record-fuzz`,
-  `-Dtls-record-test-filter`) and the two `record_codec.zig` targets:
+  `-Dtls-record-test-filter`) and the two `record_codec.zig` targets.
+
   `codec fragmentation, coalescing, and sink saturation preserve exact
-  consumption` drives a bounded oracle stream of generated valid records
-  through `Parser.feedOne` against a single-record-capacity `RecordSink`,
-  asserting exact per-record consumption, that an undrained/saturated sink
-  yields `consumed == 0` with parser and stale-sink state untouched, that
+  consumption` generates a bounded oracle stream of valid records and drives
+  it through `Parser.feedOne` against a single-record-capacity `RecordSink`,
+  offering a **fuzzer-chosen prefix** of the remaining bytes on each call so
+  a partial header or body stays buffered across the invocation boundary and
+  must resume exactly on a later call (caller-visible fragmentation, not just
+  `feedOne`'s internal byte loop); `emitted == false` is a normal outcome and
+  must absorb the whole offered fragment. The parser's version policy is part
+  of the generated case: when the initial-ClientHello compatibility window is
+  selected, the stream becomes the fragments of one real `clientHelloMessage`
+  (all handshake-content-type, so RFC 8446 SS5.1's no-interleaving rule
+  holds) with each fragment's declared legacy version independently drawn
+  from `{0x0303, 0x0301}` — every such fragment is inside the window and so
+  must be accepted regardless of the mix, after which a further `0x0301`
+  record on the same parser must be refused. The illegal placements are
+  asserted against fresh compat-policy parsers: a non-ClientHello
+  `msg_type`, a non-handshake content type, and ciphertext mode must each
+  yield `InvalidRecordVersion`. A bounded single-record subcase drives the
+  record-size boundaries (`0`, `1`, exact-maximum-minus-one, exact maximum,
+  for both the plaintext and ciphertext limits) through the valid
+  encode/parse/oracle path, and a header that merely *declares*
+  maximum-plus-one is refused with `RecordTooLarge` without that payload ever
+  existing. The target also asserts an undrained/saturated sink yields
+  `consumed == 0` with parser and stale-sink state untouched, that
   `drainReady` publishes an already-buffered complete record without new
-  input, that `finish()` only accepts a fully-drained parser, and that
-  arbitrary bytes into a fresh parser never panic or exceed the fixed
-  pending-buffer bound; `inner plaintext framing, padding, and bounds
-  remain transactional` drives `encodeInnerPlaintext`/`decodeInnerPlaintext`
-  round trips plus an independent last-nonzero-byte oracle for raw-byte
-  decoding, asserting transactional output on every rejected encode and
-  borrowed-slice containment on every accepted decode. Both targets also
-  exercise a synthetic near-`usize`-max length at least once per case (an
-  overflow-adjacent case an actual allocation could never represent) against
-  the checked scalar arithmetic helpers below.
+  input, that `finish()` only accepts a fully-drained parser, a per-case
+  iteration bound (no spin on repeated non-progress), and that arbitrary
+  bytes into a fresh parser never panic or exceed the fixed pending-buffer
+  bound.
+
+  `inner plaintext framing, padding, and bounds remain transactional`
+  classifies the expected outcome of every `encodeInnerPlaintext` call
+  **before** making it (`expectedInnerPlaintextEncode`, mirroring the
+  documented rejection order: illegal content type, oversized content,
+  overflow/oversized total, output capacity) and asserts that exact typed
+  error rather than accepting any rejection, with the destination sentinel
+  re-verified after each one. Content length, padding length, and output
+  capacity each come from a boundary matrix — content around
+  `max_plaintext_fragment_len`, total around `max_ciphertext_fragment_len`
+  (padding carries the bulk, so exact-max and max-plus-one totals need no
+  oversized content buffer), and capacity at exact-minus-one/exact/
+  exact-plus-one — and `change_cipher_spec` is generated periodically and
+  must always be `InvalidRecordType`. Raw-byte decoding is checked against an
+  independent last-nonzero-byte oracle over a length matrix that reaches the
+  exact ciphertext-fragment maximum and one past it, asserting borrowed-slice
+  containment on every accepted decode. Both targets also drive a synthetic
+  near-`usize`-max length (an overflow-adjacent case no real allocation could
+  represent) against the checked scalar arithmetic helpers below.
+
+  Because the deterministic `.corpus` replay that plain `zig build test`/CI
+  runs is not guaranteed to reach every arm of these classifications, the
+  error-class and split-point properties additionally have named
+  deterministic tests next to them —
+  `encodeInnerPlaintext classifies every rejection stage at its exact
+  boundary` and `feedOne preserves exact consumption across every header and
+  payload split point`. The former was validated by mutation: swapping
+  `encodeInnerPlaintext`'s `out.len < total` error to `RecordTooLarge` makes
+  it fail under plain `zig build test-tls`, whereas the corpus replay alone
+  did not catch that regression (a coverage-guided run found it in ~15
+  runs). Treat that as the standard for future #493 slices: a property worth
+  fuzzing that CI's seed replay cannot reliably reach also needs a named
+  deterministic case.
 - Per the issue's "harden synthetic length arithmetic" requirement, this
   slice also converts the record-length-only calculations reachable from
   fuzzer-chosen scalar lengths to checked arithmetic returning a typed
@@ -588,5 +635,9 @@ legal initial-ClientHello `0x0301`, explicit epoch discard, sequence
 exhaustion, key cleanup, independent record-protection vectors) are treated
 as regression seeds/properties here, not reimplemented — the extensive
 pre-existing deterministic `record_codec.zig` test suite already pins most
-of them by name, and the #493-A property targets extend that coverage with
-randomization rather than duplicating it.
+of them by name, and the #493-A property targets promote the ones in scope
+for this slice (exact parser consumption under fragmentation, sink retry
+behavior, and the legal/illegal initial-ClientHello `0x0301` window) into
+generated properties rather than leaving them as fixed examples. The epoch
+discard, sequence exhaustion, and key cleanup classes are still
+deterministic-only and become fuzz properties in #493-B.

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -159,8 +159,16 @@ pub const QueueCounters = struct {
     }
 };
 
-fn handshakeRecordCount(bytes_len: usize) usize {
-    return (bytes_len + record_codec.max_plaintext_fragment_len - 1) / record_codec.max_plaintext_fragment_len;
+/// Uses `std.math.divCeil`'s `@divFloor(numerator - 1, denominator) + 1`
+/// form rather than the `(bytes_len + chunk_size - 1) / chunk_size` idiom,
+/// so a synthetic near-`usize`-max `bytes_len` -- the #493 "overflow-
+/// adjacent synthetic limits" case -- never overflows this addition, unlike
+/// the naive form; mirrors `record_epoch_bridge.zig`'s `chunkCount`. The
+/// `Error!` return exists for parity with that helper's signature, not
+/// because this one can itself overflow.
+fn handshakeRecordCount(bytes_len: usize) record_codec.Error!usize {
+    if (bytes_len == 0) return 0;
+    return std.math.divCeil(usize, bytes_len, record_codec.max_plaintext_fragment_len) catch error.RecordTooLarge;
 }
 
 pub const BufferCounters = struct {
@@ -2251,10 +2259,20 @@ test "TLS buffer defaults validate and expose bounded snapshot" {
     try testing.expectEqual(AccountingBoundary.complete_stream_owned, snapshot.accounting_boundary);
 }
 
+test "handshakeRecordCount stays overflow-safe at a synthetic near-usize-max bytes_len" {
+    try testing.expectEqual(@as(usize, 0), try handshakeRecordCount(0));
+    try testing.expectEqual(@as(usize, 1), try handshakeRecordCount(record_codec.max_plaintext_fragment_len));
+    try testing.expectEqual(@as(usize, 2), try handshakeRecordCount(record_codec.max_plaintext_fragment_len + 1));
+    try testing.expectEqual(
+        try std.math.divCeil(usize, std.math.maxInt(usize), record_codec.max_plaintext_fragment_len),
+        try handshakeRecordCount(std.math.maxInt(usize)),
+    );
+}
+
 test "record stream maximum emitted ticket fits four-record ciphertext queue" {
     try std.testing.expectEqual(4 * record_codec.max_ciphertext_record_len, PureZigRecordStream.max_ciphertext_queue);
     const bytes_len = tls13_transport.max_emitted_new_session_ticket_message_len;
-    const records = handshakeRecordCount(bytes_len);
+    const records = try handshakeRecordCount(bytes_len);
     const protected_len = bytes_len + records * (record_codec.header_len + 1 + 16);
     try std.testing.expect(protected_len <= PureZigRecordStream.max_ciphertext_queue);
 }

--- a/src/tls/record_codec.zig
+++ b/src/tls/record_codec.zig
@@ -1115,6 +1115,64 @@ test "inner plaintext encodes content type followed by zero padding" {
     try testing.expectEqual(@as(usize, 3), decoded.padding_len);
 }
 
+// Pins each of `encodeInnerPlaintext`'s four typed outcomes at its exact
+// boundary, in the documented rejection order. The fuzz target below asserts
+// the same classification against generated inputs, but its `.corpus` replay
+// (what plain `zig build test`/CI runs) is not guaranteed to reach every arm,
+// so an error-class regression -- e.g. returning `RecordTooLarge` for an
+// ordinary undersized output -- needs deterministic coverage here too. This
+// was verified by mutation: swapping the `out.len < total` error makes this
+// test fail.
+test "encodeInnerPlaintext classifies every rejection stage at its exact boundary" {
+    var out: [max_ciphertext_fragment_len]u8 = undefined;
+    const content = "finished";
+
+    // 1. change_cipher_spec has no legal inner-plaintext encoding, and is
+    // refused before any length is even considered.
+    try testing.expectError(error.InvalidRecordType, encodeInnerPlaintext(.change_cipher_spec, content, 0, &out));
+    try testing.expectError(error.InvalidRecordType, encodeInnerPlaintext(.change_cipher_spec, "", 0, out[0..0]));
+
+    // 2. content longer than the plaintext fragment maximum.
+    const oversized_content = [_]u8{0} ** (max_plaintext_fragment_len + 1);
+    try testing.expectError(error.RecordTooLarge, encodeInnerPlaintext(.handshake, &oversized_content, 0, &out));
+    // Exactly at the maximum, content alone is fine; it is the total that
+    // then exceeds the ciphertext fragment maximum only once padding pushes
+    // it over (checked in stage 3).
+    const max_content = [_]u8{0} ** max_plaintext_fragment_len;
+    const at_max = try encodeInnerPlaintext(.handshake, &max_content, 0, &out);
+    try testing.expectEqual(max_plaintext_fragment_len + 1, at_max.len);
+
+    // 3. total (content || type || padding) across the ciphertext fragment
+    // maximum: exact-minus-one and exact succeed, exact-plus-one does not.
+    const max_total = max_ciphertext_fragment_len;
+    const under = try encodeInnerPlaintext(.handshake, content, max_total - content.len - 2, &out);
+    try testing.expectEqual(max_total - 1, under.len);
+    const exact = try encodeInnerPlaintext(.handshake, content, max_total - content.len - 1, &out);
+    try testing.expectEqual(max_total, exact.len);
+    try testing.expectError(
+        error.RecordTooLarge,
+        encodeInnerPlaintext(.handshake, content, max_total - content.len, &out),
+    );
+    // And a padding length that overflows `usize` arithmetic outright.
+    try testing.expectError(error.RecordTooLarge, encodeInnerPlaintext(.handshake, content, std.math.maxInt(usize), &out));
+
+    // 4. output capacity, at exact-minus-one / exact / exact-plus-one. This
+    // is the arm that must stay `RecordBufferOverflow` and not collapse into
+    // `RecordTooLarge`.
+    const needed = content.len + 1 + 3;
+    try testing.expectError(
+        error.RecordBufferOverflow,
+        encodeInnerPlaintext(.handshake, content, 3, out[0 .. needed - 1]),
+    );
+    const exact_out = try encodeInnerPlaintext(.handshake, content, 3, out[0..needed]);
+    try testing.expectEqual(needed, exact_out.len);
+    const roomy_out = try encodeInnerPlaintext(.handshake, content, 3, out[0 .. needed + 1]);
+    try testing.expectEqual(needed, roomy_out.len);
+    // A zero-capacity destination is still the output-capacity error, not a
+    // size error, even for the smallest possible encoding.
+    try testing.expectError(error.RecordBufferOverflow, encodeInnerPlaintext(.handshake, "", 0, out[0..0]));
+}
+
 test "inner plaintext rejects all-zero, invalid type, and oversized content" {
     try testing.expectError(error.MalformedInnerPlaintext, decodeInnerPlaintext(&.{ 0, 0, 0 }));
     try testing.expectError(error.MalformedInnerPlaintext, decodeInnerPlaintext(&.{ 1, 99, 0 }));
@@ -1177,25 +1235,82 @@ fn withinBounds(outer: []const u8, inner: []const u8) bool {
 
 const fuzz_codec_max_records = 4;
 const fuzz_codec_max_payload = 48;
+/// Bounded so a whole generated ClientHello message
+/// (`handshake_header_len + body`) still fits in one `fuzz_codec_max_payload`
+/// record payload, which is what makes a single-fragment compatibility-window
+/// case representable alongside the multi-fragment ones.
+const fuzz_codec_max_compat_body = fuzz_codec_max_payload - handshake_header_len;
+
+// Every split point of a two-call `feedOne` sequence must preserve exact
+// consumption: splitting after each of the five header bytes, and at
+// representative payload boundaries, leaves the remainder buffered and
+// resumes it on the next call without losing or duplicating a byte. The
+// fuzz target below randomizes this; this pins it deterministically at every
+// header offset, which a coverage-guided run should never have to
+// rediscover.
+test "feedOne preserves exact consumption across every header and payload split point" {
+    var encoded: [header_len + 6]u8 = undefined;
+    const record = try encodePlaintextRecord(.handshake, "abcdef", &encoded);
+
+    for (1..record.len) |split_at| {
+        var parser = Parser.init(.plaintext);
+        var sink = RecordSink(1, 32){};
+
+        const first = try parser.feedOne(record[0..split_at], &sink);
+        // A prefix shorter than the whole record can never emit, and must
+        // absorb every offered byte into the pending buffer.
+        try testing.expect(!first.emitted);
+        try testing.expectEqual(split_at, first.consumed);
+        try testing.expectEqual(@as(usize, 0), sink.len);
+        try testing.expectError(error.TruncatedRecord, parser.finish());
+
+        const second = try parser.feedOne(record[split_at..], &sink);
+        try testing.expect(second.emitted);
+        try testing.expectEqual(record.len - split_at, second.consumed);
+        try testing.expectEqual(@as(usize, 1), sink.len);
+        try testing.expectEqual(ContentType.handshake, sink.items[0].content_type);
+        try testing.expectEqualStrings("abcdef", sink.items[0].payload);
+        try parser.finish();
+    }
+}
 
 test "fuzz: TLS record: codec fragmentation, coalescing, and sink saturation preserve exact consumption" {
     try std.testing.fuzz({}, fuzzCodecFragmentationInput, .{ .corpus = &.{
         "",
         &[_]u8{0},
         &[_]u8{ 0, 0 },
+        &[_]u8{ 1, 1 },
+        &[_]u8{ 0, 1, 0, 1 },
         &[_]u8{ 22, 3, 3, 0, 0 },
         &[_]u8{ 22, 3, 3, 0, 5, 1, 2, 3, 4, 5 },
+        &[_]u8{ 22, 3, 1, 0, 4, 1, 0, 0, 0 },
         &[_]u8{ 21, 3, 3, 0, 2, 1, 0 },
         &[_]u8{ 20, 3, 3, 0, 1, 1 },
         &[_]u8{ 23, 3, 3, 0, 3, 9, 9, 9 },
+        &[_]u8{ 0, 0, 1, 2, 3, 4, 0x40, 0x00 },
+        &[_]u8{ 3, 3, 1, 1, 0x40, 0x01 },
         &([_]u8{0xff} ** 64),
         &([_]u8{0x01} ** 200),
+        &([_]u8{ 0, 2, 4, 8, 16, 32, 64, 128 } ** 8),
     } });
 }
 
 fn fuzzCodecFragmentationInput(_: void, smith: *std.testing.Smith) !void {
     const mode: RecordMode = if (smith.index(2) == 0) .plaintext else .ciphertext;
-    var parser = Parser.init(mode);
+    // The initial-ClientHello `0x0301` compatibility window is part of the
+    // generated case, not a separate deterministic-only scenario: when it is
+    // selected the whole oracle stream below becomes the fragments of one
+    // real ClientHello message (all handshake-content-type, so RFC 8446
+    // SS5.1's no-interleaving rule is respected), with each fragment's
+    // declared legacy version independently chosen from {0x0303, 0x0301}.
+    // Every such fragment is inside the window and therefore legal
+    // regardless of the mix, so the exact-consumption oracle applies
+    // unchanged; the illegal placements are asserted separately below.
+    const allow_compat = mode == .plaintext and smith.index(2) == 0;
+    var parser = if (allow_compat)
+        Parser.initWithVersionPolicy(.plaintext, .allow_initial_client_hello_compat)
+    else
+        Parser.init(mode);
 
     const Expected = struct {
         content_type: ContentType,
@@ -1206,54 +1321,123 @@ fn fuzzCodecFragmentationInput(_: void, smith: *std.testing.Smith) !void {
     var expected: [fuzz_codec_max_records]Expected = undefined;
     var stream_buf: [fuzz_codec_max_records * (header_len + fuzz_codec_max_payload)]u8 = undefined;
     var stream_len: usize = 0;
-    const record_count = 1 + smith.index(fuzz_codec_max_records);
+    var record_count: usize = 0;
 
-    for (0..record_count) |i| {
-        var payload_buf: [fuzz_codec_max_payload]u8 = undefined;
-        const payload_len = smith.index(payload_buf.len + 1);
-        smith.bytes(payload_buf[0..payload_len]);
-        const content_type: ContentType = switch (mode) {
-            .plaintext => switch (smith.index(3)) {
-                0 => .handshake,
-                1 => .alert,
-                else => .change_cipher_spec,
-            },
-            .ciphertext => .application_data,
-        };
-        var record_out: [header_len + fuzz_codec_max_payload]u8 = undefined;
-        const encoded = switch (mode) {
-            .plaintext => try encodePlaintextRecord(content_type, payload_buf[0..payload_len], &record_out),
-            .ciphertext => try encodeCiphertextRecord(payload_buf[0..payload_len], &record_out),
-        };
-        @memcpy(stream_buf[stream_len..][0..encoded.len], encoded);
-        stream_len += encoded.len;
-        expected[i] = .{
-            .content_type = content_type,
-            .legacy_version = legacy_record_version,
-            .payload = payload_buf,
-            .payload_len = payload_len,
-        };
+    if (allow_compat) {
+        // One real `msg_type=1, uint24 length, body` ClientHello, split at
+        // fuzzer-chosen boundaries -- including inside its own 4-byte
+        // handshake header, which is exactly the #408 compatibility-window
+        // fragmentation class.
+        var body: [fuzz_codec_max_compat_body]u8 = undefined;
+        const body_len = smith.index(body.len + 1);
+        smith.bytes(body[0..body_len]);
+        var message_buf: [handshake_header_len + fuzz_codec_max_compat_body]u8 = undefined;
+        const message = clientHelloMessage(body[0..body_len], &message_buf);
+
+        const max_fragments = @min(fuzz_codec_max_records, message.len);
+        record_count = 1 + smith.index(max_fragments);
+        var message_offset: usize = 0;
+        for (0..record_count) |i| {
+            const fragments_left = record_count - i;
+            const take = if (fragments_left == 1)
+                message.len - message_offset
+            else
+                1 + smith.index(message.len - message_offset - (fragments_left - 1));
+            const fragment = message[message_offset..][0..take];
+            message_offset += take;
+
+            var record_out: [header_len + fuzz_codec_max_payload]u8 = undefined;
+            const encoded = try encodePlaintextRecord(.handshake, fragment, &record_out);
+            const record_start = stream_len;
+            @memcpy(stream_buf[record_start..][0..encoded.len], encoded);
+            stream_len += encoded.len;
+
+            // `encodePlaintextRecord` always writes 0x0303; rewrite the
+            // version field in place when this fragment should claim the
+            // compatibility version instead.
+            const use_compat_version = smith.index(2) == 0;
+            if (use_compat_version) {
+                std.mem.writeInt(u16, stream_buf[record_start + 1 ..][0..2], compat_client_hello_version, .big);
+            }
+
+            var payload: [fuzz_codec_max_payload]u8 = undefined;
+            @memcpy(payload[0..take], fragment);
+            expected[i] = .{
+                .content_type = .handshake,
+                .legacy_version = if (use_compat_version) compat_client_hello_version else legacy_record_version,
+                .payload = payload,
+                .payload_len = take,
+            };
+        }
+        try testing.expectEqual(message.len, message_offset);
+    } else {
+        record_count = 1 + smith.index(fuzz_codec_max_records);
+        for (0..record_count) |i| {
+            var payload_buf: [fuzz_codec_max_payload]u8 = undefined;
+            const payload_len = smith.index(payload_buf.len + 1);
+            smith.bytes(payload_buf[0..payload_len]);
+            const content_type: ContentType = switch (mode) {
+                .plaintext => switch (smith.index(3)) {
+                    0 => .handshake,
+                    1 => .alert,
+                    else => .change_cipher_spec,
+                },
+                .ciphertext => .application_data,
+            };
+            var record_out: [header_len + fuzz_codec_max_payload]u8 = undefined;
+            const encoded = switch (mode) {
+                .plaintext => try encodePlaintextRecord(content_type, payload_buf[0..payload_len], &record_out),
+                .ciphertext => try encodeCiphertextRecord(payload_buf[0..payload_len], &record_out),
+            };
+            @memcpy(stream_buf[stream_len..][0..encoded.len], encoded);
+            stream_len += encoded.len;
+            expected[i] = .{
+                .content_type = content_type,
+                .legacy_version = legacy_record_version,
+                .payload = payload_buf,
+                .payload_len = payload_len,
+            };
+        }
     }
 
     // Drive the coalesced oracle stream through `feedOne` with a
-    // single-record-capacity sink, so saturation is normal rather than
-    // exceptional: every source byte must be consumed exactly once, in
-    // order, with no record skipped or duplicated.
+    // single-record-capacity sink, offering a fuzzer-chosen *prefix* of the
+    // remaining bytes on every call. Offering less than a whole record is
+    // the point: a partial header or body then stays buffered across the
+    // invocation boundary and must resume exactly on a later call, which is
+    // the caller-visible fragmentation boundary (not merely `feedOne`'s
+    // internal byte loop). Every source byte must still be consumed exactly
+    // once, in order, with no record skipped or duplicated.
     var sink = RecordSink(1, fuzz_codec_max_payload + header_len){};
     var offset: usize = 0;
     var expected_idx: usize = 0;
+    // Progress bound: each iteration consumes at least one offered byte, so
+    // this can only be reached if the parser stops making progress.
+    var iterations: usize = 0;
+    const max_iterations = stream_len * 2 + 16;
     while (offset < stream_len) {
+        iterations += 1;
+        try testing.expect(iterations <= max_iterations);
         try testing.expectEqual(@as(usize, 0), sink.len);
-        const result = try parser.feedOne(stream_buf[offset..stream_len], &sink);
+
+        const remaining = stream_len - offset;
+        const offered_len = 1 + smith.index(remaining);
+        const result = try parser.feedOne(stream_buf[offset..][0..offered_len], &sink);
         try testing.expect(parser.len <= parser.pending.len);
-        try testing.expect(offset + result.consumed <= stream_len);
-        // The remaining slice is always one-or-more complete, well-formed
-        // records (the oracle stream), so a freshly-emptied sink must
-        // always be able to emit exactly the next one.
-        try testing.expect(result.emitted);
+        try testing.expect(result.consumed <= offered_len);
+        offset += result.consumed;
+
+        if (!result.emitted) {
+            // No record completed within the offered fragment, so the whole
+            // fragment must have been absorbed into the bounded pending
+            // buffer -- nothing dropped, nothing emitted.
+            try testing.expectEqual(@as(usize, 0), sink.len);
+            try testing.expectEqual(offered_len, result.consumed);
+            continue;
+        }
+
         try testing.expect(result.consumed > 0);
         try testing.expectEqual(@as(usize, 1), sink.len);
-
         try testing.expect(expected_idx < record_count);
         const exp = expected[expected_idx];
         try testing.expectEqual(exp.content_type, sink.items[0].content_type);
@@ -1261,13 +1445,12 @@ fn fuzzCodecFragmentationInput(_: void, smith: *std.testing.Smith) !void {
         try testing.expectEqualSlices(u8, exp.payload[0..exp.payload_len], sink.items[0].payload);
         try testing.expect(withinBounds(sink.scratch[0..], sink.items[0].payload));
 
-        offset += result.consumed;
         expected_idx += 1;
 
         // Occasionally simulate a caller that has not drained the sink yet:
-        // the next `feedOne` against the following record must consume
-        // nothing and leave parser and stale-sink state untouched, and a
-        // reset + exact retry must then succeed once.
+        // the next `feedOne` must consume nothing and leave parser and
+        // stale-sink state untouched, and a reset + exact retry must then
+        // succeed once.
         if (smith.index(2) == 0 and offset < stream_len) {
             const parser_len_before = parser.len;
             const stale = try parser.feedOne(stream_buf[offset..stream_len], &sink);
@@ -1280,6 +1463,131 @@ fn fuzzCodecFragmentationInput(_: void, smith: *std.testing.Smith) !void {
     }
     try testing.expectEqual(record_count, expected_idx);
     try parser.finish();
+
+    // The compatibility window closes for good once that initial
+    // ClientHello has been fully consumed: a further `0x0301` record on the
+    // same parser must now be refused.
+    if (allow_compat) {
+        var closed_sink = DefaultSink{};
+        try testing.expectError(
+            error.InvalidRecordVersion,
+            parser.feed(&.{ 22, 3, 1, 0, 1, 1 }, &closed_sink),
+        );
+    }
+
+    // Illegal `0x0301` placements. The exception is scoped to an initial
+    // ClientHello on a plaintext parser, so it must be refused for a
+    // non-ClientHello handshake message, a non-handshake content type, and
+    // every ciphertext-mode record -- each against a fresh parser that has
+    // the compatibility policy enabled, so only the placement differs.
+    {
+        // (a) handshake content type, compat version, but `msg_type != 1`.
+        var msg_type_byte: [1]u8 = undefined;
+        smith.bytes(&msg_type_byte);
+        const non_client_hello_type: u8 = if (msg_type_byte[0] == client_hello_msg_type)
+            client_hello_msg_type + 1
+        else
+            msg_type_byte[0];
+        var other_message: [handshake_header_len + 4]u8 = undefined;
+        other_message[0] = non_client_hello_type;
+        other_message[1] = 0;
+        other_message[2] = 0;
+        other_message[3] = 4;
+        smith.bytes(other_message[handshake_header_len..]);
+        var other_record: [header_len + handshake_header_len + 4]u8 = undefined;
+        const other_encoded = try encodePlaintextRecord(.handshake, &other_message, &other_record);
+        std.mem.writeInt(u16, other_record[1..3], compat_client_hello_version, .big);
+
+        var other_parser = Parser.initWithVersionPolicy(.plaintext, .allow_initial_client_hello_compat);
+        var other_sink = DefaultSink{};
+        try testing.expectError(
+            error.InvalidRecordVersion,
+            other_parser.feed(other_encoded, &other_sink),
+        );
+
+        // (b) compat version on a non-handshake content type.
+        const non_handshake: u8 = if (smith.index(2) == 0)
+            @intFromEnum(ContentType.alert)
+        else
+            @intFromEnum(ContentType.change_cipher_spec);
+        var non_handshake_parser = Parser.initWithVersionPolicy(.plaintext, .allow_initial_client_hello_compat);
+        var non_handshake_sink = DefaultSink{};
+        try testing.expectError(
+            error.InvalidRecordVersion,
+            non_handshake_parser.feed(&.{ non_handshake, 3, 1, 0, 1, 1 }, &non_handshake_sink),
+        );
+
+        // (c) compat version has no meaning post-encryption: a
+        // ciphertext-mode parser must refuse it even with the policy set.
+        var cipher_parser = Parser.initWithVersionPolicy(.ciphertext, .allow_initial_client_hello_compat);
+        var cipher_sink = DefaultSink{};
+        try testing.expectError(
+            error.InvalidRecordVersion,
+            cipher_parser.feed(&.{ 23, 3, 1, 0, 0 }, &cipher_sink),
+        );
+    }
+
+    // Record-size boundaries, as a bounded single-record subcase rather
+    // than by making every generated record maximum-sized: zero, one,
+    // exact-maximum-minus-one, and exact-maximum payloads must all traverse
+    // the valid encode/parse/oracle path, and a header that merely
+    // *declares* maximum-plus-one must be refused with `RecordTooLarge`
+    // without that payload ever having to exist.
+    {
+        const max_len: usize = switch (mode) {
+            .plaintext => max_plaintext_fragment_len,
+            .ciphertext => max_ciphertext_fragment_len,
+        };
+        const payload_len = switch (smith.index(5)) {
+            0 => 0,
+            1 => 1,
+            2 => max_len - 1,
+            3 => max_len,
+            else => smith.index(max_len + 1),
+        };
+
+        // Cheap deterministic fill: a fuzzer-chosen seed byte expanded over
+        // the (possibly 16 KiB) payload, rather than drawing that many
+        // bytes from Smith per case. The bytes are not the property under
+        // test here -- the length boundary is.
+        var seed: [1]u8 = undefined;
+        smith.bytes(&seed);
+        var payload_buf: [max_ciphertext_fragment_len]u8 = undefined;
+        for (payload_buf[0..payload_len], 0..) |*byte, i| {
+            byte.* = seed[0] ^ @as(u8, @truncate(i));
+        }
+
+        var record_buf: [max_ciphertext_record_len]u8 = undefined;
+        const boundary_content_type: ContentType = if (mode == .plaintext) .handshake else .application_data;
+        const encoded = switch (mode) {
+            .plaintext => try encodePlaintextRecord(.handshake, payload_buf[0..payload_len], &record_buf),
+            .ciphertext => try encodeCiphertextRecord(payload_buf[0..payload_len], &record_buf),
+        };
+        try testing.expectEqual(header_len + payload_len, encoded.len);
+
+        var boundary_parser = Parser.init(mode);
+        var boundary_sink = RecordSink(1, max_ciphertext_fragment_len){};
+        const boundary_result = try boundary_parser.feedOne(encoded, &boundary_sink);
+        try testing.expect(boundary_result.emitted);
+        try testing.expectEqual(encoded.len, boundary_result.consumed);
+        try testing.expectEqual(@as(usize, 1), boundary_sink.len);
+        try testing.expectEqual(boundary_content_type, boundary_sink.items[0].content_type);
+        try testing.expectEqualSlices(u8, payload_buf[0..payload_len], boundary_sink.items[0].payload);
+        try boundary_parser.finish();
+
+        // Declared maximum-plus-one: only the 2-byte length field changes,
+        // and `max_len + 1` still fits in a `u16` for both modes, so this
+        // needs no oversized allocation at all.
+        var oversized_header: [header_len]u8 = undefined;
+        @memcpy(&oversized_header, encoded[0..header_len]);
+        std.mem.writeInt(u16, oversized_header[3..5], @intCast(max_len + 1), .big);
+        var oversized_parser = Parser.init(mode);
+        var oversized_sink = RecordSink(1, 16){};
+        try testing.expectError(
+            error.RecordTooLarge,
+            oversized_parser.feed(&oversized_header, &oversized_sink),
+        );
+    }
 
     // `drainReady` publishes an already-complete buffered record without
     // accepting new input, and a record that overflows the sink at push
@@ -1337,16 +1645,27 @@ const fuzz_inner_plaintext_max_out = max_ciphertext_fragment_len + 16;
 const fuzz_inner_plaintext_max_padding = 512;
 
 test "fuzz: TLS record: inner plaintext framing, padding, and bounds remain transactional" {
-    try std.testing.fuzz({}, fuzzInnerPlaintextInput, .{ .corpus = &.{
-        "",
-        &[_]u8{0},
-        &[_]u8{ 0, 0, 0 },
-        &[_]u8{ 1, 99, 0 },
-        &[_]u8{ 20, 0 },
-        &[_]u8{ 'f', 'i', 'n', 22, 0, 0, 0 },
-        &([_]u8{0} ** 64 ++ [_]u8{23}),
-        &([_]u8{0xff} ** 128),
-    } });
+    try std.testing.fuzz({}, fuzzInnerPlaintextInput, .{
+        .corpus = &.{
+            "",
+            &[_]u8{0},
+            &[_]u8{ 0, 0, 0 },
+            &[_]u8{ 1, 99, 0 },
+            &[_]u8{ 20, 0 },
+            &[_]u8{ 'f', 'i', 'n', 22, 0, 0, 0 },
+            // Length/capacity-matrix selectors: small leading indices steer the
+            // content/padding/output-capacity switches toward their boundary
+            // arms (0, 1, exact-max-minus-one, exact-max, exact-max-plus-one).
+            &[_]u8{ 0, 0, 0, 0, 0, 0 },
+            &[_]u8{ 1, 1, 1, 1, 1, 1 },
+            &[_]u8{ 2, 3, 4, 5, 0, 1 },
+            &[_]u8{ 3, 4, 5, 2, 1, 0 },
+            &[_]u8{ 4, 5, 3, 0, 2, 1 },
+            &[_]u8{ 5, 2, 0, 1, 3, 4 },
+            &([_]u8{0} ** 64 ++ [_]u8{23}),
+            &([_]u8{0xff} ** 128),
+        },
+    });
 }
 
 /// Independent re-derivation of `decodeInnerPlaintext`'s documented
@@ -1375,49 +1694,162 @@ fn expectedInnerPlaintext(bytes: []const u8) InnerPlaintextOracle {
     return .malformed;
 }
 
+/// The expected outcome of one `encodeInnerPlaintext` call, computed from the
+/// generated inputs *before* the call so the fuzz target asserts an exact
+/// typed error rather than accepting any rejection. Mirrors the documented
+/// rejection order in `encodeInnerPlaintext`: illegal content type, then
+/// oversized content, then overflow/oversized total, then output capacity.
+const InnerPlaintextEncodeOracle = union(enum) {
+    invalid_type,
+    too_large,
+    output_overflow,
+    ok: usize,
+};
+
+fn expectedInnerPlaintextEncode(
+    content_type: ContentType,
+    content_len: usize,
+    padding_len: usize,
+    out_cap: usize,
+) InnerPlaintextEncodeOracle {
+    if (content_type == .change_cipher_spec) return .invalid_type;
+    if (content_len > max_plaintext_fragment_len) return .too_large;
+    const with_type = std.math.add(usize, content_len, 1) catch return .too_large;
+    const total = std.math.add(usize, with_type, padding_len) catch return .too_large;
+    if (total > max_ciphertext_fragment_len) return .too_large;
+    if (out_cap < total) return .output_overflow;
+    return .{ .ok = total };
+}
+
 fn fuzzInnerPlaintextInput(_: void, smith: *std.testing.Smith) !void {
-    // 1. Valid content/type/padding/output-capacity generation, driving
-    // encode -> decode round trips and transactional-output verification on
-    // every rejected encode.
+    // 1. Content type/content/padding/output-capacity generation, driving
+    // encode -> decode round trips, an exact expected-error classification
+    // on every rejection, and transactional-output verification.
     const valid_types = [_]ContentType{ .alert, .handshake, .application_data };
-    const content_type = valid_types[smith.index(valid_types.len)];
-
-    var content_buf: [fuzz_inner_plaintext_max_content]u8 = undefined;
-    const content_len = smith.index(content_buf.len + 1);
-    smith.bytes(content_buf[0..content_len]);
-
-    // Occasionally drive a synthetic near-`usize`-max padding length: the
-    // #493 "overflow-adjacent synthetic limits" requirement, which cannot
-    // be represented by an actual padding allocation.
-    const padding_len: usize = if (smith.index(4) == 0)
-        std.math.maxInt(usize)
+    // `change_cipher_spec` has no legal `TLSInnerPlaintext` encoding and must
+    // always be refused with `InvalidRecordType`, so generate it sometimes
+    // rather than only ever generating encodable types.
+    const content_type: ContentType = if (smith.index(8) == 0)
+        .change_cipher_spec
     else
-        smith.index(fuzz_inner_plaintext_max_padding + 1);
+        valid_types[smith.index(valid_types.len)];
 
-    var out_buf: [fuzz_inner_plaintext_max_out]u8 = undefined;
-    const out_cap = smith.index(out_buf.len + 1);
-    const out = out_buf[0..out_cap];
-    @memset(out, 0xa5);
-    var before_buf: [fuzz_inner_plaintext_max_out]u8 = undefined;
-    @memcpy(before_buf[0..out_cap], out);
-
-    encode_check: {
-        const encoded = encodeInnerPlaintext(content_type, content_buf[0..content_len], padding_len, out) catch {
-            // Every rejected encode (`RecordTooLarge`/`RecordBufferOverflow`/
-            // `InvalidRecordType`) must leave the destination untouched.
-            try testing.expectEqualSlices(u8, before_buf[0..out_cap], out);
-            break :encode_check;
-        };
-        const decoded = try decodeInnerPlaintext(encoded);
-        try testing.expectEqual(content_type, decoded.content_type);
-        try testing.expectEqualSlices(u8, content_buf[0..content_len], decoded.content);
-        try testing.expectEqual(padding_len, decoded.padding_len);
-        try testing.expect(withinBounds(encoded, decoded.content));
+    // Content length matrix around the plaintext-fragment maximum, so the
+    // `content.len > max_plaintext_fragment_len` rejection stage is a
+    // property rather than a deterministic-only test. Large contents are
+    // filled from a cheap seeded pattern instead of drawing 16 KiB from
+    // Smith per case -- the length boundary is what is under test here, not
+    // the byte values.
+    var content_buf: [max_plaintext_fragment_len + 1]u8 = undefined;
+    const content_len = switch (smith.index(7)) {
+        0 => 0,
+        1 => 1,
+        2 => max_plaintext_fragment_len - 1,
+        3 => max_plaintext_fragment_len,
+        4 => max_plaintext_fragment_len + 1,
+        else => smith.index(fuzz_inner_plaintext_max_content + 1),
+    };
+    var content_seed: [1]u8 = undefined;
+    smith.bytes(&content_seed);
+    for (content_buf[0..content_len], 0..) |*byte, i| {
+        byte.* = content_seed[0] ^ @as(u8, @truncate(i));
     }
 
-    // 2. Raw-bytes decode fuzzing against the independent oracle above.
+    // Padding matrix around the *total* inner-plaintext maximum
+    // (`content || type || padding`). Padding carries the bulk of a
+    // maximum-sized total because it is a scalar the encoder zero-fills, so
+    // exact-max and max-plus-one totals need no oversized content buffer.
+    // The `maxInt(usize)` case is the #493 overflow-adjacent synthetic
+    // limit, which no real padding allocation could represent.
+    const padding_headroom = max_ciphertext_fragment_len - @min(content_len, max_ciphertext_fragment_len);
+    const padding_len: usize = switch (smith.index(8)) {
+        0 => std.math.maxInt(usize),
+        1 => 0,
+        2 => 1,
+        // Exact-maximum total, one under, and one over, when the chosen
+        // content length leaves room to express them.
+        3 => if (padding_headroom >= 2) padding_headroom - 2 else 0,
+        4 => if (padding_headroom >= 1) padding_headroom - 1 else 0,
+        5 => padding_headroom,
+        else => smith.index(fuzz_inner_plaintext_max_padding + 1),
+    };
+
+    // Output-capacity matrix around the exact required total, so the
+    // `RecordBufferOverflow` boundary is exercised at exact-minus-one,
+    // exact, and exact-plus-one rather than only at random capacities.
+    var out_buf: [fuzz_inner_plaintext_max_out]u8 = undefined;
+    const required_total: ?usize = switch (expectedInnerPlaintextEncode(content_type, content_len, padding_len, out_buf.len)) {
+        .ok => |total| total,
+        else => null,
+    };
+    const out_cap = switch (smith.index(6)) {
+        0 => if (required_total) |total| @min(total, out_buf.len) else smith.index(out_buf.len + 1),
+        1 => if (required_total) |total| (if (total == 0) 0 else @min(total - 1, out_buf.len)) else smith.index(out_buf.len + 1),
+        2 => if (required_total) |total| @min(total + 1, out_buf.len) else smith.index(out_buf.len + 1),
+        else => smith.index(out_buf.len + 1),
+    };
+    const out = out_buf[0..out_cap];
+    const sentinel: u8 = 0xa5;
+    @memset(out, sentinel);
+
+    switch (expectedInnerPlaintextEncode(content_type, content_len, padding_len, out_cap)) {
+        .invalid_type => {
+            try testing.expectError(
+                error.InvalidRecordType,
+                encodeInnerPlaintext(content_type, content_buf[0..content_len], padding_len, out),
+            );
+            try testing.expect(std.mem.allEqual(u8, out, sentinel));
+        },
+        .too_large => {
+            try testing.expectError(
+                error.RecordTooLarge,
+                encodeInnerPlaintext(content_type, content_buf[0..content_len], padding_len, out),
+            );
+            try testing.expect(std.mem.allEqual(u8, out, sentinel));
+        },
+        .output_overflow => {
+            try testing.expectError(
+                error.RecordBufferOverflow,
+                encodeInnerPlaintext(content_type, content_buf[0..content_len], padding_len, out),
+            );
+            try testing.expect(std.mem.allEqual(u8, out, sentinel));
+        },
+        .ok => |total| {
+            const encoded = try encodeInnerPlaintext(content_type, content_buf[0..content_len], padding_len, out);
+            try testing.expectEqual(total, encoded.len);
+            try testing.expect(withinBounds(out, encoded));
+            const decoded = try decodeInnerPlaintext(encoded);
+            try testing.expectEqual(content_type, decoded.content_type);
+            try testing.expectEqualSlices(u8, content_buf[0..content_len], decoded.content);
+            try testing.expectEqual(padding_len, decoded.padding_len);
+            try testing.expect(withinBounds(encoded, decoded.content));
+            // Bytes past the encoded region must still be untouched.
+            try testing.expect(std.mem.allEqual(u8, out[total..], sentinel));
+        },
+    }
+
+    // 2. Raw-bytes decode fuzzing against the independent oracle above,
+    // with a length matrix that reaches the exact ciphertext-fragment
+    // maximum and one past it (the `RecordTooLarge` decode stage).
     var raw_buf: [fuzz_inner_plaintext_max_out]u8 = undefined;
-    const raw_len = smith.slice(&raw_buf);
+    const raw_len = switch (smith.index(8)) {
+        0 => 0,
+        1 => 1,
+        2 => max_ciphertext_fragment_len - 1,
+        3 => max_ciphertext_fragment_len,
+        4 => max_ciphertext_fragment_len + 1,
+        else => smith.index(fuzz_inner_plaintext_max_content + 1),
+    };
+    // Seeded pattern for the bulk, with the trailing window Smith-filled:
+    // the last nonzero byte is what decides the decoded type/padding split,
+    // so that is the region worth fuzzer control.
+    var raw_seed: [1]u8 = undefined;
+    smith.bytes(&raw_seed);
+    for (raw_buf[0..raw_len], 0..) |*byte, i| {
+        byte.* = raw_seed[0] ^ @as(u8, @truncate(i));
+    }
+    const tail_len = @min(raw_len, 8);
+    smith.bytes(raw_buf[raw_len - tail_len ..][0..tail_len]);
     const raw = raw_buf[0..raw_len];
 
     const oracle = expectedInnerPlaintext(raw);

--- a/src/tls/record_codec.zig
+++ b/src/tls/record_codec.zig
@@ -206,6 +206,25 @@ pub fn RecordSink(comptime max_record_count: usize, comptime max_payload_bytes: 
 
 pub const DefaultSink = RecordSink(16, 64 * 1024);
 
+/// Checked `self_len + queued_len`, factored out of
+/// `Parser.pendingRecordBytesNeededWith`/`pendingRecordPayloadLenWith` so a
+/// synthetic near-`usize`-max length -- impossible to represent with any
+/// real allocation, but exactly the "arithmetic/offset overflow-adjacent
+/// synthetic limits" #493 requires coverage for -- can be driven directly
+/// by a test/fuzzer as a bare scalar, without needing a slice anywhere near
+/// that size.
+fn checkedOwnedLen(self_len: usize, queued_len: usize) Error!usize {
+    return std.math.add(usize, self_len, queued_len) catch error.RecordTooLarge;
+}
+
+/// Checked `header_len + payload_len`, split out for the same reason as
+/// `checkedOwnedLen`. `payload_len` is wire-bounded to a `u16` in practice
+/// (see `parseHeader`), so this can never actually overflow today, but it
+/// stays checked rather than relying on that invariant holding forever.
+fn checkedRecordLen(payload_len: usize) Error!usize {
+    return std.math.add(usize, header_len, payload_len) catch error.RecordTooLarge;
+}
+
 pub const Parser = struct {
     mode: RecordMode,
     pending: [max_ciphertext_record_len]u8 = undefined,
@@ -296,10 +315,11 @@ pub const Parser = struct {
     /// prefix when determining how many *additional socket bytes* could still
     /// advance this record. The queued prefix is not consumed or retained.
     pub fn pendingRecordBytesNeededWith(self: *const Parser, queued: []const u8) Error!usize {
-        if (self.len + queued.len < header_len) return header_len - (self.len + queued.len);
+        const owned = try checkedOwnedLen(self.len, queued.len);
+        if (owned < header_len) return header_len - owned;
         const payload_len = try self.pendingRecordPayloadLenWith(queued) orelse unreachable;
-        const record_len = header_len + payload_len;
-        const already_owned = @min(record_len, self.len + queued.len);
+        const record_len = try checkedRecordLen(payload_len);
+        const already_owned = @min(record_len, owned);
         return record_len - already_owned;
     }
 
@@ -310,7 +330,8 @@ pub const Parser = struct {
             const header = try parseHeader(self.pending[0..header_len], self.mode, self.currentVersionPolicy());
             return header.payload_len;
         }
-        if (self.len + bytes.len < header_len) return null;
+        const combined = try checkedOwnedLen(self.len, bytes.len);
+        if (combined < header_len) return null;
 
         var header_bytes: [header_len]u8 = undefined;
         @memcpy(header_bytes[0..self.len], self.pending[0..self.len]);
@@ -492,16 +513,6 @@ pub fn decodeInnerPlaintext(bytes: []const u8) Error!InnerPlaintext {
 
 fn parseContentType(value: u8) Error!ContentType {
     return std.enums.fromInt(ContentType, value) orelse error.InvalidRecordType;
-}
-
-/// Fuzz entrypoint for #327-G. It intentionally swallows parser errors because
-/// malformed input is the expected corpus majority; crashes and bounds failures
-/// are the signal.
-pub fn fuzzRecordInput(bytes: []const u8) void {
-    var parser = Parser.init(.ciphertext);
-    var sink = DefaultSink{};
-    parser.feed(bytes, &sink) catch {};
-    parser.finish() catch {};
 }
 
 const testing = std.testing;
@@ -1114,6 +1125,311 @@ test "inner plaintext rejects all-zero, invalid type, and oversized content" {
     try testing.expectError(error.RecordTooLarge, encodeInnerPlaintext(.handshake, "", std.math.maxInt(usize), &out));
 }
 
-test "fuzz entrypoint accepts arbitrary bytes without escaping errors" {
-    fuzzRecordInput(&.{ 23, 3, 3, 0, 3, 0, 0, 0, 99, 1, 2 });
+test "checkedOwnedLen rejects a synthetic near-usize-max queued length instead of wrapping" {
+    try testing.expectEqual(@as(usize, 15), try checkedOwnedLen(5, 10));
+    try testing.expectEqual(@as(usize, std.math.maxInt(usize)), try checkedOwnedLen(0, std.math.maxInt(usize)));
+    try testing.expectError(error.RecordTooLarge, checkedOwnedLen(5, std.math.maxInt(usize)));
+    try testing.expectError(error.RecordTooLarge, checkedOwnedLen(std.math.maxInt(usize), std.math.maxInt(usize)));
+}
+
+test "checkedRecordLen rejects a synthetic near-usize-max payload length instead of wrapping" {
+    try testing.expectEqual(@as(usize, header_len + 10), try checkedRecordLen(10));
+    try testing.expectError(error.RecordTooLarge, checkedRecordLen(std.math.maxInt(usize)));
+}
+
+test "pendingRecordBytesNeededWith and pendingRecordPayloadLenWith stay accurate once combined length no longer overflows" {
+    var parser = Parser.init(.plaintext);
+    var sink = DefaultSink{};
+    var encoded: [32]u8 = undefined;
+    const record = try encodePlaintextRecord(.handshake, "hi", &encoded);
+
+    // Header not yet complete: exercises the `checkedOwnedLen` path inside
+    // both `pendingRecordBytesNeededWith` and `pendingRecordPayloadLenWith`.
+    _ = try parser.feedOne(record[0..2], &sink);
+    try testing.expectEqual(@as(usize, header_len - 2), try parser.pendingRecordBytesNeededWith(&.{}));
+    try testing.expectEqual(@as(?usize, null), try parser.pendingRecordPayloadLenWith(&.{}));
+
+    // Header completes exactly from a 3-byte queued prefix (parser already
+    // owns 2 of the 5 header bytes): the still-needed count is the payload
+    // length alone, since header_len (5) == parser.len (2) + queued.len (3).
+    try testing.expectEqual(@as(usize, 2), try parser.pendingRecordPayloadLenWith(record[2..5]));
+    try testing.expectEqual(@as(usize, 2), try parser.pendingRecordBytesNeededWith(record[2..5]));
+}
+
+// -----------------------------------------------------------------------
+// #493 fuzz targets. See docs/CRYPTO_FUZZ_CONTRACT.md's "#493" section for
+// the shared rules these follow (fresh state per case, fixed buffers,
+// explicit bounds, typed-error classification, sanitized diagnostics).
+// -----------------------------------------------------------------------
+
+/// True when `inner` is empty or wholly contained within `outer`'s backing
+/// bytes (pointer-range containment) -- the #493 borrowed-slice-safety
+/// property for sink/decode payload views, matching the equivalent helper
+/// in new_session_ticket.zig's #494 fuzz target.
+fn withinBounds(outer: []const u8, inner: []const u8) bool {
+    if (inner.len == 0) return true;
+    const outer_start = @intFromPtr(outer.ptr);
+    const outer_end = outer_start + outer.len;
+    const inner_start = @intFromPtr(inner.ptr);
+    const inner_end = inner_start + inner.len;
+    return inner_start >= outer_start and inner_end <= outer_end and inner_end >= inner_start;
+}
+
+const fuzz_codec_max_records = 4;
+const fuzz_codec_max_payload = 48;
+
+test "fuzz: TLS record: codec fragmentation, coalescing, and sink saturation preserve exact consumption" {
+    try std.testing.fuzz({}, fuzzCodecFragmentationInput, .{ .corpus = &.{
+        "",
+        &[_]u8{0},
+        &[_]u8{ 0, 0 },
+        &[_]u8{ 22, 3, 3, 0, 0 },
+        &[_]u8{ 22, 3, 3, 0, 5, 1, 2, 3, 4, 5 },
+        &[_]u8{ 21, 3, 3, 0, 2, 1, 0 },
+        &[_]u8{ 20, 3, 3, 0, 1, 1 },
+        &[_]u8{ 23, 3, 3, 0, 3, 9, 9, 9 },
+        &([_]u8{0xff} ** 64),
+        &([_]u8{0x01} ** 200),
+    } });
+}
+
+fn fuzzCodecFragmentationInput(_: void, smith: *std.testing.Smith) !void {
+    const mode: RecordMode = if (smith.index(2) == 0) .plaintext else .ciphertext;
+    var parser = Parser.init(mode);
+
+    const Expected = struct {
+        content_type: ContentType,
+        legacy_version: u16,
+        payload: [fuzz_codec_max_payload]u8,
+        payload_len: usize,
+    };
+    var expected: [fuzz_codec_max_records]Expected = undefined;
+    var stream_buf: [fuzz_codec_max_records * (header_len + fuzz_codec_max_payload)]u8 = undefined;
+    var stream_len: usize = 0;
+    const record_count = 1 + smith.index(fuzz_codec_max_records);
+
+    for (0..record_count) |i| {
+        var payload_buf: [fuzz_codec_max_payload]u8 = undefined;
+        const payload_len = smith.index(payload_buf.len + 1);
+        smith.bytes(payload_buf[0..payload_len]);
+        const content_type: ContentType = switch (mode) {
+            .plaintext => switch (smith.index(3)) {
+                0 => .handshake,
+                1 => .alert,
+                else => .change_cipher_spec,
+            },
+            .ciphertext => .application_data,
+        };
+        var record_out: [header_len + fuzz_codec_max_payload]u8 = undefined;
+        const encoded = switch (mode) {
+            .plaintext => try encodePlaintextRecord(content_type, payload_buf[0..payload_len], &record_out),
+            .ciphertext => try encodeCiphertextRecord(payload_buf[0..payload_len], &record_out),
+        };
+        @memcpy(stream_buf[stream_len..][0..encoded.len], encoded);
+        stream_len += encoded.len;
+        expected[i] = .{
+            .content_type = content_type,
+            .legacy_version = legacy_record_version,
+            .payload = payload_buf,
+            .payload_len = payload_len,
+        };
+    }
+
+    // Drive the coalesced oracle stream through `feedOne` with a
+    // single-record-capacity sink, so saturation is normal rather than
+    // exceptional: every source byte must be consumed exactly once, in
+    // order, with no record skipped or duplicated.
+    var sink = RecordSink(1, fuzz_codec_max_payload + header_len){};
+    var offset: usize = 0;
+    var expected_idx: usize = 0;
+    while (offset < stream_len) {
+        try testing.expectEqual(@as(usize, 0), sink.len);
+        const result = try parser.feedOne(stream_buf[offset..stream_len], &sink);
+        try testing.expect(parser.len <= parser.pending.len);
+        try testing.expect(offset + result.consumed <= stream_len);
+        // The remaining slice is always one-or-more complete, well-formed
+        // records (the oracle stream), so a freshly-emptied sink must
+        // always be able to emit exactly the next one.
+        try testing.expect(result.emitted);
+        try testing.expect(result.consumed > 0);
+        try testing.expectEqual(@as(usize, 1), sink.len);
+
+        try testing.expect(expected_idx < record_count);
+        const exp = expected[expected_idx];
+        try testing.expectEqual(exp.content_type, sink.items[0].content_type);
+        try testing.expectEqual(exp.legacy_version, sink.items[0].legacy_version);
+        try testing.expectEqualSlices(u8, exp.payload[0..exp.payload_len], sink.items[0].payload);
+        try testing.expect(withinBounds(sink.scratch[0..], sink.items[0].payload));
+
+        offset += result.consumed;
+        expected_idx += 1;
+
+        // Occasionally simulate a caller that has not drained the sink yet:
+        // the next `feedOne` against the following record must consume
+        // nothing and leave parser and stale-sink state untouched, and a
+        // reset + exact retry must then succeed once.
+        if (smith.index(2) == 0 and offset < stream_len) {
+            const parser_len_before = parser.len;
+            const stale = try parser.feedOne(stream_buf[offset..stream_len], &sink);
+            try testing.expectEqual(@as(usize, 0), stale.consumed);
+            try testing.expect(stale.emitted);
+            try testing.expectEqual(parser_len_before, parser.len);
+            try testing.expectEqualSlices(u8, exp.payload[0..exp.payload_len], sink.items[0].payload);
+        }
+        sink.reset();
+    }
+    try testing.expectEqual(record_count, expected_idx);
+    try parser.finish();
+
+    // `drainReady` publishes an already-complete buffered record without
+    // accepting new input, and a record that overflows the sink at push
+    // time stays buffered for an exact retry rather than being dropped or
+    // double-counted -- the #408 sink-saturation regression class, replayed
+    // here against fuzzer-chosen content.
+    {
+        var backpressure_parser = Parser.init(mode);
+        var backpressure_sink = RecordSink(1, 32){};
+        try backpressure_sink.push(.{ .content_type = .alert, .legacy_version = legacy_record_version, .payload = "x" });
+
+        var one_byte: [1]u8 = undefined;
+        smith.bytes(&one_byte);
+        var record_out: [header_len + 1]u8 = undefined;
+        const encoded = switch (mode) {
+            .plaintext => try encodePlaintextRecord(.handshake, &one_byte, &record_out),
+            .ciphertext => try encodeCiphertextRecord(&one_byte, &record_out),
+        };
+
+        try testing.expectError(error.RecordSinkOverflow, backpressure_parser.feed(encoded, &backpressure_sink));
+        try testing.expectEqualStrings("x", backpressure_sink.items[0].payload);
+
+        backpressure_sink.reset();
+        try backpressure_parser.drainReady(&backpressure_sink);
+        try testing.expectEqual(@as(usize, 1), backpressure_sink.len);
+        try testing.expectEqualSlices(u8, &one_byte, backpressure_sink.items[0].payload);
+        try backpressure_parser.finish();
+    }
+
+    // `finish()` only succeeds with no partial record buffered.
+    {
+        var truncated_parser = Parser.init(mode);
+        var truncated_sink = DefaultSink{};
+        var trunc_byte: [1]u8 = undefined;
+        smith.bytes(&trunc_byte);
+        try truncated_parser.feed(trunc_byte[0..1], &truncated_sink);
+        try testing.expectError(error.TruncatedRecord, truncated_parser.finish());
+    }
+
+    // Arbitrary bytes into a fresh parser: malformed input is the expected
+    // majority outcome and must produce only the documented codec errors
+    // (guaranteed by `Error`'s return type) without panicking, spinning, or
+    // growing the pending buffer beyond its fixed capacity.
+    var junk_buf: [256]u8 = undefined;
+    const junk_len = smith.slice(&junk_buf);
+    var junk_parser = Parser.init(mode);
+    var junk_sink = DefaultSink{};
+    junk_parser.feed(junk_buf[0..junk_len], &junk_sink) catch {};
+    junk_parser.finish() catch {};
+    try testing.expect(junk_parser.len <= junk_parser.pending.len);
+}
+
+const fuzz_inner_plaintext_max_content = 512;
+const fuzz_inner_plaintext_max_out = max_ciphertext_fragment_len + 16;
+const fuzz_inner_plaintext_max_padding = 512;
+
+test "fuzz: TLS record: inner plaintext framing, padding, and bounds remain transactional" {
+    try std.testing.fuzz({}, fuzzInnerPlaintextInput, .{ .corpus = &.{
+        "",
+        &[_]u8{0},
+        &[_]u8{ 0, 0, 0 },
+        &[_]u8{ 1, 99, 0 },
+        &[_]u8{ 20, 0 },
+        &[_]u8{ 'f', 'i', 'n', 22, 0, 0, 0 },
+        &([_]u8{0} ** 64 ++ [_]u8{23}),
+        &([_]u8{0xff} ** 128),
+    } });
+}
+
+/// Independent re-derivation of `decodeInnerPlaintext`'s documented
+/// semantics (RFC 8446 SS5.2: strip trailing zero padding, the last nonzero
+/// byte is the real `ContentType`), so the fuzz property compares the
+/// implementation against a second, explicit statement of the contract
+/// rather than just checking "does not crash".
+const InnerPlaintextOracle = union(enum) {
+    malformed,
+    too_large,
+    ok: struct { content_type: ContentType, content_len: usize, padding_len: usize },
+};
+
+fn expectedInnerPlaintext(bytes: []const u8) InnerPlaintextOracle {
+    if (bytes.len == 0) return .malformed;
+    if (bytes.len > max_ciphertext_fragment_len) return .too_large;
+    var index = bytes.len;
+    while (index > 0) {
+        index -= 1;
+        if (bytes[index] != 0) {
+            const content_type = std.enums.fromInt(ContentType, bytes[index]) orelse return .malformed;
+            if (content_type == .change_cipher_spec) return .malformed;
+            return .{ .ok = .{ .content_type = content_type, .content_len = index, .padding_len = bytes.len - index - 1 } };
+        }
+    }
+    return .malformed;
+}
+
+fn fuzzInnerPlaintextInput(_: void, smith: *std.testing.Smith) !void {
+    // 1. Valid content/type/padding/output-capacity generation, driving
+    // encode -> decode round trips and transactional-output verification on
+    // every rejected encode.
+    const valid_types = [_]ContentType{ .alert, .handshake, .application_data };
+    const content_type = valid_types[smith.index(valid_types.len)];
+
+    var content_buf: [fuzz_inner_plaintext_max_content]u8 = undefined;
+    const content_len = smith.index(content_buf.len + 1);
+    smith.bytes(content_buf[0..content_len]);
+
+    // Occasionally drive a synthetic near-`usize`-max padding length: the
+    // #493 "overflow-adjacent synthetic limits" requirement, which cannot
+    // be represented by an actual padding allocation.
+    const padding_len: usize = if (smith.index(4) == 0)
+        std.math.maxInt(usize)
+    else
+        smith.index(fuzz_inner_plaintext_max_padding + 1);
+
+    var out_buf: [fuzz_inner_plaintext_max_out]u8 = undefined;
+    const out_cap = smith.index(out_buf.len + 1);
+    const out = out_buf[0..out_cap];
+    @memset(out, 0xa5);
+    var before_buf: [fuzz_inner_plaintext_max_out]u8 = undefined;
+    @memcpy(before_buf[0..out_cap], out);
+
+    encode_check: {
+        const encoded = encodeInnerPlaintext(content_type, content_buf[0..content_len], padding_len, out) catch {
+            // Every rejected encode (`RecordTooLarge`/`RecordBufferOverflow`/
+            // `InvalidRecordType`) must leave the destination untouched.
+            try testing.expectEqualSlices(u8, before_buf[0..out_cap], out);
+            break :encode_check;
+        };
+        const decoded = try decodeInnerPlaintext(encoded);
+        try testing.expectEqual(content_type, decoded.content_type);
+        try testing.expectEqualSlices(u8, content_buf[0..content_len], decoded.content);
+        try testing.expectEqual(padding_len, decoded.padding_len);
+        try testing.expect(withinBounds(encoded, decoded.content));
+    }
+
+    // 2. Raw-bytes decode fuzzing against the independent oracle above.
+    var raw_buf: [fuzz_inner_plaintext_max_out]u8 = undefined;
+    const raw_len = smith.slice(&raw_buf);
+    const raw = raw_buf[0..raw_len];
+
+    const oracle = expectedInnerPlaintext(raw);
+    switch (oracle) {
+        .malformed => try testing.expectError(error.MalformedInnerPlaintext, decodeInnerPlaintext(raw)),
+        .too_large => try testing.expectError(error.RecordTooLarge, decodeInnerPlaintext(raw)),
+        .ok => |exp| {
+            const got = try decodeInnerPlaintext(raw);
+            try testing.expectEqual(exp.content_type, got.content_type);
+            try testing.expectEqualSlices(u8, raw[0..exp.content_len], got.content);
+            try testing.expectEqual(exp.padding_len, got.padding_len);
+            try testing.expect(withinBounds(raw, got.content));
+        },
+    }
 }

--- a/src/tls/record_epoch_bridge.zig
+++ b/src/tls/record_epoch_bridge.zig
@@ -209,7 +209,7 @@ pub const Bridge = struct {
         return switch (epoch) {
             .initial => blk: {
                 if (self.initial_discarded) return error.UnsupportedRecordEpoch;
-                const needed = plaintextHandshakeRecordLen(bytes.len);
+                const needed = try plaintextHandshakeRecordLen(bytes.len);
                 if (out.len < needed) return error.RecordBufferOverflow;
                 var in_pos: usize = 0;
                 var out_pos: usize = 0;
@@ -243,20 +243,20 @@ pub const Bridge = struct {
             .initial => if (self.initial_discarded)
                 error.UnsupportedRecordEpoch
             else
-                plaintextHandshakeRecordLen(bytes_len),
+                try plaintextHandshakeRecordLen(bytes_len),
             .handshake => blk: {
                 const write = self.writeHandshake() orelse return error.MissingWriteKeys;
-                break :blk protectedHandshakeRecordLen(write, bytes_len);
+                break :blk try protectedHandshakeRecordLen(write, bytes_len);
             },
             .application => blk: {
                 if (!self.handshake_complete) return error.HandshakeNotComplete;
                 const write = self.writeApplication() orelse return error.MissingWriteKeys;
-                break :blk protectedHandshakeRecordLen(write, bytes_len);
+                break :blk try protectedHandshakeRecordLen(write, bytes_len);
             },
             .zero_rtt => blk: {
                 if (self.handshake_complete) return error.UnsupportedRecordEpoch;
                 const write = self.writeZeroRtt() orelse return error.MissingWriteKeys;
-                break :blk protectedHandshakeRecordLen(write, bytes_len);
+                break :blk try protectedHandshakeRecordLen(write, bytes_len);
             },
         };
     }
@@ -424,14 +424,33 @@ fn clearWrite(slot: *?record_protection.WriteState) void {
     slot.* = null;
 }
 
-fn plaintextHandshakeRecordLen(bytes_len: usize) usize {
-    const chunks = (bytes_len + record_codec.max_plaintext_fragment_len - 1) / record_codec.max_plaintext_fragment_len;
-    return bytes_len + chunks * record_codec.header_len;
+/// Number of `max_plaintext_fragment_len`-sized chunks `bytes_len` splits
+/// into (0 for an empty input). Uses `std.math.divCeil`'s
+/// `@divFloor(numerator - 1, denominator) + 1` form rather than the
+/// `(bytes_len + chunk_size - 1) / chunk_size` idiom, so a synthetic
+/// near-`usize`-max `bytes_len` -- impossible to represent with a real
+/// allocation, but exactly the "arithmetic/offset overflow-adjacent
+/// synthetic limits" #493 requires coverage for -- never overflows this
+/// step's own `+ chunk_size - 1` addition; the `Error!` return still exists
+/// because callers (`plaintextHandshakeRecordLen`/
+/// `protectedHandshakeRecordLen`) add `bytes_len` back on top of the chunk
+/// overhead, and that addition can overflow even though this one can't.
+fn chunkCount(bytes_len: usize) Error!usize {
+    if (bytes_len == 0) return 0;
+    return std.math.divCeil(usize, bytes_len, record_codec.max_plaintext_fragment_len) catch error.RecordTooLarge;
 }
 
-fn protectedHandshakeRecordLen(write: *const record_protection.WriteState, bytes_len: usize) usize {
-    const chunks = (bytes_len + record_codec.max_plaintext_fragment_len - 1) / record_codec.max_plaintext_fragment_len;
-    return bytes_len + chunks * (record_codec.header_len + 1 + write.keys.profile.aead.tagLength());
+fn plaintextHandshakeRecordLen(bytes_len: usize) Error!usize {
+    const chunks = try chunkCount(bytes_len);
+    const overhead = std.math.mul(usize, chunks, record_codec.header_len) catch return error.RecordTooLarge;
+    return std.math.add(usize, bytes_len, overhead) catch error.RecordTooLarge;
+}
+
+fn protectedHandshakeRecordLen(write: *const record_protection.WriteState, bytes_len: usize) Error!usize {
+    const chunks = try chunkCount(bytes_len);
+    const per_chunk_overhead = record_codec.header_len + 1 + write.keys.profile.aead.tagLength();
+    const overhead = std.math.mul(usize, chunks, per_chunk_overhead) catch return error.RecordTooLarge;
+    return std.math.add(usize, bytes_len, overhead) catch error.RecordTooLarge;
 }
 
 fn sealHandshakeFragments(
@@ -440,9 +459,9 @@ fn sealHandshakeFragments(
     out: []u8,
 ) Error![]const u8 {
     if (write.exhausted) return error.SequenceExhausted;
-    const chunks = (bytes.len + record_codec.max_plaintext_fragment_len - 1) / record_codec.max_plaintext_fragment_len;
+    const chunks = try chunkCount(bytes.len);
     if (chunks > 0 and chunks - 1 > std.math.maxInt(u64) - write.sequence) return error.SequenceExhausted;
-    const needed = protectedHandshakeRecordLen(write, bytes.len);
+    const needed = try protectedHandshakeRecordLen(write, bytes.len);
     if (out.len < needed) return error.RecordBufferOverflow;
 
     var in_pos: usize = 0;
@@ -491,6 +510,34 @@ fn expectAes128TrafficKeys(traffic_secret: [32]u8, keys: record_protection.Traff
 }
 
 const testing = std.testing;
+
+test "chunkCount stays overflow-safe at a synthetic near-usize-max bytes_len" {
+    try testing.expectEqual(@as(usize, 0), try chunkCount(0));
+    try testing.expectEqual(@as(usize, 1), try chunkCount(1));
+    try testing.expectEqual(@as(usize, 1), try chunkCount(record_codec.max_plaintext_fragment_len));
+    try testing.expectEqual(@as(usize, 2), try chunkCount(record_codec.max_plaintext_fragment_len + 1));
+    // `divCeil`'s `@divFloor(numerator - 1, denominator) + 1` form (unlike
+    // the naive `(numerator + denominator - 1) / denominator` idiom this
+    // replaced) cannot itself overflow for a positive numerator/denominator,
+    // so a synthetic near-`usize`-max `bytes_len` still succeeds here with a
+    // huge-but-exact chunk count; the overflow this hardening actually
+    // guards against surfaces one step later, in
+    // `plaintextHandshakeRecordLen`/`protectedHandshakeRecordLen`'s
+    // `bytes_len + chunks * overhead` addition (see the next test).
+    try testing.expectEqual(
+        try std.math.divCeil(usize, std.math.maxInt(usize), record_codec.max_plaintext_fragment_len),
+        try chunkCount(std.math.maxInt(usize)),
+    );
+}
+
+test "plaintextHandshakeRecordLen rejects synthetic overflow-adjacent bytes_len" {
+    try testing.expectEqual(@as(usize, 0), try plaintextHandshakeRecordLen(0));
+    try testing.expectEqual(
+        record_codec.max_plaintext_fragment_len + record_codec.header_len,
+        try plaintextHandshakeRecordLen(record_codec.max_plaintext_fragment_len),
+    );
+    try testing.expectError(error.RecordTooLarge, plaintextHandshakeRecordLen(std.math.maxInt(usize)));
+}
 
 test "record epoch bridge drives event loopback across plaintext, handshake, application, and post-handshake records" {
     const cp = testProvider();
@@ -604,6 +651,33 @@ test "record epoch bridge fragments large post-handshake messages into multiple 
     }
     try testing.expectEqual(payload.len, offset);
     try testing.expectEqualSlices(u8, &payload, &reassembled);
+}
+
+test "sealedHandshakeLen rejects a synthetic overflow-adjacent bytes_len at every installed epoch" {
+    const cp = testProvider();
+    var server = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer server.deinit();
+
+    const hs = secret(0x73);
+    const app = secret(0x74);
+    try server.installTrafficSecret(.handshake, .write, &hs);
+    try testing.expectError(error.RecordTooLarge, server.sealedHandshakeLen(.handshake, std.math.maxInt(usize)));
+
+    try server.installTrafficSecret(.handshake, .read, &hs);
+    try server.installTrafficSecret(.application, .read, &app);
+    try server.installTrafficSecret(.application, .write, &app);
+    try server.discardEpoch(.initial);
+    try server.discardEpoch(.handshake);
+    try server.markHandshakeComplete();
+    try testing.expectError(error.RecordTooLarge, server.sealedHandshakeLen(.application, std.math.maxInt(usize)));
+
+    // A small, real length still computes correctly alongside the rejected
+    // synthetic one, proving the checked helpers didn't just start
+    // rejecting everything.
+    try testing.expectEqual(
+        @as(usize, 4 + record_codec.header_len + 1 + 16),
+        try server.sealedHandshakeLen(.application, 4),
+    );
 }
 
 test "record epoch bridge rejects early, duplicate, missing, and unsupported transitions" {


### PR DESCRIPTION
## Summary
- First of three planned PRs for #493 (record/protection/epoch/encrypted-stream fuzzing, epic #325-K), per the issue's own "Implementation plan / agent handoff" comment recommending a 493-A/493-B/493-C split — mirroring how #494 was delivered as #574 (494-A) + #575 (494-B).
- Adds `test-tls-record-fuzz` build step + `-Dtls-record-test-filter` option in `build.zig`, matching the existing `test-tls-resumption-fuzz`/`test-tls-protocol-fuzz` pattern.
- Adds two `std.testing.Smith` fuzz targets in `src/tls/record_codec.zig`:
  - `fuzz: TLS record: codec fragmentation, coalescing, and sink saturation preserve exact consumption` — drives fuzzer-generated valid record streams through `Parser.feedOne` against a single-record-capacity sink, asserting exact per-record byte consumption, correct saturation/`drainReady`/`finish` backpressure semantics (the #408 regression class), and that arbitrary malformed bytes into a fresh parser never panic or exceed the fixed pending buffer.
  - `fuzz: TLS record: inner plaintext framing, padding, and bounds remain transactional` — fuzzes `encodeInnerPlaintext`/`decodeInnerPlaintext` round trips plus raw-byte decoding against an independent last-nonzero-byte oracle, asserting transactional output on every rejected encode and borrowed-slice containment on every accepted decode.
- Removes the shallow, superseded `#327-G` `fuzzRecordInput` helper (unused elsewhere, no real corpus, swallowed all errors).
- Hardens record-length-only arithmetic reachable from fuzzer-chosen scalar lengths to checked `std.math` arithmetic (per the issue's "harden synthetic length arithmetic" requirement), each with its own named boundary test:
  - `record_codec.zig`: new `checkedOwnedLen`/`checkedRecordLen` helpers back `Parser.pendingRecordBytesNeededWith`/`pendingRecordPayloadLenWith`.
  - `record_epoch_bridge.zig`: new `chunkCount` helper (via `std.math.divCeil`) backs `plaintextHandshakeRecordLen`/`protectedHandshakeRecordLen`/`sealHandshakeFragments`/`sealedHandshakeLen`.
  - `encrypted_stream.zig`: `handshakeRecordCount` converted the same way.
- Adds a `#493` section to `docs/CRYPTO_FUZZ_CONTRACT.md` documenting the target names, delivery split, and reproduction commands, and a `CHANGELOG.md` Testing entry.

## Test plan
- [x] `zig fmt --check build.zig src/ tests/`
- [x] `zig build test-tls-record-fuzz --summary all --error-style verbose` (deterministic corpus replay, 4/4 pass)
- [x] `zig build test-tls --summary all --error-style verbose` (905/905 pass)
- [x] `zig build test --summary all --error-style verbose` (3180/3181 pass, 1 pre-existing skip per repo convention — sandboxed UDP smoke test)
- [x] `zig build test -Dtls-profile=appliance --summary all --error-style verbose` (3149/3150 pass, same pre-existing skip)
- [x] Bounded `ReleaseFast` fuzz smoke, 200,000 runs each, no crashes:
  - `zig build test-tls-record-fuzz -Doptimize=ReleaseFast -Dtls-record-test-filter="fuzz: TLS record: codec fragmentation, coalescing, and sink saturation preserve exact consumption" --fuzz=200000`
  - `zig build test-tls-record-fuzz -Doptimize=ReleaseFast -Dtls-record-test-filter="fuzz: TLS record: inner plaintext framing, padding, and bounds remain transactional" --fuzz=200000`

## Follow-on

493-B (record protection + epoch/key lifecycle) and 493-C (scripted in-memory carrier + encrypted-stream progression + docs closeout) are tracked as separate follow-on PRs against the same issue.

Closes: none (partial — #493 stays open for 493-B/493-C)
Ref #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)