### PR TITLE
perf: add writev response writer

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -90,6 +90,15 @@ logs are written through `src/http/logger.zig`.
   transports stream. Unix-socket and upstream-mTLS targets stream like any other
   upstream and no longer emit a fallback reason.
 - reverse-proxy upstream TTFB summary: `tardigrade_proxy_ttfb_ms`
+- HTTP/1 response writer counters:
+  `tardigrade_response_write_mode_total{mode=...}`,
+  `tardigrade_response_writev_iovecs_total`, and
+  `tardigrade_response_write_errors_total{mode=...}`. Plaintext socket writers
+  use `mode="writev"` when status/headers and body are emitted as gathered
+  fragments. Header-only writes use `mode="single_write"`. TLS writers stay on
+  the TLS library's buffered write path and are reported as
+  `mode="tls_buffered"` when callers use the tracked response-write API;
+  generic in-memory or compatibility writers use `mode="fallback"`.
 - HTTP-level early-data counters (fixed labels only):
   `tardigrade_http_early_data_requests_total{protocol,source}`,
   `tardigrade_http_early_data_decisions_total{protocol,decision}`,

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -95,10 +95,11 @@ logs are written through `src/http/logger.zig`.
   `tardigrade_response_writev_iovecs_total`, and
   `tardigrade_response_write_errors_total{mode=...}`. Plaintext socket writers
   use `mode="writev"` when status/headers and body are emitted as gathered
-  fragments. Header-only writes use `mode="single_write"`. TLS writers stay on
-  the TLS library's buffered write path and are reported as
-  `mode="tls_buffered"` when callers use the tracked response-write API;
-  generic in-memory or compatibility writers use `mode="fallback"`.
+  fragments. Header-only or empty-body responses on gathered-capable writers
+  serialize the head once and use `mode="single_write"`. TLS writers stay on the
+  TLS library's buffered write path and are reported as `mode="tls_buffered"`
+  when callers use the tracked response-write API; generic in-memory or
+  compatibility writers use `mode="fallback"`.
 - HTTP-level early-data counters (fixed labels only):
   `tardigrade_http_early_data_requests_total{protocol,source}`,
   `tardigrade_http_early_data_decisions_total{protocol,decision}`,

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -3879,7 +3879,7 @@ fn handleConnection(conn: anytype, session: *ConnectionSession, cfg: *const edge
                 .setBody(key_auth)
                 .setHeader("Content-Type", "application/octet-stream")
                 .setConnection(keep_alive);
-            try acme_response.write(writer);
+            try acme_response.writeWithMetrics(writer, &state.metrics, &state.metrics_mutex);
             // ACME HTTP-01 challenges are ordinary requests; keep them visible in
             // access logs and status metrics like every other terminal (#201).
             state.metricsRecord(200);
@@ -3957,7 +3957,7 @@ fn handleConnection(conn: anytype, session: *ConnectionSession, cfg: *const edge
                 defer response.deinit();
                 _ = response.setConnection(keep_alive).setHeader(http.correlation.HEADER_NAME, correlation_id);
                 gp.applyResponseHeaders(state, &response);
-                try response.write(writer);
+                try response.writeWithMetrics(writer, &state.metrics, &state.metrics_mutex);
                 state.metricsRecord(r.status);
                 ghandlers.logAccessForRequest(state, &ctx, &request, r.status);
                 return;
@@ -4000,7 +4000,7 @@ fn handleConnection(conn: anytype, session: *ConnectionSession, cfg: *const edge
             defer response.deinit();
             _ = response.setConnection(keep_alive).setHeader(http.correlation.HEADER_NAME, correlation_id);
             gp.applyResponseHeaders(state, &response);
-            try response.write(writer);
+            try response.writeWithMetrics(writer, &state.metrics, &state.metrics_mutex);
             state.metricsRecord(r.status);
             ghandlers.logAccessForRequest(state, &ctx, &request, r.status);
             return;

--- a/src/gateway_handlers.zig
+++ b/src/gateway_handlers.zig
@@ -209,7 +209,7 @@ pub fn writeTooEarlyResponse(
     setRequestIdHeaders(&response, correlation_id);
     ctx.response_bytes = payload.len;
     applyResponseHeaders(state, &response);
-    try response.write(writer);
+    try response.writeWithMetrics(writer, &state.metrics, &state.metrics_mutex);
     state.metricsRecord(@intFromEnum(plan.status));
     state.metricsRecordErrorCode(plan.code);
     return @intFromEnum(plan.status);
@@ -390,7 +390,7 @@ pub fn writeReturnResponsePlan(
             setRequestIdHeaders(&response, correlation_id);
             ctx.response_bytes = payload.len;
             applyResponseHeaders(state, &response);
-            try response.write(writer);
+            try response.writeWithMetrics(writer, &state.metrics, &state.metrics_mutex);
             return .{ .status = 405, .error_code = "invalid_request" };
         },
         .redirect => |r| {
@@ -400,7 +400,7 @@ pub fn writeReturnResponsePlan(
             setRequestIdHeaders(&response, correlation_id);
             ctx.response_bytes = 0;
             applyResponseHeaders(state, &response);
-            try response.write(writer);
+            try response.writeWithMetrics(writer, &state.metrics, &state.metrics_mutex);
             return .{ .status = r.status };
         },
         .body => |b| {
@@ -413,7 +413,7 @@ pub fn writeReturnResponsePlan(
             setRequestIdHeaders(&response, correlation_id);
             ctx.response_bytes = b.body.len;
             applyResponseHeaders(state, &response);
-            try response.write(writer);
+            try response.writeWithMetrics(writer, &state.metrics, &state.metrics_mutex);
             return .{ .status = b.status };
         },
     }
@@ -1004,7 +1004,7 @@ fn handleReloadStatusRoute(
         .setConnection(keep_alive)
         .setHeader(http.correlation.HEADER_NAME, correlation_id);
     applyResponseHeaders(state, &response);
-    try response.write(writer);
+    try response.writeWithMetrics(writer, &state.metrics, &state.metrics_mutex);
     return 200;
 }
 
@@ -1044,11 +1044,11 @@ fn handleMetricsRoute(
         _ = response.setContentLength(payload.len);
         ctx.response_bytes = 0;
         applyResponseHeaders(state, &response);
-        try response.writeHead(writer);
+        try response.writeHeadWithMetrics(writer, &state.metrics, &state.metrics_mutex);
     } else {
         ctx.response_bytes = payload.len;
         applyResponseHeaders(state, &response);
-        try response.write(writer);
+        try response.writeWithMetrics(writer, &state.metrics, &state.metrics_mutex);
     }
     return 200;
 }
@@ -1091,9 +1091,9 @@ fn writeJsonPayload(
         .setHeader(http.correlation.HEADER_NAME, correlation_id);
     applyResponseHeaders(state, &response);
     if (head_only) {
-        try response.writeHead(writer);
+        try response.writeHeadWithMetrics(writer, &state.metrics, &state.metrics_mutex);
     } else {
-        try response.write(writer);
+        try response.writeWithMetrics(writer, &state.metrics, &state.metrics_mutex);
     }
 }
 
@@ -1206,7 +1206,7 @@ pub fn runMiddlewarePipeline(
             .setHeader("Retry-After", "1")
             .setHeader(http.correlation.HEADER_NAME, correlation_id);
         applyResponseHeaders(state, &response);
-        try response.write(writer);
+        try response.writeWithMetrics(writer, &state.metrics, &state.metrics_mutex);
         state.metricsRecord(429);
         state.metricsRecordErrorCode("rate_limited");
         logAccessForRequest(state, ctx, request, 429);

--- a/src/gateway_proxy.zig
+++ b/src/gateway_proxy.zig
@@ -43,6 +43,7 @@ pub const applyResponseHeaders = gpres.applyResponseHeaders;
 pub const writeStreamedUpstreamResponse = gpres.writeStreamedUpstreamResponse;
 pub const writeStreamedUpstreamResponseHeadFromHeaders = gpres.writeStreamedUpstreamResponseHeadFromHeaders;
 pub const writeBufferedUpstreamResponse = gpres.writeBufferedUpstreamResponse;
+pub const writeBufferedUpstreamResponseWithMetrics = gpres.writeBufferedUpstreamResponseWithMetrics;
 pub const computeHstsValue = gpres.computeHstsValue;
 pub const writeSecurityHeaders = gpres.writeSecurityHeaders;
 pub const writeChunk = gpres.writeChunk;

--- a/src/gateway_proxy_response.zig
+++ b/src/gateway_proxy_response.zig
@@ -237,6 +237,12 @@ fn writeBufferedUpstreamResponseMeasured(
             try writer.writeAll(head.bytes);
             return .{ .mode = .single_write };
         }
+        const total_len = head.bytes.len + upstream_response.body.len;
+        if (head.allocator == null and total_len <= scratch.len) {
+            @memcpy(scratch[head.bytes.len..total_len], upstream_response.body);
+            try writer.writeAll(scratch[0..total_len]);
+            return .{ .mode = .single_write };
+        }
         const fragments = [_][]const u8{ head.bytes, upstream_response.body };
         return .{
             .mode = .writev,
@@ -601,7 +607,7 @@ test "writeBufferedUpstreamResponse serializes a single forwarded response head"
     try std.testing.expect(std.mem.endsWith(u8, output, "\r\n\r\npong"));
 }
 
-test "writeBufferedUpstreamResponseWithMetrics uses gathered write for data-plane body" {
+test "writeBufferedUpstreamResponseWithMetrics keeps small data-plane body on single-write fast path" {
     const allocator = std.testing.allocator;
     const body = try allocator.dupe(u8, "pong");
     var upstream_headers = [_]TestUpstreamHeader{
@@ -633,11 +639,53 @@ test "writeBufferedUpstreamResponseWithMetrics uses gathered write for data-plan
         &metrics_mutex,
     );
 
+    try std.testing.expectEqual(@as(usize, 0), writer.writev_calls);
+    try std.testing.expectEqual(@as(usize, 0), writer.writev_iovecs);
+    try std.testing.expectEqual(@as(usize, 1), writer.write_all_calls);
+    try std.testing.expect(std.mem.startsWith(u8, writer.output.items, "HTTP/1.1 200 OK\r\n"));
+    try std.testing.expect(std.mem.endsWith(u8, writer.output.items, "pong"));
+    try std.testing.expectEqual(@as(u64, 1), metrics.response_write_mode_total[1]);
+    try std.testing.expectEqual(@as(u64, 0), metrics.response_writev_iovecs_total);
+}
+
+test "writeBufferedUpstreamResponseWithMetrics uses gathered write when body does not fit scratch" {
+    const allocator = std.testing.allocator;
+    const body = try allocator.alloc(u8, 10 * 1024);
+    @memset(body, 'x');
+    var upstream_headers = [_]TestUpstreamHeader{
+        .{ .name = "Content-Type", .value = "text/plain" },
+    };
+    var response = TestBufferedUpstreamResponse{
+        .metadata_arena = std.heap.ArenaAllocator.init(allocator),
+        .status_code = 200,
+        .reason = "OK",
+        .headers = upstream_headers[0..],
+        .body = body,
+    };
+    defer response.deinit(allocator);
+
+    var writer = TestGatheredProxyWriter.init(allocator);
+    defer writer.deinit();
+    var metrics = http.metrics.Metrics.init();
+    var metrics_mutex = compat.Mutex{};
+
+    try writeBufferedUpstreamResponseWithMetrics(
+        &writer,
+        &response,
+        true,
+        "req-gathered-large",
+        &http.security_headers.SecurityHeaders.api,
+        null,
+        null,
+        &metrics,
+        &metrics_mutex,
+    );
+
     try std.testing.expectEqual(@as(usize, 1), writer.writev_calls);
     try std.testing.expectEqual(@as(usize, 2), writer.writev_iovecs);
     try std.testing.expectEqual(@as(usize, 0), writer.write_all_calls);
     try std.testing.expect(std.mem.startsWith(u8, writer.output.items, "HTTP/1.1 200 OK\r\n"));
-    try std.testing.expect(std.mem.endsWith(u8, writer.output.items, "pong"));
+    try std.testing.expect(std.mem.endsWith(u8, writer.output.items, body));
     try std.testing.expectEqual(@as(u64, 1), metrics.response_write_mode_total[0]);
     try std.testing.expectEqual(@as(u64, 2), metrics.response_writev_iovecs_total);
 }

--- a/src/gateway_proxy_response.zig
+++ b/src/gateway_proxy_response.zig
@@ -298,7 +298,7 @@ pub fn sendApiError(allocator: std.mem.Allocator, writer: anytype, status: http.
         gph.setRequestIdHeaders(&response, rid);
     }
     applyResponseHeaders(state, &response);
-    try response.write(writer);
+    try response.writeWithMetrics(writer, &state.metrics, &state.metrics_mutex);
     state.metricsRecord(@intFromEnum(status));
     state.metricsRecordErrorCode(code);
 }

--- a/src/gateway_proxy_response.zig
+++ b/src/gateway_proxy_response.zig
@@ -180,6 +180,130 @@ pub fn writeBufferedUpstreamResponse(
     try writer.writeAll(response_stream.getWritten());
 }
 
+pub fn writeBufferedUpstreamResponseWithMetrics(
+    writer: anytype,
+    upstream_response: anytype,
+    keep_alive: bool,
+    correlation_id: []const u8,
+    security: *const http.security_headers.SecurityHeaders,
+    alt_svc: ?[]const u8,
+    sticky_set_cookie: ?[]const u8,
+    metrics: *http.metrics.Metrics,
+    metrics_mutex: *compat.Mutex,
+) !void {
+    const result = writeBufferedUpstreamResponseMeasured(
+        writer,
+        upstream_response,
+        keep_alive,
+        correlation_id,
+        security,
+        alt_svc,
+        sticky_set_cookie,
+    ) catch |err| {
+        recordResponseWriteMetric(metrics, metrics_mutex, attemptedWriterMode(@TypeOf(writer), upstream_response.body.len == 0), 0, true);
+        return err;
+    };
+    recordResponseWriteMetric(metrics, metrics_mutex, result.mode, result.iovecs, false);
+}
+
+const BufferedWriteMeasurement = struct {
+    mode: http.metrics.ResponseWriteMode,
+    iovecs: usize = 0,
+};
+
+fn writeBufferedUpstreamResponseMeasured(
+    writer: anytype,
+    upstream_response: anytype,
+    keep_alive: bool,
+    correlation_id: []const u8,
+    security: *const http.security_headers.SecurityHeaders,
+    alt_svc: ?[]const u8,
+    sticky_set_cookie: ?[]const u8,
+) !BufferedWriteMeasurement {
+    const Writer = @TypeOf(writer);
+    if (comptime writerSupportsGatheredWrite(Writer)) {
+        var scratch: [8192]u8 = undefined;
+        const head = try buildBufferedUpstreamResponseHeadBounded(
+            &scratch,
+            upstream_response,
+            keep_alive,
+            correlation_id,
+            security,
+            alt_svc,
+            sticky_set_cookie,
+        );
+        defer head.deinit();
+        if (upstream_response.body.len == 0) {
+            try writer.writeAll(head.bytes);
+            return .{ .mode = .single_write };
+        }
+        const fragments = [_][]const u8{ head.bytes, upstream_response.body };
+        return .{
+            .mode = .writev,
+            .iovecs = try writer.writeGatheredAll(&fragments),
+        };
+    }
+
+    try writeBufferedUpstreamResponse(
+        writer,
+        upstream_response,
+        keep_alive,
+        correlation_id,
+        security,
+        alt_svc,
+        sticky_set_cookie,
+    );
+    return .{ .mode = classifyWriterMode(Writer, upstream_response.body.len == 0) };
+}
+
+const HeaderBytes = struct {
+    allocator: ?std.mem.Allocator = null,
+    bytes: []u8,
+
+    fn deinit(self: HeaderBytes) void {
+        if (self.allocator) |allocator| allocator.free(self.bytes);
+    }
+};
+
+fn buildBufferedUpstreamResponseHeadBounded(
+    scratch: []u8,
+    upstream_response: anytype,
+    keep_alive: bool,
+    correlation_id: []const u8,
+    security: *const http.security_headers.SecurityHeaders,
+    alt_svc: ?[]const u8,
+    sticky_set_cookie: ?[]const u8,
+) !HeaderBytes {
+    var stream = compat.fixedBufferStream(scratch);
+    writeBufferedUpstreamResponseHead(
+        stream.writer(),
+        upstream_response,
+        keep_alive,
+        correlation_id,
+        security,
+        alt_svc,
+        sticky_set_cookie,
+    ) catch {
+        const fallback_allocator = std.heap.page_allocator;
+        var allocating: std.Io.Writer.Allocating = .init(fallback_allocator);
+        errdefer allocating.deinit();
+        try writeBufferedUpstreamResponseHead(
+            &allocating.writer,
+            upstream_response,
+            keep_alive,
+            correlation_id,
+            security,
+            alt_svc,
+            sticky_set_cookie,
+        );
+        return .{
+            .allocator = fallback_allocator,
+            .bytes = try allocating.toOwnedSlice(),
+        };
+    };
+    return .{ .bytes = stream.getWritten() };
+}
+
 pub fn writeBufferedUpstreamResponseHead(
     writer: anytype,
     upstream_response: anytype,
@@ -214,6 +338,46 @@ pub fn writeBufferedUpstreamResponseHead(
     try writeSecurityHeadersFiltered(writer, security, upstream_response.headers);
     if (alt_svc) |value| try writer.print("Alt-Svc: {s}\r\n", .{value});
     try writer.writeAll("\r\n");
+}
+
+fn classifyWriterMode(comptime Writer: type, body_empty: bool) http.metrics.ResponseWriteMode {
+    _ = body_empty;
+    const name = @typeName(Writer);
+    if (std.mem.indexOf(u8, name, "tls_termination.TlsConnection.Writer") != null or
+        std.mem.indexOf(u8, name, "encrypted_stream_connection.EncryptedStreamHttpConnection.Writer") != null)
+    {
+        return .tls_buffered;
+    }
+    return .fallback;
+}
+
+fn attemptedWriterMode(comptime Writer: type, body_empty: bool) http.metrics.ResponseWriteMode {
+    if (comptime writerSupportsGatheredWrite(Writer)) return if (body_empty) .single_write else .writev;
+    return classifyWriterMode(Writer, body_empty);
+}
+
+fn writerSupportsGatheredWrite(comptime Writer: type) bool {
+    return switch (@typeInfo(Writer)) {
+        .pointer => |ptr| @hasDecl(ptr.child, "writeGatheredAll"),
+        .@"struct", .@"enum", .@"union", .@"opaque" => @hasDecl(Writer, "writeGatheredAll"),
+        else => false,
+    };
+}
+
+fn recordResponseWriteMetric(
+    metrics: *http.metrics.Metrics,
+    metrics_mutex: *compat.Mutex,
+    mode: http.metrics.ResponseWriteMode,
+    iovecs: usize,
+    failed: bool,
+) void {
+    metrics_mutex.lock();
+    defer metrics_mutex.unlock();
+    if (failed) {
+        metrics.recordResponseWriteError(mode);
+    } else {
+        metrics.recordResponseWriteMode(mode, iovecs);
+    }
 }
 
 pub fn computeHstsValue(allocator: std.mem.Allocator, cfg: *const edge_config.EdgeConfig) ![]u8 {
@@ -322,6 +486,35 @@ const TestBufferedUpstreamResponse = struct {
     }
 };
 
+const TestGatheredProxyWriter = struct {
+    allocator: std.mem.Allocator,
+    output: std.ArrayList(u8) = .empty,
+    writev_calls: usize = 0,
+    writev_iovecs: usize = 0,
+    write_all_calls: usize = 0,
+
+    fn init(allocator: std.mem.Allocator) TestGatheredProxyWriter {
+        return .{ .allocator = allocator };
+    }
+
+    fn deinit(self: *TestGatheredProxyWriter) void {
+        self.output.deinit(self.allocator);
+        self.* = undefined;
+    }
+
+    pub fn writeAll(self: *TestGatheredProxyWriter, bytes: []const u8) !void {
+        self.write_all_calls += 1;
+        try self.output.appendSlice(self.allocator, bytes);
+    }
+
+    pub fn writeGatheredAll(self: *TestGatheredProxyWriter, fragments: []const []const u8) !usize {
+        self.writev_calls += 1;
+        self.writev_iovecs += fragments.len;
+        for (fragments) |fragment| try self.output.appendSlice(self.allocator, fragment);
+        return fragments.len;
+    }
+};
+
 test "writeBufferedUpstreamResponse preserves oversized body bytes exactly" {
     const allocator = std.testing.allocator;
     const prefix = "/*! tailwindcss v4.1.4 | MIT License | synthetic */\n";
@@ -406,6 +599,47 @@ test "writeBufferedUpstreamResponse serializes a single forwarded response head"
     try std.testing.expect(std.mem.find(u8, output, "X-Correlation-ID: tg-1778460305668-bfebecb410803023\r\n") != null);
     try std.testing.expect(std.mem.find(u8, output, "Server: python\r\n") == null);
     try std.testing.expect(std.mem.endsWith(u8, output, "\r\n\r\npong"));
+}
+
+test "writeBufferedUpstreamResponseWithMetrics uses gathered write for data-plane body" {
+    const allocator = std.testing.allocator;
+    const body = try allocator.dupe(u8, "pong");
+    var upstream_headers = [_]TestUpstreamHeader{
+        .{ .name = "Content-Type", .value = "text/plain" },
+    };
+    var response = TestBufferedUpstreamResponse{
+        .metadata_arena = std.heap.ArenaAllocator.init(allocator),
+        .status_code = 200,
+        .reason = "OK",
+        .headers = upstream_headers[0..],
+        .body = body,
+    };
+    defer response.deinit(allocator);
+
+    var writer = TestGatheredProxyWriter.init(allocator);
+    defer writer.deinit();
+    var metrics = http.metrics.Metrics.init();
+    var metrics_mutex = compat.Mutex{};
+
+    try writeBufferedUpstreamResponseWithMetrics(
+        &writer,
+        &response,
+        true,
+        "req-gathered",
+        &http.security_headers.SecurityHeaders.api,
+        null,
+        null,
+        &metrics,
+        &metrics_mutex,
+    );
+
+    try std.testing.expectEqual(@as(usize, 1), writer.writev_calls);
+    try std.testing.expectEqual(@as(usize, 2), writer.writev_iovecs);
+    try std.testing.expectEqual(@as(usize, 0), writer.write_all_calls);
+    try std.testing.expect(std.mem.startsWith(u8, writer.output.items, "HTTP/1.1 200 OK\r\n"));
+    try std.testing.expect(std.mem.endsWith(u8, writer.output.items, "pong"));
+    try std.testing.expectEqual(@as(u64, 1), metrics.response_write_mode_total[0]);
+    try std.testing.expectEqual(@as(u64, 2), metrics.response_writev_iovecs_total);
 }
 
 test "writeBufferedUpstreamResponse strips upstream Alt-Svc and emits effective policy once" {

--- a/src/gateway_proxy_runtime.zig
+++ b/src/gateway_proxy_runtime.zig
@@ -436,7 +436,7 @@ fn executeVersionedApiProxyRoute(
                 _ = response.setHeader("Set-Cookie", cookie);
             }
             applyResponseHeaders(state, &response);
-            try response.write(writer);
+            try response.writeWithMetrics(writer, &state.metrics, &state.metrics_mutex);
             ctx.setUpstreamResult(resp.upstream_addr, resp.status, resp.body.len);
             state.metricsRecord(resp.status);
             return resp.status;

--- a/src/gateway_proxy_runtime.zig
+++ b/src/gateway_proxy_runtime.zig
@@ -32,7 +32,7 @@ const mapControlPlaneProxyExecutionError = gp.mapControlPlaneProxyExecutionError
 const sendApiError = gp.sendApiError;
 const setRequestIdHeaders = gp.setRequestIdHeaders;
 const applyResponseHeaders = gp.applyResponseHeaders;
-const writeBufferedUpstreamResponse = gp.writeBufferedUpstreamResponse;
+const writeBufferedUpstreamResponseWithMetrics = gp.writeBufferedUpstreamResponseWithMetrics;
 
 pub const StreamingRequestBody = gp.StreamingRequestBody;
 
@@ -97,10 +97,12 @@ pub const DataPlaneProxyResponse = union(enum) {
         security: *const http.security_headers.SecurityHeaders,
         alt_svc: ?[]const u8,
         sticky_set_cookie: ?[]const u8,
+        metrics: *http.metrics.Metrics,
+        metrics_mutex: *compat.Mutex,
     ) !void {
         switch (self.*) {
             .bounded_buffered => |*response| {
-                try writeBufferedUpstreamResponse(writer, response, keep_alive, correlation_id, security, alt_svc, sticky_set_cookie);
+                try writeBufferedUpstreamResponseWithMetrics(writer, response, keep_alive, correlation_id, security, alt_svc, sticky_set_cookie, metrics, metrics_mutex);
             },
         }
     }
@@ -735,7 +737,7 @@ pub fn handleLocationProxyPass(
         }
     }
     ctx.setUpstreamResult(resolved.upstream_host, upstream_response.statusCode(), upstream_response.bodyLen());
-    try upstream_response.writeHttp1(writer, keep_alive, correlation_id, &state.security_headers, state.http3_alt_svc, sticky_set_cookie);
+    try upstream_response.writeHttp1(writer, keep_alive, correlation_id, &state.security_headers, state.http3_alt_svc, sticky_set_cookie, &state.metrics, &state.metrics_mutex);
     const status_code = upstream_response.statusCode();
     state.metricsRecord(status_code);
     return status_code;

--- a/src/gateway_static_runtime.zig
+++ b/src/gateway_static_runtime.zig
@@ -111,9 +111,9 @@ pub fn handleStaticLocation(
                     .setHeader(http.correlation.HEADER_NAME, correlation_id);
                 gp.applyResponseHeaders(state, &response);
                 if (request.method == .HEAD) {
-                    try response.writeHead(writer);
+                    try response.writeHeadWithMetrics(writer, &state.metrics, &state.metrics_mutex);
                 } else {
-                    try response.write(writer);
+                    try response.writeWithMetrics(writer, &state.metrics, &state.metrics_mutex);
                 }
                 state.metricsRecord(302);
                 return 302;
@@ -139,9 +139,9 @@ pub fn handleStaticLocation(
                         .setHeader(http.correlation.HEADER_NAME, correlation_id);
                     gp.applyResponseHeaders(state, &response);
                     if (request.method == .HEAD) {
-                        try response.writeHead(writer);
+                        try response.writeHeadWithMetrics(writer, &state.metrics, &state.metrics_mutex);
                     } else {
-                        try response.write(writer);
+                        try response.writeWithMetrics(writer, &state.metrics, &state.metrics_mutex);
                     }
                     state.metricsRecord(302);
                     return 302;
@@ -251,7 +251,7 @@ pub fn writeStaticServedResponse(
     }
 
     gp.applyResponseHeaders(state, &response);
-    try response.writeHead(writer);
+    try response.writeHeadWithMetrics(writer, &state.metrics, &state.metrics_mutex);
 
     if (head_only) {
         if (served.file_path) |file_path| {

--- a/src/gateway_static_runtime.zig
+++ b/src/gateway_static_runtime.zig
@@ -251,6 +251,18 @@ pub fn writeStaticServedResponse(
     }
 
     gp.applyResponseHeaders(state, &response);
+    if (!head_only and served.file_path == null) {
+        try response.writeWithMetrics(writer, &state.metrics, &state.metrics_mutex);
+        if (compress_result.compressed) {
+            state.logger.debug(correlation_id, "served static file via buffered path (compressed: {s})", .{
+                if (compress_result.encoding) |enc| enc.headerValue() else "?",
+            });
+        } else {
+            state.logger.debug(correlation_id, "served static file via buffered path", .{});
+        }
+        return @intFromEnum(served.status_code);
+    }
+
     try response.writeHeadWithMetrics(writer, &state.metrics, &state.metrics_mutex);
 
     if (head_only) {
@@ -274,15 +286,6 @@ pub fn writeStaticServedResponse(
             state.logger.debug(correlation_id, "served static file via file-backed path: {s}", .{file_path});
         } else {
             return error.InvalidStaticTransferState;
-        }
-    } else if (out_body) |body| {
-        try writer.writeAll(body);
-        if (compress_result.compressed) {
-            state.logger.debug(correlation_id, "served static file via buffered path (compressed: {s})", .{
-                if (compress_result.encoding) |enc| enc.headerValue() else "?",
-            });
-        } else {
-            state.logger.debug(correlation_id, "served static file via buffered path", .{});
         }
     }
 

--- a/src/http/metrics.zig
+++ b/src/http/metrics.zig
@@ -28,6 +28,7 @@ pub const TicketResult = enum { success, rejected, failed };
 pub const TicketKeyReloadOutcome = enum { initial_load_success, initial_load_failure, reload_accepted, reload_rejected };
 
 pub const HttpProtocol = enum { h1, h2, h3 };
+pub const ResponseWriteMode = enum { writev, single_write, tls_buffered, fallback };
 
 /// Why a reverse-proxy request took the bounded buffered path instead of
 /// streaming (#139). This lives here, next to the counters, so it is the single
@@ -102,6 +103,7 @@ const resumption_mode_count = 3;
 const ticket_result_count = 3;
 const ticket_key_reload_outcome_count = 4;
 const http_protocol_count = 3;
+const response_write_mode_count = 4;
 const early_data_source_count = 3;
 const early_data_decision_count = 4;
 const early_data_upstream_425_action_count = 2;
@@ -253,6 +255,9 @@ pub const Metrics = struct {
     tls_ticket_key_reload_total: [ticket_key_reload_outcome_count]u64,
     /// HTTP early-data replay-exposed requests by protocol and source.
     http_early_data_requests_total: [http_protocol_count][early_data_source_count]u64,
+    response_write_mode_total: [response_write_mode_count]u64,
+    response_writev_iovecs_total: u64,
+    response_write_errors_total: [response_write_mode_count]u64,
     /// HTTP early-data decisions by protocol.
     http_early_data_decisions_total: [http_protocol_count][early_data_decision_count]u64,
     /// Upstream 425 handling actions (bounded RFC 8470 semantics only).
@@ -381,6 +386,9 @@ pub const Metrics = struct {
             .tls_ticket_resolve_total = .{.{0} ** ticket_result_count} ** resumption_mode_count,
             .tls_ticket_key_reload_total = .{0} ** ticket_key_reload_outcome_count,
             .http_early_data_requests_total = .{.{0} ** early_data_source_count} ** http_protocol_count,
+            .response_write_mode_total = .{0} ** response_write_mode_count,
+            .response_writev_iovecs_total = 0,
+            .response_write_errors_total = .{0} ** response_write_mode_count,
             .http_early_data_decisions_total = .{.{0} ** early_data_decision_count} ** http_protocol_count,
             .http_early_data_upstream_425_total = .{0} ** early_data_upstream_425_action_count,
             .http_early_data_retry_total = .{0} ** early_data_retry_result_count,
@@ -473,6 +481,15 @@ pub const Metrics = struct {
 
     pub fn recordHttpEarlyDataRequest(self: *Metrics, protocol: HttpProtocol, source: EarlyDataSource) void {
         self.http_early_data_requests_total[httpProtocolIndex(protocol)][earlyDataSourceIndex(source)] += 1;
+    }
+
+    pub fn recordResponseWriteMode(self: *Metrics, mode: ResponseWriteMode, iovecs: usize) void {
+        self.response_write_mode_total[responseWriteModeIndex(mode)] += 1;
+        if (mode == .writev) self.response_writev_iovecs_total += @intCast(iovecs);
+    }
+
+    pub fn recordResponseWriteError(self: *Metrics, mode: ResponseWriteMode) void {
+        self.response_write_errors_total[responseWriteModeIndex(mode)] += 1;
     }
 
     pub fn recordHttpEarlyDataDecision(self: *Metrics, protocol: HttpProtocol, decision: EarlyDataDecision) void {
@@ -986,6 +1003,7 @@ pub const Metrics = struct {
         });
 
         try self.appendTlsBufferPrometheus(&out);
+        try self.appendResponseWritePrometheus(&out);
         try self.appendResumptionPrometheus(&out);
         try self.appendHttpEarlyDataPrometheus(&out);
         try self.appendEarlyDataReplayPrometheus(&out);
@@ -1283,6 +1301,34 @@ pub const Metrics = struct {
             try out.print("tardigrade_tls_buffer_stalled_drives_total{{backend=\"{s}\"}} {d}\n", .{
                 tlsBackendLabel(backend),
                 self.tls_buffer_stalled_drives[tlsBackendIndex(backend)],
+            });
+        }
+    }
+
+    fn appendResponseWritePrometheus(self: *const Metrics, out: *std.array_list.Managed(u8)) !void {
+        try out.appendSlice(
+            \\# HELP tardigrade_response_write_mode_total HTTP/1 response write attempts by transport mode
+            \\# TYPE tardigrade_response_write_mode_total counter
+            \\
+        );
+        inline for (.{ ResponseWriteMode.writev, ResponseWriteMode.single_write, ResponseWriteMode.tls_buffered, ResponseWriteMode.fallback }) |mode| {
+            try out.print("tardigrade_response_write_mode_total{{mode=\"{s}\"}} {d}\n", .{
+                responseWriteModeLabel(mode),
+                self.response_write_mode_total[responseWriteModeIndex(mode)],
+            });
+        }
+        try out.print(
+            \\# HELP tardigrade_response_writev_iovecs_total Total iovecs submitted by HTTP/1 response writev attempts
+            \\# TYPE tardigrade_response_writev_iovecs_total counter
+            \\tardigrade_response_writev_iovecs_total {d}
+            \\# HELP tardigrade_response_write_errors_total HTTP/1 response write errors by transport mode
+            \\# TYPE tardigrade_response_write_errors_total counter
+            \\
+        , .{self.response_writev_iovecs_total});
+        inline for (.{ ResponseWriteMode.writev, ResponseWriteMode.single_write, ResponseWriteMode.tls_buffered, ResponseWriteMode.fallback }) |mode| {
+            try out.print("tardigrade_response_write_errors_total{{mode=\"{s}\"}} {d}\n", .{
+                responseWriteModeLabel(mode),
+                self.response_write_errors_total[responseWriteModeIndex(mode)],
             });
         }
     }
@@ -1707,6 +1753,15 @@ fn httpProtocolIndex(protocol: HttpProtocol) usize {
     };
 }
 
+fn responseWriteModeIndex(mode: ResponseWriteMode) usize {
+    return switch (mode) {
+        .writev => 0,
+        .single_write => 1,
+        .tls_buffered => 2,
+        .fallback => 3,
+    };
+}
+
 fn earlyDataSourceIndex(source: EarlyDataSource) usize {
     return switch (source) {
         .transport => 0,
@@ -1798,6 +1853,15 @@ fn httpProtocolLabel(protocol: HttpProtocol) []const u8 {
         .h1 => "h1",
         .h2 => "h2",
         .h3 => "h3",
+    };
+}
+
+fn responseWriteModeLabel(mode: ResponseWriteMode) []const u8 {
+    return switch (mode) {
+        .writev => "writev",
+        .single_write => "single_write",
+        .tls_buffered => "tls_buffered",
+        .fallback => "fallback",
     };
 }
 

--- a/src/http/response.zig
+++ b/src/http/response.zig
@@ -6,6 +6,7 @@ const Status = @import("status.zig").Status;
 const Headers = @import("headers.zig").Headers;
 const Version = @import("version.zig").Version;
 const correlation = @import("correlation_id.zig");
+const metrics_mod = @import("metrics.zig");
 
 /// Server name and version for Server header
 pub const SERVER_NAME = "tardigrade";
@@ -125,44 +126,20 @@ pub const Response = struct {
 
     /// Write the response to a writer
     pub fn write(self: *Response, writer: anytype) !void {
-        // Status line
-        try writer.print("{s} {d} {s}\r\n", .{
-            self.version.toString(),
-            self.status.code(),
-            self.status.phrase(),
-        });
+        _ = try self.writeMeasured(writer);
+    }
 
-        // Auto-generate Date header
-        try self.writeDate(writer);
-
-        // Server header
-        try writer.print("Server: {s}\r\n", .{SERVER_NAME});
-
-        // Content-Length
-        if (self.headers.get("content-length")) |content_length| {
-            try writer.print("Content-Length: {s}\r\n", .{content_length});
-        } else {
-            const body_len = if (self.body) |b| b.len else 0;
-            try writer.print("Content-Length: {d}\r\n", .{body_len});
-        }
-
-        try self.writeRequestIdHeaders(writer);
-
-        // User-defined headers
-        for (self.headers.iterator()) |header| {
-            if (std.ascii.eqlIgnoreCase(header.name, "content-length")) continue;
-            if (std.ascii.eqlIgnoreCase(header.name, correlation.HEADER_NAME) or
-                std.ascii.eqlIgnoreCase(header.name, correlation.REQUEST_HEADER_NAME)) continue;
-            try writer.print("{s}: {s}\r\n", .{ header.name, header.value });
-        }
-
-        // End of headers
-        try writer.writeAll("\r\n");
-
-        // Body
-        if (self.body) |b| {
-            try writer.writeAll(b);
-        }
+    pub fn writeWithMetrics(
+        self: *Response,
+        writer: anytype,
+        metrics: *metrics_mod.Metrics,
+        metrics_mutex: *compat.Mutex,
+    ) !void {
+        const result = self.writeMeasured(writer) catch |err| {
+            recordResponseWriteMetric(metrics, metrics_mutex, attemptedWriterMode(@TypeOf(writer), self.body == null or self.body.?.len == 0), 0, true);
+            return err;
+        };
+        recordResponseWriteMetric(metrics, metrics_mutex, result.mode, result.iovecs, false);
     }
 
     pub fn buildHeaderBytes(self: *Response, allocator: Allocator) ![]u8 {
@@ -196,38 +173,68 @@ pub const Response = struct {
 
     /// Write the response without body (for HEAD requests)
     pub fn writeHead(self: *Response, writer: anytype) !void {
-        // Status line
+        try self.writeHeaders(writer);
+    }
+
+    pub fn writeHeadWithMetrics(
+        self: *Response,
+        writer: anytype,
+        metrics: *metrics_mod.Metrics,
+        metrics_mutex: *compat.Mutex,
+    ) !void {
+        self.writeHead(writer) catch |err| {
+            recordResponseWriteMetric(metrics, metrics_mutex, .single_write, 0, true);
+            return err;
+        };
+        recordResponseWriteMetric(metrics, metrics_mutex, .single_write, 0, false);
+    }
+
+    const WriteMeasurement = struct {
+        mode: metrics_mod.ResponseWriteMode,
+        iovecs: usize = 0,
+    };
+
+    fn writeMeasured(self: *Response, writer: anytype) !WriteMeasurement {
+        const body_bytes = self.body orelse "";
+        const Writer = @TypeOf(writer);
+        if (comptime writerSupportsGatheredWrite(Writer)) {
+            const header_bytes = try self.buildHeaderBytes(self.allocator);
+            defer self.allocator.free(header_bytes);
+            if (body_bytes.len == 0) {
+                try writer.writeAll(header_bytes);
+                return .{ .mode = .single_write };
+            }
+            const fragments = [_][]const u8{ header_bytes, body_bytes };
+            try writer.writeGatheredAll(&fragments);
+            return .{ .mode = .writev, .iovecs = fragments.len };
+        }
+
+        try self.writeHeaders(writer);
+        if (body_bytes.len > 0) try writer.writeAll(body_bytes);
+        return .{ .mode = classifyWriterMode(Writer, body_bytes.len == 0) };
+    }
+
+    fn writeHeaders(self: *Response, writer: anytype) !void {
         try writer.print("{s} {d} {s}\r\n", .{
             self.version.toString(),
             self.status.code(),
             self.status.phrase(),
         });
-
-        // Auto-generate Date header
         try self.writeDate(writer);
-
-        // Server header
         try writer.print("Server: {s}\r\n", .{SERVER_NAME});
-
-        // Content-Length (still include even for HEAD)
         if (self.headers.get("content-length")) |content_length| {
             try writer.print("Content-Length: {s}\r\n", .{content_length});
         } else {
             const body_len = if (self.body) |b| b.len else 0;
             try writer.print("Content-Length: {d}\r\n", .{body_len});
         }
-
         try self.writeRequestIdHeaders(writer);
-
-        // User-defined headers
         for (self.headers.iterator()) |header| {
             if (std.ascii.eqlIgnoreCase(header.name, "content-length")) continue;
             if (std.ascii.eqlIgnoreCase(header.name, correlation.HEADER_NAME) or
                 std.ascii.eqlIgnoreCase(header.name, correlation.REQUEST_HEADER_NAME)) continue;
             try writer.print("{s}: {s}\r\n", .{ header.name, header.value });
         }
-
-        // End of headers
         try writer.writeAll("\r\n");
     }
 
@@ -477,6 +484,47 @@ pub const Response = struct {
     }
 };
 
+fn classifyWriterMode(comptime Writer: type, header_only: bool) metrics_mod.ResponseWriteMode {
+    if (header_only) return .single_write;
+    const name = @typeName(Writer);
+    if (std.mem.indexOf(u8, name, "tls_termination.TlsConnection.Writer") != null or
+        std.mem.indexOf(u8, name, "encrypted_stream_connection.EncryptedStreamHttpConnection.Writer") != null)
+    {
+        return .tls_buffered;
+    }
+    return .fallback;
+}
+
+fn attemptedWriterMode(comptime Writer: type, header_only: bool) metrics_mod.ResponseWriteMode {
+    if (header_only) return .single_write;
+    if (comptime writerSupportsGatheredWrite(Writer)) return .writev;
+    return classifyWriterMode(Writer, false);
+}
+
+fn writerSupportsGatheredWrite(comptime Writer: type) bool {
+    return switch (@typeInfo(Writer)) {
+        .pointer => |ptr| @hasDecl(ptr.child, "writeGatheredAll"),
+        .@"struct", .@"enum", .@"union", .@"opaque" => @hasDecl(Writer, "writeGatheredAll"),
+        else => false,
+    };
+}
+
+fn recordResponseWriteMetric(
+    metrics: *metrics_mod.Metrics,
+    metrics_mutex: *compat.Mutex,
+    mode: metrics_mod.ResponseWriteMode,
+    iovecs: usize,
+    failed: bool,
+) void {
+    metrics_mutex.lock();
+    defer metrics_mutex.unlock();
+    if (failed) {
+        metrics.recordResponseWriteError(mode);
+    } else {
+        metrics.recordResponseWriteMode(mode, iovecs);
+    }
+}
+
 pub const ResponseWriteOutcome = enum {
     done,
     wait_write,
@@ -563,6 +611,34 @@ const TestPartialWriter = struct {
         const n = @min(self.max_chunk, bytes.len);
         try self.output.appendSlice(self.allocator, bytes[0..n]);
         return n;
+    }
+};
+
+const TestVectoredWriter = struct {
+    allocator: Allocator,
+    output: std.ArrayList(u8) = .empty,
+    writev_calls: usize = 0,
+    writev_iovecs: usize = 0,
+    write_all_calls: usize = 0,
+
+    fn init(allocator: Allocator) TestVectoredWriter {
+        return .{ .allocator = allocator };
+    }
+
+    fn deinit(self: *TestVectoredWriter) void {
+        self.output.deinit(self.allocator);
+        self.* = undefined;
+    }
+
+    pub fn writeAll(self: *TestVectoredWriter, bytes: []const u8) !void {
+        self.write_all_calls += 1;
+        try self.output.appendSlice(self.allocator, bytes);
+    }
+
+    pub fn writeGatheredAll(self: *TestVectoredWriter, fragments: []const []const u8) !void {
+        self.writev_calls += 1;
+        self.writev_iovecs += fragments.len;
+        for (fragments) |fragment| try self.output.appendSlice(self.allocator, fragment);
     }
 };
 
@@ -765,6 +841,68 @@ test "response write is transport-agnostic: in-memory buffer" {
     try testing.expect(std.mem.endsWith(u8, out, "ok"));
 }
 
+test "response write uses vectored writer for small body" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var response = Response.init(allocator);
+    defer response.deinit();
+    _ = response.setStatus(.ok).setBody("ok").setContentType("text/plain");
+
+    var writer = TestVectoredWriter.init(allocator);
+    defer writer.deinit();
+
+    try response.write(&writer);
+
+    try testing.expectEqual(@as(usize, 1), writer.writev_calls);
+    try testing.expectEqual(@as(usize, 2), writer.writev_iovecs);
+    try testing.expectEqual(@as(usize, 0), writer.write_all_calls);
+    try testing.expect(std.mem.startsWith(u8, writer.output.items, "HTTP/1.1 200 OK\r\n"));
+    try testing.expect(std.mem.endsWith(u8, writer.output.items, "ok"));
+}
+
+test "response write uses vectored writer for large body" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    const body = try allocator.alloc(u8, 128 * 1024);
+    defer allocator.free(body);
+    @memset(body, 'x');
+
+    var response = Response.init(allocator);
+    defer response.deinit();
+    _ = response.setStatus(.ok).setBody(body).setContentType("application/octet-stream");
+
+    var writer = TestVectoredWriter.init(allocator);
+    defer writer.deinit();
+
+    try response.write(&writer);
+
+    try testing.expectEqual(@as(usize, 1), writer.writev_calls);
+    try testing.expectEqual(@as(usize, 2), writer.writev_iovecs);
+    const header_end = std.mem.indexOf(u8, writer.output.items, "\r\n\r\n") orelse return error.TestExpectedHeaders;
+    try testing.expectEqualSlices(u8, body, writer.output.items[header_end + 4 ..]);
+}
+
+test "response write empty body stays single write" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var response = Response.init(allocator);
+    defer response.deinit();
+    _ = response.setStatus(.no_content);
+
+    var writer = TestVectoredWriter.init(allocator);
+    defer writer.deinit();
+
+    try response.write(&writer);
+
+    try testing.expectEqual(@as(usize, 0), writer.writev_calls);
+    try testing.expectEqual(@as(usize, 1), writer.write_all_calls);
+    try testing.expect(std.mem.startsWith(u8, writer.output.items, "HTTP/1.1 204 No Content\r\n"));
+    try testing.expect(std.mem.endsWith(u8, writer.output.items, "\r\n\r\n"));
+}
+
 test "response writeHead emits only headers to in-memory buffer" {
     const testing = std.testing;
     const allocator = testing.allocator;
@@ -781,6 +919,24 @@ test "response writeHead emits only headers to in-memory buffer" {
     try testing.expect(std.mem.startsWith(u8, out, "HTTP/1.1 204 No Content\r\n"));
     // writeHead should not emit a body
     try testing.expect(std.mem.endsWith(u8, out, "\r\n"));
+}
+
+test "response writeWithMetrics records writev and error response modes" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var metrics = metrics_mod.Metrics.init();
+    var metrics_mutex = compat.Mutex{};
+
+    var response = Response.internalServerError(allocator);
+    defer response.deinit();
+
+    var writer = TestVectoredWriter.init(allocator);
+    defer writer.deinit();
+
+    try response.writeWithMetrics(&writer, &metrics, &metrics_mutex);
+    try testing.expectEqual(@as(u64, 1), metrics.response_write_mode_total[0]);
+    try testing.expectEqual(@as(u64, 2), metrics.response_writev_iovecs_total);
 }
 
 test "response write state resumes partial body writes after WouldBlock" {

--- a/src/http/response.zig
+++ b/src/http/response.zig
@@ -11,6 +11,7 @@ const metrics_mod = @import("metrics.zig");
 /// Server name and version for Server header
 pub const SERVER_NAME = "tardigrade";
 pub const SERVER_VERSION = build_options.version;
+const gathered_header_scratch_len = 8 * 1024;
 
 // Try to load a custom error page from `public/errors/<code>.html`.
 fn loadCustomErrorPage(allocator: Allocator, status: Status) ?[]const u8 {
@@ -173,7 +174,7 @@ pub const Response = struct {
 
     /// Write the response without body (for HEAD requests)
     pub fn writeHead(self: *Response, writer: anytype) !void {
-        try self.writeHeaders(writer);
+        _ = try self.writeHeadMeasured(writer);
     }
 
     pub fn writeHeadWithMetrics(
@@ -182,11 +183,11 @@ pub const Response = struct {
         metrics: *metrics_mod.Metrics,
         metrics_mutex: *compat.Mutex,
     ) !void {
-        self.writeHead(writer) catch |err| {
-            recordResponseWriteMetric(metrics, metrics_mutex, .single_write, 0, true);
+        const result = self.writeHeadMeasured(writer) catch |err| {
+            recordResponseWriteMetric(metrics, metrics_mutex, attemptedWriterMode(@TypeOf(writer), true), 0, true);
             return err;
         };
-        recordResponseWriteMetric(metrics, metrics_mutex, .single_write, 0, false);
+        recordResponseWriteMetric(metrics, metrics_mutex, result.mode, result.iovecs, false);
     }
 
     const WriteMeasurement = struct {
@@ -198,20 +199,52 @@ pub const Response = struct {
         const body_bytes = self.body orelse "";
         const Writer = @TypeOf(writer);
         if (comptime writerSupportsGatheredWrite(Writer)) {
-            const header_bytes = try self.buildHeaderBytes(self.allocator);
-            defer self.allocator.free(header_bytes);
+            var scratch: [gathered_header_scratch_len]u8 = undefined;
+            const header = try self.buildHeaderBytesBounded(&scratch);
+            defer header.deinit(self.allocator);
             if (body_bytes.len == 0) {
-                try writer.writeAll(header_bytes);
+                try writer.writeAll(header.bytes);
                 return .{ .mode = .single_write };
             }
-            const fragments = [_][]const u8{ header_bytes, body_bytes };
-            try writer.writeGatheredAll(&fragments);
-            return .{ .mode = .writev, .iovecs = fragments.len };
+            const fragments = [_][]const u8{ header.bytes, body_bytes };
+            const iovecs = try writer.writeGatheredAll(&fragments);
+            return .{ .mode = .writev, .iovecs = iovecs };
         }
 
         try self.writeHeaders(writer);
         if (body_bytes.len > 0) try writer.writeAll(body_bytes);
         return .{ .mode = classifyWriterMode(Writer, body_bytes.len == 0) };
+    }
+
+    fn writeHeadMeasured(self: *Response, writer: anytype) !WriteMeasurement {
+        const Writer = @TypeOf(writer);
+        if (comptime writerSupportsGatheredWrite(Writer)) {
+            var scratch: [gathered_header_scratch_len]u8 = undefined;
+            const header = try self.buildHeaderBytesBounded(&scratch);
+            defer header.deinit(self.allocator);
+            try writer.writeAll(header.bytes);
+            return .{ .mode = .single_write };
+        }
+
+        try self.writeHeaders(writer);
+        return .{ .mode = classifyWriterMode(Writer, true) };
+    }
+
+    const HeaderBytes = struct {
+        bytes: []u8,
+        owned: bool = false,
+
+        fn deinit(self: HeaderBytes, allocator: Allocator) void {
+            if (self.owned) allocator.free(self.bytes);
+        }
+    };
+
+    fn buildHeaderBytesBounded(self: *Response, scratch: []u8) !HeaderBytes {
+        var stream = compat.fixedBufferStream(scratch);
+        self.writeHeaders(stream.writer()) catch {
+            return .{ .bytes = try self.buildHeaderBytes(self.allocator), .owned = true };
+        };
+        return .{ .bytes = stream.getWritten() };
     }
 
     fn writeHeaders(self: *Response, writer: anytype) !void {
@@ -485,7 +518,7 @@ pub const Response = struct {
 };
 
 fn classifyWriterMode(comptime Writer: type, header_only: bool) metrics_mod.ResponseWriteMode {
-    if (header_only) return .single_write;
+    _ = header_only;
     const name = @typeName(Writer);
     if (std.mem.indexOf(u8, name, "tls_termination.TlsConnection.Writer") != null or
         std.mem.indexOf(u8, name, "encrypted_stream_connection.EncryptedStreamHttpConnection.Writer") != null)
@@ -496,8 +529,7 @@ fn classifyWriterMode(comptime Writer: type, header_only: bool) metrics_mod.Resp
 }
 
 fn attemptedWriterMode(comptime Writer: type, header_only: bool) metrics_mod.ResponseWriteMode {
-    if (header_only) return .single_write;
-    if (comptime writerSupportsGatheredWrite(Writer)) return .writev;
+    if (comptime writerSupportsGatheredWrite(Writer)) return if (header_only) .single_write else .writev;
     return classifyWriterMode(Writer, false);
 }
 
@@ -635,10 +667,11 @@ const TestVectoredWriter = struct {
         try self.output.appendSlice(self.allocator, bytes);
     }
 
-    pub fn writeGatheredAll(self: *TestVectoredWriter, fragments: []const []const u8) !void {
+    pub fn writeGatheredAll(self: *TestVectoredWriter, fragments: []const []const u8) !usize {
         self.writev_calls += 1;
         self.writev_iovecs += fragments.len;
         for (fragments) |fragment| try self.output.appendSlice(self.allocator, fragment);
+        return fragments.len;
     }
 };
 
@@ -919,6 +952,26 @@ test "response writeHead emits only headers to in-memory buffer" {
     try testing.expect(std.mem.startsWith(u8, out, "HTTP/1.1 204 No Content\r\n"));
     // writeHead should not emit a body
     try testing.expect(std.mem.endsWith(u8, out, "\r\n"));
+}
+
+test "response writeHead uses one write on gathered writer" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var response = Response.init(allocator);
+    defer response.deinit();
+    _ = response.setStatus(.ok).setBody("not sent").setContentType("text/plain");
+
+    var writer = TestVectoredWriter.init(allocator);
+    defer writer.deinit();
+
+    try response.writeHead(&writer);
+
+    try testing.expectEqual(@as(usize, 0), writer.writev_calls);
+    try testing.expectEqual(@as(usize, 1), writer.write_all_calls);
+    try testing.expect(std.mem.startsWith(u8, writer.output.items, "HTTP/1.1 200 OK\r\n"));
+    try testing.expect(std.mem.find(u8, writer.output.items, "Content-Length: 8\r\n") != null);
+    try testing.expect(std.mem.find(u8, writer.output.items, "not sent") == null);
 }
 
 test "response writeWithMetrics records writev and error response modes" {

--- a/src/zig_compat.zig
+++ b/src/zig_compat.zig
@@ -135,6 +135,14 @@ pub const NetStream = struct {
             try self.stream.writeAll(data);
         }
 
+        pub fn writeGatheredAll(self: Writer, data: []const []const u8) WriteError!void {
+            if (self.stream.inner != null) {
+                for (data) |fragment| try self.writeAll(fragment);
+                return;
+            }
+            try writevAllFd(self.stream.handle, data);
+        }
+
         pub fn writeByte(self: Writer, byte: u8) WriteError!void {
             try self.writeAll(&[_]u8{byte});
         }
@@ -183,6 +191,64 @@ pub const NetStream = struct {
         return .{ .stream = self };
     }
 };
+
+fn writevAllFd(fd: std.posix.fd_t, data: []const []const u8) !void {
+    var index: usize = 0;
+    var offset: usize = 0;
+    while (index < data.len) {
+        while (index < data.len and offset == data[index].len) {
+            index += 1;
+            offset = 0;
+        }
+        if (index >= data.len) return;
+
+        var iovecs: [16]std.posix.iovec_const = undefined;
+        var iov_len: usize = 0;
+        var i = index;
+        var first_offset = offset;
+        while (i < data.len and iov_len < iovecs.len) : (i += 1) {
+            if (data[i].len == first_offset) {
+                first_offset = 0;
+                continue;
+            }
+            iovecs[iov_len] = .{
+                .base = data[i].ptr + first_offset,
+                .len = data[i].len - first_offset,
+            };
+            iov_len += 1;
+            first_offset = 0;
+        }
+
+        const written = try writevFd(fd, iovecs[0..iov_len]);
+        if (written == 0) return error.WriteFailed;
+
+        var remaining = written;
+        while (remaining > 0) {
+            const available = data[index].len - offset;
+            if (remaining < available) {
+                offset += remaining;
+                remaining = 0;
+            } else {
+                remaining -= available;
+                index += 1;
+                offset = 0;
+            }
+        }
+    }
+}
+
+fn writevFd(fd: std.posix.fd_t, iovecs: []const std.posix.iovec_const) !usize {
+    while (true) {
+        const rc = std.c.writev(fd, iovecs.ptr, @intCast(iovecs.len));
+        switch (std.c.errno(rc)) {
+            .SUCCESS => return @intCast(rc),
+            .INTR => continue,
+            .AGAIN => return error.WouldBlock,
+            .PIPE => return error.BrokenPipe,
+            else => return error.WriteFailed,
+        }
+    }
+}
 
 pub fn netStreamFromFd(fd: std.posix.fd_t) NetStream {
     return .{

--- a/src/zig_compat.zig
+++ b/src/zig_compat.zig
@@ -135,12 +135,12 @@ pub const NetStream = struct {
             try self.stream.writeAll(data);
         }
 
-        pub fn writeGatheredAll(self: Writer, data: []const []const u8) WriteError!void {
+        pub fn writeGatheredAll(self: Writer, data: []const []const u8) WriteError!usize {
             if (self.stream.inner != null) {
                 for (data) |fragment| try self.writeAll(fragment);
-                return;
+                return data.len;
             }
-            try writevAllFd(self.stream.handle, data);
+            return writevAllFd(self.stream.handle, data);
         }
 
         pub fn writeByte(self: Writer, byte: u8) WriteError!void {
@@ -192,15 +192,30 @@ pub const NetStream = struct {
     }
 };
 
-fn writevAllFd(fd: std.posix.fd_t, data: []const []const u8) !void {
+fn writevAllFd(fd: std.posix.fd_t, data: []const []const u8) !usize {
+    const Syscall = struct {
+        fn call(ctx: std.posix.fd_t, iovecs: []const std.posix.iovec_const) !usize {
+            return writevFd(ctx, iovecs);
+        }
+    };
+    return writevAllWith(std.posix.fd_t, fd, data, Syscall.call);
+}
+
+fn writevAllWith(
+    comptime Context: type,
+    context: Context,
+    data: []const []const u8,
+    writev_fn: *const fn (Context, []const std.posix.iovec_const) anyerror!usize,
+) !usize {
     var index: usize = 0;
     var offset: usize = 0;
+    var submitted_iovecs: usize = 0;
     while (index < data.len) {
         while (index < data.len and offset == data[index].len) {
             index += 1;
             offset = 0;
         }
-        if (index >= data.len) return;
+        if (index >= data.len) return submitted_iovecs;
 
         var iovecs: [16]std.posix.iovec_const = undefined;
         var iov_len: usize = 0;
@@ -219,7 +234,11 @@ fn writevAllFd(fd: std.posix.fd_t, data: []const []const u8) !void {
             first_offset = 0;
         }
 
-        const written = try writevFd(fd, iovecs[0..iov_len]);
+        submitted_iovecs += iov_len;
+        const written = writev_fn(context, iovecs[0..iov_len]) catch |err| switch (err) {
+            error.Interrupted => continue,
+            else => return err,
+        };
         if (written == 0) return error.WriteFailed;
 
         var remaining = written;
@@ -235,6 +254,7 @@ fn writevAllFd(fd: std.posix.fd_t, data: []const []const u8) !void {
             }
         }
     }
+    return submitted_iovecs;
 }
 
 fn writevFd(fd: std.posix.fd_t, iovecs: []const std.posix.iovec_const) !usize {
@@ -242,7 +262,7 @@ fn writevFd(fd: std.posix.fd_t, iovecs: []const std.posix.iovec_const) !usize {
         const rc = std.c.writev(fd, iovecs.ptr, @intCast(iovecs.len));
         switch (std.c.errno(rc)) {
             .SUCCESS => return @intCast(rc),
-            .INTR => continue,
+            .INTR => return error.Interrupted,
             .AGAIN => return error.WouldBlock,
             .PIPE => return error.BrokenPipe,
             else => return error.WriteFailed,
@@ -919,6 +939,110 @@ test "fixedBufferStream write and read back" {
     var fbs = fixedBufferStream(&buf);
     try fbs.writer().writeAll("hello");
     try std.testing.expectEqualStrings("hello", fbs.getWritten());
+}
+
+const ScriptedWritev = struct {
+    const Step = union(enum) {
+        write: usize,
+        interrupt,
+        zero,
+        fail,
+    };
+
+    allocator: std.mem.Allocator,
+    steps: []const Step,
+    step_index: usize = 0,
+    output: std.ArrayList(u8) = .empty,
+    submitted_iovecs: usize = 0,
+
+    fn init(allocator: std.mem.Allocator, steps: []const Step) ScriptedWritev {
+        return .{ .allocator = allocator, .steps = steps };
+    }
+
+    fn deinit(self: *ScriptedWritev) void {
+        self.output.deinit(self.allocator);
+        self.* = undefined;
+    }
+
+    fn call(self: *ScriptedWritev, iovecs: []const std.posix.iovec_const) !usize {
+        self.submitted_iovecs += iovecs.len;
+        if (self.step_index >= self.steps.len) return error.TestUnexpectedWritevCall;
+        const step = self.steps[self.step_index];
+        self.step_index += 1;
+        switch (step) {
+            .interrupt => return error.Interrupted,
+            .zero => return 0,
+            .fail => return error.WouldBlock,
+            .write => |n| {
+                var remaining = n;
+                for (iovecs) |iov| {
+                    if (remaining == 0) break;
+                    const take = @min(remaining, iov.len);
+                    try self.output.appendSlice(self.allocator, iov.base[0..take]);
+                    remaining -= take;
+                }
+                return n;
+            },
+        }
+    }
+};
+
+test "writevAllWith resumes after short write inside first iovec" {
+    const parts = [_][]const u8{ "header", "body" };
+    const steps = [_]ScriptedWritev.Step{ .{ .write = 3 }, .{ .write = 7 } };
+    var scripted = ScriptedWritev.init(std.testing.allocator, &steps);
+    defer scripted.deinit();
+
+    const submitted = try writevAllWith(*ScriptedWritev, &scripted, &parts, ScriptedWritev.call);
+
+    try std.testing.expectEqualStrings("headerbody", scripted.output.items);
+    try std.testing.expectEqual(@as(usize, 4), submitted);
+    try std.testing.expectEqual(submitted, scripted.submitted_iovecs);
+}
+
+test "writevAllWith resumes exactly at iovec boundary" {
+    const parts = [_][]const u8{ "header", "body" };
+    const steps = [_]ScriptedWritev.Step{ .{ .write = 6 }, .{ .write = 4 } };
+    var scripted = ScriptedWritev.init(std.testing.allocator, &steps);
+    defer scripted.deinit();
+
+    const submitted = try writevAllWith(*ScriptedWritev, &scripted, &parts, ScriptedWritev.call);
+
+    try std.testing.expectEqualStrings("headerbody", scripted.output.items);
+    try std.testing.expectEqual(@as(usize, 3), submitted);
+    try std.testing.expectEqual(submitted, scripted.submitted_iovecs);
+}
+
+test "writevAllWith resumes after short write inside body iovec" {
+    const parts = [_][]const u8{ "header", "body" };
+    const steps = [_]ScriptedWritev.Step{ .{ .write = 8 }, .{ .write = 2 } };
+    var scripted = ScriptedWritev.init(std.testing.allocator, &steps);
+    defer scripted.deinit();
+
+    const submitted = try writevAllWith(*ScriptedWritev, &scripted, &parts, ScriptedWritev.call);
+
+    try std.testing.expectEqualStrings("headerbody", scripted.output.items);
+    try std.testing.expectEqual(@as(usize, 4), submitted);
+    try std.testing.expectEqual(submitted, scripted.submitted_iovecs);
+}
+
+test "writevAllWith retries interrupt and reports zero and error" {
+    const parts = [_][]const u8{ "he", "llo" };
+    const retry_steps = [_]ScriptedWritev.Step{ .interrupt, .{ .write = 5 } };
+    var retry = ScriptedWritev.init(std.testing.allocator, &retry_steps);
+    defer retry.deinit();
+    try std.testing.expectEqual(@as(usize, 4), try writevAllWith(*ScriptedWritev, &retry, &parts, ScriptedWritev.call));
+    try std.testing.expectEqualStrings("hello", retry.output.items);
+
+    const zero_steps = [_]ScriptedWritev.Step{.zero};
+    var zero = ScriptedWritev.init(std.testing.allocator, &zero_steps);
+    defer zero.deinit();
+    try std.testing.expectError(error.WriteFailed, writevAllWith(*ScriptedWritev, &zero, &parts, ScriptedWritev.call));
+
+    const fail_steps = [_]ScriptedWritev.Step{.fail};
+    var fail = ScriptedWritev.init(std.testing.allocator, &fail_steps);
+    defer fail.deinit();
+    try std.testing.expectError(error.WouldBlock, writevAllWith(*ScriptedWritev, &fail, &parts, ScriptedWritev.call));
 }
 
 test "trimRight removes trailing characters" {


### PR DESCRIPTION
## Summary
- add a gathered plaintext response write path for HTTP/1 responses via a raw-socket writev helper
- keep TLS and generic writers on buffered/fallback writes, with documented response-write metrics
- wire tracked response writes through gateway/static/proxy response paths and add response writer tests

Refs #144

## Validation
- zig build test --summary all --error-style verbose
- zig build -Doptimize=ReleaseFast --summary all --error-style verbose
- zig build bench-allocations --summary all --error-style verbose
- ./benchmarks/ci-smoke.sh --duration 5 --connections 10 --threads 2

## Benchmark smoke notes
Local loopback smoke on Apple M4, 5s duration, 10 connections, 2 threads:
- static-http1: 97,796.78 req/s, p99 13.063 ms, errors 0
- proxy-http1: 23,922.26 req/s, p99 9.532 ms, errors 0
- keepalive: 85,529.06 req/s, p99 2.618 ms, errors 0
- upstream connection reuse: 122036/122046 (99%)