### PR TITLE
perf(event-loop): readiness-only io_uring backend behind a feature flag (#148)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ operate without guessing which config file or pid file is active.
 | Core v1 support matrix | [docs/SUPPORT_MATRIX.md](docs/SUPPORT_MATRIX.md) |
 | HTTP/3 rollout and lifecycle | [docs/HTTP3_ROLLOUT.md](docs/HTTP3_ROLLOUT.md) |
 | Concurrency & hot-path audit | [docs/CONCURRENCY.md](docs/CONCURRENCY.md) |
+| Event-loop backend evaluation (epoll/kqueue vs libxev/std.Io/io_uring) | [docs/EVENT_LOOP_BACKENDS.md](docs/EVENT_LOOP_BACKENDS.md) |
 | Observability | [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) |
 | Proxy security | [docs/PROXY_SECURITY.md](docs/PROXY_SECURITY.md) |
 | Security test plan | [docs/SECURITY_TEST_PLAN.md](docs/SECURITY_TEST_PLAN.md) |

--- a/docs/CONCURRENCY.md
+++ b/docs/CONCURRENCY.md
@@ -103,6 +103,15 @@ Do not start an `io_uring` or async-runtime rewrite from this boundary. Any new
 backend must be benchmark-justified and fit behind the same socket/protocol
 ownership rules.
 
+That rule still stands, and the opt-in `io_uring` backend added under #148 does
+not relax it. That backend is a readiness-only replacement for `epoll_wait`
+behind the existing `EventLoop` seam — it is not a rewrite, it leaves
+`accept()` and all per-request I/O as blocking calls on worker threads, and it
+is off unless `TARDIGRADE_EVENT_LOOP_BACKEND=io_uring` is set. It is
+explicitly **not** benchmark-justified yet, which is why it is opt-in and why
+`epoll`/`kqueue` remains the default. See
+[`docs/EVENT_LOOP_BACKENDS.md`](EVENT_LOOP_BACKENDS.md).
+
 ## Pure Zig QUIC / H3 Embedding Target
 
 Pure Zig QUIC/H3 work starts upstream-first. Tardigrade should validate QUIC

--- a/docs/EVENT_LOOP_BACKENDS.md
+++ b/docs/EVENT_LOOP_BACKENDS.md
@@ -90,10 +90,19 @@ detail in [`docs/CONCURRENCY.md`](CONCURRENCY.md):
   handles roles 2 and 3 above. Accepted fds from every shard still enter
   the same bounded worker pool.
 - Accepted connections are dispatched to a bounded `WorkerPool`
-  (`src/http/worker_pool.zig`) of OS threads. Each worker owns one
-  connection's full synchronous lifecycle — TLS handshake, HTTP parse,
-  proxy/serve, response write — using **blocking** socket calls
-  (`read`/`write`/`poll`/`SO_RCVTIMEO`/`SO_SNDTIMEO`). `worker_pool.zig`
+  (`src/http/worker_pool.zig`) of OS threads, but "one worker owns the whole
+  connection lifecycle uninterrupted" is only accurate for the legacy
+  OpenSSL/plaintext path — there a worker does own one connection's full
+  synchronous lifecycle (TLS handshake, HTTP parse, proxy/serve, response
+  write) using **blocking** socket calls
+  (`read`/`write`/`poll`/`SO_RCVTIMEO`/`SO_SNDTIMEO`) with no handoff back to
+  `EventLoop` until an idle keepalive gap. For the native-TLS path, a worker
+  instead owns *active request/handshake processing*: a connection can yield
+  out of `native_handshake` (or the idle gap after a response) back to
+  `EventLoop`/`ActiveRegistry` and be re-dispatched to a different worker
+  later, so no single worker owns that connection's end-to-end lifecycle —
+  only each checked-out slice of it, which is itself still blocking work.
+  `worker_pool.zig`
   documents why this is deliberate: `std.Io.Group` (Zig 0.16) and the removed
   `std.Thread.Pool` both assume non-blocking, async-style work items, and
   Tardigrade needs direct control over thread count, work-stealing, CPU
@@ -126,10 +135,37 @@ exactly the surface `src/http/event_loop.zig` already exposes:
 - block for a bounded time and return ready events (`wait`)
 - report a stable backend identifier for logs/metrics (`backendName`)
 
+This is a **readiness-poller** abstraction, not an operation/completion
+abstraction: it has no submission-token model, no way to submit an
+accept/read/write/timeout operation, and no way to return an operation
+result (an accepted fd, a byte count). That shape is a deliberate choice for
+Phase 0, not an oversight — see the explicit call-out at the end of this
+section.
+
 Any alternative backend considered below is evaluated against whether it can
 sit behind this same four-operation boundary without forcing a rewrite of the
 blocking, thread-per-request handler code that currently owns TLS, HTTP
 framing, and proxy streaming.
+
+**This constrains what a future `io_uring` backend may be, and this doc picks
+the narrower of the two honest options:** a future `io_uring` backend
+targeting this boundary is a **readiness-only poller replacement** —
+`IORING_OP_POLL_ADD`/`IORING_OP_POLL_REMOVE` (plus a ring-native timeout for
+`wait`'s bounded-block behavior) standing in for `epoll_wait`/`kqueue`, with
+`accept()` and all request I/O staying exactly where they are today: outside
+the ring, as blocking calls on worker threads. It is **not** a wider
+operation/completion abstraction using `IORING_OP_ACCEPT`, registered
+buffers/files, or multishot variants — adopting those would require
+widening this boundary to typed submissions/completions (e.g. `submitAccept`,
+`submitRead`, `submitWrite`, `submitTimer`, `cancel`, `waitCompletions` with
+opaque tokens) and defining how `epoll`/`kqueue` implement or adapt that
+wider contract, which is a materially larger design than Phase 0 scopes and
+is explicitly out of scope here. A later doc revision would need to make
+that adoption case explicitly, including why the readiness-only version was
+insufficient. Under the readiness-only choice, the sharded per-shard accept
+`poll()` loops (`gateway_accept.zig`) are **not** exercised by this boundary
+at all unless a separate future change first migrates them onto the shared
+`EventLoop` — they stay on `std.posix.poll()` either way.
 
 ## Alternatives compared
 
@@ -245,11 +281,16 @@ framing, and proxy streaming.
   scheduling, not the request hot path itself: per-request reads/writes stay
   synchronous blocking calls on worker threads (including within the
   native-TLS path's own `WaitingEncryptedHttpConnection.waitFor`, which polls
-  locally rather than through the shared loop). Useful `io_uring`
-  features (e.g. `IORING_OP_ACCEPT`, fixed buffers, registered fds) require
-  reasonably recent kernels (5.5+ minimum, several features need 5.11+ or
-  5.19+), which is a real portability constraint the current epoll fallback
-  does not have.
+  locally rather than through the shared loop). Per the "Backend abstraction
+  boundary" section above, a backend targeting this boundary is
+  **readiness-only** (`IORING_OP_POLL_ADD`/`IORING_OP_POLL_REMOVE` plus a
+  ring-native timeout) — it does not use `IORING_OP_ACCEPT`, registered
+  buffers/files, or multishot variants, since those require widening the
+  boundary to an operation/completion abstraction, which is explicitly out
+  of scope for Phase 0. The readiness-only operation set is available from
+  the original `io_uring` interface (Linux 5.1); see "Failure modes and
+  fallback policy" below for how kernel-requirement documentation should be
+  structured if a wider abstraction is ever proposed instead.
 - **macOS support:** None — `io_uring` is Linux-only, so this would always
   need to stay behind a compile-time/feature-flag gate with `epoll`/`kqueue`
   as the portable default, exactly as #148 already proposes.
@@ -380,14 +421,22 @@ no prototype exists yet:
   runtime conditions (log, drain, exit), consistent with how the current
   `EventLoop.wait()` error path already just logs and continues rather than
   trying to self-heal by rebuilding the poller.
-- **Kernel/toolchain requirements, if pursued:** modern `io_uring` opcodes
-  useful here (`IORING_OP_ACCEPT`, fixed buffers/files, multishot variants)
-  need meaningfully newer kernels than the epoll baseline requires — commonly
-  cited minimums range from 5.5 (basic ring support) through 5.11/5.19 for
-  specific opcodes/features relevant to a listener-readiness use case. A
-  prototype must pin and document the exact minimum kernel version it
-  targets and probe for it explicitly rather than assuming availability from
-  a compile-time Linux check.
+- **Kernel/toolchain requirements, if pursued:** separate the **ring
+  baseline** from the **prototype's exact operation set**, rather than citing
+  one number for "basic support." `io_uring` itself — the
+  `io_uring_setup`/`io_uring_enter`/`io_uring_register` syscalls, and with
+  them `IORING_OP_POLL_ADD`/`IORING_OP_POLL_REMOVE` (the readiness-only
+  operation set this doc scopes a prototype to, per "Backend abstraction
+  boundary" above) — landed in Linux **5.1**. Individual capabilities this
+  doc explicitly excludes from a readiness-only prototype have their own,
+  later floors if a future wider abstraction ever adopts them:
+  `IORING_OP_ACCEPT` (5.5), multishot poll (5.13), and multishot accept
+  (5.19, per upstream `liburing` docs) are commonly cited examples, not an
+  exhaustive list. A prototype must pin and document the exact minimum
+  kernel version it targets **for the specific opcodes/features it actually
+  uses**, and probe for those capabilities explicitly at startup rather than
+  assuming availability from a compile-time Linux check or from the 5.1 ring
+  baseline alone.
 
 This policy applies to whichever `EventLoop` role(s) a future prototype
 targets (unsharded accept, parked keepalive, and/or native-TLS active

--- a/docs/EVENT_LOOP_BACKENDS.md
+++ b/docs/EVENT_LOOP_BACKENDS.md
@@ -563,25 +563,28 @@ loop.
 
 ### Validation status — read this before citing the prototype
 
-- **Unit tests:** the `epoll`/`kqueue` behaviour tests in `event_loop.zig` are
-  mirrored for the `io_uring` backend (write readiness, `modify` replacing
-  interest, re-arm persistence, removal, duplicate-registration rejection),
-  plus fail-closed tests for an unavailable backend and an unusable ring size,
-  a close/fd-number-reuse test that verifies no completion from a closed
-  registration is reported against or re-armed on the descriptor that inherits
-  its number, and a CQ-pressure regression that makes 150 fds ready
-  simultaneously against a 128-entry completion queue and requires every one
-  to surface. The behaviour tests skip themselves when `io_uring_setup` is
-  unavailable — container seccomp profiles, Docker's default among them, block
-  it outright — since that is an environment property, not a defect in the
-  backend.
+- **Unit tests: eight Linux-only tests** — one ring-size fail-closed test plus
+  seven that drive a live ring. They mirror the `epoll`/`kqueue` behaviour
+  tests (write readiness, `modify` replacing interest, re-arm persistence,
+  removal, duplicate-registration rejection) and add three regressions for the
+  failure modes above: a close/fd-number-reuse test verifying no completion
+  from a closed registration is reported against or re-armed on the descriptor
+  that inherits its number; a CQ-pressure test making 150 fds ready against a
+  128-entry completion queue and requiring every one to surface; and an
+  operation-error test asserting that a negative completion on a live token
+  makes `wait` return `error.EventLoopUnrecoverable` rather than silently
+  dropping the registration. There is also a platform fail-closed test for an
+  unavailable backend. The live-ring tests skip themselves when
+  `io_uring_setup` is unavailable — container seccomp profiles, Docker's
+  default among them, block it outright — since that is an environment
+  property, not a defect in the backend.
 - **Executed on Linux by CI, not by the author.** The development host for
   this change was macOS/arm64, where the io_uring path compiles out entirely;
   it was validated there only by cross-compiling for `x86_64-linux-gnu` and by
   review. The Linux CI jobs were the first actual execution, and all six
   io_uring tests ran and passed there on both `ubuntu-latest` (x86_64) and
   `ubuntu-24.04-arm` (aarch64) — confirmed by skip-count differential: the
-  macOS job skips 7 tests where the Linux jobs skip 1, and the difference of 6
+  macOS job skips 9 tests where the Linux jobs skip 1, and the difference of 8
   is exactly this backend's tests. So `io_uring_setup` is not blocked on those
   runners, the capability probe succeeds, and the readiness, `modify`,
   re-arm, removal, and recycled-fd paths all behave as intended on a live

--- a/docs/EVENT_LOOP_BACKENDS.md
+++ b/docs/EVENT_LOOP_BACKENDS.md
@@ -1,0 +1,317 @@
+# Event-loop backend evaluation (#148)
+
+Status: **Phase 0 — design doc only.** No runtime behavior changes. This
+document satisfies the design-doc acceptance criteria from #148 and from the
+consolidated architecture-evaluation scope folded in from #213. It does not
+implement, prototype, or benchmark an `io_uring` (or other) backend.
+
+## Why
+
+#148 asks Tardigrade to evaluate an optional Linux `io_uring` backend behind
+an event-loop abstraction, and #213 broadened that into a comparison of the
+current epoll/kqueue model against `libxev`, `std.Io` evented/proactor
+facilities, and direct `io_uring`, for the repository's pinned Zig toolchain
+(`minimum_zig_version = 0.16.0`, see `build.zig.zon`).
+
+#148 explicitly scopes itself as a second-order optimization: "research
+suggests this is a second-order optimization after listener sharding,
+buffering/backpressure, and upstream connection economics," and states it
+"should be tackled after #137, #138, #139, #140, and #141 provide stronger
+baseline wins."
+
+## Dependency status (checked 2026-08-10)
+
+| Issue | Title | Status |
+|---|---|---|
+| #136 | Benchmark harness and telemetry | Closed |
+| #137 | Per-core listener sharding (`SO_REUSEPORT`) | Closed |
+| #138 | Park idle keepalive connections outside workers | Closed |
+| #139 | Streaming reverse proxy with bounded buffering | Closed |
+| #140 | Watermark-based backpressure for proxy/connection buffers | **Open** — PR #600 (HTTP/1 relay buffer bounding) in flight |
+| #141 | Upstream connection pooling redesign | Closed |
+
+Four of the five prerequisite baseline-wins issues are closed; #140 is not.
+Per #148's own stated ordering, this is not yet the point at which a
+prototype or migration should start. This doc proceeds only as far as the
+design/comparison work, and defers the prototype/benchmark decision until
+#140 lands (see "Recommendation" below).
+
+## Current architecture and poller assumptions
+
+Tardigrade uses a **blocking I/O, thread-per-request** model, audited in
+detail in [`docs/CONCURRENCY.md`](CONCURRENCY.md):
+
+- `src/http/event_loop.zig` (`EventLoop`) wraps `epoll` on Linux and `kqueue`
+  on BSD/macOS behind a small `add`/`modify`/`remove`/`wait` interface keyed
+  on raw fds, with `Interest{ read, write }` and a fixed-capacity `Event`
+  output array. `EventLoop.init()` picks the backend from `builtin.os.tag` at
+  compile/runtime; there is no runtime backend override today.
+- The event loop's job is narrow: watch the listener fd(s) for `accept`
+  readiness and watch **parked idle keepalive connections**
+  (`src/http/keepalive_park.zig`, #138) for the next request byte. It is not
+  a general async-I/O runtime — active request handling never touches it.
+- Accepted connections are dispatched to a bounded `WorkerPool`
+  (`src/http/worker_pool.zig`) of OS threads. Each worker owns one
+  connection's full synchronous lifecycle — TLS handshake, HTTP parse,
+  proxy/serve, response write — using **blocking** socket calls
+  (`read`/`write`/`poll`/`SO_RCVTIMEO`/`SO_SNDTIMEO`). `worker_pool.zig`
+  documents why this is deliberate: `std.Io.Group` (Zig 0.16) and the removed
+  `std.Thread.Pool` both assume non-blocking, async-style work items, and
+  Tardigrade needs direct control over thread count, work-stealing, CPU
+  affinity, and drain-before-shutdown semantics for a production reverse
+  proxy.
+- Listener sharding (#137) runs one independent blocking `poll()`-based
+  accept loop per shard thread (`src/gateway_accept.zig`) when
+  `TARDIGRADE_LISTENER_SHARDS > 1` and `SO_REUSEPORT`/`SO_REUSEPORT_LB` is
+  available; accepted fds still enter the same bounded worker pool.
+- `docs/CONCURRENCY.md` already states the project's standing position on
+  this exact question: *"Do not start an `io_uring` or async-runtime rewrite
+  from this boundary. Any new backend must be benchmark-justified and fit
+  behind the same socket/protocol ownership rules."* This design doc does not
+  change that position; it documents the comparison the maintainer status
+  block on #148 asked for so the position is backed by a written rationale
+  rather than only a one-line rule.
+- `tardigrade_event_loop_iterations_total` (a counter of timer-tick
+  iterations) is already exported in Prometheus and JSON metrics
+  (`src/http/metrics.zig`); the event-loop backend name (`"epoll"` /
+  `"kqueue"`) is already logged once at startup
+  (`src/edge_gateway.zig:576`) but is not yet attached as a metric label.
+  Adding a `backend` label to the existing counter (mirroring the
+  `{backend=...}` pattern already used by the TLS buffer metrics) is a small,
+  low-risk follow-up independent of the rest of this evaluation — see
+  "Small independent follow-up" below.
+
+## Backend abstraction boundary
+
+For the purposes of this comparison, the "event-loop backend" boundary is
+exactly the surface `src/http/event_loop.zig` already exposes:
+
+- register/modify/remove readiness interest for a fd (`add`, `modify`,
+  `remove`)
+- block for a bounded time and return ready events (`wait`)
+- report a stable backend identifier for logs/metrics (`backendName`)
+
+Any alternative backend considered below is evaluated against whether it can
+sit behind this same four-operation boundary without forcing a rewrite of the
+blocking, thread-per-request handler code that currently owns TLS, HTTP
+framing, and proxy streaming.
+
+## Alternatives compared
+
+### A. Current model — direct `epoll`/`kqueue`, thread-per-request workers
+
+- **Linux fast path:** Mature, well-understood, level-triggered epoll used
+  only for accept + parked-keepalive readiness (a small fraction of total
+  I/O — active request I/O is synchronous blocking calls on worker threads).
+  No known syscall-count problem has been measured in this narrow role;
+  #148's own research basis frames `io_uring`'s syscall-reduction pitch as
+  most valuable for I/O-heavy async runtimes, which this narrow accept/park
+  loop is not.
+- **macOS/kernel requirements:** `kqueue` is available on every supported
+  BSD/macOS target with no minimum-version gymnastics. No portability
+  fallback logic needed — it already covers both `SUPPORT_MATRIX.md`
+  platforms.
+- **Complexity / maintenance:** Already implemented, tested, and in
+  production use (398 lines, unit-tested for both backends via CI matrix).
+  Zero incremental maintenance cost to keep it.
+- **TLS/encrypted-stream integration:** Already fully integrated —
+  `keepalive_park.zig` moves `TlsConnection` state off the worker stack
+  across the idle gap and the event loop only tracks fd readiness, never TLS
+  record state.
+- **Proxy streaming / backpressure:** Already integrated with #139's
+  streaming relay and #140's (in-progress) watermark work, which are both
+  built on synchronous blocking reads/writes, not on event-loop readiness
+  callbacks.
+- **Timers, cancellation, keepalive parking, graceful drain:** Already
+  implemented (`keepalive_park.zig` idle reaper on the maintenance tick,
+  `gateway_shutdown.zig` drain, per-phase `poll(2)`/`SO_*TIMEO` deadlines on
+  worker threads).
+- **Prototype needed?** No — this is the shipped baseline.
+
+### B. Cleaner direct epoll/kqueue abstraction (refactor only, same backends)
+
+- Would not change Linux/macOS support or kernel requirements at all — same
+  syscalls, same platforms.
+- Only credible motivation is code-quality (e.g., unifying edge- vs
+  level-triggered handling, or widening the event loop's role beyond
+  accept/park). #148 does not identify a concrete pain point in the current
+  abstraction that blocks other roadmap work, and `CONCURRENCY.md`'s
+  "Follow-up work" table (h1/h2/h3 stream transport boundary, QUIC UDP
+  endpoint) tracks the actual seams that need boundary work next (#241,
+  #242, #248), not `event_loop.zig` itself.
+- **Verdict:** No action item here beyond normal refactoring hygiene; not a
+  distinct backend decision.
+
+### C. `libxev`
+
+- Not vendored or referenced anywhere in this repository today (`libxev`
+  search returns no hits).
+- Would require adopting `libxev`'s completion-based (io_uring-on-Linux,
+  kqueue-on-BSD/macOS, IOCP-on-Windows) async model, which is fundamentally
+  callback/completion-oriented — a different concurrency shape than
+  Tardigrade's blocking-thread-per-request handler. Adopting it for real gain
+  would mean rewriting the request handler to be non-blocking end-to-end
+  (TLS, HTTP parsing, proxy relay, FastCGI/SCGI/uWSGI transports), which
+  `worker_pool.zig`'s design rationale explicitly warns against doing without
+  first replacing the blocking I/O model throughout the connection handler
+  and capturing an expected throughput/latency delta.
+- Pulling in `libxev` as a dependency also cuts against the project's
+  documented "core Zig only" direction for the data plane (see
+  `docs/UPSTREAM_POOLING.md`'s HTTP/2 upstream work, which built h2 framing
+  in-repo rather than take an external dependency, keeping OpenSSL as the
+  one intentional exception).
+- **Verdict:** Not justified now. Revisit only if/when the handler model
+  itself is being redesigned around non-blocking I/O for other reasons.
+
+### D. `std.Io` evented/proactor facilities
+
+- `zig_compat.zig` and `CONCURRENCY.md` already draw this exact line:
+  high-level, non-socket-path code uses `std.Io`/`zig_compat`; the
+  listener/gateway/proxy/H2/H3 socket path deliberately stays on raw
+  `std.posix`/`std.c` because Zig 0.16's `std.Io` does not yet expose
+  stable, production-grade semantics for `accept`, `poll`, non-blocking
+  toggles, `SO_*TIMEO`, and peer-address extraction on the data plane.
+- `worker_pool.zig` already tried and rejected `std.Io.Group` for the exact
+  reason relevant here: it expects non-blocking, async-style work items, and
+  a blocking call on a Group-managed thread stalls the whole group. FastCGI
+  pooling (`docs/UPSTREAM_POOLING.md` Phase 2) hit this directly in
+  production — FastCGI/SCGI/uWSGI over `std.Io` event-loop streams **hung**
+  against `php-fpm`'s blocking request/response exchange, and had to be
+  switched to raw blocking sockets to fix it.
+- **Verdict:** Not viable as a socket-path backend on the pinned Zig 0.16
+  toolchain today, independent of `io_uring` specifically. This is a
+  toolchain-maturity blocker, not a design preference, and should be
+  re-evaluated only if a future Zig release stabilizes proactor-style I/O for
+  the primitives the data plane needs (`accept`, bounded `poll`/timeout
+  reads and writes, peer address extraction).
+
+### E. Direct `io_uring`
+
+- **Linux fast path / kernel requirements:** Real syscall-batching and
+  completion-based I/O upside exists, but it is most valuable for
+  high-fan-out non-blocking I/O (many concurrent reads/writes multiplexed
+  through one submission/completion queue), which is exactly the shape
+  Tardigrade's worker pool does *not* have — each worker already does one
+  blocking `read`/`write` at a time on its own thread. The event loop's
+  actual `io_uring`-addressable surface today is narrow: listener accept and
+  parked-keepalive readiness, not the request hot path. Useful `io_uring`
+  features (e.g. `IORING_OP_ACCEPT`, fixed buffers, registered fds) require
+  reasonably recent kernels (5.5+ minimum, several features need 5.11+ or
+  5.19+), which is a real portability constraint the current epoll fallback
+  does not have.
+- **macOS support:** None — `io_uring` is Linux-only, so this would always
+  need to stay behind a compile-time/feature-flag gate with `epoll`/`kqueue`
+  as the portable default, exactly as #148 already proposes.
+- **Complexity / maintenance:** High. A correct `io_uring` integration means
+  new submission/completion-queue lifecycle code, a second set of
+  cancellation/timeout semantics, and (per Envoy's and Monoio's own
+  documented experience, cited in #148's research basis) materially more
+  operational surface than epoll for a comparatively narrow accept/park role
+  in this codebase's current architecture.
+- **TLS/encrypted-stream integration:** Would not change — TLS record
+  handling happens inside the blocking worker, not in the event loop, so
+  `io_uring` adoption at the accept/park boundary would not touch TLS state
+  machines either way.
+- **Proxy streaming and backpressure:** No expected interaction with #139
+  (streaming relay) or #140 (watermark backpressure) as currently designed,
+  since both operate on synchronous blocking reads/writes inside worker
+  threads, not on event-loop-driven readiness.
+- **Timers, cancellation, keepalive parking, graceful drain:** `io_uring`
+  can express timeouts and cancellation natively, which could simplify
+  `keepalive_park.zig`'s reaper in principle, but the current reaper (a
+  periodic scan under one mutex) is not a known bottleneck — no profiling
+  evidence in this repo suggests it needs replacing.
+- **Prototype needed to resolve the decision?** Not yet — see
+  "Recommendation."
+
+## Comparison matrix
+
+| Dimension | A. Current (epoll/kqueue) | B. Cleaner direct abstraction | C. `libxev` | D. `std.Io` proactor | E. Direct `io_uring` |
+|---|---|---|---|---|---|
+| Linux fast path today | Proven, narrow role | Same as A | Needs non-blocking rewrite to pay off | Not production-ready on 0.16 for socket path | Real upside only for non-blocking, high-fan-out I/O Tardigrade doesn't have yet |
+| macOS support | Native (`kqueue`) | Native | Native (kqueue backend) | Blocked on 0.16 maturity | None — Linux-only, needs feature-flag gate |
+| Complexity / maintenance | Already paid for | Refactor cost, no new capability | New dependency + handler rewrite | Blocked, not a maintenance question yet | High — new SQ/CQ lifecycle, cancellation model |
+| TLS integration | Done, out of event loop's path | Unaffected | Would need rework if handler goes non-blocking | Unaffected until viable | Unaffected (TLS stays in worker) |
+| Proxy streaming/backpressure (#139/#140) | Built on blocking relay, already integrated | Unaffected | Would require redesign | Already broke FastCGI in production (Phase 2) | No interaction as currently designed |
+| Timers/cancellation/parking/drain | Implemented, no known bottleneck | Unaffected | Would move into libxev's model | Unaffected until viable | Could simplify parking reaper, unproven need |
+| Prototype required to decide? | N/A (shipped) | No | Only if handler model changes | No — blocked on toolchain, not on prototyping | Not yet (see recommendation) |
+
+## Recommendation
+
+### Short-term (now)
+
+- **No backend change.** Keep the existing `epoll`/`kqueue` `EventLoop` as
+  the only backend, exactly as `docs/CONCURRENCY.md` already directs.
+- **No `io_uring`, `libxev`, or `std.Io` proactor prototype in this PR or in
+  the immediate next one.** #148's own dependency ordering says this issue
+  should follow stronger baseline wins from #137–#141, and #140
+  (watermark-based backpressure) is still open with PR #600 in flight. Since
+  #140's design directly shapes how proxy buffers would interact with any
+  future async I/O model, starting an `io_uring` prototype before it lands
+  risks throwaway work.
+- **Small independent follow-up (optional, not gated on the rest of this
+  doc):** attach a `backend` label to the existing
+  `tardigrade_event_loop_iterations_total` counter (the backend name is
+  already computed via `EventLoop.backendName()` and already logged once at
+  startup), so operators can see the active backend in
+  `/status/metrics` without parsing startup logs. This is a few-line,
+  low-risk metrics change independent of the architecture question and can
+  land whenever convenient; it is not required to close #148.
+
+### Long-term
+
+- **`io_uring` is a "later, and only if measured" candidate, not a "now" or
+  "never."** The condition for revisiting it: #140 lands, and a profiling
+  pass (`perf record -g` per `CONCURRENCY.md`'s "How to measure" section)
+  against the `benchmarks/` harness (#136) shows the accept/park event-loop
+  path — not worker-thread blocking I/O — is a measurable bottleneck under
+  realistic high-churn or many-idle-keepalive workloads. Given the event
+  loop's current narrow role, that evidence does not exist yet and this doc
+  does not manufacture it.
+- **`libxev` and `std.Io` proactor mode are "not now" for a different
+  reason each:** `libxev` requires a handler-model rewrite this project has
+  explicitly deferred (`worker_pool.zig`); `std.Io`'s proactor facilities are
+  not yet production-ready for the raw socket primitives the data plane
+  needs on the pinned Zig 0.16 toolchain (demonstrated in production by the
+  Phase 2 FastCGI stall). Re-evaluate `std.Io` specifically on each Zig
+  toolchain bump.
+- If a future profiling pass does justify pursuing `io_uring`, the correct
+  next step is a narrowly scoped, Linux-only, feature-flagged prototype
+  limited to the accept/park boundary (not a rewrite of worker I/O), matching
+  #148's original "Prototype Linux `io_uring` support behind a feature flag"
+  proposal, with its own follow-up issue and its own benchmark evidence
+  gathered on real hardware (per the project's standing practice — see
+  `docs/UPSTREAM_POOLING.md` and `CONCURRENCY.md`, both of which note that
+  benchmark numbers must be captured on real hardware, not in a sandboxed
+  dev/CI environment).
+
+## Metrics
+
+No new metrics are added by this doc. The event-loop metrics already in
+place:
+
+- `tardigrade_event_loop_iterations_total` — timer-tick iteration counter
+  (`src/http/metrics.zig`).
+- Backend name (`epoll`/`kqueue`) logged once at startup
+  (`src/edge_gateway.zig`).
+- Per-shard accept metrics from #137
+  (`tardigrade_listener_shards`-equivalent gauges and
+  `accepts_total`/`accept_errors_total{shard=...}`, `src/http/metrics.zig`).
+
+`tardigrade_event_loop_wakeups_total{backend=...}` from #148's proposed
+metrics list is not added here — it would require instrumenting the
+epoll/kqueue `wait()` call sites themselves, which is more naturally scoped
+to whichever PR first needs wakeup-count evidence (e.g. a future profiling
+or prototype effort), not to a design-only doc.
+
+## Relation to other open issues
+
+- Depends on / informed by: #136 (closed, benchmark harness exists), #137
+  (closed, listener sharding), #138 (closed, keepalive parking), #139
+  (closed, streaming proxy), #141 (closed, upstream pooling).
+- Blocked on: #140 (open) for the buffer-accounting model any future async
+  I/O design would need to interact with.
+- No follow-up implementation issues are opened by this doc, per #148's own
+  acceptance criterion that "focused follow-up implementation issues are
+  created only if a migration or additional backend is approved" — this doc
+  approves neither.

--- a/docs/EVENT_LOOP_BACKENDS.md
+++ b/docs/EVENT_LOOP_BACKENDS.md
@@ -305,12 +305,12 @@ at all unless a separate future change first migrates them onto the shared
   buffers/files, or multishot variants, since those require widening the
   boundary to an operation/completion abstraction, which is explicitly out
   of scope for Phase 0. `POLL_ADD`/`POLL_REMOVE` exist from the original
-  `io_uring` interface (Linux 5.1), but this readiness-only prototype's
-  actual minimum is **Linux 5.4**, because `EventLoop.wait(timeout_ms)`'s
-  bounded-block behavior is implemented with `IORING_OP_TIMEOUT`, which is
-  not present in 5.1; see "Failure modes and fallback policy" below for how
-  kernel-requirement documentation should be structured if a wider
-  abstraction is ever proposed instead.
+  `io_uring` interface (Linux 5.1), but this readiness-only design needs
+  `IORING_OP_TIMEOUT` for `EventLoop.wait(timeout_ms)`'s bounded block, which
+  is not present in 5.1 and lands in **5.4**. Implementation then raised the
+  floor once more, to **Linux 5.5**, because re-arming one-shot polls makes
+  dropped completions unrecoverable and `IORING_FEAT_NODROP` is 5.5 — see
+  "Phase 1 prototype" and "Failure modes and fallback policy" below.
 - **macOS support:** None — `io_uring` is Linux-only, so this would always
   need to stay behind a compile-time/feature-flag gate with `epoll`/`kqueue`
   as the portable default, exactly as #148 already proposes.
@@ -450,7 +450,7 @@ implements the policy in "Failure modes and fallback policy" below.
 The 256-entry default is chosen so the ring's mmap'd SQ/CQ memory (~24 KiB)
 fits inside the 64 KiB `RLIMIT_MEMLOCK` soft limit common on stock hosts;
 kernels before 5.12 charge ring memory against that limit, so a much deeper
-default would fail `io_uring_setup` with `ENOMEM` on exactly the 5.4-era
+default would fail `io_uring_setup` with `ENOMEM` on exactly the 5.5-era
 kernels this prototype targets.
 
 ### What it uses, and what it deliberately does not
@@ -491,18 +491,30 @@ These are the three places where the ring is not a drop-in for level-triggered
    would have coalesced both. No readiness is lost — the fd is re-armed
    immediately — but a caller may need one extra loop iteration. Closing this
    gap needs `IORING_POLL_ADD_LEVEL`, which is Linux 5.13+ and therefore above
-   this prototype's 5.4 floor.
-3. **Closing a fd does not unregister it.** `epoll` drops a fd from every set
-   when it is closed, and this codebase relies on that:
-   `parkedConnectionCloseHook` and `activeConnectionCloseHook` only release
-   accounting slots, so the keepalive idle reaper and the active-connection
-   reaper close registered fds without unregistering them. The ring has no
-   equivalent implicit cleanup, so `add` treats a surviving table entry for a
-   fd it is asked to register as a stale registration for a recycled fd
-   number: it cancels the stale poll and takes the fd over, rather than
-   reporting the `EEXIST` that `EPOLL_CTL_ADD` would.
+   this prototype's floor.
+3. **Closing a fd does not unregister it, so unregister-before-close is an
+   invariant.** `epoll` drops a fd from every set when it is closed.
+   `IORING_OP_POLL_ADD` instead pins the underlying file, so a poll left armed
+   across a close survives it — and if the kernel recycles that integer for an
+   unrelated descriptor, the stale completion is reported against, and
+   re-armed on, the wrong file. The active-connection expiry reaper already
+   removed the fd before `conn.deinit()`; the parked path did not, relying on
+   epoll's implicit cleanup. `parkedConnectionCloseHook` now removes the fd
+   from the loop before `ParkedRegistry.freeConn` closes it, which covers the
+   idle reaper, the drain, and `closeAll`. `add` therefore keeps strict
+   `EPOLL_CTL_ADD`-style `EEXIST` semantics: inferring staleness from a
+   duplicate fd number was tried first and is unsound, because it cannot cover
+   the case where the stale completion is reaped *before* the re-add.
+4. **A dropped completion strands a registration permanently.** Because a
+   one-shot poll is re-armed only after its CQE is consumed, losing that CQE
+   means the table still believes the fd is armed while nothing will ever
+   re-arm it — the fd silently disappears from readiness. Kernels before 5.5
+   discard completions when the CQ is full; 5.5+ advertise
+   `IORING_FEAT_NODROP` and retain them on an overflow list. Startup requires
+   that feature and fails closed without it, which is what sets the floor at
+   5.5 rather than the 5.4 that `IORING_OP_TIMEOUT` alone implies.
 
-A fourth difference is internal rather than behavioural: `epoll_ctl` is
+A fifth difference is internal rather than behavioural: `epoll_ctl` is
 kernel-synchronized and safe to call from any thread while another sits in
 `epoll_wait`, which `removeReadFd` documents worker threads doing. The io_uring
 submission queue is plain shared memory, so every userspace ring mutation is
@@ -513,26 +525,56 @@ monotonic token in the high half of `user_data` so that a completion racing
 with a `POLL_REMOVE` is discarded rather than reported against a fd the caller
 has already removed and possibly closed.
 
-### Capability probing
+### Capability probing and the kernel floor
 
-`IoUring.init` succeeding only proves the 5.1 ring baseline, so the three
-opcodes are established explicitly at startup rather than inferred from a
-compile-time Linux check. `IORING_REGISTER_PROBE` is used where available and
-checks all three opcodes directly — but that register opcode is itself only
-present from 5.6, so kernels in the 5.1–5.5 window instead get a functional
-probe that submits an already-expired `IORING_OP_TIMEOUT` and requires the
-kernel to complete it with `-ETIME` rather than reject it. That functional
-probe is what actually enforces this prototype's 5.4 floor.
+`IoUring.init` succeeding only proves the 5.1 ring baseline, so everything this
+backend depends on is established explicitly at startup rather than inferred
+from a compile-time Linux check or a version number:
+
+- **`IORING_FEAT_NODROP`** is required from the setup features, failing closed
+  when absent. This is the binding constraint and puts the effective floor at
+  **Linux 5.5** — see difference 4 above for why a prototype that re-arms
+  one-shot polls cannot tolerate dropped completions.
+- **The three opcodes** are checked via `IORING_REGISTER_PROBE` where
+  available. That register opcode is itself only present from 5.6, so a kernel
+  at exactly 5.5 instead gets a functional probe: submit an already-expired
+  `IORING_OP_TIMEOUT` and require the kernel to complete it with `-ETIME`
+  rather than reject it.
+
+Kernel-version numbers are used here only to explain *why* each gate exists;
+every gate is a runtime feature or opcode check, so a backported or vendor
+kernel is judged on what it actually supports.
+
+### Runtime ring failures
+
+Submission failures are not swallowed. A poll or timer counts as armed only
+once the kernel has accepted it — `EINTR` from `io_uring_enter` with
+`min_complete = 0` is explicitly not treated as success, since it may have
+submitted nothing. If the bounded-wait timer cannot be queued under submission
+pressure, `wait` degrades to a non-blocking poll rather than blocking on
+`min_complete = 1` with no timer to break it.
+
+Anything worse is unrecoverable and sticky: the polls this backend believes are
+armed may not be, and there is no deadline reaper behind the listener
+registration to notice. `wait` then reports `error.EventLoopUnrecoverable`, and
+`edge_gateway` takes the fatal path this document already specified — log,
+request shutdown, drain, exit — instead of logging and continuing with a wedged
+loop.
 
 ### Validation status — read this before citing the prototype
 
 - **Unit tests:** the `epoll`/`kqueue` behaviour tests in `event_loop.zig` are
   mirrored for the `io_uring` backend (write readiness, `modify` replacing
-  interest, re-arm persistence, removal, recycled-fd re-registration), plus
-  fail-closed tests for an unavailable backend and an unusable ring size. The
-  behaviour tests skip themselves when `io_uring_setup` is unavailable —
-  container seccomp profiles, Docker's default among them, block it outright —
-  since that is an environment property, not a defect in the backend.
+  interest, re-arm persistence, removal, duplicate-registration rejection),
+  plus fail-closed tests for an unavailable backend and an unusable ring size,
+  a close/fd-number-reuse test that verifies no completion from a closed
+  registration is reported against or re-armed on the descriptor that inherits
+  its number, and a CQ-pressure regression that makes 150 fds ready
+  simultaneously against a 128-entry completion queue and requires every one
+  to surface. The behaviour tests skip themselves when `io_uring_setup` is
+  unavailable — container seccomp profiles, Docker's default among them, block
+  it outright — since that is an environment property, not a defect in the
+  backend.
 - **Executed on Linux by CI, not by the author.** The development host for
   this change was macOS/arm64, where the io_uring path compiles out entirely;
   it was validated there only by cross-compiling for `x86_64-linux-gnu` and by
@@ -544,12 +586,14 @@ probe is what actually enforces this prototype's 5.4 floor.
   runners, the capability probe succeeds, and the readiness, `modify`,
   re-arm, removal, and recycled-fd paths all behave as intended on a live
   kernel.
-- **The 5.1–5.5 probe fallback is still unexercised.** CI runners are on
+- **The functional probe fallback is still unexercised.** CI runners are on
   modern kernels where `IORING_REGISTER_PROBE` is available, so probing always
-  takes the register path. The functional `-ETIME` fallback — the branch that
-  actually enforces the documented 5.4 floor — has never run. Anyone
-  validating this prototype against a 5.4-era kernel should treat that path as
-  unverified.
+  takes the register path. The `-ETIME` fallback — reachable only on a kernel
+  at exactly 5.5 — has never run. Likewise, the `IORING_FEAT_NODROP`
+  fail-closed branch cannot be exercised on a kernel that has the feature, so
+  the CQ-pressure test proves the overflow backlog works *with* NODROP but not
+  that the refusal path works without it. Anyone validating against a 5.4/5.5
+  kernel should treat both as unverified.
 - **No benchmark evidence of any kind.** No profiling pass has shown the
   shared `EventLoop`'s readiness/idle-wait role to be a bottleneck, and no
   throughput or latency comparison against `epoll` has been run. Per
@@ -584,7 +628,8 @@ contract that backend is held to:
   requests an `io_uring` backend (`TARDIGRADE_EVENT_LOOP_BACKEND=io_uring`)
   and required kernel
   capabilities cannot be established at startup — unsupported kernel version,
-  missing opcodes, seccomp/container restrictions blocking `io_uring_setup`,
+  missing opcodes, a missing `IORING_FEAT_NODROP` guarantee,
+  seccomp/container restrictions blocking `io_uring_setup`,
   or resource exhaustion (`RLIMIT_MEMLOCK`, ring allocation failure) — the
   process must fail startup with a clear error, not silently fall back to
   epoll. An operator who explicitly asked for `io_uring` needs to know their
@@ -600,9 +645,13 @@ contract that backend is held to:
   (e.g. a ring entering a bad state after `io_uring_enter` failures) are not
   a live-migration trigger back to epoll; they surface through the same
   error/drain semantics `gateway_shutdown.zig` already uses for other fatal
-  runtime conditions (log, drain, exit), consistent with how the current
-  `EventLoop.wait()` error path already just logs and continues rather than
-  trying to self-heal by rebuilding the poller.
+  runtime conditions (log, drain, exit), rather than self-healing by
+  rebuilding the poller. **Implemented:** an unrecoverable ring state is
+  sticky and surfaces from `wait` as `error.EventLoopUnrecoverable`, on which
+  `edge_gateway` requests shutdown and drains. Note this is deliberately
+  *stricter* than the `epoll` path's log-and-continue, because a wedged ring
+  can silently stop delivering listener readiness while the process still
+  looks healthy.
 - **Kernel/toolchain requirements, if pursued:** separate the **historical
   ring/poll baseline** from **this prototype's actual minimum**, rather than
   citing one number for "basic support." `io_uring` itself — the
@@ -611,19 +660,23 @@ contract that backend is held to:
   **5.1**. But the readiness-only prototype this doc actually scopes to (see
   "Backend abstraction boundary") also relies on `IORING_OP_TIMEOUT` to
   implement `EventLoop.wait(timeout_ms)`'s bounded-block behavior, and that
-  opcode is not present in 5.1 — it landed in Linux **5.4**. So **this
-  prototype's real minimum is Linux 5.4**, not 5.1, unless a future revision
-  explicitly chooses a different, non-`IORING_OP_TIMEOUT` bounded-wait
-  mechanism instead. Individual capabilities this doc explicitly excludes
-  from the readiness-only prototype have their own, later floors if a future
-  wider abstraction ever adopts them: `IORING_OP_ACCEPT` (5.5), multishot
-  poll (5.13), and multishot accept (5.19, per upstream `liburing` docs) are
-  commonly cited examples, not an exhaustive list. A prototype must pin and
-  document the exact minimum kernel version it targets **for the specific
-  opcodes/features it actually uses** — 5.4 for the operation set chosen
+  opcode is not present in 5.1 — it landed in Linux **5.4**. So the *operation
+  set* alone implies 5.4, not 5.1.
+
+  **The implemented prototype's real minimum is Linux 5.5**, because the
+  operation set is not the only requirement: re-arming one-shot polls makes
+  completion loss unrecoverable, so `IORING_FEAT_NODROP` — which preserves
+  completions on CQ overflow instead of discarding them, and which arrives in
+  **5.5** — is required at startup too. Individual capabilities this doc
+  excludes from the readiness-only prototype have their own, later floors if a
+  future wider abstraction ever adopts them: `IORING_OP_ACCEPT` (5.5),
+  multishot poll (5.13), and multishot accept (5.19, per upstream `liburing`
+  docs) are commonly cited examples, not an exhaustive list. A prototype must
+  pin and document the exact minimum it targets **for the specific
+  opcodes and features it actually uses** — 5.5 for the combination chosen
   here — and probe for those capabilities explicitly at startup rather than
-  assuming availability from a compile-time Linux check or from the 5.1 ring
-  baseline alone.
+  assuming availability from a compile-time Linux check, from a version
+  number, or from the 5.1 ring baseline alone.
 
 This policy applies to whichever `EventLoop` role(s) a future prototype
 targets (unsharded accept, parked keepalive, and/or native-TLS active

--- a/docs/EVENT_LOOP_BACKENDS.md
+++ b/docs/EVENT_LOOP_BACKENDS.md
@@ -1,9 +1,20 @@
 # Event-loop backend evaluation (#148)
 
-Status: **Phase 0 — design doc only.** No runtime behavior changes. This
-document satisfies the design-doc acceptance criteria from #148 and from the
-consolidated architecture-evaluation scope folded in from #213. It does not
-implement, prototype, or benchmark an `io_uring` (or other) backend.
+Status: **Phase 1 — readiness-only `io_uring` prototype landed, unbenchmarked.**
+Phase 0's comparison (below) is unchanged and still records why `epoll`/`kqueue`
+remains the default. What has changed is that the narrowly scoped, Linux-only,
+feature-flagged prototype this document specified now exists in
+`src/http/event_loop.zig`, behind `TARDIGRADE_EVENT_LOOP_BACKEND=io_uring`.
+
+**Default behavior is unchanged on every platform.** The prototype is off
+unless an operator explicitly names it, and it is deliberately shipped without
+performance claims: no benchmark evidence has been gathered for it, so the
+"Recommendation" section's bar for adopting `io_uring` as a default is **not**
+met. See "Phase 1 prototype" below for exactly what was and was not validated.
+
+This document satisfies the design-doc acceptance criteria from #148 and from
+the consolidated architecture-evaluation scope folded in from #213. It does not
+benchmark an `io_uring` (or other) backend.
 
 ## Why
 
@@ -46,8 +57,11 @@ detail in [`docs/CONCURRENCY.md`](CONCURRENCY.md):
 - `src/http/event_loop.zig` (`EventLoop`) wraps `epoll` on Linux and `kqueue`
   on BSD/macOS behind a small `add`/`modify`/`remove`/`wait` interface keyed
   on raw fds, with `Interest{ read, write }` and a fixed-capacity `Event`
-  output array. `EventLoop.init()` picks the backend from `builtin.os.tag` at
-  compile/runtime; there is no runtime backend override today.
+  output array. `EventLoop.init()` picks the backend from `builtin.os.tag`,
+  and that remains what runs unless an operator sets
+  `TARDIGRADE_EVENT_LOOP_BACKEND` to name one explicitly (Phase 1; see
+  "Phase 1 prototype" below). This section describes the default path, which
+  the prototype does not alter.
 - The single shared `EventLoop` instance in `edge_gateway.zig`'s main loop
   currently has **three** roles, not one:
   1. **Unsharded listener accept readiness** — only when listener sharding
@@ -328,8 +342,9 @@ at all unless a separate future change first migrates them onto the shared
   using that to actually simplify the reaper would require the wider
   operation/completion abstraction this doc explicitly defers (see "Backend
   abstraction boundary"), not the readiness-only prototype scoped here.
-- **Prototype needed to resolve the decision?** Not yet — see
-  "Recommendation."
+- **Prototype needed to resolve the decision?** Built (Phase 1, opt-in and
+  unbenchmarked) — see "Phase 1 prototype" and "Recommendation." Its existence
+  does not resolve the decision; the profiling/benchmark evidence still does.
 
 ## Comparison matrix
 
@@ -341,14 +356,16 @@ at all unless a separate future change first migrates them onto the shared
 | TLS integration | Done for both OpenSSL (park) and native (active registry) paths, out of event loop's path | Unaffected | Would need rework if handler goes non-blocking | Unaffected until viable | Unaffected (TLS stays in worker) |
 | Proxy streaming/backpressure (#139/#140) | Built on blocking relay, already integrated | Unaffected | Would require redesign | Already broke FastCGI in production (Phase 2) | No interaction as currently designed |
 | Timers/cancellation/parking/drain | Implemented, no known bottleneck | Unaffected | Would move into libxev's model | Unaffected until viable | Unchanged at readiness-only boundary — reaper/drain untouched |
-| Prototype required to decide? | N/A (shipped) | No | Only if handler model changes | No — blocked on toolchain, not on prototyping | Not yet (see recommendation) |
+| Prototype required to decide? | N/A (shipped) | No | Only if handler model changes | No — blocked on toolchain, not on prototyping | Built, opt-in, unbenchmarked (Phase 1) |
 
 ## Recommendation
 
 ### Short-term (now)
 
-- **No backend change.** Keep the existing `epoll`/`kqueue` `EventLoop` as
-  the only backend, exactly as `docs/CONCURRENCY.md` already directs.
+- **No change to the default backend.** `epoll`/`kqueue` remains the backend
+  selected on every platform when `TARDIGRADE_EVENT_LOOP_BACKEND` is unset or
+  `default`, exactly as `docs/CONCURRENCY.md` already directs. The Phase 1
+  `io_uring` prototype is opt-in only and carries no performance claim.
 - **Ordering precondition cleared; evidence precondition is not.** #140
   (watermark-based backpressure) merged via PR #600, closing out the last of
   #148's named prerequisites (#137, #138, #139, #140, #141 are all now
@@ -363,14 +380,15 @@ at all unless a separate future change first migrates them onto the shared
   bar or supplies that evidence — #600 bounds HTTP/1 relay memory per
   origin, which is orthogonal to whether the accept/park/native-TLS
   readiness loop is a bottleneck.
-- **Still no `io_uring`, `libxev`, or `std.Io` proactor prototype in this
-  PR.** With the ordering precondition cleared, the next concrete step is
-  gathering that profiling evidence (or determining it's not worth
-  gathering yet against other roadmap priorities) — not writing prototype
-  code speculatively. This sandboxed session also has no Zig toolchain and
-  no representative benchmarking hardware, so it could not produce that
-  evidence even if it attempted to; see "Long-term" for what a prototype
-  attempt needs before it starts.
+- **The `io_uring` prototype now exists; `libxev` and `std.Io` proactor still
+  do not, and should not.** The prototype was built ahead of the profiling
+  evidence rather than after it, as a deliberate call to make the option
+  concrete and measurable. That ordering does not retire the evidence
+  precondition — it only means the thing to be measured now exists. Nothing
+  about the prototype's existence argues for changing the default; see
+  "Phase 1 prototype" for what is still missing. `libxev` and `std.Io`
+  proactor mode remain rejected for the reasons in sections C and D, which
+  the prototype does not affect.
 - **Small independent follow-up (optional, not gated on the rest of this
   doc):** attach a `backend` label to the existing
   `tardigrade_event_loop_iterations_total` counter (the backend name is
@@ -402,34 +420,157 @@ at all unless a separate future change first migrates them onto the shared
   needs on the pinned Zig 0.16 toolchain (demonstrated in production by the
   Phase 2 FastCGI stall). Re-evaluate `std.Io` specifically on each Zig
   toolchain bump.
-- If a future profiling pass does justify pursuing `io_uring`, the correct
-  next step is a narrowly scoped, Linux-only, feature-flagged prototype
-  limited to the shared `EventLoop`'s existing readiness/idle-wait roles
-  (not a rewrite of worker I/O or of the native-TLS path's own local
-  `poll()`-based per-request wait), matching #148's original "Prototype
-  Linux `io_uring` support behind a feature flag" proposal, with its own
-  follow-up issue and its own benchmark evidence gathered on real hardware
-  (per the project's standing practice — see `docs/UPSTREAM_POOLING.md` and
-  `CONCURRENCY.md`, both of which note that benchmark numbers must be
-  captured on real hardware, not in a sandboxed dev/CI environment). See
-  "Failure modes and fallback policy" below for the minimum policy such a
-  prototype must define before it lands.
+- The narrowly scoped, Linux-only, feature-flagged prototype described here —
+  limited to the shared `EventLoop`'s existing readiness/idle-wait roles, and
+  not a rewrite of worker I/O or of the native-TLS path's own local
+  `poll()`-based per-request wait — is what Phase 1 built, matching #148's
+  original "Prototype Linux `io_uring` support behind a feature flag"
+  proposal. What it still owes is benchmark evidence gathered on real
+  hardware (per the project's standing practice — see
+  `docs/UPSTREAM_POOLING.md` and `CONCURRENCY.md`, both of which note that
+  benchmark numbers must be captured on real hardware, not in a sandboxed
+  dev/CI environment). Until that exists, the prototype stays opt-in and the
+  default is unchanged. See "Failure modes and fallback policy" below for the
+  policy it implements.
 
-## Failure modes and fallback policy for a future `io_uring` backend
+## Phase 1 prototype (implemented)
+
+The readiness-only prototype specified by this document is implemented in
+`src/http/event_loop.zig` as `Backend.io_uring`. It sits behind the existing
+`add`/`modify`/`remove`/`wait` seam with no change to that seam's shape, and
+implements the policy in "Failure modes and fallback policy" below.
+
+### Configuration
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `TARDIGRADE_EVENT_LOOP_BACKEND` | `default` | `default` keeps the platform backend (`epoll`/`kqueue`). `io_uring` selects the prototype. `epoll`/`kqueue` may be named explicitly and fail closed if they are not this platform's backend. `auto` is rejected — the auto-detect-with-fallback mode sketched below is deliberately not implemented. |
+| `TARDIGRADE_EVENT_LOOP_IO_URING_ENTRIES` | `256` | Submission-queue depth; ignored by the other backends. Bounded to 64–4096. |
+
+The 256-entry default is chosen so the ring's mmap'd SQ/CQ memory (~24 KiB)
+fits inside the 64 KiB `RLIMIT_MEMLOCK` soft limit common on stock hosts;
+kernels before 5.12 charge ring memory against that limit, so a much deeper
+default would fail `io_uring_setup` with `ENOMEM` on exactly the 5.4-era
+kernels this prototype targets.
+
+### What it uses, and what it deliberately does not
+
+Only `IORING_OP_POLL_ADD`, `IORING_OP_POLL_REMOVE`, and `IORING_OP_TIMEOUT`
+(the last solely to implement `wait(timeout_ms)`'s bounded block). No
+`IORING_OP_ACCEPT`, no registered buffers or files, no multishot variants —
+adopting those requires the wider operation/completion abstraction that the
+"Backend abstraction boundary" section rules out of scope. Accordingly:
+
+- `accept()` and all per-request reads/writes stay outside the ring, as
+  blocking calls on worker threads, byte for byte as before.
+- The sharded per-shard accept `poll()` loops in `gateway_accept.zig` are
+  untouched and stay on `std.posix.poll()`.
+- `keepalive_park.zig`'s `ParkedRegistry` reaper, its maintenance-tick logic,
+  and `gateway_shutdown.zig`'s drain are untouched. As this document argued
+  after review, a readiness-only boundary exposes no per-connection
+  timer/cancellation operation, so there is nothing here that could simplify
+  them.
+
+The backend serves all three of the shared `EventLoop`'s roles identically to
+`epoll`: unsharded listener accept readiness, parked HTTP/1 keepalive
+readiness, and native-TLS `ActiveRegistry`/`ManagedConnection` handshake and
+idle readiness.
+
+### Behavioural differences from `epoll` that the adapter has to absorb
+
+These are the three places where the ring is not a drop-in for level-triggered
+`epoll`, and they are the parts most worth reviewing:
+
+1. **`POLL_ADD` is one-shot.** `epoll` in level-triggered mode keeps reporting
+   a fd until it is drained or removed, and callers depend on that — the
+   listener fd is registered once and never re-added. Every delivered
+   completion is therefore re-armed inside `wait` before it returns.
+2. **A completion carries the mask from when the poll fired**, not the fd's
+   readiness at `wait` time. A fd registered for read and write can be
+   reported writable on one iteration and readable on the next, where `epoll`
+   would have coalesced both. No readiness is lost — the fd is re-armed
+   immediately — but a caller may need one extra loop iteration. Closing this
+   gap needs `IORING_POLL_ADD_LEVEL`, which is Linux 5.13+ and therefore above
+   this prototype's 5.4 floor.
+3. **Closing a fd does not unregister it.** `epoll` drops a fd from every set
+   when it is closed, and this codebase relies on that:
+   `parkedConnectionCloseHook` and `activeConnectionCloseHook` only release
+   accounting slots, so the keepalive idle reaper and the active-connection
+   reaper close registered fds without unregistering them. The ring has no
+   equivalent implicit cleanup, so `add` treats a surviving table entry for a
+   fd it is asked to register as a stale registration for a recycled fd
+   number: it cancels the stale poll and takes the fd over, rather than
+   reporting the `EEXIST` that `EPOLL_CTL_ADD` would.
+
+A fourth difference is internal rather than behavioural: `epoll_ctl` is
+kernel-synchronized and safe to call from any thread while another sits in
+`epoll_wait`, which `removeReadFd` documents worker threads doing. The io_uring
+submission queue is plain shared memory, so every userspace ring mutation is
+taken under a mutex, and submitting threads call `io_uring_enter` themselves
+with `min_complete = 0` so a poll armed from a worker takes effect even while
+the loop thread is blocked in its own `io_uring_enter`. Registrations carry a
+monotonic token in the high half of `user_data` so that a completion racing
+with a `POLL_REMOVE` is discarded rather than reported against a fd the caller
+has already removed and possibly closed.
+
+### Capability probing
+
+`IoUring.init` succeeding only proves the 5.1 ring baseline, so the three
+opcodes are established explicitly at startup rather than inferred from a
+compile-time Linux check. `IORING_REGISTER_PROBE` is used where available and
+checks all three opcodes directly — but that register opcode is itself only
+present from 5.6, so kernels in the 5.1–5.5 window instead get a functional
+probe that submits an already-expired `IORING_OP_TIMEOUT` and requires the
+kernel to complete it with `-ETIME` rather than reject it. That functional
+probe is what actually enforces this prototype's 5.4 floor.
+
+### Validation status — read this before citing the prototype
+
+- **Unit tests:** the `epoll`/`kqueue` behaviour tests in `event_loop.zig` are
+  mirrored for the `io_uring` backend (write readiness, `modify` replacing
+  interest, re-arm persistence, removal, recycled-fd re-registration), plus
+  fail-closed tests for an unavailable backend and an unusable ring size. The
+  behaviour tests skip themselves when `io_uring_setup` is unavailable —
+  container seccomp profiles, Docker's default among them, block it outright —
+  since that is an environment property, not a defect in the backend.
+- **Not executed by the author.** The development host for this change was
+  macOS/arm64, where the io_uring path is compiled out entirely. It was
+  validated there by cross-compiling for `x86_64-linux-gnu` (both the gateway
+  binary and the test binaries build clean) and by review, **not** by running
+  it. The Linux CI jobs are the first place these tests actually execute.
+- **No benchmark evidence of any kind.** No profiling pass has shown the
+  shared `EventLoop`'s readiness/idle-wait role to be a bottleneck, and no
+  throughput or latency comparison against `epoll` has been run. Per
+  `docs/CONCURRENCY.md` and `docs/UPSTREAM_POOLING.md`, such numbers must come
+  from real hardware, not a sandboxed dev or CI environment. Nothing in this
+  change should be cited as evidence that `io_uring` is faster, slower, or
+  equivalent for this workload.
+- **Not recommended for production use.** It is a prototype whose purpose is
+  to make the option measurable.
+
+### What would close #148
+
+Running the `benchmarks/` harness (#136) on representative hardware against
+both backends under high-churn and many-idle-keepalive workloads, plus the
+`perf record -g` pass described under "Long-term". If that evidence shows no
+measurable win, the honest outcome is to remove this prototype rather than
+carry it, and this document should say so.
+
+## Failure modes and fallback policy for the `io_uring` backend
 
 #148 requires failure modes, kernel/toolchain requirements, and fallback
 behavior to be documented as part of the design, not deferred to whenever a
-prototype is written. This section states that policy now so a future
-feature-flagged prototype has a contract to implement against, even though
-no prototype exists yet:
+prototype is written. This section stated that policy before any prototype
+existed; the Phase 1 prototype implements it, and the policy below is now the
+contract that backend is held to:
 
 - **Default unchanged.** `epoll`/`kqueue` remains the only backend selected
   by default on every platform, in every mode (including when listener
   sharding is enabled, where the shards' own `poll()` loops are separate
   from `EventLoop` entirely — see "Current architecture" above).
 - **Explicit opt-in fails closed, not open.** If an operator explicitly
-  requests an `io_uring` backend (e.g. a future
-  `TARDIGRADE_EVENT_LOOP_BACKEND=io_uring`-style flag) and required kernel
+  requests an `io_uring` backend (`TARDIGRADE_EVENT_LOOP_BACKEND=io_uring`)
+  and required kernel
   capabilities cannot be established at startup — unsupported kernel version,
   missing opcodes, seccomp/container restrictions blocking `io_uring_setup`,
   or resource exhaustion (`RLIMIT_MEMLOCK`, ring allocation failure) — the

--- a/docs/EVENT_LOOP_BACKENDS.md
+++ b/docs/EVENT_LOOP_BACKENDS.md
@@ -533,11 +533,23 @@ probe is what actually enforces this prototype's 5.4 floor.
   behaviour tests skip themselves when `io_uring_setup` is unavailable —
   container seccomp profiles, Docker's default among them, block it outright —
   since that is an environment property, not a defect in the backend.
-- **Not executed by the author.** The development host for this change was
-  macOS/arm64, where the io_uring path is compiled out entirely. It was
-  validated there by cross-compiling for `x86_64-linux-gnu` (both the gateway
-  binary and the test binaries build clean) and by review, **not** by running
-  it. The Linux CI jobs are the first place these tests actually execute.
+- **Executed on Linux by CI, not by the author.** The development host for
+  this change was macOS/arm64, where the io_uring path compiles out entirely;
+  it was validated there only by cross-compiling for `x86_64-linux-gnu` and by
+  review. The Linux CI jobs were the first actual execution, and all six
+  io_uring tests ran and passed there on both `ubuntu-latest` (x86_64) and
+  `ubuntu-24.04-arm` (aarch64) — confirmed by skip-count differential: the
+  macOS job skips 7 tests where the Linux jobs skip 1, and the difference of 6
+  is exactly this backend's tests. So `io_uring_setup` is not blocked on those
+  runners, the capability probe succeeds, and the readiness, `modify`,
+  re-arm, removal, and recycled-fd paths all behave as intended on a live
+  kernel.
+- **The 5.1–5.5 probe fallback is still unexercised.** CI runners are on
+  modern kernels where `IORING_REGISTER_PROBE` is available, so probing always
+  takes the register path. The functional `-ETIME` fallback — the branch that
+  actually enforces the documented 5.4 floor — has never run. Anyone
+  validating this prototype against a 5.4-era kernel should treat that path as
+  unverified.
 - **No benchmark evidence of any kind.** No profiling pass has shown the
   shared `EventLoop`'s readiness/idle-wait role to be a bottleneck, and no
   throughput or latency comparison against `epoll` has been run. Per

--- a/docs/EVENT_LOOP_BACKENDS.md
+++ b/docs/EVENT_LOOP_BACKENDS.md
@@ -581,7 +581,7 @@ loop.
 - **Executed on Linux by CI, not by the author.** The development host for
   this change was macOS/arm64, where the io_uring path compiles out entirely;
   it was validated there only by cross-compiling for `x86_64-linux-gnu` and by
-  review. The Linux CI jobs were the first actual execution, and all six
+  review. The Linux CI jobs were the first actual execution, and all eight
   io_uring tests ran and passed there on both `ubuntu-latest` (x86_64) and
   `ubuntu-24.04-arm` (aarch64) — confirmed by skip-count differential: the
   macOS job skips 9 tests where the Linux jobs skip 1, and the difference of 8

--- a/docs/EVENT_LOOP_BACKENDS.md
+++ b/docs/EVENT_LOOP_BACKENDS.md
@@ -46,10 +46,49 @@ detail in [`docs/CONCURRENCY.md`](CONCURRENCY.md):
   on raw fds, with `Interest{ read, write }` and a fixed-capacity `Event`
   output array. `EventLoop.init()` picks the backend from `builtin.os.tag` at
   compile/runtime; there is no runtime backend override today.
-- The event loop's job is narrow: watch the listener fd(s) for `accept`
-  readiness and watch **parked idle keepalive connections**
-  (`src/http/keepalive_park.zig`, #138) for the next request byte. It is not
-  a general async-I/O runtime — active request handling never touches it.
+- The single shared `EventLoop` instance in `edge_gateway.zig`'s main loop
+  currently has **three** roles, not one:
+  1. **Unsharded listener accept readiness** — only when listener sharding
+     (#137) is off. The main loop's `event_loop.wait()` result checks
+     `ev.fd == listen_fd and !sharding_enabled` before calling
+     `gaccept.acceptReadyConnections`.
+  2. **Parked HTTP/1 keepalive readiness** for the legacy blocking
+     OpenSSL/plaintext path (`src/http/keepalive_park.zig`'s
+     `ParkedRegistry`, #138) — the idle gap between requests on a
+     keep-alive connection served by a worker.
+  3. **Active managed/native downstream readiness and drive scheduling**
+     for the optional pure-Zig (`native_tls_provider`) TLS path
+     (`src/http/downstream_connection.zig`'s `ActiveRegistry` /
+     `ManagedConnection`): the main loop checks `active.contains(ev.fd)`
+     before the listener/park checks and dispatches
+     `worker_pool.submitActiveSocketReady`. A native connection is
+     registered here while waiting for TLS handshake bytes
+     (`native_handshake` phase) and again for the idle gap between
+     requests once negotiated (`native_http1`/`native_http2` phases,
+     `rearmActiveConnection`); `active.reapExpired` and
+     `active.dueDrivePollFds`, driven from the same periodic maintenance
+     tick as `keepalive_park`'s reaper, handle handshake-deadline expiry
+     and scheduled re-drives. **Actual per-request I/O for a checked-out
+     native connection still blocks** — `advanceNativeHttp1`/
+     `advanceNativeHttp2` call `serveOneRequest` through a
+     `WaitingEncryptedHttpConnection` adapter whose `waitFor` does its own
+     local, per-call `std.posix.poll()` rather than looping back through
+     the shared `EventLoop`. So the shared loop's role for this path,
+     like for parked keepalive, is bounding idle/handshake wait time off
+     a worker thread — not driving the request hot path.
+  Request processing on the default OpenSSL/plaintext path is unaffected by
+  any of this: it never touches `EventLoop` and blocks on the worker thread
+  for its full lifecycle.
+- When listener sharding (#137) is enabled
+  (`TARDIGRADE_LISTENER_SHARDS > 1` on a platform with
+  `SO_REUSEPORT`/`SO_REUSEPORT_LB`), accept readiness for **all** shards is
+  handled entirely outside the shared `EventLoop`: each shard thread runs
+  its own independent blocking `poll()` loop
+  (`gaccept.runShardAcceptLoop`/`acceptReadyConnectionsShard` in
+  `src/gateway_accept.zig`) against its own listener fd, and the shared
+  `EventLoop` registers no listener fd at all in that mode — it still
+  handles roles 2 and 3 above. Accepted fds from every shard still enter
+  the same bounded worker pool.
 - Accepted connections are dispatched to a bounded `WorkerPool`
   (`src/http/worker_pool.zig`) of OS threads. Each worker owns one
   connection's full synchronous lifecycle — TLS handshake, HTTP parse,
@@ -60,10 +99,6 @@ detail in [`docs/CONCURRENCY.md`](CONCURRENCY.md):
   Tardigrade needs direct control over thread count, work-stealing, CPU
   affinity, and drain-before-shutdown semantics for a production reverse
   proxy.
-- Listener sharding (#137) runs one independent blocking `poll()`-based
-  accept loop per shard thread (`src/gateway_accept.zig`) when
-  `TARDIGRADE_LISTENER_SHARDS > 1` and `SO_REUSEPORT`/`SO_REUSEPORT_LB` is
-  available; accepted fds still enter the same bounded worker pool.
 - `docs/CONCURRENCY.md` already states the project's standing position on
   this exact question: *"Do not start an `io_uring` or async-runtime rewrite
   from this boundary. Any new backend must be benchmark-justified and fit
@@ -101,12 +136,14 @@ framing, and proxy streaming.
 ### A. Current model — direct `epoll`/`kqueue`, thread-per-request workers
 
 - **Linux fast path:** Mature, well-understood, level-triggered epoll used
-  only for accept + parked-keepalive readiness (a small fraction of total
-  I/O — active request I/O is synchronous blocking calls on worker threads).
-  No known syscall-count problem has been measured in this narrow role;
-  #148's own research basis frames `io_uring`'s syscall-reduction pitch as
-  most valuable for I/O-heavy async runtimes, which this narrow accept/park
-  loop is not.
+  for unsharded listener accept, parked-keepalive readiness, and native-TLS
+  active-connection handshake/idle readiness (see "Current architecture"
+  above for all three roles) — in every case bounding idle wait time off a
+  worker thread, not driving per-request I/O, which stays synchronous
+  blocking calls on worker threads. No known syscall-count problem has been
+  measured in this role; #148's own research basis frames `io_uring`'s
+  syscall-reduction pitch as most valuable for I/O-heavy async runtimes,
+  which this readiness-only loop is not.
 - **macOS/kernel requirements:** `kqueue` is available on every supported
   BSD/macOS target with no minimum-version gymnastics. No portability
   fallback logic needed — it already covers both `SUPPORT_MATRIX.md`
@@ -114,10 +151,14 @@ framing, and proxy streaming.
 - **Complexity / maintenance:** Already implemented, tested, and in
   production use (398 lines, unit-tested for both backends via CI matrix).
   Zero incremental maintenance cost to keep it.
-- **TLS/encrypted-stream integration:** Already fully integrated —
-  `keepalive_park.zig` moves `TlsConnection` state off the worker stack
-  across the idle gap and the event loop only tracks fd readiness, never TLS
-  record state.
+- **TLS/encrypted-stream integration:** Already fully integrated for both
+  TLS paths — `keepalive_park.zig` moves the legacy blocking `TlsConnection`
+  (OpenSSL) state off the worker stack across the idle gap, and
+  `downstream_connection.ActiveRegistry`/`ManagedConnection` does the
+  analogous thing for the optional pure-Zig native TLS path (handshake wait
+  and idle-between-requests wait). In both cases the event loop only tracks
+  fd readiness; it never touches TLS record state or drives handshake/record
+  processing itself.
 - **Proxy streaming / backpressure:** Already integrated with #139's
   streaming relay and #140's (in-progress) watermark work, which are both
   built on synchronous blocking reads/writes, not on event-loop readiness
@@ -146,9 +187,12 @@ framing, and proxy streaming.
 
 - Not vendored or referenced anywhere in this repository today (`libxev`
   search returns no hits).
-- Would require adopting `libxev`'s completion-based (io_uring-on-Linux,
-  kqueue-on-BSD/macOS, IOCP-on-Windows) async model, which is fundamentally
-  callback/completion-oriented — a different concurrency shape than
+- Would require adopting `libxev`'s completion-based async model
+  (`io_uring` or epoll on Linux, `kqueue` on macOS, and WASM, per upstream
+  `mitchellh/libxev` docs; Windows/IOCP is documented upstream as
+  planned/upcoming rather than a currently shipped backend), which is
+  fundamentally callback/completion-oriented — a different concurrency shape
+  than
   Tardigrade's blocking-thread-per-request handler. Adopting it for real gain
   would mean rewriting the request handler to be non-blocking end-to-end
   (TLS, HTTP parsing, proxy relay, FastCGI/SCGI/uWSGI transports), which
@@ -193,8 +237,15 @@ framing, and proxy streaming.
   through one submission/completion queue), which is exactly the shape
   Tardigrade's worker pool does *not* have — each worker already does one
   blocking `read`/`write` at a time on its own thread. The event loop's
-  actual `io_uring`-addressable surface today is narrow: listener accept and
-  parked-keepalive readiness, not the request hot path. Useful `io_uring`
+  actual `io_uring`-addressable surface today spans three readiness roles
+  (unsharded listener accept, legacy-TLS/plaintext parked keepalive, and
+  native-TLS active-connection handshake/idle readiness — see "Current
+  architecture" above), plus the sharded per-shard accept `poll()` loops if
+  those were also moved onto it, but in every case it is readiness/idle-wait
+  scheduling, not the request hot path itself: per-request reads/writes stay
+  synchronous blocking calls on worker threads (including within the
+  native-TLS path's own `WaitingEncryptedHttpConnection.waitFor`, which polls
+  locally rather than through the shared loop). Useful `io_uring`
   features (e.g. `IORING_OP_ACCEPT`, fixed buffers, registered fds) require
   reasonably recent kernels (5.5+ minimum, several features need 5.11+ or
   5.19+), which is a real portability constraint the current epoll fallback
@@ -206,12 +257,14 @@ framing, and proxy streaming.
   new submission/completion-queue lifecycle code, a second set of
   cancellation/timeout semantics, and (per Envoy's and Monoio's own
   documented experience, cited in #148's research basis) materially more
-  operational surface than epoll for a comparatively narrow accept/park role
-  in this codebase's current architecture.
+  operational surface than epoll for a readiness/idle-wait role — even
+  spanning all three current `EventLoop` responsibilities — that never
+  drives per-request I/O in this codebase's current architecture.
 - **TLS/encrypted-stream integration:** Would not change — TLS record
-  handling happens inside the blocking worker, not in the event loop, so
-  `io_uring` adoption at the accept/park boundary would not touch TLS state
-  machines either way.
+  handling (both the legacy OpenSSL path and the native pure-Zig path)
+  happens inside the blocking worker once a connection is checked out, not
+  in the event loop, so `io_uring` adoption at the readiness/idle-wait
+  boundary described above would not touch TLS state machines either way.
 - **Proxy streaming and backpressure:** No expected interaction with #139
   (streaming relay) or #140 (watermark backpressure) as currently designed,
   since both operate on synchronous blocking reads/writes inside worker
@@ -228,10 +281,10 @@ framing, and proxy streaming.
 
 | Dimension | A. Current (epoll/kqueue) | B. Cleaner direct abstraction | C. `libxev` | D. `std.Io` proactor | E. Direct `io_uring` |
 |---|---|---|---|---|---|
-| Linux fast path today | Proven, narrow role | Same as A | Needs non-blocking rewrite to pay off | Not production-ready on 0.16 for socket path | Real upside only for non-blocking, high-fan-out I/O Tardigrade doesn't have yet |
+| Linux fast path today | Proven, readiness-only role (accept/park/native-active) | Same as A | Needs non-blocking rewrite to pay off | Not production-ready on 0.16 for socket path | Real upside only for non-blocking, high-fan-out I/O Tardigrade doesn't have yet |
 | macOS support | Native (`kqueue`) | Native | Native (kqueue backend) | Blocked on 0.16 maturity | None — Linux-only, needs feature-flag gate |
 | Complexity / maintenance | Already paid for | Refactor cost, no new capability | New dependency + handler rewrite | Blocked, not a maintenance question yet | High — new SQ/CQ lifecycle, cancellation model |
-| TLS integration | Done, out of event loop's path | Unaffected | Would need rework if handler goes non-blocking | Unaffected until viable | Unaffected (TLS stays in worker) |
+| TLS integration | Done for both OpenSSL (park) and native (active registry) paths, out of event loop's path | Unaffected | Would need rework if handler goes non-blocking | Unaffected until viable | Unaffected (TLS stays in worker) |
 | Proxy streaming/backpressure (#139/#140) | Built on blocking relay, already integrated | Unaffected | Would require redesign | Already broke FastCGI in production (Phase 2) | No interaction as currently designed |
 | Timers/cancellation/parking/drain | Implemented, no known bottleneck | Unaffected | Would move into libxev's model | Unaffected until viable | Could simplify parking reaper, unproven need |
 | Prototype required to decide? | N/A (shipped) | No | Only if handler model changes | No — blocked on toolchain, not on prototyping | Not yet (see recommendation) |
@@ -254,20 +307,24 @@ framing, and proxy streaming.
   `tardigrade_event_loop_iterations_total` counter (the backend name is
   already computed via `EventLoop.backendName()` and already logged once at
   startup), so operators can see the active backend in
-  `/status/metrics` without parsing startup logs. This is a few-line,
-  low-risk metrics change independent of the architecture question and can
-  land whenever convenient; it is not required to close #148.
+  `/status/metrics` without parsing startup logs. This can land
+  independently of the architecture prototype work; this Phase 0 PR does not
+  implement it, and it remains follow-up work under #148 before closure,
+  per #148's "Metrics to add or verify" section (event-loop backend
+  identifier in logs/metrics, `tardigrade_event_loop_iterations_total{backend=...}`).
 
 ### Long-term
 
 - **`io_uring` is a "later, and only if measured" candidate, not a "now" or
   "never."** The condition for revisiting it: #140 lands, and a profiling
   pass (`perf record -g` per `CONCURRENCY.md`'s "How to measure" section)
-  against the `benchmarks/` harness (#136) shows the accept/park event-loop
-  path — not worker-thread blocking I/O — is a measurable bottleneck under
-  realistic high-churn or many-idle-keepalive workloads. Given the event
-  loop's current narrow role, that evidence does not exist yet and this doc
-  does not manufacture it.
+  against the `benchmarks/` harness (#136) shows the shared `EventLoop`'s
+  readiness/idle-wait role (unsharded accept, parked keepalive, and/or
+  native-TLS active-connection scheduling — see "Current architecture"
+  above) — not worker-thread blocking I/O — is a measurable bottleneck under
+  realistic high-churn or many-idle-keepalive workloads. Given that role is
+  readiness/idle-wait scheduling rather than the request hot path, that
+  evidence does not exist yet and this doc does not manufacture it.
 - **`libxev` and `std.Io` proactor mode are "not now" for a different
   reason each:** `libxev` requires a handler-model rewrite this project has
   explicitly deferred (`worker_pool.zig`); `std.Io`'s proactor facilities are
@@ -277,13 +334,64 @@ framing, and proxy streaming.
   toolchain bump.
 - If a future profiling pass does justify pursuing `io_uring`, the correct
   next step is a narrowly scoped, Linux-only, feature-flagged prototype
-  limited to the accept/park boundary (not a rewrite of worker I/O), matching
-  #148's original "Prototype Linux `io_uring` support behind a feature flag"
-  proposal, with its own follow-up issue and its own benchmark evidence
-  gathered on real hardware (per the project's standing practice — see
-  `docs/UPSTREAM_POOLING.md` and `CONCURRENCY.md`, both of which note that
-  benchmark numbers must be captured on real hardware, not in a sandboxed
-  dev/CI environment).
+  limited to the shared `EventLoop`'s existing readiness/idle-wait roles
+  (not a rewrite of worker I/O or of the native-TLS path's own local
+  `poll()`-based per-request wait), matching #148's original "Prototype
+  Linux `io_uring` support behind a feature flag" proposal, with its own
+  follow-up issue and its own benchmark evidence gathered on real hardware
+  (per the project's standing practice — see `docs/UPSTREAM_POOLING.md` and
+  `CONCURRENCY.md`, both of which note that benchmark numbers must be
+  captured on real hardware, not in a sandboxed dev/CI environment). See
+  "Failure modes and fallback policy" below for the minimum policy such a
+  prototype must define before it lands.
+
+## Failure modes and fallback policy for a future `io_uring` backend
+
+#148 requires failure modes, kernel/toolchain requirements, and fallback
+behavior to be documented as part of the design, not deferred to whenever a
+prototype is written. This section states that policy now so a future
+feature-flagged prototype has a contract to implement against, even though
+no prototype exists yet:
+
+- **Default unchanged.** `epoll`/`kqueue` remains the only backend selected
+  by default on every platform, in every mode (including when listener
+  sharding is enabled, where the shards' own `poll()` loops are separate
+  from `EventLoop` entirely — see "Current architecture" above).
+- **Explicit opt-in fails closed, not open.** If an operator explicitly
+  requests an `io_uring` backend (e.g. a future
+  `TARDIGRADE_EVENT_LOOP_BACKEND=io_uring`-style flag) and required kernel
+  capabilities cannot be established at startup — unsupported kernel version,
+  missing opcodes, seccomp/container restrictions blocking `io_uring_setup`,
+  or resource exhaustion (`RLIMIT_MEMLOCK`, ring allocation failure) — the
+  process must fail startup with a clear error, not silently fall back to
+  epoll. An operator who explicitly asked for `io_uring` needs to know their
+  deployment target doesn't support it, not discover a silent downgrade
+  later during an incident.
+- **A future `auto` mode, if ever added, fails safe before accepting
+  traffic.** If a later revision adds an auto-detect mode, capability
+  probing must happen during startup, before the listener(s) start
+  accepting connections; a failed probe logs/increments a metric with the
+  failure reason and falls back to `epoll`, never mid-flight.
+- **No runtime hot-switching.** Once a backend is selected at startup, the
+  process does not switch backends while running. Runtime SQ/CQ errors
+  (e.g. a ring entering a bad state after `io_uring_enter` failures) are not
+  a live-migration trigger back to epoll; they surface through the same
+  error/drain semantics `gateway_shutdown.zig` already uses for other fatal
+  runtime conditions (log, drain, exit), consistent with how the current
+  `EventLoop.wait()` error path already just logs and continues rather than
+  trying to self-heal by rebuilding the poller.
+- **Kernel/toolchain requirements, if pursued:** modern `io_uring` opcodes
+  useful here (`IORING_OP_ACCEPT`, fixed buffers/files, multishot variants)
+  need meaningfully newer kernels than the epoll baseline requires — commonly
+  cited minimums range from 5.5 (basic ring support) through 5.11/5.19 for
+  specific opcodes/features relevant to a listener-readiness use case. A
+  prototype must pin and document the exact minimum kernel version it
+  targets and probe for it explicitly rather than assuming availability from
+  a compile-time Linux check.
+
+This policy applies to whichever `EventLoop` role(s) a future prototype
+targets (unsharded accept, parked keepalive, and/or native-TLS active
+readiness); it does not change based on which of those roles is chosen.
 
 ## Metrics
 

--- a/docs/EVENT_LOOP_BACKENDS.md
+++ b/docs/EVENT_LOOP_BACKENDS.md
@@ -19,7 +19,7 @@ buffering/backpressure, and upstream connection economics," and states it
 "should be tackled after #137, #138, #139, #140, and #141 provide stronger
 baseline wins."
 
-## Dependency status (checked 2026-08-10)
+## Dependency status (checked 2026-08-10, updated after #600 merged)
 
 | Issue | Title | Status |
 |---|---|---|
@@ -27,14 +27,16 @@ baseline wins."
 | #137 | Per-core listener sharding (`SO_REUSEPORT`) | Closed |
 | #138 | Park idle keepalive connections outside workers | Closed |
 | #139 | Streaming reverse proxy with bounded buffering | Closed |
-| #140 | Watermark-based backpressure for proxy/connection buffers | **Open** — PR #600 (HTTP/1 relay buffer bounding) in flight |
+| #140 | Watermark-based backpressure for proxy/connection buffers | Closed — PR #600 (per-origin HTTP/1 relay buffer bounding, merged after #595/#599/#418) |
 | #141 | Upstream connection pooling redesign | Closed |
 
-Four of the five prerequisite baseline-wins issues are closed; #140 is not.
-Per #148's own stated ordering, this is not yet the point at which a
-prototype or migration should start. This doc proceeds only as far as the
-design/comparison work, and defers the prototype/benchmark decision until
-#140 lands (see "Recommendation" below).
+All five prerequisite baseline-wins issues named in #148's own stated
+ordering ("should be tackled after #137, #138, #139, #140, and #141 provide
+stronger baseline wins") are now closed. That clears the *ordering*
+precondition — it does not by itself supply the profiling evidence #148's
+acceptance criteria still require before a prototype is justified (see
+"Recommendation" below); it removes the one concrete reason this doc
+previously gave for not starting that evidence-gathering yet.
 
 ## Current architecture and poller assumptions
 
@@ -196,8 +198,9 @@ at all unless a separate future change first migrates them onto the shared
   fd readiness; it never touches TLS record state or drives handshake/record
   processing itself.
 - **Proxy streaming / backpressure:** Already integrated with #139's
-  streaming relay and #140's (in-progress) watermark work, which are both
-  built on synchronous blocking reads/writes, not on event-loop readiness
+  streaming relay and #140's (now closed) watermark/buffer-accounting work,
+  which are both built on synchronous blocking reads/writes, not on
+  event-loop readiness
   callbacks.
 - **Timers, cancellation, keepalive parking, graceful drain:** Already
   implemented (`keepalive_park.zig` idle reaper on the maintenance tick,
@@ -346,13 +349,28 @@ at all unless a separate future change first migrates them onto the shared
 
 - **No backend change.** Keep the existing `epoll`/`kqueue` `EventLoop` as
   the only backend, exactly as `docs/CONCURRENCY.md` already directs.
-- **No `io_uring`, `libxev`, or `std.Io` proactor prototype in this PR or in
-  the immediate next one.** #148's own dependency ordering says this issue
-  should follow stronger baseline wins from #137–#141, and #140
-  (watermark-based backpressure) is still open with PR #600 in flight. Since
-  #140's design directly shapes how proxy buffers would interact with any
-  future async I/O model, starting an `io_uring` prototype before it lands
-  risks throwaway work.
+- **Ordering precondition cleared; evidence precondition is not.** #140
+  (watermark-based backpressure) merged via PR #600, closing out the last of
+  #148's named prerequisites (#137, #138, #139, #140, #141 are all now
+  closed). That removes the *specific* reason this doc previously gave for
+  not starting `io_uring` work yet — the risk of throwaway design work while
+  #140's buffer-accounting model was still moving. It does **not** supply
+  the separate thing #148's acceptance criteria actually require before a
+  prototype is justified: profiling evidence, gathered against the
+  `benchmarks/` harness (#136) on real hardware, showing the shared
+  `EventLoop`'s readiness/idle-wait role is a measurable bottleneck (see
+  "Long-term" below for the exact bar). Nothing in #600's scope changes that
+  bar or supplies that evidence — #600 bounds HTTP/1 relay memory per
+  origin, which is orthogonal to whether the accept/park/native-TLS
+  readiness loop is a bottleneck.
+- **Still no `io_uring`, `libxev`, or `std.Io` proactor prototype in this
+  PR.** With the ordering precondition cleared, the next concrete step is
+  gathering that profiling evidence (or determining it's not worth
+  gathering yet against other roadmap priorities) — not writing prototype
+  code speculatively. This sandboxed session also has no Zig toolchain and
+  no representative benchmarking hardware, so it could not produce that
+  evidence even if it attempted to; see "Long-term" for what a prototype
+  attempt needs before it starts.
 - **Small independent follow-up (optional, not gated on the rest of this
   doc):** attach a `backend` label to the existing
   `tardigrade_event_loop_iterations_total` counter (the backend name is
@@ -367,9 +385,10 @@ at all unless a separate future change first migrates them onto the shared
 ### Long-term
 
 - **`io_uring` is a "later, and only if measured" candidate, not a "now" or
-  "never."** The condition for revisiting it: #140 lands, and a profiling
-  pass (`perf record -g` per `CONCURRENCY.md`'s "How to measure" section)
-  against the `benchmarks/` harness (#136) shows the shared `EventLoop`'s
+  "never."** With #140 now closed, the remaining condition for revisiting it
+  is a profiling pass (`perf record -g` per `CONCURRENCY.md`'s "How to
+  measure" section) against the `benchmarks/` harness (#136) that shows the
+  shared `EventLoop`'s
   readiness/idle-wait role (unsharded accept, parked keepalive, and/or
   native-TLS active-connection scheduling — see "Current architecture"
   above) — not worker-thread blocking I/O — is a measurable bottleneck under
@@ -480,10 +499,14 @@ or prototype effort), not to a design-only doc.
 
 - Depends on / informed by: #136 (closed, benchmark harness exists), #137
   (closed, listener sharding), #138 (closed, keepalive parking), #139
-  (closed, streaming proxy), #141 (closed, upstream pooling).
-- Blocked on: #140 (open) for the buffer-accounting model any future async
-  I/O design would need to interact with.
+  (closed, streaming proxy), #140 (closed, watermark/buffer-accounting
+  model), #141 (closed, upstream pooling). All five of #148's named
+  prerequisites are now closed.
+- Not blocked on any other open issue. The remaining precondition is
+  profiling evidence, not another issue's completion — see "Recommendation"
+  above.
 - No follow-up implementation issues are opened by this doc, per #148's own
   acceptance criterion that "focused follow-up implementation issues are
   created only if a migration or additional backend is approved" — this doc
-  approves neither.
+  approves neither. #148 itself stays open to track the still-missing
+  profiling/benchmark evidence and the eventual prototype decision.

--- a/docs/EVENT_LOOP_BACKENDS.md
+++ b/docs/EVENT_LOOP_BACKENDS.md
@@ -150,7 +150,7 @@ framing, and proxy streaming.
 **This constrains what a future `io_uring` backend may be, and this doc picks
 the narrower of the two honest options:** a future `io_uring` backend
 targeting this boundary is a **readiness-only poller replacement** —
-`IORING_OP_POLL_ADD`/`IORING_OP_POLL_REMOVE` (plus a ring-native timeout for
+`IORING_OP_POLL_ADD`/`IORING_OP_POLL_REMOVE` plus `IORING_OP_TIMEOUT` (for
 `wait`'s bounded-block behavior) standing in for `epoll_wait`/`kqueue`, with
 `accept()` and all request I/O staying exactly where they are today: outside
 the ring, as blocking calls on worker threads. It is **not** a wider
@@ -283,14 +283,17 @@ at all unless a separate future change first migrates them onto the shared
   native-TLS path's own `WaitingEncryptedHttpConnection.waitFor`, which polls
   locally rather than through the shared loop). Per the "Backend abstraction
   boundary" section above, a backend targeting this boundary is
-  **readiness-only** (`IORING_OP_POLL_ADD`/`IORING_OP_POLL_REMOVE` plus a
-  ring-native timeout) — it does not use `IORING_OP_ACCEPT`, registered
+  **readiness-only** (`IORING_OP_POLL_ADD`/`IORING_OP_POLL_REMOVE` plus
+  `IORING_OP_TIMEOUT`) — it does not use `IORING_OP_ACCEPT`, registered
   buffers/files, or multishot variants, since those require widening the
   boundary to an operation/completion abstraction, which is explicitly out
-  of scope for Phase 0. The readiness-only operation set is available from
-  the original `io_uring` interface (Linux 5.1); see "Failure modes and
-  fallback policy" below for how kernel-requirement documentation should be
-  structured if a wider abstraction is ever proposed instead.
+  of scope for Phase 0. `POLL_ADD`/`POLL_REMOVE` exist from the original
+  `io_uring` interface (Linux 5.1), but this readiness-only prototype's
+  actual minimum is **Linux 5.4**, because `EventLoop.wait(timeout_ms)`'s
+  bounded-block behavior is implemented with `IORING_OP_TIMEOUT`, which is
+  not present in 5.1; see "Failure modes and fallback policy" below for how
+  kernel-requirement documentation should be structured if a wider
+  abstraction is ever proposed instead.
 - **macOS support:** None — `io_uring` is Linux-only, so this would always
   need to stay behind a compile-time/feature-flag gate with `epoll`/`kqueue`
   as the portable default, exactly as #148 already proposes.
@@ -310,11 +313,18 @@ at all unless a separate future change first migrates them onto the shared
   (streaming relay) or #140 (watermark backpressure) as currently designed,
   since both operate on synchronous blocking reads/writes inside worker
   threads, not on event-loop-driven readiness.
-- **Timers, cancellation, keepalive parking, graceful drain:** `io_uring`
-  can express timeouts and cancellation natively, which could simplify
-  `keepalive_park.zig`'s reaper in principle, but the current reaper (a
-  periodic scan under one mutex) is not a known bottleneck — no profiling
-  evidence in this repo suggests it needs replacing.
+- **Timers, cancellation, keepalive parking, graceful drain:** Unchanged at
+  the readiness-only boundary chosen above. The retained API is still just
+  `add`/`modify`/`remove` plus one bounded `wait(timeout_ms)` — it has no
+  per-connection timer-submission or cancellation operation.
+  `IORING_OP_TIMEOUT` is used only to implement that single bounded
+  `wait()`, not a per-connection deadline; `keepalive_park.zig`'s
+  `ParkedRegistry` maintenance-tick reaper and `gateway_shutdown.zig`'s
+  drain behavior are unaffected and unchanged either way. `io_uring` *can*
+  express native per-operation timeouts and cancellation in general, but
+  using that to actually simplify the reaper would require the wider
+  operation/completion abstraction this doc explicitly defers (see "Backend
+  abstraction boundary"), not the readiness-only prototype scoped here.
 - **Prototype needed to resolve the decision?** Not yet — see
   "Recommendation."
 
@@ -327,7 +337,7 @@ at all unless a separate future change first migrates them onto the shared
 | Complexity / maintenance | Already paid for | Refactor cost, no new capability | New dependency + handler rewrite | Blocked, not a maintenance question yet | High — new SQ/CQ lifecycle, cancellation model |
 | TLS integration | Done for both OpenSSL (park) and native (active registry) paths, out of event loop's path | Unaffected | Would need rework if handler goes non-blocking | Unaffected until viable | Unaffected (TLS stays in worker) |
 | Proxy streaming/backpressure (#139/#140) | Built on blocking relay, already integrated | Unaffected | Would require redesign | Already broke FastCGI in production (Phase 2) | No interaction as currently designed |
-| Timers/cancellation/parking/drain | Implemented, no known bottleneck | Unaffected | Would move into libxev's model | Unaffected until viable | Could simplify parking reaper, unproven need |
+| Timers/cancellation/parking/drain | Implemented, no known bottleneck | Unaffected | Would move into libxev's model | Unaffected until viable | Unchanged at readiness-only boundary — reaper/drain untouched |
 | Prototype required to decide? | N/A (shipped) | No | Only if handler model changes | No — blocked on toolchain, not on prototyping | Not yet (see recommendation) |
 
 ## Recommendation
@@ -421,20 +431,25 @@ no prototype exists yet:
   runtime conditions (log, drain, exit), consistent with how the current
   `EventLoop.wait()` error path already just logs and continues rather than
   trying to self-heal by rebuilding the poller.
-- **Kernel/toolchain requirements, if pursued:** separate the **ring
-  baseline** from the **prototype's exact operation set**, rather than citing
-  one number for "basic support." `io_uring` itself — the
+- **Kernel/toolchain requirements, if pursued:** separate the **historical
+  ring/poll baseline** from **this prototype's actual minimum**, rather than
+  citing one number for "basic support." `io_uring` itself — the
   `io_uring_setup`/`io_uring_enter`/`io_uring_register` syscalls, and with
-  them `IORING_OP_POLL_ADD`/`IORING_OP_POLL_REMOVE` (the readiness-only
-  operation set this doc scopes a prototype to, per "Backend abstraction
-  boundary" above) — landed in Linux **5.1**. Individual capabilities this
-  doc explicitly excludes from a readiness-only prototype have their own,
-  later floors if a future wider abstraction ever adopts them:
-  `IORING_OP_ACCEPT` (5.5), multishot poll (5.13), and multishot accept
-  (5.19, per upstream `liburing` docs) are commonly cited examples, not an
-  exhaustive list. A prototype must pin and document the exact minimum
-  kernel version it targets **for the specific opcodes/features it actually
-  uses**, and probe for those capabilities explicitly at startup rather than
+  them `IORING_OP_POLL_ADD`/`IORING_OP_POLL_REMOVE` — landed in Linux
+  **5.1**. But the readiness-only prototype this doc actually scopes to (see
+  "Backend abstraction boundary") also relies on `IORING_OP_TIMEOUT` to
+  implement `EventLoop.wait(timeout_ms)`'s bounded-block behavior, and that
+  opcode is not present in 5.1 — it landed in Linux **5.4**. So **this
+  prototype's real minimum is Linux 5.4**, not 5.1, unless a future revision
+  explicitly chooses a different, non-`IORING_OP_TIMEOUT` bounded-wait
+  mechanism instead. Individual capabilities this doc explicitly excludes
+  from the readiness-only prototype have their own, later floors if a future
+  wider abstraction ever adopts them: `IORING_OP_ACCEPT` (5.5), multishot
+  poll (5.13), and multishot accept (5.19, per upstream `liburing` docs) are
+  commonly cited examples, not an exhaustive list. A prototype must pin and
+  document the exact minimum kernel version it targets **for the specific
+  opcodes/features it actually uses** — 5.4 for the operation set chosen
+  here — and probe for those capabilities explicitly at startup rather than
   assuming availability from a compile-time Linux check or from the 5.1 ring
   baseline alone.
 

--- a/src/edge_config.zig
+++ b/src/edge_config.zig
@@ -415,6 +415,18 @@ pub const EdgeConfig = struct {
     /// single-listener behavior.
     /// Set via TARDIGRADE_LISTENER_SHARDS.
     listener_shards: u16,
+    /// Event-loop backend override (#148). `null` keeps the platform default
+    /// (`epoll` on Linux, `kqueue` elsewhere), which is the shipped behavior.
+    /// Setting this to `io_uring` opts into the Linux-only readiness-only
+    /// `io_uring` poller; if its kernel capabilities cannot be established at
+    /// startup the process fails to start rather than silently downgrading to
+    /// `epoll`. Set via TARDIGRADE_EVENT_LOOP_BACKEND.
+    /// See docs/EVENT_LOOP_BACKENDS.md.
+    event_loop_backend: ?http.event_loop.Backend,
+    /// Submission-queue depth for the `io_uring` backend. Ignored by the
+    /// `epoll`/`kqueue` backends. Set via
+    /// TARDIGRADE_EVENT_LOOP_IO_URING_ENTRIES.
+    event_loop_io_uring_entries: u16,
     /// Enable master process supervision mode.
     master_process_enabled: bool,
     /// Number of worker processes when master mode is enabled.
@@ -1211,6 +1223,24 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
     defer allocator.free(worker_threads_str);
     const worker_threads = std.fmt.parseInt(u32, worker_threads_str, 10) catch 0;
     const listener_shards = parseIntEnv(u16, allocator, "TARDIGRADE_LISTENER_SHARDS", 0);
+    const event_loop_backend_str = envOrDefault(allocator, "TARDIGRADE_EVENT_LOOP_BACKEND", "default") catch unreachable;
+    defer allocator.free(event_loop_backend_str);
+    const event_loop_backend = try parseEventLoopBackendConfig(event_loop_backend_str);
+    const event_loop_io_uring_entries = parseIntEnv(
+        u16,
+        allocator,
+        "TARDIGRADE_EVENT_LOOP_IO_URING_ENTRIES",
+        http.event_loop.default_io_uring_entries,
+    );
+    if (event_loop_io_uring_entries < http.event_loop.min_io_uring_entries or
+        event_loop_io_uring_entries > http.event_loop.max_io_uring_entries)
+    {
+        logConfigDiagnostic("config validation failed: event_loop_io_uring_entries must be between {d} and {d}", .{
+            http.event_loop.min_io_uring_entries,
+            http.event_loop.max_io_uring_entries,
+        });
+        return error.InvalidConfigValue;
+    }
     const master_process_enabled = parseBoolEnv(allocator, "TARDIGRADE_MASTER_PROCESS", false);
     const worker_processes = parseIntEnv(u32, allocator, "TARDIGRADE_WORKER_PROCESSES", 1);
     const binary_upgrade_enabled = parseBoolEnv(allocator, "TARDIGRADE_BINARY_UPGRADE", true);
@@ -1668,6 +1698,8 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
         .cb_timeout_ms = cb_timeout_ms,
         .worker_threads = worker_threads,
         .listener_shards = listener_shards,
+        .event_loop_backend = event_loop_backend,
+        .event_loop_io_uring_entries = event_loop_io_uring_entries,
         .master_process_enabled = master_process_enabled,
         .worker_processes = worker_processes,
         .binary_upgrade_enabled = binary_upgrade_enabled,
@@ -2015,6 +2047,21 @@ fn parseAccessLogFormatConfig(raw: []const u8) !http.access_log.Format {
     const value = std.mem.trim(u8, raw, " \t\r\n");
     return http.access_log.Format.parse(value) orelse {
         logConfigDiagnostic("config validation failed: access_log_format must be one of json, plain, custom", .{});
+        return error.InvalidConfigValue;
+    };
+}
+
+/// `default` (the shipped behavior) leaves backend selection to the platform.
+/// Any other value names an explicit backend, which fails closed at startup if
+/// it is unavailable — see docs/EVENT_LOOP_BACKENDS.md.
+fn parseEventLoopBackendConfig(raw: []const u8) !?http.event_loop.Backend {
+    const value = std.mem.trim(u8, raw, " \t\r\n");
+    // `auto` is deliberately NOT accepted: the auto-detect-with-fallback mode
+    // sketched in docs/EVENT_LOOP_BACKENDS.md is not implemented, and silently
+    // treating it as `default` would misrepresent that.
+    if (value.len == 0 or std.ascii.eqlIgnoreCase(value, "default")) return null;
+    return http.event_loop.Backend.parse(value) orelse {
+        logConfigDiagnostic("config validation failed: event_loop_backend must be one of default, epoll, kqueue, io_uring", .{});
         return error.InvalidConfigValue;
     };
 }
@@ -3405,6 +3452,23 @@ test "parse upstream lb algorithm aliases" {
     try std.testing.expectEqual(UpstreamLbAlgorithm.generic_hash, UpstreamLbAlgorithm.parse("generic-hash").?);
     try std.testing.expectEqual(UpstreamLbAlgorithm.random_two_choices, UpstreamLbAlgorithm.parse("random_two_choices").?);
     try std.testing.expect(UpstreamLbAlgorithm.parse("unknown") == null);
+}
+
+test "parse event loop backend config" {
+    // The default keeps the shipped epoll/kqueue behavior.
+    try std.testing.expect(try parseEventLoopBackendConfig("default") == null);
+    try std.testing.expect(try parseEventLoopBackendConfig("  ") == null);
+    try std.testing.expect(try parseEventLoopBackendConfig("") == null);
+
+    try std.testing.expectEqual(http.event_loop.Backend.io_uring, (try parseEventLoopBackendConfig("io_uring")).?);
+    try std.testing.expectEqual(http.event_loop.Backend.io_uring, (try parseEventLoopBackendConfig(" IO-URING ")).?);
+    try std.testing.expectEqual(http.event_loop.Backend.epoll, (try parseEventLoopBackendConfig("epoll")).?);
+
+    // `auto` is rejected rather than aliased to `default`: the auto-detect
+    // mode with epoll fallback described in docs/EVENT_LOOP_BACKENDS.md is
+    // not implemented, and accepting the name would imply otherwise.
+    try std.testing.expectError(error.InvalidConfigValue, parseEventLoopBackendConfig("auto"));
+    try std.testing.expectError(error.InvalidConfigValue, parseEventLoopBackendConfig("uring"));
 }
 
 test "parse upstream base url weights csv" {

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -286,7 +286,22 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
         state.logger.warn(null, "privilege drop configuration failed: {}", .{err});
     };
 
-    var event_loop = try http.event_loop.EventLoop.init();
+    // #148: an explicitly requested backend fails startup when it is
+    // unavailable rather than silently downgrading, so an operator who asked
+    // for io_uring learns their deployment target cannot provide it here and
+    // not during a later incident. `null` keeps the platform default.
+    var event_loop = if (cfg.event_loop_backend) |requested|
+        http.event_loop.EventLoop.initBackend(state_allocator, requested, .{
+            .io_uring_entries = cfg.event_loop_io_uring_entries,
+        }) catch |err| {
+            state.logger.err(null, "event loop backend '{s}' requested but unavailable: {} (refusing to fall back)", .{
+                @tagName(requested),
+                err,
+            });
+            return err;
+        }
+    else
+        try http.event_loop.EventLoop.init();
     defer event_loop.deinit();
     if (!sharding_enabled) {
         try event_loop.addReadFd(listen_fd);

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -568,11 +568,13 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
 
     // Registry of idle keepalive connections parked off the worker pool (#138).
     // Its close hook releases the connection slot held since accept, so parked
-    // connections torn down by the reaper/drain are accounted correctly. The
-    // deinit (closeAll) runs before session_pool.deinit thanks to defer order.
+    // connections torn down by the reaper/drain are accounted correctly, and
+    // unregisters the fd from the event loop before it is closed. The deinit
+    // (closeAll) runs before session_pool.deinit thanks to defer order.
     var parked = http.keepalive_park.ParkedRegistry.init(state_allocator, &session_pool);
+    var parked_close_ctx = ParkedCloseCtx{ .state = &state, .event_loop = &event_loop };
     parked.close_hook = parkedConnectionCloseHook;
-    parked.close_hook_ctx = &state;
+    parked.close_hook_ctx = &parked_close_ctx;
     defer parked.deinit();
     worker_ctx.parked = &parked;
 
@@ -842,7 +844,21 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
     while (!http.shutdown.isShutdownRequested()) {
         const now_ms = http.event_loop.monotonicMs();
         const timeout_ms = timer.msUntilNextTick(now_ms);
-        const event_count = event_loop.wait(ready_events[0..], timeout_ms) catch |err| {
+        const event_count = event_loop.wait(ready_events[0..], timeout_ms) catch |err| blk: {
+            if (err == error.EventLoopUnrecoverable) {
+                // #148: the ring stopped accepting submissions, so readiness
+                // this loop believes is armed may not be. Continuing would
+                // leave the process up but deaf — the listener could stop
+                // reporting accepts with no deadline reaper behind it. Take
+                // the documented fatal path (log, drain, exit) instead of
+                // self-healing or silently degrading.
+                state.logger.err(null, "event loop backend '{s}' is unrecoverable: {}; draining and shutting down", .{
+                    event_loop.backendName(),
+                    err,
+                });
+                http.shutdown.requestShutdown();
+                break :blk 0;
+            }
             state.logger.err(null, "event loop wait error: {}", .{err});
             continue;
         };
@@ -2280,9 +2296,28 @@ fn advanceNativeHttp2(ctx: *WorkerContext, managed: *http.downstream_connection.
 
 /// Registry teardown hook: release the connection slot held since accept when a
 /// parked connection is finally closed (resume-close, idle reap, or drain).
-fn parkedConnectionCloseHook(raw_state: *anyopaque, fd: std.posix.fd_t) void {
-    const state: *GatewayState = @ptrCast(@alignCast(raw_state));
-    state.releaseConnectionSlot(fd);
+const ParkedCloseCtx = struct {
+    state: *GatewayState,
+    event_loop: *http.event_loop.EventLoop,
+};
+
+/// Runs from `ParkedRegistry.freeConn` immediately before the fd is closed
+/// (reaper, drain, and `closeAll` all funnel through it), without the registry
+/// mutex held.
+///
+/// Unregistering here is an invariant, not an optimization. `epoll` drops a
+/// closed fd from its set implicitly, so this hook historically only needed to
+/// release the accounting slot. `IORING_OP_POLL_ADD` instead pins the
+/// underlying file, so a poll left armed across the close survives it; if the
+/// kernel then recycles that integer for an unrelated descriptor, the stale
+/// completion would be attributed — and re-armed — against the wrong file.
+/// The active-connection expiry reaper already removes before `deinit`; this
+/// makes the parked path match.
+fn parkedConnectionCloseHook(raw_ctx: *anyopaque, fd: std.posix.fd_t) void {
+    const ctx: *ParkedCloseCtx = @ptrCast(@alignCast(raw_ctx));
+    // A checked-out connection is not registered, so ENOENT here is normal.
+    ctx.event_loop.remove(fd) catch {};
+    ctx.state.releaseConnectionSlot(fd);
 }
 
 fn recordHttp3EarlyDataCompatFromRuntime(

--- a/src/http/event_loop.zig
+++ b/src/http/event_loop.zig
@@ -313,19 +313,36 @@ fn initIoUring(allocator: std.mem.Allocator, entries: u16) !EventLoop {
 /// Emulates the level-triggered `add`/`modify`/`remove`/`wait` contract the
 /// rest of the gateway already programs against, using only
 /// `IORING_OP_POLL_ADD`, `IORING_OP_POLL_REMOVE` and `IORING_OP_TIMEOUT`.
-/// Two behaviours of the ring have to be papered over to match `epoll`:
+/// Requires Linux 5.5: `IORING_OP_TIMEOUT` is 5.4, but `IORING_FEAT_NODROP`
+/// (see point 3) raises the implemented floor. Several behaviours of the ring
+/// have to be reconciled with `epoll`:
 ///
 ///  1. **`POLL_ADD` is one-shot.** `epoll` in level-triggered mode keeps
 ///     reporting a fd until the caller drains or removes it, and callers rely
 ///     on that (the listener fd is registered once and never re-added). Every
 ///     delivered completion is therefore immediately re-armed inside `wait`.
-///  2. **Closing a fd does not unregister it.** `epoll` drops a fd from every
-///     set when it is closed, and the gateway's close hooks rely on that —
-///     they only release accounting slots. The ring keeps the poll armed and
-///     this poller keeps its table entry, so `add` treats a surviving entry
-///     for a fd it is asked to register as a stale one from a recycled fd
-///     number, cancels it, and takes the fd over.
-///  3. **The submission queue is not kernel-synchronized.** `epoll_ctl` is
+///  2. **Closing a fd does not unregister it, so unregister-before-close is an
+///     invariant.** `epoll` drops a fd from every set when it is closed;
+///     `POLL_ADD` instead pins the underlying file, so a poll left armed
+///     across a close survives it and can be reported against — and re-armed
+///     on — whatever unrelated descriptor inherits that number. Every path
+///     that closes a registered fd therefore unregisters first:
+///     `parkedConnectionCloseHook` removes before `ParkedRegistry.freeConn`
+///     closes (covering the idle reaper, drain and `closeAll`), and
+///     `reapActiveConnections` already removed before `deinit`. `add`
+///     consequently keeps strict `EPOLL_CTL_ADD`/`EEXIST` semantics —
+///     inferring staleness from a duplicate fd number was tried and is
+///     unsound, since it cannot cover a stale completion reaped *before* the
+///     re-add.
+///  3. **A lost or failed completion strands a registration.** Since a
+///     one-shot poll is re-armed only after its CQE is consumed, anything that
+///     consumes the poll without yielding a usable completion leaves the table
+///     claiming the fd is armed when nothing will ever re-arm it — silently
+///     fatal for the listener. Two guards follow: startup requires
+///     `IORING_FEAT_NODROP` so the kernel never discards completions on CQ
+///     overflow, and a negative `cqe.res` on a live token fails the loop
+///     rather than being skipped.
+///  4. **The submission queue is not kernel-synchronized.** `epoll_ctl` is
 ///     safe to call from any thread while another sits in `epoll_wait`, and
 ///     `removeReadFd` documents that worker threads do exactly that. The SQ
 ///     is plain shared memory, so every userspace ring mutation here is taken
@@ -349,7 +366,7 @@ fn initIoUring(allocator: std.mem.Allocator, entries: u16) !EventLoop {
 /// level-triggered, re-poll-until-drained consumers in `edge_gateway.zig`, but
 /// it does mean a caller may need one extra loop iteration. Closing the gap
 /// would require `IORING_POLL_ADD_LEVEL`, which is Linux 5.13+ and therefore
-/// above this prototype's documented 5.4 floor.
+/// above this prototype's documented 5.5 floor.
 const IoUringPollerLinux = struct {
     const linux = std.os.linux;
 
@@ -579,13 +596,19 @@ const IoUringPollerLinux = struct {
             // Stale completion for a registration that was removed or
             // re-armed under a new interest.
             if (reg.token != decodeToken(cqe.user_data)) continue;
-            // A negative result is a negated errno, not a poll mask. The
-            // common case is -ECANCELED, though a cancel normally also
-            // removes or re-tokenizes the registration and so is already
-            // filtered above. Anything else is a poll the kernel refused;
-            // like the epoll path's error handling, this reports no readiness
-            // and does not try to self-heal by re-arming.
-            if (cqe.res < 0) continue;
+            // A negative result is a negated errno, not a poll mask, and
+            // reaching here means it belongs to the *live* registration:
+            // cancellations are already filtered out above, because `remove`
+            // deletes the map entry and `modify` re-tokenizes before the old
+            // cancellation can be accepted. `POLL_ADD` is one-shot, so the
+            // request is now terminated while the table still says this fd is
+            // armed. Continuing would strand it exactly like a dropped CQE —
+            // and for the listener that means staying up while never seeing
+            // another accept. Fail fast instead.
+            if (cqe.res < 0) {
+                _ = self.registrations.remove(fd);
+                return self.markFatal();
+            }
 
             const mask: u32 = @intCast(cqe.res);
             const errored = (mask & (pollErr | pollHup)) != 0;
@@ -1058,6 +1081,33 @@ test "io_uring event loop attributes nothing to a closed fd whose number is reus
     try loop.add(reused_number, .{ .read = true });
     defer loop.remove(reused_number) catch {};
     try std.testing.expectEqual(@as(usize, 0), try loop.wait(&events, 20));
+}
+
+test "io_uring event loop fails fast when a live poll completes with an error" {
+    var loop = try testIoUringLoopOrSkip();
+    defer loop.deinit();
+
+    const fds = try testSocketPair();
+    closeFd(fds[1]);
+    const dead = fds[0];
+    closeFd(dead);
+
+    // Polling a closed descriptor: the SQE is accepted and the kernel reports
+    // the failure asynchronously as a negative `cqe.res`. That terminates the
+    // one-shot poll, so the registration can never be re-armed — the loop must
+    // surface it rather than silently going deaf on that fd.
+    loop.add(dead, .{ .read = true }) catch |err| {
+        // A kernel that rejects it at submission time instead is equally
+        // fail-closed; either way the error must not be swallowed.
+        try std.testing.expect(err == error.EventLoopUnrecoverable);
+        return;
+    };
+
+    var events: [4]Event = undefined;
+    try std.testing.expectError(error.EventLoopUnrecoverable, loop.wait(&events, 50));
+    // The unrecoverable state is sticky, so the gateway cannot accidentally
+    // keep running past it.
+    try std.testing.expectError(error.EventLoopUnrecoverable, loop.wait(&events, 0));
 }
 
 test "io_uring event loop drains more ready fds than the completion queue holds" {

--- a/src/http/event_loop.zig
+++ b/src/http/event_loop.zig
@@ -285,7 +285,7 @@ fn findOrAppendByFd(out_events: []Event, out_len: *usize, fd: std.posix.fd_t) ?*
 /// SQ/CQ memory is charged against `RLIMIT_MEMLOCK`, whose default soft limit
 /// is commonly 64 KiB. At 256 entries the rings cost roughly 24 KiB (256
 /// 64-byte SQEs plus 512 16-byte CQEs), which fits that default; much deeper
-/// rings would make `io_uring_setup` fail with `ENOMEM` on stock 5.4-era
+/// rings would make `io_uring_setup` fail with `ENOMEM` on stock 5.5-era
 /// hosts. Operators who want a deeper ring can raise `RLIMIT_MEMLOCK` and set
 /// `TARDIGRADE_EVENT_LOOP_IO_URING_ENTRIES`.
 pub const default_io_uring_entries: u16 = 256;
@@ -369,6 +369,13 @@ const IoUringPollerLinux = struct {
     mutex: compat.Mutex = .{},
     registrations: std.AutoHashMapUnmanaged(std.posix.fd_t, Registration) = .empty,
     next_token: u32 = 1,
+    /// Sticky. A ring that fails to accept submissions cannot be trusted to
+    /// deliver readiness again: the polls this backend believes are armed may
+    /// not be, and unlike a per-connection wait there is no deadline reaper
+    /// behind the listener registration to recover it. Once set, `wait`
+    /// reports `error.EventLoopUnrecoverable` so the gateway can drain and
+    /// exit rather than stay up with a wedged loop.
+    fatal: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
 
     fn init(allocator: std.mem.Allocator, entries: u16) !IoUringPollerLinux {
         if (entries < min_io_uring_entries or entries > max_io_uring_entries) {
@@ -383,6 +390,20 @@ const IoUringPollerLinux = struct {
             else => return error.IoUringUnavailable,
         };
         errdefer ring.deinit();
+
+        // CQ overflow must not lose completions. This backend re-arms a
+        // one-shot `POLL_ADD` only after its completion is reaped, so a
+        // dropped CQE does not merely delay an event — it strands that
+        // registration permanently: the table still says the fd is armed, and
+        // nothing will ever re-arm it. Kernels before 5.5 discard completions
+        // on overflow (bumping `cq_overflow`); 5.5+ advertise
+        // `IORING_FEAT_NODROP` and retain them on an overflow list instead.
+        // Gate on the feature rather than on a version number, and fail closed
+        // when it is absent. This is what actually sets the prototype's floor
+        // at Linux 5.5, above the 5.4 that `IORING_OP_TIMEOUT` alone implies.
+        if ((ring.features & linux.IORING_FEAT_NODROP) == 0) {
+            return error.IoUringCqOverflowUnsafe;
+        }
 
         try probeCapabilities(&ring);
 
@@ -434,24 +455,14 @@ const IoUringPollerLinux = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
 
-        // Closing a fd removes it from every epoll set automatically, and this
-        // codebase relies on that: both `parkedConnectionCloseHook` and
-        // `activeConnectionCloseHook` only do accounting, so the keepalive idle
-        // reaper and the active-connection reaper close registered fds without
-        // unregistering them first. io_uring has no equivalent implicit
-        // cleanup, so an entry still present here belongs to a closed fd whose
-        // number the kernel has since recycled. Cancel that stale poll and take
-        // the fd over, which is what the caller would have observed under
-        // epoll — rather than reporting EEXIST for a connection it considers
-        // brand new and failing to register it at all.
-        if (self.registrations.getPtr(fd)) |stale| {
-            self.cancelLocked(fd, stale.token) catch {};
-            stale.interest = interest;
-            stale.token = self.takeTokenLocked();
-            try self.armLocked(fd, stale);
-            try self.submitLocked();
-            return;
-        }
+        // Mirror EPOLL_CTL_ADD's EEXIST. A live entry here is a genuine
+        // double-registration, not a recycled fd: every path that closes a
+        // registered fd unregisters it first (see `parkedConnectionCloseHook`
+        // and `reapActiveConnections`). Treating a duplicate as a stale entry
+        // to take over would be unsound anyway — it cannot fix the case where
+        // the old poll completes *before* the re-add, which is precisely why
+        // unregister-before-close has to be the invariant.
+        if (self.registrations.contains(fd)) return error.Unexpected;
 
         const token = self.takeTokenLocked();
         try self.registrations.put(self.allocator, fd, .{ .interest = interest, .token = token });
@@ -489,8 +500,14 @@ const IoUringPollerLinux = struct {
     }
 
     fn wait(self: *IoUringPollerLinux, out_events: []Event, timeout_ms: i32) !usize {
+        try self.checkFatal();
+
         var ts: linux.kernel_timespec = undefined;
-        var timer_armed = false;
+        // Set only once the timer SQE has been *accepted by the kernel*, not
+        // merely filled in. Blocking on `min_complete = 1` while believing in
+        // a timeout that was never submitted would park the loop thread
+        // indefinitely, past its own maintenance and shutdown deadlines.
+        var timer_submitted = false;
         {
             self.mutex.lock();
             defer self.mutex.unlock();
@@ -505,17 +522,17 @@ const IoUringPollerLinux = struct {
                 // completion is posted, or when `ts` elapses — the same shape
                 // as `epoll_wait(timeout)`, and self-completing either way so
                 // no dangling timer has to be cancelled afterwards.
-                if (self.ring.timeout(timeout_user_data, &ts, 1, 0)) |_| {
-                    timer_armed = true;
-                } else |_| {}
+                timer_submitted = self.armTimeoutLocked(&ts) catch |err| blk: {
+                    // A ring-level failure is fatal; pure queue pressure is
+                    // not, and degrades this call to a non-blocking poll.
+                    if (err == error.EventLoopUnrecoverable) return err;
+                    break :blk false;
+                };
             }
-            self.submitLocked() catch {};
+            try self.submitLocked();
         }
 
-        // Never block without a timer to break it: a bounded wait whose timer
-        // could not be queued degrades to a non-blocking poll rather than
-        // hanging the loop thread past its caller's deadline.
-        const may_block = if (timeout_ms > 0) timer_armed else timeout_ms < 0;
+        const may_block = if (timeout_ms > 0) timer_submitted else timeout_ms < 0;
 
         // Block outside the lock so worker threads can keep arming and
         // cancelling polls while the loop thread waits.
@@ -525,11 +542,24 @@ const IoUringPollerLinux = struct {
                 // are running; treat it as "no events", mirroring the
                 // epoll/kqueue paths.
                 error.SignalInterrupt => return 0,
-                else => return error.Unexpected,
+                else => return self.markFatal(),
             };
         }
 
         return self.reap(out_events);
+    }
+
+    /// Queue and submit the bounded-wait timer. Returns true once the kernel
+    /// has accepted it; returns `error.SubmissionQueueFull` (recoverable — the
+    /// caller degrades to a non-blocking poll) or `error.EventLoopUnrecoverable`.
+    fn armTimeoutLocked(self: *IoUringPollerLinux, ts: *const linux.kernel_timespec) !bool {
+        _ = self.ring.timeout(timeout_user_data, ts, 1, 0) catch {
+            try self.submitLocked();
+            _ = self.ring.timeout(timeout_user_data, ts, 1, 0) catch
+                return error.SubmissionQueueFull;
+        };
+        try self.submitLocked();
+        return true;
     }
 
     fn reap(self: *IoUringPollerLinux, out_events: []Event) !usize {
@@ -539,7 +569,7 @@ const IoUringPollerLinux = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
 
-        const copied = self.ring.copy_cqes(cqes[0..cap], 0) catch return error.Unexpected;
+        const copied = self.ring.copy_cqes(cqes[0..cap], 0) catch return self.markFatal();
         var out_len: usize = 0;
         for (cqes[0..copied]) |cqe| {
             if (cqe.user_data == timeout_user_data or cqe.user_data == cancel_user_data) continue;
@@ -566,13 +596,13 @@ const IoUringPollerLinux = struct {
             }
 
             // Re-arm: POLL_ADD is one-shot, but callers expect epoll's
-            // level-triggered persistence. Dropping the re-arm on error is
-            // safe in the same way the epoll path's errors are: the caller
-            // sees no further readiness and the connection's own deadline
-            // reaper reclaims it.
-            self.armLocked(fd, reg) catch continue;
+            // level-triggered persistence. A failure here must not be
+            // swallowed — losing the listener's re-arm would silently stop the
+            // server accepting while leaving the process healthy-looking, and
+            // no per-connection deadline reaper covers that registration.
+            try self.armLocked(fd, reg);
         }
-        self.submitLocked() catch {};
+        try self.submitLocked();
         return out_len;
     }
 
@@ -584,14 +614,24 @@ const IoUringPollerLinux = struct {
         return token;
     }
 
+    fn markFatal(self: *IoUringPollerLinux) error{EventLoopUnrecoverable} {
+        self.fatal.store(true, .release);
+        return error.EventLoopUnrecoverable;
+    }
+
+    fn checkFatal(self: *IoUringPollerLinux) !void {
+        if (self.fatal.load(.acquire)) return error.EventLoopUnrecoverable;
+    }
+
     fn armLocked(self: *IoUringPollerLinux, fd: std.posix.fd_t, reg: *const Registration) !void {
         const user_data = encodeUserData(fd, reg.token);
         const mask = pollMaskFor(reg.interest);
         // The only failure `get_sqe` reports is a full submission queue; flush
-        // it to the kernel and retry once before giving up.
+        // it to the kernel and retry once. Still full afterwards means the ring
+        // is not draining, which this backend cannot recover from.
         _ = self.ring.poll_add(user_data, fd, mask) catch {
             try self.submitLocked();
-            _ = self.ring.poll_add(user_data, fd, mask) catch return error.Unexpected;
+            _ = self.ring.poll_add(user_data, fd, mask) catch return self.markFatal();
         };
     }
 
@@ -599,20 +639,34 @@ const IoUringPollerLinux = struct {
         const target = encodeUserData(fd, token);
         _ = self.ring.poll_remove(cancel_user_data, target) catch {
             try self.submitLocked();
-            _ = self.ring.poll_remove(cancel_user_data, target) catch return error.Unexpected;
+            _ = self.ring.poll_remove(cancel_user_data, target) catch return self.markFatal();
         };
     }
 
-    /// Push queued SQEs to the kernel without blocking. Called by whichever
+    /// Push queued SQEs to the kernel without blocking, and only return
+    /// success once the kernel has actually consumed them. Called by whichever
     /// thread queued them, so a poll armed from a worker takes effect even
     /// while the loop thread is parked in `io_uring_enter`.
+    ///
+    /// `EINTR` is explicitly *not* success: with `min_complete = 0` the call
+    /// may have submitted nothing, and reporting success would leave callers
+    /// believing in polls and timers the kernel never saw. The count is
+    /// recomputed each pass because an interrupted `enter` may have consumed
+    /// part of the queue.
     fn submitLocked(self: *IoUringPollerLinux) !void {
-        const to_submit = self.ring.flush_sq();
-        if (to_submit == 0) return;
-        _ = self.ring.enter(to_submit, 0, 0) catch |err| switch (err) {
-            error.SignalInterrupt => return,
-            else => return error.Unexpected,
-        };
+        var attempts: u8 = 0;
+        while (true) {
+            const to_submit = self.ring.flush_sq();
+            if (to_submit == 0) return;
+            if (self.ring.enter(to_submit, 0, 0)) |_| {
+                if (self.ring.sq_ready() == 0) return;
+            } else |err| switch (err) {
+                error.SignalInterrupt => {},
+                else => return self.markFatal(),
+            }
+            attempts += 1;
+            if (attempts >= 16) return self.markFatal();
+        }
     }
 
     const pollIn: u32 = std.posix.POLL.IN;
@@ -839,6 +893,7 @@ fn testIoUringLoopOrSkip() !EventLoop {
     return EventLoop.initBackend(std.testing.allocator, .io_uring, .{}) catch |err| switch (err) {
         error.IoUringUnavailable,
         error.IoUringRingAllocationFailed,
+        error.IoUringCqOverflowUnsafe,
         error.IoUringPollAddUnsupported,
         error.IoUringPollRemoveUnsupported,
         error.IoUringTimeoutUnsupported,
@@ -952,33 +1007,119 @@ test "io_uring event loop stops reporting a removed fd" {
     try std.testing.expectError(error.Unexpected, loop.remove(fds[0]));
 }
 
-test "io_uring event loop re-registers a fd whose number was recycled" {
+test "io_uring event loop rejects a duplicate registration" {
     var loop = try testIoUringLoopOrSkip();
     defer loop.deinit();
     const fds = try testSocketPair();
     defer closeFd(fds[0]);
     defer closeFd(fds[1]);
 
-    // The keepalive and active-connection reapers close registered fds without
-    // unregistering them, because epoll would have dropped the registration on
-    // close. Registering the same fd number again must therefore succeed and
-    // apply the new interest, not fail the way EPOLL_CTL_ADD's EEXIST would.
     try loop.add(fds[0], .{ .read = true });
-    try loop.add(fds[0], .{ .write = true });
     defer loop.remove(fds[0]) catch {};
+    // Mirrors EPOLL_CTL_ADD's EEXIST. A live entry is a real double-register,
+    // not a recycled fd: every path that closes a registered fd unregisters it
+    // first, so staleness is never inferred here.
+    try std.testing.expectError(error.Unexpected, loop.add(fds[0], .{ .read = true }));
+}
 
+test "io_uring event loop attributes nothing to a closed fd whose number is reused" {
+    var loop = try testIoUringLoopOrSkip();
+    defer loop.deinit();
+
+    const doomed = try testSocketPair();
+    // Make it readable first, so a completion for this registration is already
+    // in flight when the fd goes away.
+    try writeFd(doomed[1], "x");
+    try loop.add(doomed[0], .{ .read = true });
+
+    // Unregister-before-close: the invariant `parkedConnectionCloseHook` now
+    // upholds. POLL_ADD pins the file, so skipping this would leave a poll
+    // armed across the close.
+    try loop.remove(doomed[0]);
+    const reused_number = doomed[0];
+    closeFd(doomed[0]);
+    closeFd(doomed[1]);
+
+    // Linux hands out the lowest free descriptor, so this should reclaim the
+    // numbers just released.
+    const fresh = try testSocketPair();
+    defer closeFd(fresh[0]);
+    defer closeFd(fresh[1]);
+    if (fresh[0] != reused_number and fresh[1] != reused_number) return error.SkipZigTest;
+
+    // The replacement descriptor is idle. A completion left over from the
+    // closed registration must not be reported against it, nor re-arm a poll
+    // on it.
     var events: [4]Event = undefined;
-    const count = try loop.wait(&events, 50);
-    try std.testing.expect(count > 0);
-    var saw_write = false;
-    for (events[0..count]) |ev| {
-        if (ev.fd == fds[0] and ev.writable) saw_write = true;
-    }
-    try std.testing.expect(saw_write);
-
-    // The stale first registration must not survive as a second live poll.
-    try loop.remove(fds[0]);
     try std.testing.expectEqual(@as(usize, 0), try loop.wait(&events, 20));
+    try std.testing.expectEqual(@as(usize, 0), try loop.wait(&events, 20));
+
+    // And no stale table entry may block registering the new descriptor.
+    try loop.add(reused_number, .{ .read = true });
+    defer loop.remove(reused_number) catch {};
+    try std.testing.expectEqual(@as(usize, 0), try loop.wait(&events, 20));
+}
+
+test "io_uring event loop drains more ready fds than the completion queue holds" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    // Smallest permitted ring: 64 SQEs, so a 128-entry CQ.
+    var loop = EventLoop.initBackend(
+        std.testing.allocator,
+        .io_uring,
+        .{ .io_uring_entries = min_io_uring_entries },
+    ) catch |err| switch (err) {
+        error.IoUringUnavailable,
+        error.IoUringRingAllocationFailed,
+        error.IoUringCqOverflowUnsafe,
+        error.IoUringPollAddUnsupported,
+        error.IoUringPollRemoveUnsupported,
+        error.IoUringTimeoutUnsupported,
+        => return error.SkipZigTest,
+        else => return err,
+    };
+    defer loop.deinit();
+
+    // More simultaneously-ready one-shot polls than the CQ can hold, so the
+    // kernel must use its overflow backlog. Without IORING_FEAT_NODROP the
+    // kernel would discard the excess and those registrations would be
+    // stranded forever, since a poll is only re-armed once its CQE is reaped.
+    const total = 150;
+    var pairs: [total][2]std.posix.fd_t = undefined;
+    var made: usize = 0;
+    defer for (pairs[0..made]) |p| {
+        closeFd(p[0]);
+        closeFd(p[1]);
+    };
+    var exhausted = false;
+    while (made < total) {
+        pairs[made] = testSocketPair() catch {
+            exhausted = true;
+            break;
+        };
+        made += 1;
+    }
+    // A constrained RLIMIT_NOFILE is an environment property, not a defect.
+    if (exhausted) return error.SkipZigTest;
+
+    for (pairs[0..made]) |p| {
+        try loop.add(p[0], .{ .read = true });
+        try writeFd(p[1], "x");
+    }
+
+    var seen = std.AutoHashMap(std.posix.fd_t, void).init(std.testing.allocator);
+    defer seen.deinit();
+
+    var iterations: usize = 0;
+    while (seen.count() < made and iterations < 200) : (iterations += 1) {
+        var events: [64]Event = undefined;
+        const count = try loop.wait(&events, 50);
+        for (events[0..count]) |ev| {
+            if (ev.readable) try seen.put(ev.fd, {});
+        }
+    }
+
+    // Every registration must surface; none may be lost to CQ overflow.
+    try std.testing.expectEqual(made, seen.count());
 }
 
 fn testSocketPair() ![2]std.posix.fd_t {

--- a/src/http/event_loop.zig
+++ b/src/http/event_loop.zig
@@ -5,6 +5,22 @@ const std = @import("std");
 pub const Backend = enum {
     epoll,
     kqueue,
+    /// Linux-only, opt-in readiness-only `io_uring` poller (#148). Stands in
+    /// for `epoll_wait` using `IORING_OP_POLL_ADD`/`IORING_OP_POLL_REMOVE`
+    /// plus `IORING_OP_TIMEOUT` for `wait`'s bounded block. It deliberately
+    /// does **not** submit accept/read/write operations: `accept()` and all
+    /// request I/O stay outside the ring as blocking calls on worker threads,
+    /// exactly as with `epoll`/`kqueue`. See `docs/EVENT_LOOP_BACKENDS.md`.
+    io_uring,
+
+    /// Parse an operator-supplied backend name. Returns null for unknown
+    /// names so the caller can emit a config diagnostic listing valid values.
+    pub fn parse(value: []const u8) ?Backend {
+        if (std.ascii.eqlIgnoreCase(value, "epoll")) return .epoll;
+        if (std.ascii.eqlIgnoreCase(value, "kqueue")) return .kqueue;
+        if (std.ascii.eqlIgnoreCase(value, "io_uring") or std.ascii.eqlIgnoreCase(value, "io-uring")) return .io_uring;
+        return null;
+    }
 };
 
 pub const Event = struct {
@@ -26,6 +42,10 @@ pub const Interest = packed struct {
 pub const EventLoop = struct {
     fd: std.posix.fd_t,
     backend: Backend,
+    /// Only populated for `Backend.io_uring`. Heap-allocated so the poller's
+    /// mutex and registration table keep a stable address even though callers
+    /// pass `*EventLoop` around by pointer.
+    ring: ?*IoUringPoller = null,
 
     pub fn init() !EventLoop {
         return if (builtin.os.tag == .linux) blk: {
@@ -40,7 +60,35 @@ pub const EventLoop = struct {
         };
     }
 
+    /// Initialize a specific backend, failing closed if it is unavailable.
+    ///
+    /// An operator who explicitly asks for a backend must learn at startup
+    /// that their deployment target does not support it rather than discover
+    /// a silent downgrade during an incident, so this never falls back to the
+    /// platform default (`docs/EVENT_LOOP_BACKENDS.md`, "Failure modes and
+    /// fallback policy"). `allocator` is only used by `.io_uring`.
+    pub fn initBackend(allocator: std.mem.Allocator, backend: Backend, options: InitOptions) !EventLoop {
+        const platform_default = try detectBackend();
+        switch (backend) {
+            .epoll, .kqueue => {
+                if (backend != platform_default) return error.UnsupportedBackendForPlatform;
+                return init();
+            },
+            .io_uring => {
+                if (builtin.os.tag != .linux) return error.UnsupportedBackendForPlatform;
+                return initIoUring(allocator, options.io_uring_entries);
+            },
+        }
+    }
+
     pub fn deinit(self: *EventLoop) void {
+        if (builtin.os.tag == .linux) {
+            if (self.ring) |poller| {
+                poller.deinit();
+                self.* = undefined;
+                return;
+            }
+        }
         _ = std.c.close(self.fd);
         self.* = undefined;
     }
@@ -49,6 +97,7 @@ pub const EventLoop = struct {
         return switch (self.backend) {
             .epoll => "epoll",
             .kqueue => "kqueue",
+            .io_uring => "io_uring",
         };
     }
 
@@ -59,6 +108,7 @@ pub const EventLoop = struct {
     pub fn add(self: *EventLoop, fd: std.posix.fd_t, interest: Interest) !void {
         if (!interest.any()) return error.InvalidEventInterest;
         if (builtin.os.tag == .linux) {
+            if (self.ring) |poller| return poller.add(fd, interest);
             const linux = std.os.linux;
             var event = linux.epoll_event{
                 .events = epollEventsFor(interest),
@@ -74,6 +124,7 @@ pub const EventLoop = struct {
     pub fn modify(self: *EventLoop, fd: std.posix.fd_t, interest: Interest) !void {
         if (!interest.any()) return error.InvalidEventInterest;
         if (builtin.os.tag == .linux) {
+            if (self.ring) |poller| return poller.modify(fd, interest);
             const linux = std.os.linux;
             var event = linux.epoll_event{
                 .events = epollEventsFor(interest),
@@ -97,6 +148,7 @@ pub const EventLoop = struct {
 
     pub fn remove(self: *EventLoop, fd: std.posix.fd_t) !void {
         if (builtin.os.tag == .linux) {
+            if (self.ring) |poller| return poller.remove(fd);
             const linux = std.os.linux;
             // EPOLL_CTL_DEL ignores the event argument on modern kernels, but a
             // valid pointer is passed for portability with older ones.
@@ -114,10 +166,11 @@ pub const EventLoop = struct {
     pub fn wait(self: *EventLoop, out_events: []Event, timeout_ms: i32) !usize {
         if (out_events.len == 0) return 0;
 
-        return if (builtin.os.tag == .linux)
-            self.waitEpoll(out_events, timeout_ms)
-        else
-            self.waitKqueue(out_events, timeout_ms);
+        if (builtin.os.tag == .linux) {
+            if (self.ring) |poller| return poller.wait(out_events, timeout_ms);
+            return self.waitEpoll(out_events, timeout_ms);
+        }
+        return self.waitKqueue(out_events, timeout_ms);
     }
 
     fn waitEpoll(self: *EventLoop, out_events: []Event, timeout_ms: i32) usize {
@@ -179,17 +232,6 @@ pub const EventLoop = struct {
         return out_len;
     }
 
-    fn findOrAppendByFd(out_events: []Event, out_len: *usize, fd: std.posix.fd_t) ?*Event {
-        for (out_events[0..out_len.*]) |*event| {
-            if (event.fd == fd) return event;
-        }
-        if (out_len.* == out_events.len) return null;
-        const slot = &out_events[out_len.*];
-        slot.* = .{ .fd = fd };
-        out_len.* += 1;
-        return slot;
-    }
-
     fn applyKqueueInterest(self: *EventLoop, fd: std.posix.fd_t, interest: Interest, op: enum { add, modify, remove }) !void {
         if (op == .modify or op == .remove) {
             try self.kqueueFilterChange(fd, std.c.EVFILT.READ, std.c.EV.DELETE, true);
@@ -220,6 +262,381 @@ pub const EventLoop = struct {
             if (ignore_missing and std.posix.errno(ret) == .NOENT) return;
             return error.Unexpected;
         }
+    }
+};
+
+/// Fold a per-filter/per-completion readiness signal into the caller's
+/// per-fd output slice. Shared by the kqueue and io_uring paths, both of
+/// which can observe read and write readiness for one fd separately.
+fn findOrAppendByFd(out_events: []Event, out_len: *usize, fd: std.posix.fd_t) ?*Event {
+    for (out_events[0..out_len.*]) |*event| {
+        if (event.fd == fd) return event;
+    }
+    if (out_len.* == out_events.len) return null;
+    const slot = &out_events[out_len.*];
+    slot.* = .{ .fd = fd };
+    out_len.* += 1;
+    return slot;
+}
+
+/// Default submission-queue depth for the `io_uring` backend.
+///
+/// Kept modest on purpose: on kernels older than 5.12 the ring's mmap'd
+/// SQ/CQ memory is charged against `RLIMIT_MEMLOCK`, whose default soft limit
+/// is commonly 64 KiB. At 256 entries the rings cost roughly 24 KiB (256
+/// 64-byte SQEs plus 512 16-byte CQEs), which fits that default; much deeper
+/// rings would make `io_uring_setup` fail with `ENOMEM` on stock 5.4-era
+/// hosts. Operators who want a deeper ring can raise `RLIMIT_MEMLOCK` and set
+/// `TARDIGRADE_EVENT_LOOP_IO_URING_ENTRIES`.
+pub const default_io_uring_entries: u16 = 256;
+pub const min_io_uring_entries: u16 = 64;
+pub const max_io_uring_entries: u16 = 4096;
+
+pub const InitOptions = struct {
+    io_uring_entries: u16 = default_io_uring_entries,
+};
+
+/// Opaque on non-Linux targets so that referencing `?*IoUringPoller` as an
+/// `EventLoop` field never drags `std.os.linux.IoUring` into analysis on
+/// macOS/BSD builds.
+const IoUringPoller = if (builtin.os.tag == .linux) IoUringPollerLinux else opaque {};
+
+fn initIoUring(allocator: std.mem.Allocator, entries: u16) !EventLoop {
+    const poller = try allocator.create(IoUringPollerLinux);
+    errdefer allocator.destroy(poller);
+    poller.* = try IoUringPollerLinux.init(allocator, entries);
+    return .{ .fd = poller.ring.fd, .backend = .io_uring, .ring = poller };
+}
+
+/// Readiness-only `io_uring` poller (#148).
+///
+/// Emulates the level-triggered `add`/`modify`/`remove`/`wait` contract the
+/// rest of the gateway already programs against, using only
+/// `IORING_OP_POLL_ADD`, `IORING_OP_POLL_REMOVE` and `IORING_OP_TIMEOUT`.
+/// Two behaviours of the ring have to be papered over to match `epoll`:
+///
+///  1. **`POLL_ADD` is one-shot.** `epoll` in level-triggered mode keeps
+///     reporting a fd until the caller drains or removes it, and callers rely
+///     on that (the listener fd is registered once and never re-added). Every
+///     delivered completion is therefore immediately re-armed inside `wait`.
+///  2. **Closing a fd does not unregister it.** `epoll` drops a fd from every
+///     set when it is closed, and the gateway's close hooks rely on that —
+///     they only release accounting slots. The ring keeps the poll armed and
+///     this poller keeps its table entry, so `add` treats a surviving entry
+///     for a fd it is asked to register as a stale one from a recycled fd
+///     number, cancels it, and takes the fd over.
+///  3. **The submission queue is not kernel-synchronized.** `epoll_ctl` is
+///     safe to call from any thread while another sits in `epoll_wait`, and
+///     `removeReadFd` documents that worker threads do exactly that. The SQ
+///     is plain shared memory, so every userspace ring mutation here is taken
+///     under `mutex`, and submitting threads call `io_uring_enter` themselves
+///     (with `min_complete = 0`) so a newly armed poll takes effect even
+///     while the loop thread is blocked in its own `io_uring_enter`.
+///
+/// A registration's `user_data` packs a monotonic 32-bit token above the fd.
+/// `POLL_REMOVE` races with an already-completing poll, so a completion whose
+/// token no longer matches the live registration is dropped rather than
+/// reported against a fd the caller has since removed (and possibly closed).
+///
+/// **Known behavioural difference from `epoll`.** A `POLL_ADD` completion
+/// carries the mask captured when the poll fired, whereas `epoll_wait` reports
+/// whatever the fd's readiness is at the moment of the call. A fd registered
+/// for both read and write can therefore be reported as only writable here
+/// (sockets are almost always immediately writable) and become readable on a
+/// following `wait`, where `epoll` would have coalesced both into one event.
+/// No readiness is lost — the fd is re-armed immediately and the remaining
+/// readiness surfaces on the next iteration — so this is safe for the
+/// level-triggered, re-poll-until-drained consumers in `edge_gateway.zig`, but
+/// it does mean a caller may need one extra loop iteration. Closing the gap
+/// would require `IORING_POLL_ADD_LEVEL`, which is Linux 5.13+ and therefore
+/// above this prototype's documented 5.4 floor.
+const IoUringPollerLinux = struct {
+    const linux = std.os.linux;
+
+    /// A live registration's token occupies the high 32 bits and is handed
+    /// out from `next_token`, which starts at 1 and never reaches these
+    /// values in practice, so neither sentinel can collide with one.
+    const timeout_user_data: u64 = std.math.maxInt(u64);
+    const cancel_user_data: u64 = std.math.maxInt(u64) - 1;
+
+    const Registration = struct {
+        interest: Interest,
+        token: u32,
+    };
+
+    allocator: std.mem.Allocator,
+    ring: linux.IoUring,
+    mutex: compat.Mutex = .{},
+    registrations: std.AutoHashMapUnmanaged(std.posix.fd_t, Registration) = .empty,
+    next_token: u32 = 1,
+
+    fn init(allocator: std.mem.Allocator, entries: u16) !IoUringPollerLinux {
+        if (entries < min_io_uring_entries or entries > max_io_uring_entries) {
+            return error.InvalidIoUringRingSize;
+        }
+        var ring = linux.IoUring.init(entries, 0) catch |err| switch (err) {
+            // `io_uring_setup` is commonly blocked outright by container
+            // seccomp profiles (Docker's default profile denies it), which
+            // surfaces as EPERM/ENOSYS rather than as a missing opcode.
+            error.PermissionDenied, error.SystemOutdated => return error.IoUringUnavailable,
+            error.SystemResources => return error.IoUringRingAllocationFailed,
+            else => return error.IoUringUnavailable,
+        };
+        errdefer ring.deinit();
+
+        try probeCapabilities(&ring);
+
+        return .{ .allocator = allocator, .ring = ring };
+    }
+
+    /// Establish that the three opcodes this backend actually submits are
+    /// present, rather than inferring them from a compile-time Linux check or
+    /// from the fact that the ring was created at all.
+    ///
+    /// A successful `IoUring.init` only proves the 5.1 ring baseline.
+    /// `IORING_OP_TIMEOUT` — which `wait`'s bounded block depends on — did not
+    /// land until 5.4, so it has to be checked separately. `IORING_REGISTER_PROBE`
+    /// is itself only available from 5.6, so kernels in the 5.1-5.5 window fall
+    /// back to submitting a real already-expired timeout and confirming the
+    /// kernel completes it with `-ETIME` instead of rejecting the opcode.
+    fn probeCapabilities(ring: *linux.IoUring) !void {
+        if (ring.get_probe()) |probe| {
+            if (!probe.is_supported(.POLL_ADD)) return error.IoUringPollAddUnsupported;
+            if (!probe.is_supported(.POLL_REMOVE)) return error.IoUringPollRemoveUnsupported;
+            if (!probe.is_supported(.TIMEOUT)) return error.IoUringTimeoutUnsupported;
+            return;
+        } else |_| {
+            // REGISTER_PROBE unavailable (pre-5.6): fall through to the
+            // functional probe below.
+        }
+
+        const ts: linux.kernel_timespec = .{ .sec = 0, .nsec = 0 };
+        _ = ring.timeout(timeout_user_data, &ts, 0, 0) catch return error.IoUringTimeoutUnsupported;
+        _ = ring.submit_and_wait(1) catch return error.IoUringTimeoutUnsupported;
+        const cqe = ring.copy_cqe() catch return error.IoUringTimeoutUnsupported;
+        // An already-expired timeout completes with -ETIME. A kernel that does
+        // not know the opcode rejects it with -EINVAL/-EOPNOTSUPP instead.
+        // `cqe.res` carries the raw negated errno, and ETIME's numeric value
+        // is architecture-dependent, so compare against the enum.
+        if (cqe.res >= 0) return error.IoUringTimeoutUnsupported;
+        const completion_errno: u32 = @intCast(-cqe.res);
+        if (completion_errno != @intFromEnum(linux.E.TIME)) return error.IoUringTimeoutUnsupported;
+    }
+
+    fn deinit(self: *IoUringPollerLinux) void {
+        const allocator = self.allocator;
+        self.registrations.deinit(allocator);
+        self.ring.deinit();
+        allocator.destroy(self);
+    }
+
+    fn add(self: *IoUringPollerLinux, fd: std.posix.fd_t, interest: Interest) !void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        // Closing a fd removes it from every epoll set automatically, and this
+        // codebase relies on that: both `parkedConnectionCloseHook` and
+        // `activeConnectionCloseHook` only do accounting, so the keepalive idle
+        // reaper and the active-connection reaper close registered fds without
+        // unregistering them first. io_uring has no equivalent implicit
+        // cleanup, so an entry still present here belongs to a closed fd whose
+        // number the kernel has since recycled. Cancel that stale poll and take
+        // the fd over, which is what the caller would have observed under
+        // epoll — rather than reporting EEXIST for a connection it considers
+        // brand new and failing to register it at all.
+        if (self.registrations.getPtr(fd)) |stale| {
+            self.cancelLocked(fd, stale.token) catch {};
+            stale.interest = interest;
+            stale.token = self.takeTokenLocked();
+            try self.armLocked(fd, stale);
+            try self.submitLocked();
+            return;
+        }
+
+        const token = self.takeTokenLocked();
+        try self.registrations.put(self.allocator, fd, .{ .interest = interest, .token = token });
+        errdefer _ = self.registrations.remove(fd);
+
+        const reg = self.registrations.getPtr(fd).?;
+        try self.armLocked(fd, reg);
+        try self.submitLocked();
+    }
+
+    fn modify(self: *IoUringPollerLinux, fd: std.posix.fd_t, interest: Interest) !void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        // Mirror EPOLL_CTL_MOD's ENOENT.
+        const reg = self.registrations.getPtr(fd) orelse return error.Unexpected;
+
+        // Cancel the in-flight poll and re-arm under a fresh token so a
+        // completion already in flight for the old interest is discarded.
+        try self.cancelLocked(fd, reg.token);
+        reg.interest = interest;
+        reg.token = self.takeTokenLocked();
+        try self.armLocked(fd, reg);
+        try self.submitLocked();
+    }
+
+    fn remove(self: *IoUringPollerLinux, fd: std.posix.fd_t) !void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        // Mirror EPOLL_CTL_DEL's ENOENT.
+        const entry = self.registrations.fetchRemove(fd) orelse return error.Unexpected;
+        try self.cancelLocked(fd, entry.value.token);
+        try self.submitLocked();
+    }
+
+    fn wait(self: *IoUringPollerLinux, out_events: []Event, timeout_ms: i32) !usize {
+        var ts: linux.kernel_timespec = undefined;
+        var timer_armed = false;
+        {
+            self.mutex.lock();
+            defer self.mutex.unlock();
+
+            if (timeout_ms > 0) {
+                const millis: u64 = @intCast(timeout_ms);
+                ts = .{
+                    .sec = @intCast(millis / std.time.ms_per_s),
+                    .nsec = @intCast((millis % std.time.ms_per_s) * std.time.ns_per_ms),
+                };
+                // `count = 1` makes the timer complete as soon as one other
+                // completion is posted, or when `ts` elapses — the same shape
+                // as `epoll_wait(timeout)`, and self-completing either way so
+                // no dangling timer has to be cancelled afterwards.
+                if (self.ring.timeout(timeout_user_data, &ts, 1, 0)) |_| {
+                    timer_armed = true;
+                } else |_| {}
+            }
+            self.submitLocked() catch {};
+        }
+
+        // Never block without a timer to break it: a bounded wait whose timer
+        // could not be queued degrades to a non-blocking poll rather than
+        // hanging the loop thread past its caller's deadline.
+        const may_block = if (timeout_ms > 0) timer_armed else timeout_ms < 0;
+
+        // Block outside the lock so worker threads can keep arming and
+        // cancelling polls while the loop thread waits.
+        if (may_block and self.ring.cq_ready() == 0) {
+            _ = self.ring.enter(0, 1, linux.IORING_ENTER_GETEVENTS) catch |err| switch (err) {
+                // Signals reach this thread routinely once background workers
+                // are running; treat it as "no events", mirroring the
+                // epoll/kqueue paths.
+                error.SignalInterrupt => return 0,
+                else => return error.Unexpected,
+            };
+        }
+
+        return self.reap(out_events);
+    }
+
+    fn reap(self: *IoUringPollerLinux, out_events: []Event) !usize {
+        var cqes: [64]linux.io_uring_cqe = undefined;
+        const cap = @min(out_events.len, cqes.len);
+
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        const copied = self.ring.copy_cqes(cqes[0..cap], 0) catch return error.Unexpected;
+        var out_len: usize = 0;
+        for (cqes[0..copied]) |cqe| {
+            if (cqe.user_data == timeout_user_data or cqe.user_data == cancel_user_data) continue;
+
+            const fd = decodeFd(cqe.user_data);
+            const reg = self.registrations.getPtr(fd) orelse continue;
+            // Stale completion for a registration that was removed or
+            // re-armed under a new interest.
+            if (reg.token != decodeToken(cqe.user_data)) continue;
+            // A negative result is a negated errno, not a poll mask. The
+            // common case is -ECANCELED, though a cancel normally also
+            // removes or re-tokenizes the registration and so is already
+            // filtered above. Anything else is a poll the kernel refused;
+            // like the epoll path's error handling, this reports no readiness
+            // and does not try to self-heal by re-arming.
+            if (cqe.res < 0) continue;
+
+            const mask: u32 = @intCast(cqe.res);
+            const errored = (mask & (pollErr | pollHup)) != 0;
+            if (findOrAppendByFd(out_events, &out_len, fd)) |slot| {
+                slot.readable = slot.readable or (mask & pollIn) != 0 or errored;
+                slot.writable = slot.writable or (mask & pollOut) != 0;
+                slot.errored = slot.errored or errored;
+            }
+
+            // Re-arm: POLL_ADD is one-shot, but callers expect epoll's
+            // level-triggered persistence. Dropping the re-arm on error is
+            // safe in the same way the epoll path's errors are: the caller
+            // sees no further readiness and the connection's own deadline
+            // reaper reclaims it.
+            self.armLocked(fd, reg) catch continue;
+        }
+        self.submitLocked() catch {};
+        return out_len;
+    }
+
+    fn takeTokenLocked(self: *IoUringPollerLinux) u32 {
+        const token = self.next_token;
+        // Skip 0 on wrap so a zeroed user_data can never look like a live
+        // registration.
+        self.next_token = if (token == std.math.maxInt(u32) - 2) 1 else token + 1;
+        return token;
+    }
+
+    fn armLocked(self: *IoUringPollerLinux, fd: std.posix.fd_t, reg: *const Registration) !void {
+        const user_data = encodeUserData(fd, reg.token);
+        const mask = pollMaskFor(reg.interest);
+        // The only failure `get_sqe` reports is a full submission queue; flush
+        // it to the kernel and retry once before giving up.
+        _ = self.ring.poll_add(user_data, fd, mask) catch {
+            try self.submitLocked();
+            _ = self.ring.poll_add(user_data, fd, mask) catch return error.Unexpected;
+        };
+    }
+
+    fn cancelLocked(self: *IoUringPollerLinux, fd: std.posix.fd_t, token: u32) !void {
+        const target = encodeUserData(fd, token);
+        _ = self.ring.poll_remove(cancel_user_data, target) catch {
+            try self.submitLocked();
+            _ = self.ring.poll_remove(cancel_user_data, target) catch return error.Unexpected;
+        };
+    }
+
+    /// Push queued SQEs to the kernel without blocking. Called by whichever
+    /// thread queued them, so a poll armed from a worker takes effect even
+    /// while the loop thread is parked in `io_uring_enter`.
+    fn submitLocked(self: *IoUringPollerLinux) !void {
+        const to_submit = self.ring.flush_sq();
+        if (to_submit == 0) return;
+        _ = self.ring.enter(to_submit, 0, 0) catch |err| switch (err) {
+            error.SignalInterrupt => return,
+            else => return error.Unexpected,
+        };
+    }
+
+    const pollIn: u32 = std.posix.POLL.IN;
+    const pollOut: u32 = std.posix.POLL.OUT;
+    const pollErr: u32 = std.posix.POLL.ERR;
+    const pollHup: u32 = std.posix.POLL.HUP;
+
+    fn pollMaskFor(interest: Interest) u32 {
+        var mask: u32 = pollErr | pollHup;
+        if (interest.read) mask |= pollIn;
+        if (interest.write) mask |= pollOut;
+        return mask;
+    }
+
+    fn encodeUserData(fd: std.posix.fd_t, token: u32) u64 {
+        return (@as(u64, token) << 32) | @as(u64, @as(u32, @bitCast(fd)));
+    }
+
+    fn decodeFd(user_data: u64) std.posix.fd_t {
+        return @bitCast(@as(u32, @truncate(user_data)));
+    }
+
+    fn decodeToken(user_data: u64) u32 {
+        return @truncate(user_data >> 32);
     }
 };
 
@@ -360,6 +777,208 @@ test "event loop coalesces simultaneous read and write readiness by fd" {
     try std.testing.expectEqual(fds[0], events[0].fd);
     try std.testing.expect(events[0].readable);
     try std.testing.expect(events[0].writable);
+}
+
+test "backend names parse and round-trip" {
+    try std.testing.expectEqual(Backend.epoll, Backend.parse("epoll").?);
+    try std.testing.expectEqual(Backend.kqueue, Backend.parse("KQUEUE").?);
+    try std.testing.expectEqual(Backend.io_uring, Backend.parse("io_uring").?);
+    try std.testing.expectEqual(Backend.io_uring, Backend.parse("io-uring").?);
+    try std.testing.expect(Backend.parse("iouring") == null);
+    try std.testing.expect(Backend.parse("") == null);
+
+    inline for (.{ Backend.epoll, Backend.kqueue, Backend.io_uring }) |backend| {
+        const loop = EventLoop{ .fd = -1, .backend = backend };
+        try std.testing.expectEqual(backend, Backend.parse(loop.backendName()).?);
+    }
+}
+
+test "explicitly requested platform-default backend initializes" {
+    const expected = try detectBackend();
+    var loop = try EventLoop.initBackend(std.testing.allocator, expected, .{});
+    defer loop.deinit();
+    try std.testing.expectEqual(expected, loop.backend);
+}
+
+test "explicitly requested backend fails closed when the platform cannot provide it" {
+    // #148 fail-closed policy: an operator who names a backend must get a
+    // startup error when it is unavailable, never a silent downgrade to the
+    // platform default.
+    const foreign: Backend = if (builtin.os.tag == .linux) .kqueue else .epoll;
+    try std.testing.expectError(
+        error.UnsupportedBackendForPlatform,
+        EventLoop.initBackend(std.testing.allocator, foreign, .{}),
+    );
+
+    if (builtin.os.tag != .linux) {
+        try std.testing.expectError(
+            error.UnsupportedBackendForPlatform,
+            EventLoop.initBackend(std.testing.allocator, .io_uring, .{}),
+        );
+    }
+}
+
+test "io_uring backend fails closed on an unusable ring size" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    try std.testing.expectError(
+        error.InvalidIoUringRingSize,
+        EventLoop.initBackend(std.testing.allocator, .io_uring, .{ .io_uring_entries = 1 }),
+    );
+    try std.testing.expectError(
+        error.InvalidIoUringRingSize,
+        EventLoop.initBackend(std.testing.allocator, .io_uring, .{ .io_uring_entries = max_io_uring_entries + 1 }),
+    );
+}
+
+/// Build an io_uring-backed loop, or skip. Container seccomp profiles (the
+/// Docker default among them) block `io_uring_setup` outright, and kernels
+/// older than 5.4 lack `IORING_OP_TIMEOUT`; neither is a defect in this
+/// backend, so those cases skip rather than fail.
+fn testIoUringLoopOrSkip() !EventLoop {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    return EventLoop.initBackend(std.testing.allocator, .io_uring, .{}) catch |err| switch (err) {
+        error.IoUringUnavailable,
+        error.IoUringRingAllocationFailed,
+        error.IoUringPollAddUnsupported,
+        error.IoUringPollRemoveUnsupported,
+        error.IoUringTimeoutUnsupported,
+        => error.SkipZigTest,
+        else => err,
+    };
+}
+
+test "io_uring event loop reports write readiness" {
+    var loop = try testIoUringLoopOrSkip();
+    defer loop.deinit();
+    const fds = try testSocketPair();
+    defer closeFd(fds[0]);
+    defer closeFd(fds[1]);
+
+    try loop.add(fds[0], .{ .write = true });
+    defer loop.remove(fds[0]) catch {};
+
+    var events: [4]Event = undefined;
+    const count = try loop.wait(&events, 50);
+    try std.testing.expect(count > 0);
+    var saw_write = false;
+    for (events[0..count]) |ev| {
+        if (ev.fd == fds[0] and ev.writable) saw_write = true;
+    }
+    try std.testing.expect(saw_write);
+}
+
+test "io_uring event loop modify replaces write interest with read interest" {
+    var loop = try testIoUringLoopOrSkip();
+    defer loop.deinit();
+    const fds = try testSocketPair();
+    defer closeFd(fds[0]);
+    defer closeFd(fds[1]);
+
+    try loop.add(fds[0], .{ .write = true });
+    defer loop.remove(fds[0]) catch {};
+    try loop.modify(fds[0], .{ .read = true });
+
+    // The write poll armed by `add` may already have completed; `modify`
+    // re-tokenizes the registration so that stale completion is discarded
+    // rather than reported as spurious write readiness.
+    var events: [4]Event = undefined;
+    try std.testing.expectEqual(@as(usize, 0), try loop.wait(&events, 10));
+
+    try writeFd(fds[1], "x");
+    const count = try loop.wait(&events, 50);
+    try std.testing.expect(count > 0);
+    var saw_read = false;
+    var saw_write = false;
+    for (events[0..count]) |ev| {
+        if (ev.fd != fds[0]) continue;
+        saw_read = saw_read or ev.readable;
+        saw_write = saw_write or ev.writable;
+    }
+    try std.testing.expect(saw_read);
+    try std.testing.expect(!saw_write);
+}
+
+test "io_uring event loop re-arms one-shot polls so readiness persists" {
+    var loop = try testIoUringLoopOrSkip();
+    defer loop.deinit();
+    const fds = try testSocketPair();
+    defer closeFd(fds[0]);
+    defer closeFd(fds[1]);
+
+    try loop.add(fds[0], .{ .read = true, .write = true });
+    defer loop.remove(fds[0]) catch {};
+    try writeFd(fds[1], "x");
+
+    // Nothing ever drains fds[0], so a level-triggered poller must keep
+    // reporting it. Unlike epoll, a single POLL_ADD completion carries only
+    // the mask captured when it fired, so read and write readiness may arrive
+    // on separate iterations — but neither may be lost.
+    var saw_read = false;
+    var saw_write = false;
+    var iterations: usize = 0;
+    while (iterations < 8 and !(saw_read and saw_write)) : (iterations += 1) {
+        var events: [4]Event = undefined;
+        const count = try loop.wait(&events, 50);
+        for (events[0..count]) |ev| {
+            if (ev.fd != fds[0]) continue;
+            saw_read = saw_read or ev.readable;
+            saw_write = saw_write or ev.writable;
+        }
+    }
+    try std.testing.expect(saw_read);
+    try std.testing.expect(saw_write);
+}
+
+test "io_uring event loop stops reporting a removed fd" {
+    var loop = try testIoUringLoopOrSkip();
+    defer loop.deinit();
+    const fds = try testSocketPair();
+    defer closeFd(fds[0]);
+    defer closeFd(fds[1]);
+
+    try loop.add(fds[0], .{ .read = true });
+    try writeFd(fds[1], "x");
+
+    var events: [4]Event = undefined;
+    _ = try loop.wait(&events, 50);
+
+    // This is the un-park path (`removeReadFd`) that keeps a level-triggered
+    // backend from re-firing while a worker drains the socket.
+    try loop.remove(fds[0]);
+    try std.testing.expectEqual(@as(usize, 0), try loop.wait(&events, 20));
+    try std.testing.expectEqual(@as(usize, 0), try loop.wait(&events, 20));
+
+    // Removing twice mirrors EPOLL_CTL_DEL's ENOENT.
+    try std.testing.expectError(error.Unexpected, loop.remove(fds[0]));
+}
+
+test "io_uring event loop re-registers a fd whose number was recycled" {
+    var loop = try testIoUringLoopOrSkip();
+    defer loop.deinit();
+    const fds = try testSocketPair();
+    defer closeFd(fds[0]);
+    defer closeFd(fds[1]);
+
+    // The keepalive and active-connection reapers close registered fds without
+    // unregistering them, because epoll would have dropped the registration on
+    // close. Registering the same fd number again must therefore succeed and
+    // apply the new interest, not fail the way EPOLL_CTL_ADD's EEXIST would.
+    try loop.add(fds[0], .{ .read = true });
+    try loop.add(fds[0], .{ .write = true });
+    defer loop.remove(fds[0]) catch {};
+
+    var events: [4]Event = undefined;
+    const count = try loop.wait(&events, 50);
+    try std.testing.expect(count > 0);
+    var saw_write = false;
+    for (events[0..count]) |ev| {
+        if (ev.fd == fds[0] and ev.writable) saw_write = true;
+    }
+    try std.testing.expect(saw_write);
+
+    // The stale first registration must not survive as a second live poll.
+    try loop.remove(fds[0]);
+    try std.testing.expectEqual(@as(usize, 0), try loop.wait(&events, 20));
 }
 
 fn testSocketPair() ![2]std.posix.fd_t {


### PR DESCRIPTION
## Summary

Phase 0 (the design doc) plus **Phase 1: the readiness-only `io_uring`
prototype that doc specified now exists**, behind
`TARDIGRADE_EVENT_LOOP_BACKEND=io_uring`.

`epoll`/`kqueue` remains the default on every platform. Nothing changes
unless an operator explicitly opts in.

## What the backend is

It sits behind `event_loop.zig`'s existing `add`/`modify`/`remove`/`wait`
seam — the seam's shape is unchanged — and uses only `IORING_OP_POLL_ADD`,
`IORING_OP_POLL_REMOVE`, and `IORING_OP_TIMEOUT` (the last solely to
implement `wait(timeout_ms)`'s bounded block).

It is **not** an operation/completion abstraction: no `IORING_OP_ACCEPT`, no
registered buffers/files, no multishot variants. `accept()` and every
per-request read/write stay exactly where they were, as blocking calls on
worker threads. `gateway_accept.zig`'s sharded accept `poll()` loops,
`keepalive_park.zig`'s `ParkedRegistry` reaper and maintenance tick, and
`gateway_shutdown.zig`'s drain are all untouched — as this doc argued after
review, a readiness-only boundary exposes no per-connection
timer/cancellation op, so there is nothing there it could simplify.

It serves all three shared-`EventLoop` roles identically to `epoll`:
unsharded listener accept, parked HTTP/1 keepalive, and native-TLS
`ActiveRegistry`/`ManagedConnection` handshake+idle readiness.

**Minimum kernel: Linux 5.5**, established by runtime feature/opcode probing
rather than a version check. `IORING_OP_TIMEOUT` alone would imply 5.4;
`IORING_FEAT_NODROP` raises it to 5.5 (see difference 3 below).

## The parts most worth reviewing

Four places where the ring is genuinely not a drop-in for level-triggered
`epoll`:

1. **`POLL_ADD` is one-shot.** Callers depend on level-triggered persistence
   (the listener fd is registered once and never re-added), so every
   delivered completion is re-armed inside `wait` before it returns.
2. **A completion carries the mask from when the poll fired**, not readiness
   at `wait` time — so read and write readiness for one fd can arrive on
   separate iterations where `epoll` would coalesce them. No readiness is
   lost. Closing the gap needs `IORING_POLL_ADD_LEVEL`, which is 5.13+ and
   above this prototype's floor.
3. **A lost or failed completion strands a registration permanently.**
   Because a one-shot poll is re-armed only after its CQE is consumed,
   anything that consumes the poll without yielding a usable completion
   leaves the table claiming the fd is armed when nothing will ever re-arm
   it — silently fatal for the listener. Two guards: startup requires
   `IORING_FEAT_NODROP` (kernels before 5.5 discard completions on CQ
   overflow), and a negative `cqe.res` on a live token fails the loop instead
   of being skipped.
4. **Closing a fd does not unregister it, so unregister-before-close is an
   invariant.** `epoll` drops a closed fd from every set; `POLL_ADD` instead
   pins the underlying file, so a poll left armed across a close survives it
   and can be reported against — and re-armed on — whatever descriptor
   inherits that number. `reapActiveConnections` already removed before
   `deinit`; `parkedConnectionCloseHook` now removes before
   `ParkedRegistry.freeConn` closes, covering the idle reaper, drain and
   `closeAll`. `add` keeps strict `EPOLL_CTL_ADD`/`EEXIST` semantics —
   inferring staleness from a duplicate fd number was tried and is unsound,
   since it cannot cover a stale completion reaped *before* the re-add.

Plus one internal concern: `epoll_ctl` is kernel-synchronized and
`removeReadFd` documents worker threads calling it while the loop thread is
in `epoll_wait`. The io_uring SQ is plain shared memory, so every userspace
ring mutation is mutex-guarded and submitting threads call `io_uring_enter`
themselves with `min_complete = 0`, so a poll armed from a worker takes
effect even while the loop thread is blocked in its own `io_uring_enter`.
Registrations carry a monotonic token in the high half of `user_data` so a
completion racing a `POLL_REMOVE` is discarded rather than reported against
a fd the caller has already removed.

## Failure handling

**Startup fails closed.** An explicitly requested backend that cannot be
established — unsupported kernel, missing opcode, missing
`IORING_FEAT_NODROP`, seccomp-blocked `io_uring_setup`,
`RLIMIT_MEMLOCK`/ring allocation failure — aborts startup with a clear error
rather than silently falling back to `epoll`. No runtime hot-switching.
`auto` is rejected as a config value, because the auto-detect-with-fallback
mode the doc sketches is deliberately not implemented.

**Runtime failures are not swallowed.** A poll or timer counts as armed only
once the kernel accepts it; `EINTR` from `io_uring_enter` with
`min_complete = 0` is not treated as success. If the bounded-wait timer
cannot be queued under pressure, `wait` degrades to a non-blocking poll
rather than blocking with no timer to break it. Anything worse is sticky and
surfaces as `error.EventLoopUnrecoverable`, on which `edge_gateway` requests
shutdown and drains — deliberately stricter than the epoll path's
log-and-continue, because a wedged ring can stop delivering listener
readiness while the process still looks healthy.

## Configuration

| Variable | Default | Meaning |
|---|---|---|
| `TARDIGRADE_EVENT_LOOP_BACKEND` | `default` | `default` keeps the platform backend. `io_uring` selects the prototype. `epoll`/`kqueue` may be named explicitly and fail closed if not this platform's backend. |
| `TARDIGRADE_EVENT_LOOP_IO_URING_ENTRIES` | `256` | SQ depth, bounded 64–4096. The modest default keeps ring memory (~24 KiB) inside the 64 KiB `RLIMIT_MEMLOCK` soft limit common on stock hosts, since kernels before 5.12 charge ring memory against it. |

## Validation status — please read before citing this

- **Eight Linux-only tests:** one ring-size fail-closed test plus seven that
  drive a live ring. They mirror the `epoll`/`kqueue` behaviour tests (write
  readiness, `modify`, re-arm persistence, removal, duplicate rejection) and
  add three regressions for the failure modes above — close/fd-number-reuse,
  CQ pressure (150 ready fds against a 128-entry CQ), and a failed completion
  on a live token surfacing as `EventLoopUnrecoverable`. Live-ring tests skip
  themselves where `io_uring_setup` is blocked.
- **Executed on Linux by CI, not by me.** My development host was
  macOS/arm64, where this path compiles out entirely; I validated it there
  only by cross-compiling for `x86_64-linux-gnu` and by review. CI is the
  first actual execution, and the io_uring tests run rather than skip on both
  `ubuntu-latest` (x86_64) and `ubuntu-24.04-arm` (aarch64) — confirmed by
  skip differential: macOS skips 9 where Linux skips 1, a difference of
  exactly 8.
- **Two branches remain unexercised.** CI kernels always have
  `IORING_REGISTER_PROBE`, so the functional `-ETIME` fallback (reachable
  only at exactly 5.5) never runs; and the `IORING_FEAT_NODROP` refusal path
  cannot run on a kernel that has the feature. The CQ-pressure test proves
  the overflow backlog works *with* NODROP, not that the refusal works
  without it.
- **No benchmark evidence of any kind.** No profiling pass has shown the
  shared `EventLoop`'s readiness/idle-wait role to be a bottleneck, and no
  throughput/latency comparison against `epoll` has been run. Per
  `CONCURRENCY.md` and `UPSTREAM_POOLING.md`, such numbers must come from
  real hardware. Nothing here should be cited as evidence `io_uring` is
  faster, slower, or equivalent for this workload.

The evidence precondition in the doc's Recommendation is therefore still
**not** met. The prototype was built ahead of that evidence deliberately, to
make the option concrete and measurable — not to argue for changing the
default.

## Docs

`docs/EVENT_LOOP_BACKENDS.md` gains a "Phase 1 prototype" section covering
all of the above, and its status/recommendation/matrix are reconciled.
`docs/CONCURRENCY.md`'s standing "any new backend must be
benchmark-justified" rule is reconciled explicitly: it still stands, and
this backend is opt-in precisely because it does not yet meet it.

## Follow-ups still open under #148

This PR does not close #148. Still outstanding:

- Benchmark/profiling evidence on real hardware against the `benchmarks/`
  harness (#136). If it shows no measurable win, the honest outcome is to
  remove the prototype rather than carry it.
- `tardigrade_event_loop_iterations_total{backend=...}` label.

Refs #148.
