### PR TITLE
perf(proxy): enforce HTTP/2 watermark and aggregate buffer backpressure (#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable user-facing changes to Tardigrade are documented here.
 ## [Unreleased]
 
 ### Added
+- **HTTP/2 proxy response buffering is bounded per stream *and* in aggregate
+  (#140)** — the streaming receive window an HTTP/2 upstream connection
+  advertises is now `TARDIGRADE_PROXY_BUFFER_PER_STREAM_HIGH_WATERMARK_BYTES`
+  rather than a fixed 1 MiB, so the protocol's own flow control stops a
+  well-behaved origin exactly where the buffer-accounting model says the
+  stream's queue is full. Credit is returned with hysteresis: a queue that
+  reached the high watermark is credited nothing until it drains below
+  `TARDIGRADE_PROXY_BUFFER_PER_STREAM_LOW_WATERMARK_BYTES`, then receives one
+  coalesced `WINDOW_UPDATE`. Crediting each consumed chunk would have let the
+  origin refill immediately and the watermark band would never pause anything.
+  Both transitions are now real signals on
+  `tardigrade_buffer_read_pauses_total{side="upstream"}` and its resume
+  counterpart, which previously only ever read zero.
+
+  Because per-stream bounds alone let N concurrent slow streams retain N
+  windows, `TARDIGRADE_PROXY_BUFFER_PER_ORIGIN_HARD_LIMIT_BYTES` and
+  `TARDIGRADE_PROXY_BUFFER_GLOBAL_HARD_LIMIT_BYTES` are now enforced rather than
+  merely validated. Reservations are taken before any memory is committed and
+  track each queue's **retained allocation** rather than its logical length — a
+  drained queue still owning its peak buffer would otherwise be invisible to
+  these limits — and a queue's storage is released as soon as it drains empty.
+  A refusal at one scope rolls back the other, so no scope is left holding bytes
+  the stream never took. Both limits still default to `0` (unlimited), so
+  existing deployments are unchanged until they opt in.
+
+  Refusals are deterministic on both sides of the downstream commitment
+  boundary. Before the response head is written the request fails with `503`
+  and the code `proxy_buffer_saturated`; after commitment the stream is reset
+  upstream, the response is truncated, and the event is logged. Either way this
+  is *local* saturation and is never recorded against upstream health, so proxy
+  memory pressure cannot trip a healthy origin's failure policy, and a refused
+  stream becomes discard-only so one refusal cannot be re-counted. Unrelated
+  streams, including others on the same connection, are untouched.
+  `tardigrade_buffer_limit_exceeded_total` now carries `scope="origin"` and
+  `scope="global"` alongside `scope="stream"`, and per-origin queued bytes are
+  visible as `tardigrade_upstream_h2_pool_buffered_bytes{upstream}`.
+
+  A high watermark that could not be advertised as an HTTP/2 window is rejected
+  at startup and reload. On reload, aggregate hard limits apply immediately,
+  including to origins already holding reservations; the per-stream policy
+  applies to connections opened afterwards, because
+  `SETTINGS_INITIAL_WINDOW_SIZE` is negotiated once per connection. Each
+  connection pins the whole policy it advertised, so a peer is always judged by
+  the credit it was actually granted rather than by a newer snapshot.
+
 - **Streaming reverse proxy completes its request-upload and transport scope
   (#139)** — `proxy_streaming_mode full` (and the per-route `proxy_streaming
   full` override) now relays `Transfer-Encoding: chunked` client uploads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,18 @@ All notable user-facing changes to Tardigrade are documented here.
   `RST_STREAM(FLOW_CONTROL_ERROR)` instead of being left to keep sending on a
   stream the proxy had already failed.
   `tardigrade_buffer_limit_exceeded_total` now carries `scope="origin"` and
-  `scope="global"` alongside `scope="stream"`, and per-origin queued bytes are
-  visible as `tardigrade_upstream_h2_pool_buffered_bytes{upstream}`.
+  `scope="global"` alongside `scope="stream"`; per-origin queued bytes are
+  visible as `tardigrade_upstream_h2_pool_buffered_bytes{upstream}`; and a
+  post-commitment truncation is counted as
+  `tardigrade_proxy_local_capacity_aborts_total` rather than
+  `tardigrade_proxy_upstream_aborts_total`, which means the *origin* aborted.
+
+  The bytes the global hard limit is actually checked against are exported as
+  `tardigrade_proxy_buffer_aggregate_bytes_current{direction,scope="global"}`,
+  read from the enforcing account. This is the series to compare with the
+  configured limit: `tardigrade_buffered_bytes_current{scope="global"}` is a
+  roll-up across every proxy-owned buffer, while the limit currently governs
+  HTTP/2 streaming response queues only.
 
   A high watermark that could not be advertised as an HTTP/2 window is rejected
   at startup and reload. On reload, aggregate hard limits apply immediately,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,13 +31,19 @@ All notable user-facing changes to Tardigrade are documented here.
   existing deployments are unchanged until they opt in.
 
   Refusals are deterministic on both sides of the downstream commitment
-  boundary. Before the response head is written the request fails with `503`
-  and the code `proxy_buffer_saturated`; after commitment the stream is reset
-  upstream, the response is truncated, and the event is logged. Either way this
-  is *local* saturation and is never recorded against upstream health, so proxy
-  memory pressure cannot trip a healthy origin's failure policy, and a refused
-  stream becomes discard-only so one refusal cannot be re-counted. Unrelated
-  streams, including others on the same connection, are untouched.
+  boundary, which is claimed under the connection's state lock rather than
+  raced. Before the response head is written the request fails with `503` and
+  the code `proxy_buffer_saturated` — including when an origin answers while a
+  streaming upload is still being written, so the refusal surfaces through the
+  next upload write; after commitment the stream is reset upstream, the
+  response is truncated, and the event is logged. Either way this is *local*
+  saturation and is never recorded against upstream health, so proxy memory
+  pressure cannot trip a healthy origin's failure policy, and a refused stream
+  becomes discard-only so one refusal cannot be re-counted. Unrelated streams,
+  including others on the same connection, are untouched. An origin that
+  overruns its advertised window is now also reset with
+  `RST_STREAM(FLOW_CONTROL_ERROR)` instead of being left to keep sending on a
+  stream the proxy had already failed.
   `tardigrade_buffer_limit_exceeded_total` now carries `scope="origin"` and
   `scope="global"` alongside `scope="stream"`, and per-origin queued bytes are
   visible as `tardigrade_upstream_h2_pool_buffered_bytes{upstream}`.

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -54,10 +54,17 @@ logs are written through `src/http/logger.zig`.
   URLs, request IDs, or stream IDs. Current byte gauges cover bounded buffered
   responses, HTTP/1 streaming relay buffers, and HTTP/2 streaming response
   queues. `scope="stream"` reports logical queue occupancy; `scope="global"`
-  reports retained allocation, which is the quantity the global hard limit is
-  enforced against, so that gauge is directly comparable to
-  `tardigrade_buffer_config_limit_bytes{scope="global"}`. The two differ while a
-  queue is partially drained but still owns its buffer.
+  reports retained allocation, and the two differ while a queue is partially
+  drained but still owns its buffer. The `scope="global"` series is a roll-up
+  across *all* proxy paths and is **not** the quantity the configured global
+  hard limit is checked against — see the next entry.
+- the aggregate bytes the global hard limit is enforced against:
+  `tardigrade_proxy_buffer_aggregate_bytes_current{direction,scope="global"}`,
+  read directly from the account that performs the enforcement. Today that
+  covers HTTP/2 streaming response queues only, so this is the series to compare
+  with `tardigrade_buffer_config_limit_bytes{scope="global",limit="hard"}`;
+  comparing the broader `tardigrade_buffered_bytes_current{scope="global"}`
+  roll-up with that limit overstates pressure under mixed traffic.
   `tardigrade_buffer_limit_exceeded_total` carries `scope="origin"` and
   `scope="global"` alongside `scope="stream"`: an aggregate refusal means the
   upstream origin (or the process) had no room for bytes the stream itself could
@@ -94,8 +101,14 @@ logs are written through `src/http/logger.zig`.
   handshake low/high/hard watermarks. These are not described as enforced by
   OpenSSL.
 - reverse-proxy abort counters:
-  `tardigrade_proxy_client_aborts_total` and
-  `tardigrade_proxy_upstream_aborts_total`
+  `tardigrade_proxy_client_aborts_total`,
+  `tardigrade_proxy_upstream_aborts_total`, and
+  `tardigrade_proxy_local_capacity_aborts_total`. The three are mutually
+  exclusive causes for one truncated transfer: the client went away, the origin
+  went away, or this proxy ran out of buffer capacity after the response head
+  was committed. The last is local pressure and is deliberately kept out of the
+  upstream series, and out of upstream health and circuit-breaker state, so it
+  cannot be mistaken for an origin fault.
 - reverse-proxy streaming fallback event counter:
   `tardigrade_proxy_streaming_fallback_total{reason=...}` with fixed reasons
   `policy_disabled`, `retries_configured`, and `early_data_retry_semantics` for

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -53,8 +53,20 @@ logs are written through `src/http/logger.zig`.
   to protocol-independent directions, scopes, and sides; they never include
   URLs, request IDs, or stream IDs. Current byte gauges cover bounded buffered
   responses, HTTP/1 streaming relay buffers, and HTTP/2 streaming response queues.
-  Pause/resume counters are exported as reserved zero-valued series until a later
-  backpressure slice adds production pause/resume transition sites.
+  `tardigrade_buffer_limit_exceeded_total` carries `scope="origin"` and
+  `scope="global"` alongside `scope="stream"`: an aggregate refusal means the
+  upstream origin (or the process) had no room for bytes the stream itself could
+  have held. `tardigrade_buffer_read_pauses_total{side="upstream"}` and its
+  resume counterpart record HTTP/2 streaming response queues crossing their high
+  and low watermarks — a pause means stream credit is being withheld from the
+  origin, a resume means the coalesced `WINDOW_UPDATE` went out. The
+  `side="downstream"` series remain reserved at zero until the HTTP/1 relay
+  gains pause/resume transition sites.
+- per-origin HTTP/2 buffer accounting:
+  `tardigrade_upstream_h2_pool_buffered_bytes{upstream}` and
+  `tardigrade_upstream_h2_pool_buffer_limit_exceeded_total{upstream}`. Label
+  cardinality is bounded by the number of distinct configured origins, matching
+  the other `tardigrade_upstream_h2_pool_*` series.
 - configured proxy buffer limits:
   `tardigrade_buffer_config_limit_bytes{direction,scope,limit}` for the
   per-stream low/high/hard watermarks plus per-origin/global hard-limit
@@ -300,11 +312,11 @@ Two outcome shapes exist:
 | Single header too large | `TARDIGRADE_MAX_HEADER_SIZE` | 8 KiB | `request_limits.validateHeaderSize` | `431`-class rejection |
 | All headers too large | `TARDIGRADE_MAX_HEADERS_TOTAL_SIZE` | 32 KiB | `request_limits.validateHeadersTotalSize` | `431` before body allocation |
 | Request body too large | `TARDIGRADE_MAX_BODY_SIZE` | 1 MiB | `request_limits.validateBodySize` | `413`-class rejection |
-| Proxy per-stream buffer low watermark | `TARDIGRADE_PROXY_BUFFER_PER_STREAM_LOW_WATERMARK_BYTES` | 256 KiB | proxy buffer accounting | Paired with high watermark for pause/resume decisions; must satisfy `low < high <= hard` |
-| Proxy per-stream buffer high watermark | `TARDIGRADE_PROXY_BUFFER_PER_STREAM_HIGH_WATERMARK_BYTES` | 768 KiB | proxy buffer accounting | High-watermark transition is observable through `tardigrade_buffer_high_watermark_events_total` |
+| Proxy per-stream buffer low watermark | `TARDIGRADE_PROXY_BUFFER_PER_STREAM_LOW_WATERMARK_BYTES` | 256 KiB | proxy buffer accounting; HTTP/2 stream credit | Must satisfy `low < high <= hard`. An HTTP/2 stream queue that reached the high watermark is credited nothing until it drains below this, then receives one coalesced `WINDOW_UPDATE` |
+| Proxy per-stream buffer high watermark | `TARDIGRADE_PROXY_BUFFER_PER_STREAM_HIGH_WATERMARK_BYTES` | 768 KiB | proxy buffer accounting; HTTP/2 `SETTINGS_INITIAL_WINDOW_SIZE` | High-watermark transition is observable through `tardigrade_buffer_high_watermark_events_total`. This value is advertised verbatim as the streaming HTTP/2 receive window, so a well-behaved origin stops sending once a stream holds this many unconsumed bytes. A reload applies to connections opened afterwards (SETTINGS are per connection) |
 | Proxy per-stream buffer hard limit | `TARDIGRADE_PROXY_BUFFER_PER_STREAM_HARD_LIMIT_BYTES` | 1 MiB | proxy buffer accounting | Hard-limit exceedance is observable through `tardigrade_buffer_limit_exceeded_total`; enforcement lands per proxy path as backpressure work expands |
-| Proxy per-origin buffer hard limit | `TARDIGRADE_PROXY_BUFFER_PER_ORIGIN_HARD_LIMIT_BYTES` | 0 (not enforced yet) | future aggregate proxy buffer accounting | When non-zero, must be at least the per-stream hard limit |
-| Proxy global buffer hard limit | `TARDIGRADE_PROXY_BUFFER_GLOBAL_HARD_LIMIT_BYTES` | 0 (not enforced yet) | future aggregate proxy buffer accounting | When non-zero, must be at least the per-stream hard limit |
+| Proxy per-origin buffer hard limit | `TARDIGRADE_PROXY_BUFFER_PER_ORIGIN_HARD_LIMIT_BYTES` | 0 (unlimited) | HTTP/2 streaming response queues | When non-zero, must be at least the per-stream hard limit. Caps the retained response-queue memory all streams to one origin hold together. Refused before commitment → `503 proxy_buffer_saturated`; refused after → that stream is reset and truncated. Never counted against upstream health. Reload applies immediately |
+| Proxy global buffer hard limit | `TARDIGRADE_PROXY_BUFFER_GLOBAL_HARD_LIMIT_BYTES` | 0 (unlimited) | HTTP/2 streaming response queues | When non-zero, must be at least the per-stream hard limit. Process-wide ceiling across every origin, with the same pre/post-commitment behavior; reload applies immediately |
 | Native TLS inbound ciphertext watermarks | `TARDIGRADE_TLS_INBOUND_CIPHERTEXT_LOW_WATERMARK_BYTES`, `TARDIGRADE_TLS_INBOUND_CIPHERTEXT_HIGH_WATERMARK_BYTES`, `TARDIGRADE_TLS_INBOUND_CIPHERTEXT_HARD_LIMIT_BYTES` | TLS core defaults | pure-Zig TLS record stream | Invalid ordering, capacity overflow, or reserve violations reject startup/reload |
 | Native TLS inbound plaintext watermarks | `TARDIGRADE_TLS_INBOUND_PLAINTEXT_LOW_WATERMARK_BYTES`, `TARDIGRADE_TLS_INBOUND_PLAINTEXT_HIGH_WATERMARK_BYTES`, `TARDIGRADE_TLS_INBOUND_PLAINTEXT_HARD_LIMIT_BYTES` | TLS core defaults | pure-Zig TLS record stream | High pauses carrier reads; resume occurs only after all inbound queues drain to low |
 | Native TLS outbound ciphertext watermarks | `TARDIGRADE_TLS_OUTBOUND_CIPHERTEXT_LOW_WATERMARK_BYTES`, `TARDIGRADE_TLS_OUTBOUND_CIPHERTEXT_HIGH_WATERMARK_BYTES`, `TARDIGRADE_TLS_OUTBOUND_CIPHERTEXT_HARD_LIMIT_BYTES` | TLS core defaults | pure-Zig TLS record stream | High pauses plaintext writes; hard-limit rejection does not advance write state |

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -52,7 +52,12 @@ logs are written through `src/http/logger.zig`.
   `tardigrade_buffer_limit_exceeded_total{direction,scope}`. Labels are fixed
   to protocol-independent directions, scopes, and sides; they never include
   URLs, request IDs, or stream IDs. Current byte gauges cover bounded buffered
-  responses, HTTP/1 streaming relay buffers, and HTTP/2 streaming response queues.
+  responses, HTTP/1 streaming relay buffers, and HTTP/2 streaming response
+  queues. `scope="stream"` reports logical queue occupancy; `scope="global"`
+  reports retained allocation, which is the quantity the global hard limit is
+  enforced against, so that gauge is directly comparable to
+  `tardigrade_buffer_config_limit_bytes{scope="global"}`. The two differ while a
+  queue is partially drained but still owns its buffer.
   `tardigrade_buffer_limit_exceeded_total` carries `scope="origin"` and
   `scope="global"` alongside `scope="stream"`: an aggregate refusal means the
   upstream origin (or the process) had no room for bytes the stream itself could

--- a/docs/PROXY_STREAMING.md
+++ b/docs/PROXY_STREAMING.md
@@ -152,6 +152,72 @@ size. The response buffer is `proxy_stream_buffer_size` (floored at 16 KiB); the
 upload buffer is a fixed 16 KiB. The HTTP/2 relay is bounded by the per-stream
 receive window, replenished only as the downstream relay drains.
 
-Configurable buffer accounting, aggregate caps, and pause/resume metrics are
-tracked separately in #140; the bounds described here are structural, not a
-substitute for that enforcement.
+### HTTP/2 response bounds
+
+The streaming receive window an HTTP/2 upstream connection advertises is
+`TARDIGRADE_PROXY_BUFFER_PER_STREAM_HIGH_WATERMARK_BYTES` — the same value the
+accounting model treats as "this stream's queue is full" — so a well-behaved
+origin stops sending exactly there. An origin that overruns the window is
+committing a flow-control violation and fails only its own stream.
+
+Credit is then returned with hysteresis rather than chunk by chunk. While a
+stream's queue sits at or above the high watermark, downstream-consumed bytes
+are accumulated but **not** credited back to the origin; the accumulated total
+is sent as a single `WINDOW_UPDATE` once the queue drains below
+`TARDIGRADE_PROXY_BUFFER_PER_STREAM_LOW_WATERMARK_BYTES`. Crediting each chunk
+as it drained would let the origin refill the queue immediately and the
+watermark band would never actually pause anything. Each transition is visible
+as `tardigrade_buffer_read_pauses_total{side="upstream"}` and
+`tardigrade_buffer_read_resumes_total{side="upstream"}`.
+
+Per-stream bounds alone do not bound the process: N concurrent slow streams
+retain up to N windows. Two aggregate hard limits close that gap:
+
+| Limit | Scope |
+| --- | --- |
+| `TARDIGRADE_PROXY_BUFFER_PER_ORIGIN_HARD_LIMIT_BYTES` | every stream on every connection to one upstream origin |
+| `TARDIGRADE_PROXY_BUFFER_GLOBAL_HARD_LIMIT_BYTES` | the whole process, across all origins |
+
+Both default to `0`, which means unlimited. Reservations are taken *before* any
+memory is committed, and they track each queue's **retained allocation** rather
+than its logical length — a drained queue that still owned its peak buffer
+would otherwise be invisible to these limits. A queue's storage (and its
+reservation) is released as soon as it drains empty.
+
+#### What a refusal does
+
+The behavior depends on whether the downstream response has been committed:
+
+- **Before the response head is written** — including the case where the reader
+  rejects DATA between decoding the origin's headers and the worker relaying
+  them — the request fails with `503` and the code `proxy_buffer_saturated`.
+  This is *local* saturation, so it is never recorded against upstream health
+  or the circuit breaker, and it is not retried: a retry would meet the same
+  wall.
+- **After commitment** the status can no longer change. The stream is reset
+  upstream immediately (`RST_STREAM(CANCEL)`), the downstream response is
+  truncated, every scope's reservation is released, and the truncation is
+  logged. It is counted in `tardigrade_buffer_limit_exceeded_total` at the
+  refusing scope but, again, is **not** counted as an upstream failure — local
+  memory pressure must not trip a healthy origin's failure policy.
+
+In both cases the stream becomes discard-only: DATA still in flight for it is
+dropped without reserving again, so a single refusal cannot be re-counted or
+re-queue bytes behind an error the consumer has not seen yet. Unrelated
+streams — including others on the same connection — are untouched, and a
+refusal rolls back cleanly across scopes, so a stream the origin scope rejects
+never leaves bytes reserved at the global scope.
+
+#### Reload semantics
+
+Aggregate hard limits apply immediately, including to origins that already hold
+reservations. The per-stream policy — and the receive window derived from it —
+applies to connections opened after the reload: `SETTINGS_INITIAL_WINDOW_SIZE`
+is negotiated once per connection, and a peer already holding credit is still
+judged by what it was granted. Each connection therefore pins the complete
+low/high/hard policy it advertised, and every stream on it is measured against
+that, never against a newer snapshot.
+
+The HTTP/1 relay's fixed buffers are accounted per stream but are not reserved
+against the aggregate scopes; their size does not grow with concurrency the way
+an HTTP/2 stream queue does.

--- a/docs/PROXY_STREAMING.md
+++ b/docs/PROXY_STREAMING.md
@@ -158,7 +158,9 @@ The streaming receive window an HTTP/2 upstream connection advertises is
 `TARDIGRADE_PROXY_BUFFER_PER_STREAM_HIGH_WATERMARK_BYTES` — the same value the
 accounting model treats as "this stream's queue is full" — so a well-behaved
 origin stops sending exactly there. An origin that overruns the window is
-committing a flow-control violation and fails only its own stream.
+committing a flow-control violation: that stream is failed, reset upstream with
+`RST_STREAM(FLOW_CONTROL_ERROR)` so the origin actually stops sending on it, and
+left discard-only. Other streams on the connection are unaffected.
 
 Credit is then returned with hysteresis rather than chunk by chunk. While a
 stream's queue sits at or above the high watermark, downstream-consumed bytes
@@ -184,16 +186,28 @@ than its logical length — a drained queue that still owned its peak buffer
 would otherwise be invisible to these limits. A queue's storage (and its
 reservation) is released as soon as it drains empty.
 
+This is also why the two current-byte gauges move on different schedules:
+`tardigrade_buffered_bytes_current{scope="stream"}` reports logical queue
+occupancy, while `scope="global"` reports retained allocation — the same
+quantity `TARDIGRADE_PROXY_BUFFER_GLOBAL_HARD_LIMIT_BYTES` is enforced against,
+so the gauge and its limit are directly comparable. A partially drained queue
+shows a lower stream value than global value; that is the buffer it still owns.
+
 #### What a refusal does
 
-The behavior depends on whether the downstream response has been committed:
+The behavior depends on whether the downstream response has been committed.
+That question is decided, not raced: the worker claims the commitment boundary
+under the connection's state lock immediately before writing the head, so a
+refusal that physically happened first is always treated as pre-commitment.
 
-- **Before the response head is written** — including the case where the reader
-  rejects DATA between decoding the origin's headers and the worker relaying
-  them — the request fails with `503` and the code `proxy_buffer_saturated`.
-  This is *local* saturation, so it is never recorded against upstream health
-  or the circuit breaker, and it is not retried: a retry would meet the same
-  wall.
+- **Before the response head is written** the request fails with `503` and the
+  code `proxy_buffer_saturated`. This covers the reader rejecting DATA between
+  decoding the origin's headers and the worker relaying them, and it also
+  covers a streaming upload: an origin can answer while the request body is
+  still being written, so a capacity refusal can surface through the *next
+  upload write* rather than through the response path. All of these are *local*
+  saturation, so none is recorded against upstream health or the circuit
+  breaker, and none is retried — a retry would meet the same wall.
 - **After commitment** the status can no longer change. The stream is reset
   upstream immediately (`RST_STREAM(CANCEL)`), the downstream response is
   truncated, every scope's reservation is released, and the truncation is

--- a/docs/PROXY_STREAMING.md
+++ b/docs/PROXY_STREAMING.md
@@ -186,12 +186,26 @@ than its logical length — a drained queue that still owned its peak buffer
 would otherwise be invisible to these limits. A queue's storage (and its
 reservation) is released as soon as it drains empty.
 
-This is also why the two current-byte gauges move on different schedules:
+This is also why the current-byte gauges move on different schedules:
 `tardigrade_buffered_bytes_current{scope="stream"}` reports logical queue
-occupancy, while `scope="global"` reports retained allocation — the same
-quantity `TARDIGRADE_PROXY_BUFFER_GLOBAL_HARD_LIMIT_BYTES` is enforced against,
-so the gauge and its limit are directly comparable. A partially drained queue
-shows a lower stream value than global value; that is the buffer it still owns.
+occupancy, while `scope="global"` reports retained allocation. A partially
+drained queue shows a lower stream value than global value; that is the buffer
+it still owns.
+
+**Do not compare `tardigrade_buffered_bytes_current{scope="global"}` with
+`TARDIGRADE_PROXY_BUFFER_GLOBAL_HARD_LIMIT_BYTES`.** That gauge is a roll-up of
+every proxy-owned buffer — bounded buffered responses, HTTP/1 relay buffers,
+request-side buffers, and HTTP/2 stream queues — whereas the hard limit is
+currently enforced only against HTTP/2 streaming response queues. Under mixed
+traffic the roll-up is larger than the quantity being checked, so reading it as
+"how close am I to the limit" overstates pressure.
+
+The series to put next to the limit is
+`tardigrade_proxy_buffer_aggregate_bytes_current{direction,scope="global"}`,
+which is read directly from the account that performs the enforcement. Bringing
+the remaining paths under the same aggregate is request-direction work (the
+issue's PR 3); until then these two gauges answer different questions, and the
+narrower one is the one the limit governs.
 
 #### What a refusal does
 

--- a/src/edge_config.zig
+++ b/src/edge_config.zig
@@ -1286,12 +1286,13 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
     const max_buffered_upstream_resp_str = envOrDefault(allocator, "TARDIGRADE_MAX_BUFFERED_UPSTREAM_RESPONSE_BYTES", "262144") catch unreachable;
     defer allocator.free(max_buffered_upstream_resp_str);
     const max_buffered_upstream_response_bytes = std.fmt.parseInt(usize, max_buffered_upstream_resp_str, 10) catch 256 * 1024;
+    const proxy_buffer_defaults = http.proxy_buffer_account.Limits.defaults();
     const proxy_buffer_limits = http.proxy_buffer_account.Limits{
-        .per_stream_low_watermark = parseIntEnv(usize, allocator, "TARDIGRADE_PROXY_BUFFER_PER_STREAM_LOW_WATERMARK_BYTES", 256 * 1024),
-        .per_stream_high_watermark = parseIntEnv(usize, allocator, "TARDIGRADE_PROXY_BUFFER_PER_STREAM_HIGH_WATERMARK_BYTES", 768 * 1024),
-        .per_stream_hard_limit = parseIntEnv(usize, allocator, "TARDIGRADE_PROXY_BUFFER_PER_STREAM_HARD_LIMIT_BYTES", 1024 * 1024),
-        .per_origin_hard_limit = parseIntEnv(usize, allocator, "TARDIGRADE_PROXY_BUFFER_PER_ORIGIN_HARD_LIMIT_BYTES", 0),
-        .global_hard_limit = parseIntEnv(usize, allocator, "TARDIGRADE_PROXY_BUFFER_GLOBAL_HARD_LIMIT_BYTES", 0),
+        .per_stream_low_watermark = parseIntEnv(usize, allocator, "TARDIGRADE_PROXY_BUFFER_PER_STREAM_LOW_WATERMARK_BYTES", proxy_buffer_defaults.per_stream_low_watermark),
+        .per_stream_high_watermark = parseIntEnv(usize, allocator, "TARDIGRADE_PROXY_BUFFER_PER_STREAM_HIGH_WATERMARK_BYTES", proxy_buffer_defaults.per_stream_high_watermark),
+        .per_stream_hard_limit = parseIntEnv(usize, allocator, "TARDIGRADE_PROXY_BUFFER_PER_STREAM_HARD_LIMIT_BYTES", proxy_buffer_defaults.per_stream_hard_limit),
+        .per_origin_hard_limit = parseIntEnv(usize, allocator, "TARDIGRADE_PROXY_BUFFER_PER_ORIGIN_HARD_LIMIT_BYTES", proxy_buffer_defaults.per_origin_hard_limit),
+        .global_hard_limit = parseIntEnv(usize, allocator, "TARDIGRADE_PROXY_BUFFER_GLOBAL_HARD_LIMIT_BYTES", proxy_buffer_defaults.global_hard_limit),
     };
 
     const proxy_streaming_mode_str = envOrDefault(allocator, "TARDIGRADE_PROXY_STREAMING_MODE", "off") catch unreachable;
@@ -4293,6 +4294,19 @@ test "proxy buffer limits validate low high hard ordering" {
         .per_origin_hard_limit = 512 * 1024,
         .global_hard_limit = 0,
     }).validate());
+}
+
+test "default proxy buffer limits produce the advertised HTTP/2 stream window" {
+    const allocator = std.testing.allocator;
+    var cfg = try loadFromEnv(allocator);
+    defer cfg.deinit(allocator);
+
+    // The window an h2 connection advertises is the configured high watermark,
+    // not the protocol-independent default.
+    try std.testing.expectEqual(
+        @as(u31, 768 * 1024),
+        http.proxy_buffer_account.streamReceiveWindow(cfg.proxy_buffer_limits),
+    );
 }
 
 test "TLS buffer limits default from TLS core" {

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -121,6 +121,7 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
         .connection_memory_estimate_bytes = if (cfg.max_connection_memory_bytes > 0) cfg.max_connection_memory_bytes else MAX_REQUEST_SIZE,
         .max_total_connection_memory_bytes = cfg.max_total_connection_memory_bytes,
         .proxy_buffer_limits = cfg.proxy_buffer_limits,
+        .proxy_buffer_global_account = http.proxy_buffer_account.Aggregate.init(.global, cfg.proxy_buffer_limits.global_hard_limit),
         .tls_buffer_limits = cfg.tls_buffer_limits,
         .upstream_rr_index = 0,
         .upstream_backup_rr_index = 0,
@@ -141,6 +142,10 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
         .h2_pool = http.upstream_h2.H2ConnPool.init(state_allocator, .{
             .idle_timeout_ms = cfg.upstream_pool_idle_timeout_ms,
             .max_lifetime_ms = cfg.upstream_pool_max_lifetime_ms,
+            // The advertised per-stream receive window *is* the configured
+            // per-stream high watermark (#140), so a well-behaved origin stops
+            // sending exactly where the accounting model fills up.
+            .proxy_buffer_limits = cfg.proxy_buffer_limits,
         }),
         .fastcgi_next_request_id = std.StringHashMap(u16).init(state_allocator),
         .proxy_cache_locks = std.StringHashMap(u32).init(state_allocator),

--- a/src/gateway_proxy.zig
+++ b/src/gateway_proxy.zig
@@ -191,6 +191,12 @@ pub const StreamingProxyResult = struct {
     response_body_bytes: usize,
     upstream_ttfb_ms: u64,
     upstream_aborted: bool = false,
+    /// The relay was truncated because *local* proxy buffer capacity ran out,
+    /// not because the origin failed. The response head was already committed
+    /// so the status cannot change, but the origin must not be blamed for it —
+    /// counting this against upstream health would let local memory pressure
+    /// trip a healthy origin's circuit breaker.
+    local_capacity_aborted: bool = false,
 };
 
 pub fn uriComponentBytes(component: std.Uri.Component) []const u8 {
@@ -801,6 +807,7 @@ fn streamViaH2Pool(
     cancel_token: ?*const CancellationToken,
     proxy_buffer_limits: proxy_buffer_account.Limits,
     proxy_buffer_observer: proxy_buffer_account.Observer,
+    proxy_buffer_global: ?*proxy_buffer_account.Aggregate,
 ) !StreamingProxyResult {
     const deadline_ms: u32 = if (read_deadline_ms > 0)
         read_deadline_ms
@@ -833,6 +840,25 @@ fn streamViaH2Pool(
             .h2 => |conn| {
                 if (h1_pool) |p| p.recordProtocol(true);
 
+                // Aggregate capacity for this origin's queued response bytes
+                // (#140). Looked up only on the h2 path, so an ALPN-h1 origin
+                // never creates an h2 origin entry. The pointer is stable for
+                // the pool's life, surviving retries and reconnects.
+                //
+                // A failure here means the accounting itself is unavailable
+                // (allocation failure) — precisely when these limits matter
+                // most. Dropping the scope would let the request retain
+                // response bytes outside the configured per-origin bound, so
+                // this is a deterministic pre-commit rejection instead.
+                const origin_buffer_account = h2_pool.originBufferAccount(key) catch {
+                    h2_pool.release(conn);
+                    return error.ProxyBufferCapacityUnavailable;
+                };
+                const proxy_buffer_capacity = proxy_buffer_account.AggregateCapacity{
+                    .origin = origin_buffer_account,
+                    .global = proxy_buffer_global,
+                };
+
                 var authority_buf: [300]u8 = undefined;
                 const authority = if (port == default_port)
                     host
@@ -857,8 +883,9 @@ fn streamViaH2Pool(
                     .headers = extra_headers,
                     .body = buffered_body,
                     .body_mode = if (streaming_body == null) .complete else .streaming,
-                    .proxy_buffer_limits = proxy_buffer_limits,
+                    .proxy_buffer_accounting = true,
                     .proxy_buffer_observer = proxy_buffer_observer,
+                    .proxy_buffer_capacity = proxy_buffer_capacity,
                 }) catch |err| {
                     // Nothing has reached the client yet: evict the dead
                     // connection so new requests do not pick it, and retry
@@ -893,6 +920,10 @@ fn streamViaH2Pool(
                     conn.finishStreaming(stream);
                     if (!conn.healthy()) h2_pool.evict(key, conn);
                     h2_pool.release(conn);
+                    // Local capacity, not the origin: nothing has reached the
+                    // client, so this becomes a clean 503 and never counts
+                    // against the origin. Retrying would hit the same wall.
+                    if (err == error.BufferLimitExceeded) return error.ProxyBufferCapacityUnavailable;
                     if (streaming_body == null and attempt == 0 and (err == error.Http2GoAway or err == error.Http2ConnectionClosed or err == error.Http2StreamReset)) {
                         continue;
                     }
@@ -921,6 +952,7 @@ fn streamViaH2Pool(
 
                 var body_bytes: usize = 0;
                 var aborted = false;
+                var local_capacity_aborted = false;
                 if (body_allowed) {
                     while (true) {
                         if (cancelStopped(cancel_token)) {
@@ -928,12 +960,19 @@ fn streamViaH2Pool(
                             h2_pool.release(conn);
                             return error.RequestCancelled;
                         }
-                        const n = conn.readStreamingBody(stream, read_buf) catch {
-                            // Upstream failed mid-body after the head went
-                            // downstream: report an aborted relay (the client
-                            // sees the truncated chunked body); other streams
-                            // on the connection are unaffected unless the
-                            // whole connection died (handled below).
+                        const n = conn.readStreamingBody(stream, read_buf) catch |err| {
+                            // Failed mid-body after the head went downstream:
+                            // report an aborted relay (the client sees the
+                            // truncated chunked body); other streams on the
+                            // connection are unaffected unless the whole
+                            // connection died (handled below).
+                            //
+                            // The status can no longer change, but the *cause*
+                            // still matters: a local buffer-capacity abort is
+                            // this proxy running out of room, and blaming the
+                            // origin for it would let local memory pressure
+                            // trip a healthy origin's failure policy.
+                            local_capacity_aborted = err == error.BufferLimitExceeded;
                             aborted = true;
                             break;
                         };
@@ -969,6 +1008,7 @@ fn streamViaH2Pool(
                     .response_body_bytes = body_bytes,
                     .upstream_ttfb_ms = ttfb_ms,
                     .upstream_aborted = aborted,
+                    .local_capacity_aborted = local_capacity_aborted,
                 };
             },
         }
@@ -1974,6 +2014,10 @@ pub fn executeStreamingHttpProxyRequest(
     sticky_set_cookie: ?[]const u8,
     cancel_token: ?*const CancellationToken,
     proxy_buffer_observer: proxy_buffer_account.Observer,
+    /// Process-wide proxy buffer aggregate (#140). Streams reserve against it
+    /// before retaining queued body bytes, so aggregate memory stays bounded no
+    /// matter how many origins or concurrent streams are slow.
+    proxy_buffer_global: ?*proxy_buffer_account.Aggregate,
     pool: ?*http.upstream_pool.UpstreamPool,
     /// Optional per-origin HTTP/2 multiplexing pool (#145).
     h2_pool: ?*http.upstream_h2.H2ConnPool,
@@ -2046,7 +2090,7 @@ pub fn executeStreamingHttpProxyRequest(
     if (stream_h2) {
         if (h2_pool) |hp| {
             const h2_opts: ?http.tls_termination.UpstreamTlsOptions = if (is_https) tls_options.? else null;
-            return streamViaH2Pool(allocator, hp, pool, host, port, h2_opts, uri, method, extra_headers.items, buffered_body, streaming_body, read_buf, downstream_conn, downstream_writer, security, alt_svc, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, cfg.proxy_buffer_limits, proxy_buffer_observer);
+            return streamViaH2Pool(allocator, hp, pool, host, port, h2_opts, uri, method, extra_headers.items, buffered_body, streaming_body, read_buf, downstream_conn, downstream_writer, security, alt_svc, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, cfg.proxy_buffer_limits, proxy_buffer_observer, proxy_buffer_global);
         }
         if (streaming_body != null) {
             if (pool) |p| p.recordH2StreamingUploadFallback();

--- a/src/gateway_proxy.zig
+++ b/src/gateway_proxy.zig
@@ -168,6 +168,10 @@ const ProxyBufferReservation = struct {
             after.high_watermark_events > before.high_watermark_events,
             after.limit_exceeded_events > before.limit_exceeded_events,
         );
+        // The HTTP/1 relay's buffer is allocated for as long as it is reserved,
+        // so its logical and retained byte counts move together — unlike an
+        // HTTP/2 stream queue, which drains ahead of its backing storage.
+        self.observer.recordRetainedBytes(self.account.direction, bytes);
         self.active = true;
     }
 
@@ -175,6 +179,7 @@ const ProxyBufferReservation = struct {
         if (!self.active) return;
         self.account.release(bytes) catch unreachable;
         self.observer.releaseReservation(self.account.direction, bytes);
+        self.observer.releaseRetainedBytes(self.account.direction, bytes);
         self.active = self.account.snapshot().current != 0;
     }
 
@@ -909,9 +914,18 @@ fn streamViaH2Pool(
                         proxy_buffer_limits,
                         proxy_buffer_observer,
                     ) catch |err| {
+                        const capacity_abort = err == error.BufferLimitExceeded or
+                            conn.abortCause(stream) == .local_capacity;
                         conn.finishStreaming(stream);
                         if (!conn.healthy()) h2_pool.evict(key, conn);
                         h2_pool.release(conn);
+                        // An early response can exhaust local buffer capacity
+                        // while the upload is still being written, and the
+                        // reader reports that through the *next* body write.
+                        // Nothing is committed downstream yet, so it is a 503 —
+                        // returning the raw error here made it a 502 charged to
+                        // a healthy origin.
+                        if (capacity_abort) return error.ProxyBufferCapacityUnavailable;
                         return err;
                     };
                 }
@@ -934,6 +948,18 @@ fn streamViaH2Pool(
 
                 const reason = gpres.upstreamReasonPhrase(@enumFromInt(status));
                 const body_allowed = gpres.responseBodyAllowed(method, status);
+                // Linearize the commitment boundary: the reader can reject DATA
+                // in the gap between the head arriving and this write starting.
+                // Claiming the transition under the connection's state lock
+                // makes that a decided question — a refusal that lands first is
+                // still a pre-commit 503 rather than a committed origin status
+                // that we then have to truncate.
+                conn.beginDownstreamCommit(stream) catch {
+                    conn.finishStreaming(stream);
+                    if (!conn.healthy()) h2_pool.evict(key, conn);
+                    h2_pool.release(conn);
+                    return error.ProxyBufferCapacityUnavailable;
+                };
                 gpres.writeStreamedUpstreamResponseHeadFromHeaders(
                     downstream_writer,
                     status,

--- a/src/gateway_proxy_runtime.zig
+++ b/src/gateway_proxy_runtime.zig
@@ -632,7 +632,15 @@ pub fn handleLocationProxyPass(
                     state.recordUpstreamSuccess(cfg, selection.base_url);
                 }
             }
-            if (streamed.upstream_aborted) state.metricsRecordProxyUpstreamAbort();
+            // `tardigrade_proxy_upstream_aborts_total` means "aborted by the
+            // origin". A truncation this proxy caused by running out of buffer
+            // capacity is not that, and counting it there would misattribute
+            // local pressure to the origin in dashboards and alerts.
+            if (streamed.local_capacity_aborted) {
+                state.metricsRecordProxyLocalCapacityAbort();
+            } else if (streamed.upstream_aborted) {
+                state.metricsRecordProxyUpstreamAbort();
+            }
             state.metricsRecordProxyStreamingRequest(streamed.upstream_ttfb_ms);
             ctx.setUpstreamResult(resolved.upstream_host, streamed.status_code, streamed.response_body_bytes);
             state.metricsRecord(streamed.status_code);

--- a/src/gateway_proxy_runtime.zig
+++ b/src/gateway_proxy_runtime.zig
@@ -544,6 +544,7 @@ pub fn handleLocationProxyPass(
                 sticky_set_cookie,
                 if (ctx.lifecycle) |lc| &lc.token else null,
                 proxy_buffer_observer,
+                state.proxyBufferGlobalAccount(),
                 &state.upstream_pool,
                 &state.h2_pool,
             ) catch |err| {
@@ -551,6 +552,15 @@ pub fn handleLocationProxyPass(
                 if (err == error.ClientAborted) {
                     state.metricsRecordProxyClientAbort();
                     return err;
+                }
+                if (err == error.ProxyBufferCapacityUnavailable) {
+                    // Local proxy buffer capacity, refused before any response
+                    // byte was committed (#140). Like the active-connection cap
+                    // above this is local saturation, not an origin fault, so
+                    // it must not touch upstream health / circuit-breaker state.
+                    try sendApiError(allocator, writer, .service_unavailable, "proxy_buffer_saturated", "Proxy buffer capacity exhausted", correlation_id, false, state);
+                    ctx.setUpstreamResult(resolved.upstream_host, @intFromEnum(http.Status.service_unavailable), 0);
+                    return @intFromEnum(http.Status.service_unavailable);
                 }
                 if (err == error.UpstreamAtCapacity) {
                     // Fail-fast at the per-origin active cap (#239): a local
@@ -611,7 +621,12 @@ pub fn handleLocationProxyPass(
                 transcript_redactions,
             );
             if (!isAbsoluteHttpUrl(std.mem.trim(u8, target, " \t\r\n"))) {
-                if (streamed.status_code >= 500 or streamed.upstream_aborted) {
+                // A relay truncated by local buffer capacity is not evidence
+                // about the origin, so it is neither a failure nor a success
+                // for health purposes (#140).
+                if (streamed.local_capacity_aborted) {
+                    state.logger.warn(correlation_id, "streaming relay truncated: local proxy buffer capacity exhausted", .{});
+                } else if (streamed.status_code >= 500 or streamed.upstream_aborted) {
                     state.recordUpstreamFailure(cfg, selection.base_url);
                 } else {
                     state.recordUpstreamSuccess(cfg, selection.base_url);

--- a/src/gateway_shutdown.zig
+++ b/src/gateway_shutdown.zig
@@ -740,13 +740,10 @@ test "applyReloadedRuntimeConfig updates exported proxy buffer limits" {
     state.max_in_flight_requests = 0;
     state.max_total_connection_memory_bytes = 0;
     state.connection_memory_estimate_bytes = MAX_REQUEST_SIZE;
-    state.proxy_buffer_limits = .{
-        .per_stream_low_watermark = 256 * 1024,
-        .per_stream_high_watermark = 768 * 1024,
-        .per_stream_hard_limit = 1024 * 1024,
-        .per_origin_hard_limit = 0,
-        .global_hard_limit = 0,
-    };
+    state.proxy_buffer_limits = http.proxy_buffer_account.Limits.defaults();
+    // Rendered as a gauge by `metricsToPrometheus` below, and this state starts
+    // as `undefined`, so it has to be initialized rather than inherited.
+    state.proxy_buffer_global_account = http.proxy_buffer_account.Aggregate.init(.global, 0);
     state.tls_buffer_limits = @import("tls_core").encrypted_stream.BufferLimits.defaults();
     state.compression_config = .{};
     state.logger = http.logger.Logger.init(.info, "test");

--- a/src/gateway_shutdown.zig
+++ b/src/gateway_shutdown.zig
@@ -630,6 +630,13 @@ pub fn applyReloadedRuntimeConfig(cfg: *const edge_config.EdgeConfig, state: *Ga
     state.max_total_connection_memory_bytes = cfg.max_total_connection_memory_bytes;
     state.connection_memory_estimate_bytes = if (cfg.max_connection_memory_bytes > 0) cfg.max_connection_memory_bytes else MAX_REQUEST_SIZE;
     state.proxy_buffer_limits = cfg.proxy_buffer_limits;
+    // Aggregate hard limits take effect immediately, at every scope and for
+    // origins that already exist. The per-stream policy — and the HTTP/2
+    // receive window derived from it — reaches connections opened after this
+    // point: SETTINGS_INITIAL_WINDOW_SIZE is negotiated once per connection, so
+    // a peer already holding credit is still judged by what it was granted.
+    state.proxy_buffer_global_account.setHardLimit(cfg.proxy_buffer_limits.global_hard_limit);
+    state.h2_pool.setProxyBufferLimits(cfg.proxy_buffer_limits);
     state.tls_buffer_limits = cfg.tls_buffer_limits;
     state.compression_config = .{
         .enabled = cfg.compression_enabled,

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -467,6 +467,10 @@ pub const GatewayState = struct {
     connection_memory_estimate_bytes: usize, // cfg-derived; updated on reload [runtime_mutex]
     max_total_connection_memory_bytes: usize, // cfg snapshot; updated on reload [runtime_mutex]
     proxy_buffer_limits: http.proxy_buffer_account.Limits, // cfg snapshot; updated on reload [runtime_mutex]
+    /// Process-wide proxy buffer reservations (#140). Lock-free and shared by
+    /// every worker, so its hard limit caps aggregate proxy body memory no
+    /// matter how many origins or streams are in flight. [atomic, no mutex]
+    proxy_buffer_global_account: http.proxy_buffer_account.Aggregate = http.proxy_buffer_account.Aggregate.init(.global, 0),
     tls_buffer_limits: @import("tls_core").encrypted_stream.BufferLimits, // cfg snapshot for native TLS; updated on reload [runtime_mutex]
     upstream_rr_index: usize, // LB selection state [upstream_mutex]
     upstream_backup_rr_index: usize, // LB selection state [upstream_mutex]
@@ -1514,12 +1518,54 @@ pub const GatewayState = struct {
         self.metrics.releaseProxyBufferReservation(direction, bytes) catch unreachable;
     }
 
+    pub fn metricsRecordProxyBufferLimitExceeded(
+        self: *GatewayState,
+        direction: http.proxy_buffer_account.Direction,
+        scope: http.proxy_buffer_account.Scope,
+    ) void {
+        self.metrics_mutex.lock();
+        defer self.metrics_mutex.unlock();
+        self.metrics.recordProxyBufferLimitExceeded(direction, scope);
+    }
+
+    /// The process-wide aggregate every proxy body reservation clears. Its hard
+    /// limit tracks `proxy_buffer_limits.global_hard_limit` across reloads.
+    pub fn proxyBufferGlobalAccount(self: *GatewayState) *http.proxy_buffer_account.Aggregate {
+        return &self.proxy_buffer_global_account;
+    }
+
     pub fn proxyBufferObserver(self: *GatewayState) http.proxy_buffer_account.Observer {
         return .{
             .context = self,
             .recordReservationFn = recordProxyBufferReservationObserved,
             .releaseReservationFn = releaseProxyBufferReservationObserved,
+            .recordAggregateLimitExceededFn = recordProxyBufferAggregateLimitExceededObserved,
+            .recordReadPauseFn = recordProxyBufferReadPauseObserved,
+            .recordReadResumeFn = recordProxyBufferReadResumeObserved,
         };
+    }
+
+    fn recordProxyBufferReadPauseObserved(context: *anyopaque, side: http.proxy_buffer_account.Side) void {
+        const self: *GatewayState = @ptrCast(@alignCast(context));
+        self.metrics_mutex.lock();
+        defer self.metrics_mutex.unlock();
+        self.metrics.recordProxyBufferReadPause(side.label());
+    }
+
+    fn recordProxyBufferReadResumeObserved(context: *anyopaque, side: http.proxy_buffer_account.Side) void {
+        const self: *GatewayState = @ptrCast(@alignCast(context));
+        self.metrics_mutex.lock();
+        defer self.metrics_mutex.unlock();
+        self.metrics.recordProxyBufferReadResume(side.label());
+    }
+
+    fn recordProxyBufferAggregateLimitExceededObserved(
+        context: *anyopaque,
+        direction: http.proxy_buffer_account.Direction,
+        scope: http.proxy_buffer_account.Scope,
+    ) void {
+        const self: *GatewayState = @ptrCast(@alignCast(context));
+        self.metricsRecordProxyBufferLimitExceeded(direction, scope);
     }
 
     fn recordProxyBufferReservationObserved(
@@ -1705,6 +1751,10 @@ pub const GatewayState = struct {
                 \\# TYPE tardigrade_upstream_h2_pool_stream_resets_total counter
                 \\# HELP tardigrade_upstream_h2_pool_goaway_total GOAWAY frames received per origin
                 \\# TYPE tardigrade_upstream_h2_pool_goaway_total counter
+                \\# HELP tardigrade_upstream_h2_pool_buffered_bytes Response bytes currently queued in HTTP/2 stream buffers per origin
+                \\# TYPE tardigrade_upstream_h2_pool_buffered_bytes gauge
+                \\# HELP tardigrade_upstream_h2_pool_buffer_limit_exceeded_total Origin-scope proxy buffer hard-limit refusals per origin
+                \\# TYPE tardigrade_upstream_h2_pool_buffer_limit_exceeded_total counter
                 \\
             );
             for (h2_origins) |snap| {
@@ -1712,6 +1762,8 @@ pub const GatewayState = struct {
                 try appendUpstreamLabelMetric(out, "tardigrade_upstream_h2_pool_streams_active", snap.origin, "{d}", .{snap.streams_active});
                 try appendUpstreamLabelMetric(out, "tardigrade_upstream_h2_pool_stream_resets_total", snap.origin, "{d}", .{snap.stream_resets_total});
                 try appendUpstreamLabelMetric(out, "tardigrade_upstream_h2_pool_goaway_total", snap.origin, "{d}", .{snap.goaway_total});
+                try appendUpstreamLabelMetric(out, "tardigrade_upstream_h2_pool_buffered_bytes", snap.origin, "{d}", .{snap.buffered_bytes});
+                try appendUpstreamLabelMetric(out, "tardigrade_upstream_h2_pool_buffer_limit_exceeded_total", snap.origin, "{d}", .{snap.buffer_limit_exceeded_total});
             }
         }
     }

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -1494,6 +1494,12 @@ pub const GatewayState = struct {
         self.metrics.recordProxyUpstreamAbort();
     }
 
+    pub fn metricsRecordProxyLocalCapacityAbort(self: *GatewayState) void {
+        self.metrics_mutex.lock();
+        defer self.metrics_mutex.unlock();
+        self.metrics.recordProxyLocalCapacityAbort();
+    }
+
     pub fn metricsRecordProxyStreamingFallback(self: *GatewayState, reason: http.metrics.ProxyStreamingFallbackReason) void {
         self.metrics_mutex.lock();
         defer self.metrics_mutex.unlock();
@@ -1841,6 +1847,7 @@ pub const GatewayState = struct {
         const http3_advertisement_state = self.http3_advertisement_state;
         self.runtime_mutex.unlock();
         try appendProxyBufferConfigPrometheus(&combined, proxy_buffer_limits);
+        try self.appendProxyBufferAggregatePrometheus(&combined);
         try appendTlsBufferConfigPrometheus(&combined, tls_buffer_limits);
         try combined.appendSlice(
             \\# HELP tardigrade_http3_effective_state HTTP/3 effective listener and advertisement state
@@ -1862,6 +1869,34 @@ pub const GatewayState = struct {
         }
         try self.appendUpstreamPoolPrometheus(&combined);
         return combined.toOwnedSlice();
+    }
+
+    /// The bytes the global hard limit is actually checked against, read
+    /// straight from the account that does the checking.
+    ///
+    /// This is deliberately a separate series from
+    /// `tardigrade_buffered_bytes_current{scope="global"}`: that gauge is a
+    /// roll-up of every proxy-owned buffer (bounded buffered responses, HTTP/1
+    /// relay buffers, request-side buffers, HTTP/2 queues), whereas
+    /// `TARDIGRADE_PROXY_BUFFER_GLOBAL_HARD_LIMIT_BYTES` is currently enforced
+    /// only against HTTP/2 streaming response queues. Comparing the roll-up
+    /// with the limit would mislead under mixed traffic; this series is the one
+    /// an operator can put next to the configured limit.
+    fn appendProxyBufferAggregatePrometheus(self: *GatewayState, out: *std.array_list.Managed(u8)) !void {
+        try out.appendSlice(
+            \\# HELP tardigrade_proxy_buffer_aggregate_bytes_current Bytes reserved at the aggregate scope the configured hard limit is enforced against (HTTP/2 streaming response queues)
+            \\# TYPE tardigrade_proxy_buffer_aggregate_bytes_current gauge
+            \\
+        );
+        inline for (.{
+            .{ "downstream_to_upstream", http.proxy_buffer_account.Direction.downstream_to_upstream },
+            .{ "upstream_to_downstream", http.proxy_buffer_account.Direction.upstream_to_downstream },
+        }) |entry| {
+            try out.print(
+                "tardigrade_proxy_buffer_aggregate_bytes_current{{direction=\"{s}\",scope=\"global\"}} {d}\n",
+                .{ entry[0], self.proxy_buffer_global_account.currentBytes(entry[1]) },
+            );
+        }
     }
 
     fn appendProxyBufferConfigPrometheus(out: *std.array_list.Managed(u8), limits: http.proxy_buffer_account.Limits) !void {
@@ -3611,13 +3646,14 @@ fn initMetricsJsonTestState(gs: *GatewayState, allocator: std.mem.Allocator) voi
     gs.upstream_pool = http.upstream_pool.UpstreamPool.init(allocator, .{});
     gs.h2_pool = http.upstream_h2.H2ConnPool.init(allocator, .{});
     gs.http3_advertisement_state = .disabled;
-    gs.proxy_buffer_limits = .{
-        .per_stream_low_watermark = 256 * 1024,
-        .per_stream_high_watermark = 768 * 1024,
-        .per_stream_hard_limit = 1024 * 1024,
-        .per_origin_hard_limit = 0,
-        .global_hard_limit = 0,
-    };
+    gs.proxy_buffer_limits = http.proxy_buffer_account.Limits.defaults();
+    // The state starts as `undefined`, so every field the metrics path reads
+    // has to be set here — the aggregate account is rendered as a gauge, and
+    // leaving it uninitialized would put garbage in the served metrics.
+    gs.proxy_buffer_global_account = http.proxy_buffer_account.Aggregate.init(
+        .global,
+        gs.proxy_buffer_limits.global_hard_limit,
+    );
     gs.tls_buffer_limits = @import("tls_core").encrypted_stream.BufferLimits.defaults();
 }
 
@@ -3675,6 +3711,36 @@ test "served Prometheus metrics expose h2 streaming upload fallback counter" {
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_config_limit_bytes{direction=\"upstream_to_downstream\",scope=\"stream\",limit=\"high\"} 786432\n") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_tls_buffer_config_limit_bytes{queue=\"outbound_ciphertext\",limit=\"hard\"}") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http3_effective_state{state=\"disabled\"} 1\n") != null);
+}
+
+test "served Prometheus metrics expose the aggregate bytes the global limit is enforced against" {
+    var gs: GatewayState = undefined;
+    initMetricsJsonTestState(&gs, std.testing.allocator);
+    defer gs.h2_pool.deinit();
+    defer gs.upstream_pool.deinit();
+    defer gs.mux_subscriptions_by_device.deinit();
+
+    gs.proxy_buffer_global_account.setHardLimit(4096);
+    try gs.proxy_buffer_global_account.reserve(.upstream_to_downstream, 1500);
+
+    // A buffered response also moves the generic roll-up gauge. The two series
+    // are intentionally different quantities: the roll-up covers every
+    // proxy-owned buffer, while the aggregate gauge is exactly what the
+    // configured global hard limit is checked against.
+    gs.metrics.recordProxyBufferedRequest(64, 5);
+
+    const prom = try gs.metricsToPrometheus(std.testing.allocator);
+    defer std.testing.allocator.free(prom);
+
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_proxy_buffer_aggregate_bytes_current{direction=\"upstream_to_downstream\",scope=\"global\"} 1500\n") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_proxy_buffer_aggregate_bytes_current{direction=\"downstream_to_upstream\",scope=\"global\"} 0\n") != null);
+    // The roll-up reports the buffered response, not the enforced reservation.
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffered_bytes_current{direction=\"upstream_to_downstream\",scope=\"global\"} 64\n") != null);
+
+    gs.proxy_buffer_global_account.release(.upstream_to_downstream, 1500);
+    const drained = try gs.metricsToPrometheus(std.testing.allocator);
+    defer std.testing.allocator.free(drained);
+    try std.testing.expect(std.mem.find(u8, drained, "tardigrade_proxy_buffer_aggregate_bytes_current{direction=\"upstream_to_downstream\",scope=\"global\"} 0\n") != null);
 }
 
 test "served Prometheus metrics reflect updated proxy buffer limit snapshot" {

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -1542,7 +1542,23 @@ pub const GatewayState = struct {
             .recordAggregateLimitExceededFn = recordProxyBufferAggregateLimitExceededObserved,
             .recordReadPauseFn = recordProxyBufferReadPauseObserved,
             .recordReadResumeFn = recordProxyBufferReadResumeObserved,
+            .recordRetainedBytesFn = recordProxyBufferRetainedObserved,
+            .releaseRetainedBytesFn = releaseProxyBufferRetainedObserved,
         };
+    }
+
+    fn recordProxyBufferRetainedObserved(context: *anyopaque, direction: http.proxy_buffer_account.Direction, bytes: usize) void {
+        const self: *GatewayState = @ptrCast(@alignCast(context));
+        self.metrics_mutex.lock();
+        defer self.metrics_mutex.unlock();
+        self.metrics.recordProxyBufferRetained(direction, bytes);
+    }
+
+    fn releaseProxyBufferRetainedObserved(context: *anyopaque, direction: http.proxy_buffer_account.Direction, bytes: usize) void {
+        const self: *GatewayState = @ptrCast(@alignCast(context));
+        self.metrics_mutex.lock();
+        defer self.metrics_mutex.unlock();
+        self.metrics.releaseProxyBufferRetained(direction, bytes) catch unreachable;
     }
 
     fn recordProxyBufferReadPauseObserved(context: *anyopaque, side: http.proxy_buffer_account.Side) void {

--- a/src/http/metrics.zig
+++ b/src/http/metrics.zig
@@ -148,6 +148,10 @@ pub const Metrics = struct {
     proxy_buffer_high_watermark_upstream_to_downstream_stream: u64,
     proxy_buffer_limit_exceeded_downstream_to_upstream_stream: u64,
     proxy_buffer_limit_exceeded_upstream_to_downstream_stream: u64,
+    proxy_buffer_limit_exceeded_downstream_to_upstream_origin: u64,
+    proxy_buffer_limit_exceeded_upstream_to_downstream_origin: u64,
+    proxy_buffer_limit_exceeded_downstream_to_upstream_global: u64,
+    proxy_buffer_limit_exceeded_upstream_to_downstream_global: u64,
     proxy_buffer_read_pauses_downstream: u64,
     proxy_buffer_read_pauses_upstream: u64,
     proxy_buffer_read_resumes_downstream: u64,
@@ -304,6 +308,10 @@ pub const Metrics = struct {
             .proxy_buffer_high_watermark_upstream_to_downstream_stream = 0,
             .proxy_buffer_limit_exceeded_downstream_to_upstream_stream = 0,
             .proxy_buffer_limit_exceeded_upstream_to_downstream_stream = 0,
+            .proxy_buffer_limit_exceeded_downstream_to_upstream_origin = 0,
+            .proxy_buffer_limit_exceeded_upstream_to_downstream_origin = 0,
+            .proxy_buffer_limit_exceeded_downstream_to_upstream_global = 0,
+            .proxy_buffer_limit_exceeded_upstream_to_downstream_global = 0,
             .proxy_buffer_read_pauses_downstream = 0,
             .proxy_buffer_read_pauses_upstream = 0,
             .proxy_buffer_read_resumes_downstream = 0,
@@ -632,10 +640,21 @@ pub const Metrics = struct {
     }
 
     pub fn recordProxyBufferLimitExceeded(self: *Metrics, direction: proxy_buffer_account.Direction, scope: proxy_buffer_account.Scope) void {
-        if (scope != .stream) return;
-        switch (direction) {
-            .downstream_to_upstream => self.proxy_buffer_limit_exceeded_downstream_to_upstream_stream += 1,
-            .upstream_to_downstream => self.proxy_buffer_limit_exceeded_upstream_to_downstream_stream += 1,
+        switch (scope) {
+            .stream => switch (direction) {
+                .downstream_to_upstream => self.proxy_buffer_limit_exceeded_downstream_to_upstream_stream += 1,
+                .upstream_to_downstream => self.proxy_buffer_limit_exceeded_upstream_to_downstream_stream += 1,
+            },
+            .origin => switch (direction) {
+                .downstream_to_upstream => self.proxy_buffer_limit_exceeded_downstream_to_upstream_origin += 1,
+                .upstream_to_downstream => self.proxy_buffer_limit_exceeded_upstream_to_downstream_origin += 1,
+            },
+            .global => switch (direction) {
+                .downstream_to_upstream => self.proxy_buffer_limit_exceeded_downstream_to_upstream_global += 1,
+                .upstream_to_downstream => self.proxy_buffer_limit_exceeded_upstream_to_downstream_global += 1,
+            },
+            // Downstream-connection scope has no proxy body queue of its own.
+            .connection => {},
         }
     }
 
@@ -969,6 +988,10 @@ pub const Metrics = struct {
             \\# TYPE tardigrade_buffer_limit_exceeded_total counter
             \\tardigrade_buffer_limit_exceeded_total{{direction="downstream_to_upstream",scope="stream"}} {d}
             \\tardigrade_buffer_limit_exceeded_total{{direction="upstream_to_downstream",scope="stream"}} {d}
+            \\tardigrade_buffer_limit_exceeded_total{{direction="downstream_to_upstream",scope="origin"}} {d}
+            \\tardigrade_buffer_limit_exceeded_total{{direction="upstream_to_downstream",scope="origin"}} {d}
+            \\tardigrade_buffer_limit_exceeded_total{{direction="downstream_to_upstream",scope="global"}} {d}
+            \\tardigrade_buffer_limit_exceeded_total{{direction="upstream_to_downstream",scope="global"}} {d}
             \\
         , .{
             self.proxy_buffer_downstream_to_upstream_stream_current,
@@ -983,6 +1006,10 @@ pub const Metrics = struct {
             self.proxy_buffer_read_resumes_upstream,
             self.proxy_buffer_limit_exceeded_downstream_to_upstream_stream,
             self.proxy_buffer_limit_exceeded_upstream_to_downstream_stream,
+            self.proxy_buffer_limit_exceeded_downstream_to_upstream_origin,
+            self.proxy_buffer_limit_exceeded_upstream_to_downstream_origin,
+            self.proxy_buffer_limit_exceeded_downstream_to_upstream_global,
+            self.proxy_buffer_limit_exceeded_upstream_to_downstream_global,
         });
 
         try self.appendTlsBufferPrometheus(&out);
@@ -2131,6 +2158,8 @@ test "Metrics toPrometheus produces valid Prometheus text" {
     m.recordProxyBufferReadPause("upstream");
     m.recordProxyBufferReadResume("upstream");
     m.recordProxyBufferLimitExceeded(.upstream_to_downstream, .stream);
+    m.recordProxyBufferLimitExceeded(.upstream_to_downstream, .origin);
+    m.recordProxyBufferLimitExceeded(.downstream_to_upstream, .global);
 
     const prom = try m.toPrometheus(allocator);
     defer allocator.free(prom);
@@ -2152,6 +2181,10 @@ test "Metrics toPrometheus produces valid Prometheus text" {
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_read_pauses_total{side=\"upstream\"} 1") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_read_resumes_total{side=\"upstream\"} 1") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_limit_exceeded_total{direction=\"upstream_to_downstream\",scope=\"stream\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_limit_exceeded_total{direction=\"upstream_to_downstream\",scope=\"origin\"} 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_limit_exceeded_total{direction=\"downstream_to_upstream\",scope=\"global\"} 1") != null);
+    // Aggregate scopes are counted independently of the per-stream scope.
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_limit_exceeded_total{direction=\"downstream_to_upstream\",scope=\"origin\"} 0") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_proxy_ttfb_ms_count 2") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_worker_active_jobs") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_worker_queued_jobs") != null);

--- a/src/http/metrics.zig
+++ b/src/http/metrics.zig
@@ -163,6 +163,7 @@ pub const Metrics = struct {
     tls_buffer_stalled_drives: [tls_backend_count]u64,
     proxy_client_aborts: u64,
     proxy_upstream_aborts: u64,
+    proxy_local_capacity_aborts: u64,
     proxy_streaming_fallback_policy_disabled: u64,
     proxy_streaming_fallback_retries_configured: u64,
     proxy_streaming_fallback_missing_content_length: u64,
@@ -323,6 +324,7 @@ pub const Metrics = struct {
             .tls_buffer_stalled_drives = .{0} ** tls_backend_count,
             .proxy_client_aborts = 0,
             .proxy_upstream_aborts = 0,
+            .proxy_local_capacity_aborts = 0,
             .proxy_streaming_fallback_policy_disabled = 0,
             .proxy_streaming_fallback_retries_configured = 0,
             .proxy_streaming_fallback_missing_content_length = 0,
@@ -743,6 +745,13 @@ pub const Metrics = struct {
         self.proxy_upstream_aborts += 1;
     }
 
+    /// A relay truncated because *this proxy* ran out of buffer capacity after
+    /// the response head was committed. Deliberately separate from
+    /// `proxy_upstream_aborts`, which means the origin aborted.
+    pub fn recordProxyLocalCapacityAbort(self: *Metrics) void {
+        self.proxy_local_capacity_aborts += 1;
+    }
+
     /// Exhaustive by construction: a new `ProxyStreamingFallbackReason` case
     /// fails to compile here until it is given a counter, which is what keeps a
     /// reason from being emitted into a metric that silently drops it.
@@ -1024,6 +1033,9 @@ pub const Metrics = struct {
             \\# HELP tardigrade_proxy_upstream_aborts_total Total proxied transfers aborted by upstream origins
             \\# TYPE tardigrade_proxy_upstream_aborts_total counter
             \\tardigrade_proxy_upstream_aborts_total {d}
+            \\# HELP tardigrade_proxy_local_capacity_aborts_total Total proxied responses truncated after commitment because local proxy buffer capacity was exhausted
+            \\# TYPE tardigrade_proxy_local_capacity_aborts_total counter
+            \\tardigrade_proxy_local_capacity_aborts_total {d}
             \\# HELP tardigrade_proxy_streaming_fallback_total Total streaming eligibility fallback events by reason
             \\# TYPE tardigrade_proxy_streaming_fallback_total counter
             \\tardigrade_proxy_streaming_fallback_total{{reason="policy_disabled"}} {d}
@@ -1059,6 +1071,7 @@ pub const Metrics = struct {
         , .{
             self.proxy_client_aborts,
             self.proxy_upstream_aborts,
+            self.proxy_local_capacity_aborts,
             self.proxy_streaming_fallback_policy_disabled,
             self.proxy_streaming_fallback_retries_configured,
             self.proxy_streaming_fallback_missing_content_length,
@@ -1997,6 +2010,12 @@ test "Metrics tracks active connections and rejections" {
     try std.testing.expectEqual(@as(u64, 128), m.proxy_buffered_bytes_total);
     try std.testing.expectEqual(@as(u64, 1), m.proxy_client_aborts);
     try std.testing.expectEqual(@as(u64, 1), m.proxy_upstream_aborts);
+    // Local-capacity truncations are counted separately from origin aborts:
+    // `tardigrade_proxy_upstream_aborts_total` means the *origin* gave up.
+    try std.testing.expectEqual(@as(u64, 0), m.proxy_local_capacity_aborts);
+    m.recordProxyLocalCapacityAbort();
+    try std.testing.expectEqual(@as(u64, 1), m.proxy_local_capacity_aborts);
+    try std.testing.expectEqual(@as(u64, 1), m.proxy_upstream_aborts);
     try std.testing.expectEqual(@as(u64, 2), m.proxy_ttfb_ms_count);
     try std.testing.expectEqual(@as(u64, 20), m.proxy_ttfb_ms_sum);
     m.setUpstreamUnhealthyBackends(3);
@@ -2182,6 +2201,8 @@ test "Metrics toPrometheus produces valid Prometheus text" {
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_read_resumes_total{side=\"upstream\"} 1") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_limit_exceeded_total{direction=\"upstream_to_downstream\",scope=\"stream\"} 1") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_limit_exceeded_total{direction=\"upstream_to_downstream\",scope=\"origin\"} 1") != null);
+    // A local-capacity truncation must not land in the upstream-abort series.
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_proxy_local_capacity_aborts_total 0") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_limit_exceeded_total{direction=\"downstream_to_upstream\",scope=\"global\"} 1") != null);
     // Aggregate scopes are counted independently of the per-stream scope.
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_buffer_limit_exceeded_total{direction=\"downstream_to_upstream\",scope=\"origin\"} 0") != null);

--- a/src/http/metrics.zig
+++ b/src/http/metrics.zig
@@ -562,9 +562,16 @@ pub const Metrics = struct {
         const bytes: u64 = @intCast(buffered_bytes);
         if (bytes > self.proxy_buffered_bytes_current) return error.BufferAccountingUnderflow;
         self.proxy_buffered_bytes_current -= bytes;
+        // A fully buffered response holds one allocation for exactly as long as
+        // it holds the bytes, so both scopes move together here.
         try self.releaseProxyBufferReservation(.upstream_to_downstream, buffered_bytes);
+        try self.releaseProxyBufferRetained(.upstream_to_downstream, buffered_bytes);
     }
 
+    /// Per-stream logical queue occupancy. Deliberately does **not** touch the
+    /// aggregate gauge: the `scope="global"` series reports retained allocation
+    /// (what the global hard limit enforces), which a partially drained queue
+    /// still owns. Callers pair this with `recordProxyBufferRetained`.
     pub fn recordProxyBufferReservation(
         self: *Metrics,
         direction: proxy_buffer_account.Direction,
@@ -573,28 +580,21 @@ pub const Metrics = struct {
         limit_exceeded: bool,
     ) void {
         self.recordProxyBufferBytes(direction, .stream, bytes);
-        self.recordProxyBufferBytes(direction, .global, bytes);
         if (high_watermark) self.recordProxyBufferHighWatermark(direction, .stream);
         if (limit_exceeded) self.recordProxyBufferLimitExceeded(direction, .stream);
     }
 
     pub fn releaseProxyBufferReservation(self: *Metrics, direction: proxy_buffer_account.Direction, bytes: usize) !void {
-        const value: u64 = @intCast(bytes);
-        var stream_slot: *u64 = undefined;
-        var global_slot: *u64 = undefined;
-        switch (direction) {
-            .downstream_to_upstream => {
-                stream_slot = &self.proxy_buffer_downstream_to_upstream_stream_current;
-                global_slot = &self.proxy_buffer_downstream_to_upstream_global_current;
-            },
-            .upstream_to_downstream => {
-                stream_slot = &self.proxy_buffer_upstream_to_downstream_stream_current;
-                global_slot = &self.proxy_buffer_upstream_to_downstream_global_current;
-            },
-        }
-        if (value > stream_slot.* or value > global_slot.*) return error.BufferAccountingUnderflow;
-        stream_slot.* -= value;
-        global_slot.* -= value;
+        try self.releaseProxyBufferBytes(direction, .stream, bytes);
+    }
+
+    /// Bytes entering the aggregate scopes, i.e. allocation an owner retains.
+    pub fn recordProxyBufferRetained(self: *Metrics, direction: proxy_buffer_account.Direction, bytes: usize) void {
+        self.recordProxyBufferBytes(direction, .global, bytes);
+    }
+
+    pub fn releaseProxyBufferRetained(self: *Metrics, direction: proxy_buffer_account.Direction, bytes: usize) !void {
+        try self.releaseProxyBufferBytes(direction, .global, bytes);
     }
 
     pub fn recordProxyBufferBytes(self: *Metrics, direction: proxy_buffer_account.Direction, scope: proxy_buffer_account.Scope, bytes: usize) void {
@@ -976,11 +976,11 @@ pub const Metrics = struct {
             \\# TYPE tardigrade_buffer_high_watermark_events_total counter
             \\tardigrade_buffer_high_watermark_events_total{{direction="downstream_to_upstream",scope="stream"}} {d}
             \\tardigrade_buffer_high_watermark_events_total{{direction="upstream_to_downstream",scope="stream"}} {d}
-            \\# HELP tardigrade_buffer_read_pauses_total Reserved for future proxy reads paused by stalled buffer pressure side
+            \\# HELP tardigrade_buffer_read_pauses_total Proxy reads paused by buffer pressure, by peer side
             \\# TYPE tardigrade_buffer_read_pauses_total counter
             \\tardigrade_buffer_read_pauses_total{{side="downstream"}} {d}
             \\tardigrade_buffer_read_pauses_total{{side="upstream"}} {d}
-            \\# HELP tardigrade_buffer_read_resumes_total Reserved for future proxy reads resumed after buffer pressure drops
+            \\# HELP tardigrade_buffer_read_resumes_total Proxy reads resumed after buffer pressure dropped below the low watermark, by peer side
             \\# TYPE tardigrade_buffer_read_resumes_total counter
             \\tardigrade_buffer_read_resumes_total{{side="downstream"}} {d}
             \\tardigrade_buffer_read_resumes_total{{side="upstream"}} {d}

--- a/src/http/proxy_buffer_account.zig
+++ b/src/http/proxy_buffer_account.zig
@@ -120,6 +120,13 @@ pub const Observer = struct {
     /// its high watermark, and resumed once it drained back below low.
     recordReadPauseFn: ?*const fn (*anyopaque, Side) void = null,
     recordReadResumeFn: ?*const fn (*anyopaque, Side) void = null,
+    /// Optional: bytes entering or leaving the *aggregate* scopes. These track
+    /// retained allocation, which is what the aggregate hard limits enforce and
+    /// therefore what the aggregate current-byte gauge must report — it moves
+    /// on a different schedule from the per-stream logical queue length, which
+    /// drains ahead of the storage backing it.
+    recordRetainedBytesFn: ?*const fn (*anyopaque, Direction, usize) void = null,
+    releaseRetainedBytesFn: ?*const fn (*anyopaque, Direction, usize) void = null,
 
     pub fn recordReservation(self: Observer, direction: Direction, bytes: usize, high_watermark: bool, limit_exceeded: bool) void {
         self.recordReservationFn(self.context, direction, bytes, high_watermark, limit_exceeded);
@@ -139,6 +146,16 @@ pub const Observer = struct {
 
     pub fn recordReadResume(self: Observer, side: Side) void {
         if (self.recordReadResumeFn) |f| f(self.context, side);
+    }
+
+    pub fn recordRetainedBytes(self: Observer, direction: Direction, bytes: usize) void {
+        if (bytes == 0) return;
+        if (self.recordRetainedBytesFn) |f| f(self.context, direction, bytes);
+    }
+
+    pub fn releaseRetainedBytes(self: Observer, direction: Direction, bytes: usize) void {
+        if (bytes == 0) return;
+        if (self.releaseRetainedBytesFn) |f| f(self.context, direction, bytes);
     }
 };
 

--- a/src/http/proxy_buffer_account.zig
+++ b/src/http/proxy_buffer_account.zig
@@ -12,6 +12,19 @@ pub const Direction = enum {
     }
 };
 
+/// Which peer's reads a pause/resume transition applies to.
+pub const Side = enum {
+    downstream,
+    upstream,
+
+    pub fn label(self: Side) []const u8 {
+        return switch (self) {
+            .downstream => "downstream",
+            .upstream => "upstream",
+        };
+    }
+};
+
 pub const Scope = enum {
     stream,
     connection,
@@ -35,6 +48,20 @@ pub const Limits = struct {
     per_origin_hard_limit: usize,
     global_hard_limit: usize,
 
+    /// The shipped defaults, and the single source of truth for them:
+    /// `edge_config` parses each environment override against these, and code
+    /// that needs a valid policy without a config (tests, unpooled
+    /// connections) uses them directly rather than inventing its own.
+    pub fn defaults() Limits {
+        return .{
+            .per_stream_low_watermark = 256 * 1024,
+            .per_stream_high_watermark = 768 * 1024,
+            .per_stream_hard_limit = 1024 * 1024,
+            .per_origin_hard_limit = 0,
+            .global_hard_limit = 0,
+        };
+    }
+
     pub fn validate(self: Limits) !void {
         if (self.per_stream_low_watermark == 0 or
             self.per_stream_high_watermark == 0 or
@@ -53,8 +80,27 @@ pub const Limits = struct {
         if (self.global_hard_limit != 0 and self.global_hard_limit < self.per_stream_hard_limit) {
             return error.InvalidBufferLimits;
         }
+        // The high watermark becomes an HTTP/2 receive window verbatim; a value
+        // that would have to be clamped would silently stop matching the
+        // configured policy.
+        if (self.per_stream_high_watermark > max_stream_receive_window) {
+            return error.InvalidBufferLimits;
+        }
     }
 };
+
+/// Largest window HTTP/2 flow control can advertise (RFC 9113 §6.9.1). The
+/// per-stream policy is clamped to this when it is turned into a receive
+/// window; `validate` rejects a high watermark that would need clamping.
+pub const max_stream_receive_window: usize = 0x7FFF_FFFF;
+
+/// The receive window a streaming HTTP/2 stream advertises: the per-stream high
+/// watermark, so the peer stops sending exactly where the accounting model says
+/// the queue is full. The hard limit (>= high) absorbs DATA already in flight
+/// when the window closes.
+pub fn streamReceiveWindow(limits: Limits) u31 {
+    return @intCast(@min(limits.per_stream_high_watermark, max_stream_receive_window));
+}
 
 pub const Snapshot = struct {
     current: usize,
@@ -67,6 +113,13 @@ pub const Observer = struct {
     context: *anyopaque,
     recordReservationFn: *const fn (*anyopaque, Direction, usize, bool, bool) void,
     releaseReservationFn: *const fn (*anyopaque, Direction, usize) void,
+    /// Optional: a hard-limit rejection at an aggregate scope (origin/global).
+    /// Per-stream rejections are reported through `recordReservationFn`.
+    recordAggregateLimitExceededFn: ?*const fn (*anyopaque, Direction, Scope) void = null,
+    /// Optional: reads on `side` stopped being credited because a queue rose to
+    /// its high watermark, and resumed once it drained back below low.
+    recordReadPauseFn: ?*const fn (*anyopaque, Side) void = null,
+    recordReadResumeFn: ?*const fn (*anyopaque, Side) void = null,
 
     pub fn recordReservation(self: Observer, direction: Direction, bytes: usize, high_watermark: bool, limit_exceeded: bool) void {
         self.recordReservationFn(self.context, direction, bytes, high_watermark, limit_exceeded);
@@ -74,6 +127,139 @@ pub const Observer = struct {
 
     pub fn releaseReservation(self: Observer, direction: Direction, bytes: usize) void {
         self.releaseReservationFn(self.context, direction, bytes);
+    }
+
+    pub fn recordAggregateLimitExceeded(self: Observer, direction: Direction, scope: Scope) void {
+        if (self.recordAggregateLimitExceededFn) |f| f(self.context, direction, scope);
+    }
+
+    pub fn recordReadPause(self: Observer, side: Side) void {
+        if (self.recordReadPauseFn) |f| f(self.context, side);
+    }
+
+    pub fn recordReadResume(self: Observer, side: Side) void {
+        if (self.recordReadResumeFn) |f| f(self.context, side);
+    }
+};
+
+/// Which aggregate scope refused a reservation. Distinct errors so the caller
+/// can label the metric without a second lookup.
+pub const AggregateError = error{
+    OriginBufferLimitExceeded,
+    GlobalBufferLimitExceeded,
+};
+
+pub fn aggregateFailureScope(err: AggregateError) Scope {
+    return switch (err) {
+        error.OriginBufferLimitExceeded => .origin,
+        error.GlobalBufferLimitExceeded => .global,
+    };
+}
+
+/// Thread-safe reservation counter for a scope shared by many streams (one
+/// upstream origin, or the whole process). Concurrent streams reserve here
+/// *before* they may retain bytes, so concurrency cannot multiply the
+/// per-stream bound without bound. A zero hard limit means "unlimited" and
+/// keeps the counter as a pure gauge.
+///
+/// Lock-free: `reserve` is a compare-and-swap loop against the scope's current
+/// byte count, so the HTTP/2 reader thread never blocks another origin's reader
+/// on a shared mutex.
+pub const Aggregate = struct {
+    scope: Scope,
+    hard_limit: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+    current: [2]std.atomic.Value(usize) = .{
+        std.atomic.Value(usize).init(0),
+        std.atomic.Value(usize).init(0),
+    },
+    limit_exceeded_events: [2]std.atomic.Value(u64) = .{
+        std.atomic.Value(u64).init(0),
+        std.atomic.Value(u64).init(0),
+    },
+
+    pub fn init(scope: Scope, hard_limit: usize) Aggregate {
+        return .{
+            .scope = scope,
+            .hard_limit = std.atomic.Value(usize).init(hard_limit),
+        };
+    }
+
+    /// Apply a reloaded limit. Bytes already reserved above the new limit stay
+    /// reserved; the next reservation is refused until the scope drains.
+    pub fn setHardLimit(self: *Aggregate, hard_limit: usize) void {
+        self.hard_limit.store(hard_limit, .monotonic);
+    }
+
+    pub fn hardLimit(self: *const Aggregate) usize {
+        return self.hard_limit.load(.monotonic);
+    }
+
+    pub fn reserve(self: *Aggregate, direction: Direction, bytes: usize) error{BufferLimitExceeded}!void {
+        const slot = &self.current[@intFromEnum(direction)];
+        const limit = self.hard_limit.load(.monotonic);
+        var current = slot.load(.monotonic);
+        while (true) {
+            const next = std.math.add(usize, current, bytes) catch {
+                self.noteLimitExceeded(direction);
+                return error.BufferLimitExceeded;
+            };
+            if (limit != 0 and next > limit) {
+                self.noteLimitExceeded(direction);
+                return error.BufferLimitExceeded;
+            }
+            if (slot.cmpxchgWeak(current, next, .monotonic, .monotonic)) |actual| {
+                current = actual;
+                continue;
+            }
+            return;
+        }
+    }
+
+    pub fn release(self: *Aggregate, direction: Direction, bytes: usize) void {
+        if (bytes == 0) return;
+        const slot = &self.current[@intFromEnum(direction)];
+        std.debug.assert(slot.load(.monotonic) >= bytes);
+        _ = slot.fetchSub(bytes, .monotonic);
+    }
+
+    pub fn currentBytes(self: *const Aggregate, direction: Direction) usize {
+        return self.current[@intFromEnum(direction)].load(.monotonic);
+    }
+
+    pub fn limitExceededEvents(self: *const Aggregate, direction: Direction) u64 {
+        return self.limit_exceeded_events[@intFromEnum(direction)].load(.monotonic);
+    }
+
+    fn noteLimitExceeded(self: *Aggregate, direction: Direction) void {
+        _ = self.limit_exceeded_events[@intFromEnum(direction)].fetchAdd(1, .monotonic);
+    }
+};
+
+/// The aggregate scopes one stream's queued bytes must clear. Either member may
+/// be null (a path with no origin identity, or a test harness), which makes
+/// that scope unlimited and unaccounted.
+pub const AggregateCapacity = struct {
+    origin: ?*Aggregate = null,
+    global: ?*Aggregate = null,
+
+    /// Reserve at every configured scope, or nothing at all: a refusal at the
+    /// origin scope rolls the global reservation back, so no scope is left
+    /// holding bytes the stream never retained.
+    pub fn reserve(self: AggregateCapacity, direction: Direction, bytes: usize) AggregateError!void {
+        if (self.global) |g| {
+            g.reserve(direction, bytes) catch return error.GlobalBufferLimitExceeded;
+        }
+        if (self.origin) |o| {
+            o.reserve(direction, bytes) catch {
+                if (self.global) |g| g.release(direction, bytes);
+                return error.OriginBufferLimitExceeded;
+            };
+        }
+    }
+
+    pub fn release(self: AggregateCapacity, direction: Direction, bytes: usize) void {
+        if (self.origin) |o| o.release(direction, bytes);
+        if (self.global) |g| g.release(direction, bytes);
     }
 };
 
@@ -190,6 +376,95 @@ test "proxy buffer account tracks high low transitions and release" {
     try std.testing.expectEqual(@as(u64, 1), account.snapshot().limit_exceeded_events);
     account.releaseAll();
     try std.testing.expectEqual(@as(usize, 0), account.snapshot().current);
+}
+
+test "stream receive window follows the configured high watermark" {
+    try std.testing.expectEqual(@as(u31, 768 * 1024), streamReceiveWindow(.{
+        .per_stream_low_watermark = 256 * 1024,
+        .per_stream_high_watermark = 768 * 1024,
+        .per_stream_hard_limit = 1024 * 1024,
+        .per_origin_hard_limit = 0,
+        .global_hard_limit = 0,
+    }));
+
+    try std.testing.expectError(error.InvalidBufferLimits, (Limits{
+        .per_stream_low_watermark = 4,
+        .per_stream_high_watermark = max_stream_receive_window + 1,
+        .per_stream_hard_limit = max_stream_receive_window + 2,
+        .per_origin_hard_limit = 0,
+        .global_hard_limit = 0,
+    }).validate());
+}
+
+test "aggregate enforces a hard limit and releases back to zero" {
+    var aggregate = Aggregate.init(.origin, 32);
+
+    try aggregate.reserve(.upstream_to_downstream, 24);
+    try std.testing.expectEqual(@as(usize, 24), aggregate.currentBytes(.upstream_to_downstream));
+
+    try std.testing.expectError(error.BufferLimitExceeded, aggregate.reserve(.upstream_to_downstream, 16));
+    try std.testing.expectEqual(@as(u64, 1), aggregate.limitExceededEvents(.upstream_to_downstream));
+    // The refused reservation retained nothing.
+    try std.testing.expectEqual(@as(usize, 24), aggregate.currentBytes(.upstream_to_downstream));
+
+    // Directions are accounted independently.
+    try aggregate.reserve(.downstream_to_upstream, 32);
+    try std.testing.expectEqual(@as(usize, 32), aggregate.currentBytes(.downstream_to_upstream));
+
+    aggregate.release(.upstream_to_downstream, 24);
+    aggregate.release(.downstream_to_upstream, 32);
+    try std.testing.expectEqual(@as(usize, 0), aggregate.currentBytes(.upstream_to_downstream));
+    try std.testing.expectEqual(@as(usize, 0), aggregate.currentBytes(.downstream_to_upstream));
+}
+
+test "aggregate with no hard limit stays a pure gauge" {
+    var aggregate = Aggregate.init(.global, 0);
+    try aggregate.reserve(.upstream_to_downstream, std.math.maxInt(usize) / 2);
+    try std.testing.expectEqual(@as(u64, 0), aggregate.limitExceededEvents(.upstream_to_downstream));
+    aggregate.release(.upstream_to_downstream, std.math.maxInt(usize) / 2);
+    try std.testing.expectEqual(@as(usize, 0), aggregate.currentBytes(.upstream_to_downstream));
+}
+
+test "aggregate capacity rolls the global reservation back when the origin refuses" {
+    var origin = Aggregate.init(.origin, 16);
+    var global = Aggregate.init(.global, 1024);
+    const capacity = AggregateCapacity{ .origin = &origin, .global = &global };
+
+    try capacity.reserve(.upstream_to_downstream, 16);
+    try std.testing.expectEqual(@as(usize, 16), global.currentBytes(.upstream_to_downstream));
+
+    try std.testing.expectError(
+        error.OriginBufferLimitExceeded,
+        capacity.reserve(.upstream_to_downstream, 8),
+    );
+    // The global scope must not retain bytes for a reservation the origin refused.
+    try std.testing.expectEqual(@as(usize, 16), global.currentBytes(.upstream_to_downstream));
+    try std.testing.expectEqual(@as(usize, 16), origin.currentBytes(.upstream_to_downstream));
+
+    capacity.release(.upstream_to_downstream, 16);
+    try std.testing.expectEqual(@as(usize, 0), global.currentBytes(.upstream_to_downstream));
+    try std.testing.expectEqual(@as(usize, 0), origin.currentBytes(.upstream_to_downstream));
+}
+
+test "aggregate capacity reports the refusing scope" {
+    var origin = Aggregate.init(.origin, 1024);
+    var global = Aggregate.init(.global, 8);
+    const capacity = AggregateCapacity{ .origin = &origin, .global = &global };
+
+    try std.testing.expectError(
+        error.GlobalBufferLimitExceeded,
+        capacity.reserve(.upstream_to_downstream, 9),
+    );
+    try std.testing.expectEqual(Scope.global, aggregateFailureScope(error.GlobalBufferLimitExceeded));
+    try std.testing.expectEqual(Scope.origin, aggregateFailureScope(error.OriginBufferLimitExceeded));
+    // A refusal at the first scope never touches the origin.
+    try std.testing.expectEqual(@as(usize, 0), origin.currentBytes(.upstream_to_downstream));
+}
+
+test "unconfigured aggregate capacity is a no-op" {
+    const capacity = AggregateCapacity{};
+    try capacity.reserve(.upstream_to_downstream, std.math.maxInt(usize));
+    capacity.release(.upstream_to_downstream, std.math.maxInt(usize));
 }
 
 test "proxy buffer account reports over-release without changing current" {

--- a/src/http/upstream_h2.zig
+++ b/src/http/upstream_h2.zig
@@ -977,6 +977,16 @@ pub fn H2Conn(comptime Transport: type) type {
             return stream.abort_cause;
         }
 
+        /// The buffer policy this stream is being judged by — the connection's
+        /// pinned policy when accounting is on. Locked because the reader
+        /// mutates the account it lives in.
+        pub fn streamBufferLimits(self: *Self, stream: *Stream) ?proxy_buffer_account.Limits {
+            self.state_mutex.lock();
+            defer self.state_mutex.unlock();
+            const account = stream.proxy_body_account orelse return null;
+            return account.limits;
+        }
+
         /// Copy the next chunk of a streaming response body into `out`,
         /// blocking (deadline-bounded) until data, end-of-stream, or an error.
         /// Returns 0 at end of stream. The caller must acknowledge each
@@ -2616,8 +2626,13 @@ test "an open connection keeps the per-stream policy it advertised" {
         .path = "/",
         .proxy_buffer_accounting = true,
     });
-    try testing.expectEqual(pinned, stream.proxy_body_account.?.limits);
-    try testing.expectEqual(@as(i64, 64 * 1024), stream.recv_window);
+    try testing.expectEqual(pinned, conn.streamBufferLimits(stream).?);
+    // Deliberately no assertion on `stream.recv_window` here: the reader
+    // decrements it as response DATA lands, so any value read from this thread
+    // is a race with the origin. The window's actual size is pinned down
+    // deterministically by "configured per-stream window replaces the default
+    // streaming receive window", which cuts the peer off at exactly the
+    // advertised byte count.
 
     conn.finishStreaming(stream);
     conn.deinit();

--- a/src/http/upstream_h2.zig
+++ b/src/http/upstream_h2.zig
@@ -64,6 +64,16 @@ const CONN_RECV_WINDOW: i64 = 8 << 20;
 const WAIT_SWEEP_INTERVAL_MS: u64 = 1_000;
 const STREAM_ID: u31 = 1;
 
+/// RST_STREAM error codes we emit (RFC 9113 §7).
+const RST_FLOW_CONTROL_ERROR: u32 = 0x3;
+const RST_CANCEL: u32 = 0x8;
+
+fn rstStreamPayload(code: u32) [4]u8 {
+    var buf: [4]u8 = undefined;
+    std.mem.writeInt(u32, &buf, code, .big);
+    return buf;
+}
+
 pub const H2Error = error{
     Http2Timeout,
     Http2GoAway,
@@ -101,6 +111,24 @@ pub const Request = struct {
 pub const BodyMode = enum {
     complete,
     streaming,
+};
+
+/// Why a stream was aborted. `local_capacity` means *this proxy* ran out of
+/// buffer room, which is never evidence about the origin — the distinction has
+/// to survive all the way out to status selection and upstream health.
+pub const AbortCause = enum {
+    none,
+    upstream,
+    local_capacity,
+};
+
+/// How far the downstream response has got. The transition to `committing` is
+/// the linearization point for the commitment boundary: taken under
+/// `state_mutex`, it makes "did the reader reject DATA before or after we
+/// started writing the head?" a decided question rather than a race.
+pub const DownstreamCommitState = enum {
+    precommit,
+    committing,
 };
 
 pub const Response = struct {
@@ -471,15 +499,18 @@ pub const Stream = struct {
     /// reader extends it on progress). Bounds every wait even when the shared
     /// connection stays busy with other streams (#196 guarantee).
     wait_deadline_ms: u64 = 0,
-    /// True once the stream's HEADERS frame reached the wire. Guards
-    /// `finishStreaming`'s RST_STREAM: resetting a stream the peer never saw
-    /// (idle state) would be a connection-level PROTOCOL_ERROR. Written and
-    /// read only by the owning worker thread.
+    /// True once the stream's HEADERS frame is being put on the wire. Guards
+    /// every RST_STREAM: resetting a stream the peer never saw (idle state)
+    /// would be a connection-level PROTOCOL_ERROR. Set by the owning worker and
+    /// read by the reader thread, so it lives under `state_mutex` like the rest
+    /// of the stream state machine.
     wire_opened: bool = false,
     local_abort: bool = false,
-    /// Set once the reader has emitted RST_STREAM for a locally aborted stream,
-    /// so `finishStreaming` does not send a second one.
+    /// Set once the reader has emitted RST_STREAM for this stream, so
+    /// `finishStreaming` does not send a second one.
     rst_sent: bool = false,
+    abort_cause: AbortCause = .none,
+    downstream_state: DownstreamCommitState = .precommit,
     /// Per-stream logical queue length: the bytes a downstream consumer has not
     /// taken yet. Drives the high/low watermark hysteresis.
     proxy_body_account: ?proxy_buffer_account.Account = null,
@@ -566,6 +597,9 @@ pub const Stream = struct {
         try self.body.ensureTotalCapacityPrecise(allocator, needed_capacity);
         self.body.appendSliceAssumeCapacity(payload);
         self.proxy_capacity_reserved += capacity_delta;
+        if (self.proxy_buffer_observer) |observer| {
+            observer.recordRetainedBytes(direction, capacity_delta);
+        }
 
         const after = account.snapshot();
         const crossed_high = after.high_watermark_events > before.high_watermark_events;
@@ -600,7 +634,11 @@ pub const Stream = struct {
     /// aggregate limits exist to prevent.
     fn releaseRetainedStorage(self: *Stream) void {
         if (self.proxy_capacity_reserved == 0) return;
-        self.proxy_buffer_capacity.release(self.accountDirection(), self.proxy_capacity_reserved);
+        const direction = self.accountDirection();
+        self.proxy_buffer_capacity.release(direction, self.proxy_capacity_reserved);
+        if (self.proxy_buffer_observer) |observer| {
+            observer.releaseRetainedBytes(direction, self.proxy_capacity_reserved);
+        }
         self.proxy_capacity_reserved = 0;
     }
 
@@ -917,6 +955,28 @@ pub fn H2Conn(comptime Transport: type) type {
             if (write_result) |_| {} else |err| return self.markWriteFailure(err);
         }
 
+        /// Claim the commitment boundary for this stream's downstream response.
+        /// Call immediately before writing the response head; it fails when the
+        /// stream was already aborted for local buffer capacity, so a refusal
+        /// that physically happened before the head reached the client is
+        /// reported as one instead of becoming a truncated origin status.
+        ///
+        /// Once this returns, the reader knows the head is going out and later
+        /// capacity failures are handled as post-commitment truncations.
+        pub fn beginDownstreamCommit(self: *Self, stream: *Stream) error{BufferLimitExceeded}!void {
+            self.state_mutex.lock();
+            defer self.state_mutex.unlock();
+            if (stream.abort_cause == .local_capacity) return error.BufferLimitExceeded;
+            stream.downstream_state = .committing;
+        }
+
+        /// Why this stream aborted, if it did.
+        pub fn abortCause(self: *Self, stream: *Stream) AbortCause {
+            self.state_mutex.lock();
+            defer self.state_mutex.unlock();
+            return stream.abort_cause;
+        }
+
         /// Copy the next chunk of a streaming response body into `out`,
         /// blocking (deadline-bounded) until data, end-of-stream, or an error.
         /// Returns 0 at end of stream. The caller must acknowledge each
@@ -1084,11 +1144,24 @@ pub fn H2Conn(comptime Transport: type) type {
             // per frame — and, crucially, never holds it while waiting on
             // state_mutex for flow-control window (the reader needs write_mutex
             // for PING/SETTINGS acks; holding both would deadlock it).
+            //
+            // Publish `wire_opened` under `state_mutex` *before* the write: a
+            // fast origin can respond the instant the HEADERS syscall lands, so
+            // the reader may need to reset this stream while this thread is
+            // still inside the write. Setting it afterwards left the reader
+            // racing a plain store and potentially skipping a reset for a
+            // stream the peer had already seen. A failed write poisons
+            // `conn_err`, which keeps `finishStreaming` from emitting a reset
+            // for a request that never reached the peer.
+            {
+                self.state_mutex.lock();
+                stream.wire_opened = true;
+                self.state_mutex.unlock();
+            }
             self.write_mutex.lock();
             const write_result = self.writeHeaderBlockLocked(stream.id, block, end_stream);
             self.write_mutex.unlock();
             if (write_result) |_| {} else |err| return self.markWriteFailure(err);
-            stream.wire_opened = true;
             if (req.body.len > 0) try self.sendBody(stream, req.body, request_body_complete);
         }
 
@@ -1347,7 +1420,9 @@ pub fn H2Conn(comptime Transport: type) type {
             const maybe_stream = self.streams.get(fr.stream_id);
             var replenish_stream = false;
             var flow_violation = false;
-            var reset_stream = false;
+            // RST_STREAM error code to emit for this stream once the lock is
+            // dropped, if any (RFC 9113 §7).
+            var reset_code: ?u32 = null;
             if (maybe_stream) |s| {
                 var deliver = fr.payload.len > 0;
                 // A stream we already gave up on is discard-only. Without this,
@@ -1366,6 +1441,17 @@ pub fn H2Conn(comptime Transport: type) type {
                     s.recv_window -= @as(i64, @intCast(fr.payload.len));
                     if (s.recv_window < 0) {
                         if (s.err == null) s.err = error.Http2FlowControlError;
+                        // Tell the peer to stop. Without this the origin keeps
+                        // sending on a stream we have already failed — the
+                        // connection window is replenished per frame, so
+                        // nothing else would slow it down — until the worker
+                        // eventually finishes the stream. `finishStreaming`
+                        // will not cover this either: its predicate skips
+                        // streams carrying a non-local error.
+                        if (!s.rst_sent and s.wire_opened) {
+                            s.rst_sent = true;
+                            reset_code = RST_FLOW_CONTROL_ERROR;
+                        }
                         flow_violation = true;
                         deliver = false;
                     }
@@ -1381,9 +1467,10 @@ pub fn H2Conn(comptime Transport: type) type {
                         error.BufferLimitExceeded => {
                             if (s.err == null) s.err = err;
                             s.local_abort = true;
+                            s.abort_cause = .local_capacity;
                             if (!s.rst_sent and s.wire_opened) {
                                 s.rst_sent = true;
-                                reset_stream = true;
+                                reset_code = RST_CANCEL;
                             }
                             deliver = false;
                         },
@@ -1402,9 +1489,9 @@ pub fn H2Conn(comptime Transport: type) type {
             self.state_mutex.unlock();
             // Send-window waiters block on the connection cond.
             if (flow_violation) self.cond.broadcast();
-            if (reset_stream) {
-                const cancel_code = [4]u8{ 0, 0, 0, 8 }; // CANCEL
-                self.writeControl(.rst_stream, 0, fr.stream_id, &cancel_code);
+            if (reset_code) |code| {
+                const payload = rstStreamPayload(code);
+                self.writeControl(.rst_stream, 0, fr.stream_id, &payload);
             }
 
             if (fr.payload.len > 0) {
@@ -2014,6 +2101,9 @@ const TestProxyBufferObserver = struct {
     global_limit_exceeded: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
     read_pauses: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
     read_resumes: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    /// Mirrors what the `scope="global"` gauge would report: retained
+    /// allocation, which moves on a different schedule from `current`.
+    retained: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
 
     fn observer(self: *TestProxyBufferObserver) proxy_buffer_account.Observer {
         return .{
@@ -2023,7 +2113,19 @@ const TestProxyBufferObserver = struct {
             .recordAggregateLimitExceededFn = recordAggregateLimitExceeded,
             .recordReadPauseFn = recordReadPause,
             .recordReadResumeFn = recordReadResume,
+            .recordRetainedBytesFn = recordRetained,
+            .releaseRetainedBytesFn = releaseRetained,
         };
+    }
+
+    fn recordRetained(context: *anyopaque, _: proxy_buffer_account.Direction, bytes: usize) void {
+        const self: *TestProxyBufferObserver = @ptrCast(@alignCast(context));
+        _ = self.retained.fetchAdd(bytes, .monotonic);
+    }
+
+    fn releaseRetained(context: *anyopaque, _: proxy_buffer_account.Direction, bytes: usize) void {
+        const self: *TestProxyBufferObserver = @ptrCast(@alignCast(context));
+        _ = self.retained.fetchSub(bytes, .monotonic);
     }
 
     fn recordReadPause(context: *anyopaque, _: proxy_buffer_account.Side) void {
@@ -2849,13 +2951,22 @@ test "streaming response trailers end the stream and are discarded" {
     _ = std.c.close(fds[1]);
 }
 
+/// What the flow-violation server observed coming back from the client.
+const FlowViolationObservation = struct {
+    /// Set once the client's PING ACK arrives, proving its reader has processed
+    /// every frame the server sent — including the over-window one.
+    saw_ack: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    rst_stream_id: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+    rst_code: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+};
+
 /// Canned server that violates flow control: sends `window` bytes of DATA
 /// (filling the advertised stream window exactly) plus one more frame beyond it
 /// without waiting for replenishment, then a PING whose ACK proves the client's
-/// reader has processed every prior frame. `saw_ack` is set once the ACK
-/// arrives so the test can start consuming deterministically. `window` must be
-/// a multiple of `DEFAULT_MAX_FRAME`.
-fn cannedFlowViolationServer(peer_fd: std.posix.fd_t, window: usize, saw_ack: *std.atomic.Value(bool)) void {
+/// reader has processed every prior frame. `window` must be a multiple of
+/// `DEFAULT_MAX_FRAME`. Any RST_STREAM the client sends before that ACK is
+/// recorded, which is how the overrun reset is asserted.
+fn cannedFlowViolationServer(peer_fd: std.posix.fd_t, window: usize, obs: *FlowViolationObservation) void {
     const a = std.heap.page_allocator;
     var srv = PlainTransport{ .fd = peer_fd };
     var preface: [PREFACE.len]u8 = undefined;
@@ -2888,9 +2999,13 @@ fn cannedFlowViolationServer(peer_fd: std.posix.fd_t, window: usize, saw_ack: *s
     while (true) {
         var fr = readFrameBounded(&srv, peer_fd, a, 5000) catch return;
         const is_ack = fr.typ == .ping and (fr.flags & frame.Flags.ACK) != 0;
+        if (fr.typ == .rst_stream and fr.payload.len >= 4) {
+            obs.rst_code.store(std.mem.readInt(u32, fr.payload[0..4], .big), .release);
+            obs.rst_stream_id.store(@intCast(fr.stream_id), .release);
+        }
         frame.deinitFrame(a, &fr);
         if (is_ack) {
-            saw_ack.store(true, .release);
+            obs.saw_ack.store(true, .release);
             return;
         }
     }
@@ -2898,8 +3013,8 @@ fn cannedFlowViolationServer(peer_fd: std.posix.fd_t, window: usize, saw_ack: *s
 
 test "streaming stream fails when the peer overruns the advertised window" {
     const fds = try makeSocketpair();
-    var saw_ack = std.atomic.Value(bool).init(false);
-    const server = try std.Thread.spawn(.{}, cannedFlowViolationServer, .{ fds[1], DEFAULT_STREAM_RECV_WINDOW, &saw_ack });
+    var obs = FlowViolationObservation{};
+    const server = try std.Thread.spawn(.{}, cannedFlowViolationServer, .{ fds[1], DEFAULT_STREAM_RECV_WINDOW, &obs });
 
     var transport = PlainTransport{ .fd = fds[0] };
     const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 5000, null, null, null, windowLimits(DEFAULT_STREAM_RECV_WINDOW));
@@ -2910,8 +3025,8 @@ test "streaming stream fails when the peer overruns the advertised window" {
     // server sent — including the over-window one — so the violation is
     // recorded before we start draining (draining replenishes the window).
     var spins: usize = 0;
-    while (!saw_ack.load(.acquire) and spins < 100_000_000) : (spins += 1) std.Thread.yield() catch {};
-    try testing.expect(saw_ack.load(.acquire));
+    while (!obs.saw_ack.load(.acquire) and spins < 100_000_000) : (spins += 1) std.Thread.yield() catch {};
+    try testing.expect(obs.saw_ack.load(.acquire));
 
     // The in-window megabyte drains fine; the overrun then surfaces as a
     // flow-control error rather than unbounded buffering.
@@ -2925,6 +3040,12 @@ test "streaming stream fails when the peer overruns the advertised window" {
     };
     try testing.expectEqual(@as(usize, DEFAULT_STREAM_RECV_WINDOW), total);
     try testing.expectError(error.Http2FlowControlError, @as(anyerror!void, read_err));
+
+    // The peer is actually told to stop. Without a reset it could keep sending
+    // on a stream we have already failed — the connection window is replenished
+    // per frame, so nothing else would slow it down.
+    try testing.expectEqual(@as(u32, stream.id), obs.rst_stream_id.load(.acquire));
+    try testing.expectEqual(RST_FLOW_CONTROL_ERROR, obs.rst_code.load(.acquire));
 
     conn.finishStreaming(stream);
     conn.deinit();
@@ -2941,8 +3062,8 @@ test "configured per-stream window replaces the default streaming receive window
     try testing.expectEqual(@as(u31, 4 * DEFAULT_MAX_FRAME), window);
 
     const fds = try makeSocketpair();
-    var saw_ack = std.atomic.Value(bool).init(false);
-    const server = try std.Thread.spawn(.{}, cannedFlowViolationServer, .{ fds[1], @as(usize, window), &saw_ack });
+    var obs = FlowViolationObservation{};
+    const server = try std.Thread.spawn(.{}, cannedFlowViolationServer, .{ fds[1], @as(usize, window), &obs });
 
     var transport = PlainTransport{ .fd = fds[0] };
     const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 5000, null, null, null, limits);
@@ -2950,8 +3071,8 @@ test "configured per-stream window replaces the default streaming receive window
     const stream = try conn.requestStreaming(.{ .method = "GET", .authority = "window.test", .path = "/" });
 
     var spins: usize = 0;
-    while (!saw_ack.load(.acquire) and spins < 100_000_000) : (spins += 1) std.Thread.yield() catch {};
-    try testing.expect(saw_ack.load(.acquire));
+    while (!obs.saw_ack.load(.acquire) and spins < 100_000_000) : (spins += 1) std.Thread.yield() catch {};
+    try testing.expect(obs.saw_ack.load(.acquire));
 
     var total: usize = 0;
     var buf: [8 * 1024]u8 = undefined;
@@ -3011,10 +3132,16 @@ test "streaming response reservations clear every aggregate scope after teardown
 }
 
 /// Canned server for the concurrent-stream aggregate case: answers two
-/// streams, fills the first with `first_bytes` of DATA and then sends
-/// `second_bytes` on the second, and reports the id of whichever stream the
-/// client resets. Both DATA bursts stay inside each stream's own advertised
-/// window, so anything the client refuses it refuses on aggregate grounds.
+/// streams, completes the first with `first_bytes` of DATA carrying
+/// END_STREAM, then sends `second_bytes` on the second. Both bursts stay
+/// inside each stream's own advertised window, so anything the client refuses
+/// it refuses on aggregate grounds.
+///
+/// The first stream is completed rather than left open on purpose: a
+/// wire-open stream is legitimately reset by `finishStreaming`, and an earlier
+/// revision of this test recorded that unrelated CANCEL as "the" reset and
+/// failed on CI. The server records *every* reset id so the assertion can be
+/// about which stream was reset for the capacity event, not about ordering.
 fn cannedTwoStreamServer(
     peer_fd: std.posix.fd_t,
     first_bytes: usize,
@@ -3048,7 +3175,9 @@ fn cannedTwoStreamServer(
     }
 
     const payload = [_]u8{'x'} ** 256;
-    frame.writeFrame(&srv, .data, 0, ids[0], payload[0..first_bytes]) catch return;
+    // END_STREAM: the healthy stream completes, so nothing later has cause to
+    // reset it and any reset the client sends is the capacity one.
+    frame.writeFrame(&srv, .data, frame.Flags.END_STREAM, ids[0], payload[0..first_bytes]) catch return;
     frame.writeFrame(&srv, .data, 0, ids[1], payload[0..second_bytes]) catch return;
 
     while (true) {
@@ -3104,11 +3233,22 @@ test "origin capacity bounds concurrent streams and refuses only the overflowing
     // The second stream is refused; the first is untouched and still usable.
     var buf: [128]u8 = undefined;
     try testing.expectError(error.BufferLimitExceeded, conn.readStreamingBody(refused, buf[0..]));
+    try testing.expectEqual(AbortCause.local_capacity, conn.abortCause(refused));
+    // The refusal landed before any head relay, so claiming the commitment
+    // boundary must fail — this is what turns the race into a pre-commit 503
+    // instead of a committed origin status followed by a truncation.
+    try testing.expectError(error.BufferLimitExceeded, conn.beginDownstreamCommit(refused));
+    // The healthy stream can still commit.
+    try conn.beginDownstreamCommit(slow);
     try testing.expect(origin.currentBytes(.upstream_to_downstream) <= window);
 
     const n = try conn.readStreamingBody(slow, buf[0..]);
     try testing.expectEqual(window, n);
     conn.acknowledgeStreamingBody(slow, n);
+    // The healthy stream reaches a clean end of stream rather than being
+    // collateral damage of the other stream's capacity abort.
+    try testing.expectEqual(@as(usize, 0), try conn.readStreamingBody(slow, buf[0..]));
+    try testing.expectEqual(AbortCause.none, conn.abortCause(slow));
 
     const refused_id: u32 = refused.id;
     conn.finishStreaming(refused);
@@ -3129,6 +3269,95 @@ test "origin capacity bounds concurrent streams and refuses only the overflowing
     // The global scope had room; its rolled-back reservation must not have
     // been counted as a global refusal either.
     try testing.expectEqual(@as(u64, 0), observer.limit_exceeded.load(.monotonic));
+}
+
+/// Canned server that answers before the client has finished uploading: it
+/// replies with HEADERS and a DATA burst as soon as the request head arrives,
+/// while the client is still writing request body frames.
+fn cannedEarlyResponseServer(peer_fd: std.posix.fd_t, body_bytes: usize, saw_rst: *std.atomic.Value(bool)) void {
+    const a = std.heap.page_allocator;
+    var srv = PlainTransport{ .fd = peer_fd };
+    var preface: [PREFACE.len]u8 = undefined;
+    readExact(&srv, peer_fd, preface[0..], 2000) catch return;
+    frame.writeSettings(a, &srv, &[_][2]u32{}) catch return;
+
+    var req_stream: u31 = 0;
+    while (req_stream == 0) {
+        var fr = readFrameBounded(&srv, peer_fd, a, 2000) catch return;
+        if (fr.typ == .headers) req_stream = fr.stream_id;
+        frame.deinitFrame(a, &fr);
+    }
+
+    const block = hpack.encodeLiteralHeaderBlock(a, &[_]hpack.HeaderField{
+        .{ .name = ":status", .value = "200" },
+    }) catch return;
+    defer a.free(block);
+    frame.writeFrame(&srv, .headers, frame.Flags.END_HEADERS, req_stream, block) catch return;
+    const payload = [_]u8{'x'} ** 256;
+    frame.writeFrame(&srv, .data, 0, req_stream, payload[0..body_bytes]) catch return;
+
+    while (true) {
+        var fr = readFrameBounded(&srv, peer_fd, a, 5000) catch return;
+        const is_rst = fr.typ == .rst_stream and fr.stream_id == req_stream;
+        frame.deinitFrame(a, &fr);
+        if (is_rst) {
+            saw_rst.store(true, .release);
+            return;
+        }
+    }
+}
+
+test "response capacity exhausted during an upload surfaces before commitment" {
+    // The response can outrun the request: the origin answers while the client
+    // is still writing body frames. If that response exhausts local capacity,
+    // the failure reaches the worker through its *next upload write* — and
+    // since nothing is committed downstream yet, the cause has to survive as
+    // local capacity rather than looking like an upstream write failure.
+    const fds = try makeSocketpair();
+    var saw_rst = std.atomic.Value(bool).init(false);
+    const server = try std.Thread.spawn(.{}, cannedEarlyResponseServer, .{ fds[1], 16, &saw_rst });
+
+    var observer = TestProxyBufferObserver{};
+    // No room at the origin at all: the early response is refused on arrival.
+    var origin = proxy_buffer_account.Aggregate.init(.origin, 8);
+    var transport = PlainTransport{ .fd = fds[0] };
+    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 3000, null, null, null, windowLimits(64));
+
+    const stream = try conn.openStreaming(.{
+        .method = "POST",
+        .authority = "early.test",
+        .path = "/",
+        .body_mode = .streaming,
+        .proxy_buffer_accounting = true,
+        .proxy_buffer_observer = observer.observer(),
+        .proxy_buffer_capacity = .{ .origin = &origin },
+    });
+
+    // Wait for the reader to refuse the early response, then prove the refusal
+    // reaches the uploading worker through its next body write. Waiting on the
+    // cause first keeps this independent of how fast the reader thread runs;
+    // racing it with a write loop would make the test timing-dependent.
+    var spins: usize = 0;
+    while (conn.abortCause(stream) != .local_capacity and spins < 100_000_000) : (spins += 1) {
+        std.Thread.yield() catch {};
+    }
+    try testing.expectEqual(AbortCause.local_capacity, conn.abortCause(stream));
+
+    const chunk = [_]u8{'u'} ** 64;
+    const upload_err = conn.writeStreamingRequestBody(stream, chunk[0..], false);
+    try testing.expectError(error.BufferLimitExceeded, upload_err);
+    try testing.expectEqual(AbortCause.local_capacity, conn.abortCause(stream));
+    // Still pre-commitment, so the caller can choose a clean status.
+    try testing.expectError(error.BufferLimitExceeded, conn.beginDownstreamCommit(stream));
+
+    conn.finishStreaming(stream);
+    conn.deinit();
+    server.join();
+    _ = std.c.close(fds[1]);
+
+    try testing.expect(saw_rst.load(.acquire));
+    try testing.expectEqual(@as(usize, 0), origin.currentBytes(.upstream_to_downstream));
+    try testing.expectEqual(@as(usize, 0), observer.retained.load(.monotonic));
 }
 
 /// Canned server that fills a stream's window in one frame and then reports the
@@ -3217,6 +3446,54 @@ test "stream credit is withheld between the high and low watermarks" {
     // One coalesced update for everything drained inside the band — crediting
     // each chunk as it drained would have made this 16.
     try testing.expectEqual(@as(u32, 32), first_credit.load(.acquire));
+
+    conn.finishStreaming(stream);
+    conn.deinit();
+    server.join();
+    _ = std.c.close(fds[1]);
+}
+
+test "a partial drain keeps the aggregate gauge at the retained allocation" {
+    // The distinction the aggregate gauge has to preserve: a queue drained from
+    // 16 bytes to 8 still *owns* 16, and the global hard limit is enforced
+    // against that 16. Reporting 8 would leave operators unable to compare the
+    // gauge with the limit it is measured by.
+    const fds = try makeSocketpair();
+    const server = try std.Thread.spawn(.{}, cannedSingleDataStreamingServer, .{ fds[1], "0123456789abcdef", false });
+
+    var observer = TestProxyBufferObserver{};
+    var origin = proxy_buffer_account.Aggregate.init(.origin, 64);
+    var transport = PlainTransport{ .fd = fds[0] };
+    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 3000, null, null, null, windowLimits(64));
+
+    const stream = try conn.requestStreaming(.{
+        .method = "GET",
+        .authority = "partial.test",
+        .path = "/",
+        .proxy_buffer_accounting = true,
+        .proxy_buffer_observer = observer.observer(),
+        .proxy_buffer_capacity = .{ .origin = &origin },
+    });
+
+    var buf: [8]u8 = undefined;
+    const first = try conn.readStreamingBody(stream, buf[0..]);
+    try testing.expectEqual(@as(usize, 8), first);
+    try testing.expectEqual(@as(usize, 16), observer.retained.load(.monotonic));
+
+    conn.acknowledgeStreamingBody(stream, first);
+    // Logical occupancy halves; retained allocation — and the origin scope
+    // enforcing it — does not, because the buffer is still 16 bytes long.
+    try testing.expectEqual(@as(usize, 8), observer.current.load(.monotonic));
+    try testing.expectEqual(@as(usize, 16), observer.retained.load(.monotonic));
+    try testing.expectEqual(@as(usize, 16), origin.currentBytes(.upstream_to_downstream));
+    try testing.expectEqual(@as(usize, 16), stream.body.capacity);
+
+    const second = try conn.readStreamingBody(stream, buf[0..]);
+    conn.acknowledgeStreamingBody(stream, second);
+    // Now the storage is actually handed back, and both views agree again.
+    try testing.expectEqual(@as(usize, 0), observer.current.load(.monotonic));
+    try testing.expectEqual(@as(usize, 0), observer.retained.load(.monotonic));
+    try testing.expectEqual(@as(usize, 0), origin.currentBytes(.upstream_to_downstream));
 
     conn.finishStreaming(stream);
     conn.deinit();

--- a/src/http/upstream_h2.zig
+++ b/src/http/upstream_h2.zig
@@ -3236,7 +3236,11 @@ test "origin capacity bounds concurrent streams and refuses only the overflowing
         .proxy_buffer_observer = observer.observer(),
         .proxy_buffer_capacity = capacity,
     });
-    const refused = try conn.requestStreaming(.{
+    // `openStreaming` rather than `requestStreaming` so the handle is owned on
+    // every path: the refusal can surface from the head wait as well as from
+    // the body read, and the error path of `requestStreaming` would have
+    // finished the stream itself, leaving nothing to assert against.
+    const refused = try conn.openStreaming(.{
         .method = "GET",
         .authority = "aggregate-origin.test",
         .path = "/",
@@ -3246,9 +3250,21 @@ test "origin capacity bounds concurrent streams and refuses only the overflowing
     });
 
     // The second stream is refused; the first is untouched and still usable.
+    //
+    // Wait for the reader to actually refuse before asserting. Otherwise the
+    // test races it: the refusal legitimately surfaces from the head wait when
+    // the reader gets there first and from the body read when it does not, and
+    // an earlier revision that assumed the body-read ordering crashed on CI.
     var buf: [128]u8 = undefined;
-    try testing.expectError(error.BufferLimitExceeded, conn.readStreamingBody(refused, buf[0..]));
+    var spins: usize = 0;
+    while (conn.abortCause(refused) != .local_capacity and spins < 100_000_000) : (spins += 1) {
+        std.Thread.yield() catch {};
+    }
     try testing.expectEqual(AbortCause.local_capacity, conn.abortCause(refused));
+    // Every way the worker could learn about it reports the same thing, and
+    // reports it as still pre-commitment.
+    try testing.expectError(error.BufferLimitExceeded, conn.waitStreamingResponseHead(refused));
+    try testing.expectError(error.BufferLimitExceeded, conn.readStreamingBody(refused, buf[0..]));
     // The refusal landed before any head relay, so claiming the commitment
     // boundary must fail — this is what turns the race into a pre-commit 503
     // instead of a committed origin status followed by a truncation.

--- a/src/http/upstream_h2.zig
+++ b/src/http/upstream_h2.zig
@@ -43,11 +43,13 @@ fn nowMs() u64 {
 }
 
 const DEFAULT_MAX_FRAME: usize = 16_384;
-/// Receive window we advertise per stream (SETTINGS_INITIAL_WINDOW_SIZE). For
-/// streaming streams this doubles as the bounded per-stream buffer: the reader
-/// stops replenishing it, so a well-behaved peer can have at most this many
-/// unconsumed bytes buffered per stream.
-const OUR_INITIAL_WINDOW: u31 = 1 << 20;
+/// Receive window we advertise per stream (SETTINGS_INITIAL_WINDOW_SIZE) when
+/// no per-stream buffer policy is configured. For streaming streams this
+/// doubles as the bounded per-stream buffer: the reader stops replenishing it,
+/// so a well-behaved peer can have at most this many unconsumed bytes buffered
+/// per stream. Production connections derive the window from
+/// `proxy_buffer_account.streamReceiveWindow` instead (#140).
+pub const DEFAULT_STREAM_RECV_WINDOW: u31 = 1 << 20;
 /// HTTP/2 default initial flow-control window for a peer that sent no SETTINGS.
 const PROTOCOL_DEFAULT_WINDOW: i64 = 65_535;
 /// Grow the connection-level receive window to this at connection start so the
@@ -85,8 +87,15 @@ pub const Request = struct {
     /// Whether `body` is the complete outbound request body or the first bytes
     /// of a request body that will continue through streaming DATA writes.
     body_mode: BodyMode = .complete,
-    proxy_buffer_limits: ?proxy_buffer_account.Limits = null,
+    /// Account this stream's queued response body against the connection's
+    /// pinned buffer policy. The policy itself is never supplied per request:
+    /// it must match the receive window the connection already advertised.
+    proxy_buffer_accounting: bool = false,
     proxy_buffer_observer: ?proxy_buffer_account.Observer = null,
+    /// Aggregate (origin/global) scopes this stream's queued response bytes are
+    /// reserved against, so many concurrent slow streams cannot multiply the
+    /// per-stream bound. Only consulted alongside `proxy_buffer_accounting`.
+    proxy_buffer_capacity: proxy_buffer_account.AggregateCapacity = .{},
 };
 
 pub const BodyMode = enum {
@@ -183,7 +192,7 @@ pub fn exchange(
     try transport.writeAll(PREFACE);
     try frame.writeSettings(allocator, transport, &[_][2]u32{
         .{ 0x2, 0 }, // SETTINGS_ENABLE_PUSH = 0
-        .{ 0x4, @as(u32, OUR_INITIAL_WINDOW) }, // SETTINGS_INITIAL_WINDOW_SIZE
+        .{ 0x4, @as(u32, DEFAULT_STREAM_RECV_WINDOW) }, // SETTINGS_INITIAL_WINDOW_SIZE
     });
 
     // 2. Request HEADERS (pseudo-headers first), then DATA.
@@ -468,37 +477,109 @@ pub const Stream = struct {
     /// read only by the owning worker thread.
     wire_opened: bool = false,
     local_abort: bool = false,
+    /// Set once the reader has emitted RST_STREAM for a locally aborted stream,
+    /// so `finishStreaming` does not send a second one.
+    rst_sent: bool = false,
+    /// Per-stream logical queue length: the bytes a downstream consumer has not
+    /// taken yet. Drives the high/low watermark hysteresis.
     proxy_body_account: ?proxy_buffer_account.Account = null,
     proxy_buffer_observer: ?proxy_buffer_account.Observer = null,
+    /// Aggregate scopes backing this stream's queue.
+    proxy_buffer_capacity: proxy_buffer_account.AggregateCapacity = .{},
+    /// Bytes currently reserved at the aggregate scopes. This tracks `body`'s
+    /// **retained allocation**, not its logical length: an ArrayList that has
+    /// been drained still owns its backing memory, and retained memory is what
+    /// an aggregate limit is meant to bound. The queue's storage is freed (and
+    /// this reservation returned in full) as soon as it drains empty.
+    proxy_capacity_reserved: usize = 0,
+    /// Downstream-consumed bytes not yet credited back to the peer as stream
+    /// flow control. While the queue sits above its high watermark, credit is
+    /// withheld and accumulates here; it is released as one WINDOW_UPDATE when
+    /// the queue drains below the low watermark. This is the pause/resume
+    /// hysteresis — crediting every consumed chunk would let the peer refill
+    /// immediately and the band would never do anything.
+    pending_window_credit: usize = 0,
 
     fn destroy(self: *Stream, allocator: std.mem.Allocator) void {
         self.releaseQueuedBodyAccounting();
+        self.releaseRetainedStorage();
         freeHeaderList(allocator, &self.headers);
         self.body.deinit(allocator);
         allocator.destroy(self);
     }
 
-    fn recordQueuedBody(self: *Stream, bytes: usize) !void {
-        if (self.proxy_body_account) |*account| {
-            const before = account.snapshot();
-            account.reserve(bytes) catch |err| {
-                const after = account.snapshot();
+    /// True while the queue is in the pause band: it reached the high watermark
+    /// and has not yet drained back below the low one. Streams with no
+    /// accounting policy never pause.
+    fn aboveHighWatermark(self: *const Stream) bool {
+        const account = self.proxy_body_account orelse return false;
+        return account.snapshot().above_high_watermark;
+    }
+
+    fn accountDirection(self: *const Stream) proxy_buffer_account.Direction {
+        return if (self.proxy_body_account) |account| account.direction else .upstream_to_downstream;
+    }
+
+    /// Take ownership of `payload` on this stream's queue, reserving at every
+    /// scope *before* any memory is committed. Aggregate scopes are charged for
+    /// the queue's retained allocation, so the reservation only grows when the
+    /// queue's storage does; the per-stream account tracks the logical length
+    /// that drives the watermarks. Either reservation failing leaves the stream
+    /// exactly as it was — no bytes queued, no scope charged.
+    fn enqueueBody(self: *Stream, allocator: std.mem.Allocator, payload: []const u8) !void {
+        const account = if (self.proxy_body_account) |*a| a else {
+            try self.body.appendSlice(allocator, payload);
+            return;
+        };
+        const direction = account.direction;
+
+        // Grow the aggregate reservation to cover the storage this append will
+        // retain. Allocating precisely keeps `capacity == reserved`, so the
+        // aggregates never undercount an ArrayList's amortised over-allocation.
+        const needed_capacity = std.math.add(usize, self.body.items.len, payload.len) catch return error.BufferLimitExceeded;
+        var capacity_delta: usize = 0;
+        if (needed_capacity > self.proxy_capacity_reserved) {
+            capacity_delta = needed_capacity - self.proxy_capacity_reserved;
+            self.proxy_buffer_capacity.reserve(direction, capacity_delta) catch |err| {
                 if (self.proxy_buffer_observer) |observer| {
-                    if (after.limit_exceeded_events > before.limit_exceeded_events) {
-                        observer.recordReservation(account.direction, 0, false, true);
-                    }
+                    observer.recordAggregateLimitExceeded(direction, proxy_buffer_account.aggregateFailureScope(err));
                 }
-                return err;
+                return error.BufferLimitExceeded;
             };
+        }
+        errdefer if (capacity_delta > 0) {
+            self.proxy_buffer_capacity.release(direction, capacity_delta);
+        };
+
+        const before = account.snapshot();
+        account.reserve(payload.len) catch |err| {
             const after = account.snapshot();
             if (self.proxy_buffer_observer) |observer| {
-                observer.recordReservation(
-                    account.direction,
-                    bytes,
-                    after.high_watermark_events > before.high_watermark_events,
-                    after.limit_exceeded_events > before.limit_exceeded_events,
-                );
+                if (after.limit_exceeded_events > before.limit_exceeded_events) {
+                    observer.recordReservation(direction, 0, false, true);
+                }
             }
+            return err;
+        };
+        errdefer account.release(payload.len) catch unreachable;
+
+        try self.body.ensureTotalCapacityPrecise(allocator, needed_capacity);
+        self.body.appendSliceAssumeCapacity(payload);
+        self.proxy_capacity_reserved += capacity_delta;
+
+        const after = account.snapshot();
+        const crossed_high = after.high_watermark_events > before.high_watermark_events;
+        if (self.proxy_buffer_observer) |observer| {
+            observer.recordReservation(
+                direction,
+                payload.len,
+                crossed_high,
+                after.limit_exceeded_events > before.limit_exceeded_events,
+            );
+            // Reaching the high watermark is the moment stream credit stops
+            // flowing, so the pause belongs here rather than at the drain that
+            // eventually clears it.
+            if (crossed_high) observer.recordReadPause(.upstream);
         }
     }
 
@@ -512,7 +593,18 @@ pub const Stream = struct {
         }
     }
 
-    fn compactAcknowledgedBody(self: *Stream, bytes: usize) void {
+    /// Give the queue's backing allocation back once it drains empty, and with
+    /// it the aggregate reservation that covered it. Without this the queue
+    /// would keep its peak allocation for the stream's whole life while the
+    /// aggregate counters read zero — the concurrency multiplication the
+    /// aggregate limits exist to prevent.
+    fn releaseRetainedStorage(self: *Stream) void {
+        if (self.proxy_capacity_reserved == 0) return;
+        self.proxy_buffer_capacity.release(self.accountDirection(), self.proxy_capacity_reserved);
+        self.proxy_capacity_reserved = 0;
+    }
+
+    fn compactAcknowledgedBody(self: *Stream, allocator: std.mem.Allocator, bytes: usize) void {
         if (bytes == 0) return;
         std.debug.assert(bytes <= self.body_read_off);
         std.debug.assert(bytes <= self.body.items.len);
@@ -522,7 +614,13 @@ pub const Stream = struct {
         }
         self.body.shrinkRetainingCapacity(remaining);
         self.body_read_off -= bytes;
-        if (self.body.items.len == 0) self.body_read_off = 0;
+        if (self.body.items.len == 0) {
+            self.body_read_off = 0;
+            // Drained: hand the storage back rather than sitting on the peak
+            // allocation until the stream ends.
+            self.body.clearAndFree(allocator);
+            self.releaseRetainedStorage();
+        }
     }
 
     fn releaseQueuedBodyAccounting(self: *Stream) void {
@@ -545,6 +643,15 @@ pub fn H2Conn(comptime Transport: type) type {
         transport_allocator: ?std.mem.Allocator,
         fd: std.posix.fd_t,
         deadline_ms: u32,
+        /// The per-stream buffer policy pinned at connect time, and the source
+        /// of the SETTINGS_INITIAL_WINDOW_SIZE this connection advertised.
+        /// Pinned rather than read per request because the advertised window is
+        /// a promise: a reload that lowered the hard limit under a peer already
+        /// holding credit would abort a stream that never exceeded what it was
+        /// granted. A reloaded policy therefore applies to connections opened
+        /// afterwards, and every stream here is judged by what was advertised.
+        buffer_limits: proxy_buffer_account.Limits,
+        stream_recv_window: u31,
 
         write_mutex: compat.Mutex = .{},
         state_mutex: compat.Mutex = .{},
@@ -603,16 +710,20 @@ pub fn H2Conn(comptime Transport: type) type {
             transport_allocator: ?std.mem.Allocator,
             rst_counter: ?*std.atomic.Value(u64),
             goaway_counter: ?*std.atomic.Value(u64),
+            buffer_limits: proxy_buffer_account.Limits,
         ) !*Self {
             const self = try allocator.create(Self);
             errdefer allocator.destroy(self);
             const now = nowMs();
+            const stream_recv_window = proxy_buffer_account.streamReceiveWindow(buffer_limits);
             self.* = .{
                 .allocator = allocator,
                 .transport = transport,
                 .transport_allocator = transport_allocator,
                 .fd = fd,
                 .deadline_ms = deadline_ms,
+                .buffer_limits = buffer_limits,
+                .stream_recv_window = stream_recv_window,
                 .decoder = hpack.Decoder.init(),
                 .streams = std.AutoHashMap(u31, *Stream).init(allocator),
                 .created_ms = now,
@@ -624,7 +735,7 @@ pub fn H2Conn(comptime Transport: type) type {
             try self.transport.writeAll(PREFACE);
             try frame.writeSettings(allocator, self.transport, &[_][2]u32{
                 .{ 0x2, 0 }, // ENABLE_PUSH = 0
-                .{ 0x4, @as(u32, OUR_INITIAL_WINDOW) },
+                .{ 0x4, @as(u32, stream_recv_window) },
             });
             // Grow the connection-level receive window once up front; the
             // reader keeps it topped up per DATA frame afterwards.
@@ -747,9 +858,12 @@ pub fn H2Conn(comptime Transport: type) type {
         pub fn openStreaming(self: *Self, req: Request) !*Stream {
             const stream = try self.beginStream(true);
             errdefer self.finishStreaming(stream);
-            if (req.proxy_buffer_limits) |limits| {
-                stream.proxy_body_account = proxy_buffer_account.Account.init(.upstream_to_downstream, .stream, limits);
+            if (req.proxy_buffer_accounting) {
+                // The connection's pinned policy, not a caller snapshot: the
+                // stream is judged by exactly the window it advertised.
+                stream.proxy_body_account = proxy_buffer_account.Account.init(.upstream_to_downstream, .stream, self.buffer_limits);
                 stream.proxy_buffer_observer = req.proxy_buffer_observer;
+                stream.proxy_buffer_capacity = req.proxy_buffer_capacity;
             }
             try self.sendRequest(stream, req);
             return stream;
@@ -767,8 +881,17 @@ pub fn H2Conn(comptime Transport: type) type {
             stream.wait_deadline_ms = 0;
             const stream_err: ?anyerror = if (stream.err != null) stream.err else self.conn_err;
             const status = stream.status;
+            // The reader can decode HEADERS and then reject DATA before this
+            // worker ever writes the head downstream. Reporting success there
+            // would commit the origin's status and force a truncation, when
+            // nothing has reached the client yet and the caller can still
+            // choose a clean pre-commitment status.
+            const aborted_locally = stream.local_abort;
             self.state_mutex.unlock();
 
+            if (aborted_locally) {
+                if (stream_err) |e| return e;
+            }
             if (status != null) return;
             if (stream_err) |e| return e;
             return error.Http2MissingStatus;
@@ -837,14 +960,36 @@ pub fn H2Conn(comptime Transport: type) type {
         pub fn acknowledgeStreamingBody(self: *Self, stream: *Stream, bytes: usize) void {
             if (bytes == 0) return;
             self.state_mutex.lock();
+            const was_above_high = stream.aboveHighWatermark();
             stream.releaseQueuedBody(bytes);
-            stream.compactAcknowledgedBody(bytes);
-            stream.recv_window += @as(i64, @intCast(bytes));
-            const replenish = !stream.done;
+            stream.compactAcknowledgedBody(self.allocator, bytes);
+            const still_above_high = stream.aboveHighWatermark();
+
+            // Hysteresis (#140): while the queue sits above its high watermark
+            // the peer gets no new credit, so it stops sending instead of
+            // refilling whatever the consumer just drained. Credit accumulates
+            // and is released as a single WINDOW_UPDATE when the queue falls
+            // below the low watermark.
+            stream.pending_window_credit += bytes;
+            var credit: usize = 0;
+            if (!still_above_high) {
+                credit = stream.pending_window_credit;
+                stream.pending_window_credit = 0;
+                stream.recv_window += @as(i64, @intCast(credit));
+            }
+            const resumed = was_above_high and !still_above_high;
+            const observer = stream.proxy_buffer_observer;
+            const replenish = !stream.done and credit > 0;
             const id = stream.id;
             self.state_mutex.unlock();
+
+            // The pause is recorded where credit stops (`enqueueBody`); this is
+            // where it starts flowing again.
+            if (resumed) {
+                if (observer) |obs| obs.recordReadResume(.upstream);
+            }
             if (replenish) {
-                const inc = windowIncrement(bytes);
+                const inc = windowIncrement(credit);
                 self.writeControl(.window_update, 0, id, &inc);
             }
         }
@@ -858,7 +1003,10 @@ pub fn H2Conn(comptime Transport: type) type {
             self.state_mutex.lock();
             const removed = self.streams.remove(stream.id);
             if (removed and self.active_streams > 0) self.active_streams -= 1;
-            const need_rst = stream.wire_opened and (stream.err == null or stream.local_abort) and !stream.done and self.conn_err == null;
+            // `rst_sent` means the reader already cancelled this stream when it
+            // hit a hard limit; a second RST would be redundant.
+            const need_rst = stream.wire_opened and !stream.rst_sent and
+                (stream.err == null or stream.local_abort) and !stream.done and self.conn_err == null;
             const id = stream.id;
             self.state_mutex.unlock();
             self.last_activity_ms.store(nowMs(), .monotonic);
@@ -886,7 +1034,7 @@ pub fn H2Conn(comptime Transport: type) type {
                 .id = id,
                 .send_window = self.peer_initial_window,
                 .streaming = streaming,
-                .recv_window = if (streaming) @as(i64, OUR_INITIAL_WINDOW) else 0,
+                .recv_window = if (streaming) @as(i64, self.stream_recv_window) else 0,
             };
             try self.streams.put(id, stream);
             self.active_streams += 1;
@@ -1199,8 +1347,15 @@ pub fn H2Conn(comptime Transport: type) type {
             const maybe_stream = self.streams.get(fr.stream_id);
             var replenish_stream = false;
             var flow_violation = false;
+            var reset_stream = false;
             if (maybe_stream) |s| {
                 var deliver = fr.payload.len > 0;
+                // A stream we already gave up on is discard-only. Without this,
+                // later DATA could reserve again once another stream drained
+                // capacity free, re-queue bytes behind an error the consumer
+                // has not observed yet, and re-count the limit event on every
+                // frame while the worker is blocked on a slow downstream write.
+                if (s.local_abort or s.err != null) deliver = false;
                 if (deliver and s.streaming) {
                     // Bounded-buffer backpressure: account the bytes against
                     // the advertised stream window; the consumer replenishes
@@ -1218,21 +1373,24 @@ pub fn H2Conn(comptime Transport: type) type {
                     replenish_stream = true;
                 }
                 if (deliver) {
-                    s.recordQueuedBody(fr.payload.len) catch |err| {
-                        if (err == error.BufferLimitExceeded) {
+                    s.enqueueBody(self.allocator, fr.payload) catch |err| switch (err) {
+                        // Local capacity is exhausted at some scope. Make the
+                        // stream terminal here and now: reset it upstream so
+                        // the origin stops sending, and leave it discard-only
+                        // for any DATA already in flight.
+                        error.BufferLimitExceeded => {
                             if (s.err == null) s.err = err;
                             s.local_abort = true;
+                            if (!s.rst_sent and s.wire_opened) {
+                                s.rst_sent = true;
+                                reset_stream = true;
+                            }
                             deliver = false;
-                        } else {
+                        },
+                        else => {
                             self.state_mutex.unlock();
                             return err;
-                        }
-                    };
-                }
-                if (deliver) {
-                    s.body.appendSlice(self.allocator, fr.payload) catch {
-                        self.state_mutex.unlock();
-                        return error.OutOfMemory;
+                        },
                     };
                 }
                 if (end_stream) s.done = true;
@@ -1244,6 +1402,10 @@ pub fn H2Conn(comptime Transport: type) type {
             self.state_mutex.unlock();
             // Send-window waiters block on the connection cond.
             if (flow_violation) self.cond.broadcast();
+            if (reset_stream) {
+                const cancel_code = [4]u8{ 0, 0, 0, 8 }; // CANCEL
+                self.writeControl(.rst_stream, 0, fr.stream_id, &cancel_code);
+            }
 
             if (fr.payload.len > 0) {
                 // Always replenish the connection window promptly — one slow
@@ -1389,6 +1551,11 @@ pub const H2PoolStats = struct {
 pub const H2OriginCounters = struct {
     stream_resets_total: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
     goaway_total: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    /// Origin-scope proxy buffer reservations (#140). Shared by every stream on
+    /// every connection to this origin, so the origin's queued response bytes
+    /// are bounded no matter how many slow streams it fans out to. Lives as
+    /// long as the entry, which outlives every reader holding a pointer to it.
+    buffer: proxy_buffer_account.Aggregate = proxy_buffer_account.Aggregate.init(.origin, 0),
 };
 
 /// A copy of one origin's identity + h2 metrics for rendering. `origin` is the
@@ -1400,6 +1567,9 @@ pub const H2OriginSnapshot = struct {
     streams_active: u64,
     stream_resets_total: u64,
     goaway_total: u64,
+    /// Response bytes this origin's streams currently hold in h2 stream queues.
+    buffered_bytes: usize,
+    buffer_limit_exceeded_total: u64,
 };
 
 pub fn freeH2OriginSnapshots(allocator: std.mem.Allocator, snaps: []H2OriginSnapshot) void {
@@ -1428,6 +1598,13 @@ pub const H2ConnPool = struct {
         idle_timeout_ms: u64 = 90_000,
         /// Hard cap on total connection age (0 = unlimited).
         max_lifetime_ms: u64 = 0,
+        /// Proxy buffer policy for connections this pool opens (#140). The
+        /// per-stream high watermark becomes each connection's advertised
+        /// SETTINGS_INITIAL_WINDOW_SIZE; the aggregate hard limits are applied
+        /// to the per-origin accounts. Update through
+        /// `H2ConnPool.setProxyBufferLimits`, never by writing this field, so
+        /// existing origins pick the change up too.
+        proxy_buffer_limits: proxy_buffer_account.Limits = proxy_buffer_account.Limits.defaults(),
     };
 
     allocator: std.mem.Allocator,
@@ -1483,10 +1660,46 @@ pub const H2ConnPool = struct {
             const counters = try self.allocator.create(H2OriginCounters);
             errdefer self.allocator.destroy(counters);
             counters.* = .{};
+            // A new origin starts under the policy in force right now, not the
+            // aggregate type's unlimited default.
+            counters.buffer.setHardLimit(self.config.proxy_buffer_limits.per_origin_hard_limit);
             gop.key_ptr.* = try self.allocator.dupe(u8, key);
             gop.value_ptr.* = counters;
         }
         return gop.value_ptr.*;
+    }
+
+    /// The origin-scope buffer aggregate for `key`. Read-only with respect to
+    /// policy: the limit comes from `config.proxy_buffer_limits`, which only
+    /// `setProxyBufferLimits` writes. A request must never push its own config
+    /// snapshot into shared state — a request that started before a reload
+    /// would otherwise land here afterwards and restore the superseded limit.
+    /// The returned pointer is stable for the pool's lifetime.
+    pub fn originBufferAccount(self: *H2ConnPool, key: []const u8) !*proxy_buffer_account.Aggregate {
+        const counters = try self.originCounters(key);
+        return &counters.buffer;
+    }
+
+    /// Apply a reloaded proxy buffer policy. Aggregate hard limits take effect
+    /// immediately for every origin, including ones already carrying
+    /// reservations; the per-stream policy (and the receive window derived from
+    /// it) applies to connections opened after this call, because
+    /// SETTINGS_INITIAL_WINDOW_SIZE is negotiated once per connection and
+    /// existing peers already hold credit under the previous advertisement.
+    pub fn currentProxyBufferLimits(self: *H2ConnPool) proxy_buffer_account.Limits {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        return self.config.proxy_buffer_limits;
+    }
+
+    pub fn setProxyBufferLimits(self: *H2ConnPool, limits: proxy_buffer_account.Limits) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.config.proxy_buffer_limits = limits;
+        var it = self.origin_counters.valueIterator();
+        while (it.next()) |counters| {
+            counters.*.buffer.setHardLimit(limits.per_origin_hard_limit);
+        }
     }
 
     /// Get a healthy h2 connection for `key`, creating one if needed. On the h2
@@ -1580,7 +1793,10 @@ pub const H2ConnPool = struct {
             return e;
         };
 
-        const conn = PooledH2Conn.init(self.allocator, transport, fd, deadline_ms, self.allocator, &counters.stream_resets_total, &counters.goaway_total) catch |e| {
+        // Snapshot the policy under the lock: a reload can rewrite it, and this
+        // connection pins whatever it advertises for its whole life.
+        const buffer_limits = self.currentProxyBufferLimits();
+        const conn = PooledH2Conn.init(self.allocator, transport, fd, deadline_ms, self.allocator, &counters.stream_resets_total, &counters.goaway_total, buffer_limits) catch |e| {
             transport.close();
             self.allocator.destroy(transport);
             return e;
@@ -1685,6 +1901,8 @@ pub const H2ConnPool = struct {
                 .streams_active = 0,
                 .stream_resets_total = e.value_ptr.*.stream_resets_total.load(.monotonic),
                 .goaway_total = e.value_ptr.*.goaway_total.load(.monotonic),
+                .buffered_bytes = e.value_ptr.*.buffer.currentBytes(.upstream_to_downstream),
+                .buffer_limit_exceeded_total = e.value_ptr.*.buffer.limitExceededEvents(.upstream_to_downstream),
             };
             errdefer allocator.free(snap.origin);
             if (self.conns.get(e.key_ptr.*)) |conn| {
@@ -1792,13 +2010,43 @@ const testing = std.testing;
 const TestProxyBufferObserver = struct {
     current: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
     limit_exceeded: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    origin_limit_exceeded: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    global_limit_exceeded: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    read_pauses: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    read_resumes: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
 
     fn observer(self: *TestProxyBufferObserver) proxy_buffer_account.Observer {
         return .{
             .context = self,
             .recordReservationFn = record,
             .releaseReservationFn = release,
+            .recordAggregateLimitExceededFn = recordAggregateLimitExceeded,
+            .recordReadPauseFn = recordReadPause,
+            .recordReadResumeFn = recordReadResume,
         };
+    }
+
+    fn recordReadPause(context: *anyopaque, _: proxy_buffer_account.Side) void {
+        const self: *TestProxyBufferObserver = @ptrCast(@alignCast(context));
+        _ = self.read_pauses.fetchAdd(1, .monotonic);
+    }
+
+    fn recordReadResume(context: *anyopaque, _: proxy_buffer_account.Side) void {
+        const self: *TestProxyBufferObserver = @ptrCast(@alignCast(context));
+        _ = self.read_resumes.fetchAdd(1, .monotonic);
+    }
+
+    fn recordAggregateLimitExceeded(
+        context: *anyopaque,
+        _: proxy_buffer_account.Direction,
+        scope: proxy_buffer_account.Scope,
+    ) void {
+        const self: *TestProxyBufferObserver = @ptrCast(@alignCast(context));
+        switch (scope) {
+            .origin => _ = self.origin_limit_exceeded.fetchAdd(1, .monotonic),
+            .global => _ = self.global_limit_exceeded.fetchAdd(1, .monotonic),
+            else => {},
+        }
     }
 
     fn record(context: *anyopaque, _: proxy_buffer_account.Direction, bytes: usize, _: bool, limit_exceeded: bool) void {
@@ -1813,11 +2061,15 @@ const TestProxyBufferObserver = struct {
     }
 };
 
-fn smallProxyBufferLimits(hard: usize) proxy_buffer_account.Limits {
+/// A per-stream policy whose advertised receive window is exactly `window`,
+/// with the low watermark half way down so the pause/resume band is testable.
+/// `hard == high` because the window already caps what a compliant peer can
+/// queue: anything beyond it is a flow-control violation, not a buffer overrun.
+fn windowLimits(window: usize) proxy_buffer_account.Limits {
     return .{
-        .per_stream_low_watermark = 1,
-        .per_stream_high_watermark = @max(2, @min(hard, 8)),
-        .per_stream_hard_limit = hard,
+        .per_stream_low_watermark = @max(1, window / 2),
+        .per_stream_high_watermark = window,
+        .per_stream_hard_limit = window,
         .per_origin_hard_limit = 0,
         .global_hard_limit = 0,
     };
@@ -2004,7 +2256,7 @@ test "h2 actor multiplexes concurrent requests over one connection" {
     const server = try std.Thread.spawn(.{}, cannedMuxServer, .{ fds[1], @as(usize, N) });
 
     var transport = PlainTransport{ .fd = fds[0] };
-    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 2000, null, null, null);
+    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 2000, null, null, null, windowLimits(DEFAULT_STREAM_RECV_WINDOW));
 
     var ctxs: [N]MuxClientCtx = undefined;
     var threads: [N]std.Thread = undefined;
@@ -2196,6 +2448,81 @@ test "h2 pool per-origin counters persist and feed both labelled and global snap
     }
 }
 
+test "reloaded proxy buffer limits reach existing origins but not open connections" {
+    const before = proxy_buffer_account.Limits{
+        .per_stream_low_watermark = 32 * 1024,
+        .per_stream_high_watermark = 64 * 1024,
+        .per_stream_hard_limit = 64 * 1024,
+        .per_origin_hard_limit = 256 * 1024,
+        .global_hard_limit = 0,
+    };
+    const after = proxy_buffer_account.Limits{
+        .per_stream_low_watermark = 8 * 1024,
+        .per_stream_high_watermark = 16 * 1024,
+        .per_stream_hard_limit = 16 * 1024,
+        .per_origin_hard_limit = 32 * 1024,
+        .global_hard_limit = 0,
+    };
+    try before.validate();
+    try after.validate();
+
+    var pool = H2ConnPool.init(testing.allocator, .{ .proxy_buffer_limits = before });
+    defer pool.deinit();
+
+    const existing = try pool.originBufferAccount("h2:origin-a:443");
+    try testing.expectEqual(before.per_origin_hard_limit, existing.hardLimit());
+    // Reserve against the pre-reload limit so the reload lands on a scope that
+    // is already carrying bytes.
+    try existing.reserve(.upstream_to_downstream, 24 * 1024);
+
+    pool.setProxyBufferLimits(after);
+
+    // Aggregate limits change immediately, in place: the stable pointer the
+    // readers hold now enforces the reloaded cap.
+    try testing.expectEqual(after.per_origin_hard_limit, existing.hardLimit());
+    try testing.expectEqual(@as(usize, 24 * 1024), existing.currentBytes(.upstream_to_downstream));
+    try testing.expectError(
+        error.BufferLimitExceeded,
+        existing.reserve(.upstream_to_downstream, 16 * 1024),
+    );
+    existing.release(.upstream_to_downstream, 24 * 1024);
+
+    // An origin first seen after the reload starts under the new policy, not
+    // the aggregate type's unlimited default.
+    const fresh = try pool.originBufferAccount("h2:origin-b:443");
+    try testing.expectEqual(after.per_origin_hard_limit, fresh.hardLimit());
+
+    // Connections opened from here on advertise the reloaded window.
+    try testing.expectEqual(after, pool.currentProxyBufferLimits());
+}
+
+test "an open connection keeps the per-stream policy it advertised" {
+    // SETTINGS_INITIAL_WINDOW_SIZE is negotiated once, so a connection must
+    // judge its streams by what it granted them. A stream therefore takes its
+    // policy from the connection, and no caller can supply a different one.
+    const fds = try makeSocketpair();
+    const server = try std.Thread.spawn(.{}, cannedSingleDataStreamingServer, .{ fds[1], "payload", true });
+
+    const pinned = windowLimits(64 * 1024);
+    var transport = PlainTransport{ .fd = fds[0] };
+    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 3000, null, null, null, pinned);
+    try testing.expectEqual(@as(u31, 64 * 1024), conn.stream_recv_window);
+
+    const stream = try conn.requestStreaming(.{
+        .method = "GET",
+        .authority = "pinned.test",
+        .path = "/",
+        .proxy_buffer_accounting = true,
+    });
+    try testing.expectEqual(pinned, stream.proxy_body_account.?.limits);
+    try testing.expectEqual(@as(i64, 64 * 1024), stream.recv_window);
+
+    conn.finishStreaming(stream);
+    conn.deinit();
+    server.join();
+    _ = std.c.close(fds[1]);
+}
+
 test "evictionDecision honours active-stream, health, idle, and lifetime gates" {
     const cfg = H2ConnPool.Config{ .idle_timeout_ms = 1000, .max_lifetime_ms = 5000 };
 
@@ -2279,7 +2606,7 @@ test "reader bumps the pool RST_STREAM counter per frame received" {
     var rst = std.atomic.Value(u64).init(0);
     var goaway = std.atomic.Value(u64).init(0);
     var transport = PlainTransport{ .fd = fds[0] };
-    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 2000, null, &rst, &goaway);
+    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 2000, null, &rst, &goaway, windowLimits(DEFAULT_STREAM_RECV_WINDOW));
 
     const res = conn.request(.{ .method = "GET", .authority = "rst.test", .path = "/" });
     try testing.expectError(error.Http2StreamReset, res);
@@ -2315,7 +2642,7 @@ test "reader bumps the pool GOAWAY counter on a connection GOAWAY" {
     var rst = std.atomic.Value(u64).init(0);
     var goaway = std.atomic.Value(u64).init(0);
     var transport = PlainTransport{ .fd = fds[0] };
-    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 2000, null, &rst, &goaway);
+    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 2000, null, &rst, &goaway, windowLimits(DEFAULT_STREAM_RECV_WINDOW));
 
     // Wait (bounded spin, no sleep-dependent assertion) until the reader has
     // processed the GOAWAY — otherwise deinit's shutdown could win the race and
@@ -2376,7 +2703,7 @@ test "streaming request relays a multi-frame body with consumer-driven window re
     const server = try std.Thread.spawn(.{}, cannedStreamingServer, .{fds[1]});
 
     var transport = PlainTransport{ .fd = fds[0] };
-    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 3000, null, null, null);
+    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 3000, null, null, null, windowLimits(DEFAULT_STREAM_RECV_WINDOW));
 
     const stream = try conn.requestStreaming(.{ .method = "GET", .authority = "stream.test", .path = "/" });
     try testing.expectEqual(@as(u16, 200), stream.status.?);
@@ -2437,13 +2764,13 @@ test "streaming body accounting releases only after consumer acknowledgement and
 
     var observer = TestProxyBufferObserver{};
     var transport = PlainTransport{ .fd = fds[0] };
-    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 3000, null, null, null);
+    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 3000, null, null, null, windowLimits(DEFAULT_STREAM_RECV_WINDOW));
 
     const stream = try conn.requestStreaming(.{
         .method = "GET",
         .authority = "account.test",
         .path = "/",
-        .proxy_buffer_limits = smallProxyBufferLimits(64),
+        .proxy_buffer_accounting = true,
         .proxy_buffer_observer = observer.observer(),
     });
     var buf: [16]u8 = undefined;
@@ -2462,67 +2789,6 @@ test "streaming body accounting releases only after consumer acknowledgement and
     conn.deinit();
     server.join();
     _ = std.c.close(fds[1]);
-}
-
-fn cannedLimitExceededStreamingServer(peer_fd: std.posix.fd_t, saw_rst: *std.atomic.Value(bool)) void {
-    const a = std.heap.page_allocator;
-    var srv = PlainTransport{ .fd = peer_fd };
-    var preface: [PREFACE.len]u8 = undefined;
-    readExact(&srv, peer_fd, preface[0..], 2000) catch return;
-    frame.writeSettings(a, &srv, &[_][2]u32{}) catch return;
-
-    var req_stream: u31 = 0;
-    while (req_stream == 0) {
-        var fr = readFrameBounded(&srv, peer_fd, a, 2000) catch return;
-        if (fr.typ == .headers) req_stream = fr.stream_id;
-        frame.deinitFrame(a, &fr);
-    }
-
-    const block = hpack.encodeLiteralHeaderBlock(a, &[_]hpack.HeaderField{
-        .{ .name = ":status", .value = "200" },
-    }) catch return;
-    defer a.free(block);
-    frame.writeFrame(&srv, .headers, frame.Flags.END_HEADERS, req_stream, block) catch return;
-    frame.writeFrame(&srv, .data, 0, req_stream, "0123456789abcdef") catch return;
-
-    while (true) {
-        var fr = readFrameBounded(&srv, peer_fd, a, 5000) catch return;
-        const is_rst = fr.typ == .rst_stream and fr.stream_id == req_stream;
-        frame.deinitFrame(a, &fr);
-        if (is_rst) {
-            saw_rst.store(true, .release);
-            return;
-        }
-    }
-}
-
-test "streaming body hard-limit abort resets stream and releases accounting" {
-    const fds = try makeSocketpair();
-    var saw_rst = std.atomic.Value(bool).init(false);
-    const server = try std.Thread.spawn(.{}, cannedLimitExceededStreamingServer, .{ fds[1], &saw_rst });
-
-    var observer = TestProxyBufferObserver{};
-    var transport = PlainTransport{ .fd = fds[0] };
-    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 3000, null, null, null);
-
-    const stream = try conn.requestStreaming(.{
-        .method = "GET",
-        .authority = "limit.test",
-        .path = "/",
-        .proxy_buffer_limits = smallProxyBufferLimits(8),
-        .proxy_buffer_observer = observer.observer(),
-    });
-    var buf: [16]u8 = undefined;
-    try testing.expectError(error.BufferLimitExceeded, conn.readStreamingBody(stream, buf[0..]));
-    conn.finishStreaming(stream);
-
-    conn.deinit();
-    server.join();
-    _ = std.c.close(fds[1]);
-
-    try testing.expect(saw_rst.load(.acquire));
-    try testing.expectEqual(@as(usize, 0), observer.current.load(.monotonic));
-    try testing.expectEqual(@as(u64, 1), observer.limit_exceeded.load(.monotonic));
 }
 
 /// Canned server: HEADERS + DATA + a trailer HEADERS block (END_STREAM). The
@@ -2559,7 +2825,7 @@ test "streaming response trailers end the stream and are discarded" {
     const server = try std.Thread.spawn(.{}, cannedTrailerServer, .{fds[1]});
 
     var transport = PlainTransport{ .fd = fds[0] };
-    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 3000, null, null, null);
+    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 3000, null, null, null, windowLimits(DEFAULT_STREAM_RECV_WINDOW));
 
     const stream = try conn.requestStreaming(.{ .method = "GET", .authority = "trailer.test", .path = "/" });
     try testing.expectEqual(@as(u16, 200), stream.status.?);
@@ -2583,12 +2849,13 @@ test "streaming response trailers end the stream and are discarded" {
     _ = std.c.close(fds[1]);
 }
 
-/// Canned server that violates flow control: sends OUR_INITIAL_WINDOW bytes of
-/// DATA (filling the advertised stream window exactly) plus one more frame
-/// beyond it without waiting for replenishment, then a PING whose ACK proves
-/// the client's reader has processed every prior frame. `saw_ack` is set once
-/// the ACK arrives so the test can start consuming deterministically.
-fn cannedFlowViolationServer(peer_fd: std.posix.fd_t, saw_ack: *std.atomic.Value(bool)) void {
+/// Canned server that violates flow control: sends `window` bytes of DATA
+/// (filling the advertised stream window exactly) plus one more frame beyond it
+/// without waiting for replenishment, then a PING whose ACK proves the client's
+/// reader has processed every prior frame. `saw_ack` is set once the ACK
+/// arrives so the test can start consuming deterministically. `window` must be
+/// a multiple of `DEFAULT_MAX_FRAME`.
+fn cannedFlowViolationServer(peer_fd: std.posix.fd_t, window: usize, saw_ack: *std.atomic.Value(bool)) void {
     const a = std.heap.page_allocator;
     var srv = PlainTransport{ .fd = peer_fd };
     var preface: [PREFACE.len]u8 = undefined;
@@ -2610,7 +2877,7 @@ fn cannedFlowViolationServer(peer_fd: std.posix.fd_t, saw_ack: *std.atomic.Value
 
     const chunk = [_]u8{'x'} ** DEFAULT_MAX_FRAME;
     var sent: usize = 0;
-    while (sent < OUR_INITIAL_WINDOW) : (sent += chunk.len) {
+    while (sent < window) : (sent += chunk.len) {
         frame.writeFrame(&srv, .data, 0, req_stream, chunk[0..]) catch return;
     }
     // One frame past the advertised window: a flow-control violation.
@@ -2632,10 +2899,10 @@ fn cannedFlowViolationServer(peer_fd: std.posix.fd_t, saw_ack: *std.atomic.Value
 test "streaming stream fails when the peer overruns the advertised window" {
     const fds = try makeSocketpair();
     var saw_ack = std.atomic.Value(bool).init(false);
-    const server = try std.Thread.spawn(.{}, cannedFlowViolationServer, .{ fds[1], &saw_ack });
+    const server = try std.Thread.spawn(.{}, cannedFlowViolationServer, .{ fds[1], DEFAULT_STREAM_RECV_WINDOW, &saw_ack });
 
     var transport = PlainTransport{ .fd = fds[0] };
-    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 5000, null, null, null);
+    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 5000, null, null, null, windowLimits(DEFAULT_STREAM_RECV_WINDOW));
 
     const stream = try conn.requestStreaming(.{ .method = "GET", .authority = "flood.test", .path = "/" });
 
@@ -2656,8 +2923,339 @@ test "streaming stream fails when the peer overruns the advertised window" {
         total += n;
         conn.acknowledgeStreamingBody(stream, n);
     };
-    try testing.expectEqual(@as(usize, OUR_INITIAL_WINDOW), total);
+    try testing.expectEqual(@as(usize, DEFAULT_STREAM_RECV_WINDOW), total);
     try testing.expectError(error.Http2FlowControlError, @as(anyerror!void, read_err));
+
+    conn.finishStreaming(stream);
+    conn.deinit();
+    server.join();
+    _ = std.c.close(fds[1]);
+}
+
+test "configured per-stream window replaces the default streaming receive window" {
+    // 64 KiB high watermark: the peer may park exactly that much unconsumed
+    // response body per stream, a sixteenth of the built-in default.
+    const limits = windowLimits(4 * DEFAULT_MAX_FRAME);
+    try limits.validate();
+    const window = proxy_buffer_account.streamReceiveWindow(limits);
+    try testing.expectEqual(@as(u31, 4 * DEFAULT_MAX_FRAME), window);
+
+    const fds = try makeSocketpair();
+    var saw_ack = std.atomic.Value(bool).init(false);
+    const server = try std.Thread.spawn(.{}, cannedFlowViolationServer, .{ fds[1], @as(usize, window), &saw_ack });
+
+    var transport = PlainTransport{ .fd = fds[0] };
+    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 5000, null, null, null, limits);
+
+    const stream = try conn.requestStreaming(.{ .method = "GET", .authority = "window.test", .path = "/" });
+
+    var spins: usize = 0;
+    while (!saw_ack.load(.acquire) and spins < 100_000_000) : (spins += 1) std.Thread.yield() catch {};
+    try testing.expect(saw_ack.load(.acquire));
+
+    var total: usize = 0;
+    var buf: [8 * 1024]u8 = undefined;
+    const read_err = while (true) {
+        const n = conn.readStreamingBody(stream, buf[0..]) catch |e| break e;
+        try testing.expect(n != 0);
+        total += n;
+        conn.acknowledgeStreamingBody(stream, n);
+    };
+    // Exactly the configured window was accepted — not the 1 MiB default.
+    try testing.expectEqual(@as(usize, window), total);
+    try testing.expectError(error.Http2FlowControlError, @as(anyerror!void, read_err));
+
+    conn.finishStreaming(stream);
+    conn.deinit();
+    server.join();
+    _ = std.c.close(fds[1]);
+}
+
+test "streaming response reservations clear every aggregate scope after teardown" {
+    const fds = try makeSocketpair();
+    const server = try std.Thread.spawn(.{}, cannedSingleDataStreamingServer, .{ fds[1], "payload", false });
+
+    var observer = TestProxyBufferObserver{};
+    var origin = proxy_buffer_account.Aggregate.init(.origin, 1024);
+    var global = proxy_buffer_account.Aggregate.init(.global, 4096);
+    var transport = PlainTransport{ .fd = fds[0] };
+    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 3000, null, null, null, windowLimits(DEFAULT_STREAM_RECV_WINDOW));
+
+    const stream = try conn.requestStreaming(.{
+        .method = "GET",
+        .authority = "aggregate.test",
+        .path = "/",
+        .proxy_buffer_accounting = true,
+        .proxy_buffer_observer = observer.observer(),
+        .proxy_buffer_capacity = .{ .origin = &origin, .global = &global },
+    });
+    var buf: [16]u8 = undefined;
+    const n = try conn.readStreamingBody(stream, buf[0..]);
+    try testing.expectEqualStrings("payload", buf[0..n]);
+    // Queued bytes are held at every scope until the consumer acknowledges.
+    try testing.expectEqual(@as(usize, 7), origin.currentBytes(.upstream_to_downstream));
+    try testing.expectEqual(@as(usize, 7), global.currentBytes(.upstream_to_downstream));
+
+    conn.acknowledgeStreamingBody(stream, n);
+    try testing.expectEqual(@as(usize, 0), origin.currentBytes(.upstream_to_downstream));
+    try testing.expectEqual(@as(usize, 0), global.currentBytes(.upstream_to_downstream));
+
+    conn.finishStreaming(stream);
+    conn.deinit();
+    server.join();
+    _ = std.c.close(fds[1]);
+
+    try testing.expectEqual(@as(usize, 0), observer.current.load(.monotonic));
+    try testing.expectEqual(@as(u64, 0), observer.origin_limit_exceeded.load(.monotonic));
+    try testing.expectEqual(@as(u64, 0), observer.global_limit_exceeded.load(.monotonic));
+}
+
+/// Canned server for the concurrent-stream aggregate case: answers two
+/// streams, fills the first with `first_bytes` of DATA and then sends
+/// `second_bytes` on the second, and reports the id of whichever stream the
+/// client resets. Both DATA bursts stay inside each stream's own advertised
+/// window, so anything the client refuses it refuses on aggregate grounds.
+fn cannedTwoStreamServer(
+    peer_fd: std.posix.fd_t,
+    first_bytes: usize,
+    second_bytes: usize,
+    rst_stream_id: *std.atomic.Value(u32),
+) void {
+    const a = std.heap.page_allocator;
+    var srv = PlainTransport{ .fd = peer_fd };
+    var preface: [PREFACE.len]u8 = undefined;
+    readExact(&srv, peer_fd, preface[0..], 2000) catch return;
+    frame.writeSettings(a, &srv, &[_][2]u32{}) catch return;
+
+    const block = hpack.encodeLiteralHeaderBlock(a, &[_]hpack.HeaderField{
+        .{ .name = ":status", .value = "200" },
+    }) catch return;
+    defer a.free(block);
+
+    // Answer each request as it arrives so the client can open the second
+    // stream (its `requestStreaming` blocks on the response head).
+    var ids: [2]u31 = .{ 0, 0 };
+    var seen: usize = 0;
+    while (seen < 2) {
+        var fr = readFrameBounded(&srv, peer_fd, a, 3000) catch return;
+        const is_headers = fr.typ == .headers;
+        const id = fr.stream_id;
+        frame.deinitFrame(a, &fr);
+        if (!is_headers) continue;
+        ids[seen] = id;
+        seen += 1;
+        frame.writeFrame(&srv, .headers, frame.Flags.END_HEADERS, id, block) catch return;
+    }
+
+    const payload = [_]u8{'x'} ** 256;
+    frame.writeFrame(&srv, .data, 0, ids[0], payload[0..first_bytes]) catch return;
+    frame.writeFrame(&srv, .data, 0, ids[1], payload[0..second_bytes]) catch return;
+
+    while (true) {
+        var fr = readFrameBounded(&srv, peer_fd, a, 5000) catch return;
+        const is_rst = fr.typ == .rst_stream;
+        const id = fr.stream_id;
+        frame.deinitFrame(a, &fr);
+        if (is_rst) {
+            rst_stream_id.store(@intCast(id), .release);
+            return;
+        }
+    }
+}
+
+test "origin capacity bounds concurrent streams and refuses only the overflowing one" {
+    // Each stream may hold 64 bytes, and so may the origin as a whole — a
+    // valid production shape (`origin_hard >= per_stream_hard`). One slow
+    // stream holding its full window therefore leaves the origin with no room
+    // for a second, which is the concurrency multiplication the aggregate
+    // limit exists to stop.
+    const window: usize = 64;
+    const limits = windowLimits(window);
+    try limits.validate();
+
+    const fds = try makeSocketpair();
+    var rst_stream_id = std.atomic.Value(u32).init(0);
+    const server = try std.Thread.spawn(.{}, cannedTwoStreamServer, .{ fds[1], window, 16, &rst_stream_id });
+
+    var observer = TestProxyBufferObserver{};
+    var origin = proxy_buffer_account.Aggregate.init(.origin, window);
+    var global = proxy_buffer_account.Aggregate.init(.global, 1024);
+    var transport = PlainTransport{ .fd = fds[0] };
+    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 3000, null, null, null, limits);
+
+    const capacity = proxy_buffer_account.AggregateCapacity{ .origin = &origin, .global = &global };
+    const slow = try conn.requestStreaming(.{
+        .method = "GET",
+        .authority = "aggregate-origin.test",
+        .path = "/",
+        .proxy_buffer_accounting = true,
+        .proxy_buffer_observer = observer.observer(),
+        .proxy_buffer_capacity = capacity,
+    });
+    const refused = try conn.requestStreaming(.{
+        .method = "GET",
+        .authority = "aggregate-origin.test",
+        .path = "/",
+        .proxy_buffer_accounting = true,
+        .proxy_buffer_observer = observer.observer(),
+        .proxy_buffer_capacity = capacity,
+    });
+
+    // The second stream is refused; the first is untouched and still usable.
+    var buf: [128]u8 = undefined;
+    try testing.expectError(error.BufferLimitExceeded, conn.readStreamingBody(refused, buf[0..]));
+    try testing.expect(origin.currentBytes(.upstream_to_downstream) <= window);
+
+    const n = try conn.readStreamingBody(slow, buf[0..]);
+    try testing.expectEqual(window, n);
+    conn.acknowledgeStreamingBody(slow, n);
+
+    const refused_id: u32 = refused.id;
+    conn.finishStreaming(refused);
+    conn.finishStreaming(slow);
+    conn.deinit();
+    server.join();
+    _ = std.c.close(fds[1]);
+
+    // The refused stream — not the healthy one — was reset upstream.
+    try testing.expectEqual(refused_id, rst_stream_id.load(.acquire));
+    try testing.expectEqual(@as(usize, 0), origin.currentBytes(.upstream_to_downstream));
+    try testing.expectEqual(@as(usize, 0), global.currentBytes(.upstream_to_downstream));
+    try testing.expectEqual(@as(usize, 0), observer.current.load(.monotonic));
+    // Exactly one origin-scope refusal: a stream we gave up on is discard-only,
+    // so later DATA on it neither reserves again nor re-counts the event.
+    try testing.expectEqual(@as(u64, 1), observer.origin_limit_exceeded.load(.monotonic));
+    try testing.expectEqual(@as(u64, 0), observer.global_limit_exceeded.load(.monotonic));
+    // The global scope had room; its rolled-back reservation must not have
+    // been counted as a global refusal either.
+    try testing.expectEqual(@as(u64, 0), observer.limit_exceeded.load(.monotonic));
+}
+
+/// Canned server that fills a stream's window in one frame and then reports the
+/// increment carried by the **first** stream-level WINDOW_UPDATE the client
+/// sends back. Connection-level updates (stream 0) are ignored.
+fn cannedWindowCreditServer(
+    peer_fd: std.posix.fd_t,
+    body_bytes: usize,
+    first_credit: *std.atomic.Value(u32),
+) void {
+    const a = std.heap.page_allocator;
+    var srv = PlainTransport{ .fd = peer_fd };
+    var preface: [PREFACE.len]u8 = undefined;
+    readExact(&srv, peer_fd, preface[0..], 2000) catch return;
+    frame.writeSettings(a, &srv, &[_][2]u32{}) catch return;
+
+    var req_stream: u31 = 0;
+    while (req_stream == 0) {
+        var fr = readFrameBounded(&srv, peer_fd, a, 2000) catch return;
+        if (fr.typ == .headers) req_stream = fr.stream_id;
+        frame.deinitFrame(a, &fr);
+    }
+
+    const block = hpack.encodeLiteralHeaderBlock(a, &[_]hpack.HeaderField{
+        .{ .name = ":status", .value = "200" },
+    }) catch return;
+    defer a.free(block);
+    frame.writeFrame(&srv, .headers, frame.Flags.END_HEADERS, req_stream, block) catch return;
+
+    const payload = [_]u8{'x'} ** 256;
+    frame.writeFrame(&srv, .data, 0, req_stream, payload[0..body_bytes]) catch return;
+
+    while (true) {
+        var fr = readFrameBounded(&srv, peer_fd, a, 5000) catch return;
+        const is_stream_update = fr.typ == .window_update and fr.stream_id == req_stream;
+        const increment: u32 = if (is_stream_update and fr.payload.len >= 4)
+            std.mem.readInt(u32, fr.payload[0..4], .big) & 0x7FFF_FFFF
+        else
+            0;
+        frame.deinitFrame(a, &fr);
+        if (is_stream_update) {
+            first_credit.store(increment, .release);
+            return;
+        }
+    }
+}
+
+test "stream credit is withheld between the high and low watermarks" {
+    // Window (== high) 64, low 32: draining from 64 to 48 stays inside the
+    // pause band, so the peer must get no credit until the queue reaches 32.
+    const window: usize = 64;
+    const limits = windowLimits(window);
+    try testing.expectEqual(@as(usize, 32), limits.per_stream_low_watermark);
+
+    const fds = try makeSocketpair();
+    var first_credit = std.atomic.Value(u32).init(0);
+    const server = try std.Thread.spawn(.{}, cannedWindowCreditServer, .{ fds[1], window, &first_credit });
+
+    var observer = TestProxyBufferObserver{};
+    var transport = PlainTransport{ .fd = fds[0] };
+    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 3000, null, null, null, limits);
+
+    const stream = try conn.requestStreaming(.{
+        .method = "GET",
+        .authority = "hysteresis.test",
+        .path = "/",
+        .proxy_buffer_accounting = true,
+        .proxy_buffer_observer = observer.observer(),
+    });
+
+    // Fill the queue to the high watermark, which pauses the upstream.
+    var buf: [16]u8 = undefined;
+    const first = try conn.readStreamingBody(stream, buf[0..]);
+    try testing.expectEqual(@as(usize, 16), first);
+    conn.acknowledgeStreamingBody(stream, first); // queue 48: still above low
+    try testing.expectEqual(@as(u64, 1), observer.read_pauses.load(.monotonic));
+    try testing.expectEqual(@as(u64, 0), observer.read_resumes.load(.monotonic));
+
+    const second = try conn.readStreamingBody(stream, buf[0..]);
+    try testing.expectEqual(@as(usize, 16), second);
+    conn.acknowledgeStreamingBody(stream, second); // queue 32: crosses low
+    try testing.expectEqual(@as(u64, 1), observer.read_resumes.load(.monotonic));
+
+    var spins: usize = 0;
+    while (first_credit.load(.acquire) == 0 and spins < 100_000_000) : (spins += 1) std.Thread.yield() catch {};
+    // One coalesced update for everything drained inside the band — crediting
+    // each chunk as it drained would have made this 16.
+    try testing.expectEqual(@as(u32, 32), first_credit.load(.acquire));
+
+    conn.finishStreaming(stream);
+    conn.deinit();
+    server.join();
+    _ = std.c.close(fds[1]);
+}
+
+test "a drained queue returns its backing allocation to the aggregate scopes" {
+    // A stream that fills and drains repeatedly must not sit on its peak
+    // allocation: the aggregate scopes bound retained memory, so a queue whose
+    // logical length is zero has to have given its storage back too.
+    const window: usize = 64;
+    const fds = try makeSocketpair();
+    const server = try std.Thread.spawn(.{}, cannedSingleDataStreamingServer, .{ fds[1], "0123456789abcdef", false });
+
+    var origin = proxy_buffer_account.Aggregate.init(.origin, window);
+    var global = proxy_buffer_account.Aggregate.init(.global, 1024);
+    var transport = PlainTransport{ .fd = fds[0] };
+    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 3000, null, null, null, windowLimits(window));
+
+    const stream = try conn.requestStreaming(.{
+        .method = "GET",
+        .authority = "retained.test",
+        .path = "/",
+        .proxy_buffer_accounting = true,
+        .proxy_buffer_capacity = .{ .origin = &origin, .global = &global },
+    });
+
+    var buf: [16]u8 = undefined;
+    const n = try conn.readStreamingBody(stream, buf[0..]);
+    try testing.expectEqual(@as(usize, 16), n);
+    try testing.expectEqual(@as(usize, 16), origin.currentBytes(.upstream_to_downstream));
+
+    conn.acknowledgeStreamingBody(stream, n);
+    // Logical length *and* retained capacity are both back to zero.
+    try testing.expectEqual(@as(usize, 0), stream.body.items.len);
+    try testing.expectEqual(@as(usize, 0), stream.body.capacity);
+    try testing.expectEqual(@as(usize, 0), origin.currentBytes(.upstream_to_downstream));
+    try testing.expectEqual(@as(usize, 0), global.currentBytes(.upstream_to_downstream));
 
     conn.finishStreaming(stream);
     conn.deinit();
@@ -2704,7 +3302,7 @@ test "stalled streaming stream times out via the reader sweep while other frames
     var transport = PlainTransport{ .fd = fds[0] };
     // Short stream deadline; PINGs every 20ms keep the reader's frame reads
     // alive, so only the sweep can bound the body wait.
-    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 300, null, null, null);
+    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 300, null, null, null, windowLimits(DEFAULT_STREAM_RECV_WINDOW));
 
     const stream = try conn.requestStreaming(.{ .method = "GET", .authority = "stall.test", .path = "/" });
     var buf: [64]u8 = undefined;
@@ -2755,7 +3353,7 @@ test "streaming and buffered requests multiplex together on one connection" {
     const server = try std.Thread.spawn(.{}, cannedMuxServer, .{ fds[1], @as(usize, N_BUF + N_STREAM) });
 
     var transport = PlainTransport{ .fd = fds[0] };
-    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 3000, null, null, null);
+    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 3000, null, null, null, windowLimits(DEFAULT_STREAM_RECV_WINDOW));
 
     var bctxs: [N_BUF]MuxClientCtx = undefined;
     var sctxs: [N_STREAM]MuxStreamingClientCtx = undefined;
@@ -2857,7 +3455,7 @@ test "streaming request upload sends DATA incrementally and waits for flow-contr
     const server = try std.Thread.spawn(.{}, cannedStreamingUploadServer, .{ fds[1], &writer_done, &blocked_observed, upload_len });
 
     var transport = PlainTransport{ .fd = fds[0] };
-    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 3000, null, null, null);
+    const conn = try H2Conn(*PlainTransport).init(testing.allocator, &transport, fds[0], 3000, null, null, null, windowLimits(DEFAULT_STREAM_RECV_WINDOW));
 
     const stream = try conn.openStreaming(.{
         .method = "POST",
@@ -2904,7 +3502,7 @@ test "streaming request upload DATA write failure poisons the h2 connection" {
     defer _ = std.c.close(fds[1]);
 
     var transport = FailingDataTransport{ .fd = fds[0] };
-    const conn = try H2Conn(*FailingDataTransport).init(testing.allocator, &transport, fds[0], 3000, null, null, null);
+    const conn = try H2Conn(*FailingDataTransport).init(testing.allocator, &transport, fds[0], 3000, null, null, null, windowLimits(DEFAULT_STREAM_RECV_WINDOW));
 
     const stream = try conn.openStreaming(.{
         .method = "POST",


### PR DESCRIPTION
## Summary

Implements the HTTP/2 response-enforcement slice of #140 (the issue's "PR 2"), plus the aggregate policy from its PR 4. The shared accounting type, config, and metrics from PR 1 already existed; this makes them *enforce* rather than merely observe.

**This PR does not close #140.** The issue's PR-3 slice — request-direction accounting and HTTP/1 pause/resume observability, with its slow-origin, large-upload, and client-abort coverage — is still outstanding, and #140's acceptance criteria require it.

### HTTP/2 per-stream bounds

- **The advertised receive window is derived from configuration.** `SETTINGS_INITIAL_WINDOW_SIZE` was a fixed 1 MiB constant unrelated to `TARDIGRADE_PROXY_BUFFER_PER_STREAM_HIGH_WATERMARK_BYTES`. It is now that value, so protocol flow control stops a well-behaved origin exactly where the accounting model says the queue is full.
- **Credit is returned with hysteresis.** While a queue sits at or above the high watermark, consumed bytes accumulate uncredited; the total goes out as one `WINDOW_UPDATE` when the queue drains below the low watermark. Crediting each chunk let the origin refill immediately, so the band never paused anything. `tardigrade_buffer_read_pauses_total{side="upstream"}` and its resume counterpart are now real signals instead of always-zero series.

### Aggregate bounds

- **Per-origin and global hard limits are enforced**, not just validated — N concurrent slow streams could previously retain N windows.
- **Reservations track retained allocation, not logical length.** `shrinkRetainingCapacity` keeps the backing buffer, so a drained queue could return its bytes to the aggregates while still owning ~a window of memory; RSS could grow by `N × window` with the counters near zero. Queues now allocate precisely and hand storage back the moment they drain empty.
- Reservations are taken before memory is committed, and a refusal at one scope rolls the other back.
- Both limits still default to `0` (unlimited), so existing deployments are unchanged until they opt in.

### Failure semantics

Deterministic on both sides of the downstream commitment boundary:

- **Pre-commit** — including when the reader rejects DATA between decoding the origin's headers and the worker relaying them — the request fails `503 proxy_buffer_saturated` and is not retried.
- **Post-commit** the stream is reset upstream, the response truncated, reservations released, and the reason logged.

Neither counts against upstream health: local memory pressure must not trip a healthy origin's failure policy. A refused stream becomes discard-only, so DATA still in flight cannot re-reserve, re-count the limit event, or queue bytes behind an error the consumer has not seen. Unrelated streams, including others on the same connection, are untouched. Allocation failure while setting up origin accounting is a `503` rather than silently dropping the scope.

### Configuration and reload

Each connection pins the whole per-stream policy it advertised, so a peer is judged by the credit it was actually granted rather than a newer snapshot. The pool owns per-origin limits and applies a reload to existing origins; requests no longer write their own config snapshot into shared state. Aggregate limits reload immediately; the per-stream policy reaches connections opened afterwards, since SETTINGS are negotiated once per connection. A high watermark too large to advertise as an HTTP/2 window is rejected at startup and reload.

Docs updated in `PROXY_STREAMING.md`, `OBSERVABILITY.md`, and the changelog.

**Out of scope**, per the issue's sequencing: the HTTP/1 relay keeps its fixed buffers, gains no queue, and takes no aggregate reservation — its buffers do not grow with concurrency the way an h2 stream queue does.

## Test plan

- [x] `zig build test` — full unit suite passes
- [x] `zig build test-integration` — passes (65 skips are the pre-existing socket-sandbox skips)
- [x] `zig build -Doptimize=ReleaseFast` — clean
- [x] **Concurrent-stream aggregate case** with limits that pass `validate()` (`origin_hard == per_stream_hard`): one slow stream holds its full window, a second stream's DATA is refused, and the test asserts the *refused* stream is the one reset upstream, the healthy stream stays usable, origin bytes never exceed the cap, exactly one refusal is counted, and every scope returns to zero
- [x] **Hysteresis**: the first stream-level `WINDOW_UPDATE` the peer sees carries the coalesced 32 bytes drained across the band, not the 16 of the first chunk — an eager implementation fails this
- [x] **Retained storage**: after a fill/drain cycle both `body.capacity` and the aggregate counters are zero
- [x] **Reload**: an existing origin's in-place limit changes and immediately refuses an over-cap reservation, a newly seen origin starts under the reloaded policy, and an open connection keeps the window and policy it advertised
- [x] Window derivation from config; a peer flooding past a *small configured* window is cut off at exactly that window
- [x] Prometheus rendering covers the origin/global `scope` labels, including a zero-valued scope

Refs #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)