### PR TITLE
tls: [325-H] support TLS-over-TCP KeyUpdate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,12 @@ All notable user-facing changes to Tardigrade are documented here.
   `setKeyUpdateLimits`/`keyUpdateDue` expose a records-sealed threshold for
   proactive updates. The threshold reports only — nothing fires an update on
   its own, and it is disabled by default, so an existing connection's wire
-  behaviour is unchanged until a caller opts in.
+  behaviour is unchanged until a caller opts in. `records` is a cap on the
+  whole generation, counting the `KeyUpdate` that retires it: the predicate
+  becomes due one record early, since that message is itself sealed under the
+  keys it is retiring. A caller can therefore pass RFC 8446 §5.5's AES-GCM
+  record limit directly and get that bound, rather than exceeding it by the
+  one control record.
 
   `KeyUpdate` is record-mode only. RFC 9001 §6 removes it from TLS-over-QUIC,
   which carries its own key phase in the packet header, so a QUIC-profile
@@ -37,9 +42,12 @@ All notable user-facing changes to Tardigrade are documented here.
   moment a conforming peer rotated its keys. Messages that fit inline (today,
   exactly `KeyUpdate`) now reassemble without an allocator. A `KeyUpdate`
   declaring a body of any other length is rejected as a framing error before a
-  buffer is chosen, so the failure class no longer depends on whether tickets
-  were configured, and an attacker-chosen length is never buffered for a
-  five-byte message.
+  buffer is chosen — at *every* declared length, including one past the generic
+  post-handshake size cap, which would otherwise have been classified as a
+  buffer overflow and terminated the connection locally without the RFC's
+  `decode_error` alert. The failure class therefore no longer depends on the
+  declared length or on whether tickets were configured, and an attacker-chosen
+  length is never buffered for a five-byte message.
 - **HelloRetryRequest handshakes failed against compatibility-mode TLS clients
   (#338)** — RFC 8446 §5.1 has a client send `change_cipher_spec` immediately
   after receiving a HelloRetryRequest, before ClientHello2. An HRR flight

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,42 @@ All notable user-facing changes to Tardigrade are documented here.
 
 ## [Unreleased]
 
+### Added
+- **TLS-over-TCP post-handshake `KeyUpdate` (#357, research story 325-H)** —
+  record-mode TLS 1.3 now sends and receives RFC 8446 §4.6.3 `KeyUpdate`,
+  advancing one direction's application traffic secret at a time along §7.2's
+  `"traffic upd"` chain. Receiving keys advance immediately after a valid
+  update is processed; sending keys advance only *after* the outgoing
+  `KeyUpdate` has been sealed, so the message that announces a transition is
+  still readable under the generation it retires. `update_requested` draws
+  exactly one reciprocal update, which always carries `update_not_requested`
+  and therefore cannot start a loop. Each transition restarts that direction's
+  record sequence at zero and zeroizes the keys and secret it replaced.
+
+  `PureZigRecordStream.requestKeyUpdate` initiates one locally;
+  `setKeyUpdateLimits`/`keyUpdateDue` expose a records-sealed threshold for
+  proactive updates. The threshold reports only — nothing fires an update on
+  its own, and it is disabled by default, so an existing connection's wire
+  behaviour is unchanged until a caller opts in.
+
+  `KeyUpdate` is record-mode only. RFC 9001 §6 removes it from TLS-over-QUIC,
+  which carries its own key phase in the packet header, so a QUIC-profile
+  engine neither offers a way to send one nor accepts one that arrives.
+  Verified against OpenSSL in both client and server roles by three new rows in
+  the shared interop matrix.
+
 ### Fixed
+- **A peer's `KeyUpdate` failed any connection that had not opted into session
+  tickets (#357)** — post-handshake message reassembly always allocated, and
+  the allocator is only installed by a client that configured a session-ticket
+  consumer. Since any peer may send a `KeyUpdate` on any completed connection,
+  an endpoint that simply did not use tickets would fail the connection the
+  moment a conforming peer rotated its keys. Messages that fit inline (today,
+  exactly `KeyUpdate`) now reassemble without an allocator. A `KeyUpdate`
+  declaring a body of any other length is rejected as a framing error before a
+  buffer is chosen, so the failure class no longer depends on whether tickets
+  were configured, and an attacker-chosen length is never buffered for a
+  five-byte message.
 - **HelloRetryRequest handshakes failed against compatibility-mode TLS clients
   (#338)** — RFC 8446 §5.1 has a client send `change_cipher_spec` immediately
   after receiving a HelloRetryRequest, before ClientHello2. An HRR flight

--- a/docs/CRYPTO_FUZZ_CONTRACT.md
+++ b/docs/CRYPTO_FUZZ_CONTRACT.md
@@ -985,11 +985,20 @@ issue's implementation-plan comment:
   that a mutation which merely turns some test red is not the same as one that
   proves the property under test bites.
 
-  TLS-over-TCP KeyUpdate and key replacement remain #357: the bridge exposes
-  no such surface today, so the epoch target's operation set is the extension
-  point for it rather than a fabricated API. The stream targets' operation
-  sets are the corresponding extension point for any future post-handshake
-  record-layer operation.
+  TLS-over-TCP KeyUpdate and key replacement landed in #357, and the bridge
+  now does expose that surface: `Bridge.updateTrafficSecret(direction)` walks
+  RFC 8446 §7.2's `"traffic upd"` chain for one direction, replacing that
+  direction's record keys and restarting its sequence. It is the extension
+  point this note anticipated — a generated operation for the epoch target,
+  not a fabricated API — and adding it there would let the existing one-way
+  key-lifecycle property cover generation transitions too. The deterministic
+  properties it must preserve are already pinned by name in
+  `record_epoch_bridge.zig` (chain arithmetic against an independent HKDF
+  computation, sequence restart, old-generation records failing to open, no
+  retired key material anywhere in the bridge, and rejection outside a live
+  completed application epoch). The stream targets' operation sets remain the
+  corresponding extension point for the post-handshake record-layer exchange
+  itself.
 
 Ownership stays exactly as scoped above and in the issue: shared TLS
 message/negotiation/transcript fuzzing is #491; PKI fuzzing is #492;

--- a/docs/TLS_INTEROP_MATRIX.md
+++ b/docs/TLS_INTEROP_MATRIX.md
@@ -106,6 +106,38 @@ where it was told to. The external QUIC/H3 peer matrix (ngtcp2, quiche,
 aioquic, both directions, HRR included) already exists in
 `scripts/interop/run-interop.sh` and is not duplicated here.
 
+### Post-handshake KeyUpdate
+
+Three rows (#357) exercise RFC 8446 §4.6.3 against OpenSSL in both roles. The
+native side sends exactly one `KeyUpdate` as soon as the connection opens and
+**before** its application payload, so every application byte in the row
+crosses under the new generation — a peer that did not follow the transition
+could not read the exchange at all, and the row fails rather than passing on a
+`KeyUpdate` the peer quietly ignored.
+
+| Row | Native sends | Also requires |
+| --- | --- | --- |
+| `record/server/openssl/key-update/reciprocal` | `update_requested` | the peer's answering `KeyUpdate`, applied |
+| `record/client/openssl/key-update/reciprocal` | `update_requested` | the peer's answering `KeyUpdate`, applied |
+| `record/client/openssl/key-update/one-way` | `update_not_requested` | nothing back — the peer follows unprompted |
+
+`--expect-key-updates N` asserts the *receiving* half: it requires the engine
+to have advanced its own read secret N times, which only happens by processing
+a real `KeyUpdate` from the peer. Both halves are asserted together, since
+either alone is satisfiable without the mechanism working.
+
+The server-role row feeds its external client a second, delayed request. RFC
+8446 §4.6.3 obliges a peer receiving `update_requested` to answer "prior to
+sending its next Application Data record", so a client that has already
+stopped writing owes no reply and the row would otherwise wait for something
+the standard never required. That second request also lands *after* the
+transition, so the peer must have followed the update to send it at all.
+
+One tuple per role suffices: `KeyUpdate` advances a traffic secret through the
+negotiated suite's own HKDF, which the positive matrix already sweeps for
+every suite. What is peer-specific here is the message exchange, not the
+arithmetic.
+
 ### Negative conformance
 
 Each of these asserts the failure **class**, using the RFC 8446 §6 alert where

--- a/scripts/interop/run-tls-interop.sh
+++ b/scripts/interop/run-tls-interop.sh
@@ -244,11 +244,34 @@ gnutls_row_in_profile() { # suite group signature
 
 # ── row runners ─────────────────────────────────────────────────────────────
 
+# What an external client feeds the native server on stdin.
+#
+# `once` is the ordinary case: one request, then EOF.
+#
+# `keep_writing` exists for the KeyUpdate rows (#357). RFC 8446 §4.6.3 obliges
+# a peer that receives `update_requested` to answer "prior to sending its next
+# Application Data record" -- so a peer that has already stopped writing owes
+# us nothing, and the row would time out waiting for a reply the standard never
+# required. The delayed second request *is* that next record, and it also
+# lands after the transition, so the peer has to have followed the update to
+# send it at all.
+peer_request_stdin() { # once|keep_writing
+  case "$1" in
+    keep_writing)
+      printf 'GET / HTTP/1.0\r\n\r\n'
+      sleep 2
+      printf 'GET / HTTP/1.0\r\nX-Key-Update-Probe: 1\r\n\r\n'
+      sleep 2
+      ;;
+    *) printf 'GET / HTTP/1.0\r\n\r\n' ;;
+  esac
+}
+
 # native TLS server <- external client
 run_server_row() { # name peer suite group signature [extra native args...]
   local name="$1" peer="$2" suite="$3" group="$4" sig="$5"
   shift 5
-  local p log cert peer_groups
+  local p log cert peer_groups peer_stdin
   next_port; p="$port"
   log="$logs/${name//\//_}"
   cert="$(cert_for_signature "$sig")"
@@ -256,6 +279,8 @@ run_server_row() { # name peer suite group signature [extra native args...]
   # native server does not accept; ordinary rows offer the row's own group.
   peer_groups="$(openssl_group "$group")"
   case " $* " in *" --expect-hrr "*) peer_groups="P-384:$(openssl_group "$group")" ;; esac
+  peer_stdin=once
+  case " $* " in *" --key-update "*) peer_stdin=keep_writing ;; esac
 
   "$tls_tool" server --port "$p" --cert "$cert-cert.pem" --key "$cert-key.pem" \
     --cipher-suite "$suite" --group "$group" --signature "$sig" \
@@ -270,14 +295,14 @@ run_server_row() { # name peer suite group signature [extra native args...]
 
   case "$peer" in
     openssl)
-      printf 'GET / HTTP/1.0\r\n\r\n' | "$openssl_bin" s_client -connect "127.0.0.1:$p" \
+      peer_request_stdin "$peer_stdin" | "$openssl_bin" s_client -connect "127.0.0.1:$p" \
         -servername tardigrade.test -tls1_3 \
         -ciphersuites "$(openssl_suite "$suite")" -groups "$peer_groups" \
         -sigalgs "$(openssl_sigalg "$sig")" -alpn http/1.1 \
         -CAfile "$cert-cert.pem" > "$log.peer" 2>&1
       ;;
     gnutls)
-      printf 'GET / HTTP/1.0\r\n\r\n' | "$gnutls_cli" --port "$p" \
+      peer_request_stdin "$peer_stdin" | "$gnutls_cli" --port "$p" \
         --x509cafile "$cert-cert.pem" --alpn=http/1.1 --sni-hostname=tardigrade.test \
         --priority "$(gnutls_priority "$suite" "$group" "$sig")" 127.0.0.1 > "$log.peer" 2>&1
       ;;
@@ -513,6 +538,33 @@ run_server_row "record/server/openssl/hrr" openssl aes128-gcm-sha256 x25519 ed25
 # The native client omits its initial key share, forcing the peer to retry.
 run_client_row "record/client/openssl/hrr" openssl aes128-gcm-sha256 x25519 ed25519 \
   --empty-initial-key-share --expect-hrr
+
+# ── 2b. post-handshake KeyUpdate, both roles ────────────────────────────────
+
+say ""
+say "== record transport: post-handshake KeyUpdate =="
+# #357. Each row makes the native side send one KeyUpdate once the connection
+# is open and *before* its application payload, so every application byte in
+# the row crosses under the new generation -- a peer that failed to follow the
+# transition could not read the exchange at all, and the row fails.
+#
+# `--key-update requested` also obliges the peer to roll its own sending keys
+# and answer with `update_not_requested`. `--expect-key-updates 1` requires
+# that answer to have arrived and been applied, which is what exercises the
+# *receiving* half against a real implementation rather than against ourselves.
+#
+# One tuple per role is enough: KeyUpdate advances a traffic secret through the
+# negotiated suite's own HKDF, which the positive matrix above already sweeps
+# for every suite. What is peer-specific here is the message exchange, not the
+# arithmetic.
+run_server_row "record/server/openssl/key-update/reciprocal" openssl aes128-gcm-sha256 x25519 ed25519 \
+  --key-update requested --expect-key-updates 1
+run_client_row "record/client/openssl/key-update/reciprocal" openssl aes128-gcm-sha256 x25519 ed25519 \
+  --key-update requested --expect-key-updates 1
+# The one-way form: we refresh our sending keys and ask nothing back, so the
+# peer must follow the transition without being prompted to make one itself.
+run_client_row "record/client/openssl/key-update/one-way" openssl aes128-gcm-sha256 x25519 ed25519 \
+  --key-update not-requested
 
 # ── 3. negative conformance rows ────────────────────────────────────────────
 

--- a/src/quic/tls_backend.zig
+++ b/src/quic/tls_backend.zig
@@ -631,6 +631,13 @@ fn translate(allocator: ?std.mem.Allocator, source: *RecordSink, destination: *E
             .alpn => |protocol| try destination.emitAlpn(protocol),
             .certificate => |state| try destination.emitCertificate(state),
             .discard_epoch => |epoch| try destination.emitDiscardEpoch(toLevel(epoch)),
+            // RFC 9001 §6: TLS `KeyUpdate` is not part of TLS-over-QUIC, so
+            // this event has no QUIC translation. The shared engine rejects
+            // an inbound `KeyUpdate` outright under a QUIC transport profile
+            // and never emits this, so it is unreachable in practice — kept
+            // as an explicit failure rather than a dropped event so a future
+            // engine change cannot quietly lose a key transition here.
+            .key_update => return error.InvalidHandshakeState,
             .handshake_complete => try destination.emitHandshakeComplete(),
             .fatal_alert => |alert| try destination.emitFatalAlert(alert),
         }

--- a/src/quic/tls_handshake.zig
+++ b/src/quic/tls_handshake.zig
@@ -378,6 +378,14 @@ pub const Handshake = struct {
                     if (cert_state == .invalid) return self.fail(error.CertificateInvalid);
                 },
                 .discard_epoch => |level| self.discardOrDefer(level),
+                // RFC 9001 SS6: TLS `KeyUpdate` does not exist over QUIC --
+                // QUIC carries its own key phase in the packet header
+                // (`commitApplicationReadKeyUpdate`), a separate mechanism.
+                // The engine already refuses to produce this event under a
+                // QUIC transport profile, so reaching here is an internal
+                // inconsistency, not peer input; fail closed rather than
+                // silently ignoring a key transition.
+                .key_update => return self.fail(error.InvalidHandshakeState),
                 .handshake_complete => try self.complete(),
                 // QUIC never emits this: RFC 9001 SS4.8 has the connection
                 // derive its own CRYPTO_ERROR close from the returned

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -13,6 +13,7 @@ const algorithms = @import("algorithms.zig");
 const alerts = @import("alerts.zig");
 const engine = @import("engine.zig");
 const events = @import("events.zig");
+const key_update = @import("key_update.zig");
 const record_codec = @import("record_codec.zig");
 const record_epoch_bridge = @import("record_epoch_bridge.zig");
 const tls_state = @import("state.zig");
@@ -429,6 +430,10 @@ pub const PureZigRecordStream = struct {
     inbound_plaintext_provenance: PlaintextProvenanceQueue(max_plaintext_queue) = .{},
     outbound_ciphertext: ByteQueue(max_ciphertext_queue, error.CiphertextBufferFull) = .{},
     inbound_handshake: ByteQueue(max_handshake_queue, error.PlaintextBufferFull) = .{},
+    /// Proactive `KeyUpdate` policy (#357), disabled by default. See
+    /// `keyUpdateDue` — this stream reports the threshold but never acts on it
+    /// by itself.
+    key_update_limits: key_update.UsageLimits = .{},
     buffer_limits: BufferLimits = BufferLimits.defaults(),
     buffer_peaks: QueueBytes = .{},
     peak_total_owned: usize = 0,
@@ -1065,6 +1070,16 @@ pub const PureZigRecordStream = struct {
                     self.bridge.installTrafficSecret(ts.epoch, ts.direction, ts.data) catch |err| return self.fail(err);
                     self.advanceEpochOnSecret(ts.epoch, ts.direction);
                 },
+                // #357. Position in the batch is the protocol: the write-side
+                // update follows the `handshake_bytes` arm that already sealed
+                // our own `KeyUpdate` under the outgoing generation, and the
+                // read-side update follows the record the peer's `KeyUpdate`
+                // arrived in. Applying events in order is therefore what puts
+                // each direction's boundary in the right place -- this arm
+                // must not be hoisted or deferred.
+                .key_update => |update| {
+                    self.bridge.updateTrafficSecret(update.direction) catch |err| return self.fail(err);
+                },
                 .alpn => |protocol| {
                     try self.captureAlpn(protocol);
                     if (self.alpnPolicyError(protocol)) |err| {
@@ -1368,6 +1383,60 @@ pub const PureZigRecordStream = struct {
             }
         }
         return consumed;
+    }
+
+    /// Queues a locally initiated post-handshake `KeyUpdate` (#357).
+    ///
+    /// The emitted batch is applied in order by `applyDriverOutcome`: the
+    /// `KeyUpdate` record is sealed under the outgoing keys first, then the
+    /// write-side advance replaces them, so the message the peer needs in
+    /// order to follow the transition is itself readable under the generation
+    /// it is announcing the end of.
+    ///
+    /// `.update_requested` additionally obliges the peer to advance *its*
+    /// sending keys. That is the only way to refresh the keys this endpoint
+    /// *reads* under, since a direction's chain can only ever be advanced by
+    /// its sender — so a caller that wants both directions refreshed must use
+    /// this form rather than calling twice.
+    ///
+    /// Fails with `error.InvalidHandshakeState` before the handshake completes
+    /// or on a backend whose transport has no `KeyUpdate`, and `error.WouldBlock`
+    /// when the outbound queue has no room to serialize the batch atomically —
+    /// the same admission rule every other emitted handshake batch follows.
+    pub fn requestKeyUpdate(self: *PureZigRecordStream, request: key_update.Request) Error!void {
+        if (self.failed) |err| return err;
+        if (self.pending_terminal) |err| return err;
+        if (self.pending_terminal_read_error) |err| return err;
+        if (self.lifecycle != .open or !self.bridge.handshake_complete) return error.InvalidHandshakeState;
+        const driver = if (self.driverPresent()) &self.handshake_driver.? else return error.InvalidHandshakeState;
+        if (!driver.supportsKeyUpdate()) return error.InvalidHandshakeState;
+        if (!self.canReserveHandshakeOutputBatch()) return error.WouldBlock;
+        const outcome = driver.requestKeyUpdateOutcome(request);
+        try self.applyDriverOutcome(outcome);
+        try self.raisePendingTerminalError();
+    }
+
+    /// Proactive-update policy (#357). Defaults to disabled, so configuring
+    /// nothing keeps a connection's wire behavior exactly as it was.
+    pub fn setKeyUpdateLimits(self: *PureZigRecordStream, limits: key_update.UsageLimits) void {
+        self.key_update_limits = limits;
+    }
+
+    /// Whether the configured usage limit has been reached for the *sending*
+    /// direction. This is the hook, not the trigger: nothing in `drive()`
+    /// consults it, so acting on it stays an explicit `requestKeyUpdate` call
+    /// by the owner, who is the only layer that knows whether stalling the
+    /// stream to emit one is acceptable right now.
+    pub fn keyUpdateDue(self: *const PureZigRecordStream) bool {
+        return self.key_update_limits.reached(self.bridge.applicationRecordsSealed());
+    }
+
+    /// How many times each direction has advanced its application traffic
+    /// secret. Exposed for observability and tests: it distinguishes "the keys
+    /// rolled" from "the same keys are still in place", which no amount of
+    /// looking at ciphertext can.
+    pub fn keyUpdateGenerations(self: *const PureZigRecordStream) struct { read: u64, write: u64 } {
+        return .{ .read = self.bridge.read_key_generation, .write = self.bridge.write_key_generation };
     }
 
     pub fn markPeerEof(self: *PureZigRecordStream) Error!void {

--- a/src/tls/engine.zig
+++ b/src/tls/engine.zig
@@ -10,6 +10,7 @@ pub const state = @import("state.zig");
 pub const events = @import("events.zig");
 pub const handshake = @import("handshake.zig");
 pub const key_schedule = @import("key_schedule.zig");
+pub const key_update = @import("key_update.zig");
 const messages = @import("messages.zig");
 pub const transcript = @import("transcript.zig");
 
@@ -166,6 +167,27 @@ pub fn Driver(comptime Transport: type) type {
             if (self.state == .failed) return .{ .sink = &self.sink, .terminal_error = self.failure_reason };
             self.sink.reset();
             self.backend.resumeAuth(&self.sink) catch |err| self.markFailed(err);
+            return .{ .sink = &self.sink, .terminal_error = self.failure_reason };
+        }
+
+        /// Whether the backend's transport has post-handshake `KeyUpdate`
+        /// (#357). False for QUIC, which has no such message (RFC 9001 §6).
+        pub fn supportsKeyUpdate(self: *const Self) bool {
+            return self.backend.supportsKeyUpdate();
+        }
+
+        /// Queue a locally initiated `KeyUpdate`, returning the resulting event
+        /// batch the same way `receiveOutcome` does — the batch carries the
+        /// `KeyUpdate` bytes and the write-side advance that must be applied
+        /// after them, so it must be applied in order.
+        ///
+        /// Callers must check `supportsKeyUpdate` first: on a backend without
+        /// `KeyUpdate` this emits nothing and reports no error, which is
+        /// indistinguishable here from a successful empty batch.
+        pub fn requestKeyUpdateOutcome(self: *Self, request: key_update.Request) Outcome {
+            if (self.state == .failed) return .{ .sink = &self.sink, .terminal_error = self.failure_reason };
+            self.sink.reset();
+            _ = self.backend.requestKeyUpdate(request, &self.sink) catch |err| self.markFailed(err);
             return .{ .sink = &self.sink, .terminal_error = self.failure_reason };
         }
 

--- a/src/tls/events.zig
+++ b/src/tls/events.zig
@@ -136,11 +136,30 @@ pub const NegotiatedParameters = struct {
     transcript_hash: TranscriptHash,
 };
 
+/// Advance one direction's application traffic secret one step along RFC 8446
+/// §7.2's `"traffic upd"` chain, replacing that direction's record keys and
+/// restarting its record sequence at zero (#357).
+///
+/// Ordering carries the protocol meaning, so a consumer must apply this in
+/// event order and never reorder it against `handshake_bytes`:
+///
+///   * `.read` is emitted *after* the peer's `KeyUpdate` has been processed,
+///     so the record that carried it was still opened under the old keys and
+///     everything after it uses the new ones.
+///   * `.write` is emitted *after* the `handshake_bytes` event carrying our
+///     own `KeyUpdate`, so that message is sealed under the old keys — as RFC
+///     8446 §4.6.3 requires — and only later records use the new ones.
+///
+/// Record mode only. QUIC has no `KeyUpdate` (RFC 9001 §6) and never sees this
+/// event; its own key phase is a packet-header mechanism.
+pub const KeyUpdate = struct { direction: SecretDirection };
+
 pub const Event = union(enum) {
     handshake_bytes: struct { epoch: EncryptionEpoch, data: []const u8 },
     negotiated_parameters: NegotiatedParameters,
     early_data_parameters: NegotiatedParameters,
     traffic_secret: struct { epoch: EncryptionEpoch, direction: SecretDirection, data: []const u8 },
+    key_update: KeyUpdate,
     alpn: []const u8,
     certificate: CertificateState,
     discard_epoch: EncryptionEpoch,

--- a/src/tls/handshake.zig
+++ b/src/tls/handshake.zig
@@ -156,6 +156,18 @@ pub const Core = struct {
             try self.transcript.update(message.raw);
             return message;
         }
+        // KeyUpdate (RFC 8446 §4.6.3, #357) is post-handshake and symmetric:
+        // unlike NewSessionTicket either role may send it, so the only
+        // ordering constraint is that the handshake has finished. A KeyUpdate
+        // before that is a legal message in an illegal position — the
+        // `unexpected_message` class, not a decode failure.
+        //
+        // Deliberately not hashed into the transcript; `key_update.zig`'s
+        // module comment records why.
+        if (message.kind == .key_update) {
+            if (self.handshake_lifecycle != .complete) return error.UnexpectedHandshakeMessage;
+            return message;
+        }
         // A CertificateRequest (server->client, #334) is an optional message the
         // server inserts before its Certificate. Accept it transparently while
         // the client is still expecting the server's Certificate; the client

--- a/src/tls/key_schedule.zig
+++ b/src/tls/key_schedule.zig
@@ -342,6 +342,34 @@ pub const KeySchedule = struct {
         try crypto_provider.hkdfExpandLabel(hash, early_secret[0..n], "c e traffic", client_hello_hash, out);
     }
 
+    /// RFC 8446 §7.2: `application_traffic_secret_N+1 =
+    /// HKDF-Expand-Label(application_traffic_secret_N, "traffic upd", "",
+    /// Hash.length)` — the one-way step a post-handshake `KeyUpdate` (#357)
+    /// takes to replace one direction's application traffic secret.
+    ///
+    /// Independent of `KeySchedule` because it is: the chain is seeded by the
+    /// application traffic secret and never touches the master secret again,
+    /// so a record layer holding only the current secret can advance without
+    /// retaining the handshake's key schedule. It is also direction-agnostic
+    /// — each direction advances its own secret on its own schedule.
+    ///
+    /// `traffic_secret` and `out` must both be exactly `hash.digestLength()`
+    /// bytes and must not alias: `traffic_secret` is the HKDF PRK, re-read for
+    /// every output block, so writing the new secret over it in place would
+    /// feed later blocks a mutated key. Callers advancing a secret in place
+    /// derive into a scratch buffer and then replace.
+    pub fn nextTrafficSecret(
+        crypto_provider: provider.CryptoProvider,
+        hash: provider.Hash,
+        traffic_secret: []const u8,
+        out: []u8,
+    ) Error!void {
+        const n = hash.digestLength();
+        if (traffic_secret.len != n or out.len != n) return error.InvalidSecretLength;
+        errdefer provider.secureZero(out);
+        try crypto_provider.hkdfExpandLabel(hash, traffic_secret, "traffic upd", "", out);
+    }
+
     pub fn finishedKey(crypto_provider: provider.CryptoProvider, hash: provider.Hash, traffic_secret: []const u8, out: []u8) Error!void {
         const n = hash.digestLength();
         if (traffic_secret.len != n or out.len != n) return error.InvalidSecretLength;

--- a/src/tls/key_update.zig
+++ b/src/tls/key_update.zig
@@ -80,22 +80,44 @@ pub fn encode(request: Request, out: []u8) EncodeError![]const u8 {
 /// owner of the write state calls; whether to act on it is that owner's
 /// policy, which keeps this module free of any transport concern.
 pub const UsageLimits = struct {
-    /// Advance sending keys once this many records have been sealed under the
-    /// current generation. `null` disables proactive updates entirely, which
-    /// is the default: an endpoint is always free to never send a `KeyUpdate`,
-    /// and turning it on by default would change the wire behavior of every
-    /// existing connection.
+    /// The most records one generation of sending keys may protect, *counting
+    /// the `KeyUpdate` that retires it*. `null` disables proactive updates
+    /// entirely, which is the default: an endpoint is always free to never
+    /// send a `KeyUpdate`, and turning it on by default would change the wire
+    /// behavior of every existing connection.
+    ///
+    /// This is a cap on the generation, not a count at which to start
+    /// thinking about one — see `reached`, which fires a record early so that
+    /// the `KeyUpdate` fits underneath the cap rather than exceeding it.
     records: ?u64 = null,
 
     /// RFC 8446 §5.5's AES-GCM record limit (2^24.5, rounded down to a whole
     /// number of records). Callers opting into proactive updates should pick a
     /// value at or below this; it is offered as a named constant rather than a
     /// default so the choice stays explicit at the call site.
+    ///
+    /// Safe to pass straight to `records`: `reached` reserves the control
+    /// record, so a caller writing the RFC's own number gets the RFC's own
+    /// guarantee without having to subtract anything themselves.
     pub const aes_gcm_record_limit: u64 = 23_726_566;
 
+    /// Whether `records_sealed` records under the current generation is enough
+    /// to act on.
+    ///
+    /// Fires one record *before* the configured cap, because acting on it is
+    /// not free: `requestKeyUpdate` must seal the `KeyUpdate` itself under the
+    /// keys it is retiring (RFC 8446 §4.6.3 — the message announcing a
+    /// transition is protected by the generation it ends), so that message is
+    /// one more record against the old keys. Firing at the cap itself would
+    /// let the retiring generation protect `records + 1` records, which is
+    /// precisely the bound the caller asked not to cross.
+    ///
+    /// Saturating rather than wrapping: a nonsensical `records = 0` is due
+    /// immediately instead of underflowing into a limit of `2^64 - 1`, which
+    /// would silently disable the policy it was meant to enforce.
     pub fn reached(self: UsageLimits, records_sealed: u64) bool {
         const limit = self.records orelse return false;
-        return records_sealed >= limit;
+        return records_sealed >= limit -| 1;
     }
 };
 
@@ -136,8 +158,42 @@ test "usage limits stay inert until configured" {
     try std.testing.expect(!off.reached(0));
     try std.testing.expect(!off.reached(std.math.maxInt(u64)));
 
+    // A cap of 4 becomes due at 3 sealed records: the KeyUpdate is then the
+    // 4th and final record the retiring generation protects.
     const on: UsageLimits = .{ .records = 4 };
-    try std.testing.expect(!on.reached(3));
+    try std.testing.expect(!on.reached(2));
+    try std.testing.expect(on.reached(3));
     try std.testing.expect(on.reached(4));
-    try std.testing.expect(on.reached(5));
+}
+
+test "the AES-GCM cap leaves room for the KeyUpdate that retires the generation" {
+    // The property the constant exists for: a caller who configures RFC 8446
+    // §5.5's own number must never let the retiring keys protect more records
+    // than it names. Since `requestKeyUpdate` seals the KeyUpdate under those
+    // same old keys, becoming due at the cap itself would make that message
+    // the (limit + 1)-th record -- one past the bound.
+    const policy: UsageLimits = .{ .records = UsageLimits.aes_gcm_record_limit };
+    try std.testing.expect(!policy.reached(UsageLimits.aes_gcm_record_limit - 2));
+    try std.testing.expect(policy.reached(UsageLimits.aes_gcm_record_limit - 1));
+    // Acting the moment it is due seals the KeyUpdate as record number
+    // `aes_gcm_record_limit`, the last one permitted -- not the first one
+    // beyond it.
+    try std.testing.expectEqual(
+        UsageLimits.aes_gcm_record_limit,
+        (UsageLimits.aes_gcm_record_limit - 1) + 1,
+    );
+}
+
+test "a degenerate zero cap is due immediately rather than underflowing" {
+    // `0 -| 1` saturates to 0, so this reports due at once. Wrapping would
+    // have produced a limit of 2^64 - 1 and silently disabled the policy.
+    const zero: UsageLimits = .{ .records = 0 };
+    try std.testing.expect(zero.reached(0));
+
+    const one: UsageLimits = .{ .records = 1 };
+    try std.testing.expect(one.reached(0));
+
+    const huge: UsageLimits = .{ .records = std.math.maxInt(u64) };
+    try std.testing.expect(!huge.reached(std.math.maxInt(u64) - 2));
+    try std.testing.expect(huge.reached(std.math.maxInt(u64) - 1));
 }

--- a/src/tls/key_update.zig
+++ b/src/tls/key_update.zig
@@ -1,0 +1,143 @@
+//! TLS 1.3 post-handshake `KeyUpdate` (RFC 8446 §4.6.3).
+//!
+//! This module owns only the message's wire form and the local policy for
+//! *when* an endpoint should ask for a proactive update. It has no record,
+//! socket, QUIC, or key-schedule types: the secret advancement itself is
+//! `key_schedule.KeySchedule.nextTrafficSecret`, and applying that to live
+//! traffic keys is `record_epoch_bridge`.
+//!
+//! `KeyUpdate` is record-mode-only. RFC 9001 §6 removes it from TLS-over-QUIC
+//! entirely — QUIC carries its own key phase in the packet header — so a QUIC
+//! endpoint that receives one must abort with `unexpected_message`. That
+//! rejection lives at the transport seam that knows which profile is in use
+//! (`tls13_backend.onKeyUpdate`), not here.
+//!
+//! `KeyUpdate` is deliberately *not* fed to the handshake transcript. The
+//! message has no transcript-derived output of its own, every transcript-bound
+//! secret this implementation derives is fixed no later than the client's
+//! Finished, and mainstream implementations (OpenSSL, BoringSSL) leave it out
+//! as well — hashing it in would desynchronize the transcript against any peer
+//! that does not.
+
+const std = @import("std");
+const messages = @import("messages.zig");
+
+/// `KeyUpdateRequest` (RFC 8446 §4.6.3). The value tells the receiver whether
+/// it must respond with a `KeyUpdate` of its own.
+pub const Request = enum(u8) {
+    /// The sender advanced its own sending keys and wants nothing back.
+    update_not_requested = 0,
+    /// The sender advanced its own sending keys and asks the peer to advance
+    /// *its* sending keys too, replying with `update_not_requested`.
+    update_requested = 1,
+};
+
+/// `KeyUpdate`'s body is a single `KeyUpdateRequest` byte.
+pub const body_len = 1;
+/// Framed message length: 1-byte type + 3-byte length + `body_len`.
+pub const message_len = 4 + body_len;
+
+/// RFC 8446 §4.6.3 separates the two ways a `KeyUpdate` can be wrong, and the
+/// alerts differ, so the decoder does too:
+///
+///   * a body that is not exactly one byte is a framing failure
+///     (`decode_error`), and
+///   * a well-framed body carrying a value outside `KeyUpdateRequest` is a
+///     semantic failure the RFC names explicitly: "If an implementation
+///     receives any other value, it MUST terminate the connection with an
+///     `illegal_parameter` alert."
+pub const DecodeError = error{ MalformedHandshake, IllegalParameter };
+pub const EncodeError = error{HandshakeBufferOverflow};
+
+/// Decodes a `KeyUpdate` *body* (the bytes after the 4-byte handshake header).
+pub fn decode(body: []const u8) DecodeError!Request {
+    if (body.len != body_len) return error.MalformedHandshake;
+    return std.enums.fromInt(Request, body[0]) orelse error.IllegalParameter;
+}
+
+/// Encodes a complete framed `KeyUpdate` handshake message into `out`.
+pub fn encode(request: Request, out: []u8) EncodeError![]const u8 {
+    const body = [body_len]u8{@intFromEnum(request)};
+    return messages.encode(.key_update, &body, out) catch |err| switch (err) {
+        error.HandshakeBufferOverflow => error.HandshakeBufferOverflow,
+        // `body` is one byte, so neither the message-length nor the
+        // extension-shaped failures `messages.encode` declares can occur.
+        else => unreachable,
+    };
+}
+
+/// When to advance sending keys without being asked.
+///
+/// RFC 8446 §5.5 bounds how much traffic a single set of record keys may
+/// protect, and the bound is per-suite (AES-GCM's is the record count at which
+/// its confidentiality/integrity margins are still acceptable). This type is
+/// the hook the record layer consults; it deliberately expresses the limit in
+/// *records sealed*, which is exactly `record_protection.WriteState.sequence`,
+/// so no separate accounting can drift away from the sequence number that
+/// actually feeds the per-record nonce.
+///
+/// Nothing here schedules an update on its own. `reached` is a predicate the
+/// owner of the write state calls; whether to act on it is that owner's
+/// policy, which keeps this module free of any transport concern.
+pub const UsageLimits = struct {
+    /// Advance sending keys once this many records have been sealed under the
+    /// current generation. `null` disables proactive updates entirely, which
+    /// is the default: an endpoint is always free to never send a `KeyUpdate`,
+    /// and turning it on by default would change the wire behavior of every
+    /// existing connection.
+    records: ?u64 = null,
+
+    /// RFC 8446 §5.5's AES-GCM record limit (2^24.5, rounded down to a whole
+    /// number of records). Callers opting into proactive updates should pick a
+    /// value at or below this; it is offered as a named constant rather than a
+    /// default so the choice stays explicit at the call site.
+    pub const aes_gcm_record_limit: u64 = 23_726_566;
+
+    pub fn reached(self: UsageLimits, records_sealed: u64) bool {
+        const limit = self.records orelse return false;
+        return records_sealed >= limit;
+    }
+};
+
+test "decode accepts both defined request values" {
+    try std.testing.expectEqual(Request.update_not_requested, try decode(&.{0}));
+    try std.testing.expectEqual(Request.update_requested, try decode(&.{1}));
+}
+
+test "decode separates framing failures from illegal request values" {
+    // Wrong body length is a framing failure -> decode_error.
+    try std.testing.expectError(error.MalformedHandshake, decode(&.{}));
+    try std.testing.expectError(error.MalformedHandshake, decode(&.{ 0, 0 }));
+    // Well-framed but undefined value -> illegal_parameter (RFC 8446 §4.6.3).
+    var value: u16 = 2;
+    while (value <= 255) : (value += 1) {
+        try std.testing.expectError(error.IllegalParameter, decode(&.{@intCast(value)}));
+    }
+}
+
+test "encode produces the framed message decode round-trips" {
+    for ([_]Request{ .update_not_requested, .update_requested }) |request| {
+        var buf: [message_len]u8 = undefined;
+        const framed = try encode(request, &buf);
+        try std.testing.expectEqual(@as(usize, message_len), framed.len);
+        const message = try messages.decode(framed);
+        try std.testing.expectEqual(messages.MessageType.key_update, message.kind);
+        try std.testing.expectEqual(request, try decode(message.body));
+    }
+}
+
+test "encode rejects a buffer that cannot hold the framed message" {
+    var buf: [message_len - 1]u8 = undefined;
+    try std.testing.expectError(error.HandshakeBufferOverflow, encode(.update_requested, &buf));
+}
+
+test "usage limits stay inert until configured" {
+    const off: UsageLimits = .{};
+    try std.testing.expect(!off.reached(0));
+    try std.testing.expect(!off.reached(std.math.maxInt(u64)));
+
+    const on: UsageLimits = .{ .records = 4 };
+    try std.testing.expect(!on.reached(3));
+    try std.testing.expect(on.reached(4));
+    try std.testing.expect(on.reached(5));
+}

--- a/src/tls/record_epoch_bridge.zig
+++ b/src/tls/record_epoch_bridge.zig
@@ -12,14 +12,16 @@ const crypto = @import("crypto");
 const algorithms = @import("algorithms.zig");
 const engine = @import("engine.zig");
 const events = @import("events.zig");
+const key_schedule = @import("key_schedule.zig");
 const record_codec = @import("record_codec.zig");
 const record_protection = @import("record_protection.zig");
 const tls_state = @import("state.zig");
 const transport = @import("transport.zig");
 
 const provider = crypto.provider;
+const secrets = crypto.secrets;
 
-pub const Error = record_codec.Error || record_protection.Error || error{
+pub const Error = record_codec.Error || record_protection.Error || key_schedule.Error || error{
     UnsupportedRecordEpoch,
     DuplicateTrafficSecret,
     MissingReadKeys,
@@ -30,7 +32,20 @@ pub const Error = record_codec.Error || record_protection.Error || error{
     UnexpectedRecordContent,
     EpochAlreadyDiscarded,
     EpochDiscardTooEarly,
+    /// A `KeyUpdate` arrived for a direction whose application traffic secret
+    /// is not (or no longer) retained, so the `"traffic upd"` chain cannot be
+    /// advanced. Distinct from `MissingApplicationKeys`: the derived record
+    /// keys may well still exist — it is the *secret* they came from that is
+    /// gone, which is exactly the state an orderly discard leaves behind.
+    MissingTrafficSecret,
 };
+
+/// One direction's retained application traffic secret, kept alongside the
+/// derived record keys purely so `KeyUpdate` can walk RFC 8446 §7.2's
+/// `"traffic upd"` chain (#357). Handshake- and 0-RTT-epoch secrets are never
+/// retained: neither epoch can be updated, so keeping their secrets past key
+/// derivation would extend their lifetime for no protocol reason.
+const TrafficSecret = secrets.FixedSecret(provider.max_digest_len);
 
 pub const OpenedRecord = struct {
     epoch: events.EncryptionEpoch,
@@ -53,6 +68,17 @@ pub const Bridge = struct {
     write_zero_rtt: ?record_protection.WriteState = null,
     read_application: ?record_protection.ReadState = null,
     write_application: ?record_protection.WriteState = null,
+    /// Retained application traffic secrets, the input to the next `KeyUpdate`
+    /// (#357). Kept per direction because each direction advances its own
+    /// chain independently and at its own time.
+    read_application_secret: TrafficSecret = .{},
+    write_application_secret: TrafficSecret = .{},
+    /// How many times each direction has advanced past the handshake's
+    /// original application traffic secret (0 = `application_traffic_secret_0`).
+    /// Observable state, not a limit: it lets a caller — and this module's
+    /// tests — tell "the keys changed" from "the same keys were reinstalled".
+    read_key_generation: u64 = 0,
+    write_key_generation: u64 = 0,
     read_phase: DirectionPhase = .initial,
     write_phase: DirectionPhase = .initial,
     initial_discarded: bool = false,
@@ -94,6 +120,8 @@ pub const Bridge = struct {
         clearWrite(&self.write_zero_rtt);
         clearRead(&self.read_application);
         clearWrite(&self.write_application);
+        self.read_application_secret.deinit();
+        self.write_application_secret.deinit();
         self.initial_discarded = true;
         self.handshake_discarded = true;
         self.application_discarded = true;
@@ -113,6 +141,12 @@ pub const Bridge = struct {
             .negotiated_parameters, .early_data_parameters => |params| self.cipher_suite = algorithms.fromInt(algorithms.CipherSuite, params.cipher_suite) orelse
                 return error.UnsupportedRecordEpoch,
             .traffic_secret => |traffic_secret| try self.installTrafficSecret(traffic_secret.epoch, traffic_secret.direction, traffic_secret.data),
+            // Ordering is the protocol here (`events.KeyUpdate`): this arrives
+            // after the peer's `KeyUpdate` was opened (`.read`) or after our
+            // own was sealed by the `handshake_bytes` arm above (`.write`), so
+            // applying it in event order is what puts the boundary in the
+            // right place.
+            .key_update => |update| try self.updateTrafficSecret(update.direction),
             .discard_epoch => |epoch| try self.discardEpoch(epoch),
             .handshake_complete => try self.markHandshakeComplete(),
             .alpn,
@@ -148,11 +182,16 @@ pub const Bridge = struct {
                 .read => {
                     if (self.read_phase != .handshake or self.handshake_discarded or self.application_discarded) return error.InvalidEpochTransition;
                     try self.installRead(&self.read_application, traffic_secret);
+                    // Retained only after the keys derived successfully, so a
+                    // failed install never leaves a secret behind that a later
+                    // `KeyUpdate` could advance off of.
+                    self.read_application_secret.replace(traffic_secret) catch return error.InvalidTrafficSecretLength;
                     self.read_phase = .application;
                 },
                 .write => {
                     if (self.write_phase != .handshake or self.handshake_discarded or self.application_discarded) return error.InvalidEpochTransition;
                     try self.installWrite(&self.write_application, traffic_secret);
+                    self.write_application_secret.replace(traffic_secret) catch return error.InvalidTrafficSecretLength;
                     self.write_phase = .application;
                 },
             },
@@ -200,6 +239,8 @@ pub const Bridge = struct {
                 }
                 clearRead(&self.read_application);
                 clearWrite(&self.write_application);
+                self.read_application_secret.deinit();
+                self.write_application_secret.deinit();
                 self.application_discarded = true;
                 self.read_phase = .initial;
                 self.write_phase = .initial;
@@ -227,6 +268,75 @@ pub const Bridge = struct {
         self.handshake_complete = true;
         self.read_phase = .complete;
         self.write_phase = .complete;
+    }
+
+    /// Advances `direction`'s application traffic secret one step along RFC
+    /// 8446 §7.2's chain and rebuilds that direction's record keys from it
+    /// (#357).
+    ///
+    /// The transition is all-or-nothing. The new secret and the new keys are
+    /// both derived into scratch *before* anything installed is touched, so a
+    /// provider failure anywhere leaves the direction still protecting traffic
+    /// under the generation it had — a half-updated direction would be
+    /// undecryptable in both generations at once.
+    ///
+    /// On success the previous keys are zeroized (`WriteState.deinit`/
+    /// `ReadState.deinit` wipe their `TrafficKeys`), the previous secret is
+    /// overwritten in place by `FixedSecret.replace`, and the record sequence
+    /// restarts at zero — RFC 8446 §5.3's requirement, since the nonce is the
+    /// static IV XOR the sequence and a fresh key must not reuse a nonce that
+    /// key never used, but also must start counting again rather than carry
+    /// the old count forward.
+    ///
+    /// Only the application epoch can be updated, and only on a live,
+    /// completed, not-torn-down session: `KeyUpdate` is defined solely as a
+    /// post-handshake message, so a pre-handshake or post-teardown call is a
+    /// state error rather than a no-op.
+    pub fn updateTrafficSecret(self: *Bridge, direction: events.SecretDirection) Error!void {
+        if (self.torn_down or self.application_discarded) return error.InvalidEpochTransition;
+        if (!self.handshake_complete) return error.HandshakeNotComplete;
+
+        const hash = record_protection.suiteProfile(self.cipher_suite).hash;
+        var next: [provider.max_digest_len]u8 = undefined;
+        defer provider.secureZero(&next);
+        const digest_len = hash.digestLength();
+
+        switch (direction) {
+            .read => {
+                const state = self.readApplication() orelse return error.MissingReadKeys;
+                const current = self.read_application_secret.slice();
+                if (current.len == 0) return error.MissingTrafficSecret;
+                try key_schedule.KeySchedule.nextTrafficSecret(self.crypto_provider, hash, current, next[0..digest_len]);
+                var keys = try record_protection.TrafficKeys.derive(self.crypto_provider, self.cipher_suite, next[0..digest_len]);
+                errdefer keys.deinit();
+                self.read_application_secret.replace(next[0..digest_len]) catch return error.InvalidTrafficSecretLength;
+                state.deinit();
+                state.* = record_protection.ReadState.init(self.crypto_provider, keys);
+                self.read_key_generation += 1;
+            },
+            .write => {
+                const state = self.writeApplication() orelse return error.MissingWriteKeys;
+                const current = self.write_application_secret.slice();
+                if (current.len == 0) return error.MissingTrafficSecret;
+                try key_schedule.KeySchedule.nextTrafficSecret(self.crypto_provider, hash, current, next[0..digest_len]);
+                var keys = try record_protection.TrafficKeys.derive(self.crypto_provider, self.cipher_suite, next[0..digest_len]);
+                errdefer keys.deinit();
+                self.write_application_secret.replace(next[0..digest_len]) catch return error.InvalidTrafficSecretLength;
+                state.deinit();
+                state.* = record_protection.WriteState.init(self.crypto_provider, keys);
+                self.write_key_generation += 1;
+            },
+        }
+    }
+
+    /// Records sealed under the current write generation — i.e. the write
+    /// state's next sequence number, which a `KeyUpdate` reset to zero. This
+    /// is the input `key_update.UsageLimits.reached` is written against, kept
+    /// as an accessor rather than a mirrored counter so proactive-update
+    /// policy can never disagree with the sequence feeding the record nonce.
+    pub fn applicationRecordsSealed(self: *const Bridge) u64 {
+        const state = self.write_application orelse return 0;
+        return state.sequence;
     }
 
     pub fn sealHandshake(self: *Bridge, epoch: events.EncryptionEpoch, bytes: []const u8, out: []u8) Error![]const u8 {
@@ -1085,6 +1195,10 @@ test "record epoch bridge shuttles protocol-neutral driver events through record
                     .early_data_parameters => |params| {
                         var scratch: [1]u8 = undefined;
                         _ = try sender_bridge.applyEvent(.{ .early_data_parameters = params }, &scratch);
+                    },
+                    .key_update => |update| {
+                        var scratch: [1]u8 = undefined;
+                        _ = try sender_bridge.applyEvent(.{ .key_update = update }, &scratch);
                     },
                     .peer_transport_parameters,
                     .alpn,
@@ -1972,4 +2086,298 @@ test "record epoch bridge cannot reinstall zero-rtt keys after teardown" {
     defer fresh.deinit();
     try fresh.installTrafficSecret(.zero_rtt, .write, &early);
     try testing.expect(fresh.hasWriteKeys(.zero_rtt));
+}
+
+// ── KeyUpdate: application traffic secret advancement (#357) ────────────────
+
+/// A bridge pair carried to a completed handshake with the given application
+/// secrets, so a `KeyUpdate` test starts from the only state `KeyUpdate` is
+/// ever legal in. `a`'s write secret is `b`'s read secret and vice versa,
+/// which is what makes an update on one side observable on the other.
+fn establishedPair(
+    a: *Bridge,
+    b: *Bridge,
+    a_to_b: []const u8,
+    b_to_a: []const u8,
+) !void {
+    const hs_a_to_b = secret(0x01);
+    const hs_b_to_a = secret(0x02);
+    for ([_]struct { bridge: *Bridge, write: []const u8, read: []const u8 }{
+        .{ .bridge = a, .write = &hs_a_to_b, .read = &hs_b_to_a },
+        .{ .bridge = b, .write = &hs_b_to_a, .read = &hs_a_to_b },
+    }) |side| {
+        try side.bridge.installTrafficSecret(.handshake, .write, side.write);
+        try side.bridge.installTrafficSecret(.handshake, .read, side.read);
+    }
+    try a.installTrafficSecret(.application, .write, a_to_b);
+    try a.installTrafficSecret(.application, .read, b_to_a);
+    try b.installTrafficSecret(.application, .write, b_to_a);
+    try b.installTrafficSecret(.application, .read, a_to_b);
+    for ([_]*Bridge{ a, b }) |bridge| {
+        try bridge.discardEpoch(.initial);
+        try bridge.discardEpoch(.handshake);
+        try bridge.markHandshakeComplete();
+    }
+}
+
+/// RFC 8446 §7.2's `"traffic upd"` step, computed independently of the module
+/// under test so a test cannot pass by agreeing with a wrong implementation.
+fn expectedNextSecret(current: [32]u8) [32]u8 {
+    const HkdfSha256 = std.crypto.kdf.hkdf.HkdfSha256;
+    return std.crypto.tls.hkdfExpandLabel(HkdfSha256, current, "traffic upd", "", 32);
+}
+
+fn sealOne(bridge: *Bridge, plaintext: []const u8, out: []u8) ![]const u8 {
+    return bridge.sealApplicationData(plaintext, out);
+}
+
+test "key update advances one direction along the RFC 8446 traffic-upd chain" {
+    const cp = testProvider();
+    var client = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+    var server = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer server.deinit();
+    const c2s = secret(0x33);
+    const s2c = secret(0x44);
+    try establishedPair(&client, &server, &c2s, &s2c);
+
+    // The client updates its *sending* keys; the server updates the matching
+    // *receiving* keys. Every other direction is untouched -- a one-way
+    // update must not disturb the reverse direction's chain.
+    try client.updateTrafficSecret(.write);
+    try server.updateTrafficSecret(.read);
+
+    const expected = expectedNextSecret(c2s);
+    try testing.expectEqualSlices(u8, &expected, client.write_application_secret.slice());
+    try testing.expectEqualSlices(u8, &expected, server.read_application_secret.slice());
+    try expectAes128TrafficKeys(expected, client.write_application.?.keys);
+    try expectAes128TrafficKeys(expected, server.read_application.?.keys);
+
+    // The reverse direction stayed on generation 0.
+    try testing.expectEqualSlices(u8, &s2c, server.write_application_secret.slice());
+    try testing.expectEqualSlices(u8, &s2c, client.read_application_secret.slice());
+    try testing.expectEqual(@as(u64, 1), client.write_key_generation);
+    try testing.expectEqual(@as(u64, 1), server.read_key_generation);
+    try testing.expectEqual(@as(u64, 0), client.read_key_generation);
+    try testing.expectEqual(@as(u64, 0), server.write_key_generation);
+
+    // Traffic still flows, under the new keys, in both directions.
+    var protected: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    const forward = try parseSingleRecord(.ciphertext, try sealOne(&client, "after update", &protected));
+    try testing.expectEqualStrings("after update", (try server.openApplicationData(forward, &plaintext)).inner.content);
+    const back = try parseSingleRecord(.ciphertext, try sealOne(&server, "still fine", &protected));
+    try testing.expectEqualStrings("still fine", (try client.openApplicationData(back, &plaintext)).inner.content);
+}
+
+test "key update restarts the record sequence and retires the previous keys" {
+    const cp = testProvider();
+    var client = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+    var server = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer server.deinit();
+    const c2s = secret(0x51);
+    const s2c = secret(0x52);
+    try establishedPair(&client, &server, &c2s, &s2c);
+
+    var protected: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+
+    // Move both sides off sequence zero so the reset is observable as a
+    // change rather than as a value that happened to already hold.
+    for (0..3) |_| {
+        const record = try parseSingleRecord(.ciphertext, try sealOne(&client, "pre", &protected));
+        _ = try server.openApplicationData(record, &plaintext);
+    }
+    try testing.expectEqual(@as(u64, 3), client.write_application.?.sequence);
+    try testing.expectEqual(@as(u64, 3), server.read_application.?.sequence);
+
+    // A record sealed under the old keys, captured *before* the transition.
+    var stale_buf: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    const stale_bytes = try sealOne(&client, "old generation", &stale_buf);
+    var stale_copy: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    @memcpy(stale_copy[0..stale_bytes.len], stale_bytes);
+    const stale = try parseSingleRecord(.ciphertext, stale_copy[0..stale_bytes.len]);
+
+    try client.updateTrafficSecret(.write);
+    try server.updateTrafficSecret(.read);
+
+    // RFC 8446 §5.3: the new key starts counting from zero again.
+    try testing.expectEqual(@as(u64, 0), client.write_application.?.sequence);
+    try testing.expectEqual(@as(u64, 0), server.read_application.?.sequence);
+
+    // The old keys are gone on the receiving side: a record sealed under the
+    // previous generation no longer authenticates.
+    try testing.expectError(error.AuthenticationFailed, server.openApplicationData(stale, &plaintext));
+
+    // ...and sequence semantics resume normally from the new zero.
+    const fresh = try parseSingleRecord(.ciphertext, try sealOne(&client, "new generation", &protected));
+    try testing.expectEqualStrings("new generation", (try server.openApplicationData(fresh, &plaintext)).inner.content);
+    try testing.expectEqual(@as(u64, 1), client.write_application.?.sequence);
+    try testing.expectEqual(@as(u64, 1), server.read_application.?.sequence);
+}
+
+test "repeated key updates keep both directions walking the same chain" {
+    const cp = testProvider();
+    var client = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+    var server = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer server.deinit();
+    const c2s = secret(0x61);
+    const s2c = secret(0x62);
+    try establishedPair(&client, &server, &c2s, &s2c);
+
+    var protected: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    var expected_c2s = c2s;
+    var expected_s2c = s2c;
+
+    // Simultaneous updates: each round advances both directions, which is the
+    // state two endpoints reach when their updates cross on the wire.
+    for (1..9) |round| {
+        try client.updateTrafficSecret(.write);
+        try server.updateTrafficSecret(.read);
+        try server.updateTrafficSecret(.write);
+        try client.updateTrafficSecret(.read);
+        expected_c2s = expectedNextSecret(expected_c2s);
+        expected_s2c = expectedNextSecret(expected_s2c);
+
+        try testing.expectEqualSlices(u8, &expected_c2s, client.write_application_secret.slice());
+        try testing.expectEqualSlices(u8, &expected_c2s, server.read_application_secret.slice());
+        try testing.expectEqualSlices(u8, &expected_s2c, server.write_application_secret.slice());
+        try testing.expectEqualSlices(u8, &expected_s2c, client.read_application_secret.slice());
+        try testing.expectEqual(round, client.write_key_generation);
+        try testing.expectEqual(round, client.read_key_generation);
+
+        const forward = try parseSingleRecord(.ciphertext, try sealOne(&client, "c2s", &protected));
+        try testing.expectEqualStrings("c2s", (try server.openApplicationData(forward, &plaintext)).inner.content);
+        const back = try parseSingleRecord(.ciphertext, try sealOne(&server, "s2c", &protected));
+        try testing.expectEqualStrings("s2c", (try client.openApplicationData(back, &plaintext)).inner.content);
+    }
+}
+
+test "a direction that skipped an update cannot read the peer's next generation" {
+    // The chain is one-way and per-direction: falling one step behind is not
+    // recoverable by the record layer, which is exactly why the transition
+    // point has to be exact rather than approximately right.
+    const cp = testProvider();
+    var client = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+    var server = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer server.deinit();
+    const c2s = secret(0x71);
+    const s2c = secret(0x72);
+    try establishedPair(&client, &server, &c2s, &s2c);
+
+    try client.updateTrafficSecret(.write);
+    var protected: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    const record = try parseSingleRecord(.ciphertext, try sealOne(&client, "generation 1", &protected));
+    try testing.expectError(error.AuthenticationFailed, server.openApplicationData(record, &plaintext));
+}
+
+test "key update replaces key material without leaving the previous generation in the bridge" {
+    const cp = testProvider();
+    var client = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+    var server = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer server.deinit();
+    const c2s = secret(0x81);
+    const s2c = secret(0x82);
+    try establishedPair(&client, &server, &c2s, &s2c);
+
+    var old_secret: [32]u8 = undefined;
+    @memcpy(&old_secret, client.write_application_secret.slice());
+    var old_key: [16]u8 = undefined;
+    @memcpy(&old_key, client.write_application.?.keys.key.slice());
+    var old_iv: [provider.aead_nonce_len]u8 = undefined;
+    @memcpy(&old_iv, client.write_application.?.keys.iv.slice());
+
+    try client.updateTrafficSecret(.write);
+
+    // Every byte string the previous generation consisted of must be absent
+    // from the bridge's entire footprint -- not merely absent from the slot it
+    // used to occupy, which a "keep the old keys for late records" change
+    // would still satisfy while leaving retired material live.
+    const footprint = std.mem.asBytes(&client);
+    try testing.expect(std.mem.indexOf(u8, footprint, &old_secret) == null);
+    try testing.expect(std.mem.indexOf(u8, footprint, &old_key) == null);
+    try testing.expect(std.mem.indexOf(u8, footprint, &old_iv) == null);
+    // The new generation is present, so the search above is a real search.
+    try testing.expect(std.mem.indexOf(u8, footprint, &expectedNextSecret(c2s)) != null);
+
+    // Teardown after an update still wipes whatever generation is current.
+    var current_secret: [32]u8 = undefined;
+    @memcpy(&current_secret, client.write_application_secret.slice());
+    client.deinit();
+    try testing.expect(std.mem.indexOf(u8, footprint, &current_secret) == null);
+    try testing.expect(client.write_application == null);
+    try testing.expectEqual(@as(usize, 0), client.write_application_secret.slice().len);
+}
+
+test "key update is rejected outside a live, completed application epoch" {
+    const cp = testProvider();
+
+    // Before the handshake completes there is no application epoch to update.
+    var early = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer early.deinit();
+    try testing.expectError(error.HandshakeNotComplete, early.updateTrafficSecret(.write));
+    try testing.expectError(error.HandshakeNotComplete, early.updateTrafficSecret(.read));
+    const hs = secret(0x91);
+    try early.installTrafficSecret(.handshake, .write, &hs);
+    try early.installTrafficSecret(.handshake, .read, &hs);
+    try testing.expectError(error.HandshakeNotComplete, early.updateTrafficSecret(.write));
+    const app = secret(0x92);
+    try early.installTrafficSecret(.application, .write, &app);
+    try early.installTrafficSecret(.application, .read, &app);
+    // Application keys exist, but `handshake_complete` has not been marked --
+    // `KeyUpdate` is post-handshake by definition, so key presence alone is
+    // not enough.
+    try testing.expectError(error.HandshakeNotComplete, early.updateTrafficSecret(.write));
+
+    // After teardown the session is over in both directions.
+    var torn = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    var peer = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer peer.deinit();
+    const c2s = secret(0x93);
+    const s2c = secret(0x94);
+    try establishedPair(&torn, &peer, &c2s, &s2c);
+    try torn.updateTrafficSecret(.write);
+    torn.deinit();
+    try testing.expectError(error.InvalidEpochTransition, torn.updateTrafficSecret(.write));
+    try testing.expectError(error.InvalidEpochTransition, torn.updateTrafficSecret(.read));
+
+    // Orderly application-epoch discard is teardown too, and drops the
+    // retained secrets along with the keys.
+    var closed = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer closed.deinit();
+    var closed_peer = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer closed_peer.deinit();
+    try establishedPair(&closed, &closed_peer, &c2s, &s2c);
+    try closed.discardEpoch(.application);
+    try testing.expectEqual(@as(usize, 0), closed.write_application_secret.slice().len);
+    try testing.expectError(error.InvalidEpochTransition, closed.updateTrafficSecret(.write));
+}
+
+test "applicationRecordsSealed tracks the current generation's sequence for usage limits" {
+    const cp = testProvider();
+    var client = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+    var server = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer server.deinit();
+    const c2s = secret(0xa1);
+    const s2c = secret(0xa2);
+
+    // No application keys yet: nothing has been sealed.
+    try testing.expectEqual(@as(u64, 0), client.applicationRecordsSealed());
+    try establishedPair(&client, &server, &c2s, &s2c);
+    try testing.expectEqual(@as(u64, 0), client.applicationRecordsSealed());
+
+    var protected: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    for (0..5) |_| _ = try sealOne(&client, "x", &protected);
+    try testing.expectEqual(@as(u64, 5), client.applicationRecordsSealed());
+    // The counter is the write sequence itself, so an update resets it with
+    // the sequence rather than tracking a lifetime total.
+    try client.updateTrafficSecret(.write);
+    try testing.expectEqual(@as(u64, 0), client.applicationRecordsSealed());
 }

--- a/src/tls/root.zig
+++ b/src/tls/root.zig
@@ -12,6 +12,7 @@ pub const events = @import("events.zig");
 pub const algorithms = @import("algorithms.zig");
 pub const crypto_profile = @import("crypto_profile.zig");
 pub const key_schedule = @import("key_schedule.zig");
+pub const key_update = @import("key_update.zig");
 pub const messages = @import("messages.zig");
 pub const new_session_ticket = @import("new_session_ticket.zig");
 pub const negotiation = @import("negotiation.zig");

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -175,18 +175,26 @@ const PostHandshakeInput = struct {
                 }
                 const body_len: usize = @intCast(std.mem.readInt(u24, self.header[1..4], .big));
                 const frame_len = handshake_header_len + body_len;
-                if (frame_len > max_new_session_ticket_message_len) return error.HandshakeBufferOverflow;
                 // `KeyUpdate` has exactly one legal framed length (RFC 8446
-                // §4.6.3, #357). Rejecting a wrong declared length here —
-                // before a buffer is chosen — does two things: it keeps the
-                // failure a framing error whether or not this endpoint
-                // configured a post-handshake allocator (otherwise an
-                // over-long body would fall to the allocator path and be
-                // reported as a missing allocator instead), and it declines to
-                // buffer an attacker-chosen length for a five-byte message.
+                // §4.6.3, #357), so its own length check runs *before* the
+                // generic post-handshake size cap below — the message type is
+                // already known from the header, and type-specific framing is
+                // the more precise classification.
+                //
+                // Order matters for two reasons beyond tidiness. The cap
+                // raises `HandshakeBufferOverflow`, which `mappedFatalAlert`
+                // does not map, so a `KeyUpdate` declaring a body past the cap
+                // would terminate locally with no `decode_error` alert on the
+                // wire. And checking here — before a buffer is chosen — is
+                // what makes the failure class independent of whether this
+                // endpoint configured a post-handshake allocator, rather than
+                // an over-long body falling to the allocator path and
+                // surfacing as a missing allocator instead. Every non-1-byte
+                // body is a framing error, at every declared length.
                 if (self.header[0] == @intFromEnum(MessageType.key_update) and frame_len != key_update.message_len) {
                     return error.MalformedHandshake;
                 }
+                if (frame_len > max_new_session_ticket_message_len) return error.HandshakeBufferOverflow;
                 if (frame_len <= inline_capacity) {
                     self.inline_len = frame_len;
                 } else {

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -29,6 +29,7 @@ const crypto_pkg = @import("crypto");
 const tls_handshake_codec = @import("handshake.zig");
 const hello_retry = @import("hello_retry.zig");
 const tls_key_schedule = @import("key_schedule.zig");
+const key_update = @import("key_update.zig");
 const new_session_ticket = @import("new_session_ticket.zig");
 const pre_shared_key = @import("pre_shared_key.zig");
 const session = @import("session.zig");
@@ -116,8 +117,36 @@ const PostHandshakeInput = struct {
     buf_allocator: ?std.mem.Allocator = null,
     header: [handshake_header_len]u8 = undefined,
     header_len: usize = 0,
+    /// Heap storage, used only for a message too large to reassemble inline.
     buf: []u8 = &.{},
+    /// Frame length when the message fits `inline_buf`, 0 otherwise. Held as
+    /// a length rather than a slice so this struct never contains a pointer
+    /// into itself: `Tls13Backend` values are built in place and assigned by
+    /// value, and a self-referential slice would not survive that.
+    inline_len: usize = 0,
+    inline_buf: [inline_capacity]u8 = undefined,
     len: usize = 0,
+
+    /// Largest post-handshake message reassembled without an allocator.
+    ///
+    /// `KeyUpdate` (#357) is five bytes, and *any* peer may send one on *any*
+    /// completed connection at any time — unlike `NewSessionTicket`, which
+    /// only arrives because this endpoint asked for tickets and therefore
+    /// configured `setPostHandshakeAllocator`. Routing it through the
+    /// allocator too would fail every connection whose owner simply does not
+    /// use tickets, the moment a conforming peer rotates its keys.
+    const inline_capacity = key_update.message_len;
+
+    /// The reassembly frame currently in use, empty when no message has been
+    /// framed yet.
+    fn frame(self: *const PostHandshakeInput) []const u8 {
+        if (self.inline_len > 0) return self.inline_buf[0..self.inline_len];
+        return self.buf;
+    }
+
+    fn capacity(self: *const PostHandshakeInput) usize {
+        return self.frame().len;
+    }
 
     fn setAllocator(self: *PostHandshakeInput, allocator: std.mem.Allocator) HandshakeError!void {
         if (self.buf.len > 0 and !sameAllocator(self.buf_allocator.?, allocator)) return error.InvalidHandshakeState;
@@ -126,16 +155,17 @@ const PostHandshakeInput = struct {
 
     fn deinit(self: *PostHandshakeInput) void {
         if (self.buf.len > 0) crypto_pkg.secrets.secureZeroAndFree(self.buf_allocator.?, self.buf);
+        if (self.inline_len > 0) crypto.secureZero(u8, self.inline_buf[0..self.inline_len]);
         if (self.header_len > 0) crypto.secureZero(u8, self.header[0..self.header_len]);
         self.* = .{};
     }
 
     fn append(self: *PostHandshakeInput, bytes: []const u8) HandshakeError!usize {
-        if (self.buf.len > 0 and self.len == self.buf.len) return 0;
+        if (self.capacity() > 0 and self.len == self.capacity()) return 0;
         var rest = bytes;
         const original_len = bytes.len;
         while (rest.len > 0) {
-            if (self.buf.len == 0) {
+            if (self.capacity() == 0) {
                 if (self.header_len < handshake_header_len) {
                     const take = @min(handshake_header_len - self.header_len, rest.len);
                     @memcpy(self.header[self.header_len..][0..take], rest[0..take]);
@@ -146,33 +176,60 @@ const PostHandshakeInput = struct {
                 const body_len: usize = @intCast(std.mem.readInt(u24, self.header[1..4], .big));
                 const frame_len = handshake_header_len + body_len;
                 if (frame_len > max_new_session_ticket_message_len) return error.HandshakeBufferOverflow;
-                const allocator = self.allocator orelse return error.InvalidHandshakeState;
-                self.buf = allocator.alloc(u8, frame_len) catch return error.CredentialProviderFailed;
-                self.buf_allocator = allocator;
-                @memcpy(self.buf[0..handshake_header_len], &self.header);
+                // `KeyUpdate` has exactly one legal framed length (RFC 8446
+                // §4.6.3, #357). Rejecting a wrong declared length here —
+                // before a buffer is chosen — does two things: it keeps the
+                // failure a framing error whether or not this endpoint
+                // configured a post-handshake allocator (otherwise an
+                // over-long body would fall to the allocator path and be
+                // reported as a missing allocator instead), and it declines to
+                // buffer an attacker-chosen length for a five-byte message.
+                if (self.header[0] == @intFromEnum(MessageType.key_update) and frame_len != key_update.message_len) {
+                    return error.MalformedHandshake;
+                }
+                if (frame_len <= inline_capacity) {
+                    self.inline_len = frame_len;
+                } else {
+                    const allocator = self.allocator orelse return error.InvalidHandshakeState;
+                    self.buf = allocator.alloc(u8, frame_len) catch return error.CredentialProviderFailed;
+                    self.buf_allocator = allocator;
+                }
+                @memcpy(self.writable()[0..handshake_header_len], &self.header);
                 self.len = handshake_header_len;
                 crypto.secureZero(u8, &self.header);
                 self.header_len = 0;
             }
-            const take = @min(self.buf.len - self.len, rest.len);
-            @memcpy(self.buf[self.len..][0..take], rest[0..take]);
+            const take = @min(self.capacity() - self.len, rest.len);
+            @memcpy(self.writable()[self.len..][0..take], rest[0..take]);
             self.len += take;
             rest = rest[take..];
-            if (self.len == self.buf.len) break;
+            if (self.len == self.capacity()) break;
         }
         return original_len - rest.len;
     }
 
+    fn writable(self: *PostHandshakeInput) []u8 {
+        if (self.inline_len > 0) return self.inline_buf[0..self.inline_len];
+        return self.buf;
+    }
+
     fn peek(self: *PostHandshakeInput) tls_handshake_codec.Error!?tls_handshake_codec.Message {
-        if (self.buf.len == 0 or self.len < self.buf.len) return null;
-        return try tls_handshake_codec.decode(self.buf[0..self.len]);
+        const cap = self.capacity();
+        if (cap == 0 or self.len < cap) return null;
+        return try tls_handshake_codec.decode(self.frame()[0..self.len]);
     }
 
     fn discard(self: *PostHandshakeInput, len: usize) tls_handshake_codec.Error!void {
-        if (self.buf.len == 0 or len != self.buf.len) return error.MalformedHandshake;
-        crypto_pkg.secrets.secureZeroAndFree(self.buf_allocator.?, self.buf);
-        self.buf_allocator = null;
-        self.buf = &.{};
+        const cap = self.capacity();
+        if (cap == 0 or len != cap) return error.MalformedHandshake;
+        if (self.inline_len > 0) {
+            crypto.secureZero(u8, self.inline_buf[0..self.inline_len]);
+            self.inline_len = 0;
+        } else {
+            crypto_pkg.secrets.secureZeroAndFree(self.buf_allocator.?, self.buf);
+            self.buf_allocator = null;
+            self.buf = &.{};
+        }
         self.len = 0;
     }
 };
@@ -1537,7 +1594,21 @@ pub const Tls13Backend = struct {
             .earlyDataMaxBytesFn = earlyDataMaxBytesImpl,
             .earlyDataDiscardLimitFn = earlyDataDiscardLimitImpl,
             .helloRetryRequestSentFn = helloRetryRequestSentImpl,
+            // Wired only under the record profile, so `supportsKeyUpdate` is
+            // an honest answer rather than a slot that always exists and then
+            // refuses: RFC 9001 §6 gives TLS-over-QUIC no `KeyUpdate` at all
+            // (#357). `requestKeyUpdate` re-checks the profile anyway, since
+            // it is also reachable directly.
+            .requestKeyUpdateFn = switch (self.profile) {
+                .record => requestKeyUpdateImpl,
+                .extension => null,
+            },
         };
+    }
+
+    fn requestKeyUpdateImpl(ptr: *anyopaque, request: key_update.Request, sink: *EventSink) HandshakeError!void {
+        const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
+        return self.requestKeyUpdate(request, sink);
     }
 
     /// #338: a server has sent a HelloRetryRequest, which it only does after
@@ -2287,7 +2358,7 @@ pub const Tls13Backend = struct {
             .certificate_verify,
             .finished,
             => .handshake,
-            .new_session_ticket => .application,
+            .new_session_ticket, .key_update => .application,
             else => error.UnexpectedHandshakeMessage,
         };
     }
@@ -2428,6 +2499,11 @@ pub const Tls13Backend = struct {
             return;
         }
 
+        if (kind == .key_update) {
+            try self.onKeyUpdate(body, sink);
+            return;
+        }
+
         // Message ordering has already been enforced by `core.acceptReceived`.
         // Dispatch the shared TLS semantics; transport extension contents stay
         // opaque and are consumed by the owning adapter.
@@ -2448,6 +2524,69 @@ pub const Tls13Backend = struct {
             },
             else => return error.UnexpectedHandshakeMessage,
         }
+    }
+
+    /// Post-handshake `KeyUpdate` (RFC 8446 §4.6.3, #357).
+    ///
+    /// Emits `key_update{.read}` so the transport advances its *receiving*
+    /// keys for everything after the record this message arrived in, and — if
+    /// the peer asked — an answering `KeyUpdate` plus `key_update{.write}` for
+    /// its *sending* keys. The answer always carries `update_not_requested`,
+    /// which is what makes the exchange terminate: a reciprocal update cannot
+    /// itself request another, so two endpoints can never trade updates
+    /// indefinitely off a single request.
+    fn onKeyUpdate(self: *Tls13Backend, body: []const u8, sink: *EventSink) HandshakeError!void {
+        // RFC 9001 §6 removes `KeyUpdate` from TLS-over-QUIC: QUIC updates
+        // keys with the packet-header key phase instead, and a QUIC endpoint
+        // receiving this message "MUST terminate the connection with error
+        // code 0x010a" — the `unexpected_message` alert's QUIC equivalent.
+        // Checked before decoding: in QUIC mode the message is illegal
+        // whatever it says, so a malformed body must not turn this into a
+        // decode failure and mask which rule was actually broken.
+        switch (self.profile) {
+            .record => {},
+            .extension => return error.UnexpectedHandshakeMessage,
+        }
+        const request = try key_update.decode(body);
+        try sink.emitKeyUpdate(.read);
+        if (request == .update_requested) {
+            try self.emitKeyUpdateMessage(.update_not_requested, sink);
+        }
+    }
+
+    /// Starts a locally initiated key update: queues a `KeyUpdate` at the
+    /// application epoch and the `key_update{.write}` that advances our
+    /// sending keys behind it.
+    ///
+    /// `request` is the caller's policy. `.update_not_requested` refreshes
+    /// only this endpoint's sending keys; `.update_requested` also obliges the
+    /// peer to refresh its own (RFC 8446 §4.6.3), which is the form a caller
+    /// acting on `key_update.UsageLimits` for the *receiving* direction wants,
+    /// since only the peer can advance the keys we read under.
+    ///
+    /// Record mode only, and only once the handshake is complete — `KeyUpdate`
+    /// has no meaning before then, and the application epoch it must be sealed
+    /// under does not exist yet.
+    pub fn requestKeyUpdate(self: *Tls13Backend, request: key_update.Request, sink: *EventSink) HandshakeError!void {
+        switch (self.profile) {
+            .record => {},
+            .extension => return error.InvalidHandshakeState,
+        }
+        if (self.core.handshake_lifecycle != .complete) return error.InvalidHandshakeState;
+        return self.emitKeyUpdateMessage(request, sink);
+    }
+
+    /// Emits the message and then the write-side advance, in that order. The
+    /// order is the RFC requirement, not a convenience: §4.6.3 has the sender
+    /// protect the `KeyUpdate` itself with the *old* keys and only subsequent
+    /// records with the new ones, so the transport must seal these bytes
+    /// before it applies the advance that follows them.
+    fn emitKeyUpdateMessage(self: *Tls13Backend, request: key_update.Request, sink: *EventSink) HandshakeError!void {
+        _ = self;
+        var buf: [key_update.message_len]u8 = undefined;
+        const message = key_update.encode(request, &buf) catch return error.TransportBufferOverflow;
+        try sink.emitHandshakeBytes(.application, message);
+        try sink.emitKeyUpdate(.write);
     }
 
     fn onNewSessionTicket(self: *Tls13Backend, body: []const u8) HandshakeError!void {

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -395,6 +395,10 @@ fn pumpDirect(
             var scratch: [1]u8 = undefined;
             _ = try sender_bridge.applyEvent(.{ .early_data_parameters = params }, &scratch);
         },
+        .key_update => |update| {
+            var scratch: [1]u8 = undefined;
+            _ = try sender_bridge.applyEvent(.{ .key_update = update }, &scratch);
+        },
         .peer_transport_parameters => {},
         .alpn => |protocol| observed.noteAlpn(protocol),
         .certificate => |state| observed.certificate_state = state,
@@ -12740,4 +12744,509 @@ test "#369 Slice 2 rt0.reject.cross_worker_duplicate: worker A's accepted claim 
     try std.testing.expect(worker_b.server_backend.core.psk_authenticated);
 
     try std.testing.expectEqual(@as(usize, 1), store.count());
+}
+
+// ===========================================================================
+// #357: post-handshake KeyUpdate over the record stream.
+//
+// The bridge-level chain arithmetic, sequence reset, and zeroization are
+// pinned in `record_epoch_bridge.zig`. What is proved here is the *protocol*:
+// two real engines over a real socket pair, exchanging real KeyUpdate records
+// and continuing to talk afterwards.
+// ===========================================================================
+
+const key_update = tls_core.key_update;
+
+const Generations = struct {
+    client_read: u64,
+    client_write: u64,
+    server_read: u64,
+    server_write: u64,
+};
+
+fn generations(h: *SocketHarness) Generations {
+    return .{
+        .client_read = h.client.bridge.read_key_generation,
+        .client_write = h.client.bridge.write_key_generation,
+        .server_read = h.server.bridge.read_key_generation,
+        .server_write = h.server.bridge.write_key_generation,
+    };
+}
+
+/// Both directions still carry application data end to end. Run after every
+/// transition: agreeing generation counters would still be agreeing if both
+/// sides had derived the same *wrong* keys, but a byte that survives the round
+/// trip could only have been sealed and opened under matching key material.
+fn expectTrafficBothWays(h: *SocketHarness, tag: []const u8) !void {
+    var buf: [64]u8 = undefined;
+
+    try std.testing.expectEqual(tag.len, try h.client.stream().write(tag));
+    try h.driveUntil(struct {
+        fn done(hh: *SocketHarness) bool {
+            return hh.server.readiness().can_read_plaintext;
+        }
+    }.done);
+    try std.testing.expectEqualStrings(tag, buf[0..try h.server.stream().read(&buf)]);
+
+    try std.testing.expectEqual(tag.len, try h.server.stream().write(tag));
+    try h.driveUntil(struct {
+        fn done(hh: *SocketHarness) bool {
+            return hh.client.readiness().can_read_plaintext;
+        }
+    }.done);
+    try std.testing.expectEqualStrings(tag, buf[0..try h.client.stream().read(&buf)]);
+}
+
+/// Each direction's sender and receiver hold the same secret. This is the
+/// property a mis-timed transition breaks: if one side advances a record too
+/// early or too late the counters can still match while the secrets do not.
+fn expectSecretsAgree(h: *SocketHarness) !void {
+    try std.testing.expectEqualSlices(
+        u8,
+        h.client.bridge.write_application_secret.slice(),
+        h.server.bridge.read_application_secret.slice(),
+    );
+    try std.testing.expectEqualSlices(
+        u8,
+        h.server.bridge.write_application_secret.slice(),
+        h.client.bridge.read_application_secret.slice(),
+    );
+}
+
+/// Drive the server until it latches a terminal error, so a test can pin the
+/// failure class an injected record produces without depending on how many
+/// drives the carrier needs to deliver it.
+fn driveServerUntilError(h: *SocketHarness) anyerror {
+    var rounds: usize = 0;
+    while (rounds < 256) : (rounds += 1) {
+        _ = h.driveServer() catch |err| return err;
+        _ = h.driveClient() catch {};
+    }
+    return error.NoFailureLatched;
+}
+
+fn driveUntilServerRead(h: *SocketHarness, target: u64) !void {
+    const Target = struct {
+        var want: u64 = 0;
+        fn done(hh: *SocketHarness) bool {
+            return hh.server.bridge.read_key_generation >= want;
+        }
+    };
+    Target.want = target;
+    try h.driveUntil(Target.done);
+}
+
+test "#357 a one-way KeyUpdate advances only the sending direction" {
+    const h = try SocketHarness.create(.{});
+    defer h.destroy();
+    try h.driveUntil(SocketHarness.bothComplete);
+    try expectTrafficBothWays(h, "before-update");
+
+    // `update_not_requested`: refresh our own sending keys and ask nothing of
+    // the peer.
+    try h.client.requestKeyUpdate(.update_not_requested);
+    try driveUntilServerRead(h, 1);
+
+    try std.testing.expectEqual(Generations{
+        .client_read = 0,
+        .client_write = 1,
+        .server_read = 1,
+        .server_write = 0,
+    }, generations(h));
+    try expectSecretsAgree(h);
+    try expectTrafficBothWays(h, "after-update");
+}
+
+test "#357 update_requested draws exactly one reciprocal update and then stops" {
+    const h = try SocketHarness.create(.{});
+    defer h.destroy();
+    try h.driveUntil(SocketHarness.bothComplete);
+
+    try h.client.requestKeyUpdate(.update_requested);
+    try h.driveUntil(struct {
+        fn done(hh: *SocketHarness) bool {
+            return hh.client.bridge.read_key_generation == 1 and hh.server.bridge.read_key_generation == 1;
+        }
+    }.done);
+
+    // Both directions advanced exactly once: the client's own update, and the
+    // server's reciprocal one.
+    try std.testing.expectEqual(Generations{
+        .client_read = 1,
+        .client_write = 1,
+        .server_read = 1,
+        .server_write = 1,
+    }, generations(h));
+    try expectSecretsAgree(h);
+    try expectTrafficBothWays(h, "reciprocal");
+
+    // And it terminates. The reciprocal update carries
+    // `update_not_requested`, so nothing obliges the client to answer it --
+    // driving both sides to a standstill must not produce a further
+    // generation on either side.
+    var rounds: usize = 0;
+    while (rounds < 64) : (rounds += 1) {
+        _ = try h.driveClient();
+        _ = try h.driveServer();
+    }
+    try std.testing.expectEqual(Generations{
+        .client_read = 1,
+        .client_write = 1,
+        .server_read = 1,
+        .server_write = 1,
+    }, generations(h));
+    try expectTrafficBothWays(h, "still-quiet");
+}
+
+test "#357 repeated updates from both roles keep the two chains in step" {
+    const h = try SocketHarness.create(.{});
+    defer h.destroy();
+    try h.driveUntil(SocketHarness.bothComplete);
+
+    for (1..6) |round| {
+        // Client-initiated, one-way.
+        try h.client.requestKeyUpdate(.update_not_requested);
+        try driveUntilServerRead(h, round);
+
+        // Server-initiated, one-way, in the other direction.
+        try h.server.requestKeyUpdate(.update_not_requested);
+        try h.driveUntil(struct {
+            fn done(hh: *SocketHarness) bool {
+                return hh.client.bridge.read_key_generation == hh.server.bridge.write_key_generation;
+            }
+        }.done);
+
+        try std.testing.expectEqual(Generations{
+            .client_read = round,
+            .client_write = round,
+            .server_read = round,
+            .server_write = round,
+        }, generations(h));
+        try expectSecretsAgree(h);
+        try expectTrafficBothWays(h, "round");
+    }
+}
+
+test "#357 simultaneous updates crossing on the wire converge without a loop" {
+    const h = try SocketHarness.create(.{});
+    defer h.destroy();
+    try h.driveUntil(SocketHarness.bothComplete);
+
+    // Both endpoints request an update before either has seen the other's:
+    // the case where each side's KeyUpdate is already in flight when the
+    // peer's arrives, which RFC 8446 §4.6.3 explicitly allows.
+    try h.client.requestKeyUpdate(.update_requested);
+    try h.server.requestKeyUpdate(.update_requested);
+
+    try h.driveUntil(struct {
+        fn done(hh: *SocketHarness) bool {
+            return hh.client.bridge.read_key_generation == 2 and hh.server.bridge.read_key_generation == 2;
+        }
+    }.done);
+
+    // Each side advanced its sending keys twice -- once for its own request,
+    // once for the reciprocal answer it owed the peer -- and its receiving
+    // keys twice to match. The exchange then stops: neither reciprocal
+    // message requests anything further.
+    try std.testing.expectEqual(Generations{
+        .client_read = 2,
+        .client_write = 2,
+        .server_read = 2,
+        .server_write = 2,
+    }, generations(h));
+    try expectSecretsAgree(h);
+    try expectTrafficBothWays(h, "crossed");
+
+    var rounds: usize = 0;
+    while (rounds < 64) : (rounds += 1) {
+        _ = try h.driveClient();
+        _ = try h.driveServer();
+    }
+    try std.testing.expectEqual(@as(u64, 2), h.client.bridge.write_key_generation);
+    try std.testing.expectEqual(@as(u64, 2), h.server.bridge.write_key_generation);
+}
+
+/// Seal `bytes` as an application-epoch handshake record with one endpoint's
+/// own write keys and push it straight down the socket, bypassing that
+/// stream's queue. Lets a test emit exactly the record sequence a peer would
+/// -- including ones this implementation would never itself produce.
+fn injectClientHandshakeRecord(h: *SocketHarness, bytes: []const u8) !void {
+    var record_buf: [tls_core.record_codec.max_ciphertext_record_len]u8 = undefined;
+    const record = try h.client.bridge.sealProtected(.application, .handshake, bytes, &record_buf);
+    try h.injectFromClient(record);
+}
+
+fn injectServerHandshakeRecord(h: *SocketHarness, bytes: []const u8) !void {
+    var record_buf: [tls_core.record_codec.max_ciphertext_record_len]u8 = undefined;
+    const record = try h.server.bridge.sealProtected(.application, .handshake, bytes, &record_buf);
+    var written: usize = 0;
+    while (written < record.len) {
+        written += try writeFd(h.fds[1], record[written..]);
+    }
+}
+
+/// The client counterpart of `driveServerUntilError`.
+fn driveClientUntilError(h: *SocketHarness) anyerror {
+    var rounds: usize = 0;
+    while (rounds < 256) : (rounds += 1) {
+        _ = h.driveClient() catch |err| return err;
+        _ = h.driveServer() catch {};
+    }
+    return error.NoFailureLatched;
+}
+
+test "#357 a KeyUpdate fragmented across two records is reassembled and applied once" {
+    const h = try SocketHarness.create(.{});
+    defer h.destroy();
+    try h.driveUntil(SocketHarness.bothComplete);
+    try expectTrafficBothWays(h, "before-fragment");
+
+    var message_buf: [key_update.message_len]u8 = undefined;
+    const message = try key_update.encode(.update_not_requested, &message_buf);
+
+    // Split mid-header and mid-body, so the server has to hold an incomplete
+    // handshake message across a record boundary rather than getting a
+    // conveniently whole one in each record.
+    for ([_]usize{ 1, 2, 3, 4 }) |split| {
+        const before = generations(h);
+        try injectClientHandshakeRecord(h, message[0..split]);
+        try injectClientHandshakeRecord(h, message[split..]);
+        // The client sealed those two records itself, so its own sending keys
+        // advance exactly where the peer will expect them to: after the
+        // KeyUpdate, never before it.
+        try h.client.bridge.updateTrafficSecret(.write);
+
+        try driveUntilServerRead(h, before.server_read + 1);
+        try std.testing.expectEqual(before.server_read + 1, h.server.bridge.read_key_generation);
+        // A partial message must not have been mistaken for a whole one.
+        try std.testing.expectEqual(before.server_write, h.server.bridge.write_key_generation);
+        try expectSecretsAgree(h);
+        try expectTrafficBothWays(h, "after-fragment");
+    }
+}
+
+test "#357 an undefined KeyUpdate request value fails as illegal_parameter" {
+    const h = try SocketHarness.create(.{});
+    defer h.destroy();
+    try h.driveUntil(SocketHarness.bothComplete);
+
+    // Well-framed KeyUpdate whose request byte is outside the two defined
+    // values. RFC 8446 §4.6.3 requires `illegal_parameter`, not a decode
+    // error -- the bytes parse fine, the value is wrong.
+    try injectClientHandshakeRecord(h, &.{ 24, 0, 0, 1, 0x05 });
+
+    try std.testing.expectEqual(@as(anyerror, error.IllegalParameter), driveServerUntilError(h));
+    try std.testing.expectEqual(
+        tls_core.alerts.AlertDescription.illegal_parameter,
+        tls_core.alerts.fromHandshakeError(error.IllegalParameter),
+    );
+    // The client sees the class the server actually put on the wire.
+    var rounds: usize = 0;
+    while (rounds < 64 and h.client.peerAlert() == null) : (rounds += 1) _ = h.driveClient() catch {};
+    try std.testing.expectEqual(tls_core.alerts.AlertDescription.illegal_parameter, h.client.peerAlert().?);
+    try std.testing.expectEqual(@as(u64, 0), h.server.bridge.read_key_generation);
+}
+
+test "#357 a wrong-length KeyUpdate body fails as a decode error, not illegal_parameter" {
+    const h = try SocketHarness.create(.{});
+    defer h.destroy();
+    try h.driveUntil(SocketHarness.bothComplete);
+
+    // Two body bytes where the message is defined to carry exactly one: a
+    // framing failure, which is the `decode_error` class.
+    try injectClientHandshakeRecord(h, &.{ 24, 0, 0, 2, 0x00, 0x00 });
+
+    try std.testing.expectEqual(@as(anyerror, error.MalformedHandshake), driveServerUntilError(h));
+    try std.testing.expectEqual(@as(u64, 0), h.server.bridge.read_key_generation);
+}
+
+test "#357 an over-long KeyUpdate is a framing error with or without a post-handshake allocator" {
+    // The failure class must not depend on whether this endpoint happens to
+    // have configured a ticket allocator. A KeyUpdate declaring a body too
+    // large for the inline reassembly buffer would otherwise reach the
+    // allocator path and be reported as a missing allocator on one connection
+    // and a decode error on another.
+    //
+    // Only a client can hold a post-handshake allocator (it exists to
+    // reassemble NewSessionTicket, which travels server->client only), so the
+    // client is the receiver that can actually exercise both settings.
+    for ([_]?std.mem.Allocator{ null, std.testing.allocator }) |maybe_allocator| {
+        const h = try SocketHarness.create(.{ .client_post_handshake_allocator = maybe_allocator });
+        defer h.destroy();
+        try h.driveUntil(SocketHarness.bothComplete);
+
+        // A declared 64-byte body: well past the five bytes a KeyUpdate can
+        // ever occupy, and past the inline buffer.
+        var oversized: [4 + 64]u8 = undefined;
+        oversized[0] = 24;
+        std.mem.writeInt(u24, oversized[1..4], 64, .big);
+        @memset(oversized[4..], 0);
+        try injectServerHandshakeRecord(h, &oversized);
+
+        try std.testing.expectEqual(@as(anyerror, error.MalformedHandshake), driveClientUntilError(h));
+        try std.testing.expectEqual(@as(u64, 0), h.client.bridge.read_key_generation);
+    }
+}
+
+test "#357 a KeyUpdate before the handshake completes is rejected in both roles" {
+    // Pre-handshake rejection has two distinct causes and both must bite: the
+    // message arriving at an epoch it is never carried at, and the message
+    // arriving at the right epoch before the handshake has finished.
+    for ([_]tls_core.state.Role{ .client, .server }) |role| {
+        var storage: ProviderStorage = .{};
+        const cp = storage.init(if (role == .client) client_provider_seed else server_provider_seed);
+        var engine = if (role == .client)
+            tls_backend.Tls13Backend.initClient(clientEntropy(), cp, .{ .pinned_certificate = tls_backend.testdata.certificate_der }, .record)
+        else
+            tls_backend.Tls13Backend.initServer(serverEntropy(), cp, fixtureIdentity(), .record);
+        defer engine.deinit();
+        var sink = DirectSink{};
+        defer sink.deinit();
+        try engine.backend().start(role, {}, &sink);
+
+        var message_buf: [key_update.message_len]u8 = undefined;
+        const message = try key_update.encode(.update_not_requested, &message_buf);
+
+        // Wrong epoch: KeyUpdate is an application-epoch message only, so it
+        // is refused before it is ever decoded.
+        sink.reset();
+        try std.testing.expectError(
+            error.UnexpectedTransportEpoch,
+            engine.backend().receive(.handshake, message, &sink),
+        );
+
+        // Right epoch, wrong time: the application epoch does not exist for
+        // inbound purposes until the handshake completes, so a KeyUpdate
+        // arriving there early is refused on the same deterministic ground
+        // rather than reaching the post-handshake reassembly buffer.
+        sink.reset();
+        try std.testing.expectError(
+            error.UnexpectedTransportEpoch,
+            engine.backend().receive(.application, message, &sink),
+        );
+        try std.testing.expectEqual(@as(usize, 0), sink.len);
+    }
+}
+
+test "#357 QUIC-mode engines have no KeyUpdate and reject one that arrives" {
+    var harness: DirectHarness = undefined;
+    harness.initExtension();
+    defer harness.deinit();
+    try harness.run();
+    try std.testing.expect(harness.client_driver.isComplete());
+    try std.testing.expect(harness.server_driver.isComplete());
+
+    var message_buf: [key_update.message_len]u8 = undefined;
+    const message = try key_update.encode(.update_not_requested, &message_buf);
+
+    // RFC 9001 §6: the message does not exist over QUIC. Both roles reject a
+    // received one as `unexpected_message`, and neither exposes a way to send
+    // one -- an engine that merely refused to *send* while still accepting
+    // inbound updates would silently roll its own receiving keys on a peer's
+    // say-so.
+    for ([_]*tls_backend.Tls13Backend{ &harness.client_backend, &harness.server_backend }) |engine| {
+        var sink = DirectSink{};
+        defer sink.deinit();
+        try std.testing.expect(!engine.backend().supportsKeyUpdate());
+        try std.testing.expectError(
+            error.InvalidHandshakeState,
+            engine.requestKeyUpdate(.update_requested, &sink),
+        );
+        try std.testing.expectEqual(@as(usize, 0), sink.len);
+        try std.testing.expectError(
+            error.UnexpectedHandshakeMessage,
+            engine.backend().receive(.application, message, &sink),
+        );
+    }
+}
+
+test "#357 record-mode engines expose KeyUpdate only after the handshake completes" {
+    var harness: DirectHarness = undefined;
+    harness.init();
+    defer harness.deinit();
+
+    // The capability is a property of the transport profile, so it is present
+    // from the start...
+    try std.testing.expect(harness.client_backend.backend().supportsKeyUpdate());
+    try std.testing.expect(harness.server_backend.backend().supportsKeyUpdate());
+
+    // ...but using it before completion is a state error, not a queued
+    // message waiting for keys that do not exist yet.
+    var early_sink = DirectSink{};
+    defer early_sink.deinit();
+    try std.testing.expectError(
+        error.InvalidHandshakeState,
+        harness.client_backend.requestKeyUpdate(.update_not_requested, &early_sink),
+    );
+    try std.testing.expectEqual(@as(usize, 0), early_sink.len);
+
+    try harness.run();
+
+    // After completion it emits the message and the write-side advance, in
+    // that order -- the message must be sealed under the keys it retires.
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try harness.client_backend.requestKeyUpdate(.update_requested, &sink);
+    try std.testing.expectEqual(@as(usize, 2), sink.len);
+    try std.testing.expectEqual(events.EncryptionEpoch.application, sink.items[0].handshake_bytes.epoch);
+    try std.testing.expectEqual(
+        key_update.Request.update_requested,
+        try key_update.decode((try tls_core.messages.decode(sink.items[0].handshake_bytes.data)).body),
+    );
+    try std.testing.expectEqual(events.SecretDirection.write, sink.items[1].key_update.direction);
+}
+
+test "#357 the stream refuses a locally initiated KeyUpdate outside an open session" {
+    const h = try SocketHarness.create(.{});
+    defer h.destroy();
+
+    // Before the handshake completes there is no application epoch to seal a
+    // KeyUpdate under.
+    try std.testing.expectError(error.InvalidHandshakeState, h.client.requestKeyUpdate(.update_not_requested));
+    try std.testing.expectError(error.InvalidHandshakeState, h.server.requestKeyUpdate(.update_requested));
+
+    try h.driveUntil(SocketHarness.bothComplete);
+    try h.client.requestKeyUpdate(.update_not_requested);
+    try driveUntilServerRead(h, 1);
+
+    // A closed stream is past updating, whatever its keys were.
+    h.client.stream().close();
+    try h.driveUntil(struct {
+        fn done(hh: *SocketHarness) bool {
+            return hh.client.lifecycle == .closed;
+        }
+    }.done);
+    try std.testing.expectError(error.InvalidHandshakeState, h.client.requestKeyUpdate(.update_not_requested));
+}
+
+test "#357 usage limits report when a proactive update is due without forcing one" {
+    const h = try SocketHarness.create(.{});
+    defer h.destroy();
+    try h.driveUntil(SocketHarness.bothComplete);
+
+    // Unconfigured is the default, and stays false however much traffic runs.
+    try std.testing.expect(!h.client.keyUpdateDue());
+    try expectTrafficBothWays(h, "unlimited");
+    try std.testing.expect(!h.client.keyUpdateDue());
+
+    h.client.setKeyUpdateLimits(.{ .records = 3 });
+    try std.testing.expect(!h.client.keyUpdateDue());
+    for (0..3) |_| {
+        _ = try h.client.stream().write("x");
+        _ = try h.driveClient();
+        _ = try h.driveServer();
+    }
+    try std.testing.expect(h.client.keyUpdateDue());
+
+    // Reaching the limit does not itself update anything: the hook reports,
+    // the owner decides.
+    try std.testing.expectEqual(@as(u64, 0), h.client.bridge.write_key_generation);
+    var buf: [16]u8 = undefined;
+    while (h.server.readiness().can_read_plaintext) _ = try h.server.stream().read(&buf);
+
+    try h.client.requestKeyUpdate(.update_not_requested);
+    try driveUntilServerRead(h, 1);
+    // The sequence restarted, so the limit is no longer met.
+    try std.testing.expect(!h.client.keyUpdateDue());
+    try std.testing.expectEqual(@as(u64, 1), h.client.bridge.write_key_generation);
 }

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -13088,6 +13088,49 @@ test "#357 an over-long KeyUpdate is a framing error with or without a post-hand
     }
 }
 
+test "#357 a KeyUpdate header declaring a body past the ticket cap is still a framing error" {
+    // Review finding on #591: the generic post-handshake size cap used to run
+    // *before* the KeyUpdate-specific length check, so a KeyUpdate declaring a
+    // body large enough to exceed it was classified `HandshakeBufferOverflow`
+    // rather than `MalformedHandshake`. `mappedFatalAlert` has no arm for
+    // `HandshakeBufferOverflow`, so that path terminated locally and put no
+    // `decode_error` on the wire at all -- and it made the failure class
+    // depend on how large the declared body was, which is exactly the
+    // invariant the inline-reassembly change set out to establish.
+    //
+    // Only the four-byte header is ever sent. Nothing behind it needs to
+    // arrive, and nothing should be buffered waiting for it: the declared
+    // length alone is enough to know the message cannot be a KeyUpdate.
+    const declared_body_len: u24 = std.math.maxInt(u24);
+    try std.testing.expect(
+        @as(usize, declared_body_len) + 4 > tls_backend.max_new_session_ticket_message_len,
+    );
+
+    for ([_]?std.mem.Allocator{ null, std.testing.allocator }) |maybe_allocator| {
+        const h = try SocketHarness.create(.{ .client_post_handshake_allocator = maybe_allocator });
+        defer h.destroy();
+        try h.driveUntil(SocketHarness.bothComplete);
+
+        var header: [4]u8 = undefined;
+        header[0] = 24;
+        std.mem.writeInt(u24, header[1..4], declared_body_len, .big);
+        try injectServerHandshakeRecord(h, &header);
+
+        try std.testing.expectEqual(@as(anyerror, error.MalformedHandshake), driveClientUntilError(h));
+        try std.testing.expectEqual(@as(u64, 0), h.client.bridge.read_key_generation);
+
+        // The RFC-mandated alert reaches the peer, rather than the connection
+        // dying quietly on an unmapped error.
+        try std.testing.expectEqual(
+            tls_core.alerts.AlertDescription.decode_error,
+            tls_core.alerts.fromHandshakeError(error.MalformedHandshake),
+        );
+        var rounds: usize = 0;
+        while (rounds < 64 and h.server.peerAlert() == null) : (rounds += 1) _ = h.driveServer() catch {};
+        try std.testing.expectEqual(tls_core.alerts.AlertDescription.decode_error, h.server.peerAlert().?);
+    }
+}
+
 test "#357 a KeyUpdate before the handshake completes is rejected in both roles" {
     // Pre-handshake rejection has two distinct causes and both must bite: the
     // message arriving at an epoch it is never carried at, and the message
@@ -13229,24 +13272,44 @@ test "#357 usage limits report when a proactive update is due without forcing on
     try expectTrafficBothWays(h, "unlimited");
     try std.testing.expect(!h.client.keyUpdateDue());
 
-    h.client.setKeyUpdateLimits(.{ .records = 3 });
+    // A cap of 4 records on the generation. It becomes due one record early,
+    // because acting on it seals the KeyUpdate under these same keys -- so
+    // that message is the 4th record the generation protects, not a 5th
+    // (review finding on #591).
+    const cap: u64 = 4;
+    h.client.setKeyUpdateLimits(.{ .records = cap });
     try std.testing.expect(!h.client.keyUpdateDue());
-    for (0..3) |_| {
+
+    var buf: [16]u8 = undefined;
+    // Seal one record at a time, checking the boundary against the write
+    // sequence itself rather than against the loop counter: a short write or
+    // an unrelated queued record would otherwise make the count drift.
+    while (h.client.bridge.applicationRecordsSealed() < cap - 1) {
+        try std.testing.expect(!h.client.keyUpdateDue());
         _ = try h.client.stream().write("x");
         _ = try h.driveClient();
         _ = try h.driveServer();
+        while (h.server.readiness().can_read_plaintext) _ = try h.server.stream().read(&buf);
     }
+    try std.testing.expectEqual(cap - 1, h.client.bridge.applicationRecordsSealed());
     try std.testing.expect(h.client.keyUpdateDue());
 
     // Reaching the limit does not itself update anything: the hook reports,
     // the owner decides.
     try std.testing.expectEqual(@as(u64, 0), h.client.bridge.write_key_generation);
-    var buf: [16]u8 = undefined;
-    while (h.server.readiness().can_read_plaintext) _ = try h.server.stream().read(&buf);
 
+    // Becoming due at exactly `cap - 1` is what makes the KeyUpdate the
+    // cap-th record under the retiring generation -- the last one permitted,
+    // not the first one beyond it. The count itself is not observable *after*
+    // the call: `requestKeyUpdate` seals the message and applies the write-side
+    // advance in one event batch, so the sequence has already restarted by the
+    // time it returns. The assertion above, taken before it, is the one that
+    // pins the boundary.
     try h.client.requestKeyUpdate(.update_not_requested);
     try driveUntilServerRead(h, 1);
-    // The sequence restarted, so the limit is no longer met.
+    // The sequence restarted with the new generation, so the limit is no
+    // longer met.
     try std.testing.expect(!h.client.keyUpdateDue());
+    try std.testing.expectEqual(@as(u64, 0), h.client.bridge.applicationRecordsSealed());
     try std.testing.expectEqual(@as(u64, 1), h.client.bridge.write_key_generation);
 }

--- a/src/tls/transport.zig
+++ b/src/tls/transport.zig
@@ -30,6 +30,7 @@ const std = @import("std");
 const crypto_secrets = @import("crypto_secrets");
 const alerts = @import("alerts.zig");
 const events = @import("events.zig");
+const key_update = @import("key_update.zig");
 const state = @import("state.zig");
 
 pub fn Contract(
@@ -74,6 +75,11 @@ pub fn ContractWithOptions(
             early_data_parameters: events.NegotiatedParameters,
             /// A traffic secret to install for `epoch`/`direction`.
             traffic_secret: struct { epoch: Epoch, direction: events.SecretDirection, data: []const u8 },
+            /// Advance one direction's application traffic secret one step
+            /// along RFC 8446 §7.2's `"traffic upd"` chain (#357). Record mode
+            /// only — see `events.KeyUpdate` for the ordering contract, which
+            /// is load-bearing: consumers must apply it in event order.
+            key_update: events.KeyUpdate,
             /// Transport-owned peer parameters carried by the TLS handshake.
             peer_transport_parameters: TransportParameters,
             /// The negotiated ALPN protocol.
@@ -246,6 +252,14 @@ pub fn ContractWithOptions(
                 self.pushUnchecked(.{ .traffic_secret = .{ .epoch = epoch, .direction = direction, .data = stored } });
             }
 
+            /// Emitted *after* whichever event establishes the boundary the
+            /// update takes effect at: the peer's processed `KeyUpdate` for
+            /// `.read`, our own emitted `KeyUpdate` bytes for `.write`.
+            pub fn emitKeyUpdate(self: *EventSink, direction: events.SecretDirection) ErrorSet!void {
+                try self.reserve(0);
+                self.pushUnchecked(.{ .key_update = .{ .direction = direction } });
+            }
+
             pub fn emitPeerTransportParameters(self: *EventSink, params: TransportParameters) ErrorSet!void {
                 try self.reserve(0);
                 self.pushUnchecked(.{ .peer_transport_parameters = params });
@@ -315,6 +329,13 @@ pub fn ContractWithOptions(
             /// derives no traffic secrets to infer that from. Backends that
             /// never emit HRR leave this null.
             helloRetryRequestSentFn: ?*const fn (ptr: *anyopaque) bool = null,
+            /// Locally initiated post-handshake `KeyUpdate` (#357). Record-mode
+            /// backends wire this; QUIC's leaves it null, because RFC 9001 §6
+            /// removes `KeyUpdate` from TLS-over-QUIC entirely. Null is
+            /// therefore a real answer ("this transport has no such message"),
+            /// not a missing feature — which is why `requestKeyUpdate` reports
+            /// it to the caller instead of quietly doing nothing.
+            requestKeyUpdateFn: ?*const fn (ptr: *anyopaque, request: key_update.Request, sink: *EventSink) ErrorSet!void = null,
 
             pub fn start(self: Backend, role: state.Role, params: TransportParameters, sink: *EventSink) ErrorSet!void {
                 return self.startFn(self.ptr, role, params, sink);
@@ -362,6 +383,24 @@ pub fn ContractWithOptions(
             pub fn helloRetryRequestSent(self: Backend) bool {
                 if (self.helloRetryRequestSentFn) |f| return f(self.ptr);
                 return false;
+            }
+
+            /// Whether this backend's transport has `KeyUpdate` at all.
+            pub fn supportsKeyUpdate(self: Backend) bool {
+                return self.requestKeyUpdateFn != null;
+            }
+
+            /// Queue a locally initiated `KeyUpdate` and the write-side key
+            /// advance behind it. Returns false — emitting nothing — when the
+            /// backend has no `KeyUpdate` (QUIC). The result is a `bool` rather
+            /// than an error because this contract is generic over `ErrorSet`
+            /// and cannot name an error of its own; callers must decide what an
+            /// unsupported transport means for them, and cannot silently ignore
+            /// it.
+            pub fn requestKeyUpdate(self: Backend, request: key_update.Request, sink: *EventSink) ErrorSet!bool {
+                const f = self.requestKeyUpdateFn orelse return false;
+                try f(self.ptr, request, sink);
+                return true;
             }
 
             pub fn deinit(self: Backend) void {

--- a/tests/tls_interop_tool.zig
+++ b/tests/tls_interop_tool.zig
@@ -110,6 +110,15 @@ const Args = struct {
     /// Server: require the engine to have selected a credential signing with
     /// exactly this scheme. Empty leaves selection unchecked.
     expect_signature: []const u8 = "",
+    /// #357: send exactly one post-handshake `KeyUpdate` once the connection
+    /// is open, before this side's application payload. `update_requested`
+    /// additionally obliges the peer to roll its own sending keys, which is
+    /// how a row exercises the *receiving* path against a real peer.
+    key_update: ?tls.key_update.Request = null,
+    /// #357: require this side to have advanced its receiving keys at least
+    /// this many times by the end of the exchange -- i.e. to have processed
+    /// that many `KeyUpdate` messages from the peer.
+    expect_key_updates: u64 = 0,
 
     const Identity = struct {
         pattern: []const u8,
@@ -150,6 +159,8 @@ const usage =
     \\  --expect ok|fail --expect-alert NAME --expect-error NAME
     \\  --expect-alpn NAME --expect-hrr
     \\  --send STR --expect-contains STR
+    \\  --key-update not-requested|requested   send one post-handshake KeyUpdate
+    \\  --expect-key-updates N                 require N received KeyUpdates
     \\  --transcript PATH             secret-free transcript + failure fixture
     \\  --verbose
     \\
@@ -245,6 +256,16 @@ fn parseArgs(allocator: std.mem.Allocator, init_args: std.process.Args) !?Args {
             args.identity_count += 1;
         } else if (std.mem.eql(u8, arg, "--expect-signature")) {
             args.expect_signature = try allocator.dupe(u8, it.next() orelse return error.MissingValue);
+        } else if (std.mem.eql(u8, arg, "--key-update")) {
+            const raw = it.next() orelse return error.MissingValue;
+            args.key_update = if (std.mem.eql(u8, raw, "not-requested"))
+                .update_not_requested
+            else if (std.mem.eql(u8, raw, "requested"))
+                .update_requested
+            else
+                return error.UnknownKeyUpdateRequest;
+        } else if (std.mem.eql(u8, arg, "--expect-key-updates")) {
+            args.expect_key_updates = try std.fmt.parseInt(u64, it.next() orelse return error.MissingValue, 10);
         } else {
             std.debug.print("tls-interop: unknown argument {s}\n", .{arg});
             return error.UnknownArgument;
@@ -515,6 +536,14 @@ const Outcome = struct {
     /// The fatal alert the peer sent us, as observed by the record stream.
     peer_alert: ?alerts.AlertDescription = null,
     received_len: usize = 0,
+    /// #357: how many times each direction's application traffic secret
+    /// advanced. `read` counts KeyUpdates this side processed from the peer,
+    /// `write` counts the ones it sent.
+    key_updates_read: u64 = 0,
+    key_updates_written: u64 = 0,
+    /// True once the row's own `--key-update` message has been queued, so the
+    /// send is attempted exactly once however many times the loop spins.
+    key_update_sent: bool = false,
 };
 
 /// The alert that characterises this run's failure, whichever side produced
@@ -733,6 +762,24 @@ const Runner = struct {
             if (stream.applicationDataOpen()) {
                 outcome.handshake_complete = true;
 
+                // #357: roll our sending keys before the row's payload goes
+                // out, so every application byte below crosses under the new
+                // generation. `WouldBlock` here only means the outbound queue
+                // has no room for the record yet; the next spin retries.
+                if (self.args.key_update) |request| {
+                    if (!outcome.key_update_sent) {
+                        stream.requestKeyUpdate(request) catch |err| switch (err) {
+                            error.WouldBlock => {},
+                            else => {
+                                if (delivered) break;
+                                outcome.failure = err;
+                                break;
+                            },
+                        };
+                        outcome.key_update_sent = stream.keyUpdateGenerations().write > 0;
+                    }
+                }
+
                 var buf: [4096]u8 = undefined;
                 const n = stream.stream().read(&buf) catch |err| switch (err) {
                     error.WouldBlock => 0,
@@ -763,7 +810,11 @@ const Runner = struct {
                     sent_len += wrote;
                 }
 
-                delivered = sent_len == self.args.send.len and self.matched(received.items);
+                const generations = stream.keyUpdateGenerations();
+                delivered = sent_len == self.args.send.len and
+                    self.matched(received.items) and
+                    (self.args.key_update == null or generations.write > 0) and
+                    generations.read >= self.args.expect_key_updates;
                 if (delivered) {
                     outcome.ok = true;
                     // Keep driving until our reply has actually left the
@@ -783,6 +834,9 @@ const Runner = struct {
         }
 
         outcome.received_len = received.items.len;
+        const final_generations = stream.keyUpdateGenerations();
+        outcome.key_updates_read = final_generations.read;
+        outcome.key_updates_written = final_generations.write;
         outcome.hello_retry_request = backend.core.retry_state != .none;
         outcome.certificate = stream.certificateState();
         outcome.peer_alert = stream.peerAlert();
@@ -894,7 +948,14 @@ fn reportLine(buf: []u8, args: Args, outcome: Outcome) []const u8 {
             if (outcome.peer_alert != null) "peer" else "local",
         });
     }
-    report.print(" app_bytes={d}\n", .{outcome.received_len});
+    report.print(" app_bytes={d}", .{outcome.received_len});
+    if (outcome.key_updates_written > 0 or outcome.key_updates_read > 0) {
+        report.print(" key_updates_sent={d} key_updates_received={d}", .{
+            outcome.key_updates_written,
+            outcome.key_updates_read,
+        });
+    }
+    report.print("\n", .{});
     return report.written();
 }
 
@@ -924,6 +985,8 @@ fn writeTranscript(path: []const u8, args: Args, outcome: Outcome, transcript: *
     report.print("certificate: {s}\n", .{@tagName(outcome.certificate)});
     report.print("hello_retry_request: {}\n", .{outcome.hello_retry_request});
     report.print("application_bytes_received: {d}\n", .{outcome.received_len});
+    report.print("key_updates.sent: {d}\n", .{outcome.key_updates_written});
+    report.print("key_updates.received: {d}\n", .{outcome.key_updates_read});
     if (outcome.failure) |err| report.print("failure: {s}\n", .{@errorName(err)});
     if (outcome.emitted_alert) |desc| report.print("alert.local: {s}\n", .{@tagName(desc)});
     if (outcome.peer_alert) |desc| report.print("alert.peer: {s}\n", .{@tagName(desc)});
@@ -1006,6 +1069,23 @@ fn evaluate(args: Args, outcome: Outcome) u8 {
 
     if (args.expect_hrr and !outcome.hello_retry_request) {
         std.debug.print("tls-interop: expected a HelloRetryRequest but none was observed\n", .{});
+        failed = true;
+    }
+
+    // #357. Both halves are asserted, because either alone is satisfiable
+    // without the mechanism working: a KeyUpdate we sent but the peer ignored
+    // would still leave our own write generation at 1, and a row that only
+    // counted received updates could pass on a peer that rolled its keys for
+    // reasons of its own.
+    if (args.key_update != null and outcome.key_updates_written == 0) {
+        std.debug.print("tls-interop: expected to send a KeyUpdate but the sending keys never advanced\n", .{});
+        failed = true;
+    }
+    if (outcome.key_updates_read < args.expect_key_updates) {
+        std.debug.print("tls-interop: expected at least {d} KeyUpdate(s) from the peer but observed {d}\n", .{
+            args.expect_key_updates,
+            outcome.key_updates_read,
+        });
         failed = true;
     }
 


### PR DESCRIPTION
## Summary

Implements RFC 8446 §4.6.3 post-handshake `KeyUpdate` for record-mode TLS, advancing one direction's application traffic secret at a time along §7.2's `"traffic upd"` chain.

- **Transition points are where the RFC puts them, and event ordering enforces them.** Receiving keys advance after the peer's `KeyUpdate` has been processed; sending keys advance only *after* our own has been sealed — so the message announcing a transition stays readable under the generation it retires. Each transition restarts that direction's record sequence at zero and zeroizes the keys and secret it replaced.
- **No update loops.** `update_requested` draws exactly one reciprocal update, which always carries `update_not_requested`. Simultaneous updates crossing on the wire converge at two generations per direction and stop.
- **Record-mode only.** RFC 9001 §6 removes `KeyUpdate` from TLS-over-QUIC, which carries its own key phase in the packet header, so a QUIC-profile engine neither offers a way to send one nor accepts one that arrives.
- **Usage thresholds are a hook, not a trigger.** `PureZigRecordStream.requestKeyUpdate` initiates one locally; `setKeyUpdateLimits`/`keyUpdateDue` expose a records-sealed threshold. Nothing fires an update on its own, and it is disabled by default, so existing connections' wire behaviour is unchanged until a caller opts in.

New module [key_update.zig](src/tls/key_update.zig) owns the wire form and the proactive-update policy; the secret step is `KeySchedule.nextTrafficSecret`; applying it to live keys is `Bridge.updateTrafficSecret`.

## Defect found and fixed while building this

Post-handshake reassembly always allocated, and the allocator is only installed by a client that configured a session-ticket consumer. Since **any** peer may send a `KeyUpdate` on **any** completed connection, an endpoint that simply did not use tickets would have failed the connection the moment a conforming peer rotated its keys.

Messages that fit inline (today, exactly `KeyUpdate`) now reassemble without an allocator, and a `KeyUpdate` declaring any other body length is rejected as a framing error *before* a buffer is chosen — so the failure class no longer depends on whether tickets were configured, and an attacker-chosen length is never buffered for a five-byte message.

## Test plan

- [x] `zig build test` — full suite green, including the crypto-boundary audit
- [x] `zig build test -Dtls-profile=appliance`, `test-integration-native-tls`, `test-tls-interop-matrix`
- [x] One-way, reciprocal, repeated, fragmented (every split point), and simultaneous updates over real socket pairs with two real engines
- [x] Chain arithmetic checked against an independent HKDF computation, not against the implementation
- [x] Sequence restarts at zero; old-generation records fail to open; a direction that skipped an update cannot read the next generation
- [x] No retired secret, key, or IV survives anywhere in the bridge's footprint after an update or teardown
- [x] Deterministic rejection of illegal request values (`illegal_parameter`, alert observed on the peer), wrong-length and over-long bodies (`decode_error`, identical with and without a post-handshake allocator), pre-handshake updates in both roles, and QUIC-mode messages
- [x] **OpenSSL 3.6.2 interop in both roles** — 3 new matrix rows, all passing:
  ```
  record/server/openssl/key-update/reciprocal   PASS  key_updates_sent=1 key_updates_received=1
  record/client/openssl/key-update/reciprocal   PASS  key_updates_sent=1 key_updates_received=1
  record/client/openssl/key-update/one-way      PASS  key_updates_sent=1 key_updates_received=0
  ```
- [x] **Mutation-checked**: inverting the emit ordering so the `KeyUpdate` is sealed under the *new* keys fails 7 unit tests and is rejected by OpenSSL with a fatal alert — the rows bite rather than passing on an ignored message.

Closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)