### PR TITLE
security: [493-B] fuzz TLS record protection and epoch/key lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,8 +83,12 @@ All notable user-facing changes to Tardigrade are documented here.
   retained key after discard or teardown, or a read sequence consumed by a
   failed open all fail the property. Adds named deterministic companions
   pinning every seal/open rejection stage per suite, record-protection
-  teardown zeroization, and a scripted full epoch progression through
-  teardown.
+  teardown zeroization, a scripted full epoch progression through teardown,
+  and a post-teardown 0-RTT reinstall regression for the terminal-teardown
+  defect recorded under Fixed below. The model states "teardown is terminal"
+  as its own rule rather than re-deriving it from the bridge's per-epoch
+  flags, which is what turns that defect into a detected disagreement
+  instead of a match.
 
 ### Features
 - **QUIC negotiated TLS suite packet protection (#566)** — Handshake, 0-RTT,
@@ -748,6 +752,19 @@ All notable user-facing changes to Tardigrade are documented here.
   number space so Initial, Handshake, and Application ranges cannot merge.
 
 ### Fixed
+- **TLS record epoch bridge teardown is now terminal (#493-B)** — found by
+  review of the #493-B fuzz oracle. `Bridge.deinit()` wipes every key slot
+  and sets the initial/handshake/application discard flags, but it also
+  resets `handshake_complete` to false — and that flag was the *only*
+  condition `installTrafficSecret(.zero_rtt, ...)` checked. A torn-down
+  bridge could therefore have fresh 0-RTT read and write keys installed and
+  resume sealing and opening records on that epoch, so teardown was not
+  actually terminal for the one epoch whose gate `deinit` reopened. `Bridge`
+  now carries a `torn_down` flag that `deinit` sets and nothing clears, and
+  `installTrafficSecret` rejects every epoch and direction once it is set;
+  starting a new session remains `Bridge.init`, which yields a fresh value
+  with the flag clear. No production caller reused a bridge after `deinit`,
+  so this only closes the resurrection path.
 - **Checked-in side-channel, secret-lifetime, and observability audit for
   native TLS/QUIC/PKI (#375)** — adds `docs/CRYPTO_SECURITY_AUDIT.md` (the
   audit matrix) and `docs/SECURITY_REVIEW_CHECKLIST.md` (the reusable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,11 +84,11 @@ All notable user-facing changes to Tardigrade are documented here.
   failed open all fail the property. Adds named deterministic companions
   pinning every seal/open rejection stage per suite, record-protection
   teardown zeroization, a scripted full epoch progression through teardown,
-  and a post-teardown 0-RTT reinstall regression for the terminal-teardown
-  defect recorded under Fixed below. The model states "teardown is terminal"
-  as its own rule rather than re-deriving it from the bridge's per-epoch
-  flags, which is what turns that defect into a detected disagreement
-  instead of a match.
+  and a 0-RTT reinstall regression for each of the two teardown paths behind
+  the terminal-teardown defect recorded under Fixed below. The model states
+  "a torn-down session never acquires key material again" as its own rule
+  rather than re-deriving it from the bridge's per-epoch flags, which is
+  what turns those defects into detected disagreements instead of matches.
 
 ### Features
 - **QUIC negotiated TLS suite packet protection (#566)** — Handshake, 0-RTT,
@@ -753,18 +753,23 @@ All notable user-facing changes to Tardigrade are documented here.
 
 ### Fixed
 - **TLS record epoch bridge teardown is now terminal (#493-B)** — found by
-  review of the #493-B fuzz oracle. `Bridge.deinit()` wipes every key slot
-  and sets the initial/handshake/application discard flags, but it also
-  resets `handshake_complete` to false — and that flag was the *only*
-  condition `installTrafficSecret(.zero_rtt, ...)` checked. A torn-down
-  bridge could therefore have fresh 0-RTT read and write keys installed and
-  resume sealing and opening records on that epoch, so teardown was not
-  actually terminal for the one epoch whose gate `deinit` reopened. `Bridge`
-  now carries a `torn_down` flag that `deinit` sets and nothing clears, and
-  `installTrafficSecret` rejects every epoch and direction once it is set;
-  starting a new session remains `Bridge.init`, which yields a fresh value
-  with the flag clear. No production caller reused a bridge after `deinit`,
-  so this only closes the resurrection path.
+  review of the #493-B fuzz oracle. The record contract has two session
+  teardown paths, and both reset `handshake_complete` to false — which was
+  the *only* condition `installTrafficSecret(.zero_rtt, ...)` checked. After
+  either one, a bridge could have fresh 0-RTT read and write keys installed
+  and resume sealing and opening records on that epoch:
+  - `Bridge.deinit()`, the unconditional wipe for an abandoned or failed
+    handshake; and
+  - `discardEpoch(.application)`, the *orderly* teardown of a completed
+    session, which that function's own documentation calls session teardown.
+
+  `Bridge` now carries a `torn_down` flag that both paths set and nothing
+  clears, and `installTrafficSecret` rejects every epoch and direction once
+  it is set; starting a new session remains `Bridge.init`, which yields a
+  fresh value with the flag clear. 0-RTT discard is deliberately unaffected:
+  it is epoch-scoped rather than session teardown, emitted whenever early
+  data ends including mid-handshake. No production caller reused a bridge
+  after either teardown path, so this only closes the resurrection paths.
 - **Checked-in side-channel, secret-lifetime, and observability audit for
   native TLS/QUIC/PKI (#375)** — adds `docs/CRYPTO_SECURITY_AUDIT.md` (the
   audit matrix) and `docs/SECURITY_REVIEW_CHECKLIST.md` (the reusable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,39 @@ All notable user-facing changes to Tardigrade are documented here.
   `zig build test`/`zig build test-tls` (already run deterministically) via
   the new `test-tls-record-fuzz` step and `-Dtls-record-test-filter` build
   option for targeted longer coverage-guided runs.
+- **TLS record protection and epoch/key-lifecycle fuzz targets (#493-B, epic
+  #325-K)** — adds two more `std.testing.Smith` targets under the same
+  `test-tls-record-fuzz` step. `protection tamper and sequence boundaries
+  preserve authentication state` (in `src/tls/record_protection.zig`)
+  classifies every `WriteState.seal` outcome before the call and asserts the
+  exact typed error with an unchanged sequence and untouched destination on
+  each rejection, over suite, traffic-secret-length, content, padding,
+  output-capacity, and sequence matrices that reach the exact
+  maximum sealed payload, one past it, a synthetic near-`usize`-max padding
+  length, and both ends of the 64-bit sequence-exhaustion boundary. Each
+  sealed record then runs a tamper battery (ciphertext and tag bit flips,
+  tag truncation, associated-data type/version mutation, wrong read
+  sequence, wrong traffic secret, wrong suite-derived keys,
+  authenticated-but-malformed inner plaintext, exact-minus-one output
+  buffer) against one shared read state, asserting that authentication
+  failure never advances the sequence and never exposes unauthenticated
+  plaintext, that preflight failures leave the caller's buffer untouched,
+  and that a legitimate open still succeeds afterwards. A test-only
+  capability-masking/fault-injecting provider wrapper makes the documented
+  `UnsupportedCapability` and `InvalidInput` provider error classes
+  reachable deterministically instead of inventing errors the record API
+  cannot return. `epoch operation sequences preserve one-way key lifecycle`
+  (in `src/tls/record_epoch_bridge.zig`) runs bounded programs of up to 48
+  install/discard/complete/suite-update/seal/open/teardown operations against
+  a `Bridge` and an independent reference model, comparing a full state
+  snapshot — both direction phases, all discard and completion flags, the
+  negotiated suite, and per-slot key presence *and* sequence — after every
+  operation, so a premature, duplicate, or partially applied transition, a
+  retained key after discard or teardown, or a read sequence consumed by a
+  failed open all fail the property. Adds named deterministic companions
+  pinning every seal/open rejection stage per suite, record-protection
+  teardown zeroization, and a scripted full epoch progression through
+  teardown.
 
 ### Features
 - **QUIC negotiated TLS suite packet protection (#566)** — Handshake, 0-RTT,

--- a/docs/CRYPTO_FUZZ_CONTRACT.md
+++ b/docs/CRYPTO_FUZZ_CONTRACT.md
@@ -717,18 +717,40 @@ issue's implementation-plan comment:
   opened a record under the wrong epoch's keys, or that consumed a read
   sequence number on a failed open, fails here.
 
+  Terminal teardown is stated in the model as its own rule (`torn_down`)
+  rather than being re-derived from the per-epoch discard and completion
+  flags. That distinction is load-bearing: review of this slice found the
+  model had reproduced a real `Bridge` defect instead of detecting it.
+  `deinit` resets `handshake_complete` to false, which was the *only* gate
+  `installTrafficSecret(.zero_rtt, ...)` checked, so a torn-down bridge could
+  reinstall both 0-RTT directions and resume sealing and opening records on
+  that epoch — and because the model derived the same rule from the same
+  flags, model and implementation compared equal all the way through the
+  resurrection. `Bridge` now carries a `torn_down` flag that `deinit` sets
+  and nothing clears (starting a new session is `Bridge.init`), the model
+  states the rule independently, and the snapshot compares the flag. The
+  general lesson for #493-C and later slices: a reference model that
+  paraphrases the implementation's own gate expressions can only find
+  inconsistencies, not policy violations — rules the contract requires
+  should be written from the contract.
+
   Following #493-A's standard, both targets have named deterministic
   companions for the classifications CI's seed replay cannot reliably reach:
   `seal classifies every rejection stage at its exact boundary for every
   suite`, `open classifies every rejection stage at its exact boundary and
   never advances read state`, `record protection teardown zeroizes keys,
   resets sequence, and marks state exhausted`, and `the epoch lifecycle
-  model agrees with a scripted full progression through teardown`. All four
-  were validated by mutation: dropping `discardEpoch(.application)`'s
-  `handshake_complete = false` and swapping `seal`'s `RecordBufferOverflow`
-  for `RecordTooLarge` each fail under plain `zig build test-tls`, while the
-  corpus replay alone caught neither (a coverage-guided run found the epoch
-  one in 16 runs).
+  model agrees with a scripted full progression through teardown`, plus
+  `record epoch bridge cannot reinstall zero-rtt keys after teardown` for
+  the defect above. All were validated by mutation: dropping
+  `discardEpoch(.application)`'s `handshake_complete = false`, swapping
+  `seal`'s `RecordBufferOverflow` for `RecordTooLarge`, and removing
+  `installTrafficSecret`'s `torn_down` guard each fail under plain
+  `zig build test-tls`, while the corpus replay alone caught none of them
+  (coverage-guided runs found the first in 16 runs and the teardown one in
+  17). Removing the *model's* independent `torn_down` rule while leaving the
+  production guard in place also fails the scripted companion, so the
+  oracle cannot silently regress back to mirroring the implementation.
 - **#493-C** (scripted in-memory carrier, encrypted-stream progression, docs
   closeout) is tracked as a follow-on slice of the same issue and will
   extend this section and the `-Dtls-record-test-filter` namespace when it

--- a/docs/CRYPTO_FUZZ_CONTRACT.md
+++ b/docs/CRYPTO_FUZZ_CONTRACT.md
@@ -720,19 +720,33 @@ issue's implementation-plan comment:
   Terminal teardown is stated in the model as its own rule (`torn_down`)
   rather than being re-derived from the per-epoch discard and completion
   flags. That distinction is load-bearing: review of this slice found the
-  model had reproduced a real `Bridge` defect instead of detecting it.
-  `deinit` resets `handshake_complete` to false, which was the *only* gate
-  `installTrafficSecret(.zero_rtt, ...)` checked, so a torn-down bridge could
-  reinstall both 0-RTT directions and resume sealing and opening records on
-  that epoch — and because the model derived the same rule from the same
-  flags, model and implementation compared equal all the way through the
-  resurrection. `Bridge` now carries a `torn_down` flag that `deinit` sets
-  and nothing clears (starting a new session is `Bridge.init`), the model
-  states the rule independently, and the snapshot compares the flag. The
-  general lesson for #493-C and later slices: a reference model that
+  model had reproduced two real `Bridge` defects instead of detecting them.
+  The record contract has **two** session-teardown paths, and both reset
+  `handshake_complete` to false — which was the *only* gate
+  `installTrafficSecret(.zero_rtt, ...)` checked:
+
+  1. `deinit`, the unconditional wipe for an abandoned or failed handshake;
+  2. `discardEpoch(.application)`, the orderly teardown of a completed
+     session, which `discardEpoch`'s own documentation calls session
+     teardown.
+
+  After either one, a bridge could reinstall both 0-RTT directions and
+  resume sealing and opening records on that epoch. Because the model
+  derived its rule from the same flags the implementation reset, model and
+  implementation compared equal all the way through both resurrections.
+  `Bridge` now carries a `torn_down` flag that every teardown path sets and
+  nothing clears (starting a new session is `Bridge.init`), the model states
+  the rule independently for both paths, and the snapshot compares the flag.
+  0-RTT discard is deliberately *not* terminal: it is epoch-scoped, emitted
+  whenever early data ends including mid-handshake, so the rule is scoped to
+  session teardown rather than to "any discard".
+
+  The general lesson for #493-C and later slices: a reference model that
   paraphrases the implementation's own gate expressions can only find
   inconsistencies, not policy violations — rules the contract requires
-  should be written from the contract.
+  should be written from the contract. The second defect is the sharper
+  illustration, because fixing only the first path left the model still
+  agreeing with the implementation on the second.
 
   Following #493-A's standard, both targets have named deterministic
   companions for the classifications CI's seed replay cannot reliably reach:
@@ -740,17 +754,28 @@ issue's implementation-plan comment:
   suite`, `open classifies every rejection stage at its exact boundary and
   never advances read state`, `record protection teardown zeroizes keys,
   resets sequence, and marks state exhausted`, and `the epoch lifecycle
-  model agrees with a scripted full progression through teardown`, plus
-  `record epoch bridge cannot reinstall zero-rtt keys after teardown` for
-  the defect above. All were validated by mutation: dropping
-  `discardEpoch(.application)`'s `handshake_complete = false`, swapping
-  `seal`'s `RecordBufferOverflow` for `RecordTooLarge`, and removing
-  `installTrafficSecret`'s `torn_down` guard each fail under plain
-  `zig build test-tls`, while the corpus replay alone caught none of them
-  (coverage-guided runs found the first in 16 runs and the teardown one in
-  17). Removing the *model's* independent `torn_down` rule while leaving the
-  production guard in place also fails the scripted companion, so the
-  oracle cannot silently regress back to mirroring the implementation.
+  model agrees with a scripted full progression through teardown`, plus one
+  per teardown path for the defects above: `record epoch bridge cannot
+  reinstall zero-rtt keys after teardown` and `record epoch bridge cannot
+  reinstall zero-rtt keys after orderly application discard`. The scripted
+  companion exercises the application-discard window *before* any `deinit`
+  call, so the two paths are mutation-detectable independently.
+
+  All were validated by mutation, and in both directions for the terminal
+  rule:
+
+  | Mutation | Caught by |
+  | --- | --- |
+  | Drop `discardEpoch(.application)`'s `handshake_complete = false` | scripted companion (fuzz target in 16 runs) |
+  | Swap `seal`'s `RecordBufferOverflow` for `RecordTooLarge` | `seal classifies every rejection stage…` |
+  | Remove `installTrafficSecret`'s `torn_down` guard | both named teardown regressions (fuzz target in 17 runs) |
+  | Remove production `torn_down` on application discard only | `…after orderly application discard` + companion (fuzz target in 38 runs) |
+  | Remove the *model's* `torn_down` rule (either path) | scripted companion |
+
+  The seed-corpus replay alone caught none of them, which is why each has a
+  named companion. The last two rows are what keep the oracle honest: the
+  model cannot silently regress back to mirroring the implementation on
+  either teardown path.
 - **#493-C** (scripted in-memory carrier, encrypted-stream progression, docs
   closeout) is tracked as a follow-on slice of the same issue and will
   extend this section and the `-Dtls-record-test-filter` namespace when it

--- a/docs/CRYPTO_FUZZ_CONTRACT.md
+++ b/docs/CRYPTO_FUZZ_CONTRACT.md
@@ -523,7 +523,35 @@ zig build test-tls-record-fuzz --summary all --error-style verbose
 zig build test-tls-record-fuzz -Doptimize=ReleaseFast --fuzz=10M --summary all --error-style verbose
 zig build test-tls-record-fuzz -Doptimize=ReleaseFast -Dtls-record-test-filter="fuzz: TLS record: codec fragmentation, coalescing, and sink saturation preserve exact consumption" --fuzz=10M --summary all --error-style verbose
 zig build test-tls-record-fuzz -Doptimize=ReleaseFast -Dtls-record-test-filter="fuzz: TLS record: inner plaintext framing, padding, and bounds remain transactional" --fuzz=10M --summary all --error-style verbose
+zig build test-tls-record-fuzz -Doptimize=ReleaseFast -Dtls-record-test-filter="fuzz: TLS record: protection tamper and sequence boundaries preserve authentication state" --fuzz=10M --summary all --error-style verbose
+zig build test-tls-record-fuzz -Doptimize=ReleaseFast -Dtls-record-test-filter="fuzz: TLS record: epoch operation sequences preserve one-way key lifecycle" --fuzz=10M --summary all --error-style verbose
+
+# Replay one named deterministic regression/companion case on its own
+# (the same filter option also selects non-"fuzz:" test names):
+zig build test-tls-record-fuzz -Dtls-record-test-filter="seal classifies every rejection stage at its exact boundary for every suite" --summary all --error-style verbose
 ```
+
+No #493 target performs network I/O, draws ambient entropy, loads a real
+key or certificate, or contacts an external peer: every case builds its own
+`pure_zig.DeterministicEntropy`/`pure_zig.Provider` pair inside the callback
+and works entirely from fixed stack buffers. The explicit bounds are:
+
+| Bound | Value |
+| --- | --- |
+| Generated records per codec case | 4 (`fuzz_codec_max_records`) |
+| Generated record payload | 48 bytes (`fuzz_codec_max_payload`) |
+| Codec sink capacity | 1 record |
+| Codec parser progress bound | `2 * stream_len + 16` `feedOne` calls |
+| Inner-plaintext content / padding | 512 bytes each (boundary arms aside) |
+| Protection content / padding | 64 / 32 bytes (boundary arms aside) |
+| Protection output buffer | `max_ciphertext_record_len` (16 645 bytes) |
+| Epoch operations per program | 48 (`fuzz_epoch_max_operations`) |
+| Epoch record content | 24 bytes (`fuzz_epoch_content_len`) |
+
+Boundary arms deliberately reach the real protocol limits
+(`max_plaintext_fragment_len`, `max_ciphertext_fragment_len`, and one past
+each) plus synthetic near-`usize`-max scalar lengths, which are driven
+through length-only helpers rather than allocations.
 
 `-Dtls-record-test-filter` defaults to `"fuzz: TLS record:"` (every #493
 target; scoped narrower than a bare `"fuzz: "` prefix for the same reason
@@ -619,11 +647,95 @@ issue's implementation-plan comment:
   input rather than an error — the actual overflow these targets guard
   against surfaces one step later, in the callers that add `bytes_len` back
   on top of the chunk overhead.
-- **#493-B** (record protection and epoch/key lifecycle) and **#493-C**
-  (scripted in-memory carrier, encrypted-stream progression, docs
-  closeout) are tracked as follow-on slices of the same issue and will
-  extend this section and the `-Dtls-record-test-filter` namespace when
-  they land, rather than duplicating this contract.
+- **#493-B** (this slice) — the `record_protection.zig` and
+  `record_epoch_bridge.zig` targets.
+
+  `protection tamper and sequence boundaries preserve authentication state`
+  classifies the expected outcome of every `WriteState.seal` call **before**
+  making it (`expectedSeal`, mirroring `seal`'s documented rejection order:
+  exhausted sequence, `encodeInnerPlaintext`'s stages, sealed payload size,
+  then output capacity) and asserts that exact typed error with the
+  destination sentinel and the write sequence re-verified after each one.
+  Each case picks one of the three suites, drives the traffic-secret length
+  at exact-minus-one/exact/exact-plus-one for that suite's hash, and starts
+  both directions at a sequence drawn from `{0, 1, 255, 256, maxInt-1,
+  maxInt}`. Padding carries the size boundaries because it is a scalar the
+  encoder zero-fills: the exact-maximum sealed payload, one past it, and a
+  synthetic `maxInt(usize)` are all expressible without an oversized content
+  buffer. On the accepting path the serialized header is re-derived
+  independently and compared field by field (it is what the AEAD
+  authenticates as associated data), a write at `maxInt(u64)` is proven
+  usable exactly once before the state latches exhausted, and every returned
+  view is checked for containment in its backing buffer.
+
+  Each sealed record then runs a tamper battery against one shared read
+  state — ciphertext bit flip, tag bit flip, tag truncation at every
+  representative boundary, associated-data content-type and version
+  mutation, a wrong read sequence, a wrong traffic secret, wrong
+  suite-derived keys from the same secret, an authenticated-but-malformed
+  all-zero inner plaintext, and an exact-minus-one output buffer. Every one
+  must fail with its exact typed error and leave the sequence and exhaustion
+  flag untouched; failures that reach the AEAD must leave the attempted
+  plaintext span zeroed, while validation and preflight failures must leave
+  the caller's buffer entirely untouched. Because all of them run against the
+  *same* read state, the legitimate open that follows also proves a failed
+  open leaves the state usable — and, once it succeeds, that replaying the
+  same record at the now-advanced sequence fails closed.
+
+  Provider error classes are exercised through a test-only `FaultProvider`
+  wrapper rather than invented: `UnsupportedCapability` comes from masking
+  one of the suite's two required capabilities so `TrafficKeys.derive`'s own
+  preflight rejects it, and `InvalidInput` is injected at the
+  `aeadSeal`/`aeadOpen`/HKDF vtable seam — the record API's own call shapes
+  never produce it from a conforming pure-Zig provider, and `HkdfError`/
+  `SealError` contain nothing else. The fixture zeroes `plaintext` on a
+  forced open failure so the "no unauthenticated plaintext" property is not
+  proven against a fixture weaker than the interface it stands in for.
+  Teardown is asserted directly on the public `FixedSecret` backing arrays
+  (`expectSecretsCleared`): key and IV bytes zero, lengths zero, sequence
+  reset, state marked exhausted, and repeated teardown safe.
+
+  `epoch operation sequences preserve one-way key lifecycle` runs a bounded
+  program of at most 48 operations — traffic-secret install at every
+  epoch/direction with a length matrix, epoch discard, handshake completion,
+  negotiated-suite updates including unknown code points, seal and open at
+  each epoch, and `deinit` teardown at an arbitrary point followed by
+  continued operation — against a `Bridge` and an independent `EpochModel`
+  written from the documented transition rules rather than from the
+  implementation. After **every** operation, accepted or rejected, a
+  `BridgeSnapshot` (both direction phases, all three discard flags,
+  completion, the negotiated suite, and for each of the six key slots an
+  optional holding its sequence) must equal the model's prediction. Folding
+  key presence and sequence into one optional means the comparison catches
+  both a key that should have been wiped and a sequence that advanced when
+  it should not have; the snapshot also cross-checks `hasReadKeys`/
+  `hasWriteKeys` against the private slots at every step. The model predicts
+  not only each gate but whether a record can authenticate at all — it
+  tracks the suite each slot was installed under and both sequence counters,
+  and the target always uses one fixed secret per epoch so identical
+  suite plus identical sequence means byte-identical keys. A bridge that
+  opened a record under the wrong epoch's keys, or that consumed a read
+  sequence number on a failed open, fails here.
+
+  Following #493-A's standard, both targets have named deterministic
+  companions for the classifications CI's seed replay cannot reliably reach:
+  `seal classifies every rejection stage at its exact boundary for every
+  suite`, `open classifies every rejection stage at its exact boundary and
+  never advances read state`, `record protection teardown zeroizes keys,
+  resets sequence, and marks state exhausted`, and `the epoch lifecycle
+  model agrees with a scripted full progression through teardown`. All four
+  were validated by mutation: dropping `discardEpoch(.application)`'s
+  `handshake_complete = false` and swapping `seal`'s `RecordBufferOverflow`
+  for `RecordTooLarge` each fail under plain `zig build test-tls`, while the
+  corpus replay alone caught neither (a coverage-guided run found the epoch
+  one in 16 runs).
+- **#493-C** (scripted in-memory carrier, encrypted-stream progression, docs
+  closeout) is tracked as a follow-on slice of the same issue and will
+  extend this section and the `-Dtls-record-test-filter` namespace when it
+  lands, rather than duplicating this contract. TLS-over-TCP KeyUpdate and
+  key replacement remain #357: the bridge exposes no such surface today, so
+  the epoch target's operation set is the extension point for it rather
+  than a fabricated API.
 
 Ownership stays exactly as scoped above and in the issue: shared TLS
 message/negotiation/transcript fuzzing is #491; PKI fuzzing is #492;
@@ -635,9 +747,10 @@ legal initial-ClientHello `0x0301`, explicit epoch discard, sequence
 exhaustion, key cleanup, independent record-protection vectors) are treated
 as regression seeds/properties here, not reimplemented — the extensive
 pre-existing deterministic `record_codec.zig` test suite already pins most
-of them by name, and the #493-A property targets promote the ones in scope
-for this slice (exact parser consumption under fragmentation, sink retry
-behavior, and the legal/illegal initial-ClientHello `0x0301` window) into
-generated properties rather than leaving them as fixed examples. The epoch
-discard, sequence exhaustion, and key cleanup classes are still
-deterministic-only and become fuzz properties in #493-B.
+of them by name, and the #493 property targets promote them into generated
+properties rather than leaving them as fixed examples: exact parser
+consumption under fragmentation, sink retry behavior, and the
+legal/illegal initial-ClientHello `0x0301` window in #493-A, and epoch
+discard/transition ordering, sequence exhaustion, and key cleanup in
+#493-B. The encrypted-stream progression and terminal-error classes remain
+deterministic-only until #493-C.

--- a/src/tls/record_epoch_bridge.zig
+++ b/src/tls/record_epoch_bridge.zig
@@ -1102,3 +1102,668 @@ test "record epoch bridge shuttles protocol-neutral driver events through record
     try testing.expectEqual(@as(u64, 1), server_bridge.write_application.?.sequence);
     try testing.expectEqual(@as(u64, 1), client_bridge.read_application.?.sequence);
 }
+
+// -----------------------------------------------------------------------
+// #493 epoch/key-lifecycle fuzz target. See docs/CRYPTO_FUZZ_CONTRACT.md's
+// "#493" section for the shared rules this follows (fresh provider and
+// bridge per case, fixed buffers, explicit operation bounds, typed-error
+// classification, sanitized diagnostics).
+// -----------------------------------------------------------------------
+
+const fuzz_epoch_max_operations = 48;
+const fuzz_epoch_content_len = 24;
+
+const all_epochs = [_]events.EncryptionEpoch{ .initial, .zero_rtt, .handshake, .application };
+const all_suites = [_]algorithms.CipherSuite{
+    .tls_aes_128_gcm_sha256,
+    .tls_aes_256_gcm_sha384,
+    .tls_chacha20_poly1305_sha256,
+};
+
+fn epochIndex(epoch: events.EncryptionEpoch) usize {
+    return switch (epoch) {
+        .initial => 0,
+        .zero_rtt => 1,
+        .handshake => 2,
+        .application => 3,
+    };
+}
+
+/// The traffic secret this target always uses for `epoch`, so a read slot and
+/// a write slot installed for the same epoch under the same suite hold
+/// byte-identical key material. That makes "does this record authenticate?"
+/// a function of the model's tracked suite and sequence alone, rather than of
+/// key bytes the model would otherwise have to reproduce.
+fn fuzzEpochSecret(epoch: events.EncryptionEpoch, len: usize, out: []u8) []const u8 {
+    const tag: u8 = 0x40 +% @as(u8, @intCast(epochIndex(epoch)));
+    for (out[0..len], 0..) |*byte, i| byte.* = tag ^ @as(u8, @truncate(i));
+    return out[0..len];
+}
+
+/// The externally observable state of a `Bridge`: direction phases, the
+/// discard/completion flags, the negotiated suite, and -- for each of the six
+/// key slots -- whether a key is installed and, if so, its sequence counter.
+/// Folding presence and sequence into one optional means a comparison catches
+/// both a key that should have been wiped and a sequence that advanced when
+/// it should not have.
+const BridgeSnapshot = struct {
+    cipher_suite: algorithms.CipherSuite,
+    read_phase: DirectionPhase,
+    write_phase: DirectionPhase,
+    read_handshake: ?u64,
+    write_handshake: ?u64,
+    read_zero_rtt: ?u64,
+    write_zero_rtt: ?u64,
+    read_application: ?u64,
+    write_application: ?u64,
+    initial_discarded: bool,
+    handshake_discarded: bool,
+    application_discarded: bool,
+    handshake_complete: bool,
+};
+
+fn bridgeSnapshot(bridge: *const Bridge) !BridgeSnapshot {
+    const snapshot = BridgeSnapshot{
+        .cipher_suite = bridge.cipher_suite,
+        .read_phase = bridge.read_phase,
+        .write_phase = bridge.write_phase,
+        .read_handshake = if (bridge.read_handshake) |state| state.sequence else null,
+        .write_handshake = if (bridge.write_handshake) |state| state.sequence else null,
+        .read_zero_rtt = if (bridge.read_zero_rtt) |state| state.sequence else null,
+        .write_zero_rtt = if (bridge.write_zero_rtt) |state| state.sequence else null,
+        .read_application = if (bridge.read_application) |state| state.sequence else null,
+        .write_application = if (bridge.write_application) |state| state.sequence else null,
+        .initial_discarded = bridge.initial_discarded,
+        .handshake_discarded = bridge.handshake_discarded,
+        .application_discarded = bridge.application_discarded,
+        .handshake_complete = bridge.handshake_complete,
+    };
+    // The public key-presence predicates must agree with the private slots
+    // they report on, at every point in the program.
+    try testing.expectEqual(snapshot.read_handshake != null, bridge.hasReadKeys(.handshake));
+    try testing.expectEqual(snapshot.write_handshake != null, bridge.hasWriteKeys(.handshake));
+    try testing.expectEqual(snapshot.read_zero_rtt != null, bridge.hasReadKeys(.zero_rtt));
+    try testing.expectEqual(snapshot.write_zero_rtt != null, bridge.hasWriteKeys(.zero_rtt));
+    try testing.expectEqual(snapshot.read_application != null, bridge.hasReadKeys(.application));
+    try testing.expectEqual(snapshot.write_application != null, bridge.hasWriteKeys(.application));
+    // The initial epoch never has record-protection keys of its own.
+    try testing.expect(!bridge.hasReadKeys(.initial));
+    try testing.expect(!bridge.hasWriteKeys(.initial));
+    return snapshot;
+}
+
+fn expectSnapshotEqual(expected: BridgeSnapshot, actual: BridgeSnapshot) !void {
+    try testing.expectEqual(expected.cipher_suite, actual.cipher_suite);
+    try testing.expectEqual(expected.read_phase, actual.read_phase);
+    try testing.expectEqual(expected.write_phase, actual.write_phase);
+    try testing.expectEqual(expected.read_handshake, actual.read_handshake);
+    try testing.expectEqual(expected.write_handshake, actual.write_handshake);
+    try testing.expectEqual(expected.read_zero_rtt, actual.read_zero_rtt);
+    try testing.expectEqual(expected.write_zero_rtt, actual.write_zero_rtt);
+    try testing.expectEqual(expected.read_application, actual.read_application);
+    try testing.expectEqual(expected.write_application, actual.write_application);
+    try testing.expectEqual(expected.initial_discarded, actual.initial_discarded);
+    try testing.expectEqual(expected.handshake_discarded, actual.handshake_discarded);
+    try testing.expectEqual(expected.application_discarded, actual.application_discarded);
+    try testing.expectEqual(expected.handshake_complete, actual.handshake_complete);
+}
+
+/// A compact reference model of the epoch lifecycle, written directly from
+/// the documented transition rules rather than from the `Bridge` code, so a
+/// rule the implementation silently relaxes shows up as a disagreement.
+///
+/// Per slot it tracks the suite the key was installed under (which decides
+/// whether a sealed record can authenticate against it) and the sequence
+/// counter, in addition to mere presence.
+const EpochModel = struct {
+    cipher_suite: algorithms.CipherSuite,
+    read_phase: DirectionPhase = .initial,
+    write_phase: DirectionPhase = .initial,
+    read_suite: [4]?algorithms.CipherSuite = .{null} ** 4,
+    write_suite: [4]?algorithms.CipherSuite = .{null} ** 4,
+    read_sequence: [4]u64 = .{0} ** 4,
+    write_sequence: [4]u64 = .{0} ** 4,
+    initial_discarded: bool = false,
+    handshake_discarded: bool = false,
+    application_discarded: bool = false,
+    handshake_complete: bool = false,
+
+    fn snapshot(self: *const EpochModel) BridgeSnapshot {
+        return .{
+            .cipher_suite = self.cipher_suite,
+            .read_phase = self.read_phase,
+            .write_phase = self.write_phase,
+            .read_handshake = self.slotSequence(.read, .handshake),
+            .write_handshake = self.slotSequence(.write, .handshake),
+            .read_zero_rtt = self.slotSequence(.read, .zero_rtt),
+            .write_zero_rtt = self.slotSequence(.write, .zero_rtt),
+            .read_application = self.slotSequence(.read, .application),
+            .write_application = self.slotSequence(.write, .application),
+            .initial_discarded = self.initial_discarded,
+            .handshake_discarded = self.handshake_discarded,
+            .application_discarded = self.application_discarded,
+            .handshake_complete = self.handshake_complete,
+        };
+    }
+
+    fn slotSequence(self: *const EpochModel, direction: events.SecretDirection, epoch: events.EncryptionEpoch) ?u64 {
+        const idx = epochIndex(epoch);
+        const suite = if (direction == .read) self.read_suite[idx] else self.write_suite[idx];
+        if (suite == null) return null;
+        return if (direction == .read) self.read_sequence[idx] else self.write_sequence[idx];
+    }
+
+    fn clearSlots(self: *EpochModel, epoch: events.EncryptionEpoch) void {
+        const idx = epochIndex(epoch);
+        self.read_suite[idx] = null;
+        self.write_suite[idx] = null;
+        self.read_sequence[idx] = 0;
+        self.write_sequence[idx] = 0;
+    }
+
+    fn secretLen(self: *const EpochModel) usize {
+        return record_protection.suiteProfile(self.cipher_suite).hash.digestLength();
+    }
+
+    fn predictInstall(
+        self: *const EpochModel,
+        epoch: events.EncryptionEpoch,
+        direction: events.SecretDirection,
+        secret_len: usize,
+    ) ?Error {
+        switch (epoch) {
+            // The initial epoch is plaintext-only; it has no traffic secret.
+            .initial => return error.UnsupportedRecordEpoch,
+            .handshake => {
+                const phase = if (direction == .read) self.read_phase else self.write_phase;
+                if (phase != .initial or self.handshake_discarded) return error.InvalidEpochTransition;
+            },
+            .application => {
+                const phase = if (direction == .read) self.read_phase else self.write_phase;
+                if (phase != .handshake or self.handshake_discarded or self.application_discarded) {
+                    return error.InvalidEpochTransition;
+                }
+            },
+            .zero_rtt => {
+                if (self.handshake_complete) return error.InvalidEpochTransition;
+            },
+        }
+        const idx = epochIndex(epoch);
+        const slot = if (direction == .read) self.read_suite[idx] else self.write_suite[idx];
+        // Duplicate detection happens before key derivation, so a duplicate
+        // install is reported as such even when its length is also wrong.
+        if (slot != null) return error.DuplicateTrafficSecret;
+        if (secret_len != self.secretLen()) return error.InvalidTrafficSecretLength;
+        return null;
+    }
+
+    fn applyInstall(self: *EpochModel, epoch: events.EncryptionEpoch, direction: events.SecretDirection) void {
+        const idx = epochIndex(epoch);
+        if (direction == .read) {
+            self.read_suite[idx] = self.cipher_suite;
+            self.read_sequence[idx] = 0;
+        } else {
+            self.write_suite[idx] = self.cipher_suite;
+            self.write_sequence[idx] = 0;
+        }
+        switch (epoch) {
+            .handshake => if (direction == .read) {
+                self.read_phase = .handshake;
+            } else {
+                self.write_phase = .handshake;
+            },
+            .application => if (direction == .read) {
+                self.read_phase = .application;
+            } else {
+                self.write_phase = .application;
+            },
+            // 0-RTT keys live alongside the phase progression rather than
+            // advancing it.
+            .zero_rtt, .initial => {},
+        }
+    }
+
+    fn predictDiscard(self: *const EpochModel, epoch: events.EncryptionEpoch) ?Error {
+        return switch (epoch) {
+            .initial => if (self.initial_discarded)
+                error.EpochAlreadyDiscarded
+            else if (self.read_phase == .initial or self.write_phase == .initial)
+                error.EpochDiscardTooEarly
+            else
+                null,
+            .handshake => if (self.handshake_discarded)
+                error.EpochAlreadyDiscarded
+            else if (self.read_phase != .application or self.write_phase != .application)
+                error.EpochDiscardTooEarly
+            else
+                null,
+            .application => if (self.application_discarded)
+                error.EpochAlreadyDiscarded
+            else if (!self.handshake_complete or self.read_phase != .complete or self.write_phase != .complete)
+                error.EpochDiscardTooEarly
+            else
+                null,
+            // 0-RTT discard is idempotent by contract: it is emitted whenever
+            // early data ends, including when no early keys ever existed.
+            .zero_rtt => null,
+        };
+    }
+
+    fn applyDiscard(self: *EpochModel, epoch: events.EncryptionEpoch) void {
+        switch (epoch) {
+            .initial => self.initial_discarded = true,
+            .handshake => {
+                self.clearSlots(.handshake);
+                self.handshake_discarded = true;
+            },
+            .application => {
+                self.clearSlots(.application);
+                self.application_discarded = true;
+                self.read_phase = .initial;
+                self.write_phase = .initial;
+                self.handshake_complete = false;
+            },
+            .zero_rtt => self.clearSlots(.zero_rtt),
+        }
+    }
+
+    fn predictComplete(self: *const EpochModel) ?Error {
+        if (self.handshake_complete) return error.InvalidEpochTransition;
+        if (!self.initial_discarded or !self.handshake_discarded) return error.InvalidEpochTransition;
+        if (self.read_phase != .application or self.write_phase != .application) return error.InvalidEpochTransition;
+        const idx = epochIndex(.application);
+        if (self.read_suite[idx] == null or self.write_suite[idx] == null) return error.MissingApplicationKeys;
+        return null;
+    }
+
+    fn applyComplete(self: *EpochModel) void {
+        self.clearSlots(.zero_rtt);
+        self.handshake_complete = true;
+        self.read_phase = .complete;
+        self.write_phase = .complete;
+    }
+
+    fn applyTeardown(self: *EpochModel) void {
+        self.clearSlots(.zero_rtt);
+        self.clearSlots(.handshake);
+        self.clearSlots(.application);
+        self.initial_discarded = true;
+        self.handshake_discarded = true;
+        self.application_discarded = true;
+        self.handshake_complete = false;
+        // `deinit` deliberately does not rewind the direction phases: it is
+        // teardown, not a transition back to a usable earlier state.
+    }
+
+    /// The gate `sealProtected` applies before it reaches a write state, for
+    /// a `handshake` content type.
+    fn predictSealGate(self: *const EpochModel, epoch: events.EncryptionEpoch) ?Error {
+        const idx = epochIndex(epoch);
+        return switch (epoch) {
+            .initial => if (self.initial_discarded) error.UnsupportedRecordEpoch else null,
+            .handshake => if (self.write_suite[idx] == null) error.MissingWriteKeys else null,
+            .application => if (!self.handshake_complete)
+                error.HandshakeNotComplete
+            else if (self.write_suite[idx] == null)
+                error.MissingWriteKeys
+            else
+                null,
+            .zero_rtt => if (self.handshake_complete)
+                error.UnsupportedRecordEpoch
+            else if (self.write_suite[idx] == null)
+                error.MissingWriteKeys
+            else
+                null,
+        };
+    }
+
+    /// Everything `openProtected` rejects before the AEAD runs: the bridge's
+    /// own epoch gate, and then -- for a protected epoch -- `ReadState.open`'s
+    /// header preflight in its documented order. A plaintext initial-epoch
+    /// record replayed at a protected epoch is refused as `InvalidRecordType`
+    /// by that preflight, never treated as a candidate ciphertext.
+    fn predictOpenGate(self: *const EpochModel, epoch: events.EncryptionEpoch, record: record_codec.Record) ?Error {
+        const idx = epochIndex(epoch);
+        switch (epoch) {
+            .initial => {
+                if (self.initial_discarded) return error.UnsupportedRecordEpoch;
+                if (record.content_type != .handshake) return error.UnexpectedRecordContent;
+                return null;
+            },
+            .handshake => if (self.read_suite[idx] == null) return error.MissingReadKeys,
+            .application => {
+                if (!self.handshake_complete) return error.HandshakeNotComplete;
+                if (self.read_suite[idx] == null) return error.MissingReadKeys;
+            },
+            .zero_rtt => {
+                if (self.handshake_complete) return error.UnsupportedRecordEpoch;
+                if (self.read_suite[idx] == null) return error.MissingReadKeys;
+            },
+        }
+        if (record.content_type != .application_data) return error.InvalidRecordType;
+        if (record.legacy_version != record_codec.legacy_record_version) return error.InvalidRecordVersion;
+        if (record.payload.len > record_codec.max_ciphertext_fragment_len) return error.RecordTooLarge;
+        const tag_len = record_protection.suiteProfile(self.read_suite[idx].?).aead.tagLength();
+        if (record.payload.len < tag_len) return error.MalformedInnerPlaintext;
+        return null;
+    }
+};
+
+/// The most recently sealed record, and everything the model needs to decide
+/// whether re-opening it can authenticate.
+const LastRecord = struct {
+    bytes: [record_codec.max_ciphertext_record_len]u8 = undefined,
+    len: usize = 0,
+    /// `null` until this case has sealed anything: the synthetic placeholder
+    /// record can never authenticate at any epoch.
+    epoch: ?events.EncryptionEpoch = null,
+    suite: algorithms.CipherSuite = .tls_aes_128_gcm_sha256,
+    sequence: u64 = 0,
+    content: [fuzz_epoch_content_len]u8 = undefined,
+};
+
+test "fuzz: TLS record: epoch operation sequences preserve one-way key lifecycle" {
+    try testing.fuzz({}, fuzzEpochOperationsInput, .{
+        .corpus = &.{
+            "",
+            &[_]u8{0},
+            // The #408 transition classes, as operation-selector prefixes:
+            // early discard, duplicate discard, missing direction,
+            // application install before handshake, partial completion,
+            // abandoned handshake, full progression, and teardown at each
+            // boundary. The generator's own bounds keep every one of these
+            // inside `fuzz_epoch_max_operations`.
+            &[_]u8{ 1, 0, 1, 2, 1, 3 },
+            &[_]u8{ 0, 2, 0, 0, 0, 2, 1, 0 },
+            &[_]u8{ 0, 3, 0, 0, 0, 3, 1, 0, 2 },
+            &[_]u8{ 0, 2, 0, 0, 0, 2, 1, 0, 1, 2, 0, 3, 0, 0, 0, 3, 1, 0, 1, 2, 2 },
+            &[_]u8{ 6, 0, 2, 0, 0, 6, 1, 0 },
+            &[_]u8{ 4, 0, 4, 2, 4, 3, 5, 0, 5, 2, 5, 3 },
+            &[_]u8{ 3, 0, 3, 1, 3, 2, 3, 3 },
+            &([_]u8{0} ** 64),
+            &([_]u8{0xff} ** 64),
+            &([_]u8{ 0, 1, 2, 3, 4, 5, 6 } ** 8),
+        },
+    });
+}
+
+fn fuzzEpochOperationsInput(_: void, smith: *std.testing.Smith) !void {
+    const pure_zig = crypto.pure_zig;
+    // Fresh provider per case, per the #493 shared rules -- not this module's
+    // process-wide `testProvider()` singleton.
+    var entropy = pure_zig.DeterministicEntropy.init(0x493c);
+    var provider_state = pure_zig.Provider.init(entropy.entropy());
+    const cp = provider_state.cryptoProvider();
+
+    const initial_suite = all_suites[smith.index(all_suites.len)];
+    var bridge = Bridge.init(cp, initial_suite);
+    defer bridge.deinit();
+    var model = EpochModel{ .cipher_suite = initial_suite };
+    try expectSnapshotEqual(model.snapshot(), try bridgeSnapshot(&bridge));
+
+    var last = LastRecord{};
+    var out_buf: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var opened_buf: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    var secret_buf: [provider.max_digest_len + 1]u8 = undefined;
+    var scratch: [1]u8 = undefined;
+
+    const operations = smith.index(fuzz_epoch_max_operations + 1);
+    for (0..operations) |_| {
+        switch (smith.index(7)) {
+            // Install a traffic secret. The length comes from a matrix around
+            // the current suite's digest length, so a wrong-length install is
+            // a first-class operation rather than an afterthought.
+            0 => {
+                const epoch = all_epochs[smith.index(all_epochs.len)];
+                const direction: events.SecretDirection = if (smith.index(2) == 0) .read else .write;
+                const exact = model.secretLen();
+                const secret_len = switch (smith.index(4)) {
+                    0 => exact - 1,
+                    1 => exact + 1,
+                    else => exact,
+                };
+                const traffic_secret = fuzzEpochSecret(epoch, secret_len, &secret_buf);
+
+                const predicted = model.predictInstall(epoch, direction, secret_len);
+                const result = bridge.applyEvent(.{ .traffic_secret = .{
+                    .epoch = epoch,
+                    .direction = direction,
+                    .data = traffic_secret,
+                } }, &scratch);
+                if (predicted) |expected| {
+                    try testing.expectError(expected, result);
+                } else {
+                    try testing.expectEqual(@as(?[]const u8, null), try result);
+                    model.applyInstall(epoch, direction);
+                }
+            },
+            // Discard an epoch.
+            1 => {
+                const epoch = all_epochs[smith.index(all_epochs.len)];
+                const predicted = model.predictDiscard(epoch);
+                const result = bridge.applyEvent(.{ .discard_epoch = epoch }, &scratch);
+                if (predicted) |expected| {
+                    try testing.expectError(expected, result);
+                } else {
+                    try testing.expectEqual(@as(?[]const u8, null), try result);
+                    model.applyDiscard(epoch);
+                }
+            },
+            // Mark the handshake complete.
+            2 => {
+                const predicted = model.predictComplete();
+                const result = bridge.applyEvent(.handshake_complete, &scratch);
+                if (predicted) |expected| {
+                    try testing.expectError(expected, result);
+                } else {
+                    try testing.expectEqual(@as(?[]const u8, null), try result);
+                    model.applyComplete();
+                }
+            },
+            // Update the negotiated suite, including unknown code points,
+            // which must be refused without disturbing the current suite.
+            3 => {
+                const known = smith.index(4) != 0;
+                var raw: [2]u8 = undefined;
+                smith.bytes(&raw);
+                const chosen = all_suites[smith.index(all_suites.len)];
+                var wire = std.mem.readInt(u16, &raw, .big);
+                if (known) {
+                    wire = @intFromEnum(chosen);
+                } else if (algorithms.fromInt(algorithms.CipherSuite, wire) != null) {
+                    wire = 0x1300;
+                }
+                const params = events.NegotiatedParameters{
+                    .cipher_suite = wire,
+                    .transcript_hash = if (smith.index(2) == 0) .sha256 else .sha384,
+                };
+                const event: events.Event = if (smith.index(2) == 0)
+                    .{ .negotiated_parameters = params }
+                else
+                    .{ .early_data_parameters = params };
+                const result = bridge.applyEvent(event, &scratch);
+                if (algorithms.fromInt(algorithms.CipherSuite, wire)) |suite| {
+                    try testing.expectEqual(@as(?[]const u8, null), try result);
+                    model.cipher_suite = suite;
+                } else {
+                    try testing.expectError(error.UnsupportedRecordEpoch, result);
+                }
+            },
+            // Seal a handshake record at a chosen epoch.
+            4 => {
+                const epoch = all_epochs[smith.index(all_epochs.len)];
+                var content: [fuzz_epoch_content_len]u8 = undefined;
+                smith.bytes(&content);
+                const predicted = model.predictSealGate(epoch);
+                const result = bridge.sealProtected(epoch, .handshake, &content, &out_buf);
+                if (predicted) |expected| {
+                    try testing.expectError(expected, result);
+                } else {
+                    const record = try result;
+                    const idx = epochIndex(epoch);
+                    last.len = record.len;
+                    @memcpy(last.bytes[0..record.len], record);
+                    last.epoch = epoch;
+                    last.content = content;
+                    if (epoch != .initial) {
+                        last.suite = model.write_suite[idx].?;
+                        last.sequence = model.write_sequence[idx];
+                        model.write_sequence[idx] += 1;
+                    }
+                }
+            },
+            // Open the most recently sealed record at a chosen epoch. The
+            // model predicts not just the gate but whether the record can
+            // authenticate at all, so a bridge that opened a record under the
+            // wrong epoch's keys would be caught here.
+            5 => {
+                const epoch = all_epochs[smith.index(all_epochs.len)];
+                const record = if (last.epoch) |sealed_at|
+                    try parseSingleRecord(
+                        if (sealed_at == .initial) .plaintext else .ciphertext,
+                        last.bytes[0..last.len],
+                    )
+                else
+                    record_codec.Record{
+                        .content_type = .application_data,
+                        .legacy_version = record_codec.legacy_record_version,
+                        .payload = &[_]u8{0} ** 32,
+                    };
+                const idx = epochIndex(epoch);
+                const result = bridge.openProtected(epoch, record, &opened_buf);
+                if (model.predictOpenGate(epoch, record)) |expected| {
+                    try testing.expectError(expected, result);
+                } else if (last.epoch != null and last.epoch.? == epoch and
+                    (epoch == .initial or (model.read_suite[idx].? == last.suite and
+                        model.read_sequence[idx] == last.sequence)))
+                {
+                    const opened = try result;
+                    try testing.expectEqual(epoch, opened.epoch);
+                    try testing.expectEqual(record_codec.ContentType.handshake, opened.inner.content_type);
+                    try testing.expectEqualSlices(u8, &last.content, opened.inner.content);
+                    if (epoch != .initial) model.read_sequence[idx] += 1;
+                } else {
+                    // Wrong epoch, wrong suite, or a read sequence that has
+                    // moved on: the record must fail closed, and -- asserted
+                    // by the snapshot comparison below -- must not consume a
+                    // read sequence number, or a later legitimate record
+                    // would become unopenable.
+                    try testing.expectError(error.AuthenticationFailed, result);
+                }
+            },
+            // Teardown at an arbitrary point in the program, followed by
+            // continued operation: every later step must see wiped keys and
+            // terminal discard flags.
+            else => {
+                bridge.deinit();
+                model.applyTeardown();
+            },
+        }
+
+        try expectSnapshotEqual(model.snapshot(), try bridgeSnapshot(&bridge));
+    }
+
+    // Final teardown always clears every key slot regardless of how far the
+    // program progressed, including from an abandoned handshake.
+    bridge.deinit();
+    model.applyTeardown();
+    try expectSnapshotEqual(model.snapshot(), try bridgeSnapshot(&bridge));
+}
+
+// A single scripted full progression, pinned deterministically so CI's seed
+// replay always exercises the accepting path of every transition rule the
+// fuzz target's model encodes -- the generated programs reach the deepest
+// states (completion, orderly application discard, post-teardown operation)
+// only when their random operation order happens to line up.
+test "the epoch lifecycle model agrees with a scripted full progression through teardown" {
+    const cp = testProvider();
+    var bridge = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer bridge.deinit();
+    var model = EpochModel{ .cipher_suite = .tls_aes_128_gcm_sha256 };
+    var secret_buf: [provider.max_digest_len + 1]u8 = undefined;
+    var scratch: [1]u8 = undefined;
+
+    const Step = struct {
+        fn install(
+            b: *Bridge,
+            m: *EpochModel,
+            buf: []u8,
+            sc: []u8,
+            epoch: events.EncryptionEpoch,
+            direction: events.SecretDirection,
+            len: usize,
+        ) !void {
+            const data = fuzzEpochSecret(epoch, len, buf);
+            const predicted = m.predictInstall(epoch, direction, len);
+            const result = b.applyEvent(.{ .traffic_secret = .{ .epoch = epoch, .direction = direction, .data = data } }, sc);
+            if (predicted) |expected| {
+                try testing.expectError(expected, result);
+            } else {
+                _ = try result;
+                m.applyInstall(epoch, direction);
+            }
+            try expectSnapshotEqual(m.snapshot(), try bridgeSnapshot(b));
+        }
+
+        fn discard(b: *Bridge, m: *EpochModel, sc: []u8, epoch: events.EncryptionEpoch) !void {
+            const predicted = m.predictDiscard(epoch);
+            const result = b.applyEvent(.{ .discard_epoch = epoch }, sc);
+            if (predicted) |expected| {
+                try testing.expectError(expected, result);
+            } else {
+                _ = try result;
+                m.applyDiscard(epoch);
+            }
+            try expectSnapshotEqual(m.snapshot(), try bridgeSnapshot(b));
+        }
+
+        fn complete(b: *Bridge, m: *EpochModel, sc: []u8) !void {
+            const predicted = m.predictComplete();
+            const result = b.applyEvent(.handshake_complete, sc);
+            if (predicted) |expected| {
+                try testing.expectError(expected, result);
+            } else {
+                _ = try result;
+                m.applyComplete();
+            }
+            try expectSnapshotEqual(m.snapshot(), try bridgeSnapshot(b));
+        }
+    };
+
+    const hash_len = record_protection.suiteProfile(.tls_aes_128_gcm_sha256).hash.digestLength();
+
+    // Early/duplicate/wrong-length/missing-direction rejections.
+    try Step.discard(&bridge, &model, &scratch, .initial);
+    try Step.complete(&bridge, &model, &scratch);
+    try Step.install(&bridge, &model, &secret_buf, &scratch, .initial, .write, hash_len);
+    try Step.install(&bridge, &model, &secret_buf, &scratch, .application, .write, hash_len);
+    try Step.install(&bridge, &model, &secret_buf, &scratch, .handshake, .write, hash_len - 1);
+
+    // 0-RTT keys, then the full progression.
+    try Step.install(&bridge, &model, &secret_buf, &scratch, .zero_rtt, .write, hash_len);
+    try Step.install(&bridge, &model, &secret_buf, &scratch, .zero_rtt, .write, hash_len);
+    try Step.install(&bridge, &model, &secret_buf, &scratch, .handshake, .read, hash_len);
+    try Step.install(&bridge, &model, &secret_buf, &scratch, .handshake, .write, hash_len);
+    try Step.discard(&bridge, &model, &scratch, .handshake);
+    try Step.discard(&bridge, &model, &scratch, .initial);
+    try Step.discard(&bridge, &model, &scratch, .initial);
+    try Step.install(&bridge, &model, &secret_buf, &scratch, .application, .read, hash_len);
+    try Step.complete(&bridge, &model, &scratch);
+    try Step.install(&bridge, &model, &secret_buf, &scratch, .application, .write, hash_len);
+    try Step.discard(&bridge, &model, &scratch, .handshake);
+    try Step.complete(&bridge, &model, &scratch);
+    // Completion wipes any surviving 0-RTT keys.
+    try testing.expect(!bridge.hasWriteKeys(.zero_rtt));
+
+    // Orderly application discard, then teardown after a completed session.
+    try Step.discard(&bridge, &model, &scratch, .application);
+    try Step.discard(&bridge, &model, &scratch, .application);
+    bridge.deinit();
+    model.applyTeardown();
+    try expectSnapshotEqual(model.snapshot(), try bridgeSnapshot(&bridge));
+
+    // Post-teardown operations stay terminal: nothing can revive the bridge.
+    try Step.install(&bridge, &model, &secret_buf, &scratch, .handshake, .read, hash_len);
+    try Step.discard(&bridge, &model, &scratch, .handshake);
+    try Step.complete(&bridge, &model, &scratch);
+}

--- a/src/tls/record_epoch_bridge.zig
+++ b/src/tls/record_epoch_bridge.zig
@@ -59,6 +59,15 @@ pub const Bridge = struct {
     handshake_discarded: bool = false,
     application_discarded: bool = false,
     handshake_complete: bool = false,
+    /// Set by `deinit` and never cleared. Teardown is terminal: a torn-down
+    /// bridge must not be able to acquire key material again, and the
+    /// per-epoch discard flags alone cannot express that. `deinit` resets
+    /// `handshake_complete` to false, which is the *only* gate the 0-RTT
+    /// install path had, so without this flag a torn-down bridge could
+    /// reinstall both 0-RTT directions and resume sealing and opening
+    /// records on that epoch (#493-B review). Starting a new session is
+    /// `Bridge.init`, which yields a fresh value with this cleared.
+    torn_down: bool = false,
 
     pub fn init(crypto_provider: provider.CryptoProvider, cipher_suite: algorithms.CipherSuite) Bridge {
         return .{ .crypto_provider = crypto_provider, .cipher_suite = cipher_suite };
@@ -80,6 +89,7 @@ pub const Bridge = struct {
         self.handshake_discarded = true;
         self.application_discarded = true;
         self.handshake_complete = false;
+        self.torn_down = true;
     }
 
     pub fn applyEvent(self: *Bridge, event: events.Event, out: []u8) Error!?[]const u8 {
@@ -109,6 +119,9 @@ pub const Bridge = struct {
         direction: events.SecretDirection,
         traffic_secret: []const u8,
     ) Error!void {
+        // Teardown is terminal for every epoch, including the ones whose
+        // ordinary gates `deinit` happens to leave open.
+        if (self.torn_down) return error.InvalidEpochTransition;
         switch (epoch) {
             .handshake => switch (direction) {
                 .read => {
@@ -1160,6 +1173,7 @@ const BridgeSnapshot = struct {
     handshake_discarded: bool,
     application_discarded: bool,
     handshake_complete: bool,
+    torn_down: bool,
 };
 
 fn bridgeSnapshot(bridge: *const Bridge) !BridgeSnapshot {
@@ -1177,6 +1191,7 @@ fn bridgeSnapshot(bridge: *const Bridge) !BridgeSnapshot {
         .handshake_discarded = bridge.handshake_discarded,
         .application_discarded = bridge.application_discarded,
         .handshake_complete = bridge.handshake_complete,
+        .torn_down = bridge.torn_down,
     };
     // The public key-presence predicates must agree with the private slots
     // they report on, at every point in the program.
@@ -1206,6 +1221,7 @@ fn expectSnapshotEqual(expected: BridgeSnapshot, actual: BridgeSnapshot) !void {
     try testing.expectEqual(expected.handshake_discarded, actual.handshake_discarded);
     try testing.expectEqual(expected.application_discarded, actual.application_discarded);
     try testing.expectEqual(expected.handshake_complete, actual.handshake_complete);
+    try testing.expectEqual(expected.torn_down, actual.torn_down);
 }
 
 /// A compact reference model of the epoch lifecycle, written directly from
@@ -1227,6 +1243,13 @@ const EpochModel = struct {
     handshake_discarded: bool = false,
     application_discarded: bool = false,
     handshake_complete: bool = false,
+    /// Stated here as an independent rule of the lifecycle -- "teardown is
+    /// terminal" -- rather than being re-derived from whichever gates the
+    /// `Bridge` happens to implement. Deriving it from the per-epoch discard
+    /// and completion flags is exactly how this model previously came to
+    /// bless the 0-RTT resurrection path that `deinit` left open (#493-B
+    /// review): the model agreed with the bug instead of detecting it.
+    torn_down: bool = false,
 
     fn snapshot(self: *const EpochModel) BridgeSnapshot {
         return .{
@@ -1243,6 +1266,7 @@ const EpochModel = struct {
             .handshake_discarded = self.handshake_discarded,
             .application_discarded = self.application_discarded,
             .handshake_complete = self.handshake_complete,
+            .torn_down = self.torn_down,
         };
     }
 
@@ -1271,6 +1295,10 @@ const EpochModel = struct {
         direction: events.SecretDirection,
         secret_len: usize,
     ) ?Error {
+        // Terminal teardown outranks every per-epoch rule below. Stated
+        // independently, so a bridge that reopens *any* epoch after `deinit`
+        // is a disagreement rather than a match.
+        if (self.torn_down) return error.InvalidEpochTransition;
         switch (epoch) {
             // The initial epoch is plaintext-only; it has no traffic secret.
             .initial => return error.UnsupportedRecordEpoch,
@@ -1391,6 +1419,7 @@ const EpochModel = struct {
         self.handshake_discarded = true;
         self.application_discarded = true;
         self.handshake_complete = false;
+        self.torn_down = true;
         // `deinit` deliberately does not rewind the direction phases: it is
         // teardown, not a transition back to a usable earlier state.
     }
@@ -1763,7 +1792,86 @@ test "the epoch lifecycle model agrees with a scripted full progression through 
     try expectSnapshotEqual(model.snapshot(), try bridgeSnapshot(&bridge));
 
     // Post-teardown operations stay terminal: nothing can revive the bridge.
+    // 0-RTT is checked in *both* directions specifically because it is the
+    // epoch whose ordinary gate (`handshake_complete`) `deinit` reopens, so
+    // it is the one that could actually come back (#493-B review). Keeping
+    // it here means mutation validation covers the oracle too: a model that
+    // regressed to mirroring the implementation's gates would stop
+    // predicting these rejections.
+    try Step.install(&bridge, &model, &secret_buf, &scratch, .zero_rtt, .read, hash_len);
+    try Step.install(&bridge, &model, &secret_buf, &scratch, .zero_rtt, .write, hash_len);
     try Step.install(&bridge, &model, &secret_buf, &scratch, .handshake, .read, hash_len);
+    try Step.install(&bridge, &model, &secret_buf, &scratch, .application, .write, hash_len);
     try Step.discard(&bridge, &model, &scratch, .handshake);
     try Step.complete(&bridge, &model, &scratch);
+}
+
+test "record epoch bridge cannot reinstall zero-rtt keys after teardown" {
+    const cp = testProvider();
+    var bridge = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    const early = secret(0x91);
+
+    // Teardown from a fresh bridge is the worst case for the 0-RTT gate:
+    // `deinit` clears `handshake_complete`, which was the only condition
+    // `installTrafficSecret(.zero_rtt, ...)` checked, so before the
+    // `torn_down` guard both directions could be reinstalled here and the
+    // epoch used to seal and open records again.
+    bridge.deinit();
+
+    try testing.expectError(
+        error.InvalidEpochTransition,
+        bridge.installTrafficSecret(.zero_rtt, .read, &early),
+    );
+    try testing.expectError(
+        error.InvalidEpochTransition,
+        bridge.installTrafficSecret(.zero_rtt, .write, &early),
+    );
+    try testing.expect(!bridge.hasReadKeys(.zero_rtt));
+    try testing.expect(!bridge.hasWriteKeys(.zero_rtt));
+
+    // With no key material obtainable, the epoch stays unusable rather than
+    // merely un-keyed.
+    var protected: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    try testing.expectError(
+        error.MissingWriteKeys,
+        bridge.sealProtected(.zero_rtt, .application_data, "resurrected", &protected),
+    );
+    try testing.expectError(error.MissingReadKeys, bridge.openProtected(.zero_rtt, .{
+        .content_type = .application_data,
+        .legacy_version = record_codec.legacy_record_version,
+        .payload = &[_]u8{0} ** 32,
+    }, &plaintext));
+
+    // The same guard covers every other epoch, at every stage of teardown.
+    const hs = secret(0x92);
+    try testing.expectError(
+        error.InvalidEpochTransition,
+        bridge.installTrafficSecret(.handshake, .read, &hs),
+    );
+    try testing.expectError(
+        error.InvalidEpochTransition,
+        bridge.installTrafficSecret(.application, .write, &hs),
+    );
+    // Teardown after a *completed* session is the other reachable shape.
+    var completed = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    const app = secret(0x93);
+    try completed.installTrafficSecret(.handshake, .read, &hs);
+    try completed.installTrafficSecret(.handshake, .write, &hs);
+    try completed.installTrafficSecret(.application, .read, &app);
+    try completed.installTrafficSecret(.application, .write, &app);
+    try completed.discardEpoch(.initial);
+    try completed.discardEpoch(.handshake);
+    try completed.markHandshakeComplete();
+    completed.deinit();
+    try testing.expectError(
+        error.InvalidEpochTransition,
+        completed.installTrafficSecret(.zero_rtt, .write, &early),
+    );
+
+    // `Bridge.init` is the way to start a new session, and it is unaffected.
+    var fresh = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer fresh.deinit();
+    try fresh.installTrafficSecret(.zero_rtt, .write, &early);
+    try testing.expect(fresh.hasWriteKeys(.zero_rtt));
 }

--- a/src/tls/record_epoch_bridge.zig
+++ b/src/tls/record_epoch_bridge.zig
@@ -59,14 +59,23 @@ pub const Bridge = struct {
     handshake_discarded: bool = false,
     application_discarded: bool = false,
     handshake_complete: bool = false,
-    /// Set by `deinit` and never cleared. Teardown is terminal: a torn-down
-    /// bridge must not be able to acquire key material again, and the
-    /// per-epoch discard flags alone cannot express that. `deinit` resets
-    /// `handshake_complete` to false, which is the *only* gate the 0-RTT
-    /// install path had, so without this flag a torn-down bridge could
-    /// reinstall both 0-RTT directions and resume sealing and opening
-    /// records on that epoch (#493-B review). Starting a new session is
-    /// `Bridge.init`, which yields a fresh value with this cleared.
+    /// Set by every session-teardown path and never cleared. Teardown is
+    /// terminal: a torn-down bridge must not be able to acquire key material
+    /// again, and the per-epoch discard flags alone cannot express that.
+    ///
+    /// There are two teardown paths, and *both* reset `handshake_complete`
+    /// to false — which was the only gate the 0-RTT install path had. Without
+    /// this flag either one left a bridge able to reinstall both 0-RTT
+    /// directions and resume sealing and opening records on that epoch
+    /// (#493-B review):
+    ///
+    ///   * `deinit`, the unconditional wipe for an abandoned or failed
+    ///     handshake; and
+    ///   * `discardEpoch(.application)`, the *orderly* teardown of a
+    ///     completed session.
+    ///
+    /// Starting a new session is `Bridge.init`, which yields a fresh value
+    /// with this cleared.
     torn_down: bool = false,
 
     pub fn init(crypto_provider: provider.CryptoProvider, cipher_suite: algorithms.CipherSuite) Bridge {
@@ -195,6 +204,11 @@ pub const Bridge = struct {
                 self.read_phase = .initial;
                 self.write_phase = .initial;
                 self.handshake_complete = false;
+                // Orderly teardown is still teardown: clearing
+                // `handshake_complete` above would otherwise reopen the
+                // 0-RTT install gate, letting a finished session acquire
+                // fresh early-data keys and resume record traffic.
+                self.torn_down = true;
             },
             .zero_rtt => {
                 clearRead(&self.read_zero_rtt);
@@ -1243,12 +1257,15 @@ const EpochModel = struct {
     handshake_discarded: bool = false,
     application_discarded: bool = false,
     handshake_complete: bool = false,
-    /// Stated here as an independent rule of the lifecycle -- "teardown is
-    /// terminal" -- rather than being re-derived from whichever gates the
+    /// Stated here as an independent rule of the lifecycle -- "a session that
+    /// has been torn down, by either path, never acquires key material
+    /// again" -- rather than being re-derived from whichever gates the
     /// `Bridge` happens to implement. Deriving it from the per-epoch discard
-    /// and completion flags is exactly how this model previously came to
-    /// bless the 0-RTT resurrection path that `deinit` left open (#493-B
-    /// review): the model agreed with the bug instead of detecting it.
+    /// and completion flags is exactly how this model twice came to bless a
+    /// 0-RTT resurrection instead of detecting it (#493-B review): first for
+    /// `deinit`, then for orderly `discardEpoch(.application)`. Both reset
+    /// `handshake_complete`, which was the 0-RTT install path's only gate,
+    /// and a model that mirrors that expression agrees with the bug.
     torn_down: bool = false,
 
     fn snapshot(self: *const EpochModel) BridgeSnapshot {
@@ -1390,7 +1407,14 @@ const EpochModel = struct {
                 self.read_phase = .initial;
                 self.write_phase = .initial;
                 self.handshake_complete = false;
+                // Orderly session teardown, so the same terminal rule
+                // applies as for `deinit` -- stated here, not inherited from
+                // the flags this branch happens to reset.
+                self.torn_down = true;
             },
+            // 0-RTT discard is epoch-scoped, not session teardown: it is
+            // emitted whenever early data ends, including mid-handshake and
+            // when no early keys ever existed, so it must not be terminal.
             .zero_rtt => self.clearSlots(.zero_rtt),
         }
     }
@@ -1787,6 +1811,18 @@ test "the epoch lifecycle model agrees with a scripted full progression through 
     // Orderly application discard, then teardown after a completed session.
     try Step.discard(&bridge, &model, &scratch, .application);
     try Step.discard(&bridge, &model, &scratch, .application);
+
+    // The window *between* orderly application discard and `deinit`: that
+    // discard is session teardown too, and it resets `handshake_complete`,
+    // so it is the second place the 0-RTT install gate could reopen
+    // (#493-B review). Exercised here, before any `deinit`, so removing
+    // either the production or the model's terminal rule for this branch is
+    // mutation-detectable independently of the `deinit` path below.
+    try Step.install(&bridge, &model, &secret_buf, &scratch, .zero_rtt, .read, hash_len);
+    try Step.install(&bridge, &model, &secret_buf, &scratch, .zero_rtt, .write, hash_len);
+    try testing.expect(!bridge.hasReadKeys(.zero_rtt));
+    try testing.expect(!bridge.hasWriteKeys(.zero_rtt));
+
     bridge.deinit();
     model.applyTeardown();
     try expectSnapshotEqual(model.snapshot(), try bridgeSnapshot(&bridge));
@@ -1804,6 +1840,68 @@ test "the epoch lifecycle model agrees with a scripted full progression through 
     try Step.install(&bridge, &model, &secret_buf, &scratch, .application, .write, hash_len);
     try Step.discard(&bridge, &model, &scratch, .handshake);
     try Step.complete(&bridge, &model, &scratch);
+}
+
+test "record epoch bridge cannot reinstall zero-rtt keys after orderly application discard" {
+    const cp = testProvider();
+    var bridge = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer bridge.deinit();
+
+    const hs = secret(0xa1);
+    const app = secret(0xa2);
+    const early = secret(0xa3);
+
+    try bridge.installTrafficSecret(.handshake, .read, &hs);
+    try bridge.installTrafficSecret(.handshake, .write, &hs);
+    try bridge.installTrafficSecret(.application, .read, &app);
+    try bridge.installTrafficSecret(.application, .write, &app);
+    try bridge.discardEpoch(.initial);
+    try bridge.discardEpoch(.handshake);
+    try bridge.markHandshakeComplete();
+
+    // Orderly teardown of a completed session -- `discardEpoch`'s own
+    // documentation calls this session teardown. It resets
+    // `handshake_complete`, which was the 0-RTT install path's only gate, so
+    // before the terminal rule covered this branch a finished session could
+    // acquire fresh early-data keys here and resume record traffic. This is
+    // the window *before* any `deinit` call.
+    try bridge.discardEpoch(.application);
+
+    try testing.expectError(
+        error.InvalidEpochTransition,
+        bridge.installTrafficSecret(.zero_rtt, .read, &early),
+    );
+    try testing.expectError(
+        error.InvalidEpochTransition,
+        bridge.installTrafficSecret(.zero_rtt, .write, &early),
+    );
+    try testing.expect(!bridge.hasReadKeys(.zero_rtt));
+    try testing.expect(!bridge.hasWriteKeys(.zero_rtt));
+
+    // No key material is obtainable, so the epoch stays unusable rather than
+    // merely un-keyed -- and so do the epochs whose own keys this discard
+    // wiped.
+    var protected: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    try testing.expectError(
+        error.MissingWriteKeys,
+        bridge.sealProtected(.zero_rtt, .application_data, "post-teardown", &protected),
+    );
+    try testing.expectError(
+        error.HandshakeNotComplete,
+        bridge.sealApplicationData("post-teardown", &protected),
+    );
+    try testing.expectError(
+        error.InvalidEpochTransition,
+        bridge.installTrafficSecret(.handshake, .read, &hs),
+    );
+    try testing.expectError(
+        error.InvalidEpochTransition,
+        bridge.installTrafficSecret(.application, .write, &app),
+    );
+
+    // A 0-RTT *discard* stays legal and non-terminal by contract, so it must
+    // not have been swept up by the terminal rule.
+    try bridge.discardEpoch(.zero_rtt);
 }
 
 test "record epoch bridge cannot reinstall zero-rtt keys after teardown" {

--- a/src/tls/record_protection.zig
+++ b/src/tls/record_protection.zig
@@ -531,6 +531,45 @@ test "a known-answer record only authenticates at its independently-derived sequ
     try std.testing.expectEqualStrings("GET / HTTP/1.1\r\n\r\n", inner.content);
 }
 
+test "record protection teardown zeroizes keys, resets sequence, and marks state exhausted" {
+    const cp = testProvider();
+    const secret = trafficSecret(.sha384, 0x77);
+    var keys = try TrafficKeys.derive(cp, .tls_aes_256_gcm_sha384, &secret);
+    try std.testing.expect(keys.key.len > 0);
+    try std.testing.expect(keys.iv.len > 0);
+    keys.deinit();
+    try expectSecretsCleared(&keys);
+    // Repeated teardown is safe and idempotent.
+    keys.deinit();
+    try expectSecretsCleared(&keys);
+
+    var write = WriteState.init(cp, try TrafficKeys.derive(cp, .tls_aes_256_gcm_sha384, &secret));
+    write.sequence = 1234;
+    write.deinit();
+    try expectSecretsCleared(&write.keys);
+    try std.testing.expectEqual(@as(u64, 0), write.sequence);
+    try std.testing.expect(write.exhausted);
+    write.deinit();
+    try std.testing.expect(write.exhausted);
+
+    var read = ReadState.init(cp, try TrafficKeys.derive(cp, .tls_aes_256_gcm_sha384, &secret));
+    read.sequence = 4321;
+    read.deinit();
+    try expectSecretsCleared(&read.keys);
+    try std.testing.expectEqual(@as(u64, 0), read.sequence);
+    try std.testing.expect(read.exhausted);
+
+    // An exhausted state is inert: neither direction can be revived by a
+    // caller that kept a pointer to it past teardown.
+    var protected: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    try std.testing.expectError(error.SequenceExhausted, write.seal(.application_data, "x", 0, &protected));
+    try std.testing.expectError(error.SequenceExhausted, read.open(.{
+        .content_type = .application_data,
+        .legacy_version = record_codec.legacy_record_version,
+        .payload = &[_]u8{0} ** (provider.aead_tag_len + 1),
+    }, &protected));
+}
+
 test "record protection allows final sequence number then reports exhaustion" {
     const cp = testProvider();
     const secret = trafficSecret(.sha256, 0x66);
@@ -557,4 +596,749 @@ test "record protection allows final sequence number then reports exhaustion" {
     try std.testing.expectEqualStrings("y", inner.content);
     try std.testing.expect(read.exhausted);
     try std.testing.expectError(error.SequenceExhausted, read.open(parsed, &plaintext));
+}
+
+// -----------------------------------------------------------------------
+// #493 fuzz targets and supporting fixtures. See
+// docs/CRYPTO_FUZZ_CONTRACT.md's "#493" section for the shared rules these
+// follow (fresh provider and state per case, fixed buffers, explicit
+// bounds, typed-error classification, sanitized diagnostics).
+// -----------------------------------------------------------------------
+
+/// Asserts a `TrafficKeys` has actually been wiped: not just that the
+/// borrowed `slice()` view is empty, but that the whole `FixedSecret`
+/// backing array is zero, so a shortened `len` cannot hide retained key or
+/// IV bytes.
+fn expectSecretsCleared(keys: *const TrafficKeys) !void {
+    try std.testing.expectEqual(@as(usize, 0), keys.key.len);
+    try std.testing.expectEqual(@as(usize, 0), keys.iv.len);
+    try std.testing.expect(std.mem.allEqual(u8, &keys.key.bytes, 0));
+    try std.testing.expect(std.mem.allEqual(u8, &keys.iv.bytes, 0));
+}
+
+/// Test-only provider wrapper that either hides one capability from the
+/// reported set or forces one documented typed provider failure.
+///
+/// `HkdfError` and `SealError` contain only `InvalidInput` and
+/// `UnsupportedCapability`; `OpenError` adds `AuthenticationFailed`. Real
+/// tampering already reaches `AuthenticationFailed`, and a capability mask
+/// reaches `UnsupportedCapability` through `TrafficKeys.derive`'s own
+/// preflight, but nothing this module can pass a conforming pure-Zig
+/// provider produces `InvalidInput` -- the lengths it hands over are all
+/// derived from the suite profile. Rather than invent a generic provider
+/// error the record API cannot return, this fixture injects exactly the
+/// documented ones at the vtable seam so their propagation and the caller's
+/// transactional state can be asserted.
+const FaultProvider = struct {
+    inner: provider.CryptoProvider,
+    masked_hash: ?provider.Hash = null,
+    masked_aead: ?provider.Aead = null,
+    hkdf_error: ?provider.HkdfError = null,
+    seal_error: ?provider.SealError = null,
+    open_error: ?provider.OpenError = null,
+
+    fn capabilities(context: *anyopaque) provider.Capabilities {
+        const self: *FaultProvider = @ptrCast(@alignCast(context));
+        var caps = self.inner.capabilities();
+        if (self.masked_hash) |hash| caps.hashes.remove(hash);
+        if (self.masked_aead) |aead| caps.aeads.remove(aead);
+        return caps;
+    }
+
+    fn hkdfExtract(context: *anyopaque, hash: provider.Hash, salt: []const u8, ikm: []const u8, out: []u8) provider.HkdfError!void {
+        const self: *FaultProvider = @ptrCast(@alignCast(context));
+        if (self.hkdf_error) |err| return err;
+        return self.inner.hkdfExtract(hash, salt, ikm, out);
+    }
+
+    fn hkdfExpandLabel(
+        context: *anyopaque,
+        hash: provider.Hash,
+        secret_bytes: []const u8,
+        label: []const u8,
+        hash_context: []const u8,
+        out: []u8,
+    ) provider.HkdfError!void {
+        const self: *FaultProvider = @ptrCast(@alignCast(context));
+        if (self.hkdf_error) |err| return err;
+        return self.inner.hkdfExpandLabel(hash, secret_bytes, label, hash_context, out);
+    }
+
+    fn aeadSeal(
+        context: *anyopaque,
+        aead: provider.Aead,
+        key: []const u8,
+        nonce: []const u8,
+        associated_data: []const u8,
+        plaintext: []const u8,
+        ciphertext: []u8,
+        tag: []u8,
+    ) provider.SealError!void {
+        const self: *FaultProvider = @ptrCast(@alignCast(context));
+        if (self.seal_error) |err| return err;
+        return self.inner.aeadSeal(aead, key, nonce, associated_data, plaintext, ciphertext, tag);
+    }
+
+    fn aeadOpen(
+        context: *anyopaque,
+        aead: provider.Aead,
+        key: []const u8,
+        nonce: []const u8,
+        associated_data: []const u8,
+        ciphertext: []const u8,
+        tag: []const u8,
+        plaintext: []u8,
+    ) provider.OpenError!void {
+        const self: *FaultProvider = @ptrCast(@alignCast(context));
+        if (self.open_error) |err| {
+            // A conforming provider never leaves unauthenticated plaintext
+            // behind on a failed open (the `aeadOpen` vtable contract), so
+            // the fixture must not either -- otherwise the "no plaintext
+            // exposure" property would be proven against a fixture that is
+            // weaker than the interface it stands in for.
+            provider.secureZero(plaintext);
+            return err;
+        }
+        return self.inner.aeadOpen(aead, key, nonce, associated_data, ciphertext, tag, plaintext);
+    }
+
+    fn quicHeaderProtectionMask(
+        context: *anyopaque,
+        hp: provider.QuicHeaderProtection,
+        key: []const u8,
+        sample: []const u8,
+        mask: []u8,
+    ) provider.QuicHeaderProtectionError!void {
+        const self: *FaultProvider = @ptrCast(@alignCast(context));
+        return self.inner.quicHeaderProtectionMask(hp, key, sample, mask);
+    }
+
+    fn generateKeyShare(context: *anyopaque, group: provider.Group, public_out: []u8, private_out: []u8) provider.KeyShareError!void {
+        const self: *FaultProvider = @ptrCast(@alignCast(context));
+        return self.inner.generateKeyShare(group, public_out, private_out);
+    }
+
+    fn deriveSharedSecret(
+        context: *anyopaque,
+        group: provider.Group,
+        private_scalar: []const u8,
+        peer_public: []const u8,
+        out: []u8,
+    ) provider.DeriveError!void {
+        const self: *FaultProvider = @ptrCast(@alignCast(context));
+        return self.inner.deriveSharedSecret(group, private_scalar, peer_public, out);
+    }
+
+    fn verify(
+        context: *anyopaque,
+        scheme: provider.SignatureScheme,
+        public_key: []const u8,
+        message: []const u8,
+        signature: []const u8,
+    ) provider.VerifyError!void {
+        const self: *FaultProvider = @ptrCast(@alignCast(context));
+        return self.inner.verify(scheme, public_key, message, signature);
+    }
+
+    fn cryptoProvider(self: *FaultProvider) provider.CryptoProvider {
+        const vtable = provider.CryptoProvider.VTable{
+            .capabilities = capabilities,
+            .hkdfExtract = hkdfExtract,
+            .hkdfExpandLabel = hkdfExpandLabel,
+            .aeadSeal = aeadSeal,
+            .aeadOpen = aeadOpen,
+            .quicHeaderProtectionMask = quicHeaderProtectionMask,
+            .generateKeyShare = generateKeyShare,
+            .deriveSharedSecret = deriveSharedSecret,
+            .verify = verify,
+        };
+        return .{ .context = self, .vtable = &vtable, .entropy = self.inner.entropy };
+    }
+};
+
+const fuzz_protection_max_content = 64;
+const fuzz_protection_max_padding = 32;
+const fuzz_protection_sentinel: u8 = 0xa5;
+
+const all_suites = [_]algorithms.CipherSuite{
+    .tls_aes_128_gcm_sha256,
+    .tls_aes_256_gcm_sha384,
+    .tls_chacha20_poly1305_sha256,
+};
+
+/// The expected outcome of one `WriteState.seal` call, computed from the
+/// generated inputs *before* the call so the fuzz target asserts an exact
+/// typed error rather than accepting any rejection. Mirrors `seal`'s
+/// documented rejection order: exhausted sequence, then
+/// `encodeInnerPlaintext`'s own stages, then the sealed payload's size, then
+/// the caller's output capacity.
+const SealOracle = union(enum) {
+    sequence_exhausted,
+    invalid_type,
+    too_large,
+    output_overflow,
+    ok: struct { record_len: usize, payload_len: usize },
+};
+
+fn expectedSeal(
+    profile: SuiteProfile,
+    exhausted: bool,
+    content_type: record_codec.ContentType,
+    content_len: usize,
+    padding_len: usize,
+    out_cap: usize,
+) SealOracle {
+    if (exhausted) return .sequence_exhausted;
+    if (content_type == .change_cipher_spec) return .invalid_type;
+    if (content_len > record_codec.max_plaintext_fragment_len) return .too_large;
+    const with_type = std.math.add(usize, content_len, 1) catch return .too_large;
+    const inner_len = std.math.add(usize, with_type, padding_len) catch return .too_large;
+    // `seal` gives `encodeInnerPlaintext` a fixed `max_ciphertext_fragment_len`
+    // scratch buffer, so the encoder's own capacity stage collapses into this
+    // same bound and can never surface as `RecordBufferOverflow` from there.
+    if (inner_len > record_codec.max_ciphertext_fragment_len) return .too_large;
+    const payload_len = inner_len + profile.aead.tagLength();
+    if (payload_len > record_codec.max_ciphertext_fragment_len) return .too_large;
+    const record_len = record_codec.header_len + payload_len;
+    if (out_cap < record_len) return .output_overflow;
+    return .{ .ok = .{ .record_len = record_len, .payload_len = payload_len } };
+}
+
+/// Asserts one rejected `open` is transactional: the exact typed error, an
+/// unchanged sequence/exhaustion snapshot, and either a fully untouched
+/// output buffer (validation and preflight failures, which never reach the
+/// AEAD) or a decrypted span that has been zeroed rather than left holding
+/// unauthenticated plaintext.
+fn expectFailedOpen(
+    read: *ReadState,
+    record: record_codec.TLSCiphertext,
+    out: []u8,
+    expected: anyerror,
+    zeroes_attempted_span: bool,
+) !void {
+    const sequence_before = read.sequence;
+    const exhausted_before = read.exhausted;
+    @memset(out, fuzz_protection_sentinel);
+
+    try std.testing.expectError(expected, read.open(record, out));
+    try std.testing.expectEqual(sequence_before, read.sequence);
+    try std.testing.expectEqual(exhausted_before, read.exhausted);
+
+    if (zeroes_attempted_span) {
+        const ciphertext_len = record.payload.len - read.keys.profile.aead.tagLength();
+        try std.testing.expect(std.mem.allEqual(u8, out[0..ciphertext_len], 0));
+        try std.testing.expect(std.mem.allEqual(u8, out[ciphertext_len..], fuzz_protection_sentinel));
+    } else {
+        try std.testing.expect(std.mem.allEqual(u8, out, fuzz_protection_sentinel));
+    }
+}
+
+test "fuzz: TLS record: protection tamper and sequence boundaries preserve authentication state" {
+    try std.testing.fuzz({}, fuzzProtectionInput, .{
+        .corpus = &.{
+            "",
+            &[_]u8{0},
+            // Leading selector bytes steer the suite / traffic-secret-length /
+            // content-type / content-length / padding / capacity / sequence
+            // matrices toward their boundary arms.
+            &[_]u8{ 0, 1, 0, 0, 1, 1, 0 },
+            &[_]u8{ 1, 1, 1, 1, 2, 1, 1 },
+            &[_]u8{ 2, 1, 2, 2, 3, 1, 2 },
+            &[_]u8{ 0, 0, 0, 3, 4, 0, 3 },
+            &[_]u8{ 1, 2, 1, 4, 5, 2, 4 },
+            &[_]u8{ 2, 3, 2, 5, 0, 1, 5 },
+            &[_]u8{ 0, 1, 3, 1, 1, 1, 4 },
+            &[_]u8{ 1, 1, 0, 0, 2, 0, 5 },
+            &([_]u8{0} ** 32),
+            &([_]u8{0xff} ** 32),
+            &([_]u8{ 1, 2, 3, 4, 5 } ** 8),
+        },
+    });
+}
+
+fn fuzzProtectionInput(_: void, smith: *std.testing.Smith) !void {
+    const pure_zig = crypto.pure_zig;
+    // Per the #493 shared rules, crypto state is constructed fresh inside the
+    // callback rather than reusing this module's process-wide `testProvider()`
+    // singleton, so no case can observe another case's provider state.
+    var entropy = pure_zig.DeterministicEntropy.init(0x493b);
+    var provider_state = pure_zig.Provider.init(entropy.entropy());
+    const cp = provider_state.cryptoProvider();
+
+    const suite = all_suites[smith.index(all_suites.len)];
+    const profile = suiteProfile(suite);
+    const digest_len = profile.hash.digestLength();
+    const tag_len = profile.aead.tagLength();
+
+    // 1. Traffic-secret length matrix at exact-minus-one/exact/exact-plus-one
+    // for whichever of SHA-256/SHA-384 this suite uses. A wrong length must
+    // be refused before any key material is derived.
+    var secret_buf: [provider.max_digest_len + 1]u8 = undefined;
+    var secret_seed: [1]u8 = undefined;
+    smith.bytes(&secret_seed);
+    for (&secret_buf, 0..) |*byte, i| byte.* = secret_seed[0] ^ @as(u8, @truncate(i));
+    const wrong_len: usize = switch (smith.index(3)) {
+        0 => digest_len - 1,
+        1 => digest_len + 1,
+        else => 0,
+    };
+    try std.testing.expectError(
+        error.InvalidTrafficSecretLength,
+        TrafficKeys.derive(cp, suite, secret_buf[0..wrong_len]),
+    );
+    const traffic_secret = secret_buf[0..digest_len];
+
+    // 2. `UnsupportedCapability` is reachable only through `derive`'s
+    // capability preflight, so drive it from a masked view of this same
+    // provider -- alternating which of the suite's two required capabilities
+    // is hidden -- and confirm the unmasked path still works.
+    {
+        var masked = FaultProvider{ .inner = cp };
+        if (smith.index(2) == 0) masked.masked_hash = profile.hash else masked.masked_aead = profile.aead;
+        try std.testing.expectError(
+            error.UnsupportedCapability,
+            TrafficKeys.derive(masked.cryptoProvider(), suite, traffic_secret),
+        );
+    }
+
+    // 3. Sequence matrix: the ordinary counters plus both ends of the
+    // 64-bit exhaustion boundary.
+    const initial_sequence: u64 = switch (smith.index(6)) {
+        0 => 0,
+        1 => 1,
+        2 => 255,
+        3 => 256,
+        4 => std.math.maxInt(u64) - 1,
+        else => std.math.maxInt(u64),
+    };
+
+    var write = WriteState.init(cp, try TrafficKeys.derive(cp, suite, traffic_secret));
+    defer write.deinit();
+    var read = ReadState.init(cp, try TrafficKeys.derive(cp, suite, traffic_secret));
+    defer read.deinit();
+    write.sequence = initial_sequence;
+    read.sequence = initial_sequence;
+
+    // 4. Content type, content, padding, and output capacity. Padding
+    // carries the size boundaries because it is a scalar the encoder
+    // zero-fills: an exact-maximum sealed payload, one past it, and a
+    // synthetic near-`usize`-max value are all expressible without an
+    // oversized content buffer.
+    const valid_types = [_]record_codec.ContentType{ .alert, .handshake, .application_data };
+    const content_type: record_codec.ContentType = if (smith.index(8) == 0)
+        .change_cipher_spec
+    else
+        valid_types[smith.index(valid_types.len)];
+
+    var content_buf: [fuzz_protection_max_content]u8 = undefined;
+    const content_len = switch (smith.index(4)) {
+        0 => 0,
+        1 => 1,
+        else => smith.index(content_buf.len + 1),
+    };
+    smith.bytes(content_buf[0..content_len]);
+
+    // The largest padding whose sealed payload still fits the ciphertext
+    // fragment limit, given this content length and tag length.
+    const max_valid_padding = record_codec.max_ciphertext_fragment_len - tag_len - 1 - content_len;
+    const padding_len: usize = switch (smith.index(6)) {
+        0 => 0,
+        1 => 1,
+        2 => max_valid_padding,
+        3 => max_valid_padding + 1,
+        4 => std.math.maxInt(usize),
+        else => smith.index(fuzz_protection_max_padding + 1),
+    };
+
+    var out_buf: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    const required_len: ?usize = switch (expectedSeal(profile, false, content_type, content_len, padding_len, out_buf.len)) {
+        .ok => |ok| ok.record_len,
+        else => null,
+    };
+    const out_cap = switch (smith.index(4)) {
+        0 => if (required_len) |len| len else smith.index(out_buf.len + 1),
+        1 => if (required_len) |len| (if (len == 0) 0 else len - 1) else smith.index(out_buf.len + 1),
+        2 => if (required_len) |len| @min(len + 1, out_buf.len) else smith.index(out_buf.len + 1),
+        else => smith.index(out_buf.len + 1),
+    };
+    const out = out_buf[0..out_cap];
+    @memset(out, fuzz_protection_sentinel);
+
+    const seal_oracle = expectedSeal(profile, write.exhausted, content_type, content_len, padding_len, out_cap);
+    var plaintext_buf: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+
+    switch (seal_oracle) {
+        .sequence_exhausted, .invalid_type, .too_large, .output_overflow => {
+            const expected: anyerror = switch (seal_oracle) {
+                .sequence_exhausted => error.SequenceExhausted,
+                .invalid_type => error.InvalidRecordType,
+                .too_large => error.RecordTooLarge,
+                .output_overflow => error.RecordBufferOverflow,
+                .ok => unreachable,
+            };
+            try std.testing.expectError(expected, write.seal(content_type, content_buf[0..content_len], padding_len, out));
+            // A rejected seal is transactional: no sequence advance and not
+            // one byte written to the caller's buffer.
+            try std.testing.expectEqual(initial_sequence, write.sequence);
+            try std.testing.expect(std.mem.allEqual(u8, out, fuzz_protection_sentinel));
+        },
+        .ok => |ok| {
+            const record = try write.seal(content_type, content_buf[0..content_len], padding_len, out);
+            try std.testing.expectEqual(ok.record_len, record.len);
+            try std.testing.expect(withinRange(out, record));
+            // Bytes past the sealed record must still be untouched.
+            try std.testing.expect(std.mem.allEqual(u8, out[record.len..], fuzz_protection_sentinel));
+
+            // The header the AEAD authenticated as associated data must be
+            // exactly the serialized record header, re-derived here rather
+            // than read back from the implementation's own writer.
+            try std.testing.expectEqual(@as(u8, @intFromEnum(record_codec.ContentType.application_data)), record[0]);
+            try std.testing.expectEqual(record_codec.legacy_record_version, std.mem.readInt(u16, record[1..3], .big));
+            try std.testing.expectEqual(ok.payload_len, std.mem.readInt(u16, record[3..5], .big));
+
+            // A write at `maxInt(u64)` is legal exactly once, after which the
+            // state is exhausted rather than wrapping to a reused nonce.
+            if (initial_sequence == std.math.maxInt(u64)) {
+                try std.testing.expectEqual(std.math.maxInt(u64), write.sequence);
+                try std.testing.expect(write.exhausted);
+                var exhausted_out: [record_codec.header_len + 64]u8 = undefined;
+                @memset(&exhausted_out, fuzz_protection_sentinel);
+                try std.testing.expectError(
+                    error.SequenceExhausted,
+                    write.seal(.application_data, "x", 0, &exhausted_out),
+                );
+                try std.testing.expect(std.mem.allEqual(u8, &exhausted_out, fuzz_protection_sentinel));
+            } else {
+                try std.testing.expectEqual(initial_sequence + 1, write.sequence);
+                try std.testing.expect(!write.exhausted);
+            }
+
+            var record_buf: [record_codec.max_ciphertext_record_len]u8 = undefined;
+            @memcpy(record_buf[0..record.len], record);
+            const sealed = record_buf[0..record.len];
+            const ciphertext_len = ok.payload_len - tag_len;
+            const parsed = record_codec.TLSCiphertext{
+                .content_type = .application_data,
+                .legacy_version = record_codec.legacy_record_version,
+                .payload = sealed[record_codec.header_len..],
+            };
+
+            // 5. Tamper battery. Every mutation runs against the same read
+            // state, so each one also proves the failure left that state
+            // usable for the legitimate open at the end.
+            try fuzzProtectionTamper(smith, cp, suite, traffic_secret, &read, parsed, sealed, ciphertext_len, &plaintext_buf);
+
+            // 6. A valid open against the same read state and sequence still
+            // succeeds after every one of those failures, round-trips the
+            // content exactly, and advances the read sequence exactly once.
+            @memset(plaintext_buf[0..ciphertext_len], fuzz_protection_sentinel);
+            const inner = try read.open(parsed, &plaintext_buf);
+            try std.testing.expectEqual(content_type, inner.content_type);
+            try std.testing.expectEqualSlices(u8, content_buf[0..content_len], inner.content);
+            try std.testing.expectEqual(padding_len, inner.padding_len);
+            try std.testing.expect(withinRange(plaintext_buf[0..ciphertext_len], inner.content));
+
+            if (initial_sequence == std.math.maxInt(u64)) {
+                try std.testing.expectEqual(std.math.maxInt(u64), read.sequence);
+                try std.testing.expect(read.exhausted);
+                try expectFailedOpen(&read, parsed, plaintext_buf[0..ciphertext_len], error.SequenceExhausted, false);
+            } else {
+                try std.testing.expectEqual(initial_sequence + 1, read.sequence);
+                try std.testing.expect(!read.exhausted);
+                // The same record at the *next* sequence has a different
+                // nonce, so replaying it must fail closed.
+                try expectFailedOpen(&read, parsed, plaintext_buf[0..ciphertext_len], error.AuthenticationFailed, true);
+            }
+        },
+    }
+
+    // 7. Teardown wipes both directions unconditionally, and a repeat is
+    // safe -- the deferred `deinit`s above run again on the way out.
+    write.deinit();
+    read.deinit();
+    try expectSecretsCleared(&write.keys);
+    try expectSecretsCleared(&read.keys);
+    try std.testing.expectEqual(@as(u64, 0), write.sequence);
+    try std.testing.expectEqual(@as(u64, 0), read.sequence);
+    try std.testing.expect(write.exhausted);
+    try std.testing.expect(read.exhausted);
+}
+
+/// The independent tamper scenarios #493 requires, run against one sealed
+/// record and a read state positioned at its sequence. Each must fail with
+/// its exact typed error, leave the read sequence and exhaustion flag
+/// untouched, and never hand back a plaintext view.
+fn fuzzProtectionTamper(
+    smith: *std.testing.Smith,
+    cp: provider.CryptoProvider,
+    suite: algorithms.CipherSuite,
+    traffic_secret: []const u8,
+    read: *ReadState,
+    parsed: record_codec.TLSCiphertext,
+    sealed: []u8,
+    ciphertext_len: usize,
+    plaintext_buf: []u8,
+) !void {
+    const profile = suiteProfile(suite);
+    const tag_len = profile.aead.tagLength();
+    const out = plaintext_buf[0..ciphertext_len];
+
+    // (a) Ciphertext bit flip at a fuzzer-chosen offset.
+    if (ciphertext_len > 0) {
+        var flip_byte: [1]u8 = undefined;
+        smith.bytes(&flip_byte);
+        const offset = record_codec.header_len + smith.index(ciphertext_len);
+        const original = sealed[offset];
+        sealed[offset] ^= if (flip_byte[0] == 0) 0x01 else flip_byte[0];
+        try expectFailedOpen(read, parsed, out, error.AuthenticationFailed, true);
+        sealed[offset] = original;
+    }
+
+    // (b) Tag bit flip at a fuzzer-chosen offset within the tag.
+    {
+        const offset = record_codec.header_len + ciphertext_len + smith.index(tag_len);
+        const original = sealed[offset];
+        sealed[offset] ^= 0x80;
+        try expectFailedOpen(read, parsed, out, error.AuthenticationFailed, true);
+        sealed[offset] = original;
+    }
+
+    // (c) Tag truncation: the shortened payload changes both the tag and the
+    // length field the associated data is built from. Dropping the whole tag
+    // (and more) falls below the minimum payload and must be refused before
+    // the AEAD runs, leaving the output entirely untouched.
+    {
+        const drop = 1 + smith.index(tag_len);
+        const truncated = record_codec.TLSCiphertext{
+            .content_type = .application_data,
+            .legacy_version = record_codec.legacy_record_version,
+            .payload = parsed.payload[0 .. parsed.payload.len - drop],
+        };
+        if (truncated.payload.len < tag_len) {
+            try expectFailedOpen(read, truncated, out, error.MalformedInnerPlaintext, false);
+        } else {
+            try expectFailedOpen(read, truncated, out, error.AuthenticationFailed, true);
+        }
+    }
+
+    // (d) Associated-data content type and version mutations are refused by
+    // `open`'s own preflight, before any key is touched.
+    {
+        const wrong_types = [_]record_codec.ContentType{ .handshake, .alert, .change_cipher_spec };
+        var wrong_type = parsed;
+        wrong_type.content_type = wrong_types[smith.index(wrong_types.len)];
+        try expectFailedOpen(read, wrong_type, out, error.InvalidRecordType, false);
+
+        var wrong_version = parsed;
+        wrong_version.legacy_version = if (smith.index(2) == 0) 0x0301 else 0x0304;
+        try expectFailedOpen(read, wrong_version, out, error.InvalidRecordVersion, false);
+    }
+
+    // (e) Wrong read sequence: the nonce is the sequence XORed into the IV,
+    // so a reader positioned anywhere else fails closed even with correct
+    // key material.
+    {
+        const correct = read.sequence;
+        const delta: u64 = 1 + smith.index(255);
+        read.sequence = if (correct >= delta) correct - delta else correct + delta;
+        try expectFailedOpen(read, parsed, out, error.AuthenticationFailed, true);
+        read.sequence = correct;
+    }
+
+    // (f) Wrong traffic secret, and (g) wrong suite-derived keys from the
+    // *same* secret. Both are fresh states, so the shared read state's
+    // sequence is untouched by construction.
+    {
+        var wrong_secret_buf: [provider.max_digest_len]u8 = undefined;
+        @memcpy(wrong_secret_buf[0..traffic_secret.len], traffic_secret);
+        wrong_secret_buf[smith.index(traffic_secret.len)] ^= 0x01;
+        var wrong_secret_read = ReadState.init(cp, try TrafficKeys.derive(cp, suite, wrong_secret_buf[0..traffic_secret.len]));
+        defer wrong_secret_read.deinit();
+        wrong_secret_read.sequence = read.sequence;
+        try expectFailedOpen(&wrong_secret_read, parsed, out, error.AuthenticationFailed, true);
+
+        // Only suites whose hash agrees can consume this secret length, so
+        // pick the other same-hash suite when one exists.
+        const other_suite: ?algorithms.CipherSuite = switch (suite) {
+            .tls_aes_128_gcm_sha256 => .tls_chacha20_poly1305_sha256,
+            .tls_chacha20_poly1305_sha256 => .tls_aes_128_gcm_sha256,
+            .tls_aes_256_gcm_sha384 => null,
+        };
+        if (other_suite) |other| {
+            var wrong_suite_read = ReadState.init(cp, try TrafficKeys.derive(cp, other, traffic_secret));
+            defer wrong_suite_read.deinit();
+            wrong_suite_read.sequence = read.sequence;
+            try expectFailedOpen(&wrong_suite_read, parsed, out, error.AuthenticationFailed, true);
+        }
+    }
+
+    // (h) Authenticated but malformed inner plaintext: an all-zero inner
+    // plaintext carries no content type, so it must be rejected *after* a
+    // successful AEAD open, with the decrypted span zeroed and the sequence
+    // still not advanced.
+    {
+        const inner_len = 1 + smith.index(8);
+        var inner = [_]u8{0} ** 9;
+        const payload_len = inner_len + tag_len;
+        var forged: [9 + provider.aead_tag_len + record_codec.header_len]u8 = undefined;
+        writeCiphertextHeader(payload_len, forged[0..record_codec.header_len]);
+        var nonce = nonceFor(read.keys.iv.slice(), read.sequence);
+        defer provider.secureZero(&nonce);
+        try cp.aeadSeal(
+            profile.aead,
+            read.keys.key.slice(),
+            &nonce,
+            forged[0..record_codec.header_len],
+            inner[0..inner_len],
+            forged[record_codec.header_len..][0..inner_len],
+            forged[record_codec.header_len + inner_len ..][0..tag_len],
+        );
+        const forged_record = record_codec.TLSCiphertext{
+            .content_type = .application_data,
+            .legacy_version = record_codec.legacy_record_version,
+            .payload = forged[record_codec.header_len..][0..payload_len],
+        };
+        try expectFailedOpen(read, forged_record, plaintext_buf[0..inner_len], error.MalformedInnerPlaintext, true);
+    }
+
+    // (i) Output capacity at exact-minus-one is a preflight failure: the
+    // record is authentic, but a caller who cannot receive the whole
+    // plaintext must get nothing rather than a truncated prefix.
+    if (ciphertext_len > 0) {
+        try expectFailedOpen(read, parsed, plaintext_buf[0 .. ciphertext_len - 1], error.RecordBufferOverflow, false);
+    }
+
+    // (j) Documented provider error classes propagate exactly and leave the
+    // caller's state transactional. `AuthenticationFailed` is already covered
+    // by real tampering above; these are the two that no conforming pure-Zig
+    // provider produces from this module's own call shapes.
+    {
+        var fault = FaultProvider{ .inner = cp, .open_error = error.InvalidInput };
+        var fault_read = ReadState.init(fault.cryptoProvider(), try TrafficKeys.derive(cp, suite, traffic_secret));
+        defer fault_read.deinit();
+        fault_read.sequence = read.sequence;
+        try expectFailedOpen(&fault_read, parsed, out, error.InvalidInput, true);
+
+        fault.open_error = error.UnsupportedCapability;
+        try expectFailedOpen(&fault_read, parsed, out, error.UnsupportedCapability, true);
+
+        var seal_fault = FaultProvider{ .inner = cp, .seal_error = error.InvalidInput };
+        var fault_write = WriteState.init(seal_fault.cryptoProvider(), try TrafficKeys.derive(cp, suite, traffic_secret));
+        defer fault_write.deinit();
+        fault_write.sequence = read.sequence;
+        var fault_out: [record_codec.header_len + 32]u8 = undefined;
+        @memset(&fault_out, fuzz_protection_sentinel);
+        try std.testing.expectError(error.InvalidInput, fault_write.seal(.application_data, "x", 0, &fault_out));
+        try std.testing.expectEqual(read.sequence, fault_write.sequence);
+        try std.testing.expect(!fault_write.exhausted);
+
+        var hkdf_fault = FaultProvider{ .inner = cp, .hkdf_error = error.InvalidInput };
+        try std.testing.expectError(
+            error.InvalidInput,
+            TrafficKeys.derive(hkdf_fault.cryptoProvider(), suite, traffic_secret),
+        );
+    }
+}
+
+/// True when `inner` is empty or lies wholly inside `outer`'s backing bytes,
+/// mirroring `record_codec`'s `withinBounds` -- the #493 borrowed-view
+/// lifetime property for sealed records and decoded inner plaintext.
+fn withinRange(outer: []const u8, inner: []const u8) bool {
+    if (inner.len == 0) return true;
+    const outer_start = @intFromPtr(outer.ptr);
+    const inner_start = @intFromPtr(inner.ptr);
+    return inner_start >= outer_start and inner_start + inner.len <= outer_start + outer.len;
+}
+
+// The fuzz target's tamper battery reaches each of these arms only when the
+// generated case happens to select the matching suite/length combination, and
+// CI replays the seed corpus alone. These pin the classification stages
+// deterministically, at every suite, so a regression cannot survive a plain
+// `zig build test-tls`.
+test "seal classifies every rejection stage at its exact boundary for every suite" {
+    const cp = testProvider();
+    inline for (all_suites) |suite| {
+        const profile = comptime suiteProfile(suite);
+        const secret = trafficSecret(profile.hash, 0x5a);
+        var write = WriteState.init(cp, try TrafficKeys.derive(cp, suite, &secret));
+        defer write.deinit();
+
+        var out: [record_codec.max_ciphertext_record_len]u8 = undefined;
+        const tag_len = profile.aead.tagLength();
+        const max_valid_padding = record_codec.max_ciphertext_fragment_len - tag_len - 1;
+
+        // change_cipher_spec has no legal inner-plaintext encoding.
+        try std.testing.expectError(
+            error.InvalidRecordType,
+            write.seal(.change_cipher_spec, "", 0, &out),
+        );
+        // Exactly the largest sealable payload, then one byte past it.
+        const largest = try write.seal(.application_data, "", max_valid_padding, &out);
+        try std.testing.expectEqual(
+            record_codec.header_len + record_codec.max_ciphertext_fragment_len,
+            largest.len,
+        );
+        try std.testing.expectError(
+            error.RecordTooLarge,
+            write.seal(.application_data, "", max_valid_padding + 1, &out),
+        );
+        // A padding length no allocation could represent still fails typed
+        // rather than wrapping the inner-plaintext total.
+        try std.testing.expectError(
+            error.RecordTooLarge,
+            write.seal(.application_data, "", std.math.maxInt(usize), &out),
+        );
+        // Output capacity at exactly one byte short of the record.
+        const needed = record_codec.header_len + 1 + 1 + tag_len;
+        try std.testing.expectError(
+            error.RecordBufferOverflow,
+            write.seal(.application_data, "x", 0, out[0 .. needed - 1]),
+        );
+        const exact = try write.seal(.application_data, "x", 0, out[0..needed]);
+        try std.testing.expectEqual(needed, exact.len);
+    }
+}
+
+test "open classifies every rejection stage at its exact boundary and never advances read state" {
+    const cp = testProvider();
+    inline for (all_suites) |suite| {
+        const profile = comptime suiteProfile(suite);
+        const secret = trafficSecret(profile.hash, 0x6b);
+        var write = WriteState.init(cp, try TrafficKeys.derive(cp, suite, &secret));
+        defer write.deinit();
+        var read = ReadState.init(cp, try TrafficKeys.derive(cp, suite, &secret));
+        defer read.deinit();
+
+        var protected: [record_codec.max_ciphertext_record_len]u8 = undefined;
+        const record = try write.seal(.handshake, "finished", 3, &protected);
+        const parsed = try parsedCiphertext(record);
+        const tag_len = profile.aead.tagLength();
+        const ciphertext_len = parsed.payload.len - tag_len;
+        var plaintext: [64]u8 = undefined;
+
+        var wrong_type = parsed;
+        wrong_type.content_type = .handshake;
+        try expectFailedOpen(&read, wrong_type, plaintext[0..ciphertext_len], error.InvalidRecordType, false);
+
+        var wrong_version = parsed;
+        wrong_version.legacy_version = 0x0301;
+        try expectFailedOpen(&read, wrong_version, plaintext[0..ciphertext_len], error.InvalidRecordVersion, false);
+
+        const short = record_codec.TLSCiphertext{
+            .content_type = .application_data,
+            .legacy_version = record_codec.legacy_record_version,
+            .payload = parsed.payload[0 .. tag_len - 1],
+        };
+        try expectFailedOpen(&read, short, plaintext[0..ciphertext_len], error.MalformedInnerPlaintext, false);
+
+        try expectFailedOpen(&read, parsed, plaintext[0 .. ciphertext_len - 1], error.RecordBufferOverflow, false);
+
+        // Every preceding rejection left the read state exactly where it
+        // started, so the authentic record still opens at sequence 0.
+        try std.testing.expectEqual(@as(u64, 0), read.sequence);
+        const inner = try read.open(parsed, &plaintext);
+        try std.testing.expectEqualStrings("finished", inner.content);
+        try std.testing.expectEqual(@as(usize, 3), inner.padding_len);
+        try std.testing.expectEqual(@as(u64, 1), read.sequence);
+    }
 }


### PR DESCRIPTION
## Summary

Second of #493's three planned slices (per the issue's implementation-plan comment): **record protection** and **epoch/key lifecycle**. Adds two `std.testing.Smith` targets under the existing `test-tls-record-fuzz` step that #493-A wired up, plus named deterministic companions for the arms CI's seed-corpus replay cannot reliably reach.

**This slice carries a production fix.** Review of the epoch oracle uncovered a real lifecycle defect in `record_epoch_bridge.zig`: **teardown was not terminal**, and the reference model agreed with the bug rather than detecting it.

The record contract has two session-teardown paths, and both reset `handshake_complete` to false — which was the *only* condition `installTrafficSecret(.zero_rtt, ...)` checked:

1. `Bridge.deinit()`, the unconditional wipe for an abandoned or failed handshake;
2. `discardEpoch(.application)`, the **orderly** teardown of a completed session, which that function's own documentation calls session teardown.

After either one, a bridge could have fresh 0-RTT read and write keys installed and resume sealing and opening records on that epoch. Both were confirmed with throwaway repros before fixing (seal → open → plaintext recovered), and both are now closed by a `torn_down` flag that every teardown path sets and nothing clears; `installTrafficSecret` rejects every epoch and direction once set. 0-RTT *discard* is deliberately unaffected — it is epoch-scoped, not session teardown. No production caller reused a bridge across either path, so this only closes the resurrection paths.

The record-protection target itself found no defect.

### `fuzz: TLS record: protection tamper and sequence boundaries preserve authentication state`

In `src/tls/record_protection.zig`.

- Classifies every `WriteState.seal` outcome **before** the call (`expectedSeal`, mirroring `seal`'s documented rejection order: exhausted sequence → `encodeInnerPlaintext`'s stages → sealed payload size → output capacity) and asserts that exact typed error, with the destination sentinel and write sequence re-verified after each rejection.
- Matrices over suite, traffic-secret length (exact-minus-one/exact/exact-plus-one per hash), content, padding, output capacity, and initial sequence (`{0, 1, 255, 256, maxInt-1, maxInt}`). Padding carries the size boundaries because it is a scalar the encoder zero-fills, so the exact-maximum sealed payload, one past it, and a synthetic `maxInt(usize)` need no oversized content buffer.
- On the accepting path the serialized header (what the AEAD authenticates as associated data) is re-derived independently and compared field by field; a write at `maxInt(u64)` is proven usable exactly once before the state latches exhausted; returned views are checked for containment in their backing buffer.
- Tamper battery against **one shared read state**: ciphertext bit flip, tag bit flip, tag truncation at every representative boundary, associated-data content-type and version mutation, wrong read sequence, wrong traffic secret, wrong suite-derived keys from the same secret, authenticated-but-malformed all-zero inner plaintext, and an exact-minus-one output buffer. Each must fail with its exact typed error and leave sequence/exhaustion untouched; failures reaching the AEAD must leave the attempted plaintext span **zeroed**, while validation/preflight failures must leave the buffer **entirely untouched**. Because they share one read state, the legitimate open that follows also proves a failed open leaves the state usable — and, once it succeeds, that replaying at the advanced sequence fails closed.
- A test-only `FaultProvider` wrapper makes the documented `UnsupportedCapability` (capability mask, caught by `TrafficKeys.derive`'s preflight) and `InvalidInput` (injected at the `aeadSeal`/`aeadOpen`/HKDF vtable seam) classes reachable deterministically, rather than inventing errors the record API cannot return. The fixture zeroes `plaintext` on a forced open failure so the "no unauthenticated plaintext" property is not proven against a fixture weaker than the interface it stands in for.
- Teardown is asserted directly on the public `FixedSecret` backing arrays: key/IV bytes zero, lengths zero, sequence reset, state exhausted, repeated teardown safe.

### `fuzz: TLS record: epoch operation sequences preserve one-way key lifecycle`

In `src/tls/record_epoch_bridge.zig`.

- Bounded programs of up to 48 operations — traffic-secret install at every epoch/direction with a length matrix, epoch discard, handshake completion, negotiated-suite updates including unknown code points, seal and open at each epoch, and `deinit` teardown at an arbitrary point followed by continued operation — driven against a `Bridge` and an independent `EpochModel` written from the documented transition rules rather than from the implementation.
- After **every** operation, accepted or rejected, a full `BridgeSnapshot` must equal the model's prediction: both direction phases, all three discard flags, completion, the negotiated suite, and for each of the six key slots an optional holding its sequence. Folding presence and sequence into one optional catches both a key that should have been wiped and a sequence that advanced when it should not have; the snapshot also cross-checks `hasReadKeys`/`hasWriteKeys` against the private slots at every step.
- The model predicts not just each gate but whether a record can authenticate at all — it tracks the suite each slot was installed under plus both sequence counters, and the target uses one fixed secret per epoch, so identical suite + identical sequence means byte-identical keys. A bridge that opened a record under the wrong epoch's keys, or consumed a read sequence number on a failed open, fails here.
- Covers the #408 transition classes as seeds: early discard, duplicate discard, missing direction, application install before handshake, partial completion, abandoned handshake, full progression, and teardown at every boundary.

TLS-over-TCP KeyUpdate/replacement remains #357 — the bridge exposes no such surface, so the operation set is documented as the extension point rather than a fabricated API.

### Docs

`docs/CRYPTO_FUZZ_CONTRACT.md` gains the #493-B narrative, the new filtered/long-run commands, a named-regression replay command, an explicit bounds table for all four #493 targets so far, and a statement that no #493 target uses network I/O, ambient entropy, real secrets, or external peers. `CHANGELOG.md` gains a Testing entry.

## Test plan

- [x] `zig fmt --check build.zig src/ tests/`
- [x] `zig fmt --check build.zig src/ tests/`
- [x] `zig build test-tls-record-fuzz --summary all` — 6/6
- [x] `zig build test-tls --summary all` — 915/915
- [x] `zig build test --summary all` — 3190/3191 (1 pre-existing skip)
- [x] `zig build test -Dtls-profile=appliance --summary all` — 3159/3160 (1 pre-existing skip)
- [x] Bounded `ReleaseFast` coverage-guided smoke, both new targets at `--fuzz=2M`, re-run after each production fix:
  - `protection tamper and sequence boundaries…` → 2 200 294 runs, clean
  - `epoch operation sequences…` → 2 000 286 runs after fix 1, and re-run again after fix 2, clean
- [x] **Both production defects confirmed by throwaway repro before fixing** — deinit (or application discard) → reinstall both 0-RTT directions → seal → open → plaintext recovered. Each repro passed against the unfixed bridge, then was deleted and replaced by a named regression.
- [x] **Oracle bug found by the coverage-guided run**, not the corpus: the epoch model did not predict `ReadState.open`'s `InvalidRecordType` preflight, so replaying an initial-epoch *plaintext* record at a protected epoch mispredicted `AuthenticationFailed`. The model now mirrors the full preflight order.
- [x] **Mutation-validated in both directions**, following #493-A's standard. Production-side mutations prove the tests catch the defect; oracle-side mutations prove the model cannot regress to mirroring the implementation:

| Mutation | Caught by |
| --- | --- |
| Drop `discardEpoch(.application)`'s `handshake_complete = false` | scripted companion (fuzz target in 16 runs) |
| Swap `seal`'s `RecordBufferOverflow` for `RecordTooLarge` | `seal classifies every rejection stage…` |
| Remove `installTrafficSecret`'s `torn_down` guard | both named teardown regressions (fuzz target in 17 runs) |
| Remove production `torn_down` on application discard only | `…after orderly application discard` + companion (fuzz target in 38 runs) |
| Remove the **model's** `torn_down` rule (either path) | scripted companion |

  The seed-corpus replay alone caught none of these, which is exactly why each has a named companion.

Ref #493 (closed by #493-C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
