### PR TITLE
Refresh qlog serializers for current drafts

### DIFF
--- a/docs/QUIC_QLOG.md
+++ b/docs/QUIC_QLOG.md
@@ -112,19 +112,19 @@ Names below are `namespace:event`. Transport events (`src/quic/qlog.zig`):
 
 | Requirement (#255)        | qlog event                          | Key data |
 |---------------------------|-------------------------------------|----------|
-| handshake                 | `quic:connection_started`           | odcid/scid/dcid lengths |
+| handshake                 | `quic:connection_started`           | required `local` / `remote` endpoint objects, plus Tardigrade CID-length diagnostics |
 |                           | `tardigrade:quic_handshake_progressed` | `stage` (started -> confirmed / failed) |
 |                           | `quic:connection_closed`            | `reason`, optional `error_code` |
-|                           | `quic:key_updated`                  | `key_phase` |
-| packet sent               | `quic:packet_sent`                  | type, number, length, ack-eliciting |
-| packet received           | `quic:packet_received`              | type, number, length |
-| packet lost               | `quic:packet_lost`                  | type, number |
+|                           | `quic:key_updated`                  | required `key_type`, optional full `key_phase` and `trigger` |
+| packet sent               | `quic:packet_sent`                  | `header`, `raw`, Tardigrade ack-eliciting diagnostic |
+| packet received           | `quic:packet_received`              | `header`, `raw` |
+| packet lost               | `quic:packet_lost`                  | `header` |
 | recovery metrics          | `quic:recovery_metrics_updated`     | RTT/PTO/cwnd/bytes-in-flight updates |
 | **deprotection failure**  | `quic:packet_dropped`               | `trigger:"decryption_failure"` |
 | PATH_CHALLENGE/RESPONSE   | `tardigrade:quic_path_validation`   | `phase` (challenge/response sent/received, validated, failed) |
-| migration                 | `quic:migration_state_updated`      | `trigger` (nat_rebinding/active), `state` (accepted/blocked) |
+| migration                 | `quic:migration_state_updated`      | required `new` migration state, optional `old` |
 | stream reset              | `tardigrade:quic_stream_reset`      | `direction` (reset/stop-sending, sent/received), stream id, error code |
-| flow-control blocked      | `quic:connection_data_blocked_updated` / `quic:stream_data_blocked_updated` | optional stream id, limit |
+| flow-control blocked      | `quic:connection_data_blocked_updated` / `quic:stream_data_blocked_updated` | required `new` blocked state, optional `old` / `reason`; stream variant requires `stream_id` |
 
 Application events (`src/http3/qlog.zig`):
 
@@ -132,13 +132,13 @@ Application events (`src/http3/qlog.zig`):
 |---------------------------|-------------------------------------|----------|
 | SETTINGS                  | `http3:parameters_set`              | max field section size, QPACK table cap, blocked streams |
 | control stream            | `http3:stream_type_set`             | stream id, stream type |
-| HEADERS / DATA / GOAWAY   | `http3:frame_created` / `http3:frame_parsed` | frame type, stream id, raw length |
+| HEADERS / DATA / GOAWAY   | `http3:frame_created` / `http3:frame_parsed` | variant-specific frame payloads; HEADERS carries `headers`, SETTINGS carries `settings`, GOAWAY carries `id` |
 | **QPACK blocked**         | `tardigrade:qpack_stream_state_updated` | `state` (blocked/unblocked), stream id |
 
 `quic:packet_dropped` with `trigger:"decryption_failure"` is the
 canonical qlog encoding of an AEAD deprotection failure, satisfying the #255
 requirement that deprotection failures are reported deterministically. It is
-distinct from a normal drop (`unknown_connection_id`, `key_unavailable`, …).
+distinct from a normal drop (`connection_unknown`, `key_unavailable`, ...).
 
 ### Serialization format
 
@@ -158,11 +158,13 @@ Each record is one JSON-SEQ line:
   `file_schema: urn:ietf:params:qlog:file:sequential`,
   `serialization_format: application/qlog+json-seq`, `trace`,
   `event_schemas`, vantage point, and ODCID `group_id` as the first JSON-SEQ
-  record. The header spans both packages — the `group_id` ties transport and
+  record. The trace declares `clock_type: monotonic` and `epoch: unknown`
+  because event timestamps are monotonic process-relative values, not Unix
+  timestamps. The header spans both packages — the `group_id` ties transport and
   H3 events to one connection — so the **composition root** fills it in and
   writes it once, then appends event records from both `quic` and `http3`. The
   `tests/quic_h3_smoke.zig` harness exercises exactly this shape (header +
-  transport record + H3 record) so the merged-file contract is locked.
+  representative QUIC/H3 records) so the merged-file contract is locked.
 - JSON-SEQ qlog artifacts use the `.sqlog` suffix. Reserve `.qlog` for the
   normal contained JSON qlog form.
 

--- a/docs/QUIC_QLOG.md
+++ b/docs/QUIC_QLOG.md
@@ -114,7 +114,7 @@ Names below are `namespace:event`. Transport events (`src/quic/qlog.zig`):
 |---------------------------|-------------------------------------|----------|
 | handshake                 | `quic:connection_started`           | required `local` / `remote` endpoint objects, plus Tardigrade CID-length diagnostics |
 |                           | `tardigrade:quic_handshake_progressed` | `stage` (started -> confirmed / failed) |
-|                           | `quic:connection_closed`            | `reason`, optional `error_code` |
+|                           | `quic:connection_closed`            | `reason`, optional unknown connection/application error category plus `error_code` |
 |                           | `quic:key_updated`                  | required `key_type`, optional full `key_phase` and `trigger` |
 | packet sent               | `quic:packet_sent`                  | `header`, `raw`, Tardigrade ack-eliciting diagnostic |
 | packet received           | `quic:packet_received`              | `header`, `raw` |

--- a/docs/QUIC_QLOG.md
+++ b/docs/QUIC_QLOG.md
@@ -152,7 +152,11 @@ Each record is one JSON-SEQ line:
   precision, derived from a monotonic `time_us`.
 - Writers are **allocation-free**: they format into a caller-owned buffer
   (`writeJson(record, buf)`), matching the bounded-buffer style already used by
-  the TLS handshake wire writer. A 512-byte buffer covers every event.
+  the TLS handshake wire writer. Fixed-size QUIC transport records remain
+  small, but H3 HEADERS, SETTINGS, and PUSH_PROMISE records grow with supplied
+  field/setting slices. Composition-root writers must size the record buffer
+  for the configured field-section budget, stream records directly, or retain
+  `NoSpaceLeft` as an explicit dropped-record diagnostic.
 - A qlog file is a `QlogFileSeq` header followed by event lines.
   `qlog.writeTraceHeader(header, buf)` serializes the
   `file_schema: urn:ietf:params:qlog:file:sequential`,

--- a/docs/QUIC_QLOG.md
+++ b/docs/QUIC_QLOG.md
@@ -22,7 +22,7 @@ layering, and the safety rules up front so those call-sites are mechanical.
   from a captured trace, not just from ad-hoc `std.log` lines.
 - Provide the primitives (trace-header + event-line + keylog-line writers) so
   that, once the composition root assembles them, the interop/failure harnesses
-  (#247) save `*.qlog` / `*.keys` artifacts that qvis / Wireshark consume
+  (#247) save `*.sqlog` / `*.keys` artifacts that qvis / Wireshark consume
   directly. This PR ships those writers and the merged-shape test; the root
   wiring that emits real flows is follow-up.
 - Keep everything **off by default** and cheap when off.
@@ -43,7 +43,7 @@ respects that boundary rather than punching through it.
 ```
                  composition root (gateway h3 listener / smoke harness)
                  ┌───────────────────────────────────────────────────┐
-                 │  owns the *.qlog file + *.keys file writers        │
+                 │  owns the *.sqlog file + *.keys file writers       │
                  │  installs one quic.qlog.Sink, one http3.qlog.Sink, │
                  │  one quic.keylog.Sink; interleaves all three       │
                  └───────────────▲───────────────▲───────────────▲────┘
@@ -67,7 +67,7 @@ Rules:
    `Sink{}` is a no-op, so the seam costs nothing until a root wires it.
 4. The **concrete file writers** live at the composition root, which already
    owns both packages. It timestamps and interleaves the streams into one
-   JSON-SEQ `.qlog` file, so a single trace still shows transport and H3 events
+   JSON-SEQ `.sqlog` file, so a single trace still shows transport and H3 events
    side by side without either package depending on the other.
 
 This is why there is no single shared "qlog writer" module: sharing one would
@@ -89,32 +89,53 @@ into one valid file at the root instead.
 
 ## qlog event catalogue
 
-Names below are `category:event`. Transport events (`src/quic/qlog.zig`):
+The qlog scaffold tracks the July 2026 submitted drafts:
+
+- `draft-ietf-quic-qlog-main-schema-14`
+- `draft-ietf-quic-qlog-quic-events-13`
+- `draft-ietf-quic-qlog-h3-events-13`
+
+Because these are still drafts, the sequential trace header declares
+draft-qualified event schema URIs:
+
+- `urn:ietf:params:qlog:events:quic-13`
+- `urn:ietf:params:qlog:events:http3-13`
+- `https://bare.systems/tardigrade/qlog/events/debug-1`
+
+The Tardigrade URI covers debug events that are useful for #255 but are not
+standardized qlog events. Most importantly, current HTTP/3 qlog no longer
+standardizes QPACK events, so QPACK blocked-stream visibility is either a
+Prometheus/structured diagnostic signal or the explicit
+`tardigrade:qpack_stream_state_updated` extension below.
+
+Names below are `namespace:event`. Transport events (`src/quic/qlog.zig`):
 
 | Requirement (#255)        | qlog event                          | Key data |
 |---------------------------|-------------------------------------|----------|
-| handshake                 | `connectivity:connection_started`   | odcid/scid/dcid lengths |
-|                           | `connectivity:handshake`            | `stage` (started → confirmed / failed) |
-|                           | `connectivity:connection_closed`    | `reason`, optional `error_code` |
-|                           | `security:key_updated`              | `key_phase` |
-| packet sent               | `transport:packet_sent`             | type, number, length, ack-eliciting |
-| packet received           | `transport:packet_received`         | type, number, length |
-| packet lost               | `recovery:packet_lost`              | type, number, bytes-in-flight, cwnd |
-| **deprotection failure**  | `transport:packet_dropped`          | `trigger:"payload_decrypt_error"` |
-| PATH_CHALLENGE/RESPONSE   | `transport:path_validation`         | `phase` (challenge/response sent/received, validated, failed) |
-| migration                 | `connectivity:connection_migrated`  | `kind` (nat_rebinding/active), `outcome` (accepted/blocked) |
-| stream reset              | `transport:stream_reset`            | `direction` (reset/stop-sending, sent/received), stream id, error code |
-| flow-control blocked      | `transport:data_blocked`            | `scope` (connection/stream), optional stream id, limit |
+| handshake                 | `quic:connection_started`           | odcid/scid/dcid lengths |
+|                           | `tardigrade:quic_handshake_progressed` | `stage` (started -> confirmed / failed) |
+|                           | `quic:connection_closed`            | `reason`, optional `error_code` |
+|                           | `quic:key_updated`                  | `key_phase` |
+| packet sent               | `quic:packet_sent`                  | type, number, length, ack-eliciting |
+| packet received           | `quic:packet_received`              | type, number, length |
+| packet lost               | `quic:packet_lost`                  | type, number |
+| recovery metrics          | `quic:recovery_metrics_updated`     | RTT/PTO/cwnd/bytes-in-flight updates |
+| **deprotection failure**  | `quic:packet_dropped`               | `trigger:"decryption_failure"` |
+| PATH_CHALLENGE/RESPONSE   | `tardigrade:quic_path_validation`   | `phase` (challenge/response sent/received, validated, failed) |
+| migration                 | `quic:migration_state_updated`      | `trigger` (nat_rebinding/active), `state` (accepted/blocked) |
+| stream reset              | `tardigrade:quic_stream_reset`      | `direction` (reset/stop-sending, sent/received), stream id, error code |
+| flow-control blocked      | `quic:connection_data_blocked_updated` / `quic:stream_data_blocked_updated` | optional stream id, limit |
 
 Application events (`src/http3/qlog.zig`):
 
 | Requirement (#255)        | qlog event                          | Key data |
 |---------------------------|-------------------------------------|----------|
-| SETTINGS                  | `http:parameters_set`               | max field section size, QPACK table cap, blocked streams |
-| control stream / HEADERS / DATA / GOAWAY | `http:frame_created` / `http:frame_parsed` | frame type, stream id, length |
-| **QPACK blocked**         | `qpack:stream_state_updated`        | `state` (blocked/unblocked), stream id |
+| SETTINGS                  | `http3:parameters_set`              | max field section size, QPACK table cap, blocked streams |
+| control stream            | `http3:stream_type_set`             | stream id, stream type |
+| HEADERS / DATA / GOAWAY   | `http3:frame_created` / `http3:frame_parsed` | frame type, stream id, raw length |
+| **QPACK blocked**         | `tardigrade:qpack_stream_state_updated` | `state` (blocked/unblocked), stream id |
 
-`transport:packet_dropped` with `trigger:"payload_decrypt_error"` is the
+`quic:packet_dropped` with `trigger:"decryption_failure"` is the
 canonical qlog encoding of an AEAD deprotection failure, satisfying the #255
 requirement that deprotection failures are reported deterministically. It is
 distinct from a normal drop (`unknown_connection_id`, `key_unavailable`, …).
@@ -124,7 +145,7 @@ distinct from a normal drop (`unknown_connection_id`, `key_unavailable`, …).
 Each record is one JSON-SEQ line:
 
 ```
-0x1E {"time":<ms>.<us>,"name":"transport:packet_sent","data":{ … }}\n
+0x1E {"time":<ms>.<us>,"name":"quic:packet_sent","data":{ ... }}\n
 ```
 
 - Time is milliseconds (qlog's default `time_units`) with microsecond
@@ -132,14 +153,18 @@ Each record is one JSON-SEQ line:
 - Writers are **allocation-free**: they format into a caller-owned buffer
   (`writeJson(record, buf)`), matching the bounded-buffer style already used by
   the TLS handshake wire writer. A 512-byte buffer covers every event.
-- A qlog file is a trace header followed by these event lines.
-  `qlog.writeTraceHeader(header, buf)` serializes that header (qlog version,
-  vantage point, `reference_time`, and ODCID `group_id`) as the first JSON-SEQ
+- A qlog file is a `QlogFileSeq` header followed by event lines.
+  `qlog.writeTraceHeader(header, buf)` serializes the
+  `file_schema: urn:ietf:params:qlog:file:sequential`,
+  `serialization_format: application/qlog+json-seq`, `trace`,
+  `event_schemas`, vantage point, and ODCID `group_id` as the first JSON-SEQ
   record. The header spans both packages — the `group_id` ties transport and
   H3 events to one connection — so the **composition root** fills it in and
   writes it once, then appends event records from both `quic` and `http3`. The
   `tests/quic_h3_smoke.zig` harness exercises exactly this shape (header +
   transport record + H3 record) so the merged-file contract is locked.
+- JSON-SEQ qlog artifacts use the `.sqlog` suffix. Reserve `.qlog` for the
+  normal contained JSON qlog form.
 
 ### Sink error handling
 
@@ -186,7 +211,7 @@ capture can decrypt the entire connection.
   authorized to decrypt.
 - The adapter otherwise wipes these secrets (`SecretStore.wipe`); the key log is
   the only path by which they leave the process.
-- Artifacts the harness saves (`*.qlog`, `*.keys`) inherit this: store them with
+- Artifacts the harness saves (`*.sqlog`, `*.keys`) inherit this: store them with
   the capture, scrub them from CI logs, and never attach them to public issues.
 
 ## Configuration
@@ -232,9 +257,9 @@ counters they read from already exist.
   for representative transport events, QPACK blocking, and keylog line format,
   in `src/quic/qlog.zig`, `src/http3/qlog.zig`, `src/quic/keylog.zig`.
 - **Integration** (follow-up, with the connection layer): drive a handshake and
-  assert a produced `.qlog` contains the expected event classes; snapshot
+  assert a produced `.sqlog` contains the expected event classes; snapshot
   metrics on common error paths.
-- **Manual**: load a saved `.qlog` in qvis and a capture + `.keys` in Wireshark
+- **Manual**: load a saved `.sqlog` in qvis and a capture + `.keys` in Wireshark
   once enough transport exists to produce real flows.
 
 ## References

--- a/docs/QUIC_QLOG.md
+++ b/docs/QUIC_QLOG.md
@@ -124,7 +124,7 @@ Names below are `namespace:event`. Transport events (`src/quic/qlog.zig`):
 | PATH_CHALLENGE/RESPONSE   | `tardigrade:quic_path_validation`   | `phase` (challenge/response sent/received, validated, failed) |
 | migration                 | `quic:migration_state_updated`      | required `new` migration state, optional `old` |
 | stream reset              | `tardigrade:quic_stream_reset`      | `direction` (reset/stop-sending, sent/received), stream id, error code |
-| flow-control blocked      | `quic:connection_data_blocked_updated` / `quic:stream_data_blocked_updated` | required `new` blocked state, optional `old` / `reason`; stream variant requires `stream_id` |
+| flow-control blocked      | `quic:connection_data_blocked_updated` / `quic:stream_data_blocked_updated` | required `new` blocked state, optional `old` / draft `$BlockedReason`; stream variant requires `stream_id` |
 
 Application events (`src/http3/qlog.zig`):
 
@@ -132,7 +132,7 @@ Application events (`src/http3/qlog.zig`):
 |---------------------------|-------------------------------------|----------|
 | SETTINGS                  | `http3:parameters_set`              | max field section size, QPACK table cap, blocked streams |
 | control stream            | `http3:stream_type_set`             | stream id, stream type |
-| HEADERS / DATA / GOAWAY   | `http3:frame_created` / `http3:frame_parsed` | variant-specific frame payloads; HEADERS carries `headers`, SETTINGS carries `settings`, GOAWAY carries `id` |
+| HEADERS / DATA / GOAWAY   | `http3:frame_created` / `http3:frame_parsed` | variant-specific frame payloads; HEADERS carries escaped `headers`, SETTINGS carries typed lower-case qlog `settings`, GOAWAY carries `id` |
 | **QPACK blocked**         | `tardigrade:qpack_stream_state_updated` | `state` (blocked/unblocked), stream id |
 
 `quic:packet_dropped` with `trigger:"decryption_failure"` is the
@@ -167,6 +167,9 @@ Each record is one JSON-SEQ line:
   representative QUIC/H3 records) so the merged-file contract is locked.
 - JSON-SEQ qlog artifacts use the `.sqlog` suffix. Reserve `.qlog` for the
   normal contained JSON qlog form.
+- Dynamic qlog text fields, including trace `title`/`description` and HTTP
+  field names/values, are JSON-string escaped by the serializers before
+  writing into the caller-owned buffer.
 
 ### Sink error handling
 

--- a/src/http3/qlog.zig
+++ b/src/http3/qlog.zig
@@ -54,6 +54,59 @@ pub const StreamType = enum {
 /// encoder stream, and `unblocked` once the required insert count arrives.
 pub const QpackState = enum { blocked, unblocked };
 
+pub const HttpField = struct {
+    name: []const u8,
+    value: []const u8,
+};
+
+pub const Setting = struct {
+    name: []const u8,
+    value: u64,
+};
+
+pub const Frame = union(enum) {
+    data: struct {
+        raw_length: ?usize = null,
+    },
+    headers: struct {
+        headers: []const HttpField = &.{},
+        raw_length: ?usize = null,
+    },
+    settings: struct {
+        settings: []const Setting = &.{},
+        raw_length: ?usize = null,
+    },
+    goaway: struct {
+        id: u64,
+        raw_length: ?usize = null,
+    },
+    push_promise: struct {
+        push_id: u64,
+        headers: []const HttpField = &.{},
+        raw_length: ?usize = null,
+    },
+    cancel_push: struct {
+        push_id: u64,
+        raw_length: ?usize = null,
+    },
+    max_push_id: struct {
+        push_id: u64,
+        raw_length: ?usize = null,
+    },
+
+    pub fn frameType(self: Frame) FrameType {
+        return switch (self) {
+            .data => .data,
+            .headers => .headers,
+            .settings => .settings,
+            .goaway => .goaway,
+            .push_promise => .push_promise,
+            .cancel_push => .cancel_push,
+            .max_push_id => .max_push_id,
+        };
+    }
+};
+
 pub const Event = union(enum) {
     /// http3:parameters_set (SETTINGS applied)
     parameters_set: struct {
@@ -70,9 +123,8 @@ pub const Event = union(enum) {
     /// http3:frame_created / http3:frame_parsed
     frame: struct {
         direction: Direction,
-        frame_type: FrameType,
         stream_id: u64,
-        length: usize = 0,
+        frame: Frame,
     },
     /// tardigrade:qpack_stream_state_updated (head-of-line blocking)
     qpack_state_updated: struct {
@@ -143,6 +195,68 @@ const Buf = struct {
     }
 };
 
+fn writeRawLength(b: *Buf, length: ?usize, need_comma: *bool) error{NoSpaceLeft}!void {
+    if (length) |v| {
+        if (need_comma.*) try b.add(",", .{});
+        try b.add("\"raw\":{{\"length\":{d}}}", .{v});
+        need_comma.* = true;
+    }
+}
+
+fn writeHeaders(b: *Buf, headers: []const HttpField) error{NoSpaceLeft}!void {
+    try b.add("\"headers\":[", .{});
+    for (headers, 0..) |field, i| {
+        if (i != 0) try b.add(",", .{});
+        try b.add("{{\"name\":\"{s}\",\"value\":\"{s}\"}}", .{ field.name, field.value });
+    }
+    try b.add("]", .{});
+}
+
+fn writeSettings(b: *Buf, settings: []const Setting) error{NoSpaceLeft}!void {
+    try b.add("\"settings\":[", .{});
+    for (settings, 0..) |setting, i| {
+        if (i != 0) try b.add(",", .{});
+        try b.add("{{\"name\":\"{s}\",\"value\":{d}}}", .{ setting.name, setting.value });
+    }
+    try b.add("]", .{});
+}
+
+fn writeFrame(b: *Buf, frame: Frame) error{NoSpaceLeft}!void {
+    try b.add("{{\"frame_type\":\"{s}\"", .{frame.frameType().label()});
+    var need_comma = true;
+    switch (frame) {
+        .data => |d| try writeRawLength(b, d.raw_length, &need_comma),
+        .headers => |d| {
+            try b.add(",", .{});
+            try writeHeaders(b, d.headers);
+            try writeRawLength(b, d.raw_length, &need_comma);
+        },
+        .settings => |d| {
+            try b.add(",", .{});
+            try writeSettings(b, d.settings);
+            try writeRawLength(b, d.raw_length, &need_comma);
+        },
+        .goaway => |d| {
+            try b.add(",\"id\":{d}", .{d.id});
+            try writeRawLength(b, d.raw_length, &need_comma);
+        },
+        .push_promise => |d| {
+            try b.add(",\"push_id\":{d},", .{d.push_id});
+            try writeHeaders(b, d.headers);
+            try writeRawLength(b, d.raw_length, &need_comma);
+        },
+        .cancel_push => |d| {
+            try b.add(",\"push_id\":{d}", .{d.push_id});
+            try writeRawLength(b, d.raw_length, &need_comma);
+        },
+        .max_push_id => |d| {
+            try b.add(",\"push_id\":{d}", .{d.push_id});
+            try writeRawLength(b, d.raw_length, &need_comma);
+        },
+    }
+    try b.add("}}", .{});
+}
+
 fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
     switch (event) {
         .parameters_set => |d| {
@@ -172,10 +286,11 @@ fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
             "{{\"stream_id\":{d},\"stream_type\":\"{s}\"}}",
             .{ d.stream_id, @tagName(d.stream_type) },
         ),
-        .frame => |d| try b.add(
-            "{{\"stream_id\":{d},\"frame\":{{\"frame_type\":\"{s}\",\"raw\":{{\"length\":{d}}}}}}}",
-            .{ d.stream_id, d.frame_type.label(), d.length },
-        ),
+        .frame => |d| {
+            try b.add("{{\"stream_id\":{d},\"frame\":", .{d.stream_id});
+            try writeFrame(b, d.frame);
+            try b.add("}}", .{});
+        },
         .qpack_state_updated => |d| try b.add(
             "{{\"stream_id\":{d},\"state\":\"{s}\"}}",
             .{ d.stream_id, @tagName(d.state) },
@@ -220,11 +335,11 @@ test "qpack blocking is a Tardigrade extension event" {
 
 test "frame direction chooses frame_created vs frame_parsed" {
     try expectJson(
-        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .frame_type = .headers, .stream_id = 0, .length = 20 } } },
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .headers = .{ .headers = &.{.{ .name = ":status", .value = "200" }}, .raw_length = 20 } } } } },
         "\"name\":\"http3:frame_created\"",
     );
     try expectJson(
-        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .parsed, .frame_type = .goaway, .stream_id = 3 } } },
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .parsed, .stream_id = 3, .frame = .{ .goaway = .{ .id = 0 } } } } },
         "\"name\":\"http3:frame_parsed\"",
     );
 }
@@ -242,16 +357,20 @@ test "stream_type_set and representative frames use http3 names" {
         "\"name\":\"http3:stream_type_set\"",
     );
     try expectJson(
-        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .frame_type = .settings, .stream_id = 0 } } },
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = &.{.{ .name = "SETTINGS_QPACK_BLOCKED_STREAMS", .value = 16 }} } } } } },
         "\"frame_type\":\"settings\"",
     );
     try expectJson(
-        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .parsed, .frame_type = .headers, .stream_id = 4, .length = 32 } } },
-        "\"frame_type\":\"headers\"",
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = &.{.{ .name = "SETTINGS_QPACK_BLOCKED_STREAMS", .value = 16 }} } } } } },
+        "\"settings\":[{\"name\":\"SETTINGS_QPACK_BLOCKED_STREAMS\",\"value\":16}]",
     );
     try expectJson(
-        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .frame_type = .goaway, .stream_id = 0 } } },
-        "\"frame_type\":\"goaway\"",
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .parsed, .stream_id = 4, .frame = .{ .headers = .{ .headers = &.{.{ .name = ":path", .value = "/" }}, .raw_length = 32 } } } } },
+        "\"headers\":[{\"name\":\":path\",\"value\":\"/\"}]",
+    );
+    try expectJson(
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .goaway = .{ .id = 4 } } } } },
+        "\"id\":4",
     );
 }
 

--- a/src/http3/qlog.zig
+++ b/src/http3/qlog.zig
@@ -1,27 +1,25 @@
 //! HTTP/3- and QPACK-vantage qlog events (#255).
 //!
 //! The symmetric half of `src/quic/qlog.zig`. It exists here, in `src/http3`,
-//! because these events (`http:*`, `qpack:*`) describe the *application*
+//! because these events (`http3:*`) describe the *application*
 //! mapping — SETTINGS, control-stream framing, HEADERS/DATA, GOAWAY, and QPACK
-//! head-of-line blocking — and must not leak into the transport package. Just
+//! diagnostics — and must not leak into the transport package. Just
 //! like the transport side it emits through an injected `Sink`; the concrete
 //! qlog file writer lives at the composition root and interleaves this stream
 //! with the transport stream into one trace.
 //!
 //! Scope note: only the events needed before external interop are modelled
-//! here. `qpack_state_updated` (blocked/unblocked) is the load-bearing one for
-//! #255 — QPACK head-of-line blocking is otherwise invisible in application
-//! logs — with the frame/settings events included so a trace can attribute a
-//! stall to the right H3 exchange.
+//! here. The current HTTP/3 qlog draft no longer standardizes QPACK events, so
+//! `qpack_state_updated` is emitted as a documented `tardigrade:*` extension.
 
 const std = @import("std");
 
-/// qlog application-vantage categories owned by HTTP/3.
-pub const Category = enum {
-    http,
-    qpack,
+/// qlog application-vantage namespaces owned by HTTP/3.
+pub const Namespace = enum {
+    http3,
+    tardigrade,
 
-    pub fn label(self: Category) []const u8 {
+    pub fn label(self: Namespace) []const u8 {
         return @tagName(self);
     }
 };
@@ -42,6 +40,14 @@ pub const FrameType = enum {
 };
 
 pub const Direction = enum { created, parsed };
+pub const Initiator = enum { local, remote };
+pub const StreamType = enum {
+    control,
+    qpack_encode,
+    qpack_decode,
+    request,
+    push,
+};
 
 /// QPACK stream state (RFC 9204 §2.1.2): a request stream becomes `blocked`
 /// when it references a dynamic-table entry not yet acknowledged by the
@@ -49,40 +55,47 @@ pub const Direction = enum { created, parsed };
 pub const QpackState = enum { blocked, unblocked };
 
 pub const Event = union(enum) {
-    /// http:parameters_set (SETTINGS applied)
+    /// http3:parameters_set (SETTINGS applied)
     parameters_set: struct {
+        initiator: ?Initiator = null,
         max_field_section_size: ?u64 = null,
-        qpack_max_table_capacity: ?u64 = null,
-        qpack_blocked_streams: ?u64 = null,
+        max_table_capacity: ?u64 = null,
+        blocked_streams_count: ?u64 = null,
     },
-    /// http:frame_created / http:frame_parsed
+    /// http3:stream_type_set
+    stream_type_set: struct {
+        stream_id: u64,
+        stream_type: StreamType,
+    },
+    /// http3:frame_created / http3:frame_parsed
     frame: struct {
         direction: Direction,
         frame_type: FrameType,
         stream_id: u64,
         length: usize = 0,
     },
-    /// qpack:stream_state_updated (head-of-line blocking)
+    /// tardigrade:qpack_stream_state_updated (head-of-line blocking)
     qpack_state_updated: struct {
         state: QpackState,
         stream_id: u64,
     },
 
-    pub fn category(self: Event) Category {
+    pub fn namespace(self: Event) Namespace {
         return switch (self) {
-            .parameters_set, .frame => .http,
-            .qpack_state_updated => .qpack,
+            .parameters_set, .stream_type_set, .frame => .http3,
+            .qpack_state_updated => .tardigrade,
         };
     }
 
     pub fn name(self: Event) []const u8 {
         return switch (self) {
             .parameters_set => "parameters_set",
+            .stream_type_set => "stream_type_set",
             .frame => |f| switch (f.direction) {
                 .created => "frame_created",
                 .parsed => "frame_parsed",
             },
-            .qpack_state_updated => "stream_state_updated",
+            .qpack_state_updated => "qpack_stream_state_updated",
         };
     }
 };
@@ -135,23 +148,32 @@ fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
         .parameters_set => |d| {
             try b.add("{{", .{});
             var need_comma = false;
+            if (d.initiator) |v| {
+                try b.add("\"initiator\":\"{s}\"", .{@tagName(v)});
+                need_comma = true;
+            }
             if (d.max_field_section_size) |v| {
+                if (need_comma) try b.add(",", .{});
                 try b.add("\"max_field_section_size\":{d}", .{v});
                 need_comma = true;
             }
-            if (d.qpack_max_table_capacity) |v| {
+            if (d.max_table_capacity) |v| {
                 if (need_comma) try b.add(",", .{});
-                try b.add("\"qpack_max_table_capacity\":{d}", .{v});
+                try b.add("\"max_table_capacity\":{d}", .{v});
                 need_comma = true;
             }
-            if (d.qpack_blocked_streams) |v| {
+            if (d.blocked_streams_count) |v| {
                 if (need_comma) try b.add(",", .{});
-                try b.add("\"qpack_blocked_streams\":{d}", .{v});
+                try b.add("\"blocked_streams_count\":{d}", .{v});
             }
             try b.add("}}", .{});
         },
+        .stream_type_set => |d| try b.add(
+            "{{\"stream_id\":{d},\"stream_type\":\"{s}\"}}",
+            .{ d.stream_id, @tagName(d.stream_type) },
+        ),
         .frame => |d| try b.add(
-            "{{\"stream_id\":{d},\"frame\":{{\"frame_type\":\"{s}\"}},\"length\":{d}}}",
+            "{{\"stream_id\":{d},\"frame\":{{\"frame_type\":\"{s}\",\"raw\":{{\"length\":{d}}}}}}}",
             .{ d.stream_id, d.frame_type.label(), d.length },
         ),
         .qpack_state_updated => |d| try b.add(
@@ -168,7 +190,7 @@ pub fn writeJson(record: Record, out: []u8) error{NoSpaceLeft}![]const u8 {
     try b.add("{c}", .{record_separator});
     try b.add(
         "{{\"time\":{d}.{d:0>3},\"name\":\"{s}:{s}\",\"data\":",
-        .{ record.time_us / 1000, record.time_us % 1000, record.event.category().label(), record.event.name() },
+        .{ record.time_us / 1000, record.time_us % 1000, record.event.namespace().label(), record.event.name() },
     );
     try writeData(&b, record.event);
     try b.add("}}\n", .{});
@@ -189,28 +211,47 @@ fn expectJson(record: Record, needle: []const u8) !void {
     try testing.expect(std.mem.indexOf(u8, line, needle) != null);
 }
 
-test "qpack blocking is a qpack:stream_state_updated event" {
+test "qpack blocking is a Tardigrade extension event" {
     const ev = Event{ .qpack_state_updated = .{ .state = .blocked, .stream_id = 12 } };
-    try testing.expectEqual(Category.qpack, ev.category());
-    try expectJson(.{ .time_us = 42, .event = ev }, "\"name\":\"qpack:stream_state_updated\"");
+    try testing.expectEqual(Namespace.tardigrade, ev.namespace());
+    try expectJson(.{ .time_us = 42, .event = ev }, "\"name\":\"tardigrade:qpack_stream_state_updated\"");
     try expectJson(.{ .time_us = 42, .event = ev }, "\"state\":\"blocked\"");
 }
 
 test "frame direction chooses frame_created vs frame_parsed" {
     try expectJson(
         .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .frame_type = .headers, .stream_id = 0, .length = 20 } } },
-        "\"name\":\"http:frame_created\"",
+        "\"name\":\"http3:frame_created\"",
     );
     try expectJson(
         .{ .time_us = 0, .event = .{ .frame = .{ .direction = .parsed, .frame_type = .goaway, .stream_id = 3 } } },
-        "\"name\":\"http:frame_parsed\"",
+        "\"name\":\"http3:frame_parsed\"",
     );
 }
 
 test "parameters_set only emits present settings" {
     try expectJson(
-        .{ .time_us = 0, .event = .{ .parameters_set = .{ .qpack_blocked_streams = 16 } } },
-        "{\"qpack_blocked_streams\":16}",
+        .{ .time_us = 0, .event = .{ .parameters_set = .{ .blocked_streams_count = 16 } } },
+        "{\"blocked_streams_count\":16}",
+    );
+}
+
+test "stream_type_set and representative frames use http3 names" {
+    try expectJson(
+        .{ .time_us = 0, .event = .{ .stream_type_set = .{ .stream_id = 2, .stream_type = .control } } },
+        "\"name\":\"http3:stream_type_set\"",
+    );
+    try expectJson(
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .frame_type = .settings, .stream_id = 0 } } },
+        "\"frame_type\":\"settings\"",
+    );
+    try expectJson(
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .parsed, .frame_type = .headers, .stream_id = 4, .length = 32 } } },
+        "\"frame_type\":\"headers\"",
+    );
+    try expectJson(
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .frame_type = .goaway, .stream_id = 0 } } },
+        "\"frame_type\":\"goaway\"",
     );
 }
 

--- a/src/http3/qlog.zig
+++ b/src/http3/qlog.zig
@@ -251,7 +251,11 @@ fn writeSettings(b: *Buf, settings: []const Setting) WriteError!void {
     try b.add("\"settings\":[", .{});
     for (settings, 0..) |setting, i| {
         if (i != 0) try b.add(",", .{});
-        if (setting.name == .unknown and setting.name_bytes == null) return error.InvalidSettingName;
+        if (setting.name == .unknown) {
+            if (setting.name_bytes == null) return error.InvalidSettingName;
+        } else if (setting.name_bytes != null) {
+            return error.InvalidSettingName;
+        }
         try b.add("{{\"name\":\"{s}\"", .{@tagName(setting.name)});
         if (setting.name_bytes) |name_bytes| try b.add(",\"name_bytes\":{d}", .{name_bytes});
         try b.add(",\"value\":{d}}}", .{setting.value});
@@ -336,8 +340,10 @@ fn writeData(b: *Buf, event: Event) WriteError!void {
     }
 }
 
-/// Serialize one `Record` into `out` as a single qlog JSON-SEQ line. Same shape
-/// as `quic.qlog.writeJson` so a merged trace is uniform.
+/// Serialize one `Record` into `out` as a single qlog JSON-SEQ line. H3
+/// HEADERS, SETTINGS, and PUSH_PROMISE records can grow with the supplied
+/// slices; callers must size `out` for their configured field-section budget or
+/// retain `NoSpaceLeft` as a dropped-record diagnostic.
 pub fn writeJson(record: Record, out: []u8) WriteError![]const u8 {
     var b = Buf{ .buf = out };
     try b.add("{c}", .{record_separator});
@@ -438,10 +444,46 @@ test "unknown setting requires name_bytes" {
         .time_us = 0,
         .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = &.{.{ .name = .unknown, .value = 1 }} } } } },
     }, &buf));
+    try testing.expectError(error.InvalidSettingName, writeJson(.{
+        .time_us = 0,
+        .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = &.{.{ .name = .settings_qpack_blocked_streams, .name_bytes = 0x21, .value = 1 }} } } } },
+    }, &buf));
     try expectJson(
         .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = &.{.{ .name = .unknown, .name_bytes = 0x21, .value = 1 }} } } } } },
         "\"settings\":[{\"name\":\"unknown\",\"name_bytes\":33,\"value\":1}]",
     );
+}
+
+test "large header sections require a caller-sized buffer" {
+    const headers = [_]HttpField{
+        .{ .name = "x-debug-0", .value = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+        .{ .name = "x-debug-1", .value = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" },
+        .{ .name = "x-debug-2", .value = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" },
+        .{ .name = "x-debug-3", .value = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd" },
+        .{ .name = "x-debug-4", .value = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" },
+        .{ .name = "x-debug-5", .value = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" },
+    };
+    const record = Record{
+        .time_us = 0,
+        .event = .{ .frame = .{
+            .direction = .parsed,
+            .stream_id = 4,
+            .frame = .{ .headers = .{ .headers = &headers, .raw_length = 512 } },
+        } },
+    };
+
+    var too_small: [512]u8 = undefined;
+    try testing.expectError(error.NoSpaceLeft, writeJson(record, &too_small));
+
+    var enough: [2048]u8 = undefined;
+    const line = try writeJson(record, &enough);
+    try testing.expect(line.len > 512);
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, line[1 .. line.len - 1], .{});
+    defer parsed.deinit();
+    const root = parsed.value.object;
+    const data = root.get("data").?.object;
+    const frame = data.get("frame").?.object;
+    try testing.expectEqual(@as(usize, headers.len), frame.get("headers").?.array.items.len);
 }
 
 test "default sink is a no-op" {

--- a/src/http3/qlog.zig
+++ b/src/http3/qlog.zig
@@ -59,8 +59,19 @@ pub const HttpField = struct {
     value: []const u8,
 };
 
+pub const SettingName = enum {
+    settings_qpack_max_table_capacity,
+    settings_max_field_section_size,
+    settings_qpack_blocked_streams,
+    settings_enable_connect_protocol,
+    settings_h3_datagram,
+    reserved,
+    unknown,
+};
+
 pub const Setting = struct {
-    name: []const u8,
+    name: SettingName,
+    name_bytes: ?u64 = null,
     value: u64,
 };
 
@@ -195,6 +206,26 @@ const Buf = struct {
     }
 };
 
+const WriteError = error{ NoSpaceLeft, InvalidSettingName };
+
+fn writeJsonString(b: *Buf, value: []const u8) error{NoSpaceLeft}!void {
+    try b.add("\"", .{});
+    for (value) |c| {
+        switch (c) {
+            '"' => try b.add("\\\"", .{}),
+            '\\' => try b.add("\\\\", .{}),
+            0x08 => try b.add("\\b", .{}),
+            0x0c => try b.add("\\f", .{}),
+            '\n' => try b.add("\\n", .{}),
+            '\r' => try b.add("\\r", .{}),
+            '\t' => try b.add("\\t", .{}),
+            0x00...0x07, 0x0b, 0x0e...0x1f => try b.add("\\u00{x:0>2}", .{c}),
+            else => try b.add("{c}", .{c}),
+        }
+    }
+    try b.add("\"", .{});
+}
+
 fn writeRawLength(b: *Buf, length: ?usize, need_comma: *bool) error{NoSpaceLeft}!void {
     if (length) |v| {
         if (need_comma.*) try b.add(",", .{});
@@ -207,21 +238,28 @@ fn writeHeaders(b: *Buf, headers: []const HttpField) error{NoSpaceLeft}!void {
     try b.add("\"headers\":[", .{});
     for (headers, 0..) |field, i| {
         if (i != 0) try b.add(",", .{});
-        try b.add("{{\"name\":\"{s}\",\"value\":\"{s}\"}}", .{ field.name, field.value });
+        try b.add("{{\"name\":", .{});
+        try writeJsonString(b, field.name);
+        try b.add(",\"value\":", .{});
+        try writeJsonString(b, field.value);
+        try b.add("}}", .{});
     }
     try b.add("]", .{});
 }
 
-fn writeSettings(b: *Buf, settings: []const Setting) error{NoSpaceLeft}!void {
+fn writeSettings(b: *Buf, settings: []const Setting) WriteError!void {
     try b.add("\"settings\":[", .{});
     for (settings, 0..) |setting, i| {
         if (i != 0) try b.add(",", .{});
-        try b.add("{{\"name\":\"{s}\",\"value\":{d}}}", .{ setting.name, setting.value });
+        if (setting.name == .unknown and setting.name_bytes == null) return error.InvalidSettingName;
+        try b.add("{{\"name\":\"{s}\"", .{@tagName(setting.name)});
+        if (setting.name_bytes) |name_bytes| try b.add(",\"name_bytes\":{d}", .{name_bytes});
+        try b.add(",\"value\":{d}}}", .{setting.value});
     }
     try b.add("]", .{});
 }
 
-fn writeFrame(b: *Buf, frame: Frame) error{NoSpaceLeft}!void {
+fn writeFrame(b: *Buf, frame: Frame) WriteError!void {
     try b.add("{{\"frame_type\":\"{s}\"", .{frame.frameType().label()});
     var need_comma = true;
     switch (frame) {
@@ -257,7 +295,7 @@ fn writeFrame(b: *Buf, frame: Frame) error{NoSpaceLeft}!void {
     try b.add("}}", .{});
 }
 
-fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
+fn writeData(b: *Buf, event: Event) WriteError!void {
     switch (event) {
         .parameters_set => |d| {
             try b.add("{{", .{});
@@ -300,7 +338,7 @@ fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
 
 /// Serialize one `Record` into `out` as a single qlog JSON-SEQ line. Same shape
 /// as `quic.qlog.writeJson` so a merged trace is uniform.
-pub fn writeJson(record: Record, out: []u8) error{NoSpaceLeft}![]const u8 {
+pub fn writeJson(record: Record, out: []u8) WriteError![]const u8 {
     var b = Buf{ .buf = out };
     try b.add("{c}", .{record_separator});
     try b.add(
@@ -357,12 +395,12 @@ test "stream_type_set and representative frames use http3 names" {
         "\"name\":\"http3:stream_type_set\"",
     );
     try expectJson(
-        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = &.{.{ .name = "SETTINGS_QPACK_BLOCKED_STREAMS", .value = 16 }} } } } } },
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = &.{.{ .name = .settings_qpack_blocked_streams, .value = 16 }} } } } } },
         "\"frame_type\":\"settings\"",
     );
     try expectJson(
-        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = &.{.{ .name = "SETTINGS_QPACK_BLOCKED_STREAMS", .value = 16 }} } } } } },
-        "\"settings\":[{\"name\":\"SETTINGS_QPACK_BLOCKED_STREAMS\",\"value\":16}]",
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = &.{.{ .name = .settings_qpack_blocked_streams, .value = 16 }} } } } } },
+        "\"settings\":[{\"name\":\"settings_qpack_blocked_streams\",\"value\":16}]",
     );
     try expectJson(
         .{ .time_us = 0, .event = .{ .frame = .{ .direction = .parsed, .stream_id = 4, .frame = .{ .headers = .{ .headers = &.{.{ .name = ":path", .value = "/" }}, .raw_length = 32 } } } } },
@@ -371,6 +409,38 @@ test "stream_type_set and representative frames use http3 names" {
     try expectJson(
         .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .goaway = .{ .id = 4 } } } } },
         "\"id\":4",
+    );
+}
+
+test "headers escape JSON string content" {
+    var buf: [512]u8 = undefined;
+    const line = try writeJson(.{
+        .time_us = 0,
+        .event = .{ .frame = .{
+            .direction = .parsed,
+            .stream_id = 4,
+            .frame = .{ .headers = .{ .headers = &.{.{ .name = "x-debug", .value = "quoted \"value\" \\ path\nnext" }} } },
+        } },
+    }, &buf);
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, line[1 .. line.len - 1], .{});
+    defer parsed.deinit();
+    const root = parsed.value.object;
+    const data = root.get("data").?.object;
+    const frame = data.get("frame").?.object;
+    const headers = frame.get("headers").?.array;
+    const first = headers.items[0].object;
+    try testing.expectEqualStrings("quoted \"value\" \\ path\nnext", first.get("value").?.string);
+}
+
+test "unknown setting requires name_bytes" {
+    var buf: [512]u8 = undefined;
+    try testing.expectError(error.InvalidSettingName, writeJson(.{
+        .time_us = 0,
+        .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = &.{.{ .name = .unknown, .value = 1 }} } } } },
+    }, &buf));
+    try expectJson(
+        .{ .time_us = 0, .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = &.{.{ .name = .unknown, .name_bytes = 0x21, .value = 1 }} } } } } },
+        "\"settings\":[{\"name\":\"unknown\",\"name_bytes\":33,\"value\":1}]",
     );
 }
 

--- a/src/quic/qlog.zig
+++ b/src/quic/qlog.zig
@@ -96,6 +96,12 @@ pub const CloseReason = enum {
     handshake_failure,
 };
 
+pub const CloseError = union(enum) {
+    none,
+    connection_unknown: u64,
+    application_unknown: u64,
+};
+
 /// PATH_CHALLENGE / PATH_RESPONSE lifecycle phases (RFC 9000 §8.2).
 pub const PathEventKind = enum {
     challenge_sent,
@@ -207,7 +213,7 @@ pub const Event = union(enum) {
     /// quic:connection_closed
     connection_closed: struct {
         reason: CloseReason,
-        error_code: ?u64 = null,
+        close_error: CloseError = .none,
     },
     /// tardigrade:quic_handshake_progressed (progress milestone; not a
     /// standard qlog event, kept under a Tardigrade namespace for stage
@@ -390,7 +396,11 @@ fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
         ),
         .connection_closed => |d| {
             try b.add("{{\"reason\":\"{s}\"", .{@tagName(d.reason)});
-            if (d.error_code) |code| try b.add(",\"error_code\":{d}", .{code});
+            switch (d.close_error) {
+                .none => {},
+                .connection_unknown => |code| try b.add(",\"connection_error\":\"unknown\",\"error_code\":{d}", .{code}),
+                .application_unknown => |code| try b.add(",\"application_error\":\"unknown\",\"error_code\":{d}", .{code}),
+            }
             try b.add("}}", .{});
         },
         .handshake_progressed => |d| try b.add(
@@ -587,6 +597,17 @@ test "0-RTT key type serializes as a standard key_updated value" {
     try expectJson(
         .{ .time_us = 0, .event = .{ .key_updated = .{ .key_type = .server_0rtt_secret } } },
         "\"key_type\":\"server_0rtt_secret\"",
+    );
+}
+
+test "connection_closed ties error_code to an unknown error category" {
+    try expectJson(
+        .{ .time_us = 0, .event = .{ .connection_closed = .{ .reason = .transport_error, .close_error = .{ .connection_unknown = 0x123 } } } },
+        "\"connection_error\":\"unknown\",\"error_code\":291",
+    );
+    try expectJson(
+        .{ .time_us = 0, .event = .{ .connection_closed = .{ .reason = .application_close, .close_error = .{ .application_unknown = 0x456 } } } },
+        "\"application_error\":\"unknown\",\"error_code\":1110",
     );
 }
 

--- a/src/quic/qlog.zig
+++ b/src/quic/qlog.zig
@@ -16,8 +16,8 @@
 //!
 //! ## Layering (the #255 "don't leak H3 into src/quic" decision)
 //!
-//! `src/quic` owns *only* transport-vantage events (qlog categories
-//! `connectivity`, `security`, `transport`, `recovery`). HTTP/3- and
+//! `src/quic` owns *only* transport-vantage events (the `quic:*` namespace
+//! plus documented `tardigrade:*` debug extensions). HTTP/3- and
 //! QPACK-vantage events live in `src/http3/qlog.zig` and are emitted from
 //! `src/http3`. Neither package imports the other — the same boundary the
 //! build graph already enforces (see build.zig: the smoke harness stitches the
@@ -39,15 +39,20 @@
 
 const std = @import("std");
 
-/// qlog top-level event categories this transport emits. Application (`http`,
-/// `qpack`) categories are intentionally absent: they belong to `src/http3`.
-pub const Category = enum {
-    connectivity,
-    security,
-    transport,
-    recovery,
+pub const quic_event_schema_uri = "urn:ietf:params:qlog:events:quic-13";
+pub const http3_event_schema_uri = "urn:ietf:params:qlog:events:http3-13";
+pub const tardigrade_event_schema_uri = "https://bare.systems/tardigrade/qlog/events/debug-1";
+pub const file_schema_uri = "urn:ietf:params:qlog:file:sequential";
+pub const serialization_format = "application/qlog+json-seq";
+pub const sqlog_suffix = ".sqlog";
 
-    pub fn label(self: Category) []const u8 {
+/// qlog event namespace this transport emits. Application (`http3`) events are
+/// intentionally absent: they belong to `src/http3`.
+pub const Namespace = enum {
+    quic,
+    tardigrade,
+
+    pub fn label(self: Namespace) []const u8 {
         return @tagName(self);
     }
 };
@@ -82,7 +87,7 @@ pub const HandshakeStage = enum {
     failed,
 };
 
-/// Why a connection closed (drives `connectivity:connection_closed`).
+/// Why a connection closed (drives `quic:connection_closed`).
 pub const CloseReason = enum {
     idle_timeout,
     application_close,
@@ -116,124 +121,144 @@ pub const StreamResetKind = enum {
 /// DATA_BLOCKED vs. STREAM_DATA_BLOCKED (RFC 9000 §19.12, §19.13).
 pub const BlockedScope = enum { connection, stream };
 
-/// Why an inbound packet was dropped. `payload_decrypt_error` is the qlog
+/// Why an inbound packet was dropped. `decryption_failure` is the qlog
 /// canonical trigger for AEAD deprotection failure — the #255 requirement that
 /// deprotection failures are reported deterministically.
 pub const DropTrigger = enum {
-    payload_decrypt_error,
+    decryption_failure,
     key_unavailable,
-    unknown_connection_id,
-    unexpected_packet,
-    header_parse_error,
+    connection_unknown,
+    invalid,
+    unsupported,
+    duplicate,
+    internal_error,
+    rejected,
+    general,
+};
+
+pub const RecoveryMetrics = struct {
+    latest_rtt_ms: ?u64 = null,
+    smoothed_rtt_ms: ?u64 = null,
+    rtt_variance_ms: ?u64 = null,
+    pto_count: ?u16 = null,
+    congestion_window: ?u64 = null,
+    bytes_in_flight: ?u64 = null,
 };
 
 /// The closed set of transport-vantage events. Data payloads are kept small and
 /// copy-free (scalars/enums only) so emitting is cheap and the union never
 /// borrows connection-owned buffers.
 pub const Event = union(enum) {
-    /// connectivity:connection_started
+    /// quic:connection_started
     connection_started: struct {
         odcid_len: u8 = 0,
         scid_len: u8 = 0,
         dcid_len: u8 = 0,
     },
-    /// connectivity:connection_closed
+    /// quic:connection_closed
     connection_closed: struct {
         reason: CloseReason,
         error_code: ?u64 = null,
     },
-    /// connectivity:handshake (progress milestone; not a base qlog name, kept
-    /// under connectivity as a Tardigrade extension for stage visibility)
+    /// tardigrade:quic_handshake_progressed (progress milestone; not a
+    /// standard qlog event, kept under a Tardigrade namespace for stage
+    /// visibility)
     handshake_progressed: struct {
         stage: HandshakeStage,
     },
-    /// security:key_updated (1-RTT key-phase flip, RFC 9001 §6)
+    /// quic:key_updated (1-RTT key-phase flip, RFC 9001 §6)
     key_updated: struct {
         phase: u1,
     },
-    /// transport:packet_sent
+    /// quic:packet_sent
     packet_sent: struct {
         packet_type: PacketType,
         packet_number: u64,
         length: usize,
         ack_eliciting: bool = false,
     },
-    /// transport:packet_received
+    /// quic:packet_received
     packet_received: struct {
         packet_type: PacketType,
         packet_number: u64,
         length: usize,
     },
-    /// recovery:packet_lost
+    /// quic:packet_lost
     packet_lost: struct {
         packet_type: PacketType,
         packet_number: ?u64 = null,
-        bytes_in_flight: usize = 0,
-        congestion_window: usize = 0,
     },
-    /// transport:packet_dropped (deprotection failure and other drops)
+    /// quic:recovery_metrics_updated
+    recovery_metrics_updated: RecoveryMetrics,
+    /// quic:packet_dropped (deprotection failure and other drops)
     packet_dropped: struct {
         packet_type: ?PacketType = null,
         trigger: DropTrigger,
         length: usize = 0,
     },
-    /// transport:path_validation (PATH_CHALLENGE / PATH_RESPONSE)
+    /// tardigrade:quic_path_validation (PATH_CHALLENGE / PATH_RESPONSE)
     path_validation: struct {
         kind: PathEventKind,
         path_id: u8 = 0,
     },
-    /// connectivity:connection_migrated
+    /// quic:migration_state_updated
     connection_migrated: struct {
         kind: MigrationKind,
         outcome: MigrationOutcome,
     },
-    /// transport:stream_reset (RESET_STREAM / STOP_SENDING)
+    /// tardigrade:quic_stream_reset (RESET_STREAM / STOP_SENDING)
     stream_reset: struct {
         kind: StreamResetKind,
         stream_id: u64,
         error_code: u64 = 0,
     },
-    /// transport:data_blocked (flow-control blocked)
+    /// quic:connection_data_blocked_updated /
+    /// quic:stream_data_blocked_updated (flow-control blocked)
     data_blocked: struct {
         scope: BlockedScope,
         stream_id: ?u64 = null,
         limit: u64 = 0,
     },
 
-    pub fn category(self: Event) Category {
+    pub fn namespace(self: Event) Namespace {
         return switch (self) {
             .connection_started,
             .connection_closed,
-            .handshake_progressed,
             .connection_migrated,
-            => .connectivity,
-            .key_updated => .security,
-            .packet_lost => .recovery,
+            .key_updated,
+            .packet_lost,
+            .recovery_metrics_updated,
             .packet_sent,
             .packet_received,
             .packet_dropped,
+            .data_blocked,
+            => .quic,
             .path_validation,
             .stream_reset,
-            .data_blocked,
-            => .transport,
+            .handshake_progressed,
+            => .tardigrade,
         };
     }
 
-    /// The qlog event name within the category (the part after the `:`).
+    /// The qlog event name within the namespace (the part after the `:`).
     pub fn name(self: Event) []const u8 {
         return switch (self) {
             .connection_started => "connection_started",
             .connection_closed => "connection_closed",
-            .handshake_progressed => "handshake",
+            .handshake_progressed => "quic_handshake_progressed",
             .key_updated => "key_updated",
             .packet_sent => "packet_sent",
             .packet_received => "packet_received",
             .packet_lost => "packet_lost",
+            .recovery_metrics_updated => "recovery_metrics_updated",
             .packet_dropped => "packet_dropped",
-            .path_validation => "path_validation",
-            .connection_migrated => "connection_migrated",
-            .stream_reset => "stream_reset",
-            .data_blocked => "data_blocked",
+            .path_validation => "quic_path_validation",
+            .connection_migrated => "migration_state_updated",
+            .stream_reset => "quic_stream_reset",
+            .data_blocked => |d| switch (d.scope) {
+                .connection => "connection_data_blocked_updated",
+                .stream => "stream_data_blocked_updated",
+            },
         };
     }
 };
@@ -309,33 +334,63 @@ fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
         ),
         .key_updated => |d| try b.add("{{\"key_phase\":{d}}}", .{d.phase}),
         .packet_sent => |d| try b.add(
-            "{{\"packet_type\":\"{s}\",\"packet_number\":{d},\"length\":{d},\"ack_eliciting\":{s}}}",
+            "{{\"header\":{{\"packet_type\":\"{s}\",\"packet_number\":{d}}},\"raw\":{{\"length\":{d}}},\"tardigrade_ack_eliciting\":{s}}}",
             .{ d.packet_type.label(), d.packet_number, d.length, boolText(d.ack_eliciting) },
         ),
         .packet_received => |d| try b.add(
-            "{{\"packet_type\":\"{s}\",\"packet_number\":{d},\"length\":{d}}}",
+            "{{\"header\":{{\"packet_type\":\"{s}\",\"packet_number\":{d}}},\"raw\":{{\"length\":{d}}}}}",
             .{ d.packet_type.label(), d.packet_number, d.length },
         ),
         .packet_lost => |d| {
-            try b.add("{{\"packet_type\":\"{s}\"", .{d.packet_type.label()});
+            try b.add("{{\"header\":{{\"packet_type\":\"{s}\"", .{d.packet_type.label()});
             if (d.packet_number) |pn| try b.add(",\"packet_number\":{d}", .{pn});
-            try b.add(
-                ",\"bytes_in_flight\":{d},\"congestion_window\":{d}}}",
-                .{ d.bytes_in_flight, d.congestion_window },
-            );
+            try b.add("}}}}", .{});
+        },
+        .recovery_metrics_updated => |d| {
+            try b.add("{{", .{});
+            var need_comma = false;
+            if (d.latest_rtt_ms) |v| {
+                try b.add("\"latest_rtt\":{d}", .{v});
+                need_comma = true;
+            }
+            if (d.smoothed_rtt_ms) |v| {
+                if (need_comma) try b.add(",", .{});
+                try b.add("\"smoothed_rtt\":{d}", .{v});
+                need_comma = true;
+            }
+            if (d.rtt_variance_ms) |v| {
+                if (need_comma) try b.add(",", .{});
+                try b.add("\"rtt_variance\":{d}", .{v});
+                need_comma = true;
+            }
+            if (d.pto_count) |v| {
+                if (need_comma) try b.add(",", .{});
+                try b.add("\"pto_count\":{d}", .{v});
+                need_comma = true;
+            }
+            if (d.congestion_window) |v| {
+                if (need_comma) try b.add(",", .{});
+                try b.add("\"congestion_window\":{d}", .{v});
+                need_comma = true;
+            }
+            if (d.bytes_in_flight) |v| {
+                if (need_comma) try b.add(",", .{});
+                try b.add("\"bytes_in_flight\":{d}", .{v});
+            }
+            try b.add("}}", .{});
         },
         .packet_dropped => |d| {
             try b.add("{{\"trigger\":\"{s}\"", .{@tagName(d.trigger)});
-            if (d.packet_type) |pt| try b.add(",\"packet_type\":\"{s}\"", .{pt.label()});
-            try b.add(",\"length\":{d}}}", .{d.length});
+            if (d.packet_type) |pt| try b.add(",\"header\":{{\"packet_type\":\"{s}\"}}", .{pt.label()});
+            try b.add(",\"raw\":{{\"length\":{d}}}}}", .{d.length});
         },
         .path_validation => |d| try b.add(
             "{{\"phase\":\"{s}\",\"path_id\":{d}}}",
             .{ @tagName(d.kind), d.path_id },
         ),
         .connection_migrated => |d| try b.add(
-            "{{\"kind\":\"{s}\",\"outcome\":\"{s}\"}}",
-            .{ @tagName(d.kind), @tagName(d.outcome) },
+            "{{\"state\":\"{s}\",\"trigger\":\"{s}\"}}",
+            .{ @tagName(d.outcome), @tagName(d.kind) },
         ),
         .stream_reset => |d| try b.add(
             "{{\"direction\":\"{s}\",\"stream_id\":{d},\"error_code\":{d}}}",
@@ -359,29 +414,28 @@ pub const VantagePoint = enum { client, server };
 /// (ASCII / hex); they are emitted verbatim without escaping.
 pub const TraceHeader = struct {
     vantage_point: VantagePoint,
-    reference_time_us: u64 = 0,
     group_id: []const u8 = "",
     title: []const u8 = "tardigrade-quic",
-    qlog_version: []const u8 = "0.3",
+    description: []const u8 = "Tardigrade QUIC/HTTP-3 debug trace",
 };
 
 /// Serialize the qlog file header as the first JSON-SEQ record. A composition
 /// root writes this once, then appends `writeJson` event records (from both
-/// `quic` and `http3`) to form a complete `.qlog` file qvis can consume.
+/// `quic` and `http3`) to form a complete `.sqlog` file qvis can consume.
 /// Returns the written slice; a 512-byte buffer is enough.
 pub fn writeTraceHeader(header: TraceHeader, out: []u8) error{NoSpaceLeft}![]const u8 {
     var b = Buf{ .buf = out };
     try b.add("{c}", .{record_separator});
     try b.add(
-        "{{\"qlog_version\":\"{s}\",\"qlog_format\":\"JSON-SEQ\",\"title\":\"{s}\",\"trace\":{{\"vantage_point\":{{\"type\":\"{s}\"}},\"common_fields\":{{\"reference_time\":{d}.{d:0>3},\"group_id\":\"{s}\"}}}}}}\n",
-        .{ header.qlog_version, header.title, @tagName(header.vantage_point), header.reference_time_us / 1000, header.reference_time_us % 1000, header.group_id },
+        "{{\"file_schema\":\"{s}\",\"serialization_format\":\"{s}\",\"title\":\"{s}\",\"description\":\"{s}\",\"trace\":{{\"common_fields\":{{\"group_id\":\"{s}\",\"time_format\":\"relative_to_epoch\",\"reference_time\":{{\"clock_type\":\"system\",\"epoch\":\"1970-01-01T00:00:00.000Z\"}}}},\"vantage_point\":{{\"type\":\"{s}\"}},\"event_schemas\":[\"{s}\",\"{s}\",\"{s}\"]}}}}\n",
+        .{ file_schema_uri, serialization_format, header.title, header.description, header.group_id, @tagName(header.vantage_point), quic_event_schema_uri, http3_event_schema_uri, tardigrade_event_schema_uri },
     );
     return b.slice();
 }
 
 /// Serialize one `Record` into `out` as a single qlog JSON-SEQ line:
 ///
-///     0x1E {"time":<ms>,"name":"<category>:<event>","data":{...}} \n
+///     0x1E {"time":<ms>,"name":"<namespace>:<event>","data":{...}} \n
 ///
 /// Returns the written slice. Errors only if `out` is too small; a 512-byte
 /// buffer is comfortably enough for every event above.
@@ -391,7 +445,7 @@ pub fn writeJson(record: Record, out: []u8) error{NoSpaceLeft}![]const u8 {
     // qlog default time unit is milliseconds; keep microsecond precision.
     try b.add(
         "{{\"time\":{d}.{d:0>3},\"name\":\"{s}:{s}\",\"data\":",
-        .{ record.time_us / 1000, record.time_us % 1000, record.event.category().label(), record.event.name() },
+        .{ record.time_us / 1000, record.time_us % 1000, record.event.namespace().label(), record.event.name() },
     );
     try writeData(&b, record.event);
     try b.add("}}\n", .{});
@@ -412,18 +466,19 @@ fn expectJson(record: Record, needle: []const u8) !void {
     try testing.expect(std.mem.indexOf(u8, line, needle) != null);
 }
 
-test "category and name mapping stays aligned with qlog vantage points" {
-    try testing.expectEqual(Category.transport, (Event{ .packet_sent = .{ .packet_type = .one_rtt, .packet_number = 0, .length = 0 } }).category());
-    try testing.expectEqual(Category.recovery, (Event{ .packet_lost = .{ .packet_type = .one_rtt } }).category());
-    try testing.expectEqual(Category.security, (Event{ .key_updated = .{ .phase = 1 } }).category());
-    try testing.expectEqual(Category.connectivity, (Event{ .connection_migrated = .{ .kind = .active, .outcome = .blocked } }).category());
-    try testing.expectEqualStrings("packet_dropped", (Event{ .packet_dropped = .{ .trigger = .payload_decrypt_error } }).name());
+test "namespace and name mapping stays aligned with qlog vantage points" {
+    try testing.expectEqual(Namespace.quic, (Event{ .packet_sent = .{ .packet_type = .one_rtt, .packet_number = 0, .length = 0 } }).namespace());
+    try testing.expectEqual(Namespace.quic, (Event{ .packet_lost = .{ .packet_type = .one_rtt } }).namespace());
+    try testing.expectEqual(Namespace.quic, (Event{ .key_updated = .{ .phase = 1 } }).namespace());
+    try testing.expectEqual(Namespace.quic, (Event{ .connection_migrated = .{ .kind = .active, .outcome = .blocked } }).namespace());
+    try testing.expectEqual(Namespace.tardigrade, (Event{ .stream_reset = .{ .kind = .reset_sent, .stream_id = 0 } }).namespace());
+    try testing.expectEqualStrings("packet_dropped", (Event{ .packet_dropped = .{ .trigger = .decryption_failure } }).name());
 }
 
-test "packet_sent serializes to a transport JSON-SEQ line" {
+test "packet_sent serializes to a quic JSON-SEQ line" {
     try expectJson(
         .{ .time_us = 1_234_567, .event = .{ .packet_sent = .{ .packet_type = .initial, .packet_number = 7, .length = 1200, .ack_eliciting = true } } },
-        "\"name\":\"transport:packet_sent\"",
+        "\"name\":\"quic:packet_sent\"",
     );
     try expectJson(
         .{ .time_us = 1_234_567, .event = .{ .packet_sent = .{ .packet_type = .one_rtt, .packet_number = 7, .length = 1200 } } },
@@ -431,10 +486,10 @@ test "packet_sent serializes to a transport JSON-SEQ line" {
     );
 }
 
-test "deprotection failure is a packet_dropped with payload_decrypt_error" {
+test "deprotection failure is a packet_dropped with decryption_failure" {
     try expectJson(
-        .{ .time_us = 0, .event = .{ .packet_dropped = .{ .packet_type = .one_rtt, .trigger = .payload_decrypt_error, .length = 42 } } },
-        "\"trigger\":\"payload_decrypt_error\"",
+        .{ .time_us = 0, .event = .{ .packet_dropped = .{ .packet_type = .one_rtt, .trigger = .decryption_failure, .length = 42 } } },
+        "\"trigger\":\"decryption_failure\"",
     );
 }
 
@@ -446,21 +501,34 @@ test "time is rendered in milliseconds with microsecond precision" {
 
 test "path, migration, stream reset and flow-control events serialize" {
     try expectJson(.{ .time_us = 5, .event = .{ .path_validation = .{ .kind = .response_received } } }, "\"phase\":\"response_received\"");
-    try expectJson(.{ .time_us = 5, .event = .{ .connection_migrated = .{ .kind = .nat_rebinding, .outcome = .accepted } } }, "connection_migrated");
+    try expectJson(.{ .time_us = 5, .event = .{ .connection_migrated = .{ .kind = .nat_rebinding, .outcome = .accepted } } }, "migration_state_updated");
     try expectJson(.{ .time_us = 5, .event = .{ .stream_reset = .{ .kind = .reset_received, .stream_id = 4, .error_code = 9 } } }, "\"stream_id\":4");
     try expectJson(.{ .time_us = 5, .event = .{ .data_blocked = .{ .scope = .stream, .stream_id = 8, .limit = 4096 } } }, "\"scope\":\"stream\"");
 }
 
+test "recovery metrics serialize as a quic event" {
+    try expectJson(
+        .{ .time_us = 5, .event = .{ .recovery_metrics_updated = .{ .congestion_window = 12_000, .bytes_in_flight = 1_200, .pto_count = 2 } } },
+        "\"name\":\"quic:recovery_metrics_updated\"",
+    );
+    try expectJson(
+        .{ .time_us = 5, .event = .{ .recovery_metrics_updated = .{ .congestion_window = 12_000, .bytes_in_flight = 1_200, .pto_count = 2 } } },
+        "\"bytes_in_flight\":1200",
+    );
+}
+
 test "trace header then event forms a two-record JSON-SEQ stream" {
     var buf: [1024]u8 = undefined;
-    const header = try writeTraceHeader(.{ .vantage_point = .server, .reference_time_us = 1_000, .group_id = "0011deadbeef" }, &buf);
+    const header = try writeTraceHeader(.{ .vantage_point = .server, .group_id = "0011deadbeef" }, &buf);
     const event = try writeJson(.{ .time_us = 2_500, .event = .{ .packet_sent = .{ .packet_type = .initial, .packet_number = 0, .length = 1200 } } }, buf[header.len..]);
     // Exactly two record separators, one per record.
     try testing.expectEqual(@as(usize, 2), std.mem.count(u8, buf[0 .. header.len + event.len], &[_]u8{record_separator}));
-    try testing.expect(std.mem.indexOf(u8, header, "\"qlog_format\":\"JSON-SEQ\"") != null);
+    try testing.expect(std.mem.indexOf(u8, header, "\"file_schema\":\"urn:ietf:params:qlog:file:sequential\"") != null);
+    try testing.expect(std.mem.indexOf(u8, header, "\"serialization_format\":\"application/qlog+json-seq\"") != null);
+    try testing.expect(std.mem.indexOf(u8, header, "\"event_schemas\":[\"urn:ietf:params:qlog:events:quic-13\",\"urn:ietf:params:qlog:events:http3-13\"") != null);
     try testing.expect(std.mem.indexOf(u8, header, "\"vantage_point\":{\"type\":\"server\"}") != null);
     try testing.expect(std.mem.indexOf(u8, header, "\"group_id\":\"0011deadbeef\"") != null);
-    try testing.expect(std.mem.indexOf(u8, event, "transport:packet_sent") != null);
+    try testing.expect(std.mem.indexOf(u8, event, "quic:packet_sent") != null);
 }
 
 test "default sink is a no-op and log() stamps time" {

--- a/src/quic/qlog.zig
+++ b/src/quic/qlog.zig
@@ -113,6 +113,8 @@ pub const KeyType = enum {
     client_initial_secret,
     server_handshake_secret,
     client_handshake_secret,
+    server_0rtt_secret,
+    client_0rtt_secret,
     server_1rtt_secret,
     client_1rtt_secret,
 };
@@ -142,9 +144,14 @@ pub const StreamResetKind = enum {
 
 pub const BlockedState = enum { blocked, unblocked };
 pub const BlockedReason = enum {
-    data_blocked_frame,
-    stream_data_blocked_frame,
-    flow_control_limit,
+    scheduling,
+    pacing,
+    amplification_protection,
+    congestion_control,
+    connection_flow_control,
+    stream_flow_control,
+    stream_id,
+    application,
 };
 
 pub const DataBlocked = union(enum) {
@@ -357,6 +364,24 @@ fn boolText(value: bool) []const u8 {
     return if (value) "true" else "false";
 }
 
+fn writeJsonString(b: *Buf, value: []const u8) error{NoSpaceLeft}!void {
+    try b.add("\"", .{});
+    for (value) |c| {
+        switch (c) {
+            '"' => try b.add("\\\"", .{}),
+            '\\' => try b.add("\\\\", .{}),
+            0x08 => try b.add("\\b", .{}),
+            0x0c => try b.add("\\f", .{}),
+            '\n' => try b.add("\\n", .{}),
+            '\r' => try b.add("\\r", .{}),
+            '\t' => try b.add("\\t", .{}),
+            0x00...0x07, 0x0b, 0x0e...0x1f => try b.add("\\u00{x:0>2}", .{c}),
+            else => try b.add("{c}", .{c}),
+        }
+    }
+    try b.add("\"", .{});
+}
+
 fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
     switch (event) {
         .connection_started => |d| try b.add(
@@ -488,10 +513,13 @@ pub const TraceHeader = struct {
 pub fn writeTraceHeader(header: TraceHeader, out: []u8) error{NoSpaceLeft}![]const u8 {
     var b = Buf{ .buf = out };
     try b.add("{c}", .{record_separator});
-    try b.add(
-        "{{\"file_schema\":\"{s}\",\"serialization_format\":\"{s}\",\"title\":\"{s}\",\"description\":\"{s}\",\"trace\":{{\"common_fields\":{{\"group_id\":\"{s}\",\"time_format\":\"relative_to_epoch\",\"reference_time\":{{\"clock_type\":\"monotonic\",\"epoch\":\"unknown\"}}}},\"vantage_point\":{{\"type\":\"{s}\"}},\"event_schemas\":[\"{s}\",\"{s}\",\"{s}\"]}}}}\n",
-        .{ file_schema_uri, serialization_format, header.title, header.description, header.group_id, @tagName(header.vantage_point), quic_event_schema_uri, http3_event_schema_uri, tardigrade_event_schema_uri },
-    );
+    try b.add("{{\"file_schema\":\"{s}\",\"serialization_format\":\"{s}\",\"title\":", .{ file_schema_uri, serialization_format });
+    try writeJsonString(&b, header.title);
+    try b.add(",\"description\":", .{});
+    try writeJsonString(&b, header.description);
+    try b.add(",\"trace\":{{\"common_fields\":{{\"group_id\":", .{});
+    try writeJsonString(&b, header.group_id);
+    try b.add(",\"time_format\":\"relative_to_epoch\",\"reference_time\":{{\"clock_type\":\"monotonic\",\"epoch\":\"unknown\"}}}},\"vantage_point\":{{\"type\":\"{s}\"}},\"event_schemas\":[\"{s}\",\"{s}\",\"{s}\"]}}}}\n", .{ @tagName(header.vantage_point), quic_event_schema_uri, http3_event_schema_uri, tardigrade_event_schema_uri });
     return b.slice();
 }
 
@@ -555,6 +583,28 @@ test "deprotection failure is a packet_dropped with decryption_failure" {
     );
 }
 
+test "0-RTT key type serializes as a standard key_updated value" {
+    try expectJson(
+        .{ .time_us = 0, .event = .{ .key_updated = .{ .key_type = .server_0rtt_secret } } },
+        "\"key_type\":\"server_0rtt_secret\"",
+    );
+}
+
+test "trace header escapes free-form text fields" {
+    var buf: [1024]u8 = undefined;
+    const header = try writeTraceHeader(.{
+        .vantage_point = .server,
+        .group_id = "0011deadbeef",
+        .title = "test \"trace\"",
+        .description = "debug \\ trace\nnext",
+    }, &buf);
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, header[1 .. header.len - 1], .{});
+    defer parsed.deinit();
+    const root = parsed.value.object;
+    try testing.expectEqualStrings("test \"trace\"", root.get("title").?.string);
+    try testing.expectEqualStrings("debug \\ trace\nnext", root.get("description").?.string);
+}
+
 test "time is rendered in milliseconds with microsecond precision" {
     var buf: [512]u8 = undefined;
     const line = try writeJson(.{ .time_us = 1_002_003, .event = .{ .key_updated = .{ .key_type = .server_1rtt_secret, .key_phase = 1 } } }, &buf);
@@ -565,8 +615,8 @@ test "path, migration, stream reset and flow-control events serialize" {
     try expectJson(.{ .time_us = 5, .event = .{ .path_validation = .{ .kind = .response_received } } }, "\"phase\":\"response_received\"");
     try expectJson(.{ .time_us = 5, .event = .{ .connection_migrated = .{ .old = .migration_started, .new = .migration_complete } } }, "migration_state_updated");
     try expectJson(.{ .time_us = 5, .event = .{ .stream_reset = .{ .kind = .reset_received, .stream_id = 4, .error_code = 9 } } }, "\"stream_id\":4");
-    try expectJson(.{ .time_us = 5, .event = .{ .data_blocked = .{ .stream = .{ .stream_id = 8, .new = .blocked, .reason = .stream_data_blocked_frame } } } }, "\"name\":\"quic:stream_data_blocked_updated\"");
-    try expectJson(.{ .time_us = 5, .event = .{ .data_blocked = .{ .connection = .{ .new = .blocked, .reason = .data_blocked_frame } } } }, "\"name\":\"quic:connection_data_blocked_updated\"");
+    try expectJson(.{ .time_us = 5, .event = .{ .data_blocked = .{ .stream = .{ .stream_id = 8, .new = .blocked, .reason = .stream_flow_control } } } }, "\"name\":\"quic:stream_data_blocked_updated\"");
+    try expectJson(.{ .time_us = 5, .event = .{ .data_blocked = .{ .connection = .{ .new = .blocked, .reason = .connection_flow_control } } } }, "\"name\":\"quic:connection_data_blocked_updated\"");
 }
 
 test "recovery metrics serialize as a quic event" {

--- a/src/quic/qlog.zig
+++ b/src/quic/qlog.zig
@@ -106,9 +106,31 @@ pub const PathEventKind = enum {
     failed,
 };
 
-/// Connection-migration classification and policy outcome (RFC 9000 §9).
-pub const MigrationKind = enum { nat_rebinding, active };
-pub const MigrationOutcome = enum { accepted, blocked };
+pub const TupleEndpointInfo = struct {};
+
+pub const KeyType = enum {
+    server_initial_secret,
+    client_initial_secret,
+    server_handshake_secret,
+    client_handshake_secret,
+    server_1rtt_secret,
+    client_1rtt_secret,
+};
+
+pub const KeyUpdateTrigger = enum {
+    tls,
+    local_update,
+    remote_update,
+};
+
+pub const MigrationState = enum {
+    probing_started,
+    probing_abandoned,
+    probing_successful,
+    migration_started,
+    migration_abandoned,
+    migration_complete,
+};
 
 /// RESET_STREAM / STOP_SENDING direction (RFC 9000 §19.4, §19.5).
 pub const StreamResetKind = enum {
@@ -118,8 +140,26 @@ pub const StreamResetKind = enum {
     stop_sending_received,
 };
 
-/// DATA_BLOCKED vs. STREAM_DATA_BLOCKED (RFC 9000 §19.12, §19.13).
-pub const BlockedScope = enum { connection, stream };
+pub const BlockedState = enum { blocked, unblocked };
+pub const BlockedReason = enum {
+    data_blocked_frame,
+    stream_data_blocked_frame,
+    flow_control_limit,
+};
+
+pub const DataBlocked = union(enum) {
+    connection: struct {
+        old: ?BlockedState = null,
+        new: BlockedState,
+        reason: ?BlockedReason = null,
+    },
+    stream: struct {
+        stream_id: u64,
+        old: ?BlockedState = null,
+        new: BlockedState,
+        reason: ?BlockedReason = null,
+    },
+};
 
 /// Why an inbound packet was dropped. `decryption_failure` is the qlog
 /// canonical trigger for AEAD deprotection failure — the #255 requirement that
@@ -151,6 +191,8 @@ pub const RecoveryMetrics = struct {
 pub const Event = union(enum) {
     /// quic:connection_started
     connection_started: struct {
+        local: TupleEndpointInfo = .{},
+        remote: TupleEndpointInfo = .{},
         odcid_len: u8 = 0,
         scid_len: u8 = 0,
         dcid_len: u8 = 0,
@@ -168,7 +210,9 @@ pub const Event = union(enum) {
     },
     /// quic:key_updated (1-RTT key-phase flip, RFC 9001 §6)
     key_updated: struct {
-        phase: u1,
+        key_type: KeyType,
+        key_phase: ?u64 = null,
+        trigger: ?KeyUpdateTrigger = null,
     },
     /// quic:packet_sent
     packet_sent: struct {
@@ -203,8 +247,8 @@ pub const Event = union(enum) {
     },
     /// quic:migration_state_updated
     connection_migrated: struct {
-        kind: MigrationKind,
-        outcome: MigrationOutcome,
+        old: ?MigrationState = null,
+        new: MigrationState,
     },
     /// tardigrade:quic_stream_reset (RESET_STREAM / STOP_SENDING)
     stream_reset: struct {
@@ -214,11 +258,7 @@ pub const Event = union(enum) {
     },
     /// quic:connection_data_blocked_updated /
     /// quic:stream_data_blocked_updated (flow-control blocked)
-    data_blocked: struct {
-        scope: BlockedScope,
-        stream_id: ?u64 = null,
-        limit: u64 = 0,
-    },
+    data_blocked: DataBlocked,
 
     pub fn namespace(self: Event) Namespace {
         return switch (self) {
@@ -255,7 +295,7 @@ pub const Event = union(enum) {
             .path_validation => "quic_path_validation",
             .connection_migrated => "migration_state_updated",
             .stream_reset => "quic_stream_reset",
-            .data_blocked => |d| switch (d.scope) {
+            .data_blocked => |d| switch (d) {
                 .connection => "connection_data_blocked_updated",
                 .stream => "stream_data_blocked_updated",
             },
@@ -320,7 +360,7 @@ fn boolText(value: bool) []const u8 {
 fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
     switch (event) {
         .connection_started => |d| try b.add(
-            "{{\"odcid_length\":{d},\"scid_length\":{d},\"dcid_length\":{d}}}",
+            "{{\"local\":{{}},\"remote\":{{}},\"tardigrade_odcid_length\":{d},\"tardigrade_scid_length\":{d},\"tardigrade_dcid_length\":{d}}}",
             .{ d.odcid_len, d.scid_len, d.dcid_len },
         ),
         .connection_closed => |d| {
@@ -332,7 +372,12 @@ fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
             "{{\"stage\":\"{s}\"}}",
             .{@tagName(d.stage)},
         ),
-        .key_updated => |d| try b.add("{{\"key_phase\":{d}}}", .{d.phase}),
+        .key_updated => |d| {
+            try b.add("{{\"key_type\":\"{s}\"", .{@tagName(d.key_type)});
+            if (d.key_phase) |phase| try b.add(",\"key_phase\":{d}", .{phase});
+            if (d.trigger) |trigger| try b.add(",\"trigger\":\"{s}\"", .{@tagName(trigger)});
+            try b.add("}}", .{});
+        },
         .packet_sent => |d| try b.add(
             "{{\"header\":{{\"packet_type\":\"{s}\",\"packet_number\":{d}}},\"raw\":{{\"length\":{d}}},\"tardigrade_ack_eliciting\":{s}}}",
             .{ d.packet_type.label(), d.packet_number, d.length, boolText(d.ack_eliciting) },
@@ -388,18 +433,35 @@ fn writeData(b: *Buf, event: Event) error{NoSpaceLeft}!void {
             "{{\"phase\":\"{s}\",\"path_id\":{d}}}",
             .{ @tagName(d.kind), d.path_id },
         ),
-        .connection_migrated => |d| try b.add(
-            "{{\"state\":\"{s}\",\"trigger\":\"{s}\"}}",
-            .{ @tagName(d.outcome), @tagName(d.kind) },
-        ),
+        .connection_migrated => |d| {
+            try b.add("{{", .{});
+            if (d.old) |old| try b.add("\"old\":\"{s}\",", .{@tagName(old)});
+            try b.add("\"new\":\"{s}\"}}", .{@tagName(d.new)});
+        },
         .stream_reset => |d| try b.add(
             "{{\"direction\":\"{s}\",\"stream_id\":{d},\"error_code\":{d}}}",
             .{ @tagName(d.kind), d.stream_id, d.error_code },
         ),
-        .data_blocked => |d| {
-            try b.add("{{\"scope\":\"{s}\"", .{@tagName(d.scope)});
-            if (d.stream_id) |sid| try b.add(",\"stream_id\":{d}", .{sid});
-            try b.add(",\"limit\":{d}}}", .{d.limit});
+        .data_blocked => |d| switch (d) {
+            .connection => |blocked| {
+                try b.add("{{", .{});
+                var need_comma = false;
+                if (blocked.old) |old| {
+                    try b.add("\"old\":\"{s}\"", .{@tagName(old)});
+                    need_comma = true;
+                }
+                if (need_comma) try b.add(",", .{});
+                try b.add("\"new\":\"{s}\"", .{@tagName(blocked.new)});
+                if (blocked.reason) |reason| try b.add(",\"reason\":\"{s}\"", .{@tagName(reason)});
+                try b.add("}}", .{});
+            },
+            .stream => |blocked| {
+                try b.add("{{\"stream_id\":{d}", .{blocked.stream_id});
+                if (blocked.old) |old| try b.add(",\"old\":\"{s}\"", .{@tagName(old)});
+                try b.add(",\"new\":\"{s}\"", .{@tagName(blocked.new)});
+                if (blocked.reason) |reason| try b.add(",\"reason\":\"{s}\"", .{@tagName(reason)});
+                try b.add("}}", .{});
+            },
         },
     }
 }
@@ -427,7 +489,7 @@ pub fn writeTraceHeader(header: TraceHeader, out: []u8) error{NoSpaceLeft}![]con
     var b = Buf{ .buf = out };
     try b.add("{c}", .{record_separator});
     try b.add(
-        "{{\"file_schema\":\"{s}\",\"serialization_format\":\"{s}\",\"title\":\"{s}\",\"description\":\"{s}\",\"trace\":{{\"common_fields\":{{\"group_id\":\"{s}\",\"time_format\":\"relative_to_epoch\",\"reference_time\":{{\"clock_type\":\"system\",\"epoch\":\"1970-01-01T00:00:00.000Z\"}}}},\"vantage_point\":{{\"type\":\"{s}\"}},\"event_schemas\":[\"{s}\",\"{s}\",\"{s}\"]}}}}\n",
+        "{{\"file_schema\":\"{s}\",\"serialization_format\":\"{s}\",\"title\":\"{s}\",\"description\":\"{s}\",\"trace\":{{\"common_fields\":{{\"group_id\":\"{s}\",\"time_format\":\"relative_to_epoch\",\"reference_time\":{{\"clock_type\":\"monotonic\",\"epoch\":\"unknown\"}}}},\"vantage_point\":{{\"type\":\"{s}\"}},\"event_schemas\":[\"{s}\",\"{s}\",\"{s}\"]}}}}\n",
         .{ file_schema_uri, serialization_format, header.title, header.description, header.group_id, @tagName(header.vantage_point), quic_event_schema_uri, http3_event_schema_uri, tardigrade_event_schema_uri },
     );
     return b.slice();
@@ -469,8 +531,8 @@ fn expectJson(record: Record, needle: []const u8) !void {
 test "namespace and name mapping stays aligned with qlog vantage points" {
     try testing.expectEqual(Namespace.quic, (Event{ .packet_sent = .{ .packet_type = .one_rtt, .packet_number = 0, .length = 0 } }).namespace());
     try testing.expectEqual(Namespace.quic, (Event{ .packet_lost = .{ .packet_type = .one_rtt } }).namespace());
-    try testing.expectEqual(Namespace.quic, (Event{ .key_updated = .{ .phase = 1 } }).namespace());
-    try testing.expectEqual(Namespace.quic, (Event{ .connection_migrated = .{ .kind = .active, .outcome = .blocked } }).namespace());
+    try testing.expectEqual(Namespace.quic, (Event{ .key_updated = .{ .key_type = .server_1rtt_secret, .key_phase = 1 } }).namespace());
+    try testing.expectEqual(Namespace.quic, (Event{ .connection_migrated = .{ .new = .migration_complete } }).namespace());
     try testing.expectEqual(Namespace.tardigrade, (Event{ .stream_reset = .{ .kind = .reset_sent, .stream_id = 0 } }).namespace());
     try testing.expectEqualStrings("packet_dropped", (Event{ .packet_dropped = .{ .trigger = .decryption_failure } }).name());
 }
@@ -495,15 +557,16 @@ test "deprotection failure is a packet_dropped with decryption_failure" {
 
 test "time is rendered in milliseconds with microsecond precision" {
     var buf: [512]u8 = undefined;
-    const line = try writeJson(.{ .time_us = 1_002_003, .event = .{ .key_updated = .{ .phase = 1 } } }, &buf);
+    const line = try writeJson(.{ .time_us = 1_002_003, .event = .{ .key_updated = .{ .key_type = .server_1rtt_secret, .key_phase = 1 } } }, &buf);
     try testing.expect(std.mem.indexOf(u8, line, "\"time\":1002.003") != null);
 }
 
 test "path, migration, stream reset and flow-control events serialize" {
     try expectJson(.{ .time_us = 5, .event = .{ .path_validation = .{ .kind = .response_received } } }, "\"phase\":\"response_received\"");
-    try expectJson(.{ .time_us = 5, .event = .{ .connection_migrated = .{ .kind = .nat_rebinding, .outcome = .accepted } } }, "migration_state_updated");
+    try expectJson(.{ .time_us = 5, .event = .{ .connection_migrated = .{ .old = .migration_started, .new = .migration_complete } } }, "migration_state_updated");
     try expectJson(.{ .time_us = 5, .event = .{ .stream_reset = .{ .kind = .reset_received, .stream_id = 4, .error_code = 9 } } }, "\"stream_id\":4");
-    try expectJson(.{ .time_us = 5, .event = .{ .data_blocked = .{ .scope = .stream, .stream_id = 8, .limit = 4096 } } }, "\"scope\":\"stream\"");
+    try expectJson(.{ .time_us = 5, .event = .{ .data_blocked = .{ .stream = .{ .stream_id = 8, .new = .blocked, .reason = .stream_data_blocked_frame } } } }, "\"name\":\"quic:stream_data_blocked_updated\"");
+    try expectJson(.{ .time_us = 5, .event = .{ .data_blocked = .{ .connection = .{ .new = .blocked, .reason = .data_blocked_frame } } } }, "\"name\":\"quic:connection_data_blocked_updated\"");
 }
 
 test "recovery metrics serialize as a quic event" {
@@ -525,6 +588,7 @@ test "trace header then event forms a two-record JSON-SEQ stream" {
     try testing.expectEqual(@as(usize, 2), std.mem.count(u8, buf[0 .. header.len + event.len], &[_]u8{record_separator}));
     try testing.expect(std.mem.indexOf(u8, header, "\"file_schema\":\"urn:ietf:params:qlog:file:sequential\"") != null);
     try testing.expect(std.mem.indexOf(u8, header, "\"serialization_format\":\"application/qlog+json-seq\"") != null);
+    try testing.expect(std.mem.indexOf(u8, header, "\"reference_time\":{\"clock_type\":\"monotonic\",\"epoch\":\"unknown\"}") != null);
     try testing.expect(std.mem.indexOf(u8, header, "\"event_schemas\":[\"urn:ietf:params:qlog:events:quic-13\",\"urn:ietf:params:qlog:events:http3-13\"") != null);
     try testing.expect(std.mem.indexOf(u8, header, "\"vantage_point\":{\"type\":\"server\"}") != null);
     try testing.expect(std.mem.indexOf(u8, header, "\"group_id\":\"0011deadbeef\"") != null);
@@ -539,7 +603,7 @@ test "default sink is a no-op and log() stamps time" {
         }
     };
     const noop = Sink{};
-    noop.log(1, .{ .key_updated = .{ .phase = 0 } }); // must not crash
+    noop.log(1, .{ .key_updated = .{ .key_type = .client_1rtt_secret, .key_phase = 0 } }); // must not crash
 
     Collector.last = null;
     const sink = Sink{ .emit_fn = Collector.emit };

--- a/tests/quic_h3_smoke.zig
+++ b/tests/quic_h3_smoke.zig
@@ -1209,10 +1209,10 @@ test "qlog composition root interleaves transport and h3 records under one heade
 
     const h3_settings = try h3qlog.writeJson(.{
         .time_us = 2_000,
-        .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = &.{.{ .name = "SETTINGS_QPACK_BLOCKED_STREAMS", .value = 16 }}, .raw_length = 6 } } } },
+        .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = &.{.{ .name = .settings_qpack_blocked_streams, .value = 16 }}, .raw_length = 6 } } } },
     }, file[len..]);
     len += h3_settings.len;
-    try expectQlogRecord(h3_settings, "{\"time\":2.000,\"name\":\"http3:frame_created\",\"data\":{\"stream_id\":0,\"frame\":{\"frame_type\":\"settings\",\"settings\":[{\"name\":\"SETTINGS_QPACK_BLOCKED_STREAMS\",\"value\":16}],\"raw\":{\"length\":6}}}}");
+    try expectQlogRecord(h3_settings, "{\"time\":2.000,\"name\":\"http3:frame_created\",\"data\":{\"stream_id\":0,\"frame\":{\"frame_type\":\"settings\",\"settings\":[{\"name\":\"settings_qpack_blocked_streams\",\"value\":16}],\"raw\":{\"length\":6}}}}");
 
     const h3_headers = try h3qlog.writeJson(.{
         .time_us = 2_250,

--- a/tests/quic_h3_smoke.zig
+++ b/tests/quic_h3_smoke.zig
@@ -1155,7 +1155,6 @@ test "qlog composition root interleaves transport and h3 records under one heade
 
     const header = try qlog.writeTraceHeader(.{
         .vantage_point = .server,
-        .reference_time_us = 0,
         .group_id = "0011223344556677",
     }, file[len..]);
     len += header.len;
@@ -1175,9 +1174,10 @@ test "qlog composition root interleaves transport and h3 records under one heade
     const stream = file[0..len];
     // Three records: header + one transport + one h3, each JSON-SEQ delimited.
     try testing.expectEqual(@as(usize, 3), std.mem.count(u8, stream, &[_]u8{qlog.record_separator}));
-    try testing.expect(std.mem.indexOf(u8, stream, "\"qlog_format\":\"JSON-SEQ\"") != null);
-    try testing.expect(std.mem.indexOf(u8, stream, "transport:packet_received") != null);
-    try testing.expect(std.mem.indexOf(u8, stream, "qpack:stream_state_updated") != null);
+    try testing.expect(std.mem.indexOf(u8, stream, "\"file_schema\":\"urn:ietf:params:qlog:file:sequential\"") != null);
+    try testing.expect(std.mem.indexOf(u8, stream, "\"serialization_format\":\"application/qlog+json-seq\"") != null);
+    try testing.expect(std.mem.indexOf(u8, stream, "quic:packet_received") != null);
+    try testing.expect(std.mem.indexOf(u8, stream, "tardigrade:qpack_stream_state_updated") != null);
     // Both writers frame identically, so the merged stream is uniform.
     try testing.expectEqual(qlog.record_separator, h3qlog.record_separator);
 }

--- a/tests/quic_h3_smoke.zig
+++ b/tests/quic_h3_smoke.zig
@@ -1146,11 +1146,22 @@ test "smoke harness fails truncated long-header packets deterministically" {
 // interleaves transport records (src/quic) and HTTP/3 records (src/http3) into
 // a single JSON-SEQ stream. This test locks that intended file shape — the seam
 // #255 designs — without either package importing the other.
+fn expectQlogRecord(record: []const u8, expected_json: []const u8) !void {
+    try testing.expect(record.len >= 2);
+    try testing.expectEqual(quic.qlog.record_separator, record[0]);
+    try testing.expectEqual(@as(u8, '\n'), record[record.len - 1]);
+
+    const payload = record[1 .. record.len - 1];
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, payload, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings(expected_json, payload);
+}
+
 test "qlog composition root interleaves transport and h3 records under one header" {
     const qlog = quic.qlog;
     const h3qlog = http3.qlog;
 
-    var file: [1024]u8 = undefined;
+    var file: [8192]u8 = undefined;
     var len: usize = 0;
 
     const header = try qlog.writeTraceHeader(.{
@@ -1159,25 +1170,74 @@ test "qlog composition root interleaves transport and h3 records under one heade
     }, file[len..]);
     len += header.len;
 
-    const transport_rec = try qlog.writeJson(.{
+    try expectQlogRecord(header, "{\"file_schema\":\"urn:ietf:params:qlog:file:sequential\",\"serialization_format\":\"application/qlog+json-seq\",\"title\":\"tardigrade-quic\",\"description\":\"Tardigrade QUIC/HTTP-3 debug trace\",\"trace\":{\"common_fields\":{\"group_id\":\"0011223344556677\",\"time_format\":\"relative_to_epoch\",\"reference_time\":{\"clock_type\":\"monotonic\",\"epoch\":\"unknown\"}},\"vantage_point\":{\"type\":\"server\"},\"event_schemas\":[\"urn:ietf:params:qlog:events:quic-13\",\"urn:ietf:params:qlog:events:http3-13\",\"https://bare.systems/tardigrade/qlog/events/debug-1\"]}}");
+
+    const connection_started = try qlog.writeJson(.{
+        .time_us = 500,
+        .event = .{ .connection_started = .{ .odcid_len = 8, .scid_len = 8, .dcid_len = 8 } },
+    }, file[len..]);
+    len += connection_started.len;
+    try expectQlogRecord(connection_started, "{\"time\":0.500,\"name\":\"quic:connection_started\",\"data\":{\"local\":{},\"remote\":{},\"tardigrade_odcid_length\":8,\"tardigrade_scid_length\":8,\"tardigrade_dcid_length\":8}}");
+
+    const packet_sent = try qlog.writeJson(.{
+        .time_us = 1_000,
+        .event = .{ .packet_sent = .{ .packet_type = .initial, .packet_number = 0, .length = 1200, .ack_eliciting = true } },
+    }, file[len..]);
+    len += packet_sent.len;
+    try expectQlogRecord(packet_sent, "{\"time\":1.000,\"name\":\"quic:packet_sent\",\"data\":{\"header\":{\"packet_type\":\"initial\",\"packet_number\":0},\"raw\":{\"length\":1200},\"tardigrade_ack_eliciting\":true}}");
+
+    const packet_received = try qlog.writeJson(.{
         .time_us = 1_000,
         .event = .{ .packet_received = .{ .packet_type = .initial, .packet_number = 0, .length = 1200 } },
     }, file[len..]);
-    len += transport_rec.len;
+    len += packet_received.len;
+    try expectQlogRecord(packet_received, "{\"time\":1.000,\"name\":\"quic:packet_received\",\"data\":{\"header\":{\"packet_type\":\"initial\",\"packet_number\":0},\"raw\":{\"length\":1200}}}");
 
-    const h3_rec = try h3qlog.writeJson(.{
+    const packet_lost = try qlog.writeJson(.{
+        .time_us = 1_500,
+        .event = .{ .packet_lost = .{ .packet_type = .one_rtt, .packet_number = 7 } },
+    }, file[len..]);
+    len += packet_lost.len;
+    try expectQlogRecord(packet_lost, "{\"time\":1.500,\"name\":\"quic:packet_lost\",\"data\":{\"header\":{\"packet_type\":\"1RTT\",\"packet_number\":7}}}");
+
+    const recovery_metrics = try qlog.writeJson(.{
+        .time_us = 1_750,
+        .event = .{ .recovery_metrics_updated = .{ .latest_rtt_ms = 21, .smoothed_rtt_ms = 23, .rtt_variance_ms = 4, .pto_count = 1, .congestion_window = 12000, .bytes_in_flight = 1200 } },
+    }, file[len..]);
+    len += recovery_metrics.len;
+    try expectQlogRecord(recovery_metrics, "{\"time\":1.750,\"name\":\"quic:recovery_metrics_updated\",\"data\":{\"latest_rtt\":21,\"smoothed_rtt\":23,\"rtt_variance\":4,\"pto_count\":1,\"congestion_window\":12000,\"bytes_in_flight\":1200}}");
+
+    const h3_settings = try h3qlog.writeJson(.{
+        .time_us = 2_000,
+        .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .settings = .{ .settings = &.{.{ .name = "SETTINGS_QPACK_BLOCKED_STREAMS", .value = 16 }}, .raw_length = 6 } } } },
+    }, file[len..]);
+    len += h3_settings.len;
+    try expectQlogRecord(h3_settings, "{\"time\":2.000,\"name\":\"http3:frame_created\",\"data\":{\"stream_id\":0,\"frame\":{\"frame_type\":\"settings\",\"settings\":[{\"name\":\"SETTINGS_QPACK_BLOCKED_STREAMS\",\"value\":16}],\"raw\":{\"length\":6}}}}");
+
+    const h3_headers = try h3qlog.writeJson(.{
+        .time_us = 2_250,
+        .event = .{ .frame = .{ .direction = .parsed, .stream_id = 4, .frame = .{ .headers = .{ .headers = &.{ .{ .name = ":method", .value = "GET" }, .{ .name = ":path", .value = "/" } }, .raw_length = 12 } } } },
+    }, file[len..]);
+    len += h3_headers.len;
+    try expectQlogRecord(h3_headers, "{\"time\":2.250,\"name\":\"http3:frame_parsed\",\"data\":{\"stream_id\":4,\"frame\":{\"frame_type\":\"headers\",\"headers\":[{\"name\":\":method\",\"value\":\"GET\"},{\"name\":\":path\",\"value\":\"/\"}],\"raw\":{\"length\":12}}}}");
+
+    const h3_goaway = try h3qlog.writeJson(.{
+        .time_us = 2_500,
+        .event = .{ .frame = .{ .direction = .created, .stream_id = 0, .frame = .{ .goaway = .{ .id = 4, .raw_length = 1 } } } },
+    }, file[len..]);
+    len += h3_goaway.len;
+    try expectQlogRecord(h3_goaway, "{\"time\":2.500,\"name\":\"http3:frame_created\",\"data\":{\"stream_id\":0,\"frame\":{\"frame_type\":\"goaway\",\"id\":4,\"raw\":{\"length\":1}}}}");
+
+    const qpack_extension = try h3qlog.writeJson(.{
         .time_us = 2_000,
         .event = .{ .qpack_state_updated = .{ .state = .blocked, .stream_id = 0 } },
     }, file[len..]);
-    len += h3_rec.len;
+    len += qpack_extension.len;
+    try expectQlogRecord(qpack_extension, "{\"time\":2.000,\"name\":\"tardigrade:qpack_stream_state_updated\",\"data\":{\"stream_id\":0,\"state\":\"blocked\"}}");
 
     const stream = file[0..len];
-    // Three records: header + one transport + one h3, each JSON-SEQ delimited.
-    try testing.expectEqual(@as(usize, 3), std.mem.count(u8, stream, &[_]u8{qlog.record_separator}));
-    try testing.expect(std.mem.indexOf(u8, stream, "\"file_schema\":\"urn:ietf:params:qlog:file:sequential\"") != null);
-    try testing.expect(std.mem.indexOf(u8, stream, "\"serialization_format\":\"application/qlog+json-seq\"") != null);
-    try testing.expect(std.mem.indexOf(u8, stream, "quic:packet_received") != null);
-    try testing.expect(std.mem.indexOf(u8, stream, "tardigrade:qpack_stream_state_updated") != null);
+    // Header + representative QUIC/H3 records, each JSON-SEQ delimited.
+    try testing.expectEqual(@as(usize, 10), std.mem.count(u8, stream, &[_]u8{qlog.record_separator}));
     // Both writers frame identically, so the merged stream is uniform.
     try testing.expectEqual(qlog.record_separator, h3qlog.record_separator);
 }


### PR DESCRIPTION
## Summary
- update QUIC qlog to draft-qualified `quic:*` names, current JSON-SEQ `QlogFileSeq` header fields, `.sqlog` constants, packet `header`/`raw` payload shapes, `decryption_failure` drops, and `quic:recovery_metrics_updated`
- update HTTP/3 qlog to `http3:*` names, current SETTINGS field names, `stream_type_set`, representative frame payloads, and a `tardigrade:*` QPACK blocking extension instead of the removed standard QPACK namespace
- refresh qlog docs and the composition smoke test for draft-14/draft-13 schema URIs and `.sqlog` artifacts

Refs #255 (slice 1 only)

## Validation
- `zig fmt --check build.zig src/ tests/`
- `zig build test-quic --summary all --error-style verbose` (755/755 tests passed)

## Notes
- qvis is not installed in this environment (`command -v qvis` returned no path), so I could not perform the requested manual qvis load check locally.
