### PR TITLE
Wire H3 qlog events and QPACK metrics

### DIFF
--- a/docs/QUIC_QLOG.md
+++ b/docs/QUIC_QLOG.md
@@ -112,19 +112,19 @@ Names below are `namespace:event`. Transport events (`src/quic/qlog.zig`):
 
 | Requirement (#255)        | qlog event                          | Key data |
 |---------------------------|-------------------------------------|----------|
-| handshake                 | `quic:connection_started`           | odcid/scid/dcid lengths |
+| handshake                 | `quic:connection_started`           | required `local` / `remote` endpoint objects, plus Tardigrade CID-length diagnostics |
 |                           | `tardigrade:quic_handshake_progressed` | `stage` (started -> confirmed / failed) |
 |                           | `quic:connection_closed`            | `reason`, optional `error_code` |
-|                           | `quic:key_updated`                  | `key_phase` |
-| packet sent               | `quic:packet_sent`                  | type, number, length, ack-eliciting |
-| packet received           | `quic:packet_received`              | type, number, length |
-| packet lost               | `quic:packet_lost`                  | type, number |
+|                           | `quic:key_updated`                  | required `key_type`, optional full `key_phase` and `trigger` |
+| packet sent               | `quic:packet_sent`                  | `header`, `raw`, Tardigrade ack-eliciting diagnostic |
+| packet received           | `quic:packet_received`              | `header`, `raw` |
+| packet lost               | `quic:packet_lost`                  | `header` |
 | recovery metrics          | `quic:recovery_metrics_updated`     | RTT/PTO/cwnd/bytes-in-flight updates |
 | **deprotection failure**  | `quic:packet_dropped`               | `trigger:"decryption_failure"` |
 | PATH_CHALLENGE/RESPONSE   | `tardigrade:quic_path_validation`   | `phase` (challenge/response sent/received, validated, failed) |
-| migration                 | `quic:migration_state_updated`      | `trigger` (nat_rebinding/active), `state` (accepted/blocked) |
+| migration                 | `quic:migration_state_updated`      | required `new` migration state, optional `old` |
 | stream reset              | `tardigrade:quic_stream_reset`      | `direction` (reset/stop-sending, sent/received), stream id, error code |
-| flow-control blocked      | `quic:connection_data_blocked_updated` / `quic:stream_data_blocked_updated` | optional stream id, limit |
+| flow-control blocked      | `quic:connection_data_blocked_updated` / `quic:stream_data_blocked_updated` | required `new` blocked state, optional `old` / `reason`; stream variant requires `stream_id` |
 
 Application events (`src/http3/qlog.zig`):
 
@@ -132,13 +132,13 @@ Application events (`src/http3/qlog.zig`):
 |---------------------------|-------------------------------------|----------|
 | SETTINGS                  | `http3:parameters_set`              | max field section size, QPACK table cap, blocked streams |
 | control stream            | `http3:stream_type_set`             | stream id, stream type |
-| HEADERS / DATA / GOAWAY   | `http3:frame_created` / `http3:frame_parsed` | frame type, stream id, raw length |
+| HEADERS / DATA / GOAWAY   | `http3:frame_created` / `http3:frame_parsed` | variant-specific frame payloads; HEADERS carries `headers`, SETTINGS carries `settings`, GOAWAY carries `id` |
 | **QPACK blocked**         | `tardigrade:qpack_stream_state_updated` | `state` (blocked/unblocked), stream id |
 
 `quic:packet_dropped` with `trigger:"decryption_failure"` is the
 canonical qlog encoding of an AEAD deprotection failure, satisfying the #255
 requirement that deprotection failures are reported deterministically. It is
-distinct from a normal drop (`unknown_connection_id`, `key_unavailable`, …).
+distinct from a normal drop (`connection_unknown`, `key_unavailable`, ...).
 
 ### Serialization format
 
@@ -158,11 +158,13 @@ Each record is one JSON-SEQ line:
   `file_schema: urn:ietf:params:qlog:file:sequential`,
   `serialization_format: application/qlog+json-seq`, `trace`,
   `event_schemas`, vantage point, and ODCID `group_id` as the first JSON-SEQ
-  record. The header spans both packages — the `group_id` ties transport and
+  record. The trace declares `clock_type: monotonic` and `epoch: unknown`
+  because event timestamps are monotonic process-relative values, not Unix
+  timestamps. The header spans both packages — the `group_id` ties transport and
   H3 events to one connection — so the **composition root** fills it in and
   writes it once, then appends event records from both `quic` and `http3`. The
   `tests/quic_h3_smoke.zig` harness exercises exactly this shape (header +
-  transport record + H3 record) so the merged-file contract is locked.
+  representative QUIC/H3 records) so the merged-file contract is locked.
 - JSON-SEQ qlog artifacts use the `.sqlog` suffix. Reserve `.qlog` for the
   normal contained JSON qlog form.
 

--- a/docs/QUIC_QLOG.md
+++ b/docs/QUIC_QLOG.md
@@ -22,7 +22,7 @@ layering, and the safety rules up front so those call-sites are mechanical.
   from a captured trace, not just from ad-hoc `std.log` lines.
 - Provide the primitives (trace-header + event-line + keylog-line writers) so
   that, once the composition root assembles them, the interop/failure harnesses
-  (#247) save `*.qlog` / `*.keys` artifacts that qvis / Wireshark consume
+  (#247) save `*.sqlog` / `*.keys` artifacts that qvis / Wireshark consume
   directly. This PR ships those writers and the merged-shape test; the root
   wiring that emits real flows is follow-up.
 - Keep everything **off by default** and cheap when off.
@@ -43,7 +43,7 @@ respects that boundary rather than punching through it.
 ```
                  composition root (gateway h3 listener / smoke harness)
                  ┌───────────────────────────────────────────────────┐
-                 │  owns the *.qlog file + *.keys file writers        │
+                 │  owns the *.sqlog file + *.keys file writers       │
                  │  installs one quic.qlog.Sink, one http3.qlog.Sink, │
                  │  one quic.keylog.Sink; interleaves all three       │
                  └───────────────▲───────────────▲───────────────▲────┘
@@ -67,7 +67,7 @@ Rules:
    `Sink{}` is a no-op, so the seam costs nothing until a root wires it.
 4. The **concrete file writers** live at the composition root, which already
    owns both packages. It timestamps and interleaves the streams into one
-   JSON-SEQ `.qlog` file, so a single trace still shows transport and H3 events
+   JSON-SEQ `.sqlog` file, so a single trace still shows transport and H3 events
    side by side without either package depending on the other.
 
 This is why there is no single shared "qlog writer" module: sharing one would
@@ -89,32 +89,53 @@ into one valid file at the root instead.
 
 ## qlog event catalogue
 
-Names below are `category:event`. Transport events (`src/quic/qlog.zig`):
+The qlog scaffold tracks the July 2026 submitted drafts:
+
+- `draft-ietf-quic-qlog-main-schema-14`
+- `draft-ietf-quic-qlog-quic-events-13`
+- `draft-ietf-quic-qlog-h3-events-13`
+
+Because these are still drafts, the sequential trace header declares
+draft-qualified event schema URIs:
+
+- `urn:ietf:params:qlog:events:quic-13`
+- `urn:ietf:params:qlog:events:http3-13`
+- `https://bare.systems/tardigrade/qlog/events/debug-1`
+
+The Tardigrade URI covers debug events that are useful for #255 but are not
+standardized qlog events. Most importantly, current HTTP/3 qlog no longer
+standardizes QPACK events, so QPACK blocked-stream visibility is either a
+Prometheus/structured diagnostic signal or the explicit
+`tardigrade:qpack_stream_state_updated` extension below.
+
+Names below are `namespace:event`. Transport events (`src/quic/qlog.zig`):
 
 | Requirement (#255)        | qlog event                          | Key data |
 |---------------------------|-------------------------------------|----------|
-| handshake                 | `connectivity:connection_started`   | odcid/scid/dcid lengths |
-|                           | `connectivity:handshake`            | `stage` (started → confirmed / failed) |
-|                           | `connectivity:connection_closed`    | `reason`, optional `error_code` |
-|                           | `security:key_updated`              | `key_phase` |
-| packet sent               | `transport:packet_sent`             | type, number, length, ack-eliciting |
-| packet received           | `transport:packet_received`         | type, number, length |
-| packet lost               | `recovery:packet_lost`              | type, number, bytes-in-flight, cwnd |
-| **deprotection failure**  | `transport:packet_dropped`          | `trigger:"payload_decrypt_error"` |
-| PATH_CHALLENGE/RESPONSE   | `transport:path_validation`         | `phase` (challenge/response sent/received, validated, failed) |
-| migration                 | `connectivity:connection_migrated`  | `kind` (nat_rebinding/active), `outcome` (accepted/blocked) |
-| stream reset              | `transport:stream_reset`            | `direction` (reset/stop-sending, sent/received), stream id, error code |
-| flow-control blocked      | `transport:data_blocked`            | `scope` (connection/stream), optional stream id, limit |
+| handshake                 | `quic:connection_started`           | odcid/scid/dcid lengths |
+|                           | `tardigrade:quic_handshake_progressed` | `stage` (started -> confirmed / failed) |
+|                           | `quic:connection_closed`            | `reason`, optional `error_code` |
+|                           | `quic:key_updated`                  | `key_phase` |
+| packet sent               | `quic:packet_sent`                  | type, number, length, ack-eliciting |
+| packet received           | `quic:packet_received`              | type, number, length |
+| packet lost               | `quic:packet_lost`                  | type, number |
+| recovery metrics          | `quic:recovery_metrics_updated`     | RTT/PTO/cwnd/bytes-in-flight updates |
+| **deprotection failure**  | `quic:packet_dropped`               | `trigger:"decryption_failure"` |
+| PATH_CHALLENGE/RESPONSE   | `tardigrade:quic_path_validation`   | `phase` (challenge/response sent/received, validated, failed) |
+| migration                 | `quic:migration_state_updated`      | `trigger` (nat_rebinding/active), `state` (accepted/blocked) |
+| stream reset              | `tardigrade:quic_stream_reset`      | `direction` (reset/stop-sending, sent/received), stream id, error code |
+| flow-control blocked      | `quic:connection_data_blocked_updated` / `quic:stream_data_blocked_updated` | optional stream id, limit |
 
 Application events (`src/http3/qlog.zig`):
 
 | Requirement (#255)        | qlog event                          | Key data |
 |---------------------------|-------------------------------------|----------|
-| SETTINGS                  | `http:parameters_set`               | max field section size, QPACK table cap, blocked streams |
-| control stream / HEADERS / DATA / GOAWAY | `http:frame_created` / `http:frame_parsed` | frame type, stream id, length |
-| **QPACK blocked**         | `qpack:stream_state_updated`        | `state` (blocked/unblocked), stream id |
+| SETTINGS                  | `http3:parameters_set`              | max field section size, QPACK table cap, blocked streams |
+| control stream            | `http3:stream_type_set`             | stream id, stream type |
+| HEADERS / DATA / GOAWAY   | `http3:frame_created` / `http3:frame_parsed` | frame type, stream id, raw length |
+| **QPACK blocked**         | `tardigrade:qpack_stream_state_updated` | `state` (blocked/unblocked), stream id |
 
-`transport:packet_dropped` with `trigger:"payload_decrypt_error"` is the
+`quic:packet_dropped` with `trigger:"decryption_failure"` is the
 canonical qlog encoding of an AEAD deprotection failure, satisfying the #255
 requirement that deprotection failures are reported deterministically. It is
 distinct from a normal drop (`unknown_connection_id`, `key_unavailable`, …).
@@ -124,7 +145,7 @@ distinct from a normal drop (`unknown_connection_id`, `key_unavailable`, …).
 Each record is one JSON-SEQ line:
 
 ```
-0x1E {"time":<ms>.<us>,"name":"transport:packet_sent","data":{ … }}\n
+0x1E {"time":<ms>.<us>,"name":"quic:packet_sent","data":{ ... }}\n
 ```
 
 - Time is milliseconds (qlog's default `time_units`) with microsecond
@@ -132,14 +153,18 @@ Each record is one JSON-SEQ line:
 - Writers are **allocation-free**: they format into a caller-owned buffer
   (`writeJson(record, buf)`), matching the bounded-buffer style already used by
   the TLS handshake wire writer. A 512-byte buffer covers every event.
-- A qlog file is a trace header followed by these event lines.
-  `qlog.writeTraceHeader(header, buf)` serializes that header (qlog version,
-  vantage point, `reference_time`, and ODCID `group_id`) as the first JSON-SEQ
+- A qlog file is a `QlogFileSeq` header followed by event lines.
+  `qlog.writeTraceHeader(header, buf)` serializes the
+  `file_schema: urn:ietf:params:qlog:file:sequential`,
+  `serialization_format: application/qlog+json-seq`, `trace`,
+  `event_schemas`, vantage point, and ODCID `group_id` as the first JSON-SEQ
   record. The header spans both packages — the `group_id` ties transport and
   H3 events to one connection — so the **composition root** fills it in and
   writes it once, then appends event records from both `quic` and `http3`. The
   `tests/quic_h3_smoke.zig` harness exercises exactly this shape (header +
   transport record + H3 record) so the merged-file contract is locked.
+- JSON-SEQ qlog artifacts use the `.sqlog` suffix. Reserve `.qlog` for the
+  normal contained JSON qlog form.
 
 ### Sink error handling
 
@@ -186,7 +211,7 @@ capture can decrypt the entire connection.
   authorized to decrypt.
 - The adapter otherwise wipes these secrets (`SecretStore.wipe`); the key log is
   the only path by which they leave the process.
-- Artifacts the harness saves (`*.qlog`, `*.keys`) inherit this: store them with
+- Artifacts the harness saves (`*.sqlog`, `*.keys`) inherit this: store them with
   the capture, scrub them from CI logs, and never attach them to public issues.
 
 ## Configuration
@@ -232,9 +257,9 @@ counters they read from already exist.
   for representative transport events, QPACK blocking, and keylog line format,
   in `src/quic/qlog.zig`, `src/http3/qlog.zig`, `src/quic/keylog.zig`.
 - **Integration** (follow-up, with the connection layer): drive a handshake and
-  assert a produced `.qlog` contains the expected event classes; snapshot
+  assert a produced `.sqlog` contains the expected event classes; snapshot
   metrics on common error paths.
-- **Manual**: load a saved `.qlog` in qvis and a capture + `.keys` in Wireshark
+- **Manual**: load a saved `.sqlog` in qvis and a capture + `.keys` in Wireshark
   once enough transport exists to produce real flows.
 
 ## References

--- a/docs/QUIC_QLOG.md
+++ b/docs/QUIC_QLOG.md
@@ -114,10 +114,10 @@ Names below are `namespace:event`. Transport events (`src/quic/qlog.zig`):
 |---------------------------|-------------------------------------|----------|
 | handshake                 | `quic:connection_started`           | required `local` / `remote` endpoint objects, plus Tardigrade CID-length diagnostics |
 |                           | `tardigrade:quic_handshake_progressed` | `stage` (started -> confirmed / failed) |
-|                           | `quic:connection_closed`            | `reason`, optional unknown connection/application error category plus `error_code` |
+|                           | `quic:connection_closed`            | standard `trigger`, optional unknown connection/application error category plus `error_code` |
 |                           | `quic:key_updated`                  | required `key_type`, optional full `key_phase` and `trigger` |
-| packet sent               | `quic:packet_sent`                  | `header`, `raw`, Tardigrade ack-eliciting diagnostic |
-| packet received           | `quic:packet_received`              | `header`, `raw` |
+| packet sent               | `quic:packet_sent`                  | `header` with packet number only for numbered packet types, `raw`, Tardigrade ack-eliciting diagnostic |
+| packet received           | `quic:packet_received`              | `header` with packet number only for numbered packet types, `raw` |
 | packet lost               | `quic:packet_lost`                  | `header` |
 | recovery metrics          | `quic:recovery_metrics_updated`     | RTT/PTO/cwnd/bytes-in-flight updates |
 | **deprotection failure**  | `quic:packet_dropped`               | `trigger:"decryption_failure"` |

--- a/docs/QUIC_QLOG.md
+++ b/docs/QUIC_QLOG.md
@@ -59,9 +59,9 @@ Rules:
 1. **Transport-vantage events** (`connectivity`, `security`, `transport`,
    `recovery` qlog categories) are defined in `src/quic/qlog.zig` and emitted
    from the transport layers. `src/quic` imports no HTTP/3 type.
-2. **Application-vantage events** (`http`, `qpack` categories) are defined in
-   `src/http3/qlog.zig` and emitted from `src/http3`. `src/http3` imports no
-   transport type.
+2. **Application-vantage events** (`http3` plus documented Tardigrade QPACK
+   diagnostics) are defined in `src/http3/qlog.zig` and emitted from
+   `src/http3`. `src/http3` imports no transport type.
 3. Both packages emit through an **injected `Sink`** — an opaque context plus a
    function pointer, exactly like the existing `recovery.EventSink`. A default
    `Sink{}` is a no-op, so the seam costs nothing until a root wires it.
@@ -130,7 +130,7 @@ Application events (`src/http3/qlog.zig`):
 
 | Requirement (#255)        | qlog event                          | Key data |
 |---------------------------|-------------------------------------|----------|
-| SETTINGS                  | `http3:parameters_set`              | max field section size, QPACK table cap, blocked streams |
+| SETTINGS                  | `http3:parameters_set`              | max field section size, QPACK table cap, blocked streams, extended CONNECT, H3 datagram |
 | control stream            | `http3:stream_type_set`             | stream id, stream type |
 | HEADERS / DATA / GOAWAY   | `http3:frame_created` / `http3:frame_parsed` | variant-specific frame payloads; HEADERS carries escaped `headers`, SETTINGS carries typed lower-case qlog `settings`, GOAWAY carries `id` |
 | **QPACK blocked**         | `tardigrade:qpack_stream_state_updated` | `state` (blocked/unblocked), stream id |
@@ -259,6 +259,13 @@ are the source. The gateway `/status/metrics` endpoint (see
 Labels are kept low-cardinality (e.g. `stage`, not per-client) per the issue's
 non-goals. Wiring these into the gateway registry is follow-up work; the
 counters they read from already exist.
+
+Production caveat: the current native H3 connection path still uses the static
+decoder and does not compose `DynamicDecoder.decodeOrBlock()` into request
+processing. Until that changes, dynamic-QPACK blocked/table/decode metrics and
+`tardigrade:qpack_stream_state_updated` remain zero/unemitted in production; a
+zero means "dynamic decoder not composed", not "dynamic blocking was observed
+and absent."
 
 ## Testing strategy
 

--- a/docs/QUIC_QLOG.md
+++ b/docs/QUIC_QLOG.md
@@ -131,8 +131,9 @@ Application events (`src/http3/qlog.zig`):
 | Requirement (#255)        | qlog event                          | Key data |
 |---------------------------|-------------------------------------|----------|
 | SETTINGS                  | `http3:parameters_set`              | max field section size, QPACK table cap, blocked streams |
-| control stream            | `http3:stream_type_set`             | stream id, stream type |
-| HEADERS / DATA / GOAWAY   | `http3:frame_created` / `http3:frame_parsed` | variant-specific frame payloads; HEADERS carries `headers`, SETTINGS carries `settings`, GOAWAY carries `id` |
+| stream classification     | `http3:stream_type_set`             | stream id, request/control/QPACK/push/unknown stream type |
+| HEADERS / DATA / GOAWAY / PRIORITY_UPDATE | `http3:frame_created` / `http3:frame_parsed` | variant-specific frame payloads; HEADERS carries `headers`, SETTINGS carries `settings`, GOAWAY carries `id`, raw lengths live under `raw.length` |
+| priority changes          | `http3:priority_updated`            | stream id and `new` HTTP priority field value |
 | **QPACK blocked**         | `tardigrade:qpack_stream_state_updated` | `state` (blocked/unblocked), stream id |
 
 `quic:packet_dropped` with `trigger:"decryption_failure"` is the

--- a/docs/QUIC_QLOG.md
+++ b/docs/QUIC_QLOG.md
@@ -135,6 +135,17 @@ Application events (`src/http3/qlog.zig`):
 | HEADERS / DATA / GOAWAY   | `http3:frame_created` / `http3:frame_parsed` | variant-specific frame payloads; HEADERS carries escaped `headers`, SETTINGS carries typed lower-case qlog `settings`, GOAWAY carries `id` |
 | **QPACK blocked**         | `tardigrade:qpack_stream_state_updated` | `state` (blocked/unblocked), stream id |
 
+For HEADERS and PUSH_PROMISE, the H3 observer uses the current static/bounded
+QPACK decoder only as a best-effort diagnostic helper. If that helper rejects a
+field section, the trace retains the real `frame_type` but uses the custom
+`tardigrade_qpack_decode_failed: true` and
+`tardigrade_qpack_decode_reason: "diagnostic_decoder_rejected"` fields instead
+of asserting `tardigrade_malformed_payload`. This distinction is intentional:
+the decode failure can be caused by valid dynamic-table input or local
+diagnostic bounds, so it is not evidence that the peer sent malformed wire.
+Non-QPACK known-frame payloads that are structurally invalid continue to use
+the `tardigrade_malformed_payload` diagnostic.
+
 `quic:packet_dropped` with `trigger:"decryption_failure"` is the
 canonical qlog encoding of an AEAD deprotection failure, satisfying the #255
 requirement that deprotection failures are reported deterministically. It is

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -1278,8 +1278,8 @@ pub const Runtime = struct {
                 .max_field_section_size = parameters.settings.max_field_section_size,
                 .max_table_capacity = if (parameters.settings.qpack_max_table_capacity == 0) null else parameters.settings.qpack_max_table_capacity,
                 .blocked_streams_count = if (parameters.settings.qpack_blocked_streams == 0) null else parameters.settings.qpack_blocked_streams,
-                .extended_connect = if (parameters.settings.enable_connect_protocol) true else null,
-                .h3_datagram = if (parameters.settings.h3_datagram) true else null,
+                .extended_connect = if (parameters.settings.enable_connect_protocol) 1 else null,
+                .h3_datagram = if (parameters.settings.h3_datagram) 1 else null,
             } },
             .stream_type_set => |stream| .{ .stream_type_set = .{
                 .stream_id = stream.stream_id,
@@ -1316,6 +1316,25 @@ pub const Runtime = struct {
             .cancel_push => |c| .{ .cancel_push = .{ .push_id = c.push_id, .raw_length = c.raw_length } },
             .max_push_id => |m| .{ .max_push_id = .{ .push_id = m.push_id, .raw_length = m.raw_length } },
             .unknown => |u| .{ .unknown = .{ .frame_type_bytes = u.frame_type_value, .raw_length = u.raw_length } },
+            .malformed => |m| .{ .malformed = .{
+                .frame_type = h3FrameTypeToQlog(m.frame_type),
+                .frame_type_bytes = m.frame_type_value,
+                .raw_length = m.raw_length,
+            } },
+        };
+    }
+
+    fn h3FrameTypeToQlog(typ: http3.frame.FrameType) http3.qlog.FrameType {
+        return switch (typ) {
+            .data => .data,
+            .headers => .headers,
+            .settings => .settings,
+            .goaway => .goaway,
+            .priority_update_request, .priority_update_push => .priority_update,
+            .push_promise => .push_promise,
+            .cancel_push => .cancel_push,
+            .max_push_id => .max_push_id,
+            .unknown => .unknown,
         };
     }
 

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -1278,6 +1278,8 @@ pub const Runtime = struct {
                 .max_field_section_size = parameters.settings.max_field_section_size,
                 .max_table_capacity = if (parameters.settings.qpack_max_table_capacity == 0) null else parameters.settings.qpack_max_table_capacity,
                 .blocked_streams_count = if (parameters.settings.qpack_blocked_streams == 0) null else parameters.settings.qpack_blocked_streams,
+                .extended_connect = if (parameters.settings.enable_connect_protocol) true else null,
+                .h3_datagram = if (parameters.settings.h3_datagram) true else null,
             } },
             .stream_type_set => |stream| .{ .stream_type_set = .{
                 .stream_id = stream.stream_id,
@@ -1304,7 +1306,7 @@ pub const Runtime = struct {
         return switch (event_frame) {
             .data => |d| .{ .data = .{ .raw_length = d.raw_length } },
             .headers => |h| .{ .headers = .{ .headers = h.fields, .raw_length = h.raw_length } },
-            .settings => |s| .{ .settings = .{ .settings = s.settings, .raw_length = s.raw_length } },
+            .settings => |s| .{ .settings = .{ .settings = @ptrCast(s.entries), .raw_length = s.raw_length } },
             .goaway => |g| .{ .goaway = .{ .id = g.id, .raw_length = g.raw_length } },
             .priority_update => |update| .{ .priority_update = switch (update) {
                 .request => |r| .{ .request = .{ .stream_id = r.stream_id, .priority_field_value = r.field_value, .raw_length = r.raw_length } },
@@ -1313,6 +1315,7 @@ pub const Runtime = struct {
             .push_promise => |p| .{ .push_promise = .{ .push_id = p.push_id, .raw_length = p.raw_length } },
             .cancel_push => |c| .{ .cancel_push = .{ .push_id = c.push_id, .raw_length = c.raw_length } },
             .max_push_id => |m| .{ .max_push_id = .{ .push_id = m.push_id, .raw_length = m.raw_length } },
+            .unknown => |u| .{ .unknown = .{ .frame_type_bytes = u.frame_type_value, .raw_length = u.raw_length } },
         };
     }
 
@@ -1699,6 +1702,7 @@ const H3QlogRecorder = struct {
     records: std.ArrayList(http3.qlog.Record) = .empty,
 
     fn deinit(self: *H3QlogRecorder, allocator: std.mem.Allocator) void {
+        for (self.records.items) |record| freeRecord(allocator, record);
         self.records.deinit(allocator);
     }
 
@@ -1708,7 +1712,74 @@ const H3QlogRecorder = struct {
 
     fn emit(ctx: ?*anyopaque, record: http3.qlog.Record) void {
         const self: *H3QlogRecorder = @ptrCast(@alignCast(ctx.?));
-        self.records.append(testing.allocator, record) catch unreachable;
+        self.records.append(testing.allocator, cloneRecord(testing.allocator, record) catch unreachable) catch unreachable;
+    }
+
+    fn cloneFields(allocator: std.mem.Allocator, fields: []const http3.qpack.HeaderField) ![]const http3.qpack.HeaderField {
+        const copy = try allocator.alloc(http3.qpack.HeaderField, fields.len);
+        errdefer allocator.free(copy);
+        for (fields, 0..) |field, i| {
+            const name = try allocator.dupe(u8, field.name);
+            errdefer allocator.free(name);
+            const value = try allocator.dupe(u8, field.value);
+            errdefer allocator.free(value);
+            copy[i] = .{ .name = name, .value = value };
+        }
+        return copy;
+    }
+
+    fn freeFields(allocator: std.mem.Allocator, fields: []const http3.qpack.HeaderField) void {
+        for (fields) |field| {
+            allocator.free(field.name);
+            allocator.free(field.value);
+        }
+        allocator.free(fields);
+    }
+
+    fn cloneFrame(allocator: std.mem.Allocator, event_frame: http3.qlog.Frame) !http3.qlog.Frame {
+        return switch (event_frame) {
+            .headers => |h| .{ .headers = .{ .headers = try cloneFields(allocator, h.headers), .raw_length = h.raw_length } },
+            .settings => |s| .{ .settings = .{ .settings = try allocator.dupe(http3.qlog.QlogSetting, s.settings), .raw_length = s.raw_length } },
+            .priority_update => |update| .{ .priority_update = switch (update) {
+                .request => |r| .{ .request = .{
+                    .stream_id = r.stream_id,
+                    .priority_field_value = try allocator.dupe(u8, r.priority_field_value),
+                    .raw_length = r.raw_length,
+                } },
+                .push => |p| .{ .push = .{
+                    .push_id = p.push_id,
+                    .priority_field_value = try allocator.dupe(u8, p.priority_field_value),
+                    .raw_length = p.raw_length,
+                } },
+            } },
+            else => event_frame,
+        };
+    }
+
+    fn freeFrame(allocator: std.mem.Allocator, event_frame: http3.qlog.Frame) void {
+        switch (event_frame) {
+            .headers => |h| freeFields(allocator, h.headers),
+            .settings => |s| allocator.free(s.settings),
+            .priority_update => |update| switch (update) {
+                .request => |r| allocator.free(r.priority_field_value),
+                .push => |p| allocator.free(p.priority_field_value),
+            },
+            else => {},
+        }
+    }
+
+    fn cloneRecord(allocator: std.mem.Allocator, record: http3.qlog.Record) !http3.qlog.Record {
+        return .{ .time_us = record.time_us, .event = switch (record.event) {
+            .frame => |f| .{ .frame = .{ .direction = f.direction, .stream_id = f.stream_id, .frame = try cloneFrame(allocator, f.frame) } },
+            else => record.event,
+        } };
+    }
+
+    fn freeRecord(allocator: std.mem.Allocator, record: http3.qlog.Record) void {
+        switch (record.event) {
+            .frame => |f| freeFrame(allocator, f.frame),
+            else => {},
+        }
     }
 };
 
@@ -1753,13 +1824,18 @@ test "http3 runtime: H3 qlog adapter preserves typed event payloads" {
         .max_field_section_size = 4096,
         .qpack_blocked_streams = 7,
     };
+    const setting_entries = [_]http3.conn.EventSetting{
+        .{ .id_value = 0x01, .value = 128 },
+        .{ .id_value = 0x06, .value = 4096 },
+        .{ .id_value = 0x07, .value = 7 },
+    };
     const fields = [_]http3.qpack.HeaderField{
         .{ .name = ":method", .value = "GET" },
         .{ .name = ":path", .value = "/trace" },
     };
 
     Runtime.h3ConnectionEvent(&observer, .{ .parameters_set = .{ .initiator = .local, .settings = settings } });
-    Runtime.h3ConnectionEvent(&observer, .{ .frame_parsed = .{ .stream_id = 0, .frame = .{ .settings = .{ .settings = settings, .raw_length = 9 } } } });
+    Runtime.h3ConnectionEvent(&observer, .{ .frame_parsed = .{ .stream_id = 0, .frame = .{ .settings = .{ .entries = &setting_entries, .raw_length = 9 } } } });
     Runtime.h3ConnectionEvent(&observer, .{ .frame_parsed = .{ .stream_id = 4, .frame = .{ .headers = .{ .fields = &fields, .raw_length = 12 } } } });
     Runtime.h3ConnectionEvent(&observer, .{ .frame_created = .{ .stream_id = 0, .frame = .{ .goaway = .{ .id = 12, .raw_length = 2 } } } });
     Runtime.h3ConnectionEvent(&observer, .{ .frame_parsed = .{ .stream_id = 0, .frame = .{ .priority_update = .{ .request = .{ .stream_id = 8, .field_value = "u=2", .raw_length = 7 } } } } });
@@ -1777,8 +1853,10 @@ test "http3 runtime: H3 qlog adapter preserves typed event payloads" {
     switch (recorder.records.items[1].event) {
         .frame => |event| switch (event.frame) {
             .settings => |frame_event| {
-                try testing.expectEqual(@as(u64, 128), frame_event.settings.?.qpack_max_table_capacity);
-                try testing.expectEqual(@as(u64, 4096), frame_event.settings.?.max_field_section_size.?);
+                try testing.expectEqual(@as(u64, 0x01), frame_event.settings[0].id_value);
+                try testing.expectEqual(@as(u64, 128), frame_event.settings[0].value);
+                try testing.expectEqual(@as(u64, 0x06), frame_event.settings[1].id_value);
+                try testing.expectEqual(@as(u64, 4096), frame_event.settings[1].value);
                 try testing.expectEqual(@as(usize, 9), frame_event.raw_length.?);
             },
             else => return error.TestUnexpectedResult,

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -743,7 +743,9 @@ pub const Runtime = struct {
             .cid_len = parsed.dcid.len,
             .accepted_at_us = now,
         };
-        entry.h3.setEventSink(.{ .context = &entry.h3_observer, .emitFn = h3ConnectionEvent });
+        if (h3EventSinkFor(&entry.h3_observer)) |event_sink| {
+            entry.h3.setEventSink(event_sink);
+        }
 
         const cid = quic.cid.ConnectionId.init(parsed.dcid) catch {
             entry.deinit(allocator);
@@ -1268,6 +1270,11 @@ pub const Runtime = struct {
         observer.qlog_sink.log(nowUs(), h3EventToQlog(event) orelse return);
     }
 
+    fn h3EventSinkFor(observer: *ConnEntry.H3Observer) ?http3.conn.EventSink {
+        if (observer.qlog_sink.emit_fn == null) return null;
+        return .{ .context = observer, .emitFn = h3ConnectionEvent };
+    }
+
     fn h3EventToQlog(event: http3.conn.Event) ?http3.qlog.Event {
         return switch (event) {
             .parameters_set => |parameters| .{ .parameters_set = .{
@@ -1312,7 +1319,7 @@ pub const Runtime = struct {
                 .request => |r| .{ .request = .{ .stream_id = r.stream_id, .priority_field_value = r.field_value, .raw_length = r.raw_length } },
                 .push => |p| .{ .push = .{ .push_id = p.push_id, .priority_field_value = p.field_value, .raw_length = p.raw_length } },
             } },
-            .push_promise => |p| .{ .push_promise = .{ .push_id = p.push_id, .raw_length = p.raw_length } },
+            .push_promise => |p| .{ .push_promise = .{ .push_id = p.push_id, .headers = p.fields, .raw_length = p.raw_length } },
             .cancel_push => |c| .{ .cancel_push = .{ .push_id = c.push_id, .raw_length = c.raw_length } },
             .max_push_id => |m| .{ .max_push_id = .{ .push_id = m.push_id, .raw_length = m.raw_length } },
             .unknown => |u| .{ .unknown = .{ .frame_type_bytes = u.frame_type_value, .raw_length = u.raw_length } },
@@ -1771,6 +1778,11 @@ const H3QlogRecorder = struct {
                     .raw_length = p.raw_length,
                 } },
             } },
+            .push_promise => |p| .{ .push_promise = .{
+                .push_id = p.push_id,
+                .headers = try cloneFields(allocator, p.headers),
+                .raw_length = p.raw_length,
+            } },
             else => event_frame,
         };
     }
@@ -1783,6 +1795,7 @@ const H3QlogRecorder = struct {
                 .request => |r| allocator.free(r.priority_field_value),
                 .push => |p| allocator.free(p.priority_field_value),
             },
+            .push_promise => |p| freeFields(allocator, p.headers),
             else => {},
         }
     }
@@ -1828,6 +1841,24 @@ test "http3 runtime: H3 qlog events route through connection-scoped observers" {
     try testing.expectEqual(http3.qlog.Event{ .stream_type_set = .{ .stream_id = 0, .stream_type = .request } }, second.records.items[0].event);
 }
 
+test "http3 runtime: no-op H3 qlog sink does not install connection event observer" {
+    var no_op_observer = ConnEntry.H3Observer{
+        .runtime = undefined,
+        .connection_handle = 1,
+        .qlog_sink = .{},
+    };
+    try testing.expect(Runtime.h3EventSinkFor(&no_op_observer) == null);
+
+    var recorder = H3QlogRecorder{};
+    defer recorder.deinit(testing.allocator);
+    var enabled_observer = ConnEntry.H3Observer{
+        .runtime = undefined,
+        .connection_handle = 2,
+        .qlog_sink = recorder.sink(),
+    };
+    try testing.expect(Runtime.h3EventSinkFor(&enabled_observer) != null);
+}
+
 test "http3 runtime: H3 qlog adapter preserves typed event payloads" {
     var recorder = H3QlogRecorder{};
     defer recorder.deinit(testing.allocator);
@@ -1858,8 +1889,9 @@ test "http3 runtime: H3 qlog adapter preserves typed event payloads" {
     Runtime.h3ConnectionEvent(&observer, .{ .frame_parsed = .{ .stream_id = 4, .frame = .{ .headers = .{ .fields = &fields, .raw_length = 12 } } } });
     Runtime.h3ConnectionEvent(&observer, .{ .frame_created = .{ .stream_id = 0, .frame = .{ .goaway = .{ .id = 12, .raw_length = 2 } } } });
     Runtime.h3ConnectionEvent(&observer, .{ .frame_parsed = .{ .stream_id = 0, .frame = .{ .priority_update = .{ .request = .{ .stream_id = 8, .field_value = "u=2", .raw_length = 7 } } } } });
+    Runtime.h3ConnectionEvent(&observer, .{ .frame_parsed = .{ .stream_id = 4, .frame = .{ .push_promise = .{ .push_id = 3, .fields = &fields, .raw_length = 10 } } } });
 
-    try testing.expectEqual(@as(usize, 5), recorder.records.items.len);
+    try testing.expectEqual(@as(usize, 6), recorder.records.items.len);
     switch (recorder.records.items[0].event) {
         .parameters_set => |event| {
             try testing.expectEqual(http3.qlog.Initiator.local, event.initiator.?);
@@ -1907,6 +1939,17 @@ test "http3 runtime: H3 qlog adapter preserves typed event payloads" {
                     try testing.expectEqualStrings("u=2", frame_event.priority_field_value);
                 },
                 else => return error.TestUnexpectedResult,
+            },
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    switch (recorder.records.items[5].event) {
+        .frame => |event| switch (event.frame) {
+            .push_promise => |frame_event| {
+                try testing.expectEqual(@as(u64, 3), frame_event.push_id);
+                try testing.expectEqualStrings(":method", frame_event.headers[0].name);
+                try testing.expectEqualStrings("GET", frame_event.headers[0].value);
             },
             else => return error.TestUnexpectedResult,
         },

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -103,6 +103,14 @@ pub const Config = struct {
     /// (`quic.connection.Event.zero_rtt_packet`), bridged the same way.
     quic_zero_rtt_packet_metrics_ctx: ?*anyopaque = null,
     quic_zero_rtt_packet_metrics_cb: ?*const fn (*anyopaque, metrics_mod.QuicZeroRttPacketOutcome) void = null,
+    /// Optional H3 qlog sink. Defaults to no-op; concrete file ownership stays
+    /// in the composition root and sink errors must not affect protocol state.
+    h3_qlog_sink: http3.qlog.Sink = .{},
+    /// Optional per-connection H3 qlog sink factory. When set, this overrides
+    /// `h3_qlog_sink` for accepted connections and lets the composition root
+    /// route H3 events to the same connection trace as QUIC events.
+    h3_qlog_sink_factory_ctx: ?*anyopaque = null,
+    h3_qlog_sink_factory_cb: ?*const fn (?*anyopaque, u64) http3.qlog.Sink = null,
 };
 
 /// Half-open admission limits (#328 review). The native stack does not send
@@ -171,9 +179,16 @@ pub const Snapshot = struct {
 
 /// One accepted QUIC connection with its HTTP/3 session state.
 const ConnEntry = struct {
+    const H3Observer = struct {
+        runtime: *Runtime,
+        connection_handle: u64,
+        qlog_sink: http3.qlog.Sink = .{},
+    };
+
     backend: *quic.tls_backend.Tls13Backend,
     conn: *Connection,
     h3: H3,
+    h3_observer: H3Observer = undefined,
     h3_started: bool = false,
     /// Source IPv4 address of the Initial that opened the connection,
     /// immutable for the connection's lifetime. Used only for half-open
@@ -258,6 +273,9 @@ pub const Runtime = struct {
     quic_early_data_decision_metrics_cb: ?*const fn (*anyopaque, metrics_mod.QuicEarlyDataDecision) void = null,
     quic_zero_rtt_packet_metrics_ctx: ?*anyopaque = null,
     quic_zero_rtt_packet_metrics_cb: ?*const fn (*anyopaque, metrics_mod.QuicZeroRttPacketOutcome) void = null,
+    h3_qlog_sink: http3.qlog.Sink = .{},
+    h3_qlog_sink_factory_ctx: ?*anyopaque = null,
+    h3_qlog_sink_factory_cb: ?*const fn (?*anyopaque, u64) http3.qlog.Sink = null,
     snapshot_mutex: compat.Mutex = .{},
     snapshot_state: Snapshot,
     stopping: std.atomic.Value(bool),
@@ -329,6 +347,9 @@ pub const Runtime = struct {
             .quic_early_data_decision_metrics_cb = cfg.quic_early_data_decision_metrics_cb,
             .quic_zero_rtt_packet_metrics_ctx = cfg.quic_zero_rtt_packet_metrics_ctx,
             .quic_zero_rtt_packet_metrics_cb = cfg.quic_zero_rtt_packet_metrics_cb,
+            .h3_qlog_sink = cfg.h3_qlog_sink,
+            .h3_qlog_sink_factory_ctx = cfg.h3_qlog_sink_factory_ctx,
+            .h3_qlog_sink_factory_cb = cfg.h3_qlog_sink_factory_cb,
             .snapshot_state = .{ .quic_port = cfg.quic_port },
             .stopping = std.atomic.Value(bool).init(false),
             .drain_requested = std.atomic.Value(bool).init(false),
@@ -706,17 +727,24 @@ pub const Runtime = struct {
             allocator.destroy(backend);
             return null;
         };
+        const handle = next_handle.*;
+        next_handle.* += 1;
+        const h3_sink = if (self.h3_qlog_sink_factory_cb) |factory|
+            factory(self.h3_qlog_sink_factory_ctx, handle)
+        else
+            self.h3_qlog_sink;
+        const h3 = H3.initWithSettings(allocator, .server, self.h3_settings);
         entry.* = .{
             .backend = backend,
             .conn = conn,
-            .h3 = H3.initWithSettings(allocator, .server, self.h3_settings),
+            .h3 = h3,
+            .h3_observer = .{ .runtime = self, .connection_handle = handle, .qlog_sink = h3_sink },
             .admission_source_ip = peer.addr,
             .cid_len = parsed.dcid.len,
             .accepted_at_us = now,
         };
+        entry.h3.setEventSink(.{ .context = &entry.h3_observer, .emitFn = h3ConnectionEvent });
 
-        const handle = next_handle.*;
-        next_handle.* += 1;
         const cid = quic.cid.ConnectionId.init(parsed.dcid) catch {
             entry.deinit(allocator);
             allocator.destroy(entry);
@@ -1234,6 +1262,71 @@ pub const Runtime = struct {
         cb(cb_ctx, outcome);
     }
 
+    fn h3ConnectionEvent(ctx: ?*anyopaque, event: http3.conn.Event) void {
+        const observer: *ConnEntry.H3Observer = @ptrCast(@alignCast(ctx.?));
+        _ = observer.connection_handle;
+        observer.qlog_sink.log(nowUs(), h3EventToQlog(event) orelse return);
+    }
+
+    fn h3EventToQlog(event: http3.conn.Event) ?http3.qlog.Event {
+        return switch (event) {
+            .parameters_set => |parameters| .{ .parameters_set = .{
+                .initiator = switch (parameters.initiator) {
+                    .local => .local,
+                    .remote => .remote,
+                },
+                .max_field_section_size = parameters.settings.max_field_section_size,
+                .max_table_capacity = if (parameters.settings.qpack_max_table_capacity == 0) null else parameters.settings.qpack_max_table_capacity,
+                .blocked_streams_count = if (parameters.settings.qpack_blocked_streams == 0) null else parameters.settings.qpack_blocked_streams,
+            } },
+            .stream_type_set => |stream| .{ .stream_type_set = .{
+                .stream_id = stream.stream_id,
+                .stream_type = h3StreamTypeToQlog(stream.stream_type),
+            } },
+            .frame_created => |created| .{ .frame = .{
+                .direction = .created,
+                .stream_id = created.stream_id,
+                .frame = h3FrameToQlog(created.frame),
+            } },
+            .frame_parsed => |parsed| .{ .frame = .{
+                .direction = .parsed,
+                .stream_id = parsed.stream_id,
+                .frame = h3FrameToQlog(parsed.frame),
+            } },
+            .priority_updated => |updated| .{ .priority_updated = .{
+                .stream_id = updated.stream_id,
+                .new = .{ .urgency = updated.urgency, .incremental = updated.incremental },
+            } },
+        };
+    }
+
+    fn h3FrameToQlog(event_frame: http3.conn.EventFrame) http3.qlog.Frame {
+        return switch (event_frame) {
+            .data => |d| .{ .data = .{ .raw_length = d.raw_length } },
+            .headers => |h| .{ .headers = .{ .headers = h.fields, .raw_length = h.raw_length } },
+            .settings => |s| .{ .settings = .{ .settings = s.settings, .raw_length = s.raw_length } },
+            .goaway => |g| .{ .goaway = .{ .id = g.id, .raw_length = g.raw_length } },
+            .priority_update => |update| .{ .priority_update = switch (update) {
+                .request => |r| .{ .request = .{ .stream_id = r.stream_id, .priority_field_value = r.field_value, .raw_length = r.raw_length } },
+                .push => |p| .{ .push = .{ .push_id = p.push_id, .priority_field_value = p.field_value, .raw_length = p.raw_length } },
+            } },
+            .push_promise => |p| .{ .push_promise = .{ .push_id = p.push_id, .raw_length = p.raw_length } },
+            .cancel_push => |c| .{ .cancel_push = .{ .push_id = c.push_id, .raw_length = c.raw_length } },
+            .max_push_id => |m| .{ .max_push_id = .{ .push_id = m.push_id, .raw_length = m.raw_length } },
+        };
+    }
+
+    fn h3StreamTypeToQlog(typ: http3.conn.EventStreamType) http3.qlog.StreamType {
+        return switch (typ) {
+            .request => .request,
+            .control => .control,
+            .push => .push,
+            .qpack_encoder => .qpack_encode,
+            .qpack_decoder => .qpack_decode,
+            .unknown => .unknown,
+        };
+    }
+
     /// #523: bridges `quic.connection.Event`s from every accepted
     /// connection into the composition root's metrics — without this,
     /// `accept()` would construct connections with no `EventSink` at all
@@ -1601,6 +1694,128 @@ fn openUdpSocket(sa_family: u32) std.c.fd_t {
 }
 
 const testing = std.testing;
+
+const H3QlogRecorder = struct {
+    records: std.ArrayList(http3.qlog.Record) = .empty,
+
+    fn deinit(self: *H3QlogRecorder, allocator: std.mem.Allocator) void {
+        self.records.deinit(allocator);
+    }
+
+    fn sink(self: *H3QlogRecorder) http3.qlog.Sink {
+        return .{ .context = self, .emit_fn = emit };
+    }
+
+    fn emit(ctx: ?*anyopaque, record: http3.qlog.Record) void {
+        const self: *H3QlogRecorder = @ptrCast(@alignCast(ctx.?));
+        self.records.append(testing.allocator, record) catch unreachable;
+    }
+};
+
+test "http3 runtime: H3 qlog events route through connection-scoped observers" {
+    var first = H3QlogRecorder{};
+    defer first.deinit(testing.allocator);
+    var second = H3QlogRecorder{};
+    defer second.deinit(testing.allocator);
+
+    var first_observer = ConnEntry.H3Observer{
+        .runtime = undefined,
+        .connection_handle = 1,
+        .qlog_sink = first.sink(),
+    };
+    var second_observer = ConnEntry.H3Observer{
+        .runtime = undefined,
+        .connection_handle = 2,
+        .qlog_sink = second.sink(),
+    };
+
+    Runtime.h3ConnectionEvent(&first_observer, .{ .stream_type_set = .{ .stream_id = 0, .stream_type = .request } });
+    Runtime.h3ConnectionEvent(&second_observer, .{ .stream_type_set = .{ .stream_id = 0, .stream_type = .request } });
+
+    try testing.expectEqual(@as(usize, 1), first.records.items.len);
+    try testing.expectEqual(@as(usize, 1), second.records.items.len);
+    try testing.expectEqual(http3.qlog.Event{ .stream_type_set = .{ .stream_id = 0, .stream_type = .request } }, first.records.items[0].event);
+    try testing.expectEqual(http3.qlog.Event{ .stream_type_set = .{ .stream_id = 0, .stream_type = .request } }, second.records.items[0].event);
+}
+
+test "http3 runtime: H3 qlog adapter preserves typed event payloads" {
+    var recorder = H3QlogRecorder{};
+    defer recorder.deinit(testing.allocator);
+
+    var observer = ConnEntry.H3Observer{
+        .runtime = undefined,
+        .connection_handle = 1,
+        .qlog_sink = recorder.sink(),
+    };
+
+    const settings = http3.frame.Settings{
+        .qpack_max_table_capacity = 128,
+        .max_field_section_size = 4096,
+        .qpack_blocked_streams = 7,
+    };
+    const fields = [_]http3.qpack.HeaderField{
+        .{ .name = ":method", .value = "GET" },
+        .{ .name = ":path", .value = "/trace" },
+    };
+
+    Runtime.h3ConnectionEvent(&observer, .{ .parameters_set = .{ .initiator = .local, .settings = settings } });
+    Runtime.h3ConnectionEvent(&observer, .{ .frame_parsed = .{ .stream_id = 0, .frame = .{ .settings = .{ .settings = settings, .raw_length = 9 } } } });
+    Runtime.h3ConnectionEvent(&observer, .{ .frame_parsed = .{ .stream_id = 4, .frame = .{ .headers = .{ .fields = &fields, .raw_length = 12 } } } });
+    Runtime.h3ConnectionEvent(&observer, .{ .frame_created = .{ .stream_id = 0, .frame = .{ .goaway = .{ .id = 12, .raw_length = 2 } } } });
+    Runtime.h3ConnectionEvent(&observer, .{ .frame_parsed = .{ .stream_id = 0, .frame = .{ .priority_update = .{ .request = .{ .stream_id = 8, .field_value = "u=2", .raw_length = 7 } } } } });
+
+    try testing.expectEqual(@as(usize, 5), recorder.records.items.len);
+    switch (recorder.records.items[0].event) {
+        .parameters_set => |event| {
+            try testing.expectEqual(http3.qlog.Initiator.local, event.initiator.?);
+            try testing.expectEqual(@as(u64, 128), event.max_table_capacity.?);
+            try testing.expectEqual(@as(u64, 4096), event.max_field_section_size.?);
+            try testing.expectEqual(@as(u64, 7), event.blocked_streams_count.?);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    switch (recorder.records.items[1].event) {
+        .frame => |event| switch (event.frame) {
+            .settings => |frame_event| {
+                try testing.expectEqual(@as(u64, 128), frame_event.settings.?.qpack_max_table_capacity);
+                try testing.expectEqual(@as(u64, 4096), frame_event.settings.?.max_field_section_size.?);
+                try testing.expectEqual(@as(usize, 9), frame_event.raw_length.?);
+            },
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    switch (recorder.records.items[2].event) {
+        .frame => |event| switch (event.frame) {
+            .headers => |frame_event| {
+                try testing.expectEqualStrings(":path", frame_event.headers[1].name);
+                try testing.expectEqualStrings("/trace", frame_event.headers[1].value);
+            },
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    switch (recorder.records.items[3].event) {
+        .frame => |event| switch (event.frame) {
+            .goaway => |frame_event| try testing.expectEqual(@as(u64, 12), frame_event.id),
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    switch (recorder.records.items[4].event) {
+        .frame => |event| switch (event.frame) {
+            .priority_update => |update| switch (update) {
+                .request => |frame_event| {
+                    try testing.expectEqual(@as(u64, 8), frame_event.stream_id);
+                    try testing.expectEqualStrings("u=2", frame_event.priority_field_value);
+                },
+                else => return error.TestUnexpectedResult,
+            },
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
 
 const RuntimeCidHarness = struct {
     client_backend: quic.tls_backend.Tls13Backend,

--- a/src/http/metrics.zig
+++ b/src/http/metrics.zig
@@ -294,6 +294,14 @@ pub const Metrics = struct {
     /// #523: per-packet 0-RTT authentication/admission outcomes. See
     /// `QuicZeroRttPacketOutcome`.
     quic_zero_rtt_packet_total: [quic_zero_rtt_packet_outcome_count]u64,
+    /// #255 Slice 3: process-wide QPACK dynamic decoder observability. These
+    /// remain zero until the live H3 path composes the dynamic decoder.
+    h3_qpack_blocked_streams_current: u64,
+    h3_qpack_blocked_streams_total: u64,
+    h3_qpack_unblocked_streams_total: u64,
+    h3_qpack_cancelled_streams_total: u64,
+    h3_qpack_table_bytes: u64,
+    h3_qpack_decode_failures_total: u64,
     /// Total graceful-shutdown drains started.
     drain_total: u64,
     /// Total drains that hit the configured drain timeout before work finished.
@@ -432,6 +440,12 @@ pub const Metrics = struct {
             .tls_early_data_replay_total = .{0} ** early_data_replay_outcome_count,
             .quic_early_data_decision_total = .{0} ** quic_early_data_decision_count,
             .quic_zero_rtt_packet_total = .{0} ** quic_zero_rtt_packet_outcome_count,
+            .h3_qpack_blocked_streams_current = 0,
+            .h3_qpack_blocked_streams_total = 0,
+            .h3_qpack_unblocked_streams_total = 0,
+            .h3_qpack_cancelled_streams_total = 0,
+            .h3_qpack_table_bytes = 0,
+            .h3_qpack_decode_failures_total = 0,
             .drain_total = 0,
             .drain_timeouts_total = 0,
             .drain_forced_closes_total = 0,
@@ -566,6 +580,36 @@ pub const Metrics = struct {
     /// #523: record one 0-RTT packet's authentication/admission outcome.
     pub fn recordQuicZeroRttPacket(self: *Metrics, outcome: QuicZeroRttPacketOutcome) void {
         self.quic_zero_rtt_packet_total[quicZeroRttPacketOutcomeIndex(outcome)] += 1;
+    }
+
+    pub const H3QpackSnapshot = struct {
+        current_blocked_streams: u64 = 0,
+        blocked_streams: u64 = 0,
+        unblocked_streams: u64 = 0,
+        cancelled_streams: u64 = 0,
+        table_bytes: u64 = 0,
+        decode_failures: u64 = 0,
+    };
+
+    /// Fold one connection's cumulative QPACK metrics. Gauge values are
+    /// adjusted from previous/current state so multi-connection totals compose
+    /// and teardown can subtract the final per-connection snapshot.
+    pub fn recordH3QpackSnapshotDelta(self: *Metrics, previous: H3QpackSnapshot, current: H3QpackSnapshot) void {
+        self.h3_qpack_blocked_streams_total += current.blocked_streams -| previous.blocked_streams;
+        self.h3_qpack_unblocked_streams_total += current.unblocked_streams -| previous.unblocked_streams;
+        self.h3_qpack_cancelled_streams_total += current.cancelled_streams -| previous.cancelled_streams;
+        self.h3_qpack_decode_failures_total += current.decode_failures -| previous.decode_failures;
+        self.h3_qpack_blocked_streams_current = addGaugeDelta(
+            self.h3_qpack_blocked_streams_current,
+            previous.current_blocked_streams,
+            current.current_blocked_streams,
+        );
+        self.h3_qpack_table_bytes = addGaugeDelta(self.h3_qpack_table_bytes, previous.table_bytes, current.table_bytes);
+    }
+
+    pub fn removeH3QpackSnapshot(self: *Metrics, snapshot: H3QpackSnapshot) void {
+        self.h3_qpack_blocked_streams_current -|= snapshot.current_blocked_streams;
+        self.h3_qpack_table_bytes -|= snapshot.table_bytes;
     }
 
     /// Record the start of a config hot-reload attempt.
@@ -1689,6 +1733,35 @@ pub const Metrics = struct {
                 self.quic_zero_rtt_packet_total[quicZeroRttPacketOutcomeIndex(outcome)],
             });
         }
+
+        try out.print(
+            \\# HELP tardigrade_h3_qpack_blocked_streams Current HTTP/3 QPACK blocked streams
+            \\# TYPE tardigrade_h3_qpack_blocked_streams gauge
+            \\tardigrade_h3_qpack_blocked_streams {d}
+            \\# HELP tardigrade_h3_qpack_blocked_streams_total Total HTTP/3 QPACK streams that became blocked
+            \\# TYPE tardigrade_h3_qpack_blocked_streams_total counter
+            \\tardigrade_h3_qpack_blocked_streams_total {d}
+            \\# HELP tardigrade_h3_qpack_unblocked_streams_total Total HTTP/3 QPACK streams unblocked by encoder progress
+            \\# TYPE tardigrade_h3_qpack_unblocked_streams_total counter
+            \\tardigrade_h3_qpack_unblocked_streams_total {d}
+            \\# HELP tardigrade_h3_qpack_cancelled_streams_total Total HTTP/3 QPACK blocked streams cancelled before unblock
+            \\# TYPE tardigrade_h3_qpack_cancelled_streams_total counter
+            \\tardigrade_h3_qpack_cancelled_streams_total {d}
+            \\# HELP tardigrade_h3_qpack_table_bytes Current HTTP/3 QPACK dynamic table bytes
+            \\# TYPE tardigrade_h3_qpack_table_bytes gauge
+            \\tardigrade_h3_qpack_table_bytes {d}
+            \\# HELP tardigrade_h3_qpack_decode_failures_total Total HTTP/3 QPACK dynamic decode failures
+            \\# TYPE tardigrade_h3_qpack_decode_failures_total counter
+            \\tardigrade_h3_qpack_decode_failures_total {d}
+            \\
+        , .{
+            self.h3_qpack_blocked_streams_current,
+            self.h3_qpack_blocked_streams_total,
+            self.h3_qpack_unblocked_streams_total,
+            self.h3_qpack_cancelled_streams_total,
+            self.h3_qpack_table_bytes,
+            self.h3_qpack_decode_failures_total,
+        });
     }
 
     /// #368 Slice 3: process-local anti-replay store outcomes. Every label
@@ -1784,6 +1857,13 @@ pub const Metrics = struct {
         return out.toOwnedSlice();
     }
 };
+
+fn addGaugeDelta(current_total: u64, previous_value: u64, current_value: u64) u64 {
+    if (current_value >= previous_value) {
+        return current_total + (current_value - previous_value);
+    }
+    return current_total -| (previous_value - current_value);
+}
 
 fn zeroTlsQueueMatrix() [tls_backend_count][tls_queue_count]u64 {
     return .{.{0} ** tls_queue_count} ** tls_backend_count;
@@ -2705,6 +2785,51 @@ test "early-data metrics record bounded labels and emit Prometheus series" {
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_retry_total{result=\"too_early\"} 1") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http3_early_data_compat_total{decision=\"compatible\"} 1") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http3_early_data_compat_total{decision=\"missing_state\"} 1") != null);
+}
+
+test "H3 QPACK metrics expose current blocked gauge and monotonic counters" {
+    const allocator = std.testing.allocator;
+    var m = Metrics.init();
+
+    const empty = Metrics.H3QpackSnapshot{};
+    const conn_a = Metrics.H3QpackSnapshot{
+        .current_blocked_streams = 2,
+        .blocked_streams = 3,
+        .table_bytes = 128,
+        .decode_failures = 1,
+    };
+    const conn_b = Metrics.H3QpackSnapshot{
+        .current_blocked_streams = 1,
+        .blocked_streams = 1,
+        .table_bytes = 64,
+    };
+    const conn_a_later = Metrics.H3QpackSnapshot{
+        .current_blocked_streams = 1,
+        .blocked_streams = 3,
+        .unblocked_streams = 1,
+        .table_bytes = 96,
+        .decode_failures = 2,
+    };
+
+    m.recordH3QpackSnapshotDelta(empty, conn_a);
+    m.recordH3QpackSnapshotDelta(empty, conn_b);
+    m.recordH3QpackSnapshotDelta(conn_a, conn_a_later);
+
+    try std.testing.expectEqual(@as(u64, 2), m.h3_qpack_blocked_streams_current);
+    try std.testing.expectEqual(@as(u64, 160), m.h3_qpack_table_bytes);
+    const prom = try m.toPrometheus(allocator);
+    defer allocator.free(prom);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_h3_qpack_blocked_streams 2") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_h3_qpack_blocked_streams_total 4") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_h3_qpack_unblocked_streams_total 1") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_h3_qpack_table_bytes 160") != null);
+    try std.testing.expect(std.mem.find(u8, prom, "tardigrade_h3_qpack_decode_failures_total 2") != null);
+
+    m.removeH3QpackSnapshot(conn_a_later);
+    m.removeH3QpackSnapshot(conn_b);
+    try std.testing.expectEqual(@as(u64, 0), m.h3_qpack_blocked_streams_current);
+    try std.testing.expectEqual(@as(u64, 0), m.h3_qpack_table_bytes);
+    try std.testing.expectEqual(@as(u64, 4), m.h3_qpack_blocked_streams_total);
 }
 
 test "listener sharding metrics record per-shard accepts and errors and emit Prometheus series (#137)" {

--- a/src/http3/conn.zig
+++ b/src/http3/conn.zig
@@ -69,6 +69,7 @@ pub const EventFrame = union(enum) {
     },
     push_promise: struct {
         push_id: u64,
+        fields: []const qpack.HeaderField = &.{},
         raw_length: usize,
     },
     cancel_push: struct {
@@ -574,8 +575,8 @@ pub fn Conn(comptime Transport: type) type {
         fn ingestControlFrame(self: *Self, transport: *Transport, raw: frame.RawFrame) H3Error!void {
             const had_settings = self.peer_control_view.saw_settings;
             if (self.peer_control) |control| {
-                var settings_scratch: [32]EventSetting = undefined;
-                self.events.emit(.{ .frame_parsed = .{ .stream_id = control, .frame = eventFrameFromRaw(raw, &settings_scratch) } });
+                var event_scratch = EventDecodeScratch{};
+                self.events.emit(.{ .frame_parsed = .{ .stream_id = control, .frame = eventFrameFromRaw(raw, &event_scratch) } });
             }
             switch (raw.typ) {
                 .priority_update_request, .priority_update_push => {
@@ -660,8 +661,8 @@ pub fn Conn(comptime Transport: type) type {
                     } } } });
                     return;
                 }
-                var settings_scratch: [32]EventSetting = undefined;
-                self.conn.events.emit(.{ .frame_parsed = .{ .stream_id = self.stream_id, .frame = eventFrameFromRaw(raw, &settings_scratch) } });
+                var event_scratch = EventDecodeScratch{};
+                self.conn.events.emit(.{ .frame_parsed = .{ .stream_id = self.stream_id, .frame = eventFrameFromRaw(raw, &event_scratch) } });
             }
         };
 
@@ -873,13 +874,13 @@ pub fn Conn(comptime Transport: type) type {
                         body_len += raw.payload.len;
                     },
                     .priority_update_request, .priority_update_push => {
-                        var settings_scratch: [32]EventSetting = undefined;
-                        self.events.emit(.{ .frame_parsed = .{ .stream_id = id, .frame = eventFrameFromRaw(raw, &settings_scratch) } });
+                        var event_scratch = EventDecodeScratch{};
+                        self.events.emit(.{ .frame_parsed = .{ .stream_id = id, .frame = eventFrameFromRaw(raw, &event_scratch) } });
                         return self.fail(.frame_unexpected);
                     },
                     else => {
-                        var settings_scratch: [32]EventSetting = undefined;
-                        self.events.emit(.{ .frame_parsed = .{ .stream_id = id, .frame = eventFrameFromRaw(raw, &settings_scratch) } });
+                        var event_scratch = EventDecodeScratch{};
+                        self.events.emit(.{ .frame_parsed = .{ .stream_id = id, .frame = eventFrameFromRaw(raw, &event_scratch) } });
                     },
                 }
                 offset += raw.len;
@@ -1050,13 +1051,19 @@ fn decodeEventSettings(payload: []const u8, scratch: []EventSetting) ?[]const Ev
     return scratch[0..count];
 }
 
-fn eventFrameFromRaw(raw: frame.RawFrame, settings_scratch: []EventSetting) EventFrame {
+const EventDecodeScratch = struct {
+    settings: [32]EventSetting = undefined,
+    fields: [128]qpack.HeaderField = undefined,
+    qpack: [4096]u8 = undefined,
+};
+
+fn eventFrameFromRaw(raw: frame.RawFrame, scratch: *EventDecodeScratch) EventFrame {
     const malformed = EventFrame{ .malformed = .{ .frame_type = raw.typ, .frame_type_value = raw.type_value, .raw_length = raw.len } };
     return switch (raw.typ) {
         .data => .{ .data = .{ .raw_length = raw.len } },
         .headers => .{ .headers = .{ .raw_length = raw.len } },
         .settings => blk: {
-            const entries = decodeEventSettings(raw.payload, settings_scratch) orelse return malformed;
+            const entries = decodeEventSettings(raw.payload, &scratch.settings) orelse return malformed;
             break :blk .{ .settings = .{ .entries = entries, .raw_length = raw.len } };
         },
         .goaway => blk: {
@@ -1080,7 +1087,15 @@ fn eventFrameFromRaw(raw: frame.RawFrame, settings_scratch: []EventSetting) Even
                 } } },
             };
         },
-        .push_promise => malformed,
+        .push_promise => blk: {
+            const decoded = varint.decode(raw.payload) catch return malformed;
+            const count = qpack.decode(raw.payload[decoded.len..], &scratch.fields, &scratch.qpack) catch return .{ .malformed = .{
+                .frame_type = raw.typ,
+                .frame_type_value = raw.type_value,
+                .raw_length = raw.len,
+            } };
+            break :blk .{ .push_promise = .{ .push_id = decoded.value, .fields = scratch.fields[0..count], .raw_length = raw.len } };
+        },
         .cancel_push => blk: {
             const decoded = varint.decode(raw.payload) catch return malformed;
             if (decoded.len != raw.payload.len) return malformed;
@@ -1276,6 +1291,11 @@ const EventRecorder = struct {
                     .raw_length = p.raw_length,
                 } },
             } },
+            .push_promise => |p| .{ .push_promise = .{
+                .push_id = p.push_id,
+                .fields = try cloneFields(allocator, p.fields),
+                .raw_length = p.raw_length,
+            } },
             else => event_frame,
         };
     }
@@ -1288,6 +1308,7 @@ const EventRecorder = struct {
                 .request => |r| allocator.free(r.field_value),
                 .push => |p| allocator.free(p.field_value),
             },
+            .push_promise => |p| freeFields(allocator, p.fields),
             else => {},
         }
     }
@@ -1809,7 +1830,7 @@ test "H3 conn: malformed known frames are not observed as unknown" {
     try testing.expect(!client_events.sawUnknownFrame(@intFromEnum(frame.FrameType.goaway)));
 }
 
-test "H3 conn: PUSH_PROMISE is preserved as malformed known frame until decoded" {
+test "H3 conn: incomplete PUSH_PROMISE is preserved as malformed known frame" {
     const allocator = testing.allocator;
     var client_transport = MockTransport.init(allocator, true);
     defer client_transport.deinit();
@@ -1834,6 +1855,41 @@ test "H3 conn: PUSH_PROMISE is preserved as malformed known frame until decoded"
 
     try testing.expectError(error.ProtocolError, server.pump(&server_transport));
     try testing.expect(server_events.sawMalformedFrame(.push_promise));
+    try testing.expect(!server_events.sawUnknownFrame(@intFromEnum(frame.FrameType.push_promise)));
+}
+
+test "H3 conn: valid PUSH_PROMISE is observed as known decoded frame" {
+    const allocator = testing.allocator;
+    var client_transport = MockTransport.init(allocator, true);
+    defer client_transport.deinit();
+    var server_transport = MockTransport.init(allocator, false);
+    defer server_transport.deinit();
+    client_transport.peer = &server_transport;
+    server_transport.peer = &client_transport;
+
+    const H3 = Conn(MockTransport);
+    var server = H3.init(allocator, .server);
+    defer server.deinit();
+    var server_events = EventRecorder{};
+    defer server_events.deinit(allocator);
+    server.setEventSink(server_events.sink());
+
+    const id = try client_transport.openStream(.bidi);
+    var payload: [128]u8 = undefined;
+    var payload_len = try varint.encode(1, &payload);
+    const fields = [_]qpack.HeaderField{
+        .{ .name = ":method", .value = "GET" },
+        .{ .name = ":path", .value = "/" },
+    };
+    const encoded_fields = try qpack.encode(&fields, payload[payload_len..]);
+    payload_len += encoded_fields.len;
+    var wire: [160]u8 = undefined;
+    const push_promise = try frame.encodeKnownFrame(.push_promise, payload[0..payload_len], &wire);
+    _ = try client_transport.writeStream(id, push_promise, false);
+
+    try testing.expectError(error.ProtocolError, server.pump(&server_transport));
+    try testing.expect(server_events.sawFrame(.parsed, .push_promise));
+    try testing.expect(!server_events.sawMalformedFrame(.push_promise));
     try testing.expect(!server_events.sawUnknownFrame(@intFromEnum(frame.FrameType.push_promise)));
 }
 

--- a/src/http3/conn.zig
+++ b/src/http3/conn.zig
@@ -34,6 +34,11 @@ pub const EventStreamType = enum {
 
 pub const EventInitiator = enum { local, remote };
 
+pub const EventSetting = struct {
+    id_value: u64,
+    value: u64,
+};
+
 pub const EventFrame = union(enum) {
     data: struct {
         raw_length: usize,
@@ -43,7 +48,7 @@ pub const EventFrame = union(enum) {
         raw_length: usize,
     },
     settings: struct {
-        settings: frame.Settings,
+        entries: []const EventSetting,
         raw_length: usize,
     },
     goaway: struct {
@@ -74,6 +79,10 @@ pub const EventFrame = union(enum) {
         push_id: u64,
         raw_length: usize,
     },
+    unknown: struct {
+        frame_type_value: u64,
+        raw_length: usize,
+    },
 };
 
 pub const Event = union(enum) {
@@ -102,6 +111,10 @@ pub const Event = union(enum) {
 
 /// Diagnostics hook for H3/qlog. Must not block or feed errors back into
 /// protocol state; sinks retain failures out-of-band.
+///
+/// All slices inside `event` are borrowed and valid only for the synchronous
+/// callback. Implementations must serialize or deep-copy before returning and
+/// must not retain/enqueue `event` itself.
 pub const EventSink = struct {
     context: ?*anyopaque = null,
     emitFn: ?*const fn (?*anyopaque, Event) void = null,
@@ -351,11 +364,12 @@ pub fn Conn(comptime Transport: type) type {
             len += (try frame.encodeStreamType(.control, bytes[len..])).len;
             var settings_payload: [64]u8 = undefined;
             var settings_entries: [5]frame.Setting = undefined;
-            const settings = try encodeLocalSettings(self.local_settings, &settings_entries, &settings_payload);
-            const settings_frame = try frame.encodeKnownFrame(.settings, settings, bytes[len..]);
+            var event_settings: [5]EventSetting = undefined;
+            const settings = try encodeLocalSettings(self.local_settings, &settings_entries, &event_settings, &settings_payload);
+            const settings_frame = try frame.encodeKnownFrame(.settings, settings.payload, bytes[len..]);
             len += settings_frame.len;
             self.events.emit(.{ .stream_type_set = .{ .stream_id = control, .stream_type = .control } });
-            self.events.emit(.{ .frame_created = .{ .stream_id = control, .frame = .{ .settings = .{ .settings = self.local_settings, .raw_length = settings_frame.len } } } });
+            self.events.emit(.{ .frame_created = .{ .stream_id = control, .frame = .{ .settings = .{ .entries = settings.entries, .raw_length = settings_frame.len } } } });
             _ = try transport.writeStream(control, bytes[0..len], false);
             self.control_out = control;
             self.events.emit(.{ .parameters_set = .{ .initiator = .local, .settings = self.local_settings } });
@@ -373,29 +387,35 @@ pub fn Conn(comptime Transport: type) type {
             }) catch return error.ProtocolError;
         }
 
-        fn encodeLocalSettings(settings: frame.Settings, entries: *[5]frame.Setting, out: []u8) ![]u8 {
+        fn encodeLocalSettings(settings: frame.Settings, entries: *[5]frame.Setting, event_entries: *[5]EventSetting, out: []u8) !struct { payload: []u8, entries: []const EventSetting } {
             var count: usize = 0;
             if (settings.qpack_max_table_capacity != 0) {
                 entries[count] = .{ .id = .qpack_max_table_capacity, .id_value = 0x01, .value = settings.qpack_max_table_capacity };
+                event_entries[count] = .{ .id_value = entries[count].id_value, .value = entries[count].value };
                 count += 1;
             }
             if (settings.max_field_section_size) |max| {
                 entries[count] = .{ .id = .max_field_section_size, .id_value = 0x06, .value = max };
+                event_entries[count] = .{ .id_value = entries[count].id_value, .value = entries[count].value };
                 count += 1;
             }
             if (settings.qpack_blocked_streams != 0) {
                 entries[count] = .{ .id = .qpack_blocked_streams, .id_value = 0x07, .value = settings.qpack_blocked_streams };
+                event_entries[count] = .{ .id_value = entries[count].id_value, .value = entries[count].value };
                 count += 1;
             }
             if (settings.enable_connect_protocol) {
                 entries[count] = .{ .id = .enable_connect_protocol, .id_value = 0x08, .value = 1 };
+                event_entries[count] = .{ .id_value = entries[count].id_value, .value = entries[count].value };
                 count += 1;
             }
             if (settings.h3_datagram) {
                 entries[count] = .{ .id = .h3_datagram, .id_value = 0x33, .value = 1 };
+                event_entries[count] = .{ .id_value = entries[count].id_value, .value = entries[count].value };
                 count += 1;
             }
-            return frame.encodeSettings(entries[0..count], out);
+            const payload = try frame.encodeSettings(entries[0..count], out);
+            return .{ .payload = payload, .entries = event_entries[0..count] };
         }
 
         /// Drain newly accepted and readable peer streams. Call after every
@@ -549,9 +569,8 @@ pub fn Conn(comptime Transport: type) type {
         fn ingestControlFrame(self: *Self, transport: *Transport, raw: frame.RawFrame) H3Error!void {
             const had_settings = self.peer_control_view.saw_settings;
             if (self.peer_control) |control| {
-                if (eventFrameFromRaw(raw)) |event_frame| {
-                    self.events.emit(.{ .frame_parsed = .{ .stream_id = control, .frame = event_frame } });
-                }
+                var settings_scratch: [32]EventSetting = undefined;
+                self.events.emit(.{ .frame_parsed = .{ .stream_id = control, .frame = eventFrameFromRaw(raw, &settings_scratch) } });
             }
             switch (raw.typ) {
                 .priority_update_request, .priority_update_push => {
@@ -633,7 +652,8 @@ pub fn Conn(comptime Transport: type) type {
                     } } } });
                     return;
                 }
-                self.conn.events.emit(.{ .frame_parsed = .{ .stream_id = self.stream_id, .frame = eventFrameFromRaw(raw) orelse .{ .data = .{ .raw_length = raw.len } } } });
+                var settings_scratch: [32]EventSetting = undefined;
+                self.conn.events.emit(.{ .frame_parsed = .{ .stream_id = self.stream_id, .frame = eventFrameFromRaw(raw, &settings_scratch) } });
             }
         };
 
@@ -815,10 +835,13 @@ pub fn Conn(comptime Transport: type) type {
                 const raw = frame.decodeFrameWithLimit(response.buffer.items[offset..], max_response_len) catch return error.ProtocolError;
                 switch (raw.typ) {
                     .headers => {
-                        if (status != null) return error.ProtocolError;
                         var scratch: []u8 = &response.scratch;
-                        field_count = qpack.decode(raw.payload, &response.fields, scratch[0..]) catch return error.ProtocolError;
+                        field_count = qpack.decode(raw.payload, &response.fields, scratch[0..]) catch {
+                            self.events.emit(.{ .frame_parsed = .{ .stream_id = id, .frame = .{ .headers = .{ .raw_length = raw.len } } } });
+                            return error.ProtocolError;
+                        };
                         self.events.emit(.{ .frame_parsed = .{ .stream_id = id, .frame = .{ .headers = .{ .fields = response.fields[0..field_count], .raw_length = raw.len } } } });
+                        if (status != null) return error.ProtocolError;
                         if (field_count == 0) return error.ProtocolError;
                         if (!std.mem.eql(u8, response.fields[0].name, ":status")) return error.ProtocolError;
                         status = std.fmt.parseInt(u16, response.fields[0].value, 10) catch return error.ProtocolError;
@@ -841,12 +864,14 @@ pub fn Conn(comptime Transport: type) type {
                         body_len += raw.payload.len;
                     },
                     .priority_update_request, .priority_update_push => {
-                        if (eventFrameFromRaw(raw)) |event_frame| {
-                            self.events.emit(.{ .frame_parsed = .{ .stream_id = id, .frame = event_frame } });
-                        }
+                        var settings_scratch: [32]EventSetting = undefined;
+                        self.events.emit(.{ .frame_parsed = .{ .stream_id = id, .frame = eventFrameFromRaw(raw, &settings_scratch) } });
                         return self.fail(.frame_unexpected);
                     },
-                    else => {}, // unknown frames on request streams are ignored (RFC 9114 §9)
+                    else => {
+                        var settings_scratch: [32]EventSetting = undefined;
+                        self.events.emit(.{ .frame_parsed = .{ .stream_id = id, .frame = eventFrameFromRaw(raw, &settings_scratch) } });
+                    },
                 }
                 offset += raw.len;
             }
@@ -1001,22 +1026,37 @@ fn containsPriorityUpdateFrame(bytes: []const u8) bool {
     return false;
 }
 
-fn eventFrameFromRaw(raw: frame.RawFrame) ?EventFrame {
+fn decodeEventSettings(payload: []const u8, scratch: []EventSetting) ?[]const EventSetting {
+    var count: usize = 0;
+    var pos: usize = 0;
+    while (pos < payload.len) {
+        if (count >= scratch.len) return null;
+        const id = varint.decode(payload[pos..]) catch return null;
+        pos += id.len;
+        const value = varint.decode(payload[pos..]) catch return null;
+        pos += value.len;
+        scratch[count] = .{ .id_value = id.value, .value = value.value };
+        count += 1;
+    }
+    return scratch[0..count];
+}
+
+fn eventFrameFromRaw(raw: frame.RawFrame, settings_scratch: []EventSetting) EventFrame {
     return switch (raw.typ) {
         .data => .{ .data = .{ .raw_length = raw.len } },
         .headers => .{ .headers = .{ .raw_length = raw.len } },
         .settings => blk: {
-            var scratch: [8]frame.Setting = undefined;
-            const decoded = frame.decodeSettings(raw.payload, &scratch) catch return .{ .settings = .{ .settings = .{}, .raw_length = raw.len } };
-            break :blk .{ .settings = .{ .settings = decoded.parsed, .raw_length = raw.len } };
+            const entries = decodeEventSettings(raw.payload, settings_scratch) orelse return .{ .unknown = .{ .frame_type_value = raw.type_value, .raw_length = raw.len } };
+            break :blk .{ .settings = .{ .entries = entries, .raw_length = raw.len } };
         },
         .goaway => blk: {
-            const decoded = varint.decode(raw.payload) catch return .{ .goaway = .{ .id = 0, .raw_length = raw.len } };
+            const decoded = varint.decode(raw.payload) catch return .{ .unknown = .{ .frame_type_value = raw.type_value, .raw_length = raw.len } };
+            if (decoded.len != raw.payload.len) return .{ .unknown = .{ .frame_type_value = raw.type_value, .raw_length = raw.len } };
             break :blk .{ .goaway = .{ .id = decoded.value, .raw_length = raw.len } };
         },
         .priority_update_request, .priority_update_push => blk: {
-            const decoded = priority.decodePayload(raw.payload) catch return null;
-            const kind = priority.kindFromFrameType(raw.typ) orelse return null;
+            const decoded = priority.decodePayload(raw.payload) catch return .{ .unknown = .{ .frame_type_value = raw.type_value, .raw_length = raw.len } };
+            const kind = priority.kindFromFrameType(raw.typ) orelse return .{ .unknown = .{ .frame_type_value = raw.type_value, .raw_length = raw.len } };
             break :blk switch (kind) {
                 .request => .{ .priority_update = .{ .request = .{
                     .stream_id = decoded.element_id,
@@ -1030,19 +1070,18 @@ fn eventFrameFromRaw(raw: frame.RawFrame) ?EventFrame {
                 } } },
             };
         },
-        .push_promise => blk: {
-            const decoded = varint.decode(raw.payload) catch return .{ .push_promise = .{ .push_id = 0, .raw_length = raw.len } };
-            break :blk .{ .push_promise = .{ .push_id = decoded.value, .raw_length = raw.len } };
-        },
+        .push_promise => .{ .unknown = .{ .frame_type_value = raw.type_value, .raw_length = raw.len } },
         .cancel_push => blk: {
-            const decoded = varint.decode(raw.payload) catch return .{ .cancel_push = .{ .push_id = 0, .raw_length = raw.len } };
+            const decoded = varint.decode(raw.payload) catch return .{ .unknown = .{ .frame_type_value = raw.type_value, .raw_length = raw.len } };
+            if (decoded.len != raw.payload.len) return .{ .unknown = .{ .frame_type_value = raw.type_value, .raw_length = raw.len } };
             break :blk .{ .cancel_push = .{ .push_id = decoded.value, .raw_length = raw.len } };
         },
         .max_push_id => blk: {
-            const decoded = varint.decode(raw.payload) catch return .{ .max_push_id = .{ .push_id = 0, .raw_length = raw.len } };
+            const decoded = varint.decode(raw.payload) catch return .{ .unknown = .{ .frame_type_value = raw.type_value, .raw_length = raw.len } };
+            if (decoded.len != raw.payload.len) return .{ .unknown = .{ .frame_type_value = raw.type_value, .raw_length = raw.len } };
             break :blk .{ .max_push_id = .{ .push_id = decoded.value, .raw_length = raw.len } };
         },
-        .unknown => null,
+        .unknown => .{ .unknown = .{ .frame_type_value = raw.type_value, .raw_length = raw.len } },
     };
 }
 
@@ -1174,6 +1213,7 @@ const EventRecorder = struct {
     events: std.ArrayList(Event) = .empty,
 
     fn deinit(self: *EventRecorder, allocator: std.mem.Allocator) void {
+        for (self.events.items) |*event| freeEvent(allocator, event.*);
         self.events.deinit(allocator);
     }
 
@@ -1183,7 +1223,79 @@ const EventRecorder = struct {
 
     fn emit(ctx: ?*anyopaque, event: Event) void {
         const self: *EventRecorder = @ptrCast(@alignCast(ctx.?));
-        self.events.append(testing.allocator, event) catch unreachable;
+        self.events.append(testing.allocator, cloneEvent(testing.allocator, event) catch unreachable) catch unreachable;
+    }
+
+    fn cloneFields(allocator: std.mem.Allocator, fields: []const qpack.HeaderField) ![]const qpack.HeaderField {
+        const copy = try allocator.alloc(qpack.HeaderField, fields.len);
+        errdefer allocator.free(copy);
+        for (fields, 0..) |field, i| {
+            const name = try allocator.dupe(u8, field.name);
+            errdefer allocator.free(name);
+            const value = try allocator.dupe(u8, field.value);
+            errdefer allocator.free(value);
+            copy[i] = .{ .name = name, .value = value };
+        }
+        return copy;
+    }
+
+    fn freeFields(allocator: std.mem.Allocator, fields: []const qpack.HeaderField) void {
+        for (fields) |field| {
+            allocator.free(field.name);
+            allocator.free(field.value);
+        }
+        allocator.free(fields);
+    }
+
+    fn cloneFrame(allocator: std.mem.Allocator, event_frame: EventFrame) !EventFrame {
+        return switch (event_frame) {
+            .headers => |h| .{ .headers = .{ .fields = try cloneFields(allocator, h.fields), .raw_length = h.raw_length } },
+            .settings => |s| blk: {
+                const entries = try allocator.dupe(EventSetting, s.entries);
+                break :blk .{ .settings = .{ .entries = entries, .raw_length = s.raw_length } };
+            },
+            .priority_update => |update| .{ .priority_update = switch (update) {
+                .request => |r| .{ .request = .{
+                    .stream_id = r.stream_id,
+                    .field_value = try allocator.dupe(u8, r.field_value),
+                    .raw_length = r.raw_length,
+                } },
+                .push => |p| .{ .push = .{
+                    .push_id = p.push_id,
+                    .field_value = try allocator.dupe(u8, p.field_value),
+                    .raw_length = p.raw_length,
+                } },
+            } },
+            else => event_frame,
+        };
+    }
+
+    fn freeFrame(allocator: std.mem.Allocator, event_frame: EventFrame) void {
+        switch (event_frame) {
+            .headers => |h| freeFields(allocator, h.fields),
+            .settings => |s| allocator.free(s.entries),
+            .priority_update => |update| switch (update) {
+                .request => |r| allocator.free(r.field_value),
+                .push => |p| allocator.free(p.field_value),
+            },
+            else => {},
+        }
+    }
+
+    fn cloneEvent(allocator: std.mem.Allocator, event: Event) !Event {
+        return switch (event) {
+            .frame_created => |f| .{ .frame_created = .{ .stream_id = f.stream_id, .frame = try cloneFrame(allocator, f.frame) } },
+            .frame_parsed => |f| .{ .frame_parsed = .{ .stream_id = f.stream_id, .frame = try cloneFrame(allocator, f.frame) } },
+            else => event,
+        };
+    }
+
+    fn freeEvent(allocator: std.mem.Allocator, event: Event) void {
+        switch (event) {
+            .frame_created => |f| freeFrame(allocator, f.frame),
+            .frame_parsed => |f| freeFrame(allocator, f.frame),
+            else => {},
+        }
     }
 
     fn eventFrameType(event_frame: EventFrame) frame.FrameType {
@@ -1199,6 +1311,7 @@ const EventRecorder = struct {
             .push_promise => .push_promise,
             .cancel_push => .cancel_push,
             .max_push_id => .max_push_id,
+            .unknown => .unknown,
         };
     }
 
@@ -1215,6 +1328,7 @@ const EventRecorder = struct {
             .push_promise => |f| f.raw_length,
             .cancel_push => |f| f.raw_length,
             .max_push_id => |f| f.raw_length,
+            .unknown => |f| f.raw_length,
         };
     }
 
@@ -1256,6 +1370,55 @@ const EventRecorder = struct {
         for (self.events.items) |event| switch (event) {
             .frame_parsed => |parsed| switch (parsed.frame) {
                 .goaway => |g| if (g.id == id) return true,
+                else => {},
+            },
+            else => {},
+        };
+        return false;
+    }
+
+    fn sawSettingsEntry(self: *const EventRecorder, id_value: u64, value: u64) bool {
+        for (self.events.items) |event| switch (event) {
+            .frame_created => |parsed| switch (parsed.frame) {
+                .settings => |settings| for (settings.entries) |entry| {
+                    if (entry.id_value == id_value and entry.value == value) return true;
+                },
+                else => {},
+            },
+            .frame_parsed => |parsed| switch (parsed.frame) {
+                .settings => |settings| for (settings.entries) |entry| {
+                    if (entry.id_value == id_value and entry.value == value) return true;
+                },
+                else => {},
+            },
+            else => {},
+        };
+        return false;
+    }
+
+    fn sawSettingsEntryCountAtLeast(self: *const EventRecorder, min_count: usize) bool {
+        for (self.events.items) |event| switch (event) {
+            .frame_created => |parsed| switch (parsed.frame) {
+                .settings => |settings| if (settings.entries.len >= min_count) return true,
+                else => {},
+            },
+            .frame_parsed => |parsed| switch (parsed.frame) {
+                .settings => |settings| if (settings.entries.len >= min_count) return true,
+                else => {},
+            },
+            else => {},
+        };
+        return false;
+    }
+
+    fn sawUnknownFrame(self: *const EventRecorder, frame_type_value: u64) bool {
+        for (self.events.items) |event| switch (event) {
+            .frame_created => |parsed| switch (parsed.frame) {
+                .unknown => |unknown| if (unknown.frame_type_value == frame_type_value) return true,
+                else => {},
+            },
+            .frame_parsed => |parsed| switch (parsed.frame) {
+                .unknown => |unknown| if (unknown.frame_type_value == frame_type_value) return true,
                 else => {},
             },
             else => {},
@@ -1314,6 +1477,88 @@ test "H3 conn: SETTINGS exchange and request/response over a mock transport" {
     try testing.expectEqualStrings("pong", response.body);
     try testing.expectEqualStrings("server", response.headers[0].name);
     client.releaseResponse(id);
+}
+
+test "H3 conn: client observes response HEADERS before QPACK failure" {
+    const allocator = testing.allocator;
+    var client_transport = MockTransport.init(allocator, true);
+    defer client_transport.deinit();
+    var server_transport = MockTransport.init(allocator, false);
+    defer server_transport.deinit();
+    client_transport.peer = &server_transport;
+    server_transport.peer = &client_transport;
+
+    const H3 = Conn(MockTransport);
+    var client = H3.init(allocator, .client);
+    defer client.deinit();
+    var client_events = EventRecorder{};
+    defer client_events.deinit(allocator);
+    client.setEventSink(client_events.sink());
+
+    const id = try client.sendRequest(&client_transport, .{ .authority = "tardigrade.test", .path = "/bad-qpack" });
+    var wire: [64]u8 = undefined;
+    const headers = try frame.encodeKnownFrame(.headers, &.{ 0x00, 0x00, 0x80 }, &wire);
+    _ = try server_transport.writeStream(id, headers, true);
+    try client.pump(&client_transport);
+
+    try testing.expectError(error.ProtocolError, client.pollResponse(id));
+    try testing.expect(client_events.sawFrame(.parsed, .headers));
+}
+
+test "H3 conn: client observes duplicate response HEADERS before rejection" {
+    const allocator = testing.allocator;
+    var client_transport = MockTransport.init(allocator, true);
+    defer client_transport.deinit();
+    var server_transport = MockTransport.init(allocator, false);
+    defer server_transport.deinit();
+    client_transport.peer = &server_transport;
+    server_transport.peer = &client_transport;
+
+    const H3 = Conn(MockTransport);
+    var client = H3.init(allocator, .client);
+    defer client.deinit();
+    var client_events = EventRecorder{};
+    defer client_events.deinit(allocator);
+    client.setEventSink(client_events.sink());
+
+    const id = try client.sendRequest(&client_transport, .{ .authority = "tardigrade.test", .path = "/duplicate-headers" });
+    var wire: [512]u8 = undefined;
+    var len: usize = 0;
+    const first = try session.ResponseEncoder.encodeHeaders(200, &.{}, wire[len..]);
+    len += first.len;
+    const second = try session.ResponseEncoder.encodeHeaders(200, &.{}, wire[len..]);
+    len += second.len;
+    _ = try server_transport.writeStream(id, wire[0..len], true);
+    try client.pump(&client_transport);
+
+    try testing.expectError(error.ProtocolError, client.pollResponse(id));
+    try testing.expect(client_events.sawFrame(.parsed, .headers));
+}
+
+test "H3 conn: client observes response DATA before missing-headers rejection" {
+    const allocator = testing.allocator;
+    var client_transport = MockTransport.init(allocator, true);
+    defer client_transport.deinit();
+    var server_transport = MockTransport.init(allocator, false);
+    defer server_transport.deinit();
+    client_transport.peer = &server_transport;
+    server_transport.peer = &client_transport;
+
+    const H3 = Conn(MockTransport);
+    var client = H3.init(allocator, .client);
+    defer client.deinit();
+    var client_events = EventRecorder{};
+    defer client_events.deinit(allocator);
+    client.setEventSink(client_events.sink());
+
+    const id = try client.sendRequest(&client_transport, .{ .authority = "tardigrade.test", .path = "/data-first" });
+    var wire: [64]u8 = undefined;
+    const data = try frame.encodeKnownFrame(.data, "body", &wire);
+    _ = try server_transport.writeStream(id, data, true);
+    try client.pump(&client_transport);
+
+    try testing.expectError(error.ProtocolError, client.pollResponse(id));
+    try testing.expect(client_events.sawFrame(.parsed, .data));
 }
 
 test "H3 conn: event sink observes settings stream frames and priority updates" {
@@ -1407,6 +1652,103 @@ test "H3 conn: control frame observer reports GOAWAY before semantic rejection" 
 
     try testing.expectError(error.ProtocolError, client.pump(&client_transport));
     try testing.expect(client_events.sawGoawayParsed(1));
+}
+
+test "H3 conn: SETTINGS frame events preserve wire entries before semantic policy" {
+    const allocator = testing.allocator;
+    var client_transport = MockTransport.init(allocator, true);
+    defer client_transport.deinit();
+    var server_transport = MockTransport.init(allocator, false);
+    defer server_transport.deinit();
+    client_transport.peer = &server_transport;
+    server_transport.peer = &client_transport;
+
+    const H3 = Conn(MockTransport);
+    var client = H3.init(allocator, .client);
+    defer client.deinit();
+    var client_events = EventRecorder{};
+    defer client_events.deinit(allocator);
+    client.setEventSink(client_events.sink());
+
+    const control = try server_transport.openStream(.uni);
+    var settings_entries: [10]frame.Setting = undefined;
+    settings_entries[0] = .{ .id = .qpack_blocked_streams, .id_value = 0x07, .value = 0 };
+    settings_entries[1] = .{ .id = .enable_connect_protocol, .id_value = 0x08, .value = 0 };
+    inline for (0..8) |i| {
+        settings_entries[i + 2] = .{ .id = .unknown, .id_value = 0x21 + i, .value = i };
+    }
+    var payload: [128]u8 = undefined;
+    const settings_payload = try frame.encodeSettings(&settings_entries, &payload);
+    var wire: [160]u8 = undefined;
+    var len: usize = 0;
+    len += (try frame.encodeStreamType(.control, wire[len..])).len;
+    len += (try frame.encodeKnownFrame(.settings, settings_payload, wire[len..])).len;
+    _ = try server_transport.writeStream(control, wire[0..len], false);
+
+    try client.pump(&client_transport);
+    try testing.expect(client_events.sawSettingsEntry(0x07, 0));
+    try testing.expect(client_events.sawSettingsEntry(0x08, 0));
+    try testing.expect(client_events.sawSettingsEntry(0x21, 0));
+    try testing.expect(client_events.sawSettingsEntryCountAtLeast(10));
+}
+
+test "H3 conn: rejected SETTINGS frame remains observable" {
+    const allocator = testing.allocator;
+    var client_transport = MockTransport.init(allocator, true);
+    defer client_transport.deinit();
+    var server_transport = MockTransport.init(allocator, false);
+    defer server_transport.deinit();
+    client_transport.peer = &server_transport;
+    server_transport.peer = &client_transport;
+
+    const H3 = Conn(MockTransport);
+    var client = H3.init(allocator, .client);
+    defer client.deinit();
+    var client_events = EventRecorder{};
+    defer client_events.deinit(allocator);
+    client.setEventSink(client_events.sink());
+
+    const control = try server_transport.openStream(.uni);
+    var payload: [32]u8 = undefined;
+    const settings_payload = try frame.encodeSettings(&.{
+        .{ .id = .unknown, .id_value = 0x02, .value = 1 },
+        .{ .id = .qpack_blocked_streams, .id_value = 0x07, .value = 0 },
+    }, &payload);
+    var wire: [64]u8 = undefined;
+    var len: usize = 0;
+    len += (try frame.encodeStreamType(.control, wire[len..])).len;
+    len += (try frame.encodeKnownFrame(.settings, settings_payload, wire[len..])).len;
+    _ = try server_transport.writeStream(control, wire[0..len], false);
+
+    try testing.expectError(error.ProtocolError, client.pump(&client_transport));
+    try testing.expect(client_events.sawSettingsEntry(0x02, 1));
+    try testing.expect(client_events.sawSettingsEntry(0x07, 0));
+}
+
+test "H3 conn: unknown request frame is observed as unknown" {
+    const allocator = testing.allocator;
+    var client_transport = MockTransport.init(allocator, true);
+    defer client_transport.deinit();
+    var server_transport = MockTransport.init(allocator, false);
+    defer server_transport.deinit();
+    client_transport.peer = &server_transport;
+    server_transport.peer = &client_transport;
+
+    const H3 = Conn(MockTransport);
+    var server = H3.init(allocator, .server);
+    defer server.deinit();
+    var server_events = EventRecorder{};
+    defer server_events.deinit(allocator);
+    server.setEventSink(server_events.sink());
+
+    const id = try client_transport.openStream(.bidi);
+    var wire: [32]u8 = undefined;
+    const unknown = try frame.encodeFrame(0x21, "", &wire);
+    _ = try client_transport.writeStream(id, unknown, false);
+
+    try server.pump(&server_transport);
+    try testing.expect(server_events.sawUnknownFrame(0x21));
+    try testing.expect(!server_events.sawFrame(.parsed, .data));
 }
 
 test "H3 conn: frame_created is emitted when encoded request write fails" {

--- a/src/http3/conn.zig
+++ b/src/http3/conn.zig
@@ -23,6 +23,94 @@ const varint = @import("quic_varint");
 
 pub const Role = enum { client, server };
 
+pub const EventStreamType = enum {
+    request,
+    control,
+    push,
+    qpack_encoder,
+    qpack_decoder,
+    unknown,
+};
+
+pub const EventInitiator = enum { local, remote };
+
+pub const EventFrame = union(enum) {
+    data: struct {
+        raw_length: usize,
+    },
+    headers: struct {
+        fields: []const qpack.HeaderField = &.{},
+        raw_length: usize,
+    },
+    settings: struct {
+        settings: frame.Settings,
+        raw_length: usize,
+    },
+    goaway: struct {
+        id: u64,
+        raw_length: usize,
+    },
+    priority_update: union(enum) {
+        request: struct {
+            stream_id: u64,
+            field_value: []const u8,
+            raw_length: usize,
+        },
+        push: struct {
+            push_id: u64,
+            field_value: []const u8,
+            raw_length: usize,
+        },
+    },
+    push_promise: struct {
+        push_id: u64,
+        raw_length: usize,
+    },
+    cancel_push: struct {
+        push_id: u64,
+        raw_length: usize,
+    },
+    max_push_id: struct {
+        push_id: u64,
+        raw_length: usize,
+    },
+};
+
+pub const Event = union(enum) {
+    parameters_set: struct {
+        initiator: EventInitiator,
+        settings: frame.Settings,
+    },
+    stream_type_set: struct {
+        stream_id: u64,
+        stream_type: EventStreamType,
+    },
+    frame_created: struct {
+        stream_id: u64,
+        frame: EventFrame,
+    },
+    frame_parsed: struct {
+        stream_id: u64,
+        frame: EventFrame,
+    },
+    priority_updated: struct {
+        stream_id: u64,
+        urgency: u3,
+        incremental: bool,
+    },
+};
+
+/// Diagnostics hook for H3/qlog. Must not block or feed errors back into
+/// protocol state; sinks retain failures out-of-band.
+pub const EventSink = struct {
+    context: ?*anyopaque = null,
+    emitFn: ?*const fn (?*anyopaque, Event) void = null,
+
+    pub fn emit(self: EventSink, event: Event) void {
+        if (self.emitFn) |emit_fn| emit_fn(self.context, event);
+    }
+};
+
 pub const H3Error = error{
     OutOfMemory,
     ProtocolError,
@@ -99,6 +187,7 @@ pub fn Conn(comptime Transport: type) type {
         local_goaway_id: ?u64 = null,
         /// Bidirectional streams the peer opened that we haven't classified.
         metrics: Metrics = .{},
+        events: EventSink = .{},
         /// The RFC 9114 code to close the QUIC connection with after a
         /// method returned `error.ProtocolError`; see `closeCode`.
         close_code: ?ErrorCode = null,
@@ -174,6 +263,10 @@ pub fn Conn(comptime Transport: type) type {
                 .pending_priority_updates = std.AutoHashMap(u64, priority.Priority).init(allocator),
                 .responses = std.AutoHashMap(u64, *ClientResponse).init(allocator),
             };
+        }
+
+        pub fn setEventSink(self: *Self, sink: EventSink) void {
+            self.events = sink;
         }
 
         pub fn deinit(self: *Self) void {
@@ -259,9 +352,13 @@ pub fn Conn(comptime Transport: type) type {
             var settings_payload: [64]u8 = undefined;
             var settings_entries: [5]frame.Setting = undefined;
             const settings = try encodeLocalSettings(self.local_settings, &settings_entries, &settings_payload);
-            len += (try frame.encodeKnownFrame(.settings, settings, bytes[len..])).len;
+            const settings_frame = try frame.encodeKnownFrame(.settings, settings, bytes[len..]);
+            len += settings_frame.len;
+            self.events.emit(.{ .stream_type_set = .{ .stream_id = control, .stream_type = .control } });
+            self.events.emit(.{ .frame_created = .{ .stream_id = control, .frame = .{ .settings = .{ .settings = self.local_settings, .raw_length = settings_frame.len } } } });
             _ = try transport.writeStream(control, bytes[0..len], false);
             self.control_out = control;
+            self.events.emit(.{ .parameters_set = .{ .initiator = .local, .settings = self.local_settings } });
             if (self.role == .client) try self.publishEarlyTicketSnapshot(transport);
         }
 
@@ -322,6 +419,7 @@ pub fn Conn(comptime Transport: type) type {
                         .stream = session.RequestStream.init(self.allocator, id),
                         .transport_early = transportStreamTransportEarly(transport, id),
                     };
+                    self.events.emit(.{ .stream_type_set = .{ .stream_id = id, .stream_type = .request } });
                     if (self.pending_priority_updates.fetchRemove(id)) |pending| {
                         request.pending_priority_update = pending.value;
                     }
@@ -363,6 +461,7 @@ pub fn Conn(comptime Transport: type) type {
                         const decoded = frame.decodeStreamType(bytes) catch break;
                         state.classified = true;
                         state.typ = decoded.typ;
+                        self.events.emit(.{ .stream_type_set = .{ .stream_id = id, .stream_type = eventStreamTypeFromWire(decoded.typ) } });
                         // The control-stream view consumes its own stream-type
                         // varint; strip it only for the other types.
                         if (decoded.typ != .control) bytes = bytes[decoded.len..];
@@ -448,6 +547,12 @@ pub fn Conn(comptime Transport: type) type {
         }
 
         fn ingestControlFrame(self: *Self, transport: *Transport, raw: frame.RawFrame) H3Error!void {
+            const had_settings = self.peer_control_view.saw_settings;
+            if (self.peer_control) |control| {
+                if (eventFrameFromRaw(raw)) |event_frame| {
+                    self.events.emit(.{ .frame_parsed = .{ .stream_id = control, .frame = event_frame } });
+                }
+            }
             switch (raw.typ) {
                 .priority_update_request, .priority_update_push => {
                     if (!self.peer_control_view.saw_settings) return self.fail(.missing_settings);
@@ -458,6 +563,9 @@ pub fn Conn(comptime Transport: type) type {
                     try self.applyGoaway(raw);
                 },
                 else => self.peer_control_view.ingestFrame(raw) catch |err| return self.failControl(err),
+            }
+            if (!had_settings and self.peer_control_view.saw_settings) {
+                self.events.emit(.{ .parameters_set = .{ .initiator = .remote, .settings = self.peer_control_view.settings } });
             }
         }
 
@@ -491,7 +599,7 @@ pub fn Conn(comptime Transport: type) type {
             if (parsed.duplicate_parameter) self.metrics.priority_duplicate_parameters += 1;
             if (self.requests.get(update.element_id)) |request| {
                 request.pending_priority_update = parsed.effective();
-                if (request.stream.saw_headers) self.applyPendingPriorityUpdate(request);
+                if (request.stream.saw_headers) self.applyPendingPriorityUpdate(update.element_id, request);
                 _ = applyTransportPriority(transport, update.element_id, parsed.effective());
             } else {
                 if (applyTransportPriority(transport, update.element_id, parsed.effective())) return;
@@ -504,6 +612,30 @@ pub fn Conn(comptime Transport: type) type {
                 self.metrics.priority_updates_buffered += 1;
             }
         }
+
+        const RequestFrameObserver = struct {
+            conn: *Self,
+            stream_id: u64,
+
+            fn observer(self: *RequestFrameObserver) session.RequestStream.FrameObserver {
+                return .{ .context = self, .parsedFn = parsed };
+            }
+
+            fn parsed(ctx: ?*anyopaque, raw: frame.RawFrame) void {
+                const self: *RequestFrameObserver = @ptrCast(@alignCast(ctx.?));
+                if (raw.typ == .headers) {
+                    var fields: [128]qpack.HeaderField = undefined;
+                    var scratch: [4096]u8 = undefined;
+                    const count = qpack.decode(raw.payload, &fields, &scratch) catch 0;
+                    self.conn.events.emit(.{ .frame_parsed = .{ .stream_id = self.stream_id, .frame = .{ .headers = .{
+                        .fields = fields[0..count],
+                        .raw_length = raw.len,
+                    } } } });
+                    return;
+                }
+                self.conn.events.emit(.{ .frame_parsed = .{ .stream_id = self.stream_id, .frame = eventFrameFromRaw(raw) orelse .{ .data = .{ .raw_length = raw.len } } } });
+            }
+        };
 
         fn pumpRequests(self: *Self, transport: *Transport) H3Error!void {
             var reset_requests: std.ArrayList(u64) = .empty;
@@ -524,12 +656,13 @@ pub fn Conn(comptime Transport: type) type {
                     };
                     request.transport_early = request.transport_early or transportStreamTransportEarly(transport, id);
                     if (result.len > 0) {
-                        _ = request.stream.ingestBytes(buf[0..result.len], &qpack_scratch) catch |err| {
+                        var observer = RequestFrameObserver{ .conn = self, .stream_id = id };
+                        _ = request.stream.ingestBytesWithObserver(buf[0..result.len], &qpack_scratch, observer.observer()) catch |err| {
                             if (err == error.UnexpectedFrame) return self.fail(.frame_unexpected);
                             return self.fail(.message_error);
                         };
                         self.recordPriorityHeaderMetrics(request);
-                        self.applyPendingPriorityUpdate(request);
+                        self.applyPendingPriorityUpdate(id, request);
                     }
                     if (result.fin) {
                         request.finished = true;
@@ -541,11 +674,16 @@ pub fn Conn(comptime Transport: type) type {
             for (reset_requests.items) |id| self.finishRequest(id);
         }
 
-        fn applyPendingPriorityUpdate(_: *Self, request: *ServerRequest) void {
+        fn applyPendingPriorityUpdate(self: *Self, stream_id: u64, request: *ServerRequest) void {
             if (!request.stream.saw_headers) return;
             if (request.pending_priority_update) |update| {
                 request.stream.priority = update;
                 request.pending_priority_update = null;
+                self.events.emit(.{ .priority_updated = .{
+                    .stream_id = stream_id,
+                    .urgency = update.urgency,
+                    .incremental = update.incremental,
+                } });
             }
         }
 
@@ -622,6 +760,7 @@ pub fn Conn(comptime Transport: type) type {
             std.debug.assert(self.role == .client);
             if (self.peer_goaway_id != null) return error.GoawayReceived;
             const id = try transport.openStream(.bidi);
+            self.events.emit(.{ .stream_type_set = .{ .stream_id = id, .stream_type = .request } });
 
             var fields_buf: [68]qpack.HeaderField = undefined;
             fields_buf[0] = .{ .name = ":method", .value = request.method };
@@ -635,9 +774,15 @@ pub fn Conn(comptime Transport: type) type {
             const header_block = try qpack.encode(fields_buf[0 .. 4 + request.headers.len], &block);
             var wire: [8192]u8 = undefined;
             var len: usize = 0;
-            len += (try frame.encodeKnownFrame(.headers, header_block, wire[len..])).len;
+            const headers_frame = try frame.encodeKnownFrame(.headers, header_block, wire[len..]);
+            len += headers_frame.len;
+            self.events.emit(.{ .frame_created = .{ .stream_id = id, .frame = .{ .headers = .{ .fields = fields_buf[0 .. 4 + request.headers.len], .raw_length = headers_frame.len } } } });
+            var data_frame_len: usize = 0;
             if (request.body.len > 0) {
-                len += (try frame.encodeKnownFrame(.data, request.body, wire[len..])).len;
+                const data_frame = try frame.encodeKnownFrame(.data, request.body, wire[len..]);
+                data_frame_len = data_frame.len;
+                len += data_frame.len;
+                self.events.emit(.{ .frame_created = .{ .stream_id = id, .frame = .{ .data = .{ .raw_length = data_frame_len } } } });
             }
             var written: usize = 0;
             while (written < len) {
@@ -673,11 +818,13 @@ pub fn Conn(comptime Transport: type) type {
                         if (status != null) return error.ProtocolError;
                         var scratch: []u8 = &response.scratch;
                         field_count = qpack.decode(raw.payload, &response.fields, scratch[0..]) catch return error.ProtocolError;
+                        self.events.emit(.{ .frame_parsed = .{ .stream_id = id, .frame = .{ .headers = .{ .fields = response.fields[0..field_count], .raw_length = raw.len } } } });
                         if (field_count == 0) return error.ProtocolError;
                         if (!std.mem.eql(u8, response.fields[0].name, ":status")) return error.ProtocolError;
                         status = std.fmt.parseInt(u16, response.fields[0].value, 10) catch return error.ProtocolError;
                     },
                     .data => {
+                        self.events.emit(.{ .frame_parsed = .{ .stream_id = id, .frame = .{ .data = .{ .raw_length = raw.len } } } });
                         if (status == null) return error.ProtocolError;
                         if (body_len == 0) {
                             body_start = offset + (raw.len - raw.payload.len);
@@ -693,7 +840,12 @@ pub fn Conn(comptime Transport: type) type {
                         }
                         body_len += raw.payload.len;
                     },
-                    .priority_update_request, .priority_update_push => return self.fail(.frame_unexpected),
+                    .priority_update_request, .priority_update_push => {
+                        if (eventFrameFromRaw(raw)) |event_frame| {
+                            self.events.emit(.{ .frame_parsed = .{ .stream_id = id, .frame = event_frame } });
+                        }
+                        return self.fail(.frame_unexpected);
+                    },
                     else => {}, // unknown frames on request streams are ignored (RFC 9114 §9)
                 }
                 offset += raw.len;
@@ -768,6 +920,13 @@ pub fn Conn(comptime Transport: type) type {
         ) !void {
             var wire: [8192]u8 = undefined;
             const header_frame = try session.ResponseEncoder.encodeHeaders(status, headers, &wire);
+            var event_fields: [129]qpack.HeaderField = undefined;
+            var status_buf: [3]u8 = undefined;
+            const status_text = std.fmt.bufPrint(&status_buf, "{d}", .{status}) catch "500";
+            event_fields[0] = .{ .name = ":status", .value = status_text };
+            if (headers.len > event_fields.len - 1) return error.TooManyHeaders;
+            for (headers, 0..) |header, i| event_fields[i + 1] = .{ .name = header.name, .value = header.value };
+            self.events.emit(.{ .frame_created = .{ .stream_id = stream_id, .frame = .{ .headers = .{ .fields = event_fields[0 .. headers.len + 1], .raw_length = header_frame.len } } } });
             try self.writeAll(transport, stream_id, header_frame, body.len == 0);
 
             var offset: usize = 0;
@@ -775,6 +934,7 @@ pub fn Conn(comptime Transport: type) type {
                 const chunk_len = @min(body.len - offset, 4096);
                 const chunk = try session.ResponseEncoder.encodeData(body[offset..][0..chunk_len], &wire);
                 offset += chunk_len;
+                self.events.emit(.{ .frame_created = .{ .stream_id = stream_id, .frame = .{ .data = .{ .raw_length = chunk.len } } } });
                 try self.writeAll(transport, stream_id, chunk, offset == body.len);
             }
             self.finishRequest(stream_id);
@@ -787,6 +947,7 @@ pub fn Conn(comptime Transport: type) type {
             }
             var wire: [32]u8 = undefined;
             const goaway = try session.ResponseEncoder.encodeGoaway(stream_id, &wire);
+            self.events.emit(.{ .frame_created = .{ .stream_id = control, .frame = .{ .goaway = .{ .id = stream_id, .raw_length = goaway.len } } } });
             try self.writeAll(transport, control, goaway, false);
             self.local_goaway_id = stream_id;
         }
@@ -840,6 +1001,61 @@ fn containsPriorityUpdateFrame(bytes: []const u8) bool {
     return false;
 }
 
+fn eventFrameFromRaw(raw: frame.RawFrame) ?EventFrame {
+    return switch (raw.typ) {
+        .data => .{ .data = .{ .raw_length = raw.len } },
+        .headers => .{ .headers = .{ .raw_length = raw.len } },
+        .settings => blk: {
+            var scratch: [8]frame.Setting = undefined;
+            const decoded = frame.decodeSettings(raw.payload, &scratch) catch return .{ .settings = .{ .settings = .{}, .raw_length = raw.len } };
+            break :blk .{ .settings = .{ .settings = decoded.parsed, .raw_length = raw.len } };
+        },
+        .goaway => blk: {
+            const decoded = varint.decode(raw.payload) catch return .{ .goaway = .{ .id = 0, .raw_length = raw.len } };
+            break :blk .{ .goaway = .{ .id = decoded.value, .raw_length = raw.len } };
+        },
+        .priority_update_request, .priority_update_push => blk: {
+            const decoded = priority.decodePayload(raw.payload) catch return null;
+            const kind = priority.kindFromFrameType(raw.typ) orelse return null;
+            break :blk switch (kind) {
+                .request => .{ .priority_update = .{ .request = .{
+                    .stream_id = decoded.element_id,
+                    .field_value = decoded.field_value,
+                    .raw_length = raw.len,
+                } } },
+                .push => .{ .priority_update = .{ .push = .{
+                    .push_id = decoded.element_id,
+                    .field_value = decoded.field_value,
+                    .raw_length = raw.len,
+                } } },
+            };
+        },
+        .push_promise => blk: {
+            const decoded = varint.decode(raw.payload) catch return .{ .push_promise = .{ .push_id = 0, .raw_length = raw.len } };
+            break :blk .{ .push_promise = .{ .push_id = decoded.value, .raw_length = raw.len } };
+        },
+        .cancel_push => blk: {
+            const decoded = varint.decode(raw.payload) catch return .{ .cancel_push = .{ .push_id = 0, .raw_length = raw.len } };
+            break :blk .{ .cancel_push = .{ .push_id = decoded.value, .raw_length = raw.len } };
+        },
+        .max_push_id => blk: {
+            const decoded = varint.decode(raw.payload) catch return .{ .max_push_id = .{ .push_id = 0, .raw_length = raw.len } };
+            break :blk .{ .max_push_id = .{ .push_id = decoded.value, .raw_length = raw.len } };
+        },
+        .unknown => null,
+    };
+}
+
+fn eventStreamTypeFromWire(typ: frame.StreamType) EventStreamType {
+    return switch (typ) {
+        .control => .control,
+        .push => .push,
+        .qpack_encoder => .qpack_encoder,
+        .qpack_decoder => .qpack_decoder,
+        .unknown => .unknown,
+    };
+}
+
 // ---------------------------------------------------------------------------
 // Tests with an in-memory mock transport (the full QUIC-backed end-to-end
 // path is exercised in tests/quic_h3_e2e.zig).
@@ -865,6 +1081,8 @@ const MockTransport = struct {
     next_bidi: u64 = 0,
     next_uni: u64 = 0,
     accepted: std.ArrayList(u64) = .empty,
+    write_calls: usize = 0,
+    fail_writes_after: ?usize = null,
 
     fn init(allocator: std.mem.Allocator, is_client: bool) MockTransport {
         return .{
@@ -912,6 +1130,10 @@ const MockTransport = struct {
     }
 
     pub fn writeStream(self: *MockTransport, id: u64, bytes: []const u8, fin: bool) !usize {
+        if (self.fail_writes_after) |limit| {
+            if (self.write_calls >= limit) return error.StreamBackpressure;
+        }
+        self.write_calls += 1;
         const target = self.peer orelse return error.UnknownStream;
         const s = try target.stream(id);
         try s.data.appendSlice(target.allocator, bytes);
@@ -945,6 +1167,108 @@ const MockTransport = struct {
     fn resetStreamForTest(self: *MockTransport, id: u64) !void {
         const s = try self.stream(id);
         s.reset = true;
+    }
+};
+
+const EventRecorder = struct {
+    events: std.ArrayList(Event) = .empty,
+
+    fn deinit(self: *EventRecorder, allocator: std.mem.Allocator) void {
+        self.events.deinit(allocator);
+    }
+
+    fn sink(self: *EventRecorder) EventSink {
+        return .{ .context = self, .emitFn = emit };
+    }
+
+    fn emit(ctx: ?*anyopaque, event: Event) void {
+        const self: *EventRecorder = @ptrCast(@alignCast(ctx.?));
+        self.events.append(testing.allocator, event) catch unreachable;
+    }
+
+    fn eventFrameType(event_frame: EventFrame) frame.FrameType {
+        return switch (event_frame) {
+            .data => .data,
+            .headers => .headers,
+            .settings => .settings,
+            .goaway => .goaway,
+            .priority_update => |update| switch (update) {
+                .request => .priority_update_request,
+                .push => .priority_update_push,
+            },
+            .push_promise => .push_promise,
+            .cancel_push => .cancel_push,
+            .max_push_id => .max_push_id,
+        };
+    }
+
+    fn eventFrameRawLength(event_frame: EventFrame) usize {
+        return switch (event_frame) {
+            .data => |f| f.raw_length,
+            .headers => |f| f.raw_length,
+            .settings => |f| f.raw_length,
+            .goaway => |f| f.raw_length,
+            .priority_update => |update| switch (update) {
+                .request => |f| f.raw_length,
+                .push => |f| f.raw_length,
+            },
+            .push_promise => |f| f.raw_length,
+            .cancel_push => |f| f.raw_length,
+            .max_push_id => |f| f.raw_length,
+        };
+    }
+
+    fn sawFrame(self: *const EventRecorder, direction: enum { created, parsed }, typ: frame.FrameType) bool {
+        for (self.events.items) |event| switch (event) {
+            .frame_created => |f| if (direction == .created and eventFrameType(f.frame) == typ) return true,
+            .frame_parsed => |f| if (direction == .parsed and eventFrameType(f.frame) == typ) return true,
+            else => {},
+        };
+        return false;
+    }
+
+    fn sawStreamType(self: *const EventRecorder, typ: EventStreamType) bool {
+        for (self.events.items) |event| switch (event) {
+            .stream_type_set => |s| if (s.stream_type == typ) return true,
+            else => {},
+        };
+        return false;
+    }
+
+    fn sawFrameWithLength(self: *const EventRecorder, direction: enum { created, parsed }, typ: frame.FrameType, length: usize) bool {
+        for (self.events.items) |event| switch (event) {
+            .frame_created => |f| if (direction == .created and eventFrameType(f.frame) == typ and eventFrameRawLength(f.frame) == length) return true,
+            .frame_parsed => |f| if (direction == .parsed and eventFrameType(f.frame) == typ and eventFrameRawLength(f.frame) == length) return true,
+            else => {},
+        };
+        return false;
+    }
+
+    fn sawParametersSet(self: *const EventRecorder) bool {
+        for (self.events.items) |event| switch (event) {
+            .parameters_set => return true,
+            else => {},
+        };
+        return false;
+    }
+
+    fn sawGoawayParsed(self: *const EventRecorder, id: u64) bool {
+        for (self.events.items) |event| switch (event) {
+            .frame_parsed => |parsed| switch (parsed.frame) {
+                .goaway => |g| if (g.id == id) return true,
+                else => {},
+            },
+            else => {},
+        };
+        return false;
+    }
+
+    fn sawPriorityUpdated(self: *const EventRecorder, stream_id: u64, urgency: u3, incremental: bool) bool {
+        for (self.events.items) |event| switch (event) {
+            .priority_updated => |p| if (p.stream_id == stream_id and p.urgency == urgency and p.incremental == incremental) return true,
+            else => {},
+        };
+        return false;
     }
 };
 
@@ -990,6 +1314,126 @@ test "H3 conn: SETTINGS exchange and request/response over a mock transport" {
     try testing.expectEqualStrings("pong", response.body);
     try testing.expectEqualStrings("server", response.headers[0].name);
     client.releaseResponse(id);
+}
+
+test "H3 conn: event sink observes settings stream frames and priority updates" {
+    const allocator = testing.allocator;
+    var client_transport = MockTransport.init(allocator, true);
+    defer client_transport.deinit();
+    var server_transport = MockTransport.init(allocator, false);
+    defer server_transport.deinit();
+    client_transport.peer = &server_transport;
+    server_transport.peer = &client_transport;
+
+    const H3 = Conn(MockTransport);
+    var client = H3.init(allocator, .client);
+    defer client.deinit();
+    var server = H3.init(allocator, .server);
+    defer server.deinit();
+
+    var client_events = EventRecorder{};
+    defer client_events.deinit(allocator);
+    var server_events = EventRecorder{};
+    defer server_events.deinit(allocator);
+    client.setEventSink(client_events.sink());
+    server.setEventSink(server_events.sink());
+
+    try client.start(&client_transport);
+    try server.start(&server_transport);
+    try server.pump(&server_transport);
+    try client.pump(&client_transport);
+
+    try testing.expect(client_events.sawFrame(.created, .settings));
+    try testing.expect(client_events.sawParametersSet());
+    try testing.expect(server_events.sawFrame(.parsed, .settings));
+    try testing.expect(server_events.sawStreamType(.control));
+    try testing.expect(server_events.sawParametersSet());
+
+    var expected_body_frame: [64]u8 = undefined;
+    const expected_data_len = (try frame.encodeKnownFrame(.data, "body", &expected_body_frame)).len;
+    const request_id = try client.sendRequest(&client_transport, .{
+        .authority = "tardigrade.test",
+        .path = "/priority",
+        .headers = &.{.{ .name = "priority", .value = "u=1, i" }},
+        .body = "body",
+    });
+    try testing.expect(client_events.sawStreamType(.request));
+    try testing.expect(client_events.sawFrame(.created, .headers));
+    try testing.expect(client_events.sawFrameWithLength(.created, .data, expected_data_len));
+    try server.pump(&server_transport);
+    try testing.expect(server_events.sawStreamType(.request));
+    try testing.expect(server_events.sawFrame(.parsed, .headers));
+    try testing.expect(server_events.sawFrameWithLength(.parsed, .data, expected_data_len));
+
+    var payload: [32]u8 = undefined;
+    const priority_payload = try priority.encodePayload(.{ .element_id = request_id, .field_value = "u=2" }, &payload);
+    var wire: [64]u8 = undefined;
+    const priority_frame = try frame.encodeKnownFrame(.priority_update_request, priority_payload, &wire);
+    _ = try client_transport.writeStream(client.control_out.?, priority_frame, false);
+    try server.pump(&server_transport);
+    try testing.expect(server_events.sawFrame(.parsed, .priority_update_request));
+    try testing.expect(server_events.sawPriorityUpdated(request_id, 2, false));
+}
+
+test "H3 conn: control frame observer reports GOAWAY before semantic rejection" {
+    const allocator = testing.allocator;
+    var client_transport = MockTransport.init(allocator, true);
+    defer client_transport.deinit();
+    var server_transport = MockTransport.init(allocator, false);
+    defer server_transport.deinit();
+    client_transport.peer = &server_transport;
+    server_transport.peer = &client_transport;
+
+    const H3 = Conn(MockTransport);
+    var client = H3.init(allocator, .client);
+    defer client.deinit();
+    var server = H3.init(allocator, .server);
+    defer server.deinit();
+
+    var client_events = EventRecorder{};
+    defer client_events.deinit(allocator);
+    client.setEventSink(client_events.sink());
+
+    try client.start(&client_transport);
+    try server.start(&server_transport);
+    try client.pump(&client_transport);
+    try testing.expect(client.metrics.settings_received);
+
+    var payload: [8]u8 = undefined;
+    const payload_len = try varint.encode(1, &payload);
+    var wire: [16]u8 = undefined;
+    const goaway = try frame.encodeKnownFrame(.goaway, payload[0..payload_len], &wire);
+    _ = try server_transport.writeStream(server.control_out.?, goaway, false);
+
+    try testing.expectError(error.ProtocolError, client.pump(&client_transport));
+    try testing.expect(client_events.sawGoawayParsed(1));
+}
+
+test "H3 conn: frame_created is emitted when encoded request write fails" {
+    const allocator = testing.allocator;
+    var client_transport = MockTransport.init(allocator, true);
+    defer client_transport.deinit();
+    var server_transport = MockTransport.init(allocator, false);
+    defer server_transport.deinit();
+    client_transport.peer = &server_transport;
+    server_transport.peer = &client_transport;
+    client_transport.fail_writes_after = 0;
+
+    const H3 = Conn(MockTransport);
+    var client = H3.init(allocator, .client);
+    defer client.deinit();
+    var client_events = EventRecorder{};
+    defer client_events.deinit(allocator);
+    client.setEventSink(client_events.sink());
+
+    try testing.expectError(error.StreamBackpressure, client.sendRequest(&client_transport, .{
+        .authority = "tardigrade.test",
+        .path = "/blocked",
+        .body = "body",
+    }));
+    try testing.expect(client_events.sawStreamType(.request));
+    try testing.expect(client_events.sawFrame(.created, .headers));
+    try testing.expect(client_events.sawFrame(.created, .data));
 }
 
 test "H3 conn: sendGoaway writes the selected request boundary on the control stream" {

--- a/src/http3/conn.zig
+++ b/src/http3/conn.zig
@@ -83,6 +83,11 @@ pub const EventFrame = union(enum) {
         frame_type_value: u64,
         raw_length: usize,
     },
+    malformed: struct {
+        frame_type: frame.FrameType,
+        frame_type_value: u64,
+        raw_length: usize,
+    },
 };
 
 pub const Event = union(enum) {
@@ -645,7 +650,10 @@ pub fn Conn(comptime Transport: type) type {
                 if (raw.typ == .headers) {
                     var fields: [128]qpack.HeaderField = undefined;
                     var scratch: [4096]u8 = undefined;
-                    const count = qpack.decode(raw.payload, &fields, &scratch) catch 0;
+                    const count = qpack.decode(raw.payload, &fields, &scratch) catch {
+                        self.conn.events.emit(.{ .frame_parsed = .{ .stream_id = self.stream_id, .frame = .{ .malformed = .{ .frame_type = raw.typ, .frame_type_value = raw.type_value, .raw_length = raw.len } } } });
+                        return;
+                    };
                     self.conn.events.emit(.{ .frame_parsed = .{ .stream_id = self.stream_id, .frame = .{ .headers = .{
                         .fields = fields[0..count],
                         .raw_length = raw.len,
@@ -677,7 +685,8 @@ pub fn Conn(comptime Transport: type) type {
                     request.transport_early = request.transport_early or transportStreamTransportEarly(transport, id);
                     if (result.len > 0) {
                         var observer = RequestFrameObserver{ .conn = self, .stream_id = id };
-                        _ = request.stream.ingestBytesWithObserver(buf[0..result.len], &qpack_scratch, observer.observer()) catch |err| {
+                        const frame_observer = if (self.events.emitFn != null) observer.observer() else null;
+                        _ = request.stream.ingestBytesWithObserver(buf[0..result.len], &qpack_scratch, frame_observer) catch |err| {
                             if (err == error.UnexpectedFrame) return self.fail(.frame_unexpected);
                             return self.fail(.message_error);
                         };
@@ -837,7 +846,7 @@ pub fn Conn(comptime Transport: type) type {
                     .headers => {
                         var scratch: []u8 = &response.scratch;
                         field_count = qpack.decode(raw.payload, &response.fields, scratch[0..]) catch {
-                            self.events.emit(.{ .frame_parsed = .{ .stream_id = id, .frame = .{ .headers = .{ .raw_length = raw.len } } } });
+                            self.events.emit(.{ .frame_parsed = .{ .stream_id = id, .frame = .{ .malformed = .{ .frame_type = raw.typ, .frame_type_value = raw.type_value, .raw_length = raw.len } } } });
                             return error.ProtocolError;
                         };
                         self.events.emit(.{ .frame_parsed = .{ .stream_id = id, .frame = .{ .headers = .{ .fields = response.fields[0..field_count], .raw_length = raw.len } } } });
@@ -1042,21 +1051,22 @@ fn decodeEventSettings(payload: []const u8, scratch: []EventSetting) ?[]const Ev
 }
 
 fn eventFrameFromRaw(raw: frame.RawFrame, settings_scratch: []EventSetting) EventFrame {
+    const malformed = EventFrame{ .malformed = .{ .frame_type = raw.typ, .frame_type_value = raw.type_value, .raw_length = raw.len } };
     return switch (raw.typ) {
         .data => .{ .data = .{ .raw_length = raw.len } },
         .headers => .{ .headers = .{ .raw_length = raw.len } },
         .settings => blk: {
-            const entries = decodeEventSettings(raw.payload, settings_scratch) orelse return .{ .unknown = .{ .frame_type_value = raw.type_value, .raw_length = raw.len } };
+            const entries = decodeEventSettings(raw.payload, settings_scratch) orelse return malformed;
             break :blk .{ .settings = .{ .entries = entries, .raw_length = raw.len } };
         },
         .goaway => blk: {
-            const decoded = varint.decode(raw.payload) catch return .{ .unknown = .{ .frame_type_value = raw.type_value, .raw_length = raw.len } };
-            if (decoded.len != raw.payload.len) return .{ .unknown = .{ .frame_type_value = raw.type_value, .raw_length = raw.len } };
+            const decoded = varint.decode(raw.payload) catch return malformed;
+            if (decoded.len != raw.payload.len) return malformed;
             break :blk .{ .goaway = .{ .id = decoded.value, .raw_length = raw.len } };
         },
         .priority_update_request, .priority_update_push => blk: {
-            const decoded = priority.decodePayload(raw.payload) catch return .{ .unknown = .{ .frame_type_value = raw.type_value, .raw_length = raw.len } };
-            const kind = priority.kindFromFrameType(raw.typ) orelse return .{ .unknown = .{ .frame_type_value = raw.type_value, .raw_length = raw.len } };
+            const decoded = priority.decodePayload(raw.payload) catch return malformed;
+            const kind = priority.kindFromFrameType(raw.typ) orelse return malformed;
             break :blk switch (kind) {
                 .request => .{ .priority_update = .{ .request = .{
                     .stream_id = decoded.element_id,
@@ -1070,15 +1080,15 @@ fn eventFrameFromRaw(raw: frame.RawFrame, settings_scratch: []EventSetting) Even
                 } } },
             };
         },
-        .push_promise => .{ .unknown = .{ .frame_type_value = raw.type_value, .raw_length = raw.len } },
+        .push_promise => malformed,
         .cancel_push => blk: {
-            const decoded = varint.decode(raw.payload) catch return .{ .unknown = .{ .frame_type_value = raw.type_value, .raw_length = raw.len } };
-            if (decoded.len != raw.payload.len) return .{ .unknown = .{ .frame_type_value = raw.type_value, .raw_length = raw.len } };
+            const decoded = varint.decode(raw.payload) catch return malformed;
+            if (decoded.len != raw.payload.len) return malformed;
             break :blk .{ .cancel_push = .{ .push_id = decoded.value, .raw_length = raw.len } };
         },
         .max_push_id => blk: {
-            const decoded = varint.decode(raw.payload) catch return .{ .unknown = .{ .frame_type_value = raw.type_value, .raw_length = raw.len } };
-            if (decoded.len != raw.payload.len) return .{ .unknown = .{ .frame_type_value = raw.type_value, .raw_length = raw.len } };
+            const decoded = varint.decode(raw.payload) catch return malformed;
+            if (decoded.len != raw.payload.len) return malformed;
             break :blk .{ .max_push_id = .{ .push_id = decoded.value, .raw_length = raw.len } };
         },
         .unknown => .{ .unknown = .{ .frame_type_value = raw.type_value, .raw_length = raw.len } },
@@ -1312,6 +1322,7 @@ const EventRecorder = struct {
             .cancel_push => .cancel_push,
             .max_push_id => .max_push_id,
             .unknown => .unknown,
+            .malformed => |f| f.frame_type,
         };
     }
 
@@ -1329,6 +1340,7 @@ const EventRecorder = struct {
             .cancel_push => |f| f.raw_length,
             .max_push_id => |f| f.raw_length,
             .unknown => |f| f.raw_length,
+            .malformed => |f| f.raw_length,
         };
     }
 
@@ -1426,6 +1438,21 @@ const EventRecorder = struct {
         return false;
     }
 
+    fn sawMalformedFrame(self: *const EventRecorder, typ: frame.FrameType) bool {
+        for (self.events.items) |event| switch (event) {
+            .frame_created => |parsed| switch (parsed.frame) {
+                .malformed => |malformed| if (malformed.frame_type == typ) return true,
+                else => {},
+            },
+            .frame_parsed => |parsed| switch (parsed.frame) {
+                .malformed => |malformed| if (malformed.frame_type == typ) return true,
+                else => {},
+            },
+            else => {},
+        };
+        return false;
+    }
+
     fn sawPriorityUpdated(self: *const EventRecorder, stream_id: u64, urgency: u3, incremental: bool) bool {
         for (self.events.items) |event| switch (event) {
             .priority_updated => |p| if (p.stream_id == stream_id and p.urgency == urgency and p.incremental == incremental) return true,
@@ -1502,7 +1529,7 @@ test "H3 conn: client observes response HEADERS before QPACK failure" {
     try client.pump(&client_transport);
 
     try testing.expectError(error.ProtocolError, client.pollResponse(id));
-    try testing.expect(client_events.sawFrame(.parsed, .headers));
+    try testing.expect(client_events.sawMalformedFrame(.headers));
 }
 
 test "H3 conn: client observes duplicate response HEADERS before rejection" {
@@ -1749,6 +1776,65 @@ test "H3 conn: unknown request frame is observed as unknown" {
     try server.pump(&server_transport);
     try testing.expect(server_events.sawUnknownFrame(0x21));
     try testing.expect(!server_events.sawFrame(.parsed, .data));
+}
+
+test "H3 conn: malformed known frames are not observed as unknown" {
+    const allocator = testing.allocator;
+    var client_transport = MockTransport.init(allocator, true);
+    defer client_transport.deinit();
+    var server_transport = MockTransport.init(allocator, false);
+    defer server_transport.deinit();
+    client_transport.peer = &server_transport;
+    server_transport.peer = &client_transport;
+
+    const H3 = Conn(MockTransport);
+    var client = H3.init(allocator, .client);
+    defer client.deinit();
+    var server = H3.init(allocator, .server);
+    defer server.deinit();
+    var client_events = EventRecorder{};
+    defer client_events.deinit(allocator);
+    client.setEventSink(client_events.sink());
+
+    try client.start(&client_transport);
+    try server.start(&server_transport);
+    try client.pump(&client_transport);
+
+    var wire: [32]u8 = undefined;
+    const malformed_goaway = try frame.encodeKnownFrame(.goaway, &.{}, &wire);
+    _ = try server_transport.writeStream(server.control_out.?, malformed_goaway, false);
+
+    try testing.expectError(error.ProtocolError, client.pump(&client_transport));
+    try testing.expect(client_events.sawMalformedFrame(.goaway));
+    try testing.expect(!client_events.sawUnknownFrame(@intFromEnum(frame.FrameType.goaway)));
+}
+
+test "H3 conn: PUSH_PROMISE is preserved as malformed known frame until decoded" {
+    const allocator = testing.allocator;
+    var client_transport = MockTransport.init(allocator, true);
+    defer client_transport.deinit();
+    var server_transport = MockTransport.init(allocator, false);
+    defer server_transport.deinit();
+    client_transport.peer = &server_transport;
+    server_transport.peer = &client_transport;
+
+    const H3 = Conn(MockTransport);
+    var server = H3.init(allocator, .server);
+    defer server.deinit();
+    var server_events = EventRecorder{};
+    defer server_events.deinit(allocator);
+    server.setEventSink(server_events.sink());
+
+    const id = try client_transport.openStream(.bidi);
+    var payload: [8]u8 = undefined;
+    const payload_len = try varint.encode(1, &payload);
+    var wire: [32]u8 = undefined;
+    const push_promise = try frame.encodeKnownFrame(.push_promise, payload[0..payload_len], &wire);
+    _ = try client_transport.writeStream(id, push_promise, false);
+
+    try testing.expectError(error.ProtocolError, server.pump(&server_transport));
+    try testing.expect(server_events.sawMalformedFrame(.push_promise));
+    try testing.expect(!server_events.sawUnknownFrame(@intFromEnum(frame.FrameType.push_promise)));
 }
 
 test "H3 conn: frame_created is emitted when encoded request write fails" {

--- a/src/http3/qlog.zig
+++ b/src/http3/qlog.zig
@@ -13,6 +13,8 @@
 //! `qpack_state_updated` is emitted as a documented `tardigrade:*` extension.
 
 const std = @import("std");
+const http3_frame = @import("frame.zig");
+const qpack = @import("qpack.zig");
 
 /// qlog application-vantage namespaces owned by HTTP/3.
 pub const Namespace = enum {
@@ -30,6 +32,7 @@ pub const FrameType = enum {
     headers,
     settings,
     goaway,
+    priority_update,
     push_promise,
     cancel_push,
     max_push_id,
@@ -47,6 +50,7 @@ pub const StreamType = enum {
     qpack_decode,
     request,
     push,
+    unknown,
 };
 
 /// QPACK stream state (RFC 9204 §2.1.2): a request stream becomes `blocked`
@@ -54,14 +58,19 @@ pub const StreamType = enum {
 /// encoder stream, and `unblocked` once the required insert count arrives.
 pub const QpackState = enum { blocked, unblocked };
 
-pub const HttpField = struct {
-    name: []const u8,
-    value: []const u8,
+pub const HttpField = qpack.HeaderField;
+
+pub const SettingName = enum {
+    settings_qpack_max_table_capacity,
+    settings_max_field_section_size,
+    settings_qpack_blocked_streams,
+    settings_enable_connect_protocol,
+    settings_h3_datagram,
 };
 
-pub const Setting = struct {
-    name: []const u8,
-    value: u64,
+pub const HttpPriority = struct {
+    urgency: u3,
+    incremental: bool,
 };
 
 pub const Frame = union(enum) {
@@ -73,12 +82,24 @@ pub const Frame = union(enum) {
         raw_length: ?usize = null,
     },
     settings: struct {
-        settings: []const Setting = &.{},
+        settings: ?http3_frame.Settings = null,
         raw_length: ?usize = null,
     },
     goaway: struct {
         id: u64,
         raw_length: ?usize = null,
+    },
+    priority_update: union(enum) {
+        request: struct {
+            stream_id: u64,
+            priority_field_value: []const u8,
+            raw_length: ?usize = null,
+        },
+        push: struct {
+            push_id: u64,
+            priority_field_value: []const u8,
+            raw_length: ?usize = null,
+        },
     },
     push_promise: struct {
         push_id: u64,
@@ -100,6 +121,7 @@ pub const Frame = union(enum) {
             .headers => .headers,
             .settings => .settings,
             .goaway => .goaway,
+            .priority_update => .priority_update,
             .push_promise => .push_promise,
             .cancel_push => .cancel_push,
             .max_push_id => .max_push_id,
@@ -126,6 +148,11 @@ pub const Event = union(enum) {
         stream_id: u64,
         frame: Frame,
     },
+    /// http3:priority_updated
+    priority_updated: struct {
+        stream_id: u64,
+        new: HttpPriority,
+    },
     /// tardigrade:qpack_stream_state_updated (head-of-line blocking)
     qpack_state_updated: struct {
         state: QpackState,
@@ -134,7 +161,7 @@ pub const Event = union(enum) {
 
     pub fn namespace(self: Event) Namespace {
         return switch (self) {
-            .parameters_set, .stream_type_set, .frame => .http3,
+            .parameters_set, .stream_type_set, .frame, .priority_updated => .http3,
             .qpack_state_updated => .tardigrade,
         };
     }
@@ -147,6 +174,7 @@ pub const Event = union(enum) {
                 .created => "frame_created",
                 .parsed => "frame_parsed",
             },
+            .priority_updated => "priority_updated",
             .qpack_state_updated => "qpack_stream_state_updated",
         };
     }
@@ -203,20 +231,81 @@ fn writeRawLength(b: *Buf, length: ?usize, need_comma: *bool) error{NoSpaceLeft}
     }
 }
 
+fn writeHexNibble(b: *Buf, value: u8) error{NoSpaceLeft}!void {
+    const c: u8 = if (value < 10) '0' + value else 'a' + (value - 10);
+    try b.add("{c}", .{c});
+}
+
+fn writeHexBytes(b: *Buf, value: []const u8) error{NoSpaceLeft}!void {
+    try b.add("\"", .{});
+    for (value) |byte| {
+        try writeHexNibble(b, byte >> 4);
+        try writeHexNibble(b, byte & 0x0f);
+    }
+    try b.add("\"", .{});
+}
+
+fn writeJsonString(b: *Buf, value: []const u8) error{NoSpaceLeft}!void {
+    try b.add("\"", .{});
+    for (value) |byte| {
+        switch (byte) {
+            '"' => try b.add("\\\"", .{}),
+            '\\' => try b.add("\\\\", .{}),
+            0x08 => try b.add("\\b", .{}),
+            0x0c => try b.add("\\f", .{}),
+            '\n' => try b.add("\\n", .{}),
+            '\r' => try b.add("\\r", .{}),
+            '\t' => try b.add("\\t", .{}),
+            else => if (byte >= 0x20) {
+                try b.add("{c}", .{byte});
+            } else {
+                try b.add("\\u00", .{});
+                try writeHexNibble(b, byte >> 4);
+                try writeHexNibble(b, byte & 0x0f);
+            },
+        }
+    }
+    try b.add("\"", .{});
+}
+
+fn writeTextOrBytes(b: *Buf, text_key: []const u8, bytes_key: []const u8, value: []const u8) error{NoSpaceLeft}!void {
+    if (std.unicode.utf8ValidateSlice(value)) {
+        try b.add("\"{s}\":", .{text_key});
+        try writeJsonString(b, value);
+    } else {
+        try b.add("\"{s}\":", .{bytes_key});
+        try writeHexBytes(b, value);
+    }
+}
+
 fn writeHeaders(b: *Buf, headers: []const HttpField) error{NoSpaceLeft}!void {
     try b.add("\"headers\":[", .{});
     for (headers, 0..) |field, i| {
         if (i != 0) try b.add(",", .{});
-        try b.add("{{\"name\":\"{s}\",\"value\":\"{s}\"}}", .{ field.name, field.value });
+        try b.add("{{", .{});
+        try writeTextOrBytes(b, "name", "name_bytes", field.name);
+        try b.add(",", .{});
+        try writeTextOrBytes(b, "value", "value_bytes", field.value);
+        try b.add("}}", .{});
     }
     try b.add("]", .{});
 }
 
-fn writeSettings(b: *Buf, settings: []const Setting) error{NoSpaceLeft}!void {
+fn writeSetting(b: *Buf, name: SettingName, value: u64, first: *bool) error{NoSpaceLeft}!void {
+    if (!first.*) try b.add(",", .{});
+    first.* = false;
+    try b.add("{{\"name\":\"{s}\",\"value\":{d}}}", .{ @tagName(name), value });
+}
+
+fn writeSettings(b: *Buf, settings: ?http3_frame.Settings) error{NoSpaceLeft}!void {
     try b.add("\"settings\":[", .{});
-    for (settings, 0..) |setting, i| {
-        if (i != 0) try b.add(",", .{});
-        try b.add("{{\"name\":\"{s}\",\"value\":{d}}}", .{ setting.name, setting.value });
+    if (settings) |s| {
+        var first = true;
+        if (s.qpack_max_table_capacity != 0) try writeSetting(b, .settings_qpack_max_table_capacity, s.qpack_max_table_capacity, &first);
+        if (s.max_field_section_size) |max| try writeSetting(b, .settings_max_field_section_size, max, &first);
+        if (s.qpack_blocked_streams != 0) try writeSetting(b, .settings_qpack_blocked_streams, s.qpack_blocked_streams, &first);
+        if (s.enable_connect_protocol) try writeSetting(b, .settings_enable_connect_protocol, 1, &first);
+        if (s.h3_datagram) try writeSetting(b, .settings_h3_datagram, 1, &first);
     }
     try b.add("]", .{});
 }
@@ -239,6 +328,20 @@ fn writeFrame(b: *Buf, frame: Frame) error{NoSpaceLeft}!void {
         .goaway => |d| {
             try b.add(",\"id\":{d}", .{d.id});
             try writeRawLength(b, d.raw_length, &need_comma);
+        },
+        .priority_update => |d| {
+            switch (d) {
+                .request => |r| {
+                    try b.add(",\"stream_id\":{d},\"priority_field_value\":", .{r.stream_id});
+                    try writeJsonString(b, r.priority_field_value);
+                    try writeRawLength(b, r.raw_length, &need_comma);
+                },
+                .push => |p| {
+                    try b.add(",\"push_id\":{d},\"priority_field_value\":", .{p.push_id});
+                    try writeJsonString(b, p.priority_field_value);
+                    try writeRawLength(b, p.raw_length, &need_comma);
+                },
+            }
         },
         .push_promise => |d| {
             try b.add(",\"push_id\":{d},", .{d.push_id});
@@ -291,6 +394,11 @@ fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
             try writeFrame(b, d.frame);
             try b.add("}}", .{});
         },
+        .priority_updated => |d| {
+            try b.add("{{\"stream_id\":{d},\"new\":\"u={d}", .{ d.stream_id, d.new.urgency });
+            if (d.new.incremental) try b.add(", i", .{});
+            try b.add("\"}}", .{});
+        },
         .qpack_state_updated => |d| try b.add(
             "{{\"stream_id\":{d},\"state\":\"{s}\"}}",
             .{ d.stream_id, @tagName(d.state) },
@@ -319,11 +427,18 @@ pub fn writeJson(record: Record, out: []u8) error{NoSpaceLeft}![]const u8 {
 const testing = std.testing;
 
 fn expectJson(record: Record, needle: []const u8) !void {
-    var buf: [512]u8 = undefined;
+    var buf: [2048]u8 = undefined;
     const line = try writeJson(record, &buf);
     try testing.expect(line[0] == record_separator);
     try testing.expect(line[line.len - 1] == '\n');
     try testing.expect(std.mem.indexOf(u8, line, needle) != null);
+}
+
+fn expectValidJson(record: Record) !void {
+    var buf: [2048]u8 = undefined;
+    const line = try writeJson(record, &buf);
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, line[1 .. line.len - 1], .{});
+    defer parsed.deinit();
 }
 
 test "qpack blocking is a Tardigrade extension event" {
@@ -346,8 +461,8 @@ test "frame direction chooses frame_created vs frame_parsed" {
 
 test "parameters_set only emits present settings" {
     try expectJson(
-        .{ .time_us = 0, .event = .{ .parameters_set = .{ .blocked_streams_count = 16 } } },
-        "{\"blocked_streams_count\":16}",
+        .{ .time_us = 0, .event = .{ .parameters_set = .{ .initiator = .remote, .blocked_streams_count = 16 } } },
+        "{\"initiator\":\"remote\",\"blocked_streams_count\":16}",
     );
 }
 
@@ -357,12 +472,12 @@ test "stream_type_set and representative frames use http3 names" {
         "\"name\":\"http3:stream_type_set\"",
     );
     try expectJson(
-        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = &.{.{ .name = "SETTINGS_QPACK_BLOCKED_STREAMS", .value = 16 }} } } } } },
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = .{ .qpack_blocked_streams = 16 } } } } } },
         "\"frame_type\":\"settings\"",
     );
     try expectJson(
-        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = &.{.{ .name = "SETTINGS_QPACK_BLOCKED_STREAMS", .value = 16 }} } } } } },
-        "\"settings\":[{\"name\":\"SETTINGS_QPACK_BLOCKED_STREAMS\",\"value\":16}]",
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = .{ .qpack_blocked_streams = 16, .max_field_section_size = 4096 } } } } } },
+        "\"settings\":[{\"name\":\"settings_max_field_section_size\",\"value\":4096},{\"name\":\"settings_qpack_blocked_streams\",\"value\":16}]",
     );
     try expectJson(
         .{ .time_us = 0, .event = .{ .frame = .{ .direction = .parsed, .stream_id = 4, .frame = .{ .headers = .{ .headers = &.{.{ .name = ":path", .value = "/" }}, .raw_length = 32 } } } } },
@@ -372,6 +487,44 @@ test "stream_type_set and representative frames use http3 names" {
         .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .goaway = .{ .id = 4 } } } } },
         "\"id\":4",
     );
+}
+
+test "frame JSON string fields are escaped and parseable" {
+    const record = Record{ .time_us = 0, .event = .{ .frame = .{ .direction = .parsed, .stream_id = 4, .frame = .{ .headers = .{
+        .headers = &.{.{ .name = "x\"name", .value = "a\\b\n" }},
+        .raw_length = 12,
+    } } } } };
+    try expectJson(record, "\"name\":\"x\\\"name\"");
+    try expectJson(record, "\"value\":\"a\\\\b\\n\"");
+    try expectValidJson(record);
+}
+
+test "header fields with non UTF-8 bytes use byte-oriented qlog fields" {
+    const record = Record{ .time_us = 0, .event = .{ .frame = .{ .direction = .parsed, .stream_id = 4, .frame = .{ .headers = .{
+        .headers = &.{.{ .name = "x", .value = &.{ 0xff, 0x00, '"' } }},
+        .raw_length = 12,
+    } } } } };
+    try expectJson(record, "\"name\":\"x\"");
+    try expectJson(record, "\"value_bytes\":\"ff0022\"");
+    try expectValidJson(record);
+}
+
+test "priority_update frames emit typed targets and escaped values" {
+    const request = Record{ .time_us = 0, .event = .{ .frame = .{ .direction = .parsed, .stream_id = 0, .frame = .{ .priority_update = .{ .request = .{
+        .stream_id = 8,
+        .priority_field_value = "u=1\"",
+        .raw_length = 9,
+    } } } } } };
+    try expectJson(request, "\"stream_id\":8,\"priority_field_value\":\"u=1\\\"\"");
+    try expectValidJson(request);
+
+    const push = Record{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .priority_update = .{ .push = .{
+        .push_id = 3,
+        .priority_field_value = "i",
+        .raw_length = 5,
+    } } } } } };
+    try expectJson(push, "\"push_id\":3,\"priority_field_value\":\"i\"");
+    try expectValidJson(push);
 }
 
 test "default sink is a no-op" {

--- a/src/http3/qlog.zig
+++ b/src/http3/qlog.zig
@@ -54,6 +54,59 @@ pub const StreamType = enum {
 /// encoder stream, and `unblocked` once the required insert count arrives.
 pub const QpackState = enum { blocked, unblocked };
 
+pub const HttpField = struct {
+    name: []const u8,
+    value: []const u8,
+};
+
+pub const Setting = struct {
+    name: []const u8,
+    value: u64,
+};
+
+pub const Frame = union(enum) {
+    data: struct {
+        raw_length: ?usize = null,
+    },
+    headers: struct {
+        headers: []const HttpField = &.{},
+        raw_length: ?usize = null,
+    },
+    settings: struct {
+        settings: []const Setting = &.{},
+        raw_length: ?usize = null,
+    },
+    goaway: struct {
+        id: u64,
+        raw_length: ?usize = null,
+    },
+    push_promise: struct {
+        push_id: u64,
+        headers: []const HttpField = &.{},
+        raw_length: ?usize = null,
+    },
+    cancel_push: struct {
+        push_id: u64,
+        raw_length: ?usize = null,
+    },
+    max_push_id: struct {
+        push_id: u64,
+        raw_length: ?usize = null,
+    },
+
+    pub fn frameType(self: Frame) FrameType {
+        return switch (self) {
+            .data => .data,
+            .headers => .headers,
+            .settings => .settings,
+            .goaway => .goaway,
+            .push_promise => .push_promise,
+            .cancel_push => .cancel_push,
+            .max_push_id => .max_push_id,
+        };
+    }
+};
+
 pub const Event = union(enum) {
     /// http3:parameters_set (SETTINGS applied)
     parameters_set: struct {
@@ -70,9 +123,8 @@ pub const Event = union(enum) {
     /// http3:frame_created / http3:frame_parsed
     frame: struct {
         direction: Direction,
-        frame_type: FrameType,
         stream_id: u64,
-        length: usize = 0,
+        frame: Frame,
     },
     /// tardigrade:qpack_stream_state_updated (head-of-line blocking)
     qpack_state_updated: struct {
@@ -143,6 +195,68 @@ const Buf = struct {
     }
 };
 
+fn writeRawLength(b: *Buf, length: ?usize, need_comma: *bool) error{NoSpaceLeft}!void {
+    if (length) |v| {
+        if (need_comma.*) try b.add(",", .{});
+        try b.add("\"raw\":{{\"length\":{d}}}", .{v});
+        need_comma.* = true;
+    }
+}
+
+fn writeHeaders(b: *Buf, headers: []const HttpField) error{NoSpaceLeft}!void {
+    try b.add("\"headers\":[", .{});
+    for (headers, 0..) |field, i| {
+        if (i != 0) try b.add(",", .{});
+        try b.add("{{\"name\":\"{s}\",\"value\":\"{s}\"}}", .{ field.name, field.value });
+    }
+    try b.add("]", .{});
+}
+
+fn writeSettings(b: *Buf, settings: []const Setting) error{NoSpaceLeft}!void {
+    try b.add("\"settings\":[", .{});
+    for (settings, 0..) |setting, i| {
+        if (i != 0) try b.add(",", .{});
+        try b.add("{{\"name\":\"{s}\",\"value\":{d}}}", .{ setting.name, setting.value });
+    }
+    try b.add("]", .{});
+}
+
+fn writeFrame(b: *Buf, frame: Frame) error{NoSpaceLeft}!void {
+    try b.add("{{\"frame_type\":\"{s}\"", .{frame.frameType().label()});
+    var need_comma = true;
+    switch (frame) {
+        .data => |d| try writeRawLength(b, d.raw_length, &need_comma),
+        .headers => |d| {
+            try b.add(",", .{});
+            try writeHeaders(b, d.headers);
+            try writeRawLength(b, d.raw_length, &need_comma);
+        },
+        .settings => |d| {
+            try b.add(",", .{});
+            try writeSettings(b, d.settings);
+            try writeRawLength(b, d.raw_length, &need_comma);
+        },
+        .goaway => |d| {
+            try b.add(",\"id\":{d}", .{d.id});
+            try writeRawLength(b, d.raw_length, &need_comma);
+        },
+        .push_promise => |d| {
+            try b.add(",\"push_id\":{d},", .{d.push_id});
+            try writeHeaders(b, d.headers);
+            try writeRawLength(b, d.raw_length, &need_comma);
+        },
+        .cancel_push => |d| {
+            try b.add(",\"push_id\":{d}", .{d.push_id});
+            try writeRawLength(b, d.raw_length, &need_comma);
+        },
+        .max_push_id => |d| {
+            try b.add(",\"push_id\":{d}", .{d.push_id});
+            try writeRawLength(b, d.raw_length, &need_comma);
+        },
+    }
+    try b.add("}}", .{});
+}
+
 fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
     switch (event) {
         .parameters_set => |d| {
@@ -172,10 +286,11 @@ fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
             "{{\"stream_id\":{d},\"stream_type\":\"{s}\"}}",
             .{ d.stream_id, @tagName(d.stream_type) },
         ),
-        .frame => |d| try b.add(
-            "{{\"stream_id\":{d},\"frame\":{{\"frame_type\":\"{s}\",\"raw\":{{\"length\":{d}}}}}}}",
-            .{ d.stream_id, d.frame_type.label(), d.length },
-        ),
+        .frame => |d| {
+            try b.add("{{\"stream_id\":{d},\"frame\":", .{d.stream_id});
+            try writeFrame(b, d.frame);
+            try b.add("}}", .{});
+        },
         .qpack_state_updated => |d| try b.add(
             "{{\"stream_id\":{d},\"state\":\"{s}\"}}",
             .{ d.stream_id, @tagName(d.state) },
@@ -220,11 +335,11 @@ test "qpack blocking is a Tardigrade extension event" {
 
 test "frame direction chooses frame_created vs frame_parsed" {
     try expectJson(
-        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .frame_type = .headers, .stream_id = 0, .length = 20 } } },
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .headers = .{ .headers = &.{.{ .name = ":status", .value = "200" }}, .raw_length = 20 } } } } },
         "\"name\":\"http3:frame_created\"",
     );
     try expectJson(
-        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .parsed, .frame_type = .goaway, .stream_id = 3 } } },
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .parsed, .stream_id = 3, .frame = .{ .goaway = .{ .id = 0 } } } } },
         "\"name\":\"http3:frame_parsed\"",
     );
 }
@@ -242,16 +357,20 @@ test "stream_type_set and representative frames use http3 names" {
         "\"name\":\"http3:stream_type_set\"",
     );
     try expectJson(
-        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .frame_type = .settings, .stream_id = 0 } } },
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = &.{.{ .name = "SETTINGS_QPACK_BLOCKED_STREAMS", .value = 16 }} } } } } },
         "\"frame_type\":\"settings\"",
     );
     try expectJson(
-        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .parsed, .frame_type = .headers, .stream_id = 4, .length = 32 } } },
-        "\"frame_type\":\"headers\"",
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = &.{.{ .name = "SETTINGS_QPACK_BLOCKED_STREAMS", .value = 16 }} } } } } },
+        "\"settings\":[{\"name\":\"SETTINGS_QPACK_BLOCKED_STREAMS\",\"value\":16}]",
     );
     try expectJson(
-        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .frame_type = .goaway, .stream_id = 0 } } },
-        "\"frame_type\":\"goaway\"",
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .parsed, .stream_id = 4, .frame = .{ .headers = .{ .headers = &.{.{ .name = ":path", .value = "/" }}, .raw_length = 32 } } } } },
+        "\"headers\":[{\"name\":\":path\",\"value\":\"/\"}]",
+    );
+    try expectJson(
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .goaway = .{ .id = 4 } } } } },
+        "\"id\":4",
     );
 }
 

--- a/src/http3/qlog.zig
+++ b/src/http3/qlog.zig
@@ -383,6 +383,10 @@ fn writePriorityFieldValue(b: *Buf, value: []const u8) error{NoSpaceLeft}!void {
     }
 }
 
+fn qpackPayloadFrame(frame_type: FrameType) bool {
+    return frame_type == .headers or frame_type == .push_promise;
+}
+
 fn writeFrame(b: *Buf, frame: Frame) error{NoSpaceLeft}!void {
     try b.add("{{\"frame_type\":\"{s}\"", .{frame.frameType().label()});
     var need_comma = true;
@@ -434,8 +438,18 @@ fn writeFrame(b: *Buf, frame: Frame) error{NoSpaceLeft}!void {
             try writeRawLength(b, d.raw_length, &need_comma);
         },
         .malformed => |d| {
-            try b.add(",\"frame_type_bytes\":{d},\"tardigrade_malformed_payload\":true,\"tardigrade_malformed_reason\":", .{d.frame_type_bytes});
-            try writeJsonString(b, d.reason);
+            if (qpackPayloadFrame(d.frame_type)) {
+                // The H3 observer uses the production static/bounded QPACK
+                // decoder as a best-effort diagnostic helper. A decode error
+                // here can mean valid dynamic-table input or local diagnostic
+                // capacity exhaustion, so do not claim the peer sent malformed
+                // wire. Preserve the parsed frame boundary with an explicitly
+                // Tardigrade-namespaced decode-failure diagnostic instead.
+                try b.add(",\"frame_type_bytes\":{d},\"tardigrade_qpack_decode_failed\":true,\"tardigrade_qpack_decode_reason\":\"diagnostic_decoder_rejected\"", .{d.frame_type_bytes});
+            } else {
+                try b.add(",\"frame_type_bytes\":{d},\"tardigrade_malformed_payload\":true,\"tardigrade_malformed_reason\":", .{d.frame_type_bytes});
+                try writeJsonString(b, d.reason);
+            }
             try writeRawLength(b, d.raw_length, &need_comma);
         },
     }
@@ -527,6 +541,12 @@ fn expectJson(record: Record, needle: []const u8) !void {
     try testing.expect(line[0] == record_separator);
     try testing.expect(line[line.len - 1] == '\n');
     try testing.expect(std.mem.indexOf(u8, line, needle) != null);
+}
+
+fn expectNoJson(record: Record, needle: []const u8) !void {
+    var buf: [2048]u8 = undefined;
+    const line = try writeJson(record, &buf);
+    try testing.expect(std.mem.indexOf(u8, line, needle) == null);
 }
 
 fn expectValidJson(record: Record) !void {
@@ -685,6 +705,19 @@ test "malformed frame preserves real frame type and diagnostic" {
     try expectJson(record, "\"frame_type\":\"goaway\"");
     try expectJson(record, "\"frame_type_bytes\":7");
     try expectJson(record, "\"tardigrade_malformed_payload\":true");
+    try expectValidJson(record);
+}
+
+test "QPACK decode failure does not claim malformed wire" {
+    const record = Record{ .time_us = 0, .event = .{ .frame = .{
+        .direction = .parsed,
+        .stream_id = 4,
+        .frame = .{ .malformed = .{ .frame_type = .push_promise, .frame_type_bytes = 0x05, .raw_length = 8 } },
+    } } };
+    try expectJson(record, "\"frame_type\":\"push_promise\"");
+    try expectJson(record, "\"tardigrade_qpack_decode_failed\":true");
+    try expectJson(record, "\"tardigrade_qpack_decode_reason\":\"diagnostic_decoder_rejected\"");
+    try expectNoJson(record, "\"tardigrade_malformed_payload\"");
     try expectValidJson(record);
 }
 

--- a/src/http3/qlog.zig
+++ b/src/http3/qlog.zig
@@ -13,7 +13,6 @@
 //! `qpack_state_updated` is emitted as a documented `tardigrade:*` extension.
 
 const std = @import("std");
-const http3_frame = @import("frame.zig");
 const qpack = @import("qpack.zig");
 
 /// qlog application-vantage namespaces owned by HTTP/3.
@@ -36,6 +35,7 @@ pub const FrameType = enum {
     push_promise,
     cancel_push,
     max_push_id,
+    unknown,
 
     pub fn label(self: FrameType) []const u8 {
         return @tagName(self);
@@ -66,11 +66,18 @@ pub const SettingName = enum {
     settings_qpack_blocked_streams,
     settings_enable_connect_protocol,
     settings_h3_datagram,
+    reserved,
+    unknown,
 };
 
 pub const HttpPriority = struct {
     urgency: u3,
     incremental: bool,
+};
+
+pub const QlogSetting = struct {
+    id_value: u64,
+    value: u64,
 };
 
 pub const Frame = union(enum) {
@@ -82,7 +89,7 @@ pub const Frame = union(enum) {
         raw_length: ?usize = null,
     },
     settings: struct {
-        settings: ?http3_frame.Settings = null,
+        settings: []const QlogSetting = &.{},
         raw_length: ?usize = null,
     },
     goaway: struct {
@@ -92,12 +99,12 @@ pub const Frame = union(enum) {
     priority_update: union(enum) {
         request: struct {
             stream_id: u64,
-            priority_field_value: []const u8,
+            priority_field_value: []const u8 = "",
             raw_length: ?usize = null,
         },
         push: struct {
             push_id: u64,
-            priority_field_value: []const u8,
+            priority_field_value: []const u8 = "",
             raw_length: ?usize = null,
         },
     },
@@ -114,6 +121,10 @@ pub const Frame = union(enum) {
         push_id: u64,
         raw_length: ?usize = null,
     },
+    unknown: struct {
+        frame_type_bytes: u64,
+        raw_length: ?usize = null,
+    },
 
     pub fn frameType(self: Frame) FrameType {
         return switch (self) {
@@ -125,6 +136,7 @@ pub const Frame = union(enum) {
             .push_promise => .push_promise,
             .cancel_push => .cancel_push,
             .max_push_id => .max_push_id,
+            .unknown => .unknown,
         };
     }
 };
@@ -136,6 +148,8 @@ pub const Event = union(enum) {
         max_field_section_size: ?u64 = null,
         max_table_capacity: ?u64 = null,
         blocked_streams_count: ?u64 = null,
+        extended_connect: ?bool = null,
+        h3_datagram: ?bool = null,
     },
     /// http3:stream_type_set
     stream_type_set: struct {
@@ -192,6 +206,10 @@ pub const Record = struct {
 /// `emit_fn` returns `void`, so a concrete file sink cannot propagate write
 /// errors here. Same contract as the transport sink: retain the first error
 /// and/or count dropped records out-of-band so a truncated trace is detectable.
+///
+/// All slices inside `record` are borrowed and valid only for the synchronous
+/// callback. Implementations must serialize or deep-copy before returning and
+/// must not retain/enqueue `record` itself.
 pub const Sink = struct {
     context: ?*anyopaque = null,
     emit_fn: ?*const fn (?*anyopaque, Record) void = null,
@@ -208,6 +226,11 @@ pub const Sink = struct {
 /// JSON-SEQ record separator (RFC 7464), identical framing to the transport
 /// side so both streams concatenate into one valid qlog JSON-SEQ file.
 pub const record_separator: u8 = 0x1e;
+
+/// Recommended per-record buffer for composition-root sinks. H3 HEADERS and
+/// PUSH_PROMISE records grow with decoded field sections and byte escaping, so
+/// small fixed buffers can legitimately return `NoSpaceLeft`.
+pub const max_serialized_record_len: usize = 64 * 1024;
 
 const Buf = struct {
     buf: []u8,
@@ -268,8 +291,36 @@ fn writeJsonString(b: *Buf, value: []const u8) error{NoSpaceLeft}!void {
     try b.add("\"", .{});
 }
 
-fn writeTextOrBytes(b: *Buf, text_key: []const u8, bytes_key: []const u8, value: []const u8) error{NoSpaceLeft}!void {
-    if (std.unicode.utf8ValidateSlice(value)) {
+fn isHttpFieldNameText(value: []const u8) bool {
+    if (value.len == 0) return false;
+    const start: usize = if (value[0] == ':') 1 else 0;
+    if (start == value.len) return false;
+    for (value[start..]) |byte| switch (byte) {
+        'a'...'z', 'A'...'Z', '0'...'9', '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~' => {},
+        else => return false,
+    };
+    return true;
+}
+
+fn isHttpFieldValueText(value: []const u8) bool {
+    for (value) |byte| switch (byte) {
+        '\t', 0x20...0x7e => {},
+        else => return false,
+    };
+    return true;
+}
+
+fn isPriorityFieldValueText(value: []const u8) bool {
+    if (value.len == 0) return false;
+    for (value) |byte| switch (byte) {
+        0x20...0x7e => {},
+        else => return false,
+    };
+    return true;
+}
+
+fn writeTextOrBytes(b: *Buf, text_key: []const u8, bytes_key: []const u8, value: []const u8, is_text: bool) error{NoSpaceLeft}!void {
+    if (is_text) {
         try b.add("\"{s}\":", .{text_key});
         try writeJsonString(b, value);
     } else {
@@ -283,31 +334,46 @@ fn writeHeaders(b: *Buf, headers: []const HttpField) error{NoSpaceLeft}!void {
     for (headers, 0..) |field, i| {
         if (i != 0) try b.add(",", .{});
         try b.add("{{", .{});
-        try writeTextOrBytes(b, "name", "name_bytes", field.name);
+        try writeTextOrBytes(b, "name", "name_bytes", field.name, isHttpFieldNameText(field.name));
         try b.add(",", .{});
-        try writeTextOrBytes(b, "value", "value_bytes", field.value);
+        try writeTextOrBytes(b, "value", "value_bytes", field.value, isHttpFieldValueText(field.value));
         try b.add("}}", .{});
     }
     try b.add("]", .{});
 }
 
-fn writeSetting(b: *Buf, name: SettingName, value: u64, first: *bool) error{NoSpaceLeft}!void {
-    if (!first.*) try b.add(",", .{});
-    first.* = false;
-    try b.add("{{\"name\":\"{s}\",\"value\":{d}}}", .{ @tagName(name), value });
+fn settingNameFromId(id_value: u64) struct { name: SettingName, name_bytes: ?u64 = null } {
+    return switch (id_value) {
+        0x01 => .{ .name = .settings_qpack_max_table_capacity },
+        0x06 => .{ .name = .settings_max_field_section_size },
+        0x07 => .{ .name = .settings_qpack_blocked_streams },
+        0x08 => .{ .name = .settings_enable_connect_protocol },
+        0x33 => .{ .name = .settings_h3_datagram },
+        0x00, 0x02, 0x03, 0x04, 0x05 => .{ .name = .reserved, .name_bytes = id_value },
+        else => .{ .name = .unknown, .name_bytes = id_value },
+    };
 }
 
-fn writeSettings(b: *Buf, settings: ?http3_frame.Settings) error{NoSpaceLeft}!void {
+fn writeSettings(b: *Buf, settings: []const QlogSetting) error{NoSpaceLeft}!void {
     try b.add("\"settings\":[", .{});
-    if (settings) |s| {
-        var first = true;
-        if (s.qpack_max_table_capacity != 0) try writeSetting(b, .settings_qpack_max_table_capacity, s.qpack_max_table_capacity, &first);
-        if (s.max_field_section_size) |max| try writeSetting(b, .settings_max_field_section_size, max, &first);
-        if (s.qpack_blocked_streams != 0) try writeSetting(b, .settings_qpack_blocked_streams, s.qpack_blocked_streams, &first);
-        if (s.enable_connect_protocol) try writeSetting(b, .settings_enable_connect_protocol, 1, &first);
-        if (s.h3_datagram) try writeSetting(b, .settings_h3_datagram, 1, &first);
+    for (settings, 0..) |setting, i| {
+        if (i != 0) try b.add(",", .{});
+        const mapped = settingNameFromId(setting.id_value);
+        try b.add("{{\"name\":\"{s}\"", .{@tagName(mapped.name)});
+        if (mapped.name_bytes) |name_bytes| try b.add(",\"name_bytes\":{d}", .{name_bytes});
+        try b.add(",\"value\":{d}}}", .{setting.value});
     }
     try b.add("]", .{});
+}
+
+fn writePriorityFieldValue(b: *Buf, value: []const u8) error{NoSpaceLeft}!void {
+    if (isPriorityFieldValueText(value)) {
+        try b.add(",\"priority_field_value\":", .{});
+        try writeJsonString(b, value);
+    } else {
+        try b.add(",\"priority_field_value_bytes\":", .{});
+        try writeHexBytes(b, value);
+    }
 }
 
 fn writeFrame(b: *Buf, frame: Frame) error{NoSpaceLeft}!void {
@@ -332,13 +398,13 @@ fn writeFrame(b: *Buf, frame: Frame) error{NoSpaceLeft}!void {
         .priority_update => |d| {
             switch (d) {
                 .request => |r| {
-                    try b.add(",\"stream_id\":{d},\"priority_field_value\":", .{r.stream_id});
-                    try writeJsonString(b, r.priority_field_value);
+                    try b.add(",\"stream_id\":{d}", .{r.stream_id});
+                    try writePriorityFieldValue(b, r.priority_field_value);
                     try writeRawLength(b, r.raw_length, &need_comma);
                 },
                 .push => |p| {
-                    try b.add(",\"push_id\":{d},\"priority_field_value\":", .{p.push_id});
-                    try writeJsonString(b, p.priority_field_value);
+                    try b.add(",\"push_id\":{d}", .{p.push_id});
+                    try writePriorityFieldValue(b, p.priority_field_value);
                     try writeRawLength(b, p.raw_length, &need_comma);
                 },
             }
@@ -354,6 +420,10 @@ fn writeFrame(b: *Buf, frame: Frame) error{NoSpaceLeft}!void {
         },
         .max_push_id => |d| {
             try b.add(",\"push_id\":{d}", .{d.push_id});
+            try writeRawLength(b, d.raw_length, &need_comma);
+        },
+        .unknown => |d| {
+            try b.add(",\"frame_type_bytes\":{d}", .{d.frame_type_bytes});
             try writeRawLength(b, d.raw_length, &need_comma);
         },
     }
@@ -382,6 +452,16 @@ fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
             if (d.blocked_streams_count) |v| {
                 if (need_comma) try b.add(",", .{});
                 try b.add("\"blocked_streams_count\":{d}", .{v});
+                need_comma = true;
+            }
+            if (d.extended_connect) |v| {
+                if (need_comma) try b.add(",", .{});
+                try b.add("\"extended_connect\":{s}", .{if (v) "true" else "false"});
+                need_comma = true;
+            }
+            if (d.h3_datagram) |v| {
+                if (need_comma) try b.add(",", .{});
+                try b.add("\"h3_datagram\":{s}", .{if (v) "true" else "false"});
             }
             try b.add("}}", .{});
         },
@@ -407,7 +487,10 @@ fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
 }
 
 /// Serialize one `Record` into `out` as a single qlog JSON-SEQ line. Same shape
-/// as `quic.qlog.writeJson` so a merged trace is uniform.
+/// as `quic.qlog.writeJson` so a merged trace is uniform. H3 HEADERS and
+/// PUSH_PROMISE records can grow with decoded field slices; callers should use
+/// `max_serialized_record_len` or retain `NoSpaceLeft` as a dropped-record
+/// diagnostic.
 pub fn writeJson(record: Record, out: []u8) error{NoSpaceLeft}![]const u8 {
     var b = Buf{ .buf = out };
     try b.add("{c}", .{record_separator});
@@ -472,11 +555,11 @@ test "stream_type_set and representative frames use http3 names" {
         "\"name\":\"http3:stream_type_set\"",
     );
     try expectJson(
-        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = .{ .qpack_blocked_streams = 16 } } } } } },
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = &.{.{ .id_value = 0x07, .value = 16 }} } } } } },
         "\"frame_type\":\"settings\"",
     );
     try expectJson(
-        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = .{ .qpack_blocked_streams = 16, .max_field_section_size = 4096 } } } } } },
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = &.{ .{ .id_value = 0x06, .value = 4096 }, .{ .id_value = 0x07, .value = 16 } } } } } } },
         "\"settings\":[{\"name\":\"settings_max_field_section_size\",\"value\":4096},{\"name\":\"settings_qpack_blocked_streams\",\"value\":16}]",
     );
     try expectJson(
@@ -491,11 +574,11 @@ test "stream_type_set and representative frames use http3 names" {
 
 test "frame JSON string fields are escaped and parseable" {
     const record = Record{ .time_us = 0, .event = .{ .frame = .{ .direction = .parsed, .stream_id = 4, .frame = .{ .headers = .{
-        .headers = &.{.{ .name = "x\"name", .value = "a\\b\n" }},
+        .headers = &.{.{ .name = "x-name", .value = "a\\b" }},
         .raw_length = 12,
     } } } } };
-    try expectJson(record, "\"name\":\"x\\\"name\"");
-    try expectJson(record, "\"value\":\"a\\\\b\\n\"");
+    try expectJson(record, "\"name\":\"x-name\"");
+    try expectJson(record, "\"value\":\"a\\\\b\"");
     try expectValidJson(record);
 }
 
@@ -507,6 +590,32 @@ test "header fields with non UTF-8 bytes use byte-oriented qlog fields" {
     try expectJson(record, "\"name\":\"x\"");
     try expectJson(record, "\"value_bytes\":\"ff0022\"");
     try expectValidJson(record);
+}
+
+test "HTTP-invalid field bytes use byte-oriented qlog fields" {
+    const record = Record{ .time_us = 0, .event = .{ .frame = .{ .direction = .parsed, .stream_id = 4, .frame = .{ .headers = .{
+        .headers = &.{.{ .name = "bad name", .value = "snowman \xe2\x98\x83" }},
+        .raw_length = 12,
+    } } } } };
+    try expectJson(record, "\"name_bytes\":\"626164206e616d65\"");
+    try expectJson(record, "\"value_bytes\":\"736e6f776d616e20e29883\"");
+    try expectValidJson(record);
+}
+
+test "settings frames preserve explicit zero reserved and unknown IDs" {
+    const record = Record{ .time_us = 0, .event = .{ .frame = .{ .direction = .parsed, .stream_id = 0, .frame = .{ .settings = .{
+        .settings = &.{
+            .{ .id_value = 0x07, .value = 0 },
+            .{ .id_value = 0x08, .value = 0 },
+            .{ .id_value = 0x21, .value = 99 },
+            .{ .id_value = 0x02, .value = 1 },
+        },
+        .raw_length = 12,
+    } } } } };
+    try expectJson(record, "{\"name\":\"settings_qpack_blocked_streams\",\"value\":0}");
+    try expectJson(record, "{\"name\":\"settings_enable_connect_protocol\",\"value\":0}");
+    try expectJson(record, "{\"name\":\"unknown\",\"name_bytes\":33,\"value\":99}");
+    try expectJson(record, "{\"name\":\"reserved\",\"name_bytes\":2,\"value\":1}");
 }
 
 test "priority_update frames emit typed targets and escaped values" {
@@ -525,6 +634,48 @@ test "priority_update frames emit typed targets and escaped values" {
     } } } } } };
     try expectJson(push, "\"push_id\":3,\"priority_field_value\":\"i\"");
     try expectValidJson(push);
+}
+
+test "priority_update invalid bytes use byte-oriented qlog field" {
+    const record = Record{ .time_us = 0, .event = .{ .frame = .{ .direction = .parsed, .stream_id = 0, .frame = .{ .priority_update = .{ .request = .{
+        .stream_id = 8,
+        .priority_field_value = &.{ 0xff, '\n' },
+        .raw_length = 9,
+    } } } } } };
+    try expectJson(record, "\"priority_field_value_bytes\":\"ff0a\"");
+    try expectValidJson(record);
+}
+
+test "unknown frame serializes with original frame type bytes" {
+    try expectJson(
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .parsed, .stream_id = 4, .frame = .{ .unknown = .{ .frame_type_bytes = 0x21, .raw_length = 2 } } } } },
+        "\"frame_type\":\"unknown\",\"frame_type_bytes\":33",
+    );
+}
+
+test "large header records require a caller-sized buffer" {
+    const headers = [_]HttpField{
+        .{ .name = "x-debug-0", .value = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+        .{ .name = "x-debug-1", .value = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" },
+        .{ .name = "x-debug-2", .value = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" },
+        .{ .name = "x-debug-3", .value = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd" },
+        .{ .name = "x-debug-4", .value = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" },
+        .{ .name = "x-debug-5", .value = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" },
+    };
+    const record = Record{ .time_us = 0, .event = .{ .frame = .{
+        .direction = .parsed,
+        .stream_id = 4,
+        .frame = .{ .headers = .{ .headers = &headers, .raw_length = 512 } },
+    } } };
+
+    var too_small: [512]u8 = undefined;
+    try testing.expectError(error.NoSpaceLeft, writeJson(record, &too_small));
+
+    var enough: [max_serialized_record_len]u8 = undefined;
+    const line = try writeJson(record, &enough);
+    try testing.expect(line.len > 512);
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, line[1 .. line.len - 1], .{});
+    defer parsed.deinit();
 }
 
 test "default sink is a no-op" {

--- a/src/http3/qlog.zig
+++ b/src/http3/qlog.zig
@@ -125,6 +125,12 @@ pub const Frame = union(enum) {
         frame_type_bytes: u64,
         raw_length: ?usize = null,
     },
+    malformed: struct {
+        frame_type: FrameType,
+        frame_type_bytes: u64,
+        raw_length: ?usize = null,
+        reason: []const u8 = "malformed_payload",
+    },
 
     pub fn frameType(self: Frame) FrameType {
         return switch (self) {
@@ -137,6 +143,7 @@ pub const Frame = union(enum) {
             .cancel_push => .cancel_push,
             .max_push_id => .max_push_id,
             .unknown => .unknown,
+            .malformed => |d| d.frame_type,
         };
     }
 };
@@ -148,8 +155,8 @@ pub const Event = union(enum) {
         max_field_section_size: ?u64 = null,
         max_table_capacity: ?u64 = null,
         blocked_streams_count: ?u64 = null,
-        extended_connect: ?bool = null,
-        h3_datagram: ?bool = null,
+        extended_connect: ?u16 = null,
+        h3_datagram: ?u16 = null,
     },
     /// http3:stream_type_set
     stream_type_set: struct {
@@ -349,7 +356,7 @@ fn settingNameFromId(id_value: u64) struct { name: SettingName, name_bytes: ?u64
         0x07 => .{ .name = .settings_qpack_blocked_streams },
         0x08 => .{ .name = .settings_enable_connect_protocol },
         0x33 => .{ .name = .settings_h3_datagram },
-        0x00, 0x02, 0x03, 0x04, 0x05 => .{ .name = .reserved, .name_bytes = id_value },
+        0x00, 0x02, 0x03, 0x04, 0x05 => .{ .name = .reserved },
         else => .{ .name = .unknown, .name_bytes = id_value },
     };
 }
@@ -371,7 +378,7 @@ fn writePriorityFieldValue(b: *Buf, value: []const u8) error{NoSpaceLeft}!void {
         try b.add(",\"priority_field_value\":", .{});
         try writeJsonString(b, value);
     } else {
-        try b.add(",\"priority_field_value_bytes\":", .{});
+        try b.add(",\"tardigrade_priority_field_value_bytes\":", .{});
         try writeHexBytes(b, value);
     }
 }
@@ -426,6 +433,11 @@ fn writeFrame(b: *Buf, frame: Frame) error{NoSpaceLeft}!void {
             try b.add(",\"frame_type_bytes\":{d}", .{d.frame_type_bytes});
             try writeRawLength(b, d.raw_length, &need_comma);
         },
+        .malformed => |d| {
+            try b.add(",\"frame_type_bytes\":{d},\"tardigrade_malformed_payload\":true,\"tardigrade_malformed_reason\":", .{d.frame_type_bytes});
+            try writeJsonString(b, d.reason);
+            try writeRawLength(b, d.raw_length, &need_comma);
+        },
     }
     try b.add("}}", .{});
 }
@@ -456,12 +468,12 @@ fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
             }
             if (d.extended_connect) |v| {
                 if (need_comma) try b.add(",", .{});
-                try b.add("\"extended_connect\":{s}", .{if (v) "true" else "false"});
+                try b.add("\"extended_connect\":{d}", .{v});
                 need_comma = true;
             }
             if (d.h3_datagram) |v| {
                 if (need_comma) try b.add(",", .{});
-                try b.add("\"h3_datagram\":{s}", .{if (v) "true" else "false"});
+                try b.add("\"h3_datagram\":{d}", .{v});
             }
             try b.add("}}", .{});
         },
@@ -549,6 +561,17 @@ test "parameters_set only emits present settings" {
     );
 }
 
+test "parameters_set extended settings use numeric values" {
+    const record = Record{ .time_us = 0, .event = .{ .parameters_set = .{
+        .initiator = .remote,
+        .extended_connect = 1,
+        .h3_datagram = 0,
+    } } };
+    try expectJson(record, "\"extended_connect\":1");
+    try expectJson(record, "\"h3_datagram\":0");
+    try expectValidJson(record);
+}
+
 test "stream_type_set and representative frames use http3 names" {
     try expectJson(
         .{ .time_us = 0, .event = .{ .stream_type_set = .{ .stream_id = 2, .stream_type = .control } } },
@@ -615,7 +638,7 @@ test "settings frames preserve explicit zero reserved and unknown IDs" {
     try expectJson(record, "{\"name\":\"settings_qpack_blocked_streams\",\"value\":0}");
     try expectJson(record, "{\"name\":\"settings_enable_connect_protocol\",\"value\":0}");
     try expectJson(record, "{\"name\":\"unknown\",\"name_bytes\":33,\"value\":99}");
-    try expectJson(record, "{\"name\":\"reserved\",\"name_bytes\":2,\"value\":1}");
+    try expectJson(record, "{\"name\":\"reserved\",\"value\":1}");
 }
 
 test "priority_update frames emit typed targets and escaped values" {
@@ -642,7 +665,7 @@ test "priority_update invalid bytes use byte-oriented qlog field" {
         .priority_field_value = &.{ 0xff, '\n' },
         .raw_length = 9,
     } } } } } };
-    try expectJson(record, "\"priority_field_value_bytes\":\"ff0a\"");
+    try expectJson(record, "\"tardigrade_priority_field_value_bytes\":\"ff0a\"");
     try expectValidJson(record);
 }
 
@@ -651,6 +674,18 @@ test "unknown frame serializes with original frame type bytes" {
         .{ .time_us = 0, .event = .{ .frame = .{ .direction = .parsed, .stream_id = 4, .frame = .{ .unknown = .{ .frame_type_bytes = 0x21, .raw_length = 2 } } } } },
         "\"frame_type\":\"unknown\",\"frame_type_bytes\":33",
     );
+}
+
+test "malformed frame preserves real frame type and diagnostic" {
+    const record = Record{ .time_us = 0, .event = .{ .frame = .{
+        .direction = .parsed,
+        .stream_id = 0,
+        .frame = .{ .malformed = .{ .frame_type = .goaway, .frame_type_bytes = 0x07, .raw_length = 2 } },
+    } } };
+    try expectJson(record, "\"frame_type\":\"goaway\"");
+    try expectJson(record, "\"frame_type_bytes\":7");
+    try expectJson(record, "\"tardigrade_malformed_payload\":true");
+    try expectValidJson(record);
 }
 
 test "large header records require a caller-sized buffer" {

--- a/src/http3/qlog.zig
+++ b/src/http3/qlog.zig
@@ -1,27 +1,25 @@
 //! HTTP/3- and QPACK-vantage qlog events (#255).
 //!
 //! The symmetric half of `src/quic/qlog.zig`. It exists here, in `src/http3`,
-//! because these events (`http:*`, `qpack:*`) describe the *application*
+//! because these events (`http3:*`) describe the *application*
 //! mapping — SETTINGS, control-stream framing, HEADERS/DATA, GOAWAY, and QPACK
-//! head-of-line blocking — and must not leak into the transport package. Just
+//! diagnostics — and must not leak into the transport package. Just
 //! like the transport side it emits through an injected `Sink`; the concrete
 //! qlog file writer lives at the composition root and interleaves this stream
 //! with the transport stream into one trace.
 //!
 //! Scope note: only the events needed before external interop are modelled
-//! here. `qpack_state_updated` (blocked/unblocked) is the load-bearing one for
-//! #255 — QPACK head-of-line blocking is otherwise invisible in application
-//! logs — with the frame/settings events included so a trace can attribute a
-//! stall to the right H3 exchange.
+//! here. The current HTTP/3 qlog draft no longer standardizes QPACK events, so
+//! `qpack_state_updated` is emitted as a documented `tardigrade:*` extension.
 
 const std = @import("std");
 
-/// qlog application-vantage categories owned by HTTP/3.
-pub const Category = enum {
-    http,
-    qpack,
+/// qlog application-vantage namespaces owned by HTTP/3.
+pub const Namespace = enum {
+    http3,
+    tardigrade,
 
-    pub fn label(self: Category) []const u8 {
+    pub fn label(self: Namespace) []const u8 {
         return @tagName(self);
     }
 };
@@ -42,6 +40,14 @@ pub const FrameType = enum {
 };
 
 pub const Direction = enum { created, parsed };
+pub const Initiator = enum { local, remote };
+pub const StreamType = enum {
+    control,
+    qpack_encode,
+    qpack_decode,
+    request,
+    push,
+};
 
 /// QPACK stream state (RFC 9204 §2.1.2): a request stream becomes `blocked`
 /// when it references a dynamic-table entry not yet acknowledged by the
@@ -49,40 +55,47 @@ pub const Direction = enum { created, parsed };
 pub const QpackState = enum { blocked, unblocked };
 
 pub const Event = union(enum) {
-    /// http:parameters_set (SETTINGS applied)
+    /// http3:parameters_set (SETTINGS applied)
     parameters_set: struct {
+        initiator: ?Initiator = null,
         max_field_section_size: ?u64 = null,
-        qpack_max_table_capacity: ?u64 = null,
-        qpack_blocked_streams: ?u64 = null,
+        max_table_capacity: ?u64 = null,
+        blocked_streams_count: ?u64 = null,
     },
-    /// http:frame_created / http:frame_parsed
+    /// http3:stream_type_set
+    stream_type_set: struct {
+        stream_id: u64,
+        stream_type: StreamType,
+    },
+    /// http3:frame_created / http3:frame_parsed
     frame: struct {
         direction: Direction,
         frame_type: FrameType,
         stream_id: u64,
         length: usize = 0,
     },
-    /// qpack:stream_state_updated (head-of-line blocking)
+    /// tardigrade:qpack_stream_state_updated (head-of-line blocking)
     qpack_state_updated: struct {
         state: QpackState,
         stream_id: u64,
     },
 
-    pub fn category(self: Event) Category {
+    pub fn namespace(self: Event) Namespace {
         return switch (self) {
-            .parameters_set, .frame => .http,
-            .qpack_state_updated => .qpack,
+            .parameters_set, .stream_type_set, .frame => .http3,
+            .qpack_state_updated => .tardigrade,
         };
     }
 
     pub fn name(self: Event) []const u8 {
         return switch (self) {
             .parameters_set => "parameters_set",
+            .stream_type_set => "stream_type_set",
             .frame => |f| switch (f.direction) {
                 .created => "frame_created",
                 .parsed => "frame_parsed",
             },
-            .qpack_state_updated => "stream_state_updated",
+            .qpack_state_updated => "qpack_stream_state_updated",
         };
     }
 };
@@ -135,23 +148,32 @@ fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
         .parameters_set => |d| {
             try b.add("{{", .{});
             var need_comma = false;
+            if (d.initiator) |v| {
+                try b.add("\"initiator\":\"{s}\"", .{@tagName(v)});
+                need_comma = true;
+            }
             if (d.max_field_section_size) |v| {
+                if (need_comma) try b.add(",", .{});
                 try b.add("\"max_field_section_size\":{d}", .{v});
                 need_comma = true;
             }
-            if (d.qpack_max_table_capacity) |v| {
+            if (d.max_table_capacity) |v| {
                 if (need_comma) try b.add(",", .{});
-                try b.add("\"qpack_max_table_capacity\":{d}", .{v});
+                try b.add("\"max_table_capacity\":{d}", .{v});
                 need_comma = true;
             }
-            if (d.qpack_blocked_streams) |v| {
+            if (d.blocked_streams_count) |v| {
                 if (need_comma) try b.add(",", .{});
-                try b.add("\"qpack_blocked_streams\":{d}", .{v});
+                try b.add("\"blocked_streams_count\":{d}", .{v});
             }
             try b.add("}}", .{});
         },
+        .stream_type_set => |d| try b.add(
+            "{{\"stream_id\":{d},\"stream_type\":\"{s}\"}}",
+            .{ d.stream_id, @tagName(d.stream_type) },
+        ),
         .frame => |d| try b.add(
-            "{{\"stream_id\":{d},\"frame\":{{\"frame_type\":\"{s}\"}},\"length\":{d}}}",
+            "{{\"stream_id\":{d},\"frame\":{{\"frame_type\":\"{s}\",\"raw\":{{\"length\":{d}}}}}}}",
             .{ d.stream_id, d.frame_type.label(), d.length },
         ),
         .qpack_state_updated => |d| try b.add(
@@ -168,7 +190,7 @@ pub fn writeJson(record: Record, out: []u8) error{NoSpaceLeft}![]const u8 {
     try b.add("{c}", .{record_separator});
     try b.add(
         "{{\"time\":{d}.{d:0>3},\"name\":\"{s}:{s}\",\"data\":",
-        .{ record.time_us / 1000, record.time_us % 1000, record.event.category().label(), record.event.name() },
+        .{ record.time_us / 1000, record.time_us % 1000, record.event.namespace().label(), record.event.name() },
     );
     try writeData(&b, record.event);
     try b.add("}}\n", .{});
@@ -189,28 +211,47 @@ fn expectJson(record: Record, needle: []const u8) !void {
     try testing.expect(std.mem.indexOf(u8, line, needle) != null);
 }
 
-test "qpack blocking is a qpack:stream_state_updated event" {
+test "qpack blocking is a Tardigrade extension event" {
     const ev = Event{ .qpack_state_updated = .{ .state = .blocked, .stream_id = 12 } };
-    try testing.expectEqual(Category.qpack, ev.category());
-    try expectJson(.{ .time_us = 42, .event = ev }, "\"name\":\"qpack:stream_state_updated\"");
+    try testing.expectEqual(Namespace.tardigrade, ev.namespace());
+    try expectJson(.{ .time_us = 42, .event = ev }, "\"name\":\"tardigrade:qpack_stream_state_updated\"");
     try expectJson(.{ .time_us = 42, .event = ev }, "\"state\":\"blocked\"");
 }
 
 test "frame direction chooses frame_created vs frame_parsed" {
     try expectJson(
         .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .frame_type = .headers, .stream_id = 0, .length = 20 } } },
-        "\"name\":\"http:frame_created\"",
+        "\"name\":\"http3:frame_created\"",
     );
     try expectJson(
         .{ .time_us = 0, .event = .{ .frame = .{ .direction = .parsed, .frame_type = .goaway, .stream_id = 3 } } },
-        "\"name\":\"http:frame_parsed\"",
+        "\"name\":\"http3:frame_parsed\"",
     );
 }
 
 test "parameters_set only emits present settings" {
     try expectJson(
-        .{ .time_us = 0, .event = .{ .parameters_set = .{ .qpack_blocked_streams = 16 } } },
-        "{\"qpack_blocked_streams\":16}",
+        .{ .time_us = 0, .event = .{ .parameters_set = .{ .blocked_streams_count = 16 } } },
+        "{\"blocked_streams_count\":16}",
+    );
+}
+
+test "stream_type_set and representative frames use http3 names" {
+    try expectJson(
+        .{ .time_us = 0, .event = .{ .stream_type_set = .{ .stream_id = 2, .stream_type = .control } } },
+        "\"name\":\"http3:stream_type_set\"",
+    );
+    try expectJson(
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .frame_type = .settings, .stream_id = 0 } } },
+        "\"frame_type\":\"settings\"",
+    );
+    try expectJson(
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .parsed, .frame_type = .headers, .stream_id = 4, .length = 32 } } },
+        "\"frame_type\":\"headers\"",
+    );
+    try expectJson(
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .frame_type = .goaway, .stream_id = 0 } } },
+        "\"frame_type\":\"goaway\"",
     );
 }
 

--- a/src/http3/qlog.zig
+++ b/src/http3/qlog.zig
@@ -688,6 +688,22 @@ test "malformed frame preserves real frame type and diagnostic" {
     try expectValidJson(record);
 }
 
+test "push_promise frame serializes decoded headers" {
+    const record = Record{ .time_us = 0, .event = .{ .frame = .{
+        .direction = .parsed,
+        .stream_id = 4,
+        .frame = .{ .push_promise = .{
+            .push_id = 3,
+            .headers = &.{ .{ .name = ":method", .value = "GET" }, .{ .name = ":path", .value = "/" } },
+            .raw_length = 10,
+        } },
+    } } };
+    try expectJson(record, "\"frame_type\":\"push_promise\"");
+    try expectJson(record, "\"push_id\":3");
+    try expectJson(record, "\"headers\":[{\"name\":\":method\",\"value\":\"GET\"},{\"name\":\":path\",\"value\":\"/\"}]");
+    try expectValidJson(record);
+}
+
 test "large header records require a caller-sized buffer" {
     const headers = [_]HttpField{
         .{ .name = "x-debug-0", .value = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },

--- a/src/http3/qpack.zig
+++ b/src/http3/qpack.zig
@@ -570,6 +570,10 @@ pub const BlockedStreams = struct {
         self.streams.deinit();
     }
 
+    pub fn currentCount(self: *const BlockedStreams) u64 {
+        return self.streams.count();
+    }
+
     pub fn waitFor(self: *BlockedStreams, stream_id: u64, required_insert_count: u64, metrics: *DynamicMetrics) !void {
         if (self.streams.get(stream_id)) |blocked| {
             if (required_insert_count > blocked.required_insert_count) {
@@ -1178,6 +1182,24 @@ test "dynamic settings initialize table capacity and blocked-stream limit" {
     try testing.expectEqual(@as(u64, 128), table.max_capacity);
     try testing.expectEqual(@as(u64, 0), table.capacity);
     try testing.expectEqual(@as(u64, 2), decoder.blocked.max_blocked);
+}
+
+test "blocked stream set exposes current gauge count" {
+    var blocked = BlockedStreams.init(testing.allocator, 4);
+    defer blocked.deinit();
+    var metrics = DynamicMetrics{};
+    var out: [2]u64 = undefined;
+
+    try testing.expectEqual(@as(u64, 0), blocked.currentCount());
+    try blocked.waitFor(0, 2, &metrics);
+    try blocked.waitFor(4, 3, &metrics);
+    try testing.expectEqual(@as(u64, 2), blocked.currentCount());
+    try testing.expectEqual(@as(u64, 2), metrics.blocked_streams);
+
+    _ = blocked.unblockAvailable(2, &out, &metrics);
+    try testing.expectEqual(@as(u64, 1), blocked.currentCount());
+    blocked.cancel(4, &metrics);
+    try testing.expectEqual(@as(u64, 0), blocked.currentCount());
 }
 
 test "dynamic table capacity is capped by negotiated SETTINGS and can be lowered to zero" {

--- a/src/http3/session.zig
+++ b/src/http3/session.zig
@@ -85,12 +85,26 @@ pub const RequestStream = struct {
     }
 
     pub fn ingestBytes(self: *RequestStream, bytes: []const u8, qpack_scratch: []u8) SessionError!usize {
+        return self.ingestBytesWithObserver(bytes, qpack_scratch, null);
+    }
+
+    pub const FrameObserver = struct {
+        context: ?*anyopaque = null,
+        parsedFn: ?*const fn (?*anyopaque, frame.RawFrame) void = null,
+
+        fn parsed(self: FrameObserver, raw: frame.RawFrame) void {
+            if (self.parsedFn) |parsed_fn| parsed_fn(self.context, raw);
+        }
+    };
+
+    pub fn ingestBytesWithObserver(self: *RequestStream, bytes: []const u8, qpack_scratch: []u8, observer: ?FrameObserver) SessionError!usize {
         self.pending.appendSlice(self.allocator, bytes) catch return error.OutOfMemory;
         while (true) {
             const raw = frame.decodeFrameWithLimit(self.pending.items, max_frame_payload_len) catch |err| switch (err) {
                 error.BufferTooShort => return bytes.len,
                 else => return mapFrameDecodeError(err),
             };
+            if (observer) |obs| obs.parsed(raw);
             try self.ingestFrame(raw, qpack_scratch);
             discardPrefix(&self.pending, raw.len);
         }
@@ -246,6 +260,23 @@ fn mapFrameDecodeError(err: frame.DecodeError) SessionError {
 }
 
 const testing = std.testing;
+
+const ParsedFrameRecorder = struct {
+    frames: std.ArrayList(frame.RawFrame) = .empty,
+
+    fn deinit(self: *ParsedFrameRecorder, allocator: std.mem.Allocator) void {
+        self.frames.deinit(allocator);
+    }
+
+    fn observer(self: *ParsedFrameRecorder) RequestStream.FrameObserver {
+        return .{ .context = self, .parsedFn = parsed };
+    }
+
+    fn parsed(ctx: ?*anyopaque, raw: frame.RawFrame) void {
+        const self: *ParsedFrameRecorder = @ptrCast(@alignCast(ctx.?));
+        self.frames.append(testing.allocator, raw) catch unreachable;
+    }
+};
 
 test "request stream maps HEADERS and DATA onto stream_transport Exchange" {
     const allocator = testing.allocator;
@@ -440,6 +471,59 @@ test "request stream ingests split frame type length and payload incrementally" 
 
     const exchange = try req.finish();
     try testing.expectEqualStrings("GET", exchange.request.method);
+}
+
+test "request stream frame observer reports every decoded frame with exact wire length" {
+    const allocator = testing.allocator;
+    var qpack_buf: [512]u8 = undefined;
+    const block = try qpack.encode(&.{
+        .{ .name = ":method", .value = "POST" },
+        .{ .name = ":scheme", .value = "https" },
+        .{ .name = ":authority", .value = "example.com" },
+        .{ .name = ":path", .value = "/" },
+    }, &qpack_buf);
+
+    var wire: [1024]u8 = undefined;
+    var pos: usize = 0;
+    const headers = try frame.encodeKnownFrame(.headers, block, wire[pos..]);
+    pos += headers.len;
+    const data_a = try frame.encodeKnownFrame(.data, "abc", wire[pos..]);
+    pos += data_a.len;
+    const data_b = try frame.encodeKnownFrame(.data, "defg", wire[pos..]);
+    pos += data_b.len;
+
+    var req = RequestStream.init(allocator, 0);
+    defer req.deinit();
+    var recorder = ParsedFrameRecorder{};
+    defer recorder.deinit(allocator);
+    var scratch: [512]u8 = undefined;
+
+    try testing.expectEqual(pos - 1, try req.ingestBytesWithObserver(wire[0 .. pos - 1], &scratch, recorder.observer()));
+    try testing.expectEqual(@as(usize, 2), recorder.frames.items.len);
+    try testing.expectEqual(@as(usize, 1), try req.ingestBytesWithObserver(wire[pos - 1 .. pos], &scratch, recorder.observer()));
+    try testing.expectEqual(@as(usize, 3), recorder.frames.items.len);
+    try testing.expectEqual(frame.FrameType.headers, recorder.frames.items[0].typ);
+    try testing.expectEqual(headers.len, recorder.frames.items[0].len);
+    try testing.expectEqual(frame.FrameType.data, recorder.frames.items[1].typ);
+    try testing.expectEqual(data_a.len, recorder.frames.items[1].len);
+    try testing.expectEqual(frame.FrameType.data, recorder.frames.items[2].typ);
+    try testing.expectEqual(data_b.len, recorder.frames.items[2].len);
+}
+
+test "request stream frame observer reports DATA before semantic rejection" {
+    var wire: [64]u8 = undefined;
+    const data = try frame.encodeKnownFrame(.data, "x", &wire);
+
+    var req = RequestStream.init(testing.allocator, 0);
+    defer req.deinit();
+    var recorder = ParsedFrameRecorder{};
+    defer recorder.deinit(testing.allocator);
+    var scratch: [128]u8 = undefined;
+
+    try testing.expectError(error.InvalidRequestFrame, req.ingestBytesWithObserver(data, &scratch, recorder.observer()));
+    try testing.expectEqual(@as(usize, 1), recorder.frames.items.len);
+    try testing.expectEqual(frame.FrameType.data, recorder.frames.items[0].typ);
+    try testing.expectEqual(data.len, recorder.frames.items[0].len);
 }
 
 test "request stream rejects DATA before HEADERS and trailers for the MVP" {

--- a/src/quic/qlog.zig
+++ b/src/quic/qlog.zig
@@ -87,13 +87,15 @@ pub const HandshakeStage = enum {
     failed,
 };
 
-/// Why a connection closed (drives `quic:connection_closed`).
-pub const CloseReason = enum {
+/// Standard qlog `quic:connection_closed` trigger.
+pub const CloseTrigger = enum {
     idle_timeout,
-    application_close,
-    transport_error,
+    application,
+    @"error",
+    version_mismatch,
     stateless_reset,
-    handshake_failure,
+    aborted,
+    unspecified,
 };
 
 pub const CloseError = union(enum) {
@@ -212,7 +214,7 @@ pub const Event = union(enum) {
     },
     /// quic:connection_closed
     connection_closed: struct {
-        reason: CloseReason,
+        trigger: CloseTrigger,
         close_error: CloseError = .none,
     },
     /// tardigrade:quic_handshake_progressed (progress milestone; not a
@@ -230,14 +232,14 @@ pub const Event = union(enum) {
     /// quic:packet_sent
     packet_sent: struct {
         packet_type: PacketType,
-        packet_number: u64,
+        packet_number: ?u64 = null,
         length: usize,
         ack_eliciting: bool = false,
     },
     /// quic:packet_received
     packet_received: struct {
         packet_type: PacketType,
-        packet_number: u64,
+        packet_number: ?u64 = null,
         length: usize,
     },
     /// quic:packet_lost
@@ -395,7 +397,7 @@ fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
             .{ d.odcid_len, d.scid_len, d.dcid_len },
         ),
         .connection_closed => |d| {
-            try b.add("{{\"reason\":\"{s}\"", .{@tagName(d.reason)});
+            try b.add("{{\"trigger\":\"{s}\"", .{@tagName(d.trigger)});
             switch (d.close_error) {
                 .none => {},
                 .connection_unknown => |code| try b.add(",\"connection_error\":\"unknown\",\"error_code\":{d}", .{code}),
@@ -413,14 +415,16 @@ fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
             if (d.trigger) |trigger| try b.add(",\"trigger\":\"{s}\"", .{@tagName(trigger)});
             try b.add("}}", .{});
         },
-        .packet_sent => |d| try b.add(
-            "{{\"header\":{{\"packet_type\":\"{s}\",\"packet_number\":{d}}},\"raw\":{{\"length\":{d}}},\"tardigrade_ack_eliciting\":{s}}}",
-            .{ d.packet_type.label(), d.packet_number, d.length, boolText(d.ack_eliciting) },
-        ),
-        .packet_received => |d| try b.add(
-            "{{\"header\":{{\"packet_type\":\"{s}\",\"packet_number\":{d}}},\"raw\":{{\"length\":{d}}}}}",
-            .{ d.packet_type.label(), d.packet_number, d.length },
-        ),
+        .packet_sent => |d| {
+            try b.add("{{\"header\":{{\"packet_type\":\"{s}\"", .{d.packet_type.label()});
+            if (d.packet_number) |pn| try b.add(",\"packet_number\":{d}", .{pn});
+            try b.add("}},\"raw\":{{\"length\":{d}}},\"tardigrade_ack_eliciting\":{s}}}", .{ d.length, boolText(d.ack_eliciting) });
+        },
+        .packet_received => |d| {
+            try b.add("{{\"header\":{{\"packet_type\":\"{s}\"", .{d.packet_type.label()});
+            if (d.packet_number) |pn| try b.add(",\"packet_number\":{d}", .{pn});
+            try b.add("}},\"raw\":{{\"length\":{d}}}}}", .{d.length});
+        },
         .packet_lost => |d| {
             try b.add("{{\"header\":{{\"packet_type\":\"{s}\"", .{d.packet_type.label()});
             if (d.packet_number) |pn| try b.add(",\"packet_number\":{d}", .{pn});
@@ -566,6 +570,16 @@ fn expectJson(record: Record, needle: []const u8) !void {
     try testing.expect(std.mem.indexOf(u8, line, needle) != null);
 }
 
+fn expectNoJson(record: Record, needle: []const u8) !void {
+    var buf: [512]u8 = undefined;
+    const line = try writeJson(record, &buf);
+    try testing.expect(line[0] == record_separator);
+    try testing.expect(line[line.len - 1] == '\n');
+    try testing.expect(std.mem.indexOf(u8, line, needle) == null);
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, line[1 .. line.len - 1], .{});
+    defer parsed.deinit();
+}
+
 test "namespace and name mapping stays aligned with qlog vantage points" {
     try testing.expectEqual(Namespace.quic, (Event{ .packet_sent = .{ .packet_type = .one_rtt, .packet_number = 0, .length = 0 } }).namespace());
     try testing.expectEqual(Namespace.quic, (Event{ .packet_lost = .{ .packet_type = .one_rtt } }).namespace());
@@ -586,6 +600,25 @@ test "packet_sent serializes to a quic JSON-SEQ line" {
     );
 }
 
+test "non-numbered packets omit packet_number" {
+    try expectJson(
+        .{ .time_us = 0, .event = .{ .packet_sent = .{ .packet_type = .retry, .length = 1200 } } },
+        "\"header\":{\"packet_type\":\"retry\"}",
+    );
+    try expectNoJson(
+        .{ .time_us = 0, .event = .{ .packet_sent = .{ .packet_type = .retry, .length = 1200 } } },
+        "\"packet_number\"",
+    );
+    try expectJson(
+        .{ .time_us = 0, .event = .{ .packet_received = .{ .packet_type = .version_negotiation, .length = 37 } } },
+        "\"header\":{\"packet_type\":\"version_negotiation\"}",
+    );
+    try expectNoJson(
+        .{ .time_us = 0, .event = .{ .packet_received = .{ .packet_type = .version_negotiation, .length = 37 } } },
+        "\"packet_number\"",
+    );
+}
+
 test "deprotection failure is a packet_dropped with decryption_failure" {
     try expectJson(
         .{ .time_us = 0, .event = .{ .packet_dropped = .{ .packet_type = .one_rtt, .trigger = .decryption_failure, .length = 42 } } },
@@ -602,11 +635,15 @@ test "0-RTT key type serializes as a standard key_updated value" {
 
 test "connection_closed ties error_code to an unknown error category" {
     try expectJson(
-        .{ .time_us = 0, .event = .{ .connection_closed = .{ .reason = .transport_error, .close_error = .{ .connection_unknown = 0x123 } } } },
+        .{ .time_us = 0, .event = .{ .connection_closed = .{ .trigger = .@"error", .close_error = .{ .connection_unknown = 0x123 } } } },
+        "\"trigger\":\"error\"",
+    );
+    try expectJson(
+        .{ .time_us = 0, .event = .{ .connection_closed = .{ .trigger = .@"error", .close_error = .{ .connection_unknown = 0x123 } } } },
         "\"connection_error\":\"unknown\",\"error_code\":291",
     );
     try expectJson(
-        .{ .time_us = 0, .event = .{ .connection_closed = .{ .reason = .application_close, .close_error = .{ .application_unknown = 0x456 } } } },
+        .{ .time_us = 0, .event = .{ .connection_closed = .{ .trigger = .application, .close_error = .{ .application_unknown = 0x456 } } } },
         "\"application_error\":\"unknown\",\"error_code\":1110",
     );
 }
@@ -678,7 +715,7 @@ test "default sink is a no-op and log() stamps time" {
 
     Collector.last = null;
     const sink = Sink{ .emit_fn = Collector.emit };
-    sink.log(99, .{ .connection_closed = .{ .reason = .idle_timeout } });
+    sink.log(99, .{ .connection_closed = .{ .trigger = .idle_timeout } });
     try testing.expect(Collector.last != null);
     try testing.expectEqual(@as(u64, 99), Collector.last.?.time_us);
 }

--- a/src/quic/qlog.zig
+++ b/src/quic/qlog.zig
@@ -16,8 +16,8 @@
 //!
 //! ## Layering (the #255 "don't leak H3 into src/quic" decision)
 //!
-//! `src/quic` owns *only* transport-vantage events (qlog categories
-//! `connectivity`, `security`, `transport`, `recovery`). HTTP/3- and
+//! `src/quic` owns *only* transport-vantage events (the `quic:*` namespace
+//! plus documented `tardigrade:*` debug extensions). HTTP/3- and
 //! QPACK-vantage events live in `src/http3/qlog.zig` and are emitted from
 //! `src/http3`. Neither package imports the other — the same boundary the
 //! build graph already enforces (see build.zig: the smoke harness stitches the
@@ -39,15 +39,20 @@
 
 const std = @import("std");
 
-/// qlog top-level event categories this transport emits. Application (`http`,
-/// `qpack`) categories are intentionally absent: they belong to `src/http3`.
-pub const Category = enum {
-    connectivity,
-    security,
-    transport,
-    recovery,
+pub const quic_event_schema_uri = "urn:ietf:params:qlog:events:quic-13";
+pub const http3_event_schema_uri = "urn:ietf:params:qlog:events:http3-13";
+pub const tardigrade_event_schema_uri = "https://bare.systems/tardigrade/qlog/events/debug-1";
+pub const file_schema_uri = "urn:ietf:params:qlog:file:sequential";
+pub const serialization_format = "application/qlog+json-seq";
+pub const sqlog_suffix = ".sqlog";
 
-    pub fn label(self: Category) []const u8 {
+/// qlog event namespace this transport emits. Application (`http3`) events are
+/// intentionally absent: they belong to `src/http3`.
+pub const Namespace = enum {
+    quic,
+    tardigrade,
+
+    pub fn label(self: Namespace) []const u8 {
         return @tagName(self);
     }
 };
@@ -82,7 +87,7 @@ pub const HandshakeStage = enum {
     failed,
 };
 
-/// Why a connection closed (drives `connectivity:connection_closed`).
+/// Why a connection closed (drives `quic:connection_closed`).
 pub const CloseReason = enum {
     idle_timeout,
     application_close,
@@ -116,124 +121,144 @@ pub const StreamResetKind = enum {
 /// DATA_BLOCKED vs. STREAM_DATA_BLOCKED (RFC 9000 §19.12, §19.13).
 pub const BlockedScope = enum { connection, stream };
 
-/// Why an inbound packet was dropped. `payload_decrypt_error` is the qlog
+/// Why an inbound packet was dropped. `decryption_failure` is the qlog
 /// canonical trigger for AEAD deprotection failure — the #255 requirement that
 /// deprotection failures are reported deterministically.
 pub const DropTrigger = enum {
-    payload_decrypt_error,
+    decryption_failure,
     key_unavailable,
-    unknown_connection_id,
-    unexpected_packet,
-    header_parse_error,
+    connection_unknown,
+    invalid,
+    unsupported,
+    duplicate,
+    internal_error,
+    rejected,
+    general,
+};
+
+pub const RecoveryMetrics = struct {
+    latest_rtt_ms: ?u64 = null,
+    smoothed_rtt_ms: ?u64 = null,
+    rtt_variance_ms: ?u64 = null,
+    pto_count: ?u16 = null,
+    congestion_window: ?u64 = null,
+    bytes_in_flight: ?u64 = null,
 };
 
 /// The closed set of transport-vantage events. Data payloads are kept small and
 /// copy-free (scalars/enums only) so emitting is cheap and the union never
 /// borrows connection-owned buffers.
 pub const Event = union(enum) {
-    /// connectivity:connection_started
+    /// quic:connection_started
     connection_started: struct {
         odcid_len: u8 = 0,
         scid_len: u8 = 0,
         dcid_len: u8 = 0,
     },
-    /// connectivity:connection_closed
+    /// quic:connection_closed
     connection_closed: struct {
         reason: CloseReason,
         error_code: ?u64 = null,
     },
-    /// connectivity:handshake (progress milestone; not a base qlog name, kept
-    /// under connectivity as a Tardigrade extension for stage visibility)
+    /// tardigrade:quic_handshake_progressed (progress milestone; not a
+    /// standard qlog event, kept under a Tardigrade namespace for stage
+    /// visibility)
     handshake_progressed: struct {
         stage: HandshakeStage,
     },
-    /// security:key_updated (1-RTT key-phase flip, RFC 9001 §6)
+    /// quic:key_updated (1-RTT key-phase flip, RFC 9001 §6)
     key_updated: struct {
         phase: u1,
     },
-    /// transport:packet_sent
+    /// quic:packet_sent
     packet_sent: struct {
         packet_type: PacketType,
         packet_number: u64,
         length: usize,
         ack_eliciting: bool = false,
     },
-    /// transport:packet_received
+    /// quic:packet_received
     packet_received: struct {
         packet_type: PacketType,
         packet_number: u64,
         length: usize,
     },
-    /// recovery:packet_lost
+    /// quic:packet_lost
     packet_lost: struct {
         packet_type: PacketType,
         packet_number: ?u64 = null,
-        bytes_in_flight: usize = 0,
-        congestion_window: usize = 0,
     },
-    /// transport:packet_dropped (deprotection failure and other drops)
+    /// quic:recovery_metrics_updated
+    recovery_metrics_updated: RecoveryMetrics,
+    /// quic:packet_dropped (deprotection failure and other drops)
     packet_dropped: struct {
         packet_type: ?PacketType = null,
         trigger: DropTrigger,
         length: usize = 0,
     },
-    /// transport:path_validation (PATH_CHALLENGE / PATH_RESPONSE)
+    /// tardigrade:quic_path_validation (PATH_CHALLENGE / PATH_RESPONSE)
     path_validation: struct {
         kind: PathEventKind,
         path_id: u8 = 0,
     },
-    /// connectivity:connection_migrated
+    /// quic:migration_state_updated
     connection_migrated: struct {
         kind: MigrationKind,
         outcome: MigrationOutcome,
     },
-    /// transport:stream_reset (RESET_STREAM / STOP_SENDING)
+    /// tardigrade:quic_stream_reset (RESET_STREAM / STOP_SENDING)
     stream_reset: struct {
         kind: StreamResetKind,
         stream_id: u64,
         error_code: u64 = 0,
     },
-    /// transport:data_blocked (flow-control blocked)
+    /// quic:connection_data_blocked_updated /
+    /// quic:stream_data_blocked_updated (flow-control blocked)
     data_blocked: struct {
         scope: BlockedScope,
         stream_id: ?u64 = null,
         limit: u64 = 0,
     },
 
-    pub fn category(self: Event) Category {
+    pub fn namespace(self: Event) Namespace {
         return switch (self) {
             .connection_started,
             .connection_closed,
-            .handshake_progressed,
             .connection_migrated,
-            => .connectivity,
-            .key_updated => .security,
-            .packet_lost => .recovery,
+            .key_updated,
+            .packet_lost,
+            .recovery_metrics_updated,
             .packet_sent,
             .packet_received,
             .packet_dropped,
+            .data_blocked,
+            => .quic,
             .path_validation,
             .stream_reset,
-            .data_blocked,
-            => .transport,
+            .handshake_progressed,
+            => .tardigrade,
         };
     }
 
-    /// The qlog event name within the category (the part after the `:`).
+    /// The qlog event name within the namespace (the part after the `:`).
     pub fn name(self: Event) []const u8 {
         return switch (self) {
             .connection_started => "connection_started",
             .connection_closed => "connection_closed",
-            .handshake_progressed => "handshake",
+            .handshake_progressed => "quic_handshake_progressed",
             .key_updated => "key_updated",
             .packet_sent => "packet_sent",
             .packet_received => "packet_received",
             .packet_lost => "packet_lost",
+            .recovery_metrics_updated => "recovery_metrics_updated",
             .packet_dropped => "packet_dropped",
-            .path_validation => "path_validation",
-            .connection_migrated => "connection_migrated",
-            .stream_reset => "stream_reset",
-            .data_blocked => "data_blocked",
+            .path_validation => "quic_path_validation",
+            .connection_migrated => "migration_state_updated",
+            .stream_reset => "quic_stream_reset",
+            .data_blocked => |d| switch (d.scope) {
+                .connection => "connection_data_blocked_updated",
+                .stream => "stream_data_blocked_updated",
+            },
         };
     }
 };
@@ -309,33 +334,63 @@ fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
         ),
         .key_updated => |d| try b.add("{{\"key_phase\":{d}}}", .{d.phase}),
         .packet_sent => |d| try b.add(
-            "{{\"packet_type\":\"{s}\",\"packet_number\":{d},\"length\":{d},\"ack_eliciting\":{s}}}",
+            "{{\"header\":{{\"packet_type\":\"{s}\",\"packet_number\":{d}}},\"raw\":{{\"length\":{d}}},\"tardigrade_ack_eliciting\":{s}}}",
             .{ d.packet_type.label(), d.packet_number, d.length, boolText(d.ack_eliciting) },
         ),
         .packet_received => |d| try b.add(
-            "{{\"packet_type\":\"{s}\",\"packet_number\":{d},\"length\":{d}}}",
+            "{{\"header\":{{\"packet_type\":\"{s}\",\"packet_number\":{d}}},\"raw\":{{\"length\":{d}}}}}",
             .{ d.packet_type.label(), d.packet_number, d.length },
         ),
         .packet_lost => |d| {
-            try b.add("{{\"packet_type\":\"{s}\"", .{d.packet_type.label()});
+            try b.add("{{\"header\":{{\"packet_type\":\"{s}\"", .{d.packet_type.label()});
             if (d.packet_number) |pn| try b.add(",\"packet_number\":{d}", .{pn});
-            try b.add(
-                ",\"bytes_in_flight\":{d},\"congestion_window\":{d}}}",
-                .{ d.bytes_in_flight, d.congestion_window },
-            );
+            try b.add("}}}}", .{});
+        },
+        .recovery_metrics_updated => |d| {
+            try b.add("{{", .{});
+            var need_comma = false;
+            if (d.latest_rtt_ms) |v| {
+                try b.add("\"latest_rtt\":{d}", .{v});
+                need_comma = true;
+            }
+            if (d.smoothed_rtt_ms) |v| {
+                if (need_comma) try b.add(",", .{});
+                try b.add("\"smoothed_rtt\":{d}", .{v});
+                need_comma = true;
+            }
+            if (d.rtt_variance_ms) |v| {
+                if (need_comma) try b.add(",", .{});
+                try b.add("\"rtt_variance\":{d}", .{v});
+                need_comma = true;
+            }
+            if (d.pto_count) |v| {
+                if (need_comma) try b.add(",", .{});
+                try b.add("\"pto_count\":{d}", .{v});
+                need_comma = true;
+            }
+            if (d.congestion_window) |v| {
+                if (need_comma) try b.add(",", .{});
+                try b.add("\"congestion_window\":{d}", .{v});
+                need_comma = true;
+            }
+            if (d.bytes_in_flight) |v| {
+                if (need_comma) try b.add(",", .{});
+                try b.add("\"bytes_in_flight\":{d}", .{v});
+            }
+            try b.add("}}", .{});
         },
         .packet_dropped => |d| {
             try b.add("{{\"trigger\":\"{s}\"", .{@tagName(d.trigger)});
-            if (d.packet_type) |pt| try b.add(",\"packet_type\":\"{s}\"", .{pt.label()});
-            try b.add(",\"length\":{d}}}", .{d.length});
+            if (d.packet_type) |pt| try b.add(",\"header\":{{\"packet_type\":\"{s}\"}}", .{pt.label()});
+            try b.add(",\"raw\":{{\"length\":{d}}}}}", .{d.length});
         },
         .path_validation => |d| try b.add(
             "{{\"phase\":\"{s}\",\"path_id\":{d}}}",
             .{ @tagName(d.kind), d.path_id },
         ),
         .connection_migrated => |d| try b.add(
-            "{{\"kind\":\"{s}\",\"outcome\":\"{s}\"}}",
-            .{ @tagName(d.kind), @tagName(d.outcome) },
+            "{{\"state\":\"{s}\",\"trigger\":\"{s}\"}}",
+            .{ @tagName(d.outcome), @tagName(d.kind) },
         ),
         .stream_reset => |d| try b.add(
             "{{\"direction\":\"{s}\",\"stream_id\":{d},\"error_code\":{d}}}",
@@ -359,29 +414,28 @@ pub const VantagePoint = enum { client, server };
 /// (ASCII / hex); they are emitted verbatim without escaping.
 pub const TraceHeader = struct {
     vantage_point: VantagePoint,
-    reference_time_us: u64 = 0,
     group_id: []const u8 = "",
     title: []const u8 = "tardigrade-quic",
-    qlog_version: []const u8 = "0.3",
+    description: []const u8 = "Tardigrade QUIC/HTTP-3 debug trace",
 };
 
 /// Serialize the qlog file header as the first JSON-SEQ record. A composition
 /// root writes this once, then appends `writeJson` event records (from both
-/// `quic` and `http3`) to form a complete `.qlog` file qvis can consume.
+/// `quic` and `http3`) to form a complete `.sqlog` file qvis can consume.
 /// Returns the written slice; a 512-byte buffer is enough.
 pub fn writeTraceHeader(header: TraceHeader, out: []u8) error{NoSpaceLeft}![]const u8 {
     var b = Buf{ .buf = out };
     try b.add("{c}", .{record_separator});
     try b.add(
-        "{{\"qlog_version\":\"{s}\",\"qlog_format\":\"JSON-SEQ\",\"title\":\"{s}\",\"trace\":{{\"vantage_point\":{{\"type\":\"{s}\"}},\"common_fields\":{{\"reference_time\":{d}.{d:0>3},\"group_id\":\"{s}\"}}}}}}\n",
-        .{ header.qlog_version, header.title, @tagName(header.vantage_point), header.reference_time_us / 1000, header.reference_time_us % 1000, header.group_id },
+        "{{\"file_schema\":\"{s}\",\"serialization_format\":\"{s}\",\"title\":\"{s}\",\"description\":\"{s}\",\"trace\":{{\"common_fields\":{{\"group_id\":\"{s}\",\"time_format\":\"relative_to_epoch\",\"reference_time\":{{\"clock_type\":\"system\",\"epoch\":\"1970-01-01T00:00:00.000Z\"}}}},\"vantage_point\":{{\"type\":\"{s}\"}},\"event_schemas\":[\"{s}\",\"{s}\",\"{s}\"]}}}}\n",
+        .{ file_schema_uri, serialization_format, header.title, header.description, header.group_id, @tagName(header.vantage_point), quic_event_schema_uri, http3_event_schema_uri, tardigrade_event_schema_uri },
     );
     return b.slice();
 }
 
 /// Serialize one `Record` into `out` as a single qlog JSON-SEQ line:
 ///
-///     0x1E {"time":<ms>,"name":"<category>:<event>","data":{...}} \n
+///     0x1E {"time":<ms>,"name":"<namespace>:<event>","data":{...}} \n
 ///
 /// Returns the written slice. Errors only if `out` is too small; a 512-byte
 /// buffer is comfortably enough for every event above.
@@ -391,7 +445,7 @@ pub fn writeJson(record: Record, out: []u8) error{NoSpaceLeft}![]const u8 {
     // qlog default time unit is milliseconds; keep microsecond precision.
     try b.add(
         "{{\"time\":{d}.{d:0>3},\"name\":\"{s}:{s}\",\"data\":",
-        .{ record.time_us / 1000, record.time_us % 1000, record.event.category().label(), record.event.name() },
+        .{ record.time_us / 1000, record.time_us % 1000, record.event.namespace().label(), record.event.name() },
     );
     try writeData(&b, record.event);
     try b.add("}}\n", .{});
@@ -412,18 +466,19 @@ fn expectJson(record: Record, needle: []const u8) !void {
     try testing.expect(std.mem.indexOf(u8, line, needle) != null);
 }
 
-test "category and name mapping stays aligned with qlog vantage points" {
-    try testing.expectEqual(Category.transport, (Event{ .packet_sent = .{ .packet_type = .one_rtt, .packet_number = 0, .length = 0 } }).category());
-    try testing.expectEqual(Category.recovery, (Event{ .packet_lost = .{ .packet_type = .one_rtt } }).category());
-    try testing.expectEqual(Category.security, (Event{ .key_updated = .{ .phase = 1 } }).category());
-    try testing.expectEqual(Category.connectivity, (Event{ .connection_migrated = .{ .kind = .active, .outcome = .blocked } }).category());
-    try testing.expectEqualStrings("packet_dropped", (Event{ .packet_dropped = .{ .trigger = .payload_decrypt_error } }).name());
+test "namespace and name mapping stays aligned with qlog vantage points" {
+    try testing.expectEqual(Namespace.quic, (Event{ .packet_sent = .{ .packet_type = .one_rtt, .packet_number = 0, .length = 0 } }).namespace());
+    try testing.expectEqual(Namespace.quic, (Event{ .packet_lost = .{ .packet_type = .one_rtt } }).namespace());
+    try testing.expectEqual(Namespace.quic, (Event{ .key_updated = .{ .phase = 1 } }).namespace());
+    try testing.expectEqual(Namespace.quic, (Event{ .connection_migrated = .{ .kind = .active, .outcome = .blocked } }).namespace());
+    try testing.expectEqual(Namespace.tardigrade, (Event{ .stream_reset = .{ .kind = .reset_sent, .stream_id = 0 } }).namespace());
+    try testing.expectEqualStrings("packet_dropped", (Event{ .packet_dropped = .{ .trigger = .decryption_failure } }).name());
 }
 
-test "packet_sent serializes to a transport JSON-SEQ line" {
+test "packet_sent serializes to a quic JSON-SEQ line" {
     try expectJson(
         .{ .time_us = 1_234_567, .event = .{ .packet_sent = .{ .packet_type = .initial, .packet_number = 7, .length = 1200, .ack_eliciting = true } } },
-        "\"name\":\"transport:packet_sent\"",
+        "\"name\":\"quic:packet_sent\"",
     );
     try expectJson(
         .{ .time_us = 1_234_567, .event = .{ .packet_sent = .{ .packet_type = .one_rtt, .packet_number = 7, .length = 1200 } } },
@@ -431,10 +486,10 @@ test "packet_sent serializes to a transport JSON-SEQ line" {
     );
 }
 
-test "deprotection failure is a packet_dropped with payload_decrypt_error" {
+test "deprotection failure is a packet_dropped with decryption_failure" {
     try expectJson(
-        .{ .time_us = 0, .event = .{ .packet_dropped = .{ .packet_type = .one_rtt, .trigger = .payload_decrypt_error, .length = 42 } } },
-        "\"trigger\":\"payload_decrypt_error\"",
+        .{ .time_us = 0, .event = .{ .packet_dropped = .{ .packet_type = .one_rtt, .trigger = .decryption_failure, .length = 42 } } },
+        "\"trigger\":\"decryption_failure\"",
     );
 }
 
@@ -446,21 +501,34 @@ test "time is rendered in milliseconds with microsecond precision" {
 
 test "path, migration, stream reset and flow-control events serialize" {
     try expectJson(.{ .time_us = 5, .event = .{ .path_validation = .{ .kind = .response_received } } }, "\"phase\":\"response_received\"");
-    try expectJson(.{ .time_us = 5, .event = .{ .connection_migrated = .{ .kind = .nat_rebinding, .outcome = .accepted } } }, "connection_migrated");
+    try expectJson(.{ .time_us = 5, .event = .{ .connection_migrated = .{ .kind = .nat_rebinding, .outcome = .accepted } } }, "migration_state_updated");
     try expectJson(.{ .time_us = 5, .event = .{ .stream_reset = .{ .kind = .reset_received, .stream_id = 4, .error_code = 9 } } }, "\"stream_id\":4");
     try expectJson(.{ .time_us = 5, .event = .{ .data_blocked = .{ .scope = .stream, .stream_id = 8, .limit = 4096 } } }, "\"scope\":\"stream\"");
 }
 
+test "recovery metrics serialize as a quic event" {
+    try expectJson(
+        .{ .time_us = 5, .event = .{ .recovery_metrics_updated = .{ .congestion_window = 12_000, .bytes_in_flight = 1_200, .pto_count = 2 } } },
+        "\"name\":\"quic:recovery_metrics_updated\"",
+    );
+    try expectJson(
+        .{ .time_us = 5, .event = .{ .recovery_metrics_updated = .{ .congestion_window = 12_000, .bytes_in_flight = 1_200, .pto_count = 2 } } },
+        "\"bytes_in_flight\":1200",
+    );
+}
+
 test "trace header then event forms a two-record JSON-SEQ stream" {
     var buf: [1024]u8 = undefined;
-    const header = try writeTraceHeader(.{ .vantage_point = .server, .reference_time_us = 1_000, .group_id = "0011deadbeef" }, &buf);
+    const header = try writeTraceHeader(.{ .vantage_point = .server, .group_id = "0011deadbeef" }, &buf);
     const event = try writeJson(.{ .time_us = 2_500, .event = .{ .packet_sent = .{ .packet_type = .initial, .packet_number = 0, .length = 1200 } } }, buf[header.len..]);
     // Exactly two record separators, one per record.
     try testing.expectEqual(@as(usize, 2), std.mem.count(u8, buf[0 .. header.len + event.len], &[_]u8{record_separator}));
-    try testing.expect(std.mem.indexOf(u8, header, "\"qlog_format\":\"JSON-SEQ\"") != null);
+    try testing.expect(std.mem.indexOf(u8, header, "\"file_schema\":\"urn:ietf:params:qlog:file:sequential\"") != null);
+    try testing.expect(std.mem.indexOf(u8, header, "\"serialization_format\":\"application/qlog+json-seq\"") != null);
+    try testing.expect(std.mem.indexOf(u8, header, "\"event_schemas\":[\"urn:ietf:params:qlog:events:quic-13\",\"urn:ietf:params:qlog:events:http3-13\"") != null);
     try testing.expect(std.mem.indexOf(u8, header, "\"vantage_point\":{\"type\":\"server\"}") != null);
     try testing.expect(std.mem.indexOf(u8, header, "\"group_id\":\"0011deadbeef\"") != null);
-    try testing.expect(std.mem.indexOf(u8, event, "transport:packet_sent") != null);
+    try testing.expect(std.mem.indexOf(u8, event, "quic:packet_sent") != null);
 }
 
 test "default sink is a no-op and log() stamps time" {

--- a/src/quic/qlog.zig
+++ b/src/quic/qlog.zig
@@ -106,9 +106,31 @@ pub const PathEventKind = enum {
     failed,
 };
 
-/// Connection-migration classification and policy outcome (RFC 9000 §9).
-pub const MigrationKind = enum { nat_rebinding, active };
-pub const MigrationOutcome = enum { accepted, blocked };
+pub const TupleEndpointInfo = struct {};
+
+pub const KeyType = enum {
+    server_initial_secret,
+    client_initial_secret,
+    server_handshake_secret,
+    client_handshake_secret,
+    server_1rtt_secret,
+    client_1rtt_secret,
+};
+
+pub const KeyUpdateTrigger = enum {
+    tls,
+    local_update,
+    remote_update,
+};
+
+pub const MigrationState = enum {
+    probing_started,
+    probing_abandoned,
+    probing_successful,
+    migration_started,
+    migration_abandoned,
+    migration_complete,
+};
 
 /// RESET_STREAM / STOP_SENDING direction (RFC 9000 §19.4, §19.5).
 pub const StreamResetKind = enum {
@@ -118,8 +140,26 @@ pub const StreamResetKind = enum {
     stop_sending_received,
 };
 
-/// DATA_BLOCKED vs. STREAM_DATA_BLOCKED (RFC 9000 §19.12, §19.13).
-pub const BlockedScope = enum { connection, stream };
+pub const BlockedState = enum { blocked, unblocked };
+pub const BlockedReason = enum {
+    data_blocked_frame,
+    stream_data_blocked_frame,
+    flow_control_limit,
+};
+
+pub const DataBlocked = union(enum) {
+    connection: struct {
+        old: ?BlockedState = null,
+        new: BlockedState,
+        reason: ?BlockedReason = null,
+    },
+    stream: struct {
+        stream_id: u64,
+        old: ?BlockedState = null,
+        new: BlockedState,
+        reason: ?BlockedReason = null,
+    },
+};
 
 /// Why an inbound packet was dropped. `decryption_failure` is the qlog
 /// canonical trigger for AEAD deprotection failure — the #255 requirement that
@@ -151,6 +191,8 @@ pub const RecoveryMetrics = struct {
 pub const Event = union(enum) {
     /// quic:connection_started
     connection_started: struct {
+        local: TupleEndpointInfo = .{},
+        remote: TupleEndpointInfo = .{},
         odcid_len: u8 = 0,
         scid_len: u8 = 0,
         dcid_len: u8 = 0,
@@ -168,7 +210,9 @@ pub const Event = union(enum) {
     },
     /// quic:key_updated (1-RTT key-phase flip, RFC 9001 §6)
     key_updated: struct {
-        phase: u1,
+        key_type: KeyType,
+        key_phase: ?u64 = null,
+        trigger: ?KeyUpdateTrigger = null,
     },
     /// quic:packet_sent
     packet_sent: struct {
@@ -203,8 +247,8 @@ pub const Event = union(enum) {
     },
     /// quic:migration_state_updated
     connection_migrated: struct {
-        kind: MigrationKind,
-        outcome: MigrationOutcome,
+        old: ?MigrationState = null,
+        new: MigrationState,
     },
     /// tardigrade:quic_stream_reset (RESET_STREAM / STOP_SENDING)
     stream_reset: struct {
@@ -214,11 +258,7 @@ pub const Event = union(enum) {
     },
     /// quic:connection_data_blocked_updated /
     /// quic:stream_data_blocked_updated (flow-control blocked)
-    data_blocked: struct {
-        scope: BlockedScope,
-        stream_id: ?u64 = null,
-        limit: u64 = 0,
-    },
+    data_blocked: DataBlocked,
 
     pub fn namespace(self: Event) Namespace {
         return switch (self) {
@@ -255,7 +295,7 @@ pub const Event = union(enum) {
             .path_validation => "quic_path_validation",
             .connection_migrated => "migration_state_updated",
             .stream_reset => "quic_stream_reset",
-            .data_blocked => |d| switch (d.scope) {
+            .data_blocked => |d| switch (d) {
                 .connection => "connection_data_blocked_updated",
                 .stream => "stream_data_blocked_updated",
             },
@@ -320,7 +360,7 @@ fn boolText(value: bool) []const u8 {
 fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
     switch (event) {
         .connection_started => |d| try b.add(
-            "{{\"odcid_length\":{d},\"scid_length\":{d},\"dcid_length\":{d}}}",
+            "{{\"local\":{{}},\"remote\":{{}},\"tardigrade_odcid_length\":{d},\"tardigrade_scid_length\":{d},\"tardigrade_dcid_length\":{d}}}",
             .{ d.odcid_len, d.scid_len, d.dcid_len },
         ),
         .connection_closed => |d| {
@@ -332,7 +372,12 @@ fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
             "{{\"stage\":\"{s}\"}}",
             .{@tagName(d.stage)},
         ),
-        .key_updated => |d| try b.add("{{\"key_phase\":{d}}}", .{d.phase}),
+        .key_updated => |d| {
+            try b.add("{{\"key_type\":\"{s}\"", .{@tagName(d.key_type)});
+            if (d.key_phase) |phase| try b.add(",\"key_phase\":{d}", .{phase});
+            if (d.trigger) |trigger| try b.add(",\"trigger\":\"{s}\"", .{@tagName(trigger)});
+            try b.add("}}", .{});
+        },
         .packet_sent => |d| try b.add(
             "{{\"header\":{{\"packet_type\":\"{s}\",\"packet_number\":{d}}},\"raw\":{{\"length\":{d}}},\"tardigrade_ack_eliciting\":{s}}}",
             .{ d.packet_type.label(), d.packet_number, d.length, boolText(d.ack_eliciting) },
@@ -388,18 +433,35 @@ fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
             "{{\"phase\":\"{s}\",\"path_id\":{d}}}",
             .{ @tagName(d.kind), d.path_id },
         ),
-        .connection_migrated => |d| try b.add(
-            "{{\"state\":\"{s}\",\"trigger\":\"{s}\"}}",
-            .{ @tagName(d.outcome), @tagName(d.kind) },
-        ),
+        .connection_migrated => |d| {
+            try b.add("{{", .{});
+            if (d.old) |old| try b.add("\"old\":\"{s}\",", .{@tagName(old)});
+            try b.add("\"new\":\"{s}\"}}", .{@tagName(d.new)});
+        },
         .stream_reset => |d| try b.add(
             "{{\"direction\":\"{s}\",\"stream_id\":{d},\"error_code\":{d}}}",
             .{ @tagName(d.kind), d.stream_id, d.error_code },
         ),
-        .data_blocked => |d| {
-            try b.add("{{\"scope\":\"{s}\"", .{@tagName(d.scope)});
-            if (d.stream_id) |sid| try b.add(",\"stream_id\":{d}", .{sid});
-            try b.add(",\"limit\":{d}}}", .{d.limit});
+        .data_blocked => |d| switch (d) {
+            .connection => |blocked| {
+                try b.add("{{", .{});
+                var need_comma = false;
+                if (blocked.old) |old| {
+                    try b.add("\"old\":\"{s}\"", .{@tagName(old)});
+                    need_comma = true;
+                }
+                if (need_comma) try b.add(",", .{});
+                try b.add("\"new\":\"{s}\"", .{@tagName(blocked.new)});
+                if (blocked.reason) |reason| try b.add(",\"reason\":\"{s}\"", .{@tagName(reason)});
+                try b.add("}}", .{});
+            },
+            .stream => |blocked| {
+                try b.add("{{\"stream_id\":{d}", .{blocked.stream_id});
+                if (blocked.old) |old| try b.add(",\"old\":\"{s}\"", .{@tagName(old)});
+                try b.add(",\"new\":\"{s}\"", .{@tagName(blocked.new)});
+                if (blocked.reason) |reason| try b.add(",\"reason\":\"{s}\"", .{@tagName(reason)});
+                try b.add("}}", .{});
+            },
         },
     }
 }
@@ -427,7 +489,7 @@ pub fn writeTraceHeader(header: TraceHeader, out: []u8) error{NoSpaceLeft}![]con
     var b = Buf{ .buf = out };
     try b.add("{c}", .{record_separator});
     try b.add(
-        "{{\"file_schema\":\"{s}\",\"serialization_format\":\"{s}\",\"title\":\"{s}\",\"description\":\"{s}\",\"trace\":{{\"common_fields\":{{\"group_id\":\"{s}\",\"time_format\":\"relative_to_epoch\",\"reference_time\":{{\"clock_type\":\"system\",\"epoch\":\"1970-01-01T00:00:00.000Z\"}}}},\"vantage_point\":{{\"type\":\"{s}\"}},\"event_schemas\":[\"{s}\",\"{s}\",\"{s}\"]}}}}\n",
+        "{{\"file_schema\":\"{s}\",\"serialization_format\":\"{s}\",\"title\":\"{s}\",\"description\":\"{s}\",\"trace\":{{\"common_fields\":{{\"group_id\":\"{s}\",\"time_format\":\"relative_to_epoch\",\"reference_time\":{{\"clock_type\":\"monotonic\",\"epoch\":\"unknown\"}}}},\"vantage_point\":{{\"type\":\"{s}\"}},\"event_schemas\":[\"{s}\",\"{s}\",\"{s}\"]}}}}\n",
         .{ file_schema_uri, serialization_format, header.title, header.description, header.group_id, @tagName(header.vantage_point), quic_event_schema_uri, http3_event_schema_uri, tardigrade_event_schema_uri },
     );
     return b.slice();
@@ -469,8 +531,8 @@ fn expectJson(record: Record, needle: []const u8) !void {
 test "namespace and name mapping stays aligned with qlog vantage points" {
     try testing.expectEqual(Namespace.quic, (Event{ .packet_sent = .{ .packet_type = .one_rtt, .packet_number = 0, .length = 0 } }).namespace());
     try testing.expectEqual(Namespace.quic, (Event{ .packet_lost = .{ .packet_type = .one_rtt } }).namespace());
-    try testing.expectEqual(Namespace.quic, (Event{ .key_updated = .{ .phase = 1 } }).namespace());
-    try testing.expectEqual(Namespace.quic, (Event{ .connection_migrated = .{ .kind = .active, .outcome = .blocked } }).namespace());
+    try testing.expectEqual(Namespace.quic, (Event{ .key_updated = .{ .key_type = .server_1rtt_secret, .key_phase = 1 } }).namespace());
+    try testing.expectEqual(Namespace.quic, (Event{ .connection_migrated = .{ .new = .migration_complete } }).namespace());
     try testing.expectEqual(Namespace.tardigrade, (Event{ .stream_reset = .{ .kind = .reset_sent, .stream_id = 0 } }).namespace());
     try testing.expectEqualStrings("packet_dropped", (Event{ .packet_dropped = .{ .trigger = .decryption_failure } }).name());
 }
@@ -495,15 +557,16 @@ test "deprotection failure is a packet_dropped with decryption_failure" {
 
 test "time is rendered in milliseconds with microsecond precision" {
     var buf: [512]u8 = undefined;
-    const line = try writeJson(.{ .time_us = 1_002_003, .event = .{ .key_updated = .{ .phase = 1 } } }, &buf);
+    const line = try writeJson(.{ .time_us = 1_002_003, .event = .{ .key_updated = .{ .key_type = .server_1rtt_secret, .key_phase = 1 } } }, &buf);
     try testing.expect(std.mem.indexOf(u8, line, "\"time\":1002.003") != null);
 }
 
 test "path, migration, stream reset and flow-control events serialize" {
     try expectJson(.{ .time_us = 5, .event = .{ .path_validation = .{ .kind = .response_received } } }, "\"phase\":\"response_received\"");
-    try expectJson(.{ .time_us = 5, .event = .{ .connection_migrated = .{ .kind = .nat_rebinding, .outcome = .accepted } } }, "migration_state_updated");
+    try expectJson(.{ .time_us = 5, .event = .{ .connection_migrated = .{ .old = .migration_started, .new = .migration_complete } } }, "migration_state_updated");
     try expectJson(.{ .time_us = 5, .event = .{ .stream_reset = .{ .kind = .reset_received, .stream_id = 4, .error_code = 9 } } }, "\"stream_id\":4");
-    try expectJson(.{ .time_us = 5, .event = .{ .data_blocked = .{ .scope = .stream, .stream_id = 8, .limit = 4096 } } }, "\"scope\":\"stream\"");
+    try expectJson(.{ .time_us = 5, .event = .{ .data_blocked = .{ .stream = .{ .stream_id = 8, .new = .blocked, .reason = .stream_data_blocked_frame } } } }, "\"name\":\"quic:stream_data_blocked_updated\"");
+    try expectJson(.{ .time_us = 5, .event = .{ .data_blocked = .{ .connection = .{ .new = .blocked, .reason = .data_blocked_frame } } } }, "\"name\":\"quic:connection_data_blocked_updated\"");
 }
 
 test "recovery metrics serialize as a quic event" {
@@ -525,6 +588,7 @@ test "trace header then event forms a two-record JSON-SEQ stream" {
     try testing.expectEqual(@as(usize, 2), std.mem.count(u8, buf[0 .. header.len + event.len], &[_]u8{record_separator}));
     try testing.expect(std.mem.indexOf(u8, header, "\"file_schema\":\"urn:ietf:params:qlog:file:sequential\"") != null);
     try testing.expect(std.mem.indexOf(u8, header, "\"serialization_format\":\"application/qlog+json-seq\"") != null);
+    try testing.expect(std.mem.indexOf(u8, header, "\"reference_time\":{\"clock_type\":\"monotonic\",\"epoch\":\"unknown\"}") != null);
     try testing.expect(std.mem.indexOf(u8, header, "\"event_schemas\":[\"urn:ietf:params:qlog:events:quic-13\",\"urn:ietf:params:qlog:events:http3-13\"") != null);
     try testing.expect(std.mem.indexOf(u8, header, "\"vantage_point\":{\"type\":\"server\"}") != null);
     try testing.expect(std.mem.indexOf(u8, header, "\"group_id\":\"0011deadbeef\"") != null);
@@ -539,7 +603,7 @@ test "default sink is a no-op and log() stamps time" {
         }
     };
     const noop = Sink{};
-    noop.log(1, .{ .key_updated = .{ .phase = 0 } }); // must not crash
+    noop.log(1, .{ .key_updated = .{ .key_type = .client_1rtt_secret, .key_phase = 0 } }); // must not crash
 
     Collector.last = null;
     const sink = Sink{ .emit_fn = Collector.emit };

--- a/src/quic/qlog.zig
+++ b/src/quic/qlog.zig
@@ -372,6 +372,13 @@ fn boolText(value: bool) []const u8 {
     return if (value) "true" else "false";
 }
 
+fn packetTypeCarriesNumber(packet_type: PacketType) bool {
+    return switch (packet_type) {
+        .initial, .zero_rtt, .handshake, .one_rtt => true,
+        .retry, .version_negotiation => false,
+    };
+}
+
 fn writeJsonString(b: *Buf, value: []const u8) error{NoSpaceLeft}!void {
     try b.add("\"", .{});
     for (value) |c| {
@@ -417,12 +424,16 @@ fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
         },
         .packet_sent => |d| {
             try b.add("{{\"header\":{{\"packet_type\":\"{s}\"", .{d.packet_type.label()});
-            if (d.packet_number) |pn| try b.add(",\"packet_number\":{d}", .{pn});
+            if (packetTypeCarriesNumber(d.packet_type)) {
+                if (d.packet_number) |pn| try b.add(",\"packet_number\":{d}", .{pn});
+            }
             try b.add("}},\"raw\":{{\"length\":{d}}},\"tardigrade_ack_eliciting\":{s}}}", .{ d.length, boolText(d.ack_eliciting) });
         },
         .packet_received => |d| {
             try b.add("{{\"header\":{{\"packet_type\":\"{s}\"", .{d.packet_type.label()});
-            if (d.packet_number) |pn| try b.add(",\"packet_number\":{d}", .{pn});
+            if (packetTypeCarriesNumber(d.packet_type)) {
+                if (d.packet_number) |pn| try b.add(",\"packet_number\":{d}", .{pn});
+            }
             try b.add("}},\"raw\":{{\"length\":{d}}}}}", .{d.length});
         },
         .packet_lost => |d| {
@@ -602,19 +613,19 @@ test "packet_sent serializes to a quic JSON-SEQ line" {
 
 test "non-numbered packets omit packet_number" {
     try expectJson(
-        .{ .time_us = 0, .event = .{ .packet_sent = .{ .packet_type = .retry, .length = 1200 } } },
+        .{ .time_us = 0, .event = .{ .packet_sent = .{ .packet_type = .retry, .packet_number = 99, .length = 1200 } } },
         "\"header\":{\"packet_type\":\"retry\"}",
     );
     try expectNoJson(
-        .{ .time_us = 0, .event = .{ .packet_sent = .{ .packet_type = .retry, .length = 1200 } } },
+        .{ .time_us = 0, .event = .{ .packet_sent = .{ .packet_type = .retry, .packet_number = 99, .length = 1200 } } },
         "\"packet_number\"",
     );
     try expectJson(
-        .{ .time_us = 0, .event = .{ .packet_received = .{ .packet_type = .version_negotiation, .length = 37 } } },
+        .{ .time_us = 0, .event = .{ .packet_received = .{ .packet_type = .version_negotiation, .packet_number = 99, .length = 37 } } },
         "\"header\":{\"packet_type\":\"version_negotiation\"}",
     );
     try expectNoJson(
-        .{ .time_us = 0, .event = .{ .packet_received = .{ .packet_type = .version_negotiation, .length = 37 } } },
+        .{ .time_us = 0, .event = .{ .packet_received = .{ .packet_type = .version_negotiation, .packet_number = 99, .length = 37 } } },
         "\"packet_number\"",
     );
 }

--- a/tests/quic_h3_smoke.zig
+++ b/tests/quic_h3_smoke.zig
@@ -1209,10 +1209,10 @@ test "qlog composition root interleaves transport and h3 records under one heade
 
     const h3_settings = try h3qlog.writeJson(.{
         .time_us = 2_000,
-        .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = &.{.{ .name = "SETTINGS_QPACK_BLOCKED_STREAMS", .value = 16 }}, .raw_length = 6 } } } },
+        .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = .{ .qpack_blocked_streams = 16 }, .raw_length = 6 } } } },
     }, file[len..]);
     len += h3_settings.len;
-    try expectQlogRecord(h3_settings, "{\"time\":2.000,\"name\":\"http3:frame_created\",\"data\":{\"stream_id\":0,\"frame\":{\"frame_type\":\"settings\",\"settings\":[{\"name\":\"SETTINGS_QPACK_BLOCKED_STREAMS\",\"value\":16}],\"raw\":{\"length\":6}}}}");
+    try expectQlogRecord(h3_settings, "{\"time\":2.000,\"name\":\"http3:frame_created\",\"data\":{\"stream_id\":0,\"frame\":{\"frame_type\":\"settings\",\"settings\":[{\"name\":\"settings_qpack_blocked_streams\",\"value\":16}],\"raw\":{\"length\":6}}}}");
 
     const h3_headers = try h3qlog.writeJson(.{
         .time_us = 2_250,

--- a/tests/quic_h3_smoke.zig
+++ b/tests/quic_h3_smoke.zig
@@ -1155,7 +1155,6 @@ test "qlog composition root interleaves transport and h3 records under one heade
 
     const header = try qlog.writeTraceHeader(.{
         .vantage_point = .server,
-        .reference_time_us = 0,
         .group_id = "0011223344556677",
     }, file[len..]);
     len += header.len;
@@ -1175,9 +1174,10 @@ test "qlog composition root interleaves transport and h3 records under one heade
     const stream = file[0..len];
     // Three records: header + one transport + one h3, each JSON-SEQ delimited.
     try testing.expectEqual(@as(usize, 3), std.mem.count(u8, stream, &[_]u8{qlog.record_separator}));
-    try testing.expect(std.mem.indexOf(u8, stream, "\"qlog_format\":\"JSON-SEQ\"") != null);
-    try testing.expect(std.mem.indexOf(u8, stream, "transport:packet_received") != null);
-    try testing.expect(std.mem.indexOf(u8, stream, "qpack:stream_state_updated") != null);
+    try testing.expect(std.mem.indexOf(u8, stream, "\"file_schema\":\"urn:ietf:params:qlog:file:sequential\"") != null);
+    try testing.expect(std.mem.indexOf(u8, stream, "\"serialization_format\":\"application/qlog+json-seq\"") != null);
+    try testing.expect(std.mem.indexOf(u8, stream, "quic:packet_received") != null);
+    try testing.expect(std.mem.indexOf(u8, stream, "tardigrade:qpack_stream_state_updated") != null);
     // Both writers frame identically, so the merged stream is uniform.
     try testing.expectEqual(qlog.record_separator, h3qlog.record_separator);
 }

--- a/tests/quic_h3_smoke.zig
+++ b/tests/quic_h3_smoke.zig
@@ -1146,11 +1146,22 @@ test "smoke harness fails truncated long-header packets deterministically" {
 // interleaves transport records (src/quic) and HTTP/3 records (src/http3) into
 // a single JSON-SEQ stream. This test locks that intended file shape — the seam
 // #255 designs — without either package importing the other.
+fn expectQlogRecord(record: []const u8, expected_json: []const u8) !void {
+    try testing.expect(record.len >= 2);
+    try testing.expectEqual(quic.qlog.record_separator, record[0]);
+    try testing.expectEqual(@as(u8, '\n'), record[record.len - 1]);
+
+    const payload = record[1 .. record.len - 1];
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, payload, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings(expected_json, payload);
+}
+
 test "qlog composition root interleaves transport and h3 records under one header" {
     const qlog = quic.qlog;
     const h3qlog = http3.qlog;
 
-    var file: [1024]u8 = undefined;
+    var file: [8192]u8 = undefined;
     var len: usize = 0;
 
     const header = try qlog.writeTraceHeader(.{
@@ -1159,25 +1170,74 @@ test "qlog composition root interleaves transport and h3 records under one heade
     }, file[len..]);
     len += header.len;
 
-    const transport_rec = try qlog.writeJson(.{
+    try expectQlogRecord(header, "{\"file_schema\":\"urn:ietf:params:qlog:file:sequential\",\"serialization_format\":\"application/qlog+json-seq\",\"title\":\"tardigrade-quic\",\"description\":\"Tardigrade QUIC/HTTP-3 debug trace\",\"trace\":{\"common_fields\":{\"group_id\":\"0011223344556677\",\"time_format\":\"relative_to_epoch\",\"reference_time\":{\"clock_type\":\"monotonic\",\"epoch\":\"unknown\"}},\"vantage_point\":{\"type\":\"server\"},\"event_schemas\":[\"urn:ietf:params:qlog:events:quic-13\",\"urn:ietf:params:qlog:events:http3-13\",\"https://bare.systems/tardigrade/qlog/events/debug-1\"]}}");
+
+    const connection_started = try qlog.writeJson(.{
+        .time_us = 500,
+        .event = .{ .connection_started = .{ .odcid_len = 8, .scid_len = 8, .dcid_len = 8 } },
+    }, file[len..]);
+    len += connection_started.len;
+    try expectQlogRecord(connection_started, "{\"time\":0.500,\"name\":\"quic:connection_started\",\"data\":{\"local\":{},\"remote\":{},\"tardigrade_odcid_length\":8,\"tardigrade_scid_length\":8,\"tardigrade_dcid_length\":8}}");
+
+    const packet_sent = try qlog.writeJson(.{
+        .time_us = 1_000,
+        .event = .{ .packet_sent = .{ .packet_type = .initial, .packet_number = 0, .length = 1200, .ack_eliciting = true } },
+    }, file[len..]);
+    len += packet_sent.len;
+    try expectQlogRecord(packet_sent, "{\"time\":1.000,\"name\":\"quic:packet_sent\",\"data\":{\"header\":{\"packet_type\":\"initial\",\"packet_number\":0},\"raw\":{\"length\":1200},\"tardigrade_ack_eliciting\":true}}");
+
+    const packet_received = try qlog.writeJson(.{
         .time_us = 1_000,
         .event = .{ .packet_received = .{ .packet_type = .initial, .packet_number = 0, .length = 1200 } },
     }, file[len..]);
-    len += transport_rec.len;
+    len += packet_received.len;
+    try expectQlogRecord(packet_received, "{\"time\":1.000,\"name\":\"quic:packet_received\",\"data\":{\"header\":{\"packet_type\":\"initial\",\"packet_number\":0},\"raw\":{\"length\":1200}}}");
 
-    const h3_rec = try h3qlog.writeJson(.{
+    const packet_lost = try qlog.writeJson(.{
+        .time_us = 1_500,
+        .event = .{ .packet_lost = .{ .packet_type = .one_rtt, .packet_number = 7 } },
+    }, file[len..]);
+    len += packet_lost.len;
+    try expectQlogRecord(packet_lost, "{\"time\":1.500,\"name\":\"quic:packet_lost\",\"data\":{\"header\":{\"packet_type\":\"1RTT\",\"packet_number\":7}}}");
+
+    const recovery_metrics = try qlog.writeJson(.{
+        .time_us = 1_750,
+        .event = .{ .recovery_metrics_updated = .{ .latest_rtt_ms = 21, .smoothed_rtt_ms = 23, .rtt_variance_ms = 4, .pto_count = 1, .congestion_window = 12000, .bytes_in_flight = 1200 } },
+    }, file[len..]);
+    len += recovery_metrics.len;
+    try expectQlogRecord(recovery_metrics, "{\"time\":1.750,\"name\":\"quic:recovery_metrics_updated\",\"data\":{\"latest_rtt\":21,\"smoothed_rtt\":23,\"rtt_variance\":4,\"pto_count\":1,\"congestion_window\":12000,\"bytes_in_flight\":1200}}");
+
+    const h3_settings = try h3qlog.writeJson(.{
+        .time_us = 2_000,
+        .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = &.{.{ .name = "SETTINGS_QPACK_BLOCKED_STREAMS", .value = 16 }}, .raw_length = 6 } } } },
+    }, file[len..]);
+    len += h3_settings.len;
+    try expectQlogRecord(h3_settings, "{\"time\":2.000,\"name\":\"http3:frame_created\",\"data\":{\"stream_id\":0,\"frame\":{\"frame_type\":\"settings\",\"settings\":[{\"name\":\"SETTINGS_QPACK_BLOCKED_STREAMS\",\"value\":16}],\"raw\":{\"length\":6}}}}");
+
+    const h3_headers = try h3qlog.writeJson(.{
+        .time_us = 2_250,
+        .event = .{ .frame = .{ .direction = .parsed, .stream_id = 4, .frame = .{ .headers = .{ .headers = &.{ .{ .name = ":method", .value = "GET" }, .{ .name = ":path", .value = "/" } }, .raw_length = 12 } } } },
+    }, file[len..]);
+    len += h3_headers.len;
+    try expectQlogRecord(h3_headers, "{\"time\":2.250,\"name\":\"http3:frame_parsed\",\"data\":{\"stream_id\":4,\"frame\":{\"frame_type\":\"headers\",\"headers\":[{\"name\":\":method\",\"value\":\"GET\"},{\"name\":\":path\",\"value\":\"/\"}],\"raw\":{\"length\":12}}}}");
+
+    const h3_goaway = try h3qlog.writeJson(.{
+        .time_us = 2_500,
+        .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .goaway = .{ .id = 4, .raw_length = 1 } } } },
+    }, file[len..]);
+    len += h3_goaway.len;
+    try expectQlogRecord(h3_goaway, "{\"time\":2.500,\"name\":\"http3:frame_created\",\"data\":{\"stream_id\":0,\"frame\":{\"frame_type\":\"goaway\",\"id\":4,\"raw\":{\"length\":1}}}}");
+
+    const qpack_extension = try h3qlog.writeJson(.{
         .time_us = 2_000,
         .event = .{ .qpack_state_updated = .{ .state = .blocked, .stream_id = 0 } },
     }, file[len..]);
-    len += h3_rec.len;
+    len += qpack_extension.len;
+    try expectQlogRecord(qpack_extension, "{\"time\":2.000,\"name\":\"tardigrade:qpack_stream_state_updated\",\"data\":{\"stream_id\":0,\"state\":\"blocked\"}}");
 
     const stream = file[0..len];
-    // Three records: header + one transport + one h3, each JSON-SEQ delimited.
-    try testing.expectEqual(@as(usize, 3), std.mem.count(u8, stream, &[_]u8{qlog.record_separator}));
-    try testing.expect(std.mem.indexOf(u8, stream, "\"file_schema\":\"urn:ietf:params:qlog:file:sequential\"") != null);
-    try testing.expect(std.mem.indexOf(u8, stream, "\"serialization_format\":\"application/qlog+json-seq\"") != null);
-    try testing.expect(std.mem.indexOf(u8, stream, "quic:packet_received") != null);
-    try testing.expect(std.mem.indexOf(u8, stream, "tardigrade:qpack_stream_state_updated") != null);
+    // Header + representative QUIC/H3 records, each JSON-SEQ delimited.
+    try testing.expectEqual(@as(usize, 10), std.mem.count(u8, stream, &[_]u8{qlog.record_separator}));
     // Both writers frame identically, so the merged stream is uniform.
     try testing.expectEqual(qlog.record_separator, h3qlog.record_separator);
 }

--- a/tests/quic_h3_smoke.zig
+++ b/tests/quic_h3_smoke.zig
@@ -1209,7 +1209,7 @@ test "qlog composition root interleaves transport and h3 records under one heade
 
     const h3_settings = try h3qlog.writeJson(.{
         .time_us = 2_000,
-        .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = .{ .qpack_blocked_streams = 16 }, .raw_length = 6 } } } },
+        .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = &.{.{ .id_value = 0x07, .value = 16 }}, .raw_length = 6 } } } },
     }, file[len..]);
     len += h3_settings.len;
     try expectQlogRecord(h3_settings, "{\"time\":2.000,\"name\":\"http3:frame_created\",\"data\":{\"stream_id\":0,\"frame\":{\"frame_type\":\"settings\",\"settings\":[{\"name\":\"settings_qpack_blocked_streams\",\"value\":16}],\"raw\":{\"length\":6}}}}");


### PR DESCRIPTION
## Summary
- add a typed HTTP/3 EventSink and emit SETTINGS, stream classification, frame create/parse, GOAWAY, and priority update events at H3 state-machine boundaries
- bridge accepted runtime H3 events into the injected http3 qlog sink, keeping the default no-op behavior
- expose aggregate QPACK blocked/unblocked/cancelled/table/decode-failure Prometheus metrics and document the static-decoder caveat

Refs #255 (slice 3)

## Tests
- zig build test-quic
- zig build test