### PR TITLE
perf(proxy): account and bound request-direction buffers, surface HTTP/1 stalls (#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,36 @@ All notable user-facing changes to Tardigrade are documented here.
   `tardigrade_proxy_buffer_aggregate_bytes_current{direction,scope="global"}`,
   read from the enforcing account. This is the series to compare with the
   configured limit: `tardigrade_buffered_bytes_current{scope="global"}` is a
-  roll-up across every proxy-owned buffer, while the limit currently governs
-  HTTP/2 streaming response queues only.
+  roll-up across every proxy-owned buffer, including the bounded buffered
+  compatibility path, which the limit does not govern.
+
+- **Client uploads are accounted and bounded the same way, and a slow origin is
+  now visible (#140)** — request-direction relay buffers on both HTTP/1 and
+  HTTP/2 now clear `TARDIGRADE_PROXY_BUFFER_GLOBAL_HARD_LIMIT_BYTES` (and, on
+  HTTP/2, the per-origin limit) before they are used, so concurrent uploads can
+  no longer multiply upload memory past the configured ceiling. An HTTP/2 upload
+  reserves its relay buffer once for the whole upload instead of reserving and
+  releasing per DATA frame, which was a flicker no concurrent stream could ever
+  have been bounded by. Reservations are released on every exit — completion,
+  client abort, cancellation, timeout, upstream failure — so the gauges return
+  to zero.
+
+  Capacity refusals during an upload are now distinguished by what ran out,
+  because the two mean different things to the client. This upload's in-flight
+  bytes exceeding `TARDIGRADE_PROXY_BUFFER_PER_STREAM_HARD_LIMIT_BYTES` is a
+  `413 payload_too_large`; the proxy being out of room for anybody is a
+  `503 proxy_buffer_saturated`. Both are raised before the response head is
+  committed, and neither is charged to upstream health. Previously an HTTP/1
+  upload refusal surfaced as a `502` blamed on a healthy origin.
+
+  `tardigrade_buffer_read_pauses_total{side="downstream"}` and its resume
+  counterpart, which previously only ever read zero, now record the HTTP/1
+  upload relay finding the origin's send buffer full. That path deliberately has
+  no queue whose depth could cross a watermark — it reads the client again only
+  once the upstream write goes through — so a blocked upstream write *is* its
+  backpressure. Only transitions are counted, and a relay torn down mid-stall
+  still reports its resume, so the difference between the two counters reads as
+  "how many uploads are stalled right now".
 
   A high watermark that could not be advertised as an HTTP/2 window is rejected
   at startup and reload. On reload, aggregate hard limits apply immediately,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,9 +65,18 @@ All notable user-facing changes to Tardigrade are documented here.
   no longer multiply upload memory past the configured ceiling. An HTTP/2 upload
   reserves its relay buffer once for the whole upload instead of reserving and
   releasing per DATA frame, which was a flicker no concurrent stream could ever
-  have been bounded by. Reservations are released on every exit — completion,
-  client abort, cancellation, timeout, upstream failure — so the gauges return
-  to zero.
+  have been bounded by. Bytes still held from the request head are accounted
+  too: a `Content-Length` upload reserves the body bytes it will forward, and a
+  chunked upload reserves the whole raw remainder the decoder borrows — framing
+  octets included — releasing it as the decoder consumes it. Reservations are
+  released on every exit — completion, client abort, cancellation, timeout,
+  malformed chunk framing, upstream failure — so the gauges return to zero.
+
+  The reservation is taken **before anything is sent upstream**: before the
+  HTTP/1 request head is written and before HTTP/2 `HEADERS` go out. Reserving
+  inside the relay meant a local refusal could only be raised once the origin
+  had already received a real, possibly side-effecting request whose body then
+  never arrived.
 
   Capacity refusals during an upload are now distinguished by what ran out,
   because the two mean different things to the client. This upload's in-flight
@@ -82,9 +91,19 @@ All notable user-facing changes to Tardigrade are documented here.
   upload relay finding the origin's send buffer full. That path deliberately has
   no queue whose depth could cross a watermark — it reads the client again only
   once the upstream write goes through — so a blocked upstream write *is* its
-  backpressure. Only transitions are counted, and a relay torn down mid-stall
-  still reports its resume, so the difference between the two counters reads as
-  "how many uploads are stalled right now".
+  backpressure. Only a genuinely full send buffer counts: `poll` also reports a
+  descriptor ready for `POLLERR`/`POLLHUP`/`POLLNVAL`, and treating that as a
+  stall would make a dead origin look like a slow one. Only transitions are
+  counted, and a relay torn down mid-stall still reports its resume, so the
+  difference between the two counters reads as "how many uploads are stalled
+  right now".
+
+  `tardigrade_upstream_h2_pool_buffered_bytes` and
+  `tardigrade_upstream_h2_pool_buffer_limit_exceeded_total` now carry a
+  `direction` label. Uploads consume and refuse the same per-origin account as
+  response queues, so reporting only responses let these read zero while the
+  per-origin limit was actively bounding a request. Cardinality stays bounded at
+  two fixed directions per configured origin.
 
   A high watermark that could not be advertised as an HTTP/2 window is rejected
   at startup and reload. On reload, aggregate hard limits apply immediately,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,10 @@ All notable user-facing changes to Tardigrade are documented here.
   chunked upload reserves the whole raw remainder the decoder borrows — framing
   octets included — releasing it as the decoder consumes it. Reservations are
   released on every exit — completion, client abort, cancellation, timeout,
-  malformed chunk framing, upstream failure — so the gauges return to zero.
+  malformed chunk framing, upstream failure — so the gauges return to zero, and
+  on HTTP/2 the request-direction claim ends at the upload/response boundary
+  rather than lasting the whole exchange, so a slow response cannot occupy
+  upload capacity that nothing is uploading into.
 
   The reservation is taken **before anything is sent upstream**: before the
   HTTP/1 request head is written and before HTTP/2 `HEADERS` go out. Reserving

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -83,10 +83,14 @@ logs are written through `src/http/logger.zig`.
   difference between pauses and resumes reads as "how many relays are stalled
   right now".
 - per-origin HTTP/2 buffer accounting:
-  `tardigrade_upstream_h2_pool_buffered_bytes{upstream}` and
-  `tardigrade_upstream_h2_pool_buffer_limit_exceeded_total{upstream}`. Label
-  cardinality is bounded by the number of distinct configured origins, matching
-  the other `tardigrade_upstream_h2_pool_*` series.
+  `tardigrade_upstream_h2_pool_buffered_bytes{upstream,direction}` and
+  `tardigrade_upstream_h2_pool_buffer_limit_exceeded_total{upstream,direction}`.
+  Response queues and request-direction upload relay buffers are enforced
+  against the *same* per-origin account, so both directions are reported: a
+  request-only pressure would otherwise read as zero while the limit was
+  actively bounding it. Label cardinality stays bounded — two fixed directions
+  per distinct configured origin — and `direction` takes the same values as the
+  process-wide buffer family.
 - configured proxy buffer limits:
   `tardigrade_buffer_config_limit_bytes{direction,scope,limit}` for the
   per-stream low/high/hard watermarks plus per-origin/global hard-limit

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -52,19 +52,23 @@ logs are written through `src/http/logger.zig`.
   `tardigrade_buffer_limit_exceeded_total{direction,scope}`. Labels are fixed
   to protocol-independent directions, scopes, and sides; they never include
   URLs, request IDs, or stream IDs. Current byte gauges cover bounded buffered
-  responses, HTTP/1 streaming relay buffers, and HTTP/2 streaming response
-  queues. `scope="stream"` reports logical queue occupancy; `scope="global"`
+  responses, HTTP/1 streaming relay buffers in both directions, HTTP/2 streaming
+  response queues, and request-direction upload relay buffers.
+  `scope="stream"` reports logical queue occupancy; `scope="global"`
   reports retained allocation, and the two differ while a queue is partially
   drained but still owns its buffer. The `scope="global"` series is a roll-up
   across *all* proxy paths and is **not** the quantity the configured global
   hard limit is checked against — see the next entry.
 - the aggregate bytes the global hard limit is enforced against:
   `tardigrade_proxy_buffer_aggregate_bytes_current{direction,scope="global"}`,
-  read directly from the account that performs the enforcement. Today that
-  covers HTTP/2 streaming response queues only, so this is the series to compare
-  with `tardigrade_buffer_config_limit_bytes{scope="global",limit="hard"}`;
-  comparing the broader `tardigrade_buffered_bytes_current{scope="global"}`
-  roll-up with that limit overstates pressure under mixed traffic.
+  read directly from the account that performs the enforcement. That covers
+  HTTP/2 stream queues, HTTP/1 relay buffers in both directions, and
+  request-direction upload buffers on both protocols, so this is the series to
+  compare with
+  `tardigrade_buffer_config_limit_bytes{scope="global",limit="hard"}`; comparing
+  the broader `tardigrade_buffered_bytes_current{scope="global"}` roll-up with
+  that limit overstates pressure under mixed traffic, because the roll-up also
+  includes the bounded buffered compatibility path, which has its own cap.
   `tardigrade_buffer_limit_exceeded_total` carries `scope="origin"` and
   `scope="global"` alongside `scope="stream"`: an aggregate refusal means the
   upstream origin (or the process) had no room for bytes the stream itself could
@@ -72,8 +76,12 @@ logs are written through `src/http/logger.zig`.
   resume counterpart record HTTP/2 streaming response queues crossing their high
   and low watermarks — a pause means stream credit is being withheld from the
   origin, a resume means the coalesced `WINDOW_UPDATE` went out. The
-  `side="downstream"` series remain reserved at zero until the HTTP/1 relay
-  gains pause/resume transition sites.
+  `side="downstream"` series record the HTTP/1 upload relay finding the origin's
+  send buffer full: that path has no queue to cross a watermark, so a blocked
+  upstream write *is* its backpressure, and it reads the client again only once
+  the write goes through. Both sides count transitions, not writes, so the
+  difference between pauses and resumes reads as "how many relays are stalled
+  right now".
 - per-origin HTTP/2 buffer accounting:
   `tardigrade_upstream_h2_pool_buffered_bytes{upstream}` and
   `tardigrade_upstream_h2_pool_buffer_limit_exceeded_total{upstream}`. Label
@@ -332,9 +340,9 @@ Two outcome shapes exist:
 | Request body too large | `TARDIGRADE_MAX_BODY_SIZE` | 1 MiB | `request_limits.validateBodySize` | `413`-class rejection |
 | Proxy per-stream buffer low watermark | `TARDIGRADE_PROXY_BUFFER_PER_STREAM_LOW_WATERMARK_BYTES` | 256 KiB | proxy buffer accounting; HTTP/2 stream credit | Must satisfy `low < high <= hard`. An HTTP/2 stream queue that reached the high watermark is credited nothing until it drains below this, then receives one coalesced `WINDOW_UPDATE` |
 | Proxy per-stream buffer high watermark | `TARDIGRADE_PROXY_BUFFER_PER_STREAM_HIGH_WATERMARK_BYTES` | 768 KiB | proxy buffer accounting; HTTP/2 `SETTINGS_INITIAL_WINDOW_SIZE` | High-watermark transition is observable through `tardigrade_buffer_high_watermark_events_total`. This value is advertised verbatim as the streaming HTTP/2 receive window, so a well-behaved origin stops sending once a stream holds this many unconsumed bytes. A reload applies to connections opened afterwards (SETTINGS are per connection) |
-| Proxy per-stream buffer hard limit | `TARDIGRADE_PROXY_BUFFER_PER_STREAM_HARD_LIMIT_BYTES` | 1 MiB | proxy buffer accounting | Hard-limit exceedance is observable through `tardigrade_buffer_limit_exceeded_total`; enforcement lands per proxy path as backpressure work expands |
-| Proxy per-origin buffer hard limit | `TARDIGRADE_PROXY_BUFFER_PER_ORIGIN_HARD_LIMIT_BYTES` | 0 (unlimited) | HTTP/2 streaming response queues | When non-zero, must be at least the per-stream hard limit. Caps the retained response-queue memory all streams to one origin hold together. Refused before commitment → `503 proxy_buffer_saturated`; refused after → that stream is reset and truncated. Never counted against upstream health. Reload applies immediately |
-| Proxy global buffer hard limit | `TARDIGRADE_PROXY_BUFFER_GLOBAL_HARD_LIMIT_BYTES` | 0 (unlimited) | HTTP/2 streaming response queues | When non-zero, must be at least the per-stream hard limit. Process-wide ceiling across every origin, with the same pre/post-commitment behavior; reload applies immediately |
+| Proxy per-stream buffer hard limit | `TARDIGRADE_PROXY_BUFFER_PER_STREAM_HARD_LIMIT_BYTES` | 1 MiB | proxy buffer accounting | Hard-limit exceedance is observable through `tardigrade_buffer_limit_exceeded_total`. On the request direction a refusal here is *this* upload outgrowing its allowed in-flight bound → `413 payload_too_large`, distinct from an aggregate refusal's `503` |
+| Proxy per-origin buffer hard limit | `TARDIGRADE_PROXY_BUFFER_PER_ORIGIN_HARD_LIMIT_BYTES` | 0 (unlimited) | HTTP/2 stream queues (responses and uploads) | When non-zero, must be at least the per-stream hard limit. Caps the retained queue memory all streams to one origin hold together. Refused before commitment → `503 proxy_buffer_saturated`; refused after → that stream is reset and truncated. Never counted against upstream health. Reload applies immediately. HTTP/1 origins have no per-origin account; their relay memory is bounded per request by fixed buffers |
+| Proxy global buffer hard limit | `TARDIGRADE_PROXY_BUFFER_GLOBAL_HARD_LIMIT_BYTES` | 0 (unlimited) | HTTP/2 stream queues, HTTP/1 relay buffers, upload relay buffers | When non-zero, must be at least the per-stream hard limit. Process-wide ceiling across every origin and both directions, with the same pre/post-commitment behavior; reload applies immediately |
 | Native TLS inbound ciphertext watermarks | `TARDIGRADE_TLS_INBOUND_CIPHERTEXT_LOW_WATERMARK_BYTES`, `TARDIGRADE_TLS_INBOUND_CIPHERTEXT_HIGH_WATERMARK_BYTES`, `TARDIGRADE_TLS_INBOUND_CIPHERTEXT_HARD_LIMIT_BYTES` | TLS core defaults | pure-Zig TLS record stream | Invalid ordering, capacity overflow, or reserve violations reject startup/reload |
 | Native TLS inbound plaintext watermarks | `TARDIGRADE_TLS_INBOUND_PLAINTEXT_LOW_WATERMARK_BYTES`, `TARDIGRADE_TLS_INBOUND_PLAINTEXT_HIGH_WATERMARK_BYTES`, `TARDIGRADE_TLS_INBOUND_PLAINTEXT_HARD_LIMIT_BYTES` | TLS core defaults | pure-Zig TLS record stream | High pauses carrier reads; resume occurs only after all inbound queues drain to low |
 | Native TLS outbound ciphertext watermarks | `TARDIGRADE_TLS_OUTBOUND_CIPHERTEXT_LOW_WATERMARK_BYTES`, `TARDIGRADE_TLS_OUTBOUND_CIPHERTEXT_HIGH_WATERMARK_BYTES`, `TARDIGRADE_TLS_OUTBOUND_CIPHERTEXT_HARD_LIMIT_BYTES` | TLS core defaults | pure-Zig TLS record stream | High pauses plaintext writes; hard-limit rejection does not advance write state |

--- a/docs/PROXY_STREAMING.md
+++ b/docs/PROXY_STREAMING.md
@@ -194,18 +194,18 @@ it still owns.
 
 **Do not compare `tardigrade_buffered_bytes_current{scope="global"}` with
 `TARDIGRADE_PROXY_BUFFER_GLOBAL_HARD_LIMIT_BYTES`.** That gauge is a roll-up of
-every proxy-owned buffer — bounded buffered responses, HTTP/1 relay buffers,
-request-side buffers, and HTTP/2 stream queues — whereas the hard limit is
-currently enforced only against HTTP/2 streaming response queues. Under mixed
-traffic the roll-up is larger than the quantity being checked, so reading it as
-"how close am I to the limit" overstates pressure.
+every proxy-owned buffer, including paths the limit does not govern — most
+notably the bounded buffered compatibility path, which has its own hard cap in
+`TARDIGRADE_MAX_BUFFERED_UPSTREAM_RESPONSE_BYTES`. Under mixed traffic the
+roll-up is larger than the quantity being checked, so reading it as "how close
+am I to the limit" overstates pressure.
 
 The series to put next to the limit is
 `tardigrade_proxy_buffer_aggregate_bytes_current{direction,scope="global"}`,
-which is read directly from the account that performs the enforcement. Bringing
-the remaining paths under the same aggregate is request-direction work (the
-issue's PR 3); until then these two gauges answer different questions, and the
-narrower one is the one the limit governs.
+which is read directly from the account that performs the enforcement. It now
+covers HTTP/2 stream queues, HTTP/1 relay buffers in both directions, and
+request-direction upload buffers on both protocols; the remaining gap is
+per-origin accounting for HTTP/1 origins (the issue's PR 4).
 
 #### What a refusal does
 
@@ -246,6 +246,50 @@ judged by what it was granted. Each connection therefore pins the complete
 low/high/hard policy it advertised, and every stream on it is measured against
 that, never against a newer snapshot.
 
-The HTTP/1 relay's fixed buffers are accounted per stream but are not reserved
-against the aggregate scopes; their size does not grow with concurrency the way
-an HTTP/2 stream queue does.
+### Request-direction bounds
+
+Uploads are accounted the same way, under
+`direction="downstream_to_upstream"`. Both relays copy through one fixed buffer
+for the life of the upload, so what is reserved is that buffer — reserved once
+when the relay starts, not once per chunk — plus any body bytes that arrived in
+the same read as the request head, which live in a second buffer of their own.
+An upload therefore reserves a bounded amount that does not grow with the body,
+and the reservation is released on every exit: completion, client abort,
+cancellation, timeout, and upstream failure alike.
+
+Every upload reservation clears
+`TARDIGRADE_PROXY_BUFFER_GLOBAL_HARD_LIMIT_BYTES`, and an HTTP/2 upload also
+clears its origin's limit. Per-origin accounting for HTTP/1 origins is the
+issue's PR 4: an HTTP/1 origin's relay memory is already bounded per request by
+these fixed buffers, so the scope concurrency can multiply is the process.
+
+Refusals split by what ran out, because the two mean different things to the
+client:
+
+| Refused at | Status | Meaning |
+| --- | --- | --- |
+| per-stream hard limit | `413` `payload_too_large` | *this* upload's in-flight bytes exceed the bound it is allowed |
+| per-origin or global hard limit | `503` `proxy_buffer_saturated` | the proxy is out of room for anybody |
+
+Both are raised before the response head is committed, and neither is recorded
+against upstream health — a healthy origin must not be blamed for this proxy's
+memory pressure.
+
+### Seeing a slow origin on HTTP/1
+
+The HTTP/1 relay has no queue whose depth could cross a watermark: it reads the
+client only after the upstream write completes, so a full upstream send buffer
+*is* a pause of downstream reads. Before each chunk the relay asks (with a
+zero-timeout `poll`, so a healthy origin pays nothing and moves no counters)
+whether the origin can take more bytes. When it cannot, the transition is
+recorded as `tardigrade_buffer_read_pauses_total{side="downstream"}`, and the
+matching resume once the write goes through.
+
+Only transitions are counted: a relay stalled across many chunks reports one
+pause and one resume, not one per write, and a relay torn down mid-stall still
+reports its resume — so the difference between the two counters reads as "how
+many uploads are stalled right now" rather than drifting by one per abort. A
+write that begins to block only *after* the check passes is deliberately not
+counted; an origin that has genuinely stopped consuming keeps the buffer full
+across iterations and is caught, while a momentary block is not a backpressure
+event.

--- a/docs/PROXY_STREAMING.md
+++ b/docs/PROXY_STREAMING.md
@@ -271,6 +271,17 @@ An upload therefore reserves a bounded amount that does not grow with the body,
 and the reservation is released on every exit: completion, client abort,
 cancellation, timeout, malformed chunk framing, and upstream failure alike.
 
+**The claim ends when the upload does, not when the exchange does.** On HTTP/2
+the same relay buffer goes on to serve the response, so the request-direction
+reservation is released explicitly at the upload/response boundary; carrying it
+through the response would occupy upload capacity for as long as the response
+took, which is long enough for one slow response to make an unrelated upload
+fail with a `503` it should never have seen. (HTTP/1 has no equivalent window —
+the request-sending function returns, releasing its reservation, before the
+response is read.) That buffer's ownership during the HTTP/2 response phase is
+not itself accounted; that gap predates this work and belongs with the rest of
+the response-side aggregate coverage.
+
 Every upload reservation clears
 `TARDIGRADE_PROXY_BUFFER_GLOBAL_HARD_LIMIT_BYTES`, and an HTTP/2 upload also
 clears its origin's limit. Per-origin accounting for HTTP/1 origins is the

--- a/docs/PROXY_STREAMING.md
+++ b/docs/PROXY_STREAMING.md
@@ -250,12 +250,26 @@ that, never against a newer snapshot.
 
 Uploads are accounted the same way, under
 `direction="downstream_to_upstream"`. Both relays copy through one fixed buffer
-for the life of the upload, so what is reserved is that buffer — reserved once
-when the relay starts, not once per chunk — plus any body bytes that arrived in
-the same read as the request head, which live in a second buffer of their own.
+for the life of the upload, so what is reserved is that buffer — reserved once,
+not once per chunk — plus whatever the relay still holds from the request head.
+
+That second amount differs by framing, because the two retain different parts of
+the same slice. A `Content-Length` upload keeps only the body bytes it will
+forward, and gives them back as soon as they are written. A chunked upload hands
+the whole raw remainder to the decoder, framing octets included, so the raw
+length is what is reserved; the relay releases it incrementally as the decoder
+consumes it, rather than holding the request head's peak for the whole upload.
+
+**The reservation is taken before anything is sent upstream** — before the
+HTTP/1 request head is written, and before HTTP/2 `HEADERS` go out. This is not
+just bookkeeping: reserving inside the relay would mean a local `413`/`503`
+could only be raised once the origin had already received a real, possibly
+side-effecting request whose body then never arrives. Reserving first makes a
+refusal something the origin never sees.
+
 An upload therefore reserves a bounded amount that does not grow with the body,
 and the reservation is released on every exit: completion, client abort,
-cancellation, timeout, and upstream failure alike.
+cancellation, timeout, malformed chunk framing, and upstream failure alike.
 
 Every upload reservation clears
 `TARDIGRADE_PROXY_BUFFER_GLOBAL_HARD_LIMIT_BYTES`, and an HTTP/2 upload also
@@ -284,6 +298,12 @@ zero-timeout `poll`, so a healthy origin pays nothing and moves no counters)
 whether the origin can take more bytes. When it cannot, the transition is
 recorded as `tardigrade_buffer_read_pauses_total{side="downstream"}`, and the
 matching resume once the write goes through.
+
+Only a genuinely full send buffer counts. `poll` also reports a descriptor
+ready for `POLLERR`/`POLLHUP`/`POLLNVAL`, so readiness alone does not mean
+writable and its absence does not mean full; the three outcomes are separated
+deliberately, because a broken origin recorded as a stall would show up as
+backpressure on a connection that is simply dead.
 
 Only transitions are counted: a relay stalled across many chunks reports one
 pause and one resume, not one per write, and a relay torn down mid-stall still

--- a/src/gateway_proxy.zig
+++ b/src/gateway_proxy.zig
@@ -139,16 +139,22 @@ pub const StreamingRequestBody = struct {
 const ProxyBufferReservation = struct {
     account: proxy_buffer_account.Account,
     observer: proxy_buffer_account.Observer,
+    /// Aggregate scopes this relay's bytes must clear on top of the per-stream
+    /// bound. An empty capacity (a path with no origin identity and no process
+    /// account, or a test harness) leaves those scopes unlimited.
+    capacity: proxy_buffer_account.AggregateCapacity,
     active: bool = false,
 
     fn init(
         direction: proxy_buffer_account.Direction,
         limits: proxy_buffer_account.Limits,
         observer: proxy_buffer_account.Observer,
+        capacity: proxy_buffer_account.AggregateCapacity,
     ) ProxyBufferReservation {
         return .{
             .account = proxy_buffer_account.Account.init(direction, .stream, limits),
             .observer = observer,
+            .capacity = capacity,
         };
     }
 
@@ -160,6 +166,17 @@ const ProxyBufferReservation = struct {
                 self.observer.recordReservation(self.account.direction, 0, false, true);
             }
             return err;
+        };
+        // Charge the aggregate scopes only once the per-stream bound has
+        // admitted the bytes, and roll the per-stream reservation back if they
+        // refuse: no scope may be left holding bytes this relay never took.
+        self.capacity.reserve(self.account.direction, bytes) catch |err| {
+            self.account.release(bytes) catch unreachable;
+            self.observer.recordAggregateLimitExceeded(
+                self.account.direction,
+                proxy_buffer_account.aggregateFailureScope(err),
+            );
+            return error.ProxyBufferCapacityUnavailable;
         };
         const after = self.account.snapshot();
         self.observer.recordReservation(
@@ -178,6 +195,7 @@ const ProxyBufferReservation = struct {
     fn release(self: *ProxyBufferReservation, bytes: usize) void {
         if (!self.active) return;
         self.account.release(bytes) catch unreachable;
+        self.capacity.release(self.account.direction, bytes);
         self.observer.releaseReservation(self.account.direction, bytes);
         self.observer.releaseRetainedBytes(self.account.direction, bytes);
         self.active = self.account.snapshot().current != 0;
@@ -189,6 +207,35 @@ const ProxyBufferReservation = struct {
         self.release(current);
     }
 };
+
+/// Reserve request-direction relay bytes with the failure semantics #140 defines
+/// for the pre-commitment side of the boundary. The two refusals mean different
+/// things and must not collapse into one status: a per-stream refusal is this
+/// client's in-flight upload outgrowing the bound it is allowed (`413`), while
+/// an aggregate refusal is the proxy being out of room for anybody (`503`,
+/// already the error's own meaning). Both are raised before any response byte
+/// is committed, and neither is charged to the origin.
+fn reserveUploadBytes(reservation: *ProxyBufferReservation, bytes: usize) !void {
+    reservation.reserve(bytes) catch |err| return switch (err) {
+        error.BufferLimitExceeded => error.RequestBufferLimitExceeded,
+        else => err,
+    };
+}
+
+/// Note a write that cannot make progress right now as a downstream read pause.
+/// The check never waits (zero timeout), so a relay whose origin keeps draining
+/// costs one non-blocking `poll` per chunk and never touches the counters. A
+/// poll failure is not evidence of a stall, so it records nothing.
+///
+/// This reports a stall that is *already* in effect, so a single write that
+/// happens to block briefly after the check passes is not counted. That is the
+/// intended reading: an origin that has genuinely stopped consuming leaves the
+/// send buffer full across relay iterations and is caught, while a momentary
+/// block is not a backpressure event worth a counter.
+fn noteUpstreamWriteStall(fd: std.posix.fd_t, stall: *proxy_buffer_account.ReadStall) void {
+    const writable = pollFdWritable(fd) catch return;
+    if (!writable) stall.pause();
+}
 
 pub const StreamingProxyResult = struct {
     status_code: u16,
@@ -727,24 +774,33 @@ fn relayStreamingUploadToHttp2(
     cancel_token: ?*const CancellationToken,
     proxy_buffer_limits: proxy_buffer_account.Limits,
     proxy_buffer_observer: proxy_buffer_account.Observer,
+    proxy_buffer_capacity: proxy_buffer_account.AggregateCapacity,
 ) !void {
+    // The relay owns `read_buf` for the whole upload, so reserve it once rather
+    // than per chunk: the reservation then tracks memory actually retained, and
+    // the aggregate scopes see one stable claim instead of a reserve/release
+    // flicker per DATA frame that no concurrent stream could ever be bounded by.
+    var upload_reservation = ProxyBufferReservation.init(.downstream_to_upstream, proxy_buffer_limits, proxy_buffer_observer, proxy_buffer_capacity);
+    try reserveUploadBytes(&upload_reservation, read_buf.len);
+    defer upload_reservation.releaseAll();
+
     switch (sb.framing) {
         .length => |content_length| {
             var sent: usize = @min(sb.initial_bytes.len, content_length);
             if (sent > 0) {
-                var initial_reservation = ProxyBufferReservation.init(.downstream_to_upstream, proxy_buffer_limits, proxy_buffer_observer);
-                try initial_reservation.reserve(sent);
-                defer initial_reservation.releaseAll();
-                try conn.writeStreamingRequestBody(stream, sb.initial_bytes[0..sent], sent == content_length);
+                // Bytes that arrived with the request head are a second buffer.
+                try reserveUploadBytes(&upload_reservation, sent);
+                conn.writeStreamingRequestBody(stream, sb.initial_bytes[0..sent], sent == content_length) catch |err| {
+                    upload_reservation.release(sent);
+                    return err;
+                };
+                upload_reservation.release(sent);
             }
             while (sent < content_length) {
                 if (cancelStopped(cancel_token)) return error.RequestCancelled;
                 const want = @min(read_buf.len, content_length - sent);
                 const n = downstream_conn.read(read_buf[0..want]) catch return error.ClientAborted;
                 if (n == 0) return error.ClientAborted;
-                var upload_reservation = ProxyBufferReservation.init(.downstream_to_upstream, proxy_buffer_limits, proxy_buffer_observer);
-                try upload_reservation.reserve(n);
-                defer upload_reservation.releaseAll();
                 try conn.writeStreamingRequestBody(stream, read_buf[0..n], sent + n == content_length);
                 sent += n;
             }
@@ -761,9 +817,6 @@ fn relayStreamingUploadToHttp2(
                 if (cancelStopped(cancel_token)) return error.RequestCancelled;
                 const n = try reader.next(read_buf);
                 if (n == 0) break;
-                var upload_reservation = ProxyBufferReservation.init(.downstream_to_upstream, proxy_buffer_limits, proxy_buffer_observer);
-                try upload_reservation.reserve(n);
-                defer upload_reservation.releaseAll();
                 try conn.writeStreamingRequestBody(stream, read_buf[0..n], false);
             }
             try conn.writeStreamingRequestBody(stream, "", true);
@@ -838,7 +891,10 @@ fn streamViaH2Pool(
                 if (h1_pool) |p| p.recordProtocol(false);
                 const start_ms = http.event_loop.monotonicMs();
                 var wrote_downstream = false;
-                const res = try streamProxyOverTransport(allocator, tls_ptr, tls_ptr.fd, read_buf, uri, method, extra_headers, buffered_body, streaming_body, downstream_conn, downstream_writer, security, alt_svc, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, &wrote_downstream, proxy_buffer_limits, proxy_buffer_observer);
+                // An ALPN-h1 origin never creates an h2 origin entry, so this
+                // connection clears the process account only (per-origin
+                // accounting for h1 origins is the issue's PR 4).
+                const res = try streamProxyOverTransport(allocator, tls_ptr, tls_ptr.fd, read_buf, uri, method, extra_headers, buffered_body, streaming_body, downstream_conn, downstream_writer, security, alt_svc, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, &wrote_downstream, proxy_buffer_limits, proxy_buffer_observer, .{ .global = proxy_buffer_global });
                 if (h1_pool) |p| p.recordRequestLatency(false, http.event_loop.monotonicMs() - start_ms);
                 return res.result;
             },
@@ -913,6 +969,7 @@ fn streamViaH2Pool(
                         cancel_token,
                         proxy_buffer_limits,
                         proxy_buffer_observer,
+                        proxy_buffer_capacity,
                     ) catch |err| {
                         const capacity_abort = err == error.BufferLimitExceeded or
                             conn.abortCause(stream) == .local_capacity;
@@ -1363,6 +1420,20 @@ fn pollFdReadable(fd: std.posix.fd_t, timeout_ms: u32) !bool {
     return ready != 0;
 }
 
+/// Can `fd` accept bytes right now without blocking? A `false` means the send
+/// buffer is full because the peer has stopped draining — which for the
+/// synchronous HTTP/1 relay is the whole of its backpressure, since it has no
+/// queue whose depth could cross a watermark instead. Never waits.
+fn pollFdWritable(fd: std.posix.fd_t) !bool {
+    var pfds = [_]std.posix.pollfd{.{
+        .fd = fd,
+        .events = std.posix.POLL.OUT,
+        .revents = 0,
+    }};
+    const ready = try std.posix.poll(&pfds, 0);
+    return ready != 0 and (pfds[0].revents & std.posix.POLL.OUT) != 0;
+}
+
 test "parseBufferedUpstreamResponse keeps metadata in an arena and preserves forwarded headers" {
     var parsed = try parseBufferedUpstreamResponse(
         std.testing.allocator,
@@ -1791,6 +1862,7 @@ fn relayUpstreamBody(
 fn sendStreamingProxyRequest(
     allocator: std.mem.Allocator,
     transport: anytype,
+    fd: std.posix.fd_t,
     uri: std.Uri,
     method: []const u8,
     extra_headers: []const std.http.Header,
@@ -1800,6 +1872,7 @@ fn sendStreamingProxyRequest(
     cancel_token: ?*const CancellationToken,
     proxy_buffer_limits: proxy_buffer_account.Limits,
     proxy_buffer_observer: proxy_buffer_account.Observer,
+    proxy_buffer_capacity: proxy_buffer_account.AggregateCapacity,
 ) !void {
     var req_aw: std.Io.Writer.Allocating = .init(allocator);
     defer req_aw.deinit();
@@ -1838,11 +1911,13 @@ fn sendStreamingProxyRequest(
     if (streaming_body) |sb| {
         try relayStreamingUploadToHttp1(
             transport,
+            fd,
             sb,
             downstream_conn,
             cancel_token,
             proxy_buffer_limits,
             proxy_buffer_observer,
+            proxy_buffer_capacity,
         );
     } else if (buffered_body.len > 0) {
         try transport.writeAll(buffered_body);
@@ -1852,28 +1927,46 @@ fn sendStreamingProxyRequest(
 /// Relay a streamed client upload to an HTTP/1.1 upstream. Both framings copy
 /// through one fixed relay buffer, so peak user-space upload memory is bounded
 /// regardless of the body size.
+///
+/// `fd` is the upstream socket (the TLS carrier when the transport is TLS). It
+/// is used only to notice a write that would block: this relay reads the client
+/// again only after the upstream write completes, so a full upstream send buffer
+/// *is* a pause of downstream reads, and that transition is the only place a
+/// slow origin becomes visible on a path that deliberately has no queue (#140).
 fn relayStreamingUploadToHttp1(
     transport: anytype,
+    fd: std.posix.fd_t,
     sb: StreamingRequestBody,
     downstream_conn: anytype,
     cancel_token: ?*const CancellationToken,
     proxy_buffer_limits: proxy_buffer_account.Limits,
     proxy_buffer_observer: proxy_buffer_account.Observer,
+    proxy_buffer_capacity: proxy_buffer_account.AggregateCapacity,
 ) !void {
     var relay: [16 * 1024]u8 = undefined;
-    var upload_reservation = ProxyBufferReservation.init(.downstream_to_upstream, proxy_buffer_limits, proxy_buffer_observer);
-    try upload_reservation.reserve(relay.len);
+    var upload_reservation = ProxyBufferReservation.init(.downstream_to_upstream, proxy_buffer_limits, proxy_buffer_observer, proxy_buffer_capacity);
+    try reserveUploadBytes(&upload_reservation, relay.len);
     defer upload_reservation.releaseAll();
+
+    // Balanced on every exit — success, client abort, cancellation, upstream
+    // failure — so the pause/resume difference reads as "relays stalled right
+    // now" instead of drifting by one per aborted upload.
+    var stall = proxy_buffer_account.ReadStall.init(.downstream, proxy_buffer_observer);
+    defer stall.unpause();
 
     switch (sb.framing) {
         .length => |content_length| {
             var sent: usize = @min(sb.initial_bytes.len, content_length);
             if (sent > 0) {
-                try upload_reservation.reserve(sent);
+                // The bytes that arrived with the request head live in their own
+                // buffer, so they are reserved on top of the relay buffer.
+                try reserveUploadBytes(&upload_reservation, sent);
+                noteUpstreamWriteStall(fd, &stall);
                 transport.writeAll(sb.initial_bytes[0..sent]) catch |err| {
                     upload_reservation.release(sent);
                     return err;
                 };
+                stall.unpause();
                 upload_reservation.release(sent);
             }
             while (sent < content_length) {
@@ -1881,7 +1974,9 @@ fn relayStreamingUploadToHttp1(
                 const want = @min(relay.len, content_length - sent);
                 const n = downstream_conn.read(relay[0..want]) catch return error.ClientAborted;
                 if (n == 0) return error.ClientAborted;
+                noteUpstreamWriteStall(fd, &stall);
                 try transport.writeAll(relay[0..n]);
+                stall.unpause();
                 sent += n;
             }
         },
@@ -1898,9 +1993,13 @@ fn relayStreamingUploadToHttp1(
                 if (n == 0) break;
                 var size_buf: [24]u8 = undefined;
                 const size_line = std.fmt.bufPrint(&size_buf, "{x}\r\n", .{n}) catch unreachable;
+                // One stall check per chunk, not per write: the three writes
+                // below are one logical chunk and stall or drain together.
+                noteUpstreamWriteStall(fd, &stall);
                 try transport.writeAll(size_line);
                 try transport.writeAll(relay[0..n]);
                 try transport.writeAll("\r\n");
+                stall.unpause();
             }
             try transport.writeAll("0\r\n\r\n");
         },
@@ -1934,11 +2033,13 @@ fn streamProxyOverTransport(
     wrote_downstream: *bool,
     proxy_buffer_limits: proxy_buffer_account.Limits,
     proxy_buffer_observer: proxy_buffer_account.Observer,
+    proxy_buffer_capacity: proxy_buffer_account.AggregateCapacity,
 ) !struct { result: StreamingProxyResult, reusable: bool } {
     if (connect_timeout_ms > 0) setSocketTimeoutMs(fd, connect_timeout_ms, connect_timeout_ms) catch {};
     try sendStreamingProxyRequest(
         allocator,
         transport,
+        fd,
         uri,
         method,
         extra_headers,
@@ -1948,6 +2049,7 @@ fn streamProxyOverTransport(
         cancel_token,
         proxy_buffer_limits,
         proxy_buffer_observer,
+        proxy_buffer_capacity,
     );
     if (read_deadline_ms > 0) setSocketRecvTimeoutMs(fd, read_deadline_ms) catch {};
 
@@ -1962,7 +2064,7 @@ fn streamProxyOverTransport(
     const body_allowed = gpres.responseBodyAllowed(method, head.status_code);
     var response_reservation: ?ProxyBufferReservation = null;
     if (body_allowed) {
-        response_reservation = ProxyBufferReservation.init(.upstream_to_downstream, proxy_buffer_limits, proxy_buffer_observer);
+        response_reservation = ProxyBufferReservation.init(.upstream_to_downstream, proxy_buffer_limits, proxy_buffer_observer, proxy_buffer_capacity);
         try response_reservation.?.reserve(read_buf.len);
     }
     defer if (response_reservation) |*reservation| reservation.releaseAll();
@@ -2125,6 +2227,13 @@ pub fn executeStreamingHttpProxyRequest(
     // Everything below runs HTTP/1.1 (counted per request, not per attempt).
     if (pool) |p| p.recordProtocol(false);
 
+    // Aggregate capacity for this connection's relay buffers, in both
+    // directions (#140). The HTTP/1 pool has no per-origin buffer account — an
+    // h1 origin's relay memory is bounded per request by the fixed relay
+    // buffers, so the scope that concurrency can actually multiply is the
+    // process; per-origin accounting for h1 origins is the issue's PR 4.
+    const h1_buffer_capacity = proxy_buffer_account.AggregateCapacity{ .global = proxy_buffer_global };
+
     const active_pool: ?*http.upstream_pool.UpstreamPool = if (pool) |p| (if (p.config.enabled) p else null) else null;
     var key_buf: [512]u8 = undefined;
     const key = if (unix_socket_path) |socket_path|
@@ -2191,9 +2300,9 @@ pub fn executeStreamingHttpProxyRequest(
         const exchange_start_ms = http.event_loop.monotonicMs();
         const fd = conn.stream.handle;
         const res = (if (conn.tls) |tls|
-            streamProxyOverTransport(allocator, tls, fd, read_buf, uri, method, extra_headers.items, buffered_body, streaming_body, downstream_conn, downstream_writer, security, alt_svc, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, &wrote_downstream, cfg.proxy_buffer_limits, proxy_buffer_observer)
+            streamProxyOverTransport(allocator, tls, fd, read_buf, uri, method, extra_headers.items, buffered_body, streaming_body, downstream_conn, downstream_writer, security, alt_svc, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, &wrote_downstream, cfg.proxy_buffer_limits, proxy_buffer_observer, h1_buffer_capacity)
         else
-            streamProxyOverTransport(allocator, compat.netStreamFromFd(fd), fd, read_buf, uri, method, extra_headers.items, buffered_body, streaming_body, downstream_conn, downstream_writer, security, alt_svc, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, &wrote_downstream, cfg.proxy_buffer_limits, proxy_buffer_observer)) catch |err| {
+            streamProxyOverTransport(allocator, compat.netStreamFromFd(fd), fd, read_buf, uri, method, extra_headers.items, buffered_body, streaming_body, downstream_conn, downstream_writer, security, alt_svc, sticky_set_cookie, correlation_id, connect_timeout_ms, read_deadline_ms, cancel_token, &wrote_downstream, cfg.proxy_buffer_limits, proxy_buffer_observer, h1_buffer_capacity)) catch |err| {
             // Tear down the connection (release handles active-- and close).
             if (active_pool) |p| {
                 p.release(key, conn, false, http.event_loop.monotonicMs());
@@ -2782,6 +2891,380 @@ test "streaming relay rejects a chunk not terminated by CRLF" {
         false,
         &body,
     ));
+}
+
+// ---------------------------------------------------------------------------
+// Request-direction buffer accounting and HTTP/1 stall observability (#140).
+// ---------------------------------------------------------------------------
+
+/// Records everything the request-direction relays report, so a test can assert
+/// both the transitions and that every gauge returns to zero at teardown.
+const UploadBufferObserver = struct {
+    reserved: usize = 0,
+    peak_reserved: usize = 0,
+    retained: usize = 0,
+    pauses: u64 = 0,
+    resumes: u64 = 0,
+    stream_limit_exceeded: u64 = 0,
+    aggregate_limit_exceeded: u64 = 0,
+    last_aggregate_scope: ?proxy_buffer_account.Scope = null,
+
+    fn observer(self: *UploadBufferObserver) proxy_buffer_account.Observer {
+        return .{
+            .context = self,
+            .recordReservationFn = recordReservation,
+            .releaseReservationFn = releaseReservation,
+            .recordAggregateLimitExceededFn = recordAggregateLimitExceeded,
+            .recordReadPauseFn = recordReadPause,
+            .recordReadResumeFn = recordReadResume,
+            .recordRetainedBytesFn = recordRetained,
+            .releaseRetainedBytesFn = releaseRetained,
+        };
+    }
+
+    fn recordReservation(
+        context: *anyopaque,
+        _: proxy_buffer_account.Direction,
+        bytes: usize,
+        _: bool,
+        limit_exceeded: bool,
+    ) void {
+        const self: *UploadBufferObserver = @ptrCast(@alignCast(context));
+        if (limit_exceeded) self.stream_limit_exceeded += 1;
+        self.reserved += bytes;
+        self.peak_reserved = @max(self.peak_reserved, self.reserved);
+    }
+
+    fn releaseReservation(context: *anyopaque, _: proxy_buffer_account.Direction, bytes: usize) void {
+        const self: *UploadBufferObserver = @ptrCast(@alignCast(context));
+        self.reserved -= bytes;
+    }
+
+    fn recordAggregateLimitExceeded(
+        context: *anyopaque,
+        _: proxy_buffer_account.Direction,
+        scope: proxy_buffer_account.Scope,
+    ) void {
+        const self: *UploadBufferObserver = @ptrCast(@alignCast(context));
+        self.aggregate_limit_exceeded += 1;
+        self.last_aggregate_scope = scope;
+    }
+
+    fn recordReadPause(context: *anyopaque, _: proxy_buffer_account.Side) void {
+        const self: *UploadBufferObserver = @ptrCast(@alignCast(context));
+        self.pauses += 1;
+    }
+
+    fn recordReadResume(context: *anyopaque, _: proxy_buffer_account.Side) void {
+        const self: *UploadBufferObserver = @ptrCast(@alignCast(context));
+        self.resumes += 1;
+    }
+
+    fn recordRetained(context: *anyopaque, _: proxy_buffer_account.Direction, bytes: usize) void {
+        const self: *UploadBufferObserver = @ptrCast(@alignCast(context));
+        self.retained += bytes;
+    }
+
+    fn releaseRetained(context: *anyopaque, _: proxy_buffer_account.Direction, bytes: usize) void {
+        const self: *UploadBufferObserver = @ptrCast(@alignCast(context));
+        self.retained -= bytes;
+    }
+};
+
+/// A client upload served from memory. `abort_after` makes the read fail once
+/// that many bytes have been handed over, standing in for a client that
+/// disappears mid-upload.
+const FakeUploadSource = struct {
+    data: []const u8,
+    pos: usize = 0,
+    abort_after: ?usize = null,
+
+    pub fn read(self: *FakeUploadSource, buf: []u8) !usize {
+        if (self.abort_after) |limit| {
+            if (self.pos >= limit) return error.ConnectionResetByPeer;
+        }
+        const take = @min(buf.len, self.data.len - self.pos);
+        @memcpy(buf[0..take], self.data[self.pos..][0..take]);
+        self.pos += take;
+        return take;
+    }
+};
+
+fn uploadTestLimits(hard: usize) proxy_buffer_account.Limits {
+    return .{
+        .per_stream_low_watermark = hard / 4,
+        .per_stream_high_watermark = hard / 2,
+        .per_stream_hard_limit = hard,
+        .per_origin_hard_limit = 0,
+        .global_hard_limit = 0,
+    };
+}
+
+/// Drain `total` bytes from `fd` after `delay_ms`. The delay is what lets the
+/// relay observe an origin that has stopped consuming.
+fn slowUploadDrain(fd: std.posix.fd_t, delay_ms: u64, total: usize) void {
+    // A bare `poll` with no descriptors, not `std.Io.sleep`: this runs on a raw
+    // spawned thread with no Io context, and a sleep that silently no-ops would
+    // let the drain keep pace with the relay so the stall under test would
+    // never happen.
+    var no_fds: [0]std.posix.pollfd = .{};
+    _ = std.posix.poll(&no_fds, @intCast(delay_ms)) catch {};
+    var buf: [4096]u8 = undefined;
+    var drained: usize = 0;
+    while (drained < total) {
+        const n = std.c.read(fd, &buf, buf.len);
+        if (n <= 0) return;
+        drained += @intCast(n);
+    }
+}
+
+/// Write into `fd` until it will not take another byte, and report how much
+/// went in. Non-blocking for the duration, so a partially free send buffer
+/// cannot park the caller with nobody draining. This is what makes a stall a
+/// fact of the socket's state at the moment the relay looks at it, rather than
+/// a race against a background reader.
+fn fillSocketSendBuffer(fd: std.posix.fd_t) !usize {
+    const flags = std.c.fcntl(fd, std.posix.F.GETFL, @as(c_int, 0));
+    if (flags < 0) return error.SocketFillFailed;
+    const nonblock: c_int = @bitCast(@as(u32, @bitCast(std.posix.O{ .NONBLOCK = true })));
+    if (std.c.fcntl(fd, std.posix.F.SETFL, flags | nonblock) < 0) return error.SocketFillFailed;
+    defer _ = std.c.fcntl(fd, std.posix.F.SETFL, flags);
+
+    const chunk = [_]u8{'p'} ** 1024;
+    var written: usize = 0;
+    // Bounded: a platform that never reports a full buffer must fail the test,
+    // not spin here forever.
+    while (written < 8 * 1024 * 1024) {
+        const n = std.c.write(fd, &chunk, chunk.len);
+        if (n <= 0) return written;
+        written += @intCast(n);
+    }
+    return error.SocketFillFailed;
+}
+
+test "http1 upload relay reports a slow origin as a downstream read pause" {
+    const fds = try makeBlockingSocketpair();
+    const client_fd = fds[0];
+    const peer_fd = fds[1];
+    defer _ = std.c.close(client_fd);
+    defer _ = std.c.close(peer_fd);
+
+    // Shrink both ends so the origin's window fills well before the upload is
+    // done, whatever the platform default happens to be.
+    const small: c_int = 4096;
+    std.posix.setsockopt(client_fd, std.posix.SOL.SOCKET, std.posix.SO.SNDBUF, std.mem.asBytes(&small)) catch {};
+    std.posix.setsockopt(peer_fd, std.posix.SOL.SOCKET, std.posix.SO.RCVBUF, std.mem.asBytes(&small)) catch {};
+
+    const payload = try std.testing.allocator.alloc(u8, 64 * 1024);
+    defer std.testing.allocator.free(payload);
+    @memset(payload, 'u');
+
+    // Leave the origin's window already full, so the relay's first look at the
+    // socket is guaranteed to find a stall rather than racing the drainer for
+    // one. `pollFdWritable` must agree, or the check below is not testing
+    // anything.
+    const prefilled = try fillSocketSendBuffer(client_fd);
+    try std.testing.expect(prefilled > 0);
+    try std.testing.expect(!try pollFdWritable(client_fd));
+
+    const drainer = try std.Thread.spawn(.{}, slowUploadDrain, .{ peer_fd, @as(u64, 20), prefilled + payload.len });
+    defer drainer.join();
+
+    var counters = UploadBufferObserver{};
+    var source = FakeUploadSource{ .data = payload };
+    try relayStreamingUploadToHttp1(
+        compat.netStreamFromFd(client_fd),
+        client_fd,
+        .{ .framing = .{ .length = payload.len } },
+        &source,
+        null,
+        uploadTestLimits(1024 * 1024),
+        counters.observer(),
+        .{},
+    );
+
+    // The origin stopped draining, so downstream reads really were held back.
+    try std.testing.expect(counters.pauses >= 1);
+    // And every pause was resolved, not left dangling.
+    try std.testing.expectEqual(counters.pauses, counters.resumes);
+    // Peak relay memory is the fixed buffer, not the body.
+    try std.testing.expectEqual(@as(usize, 16 * 1024), counters.peak_reserved);
+    try std.testing.expectEqual(@as(usize, 0), counters.reserved);
+    try std.testing.expectEqual(@as(usize, 0), counters.retained);
+}
+
+test "http1 upload relay leaves nothing reserved when the client aborts mid-upload" {
+    const fds = try makeBlockingSocketpair();
+    const client_fd = fds[0];
+    const peer_fd = fds[1];
+    defer _ = std.c.close(client_fd);
+    defer _ = std.c.close(peer_fd);
+
+    var counters = UploadBufferObserver{};
+    var global = proxy_buffer_account.Aggregate.init(.global, 0);
+    // Promises 8 KiB, delivers 4 KiB, then the client goes away.
+    var source = FakeUploadSource{ .data = &[_]u8{'x'} ** 4096, .abort_after = 4096 };
+    try std.testing.expectError(error.ClientAborted, relayStreamingUploadToHttp1(
+        compat.netStreamFromFd(client_fd),
+        client_fd,
+        .{ .framing = .{ .length = 8192 } },
+        &source,
+        null,
+        uploadTestLimits(1024 * 1024),
+        counters.observer(),
+        .{ .global = &global },
+    ));
+
+    try std.testing.expectEqual(@as(usize, 0), counters.reserved);
+    try std.testing.expectEqual(@as(usize, 0), counters.retained);
+    try std.testing.expectEqual(@as(usize, 0), global.currentBytes(.downstream_to_upstream));
+    // Never stalled, so the pause counters stay untouched.
+    try std.testing.expectEqual(@as(u64, 0), counters.pauses);
+    try std.testing.expectEqual(@as(u64, 0), counters.resumes);
+}
+
+test "http1 upload relay rejects an over-limit in-flight upload as a client fault" {
+    const fds = try makeBlockingSocketpair();
+    const client_fd = fds[0];
+    const peer_fd = fds[1];
+    defer _ = std.c.close(client_fd);
+    defer _ = std.c.close(peer_fd);
+
+    var counters = UploadBufferObserver{};
+    var source = FakeUploadSource{ .data = "" };
+    // The relay buffer alone consumes the whole per-stream budget, so the bytes
+    // that arrived with the request head have nowhere to go.
+    try std.testing.expectError(error.RequestBufferLimitExceeded, relayStreamingUploadToHttp1(
+        compat.netStreamFromFd(client_fd),
+        client_fd,
+        .{ .framing = .{ .length = 32 }, .initial_bytes = "inline-body-bytes" },
+        &source,
+        null,
+        uploadTestLimits(16 * 1024),
+        counters.observer(),
+        .{},
+    ));
+
+    // Charged to the stream scope (a 413), not to an aggregate one (a 503).
+    try std.testing.expectEqual(@as(u64, 1), counters.stream_limit_exceeded);
+    try std.testing.expectEqual(@as(u64, 0), counters.aggregate_limit_exceeded);
+    try std.testing.expectEqual(@as(usize, 0), counters.reserved);
+    try std.testing.expectEqual(@as(usize, 0), counters.retained);
+}
+
+test "http1 upload relay refuses when a concurrent relay has taken the aggregate" {
+    const fds = try makeBlockingSocketpair();
+    const client_fd = fds[0];
+    const peer_fd = fds[1];
+    defer _ = std.c.close(client_fd);
+    defer _ = std.c.close(peer_fd);
+
+    const limits = uploadTestLimits(16 * 1024);
+    var counters = UploadBufferObserver{};
+    // Room for one relay buffer and a little more — the second upload is what
+    // proves concurrency cannot multiply the per-stream bound.
+    var global = proxy_buffer_account.Aggregate.init(.global, 24 * 1024);
+    const capacity = proxy_buffer_account.AggregateCapacity{ .global = &global };
+
+    var in_flight = ProxyBufferReservation.init(.downstream_to_upstream, limits, counters.observer(), capacity);
+    try in_flight.reserve(16 * 1024);
+
+    var source = FakeUploadSource{ .data = "" };
+    try std.testing.expectError(error.ProxyBufferCapacityUnavailable, relayStreamingUploadToHttp1(
+        compat.netStreamFromFd(client_fd),
+        client_fd,
+        .{ .framing = .{ .length = 0 } },
+        &source,
+        null,
+        limits,
+        counters.observer(),
+        capacity,
+    ));
+
+    try std.testing.expectEqual(@as(u64, 1), counters.aggregate_limit_exceeded);
+    try std.testing.expectEqual(proxy_buffer_account.Scope.global, counters.last_aggregate_scope.?);
+    // The refused relay retained nothing; the reservation that did fit is intact.
+    try std.testing.expectEqual(@as(usize, 16 * 1024), global.currentBytes(.downstream_to_upstream));
+
+    in_flight.releaseAll();
+    try std.testing.expectEqual(@as(usize, 0), global.currentBytes(.downstream_to_upstream));
+    try std.testing.expectEqual(@as(usize, 0), counters.reserved);
+    try std.testing.expectEqual(@as(usize, 0), counters.retained);
+}
+
+const FakeH2UploadStream = struct { id: u32 = 1 };
+
+const FakeH2UploadConn = struct {
+    written: usize = 0,
+    end_stream: bool = false,
+
+    fn writeStreamingRequestBody(
+        self: *FakeH2UploadConn,
+        _: *FakeH2UploadStream,
+        bytes: []const u8,
+        end_stream: bool,
+    ) !void {
+        self.written += bytes.len;
+        if (end_stream) self.end_stream = true;
+    }
+};
+
+test "http2 upload relay reserves the relay buffer once, not once per DATA frame" {
+    var conn = FakeH2UploadConn{};
+    var stream = FakeH2UploadStream{};
+    var counters = UploadBufferObserver{};
+    var global = proxy_buffer_account.Aggregate.init(.global, 0);
+
+    const payload = try std.testing.allocator.alloc(u8, 256 * 1024);
+    defer std.testing.allocator.free(payload);
+    @memset(payload, 'd');
+    var read_buf: [16 * 1024]u8 = undefined;
+    var source = FakeUploadSource{ .data = payload };
+
+    try relayStreamingUploadToHttp2(
+        &conn,
+        &stream,
+        .{ .framing = .{ .length = payload.len } },
+        &read_buf,
+        &source,
+        null,
+        uploadTestLimits(1024 * 1024),
+        counters.observer(),
+        .{ .global = &global },
+    );
+
+    try std.testing.expectEqual(payload.len, conn.written);
+    try std.testing.expect(conn.end_stream);
+    // 16 DATA frames went out, but only one buffer was ever owned.
+    try std.testing.expectEqual(@as(usize, read_buf.len), counters.peak_reserved);
+    try std.testing.expectEqual(@as(usize, 0), counters.reserved);
+    try std.testing.expectEqual(@as(usize, 0), counters.retained);
+    try std.testing.expectEqual(@as(usize, 0), global.currentBytes(.downstream_to_upstream));
+}
+
+test "http2 upload relay releases the aggregate when the client aborts" {
+    var conn = FakeH2UploadConn{};
+    var stream = FakeH2UploadStream{};
+    var counters = UploadBufferObserver{};
+    var global = proxy_buffer_account.Aggregate.init(.global, 0);
+    var read_buf: [16 * 1024]u8 = undefined;
+    var source = FakeUploadSource{ .data = &[_]u8{'y'} ** 1024, .abort_after = 1024 };
+
+    try std.testing.expectError(error.ClientAborted, relayStreamingUploadToHttp2(
+        &conn,
+        &stream,
+        .{ .framing = .{ .length = 64 * 1024 } },
+        &read_buf,
+        &source,
+        null,
+        uploadTestLimits(1024 * 1024),
+        counters.observer(),
+        .{ .global = &global },
+    ));
+
+    try std.testing.expectEqual(@as(usize, 0), counters.reserved);
+    try std.testing.expectEqual(@as(usize, 0), counters.retained);
+    try std.testing.expectEqual(@as(usize, 0), global.currentBytes(.downstream_to_upstream));
 }
 
 /// Raw blocking responder: accepts one connection, drains the request, writes a

--- a/src/gateway_proxy.zig
+++ b/src/gateway_proxy.zig
@@ -222,10 +222,56 @@ fn reserveUploadBytes(reservation: *ProxyBufferReservation, bytes: usize) !void 
     };
 }
 
+/// The HTTP/1 upload relay's fixed copy buffer. Named because the reservation
+/// covering it is taken before the request head is written, in a different
+/// function from the array it describes.
+const http1_upload_relay_bytes: usize = 16 * 1024;
+
+/// Bytes a relay retains from the request head, on top of its fixed relay
+/// buffer. The two framings retain different amounts of the same slice: a
+/// `.length` upload forwards only the body bytes it is owed, while a `.chunked`
+/// upload hands the whole raw remainder to the decoder, which reads framing
+/// octets out of it too — so the retained slice there is its raw length.
+fn uploadInitialBytesFootprint(sb: StreamingRequestBody) usize {
+    return switch (sb.framing) {
+        .length => |content_length| @min(sb.initial_bytes.len, content_length),
+        .chunked => sb.initial_bytes.len,
+    };
+}
+
+/// Claim an upload's whole known buffer footprint *before* anything is sent
+/// upstream.
+///
+/// #140 requires capacity decisions to be deterministic before request
+/// forwarding, and that is not just bookkeeping: reserving inside the relay
+/// means the request head (HTTP/1) or HEADERS (HTTP/2) has already reached the
+/// origin, so a local 413/503 would leave a real, possibly side-effecting
+/// request half-delivered. Reserving first makes a refusal something the origin
+/// never sees.
+///
+/// The returned reservation is live and owned by the caller, which must
+/// `releaseAll` it on every exit; the relay releases the initial-bytes portion
+/// as those bytes drain.
+fn preflightUploadReservation(
+    limits: proxy_buffer_account.Limits,
+    observer: proxy_buffer_account.Observer,
+    capacity: proxy_buffer_account.AggregateCapacity,
+    relay_bytes: usize,
+    initial_bytes: usize,
+) !ProxyBufferReservation {
+    var reservation = ProxyBufferReservation.init(.downstream_to_upstream, limits, observer, capacity);
+    errdefer reservation.releaseAll();
+
+    try reserveUploadBytes(&reservation, relay_bytes);
+    if (initial_bytes != 0) try reserveUploadBytes(&reservation, initial_bytes);
+    return reservation;
+}
+
 /// Note a write that cannot make progress right now as a downstream read pause.
 /// The check never waits (zero timeout), so a relay whose origin keeps draining
-/// costs one non-blocking `poll` per chunk and never touches the counters. A
-/// poll failure is not evidence of a stall, so it records nothing.
+/// costs one non-blocking `poll` per chunk and never touches the counters.
+/// Only a genuinely full send buffer counts: a socket that is erroring or hung
+/// up records nothing, so a broken upstream never looks like a slow one.
 ///
 /// This reports a stall that is *already* in effect, so a single write that
 /// happens to block briefly after the check passes is not counted. That is the
@@ -233,8 +279,7 @@ fn reserveUploadBytes(reservation: *ProxyBufferReservation, bytes: usize) !void 
 /// send buffer full across relay iterations and is caught, while a momentary
 /// block is not a backpressure event worth a counter.
 fn noteUpstreamWriteStall(fd: std.posix.fd_t, stall: *proxy_buffer_account.ReadStall) void {
-    const writable = pollFdWritable(fd) catch return;
-    if (!writable) stall.pause();
+    if (pollUpstreamWritability(fd) == .blocked) stall.pause();
 }
 
 pub const StreamingProxyResult = struct {
@@ -765,6 +810,11 @@ fn executeBufferedViaH2Pool(
 /// The caller owns connection teardown on error. `read_buf` is the single relay
 /// buffer, so upload memory stays bounded; per-stream flow control supplies the
 /// backpressure.
+///
+/// `reservation` is preflighted by the caller — before HEADERS are sent, so a
+/// capacity refusal is something the origin never sees — and already covers
+/// `read_buf` plus `uploadInitialBytesFootprint(sb)`. The caller releases the
+/// rest; this function gives back only the initial-bytes portion as it drains.
 fn relayStreamingUploadToHttp2(
     conn: anytype,
     stream: anytype,
@@ -772,29 +822,18 @@ fn relayStreamingUploadToHttp2(
     read_buf: []u8,
     downstream_conn: anytype,
     cancel_token: ?*const CancellationToken,
-    proxy_buffer_limits: proxy_buffer_account.Limits,
-    proxy_buffer_observer: proxy_buffer_account.Observer,
-    proxy_buffer_capacity: proxy_buffer_account.AggregateCapacity,
+    reservation: *ProxyBufferReservation,
 ) !void {
-    // The relay owns `read_buf` for the whole upload, so reserve it once rather
-    // than per chunk: the reservation then tracks memory actually retained, and
-    // the aggregate scopes see one stable claim instead of a reserve/release
-    // flicker per DATA frame that no concurrent stream could ever be bounded by.
-    var upload_reservation = ProxyBufferReservation.init(.downstream_to_upstream, proxy_buffer_limits, proxy_buffer_observer, proxy_buffer_capacity);
-    try reserveUploadBytes(&upload_reservation, read_buf.len);
-    defer upload_reservation.releaseAll();
-
     switch (sb.framing) {
         .length => |content_length| {
             var sent: usize = @min(sb.initial_bytes.len, content_length);
             if (sent > 0) {
-                // Bytes that arrived with the request head are a second buffer.
-                try reserveUploadBytes(&upload_reservation, sent);
                 conn.writeStreamingRequestBody(stream, sb.initial_bytes[0..sent], sent == content_length) catch |err| {
-                    upload_reservation.release(sent);
+                    reservation.release(sent);
                     return err;
                 };
-                upload_reservation.release(sent);
+                // Forwarded: the request head's body bytes are no longer held.
+                reservation.release(sent);
             }
             while (sent < content_length) {
                 if (cancelStopped(cancel_token)) return error.RequestCancelled;
@@ -813,9 +852,15 @@ fn relayStreamingUploadToHttp2(
             // the upstream never sees a Content-Length it cannot know.
             var reader = http.chunked_upload.Reader(@TypeOf(downstream_conn))
                 .init(downstream_conn, sb.initial_bytes, sb.max_body_bytes);
+            // The decoder borrows the whole raw request-head remainder, framing
+            // octets included — see `uploadInitialBytesFootprint`.
+            var head_bytes_held = sb.initial_bytes.len;
             while (true) {
                 if (cancelStopped(cancel_token)) return error.RequestCancelled;
                 const n = try reader.next(read_buf);
+                // Before acting on `n`: the terminal call consumes borrowed
+                // trailer bytes too.
+                releaseDrainedHeadBytes(reservation, &head_bytes_held, reader.pendingBytes());
                 if (n == 0) break;
                 try conn.writeStreamingRequestBody(stream, read_buf[0..n], false);
             }
@@ -935,6 +980,25 @@ fn streamViaH2Pool(
                     try path_buf.writer.writeAll(uriComponentBytes(q));
                 }
 
+                // Claim the upload's buffer footprint before `openStreaming`,
+                // which sends HEADERS (#140). Reserving after it would let a
+                // local 413/503 be raised only once the origin had already
+                // received a request it will never see the body of.
+                var upload_reservation: ?ProxyBufferReservation = null;
+                defer if (upload_reservation) |*reservation| reservation.releaseAll();
+                if (streaming_body) |sb| {
+                    upload_reservation = preflightUploadReservation(
+                        proxy_buffer_limits,
+                        proxy_buffer_observer,
+                        proxy_buffer_capacity,
+                        read_buf.len,
+                        uploadInitialBytesFootprint(sb),
+                    ) catch |err| {
+                        h2_pool.release(conn);
+                        return err;
+                    };
+                }
+
                 const start_ms = http.event_loop.monotonicMs();
                 const stream = conn.openStreaming(.{
                     .method = method,
@@ -967,9 +1031,7 @@ fn streamViaH2Pool(
                         read_buf,
                         downstream_conn,
                         cancel_token,
-                        proxy_buffer_limits,
-                        proxy_buffer_observer,
-                        proxy_buffer_capacity,
+                        &upload_reservation.?,
                     ) catch |err| {
                         const capacity_abort = err == error.BufferLimitExceeded or
                             conn.abortCause(stream) == .local_capacity;
@@ -1420,18 +1482,41 @@ fn pollFdReadable(fd: std.posix.fd_t, timeout_ms: u32) !bool {
     return ready != 0;
 }
 
-/// Can `fd` accept bytes right now without blocking? A `false` means the send
-/// buffer is full because the peer has stopped draining — which for the
-/// synchronous HTTP/1 relay is the whole of its backpressure, since it has no
-/// queue whose depth could cross a watermark instead. Never waits.
-fn pollFdWritable(fd: std.posix.fd_t) !bool {
+/// What a zero-timeout writability check found on the upstream socket.
+const UpstreamWritability = enum {
+    /// The socket can take bytes right now.
+    writable,
+    /// The send buffer is full because the peer has stopped draining, so the
+    /// next write blocks until it resumes. This — and only this — is
+    /// backpressure, and for the synchronous HTTP/1 relay it is the whole of
+    /// it, since that relay has no queue whose depth could cross a watermark.
+    blocked,
+    /// The socket is in error or hung up, or the check itself failed. A broken
+    /// connection is not a slow one: the write is about to fail, and calling
+    /// that a pause would report an upstream *failure* as a stalled origin.
+    failed,
+};
+
+/// Ask whether `fd` can take bytes right now. Never waits.
+///
+/// `poll` reports a descriptor as ready for `POLLERR`, `POLLHUP`, or
+/// `POLLNVAL` even when `POLLOUT` is absent, so readiness alone does not mean
+/// writable and its absence does not mean full — the three outcomes have to be
+/// separated or a dead upstream shows up in the backpressure counters.
+fn pollUpstreamWritability(fd: std.posix.fd_t) UpstreamWritability {
     var pfds = [_]std.posix.pollfd{.{
         .fd = fd,
         .events = std.posix.POLL.OUT,
         .revents = 0,
     }};
-    const ready = try std.posix.poll(&pfds, 0);
-    return ready != 0 and (pfds[0].revents & std.posix.POLL.OUT) != 0;
+    const ready = std.posix.poll(&pfds, 0) catch return .failed;
+    if (ready == 0) return .blocked;
+    const revents = pfds[0].revents;
+    // Error bits win even when POLLOUT is also set: the write is not going to
+    // succeed, so this is not a stall to wait out.
+    if ((revents & (std.posix.POLL.ERR | std.posix.POLL.HUP | std.posix.POLL.NVAL)) != 0) return .failed;
+    if ((revents & std.posix.POLL.OUT) != 0) return .writable;
+    return .failed;
 }
 
 test "parseBufferedUpstreamResponse keeps metadata in an arena and preserves forwarded headers" {
@@ -1874,6 +1959,22 @@ fn sendStreamingProxyRequest(
     proxy_buffer_observer: proxy_buffer_account.Observer,
     proxy_buffer_capacity: proxy_buffer_account.AggregateCapacity,
 ) !void {
+    // Claim the upload's buffer footprint before a single byte of the request
+    // reaches the origin (#140). Reserving inside the relay meant a local
+    // 413/503 could only be raised after the origin had already received a
+    // half-delivered, possibly side-effecting request.
+    var upload_reservation: ?ProxyBufferReservation = null;
+    defer if (upload_reservation) |*reservation| reservation.releaseAll();
+    if (streaming_body) |sb| {
+        upload_reservation = try preflightUploadReservation(
+            proxy_buffer_limits,
+            proxy_buffer_observer,
+            proxy_buffer_capacity,
+            http1_upload_relay_bytes,
+            uploadInitialBytesFootprint(sb),
+        );
+    }
+
     var req_aw: std.Io.Writer.Allocating = .init(allocator);
     defer req_aw.deinit();
     const w = &req_aw.writer;
@@ -1915,9 +2016,8 @@ fn sendStreamingProxyRequest(
             sb,
             downstream_conn,
             cancel_token,
-            proxy_buffer_limits,
+            &upload_reservation.?,
             proxy_buffer_observer,
-            proxy_buffer_capacity,
         );
     } else if (buffered_body.len > 0) {
         try transport.writeAll(buffered_body);
@@ -1933,41 +2033,41 @@ fn sendStreamingProxyRequest(
 /// again only after the upstream write completes, so a full upstream send buffer
 /// *is* a pause of downstream reads, and that transition is the only place a
 /// slow origin becomes visible on a path that deliberately has no queue (#140).
+///
+/// `reservation` is preflighted by the caller and already covers this relay
+/// buffer plus `uploadInitialBytesFootprint(sb)`; the caller releases the rest.
+/// This function only gives back the initial-bytes portion as those bytes
+/// actually drain, so a long upload does not hold the request head's peak for
+/// its whole life.
 fn relayStreamingUploadToHttp1(
     transport: anytype,
     fd: std.posix.fd_t,
     sb: StreamingRequestBody,
     downstream_conn: anytype,
     cancel_token: ?*const CancellationToken,
-    proxy_buffer_limits: proxy_buffer_account.Limits,
-    proxy_buffer_observer: proxy_buffer_account.Observer,
-    proxy_buffer_capacity: proxy_buffer_account.AggregateCapacity,
+    reservation: *ProxyBufferReservation,
+    observer: proxy_buffer_account.Observer,
 ) !void {
-    var relay: [16 * 1024]u8 = undefined;
-    var upload_reservation = ProxyBufferReservation.init(.downstream_to_upstream, proxy_buffer_limits, proxy_buffer_observer, proxy_buffer_capacity);
-    try reserveUploadBytes(&upload_reservation, relay.len);
-    defer upload_reservation.releaseAll();
+    var relay: [http1_upload_relay_bytes]u8 = undefined;
 
     // Balanced on every exit — success, client abort, cancellation, upstream
     // failure — so the pause/resume difference reads as "relays stalled right
     // now" instead of drifting by one per aborted upload.
-    var stall = proxy_buffer_account.ReadStall.init(.downstream, proxy_buffer_observer);
+    var stall = proxy_buffer_account.ReadStall.init(.downstream, observer);
     defer stall.unpause();
 
     switch (sb.framing) {
         .length => |content_length| {
             var sent: usize = @min(sb.initial_bytes.len, content_length);
             if (sent > 0) {
-                // The bytes that arrived with the request head live in their own
-                // buffer, so they are reserved on top of the relay buffer.
-                try reserveUploadBytes(&upload_reservation, sent);
                 noteUpstreamWriteStall(fd, &stall);
                 transport.writeAll(sb.initial_bytes[0..sent]) catch |err| {
-                    upload_reservation.release(sent);
+                    reservation.release(sent);
                     return err;
                 };
                 stall.unpause();
-                upload_reservation.release(sent);
+                // Forwarded: the request head's body bytes are no longer held.
+                reservation.release(sent);
             }
             while (sent < content_length) {
                 if (cancelStopped(cancel_token)) return error.RequestCancelled;
@@ -1987,9 +2087,16 @@ fn relayStreamingUploadToHttp1(
             // extensions or trailers, which this hop does not forward.
             var reader = http.chunked_upload.Reader(@TypeOf(downstream_conn))
                 .init(downstream_conn, sb.initial_bytes, sb.max_body_bytes);
+            // The decoder borrows the whole raw request-head remainder —
+            // framing octets included, which is why the reservation covers the
+            // raw length rather than the decoded payload.
+            var head_bytes_held = sb.initial_bytes.len;
             while (true) {
                 if (cancelStopped(cancel_token)) return error.RequestCancelled;
                 const n = try reader.next(&relay);
+                // Give back what the decoder has finished with, before acting on
+                // `n`: the terminal call consumes borrowed trailer bytes too.
+                releaseDrainedHeadBytes(reservation, &head_bytes_held, reader.pendingBytes());
                 if (n == 0) break;
                 var size_buf: [24]u8 = undefined;
                 const size_line = std.fmt.bufPrint(&size_buf, "{x}\r\n", .{n}) catch unreachable;
@@ -2004,6 +2111,19 @@ fn relayStreamingUploadToHttp1(
             try transport.writeAll("0\r\n\r\n");
         },
     }
+}
+
+/// Release the request-head bytes a chunked decoder has consumed since the last
+/// check. `still_held` is what it still borrows; anything below the previous
+/// mark has been copied out and is no longer retained.
+fn releaseDrainedHeadBytes(
+    reservation: *ProxyBufferReservation,
+    head_bytes_held: *usize,
+    still_held: usize,
+) void {
+    if (still_held >= head_bytes_held.*) return;
+    reservation.release(head_bytes_held.* - still_held);
+    head_bytes_held.* = still_held;
 }
 
 /// Run one streaming proxy attempt over an already-connected `transport`: send
@@ -3000,6 +3120,50 @@ fn uploadTestLimits(hard: usize) proxy_buffer_account.Limits {
     };
 }
 
+/// Preflight then relay, in the order `sendStreamingProxyRequest` does, so
+/// tests exercise the same reservation lifetime production uses.
+fn runHttp1Upload(
+    transport: anytype,
+    fd: std.posix.fd_t,
+    sb: StreamingRequestBody,
+    downstream_conn: anytype,
+    limits: proxy_buffer_account.Limits,
+    observer: proxy_buffer_account.Observer,
+    capacity: proxy_buffer_account.AggregateCapacity,
+) !void {
+    var reservation = try preflightUploadReservation(
+        limits,
+        observer,
+        capacity,
+        http1_upload_relay_bytes,
+        uploadInitialBytesFootprint(sb),
+    );
+    defer reservation.releaseAll();
+    try relayStreamingUploadToHttp1(transport, fd, sb, downstream_conn, null, &reservation, observer);
+}
+
+/// The HTTP/2 mirror of `runHttp1Upload`.
+fn runHttp2Upload(
+    conn: anytype,
+    stream: anytype,
+    sb: StreamingRequestBody,
+    read_buf: []u8,
+    downstream_conn: anytype,
+    limits: proxy_buffer_account.Limits,
+    observer: proxy_buffer_account.Observer,
+    capacity: proxy_buffer_account.AggregateCapacity,
+) !void {
+    var reservation = try preflightUploadReservation(
+        limits,
+        observer,
+        capacity,
+        read_buf.len,
+        uploadInitialBytesFootprint(sb),
+    );
+    defer reservation.releaseAll();
+    try relayStreamingUploadToHttp2(conn, stream, sb, read_buf, downstream_conn, null, &reservation);
+}
+
 /// Drain `total` bytes from `fd` after `delay_ms`. The delay is what lets the
 /// relay observe an origin that has stopped consuming.
 fn slowUploadDrain(fd: std.posix.fd_t, delay_ms: u64, total: usize) void {
@@ -3061,23 +3225,21 @@ test "http1 upload relay reports a slow origin as a downstream read pause" {
 
     // Leave the origin's window already full, so the relay's first look at the
     // socket is guaranteed to find a stall rather than racing the drainer for
-    // one. `pollFdWritable` must agree, or the check below is not testing
-    // anything.
+    // one. The probe must agree, or the check below is not testing anything.
     const prefilled = try fillSocketSendBuffer(client_fd);
     try std.testing.expect(prefilled > 0);
-    try std.testing.expect(!try pollFdWritable(client_fd));
+    try std.testing.expectEqual(UpstreamWritability.blocked, pollUpstreamWritability(client_fd));
 
     const drainer = try std.Thread.spawn(.{}, slowUploadDrain, .{ peer_fd, @as(u64, 20), prefilled + payload.len });
     defer drainer.join();
 
     var counters = UploadBufferObserver{};
     var source = FakeUploadSource{ .data = payload };
-    try relayStreamingUploadToHttp1(
+    try runHttp1Upload(
         compat.netStreamFromFd(client_fd),
         client_fd,
         .{ .framing = .{ .length = payload.len } },
         &source,
-        null,
         uploadTestLimits(1024 * 1024),
         counters.observer(),
         .{},
@@ -3104,12 +3266,11 @@ test "http1 upload relay leaves nothing reserved when the client aborts mid-uplo
     var global = proxy_buffer_account.Aggregate.init(.global, 0);
     // Promises 8 KiB, delivers 4 KiB, then the client goes away.
     var source = FakeUploadSource{ .data = &[_]u8{'x'} ** 4096, .abort_after = 4096 };
-    try std.testing.expectError(error.ClientAborted, relayStreamingUploadToHttp1(
+    try std.testing.expectError(error.ClientAborted, runHttp1Upload(
         compat.netStreamFromFd(client_fd),
         client_fd,
         .{ .framing = .{ .length = 8192 } },
         &source,
-        null,
         uploadTestLimits(1024 * 1024),
         counters.observer(),
         .{ .global = &global },
@@ -3134,12 +3295,11 @@ test "http1 upload relay rejects an over-limit in-flight upload as a client faul
     var source = FakeUploadSource{ .data = "" };
     // The relay buffer alone consumes the whole per-stream budget, so the bytes
     // that arrived with the request head have nowhere to go.
-    try std.testing.expectError(error.RequestBufferLimitExceeded, relayStreamingUploadToHttp1(
+    try std.testing.expectError(error.RequestBufferLimitExceeded, runHttp1Upload(
         compat.netStreamFromFd(client_fd),
         client_fd,
         .{ .framing = .{ .length = 32 }, .initial_bytes = "inline-body-bytes" },
         &source,
-        null,
         uploadTestLimits(16 * 1024),
         counters.observer(),
         .{},
@@ -3170,12 +3330,11 @@ test "http1 upload relay refuses when a concurrent relay has taken the aggregate
     try in_flight.reserve(16 * 1024);
 
     var source = FakeUploadSource{ .data = "" };
-    try std.testing.expectError(error.ProxyBufferCapacityUnavailable, relayStreamingUploadToHttp1(
+    try std.testing.expectError(error.ProxyBufferCapacityUnavailable, runHttp1Upload(
         compat.netStreamFromFd(client_fd),
         client_fd,
         .{ .framing = .{ .length = 0 } },
         &source,
-        null,
         limits,
         counters.observer(),
         capacity,
@@ -3190,6 +3349,367 @@ test "http1 upload relay refuses when a concurrent relay has taken the aggregate
     try std.testing.expectEqual(@as(usize, 0), global.currentBytes(.downstream_to_upstream));
     try std.testing.expectEqual(@as(usize, 0), counters.reserved);
     try std.testing.expectEqual(@as(usize, 0), counters.retained);
+}
+
+/// Has anything arrived on `fd` yet? Zero timeout — used to assert an origin
+/// was left untouched, so it must not wait for something that will never come.
+fn peerHasBytes(fd: std.posix.fd_t) !bool {
+    var pfds = [_]std.posix.pollfd{.{ .fd = fd, .events = std.posix.POLL.IN, .revents = 0 }};
+    const ready = try std.posix.poll(&pfds, 0);
+    return ready != 0 and (pfds[0].revents & std.posix.POLL.IN) != 0;
+}
+
+test "http1 chunked upload accounts the raw request-head remainder and releases it as it drains" {
+    const fds = try makeBlockingSocketpair();
+    const client_fd = fds[0];
+    const peer_fd = fds[1];
+    defer _ = std.c.close(client_fd);
+    defer _ = std.c.close(peer_fd);
+
+    var counters = UploadBufferObserver{};
+    var global = proxy_buffer_account.Aggregate.init(.global, 0);
+    const limits = uploadTestLimits(1024 * 1024);
+    const capacity = proxy_buffer_account.AggregateCapacity{ .global = &global };
+
+    // The whole chunked body arrived with the request head. The decoder borrows
+    // that raw slice — framing octets included — so all 14 bytes are retained
+    // alongside the relay buffer even though only 5 are payload.
+    const head_remainder = "5\r\nhello\r\n0\r\n\r\n";
+    const sb = StreamingRequestBody{
+        .framing = .chunked,
+        .initial_bytes = head_remainder,
+        .max_body_bytes = 1024,
+    };
+    try std.testing.expectEqual(@as(usize, head_remainder.len), uploadInitialBytesFootprint(sb));
+
+    var source = FakeUploadSource{ .data = "" };
+    var reservation = try preflightUploadReservation(
+        limits,
+        counters.observer(),
+        capacity,
+        http1_upload_relay_bytes,
+        uploadInitialBytesFootprint(sb),
+    );
+    defer reservation.releaseAll();
+    try std.testing.expectEqual(
+        http1_upload_relay_bytes + head_remainder.len,
+        counters.peak_reserved,
+    );
+
+    try relayStreamingUploadToHttp1(
+        compat.netStreamFromFd(client_fd),
+        client_fd,
+        sb,
+        &source,
+        null,
+        &reservation,
+        counters.observer(),
+    );
+
+    // The relay gave the head remainder back as the decoder drained it, rather
+    // than holding the peak until teardown — only the relay buffer is left.
+    try std.testing.expectEqual(http1_upload_relay_bytes, reservation.account.snapshot().current);
+    try std.testing.expectEqual(http1_upload_relay_bytes, global.currentBytes(.downstream_to_upstream));
+
+    reservation.releaseAll();
+    try std.testing.expectEqual(@as(usize, 0), counters.reserved);
+    try std.testing.expectEqual(@as(usize, 0), counters.retained);
+    try std.testing.expectEqual(@as(usize, 0), global.currentBytes(.downstream_to_upstream));
+
+    // The re-chunked body did reach the origin.
+    var seen: [64]u8 = undefined;
+    const got = std.c.read(peer_fd, &seen, seen.len);
+    try std.testing.expect(got > 0);
+    try std.testing.expectEqualStrings("5\r\nhello\r\n0\r\n\r\n", seen[0..@intCast(got)]);
+}
+
+test "chunked request-head remainder counts against the aggregate scope" {
+    const fds = try makeBlockingSocketpair();
+    const client_fd = fds[0];
+    const peer_fd = fds[1];
+    defer _ = std.c.close(client_fd);
+    defer _ = std.c.close(peer_fd);
+
+    const limits = uploadTestLimits(64 * 1024);
+    var counters = UploadBufferObserver{};
+    var global = proxy_buffer_account.Aggregate.init(.global, 64 * 1024);
+    const capacity = proxy_buffer_account.AggregateCapacity{ .global = &global };
+
+    // Concurrent work already holds 40 KiB. The relay buffer still fits; the
+    // request-head remainder is what tips the scope over — which it could only
+    // do if that remainder is accounted at all.
+    var in_flight = ProxyBufferReservation.init(.downstream_to_upstream, limits, counters.observer(), capacity);
+    try in_flight.reserve(40 * 1024);
+
+    const head_remainder = [_]u8{'z'} ** (12 * 1024);
+    var source = FakeUploadSource{ .data = "" };
+    try std.testing.expectError(error.ProxyBufferCapacityUnavailable, runHttp1Upload(
+        compat.netStreamFromFd(client_fd),
+        client_fd,
+        .{ .framing = .chunked, .initial_bytes = &head_remainder, .max_body_bytes = 1 << 20 },
+        &source,
+        limits,
+        counters.observer(),
+        capacity,
+    ));
+
+    try std.testing.expectEqual(@as(u64, 1), counters.aggregate_limit_exceeded);
+    try std.testing.expectEqual(proxy_buffer_account.Scope.global, counters.last_aggregate_scope.?);
+    // The refused upload rolled back completely; the concurrent holder is intact.
+    try std.testing.expectEqual(@as(usize, 40 * 1024), global.currentBytes(.downstream_to_upstream));
+
+    in_flight.releaseAll();
+    try std.testing.expectEqual(@as(usize, 0), global.currentBytes(.downstream_to_upstream));
+    try std.testing.expectEqual(@as(usize, 0), counters.reserved);
+    try std.testing.expectEqual(@as(usize, 0), counters.retained);
+}
+
+test "malformed chunked framing cannot leak the request-head reservation" {
+    const fds = try makeBlockingSocketpair();
+    const client_fd = fds[0];
+    const peer_fd = fds[1];
+    defer _ = std.c.close(client_fd);
+    defer _ = std.c.close(peer_fd);
+
+    var counters = UploadBufferObserver{};
+    var global = proxy_buffer_account.Aggregate.init(.global, 0);
+    var source = FakeUploadSource{ .data = "" };
+    try std.testing.expectError(error.InvalidChunkedUpload, runHttp1Upload(
+        compat.netStreamFromFd(client_fd),
+        client_fd,
+        // Not a chunk-size line.
+        .{ .framing = .chunked, .initial_bytes = "not-hex\r\n", .max_body_bytes = 1024 },
+        &source,
+        uploadTestLimits(1024 * 1024),
+        counters.observer(),
+        .{ .global = &global },
+    ));
+
+    try std.testing.expectEqual(@as(usize, 0), counters.reserved);
+    try std.testing.expectEqual(@as(usize, 0), counters.retained);
+    try std.testing.expectEqual(@as(usize, 0), global.currentBytes(.downstream_to_upstream));
+}
+
+test "a client that vanishes mid-chunk releases the request-head reservation" {
+    const fds = try makeBlockingSocketpair();
+    const client_fd = fds[0];
+    const peer_fd = fds[1];
+    defer _ = std.c.close(client_fd);
+    defer _ = std.c.close(peer_fd);
+
+    var counters = UploadBufferObserver{};
+    var global = proxy_buffer_account.Aggregate.init(.global, 0);
+    // Announces a 16-byte chunk, supplies none of it, then goes away.
+    var source = FakeUploadSource{ .data = "", .abort_after = 0 };
+    try std.testing.expectError(error.ClientAborted, runHttp1Upload(
+        compat.netStreamFromFd(client_fd),
+        client_fd,
+        .{ .framing = .chunked, .initial_bytes = "10\r\n", .max_body_bytes = 1024 },
+        &source,
+        uploadTestLimits(1024 * 1024),
+        counters.observer(),
+        .{ .global = &global },
+    ));
+
+    try std.testing.expectEqual(@as(usize, 0), counters.reserved);
+    try std.testing.expectEqual(@as(usize, 0), counters.retained);
+    try std.testing.expectEqual(@as(usize, 0), global.currentBytes(.downstream_to_upstream));
+}
+
+test "a broken upstream socket is not counted as backpressure" {
+    const fds = try makeBlockingSocketpair();
+    const client_fd = fds[0];
+    const peer_fd = fds[1];
+    defer _ = std.c.close(client_fd);
+
+    // The origin is gone, not slow. `poll` still reports the descriptor ready
+    // — for POLLERR/POLLHUP — so a naive readiness test would call this a full
+    // send buffer and record a pause the write is about to invalidate.
+    _ = std.c.close(peer_fd);
+
+    var counters = UploadBufferObserver{};
+    var stall = proxy_buffer_account.ReadStall.init(.downstream, counters.observer());
+    try std.testing.expect(pollUpstreamWritability(client_fd) != .blocked);
+    noteUpstreamWriteStall(client_fd, &stall);
+
+    try std.testing.expectEqual(@as(u64, 0), counters.pauses);
+    try std.testing.expectEqual(@as(u64, 0), counters.resumes);
+    try std.testing.expect(!stall.paused);
+}
+
+test "http1 upload capacity is refused before the request head reaches the origin" {
+    const fds = try makeBlockingSocketpair();
+    const client_fd = fds[0];
+    const peer_fd = fds[1];
+    defer _ = std.c.close(client_fd);
+    defer _ = std.c.close(peer_fd);
+
+    const limits = uploadTestLimits(16 * 1024);
+    var counters = UploadBufferObserver{};
+    var global = proxy_buffer_account.Aggregate.init(.global, 16 * 1024);
+    const capacity = proxy_buffer_account.AggregateCapacity{ .global = &global };
+
+    // The process account is already spoken for, so this upload cannot be
+    // admitted at all.
+    var in_flight = ProxyBufferReservation.init(.downstream_to_upstream, limits, counters.observer(), capacity);
+    try in_flight.reserve(16 * 1024);
+    defer in_flight.releaseAll();
+
+    var source = FakeUploadSource{ .data = "" };
+    const uri = try std.Uri.parse("http://origin.test/upload");
+    try std.testing.expectError(error.ProxyBufferCapacityUnavailable, sendStreamingProxyRequest(
+        std.testing.allocator,
+        compat.netStreamFromFd(client_fd),
+        client_fd,
+        uri,
+        "POST",
+        &.{},
+        "",
+        .{ .framing = .{ .length = 4096 } },
+        &source,
+        null,
+        limits,
+        counters.observer(),
+        capacity,
+    ));
+
+    // The whole point: the origin never saw a request it would have had to
+    // decide what to do with. A refusal after the head went out would leave a
+    // real, possibly side-effecting request half-delivered.
+    try std.testing.expect(!try peerHasBytes(peer_fd));
+}
+
+/// A prior-knowledge h2c origin that completes just enough handshake for the
+/// pool to hand back a connection, then records everything else the client
+/// sends. Used to prove a request the proxy refused locally never reached it.
+const H2CapacityProbe = struct {
+    listen_fd: std.posix.fd_t,
+    recorded: [4096]u8 = undefined,
+    len: usize = 0,
+};
+
+fn h2PrefaceOnlyOrigin(probe: *H2CapacityProbe) void {
+    const conn = std.c.accept(probe.listen_fd, null, null);
+    if (conn < 0) return;
+    defer _ = std.c.close(conn);
+
+    var preface: [24]u8 = undefined;
+    var got: usize = 0;
+    while (got < preface.len) {
+        const n = std.c.read(conn, preface[got..].ptr, preface.len - got);
+        if (n <= 0) return;
+        got += @intCast(n);
+    }
+    // An empty SETTINGS frame is all `acquire` needs to consider the
+    // connection usable.
+    const settings = [_]u8{ 0, 0, 0, 0x04, 0, 0, 0, 0, 0 };
+    _ = std.c.write(conn, &settings, settings.len);
+
+    while (probe.len < probe.recorded.len) {
+        var pfd = [_]std.posix.pollfd{.{ .fd = conn, .events = std.posix.POLL.IN, .revents = 0 }};
+        const ready = std.posix.poll(&pfd, 500) catch return;
+        if (ready == 0) return;
+        const n = std.c.read(conn, probe.recorded[probe.len..].ptr, probe.recorded.len - probe.len);
+        if (n <= 0) return;
+        probe.len += @intCast(n);
+    }
+}
+
+/// Walk an HTTP/2 frame stream looking for one frame type. Frames are
+/// length-prefixed, so this needs no protocol state.
+fn h2StreamContainsFrameType(bytes: []const u8, wanted: u8) bool {
+    var i: usize = 0;
+    while (i + 9 <= bytes.len) {
+        const payload_len = (@as(usize, bytes[i]) << 16) | (@as(usize, bytes[i + 1]) << 8) | @as(usize, bytes[i + 2]);
+        if (bytes[i + 3] == wanted) return true;
+        i += 9 + payload_len;
+    }
+    return false;
+}
+
+test "http2 upload capacity is refused before HEADERS reach the origin" {
+    const listen_fd = std.c.socket(std.posix.AF.INET, std.posix.SOCK.STREAM, std.posix.IPPROTO.TCP);
+    try std.testing.expect(listen_fd >= 0);
+    defer _ = std.c.close(listen_fd);
+    _ = std.c.setsockopt(listen_fd, std.posix.SOL.SOCKET, std.posix.SO.REUSEADDR, std.mem.asBytes(&@as(c_int, 1)), @sizeOf(c_int));
+    const sin: std.c.sockaddr.in = .{
+        .family = std.posix.AF.INET,
+        .port = std.mem.nativeToBig(u16, 0),
+        .addr = @bitCast([4]u8{ 127, 0, 0, 1 }),
+        .zero = [8]u8{ 0, 0, 0, 0, 0, 0, 0, 0 },
+    };
+    try std.testing.expect(std.c.bind(listen_fd, @ptrCast(&sin), @sizeOf(std.c.sockaddr.in)) == 0);
+    try std.testing.expect(std.c.listen(listen_fd, 4) == 0);
+    var bound: std.c.sockaddr.in = undefined;
+    var bound_len: std.posix.socklen_t = @sizeOf(std.c.sockaddr.in);
+    try std.testing.expect(std.c.getsockname(listen_fd, @ptrCast(&bound), &bound_len) == 0);
+    const port = std.mem.bigToNative(u16, bound.port);
+
+    var probe = H2CapacityProbe{ .listen_fd = listen_fd };
+    const origin = try std.Thread.spawn(.{}, h2PrefaceOnlyOrigin, .{&probe});
+
+    const limits = uploadTestLimits(1024 * 1024);
+    var counters = UploadBufferObserver{};
+    // The process account is full before the request starts.
+    var global = proxy_buffer_account.Aggregate.init(.global, 16 * 1024);
+    var in_flight = ProxyBufferReservation.init(
+        .downstream_to_upstream,
+        limits,
+        counters.observer(),
+        .{ .global = &global },
+    );
+    try in_flight.reserve(16 * 1024);
+    defer in_flight.releaseAll();
+
+    var read_buf: [16 * 1024]u8 = undefined;
+    var source = FakeUploadSource{ .data = "" };
+    var captured = std.array_list.Managed(u8).init(std.testing.allocator);
+    defer captured.deinit();
+    var security = http.security_headers.SecurityHeaders{};
+    var url_buf: [64]u8 = undefined;
+    const uri = try std.Uri.parse(try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/upload", .{port}));
+
+    {
+        var pool = http.upstream_h2.H2ConnPool.init(std.testing.allocator, .{});
+        defer pool.deinit();
+
+        try std.testing.expectError(error.ProxyBufferCapacityUnavailable, streamViaH2Pool(
+            std.testing.allocator,
+            &pool,
+            null,
+            "127.0.0.1",
+            port,
+            null, // prior-knowledge h2c
+            uri,
+            "POST",
+            &.{},
+            "",
+            .{ .framing = .{ .length = 4096 } },
+            &read_buf,
+            &source,
+            CaptureWriter{ .list = &captured },
+            &security,
+            null,
+            null,
+            "test-correlation-id",
+            2000,
+            2000,
+            null,
+            limits,
+            counters.observer(),
+            &global,
+        ));
+    }
+    origin.join();
+
+    // The origin completed a connection but was never asked to do any work:
+    // refusing after HEADERS would have left it holding a request whose body
+    // never arrives, and any side effects that came with it.
+    try std.testing.expect(!h2StreamContainsFrameType(probe.recorded[0..probe.len], 0x01));
+    // Nothing beyond the deliberately-held reservation is outstanding: the
+    // refused request rolled back everything it touched.
+    try std.testing.expectEqual(@as(usize, 16 * 1024), counters.retained);
+    try std.testing.expectEqual(@as(usize, 16 * 1024), global.currentBytes(.downstream_to_upstream));
 }
 
 const FakeH2UploadStream = struct { id: u32 = 1 };
@@ -3221,13 +3741,12 @@ test "http2 upload relay reserves the relay buffer once, not once per DATA frame
     var read_buf: [16 * 1024]u8 = undefined;
     var source = FakeUploadSource{ .data = payload };
 
-    try relayStreamingUploadToHttp2(
+    try runHttp2Upload(
         &conn,
         &stream,
         .{ .framing = .{ .length = payload.len } },
         &read_buf,
         &source,
-        null,
         uploadTestLimits(1024 * 1024),
         counters.observer(),
         .{ .global = &global },
@@ -3242,6 +3761,47 @@ test "http2 upload relay reserves the relay buffer once, not once per DATA frame
     try std.testing.expectEqual(@as(usize, 0), global.currentBytes(.downstream_to_upstream));
 }
 
+test "http2 chunked upload accounts and releases the raw request-head remainder" {
+    var conn = FakeH2UploadConn{};
+    var stream = FakeH2UploadStream{};
+    var counters = UploadBufferObserver{};
+    var global = proxy_buffer_account.Aggregate.init(.global, 0);
+    const limits = uploadTestLimits(1024 * 1024);
+    const capacity = proxy_buffer_account.AggregateCapacity{ .global = &global };
+    var read_buf: [16 * 1024]u8 = undefined;
+
+    const head_remainder = "5\r\nhello\r\n0\r\n\r\n";
+    const sb = StreamingRequestBody{
+        .framing = .chunked,
+        .initial_bytes = head_remainder,
+        .max_body_bytes = 1024,
+    };
+    var source = FakeUploadSource{ .data = "" };
+
+    var reservation = try preflightUploadReservation(
+        limits,
+        counters.observer(),
+        capacity,
+        read_buf.len,
+        uploadInitialBytesFootprint(sb),
+    );
+    defer reservation.releaseAll();
+    try std.testing.expectEqual(read_buf.len + head_remainder.len, counters.peak_reserved);
+
+    try relayStreamingUploadToHttp2(&conn, &stream, sb, &read_buf, &source, null, &reservation);
+
+    // Decoded payload went out as DATA; the raw framing octets were accounted
+    // and then handed back as the decoder consumed them.
+    try std.testing.expectEqual(@as(usize, 5), conn.written);
+    try std.testing.expect(conn.end_stream);
+    try std.testing.expectEqual(read_buf.len, reservation.account.snapshot().current);
+
+    reservation.releaseAll();
+    try std.testing.expectEqual(@as(usize, 0), counters.reserved);
+    try std.testing.expectEqual(@as(usize, 0), counters.retained);
+    try std.testing.expectEqual(@as(usize, 0), global.currentBytes(.downstream_to_upstream));
+}
+
 test "http2 upload relay releases the aggregate when the client aborts" {
     var conn = FakeH2UploadConn{};
     var stream = FakeH2UploadStream{};
@@ -3250,13 +3810,12 @@ test "http2 upload relay releases the aggregate when the client aborts" {
     var read_buf: [16 * 1024]u8 = undefined;
     var source = FakeUploadSource{ .data = &[_]u8{'y'} ** 1024, .abort_after = 1024 };
 
-    try std.testing.expectError(error.ClientAborted, relayStreamingUploadToHttp2(
+    try std.testing.expectError(error.ClientAborted, runHttp2Upload(
         &conn,
         &stream,
         .{ .framing = .{ .length = 64 * 1024 } },
         &read_buf,
         &source,
-        null,
         uploadTestLimits(1024 * 1024),
         counters.observer(),
         .{ .global = &global },

--- a/src/gateway_proxy.zig
+++ b/src/gateway_proxy.zig
@@ -1047,6 +1047,21 @@ fn streamViaH2Pool(
                         if (capacity_abort) return error.ProxyBufferCapacityUnavailable;
                         return err;
                     };
+                    // The upload is done: `read_buf` holds no client bytes any
+                    // more, so the request-direction claim ends here rather
+                    // than at the end of the exchange. Carrying it through
+                    // `waitStreamingResponseHead` and the response relay would
+                    // occupy upload capacity for as long as the response takes
+                    // — long enough for one slow response to make unrelated
+                    // uploads fail with a 503 they should never have seen, and
+                    // long enough for the direction gauges to keep reporting an
+                    // upload that finished. (The HTTP/1 path has no equivalent
+                    // window: `sendStreamingProxyRequest` returns, releasing
+                    // its reservation, before the response is read.)
+                    if (upload_reservation) |*reservation| {
+                        reservation.releaseAll();
+                        upload_reservation = null;
+                    }
                 }
 
                 conn.waitStreamingResponseHead(stream) catch |err| {
@@ -3613,6 +3628,236 @@ fn h2PrefaceOnlyOrigin(probe: *H2CapacityProbe) void {
         if (n <= 0) return;
         probe.len += @intCast(n);
     }
+}
+
+fn readExactlyFromFd(fd: std.posix.fd_t, out: []u8) bool {
+    var got: usize = 0;
+    while (got < out.len) {
+        const n = std.c.read(fd, out[got..].ptr, out.len - got);
+        if (n <= 0) return false;
+        got += @intCast(n);
+    }
+    return true;
+}
+
+fn sleepMs(ms: u32) void {
+    var no_fds: [0]std.posix.pollfd = .{};
+    _ = std.posix.poll(&no_fds, @intCast(ms)) catch {};
+}
+
+/// Bind a loopback listener on an ephemeral port and report it.
+fn listenLoopbackEphemeral() !struct { fd: std.posix.fd_t, port: u16 } {
+    const listen_fd = std.c.socket(std.posix.AF.INET, std.posix.SOCK.STREAM, std.posix.IPPROTO.TCP);
+    if (listen_fd < 0) return error.SocketFailed;
+    errdefer _ = std.c.close(listen_fd);
+    _ = std.c.setsockopt(listen_fd, std.posix.SOL.SOCKET, std.posix.SO.REUSEADDR, std.mem.asBytes(&@as(c_int, 1)), @sizeOf(c_int));
+    const sin: std.c.sockaddr.in = .{
+        .family = std.posix.AF.INET,
+        .port = std.mem.nativeToBig(u16, 0),
+        .addr = @bitCast([4]u8{ 127, 0, 0, 1 }),
+        .zero = [8]u8{ 0, 0, 0, 0, 0, 0, 0, 0 },
+    };
+    if (std.c.bind(listen_fd, @ptrCast(&sin), @sizeOf(std.c.sockaddr.in)) != 0) return error.BindFailed;
+    if (std.c.listen(listen_fd, 4) != 0) return error.ListenFailed;
+    var bound: std.c.sockaddr.in = undefined;
+    var bound_len: std.posix.socklen_t = @sizeOf(std.c.sockaddr.in);
+    if (std.c.getsockname(listen_fd, @ptrCast(&bound), &bound_len) != 0) return error.SockNameFailed;
+    return .{ .fd = listen_fd, .port = std.mem.bigToNative(u16, bound.port) };
+}
+
+/// An h2c origin that consumes a whole upload, answers with response headers,
+/// and then holds the body back until told to release it. That gap is the
+/// window where the upload has finished but the exchange has not, which is
+/// exactly where a request-direction reservation must no longer be held.
+const H2SlowResponseOrigin = struct {
+    listen_fd: std.posix.fd_t,
+    head_sent: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    release_body: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+};
+
+fn h2SlowResponseServe(origin: *H2SlowResponseOrigin) void {
+    const conn = std.c.accept(origin.listen_fd, null, null);
+    if (conn < 0) return;
+    defer _ = std.c.close(conn);
+
+    var preface: [24]u8 = undefined;
+    if (!readExactlyFromFd(conn, &preface)) return;
+    const settings = [_]u8{ 0, 0, 0, 0x04, 0, 0, 0, 0, 0 };
+    _ = std.c.write(conn, &settings, settings.len);
+
+    // Drain frames until the request stream ends, remembering its id.
+    var stream_id: u32 = 0;
+    while (true) {
+        var hdr: [9]u8 = undefined;
+        if (!readExactlyFromFd(conn, &hdr)) return;
+        const payload_len = (@as(usize, hdr[0]) << 16) | (@as(usize, hdr[1]) << 8) | @as(usize, hdr[2]);
+        const typ = hdr[3];
+        const flags = hdr[4];
+        const sid = std.mem.readInt(u32, hdr[5..9], .big) & 0x7fff_ffff;
+        var scratch: [4096]u8 = undefined;
+        var remaining = payload_len;
+        while (remaining > 0) {
+            const take = @min(remaining, scratch.len);
+            if (!readExactlyFromFd(conn, scratch[0..take])) return;
+            remaining -= take;
+        }
+        if (typ == 0x01) stream_id = sid; // HEADERS
+        if (typ == 0x00 and (flags & 0x01) != 0) break; // DATA with END_STREAM
+    }
+    if (stream_id == 0) return;
+
+    // HEADERS, END_HEADERS, one byte of HPACK: `:status: 200` is static-table
+    // index 8, so an indexed header field encodes the whole block.
+    var head_frame = [_]u8{ 0, 0, 1, 0x01, 0x04, 0, 0, 0, 0, 0x88 };
+    std.mem.writeInt(u32, head_frame[5..9], stream_id, .big);
+    _ = std.c.write(conn, &head_frame, head_frame.len);
+    origin.head_sent.store(true, .release);
+
+    while (!origin.release_body.load(.acquire)) sleepMs(5);
+
+    var body_frame = [_]u8{ 0, 0, 2, 0x00, 0x01, 0, 0, 0, 0, 'o', 'k' };
+    std.mem.writeInt(u32, body_frame[5..9], stream_id, .big);
+    _ = std.c.write(conn, &body_frame, body_frame.len);
+
+    var drain: [256]u8 = undefined;
+    while (true) {
+        const got = std.c.read(conn, &drain, drain.len);
+        if (got <= 0) break;
+    }
+}
+
+/// Runs one `streamViaH2Pool` exchange on its own thread so the test can
+/// observe accounting while the exchange is mid-flight.
+const H2ExchangeCtx = struct {
+    pool: *http.upstream_h2.H2ConnPool,
+    port: u16,
+    uri: std.Uri,
+    read_buf: []u8,
+    source: *FakeUploadSource,
+    captured: *std.array_list.Managed(u8),
+    security: *const http.security_headers.SecurityHeaders,
+    limits: proxy_buffer_account.Limits,
+    observer: proxy_buffer_account.Observer,
+    global: *proxy_buffer_account.Aggregate,
+    finished: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    failed: bool = false,
+    status: u16 = 0,
+};
+
+fn runH2ExchangeThread(ctx: *H2ExchangeCtx) void {
+    defer ctx.finished.store(true, .release);
+    const result = streamViaH2Pool(
+        std.testing.allocator,
+        ctx.pool,
+        null,
+        "127.0.0.1",
+        ctx.port,
+        null, // prior-knowledge h2c
+        ctx.uri,
+        "POST",
+        &.{},
+        "",
+        .{ .framing = .{ .length = 8 } },
+        ctx.read_buf,
+        ctx.source,
+        CaptureWriter{ .list = ctx.captured },
+        ctx.security,
+        null,
+        null,
+        "lifetime-test",
+        2000,
+        5000,
+        null,
+        ctx.limits,
+        ctx.observer,
+        ctx.global,
+    ) catch {
+        ctx.failed = true;
+        return;
+    };
+    ctx.status = result.status_code;
+}
+
+test "an http2 upload releases request-direction capacity before its response completes" {
+    const listener = try listenLoopbackEphemeral();
+    defer _ = std.c.close(listener.fd);
+
+    var origin = H2SlowResponseOrigin{ .listen_fd = listener.fd };
+    const origin_thread = try std.Thread.spawn(.{}, h2SlowResponseServe, .{&origin});
+
+    var read_buf: [16 * 1024]u8 = undefined;
+    const limits = uploadTestLimits(1024 * 1024);
+    // Exactly one relay buffer fits per direction. The upload's claim is
+    // therefore the only thing that can keep a second upload out.
+    var global = proxy_buffer_account.Aggregate.init(.global, read_buf.len);
+
+    var counters = UploadBufferObserver{};
+    var source = FakeUploadSource{ .data = "upload!!" };
+    var captured = std.array_list.Managed(u8).init(std.testing.allocator);
+    defer captured.deinit();
+    var security = http.security_headers.SecurityHeaders{};
+    var url_buf: [64]u8 = undefined;
+    const uri = try std.Uri.parse(try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/upload", .{listener.port}));
+
+    var pool = http.upstream_h2.H2ConnPool.init(std.testing.allocator, .{});
+    var ctx = H2ExchangeCtx{
+        .pool = &pool,
+        .port = listener.port,
+        .uri = uri,
+        .read_buf = &read_buf,
+        .source = &source,
+        .captured = &captured,
+        .security = &security,
+        .limits = limits,
+        .observer = counters.observer(),
+        .global = &global,
+    };
+    const exchange = try std.Thread.spawn(.{}, runH2ExchangeThread, .{&ctx});
+
+    // The origin has taken the whole upload and answered with headers; the
+    // response body is still being withheld, so the exchange is mid-flight.
+    var waited: u32 = 0;
+    while (!origin.head_sent.load(.acquire) and waited < 5000) : (waited += 5) sleepMs(5);
+    try std.testing.expect(origin.head_sent.load(.acquire));
+
+    // The upload finished, so its capacity must be back — even though the
+    // exchange has not. Bounded wait, because the release happens on the
+    // exchange thread just after the relay returns; the budget is well inside
+    // the exchange's own read deadline so a regression fails here on the
+    // reservation rather than later on a timeout.
+    waited = 0;
+    while (global.currentBytes(.downstream_to_upstream) != 0 and waited < 1000) : (waited += 5) sleepMs(5);
+    // Checked first: it is what makes the next assertion meaningful — the
+    // capacity came back while the exchange was still running, not because it
+    // ended.
+    try std.testing.expect(!ctx.finished.load(.acquire));
+    try std.testing.expectEqual(@as(usize, 0), global.currentBytes(.downstream_to_upstream));
+
+    // And the capacity is genuinely usable: a second upload can take it. With
+    // the claim held for the whole exchange this reservation was refused, which
+    // is the false `503 proxy_buffer_saturated` an unrelated client would see.
+    var other = UploadBufferObserver{};
+    var second_upload = ProxyBufferReservation.init(
+        .downstream_to_upstream,
+        limits,
+        other.observer(),
+        .{ .global = &global },
+    );
+    try second_upload.reserve(read_buf.len);
+    second_upload.releaseAll();
+
+    origin.release_body.store(true, .release);
+    exchange.join();
+    try std.testing.expect(!ctx.failed);
+    try std.testing.expectEqual(@as(u16, 200), ctx.status);
+
+    pool.deinit();
+    origin_thread.join();
+
+    try std.testing.expectEqual(@as(usize, 0), global.currentBytes(.downstream_to_upstream));
+    try std.testing.expectEqual(@as(usize, 0), global.currentBytes(.upstream_to_downstream));
+    try std.testing.expectEqual(@as(usize, 0), counters.reserved);
+    try std.testing.expectEqual(@as(usize, 0), counters.retained);
 }
 
 /// Walk an HTTP/2 frame stream looking for one frame type. Frames are

--- a/src/gateway_proxy_runtime.zig
+++ b/src/gateway_proxy_runtime.zig
@@ -570,6 +570,16 @@ pub fn handleLocationProxyPass(
                     ctx.setUpstreamResult(resolved.upstream_host, @intFromEnum(http.Status.service_unavailable), 0);
                     return @intFromEnum(http.Status.service_unavailable);
                 }
+                // The upload's in-flight bytes outgrew the per-stream buffer
+                // hard limit (#140). Unlike the aggregate refusal above this is
+                // about *this* request rather than proxy-wide saturation, so it
+                // is the client's 413 and not a 503 — and, being a client fault
+                // raised before commitment, it is not charged to the origin.
+                if (err == error.RequestBufferLimitExceeded) {
+                    try sendApiError(allocator, writer, .payload_too_large, "payload_too_large", "Request body too large", correlation_id, false, state);
+                    ctx.setUpstreamResult(resolved.upstream_host, @intFromEnum(http.Status.payload_too_large), 0);
+                    return @intFromEnum(http.Status.payload_too_large);
+                }
                 // The client's own chunked framing was bad or its upload
                 // outgrew the request-body maximum (#139). Both are client
                 // faults raised before any response byte is committed, so the

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -1884,7 +1884,7 @@ pub const GatewayState = struct {
     /// an operator can put next to the configured limit.
     fn appendProxyBufferAggregatePrometheus(self: *GatewayState, out: *std.array_list.Managed(u8)) !void {
         try out.appendSlice(
-            \\# HELP tardigrade_proxy_buffer_aggregate_bytes_current Bytes reserved at the aggregate scope the configured hard limit is enforced against (HTTP/2 streaming response queues)
+            \\# HELP tardigrade_proxy_buffer_aggregate_bytes_current Bytes reserved at the aggregate scope the configured hard limit is enforced against (HTTP/2 stream queues, HTTP/1 relay buffers, and request-direction upload buffers)
             \\# TYPE tardigrade_proxy_buffer_aggregate_bytes_current gauge
             \\
         );

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -110,6 +110,32 @@ fn appendUpstreamLabelMetric(
     try out.appendSlice("\n");
 }
 
+/// Per-origin series that also carry the buffer `direction`. Cardinality stays
+/// bounded: two fixed directions per configured origin, and the direction label
+/// takes the same values as the process-wide buffer family.
+fn appendUpstreamDirectionLabelMetric(
+    out: *std.array_list.Managed(u8),
+    name: []const u8,
+    upstream: []const u8,
+    direction: http.proxy_buffer_account.Direction,
+    comptime value_fmt: []const u8,
+    value_args: anytype,
+) !void {
+    try out.appendSlice(name);
+    try out.appendSlice("{upstream=\"");
+    for (upstream) |c| switch (c) {
+        '\\' => try out.appendSlice("\\\\"),
+        '"' => try out.appendSlice("\\\""),
+        '\n' => try out.appendSlice("\\n"),
+        else => try out.append(c),
+    };
+    try out.appendSlice("\",direction=\"");
+    try out.appendSlice(direction.label());
+    try out.appendSlice("\"} ");
+    try out.print(value_fmt, value_args);
+    try out.appendSlice("\n");
+}
+
 pub const UpstreamPoolView = struct {
     fallback_url: []const u8,
     primary_urls: []const []const u8,
@@ -1773,9 +1799,9 @@ pub const GatewayState = struct {
                 \\# TYPE tardigrade_upstream_h2_pool_stream_resets_total counter
                 \\# HELP tardigrade_upstream_h2_pool_goaway_total GOAWAY frames received per origin
                 \\# TYPE tardigrade_upstream_h2_pool_goaway_total counter
-                \\# HELP tardigrade_upstream_h2_pool_buffered_bytes Response bytes currently queued in HTTP/2 stream buffers per origin
+                \\# HELP tardigrade_upstream_h2_pool_buffered_bytes Bytes currently held against this origin's proxy buffer account, by direction
                 \\# TYPE tardigrade_upstream_h2_pool_buffered_bytes gauge
-                \\# HELP tardigrade_upstream_h2_pool_buffer_limit_exceeded_total Origin-scope proxy buffer hard-limit refusals per origin
+                \\# HELP tardigrade_upstream_h2_pool_buffer_limit_exceeded_total Origin-scope proxy buffer hard-limit refusals per origin, by direction
                 \\# TYPE tardigrade_upstream_h2_pool_buffer_limit_exceeded_total counter
                 \\
             );
@@ -1784,8 +1810,13 @@ pub const GatewayState = struct {
                 try appendUpstreamLabelMetric(out, "tardigrade_upstream_h2_pool_streams_active", snap.origin, "{d}", .{snap.streams_active});
                 try appendUpstreamLabelMetric(out, "tardigrade_upstream_h2_pool_stream_resets_total", snap.origin, "{d}", .{snap.stream_resets_total});
                 try appendUpstreamLabelMetric(out, "tardigrade_upstream_h2_pool_goaway_total", snap.origin, "{d}", .{snap.goaway_total});
-                try appendUpstreamLabelMetric(out, "tardigrade_upstream_h2_pool_buffered_bytes", snap.origin, "{d}", .{snap.buffered_bytes});
-                try appendUpstreamLabelMetric(out, "tardigrade_upstream_h2_pool_buffer_limit_exceeded_total", snap.origin, "{d}", .{snap.buffer_limit_exceeded_total});
+                inline for (.{
+                    http.proxy_buffer_account.Direction.downstream_to_upstream,
+                    http.proxy_buffer_account.Direction.upstream_to_downstream,
+                }) |direction| {
+                    try appendUpstreamDirectionLabelMetric(out, "tardigrade_upstream_h2_pool_buffered_bytes", snap.origin, direction, "{d}", .{snap.bufferedBytes(direction)});
+                    try appendUpstreamDirectionLabelMetric(out, "tardigrade_upstream_h2_pool_buffer_limit_exceeded_total", snap.origin, direction, "{d}", .{snap.bufferLimitExceeded(direction)});
+                }
             }
         }
     }

--- a/src/http/chunked_upload.zig
+++ b/src/http/chunked_upload.zig
@@ -67,6 +67,14 @@ pub fn Reader(comptime Conn: type) type {
             return self.decoded_bytes;
         }
 
+        /// Raw request-head bytes still borrowed from the caller. The streaming
+        /// relay reserves these as retained memory (#140) — framing octets
+        /// included, since the decoder reads those out of the same slice — and
+        /// releases the reservation as this drains to zero.
+        pub fn pendingBytes(self: *const Self) usize {
+            return self.pending.len;
+        }
+
         /// Copy the next slice of decoded payload into `out`. Returns 0 once
         /// the terminal chunk and trailer section have been consumed; after
         /// that the connection is positioned at the next request.

--- a/src/http/proxy_buffer_account.zig
+++ b/src/http/proxy_buffer_account.zig
@@ -159,6 +159,46 @@ pub const Observer = struct {
     }
 };
 
+/// Whether reads on `side` are currently stopped because the opposite peer
+/// cannot accept more bytes.
+///
+/// The synchronous HTTP/1 relay has no queue to hang a watermark off — it
+/// simply blocks in `write` until the far side drains — so a blocked write *is*
+/// its backpressure, and this is the only place it becomes observable. Only
+/// state transitions are recorded: a relay whose peers keep draining never
+/// touches the counters, and one that stalls repeatedly inside a single stall
+/// emits one pause/resume pair rather than one per write.
+pub const ReadStall = struct {
+    side: Side,
+    observer: Observer,
+    paused: bool = false,
+    pauses: u64 = 0,
+    resumes: u64 = 0,
+
+    pub fn init(side: Side, observer: Observer) ReadStall {
+        return .{ .side = side, .observer = observer };
+    }
+
+    /// The next write cannot make progress, so reads on `side` have stopped.
+    pub fn pause(self: *ReadStall) void {
+        if (self.paused) return;
+        self.paused = true;
+        self.pauses += 1;
+        self.observer.recordReadPause(self.side);
+    }
+
+    /// The write made progress, or the relay finished. Either way reads on
+    /// `side` are no longer being held back, so a relay torn down mid-stall
+    /// must call this: the pause/resume difference is meant to read as "how
+    /// many relays are stalled right now", not to drift by one per abort.
+    pub fn unpause(self: *ReadStall) void {
+        if (!self.paused) return;
+        self.paused = false;
+        self.resumes += 1;
+        self.observer.recordReadResume(self.side);
+    }
+};
+
 /// Which aggregate scope refused a reservation. Distinct errors so the caller
 /// can label the metric without a second lookup.
 pub const AggregateError = error{
@@ -482,6 +522,75 @@ test "unconfigured aggregate capacity is a no-op" {
     const capacity = AggregateCapacity{};
     try capacity.reserve(.upstream_to_downstream, std.math.maxInt(usize));
     capacity.release(.upstream_to_downstream, std.math.maxInt(usize));
+}
+
+const CountingStallObserver = struct {
+    pauses: u64 = 0,
+    resumes: u64 = 0,
+
+    fn observer(self: *CountingStallObserver) Observer {
+        return .{
+            .context = self,
+            .recordReservationFn = ignoreReservation,
+            .releaseReservationFn = ignoreRelease,
+            .recordReadPauseFn = recordPause,
+            .recordReadResumeFn = recordResume,
+        };
+    }
+
+    fn ignoreReservation(_: *anyopaque, _: Direction, _: usize, _: bool, _: bool) void {}
+    fn ignoreRelease(_: *anyopaque, _: Direction, _: usize) void {}
+
+    fn recordPause(context: *anyopaque, _: Side) void {
+        const self: *CountingStallObserver = @ptrCast(@alignCast(context));
+        self.pauses += 1;
+    }
+
+    fn recordResume(context: *anyopaque, _: Side) void {
+        const self: *CountingStallObserver = @ptrCast(@alignCast(context));
+        self.resumes += 1;
+    }
+};
+
+test "read stall records one pause resume pair per stall, not per write" {
+    var counters = CountingStallObserver{};
+    var stall = ReadStall.init(.downstream, counters.observer());
+
+    // A relay that never stalls must leave the counters untouched.
+    stall.unpause();
+    try std.testing.expectEqual(@as(u64, 0), counters.pauses);
+    try std.testing.expectEqual(@as(u64, 0), counters.resumes);
+
+    // Repeated stalled writes inside one stall are a single transition.
+    stall.pause();
+    stall.pause();
+    stall.pause();
+    try std.testing.expectEqual(@as(u64, 1), counters.pauses);
+    try std.testing.expectEqual(@as(u64, 0), counters.resumes);
+
+    stall.unpause();
+    stall.unpause();
+    try std.testing.expectEqual(@as(u64, 1), counters.pauses);
+    try std.testing.expectEqual(@as(u64, 1), counters.resumes);
+
+    // A later stall is a new transition.
+    stall.pause();
+    stall.unpause();
+    try std.testing.expectEqual(@as(u64, 2), counters.pauses);
+    try std.testing.expectEqual(@as(u64, 2), counters.resumes);
+    try std.testing.expectEqual(counters.pauses, stall.pauses);
+    try std.testing.expectEqual(counters.resumes, stall.resumes);
+}
+
+test "read stall left paused at teardown balances when unpaused" {
+    var counters = CountingStallObserver{};
+    var stall = ReadStall.init(.downstream, counters.observer());
+    stall.pause();
+    // Teardown while stalled (client abort, cancellation): the relay is gone,
+    // so it is no longer holding reads back.
+    stall.unpause();
+    try std.testing.expectEqual(counters.pauses, counters.resumes);
+    try std.testing.expect(!stall.paused);
 }
 
 test "proxy buffer account reports over-release without changing current" {

--- a/src/http/upstream_h2.zig
+++ b/src/http/upstream_h2.zig
@@ -1664,9 +1664,21 @@ pub const H2OriginSnapshot = struct {
     streams_active: u64,
     stream_resets_total: u64,
     goaway_total: u64,
-    /// Response bytes this origin's streams currently hold in h2 stream queues.
-    buffered_bytes: usize,
-    buffer_limit_exceeded_total: u64,
+    /// Bytes this origin's streams currently hold, by direction. Response
+    /// queues and request-direction upload relay buffers are enforced against
+    /// the *same* per-origin limit (#140), so reporting only responses would
+    /// let the gauge read zero while the limit was being enforced against
+    /// uploads.
+    buffered_bytes: [2]usize,
+    buffer_limit_exceeded_total: [2]u64,
+
+    pub fn bufferedBytes(self: *const H2OriginSnapshot, direction: proxy_buffer_account.Direction) usize {
+        return self.buffered_bytes[@intFromEnum(direction)];
+    }
+
+    pub fn bufferLimitExceeded(self: *const H2OriginSnapshot, direction: proxy_buffer_account.Direction) u64 {
+        return self.buffer_limit_exceeded_total[@intFromEnum(direction)];
+    }
 };
 
 pub fn freeH2OriginSnapshots(allocator: std.mem.Allocator, snaps: []H2OriginSnapshot) void {
@@ -1998,8 +2010,14 @@ pub const H2ConnPool = struct {
                 .streams_active = 0,
                 .stream_resets_total = e.value_ptr.*.stream_resets_total.load(.monotonic),
                 .goaway_total = e.value_ptr.*.goaway_total.load(.monotonic),
-                .buffered_bytes = e.value_ptr.*.buffer.currentBytes(.upstream_to_downstream),
-                .buffer_limit_exceeded_total = e.value_ptr.*.buffer.limitExceededEvents(.upstream_to_downstream),
+                .buffered_bytes = .{
+                    e.value_ptr.*.buffer.currentBytes(.downstream_to_upstream),
+                    e.value_ptr.*.buffer.currentBytes(.upstream_to_downstream),
+                },
+                .buffer_limit_exceeded_total = .{
+                    e.value_ptr.*.buffer.limitExceededEvents(.downstream_to_upstream),
+                    e.value_ptr.*.buffer.limitExceededEvents(.upstream_to_downstream),
+                },
             };
             errdefer allocator.free(snap.origin);
             if (self.conns.get(e.key_ptr.*)) |conn| {
@@ -2522,6 +2540,36 @@ test "h2c pool acquires a prior-knowledge cleartext connection and round-trips" 
     try testing.expectEqual(@as(usize, 1), snaps.len);
     try testing.expectEqualStrings(key, snaps[0].origin);
     try testing.expectEqual(@as(u64, 1), snaps[0].connections_active);
+}
+
+test "per-origin buffer snapshot reports the request direction, not only responses" {
+    var pool = H2ConnPool.init(testing.allocator, .{});
+    defer pool.deinit();
+
+    const key = "h2:origin-uploads:443";
+    const account = try pool.originBufferAccount(key);
+    account.setHardLimit(4096);
+
+    // An upload relay holding this origin's buffer capacity, with no response
+    // queue anywhere. Reporting only `upstream_to_downstream` made this read as
+    // zero while the same limit was actively bounding the upload (#140).
+    try account.reserve(.downstream_to_upstream, 3072);
+    try testing.expectError(
+        error.BufferLimitExceeded,
+        account.reserve(.downstream_to_upstream, 2048),
+    );
+
+    const snaps = try pool.snapshotOrigins(testing.allocator);
+    defer freeH2OriginSnapshots(testing.allocator, snaps);
+    try testing.expectEqual(@as(usize, 1), snaps.len);
+    try testing.expectEqualStrings(key, snaps[0].origin);
+    try testing.expectEqual(@as(usize, 3072), snaps[0].bufferedBytes(.downstream_to_upstream));
+    try testing.expectEqual(@as(u64, 1), snaps[0].bufferLimitExceeded(.downstream_to_upstream));
+    // The response direction is accounted separately and stays untouched.
+    try testing.expectEqual(@as(usize, 0), snaps[0].bufferedBytes(.upstream_to_downstream));
+    try testing.expectEqual(@as(u64, 0), snaps[0].bufferLimitExceeded(.upstream_to_downstream));
+
+    account.release(.downstream_to_upstream, 3072);
 }
 
 test "h2 pool per-origin counters persist and feed both labelled and global snapshots" {


### PR DESCRIPTION
Slice 3 of #140 — the issue's **PR 3: request direction and HTTP/1 observability**. Builds on #595 (HTTP/2 response enforcement).

## Summary

**Request-direction aggregate accounting.** Upload relay buffers were accounted per stream but never charged to the per-origin or global aggregates, so `TARDIGRADE_PROXY_BUFFER_GLOBAL_HARD_LIMIT_BYTES` bounded responses while concurrent uploads could multiply past it. Both upload relays now reserve against those scopes (HTTP/2 uploads against origin + global; HTTP/1 against global — per-origin accounting for h1 origins is the issue's PR 4, and an h1 origin's relay memory is already bounded per request by fixed buffers). The HTTP/1 response relay buffer clears the global scope too, so the enforcing gauge is no longer narrower than the paths it governs.

**Reserve once, not per frame.** An HTTP/2 upload reserved and released `n` bytes per DATA frame. That tracked nothing retained and gave the aggregate scopes a flicker no concurrent stream could ever have been bounded by. It now reserves its relay buffer once for the upload's life, matching the HTTP/1 model, plus a second reservation for body bytes that arrived with the request head (a genuinely separate buffer).

**Deterministic pre-commitment failure semantics.** Capacity refusals during an upload now split by what ran out:

| Refused at | Status | Meaning |
| --- | --- | --- |
| per-stream hard limit | `413 payload_too_large` | *this* upload's in-flight bytes exceed its allowed bound |
| per-origin / global hard limit | `503 proxy_buffer_saturated` | the proxy is out of room for anybody |

Both are raised before the response head is committed, and neither is recorded against upstream health. Previously an HTTP/1 upload refusal returned the raw error and surfaced as a `502` charged to a healthy origin.

**HTTP/1 stall observability.** `tardigrade_buffer_read_pauses_total{side="downstream"}` and its resume counterpart could only ever read zero. The HTTP/1 upload relay deliberately has no queue whose depth could cross a watermark — it reads the client again only once the upstream write goes through — so a blocked upstream write *is* its backpressure. A zero-timeout writability `poll` before each chunk turns that into the pause/resume series without adding a queue, per the issue's explicit constraint. A healthy origin pays one non-blocking `poll` per chunk and moves no counters.

Only transitions are recorded, and a relay torn down mid-stall still reports its resume, so the difference between the two counters reads as "how many uploads are stalled right now" rather than drifting by one per abort. A write that begins blocking only *after* the check passes is deliberately not counted — an origin that has genuinely stopped consuming keeps the buffer full across iterations and is caught, while a momentary block is not a backpressure event.

## Test plan

`zig build test` — 3354/3355 pass (1 skipped: the known UDP smoke test under this sandbox). Run 5× to confirm the timing-sensitive test is stable. `zig build test-failure` fails identically on `main` (`error.SocketUnconnected`, a sandbox socket restriction) — unrelated to this change.

New tests:

- [x] **Slow origin → downstream read pause.** The upstream send buffer is filled to `EAGAIN` before the relay starts, so the stall is a fact of the socket's state at the moment the relay looks rather than a race against a background reader (the first draft was flaky for exactly that reason). Asserts a pause fired, pauses == resumes, and peak reserved is the fixed 16 KiB buffer — not the 64 KiB body.
- [x] **Client abort mid-upload** (HTTP/1 and HTTP/2) — every gauge and the global aggregate return to zero; the pause counters stay untouched because nothing stalled.
- [x] **Per-stream hard cap → `RequestBufferLimitExceeded`**, charged to `scope="stream"` and not to an aggregate scope.
- [x] **Aggregate exhausted by a concurrent relay → `ProxyBufferCapacityUnavailable`**, labelled `scope="global"`; the refused relay retains nothing and the reservation that did fit is intact.
- [x] **HTTP/2 upload reserves once** — 16 DATA frames go out, one buffer is ever owned.
- [x] `ReadStall` transition unit tests: no counters when nothing stalls, one pair per stall rather than one per write, balanced at teardown.

Docs (`PROXY_STREAMING.md`, `OBSERVABILITY.md`) and `CHANGELOG.md` updated, including the stale claims that the aggregate limit governs HTTP/2 response queues only and that the `side="downstream"` series is reserved at zero.

## Left to PR 4

Per-origin buffer accounting for HTTP/1 origins, and the tuning-guidance documentation — both explicitly the issue's PR 4 scope. Noted inline at the two sites that pass a global-only capacity.

Refs #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)