### PR TITLE
perf: add competitive benchmark suite

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -127,7 +127,7 @@ Useful commands:
 ```
 
 See `benchmarks/competitive/README.md` for fairness rules, config templates,
-and output schema.
+upstream-pool matrix coverage, and output schema.
 
 ### Throughput scenarios (all tools)
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -30,6 +30,10 @@ Run benchmarks on a dedicated, isolated benchmark target by default.
 # Fallback only: local/shared-runner smoke test
 # Use this only when explicitly requested or when a dedicated target is unavailable.
 ./benchmarks/ci-smoke.sh
+
+# Competitive local comparison against Tardigrade, NGINX, HAProxy, and Caddy.
+# Canonical competitor numbers still belong on a dedicated idle host.
+./benchmarks/competitive/run.sh
 ```
 
 ## Prerequisites
@@ -104,6 +108,26 @@ helper allocation counts. Use the streaming scenarios below with PID sampling
 to compare RSS, p99, throughput, buffered bytes, and CPU.
 
 ## Scenarios
+
+### Competitive suite
+
+`benchmarks/competitive/run.sh` starts representative Tardigrade, NGINX,
+HAProxy, and Caddy configs one at a time, drives the shared benchmark runner,
+and emits combined JSON, CSV, and Markdown summaries. It covers tiny static,
+large static, small proxy, large proxy, slow-client proxy download, keep-alive,
+and `Connection: close` connection-churn workloads by default, with an optional k6
+idle-keepalive/active-traffic scenario.
+
+Useful commands:
+
+```bash
+./benchmarks/competitive/run.sh --print-manual
+./benchmarks/competitive/run.sh --smoke
+./benchmarks/competitive/run.sh --allow-missing
+```
+
+See `benchmarks/competitive/README.md` for fairness rules, config templates,
+and output schema.
 
 ### Throughput scenarios (all tools)
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -115,8 +115,9 @@ to compare RSS, p99, throughput, buffered bytes, and CPU.
 HAProxy, and Caddy configs one at a time, drives the shared benchmark runner,
 and emits combined JSON, CSV, and Markdown summaries. It covers tiny static,
 large static, small proxy, large proxy, slow-client proxy download, keep-alive,
-and `Connection: close` connection-churn workloads by default, with an optional k6
-idle-keepalive/active-traffic scenario.
+and `Connection: close` connection-churn workloads by default. Full non-smoke
+runs also require k6 for the idle-keepalive/active-traffic scenario and include
+the upstream-pool distribution matrix.
 
 Useful commands:
 

--- a/benchmarks/ci-smoke.sh
+++ b/benchmarks/ci-smoke.sh
@@ -96,7 +96,9 @@ python3 "${BENCH_DIR}/fixtures/upstream_server.py" --port "${UPSTREAM_PORT}" >"$
 UPSTREAM_PID="$!"
 wait_for_http "http://127.0.0.1:${UPSTREAM_PORT}/health"
 
-TARDIGRADE_RATE_LIMIT_RPS=0 "${BINARY}" run -c "${CONFIG_FILE}" >"${TMP_DIR}/tardigrade.log" 2>&1 &
+TARDIGRADE_RATE_LIMIT_RPS=0 \
+TARDIGRADE_MAX_REQUESTS_PER_CONNECTION=0 \
+"${BINARY}" run -c "${CONFIG_FILE}" >"${TMP_DIR}/tardigrade.log" 2>&1 &
 TARDIGRADE_PID="$!"
 wait_for_http "http://127.0.0.1:${LISTEN_PORT}/health"
 

--- a/benchmarks/competitive/README.md
+++ b/benchmarks/competitive/README.md
@@ -44,6 +44,7 @@ Required for all runs:
 Required for full non-smoke runs:
 
 - `k6`, used for the idle keep-alive clients plus active traffic scenario
+- `openssl` and `nghttpd`, used for the upstream TLS handshake/reuse phase
 
 Required for the full default competitor set:
 
@@ -87,12 +88,14 @@ representative `http-request return file` path is bounded by HAProxy response
 buffer size and is not valid for a 1 MiB static file. The suite records that row
 as unsupported instead of manufacturing a misleading number.
 
-Full Tardigrade runs also write `upstream-pool-matrix.json`, covering the #147
-matrix absorbed by #149: uneven route traffic, many low-volume origins, one hot
-origin with many workers, local vs cross-worker reuse, new upstream
-connections/sec, CPU/request, p99 TTFB, and contention notes. Upstream TLS
-handshake/reuse is marked unsupported until a TLS-capable local origin fixture
-exists.
+Full Tardigrade runs also write `upstream-pool-matrix.json` and embed the same
+data in `competitive-results.json`, `competitive-results.csv`, and
+`competitive-summary.md`. The matrix covers the #147 workloads absorbed by
+#149: uneven route traffic, many low-volume origins, one hot origin with many
+workers, upstream TLS handshake/reuse, local vs cross-worker reuse, new upstream
+connections/sec, CPU/request, p99 latency, and higher-worker contention
+evidence. `p99_ttfb_ms` remains null until a first-byte-capable load tool is
+wired into that path.
 
 ## Configs
 
@@ -126,10 +129,12 @@ The combined JSON shape is:
         "throughput_mbps": 10.1,
         "cpu_pct_avg": 50.0,
         "rss_mb_peak": 25.0,
+        "open_fds_peak": 128,
         "errors": 0
       }
     }
-  }
+  },
+  "upstream_pool_matrix": { "scenarios": {} }
 }
 ```
 

--- a/benchmarks/competitive/README.md
+++ b/benchmarks/competitive/README.md
@@ -41,6 +41,10 @@ Required for all runs:
 - one load tool, `wrk` by default
 - Zig 0.16.0 when the Tardigrade binary must be built
 
+Required for full non-smoke runs:
+
+- `k6`, used for the idle keep-alive clients plus active traffic scenario
+
 Required for the full default competitor set:
 
 - `nginx`
@@ -64,7 +68,8 @@ The automated suite records these HTTP/1.1 scenarios for each selected server:
 | `proxy-slow-client-download` | Reverse proxy download through rate-limited clients. |
 | `connection-churn-http1` | Tiny static file throughput with `Connection: close`. |
 
-When run with `--tool k6`, the full suite also includes:
+The full suite also runs this auxiliary k6 scenario independent of the primary
+throughput tool:
 
 | Scenario | Purpose |
 | --- | --- |
@@ -76,6 +81,18 @@ that scenario and print the manual workflow.
 `--smoke` intentionally runs a single Tardigrade-only static pass so CI can
 validate process startup, measurement, normalization, and output generation
 without requiring competitor binaries.
+
+HAProxy does not emit a comparable `static-large-http1` row because the
+representative `http-request return file` path is bounded by HAProxy response
+buffer size and is not valid for a 1 MiB static file. The suite records that row
+as unsupported instead of manufacturing a misleading number.
+
+Full Tardigrade runs also write `upstream-pool-matrix.json`, covering the #147
+matrix absorbed by #149: uneven route traffic, many low-volume origins, one hot
+origin with many workers, local vs cross-worker reuse, new upstream
+connections/sec, CPU/request, p99 TTFB, and contention notes. Upstream TLS
+handshake/reuse is marked unsupported until a TLS-capable local origin fixture
+exists.
 
 ## Configs
 
@@ -117,5 +134,5 @@ The combined JSON shape is:
 ```
 
 Only compare rows from the same output directory. Cross-run comparisons are
-valid only when host load, tool versions, server versions, and run parameters
-match.
+valid only when host load, tool versions, server versions, ulimits, loopback
+metadata, build flags, and run parameters match.

--- a/benchmarks/competitive/README.md
+++ b/benchmarks/competitive/README.md
@@ -44,7 +44,8 @@ Required for all runs:
 Required for full non-smoke runs:
 
 - `k6`, used for the idle keep-alive clients plus active traffic scenario
-- `openssl` and `nghttpd`, used for the upstream TLS handshake/reuse phase
+- `openssl`, used to generate the local certificate for the upstream TLS
+  handshake/reuse phase
 
 Required for the full default competitor set:
 
@@ -94,8 +95,8 @@ data in `competitive-results.json`, `competitive-results.csv`, and
 #149: uneven route traffic, many low-volume origins, one hot origin with many
 workers, upstream TLS handshake/reuse, local vs cross-worker reuse, new upstream
 connections/sec, CPU/request, p99 latency, and higher-worker contention
-evidence. `p99_ttfb_ms` remains null until a first-byte-capable load tool is
-wired into that path.
+evidence. `p99_ttfb_ms` is collected with k6 for the rows that require
+first-byte timing evidence.
 
 ## Configs
 

--- a/benchmarks/competitive/README.md
+++ b/benchmarks/competitive/README.md
@@ -1,0 +1,121 @@
+# Competitive Benchmarks
+
+This directory contains the local competitive benchmark suite for comparing
+Tardigrade against representative NGINX, HAProxy, and Caddy configurations.
+
+The suite is designed for repeatability, not for publishing laptop-local claims.
+Run canonical comparisons on a dedicated, idle host with the same load tool,
+connection count, duration, kernel limits, and server versions for every target.
+
+## Quick Start
+
+```bash
+# Full local comparison, fails if any selected competitor is missing.
+./benchmarks/competitive/run.sh
+
+# Print exact manual steps without starting processes.
+./benchmarks/competitive/run.sh --print-manual
+
+# Reduced single-pass smoke path suitable for optional CI wiring.
+./benchmarks/competitive/run.sh --smoke
+```
+
+The default suite uses `wrk` through `benchmarks/run.sh`, starts one server at a
+time, and writes:
+
+- `competitive-results.json`
+- `competitive-results.csv`
+- `competitive-summary.md`
+- one normalized JSON file per server
+- raw per-pass JSON files for debugging
+
+Use `--out-dir <dir>` to choose a stable output location.
+
+## Prerequisites
+
+Required for all runs:
+
+- `jq`
+- `curl`
+- `python3`
+- one load tool, `wrk` by default
+- Zig 0.16.0 when the Tardigrade binary must be built
+
+Required for the full default competitor set:
+
+- `nginx`
+- `haproxy`
+- `caddy`
+
+Use `--allow-missing` for exploratory local runs that should skip missing
+competitors. Do not treat skipped-target results as a complete comparison.
+
+## Scenario Matrix
+
+The automated suite records these HTTP/1.1 scenarios for each selected server:
+
+| Scenario | Purpose |
+| --- | --- |
+| `static-tiny-http1` | Tiny static file throughput. |
+| `static-tiny-keepalive` | Tiny static file keep-alive reuse. |
+| `static-large-http1` | 1 MiB static file transfer throughput. |
+| `proxy-small-http1` | Reverse proxy small response throughput. |
+| `proxy-large-http1` | Reverse proxy 1 MiB response throughput. |
+| `proxy-slow-client-download` | Reverse proxy download through rate-limited clients. |
+| `connection-churn-http1` | Tiny static file throughput with `Connection: close`. |
+
+When run with `--tool k6`, the full suite also includes:
+
+| Scenario | Purpose |
+| --- | --- |
+| `idle-keepalive-active-traffic` | Many idle keep-alive clients plus active traffic. |
+
+Connection churn is automated for the default `wrk` tool. Other load tools skip
+that scenario and print the manual workflow.
+
+`--smoke` intentionally runs a single Tardigrade-only static pass so CI can
+validate process startup, measurement, normalization, and output generation
+without requiring competitor binaries.
+
+## Configs
+
+Representative config templates live under `configs/`:
+
+- `tardigrade.conf.in`
+- `nginx.conf.in`
+- `haproxy.cfg.in`
+- `Caddyfile.in`
+
+The runner renders these templates into a temporary directory with a shared
+static root and shared upstream fixture. Keep changes minimal and explain any
+non-default tuning in the template or this README. The goal is fair comparison,
+not benchmark-specialized tuning.
+
+## Interpreting Results
+
+The combined JSON shape is:
+
+```json
+{
+  "_meta": { "suite": "competitive" },
+  "servers": {
+    "tardigrade": {
+      "static-tiny-http1": {
+        "rps": 1234,
+        "p50_ms": 1.2,
+        "p95_ms": 2.3,
+        "p99_ms": 3.4,
+        "p999_ms": 4.5,
+        "throughput_mbps": 10.1,
+        "cpu_pct_avg": 50.0,
+        "rss_mb_peak": 25.0,
+        "errors": 0
+      }
+    }
+  }
+}
+```
+
+Only compare rows from the same output directory. Cross-run comparisons are
+valid only when host load, tool versions, server versions, and run parameters
+match.

--- a/benchmarks/competitive/configs/Caddyfile.in
+++ b/benchmarks/competitive/configs/Caddyfile.in
@@ -1,0 +1,17 @@
+{
+    admin off
+}
+
+:__LISTEN_PORT__ {
+    root * __STATIC_ROOT__
+
+    handle /health {
+        respond "ok" 200
+    }
+
+    handle_path /proxy/* {
+        reverse_proxy 127.0.0.1:__UPSTREAM_PORT__
+    }
+
+    file_server
+}

--- a/benchmarks/competitive/configs/haproxy.cfg.in
+++ b/benchmarks/competitive/configs/haproxy.cfg.in
@@ -1,6 +1,5 @@
 global
     master-worker
-    nbthread __THREADS__
     pidfile __PID_FILE__
     maxconn 4096
     log stdout format raw local0 warning
@@ -17,10 +16,10 @@ frontend tardigrade_competitive
     bind 127.0.0.1:__LISTEN_PORT__
     http-request return status 200 content-type text/plain string ok if { path -i /health }
     http-request return status 200 content-type text/plain file __STATIC_ROOT__/tiny.txt if { path -i /tiny.txt }
-    http-request return status 200 content-type application/octet-stream file __STATIC_ROOT__/large.bin if { path -i /large.bin }
     use_backend origin if { path_beg /proxy/ }
     http-request return status 404 content-type text/plain string not-found
 
 backend origin
     http-reuse always
+    http-request replace-path ^/proxy/(.*)$ /\1
     server origin1 127.0.0.1:__UPSTREAM_PORT__ check

--- a/benchmarks/competitive/configs/haproxy.cfg.in
+++ b/benchmarks/competitive/configs/haproxy.cfg.in
@@ -1,0 +1,26 @@
+global
+    master-worker
+    nbthread __THREADS__
+    pidfile __PID_FILE__
+    maxconn 4096
+    log stdout format raw local0 warning
+
+defaults
+    mode http
+    option httplog
+    option http-keep-alive
+    timeout connect 5s
+    timeout client 30s
+    timeout server 30s
+
+frontend tardigrade_competitive
+    bind 127.0.0.1:__LISTEN_PORT__
+    http-request return status 200 content-type text/plain string ok if { path -i /health }
+    http-request return status 200 content-type text/plain file __STATIC_ROOT__/tiny.txt if { path -i /tiny.txt }
+    http-request return status 200 content-type application/octet-stream file __STATIC_ROOT__/large.bin if { path -i /large.bin }
+    use_backend origin if { path_beg /proxy/ }
+    http-request return status 404 content-type text/plain string not-found
+
+backend origin
+    http-reuse always
+    server origin1 127.0.0.1:__UPSTREAM_PORT__ check

--- a/benchmarks/competitive/configs/nginx.conf.in
+++ b/benchmarks/competitive/configs/nginx.conf.in
@@ -1,0 +1,42 @@
+worker_processes auto;
+pid __PID_FILE__;
+
+events {
+    worker_connections 4096;
+}
+
+http {
+    access_log off;
+    error_log __ERROR_LOG__ warn;
+    sendfile on;
+    keepalive_timeout 65;
+
+    upstream tardigrade_competitive_origin {
+        server 127.0.0.1:__UPSTREAM_PORT__;
+        keepalive 128;
+    }
+
+    server {
+        listen 127.0.0.1:__LISTEN_PORT__;
+        server_name _;
+        root __STATIC_ROOT__;
+
+        location = /health {
+            return 200 "ok";
+        }
+
+        location = /tiny.txt {
+            try_files /tiny.txt =404;
+        }
+
+        location = /large.bin {
+            try_files /large.bin =404;
+        }
+
+        location /proxy/ {
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_pass http://tardigrade_competitive_origin/;
+        }
+    }
+}

--- a/benchmarks/competitive/configs/tardigrade.conf.in
+++ b/benchmarks/competitive/configs/tardigrade.conf.in
@@ -1,0 +1,12 @@
+pid __PID_FILE__;
+listen __LISTEN_PORT__;
+metrics_path /status/metrics;
+root __STATIC_ROOT__;
+
+location = /health {
+    return 200 ok;
+}
+
+location /proxy/ {
+    proxy_pass http://127.0.0.1:__UPSTREAM_PORT__/;
+}

--- a/benchmarks/competitive/run.sh
+++ b/benchmarks/competitive/run.sh
@@ -355,8 +355,8 @@ process_tree_cpu_seconds() {
             for child in "${_cpu_pids[@]}"; do
                 [[ -r "/proc/${child}/stat" ]] || continue
                 total_ticks=$((total_ticks + $(awk '{
-                    close = match($0, /\) /)
-                    rest = substr($0, close + 2)
+                    paren_idx = match($0, /\) /)
+                    rest = substr($0, paren_idx + 2)
                     split(rest, f, " ")
                     print (f[12] + f[13])
                 }' "/proc/${child}/stat")))

--- a/benchmarks/competitive/run.sh
+++ b/benchmarks/competitive/run.sh
@@ -344,9 +344,27 @@ cpu_time_to_seconds() {
 }
 
 process_tree_cpu_seconds() {
-    local pid="$1" pids
+    local pid="$1" pids clk total_ticks child
     pids="$(process_tree_pids "$pid" | paste -sd, -)"
     [[ -n "$pids" ]] || pids="$pid"
+    if [[ "$(uname -s 2>/dev/null || true)" == "Linux" ]]; then
+        clk="$(getconf CLK_TCK 2>/dev/null || true)"
+        if [[ "$clk" =~ ^[0-9]+$ && "$clk" -gt 0 ]]; then
+            total_ticks=0
+            IFS=, read -ra _cpu_pids <<< "$pids"
+            for child in "${_cpu_pids[@]}"; do
+                [[ -r "/proc/${child}/stat" ]] || continue
+                total_ticks=$((total_ticks + $(awk '{
+                    close = match($0, /\) /)
+                    rest = substr($0, close + 2)
+                    split(rest, f, " ")
+                    print (f[12] + f[13])
+                }' "/proc/${child}/stat")))
+            done
+            awk -v ticks="$total_ticks" -v clk="$clk" 'BEGIN { printf "%.6f", ticks / clk }'
+            return
+        fi
+    fi
     ps -p "$pids" -o time= 2>/dev/null | cpu_time_to_seconds
 }
 
@@ -734,30 +752,34 @@ write_combined_outputs() {
         "${server_files[@]}" > "$combined_json"
 
     jq -r '
-        ["server","scenario","supported","reason","rps","p50_ms","p95_ms","p99_ms","p999_ms","p99_ttfb_ms","throughput_mbps","cpu_pct_avg","cpu_ms_per_request","rss_mb_peak","open_fds_peak","errors"],
+        ["server","scenario","supported","reason","rps","p50_ms","p95_ms","p99_ms","p999_ms","p99_ttfb_ms","throughput_mbps","cpu_pct_avg","cpu_ms_per_request","rss_mb_peak","open_fds_peak","errors","pool_lock_wait_ns_per_request","pool_lock_wait_ns_per_acquire"],
         (.servers | to_entries[] as $server |
             $server.value | to_entries[] |
             select(.key != "_meta") |
             [$server.key, .key, (.value.supported // true), (.value.reason // null), (.value.rps // null), (.value.p50_ms // null), (.value.p95_ms // null),
              (.value.p99_ms // null), (.value.p999_ms // null), (.value.p99_ttfb_ms // null), (.value.throughput_mbps // null),
-             (.value.cpu_pct_avg // null), (.value.cpu_ms_per_request // null), (.value.rss_mb_peak // null), (.value.open_fds_peak // null), (.value.errors // null)]),
+             (.value.cpu_pct_avg // null), (.value.cpu_ms_per_request // null), (.value.rss_mb_peak // null), (.value.open_fds_peak // null), (.value.errors // null), null, null]),
         (if .upstream_pool_matrix != null then
             (.upstream_pool_matrix.scenarios | to_entries[] |
                 ["tardigrade", ("upstream-pool/" + .key), (.value.covered // .value.supported // true), (.value.reason // .value.sharding_note // null),
                  (.value.rps // null), null, null, (.value.p99_ms // null), null, (.value.p99_ttfb_ms // null), null,
-                 (.value.cpu_pct_avg // null), (.value.cpu_ms_per_request // null), (.value.rss_mb_peak // null), (.value.open_fds_peak // null), (.value.errors // null)]),
+                 (.value.cpu_pct_avg // null), (.value.cpu_ms_per_request // null), (.value.rss_mb_peak // null), (.value.open_fds_peak // null), (.value.errors // null),
+                 (.value.pool_lock_wait_ns_per_request // null), (.value.pool_lock_wait_ns_per_acquire // null)]),
             (.upstream_pool_matrix.scenarios["uneven-route-distribution"].routes // {} | to_entries[] |
                 ["tardigrade", ("upstream-pool/uneven/" + .key), (.value.covered // true), (.value.reason // null),
                  (.value.rps // null), null, null, (.value.p99_ms // null), null, (.value.p99_ttfb_ms // null), null,
-                 (.value.cpu_pct_avg // null), (.value.cpu_ms_per_request // null), (.value.rss_mb_peak // null), (.value.open_fds_peak // null), (.value.errors // null)]),
+                 (.value.cpu_pct_avg // null), (.value.cpu_ms_per_request // null), (.value.rss_mb_peak // null), (.value.open_fds_peak // null), (.value.errors // null),
+                 (.value.pool_lock_wait_ns_per_request // null), (.value.pool_lock_wait_ns_per_acquire // null)]),
             (.upstream_pool_matrix.scenarios["many-origins-low-volume"].measurements // [] | .[] |
                 ["tardigrade", ("upstream-pool/origin/" + (.origin // "unknown")), (.covered // true), (.reason // null),
                  (.rps // null), null, null, (.p99_ms // null), null, (.p99_ttfb_ms // null), null,
-                 (.cpu_pct_avg // null), (.cpu_ms_per_request // null), (.rss_mb_peak // null), (.open_fds_peak // null), (.errors // null)]),
+                 (.cpu_pct_avg // null), (.cpu_ms_per_request // null), (.rss_mb_peak // null), (.open_fds_peak // null), (.errors // null),
+                 (.pool_lock_wait_ns_per_request // null), (.pool_lock_wait_ns_per_acquire // null)]),
             (.upstream_pool_matrix.scenarios["pool-contention"].measurements // [] | .[] |
                 ["tardigrade", ("upstream-pool/contention/" + ((.worker_threads // 0) | tostring) + "w"), (.covered // true), (.reason // null),
                  (.rps // null), null, null, (.p99_ms // null), null, (.p99_ttfb_ms // null), null,
-                 (.cpu_pct_avg // null), (.cpu_ms_per_request // null), (.rss_mb_peak // null), (.open_fds_peak // null), (.errors // null)])
+                 (.cpu_pct_avg // null), (.cpu_ms_per_request // null), (.rss_mb_peak // null), (.open_fds_peak // null), (.errors // null),
+                 (.pool_lock_wait_ns_per_request // null), (.pool_lock_wait_ns_per_acquire // null)])
          else empty end)
         | @csv
     ' "$combined_json" > "$csv"
@@ -783,17 +805,17 @@ write_combined_outputs() {
             echo ""
             echo "## Upstream Pool Matrix"
             echo ""
-            echo "| Scenario | Covered | req/s | p99 ms | p99 TTFB ms | CPU % | CPU ms/req | RSS MiB | New conn/s | Reuse ratio | Sharding | Errors |"
-            echo "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: |"
+            echo "| Scenario | Covered | req/s | p99 ms | p99 TTFB ms | CPU % | CPU ms/req | RSS MiB | New conn/s | Reuse ratio | Lock wait ns/req | Sharding | Errors |"
+            echo "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: |"
             jq -r '
                 .upstream_pool_matrix.scenarios | to_entries[] |
-                "| `\(.key)` | \((.value.covered // .value.supported // true)) | \(.value.rps // "-") | \(.value.p99_ms // "-") | \(.value.p99_ttfb_ms // "-") | \(.value.cpu_pct_avg // "-") | \(.value.cpu_ms_per_request // "-") | \(.value.rss_mb_peak // "-") | \(.value.new_connections_per_sec // "-") | \(.value.reuse_ratio // "-") | \(.value.sharding_justified // "-") | \(.value.errors // "-") |"
+                "| `\(.key)` | \((.value.covered // .value.supported // true)) | \(.value.rps // "-") | \(.value.p99_ms // "-") | \(.value.p99_ttfb_ms // "-") | \(.value.cpu_pct_avg // "-") | \(.value.cpu_ms_per_request // "-") | \(.value.rss_mb_peak // "-") | \(.value.new_connections_per_sec // "-") | \(.value.reuse_ratio // "-") | \(.value.pool_lock_wait_ns_per_request // "-") | \(.value.sharding_justified // "-") | \(.value.errors // "-") |"
             ' "$combined_json"
             echo ""
             echo "### Upstream Pool Detail Rows"
             echo ""
-            echo "| Detail | req/s | p99 ms | p99 TTFB ms | CPU % | CPU ms/req | RSS MiB | Open FDs | New conn/s | Reuse ratio | Errors |"
-            echo "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+            echo "| Detail | req/s | p99 ms | p99 TTFB ms | CPU % | CPU ms/req | RSS MiB | Open FDs | New conn/s | Reuse ratio | Lock wait ns/req | Lock wait ns/acq | Errors |"
+            echo "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
             jq -r '
                 def row($name; $v):
                     "| `" + $name + "` | " +
@@ -806,6 +828,8 @@ write_combined_outputs() {
                     (($v.open_fds_peak // "-") | tostring) + " | " +
                     (($v.new_connections_per_sec // "-") | tostring) + " | " +
                     (($v.reuse_ratio // "-") | tostring) + " | " +
+                    (($v.pool_lock_wait_ns_per_request // "-") | tostring) + " | " +
+                    (($v.pool_lock_wait_ns_per_acquire // "-") | tostring) + " | " +
                     (($v.errors // "-") | tostring) + " |";
                 (.upstream_pool_matrix.scenarios["uneven-route-distribution"].routes // {} | to_entries[] | row("uneven/" + .key; .value)),
                 (.upstream_pool_matrix.scenarios["many-origins-low-volume"].measurements // [] | .[] | row("origin/" + (.origin // "unknown"); .)),
@@ -838,7 +862,6 @@ if ! $SMOKE; then
     require_tool k6
     if [[ ",$SERVERS," == *",tardigrade,"* ]]; then
         require_tool openssl
-        require_tool nghttpd
     fi
 fi
 

--- a/benchmarks/competitive/run.sh
+++ b/benchmarks/competitive/run.sh
@@ -12,6 +12,9 @@ BENCH_DIR="${REPO_ROOT}/benchmarks"
 COMP_DIR="${BENCH_DIR}/competitive"
 CONFIG_DIR="${COMP_DIR}/configs"
 BINARY="${REPO_ROOT}/zig-out/bin/tardi"
+BINARY_EXPLICIT=false
+TARDIGRADE_BUILD_FLAGS="-Doptimize=ReleaseFast"
+TARDIGRADE_BUILT=false
 SERVERS="tardigrade,nginx,haproxy,caddy"
 TOOL="wrk"
 DURATION="15"
@@ -28,10 +31,14 @@ TMP_DIR=""
 ORIGIN_PID=""
 EDGE_PID=""
 CURRENT_SERVER=""
+CURRENT_CPU_PCT_AVG="null"
+CURRENT_RSS_MB_PEAK="null"
+MONITOR_PID=""
+MONITOR_FILE=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --binary) BINARY="$2"; shift 2 ;;
+        --binary) BINARY="$2"; BINARY_EXPLICIT=true; shift 2 ;;
         --servers) SERVERS="$2"; shift 2 ;;
         --tool) TOOL="$2"; shift 2 ;;
         --duration) DURATION="$2"; shift 2 ;;
@@ -44,9 +51,9 @@ while [[ $# -gt 0 ]]; do
         --allow-missing) ALLOW_MISSING=true; shift ;;
         --smoke)
             SMOKE=true
-            DURATION="5"
-            CONNECTIONS="8"
-            THREADS="2"
+            DURATION="2"
+            CONNECTIONS="1"
+            THREADS="1"
             SERVERS="tardigrade"
             shift
             ;;
@@ -68,7 +75,7 @@ Competitive benchmark manual flow:
 3. Start the shared origin fixture:
    python3 benchmarks/fixtures/upstream_server.py --port ${UPSTREAM_PORT}
 4. For each server in ${SERVERS}, render its template from benchmarks/competitive/configs
-   with LISTEN_PORT, UPSTREAM_PORT, STATIC_ROOT, PID_FILE, ERROR_LOG, and THREADS.
+   with LISTEN_PORT, UPSTREAM_PORT, STATIC_ROOT, PID_FILE, and ERROR_LOG.
 5. Start one server at a time, wait for http://127.0.0.1:<port>/health, then run:
    benchmarks/run.sh --tool ${TOOL} --host 127.0.0.1 --port <port> \\
      --duration ${DURATION} --connections ${CONNECTIONS} --threads ${THREADS} \\
@@ -164,11 +171,19 @@ render_template() {
 }
 
 ensure_tardigrade_binary() {
-    if [[ -x "$BINARY" ]]; then
+    if $BINARY_EXPLICIT; then
+        if [[ ! -x "$BINARY" ]]; then
+            echo "Explicit Tardigrade binary is not executable: ${BINARY}" >&2
+            exit 1
+        fi
         return
     fi
-    echo "Building Tardigrade release binary..."
-    (cd "$REPO_ROOT" && zig build -Doptimize=ReleaseFast)
+    if $TARDIGRADE_BUILT; then
+        return
+    fi
+    echo "Building Tardigrade release binary (${TARDIGRADE_BUILD_FLAGS})..."
+    (cd "$REPO_ROOT" && zig build ${TARDIGRADE_BUILD_FLAGS})
+    TARDIGRADE_BUILT=true
 }
 
 start_tardigrade() {
@@ -243,6 +258,153 @@ server_version() {
     esac
 }
 
+tool_version() {
+    case "$1" in
+        wrk) { wrk --version 2>&1 || true; } | head -1 ;;
+        h2load) { h2load --version 2>&1 || true; } | head -1 ;;
+        fortio) { fortio version 2>&1 || true; } | head -1 ;;
+        k6) { k6 version 2>&1 || true; } | head -1 ;;
+        *) { "$1" --version 2>&1 || true; } | head -1 ;;
+    esac
+}
+
+loopback_info() {
+    if command -v ip >/dev/null 2>&1; then
+        ip -o addr show lo 2>/dev/null | tr '\n' ';' || echo "unknown"
+    elif command -v ifconfig >/dev/null 2>&1; then
+        ifconfig lo0 2>/dev/null | awk '{$1=$1; printf "%s; ", $0}' || echo "unknown"
+    else
+        echo "unknown"
+    fi
+}
+
+host_metadata_json() {
+    jq -n \
+        --arg load_tool "$TOOL" \
+        --arg load_tool_version "$(tool_version "$TOOL")" \
+        --arg ulimit_n "$(ulimit -n 2>/dev/null || echo unknown)" \
+        --arg ulimit_u "$(ulimit -u 2>/dev/null || echo unknown)" \
+        --arg loopback "$(loopback_info)" \
+        --arg tardigrade_build_flags "$TARDIGRADE_BUILD_FLAGS" \
+        --argjson tardigrade_binary_explicit "$($BINARY_EXPLICIT && echo true || echo false)" \
+        '{
+            load_tool: $load_tool,
+            load_tool_version: $load_tool_version,
+            ulimit: {
+                open_files: $ulimit_n,
+                max_user_processes: $ulimit_u
+            },
+            network: {
+                loopback: $loopback
+            },
+            tardigrade: {
+                build_flags: $tardigrade_build_flags,
+                binary_explicit: $tardigrade_binary_explicit
+            }
+        }'
+}
+
+process_tree_pids() {
+    local root="$1"
+    printf '%s\n' "$root"
+    local children child
+    children=$(pgrep -P "$root" 2>/dev/null || true)
+    for child in $children; do
+        process_tree_pids "$child"
+    done
+}
+
+monitor_process_tree() {
+    local pid="$1" sample_interval_s="$2" outfile="$3"
+    while kill -0 "$pid" 2>/dev/null; do
+        process_tree_pids "$pid" | paste -sd, - | {
+            read -r pids
+            [[ -n "$pids" ]] || pids="$pid"
+            ps -p "$pids" -o rss= -o %cpu= 2>/dev/null |
+                awk '{ rss += $1; cpu += $2 } END { if (rss > 0 || cpu > 0) print rss, cpu }' >> "$outfile"
+        }
+        sleep "$sample_interval_s"
+    done
+}
+
+average_column_or_null() {
+    local file="$1" column="$2"
+    awk -v col="$column" 'NF >= col { sum += $col; count += 1 } END { if (count > 0) printf "%.2f", sum / count; else printf "null" }' "$file"
+}
+
+peak_rss_mb_or_null() {
+    local file="$1"
+    awk 'NF >= 1 && $1 > max { max = $1 } END { if (max > 0) printf "%.2f", max / 1024; else printf "null" }' "$file"
+}
+
+start_process_monitor() {
+    CURRENT_CPU_PCT_AVG="null"
+    CURRENT_RSS_MB_PEAK="null"
+    MONITOR_FILE="$(mktemp /tmp/tardigrade-competitive-monitor-XXXX.txt)"
+    local sample_interval_s
+    sample_interval_s="0.500"
+    monitor_process_tree "$EDGE_PID" "$sample_interval_s" "$MONITOR_FILE" &
+    MONITOR_PID="$!"
+}
+
+stop_process_monitor() {
+    if [[ -n "$MONITOR_PID" ]]; then
+        kill "$MONITOR_PID" 2>/dev/null || true
+        wait "$MONITOR_PID" 2>/dev/null || true
+        MONITOR_PID=""
+    fi
+    if [[ -n "$MONITOR_FILE" && -f "$MONITOR_FILE" ]]; then
+        CURRENT_CPU_PCT_AVG="$(average_column_or_null "$MONITOR_FILE" 2)"
+        CURRENT_RSS_MB_PEAK="$(peak_rss_mb_or_null "$MONITOR_FILE")"
+        rm -f "$MONITOR_FILE"
+        MONITOR_FILE=""
+    fi
+}
+
+wrk_error_count() {
+    awk '
+        /Non-2xx/ {
+            for (i = 1; i <= NF; i++) {
+                if ($i ~ /^[0-9]+$/) total += $i
+            }
+        }
+        /Socket errors:/ {
+            for (i = 1; i <= NF; i++) {
+                gsub(/,/, "", $i)
+                if ($i ~ /^[0-9]+$/) total += $i
+            }
+        }
+        END { print total + 0 }
+    '
+}
+
+assert_payload_size() {
+    local url="$1"
+    local expected_bytes="$2"
+    local tmp actual_bytes
+    tmp="$(mktemp /tmp/tardigrade-competitive-payload-XXXX)"
+    curl -fsS "$url" -o "$tmp"
+    actual_bytes="$(wc -c < "$tmp" | tr -d '[:space:]')"
+    rm -f "$tmp"
+    if [[ "$actual_bytes" != "$expected_bytes" ]]; then
+        echo "Preflight failed for ${url}: expected ${expected_bytes} bytes, got ${actual_bytes}" >&2
+        exit 1
+    fi
+}
+
+preflight_server() {
+    local server="$1"
+    local port="$2"
+    local base="http://127.0.0.1:${port}"
+    assert_payload_size "${base}/tiny.txt" 3
+    if [[ "$server" != "haproxy" ]]; then
+        assert_payload_size "${base}/large.bin" 1048576
+    fi
+    assert_payload_size "${base}/proxy/health" 2
+    assert_payload_size "${base}/proxy/payload-1m.bin" 1048576
+    assert_payload_size "${base}/proxy/payload-16m.bin" 16777216
+}
+
 rename_pass_json() {
     local input="$1"
     local output="$2"
@@ -274,16 +436,18 @@ run_benchmark_pass() {
     local scenarios="$4"
     local static_path="$5"
     local proxy_path="$6"
+    local pass_tool="${7:-$TOOL}"
     local raw="${OUT_DIR}/${server}-${pass}.raw.json"
     local renamed="${OUT_DIR}/${server}-${pass}.json"
 
     "${BENCH_DIR}/run.sh" \
-        --tool "$TOOL" \
+        --tool "$pass_tool" \
         --host 127.0.0.1 \
         --port "$port" \
         --driver "competitive-loopback" \
         --config-label "${server}" \
         --pid "$EDGE_PID" \
+        --pid-tree \
         --meta-file "$META_FILE" \
         --duration "$DURATION" \
         --connections "$CONNECTIONS" \
@@ -309,10 +473,12 @@ run_connection_churn() {
 
     echo "==> connection-churn-http1: tiny static file with Connection: close"
     local raw summary_json rps p50 p95 p99 p999 errors tput_mbps
+    start_process_monitor
     raw=$(wrk --latency -s "${BENCH_DIR}/wrk-summary.lua" \
         -t"${THREADS}" -c"${CONNECTIONS}" -d"${DURATION}s" \
         -H "Connection: close" \
         "http://127.0.0.1:${port}/tiny.txt" 2>&1) || true
+    stop_process_monitor
     summary_json=$(printf '%s\n' "$raw" | sed -n 's/^WRK_SUMMARY //p' | tail -1)
     if [[ -z "$summary_json" ]]; then
         echo "wrk summary hook did not emit percentile JSON for connection churn" >&2
@@ -325,7 +491,7 @@ run_connection_churn() {
     p99=$(echo "$summary_json" | jq -r '.p99_ms // null')
     p999=$(echo "$summary_json" | jq -r '.p999_ms // null')
     tput_mbps=$(echo "$summary_json" | jq -r '.throughput_mbps // null')
-    errors=$(echo "$raw" | grep -E "Non-2xx|Socket errors" | grep -oE '[0-9]+' | head -1 || echo 0)
+    errors=$(printf '%s\n' "$raw" | wrk_error_count)
     rps=${rps:-0}
     errors=${errors:-0}
     echo "  connection-churn-http1 — ${rps} req/s  p50=${p50}ms  p95=${p95}ms  p99=${p99}ms  p999=${p999}ms  errors=${errors}"
@@ -338,6 +504,8 @@ run_connection_churn() {
         --argjson p999 "$p999" \
         --argjson mbps "$tput_mbps" \
         --argjson errors "$errors" \
+        --argjson cpu "$CURRENT_CPU_PCT_AVG" \
+        --argjson rss "$CURRENT_RSS_MB_PEAK" \
         '{
             _meta: {
                 competitive_server: $server,
@@ -351,11 +519,47 @@ run_connection_churn() {
                 p99_ms: $p99,
                 p999_ms: $p999,
                 throughput_mbps: $mbps,
-                cpu_pct_avg: null,
-                rss_mb_peak: null,
+                cpu_pct_avg: $cpu,
+                rss_mb_peak: $rss,
                 errors: $errors
             }
         }' > "$output"
+}
+
+write_unsupported_result() {
+    local server="$1"
+    local scenario="$2"
+    local reason="$3"
+    local output="$4"
+    jq -n --arg server "$server" --arg scenario "$scenario" --arg reason "$reason" '{
+        _meta: {
+            competitive_server: $server,
+            competitive_pass: $scenario
+        },
+        ($scenario): {
+            supported: false,
+            reason: $reason,
+            rps: null,
+            p50_ms: null,
+            p95_ms: null,
+            p99_ms: null,
+            p999_ms: null,
+            throughput_mbps: null,
+            cpu_pct_avg: null,
+            rss_mb_peak: null,
+            errors: null
+        }
+    }' > "$output"
+}
+
+run_idle_keepalive_aux() {
+    local server="$1"
+    local port="$2"
+    if ! command -v k6 >/dev/null 2>&1; then
+        echo "Skipping idle keepalive plus active traffic scenario; k6 is not installed."
+        return 0
+    fi
+    run_benchmark_pass "$server" "$port" "idle-keepalive" "keepalive-starvation" "/tiny.txt" "/proxy/health" "k6"
 }
 
 combine_server_results() {
@@ -395,6 +599,18 @@ combine_server_results() {
             ._meta.server_version = $version |
             . + ($doc | del(._meta))
         )
+        | with_entries(
+            if .key == "_meta" or (.value.supported? == false) then
+                .
+            else
+                .value.cpu_ms_per_request =
+                    (if ((.value.cpu_pct_avg // null) != null and (.value.rps // 0) > 0)
+                     then ((.value.cpu_pct_avg / 100.0) / .value.rps * 1000.0)
+                     else null end) |
+                .value.p99_ttfb_ms = (.value.p99_ms // null) |
+                .
+            end
+        )
     ' "${inputs[@]}" > "$combined"
 }
 
@@ -423,6 +639,7 @@ write_combined_outputs() {
                 duration_s: ($duration | tonumber),
                 connections: ($connections | tonumber),
                 threads: ($threads | tonumber),
+                host: $host_metadata,
                 note: "Compare only same-host, same-tool, same-duration results. Laptop and shared-runner output is non-canonical."
             },
             servers: (reduce .[] as $doc ({};
@@ -430,16 +647,17 @@ write_combined_outputs() {
             ))
         }
     ' --arg tool "$TOOL" --arg duration "$DURATION" --arg connections "$CONNECTIONS" --arg threads "$THREADS" \
+        --argjson host_metadata "$(host_metadata_json)" \
         "${server_files[@]}" > "$combined_json"
 
     jq -r '
-        ["server","scenario","rps","p50_ms","p95_ms","p99_ms","p999_ms","throughput_mbps","cpu_pct_avg","rss_mb_peak","errors"],
+        ["server","scenario","supported","rps","p50_ms","p95_ms","p99_ms","p999_ms","throughput_mbps","cpu_pct_avg","cpu_ms_per_request","rss_mb_peak","errors"],
         (.servers | to_entries[] as $server |
             $server.value | to_entries[] |
             select(.key != "_meta") |
-            [$server.key, .key, (.value.rps // null), (.value.p50_ms // null), (.value.p95_ms // null),
+            [$server.key, .key, (.value.supported // true), (.value.rps // null), (.value.p50_ms // null), (.value.p95_ms // null),
              (.value.p99_ms // null), (.value.p999_ms // null), (.value.throughput_mbps // null),
-             (.value.cpu_pct_avg // null), (.value.rss_mb_peak // null), (.value.errors // null)])
+             (.value.cpu_pct_avg // null), (.value.cpu_ms_per_request // null), (.value.rss_mb_peak // null), (.value.errors // null)])
         | @csv
     ' "$combined_json" > "$csv"
 
@@ -466,10 +684,21 @@ write_combined_outputs() {
     echo "  ${md}"
 }
 
+selected_tardigrade() {
+    local server
+    for server in "${SERVER_LIST[@]}"; do
+        [[ "$server" == "tardigrade" ]] && return 0
+    done
+    return 1
+}
+
 require_tool jq
 require_tool curl
 require_tool python3
 require_tool "$TOOL"
+if ! $SMOKE; then
+    require_tool k6
+fi
 
 IFS=',' read -r -a SERVER_LIST <<< "$SERVERS"
 for server in "${SERVER_LIST[@]}"; do
@@ -511,28 +740,47 @@ for index in "${!SERVER_LIST[@]}"; do
     port=$((LISTEN_BASE + index))
     echo ""
     echo "== ${server} (${port}) =="
+    if [[ "$server" == "tardigrade" ]]; then
+        ensure_tardigrade_binary
+    fi
     echo "version: $(server_version "$server")"
     start_server "$server" "$port"
+    preflight_server "$server" "$port"
 
     if $SMOKE; then
         run_benchmark_pass "$server" "$port" "tiny-static" "static-http1" "/tiny.txt" "/proxy/health"
     else
         run_benchmark_pass "$server" "$port" "tiny-proxy" "static-http1,proxy-http1,keepalive" "/tiny.txt" "/proxy/health"
-        run_benchmark_pass "$server" "$port" "large-static" "static-http1" "/large.bin" "/proxy/health"
+        if [[ "$server" == "haproxy" ]]; then
+            write_unsupported_result "$server" "static-large-http1" \
+                "HAProxy http-request return file responses must fit a response buffer; the 1 MiB static-file scenario is intentionally unsupported for this representative config." \
+                "${OUT_DIR}/${server}-large-static.json"
+        else
+            run_benchmark_pass "$server" "$port" "large-static" "static-http1" "/large.bin" "/proxy/health"
+        fi
         run_benchmark_pass "$server" "$port" "large-proxy" "proxy-http1" "/tiny.txt" "/proxy/payload-1m.bin"
         run_benchmark_pass "$server" "$port" "slow-client" "proxy-slow-client-download" "/tiny.txt" "/proxy/payload-16m.bin"
         run_connection_churn "$server" "$port"
     fi
     if $SMOKE; then
         :
-    elif [[ "$TOOL" == "k6" ]]; then
-        run_benchmark_pass "$server" "$port" "idle-keepalive" "keepalive-starvation" "/tiny.txt" "/proxy/health"
     else
-        echo "Skipping idle keepalive plus active traffic scenario; it requires --tool k6."
+        run_idle_keepalive_aux "$server" "$port"
     fi
 
     combine_server_results "$server"
     cleanup_edge
 done
+
+if ! $SMOKE && selected_tardigrade; then
+    "${COMP_DIR}/upstream-pool-matrix.sh" \
+        --binary "$BINARY" \
+        --listen-port "$((LISTEN_BASE + 50))" \
+        --origin-base-port "$((UPSTREAM_PORT + 50))" \
+        --duration "$DURATION" \
+        --connections "$CONNECTIONS" \
+        --threads "$THREADS" \
+        --output "${OUT_DIR}/upstream-pool-matrix.json"
+fi
 
 write_combined_outputs

--- a/benchmarks/competitive/run.sh
+++ b/benchmarks/competitive/run.sh
@@ -33,6 +33,7 @@ EDGE_PID=""
 CURRENT_SERVER=""
 CURRENT_CPU_PCT_AVG="null"
 CURRENT_RSS_MB_PEAK="null"
+CURRENT_OPEN_FDS_PEAK="null"
 MONITOR_PID=""
 MONITOR_FILE=""
 
@@ -314,14 +315,38 @@ process_tree_pids() {
     done
 }
 
+count_open_fds_for_pids() {
+    local pids_csv="$1"
+    local total=0 pid count
+    IFS=, read -ra _fd_pids <<< "$pids_csv"
+    for pid in "${_fd_pids[@]}"; do
+        [[ -n "$pid" ]] || continue
+        if [[ -d "/proc/${pid}/fd" ]]; then
+            count=$(find "/proc/${pid}/fd" -maxdepth 1 -type l 2>/dev/null | wc -l | tr -d ' ')
+        elif command -v lsof >/dev/null 2>&1; then
+            count=$(lsof -n -P -p "$pid" 2>/dev/null | awk 'NR > 1 { count += 1 } END { print count + 0 }')
+        else
+            count=""
+        fi
+        [[ "$count" =~ ^[0-9]+$ ]] && total=$((total + count))
+    done
+    if [[ "$total" -gt 0 ]]; then
+        printf '%s\n' "$total"
+    else
+        printf 'null\n'
+    fi
+}
+
 monitor_process_tree() {
     local pid="$1" sample_interval_s="$2" outfile="$3"
     while kill -0 "$pid" 2>/dev/null; do
         process_tree_pids "$pid" | paste -sd, - | {
             read -r pids
             [[ -n "$pids" ]] || pids="$pid"
+            local fds
+            fds="$(count_open_fds_for_pids "$pids")"
             ps -p "$pids" -o rss= -o %cpu= 2>/dev/null |
-                awk '{ rss += $1; cpu += $2 } END { if (rss > 0 || cpu > 0) print rss, cpu }' >> "$outfile"
+                awk -v fds="$fds" '{ rss += $1; cpu += $2 } END { if (rss > 0 || cpu > 0) print rss, cpu, fds }' >> "$outfile"
         }
         sleep "$sample_interval_s"
     done
@@ -340,7 +365,8 @@ peak_rss_mb_or_null() {
 start_process_monitor() {
     CURRENT_CPU_PCT_AVG="null"
     CURRENT_RSS_MB_PEAK="null"
-    MONITOR_FILE="$(mktemp /tmp/tardigrade-competitive-monitor-XXXX.txt)"
+    CURRENT_OPEN_FDS_PEAK="null"
+    MONITOR_FILE="$(mktemp /tmp/tardigrade-competitive-monitor-XXXXXX)"
     local sample_interval_s
     sample_interval_s="0.500"
     monitor_process_tree "$EDGE_PID" "$sample_interval_s" "$MONITOR_FILE" &
@@ -356,6 +382,7 @@ stop_process_monitor() {
     if [[ -n "$MONITOR_FILE" && -f "$MONITOR_FILE" ]]; then
         CURRENT_CPU_PCT_AVG="$(average_column_or_null "$MONITOR_FILE" 2)"
         CURRENT_RSS_MB_PEAK="$(peak_rss_mb_or_null "$MONITOR_FILE")"
+        CURRENT_OPEN_FDS_PEAK="$(awk 'NF >= 3 && $3 ~ /^[0-9]+$/ && $3 > max { max = $3 } END { if (max > 0) printf "%d", max; else printf "null" }' "$MONITOR_FILE")"
         rm -f "$MONITOR_FILE"
         MONITOR_FILE=""
     fi
@@ -506,6 +533,7 @@ run_connection_churn() {
         --argjson errors "$errors" \
         --argjson cpu "$CURRENT_CPU_PCT_AVG" \
         --argjson rss "$CURRENT_RSS_MB_PEAK" \
+        --argjson fds "$CURRENT_OPEN_FDS_PEAK" \
         '{
             _meta: {
                 competitive_server: $server,
@@ -521,6 +549,7 @@ run_connection_churn() {
                 throughput_mbps: $mbps,
                 cpu_pct_avg: $cpu,
                 rss_mb_peak: $rss,
+                open_fds_peak: $fds,
                 errors: $errors
             }
         }' > "$output"
@@ -607,7 +636,7 @@ combine_server_results() {
                     (if ((.value.cpu_pct_avg // null) != null and (.value.rps // 0) > 0)
                      then ((.value.cpu_pct_avg / 100.0) / .value.rps * 1000.0)
                      else null end) |
-                .value.p99_ttfb_ms = (.value.p99_ms // null) |
+                .value.p99_ttfb_ms = null |
                 .
             end
         )
@@ -630,7 +659,15 @@ write_combined_outputs() {
         exit 1
     fi
 
-    jq -s '
+    local upstream_matrix="${OUT_DIR}/upstream-pool-matrix.json"
+    local upstream_arg=()
+    if [[ -f "$upstream_matrix" ]]; then
+        upstream_arg=(--slurpfile upstream "$upstream_matrix")
+    else
+        upstream_arg=(--argjson upstream '[]')
+    fi
+
+    jq -s "${upstream_arg[@]}" '
         {
             _meta: {
                 generated_at: (now | todateiso8601),
@@ -644,20 +681,27 @@ write_combined_outputs() {
             },
             servers: (reduce .[] as $doc ({};
                 .[$doc._meta.competitive_server] = $doc
-            ))
+            )),
+            upstream_pool_matrix: (if ($upstream | length) > 0 then $upstream[0] else null end)
         }
     ' --arg tool "$TOOL" --arg duration "$DURATION" --arg connections "$CONNECTIONS" --arg threads "$THREADS" \
         --argjson host_metadata "$(host_metadata_json)" \
         "${server_files[@]}" > "$combined_json"
 
     jq -r '
-        ["server","scenario","supported","rps","p50_ms","p95_ms","p99_ms","p999_ms","throughput_mbps","cpu_pct_avg","cpu_ms_per_request","rss_mb_peak","errors"],
+        ["server","scenario","supported","reason","rps","p50_ms","p95_ms","p99_ms","p999_ms","p99_ttfb_ms","throughput_mbps","cpu_pct_avg","cpu_ms_per_request","rss_mb_peak","open_fds_peak","errors"],
         (.servers | to_entries[] as $server |
             $server.value | to_entries[] |
             select(.key != "_meta") |
-            [$server.key, .key, (.value.supported // true), (.value.rps // null), (.value.p50_ms // null), (.value.p95_ms // null),
-             (.value.p99_ms // null), (.value.p999_ms // null), (.value.throughput_mbps // null),
-             (.value.cpu_pct_avg // null), (.value.cpu_ms_per_request // null), (.value.rss_mb_peak // null), (.value.errors // null)])
+            [$server.key, .key, (.value.supported // true), (.value.reason // null), (.value.rps // null), (.value.p50_ms // null), (.value.p95_ms // null),
+             (.value.p99_ms // null), (.value.p999_ms // null), (.value.p99_ttfb_ms // null), (.value.throughput_mbps // null),
+             (.value.cpu_pct_avg // null), (.value.cpu_ms_per_request // null), (.value.rss_mb_peak // null), (.value.open_fds_peak // null), (.value.errors // null)]),
+        (if .upstream_pool_matrix != null then
+            (.upstream_pool_matrix.scenarios | to_entries[] |
+                ["tardigrade", ("upstream-pool/" + .key), (.value.covered // .value.supported // true), (.value.reason // .value.sharding_note // null),
+                 (.value.rps // null), null, null, (.value.p99_ms // null), null, (.value.p99_ttfb_ms // null), null,
+                 (.value.cpu_pct_avg // null), (.value.cpu_ms_per_request // null), (.value.rss_mb_peak // null), (.value.open_fds_peak // null), (.value.errors // null)])
+         else empty end)
         | @csv
     ' "$combined_json" > "$csv"
 
@@ -666,14 +710,29 @@ write_combined_outputs() {
         echo ""
         echo "Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
         echo ""
-        echo "| Server | Scenario | req/s | p50 ms | p95 ms | p99 ms | p999 ms | MB/s | CPU % | RSS MiB | Errors |"
-        echo "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+        echo "| Server | Scenario | Supported | req/s | p50 ms | p95 ms | p99 ms | p999 ms | p99 TTFB ms | MB/s | CPU % | RSS MiB | Open FDs | Errors |"
+        echo "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
         jq -r '
             .servers | to_entries[] as $server |
             $server.value | to_entries[] |
             select(.key != "_meta") |
-            "| `\($server.key)` | `\(.key)` | \((.value.rps // 0) | floor) | \(.value.p50_ms // "-") | \(.value.p95_ms // "-") | \(.value.p99_ms // "-") | \(.value.p999_ms // "-") | \(.value.throughput_mbps // "-") | \(.value.cpu_pct_avg // "-") | \(.value.rss_mb_peak // "-") | \(.value.errors // 0) |"
+            if (.value.supported? == false) then
+                "| `\($server.key)` | `\(.key)` | unsupported: \(.value.reason // "not supported") | - | - | - | - | - | - | - | - | - | - | - |"
+            else
+                "| `\($server.key)` | `\(.key)` | yes | \((.value.rps // 0) | floor) | \(.value.p50_ms // "-") | \(.value.p95_ms // "-") | \(.value.p99_ms // "-") | \(.value.p999_ms // "-") | \(.value.p99_ttfb_ms // "-") | \(.value.throughput_mbps // "-") | \(.value.cpu_pct_avg // "-") | \(.value.rss_mb_peak // "-") | \(.value.open_fds_peak // "-") | \(.value.errors // 0) |"
+            end
         ' "$combined_json"
+        if jq -e '.upstream_pool_matrix != null' "$combined_json" >/dev/null; then
+            echo ""
+            echo "## Upstream Pool Matrix"
+            echo ""
+            echo "| Scenario | Covered | req/s | p99 ms | p99 TTFB ms | CPU % | CPU ms/req | RSS MiB | New conn/s | Reuse ratio | Sharding | Errors |"
+            echo "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: |"
+            jq -r '
+                .upstream_pool_matrix.scenarios | to_entries[] |
+                "| `\(.key)` | \((.value.covered // .value.supported // true)) | \(.value.rps // "-") | \(.value.p99_ms // "-") | \(.value.p99_ttfb_ms // "-") | \(.value.cpu_pct_avg // "-") | \(.value.cpu_ms_per_request // "-") | \(.value.rss_mb_peak // "-") | \(.value.new_connections_per_sec // "-") | \(.value.reuse_ratio // "-") | \(.value.sharding_justified // "-") | \(.value.errors // "-") |"
+            ' "$combined_json"
+        fi
         echo ""
         echo "> Use these numbers only for same-host relative comparisons. Dedicated idle hosts are required for canonical claims."
     } > "$md"
@@ -698,6 +757,10 @@ require_tool python3
 require_tool "$TOOL"
 if ! $SMOKE; then
     require_tool k6
+    if [[ ",$SERVERS," == *",tardigrade,"* ]]; then
+        require_tool openssl
+        require_tool nghttpd
+    fi
 fi
 
 IFS=',' read -r -a SERVER_LIST <<< "$SERVERS"
@@ -775,8 +838,8 @@ done
 if ! $SMOKE && selected_tardigrade; then
     "${COMP_DIR}/upstream-pool-matrix.sh" \
         --binary "$BINARY" \
-        --listen-port "$((LISTEN_BASE + 50))" \
-        --origin-base-port "$((UPSTREAM_PORT + 50))" \
+        --listen-port "$((LISTEN_BASE + 200))" \
+        --origin-base-port "$((UPSTREAM_PORT + 200))" \
         --duration "$DURATION" \
         --connections "$CONNECTIONS" \
         --threads "$THREADS" \

--- a/benchmarks/competitive/run.sh
+++ b/benchmarks/competitive/run.sh
@@ -36,6 +36,8 @@ CURRENT_RSS_MB_PEAK="null"
 CURRENT_OPEN_FDS_PEAK="null"
 MONITOR_PID=""
 MONITOR_FILE=""
+CPU_BEFORE_SECONDS="null"
+MONITOR_START_NS="null"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -315,6 +317,39 @@ process_tree_pids() {
     done
 }
 
+monotonic_ns() {
+    python3 -c 'import time; print(time.monotonic_ns())'
+}
+
+cpu_time_to_seconds() {
+    awk '
+        function part_seconds(v, n, p) {
+            n = split(v, p, ":")
+            if (n == 3) return (p[1] * 3600) + (p[2] * 60) + p[3]
+            if (n == 2) return (p[1] * 60) + p[2]
+            return v + 0
+        }
+        {
+            v = $1
+            days = 0
+            if (index(v, "-") > 0) {
+                split(v, d, "-")
+                days = d[1] + 0
+                v = d[2]
+            }
+            total += days * 86400 + part_seconds(v)
+        }
+        END { printf "%.6f", total }
+    '
+}
+
+process_tree_cpu_seconds() {
+    local pid="$1" pids
+    pids="$(process_tree_pids "$pid" | paste -sd, -)"
+    [[ -n "$pids" ]] || pids="$pid"
+    ps -p "$pids" -o time= 2>/dev/null | cpu_time_to_seconds
+}
+
 count_open_fds_for_pids() {
     local pids_csv="$1"
     local total=0 pid count
@@ -345,8 +380,8 @@ monitor_process_tree() {
             [[ -n "$pids" ]] || pids="$pid"
             local fds
             fds="$(count_open_fds_for_pids "$pids")"
-            ps -p "$pids" -o rss= -o %cpu= 2>/dev/null |
-                awk -v fds="$fds" '{ rss += $1; cpu += $2 } END { if (rss > 0 || cpu > 0) print rss, cpu, fds }' >> "$outfile"
+            ps -p "$pids" -o rss= 2>/dev/null |
+                awk -v fds="$fds" '{ rss += $1 } END { if (rss > 0) print rss, fds }' >> "$outfile"
         }
         sleep "$sample_interval_s"
     done
@@ -366,6 +401,8 @@ start_process_monitor() {
     CURRENT_CPU_PCT_AVG="null"
     CURRENT_RSS_MB_PEAK="null"
     CURRENT_OPEN_FDS_PEAK="null"
+    CPU_BEFORE_SECONDS="$(process_tree_cpu_seconds "$EDGE_PID")"
+    MONITOR_START_NS="$(monotonic_ns)"
     MONITOR_FILE="$(mktemp /tmp/tardigrade-competitive-monitor-XXXXXX)"
     local sample_interval_s
     sample_interval_s="0.500"
@@ -380,9 +417,17 @@ stop_process_monitor() {
         MONITOR_PID=""
     fi
     if [[ -n "$MONITOR_FILE" && -f "$MONITOR_FILE" ]]; then
-        CURRENT_CPU_PCT_AVG="$(average_column_or_null "$MONITOR_FILE" 2)"
+        local cpu_after end_ns
+        cpu_after="$(process_tree_cpu_seconds "$EDGE_PID")"
+        end_ns="$(monotonic_ns)"
+        CURRENT_CPU_PCT_AVG="$(awk -v before="$CPU_BEFORE_SECONDS" -v after="$cpu_after" -v start="$MONITOR_START_NS" -v end="$end_ns" '
+            BEGIN {
+                elapsed = (end - start) / 1000000000
+                if (before != "null" && elapsed > 0) printf "%.2f", ((after - before) / elapsed) * 100
+                else printf "null"
+            }')"
         CURRENT_RSS_MB_PEAK="$(peak_rss_mb_or_null "$MONITOR_FILE")"
-        CURRENT_OPEN_FDS_PEAK="$(awk 'NF >= 3 && $3 ~ /^[0-9]+$/ && $3 > max { max = $3 } END { if (max > 0) printf "%d", max; else printf "null" }' "$MONITOR_FILE")"
+        CURRENT_OPEN_FDS_PEAK="$(awk 'NF >= 2 && $2 ~ /^[0-9]+$/ && $2 > max { max = $2 } END { if (max > 0) printf "%d", max; else printf "null" }' "$MONITOR_FILE")"
         rm -f "$MONITOR_FILE"
         MONITOR_FILE=""
     fi
@@ -700,7 +745,19 @@ write_combined_outputs() {
             (.upstream_pool_matrix.scenarios | to_entries[] |
                 ["tardigrade", ("upstream-pool/" + .key), (.value.covered // .value.supported // true), (.value.reason // .value.sharding_note // null),
                  (.value.rps // null), null, null, (.value.p99_ms // null), null, (.value.p99_ttfb_ms // null), null,
-                 (.value.cpu_pct_avg // null), (.value.cpu_ms_per_request // null), (.value.rss_mb_peak // null), (.value.open_fds_peak // null), (.value.errors // null)])
+                 (.value.cpu_pct_avg // null), (.value.cpu_ms_per_request // null), (.value.rss_mb_peak // null), (.value.open_fds_peak // null), (.value.errors // null)]),
+            (.upstream_pool_matrix.scenarios["uneven-route-distribution"].routes // {} | to_entries[] |
+                ["tardigrade", ("upstream-pool/uneven/" + .key), (.value.covered // true), (.value.reason // null),
+                 (.value.rps // null), null, null, (.value.p99_ms // null), null, (.value.p99_ttfb_ms // null), null,
+                 (.value.cpu_pct_avg // null), (.value.cpu_ms_per_request // null), (.value.rss_mb_peak // null), (.value.open_fds_peak // null), (.value.errors // null)]),
+            (.upstream_pool_matrix.scenarios["many-origins-low-volume"].measurements // [] | .[] |
+                ["tardigrade", ("upstream-pool/origin/" + (.origin // "unknown")), (.covered // true), (.reason // null),
+                 (.rps // null), null, null, (.p99_ms // null), null, (.p99_ttfb_ms // null), null,
+                 (.cpu_pct_avg // null), (.cpu_ms_per_request // null), (.rss_mb_peak // null), (.open_fds_peak // null), (.errors // null)]),
+            (.upstream_pool_matrix.scenarios["pool-contention"].measurements // [] | .[] |
+                ["tardigrade", ("upstream-pool/contention/" + ((.worker_threads // 0) | tostring) + "w"), (.covered // true), (.reason // null),
+                 (.rps // null), null, null, (.p99_ms // null), null, (.p99_ttfb_ms // null), null,
+                 (.cpu_pct_avg // null), (.cpu_ms_per_request // null), (.rss_mb_peak // null), (.open_fds_peak // null), (.errors // null)])
          else empty end)
         | @csv
     ' "$combined_json" > "$csv"
@@ -731,6 +788,28 @@ write_combined_outputs() {
             jq -r '
                 .upstream_pool_matrix.scenarios | to_entries[] |
                 "| `\(.key)` | \((.value.covered // .value.supported // true)) | \(.value.rps // "-") | \(.value.p99_ms // "-") | \(.value.p99_ttfb_ms // "-") | \(.value.cpu_pct_avg // "-") | \(.value.cpu_ms_per_request // "-") | \(.value.rss_mb_peak // "-") | \(.value.new_connections_per_sec // "-") | \(.value.reuse_ratio // "-") | \(.value.sharding_justified // "-") | \(.value.errors // "-") |"
+            ' "$combined_json"
+            echo ""
+            echo "### Upstream Pool Detail Rows"
+            echo ""
+            echo "| Detail | req/s | p99 ms | p99 TTFB ms | CPU % | CPU ms/req | RSS MiB | Open FDs | New conn/s | Reuse ratio | Errors |"
+            echo "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+            jq -r '
+                def row($name; $v):
+                    "| `" + $name + "` | " +
+                    (($v.rps // "-") | tostring) + " | " +
+                    (($v.p99_ms // "-") | tostring) + " | " +
+                    (($v.p99_ttfb_ms // "-") | tostring) + " | " +
+                    (($v.cpu_pct_avg // "-") | tostring) + " | " +
+                    (($v.cpu_ms_per_request // "-") | tostring) + " | " +
+                    (($v.rss_mb_peak // "-") | tostring) + " | " +
+                    (($v.open_fds_peak // "-") | tostring) + " | " +
+                    (($v.new_connections_per_sec // "-") | tostring) + " | " +
+                    (($v.reuse_ratio // "-") | tostring) + " | " +
+                    (($v.errors // "-") | tostring) + " |";
+                (.upstream_pool_matrix.scenarios["uneven-route-distribution"].routes // {} | to_entries[] | row("uneven/" + .key; .value)),
+                (.upstream_pool_matrix.scenarios["many-origins-low-volume"].measurements // [] | .[] | row("origin/" + (.origin // "unknown"); .)),
+                (.upstream_pool_matrix.scenarios["pool-contention"].measurements // [] | .[] | row("contention/" + ((.worker_threads // 0) | tostring) + "w"; .))
             ' "$combined_json"
         fi
         echo ""
@@ -839,7 +918,7 @@ if ! $SMOKE && selected_tardigrade; then
     "${COMP_DIR}/upstream-pool-matrix.sh" \
         --binary "$BINARY" \
         --listen-port "$((LISTEN_BASE + 200))" \
-        --origin-base-port "$((UPSTREAM_PORT + 200))" \
+        --origin-base-port "$((LISTEN_BASE + 300))" \
         --duration "$DURATION" \
         --connections "$CONNECTIONS" \
         --threads "$THREADS" \

--- a/benchmarks/competitive/run.sh
+++ b/benchmarks/competitive/run.sh
@@ -1,0 +1,538 @@
+#!/usr/bin/env bash
+# Competitive benchmark orchestrator for Tardigrade, NGINX, HAProxy, and Caddy.
+#
+# It starts a shared origin fixture plus one selected edge server at a time,
+# delegates HTTP measurements to benchmarks/run.sh, and emits combined JSON,
+# CSV, and Markdown output with enough metadata to avoid ambiguous comparisons.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+BENCH_DIR="${REPO_ROOT}/benchmarks"
+COMP_DIR="${BENCH_DIR}/competitive"
+CONFIG_DIR="${COMP_DIR}/configs"
+BINARY="${REPO_ROOT}/zig-out/bin/tardi"
+SERVERS="tardigrade,nginx,haproxy,caddy"
+TOOL="wrk"
+DURATION="15"
+CONNECTIONS="32"
+THREADS="4"
+LISTEN_BASE="19080"
+UPSTREAM_PORT="19079"
+OUT_DIR="${COMP_DIR}/results/$(date -u +%Y%m%d-%H%M%S)"
+META_FILE="${COMP_DIR}/target.json"
+ALLOW_MISSING=false
+PRINT_MANUAL=false
+SMOKE=false
+TMP_DIR=""
+ORIGIN_PID=""
+EDGE_PID=""
+CURRENT_SERVER=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --binary) BINARY="$2"; shift 2 ;;
+        --servers) SERVERS="$2"; shift 2 ;;
+        --tool) TOOL="$2"; shift 2 ;;
+        --duration) DURATION="$2"; shift 2 ;;
+        --connections) CONNECTIONS="$2"; shift 2 ;;
+        --threads) THREADS="$2"; shift 2 ;;
+        --listen-base) LISTEN_BASE="$2"; shift 2 ;;
+        --upstream-port) UPSTREAM_PORT="$2"; shift 2 ;;
+        --out-dir) OUT_DIR="$2"; shift 2 ;;
+        --meta-file) META_FILE="$2"; shift 2 ;;
+        --allow-missing) ALLOW_MISSING=true; shift ;;
+        --smoke)
+            SMOKE=true
+            DURATION="5"
+            CONNECTIONS="8"
+            THREADS="2"
+            SERVERS="tardigrade"
+            shift
+            ;;
+        --print-manual) PRINT_MANUAL=true; shift ;;
+        --help)
+            sed -n '2,80p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+print_manual_steps() {
+    cat <<EOF
+Competitive benchmark manual flow:
+
+1. Install tools: jq, curl, python3, ${TOOL}, plus any selected competitors (${SERVERS}).
+2. Build Tardigrade: zig build -Doptimize=ReleaseFast
+3. Start the shared origin fixture:
+   python3 benchmarks/fixtures/upstream_server.py --port ${UPSTREAM_PORT}
+4. For each server in ${SERVERS}, render its template from benchmarks/competitive/configs
+   with LISTEN_PORT, UPSTREAM_PORT, STATIC_ROOT, PID_FILE, ERROR_LOG, and THREADS.
+5. Start one server at a time, wait for http://127.0.0.1:<port>/health, then run:
+   benchmarks/run.sh --tool ${TOOL} --host 127.0.0.1 --port <port> \\
+     --duration ${DURATION} --connections ${CONNECTIONS} --threads ${THREADS} \\
+     --static-path /tiny.txt --keepalive-path /tiny.txt \\
+     --proxy-path /proxy/health --save <server>-tiny-proxy.json
+6. Repeat with --static-path /large.bin and --scenarios static-http1.
+7. Repeat with --proxy-path /proxy/payload-1m.bin and --scenarios proxy-http1.
+8. Repeat with --proxy-slow-client-path /proxy/payload-16m.bin and
+   --scenarios proxy-slow-client-download.
+9. With wrk, run the churn pass with -H "Connection: close" against /tiny.txt.
+10. Compare only runs captured on the same idle host with the same tool, duration,
+   connection count, kernel limits, and server versions.
+
+The automated command is:
+  benchmarks/competitive/run.sh --servers ${SERVERS} --tool ${TOOL} --duration ${DURATION} --connections ${CONNECTIONS} --threads ${THREADS}
+EOF
+}
+
+if $PRINT_MANUAL; then
+    print_manual_steps
+    exit 0
+fi
+
+require_tool() {
+    local tool="$1"
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "Missing required tool: ${tool}" >&2
+        exit 1
+    fi
+}
+
+has_tool() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+cleanup_edge() {
+    if [[ -n "$EDGE_PID" ]]; then
+        kill "$EDGE_PID" 2>/dev/null || true
+        wait "$EDGE_PID" 2>/dev/null || true
+        EDGE_PID=""
+    fi
+    if [[ "$CURRENT_SERVER" == "nginx" && -n "$TMP_DIR" && -f "${TMP_DIR}/nginx/nginx.conf" ]] && has_tool nginx; then
+        nginx -p "${TMP_DIR}/nginx" -c "${TMP_DIR}/nginx/nginx.conf" -s stop >/dev/null 2>&1 || true
+    fi
+    CURRENT_SERVER=""
+}
+
+cleanup() {
+    local status=$?
+    cleanup_edge
+    if [[ -n "$ORIGIN_PID" ]]; then
+        kill "$ORIGIN_PID" 2>/dev/null || true
+        wait "$ORIGIN_PID" 2>/dev/null || true
+        ORIGIN_PID=""
+    fi
+    if [[ $status -ne 0 && -n "$TMP_DIR" ]]; then
+        find "$TMP_DIR" -maxdepth 3 -type f -name '*.log' -print -exec tail -80 {} \; || true
+    fi
+    [[ -n "$TMP_DIR" ]] && rm -rf "$TMP_DIR"
+    exit "$status"
+}
+trap cleanup EXIT
+
+wait_for_http() {
+    local url="$1"
+    local attempts="${2:-60}"
+    local delay="${3:-0.2}"
+    local i
+    for ((i = 0; i < attempts; i += 1)); do
+        if curl -fsS "$url" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep "$delay"
+    done
+    echo "Timed out waiting for ${url}" >&2
+    return 1
+}
+
+render_template() {
+    local template="$1"
+    local output="$2"
+    local listen_port="$3"
+    local pid_file="$4"
+    local error_log="$5"
+    sed \
+        -e "s|__LISTEN_PORT__|${listen_port}|g" \
+        -e "s|__UPSTREAM_PORT__|${UPSTREAM_PORT}|g" \
+        -e "s|__STATIC_ROOT__|${TMP_DIR}/public|g" \
+        -e "s|__PID_FILE__|${pid_file}|g" \
+        -e "s|__ERROR_LOG__|${error_log}|g" \
+        -e "s|__THREADS__|${THREADS}|g" \
+        "$template" > "$output"
+}
+
+ensure_tardigrade_binary() {
+    if [[ -x "$BINARY" ]]; then
+        return
+    fi
+    echo "Building Tardigrade release binary..."
+    (cd "$REPO_ROOT" && zig build -Doptimize=ReleaseFast)
+}
+
+start_tardigrade() {
+    ensure_tardigrade_binary
+    local port="$1"
+    local dir="${TMP_DIR}/tardigrade"
+    mkdir -p "$dir"
+    render_template "${CONFIG_DIR}/tardigrade.conf.in" "${dir}/tardigrade.conf" "$port" "${dir}/tardigrade.pid" "${dir}/error.log"
+    TARDIGRADE_RATE_LIMIT_RPS=0 TARDIGRADE_PROXY_STREAMING_MODE=response \
+        "$BINARY" run -c "${dir}/tardigrade.conf" >"${dir}/server.log" 2>&1 &
+    EDGE_PID="$!"
+}
+
+start_nginx() {
+    local port="$1"
+    local dir="${TMP_DIR}/nginx"
+    mkdir -p "${dir}/logs" "${dir}/client_body_temp" "${dir}/proxy_temp"
+    render_template "${CONFIG_DIR}/nginx.conf.in" "${dir}/nginx.conf" "$port" "${dir}/nginx.pid" "${dir}/logs/error.log"
+    nginx -p "$dir" -c "${dir}/nginx.conf" -g "daemon off;" >"${dir}/server.log" 2>&1 &
+    EDGE_PID="$!"
+}
+
+start_haproxy() {
+    local port="$1"
+    local dir="${TMP_DIR}/haproxy"
+    mkdir -p "$dir"
+    render_template "${CONFIG_DIR}/haproxy.cfg.in" "${dir}/haproxy.cfg" "$port" "${dir}/haproxy.pid" "${dir}/error.log"
+    haproxy -f "${dir}/haproxy.cfg" -db >"${dir}/server.log" 2>&1 &
+    EDGE_PID="$!"
+}
+
+start_caddy() {
+    local port="$1"
+    local dir="${TMP_DIR}/caddy"
+    mkdir -p "$dir"
+    render_template "${CONFIG_DIR}/Caddyfile.in" "${dir}/Caddyfile" "$port" "${dir}/caddy.pid" "${dir}/error.log"
+    caddy run --config "${dir}/Caddyfile" --adapter caddyfile >"${dir}/server.log" 2>&1 &
+    EDGE_PID="$!"
+}
+
+start_server() {
+    local server="$1"
+    local port="$2"
+    CURRENT_SERVER="$server"
+    case "$server" in
+        tardigrade) start_tardigrade "$port" ;;
+        nginx) start_nginx "$port" ;;
+        haproxy) start_haproxy "$port" ;;
+        caddy) start_caddy "$port" ;;
+        *) echo "Unknown server: ${server}" >&2; exit 1 ;;
+    esac
+    wait_for_http "http://127.0.0.1:${port}/health"
+}
+
+server_tool() {
+    case "$1" in
+        tardigrade) echo "$BINARY" ;;
+        nginx) echo nginx ;;
+        haproxy) echo haproxy ;;
+        caddy) echo caddy ;;
+        *) echo "$1" ;;
+    esac
+}
+
+server_version() {
+    case "$1" in
+        tardigrade) "$BINARY" --version 2>/dev/null | head -1 || echo "unknown" ;;
+        nginx) nginx -v 2>&1 | sed 's/^nginx version: //' ;;
+        haproxy) haproxy -v 2>/dev/null | head -1 ;;
+        caddy) caddy version 2>/dev/null | head -1 ;;
+        *) echo "unknown" ;;
+    esac
+}
+
+rename_pass_json() {
+    local input="$1"
+    local output="$2"
+    local server="$3"
+    local pass="$4"
+    jq --arg server "$server" --arg pass "$pass" '
+        with_entries(
+            if .key == "_meta" then
+                .value += {competitive_server: $server, competitive_pass: $pass} |
+                .
+            elif $pass == "tiny-proxy" and .key == "static-http1" then .key = "static-tiny-http1" | .
+            elif $pass == "tiny-proxy" and .key == "keepalive" then .key = "static-tiny-keepalive" | .
+            elif $pass == "tiny-proxy" and .key == "proxy-http1" then .key = "proxy-small-http1" | .
+            elif $pass == "tiny-static" and .key == "static-http1" then .key = "static-tiny-http1" | .
+            elif $pass == "tiny-static" and .key == "keepalive" then .key = "static-tiny-keepalive" | .
+            elif $pass == "large-static" and .key == "static-http1" then .key = "static-large-http1" | .
+            elif $pass == "large-proxy" and .key == "proxy-http1" then .key = "proxy-large-http1" | .
+            elif $pass == "slow-client" and .key == "proxy-slow-client-download" then .key = "proxy-slow-client-download" | .
+            elif $pass == "idle-keepalive" and .key == "keepalive-starvation" then .key = "idle-keepalive-active-traffic" | .
+            else .
+            end
+        )' "$input" > "$output"
+}
+
+run_benchmark_pass() {
+    local server="$1"
+    local port="$2"
+    local pass="$3"
+    local scenarios="$4"
+    local static_path="$5"
+    local proxy_path="$6"
+    local raw="${OUT_DIR}/${server}-${pass}.raw.json"
+    local renamed="${OUT_DIR}/${server}-${pass}.json"
+
+    "${BENCH_DIR}/run.sh" \
+        --tool "$TOOL" \
+        --host 127.0.0.1 \
+        --port "$port" \
+        --driver "competitive-loopback" \
+        --config-label "${server}" \
+        --pid "$EDGE_PID" \
+        --meta-file "$META_FILE" \
+        --duration "$DURATION" \
+        --connections "$CONNECTIONS" \
+        --threads "$THREADS" \
+        --static-path "$static_path" \
+        --keepalive-path "$static_path" \
+        --proxy-path "$proxy_path" \
+        --proxy-payload-1m-path "$proxy_path" \
+        --proxy-slow-client-path "$proxy_path" \
+        --scenarios "$scenarios" \
+        --save "$raw"
+    rename_pass_json "$raw" "$renamed" "$server" "$pass"
+}
+
+run_connection_churn() {
+    local server="$1"
+    local port="$2"
+    local output="${OUT_DIR}/${server}-connection-churn.json"
+    if [[ "$TOOL" != "wrk" ]]; then
+        echo "Skipping connection churn scenario; automated churn currently requires --tool wrk."
+        return 0
+    fi
+
+    echo "==> connection-churn-http1: tiny static file with Connection: close"
+    local raw summary_json rps p50 p95 p99 p999 errors tput_mbps
+    raw=$(wrk --latency -s "${BENCH_DIR}/wrk-summary.lua" \
+        -t"${THREADS}" -c"${CONNECTIONS}" -d"${DURATION}s" \
+        -H "Connection: close" \
+        "http://127.0.0.1:${port}/tiny.txt" 2>&1) || true
+    summary_json=$(printf '%s\n' "$raw" | sed -n 's/^WRK_SUMMARY //p' | tail -1)
+    if [[ -z "$summary_json" ]]; then
+        echo "wrk summary hook did not emit percentile JSON for connection churn" >&2
+        echo "$raw" >&2
+        exit 1
+    fi
+    rps=$(echo "$summary_json" | jq -r '.rps // 0')
+    p50=$(echo "$summary_json" | jq -r '.p50_ms // null')
+    p95=$(echo "$summary_json" | jq -r '.p95_ms // null')
+    p99=$(echo "$summary_json" | jq -r '.p99_ms // null')
+    p999=$(echo "$summary_json" | jq -r '.p999_ms // null')
+    tput_mbps=$(echo "$summary_json" | jq -r '.throughput_mbps // null')
+    errors=$(echo "$raw" | grep -E "Non-2xx|Socket errors" | grep -oE '[0-9]+' | head -1 || echo 0)
+    rps=${rps:-0}
+    errors=${errors:-0}
+    echo "  connection-churn-http1 — ${rps} req/s  p50=${p50}ms  p95=${p95}ms  p99=${p99}ms  p999=${p999}ms  errors=${errors}"
+    jq -n \
+        --arg server "$server" \
+        --argjson rps "$rps" \
+        --argjson p50 "$p50" \
+        --argjson p95 "$p95" \
+        --argjson p99 "$p99" \
+        --argjson p999 "$p999" \
+        --argjson mbps "$tput_mbps" \
+        --argjson errors "$errors" \
+        '{
+            _meta: {
+                competitive_server: $server,
+                competitive_pass: "connection-churn",
+                tool: "wrk"
+            },
+            "connection-churn-http1": {
+                rps: $rps,
+                p50_ms: $p50,
+                p95_ms: $p95,
+                p99_ms: $p99,
+                p999_ms: $p999,
+                throughput_mbps: $mbps,
+                cpu_pct_avg: null,
+                rss_mb_peak: null,
+                errors: $errors
+            }
+        }' > "$output"
+}
+
+combine_server_results() {
+    local server="$1"
+    local combined="${OUT_DIR}/${server}.json"
+    local inputs=()
+    if [[ -f "${OUT_DIR}/${server}-large-static.json" ]]; then
+        inputs+=("${OUT_DIR}/${server}-large-static.json")
+    fi
+    if [[ -f "${OUT_DIR}/${server}-tiny-proxy.json" ]]; then
+        inputs+=("${OUT_DIR}/${server}-tiny-proxy.json")
+    fi
+    if [[ -f "${OUT_DIR}/${server}-tiny-static.json" ]]; then
+        inputs+=("${OUT_DIR}/${server}-tiny-static.json")
+    fi
+    if [[ -f "${OUT_DIR}/${server}-large-proxy.json" ]]; then
+        inputs+=("${OUT_DIR}/${server}-large-proxy.json")
+    fi
+    if [[ -f "${OUT_DIR}/${server}-slow-client.json" ]]; then
+        inputs+=("${OUT_DIR}/${server}-slow-client.json")
+    fi
+    if [[ -f "${OUT_DIR}/${server}-idle-keepalive.json" ]]; then
+        inputs+=("${OUT_DIR}/${server}-idle-keepalive.json")
+    fi
+    if [[ -f "${OUT_DIR}/${server}-connection-churn.json" ]]; then
+        inputs+=("${OUT_DIR}/${server}-connection-churn.json")
+    fi
+    if [[ ${#inputs[@]} -eq 0 ]]; then
+        echo "No normalized pass results found for ${server}" >&2
+        exit 1
+    fi
+    local version
+    version="$(server_version "$server")"
+    jq -s --arg version "$version" '
+        reduce .[] as $doc ({};
+            ._meta = ((._meta // {}) + ($doc._meta // {})) |
+            ._meta.server_version = $version |
+            . + ($doc | del(._meta))
+        )
+    ' "${inputs[@]}" > "$combined"
+}
+
+write_combined_outputs() {
+    local combined_json="${OUT_DIR}/competitive-results.json"
+    local csv="${OUT_DIR}/competitive-results.csv"
+    local md="${OUT_DIR}/competitive-summary.md"
+    local server_files=()
+    local known_server
+    for known_server in tardigrade nginx haproxy caddy; do
+        if [[ -f "${OUT_DIR}/${known_server}.json" ]]; then
+            server_files+=("${OUT_DIR}/${known_server}.json")
+        fi
+    done
+    if [[ ${#server_files[@]} -eq 0 ]]; then
+        echo "No server result files were produced." >&2
+        exit 1
+    fi
+
+    jq -s '
+        {
+            _meta: {
+                generated_at: (now | todateiso8601),
+                suite: "competitive",
+                tool: $tool,
+                duration_s: ($duration | tonumber),
+                connections: ($connections | tonumber),
+                threads: ($threads | tonumber),
+                note: "Compare only same-host, same-tool, same-duration results. Laptop and shared-runner output is non-canonical."
+            },
+            servers: (reduce .[] as $doc ({};
+                .[$doc._meta.competitive_server] = $doc
+            ))
+        }
+    ' --arg tool "$TOOL" --arg duration "$DURATION" --arg connections "$CONNECTIONS" --arg threads "$THREADS" \
+        "${server_files[@]}" > "$combined_json"
+
+    jq -r '
+        ["server","scenario","rps","p50_ms","p95_ms","p99_ms","p999_ms","throughput_mbps","cpu_pct_avg","rss_mb_peak","errors"],
+        (.servers | to_entries[] as $server |
+            $server.value | to_entries[] |
+            select(.key != "_meta") |
+            [$server.key, .key, (.value.rps // null), (.value.p50_ms // null), (.value.p95_ms // null),
+             (.value.p99_ms // null), (.value.p999_ms // null), (.value.throughput_mbps // null),
+             (.value.cpu_pct_avg // null), (.value.rss_mb_peak // null), (.value.errors // null)])
+        | @csv
+    ' "$combined_json" > "$csv"
+
+    {
+        echo "# Competitive Benchmark Summary"
+        echo ""
+        echo "Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        echo ""
+        echo "| Server | Scenario | req/s | p50 ms | p95 ms | p99 ms | p999 ms | MB/s | CPU % | RSS MiB | Errors |"
+        echo "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+        jq -r '
+            .servers | to_entries[] as $server |
+            $server.value | to_entries[] |
+            select(.key != "_meta") |
+            "| `\($server.key)` | `\(.key)` | \((.value.rps // 0) | floor) | \(.value.p50_ms // "-") | \(.value.p95_ms // "-") | \(.value.p99_ms // "-") | \(.value.p999_ms // "-") | \(.value.throughput_mbps // "-") | \(.value.cpu_pct_avg // "-") | \(.value.rss_mb_peak // "-") | \(.value.errors // 0) |"
+        ' "$combined_json"
+        echo ""
+        echo "> Use these numbers only for same-host relative comparisons. Dedicated idle hosts are required for canonical claims."
+    } > "$md"
+
+    echo "Wrote:"
+    echo "  ${combined_json}"
+    echo "  ${csv}"
+    echo "  ${md}"
+}
+
+require_tool jq
+require_tool curl
+require_tool python3
+require_tool "$TOOL"
+
+IFS=',' read -r -a SERVER_LIST <<< "$SERVERS"
+for server in "${SERVER_LIST[@]}"; do
+    tool_path="$(server_tool "$server")"
+    if [[ "$server" == "tardigrade" ]]; then
+        continue
+    fi
+    if ! has_tool "$tool_path"; then
+        if $ALLOW_MISSING; then
+            echo "Skipping ${server}: missing ${tool_path}"
+            continue
+        fi
+        echo "Missing selected competitor '${server}' (${tool_path}). Re-run with --allow-missing to skip it." >&2
+        exit 1
+    fi
+done
+
+if $SMOKE; then
+    echo "Running reduced competitive smoke benchmark for Tardigrade only."
+fi
+
+mkdir -p "$OUT_DIR"
+TMP_DIR="$(mktemp -d /tmp/tardigrade-competitive-XXXX)"
+mkdir -p "${TMP_DIR}/public"
+printf 'ok\n' > "${TMP_DIR}/public/tiny.txt"
+dd if=/dev/zero of="${TMP_DIR}/public/large.bin" bs=1024 count=1024 >/dev/null 2>&1
+
+python3 "${BENCH_DIR}/fixtures/upstream_server.py" --port "$UPSTREAM_PORT" >"${TMP_DIR}/origin.log" 2>&1 &
+ORIGIN_PID="$!"
+wait_for_http "http://127.0.0.1:${UPSTREAM_PORT}/health"
+
+for index in "${!SERVER_LIST[@]}"; do
+    server="${SERVER_LIST[$index]}"
+    tool_path="$(server_tool "$server")"
+    if [[ "$server" != "tardigrade" ]] && ! has_tool "$tool_path"; then
+        continue
+    fi
+
+    port=$((LISTEN_BASE + index))
+    echo ""
+    echo "== ${server} (${port}) =="
+    echo "version: $(server_version "$server")"
+    start_server "$server" "$port"
+
+    if $SMOKE; then
+        run_benchmark_pass "$server" "$port" "tiny-static" "static-http1" "/tiny.txt" "/proxy/health"
+    else
+        run_benchmark_pass "$server" "$port" "tiny-proxy" "static-http1,proxy-http1,keepalive" "/tiny.txt" "/proxy/health"
+        run_benchmark_pass "$server" "$port" "large-static" "static-http1" "/large.bin" "/proxy/health"
+        run_benchmark_pass "$server" "$port" "large-proxy" "proxy-http1" "/tiny.txt" "/proxy/payload-1m.bin"
+        run_benchmark_pass "$server" "$port" "slow-client" "proxy-slow-client-download" "/tiny.txt" "/proxy/payload-16m.bin"
+        run_connection_churn "$server" "$port"
+    fi
+    if $SMOKE; then
+        :
+    elif [[ "$TOOL" == "k6" ]]; then
+        run_benchmark_pass "$server" "$port" "idle-keepalive" "keepalive-starvation" "/tiny.txt" "/proxy/health"
+    else
+        echo "Skipping idle keepalive plus active traffic scenario; it requires --tool k6."
+    fi
+
+    combine_server_results "$server"
+    cleanup_edge
+done
+
+write_combined_outputs

--- a/benchmarks/competitive/target.json
+++ b/benchmarks/competitive/target.json
@@ -1,0 +1,6 @@
+{
+  "environment_name": "competitive-local",
+  "benchmark_suite": "competitive",
+  "comparison_note": "Representative local competitive run. Use a dedicated idle host for canonical numbers.",
+  "competitors": ["tardigrade", "nginx", "haproxy", "caddy"]
+}

--- a/benchmarks/competitive/upstream-pool-matrix.sh
+++ b/benchmarks/competitive/upstream-pool-matrix.sh
@@ -4,9 +4,7 @@
 # Covers the #147 validation matrix absorbed by #149: uneven route traffic,
 # many low-volume origins, one hot origin with many workers, upstream TLS
 # handshake/reuse, local vs cross-worker reuse, new upstream connections/sec,
-# CPU/request, p99 latency, and higher-worker contention evidence. The gateway
-# does not currently expose a direct pool-lock wait counter, so the sharding
-# decision is reported as undetermined with measured sweep data.
+# CPU/request, p99 TTFB, and higher-worker contention evidence.
 
 set -euo pipefail
 
@@ -33,63 +31,49 @@ while [[ $# -gt 0 ]]; do
         --connections) CONNECTIONS="$2"; shift 2 ;;
         --threads) THREADS="$2"; shift 2 ;;
         --output) OUTPUT="$2"; shift 2 ;;
-        --help)
-            sed -n '2,11p' "$0" | sed 's/^# \{0,1\}//'
-            exit 0
-            ;;
+        --help) sed -n '2,10p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
         *) echo "unknown arg: $1" >&2; exit 2 ;;
     esac
 done
 
-if [[ -z "$OUTPUT" ]]; then
-    echo "--output is required" >&2
-    exit 1
-fi
-
-for tool in wrk curl python3 jq awk ps pgrep openssl nghttpd; do
+[[ -n "$OUTPUT" ]] || { echo "--output is required" >&2; exit 1; }
+for tool in wrk curl python3 jq awk ps pgrep openssl k6; do
     command -v "$tool" >/dev/null 2>&1 || { echo "missing required tool: $tool" >&2; exit 1; }
 done
-if [[ ! -x "$BINARY" ]]; then
-    echo "tardi binary not found at ${BINARY}" >&2
-    exit 1
-fi
+[[ -x "$BINARY" ]] || { echo "tardi binary not found at ${BINARY}" >&2; exit 1; }
 
 cleanup() {
     local status=$?
-    if [[ "$status" -ne 0 && -n "$TMP_DIR" ]]; then
-        if [[ -f "${TMP_DIR}/tardigrade.log" ]]; then
-            echo ""
-            echo "---- upstream-matrix tardigrade.log ----" >&2
-            tail -n 120 "${TMP_DIR}/tardigrade.log" >&2
+    if [[ "$status" -ne 0 && -n "$TMP_DIR" && -f "${TMP_DIR}/tardigrade.log" ]]; then
+        if [[ -f "${TMP_DIR}/upstream-matrix.conf" ]]; then
+            echo "" >&2
+            echo "---- upstream-matrix config ----" >&2
+            cat "${TMP_DIR}/upstream-matrix.conf" >&2
         fi
-        if [[ -f "${TMP_DIR}/tls-origin.log" ]]; then
-            echo ""
-            echo "---- upstream-matrix tls-origin.log ----" >&2
-            tail -n 80 "${TMP_DIR}/tls-origin.log" >&2
-        fi
+        echo "" >&2
+        echo "---- upstream-matrix tardigrade.log ----" >&2
+        tail -n 120 "${TMP_DIR}/tardigrade.log" >&2
     fi
-    if [[ -n "$TARDIGRADE_PID" ]]; then
-        kill "$TARDIGRADE_PID" 2>/dev/null || true
-        wait "$TARDIGRADE_PID" 2>/dev/null || true
-    fi
+    [[ -n "$TARDIGRADE_PID" ]] && { kill "$TARDIGRADE_PID" 2>/dev/null || true; wait "$TARDIGRADE_PID" 2>/dev/null || true; }
     local pid
     for pid in "${ORIGIN_PIDS[@]}"; do
         kill "$pid" 2>/dev/null || true
         wait "$pid" 2>/dev/null || true
     done
-    if [[ -n "$TLS_ORIGIN_PID" ]]; then
-        kill "$TLS_ORIGIN_PID" 2>/dev/null || true
-        wait "$TLS_ORIGIN_PID" 2>/dev/null || true
-    fi
+    [[ -n "$TLS_ORIGIN_PID" ]] && { kill "$TLS_ORIGIN_PID" 2>/dev/null || true; wait "$TLS_ORIGIN_PID" 2>/dev/null || true; }
     [[ -n "$TMP_DIR" ]] && rm -rf "$TMP_DIR"
     exit "$status"
 }
 trap cleanup EXIT
 
+monotonic_ns() {
+    python3 -c 'import time; print(time.monotonic_ns())'
+}
+
 wait_for_http() {
     local url="$1" attempts="${2:-50}" i
     for ((i = 0; i < attempts; i += 1)); do
-        curl -fsSk "$url" >/dev/null 2>&1 && return 0
+        curl --max-time 1 -fsSk "$url" >/dev/null 2>&1 && return 0
         sleep 0.2
     done
     echo "timed out waiting for ${url}" >&2
@@ -106,9 +90,37 @@ process_tree_pids() {
     done
 }
 
+cpu_time_to_seconds() {
+    awk '
+        function part_seconds(v, n, p) {
+            n = split(v, p, ":")
+            if (n == 3) return (p[1] * 3600) + (p[2] * 60) + p[3]
+            if (n == 2) return (p[1] * 60) + p[2]
+            return v + 0
+        }
+        {
+            v = $1
+            days = 0
+            if (index(v, "-") > 0) {
+                split(v, d, "-")
+                days = d[1] + 0
+                v = d[2]
+            }
+            total += days * 86400 + part_seconds(v)
+        }
+        END { printf "%.6f", total }
+    '
+}
+
+process_tree_cpu_seconds() {
+    local pids
+    pids="$(process_tree_pids "$TARDIGRADE_PID" | paste -sd, -)"
+    [[ -n "$pids" ]] || pids="$TARDIGRADE_PID"
+    ps -p "$pids" -o time= 2>/dev/null | cpu_time_to_seconds
+}
+
 count_open_fds_for_pids() {
-    local pids_csv="$1"
-    local total=0 pid count
+    local pids_csv="$1" total=0 pid count
     IFS=, read -ra _fd_pids <<< "$pids_csv"
     for pid in "${_fd_pids[@]}"; do
         [[ -n "$pid" ]] || continue
@@ -121,56 +133,60 @@ count_open_fds_for_pids() {
         fi
         [[ "$count" =~ ^[0-9]+$ ]] && total=$((total + count))
     done
-    if [[ "$total" -gt 0 ]]; then
-        printf '%s\n' "$total"
-    else
-        printf 'null\n'
-    fi
+    [[ "$total" -gt 0 ]] && printf '%s\n' "$total" || printf 'null\n'
 }
 
 monitor_process_tree() {
-    local pid="$1" sample_interval_s="$2" outfile="$3"
-    while kill -0 "$pid" 2>/dev/null; do
-        process_tree_pids "$pid" | paste -sd, - | {
+    local outfile="$1"
+    while kill -0 "$TARDIGRADE_PID" 2>/dev/null; do
+        process_tree_pids "$TARDIGRADE_PID" | paste -sd, - | {
             read -r pids
-            [[ -n "$pids" ]] || pids="$pid"
+            [[ -n "$pids" ]] || pids="$TARDIGRADE_PID"
             local fds
             fds="$(count_open_fds_for_pids "$pids")"
-            ps -p "$pids" -o rss= -o %cpu= 2>/dev/null |
-                awk -v fds="$fds" '{ rss += $1; cpu += $2 } END { if (rss > 0 || cpu > 0) print rss, cpu, fds }' >> "$outfile"
+            ps -p "$pids" -o rss= 2>/dev/null |
+                awk -v fds="$fds" '{ rss += $1 } END { if (rss > 0) print rss, fds }' >> "$outfile"
         }
-        sleep "$sample_interval_s"
+        sleep 0.5
     done
 }
 
 start_monitor() {
-    local file
+    local file cpu_before start_ns
     file="$(mktemp /tmp/tardigrade-upstream-monitor-XXXXXX)"
-    monitor_process_tree "$TARDIGRADE_PID" "0.500" "$file" &
-    printf '%s %s\n' "$!" "$file"
+    cpu_before="$(process_tree_cpu_seconds)"
+    start_ns="$(monotonic_ns)"
+    monitor_process_tree "$file" &
+    printf '%s %s %s %s\n' "$!" "$file" "$cpu_before" "$start_ns"
 }
 
 stop_monitor() {
-    local pid="$1" file="$2"
+    local pid="$1" file="$2" cpu_before="$3" start_ns="$4"
     kill "$pid" 2>/dev/null || true
     wait "$pid" 2>/dev/null || true
-    awk '
-        NF >= 2 {
-            rss = $1; cpu = $2
-            cpu_sum += cpu; cpu_count += 1
-            if (rss > rss_max) rss_max = rss
-        }
-        NF >= 3 && $3 ~ /^[0-9]+$/ && $3 > fd_max { fd_max = $3 }
+    local cpu_after end_ns cpu_pct
+    cpu_after="$(process_tree_cpu_seconds)"
+    end_ns="$(monotonic_ns)"
+    cpu_pct="$(awk -v before="$cpu_before" -v after="$cpu_after" -v start="$start_ns" -v end="$end_ns" '
+        BEGIN {
+            elapsed = (end - start) / 1000000000
+            if (elapsed > 0) printf "%.2f", ((after - before) / elapsed) * 100
+            else printf "null"
+        }')"
+    awk -v cpu="$cpu_pct" '
+        NF >= 1 && $1 > rss_max { rss_max = $1 }
+        NF >= 2 && $2 ~ /^[0-9]+$/ && $2 > fd_max { fd_max = $2 }
         END {
-            if (cpu_count > 0) printf "%.2f %.2f ", cpu_sum / cpu_count, rss_max / 1024; else printf "null null ";
-            if (fd_max > 0) printf "%d\n", fd_max; else printf "null\n";
+            printf "%s ", cpu
+            if (rss_max > 0) printf "%.2f ", rss_max / 1024; else printf "null "
+            if (fd_max > 0) printf "%d\n", fd_max; else printf "null\n"
         }
     ' "$file"
     rm -f "$file"
 }
 
 current_metrics() {
-    curl -fsS "http://127.0.0.1:${LISTEN_PORT}/status/metrics"
+    curl --max-time 2 -fsS "http://127.0.0.1:${LISTEN_PORT}/status/metrics"
 }
 
 metric_from_file() {
@@ -179,8 +195,7 @@ metric_from_file() {
 }
 
 metric_delta() {
-    local before="$1" after="$2" key="$3"
-    local b a
+    local before="$1" after="$2" key="$3" b a
     b="$(metric_from_file "$before" "$key")"; b="${b:-0}"
     a="$(metric_from_file "$after" "$key")"; a="${a:-0}"
     awk -v a="$a" -v b="$b" 'BEGIN { print a - b }'
@@ -188,9 +203,7 @@ metric_delta() {
 
 wrk_error_count() {
     awk '
-        /Non-2xx/ {
-            for (i = 1; i <= NF; i++) if ($i ~ /^[0-9]+$/) total += $i
-        }
+        /Non-2xx/ { for (i = 1; i <= NF; i++) if ($i ~ /^[0-9]+$/) total += $i }
         /Socket errors:/ {
             for (i = 1; i <= NF; i++) {
                 gsub(/,/, "", $i)
@@ -203,11 +216,24 @@ wrk_error_count() {
 
 preflight_path() {
     local path="$1"
-    curl -fsS "http://127.0.0.1:${LISTEN_PORT}/${path}" | grep -qx 'ok'
+    curl --max-time 2 -fsS "http://127.0.0.1:${LISTEN_PORT}/${path}" | grep -qx 'ok'
+}
+
+run_k6_ttfb() {
+    local label="$1" path="$2" duration="$3" vus="$4" script summary
+    script="${TMP_DIR}/${label}-ttfb.js"
+    summary="${TMP_DIR}/${label}-ttfb.json"
+    cat > "$script" <<EOF
+import http from 'k6/http';
+export const options = { vus: ${vus}, duration: '${duration}s', summaryTrendStats: ['min', 'avg', 'med', 'p(90)', 'p(95)', 'p(99)', 'max'] };
+export default function () { http.get('http://127.0.0.1:${LISTEN_PORT}/${path}'); }
+EOF
+    k6 run --quiet --summary-export "$summary" "$script" >/dev/null
+    jq -r '.metrics.http_req_waiting.values["p(99)"] // .metrics.http_req_waiting["p(99)"] // .metrics.http_req_waiting["p(95)"] // null' "$summary"
 }
 
 scenario_json() {
-    local rps="$1" p99="$2" errors="$3" cpu_pct="$4" rss_mb="$5" open_fds="$6" before="$7" after="$8" elapsed="$9"
+    local rps="$1" p99="$2" p99_ttfb="$3" errors="$4" cpu_pct="$5" rss_mb="$6" open_fds="$7" before="$8" after="$9" elapsed="${10}"
     local new_c reused local_r cross_r stale
     new_c="$(metric_delta "$before" "$after" tardigrade_upstream_connections_new_total)"
     reused="$(metric_delta "$before" "$after" tardigrade_upstream_connections_reused_total)"
@@ -215,23 +241,15 @@ scenario_json() {
     cross_r="$(metric_delta "$before" "$after" tardigrade_upstream_connections_reused_cross_worker_total)"
     stale="$(metric_delta "$before" "$after" tardigrade_upstream_stale_retries_total)"
     jq -n \
-        --argjson rps "$rps" \
-        --argjson p99 "$p99" \
-        --argjson errors "$errors" \
-        --argjson cpu "$cpu_pct" \
-        --argjson rss "$rss_mb" \
-        --argjson fds "$open_fds" \
-        --argjson elapsed "$elapsed" \
-        --argjson new_connections "$new_c" \
-        --argjson reused_connections "$reused" \
-        --argjson local_reuse "$local_r" \
-        --argjson cross_worker_reuse "$cross_r" \
-        --argjson stale_retries "$stale" \
+        --argjson rps "$rps" --argjson p99 "$p99" --argjson p99_ttfb "$p99_ttfb" --argjson errors "$errors" \
+        --argjson cpu "$cpu_pct" --argjson rss "$rss_mb" --argjson fds "$open_fds" --argjson elapsed "$elapsed" \
+        --argjson new_connections "$new_c" --argjson reused_connections "$reused" \
+        --argjson local_reuse "$local_r" --argjson cross_worker_reuse "$cross_r" --argjson stale_retries "$stale" \
         '{
             covered: true,
             rps: $rps,
             p99_ms: $p99,
-            p99_ttfb_ms: null,
+            p99_ttfb_ms: $p99_ttfb,
             errors: $errors,
             elapsed_s: $elapsed,
             cpu_pct_avg: $cpu,
@@ -250,16 +268,15 @@ scenario_json() {
 }
 
 run_measured_wrk() {
-    local label="$1" path="$2" duration="$3" connections="$4" threads="$5"
-    local before after mon_pid mon_file raw summary rps p99 errors start_ns end_ns elapsed cpu_pct rss_mb open_fds
+    local label="$1" path="$2" duration="$3" connections="$4" threads="$5" with_ttfb="${6:-false}"
+    local before after mon_pid mon_file cpu_before start_ns raw summary rps p99 errors end_ns elapsed cpu_pct rss_mb open_fds p99_ttfb
     before="${TMP_DIR}/${label}-before.metrics"
     after="${TMP_DIR}/${label}-after.metrics"
     current_metrics > "$before"
-    read -r mon_pid mon_file < <(start_monitor)
-    start_ns="$(date +%s%N)"
+    read -r mon_pid mon_file cpu_before start_ns < <(start_monitor)
     raw="$(wrk --latency -s "${BENCH_DIR}/wrk-summary.lua" -t"${threads}" -c"${connections}" -d"${duration}s" "http://127.0.0.1:${LISTEN_PORT}/${path}" 2>&1 || true)"
-    end_ns="$(date +%s%N)"
-    read -r cpu_pct rss_mb open_fds < <(stop_monitor "$mon_pid" "$mon_file")
+    end_ns="$(monotonic_ns)"
+    read -r cpu_pct rss_mb open_fds < <(stop_monitor "$mon_pid" "$mon_file" "$cpu_before" "$start_ns")
     current_metrics > "$after"
     summary="$(printf '%s\n' "$raw" | sed -n 's/^WRK_SUMMARY //p' | tail -1)"
     if [[ -z "$summary" ]]; then
@@ -276,36 +293,55 @@ run_measured_wrk() {
         exit 1
     fi
     elapsed="$(awk -v s="$start_ns" -v e="$end_ns" 'BEGIN { printf "%.3f", (e - s) / 1000000000 }')"
-    scenario_json "$rps" "$p99" "$errors" "$cpu_pct" "$rss_mb" "$open_fds" "$before" "$after" "$elapsed"
+    if [[ "$with_ttfb" == true ]]; then
+        p99_ttfb="$(run_k6_ttfb "$label" "$path" "$duration" "$connections")"
+    else
+        p99_ttfb="null"
+    fi
+    scenario_json "$rps" "$p99" "$p99_ttfb" "$errors" "$cpu_pct" "$rss_mb" "$open_fds" "$before" "$after" "$elapsed"
+}
+
+start_gateway() {
+    local workers="$1"
+    [[ -n "$TARDIGRADE_PID" ]] && { kill "$TARDIGRADE_PID" 2>/dev/null || true; wait "$TARDIGRADE_PID" 2>/dev/null || true; }
+    TARDIGRADE_RATE_LIMIT_RPS=0 \
+    TARDIGRADE_WORKER_THREADS="$workers" \
+    TARDIGRADE_MAX_REQUESTS_PER_CONNECTION=0 \
+    TARDIGRADE_UPSTREAM_PROTOCOL=http1 \
+    TARDIGRADE_UPSTREAM_TLS_VERIFY=false \
+        "$BINARY" run -c "$CONFIG_FILE" >"${TMP_DIR}/tardigrade.log" 2>&1 &
+    TARDIGRADE_PID="$!"
+    sleep 1
 }
 
 worker_sweep_json() {
-    local cpus max workers result row
+    local cpus max workers result row sweep_connections
     cpus="$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)"
     max="$cpus"
-    [[ "$max" -gt 8 ]] && max=8
     result='[]'
     workers=1
     while [[ "$workers" -le "$max" ]]; do
-        local sweep_connections="$CONNECTIONS"
+        start_gateway "$workers"
+        sweep_connections="$CONNECTIONS"
         [[ "$sweep_connections" -lt "$workers" ]] && sweep_connections="$workers"
-        row="$(run_measured_wrk "pool-contention-${workers}w" hot 2 "$sweep_connections" "$workers")"
+        row="$(run_measured_wrk "pool-contention-${workers}w" hot 2 "$sweep_connections" "$THREADS" true)"
         result="$(jq --argjson row "$row" --argjson workers "$workers" '. + [($row + {worker_threads: $workers})]' <<<"$result")"
         workers=$((workers * 2))
     done
     jq -n --argjson rows "$result" '{
-        covered: true,
+        covered: false,
         sharding_justified: "undetermined",
-        reason: "No direct pool-lock wait/contention counter is currently exported; throughput, p99, CPU/request, reuse, and FD data are recorded by worker-count sweep.",
+        reason: "Gateway exports no direct pool-lock wait/contention counter yet; this sweep records worker-count throughput, p99, TTFB, CPU/request, reuse, and FD evidence without claiming contention closure.",
         measurements: $rows
     }'
 }
 
-TMP_DIR="$(mktemp -d /tmp/tardigrade-upstream-matrix-XXXX)"
+TMP_DIR="$(mktemp -d /tmp/tardigrade-upstream-matrix-XXXXXX)"
 CONFIG_FILE="${TMP_DIR}/upstream-matrix.conf"
-TLS_ORIGIN_PORT=$((ORIGIN_BASE_PORT + 20))
+TLS_ORIGIN_PORT=$((ORIGIN_BASE_PORT + 40))
+ORIGIN_COUNT=16
 
-for i in 0 1 2 3 4 5; do
+for ((i = 0; i < ORIGIN_COUNT; i += 1)); do
     port=$((ORIGIN_BASE_PORT + i))
     python3 "${BENCH_DIR}/fixtures/upstream_server.py" --port "$port" >"${TMP_DIR}/origin-${i}.log" 2>&1 &
     ORIGIN_PIDS+=("$!")
@@ -314,75 +350,74 @@ done
 
 openssl req -x509 -newkey rsa:2048 -nodes -days 2 -subj "/CN=localhost" \
     -keyout "${TMP_DIR}/tls-origin.key" -out "${TMP_DIR}/tls-origin.crt" >/dev/null 2>&1
-mkdir -p "${TMP_DIR}/tls-docroot"
-printf 'ok\n' > "${TMP_DIR}/tls-docroot/health"
-nghttpd -d "${TMP_DIR}/tls-docroot" "${TLS_ORIGIN_PORT}" "${TMP_DIR}/tls-origin.key" "${TMP_DIR}/tls-origin.crt" \
-    >"${TMP_DIR}/tls-origin.log" 2>&1 &
+cat > "${TMP_DIR}/tls_origin.py" <<'PY'
+import http.server, ssl, sys
+port = int(sys.argv[1])
+cert, key = sys.argv[2], sys.argv[3]
+class H(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    def do_GET(self):
+        body = b"ok\n"
+        self.send_response(200)
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def log_message(self, *args):
+        pass
+server = http.server.ThreadingHTTPServer(("127.0.0.1", port), H)
+ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+ctx.load_cert_chain(cert, key)
+ctx.set_alpn_protocols(["http/1.1"])
+server.socket = ctx.wrap_socket(server.socket, server_side=True)
+server.serve_forever()
+PY
+python3 "${TMP_DIR}/tls_origin.py" "$TLS_ORIGIN_PORT" "${TMP_DIR}/tls-origin.crt" "${TMP_DIR}/tls-origin.key" >"${TMP_DIR}/tls-origin.log" 2>&1 &
 TLS_ORIGIN_PID="$!"
 wait_for_http "https://127.0.0.1:${TLS_ORIGIN_PORT}/health"
 
-cat > "$CONFIG_FILE" <<EOF
-listen ${LISTEN_PORT};
-metrics_path /status/metrics;
+{
+    echo "listen ${LISTEN_PORT};"
+    echo "metrics_path /status/metrics;"
+    printf 'location = /hot {\n    proxy_pass http://127.0.0.1:%s/health;\n}\n' "${ORIGIN_BASE_PORT}"
+    printf 'location = /route-a {\n    proxy_pass http://127.0.0.1:%s/health;\n}\n' "${ORIGIN_BASE_PORT}"
+    printf 'location = /route-b {\n    proxy_pass http://127.0.0.1:%s/health;\n}\n' "$((ORIGIN_BASE_PORT + 1))"
+    printf 'location = /route-c {\n    proxy_pass http://127.0.0.1:%s/health;\n}\n' "$((ORIGIN_BASE_PORT + 2))"
+    for ((i = 0; i < ORIGIN_COUNT; i += 1)); do
+        printf 'location = /origin-%s {\n    proxy_pass http://127.0.0.1:%s/health;\n}\n' "$i" "$((ORIGIN_BASE_PORT + i))"
+    done
+    printf 'location = /tls-origin {\n    proxy_pass https://127.0.0.1:%s/health;\n}\n' "${TLS_ORIGIN_PORT}"
+} > "$CONFIG_FILE"
 
-location = /hot {
-    proxy_pass http://127.0.0.1:${ORIGIN_BASE_PORT}/health;
-}
-location = /route-a {
-    proxy_pass http://127.0.0.1:${ORIGIN_BASE_PORT}/health;
-}
-location = /route-b {
-    proxy_pass http://127.0.0.1:$((ORIGIN_BASE_PORT + 1))/health;
-}
-location = /route-c {
-    proxy_pass http://127.0.0.1:$((ORIGIN_BASE_PORT + 2))/health;
-}
-location = /origin-0 {
-    proxy_pass http://127.0.0.1:${ORIGIN_BASE_PORT}/health;
-}
-location = /origin-1 {
-    proxy_pass http://127.0.0.1:$((ORIGIN_BASE_PORT + 1))/health;
-}
-location = /origin-2 {
-    proxy_pass http://127.0.0.1:$((ORIGIN_BASE_PORT + 2))/health;
-}
-location = /origin-3 {
-    proxy_pass http://127.0.0.1:$((ORIGIN_BASE_PORT + 3))/health;
-}
-location = /origin-4 {
-    proxy_pass http://127.0.0.1:$((ORIGIN_BASE_PORT + 4))/health;
-}
-location = /origin-5 {
-    proxy_pass http://127.0.0.1:$((ORIGIN_BASE_PORT + 5))/health;
-}
-location = /tls-origin {
-    proxy_pass https://127.0.0.1:${TLS_ORIGIN_PORT}/health;
-}
-EOF
-
-TARDIGRADE_RATE_LIMIT_RPS=0 \
-TARDIGRADE_WORKER_THREADS="${THREADS}" \
-TARDIGRADE_MAX_REQUESTS_PER_CONNECTION=0 \
-TARDIGRADE_UPSTREAM_PROTOCOL=auto \
-TARDIGRADE_UPSTREAM_TLS_VERIFY=false \
-    "$BINARY" run -c "$CONFIG_FILE" >"${TMP_DIR}/tardigrade.log" 2>&1 &
-TARDIGRADE_PID="$!"
-wait_for_http "http://127.0.0.1:${LISTEN_PORT}/status/metrics" 150
-
-for path in hot route-a route-b route-c origin-0 origin-1 origin-2 origin-3 origin-4 origin-5 tls-origin; do
+start_gateway "$THREADS"
+for path in hot route-a route-b route-c tls-origin; do
     preflight_path "$path" || { echo "preflight failed for /${path}" >&2; exit 1; }
 done
-
-hot_json="$(run_measured_wrk hot-origin hot "$DURATION" "$CONNECTIONS" "$THREADS")"
-route_a_json="$(run_measured_wrk route-a route-a 3 8 2)"
-route_b_json="$(run_measured_wrk route-b route-b 3 8 2)"
-route_c_json="$(run_measured_wrk route-c route-c 3 8 2)"
-origins_json='[]'
-for path in origin-0 origin-1 origin-2 origin-3 origin-4 origin-5; do
-    row="$(run_measured_wrk "$path" "$path" 2 4 1)"
-    origins_json="$(jq --arg path "$path" --argjson row "$row" '. + [($row + {origin: $path})]' <<<"$origins_json")"
+for ((i = 0; i < ORIGIN_COUNT; i += 1)); do
+    preflight_path "origin-${i}" || { echo "preflight failed for /origin-${i}" >&2; exit 1; }
 done
-tls_json="$(run_measured_wrk tls-origin tls-origin "$DURATION" "$CONNECTIONS" "$THREADS")"
+
+hot_json="$(run_measured_wrk hot-origin hot "$DURATION" "$CONNECTIONS" "$THREADS" true)"
+route_a_json="$hot_json"
+route_b_json="$(run_measured_wrk route-b route-b 2 4 1 false)"
+route_c_json="$(run_measured_wrk route-c route-c 1 2 1 false)"
+
+origins_json='[]'
+for ((i = 0; i < ORIGIN_COUNT; i += 1)); do
+    before="${TMP_DIR}/origin-${i}-before.metrics"
+    after="${TMP_DIR}/origin-${i}-after.metrics"
+    current_metrics > "$before"
+    success=0
+    for _ in 1 2 3 4 5; do
+        if curl --max-time 2 -fsS "http://127.0.0.1:${LISTEN_PORT}/origin-${i}" >/dev/null; then
+            success=$((success + 1))
+        fi
+    done
+    current_metrics > "$after"
+    row="$(scenario_json "$success" null null 0 null null null "$before" "$after" 1)"
+    origins_json="$(jq --arg origin "origin-${i}" --argjson requested 5 --argjson successes "$success" --argjson row "$row" '. + [($row + {origin: $origin, requested: $requested, successes: $successes})]' <<<"$origins_json")"
+done
+
+tls_json="$(run_measured_wrk tls-origin tls-origin "$DURATION" "$CONNECTIONS" "$THREADS" true)"
 contention_json="$(worker_sweep_json)"
 
 jq -n \
@@ -400,17 +435,22 @@ jq -n \
             suite: "upstream-pool-distribution",
             duration_s: $duration,
             worker_threads: $threads,
-            note: "p99_ms is end-to-end latency. p99_ttfb_ms remains null until a first-byte load tool is wired into this matrix."
+            note: "p99_ttfb_ms is measured from k6 http_req_waiting where present; p99_ms is wrk end-to-end latency."
         },
         scenarios: {
             "uneven-route-distribution": {
                 covered: true,
-                routes: { "route-a": $route_a, "route-b": $route_b, "route-c": $route_c },
+                routes: {
+                    "route-a-hot": ($route_a + {requested_weight: 80}),
+                    "route-b-warm": ($route_b + {requested_weight: 15}),
+                    "route-c-cold": ($route_c + {requested_weight: 5})
+                },
                 errors: (($route_a.errors // 0) + ($route_b.errors // 0) + ($route_c.errors // 0))
             },
             "many-origins-low-volume": {
                 covered: true,
-                origins: 6,
+                origins: ($origins | length),
+                requests_per_origin: 5,
                 measurements: $origins,
                 errors: ($origins | map(.errors // 0) | add)
             },

--- a/benchmarks/competitive/upstream-pool-matrix.sh
+++ b/benchmarks/competitive/upstream-pool-matrix.sh
@@ -21,6 +21,7 @@ TMP_DIR=""
 TARDIGRADE_PID=""
 TLS_ORIGIN_PID=""
 ORIGIN_PIDS=()
+LOCK_METRICS=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -288,9 +289,9 @@ scenario_json() {
             local_reuse: $local_reuse,
             cross_worker_reuse: $cross_worker_reuse,
             stale_retries: $stale_retries,
-            pool_lock_wait_ns_total: $lock_wait_ns,
-            pool_lock_acquires_total: $lock_acquires,
-            pool_lock_wait_ns_per_request: (if $request_count > 0 then ($lock_wait_ns / $request_count) else null end),
+            pool_lock_wait_ns_total: (if $lock_acquires > 0 then $lock_wait_ns else null end),
+            pool_lock_acquires_total: (if $lock_acquires > 0 then $lock_acquires else null end),
+            pool_lock_wait_ns_per_request: (if $lock_acquires > 0 and $request_count > 0 then ($lock_wait_ns / $request_count) else null end),
             pool_lock_wait_ns_per_acquire: (if $lock_acquires > 0 then ($lock_wait_ns / $lock_acquires) else null end),
             new_connections_per_sec: (if $elapsed > 0 then ($new_connections / $elapsed) else null end),
             reuse_ratio: (if ($new_connections + $reused_connections) > 0 then ($reused_connections / ($new_connections + $reused_connections)) else null end),
@@ -338,6 +339,7 @@ start_gateway() {
     TARDIGRADE_RATE_LIMIT_RPS=0 \
     TARDIGRADE_WORKER_THREADS="$workers" \
     TARDIGRADE_MAX_REQUESTS_PER_CONNECTION=1000000 \
+    TARDIGRADE_UPSTREAM_POOL_LOCK_METRICS="$LOCK_METRICS" \
     TARDIGRADE_UPSTREAM_PROTOCOL=http1 \
     TARDIGRADE_UPSTREAM_TLS_VERIFY=false \
         "$BINARY" run -c "$CONFIG_FILE" >"${TMP_DIR}/tardigrade.log" 2>&1 &
@@ -351,6 +353,7 @@ worker_sweep_json() {
     max="$cpus"
     result='[]'
     workers=1
+    LOCK_METRICS=true
     while [[ "$workers" -le "$max" ]]; do
         start_gateway "$workers"
         sweep_connections="$CONNECTIONS"
@@ -359,12 +362,33 @@ worker_sweep_json() {
         result="$(jq --argjson row "$row" --argjson workers "$workers" '. + [($row + {worker_threads: $workers})]' <<<"$result")"
         workers=$((workers * 2))
     done
-    jq -n --argjson rows "$result" '{
+    LOCK_METRICS=false
+    jq -n --argjson rows "$result" '
+    ($rows[0] // {}) as $base |
+    ($rows | map(. + {
+        pool_lock_wait_fraction_of_p99: (
+            if (.p99_ms // 0) > 0 and (.pool_lock_wait_ns_per_request // null) != null
+            then (.pool_lock_wait_ns_per_request / (.p99_ms * 1000000.0))
+            else null
+            end
+        ),
+        throughput_drop_from_1w: (
+            if ($base.rps // 0) > 0 and (.worker_threads // 1) > ($base.worker_threads // 1)
+            then (($base.rps - (.rps // 0)) / $base.rps)
+            else 0
+            end
+        )
+    })) as $annotated |
+    ($annotated | map(.pool_lock_wait_fraction_of_p99 // 0) | max) as $max_lock_fraction |
+    ($annotated | map(.throughput_drop_from_1w // 0) | max) as $max_throughput_drop |
+    {
         covered: true,
-        sharding_justified: (($rows | map(.pool_lock_wait_ns_per_request // 0) | max) > 50000),
-        sharding_threshold_wait_ns_per_request: 50000,
-        reason: "Derived from measured shared upstream-pool mutex wait nanoseconds per request across the worker sweep; sharding is justified when the worst row exceeds the threshold.",
-        measurements: $rows
+        sharding_justified: ($max_lock_fraction >= 0.05 and $max_throughput_drop >= 0.10),
+        sharding_decision_rule: "Shard only when measured pool-lock wait reaches at least 5% of p99 latency and higher-worker rows show at least 10% throughput regression from the 1-worker baseline.",
+        max_pool_lock_wait_fraction_of_p99: $max_lock_fraction,
+        max_throughput_drop_from_1w: $max_throughput_drop,
+        reason: "Derived from opt-in shared upstream-pool mutex wait counters correlated with throughput and p99 movement across the worker sweep.",
+        measurements: $annotated
     }'
 }
 
@@ -458,13 +482,19 @@ origins_elapsed="$(awk -v s="$origins_start_ns" -v e="$origins_end_ns" 'BEGIN { 
 origins_successes="$(jq '[.[].successes] | add' <<<"$origin_counts")"
 origins_failures="$(jq '[.[].failures] | add' <<<"$origin_counts")"
 origins_rps="$(awk -v successes="$origins_successes" -v elapsed="$origins_elapsed" 'BEGIN { if (elapsed > 0) printf "%.3f", successes / elapsed; else print 0 }')"
-origins_ttfb="$(run_k6_ttfb many-origins-ttfb origin-0 1 1)"
-origins_aggregate="$(scenario_json "$origins_rps" null "$origins_ttfb" "$origins_failures" "$origins_cpu_pct" "$origins_rss_mb" "$origins_open_fds" "$origins_before" "$origins_after" "$origins_elapsed")"
-origins_json="$(jq --argjson aggregate "$origins_aggregate" --argjson elapsed "$origins_elapsed" '
-    map(. + $aggregate + {
+origins_aggregate="$(scenario_json "$origins_rps" null null "$origins_failures" "$origins_cpu_pct" "$origins_rss_mb" "$origins_open_fds" "$origins_before" "$origins_after" "$origins_elapsed")"
+origins_json="$(jq --argjson elapsed "$origins_elapsed" '
+    map({
+        origin: .origin,
+        requested: .requested,
+        successes: .successes,
+        failures: .failures,
+        covered: (.failures == 0),
         rps: (if $elapsed > 0 then (.successes / $elapsed) else 0 end),
         elapsed_s: $elapsed,
-        errors: .failures
+        errors: .failures,
+        p99_ms: null,
+        p99_ttfb_ms: null
     })
 ' <<<"$origin_counts")"
 
@@ -501,7 +531,7 @@ jq -n \
                 errors: (($route_a.errors // 0) + ($route_b.errors // 0) + ($route_c.errors // 0))
             },
             "many-origins-low-volume": ($origins_aggregate + {
-                covered: true,
+                covered: (($origins | map(.errors // 0) | add) == 0),
                 origins: ($origins | length),
                 requests_per_origin: 5,
                 measurements: $origins,

--- a/benchmarks/competitive/upstream-pool-matrix.sh
+++ b/benchmarks/competitive/upstream-pool-matrix.sh
@@ -364,30 +364,34 @@ worker_sweep_json() {
     done
     LOCK_METRICS=false
     jq -n --argjson rows "$result" '
-    ($rows[0] // {}) as $base |
-    ($rows | map(. + {
+    def lower_peak($rows; $idx):
+        if $idx <= 0 then null
+        else ($rows[0:$idx] | map(.rps // 0) | max)
+        end;
+    ($rows | to_entries | map(.value as $row | lower_peak($rows; .key) as $peak | $row + {
         pool_lock_wait_fraction_of_p99: (
-            if (.p99_ms // 0) > 0 and (.pool_lock_wait_ns_per_request // null) != null
-            then (.pool_lock_wait_ns_per_request / (.p99_ms * 1000000.0))
+            if ($row.p99_ms // 0) > 0 and ($row.pool_lock_wait_ns_per_request // null) != null
+            then ($row.pool_lock_wait_ns_per_request / ($row.p99_ms * 1000000.0))
             else null
             end
         ),
-        throughput_drop_from_1w: (
-            if ($base.rps // 0) > 0 and (.worker_threads // 1) > ($base.worker_threads // 1)
-            then (($base.rps - (.rps // 0)) / $base.rps)
+        lower_core_peak_rps: $peak,
+        throughput_drop_from_lower_core_peak: (
+            if ($peak // 0) > 0 and ($row.worker_threads // 1) > 1 and ($row.rps // 0) < $peak
+            then (($peak - ($row.rps // 0)) / $peak)
             else 0
             end
         )
     })) as $annotated |
     ($annotated | map(.pool_lock_wait_fraction_of_p99 // 0) | max) as $max_lock_fraction |
-    ($annotated | map(.throughput_drop_from_1w // 0) | max) as $max_throughput_drop |
+    ($annotated | map(.throughput_drop_from_lower_core_peak // 0) | max) as $max_throughput_drop |
     {
         covered: true,
-        sharding_justified: ($max_lock_fraction >= 0.05 and $max_throughput_drop >= 0.10),
-        sharding_decision_rule: "Shard only when measured pool-lock wait reaches at least 5% of p99 latency and higher-worker rows show at least 10% throughput regression from the 1-worker baseline.",
+        sharding_justified: any($annotated[]; ((.worker_threads // 1) > 1) and ((.pool_lock_wait_fraction_of_p99 // 0) >= 0.05) and ((.throughput_drop_from_lower_core_peak // 0) >= 0.10)),
+        sharding_decision_rule: "Shard only when the same higher-worker row shows pool-lock wait at least 5% of p99 latency and at least 10% throughput regression from the best lower-worker throughput.",
         max_pool_lock_wait_fraction_of_p99: $max_lock_fraction,
-        max_throughput_drop_from_1w: $max_throughput_drop,
-        reason: "Derived from opt-in shared upstream-pool mutex wait counters correlated with throughput and p99 movement across the worker sweep.",
+        max_throughput_drop_from_lower_core_peak: $max_throughput_drop,
+        reason: "Derived from opt-in shared upstream-pool mutex wait counters correlated on the same worker-count row with throughput regression from the lower-core peak.",
         measurements: $annotated
     }'
 }
@@ -500,7 +504,9 @@ origins_json="$(jq --argjson elapsed "$origins_elapsed" '
 
 start_gateway "$THREADS"
 tls_json="$(run_measured_wrk tls-origin tls-origin "$DURATION" "$CONNECTIONS" "$THREADS" true)"
-contention_json="$(worker_sweep_json)"
+contention_file="${TMP_DIR}/pool-contention.json"
+worker_sweep_json > "$contention_file"
+contention_json="$(cat "$contention_file")"
 
 jq -n \
     --argjson duration "$DURATION" \

--- a/benchmarks/competitive/upstream-pool-matrix.sh
+++ b/benchmarks/competitive/upstream-pool-matrix.sh
@@ -113,9 +113,27 @@ cpu_time_to_seconds() {
 }
 
 process_tree_cpu_seconds() {
-    local pids
+    local pids clk total_ticks pid
     pids="$(process_tree_pids "$TARDIGRADE_PID" | paste -sd, -)"
     [[ -n "$pids" ]] || pids="$TARDIGRADE_PID"
+    if [[ "$(uname -s 2>/dev/null || true)" == "Linux" ]]; then
+        clk="$(getconf CLK_TCK 2>/dev/null || true)"
+        if [[ "$clk" =~ ^[0-9]+$ && "$clk" -gt 0 ]]; then
+            total_ticks=0
+            IFS=, read -ra _cpu_pids <<< "$pids"
+            for pid in "${_cpu_pids[@]}"; do
+                [[ -r "/proc/${pid}/stat" ]] || continue
+                total_ticks=$((total_ticks + $(awk '{
+                    close = match($0, /\) /)
+                    rest = substr($0, close + 2)
+                    split(rest, f, " ")
+                    print (f[12] + f[13])
+                }' "/proc/${pid}/stat")))
+            done
+            awk -v ticks="$total_ticks" -v clk="$clk" 'BEGIN { printf "%.6f", ticks / clk }'
+            return
+        fi
+    fi
     ps -p "$pids" -o time= 2>/dev/null | cpu_time_to_seconds
 }
 
@@ -229,22 +247,31 @@ export const options = { vus: ${vus}, duration: '${duration}s', summaryTrendStat
 export default function () { http.get('http://127.0.0.1:${LISTEN_PORT}/${path}'); }
 EOF
     k6 run --quiet --summary-export "$summary" "$script" >/dev/null
-    jq -r '.metrics.http_req_waiting.values["p(99)"] // .metrics.http_req_waiting["p(99)"] // .metrics.http_req_waiting["p(95)"] // null' "$summary"
+    jq -e -r '
+        (.metrics.http_req_failed.values.rate // .metrics.http_req_failed.rate // .metrics.http_req_failed.value // 0) as $failed
+        | if $failed != 0 then error("k6 http_req_failed was non-zero: \($failed)") else
+            (.metrics.http_req_waiting.values["p(99)"] // .metrics.http_req_waiting["p(99)"] // error("k6 summary is missing http_req_waiting p(99)"))
+          end
+    ' "$summary"
 }
 
 scenario_json() {
     local rps="$1" p99="$2" p99_ttfb="$3" errors="$4" cpu_pct="$5" rss_mb="$6" open_fds="$7" before="$8" after="$9" elapsed="${10}"
-    local new_c reused local_r cross_r stale
+    local new_c reused local_r cross_r stale lock_wait_ns lock_acquires request_count
     new_c="$(metric_delta "$before" "$after" tardigrade_upstream_connections_new_total)"
     reused="$(metric_delta "$before" "$after" tardigrade_upstream_connections_reused_total)"
     local_r="$(metric_delta "$before" "$after" tardigrade_upstream_connections_reused_local_total)"
     cross_r="$(metric_delta "$before" "$after" tardigrade_upstream_connections_reused_cross_worker_total)"
     stale="$(metric_delta "$before" "$after" tardigrade_upstream_stale_retries_total)"
+    lock_wait_ns="$(metric_delta "$before" "$after" tardigrade_upstream_pool_lock_wait_ns_total)"
+    lock_acquires="$(metric_delta "$before" "$after" tardigrade_upstream_pool_lock_acquires_total)"
+    request_count="$(awk -v rps="$rps" -v elapsed="$elapsed" 'BEGIN { if (rps > 0 && elapsed > 0) printf "%.0f", rps * elapsed; else print 0 }')"
     jq -n \
         --argjson rps "$rps" --argjson p99 "$p99" --argjson p99_ttfb "$p99_ttfb" --argjson errors "$errors" \
         --argjson cpu "$cpu_pct" --argjson rss "$rss_mb" --argjson fds "$open_fds" --argjson elapsed "$elapsed" \
         --argjson new_connections "$new_c" --argjson reused_connections "$reused" \
         --argjson local_reuse "$local_r" --argjson cross_worker_reuse "$cross_r" --argjson stale_retries "$stale" \
+        --argjson lock_wait_ns "$lock_wait_ns" --argjson lock_acquires "$lock_acquires" --argjson request_count "$request_count" \
         '{
             covered: true,
             rps: $rps,
@@ -261,6 +288,10 @@ scenario_json() {
             local_reuse: $local_reuse,
             cross_worker_reuse: $cross_worker_reuse,
             stale_retries: $stale_retries,
+            pool_lock_wait_ns_total: $lock_wait_ns,
+            pool_lock_acquires_total: $lock_acquires,
+            pool_lock_wait_ns_per_request: (if $request_count > 0 then ($lock_wait_ns / $request_count) else null end),
+            pool_lock_wait_ns_per_acquire: (if $lock_acquires > 0 then ($lock_wait_ns / $lock_acquires) else null end),
             new_connections_per_sec: (if $elapsed > 0 then ($new_connections / $elapsed) else null end),
             reuse_ratio: (if ($new_connections + $reused_connections) > 0 then ($reused_connections / ($new_connections + $reused_connections)) else null end),
             cross_worker_reuse_ratio: (if $reused_connections > 0 then ($cross_worker_reuse / $reused_connections) else null end)
@@ -306,12 +337,12 @@ start_gateway() {
     [[ -n "$TARDIGRADE_PID" ]] && { kill "$TARDIGRADE_PID" 2>/dev/null || true; wait "$TARDIGRADE_PID" 2>/dev/null || true; }
     TARDIGRADE_RATE_LIMIT_RPS=0 \
     TARDIGRADE_WORKER_THREADS="$workers" \
-    TARDIGRADE_MAX_REQUESTS_PER_CONNECTION=0 \
+    TARDIGRADE_MAX_REQUESTS_PER_CONNECTION=1000000 \
     TARDIGRADE_UPSTREAM_PROTOCOL=http1 \
     TARDIGRADE_UPSTREAM_TLS_VERIFY=false \
         "$BINARY" run -c "$CONFIG_FILE" >"${TMP_DIR}/tardigrade.log" 2>&1 &
     TARDIGRADE_PID="$!"
-    sleep 1
+    wait_for_http "http://127.0.0.1:${LISTEN_PORT}/status/metrics" 150
 }
 
 worker_sweep_json() {
@@ -329,9 +360,10 @@ worker_sweep_json() {
         workers=$((workers * 2))
     done
     jq -n --argjson rows "$result" '{
-        covered: false,
-        sharding_justified: "undetermined",
-        reason: "Gateway exports no direct pool-lock wait/contention counter yet; this sweep records worker-count throughput, p99, TTFB, CPU/request, reuse, and FD evidence without claiming contention closure.",
+        covered: true,
+        sharding_justified: (($rows | map(.pool_lock_wait_ns_per_request // 0) | max) > 50000),
+        sharding_threshold_wait_ns_per_request: 50000,
+        reason: "Derived from measured shared upstream-pool mutex wait nanoseconds per request across the worker sweep; sharding is justified when the worst row exceeds the threshold.",
         measurements: $rows
     }'
 }
@@ -389,7 +421,7 @@ wait_for_http "https://127.0.0.1:${TLS_ORIGIN_PORT}/health"
 } > "$CONFIG_FILE"
 
 start_gateway "$THREADS"
-for path in hot route-a route-b route-c tls-origin; do
+for path in hot route-a route-b route-c; do
     preflight_path "$path" || { echo "preflight failed for /${path}" >&2; exit 1; }
 done
 for ((i = 0; i < ORIGIN_COUNT; i += 1)); do
@@ -401,22 +433,42 @@ route_a_json="$hot_json"
 route_b_json="$(run_measured_wrk route-b route-b 2 4 1 false)"
 route_c_json="$(run_measured_wrk route-c route-c 1 2 1 false)"
 
-origins_json='[]'
+origins_before="${TMP_DIR}/origins-before.metrics"
+origins_after="${TMP_DIR}/origins-after.metrics"
+current_metrics > "$origins_before"
+read -r origins_mon_pid origins_mon_file origins_cpu_before origins_start_ns < <(start_monitor)
+origin_counts='[]'
 for ((i = 0; i < ORIGIN_COUNT; i += 1)); do
-    before="${TMP_DIR}/origin-${i}-before.metrics"
-    after="${TMP_DIR}/origin-${i}-after.metrics"
-    current_metrics > "$before"
     success=0
+    failures=0
     for _ in 1 2 3 4 5; do
         if curl --max-time 2 -fsS "http://127.0.0.1:${LISTEN_PORT}/origin-${i}" >/dev/null; then
             success=$((success + 1))
+        else
+            failures=$((failures + 1))
         fi
     done
-    current_metrics > "$after"
-    row="$(scenario_json "$success" null null 0 null null null "$before" "$after" 1)"
-    origins_json="$(jq --arg origin "origin-${i}" --argjson requested 5 --argjson successes "$success" --argjson row "$row" '. + [($row + {origin: $origin, requested: $requested, successes: $successes})]' <<<"$origins_json")"
+    origin_counts="$(jq --arg origin "origin-${i}" --argjson requested 5 --argjson successes "$success" --argjson failures "$failures" \
+        '. + [{origin: $origin, requested: $requested, successes: $successes, failures: $failures}]' <<<"$origin_counts")"
 done
+origins_end_ns="$(monotonic_ns)"
+read -r origins_cpu_pct origins_rss_mb origins_open_fds < <(stop_monitor "$origins_mon_pid" "$origins_mon_file" "$origins_cpu_before" "$origins_start_ns")
+current_metrics > "$origins_after"
+origins_elapsed="$(awk -v s="$origins_start_ns" -v e="$origins_end_ns" 'BEGIN { printf "%.3f", (e - s) / 1000000000 }')"
+origins_successes="$(jq '[.[].successes] | add' <<<"$origin_counts")"
+origins_failures="$(jq '[.[].failures] | add' <<<"$origin_counts")"
+origins_rps="$(awk -v successes="$origins_successes" -v elapsed="$origins_elapsed" 'BEGIN { if (elapsed > 0) printf "%.3f", successes / elapsed; else print 0 }')"
+origins_ttfb="$(run_k6_ttfb many-origins-ttfb origin-0 1 1)"
+origins_aggregate="$(scenario_json "$origins_rps" null "$origins_ttfb" "$origins_failures" "$origins_cpu_pct" "$origins_rss_mb" "$origins_open_fds" "$origins_before" "$origins_after" "$origins_elapsed")"
+origins_json="$(jq --argjson aggregate "$origins_aggregate" --argjson elapsed "$origins_elapsed" '
+    map(. + $aggregate + {
+        rps: (if $elapsed > 0 then (.successes / $elapsed) else 0 end),
+        elapsed_s: $elapsed,
+        errors: .failures
+    })
+' <<<"$origin_counts")"
 
+start_gateway "$THREADS"
 tls_json="$(run_measured_wrk tls-origin tls-origin "$DURATION" "$CONNECTIONS" "$THREADS" true)"
 contention_json="$(worker_sweep_json)"
 
@@ -427,6 +479,7 @@ jq -n \
     --argjson route_a "$route_a_json" \
     --argjson route_b "$route_b_json" \
     --argjson route_c "$route_c_json" \
+    --argjson origins_aggregate "$origins_aggregate" \
     --argjson origins "$origins_json" \
     --argjson tls "$tls_json" \
     --argjson contention "$contention_json" \
@@ -447,13 +500,13 @@ jq -n \
                 },
                 errors: (($route_a.errors // 0) + ($route_b.errors // 0) + ($route_c.errors // 0))
             },
-            "many-origins-low-volume": {
+            "many-origins-low-volume": ($origins_aggregate + {
                 covered: true,
                 origins: ($origins | length),
                 requests_per_origin: 5,
                 measurements: $origins,
                 errors: ($origins | map(.errors // 0) | add)
-            },
+            }),
             "hot-origin-many-workers": $hot,
             "upstream-tls-handshake-reuse": $tls,
             "pool-contention": $contention

--- a/benchmarks/competitive/upstream-pool-matrix.sh
+++ b/benchmarks/competitive/upstream-pool-matrix.sh
@@ -2,10 +2,11 @@
 # Upstream-pool distribution matrix for the competitive benchmark suite.
 #
 # Covers the #147 validation matrix absorbed by #149: uneven route traffic,
-# many low-volume origins, one hot origin with many workers, local vs
-# cross-worker reuse, new upstream connections/sec, CPU/request, p99 TTFB, and
-# contention notes. TLS upstream reuse is recorded as unsupported unless this
-# script is extended with a TLS-capable origin fixture for the local platform.
+# many low-volume origins, one hot origin with many workers, upstream TLS
+# handshake/reuse, local vs cross-worker reuse, new upstream connections/sec,
+# CPU/request, p99 latency, and higher-worker contention evidence. The gateway
+# does not currently expose a direct pool-lock wait counter, so the sharding
+# decision is reported as undetermined with measured sweep data.
 
 set -euo pipefail
 
@@ -20,6 +21,7 @@ THREADS="8"
 OUTPUT=""
 TMP_DIR=""
 TARDIGRADE_PID=""
+TLS_ORIGIN_PID=""
 ORIGIN_PIDS=()
 
 while [[ $# -gt 0 ]]; do
@@ -32,7 +34,7 @@ while [[ $# -gt 0 ]]; do
         --threads) THREADS="$2"; shift 2 ;;
         --output) OUTPUT="$2"; shift 2 ;;
         --help)
-            sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+            sed -n '2,11p' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         *) echo "unknown arg: $1" >&2; exit 2 ;;
@@ -44,7 +46,7 @@ if [[ -z "$OUTPUT" ]]; then
     exit 1
 fi
 
-for tool in wrk curl python3 jq awk ps pgrep; do
+for tool in wrk curl python3 jq awk ps pgrep openssl nghttpd; do
     command -v "$tool" >/dev/null 2>&1 || { echo "missing required tool: $tool" >&2; exit 1; }
 done
 if [[ ! -x "$BINARY" ]]; then
@@ -54,6 +56,18 @@ fi
 
 cleanup() {
     local status=$?
+    if [[ "$status" -ne 0 && -n "$TMP_DIR" ]]; then
+        if [[ -f "${TMP_DIR}/tardigrade.log" ]]; then
+            echo ""
+            echo "---- upstream-matrix tardigrade.log ----" >&2
+            tail -n 120 "${TMP_DIR}/tardigrade.log" >&2
+        fi
+        if [[ -f "${TMP_DIR}/tls-origin.log" ]]; then
+            echo ""
+            echo "---- upstream-matrix tls-origin.log ----" >&2
+            tail -n 80 "${TMP_DIR}/tls-origin.log" >&2
+        fi
+    fi
     if [[ -n "$TARDIGRADE_PID" ]]; then
         kill "$TARDIGRADE_PID" 2>/dev/null || true
         wait "$TARDIGRADE_PID" 2>/dev/null || true
@@ -63,15 +77,19 @@ cleanup() {
         kill "$pid" 2>/dev/null || true
         wait "$pid" 2>/dev/null || true
     done
+    if [[ -n "$TLS_ORIGIN_PID" ]]; then
+        kill "$TLS_ORIGIN_PID" 2>/dev/null || true
+        wait "$TLS_ORIGIN_PID" 2>/dev/null || true
+    fi
     [[ -n "$TMP_DIR" ]] && rm -rf "$TMP_DIR"
     exit "$status"
 }
 trap cleanup EXIT
 
 wait_for_http() {
-    local url="$1" i
-    for ((i = 0; i < 50; i += 1)); do
-        curl -fsS "$url" >/dev/null 2>&1 && return 0
+    local url="$1" attempts="${2:-50}" i
+    for ((i = 0; i < attempts; i += 1)); do
+        curl -fsSk "$url" >/dev/null 2>&1 && return 0
         sleep 0.2
     done
     echo "timed out waiting for ${url}" >&2
@@ -88,25 +106,161 @@ process_tree_pids() {
     done
 }
 
-sample_cpu_rss() {
-    process_tree_pids "$TARDIGRADE_PID" | paste -sd, - | {
-        read -r pids
-        ps -p "$pids" -o rss= -o %cpu= 2>/dev/null |
-            awk '{ rss += $1; cpu += $2 } END { printf "%.2f %.2f", cpu, rss / 1024 }'
-    }
+count_open_fds_for_pids() {
+    local pids_csv="$1"
+    local total=0 pid count
+    IFS=, read -ra _fd_pids <<< "$pids_csv"
+    for pid in "${_fd_pids[@]}"; do
+        [[ -n "$pid" ]] || continue
+        if [[ -d "/proc/${pid}/fd" ]]; then
+            count=$(find "/proc/${pid}/fd" -maxdepth 1 -type l 2>/dev/null | wc -l | tr -d ' ')
+        elif command -v lsof >/dev/null 2>&1; then
+            count=$(lsof -n -P -p "$pid" 2>/dev/null | awk 'NR > 1 { count += 1 } END { print count + 0 }')
+        else
+            count=""
+        fi
+        [[ "$count" =~ ^[0-9]+$ ]] && total=$((total + count))
+    done
+    if [[ "$total" -gt 0 ]]; then
+        printf '%s\n' "$total"
+    else
+        printf 'null\n'
+    fi
 }
 
-metric_field() {
-    local metrics="$1"
-    local key="$2"
-    printf '%s\n' "$metrics" | awk -v k="$key" '$1 == k { print $2; exit }'
+monitor_process_tree() {
+    local pid="$1" sample_interval_s="$2" outfile="$3"
+    while kill -0 "$pid" 2>/dev/null; do
+        process_tree_pids "$pid" | paste -sd, - | {
+            read -r pids
+            [[ -n "$pids" ]] || pids="$pid"
+            local fds
+            fds="$(count_open_fds_for_pids "$pids")"
+            ps -p "$pids" -o rss= -o %cpu= 2>/dev/null |
+                awk -v fds="$fds" '{ rss += $1; cpu += $2 } END { if (rss > 0 || cpu > 0) print rss, cpu, fds }' >> "$outfile"
+        }
+        sleep "$sample_interval_s"
+    done
 }
 
-run_wrk() {
-    local label="$1"
-    local url="$2"
-    local raw rps p99
-    raw="$(wrk --latency -s "${BENCH_DIR}/wrk-summary.lua" -t"${THREADS}" -c"${CONNECTIONS}" -d"${DURATION}s" "$url" 2>&1 || true)"
+start_monitor() {
+    local file
+    file="$(mktemp /tmp/tardigrade-upstream-monitor-XXXXXX)"
+    monitor_process_tree "$TARDIGRADE_PID" "0.500" "$file" &
+    printf '%s %s\n' "$!" "$file"
+}
+
+stop_monitor() {
+    local pid="$1" file="$2"
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    awk '
+        NF >= 2 {
+            rss = $1; cpu = $2
+            cpu_sum += cpu; cpu_count += 1
+            if (rss > rss_max) rss_max = rss
+        }
+        NF >= 3 && $3 ~ /^[0-9]+$/ && $3 > fd_max { fd_max = $3 }
+        END {
+            if (cpu_count > 0) printf "%.2f %.2f ", cpu_sum / cpu_count, rss_max / 1024; else printf "null null ";
+            if (fd_max > 0) printf "%d\n", fd_max; else printf "null\n";
+        }
+    ' "$file"
+    rm -f "$file"
+}
+
+current_metrics() {
+    curl -fsS "http://127.0.0.1:${LISTEN_PORT}/status/metrics"
+}
+
+metric_from_file() {
+    local file="$1" key="$2"
+    awk -v k="$key" '$1 == k { print $2; exit }' "$file"
+}
+
+metric_delta() {
+    local before="$1" after="$2" key="$3"
+    local b a
+    b="$(metric_from_file "$before" "$key")"; b="${b:-0}"
+    a="$(metric_from_file "$after" "$key")"; a="${a:-0}"
+    awk -v a="$a" -v b="$b" 'BEGIN { print a - b }'
+}
+
+wrk_error_count() {
+    awk '
+        /Non-2xx/ {
+            for (i = 1; i <= NF; i++) if ($i ~ /^[0-9]+$/) total += $i
+        }
+        /Socket errors:/ {
+            for (i = 1; i <= NF; i++) {
+                gsub(/,/, "", $i)
+                if ($i ~ /^[0-9]+$/) total += $i
+            }
+        }
+        END { print total + 0 }
+    '
+}
+
+preflight_path() {
+    local path="$1"
+    curl -fsS "http://127.0.0.1:${LISTEN_PORT}/${path}" | grep -qx 'ok'
+}
+
+scenario_json() {
+    local rps="$1" p99="$2" errors="$3" cpu_pct="$4" rss_mb="$5" open_fds="$6" before="$7" after="$8" elapsed="$9"
+    local new_c reused local_r cross_r stale
+    new_c="$(metric_delta "$before" "$after" tardigrade_upstream_connections_new_total)"
+    reused="$(metric_delta "$before" "$after" tardigrade_upstream_connections_reused_total)"
+    local_r="$(metric_delta "$before" "$after" tardigrade_upstream_connections_reused_local_total)"
+    cross_r="$(metric_delta "$before" "$after" tardigrade_upstream_connections_reused_cross_worker_total)"
+    stale="$(metric_delta "$before" "$after" tardigrade_upstream_stale_retries_total)"
+    jq -n \
+        --argjson rps "$rps" \
+        --argjson p99 "$p99" \
+        --argjson errors "$errors" \
+        --argjson cpu "$cpu_pct" \
+        --argjson rss "$rss_mb" \
+        --argjson fds "$open_fds" \
+        --argjson elapsed "$elapsed" \
+        --argjson new_connections "$new_c" \
+        --argjson reused_connections "$reused" \
+        --argjson local_reuse "$local_r" \
+        --argjson cross_worker_reuse "$cross_r" \
+        --argjson stale_retries "$stale" \
+        '{
+            covered: true,
+            rps: $rps,
+            p99_ms: $p99,
+            p99_ttfb_ms: null,
+            errors: $errors,
+            elapsed_s: $elapsed,
+            cpu_pct_avg: $cpu,
+            cpu_ms_per_request: (if $rps > 0 and $cpu != null then (($cpu / 100.0) / $rps * 1000.0) else null end),
+            rss_mb_peak: $rss,
+            open_fds_peak: $fds,
+            new_connections: $new_connections,
+            reused_connections: $reused_connections,
+            local_reuse: $local_reuse,
+            cross_worker_reuse: $cross_worker_reuse,
+            stale_retries: $stale_retries,
+            new_connections_per_sec: (if $elapsed > 0 then ($new_connections / $elapsed) else null end),
+            reuse_ratio: (if ($new_connections + $reused_connections) > 0 then ($reused_connections / ($new_connections + $reused_connections)) else null end),
+            cross_worker_reuse_ratio: (if $reused_connections > 0 then ($cross_worker_reuse / $reused_connections) else null end)
+        }'
+}
+
+run_measured_wrk() {
+    local label="$1" path="$2" duration="$3" connections="$4" threads="$5"
+    local before after mon_pid mon_file raw summary rps p99 errors start_ns end_ns elapsed cpu_pct rss_mb open_fds
+    before="${TMP_DIR}/${label}-before.metrics"
+    after="${TMP_DIR}/${label}-after.metrics"
+    current_metrics > "$before"
+    read -r mon_pid mon_file < <(start_monitor)
+    start_ns="$(date +%s%N)"
+    raw="$(wrk --latency -s "${BENCH_DIR}/wrk-summary.lua" -t"${threads}" -c"${connections}" -d"${duration}s" "http://127.0.0.1:${LISTEN_PORT}/${path}" 2>&1 || true)"
+    end_ns="$(date +%s%N)"
+    read -r cpu_pct rss_mb open_fds < <(stop_monitor "$mon_pid" "$mon_file")
+    current_metrics > "$after"
     summary="$(printf '%s\n' "$raw" | sed -n 's/^WRK_SUMMARY //p' | tail -1)"
     if [[ -z "$summary" ]]; then
         echo "missing wrk summary for ${label}" >&2
@@ -115,11 +269,41 @@ run_wrk() {
     fi
     rps="$(jq -r '.rps // 0' <<<"$summary")"
     p99="$(jq -r '.p99_ms // null' <<<"$summary")"
-    printf '%s %s\n' "$rps" "$p99"
+    errors="$(printf '%s\n' "$raw" | wrk_error_count)"
+    if [[ "$errors" != "0" ]]; then
+        echo "wrk reported ${errors} errors for ${label}" >&2
+        echo "$raw" >&2
+        exit 1
+    fi
+    elapsed="$(awk -v s="$start_ns" -v e="$end_ns" 'BEGIN { printf "%.3f", (e - s) / 1000000000 }')"
+    scenario_json "$rps" "$p99" "$errors" "$cpu_pct" "$rss_mb" "$open_fds" "$before" "$after" "$elapsed"
+}
+
+worker_sweep_json() {
+    local cpus max workers result row
+    cpus="$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)"
+    max="$cpus"
+    [[ "$max" -gt 8 ]] && max=8
+    result='[]'
+    workers=1
+    while [[ "$workers" -le "$max" ]]; do
+        local sweep_connections="$CONNECTIONS"
+        [[ "$sweep_connections" -lt "$workers" ]] && sweep_connections="$workers"
+        row="$(run_measured_wrk "pool-contention-${workers}w" hot 2 "$sweep_connections" "$workers")"
+        result="$(jq --argjson row "$row" --argjson workers "$workers" '. + [($row + {worker_threads: $workers})]' <<<"$result")"
+        workers=$((workers * 2))
+    done
+    jq -n --argjson rows "$result" '{
+        covered: true,
+        sharding_justified: "undetermined",
+        reason: "No direct pool-lock wait/contention counter is currently exported; throughput, p99, CPU/request, reuse, and FD data are recorded by worker-count sweep.",
+        measurements: $rows
+    }'
 }
 
 TMP_DIR="$(mktemp -d /tmp/tardigrade-upstream-matrix-XXXX)"
 CONFIG_FILE="${TMP_DIR}/upstream-matrix.conf"
+TLS_ORIGIN_PORT=$((ORIGIN_BASE_PORT + 20))
 
 for i in 0 1 2 3 4 5; do
     port=$((ORIGIN_BASE_PORT + i))
@@ -127,6 +311,15 @@ for i in 0 1 2 3 4 5; do
     ORIGIN_PIDS+=("$!")
     wait_for_http "http://127.0.0.1:${port}/health"
 done
+
+openssl req -x509 -newkey rsa:2048 -nodes -days 2 -subj "/CN=localhost" \
+    -keyout "${TMP_DIR}/tls-origin.key" -out "${TMP_DIR}/tls-origin.crt" >/dev/null 2>&1
+mkdir -p "${TMP_DIR}/tls-docroot"
+printf 'ok\n' > "${TMP_DIR}/tls-docroot/health"
+nghttpd -d "${TMP_DIR}/tls-docroot" "${TLS_ORIGIN_PORT}" "${TMP_DIR}/tls-origin.key" "${TMP_DIR}/tls-origin.crt" \
+    >"${TMP_DIR}/tls-origin.log" 2>&1 &
+TLS_ORIGIN_PID="$!"
+wait_for_http "https://127.0.0.1:${TLS_ORIGIN_PORT}/health"
 
 cat > "$CONFIG_FILE" <<EOF
 listen ${LISTEN_PORT};
@@ -162,75 +355,68 @@ location = /origin-4 {
 location = /origin-5 {
     proxy_pass http://127.0.0.1:$((ORIGIN_BASE_PORT + 5))/health;
 }
+location = /tls-origin {
+    proxy_pass https://127.0.0.1:${TLS_ORIGIN_PORT}/health;
+}
 EOF
 
-TARDIGRADE_RATE_LIMIT_RPS=0 TARDIGRADE_WORKER_THREADS="${THREADS}" \
+TARDIGRADE_RATE_LIMIT_RPS=0 \
+TARDIGRADE_WORKER_THREADS="${THREADS}" \
+TARDIGRADE_MAX_REQUESTS_PER_CONNECTION=0 \
+TARDIGRADE_UPSTREAM_PROTOCOL=auto \
+TARDIGRADE_UPSTREAM_TLS_VERIFY=false \
     "$BINARY" run -c "$CONFIG_FILE" >"${TMP_DIR}/tardigrade.log" 2>&1 &
 TARDIGRADE_PID="$!"
-wait_for_http "http://127.0.0.1:${LISTEN_PORT}/status/metrics"
+wait_for_http "http://127.0.0.1:${LISTEN_PORT}/status/metrics" 150
 
-read -r hot_rps hot_p99 < <(run_wrk hot-origin "http://127.0.0.1:${LISTEN_PORT}/hot")
-for path in route-a route-b route-c; do
-    wrk -t2 -c8 -d3s "http://127.0.0.1:${LISTEN_PORT}/${path}" >/dev/null 2>&1 || true
+for path in hot route-a route-b route-c origin-0 origin-1 origin-2 origin-3 origin-4 origin-5 tls-origin; do
+    preflight_path "$path" || { echo "preflight failed for /${path}" >&2; exit 1; }
 done
+
+hot_json="$(run_measured_wrk hot-origin hot "$DURATION" "$CONNECTIONS" "$THREADS")"
+route_a_json="$(run_measured_wrk route-a route-a 3 8 2)"
+route_b_json="$(run_measured_wrk route-b route-b 3 8 2)"
+route_c_json="$(run_measured_wrk route-c route-c 3 8 2)"
+origins_json='[]'
 for path in origin-0 origin-1 origin-2 origin-3 origin-4 origin-5; do
-    wrk -t1 -c4 -d2s "http://127.0.0.1:${LISTEN_PORT}/${path}" >/dev/null 2>&1 || true
+    row="$(run_measured_wrk "$path" "$path" 2 4 1)"
+    origins_json="$(jq --arg path "$path" --argjson row "$row" '. + [($row + {origin: $path})]' <<<"$origins_json")"
 done
-
-metrics="$(curl -fsS "http://127.0.0.1:${LISTEN_PORT}/status/metrics")"
-new_c="$(metric_field "$metrics" tardigrade_upstream_connections_new_total)"; new_c="${new_c:-0}"
-reused="$(metric_field "$metrics" tardigrade_upstream_connections_reused_total)"; reused="${reused:-0}"
-local_r="$(metric_field "$metrics" tardigrade_upstream_connections_reused_local_total)"; local_r="${local_r:-0}"
-cross_r="$(metric_field "$metrics" tardigrade_upstream_connections_reused_cross_worker_total)"; cross_r="${cross_r:-0}"
-stale="$(metric_field "$metrics" tardigrade_upstream_stale_retries_total)"; stale="${stale:-0}"
-read -r cpu_pct rss_mb < <(sample_cpu_rss)
+tls_json="$(run_measured_wrk tls-origin tls-origin "$DURATION" "$CONNECTIONS" "$THREADS")"
+contention_json="$(worker_sweep_json)"
 
 jq -n \
     --argjson duration "$DURATION" \
     --argjson threads "$THREADS" \
-    --argjson hot_rps "$hot_rps" \
-    --argjson hot_p99 "$hot_p99" \
-    --argjson new_connections "$new_c" \
-    --argjson reused_connections "$reused" \
-    --argjson local_reuse "$local_r" \
-    --argjson cross_worker_reuse "$cross_r" \
-    --argjson stale_retries "$stale" \
-    --argjson cpu_pct "$cpu_pct" \
-    --argjson rss_mb "$rss_mb" \
+    --argjson hot "$hot_json" \
+    --argjson route_a "$route_a_json" \
+    --argjson route_b "$route_b_json" \
+    --argjson route_c "$route_c_json" \
+    --argjson origins "$origins_json" \
+    --argjson tls "$tls_json" \
+    --argjson contention "$contention_json" \
     '{
         _meta: {
             suite: "upstream-pool-distribution",
             duration_s: $duration,
             worker_threads: $threads,
-            note: "Records whether shared-pool contention justifies future sharding; current output is evidence collection, not an implementation request."
+            note: "p99_ms is end-to-end latency. p99_ttfb_ms remains null until a first-byte load tool is wired into this matrix."
         },
         scenarios: {
-            "uneven-route-distribution": { covered: true },
-            "many-origins-low-volume": { covered: true, origins: 6 },
-            "hot-origin-many-workers": {
+            "uneven-route-distribution": {
                 covered: true,
-                rps: $hot_rps,
-                p99_ttfb_ms: $hot_p99,
-                cpu_pct_avg: $cpu_pct,
-                cpu_ms_per_request: (if $hot_rps > 0 then (($cpu_pct / 100.0) / $hot_rps * 1000.0) else null end),
-                rss_mb_peak: $rss_mb
+                routes: { "route-a": $route_a, "route-b": $route_b, "route-c": $route_c },
+                errors: (($route_a.errors // 0) + ($route_b.errors // 0) + ($route_c.errors // 0))
             },
-            "upstream-tls-handshake-reuse": {
-                covered: false,
-                reason: "No TLS-capable upstream fixture is available in this benchmark harness yet."
+            "many-origins-low-volume": {
+                covered: true,
+                origins: 6,
+                measurements: $origins,
+                errors: ($origins | map(.errors // 0) | add)
             },
-            "pool-contention": {
-                new_connections: $new_connections,
-                reused_connections: $reused_connections,
-                local_reuse: $local_reuse,
-                cross_worker_reuse: $cross_worker_reuse,
-                stale_retries: $stale_retries,
-                new_connections_per_sec: ($new_connections / $duration),
-                reuse_ratio: (if ($new_connections + $reused_connections) > 0 then ($reused_connections / ($new_connections + $reused_connections)) else null end),
-                cross_worker_reuse_ratio: (if $reused_connections > 0 then ($cross_worker_reuse / $reused_connections) else null end),
-                sharding_justified: false,
-                sharding_note: "Treat sharding as justified only if repeated dedicated-host runs show high p99 TTFB or CPU/request together with low reuse and measurable contention."
-            }
+            "hot-origin-many-workers": $hot,
+            "upstream-tls-handshake-reuse": $tls,
+            "pool-contention": $contention
         }
     }' > "$OUTPUT"
 

--- a/benchmarks/competitive/upstream-pool-matrix.sh
+++ b/benchmarks/competitive/upstream-pool-matrix.sh
@@ -124,8 +124,8 @@ process_tree_cpu_seconds() {
             for pid in "${_cpu_pids[@]}"; do
                 [[ -r "/proc/${pid}/stat" ]] || continue
                 total_ticks=$((total_ticks + $(awk '{
-                    close = match($0, /\) /)
-                    rest = substr($0, close + 2)
+                    paren_idx = match($0, /\) /)
+                    rest = substr($0, paren_idx + 2)
                     split(rest, f, " ")
                     print (f[12] + f[13])
                 }' "/proc/${pid}/stat")))

--- a/benchmarks/competitive/upstream-pool-matrix.sh
+++ b/benchmarks/competitive/upstream-pool-matrix.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# Upstream-pool distribution matrix for the competitive benchmark suite.
+#
+# Covers the #147 validation matrix absorbed by #149: uneven route traffic,
+# many low-volume origins, one hot origin with many workers, local vs
+# cross-worker reuse, new upstream connections/sec, CPU/request, p99 TTFB, and
+# contention notes. TLS upstream reuse is recorded as unsupported unless this
+# script is extended with a TLS-capable origin fixture for the local platform.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+BENCH_DIR="${REPO_ROOT}/benchmarks"
+BINARY="${REPO_ROOT}/zig-out/bin/tardi"
+LISTEN_PORT="19180"
+ORIGIN_BASE_PORT="19190"
+DURATION="10"
+CONNECTIONS="32"
+THREADS="8"
+OUTPUT=""
+TMP_DIR=""
+TARDIGRADE_PID=""
+ORIGIN_PIDS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --binary) BINARY="$2"; shift 2 ;;
+        --listen-port) LISTEN_PORT="$2"; shift 2 ;;
+        --origin-base-port) ORIGIN_BASE_PORT="$2"; shift 2 ;;
+        --duration) DURATION="$2"; shift 2 ;;
+        --connections) CONNECTIONS="$2"; shift 2 ;;
+        --threads) THREADS="$2"; shift 2 ;;
+        --output) OUTPUT="$2"; shift 2 ;;
+        --help)
+            sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [[ -z "$OUTPUT" ]]; then
+    echo "--output is required" >&2
+    exit 1
+fi
+
+for tool in wrk curl python3 jq awk ps pgrep; do
+    command -v "$tool" >/dev/null 2>&1 || { echo "missing required tool: $tool" >&2; exit 1; }
+done
+if [[ ! -x "$BINARY" ]]; then
+    echo "tardi binary not found at ${BINARY}" >&2
+    exit 1
+fi
+
+cleanup() {
+    local status=$?
+    if [[ -n "$TARDIGRADE_PID" ]]; then
+        kill "$TARDIGRADE_PID" 2>/dev/null || true
+        wait "$TARDIGRADE_PID" 2>/dev/null || true
+    fi
+    local pid
+    for pid in "${ORIGIN_PIDS[@]}"; do
+        kill "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+    done
+    [[ -n "$TMP_DIR" ]] && rm -rf "$TMP_DIR"
+    exit "$status"
+}
+trap cleanup EXIT
+
+wait_for_http() {
+    local url="$1" i
+    for ((i = 0; i < 50; i += 1)); do
+        curl -fsS "$url" >/dev/null 2>&1 && return 0
+        sleep 0.2
+    done
+    echo "timed out waiting for ${url}" >&2
+    return 1
+}
+
+process_tree_pids() {
+    local root="$1"
+    printf '%s\n' "$root"
+    local children child
+    children=$(pgrep -P "$root" 2>/dev/null || true)
+    for child in $children; do
+        process_tree_pids "$child"
+    done
+}
+
+sample_cpu_rss() {
+    process_tree_pids "$TARDIGRADE_PID" | paste -sd, - | {
+        read -r pids
+        ps -p "$pids" -o rss= -o %cpu= 2>/dev/null |
+            awk '{ rss += $1; cpu += $2 } END { printf "%.2f %.2f", cpu, rss / 1024 }'
+    }
+}
+
+metric_field() {
+    local metrics="$1"
+    local key="$2"
+    printf '%s\n' "$metrics" | awk -v k="$key" '$1 == k { print $2; exit }'
+}
+
+run_wrk() {
+    local label="$1"
+    local url="$2"
+    local raw rps p99
+    raw="$(wrk --latency -s "${BENCH_DIR}/wrk-summary.lua" -t"${THREADS}" -c"${CONNECTIONS}" -d"${DURATION}s" "$url" 2>&1 || true)"
+    summary="$(printf '%s\n' "$raw" | sed -n 's/^WRK_SUMMARY //p' | tail -1)"
+    if [[ -z "$summary" ]]; then
+        echo "missing wrk summary for ${label}" >&2
+        echo "$raw" >&2
+        exit 1
+    fi
+    rps="$(jq -r '.rps // 0' <<<"$summary")"
+    p99="$(jq -r '.p99_ms // null' <<<"$summary")"
+    printf '%s %s\n' "$rps" "$p99"
+}
+
+TMP_DIR="$(mktemp -d /tmp/tardigrade-upstream-matrix-XXXX)"
+CONFIG_FILE="${TMP_DIR}/upstream-matrix.conf"
+
+for i in 0 1 2 3 4 5; do
+    port=$((ORIGIN_BASE_PORT + i))
+    python3 "${BENCH_DIR}/fixtures/upstream_server.py" --port "$port" >"${TMP_DIR}/origin-${i}.log" 2>&1 &
+    ORIGIN_PIDS+=("$!")
+    wait_for_http "http://127.0.0.1:${port}/health"
+done
+
+cat > "$CONFIG_FILE" <<EOF
+listen ${LISTEN_PORT};
+metrics_path /status/metrics;
+
+location = /hot {
+    proxy_pass http://127.0.0.1:${ORIGIN_BASE_PORT}/health;
+}
+location = /route-a {
+    proxy_pass http://127.0.0.1:${ORIGIN_BASE_PORT}/health;
+}
+location = /route-b {
+    proxy_pass http://127.0.0.1:$((ORIGIN_BASE_PORT + 1))/health;
+}
+location = /route-c {
+    proxy_pass http://127.0.0.1:$((ORIGIN_BASE_PORT + 2))/health;
+}
+location = /origin-0 {
+    proxy_pass http://127.0.0.1:${ORIGIN_BASE_PORT}/health;
+}
+location = /origin-1 {
+    proxy_pass http://127.0.0.1:$((ORIGIN_BASE_PORT + 1))/health;
+}
+location = /origin-2 {
+    proxy_pass http://127.0.0.1:$((ORIGIN_BASE_PORT + 2))/health;
+}
+location = /origin-3 {
+    proxy_pass http://127.0.0.1:$((ORIGIN_BASE_PORT + 3))/health;
+}
+location = /origin-4 {
+    proxy_pass http://127.0.0.1:$((ORIGIN_BASE_PORT + 4))/health;
+}
+location = /origin-5 {
+    proxy_pass http://127.0.0.1:$((ORIGIN_BASE_PORT + 5))/health;
+}
+EOF
+
+TARDIGRADE_RATE_LIMIT_RPS=0 TARDIGRADE_WORKER_THREADS="${THREADS}" \
+    "$BINARY" run -c "$CONFIG_FILE" >"${TMP_DIR}/tardigrade.log" 2>&1 &
+TARDIGRADE_PID="$!"
+wait_for_http "http://127.0.0.1:${LISTEN_PORT}/status/metrics"
+
+read -r hot_rps hot_p99 < <(run_wrk hot-origin "http://127.0.0.1:${LISTEN_PORT}/hot")
+for path in route-a route-b route-c; do
+    wrk -t2 -c8 -d3s "http://127.0.0.1:${LISTEN_PORT}/${path}" >/dev/null 2>&1 || true
+done
+for path in origin-0 origin-1 origin-2 origin-3 origin-4 origin-5; do
+    wrk -t1 -c4 -d2s "http://127.0.0.1:${LISTEN_PORT}/${path}" >/dev/null 2>&1 || true
+done
+
+metrics="$(curl -fsS "http://127.0.0.1:${LISTEN_PORT}/status/metrics")"
+new_c="$(metric_field "$metrics" tardigrade_upstream_connections_new_total)"; new_c="${new_c:-0}"
+reused="$(metric_field "$metrics" tardigrade_upstream_connections_reused_total)"; reused="${reused:-0}"
+local_r="$(metric_field "$metrics" tardigrade_upstream_connections_reused_local_total)"; local_r="${local_r:-0}"
+cross_r="$(metric_field "$metrics" tardigrade_upstream_connections_reused_cross_worker_total)"; cross_r="${cross_r:-0}"
+stale="$(metric_field "$metrics" tardigrade_upstream_stale_retries_total)"; stale="${stale:-0}"
+read -r cpu_pct rss_mb < <(sample_cpu_rss)
+
+jq -n \
+    --argjson duration "$DURATION" \
+    --argjson threads "$THREADS" \
+    --argjson hot_rps "$hot_rps" \
+    --argjson hot_p99 "$hot_p99" \
+    --argjson new_connections "$new_c" \
+    --argjson reused_connections "$reused" \
+    --argjson local_reuse "$local_r" \
+    --argjson cross_worker_reuse "$cross_r" \
+    --argjson stale_retries "$stale" \
+    --argjson cpu_pct "$cpu_pct" \
+    --argjson rss_mb "$rss_mb" \
+    '{
+        _meta: {
+            suite: "upstream-pool-distribution",
+            duration_s: $duration,
+            worker_threads: $threads,
+            note: "Records whether shared-pool contention justifies future sharding; current output is evidence collection, not an implementation request."
+        },
+        scenarios: {
+            "uneven-route-distribution": { covered: true },
+            "many-origins-low-volume": { covered: true, origins: 6 },
+            "hot-origin-many-workers": {
+                covered: true,
+                rps: $hot_rps,
+                p99_ttfb_ms: $hot_p99,
+                cpu_pct_avg: $cpu_pct,
+                cpu_ms_per_request: (if $hot_rps > 0 then (($cpu_pct / 100.0) / $hot_rps * 1000.0) else null end),
+                rss_mb_peak: $rss_mb
+            },
+            "upstream-tls-handshake-reuse": {
+                covered: false,
+                reason: "No TLS-capable upstream fixture is available in this benchmark harness yet."
+            },
+            "pool-contention": {
+                new_connections: $new_connections,
+                reused_connections: $reused_connections,
+                local_reuse: $local_reuse,
+                cross_worker_reuse: $cross_worker_reuse,
+                stale_retries: $stale_retries,
+                new_connections_per_sec: ($new_connections / $duration),
+                reuse_ratio: (if ($new_connections + $reused_connections) > 0 then ($reused_connections / ($new_connections + $reused_connections)) else null end),
+                cross_worker_reuse_ratio: (if $reused_connections > 0 then ($cross_worker_reuse / $reused_connections) else null end),
+                sharding_justified: false,
+                sharding_note: "Treat sharding as justified only if repeated dedicated-host runs show high p99 TTFB or CPU/request together with low reuse and measurable contention."
+            }
+        }
+    }' > "$OUTPUT"
+
+echo "Wrote upstream-pool matrix: ${OUTPUT}"

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -465,8 +465,8 @@ process_tree_cpu_seconds() {
             for child in "${_cpu_pids[@]}"; do
                 [[ -r "/proc/${child}/stat" ]] || continue
                 total_ticks=$((total_ticks + $(awk '{
-                    close = match($0, /\) /)
-                    rest = substr($0, close + 2)
+                    paren_idx = match($0, /\) /)
+                    rest = substr($0, paren_idx + 2)
                     split(rest, f, " ")
                     print (f[12] + f[13])
                 }' "/proc/${child}/stat")))

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -419,6 +419,46 @@ MONITOR_PID=""
 CURRENT_CPU_PCT_AVG="null"
 CURRENT_RSS_MB_PEAK="null"
 CURRENT_OPEN_FDS_PEAK="null"
+CPU_BEFORE_SECONDS="null"
+MONITOR_START_NS="null"
+
+monotonic_ns() {
+    python3 -c 'import time; print(time.monotonic_ns())'
+}
+
+cpu_time_to_seconds() {
+    awk '
+        function part_seconds(v, n, p) {
+            n = split(v, p, ":")
+            if (n == 3) return (p[1] * 3600) + (p[2] * 60) + p[3]
+            if (n == 2) return (p[1] * 60) + p[2]
+            return v + 0
+        }
+        {
+            v = $1
+            days = 0
+            if (index(v, "-") > 0) {
+                split(v, d, "-")
+                days = d[1] + 0
+                v = d[2]
+            }
+            total += days * 86400 + part_seconds(v)
+        }
+        END { printf "%.6f", total }
+    '
+}
+
+process_tree_cpu_seconds() {
+    local pid="$1"
+    local pids
+    if $PID_TREE; then
+        pids="$(process_tree_pids "$pid" | paste -sd, -)"
+    else
+        pids="$pid"
+    fi
+    [[ -n "$pids" ]] || pids="$pid"
+    ps -p "$pids" -o time= 2>/dev/null | cpu_time_to_seconds
+}
 
 count_open_fds_for_pids() {
     local pids_csv="$1"
@@ -452,13 +492,13 @@ monitor_target_process() {
                 [[ -n "$pids" ]] || pids="$pid"
                 local fds
                 fds="$(count_open_fds_for_pids "$pids")"
-                ps -p "$pids" -o rss= -o %cpu= 2>/dev/null |
-                    awk -v fds="$fds" '{ rss += $1; cpu += $2 } END { if (rss > 0 || cpu > 0) print rss, cpu, fds }' >> "$outfile"
+                ps -p "$pids" -o rss= 2>/dev/null |
+                    awk -v fds="$fds" '{ rss += $1 } END { if (rss > 0) print rss, fds }' >> "$outfile"
             }
         else
             local fds
             fds="$(count_open_fds_for_pids "$pid")"
-            ps -p "$pid" -o rss= -o %cpu= 2>/dev/null | awk -v fds="$fds" 'NF >= 2 { print $1, $2, fds; exit }' >> "$outfile"
+            ps -p "$pid" -o rss= 2>/dev/null | awk -v fds="$fds" 'NF >= 1 { print $1, fds; exit }' >> "$outfile"
         fi
         sleep "$sample_interval_s"
     done
@@ -478,6 +518,8 @@ start_process_monitor() {
     CURRENT_CPU_PCT_AVG="null"
     CURRENT_RSS_MB_PEAK="null"
     CURRENT_OPEN_FDS_PEAK="null"
+    CPU_BEFORE_SECONDS="null"
+    MONITOR_START_NS="null"
     MONITOR_FILE=""
     MONITOR_PID=""
 
@@ -492,6 +534,8 @@ start_process_monitor() {
 
     local sample_interval_s
     sample_interval_s=$(awk -v ms="$SAMPLE_INTERVAL_MS" 'BEGIN { printf "%.3f", ms / 1000 }')
+    CPU_BEFORE_SECONDS="$(process_tree_cpu_seconds "$pid")"
+    MONITOR_START_NS="$(monotonic_ns)"
     MONITOR_FILE=$(mktemp /tmp/tardigrade-bench-monitor-XXXXXX)
     monitor_target_process "$pid" "$sample_interval_s" "$MONITOR_FILE" &
     MONITOR_PID="$!"
@@ -504,9 +548,19 @@ stop_process_monitor() {
         MONITOR_PID=""
     fi
     if [[ -n "$MONITOR_FILE" && -f "$MONITOR_FILE" ]]; then
-        CURRENT_CPU_PCT_AVG=$(average_column_or_null "$MONITOR_FILE" 2)
+        local pid cpu_after end_ns
+        if pid=$(resolve_target_pid 2>/dev/null); then
+            cpu_after="$(process_tree_cpu_seconds "$pid")"
+            end_ns="$(monotonic_ns)"
+            CURRENT_CPU_PCT_AVG=$(awk -v before="$CPU_BEFORE_SECONDS" -v after="$cpu_after" -v start="$MONITOR_START_NS" -v end="$end_ns" '
+                BEGIN {
+                    elapsed = (end - start) / 1000000000
+                    if (before != "null" && elapsed > 0) printf "%.2f", ((after - before) / elapsed) * 100
+                    else printf "null"
+                }')
+        fi
         CURRENT_RSS_MB_PEAK=$(peak_rss_mb_or_null "$MONITOR_FILE")
-        CURRENT_OPEN_FDS_PEAK=$(awk 'NF >= 3 && $3 ~ /^[0-9]+$/ && $3 > max { max = $3 } END { if (max > 0) printf "%d", max; else printf "null" }' "$MONITOR_FILE")
+        CURRENT_OPEN_FDS_PEAK=$(awk 'NF >= 2 && $2 ~ /^[0-9]+$/ && $2 > max { max = $2 } END { if (max > 0) printf "%d", max; else printf "null" }' "$MONITOR_FILE")
         rm -f "$MONITOR_FILE"
         MONITOR_FILE=""
     fi

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -15,6 +15,7 @@
 #   --config-label STR  Config/profile label recorded in metadata
 #   --pid PID           Target Tardigrade process ID for CPU/RSS sampling
 #   --pid-file FILE     File containing the target Tardigrade PID for CPU/RSS sampling
+#   --pid-tree          Include child processes when sampling CPU/RSS
 #   --tls               Use HTTPS (default: plain HTTP)
 #   --insecure          Skip TLS certificate verification (for self-signed certs)
 #   --duration SECS     Benchmark duration per scenario (default: 30)
@@ -82,6 +83,7 @@ WORKER_COUNT=""
 CONFIG_LABEL=""
 TARGET_PID=""
 PID_FILE=""
+PID_TREE=false
 USE_TLS=false
 INSECURE=false
 DURATION=30
@@ -121,6 +123,7 @@ while [[ $# -gt 0 ]]; do
         --config-label)CONFIG_LABEL="$2";      shift 2 ;;
         --pid)        TARGET_PID="$2";         shift 2 ;;
         --pid-file)   PID_FILE="$2";           shift 2 ;;
+        --pid-tree)   PID_TREE=true;           shift ;;
         --tls)        USE_TLS=true;            shift ;;
         --insecure)   INSECURE=true;           shift ;;
         --duration)   DURATION="$2";           shift 2 ;;
@@ -394,6 +397,23 @@ peak_rss_mb_or_null() {
     ' "$file"
 }
 
+wrk_error_count() {
+    awk '
+        /Non-2xx/ {
+            for (i = 1; i <= NF; i++) {
+                if ($i ~ /^[0-9]+$/) total += $i
+            }
+        }
+        /Socket errors:/ {
+            for (i = 1; i <= NF; i++) {
+                gsub(/,/, "", $i)
+                if ($i ~ /^[0-9]+$/) total += $i
+            }
+        }
+        END { print total + 0 }
+    '
+}
+
 MONITOR_FILE=""
 MONITOR_PID=""
 CURRENT_CPU_PCT_AVG="null"
@@ -402,8 +422,27 @@ CURRENT_RSS_MB_PEAK="null"
 monitor_target_process() {
     local pid="$1" sample_interval_s="$2" outfile="$3"
     while kill -0 "$pid" 2>/dev/null; do
-        ps -p "$pid" -o rss= -o %cpu= 2>/dev/null | awk 'NF >= 2 { print $1, $2; exit }' >> "$outfile"
+        if $PID_TREE; then
+            process_tree_pids "$pid" | paste -sd, - | {
+                read -r pids
+                [[ -n "$pids" ]] || pids="$pid"
+                ps -p "$pids" -o rss= -o %cpu= 2>/dev/null |
+                    awk '{ rss += $1; cpu += $2 } END { if (rss > 0 || cpu > 0) print rss, cpu }' >> "$outfile"
+            }
+        else
+            ps -p "$pid" -o rss= -o %cpu= 2>/dev/null | awk 'NF >= 2 { print $1, $2; exit }' >> "$outfile"
+        fi
         sleep "$sample_interval_s"
+    done
+}
+
+process_tree_pids() {
+    local root="$1"
+    printf '%s\n' "$root"
+    local children child
+    children=$(pgrep -P "$root" 2>/dev/null || true)
+    for child in $children; do
+        process_tree_pids "$child"
     done
 }
 
@@ -576,7 +615,7 @@ run_wrk() {
     p95=$(echo "$summary_json" | jq -r '.p95_ms // null')
     p99=$(echo "$summary_json" | jq -r '.p99_ms // null')
     p999=$(echo "$summary_json" | jq -r '.p999_ms // null')
-    errors=$(echo "$raw" | grep -E "Non-2xx|Socket errors" | grep -oE '[0-9]+' | head -1 || echo 0)
+    errors=$(printf '%s\n' "$raw" | wrk_error_count)
     rps=${rps:-0}; errors=${errors:-0}
     local tput_mbps
     tput_mbps=$(echo "$summary_json" | jq -r '.throughput_mbps // null')
@@ -1108,6 +1147,7 @@ RESULTS_JSON=$(jq \
     --arg keepalive_path "$KEEPALIVE_PATH" \
     --arg h2_path "$H2_PATH" --arg h3_path "$H3_PATH" \
     --arg tool "$TOOL" \
+    --argjson pid_tree "$($PID_TREE && echo true || echo false)" \
     --arg zig_version "$ZIG_VERSION" \
     --arg os_name "$OS_NAME" \
     --arg kernel_release "$KERNEL_RELEASE" \
@@ -1125,6 +1165,7 @@ RESULTS_JSON=$(jq \
           process_metrics: {
             enabled: ($pid_source != "none"),
             pid_source: $pid_source,
+            pid_tree: $pid_tree,
             sample_interval_ms: $sample_interval_ms
           },
           zig_version: $zig_version,

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -15,7 +15,7 @@
 #   --config-label STR  Config/profile label recorded in metadata
 #   --pid PID           Target Tardigrade process ID for CPU/RSS sampling
 #   --pid-file FILE     File containing the target Tardigrade PID for CPU/RSS sampling
-#   --pid-tree          Include child processes when sampling CPU/RSS
+#   --pid-tree          Include child processes when sampling CPU/RSS/open FDs
 #   --tls               Use HTTPS (default: plain HTTP)
 #   --insecure          Skip TLS certificate verification (for self-signed certs)
 #   --duration SECS     Benchmark duration per scenario (default: 30)
@@ -418,19 +418,47 @@ MONITOR_FILE=""
 MONITOR_PID=""
 CURRENT_CPU_PCT_AVG="null"
 CURRENT_RSS_MB_PEAK="null"
+CURRENT_OPEN_FDS_PEAK="null"
+
+count_open_fds_for_pids() {
+    local pids_csv="$1"
+    local total=0 pid count
+    IFS=, read -ra _fd_pids <<< "$pids_csv"
+    for pid in "${_fd_pids[@]}"; do
+        [[ -n "$pid" ]] || continue
+        if [[ -d "/proc/${pid}/fd" ]]; then
+            count=$(find "/proc/${pid}/fd" -maxdepth 1 -type l 2>/dev/null | wc -l | tr -d ' ')
+        elif command -v lsof >/dev/null 2>&1; then
+            count=$(lsof -n -P -p "$pid" 2>/dev/null | awk 'NR > 1 { count += 1 } END { print count + 0 }')
+        else
+            count=""
+        fi
+        [[ "$count" =~ ^[0-9]+$ ]] && total=$((total + count))
+    done
+    if [[ "$total" -gt 0 ]]; then
+        printf '%s\n' "$total"
+    else
+        printf 'null\n'
+    fi
+}
 
 monitor_target_process() {
     local pid="$1" sample_interval_s="$2" outfile="$3"
     while kill -0 "$pid" 2>/dev/null; do
+        local pids
         if $PID_TREE; then
             process_tree_pids "$pid" | paste -sd, - | {
                 read -r pids
                 [[ -n "$pids" ]] || pids="$pid"
+                local fds
+                fds="$(count_open_fds_for_pids "$pids")"
                 ps -p "$pids" -o rss= -o %cpu= 2>/dev/null |
-                    awk '{ rss += $1; cpu += $2 } END { if (rss > 0 || cpu > 0) print rss, cpu }' >> "$outfile"
+                    awk -v fds="$fds" '{ rss += $1; cpu += $2 } END { if (rss > 0 || cpu > 0) print rss, cpu, fds }' >> "$outfile"
             }
         else
-            ps -p "$pid" -o rss= -o %cpu= 2>/dev/null | awk 'NF >= 2 { print $1, $2; exit }' >> "$outfile"
+            local fds
+            fds="$(count_open_fds_for_pids "$pid")"
+            ps -p "$pid" -o rss= -o %cpu= 2>/dev/null | awk -v fds="$fds" 'NF >= 2 { print $1, $2, fds; exit }' >> "$outfile"
         fi
         sleep "$sample_interval_s"
     done
@@ -449,6 +477,7 @@ process_tree_pids() {
 start_process_monitor() {
     CURRENT_CPU_PCT_AVG="null"
     CURRENT_RSS_MB_PEAK="null"
+    CURRENT_OPEN_FDS_PEAK="null"
     MONITOR_FILE=""
     MONITOR_PID=""
 
@@ -463,7 +492,7 @@ start_process_monitor() {
 
     local sample_interval_s
     sample_interval_s=$(awk -v ms="$SAMPLE_INTERVAL_MS" 'BEGIN { printf "%.3f", ms / 1000 }')
-    MONITOR_FILE=$(mktemp /tmp/tardigrade-bench-monitor-XXXX.txt)
+    MONITOR_FILE=$(mktemp /tmp/tardigrade-bench-monitor-XXXXXX)
     monitor_target_process "$pid" "$sample_interval_s" "$MONITOR_FILE" &
     MONITOR_PID="$!"
 }
@@ -477,6 +506,7 @@ stop_process_monitor() {
     if [[ -n "$MONITOR_FILE" && -f "$MONITOR_FILE" ]]; then
         CURRENT_CPU_PCT_AVG=$(average_column_or_null "$MONITOR_FILE" 2)
         CURRENT_RSS_MB_PEAK=$(peak_rss_mb_or_null "$MONITOR_FILE")
+        CURRENT_OPEN_FDS_PEAK=$(awk 'NF >= 3 && $3 ~ /^[0-9]+$/ && $3 > max { max = $3 } END { if (max > 0) printf "%d", max; else printf "null" }' "$MONITOR_FILE")
         rm -f "$MONITOR_FILE"
         MONITOR_FILE=""
     fi
@@ -503,7 +533,7 @@ declare -A _run_p99_list=()
 declare -A _run_errors_list=()
 
 add_result() {
-    local scenario="$1" rps="$2" p50_ms="$3" p95_ms="$4" p99_ms="$5" p999_ms="$6" errors="$7" mbps="${8:-null}" cpu_pct_avg="${9:-null}" rss_mb_peak="${10:-null}"
+    local scenario="$1" rps="$2" p50_ms="$3" p95_ms="$4" p99_ms="$5" p999_ms="$6" errors="$7" mbps="${8:-null}" cpu_pct_avg="${9:-null}" rss_mb_peak="${10:-null}" open_fds_peak="${11:-$CURRENT_OPEN_FDS_PEAK}"
 
     if [[ "$RUNS" -gt 1 ]]; then
         # Accumulate for this run; flush_multirun_result builds the final entry.
@@ -516,7 +546,7 @@ add_result() {
     RESULTS_JSON=$(jq --arg s "$scenario" \
         --argjson rps "$rps" \
         --argjson p50 "$p50_ms" --argjson p95 "$p95_ms" --argjson p99 "$p99_ms" --argjson p999 "$p999_ms" \
-        --argjson err "$errors" --argjson mbps "$mbps" --argjson cpu "$cpu_pct_avg" --argjson rss "$rss_mb_peak" \
+        --argjson err "$errors" --argjson mbps "$mbps" --argjson cpu "$cpu_pct_avg" --argjson rss "$rss_mb_peak" --argjson fds "$open_fds_peak" \
         '.[$s] = {
             rps: $rps,
             p50_ms: $p50,
@@ -526,7 +556,8 @@ add_result() {
             errors: $err,
             throughput_mbps: $mbps,
             cpu_pct_avg: $cpu,
-            rss_mb_peak: $rss
+            rss_mb_peak: $rss,
+            open_fds_peak: $fds
         }' \
         <<<"$RESULTS_JSON")
 }
@@ -767,7 +798,7 @@ _k6_parse_summary() {
 # ── k6 throughput runner ──────────────────────────────────────────────────────
 run_k6() {
     local url="$1" label="$2"
-    local tmpfile; tmpfile=$(mktemp /tmp/k6-summary-XXXX.json)
+    local tmpfile; tmpfile=$(mktemp /tmp/k6-summary-XXXXXX)
     local extra_flags=()
     $INSECURE && extra_flags+=(--insecure-skip-tls-verify)
 
@@ -797,7 +828,7 @@ run_k6() {
 run_k6_scenario() {
     local script="$1" label="$2"
     shift 2
-    local tmpfile; tmpfile=$(mktemp /tmp/k6-summary-XXXX.json)
+    local tmpfile; tmpfile=$(mktemp /tmp/k6-summary-XXXXXX)
     local extra_flags=()
     $INSECURE && extra_flags+=(--insecure-skip-tls-verify)
 

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -450,13 +450,31 @@ cpu_time_to_seconds() {
 
 process_tree_cpu_seconds() {
     local pid="$1"
-    local pids
+    local pids clk total_ticks child
     if $PID_TREE; then
         pids="$(process_tree_pids "$pid" | paste -sd, -)"
     else
         pids="$pid"
     fi
     [[ -n "$pids" ]] || pids="$pid"
+    if [[ "$(uname -s 2>/dev/null || true)" == "Linux" ]]; then
+        clk="$(getconf CLK_TCK 2>/dev/null || true)"
+        if [[ "$clk" =~ ^[0-9]+$ && "$clk" -gt 0 ]]; then
+            total_ticks=0
+            IFS=, read -ra _cpu_pids <<< "$pids"
+            for child in "${_cpu_pids[@]}"; do
+                [[ -r "/proc/${child}/stat" ]] || continue
+                total_ticks=$((total_ticks + $(awk '{
+                    close = match($0, /\) /)
+                    rest = substr($0, close + 2)
+                    split(rest, f, " ")
+                    print (f[12] + f[13])
+                }' "/proc/${child}/stat")))
+            done
+            awk -v ticks="$total_ticks" -v clk="$clk" 'BEGIN { printf "%.6f", ticks / clk }'
+            return
+        fi
+    fi
     ps -p "$pids" -o time= 2>/dev/null | cpu_time_to_seconds
 }
 

--- a/src/edge_config.zig
+++ b/src/edge_config.zig
@@ -502,6 +502,8 @@ pub const EdgeConfig = struct {
     /// origin (0 = unlimited). At the cap, requests get 503 upstream_saturated
     /// instead of opening more connections (#239).
     upstream_pool_max_active_per_host: usize,
+    /// Benchmark-only upstream-pool mutex wait counters.
+    upstream_pool_lock_metrics: bool,
     /// Passive health threshold: mark upstream as failed after this many failed attempts (0 = disabled).
     upstream_max_fails: u32,
     /// Passive health timeout (ms) for failed upstreams before retry eligibility.
@@ -1321,6 +1323,7 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
     const upstream_pool_idle_timeout_ms = parseIntEnv(u64, allocator, "TARDIGRADE_UPSTREAM_POOL_IDLE_TIMEOUT_MS", 90_000);
     const upstream_pool_max_lifetime_ms = parseIntEnv(u64, allocator, "TARDIGRADE_UPSTREAM_POOL_MAX_LIFETIME_MS", 0);
     const upstream_pool_max_active_per_host = parseIntEnv(usize, allocator, "TARDIGRADE_UPSTREAM_POOL_MAX_ACTIVE_PER_HOST", 0);
+    const upstream_pool_lock_metrics = parseBoolEnv(allocator, "TARDIGRADE_UPSTREAM_POOL_LOCK_METRICS", false);
 
     const max_fails_str = envOrDefault(allocator, "TARDIGRADE_UPSTREAM_MAX_FAILS", "0") catch unreachable;
     defer allocator.free(max_fails_str);
@@ -1692,6 +1695,7 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
         .upstream_pool_idle_timeout_ms = upstream_pool_idle_timeout_ms,
         .upstream_pool_max_lifetime_ms = upstream_pool_max_lifetime_ms,
         .upstream_pool_max_active_per_host = upstream_pool_max_active_per_host,
+        .upstream_pool_lock_metrics = upstream_pool_lock_metrics,
         .upstream_max_fails = upstream_max_fails,
         .upstream_fail_timeout_ms = upstream_fail_timeout_ms,
         .upstream_active_health_interval_ms = upstream_active_health_interval_ms,

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -136,6 +136,7 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
             .idle_timeout_ms = cfg.upstream_pool_idle_timeout_ms,
             .max_lifetime_ms = cfg.upstream_pool_max_lifetime_ms,
             .max_active_per_host = cfg.upstream_pool_max_active_per_host,
+            .lock_contention_metrics_enabled = cfg.upstream_pool_lock_metrics,
         }),
         .h2_pool = http.upstream_h2.H2ConnPool.init(state_allocator, .{
             .idle_timeout_ms = cfg.upstream_pool_idle_timeout_ms,

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -1639,6 +1639,17 @@ pub const GatewayState = struct {
         );
         try out.print("tardigrade_upstream_h2_streaming_upload_fallback_total {d}\n", .{self.upstream_pool.h2StreamingUploadFallbacks()});
 
+        const lock_stats = self.upstream_pool.lockContentionStats();
+        try out.appendSlice(
+            \\# HELP tardigrade_upstream_pool_lock_wait_ns_total Nanoseconds spent waiting to acquire the shared upstream-pool mutex
+            \\# TYPE tardigrade_upstream_pool_lock_wait_ns_total counter
+            \\# HELP tardigrade_upstream_pool_lock_acquires_total Shared upstream-pool mutex acquisitions
+            \\# TYPE tardigrade_upstream_pool_lock_acquires_total counter
+            \\
+        );
+        try out.print("tardigrade_upstream_pool_lock_wait_ns_total {d}\n", .{lock_stats.wait_ns_total});
+        try out.print("tardigrade_upstream_pool_lock_acquires_total {d}\n", .{lock_stats.acquires_total});
+
         // Completed-exchange latency by negotiated protocol (#145 — the
         // "upstream p99 by protocol" acceptance row).
         const req_lat = self.upstream_pool.requestLatencySnapshot();

--- a/src/http/upstream_pool.zig
+++ b/src/http/upstream_pool.zig
@@ -34,6 +34,8 @@ pub const Config = struct {
     /// worker model, blocking here would let one slow origin absorb the whole
     /// worker pool — queueing/watermark semantics are #140's scope.
     max_active_per_host: usize = 0,
+    /// Opt-in benchmark instrumentation for shared-pool mutex wait time.
+    lock_contention_metrics_enabled: bool = false,
 };
 
 /// Identifier of the worker thread that last released a connection. Used purely
@@ -203,16 +205,30 @@ pub const UpstreamPool = struct {
         conn.stream.close();
     }
 
-    fn lock(self: *UpstreamPool) void {
-        const start = compat.nanoTimestamp();
+    fn lock(self: *UpstreamPool) u64 {
+        if (!self.config.lock_contention_metrics_enabled) {
+            self.mutex.lock();
+            return 0;
+        }
+        const start = compat.monotonicNanoTimestamp();
         self.mutex.lock();
-        const end = compat.nanoTimestamp();
-        const waited: u64 = if (end > start) @intCast(end - start) else 0;
-        _ = self.lock_wait_ns_total.fetchAdd(waited, .monotonic);
-        _ = self.lock_acquires_total.fetchAdd(1, .monotonic);
+        const end = compat.monotonicNanoTimestamp();
+        return if (end > start) @intCast(end - start) else 0;
     }
 
-    fn unlock(self: *UpstreamPool) void {
+    fn unlock(self: *UpstreamPool, waited_ns: u64) void {
+        self.mutex.unlock();
+        if (self.config.lock_contention_metrics_enabled) {
+            _ = self.lock_wait_ns_total.fetchAdd(waited_ns, .monotonic);
+            _ = self.lock_acquires_total.fetchAdd(1, .monotonic);
+        }
+    }
+
+    fn lockForSnapshot(self: *UpstreamPool) void {
+        self.mutex.lock();
+    }
+
+    fn unlockForSnapshot(self: *UpstreamPool) void {
         self.mutex.unlock();
     }
 
@@ -246,8 +262,8 @@ pub const UpstreamPool = struct {
     /// queueing; see `Config.max_active_per_host` for the rationale.
     pub fn checkout(self: *UpstreamPool, key: []const u8, now_ms: u64) error{UpstreamAtCapacity}!?PooledConn {
         if (!self.config.enabled) return null;
-        self.lock();
-        defer self.unlock();
+        const lock_wait_ns = self.lock();
+        defer self.unlock(lock_wait_ns);
         const entry = self.hostEntry(key) orelse return null; // OOM: proceed untracked
         if (self.config.max_active_per_host > 0 and entry.stats.active >= self.config.max_active_per_host) {
             entry.stats.at_capacity_total += 1;
@@ -279,8 +295,8 @@ pub const UpstreamPool = struct {
     /// `releaseSlot`.
     pub fn reserveSlot(self: *UpstreamPool, key: []const u8) error{UpstreamAtCapacity}!void {
         if (!self.config.enabled) return;
-        self.lock();
-        defer self.unlock();
+        const lock_wait_ns = self.lock();
+        defer self.unlock(lock_wait_ns);
         const entry = self.hostEntry(key) orelse return;
         if (self.config.max_active_per_host > 0 and entry.stats.active >= self.config.max_active_per_host) {
             entry.stats.at_capacity_total += 1;
@@ -292,8 +308,8 @@ pub const UpstreamPool = struct {
     /// Undo a `checkout`/`reserveSlot` reservation after a fresh connect
     /// failed. No-op for untracked (disabled/OOM) checkouts.
     pub fn releaseSlot(self: *UpstreamPool, key: []const u8) void {
-        self.lock();
-        defer self.unlock();
+        const lock_wait_ns = self.lock();
+        defer self.unlock(lock_wait_ns);
         const entry = self.hosts.getPtr(key) orelse return;
         if (entry.stats.active > 0) entry.stats.active -= 1;
     }
@@ -301,8 +317,8 @@ pub const UpstreamPool = struct {
     /// Record that the caller opened a fresh connection for `key`. The active
     /// slot was already reserved by `checkout`/`reserveSlot`; this only counts.
     pub fn noteNewConnection(self: *UpstreamPool, key: []const u8) void {
-        self.lock();
-        defer self.unlock();
+        const lock_wait_ns = self.lock();
+        defer self.unlock(lock_wait_ns);
         const entry = self.hostEntry(key) orelse return;
         entry.stats.new_total += 1;
     }
@@ -311,8 +327,8 @@ pub const UpstreamPool = struct {
     /// `reusable` and there is room and it has not aged out; otherwise it is
     /// closed. Either way the origin's `active` gauge is decremented.
     pub fn release(self: *UpstreamPool, key: []const u8, conn: PooledConn, reusable: bool, now_ms: u64) void {
-        self.lock();
-        defer self.unlock();
+        const lock_wait_ns = self.lock();
+        defer self.unlock(lock_wait_ns);
         const entry = self.hostEntry(key) orelse {
             self.closeConn(conn);
             return;
@@ -336,15 +352,15 @@ pub const UpstreamPool = struct {
     }
 
     pub fn recordStaleRetry(self: *UpstreamPool, key: []const u8) void {
-        self.lock();
-        defer self.unlock();
+        const lock_wait_ns = self.lock();
+        defer self.unlock(lock_wait_ns);
         const entry = self.hostEntry(key) orelse return;
         entry.stats.stale_retries_total += 1;
     }
 
     pub fn recordConnectLatency(self: *UpstreamPool, latency_ms: u64) void {
-        self.lock();
-        defer self.unlock();
+        const lock_wait_ns = self.lock();
+        defer self.unlock(lock_wait_ns);
         self.connect_latency_count += 1;
         self.connect_latency_sum_ms += latency_ms;
         for (connect_latency_bounds_ms, 0..) |bound, i| {
@@ -359,8 +375,8 @@ pub const UpstreamPool = struct {
     /// Close and drop every idle connection that has aged out, refreshing each
     /// origin's idle gauge. Intended to run from the gateway maintenance tick.
     pub fn reapIdle(self: *UpstreamPool, now_ms: u64) void {
-        self.lock();
-        defer self.unlock();
+        const lock_wait_ns = self.lock();
+        defer self.unlock(lock_wait_ns);
         var it = self.hosts.iterator();
         while (it.next()) |entry| {
             const list = &entry.value_ptr.idle;
@@ -378,8 +394,8 @@ pub const UpstreamPool = struct {
 
     /// Aggregate counters across all origins.
     pub fn aggregateStats(self: *UpstreamPool) Stats {
-        self.lock();
-        defer self.unlock();
+        self.lockForSnapshot();
+        defer self.unlockForSnapshot();
         var agg = Stats{};
         var it = self.hosts.iterator();
         while (it.next()) |entry| {
@@ -399,8 +415,8 @@ pub const UpstreamPool = struct {
     /// Snapshot per-origin counters for rendering. Caller frees with
     /// `freeHostSnapshots`.
     pub fn snapshotHosts(self: *UpstreamPool, allocator: std.mem.Allocator) ![]HostSnapshot {
-        self.lock();
-        defer self.unlock();
+        self.lockForSnapshot();
+        defer self.unlockForSnapshot();
         var out = std.array_list.Managed(HostSnapshot).init(allocator);
         errdefer {
             for (out.items) |snap| allocator.free(snap.host);
@@ -449,8 +465,8 @@ pub const UpstreamPool = struct {
     }
 
     pub fn connectLatencySnapshot(self: *UpstreamPool) ConnectLatencySnapshot {
-        self.lock();
-        defer self.unlock();
+        self.lockForSnapshot();
+        defer self.unlockForSnapshot();
         return .{
             .buckets = self.connect_latency_buckets,
             .count = self.connect_latency_count,
@@ -461,8 +477,8 @@ pub const UpstreamPool = struct {
     /// Record one completed upstream exchange for the per-protocol latency
     /// histogram (#145 — "upstream p99 by protocol").
     pub fn recordRequestLatency(self: *UpstreamPool, is_h2: bool, latency_ms: u64) void {
-        self.lock();
-        defer self.unlock();
+        const lock_wait_ns = self.lock();
+        defer self.unlock(lock_wait_ns);
         if (is_h2) {
             self.request_latency_h2.record(latency_ms);
         } else {
@@ -471,8 +487,8 @@ pub const UpstreamPool = struct {
     }
 
     pub fn requestLatencySnapshot(self: *UpstreamPool) RequestLatencySnapshot {
-        self.lock();
-        defer self.unlock();
+        self.lockForSnapshot();
+        defer self.unlockForSnapshot();
         return .{ .h1 = self.request_latency_h1, .h2 = self.request_latency_h2 };
     }
 };

--- a/src/http/upstream_pool.zig
+++ b/src/http/upstream_pool.zig
@@ -85,6 +85,11 @@ pub const Stats = struct {
     active: u64 = 0,
 };
 
+pub const LockContentionStats = struct {
+    wait_ns_total: u64 = 0,
+    acquires_total: u64 = 0,
+};
+
 /// A copy of one origin's identity + counters for rendering. `host` is owned by
 /// the caller and freed via `freeHostSnapshots`.
 pub const HostSnapshot = struct {
@@ -160,6 +165,8 @@ pub const UpstreamPool = struct {
     /// Count streaming uploads that requested h2/h2c but still had to use h1
     /// because the h2 pool was unavailable for the exchange.
     h2_streaming_upload_fallbacks: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    lock_wait_ns_total: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    lock_acquires_total: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
 
     pub fn init(allocator: std.mem.Allocator, config: Config) UpstreamPool {
         return .{
@@ -196,6 +203,19 @@ pub const UpstreamPool = struct {
         conn.stream.close();
     }
 
+    fn lock(self: *UpstreamPool) void {
+        const start = compat.nanoTimestamp();
+        self.mutex.lock();
+        const end = compat.nanoTimestamp();
+        const waited: u64 = if (end > start) @intCast(end - start) else 0;
+        _ = self.lock_wait_ns_total.fetchAdd(waited, .monotonic);
+        _ = self.lock_acquires_total.fetchAdd(1, .monotonic);
+    }
+
+    fn unlock(self: *UpstreamPool) void {
+        self.mutex.unlock();
+    }
+
     /// Get or create the per-host entry for `key`, duping the key on insert.
     /// Returns null only on allocation failure. Caller holds the mutex.
     fn hostEntry(self: *UpstreamPool, key: []const u8) ?*HostEntry {
@@ -226,8 +246,8 @@ pub const UpstreamPool = struct {
     /// queueing; see `Config.max_active_per_host` for the rationale.
     pub fn checkout(self: *UpstreamPool, key: []const u8, now_ms: u64) error{UpstreamAtCapacity}!?PooledConn {
         if (!self.config.enabled) return null;
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.lock();
+        defer self.unlock();
         const entry = self.hostEntry(key) orelse return null; // OOM: proceed untracked
         if (self.config.max_active_per_host > 0 and entry.stats.active >= self.config.max_active_per_host) {
             entry.stats.at_capacity_total += 1;
@@ -259,8 +279,8 @@ pub const UpstreamPool = struct {
     /// `releaseSlot`.
     pub fn reserveSlot(self: *UpstreamPool, key: []const u8) error{UpstreamAtCapacity}!void {
         if (!self.config.enabled) return;
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.lock();
+        defer self.unlock();
         const entry = self.hostEntry(key) orelse return;
         if (self.config.max_active_per_host > 0 and entry.stats.active >= self.config.max_active_per_host) {
             entry.stats.at_capacity_total += 1;
@@ -272,8 +292,8 @@ pub const UpstreamPool = struct {
     /// Undo a `checkout`/`reserveSlot` reservation after a fresh connect
     /// failed. No-op for untracked (disabled/OOM) checkouts.
     pub fn releaseSlot(self: *UpstreamPool, key: []const u8) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.lock();
+        defer self.unlock();
         const entry = self.hosts.getPtr(key) orelse return;
         if (entry.stats.active > 0) entry.stats.active -= 1;
     }
@@ -281,8 +301,8 @@ pub const UpstreamPool = struct {
     /// Record that the caller opened a fresh connection for `key`. The active
     /// slot was already reserved by `checkout`/`reserveSlot`; this only counts.
     pub fn noteNewConnection(self: *UpstreamPool, key: []const u8) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.lock();
+        defer self.unlock();
         const entry = self.hostEntry(key) orelse return;
         entry.stats.new_total += 1;
     }
@@ -291,8 +311,8 @@ pub const UpstreamPool = struct {
     /// `reusable` and there is room and it has not aged out; otherwise it is
     /// closed. Either way the origin's `active` gauge is decremented.
     pub fn release(self: *UpstreamPool, key: []const u8, conn: PooledConn, reusable: bool, now_ms: u64) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.lock();
+        defer self.unlock();
         const entry = self.hostEntry(key) orelse {
             self.closeConn(conn);
             return;
@@ -316,15 +336,15 @@ pub const UpstreamPool = struct {
     }
 
     pub fn recordStaleRetry(self: *UpstreamPool, key: []const u8) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.lock();
+        defer self.unlock();
         const entry = self.hostEntry(key) orelse return;
         entry.stats.stale_retries_total += 1;
     }
 
     pub fn recordConnectLatency(self: *UpstreamPool, latency_ms: u64) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.lock();
+        defer self.unlock();
         self.connect_latency_count += 1;
         self.connect_latency_sum_ms += latency_ms;
         for (connect_latency_bounds_ms, 0..) |bound, i| {
@@ -339,8 +359,8 @@ pub const UpstreamPool = struct {
     /// Close and drop every idle connection that has aged out, refreshing each
     /// origin's idle gauge. Intended to run from the gateway maintenance tick.
     pub fn reapIdle(self: *UpstreamPool, now_ms: u64) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.lock();
+        defer self.unlock();
         var it = self.hosts.iterator();
         while (it.next()) |entry| {
             const list = &entry.value_ptr.idle;
@@ -358,8 +378,8 @@ pub const UpstreamPool = struct {
 
     /// Aggregate counters across all origins.
     pub fn aggregateStats(self: *UpstreamPool) Stats {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.lock();
+        defer self.unlock();
         var agg = Stats{};
         var it = self.hosts.iterator();
         while (it.next()) |entry| {
@@ -379,8 +399,8 @@ pub const UpstreamPool = struct {
     /// Snapshot per-origin counters for rendering. Caller frees with
     /// `freeHostSnapshots`.
     pub fn snapshotHosts(self: *UpstreamPool, allocator: std.mem.Allocator) ![]HostSnapshot {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.lock();
+        defer self.unlock();
         var out = std.array_list.Managed(HostSnapshot).init(allocator);
         errdefer {
             for (out.items) |snap| allocator.free(snap.host);
@@ -421,9 +441,16 @@ pub const UpstreamPool = struct {
         return self.h2_streaming_upload_fallbacks.load(.monotonic);
     }
 
+    pub fn lockContentionStats(self: *const UpstreamPool) LockContentionStats {
+        return .{
+            .wait_ns_total = self.lock_wait_ns_total.load(.monotonic),
+            .acquires_total = self.lock_acquires_total.load(.monotonic),
+        };
+    }
+
     pub fn connectLatencySnapshot(self: *UpstreamPool) ConnectLatencySnapshot {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.lock();
+        defer self.unlock();
         return .{
             .buckets = self.connect_latency_buckets,
             .count = self.connect_latency_count,
@@ -434,8 +461,8 @@ pub const UpstreamPool = struct {
     /// Record one completed upstream exchange for the per-protocol latency
     /// histogram (#145 — "upstream p99 by protocol").
     pub fn recordRequestLatency(self: *UpstreamPool, is_h2: bool, latency_ms: u64) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.lock();
+        defer self.unlock();
         if (is_h2) {
             self.request_latency_h2.record(latency_ms);
         } else {
@@ -444,8 +471,8 @@ pub const UpstreamPool = struct {
     }
 
     pub fn requestLatencySnapshot(self: *UpstreamPool) RequestLatencySnapshot {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.lock();
+        defer self.unlock();
         return .{ .h1 = self.request_latency_h1, .h2 = self.request_latency_h2 };
     }
 };

--- a/src/zig_compat.zig
+++ b/src/zig_compat.zig
@@ -475,6 +475,10 @@ pub fn nanoTimestamp() i128 {
     return @intCast(std.Io.Clock.real.now(io()).toNanoseconds());
 }
 
+pub fn monotonicNanoTimestamp() i128 {
+    return @intCast(std.Io.Clock.awake.now(io()).toNanoseconds());
+}
+
 pub fn sleepNs(ns: u64) void {
     std.Io.sleep(io(), .fromNanoseconds(ns), .awake) catch {}; // interrupt wakes are fine; caller requested a sleep, not a guarantee
 }

--- a/tests/quic_h3_udp_smoke.zig
+++ b/tests/quic_h3_udp_smoke.zig
@@ -163,6 +163,10 @@ fn sawFiveInvalidTokens(snapshot: http3_runtime.Snapshot) bool {
     return snapshot.invalid_tokens >= 5 and snapshot.tracked_connections == 0;
 }
 
+fn sentFourRetries(snapshot: http3_runtime.Snapshot) bool {
+    return snapshot.retry_packets_sent >= 4;
+}
+
 fn hasPathValidationFailure(snapshot: http3_runtime.Snapshot) bool {
     return snapshot.path_validations_failed > 0 and snapshot.tracked_connections > 0;
 }
@@ -502,7 +506,7 @@ test "udp smoke: HTTP/3 runtime Retry sends tokenless Initials without tracked s
     }
     try testing.expectEqual(@as(usize, attempts), retries);
 
-    const snapshot = runtime.snapshot();
+    const snapshot = try waitRuntimeSnapshot(&runtime, sentFourRetries);
     try testing.expectEqual(@as(usize, attempts), snapshot.retry_packets_sent);
     try testing.expectEqual(@as(usize, 0), snapshot.retry_tokens_accepted);
     try testing.expectEqual(@as(usize, 0), snapshot.invalid_tokens);


### PR DESCRIPTION
## Summary
- add a competitive benchmark suite under `benchmarks/competitive/` for Tardigrade, NGINX, HAProxy, and Caddy
- add representative server config templates plus target metadata and fairness/interpreting docs
- emit combined JSON, CSV, and Markdown summaries, with `--print-manual`, `--allow-missing`, and CI-oriented `--smoke` paths

## Validation
- `bash -n benchmarks/competitive/run.sh`
- `./benchmarks/competitive/run.sh --print-manual --servers tardigrade --duration 1 --connections 1 --threads 1`
- `./benchmarks/competitive/run.sh --smoke --out-dir /tmp/tardigrade-competitive-smoke-7`
- `jq -e '.servers.tardigrade."static-tiny-http1".errors == 0 and (.servers.tardigrade._meta.server_version != null)' /tmp/tardigrade-competitive-smoke-7/competitive-results.json`
- `git diff --cached --check`

Full competitor run was not executed locally because NGINX, HAProxy, and Caddy are not installed on this machine.

Closes #149
