### PR TITLE
feat(tls): negotiate record_size_limit and add bounded record padding (#359)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,10 @@ All notable user-facing changes to Tardigrade are documented here.
   becomes an enforceable receive bound only once the round trip completes, so a
   peer that ignores the extension still gets ordinary protocol record sizes.
   TLS-over-QUIC has no TLS records: it never offers the extension, and a QUIC
-  server ignores a client that does. Two GnuTLS interop rows assert the
+  server ignores a client that does. 0-RTT records are exempt from the bound:
+  RFC 8446 §4.2.10 puts early data in the client's first flight, before the
+  server's answer exists, so enforcing the value the server later settles on
+  would reject early data a conforming client could not have sized. Two GnuTLS interop rows assert the
   negotiated behaviour against an independent implementation in both roles —
   one proving we honour the peer's limit, one proving the peer honours ours.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable user-facing changes to Tardigrade are documented here.
 ## [Unreleased]
 
 ### Added
+- **Native TLS negotiates `record_size_limit` and can pad records (#359)** —
+  the record transport now offers and honors RFC 8449's `record_size_limit`
+  extension in both roles. Each side advertises the largest inner plaintext it
+  is willing to receive; outgoing protected records — application data and
+  handshake fragments alike — are sized to whatever the peer advertised, and an
+  arriving record that exceeds our own advertisement is refused before the AEAD
+  open rather than after, so the bound actually caps the work an
+  unauthenticated peer can cause. The default advertisement is the TLS 1.3
+  protocol maximum, so the extension is offered but constrains nothing until an
+  operator lowers `record_size_limit`; peers that do not implement RFC 8449
+  (OpenSSL among them) simply omit it, which the RFC defines as the protocol
+  maximum. Out-of-range values follow RFC 8449 §4's asymmetry exactly: below 64
+  is `illegal_parameter` for both roles, while above the maximum a server
+  clamps and a client rejects. TLS-over-QUIC has no TLS records and neither
+  offers nor accepts the extension.
+
+  Separately and locally, `PureZigRecordStream.setRecordPadding` enables
+  RFC 8446 §5.4 padding on application data, rounding each record's inner
+  plaintext up to a block boundary so its length no longer reveals the content
+  length. This is a traffic-analysis countermeasure, not a performance feature
+  — it makes records larger on purpose — and it is off by default. Padding is
+  clamped by the negotiated limit, never the reverse, so it can never push a
+  record past what the peer agreed to accept. `docs/TLS_RECORD_TRANSPORT.md`
+  documents the distinction, including why neither knob is record coalescing.
 - **HTTP/1 origins are bounded per origin, not just per request and per process
   (#140)** — `TARDIGRADE_PROXY_BUFFER_PER_ORIGIN_HARD_LIMIT_BYTES` now applies
   to HTTP/1 relay buffers in both directions, closing the last aggregate gap in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ All notable user-facing changes to Tardigrade are documented here.
   (OpenSSL among them) simply omit it, which the RFC defines as the protocol
   maximum. Out-of-range values follow RFC 8449 §4's asymmetry exactly: below 64
   is `illegal_parameter` for both roles, while above the maximum a server
-  clamps and a client rejects. TLS-over-QUIC has no TLS records and neither
-  offers nor accepts the extension.
+  clamps and a client rejects. TLS-over-QUIC has no TLS records: it never
+  offers the extension, and a QUIC server ignores a client that does.
 
   Separately and locally, `PureZigRecordStream.setRecordPadding` enables
   RFC 8446 §5.4 padding on application data, rounding each record's inner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,15 @@ All notable user-facing changes to Tardigrade are documented here.
   (OpenSSL among them) simply omit it, which the RFC defines as the protocol
   maximum. Out-of-range values follow RFC 8449 §4's asymmetry exactly: below 64
   is `illegal_parameter` for both roles, while above the maximum a server
-  clamps and a client rejects. TLS-over-QUIC has no TLS records: it never
-  offers the extension, and a QUIC server ignores a client that does.
+  clamps and a client rejects. The server's EncryptedExtensions answer is sent
+  only in reply to a client that offered, per RFC 8446 §4.2's request/response
+  rule, and offering is kept distinct from negotiating: a configured limit
+  becomes an enforceable receive bound only once the round trip completes, so a
+  peer that ignores the extension still gets ordinary protocol record sizes.
+  TLS-over-QUIC has no TLS records: it never offers the extension, and a QUIC
+  server ignores a client that does. Two GnuTLS interop rows assert the
+  negotiated behaviour against an independent implementation in both roles —
+  one proving we honour the peer's limit, one proving the peer honours ours.
 
   Separately and locally, `PureZigRecordStream.setRecordPadding` enables
   RFC 8446 §5.4 padding on application data, rounding each record's inner

--- a/docs/TLS_INTEROP_MATRIX.md
+++ b/docs/TLS_INTEROP_MATRIX.md
@@ -171,6 +171,28 @@ negotiated suite's own HKDF, which the positive matrix already sweeps for
 every suite. What is peer-specific here is the message exchange, not the
 arithmetic.
 
+### Record size limit (RFC 8449)
+
+There is deliberately **no** dedicated row for `record_size_limit` (#359).
+OpenSSL does not implement RFC 8449 — traced against OpenSSL 3.6.2, its
+ClientHello and EncryptedExtensions carry no extension 28 in either role — so a
+row asserting a negotiated limit would assert something no peer in this harness
+can do.
+
+What the existing positive rows do cover is the case the RFC defines for
+exactly that situation: a peer that never sends the extension means "the
+protocol maximum", not "no limit". Every OpenSSL row therefore exercises the
+native side offering the extension (its default advertisement is the protocol
+maximum) to a peer that ignores it, and completing normally — which is the
+interoperability property that matters for enabling it by default.
+
+Coverage for a genuinely negotiated limit lives in-tree, where both sides can
+be driven: wire encode/decode and the role-asymmetric out-of-range handling in
+`src/tls/tls13_backend.zig` and `src/tls/tls13_backend_tests.zig`, and the
+sealing/opening bounds in `src/tls/record_epoch_bridge.zig` and
+`src/tls/encrypted_stream.zig`. If a future peer in this matrix implements RFC
+8449, a row belongs here.
+
 ### Negative conformance
 
 Each of these asserts the failure **class**, using the RFC 8446 §6 alert where

--- a/docs/TLS_INTEROP_MATRIX.md
+++ b/docs/TLS_INTEROP_MATRIX.md
@@ -173,25 +173,43 @@ arithmetic.
 
 ### Record size limit (RFC 8449)
 
-There is deliberately **no** dedicated row for `record_size_limit` (#359).
-OpenSSL does not implement RFC 8449 — traced against OpenSSL 3.6.2, its
-ClientHello and EncryptedExtensions carry no extension 28 in either role — so a
-row asserting a negotiated limit would assert something no peer in this harness
-can do.
+Two GnuTLS rows (#359) assert *negotiated* record sizing. OpenSSL does not
+implement RFC 8449 — traced against OpenSSL 3.6.2, its ClientHello carries no
+extension 28 — but GnuTLS does, and `gnutls-cli`/`gnutls-serv` expose
+`--recordsize` to advertise a non-default value. That makes these the rows
+where the extension is exercised against an independent implementation rather
+than against ourselves.
 
-What the existing positive rows do cover is the case the RFC defines for
-exactly that situation: a peer that never sends the extension means "the
-protocol maximum", not "no limit". Every OpenSSL row therefore exercises the
-native side offering the extension (its default advertisement is the protocol
-maximum) to a peer that ignores it, and completing normally — which is the
-interoperability property that matters for enabling it by default.
+One caveat worth knowing when reading them: GnuTLS's `--recordsize N`
+advertises **N+1** on the wire, because RFC 8449 measures the complete
+`TLSInnerPlaintext` and GnuTLS adds the content-type byte itself. So
+`--recordsize 1024` negotiates a 1025-byte limit, which is what the rows pin.
 
-Coverage for a genuinely negotiated limit lives in-tree, where both sides can
-be driven: wire encode/decode and the role-asymmetric out-of-range handling in
-`src/tls/tls13_backend.zig` and `src/tls/tls13_backend_tests.zig`, and the
-sealing/opening bounds in `src/tls/record_epoch_bridge.zig` and
-`src/tls/encrypted_stream.zig`. If a future peer in this matrix implements RFC
-8449, a row belongs here.
+| Row | Peer | What it proves |
+| --- | --- | --- |
+| `record/server/gnutls/record-size-limit` | `gnutls-cli --recordsize 1024` | **we honor the peer's limit**: a 3000-byte response leaves as ≥5 protected records, none with an inner plaintext above 1025 |
+| `record/client/gnutls/record-size-limit` | `gnutls-serv --recordsize 1024` | **the peer honors ours**: we advertise 512, and GnuTLS fragments its ~780-byte response to fit while still delivering every byte |
+
+The two directions are deliberately split across the rows because neither
+stands in for the other. A row that only checked our own sending would pass
+against a peer that ignored the extension completely; a row that only checked
+what arrived would pass without our sizing logic ever running.
+
+Both assert on real record sizes rather than on a completed handshake. The
+server row pins the peer's advertised value, a per-record upper bound, and a
+minimum record count — so a build that negotiated the extension and then
+ignored it fails on fragmentation, and one that stopped sending fails on the
+record count. The client row pins the received-record bound together with a
+minimum byte count, so a peer that "honored" the limit by truncating its
+response fails too. Both bounds also refuse to pass vacuously: a row where no
+protected record was sealed (or none arrived) is a failure, not a silent
+zero-versus-limit comparison.
+
+Coverage for the parts no peer can drive — the role-asymmetric handling of an
+out-of-range advertisement, the request/response rule for the server's
+EncryptedExtensions answer, and the offer-versus-negotiated distinction — lives
+in-tree, in `src/tls/tls13_backend.zig`, `src/tls/tls13_backend_tests.zig`,
+`src/tls/record_epoch_bridge.zig`, and `src/tls/encrypted_stream.zig`.
 
 ### Negative conformance
 

--- a/docs/TLS_RECORD_TRANSPORT.md
+++ b/docs/TLS_RECORD_TRANSPORT.md
@@ -113,3 +113,91 @@ immediate application work; raw socket registration is derived only from
 `wants_read` and `wants_write`. A plaintext read blocked on a TLS write retry
 therefore registers only write interest, and a plaintext write blocked on a TLS
 read retry registers only read interest.
+
+## Record sizing and padding (#359)
+
+Two independent knobs sit on the record path. They are easy to confuse and do
+opposite things, so this section names them apart explicitly.
+
+### `record_size_limit` — negotiated, bounds memory
+
+RFC 8449's `record_size_limit` extension (type 28) is a *negotiated* bound.
+Each endpoint advertises the largest `TLSInnerPlaintext` it is willing to
+**receive**; the peer must not send a protected record larger than that.
+The value covers the complete inner plaintext — content, the content-type
+byte, and any padding — which is why the TLS 1.3 maximum is 2^14+1 (16385)
+rather than 2^14, and why usable content is always one byte less than the
+advertised limit.
+
+* Record transport only. TLS-over-QUIC has no TLS records, so the QUIC
+  profile neither offers the extension nor accepts one: a peer that sends it
+  gets `unsupported_extension`.
+* The client offers it in ClientHello (in both ClientHello1 and ClientHello2,
+  at the same position, so an HRR's "ClientHello2 is a legal mutation of
+  ClientHello1" check still passes). The server answers in
+  EncryptedExtensions, on the full and PSK-resumed flights alike.
+* Configured by `policy.Policy.record_size_limit`. The default is the
+  protocol maximum: the extension is offered but constrains nothing, which is
+  the most interoperable choice and avoids inflating per-record overhead for
+  connections that never needed smaller records. Lowering it is a deliberate
+  memory/latency tradeoff.
+* Values below 64 are rejected as `illegal_parameter` by both roles. Above
+  the protocol maximum the handling is asymmetric, exactly as RFC 8449 §4
+  requires: a **server clamps** (a client may be advertising a size a future
+  version enables, and a server must not enforce the restriction), while a
+  **client rejects** — by EncryptedExtensions the negotiated version is
+  already settled, so no such reading is available.
+* Enforcement is symmetric in `record_epoch_bridge`. Outbound, every
+  protected write and every protected handshake fragment is sized by
+  `Bridge.outboundContentMax()`; sealing more than that fails closed with
+  `RecordSizeLimitExceeded` rather than silently truncating. Inbound, a
+  record whose inner plaintext would exceed our own advertisement is refused
+  *before* the AEAD open — the point of the bound is to cap the work an
+  unauthenticated peer can cause — and maps to the `record_overflow` alert.
+* Unprotected records are exempt (RFC 8449 §4). The initial-epoch plaintext
+  ClientHello/ServerHello keeps the full protocol fragment.
+
+A very small advertised limit interacts with the fixed outbound queue: a large
+server flight (certificate chain plus CertificateVerify) split into 63-byte
+fragments pays per-record overhead on every fragment. The exact requirement is
+preflighted by `sealedHandshakeLen`, so the failure mode is a deterministic
+refusal to progress, never an overflow — but an operator choosing a limit near
+RFC 8449's floor should size the certificate chain accordingly.
+
+### Padding — local, buys privacy, costs bandwidth
+
+RFC 8446 §5.4 record padding is *not* negotiated and has no wire signal. It
+appends zero bytes to the inner plaintext so that an on-path observer cannot
+read the true content length out of the record length. It is a
+traffic-analysis countermeasure, and it is the only thing here that is.
+
+* Configured per stream with `PureZigRecordStream.setRecordPadding`. Off by
+  default: every padding byte costs bandwidth and AEAD work and buys nothing
+  except length uniformity.
+* The only policy is `.block = N`, which rounds each inner plaintext up to a
+  multiple of `N`. A fixed target size was rejected because it cannot pad a
+  record that is already larger and inflates a small-record stream by a
+  constant factor; rounding degrades smoothly.
+* Applied only to `application_data`. Handshake messages have protocol-fixed
+  lengths that are already visible in the transcript, so padding them inflates
+  a latency-critical flight for no privacy; alerts are two bytes and their size
+  should not vary at all.
+* Padding is bounded by the negotiated limit, never the other way around: the
+  target length is clamped to `record_size_limit` before the padding is
+  derived from it, so `content + type + padding` is within the cap for every
+  input, including a record that is already at the cap (which gets none).
+
+Neither knob is record *coalescing*. Coalescing — merging several small
+application writes into one record to amortize the 22-byte header/tag
+overhead — is a throughput optimization that changes when bytes leave, and it
+is not implemented here: `writePlaintext` seals exactly what it accepts, one
+record per call. Padding makes records *larger* on purpose and never merges
+them; a smaller `record_size_limit` makes them *more numerous*. Reading either
+as a performance feature gets the tradeoff backwards.
+
+### Observability
+
+`PureZigRecordStream.recordSizeLimits()` reports the negotiated state and
+`recordSizeCounters()` the effects: writes narrowed by the peer's limit,
+records that carried padding, total padding bytes, and inbound records refused
+for exceeding our own advertisement.

--- a/docs/TLS_RECORD_TRANSPORT.md
+++ b/docs/TLS_RECORD_TRANSPORT.md
@@ -161,10 +161,22 @@ advertised limit.
   to fails with `record_overflow`. When the extension does not negotiate, the
   bound stays at the protocol maximum and the mark can never exceed it, so the
   measurement clears itself.
-* The retained mark covers handshake-epoch records only. A server activates when
-  it *writes* its answer, and 0-RTT records can already be in flight by then —
-  a client cannot honor a bound it has not received, so failing those
-  retroactively would reject legitimate early data.
+* **0-RTT is exempt from the bound entirely**, not merely from the retroactive
+  settle. RFC 8449 §4 renegotiates the limit on resumption and governs records
+  by the limits of the handshake that produced their protection keys; RFC 8446
+  §4.2.10 puts early data in the client's first flight, so it is created — and
+  may already be buffered in flight — before the server's answer exists. A
+  server activates its bound when it *writes* EncryptedExtensions, which is
+  before the handshake completes, so an early record can legitimately arrive at
+  a server already enforcing 512. Judging it against that value would reject
+  early data a conforming client had no way to size correctly.
+
+  The fuller answer would be to honor the *previous* session's bound, but
+  `ResumableSessionCommon` persists no record-size limit today, so there is no
+  PSK-associated value to apply. Until one exists, early records keep the
+  protocol maximum, which `record_codec` already enforces. The exemption is
+  scoped to the epoch, not the connection: the same record size is refused as
+  soon as it arrives at the handshake or application epoch.
 * The client offers it in ClientHello (in both ClientHello1 and ClientHello2,
   at the same position, so an HRR's "ClientHello2 is a legal mutation of
   ClientHello1" check still passes). The server answers in

--- a/docs/TLS_RECORD_TRANSPORT.md
+++ b/docs/TLS_RECORD_TRANSPORT.md
@@ -129,9 +129,14 @@ byte, and any padding — which is why the TLS 1.3 maximum is 2^14+1 (16385)
 rather than 2^14, and why usable content is always one byte less than the
 advertised limit.
 
-* Record transport only. TLS-over-QUIC has no TLS records, so the QUIC
-  profile neither offers the extension nor accepts one: a peer that sends it
-  gets `unsupported_extension`.
+* Record transport only. TLS-over-QUIC has no TLS records, so the QUIC profile
+  never offers the extension and never reads one. A QUIC **server** ignores a
+  client that offers it — without even validating the value — because RFC 8446
+  §4.1.2 has a server ignore an unsupported ClientHello extension, and
+  GnuTLS-based QUIC clients do send it. A **client** still rejects one in
+  EncryptedExtensions with `unsupported_extension`, which is the opposite
+  case and the one RFC 8446 §4.2 requires aborting on: a server must not answer
+  an extension the client never requested.
 * The client offers it in ClientHello (in both ClientHello1 and ClientHello2,
   at the same position, so an HRR's "ClientHello2 is a legal mutation of
   ClientHello1" check still passes). The server answers in

--- a/docs/TLS_RECORD_TRANSPORT.md
+++ b/docs/TLS_RECORD_TRANSPORT.md
@@ -149,6 +149,22 @@ advertised limit.
   limit of 512 must not make us reject a legal 8 KiB record. `Limits.local`
   therefore reports the configured value only when the extension actually
   negotiated, and the protocol maximum otherwise.
+* That split leaves one window, and it is closed retroactively. A client cannot
+  apply its bound to the server's *first* protected flight: until
+  EncryptedExtensions is parsed it does not know whether the server answered at
+  all, and pre-rejecting would break every server that did not. Those
+  handshake-epoch records are therefore opened against the protocol maximum and
+  their inner lengths retained as a high-water mark (EncryptedExtensions may
+  itself be fragmented, so it is a mark across the flight, not one record).
+  `Bridge.setRecordSizeLimits` judges them the moment the bound becomes known: a
+  server that answered extension 28 and then exceeded the value it just agreed
+  to fails with `record_overflow`. When the extension does not negotiate, the
+  bound stays at the protocol maximum and the mark can never exceed it, so the
+  measurement clears itself.
+* The retained mark covers handshake-epoch records only. A server activates when
+  it *writes* its answer, and 0-RTT records can already be in flight by then —
+  a client cannot honor a bound it has not received, so failing those
+  retroactively would reject legitimate early data.
 * The client offers it in ClientHello (in both ClientHello1 and ClientHello2,
   at the same position, so an HRR's "ClientHello2 is a legal mutation of
   ClientHello1" check still passes). The server answers in

--- a/docs/TLS_RECORD_TRANSPORT.md
+++ b/docs/TLS_RECORD_TRANSPORT.md
@@ -137,6 +137,18 @@ advertised limit.
   EncryptedExtensions with `unsupported_extension`, which is the opposite
   case and the one RFC 8446 §4.2 requires aborting on: a server must not answer
   an extension the client never requested.
+* The server's EncryptedExtensions answer is **conditional on the client having
+  offered**, for that same reason. RFC 8449 §4 says where the server's value
+  goes; it does not exempt it from RFC 8446 §4.2's request/response rule, and a
+  conforming client that does not implement RFC 8449 aborts on an unsolicited
+  response.
+* Offering is not negotiating. Our own advertised bound becomes enforceable
+  only once the round trip completes — the client on receiving the server's
+  answer, the server on writing it. Against a peer that ignores the extension,
+  RFC 8449 §4 leaves ordinary protocol record sizes permitted, so a configured
+  limit of 512 must not make us reject a legal 8 KiB record. `Limits.local`
+  therefore reports the configured value only when the extension actually
+  negotiated, and the protocol maximum otherwise.
 * The client offers it in ClientHello (in both ClientHello1 and ClientHello2,
   at the same position, so an HRR's "ClientHello2 is a legal mutation of
   ClientHello1" check still passes). The server answers in
@@ -204,5 +216,12 @@ as a performance feature gets the tradeoff backwards.
 
 `PureZigRecordStream.recordSizeLimits()` reports the negotiated state and
 `recordSizeCounters()` the effects: writes narrowed by the peer's limit,
-records that carried padding, total padding bytes, and inbound records refused
-for exceeding our own advertisement.
+records that carried padding, total padding bytes, inbound records refused for
+exceeding our own advertisement, how many protected records were sealed, and
+the high-water inner-plaintext size in each direction.
+
+The two high-water marks answer different questions and neither substitutes for
+the other: `max_sent_inner_len` against the peer's advertised bound shows *we*
+honored *theirs*, while `max_recv_inner_len` against `Limits.local` shows the
+peer honored *ours*. The interop rows in `docs/TLS_INTEROP_MATRIX.md` assert one
+of each against GnuTLS.

--- a/scripts/interop/run-tls-interop.sh
+++ b/scripts/interop/run-tls-interop.sh
@@ -57,6 +57,13 @@ openssl_bin="${OPENSSL_BIN:-openssl}"
 gnutls_cli="${GNUTLS_CLI:-gnutls-cli}"
 gnutls_serv="${GNUTLS_SERV:-gnutls-serv}"
 
+# #359: when non-empty, the GnuTLS peer advertises this RFC 8449
+# `record_size_limit` (its `--recordsize` is the payload size; GnuTLS adds the
+# content-type byte itself, so `--recordsize 1024` puts 1025 on the wire).
+# Scoped by the record-size rows and cleared straight after, so every other row
+# keeps the peer's default.
+gnutls_recordsize=""
+
 workdir="${TLS_INTEROP_WORKDIR:-$(mktemp -d)}"
 certs="$workdir/certs"
 logs="$workdir/logs"
@@ -194,6 +201,13 @@ list_matrix_rows() {
   say "positive  record/server/openssl/http2_entrypoint"
   say "positive  record/server/openssl/hrr"
   say "positive  record/client/openssl/hrr"
+  if [ "$have_gnutls" -eq 0 ]; then
+    say "skip      record/server/gnutls/record-size-limit"
+    say "skip      record/client/gnutls/record-size-limit"
+  else
+    say "positive  record/server/gnutls/record-size-limit"
+    say "positive  record/client/gnutls/record-size-limit"
+  fi
   say "positive  record/server/openssl/key-update/reciprocal"
   say "positive  record/client/openssl/key-update/reciprocal"
   say "positive  record/client/openssl/key-update/one-way"
@@ -351,9 +365,10 @@ run_server_alpn_row() { # name peer suite group signature alpn peer_stdin [extra
         -CAfile "$cert-cert.pem" > "$log.peer" 2>&1
       ;;
     gnutls)
-      peer_request_stdin "$peer_stdin" | "$gnutls_cli" --port "$p" \
-        --x509cafile "$cert-cert.pem" --alpn="$alpn" --sni-hostname=tardigrade.test \
-        --priority "$(gnutls_priority "$suite" "$group" "$sig")" 127.0.0.1 > "$log.peer" 2>&1
+      local cli_args=(--port "$p" --x509cafile "$cert-cert.pem" --alpn="$alpn"
+        --sni-hostname=tardigrade.test --priority "$(gnutls_priority "$suite" "$group" "$sig")")
+      [ -n "$gnutls_recordsize" ] && cli_args+=(--recordsize "$gnutls_recordsize")
+      peer_request_stdin "$peer_stdin" | "$gnutls_cli" "${cli_args[@]}" 127.0.0.1 > "$log.peer" 2>&1
       ;;
   esac
 
@@ -433,9 +448,11 @@ run_client_row() { # name peer suite group signature [extra native args...]
       wait_for_peer_listener "$log.peer" '^ACCEPT'
       ;;
     gnutls)
-      "$gnutls_serv" --port "$p" --http --x509certfile "$cert-cert.pem" \
-        --x509keyfile "$cert-key.pem" --alpn=http/1.1 \
-        --priority "$(gnutls_priority "$suite" "$group" "$sig")" > "$log.peer" 2>&1 &
+      local serv_args=(--port "$p" --http --x509certfile "$cert-cert.pem"
+        --x509keyfile "$cert-key.pem" --alpn=http/1.1
+        --priority "$(gnutls_priority "$suite" "$group" "$sig")")
+      [ -n "$gnutls_recordsize" ] && serv_args+=(--recordsize "$gnutls_recordsize")
+      "$gnutls_serv" "${serv_args[@]}" > "$log.peer" 2>&1 &
       peer_pid=$!
       wait_for_peer_listener "$log.peer" 'listening on ipv4'
       ;;
@@ -668,6 +685,54 @@ run_client_row "record/client/openssl/key-update/reciprocal" openssl aes128-gcm-
 # peer must follow the transition without being prompted to make one itself.
 run_client_row "record/client/openssl/key-update/one-way" openssl aes128-gcm-sha256 x25519 ed25519 \
   --key-update not-requested
+
+# ── 2c. RFC 8449 record_size_limit, both roles ──────────────────────────────
+
+say ""
+say "== record transport: record_size_limit (RFC 8449) =="
+# #359. OpenSSL does not implement RFC 8449, but GnuTLS does -- and its
+# `--recordsize` makes the peer advertise a non-default limit, so these rows
+# assert *negotiated* record sizing against an independent implementation
+# rather than against ourselves.
+#
+# The two rows deliberately cover opposite halves of the RFC, because one
+# direction cannot stand in for the other:
+#
+#   * the server row proves **we honor the peer's** limit -- a 3000-byte
+#     response must leave as several records, none larger than the 1025 the
+#     peer asked for; and
+#   * the client row proves **the peer honors ours** -- we advertise 512, and
+#     GnuTLS must fragment its ~780-byte response to fit while still
+#     delivering every byte of it.
+#
+# Both assert on real record sizes, not merely on a completed handshake: a
+# row where the extension was silently ignored fails on the size assertions.
+if [ "$have_gnutls" -eq 0 ]; then
+  result "record/server/gnutls/record-size-limit" SKIP "gnutls not installed"
+  result "record/client/gnutls/record-size-limit" SKIP "gnutls not installed"
+else
+  # Larger than the peer's 1025-byte limit, so it cannot be sent as one record.
+  record_size_payload="$(printf 'x%.0s' $(seq 1 3000))"
+
+  # `keep_writing` keeps GnuTLS attached while the response drains: a peer that
+  # sends its request and immediately EOFs would close mid-flush and the row
+  # would fail on the truncation rather than on record sizing.
+  gnutls_recordsize=1024
+  run_server_alpn_row "record/server/gnutls/record-size-limit" gnutls \
+    aes128-gcm-sha256 x25519 ed25519 http/1.1 keep_writing \
+    --record-size-limit 2048 --send "$record_size_payload" \
+    --expect-peer-record-size-limit 1025 \
+    --expect-max-record-bytes 1025 --expect-min-records-sent 5
+
+  # We advertise 512 while the peer advertises 1025, so both directions are
+  # pinned in one row: the peer's value must round-trip to us, and every
+  # record it sends must fit the bound we asked for.
+  run_client_row "record/client/gnutls/record-size-limit" gnutls \
+    aes128-gcm-sha256 x25519 ed25519 \
+    --record-size-limit 512 --expect-peer-record-size-limit 1025 \
+    --expect-max-received-record-bytes 512 --expect-min-bytes 700
+  gnutls_recordsize=""
+fi
 
 # #358: shutdown semantics are asserted explicitly because ordinary positive
 # rows may complete before observing the peer's terminal close behavior.

--- a/src/tls/alerts.zig
+++ b/src/tls/alerts.zig
@@ -11,6 +11,10 @@ const events = @import("events.zig");
 pub const AlertDescription = enum(u8) {
     close_notify = 0,
     unexpected_message = 10,
+    /// RFC 8446 §6: a record whose length exceeded what the receiver accepts.
+    /// Reachable both ways — a peer may send it to us, and #359's negotiated
+    /// `record_size_limit` gives us a reason to send it ourselves.
+    record_overflow = 22,
     handshake_failure = 40,
     bad_certificate = 42,
     unsupported_certificate = 43,

--- a/src/tls/algorithms.zig
+++ b/src/tls/algorithms.zig
@@ -51,6 +51,9 @@ pub const ExtensionType = enum(u16) {
     signature_algorithms = 13,
     application_layer_protocol_negotiation = 16,
     padding = 21,
+    /// RFC 8449. Record-transport only: QUIC carries no TLS records, so a
+    /// QUIC endpoint neither offers nor honors it (#359).
+    record_size_limit = 28,
     early_data = 42,
     pre_shared_key = 41,
     supported_versions = 43,

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -1100,7 +1100,14 @@ pub const PureZigRecordStream = struct {
         // flight this very batch emits, and a client learns the server's limit
         // from EncryptedExtensions and must honor it in the Finished that
         // follows in the same batch.
-        self.refreshRecordSizeLimits() catch |err| return self.fail(err);
+        // A retroactive `RecordSizeLimitExceeded` here means the peer answered
+        // extension 28 and then exceeded the value it had just agreed to.
+        // RFC 8446 §6 makes that a fatal `record_overflow`, so it is deferred
+        // (alert queued, then latched) rather than torn down silently.
+        self.refreshRecordSizeLimits() catch |err| {
+            self.deferHandshakeFailure(err, null);
+            return;
+        };
         // A completion batch may contain application secrets, Client Finished,
         // and handshake-key discard before `handshake_complete`. Validate the
         // batch's final authentication/ALPN state first so policy failure sends
@@ -4422,9 +4429,19 @@ const ScriptedRecordBackend = struct {
     /// How many times the stream released this backend. `Driver.deinit` is not
     /// idempotent, so this must never exceed one.
     deinit_count: usize = 0,
+    /// #359: the server's handshake-epoch Finished payload. Oversizing it is
+    /// how a row makes the server put more on the wire than it agreed to.
+    server_finished: []const u8 = "SF",
     /// #359: the negotiated `record_size_limit` state this scripted backend
     /// reports, standing in for a real handshake's advertisements.
     record_size_limits: record_size.Limits = .{},
+    /// #359: what to report *after* the peer's handshake-epoch flight has been
+    /// processed, standing in for a client learning the server's answer from
+    /// EncryptedExtensions. Before that, `record_size_limits` is reported —
+    /// which is the window in which the server's own flight has already been
+    /// opened against the protocol maximum.
+    record_size_limits_after_flight: ?record_size.Limits = null,
+    handshake_flight_seen: bool = false,
 
     const hs_c2s = secret(0x11);
     const hs_s2c = secret(0x22);
@@ -4450,6 +4467,9 @@ const ScriptedRecordBackend = struct {
 
     fn recordSizeLimits(ptr: *anyopaque) record_size.Limits {
         const self: *ScriptedRecordBackend = @ptrCast(@alignCast(ptr));
+        if (self.handshake_flight_seen) {
+            if (self.record_size_limits_after_flight) |limits| return limits;
+        }
         return self.record_size_limits;
     }
 
@@ -4469,7 +4489,7 @@ const ScriptedRecordBackend = struct {
                     try sink.emitSecret(.handshake, .read, &hs_c2s);
                     try sink.emitSecret(.handshake, .write, &hs_s2c);
                     try sink.emitDiscardEpoch(.initial);
-                    try sink.emitHandshakeBytes(.handshake, "SF");
+                    try sink.emitHandshakeBytes(.handshake, self.server_finished);
                     try sink.emitSecret(.application, .read, &app_c2s);
                     try sink.emitSecret(.application, .write, &app_s2c);
                 } else if (epoch == .handshake and std.mem.eql(u8, bytes, "CF")) {
@@ -4490,7 +4510,11 @@ const ScriptedRecordBackend = struct {
                     try sink.emitSecret(.handshake, .read, &hs_s2c);
                     try sink.emitDiscardEpoch(.initial);
                     if (self.selected_alpn) |protocol| try sink.emitAlpn(protocol);
-                } else if (epoch == .handshake and std.mem.eql(u8, bytes, "SF")) {
+                    // #359: `startsWith` rather than `eql` so a row can make the
+                    // server's Finished large enough to need one oversized
+                    // record; "SF" alone still matches.
+                } else if (epoch == .handshake and std.mem.startsWith(u8, bytes, "SF")) {
+                    self.handshake_flight_seen = true;
                     try sink.emitSecret(.application, .write, &app_c2s);
                     try sink.emitSecret(.application, .read, &app_s2c);
                     // The secure record-stream default requires a client-side
@@ -6849,4 +6873,61 @@ test "#359 an inbound record past our advertised limit fails the stream with rec
         alerts.AlertDescription.record_overflow,
         PureZigRecordStream.mappedFatalAlert(error.RecordSizeLimitExceeded).?,
     );
+}
+
+test "#359 a server that answers extension 28 and then oversizes its own flight gets record_overflow" {
+    // The client-side enforcement gap, end to end. The client advertises 512
+    // but cannot apply it to the server's first protected flight: until that
+    // flight is parsed it does not know whether the server answered extension
+    // 28 at all. Here the server does answer (modelled by the client backend
+    // reporting the negotiated bound once it has processed the flight) *and*
+    // sends a single 2000-byte handshake record. The record is opened against
+    // the protocol maximum, then judged the moment the bound becomes known.
+    const cp = testProvider();
+    var duplex = Duplex{ .max_chunk = record_codec.max_ciphertext_record_len };
+    const oversized_finished = "SF" ++ ("p" ** 2000);
+    // The server is unconstrained, so it seals that flight as one record
+    // rather than fragmenting it to the client's bound.
+    var server_backend = ScriptedRecordBackend{ .role = .server, .server_finished = oversized_finished };
+    var client_backend = ScriptedRecordBackend{
+        .role = .client,
+        .record_size_limits = .{},
+        .record_size_limits_after_flight = .{ .local = 512, .peer = record_size.max_limit },
+    };
+    var client = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
+    defer client.deinit();
+    try client.setExpectedAlpn("h1");
+    var server = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
+    defer server.deinit();
+
+    const errors = driveDriverPairUntilBothErrors(&client, &server);
+    try testing.expectEqual(@as(?anyerror, error.RecordSizeLimitExceeded), errors.client);
+    // The alert actually reached the peer rather than the stream tearing down
+    // silently: RFC 8446 §6 requires `record_overflow` for a record above what
+    // the receiver accepts.
+    try testing.expectEqual(alerts.AlertDescription.record_overflow, server.peerAlert().?);
+    try testing.expect(!client.bridge.handshake_complete);
+    try testing.expectEqual(@as(u64, 1), client.bridge.record_size_counters.oversize_records_rejected);
+}
+
+test "#359 the same oversized flight is accepted when the server never answers extension 28" {
+    // The other half of the same window: a server that does not implement
+    // RFC 8449 is entitled to the protocol maximum, so the identical flight
+    // must complete. Without the offer/negotiated split this would fail.
+    const cp = testProvider();
+    var duplex = Duplex{ .max_chunk = record_codec.max_ciphertext_record_len };
+    const oversized_finished = "SF" ++ ("p" ** 2000);
+    var server_backend = ScriptedRecordBackend{ .role = .server, .server_finished = oversized_finished };
+    // No `record_size_limits_after_flight`: the peer never answered, so the
+    // client keeps reporting the protocol maximum as its enforceable bound.
+    var client_backend = ScriptedRecordBackend{ .role = .client, .record_size_limits = .{} };
+    var client = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
+    defer client.deinit();
+    try client.setExpectedAlpn("h1");
+    var server = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
+    defer server.deinit();
+
+    try driveBothUntil(&client, &server, bothComplete);
+    try testing.expect(client.bridge.handshake_complete);
+    try testing.expectEqual(@as(u64, 0), client.bridge.record_size_counters.oversize_records_rejected);
 }

--- a/src/tls/encrypted_stream.zig
+++ b/src/tls/encrypted_stream.zig
@@ -16,6 +16,7 @@ const events = @import("events.zig");
 const key_update = @import("key_update.zig");
 const record_codec = @import("record_codec.zig");
 const record_epoch_bridge = @import("record_epoch_bridge.zig");
+const record_size = @import("record_size.zig");
 const tls_state = @import("state.zig");
 const tls13_transport = @import("tls13_transport.zig");
 
@@ -619,6 +620,41 @@ pub const PureZigRecordStream = struct {
         self.require_alpn = true;
     }
 
+    /// Install the local record-padding policy (RFC 8446 §5.4, #359).
+    ///
+    /// Padding is a privacy control, not a performance one: it hides how many
+    /// content bytes each record carried, and costs bandwidth and AEAD work
+    /// for every byte it adds. It is never negotiated, so this is a local
+    /// setting with no wire signal — and it is deliberately separate from
+    /// `record_size_limit`, which *is* negotiated and bounds what the padding
+    /// may grow into.
+    pub fn setRecordPadding(self: *PureZigRecordStream, padding: record_size.PaddingPolicy) Error!void {
+        return self.bridge.setRecordPadding(padding);
+    }
+
+    /// The connection's negotiated `record_size_limit` state (#359). Before
+    /// the handshake settles it reports this endpoint's own advertisement with
+    /// no peer value, which is the same thing an un-negotiated connection
+    /// means.
+    pub fn recordSizeLimits(self: *const PureZigRecordStream) record_size.Limits {
+        return self.bridge.record_size_limits;
+    }
+
+    /// Observable record-sizing effects: writes narrowed by the peer's limit,
+    /// padding actually emitted, and inbound records refused for exceeding
+    /// our own advertisement.
+    pub fn recordSizeCounters(self: *const PureZigRecordStream) record_size.Counters {
+        return self.bridge.record_size_counters;
+    }
+
+    /// Mirror the backend's negotiated record-size state into the bridge that
+    /// actually seals and opens records. Idempotent: re-reading a settled
+    /// negotiation installs the same values.
+    fn refreshRecordSizeLimits(self: *PureZigRecordStream) Error!void {
+        const driver = if (self.handshake_driver) |*d| d else return;
+        try self.bridge.setRecordSizeLimits(driver.backend.recordSizeLimits());
+    }
+
     /// The peer certificate validation outcome the backend reported.
     pub fn certificateState(self: *const PureZigRecordStream) events.CertificateState {
         return self.certificate_state;
@@ -843,9 +879,17 @@ pub const PureZigRecordStream = struct {
     fn emitHandshakeRecords(self: *PureZigRecordStream, epoch: events.EncryptionEpoch, bytes: []const u8) Error!void {
         if (!try self.canReserveOutboundHandshakeBytes(epoch, bytes.len)) return error.WouldBlock;
 
+        // #359: RFC 8449 §4 exempts unprotected records ("Unprotected
+        // messages are not subject to this limit"), so the initial epoch's
+        // plaintext ClientHello/ServerHello keeps the full protocol fragment
+        // even against a peer that advertised a smaller limit.
+        const chunk = if (epoch == .initial)
+            record_codec.max_plaintext_fragment_len
+        else
+            self.bridge.outboundContentMax();
         var offset: usize = 0;
         while (offset < bytes.len) {
-            const take = @min(record_codec.max_plaintext_fragment_len, bytes.len - offset);
+            const take = @min(chunk, bytes.len - offset);
             var record_buf: [record_codec.max_ciphertext_record_len]u8 = undefined;
             const record = self.bridge.sealHandshake(epoch, bytes[offset..][0..take], &record_buf) catch |err| return self.fail(err);
             self.appendOutboundCiphertext(record) catch |err| return self.fail(err);
@@ -947,8 +991,14 @@ pub const PureZigRecordStream = struct {
         if (self.outbound_ciphertext.available() < needed) return error.WouldBlock;
 
         var offset: usize = 0;
+        // #359: post-handshake messages (NewSessionTicket, KeyUpdate) travel in
+        // protected application-epoch records, so they are subject to the
+        // peer's `record_size_limit` exactly as application data is. The
+        // `sealedHandshakeLen` reservation above already sizes itself from the
+        // same bound.
+        const chunk = self.bridge.outboundContentMax();
         while (offset < event.handshake_bytes.data.len) {
-            const take = @min(record_codec.max_plaintext_fragment_len, event.handshake_bytes.data.len - offset);
+            const take = @min(chunk, event.handshake_bytes.data.len - offset);
             var record_buf: [record_codec.max_ciphertext_record_len]u8 = undefined;
             const record = try self.bridge.sealHandshake(.application, event.handshake_bytes.data[offset..][0..take], &record_buf);
             try self.appendOutboundCiphertext(record);
@@ -1043,6 +1093,14 @@ pub const PureZigRecordStream = struct {
     fn applyDriverOutcome(self: *PureZigRecordStream, outcome: RecordHandshakeDriver.Outcome) Error!void {
         var fatal_alert: ?alerts.AlertDescription = null;
         const sink = outcome.sink;
+        // #359: pull the negotiated record-size state *before* serializing
+        // this batch's `handshake_bytes`. The ordering is load-bearing on both
+        // roles: a server learns the client's limit from the ClientHello it
+        // just consumed and must already honor it in the EncryptedExtensions
+        // flight this very batch emits, and a client learns the server's limit
+        // from EncryptedExtensions and must honor it in the Finished that
+        // follows in the same batch.
+        self.refreshRecordSizeLimits() catch |err| return self.fail(err);
         // A completion batch may contain application secrets, Client Finished,
         // and handshake-key discard before `handshake_complete`. Validate the
         // batch's final authentication/ALPN state first so policy failure sends
@@ -1282,6 +1340,10 @@ pub const PureZigRecordStream = struct {
             error.NoMutualParameters,
             error.UnsupportedProtocolVersion,
             => alerts.fromHandshakeError(@errorCast(err)),
+            // #359: RFC 8446 §6 names `record_overflow` for a record longer
+            // than the receiver accepts, which is exactly what a peer that
+            // ignored our `record_size_limit` sent us.
+            error.RecordSizeLimitExceeded => .record_overflow,
             else => null,
         };
     }
@@ -1476,7 +1538,16 @@ pub const PureZigRecordStream = struct {
         if (!self.hasHardRoom(.outbound_ciphertext, self.outbound_ciphertext.len, record_codec.max_ciphertext_record_len)) return self.rejectHardLimit(.outbound_ciphertext, error.WouldBlock);
         if (self.outbound_ciphertext.available() < record_codec.max_ciphertext_record_len) return error.WouldBlock;
 
-        const n = @min(bytes.len, record_codec.max_plaintext_fragment_len);
+        // #359: one record per call, sized by whichever bound is tighter --
+        // the protocol fragment maximum or the peer's advertised
+        // `record_size_limit`. A short return is already this API's contract
+        // (callers loop), so a narrower peer limit costs more calls rather
+        // than an error.
+        const content_max = self.bridge.outboundContentMax();
+        const n = @min(bytes.len, content_max);
+        if (content_max < record_codec.max_plaintext_fragment_len and bytes.len > content_max) {
+            self.bridge.record_size_counters.peer_limited_writes +|= 1;
+        }
         if (write_epoch == .zero_rtt) {
             const max_early = if (self.handshake_driver) |*driver| driver.backend.earlyDataMaxBytes() else return error.WouldBlock;
             if (self.zero_rtt_sent >= max_early) return error.WouldBlock;
@@ -4351,6 +4422,9 @@ const ScriptedRecordBackend = struct {
     /// How many times the stream released this backend. `Driver.deinit` is not
     /// idempotent, so this must never exceed one.
     deinit_count: usize = 0,
+    /// #359: the negotiated `record_size_limit` state this scripted backend
+    /// reports, standing in for a real handshake's advertisements.
+    record_size_limits: record_size.Limits = .{},
 
     const hs_c2s = secret(0x11);
     const hs_s2c = secret(0x22);
@@ -4358,12 +4432,25 @@ const ScriptedRecordBackend = struct {
     const app_s2c = secret(0x44);
 
     fn recordBackend(self: *ScriptedRecordBackend) RecordHandshakeBackend {
-        return .{ .ptr = self, .startFn = start, .receiveFn = receive, .authPendingFn = authPending, .resumeFn = resumeAuth, .deinitFn = backendDeinit };
+        return .{
+            .ptr = self,
+            .startFn = start,
+            .receiveFn = receive,
+            .authPendingFn = authPending,
+            .resumeFn = resumeAuth,
+            .deinitFn = backendDeinit,
+            .recordSizeLimitsFn = recordSizeLimits,
+        };
     }
 
     fn backendDeinit(ptr: *anyopaque) void {
         const self: *ScriptedRecordBackend = @ptrCast(@alignCast(ptr));
         self.deinit_count += 1;
+    }
+
+    fn recordSizeLimits(ptr: *anyopaque) record_size.Limits {
+        const self: *ScriptedRecordBackend = @ptrCast(@alignCast(ptr));
+        return self.record_size_limits;
     }
 
     fn start(ptr: *anyopaque, role: tls_state.Role, _: void, sink: *RecordTransport.EventSink) RecordHandshakeError!void {
@@ -6625,4 +6712,141 @@ test "encrypted stream close is terminal and idempotent from every lifecycle sta
         try expectTeardownMetadataCleared(&pair.subject);
         try testing.expectEqual(@as(usize, 1), carrier_state.close_calls);
     }
+}
+
+// ===========================================================================
+// #359: record sizing and padding on a driver-owned stream.
+// ===========================================================================
+
+test "#359 a driver-owned stream honors the peer's record_size_limit on every protected write" {
+    const cp = testProvider();
+    var duplex = Duplex{ .max_chunk = record_codec.max_ciphertext_record_len };
+    // The server told the client it accepts at most 128-byte inner
+    // plaintexts; the client told the server the protocol maximum.
+    var client_backend = ScriptedRecordBackend{ .role = .client, .record_size_limits = .{ .peer = 128 } };
+    var server_backend = ScriptedRecordBackend{ .role = .server, .record_size_limits = .{ .local = 128 } };
+    var client = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
+    defer client.deinit();
+    try client.setExpectedAlpn("h1");
+    var server = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
+    defer server.deinit();
+
+    try driveBothUntil(&client, &server, bothComplete);
+    try testing.expectEqual(@as(?u16, 128), client.recordSizeLimits().peer);
+    try testing.expectEqual(@as(usize, 127), client.bridge.outboundContentMax());
+
+    // A single write is capped at 127 content bytes -- the peer's 128 minus
+    // the content-type byte RFC 8449 counts -- and reports the short length
+    // rather than failing.
+    const payload = [_]u8{'q'} ** 400;
+    var sent: usize = 0;
+    var writes: usize = 0;
+    while (sent < payload.len) {
+        const n = try client.stream().write(payload[sent..]);
+        try testing.expect(n <= 127);
+        sent += n;
+        writes += 1;
+        _ = try client.stream().drive();
+        _ = try server.stream().drive();
+    }
+    try testing.expectEqual(@as(usize, 4), writes);
+    try testing.expect(client.recordSizeCounters().peer_limited_writes > 0);
+
+    try driveBothUntil(&client, &server, struct {
+        fn done(_: *PureZigRecordStream, s: *PureZigRecordStream) bool {
+            return s.readiness().can_read_plaintext;
+        }
+    }.done);
+
+    // The server accepted every record: none exceeded what it advertised.
+    var received: [payload.len]u8 = undefined;
+    var total: usize = 0;
+    while (total < payload.len) {
+        const n = server.stream().read(received[total..]) catch |err| switch (err) {
+            error.WouldBlock => {
+                _ = try client.stream().drive();
+                _ = try server.stream().drive();
+                continue;
+            },
+            else => return err,
+        };
+        total += n;
+    }
+    try testing.expectEqualSlices(u8, &payload, received[0..total]);
+    try testing.expectEqual(@as(u64, 0), server.recordSizeCounters().oversize_records_rejected);
+}
+
+test "#359 a stream pads application records without ever exceeding the peer's limit" {
+    const cp = testProvider();
+    var duplex = Duplex{ .max_chunk = record_codec.max_ciphertext_record_len };
+    var client_backend = ScriptedRecordBackend{ .role = .client, .record_size_limits = .{ .peer = 512 } };
+    var server_backend = ScriptedRecordBackend{ .role = .server, .record_size_limits = .{ .local = 512 } };
+    var client = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
+    defer client.deinit();
+    try client.setExpectedAlpn("h1");
+    var server = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
+    defer server.deinit();
+    // Padding is local policy: it is set on the stream, never negotiated, and
+    // the peer learns nothing about it beyond uniform record lengths.
+    try client.setRecordPadding(.{ .block = 256 });
+
+    try driveBothUntil(&client, &server, bothComplete);
+    try testing.expectEqual(@as(usize, 4), try client.stream().write("tiny"));
+    try driveBothUntil(&client, &server, struct {
+        fn done(_: *PureZigRecordStream, s: *PureZigRecordStream) bool {
+            return s.readiness().can_read_plaintext;
+        }
+    }.done);
+
+    var buf: [32]u8 = undefined;
+    try testing.expectEqualStrings("tiny", buf[0..try server.stream().read(&buf)]);
+    // 4 content bytes + the type byte is 5; padded to the next 256 boundary.
+    const counters = client.recordSizeCounters();
+    try testing.expectEqual(@as(u64, 1), counters.padded_records);
+    try testing.expectEqual(@as(u64, 251), counters.padding_bytes);
+    // And the server, which advertised 512, accepted it: padding stayed
+    // inside the negotiated bound.
+    try testing.expectEqual(@as(u64, 0), server.recordSizeCounters().oversize_records_rejected);
+}
+
+test "#359 padding configuration outside the honorable range is rejected at the stream" {
+    const cp = testProvider();
+    var backend = ScriptedRecordBackend{ .role = .client };
+    var stream_state = try PureZigRecordStream.initWithBackend(std.testing.allocator, .client, cp, .tls_aes_128_gcm_sha256, backend.recordBackend());
+    defer stream_state.deinit();
+    try testing.expectError(error.InvalidRecordSizeLimit, stream_state.setRecordPadding(.{ .block = 0 }));
+    try testing.expectError(
+        error.InvalidRecordSizeLimit,
+        stream_state.setRecordPadding(.{ .block = record_size.PaddingPolicy.max_block + 1 }),
+    );
+    try testing.expectEqual(record_size.PaddingPolicy.none, stream_state.bridge.record_padding);
+}
+
+test "#359 an inbound record past our advertised limit fails the stream with record_overflow" {
+    // The peer ignores what we advertised: our own bridge is configured to
+    // accept only 128, while the sender still uses the protocol maximum.
+    const cp = testProvider();
+    var duplex = Duplex{ .max_chunk = record_codec.max_ciphertext_record_len };
+    var client_backend = ScriptedRecordBackend{ .role = .client };
+    var server_backend = ScriptedRecordBackend{ .role = .server };
+    var client = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .client, cp, .tls_aes_128_gcm_sha256, duplex.clientCarrier(), client_backend.recordBackend());
+    defer client.deinit();
+    try client.setExpectedAlpn("h1");
+    var server = try PureZigRecordStream.initWithCarrierAndBackend(std.testing.allocator, .server, cp, .tls_aes_128_gcm_sha256, duplex.serverCarrier(), server_backend.recordBackend());
+    defer server.deinit();
+
+    try driveBothUntil(&client, &server, bothComplete);
+    // Tighten only the receiving side, after the handshake, so the sender
+    // keeps writing full-size records into a peer that no longer accepts them.
+    try server.bridge.setRecordSizeLimits(.{ .local = 128 });
+
+    const payload = [_]u8{'w'} ** 1024;
+    _ = try client.stream().write(&payload);
+    _ = try client.stream().drive();
+    try testing.expectError(error.RecordSizeLimitExceeded, server.stream().drive());
+    try testing.expectEqual(@as(u64, 1), server.bridge.record_size_counters.oversize_records_rejected);
+    try testing.expectEqual(
+        alerts.AlertDescription.record_overflow,
+        PureZigRecordStream.mappedFatalAlert(error.RecordSizeLimitExceeded).?,
+    );
 }

--- a/src/tls/policy.zig
+++ b/src/tls/policy.zig
@@ -2,6 +2,7 @@
 
 const state = @import("state.zig");
 const algorithms = @import("algorithms.zig");
+const record_size = @import("record_size.zig");
 
 pub const CipherSuite = algorithms.CipherSuite;
 pub const NamedGroup = algorithms.NamedGroup;
@@ -57,6 +58,17 @@ pub const Policy = struct {
     alpn_protocols: []const ProtocolName,
     require_sni: bool = false,
     allow_absent_alpn: bool = false,
+    /// The `record_size_limit` this endpoint advertises (RFC 8449, #359): the
+    /// largest `TLSInnerPlaintext` it is willing to *receive*. Defaults to the
+    /// TLS 1.3 protocol maximum, so the extension is offered but constrains
+    /// nothing until an operator lowers it — an endpoint that supports every
+    /// record size interoperates most widely by saying exactly that.
+    ///
+    /// Record transport only. RFC 8449 is defined over TLS/DTLS records, which
+    /// QUIC does not use (RFC 9001 carries handshake bytes in CRYPTO frames
+    /// and bounds application data with its own flow control), so a
+    /// `.quic` policy never puts this on the wire.
+    record_size_limit: u16 = record_size.default_limit,
 
     pub fn quicDefault() Policy {
         return .{

--- a/src/tls/record_epoch_bridge.zig
+++ b/src/tls/record_epoch_bridge.zig
@@ -414,17 +414,17 @@ pub const Bridge = struct {
             },
             .handshake => blk: {
                 const write = self.writeHandshake() orelse return error.MissingWriteKeys;
-                break :blk try sealHandshakeFragments(write, bytes, content_max, out);
+                break :blk try sealHandshakeFragments(write, bytes, content_max, &self.record_size_counters, out);
             },
             .application => blk: {
                 if (!self.handshake_complete) return error.HandshakeNotComplete;
                 const write = self.writeApplication() orelse return error.MissingWriteKeys;
-                break :blk try sealHandshakeFragments(write, bytes, content_max, out);
+                break :blk try sealHandshakeFragments(write, bytes, content_max, &self.record_size_counters, out);
             },
             .zero_rtt => blk: {
                 if (self.handshake_complete) return error.UnsupportedRecordEpoch;
                 const write = self.writeZeroRtt() orelse return error.MissingWriteKeys;
-                break :blk try sealHandshakeFragments(write, bytes, content_max, out);
+                break :blk try sealHandshakeFragments(write, bytes, content_max, &self.record_size_counters, out);
             },
         };
     }
@@ -500,8 +500,12 @@ pub const Bridge = struct {
             },
         };
         // Only counted once the record actually exists: a failed seal sent
-        // nothing, so it padded nothing.
-        self.record_size_counters.notePadding(padding_len);
+        // nothing, so it padded nothing. The initial epoch is unprotected and
+        // outside RFC 8449's accounting entirely.
+        if (epoch != .initial) {
+            self.record_size_counters.notePadding(padding_len);
+            self.record_size_counters.noteSealed(bytes.len, padding_len);
+        }
         return sealed;
     }
 
@@ -554,6 +558,12 @@ pub const Bridge = struct {
                 break :blk try read.open(record, out);
             },
         };
+        // Counted only for protected epochs, and only once the AEAD actually
+        // opened the record: an unauthenticated length is not evidence of
+        // anything the peer did.
+        if (epoch != .initial) {
+            self.record_size_counters.noteOpened(inner.content.len + 1 + inner.padding_len);
+        }
         return .{ .epoch = epoch, .inner = inner };
     }
 
@@ -701,6 +711,7 @@ fn sealHandshakeFragments(
     write: *record_protection.WriteState,
     bytes: []const u8,
     content_max: usize,
+    counters: *record_size.Counters,
     out: []u8,
 ) Error![]const u8 {
     if (write.exhausted) return error.SequenceExhausted;
@@ -714,6 +725,7 @@ fn sealHandshakeFragments(
     while (in_pos < bytes.len) {
         const take = @min(content_max, bytes.len - in_pos);
         const record = try write.seal(.handshake, bytes[in_pos..][0..take], 0, out[out_pos..]);
+        counters.noteSealed(take, 0);
         in_pos += take;
         out_pos += record.len;
     }

--- a/src/tls/record_epoch_bridge.zig
+++ b/src/tls/record_epoch_bridge.zig
@@ -15,13 +15,23 @@ const events = @import("events.zig");
 const key_schedule = @import("key_schedule.zig");
 const record_codec = @import("record_codec.zig");
 const record_protection = @import("record_protection.zig");
+const record_size = @import("record_size.zig");
 const tls_state = @import("state.zig");
 const transport = @import("transport.zig");
 
 const provider = crypto.provider;
 const secrets = crypto.secrets;
 
-pub const Error = record_codec.Error || record_protection.Error || key_schedule.Error || error{
+pub const Error = record_codec.Error || record_protection.Error || key_schedule.Error ||
+    record_size.ConfigError || error{
+    /// A protected record's `TLSInnerPlaintext` exceeded the `record_size_limit`
+    /// this endpoint advertised (RFC 8449 §4), so the peer sent more than it
+    /// was told we would accept. Distinct from `RecordTooLarge`, which is the
+    /// *protocol* maximum: this one is the smaller, negotiated bound, and it
+    /// carries the `record_overflow` alert for the same reason RFC 8446 §6
+    /// gives one to an over-length record at all.
+    RecordSizeLimitExceeded,
+} || error{
     UnsupportedRecordEpoch,
     DuplicateTrafficSecret,
     MissingReadKeys,
@@ -103,6 +113,18 @@ pub const Bridge = struct {
     /// Starting a new session is `Bridge.init`, which yields a fresh value
     /// with this cleared.
     torn_down: bool = false,
+    /// Negotiated `record_size_limit` state (#359). Defaults to the protocol
+    /// maximum in both directions, which is exactly the behavior of a
+    /// connection where the extension never appeared — so a bridge driven
+    /// without a handshake backend (the low-level record-plumbing paths) is
+    /// unaffected by this feature existing.
+    record_size_limits: record_size.Limits = .{},
+    /// Local, non-negotiated padding policy (RFC 8446 §5.4). Off by default;
+    /// applies only to `application_data`, never to handshake records — see
+    /// `sealProtected`.
+    record_padding: record_size.PaddingPolicy = .none,
+    /// Observable record-sizing effects. Counters only.
+    record_size_counters: record_size.Counters = .{},
 
     pub fn init(crypto_provider: provider.CryptoProvider, cipher_suite: algorithms.CipherSuite) Bridge {
         return .{ .crypto_provider = crypto_provider, .cipher_suite = cipher_suite };
@@ -339,8 +361,40 @@ pub const Bridge = struct {
         return state.sequence;
     }
 
+    /// Install the negotiated `record_size_limit` state (#359).
+    ///
+    /// Both halves are validated here rather than trusted: `local` is our own
+    /// advertisement and must be one we could legally have sent, and `peer`
+    /// is clamped by `Limits.outboundInnerMax` so an out-of-range value can
+    /// never widen the protocol bound.
+    pub fn setRecordSizeLimits(self: *Bridge, limits: record_size.Limits) Error!void {
+        try limits.validate();
+        self.record_size_limits = limits;
+    }
+
+    /// Install the local padding policy (RFC 8446 §5.4). Purely local: nothing
+    /// about it is negotiated, and a peer cannot observe it except as record
+    /// lengths that no longer reveal content lengths.
+    pub fn setRecordPadding(self: *Bridge, padding: record_size.PaddingPolicy) Error!void {
+        try padding.validate();
+        self.record_padding = padding;
+    }
+
+    /// The largest *content* one outgoing protected record may carry: the
+    /// protocol fragment maximum, narrowed by whatever the peer advertised.
+    /// This is the fragmentation unit for every protected write, which is why
+    /// it is public — `encrypted_stream` sizes its own writes from it rather
+    /// than discovering the bound by failing a seal.
+    pub fn outboundContentMax(self: *const Bridge) usize {
+        return @min(record_codec.max_plaintext_fragment_len, self.record_size_limits.outboundContentMax());
+    }
+
     pub fn sealHandshake(self: *Bridge, epoch: events.EncryptionEpoch, bytes: []const u8, out: []u8) Error![]const u8 {
-        if (bytes.len <= record_codec.max_plaintext_fragment_len) {
+        // Unprotected records are not subject to `record_size_limit`
+        // (RFC 8449 §4: "Unprotected messages are not subject to this
+        // limit"), so the initial epoch keeps the full protocol fragment.
+        const content_max = if (epoch == .initial) record_codec.max_plaintext_fragment_len else self.outboundContentMax();
+        if (bytes.len <= content_max) {
             return self.sealProtected(epoch, .handshake, bytes, out);
         }
         return switch (epoch) {
@@ -360,22 +414,23 @@ pub const Bridge = struct {
             },
             .handshake => blk: {
                 const write = self.writeHandshake() orelse return error.MissingWriteKeys;
-                break :blk try sealHandshakeFragments(write, bytes, out);
+                break :blk try sealHandshakeFragments(write, bytes, content_max, out);
             },
             .application => blk: {
                 if (!self.handshake_complete) return error.HandshakeNotComplete;
                 const write = self.writeApplication() orelse return error.MissingWriteKeys;
-                break :blk try sealHandshakeFragments(write, bytes, out);
+                break :blk try sealHandshakeFragments(write, bytes, content_max, out);
             },
             .zero_rtt => blk: {
                 if (self.handshake_complete) return error.UnsupportedRecordEpoch;
                 const write = self.writeZeroRtt() orelse return error.MissingWriteKeys;
-                break :blk try sealHandshakeFragments(write, bytes, out);
+                break :blk try sealHandshakeFragments(write, bytes, content_max, out);
             },
         };
     }
 
     pub fn sealedHandshakeLen(self: *Bridge, epoch: events.EncryptionEpoch, bytes_len: usize) Error!usize {
+        const content_max = self.outboundContentMax();
         return switch (epoch) {
             .initial => if (self.initial_discarded)
                 error.UnsupportedRecordEpoch
@@ -383,17 +438,17 @@ pub const Bridge = struct {
                 try plaintextHandshakeRecordLen(bytes_len),
             .handshake => blk: {
                 const write = self.writeHandshake() orelse return error.MissingWriteKeys;
-                break :blk try protectedHandshakeRecordLen(write, bytes_len);
+                break :blk try protectedHandshakeRecordLen(write, bytes_len, content_max);
             },
             .application => blk: {
                 if (!self.handshake_complete) return error.HandshakeNotComplete;
                 const write = self.writeApplication() orelse return error.MissingWriteKeys;
-                break :blk try protectedHandshakeRecordLen(write, bytes_len);
+                break :blk try protectedHandshakeRecordLen(write, bytes_len, content_max);
             },
             .zero_rtt => blk: {
                 if (self.handshake_complete) return error.UnsupportedRecordEpoch;
                 const write = self.writeZeroRtt() orelse return error.MissingWriteKeys;
-                break :blk try protectedHandshakeRecordLen(write, bytes_len);
+                break :blk try protectedHandshakeRecordLen(write, bytes_len, content_max);
             },
         };
     }
@@ -405,30 +460,49 @@ pub const Bridge = struct {
         bytes: []const u8,
         out: []u8,
     ) Error![]const u8 {
-        return switch (epoch) {
-            .initial => if (self.initial_discarded)
-                error.UnsupportedRecordEpoch
-            else if (content_type == .handshake)
-                record_codec.encodePlaintextRecord(.handshake, bytes, out)
-            else
-                error.UnsupportedRecordEpoch,
+        if (epoch != .initial) {
+            // Fail closed rather than silently truncating: a caller that hands
+            // this more content than the peer agreed to receive has a sizing
+            // bug, and quietly dropping the tail would corrupt the stream.
+            if (bytes.len > self.outboundContentMax()) return error.RecordSizeLimitExceeded;
+        }
+        // RFC 8446 §5.4 padding is applied only to `application_data`.
+        // Handshake records carry messages whose lengths are already fixed by
+        // the protocol and visible in the transcript, so padding them buys no
+        // privacy while inflating a latency-critical flight; alerts are two
+        // bytes and are the one record type whose size an implementation
+        // should not vary at all.
+        const padding_len = if (epoch != .initial and content_type == .application_data)
+            self.record_padding.paddingFor(bytes.len, self.record_size_limits.outboundInnerMax())
+        else
+            0;
+        const sealed = switch (epoch) {
+            .initial => blk: {
+                if (self.initial_discarded) return error.UnsupportedRecordEpoch;
+                if (content_type != .handshake) return error.UnsupportedRecordEpoch;
+                break :blk try record_codec.encodePlaintextRecord(.handshake, bytes, out);
+            },
             .handshake => blk: {
                 const write = self.writeHandshake() orelse return error.MissingWriteKeys;
-                break :blk try write.seal(content_type, bytes, 0, out);
+                break :blk try write.seal(content_type, bytes, padding_len, out);
             },
             .application => blk: {
                 if (!self.handshake_complete and content_type != .alert) return error.HandshakeNotComplete;
                 const write = self.writeApplication() orelse return error.MissingWriteKeys;
-                break :blk try write.seal(content_type, bytes, 0, out);
+                break :blk try write.seal(content_type, bytes, padding_len, out);
             },
             .zero_rtt => blk: {
                 if (self.handshake_complete or
                     !(content_type == .application_data or content_type == .handshake))
                     return error.UnsupportedRecordEpoch;
                 const write = self.writeZeroRtt() orelse return error.MissingWriteKeys;
-                break :blk try write.seal(content_type, bytes, 0, out);
+                break :blk try write.seal(content_type, bytes, padding_len, out);
             },
         };
+        // Only counted once the record actually exists: a failed seal sent
+        // nothing, so it padded nothing.
+        self.record_size_counters.notePadding(padding_len);
+        return sealed;
     }
 
     pub fn sealApplicationData(self: *Bridge, bytes: []const u8, out: []u8) Error![]const u8 {
@@ -464,20 +538,46 @@ pub const Bridge = struct {
             },
             .handshake => blk: {
                 const read = self.readHandshake() orelse return error.MissingReadKeys;
+                try self.checkInboundRecordSize(read, record);
                 break :blk try read.open(record, out);
             },
             .application => blk: {
                 if (!self.handshake_complete) return error.HandshakeNotComplete;
                 const read = self.readApplication() orelse return error.MissingReadKeys;
+                try self.checkInboundRecordSize(read, record);
                 break :blk try read.open(record, out);
             },
             .zero_rtt => blk: {
                 if (self.handshake_complete) return error.UnsupportedRecordEpoch;
                 const read = self.readZeroRtt() orelse return error.MissingReadKeys;
+                try self.checkInboundRecordSize(read, record);
                 break :blk try read.open(record, out);
             },
         };
         return .{ .epoch = epoch, .inner = inner };
+    }
+
+    /// Reject a protected record whose `TLSInnerPlaintext` would exceed the
+    /// limit we advertised (RFC 8449 §4), *before* spending an AEAD open on it.
+    ///
+    /// The inner length is recovered from the ciphertext length rather than
+    /// measured after decryption on purpose: the whole point of advertising a
+    /// limit is to bound the work an unauthenticated peer can make us do, and
+    /// a check that only fires post-decryption would already have done it.
+    /// The subtraction is safe because `ReadState.open` is the only consumer
+    /// of a shorter payload and rejects it as malformed; a payload that cannot
+    /// even hold a tag is left for that path to name.
+    fn checkInboundRecordSize(
+        self: *Bridge,
+        read: *const record_protection.ReadState,
+        record: record_codec.Record,
+    ) Error!void {
+        const tag_len = read.keys.profile.aead.tagLength();
+        if (record.payload.len < tag_len) return;
+        const inner_len = record.payload.len - tag_len;
+        if (inner_len <= self.record_size_limits.inboundInnerMax()) return;
+        self.record_size_counters.oversize_records_rejected +|= 1;
+        return error.RecordSizeLimitExceeded;
     }
 
     pub fn openApplicationData(self: *Bridge, record: record_codec.Record, out: []u8) Error!OpenedRecord {
@@ -572,19 +672,26 @@ fn clearWrite(slot: *?record_protection.WriteState) void {
 /// because callers (`plaintextHandshakeRecordLen`/
 /// `protectedHandshakeRecordLen`) add `bytes_len` back on top of the chunk
 /// overhead, and that addition can overflow even though this one can't.
-fn chunkCount(bytes_len: usize) Error!usize {
+fn chunkCount(bytes_len: usize, chunk_size: usize) Error!usize {
     if (bytes_len == 0) return 0;
-    return std.math.divCeil(usize, bytes_len, record_codec.max_plaintext_fragment_len) catch error.RecordTooLarge;
+    // `chunk_size` is `Bridge.outboundContentMax`, which is at least
+    // `record_size.min_limit - 1` (63) and never zero, so this cannot divide
+    // by zero on any reachable path.
+    return std.math.divCeil(usize, bytes_len, chunk_size) catch error.RecordTooLarge;
 }
 
 fn plaintextHandshakeRecordLen(bytes_len: usize) Error!usize {
-    const chunks = try chunkCount(bytes_len);
+    const chunks = try chunkCount(bytes_len, record_codec.max_plaintext_fragment_len);
     const overhead = std.math.mul(usize, chunks, record_codec.header_len) catch return error.RecordTooLarge;
     return std.math.add(usize, bytes_len, overhead) catch error.RecordTooLarge;
 }
 
-fn protectedHandshakeRecordLen(write: *const record_protection.WriteState, bytes_len: usize) Error!usize {
-    const chunks = try chunkCount(bytes_len);
+fn protectedHandshakeRecordLen(
+    write: *const record_protection.WriteState,
+    bytes_len: usize,
+    content_max: usize,
+) Error!usize {
+    const chunks = try chunkCount(bytes_len, content_max);
     const per_chunk_overhead = record_codec.header_len + 1 + write.keys.profile.aead.tagLength();
     const overhead = std.math.mul(usize, chunks, per_chunk_overhead) catch return error.RecordTooLarge;
     return std.math.add(usize, bytes_len, overhead) catch error.RecordTooLarge;
@@ -593,18 +700,19 @@ fn protectedHandshakeRecordLen(write: *const record_protection.WriteState, bytes
 fn sealHandshakeFragments(
     write: *record_protection.WriteState,
     bytes: []const u8,
+    content_max: usize,
     out: []u8,
 ) Error![]const u8 {
     if (write.exhausted) return error.SequenceExhausted;
-    const chunks = try chunkCount(bytes.len);
+    const chunks = try chunkCount(bytes.len, content_max);
     if (chunks > 0 and chunks - 1 > std.math.maxInt(u64) - write.sequence) return error.SequenceExhausted;
-    const needed = try protectedHandshakeRecordLen(write, bytes.len);
+    const needed = try protectedHandshakeRecordLen(write, bytes.len, content_max);
     if (out.len < needed) return error.RecordBufferOverflow;
 
     var in_pos: usize = 0;
     var out_pos: usize = 0;
     while (in_pos < bytes.len) {
-        const take = @min(record_codec.max_plaintext_fragment_len, bytes.len - in_pos);
+        const take = @min(content_max, bytes.len - in_pos);
         const record = try write.seal(.handshake, bytes[in_pos..][0..take], 0, out[out_pos..]);
         in_pos += take;
         out_pos += record.len;
@@ -649,10 +757,15 @@ fn expectAes128TrafficKeys(traffic_secret: [32]u8, keys: record_protection.Traff
 const testing = std.testing;
 
 test "chunkCount stays overflow-safe at a synthetic near-usize-max bytes_len" {
-    try testing.expectEqual(@as(usize, 0), try chunkCount(0));
-    try testing.expectEqual(@as(usize, 1), try chunkCount(1));
-    try testing.expectEqual(@as(usize, 1), try chunkCount(record_codec.max_plaintext_fragment_len));
-    try testing.expectEqual(@as(usize, 2), try chunkCount(record_codec.max_plaintext_fragment_len + 1));
+    const full = record_codec.max_plaintext_fragment_len;
+    try testing.expectEqual(@as(usize, 0), try chunkCount(0, full));
+    try testing.expectEqual(@as(usize, 1), try chunkCount(1, full));
+    try testing.expectEqual(@as(usize, 1), try chunkCount(full, full));
+    try testing.expectEqual(@as(usize, 2), try chunkCount(full + 1, full));
+    // #359: a narrower negotiated `record_size_limit` is just a smaller chunk
+    // size here -- the same arithmetic, applied to the bound the peer set.
+    try testing.expectEqual(@as(usize, 2), try chunkCount(64, 63));
+    try testing.expectEqual(@as(usize, 1), try chunkCount(63, 63));
     // `divCeil`'s `@divFloor(numerator - 1, denominator) + 1` form (unlike
     // the naive `(numerator + denominator - 1) / denominator` idiom this
     // replaced) cannot itself overflow for a positive numerator/denominator,
@@ -662,8 +775,8 @@ test "chunkCount stays overflow-safe at a synthetic near-usize-max bytes_len" {
     // `plaintextHandshakeRecordLen`/`protectedHandshakeRecordLen`'s
     // `bytes_len + chunks * overhead` addition (see the next test).
     try testing.expectEqual(
-        try std.math.divCeil(usize, std.math.maxInt(usize), record_codec.max_plaintext_fragment_len),
-        try chunkCount(std.math.maxInt(usize)),
+        try std.math.divCeil(usize, std.math.maxInt(usize), full),
+        try chunkCount(std.math.maxInt(usize), full),
     );
 }
 
@@ -2380,4 +2493,249 @@ test "applicationRecordsSealed tracks the current generation's sequence for usag
     // the sequence rather than tracking a lifetime total.
     try client.updateTrafficSecret(.write);
     try testing.expectEqual(@as(u64, 0), client.applicationRecordsSealed());
+}
+
+// ===========================================================================
+// #359: negotiated record sizing and bounded padding.
+// ===========================================================================
+
+test "an unnegotiated bridge sends and accepts the full protocol fragment" {
+    const cp = testProvider();
+    var client = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+    var server = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer server.deinit();
+    const c2s = secret(0x51);
+    const s2c = secret(0x52);
+    try establishedPair(&client, &server, &c2s, &s2c);
+
+    try testing.expectEqual(@as(usize, record_codec.max_plaintext_fragment_len), client.outboundContentMax());
+
+    const payload = [_]u8{'z'} ** record_codec.max_plaintext_fragment_len;
+    var protected: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    const sealed = try client.sealApplicationData(&payload, &protected);
+    const opened = try server.openApplicationData(try parseSingleRecord(.ciphertext, sealed), &plaintext);
+    try testing.expectEqualSlices(u8, &payload, opened.inner.content);
+    try testing.expectEqual(@as(u64, 0), server.record_size_counters.oversize_records_rejected);
+}
+
+test "a negotiated peer limit reserves the content-type byte it counts" {
+    const cp = testProvider();
+    var bridge = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer bridge.deinit();
+
+    try bridge.setRecordSizeLimits(.{ .peer = 1024 });
+    try testing.expectEqual(@as(usize, 1023), bridge.outboundContentMax());
+    // RFC 8449's floor: 64 leaves exactly 63 usable content bytes.
+    try bridge.setRecordSizeLimits(.{ .peer = record_size.min_limit });
+    try testing.expectEqual(@as(usize, 63), bridge.outboundContentMax());
+    // A peer at (or beyond) the protocol maximum never widens it.
+    try bridge.setRecordSizeLimits(.{ .peer = record_size.max_limit });
+    try testing.expectEqual(@as(usize, record_codec.max_plaintext_fragment_len), bridge.outboundContentMax());
+}
+
+test "a local advertisement outside RFC 8449's range is rejected before it can be enforced" {
+    const cp = testProvider();
+    var bridge = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer bridge.deinit();
+    try testing.expectError(error.InvalidRecordSizeLimit, bridge.setRecordSizeLimits(.{ .local = 63 }));
+    try testing.expectError(
+        error.InvalidRecordSizeLimit,
+        bridge.setRecordSizeLimits(.{ .local = record_size.max_limit + 1 }),
+    );
+    // The rejected value never landed.
+    try testing.expectEqual(record_size.default_limit, bridge.record_size_limits.local);
+}
+
+test "sealing more content than the peer's limit fails closed instead of truncating" {
+    const cp = testProvider();
+    var client = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+    var server = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer server.deinit();
+    const c2s = secret(0x53);
+    const s2c = secret(0x54);
+    try establishedPair(&client, &server, &c2s, &s2c);
+    try client.setRecordSizeLimits(.{ .peer = 128 });
+
+    var protected: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    const at_limit = [_]u8{'a'} ** 127;
+    _ = try client.sealApplicationData(&at_limit, &protected);
+    // Off-by-one on the other side of the boundary: 128 content bytes plus
+    // the content-type byte is 129, one past the 128 the peer accepts.
+    const past_limit = [_]u8{'a'} ** 128;
+    try testing.expectError(error.RecordSizeLimitExceeded, client.sealApplicationData(&past_limit, &protected));
+}
+
+test "an inbound record past our advertised limit is refused before decryption" {
+    const cp = testProvider();
+    var client = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+    var server = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer server.deinit();
+    const c2s = secret(0x55);
+    const s2c = secret(0x56);
+    try establishedPair(&client, &server, &c2s, &s2c);
+    // The server advertised 256; the client ignores it and sends more.
+    try server.setRecordSizeLimits(.{ .local = 256 });
+
+    var protected: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+
+    // Exactly at the limit: 255 content + 1 content-type byte = 256.
+    const at_limit = [_]u8{'b'} ** 255;
+    const ok = try client.sealApplicationData(&at_limit, &protected);
+    const opened = try server.openApplicationData(try parseSingleRecord(.ciphertext, ok), &plaintext);
+    try testing.expectEqual(@as(usize, 255), opened.inner.content.len);
+    try testing.expectEqual(@as(u64, 0), server.record_size_counters.oversize_records_rejected);
+
+    // One byte more, and the record is refused. The read sequence must not
+    // advance: rejecting before the AEAD means no nonce was consumed.
+    const sequence_before = server.read_application.?.sequence;
+    const over_limit = [_]u8{'b'} ** 256;
+    const too_big = try client.sealApplicationData(&over_limit, &protected);
+    try testing.expectError(
+        error.RecordSizeLimitExceeded,
+        server.openApplicationData(try parseSingleRecord(.ciphertext, too_big), &plaintext),
+    );
+    try testing.expectEqual(sequence_before, server.read_application.?.sequence);
+    try testing.expectEqual(@as(u64, 1), server.record_size_counters.oversize_records_rejected);
+}
+
+test "a handshake flight fragments at the negotiated limit, not the protocol maximum" {
+    const cp = testProvider();
+    var client = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+    var server = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer server.deinit();
+
+    const hs_c2s = secret(0x57);
+    const hs_s2c = secret(0x58);
+    try client.installTrafficSecret(.handshake, .write, &hs_c2s);
+    try client.installTrafficSecret(.handshake, .read, &hs_s2c);
+    try server.installTrafficSecret(.handshake, .read, &hs_c2s);
+    try server.installTrafficSecret(.handshake, .write, &hs_s2c);
+    try client.setRecordSizeLimits(.{ .peer = 256 });
+    try server.setRecordSizeLimits(.{ .local = 256 });
+
+    // 1000 bytes at 255 content bytes per record is four records.
+    const flight = [_]u8{'h'} ** 1000;
+    var out: [8 * record_codec.max_ciphertext_record_len]u8 = undefined;
+    const expected_len = try client.sealedHandshakeLen(.handshake, flight.len);
+    const sealed = try client.sealHandshake(.handshake, &flight, &out);
+    try testing.expectEqual(expected_len, sealed.len);
+
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    var offset: usize = 0;
+    var reassembled: usize = 0;
+    var records: usize = 0;
+    while (offset < sealed.len) {
+        const header = try record_codec.parseHeader(sealed[offset..][0..record_codec.header_len], .ciphertext, .strict);
+        const record_len = record_codec.header_len + header.payload_len;
+        const opened = try server.openHandshake(
+            .handshake,
+            try parseSingleRecord(.ciphertext, sealed[offset..][0..record_len]),
+            &plaintext,
+        );
+        // Every fragment respects the negotiated bound the server advertised.
+        try testing.expect(opened.inner.content.len + 1 <= 256);
+        reassembled += opened.inner.content.len;
+        records += 1;
+        offset += record_len;
+    }
+    try testing.expectEqual(@as(usize, 4), records);
+    try testing.expectEqual(flight.len, reassembled);
+}
+
+test "padding rounds application records without exceeding the negotiated cap" {
+    const cp = testProvider();
+    var client = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+    var server = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer server.deinit();
+    const c2s = secret(0x59);
+    const s2c = secret(0x5a);
+    try establishedPair(&client, &server, &c2s, &s2c);
+    try client.setRecordPadding(.{ .block = 128 });
+
+    var protected: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+
+    // 10 content bytes + the type byte is 11; the next multiple of 128 is 128.
+    const sealed = try client.sealApplicationData("0123456789", &protected);
+    const opened = try server.openApplicationData(try parseSingleRecord(.ciphertext, sealed), &plaintext);
+    try testing.expectEqualStrings("0123456789", opened.inner.content);
+    try testing.expectEqual(@as(usize, 117), opened.inner.padding_len);
+    try testing.expectEqual(@as(u64, 1), client.record_size_counters.padded_records);
+    try testing.expectEqual(@as(u64, 117), client.record_size_counters.padding_bytes);
+
+    // Handshake and alert records are never padded -- see `sealProtected`.
+    const alert = try client.sealProtected(.application, .alert, &.{ 1, 0 }, &protected);
+    const alert_opened = try server.openProtected(.application, try parseSingleRecord(.ciphertext, alert), &plaintext);
+    try testing.expectEqual(@as(usize, 0), alert_opened.inner.padding_len);
+    try testing.expectEqual(@as(u64, 1), client.record_size_counters.padded_records);
+}
+
+test "padding never pushes a record past the peer's limit, at the boundary or over it" {
+    const cp = testProvider();
+    var client = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+    var server = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer server.deinit();
+    const c2s = secret(0x5b);
+    const s2c = secret(0x5c);
+    try establishedPair(&client, &server, &c2s, &s2c);
+    // A block far larger than the cap: every record would round straight past
+    // it if the policy were applied without a bound.
+    try client.setRecordSizeLimits(.{ .peer = 200 });
+    try client.setRecordPadding(.{ .block = 4096 });
+    try server.setRecordSizeLimits(.{ .local = 200 });
+
+    var protected: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    var content_len: usize = 0;
+    const content = [_]u8{'p'} ** 199;
+    while (content_len < 199) : (content_len += 1) {
+        const sealed = try client.sealApplicationData(content[0..content_len], &protected);
+        const opened = try server.openApplicationData(try parseSingleRecord(.ciphertext, sealed), &plaintext);
+        try testing.expectEqualSlices(u8, content[0..content_len], opened.inner.content);
+        // The property: the whole inner plaintext fits under the cap the peer
+        // set, which is also why the receiver above never rejected it.
+        try testing.expect(content_len + 1 + opened.inner.padding_len <= 200);
+    }
+}
+
+test "padding survives an at-capacity record by adding nothing" {
+    const cp = testProvider();
+    var client = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+    var server = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer server.deinit();
+    const c2s = secret(0x5d);
+    const s2c = secret(0x5e);
+    try establishedPair(&client, &server, &c2s, &s2c);
+    try client.setRecordPadding(.{ .block = 512 });
+
+    // A full-size fragment already fills the protocol maximum: padding it at
+    // all would produce a record no peer could accept.
+    const payload = [_]u8{'f'} ** record_codec.max_plaintext_fragment_len;
+    var protected: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    const sealed = try client.sealApplicationData(&payload, &protected);
+    const opened = try server.openApplicationData(try parseSingleRecord(.ciphertext, sealed), &plaintext);
+    try testing.expectEqual(@as(usize, 0), opened.inner.padding_len);
+    try testing.expectEqual(@as(u64, 0), client.record_size_counters.padded_records);
+}
+
+test "an invalid padding block is rejected and leaves the policy untouched" {
+    const cp = testProvider();
+    var bridge = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer bridge.deinit();
+    try testing.expectError(error.InvalidRecordSizeLimit, bridge.setRecordPadding(.{ .block = 0 }));
+    try testing.expectError(
+        error.InvalidRecordSizeLimit,
+        bridge.setRecordPadding(.{ .block = record_size.PaddingPolicy.max_block + 1 }),
+    );
+    try testing.expectEqual(record_size.PaddingPolicy.none, bridge.record_padding);
 }

--- a/src/tls/record_epoch_bridge.zig
+++ b/src/tls/record_epoch_bridge.zig
@@ -125,6 +125,27 @@ pub const Bridge = struct {
     record_padding: record_size.PaddingPolicy = .none,
     /// Observable record-sizing effects. Counters only.
     record_size_counters: record_size.Counters = .{},
+    /// #359: the largest handshake-epoch `TLSInnerPlaintext` opened so far.
+    ///
+    /// A client cannot enforce its advertised limit on the server's *first*
+    /// protected flight. Until EncryptedExtensions is parsed it does not know
+    /// whether the server answered extension 28 at all, and pre-rejecting at
+    /// the advertised value would break every server that did not answer — so
+    /// those records are opened against the protocol maximum and only measured
+    /// here. `setRecordSizeLimits` then settles them retroactively, the moment
+    /// the negotiated bound becomes known.
+    ///
+    /// A high-water mark rather than the single record that completed the
+    /// flight: EncryptedExtensions may itself be fragmented, and any record in
+    /// that flight is equally subject to the bound.
+    ///
+    /// Handshake epoch only, deliberately. A server activates when it *writes*
+    /// its answer, and 0-RTT records can already be in flight by then — a
+    /// client cannot honor a limit it has not received yet, so failing those
+    /// retroactively would reject legitimate early data. On a server no
+    /// handshake-epoch record arrives before it writes that answer (the client's
+    /// Finished follows it), so this stays zero there and the check is inert.
+    pending_handshake_inner_max: u32 = 0,
 
     pub fn init(crypto_provider: provider.CryptoProvider, cipher_suite: algorithms.CipherSuite) Bridge {
         return .{ .crypto_provider = crypto_provider, .cipher_suite = cipher_suite };
@@ -369,6 +390,21 @@ pub const Bridge = struct {
     /// never widen the protocol bound.
     pub fn setRecordSizeLimits(self: *Bridge, limits: record_size.Limits) Error!void {
         try limits.validate();
+        // #359: settle the records that were opened before the bound was
+        // knowable. RFC 8449 §4 applies the limit to protected *handshake*
+        // records too, and RFC 8446 §6 makes an over-length record a fatal
+        // `record_overflow` — so a server that answers extension 28 and then
+        // exceeds the value it just agreed to must be rejected, even though
+        // the offending record could only be measured, not refused, at the
+        // time it arrived.
+        //
+        // Self-clearing when the extension does not negotiate: `local` then
+        // stays at the protocol maximum, which no record can exceed, so there
+        // is nothing to reset explicitly.
+        if (self.pending_handshake_inner_max > limits.local) {
+            self.record_size_counters.oversize_records_rejected +|= 1;
+            return error.RecordSizeLimitExceeded;
+        }
         self.record_size_limits = limits;
     }
 
@@ -562,7 +598,13 @@ pub const Bridge = struct {
         // opened the record: an unauthenticated length is not evidence of
         // anything the peer did.
         if (epoch != .initial) {
-            self.record_size_counters.noteOpened(inner.content.len + 1 + inner.padding_len);
+            const inner_len = inner.content.len + 1 + inner.padding_len;
+            self.record_size_counters.noteOpened(inner_len);
+            // See `pending_handshake_inner_max`: measured now, judged once the
+            // negotiated bound is known.
+            if (epoch == .handshake) {
+                self.pending_handshake_inner_max = @max(self.pending_handshake_inner_max, record_size.saturatingU32(inner_len));
+            }
         }
         return .{ .epoch = epoch, .inner = inner };
     }
@@ -2750,4 +2792,127 @@ test "an invalid padding block is rejected and leaves the policy untouched" {
         bridge.setRecordPadding(.{ .block = record_size.PaddingPolicy.max_block + 1 }),
     );
     try testing.expectEqual(record_size.PaddingPolicy.none, bridge.record_padding);
+}
+
+test "#359 a handshake record opened before the bound was knowable is settled retroactively" {
+    // The client-side gap: until EncryptedExtensions is parsed, a client that
+    // advertised 512 cannot know whether the server answered extension 28, so
+    // the server's first protected flight is opened against the protocol
+    // maximum. If the server *did* answer, that flight was still subject to
+    // the bound, and the only place left to say so is activation.
+    const cp = testProvider();
+    var client = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+    var server = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer server.deinit();
+
+    const hs_s2c = secret(0x71);
+    const hs_c2s = secret(0x72);
+    try client.installTrafficSecret(.handshake, .read, &hs_s2c);
+    try client.installTrafficSecret(.handshake, .write, &hs_c2s);
+    try server.installTrafficSecret(.handshake, .write, &hs_s2c);
+    try server.installTrafficSecret(.handshake, .read, &hs_c2s);
+
+    // The server ignores the client's (not yet known to it) bound and sends a
+    // 2000-byte handshake record. The client accepts it — it has nothing to
+    // check against yet.
+    const flight = [_]u8{'h'} ** 2000;
+    var out: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    const sealed = try server.sealHandshake(.handshake, &flight, &out);
+    const opened = try client.openHandshake(.handshake, try parseSingleRecord(.ciphertext, sealed), &plaintext);
+    try testing.expectEqual(@as(usize, 2000), opened.inner.content.len);
+    try testing.expectEqual(@as(u32, 2001), client.pending_handshake_inner_max);
+
+    // Activation settles it: 2001 > 512, so the connection fails now.
+    try testing.expectError(
+        error.RecordSizeLimitExceeded,
+        client.setRecordSizeLimits(.{ .local = 512, .peer = 1024 }),
+    );
+    try testing.expectEqual(@as(u64, 1), client.record_size_counters.oversize_records_rejected);
+    // The rejected limits were not installed.
+    try testing.expectEqual(record_size.default_limit, client.record_size_limits.local);
+}
+
+test "#359 a pre-activation handshake record within the bound activates cleanly" {
+    const cp = testProvider();
+    var client = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+    var server = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer server.deinit();
+
+    const hs_s2c = secret(0x73);
+    const hs_c2s = secret(0x74);
+    try client.installTrafficSecret(.handshake, .read, &hs_s2c);
+    try client.installTrafficSecret(.handshake, .write, &hs_c2s);
+    try server.installTrafficSecret(.handshake, .write, &hs_s2c);
+    try server.installTrafficSecret(.handshake, .read, &hs_c2s);
+
+    // 511 content bytes + the content-type byte is exactly the 512 bound.
+    const flight = [_]u8{'h'} ** 511;
+    var out: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    const sealed = try server.sealHandshake(.handshake, &flight, &out);
+    _ = try client.openHandshake(.handshake, try parseSingleRecord(.ciphertext, sealed), &plaintext);
+    try testing.expectEqual(@as(u32, 512), client.pending_handshake_inner_max);
+
+    try client.setRecordSizeLimits(.{ .local = 512, .peer = 1024 });
+    try testing.expectEqual(@as(u16, 512), client.record_size_limits.local);
+    try testing.expectEqual(@as(u64, 0), client.record_size_counters.oversize_records_rejected);
+}
+
+test "#359 an unanswered extension leaves pre-activation handshake records alone" {
+    // The self-clearing property: when the peer never answers, `local` stays
+    // at the protocol maximum, which no record can exceed — so a large early
+    // flight must not retroactively fail a connection that simply never
+    // negotiated the extension.
+    const cp = testProvider();
+    var client = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+    var server = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer server.deinit();
+
+    const hs_s2c = secret(0x75);
+    const hs_c2s = secret(0x76);
+    try client.installTrafficSecret(.handshake, .read, &hs_s2c);
+    try client.installTrafficSecret(.handshake, .write, &hs_c2s);
+    try server.installTrafficSecret(.handshake, .write, &hs_s2c);
+    try server.installTrafficSecret(.handshake, .read, &hs_c2s);
+
+    const flight = [_]u8{'h'} ** record_codec.max_plaintext_fragment_len;
+    var out: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    const sealed = try server.sealHandshake(.handshake, &flight, &out);
+    _ = try client.openHandshake(.handshake, try parseSingleRecord(.ciphertext, sealed), &plaintext);
+
+    // What an un-negotiated connection reports: the protocol maximum.
+    try client.setRecordSizeLimits(.{ .local = record_size.default_limit, .peer = null });
+    try testing.expectEqual(@as(u64, 0), client.record_size_counters.oversize_records_rejected);
+}
+
+test "#359 0-RTT records are never settled retroactively against the server's own bound" {
+    // A client cannot honor a limit it has not received: it sends early data
+    // before EncryptedExtensions exists. A server activates when it *writes*
+    // that answer, so failing in-flight 0-RTT records at that moment would
+    // reject legitimate early data. Only handshake-epoch records are retained.
+    const cp = testProvider();
+    var server = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer server.deinit();
+    var client = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+
+    const early = secret(0x77);
+    try client.installTrafficSecret(.zero_rtt, .write, &early);
+    try server.installTrafficSecret(.zero_rtt, .read, &early);
+
+    const payload = [_]u8{'e'} ** 2000;
+    var out: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    const sealed = try client.sealProtected(.zero_rtt, .application_data, &payload, &out);
+    _ = try server.openProtected(.zero_rtt, try parseSingleRecord(.ciphertext, sealed), &plaintext);
+    try testing.expectEqual(@as(u32, 0), server.pending_handshake_inner_max);
+
+    // Activation with a much smaller bound must not fail the connection.
+    try server.setRecordSizeLimits(.{ .local = 512, .peer = 1024 });
+    try testing.expectEqual(@as(u16, 512), server.record_size_limits.local);
 }

--- a/src/tls/record_epoch_bridge.zig
+++ b/src/tls/record_epoch_bridge.zig
@@ -590,7 +590,23 @@ pub const Bridge = struct {
             .zero_rtt => blk: {
                 if (self.handshake_complete) return error.UnsupportedRecordEpoch;
                 const read = self.readZeroRtt() orelse return error.MissingReadKeys;
-                try self.checkInboundRecordSize(read, record);
+                // #359: deliberately *not* size-checked against this
+                // handshake's negotiated limit. RFC 8449 §4 renegotiates the
+                // limit on resumption and governs records by the limits of the
+                // handshake that produced their protection keys; RFC 8446
+                // §4.2.10 puts 0-RTT data in the client's first flight, so it
+                // is created — and may already be in flight — before the
+                // server's EncryptedExtensions answer exists. Enforcing the
+                // value the server settles on afterwards would reject early
+                // data a conforming client had no way to size correctly.
+                //
+                // Applying the *previous* session's bound would be the fuller
+                // answer, but `ResumableSessionCommon` persists no record-size
+                // limit today, so there is no PSK-associated value to honor.
+                // Until there is, early records keep the protocol maximum,
+                // which `record_codec` already enforces. See the epoch-boundary
+                // tests below: the same-sized record is refused once it arrives
+                // at the application epoch.
                 break :blk try read.open(record, out);
             },
         };
@@ -619,6 +635,11 @@ pub const Bridge = struct {
     /// The subtraction is safe because `ReadState.open` is the only consumer
     /// of a shorter payload and rejects it as malformed; a payload that cannot
     /// even hold a tag is left for that path to name.
+    /// Enforce our advertised bound on one arriving protected record.
+    ///
+    /// Applied to the handshake and application epochs only — never to
+    /// `.zero_rtt`, whose records predate the bound they would be judged
+    /// against. See the `.zero_rtt` arm of `openProtected`.
     fn checkInboundRecordSize(
         self: *Bridge,
         read: *const record_protection.ReadState,
@@ -2915,4 +2936,72 @@ test "#359 0-RTT records are never settled retroactively against the server's ow
     // Activation with a much smaller bound must not fail the connection.
     try server.setRecordSizeLimits(.{ .local = 512, .peer = 1024 });
     try testing.expectEqual(@as(u16, 512), server.record_size_limits.local);
+}
+
+test "#359 the negotiated bound governs handshake and application records but never 0-RTT" {
+    // The epoch boundary, stated directly. RFC 8449 §4 governs records by the
+    // limits of the handshake that produced their protection keys, and RFC 8446
+    // §4.2.10 puts 0-RTT data in the client's first flight — created before the
+    // server's answer exists. A server activates its own bound when it *writes*
+    // EncryptedExtensions, which is before the handshake completes, so an early
+    // record can legitimately arrive at a bridge that is already enforcing 512.
+    const cp = testProvider();
+    var server = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer server.deinit();
+    var client = Bridge.init(cp, .tls_aes_128_gcm_sha256);
+    defer client.deinit();
+
+    const early = secret(0x81);
+    const hs = secret(0x82);
+    const app = secret(0x83);
+    try client.installTrafficSecret(.zero_rtt, .write, &early);
+    try server.installTrafficSecret(.zero_rtt, .read, &early);
+    // Both directions on both sides: a bridge only leaves the initial phase
+    // once each direction has a handshake secret.
+    const hs_reverse = secret(0x84);
+    try client.installTrafficSecret(.handshake, .write, &hs);
+    try client.installTrafficSecret(.handshake, .read, &hs_reverse);
+    try server.installTrafficSecret(.handshake, .read, &hs);
+    try server.installTrafficSecret(.handshake, .write, &hs_reverse);
+
+    // The server has written its EncryptedExtensions answer: the bound is live.
+    try server.setRecordSizeLimits(.{ .local = 512, .peer = 1024 });
+
+    var out: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    const oversized = [_]u8{'e'} ** 2000;
+
+    // 0-RTT: accepted. The client could not have known this bound.
+    const early_record = try client.sealProtected(.zero_rtt, .application_data, &oversized, &out);
+    const opened_early = try server.openProtected(.zero_rtt, try parseSingleRecord(.ciphertext, early_record), &plaintext);
+    try testing.expectEqualSlices(u8, &oversized, opened_early.inner.content);
+    try testing.expectEqual(@as(u64, 0), server.record_size_counters.oversize_records_rejected);
+
+    // Handshake epoch, same size: refused. This one *is* governed by the
+    // bound the server just advertised.
+    const hs_record = try client.sealProtected(.handshake, .handshake, &oversized, &out);
+    try testing.expectError(
+        error.RecordSizeLimitExceeded,
+        server.openProtected(.handshake, try parseSingleRecord(.ciphertext, hs_record), &plaintext),
+    );
+
+    // And once the connection reaches the application epoch, still refused —
+    // the exemption is scoped to the epoch, not to the connection.
+    const app_reverse = secret(0x85);
+    try client.installTrafficSecret(.application, .write, &app);
+    try client.installTrafficSecret(.application, .read, &app_reverse);
+    try server.installTrafficSecret(.application, .read, &app);
+    try server.installTrafficSecret(.application, .write, &app_reverse);
+    try client.discardEpoch(.initial);
+    try server.discardEpoch(.initial);
+    try client.discardEpoch(.handshake);
+    try server.discardEpoch(.handshake);
+    try client.markHandshakeComplete();
+    try server.markHandshakeComplete();
+    const app_record = try client.sealProtected(.application, .application_data, &oversized, &out);
+    try testing.expectError(
+        error.RecordSizeLimitExceeded,
+        server.openProtected(.application, try parseSingleRecord(.ciphertext, app_record), &plaintext),
+    );
+    try testing.expectEqual(@as(u64, 2), server.record_size_counters.oversize_records_rejected);
 }

--- a/src/tls/record_size.zig
+++ b/src/tls/record_size.zig
@@ -255,7 +255,7 @@ pub const Counters = struct {
     }
 };
 
-fn saturatingU32(value: usize) u32 {
+pub fn saturatingU32(value: usize) u32 {
     return @intCast(@min(value, @as(usize, std.math.maxInt(u32))));
 }
 

--- a/src/tls/record_size.zig
+++ b/src/tls/record_size.zig
@@ -1,0 +1,366 @@
+//! TLS `record_size_limit` negotiation (RFC 8449) and bounded record padding.
+//!
+//! This module owns only *policy and arithmetic*: the extension's wire form,
+//! the rules for what a peer may advertise, and how large an outgoing
+//! `TLSInnerPlaintext` (and its optional padding) may be. It performs no I/O,
+//! holds no keys, and never touches the AEAD. `tls13_backend` carries the
+//! extension through the handshake, `record_epoch_bridge` applies the results
+//! to sealing and opening, and `encrypted_stream` sizes its writes from them.
+//!
+//! Two independently negotiated numbers, deliberately kept separate:
+//!
+//!   * `Limits.local` — the largest inner plaintext *we* are willing to
+//!     receive. We advertise it, and we reject any protected record that
+//!     exceeds it, because a peer that ignores our advertisement is asking us
+//!     to buffer more than we agreed to.
+//!   * `Limits.peer` — the largest inner plaintext the *peer* is willing to
+//!     receive. We cap every protected record we send to it. Absent (`null`)
+//!     means the peer never sent the extension, which RFC 8449 defines as "the
+//!     protocol maximum", not "unlimited".
+//!
+//! RFC 8449 §4 measures the limit as the length of the complete
+//! `TLSInnerPlaintext` for TLS 1.3 — `content || content_type || padding` —
+//! which is why the protocol maximum here is 2^14+1 rather than 2^14, and why
+//! usable *content* is always one byte less than the limit before padding.
+//!
+//! Padding (RFC 8446 §5.4) is a distinct, purely local knob and is not
+//! negotiated at all. It is a traffic-analysis countermeasure: it hides the
+//! true length of a record's content from an observer, at the cost of sending
+//! bytes that carry no data. It is *not* a performance feature, and it is not
+//! record coalescing — see `docs/TLS_RECORD_TRANSPORT.md`.
+
+const std = @import("std");
+const record_codec = @import("record_codec.zig");
+
+/// RFC 8449 §5: `record_size_limit(28)`.
+pub const extension_type: u16 = 28;
+
+/// The extension body is a single `uint16`.
+pub const body_len = 2;
+
+/// RFC 8449 §4: "Endpoints MUST NOT send a `record_size_limit` extension with
+/// a value smaller than 64. An endpoint MUST treat receipt of a smaller value
+/// as a fatal error and generate an `illegal_parameter` alert."
+pub const min_limit: u16 = 64;
+
+/// RFC 8449 §4: the TLS 1.3 protocol maximum, counting the content-type byte
+/// and any padding that share the inner plaintext with the content itself.
+pub const max_limit: u16 = record_codec.max_plaintext_fragment_len + 1;
+
+/// The default advertisement: the full protocol maximum. Advertising anything
+/// smaller is a deliberate memory/latency tradeoff a caller opts into — an
+/// endpoint that supports every record size interoperates most widely by
+/// saying so, and a smaller default would silently shrink every peer's records
+/// (more records, more per-record overhead) for connections that never needed
+/// it.
+pub const default_limit: u16 = max_limit;
+
+pub const DecodeError = error{
+    /// The extension body was not exactly two bytes. A framing failure ->
+    /// `decode_error`.
+    MalformedHandshake,
+    /// A well-framed value outside the range this endpoint accepts ->
+    /// `illegal_parameter`.
+    IllegalParameter,
+};
+
+pub const ConfigError = error{
+    /// A locally configured limit or padding block is outside the range the
+    /// protocol (or this record layer) can honor. Always our own bug or
+    /// misconfiguration, never a peer's.
+    InvalidRecordSizeLimit,
+};
+
+/// What to do with a peer value above `max_limit`.
+///
+/// RFC 8449 §4 makes this asymmetric on purpose: "A server MUST NOT enforce
+/// this restriction; a client might advertise a higher limit that is enabled
+/// by an extension or version the server does not understand. A client MAY
+/// abort the handshake with an `illegal_parameter` alert if the
+/// record_size_limit extension includes a value greater than the maximum
+/// record size permitted by the negotiated protocol version."
+pub const OverMaxPolicy = enum {
+    /// Server behavior: treat the value as the protocol maximum and carry on.
+    clamp,
+    /// Client behavior: the server answered with a limit larger than TLS 1.3
+    /// permits, which no future-version reading can excuse once the version is
+    /// already settled. Reject.
+    reject,
+};
+
+/// Decode the extension body. `over_max` selects the role-appropriate handling
+/// of an above-maximum advertisement; the below-minimum rejection is
+/// unconditional for both roles.
+pub fn decode(body: []const u8, over_max: OverMaxPolicy) DecodeError!u16 {
+    if (body.len != body_len) return error.MalformedHandshake;
+    const value = std.mem.readInt(u16, body[0..body_len], .big);
+    if (value < min_limit) return error.IllegalParameter;
+    if (value > max_limit) return switch (over_max) {
+        .clamp => max_limit,
+        .reject => error.IllegalParameter,
+    };
+    return value;
+}
+
+/// Encode the extension body (the two payload bytes, without the type/length
+/// header the caller's message writer owns).
+pub fn encodeBody(limit: u16) [body_len]u8 {
+    var out: [body_len]u8 = undefined;
+    std.mem.writeInt(u16, &out, limit, .big);
+    return out;
+}
+
+/// The negotiated record-size state of one connection.
+pub const Limits = struct {
+    /// Largest inner plaintext we accept from the peer, and the value we
+    /// advertise. Always within `[min_limit, max_limit]`.
+    local: u16 = default_limit,
+    /// Largest inner plaintext the peer accepts. `null` until the peer's
+    /// advertisement is parsed, and for a peer that never sends one.
+    peer: ?u16 = null,
+
+    /// Reject a local configuration the protocol cannot express, before it can
+    /// reach the wire or silently degrade into an unenforceable bound.
+    pub fn validate(self: Limits) ConfigError!void {
+        if (self.local < min_limit or self.local > max_limit) return error.InvalidRecordSizeLimit;
+    }
+
+    /// The largest `TLSInnerPlaintext` we may *send*: the peer's limit, or the
+    /// protocol maximum when it never advertised one.
+    pub fn outboundInnerMax(self: Limits) usize {
+        return @min(self.peer orelse max_limit, max_limit);
+    }
+
+    /// The largest *content* one outgoing protected record may carry, with the
+    /// content-type byte RFC 8449 counts against the limit already reserved.
+    /// Never zero: `min_limit` is 64, so at least 63 content bytes always fit.
+    pub fn outboundContentMax(self: Limits) usize {
+        return self.outboundInnerMax() - 1;
+    }
+
+    /// The largest `TLSInnerPlaintext` we accept on the wire. Bytes past this
+    /// are a peer that ignored our advertisement.
+    pub fn inboundInnerMax(self: Limits) usize {
+        return self.local;
+    }
+
+    /// True when the peer's advertisement actually constrains us — i.e. when a
+    /// write must be split more finely than the protocol maximum alone would
+    /// require. Diagnostics and metrics only.
+    pub fn peerConstrains(self: Limits) bool {
+        return self.outboundInnerMax() < max_limit;
+    }
+};
+
+/// Local, non-negotiated padding policy (RFC 8446 §5.4).
+///
+/// Padding is a *privacy* control: it obscures how many content bytes a record
+/// actually carried. It costs bandwidth and AEAD work for every byte added and
+/// buys nothing else, so the default is off.
+pub const PaddingPolicy = union(enum) {
+    /// No padding. Every record's inner plaintext is exactly
+    /// `content || content_type`.
+    none,
+    /// Round each inner plaintext up to a multiple of `block` bytes, never
+    /// past the negotiated cap. A `block` of 1 is equivalent to `.none`.
+    ///
+    /// Chosen over a fixed record size because a fixed size cannot pad a
+    /// record that is already larger, and cannot avoid inflating a
+    /// small-record stream by a constant factor; rounding degrades smoothly
+    /// and is what a length-observing adversary must actually defeat.
+    block: u16,
+
+    /// The largest block this record layer will honor. A block above the
+    /// protocol maximum could never be reached, so accepting one would
+    /// silently mean "pad to the cap" rather than what the caller wrote.
+    pub const max_block: u16 = max_limit;
+
+    pub fn validate(self: PaddingPolicy) ConfigError!void {
+        switch (self) {
+            .none => {},
+            .block => |block| if (block == 0 or block > max_block) return error.InvalidRecordSizeLimit,
+        }
+    }
+
+    /// Padding bytes to append to a record carrying `content_len` bytes, given
+    /// that the complete inner plaintext must not exceed `inner_max`.
+    ///
+    /// Total-bounded by construction: the result is derived by subtracting the
+    /// unpadded inner length from a target that is itself clamped to
+    /// `inner_max`, so `content_len + 1 + padding <= inner_max` holds for every
+    /// input — including an already-at-cap record, which gets zero.
+    pub fn paddingFor(self: PaddingPolicy, content_len: usize, inner_max: usize) usize {
+        const block = switch (self) {
+            .none => return 0,
+            .block => |value| value,
+        };
+        if (block <= 1) return 0;
+        // `content_len` is already capped to `inner_max - 1` by the caller, so
+        // this cannot overflow a `usize` on any reachable path; saturating
+        // keeps a hypothetical caller bug from wrapping into a huge padding.
+        const unpadded = content_len +| 1;
+        if (unpadded >= inner_max) return 0;
+        const remainder = unpadded % block;
+        if (remainder == 0) return 0;
+        const target = unpadded +| (block - remainder);
+        return @min(target, inner_max) - unpadded;
+    }
+};
+
+/// Observable record-sizing effects, for operators and tests. Counters only —
+/// nothing here feeds a decision.
+pub const Counters = struct {
+    /// Writes whose length was reduced by the peer's advertised limit below
+    /// what the protocol maximum alone would have allowed.
+    peer_limited_writes: u64 = 0,
+    /// Protected records that carried at least one padding byte.
+    padded_records: u64 = 0,
+    /// Total padding bytes sent.
+    padding_bytes: u64 = 0,
+    /// Inbound protected records refused for exceeding `Limits.local`.
+    oversize_records_rejected: u64 = 0,
+
+    pub fn notePadding(self: *Counters, padding_len: usize) void {
+        if (padding_len == 0) return;
+        self.padded_records +|= 1;
+        self.padding_bytes +|= padding_len;
+    }
+};
+
+const testing = std.testing;
+
+test "the protocol maximum counts the content-type byte" {
+    // RFC 8449 §4: TLS 1.3's limit is 2^14+1 precisely because the value
+    // bounds the whole TLSInnerPlaintext, not just the content.
+    try testing.expectEqual(@as(u16, 16385), max_limit);
+    try testing.expectEqual(@as(usize, record_codec.max_plaintext_fragment_len), (Limits{}).outboundContentMax());
+}
+
+test "decode round-trips every legal advertisement" {
+    for ([_]u16{ min_limit, 100, 1024, max_limit - 1, max_limit }) |limit| {
+        const body = encodeBody(limit);
+        try testing.expectEqual(limit, try decode(&body, .reject));
+        try testing.expectEqual(limit, try decode(&body, .clamp));
+    }
+}
+
+test "a body that is not exactly two bytes is a framing failure" {
+    try testing.expectError(error.MalformedHandshake, decode(&.{}, .clamp));
+    try testing.expectError(error.MalformedHandshake, decode(&.{0x40}, .clamp));
+    try testing.expectError(error.MalformedHandshake, decode(&.{ 0x40, 0x00, 0x00 }, .clamp));
+}
+
+test "values below 64 are illegal for both roles" {
+    var value: u16 = 0;
+    while (value < min_limit) : (value += 1) {
+        const body = encodeBody(value);
+        try testing.expectError(error.IllegalParameter, decode(&body, .clamp));
+        try testing.expectError(error.IllegalParameter, decode(&body, .reject));
+    }
+    // The boundary itself is legal.
+    const at_min = encodeBody(min_limit);
+    try testing.expectEqual(min_limit, try decode(&at_min, .reject));
+}
+
+test "an above-maximum value clamps for a server and is rejected by a client" {
+    for ([_]u16{ max_limit + 1, 20000, std.math.maxInt(u16) }) |value| {
+        const body = encodeBody(value);
+        // RFC 8449 §4: "A server MUST NOT enforce this restriction" -- a client
+        // may be advertising a size a future version enables.
+        try testing.expectEqual(max_limit, try decode(&body, .clamp));
+        // The client already knows the negotiated version, so no such reading
+        // is available to it; RFC 8449 §4 permits the abort and we take it.
+        try testing.expectError(error.IllegalParameter, decode(&body, .reject));
+    }
+}
+
+test "an absent peer advertisement means the protocol maximum, not unlimited" {
+    const unnegotiated = Limits{};
+    try testing.expectEqual(@as(usize, max_limit), unnegotiated.outboundInnerMax());
+    try testing.expect(!unnegotiated.peerConstrains());
+}
+
+test "outbound sizing reserves the content-type byte the peer's limit counts" {
+    const limits = Limits{ .peer = 64 };
+    try testing.expectEqual(@as(usize, 64), limits.outboundInnerMax());
+    try testing.expectEqual(@as(usize, 63), limits.outboundContentMax());
+    try testing.expect(limits.peerConstrains());
+}
+
+test "a peer value at or above the maximum never widens the protocol bound" {
+    // `peer` is only ever populated by `decode`, which already clamps, but the
+    // struct must not depend on that to stay within the protocol maximum.
+    const oversized = Limits{ .peer = std.math.maxInt(u16) };
+    try testing.expectEqual(@as(usize, max_limit), oversized.outboundInnerMax());
+    try testing.expect(!oversized.peerConstrains());
+}
+
+test "local configuration outside the protocol range is rejected" {
+    try (Limits{ .local = min_limit }).validate();
+    try (Limits{ .local = max_limit }).validate();
+    try testing.expectError(error.InvalidRecordSizeLimit, (Limits{ .local = min_limit - 1 }).validate());
+    try testing.expectError(error.InvalidRecordSizeLimit, (Limits{ .local = max_limit + 1 }).validate());
+}
+
+test "padding is off by default and a degenerate block is inert" {
+    const off: PaddingPolicy = .none;
+    try testing.expectEqual(@as(usize, 0), off.paddingFor(100, max_limit));
+    try testing.expectEqual(@as(usize, 0), (PaddingPolicy{ .block = 1 }).paddingFor(100, max_limit));
+}
+
+test "block padding rounds the whole inner plaintext, not just the content" {
+    const policy = PaddingPolicy{ .block = 64 };
+    // 100 content bytes -> 101 inner bytes -> next multiple of 64 is 128.
+    try testing.expectEqual(@as(usize, 27), policy.paddingFor(100, max_limit));
+    // 63 content bytes -> 64 inner bytes, already aligned: nothing to add.
+    try testing.expectEqual(@as(usize, 0), policy.paddingFor(63, max_limit));
+    // A single byte still costs a full block boundary.
+    try testing.expectEqual(@as(usize, 62), policy.paddingFor(1, max_limit));
+}
+
+test "padding never pushes the inner plaintext past the negotiated cap" {
+    // The acceptance criterion: for every block size, every content length,
+    // and every cap, `content + type + padding` stays within the cap.
+    const blocks = [_]u16{ 2, 3, 64, 512, 4096, max_limit };
+    const caps = [_]usize{ min_limit, 65, 100, 1024, max_limit - 1, max_limit };
+    for (blocks) |block| {
+        const policy = PaddingPolicy{ .block = block };
+        for (caps) |cap| {
+            var content_len: usize = 0;
+            while (content_len < cap) : (content_len += 1) {
+                const padding = policy.paddingFor(content_len, cap);
+                try testing.expect(content_len + 1 + padding <= cap);
+                try testing.expect(content_len + 1 + padding <= max_limit);
+            }
+        }
+    }
+}
+
+test "a record already at the cap is never padded" {
+    const policy = PaddingPolicy{ .block = 512 };
+    // Content that exactly fills the cap once the content-type byte is added.
+    try testing.expectEqual(@as(usize, 0), policy.paddingFor(max_limit - 1, max_limit));
+    try testing.expectEqual(@as(usize, 0), policy.paddingFor(min_limit - 1, min_limit));
+}
+
+test "padding policy configuration is validated" {
+    const off: PaddingPolicy = .none;
+    try off.validate();
+    try (PaddingPolicy{ .block = 1 }).validate();
+    try (PaddingPolicy{ .block = PaddingPolicy.max_block }).validate();
+    try testing.expectError(error.InvalidRecordSizeLimit, (PaddingPolicy{ .block = 0 }).validate());
+    try testing.expectError(
+        error.InvalidRecordSizeLimit,
+        (PaddingPolicy{ .block = PaddingPolicy.max_block + 1 }).validate(),
+    );
+}
+
+test "counters only move for records that actually carried padding" {
+    var counters = Counters{};
+    counters.notePadding(0);
+    try testing.expectEqual(@as(u64, 0), counters.padded_records);
+    counters.notePadding(27);
+    counters.notePadding(5);
+    try testing.expectEqual(@as(u64, 2), counters.padded_records);
+    try testing.expectEqual(@as(u64, 32), counters.padding_bytes);
+}

--- a/src/tls/record_size.zig
+++ b/src/tls/record_size.zig
@@ -219,13 +219,45 @@ pub const Counters = struct {
     padding_bytes: u64 = 0,
     /// Inbound protected records refused for exceeding `Limits.local`.
     oversize_records_rejected: u64 = 0,
+    /// Protected records sealed, across every content type.
+    protected_records_sent: u64 = 0,
+    /// The largest `TLSInnerPlaintext` actually sealed — content, its
+    /// content-type byte, and any padding. This is the quantity RFC 8449
+    /// bounds, so it is the one an interop row can hold against the peer's
+    /// advertised limit to prove records were really constrained rather than
+    /// merely that a handshake completed.
+    max_sent_inner_len: u32 = 0,
+    /// The largest `TLSInnerPlaintext` successfully opened. Held against our
+    /// *own* advertisement, this is the half of RFC 8449 a send-side counter
+    /// cannot reach: it shows the peer actually honored the limit we asked
+    /// for, rather than that we honored theirs.
+    max_recv_inner_len: u32 = 0,
 
     pub fn notePadding(self: *Counters, padding_len: usize) void {
         if (padding_len == 0) return;
         self.padded_records +|= 1;
         self.padding_bytes +|= padding_len;
     }
+
+    /// Record one sealed protected record of `content_len` content bytes plus
+    /// `padding_len` padding. The content-type byte is added here, so callers
+    /// pass what they actually sealed rather than pre-computing the framing.
+    pub fn noteSealed(self: *Counters, content_len: usize, padding_len: usize) void {
+        self.protected_records_sent +|= 1;
+        const inner = content_len +| 1 +| padding_len;
+        self.max_sent_inner_len = @max(self.max_sent_inner_len, saturatingU32(inner));
+    }
+
+    /// Record one successfully opened protected record whose complete inner
+    /// plaintext was `inner_len` bytes.
+    pub fn noteOpened(self: *Counters, inner_len: usize) void {
+        self.max_recv_inner_len = @max(self.max_recv_inner_len, saturatingU32(inner_len));
+    }
 };
+
+fn saturatingU32(value: usize) u32 {
+    return @intCast(@min(value, @as(usize, std.math.maxInt(u32))));
+}
 
 const testing = std.testing;
 
@@ -363,4 +395,37 @@ test "counters only move for records that actually carried padding" {
     counters.notePadding(5);
     try testing.expectEqual(@as(u64, 2), counters.padded_records);
     try testing.expectEqual(@as(u64, 32), counters.padding_bytes);
+}
+
+test "the sealed-record counter tracks the whole inner plaintext, padding included" {
+    var counters = Counters{};
+    counters.noteSealed(10, 0);
+    try testing.expectEqual(@as(u64, 1), counters.protected_records_sent);
+    // 10 content + the content-type byte.
+    try testing.expectEqual(@as(u32, 11), counters.max_sent_inner_len);
+
+    // Padding counts against the same bound the peer advertised, so it must
+    // count here too -- otherwise a padded record could exceed a limit this
+    // counter reported as respected.
+    counters.noteSealed(10, 100);
+    try testing.expectEqual(@as(u32, 111), counters.max_sent_inner_len);
+
+    // It is a high-water mark: a later smaller record does not lower it.
+    counters.noteSealed(1, 0);
+    try testing.expectEqual(@as(u32, 111), counters.max_sent_inner_len);
+    try testing.expectEqual(@as(u64, 3), counters.protected_records_sent);
+}
+
+test "the received-record counter is a separate high-water mark from the sent one" {
+    // The two directions answer different questions -- "did we honor the
+    // peer's limit" versus "did the peer honor ours" -- so one must never
+    // stand in for the other.
+    var counters = Counters{};
+    counters.noteSealed(4000, 0);
+    try testing.expectEqual(@as(u32, 0), counters.max_recv_inner_len);
+
+    counters.noteOpened(512);
+    counters.noteOpened(64);
+    try testing.expectEqual(@as(u32, 512), counters.max_recv_inner_len);
+    try testing.expectEqual(@as(u32, 4001), counters.max_sent_inner_len);
 }

--- a/src/tls/root.zig
+++ b/src/tls/root.zig
@@ -23,6 +23,7 @@ pub const production_crypto = @import("production_crypto.zig");
 pub const record_codec = @import("record_codec.zig");
 pub const record_epoch_bridge = @import("record_epoch_bridge.zig");
 pub const record_protection = @import("record_protection.zig");
+pub const record_size = @import("record_size.zig");
 pub const resumption_runtime = @import("resumption_runtime.zig");
 pub const session = @import("session.zig");
 pub const session_cache = @import("session_cache.zig");

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -878,6 +878,24 @@ pub const Tls13Backend = struct {
     /// and on the client from EncryptedExtensions; read through
     /// `recordSizeLimits` by the record transport, which is the only consumer.
     peer_record_size_limit: ?u16 = null,
+    /// Whether extension 28 actually *completed* its round trip (#359), as
+    /// opposed to merely having been offered.
+    ///
+    /// This is what gates our own inbound bound, and the distinction is
+    /// load-bearing: an offer is a request, not an agreement. RFC 8449 §4
+    /// bounds records only "when the `record_size_limit` extension is
+    /// negotiated", so against a peer that ignores the extension entirely,
+    /// ordinary protocol record sizes remain legal and a configured
+    /// `policy.record_size_limit` of, say, 512 must not make us reject a
+    /// perfectly valid 8 KiB record.
+    ///
+    /// The activation point differs by role, and both are "the response, not
+    /// the offer": a client sets this when the server's EncryptedExtensions
+    /// answer arrives, and a server when it actually writes that answer. The
+    /// *peer* bound (`peer_record_size_limit`) is deliberately not gated this
+    /// way — a server learns it from the ClientHello and needs it immediately,
+    /// to fragment the very handshake flight that carries its response.
+    record_size_limit_active: bool = false,
     /// Server (#366): enablement/tolerance for accepting 0-RTT, configured
     /// via `setServerEarlyDataPolicy` before `start`.
     server_early_data_policy: ServerEarlyDataPolicy = .{},
@@ -1916,6 +1934,9 @@ pub const Tls13Backend = struct {
         self.client_early_data_attempted = false;
         self.selected_client_psk_index = null;
         self.client_hello_early_data_seen = false;
+        // #359: a reset connection has negotiated nothing.
+        self.peer_record_size_limit = null;
+        self.record_size_limit_active = false;
         self.server_early_data_policy = .{};
         self.early_data_replay_gate = .{};
         self.early_data_compat_gate = .{};
@@ -2032,6 +2053,10 @@ pub const Tls13Backend = struct {
         self.client_early_data_attempted = false;
         self.selected_client_psk_index = null;
         self.client_hello_early_data_seen = false;
+        // #359: a failed handshake negotiated no record-size bound either, so
+        // neither half may stay visible to a carrier.
+        self.peer_record_size_limit = null;
+        self.record_size_limit_active = false;
         self.early_data_accepted = false;
         self.early_data_decision = .not_attempted;
         self.early_data_max_bytes = 0;
@@ -3140,17 +3165,49 @@ pub const Tls13Backend = struct {
         try w.bytes(&body);
     }
 
+    /// The server's EncryptedExtensions half of the exchange.
+    ///
+    /// Conditional on the client having offered, because RFC 8449 §4 places
+    /// the server's value in EncryptedExtensions but does not exempt it from
+    /// RFC 8446 §4.2's rule that an endpoint "MUST NOT send extension
+    /// responses if the remote endpoint did not send the corresponding
+    /// extension requests" — and a client receiving such a response "MUST
+    /// abort the handshake with an `unsupported_extension` alert". Answering
+    /// unconditionally would therefore break every conforming client that
+    /// does not implement RFC 8449, which is most of them.
+    ///
+    /// Writing the response is also the server's activation point: from here
+    /// the extension is negotiated, so our own advertised bound becomes
+    /// enforceable on arriving records.
+    fn writeRecordSizeLimitResponse(self: *Tls13Backend, w: *Writer) HandshakeError!void {
+        if (self.offeredRecordSizeLimit() == null) return;
+        if (self.peer_record_size_limit == null) return;
+        try self.writeRecordSizeLimitOffer(w);
+        self.record_size_limit_active = true;
+    }
+
     fn recordSizeLimitEncodedLen(self: *const Tls13Backend) usize {
         return if (self.offeredRecordSizeLimit() == null) 0 else 2 + 2 + record_size.body_len;
     }
 
     /// The connection's negotiated record-size state (#359), for the record
-    /// transport. `local` is what we advertised — the bound we enforce on
-    /// arriving records — and `peer` is what the peer advertised, or null
-    /// until (or unless) it does.
+    /// transport.
+    ///
+    /// `local` is the bound we enforce on arriving records, and it is the
+    /// configured advertisement *only once the extension is actually
+    /// negotiated* — see `record_size_limit_active`. Reporting the configured
+    /// value from a connection where the peer ignored the extension would
+    /// have us reject records RFC 8449 §4 still permits.
+    ///
+    /// `peer` is what the peer advertised, or null until (or unless) it does;
+    /// `Limits` treats null as the protocol maximum, which is exactly what
+    /// RFC 8449 defines an absent extension to mean.
     pub fn recordSizeLimits(self: *const Tls13Backend) record_size.Limits {
         return .{
-            .local = self.offeredRecordSizeLimit() orelse record_size.default_limit,
+            .local = if (self.record_size_limit_active)
+                self.offeredRecordSizeLimit() orelse record_size.default_limit
+            else
+                record_size.default_limit,
             .peer = self.peer_record_size_limit,
         };
     }
@@ -3175,6 +3232,9 @@ pub const Tls13Backend = struct {
             error.MalformedHandshake => return error.MalformedHandshake,
             error.IllegalParameter => return error.IllegalParameter,
         };
+        // Only ever reached from `onEncryptedExtensions`, i.e. the server's
+        // answer to an offer this client made — the client's activation point.
+        self.record_size_limit_active = true;
     }
 
     fn policyAlpnOfferEncodedLen(self: *const Tls13Backend) HandshakeError!usize {
@@ -5074,10 +5134,9 @@ pub const Tls13Backend = struct {
         }
         // #359: RFC 8449 §4 — "In TLS 1.3, the server sends the
         // `record_size_limit` extension in the EncryptedExtensions message."
-        // Sent unconditionally when the profile offers it, not only in reply
-        // to a client that asked: the value bounds what the *server* accepts,
-        // and the client needs it whether or not it advertised one itself.
-        try self.writeRecordSizeLimitOffer(&w);
+        // Only in answer to a client that offered one; see
+        // `writeRecordSizeLimitResponse`.
+        try self.writeRecordSizeLimitResponse(&w);
         // #366: signal 0-RTT acceptance with an empty `early_data`
         // extension — omitted (not merely absent-with-a-flag) for a
         // PSK-resumed but early-rejected connection, so the client's
@@ -5157,8 +5216,9 @@ pub const Tls13Backend = struct {
             try w.bytes(payload);
         }
         // #359: see `emitPskFinishFlight` — RFC 8449 §4 puts the server's
-        // advertisement in EncryptedExtensions on both flights.
-        try self.writeRecordSizeLimitOffer(&w);
+        // advertisement in EncryptedExtensions on both flights, and both are
+        // equally bound by RFC 8446 §4.2's request/response rule.
+        try self.writeRecordSizeLimitResponse(&w);
         w.patch(2, ee_extensions);
         w.patch(3, ee_len);
         const encrypted_extensions = buf[0..w.len];
@@ -7073,9 +7133,82 @@ test "#359 the record-mode ClientHello carries a well-formed record_size_limit" 
         .{ .ctx = &found, .observeFn = Found.observe },
     );
     try std.testing.expectEqual(@as(?u16, 4096), found.limit);
-    // Nothing is negotiated yet: only our own advertisement is known.
-    try std.testing.expectEqual(@as(u16, 4096), backend.recordSizeLimits().local);
+    // The wire carries the configured offer, but nothing is negotiated yet —
+    // so the *enforceable* inbound bound is still the protocol maximum. An
+    // offer is a request, not an agreement (RFC 8449 §4 bounds records only
+    // once the extension "is negotiated").
+    try std.testing.expect(!backend.record_size_limit_active);
+    try std.testing.expectEqual(record_size.default_limit, backend.recordSizeLimits().local);
     try std.testing.expectEqual(@as(?u16, null), backend.recordSizeLimits().peer);
+}
+
+test "#359 a client that offers but is ignored keeps the protocol-maximum receive bound" {
+    // The regression the offer/active split exists to prevent: configured
+    // 512, peer ignores extension 28, and a legal 8 KiB record must still be
+    // acceptable. Reporting `local = 512` here would have the bridge reject
+    // records RFC 8449 §4 still permits.
+    var storage: TestProviderStorage = .{};
+    var policy = tls_policy.Policy.recordH2Only();
+    policy.record_size_limit = 512;
+    var backend = Tls13Backend.initClientConfigured(
+        Entropy{ .hello_random = [_]u8{0x66} ** 32 },
+        storage.init(test_crypto_provider_seed),
+        .{ .pinned_certificate = testdata.certificate_der },
+        recordConfig(policy),
+        .{},
+    );
+    defer backend.deinit();
+    var sink = EventSink{};
+    defer sink.deinit();
+    try backend.backend().start(.client, {}, &sink);
+
+    // EncryptedExtensions with ALPN but *no* record_size_limit: the peer
+    // simply does not implement RFC 8449.
+    var buf: [64]u8 = undefined;
+    var w = Writer{ .buf = &buf };
+    const extensions_len = try w.reserve(2);
+    try w.u16_(ext_alpn);
+    try w.u16_(2 + 1 + 2);
+    try w.u16_(1 + 2);
+    try w.u8_(2);
+    try w.bytes("h2");
+    w.patch(2, extensions_len);
+    try backend.onEncryptedExtensions(buf[0..w.len], &sink);
+
+    try std.testing.expect(!backend.record_size_limit_active);
+    const limits = backend.recordSizeLimits();
+    try std.testing.expectEqual(record_size.default_limit, limits.local);
+    try std.testing.expectEqual(@as(usize, record_size.max_limit), limits.inboundInnerMax());
+    // And nothing bounds our sends either.
+    try std.testing.expectEqual(@as(?u16, null), limits.peer);
+    try std.testing.expect(!limits.peerConstrains());
+}
+
+test "#359 a client activates its configured receive bound only once the server answers" {
+    var storage: TestProviderStorage = .{};
+    var policy = tls_policy.Policy.recordH2Only();
+    policy.record_size_limit = 512;
+    var backend = Tls13Backend.initClientConfigured(
+        Entropy{ .hello_random = [_]u8{0x67} ** 32 },
+        storage.init(test_crypto_provider_seed),
+        .{ .pinned_certificate = testdata.certificate_der },
+        recordConfig(policy),
+        .{},
+    );
+    defer backend.deinit();
+    var sink = EventSink{};
+    defer sink.deinit();
+    try backend.backend().start(.client, {}, &sink);
+    try std.testing.expectEqual(record_size.default_limit, backend.recordSizeLimits().local);
+
+    var buf: [64]u8 = undefined;
+    const ee = encryptedExtensionsWithRecordSizeLimit(&buf, 1024);
+    try backend.onEncryptedExtensions(ee, &sink);
+
+    try std.testing.expect(backend.record_size_limit_active);
+    const limits = backend.recordSizeLimits();
+    try std.testing.expectEqual(@as(u16, 512), limits.local);
+    try std.testing.expectEqual(@as(?u16, 1024), limits.peer);
 }
 
 test "#359 the QUIC (extension) profile never offers record_size_limit" {

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -4343,6 +4343,13 @@ pub const Tls13Backend = struct {
             psk_dhe_ke_offered: bool = false,
             psk_ext: ?struct { body_offset: usize, len: usize } = null,
             early_data_seen: bool = false,
+            /// #359: whether this profile has TLS records for RFC 8449 to
+            /// bound at all. False under the QUIC profile, where the
+            /// extension is not merely unused but *unsupported* — and RFC
+            /// 8446 §4.1.2 has a server ignore an unsupported ClientHello
+            /// extension, not inspect or reject it. GnuTLS-based QUIC clients
+            /// do send it, so parsing it here would fail real handshakes.
+            record_size_limit_supported: bool,
             /// #359: the client's `record_size_limit`, already validated and
             /// (per RFC 8449 §4's server rule) clamped to the protocol
             /// maximum rather than rejected when it is larger.
@@ -4377,9 +4384,12 @@ pub const Tls13Backend = struct {
                     // restriction", because a client may be advertising a size
                     // some future version or extension enables. Clamping (not
                     // rejecting) is what lets such a client still connect.
-                    ext_record_size_limit => self_obs.record_size_limit = record_size.decode(observation.data, .clamp) catch |err| switch (err) {
-                        error.MalformedHandshake => return error.MalformedExtension,
-                        error.IllegalParameter => return error.IllegalParameter,
+                    ext_record_size_limit => {
+                        if (!self_obs.record_size_limit_supported) return;
+                        self_obs.record_size_limit = record_size.decode(observation.data, .clamp) catch |err| switch (err) {
+                            error.MalformedHandshake => return error.MalformedExtension,
+                            error.IllegalParameter => return error.IllegalParameter,
+                        };
                     },
                     else => if (self_obs.transport_extension_type) |expected_type| {
                         if (expected_type == observation.id) self_obs.transport_params = observation.data;
@@ -4388,7 +4398,10 @@ pub const Tls13Backend = struct {
             }
         };
 
-        var observer = ClientHelloObserver{ .transport_extension_type = self.profile.extensionType() };
+        var observer = ClientHelloObserver{
+            .transport_extension_type = self.profile.extensionType(),
+            .record_size_limit_supported = self.offeredRecordSizeLimit() != null,
+        };
         const parsed = tls_negotiation.parseClientHelloObserved(body, .{
             .ctx = &observer,
             .observeFn = ClientHelloObserver.observe,
@@ -4438,12 +4451,11 @@ pub const Tls13Backend = struct {
         // 0-RTT is only meaningful alongside a resumption attempt.
         if (observer.early_data_seen and observer.psk_ext == null) return error.MissingExtension;
         self.client_hello_early_data_seen = observer.early_data_seen;
-        // #359: a client offering `record_size_limit` to a profile that has no
-        // TLS records (QUIC) is offering a bound neither side can apply.
-        if (observer.record_size_limit) |limit| {
-            if (self.offeredRecordSizeLimit() == null) return error.UnsupportedExtension;
-            self.peer_record_size_limit = limit;
-        }
+        // #359: null under the QUIC profile, which never inspects the
+        // extension (see `record_size_limit_supported`), and null for a record
+        // client that simply did not offer one — RFC 8449 §4 makes that mean
+        // "the protocol maximum", which is what `recordSizeLimits` reports.
+        self.peer_record_size_limit = observer.record_size_limit;
         // signature_algorithms is required whenever the server authenticates
         // with a certificate (RFC 8446 §9.2). A missing or empty list is a
         // malformed/missing required *peer* extension — attribute it to the

--- a/src/tls/tls13_backend.zig
+++ b/src/tls/tls13_backend.zig
@@ -32,6 +32,7 @@ const tls_key_schedule = @import("key_schedule.zig");
 const key_update = @import("key_update.zig");
 const new_session_ticket = @import("new_session_ticket.zig");
 const pre_shared_key = @import("pre_shared_key.zig");
+const record_size = @import("record_size.zig");
 const session = @import("session.zig");
 const tls_state = @import("state.zig");
 const tls13_transport = @import("tls13_transport.zig");
@@ -309,6 +310,7 @@ const ext_supported_versions: u16 = @intFromEnum(tls_algorithms.ExtensionType.su
 const ext_key_share: u16 = @intFromEnum(tls_algorithms.ExtensionType.key_share);
 const ext_early_data: u16 = @intFromEnum(tls_algorithms.ExtensionType.early_data);
 const ext_cookie: u16 = @intFromEnum(tls_algorithms.ExtensionType.cookie);
+const ext_record_size_limit: u16 = record_size.extension_type;
 pub const max_transport_extension_len = 512;
 
 const native_protocol_versions = [_]tls_algorithms.ProtocolVersion{.tls13};
@@ -399,6 +401,10 @@ pub const TransportProfile = union(enum) {
                 @intFromEnum(tls_algorithms.ExtensionType.padding),
                 @intFromEnum(tls_algorithms.ExtensionType.early_data),
                 @intFromEnum(tls_algorithms.ExtensionType.cookie),
+                // #359: the record layer owns `record_size_limit`, so a
+                // transport extension configured with its ID would be
+                // misparsed as an advertisement (and vice versa).
+                ext_record_size_limit,
                 // #362: reserve the TLS-owned PSK extension IDs too — a
                 // caller configuring a transport extension with either of
                 // these types would otherwise collide with (and be
@@ -866,6 +872,12 @@ pub const Tls13Backend = struct {
     /// Server: whether the just-parsed ClientHello carried the (empty)
     /// `early_data` extension.
     client_hello_early_data_seen: bool = false,
+    /// The peer's advertised `record_size_limit` (RFC 8449, #359), or null
+    /// when the peer never sent the extension — which the RFC defines as "the
+    /// protocol maximum", not "no limit". Set on the server from ClientHello
+    /// and on the client from EncryptedExtensions; read through
+    /// `recordSizeLimits` by the record transport, which is the only consumer.
+    peer_record_size_limit: ?u16 = null,
     /// Server (#366): enablement/tolerance for accepting 0-RTT, configured
     /// via `setServerEarlyDataPolicy` before `start`.
     server_early_data_policy: ServerEarlyDataPolicy = .{},
@@ -1602,6 +1614,11 @@ pub const Tls13Backend = struct {
             .earlyDataMaxBytesFn = earlyDataMaxBytesImpl,
             .earlyDataDiscardLimitFn = earlyDataDiscardLimitImpl,
             .helloRetryRequestSentFn = helloRetryRequestSentImpl,
+            // #359: always wired. Under `.extension` (QUIC) it reports the
+            // protocol-maximum default, which is what an unnegotiated
+            // connection means anyway — the profile check lives in
+            // `offeredRecordSizeLimit`, so there is one place that decides.
+            .recordSizeLimitsFn = recordSizeLimitsImpl,
             // Wired only under the record profile, so `supportsKeyUpdate` is
             // an honest answer rather than a slot that always exists and then
             // refuses: RFC 9001 §6 gives TLS-over-QUIC no `KeyUpdate` at all
@@ -2133,6 +2150,10 @@ pub const Tls13Backend = struct {
                 if (prior.eql(protocol)) return error.InvalidTransportProfile;
             }
         }
+        // #359: an advertisement outside RFC 8449's range is a local
+        // misconfiguration, caught here rather than encoded onto the wire.
+        (record_size.Limits{ .local = self.policy.record_size_limit }).validate() catch
+            return error.InvalidTransportProfile;
         _ = try self.maxServerFlightPreflightLen();
     }
 
@@ -2152,6 +2173,7 @@ pub const Tls13Backend = struct {
         if (self.profile.localExtension()) |payload| {
             len = try checkedAdd(len, 2 + 2 + payload.len);
         }
+        len = try checkedAdd(len, self.recordSizeLimitEncodedLen()); // #359
         if (self.client_auth != .disabled) {
             len = try checkedAdd(len, 1 + 3 + 1 + 2); // CertificateRequest header, empty context, extensions vector
             len = try checkedAdd(len, 2 + 2 + 2 + 2 * self.policy.signature_schemes.len);
@@ -2738,6 +2760,14 @@ pub const Tls13Backend = struct {
             try w.bytes(payload);
         }
 
+        // record_size_limit (#359). Placed here, immediately after the
+        // transport extension, in *both* ClientHello1 and ClientHello2:
+        // `hello_retry.validateSecondClientHello` compares the two hellos'
+        // order-stable extensions positionally, so the two call sites must
+        // agree. (`cookie` and `early_data`, which follow, are excluded from
+        // that comparison and so may differ between the hellos.)
+        try self.writeRecordSizeLimitOffer(&w);
+
         // early_data (#366): an empty extension announcing a 0-RTT attempt.
         // Order relative to `pre_shared_key` doesn't matter under RFC
         // 8446 §4.2.11 (only `pre_shared_key` itself must be last), so this
@@ -3071,6 +3101,7 @@ pub const Tls13Backend = struct {
             const payload = self.profile.localExtension() orelse return error.MissingTransportExtension;
             len = try checkedAdd(len, 2 + 2 + payload.len);
         }
+        len = try checkedAdd(len, self.recordSizeLimitEncodedLen()); // #359
         return len;
     }
 
@@ -3085,6 +3116,65 @@ pub const Tls13Backend = struct {
         }
         w.patch(2, alpn_list_len);
         w.patch(2, alpn_ext_len);
+    }
+
+    /// The `record_size_limit` this endpoint advertises, or null when the
+    /// profile has no TLS records to limit.
+    ///
+    /// RFC 8449 is defined over the TLS/DTLS record layer. TLS-over-QUIC has
+    /// no records at all — handshake bytes ride CRYPTO frames and application
+    /// data rides QUIC streams under QUIC's own flow control — so offering it
+    /// there would advertise a bound nothing on either side could apply.
+    fn offeredRecordSizeLimit(self: *const Tls13Backend) ?u16 {
+        return switch (self.profile) {
+            .record => self.policy.record_size_limit,
+            .extension => null,
+        };
+    }
+
+    fn writeRecordSizeLimitOffer(self: *const Tls13Backend, w: *Writer) HandshakeError!void {
+        const limit = self.offeredRecordSizeLimit() orelse return;
+        const body = record_size.encodeBody(limit);
+        try w.u16_(ext_record_size_limit);
+        try w.u16_(record_size.body_len);
+        try w.bytes(&body);
+    }
+
+    fn recordSizeLimitEncodedLen(self: *const Tls13Backend) usize {
+        return if (self.offeredRecordSizeLimit() == null) 0 else 2 + 2 + record_size.body_len;
+    }
+
+    /// The connection's negotiated record-size state (#359), for the record
+    /// transport. `local` is what we advertised — the bound we enforce on
+    /// arriving records — and `peer` is what the peer advertised, or null
+    /// until (or unless) it does.
+    pub fn recordSizeLimits(self: *const Tls13Backend) record_size.Limits {
+        return .{
+            .local = self.offeredRecordSizeLimit() orelse record_size.default_limit,
+            .peer = self.peer_record_size_limit,
+        };
+    }
+
+    fn recordSizeLimitsImpl(ptr: *anyopaque) record_size.Limits {
+        const self: *Tls13Backend = @ptrCast(@alignCast(ptr));
+        return self.recordSizeLimits();
+    }
+
+    /// Capture a peer's `record_size_limit` advertisement. `over_max` is the
+    /// role-appropriate handling RFC 8449 §4 prescribes for a value above the
+    /// TLS 1.3 maximum: a server clamps, a client may reject.
+    fn capturePeerRecordSizeLimit(
+        self: *Tls13Backend,
+        body: []const u8,
+        over_max: record_size.OverMaxPolicy,
+    ) HandshakeError!void {
+        // A peer that sends the extension to a profile that never offered it
+        // (QUIC) has answered a question we did not ask.
+        if (self.offeredRecordSizeLimit() == null) return error.UnsupportedExtension;
+        self.peer_record_size_limit = record_size.decode(body, over_max) catch |err| switch (err) {
+            error.MalformedHandshake => return error.MalformedHandshake,
+            error.IllegalParameter => return error.IllegalParameter,
+        };
     }
 
     fn policyAlpnOfferEncodedLen(self: *const Tls13Backend) HandshakeError!usize {
@@ -3425,6 +3515,10 @@ pub const Tls13Backend = struct {
             try w.bytes(payload);
         }
 
+        // #359: same value, same position as ClientHello1 — see the matching
+        // comment in `sendClientHello`.
+        try self.writeRecordSizeLimitOffer(&w);
+
         if (request.cookie) |cookie| {
             try w.u16_(ext_cookie);
             try w.u16_(@intCast(2 + cookie.len));
@@ -3604,6 +3698,11 @@ pub const Tls13Backend = struct {
                     try ext.expectEnd();
                     early_data_seen = true;
                 },
+                // #359: RFC 8449 §4 permits a client to abort when the server
+                // names a limit larger than the negotiated version allows.
+                // The version is already settled by the time EncryptedExtensions
+                // arrives, so no future-version reading excuses it here.
+                ext_record_size_limit => try self.capturePeerRecordSizeLimit(ext.bytes, .reject),
                 else => {
                     if (self.profile.extensionType()) |expected_type| {
                         if (expected_type == ext_id) {
@@ -4244,6 +4343,10 @@ pub const Tls13Backend = struct {
             psk_dhe_ke_offered: bool = false,
             psk_ext: ?struct { body_offset: usize, len: usize } = null,
             early_data_seen: bool = false,
+            /// #359: the client's `record_size_limit`, already validated and
+            /// (per RFC 8449 §4's server rule) clamped to the protocol
+            /// maximum rather than rejected when it is larger.
+            record_size_limit: ?u16 = null,
 
             fn observe(ctx: *anyopaque, observation: tls_negotiation.ExtensionObservation) tls_negotiation.Error!void {
                 const self_obs: *@This() = @ptrCast(@alignCast(ctx));
@@ -4269,6 +4372,14 @@ pub const Tls13Backend = struct {
                     ext_early_data => {
                         if (observation.data.len != 0) return error.MalformedExtension;
                         self_obs.early_data_seen = true;
+                    },
+                    // #359: RFC 8449 §4 — "A server MUST NOT enforce this
+                    // restriction", because a client may be advertising a size
+                    // some future version or extension enables. Clamping (not
+                    // rejecting) is what lets such a client still connect.
+                    ext_record_size_limit => self_obs.record_size_limit = record_size.decode(observation.data, .clamp) catch |err| switch (err) {
+                        error.MalformedHandshake => return error.MalformedExtension,
+                        error.IllegalParameter => return error.IllegalParameter,
                     },
                     else => if (self_obs.transport_extension_type) |expected_type| {
                         if (expected_type == observation.id) self_obs.transport_params = observation.data;
@@ -4327,6 +4438,12 @@ pub const Tls13Backend = struct {
         // 0-RTT is only meaningful alongside a resumption attempt.
         if (observer.early_data_seen and observer.psk_ext == null) return error.MissingExtension;
         self.client_hello_early_data_seen = observer.early_data_seen;
+        // #359: a client offering `record_size_limit` to a profile that has no
+        // TLS records (QUIC) is offering a bound neither side can apply.
+        if (observer.record_size_limit) |limit| {
+            if (self.offeredRecordSizeLimit() == null) return error.UnsupportedExtension;
+            self.peer_record_size_limit = limit;
+        }
         // signature_algorithms is required whenever the server authenticates
         // with a certificate (RFC 8446 §9.2). A missing or empty list is a
         // malformed/missing required *peer* extension — attribute it to the
@@ -4943,6 +5060,12 @@ pub const Tls13Backend = struct {
             try w.u16_(@intCast(payload.len));
             try w.bytes(payload);
         }
+        // #359: RFC 8449 §4 — "In TLS 1.3, the server sends the
+        // `record_size_limit` extension in the EncryptedExtensions message."
+        // Sent unconditionally when the profile offers it, not only in reply
+        // to a client that asked: the value bounds what the *server* accepts,
+        // and the client needs it whether or not it advertised one itself.
+        try self.writeRecordSizeLimitOffer(&w);
         // #366: signal 0-RTT acceptance with an empty `early_data`
         // extension — omitted (not merely absent-with-a-flag) for a
         // PSK-resumed but early-rejected connection, so the client's
@@ -5021,6 +5144,9 @@ pub const Tls13Backend = struct {
             try w.u16_(@intCast(payload.len));
             try w.bytes(payload);
         }
+        // #359: see `emitPskFinishFlight` — RFC 8449 §4 puts the server's
+        // advertisement in EncryptedExtensions on both flights.
+        try self.writeRecordSizeLimitOffer(&w);
         w.patch(2, ee_extensions);
         w.patch(3, ee_len);
         const encrypted_extensions = buf[0..w.len];
@@ -6870,4 +6996,199 @@ test "abandoned backend teardown wipes ephemeral and server identity storage" {
     server.deinit();
     try std.testing.expect(!server.identity_present);
     try std.testing.expect(std.mem.allEqual(u8, std.mem.asBytes(&server.identity), 0));
+}
+
+// ===========================================================================
+// #359: `record_size_limit` (RFC 8449) wire behavior.
+// ===========================================================================
+
+/// One `record_size_limit` extension body wrapped in an EncryptedExtensions
+/// extension vector, alongside the ALPN selection the client's policy requires.
+fn encryptedExtensionsWithRecordSizeLimit(out: []u8, limit: u16) []const u8 {
+    var w = Writer{ .buf = out };
+    const extensions_len = w.reserve(2) catch unreachable;
+    w.u16_(ext_alpn) catch unreachable;
+    w.u16_(2 + 1 + 2) catch unreachable;
+    w.u16_(1 + 2) catch unreachable;
+    w.u8_(2) catch unreachable;
+    w.bytes("h2") catch unreachable;
+    w.u16_(ext_record_size_limit) catch unreachable;
+    w.u16_(record_size.body_len) catch unreachable;
+    const body = record_size.encodeBody(limit);
+    w.bytes(&body) catch unreachable;
+    w.patch(2, extensions_len);
+    return out[0..w.len];
+}
+
+fn recordSizeLimitTestClient(storage: *TestProviderStorage) Tls13Backend {
+    return Tls13Backend.initClient(
+        Entropy{ .hello_random = [_]u8{0x63} ** 32 },
+        storage.init(test_crypto_provider_seed),
+        .{ .pinned_certificate = testdata.certificate_der },
+        .record,
+    );
+}
+
+test "#359 the record-mode ClientHello carries a well-formed record_size_limit" {
+    var storage: TestProviderStorage = .{};
+    var policy = tls_policy.Policy.recordH2Only();
+    policy.record_size_limit = 4096;
+    var backend = Tls13Backend.initClientConfigured(
+        Entropy{ .hello_random = [_]u8{0x61} ** 32 },
+        storage.init(test_crypto_provider_seed),
+        .{ .pinned_certificate = testdata.certificate_der },
+        recordConfig(policy),
+        .{},
+    );
+    defer backend.deinit();
+
+    var sink = EventSink{};
+    defer sink.deinit();
+    try backend.backend().start(.client, {}, &sink);
+    const client_hello = sink.items[0].handshake_bytes.data;
+
+    const Found = struct {
+        limit: ?u16 = null,
+        fn observe(ctx: *anyopaque, observation: tls_negotiation.ExtensionObservation) tls_negotiation.Error!void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            if (observation.id != ext_record_size_limit) return;
+            self.limit = try record_size.decode(observation.data, .reject);
+        }
+    };
+    var found = Found{};
+    _ = try tls_negotiation.parseClientHelloObserved(
+        client_hello[handshake_header_len..],
+        .{ .ctx = &found, .observeFn = Found.observe },
+    );
+    try std.testing.expectEqual(@as(?u16, 4096), found.limit);
+    // Nothing is negotiated yet: only our own advertisement is known.
+    try std.testing.expectEqual(@as(u16, 4096), backend.recordSizeLimits().local);
+    try std.testing.expectEqual(@as(?u16, null), backend.recordSizeLimits().peer);
+}
+
+test "#359 the QUIC (extension) profile never offers record_size_limit" {
+    var storage: TestProviderStorage = .{};
+    var backend = Tls13Backend.initClient(
+        Entropy{ .hello_random = [_]u8{0x62} ** 32 },
+        storage.init(test_crypto_provider_seed),
+        .{ .pinned_certificate = testdata.certificate_der },
+        .{ .extension = .{ .extension_type = 57, .local = "quic transport parameters" } },
+    );
+    defer backend.deinit();
+
+    var sink = EventSink{};
+    defer sink.deinit();
+    try backend.backend().start(.client, {}, &sink);
+    const client_hello = sink.items[0].handshake_bytes.data;
+
+    const Found = struct {
+        seen: bool = false,
+        fn observe(ctx: *anyopaque, observation: tls_negotiation.ExtensionObservation) tls_negotiation.Error!void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            if (observation.id == ext_record_size_limit) self.seen = true;
+        }
+    };
+    var found = Found{};
+    _ = try tls_negotiation.parseClientHelloObserved(
+        client_hello[handshake_header_len..],
+        .{ .ctx = &found, .observeFn = Found.observe },
+    );
+    try std.testing.expect(!found.seen);
+    // RFC 8449 has nothing to say about a transport with no records, so the
+    // reported state is the protocol maximum with no peer value.
+    try std.testing.expectEqual(record_size.default_limit, backend.recordSizeLimits().local);
+    try std.testing.expectEqual(@as(?u16, null), backend.recordSizeLimits().peer);
+}
+
+test "#359 a client accepts every in-range server advertisement, at both boundaries" {
+    for ([_]u16{ record_size.min_limit, 1024, record_size.max_limit }) |limit| {
+        var storage: TestProviderStorage = .{};
+        var backend = recordSizeLimitTestClient(&storage);
+        defer backend.deinit();
+        var sink = EventSink{};
+        defer sink.deinit();
+
+        var buf: [64]u8 = undefined;
+        const ee = encryptedExtensionsWithRecordSizeLimit(&buf, limit);
+        try backend.onEncryptedExtensions(ee, &sink);
+        try std.testing.expectEqual(@as(?u16, limit), backend.recordSizeLimits().peer);
+    }
+}
+
+test "#359 a client rejects a below-minimum or above-maximum server advertisement" {
+    // RFC 8449 §4: under 64 is `illegal_parameter` for both roles.
+    for ([_]u16{ 0, 1, record_size.min_limit - 1 }) |limit| {
+        var storage: TestProviderStorage = .{};
+        var backend = recordSizeLimitTestClient(&storage);
+        defer backend.deinit();
+        var sink = EventSink{};
+        defer sink.deinit();
+        var buf: [64]u8 = undefined;
+        const ee = encryptedExtensionsWithRecordSizeLimit(&buf, limit);
+        try std.testing.expectError(error.IllegalParameter, backend.onEncryptedExtensions(ee, &sink));
+    }
+    // RFC 8449 §4 lets a client abort on a value above the negotiated
+    // version's maximum, and this one does: the version is already settled by
+    // EncryptedExtensions, so no future-version reading excuses it.
+    for ([_]u16{ record_size.max_limit + 1, 65535 }) |limit| {
+        var storage: TestProviderStorage = .{};
+        var backend = recordSizeLimitTestClient(&storage);
+        defer backend.deinit();
+        var sink = EventSink{};
+        defer sink.deinit();
+        var buf: [64]u8 = undefined;
+        const ee = encryptedExtensionsWithRecordSizeLimit(&buf, limit);
+        try std.testing.expectError(error.IllegalParameter, backend.onEncryptedExtensions(ee, &sink));
+    }
+}
+
+test "#359 a client rejects a record_size_limit body that is not exactly two bytes" {
+    var storage: TestProviderStorage = .{};
+    var backend = recordSizeLimitTestClient(&storage);
+    defer backend.deinit();
+    var sink = EventSink{};
+    defer sink.deinit();
+
+    for ([_][]const u8{ &.{}, &.{0x04}, &.{ 0x04, 0x00, 0x00 } }) |body| {
+        var buf: [64]u8 = undefined;
+        var w = Writer{ .buf = &buf };
+        const extensions_len = try w.reserve(2);
+        try w.u16_(ext_record_size_limit);
+        try w.u16_(@intCast(body.len));
+        try w.bytes(body);
+        w.patch(2, extensions_len);
+        try std.testing.expectError(error.MalformedHandshake, backend.onEncryptedExtensions(buf[0..w.len], &sink));
+    }
+}
+
+test "#359 a record_size_limit advertisement outside the legal range fails configuration, not the wire" {
+    var storage: TestProviderStorage = .{};
+    var policy = tls_policy.Policy.recordH2Only();
+    policy.record_size_limit = record_size.min_limit - 1;
+    var backend = Tls13Backend.initClientConfigured(
+        Entropy{ .hello_random = [_]u8{0x64} ** 32 },
+        storage.init(test_crypto_provider_seed),
+        .{ .pinned_certificate = testdata.certificate_der },
+        recordConfig(policy),
+        .{},
+    );
+    defer backend.deinit();
+    var sink = EventSink{};
+    defer sink.deinit();
+    try std.testing.expectError(error.InvalidTransportProfile, backend.backend().start(.client, {}, &sink));
+    try std.testing.expectEqual(@as(usize, 0), sink.len);
+}
+
+test "#359 a transport profile may not claim the record_size_limit extension ID" {
+    var storage: TestProviderStorage = .{};
+    var backend = Tls13Backend.initClient(
+        Entropy{ .hello_random = [_]u8{0x65} ** 32 },
+        storage.init(test_crypto_provider_seed),
+        .{ .pinned_certificate = testdata.certificate_der },
+        .{ .extension = .{ .extension_type = ext_record_size_limit, .local = "colliding" } },
+    );
+    defer backend.deinit();
+    var sink = EventSink{};
+    defer sink.deinit();
+    try std.testing.expectError(error.InvalidTransportProfile, backend.backend().start(.client, {}, &sink));
 }

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -13654,3 +13654,97 @@ test "#359 a PSK-resumed server flight follows the same request/response rule" {
         try std.testing.expectEqual(offered, server.recordSizeLimits().peer);
     }
 }
+
+test "#359 a server advertising 512 accepts oversized 0-RTT but rejects the same size at 1-RTT" {
+    // The epoch boundary, end to end through a real record-mode resumption.
+    // RFC 8446 §4.2.10 has 0-RTT ride the client's first flight, so it is
+    // created before the server's EncryptedExtensions answer exists — and the
+    // server activates its own bound when it *writes* that answer, before the
+    // handshake completes. An early record can therefore legitimately arrive at
+    // a server already enforcing 512, and must not be judged against it.
+    var issued = try issueEarlyCapableTicket(16384);
+    defer issued.deinit();
+
+    var resumed: DirectHarness = undefined;
+    resumed.init();
+    defer resumed.deinit();
+
+    // Replace the server with one whose policy advertises 512. Only
+    // `record_size_limit` differs, so the ticket stays resumption-compatible.
+    resumed.server_backend.deinit();
+    resumed.server_backend = tls_backend.Tls13Backend.initServerConfigured(
+        serverEntropy(),
+        resumed.server_provider_storage.provider.cryptoProvider(),
+        fixtureIdentity(),
+        tls_backend.recordConfig(recordSizeLimitPolicy(512)),
+    );
+
+    var offers: pre_shared_key.ClientPskOfferSet = .{};
+    try offers.push(&issued.ticket);
+    var clock_dummy: u8 = 0;
+    try resumed.client_backend.setClientPskOffers(&offers, &clock_dummy, earlyDataResumedClientClock);
+    var resolver_state = IdentityResolver{ .state = &issued.server_state };
+    try resumed.server_backend.setServerPskResolver(.{
+        .ctx = &resolver_state,
+        .nowUnixMsFn = IdentityResolver.now,
+        .resolveFn = IdentityResolver.resolve,
+    });
+    try resumed.client_backend.setClientEarlyDataIntent(.{ .enabled = true, .max_bytes = 16384 });
+    try resumed.server_backend.setServerEarlyDataPolicy(.{ .enabled = true, .age_skew_tolerance_ms = 60_000 });
+    const AllowGate = struct {
+        fn decide(_: *anyopaque, _: tls_backend.EarlyDataReplayCandidate) tls_backend.EarlyDataReplayDecision {
+            return .allow;
+        }
+    };
+    var gate_ctx: u8 = 0;
+    try resumed.server_backend.setEarlyDataReplayGate(.{ .ctx = &gate_ctx, .decideFn = AllowGate.decide });
+
+    try resumed.run();
+    try std.testing.expect(resumed.server_backend.earlyDataAccepted());
+
+    // The policy really reached the wire and the negotiation really settled on
+    // it — otherwise everything below would be checking nothing.
+    const server_limits = resumed.server_backend.recordSizeLimits();
+    try std.testing.expectEqual(@as(u16, 512), server_limits.local);
+    try std.testing.expectEqual(@as(?u16, record_size.max_limit), server_limits.peer);
+
+    // Model the server's mid-handshake state: 0-RTT read keys installed and the
+    // bound already active (it activates on writing EncryptedExtensions), but
+    // the handshake not yet complete. That is the exact window in which a
+    // buffered early record lands.
+    var early_provider_storage: ProviderStorage = .{};
+    var client_early_storage: ProviderStorage = .{};
+    var server_early = Bridge.init(early_provider_storage.init(server_provider_seed), .tls_aes_128_gcm_sha256);
+    defer server_early.deinit();
+    var client_early = Bridge.init(client_early_storage.init(client_provider_seed), .tls_aes_128_gcm_sha256);
+    defer client_early.deinit();
+
+    const early_secret = resumed.observed.zero_rtt_secret[0] orelse return error.TestExpectedEqual;
+    try client_early.installTrafficSecret(.zero_rtt, .write, early_secret.slice());
+    try server_early.installTrafficSecret(.zero_rtt, .read, early_secret.slice());
+    try server_early.setRecordSizeLimits(server_limits);
+
+    // >512 but protocol-legal early data: accepted.
+    const oversized = [_]u8{'e'} ** 2000;
+    var protected: [record_codec.max_ciphertext_record_len]u8 = undefined;
+    var plaintext: [record_codec.max_ciphertext_fragment_len]u8 = undefined;
+    const early_record = try client_early.sealProtected(.zero_rtt, .application_data, &oversized, &protected);
+    const opened = try server_early.openProtected(.zero_rtt, try parseSingleRecord(.ciphertext, early_record), &plaintext);
+    try std.testing.expectEqualSlices(u8, &oversized, opened.inner.content);
+    try std.testing.expectEqual(@as(u64, 0), server_early.record_size_counters.oversize_records_rejected);
+
+    // The very same size at the application epoch, on the completed
+    // connection, *is* rejected — which is what makes the exemption an epoch
+    // boundary rather than a hole.
+    try resumed.server_bridge.setRecordSizeLimits(server_limits);
+    const late_record = try resumed.client_bridge.sealProtected(.application, .application_data, oversized[0..511], &protected);
+    _ = try resumed.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, late_record), &plaintext);
+    // 511 content bytes + the type byte is exactly 512 and passes; one more
+    // does not. The client bridge is unconstrained here precisely so it can
+    // produce the over-limit record a misbehaving peer would.
+    const over_record = try resumed.client_bridge.sealProtected(.application, .application_data, oversized[0..512], &protected);
+    try std.testing.expectError(
+        error.RecordSizeLimitExceeded,
+        resumed.server_bridge.openApplicationData(try parseSingleRecord(.ciphertext, over_record), &plaintext),
+    );
+}

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -13462,7 +13462,7 @@ test "#359 a server accepts a client that never advertises, and treats it as the
     try std.testing.expectEqual(@as(usize, record_size.max_limit), limits.outboundInnerMax());
 }
 
-test "#359 a QUIC-profile server rejects a client that offers record_size_limit" {
+test "#359 a QUIC-profile server ignores a client that offers record_size_limit" {
     var server_provider_storage: ProviderStorage = .{};
     var server = tls_backend.Tls13Backend.initServer(
         serverEntropy(),
@@ -13475,13 +13475,45 @@ test "#359 a QUIC-profile server rejects a client that offers record_size_limit"
     defer sink.deinit();
     try server.backend().start(.server, {}, &sink);
 
-    // RFC 8449 bounds TLS *records*; TLS-over-QUIC has none, so this is an
-    // extension the endpoint never offered and cannot honor.
+    // RFC 8449 bounds TLS *records*; TLS-over-QUIC has none, so this endpoint
+    // does not support the extension. RFC 8446 §4.1.2 has a server *ignore* an
+    // unsupported ClientHello extension rather than reject it — and GnuTLS-based
+    // QUIC clients (the H3 interop peer) do send it, so rejecting here failed
+    // real handshakes.
     var buf: [2048]u8 = undefined;
     const hello = try buildClientHello(&buf, .{
         .alpn_protocols = &.{"h3"},
         .transport_extension = .{ .extension_type = 57, .payload = "client transport parameters" },
         .record_size_limit = 4096,
     });
-    try std.testing.expectError(error.UnsupportedExtension, server.backend().receive(.initial, hello, &sink));
+    try server.backend().receive(.initial, hello, &sink);
+    try std.testing.expectEqual(@as(?u16, null), server.recordSizeLimits().peer);
+}
+
+test "#359 a QUIC-profile server does not even validate a record_size_limit it ignores" {
+    // Ignoring means not parsing: a value this endpoint would reject as
+    // `illegal_parameter` under the record profile must not fail a QUIC
+    // handshake, because the field is not one this profile reads at all.
+    for ([_]u16{ 0, record_size.min_limit - 1, 65535 }) |limit| {
+        var server_provider_storage: ProviderStorage = .{};
+        var server = tls_backend.Tls13Backend.initServer(
+            serverEntropy(),
+            server_provider_storage.init(server_provider_seed),
+            fixtureIdentity(),
+            .{ .extension = .{ .extension_type = 57, .local = "server transport parameters" } },
+        );
+        defer server.deinit();
+        var sink = DirectSink{};
+        defer sink.deinit();
+        try server.backend().start(.server, {}, &sink);
+
+        var buf: [2048]u8 = undefined;
+        const hello = try buildClientHello(&buf, .{
+            .alpn_protocols = &.{"h3"},
+            .transport_extension = .{ .extension_type = 57, .payload = "client transport parameters" },
+            .record_size_limit = limit,
+        });
+        try server.backend().receive(.initial, hello, &sink);
+        try std.testing.expectEqual(@as(?u16, null), server.recordSizeLimits().peer);
+    }
 }

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -3169,6 +3169,13 @@ test "record and extension profiles preserve independent traffic-secret goldens"
     defer extension.deinit();
     try extension.run();
 
+    // #359: the *record* goldens moved again when record mode began offering
+    // `record_size_limit` in its ClientHello — the extension is transcript
+    // input, so every secret derived from it legitimately changed. The
+    // extension goldens are untouched, which is the property this test exists
+    // to hold: the QUIC profile does not offer RFC 8449 and its wire bytes
+    // must not drift when the record profile's do.
+    //
     // Golden values recomputed for #490: X25519 key-share generation now
     // draws its randomness from the injected `CryptoProvider.entropy`
     // (`DirectHarness`'s own `client_provider_storage`/
@@ -3178,10 +3185,10 @@ test "record and extension profiles preserve independent traffic-secret goldens"
     // and every secret derived from it — legitimately changed. Still fully
     // deterministic; recomputed by capturing this harness's own output.
     const record_goldens = [_][tls_backend.hash_len]u8{
-        secretGolden("562a506fe3b7e55763cb374bbeddf37d2f69d0ec5c8a8f8c00a06ac867a8cfed"),
-        secretGolden("9513b75f9bb12a4212c0888ab739d9bd2b75ad25ed406962d0804a69a1c5129f"),
-        secretGolden("dac1c91c15cdc4213b17931028b5d4174fef1344d14f9546bc20b42dcd7462c7"),
-        secretGolden("6626393f198c2779e2244c3b7e2dac51b44b1b1011055af9e7d93be1774ccb76"),
+        secretGolden("663e88bfb6fe69034d56689f1825afa53464eb9a7e25f184fd1d4dca038b9a22"),
+        secretGolden("ddd6d6d7b9dd196dd7b9b290ebb15d004efd16e17080cb66cce6e332687a8ba0"),
+        secretGolden("c2702e261bd5db283a6c35315479ac04bdb4a07c466d5160287a7f65762b03cc"),
+        secretGolden("59cc7445ab6f017d6108884c074492b094c6ab8a06cddad3354c94f11dc6f5b2"),
     };
     const extension_goldens = [_][tls_backend.hash_len]u8{
         secretGolden("77072190f185201fe873979e7041bad67727e1194d2baf8adfdd4ebf99ab10c1"),
@@ -4468,12 +4475,17 @@ fn findSecretEvent(sink: *const DirectSink, epoch: events.EncryptionEpoch, direc
 /// verified against an external, non-Zig implementation of the key
 /// schedule. The RFC 8448 vectors in `key_schedule.zig` remain the
 /// independent cross-check for the HKDF chain itself.
-const kat_rebound_transcript_hash = "5bfb51c897aea5192ab702f84c0cf2f9278b7d34a1d1ea5dcbde63aaa4287467";
-const kat_ch2_binder = "5b192fe318a338a3f71450de6668f10a8aa0329983b0112d19f7c857da1bddd2";
-const kat_client_hs_traffic = "14e4e36f393b5921b5e22e382b575d6ba46629807a99cd7492c8faab77ebf3f8";
-const kat_server_hs_traffic = "3663c763c789dc344190a0aa75ea73d22d4222e7dd654d9722298e2bec67accf";
-const kat_client_ap_traffic = "44b828262e6c63eef446a5250f47d902165596d5ad6fcbdb67a1de4252692aa7";
-const kat_server_ap_traffic = "a69e28ee0032c7e7fb5db9b08148d22e672de75169027fd35761d75d310d1719";
+///
+/// #359: repinned once more when record mode started offering RFC 8449's
+/// `record_size_limit`. Both ClientHellos carry the new extension, so the
+/// rebound binder transcript — and therefore every secret below it — changed
+/// with the wire bytes. Nothing about the key schedule itself moved.
+const kat_rebound_transcript_hash = "fb3115c0b053ab6507ece8e0ab58bbe58e2a00d19e63c4b4a17cfe9855380afb";
+const kat_ch2_binder = "9a3afd7699f66a9aaa4b683fea77c1555a64bb8527c57102dc2254d9a83194bc";
+const kat_client_hs_traffic = "b00b934b5a2a5c6ff0c8fcc91f377d9756b4bbbe91a76fc7ad0451180e42ece9";
+const kat_server_hs_traffic = "b3a6cf46713e7b25f67b539c18adf220eef3d4f2dc8ccf45b1c02d71aaaa2058";
+const kat_client_ap_traffic = "7982ae3d8d5555420ee9db003b4072133fd06780202ca4b5aff65a5f5afe716f";
+const kat_server_ap_traffic = "97500698f9c2f3f6be6e966ea363f4f280366c54f1aecac72940b059676e0a39";
 
 test "#485 KAT: PSK-resumed HRR handshake/application secrets match an independently computed RFC 8446 key schedule" {
     var client_provider_storage: ProviderStorage = .{};
@@ -7501,6 +7513,10 @@ const ClientHelloOptions = struct {
     /// offer, for driving an extension-profile (#392 HTTP/3) server through
     /// selection the same way a real QUIC client would.
     transport_extension: ?struct { extension_type: u16, payload: []const u8 } = null,
+    /// #359: the raw `record_size_limit` (RFC 8449) value to advertise,
+    /// written verbatim so a test can offer values a conforming client never
+    /// would (below 64, above the TLS 1.3 maximum).
+    record_size_limit: ?u16 = null,
     /// #362: offer one or more resumption PSKs, in order, as the
     /// (necessarily last) ClientHello extension. Each binder is computed
     /// over the exact bytes this function ends up producing, from the
@@ -7625,6 +7641,12 @@ fn buildClientHello(buf: []u8, opts: ClientHelloOptions) ![]const u8 {
         try w.u16_(transport.extension_type);
         try w.u16_(@intCast(transport.payload.len));
         try w.bytes(transport.payload);
+    }
+    // record_size_limit (#359)
+    if (opts.record_size_limit) |limit| {
+        try w.u16_(tls_core.record_size.extension_type);
+        try w.u16_(tls_core.record_size.body_len);
+        try w.bytes(&tls_core.record_size.encodeBody(limit));
     }
     // pre_shared_key (#362): must be the last extension.
     var psk_offer: ?pre_shared_key.ClientOfferWrite = null;
@@ -13312,4 +13334,154 @@ test "#357 usage limits report when a proactive update is due without forcing on
     try std.testing.expect(!h.client.keyUpdateDue());
     try std.testing.expectEqual(@as(u64, 0), h.client.bridge.applicationRecordsSealed());
     try std.testing.expectEqual(@as(u64, 1), h.client.bridge.write_key_generation);
+}
+
+// ===========================================================================
+// #359: end-to-end `record_size_limit` (RFC 8449) negotiation.
+// ===========================================================================
+
+const record_size = tls_core.record_size;
+
+fn recordSizeLimitPolicy(limit: u16) tls_core.policy.Policy {
+    var policy = tls_core.policy.Policy.recordH2Only();
+    policy.record_size_limit = limit;
+    return policy;
+}
+
+test "#359 a record handshake negotiates each side's advertised limit independently" {
+    var harness: DirectHarness = undefined;
+    harness.init();
+    defer harness.deinit();
+    // Replace both backends with ones that advertise distinct, non-default
+    // limits, so a value leaking from one side to the other is visible.
+    harness.client_backend.deinit();
+    harness.server_backend.deinit();
+    harness.client_backend = tls_backend.Tls13Backend.initClientConfigured(
+        clientEntropy(),
+        harness.client_provider_storage.provider.cryptoProvider(),
+        .{ .pinned_certificate = tls_backend.testdata.certificate_der },
+        tls_backend.recordConfig(recordSizeLimitPolicy(4096)),
+        .{},
+    );
+    harness.server_backend = tls_backend.Tls13Backend.initServerConfigured(
+        serverEntropy(),
+        harness.server_provider_storage.provider.cryptoProvider(),
+        fixtureIdentity(),
+        tls_backend.recordConfig(recordSizeLimitPolicy(2048)),
+    );
+
+    try harness.run();
+
+    const client_limits = harness.client_backend.recordSizeLimits();
+    try std.testing.expectEqual(@as(u16, 4096), client_limits.local);
+    try std.testing.expectEqual(@as(?u16, 2048), client_limits.peer);
+    try std.testing.expectEqual(@as(usize, 2047), client_limits.outboundContentMax());
+
+    const server_limits = harness.server_backend.recordSizeLimits();
+    try std.testing.expectEqual(@as(u16, 2048), server_limits.local);
+    try std.testing.expectEqual(@as(?u16, 4096), server_limits.peer);
+    try std.testing.expectEqual(@as(usize, 4095), server_limits.outboundContentMax());
+}
+
+test "#359 the default record handshake advertises the protocol maximum and constrains nothing" {
+    var harness: DirectHarness = undefined;
+    harness.init();
+    defer harness.deinit();
+    try harness.run();
+
+    for ([_]record_size.Limits{
+        harness.client_backend.recordSizeLimits(),
+        harness.server_backend.recordSizeLimits(),
+    }) |limits| {
+        try std.testing.expectEqual(record_size.max_limit, limits.local);
+        try std.testing.expectEqual(@as(?u16, record_size.max_limit), limits.peer);
+        try std.testing.expect(!limits.peerConstrains());
+    }
+}
+
+test "#359 a server clamps an above-maximum client advertisement rather than rejecting it" {
+    var server_provider_storage: ProviderStorage = .{};
+    var server = tls_backend.Tls13Backend.initServer(
+        serverEntropy(),
+        server_provider_storage.init(server_provider_seed),
+        fixtureIdentity(),
+        .record,
+    );
+    defer server.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+
+    // RFC 8449 §4: "A server MUST NOT enforce this restriction; a client might
+    // advertise a higher limit that is enabled by an extension or version the
+    // server does not understand." The handshake proceeds, clamped.
+    var buf: [2048]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{ .record_size_limit = 65535 });
+    try server.backend().receive(.initial, hello, &sink);
+    try std.testing.expectEqual(@as(?u16, record_size.max_limit), server.recordSizeLimits().peer);
+}
+
+test "#359 a server rejects a below-minimum client advertisement with illegal_parameter" {
+    for ([_]u16{ 0, 1, record_size.min_limit - 1 }) |limit| {
+        var server_provider_storage: ProviderStorage = .{};
+        var server = tls_backend.Tls13Backend.initServer(
+            serverEntropy(),
+            server_provider_storage.init(server_provider_seed),
+            fixtureIdentity(),
+            .record,
+        );
+        defer server.deinit();
+        var sink = DirectSink{};
+        defer sink.deinit();
+        try server.backend().start(.server, {}, &sink);
+
+        var buf: [2048]u8 = undefined;
+        const hello = try buildClientHello(&buf, .{ .record_size_limit = limit });
+        try std.testing.expectError(error.IllegalParameter, server.backend().receive(.initial, hello, &sink));
+    }
+}
+
+test "#359 a server accepts a client that never advertises, and treats it as the protocol maximum" {
+    var server_provider_storage: ProviderStorage = .{};
+    var server = tls_backend.Tls13Backend.initServer(
+        serverEntropy(),
+        server_provider_storage.init(server_provider_seed),
+        fixtureIdentity(),
+        .record,
+    );
+    defer server.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+
+    var buf: [2048]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{});
+    try server.backend().receive(.initial, hello, &sink);
+    const limits = server.recordSizeLimits();
+    try std.testing.expectEqual(@as(?u16, null), limits.peer);
+    try std.testing.expectEqual(@as(usize, record_size.max_limit), limits.outboundInnerMax());
+}
+
+test "#359 a QUIC-profile server rejects a client that offers record_size_limit" {
+    var server_provider_storage: ProviderStorage = .{};
+    var server = tls_backend.Tls13Backend.initServer(
+        serverEntropy(),
+        server_provider_storage.init(server_provider_seed),
+        fixtureIdentity(),
+        .{ .extension = .{ .extension_type = 57, .local = "server transport parameters" } },
+    );
+    defer server.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+
+    // RFC 8449 bounds TLS *records*; TLS-over-QUIC has none, so this is an
+    // extension the endpoint never offered and cannot honor.
+    var buf: [2048]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{
+        .alpn_protocols = &.{"h3"},
+        .transport_extension = .{ .extension_type = 57, .payload = "client transport parameters" },
+        .record_size_limit = 4096,
+    });
+    try std.testing.expectError(error.UnsupportedExtension, server.backend().receive(.initial, hello, &sink));
 }

--- a/src/tls/tls13_backend_tests.zig
+++ b/src/tls/tls13_backend_tests.zig
@@ -13517,3 +13517,140 @@ test "#359 a QUIC-profile server does not even validate a record_size_limit it i
         try std.testing.expectEqual(@as(?u16, null), server.recordSizeLimits().peer);
     }
 }
+
+/// Scan an EncryptedExtensions message body for extension `id`. `body` is the
+/// message *including* its 4-byte handshake header, as it appears on the wire.
+fn encryptedExtensionsHasExtension(body: []const u8, id: u16) !bool {
+    const message = try tls_core.messages.decode(body);
+    try std.testing.expectEqual(tls_core.messages.MessageType.encrypted_extensions, message.kind);
+    var r = tls_core.messages.Reader{ .bytes = message.body };
+    var extensions = tls_core.messages.ExtensionIterator.init(try r.slice(try r.u16_()));
+    while (try extensions.next()) |extension| {
+        if (extension.id == id) return true;
+    }
+    return false;
+}
+
+/// The first EncryptedExtensions message in a handshake-epoch flight. The
+/// server concatenates EE/Certificate/CertificateVerify/Finished into one
+/// event, so this walks the framed messages rather than assuming the flight is
+/// a single message.
+fn firstEncryptedExtensions(flight: []const u8) ![]const u8 {
+    var offset: usize = 0;
+    while (offset + 4 <= flight.len) {
+        const body_len = (@as(usize, flight[offset + 1]) << 16) |
+            (@as(usize, flight[offset + 2]) << 8) | flight[offset + 3];
+        const end = offset + 4 + body_len;
+        if (end > flight.len) break;
+        if (flight[offset] == @intFromEnum(tls_core.messages.MessageType.encrypted_extensions)) {
+            return flight[offset..end];
+        }
+        offset = end;
+    }
+    return error.TestExpectedEqual;
+}
+
+test "#359 a server omits record_size_limit from EncryptedExtensions when the client did not offer" {
+    // RFC 8446 §4.2: a server "MUST NOT send extension responses if the remote
+    // endpoint did not send the corresponding extension requests", and a client
+    // receiving one "MUST abort the handshake with an unsupported_extension
+    // alert". RFC 8449 §4 places the server's value in EE but does not exempt
+    // it from that rule — so answering unconditionally would break every
+    // conforming client that does not implement RFC 8449.
+    var server_provider_storage: ProviderStorage = .{};
+    var server = tls_backend.Tls13Backend.initServer(
+        serverEntropy(),
+        server_provider_storage.init(server_provider_seed),
+        fixtureIdentity(),
+        .record,
+    );
+    defer server.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+
+    var buf: [2048]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{});
+    try server.backend().receive(.initial, hello, &sink);
+
+    var flight_buf: [8192]u8 = undefined;
+    const flight = collectHandshakeCrypto(&sink, &flight_buf);
+    const ee = try firstEncryptedExtensions(flight);
+    try std.testing.expect(!try encryptedExtensionsHasExtension(ee, record_size.extension_type));
+    // And with no round trip completed, the server's own advertisement is not
+    // an enforceable receive bound either.
+    try std.testing.expectEqual(record_size.default_limit, server.recordSizeLimits().local);
+}
+
+test "#359 a server answers in EncryptedExtensions exactly when the client offered" {
+    var server_provider_storage: ProviderStorage = .{};
+    var server = tls_backend.Tls13Backend.initServerConfigured(
+        serverEntropy(),
+        server_provider_storage.init(server_provider_seed),
+        fixtureIdentity(),
+        tls_backend.recordConfig(recordSizeLimitPolicy(2048)),
+    );
+    defer server.deinit();
+    var sink = DirectSink{};
+    defer sink.deinit();
+    try server.backend().start(.server, {}, &sink);
+
+    var buf: [2048]u8 = undefined;
+    const hello = try buildClientHello(&buf, .{ .record_size_limit = 1024 });
+    try server.backend().receive(.initial, hello, &sink);
+
+    var flight_buf: [8192]u8 = undefined;
+    const flight = collectHandshakeCrypto(&sink, &flight_buf);
+    const ee = try firstEncryptedExtensions(flight);
+    try std.testing.expect(try encryptedExtensionsHasExtension(ee, record_size.extension_type));
+    // Writing the answer is the server's activation point, so its configured
+    // bound is now enforceable — and the client's bound its sending bound.
+    const limits = server.recordSizeLimits();
+    try std.testing.expectEqual(@as(u16, 2048), limits.local);
+    try std.testing.expectEqual(@as(?u16, 1024), limits.peer);
+    try std.testing.expectEqual(@as(usize, 1023), limits.outboundContentMax());
+}
+
+test "#359 a PSK-resumed server flight follows the same request/response rule" {
+    // The resumed flight is a separate EncryptedExtensions builder
+    // (`emitPskFinishFlight`), so it needs its own proof — both directions.
+    for ([_]?u16{ null, 1024 }) |offered| {
+        var server_provider_storage: ProviderStorage = .{};
+        var server = tls_backend.Tls13Backend.initServer(
+            serverEntropy(),
+            server_provider_storage.init(server_provider_seed),
+            fixtureIdentity(),
+            .record,
+        );
+        defer server.deinit();
+
+        const psk = [_]u8{0x64} ** tls_backend.hash_len;
+        var stored_state = pskStoredState(&psk);
+        defer stored_state.deinit();
+        var resolver_state = CountingResolver{ .state = &stored_state, .identity = "rsl-ticket" };
+        try server.setServerPskResolver(.{
+            .ctx = &resolver_state,
+            .nowUnixMsFn = CountingResolver.now,
+            .resolveFn = CountingResolver.resolve,
+        });
+
+        var sink = DirectSink{};
+        defer sink.deinit();
+        try server.backend().start(.server, {}, &sink);
+
+        var buf: [2048]u8 = undefined;
+        const hello = try buildClientHello(&buf, .{
+            .record_size_limit = offered,
+            .psk = .{ .items = &.{.{ .identity = "rsl-ticket", .binder_psk = &psk }} },
+        });
+        try server.backend().receive(.initial, hello, &sink);
+        try std.testing.expect(server.selected_server_psk_present);
+
+        var flight_buf: [8192]u8 = undefined;
+        const flight = collectHandshakeCrypto(&sink, &flight_buf);
+        const ee = try firstEncryptedExtensions(flight);
+        const present = try encryptedExtensionsHasExtension(ee, record_size.extension_type);
+        try std.testing.expectEqual(offered != null, present);
+        try std.testing.expectEqual(offered, server.recordSizeLimits().peer);
+    }
+}

--- a/src/tls/transport.zig
+++ b/src/tls/transport.zig
@@ -31,6 +31,7 @@ const crypto_secrets = @import("crypto_secrets");
 const alerts = @import("alerts.zig");
 const events = @import("events.zig");
 const key_update = @import("key_update.zig");
+const record_size = @import("record_size.zig");
 const state = @import("state.zig");
 
 pub fn Contract(
@@ -336,6 +337,18 @@ pub fn ContractWithOptions(
             /// not a missing feature — which is why `requestKeyUpdate` reports
             /// it to the caller instead of quietly doing nothing.
             requestKeyUpdateFn: ?*const fn (ptr: *anyopaque, request: key_update.Request, sink: *EventSink) ErrorSet!void = null,
+            /// The connection's negotiated `record_size_limit` state (RFC 8449,
+            /// #359): what this endpoint advertised, and what the peer did.
+            ///
+            /// A *pull*, not an event, for the same reason `earlyDataMaxBytes`
+            /// is: the value is settled state a transport reads when it needs
+            /// to size a record, not a moment in the handshake it must react
+            /// to at exactly the right point in an event batch. It also keeps
+            /// the extension out of QUIC's event vocabulary entirely — RFC
+            /// 8449 is defined over TLS records, which QUIC does not use, so a
+            /// QUIC backend leaves this null and gets the protocol-maximum
+            /// default below.
+            recordSizeLimitsFn: ?*const fn (ptr: *anyopaque) record_size.Limits = null,
 
             pub fn start(self: Backend, role: state.Role, params: TransportParameters, sink: *EventSink) ErrorSet!void {
                 return self.startFn(self.ptr, role, params, sink);
@@ -401,6 +414,14 @@ pub fn ContractWithOptions(
                 const f = self.requestKeyUpdateFn orelse return false;
                 try f(self.ptr, request, sink);
                 return true;
+            }
+
+            /// See `recordSizeLimitsFn`. The default is "neither side
+            /// constrained the other", which is exactly a connection where
+            /// the extension never appeared.
+            pub fn recordSizeLimits(self: Backend) record_size.Limits {
+                if (self.recordSizeLimitsFn) |f| return f(self.ptr);
+                return .{};
             }
 
             pub fn deinit(self: Backend) void {

--- a/tests/tls_interop_matrix.zig
+++ b/tests/tls_interop_matrix.zig
@@ -150,6 +150,10 @@ pub const Config = struct {
     alpn_len: usize = 0,
     require_sni: bool = false,
     allow_absent_alpn: bool = false,
+    /// #359: the RFC 8449 `record_size_limit` this side advertises. Null
+    /// leaves `tls_policy.Policy`'s own default (the protocol maximum), which
+    /// is what every row that is not about record sizing wants.
+    record_size_limit: ?u16 = null,
 
     pub fn addCipherSuite(self: *Config, name: []const u8) ParseError!void {
         try self.cipher_suites.append(try parseCipherSuite(name));
@@ -195,6 +199,7 @@ pub const Config = struct {
         }, self.alpnProtocols(default_alpns));
         result.require_sni = self.require_sni;
         result.allow_absent_alpn = self.allow_absent_alpn;
+        if (self.record_size_limit) |limit| result.record_size_limit = limit;
         return result;
     }
 

--- a/tests/tls_interop_tool.zig
+++ b/tests/tls_interop_tool.zig
@@ -122,6 +122,24 @@ const Args = struct {
     /// this many times by the end of the exchange -- i.e. to have processed
     /// that many `KeyUpdate` messages from the peer.
     expect_key_updates: u64 = 0,
+    /// #359: require the peer to have advertised exactly this
+    /// `record_size_limit`. Proves the extension actually round-tripped,
+    /// rather than the row passing because both sides quietly ignored it.
+    expect_peer_record_size_limit: ?u16 = null,
+    /// #359: require every protected record this side sealed to have carried a
+    /// `TLSInnerPlaintext` no larger than this. Held against the peer's
+    /// advertised bound, this is what proves records were *bounded* rather
+    /// than merely that a handshake completed.
+    expect_max_record_bytes: ?u32 = null,
+    /// #359: require this side to have sealed at least this many protected
+    /// records. With a payload larger than the peer's limit, this is what
+    /// proves the payload was actually *fragmented* across records.
+    expect_min_records_sent: u64 = 0,
+    /// #359: require every protected record the *peer* sent to have carried a
+    /// `TLSInnerPlaintext` no larger than this. Held against our own
+    /// advertisement, this proves the peer honored the limit we asked for --
+    /// the half of RFC 8449 that a send-side assertion cannot reach.
+    expect_max_received_record_bytes: ?u32 = null,
 
     const Identity = struct {
         pattern: []const u8,
@@ -165,6 +183,11 @@ const usage =
     \\  --expect-peer-close clean|truncated
     \\  --key-update not-requested|requested   send one post-handshake KeyUpdate
     \\  --expect-key-updates N                 require N received KeyUpdates
+    \\  --record-size-limit N                  advertise RFC 8449 extension 28
+    \\  --expect-peer-record-size-limit N      require the peer to advertise N
+    \\  --expect-max-record-bytes N            no sealed inner plaintext above N
+    \\  --expect-min-records-sent N            at least N protected records sealed
+    \\  --expect-max-received-record-bytes N   no record from the peer above N
     \\  --transcript PATH             secret-free transcript + failure fixture
     \\  --verbose
     \\
@@ -278,6 +301,16 @@ fn parseArgs(allocator: std.mem.Allocator, init_args: std.process.Args) !?Args {
                 .update_requested
             else
                 return error.UnknownKeyUpdateRequest;
+        } else if (std.mem.eql(u8, arg, "--record-size-limit")) {
+            args.config.record_size_limit = try std.fmt.parseInt(u16, it.next() orelse return error.MissingValue, 10);
+        } else if (std.mem.eql(u8, arg, "--expect-peer-record-size-limit")) {
+            args.expect_peer_record_size_limit = try std.fmt.parseInt(u16, it.next() orelse return error.MissingValue, 10);
+        } else if (std.mem.eql(u8, arg, "--expect-max-record-bytes")) {
+            args.expect_max_record_bytes = try std.fmt.parseInt(u32, it.next() orelse return error.MissingValue, 10);
+        } else if (std.mem.eql(u8, arg, "--expect-min-records-sent")) {
+            args.expect_min_records_sent = try std.fmt.parseInt(u64, it.next() orelse return error.MissingValue, 10);
+        } else if (std.mem.eql(u8, arg, "--expect-max-received-record-bytes")) {
+            args.expect_max_received_record_bytes = try std.fmt.parseInt(u32, it.next() orelse return error.MissingValue, 10);
         } else if (std.mem.eql(u8, arg, "--expect-key-updates")) {
             args.expect_key_updates = try std.fmt.parseInt(u64, it.next() orelse return error.MissingValue, 10);
         } else {
@@ -561,6 +594,15 @@ const Outcome = struct {
     /// A peer `close_notify` observed by the record stream. Abrupt EOF without
     /// `close_notify` is reported separately as `error.TruncatedStream`.
     peer_closed: bool = false,
+    /// #359: the negotiated RFC 8449 state and what this side actually did
+    /// with it -- the peer's advertised bound, our own enforceable one, the
+    /// largest inner plaintext we sealed, and how many protected records we
+    /// sent.
+    peer_record_size_limit: ?u16 = null,
+    local_record_size_limit: u16 = 0,
+    max_sent_record_bytes: u32 = 0,
+    max_received_record_bytes: u32 = 0,
+    protected_records_sent: u64 = 0,
 };
 
 /// The alert that characterises this run's failure, whichever side produced
@@ -866,6 +908,13 @@ const Runner = struct {
         outcome.certificate = stream.certificateState();
         outcome.peer_alert = stream.peerAlert();
         outcome.peer_closed = stream.readiness().peer_closed;
+        const record_size_limits = stream.recordSizeLimits();
+        const record_size_counters = stream.recordSizeCounters();
+        outcome.peer_record_size_limit = record_size_limits.peer;
+        outcome.local_record_size_limit = record_size_limits.local;
+        outcome.max_sent_record_bytes = record_size_counters.max_sent_inner_len;
+        outcome.max_received_record_bytes = record_size_counters.max_recv_inner_len;
+        outcome.protected_records_sent = record_size_counters.protected_records_sent;
         if (outcome.handshake_complete) {
             outcome.cipher_suite = backend.negotiated_cipher_suite;
             outcome.named_group = backend.negotiated_named_group;
@@ -1016,6 +1065,15 @@ fn writeTranscript(path: []const u8, args: Args, outcome: Outcome, transcript: *
     report.print("peer_close: {s}\n", .{if (outcome.peer_closed) "clean" else "none"});
     report.print("key_updates.sent: {d}\n", .{outcome.key_updates_written});
     report.print("key_updates.received: {d}\n", .{outcome.key_updates_read});
+    report.print("record_size_limit.local: {d}\n", .{outcome.local_record_size_limit});
+    if (outcome.peer_record_size_limit) |limit| {
+        report.print("record_size_limit.peer: {d}\n", .{limit});
+    } else {
+        report.print("record_size_limit.peer: absent\n", .{});
+    }
+    report.print("records.sent: {d}\n", .{outcome.protected_records_sent});
+    report.print("records.max_inner_bytes: {d}\n", .{outcome.max_sent_record_bytes});
+    report.print("records.max_received_inner_bytes: {d}\n", .{outcome.max_received_record_bytes});
     if (outcome.failure) |err| report.print("failure: {s}\n", .{@errorName(err)});
     if (outcome.emitted_alert) |desc| report.print("alert.local: {s}\n", .{@tagName(desc)});
     if (outcome.peer_alert) |desc| report.print("alert.peer: {s}\n", .{@tagName(desc)});
@@ -1114,6 +1172,50 @@ fn evaluate(args: Args, outcome: Outcome) u8 {
         std.debug.print("tls-interop: expected at least {d} KeyUpdate(s) from the peer but observed {d}\n", .{
             args.expect_key_updates,
             outcome.key_updates_read,
+        });
+        failed = true;
+    }
+
+    if (args.expect_peer_record_size_limit) |expected| {
+        if (outcome.peer_record_size_limit == null or outcome.peer_record_size_limit.? != expected) {
+            std.debug.print("tls-interop: expected the peer to advertise record_size_limit={d} but observed {?d}\n", .{
+                expected,
+                outcome.peer_record_size_limit,
+            });
+            failed = true;
+        }
+    }
+    if (args.expect_max_record_bytes) |limit| {
+        if (outcome.max_sent_record_bytes > limit) {
+            std.debug.print("tls-interop: sealed a {d}-byte inner plaintext, above the {d}-byte bound\n", .{
+                outcome.max_sent_record_bytes,
+                limit,
+            });
+            failed = true;
+        }
+        // A row that pins a bound but sent nothing would pass vacuously.
+        if (outcome.max_sent_record_bytes == 0) {
+            std.debug.print("tls-interop: no protected record was sealed, so the {d}-byte bound proves nothing\n", .{limit});
+            failed = true;
+        }
+    }
+    if (args.expect_max_received_record_bytes) |limit| {
+        if (outcome.max_received_record_bytes > limit) {
+            std.debug.print("tls-interop: the peer sent a {d}-byte inner plaintext, above the {d} we advertised\n", .{
+                outcome.max_received_record_bytes,
+                limit,
+            });
+            failed = true;
+        }
+        if (outcome.max_received_record_bytes == 0) {
+            std.debug.print("tls-interop: no protected record arrived, so the {d}-byte bound proves nothing\n", .{limit});
+            failed = true;
+        }
+    }
+    if (outcome.protected_records_sent < args.expect_min_records_sent) {
+        std.debug.print("tls-interop: expected at least {d} protected record(s) but sealed {d}\n", .{
+            args.expect_min_records_sent,
+            outcome.protected_records_sent,
         });
         failed = true;
     }


### PR DESCRIPTION
## Summary

Implements RFC 8449's `record_size_limit` extension on the native TLS record transport, plus a local, bounded RFC 8446 §5.4 padding policy. New module: [record_size.zig](src/tls/record_size.zig) owns the wire form, the range rules, and the sizing/padding arithmetic — no I/O, no keys.

**Negotiated sizing.** Each side advertises the largest `TLSInnerPlaintext` it will *receive*. Client offers in ClientHello (identically positioned in CH1 and CH2 so the HRR "legal mutation" check still passes); server answers in EncryptedExtensions on both the full and PSK-resumed flights.

- Outbound: application data, handshake fragments, and post-handshake messages are all sized from `Bridge.outboundContentMax()`. Sealing past it fails closed with `RecordSizeLimitExceeded` rather than silently truncating.
- Inbound: a record whose inner plaintext exceeds our own advertisement is refused **before** the AEAD open — the point of the bound is to cap the work an unauthenticated peer can cause — and maps to `record_overflow` (newly added to `AlertDescription`).
- Default is the TLS 1.3 protocol maximum (`policy.Policy.record_size_limit`), so the extension is offered but constrains nothing until an operator lowers it. Peers that omit it mean "protocol maximum", per the RFC.
- Out-of-range handling follows RFC 8449 §4's asymmetry exactly: `< 64` is `illegal_parameter` for both roles; above the maximum a **server clamps** (a client may be advertising a size a future version enables) and a **client rejects** (the version is already settled).
- Unprotected records stay exempt. TLS-over-QUIC has no TLS records and neither offers nor accepts the extension (`unsupported_extension`); the extension ID is also reserved against transport-profile collision.

**Padding.** `PureZigRecordStream.setRecordPadding` rounds each application record's inner plaintext up to a block boundary so length no longer reveals content length. Off by default; never applied to handshake or alert records; clamped by the negotiated limit rather than the reverse, so it can never push a record past what the peer accepts — including an already-at-cap record, which gets none.

**Observability.** `recordSizeLimits()` and `recordSizeCounters()` report the negotiated state and the effects (peer-limited writes, padded records, padding bytes, oversize records rejected).

**Docs.** [TLS_RECORD_TRANSPORT.md](docs/TLS_RECORD_TRANSPORT.md) gains a section separating privacy padding from the negotiated bound, and states explicitly that neither is record coalescing (not implemented; `writePlaintext` seals exactly what it accepts). [TLS_INTEROP_MATRIX.md](docs/TLS_INTEROP_MATRIX.md) records why there is no interop row — traced against OpenSSL 3.6.2, it does not implement RFC 8449 in either role, so the positive rows cover the "peer omits the extension" path instead.

### Goldens repinned

The record-profile transcript goldens and the #485 HRR KAT moved: both ClientHellos now carry the new extension, so every transcript-derived secret below them legitimately changed. The **extension-profile goldens are untouched**, which is exactly the property that test exists to hold. Both call sites carry a comment explaining the repin.

## Test plan

- [x] `zig build test` — full suite green
- [x] `zig fmt --check build.zig src/ tests/`
- [x] `zig build test-tls-record-fuzz`, `zig build test-quic`
- [x] `record_size.zig`: decode round-trip, 2-byte framing, `< 64` for both roles, clamp-vs-reject above max, exhaustive proof that `content + type + padding <= cap` across every block size × content length × cap
- [x] `record_epoch_bridge.zig`: boundary and off-by-one on both send and receive, read sequence unmoved by a pre-AEAD rejection, handshake flight fragmenting at the negotiated limit, padding bounded at the cap, at-capacity record gets no padding, config validation
- [x] `tls13_backend.zig` / `tls13_backend_tests.zig`: ClientHello carries a well-formed advertisement, QUIC profile does not, client accepts both boundaries and rejects out-of-range and mis-framed bodies, server clamps above-max and rejects below-min, absent advertisement, QUIC server rejects the extension, end-to-end negotiation of two distinct limits
- [x] `encrypted_stream.zig`: driver-owned handshake caps every write at the peer's limit and the peer accepts all of them, padding round-trips within the cap, oversize inbound fails with `record_overflow`
- [x] `zig build test-integration` — one pre-existing failure (`reload while serving short static requests…`, #170), confirmed identical on the base commit `fada721c` and unrelated to TLS

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)