### PR TITLE
pki: [324-K] define revocation, OCSP, CRL, and stapling policy seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,9 +215,11 @@ All notable user-facing changes to Tardigrade are documented here.
   supplied by the caller and keyed solely by SHA-256 certificate identity — never
   by path position — so one evidence set is safely shared across candidate paths
   of different shape and depth. The end-entity must-staple obligation is scoped
-  to `status_request` alone: RFC 6961 `status_request_v2` is unusable in TLS 1.3
-  and is never offered by this stack, so per RFC 7633 §§4.1/4.3.3 a certificate
-  advertising it is not rejected over it. Unauthenticated evidence never
+  by RFC 7633 §§4.1/4.3.3 to features the ClientHello actually offered: RFC 6961
+  `status_request_v2` is unusable in TLS 1.3, and `status_request` itself is not
+  yet sent by this stack, so such certificates are accepted and reported as
+  `not_offered_by_client` rather than rejected. Wiring the extension is a matter
+  of setting `offered_status_request` from the hello actually emitted. Unauthenticated evidence never
   counts as a completed check by default; the one exception is a peer-stapled
   revocation, which can only condemn the peer itself. A stale `certificateHold`
   does not outrank fresher evidence of its RFC 5280 §5.3.1 release. No

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,27 @@ All notable user-facing changes to Tardigrade are documented here.
   orderly close).
 
 ### Features
+- **Certificate-status policy seam for revocation, OCSP, CRLs, and stapling
+  (#349)** — the pure-Zig PKI path now has an explicit, testable
+  certificate-status policy (`src/pki/revocation.zig`) with four modes:
+  `disabled` (the default), `stapled_only`, `soft_fail`, and `strict`. Every
+  accepted path carries a report naming, per certificate, what status evidence
+  was checked and what was not, so an acceptance never implies revocation was
+  verified — under the default policy the report says plainly that nothing was
+  checked. RFC 7633 must-staple is parsed (new TLS Feature extension support in
+  the X.509 model, including the CA-asserted form) and enforced in every mode
+  that consults status; under `disabled` the acceptance records
+  `must_staple_unenforced` rather than silently passing. Status evidence —
+  stapled responses, cached answers, CRL sets, with freshness bounds, defect
+  reasons, and an authentication flag — is supplied by the caller, and
+  unauthenticated evidence never counts as a completed check by default. No
+  validator code performs network or file I/O: a future fetch-and-cache
+  provider implements `revocation.Provider`, runs before validation, and
+  changes no TLS-handshake or path-validation signature. Certificate
+  Authority Information Access and CRL distribution points are now surfaced
+  through typed accessors. See
+  [docs/PKI_REVOCATION.md](docs/PKI_REVOCATION.md) for the modes, the trust
+  boundary, and the privacy/availability tradeoffs. Closes #349.
 - **QUIC negotiated TLS suite packet protection (#566)** — Handshake, 0-RTT,
   and 1-RTT packet protection now follows the TLS 1.3 cipher suite negotiated
   by the native QUIC handshake (`TLS_AES_128_GCM_SHA256`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,13 +202,22 @@ All notable user-facing changes to Tardigrade are documented here.
   accepted path carries a report naming, per certificate, what status evidence
   was checked and what was not, so an acceptance never implies revocation was
   verified — under the default policy the report says plainly that nothing was
-  checked. RFC 7633 must-staple is parsed (new TLS Feature extension support in
-  the X.509 model, including the CA-asserted form) and enforced in every mode
-  that consults status; under `disabled` the acceptance records
-  `must_staple_unenforced` rather than silently passing. Status evidence —
-  stapled responses, cached answers, CRL sets, with freshness bounds, defect
-  reasons, and an authentication flag — is supplied by the caller, and
-  unauthenticated evidence never counts as a completed check by default. No
+  checked, and `disabled` never rejects on evidence either, so a peer cannot
+  fail a handshake against a gateway with revocation switched off. RFC 7633
+  must-staple is parsed (new TLS Feature extension support in the X.509 model)
+  and enforced in every mode that consults status; the report distinguishes
+  `enforced` from both unenforced cases rather than silently passing. The
+  issuer form of the extension is enforced correctly as an RFC 7633 §4.2.2
+  chain constraint — every certificate a TLS-Feature-carrying CA signs must
+  assert the same feature set or a superset — rather than as a downward
+  stapling obligation. Status evidence — stapled responses, cached answers, CRL
+  sets, with freshness bounds, defect reasons, and an authentication flag — is
+  supplied by the caller and bound to a certificate by SHA-256 identity, so an
+  alternate or cross-signed candidate path can never consume evidence gathered
+  for a different certificate at the same index. Unauthenticated evidence never
+  counts as a completed check by default; the one exception is a peer-stapled
+  revocation, which can only condemn the peer itself. A stale `certificateHold`
+  does not outrank fresher evidence of its RFC 5280 §5.3.1 release. No
   validator code performs network or file I/O: a future fetch-and-cache
   provider implements `revocation.Provider`, runs before validation, and
   changes no TLS-handshake or path-validation signature. Certificate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,9 +212,11 @@ All notable user-facing changes to Tardigrade are documented here.
   assert the same feature set or a superset — rather than as a downward
   stapling obligation. Status evidence — stapled responses, cached answers, CRL
   sets, with freshness bounds, defect reasons, and an authentication flag — is
-  supplied by the caller and bound to a certificate by SHA-256 identity, so an
-  alternate or cross-signed candidate path can never consume evidence gathered
-  for a different certificate at the same index. Unauthenticated evidence never
+  supplied by the caller and keyed solely by SHA-256 certificate identity — never
+  by path position — so one evidence set is safely shared across candidate paths
+  of different shape and depth. RFC 6961 `status_request_v2` is reported as
+  unsatisfiable rather than enforced, because RFC 8446 §4.4.2.1 forbids a TLS
+  1.3 server from acting on it. Unauthenticated evidence never
   counts as a completed check by default; the one exception is a peer-stapled
   revocation, which can only condemn the peer itself. A stale `certificateHold`
   does not outrank fresher evidence of its RFC 5280 §5.3.1 release. No

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,9 +214,10 @@ All notable user-facing changes to Tardigrade are documented here.
   sets, with freshness bounds, defect reasons, and an authentication flag — is
   supplied by the caller and keyed solely by SHA-256 certificate identity — never
   by path position — so one evidence set is safely shared across candidate paths
-  of different shape and depth. RFC 6961 `status_request_v2` is reported as
-  unsatisfiable rather than enforced, because RFC 8446 §4.4.2.1 forbids a TLS
-  1.3 server from acting on it. Unauthenticated evidence never
+  of different shape and depth. The end-entity must-staple obligation is scoped
+  to `status_request` alone: RFC 6961 `status_request_v2` is unusable in TLS 1.3
+  and is never offered by this stack, so per RFC 7633 §§4.1/4.3.3 a certificate
+  advertising it is not rejected over it. Unauthenticated evidence never
   counts as a completed check by default; the one exception is a peer-stapled
   revocation, which can only condemn the peer itself. A stale `certificateHold`
   does not outrank fresher evidence of its RFC 5280 §5.3.1 release. No

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ operate without guessing which config file or pid file is active.
 | Proxy security | [docs/PROXY_SECURITY.md](docs/PROXY_SECURITY.md) |
 | Security test plan | [docs/SECURITY_TEST_PLAN.md](docs/SECURITY_TEST_PLAN.md) |
 | TLS interop & conformance matrix | [docs/TLS_INTEROP_MATRIX.md](docs/TLS_INTEROP_MATRIX.md) |
+| Certificate-status policy (revocation/OCSP/CRL) | [docs/PKI_REVOCATION.md](docs/PKI_REVOCATION.md) |
 | Pentest playbook | [docs/PENTEST_PLAYBOOK.md](docs/PENTEST_PLAYBOOK.md) |
 | Code review checklist | [docs/CODE_REVIEW_CHECKLIST.md](docs/CODE_REVIEW_CHECKLIST.md) |
 | Release checklist | [docs/RELEASE_CHECKLIST.md](docs/RELEASE_CHECKLIST.md) |

--- a/docs/PKI_REVOCATION.md
+++ b/docs/PKI_REVOCATION.md
@@ -77,27 +77,33 @@ propagates downward — the operational must-staple requirement is read from the
 end-entity certificate after the constraint holds. The trust anchor is excluded,
 like its other extensions: anchor restrictions are local trust configuration.
 
-### `status_request_v2` is not satisfiable here
+### `status_request_v2` creates no obligation here
 
-RFC 6961 `status_request_v2` (feature 17) is a different extension, and RFC 8446
-§4.4.2.1 obsoletes it for TLS 1.3: a TLS 1.3 server MUST NOT act on or send it.
-Tardigrade's native TLS path is TLS 1.3 only, so an ordinary `status_request`
-staple cannot demonstrate that a feature-17 declaration was honored, and
-reporting it as `enforced` would be exactly the "pretend we checked" outcome
-this policy exists to prevent.
+RFC 6961 `status_request_v2` (feature 17) is a different extension, obsoleted
+for TLS 1.3 by RFC 8446 §4.4.2.1: a TLS 1.3 server must not act on or send it.
+That does **not** make a certificate carrying feature 17 invalid. RFC 7633 §4.1
+says a client need not offer or support a feature merely because a certificate
+names it, and §4.3.3 scopes invalidity to features present in *both* the
+ClientHello and the certificate that the server then fails to satisfy.
 
-A leaf declaring feature 17 — alone or alongside feature 5 — is therefore
-rejected with `must_staple_feature_unsupported` in any mode that consults
-status, and recorded as `unsatisfiable_status_request_v2` under `disabled`.
-`x509.TlsFeatures.requiresStapledStatus` covers feature 5 only;
-`assertsStatusRequestV2` reports the declaration separately.
+Tardigrade's TLS path is TLS 1.3 only and never offers feature 17, so a
+certificate advertising it — typically to serve TLS 1.2 peers as well — is
+outside that intersection and is not rejected over it. The end-entity
+must-staple obligation is scoped to `status_request` (5) alone:
+`x509.TlsFeatures.requiresStapledStatus` covers feature 5, while
+`assertsStatusRequestV2` reports the declaration separately for a future
+implementation that carries the negotiated ClientHello feature set into policy
+and enforces the §4.3.3 intersection properly.
+
+Feature 17 does still participate in the RFC 7633 §4.2.2 issuer constraint
+above, which applies to every advertised feature.
 
 ### Reporting
 
 `Report.must_staple` records what became of the assertion — `not_required`,
 `enforced`, `unenforced_status_disabled` (the mode consults nothing),
-`unenforced_by_configuration` (`enforce_must_staple` is off), or
-`unsatisfiable_status_request_v2` — so an acceptance never reads as "honored"
+or `unenforced_by_configuration` (`enforce_must_staple` is off) — so an
+acceptance never reads as "honored"
 when it was merely not applied. Operators who deploy must-staple certificates
 behind Tardigrade should run at least `stapled_only`.
 
@@ -228,7 +234,6 @@ tightening the mode.
 | `revocation_status_malformed` | evidence the provider could not interpret |
 | `revocation_status_unauthenticated` | nobody verified the responder or CRL signature |
 | `revocation_must_staple_not_satisfied` | RFC 7633 assertion unmet |
-| `revocation_must_staple_feature_unsupported` | leaf demands `status_request_v2`, unsatisfiable on TLS 1.3 |
 | `revocation_source_unsupported` | certificate publishes no revocation mechanism |
 | `tls_feature_constraint_violation` | child does not assert its issuer's TLS Feature set (RFC 7633 §4.2.2) |
 | `revocation_resource_limit_exceeded` | evidence exceeded the configured bounds |

--- a/docs/PKI_REVOCATION.md
+++ b/docs/PKI_REVOCATION.md
@@ -62,10 +62,26 @@ and found nothing".
 An **end-entity** certificate carrying the TLS Feature extension with
 `status_request` (5) asserts that its server always delivers a stapled status
 response. Tardigrade parses the extension (`x509.Certificate.mustStaple`) and
-enforces it in every mode that consults status: the leaf must have a *stapled*,
-good, usable status, or the path is rejected with `must_staple_not_satisfied`. A
-cached or CRL answer does not substitute — the point of the assertion is the
-in-band delivery.
+enforces it in every mode that consults status — provided the connection asked
+for stapling: the leaf must have a *stapled*, good, usable status, or the path
+is rejected with `must_staple_not_satisfied`. A cached or CRL answer does not
+substitute; the point of the assertion is the in-band delivery.
+
+### The demand is scoped to what the ClientHello offered
+
+RFC 7633 §4.1 says a client need not offer or support a feature merely because a
+certificate names it, and §4.3.3 makes the certificate invalid only for features
+present in **both** the ClientHello and the certificate that the server then
+fails to satisfy. A client that never requested stapling cannot hold a server to
+having provided it.
+
+`Configuration.offered_status_request` carries that handshake fact into policy.
+It defaults to **false**, because Tardigrade's TLS 1.3 ClientHello does not
+currently send `status_request` — so today a must-staple certificate is accepted
+and reported as `not_offered_by_client` rather than rejected. A caller that
+wires the extension must set the flag from the hello it actually emitted, never
+from a constant. The validator cannot observe the handshake itself, so making
+this an input keeps the seam truthful instead of encoding an assumption.
 
 The **issuer** form is a different rule. RFC 7633 §4.2.2 makes a certificate
 carrying TLS Feature a constraint on what it signs: every certificate it issues
@@ -101,8 +117,9 @@ above, which applies to every advertised feature.
 ### Reporting
 
 `Report.must_staple` records what became of the assertion — `not_required`,
-`enforced`, `unenforced_status_disabled` (the mode consults nothing),
-or `unenforced_by_configuration` (`enforce_must_staple` is off) — so an
+`enforced`, `not_offered_by_client` (outside the §4.3.3 intersection),
+`unenforced_status_disabled` (the mode consults nothing), or
+`unenforced_by_configuration` (`enforce_must_staple` is off) — so an
 acceptance never reads as "honored"
 when it was merely not applied. Operators who deploy must-staple certificates
 behind Tardigrade should run at least `stapled_only`.

--- a/docs/PKI_REVOCATION.md
+++ b/docs/PKI_REVOCATION.md
@@ -77,12 +77,29 @@ propagates downward — the operational must-staple requirement is read from the
 end-entity certificate after the constraint holds. The trust anchor is excluded,
 like its other extensions: anchor restrictions are local trust configuration.
 
-`Report.must_staple` records what became of the assertion —
-`not_required`, `enforced`, `unenforced_status_disabled` (the mode consults
-nothing), or `unenforced_by_configuration` (`enforce_must_staple` is off) — so
-an acceptance never reads as "honored" when it was merely not applied.
-Operators who deploy must-staple certificates behind Tardigrade should run at
-least `stapled_only`.
+### `status_request_v2` is not satisfiable here
+
+RFC 6961 `status_request_v2` (feature 17) is a different extension, and RFC 8446
+§4.4.2.1 obsoletes it for TLS 1.3: a TLS 1.3 server MUST NOT act on or send it.
+Tardigrade's native TLS path is TLS 1.3 only, so an ordinary `status_request`
+staple cannot demonstrate that a feature-17 declaration was honored, and
+reporting it as `enforced` would be exactly the "pretend we checked" outcome
+this policy exists to prevent.
+
+A leaf declaring feature 17 — alone or alongside feature 5 — is therefore
+rejected with `must_staple_feature_unsupported` in any mode that consults
+status, and recorded as `unsatisfiable_status_request_v2` under `disabled`.
+`x509.TlsFeatures.requiresStapledStatus` covers feature 5 only;
+`assertsStatusRequestV2` reports the declaration separately.
+
+### Reporting
+
+`Report.must_staple` records what became of the assertion — `not_required`,
+`enforced`, `unenforced_status_disabled` (the mode consults nothing),
+`unenforced_by_configuration` (`enforce_must_staple` is off), or
+`unsatisfiable_status_request_v2` — so an acceptance never reads as "honored"
+when it was merely not applied. Operators who deploy must-staple certificates
+behind Tardigrade should run at least `stapled_only`.
 
 ## Evidence and the trust boundary
 
@@ -92,10 +109,15 @@ Evidence reaches validation as `revocation.StatusAssertion` values in
 `signature_verified`.
 
 Each assertion is bound to a certificate by `CertificateIdentity` (SHA-256 over
-its exact DER), not by position. `validateCandidates` offers one evidence set to
-every candidate, and cross-signed or alternate paths routinely carry different
-certificates at the same index; an assertion whose identity does not match the
-certificate at its index is ignored rather than applied.
+its exact DER) and by nothing else — there is deliberately no path index on a
+`StatusAssertion`. `validateCandidates` offers one evidence set to every
+candidate, and candidates differ in both shape and depth: a position-derived key
+would misdirect evidence onto the wrong certificate *and* let a longer
+candidate's assertions invalidate a shorter one. Evidence for a certificate that
+is not on the path being evaluated — including the trust anchor — is simply not
+consulted; it belongs to a sibling candidate, which is expected in a shared set.
+The report's per-certificate index is derived from the path actually being
+evaluated.
 
 `signature_verified` is asserted by whoever produced the evidence. This module
 does not verify OCSP responder signatures (that needs its own delegated-responder
@@ -206,9 +228,9 @@ tightening the mode.
 | `revocation_status_malformed` | evidence the provider could not interpret |
 | `revocation_status_unauthenticated` | nobody verified the responder or CRL signature |
 | `revocation_must_staple_not_satisfied` | RFC 7633 assertion unmet |
+| `revocation_must_staple_feature_unsupported` | leaf demands `status_request_v2`, unsatisfiable on TLS 1.3 |
 | `revocation_source_unsupported` | certificate publishes no revocation mechanism |
 | `tls_feature_constraint_violation` | child does not assert its issuer's TLS Feature set (RFC 7633 §4.2.2) |
-| `revocation_evidence_invalid` | evidence filed against a certificate not in the path |
 | `revocation_resource_limit_exceeded` | evidence exceeded the configured bounds |
 
 Failure values carry only enums and indices — never borrowed certificate bytes.

--- a/docs/PKI_REVOCATION.md
+++ b/docs/PKI_REVOCATION.md
@@ -41,6 +41,11 @@ consult only evidence the caller supplies; none reaches the network.
 | `soft_fail` | all sources | accept, recorded | accept, recorded | reject |
 | `strict` | all sources | **reject** | **reject** | reject |
 
+`disabled` never rejects, and that includes rejecting *on the evidence itself*:
+supplied assertions are not examined at all, so a peer cannot fail a handshake
+against a gateway that has revocation switched off by attaching oversized or
+misfiled status data.
+
 "Present-but-unusable" means stale, malformed, or unauthenticated evidence —
 the peer or provider offered an answer and the answer cannot be trusted.
 `stapled_only` draws the line there deliberately: a peer that staples nothing
@@ -54,21 +59,30 @@ and found nothing".
 
 ## Must-staple (RFC 7633)
 
-A certificate carrying the TLS Feature extension with `status_request` (5)
-asserts that its server always delivers a stapled status response. Tardigrade
-parses the extension (`x509.Certificate.mustStaple`) and enforces it in every
-mode that consults status: the leaf must have a *stapled*, good, usable status,
-or the path is rejected with `must_staple_not_satisfied`. A cached or CRL answer
-does not substitute — the point of the assertion is the in-band delivery.
+An **end-entity** certificate carrying the TLS Feature extension with
+`status_request` (5) asserts that its server always delivers a stapled status
+response. Tardigrade parses the extension (`x509.Certificate.mustStaple`) and
+enforces it in every mode that consults status: the leaf must have a *stapled*,
+good, usable status, or the path is rejected with `must_staple_not_satisfied`. A
+cached or CRL answer does not substitute — the point of the assertion is the
+in-band delivery.
 
-RFC 7633 §4.2.3 lets an issuing CA assert the feature on behalf of the
-certificates below it, so a must-staple assertion anywhere in the path binds the
-leaf.
+The **issuer** form is a different rule. RFC 7633 §4.2.2 makes a certificate
+carrying TLS Feature a constraint on what it signs: every certificate it issues
+must assert the same feature set or a superset of it. That is a chain
+constraint, enforced during path validation for *all* advertised features (not
+just `status_request`) and independently of the status mode; a violation is
+`tls_feature_constraint_violation`. It is not a stapling obligation that
+propagates downward — the operational must-staple requirement is read from the
+end-entity certificate after the constraint holds. The trust anchor is excluded,
+like its other extensions: anchor restrictions are local trust configuration.
 
-In `disabled` mode there is no evidence channel, so the assertion cannot be
-honored. Rather than silently ignore it, acceptance sets
-`Report.must_staple_unenforced`. Operators who deploy must-staple certificates
-behind Tardigrade should run at least `stapled_only`.
+`Report.must_staple` records what became of the assertion —
+`not_required`, `enforced`, `unenforced_status_disabled` (the mode consults
+nothing), or `unenforced_by_configuration` (`enforce_must_staple` is off) — so
+an acceptance never reads as "honored" when it was merely not applied.
+Operators who deploy must-staple certificates behind Tardigrade should run at
+least `stapled_only`.
 
 ## Evidence and the trust boundary
 
@@ -77,6 +91,12 @@ Evidence reaches validation as `revocation.StatusAssertion` values in
 `Defect` when the encoded response could not be interpreted, and
 `signature_verified`.
 
+Each assertion is bound to a certificate by `CertificateIdentity` (SHA-256 over
+its exact DER), not by position. `validateCandidates` offers one evidence set to
+every candidate, and cross-signed or alternate paths routinely carry different
+certificates at the same index; an assertion whose identity does not match the
+certificate at its index is ignored rather than applied.
+
 `signature_verified` is asserted by whoever produced the evidence. This module
 does not verify OCSP responder signatures (that needs its own delegated-responder
 path validation) or CRL signatures (that needs the CRL issuer's key). With
@@ -84,9 +104,17 @@ path validation) or CRL signatures (that needs the CRL issuer's key). With
 a completed check, so a peer cannot manufacture a "good" status by stapling
 bytes nobody authenticated. Turning it off is a deliberate downgrade.
 
-A *revoked* assertion is honored even when unverified or stale. The only party
-who can supply attacker-chosen stapled bytes is the peer being authenticated,
-and a peer revoking itself is not a threat; ignoring a stale revocation would be.
+One narrow exception: a **peer-stapled** `revoked` is honored unverified. The
+only party who can supply attacker-chosen stapled bytes is the peer being
+authenticated, and a peer revoking itself is not a threat. Evidence from a
+fetched responder or a CRL gets no such exception — trusting an unauthenticated
+`revoked` there would let an on-path attacker deny service with one forged
+response.
+
+Revocation is otherwise monotonic, so staleness does not rehabilitate it — with
+one exception in the other direction: RFC 5280 §5.3.1 allows `certificateHold`
+to be released via `removeFromCRL`, so a *stale* hold does not outrank fresher
+evidence of that release.
 
 ### Freshness
 
@@ -120,13 +148,22 @@ status evidence is supplied by the caller. A future fetch-and-cache provider
 implements `revocation.Provider` and runs *before* validation:
 
 ```zig
-var evidence = try provider.collect(allocator, .{
+var collected = try provider.collect(allocator, .{
     .path = candidate_path,
     .validation_time = now,
     .stapled = stapled_from_handshake,
 });
-policy.revocation_evidence = evidence;
+defer collected.deinit(allocator);
+policy.revocation_evidence = collected.evidence();
 ```
+
+`collect` returns a `CollectedEvidence` that **owns** its assertion array,
+allocated per call with the caller's allocator. That is deliberate: a real
+provider composes each result from stapled data plus cache and CRL lookups, and
+a single provider-owned scratch buffer would alias across concurrent handshakes
+while an unreleasable per-call array would grow without bound. Only the encoded
+`raw` blobs may borrow longer-lived cache storage, which must outlive the
+validation.
 
 That is the whole seam. Adding OCSP fetching, a response cache, or a CRL-set
 distribution channel changes no signature in the TLS handshake or in
@@ -170,6 +207,7 @@ tightening the mode.
 | `revocation_status_unauthenticated` | nobody verified the responder or CRL signature |
 | `revocation_must_staple_not_satisfied` | RFC 7633 assertion unmet |
 | `revocation_source_unsupported` | certificate publishes no revocation mechanism |
+| `tls_feature_constraint_violation` | child does not assert its issuer's TLS Feature set (RFC 7633 §4.2.2) |
 | `revocation_evidence_invalid` | evidence filed against a certificate not in the path |
 | `revocation_resource_limit_exceeded` | evidence exceeded the configured bounds |
 

--- a/docs/PKI_REVOCATION.md
+++ b/docs/PKI_REVOCATION.md
@@ -1,0 +1,186 @@
+# Certificate-status policy: revocation, OCSP, CRLs, and stapling
+
+Tardigrade's pure-Zig PKI path validates certification paths per RFC 5280 and
+RFC 9618. This document covers the layer above that: deciding whether a
+certificate has been *revoked*, and what the gateway does when it cannot tell.
+
+The implementation is `src/pki/revocation.zig`, wired into
+`src/pki/path_validator.zig`. Online fetching of OCSP responses and CRLs is not
+implemented yet; the policy, the data model, and the reporting are, so nothing
+in the stack has to guess what an acceptance means.
+
+## The one rule
+
+**A path acceptance never implies revocation was checked.** Every accepted path
+carries a `revocation.Report` naming, per certificate, exactly what evidence was
+consulted and what was not. The default policy checks nothing, and says so.
+
+```zig
+var result = pki.path_validator.validateCandidates(allocator, candidates, policy, provider);
+switch (result) {
+    .accepted => |path| {
+        // .disabled, and every entry `not_checked_policy_disabled`
+        std.debug.print("status mode: {s}\n", .{@tagName(path.revocation.mode)});
+        if (!path.revocation.allChecked()) {
+            // No certificate in this path has a completed status check.
+        }
+    },
+    .rejected => |failure| { /* `failure.reason` names the revocation verdict */ },
+}
+```
+
+## Modes
+
+`revocation.Configuration.mode` selects one of four behaviors. All of them
+consult only evidence the caller supplies; none reaches the network.
+
+| Mode | Consults | Missing status | Present-but-unusable status | Revoked |
+| --- | --- | --- | --- | --- |
+| `disabled` (default) | nothing | accept, recorded | n/a | n/a |
+| `stapled_only` | stapled OCSP | accept, recorded | **reject** | reject |
+| `soft_fail` | all sources | accept, recorded | accept, recorded | reject |
+| `strict` | all sources | **reject** | **reject** | reject |
+
+"Present-but-unusable" means stale, malformed, or unauthenticated evidence —
+the peer or provider offered an answer and the answer cannot be trusted.
+`stapled_only` draws the line there deliberately: a peer that staples nothing
+never promised anything, but a peer that staples a broken response did.
+
+`strict` additionally rejects a certificate that publishes no revocation
+mechanism at all (no OCSP responder in Authority Information Access, no CRL
+distribution point), because no future provider could ever satisfy the policy
+for it. That verdict is `status_source_unsupported`, distinct from "we looked
+and found nothing".
+
+## Must-staple (RFC 7633)
+
+A certificate carrying the TLS Feature extension with `status_request` (5)
+asserts that its server always delivers a stapled status response. Tardigrade
+parses the extension (`x509.Certificate.mustStaple`) and enforces it in every
+mode that consults status: the leaf must have a *stapled*, good, usable status,
+or the path is rejected with `must_staple_not_satisfied`. A cached or CRL answer
+does not substitute — the point of the assertion is the in-band delivery.
+
+RFC 7633 §4.2.3 lets an issuing CA assert the feature on behalf of the
+certificates below it, so a must-staple assertion anywhere in the path binds the
+leaf.
+
+In `disabled` mode there is no evidence channel, so the assertion cannot be
+honored. Rather than silently ignore it, acceptance sets
+`Report.must_staple_unenforced`. Operators who deploy must-staple certificates
+behind Tardigrade should run at least `stapled_only`.
+
+## Evidence and the trust boundary
+
+Evidence reaches validation as `revocation.StatusAssertion` values in
+`ValidationPolicy.revocation_evidence` — status, source, timestamps, an optional
+`Defect` when the encoded response could not be interpreted, and
+`signature_verified`.
+
+`signature_verified` is asserted by whoever produced the evidence. This module
+does not verify OCSP responder signatures (that needs its own delegated-responder
+path validation) or CRL signatures (that needs the CRL issuer's key). With
+`require_signature_verified` — the default — unverified evidence never counts as
+a completed check, so a peer cannot manufacture a "good" status by stapling
+bytes nobody authenticated. Turning it off is a deliberate downgrade.
+
+A *revoked* assertion is honored even when unverified or stale. The only party
+who can supply attacker-chosen stapled bytes is the peer being authenticated,
+and a peer revoking itself is not a threat; ignoring a stale revocation would be.
+
+### Freshness
+
+`revocation.Freshness` bounds how old evidence may be:
+
+- `clock_skew_seconds` (default 300) — tolerance on both sides of every
+  comparison, so a modest clock offset does not fail handshakes.
+- `maximum_age_seconds` (default 7 days) — maximum age of `thisUpdate`.
+  Evidence with no `thisUpdate` cannot be aged and is unusable while this is set.
+- `require_next_update` (default true) — RFC 6960 §2.4 permits an absent
+  `nextUpdate`, but evidence with no stated expiry can never be aged out of a
+  cache, so it is unusable by default.
+
+Evidence dated in the future beyond the skew allowance, or whose `nextUpdate`
+precedes its `thisUpdate`, is incoherent and unusable.
+
+### Source precedence
+
+When several sources answer for the same certificate, a usable `revoked` from
+*any* source decides — a second source cannot launder a revocation away.
+Otherwise the highest-precedence source wins: stapled, then cached, then CRL
+set; within one source, a definite answer beats `unknown`. When nothing is
+usable, the highest-precedence blocked assertion is reported, so the operator
+learns *why* rather than just "unavailable".
+
+## No ambient I/O
+
+No code in `src/pki/` opens a socket, reads a file, or reads a clock during
+validation. Validation time is injected (`ValidationPolicy.validation_time`) and
+status evidence is supplied by the caller. A future fetch-and-cache provider
+implements `revocation.Provider` and runs *before* validation:
+
+```zig
+var evidence = try provider.collect(allocator, .{
+    .path = candidate_path,
+    .validation_time = now,
+    .stapled = stapled_from_handshake,
+});
+policy.revocation_evidence = evidence;
+```
+
+That is the whole seam. Adding OCSP fetching, a response cache, or a CRL-set
+distribution channel changes no signature in the TLS handshake or in
+`path_validator`, and cannot introduce blocking I/O into path validation,
+because path validation has no way to call out.
+
+## Operational tradeoffs
+
+**Privacy.** Online OCSP tells the CA which site each visitor is reaching, from
+which IP, and when — a per-connection disclosure to a third party. Stapling
+removes it: the server fetches its own status and delivers it in-band, so the
+responder learns about servers, not visitors. This is why `stapled_only` is the
+recommended first step rather than a fetching mode, and why any future fetch
+provider must be opt-in.
+
+**Availability.** Hard-failing on unreachable revocation infrastructure converts
+a responder outage into a gateway outage, which is why most deployed TLS stacks
+soft-fail — and why soft-fail revocation gives an on-path attacker who can block
+the responder exactly the outcome they want. Tardigrade does not resolve that
+dilemma by picking a comfortable default and hiding it; it names the modes and
+records the result. `strict` is honest but demands a status pipeline that is at
+least as available as the gateway.
+
+**Operations.** CRL sets are cheap at handshake time and stale by construction;
+OCSP is fresher and adds latency and a dependency. Stapling shifts both cost and
+dependency to the server operator, where they are visible and controllable. The
+`Report` is the observability hook: it distinguishes "checked and good" from
+"nothing was checked" so a deployment can measure its actual coverage before
+tightening the mode.
+
+## Failure reasons
+
+`path_validator.FailureReason` gains:
+
+| Reason | Meaning |
+| --- | --- |
+| `certificate_revoked` | usable evidence says revoked |
+| `revocation_status_unavailable` | the mode requires an answer; none was usable |
+| `revocation_status_stale` | evidence outside the freshness window |
+| `revocation_status_malformed` | evidence the provider could not interpret |
+| `revocation_status_unauthenticated` | nobody verified the responder or CRL signature |
+| `revocation_must_staple_not_satisfied` | RFC 7633 assertion unmet |
+| `revocation_source_unsupported` | certificate publishes no revocation mechanism |
+| `revocation_evidence_invalid` | evidence filed against a certificate not in the path |
+| `revocation_resource_limit_exceeded` | evidence exceeded the configured bounds |
+
+Failure values carry only enums and indices — never borrowed certificate bytes.
+
+## Not implemented yet
+
+- Fetching OCSP responses or CRLs, and any cache behind that.
+- Decoding OCSP responses and CRLs into `StatusAssertion` values, including
+  responder-signature verification and delegated-responder path validation
+  (`id-pkix-ocsp-nocheck` is defined in `oid.zig` for that work).
+- Wiring stapled responses from the TLS handshake into `Evidence`.
+
+Each is additive against the seam described here.

--- a/src/pki/oid.zig
+++ b/src/pki/oid.zig
@@ -167,6 +167,11 @@ pub const well_known = struct {
     pub const ext_key_usage = [_]u32{ 2, 5, 29, 37 };
     pub const inhibit_any_policy = [_]u32{ 2, 5, 29, 54 };
     pub const authority_info_access = [_]u32{ 1, 3, 6, 1, 5, 5, 7, 1, 1 };
+    /// RFC 7633 TLS Feature extension; carries the must-staple assertion.
+    pub const tls_feature = [_]u32{ 1, 3, 6, 1, 5, 5, 7, 1, 24 };
+    /// RFC 6960 §4.2.2.2.1: a responder certificate that need not itself be
+    /// revocation-checked.
+    pub const ocsp_no_check = [_]u32{ 1, 3, 6, 1, 5, 5, 7, 48, 1, 5 };
 
     // Certificate-policy qualifiers.
     pub const policy_qualifier_cps = [_]u32{ 1, 3, 6, 1, 5, 5, 7, 2, 1 };

--- a/src/pki/path_validator.zig
+++ b/src/pki/path_validator.zig
@@ -92,6 +92,7 @@ pub const FailureReason = enum {
     policy_constraints_invalid,
     inhibit_any_policy_invalid,
     certificate_policy_resource_limit_exceeded,
+    tls_feature_constraint_violation,
     certificate_revoked,
     revocation_status_unavailable,
     revocation_status_stale,
@@ -236,6 +237,10 @@ pub fn validatePath(
         if (!usage.digital_signature) return rejectOid(.key_usage_violation, 0, &wk.key_usage);
     }
 
+    if (checkTlsFeatureConstraints(path)) |validation_failure| {
+        return .{ .rejected = validation_failure };
+    }
+
     if (policy.require_server_auth_eku) {
         // A present EKU restricts every non-anchor certificate in the path;
         // absence is unrestricted. Trust-anchor purpose is configuration.
@@ -371,6 +376,39 @@ fn checkStructure(path: path_builder.Path, policy: ValidationPolicy) ?Validation
         }
     }
     return null;
+}
+
+/// RFC 7633 §4.2.2: a certificate-signing certificate carrying the TLS Feature
+/// extension constrains what it signs — every certificate it issues must assert
+/// the same feature set or a superset of it. This is a chain constraint on the
+/// extension's contents, not a stapling obligation that propagates downward:
+/// the operational must-staple requirement is read from the end-entity
+/// certificate, after this constraint holds (see `revocation.zig`).
+///
+/// The terminal trust anchor is excluded for the same reason its other
+/// extensions are: anchor restrictions are local trust configuration.
+fn checkTlsFeatureConstraints(path: path_builder.Path) ?ValidationFailure {
+    const anchor_index = path.elements.len - 1;
+    for (path.elements[1..anchor_index], 1..) |issuer, issuer_index| {
+        const required = issuer.certificate.tlsFeatures() orelse continue;
+        const child_index = issuer_index - 1;
+        const child = path.elements[child_index].certificate.tlsFeatures() orelse
+            return tlsFeatureFailure(child_index, issuer_index);
+        for (required.features) |feature| {
+            if (!child.contains(feature)) return tlsFeatureFailure(child_index, issuer_index);
+        }
+    }
+    return null;
+}
+
+fn tlsFeatureFailure(certificate_index: usize, issuer_index: usize) ValidationFailure {
+    return .{
+        .reason = .tls_feature_constraint_violation,
+        .certificate_index = certificate_index,
+        // Compile-time well-known OID, below the fixed component bound.
+        .extension_oid = oid.ObjectIdentifier.fromComponents(&wk.tls_feature) catch unreachable,
+        .constraint_certificate_index = issuer_index,
+    };
 }
 
 fn checkExtensions(certificate: *const x509.Certificate, certificate_index: usize) ?ValidationFailure {

--- a/src/pki/path_validator.zig
+++ b/src/pki/path_validator.zig
@@ -17,7 +17,11 @@
 //!   directoryName, dNSName, rfc822Name, URI, and IP forms;
 //! - certificate policies use the bounded RFC 9618 policy graph. The default
 //!   user policy is anyPolicy with no initial inhibition, preserving ordinary
-//!   validation compatibility while returning deterministic constrained sets.
+//!   validation compatibility while returning deterministic constrained sets;
+//! - certificate-status policy (revocation, OCSP, stapling, must-staple) is
+//!   evaluated from caller-supplied evidence only. It defaults to disabled and
+//!   records that fact in the accepted result rather than implying a check
+//!   happened. See `revocation.zig` for the seam and its trust boundary.
 
 const std = @import("std");
 const certificate_policy = @import("certificate_policy.zig");
@@ -26,6 +30,7 @@ const identity = @import("identity.zig");
 const name_constraints = @import("name_constraints.zig");
 const oid = @import("oid.zig");
 const path_builder = @import("path_builder.zig");
+const revocation = @import("revocation.zig");
 const verify = @import("verify.zig");
 const x509 = @import("x509.zig");
 
@@ -43,6 +48,14 @@ pub const ValidationPolicy = struct {
     maximum_extensions_per_certificate: usize = 64,
     name_constraints: name_constraints.Limits = .{},
     certificate_policy: certificate_policy.Configuration = .{},
+    /// Certificate-status policy. Defaults to disabled: no status is consulted
+    /// and the accepted result says so.
+    revocation: revocation.Configuration = .{},
+    /// Status evidence for this validation, collected by the caller before the
+    /// call. Borrowed. The validator performs no network or file I/O of any
+    /// kind, so a future fetch/cache provider fills this in without changing
+    /// this signature.
+    revocation_evidence: revocation.Evidence = .{},
     /// Anchors passed to `path_builder.build`, in the same order. Borrowed for
     /// the call only. The terminal element's input index and DER must match.
     trust_anchors: []const x509.Certificate,
@@ -79,6 +92,15 @@ pub const FailureReason = enum {
     policy_constraints_invalid,
     inhibit_any_policy_invalid,
     certificate_policy_resource_limit_exceeded,
+    certificate_revoked,
+    revocation_status_unavailable,
+    revocation_status_stale,
+    revocation_status_malformed,
+    revocation_status_unauthenticated,
+    revocation_must_staple_not_satisfied,
+    revocation_source_unsupported,
+    revocation_evidence_invalid,
+    revocation_resource_limit_exceeded,
     identity_mismatch,
     invalid_identity_reference,
     validation_resource_limit_exceeded,
@@ -98,6 +120,9 @@ pub const ValidationFailure = struct {
     policy_oid: ?oid.ObjectIdentifier = null,
     policy_graph_depth: ?usize = null,
     policy_stage: ?certificate_policy.Stage = null,
+    revocation_source: ?revocation.Source = null,
+    revocation_defect: ?revocation.Defect = null,
+    revocation_reason: ?revocation.CrlReason = null,
 };
 
 pub const AcceptedPath = struct {
@@ -106,6 +131,10 @@ pub const AcceptedPath = struct {
     accepted_path: []const path_builder.Element,
     /// Owned RFC 9618 policy outputs. Qualifiers are intentionally omitted.
     policies: certificate_policy.PolicyResult,
+    /// Owned record of what certificate-status evidence was checked, and what
+    /// was not. Present on every acceptance, including the default disabled
+    /// policy, so callers never have to assume revocation was verified.
+    revocation: revocation.Report,
 };
 
 pub const ValidationResult = union(enum) {
@@ -118,6 +147,8 @@ pub const ValidationResult = union(enum) {
                 allocator.free(accepted_value.accepted_path);
                 var policies = accepted_value.policies;
                 policies.deinit(allocator);
+                var report = accepted_value.revocation;
+                report.deinit(allocator);
             },
             .rejected => {},
         }
@@ -226,24 +257,47 @@ pub fn validatePath(
         .failure => |policy_failure| return .{ .rejected = certificatePolicyFailure(policy_failure) },
     };
 
+    // Certificate-status policy runs on caller-supplied evidence only; it
+    // never reaches a responder, a CRL endpoint, or the filesystem.
+    var status_report = switch (revocation.evaluatePath(
+        allocator,
+        path,
+        policy.revocation,
+        policy.revocation_evidence,
+        policy.validation_time,
+    )) {
+        .accepted => |report| report,
+        .rejected => |status_failure| {
+            policies.deinit(allocator);
+            return .{ .rejected = revocationFailure(status_failure) };
+        },
+    };
+
     // Identity is intentionally last: no path is accepted based on a name
     // match before its signatures and RFC 5280 policy checks succeed.
     if (policy.expected_dns_name) |expected| {
         const verdict = identity.verifyHost(leaf, expected) catch {
             policies.deinit(allocator);
+            status_report.deinit(allocator);
             return reject(.invalid_identity_reference, 0);
         };
         if (!verdict.isMatch()) {
             policies.deinit(allocator);
+            status_report.deinit(allocator);
             return reject(.identity_mismatch, 0);
         }
     }
 
     const owned = allocator.dupe(path_builder.Element, path.elements) catch {
         policies.deinit(allocator);
+        status_report.deinit(allocator);
         return rejectWithoutCertificate(.out_of_memory);
     };
-    return .{ .accepted = .{ .accepted_path = owned, .policies = policies } };
+    return .{ .accepted = .{
+        .accepted_path = owned,
+        .policies = policies,
+        .revocation = status_report,
+    } };
 }
 
 /// Validate candidates in builder order and return the first accepted path.
@@ -354,7 +408,10 @@ fn criticalExtensionHandled(extension_oid: *const oid.ObjectIdentifier) bool {
         extension_oid.eqlComponents(&wk.policy_constraints) or
         extension_oid.eqlComponents(&wk.inhibit_any_policy) or
         extension_oid.eqlComponents(&wk.subject_key_identifier) or
-        extension_oid.eqlComponents(&wk.authority_key_identifier);
+        extension_oid.eqlComponents(&wk.authority_key_identifier) or
+        // RFC 7633 permits a critical TLS Feature extension; `revocation.zig`
+        // now processes must-staple, so it is no longer unhandled.
+        extension_oid.eqlComponents(&wk.tls_feature);
 }
 
 fn certificatePolicyFailure(policy_failure: certificate_policy.Failure) ValidationFailure {
@@ -375,6 +432,28 @@ fn certificatePolicyFailure(policy_failure: certificate_policy.Failure) Validati
         .policy_oid = policy_failure.policy_oid,
         .policy_graph_depth = policy_failure.graph_depth,
         .policy_stage = policy_failure.stage,
+    };
+}
+
+fn revocationFailure(status_failure: revocation.Failure) ValidationFailure {
+    const reason: FailureReason = switch (status_failure.reason) {
+        .certificate_revoked => .certificate_revoked,
+        .status_unavailable => .revocation_status_unavailable,
+        .status_stale => .revocation_status_stale,
+        .status_malformed => .revocation_status_malformed,
+        .status_unauthenticated => .revocation_status_unauthenticated,
+        .must_staple_not_satisfied => .revocation_must_staple_not_satisfied,
+        .status_source_unsupported => .revocation_source_unsupported,
+        .evidence_index_invalid => .revocation_evidence_invalid,
+        .resource_limit_exceeded => .revocation_resource_limit_exceeded,
+        .out_of_memory => .out_of_memory,
+    };
+    return .{
+        .reason = reason,
+        .certificate_index = status_failure.certificate_index,
+        .revocation_source = status_failure.source,
+        .revocation_defect = status_failure.defect,
+        .revocation_reason = status_failure.revocation_reason,
     };
 }
 

--- a/src/pki/path_validator.zig
+++ b/src/pki/path_validator.zig
@@ -99,7 +99,6 @@ pub const FailureReason = enum {
     revocation_status_malformed,
     revocation_status_unauthenticated,
     revocation_must_staple_not_satisfied,
-    revocation_must_staple_feature_unsupported,
     revocation_source_unsupported,
     revocation_resource_limit_exceeded,
     identity_mismatch,
@@ -481,7 +480,6 @@ fn revocationFailure(status_failure: revocation.Failure) ValidationFailure {
         .status_malformed => .revocation_status_malformed,
         .status_unauthenticated => .revocation_status_unauthenticated,
         .must_staple_not_satisfied => .revocation_must_staple_not_satisfied,
-        .must_staple_feature_unsupported => .revocation_must_staple_feature_unsupported,
         .status_source_unsupported => .revocation_source_unsupported,
         // `checkStructure` already guarantees a well-formed candidate path, so
         // this is unreachable from `validatePath`; it stays mapped for direct

--- a/src/pki/path_validator.zig
+++ b/src/pki/path_validator.zig
@@ -99,8 +99,8 @@ pub const FailureReason = enum {
     revocation_status_malformed,
     revocation_status_unauthenticated,
     revocation_must_staple_not_satisfied,
+    revocation_must_staple_feature_unsupported,
     revocation_source_unsupported,
-    revocation_evidence_invalid,
     revocation_resource_limit_exceeded,
     identity_mismatch,
     invalid_identity_reference,
@@ -481,8 +481,12 @@ fn revocationFailure(status_failure: revocation.Failure) ValidationFailure {
         .status_malformed => .revocation_status_malformed,
         .status_unauthenticated => .revocation_status_unauthenticated,
         .must_staple_not_satisfied => .revocation_must_staple_not_satisfied,
+        .must_staple_feature_unsupported => .revocation_must_staple_feature_unsupported,
         .status_source_unsupported => .revocation_source_unsupported,
-        .evidence_index_invalid => .revocation_evidence_invalid,
+        // `checkStructure` already guarantees a well-formed candidate path, so
+        // this is unreachable from `validatePath`; it stays mapped for direct
+        // `revocation.evaluatePath` callers.
+        .malformed_path => .malformed_path,
         .resource_limit_exceeded => .revocation_resource_limit_exceeded,
         .out_of_memory => .out_of_memory,
     };

--- a/src/pki/path_validator_tests.zig
+++ b/src/pki/path_validator_tests.zig
@@ -3925,7 +3925,9 @@ test "a must-staple leaf is rejected without a stapled good status" {
     const cp = cryptoProvider(&entropy, &provider);
 
     var validation_policy = policy(fx.certs.items[1..2]);
-    validation_policy.revocation = .{ .mode = .soft_fail };
+    // The certificate's demand only binds because this connection offered
+    // `status_request` (RFC 7633 §4.3.3).
+    validation_policy.revocation = .{ .mode = .soft_fail, .offered_status_request = true };
     var missing = try validateBuilt(testing.allocator, &fx.certs.items[0], &.{}, fx.certs.items[1..2], validation_policy, cp);
     defer missing.deinit(testing.allocator);
     try expectRejected(&missing, .revocation_must_staple_not_satisfied, 0);
@@ -3939,12 +3941,24 @@ test "a must-staple leaf is rejected without a stapled good status" {
 
     // With status checking off, the assertion is unenforceable — and the
     // result says so instead of implying it was honored.
-    var disabled = try validateBuilt(testing.allocator, &fx.certs.items[0], &.{}, fx.certs.items[1..2], policy(fx.certs.items[1..2]), cp);
+    var disabled_policy = policy(fx.certs.items[1..2]);
+    disabled_policy.revocation = .{ .offered_status_request = true };
+    var disabled = try validateBuilt(testing.allocator, &fx.certs.items[0], &.{}, fx.certs.items[1..2], disabled_policy, cp);
     defer disabled.deinit(testing.allocator);
     try expectAccepted(&disabled, 2);
     try testing.expectEqual(
         revocation.MustStapleOutcome.unenforced_status_disabled,
         disabled.accepted.revocation.must_staple,
+    );
+
+    // And with the extension never offered, the certificate makes no demand of
+    // this handshake at all.
+    var not_offered = try validateBuilt(testing.allocator, &fx.certs.items[0], &.{}, fx.certs.items[1..2], policy(fx.certs.items[1..2]), cp);
+    defer not_offered.deinit(testing.allocator);
+    try expectAccepted(&not_offered, 2);
+    try testing.expectEqual(
+        revocation.MustStapleOutcome.not_offered_by_client,
+        not_offered.accepted.revocation.must_staple,
     );
 }
 
@@ -4123,7 +4137,7 @@ test "an issuer's TLS Feature set constrains what its children must assert" {
         statusAssertion(&fx.certs.items[0], .stapled_ocsp, .good),
     };
     var validation_policy = policy(anchors);
-    validation_policy.revocation = .{ .mode = .stapled_only };
+    validation_policy.revocation = .{ .mode = .stapled_only, .offered_status_request = true };
     validation_policy.revocation_evidence = .{ .assertions = &assertions };
     var missing = try validateBuilt(testing.allocator, &fx.certs.items[0], intermediates, anchors, validation_policy, cp);
     defer missing.deinit(testing.allocator);
@@ -4139,13 +4153,14 @@ test "an issuer's TLS Feature set constrains what its children must assert" {
     // Same set and superset both satisfy the constraint, and then normal leaf
     // must-staple processing applies. The superset leaf also declares feature
     // 17; the §4.2.2 constraint covers every advertised feature, while the
-    // end-entity obligation stays scoped to feature 5.
+    // end-entity obligation stays scoped to feature 5 — and here to a hello
+    // that never offered `status_request`.
     for (fx.certs.items[1..3], 1..) |_, index| {
         var accepted = try validateBuilt(testing.allocator, &fx.certs.items[index], intermediates, anchors, policy(anchors), cp);
         defer accepted.deinit(testing.allocator);
         try expectAccepted(&accepted, 3);
         try testing.expectEqual(
-            revocation.MustStapleOutcome.unenforced_status_disabled,
+            revocation.MustStapleOutcome.not_offered_by_client,
             accepted.accepted.revocation.must_staple,
         );
     }

--- a/src/pki/path_validator_tests.zig
+++ b/src/pki/path_validator_tests.zig
@@ -332,6 +332,9 @@ const Spec = struct {
     inhibit_any_policy_critical: bool = true,
     unknown_critical: bool = false,
     unknown_noncritical: bool = false,
+    /// RFC 7633 TLS Feature values; `status_request` is must-staple.
+    tls_features: ?[]const u16 = null,
+    tls_features_critical: bool = false,
 };
 
 const Fixtures = struct {
@@ -446,6 +449,21 @@ const Fixtures = struct {
         }
         if (spec.raw_inhibit_any_policy) |value| {
             try extensions.append(arena, try extensionTlv(arena, &oid.well_known.inhibit_any_policy, true, value));
+        }
+        if (spec.tls_features) |features| {
+            var feature_parts: std.ArrayList([]const u8) = .empty;
+            defer feature_parts.deinit(arena);
+            for (features) |feature| {
+                try feature_parts.append(arena, try tlv(arena, 0x02, &.{
+                    try nonNegativeIntegerContent(arena, feature),
+                }));
+            }
+            try extensions.append(arena, try extensionTlv(
+                arena,
+                &oid.well_known.tls_feature,
+                spec.tls_features_critical,
+                try tlv(arena, 0x30, feature_parts.items),
+            ));
         }
         const unknown_oid = [_]u32{ 1, 2, 3, 4 };
         if (spec.unknown_critical) {
@@ -3314,6 +3332,15 @@ fn expectSameVerdict(first: validator.ValidationResult, second: validator.Valida
                 try expectSameOidSlice(mine.policies.authority_constrained, other.policies.authority_constrained);
                 try expectSameOidSlice(mine.policies.user_constrained, other.policies.user_constrained);
                 try testing.expectEqual(mine.policies.resource_usage, other.policies.resource_usage);
+                // The certificate-status record is part of the accepted result
+                // for the same reason: two runs that agreed on the path but
+                // disagreed on what evidence was checked are not deterministic.
+                try testing.expectEqual(mine.revocation.mode, other.revocation.mode);
+                try testing.expectEqual(mine.revocation.must_staple_unenforced, other.revocation.must_staple_unenforced);
+                try testing.expectEqual(mine.revocation.entries.len, other.revocation.entries.len);
+                for (mine.revocation.entries, other.revocation.entries) |a, b| {
+                    try testing.expectEqual(a, b);
+                }
             },
             .rejected => return error.TestUnexpectedResult,
         },
@@ -3331,6 +3358,9 @@ fn expectSameVerdict(first: validator.ValidationResult, second: validator.Valida
                 try testing.expectEqual(mine.name_form, other.name_form);
                 try testing.expectEqual(mine.policy_stage, other.policy_stage);
                 try testing.expectEqual(mine.policy_graph_depth, other.policy_graph_depth);
+                try testing.expectEqual(mine.revocation_source, other.revocation_source);
+                try testing.expectEqual(mine.revocation_defect, other.revocation_defect);
+                try testing.expectEqual(mine.revocation_reason, other.revocation_reason);
                 try expectSameOptionalOid(mine.extension_oid, other.extension_oid);
                 try expectSameOptionalOid(mine.policy_oid, other.policy_oid);
             },
@@ -3772,6 +3802,235 @@ fn fuzzPathValidation(_: void, smith: *testing.Smith) !void {
     var fail_index: usize = 0;
     while (true) : (fail_index += 1) {
         var failing = testing.FailingAllocator.init(allocator, .{ .fail_index = fail_index });
+        var attempt = validator.validateCandidates(failing.allocator(), candidates, validation_policy, cp);
+        attempt.deinit(failing.allocator());
+        if (!failing.has_induced_failure) break;
+        try testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
+    }
+}
+
+// --- Certificate-status policy through the validator (#349) -----------------
+
+const revocation = @import("revocation.zig");
+
+fn statusAssertion(certificate_index: usize, source: revocation.Source, status: revocation.Status) revocation.StatusAssertion {
+    return .{
+        .certificate_index = certificate_index,
+        .source = source,
+        .status = status,
+        .signature_verified = true,
+        .this_update = validation_time - 3600,
+        .next_update = validation_time + 3600,
+    };
+}
+
+test "an accepted path records that revocation was not checked by default" {
+    var fx = Fixtures.init(testing.allocator);
+    defer fx.deinit();
+    try addValidChain(&fx, 1);
+
+    var entropy: crypto.pure_zig.DeterministicEntropy = undefined;
+    var provider: crypto.pure_zig.Provider = undefined;
+    const cp = cryptoProvider(&entropy, &provider);
+    var result = try validateBuilt(testing.allocator, &fx.certs.items[0], fx.certs.items[1..2], fx.certs.items[2..3], policy(fx.certs.items[2..3]), cp);
+    defer result.deinit(testing.allocator);
+    try expectAccepted(&result, 3);
+
+    // The acceptance is explicit about having checked nothing, rather than
+    // leaving a caller to assume revocation was verified.
+    const report = result.accepted.revocation;
+    try testing.expectEqual(revocation.Mode.disabled, report.mode);
+    try testing.expectEqual(@as(usize, 2), report.entries.len);
+    for (report.entries) |entry| {
+        try testing.expectEqual(revocation.Determination.not_checked_policy_disabled, entry.determination);
+    }
+    try testing.expect(!report.allChecked());
+}
+
+test "stapled status evidence is carried onto the accepted path" {
+    var fx = Fixtures.init(testing.allocator);
+    defer fx.deinit();
+    try addValidChain(&fx, 1);
+
+    const assertions = [_]revocation.StatusAssertion{
+        statusAssertion(0, .stapled_ocsp, .good),
+        statusAssertion(1, .cached_ocsp, .good),
+    };
+    var validation_policy = policy(fx.certs.items[2..3]);
+    validation_policy.revocation = .{ .mode = .strict };
+    validation_policy.revocation_evidence = .{ .assertions = &assertions };
+
+    var entropy: crypto.pure_zig.DeterministicEntropy = undefined;
+    var provider: crypto.pure_zig.Provider = undefined;
+    const cp = cryptoProvider(&entropy, &provider);
+    var result = try validateBuilt(testing.allocator, &fx.certs.items[0], fx.certs.items[1..2], fx.certs.items[2..3], validation_policy, cp);
+    defer result.deinit(testing.allocator);
+    try expectAccepted(&result, 3);
+
+    const report = result.accepted.revocation;
+    try testing.expect(report.allChecked());
+    try testing.expectEqual(revocation.Source.stapled_ocsp, report.entryFor(0).?.source.?);
+    try testing.expectEqual(revocation.Source.cached_ocsp, report.entryFor(1).?.source.?);
+}
+
+test "a revoked certificate is rejected with its CRL reason" {
+    var fx = Fixtures.init(testing.allocator);
+    defer fx.deinit();
+    try addValidChain(&fx, 1);
+
+    var revoked = statusAssertion(0, .stapled_ocsp, .revoked);
+    revoked.revocation_reason = .key_compromise;
+    const assertions = [_]revocation.StatusAssertion{revoked};
+    var validation_policy = policy(fx.certs.items[2..3]);
+    validation_policy.revocation = .{ .mode = .soft_fail };
+    validation_policy.revocation_evidence = .{ .assertions = &assertions };
+
+    var entropy: crypto.pure_zig.DeterministicEntropy = undefined;
+    var provider: crypto.pure_zig.Provider = undefined;
+    const cp = cryptoProvider(&entropy, &provider);
+    var result = try validateBuilt(testing.allocator, &fx.certs.items[0], fx.certs.items[1..2], fx.certs.items[2..3], validation_policy, cp);
+    defer result.deinit(testing.allocator);
+    try expectRejected(&result, .certificate_revoked, 0);
+    try testing.expectEqual(revocation.CrlReason.key_compromise, result.rejected.revocation_reason.?);
+}
+
+test "a must-staple leaf is rejected without a stapled good status" {
+    var fx = Fixtures.init(testing.allocator);
+    defer fx.deinit();
+    try fx.add(.{
+        .subject = "leaf",
+        .issuer = "Root",
+        .subject_key = 1,
+        .issuer_key = 3,
+        .ca = false,
+        .key_usage = 0x80,
+        .san = "leaf.example.com",
+        .tls_features = &.{x509.TlsFeatures.status_request},
+    });
+    try fx.add(.{
+        .subject = "Root",
+        .issuer = "Root",
+        .subject_key = 3,
+        .issuer_key = 3,
+        .ca = true,
+        .key_usage = 0x04,
+    });
+
+    var entropy: crypto.pure_zig.DeterministicEntropy = undefined;
+    var provider: crypto.pure_zig.Provider = undefined;
+    const cp = cryptoProvider(&entropy, &provider);
+
+    var validation_policy = policy(fx.certs.items[1..2]);
+    validation_policy.revocation = .{ .mode = .soft_fail };
+    var missing = try validateBuilt(testing.allocator, &fx.certs.items[0], &.{}, fx.certs.items[1..2], validation_policy, cp);
+    defer missing.deinit(testing.allocator);
+    try expectRejected(&missing, .revocation_must_staple_not_satisfied, 0);
+
+    const assertions = [_]revocation.StatusAssertion{statusAssertion(0, .stapled_ocsp, .good)};
+    validation_policy.revocation_evidence = .{ .assertions = &assertions };
+    var stapled = try validateBuilt(testing.allocator, &fx.certs.items[0], &.{}, fx.certs.items[1..2], validation_policy, cp);
+    defer stapled.deinit(testing.allocator);
+    try expectAccepted(&stapled, 2);
+    try testing.expect(stapled.accepted.revocation.entries[0].must_staple);
+
+    // With status checking off, the assertion is unenforceable — and the
+    // result says so instead of implying it was honored.
+    var disabled = try validateBuilt(testing.allocator, &fx.certs.items[0], &.{}, fx.certs.items[1..2], policy(fx.certs.items[1..2]), cp);
+    defer disabled.deinit(testing.allocator);
+    try expectAccepted(&disabled, 2);
+    try testing.expect(disabled.accepted.revocation.must_staple_unenforced);
+}
+
+test "a critical TLS Feature extension is a handled critical extension" {
+    var fx = Fixtures.init(testing.allocator);
+    defer fx.deinit();
+    try fx.add(.{
+        .subject = "leaf",
+        .issuer = "Root",
+        .subject_key = 1,
+        .issuer_key = 3,
+        .ca = false,
+        .key_usage = 0x80,
+        .san = "leaf.example.com",
+        .tls_features = &.{x509.TlsFeatures.status_request},
+        .tls_features_critical = true,
+    });
+    try fx.add(.{
+        .subject = "Root",
+        .issuer = "Root",
+        .subject_key = 3,
+        .issuer_key = 3,
+        .ca = true,
+        .key_usage = 0x04,
+    });
+
+    var entropy: crypto.pure_zig.DeterministicEntropy = undefined;
+    var provider: crypto.pure_zig.Provider = undefined;
+    const cp = cryptoProvider(&entropy, &provider);
+    var result = try validateBuilt(testing.allocator, &fx.certs.items[0], &.{}, fx.certs.items[1..2], policy(fx.certs.items[1..2]), cp);
+    defer result.deinit(testing.allocator);
+    try expectAccepted(&result, 2);
+}
+
+test "status evidence cannot rescue a path that fails RFC 5280 validation" {
+    var fx = Fixtures.init(testing.allocator);
+    defer fx.deinit();
+    try fx.add(.{
+        .subject = "leaf",
+        .issuer = "Root",
+        .subject_key = 1,
+        .issuer_key = 3,
+        .ca = false,
+        .key_usage = 0x80,
+        .san = "leaf.example.com",
+        .not_before = "200101000000Z",
+        .not_after = "210101000000Z",
+    });
+    try fx.add(.{
+        .subject = "Root",
+        .issuer = "Root",
+        .subject_key = 3,
+        .issuer_key = 3,
+        .ca = true,
+        .key_usage = 0x04,
+    });
+
+    const assertions = [_]revocation.StatusAssertion{statusAssertion(0, .stapled_ocsp, .good)};
+    var validation_policy = policy(fx.certs.items[1..2]);
+    validation_policy.revocation = .{ .mode = .strict };
+    validation_policy.revocation_evidence = .{ .assertions = &assertions };
+
+    var entropy: crypto.pure_zig.DeterministicEntropy = undefined;
+    var provider: crypto.pure_zig.Provider = undefined;
+    const cp = cryptoProvider(&entropy, &provider);
+    var result = try validateBuilt(testing.allocator, &fx.certs.items[0], &.{}, fx.certs.items[1..2], validation_policy, cp);
+    defer result.deinit(testing.allocator);
+    try expectRejected(&result, .certificate_expired, 0);
+}
+
+test "status policy allocation failures stay structured and leak-free" {
+    var fx = Fixtures.init(testing.allocator);
+    defer fx.deinit();
+    try addValidChain(&fx, 1);
+
+    const assertions = [_]revocation.StatusAssertion{
+        statusAssertion(0, .stapled_ocsp, .good),
+        statusAssertion(1, .cached_ocsp, .good),
+    };
+    var validation_policy = policy(fx.certs.items[2..3]);
+    validation_policy.revocation = .{ .mode = .strict };
+    validation_policy.revocation_evidence = .{ .assertions = &assertions };
+    validation_policy.expected_dns_name = "leaf.example.com";
+
+    var entropy: crypto.pure_zig.DeterministicEntropy = undefined;
+    var provider: crypto.pure_zig.Provider = undefined;
+    const cp = cryptoProvider(&entropy, &provider);
+    var candidates = try path_builder.build(testing.allocator, &fx.certs.items[0], fx.certs.items[1..2], fx.certs.items[2..3], .{});
+    defer candidates.deinit(testing.allocator);
+
+    var fail_index: usize = 0;
+    while (true) : (fail_index += 1) {
+        var failing = testing.FailingAllocator.init(testing.allocator, .{ .fail_index = fail_index });
         var attempt = validator.validateCandidates(failing.allocator(), candidates, validation_policy, cp);
         attempt.deinit(failing.allocator());
         if (!failing.has_induced_failure) break;

--- a/src/pki/path_validator_tests.zig
+++ b/src/pki/path_validator_tests.zig
@@ -3336,7 +3336,7 @@ fn expectSameVerdict(first: validator.ValidationResult, second: validator.Valida
                 // for the same reason: two runs that agreed on the path but
                 // disagreed on what evidence was checked are not deterministic.
                 try testing.expectEqual(mine.revocation.mode, other.revocation.mode);
-                try testing.expectEqual(mine.revocation.must_staple_unenforced, other.revocation.must_staple_unenforced);
+                try testing.expectEqual(mine.revocation.must_staple, other.revocation.must_staple);
                 try testing.expectEqual(mine.revocation.entries.len, other.revocation.entries.len);
                 for (mine.revocation.entries, other.revocation.entries) |a, b| {
                     try testing.expectEqual(a, b);
@@ -3813,9 +3813,15 @@ fn fuzzPathValidation(_: void, smith: *testing.Smith) !void {
 
 const revocation = @import("revocation.zig");
 
-fn statusAssertion(certificate_index: usize, source: revocation.Source, status: revocation.Status) revocation.StatusAssertion {
+fn statusAssertion(
+    certificate_index: usize,
+    certificate: *const x509.Certificate,
+    source: revocation.Source,
+    status: revocation.Status,
+) revocation.StatusAssertion {
     return .{
         .certificate_index = certificate_index,
+        .certificate = revocation.CertificateIdentity.of(certificate),
         .source = source,
         .status = status,
         .signature_verified = true,
@@ -3853,8 +3859,8 @@ test "stapled status evidence is carried onto the accepted path" {
     try addValidChain(&fx, 1);
 
     const assertions = [_]revocation.StatusAssertion{
-        statusAssertion(0, .stapled_ocsp, .good),
-        statusAssertion(1, .cached_ocsp, .good),
+        statusAssertion(0, &fx.certs.items[0], .stapled_ocsp, .good),
+        statusAssertion(1, &fx.certs.items[1], .cached_ocsp, .good),
     };
     var validation_policy = policy(fx.certs.items[2..3]);
     validation_policy.revocation = .{ .mode = .strict };
@@ -3878,7 +3884,7 @@ test "a revoked certificate is rejected with its CRL reason" {
     defer fx.deinit();
     try addValidChain(&fx, 1);
 
-    var revoked = statusAssertion(0, .stapled_ocsp, .revoked);
+    var revoked = statusAssertion(0, &fx.certs.items[0], .stapled_ocsp, .revoked);
     revoked.revocation_reason = .key_compromise;
     const assertions = [_]revocation.StatusAssertion{revoked};
     var validation_policy = policy(fx.certs.items[2..3]);
@@ -3926,7 +3932,7 @@ test "a must-staple leaf is rejected without a stapled good status" {
     defer missing.deinit(testing.allocator);
     try expectRejected(&missing, .revocation_must_staple_not_satisfied, 0);
 
-    const assertions = [_]revocation.StatusAssertion{statusAssertion(0, .stapled_ocsp, .good)};
+    const assertions = [_]revocation.StatusAssertion{statusAssertion(0, &fx.certs.items[0], .stapled_ocsp, .good)};
     validation_policy.revocation_evidence = .{ .assertions = &assertions };
     var stapled = try validateBuilt(testing.allocator, &fx.certs.items[0], &.{}, fx.certs.items[1..2], validation_policy, cp);
     defer stapled.deinit(testing.allocator);
@@ -3938,7 +3944,10 @@ test "a must-staple leaf is rejected without a stapled good status" {
     var disabled = try validateBuilt(testing.allocator, &fx.certs.items[0], &.{}, fx.certs.items[1..2], policy(fx.certs.items[1..2]), cp);
     defer disabled.deinit(testing.allocator);
     try expectAccepted(&disabled, 2);
-    try testing.expect(disabled.accepted.revocation.must_staple_unenforced);
+    try testing.expectEqual(
+        revocation.MustStapleOutcome.unenforced_status_disabled,
+        disabled.accepted.revocation.must_staple,
+    );
 }
 
 test "a critical TLS Feature extension is a handled critical extension" {
@@ -3995,7 +4004,7 @@ test "status evidence cannot rescue a path that fails RFC 5280 validation" {
         .key_usage = 0x04,
     });
 
-    const assertions = [_]revocation.StatusAssertion{statusAssertion(0, .stapled_ocsp, .good)};
+    const assertions = [_]revocation.StatusAssertion{statusAssertion(0, &fx.certs.items[0], .stapled_ocsp, .good)};
     var validation_policy = policy(fx.certs.items[1..2]);
     validation_policy.revocation = .{ .mode = .strict };
     validation_policy.revocation_evidence = .{ .assertions = &assertions };
@@ -4014,8 +4023,8 @@ test "status policy allocation failures stay structured and leak-free" {
     try addValidChain(&fx, 1);
 
     const assertions = [_]revocation.StatusAssertion{
-        statusAssertion(0, .stapled_ocsp, .good),
-        statusAssertion(1, .cached_ocsp, .good),
+        statusAssertion(0, &fx.certs.items[0], .stapled_ocsp, .good),
+        statusAssertion(1, &fx.certs.items[1], .cached_ocsp, .good),
     };
     var validation_policy = policy(fx.certs.items[2..3]);
     validation_policy.revocation = .{ .mode = .strict };
@@ -4036,4 +4045,205 @@ test "status policy allocation failures stay structured and leak-free" {
         if (!failing.has_induced_failure) break;
         try testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
     }
+}
+
+test "an issuer's TLS Feature set constrains what its children must assert" {
+    // RFC 7633 §4.2.2: a certificate-signing certificate carrying TLS Feature
+    // requires every certificate it signs to assert the same set or a superset.
+    var fx = Fixtures.init(testing.allocator);
+    defer fx.deinit();
+    // 0: leaf with no TLS Feature under a must-staple-asserting intermediate.
+    try fx.add(.{
+        .subject = "leaf",
+        .issuer = "Intermediate",
+        .subject_key = 1,
+        .issuer_key = 2,
+        .ca = false,
+        .key_usage = 0x80,
+        .san = "leaf.example.com",
+    });
+    // 1: leaf asserting exactly the issuer's set.
+    try fx.add(.{
+        .subject = "matching",
+        .issuer = "Intermediate",
+        .subject_key = 4,
+        .issuer_key = 2,
+        .ca = false,
+        .key_usage = 0x80,
+        .san = "leaf.example.com",
+        .tls_features = &.{x509.TlsFeatures.status_request},
+    });
+    // 2: leaf asserting a superset.
+    try fx.add(.{
+        .subject = "superset",
+        .issuer = "Intermediate",
+        .subject_key = 5,
+        .issuer_key = 2,
+        .ca = false,
+        .key_usage = 0x80,
+        .san = "leaf.example.com",
+        .tls_features = &.{ x509.TlsFeatures.status_request, x509.TlsFeatures.status_request_v2 },
+    });
+    // 3: leaf asserting a *different* feature than the issuer requires.
+    try fx.add(.{
+        .subject = "disjoint",
+        .issuer = "Intermediate",
+        .subject_key = 6,
+        .issuer_key = 2,
+        .ca = false,
+        .key_usage = 0x80,
+        .san = "leaf.example.com",
+        .tls_features = &.{x509.TlsFeatures.status_request_v2},
+    });
+    try fx.add(.{
+        .subject = "Intermediate",
+        .issuer = "Root",
+        .subject_key = 2,
+        .issuer_key = 3,
+        .ca = true,
+        .key_usage = 0x04,
+        .tls_features = &.{x509.TlsFeatures.status_request},
+    });
+    try fx.add(.{
+        .subject = "Root",
+        .issuer = "Root",
+        .subject_key = 3,
+        .issuer_key = 3,
+        .ca = true,
+        .key_usage = 0x04,
+    });
+
+    var entropy: crypto.pure_zig.DeterministicEntropy = undefined;
+    var provider: crypto.pure_zig.Provider = undefined;
+    const cp = cryptoProvider(&entropy, &provider);
+    const intermediates = fx.certs.items[4..5];
+    const anchors = fx.certs.items[5..6];
+
+    // A staple cannot rescue a chain that breaks the issuer's constraint: the
+    // constraint is checked during path validation, before any status policy.
+    const assertions = [_]revocation.StatusAssertion{
+        statusAssertion(0, &fx.certs.items[0], .stapled_ocsp, .good),
+    };
+    var validation_policy = policy(anchors);
+    validation_policy.revocation = .{ .mode = .stapled_only };
+    validation_policy.revocation_evidence = .{ .assertions = &assertions };
+    var missing = try validateBuilt(testing.allocator, &fx.certs.items[0], intermediates, anchors, validation_policy, cp);
+    defer missing.deinit(testing.allocator);
+    try expectRejected(&missing, .tls_feature_constraint_violation, 0);
+    // The failure names the issuer that imposed the constraint.
+    try testing.expectEqual(@as(?usize, 1), missing.rejected.constraint_certificate_index);
+
+    // A child asserting a different feature does not satisfy "same or superset".
+    var disjoint = try validateBuilt(testing.allocator, &fx.certs.items[3], intermediates, anchors, policy(anchors), cp);
+    defer disjoint.deinit(testing.allocator);
+    try expectRejected(&disjoint, .tls_feature_constraint_violation, 0);
+
+    // Same set and superset both satisfy it, and then normal leaf must-staple
+    // processing applies.
+    for (fx.certs.items[1..3], 1..) |_, index| {
+        var accepted = try validateBuilt(testing.allocator, &fx.certs.items[index], intermediates, anchors, policy(anchors), cp);
+        defer accepted.deinit(testing.allocator);
+        try expectAccepted(&accepted, 3);
+        try testing.expectEqual(
+            revocation.MustStapleOutcome.unenforced_status_disabled,
+            accepted.accepted.revocation.must_staple,
+        );
+    }
+}
+
+test "an alternate candidate cannot inherit another candidate's status evidence" {
+    // Two intermediates issue the same leaf name from the same key, so both
+    // candidates are structurally valid and carry a *different* certificate at
+    // index 1. Evidence gathered for the first must not decide the second.
+    var fx = Fixtures.init(testing.allocator);
+    defer fx.deinit();
+    try fx.add(.{
+        .subject = "leaf",
+        .issuer = "Intermediate",
+        .subject_key = 1,
+        .issuer_key = 2,
+        .ca = false,
+        .key_usage = 0x80,
+        .san = "leaf.example.com",
+    });
+    // Candidate A's intermediate expires before the validation time, so the
+    // path fails a later RFC 5280 rule and the validator moves on to B.
+    try fx.add(.{
+        .subject = "Intermediate",
+        .issuer = "Root",
+        .subject_key = 2,
+        .issuer_key = 3,
+        .ca = true,
+        .key_usage = 0x04,
+        .not_before = "200101000000Z",
+        .not_after = "210101000000Z",
+    });
+    try fx.add(.{
+        .subject = "Intermediate",
+        .issuer = "Root",
+        .subject_key = 2,
+        .issuer_key = 3,
+        .ca = true,
+        .key_usage = 0x04,
+    });
+    try fx.add(.{
+        .subject = "Root",
+        .issuer = "Root",
+        .subject_key = 3,
+        .issuer_key = 3,
+        .ca = true,
+        .key_usage = 0x04,
+    });
+
+    var entropy: crypto.pure_zig.DeterministicEntropy = undefined;
+    var provider: crypto.pure_zig.Provider = undefined;
+    const cp = cryptoProvider(&entropy, &provider);
+    const intermediates = fx.certs.items[1..3];
+    const anchors = fx.certs.items[3..4];
+
+    // Evidence covers the leaf and the *expired* intermediate only.
+    const assertions = [_]revocation.StatusAssertion{
+        statusAssertion(0, &fx.certs.items[0], .stapled_ocsp, .good),
+        statusAssertion(1, &fx.certs.items[1], .cached_ocsp, .good),
+    };
+    var validation_policy = policy(anchors);
+    validation_policy.revocation = .{ .mode = .strict };
+    validation_policy.revocation_evidence = .{ .assertions = &assertions };
+
+    // Candidate B on its own: same index 1, different certificate, no evidence
+    // of its own. Strict mode must not let it consume candidate A's `good`.
+    const candidate_b = [_]path_builder.Element{
+        .{ .certificate = &fx.certs.items[0], .source = .leaf, .input_index = 0 },
+        .{ .certificate = &fx.certs.items[2], .source = .intermediate, .input_index = 1 },
+        .{ .certificate = &fx.certs.items[3], .source = .anchor, .input_index = 0 },
+    };
+    var isolated = validator.validatePath(testing.allocator, .{ .elements = &candidate_b }, validation_policy, cp);
+    defer isolated.deinit(testing.allocator);
+    // These fixtures publish no AIA or CRL distribution point, so "no usable
+    // evidence for this certificate" surfaces as the unsupported-source
+    // verdict rather than a plain unavailable one. Either way the point holds:
+    // index 1 did not inherit the other candidate's `good`.
+    try expectRejected(&isolated, .revocation_source_unsupported, 1);
+
+    // End to end, no candidate can be accepted on that evidence: A fails its
+    // validity window and B has no status of its own.
+    var result = try validateBuilt(testing.allocator, &fx.certs.items[0], intermediates, anchors, validation_policy, cp);
+    defer result.deinit(testing.allocator);
+    switch (result) {
+        .accepted => return error.TestUnexpectedResult,
+        .rejected => {},
+    }
+
+    // Binding the same evidence to the certificate that actually validates
+    // accepts, which proves the rejection above was the identity check and not
+    // an unrelated failure.
+    const bound = [_]revocation.StatusAssertion{
+        statusAssertion(0, &fx.certs.items[0], .stapled_ocsp, .good),
+        statusAssertion(1, &fx.certs.items[2], .cached_ocsp, .good),
+    };
+    validation_policy.revocation_evidence = .{ .assertions = &bound };
+    var accepted = try validateBuilt(testing.allocator, &fx.certs.items[0], intermediates, anchors, validation_policy, cp);
+    defer accepted.deinit(testing.allocator);
+    try expectAccepted(&accepted, 3);
+    try testing.expect(accepted.accepted.revocation.allChecked());
 }

--- a/src/pki/path_validator_tests.zig
+++ b/src/pki/path_validator_tests.zig
@@ -3814,13 +3814,11 @@ fn fuzzPathValidation(_: void, smith: *testing.Smith) !void {
 const revocation = @import("revocation.zig");
 
 fn statusAssertion(
-    certificate_index: usize,
     certificate: *const x509.Certificate,
     source: revocation.Source,
     status: revocation.Status,
 ) revocation.StatusAssertion {
     return .{
-        .certificate_index = certificate_index,
         .certificate = revocation.CertificateIdentity.of(certificate),
         .source = source,
         .status = status,
@@ -3859,8 +3857,8 @@ test "stapled status evidence is carried onto the accepted path" {
     try addValidChain(&fx, 1);
 
     const assertions = [_]revocation.StatusAssertion{
-        statusAssertion(0, &fx.certs.items[0], .stapled_ocsp, .good),
-        statusAssertion(1, &fx.certs.items[1], .cached_ocsp, .good),
+        statusAssertion(&fx.certs.items[0], .stapled_ocsp, .good),
+        statusAssertion(&fx.certs.items[1], .cached_ocsp, .good),
     };
     var validation_policy = policy(fx.certs.items[2..3]);
     validation_policy.revocation = .{ .mode = .strict };
@@ -3884,7 +3882,7 @@ test "a revoked certificate is rejected with its CRL reason" {
     defer fx.deinit();
     try addValidChain(&fx, 1);
 
-    var revoked = statusAssertion(0, &fx.certs.items[0], .stapled_ocsp, .revoked);
+    var revoked = statusAssertion(&fx.certs.items[0], .stapled_ocsp, .revoked);
     revoked.revocation_reason = .key_compromise;
     const assertions = [_]revocation.StatusAssertion{revoked};
     var validation_policy = policy(fx.certs.items[2..3]);
@@ -3932,7 +3930,7 @@ test "a must-staple leaf is rejected without a stapled good status" {
     defer missing.deinit(testing.allocator);
     try expectRejected(&missing, .revocation_must_staple_not_satisfied, 0);
 
-    const assertions = [_]revocation.StatusAssertion{statusAssertion(0, &fx.certs.items[0], .stapled_ocsp, .good)};
+    const assertions = [_]revocation.StatusAssertion{statusAssertion(&fx.certs.items[0], .stapled_ocsp, .good)};
     validation_policy.revocation_evidence = .{ .assertions = &assertions };
     var stapled = try validateBuilt(testing.allocator, &fx.certs.items[0], &.{}, fx.certs.items[1..2], validation_policy, cp);
     defer stapled.deinit(testing.allocator);
@@ -4004,7 +4002,7 @@ test "status evidence cannot rescue a path that fails RFC 5280 validation" {
         .key_usage = 0x04,
     });
 
-    const assertions = [_]revocation.StatusAssertion{statusAssertion(0, &fx.certs.items[0], .stapled_ocsp, .good)};
+    const assertions = [_]revocation.StatusAssertion{statusAssertion(&fx.certs.items[0], .stapled_ocsp, .good)};
     var validation_policy = policy(fx.certs.items[1..2]);
     validation_policy.revocation = .{ .mode = .strict };
     validation_policy.revocation_evidence = .{ .assertions = &assertions };
@@ -4023,8 +4021,8 @@ test "status policy allocation failures stay structured and leak-free" {
     try addValidChain(&fx, 1);
 
     const assertions = [_]revocation.StatusAssertion{
-        statusAssertion(0, &fx.certs.items[0], .stapled_ocsp, .good),
-        statusAssertion(1, &fx.certs.items[1], .cached_ocsp, .good),
+        statusAssertion(&fx.certs.items[0], .stapled_ocsp, .good),
+        statusAssertion(&fx.certs.items[1], .cached_ocsp, .good),
     };
     var validation_policy = policy(fx.certs.items[2..3]);
     validation_policy.revocation = .{ .mode = .strict };
@@ -4122,7 +4120,7 @@ test "an issuer's TLS Feature set constrains what its children must assert" {
     // A staple cannot rescue a chain that breaks the issuer's constraint: the
     // constraint is checked during path validation, before any status policy.
     const assertions = [_]revocation.StatusAssertion{
-        statusAssertion(0, &fx.certs.items[0], .stapled_ocsp, .good),
+        statusAssertion(&fx.certs.items[0], .stapled_ocsp, .good),
     };
     var validation_policy = policy(anchors);
     validation_policy.revocation = .{ .mode = .stapled_only };
@@ -4138,16 +4136,19 @@ test "an issuer's TLS Feature set constrains what its children must assert" {
     defer disjoint.deinit(testing.allocator);
     try expectRejected(&disjoint, .tls_feature_constraint_violation, 0);
 
-    // Same set and superset both satisfy it, and then normal leaf must-staple
-    // processing applies.
-    for (fx.certs.items[1..3], 1..) |_, index| {
+    // Same set and superset both satisfy the constraint, and then normal leaf
+    // must-staple processing applies. The superset leaf also declares feature
+    // 17, which this TLS 1.3-only stack cannot satisfy — see the dedicated
+    // status_request_v2 test; here it only has to pass the chain constraint.
+    const expected_outcomes = [_]revocation.MustStapleOutcome{
+        .unenforced_status_disabled,
+        .unsatisfiable_status_request_v2,
+    };
+    for (expected_outcomes, 1..) |expected, index| {
         var accepted = try validateBuilt(testing.allocator, &fx.certs.items[index], intermediates, anchors, policy(anchors), cp);
         defer accepted.deinit(testing.allocator);
         try expectAccepted(&accepted, 3);
-        try testing.expectEqual(
-            revocation.MustStapleOutcome.unenforced_status_disabled,
-            accepted.accepted.revocation.must_staple,
-        );
+        try testing.expectEqual(expected, accepted.accepted.revocation.must_staple);
     }
 }
 
@@ -4203,8 +4204,8 @@ test "an alternate candidate cannot inherit another candidate's status evidence"
 
     // Evidence covers the leaf and the *expired* intermediate only.
     const assertions = [_]revocation.StatusAssertion{
-        statusAssertion(0, &fx.certs.items[0], .stapled_ocsp, .good),
-        statusAssertion(1, &fx.certs.items[1], .cached_ocsp, .good),
+        statusAssertion(&fx.certs.items[0], .stapled_ocsp, .good),
+        statusAssertion(&fx.certs.items[1], .cached_ocsp, .good),
     };
     var validation_policy = policy(anchors);
     validation_policy.revocation = .{ .mode = .strict };
@@ -4238,12 +4239,92 @@ test "an alternate candidate cannot inherit another candidate's status evidence"
     // accepts, which proves the rejection above was the identity check and not
     // an unrelated failure.
     const bound = [_]revocation.StatusAssertion{
-        statusAssertion(0, &fx.certs.items[0], .stapled_ocsp, .good),
-        statusAssertion(1, &fx.certs.items[2], .cached_ocsp, .good),
+        statusAssertion(&fx.certs.items[0], .stapled_ocsp, .good),
+        statusAssertion(&fx.certs.items[2], .cached_ocsp, .good),
     };
     validation_policy.revocation_evidence = .{ .assertions = &bound };
     var accepted = try validateBuilt(testing.allocator, &fx.certs.items[0], intermediates, anchors, validation_policy, cp);
     defer accepted.deinit(testing.allocator);
     try expectAccepted(&accepted, 3);
     try testing.expect(accepted.accepted.revocation.allChecked());
+}
+
+test "a longer candidate's evidence cannot reject a shorter candidate end to end" {
+    // The union evidence set covers both candidates. Candidate A is one
+    // certificate longer and fails an unrelated rule; candidate B has complete
+    // evidence of its own and must be accepted, with A's extra assertions
+    // neither applied to B nor treated as an error against it.
+    var fx = Fixtures.init(testing.allocator);
+    defer fx.deinit();
+    // 0: leaf, issued by "Intermediate".
+    try fx.add(.{
+        .subject = "leaf",
+        .issuer = "Intermediate",
+        .subject_key = 1,
+        .issuer_key = 2,
+        .ca = false,
+        .key_usage = 0x80,
+        .san = "leaf.example.com",
+    });
+    // 1: candidate A's intermediate, under an expired sub-root.
+    try fx.add(.{
+        .subject = "Intermediate",
+        .issuer = "SubRoot",
+        .subject_key = 2,
+        .issuer_key = 4,
+        .ca = true,
+        .key_usage = 0x04,
+    });
+    // 2: the expired sub-root, which makes candidate A fail on validity.
+    try fx.add(.{
+        .subject = "SubRoot",
+        .issuer = "Root",
+        .subject_key = 4,
+        .issuer_key = 3,
+        .ca = true,
+        .key_usage = 0x04,
+        .not_before = "200101000000Z",
+        .not_after = "210101000000Z",
+    });
+    // 3: candidate B's intermediate, chaining straight to the anchor.
+    try fx.add(.{
+        .subject = "Intermediate",
+        .issuer = "Root",
+        .subject_key = 2,
+        .issuer_key = 3,
+        .ca = true,
+        .key_usage = 0x04,
+    });
+    try fx.add(.{
+        .subject = "Root",
+        .issuer = "Root",
+        .subject_key = 3,
+        .issuer_key = 3,
+        .ca = true,
+        .key_usage = 0x04,
+    });
+
+    var entropy: crypto.pure_zig.DeterministicEntropy = undefined;
+    var provider: crypto.pure_zig.Provider = undefined;
+    const cp = cryptoProvider(&entropy, &provider);
+    const intermediates = fx.certs.items[1..4];
+    const anchors = fx.certs.items[4..5];
+
+    const union_evidence = [_]revocation.StatusAssertion{
+        statusAssertion(&fx.certs.items[0], .stapled_ocsp, .good),
+        statusAssertion(&fx.certs.items[1], .cached_ocsp, .good),
+        // Only candidate A has a certificate at this depth.
+        statusAssertion(&fx.certs.items[2], .cached_ocsp, .good),
+        statusAssertion(&fx.certs.items[3], .cached_ocsp, .good),
+    };
+    var validation_policy = policy(anchors);
+    validation_policy.revocation = .{ .mode = .strict };
+    validation_policy.revocation_evidence = .{ .assertions = &union_evidence };
+
+    var result = try validateBuilt(testing.allocator, &fx.certs.items[0], intermediates, anchors, validation_policy, cp);
+    defer result.deinit(testing.allocator);
+    try expectAccepted(&result, 3);
+    const report = result.accepted.revocation;
+    try testing.expect(report.allChecked());
+    try testing.expectEqual(@as(usize, 2), report.entries.len);
 }

--- a/src/pki/path_validator_tests.zig
+++ b/src/pki/path_validator_tests.zig
@@ -4138,17 +4138,16 @@ test "an issuer's TLS Feature set constrains what its children must assert" {
 
     // Same set and superset both satisfy the constraint, and then normal leaf
     // must-staple processing applies. The superset leaf also declares feature
-    // 17, which this TLS 1.3-only stack cannot satisfy — see the dedicated
-    // status_request_v2 test; here it only has to pass the chain constraint.
-    const expected_outcomes = [_]revocation.MustStapleOutcome{
-        .unenforced_status_disabled,
-        .unsatisfiable_status_request_v2,
-    };
-    for (expected_outcomes, 1..) |expected, index| {
+    // 17; the §4.2.2 constraint covers every advertised feature, while the
+    // end-entity obligation stays scoped to feature 5.
+    for (fx.certs.items[1..3], 1..) |_, index| {
         var accepted = try validateBuilt(testing.allocator, &fx.certs.items[index], intermediates, anchors, policy(anchors), cp);
         defer accepted.deinit(testing.allocator);
         try expectAccepted(&accepted, 3);
-        try testing.expectEqual(expected, accepted.accepted.revocation.must_staple);
+        try testing.expectEqual(
+            revocation.MustStapleOutcome.unenforced_status_disabled,
+            accepted.accepted.revocation.must_staple,
+        );
     }
 }
 

--- a/src/pki/revocation.zig
+++ b/src/pki/revocation.zig
@@ -1,0 +1,661 @@
+//! Certificate-status policy seam for CRLs, OCSP, stapling, and must-staple
+//! (#349).
+//!
+//! This module decides what a path's *certificate-status evidence* means. It
+//! never fetches anything: no socket, no file, no clock. Evidence arrives as
+//! caller-supplied `StatusAssertion` values, and the validator turns them into
+//! an explicit `Report` recording, per certificate, exactly what was checked
+//! and what was not. Nothing here silently pretends revocation was checked.
+//!
+//! ## Why the seam looks like this
+//!
+//! Online revocation fetching is not implemented yet. Rather than leave the
+//! question undefined, the policy is explicit and the default (`Mode.disabled`)
+//! says so in the result: every entry is `not_checked_policy_disabled`, and a
+//! must-staple certificate accepted under it sets `Report.must_staple_unenforced`.
+//! An operator can therefore tell a "no revocation check happened" acceptance
+//! from a "status was checked and is good" acceptance.
+//!
+//! A future OCSP/CRL fetch-and-cache provider produces `StatusAssertion`
+//! values before validation runs — see `Provider`. That keeps network I/O,
+//! caching, and responder-signature verification outside both the TLS
+//! handshake and the path-validation API, which is why adding one later
+//! changes no signature in `path_validator`.
+//!
+//! ## Trust boundary
+//!
+//! `StatusAssertion.signature_verified` is asserted by whoever produced the
+//! evidence, not by this module: verifying an OCSP responder signature needs
+//! its own delegated-responder path validation, and CRL verification needs the
+//! CRL issuer's key. With `Configuration.require_signature_verified` (the
+//! default), unverified evidence never counts as a completed check — a peer
+//! cannot manufacture a "good" status by stapling bytes nobody authenticated.
+//! A *revoked* assertion is honored even when unverified: the only party that
+//! can supply attacker-chosen stapled bytes is the peer being authenticated,
+//! and revoking itself is not an attack worth defending against.
+
+const std = @import("std");
+const path_builder = @import("path_builder.zig");
+const x509 = @import("x509.zig");
+
+/// Certificate-status policy. Ordered from least to most demanding.
+pub const Mode = enum {
+    /// No status is consulted. Explicitly recorded in the report; must-staple
+    /// is not enforced because no evidence channel exists in this mode.
+    disabled,
+    /// Only stapled evidence is consulted. Absent stapling is accepted (and
+    /// recorded); stapled evidence that is present but unusable is rejected.
+    stapled_only,
+    /// All supplied evidence is consulted. Revoked rejects; missing, stale,
+    /// defective, or unknown status is recorded and accepted.
+    soft_fail,
+    /// Every non-anchor certificate needs usable, good status evidence.
+    strict,
+};
+
+/// Where a status assertion came from. Precedence for selection is the
+/// declaration order: fresher, peer-delivered stapled evidence outranks a
+/// cache, which outranks a periodically distributed CRL set.
+pub const Source = enum {
+    stapled_ocsp,
+    cached_ocsp,
+    crl_set,
+};
+
+pub const Status = enum { good, revoked, unknown };
+
+/// RFC 5280 §5.3.1 CRLReason values, carried through for logging and for
+/// operators who treat `certificate_hold` differently from a key compromise.
+pub const CrlReason = enum(u8) {
+    unspecified = 0,
+    key_compromise = 1,
+    ca_compromise = 2,
+    affiliation_changed = 3,
+    superseded = 4,
+    cessation_of_operation = 5,
+    certificate_hold = 6,
+    remove_from_crl = 8,
+    privilege_withdrawn = 9,
+    aa_compromise = 10,
+};
+
+/// Why supplied evidence cannot be used at all. Reported by the producing
+/// provider; this module never decodes an OCSP response or a CRL.
+pub const Defect = enum {
+    malformed_encoding,
+    unsupported_response_type,
+    responder_not_authorized,
+    signature_invalid,
+    /// The evidence covers a different certificate than it was filed under.
+    identity_mismatch,
+    /// The responder answered with an error status (RFC 6960 §2.3).
+    responder_error,
+};
+
+/// One certificate-status assertion supplied by the caller. Timestamps are
+/// Unix seconds on the same scale as `validation_time`; all are optional
+/// because CRL sets and cache entries do not all carry every field.
+pub const StatusAssertion = struct {
+    /// Leaf-first index of the certificate this assertion covers.
+    certificate_index: usize,
+    source: Source,
+    status: Status = .unknown,
+    /// Set when the evidence could not be interpreted. A defective assertion
+    /// never contributes a status, whatever `status` says.
+    defect: ?Defect = null,
+    revocation_reason: ?CrlReason = null,
+    revoked_at: ?i64 = null,
+    this_update: ?i64 = null,
+    next_update: ?i64 = null,
+    produced_at: ?i64 = null,
+    /// True only when the producer verified the responder or CRL signature
+    /// against an issuer authorized to answer for this certificate.
+    signature_verified: bool = false,
+    /// Borrowed encoded evidence, retained for logging and future
+    /// implementations. Never decoded here.
+    raw: []const u8 = &.{},
+};
+
+/// The per-connection status evidence available to one validation.
+pub const Evidence = struct {
+    /// Borrowed for the evaluation call.
+    assertions: []const StatusAssertion = &.{},
+
+    pub fn stapledFor(self: Evidence, certificate_index: usize) ?*const StatusAssertion {
+        for (self.assertions) |*assertion| {
+            if (assertion.source == .stapled_ocsp and assertion.certificate_index == certificate_index) {
+                return assertion;
+            }
+        }
+        return null;
+    }
+};
+
+pub const Freshness = struct {
+    /// Tolerance applied on both sides of every timestamp comparison.
+    clock_skew_seconds: i64 = 300,
+    /// Maximum accepted age of `this_update`. Null accepts any age, which
+    /// also means an assertion without `this_update` stays usable.
+    maximum_age_seconds: ?i64 = 7 * 24 * 60 * 60,
+    /// RFC 6960 §2.4 permits an absent nextUpdate, but evidence with no stated
+    /// expiry cannot be aged out of a cache, so it is unusable by default.
+    require_next_update: bool = true,
+};
+
+pub const Limits = struct {
+    maximum_assertions: usize = 64,
+    /// Bounds the retained `raw` evidence a caller may attach per assertion.
+    maximum_evidence_bytes: usize = 64 * 1024,
+};
+
+pub const Configuration = struct {
+    mode: Mode = .disabled,
+    freshness: Freshness = .{},
+    /// Treat evidence nobody authenticated as unusable. Turning this off makes
+    /// a "good" status assertable by whoever supplies the bytes.
+    require_signature_verified: bool = true,
+    /// Honor RFC 7633 must-staple. Has no effect in `.disabled` mode, which
+    /// records `Report.must_staple_unenforced` instead.
+    enforce_must_staple: bool = true,
+    limits: Limits = .{},
+};
+
+/// What the policy concluded for one certificate. Every acceptance carries one
+/// of these per non-anchor certificate, so "not checked" is always visible.
+pub const Determination = enum {
+    not_checked_policy_disabled,
+    /// The certificate publishes neither an OCSP responder nor a CRL
+    /// distribution point, so no provider could ever obtain status for it.
+    not_checked_no_status_source,
+    not_checked_no_evidence,
+    not_checked_defective_evidence,
+    not_checked_stale_evidence,
+    not_checked_unauthenticated_evidence,
+    /// Usable evidence that asserts neither good nor revoked.
+    not_checked_status_unknown,
+    checked_good,
+    checked_revoked,
+
+    pub fn isChecked(self: Determination) bool {
+        return self == .checked_good or self == .checked_revoked;
+    }
+};
+
+pub const Entry = struct {
+    certificate_index: usize,
+    determination: Determination,
+    /// The assertion the determination came from, when one was consulted.
+    source: ?Source = null,
+    defect: ?Defect = null,
+    revocation_reason: ?CrlReason = null,
+    this_update: ?i64 = null,
+    next_update: ?i64 = null,
+    /// This certificate asserts RFC 7633 must-staple.
+    must_staple: bool = false,
+};
+
+/// The status evidence that was actually consulted for an accepted path.
+pub const Report = struct {
+    mode: Mode,
+    /// Owned, leaf-first, one entry per non-anchor certificate.
+    entries: []const Entry,
+    /// A must-staple certificate was accepted without the assertion being
+    /// enforced, because status checking is disabled.
+    must_staple_unenforced: bool,
+
+    pub fn deinit(self: *Report, allocator: std.mem.Allocator) void {
+        allocator.free(self.entries);
+        self.* = undefined;
+    }
+
+    /// True when every non-anchor certificate has a completed status check.
+    pub fn allChecked(self: *const Report) bool {
+        for (self.entries) |entry| {
+            if (!entry.determination.isChecked()) return false;
+        }
+        return self.entries.len != 0;
+    }
+
+    pub fn entryFor(self: *const Report, certificate_index: usize) ?*const Entry {
+        for (self.entries) |*entry| {
+            if (entry.certificate_index == certificate_index) return entry;
+        }
+        return null;
+    }
+};
+
+pub const FailureReason = enum {
+    certificate_revoked,
+    /// The mode requires a status answer and none was usable.
+    status_unavailable,
+    status_stale,
+    status_malformed,
+    status_unauthenticated,
+    must_staple_not_satisfied,
+    /// The certificate publishes no revocation mechanism at all, so a strict
+    /// policy can never be satisfied for it.
+    status_source_unsupported,
+    /// The caller filed evidence against a certificate index the path does not
+    /// contain, or against the trust anchor.
+    evidence_index_invalid,
+    resource_limit_exceeded,
+    out_of_memory,
+};
+
+pub const Failure = struct {
+    reason: FailureReason,
+    /// Leaf-first index; null when no certificate can be identified.
+    certificate_index: ?usize,
+    source: ?Source = null,
+    defect: ?Defect = null,
+    revocation_reason: ?CrlReason = null,
+};
+
+pub const Outcome = union(enum) {
+    accepted: Report,
+    rejected: Failure,
+};
+
+/// Interface for a future fetch-and-cache status provider. Implementations run
+/// *before* validation and hand back evidence; the validator itself never
+/// calls one, which is what keeps ambient network I/O out of path validation.
+/// The returned assertions borrow storage the implementation owns and must
+/// outlive the validation call.
+pub const Provider = struct {
+    context: *const anyopaque,
+    vtable: *const VTable,
+
+    pub const Request = struct {
+        /// Leaf-first path the caller is about to validate.
+        path: path_builder.Path,
+        /// Unix seconds the caller will validate at.
+        validation_time: i64,
+        /// Status responses the peer delivered in-band (TLS stapling).
+        stapled: []const StatusAssertion = &.{},
+    };
+
+    pub const VTable = struct {
+        collect: *const fn (
+            context: *const anyopaque,
+            allocator: std.mem.Allocator,
+            request: Request,
+        ) error{OutOfMemory}!Evidence,
+    };
+
+    pub fn collect(
+        self: Provider,
+        allocator: std.mem.Allocator,
+        request: Request,
+    ) error{OutOfMemory}!Evidence {
+        return self.vtable.collect(self.context, allocator, request);
+    }
+};
+
+/// Evaluate certificate-status policy over one leaf-first, anchor-last path.
+///
+/// The terminal trust anchor is excluded: an anchor's revocation status is
+/// trust configuration, removed by editing the trust store, not by consulting
+/// a responder the anchor itself would name.
+pub fn evaluatePath(
+    allocator: std.mem.Allocator,
+    path: path_builder.Path,
+    config: Configuration,
+    evidence: Evidence,
+    validation_time: i64,
+) Outcome {
+    if (path.elements.len < 2) {
+        return .{ .rejected = .{ .reason = .evidence_index_invalid, .certificate_index = null } };
+    }
+    const certificate_count = path.elements.len - 1;
+
+    if (evidence.assertions.len > config.limits.maximum_assertions) {
+        return .{ .rejected = .{ .reason = .resource_limit_exceeded, .certificate_index = null } };
+    }
+    for (evidence.assertions) |assertion| {
+        if (assertion.raw.len > config.limits.maximum_evidence_bytes) {
+            return .{ .rejected = .{
+                .reason = .resource_limit_exceeded,
+                .certificate_index = assertion.certificate_index,
+                .source = assertion.source,
+            } };
+        }
+        if (assertion.certificate_index >= certificate_count) {
+            return .{ .rejected = .{
+                .reason = .evidence_index_invalid,
+                .certificate_index = assertion.certificate_index,
+                .source = assertion.source,
+            } };
+        }
+    }
+
+    // RFC 7633 §4.2.3: a CA asserting the feature obliges the certificates it
+    // issues, so any must-staple assertion in the path binds the leaf.
+    var must_staple_required = false;
+    for (path.elements[0..certificate_count]) |element| {
+        if (element.certificate.mustStaple()) must_staple_required = true;
+    }
+
+    const entries = allocator.alloc(Entry, certificate_count) catch {
+        return .{ .rejected = .{ .reason = .out_of_memory, .certificate_index = null } };
+    };
+
+    for (path.elements[0..certificate_count], 0..) |element, certificate_index| {
+        entries[certificate_index] = .{
+            .certificate_index = certificate_index,
+            .determination = .not_checked_policy_disabled,
+            .must_staple = element.certificate.mustStaple(),
+        };
+    }
+
+    if (config.mode == .disabled) {
+        return .{ .accepted = .{
+            .mode = config.mode,
+            .entries = entries,
+            .must_staple_unenforced = must_staple_required,
+        } };
+    }
+
+    for (path.elements[0..certificate_count], 0..) |element, certificate_index| {
+        const selection = select(evidence, certificate_index, config, validation_time);
+        var entry = &entries[certificate_index];
+        entry.source = selection.source;
+        entry.defect = selection.defect;
+        entry.revocation_reason = selection.revocation_reason;
+        entry.this_update = selection.this_update;
+        entry.next_update = selection.next_update;
+        entry.determination = determination(selection, element.certificate);
+
+        if (rejectionFor(entry.*, config.mode)) |failure| {
+            allocator.free(entries);
+            return .{ .rejected = failure };
+        }
+    }
+
+    if (must_staple_required and config.enforce_must_staple) {
+        const leaf_entry = entries[0];
+        const satisfied = leaf_entry.source == .stapled_ocsp and
+            leaf_entry.determination == .checked_good;
+        if (!satisfied) {
+            const failure = Failure{
+                .reason = .must_staple_not_satisfied,
+                .certificate_index = 0,
+                .source = leaf_entry.source,
+                .defect = leaf_entry.defect,
+            };
+            allocator.free(entries);
+            return .{ .rejected = failure };
+        }
+    }
+
+    return .{ .accepted = .{
+        .mode = config.mode,
+        .entries = entries,
+        .must_staple_unenforced = false,
+    } };
+}
+
+/// Why a usable-looking assertion could not be used.
+const Blocker = enum { defective, unauthenticated, stale };
+
+const Selection = struct {
+    source: ?Source = null,
+    status: ?Status = null,
+    blocker: ?Blocker = null,
+    defect: ?Defect = null,
+    revocation_reason: ?CrlReason = null,
+    this_update: ?i64 = null,
+    next_update: ?i64 = null,
+};
+
+/// Choose the assertion that decides this certificate.
+///
+/// Revoked wins over everything, from any consulted source, so that a second
+/// source cannot launder a revocation away. Otherwise the highest-precedence
+/// source with a usable answer decides; when nothing is usable, the
+/// highest-precedence blocked assertion is reported so the operator learns why.
+fn select(
+    evidence: Evidence,
+    certificate_index: usize,
+    config: Configuration,
+    validation_time: i64,
+) Selection {
+    var best: Selection = .{};
+    var best_rank: usize = std.math.maxInt(usize);
+    var blocked: Selection = .{};
+    var blocked_rank: usize = std.math.maxInt(usize);
+
+    for (evidence.assertions) |assertion| {
+        if (assertion.certificate_index != certificate_index) continue;
+        if (!consults(config.mode, assertion.source)) continue;
+
+        const candidate = Selection{
+            .source = assertion.source,
+            .status = assertion.status,
+            .defect = assertion.defect,
+            .revocation_reason = assertion.revocation_reason,
+            .this_update = assertion.this_update,
+            .next_update = assertion.next_update,
+        };
+
+        if (assertion.defect) |defect| {
+            const rank = sourceRank(assertion.source);
+            if (rank < blocked_rank) {
+                blocked_rank = rank;
+                blocked = candidate;
+                blocked.status = null;
+                blocked.blocker = .defective;
+                blocked.defect = defect;
+            }
+            continue;
+        }
+
+        // Revocation is honored even from stale or unauthenticated evidence:
+        // ignoring it could only ever help a certificate its own issuer has
+        // withdrawn. See the trust-boundary note at the top of this file.
+        if (assertion.status == .revoked) {
+            var revoked = candidate;
+            revoked.status = .revoked;
+            return revoked;
+        }
+
+        if (config.require_signature_verified and !assertion.signature_verified) {
+            const rank = sourceRank(assertion.source);
+            if (rank < blocked_rank) {
+                blocked_rank = rank;
+                blocked = candidate;
+                blocked.status = null;
+                blocked.blocker = .unauthenticated;
+            }
+            continue;
+        }
+
+        if (!isFresh(assertion, config.freshness, validation_time)) {
+            const rank = sourceRank(assertion.source);
+            if (rank < blocked_rank) {
+                blocked_rank = rank;
+                blocked = candidate;
+                blocked.status = null;
+                blocked.blocker = .stale;
+            }
+            continue;
+        }
+
+        // Prefer the highest-precedence source, and a definite answer over an
+        // `unknown` from the same source.
+        const rank = sourceRank(assertion.source) * 2 + @intFromBool(assertion.status == .unknown);
+        if (rank < best_rank) {
+            best_rank = rank;
+            best = candidate;
+        }
+    }
+
+    if (best.status != null) return best;
+    return blocked;
+}
+
+fn consults(mode: Mode, source: Source) bool {
+    return switch (mode) {
+        .disabled => false,
+        .stapled_only => source == .stapled_ocsp,
+        .soft_fail, .strict => true,
+    };
+}
+
+fn sourceRank(source: Source) usize {
+    return @intFromEnum(source);
+}
+
+fn isFresh(assertion: StatusAssertion, freshness: Freshness, validation_time: i64) bool {
+    const skew = freshness.clock_skew_seconds;
+
+    if (assertion.this_update) |this_update| {
+        if (this_update -| skew > validation_time) return false;
+        if (freshness.maximum_age_seconds) |maximum_age| {
+            if (validation_time -| this_update > maximum_age +| skew) return false;
+        }
+    } else if (freshness.maximum_age_seconds != null) {
+        // Age cannot be bounded without a stated issuance time.
+        return false;
+    }
+
+    if (assertion.next_update) |next_update| {
+        if (validation_time > next_update +| skew) return false;
+        if (assertion.this_update) |this_update| {
+            if (next_update < this_update) return false;
+        }
+    } else if (freshness.require_next_update) {
+        return false;
+    }
+
+    return true;
+}
+
+fn determination(selection: Selection, certificate: *const x509.Certificate) Determination {
+    if (selection.status) |status| {
+        return switch (status) {
+            .good => .checked_good,
+            .revoked => .checked_revoked,
+            .unknown => .not_checked_status_unknown,
+        };
+    }
+    if (selection.blocker) |blocker| {
+        return switch (blocker) {
+            .defective => .not_checked_defective_evidence,
+            .unauthenticated => .not_checked_unauthenticated_evidence,
+            .stale => .not_checked_stale_evidence,
+        };
+    }
+    if (!publishesStatusSource(certificate)) return .not_checked_no_status_source;
+    return .not_checked_no_evidence;
+}
+
+fn publishesStatusSource(certificate: *const x509.Certificate) bool {
+    if (certificate.hasOcspResponder()) return true;
+    const points = certificate.crlDistributionPoints() orelse return false;
+    return points.len != 0;
+}
+
+/// Map one certificate's determination to a rejection, if the mode demands it.
+///
+/// `stapled_only` deliberately accepts *absent* stapling — the peer never
+/// promised any — but rejects stapling that is present and unusable, because
+/// that is a broken promise rather than a missing one.
+fn rejectionFor(entry: Entry, mode: Mode) ?Failure {
+    const failure = Failure{
+        .reason = .status_unavailable,
+        .certificate_index = entry.certificate_index,
+        .source = entry.source,
+        .defect = entry.defect,
+        .revocation_reason = entry.revocation_reason,
+    };
+
+    if (entry.determination == .checked_revoked) {
+        var revoked = failure;
+        revoked.reason = .certificate_revoked;
+        return revoked;
+    }
+    if (entry.determination == .checked_good) return null;
+
+    const evidence_present = entry.source != null;
+    const enforce = switch (mode) {
+        .disabled => false,
+        .stapled_only => evidence_present,
+        .soft_fail => false,
+        .strict => true,
+    };
+    if (!enforce) return null;
+
+    var rejected = failure;
+    rejected.reason = switch (entry.determination) {
+        .not_checked_defective_evidence => .status_malformed,
+        .not_checked_stale_evidence => .status_stale,
+        .not_checked_unauthenticated_evidence => .status_unauthenticated,
+        .not_checked_no_status_source => .status_source_unsupported,
+        else => .status_unavailable,
+    };
+    return rejected;
+}
+
+const testing = std.testing;
+
+test "freshness bounds accept only evidence inside the stated window" {
+    const now: i64 = 1_000_000;
+    const freshness = Freshness{};
+    try testing.expect(isFresh(.{
+        .certificate_index = 0,
+        .source = .stapled_ocsp,
+        .this_update = now - 60,
+        .next_update = now + 3600,
+    }, freshness, now));
+    try testing.expect(!isFresh(.{
+        .certificate_index = 0,
+        .source = .stapled_ocsp,
+        .this_update = now - 60,
+        .next_update = now - 3600,
+    }, freshness, now));
+    try testing.expect(!isFresh(.{
+        .certificate_index = 0,
+        .source = .stapled_ocsp,
+        .this_update = now + 3600,
+        .next_update = now + 7200,
+    }, freshness, now));
+    try testing.expect(!isFresh(.{
+        .certificate_index = 0,
+        .source = .stapled_ocsp,
+        .this_update = now - 60,
+    }, freshness, now));
+    try testing.expect(!isFresh(.{
+        .certificate_index = 0,
+        .source = .stapled_ocsp,
+        .next_update = now + 3600,
+    }, freshness, now));
+    // nextUpdate before thisUpdate is incoherent regardless of the window.
+    try testing.expect(!isFresh(.{
+        .certificate_index = 0,
+        .source = .stapled_ocsp,
+        .this_update = now - 60,
+        .next_update = now - 120,
+    }, .{ .clock_skew_seconds = 86_400 }, now));
+}
+
+test "clock skew is applied on both sides of the window" {
+    const now: i64 = 1_000_000;
+    const freshness = Freshness{ .clock_skew_seconds = 300 };
+    try testing.expect(isFresh(.{
+        .certificate_index = 0,
+        .source = .stapled_ocsp,
+        .this_update = now + 200,
+        .next_update = now + 3600,
+    }, freshness, now));
+    // Expired by less than the skew allowance is still usable.
+    try testing.expect(isFresh(.{
+        .certificate_index = 0,
+        .source = .stapled_ocsp,
+        .this_update = now - 400,
+        .next_update = now - 200,
+    }, freshness, now));
+}
+
+test {
+    testing.refAllDecls(@This());
+}

--- a/src/pki/revocation.zig
+++ b/src/pki/revocation.zig
@@ -43,6 +43,12 @@
 //! unauthenticated `revoked` there would let an on-path attacker deny service
 //! with one forged response.
 //!
+//! RFC 7633 feature demands are likewise scoped by what the handshake actually
+//! offered: `Configuration.offered_status_request` must reflect the ClientHello
+//! this connection emitted. A certificate cannot hold a client to a feature the
+//! client never requested (§4.3.3), and the validator has no way to observe the
+//! hello on its own, so the fact is carried in rather than assumed.
+//!
 //! Assertions are bound to a certificate by `CertificateIdentity` alone, never
 //! by position. One evidence set is shared by every candidate path, and
 //! candidates differ in shape and depth, so a position-derived key would both
@@ -205,8 +211,18 @@ pub const Configuration = struct {
     /// a "good" status assertable by whoever supplies the bytes.
     require_signature_verified: bool = true,
     /// Honor RFC 7633 must-staple. Has no effect in `.disabled` mode, which
-    /// records `Report.must_staple_unenforced` instead.
+    /// records the assertion as unenforced instead.
     enforce_must_staple: bool = true,
+    /// Whether this connection's ClientHello actually offered the TLS
+    /// `status_request` extension.
+    ///
+    /// RFC 7633 §§4.1/4.3.3 scope a certificate's feature demand to features
+    /// present in *both* the ClientHello and the certificate: a client that
+    /// never asked for stapling cannot hold the server to having provided it.
+    /// The default is false because Tardigrade's TLS 1.3 ClientHello does not
+    /// currently send `status_request`; a caller that wires the extension must
+    /// set this from the hello it actually emitted, not from a constant.
+    offered_status_request: bool = false,
     limits: Limits = .{},
 };
 
@@ -256,9 +272,15 @@ pub const MustStapleOutcome = enum {
     unenforced_status_disabled,
     /// Asserted, but `Configuration.enforce_must_staple` is off.
     unenforced_by_configuration,
+    /// Asserted, but this connection never offered `status_request`, so RFC
+    /// 7633 §4.3.3 puts the feature outside the ClientHello intersection and
+    /// the certificate makes no demand of this handshake.
+    not_offered_by_client,
 
     pub fn isUnenforced(self: MustStapleOutcome) bool {
-        return self == .unenforced_status_disabled or self == .unenforced_by_configuration;
+        return self == .unenforced_status_disabled or
+            self == .unenforced_by_configuration or
+            self == .not_offered_by_client;
     }
 };
 
@@ -399,13 +421,15 @@ pub fn evaluatePath(
     // during path validation (`path_validator.checkTlsFeatureConstraints`), not
     // an assertion that propagates down as a stapling obligation of its own.
     //
-    // Only `status_request` (5) creates that obligation. RFC 6961
-    // `status_request_v2` (17) is not offered by this TLS 1.3 profile, and
-    // RFC 7633 §§4.1/4.3.3 scope the certificate's demand to features present
-    // in *both* the ClientHello and the certificate — so a certificate that
-    // also advertises 17 for TLS 1.2 peers is perfectly usable here and must
-    // not be rejected over it.
-    const must_staple_required = path.elements[0].certificate.mustStaple();
+    // Only `status_request` (5) creates that obligation, and only when this
+    // connection actually offered it. RFC 7633 §§4.1/4.3.3 scope a
+    // certificate's demand to features present in *both* the ClientHello and
+    // the certificate, so neither a certificate advertising RFC 6961
+    // `status_request_v2` (17, never offered by this TLS 1.3 profile) nor one
+    // advertising feature 5 to a client that did not ask for stapling may be
+    // rejected over it.
+    const must_staple_asserted = path.elements[0].certificate.mustStaple();
+    const must_staple_required = must_staple_asserted and config.offered_status_request;
 
     const entries = allocator.alloc(Entry, certificate_count) catch {
         return .{ .rejected = .{ .reason = .out_of_memory, .certificate_index = null } };
@@ -426,7 +450,12 @@ pub fn evaluatePath(
         return .{ .accepted = .{
             .mode = config.mode,
             .entries = entries,
-            .must_staple = if (must_staple_required) .unenforced_status_disabled else .not_required,
+            .must_staple = if (!must_staple_asserted)
+                .not_required
+            else if (!config.offered_status_request)
+                .not_offered_by_client
+            else
+                .unenforced_status_disabled,
         } };
     }
 
@@ -465,7 +494,11 @@ pub fn evaluatePath(
         }
     }
 
-    var must_staple: MustStapleOutcome = .not_required;
+    var must_staple: MustStapleOutcome =
+        if (must_staple_asserted and !config.offered_status_request)
+            .not_offered_by_client
+        else
+            .not_required;
     if (must_staple_required) {
         if (!config.enforce_must_staple) {
             must_staple = .unenforced_by_configuration;

--- a/src/pki/revocation.zig
+++ b/src/pki/revocation.zig
@@ -12,9 +12,14 @@
 //! Online revocation fetching is not implemented yet. Rather than leave the
 //! question undefined, the policy is explicit and the default (`Mode.disabled`)
 //! says so in the result: every entry is `not_checked_policy_disabled`, and a
-//! must-staple certificate accepted under it sets `Report.must_staple_unenforced`.
-//! An operator can therefore tell a "no revocation check happened" acceptance
-//! from a "status was checked and is good" acceptance.
+//! must-staple certificate accepted under it reports
+//! `MustStapleOutcome.unenforced_status_disabled`. An operator can therefore
+//! tell a "no revocation check happened" acceptance from a "status was checked
+//! and is good" acceptance.
+//!
+//! Disabled also never *rejects*. A caller running with revocation off must not
+//! be able to fail a handshake because a peer attached oversized or misfiled
+//! status data, so evidence is not even examined in that mode.
 //!
 //! A future OCSP/CRL fetch-and-cache provider produces `StatusAssertion`
 //! values before validation runs — see `Provider`. That keeps network I/O,
@@ -30,9 +35,18 @@
 //! CRL issuer's key. With `Configuration.require_signature_verified` (the
 //! default), unverified evidence never counts as a completed check — a peer
 //! cannot manufacture a "good" status by stapling bytes nobody authenticated.
-//! A *revoked* assertion is honored even when unverified: the only party that
-//! can supply attacker-chosen stapled bytes is the peer being authenticated,
-//! and revoking itself is not an attack worth defending against.
+//!
+//! One narrow exception: a *peer-stapled* `revoked` is honored unverified,
+//! because the only party who can supply attacker-chosen stapled bytes is the
+//! peer being authenticated, and revoking itself is not an attack. Evidence
+//! from a fetched responder or a CRL gets no such exception — trusting an
+//! unauthenticated `revoked` there would let an on-path attacker deny service
+//! with one forged response.
+//!
+//! Assertions are bound to a certificate by `CertificateIdentity`, not by
+//! position, so evidence gathered for one candidate path can never be applied
+//! to a different certificate that happens to sit at the same index in an
+//! alternate or cross-signed candidate.
 
 const std = @import("std");
 const path_builder = @import("path_builder.zig");
@@ -92,12 +106,42 @@ pub const Defect = enum {
     responder_error,
 };
 
+/// Which certificate a status assertion is about, independent of where that
+/// certificate sits in any particular candidate path.
+///
+/// Position alone is not an identity: `validateCandidates` offers one evidence
+/// set to every candidate, and cross-signed or alternate paths routinely carry
+/// *different* certificates at the same index. Binding to the exact DER means
+/// evidence gathered for one candidate can never be consumed by another.
+pub const CertificateIdentity = struct {
+    /// SHA-256 over the certificate's exact DER encoding.
+    digest: [32]u8,
+
+    pub fn of(certificate: *const x509.Certificate) CertificateIdentity {
+        var digest: [32]u8 = undefined;
+        std.crypto.hash.sha2.Sha256.hash(certificate.raw, &digest, .{});
+        return .{ .digest = digest };
+    }
+
+    pub fn eql(self: CertificateIdentity, other: CertificateIdentity) bool {
+        return std.mem.eql(u8, &self.digest, &other.digest);
+    }
+
+    pub fn matches(self: CertificateIdentity, certificate: *const x509.Certificate) bool {
+        return self.eql(CertificateIdentity.of(certificate));
+    }
+};
+
 /// One certificate-status assertion supplied by the caller. Timestamps are
 /// Unix seconds on the same scale as `validation_time`; all are optional
 /// because CRL sets and cache entries do not all carry every field.
 pub const StatusAssertion = struct {
     /// Leaf-first index of the certificate this assertion covers.
     certificate_index: usize,
+    /// The certificate this assertion is about. An assertion whose identity
+    /// does not match the certificate at `certificate_index` in the path being
+    /// validated is ignored, never applied by position.
+    certificate: CertificateIdentity,
     source: Source,
     status: Status = .unknown,
     /// Set when the evidence could not be interpreted. A defective assertion
@@ -121,9 +165,12 @@ pub const Evidence = struct {
     /// Borrowed for the evaluation call.
     assertions: []const StatusAssertion = &.{},
 
-    pub fn stapledFor(self: Evidence, certificate_index: usize) ?*const StatusAssertion {
+    /// The stapled assertion bound to `certificate`, if the caller supplied
+    /// one. Identity, not position, decides the match.
+    pub fn stapledFor(self: Evidence, certificate: *const x509.Certificate) ?*const StatusAssertion {
+        const identity = CertificateIdentity.of(certificate);
         for (self.assertions) |*assertion| {
-            if (assertion.source == .stapled_ocsp and assertion.certificate_index == certificate_index) {
+            if (assertion.source == .stapled_ocsp and assertion.certificate.eql(identity)) {
                 return assertion;
             }
         }
@@ -194,14 +241,30 @@ pub const Entry = struct {
     must_staple: bool = false,
 };
 
+/// What became of an RFC 7633 must-staple assertion on this path. Both
+/// unenforced states are reported distinctly, so an acceptance never reads as
+/// "the assertion was honored" when it was merely not applied.
+pub const MustStapleOutcome = enum {
+    /// No certificate on the path asserts must-staple.
+    not_required,
+    /// Asserted, and satisfied by a stapled good status.
+    enforced,
+    /// Asserted, but the mode consults no status at all.
+    unenforced_status_disabled,
+    /// Asserted, but `Configuration.enforce_must_staple` is off.
+    unenforced_by_configuration,
+
+    pub fn isUnenforced(self: MustStapleOutcome) bool {
+        return self == .unenforced_status_disabled or self == .unenforced_by_configuration;
+    }
+};
+
 /// The status evidence that was actually consulted for an accepted path.
 pub const Report = struct {
     mode: Mode,
     /// Owned, leaf-first, one entry per non-anchor certificate.
     entries: []const Entry,
-    /// A must-staple certificate was accepted without the assertion being
-    /// enforced, because status checking is disabled.
-    must_staple_unenforced: bool,
+    must_staple: MustStapleOutcome,
 
     pub fn deinit(self: *Report, allocator: std.mem.Allocator) void {
         allocator.free(self.entries);
@@ -256,11 +319,29 @@ pub const Outcome = union(enum) {
     rejected: Failure,
 };
 
+/// One collection's evidence plus the storage that backs it.
+///
+/// The assertion array is allocated per call with the caller's allocator and
+/// released by `deinit`, so two handshakes can collect concurrently without
+/// aliasing a provider-owned scratch buffer, and a provider never has to retain
+/// per-call arrays until teardown. Only the encoded `raw` blobs may borrow
+/// longer-lived provider or cache storage; those must outlive the validation.
+pub const CollectedEvidence = struct {
+    owned_assertions: []StatusAssertion,
+
+    pub fn evidence(self: *const CollectedEvidence) Evidence {
+        return .{ .assertions = self.owned_assertions };
+    }
+
+    pub fn deinit(self: *CollectedEvidence, allocator: std.mem.Allocator) void {
+        allocator.free(self.owned_assertions);
+        self.* = undefined;
+    }
+};
+
 /// Interface for a future fetch-and-cache status provider. Implementations run
-/// *before* validation and hand back evidence; the validator itself never
-/// calls one, which is what keeps ambient network I/O out of path validation.
-/// The returned assertions borrow storage the implementation owns and must
-/// outlive the validation call.
+/// *before* validation and hand back evidence; the validator itself never calls
+/// one, which is what keeps ambient network I/O out of path validation.
 pub const Provider = struct {
     context: *const anyopaque,
     vtable: *const VTable,
@@ -279,14 +360,17 @@ pub const Provider = struct {
             context: *const anyopaque,
             allocator: std.mem.Allocator,
             request: Request,
-        ) error{OutOfMemory}!Evidence,
+        ) error{OutOfMemory}!CollectedEvidence,
     };
 
+    /// Collect status evidence for one path. The result owns its assertion
+    /// array; release it with `CollectedEvidence.deinit` and the same allocator
+    /// once validation is done with it.
     pub fn collect(
         self: Provider,
         allocator: std.mem.Allocator,
         request: Request,
-    ) error{OutOfMemory}!Evidence {
+    ) error{OutOfMemory}!CollectedEvidence {
         return self.vtable.collect(self.context, allocator, request);
     }
 };
@@ -308,32 +392,11 @@ pub fn evaluatePath(
     }
     const certificate_count = path.elements.len - 1;
 
-    if (evidence.assertions.len > config.limits.maximum_assertions) {
-        return .{ .rejected = .{ .reason = .resource_limit_exceeded, .certificate_index = null } };
-    }
-    for (evidence.assertions) |assertion| {
-        if (assertion.raw.len > config.limits.maximum_evidence_bytes) {
-            return .{ .rejected = .{
-                .reason = .resource_limit_exceeded,
-                .certificate_index = assertion.certificate_index,
-                .source = assertion.source,
-            } };
-        }
-        if (assertion.certificate_index >= certificate_count) {
-            return .{ .rejected = .{
-                .reason = .evidence_index_invalid,
-                .certificate_index = assertion.certificate_index,
-                .source = assertion.source,
-            } };
-        }
-    }
-
-    // RFC 7633 §4.2.3: a CA asserting the feature obliges the certificates it
-    // issues, so any must-staple assertion in the path binds the leaf.
-    var must_staple_required = false;
-    for (path.elements[0..certificate_count]) |element| {
-        if (element.certificate.mustStaple()) must_staple_required = true;
-    }
+    // RFC 7633 must-staple is an end-entity property. The issuer-side form of
+    // the extension is a *constraint on what the child must contain*, enforced
+    // during path validation (`path_validator.checkTlsFeatureConstraints`), not
+    // an assertion that propagates down as a stapling obligation of its own.
+    const must_staple_required = path.elements[0].certificate.mustStaple();
 
     const entries = allocator.alloc(Entry, certificate_count) catch {
         return .{ .rejected = .{ .reason = .out_of_memory, .certificate_index = null } };
@@ -347,16 +410,42 @@ pub fn evaluatePath(
         };
     }
 
+    // Disabled consults nothing, and that has to include *rejecting* on
+    // evidence: a caller running with revocation off must not be able to fail
+    // a handshake because a peer attached oversized or misfiled status data.
     if (config.mode == .disabled) {
         return .{ .accepted = .{
             .mode = config.mode,
             .entries = entries,
-            .must_staple_unenforced = must_staple_required,
+            .must_staple = if (must_staple_required) .unenforced_status_disabled else .not_required,
         } };
     }
 
+    if (evidence.assertions.len > config.limits.maximum_assertions) {
+        allocator.free(entries);
+        return .{ .rejected = .{ .reason = .resource_limit_exceeded, .certificate_index = null } };
+    }
+    for (evidence.assertions) |assertion| {
+        if (assertion.raw.len > config.limits.maximum_evidence_bytes) {
+            allocator.free(entries);
+            return .{ .rejected = .{
+                .reason = .resource_limit_exceeded,
+                .certificate_index = assertion.certificate_index,
+                .source = assertion.source,
+            } };
+        }
+        if (assertion.certificate_index >= certificate_count) {
+            allocator.free(entries);
+            return .{ .rejected = .{
+                .reason = .evidence_index_invalid,
+                .certificate_index = assertion.certificate_index,
+                .source = assertion.source,
+            } };
+        }
+    }
+
     for (path.elements[0..certificate_count], 0..) |element, certificate_index| {
-        const selection = select(evidence, certificate_index, config, validation_time);
+        const selection = select(evidence, element.certificate, certificate_index, config, validation_time);
         var entry = &entries[certificate_index];
         entry.source = selection.source;
         entry.defect = selection.defect;
@@ -371,26 +460,32 @@ pub fn evaluatePath(
         }
     }
 
-    if (must_staple_required and config.enforce_must_staple) {
-        const leaf_entry = entries[0];
-        const satisfied = leaf_entry.source == .stapled_ocsp and
-            leaf_entry.determination == .checked_good;
-        if (!satisfied) {
-            const failure = Failure{
-                .reason = .must_staple_not_satisfied,
-                .certificate_index = 0,
-                .source = leaf_entry.source,
-                .defect = leaf_entry.defect,
-            };
-            allocator.free(entries);
-            return .{ .rejected = failure };
+    var must_staple: MustStapleOutcome = .not_required;
+    if (must_staple_required) {
+        if (!config.enforce_must_staple) {
+            must_staple = .unenforced_by_configuration;
+        } else {
+            const leaf_entry = entries[0];
+            const satisfied = leaf_entry.source == .stapled_ocsp and
+                leaf_entry.determination == .checked_good;
+            if (!satisfied) {
+                const failure = Failure{
+                    .reason = .must_staple_not_satisfied,
+                    .certificate_index = 0,
+                    .source = leaf_entry.source,
+                    .defect = leaf_entry.defect,
+                };
+                allocator.free(entries);
+                return .{ .rejected = failure };
+            }
+            must_staple = .enforced;
         }
     }
 
     return .{ .accepted = .{
         .mode = config.mode,
         .entries = entries,
-        .must_staple_unenforced = false,
+        .must_staple = must_staple,
     } };
 }
 
@@ -409,12 +504,17 @@ const Selection = struct {
 
 /// Choose the assertion that decides this certificate.
 ///
-/// Revoked wins over everything, from any consulted source, so that a second
-/// source cannot launder a revocation away. Otherwise the highest-precedence
-/// source with a usable answer decides; when nothing is usable, the
-/// highest-precedence blocked assertion is reported so the operator learns why.
+/// A usable revocation wins over everything, so a second source cannot launder
+/// one away. Otherwise the highest-precedence source with a usable answer
+/// decides; when nothing is usable, the highest-precedence blocked assertion is
+/// reported so the operator learns why.
+///
+/// Assertions are matched by certificate identity, not by position: the same
+/// evidence set is offered to every candidate path, and an alternate candidate
+/// with a different certificate at this index must not inherit it.
 fn select(
     evidence: Evidence,
+    certificate: *const x509.Certificate,
     certificate_index: usize,
     config: Configuration,
     validation_time: i64,
@@ -423,9 +523,11 @@ fn select(
     var best_rank: usize = std.math.maxInt(usize);
     var blocked: Selection = .{};
     var blocked_rank: usize = std.math.maxInt(usize);
+    const identity = CertificateIdentity.of(certificate);
 
     for (evidence.assertions) |assertion| {
         if (assertion.certificate_index != certificate_index) continue;
+        if (!assertion.certificate.eql(identity)) continue;
         if (!consults(config.mode, assertion.source)) continue;
 
         const candidate = Selection{
@@ -449,22 +551,47 @@ fn select(
             continue;
         }
 
-        // Revocation is honored even from stale or unauthenticated evidence:
-        // ignoring it could only ever help a certificate its own issuer has
-        // withdrawn. See the trust-boundary note at the top of this file.
-        if (assertion.status == .revoked) {
-            var revoked = candidate;
-            revoked.status = .revoked;
-            return revoked;
-        }
-
-        if (config.require_signature_verified and !assertion.signature_verified) {
+        // Authentication comes before any status is trusted, with one narrow
+        // exception: a *peer-stapled* revocation. The only party who can supply
+        // attacker-chosen stapled bytes is the peer being authenticated, so
+        // honoring its self-revocation costs nothing. Evidence from a fetched
+        // OCSP responder or a CRL is a different matter — trusting an
+        // unauthenticated `revoked` there would hand an on-path attacker a
+        // one-packet denial of service.
+        const self_stapled_revocation =
+            assertion.source == .stapled_ocsp and assertion.status == .revoked;
+        if (config.require_signature_verified and
+            !assertion.signature_verified and
+            !self_stapled_revocation)
+        {
             const rank = sourceRank(assertion.source);
             if (rank < blocked_rank) {
                 blocked_rank = rank;
                 blocked = candidate;
                 blocked.status = null;
                 blocked.blocker = .unauthenticated;
+            }
+            continue;
+        }
+
+        if (assertion.status == .revoked) {
+            // Revocation is otherwise monotonic, so staleness does not
+            // rehabilitate it — except for certificateHold, which RFC 5280
+            // §5.3.1 explicitly allows to be released via removeFromCRL. A
+            // stale hold must not outrank fresher evidence of that release.
+            const releasable_hold = assertion.revocation_reason == .certificate_hold and
+                !isFresh(assertion, config.freshness, validation_time);
+            if (!releasable_hold) {
+                var revoked = candidate;
+                revoked.status = .revoked;
+                return revoked;
+            }
+            const rank = sourceRank(assertion.source);
+            if (rank < blocked_rank) {
+                blocked_rank = rank;
+                blocked = candidate;
+                blocked.status = null;
+                blocked.blocker = .stale;
             }
             continue;
         }
@@ -603,35 +730,41 @@ test "freshness bounds accept only evidence inside the stated window" {
     const freshness = Freshness{};
     try testing.expect(isFresh(.{
         .certificate_index = 0,
+        .certificate = .{ .digest = @splat(0) },
         .source = .stapled_ocsp,
         .this_update = now - 60,
         .next_update = now + 3600,
     }, freshness, now));
     try testing.expect(!isFresh(.{
         .certificate_index = 0,
+        .certificate = .{ .digest = @splat(0) },
         .source = .stapled_ocsp,
         .this_update = now - 60,
         .next_update = now - 3600,
     }, freshness, now));
     try testing.expect(!isFresh(.{
         .certificate_index = 0,
+        .certificate = .{ .digest = @splat(0) },
         .source = .stapled_ocsp,
         .this_update = now + 3600,
         .next_update = now + 7200,
     }, freshness, now));
     try testing.expect(!isFresh(.{
         .certificate_index = 0,
+        .certificate = .{ .digest = @splat(0) },
         .source = .stapled_ocsp,
         .this_update = now - 60,
     }, freshness, now));
     try testing.expect(!isFresh(.{
         .certificate_index = 0,
+        .certificate = .{ .digest = @splat(0) },
         .source = .stapled_ocsp,
         .next_update = now + 3600,
     }, freshness, now));
     // nextUpdate before thisUpdate is incoherent regardless of the window.
     try testing.expect(!isFresh(.{
         .certificate_index = 0,
+        .certificate = .{ .digest = @splat(0) },
         .source = .stapled_ocsp,
         .this_update = now - 60,
         .next_update = now - 120,
@@ -643,6 +776,7 @@ test "clock skew is applied on both sides of the window" {
     const freshness = Freshness{ .clock_skew_seconds = 300 };
     try testing.expect(isFresh(.{
         .certificate_index = 0,
+        .certificate = .{ .digest = @splat(0) },
         .source = .stapled_ocsp,
         .this_update = now + 200,
         .next_update = now + 3600,
@@ -650,6 +784,7 @@ test "clock skew is applied on both sides of the window" {
     // Expired by less than the skew allowance is still usable.
     try testing.expect(isFresh(.{
         .certificate_index = 0,
+        .certificate = .{ .digest = @splat(0) },
         .source = .stapled_ocsp,
         .this_update = now - 400,
         .next_update = now - 200,

--- a/src/pki/revocation.zig
+++ b/src/pki/revocation.zig
@@ -256,16 +256,9 @@ pub const MustStapleOutcome = enum {
     unenforced_status_disabled,
     /// Asserted, but `Configuration.enforce_must_staple` is off.
     unenforced_by_configuration,
-    /// The leaf declares RFC 6961 `status_request_v2`, which RFC 8446 §4.4.2.1
-    /// forbids a TLS 1.3 server from acting on. This stack cannot satisfy such
-    /// a declaration, so it is never reported as enforced; only `disabled` mode
-    /// reaches this state, because a consulting mode rejects instead.
-    unsatisfiable_status_request_v2,
 
     pub fn isUnenforced(self: MustStapleOutcome) bool {
-        return self == .unenforced_status_disabled or
-            self == .unenforced_by_configuration or
-            self == .unsatisfiable_status_request_v2;
+        return self == .unenforced_status_disabled or self == .unenforced_by_configuration;
     }
 };
 
@@ -305,9 +298,6 @@ pub const FailureReason = enum {
     status_malformed,
     status_unauthenticated,
     must_staple_not_satisfied,
-    /// The leaf demands a TLS feature this stack cannot negotiate, so its
-    /// assertion can never be honored (RFC 6961 `status_request_v2`).
-    must_staple_feature_unsupported,
     /// The certificate publishes no revocation mechanism at all, so a strict
     /// policy can never be satisfied for it.
     status_source_unsupported,
@@ -408,8 +398,14 @@ pub fn evaluatePath(
     // the extension is a *constraint on what the child must contain*, enforced
     // during path validation (`path_validator.checkTlsFeatureConstraints`), not
     // an assertion that propagates down as a stapling obligation of its own.
+    //
+    // Only `status_request` (5) creates that obligation. RFC 6961
+    // `status_request_v2` (17) is not offered by this TLS 1.3 profile, and
+    // RFC 7633 §§4.1/4.3.3 scope the certificate's demand to features present
+    // in *both* the ClientHello and the certificate — so a certificate that
+    // also advertises 17 for TLS 1.2 peers is perfectly usable here and must
+    // not be rejected over it.
     const must_staple_required = path.elements[0].certificate.mustStaple();
-    const unsatisfiable_feature = path.elements[0].certificate.assertsStatusRequestV2();
 
     const entries = allocator.alloc(Entry, certificate_count) catch {
         return .{ .rejected = .{ .reason = .out_of_memory, .certificate_index = null } };
@@ -430,12 +426,7 @@ pub fn evaluatePath(
         return .{ .accepted = .{
             .mode = config.mode,
             .entries = entries,
-            .must_staple = if (unsatisfiable_feature)
-                .unsatisfiable_status_request_v2
-            else if (must_staple_required)
-                .unenforced_status_disabled
-            else
-                .not_required,
+            .must_staple = if (must_staple_required) .unenforced_status_disabled else .not_required,
         } };
     }
 
@@ -475,21 +466,9 @@ pub fn evaluatePath(
     }
 
     var must_staple: MustStapleOutcome = .not_required;
-    if (must_staple_required or unsatisfiable_feature) {
+    if (must_staple_required) {
         if (!config.enforce_must_staple) {
             must_staple = .unenforced_by_configuration;
-        } else if (unsatisfiable_feature) {
-            // RFC 8446 §4.4.2.1 forbids acting on status_request_v2 in TLS 1.3,
-            // so this stack can never demonstrate that the declaration was
-            // honored. Reporting `enforced` off an ordinary staple would be
-            // exactly the "pretend we checked" outcome this policy exists to
-            // prevent, so a mode that consults status fails closed instead.
-            const failure = Failure{
-                .reason = .must_staple_feature_unsupported,
-                .certificate_index = 0,
-            };
-            allocator.free(entries);
-            return .{ .rejected = failure };
         } else {
             const leaf_entry = entries[0];
             const satisfied = leaf_entry.source == .stapled_ocsp and

--- a/src/pki/revocation.zig
+++ b/src/pki/revocation.zig
@@ -43,10 +43,13 @@
 //! unauthenticated `revoked` there would let an on-path attacker deny service
 //! with one forged response.
 //!
-//! Assertions are bound to a certificate by `CertificateIdentity`, not by
-//! position, so evidence gathered for one candidate path can never be applied
-//! to a different certificate that happens to sit at the same index in an
-//! alternate or cross-signed candidate.
+//! Assertions are bound to a certificate by `CertificateIdentity` alone, never
+//! by position. One evidence set is shared by every candidate path, and
+//! candidates differ in shape and depth, so a position-derived key would both
+//! misdirect evidence onto the wrong certificate and let a longer candidate's
+//! assertions invalidate a shorter one. Evidence for a certificate that is not
+//! on the path being evaluated is simply not consulted — it belongs to a
+//! sibling candidate, which is expected in a shared set.
 
 const std = @import("std");
 const path_builder = @import("path_builder.zig");
@@ -136,11 +139,11 @@ pub const CertificateIdentity = struct {
 /// Unix seconds on the same scale as `validation_time`; all are optional
 /// because CRL sets and cache entries do not all carry every field.
 pub const StatusAssertion = struct {
-    /// Leaf-first index of the certificate this assertion covers.
-    certificate_index: usize,
-    /// The certificate this assertion is about. An assertion whose identity
-    /// does not match the certificate at `certificate_index` in the path being
-    /// validated is ignored, never applied by position.
+    /// The certificate this assertion is about — the only thing that decides
+    /// which certificate it applies to. There is deliberately no path index
+    /// here: one evidence set is shared by every candidate, and candidates
+    /// differ in both shape and depth, so any position-derived key would let a
+    /// longer candidate's evidence invalidate or misdirect a shorter one's.
     certificate: CertificateIdentity,
     source: Source,
     status: Status = .unknown,
@@ -237,7 +240,7 @@ pub const Entry = struct {
     revocation_reason: ?CrlReason = null,
     this_update: ?i64 = null,
     next_update: ?i64 = null,
-    /// This certificate asserts RFC 7633 must-staple.
+    /// This certificate asserts RFC 7633 must-staple (`status_request`).
     must_staple: bool = false,
 };
 
@@ -253,9 +256,16 @@ pub const MustStapleOutcome = enum {
     unenforced_status_disabled,
     /// Asserted, but `Configuration.enforce_must_staple` is off.
     unenforced_by_configuration,
+    /// The leaf declares RFC 6961 `status_request_v2`, which RFC 8446 §4.4.2.1
+    /// forbids a TLS 1.3 server from acting on. This stack cannot satisfy such
+    /// a declaration, so it is never reported as enforced; only `disabled` mode
+    /// reaches this state, because a consulting mode rejects instead.
+    unsatisfiable_status_request_v2,
 
     pub fn isUnenforced(self: MustStapleOutcome) bool {
-        return self == .unenforced_status_disabled or self == .unenforced_by_configuration;
+        return self == .unenforced_status_disabled or
+            self == .unenforced_by_configuration or
+            self == .unsatisfiable_status_request_v2;
     }
 };
 
@@ -295,12 +305,14 @@ pub const FailureReason = enum {
     status_malformed,
     status_unauthenticated,
     must_staple_not_satisfied,
+    /// The leaf demands a TLS feature this stack cannot negotiate, so its
+    /// assertion can never be honored (RFC 6961 `status_request_v2`).
+    must_staple_feature_unsupported,
     /// The certificate publishes no revocation mechanism at all, so a strict
     /// policy can never be satisfied for it.
     status_source_unsupported,
-    /// The caller filed evidence against a certificate index the path does not
-    /// contain, or against the trust anchor.
-    evidence_index_invalid,
+    /// `evaluatePath` was handed something that is not a candidate path.
+    malformed_path,
     resource_limit_exceeded,
     out_of_memory,
 };
@@ -388,7 +400,7 @@ pub fn evaluatePath(
     validation_time: i64,
 ) Outcome {
     if (path.elements.len < 2) {
-        return .{ .rejected = .{ .reason = .evidence_index_invalid, .certificate_index = null } };
+        return .{ .rejected = .{ .reason = .malformed_path, .certificate_index = null } };
     }
     const certificate_count = path.elements.len - 1;
 
@@ -397,6 +409,7 @@ pub fn evaluatePath(
     // during path validation (`path_validator.checkTlsFeatureConstraints`), not
     // an assertion that propagates down as a stapling obligation of its own.
     const must_staple_required = path.elements[0].certificate.mustStaple();
+    const unsatisfiable_feature = path.elements[0].certificate.assertsStatusRequestV2();
 
     const entries = allocator.alloc(Entry, certificate_count) catch {
         return .{ .rejected = .{ .reason = .out_of_memory, .certificate_index = null } };
@@ -417,7 +430,12 @@ pub fn evaluatePath(
         return .{ .accepted = .{
             .mode = config.mode,
             .entries = entries,
-            .must_staple = if (must_staple_required) .unenforced_status_disabled else .not_required,
+            .must_staple = if (unsatisfiable_feature)
+                .unsatisfiable_status_request_v2
+            else if (must_staple_required)
+                .unenforced_status_disabled
+            else
+                .not_required,
         } };
     }
 
@@ -425,27 +443,23 @@ pub fn evaluatePath(
         allocator.free(entries);
         return .{ .rejected = .{ .reason = .resource_limit_exceeded, .certificate_index = null } };
     }
+    // Only the global bounds are checked here. Applicability is decided per
+    // certificate by identity: an assertion for a certificate this candidate
+    // does not contain belongs to a sibling candidate and is simply skipped,
+    // never a reason to reject this one.
     for (evidence.assertions) |assertion| {
         if (assertion.raw.len > config.limits.maximum_evidence_bytes) {
             allocator.free(entries);
             return .{ .rejected = .{
                 .reason = .resource_limit_exceeded,
-                .certificate_index = assertion.certificate_index,
-                .source = assertion.source,
-            } };
-        }
-        if (assertion.certificate_index >= certificate_count) {
-            allocator.free(entries);
-            return .{ .rejected = .{
-                .reason = .evidence_index_invalid,
-                .certificate_index = assertion.certificate_index,
+                .certificate_index = null,
                 .source = assertion.source,
             } };
         }
     }
 
     for (path.elements[0..certificate_count], 0..) |element, certificate_index| {
-        const selection = select(evidence, element.certificate, certificate_index, config, validation_time);
+        const selection = select(evidence, element.certificate, config, validation_time);
         var entry = &entries[certificate_index];
         entry.source = selection.source;
         entry.defect = selection.defect;
@@ -461,9 +475,21 @@ pub fn evaluatePath(
     }
 
     var must_staple: MustStapleOutcome = .not_required;
-    if (must_staple_required) {
+    if (must_staple_required or unsatisfiable_feature) {
         if (!config.enforce_must_staple) {
             must_staple = .unenforced_by_configuration;
+        } else if (unsatisfiable_feature) {
+            // RFC 8446 §4.4.2.1 forbids acting on status_request_v2 in TLS 1.3,
+            // so this stack can never demonstrate that the declaration was
+            // honored. Reporting `enforced` off an ordinary staple would be
+            // exactly the "pretend we checked" outcome this policy exists to
+            // prevent, so a mode that consults status fails closed instead.
+            const failure = Failure{
+                .reason = .must_staple_feature_unsupported,
+                .certificate_index = 0,
+            };
+            allocator.free(entries);
+            return .{ .rejected = failure };
         } else {
             const leaf_entry = entries[0];
             const satisfied = leaf_entry.source == .stapled_ocsp and
@@ -509,13 +535,13 @@ const Selection = struct {
 /// decides; when nothing is usable, the highest-precedence blocked assertion is
 /// reported so the operator learns why.
 ///
-/// Assertions are matched by certificate identity, not by position: the same
-/// evidence set is offered to every candidate path, and an alternate candidate
-/// with a different certificate at this index must not inherit it.
+/// Assertions are matched by certificate identity alone: the same evidence set
+/// is offered to every candidate path, so neither an alternate candidate with a
+/// different certificate at this index may inherit evidence, nor may the same
+/// certificate lose its own evidence by appearing at a different depth.
 fn select(
     evidence: Evidence,
     certificate: *const x509.Certificate,
-    certificate_index: usize,
     config: Configuration,
     validation_time: i64,
 ) Selection {
@@ -526,7 +552,6 @@ fn select(
     const identity = CertificateIdentity.of(certificate);
 
     for (evidence.assertions) |assertion| {
-        if (assertion.certificate_index != certificate_index) continue;
         if (!assertion.certificate.eql(identity)) continue;
         if (!consults(config.mode, assertion.source)) continue;
 
@@ -729,41 +754,35 @@ test "freshness bounds accept only evidence inside the stated window" {
     const now: i64 = 1_000_000;
     const freshness = Freshness{};
     try testing.expect(isFresh(.{
-        .certificate_index = 0,
         .certificate = .{ .digest = @splat(0) },
         .source = .stapled_ocsp,
         .this_update = now - 60,
         .next_update = now + 3600,
     }, freshness, now));
     try testing.expect(!isFresh(.{
-        .certificate_index = 0,
         .certificate = .{ .digest = @splat(0) },
         .source = .stapled_ocsp,
         .this_update = now - 60,
         .next_update = now - 3600,
     }, freshness, now));
     try testing.expect(!isFresh(.{
-        .certificate_index = 0,
         .certificate = .{ .digest = @splat(0) },
         .source = .stapled_ocsp,
         .this_update = now + 3600,
         .next_update = now + 7200,
     }, freshness, now));
     try testing.expect(!isFresh(.{
-        .certificate_index = 0,
         .certificate = .{ .digest = @splat(0) },
         .source = .stapled_ocsp,
         .this_update = now - 60,
     }, freshness, now));
     try testing.expect(!isFresh(.{
-        .certificate_index = 0,
         .certificate = .{ .digest = @splat(0) },
         .source = .stapled_ocsp,
         .next_update = now + 3600,
     }, freshness, now));
     // nextUpdate before thisUpdate is incoherent regardless of the window.
     try testing.expect(!isFresh(.{
-        .certificate_index = 0,
         .certificate = .{ .digest = @splat(0) },
         .source = .stapled_ocsp,
         .this_update = now - 60,
@@ -775,7 +794,6 @@ test "clock skew is applied on both sides of the window" {
     const now: i64 = 1_000_000;
     const freshness = Freshness{ .clock_skew_seconds = 300 };
     try testing.expect(isFresh(.{
-        .certificate_index = 0,
         .certificate = .{ .digest = @splat(0) },
         .source = .stapled_ocsp,
         .this_update = now + 200,
@@ -783,7 +801,6 @@ test "clock skew is applied on both sides of the window" {
     }, freshness, now));
     // Expired by less than the skew allowance is still usable.
     try testing.expect(isFresh(.{
-        .certificate_index = 0,
         .certificate = .{ .digest = @splat(0) },
         .source = .stapled_ocsp,
         .this_update = now - 400,

--- a/src/pki/revocation_tests.zig
+++ b/src/pki/revocation_tests.zig
@@ -1259,10 +1259,12 @@ test "a longer candidate's evidence cannot invalidate a shorter candidate" {
     try testing.expectEqual(@as(usize, 2), report.entries.len);
 }
 
-test "status_request_v2 cannot be satisfied by ordinary TLS 1.3 stapling" {
-    // RFC 8446 §4.4.2.1 obsoletes RFC 6961 and forbids a TLS 1.3 server from
-    // acting on status_request_v2, so a v1 staple cannot prove a feature-17
-    // declaration was honored.
+test "status_request_v2 alone creates no stapling obligation on TLS 1.3" {
+    // RFC 8446 §4.4.2.1 makes RFC 6961 status_request_v2 unusable in TLS 1.3,
+    // but RFC 7633 §§4.1/4.3.3 scope a certificate's demand to features present
+    // in *both* the ClientHello and the certificate. This client never offers
+    // feature 17, so a certificate advertising it — typically for TLS 1.2
+    // peers — is perfectly usable and must not be rejected over it.
     const allocator = testing.allocator;
     var fx = Fixtures.init(allocator);
     defer fx.deinit();
@@ -1273,75 +1275,71 @@ test "status_request_v2 cannot be satisfied by ordinary TLS 1.3 stapling" {
         .tls_features = &.{x509.TlsFeatures.status_request_v2},
     });
 
-    // Feature 17 alone is not must-staple, but it is also not satisfiable.
     try testing.expect(!fx.certs.items[0].mustStaple());
     try testing.expect(fx.certs.items[0].assertsStatusRequestV2());
 
-    const assertions = [_]revocation.StatusAssertion{stapledFor(&fx.certs.items[0], .good)};
-    const rejected = revocation.evaluatePath(
+    // No staple at all: still accepted, because feature 17 obliges nothing here.
+    var bare = revocation.evaluatePath(
         allocator,
         v2_path,
         .{ .mode = .soft_fail },
-        .{ .assertions = &assertions },
+        .{},
         validation_time,
     );
-    try expectRejected(rejected, .must_staple_feature_unsupported, 0);
+    var bare_report = try expectAccepted(&bare);
+    defer bare_report.deinit(allocator);
+    try testing.expectEqual(revocation.MustStapleOutcome.not_required, bare_report.must_staple);
+    try testing.expect(!bare_report.entries[0].must_staple);
 
-    // Disabled records it rather than rejecting, like every other unenforced
-    // must-staple state.
-    var disabled = revocation.evaluatePath(
+    const assertions = [_]revocation.StatusAssertion{stapledFor(&fx.certs.items[0], .good)};
+    var stapled = revocation.evaluatePath(
         allocator,
         v2_path,
-        .{},
+        .{ .mode = .strict },
         .{ .assertions = &assertions },
         validation_time,
     );
-    var disabled_report = try expectAccepted(&disabled);
-    defer disabled_report.deinit(allocator);
-    try testing.expectEqual(
-        revocation.MustStapleOutcome.unsatisfiable_status_request_v2,
-        disabled_report.must_staple,
-    );
+    var stapled_report = try expectAccepted(&stapled);
+    defer stapled_report.deinit(allocator);
+    try testing.expectEqual(revocation.MustStapleOutcome.not_required, stapled_report.must_staple);
+    try testing.expect(stapled_report.allChecked());
+}
 
-    // Declaring both 5 and 17 does not make 17 satisfiable either.
-    var both_fx = Fixtures.init(allocator);
-    defer both_fx.deinit();
-    var both_storage: [4]path_builder.Element = undefined;
-    const both_path = try twoCertPath(&both_fx, &both_storage, .{
+test "declaring both status_request and its v2 form is satisfied by feature 5" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{
         .subject = "leaf",
         .issuer = "Root",
         .tls_features = &.{ x509.TlsFeatures.status_request, x509.TlsFeatures.status_request_v2 },
     });
-    const both_assertions = [_]revocation.StatusAssertion{stapledFor(&both_fx.certs.items[0], .good)};
-    const both_rejected = revocation.evaluatePath(
-        allocator,
-        both_path,
-        .{ .mode = .soft_fail },
-        .{ .assertions = &both_assertions },
-        validation_time,
-    );
-    try expectRejected(both_rejected, .must_staple_feature_unsupported, 0);
+    try testing.expect(fx.certs.items[0].mustStaple());
 
-    // Ordinary feature-5 must-staple is still satisfied by a TLS 1.3 staple.
-    var v1_fx = Fixtures.init(allocator);
-    defer v1_fx.deinit();
-    var v1_storage: [4]path_builder.Element = undefined;
-    const v1_path = try twoCertPath(&v1_fx, &v1_storage, .{
-        .subject = "leaf",
-        .issuer = "Root",
-        .tls_features = &.{x509.TlsFeatures.status_request},
-    });
-    const v1_assertions = [_]revocation.StatusAssertion{stapledFor(&v1_fx.certs.items[0], .good)};
-    var accepted = revocation.evaluatePath(
+    // The ordinary TLS 1.3 staple satisfies feature 5; the unofferable feature
+    // 17 alongside it neither adds an obligation nor blocks this one.
+    const assertions = [_]revocation.StatusAssertion{stapledFor(&fx.certs.items[0], .good)};
+    var outcome = revocation.evaluatePath(
         allocator,
-        v1_path,
+        path,
         .{ .mode = .soft_fail },
-        .{ .assertions = &v1_assertions },
+        .{ .assertions = &assertions },
         validation_time,
     );
-    var report = try expectAccepted(&accepted);
+    var report = try expectAccepted(&outcome);
     defer report.deinit(allocator);
     try testing.expectEqual(revocation.MustStapleOutcome.enforced, report.must_staple);
+
+    // Feature 5 is still enforced: drop the staple and the path is rejected.
+    const missing = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .soft_fail },
+        .{},
+        validation_time,
+    );
+    try expectRejected(missing, .must_staple_not_satisfied, 0);
 }
 
 test {

--- a/src/pki/revocation_tests.zig
+++ b/src/pki/revocation_tests.zig
@@ -497,6 +497,10 @@ test "unauthenticated evidence never counts as a completed check" {
     try testing.expectEqual(revocation.Determination.checked_good, report.entries[0].determination);
 }
 
+/// Must-staple only binds when the ClientHello offered `status_request`, so
+/// every enforcement fixture has to say so explicitly.
+const offered = revocation.Configuration{ .mode = .soft_fail, .offered_status_request = true };
+
 test "must-staple requires stapled good status once a mode consults status" {
     const allocator = testing.allocator;
     var fx = Fixtures.init(allocator);
@@ -513,7 +517,7 @@ test "must-staple requires stapled good status once a mode consults status" {
     const missing = revocation.evaluatePath(
         allocator,
         path,
-        .{ .mode = .soft_fail },
+        offered,
         .{},
         validation_time,
     );
@@ -526,7 +530,7 @@ test "must-staple requires stapled good status once a mode consults status" {
     const wrong_source = revocation.evaluatePath(
         allocator,
         path,
-        .{ .mode = .soft_fail },
+        offered,
         .{ .assertions = &cached_assertions },
         validation_time,
     );
@@ -537,7 +541,7 @@ test "must-staple requires stapled good status once a mode consults status" {
     var outcome = revocation.evaluatePath(
         allocator,
         path,
-        .{ .mode = .soft_fail },
+        offered,
         .{ .assertions = &good_assertions },
         validation_time,
     );
@@ -558,7 +562,13 @@ test "must-staple is explicitly unenforced, not silently satisfied, when disable
         .tls_features = &.{x509.TlsFeatures.status_request},
     });
 
-    var outcome = revocation.evaluatePath(allocator, path, .{}, .{}, validation_time);
+    var outcome = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .offered_status_request = true },
+        .{},
+        validation_time,
+    );
     var report = try expectAccepted(&outcome);
     defer report.deinit(allocator);
     try testing.expectEqual(revocation.MustStapleOutcome.unenforced_status_disabled, report.must_staple);
@@ -579,7 +589,7 @@ test "must-staple enforcement can be disabled explicitly" {
     var outcome = revocation.evaluatePath(
         allocator,
         path,
-        .{ .mode = .soft_fail, .enforce_must_staple = false },
+        .{ .mode = .soft_fail, .enforce_must_staple = false, .offered_status_request = true },
         .{},
         validation_time,
     );
@@ -1323,7 +1333,7 @@ test "declaring both status_request and its v2 form is satisfied by feature 5" {
     var outcome = revocation.evaluatePath(
         allocator,
         path,
-        .{ .mode = .soft_fail },
+        offered,
         .{ .assertions = &assertions },
         validation_time,
     );
@@ -1332,14 +1342,100 @@ test "declaring both status_request and its v2 form is satisfied by feature 5" {
     try testing.expectEqual(revocation.MustStapleOutcome.enforced, report.must_staple);
 
     // Feature 5 is still enforced: drop the staple and the path is rejected.
-    const missing = revocation.evaluatePath(
+    const missing = revocation.evaluatePath(allocator, path, offered, .{}, validation_time);
+    try expectRejected(missing, .must_staple_not_satisfied, 0);
+}
+
+test "must-staple binds only when the client offered status_request" {
+    // RFC 7633 §4.3.3: a certificate's feature demand is scoped to features in
+    // both the ClientHello and the certificate. Tardigrade's TLS 1.3 hello does
+    // not currently send `status_request`, so a must-staple certificate makes
+    // no demand of such a connection — and the report says exactly that rather
+    // than reporting `not_required`, which would hide the assertion.
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{
+        .subject = "leaf",
+        .issuer = "Root",
+        .tls_features = &.{x509.TlsFeatures.status_request},
+    });
+    try testing.expect(fx.certs.items[0].mustStaple());
+
+    // Not offered: no staple, and no rejection, in every consulting mode.
+    for ([_]revocation.Mode{ .stapled_only, .soft_fail, .strict }) |mode| {
+        var outcome = revocation.evaluatePath(
+            allocator,
+            path,
+            .{ .mode = mode, .offered_status_request = false },
+            .{},
+            validation_time,
+        );
+        // Strict still wants status evidence for its own reasons; supply it so
+        // the only thing under test is the must-staple obligation.
+        if (mode == .strict) {
+            switch (outcome) {
+                .rejected => |failure| try testing.expectEqual(
+                    revocation.FailureReason.status_unavailable,
+                    failure.reason,
+                ),
+                .accepted => return error.TestUnexpectedResult,
+            }
+            continue;
+        }
+        var report = try expectAccepted(&outcome);
+        defer report.deinit(allocator);
+        try testing.expectEqual(revocation.MustStapleOutcome.not_offered_by_client, report.must_staple);
+        try testing.expect(report.entries[0].must_staple);
+    }
+
+    // Offered: the same certificate and the same absent staple now reject.
+    const rejected = revocation.evaluatePath(
         allocator,
         path,
-        .{ .mode = .soft_fail },
+        .{ .mode = .soft_fail, .offered_status_request = true },
         .{},
         validation_time,
     );
-    try expectRejected(missing, .must_staple_not_satisfied, 0);
+    try expectRejected(rejected, .must_staple_not_satisfied, 0);
+
+    // Offered and satisfied.
+    const assertions = [_]revocation.StatusAssertion{stapledFor(&fx.certs.items[0], .good)};
+    var accepted = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .soft_fail, .offered_status_request = true },
+        .{ .assertions = &assertions },
+        validation_time,
+    );
+    var report = try expectAccepted(&accepted);
+    defer report.deinit(allocator);
+    try testing.expectEqual(revocation.MustStapleOutcome.enforced, report.must_staple);
+}
+
+test "a certificate without must-staple reports not_required either way" {
+    // `not_offered_by_client` must describe a real assertion, never stand in
+    // for "this certificate never asked for stapling".
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
+
+    for ([_]bool{ false, true }) |client_offered| {
+        var outcome = revocation.evaluatePath(
+            allocator,
+            path,
+            .{ .mode = .soft_fail, .offered_status_request = client_offered },
+            .{},
+            validation_time,
+        );
+        var report = try expectAccepted(&outcome);
+        defer report.deinit(allocator);
+        try testing.expectEqual(revocation.MustStapleOutcome.not_required, report.must_staple);
+        try testing.expect(!report.entries[0].must_staple);
+    }
 }
 
 test {

--- a/src/pki/revocation_tests.zig
+++ b/src/pki/revocation_tests.zig
@@ -1,0 +1,887 @@
+//! Certificate-status policy fixtures (#349).
+//!
+//! These exercise `revocation.evaluatePath` directly, so the certificates only
+//! have to parse — signatures are validated one layer up, in
+//! `path_validator_tests.zig`, which also covers the wired-through policy.
+
+const std = @import("std");
+const der = @import("der.zig");
+const oid = @import("oid.zig");
+const path_builder = @import("path_builder.zig");
+const revocation = @import("revocation.zig");
+const x509 = @import("x509.zig");
+
+const testing = std.testing;
+const validation_time: i64 = 1_782_864_000; // 2026-07-01T00:00:00Z
+
+fn tlv(arena: std.mem.Allocator, tag: u8, parts: []const []const u8) ![]u8 {
+    var total: usize = 0;
+    for (parts) |part| total += part.len;
+    var len_buf: [9]u8 = undefined;
+    const len_len = try der.encodeLength(total, &len_buf);
+    const out = try arena.alloc(u8, 1 + len_len + total);
+    out[0] = tag;
+    @memcpy(out[1 .. 1 + len_len], len_buf[0..len_len]);
+    var offset = 1 + len_len;
+    for (parts) |part| {
+        @memcpy(out[offset .. offset + part.len], part);
+        offset += part.len;
+    }
+    return out;
+}
+
+fn oidTlv(arena: std.mem.Allocator, components: []const u32) ![]u8 {
+    var buffer: [64]u8 = undefined;
+    const len = try oid.encodeComponents(components, &buffer);
+    return tlv(arena, 0x06, &.{buffer[0..len]});
+}
+
+fn algorithmEd25519(arena: std.mem.Allocator) ![]u8 {
+    return tlv(arena, 0x30, &.{try oidTlv(arena, &oid.well_known.ed25519)});
+}
+
+fn nameWithCn(arena: std.mem.Allocator, common_name: []const u8) ![]u8 {
+    const attribute = try tlv(arena, 0x30, &.{
+        try oidTlv(arena, &oid.well_known.common_name),
+        try tlv(arena, 0x0c, &.{common_name}),
+    });
+    return tlv(arena, 0x30, &.{try tlv(arena, 0x31, &.{attribute})});
+}
+
+fn extensionTlv(arena: std.mem.Allocator, components: []const u32, critical: bool, value: []const u8) ![]u8 {
+    if (critical) {
+        return tlv(arena, 0x30, &.{
+            try oidTlv(arena, components),
+            try tlv(arena, 0x01, &.{&[_]u8{0xff}}),
+            try tlv(arena, 0x04, &.{value}),
+        });
+    }
+    return tlv(arena, 0x30, &.{
+        try oidTlv(arena, components),
+        try tlv(arena, 0x04, &.{value}),
+    });
+}
+
+const StatusSource = enum { none, ocsp, crl, both };
+
+const Spec = struct {
+    subject: []const u8,
+    issuer: []const u8,
+    ca: bool = false,
+    status_source: StatusSource = .ocsp,
+    tls_features: ?[]const u16 = null,
+    raw_tls_features: ?[]const u8 = null,
+    tls_features_critical: bool = false,
+};
+
+const Fixtures = struct {
+    allocator: std.mem.Allocator,
+    arena: std.heap.ArenaAllocator,
+    certs: std.ArrayList(x509.Certificate) = .empty,
+
+    fn init(allocator: std.mem.Allocator) Fixtures {
+        return .{ .allocator = allocator, .arena = std.heap.ArenaAllocator.init(allocator) };
+    }
+
+    fn deinit(self: *Fixtures) void {
+        for (self.certs.items) |*certificate| certificate.deinit(self.allocator);
+        self.certs.deinit(self.allocator);
+        self.arena.deinit();
+        self.* = undefined;
+    }
+
+    fn add(self: *Fixtures, spec: Spec) !void {
+        const arena = self.arena.allocator();
+        var extensions: std.ArrayList([]const u8) = .empty;
+        defer extensions.deinit(arena);
+
+        try extensions.append(arena, try extensionTlv(
+            arena,
+            &oid.well_known.basic_constraints,
+            true,
+            if (spec.ca)
+                try tlv(arena, 0x30, &.{try tlv(arena, 0x01, &.{&[_]u8{0xff}})})
+            else
+                try tlv(arena, 0x30, &.{}),
+        ));
+
+        if (spec.status_source == .ocsp or spec.status_source == .both) {
+            const description = try tlv(arena, 0x30, &.{
+                try oidTlv(arena, &oid.well_known.aia_ocsp),
+                try tlv(arena, 0x86, &.{"http://ocsp.example.com"}),
+            });
+            try extensions.append(arena, try extensionTlv(
+                arena,
+                &oid.well_known.authority_info_access,
+                false,
+                try tlv(arena, 0x30, &.{description}),
+            ));
+        }
+        if (spec.status_source == .crl or spec.status_source == .both) {
+            const full_name = try tlv(arena, 0xa0, &.{
+                try tlv(arena, 0xa0, &.{try tlv(arena, 0x86, &.{"http://crl.example.com/a.crl"})}),
+            });
+            try extensions.append(arena, try extensionTlv(
+                arena,
+                &oid.well_known.crl_distribution_points,
+                false,
+                try tlv(arena, 0x30, &.{try tlv(arena, 0x30, &.{full_name})}),
+            ));
+        }
+        if (spec.tls_features) |features| {
+            var parts: std.ArrayList([]const u8) = .empty;
+            defer parts.deinit(arena);
+            for (features) |feature| {
+                try parts.append(arena, try tlv(arena, 0x02, &.{try integerContent(arena, feature)}));
+            }
+            try extensions.append(arena, try extensionTlv(
+                arena,
+                &oid.well_known.tls_feature,
+                spec.tls_features_critical,
+                try tlv(arena, 0x30, parts.items),
+            ));
+        }
+        if (spec.raw_tls_features) |value| {
+            try extensions.append(arena, try extensionTlv(
+                arena,
+                &oid.well_known.tls_feature,
+                spec.tls_features_critical,
+                value,
+            ));
+        }
+
+        var tbs_parts: std.ArrayList([]const u8) = .empty;
+        defer tbs_parts.deinit(arena);
+        try tbs_parts.append(arena, try tlv(arena, 0xa0, &.{try tlv(arena, 0x02, &.{&[_]u8{2}})}));
+        const serial: u8 = @intCast(self.certs.items.len + 1);
+        try tbs_parts.append(arena, try tlv(arena, 0x02, &.{&[_]u8{serial}}));
+        try tbs_parts.append(arena, try algorithmEd25519(arena));
+        try tbs_parts.append(arena, try nameWithCn(arena, spec.issuer));
+        try tbs_parts.append(arena, try tlv(arena, 0x30, &.{
+            try tlv(arena, 0x17, &.{"260101000000Z"}),
+            try tlv(arena, 0x17, &.{"270101000000Z"}),
+        }));
+        try tbs_parts.append(arena, try nameWithCn(arena, spec.subject));
+        const public_key = [_]u8{0} ** 33;
+        try tbs_parts.append(arena, try tlv(arena, 0x30, &.{
+            try algorithmEd25519(arena),
+            try tlv(arena, 0x03, &.{&public_key}),
+        }));
+        try tbs_parts.append(arena, try tlv(arena, 0xa3, &.{try tlv(arena, 0x30, extensions.items)}));
+
+        const signature = [_]u8{0} ** 65;
+        const certificate_der = try tlv(arena, 0x30, &.{
+            try tlv(arena, 0x30, tbs_parts.items),
+            try algorithmEd25519(arena),
+            try tlv(arena, 0x03, &.{&signature}),
+        });
+
+        const certificate = try x509.Certificate.parse(self.allocator, certificate_der, .{});
+        errdefer {
+            var owned = certificate;
+            owned.deinit(self.allocator);
+        }
+        try self.certs.append(self.allocator, certificate);
+    }
+
+    fn path(self: *Fixtures, storage: []path_builder.Element) path_builder.Path {
+        for (self.certs.items, 0..) |*certificate, index| {
+            storage[index] = .{
+                .certificate = certificate,
+                .source = if (index == 0)
+                    .leaf
+                else if (index == self.certs.items.len - 1)
+                    .anchor
+                else
+                    .intermediate,
+                .input_index = if (index == 0) 0 else index - 1,
+            };
+        }
+        return .{ .elements = storage[0..self.certs.items.len] };
+    }
+};
+
+fn integerContent(arena: std.mem.Allocator, value: u16) ![]const u8 {
+    var encoded: [3]u8 = undefined;
+    encoded[0] = 0;
+    std.mem.writeInt(u16, encoded[1..3], value, .big);
+    var first: usize = 1;
+    while (first < 2 and encoded[first] == 0) first += 1;
+    if (encoded[first] & 0x80 != 0) first -= 1;
+    return arena.dupe(u8, encoded[first..]);
+}
+
+/// leaf → anchor, leaf publishing the requested status source.
+fn twoCertPath(fx: *Fixtures, storage: []path_builder.Element, leaf: Spec) !path_builder.Path {
+    try fx.add(leaf);
+    try fx.add(.{ .subject = "Root", .issuer = "Root", .ca = true, .status_source = .none });
+    return fx.path(storage);
+}
+
+fn expectAccepted(outcome: *revocation.Outcome) !revocation.Report {
+    switch (outcome.*) {
+        .accepted => |report| return report,
+        .rejected => |failure| {
+            std.debug.print("unexpected status rejection: {s} at {?}\n", .{ @tagName(failure.reason), failure.certificate_index });
+            return error.TestUnexpectedResult;
+        },
+    }
+}
+
+fn expectRejected(
+    outcome: revocation.Outcome,
+    reason: revocation.FailureReason,
+    certificate_index: ?usize,
+) !void {
+    switch (outcome) {
+        .accepted => return error.TestUnexpectedResult,
+        .rejected => |failure| {
+            try testing.expectEqual(reason, failure.reason);
+            try testing.expectEqual(certificate_index, failure.certificate_index);
+        },
+    }
+}
+
+fn stapled(status: revocation.Status) revocation.StatusAssertion {
+    return .{
+        .certificate_index = 0,
+        .source = .stapled_ocsp,
+        .status = status,
+        .signature_verified = true,
+        .this_update = validation_time - 3600,
+        .next_update = validation_time + 3600,
+    };
+}
+
+test "disabled policy records that nothing was checked" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
+
+    var outcome = revocation.evaluatePath(allocator, path, .{}, .{}, validation_time);
+    var report = try expectAccepted(&outcome);
+    defer report.deinit(allocator);
+
+    try testing.expectEqual(revocation.Mode.disabled, report.mode);
+    // One entry per non-anchor certificate; the anchor is trust configuration.
+    try testing.expectEqual(@as(usize, 1), report.entries.len);
+    try testing.expectEqual(revocation.Determination.not_checked_policy_disabled, report.entries[0].determination);
+    try testing.expect(!report.allChecked());
+    try testing.expect(!report.must_staple_unenforced);
+}
+
+test "stapled good status is recorded as a completed check" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
+
+    const assertions = [_]revocation.StatusAssertion{stapled(.good)};
+    for ([_]revocation.Mode{ .stapled_only, .soft_fail, .strict }) |mode| {
+        var outcome = revocation.evaluatePath(
+            allocator,
+            path,
+            .{ .mode = mode },
+            .{ .assertions = &assertions },
+            validation_time,
+        );
+        var report = try expectAccepted(&outcome);
+        defer report.deinit(allocator);
+        try testing.expectEqual(revocation.Determination.checked_good, report.entries[0].determination);
+        try testing.expectEqual(revocation.Source.stapled_ocsp, report.entries[0].source.?);
+        try testing.expect(report.allChecked());
+    }
+}
+
+test "stapled revoked status rejects in every consulting mode" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
+
+    var assertion = stapled(.revoked);
+    assertion.revocation_reason = .key_compromise;
+    assertion.revoked_at = validation_time - 86_400;
+    const assertions = [_]revocation.StatusAssertion{assertion};
+
+    for ([_]revocation.Mode{ .stapled_only, .soft_fail, .strict }) |mode| {
+        const outcome = revocation.evaluatePath(
+            allocator,
+            path,
+            .{ .mode = mode },
+            .{ .assertions = &assertions },
+            validation_time,
+        );
+        try expectRejected(outcome, .certificate_revoked, 0);
+        switch (outcome) {
+            .rejected => |failure| try testing.expectEqual(revocation.CrlReason.key_compromise, failure.revocation_reason.?),
+            .accepted => unreachable,
+        }
+    }
+}
+
+test "revoked evidence wins over a good answer from another source" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
+
+    var crl_revoked = stapled(.revoked);
+    crl_revoked.source = .crl_set;
+    const assertions = [_]revocation.StatusAssertion{ stapled(.good), crl_revoked };
+
+    const outcome = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .soft_fail },
+        .{ .assertions = &assertions },
+        validation_time,
+    );
+    try expectRejected(outcome, .certificate_revoked, 0);
+}
+
+test "revoked evidence is honored even when unauthenticated or stale" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
+
+    var unauthenticated = stapled(.revoked);
+    unauthenticated.signature_verified = false;
+    var stale = stapled(.revoked);
+    stale.next_update = validation_time - 86_400;
+
+    for ([_]revocation.StatusAssertion{ unauthenticated, stale }) |assertion| {
+        const assertions = [_]revocation.StatusAssertion{assertion};
+        const outcome = revocation.evaluatePath(
+            allocator,
+            path,
+            .{ .mode = .soft_fail },
+            .{ .assertions = &assertions },
+            validation_time,
+        );
+        try expectRejected(outcome, .certificate_revoked, 0);
+    }
+}
+
+test "missing status is accepted below strict and rejected by it" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
+
+    for ([_]revocation.Mode{ .stapled_only, .soft_fail }) |mode| {
+        var outcome = revocation.evaluatePath(allocator, path, .{ .mode = mode }, .{}, validation_time);
+        var report = try expectAccepted(&outcome);
+        defer report.deinit(allocator);
+        try testing.expectEqual(revocation.Determination.not_checked_no_evidence, report.entries[0].determination);
+        try testing.expectEqual(@as(?revocation.Source, null), report.entries[0].source);
+    }
+
+    const outcome = revocation.evaluatePath(allocator, path, .{ .mode = .strict }, .{}, validation_time);
+    try expectRejected(outcome, .status_unavailable, 0);
+}
+
+test "stale stapled evidence is rejected where stapling is consulted" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
+
+    var stale = stapled(.good);
+    stale.this_update = validation_time - 30 * 86_400;
+    stale.next_update = validation_time - 29 * 86_400;
+    const assertions = [_]revocation.StatusAssertion{stale};
+
+    for ([_]revocation.Mode{ .stapled_only, .strict }) |mode| {
+        const outcome = revocation.evaluatePath(
+            allocator,
+            path,
+            .{ .mode = mode },
+            .{ .assertions = &assertions },
+            validation_time,
+        );
+        try expectRejected(outcome, .status_stale, 0);
+    }
+
+    var outcome = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .soft_fail },
+        .{ .assertions = &assertions },
+        validation_time,
+    );
+    var report = try expectAccepted(&outcome);
+    defer report.deinit(allocator);
+    try testing.expectEqual(revocation.Determination.not_checked_stale_evidence, report.entries[0].determination);
+    try testing.expectEqual(stale.next_update, report.entries[0].next_update);
+}
+
+test "malformed stapled evidence is rejected where stapling is consulted" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
+
+    var malformed = stapled(.good);
+    malformed.defect = .malformed_encoding;
+    const assertions = [_]revocation.StatusAssertion{malformed};
+
+    for ([_]revocation.Mode{ .stapled_only, .strict }) |mode| {
+        const outcome = revocation.evaluatePath(
+            allocator,
+            path,
+            .{ .mode = mode },
+            .{ .assertions = &assertions },
+            validation_time,
+        );
+        try expectRejected(outcome, .status_malformed, 0);
+        switch (outcome) {
+            .rejected => |failure| try testing.expectEqual(revocation.Defect.malformed_encoding, failure.defect.?),
+            .accepted => unreachable,
+        }
+    }
+
+    var outcome = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .soft_fail },
+        .{ .assertions = &assertions },
+        validation_time,
+    );
+    var report = try expectAccepted(&outcome);
+    defer report.deinit(allocator);
+    try testing.expectEqual(revocation.Determination.not_checked_defective_evidence, report.entries[0].determination);
+}
+
+test "unauthenticated evidence never counts as a completed check" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
+
+    var unverified = stapled(.good);
+    unverified.signature_verified = false;
+    const assertions = [_]revocation.StatusAssertion{unverified};
+
+    const outcome = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .strict },
+        .{ .assertions = &assertions },
+        validation_time,
+    );
+    try expectRejected(outcome, .status_unauthenticated, 0);
+
+    // Opting out downgrades the trust boundary and makes the same bytes count.
+    var relaxed = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .strict, .require_signature_verified = false },
+        .{ .assertions = &assertions },
+        validation_time,
+    );
+    var report = try expectAccepted(&relaxed);
+    defer report.deinit(allocator);
+    try testing.expectEqual(revocation.Determination.checked_good, report.entries[0].determination);
+}
+
+test "must-staple requires stapled good status once a mode consults status" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{
+        .subject = "leaf",
+        .issuer = "Root",
+        .tls_features = &.{x509.TlsFeatures.status_request},
+    });
+    try testing.expect(fx.certs.items[0].mustStaple());
+
+    // No staple at all: soft-fail would otherwise accept.
+    const missing = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .soft_fail },
+        .{},
+        validation_time,
+    );
+    try expectRejected(missing, .must_staple_not_satisfied, 0);
+
+    // A cached answer is not a staple.
+    var cached = stapled(.good);
+    cached.source = .cached_ocsp;
+    const cached_assertions = [_]revocation.StatusAssertion{cached};
+    const wrong_source = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .soft_fail },
+        .{ .assertions = &cached_assertions },
+        validation_time,
+    );
+    try expectRejected(wrong_source, .must_staple_not_satisfied, 0);
+
+    // A good staple satisfies it.
+    const good_assertions = [_]revocation.StatusAssertion{stapled(.good)};
+    var outcome = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .soft_fail },
+        .{ .assertions = &good_assertions },
+        validation_time,
+    );
+    var report = try expectAccepted(&outcome);
+    defer report.deinit(allocator);
+    try testing.expect(report.entries[0].must_staple);
+    try testing.expect(!report.must_staple_unenforced);
+}
+
+test "must-staple is explicitly unenforced, not silently satisfied, when disabled" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{
+        .subject = "leaf",
+        .issuer = "Root",
+        .tls_features = &.{x509.TlsFeatures.status_request},
+    });
+
+    var outcome = revocation.evaluatePath(allocator, path, .{}, .{}, validation_time);
+    var report = try expectAccepted(&outcome);
+    defer report.deinit(allocator);
+    try testing.expect(report.must_staple_unenforced);
+    try testing.expect(report.entries[0].must_staple);
+}
+
+test "must-staple enforcement can be disabled explicitly" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{
+        .subject = "leaf",
+        .issuer = "Root",
+        .tls_features = &.{x509.TlsFeatures.status_request},
+    });
+
+    var outcome = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .soft_fail, .enforce_must_staple = false },
+        .{},
+        validation_time,
+    );
+    var report = try expectAccepted(&outcome);
+    defer report.deinit(allocator);
+    try testing.expectEqual(revocation.Determination.not_checked_no_evidence, report.entries[0].determination);
+}
+
+test "an issuing CA can assert must-staple for the certificates below it" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    try fx.add(.{ .subject = "leaf", .issuer = "Intermediate" });
+    try fx.add(.{
+        .subject = "Intermediate",
+        .issuer = "Root",
+        .ca = true,
+        .tls_features = &.{x509.TlsFeatures.status_request},
+    });
+    try fx.add(.{ .subject = "Root", .issuer = "Root", .ca = true, .status_source = .none });
+    var storage: [4]path_builder.Element = undefined;
+    const path = fx.path(&storage);
+
+    const outcome = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .soft_fail },
+        .{},
+        validation_time,
+    );
+    try expectRejected(outcome, .must_staple_not_satisfied, 0);
+}
+
+test "a certificate publishing no status source is unsupported under strict" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{
+        .subject = "leaf",
+        .issuer = "Root",
+        .status_source = .none,
+    });
+
+    const outcome = revocation.evaluatePath(allocator, path, .{ .mode = .strict }, .{}, validation_time);
+    try expectRejected(outcome, .status_source_unsupported, 0);
+
+    var soft = revocation.evaluatePath(allocator, path, .{ .mode = .soft_fail }, .{}, validation_time);
+    var report = try expectAccepted(&soft);
+    defer report.deinit(allocator);
+    try testing.expectEqual(revocation.Determination.not_checked_no_status_source, report.entries[0].determination);
+}
+
+test "a CRL distribution point counts as a status source" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{
+        .subject = "leaf",
+        .issuer = "Root",
+        .status_source = .crl,
+    });
+
+    try testing.expect(!fx.certs.items[0].hasOcspResponder());
+    try testing.expect(fx.certs.items[0].crlDistributionPoints().?.len == 1);
+
+    const outcome = revocation.evaluatePath(allocator, path, .{ .mode = .strict }, .{}, validation_time);
+    try expectRejected(outcome, .status_unavailable, 0);
+}
+
+test "stapled-only mode ignores cached and CRL evidence" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
+
+    var cached = stapled(.good);
+    cached.source = .cached_ocsp;
+    var crl_stale = stapled(.good);
+    crl_stale.source = .crl_set;
+    crl_stale.next_update = validation_time - 86_400;
+    const assertions = [_]revocation.StatusAssertion{ cached, crl_stale };
+
+    var outcome = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .stapled_only },
+        .{ .assertions = &assertions },
+        validation_time,
+    );
+    var report = try expectAccepted(&outcome);
+    defer report.deinit(allocator);
+    try testing.expectEqual(revocation.Determination.not_checked_no_evidence, report.entries[0].determination);
+
+    // The same evidence decides under soft-fail, where every source counts.
+    var consulted = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .soft_fail },
+        .{ .assertions = &assertions },
+        validation_time,
+    );
+    var consulted_report = try expectAccepted(&consulted);
+    defer consulted_report.deinit(allocator);
+    try testing.expectEqual(revocation.Determination.checked_good, consulted_report.entries[0].determination);
+    try testing.expectEqual(revocation.Source.cached_ocsp, consulted_report.entries[0].source.?);
+}
+
+test "stapled evidence outranks a cached answer for the same certificate" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
+
+    var cached_unknown = stapled(.unknown);
+    cached_unknown.source = .cached_ocsp;
+    const assertions = [_]revocation.StatusAssertion{ cached_unknown, stapled(.good) };
+
+    var outcome = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .strict },
+        .{ .assertions = &assertions },
+        validation_time,
+    );
+    var report = try expectAccepted(&outcome);
+    defer report.deinit(allocator);
+    try testing.expectEqual(revocation.Source.stapled_ocsp, report.entries[0].source.?);
+}
+
+test "an unknown status is not a completed check under strict" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
+
+    const assertions = [_]revocation.StatusAssertion{stapled(.unknown)};
+    const outcome = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .strict },
+        .{ .assertions = &assertions },
+        validation_time,
+    );
+    try expectRejected(outcome, .status_unavailable, 0);
+
+    var soft = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .soft_fail },
+        .{ .assertions = &assertions },
+        validation_time,
+    );
+    var report = try expectAccepted(&soft);
+    defer report.deinit(allocator);
+    try testing.expectEqual(revocation.Determination.not_checked_status_unknown, report.entries[0].determination);
+}
+
+test "strict mode requires status for intermediates as well as the leaf" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    try fx.add(.{ .subject = "leaf", .issuer = "Intermediate" });
+    try fx.add(.{ .subject = "Intermediate", .issuer = "Root", .ca = true });
+    try fx.add(.{ .subject = "Root", .issuer = "Root", .ca = true, .status_source = .none });
+    var storage: [4]path_builder.Element = undefined;
+    const path = fx.path(&storage);
+
+    const assertions = [_]revocation.StatusAssertion{stapled(.good)};
+    const outcome = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .strict },
+        .{ .assertions = &assertions },
+        validation_time,
+    );
+    try expectRejected(outcome, .status_unavailable, 1);
+
+    var intermediate = stapled(.good);
+    intermediate.certificate_index = 1;
+    intermediate.source = .cached_ocsp;
+    const both = [_]revocation.StatusAssertion{ stapled(.good), intermediate };
+    var accepted = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .strict },
+        .{ .assertions = &both },
+        validation_time,
+    );
+    var report = try expectAccepted(&accepted);
+    defer report.deinit(allocator);
+    try testing.expectEqual(@as(usize, 2), report.entries.len);
+    try testing.expect(report.allChecked());
+    try testing.expect(report.entryFor(1).?.determination == .checked_good);
+}
+
+test "evidence filed against the anchor or beyond the path is rejected" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
+
+    var anchor_evidence = stapled(.good);
+    anchor_evidence.certificate_index = 1; // the trust anchor
+    const assertions = [_]revocation.StatusAssertion{anchor_evidence};
+    const outcome = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .soft_fail },
+        .{ .assertions = &assertions },
+        validation_time,
+    );
+    try expectRejected(outcome, .evidence_index_invalid, 1);
+}
+
+test "evidence volume and size are bounded" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
+
+    var many: [5]revocation.StatusAssertion = undefined;
+    for (&many) |*assertion| assertion.* = stapled(.good);
+    const too_many = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .soft_fail, .limits = .{ .maximum_assertions = 4 } },
+        .{ .assertions = &many },
+        validation_time,
+    );
+    try expectRejected(too_many, .resource_limit_exceeded, null);
+
+    var oversized = stapled(.good);
+    oversized.raw = &[_]u8{0} ** 64;
+    const oversized_assertions = [_]revocation.StatusAssertion{oversized};
+    const too_large = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .soft_fail, .limits = .{ .maximum_evidence_bytes = 32 } },
+        .{ .assertions = &oversized_assertions },
+        validation_time,
+    );
+    try expectRejected(too_large, .resource_limit_exceeded, 0);
+}
+
+test "evidence lookup helper finds only stapled entries" {
+    const cached = revocation.StatusAssertion{
+        .certificate_index = 0,
+        .source = .cached_ocsp,
+        .status = .good,
+    };
+    const evidence = revocation.Evidence{ .assertions = &[_]revocation.StatusAssertion{ cached, stapled(.good) } };
+    try testing.expectEqual(revocation.Source.stapled_ocsp, evidence.stapledFor(0).?.source);
+    try testing.expectEqual(@as(?*const revocation.StatusAssertion, null), evidence.stapledFor(1));
+}
+
+test "TLS feature extension parses, bounds, and rejects malformed encodings" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+
+    try fx.add(.{
+        .subject = "leaf",
+        .issuer = "Root",
+        .tls_features = &.{ x509.TlsFeatures.status_request, x509.TlsFeatures.status_request_v2 },
+        .tls_features_critical = true,
+    });
+    const features = fx.certs.items[0].tlsFeatures().?;
+    try testing.expectEqual(@as(usize, 2), features.features.len);
+    try testing.expect(features.contains(x509.TlsFeatures.status_request_v2));
+    try testing.expect(features.requiresStapledStatus());
+    // The extension is now parsed, so a critical instance is handled.
+    try testing.expect(!fx.certs.items[0].hasUnhandledCriticalExtension());
+
+    // A feature the certificate does not assert does not require stapling.
+    try fx.add(.{ .subject = "other", .issuer = "Root", .tls_features = &.{22} });
+    try testing.expect(!fx.certs.items[1].mustStaple());
+
+    // Empty SEQUENCE, a negative value, and a value beyond the 16-bit TLS
+    // ExtensionType registry are all structural errors.
+    try testing.expectError(error.MalformedExtension, fx.add(.{
+        .subject = "empty",
+        .issuer = "Root",
+        .raw_tls_features = &.{ 0x30, 0x00 },
+    }));
+    try testing.expectError(error.MalformedExtension, fx.add(.{
+        .subject = "negative",
+        .issuer = "Root",
+        .raw_tls_features = &.{ 0x30, 0x03, 0x02, 0x01, 0xff },
+    }));
+    try testing.expectError(error.MalformedExtension, fx.add(.{
+        .subject = "oversized",
+        .issuer = "Root",
+        .raw_tls_features = &.{ 0x30, 0x05, 0x02, 0x03, 0x01, 0x00, 0x00 },
+    }));
+}
+
+test {
+    testing.refAllDecls(@This());
+}

--- a/src/pki/revocation_tests.zig
+++ b/src/pki/revocation_tests.zig
@@ -245,7 +245,6 @@ fn expectRejected(
 /// A fresh, authenticated stapled assertion bound to `certificate`.
 fn stapledFor(certificate: *const x509.Certificate, status: revocation.Status) revocation.StatusAssertion {
     return .{
-        .certificate_index = 0,
         .certificate = revocation.CertificateIdentity.of(certificate),
         .source = .stapled_ocsp,
         .status = status,
@@ -775,7 +774,6 @@ test "strict mode requires status for intermediates as well as the leaf" {
     try expectRejected(outcome, .status_unavailable, 1);
 
     var intermediate = stapledFor(&fx.certs.items[1], .good);
-    intermediate.certificate_index = 1;
     intermediate.source = .cached_ocsp;
     const both = [_]revocation.StatusAssertion{ stapledFor(&fx.certs.items[0], .good), intermediate };
     var accepted = revocation.evaluatePath(
@@ -792,24 +790,29 @@ test "strict mode requires status for intermediates as well as the leaf" {
     try testing.expect(report.entryFor(1).?.determination == .checked_good);
 }
 
-test "evidence filed against the anchor or beyond the path is rejected" {
+test "evidence for the trust anchor is ignored, not an error" {
+    // The anchor's status is trust configuration, so evidence about it has no
+    // certificate on the prospective path to apply to. It is skipped like any
+    // other non-matching identity — a shared evidence set legitimately carries
+    // assertions this candidate has no use for.
     const allocator = testing.allocator;
     var fx = Fixtures.init(allocator);
     defer fx.deinit();
     var storage: [4]path_builder.Element = undefined;
     const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
 
-    var anchor_evidence = stapledFor(&fx.certs.items[1], .good);
-    anchor_evidence.certificate_index = 1; // the trust anchor
-    const assertions = [_]revocation.StatusAssertion{anchor_evidence};
-    const outcome = revocation.evaluatePath(
+    const assertions = [_]revocation.StatusAssertion{stapledFor(&fx.certs.items[1], .good)};
+    var outcome = revocation.evaluatePath(
         allocator,
         path,
         .{ .mode = .soft_fail },
         .{ .assertions = &assertions },
         validation_time,
     );
-    try expectRejected(outcome, .evidence_index_invalid, 1);
+    var report = try expectAccepted(&outcome);
+    defer report.deinit(allocator);
+    try testing.expectEqual(@as(usize, 1), report.entries.len);
+    try testing.expectEqual(revocation.Determination.not_checked_no_evidence, report.entries[0].determination);
 }
 
 test "evidence volume and size are bounded" {
@@ -840,7 +843,8 @@ test "evidence volume and size are bounded" {
         .{ .assertions = &oversized_assertions },
         validation_time,
     );
-    try expectRejected(too_large, .resource_limit_exceeded, 0);
+    // A global bound has no per-path certificate to blame.
+    try expectRejected(too_large, .resource_limit_exceeded, null);
 }
 
 test "evidence lookup helper matches by certificate identity" {
@@ -914,13 +918,11 @@ test "disabled mode never rejects on evidence, however malformed" {
     var storage: [4]path_builder.Element = undefined;
     const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
 
-    var out_of_range = stapledFor(&fx.certs.items[0], .revoked);
-    out_of_range.certificate_index = 99;
     var oversized = stapledFor(&fx.certs.items[0], .good);
     oversized.raw = &[_]u8{0} ** 64;
     var foreign = stapledFor(&fx.certs.items[1], .revoked);
     foreign.defect = .malformed_encoding;
-    const assertions = [_]revocation.StatusAssertion{ out_of_range, oversized, foreign };
+    const assertions = [_]revocation.StatusAssertion{ oversized, foreign };
 
     var outcome = revocation.evaluatePath(
         allocator,
@@ -942,10 +944,8 @@ test "evidence bound to another certificate is never applied by position" {
     var storage: [4]path_builder.Element = undefined;
     const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
 
-    // A good status for a *different* certificate, filed at the leaf's index.
-    var foreign = stapledFor(&fx.certs.items[1], .good);
-    foreign.certificate_index = 0;
-    const good_assertions = [_]revocation.StatusAssertion{foreign};
+    // A good status for a *different* certificate cannot stand in for the leaf.
+    const good_assertions = [_]revocation.StatusAssertion{stapledFor(&fx.certs.items[1], .good)};
     const unusable = revocation.evaluatePath(
         allocator,
         path,
@@ -956,9 +956,7 @@ test "evidence bound to another certificate is never applied by position" {
     try expectRejected(unusable, .status_unavailable, 0);
 
     // The inverse: a foreign revocation cannot condemn this certificate.
-    var foreign_revoked = stapledFor(&fx.certs.items[1], .revoked);
-    foreign_revoked.certificate_index = 0;
-    const revoked_assertions = [_]revocation.StatusAssertion{foreign_revoked};
+    const revoked_assertions = [_]revocation.StatusAssertion{stapledFor(&fx.certs.items[1], .revoked)};
     var outcome = revocation.evaluatePath(
         allocator,
         path,
@@ -1104,7 +1102,6 @@ const StubProvider = struct {
         const assertions = try allocator.alloc(revocation.StatusAssertion, count);
         for (request.path.elements[0..count], 0..) |element, index| {
             assertions[index] = .{
-                .certificate_index = index,
                 .certificate = revocation.CertificateIdentity.of(element.certificate),
                 .source = .cached_ocsp,
                 .status = self.status,
@@ -1156,6 +1153,195 @@ test "collected evidence owns its assertions and survives concurrent collections
 
     // The first result is untouched by the second collection.
     try testing.expectEqual(revocation.Status.good, first.owned_assertions[0].status);
+}
+
+test "the same certificate consumes its own evidence at any depth" {
+    // Cross-signed and rollover chains put the same certificate at different
+    // depths in different candidates. Identity is the only key, so evidence
+    // for it applies wherever it appears.
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    try fx.add(.{ .subject = "leaf", .issuer = "Intermediate" });
+    try fx.add(.{ .subject = "Intermediate", .issuer = "Root", .ca = true });
+    try fx.add(.{ .subject = "Root", .issuer = "Root", .ca = true, .status_source = .none });
+
+    const leaf = &fx.certs.items[0];
+    const intermediate = &fx.certs.items[1];
+    const root = &fx.certs.items[2];
+
+    var intermediate_evidence = stapledFor(intermediate, .good);
+    intermediate_evidence.source = .cached_ocsp;
+    const assertions = [_]revocation.StatusAssertion{
+        stapledFor(leaf, .good),
+        intermediate_evidence,
+    };
+
+    // Depth 1: leaf -> intermediate -> root.
+    const deep = [_]path_builder.Element{
+        .{ .certificate = leaf, .source = .leaf, .input_index = 0 },
+        .{ .certificate = intermediate, .source = .intermediate, .input_index = 0 },
+        .{ .certificate = root, .source = .anchor, .input_index = 0 },
+    };
+    var deep_outcome = revocation.evaluatePath(
+        allocator,
+        .{ .elements = &deep },
+        .{ .mode = .strict },
+        .{ .assertions = &assertions },
+        validation_time,
+    );
+    var deep_report = try expectAccepted(&deep_outcome);
+    defer deep_report.deinit(allocator);
+    try testing.expect(deep_report.allChecked());
+
+    // Depth 0: the same intermediate certificate now sits at the leaf index.
+    // Its evidence must still apply.
+    const shallow = [_]path_builder.Element{
+        .{ .certificate = intermediate, .source = .leaf, .input_index = 0 },
+        .{ .certificate = root, .source = .anchor, .input_index = 0 },
+    };
+    var shallow_outcome = revocation.evaluatePath(
+        allocator,
+        .{ .elements = &shallow },
+        .{ .mode = .strict },
+        .{ .assertions = &assertions },
+        validation_time,
+    );
+    var shallow_report = try expectAccepted(&shallow_outcome);
+    defer shallow_report.deinit(allocator);
+    try testing.expectEqual(revocation.Determination.checked_good, shallow_report.entries[0].determination);
+    try testing.expectEqual(revocation.Source.cached_ocsp, shallow_report.entries[0].source.?);
+}
+
+test "a longer candidate's evidence cannot invalidate a shorter candidate" {
+    // A shared evidence set legitimately covers certificates that are not on
+    // this candidate. Those extra assertions must be skipped, never treated as
+    // a reason to reject the candidate that does have complete evidence.
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    try fx.add(.{ .subject = "leaf", .issuer = "Intermediate" });
+    try fx.add(.{ .subject = "A1", .issuer = "A2", .ca = true });
+    try fx.add(.{ .subject = "A2", .issuer = "Root", .ca = true });
+    try fx.add(.{ .subject = "B1", .issuer = "Root", .ca = true });
+    try fx.add(.{ .subject = "Root", .issuer = "Root", .ca = true, .status_source = .none });
+
+    var a1 = stapledFor(&fx.certs.items[1], .good);
+    a1.source = .cached_ocsp;
+    var a2 = stapledFor(&fx.certs.items[2], .good);
+    a2.source = .cached_ocsp;
+    var b1 = stapledFor(&fx.certs.items[3], .good);
+    b1.source = .cached_ocsp;
+    const union_evidence = [_]revocation.StatusAssertion{
+        stapledFor(&fx.certs.items[0], .good),
+        a1,
+        a2,
+        b1,
+    };
+
+    // Candidate B is two certificates shorter; A2's assertion has no place in
+    // it and must simply be ignored.
+    const candidate_b = [_]path_builder.Element{
+        .{ .certificate = &fx.certs.items[0], .source = .leaf, .input_index = 0 },
+        .{ .certificate = &fx.certs.items[3], .source = .intermediate, .input_index = 1 },
+        .{ .certificate = &fx.certs.items[4], .source = .anchor, .input_index = 0 },
+    };
+    var outcome = revocation.evaluatePath(
+        allocator,
+        .{ .elements = &candidate_b },
+        .{ .mode = .strict },
+        .{ .assertions = &union_evidence },
+        validation_time,
+    );
+    var report = try expectAccepted(&outcome);
+    defer report.deinit(allocator);
+    try testing.expect(report.allChecked());
+    try testing.expectEqual(@as(usize, 2), report.entries.len);
+}
+
+test "status_request_v2 cannot be satisfied by ordinary TLS 1.3 stapling" {
+    // RFC 8446 §4.4.2.1 obsoletes RFC 6961 and forbids a TLS 1.3 server from
+    // acting on status_request_v2, so a v1 staple cannot prove a feature-17
+    // declaration was honored.
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var v2_storage: [4]path_builder.Element = undefined;
+    const v2_path = try twoCertPath(&fx, &v2_storage, .{
+        .subject = "leaf",
+        .issuer = "Root",
+        .tls_features = &.{x509.TlsFeatures.status_request_v2},
+    });
+
+    // Feature 17 alone is not must-staple, but it is also not satisfiable.
+    try testing.expect(!fx.certs.items[0].mustStaple());
+    try testing.expect(fx.certs.items[0].assertsStatusRequestV2());
+
+    const assertions = [_]revocation.StatusAssertion{stapledFor(&fx.certs.items[0], .good)};
+    const rejected = revocation.evaluatePath(
+        allocator,
+        v2_path,
+        .{ .mode = .soft_fail },
+        .{ .assertions = &assertions },
+        validation_time,
+    );
+    try expectRejected(rejected, .must_staple_feature_unsupported, 0);
+
+    // Disabled records it rather than rejecting, like every other unenforced
+    // must-staple state.
+    var disabled = revocation.evaluatePath(
+        allocator,
+        v2_path,
+        .{},
+        .{ .assertions = &assertions },
+        validation_time,
+    );
+    var disabled_report = try expectAccepted(&disabled);
+    defer disabled_report.deinit(allocator);
+    try testing.expectEqual(
+        revocation.MustStapleOutcome.unsatisfiable_status_request_v2,
+        disabled_report.must_staple,
+    );
+
+    // Declaring both 5 and 17 does not make 17 satisfiable either.
+    var both_fx = Fixtures.init(allocator);
+    defer both_fx.deinit();
+    var both_storage: [4]path_builder.Element = undefined;
+    const both_path = try twoCertPath(&both_fx, &both_storage, .{
+        .subject = "leaf",
+        .issuer = "Root",
+        .tls_features = &.{ x509.TlsFeatures.status_request, x509.TlsFeatures.status_request_v2 },
+    });
+    const both_assertions = [_]revocation.StatusAssertion{stapledFor(&both_fx.certs.items[0], .good)};
+    const both_rejected = revocation.evaluatePath(
+        allocator,
+        both_path,
+        .{ .mode = .soft_fail },
+        .{ .assertions = &both_assertions },
+        validation_time,
+    );
+    try expectRejected(both_rejected, .must_staple_feature_unsupported, 0);
+
+    // Ordinary feature-5 must-staple is still satisfied by a TLS 1.3 staple.
+    var v1_fx = Fixtures.init(allocator);
+    defer v1_fx.deinit();
+    var v1_storage: [4]path_builder.Element = undefined;
+    const v1_path = try twoCertPath(&v1_fx, &v1_storage, .{
+        .subject = "leaf",
+        .issuer = "Root",
+        .tls_features = &.{x509.TlsFeatures.status_request},
+    });
+    const v1_assertions = [_]revocation.StatusAssertion{stapledFor(&v1_fx.certs.items[0], .good)};
+    var accepted = revocation.evaluatePath(
+        allocator,
+        v1_path,
+        .{ .mode = .soft_fail },
+        .{ .assertions = &v1_assertions },
+        validation_time,
+    );
+    var report = try expectAccepted(&accepted);
+    defer report.deinit(allocator);
+    try testing.expectEqual(revocation.MustStapleOutcome.enforced, report.must_staple);
 }
 
 test {

--- a/src/pki/revocation_tests.zig
+++ b/src/pki/revocation_tests.zig
@@ -242,9 +242,11 @@ fn expectRejected(
     }
 }
 
-fn stapled(status: revocation.Status) revocation.StatusAssertion {
+/// A fresh, authenticated stapled assertion bound to `certificate`.
+fn stapledFor(certificate: *const x509.Certificate, status: revocation.Status) revocation.StatusAssertion {
     return .{
         .certificate_index = 0,
+        .certificate = revocation.CertificateIdentity.of(certificate),
         .source = .stapled_ocsp,
         .status = status,
         .signature_verified = true,
@@ -269,7 +271,7 @@ test "disabled policy records that nothing was checked" {
     try testing.expectEqual(@as(usize, 1), report.entries.len);
     try testing.expectEqual(revocation.Determination.not_checked_policy_disabled, report.entries[0].determination);
     try testing.expect(!report.allChecked());
-    try testing.expect(!report.must_staple_unenforced);
+    try testing.expectEqual(revocation.MustStapleOutcome.not_required, report.must_staple);
 }
 
 test "stapled good status is recorded as a completed check" {
@@ -279,7 +281,7 @@ test "stapled good status is recorded as a completed check" {
     var storage: [4]path_builder.Element = undefined;
     const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
 
-    const assertions = [_]revocation.StatusAssertion{stapled(.good)};
+    const assertions = [_]revocation.StatusAssertion{stapledFor(&fx.certs.items[0], .good)};
     for ([_]revocation.Mode{ .stapled_only, .soft_fail, .strict }) |mode| {
         var outcome = revocation.evaluatePath(
             allocator,
@@ -303,7 +305,7 @@ test "stapled revoked status rejects in every consulting mode" {
     var storage: [4]path_builder.Element = undefined;
     const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
 
-    var assertion = stapled(.revoked);
+    var assertion = stapledFor(&fx.certs.items[0], .revoked);
     assertion.revocation_reason = .key_compromise;
     assertion.revoked_at = validation_time - 86_400;
     const assertions = [_]revocation.StatusAssertion{assertion};
@@ -331,9 +333,9 @@ test "revoked evidence wins over a good answer from another source" {
     var storage: [4]path_builder.Element = undefined;
     const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
 
-    var crl_revoked = stapled(.revoked);
+    var crl_revoked = stapledFor(&fx.certs.items[0], .revoked);
     crl_revoked.source = .crl_set;
-    const assertions = [_]revocation.StatusAssertion{ stapled(.good), crl_revoked };
+    const assertions = [_]revocation.StatusAssertion{ stapledFor(&fx.certs.items[0], .good), crl_revoked };
 
     const outcome = revocation.evaluatePath(
         allocator,
@@ -352,9 +354,9 @@ test "revoked evidence is honored even when unauthenticated or stale" {
     var storage: [4]path_builder.Element = undefined;
     const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
 
-    var unauthenticated = stapled(.revoked);
+    var unauthenticated = stapledFor(&fx.certs.items[0], .revoked);
     unauthenticated.signature_verified = false;
-    var stale = stapled(.revoked);
+    var stale = stapledFor(&fx.certs.items[0], .revoked);
     stale.next_update = validation_time - 86_400;
 
     for ([_]revocation.StatusAssertion{ unauthenticated, stale }) |assertion| {
@@ -396,7 +398,7 @@ test "stale stapled evidence is rejected where stapling is consulted" {
     var storage: [4]path_builder.Element = undefined;
     const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
 
-    var stale = stapled(.good);
+    var stale = stapledFor(&fx.certs.items[0], .good);
     stale.this_update = validation_time - 30 * 86_400;
     stale.next_update = validation_time - 29 * 86_400;
     const assertions = [_]revocation.StatusAssertion{stale};
@@ -432,7 +434,7 @@ test "malformed stapled evidence is rejected where stapling is consulted" {
     var storage: [4]path_builder.Element = undefined;
     const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
 
-    var malformed = stapled(.good);
+    var malformed = stapledFor(&fx.certs.items[0], .good);
     malformed.defect = .malformed_encoding;
     const assertions = [_]revocation.StatusAssertion{malformed};
 
@@ -470,7 +472,7 @@ test "unauthenticated evidence never counts as a completed check" {
     var storage: [4]path_builder.Element = undefined;
     const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
 
-    var unverified = stapled(.good);
+    var unverified = stapledFor(&fx.certs.items[0], .good);
     unverified.signature_verified = false;
     const assertions = [_]revocation.StatusAssertion{unverified};
 
@@ -519,7 +521,7 @@ test "must-staple requires stapled good status once a mode consults status" {
     try expectRejected(missing, .must_staple_not_satisfied, 0);
 
     // A cached answer is not a staple.
-    var cached = stapled(.good);
+    var cached = stapledFor(&fx.certs.items[0], .good);
     cached.source = .cached_ocsp;
     const cached_assertions = [_]revocation.StatusAssertion{cached};
     const wrong_source = revocation.evaluatePath(
@@ -532,7 +534,7 @@ test "must-staple requires stapled good status once a mode consults status" {
     try expectRejected(wrong_source, .must_staple_not_satisfied, 0);
 
     // A good staple satisfies it.
-    const good_assertions = [_]revocation.StatusAssertion{stapled(.good)};
+    const good_assertions = [_]revocation.StatusAssertion{stapledFor(&fx.certs.items[0], .good)};
     var outcome = revocation.evaluatePath(
         allocator,
         path,
@@ -543,7 +545,7 @@ test "must-staple requires stapled good status once a mode consults status" {
     var report = try expectAccepted(&outcome);
     defer report.deinit(allocator);
     try testing.expect(report.entries[0].must_staple);
-    try testing.expect(!report.must_staple_unenforced);
+    try testing.expectEqual(revocation.MustStapleOutcome.enforced, report.must_staple);
 }
 
 test "must-staple is explicitly unenforced, not silently satisfied, when disabled" {
@@ -560,7 +562,7 @@ test "must-staple is explicitly unenforced, not silently satisfied, when disable
     var outcome = revocation.evaluatePath(allocator, path, .{}, .{}, validation_time);
     var report = try expectAccepted(&outcome);
     defer report.deinit(allocator);
-    try testing.expect(report.must_staple_unenforced);
+    try testing.expectEqual(revocation.MustStapleOutcome.unenforced_status_disabled, report.must_staple);
     try testing.expect(report.entries[0].must_staple);
 }
 
@@ -585,9 +587,16 @@ test "must-staple enforcement can be disabled explicitly" {
     var report = try expectAccepted(&outcome);
     defer report.deinit(allocator);
     try testing.expectEqual(revocation.Determination.not_checked_no_evidence, report.entries[0].determination);
+    // The report must say the assertion went unenforced, not imply it held.
+    try testing.expectEqual(revocation.MustStapleOutcome.unenforced_by_configuration, report.must_staple);
 }
 
-test "an issuing CA can assert must-staple for the certificates below it" {
+test "the CA form of the TLS Feature extension is not a leaf stapling obligation" {
+    // RFC 7633 §4.2.2 makes an issuer's feature set a constraint on what its
+    // children must *contain* — enforced in `path_validator` — not an
+    // assertion that turns a featureless leaf into a must-staple certificate.
+    // A path that satisfies that constraint reaches here with the obligation
+    // read from the end-entity certificate alone.
     const allocator = testing.allocator;
     var fx = Fixtures.init(allocator);
     defer fx.deinit();
@@ -602,14 +611,18 @@ test "an issuing CA can assert must-staple for the certificates below it" {
     var storage: [4]path_builder.Element = undefined;
     const path = fx.path(&storage);
 
-    const outcome = revocation.evaluatePath(
+    var outcome = revocation.evaluatePath(
         allocator,
         path,
         .{ .mode = .soft_fail },
         .{},
         validation_time,
     );
-    try expectRejected(outcome, .must_staple_not_satisfied, 0);
+    var report = try expectAccepted(&outcome);
+    defer report.deinit(allocator);
+    try testing.expectEqual(revocation.MustStapleOutcome.not_required, report.must_staple);
+    try testing.expect(!report.entries[0].must_staple);
+    try testing.expect(report.entries[1].must_staple);
 }
 
 test "a certificate publishing no status source is unsupported under strict" {
@@ -657,9 +670,9 @@ test "stapled-only mode ignores cached and CRL evidence" {
     var storage: [4]path_builder.Element = undefined;
     const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
 
-    var cached = stapled(.good);
+    var cached = stapledFor(&fx.certs.items[0], .good);
     cached.source = .cached_ocsp;
-    var crl_stale = stapled(.good);
+    var crl_stale = stapledFor(&fx.certs.items[0], .good);
     crl_stale.source = .crl_set;
     crl_stale.next_update = validation_time - 86_400;
     const assertions = [_]revocation.StatusAssertion{ cached, crl_stale };
@@ -696,9 +709,9 @@ test "stapled evidence outranks a cached answer for the same certificate" {
     var storage: [4]path_builder.Element = undefined;
     const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
 
-    var cached_unknown = stapled(.unknown);
+    var cached_unknown = stapledFor(&fx.certs.items[0], .unknown);
     cached_unknown.source = .cached_ocsp;
-    const assertions = [_]revocation.StatusAssertion{ cached_unknown, stapled(.good) };
+    const assertions = [_]revocation.StatusAssertion{ cached_unknown, stapledFor(&fx.certs.items[0], .good) };
 
     var outcome = revocation.evaluatePath(
         allocator,
@@ -719,7 +732,7 @@ test "an unknown status is not a completed check under strict" {
     var storage: [4]path_builder.Element = undefined;
     const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
 
-    const assertions = [_]revocation.StatusAssertion{stapled(.unknown)};
+    const assertions = [_]revocation.StatusAssertion{stapledFor(&fx.certs.items[0], .unknown)};
     const outcome = revocation.evaluatePath(
         allocator,
         path,
@@ -751,7 +764,7 @@ test "strict mode requires status for intermediates as well as the leaf" {
     var storage: [4]path_builder.Element = undefined;
     const path = fx.path(&storage);
 
-    const assertions = [_]revocation.StatusAssertion{stapled(.good)};
+    const assertions = [_]revocation.StatusAssertion{stapledFor(&fx.certs.items[0], .good)};
     const outcome = revocation.evaluatePath(
         allocator,
         path,
@@ -761,10 +774,10 @@ test "strict mode requires status for intermediates as well as the leaf" {
     );
     try expectRejected(outcome, .status_unavailable, 1);
 
-    var intermediate = stapled(.good);
+    var intermediate = stapledFor(&fx.certs.items[1], .good);
     intermediate.certificate_index = 1;
     intermediate.source = .cached_ocsp;
-    const both = [_]revocation.StatusAssertion{ stapled(.good), intermediate };
+    const both = [_]revocation.StatusAssertion{ stapledFor(&fx.certs.items[0], .good), intermediate };
     var accepted = revocation.evaluatePath(
         allocator,
         path,
@@ -786,7 +799,7 @@ test "evidence filed against the anchor or beyond the path is rejected" {
     var storage: [4]path_builder.Element = undefined;
     const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
 
-    var anchor_evidence = stapled(.good);
+    var anchor_evidence = stapledFor(&fx.certs.items[1], .good);
     anchor_evidence.certificate_index = 1; // the trust anchor
     const assertions = [_]revocation.StatusAssertion{anchor_evidence};
     const outcome = revocation.evaluatePath(
@@ -807,7 +820,7 @@ test "evidence volume and size are bounded" {
     const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
 
     var many: [5]revocation.StatusAssertion = undefined;
-    for (&many) |*assertion| assertion.* = stapled(.good);
+    for (&many) |*assertion| assertion.* = stapledFor(&fx.certs.items[0], .good);
     const too_many = revocation.evaluatePath(
         allocator,
         path,
@@ -817,7 +830,7 @@ test "evidence volume and size are bounded" {
     );
     try expectRejected(too_many, .resource_limit_exceeded, null);
 
-    var oversized = stapled(.good);
+    var oversized = stapledFor(&fx.certs.items[0], .good);
     oversized.raw = &[_]u8{0} ** 64;
     const oversized_assertions = [_]revocation.StatusAssertion{oversized};
     const too_large = revocation.evaluatePath(
@@ -830,15 +843,24 @@ test "evidence volume and size are bounded" {
     try expectRejected(too_large, .resource_limit_exceeded, 0);
 }
 
-test "evidence lookup helper finds only stapled entries" {
-    const cached = revocation.StatusAssertion{
-        .certificate_index = 0,
-        .source = .cached_ocsp,
-        .status = .good,
+test "evidence lookup helper matches by certificate identity" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    _ = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
+
+    var cached = stapledFor(&fx.certs.items[0], .good);
+    cached.source = .cached_ocsp;
+    const evidence = revocation.Evidence{
+        .assertions = &[_]revocation.StatusAssertion{ cached, stapledFor(&fx.certs.items[0], .good) },
     };
-    const evidence = revocation.Evidence{ .assertions = &[_]revocation.StatusAssertion{ cached, stapled(.good) } };
-    try testing.expectEqual(revocation.Source.stapled_ocsp, evidence.stapledFor(0).?.source);
-    try testing.expectEqual(@as(?*const revocation.StatusAssertion, null), evidence.stapledFor(1));
+    try testing.expectEqual(revocation.Source.stapled_ocsp, evidence.stapledFor(&fx.certs.items[0]).?.source);
+    // The anchor has no evidence, and position cannot manufacture any.
+    try testing.expectEqual(
+        @as(?*const revocation.StatusAssertion, null),
+        evidence.stapledFor(&fx.certs.items[1]),
+    );
 }
 
 test "TLS feature extension parses, bounds, and rejects malformed encodings" {
@@ -880,6 +902,260 @@ test "TLS feature extension parses, bounds, and rejects malformed encodings" {
         .issuer = "Root",
         .raw_tls_features = &.{ 0x30, 0x05, 0x02, 0x03, 0x01, 0x00, 0x00 },
     }));
+}
+
+test "disabled mode never rejects on evidence, however malformed" {
+    // Revocation being off must not become a way to fail a handshake: a peer
+    // that attaches oversized or misfiled status data cannot turn the default
+    // policy into fail-closed behavior.
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
+
+    var out_of_range = stapledFor(&fx.certs.items[0], .revoked);
+    out_of_range.certificate_index = 99;
+    var oversized = stapledFor(&fx.certs.items[0], .good);
+    oversized.raw = &[_]u8{0} ** 64;
+    var foreign = stapledFor(&fx.certs.items[1], .revoked);
+    foreign.defect = .malformed_encoding;
+    const assertions = [_]revocation.StatusAssertion{ out_of_range, oversized, foreign };
+
+    var outcome = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .limits = .{ .maximum_assertions = 1, .maximum_evidence_bytes = 8 } },
+        .{ .assertions = &assertions },
+        validation_time,
+    );
+    var report = try expectAccepted(&outcome);
+    defer report.deinit(allocator);
+    try testing.expectEqual(revocation.Mode.disabled, report.mode);
+    try testing.expectEqual(revocation.Determination.not_checked_policy_disabled, report.entries[0].determination);
+}
+
+test "evidence bound to another certificate is never applied by position" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
+
+    // A good status for a *different* certificate, filed at the leaf's index.
+    var foreign = stapledFor(&fx.certs.items[1], .good);
+    foreign.certificate_index = 0;
+    const good_assertions = [_]revocation.StatusAssertion{foreign};
+    const unusable = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .strict },
+        .{ .assertions = &good_assertions },
+        validation_time,
+    );
+    try expectRejected(unusable, .status_unavailable, 0);
+
+    // The inverse: a foreign revocation cannot condemn this certificate.
+    var foreign_revoked = stapledFor(&fx.certs.items[1], .revoked);
+    foreign_revoked.certificate_index = 0;
+    const revoked_assertions = [_]revocation.StatusAssertion{foreign_revoked};
+    var outcome = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .soft_fail },
+        .{ .assertions = &revoked_assertions },
+        validation_time,
+    );
+    var report = try expectAccepted(&outcome);
+    defer report.deinit(allocator);
+    try testing.expectEqual(revocation.Determination.not_checked_no_evidence, report.entries[0].determination);
+}
+
+test "unauthenticated revocation is trusted only from the peer's own staple" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
+
+    // A forged responder or CRL answer must not be able to deny service.
+    for ([_]revocation.Source{ .cached_ocsp, .crl_set }) |source| {
+        var forged = stapledFor(&fx.certs.items[0], .revoked);
+        forged.source = source;
+        forged.signature_verified = false;
+        const assertions = [_]revocation.StatusAssertion{forged};
+
+        var outcome = revocation.evaluatePath(
+            allocator,
+            path,
+            .{ .mode = .soft_fail },
+            .{ .assertions = &assertions },
+            validation_time,
+        );
+        var report = try expectAccepted(&outcome);
+        defer report.deinit(allocator);
+        try testing.expectEqual(
+            revocation.Determination.not_checked_unauthenticated_evidence,
+            report.entries[0].determination,
+        );
+
+        const strict = revocation.evaluatePath(
+            allocator,
+            path,
+            .{ .mode = .strict },
+            .{ .assertions = &assertions },
+            validation_time,
+        );
+        try expectRejected(strict, .status_unauthenticated, 0);
+    }
+
+    // The peer's own staple keeps the exception: it can only condemn itself.
+    var self_revoked = stapledFor(&fx.certs.items[0], .revoked);
+    self_revoked.signature_verified = false;
+    const stapled_assertions = [_]revocation.StatusAssertion{self_revoked};
+    const outcome = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .soft_fail },
+        .{ .assertions = &stapled_assertions },
+        validation_time,
+    );
+    try expectRejected(outcome, .certificate_revoked, 0);
+}
+
+test "a stale certificate hold does not outlive its release" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
+
+    // RFC 5280 §5.3.1 lets certificateHold be released, so a stale hold must
+    // not override fresher evidence the way a stale permanent revocation does.
+    var stale_hold = stapledFor(&fx.certs.items[0], .revoked);
+    stale_hold.source = .crl_set;
+    stale_hold.revocation_reason = .certificate_hold;
+    stale_hold.this_update = validation_time - 30 * 86_400;
+    stale_hold.next_update = validation_time - 29 * 86_400;
+
+    const released = [_]revocation.StatusAssertion{ stale_hold, stapledFor(&fx.certs.items[0], .good) };
+    var outcome = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .strict },
+        .{ .assertions = &released },
+        validation_time,
+    );
+    var report = try expectAccepted(&outcome);
+    defer report.deinit(allocator);
+    try testing.expectEqual(revocation.Determination.checked_good, report.entries[0].determination);
+
+    // On its own the stale hold is simply unusable, not a revocation.
+    const alone = [_]revocation.StatusAssertion{stale_hold};
+    const stale = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .strict },
+        .{ .assertions = &alone },
+        validation_time,
+    );
+    try expectRejected(stale, .status_stale, 0);
+
+    // A *fresh* hold still revokes, and a stale permanent revocation still
+    // stands: only the releasable reason is exempt.
+    var fresh_hold = stapledFor(&fx.certs.items[0], .revoked);
+    fresh_hold.revocation_reason = .certificate_hold;
+    var stale_permanent = stapledFor(&fx.certs.items[0], .revoked);
+    stale_permanent.revocation_reason = .key_compromise;
+    stale_permanent.this_update = validation_time - 30 * 86_400;
+    stale_permanent.next_update = validation_time - 29 * 86_400;
+    for ([_]revocation.StatusAssertion{ fresh_hold, stale_permanent }) |assertion| {
+        const assertions = [_]revocation.StatusAssertion{assertion};
+        const rejected = revocation.evaluatePath(
+            allocator,
+            path,
+            .{ .mode = .soft_fail },
+            .{ .assertions = &assertions },
+            validation_time,
+        );
+        try expectRejected(rejected, .certificate_revoked, 0);
+    }
+}
+
+/// A minimal provider that composes one per-call assertion array, which is the
+/// shape a real fetch/cache provider needs and the reason `collect` returns
+/// owned storage.
+const StubProvider = struct {
+    status: revocation.Status,
+
+    fn provider(self: *const StubProvider) revocation.Provider {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    const vtable = revocation.Provider.VTable{ .collect = collect };
+
+    fn collect(
+        context: *const anyopaque,
+        allocator: std.mem.Allocator,
+        request: revocation.Provider.Request,
+    ) error{OutOfMemory}!revocation.CollectedEvidence {
+        const self: *const StubProvider = @ptrCast(@alignCast(context));
+        const count = request.path.elements.len - 1;
+        const assertions = try allocator.alloc(revocation.StatusAssertion, count);
+        for (request.path.elements[0..count], 0..) |element, index| {
+            assertions[index] = .{
+                .certificate_index = index,
+                .certificate = revocation.CertificateIdentity.of(element.certificate),
+                .source = .cached_ocsp,
+                .status = self.status,
+                .signature_verified = true,
+                .this_update = request.validation_time - 60,
+                .next_update = request.validation_time + 3600,
+            };
+        }
+        return .{ .owned_assertions = assertions };
+    }
+};
+
+test "collected evidence owns its assertions and survives concurrent collections" {
+    const allocator = testing.allocator;
+    var fx = Fixtures.init(allocator);
+    defer fx.deinit();
+    var storage: [4]path_builder.Element = undefined;
+    const path = try twoCertPath(&fx, &storage, .{ .subject = "leaf", .issuer = "Root" });
+
+    const good_stub = StubProvider{ .status = .good };
+    const revoked_stub = StubProvider{ .status = .revoked };
+    const request = revocation.Provider.Request{ .path = path, .validation_time = validation_time };
+
+    // Two results live at once: neither may alias or free the other's storage.
+    var first = try good_stub.provider().collect(allocator, request);
+    defer first.deinit(allocator);
+    var second = try revoked_stub.provider().collect(allocator, request);
+    defer second.deinit(allocator);
+
+    var accepted = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .strict },
+        first.evidence(),
+        validation_time,
+    );
+    var report = try expectAccepted(&accepted);
+    defer report.deinit(allocator);
+    try testing.expect(report.allChecked());
+
+    const rejected = revocation.evaluatePath(
+        allocator,
+        path,
+        .{ .mode = .strict },
+        second.evidence(),
+        validation_time,
+    );
+    try expectRejected(rejected, .certificate_revoked, 0);
+
+    // The first result is untouched by the second collection.
+    try testing.expectEqual(revocation.Status.good, first.owned_assertions[0].status);
 }
 
 test {

--- a/src/pki/root.zig
+++ b/src/pki/root.zig
@@ -17,6 +17,7 @@
 //! - `path_validator` — deterministic RFC 5280 candidate-path validation
 //! - `name_constraints` — bounded RFC 5280 permitted/excluded subtree state
 //! - `certificate_policy` — bounded RFC 9618 certificate-policy graph
+//! - `revocation` — certificate-status policy seam (CRL/OCSP/stapling)
 //! - `trust_store` — provider-neutral trust-anchor snapshots and bundle loader
 //!
 //! ## Policy summary
@@ -44,6 +45,7 @@ pub const verify = @import("verify.zig");
 pub const path_builder = @import("path_builder.zig");
 pub const name_constraints = @import("name_constraints.zig");
 pub const certificate_policy = @import("certificate_policy.zig");
+pub const revocation = @import("revocation.zig");
 pub const path_validator = @import("path_validator.zig");
 pub const trust_store = @import("trust_store.zig");
 
@@ -56,5 +58,6 @@ test {
     _ = @import("verify_tests.zig");
     _ = @import("path_builder_tests.zig");
     _ = @import("path_validator_tests.zig");
+    _ = @import("revocation_tests.zig");
     _ = @import("trust_store_tests.zig");
 }

--- a/src/pki/x509.zig
+++ b/src/pki/x509.zig
@@ -371,17 +371,21 @@ pub const TlsFeatures = struct {
     /// RFC 7633 §4.2.1: asserting `status_request` obliges the server to
     /// deliver a stapled certificate-status response.
     ///
-    /// Feature 17 is deliberately *not* included. RFC 6961 `status_request_v2`
-    /// is obsoleted by RFC 8446 §4.4.2.1, which forbids a TLS 1.3 server from
-    /// acting on or sending it, so an ordinary TLS 1.3 staple cannot prove that
-    /// a feature-17 declaration was honored. This stack is TLS 1.3 only; see
-    /// `assertsStatusRequestV2`.
+    /// Feature 17 is deliberately *not* included. RFC 6961
+    /// `status_request_v2` is obsoleted for TLS 1.3 by RFC 8446 §4.4.2.1, and
+    /// RFC 7633 §§4.1/4.3.3 scope a certificate's demand to features present in
+    /// *both* the ClientHello and the certificate. A TLS 1.3 client does not
+    /// offer 17, so a certificate advertising it — typically for TLS 1.2 peers
+    /// — creates no obligation here and must not be rejected over it. See
+    /// `assertsStatusRequestV2` for the declaration itself.
     pub fn requiresStapledStatus(self: *const TlsFeatures) bool {
         return self.contains(status_request);
     }
 
-    /// True when the certificate declares RFC 6961 `status_request_v2`, a
-    /// mechanism this TLS 1.3-only stack cannot negotiate or satisfy.
+    /// True when the certificate declares RFC 6961 `status_request_v2`. Kept
+    /// separate from `requiresStapledStatus` for a future implementation that
+    /// carries the negotiated ClientHello feature set into policy and enforces
+    /// the RFC 7633 §4.3.3 intersection.
     pub fn assertsStatusRequestV2(self: *const TlsFeatures) bool {
         return self.contains(status_request_v2);
     }
@@ -603,8 +607,9 @@ pub const Certificate = struct {
         return features.requiresStapledStatus();
     }
 
-    /// The certificate declares RFC 6961 `status_request_v2`, which RFC 8446
-    /// §4.4.2.1 forbids a TLS 1.3 server from acting on.
+    /// The certificate declares RFC 6961 `status_request_v2`. This TLS 1.3
+    /// profile never offers that extension, so the declaration creates no
+    /// stapling obligation on its own (RFC 7633 §4.3.3).
     pub fn assertsStatusRequestV2(self: *const Certificate) bool {
         const features = self.tlsFeatures() orelse return false;
         return features.assertsStatusRequestV2();

--- a/src/pki/x509.zig
+++ b/src/pki/x509.zig
@@ -53,6 +53,7 @@ pub const Limits = struct {
     max_policy_mappings: usize = 64,
     max_distribution_points: usize = 16,
     max_access_descriptions: usize = 16,
+    max_tls_features: usize = 16,
     max_name_constraint_subtrees: usize = 64,
 };
 
@@ -352,6 +353,28 @@ pub const DistributionPoint = struct {
     full_names: []const GeneralName,
 };
 
+/// RFC 7633 TLS Feature extension. Values are TLS ExtensionType numbers the
+/// certificate asserts the server will negotiate; `status_request` (5) is the
+/// must-staple assertion.
+pub const TlsFeatures = struct {
+    /// TLS ExtensionType registry value for `status_request` (RFC 6066 §8).
+    pub const status_request: u16 = 5;
+    /// TLS ExtensionType registry value for `status_request_v2` (RFC 6961).
+    pub const status_request_v2: u16 = 17;
+
+    features: []const u16,
+
+    pub fn contains(self: *const TlsFeatures, feature: u16) bool {
+        return std.mem.indexOfScalar(u16, self.features, feature) != null;
+    }
+
+    /// RFC 7633 §4.2.1: asserting `status_request` obliges the server to
+    /// deliver a stapled certificate-status response.
+    pub fn requiresStapledStatus(self: *const TlsFeatures) bool {
+        return self.contains(status_request) or self.contains(status_request_v2);
+    }
+};
+
 pub const PolicyQualifier = struct {
     pub const Kind = enum { cps_pointer, user_notice, unsupported };
 
@@ -400,6 +423,7 @@ pub const Extension = struct {
         policy_mappings: []const PolicyMapping,
         policy_constraints: PolicyConstraints,
         inhibit_any_policy: usize,
+        tls_features: TlsFeatures,
         unrecognized: void,
     };
 };
@@ -530,6 +554,41 @@ pub const Certificate = struct {
     pub fn inhibitAnyPolicy(self: *const Certificate) ?usize {
         const extension = self.findExtension(&wk.inhibit_any_policy) orelse return null;
         return extension.parsed.inhibit_any_policy;
+    }
+
+    /// Certificate-status evidence sources published by the certificate. These
+    /// are surfaced for revocation policy and future fetch providers; nothing
+    /// in this package dereferences a location.
+    pub fn authorityInfoAccess(self: *const Certificate) ?[]const AccessDescription {
+        const extension = self.findExtension(&wk.authority_info_access) orelse return null;
+        return extension.parsed.authority_info_access;
+    }
+
+    pub fn crlDistributionPoints(self: *const Certificate) ?[]const DistributionPoint {
+        const extension = self.findExtension(&wk.crl_distribution_points) orelse return null;
+        return extension.parsed.crl_distribution_points;
+    }
+
+    /// True when the certificate names at least one OCSP responder in its
+    /// Authority Information Access extension.
+    pub fn hasOcspResponder(self: *const Certificate) bool {
+        const descriptions = self.authorityInfoAccess() orelse return false;
+        for (descriptions) |description| {
+            if (description.method.eqlComponents(&wk.aia_ocsp)) return true;
+        }
+        return false;
+    }
+
+    pub fn tlsFeatures(self: *const Certificate) ?TlsFeatures {
+        const extension = self.findExtension(&wk.tls_feature) orelse return null;
+        return extension.parsed.tls_features;
+    }
+
+    /// RFC 7633 must-staple: the certificate asserts that its server always
+    /// delivers a stapled certificate-status response.
+    pub fn mustStaple(self: *const Certificate) bool {
+        const features = self.tlsFeatures() orelse return false;
+        return features.requiresStapledStatus();
     }
 };
 
@@ -899,6 +958,8 @@ const Parser = struct {
             return .{ .policy_constraints = try self.parsePolicyConstraints(value) };
         } else if (ext_oid.eqlComponents(&wk.inhibit_any_policy)) {
             return .{ .inhibit_any_policy = try self.parseInhibitAnyPolicy(value) };
+        } else if (ext_oid.eqlComponents(&wk.tls_feature)) {
+            return .{ .tls_features = try self.parseTlsFeatures(value) };
         }
         return .unrecognized;
     }
@@ -1359,6 +1420,27 @@ const Parser = struct {
         }
         inner.expectEnd() catch return error.MalformedExtension;
         return constraints;
+    }
+
+    /// RFC 7633 §6: `Features ::= SEQUENCE OF INTEGER`, each a TLS
+    /// ExtensionType value. Values outside the 16-bit registry cannot name a
+    /// TLS extension and are a structural encoding error.
+    fn parseTlsFeatures(self: *Parser, value: []const u8) Error!TlsFeatures {
+        var reader = der.Reader.init(value, self.limits.der);
+        var inner = reader.readSequence() catch return error.MalformedExtension;
+        reader.expectEnd() catch return error.MalformedExtension;
+
+        var features: std.ArrayList(u16) = .empty;
+        while (inner.remaining() > 0) {
+            if (features.items.len >= self.limits.max_tls_features) return error.CountLimitExceeded;
+            const integer = inner.readInteger() catch return error.MalformedExtension;
+            if (integer.isNegative()) return error.MalformedExtension;
+            const feature = integerToU32(integer) orelse return error.MalformedExtension;
+            if (feature > std.math.maxInt(u16)) return error.MalformedExtension;
+            try features.append(self.arena, @intCast(feature));
+        }
+        if (features.items.len == 0) return error.MalformedExtension;
+        return .{ .features = features.items };
     }
 
     fn parseInhibitAnyPolicy(self: *Parser, value: []const u8) Error!usize {

--- a/src/pki/x509.zig
+++ b/src/pki/x509.zig
@@ -370,8 +370,20 @@ pub const TlsFeatures = struct {
 
     /// RFC 7633 §4.2.1: asserting `status_request` obliges the server to
     /// deliver a stapled certificate-status response.
+    ///
+    /// Feature 17 is deliberately *not* included. RFC 6961 `status_request_v2`
+    /// is obsoleted by RFC 8446 §4.4.2.1, which forbids a TLS 1.3 server from
+    /// acting on or sending it, so an ordinary TLS 1.3 staple cannot prove that
+    /// a feature-17 declaration was honored. This stack is TLS 1.3 only; see
+    /// `assertsStatusRequestV2`.
     pub fn requiresStapledStatus(self: *const TlsFeatures) bool {
-        return self.contains(status_request) or self.contains(status_request_v2);
+        return self.contains(status_request);
+    }
+
+    /// True when the certificate declares RFC 6961 `status_request_v2`, a
+    /// mechanism this TLS 1.3-only stack cannot negotiate or satisfy.
+    pub fn assertsStatusRequestV2(self: *const TlsFeatures) bool {
+        return self.contains(status_request_v2);
     }
 };
 
@@ -585,10 +597,17 @@ pub const Certificate = struct {
     }
 
     /// RFC 7633 must-staple: the certificate asserts that its server always
-    /// delivers a stapled certificate-status response.
+    /// delivers a stapled certificate-status response (`status_request`).
     pub fn mustStaple(self: *const Certificate) bool {
         const features = self.tlsFeatures() orelse return false;
         return features.requiresStapledStatus();
+    }
+
+    /// The certificate declares RFC 6961 `status_request_v2`, which RFC 8446
+    /// §4.4.2.1 forbids a TLS 1.3 server from acting on.
+    pub fn assertsStatusRequestV2(self: *const Certificate) bool {
+        const features = self.tlsFeatures() orelse return false;
+        return features.assertsStatusRequestV2();
     }
 };
 

--- a/src/pki/x509_tests.zig
+++ b/src/pki/x509_tests.zig
@@ -1152,6 +1152,7 @@ const fuzz_x509_limits: x509.Limits = .{
     .max_distribution_points = 4,
     .max_access_descriptions = 4,
     .max_name_constraint_subtrees = 8,
+    .max_tls_features = 4,
 };
 
 fn expectViewContained(raw: []const u8, view: []const u8) !void {
@@ -1244,6 +1245,7 @@ fn expectParsedExtensionContained(raw: []const u8, parsed: x509.Extension.Parsed
         .policy_mappings,
         .policy_constraints,
         .inhibit_any_policy,
+        .tls_features,
         .unrecognized,
         => {},
     }
@@ -1422,6 +1424,11 @@ fn expectSameParsedExtension(expected: x509.Extension.Parsed, actual: x509.Exten
         },
         .policy_constraints => try testing.expectEqual(expected.policy_constraints, actual.policy_constraints),
         .inhibit_any_policy => try testing.expectEqual(expected.inhibit_any_policy, actual.inhibit_any_policy),
+        .tls_features => try testing.expectEqualSlices(
+            u16,
+            expected.tls_features.features,
+            actual.tls_features.features,
+        ),
         .unrecognized => {},
     }
 }
@@ -1737,6 +1744,11 @@ fn fuzzX509Semantics(_: void, smith: *testing.Smith) !void {
                 .authority_info_access => |value| try testing.expect(value.len <= fuzz_x509_limits.max_access_descriptions),
                 .crl_distribution_points => |value| try testing.expect(value.len <= fuzz_x509_limits.max_distribution_points),
                 .inhibit_any_policy => |value| try testing.expectEqual(value, certificate.inhibitAnyPolicy().?),
+                .tls_features => |value| {
+                    try testing.expect(value.features.len <= fuzz_x509_limits.max_tls_features);
+                    try testing.expectEqualSlices(u16, value.features, certificate.tlsFeatures().?.features);
+                    try testing.expectEqual(value.requiresStapledStatus(), certificate.mustStaple());
+                },
                 .unrecognized => {},
             }
         }

--- a/tests/pki_differential.zig
+++ b/tests/pki_differential.zig
@@ -289,7 +289,6 @@ fn tardigradeFailureReason(reason: pki.path_validator.FailureReason) Reason {
         .revocation_status_malformed,
         .revocation_status_unauthenticated,
         .revocation_must_staple_not_satisfied,
-        .revocation_must_staple_feature_unsupported,
         .revocation_source_unsupported,
         => .unclassified_rejection,
     };

--- a/tests/pki_differential.zig
+++ b/tests/pki_differential.zig
@@ -289,8 +289,8 @@ fn tardigradeFailureReason(reason: pki.path_validator.FailureReason) Reason {
         .revocation_status_malformed,
         .revocation_status_unauthenticated,
         .revocation_must_staple_not_satisfied,
+        .revocation_must_staple_feature_unsupported,
         .revocation_source_unsupported,
-        .revocation_evidence_invalid,
         => .unclassified_rejection,
     };
 }

--- a/tests/pki_differential.zig
+++ b/tests/pki_differential.zig
@@ -273,8 +273,22 @@ fn tardigradeFailureReason(reason: pki.path_validator.FailureReason) Reason {
         .name_constraints_resource_limit_exceeded,
         .certificate_policy_resource_limit_exceeded,
         .validation_resource_limit_exceeded,
+        .revocation_resource_limit_exceeded,
         .out_of_memory,
         => .resource_limit,
+        // The differential harness validates with certificate-status policy
+        // disabled, so no revocation verdict is comparable against OpenSSL or
+        // Go here. Reaching one would be a harness bug, and an unclassified
+        // rejection surfaces it rather than laundering it into another class.
+        .certificate_revoked,
+        .revocation_status_unavailable,
+        .revocation_status_stale,
+        .revocation_status_malformed,
+        .revocation_status_unauthenticated,
+        .revocation_must_staple_not_satisfied,
+        .revocation_source_unsupported,
+        .revocation_evidence_invalid,
+        => .unclassified_rejection,
     };
 }
 

--- a/tests/pki_differential.zig
+++ b/tests/pki_differential.zig
@@ -276,6 +276,9 @@ fn tardigradeFailureReason(reason: pki.path_validator.FailureReason) Reason {
         .revocation_resource_limit_exceeded,
         .out_of_memory,
         => .resource_limit,
+        // RFC 7633 TLS Feature chain constraints are enforced by Tardigrade
+        // and by neither oracle, so there is no comparable classification.
+        .tls_feature_constraint_violation,
         // The differential harness validates with certificate-status policy
         // disabled, so no revocation verdict is comparable against OpenSSL or
         // Go here. Reaching one would be a harness bug, and an unclassified


### PR DESCRIPTION
## Summary

Defines an explicit, testable certificate-status policy for the pure-Zig PKI path — CRLs, OCSP responses, stapling, and must-staple — without introducing online revocation fetching.

- **`src/pki/revocation.zig`** — four modes (`disabled` default, `stapled_only`, `soft_fail`, `strict`); evidence model for stapled responses, cached status, and CRL sets with freshness bounds, defect reasons, and an authentication flag; deterministic source precedence where a usable `revoked` from any source wins.
- **Explicit default** — every accepted path carries a `revocation.Report` naming, per certificate, what was checked and what was not. Under the default policy the report says nothing was checked, so an acceptance never implies revocation was verified. `disabled` also never *rejects*: evidence is not examined at all, so a peer cannot fail a handshake against a gateway with revocation switched off.
- **Evidence is keyed by certificate identity** (SHA-256 over the exact DER), never by path position. One evidence set is shared across every candidate, and candidates differ in shape and depth, so a position-derived key would both misdirect evidence onto the wrong certificate and let a longer candidate's assertions invalidate a shorter one. Assertions for certificates not on the path being evaluated are skipped.
- **Must-staple (RFC 7633)** — new TLS Feature extension parsing in the X.509 model. The **end-entity** form is the stapling obligation, enforced in every mode that consults status. The **issuer** form is a different rule: RFC 7633 §4.2.2 makes a TLS-Feature-carrying CA constrain what it signs — children must assert the same feature set or a superset, for every advertised feature — enforced during path validation as `tls_feature_constraint_violation`, independently of the status mode. The end-entity obligation is scoped by RFC 7633 §§4.1/4.3.3 to features the ClientHello actually offered, carried in as `offered_status_request` (false today, since this stack does not yet send `status_request`). A certificate advertising feature 5 or RFC 6961 feature 17 is therefore outside the intersection and reported as `not_offered_by_client` rather than rejected, while both features still participate in the §4.2.2 issuer constraint.
- **Reported, not assumed** — `Report.must_staple` distinguishes `not_required`, `enforced`, `not_offered_by_client`, `unenforced_status_disabled`, and `unenforced_by_configuration`, so an acceptance never reads as "honored" when the assertion was merely not applied.
- **Status data surfaced** — typed `authorityInfoAccess`, `crlDistributionPoints`, and `hasOcspResponder` accessors; `strict` distinguishes "certificate publishes no revocation mechanism" (`status_source_unsupported`) from "we looked and found nothing".
- **No ambient I/O** — evidence is caller-supplied. `revocation.Provider` runs before validation and returns a `CollectedEvidence` that owns its per-call assertion array, so concurrent handshakes cannot alias provider scratch storage and adding a real fetch/cache provider changes no TLS-handshake or path-validation signature.
- **Trust boundary** — unauthenticated evidence never counts as a completed check by default (`require_signature_verified`). The one exception is a *peer-stapled* revocation, which can only condemn the peer itself; an unauthenticated `revoked` from a fetched responder or CRL is refused, since trusting it would be a one-packet denial of service. Revocation is otherwise monotonic, except that a stale `certificateHold` does not outrank fresher evidence of its RFC 5280 §5.3.1 release.
- **[docs/PKI_REVOCATION.md](docs/PKI_REVOCATION.md)** — modes, trust boundary, freshness, and the privacy / availability / operational tradeoffs, plus what is deliberately not implemented yet.

## Test plan

- [x] `zig build test` — full suite green, including `src/pki/revocation_tests.zig` and end-to-end coverage in `src/pki/path_validator_tests.zig`
- [x] Stapled-good, stapled-revoked (with CRL reason), missing, stale, malformed, unauthenticated, unknown, must-staple, and unsupported-source cases across all four modes
- [x] Evidence identity: foreign evidence never applied by position in either direction; the same certificate consumes its own evidence at a different depth; a longer candidate's assertions cannot reject a shorter candidate, unit and end-to-end through `validateCandidates`
- [x] RFC 7633 §4.2.2 chain constraint: featureless child rejected even with a good staple present, child asserting a different feature rejected, same-set and superset children accepted
- [x] ClientHello intersection: feature 5 with `offered_status_request = false` accepts across every consulting mode and reports `not_offered_by_client`; the same certificate and absent staple with the flag set rejects; a certificate without the extension reports `not_required` either way
- [x] `status_request_v2`: a feature-17 leaf is accepted with `not_required` bare and with a staple; `{5,17}` reports `enforced` off an ordinary staple and still rejects when that staple is missing
- [x] Trust boundary: forged cached/CRL revocation cannot deny service, the peer's own unverified staple still self-revokes, a stale `certificateHold` loses to fresher evidence while a fresh hold and a stale permanent revocation still stand
- [x] `disabled` accepts despite oversized and misfiled evidence
- [x] Freshness boundaries: skew on both sides, future-dated evidence, absent `nextUpdate`, incoherent `nextUpdate < thisUpdate`, age bound
- [x] Provider contract: two simultaneously-live `CollectedEvidence` results, neither aliasing nor freeing the other's storage
- [x] Determinism oracle extended to cover the status report and new failure metadata; `FailingAllocator` sweep proves the status path is leak-free and degrades to a structured rejection
- [x] `zig build test-pki`, `test-pki-fuzz`, `test-pki-reduce`, `test-pki-openssl` green; `zig fmt --check` clean

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)