### PR TITLE
tls: extend OpenSSL TCP interop coverage

### DIFF
--- a/docs/TLS_INTEROP_MATRIX.md
+++ b/docs/TLS_INTEROP_MATRIX.md
@@ -1,7 +1,11 @@
 # Shared TLS-engine interoperability and conformance matrix
 
-Tracking issue: [#338](https://github.com/Bare-Systems/Tardigrade/issues/338)
-(research story 323-J).
+Tracking issues:
+
+- [#338](https://github.com/Bare-Systems/Tardigrade/issues/338) — shared TLS
+  engine conformance matrix.
+- [#358](https://github.com/Bare-Systems/Tardigrade/issues/358) — TLS-over-TCP
+  OpenSSL interoperability harness.
 
 This suite proves that the TLS 1.3 engine Tardigrade ships — one engine, two
 transports — interoperates with independent implementations across every
@@ -34,9 +38,11 @@ scripts/interop/run-tls-interop.sh --profile ci
 scripts/interop/run-tls-interop.sh --list --profile ci
 ```
 
-`openssl` is required. `gnutls-cli`/`gnutls-serv` are optional; without them
-the independent-implementation rows report `SKIP` rather than failing, so the
-suite still runs on a machine that only has OpenSSL.
+OpenSSL 3.x is required for the OpenSSL rows. The runner prints the exact
+`openssl version` in its summary so a failing transcript can be reproduced
+against the same peer build. `gnutls-cli`/`gnutls-serv` are optional; without
+them the independent-implementation rows report `SKIP` rather than failing, so
+the suite still runs on a machine that only has OpenSSL.
 
 | Variable | Meaning |
 | --- | --- |
@@ -105,6 +111,21 @@ negotiation tuple traverses the QUIC transport of the same engine and lands
 where it was told to. The external QUIC/H3 peer matrix (ngtcp2, quiche,
 aioquic, both directions, HRR included) already exists in
 `scripts/interop/run-interop.sh` and is not duplicated here.
+
+### HTTP protocol entrypoints
+
+The record-transport positive sweep uses ALPN `http/1.1` and sends application
+bytes after the Finished messages in both directions: the native server
+answers an OpenSSL client request, and the native client reads an OpenSSL
+`s_server -www` response.
+
+The dedicated `record/server/openssl/http2_entrypoint` row pins ALPN `h2`
+against `openssl s_client` and sends the RFC 9113 client connection preface
+plus an empty SETTINGS frame after negotiation. The native server verifies the
+preface arrived as decrypted application data before it completes the row.
+This keeps the TCP harness at the TLS boundary: it proves the HTTP/2 entrypoint
+is reachable under negotiated TLS keys without linking OpenSSL into any
+Tardigrade test binary.
 
 ### Post-handshake KeyUpdate
 

--- a/docs/TLS_INTEROP_MATRIX.md
+++ b/docs/TLS_INTEROP_MATRIX.md
@@ -121,11 +121,23 @@ answers an OpenSSL client request, and the native client reads an OpenSSL
 
 The dedicated `record/server/openssl/http2_entrypoint` row pins ALPN `h2`
 against `openssl s_client` and sends the RFC 9113 client connection preface
-plus an empty SETTINGS frame after negotiation. The native server verifies the
-preface arrived as decrypted application data before it completes the row.
-This keeps the TCP harness at the TLS boundary: it proves the HTTP/2 entrypoint
-is reachable under negotiated TLS keys without linking OpenSSL into any
-Tardigrade test binary.
+plus an empty SETTINGS frame after negotiation. The native server requires the
+complete 24-byte preface and the following 9-byte SETTINGS frame to arrive as
+decrypted application data before it completes the row. This keeps the TCP
+harness at the TLS boundary: it proves the HTTP/2 entrypoint is reachable
+under negotiated TLS keys without linking OpenSSL into any Tardigrade test
+binary.
+
+### Shutdown and truncation
+
+Two OpenSSL-backed server rows make TCP shutdown behavior explicit instead of
+letting ordinary positive rows finish before the peer's terminal behavior is
+observed:
+
+| Row | Peer behavior | Expectation |
+| --- | --- | --- |
+| `record/server/openssl/close_notify` | OpenSSL closes the TLS session normally after stdin EOF | the native stream observes peer `close_notify` without a terminal error |
+| `record/server/openssl/truncation` | OpenSSL is terminated after application data without sending `close_notify` | the native stream reports `TruncatedStream` |
 
 ### Post-handshake KeyUpdate
 

--- a/scripts/interop/run-tls-interop.sh
+++ b/scripts/interop/run-tls-interop.sh
@@ -171,6 +171,50 @@ check_peer_spellings() {
   fi
 }
 
+list_matrix_rows() {
+  say "profile: $profile"
+  say "engine capabilities: ${#suites[@]} suites x ${#groups[@]} groups x ${#signatures[@]} signatures"
+  for suite in "${suites[@]}"; do
+    for group in "${groups[@]}"; do
+      for sig in "${signatures[@]}"; do
+        tuple="$suite/$group/$sig"
+        say "positive  record/server/openssl/$tuple"
+        say "positive  record/client/openssl/$tuple"
+        if [ "$have_gnutls" -eq 0 ]; then
+          say "skip      record/server/gnutls/$tuple"
+          say "skip      record/client/gnutls/$tuple"
+        elif gnutls_row_in_profile "$suite" "$group" "$sig"; then
+          say "positive  record/server/gnutls/$tuple"
+          say "positive  record/client/gnutls/$tuple"
+        fi
+        say "positive  quic/loopback/$tuple"
+      done
+    done
+  done
+  say "positive  record/server/openssl/http2_entrypoint"
+  say "positive  record/server/openssl/hrr"
+  say "positive  record/client/openssl/hrr"
+  say "positive  record/server/openssl/key-update/reciprocal"
+  say "positive  record/client/openssl/key-update/reciprocal"
+  say "positive  record/client/openssl/key-update/one-way"
+  say "negative  record/negative/alpn_no_overlap"
+  say "negative  record/negative/tls12_downgrade"
+  say "negative  record/negative/cipher_no_overlap"
+  say "negative  record/negative/group_no_overlap"
+  say "negative  record/negative/signature_no_overlap"
+  say "negative  record/negative/sni_absent"
+  say "negative  record/negative/malformed_ordering"
+  say "negative  record/negative/ccs_before_clienthello"
+  say "negative  record/negative/wrong_pinned_certificate"
+  say "selection record/selection/sni_ed25519"
+  say "selection record/selection/sni_ecdsa_p256"
+  say "selection record/selection/sni_rsa"
+  say "selection record/selection/unknown_sni_uses_default"
+  say "selection record/selection/sigalgs_ed25519"
+  say "selection record/selection/sigalgs_rsa_pss"
+  say "selection record/selection/no_applicable_credential"
+}
+
 openssl_suite() {
   case "$1" in
     aes128-gcm-sha256) echo TLS_AES_128_GCM_SHA256 ;;
@@ -263,15 +307,19 @@ peer_request_stdin() { # once|keep_writing
       printf 'GET / HTTP/1.0\r\nX-Key-Update-Probe: 1\r\n\r\n'
       sleep 2
       ;;
+    h2_preface)
+      printf 'PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n'
+      printf '\x00\x00\x00\x04\x00\x00\x00\x00\x00'
+      ;;
     *) printf 'GET / HTTP/1.0\r\n\r\n' ;;
   esac
 }
 
 # native TLS server <- external client
-run_server_row() { # name peer suite group signature [extra native args...]
-  local name="$1" peer="$2" suite="$3" group="$4" sig="$5"
-  shift 5
-  local p log cert peer_groups peer_stdin
+run_server_alpn_row() { # name peer suite group signature alpn peer_stdin [extra native args...]
+  local name="$1" peer="$2" suite="$3" group="$4" sig="$5" alpn="$6" peer_stdin="$7"
+  shift 7
+  local p log cert peer_groups
   next_port; p="$port"
   log="$logs/${name//\//_}"
   cert="$(cert_for_signature "$sig")"
@@ -279,12 +327,11 @@ run_server_row() { # name peer suite group signature [extra native args...]
   # native server does not accept; ordinary rows offer the row's own group.
   peer_groups="$(openssl_group "$group")"
   case " $* " in *" --expect-hrr "*) peer_groups="P-384:$(openssl_group "$group")" ;; esac
-  peer_stdin=once
   case " $* " in *" --key-update "*) peer_stdin=keep_writing ;; esac
 
   "$tls_tool" server --port "$p" --cert "$cert-cert.pem" --key "$cert-key.pem" \
     --cipher-suite "$suite" --group "$group" --signature "$sig" \
-    --alpn http/1.1 --transcript "$transcripts/${name//\//_}.txt" \
+    --alpn "$alpn" --transcript "$transcripts/${name//\//_}.txt" \
     --timeout-ms 20000 "$@" > "$log.native" 2>&1 &
   local native_pid=$!
   if ! wait_for_native_listener "$log.native"; then
@@ -298,12 +345,12 @@ run_server_row() { # name peer suite group signature [extra native args...]
       peer_request_stdin "$peer_stdin" | "$openssl_bin" s_client -connect "127.0.0.1:$p" \
         -servername tardigrade.test -tls1_3 \
         -ciphersuites "$(openssl_suite "$suite")" -groups "$peer_groups" \
-        -sigalgs "$(openssl_sigalg "$sig")" -alpn http/1.1 \
+        -sigalgs "$(openssl_sigalg "$sig")" -alpn "$alpn" \
         -CAfile "$cert-cert.pem" > "$log.peer" 2>&1
       ;;
     gnutls)
       peer_request_stdin "$peer_stdin" | "$gnutls_cli" --port "$p" \
-        --x509cafile "$cert-cert.pem" --alpn=http/1.1 --sni-hostname=tardigrade.test \
+        --x509cafile "$cert-cert.pem" --alpn="$alpn" --sni-hostname=tardigrade.test \
         --priority "$(gnutls_priority "$suite" "$group" "$sig")" 127.0.0.1 > "$log.peer" 2>&1
       ;;
   esac
@@ -313,6 +360,12 @@ run_server_row() { # name peer suite group signature [extra native args...]
   else
     result "$name" FAIL "see $log.native"
   fi
+}
+
+run_server_row() { # name peer suite group signature [extra native args...]
+  local name="$1" peer="$2" suite="$3" group="$4" sig="$5"
+  shift 5
+  run_server_alpn_row "$name" "$peer" "$suite" "$group" "$sig" http/1.1 once "$@"
 }
 
 # native TLS client -> external server
@@ -476,15 +529,7 @@ load_capabilities
 check_peer_spellings
 
 if [ "$list_only" -eq 1 ]; then
-  say "profile: $profile"
-  say "engine capabilities: ${#suites[@]} suites x ${#groups[@]} groups x ${#signatures[@]} signatures"
-  for suite in "${suites[@]}"; do
-    for group in "${groups[@]}"; do
-      for sig in "${signatures[@]}"; do
-        say "positive  $suite/$group/$sig"
-      done
-    done
-  done
+  list_matrix_rows
   exit 0
 fi
 
@@ -524,6 +569,16 @@ for suite in "${suites[@]}"; do
     done
   done
 done
+
+say ""
+say "== record transport: HTTP protocol entrypoints =="
+# #358: the positive tuple sweep proves HTTP/1.1 application bytes in both
+# roles. This row pins the HTTP/2 ALPN entrypoint against OpenSSL too: the
+# peer sends the RFC 9113 client connection preface and an empty SETTINGS
+# frame after negotiation, and the native server verifies those bytes crossed
+# under the negotiated TLS 1.3 application keys.
+run_server_alpn_row "record/server/openssl/http2_entrypoint" openssl aes128-gcm-sha256 x25519 ed25519 \
+  h2 h2_preface --expect-contains "PRI * HTTP/2.0" --send "tardigrade-h2-interop"
 
 # ── 2. HelloRetryRequest, both roles ────────────────────────────────────────
 

--- a/scripts/interop/run-tls-interop.sh
+++ b/scripts/interop/run-tls-interop.sh
@@ -197,6 +197,8 @@ list_matrix_rows() {
   say "positive  record/server/openssl/key-update/reciprocal"
   say "positive  record/client/openssl/key-update/reciprocal"
   say "positive  record/client/openssl/key-update/one-way"
+  say "positive  record/server/openssl/close_notify"
+  say "negative  record/server/openssl/truncation"
   say "negative  record/negative/alpn_no_overlap"
   say "negative  record/negative/tls12_downgrade"
   say "negative  record/negative/cipher_no_overlap"
@@ -366,6 +368,51 @@ run_server_row() { # name peer suite group signature [extra native args...]
   local name="$1" peer="$2" suite="$3" group="$4" sig="$5"
   shift 5
   run_server_alpn_row "$name" "$peer" "$suite" "$group" "$sig" http/1.1 once "$@"
+}
+
+run_server_truncation_row() {
+  local name="record/server/openssl/truncation"
+  local suite="aes128-gcm-sha256" group="x25519" sig="ed25519"
+  local p log cert fifo peer_pid native_pid
+  next_port; p="$port"
+  log="$logs/${name//\//_}"
+  cert="$(cert_for_signature "$sig")"
+  fifo="$workdir/${name//\//_}.fifo"
+  mkfifo "$fifo"
+
+  "$tls_tool" server --port "$p" --cert "$cert-cert.pem" --key "$cert-key.pem" \
+    --cipher-suite "$suite" --group "$group" --signature "$sig" \
+    --alpn http/1.1 --expect fail --expect-error TruncatedStream \
+    --expect-peer-close truncated \
+    --transcript "$transcripts/${name//\//_}.txt" \
+    --timeout-ms 20000 > "$log.native" 2>&1 &
+  native_pid=$!
+  if ! wait_for_native_listener "$log.native"; then
+    kill "$native_pid" 2>/dev/null
+    result "$name" FAIL "native listener never came up"
+    return
+  fi
+
+  "$openssl_bin" s_client -connect "127.0.0.1:$p" \
+    -servername tardigrade.test -tls1_3 \
+    -ciphersuites "$(openssl_suite "$suite")" -groups "$(openssl_group "$group")" \
+    -sigalgs "$(openssl_sigalg "$sig")" -alpn http/1.1 \
+    -CAfile "$cert-cert.pem" < "$fifo" > "$log.peer" 2>&1 &
+  peer_pid=$!
+
+  exec 3>"$fifo"
+  printf 'GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n' >&3
+  sleep 1
+  kill -KILL "$peer_pid" 2>/dev/null
+  exec 3>&-
+  wait "$peer_pid" 2>/dev/null
+  rm -f "$fifo"
+
+  if wait "$native_pid"; then
+    result "$name" PASS "$(grep -o 'error=.*' "$log.native" | head -1)"
+  else
+    result "$name" FAIL "see $log.native"
+  fi
 }
 
 # native TLS client -> external server
@@ -578,7 +625,8 @@ say "== record transport: HTTP protocol entrypoints =="
 # frame after negotiation, and the native server verifies those bytes crossed
 # under the negotiated TLS 1.3 application keys.
 run_server_alpn_row "record/server/openssl/http2_entrypoint" openssl aes128-gcm-sha256 x25519 ed25519 \
-  h2 h2_preface --expect-contains "PRI * HTTP/2.0" --send "tardigrade-h2-interop"
+  h2 h2_preface --expect-contains $'PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n' \
+  --expect-min-bytes 33 --send "tardigrade-h2-interop"
 
 # ── 2. HelloRetryRequest, both roles ────────────────────────────────────────
 
@@ -620,6 +668,12 @@ run_client_row "record/client/openssl/key-update/reciprocal" openssl aes128-gcm-
 # peer must follow the transition without being prompted to make one itself.
 run_client_row "record/client/openssl/key-update/one-way" openssl aes128-gcm-sha256 x25519 ed25519 \
   --key-update not-requested
+
+# #358: shutdown semantics are asserted explicitly because ordinary positive
+# rows may complete before observing the peer's terminal close behavior.
+run_server_row "record/server/openssl/close_notify" openssl aes128-gcm-sha256 x25519 ed25519 \
+  --expect-peer-close clean
+run_server_truncation_row
 
 # ── 3. negative conformance rows ────────────────────────────────────────────
 

--- a/scripts/interop/run-tls-interop.sh
+++ b/scripts/interop/run-tls-interop.sh
@@ -383,7 +383,7 @@ run_server_truncation_row() {
   "$tls_tool" server --port "$p" --cert "$cert-cert.pem" --key "$cert-key.pem" \
     --cipher-suite "$suite" --group "$group" --signature "$sig" \
     --alpn http/1.1 --expect fail --expect-error TruncatedStream \
-    --expect-peer-close truncated \
+    --expect-peer-close truncated --expect-min-bytes 42 \
     --transcript "$transcripts/${name//\//_}.txt" \
     --timeout-ms 20000 > "$log.native" 2>&1 &
   native_pid=$!

--- a/tests/tls_interop_tool.zig
+++ b/tests/tls_interop_tool.zig
@@ -73,6 +73,7 @@ fn trace(comptime fmt: []const u8, args: anytype) void {
 // -- Arguments --------------------------------------------------------------
 
 const Expect = enum { ok, fail };
+const PeerCloseExpectation = enum { none, clean, truncated };
 
 const Args = struct {
     mode: enum { client, server },
@@ -90,6 +91,8 @@ const Args = struct {
     expect_alpn: []const u8 = "",
     send: []const u8 = "",
     expect_contains: []const u8 = "",
+    expect_min_bytes: usize = 0,
+    expect_peer_close: PeerCloseExpectation = .none,
     expect: Expect = .ok,
     expect_alert: []const u8 = "",
     expect_error: []const u8 = "",
@@ -158,7 +161,8 @@ const usage =
     \\expectations (these drive the exit code):
     \\  --expect ok|fail --expect-alert NAME --expect-error NAME
     \\  --expect-alpn NAME --expect-hrr
-    \\  --send STR --expect-contains STR
+    \\  --send STR --expect-contains STR --expect-min-bytes N
+    \\  --expect-peer-close clean|truncated
     \\  --key-update not-requested|requested   send one post-handshake KeyUpdate
     \\  --expect-key-updates N                 require N received KeyUpdates
     \\  --transcript PATH             secret-free transcript + failure fixture
@@ -223,6 +227,16 @@ fn parseArgs(allocator: std.mem.Allocator, init_args: std.process.Args) !?Args {
             args.send = try allocator.dupe(u8, it.next() orelse return error.MissingValue);
         } else if (std.mem.eql(u8, arg, "--expect-contains")) {
             args.expect_contains = try allocator.dupe(u8, it.next() orelse return error.MissingValue);
+        } else if (std.mem.eql(u8, arg, "--expect-min-bytes")) {
+            args.expect_min_bytes = try std.fmt.parseInt(usize, it.next() orelse return error.MissingValue, 10);
+        } else if (std.mem.eql(u8, arg, "--expect-peer-close")) {
+            const raw = it.next() orelse return error.MissingValue;
+            args.expect_peer_close = if (std.mem.eql(u8, raw, "clean"))
+                .clean
+            else if (std.mem.eql(u8, raw, "truncated"))
+                .truncated
+            else
+                return error.UnknownPeerCloseExpectation;
         } else if (std.mem.eql(u8, arg, "--expect")) {
             const raw = it.next() orelse return error.MissingValue;
             args.expect = if (std.mem.eql(u8, raw, "ok"))
@@ -544,6 +558,9 @@ const Outcome = struct {
     /// True once the row's own `--key-update` message has been queued, so the
     /// send is attempted exactly once however many times the loop spins.
     key_update_sent: bool = false,
+    /// A peer `close_notify` observed by the record stream. Abrupt EOF without
+    /// `close_notify` is reported separately as `error.TruncatedStream`.
+    peer_closed: bool = false,
 };
 
 /// The alert that characterises this run's failure, whichever side produced
@@ -751,13 +768,17 @@ const Runner = struct {
         // connection is finishing normally, not failing -- so a close observed
         // afterwards must not overwrite the result.
         var delivered = false;
+        const expect_peer_close = self.args.expect_peer_close != .none;
 
         while (nowMs() < deadline) {
             _ = stream.drive() catch |err| {
-                if (delivered) break;
+                if (delivered and !expect_peer_close) break;
                 outcome.failure = err;
+                outcome.ok = false;
                 break;
             };
+
+            if (delivered and self.args.expect_peer_close == .clean and stream.readiness().peer_closed) break;
 
             if (stream.applicationDataOpen()) {
                 outcome.handshake_complete = true;
@@ -771,8 +792,9 @@ const Runner = struct {
                         stream.requestKeyUpdate(request) catch |err| switch (err) {
                             error.WouldBlock => {},
                             else => {
-                                if (delivered) break;
+                                if (delivered and !expect_peer_close) break;
                                 outcome.failure = err;
+                                outcome.ok = false;
                                 break;
                             },
                         };
@@ -784,8 +806,9 @@ const Runner = struct {
                 const n = stream.stream().read(&buf) catch |err| switch (err) {
                     error.WouldBlock => 0,
                     else => {
-                        if (delivered) break;
+                        if (delivered and !expect_peer_close) break;
                         outcome.failure = err;
+                        outcome.ok = false;
                         break;
                     },
                 };
@@ -802,8 +825,9 @@ const Runner = struct {
                     const wrote = stream.stream().write(self.args.send[sent_len..]) catch |err| switch (err) {
                         error.WouldBlock => 0,
                         else => {
-                            if (delivered) break;
+                            if (delivered and !expect_peer_close) break;
                             outcome.failure = err;
+                            outcome.ok = false;
                             break;
                         },
                     };
@@ -821,13 +845,14 @@ const Runner = struct {
                     // outbound queue. Breaking with bytes still buffered would
                     // close the connection before the peer ever saw them,
                     // failing the row on the peer's side instead of ours.
-                    if (stream.bufferSnapshot().current.outbound_ciphertext == 0) break;
+                    if (stream.bufferSnapshot().current.outbound_ciphertext == 0 and !expect_peer_close) break;
                 }
             }
 
             if (stream.failed) |err| {
-                if (delivered) break;
+                if (delivered and !expect_peer_close) break;
                 outcome.failure = err;
+                outcome.ok = false;
                 break;
             }
             waitForCarrier(fd, &stream, deadline);
@@ -840,6 +865,7 @@ const Runner = struct {
         outcome.hello_retry_request = backend.core.retry_state != .none;
         outcome.certificate = stream.certificateState();
         outcome.peer_alert = stream.peerAlert();
+        outcome.peer_closed = stream.readiness().peer_closed;
         if (outcome.handshake_complete) {
             outcome.cipher_suite = backend.negotiated_cipher_suite;
             outcome.named_group = backend.negotiated_named_group;
@@ -866,6 +892,7 @@ const Runner = struct {
     /// a real proof: bytes only arrive after both Finished messages verified
     /// and the traffic keys agreed.
     fn matched(self: *const Runner, received: []const u8) bool {
+        if (received.len < self.args.expect_min_bytes) return false;
         if (self.args.expect_contains.len == 0) return received.len > 0;
         return std.mem.indexOf(u8, received, self.args.expect_contains) != null;
     }
@@ -955,6 +982,7 @@ fn reportLine(buf: []u8, args: Args, outcome: Outcome) []const u8 {
             outcome.key_updates_read,
         });
     }
+    if (outcome.peer_closed) report.print(" peer_close=clean", .{});
     report.print("\n", .{});
     return report.written();
 }
@@ -985,6 +1013,7 @@ fn writeTranscript(path: []const u8, args: Args, outcome: Outcome, transcript: *
     report.print("certificate: {s}\n", .{@tagName(outcome.certificate)});
     report.print("hello_retry_request: {}\n", .{outcome.hello_retry_request});
     report.print("application_bytes_received: {d}\n", .{outcome.received_len});
+    report.print("peer_close: {s}\n", .{if (outcome.peer_closed) "clean" else "none"});
     report.print("key_updates.sent: {d}\n", .{outcome.key_updates_written});
     report.print("key_updates.received: {d}\n", .{outcome.key_updates_read});
     if (outcome.failure) |err| report.print("failure: {s}\n", .{@errorName(err)});
@@ -1087,6 +1116,31 @@ fn evaluate(args: Args, outcome: Outcome) u8 {
             outcome.key_updates_read,
         });
         failed = true;
+    }
+
+    if (outcome.received_len < args.expect_min_bytes) {
+        std.debug.print("tls-interop: expected at least {d} application byte(s) but observed {d}\n", .{
+            args.expect_min_bytes,
+            outcome.received_len,
+        });
+        failed = true;
+    }
+
+    switch (args.expect_peer_close) {
+        .none => {},
+        .clean => if (!outcome.peer_closed or outcome.failure != null) {
+            std.debug.print("tls-interop: expected clean peer close_notify but observed peer_closed={} error={?s}\n", .{
+                outcome.peer_closed,
+                if (outcome.failure) |err| @errorName(err) else null,
+            });
+            failed = true;
+        },
+        .truncated => if (outcome.failure == null or outcome.failure.? != error.TruncatedStream) {
+            std.debug.print("tls-interop: expected truncated peer close but observed error={?s}\n", .{
+                if (outcome.failure) |err| @errorName(err) else null,
+            });
+            failed = true;
+        },
     }
 
     // Which credential the *engine* selected, for rows that offer several.


### PR DESCRIPTION
## Summary

- add an explicit OpenSSL TCP `h2` entrypoint row that negotiates ALPN `h2` and verifies the full HTTP/2 client preface plus SETTINGS frame arrives as decrypted application data
- expand `run-tls-interop.sh --list` to show OpenSSL client/server, negative, KeyUpdate, selection, QUIC, shutdown, and HTTP entrypoint rows
- document issue #358 coverage, OpenSSL 3.x prerequisites, HTTP/1.1/HTTP/2 entrypoint behavior, and clean-close/truncation expectations

Closes #358

## Validation

- `bash -n scripts/interop/run-tls-interop.sh`
- `./scripts/interop/run-tls-interop.sh --list --profile ci`
- `zig build build-tls-interop build-h3-interop --summary all --error-style verbose`
- `zig build test-tls-interop-matrix --summary all --error-style verbose`
- `shellcheck scripts/interop/run-tls-interop.sh`
- `TLS_INTEROP_WORKDIR="$PWD/.tmp-tls-interop-594-latest" ./scripts/interop/run-tls-interop.sh --profile ci` (`pass=84 fail=0 skip=0`)
