### PR TITLE
perf(quic): make the outbound datagram size a real transport invariant (#256-A)

### DIFF
--- a/docs/HTTP3_ROLLOUT.md
+++ b/docs/HTTP3_ROLLOUT.md
@@ -64,8 +64,10 @@ Consequences worth knowing before tuning it:
 - The 2048 ceiling is the transport's work-buffer size, not a path property.
 
 Nothing about this setting relaxes congestion control, flow control, or the
-server's anti-amplification budget; those gates run after the size cap and
-still bound every byte sent.
+server's anti-amplification budget. In particular, an ordinary packet's
+in-flight content is bounded by the *remaining congestion window*, not by this
+cap, so raising the cap cannot widen how far in-flight bytes cross the window.
+Pure ACKs (not in flight) and PTO probes keep their RFC 9002 exemptions.
 
 ## Reload
 

--- a/docs/HTTP3_ROLLOUT.md
+++ b/docs/HTTP3_ROLLOUT.md
@@ -31,6 +31,42 @@ During drain or rollback withdrawal, eligible TCP responses emit
 upstream `Alt-Svc` response headers and emits at most one gateway-owned
 `Alt-Svc` value.
 
+## Datagram size
+
+`TARDIGRADE_HTTP3_MAX_DATAGRAM_SIZE` is the **local** bound on the UDP payload
+of every datagram this process sends, and the `max_udp_payload_size` transport
+parameter it advertises to peers. It defaults to **1200** — the size RFC 9000
+§14 requires every QUIC path to carry — and is clamped into `[1200, 2048]`.
+
+It is only one of the inputs to the size actually emitted. The transport
+resolves one *effective* cap per connection as the smallest of:
+
+1. this local configured maximum;
+2. the peer's advertised `max_udp_payload_size`, once its transport parameters
+   are authenticated;
+3. the validated path size.
+
+Consequences worth knowing before tuning it:
+
+- **The cap sits at 1200 for the whole handshake.** A raised local value only
+  takes effect once the peer has authenticated and committed to accepting
+  larger datagrams. Datagrams carrying Initial packets are always padded to
+  1200 regardless.
+- **A peer always wins when it asks for less.** Raising this value can never
+  push a datagram past what the peer advertised.
+- **Raising it is an assertion about the path**, not a measurement. Tardigrade
+  does not yet run DPLPMTUD (RFC 8899), so a value above 1200 says "I know this
+  path carries this much". If it does not, those datagrams are dropped and the
+  connection stalls until the peer's PTO retransmits. Raise it only for paths
+  whose MTU you control end to end (a dedicated link, a loopback or same-rack
+  benchmark host, a known-jumbo-frame fabric). Leave it at the default on the
+  open internet.
+- The 2048 ceiling is the transport's work-buffer size, not a path property.
+
+Nothing about this setting relaxes congestion control, flow control, or the
+server's anti-amplification budget; those gates run after the size cap and
+still bound every byte sent.
+
 ## Reload
 
 Advertisement-only knobs can hot reload:

--- a/docs/HTTP3_ROLLOUT.md
+++ b/docs/HTTP3_ROLLOUT.md
@@ -33,22 +33,29 @@ upstream `Alt-Svc` response headers and emits at most one gateway-owned
 
 ## Datagram size
 
-`TARDIGRADE_HTTP3_MAX_DATAGRAM_SIZE` is the **local** bound on the UDP payload
-of every datagram this process sends, and the `max_udp_payload_size` transport
-parameter it advertises to peers. It defaults to **1200** — the size RFC 9000
-§14 requires every QUIC path to carry — and is clamped into `[1200, 2048]`.
+Two different quantities share the name "max UDP payload size" in QUIC, and
+Tardigrade keeps them separate.
 
-It is only one of the inputs to the size actually emitted. The transport
-resolves one *effective* cap per connection as the smallest of:
+**Receive capacity** is what this endpoint tells peers it is willing to receive,
+via the `max_udp_payload_size` transport parameter. It is a property of the
+receive buffers the implementation allocates — **2048 bytes** — not something an
+operator tunes, and it never changes for the life of a connection. The config
+layer refuses to advertise more than the transport can actually deprotect.
 
-1. this local configured maximum;
-2. the peer's advertised `max_udp_payload_size`, once its transport parameters
-   are authenticated;
-3. the validated path size.
+**Send size** is what this process puts on the wire, and that is what
+`TARDIGRADE_HTTP3_MAX_DATAGRAM_SIZE` controls. It defaults to **1200** — the
+size RFC 9000 §14 requires every QUIC path to carry — and is clamped into
+`[1200, 2048]`. The transport resolves the size actually emitted as the smallest
+of:
+
+1. the current path size (this knob, until DPLPMTUD replaces it);
+2. this endpoint's send ceiling (2048);
+3. the peer's advertised receive capacity, once its transport parameters are
+   authenticated.
 
 Consequences worth knowing before tuning it:
 
-- **The cap sits at 1200 for the whole handshake.** A raised local value only
+- **The send size sits at 1200 for the whole handshake.** A raised value only
   takes effect once the peer has authenticated and committed to accepting
   larger datagrams. Datagrams carrying Initial packets are always padded to
   1200 regardless.
@@ -56,18 +63,33 @@ Consequences worth knowing before tuning it:
   push a datagram past what the peer advertised.
 - **Raising it is an assertion about the path**, not a measurement. Tardigrade
   does not yet run DPLPMTUD (RFC 8899), so a value above 1200 says "I know this
-  path carries this much". If it does not, those datagrams are dropped and the
-  connection stalls until the peer's PTO retransmits. Raise it only for paths
-  whose MTU you control end to end (a dedicated link, a loopback or same-rack
-  benchmark host, a known-jumbo-frame fabric). Leave it at the default on the
-  open internet.
-- The 2048 ceiling is the transport's work-buffer size, not a path property.
+  path carries this much". If it does not, those datagrams are dropped in the
+  network. Tardigrade's own loss recovery will notice and retransmit — but with
+  no PMTU black-hole fallback yet, the retransmissions are the same oversized
+  datagrams, so the connection can stall indefinitely rather than recovering at
+  a smaller size. Raise it only for paths whose MTU you control end to end (a
+  dedicated link, a loopback or same-rack benchmark host, a known-jumbo-frame
+  fabric). Leave it at the default on the open internet.
 
 Nothing about this setting relaxes congestion control, flow control, or the
-server's anti-amplification budget. In particular, an ordinary packet's
-in-flight content is bounded by the *remaining congestion window*, not by this
-cap, so raising the cap cannot widen how far in-flight bytes cross the window.
-Pure ACKs (not in flight) and PTO probes keep their RFC 9002 exemptions.
+server's anti-amplification budget:
+
+- An in-flight packet's content is bounded by the *remaining congestion
+  window*, not by the datagram size, so raising the size cannot widen how far
+  in-flight bytes cross the window. The budget covers the packet's **final**
+  size, including the padding RFC 9000 mandates for Initial-bearing and
+  path-validation datagrams.
+- Path validation is delayed when the window cannot cover its padded datagram
+  (RFC 9000 §8.2 permits this) rather than being sent uncharged.
+- Recovery's packet tracker is bounded; when it is full the transport
+  backpressures instead of emitting in-flight packets it cannot track.
+- Pure ACKs (never in flight) and PTO probes keep their RFC 9002 exemptions.
+  A packet carrying PADDING is in flight even when nothing in it is
+  ack-eliciting, and is charged accordingly.
+
+RFC 9002's NewReno windows are defined in terms of the sender's current maximum
+datagram size, so the initial window, minimum window, and congestion-avoidance
+growth all scale with the value above rather than with a fixed 1200.
 
 ## Reload
 

--- a/src/edge_config.zig
+++ b/src/edge_config.zig
@@ -935,9 +935,11 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
     const http3_retry_policy_str = envOrDefault(allocator, "TARDIGRADE_HTTP3_RETRY_POLICY", "off") catch unreachable;
     defer allocator.free(http3_retry_policy_str);
     const http3_retry_policy = try parseHttp3RetryPolicyConfig(http3_retry_policy_str);
-    // #256-A: one authoritative default, owned by `quic.datagram`. The
-    // transport clamps this into `[base_size, max_size]` and lowers it further
-    // whenever the peer advertises a smaller `max_udp_payload_size`.
+    // #256-A: the **send** size, owned by `quic.datagram`. This is not the
+    // `max_udp_payload_size` this endpoint advertises — that is receive
+    // capacity, fixed by the transport's buffers. The transport clamps this
+    // into `[base_size, max_size]` and lowers it further whenever the peer
+    // advertises smaller receive capacity.
     const http3_max_datagram_size = parseIntEnv(usize, allocator, "TARDIGRADE_HTTP3_MAX_DATAGRAM_SIZE", http.quic.datagram.base_size);
     const proxy_protocol_mode_str = envOrDefault(allocator, "TARDIGRADE_PROXY_PROTOCOL", "off") catch unreachable;
     defer allocator.free(proxy_protocol_mode_str);

--- a/src/edge_config.zig
+++ b/src/edge_config.zig
@@ -935,7 +935,10 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
     const http3_retry_policy_str = envOrDefault(allocator, "TARDIGRADE_HTTP3_RETRY_POLICY", "off") catch unreachable;
     defer allocator.free(http3_retry_policy_str);
     const http3_retry_policy = try parseHttp3RetryPolicyConfig(http3_retry_policy_str);
-    const http3_max_datagram_size = parseIntEnv(usize, allocator, "TARDIGRADE_HTTP3_MAX_DATAGRAM_SIZE", 1350);
+    // #256-A: one authoritative default, owned by `quic.datagram`. The
+    // transport clamps this into `[base_size, max_size]` and lowers it further
+    // whenever the peer advertises a smaller `max_udp_payload_size`.
+    const http3_max_datagram_size = parseIntEnv(usize, allocator, "TARDIGRADE_HTTP3_MAX_DATAGRAM_SIZE", http.quic.datagram.base_size);
     const proxy_protocol_mode_str = envOrDefault(allocator, "TARDIGRADE_PROXY_PROTOCOL", "off") catch unreachable;
     defer allocator.free(proxy_protocol_mode_str);
     const proxy_protocol_mode = try parseProxyProtocolModeConfig(proxy_protocol_mode_str);

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -88,7 +88,13 @@ pub const Config = struct {
     h3_settings: http3.frame.Settings = .{},
     connection_migration: bool = false,
     retry_policy: quic.config.RetryPolicy = .off,
-    max_datagram_size: usize = 1350,
+    /// Operator-facing local bound on outbound UDP datagrams, clamped into
+    /// `[quic.datagram.base_size, quic.datagram.max_size]` and handed to the
+    /// transport as `max_udp_payload_size`. The default is the one
+    /// authoritative value in `quic.datagram` rather than a second knob that
+    /// can drift from it (#256-A); the transport lowers it further whenever
+    /// the peer advertises less.
+    max_datagram_size: usize = quic.datagram.base_size,
     request_handler: ?RequestHandler = null,
     request_handler_ctx: ?*anyopaque = null,
     early_data_compat_metrics_ctx: ?*anyopaque = null,
@@ -440,7 +446,7 @@ pub const Runtime = struct {
             // 1) Timers and transmission for every connection.
             var wake_us: u64 = now + 100_000;
             {
-                var out: [2048]u8 = undefined;
+                var out: [quic.datagram.max_size]u8 = undefined;
                 var reap: [16]u64 = undefined;
                 var reap_count: usize = 0;
                 var it = connections.iterator();
@@ -488,7 +494,7 @@ pub const Runtime = struct {
             _ = posix.poll(&fds, timeout_ms) catch {};
 
             // 3) Ingest every waiting datagram.
-            var buf: [2048]u8 = undefined;
+            var buf: [quic.datagram.max_size]u8 = undefined;
             var from: std.c.sockaddr.storage = undefined;
             while (true) {
                 var from_len: std.c.socklen_t = @sizeOf(std.c.sockaddr.storage);
@@ -591,7 +597,7 @@ pub const Runtime = struct {
         }
         self.maybeIssueSessionTicket(entry);
 
-        var out: [2048]u8 = undefined;
+        var out: [quic.datagram.max_size]u8 = undefined;
         while (entry.conn.pollTransmitOnPath(&out, now)) |t| {
             self.sendDatagram(sockaddrInFromAddress(t.path.remote), t.bytes);
         }
@@ -1439,7 +1445,7 @@ fn buildStreamRequest(allocator: std.mem.Allocator, exchange: stream_transport.E
 /// config.
 fn quicConfigFrom(cfg: Config) quic.config.Config {
     return .{
-        .max_udp_payload_size = std.math.clamp(cfg.max_datagram_size, 1200, 2048),
+        .max_udp_payload_size = std.math.clamp(cfg.max_datagram_size, quic.datagram.base_size, quic.datagram.max_size),
         .zero_rtt_enabled = zeroRttCarrierEnabled(cfg),
         .retry_policy = cfg.retry_policy,
         .migration_policy = if (cfg.connection_migration) .full else .nat_rebinding_only,
@@ -1773,6 +1779,17 @@ test "quicConfigFrom clamps datagram size into the work-buffer range" {
         .quic_port = 443,
         .retry_policy = .address_validation,
     }).retry_policy);
+}
+
+test "quicConfigFrom: the runtime default is the transport's own authoritative default" {
+    // #256-A: the runtime must not carry a second datagram-size default that
+    // can drift from the transport's. Both come from `quic.datagram`.
+    const runtime_default = Config{ .listen_host = "::", .quic_port = 443 };
+    try testing.expectEqual(quic.datagram.base_size, runtime_default.max_datagram_size);
+    try testing.expectEqual(
+        (quic.config.Config{}).max_udp_payload_size,
+        quicConfigFrom(runtime_default).max_udp_payload_size,
+    );
 }
 
 test "http3 runtime: spare CID route is registered before NEW_CONNECTION_ID is pollable" {

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -88,12 +88,14 @@ pub const Config = struct {
     h3_settings: http3.frame.Settings = .{},
     connection_migration: bool = false,
     retry_policy: quic.config.RetryPolicy = .off,
-    /// Operator-facing local bound on outbound UDP datagrams, clamped into
-    /// `[quic.datagram.base_size, quic.datagram.max_size]` and handed to the
-    /// transport as `max_udp_payload_size`. The default is the one
-    /// authoritative value in `quic.datagram` rather than a second knob that
-    /// can drift from it (#256-A); the transport lowers it further whenever
-    /// the peer advertises less.
+    /// Operator-facing bound on the size of datagrams this listener **sends**,
+    /// clamped into `[quic.datagram.base_size, quic.datagram.max_size]`. It is
+    /// the assumed path MTU, not a receive limit: the `max_udp_payload_size`
+    /// this endpoint advertises is its own receive capacity and is fixed by
+    /// the transport's buffers, not by this knob (#256-A). The default is the
+    /// one authoritative value in `quic.datagram` rather than a second knob
+    /// that can drift from it; the transport lowers it further whenever the
+    /// peer advertises less receive capacity.
     max_datagram_size: usize = quic.datagram.base_size,
     request_handler: ?RequestHandler = null,
     request_handler_ctx: ?*anyopaque = null,
@@ -1445,7 +1447,7 @@ fn buildStreamRequest(allocator: std.mem.Allocator, exchange: stream_transport.E
 /// config.
 fn quicConfigFrom(cfg: Config) quic.config.Config {
     return .{
-        .max_udp_payload_size = std.math.clamp(cfg.max_datagram_size, quic.datagram.base_size, quic.datagram.max_size),
+        .max_send_udp_payload_size = std.math.clamp(cfg.max_datagram_size, quic.datagram.base_size, quic.datagram.max_size),
         .zero_rtt_enabled = zeroRttCarrierEnabled(cfg),
         .retry_policy = cfg.retry_policy,
         .migration_policy = if (cfg.connection_migration) .full else .nat_rebinding_only,
@@ -1756,17 +1758,17 @@ test "quicConfigFrom clamps datagram size into the work-buffer range" {
         .listen_host = "::",
         .quic_port = 443,
         .max_datagram_size = 512,
-    }).max_udp_payload_size);
+    }).max_send_udp_payload_size);
     // Above the 2048-byte work buffer snaps down.
     try testing.expectEqual(@as(u64, 2048), quicConfigFrom(.{
         .listen_host = "::",
         .quic_port = 443,
         .max_datagram_size = 9000,
-    }).max_udp_payload_size);
+    }).max_send_udp_payload_size);
     // An in-range value passes through, and default migration allows validated
     // same-IP NAT rebinding while still advertising disable_active_migration.
     const mid = quicConfigFrom(.{ .listen_host = "::", .quic_port = 443, .max_datagram_size = 1350 });
-    try testing.expectEqual(@as(u64, 1350), mid.max_udp_payload_size);
+    try testing.expectEqual(@as(u64, 1350), mid.max_send_udp_payload_size);
     try testing.expectEqual(quic.config.MigrationPolicy.nat_rebinding_only, mid.migration_policy);
     try testing.expectEqual(quic.config.RetryPolicy.off, mid.retry_policy);
     try testing.expectEqual(quic.config.MigrationPolicy.full, quicConfigFrom(.{
@@ -1786,10 +1788,29 @@ test "quicConfigFrom: the runtime default is the transport's own authoritative d
     // can drift from the transport's. Both come from `quic.datagram`.
     const runtime_default = Config{ .listen_host = "::", .quic_port = 443 };
     try testing.expectEqual(quic.datagram.base_size, runtime_default.max_datagram_size);
+    const mapped = quicConfigFrom(runtime_default);
+    try testing.expectEqual(
+        (quic.config.Config{}).max_send_udp_payload_size,
+        mapped.max_send_udp_payload_size,
+    );
+    // The advertised receive capacity is a property of the transport's
+    // buffers, not of this operator knob, so the knob must not move it.
     try testing.expectEqual(
         (quic.config.Config{}).max_udp_payload_size,
-        quicConfigFrom(runtime_default).max_udp_payload_size,
+        mapped.max_udp_payload_size,
     );
+    try testing.expectEqual(
+        quic.datagram.max_size,
+        quicConfigFrom(.{ .listen_host = "::", .quic_port = 443, .max_datagram_size = 1350 }).max_udp_payload_size,
+    );
+}
+
+test "http3 runtime: receive buffers match the advertised receive capacity" {
+    // The `max_udp_payload_size` this endpoint promises the peer must not
+    // exceed what the listener and connection can actually deprotect.
+    const advertised = (quic.config.Config{}).max_udp_payload_size;
+    try testing.expectEqual(@as(u64, quic.datagram.max_size), advertised);
+    try testing.expectEqual(quic.datagram.max_size, quic.connection.max_receive_datagram_size);
 }
 
 test "http3 runtime: spare CID route is registered before NEW_CONNECTION_ID is pollable" {

--- a/src/quic/config.zig
+++ b/src/quic/config.zig
@@ -73,12 +73,21 @@ pub const Config = struct {
     versions: VersionSet = .{},
     idle_timeout_ms: u64 = 30_000,
     active_connection_id_limit: u64 = 4,
-    /// The local bound on outbound UDP datagrams, also advertised to the peer
-    /// as the `max_udp_payload_size` transport parameter. `quic.datagram`
-    /// owns the authoritative default and the rule that combines this with the
-    /// peer's advertisement and the validated path size (#256-A); nothing
-    /// downstream should carry its own datagram-size default.
-    max_udp_payload_size: u64 = quic_datagram.base_size,
+    /// RFC 9000 §18.2: the largest UDP payload this endpoint is willing to
+    /// **receive**, advertised to the peer. It is endpoint receive capacity,
+    /// not path state, so it must not exceed the receive buffers the
+    /// implementation actually allocates — `validate()` enforces that against
+    /// `quic.datagram.max_size`, which is the same symbol those buffers are
+    /// sized from. Send-side limits live in `max_send_udp_payload_size` and
+    /// `quic.datagram.Limits`.
+    max_udp_payload_size: u64 = quic_datagram.max_size,
+    /// The sender's maximum datagram size for a new path: what this endpoint
+    /// assumes the path carries before anything has measured it. Defaults to
+    /// the RFC 9000 §14 floor, the only size every path must support. Raising
+    /// it asserts a path MTU rather than measuring one; #256-B replaces the
+    /// assertion with DPLPMTUD. Always additionally bounded by the peer's
+    /// advertised receive capacity.
+    max_send_udp_payload_size: u64 = quic_datagram.base_size,
     initial_max_data: u64 = 8 * 1024 * 1024,
     initial_max_stream_data_bidi_local: u64 = 1024 * 1024,
     initial_max_stream_data_bidi_remote: u64 = 1024 * 1024,
@@ -97,10 +106,11 @@ pub const Config = struct {
         if (self.versions.preferred() == null) return error.UnsupportedQuicVersion;
         if (self.idle_timeout_ms == 0) return error.InvalidIdleTimeout;
         if (self.active_connection_id_limit < 2) return error.InvalidActiveConnectionIdLimit;
-        // RFC 9000 §18.2 bounds on the advertised parameter. The emitted size
-        // is clamped further by `quic.datagram`; this only rejects values that
-        // are illegal to advertise at all.
-        if (self.max_udp_payload_size < quic_datagram.base_size or self.max_udp_payload_size > 65_527) return error.InvalidMaxUdpPayloadSize;
+        // Never advertise receive capacity the implementation cannot process:
+        // the ceiling here is the same symbol the receive scratch buffers are
+        // sized from, so the two cannot drift.
+        if (self.max_udp_payload_size < quic_datagram.base_size or self.max_udp_payload_size > quic_datagram.max_size) return error.InvalidMaxUdpPayloadSize;
+        if (self.max_send_udp_payload_size < quic_datagram.base_size or self.max_send_udp_payload_size > quic_datagram.max_size) return error.InvalidMaxSendUdpPayloadSize;
         if (self.initial_max_data == 0) return error.InvalidFlowControlWindow;
         if (self.initial_max_stream_data_bidi_local > self.initial_max_data) return error.InvalidFlowControlWindow;
         if (self.initial_max_stream_data_bidi_remote > self.initial_max_data) return error.InvalidFlowControlWindow;
@@ -203,7 +213,10 @@ test "default QUIC config maps to conservative transport parameters" {
     try std.testing.expect(!cfg.versions.supports(.v2));
     try std.testing.expectEqual(@as(u64, 30_000), params.max_idle_timeout_ms);
     try std.testing.expectEqual(@as(u64, 4), params.active_connection_id_limit);
-    try std.testing.expectEqual(@as(u64, 1200), params.max_udp_payload_size);
+    // The advertised parameter is receive capacity, so it matches the receive
+    // buffers the implementation allocates; the send side stays conservative.
+    try std.testing.expectEqual(@as(u64, quic_datagram.max_size), params.max_udp_payload_size);
+    try std.testing.expectEqual(@as(u64, quic_datagram.base_size), cfg.max_send_udp_payload_size);
     try std.testing.expect(params.disable_active_migration);
     try std.testing.expect(!cfg.zero_rtt_enabled);
     try std.testing.expectEqual(QpackMode.static_only, cfg.qpack.mode);
@@ -213,6 +226,11 @@ test "QUIC config validation rejects unsafe combinations" {
     try std.testing.expectError(error.UnsupportedQuicVersion, (Config{ .versions = .{ .v1 = false, .v2 = false } }).validate());
     try std.testing.expectError(error.InvalidActiveConnectionIdLimit, (Config{ .active_connection_id_limit = 1 }).validate());
     try std.testing.expectError(error.InvalidMaxUdpPayloadSize, (Config{ .max_udp_payload_size = 1199 }).validate());
+    // Advertising more than the implementation can actually receive is
+    // rejected rather than promised to the peer.
+    try std.testing.expectError(error.InvalidMaxUdpPayloadSize, (Config{ .max_udp_payload_size = quic_datagram.max_size + 1 }).validate());
+    try std.testing.expectError(error.InvalidMaxSendUdpPayloadSize, (Config{ .max_send_udp_payload_size = 1199 }).validate());
+    try std.testing.expectError(error.InvalidMaxSendUdpPayloadSize, (Config{ .max_send_udp_payload_size = quic_datagram.max_size + 1 }).validate());
     try std.testing.expectError(error.InvalidStreamLimit, (Config{ .initial_max_streams_bidi = max_initial_streams_transport_parameter + 1 }).validate());
     try std.testing.expectError(error.InvalidStreamLimit, (Config{ .initial_max_streams_uni = max_initial_streams_transport_parameter + 1 }).validate());
     try std.testing.expectError(error.InvalidFlowControlWindow, (Config{

--- a/src/quic/config.zig
+++ b/src/quic/config.zig
@@ -7,6 +7,7 @@
 
 const std = @import("std");
 const secrets = @import("crypto_secrets");
+const quic_datagram = @import("datagram.zig");
 
 pub const QuicVersion = enum(u32) {
     v1 = 0x00000001,
@@ -72,7 +73,12 @@ pub const Config = struct {
     versions: VersionSet = .{},
     idle_timeout_ms: u64 = 30_000,
     active_connection_id_limit: u64 = 4,
-    max_udp_payload_size: u64 = 1200,
+    /// The local bound on outbound UDP datagrams, also advertised to the peer
+    /// as the `max_udp_payload_size` transport parameter. `quic.datagram`
+    /// owns the authoritative default and the rule that combines this with the
+    /// peer's advertisement and the validated path size (#256-A); nothing
+    /// downstream should carry its own datagram-size default.
+    max_udp_payload_size: u64 = quic_datagram.base_size,
     initial_max_data: u64 = 8 * 1024 * 1024,
     initial_max_stream_data_bidi_local: u64 = 1024 * 1024,
     initial_max_stream_data_bidi_remote: u64 = 1024 * 1024,
@@ -91,7 +97,10 @@ pub const Config = struct {
         if (self.versions.preferred() == null) return error.UnsupportedQuicVersion;
         if (self.idle_timeout_ms == 0) return error.InvalidIdleTimeout;
         if (self.active_connection_id_limit < 2) return error.InvalidActiveConnectionIdLimit;
-        if (self.max_udp_payload_size < 1200 or self.max_udp_payload_size > 65_527) return error.InvalidMaxUdpPayloadSize;
+        // RFC 9000 §18.2 bounds on the advertised parameter. The emitted size
+        // is clamped further by `quic.datagram`; this only rejects values that
+        // are illegal to advertise at all.
+        if (self.max_udp_payload_size < quic_datagram.base_size or self.max_udp_payload_size > 65_527) return error.InvalidMaxUdpPayloadSize;
         if (self.initial_max_data == 0) return error.InvalidFlowControlWindow;
         if (self.initial_max_stream_data_bidi_local > self.initial_max_data) return error.InvalidFlowControlWindow;
         if (self.initial_max_stream_data_bidi_remote > self.initial_max_data) return error.InvalidFlowControlWindow;

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -3011,22 +3011,18 @@ pub const Connection = struct {
         self.next_pn[space_idx] = pn + 1;
 
         if (record.ack_eliciting) {
-            var tracked = true;
-            self.recovery.onPacketSent(.{
+            // Slot preflighted at the top, before the PATH_RESPONSE was
+            // dequeued or `needs_send` cleared.
+            self.recovery.onPacketSentAssumeCapacity(.{
                 .space = .application,
                 .packet_number = pn,
                 .time_sent_us = now_us,
                 .size = total,
                 .ack_eliciting = true,
                 .in_flight = true,
-            }) catch {
-                // Preflighted above; charge the window regardless so this
-                // cannot become a congestion-control bypass.
-                self.recovery.congestion.onPacketSent(total);
-                tracked = false;
-            };
+            });
             self.last_ack_eliciting_sent_us[space_idx] = now_us;
-            if (tracked) publishSentRecord(self, &record);
+            publishSentRecord(self, &record);
         }
         self.paths.recordSentOnPath(path, total);
         self.metrics.packets_sent += 1;
@@ -3062,7 +3058,18 @@ pub const Connection = struct {
         ctx: BuildContext,
     ) ?BuiltPacket {
         const space_idx = spaceIndex(space);
-        const probe = self.probes_pending[space_idx] > 0;
+        // Recovery's tracker is bounded, and an in-flight packet it cannot
+        // track escapes loss detection *and* leaves bytes in
+        // `bytes_in_flight` that nothing can ever remove. Ordinary traffic
+        // stops short of a reserve; traffic recovery cannot defer draws on it.
+        const can_track_ordinary = self.recovery.canTrackPacket();
+        const can_track_recovery = self.recovery.canTrackRecoveryPacket();
+        // RFC 9002 §7.5 exempts a PTO probe from the congestion gate but still
+        // counts it in flight, so the probe needs a slot like anything else.
+        // Without one it stays owed (`probes_pending` is untouched) and is
+        // retried once an ACK or loss frees capacity — delayed, never
+        // untracked.
+        const probe = self.probes_pending[space_idx] > 0 and can_track_recovery;
 
         // Congestion gate: in-flight bytes need window; pure ACK packets and
         // PTO probes are exempt (RFC 9002 §7, §6.2.4).
@@ -3071,8 +3078,7 @@ pub const Connection = struct {
         // would escape both loss detection and the congestion window, so
         // preflight a slot here — before any frame is dequeued — and fall back
         // to ACK-only output rather than sending something uncharged.
-        const can_track = self.recovery.canTrackPacket();
-        const can_send_data = can_track and (probe or
+        const can_send_data = can_track_ordinary and (probe or
             cwnd_room >= self.recovery.congestion.max_datagram_size / 2 or
             self.recovery.congestion.bytes_in_flight == 0);
 
@@ -3095,6 +3101,10 @@ pub const Connection = struct {
         if (!probe and initial_pad_target > cwnd_room and self.recovery.congestion.bytes_in_flight != 0) {
             return null;
         }
+        // PADDING alone makes a packet in flight (RFC 9002 §2), so a packet
+        // that will be padded needs a tracker slot even when everything it
+        // carries would otherwise be exempt — an ACK-only Initial included.
+        if (initial_pad_target > 0 and !can_track_recovery) return null;
 
         // Same rule for a PATH_RESPONSE riding on the active path: it forces
         // the datagram to 1200 (§8.2.1-2). RFC 9000 §8.2 explicitly permits
@@ -3102,9 +3112,9 @@ pub const Connection = struct {
         // padded size does not fit, the response stays queued rather than
         // being sent uncharged.
         const path_response_final: usize = min_initial_datagram -| ctx.datagram_so_far;
-        const allow_path_response = probe or
+        const allow_path_response = can_track_recovery and (probe or
             path_response_final <= cwnd_room or
-            self.recovery.congestion.bytes_in_flight == 0;
+            self.recovery.congestion.bytes_in_flight == 0);
 
         var want_ack = self.ack_needed[space_idx];
         if (space == .application and want_ack) {
@@ -3120,7 +3130,7 @@ pub const Connection = struct {
             .application => !self.crypto_tx[2].pending.isEmpty(),
         };
         const has_app = space == .application and self.hasAppContent();
-        if (!want_ack and !has_crypto and !(has_app and can_send_data) and !(probe and can_track)) return null;
+        if (!want_ack and !has_crypto and !(has_app and can_send_data) and !probe) return null;
         if ((has_crypto or has_app) and !can_send_data and !want_ack and !probe) return null;
 
         // Header sizing.
@@ -3307,24 +3317,22 @@ pub const Connection = struct {
         // exempt: the peer never acknowledges it, so tracking it would only
         // consume tracker slots.
         if (recordIsInFlight(record)) {
-            var tracked = true;
-            self.recovery.onPacketSent(.{
+            // Every path that can reach here preflighted a tracker slot before
+            // committing a frame — `can_track_ordinary` for ordinary content,
+            // `can_track_recovery` for probes and mandatory padding — so this
+            // cannot fail. Asserting beats a fallback branch: there is no safe
+            // way to handle exhaustion once the frames are dequeued and the
+            // packet is sealed.
+            self.recovery.onPacketSentAssumeCapacity(.{
                 .space = space,
                 .packet_number = pn,
                 .time_sent_us = now_us,
                 .size = total,
                 .ack_eliciting = record.ack_eliciting,
                 .in_flight = true,
-            }) catch {
-                // `can_track` preflighted a slot before any frame was
-                // dequeued, so this is unreachable in practice. Charge the
-                // bytes anyway rather than letting an in-flight packet escape
-                // the congestion window.
-                self.recovery.congestion.onPacketSent(total);
-                tracked = false;
-            };
+            });
             if (record.ack_eliciting) self.last_ack_eliciting_sent_us[space_idx] = now_us;
-            if (tracked) publishSentRecord(self, &record);
+            publishSentRecord(self, &record);
         }
         if (record.has_new_connection_id) {
             if (self.local_cids) |*registry| registry.markAdvertised(record.carried_new_connection_id.sequence) catch {};
@@ -8316,4 +8324,181 @@ test "driver: a saturated recovery tracker backpressures instead of sending untr
     try testing.expect(pair.server.recovery.tracker.count > tracked_before);
     try testing.expect(congestion.bytes_in_flight >= in_flight_before + sent.bytes.len);
     try testing.expect(pair.server.next_pn[Connection.spaceIndex(.application)] > pn_before);
+}
+
+/// Occupy tracker slots with zero-size entries in a space the caller is not
+/// otherwise using, so capacity can be exhausted without perturbing congestion
+/// accounting. Returns how many were added.
+fn fillTracker(conn: *Connection, until_recovery_reserve: bool) !usize {
+    var added: usize = 0;
+    while (if (until_recovery_reserve) conn.recovery.canTrackRecoveryPacket() else conn.recovery.canTrackPacket()) {
+        try conn.recovery.tracker.onPacketSent(.{
+            .space = .initial,
+            .packet_number = 900_000 + added,
+            .time_sent_us = 1,
+            .size = 0,
+        });
+        added += 1;
+    }
+    return added;
+}
+
+/// Drive `conn` to its next deadline until a PTO arms probes in app space.
+fn fireApplicationPto(conn: *Connection, now_us: *u64) !void {
+    var rounds: usize = 0;
+    while (rounds < 8) : (rounds += 1) {
+        const deadline = conn.nextTimeoutUs() orelse return error.TestExpectedEqual;
+        now_us.* = @max(now_us.*, deadline);
+        conn.onTimeout(now_us.*);
+        if (conn.probes_pending[Connection.spaceIndex(.application)] > 0) return;
+    }
+    return error.TestExpectedEqual;
+}
+
+test "driver: a PTO probe at the ordinary tracking limit is emitted tracked and charged" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.initWithConfigs(allocator, .{}, .{ .max_send_udp_payload_size = 1452 });
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const sid = try openServerResponseStream(pair);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x63} ** 4096, false);
+    var out: [max_datagram_size_ceiling]u8 = undefined;
+    while (pair.server.pollTransmitOnPath(&out, pair.now_us)) |_| {
+        pair.now_us += 500;
+    }
+    const congestion = &pair.server.recovery.congestion;
+    congestion.congestion_window = 1 << 24;
+
+    // Ordinary traffic is at its backpressure threshold; the recovery reserve
+    // is untouched.
+    _ = try fillTracker(pair.server, false);
+    try testing.expect(!pair.server.recovery.canTrackPacket());
+    try testing.expect(pair.server.recovery.canTrackRecoveryPacket());
+
+    // More stream data cannot go out ...
+    _ = try pair.server.writeStream(sid, &[_]u8{0x64} ** 4096, false);
+    while (pair.server.pollTransmitOnPath(&out, pair.now_us)) |t| {
+        try testing.expect(t.bytes.len < base_datagram_size);
+        pair.now_us += 500;
+    }
+
+    // ... but a real PTO still gets its probe out, tracked and charged
+    // (RFC 9002 §6.2.4 requires the probe; §7.5 keeps it in flight).
+    try fireApplicationPto(pair.server, &pair.now_us);
+    const tracked_before = pair.server.recovery.tracker.count;
+    const in_flight_before = congestion.bytes_in_flight;
+    const probe = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
+    try testing.expect(pair.server.recovery.tracker.count > tracked_before);
+    try testing.expectEqual(in_flight_before + probe.bytes.len, congestion.bytes_in_flight);
+
+    // The probe's bytes are removable: the peer's ACK takes them back out,
+    // which an untracked packet could never allow.
+    const ingress = quic_path.PathKey{ .local = probe.path.remote, .remote = probe.path.local };
+    try pair.client.ingestOnPath(probe.bytes, ingress, TestPair.test_challenge_entropy, pair.now_us);
+    // Past the delayed-ACK timer so a single ack-eliciting packet is enough.
+    pair.now_us += 2 * local_max_ack_delay_us;
+    var reply: [max_datagram_size_ceiling]u8 = undefined;
+    while (pair.client.pollTransmitOnPath(&reply, pair.now_us)) |t| {
+        const back = quic_path.PathKey{ .local = t.path.remote, .remote = t.path.local };
+        try pair.server.ingestOnPath(t.bytes, back, TestPair.test_challenge_entropy, pair.now_us);
+        pair.now_us += 500;
+    }
+    try testing.expect(congestion.bytes_in_flight < in_flight_before + probe.bytes.len);
+}
+
+test "driver: repeated PTOs at capacity stay tracked, then wait rather than go untracked" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.initWithConfigs(allocator, .{}, .{ .max_send_udp_payload_size = 1452 });
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const sid = try openServerResponseStream(pair);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x65} ** 4096, false);
+    var out: [max_datagram_size_ceiling]u8 = undefined;
+    while (pair.server.pollTransmitOnPath(&out, pair.now_us)) |_| {
+        pair.now_us += 500;
+    }
+    pair.server.recovery.congestion.congestion_window = 1 << 24;
+    _ = try fillTracker(pair.server, false);
+
+    // The reserve is not a single-probe illusion: every probe it covers is
+    // emitted with a tracker entry and charged to the window.
+    var probes: usize = 0;
+    while (probes < recovery.reserved_tracked_packets) : (probes += 1) {
+        if (!pair.server.recovery.canTrackRecoveryPacket()) break;
+        pair.server.probes_pending[Connection.spaceIndex(.application)] = 1;
+        const before = pair.server.recovery.tracker.count;
+        const in_flight_before = pair.server.recovery.congestion.bytes_in_flight;
+        const probe = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse break;
+        try testing.expectEqual(before + 1, pair.server.recovery.tracker.count);
+        try testing.expectEqual(
+            in_flight_before + probe.bytes.len,
+            pair.server.recovery.congestion.bytes_in_flight,
+        );
+        pair.now_us += 500;
+    }
+    try testing.expect(probes > 1);
+
+    // Once even the reserve is spent, the probe waits: it is still owed, and
+    // nothing untracked leaves.
+    _ = try fillTracker(pair.server, true);
+    try testing.expect(!pair.server.recovery.canTrackRecoveryPacket());
+    pair.server.probes_pending[Connection.spaceIndex(.application)] = 1;
+    const saturated_tracked = pair.server.recovery.tracker.count;
+    const saturated_in_flight = pair.server.recovery.congestion.bytes_in_flight;
+    while (pair.server.pollTransmitOnPath(&out, pair.now_us)) |t| {
+        try testing.expect(t.bytes.len < base_datagram_size);
+        pair.now_us += 500;
+    }
+    try testing.expectEqual(saturated_tracked, pair.server.recovery.tracker.count);
+    try testing.expectEqual(saturated_in_flight, pair.server.recovery.congestion.bytes_in_flight);
+    try testing.expect(pair.server.probes_pending[Connection.spaceIndex(.application)] > 0);
+
+    // Freeing capacity releases the owed probe.
+    _ = pair.server.recovery.tracker.dropSpace(.initial);
+    const freed_tracked = pair.server.recovery.tracker.count;
+    const released = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
+    try testing.expect(released.bytes.len > 0);
+    try testing.expect(pair.server.recovery.tracker.count > freed_tracked);
+}
+
+test "driver: a fully saturated tracker never seals a padded in-flight packet" {
+    const allocator = testing.allocator;
+    // Every Initial-bearing datagram is padded to 1200 and is therefore in
+    // flight (RFC 9002 §2) whatever it carries — including an ACK-only one.
+    // With no trackable slot at all, a whole handshake must produce no such
+    // datagram. `onPacketSentAssumeCapacity` asserts the same invariant from
+    // the other side for every packet any test in this file builds.
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+
+    _ = try fillTracker(pair.client, true);
+    _ = try fillTracker(pair.server, true);
+    try testing.expect(!pair.client.recovery.canTrackRecoveryPacket());
+    try testing.expect(!pair.server.recovery.canTrackRecoveryPacket());
+
+    const client_in_flight = pair.client.recovery.congestion.bytes_in_flight;
+    const server_in_flight = pair.server.recovery.congestion.bytes_in_flight;
+
+    var out: [max_datagram_size_ceiling]u8 = undefined;
+    var rounds: usize = 0;
+    while (rounds < 8) : (rounds += 1) {
+        while (pair.client.pollTransmitOnPath(&out, pair.now_us)) |t| {
+            try testing.expect(t.bytes.len < min_initial_datagram);
+            pair.now_us += 500;
+        }
+        while (pair.server.pollTransmitOnPath(&out, pair.now_us)) |t| {
+            try testing.expect(t.bytes.len < min_initial_datagram);
+            pair.now_us += 500;
+        }
+    }
+    try testing.expectEqual(client_in_flight, pair.client.recovery.congestion.bytes_in_flight);
+    try testing.expectEqual(server_in_flight, pair.server.recovery.congestion.bytes_in_flight);
+
+    // With capacity back, the padded Initial flows normally.
+    _ = pair.client.recovery.tracker.dropSpace(.initial);
+    _ = pair.server.recovery.tracker.dropSpace(.initial);
+    try pair.pump();
+    try testing.expect(pair.server.isEstablished());
 }

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -24,6 +24,7 @@ const std = @import("std");
 const crypto_secrets = @import("crypto_secrets");
 const varint = @import("quic_varint");
 const config = @import("config.zig");
+const quic_datagram = @import("datagram.zig");
 const packet = @import("packet.zig");
 const frame = @import("frame.zig");
 const tls_adapter = @import("tls_adapter.zig");
@@ -56,13 +57,19 @@ pub const State = enum {
     closed,
 };
 
-/// The datagram size this driver sends. Conservative (RFC 9000 §14.1 minimum)
-/// until DPLPMTUD lands under #256.
-pub const max_datagram_size: usize = recovery.max_datagram_size;
+/// The datagram size every QUIC path must support (RFC 9000 §14), and the
+/// floor of this driver's effective send cap. What a connection actually
+/// emits is `Connection.effectiveMaxDatagramSize()`, which combines the local
+/// config, the peer's advertised maximum, and the validated path size (#256-A).
+pub const base_datagram_size: usize = quic_datagram.base_size;
+/// Hard ceiling on any datagram this driver emits, and the size of the
+/// per-packet plaintext scratch buffers below. An `out` buffer larger than
+/// this is simply not used past the effective cap.
+pub const max_datagram_size_ceiling: usize = quic_datagram.max_size;
 pub const max_application_crypto_outstanding: usize = 2 * tls_core.tls13_transport.max_emitted_new_session_ticket_message_len;
-const min_application_crypto_payload: usize = max_datagram_size / 2;
+const min_application_crypto_payload: usize = base_datagram_size / 2;
 /// RFC 9000 §14.1: datagrams carrying Initial packets are padded to 1200.
-pub const min_initial_datagram: usize = 1200;
+pub const min_initial_datagram: usize = base_datagram_size;
 
 /// Hard bound on bytes buffered per stream for transmission (unsent +
 /// unacked). `writeStream` accepts partial writes beyond it.
@@ -1086,6 +1093,32 @@ pub const Connection = struct {
 
     pub fn peerTransportParameters(self: *const Connection) ?config.TransportParameters {
         return self.adapter.peerTransportParameters();
+    }
+
+    /// The bounds that decide how large an outbound datagram may be (#256-A).
+    /// Derived on demand rather than cached so a peer's transport parameters
+    /// take effect the moment they are authenticated, with no separate
+    /// invalidation step to get wrong.
+    pub fn datagramLimits(self: *const Connection) quic_datagram.Limits {
+        return .{
+            .local_max = self.cfg.max_udp_payload_size,
+            .peer_max = if (self.adapter.peerTransportParameters()) |peer|
+                peer.max_udp_payload_size
+            else
+                null,
+            // #256-B fills this in from per-path DPLPMTUD state. Until then
+            // the locally configured maximum is the operator's path assertion,
+            // and it defaults to the RFC 9000 §14 floor.
+            .validated_path_max = null,
+        };
+    }
+
+    /// The one authoritative cap on an ordinary outbound UDP datagram: the
+    /// smallest of the locally configured maximum, the peer's advertised
+    /// `max_udp_payload_size` once authenticated, and the validated path size.
+    /// Never below `base_datagram_size`, so Initial padding always fits.
+    pub fn effectiveMaxDatagramSize(self: *const Connection) usize {
+        return self.datagramLimits().effective();
     }
 
     pub fn closeInfo(self: *const Connection) ?CloseInfo {
@@ -2719,7 +2752,7 @@ pub const Connection = struct {
     /// tried first so a probe is never starved behind ordinary traffic.
     pub fn pollTransmitOnPath(self: *Connection, out: []u8, now_us: u64) ?Transmit {
         if (self.state_ == .closed or self.state_ == .draining) return null;
-        if (out.len < max_datagram_size) return null;
+        if (out.len < base_datagram_size) return null;
 
         if (self.state_ == .closing) {
             if (!self.close_needs_send) return null;
@@ -2748,7 +2781,11 @@ pub const Connection = struct {
             self.ack_eliciting_since_ack[2] = ack_eliciting_threshold;
         }
 
-        const budget = @min(out.len, max_datagram_size);
+        // #256-A: the single cap every ordinary outbound datagram respects.
+        // Coalescing below only ever fills `out[0..budget]`, so no level can
+        // push the datagram past the local config, the peer's advertised
+        // `max_udp_payload_size`, or the validated path size.
+        const budget = @min(out.len, self.effectiveMaxDatagramSize());
         var datagram_len: usize = 0;
         var has_initial = false;
         var sent_ack_eliciting = false;
@@ -2835,21 +2872,26 @@ pub const Connection = struct {
     /// budget. Never carries ACK/STREAM/CRYPTO/flow-control/CID-management
     /// content — that stays exclusively on the active path until promotion.
     fn buildCandidatePacket(self: *Connection, path: quic_path.PathKey, out: []u8, now_us: u64) ?Transmit {
-        if (out.len < max_datagram_size) return null;
+        if (out.len < base_datagram_size) return null;
         var keys = (self.adapter.protectionKeys(.application, .write) catch unreachable) orelse return null;
         defer keys.deinit();
 
         const remaining = self.paths.remainingOnPath(path);
         if (remaining == 0) return null;
 
+        // #256-A: candidate-path probes obey the same effective cap as
+        // ordinary traffic. They are padded to `min_initial_datagram`, which
+        // the cap's floor guarantees room for.
+        const budget = @min(out.len, self.effectiveMaxDatagramSize());
+
         const space_idx = spaceIndex(.application);
         const pn = self.next_pn[space_idx];
         const pn_len: u3 = packet.packetNumberLength(pn, self.largest_peer_acked[space_idx]);
         const pn_offset = packet.writeShortHeader(self.peer_cid.slice(), self.adapter.applicationWriteKeyPhase(), pn_len, out) catch return null;
 
-        const max_packet = @min(out.len, @as(usize, @intCast(@min(@as(u64, out.len), remaining))));
+        const max_packet: usize = @intCast(@min(@as(u64, budget), remaining));
         if (max_packet <= pn_offset + pn_len + aead_tag_len + 16) return null;
-        var plain: [max_datagram_size]u8 = undefined;
+        var plain: [max_datagram_size_ceiling]u8 = undefined;
         const plain_budget = @min(plain.len, max_packet - pn_offset - pn_len - aead_tag_len);
         var plain_len: usize = 0;
         var record = SentRecord{ .space = .application, .packet_number = pn, .ack_eliciting = false };
@@ -2972,7 +3014,7 @@ pub const Connection = struct {
         // Congestion gate: in-flight (ack-eliciting) bytes need window; pure
         // ACK packets and PTO probes are exempt (RFC 9002 §7, §6.2.4).
         const cwnd_room = self.recovery.congestion.congestion_window -| self.recovery.congestion.bytes_in_flight;
-        const can_send_data = probe or cwnd_room >= max_datagram_size / 2 or
+        const can_send_data = probe or cwnd_room >= recovery.max_datagram_size / 2 or
             self.recovery.congestion.bytes_in_flight == 0;
 
         // Anti-amplification gate applies to every byte a server sends before
@@ -3022,7 +3064,7 @@ pub const Connection = struct {
         // Available plaintext room in this packet.
         const max_packet = @min(out.len, @as(usize, @intCast(@min(@as(u64, out.len), amp_room -| ctx.datagram_so_far))));
         if (max_packet <= pn_offset + pn_len + aead_tag_len + 16) return null;
-        var plain: [max_datagram_size]u8 = undefined;
+        var plain: [max_datagram_size_ceiling]u8 = undefined;
         const plain_budget = @min(plain.len, max_packet - pn_offset - pn_len - aead_tag_len);
         var plain_len: usize = 0;
         var record = SentRecord{
@@ -3860,6 +3902,14 @@ const TestPair = struct {
     const test_challenge_entropy = [_]u8{0x5a} ** quic_path.path_challenge_len;
 
     fn init(allocator: std.mem.Allocator) !*TestPair {
+        return initWithConfigs(allocator, .{}, .{});
+    }
+
+    fn initWithConfigs(
+        allocator: std.mem.Allocator,
+        client_config: config.Config,
+        server_config: config.Config,
+    ) !*TestPair {
         const pair = try allocator.create(TestPair);
         const client_crypto_provider = pair.client_provider_storage.init(0x442_c);
         const server_crypto_provider = pair.server_provider_storage.init(0x442_5);
@@ -3883,6 +3933,7 @@ const TestPair = struct {
         errdefer allocator.destroy(pair);
         pair.client = try Connection.init(allocator, .{
             .role = .client,
+            .config = client_config,
             .local_cid = &client_cid,
             .original_destination_cid = &odcid,
             .initial_secret_dcid = &odcid,
@@ -3895,6 +3946,7 @@ const TestPair = struct {
         errdefer pair.client.deinit();
         pair.server = try Connection.init(allocator, .{
             .role = .server,
+            .config = server_config,
             .local_cid = &odcid,
             .original_destination_cid = &odcid,
             .initial_secret_dcid = &odcid,
@@ -4654,7 +4706,7 @@ test "driver: stream scheduling hint sends lower urgency first" {
     _ = try pair.server.writeStream(high, "less urgent response", false);
     _ = try pair.server.writeStream(low, "more urgent response", false);
 
-    var out: [max_datagram_size]u8 = undefined;
+    var out: [max_datagram_size_ceiling]u8 = undefined;
     _ = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
     const record = lastSentRecordWithStreams(pair.server) orelse return error.TestExpectedEqual;
     try testing.expect(record.stream_count > 0);
@@ -4678,7 +4730,7 @@ test "driver: equal urgency stream scheduling gives peers progress" {
     _ = try pair.server.writeStream(first, "first response chunk", false);
     _ = try pair.server.writeStream(second, "second response chunk", false);
 
-    var out: [max_datagram_size]u8 = undefined;
+    var out: [max_datagram_size_ceiling]u8 = undefined;
     _ = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
     const record = lastSentRecordWithStreams(pair.server) orelse return error.TestExpectedEqual;
     try testing.expect(streamRecordContains(record.*, first));
@@ -4700,12 +4752,12 @@ test "driver: equal urgency mixed incremental streams both make repeated progres
     try pair.server.setStreamSchedulingHint(incremental, .{ .urgency = 2, .incremental = true });
     try pair.server.setStreamSchedulingHint(non_incremental, .{ .urgency = 2, .incremental = false });
 
-    const large_incremental = [_]u8{'i'} ** (max_datagram_size * 3);
-    const large_non_incremental = [_]u8{'n'} ** (max_datagram_size * 3);
+    const large_incremental = [_]u8{'i'} ** (base_datagram_size * 3);
+    const large_non_incremental = [_]u8{'n'} ** (base_datagram_size * 3);
     _ = try pair.server.writeStream(incremental, &large_incremental, false);
     _ = try pair.server.writeStream(non_incremental, &large_non_incremental, false);
 
-    var out: [max_datagram_size]u8 = undefined;
+    var out: [max_datagram_size_ceiling]u8 = undefined;
     var incremental_records: usize = 0;
     var non_incremental_records: usize = 0;
     var polls: usize = 0;
@@ -6258,14 +6310,14 @@ test "driver: maximum NewSessionTicket survives real loss reordering PTO and ACK
         .issued_at_unix_ms = 10,
     }, limits);
     defer server_state.deinit();
-    try testing.expect(pair.server.crypto_tx[2].data.items.len > max_datagram_size);
+    try testing.expect(pair.server.crypto_tx[2].data.items.len > base_datagram_size);
 
     var datagrams = std.ArrayList([]u8).empty;
     defer {
         for (datagrams.items) |copy| allocator.free(copy);
         datagrams.deinit(allocator);
     }
-    var buf: [max_datagram_size]u8 = undefined;
+    var buf: [max_datagram_size_ceiling]u8 = undefined;
     while (pair.server.pollTransmitOnPath(&buf, pair.now_us)) |t| {
         const copy = try allocator.dupe(u8, t.bytes);
         errdefer allocator.free(copy);
@@ -7592,7 +7644,7 @@ test "driver: 1-RTT packets are dropped before deprotection until TLS handshake 
 
     const id = try pair.client.openStream(.bidi);
     try testing.expectEqual(@as(usize, 5), try pair.client.writeStream(id, "hello", false));
-    var datagram: [max_datagram_size]u8 = undefined;
+    var datagram: [max_datagram_size_ceiling]u8 = undefined;
     const one_rtt = pair.client.pollTransmitOnPath(&datagram, pair.now_us) orelse return error.TestExpectedEqual;
 
     const received_before = pair.server.metrics.packets_received;
@@ -7717,4 +7769,157 @@ test "a real Connection closes with handshake_failure when the server has no app
 
 test {
     std.testing.refAllDecls(@This());
+}
+
+// ---------------------------------------------------------------------------
+// #256-A: the effective outbound datagram cap.
+// ---------------------------------------------------------------------------
+
+const EmittedDatagrams = struct {
+    count: usize = 0,
+    largest: usize = 0,
+    total: usize = 0,
+};
+
+/// Drain everything `conn` will send right now, advancing `now_us` the way
+/// `TestPair.pump` does, and report what came out. The `out` buffer is
+/// deliberately the driver's ceiling rather than the effective cap, so a
+/// datagram that overran the cap would be visible here instead of being
+/// silently clipped by a too-small caller buffer.
+fn drainTransmits(conn: *Connection, now_us: *u64) EmittedDatagrams {
+    var seen = EmittedDatagrams{};
+    var out: [max_datagram_size_ceiling]u8 = undefined;
+    while (conn.pollTransmitOnPath(&out, now_us.*)) |t| {
+        seen.count += 1;
+        seen.largest = @max(seen.largest, t.bytes.len);
+        seen.total += t.bytes.len;
+        now_us.* += 500;
+    }
+    return seen;
+}
+
+/// A client-opened bidi stream, established and known to both sides, ready
+/// for the server to write a response the size of which the test controls.
+fn openServerResponseStream(pair: *TestPair) !StreamId {
+    const sid = try pair.client.openStream(.bidi);
+    _ = try pair.client.writeStream(sid, "request", false);
+    try pair.pump();
+    return sid;
+}
+
+test "driver: a raised local maximum is enforced by the datagrams actually emitted" {
+    const allocator = testing.allocator;
+    const raised = config.Config{ .max_udp_payload_size = 1452 };
+    var pair = try TestPair.initWithConfigs(allocator, raised, raised);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    try testing.expectEqual(@as(usize, 1452), pair.server.effectiveMaxDatagramSize());
+
+    const sid = try openServerResponseStream(pair);
+    const payload = [_]u8{0xab} ** (16 * 1024);
+    _ = try pair.server.writeStream(sid, &payload, false);
+
+    const seen = drainTransmits(pair.server, &pair.now_us);
+    try testing.expect(seen.count > 1);
+    // The knob is real: datagrams grew past the RFC floor ...
+    try testing.expect(seen.largest > base_datagram_size);
+    // ... but never past what was configured.
+    try testing.expect(seen.largest <= 1452);
+}
+
+test "driver: the peer's advertised maximum lowers the effective cap" {
+    const allocator = testing.allocator;
+    // Server configured high, client advertising the floor: the smaller of
+    // the two wins, so a larger local setting never overrides a smaller peer
+    // limit.
+    var pair = try TestPair.initWithConfigs(
+        allocator,
+        .{ .max_udp_payload_size = base_datagram_size },
+        .{ .max_udp_payload_size = max_datagram_size_ceiling },
+    );
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    try testing.expectEqual(base_datagram_size, pair.server.effectiveMaxDatagramSize());
+    try testing.expectEqual(
+        @as(u64, base_datagram_size),
+        pair.server.peerTransportParameters().?.max_udp_payload_size,
+    );
+
+    const sid = try openServerResponseStream(pair);
+    const payload = [_]u8{0xcd} ** (16 * 1024);
+    _ = try pair.server.writeStream(sid, &payload, false);
+
+    const seen = drainTransmits(pair.server, &pair.now_us);
+    try testing.expect(seen.count > 1);
+    try testing.expect(seen.largest <= base_datagram_size);
+}
+
+test "driver: the cap stays at the floor until the peer's transport parameters arrive" {
+    const allocator = testing.allocator;
+    const raised = config.Config{ .max_udp_payload_size = max_datagram_size_ceiling };
+    var pair = try TestPair.initWithConfigs(allocator, raised, raised);
+    defer pair.deinit(allocator);
+
+    // Nothing is authenticated yet, so the local maximum must not raise the
+    // cap, and the client's first Initial datagram is still padded to exactly
+    // the RFC 9000 §14.1 minimum rather than to the configured maximum.
+    try testing.expectEqual(base_datagram_size, pair.client.effectiveMaxDatagramSize());
+    var out: [max_datagram_size_ceiling]u8 = undefined;
+    const initial = pair.client.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
+    try testing.expectEqual(min_initial_datagram, initial.bytes.len);
+
+    // Hand that same Initial on so the handshake still completes, then the
+    // authenticated peer parameters let the configured maximum take effect.
+    const ingress = quic_path.PathKey{ .local = initial.path.remote, .remote = initial.path.local };
+    try pair.server.ingestOnPath(initial.bytes, ingress, TestPair.test_challenge_entropy, pair.now_us);
+    pair.now_us += 500;
+    try pair.pump();
+    try testing.expectEqual(max_datagram_size_ceiling, pair.client.effectiveMaxDatagramSize());
+}
+
+test "driver: a raised local maximum does not widen the anti-amplification budget" {
+    const allocator = testing.allocator;
+    const raised = config.Config{ .max_udp_payload_size = max_datagram_size_ceiling };
+    var pair = try TestPair.initWithConfigs(allocator, raised, raised);
+    defer pair.deinit(allocator);
+
+    var received: usize = 0;
+    var buf: [max_datagram_size_ceiling]u8 = undefined;
+    while (pair.client.pollTransmitOnPath(&buf, pair.now_us)) |t| {
+        const ingress = quic_path.PathKey{ .local = t.path.remote, .remote = t.path.local };
+        try pair.server.ingestOnPath(t.bytes, ingress, TestPair.test_challenge_entropy, pair.now_us);
+        received += t.bytes.len;
+        pair.now_us += 500;
+    }
+    try testing.expect(received > 0);
+
+    const seen = drainTransmits(pair.server, &pair.now_us);
+    try testing.expect(seen.count > 0);
+    try testing.expect(seen.total <= 3 * received);
+}
+
+test "driver: raising the cap leaves packet-number and congestion accounting intact" {
+    const allocator = testing.allocator;
+    const raised = config.Config{ .max_udp_payload_size = 1452 };
+    var pair = try TestPair.initWithConfigs(allocator, raised, raised);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const sid = try openServerResponseStream(pair);
+    const payload = [_]u8{0xef} ** (16 * 1024);
+    _ = try pair.server.writeStream(sid, &payload, false);
+
+    const pn_before = pair.server.next_pn[Connection.spaceIndex(.application)];
+    const seen = drainTransmits(pair.server, &pair.now_us);
+    const pn_after = pair.server.next_pn[Connection.spaceIndex(.application)];
+
+    // Only application keys remain after the handshake, so each datagram
+    // carries exactly one packet and consumes exactly one packet number.
+    try testing.expectEqual(seen.count, pn_after - pn_before);
+    // Congestion control, not the datagram size, still bounds what goes out:
+    // the last packet may straddle the window, nothing beyond it may.
+    const congestion = pair.server.recovery.congestion;
+    try testing.expect(congestion.bytes_in_flight <= congestion.congestion_window + seen.largest);
 }

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -767,26 +767,37 @@ fn wipeSentRecordTokens(records: []SentRecord) void {
     for (records) |*record| wipeSentRecordToken(record);
 }
 
-/// Publish `source` (a function-local `SentRecord` about to be sealed and
-/// sent) into `self.sent_records` by writing directly into the reserved
-/// destination slot, rather than passing it by value into
-/// `ArrayList.append` — which would create an unowned intermediate copy of
-/// any carried reset token. Capacity is always available here: every call
-/// site only reaches this after `self.recovery.onPacketSent` accepted the
-/// packet, and that tracker is itself bounded by `recovery.max_tracked_packets`
-/// — the same bound `init()` reserves `sent_records`' capacity to once, up
-/// front.
+/// Grow `sent_records` without freeing a backing allocation that may contain a
+/// copied stateless-reset token before scrubbing it. Ordinary traffic remains
+/// inside the fixed capacity reserved at init; only required recovery overflow
+/// uses this path.
+fn ensureSentRecordCapacity(self: *Connection, needed: usize) !void {
+    if (self.sent_records.capacity >= needed) return;
+    const doubled = self.sent_records.capacity *| 2;
+    const new_capacity = @max(needed, @max(doubled, recovery.max_tracked_packets));
+    const replacement = try self.allocator.alloc(SentRecord, new_capacity);
+    const old_len = self.sent_records.items.len;
+    @memcpy(replacement[0..old_len], self.sent_records.items);
+
+    if (self.sent_records.capacity > 0) {
+        crypto_secrets.secureZero(std.mem.sliceAsBytes(self.sent_records.allocatedSlice()));
+        self.allocator.free(self.sent_records.allocatedSlice());
+    }
+    self.sent_records.items = replacement[0..old_len];
+    self.sent_records.capacity = replacement.len;
+}
+
+/// Reserve both recovery representations before dequeuing any frame. If OOM
+/// prevents either reservation, the required packet stays owed and no semantic
+/// state has been committed.
+fn ensureRecoveryTrackingCapacity(self: *Connection) bool {
+    self.recovery.ensureRecoveryPacketCapacity(self.allocator, 1) catch return false;
+    ensureSentRecordCapacity(self, self.sent_records.items.len + 1) catch return false;
+    return self.recovery.canTrackRecoveryPacket();
+}
+
 fn publishSentRecord(self: *Connection, source: *const SentRecord) void {
-    // Real traffic can never exceed capacity here: `sent_records` only ever
-    // grows in lockstep with `self.recovery.tracker` (both gated by
-    // `onPacketSent`) and shrinks in lockstep with it (ACK/loss processing
-    // remove from both together), and the tracker is bounded by the same
-    // `recovery.max_tracked_packets` this reserves capacity to. If that ever
-    // desyncs, degrade to an untracked send — like recovery-tracker
-    // exhaustion itself, just above — rather than growing the backing
-    // allocation and reopening the unwiped-growth path capacity reservation
-    // exists to close.
-    if (self.sent_records.items.len == self.sent_records.capacity) return;
+    std.debug.assert(self.sent_records.items.len < self.sent_records.capacity);
     self.sent_records.addOneAssumeCapacity().* = source.*;
 }
 
@@ -983,17 +994,11 @@ pub const Connection = struct {
         conn.paths = quic_path.PathManager.init(conn.cfg.migration_policy, options.initial_path, initial_validated);
         errdefer conn.deinitPartial();
 
-        // Reserve the full capacity these two collections can ever need,
-        // before any locally-generated stateless-reset token is queued into
-        // them: `sent_records` cannot exceed `recovery.max_tracked_packets`
-        // (every append is gated by a successful recovery-tracker insert,
-        // itself bounded there), and `pending_new_connection_ids` cannot
-        // exceed `quic_cid.max_local_active_cids` (the local CID registry's
-        // own issuance limit). With capacity reserved up front, later
-        // `append`/`ensureUnusedCapacity` calls never trigger `std.ArrayList`'s
-        // grow-and-free-the-old-backing-unwiped path, which would otherwise
-        // copy a live reset token into a new allocation and free the old one
-        // without scrubbing it.
+        // Preallocate the full fixed recovery footprint before sent records can
+        // hold reset-token copies. Ordinary traffic never grows this backing
+        // allocation. Required recovery overflow uses `ensureSentRecordCapacity`,
+        // whose explicit copy -> secure-wipe old backing -> free sequence keeps
+        // token lifetime guarantees intact.
         try conn.sent_records.ensureTotalCapacityPrecise(allocator, recovery.max_tracked_packets);
         try conn.pending_new_connection_ids.ensureTotalCapacityPrecise(allocator, quic_cid.max_local_active_cids);
 
@@ -1070,6 +1075,7 @@ pub const Connection = struct {
         self.stream_transport_early.deinit();
         self.accept_queue.deinit(self.allocator);
         for (&self.crypto_tx) |*tx| tx.deinit(self.allocator);
+        self.recovery.deinit(self.allocator);
         // Any still-outstanding (unacked/unlost) or still-queued
         // NEW_CONNECTION_ID carries a stateless-reset token copy; teardown
         // must scrub those before the backing allocations are freed, not
@@ -1855,22 +1861,8 @@ pub const Connection = struct {
         return count;
     }
 
-    /// Make a tracker slot available for a PTO probe that RFC 9002 §6.2.4
-    /// requires be sent. Returns false only when the tracker holds nothing at
-    /// all to retire, which cannot happen while it is full.
-    fn reclaimTrackerSlotForProbe(self: *Connection, space: PacketNumberSpace) bool {
-        if (self.recovery.canTrackRecoveryPacket()) return true;
-        const retired = self.recovery.retireOldestForRecovery(space) orelse return false;
-        _ = self.requeueUntrackedRecords(retired.space);
-        self.metrics.packets_lost += 1;
-        return self.recovery.canTrackRecoveryPacket();
-    }
-
     fn trackerContains(self: *const Connection, space: PacketNumberSpace, pn: u64) bool {
-        for (self.recovery.tracker.packets[0..self.recovery.tracker.count]) |p| {
-            if (p.space == space and p.packet_number == pn) return true;
-        }
-        return false;
+        return self.recovery.tracker.contains(space, pn);
     }
 
     /// Requeue everything a lost packet carried.
@@ -2487,12 +2479,11 @@ pub const Connection = struct {
         if (self.ack_needed[2] and self.ack_eliciting_since_ack[2] < ack_eliciting_threshold) {
             deadline = minOpt(deadline, self.ack_armed_at_us[2] + local_max_ack_delay_us);
         }
-        // Loss time: earliest tracked packet that can become time-lost.
+        // Loss time: earliest fixed or recovery-overflow packet that can become
+        // time-lost.
         const loss_delay = self.recovery.rtt.lossDelay();
-        for (self.recovery.tracker.packets[0..self.recovery.tracker.count]) |p| {
-            const largest = self.recovery.tracker.largest_acked[@intFromEnum(p.space)] orelse continue;
-            if (p.packet_number > largest) continue;
-            deadline = minOpt(deadline, p.time_sent_us + loss_delay);
+        if (self.recovery.tracker.nextLossDeadline(loss_delay)) |loss_deadline| {
+            deadline = minOpt(deadline, loss_deadline);
         }
         // PTO per space with ack-eliciting packets in flight.
         const backoff = @as(u64, 1) << @intCast(@min(self.pto_count, 16));
@@ -2520,10 +2511,7 @@ pub const Connection = struct {
     }
 
     fn spaceHasAckElicitingInFlight(self: *const Connection, space: PacketNumberSpace) bool {
-        for (self.recovery.tracker.packets[0..self.recovery.tracker.count]) |p| {
-            if (p.space == space and p.ack_eliciting) return true;
-        }
-        return false;
+        return self.recovery.tracker.hasAckElicitingInFlight(space);
     }
 
     /// Process timer expiry at `now_us`. Cheap when nothing expired.
@@ -2840,47 +2828,24 @@ pub const Connection = struct {
         // push the datagram past the local config, the peer's advertised
         // `max_udp_payload_size`, or the validated path size.
         const budget = @min(out.len, self.effectiveMaxDatagramSize());
-        const amp_before = self.paths.activePath().anti_amplification.remaining();
         var datagram_len: usize = 0;
         var has_initial = false;
         var sent_ack_eliciting = false;
-        var packets_in_datagram: usize = 0;
 
         const levels = [_]EncryptionLevel{ .initial, .handshake, .application };
-        for (levels, 0..) |level, i| {
+        for (levels) |level| {
             if (!(self.adapter.hasProtectionKeys(level, .write) catch unreachable)) continue;
             const space = spaceForLevel(level);
-            // Who owns the RFC 9000 §14.1 expansion to 1200 bytes. Having a
-            // later write key is *not* a promise that the later level will
-            // actually contribute a packet: it may have nothing to send, be
-            // out of anti-amplification budget, or — now that the bounded
-            // tracker backpressures — have no slot left. If the Initial
-            // deferred on that basis and the later packet then declined, the
-            // datagram would go out under 1200. Ask whether the later level
-            // will really contribute, and err toward the Initial padding
-            // itself: an extra padded Initial is legal, a short one is not.
-            var last_level = true;
-            for (levels[i + 1 ..]) |later| {
-                // `+ 1`: the packet about to be built takes a tracker slot
-                // before the later level is ever asked for one.
-                if (self.levelWillContribute(later, spaceForLevel(later), datagram_len, packets_in_datagram + 1)) {
-                    last_level = false;
-                }
-            }
             const written = self.buildPacket(level, space, out[datagram_len..budget], now_us, .{
                 .datagram_has_initial = has_initial or level == .initial,
-                .is_last_level = last_level,
                 .datagram_so_far = datagram_len,
             }) orelse continue;
             datagram_len += written.len;
-            packets_in_datagram += 1;
             has_initial = has_initial or level == .initial;
             sent_ack_eliciting = sent_ack_eliciting or written.ack_eliciting;
             if (level == .handshake) {
                 if (!self.sent_handshake_packet) {
                     self.sent_handshake_packet = true;
-                    // Client: sending at the Handshake level retires Initial
-                    // keys (RFC 9001 §4.9.1).
                     if (self.role == .client) self.discardKeys(.initial);
                 }
             }
@@ -2890,19 +2855,6 @@ pub const Connection = struct {
             self.discardKeys(.handshake);
         }
         if (datagram_len == 0) return null;
-
-        // Backstop for RFC 9000 §14.1. The planning above decides who pads
-        // before any packet is sealed, and padding cannot be added afterwards
-        // — so if a datagram carrying an Initial still came out short, drop it
-        // rather than put an illegal datagram on the wire. Its packets stay
-        // tracked and their content is requeued by ordinary loss detection.
-        // Excluded: a server legitimately limited by anti-amplification (§8.1)
-        // or by a datagram cap below the minimum, where §14.1 cannot be met.
-        if (has_initial and datagram_len < min_initial_datagram and
-            budget >= min_initial_datagram and amp_before >= min_initial_datagram)
-        {
-            return null;
-        }
 
         const active_key = self.paths.activePath().key;
         self.paths.recordSentOnPath(active_key, datagram_len);
@@ -3081,51 +3033,8 @@ pub const Connection = struct {
         return .{ .bytes = out[0..total], .path = path };
     }
 
-    /// Whether `level` would produce a packet right now, evaluated against the
-    /// same gates `buildPacket` applies. Used to plan who pads an
-    /// Initial-bearing datagram (RFC 9000 §14.1) before the first packet is
-    /// committed, since that decision cannot be revisited once a packet is
-    /// sealed.
-    ///
-    /// Side-effect free, so it deliberately does *not* consider the recovery
-    /// slot reclamation a real probe build may perform. That only ever makes
-    /// the answer more pessimistic, which is the safe direction: the Initial
-    /// pads itself and the later packet coalesces on top of a datagram that
-    /// is already legal.
-    fn levelWillContribute(
-        self: *Connection,
-        level: EncryptionLevel,
-        space: PacketNumberSpace,
-        datagram_so_far: usize,
-        pending_packets: usize,
-    ) bool {
-        if (!(self.adapter.hasProtectionKeys(level, .write) catch unreachable)) return false;
-        if (self.paths.activePath().anti_amplification.remaining() <= datagram_so_far) return false;
-
-        const space_idx = spaceIndex(space);
-        const probe = self.probes_pending[space_idx] > 0 and
-            self.recovery.canTrackRecoveryPacketWithPending(pending_packets);
-        const cwnd_room = self.recovery.congestion.congestion_window -| self.recovery.congestion.bytes_in_flight;
-        const can_send_data = self.recovery.canTrackPacketWithPending(pending_packets) and (probe or
-            cwnd_room >= self.recovery.congestion.max_datagram_size / 2 or
-            self.recovery.congestion.bytes_in_flight == 0);
-
-        var want_ack = self.ack_needed[space_idx];
-        if (space == .application and want_ack) {
-            const forced = self.ack_eliciting_since_ack[space_idx] >= ack_eliciting_threshold;
-            if (!forced and !self.hasAppContent() and !probe) want_ack = false;
-        }
-        const has_crypto = !self.crypto_tx[space_idx].pending.isEmpty();
-        const has_app = space == .application and self.hasAppContent();
-
-        if (!want_ack and !has_crypto and !(has_app and can_send_data) and !probe) return false;
-        if ((has_crypto or has_app) and !can_send_data and !want_ack and !probe) return false;
-        return true;
-    }
-
     const BuildContext = struct {
         datagram_has_initial: bool,
-        is_last_level: bool,
         datagram_so_far: usize,
     };
 
@@ -3145,25 +3054,11 @@ pub const Connection = struct {
         ctx: BuildContext,
     ) ?BuiltPacket {
         const space_idx = spaceIndex(space);
-        // Recovery's tracker is bounded, and an in-flight packet it cannot
-        // track escapes loss detection *and* leaves bytes in
-        // `bytes_in_flight` that nothing can ever remove. Ordinary traffic
-        // stops short of a reserve; traffic recovery cannot defer draws on it.
+        // Ordinary traffic stays on the fixed tracker. Required PTO/padding
+        // traffic pre-reserves recovery overflow before any frame is dequeued.
         const can_track_ordinary = self.recovery.canTrackPacket();
-        // RFC 9002 §7.5 exempts a PTO probe from the congestion gate but still
-        // counts it in flight, so the probe needs a tracker slot like anything
-        // else — and §6.2.4 requires a probe on *every* PTO expiration, which
-        // a fixed reserve cannot promise (a total-loss episode retires
-        // nothing, so the reserve drains and never refills). When capacity is
-        // gone, reclaim it by retiring the oldest outstanding packet and
-        // requeuing its content, so probe progress survives for the whole
-        // connection lifetime instead of a fixed number of probes.
-        const probe_owed = self.probes_pending[space_idx] > 0;
-        const can_track_recovery = if (probe_owed)
-            self.reclaimTrackerSlotForProbe(space)
-        else
-            self.recovery.canTrackRecoveryPacket();
-        const probe = probe_owed and can_track_recovery;
+        const can_track_recovery = ensureRecoveryTrackingCapacity(self);
+        const probe = self.probes_pending[space_idx] > 0 and can_track_recovery;
 
         // Congestion gate: in-flight bytes need window; pure ACK packets and
         // PTO probes are exempt (RFC 9002 §7, §6.2.4).
@@ -3183,12 +3078,12 @@ pub const Connection = struct {
         const amp_room = self.paths.activePath().anti_amplification.remaining();
         if (amp_room == 0) return null;
 
-        // RFC 9000 §14.1 expands an Initial-bearing datagram to 1200 whatever
-        // it carries, and recovery charges that padded size — so the padding
-        // has to be budgeted before anything is built, not discovered after
-        // the frames are already committed. The zero-in-flight escape keeps
-        // the very first flight sendable.
-        const initial_pad_target: usize = if (ctx.datagram_has_initial and ctx.is_last_level)
+        // RFC 9000 §14.1 expands an Initial-bearing datagram to 1200. Keep the
+        // obligation on the Initial itself: later key availability is not a
+        // guarantee that a later packet passes tracker/cwnd/anti-amplification
+        // gates. Later coalesced packets see `datagram_so_far >= 1200` and have
+        // no remaining padding target.
+        const initial_pad_target: usize = if (ctx.datagram_has_initial)
             min_initial_datagram -| ctx.datagram_so_far
         else
             0;
@@ -7728,14 +7623,14 @@ test "wipePendingNewConnectionIdsOrderedRemoveResidue zeroes the vacated slot re
     for (ghost) |byte| try testing.expectEqual(@as(u8, 0), byte);
 }
 
-test "connection: sent_records and pending_new_connection_ids reserve capacity once and never regrow" {
+test "connection: fixed sent-record and pending-CID capacities are preallocated" {
     const allocator = testing.allocator;
     var pair = try TestPair.init(allocator);
     defer pair.deinit(allocator);
 
-    // `Connection.init` reserves the full protocol-bounded capacity for
-    // both collections before either can ever hold a locally-generated
-    // reset token.
+    // `Connection.init` reserves the fixed recovery footprint and hard
+    // CID-queue bound before either can hold a reset token. Recovery-only
+    // overflow has the explicit secure-growth path above.
     try testing.expect(pair.server.sent_records.capacity >= recovery.max_tracked_packets);
     try testing.expect(pair.server.pending_new_connection_ids.capacity >= quic_cid.max_local_active_cids);
 
@@ -8501,98 +8396,122 @@ test "driver: a PTO probe at the ordinary tracking limit is emitted tracked and 
     try testing.expect(congestion.bytes_in_flight < in_flight_before + probe.bytes.len);
 }
 
-test "driver: every PTO in a total-loss episode still emits a tracked probe" {
+fn fillOrdinaryTrackerWithRecords(conn: *Connection) !usize {
+    var added: usize = 0;
+    while (conn.recovery.canTrackPacket()) : (added += 1) {
+        const pn: u64 = 910_000 + added;
+        try conn.recovery.tracker.onPacketSent(.{
+            .space = .initial,
+            .packet_number = pn,
+            .time_sent_us = 1,
+            .size = 0,
+            .ack_eliciting = false,
+            .in_flight = false,
+        });
+        std.debug.assert(conn.sent_records.items.len < conn.sent_records.capacity);
+        conn.sent_records.addOneAssumeCapacity().* = .{
+            .space = .initial,
+            .packet_number = pn,
+            .ack_eliciting = false,
+        };
+    }
+    return added;
+}
+
+test "driver: every PTO remains tracked through sustained total loss past the fixed reserve" {
     const allocator = testing.allocator;
-    var pair = try TestPair.initWithConfigs(allocator, .{}, .{ .max_send_udp_payload_size = 1452 });
+    var pair = try TestPair.initWithConfigs(
+        allocator,
+        .{ .idle_timeout_ms = 86_400_000 },
+        .{ .idle_timeout_ms = 86_400_000, .max_send_udp_payload_size = 1452 },
+    );
     defer pair.deinit(allocator);
     try pair.pump();
 
     const sid = try openServerResponseStream(pair);
-    _ = try pair.server.writeStream(sid, &[_]u8{0x65} ** 4096, false);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x65} ** (16 * 1024), false);
     var out: [max_datagram_size_ceiling]u8 = undefined;
     while (pair.server.pollTransmitOnPath(&out, pair.now_us)) |_| {
         pair.now_us += 500;
     }
     pair.server.recovery.congestion.congestion_window = 1 << 24;
-    _ = try fillTracker(pair.server, false);
+    try testing.expect(pair.server.spaceHasAckElicitingInFlight(.application));
 
-    // A total blackhole: nothing is ever delivered, so no ACK arrives and
-    // threshold loss detection never retires anything. RFC 9002 §6.2.4 still
-    // requires an ack-eliciting probe on *every* PTO expiration — far more
-    // than any fixed reserve could hold.
-    const rounds = 4 * recovery.reserved_tracked_packets;
+    _ = try fillOrdinaryTrackerWithRecords(pair.server);
+    try testing.expect(!pair.server.recovery.canTrackPacket());
+
+    const app_idx = Connection.spaceIndex(.application);
+    const rounds = recovery.reserved_tracked_packets / 2 + 3;
     var round: usize = 0;
     while (round < rounds) : (round += 1) {
-        pair.server.probes_pending[Connection.spaceIndex(.application)] = 1;
-        const tracked_before = pair.server.recovery.tracker.count;
-        const probe = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse {
-            std.debug.print("no probe emitted on PTO round {d}\n", .{round});
-            return error.TestExpectedEqual;
-        };
-        try testing.expect(probe.bytes.len > 0);
-        // Emitted *and* recorded: the tracker never loses an entry to make
-        // room, and in-flight bytes stay bounded instead of ratcheting up
-        // behind untracked packets.
-        try testing.expect(pair.server.recovery.tracker.count >= tracked_before);
-        try testing.expect(pair.server.recovery.canTrackRecoveryPacket() or
-            pair.server.recovery.tracker.count == recovery.max_tracked_packets);
-        try testing.expect(
-            pair.server.recovery.congestion.bytes_in_flight <= recovery.max_tracked_packets * max_datagram_size_ceiling,
-        );
-        pair.now_us += 500;
+        try fireApplicationPto(pair.server, &pair.now_us);
+        try testing.expect(pair.server.probes_pending[app_idx] > 0);
+
+        var emitted: usize = 0;
+        while (pair.server.probes_pending[app_idx] > 0) {
+            const tracked_before = pair.server.recovery.tracker.totalCount();
+            const records_before = pair.server.sent_records.items.len;
+            const in_flight_before = pair.server.recovery.congestion.bytes_in_flight;
+            const probe = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
+            try testing.expectEqual(tracked_before + 1, pair.server.recovery.tracker.totalCount());
+            try testing.expectEqual(records_before + 1, pair.server.sent_records.items.len);
+            try testing.expectEqual(in_flight_before + probe.bytes.len, pair.server.recovery.congestion.bytes_in_flight);
+            emitted += 1;
+            pair.now_us += 500;
+        }
+        try testing.expect(emitted >= 1);
     }
 
-    // Every probe that ever went out is still accounted for by a tracker
-    // entry — none escaped into an untracked limbo.
-    try testing.expect(pair.server.recovery.tracker.count <= recovery.max_tracked_packets);
+    try testing.expect(pair.server.recovery.tracker.totalCount() > recovery.max_tracked_packets);
+    try testing.expect(pair.server.recovery.tracker.recovery_overflow.items.len > 0);
+    try testing.expect(pair.server.sent_records.items.len > recovery.max_tracked_packets);
+    try testing.expect(pair.server.sent_records.capacity > recovery.max_tracked_packets);
 }
 
-test "driver: a coalesced Initial-bearing datagram is never emitted below 1200" {
+test "driver: Initial remains 1200 bytes when Handshake becomes tracker-backpressured" {
     const allocator = testing.allocator;
     var pair = try TestPair.init(allocator);
     defer pair.deinit(allocator);
 
-    // Server holds Initial + Handshake write keys with pending flights in
-    // both, so its next datagram wants to coalesce.
     try pair.deliverOneClientDatagram();
     try testing.expect(pair.server.adapter.hasProtectionKeys(.initial, .write) catch unreachable);
     try testing.expect(pair.server.adapter.hasProtectionKeys(.handshake, .write) catch unreachable);
+    try testing.expect(!pair.server.crypto_tx[0].pending.isEmpty());
+    try testing.expect(!pair.server.crypto_tx[1].pending.isEmpty());
 
-    // Exactly one ordinary tracker slot left: the Initial takes it, and the
-    // Handshake packet that a later write key seemed to promise cannot be
-    // built. RFC 9000 §14.1 still requires >= 1200 bytes.
-    while (pair.server.recovery.canTrackPacketWithPending(1)) {
+    const target = recovery.max_tracked_packets - recovery.reserved_tracked_packets - 1;
+    var synthetic_pn: u64 = 800_000;
+    while (pair.server.recovery.tracker.count < target) : (synthetic_pn += 1) {
         try pair.server.recovery.tracker.onPacketSent(.{
             .space = .application,
-            .packet_number = 800_000 + pair.server.recovery.tracker.count,
+            .packet_number = synthetic_pn,
             .time_sent_us = 1,
             .size = 0,
+            .ack_eliciting = false,
+            .in_flight = false,
         });
     }
     try testing.expect(pair.server.recovery.canTrackPacket());
-    try testing.expect(!pair.server.recovery.canTrackPacketWithPending(1));
 
+    const tracked_before = pair.server.recovery.tracker.count;
+    const in_flight_before = pair.server.recovery.congestion.bytes_in_flight;
     var out: [max_datagram_size_ceiling]u8 = undefined;
-    var emitted: usize = 0;
-    while (pair.server.pollTransmitOnPath(&out, pair.now_us)) |t| {
-        // Every datagram carrying an Initial is either fully expanded or not
-        // sent at all; a short one would be a §14.1 violation.
-        try testing.expect(t.bytes.len >= min_initial_datagram);
-        emitted += 1;
-        pair.now_us += 500;
-        if (emitted > 4) break;
-    }
-    try testing.expect(emitted > 0);
-    try testing.expect(pair.server.recovery.tracker.count <= recovery.max_tracked_packets);
+    const sent = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
+
+    try testing.expectEqual(@as(usize, min_initial_datagram), sent.bytes.len);
+    try testing.expectEqual(tracked_before + 1, pair.server.recovery.tracker.count);
+    try testing.expect(!pair.server.recovery.canTrackPacket());
+    try testing.expect(!pair.server.crypto_tx[1].pending.isEmpty());
+    try testing.expectEqual(in_flight_before + sent.bytes.len, pair.server.recovery.congestion.bytes_in_flight);
 }
 
 test "driver: a fully saturated tracker never seals a padded in-flight packet" {
     const allocator = testing.allocator;
     // Every Initial-bearing datagram is padded to 1200 and is therefore in
     // flight (RFC 9002 §2) whatever it carries — including an ACK-only one.
-    // With no trackable slot at all, a whole handshake must produce no such
-    // datagram. `onPacketSentAssumeCapacity` asserts the same invariant from
-    // the other side for every packet any test in this file builds.
+    // With the ordinary fixed tracker saturated, handshake CRYPTO remains
+    // backpressured; recovery overflow is reserved only for PTO/mandatory-
+    // padding traffic and must not turn ordinary CRYPTO into unbounded output.
     var pair = try TestPair.init(allocator);
     defer pair.deinit(allocator);
 

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -1822,17 +1822,27 @@ pub const Connection = struct {
     fn detectAndRequeueLost(self: *Connection, space: PacketNumberSpace, now_us: u64) void {
         const loss = self.recovery.detectLost(space, now_us);
         if (loss.packet_threshold_losses + loss.time_threshold_losses == 0) return;
-        // The tracker dropped the lost packets; any record of this space no
-        // longer tracked (and not acked, i.e. still recorded) is lost.
+        const lost_count = self.requeueUntrackedRecords(space);
+        if (lost_count > 0) {
+            self.metrics.packets_lost += lost_count;
+            self.events.emit(.{ .packets_lost = .{ .space = space, .bytes = loss.lost_bytes } });
+        }
+    }
+
+    /// Requeue the content of every record in `space` the tracker no longer
+    /// holds. Shared by loss detection and by recovery-slot reclamation, which
+    /// retires a tracked packet for exactly the same reason: its content must
+    /// be resent, and its record must not outlive its tracker entry.
+    fn requeueUntrackedRecords(self: *Connection, space: PacketNumberSpace) u64 {
         var index: usize = 0;
-        var lost_count: u64 = 0;
+        var count: u64 = 0;
         while (index < self.sent_records.items.len) {
             const record = &self.sent_records.items[index];
             if (record.space != space or self.trackerContains(space, record.packet_number)) {
                 index += 1;
                 continue;
             }
-            lost_count += 1;
+            count += 1;
             // Read the live element to requeue its content (a fresh copy of
             // any carried reset token lands in `pending_new_connection_ids`
             // via `requeueRecord`) before wiping this now-redundant copy and
@@ -1842,10 +1852,18 @@ pub const Connection = struct {
             _ = self.sent_records.swapRemove(index);
             wipeSentRecordsSwapRemoveResidue(&self.sent_records);
         }
-        if (lost_count > 0) {
-            self.metrics.packets_lost += lost_count;
-            self.events.emit(.{ .packets_lost = .{ .space = space, .bytes = loss.lost_bytes } });
-        }
+        return count;
+    }
+
+    /// Make a tracker slot available for a PTO probe that RFC 9002 §6.2.4
+    /// requires be sent. Returns false only when the tracker holds nothing at
+    /// all to retire, which cannot happen while it is full.
+    fn reclaimTrackerSlotForProbe(self: *Connection, space: PacketNumberSpace) bool {
+        if (self.recovery.canTrackRecoveryPacket()) return true;
+        const retired = self.recovery.retireOldestForRecovery(space) orelse return false;
+        _ = self.requeueUntrackedRecords(retired.space);
+        self.metrics.packets_lost += 1;
+        return self.recovery.canTrackRecoveryPacket();
     }
 
     fn trackerContains(self: *const Connection, space: PacketNumberSpace, pn: u64) bool {
@@ -2822,19 +2840,32 @@ pub const Connection = struct {
         // push the datagram past the local config, the peer's advertised
         // `max_udp_payload_size`, or the validated path size.
         const budget = @min(out.len, self.effectiveMaxDatagramSize());
+        const amp_before = self.paths.activePath().anti_amplification.remaining();
         var datagram_len: usize = 0;
         var has_initial = false;
         var sent_ack_eliciting = false;
+        var packets_in_datagram: usize = 0;
 
         const levels = [_]EncryptionLevel{ .initial, .handshake, .application };
         for (levels, 0..) |level, i| {
             if (!(self.adapter.hasProtectionKeys(level, .write) catch unreachable)) continue;
             const space = spaceForLevel(level);
-            // Is this the last level that could contribute? Needed for the
-            // Initial padding rule.
+            // Who owns the RFC 9000 §14.1 expansion to 1200 bytes. Having a
+            // later write key is *not* a promise that the later level will
+            // actually contribute a packet: it may have nothing to send, be
+            // out of anti-amplification budget, or — now that the bounded
+            // tracker backpressures — have no slot left. If the Initial
+            // deferred on that basis and the later packet then declined, the
+            // datagram would go out under 1200. Ask whether the later level
+            // will really contribute, and err toward the Initial padding
+            // itself: an extra padded Initial is legal, a short one is not.
             var last_level = true;
             for (levels[i + 1 ..]) |later| {
-                if (self.adapter.hasProtectionKeys(later, .write) catch unreachable) last_level = false;
+                // `+ 1`: the packet about to be built takes a tracker slot
+                // before the later level is ever asked for one.
+                if (self.levelWillContribute(later, spaceForLevel(later), datagram_len, packets_in_datagram + 1)) {
+                    last_level = false;
+                }
             }
             const written = self.buildPacket(level, space, out[datagram_len..budget], now_us, .{
                 .datagram_has_initial = has_initial or level == .initial,
@@ -2842,6 +2873,7 @@ pub const Connection = struct {
                 .datagram_so_far = datagram_len,
             }) orelse continue;
             datagram_len += written.len;
+            packets_in_datagram += 1;
             has_initial = has_initial or level == .initial;
             sent_ack_eliciting = sent_ack_eliciting or written.ack_eliciting;
             if (level == .handshake) {
@@ -2858,6 +2890,19 @@ pub const Connection = struct {
             self.discardKeys(.handshake);
         }
         if (datagram_len == 0) return null;
+
+        // Backstop for RFC 9000 §14.1. The planning above decides who pads
+        // before any packet is sealed, and padding cannot be added afterwards
+        // — so if a datagram carrying an Initial still came out short, drop it
+        // rather than put an illegal datagram on the wire. Its packets stay
+        // tracked and their content is requeued by ordinary loss detection.
+        // Excluded: a server legitimately limited by anti-amplification (§8.1)
+        // or by a datagram cap below the minimum, where §14.1 cannot be met.
+        if (has_initial and datagram_len < min_initial_datagram and
+            budget >= min_initial_datagram and amp_before >= min_initial_datagram)
+        {
+            return null;
+        }
 
         const active_key = self.paths.activePath().key;
         self.paths.recordSentOnPath(active_key, datagram_len);
@@ -3036,6 +3081,48 @@ pub const Connection = struct {
         return .{ .bytes = out[0..total], .path = path };
     }
 
+    /// Whether `level` would produce a packet right now, evaluated against the
+    /// same gates `buildPacket` applies. Used to plan who pads an
+    /// Initial-bearing datagram (RFC 9000 §14.1) before the first packet is
+    /// committed, since that decision cannot be revisited once a packet is
+    /// sealed.
+    ///
+    /// Side-effect free, so it deliberately does *not* consider the recovery
+    /// slot reclamation a real probe build may perform. That only ever makes
+    /// the answer more pessimistic, which is the safe direction: the Initial
+    /// pads itself and the later packet coalesces on top of a datagram that
+    /// is already legal.
+    fn levelWillContribute(
+        self: *Connection,
+        level: EncryptionLevel,
+        space: PacketNumberSpace,
+        datagram_so_far: usize,
+        pending_packets: usize,
+    ) bool {
+        if (!(self.adapter.hasProtectionKeys(level, .write) catch unreachable)) return false;
+        if (self.paths.activePath().anti_amplification.remaining() <= datagram_so_far) return false;
+
+        const space_idx = spaceIndex(space);
+        const probe = self.probes_pending[space_idx] > 0 and
+            self.recovery.canTrackRecoveryPacketWithPending(pending_packets);
+        const cwnd_room = self.recovery.congestion.congestion_window -| self.recovery.congestion.bytes_in_flight;
+        const can_send_data = self.recovery.canTrackPacketWithPending(pending_packets) and (probe or
+            cwnd_room >= self.recovery.congestion.max_datagram_size / 2 or
+            self.recovery.congestion.bytes_in_flight == 0);
+
+        var want_ack = self.ack_needed[space_idx];
+        if (space == .application and want_ack) {
+            const forced = self.ack_eliciting_since_ack[space_idx] >= ack_eliciting_threshold;
+            if (!forced and !self.hasAppContent() and !probe) want_ack = false;
+        }
+        const has_crypto = !self.crypto_tx[space_idx].pending.isEmpty();
+        const has_app = space == .application and self.hasAppContent();
+
+        if (!want_ack and !has_crypto and !(has_app and can_send_data) and !probe) return false;
+        if ((has_crypto or has_app) and !can_send_data and !want_ack and !probe) return false;
+        return true;
+    }
+
     const BuildContext = struct {
         datagram_has_initial: bool,
         is_last_level: bool,
@@ -3063,13 +3150,20 @@ pub const Connection = struct {
         // `bytes_in_flight` that nothing can ever remove. Ordinary traffic
         // stops short of a reserve; traffic recovery cannot defer draws on it.
         const can_track_ordinary = self.recovery.canTrackPacket();
-        const can_track_recovery = self.recovery.canTrackRecoveryPacket();
         // RFC 9002 §7.5 exempts a PTO probe from the congestion gate but still
-        // counts it in flight, so the probe needs a slot like anything else.
-        // Without one it stays owed (`probes_pending` is untouched) and is
-        // retried once an ACK or loss frees capacity — delayed, never
-        // untracked.
-        const probe = self.probes_pending[space_idx] > 0 and can_track_recovery;
+        // counts it in flight, so the probe needs a tracker slot like anything
+        // else — and §6.2.4 requires a probe on *every* PTO expiration, which
+        // a fixed reserve cannot promise (a total-loss episode retires
+        // nothing, so the reserve drains and never refills). When capacity is
+        // gone, reclaim it by retiring the oldest outstanding packet and
+        // requeuing its content, so probe progress survives for the whole
+        // connection lifetime instead of a fixed number of probes.
+        const probe_owed = self.probes_pending[space_idx] > 0;
+        const can_track_recovery = if (probe_owed)
+            self.reclaimTrackerSlotForProbe(space)
+        else
+            self.recovery.canTrackRecoveryPacket();
+        const probe = probe_owed and can_track_recovery;
 
         // Congestion gate: in-flight bytes need window; pure ACK packets and
         // PTO probes are exempt (RFC 9002 §7, §6.2.4).
@@ -8407,7 +8501,7 @@ test "driver: a PTO probe at the ordinary tracking limit is emitted tracked and 
     try testing.expect(congestion.bytes_in_flight < in_flight_before + probe.bytes.len);
 }
 
-test "driver: repeated PTOs at capacity stay tracked, then wait rather than go untracked" {
+test "driver: every PTO in a total-loss episode still emits a tracked probe" {
     const allocator = testing.allocator;
     var pair = try TestPair.initWithConfigs(allocator, .{}, .{ .max_send_udp_payload_size = 1452 });
     defer pair.deinit(allocator);
@@ -8422,45 +8516,74 @@ test "driver: repeated PTOs at capacity stay tracked, then wait rather than go u
     pair.server.recovery.congestion.congestion_window = 1 << 24;
     _ = try fillTracker(pair.server, false);
 
-    // The reserve is not a single-probe illusion: every probe it covers is
-    // emitted with a tracker entry and charged to the window.
-    var probes: usize = 0;
-    while (probes < recovery.reserved_tracked_packets) : (probes += 1) {
-        if (!pair.server.recovery.canTrackRecoveryPacket()) break;
+    // A total blackhole: nothing is ever delivered, so no ACK arrives and
+    // threshold loss detection never retires anything. RFC 9002 §6.2.4 still
+    // requires an ack-eliciting probe on *every* PTO expiration — far more
+    // than any fixed reserve could hold.
+    const rounds = 4 * recovery.reserved_tracked_packets;
+    var round: usize = 0;
+    while (round < rounds) : (round += 1) {
         pair.server.probes_pending[Connection.spaceIndex(.application)] = 1;
-        const before = pair.server.recovery.tracker.count;
-        const in_flight_before = pair.server.recovery.congestion.bytes_in_flight;
-        const probe = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse break;
-        try testing.expectEqual(before + 1, pair.server.recovery.tracker.count);
-        try testing.expectEqual(
-            in_flight_before + probe.bytes.len,
-            pair.server.recovery.congestion.bytes_in_flight,
+        const tracked_before = pair.server.recovery.tracker.count;
+        const probe = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse {
+            std.debug.print("no probe emitted on PTO round {d}\n", .{round});
+            return error.TestExpectedEqual;
+        };
+        try testing.expect(probe.bytes.len > 0);
+        // Emitted *and* recorded: the tracker never loses an entry to make
+        // room, and in-flight bytes stay bounded instead of ratcheting up
+        // behind untracked packets.
+        try testing.expect(pair.server.recovery.tracker.count >= tracked_before);
+        try testing.expect(pair.server.recovery.canTrackRecoveryPacket() or
+            pair.server.recovery.tracker.count == recovery.max_tracked_packets);
+        try testing.expect(
+            pair.server.recovery.congestion.bytes_in_flight <= recovery.max_tracked_packets * max_datagram_size_ceiling,
         );
         pair.now_us += 500;
     }
-    try testing.expect(probes > 1);
 
-    // Once even the reserve is spent, the probe waits: it is still owed, and
-    // nothing untracked leaves.
-    _ = try fillTracker(pair.server, true);
-    try testing.expect(!pair.server.recovery.canTrackRecoveryPacket());
-    pair.server.probes_pending[Connection.spaceIndex(.application)] = 1;
-    const saturated_tracked = pair.server.recovery.tracker.count;
-    const saturated_in_flight = pair.server.recovery.congestion.bytes_in_flight;
-    while (pair.server.pollTransmitOnPath(&out, pair.now_us)) |t| {
-        try testing.expect(t.bytes.len < base_datagram_size);
-        pair.now_us += 500;
+    // Every probe that ever went out is still accounted for by a tracker
+    // entry — none escaped into an untracked limbo.
+    try testing.expect(pair.server.recovery.tracker.count <= recovery.max_tracked_packets);
+}
+
+test "driver: a coalesced Initial-bearing datagram is never emitted below 1200" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+
+    // Server holds Initial + Handshake write keys with pending flights in
+    // both, so its next datagram wants to coalesce.
+    try pair.deliverOneClientDatagram();
+    try testing.expect(pair.server.adapter.hasProtectionKeys(.initial, .write) catch unreachable);
+    try testing.expect(pair.server.adapter.hasProtectionKeys(.handshake, .write) catch unreachable);
+
+    // Exactly one ordinary tracker slot left: the Initial takes it, and the
+    // Handshake packet that a later write key seemed to promise cannot be
+    // built. RFC 9000 §14.1 still requires >= 1200 bytes.
+    while (pair.server.recovery.canTrackPacketWithPending(1)) {
+        try pair.server.recovery.tracker.onPacketSent(.{
+            .space = .application,
+            .packet_number = 800_000 + pair.server.recovery.tracker.count,
+            .time_sent_us = 1,
+            .size = 0,
+        });
     }
-    try testing.expectEqual(saturated_tracked, pair.server.recovery.tracker.count);
-    try testing.expectEqual(saturated_in_flight, pair.server.recovery.congestion.bytes_in_flight);
-    try testing.expect(pair.server.probes_pending[Connection.spaceIndex(.application)] > 0);
+    try testing.expect(pair.server.recovery.canTrackPacket());
+    try testing.expect(!pair.server.recovery.canTrackPacketWithPending(1));
 
-    // Freeing capacity releases the owed probe.
-    _ = pair.server.recovery.tracker.dropSpace(.initial);
-    const freed_tracked = pair.server.recovery.tracker.count;
-    const released = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
-    try testing.expect(released.bytes.len > 0);
-    try testing.expect(pair.server.recovery.tracker.count > freed_tracked);
+    var out: [max_datagram_size_ceiling]u8 = undefined;
+    var emitted: usize = 0;
+    while (pair.server.pollTransmitOnPath(&out, pair.now_us)) |t| {
+        // Every datagram carrying an Initial is either fully expanded or not
+        // sent at all; a short one would be a §14.1 violation.
+        try testing.expect(t.bytes.len >= min_initial_datagram);
+        emitted += 1;
+        pair.now_us += 500;
+        if (emitted > 4) break;
+    }
+    try testing.expect(emitted > 0);
+    try testing.expect(pair.server.recovery.tracker.count <= recovery.max_tracked_packets);
 }
 
 test "driver: a fully saturated tracker never seals a padded in-flight packet" {

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -3096,6 +3096,25 @@ pub const Connection = struct {
             }
         }
 
+        // Congestion budget for in-flight content, applied on top of the
+        // datagram cap (#256-A). `can_send_data` only decides *whether* data
+        // may go out; without this, a packet admitted on 600 bytes of window
+        // would still be filled to the full effective datagram size, so
+        // raising that size would widen how far `bytes_in_flight` overshoots
+        // `congestion_window`. Bounding the payload by the remaining window
+        // instead keeps the overshoot independent of the cap.
+        //
+        // Both RFC 9002 exemptions survive: a pure ACK never reaches here
+        // with content (§2, not in flight — the ACK above already used the
+        // full `plain_budget`), and a PTO probe may exceed the window (§7.5).
+        // `@max(plain_len, ...)` keeps the bound from cutting into bytes the
+        // exempt ACK already wrote.
+        const packet_overhead = pn_offset + pn_len + aead_tag_len;
+        const data_budget = if (probe)
+            plain_budget
+        else
+            @max(plain_len, @min(plain_budget, cwnd_room -| packet_overhead));
+
         // 2) CRYPTO retransmission/transmission
         if (has_crypto and (can_send_data or probe)) {
             const tx = switch (space) {
@@ -3103,8 +3122,8 @@ pub const Connection = struct {
                 .handshake => &self.crypto_tx[1],
                 .application => &self.crypto_tx[2],
             };
-            while (!tx.pending.isEmpty() and plain_len + frame.max_crypto_overhead + 16 < plain_budget) {
-                const room: u64 = @intCast(plain_budget - plain_len - frame.max_crypto_overhead);
+            while (!tx.pending.isEmpty() and plain_len + frame.max_crypto_overhead + 16 < data_budget) {
+                const room: u64 = @intCast(data_budget - plain_len - frame.max_crypto_overhead);
                 var range = tx.pending.takeFirst(room) orelse break;
                 range = tx.liveRange(range) orelse continue;
                 if (record.crypto) |existing| {
@@ -3118,7 +3137,7 @@ pub const Connection = struct {
                     }
                 }
                 const data = tx.slice(range);
-                const n = frame.encodeCrypto(range.start, data, plain[plain_len..plain_budget]) catch {
+                const n = frame.encodeCrypto(range.start, data, plain[plain_len..data_budget]) catch {
                     if (space == .application) {
                         tx.pending.insertAssumeCapacity(range);
                     } else {
@@ -3140,7 +3159,7 @@ pub const Connection = struct {
 
         // 3) Application-space control and stream frames
         if (space == .application and self.state_ == .established and (can_send_data or probe)) {
-            plain_len = self.buildAppFrames(&record, &plain, plain_len, plain_budget);
+            plain_len = self.buildAppFrames(&record, &plain, plain_len, data_budget);
         }
 
         // 4) Probe padding: a PTO probe with nothing else carries a PING.
@@ -3168,7 +3187,6 @@ pub const Connection = struct {
         // which §8.2.1 lets cap the expansion.
         if ((ctx.datagram_has_initial and ctx.is_last_level) or record.carried_path_response) {
             const target = min_initial_datagram -| ctx.datagram_so_far;
-            const packet_overhead = pn_offset + pn_len + aead_tag_len;
             if (packet_overhead + plain_len < target and target <= plain_budget + packet_overhead) {
                 const padded = target - packet_overhead;
                 @memset(plain[plain_len..padded], 0);
@@ -7918,8 +7936,72 @@ test "driver: raising the cap leaves packet-number and congestion accounting int
     // Only application keys remain after the handshake, so each datagram
     // carries exactly one packet and consumes exactly one packet number.
     try testing.expectEqual(seen.count, pn_after - pn_before);
-    // Congestion control, not the datagram size, still bounds what goes out:
-    // the last packet may straddle the window, nothing beyond it may.
+    // Congestion control, not the datagram size, bounds what goes out: every
+    // in-flight byte fits inside the window, with no straddle allowance.
     const congestion = pair.server.recovery.congestion;
-    try testing.expect(congestion.bytes_in_flight <= congestion.congestion_window + seen.largest);
+    try testing.expect(congestion.bytes_in_flight <= congestion.congestion_window);
+}
+
+test "driver: a raised datagram cap cannot widen the congestion overshoot" {
+    const allocator = testing.allocator;
+    const raised = config.Config{ .max_udp_payload_size = max_datagram_size_ceiling };
+    var pair = try TestPair.initWithConfigs(allocator, raised, raised);
+    defer pair.deinit(allocator);
+    try pair.pump();
+    try testing.expectEqual(max_datagram_size_ceiling, pair.server.effectiveMaxDatagramSize());
+
+    const sid = try openServerResponseStream(pair);
+    const payload = [_]u8{0x5a} ** (16 * 1024);
+    _ = try pair.server.writeStream(sid, &payload, false);
+
+    // A window that clears the send gate's half-datagram threshold but is far
+    // below the raised cap: exactly the gap where a cap-sized packet would
+    // otherwise be built on top of a nearly full window.
+    const congestion = &pair.server.recovery.congestion;
+    const room: usize = 700;
+    congestion.congestion_window = congestion.bytes_in_flight + room;
+    const window = congestion.congestion_window;
+    const in_flight_before = congestion.bytes_in_flight;
+
+    var out: [max_datagram_size_ceiling]u8 = undefined;
+    const sent = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
+    // The packet is sized by the remaining window, not by the datagram cap.
+    try testing.expect(sent.bytes.len <= room);
+    try testing.expect(congestion.bytes_in_flight <= window);
+    try testing.expect(congestion.bytes_in_flight > in_flight_before);
+
+    // With the window now spent, no further ordinary data packet is admitted.
+    pair.now_us += 500;
+    try testing.expectEqual(@as(?Transmit, null), pair.server.pollTransmitOnPath(&out, pair.now_us));
+}
+
+test "driver: a PTO probe keeps its congestion exemption under a raised cap" {
+    const allocator = testing.allocator;
+    const raised = config.Config{ .max_udp_payload_size = max_datagram_size_ceiling };
+    var pair = try TestPair.initWithConfigs(allocator, raised, raised);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const sid = try openServerResponseStream(pair);
+    const payload = [_]u8{0x5a} ** (16 * 1024);
+    _ = try pair.server.writeStream(sid, &payload, false);
+
+    // Window fully spent: no queued stream data may go out, and nothing that
+    // does (a pure ACK is exempt, being not in flight) adds to the window.
+    const congestion = &pair.server.recovery.congestion;
+    congestion.congestion_window = congestion.bytes_in_flight;
+    const in_flight_before = congestion.bytes_in_flight;
+    var out: [max_datagram_size_ceiling]u8 = undefined;
+    while (pair.server.pollTransmitOnPath(&out, pair.now_us)) |exempt| {
+        try testing.expect(exempt.bytes.len < base_datagram_size);
+        pair.now_us += 500;
+    }
+    try testing.expectEqual(in_flight_before, congestion.bytes_in_flight);
+
+    // A PTO probe keeps its exemption and may exceed the window (RFC 9002 §7.5).
+    pair.server.probes_pending[Connection.spaceIndex(.application)] = 1;
+    const probe = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
+    try testing.expect(probe.bytes.len > 0);
+    try testing.expect(probe.bytes.len <= max_datagram_size_ceiling);
+    try testing.expect(congestion.bytes_in_flight > congestion.congestion_window);
 }

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -66,6 +66,12 @@ pub const base_datagram_size: usize = quic_datagram.base_size;
 /// per-packet plaintext scratch buffers below. An `out` buffer larger than
 /// this is simply not used past the effective cap.
 pub const max_datagram_size_ceiling: usize = quic_datagram.max_size;
+/// The largest UDP payload `ingest` can deprotect, and therefore the receive
+/// capacity this endpoint may advertise as `max_udp_payload_size`. Every
+/// receive scratch buffer below derives from it, and `config.validate()`
+/// rejects an advertisement above it, so the promise and the buffers cannot
+/// drift apart.
+pub const max_receive_datagram_size: usize = quic_datagram.max_size;
 pub const max_application_crypto_outstanding: usize = 2 * tls_core.tls13_transport.max_emitted_new_session_ticket_message_len;
 const min_application_crypto_payload: usize = base_datagram_size / 2;
 /// RFC 9000 §14.1: datagrams carrying Initial packets are padded to 1200.
@@ -726,6 +732,10 @@ const SentRecord = struct {
     /// re-challenges instead), so it needs no requeue-identifying field.
     carried_path_challenge_path: ?quic_path.PathKey = null,
     carried_path_response: bool = false,
+    /// RFC 9002 §2: PADDING makes a packet count as in flight even when it
+    /// carries nothing ack-eliciting, so it must still be tracked and charged
+    /// to the congestion window.
+    carried_padding: bool = false,
     carried_ack_largest: ?u64 = null,
 
     const StreamRange = struct {
@@ -740,6 +750,15 @@ const SentRecord = struct {
 /// copies, requeues, or discards a `SentRecord` mints or drops an
 /// independent copy of it; each of those copies must be scrubbed once it is
 /// no longer needed rather than left for the allocator to reclaim unwiped.
+/// RFC 9002 §2: a packet is *in flight* when it is ack-eliciting **or**
+/// carries PADDING. The two are not synonymous — a padded ACK-only Initial is
+/// not ack-eliciting yet still consumes congestion window and must be tracked,
+/// so the send path keys recovery accounting off this rather than off
+/// `ack_eliciting` alone (#256-A review).
+fn recordIsInFlight(record: SentRecord) bool {
+    return record.ack_eliciting or record.carried_padding;
+}
+
 fn wipeSentRecordToken(record: *SentRecord) void {
     if (record.has_new_connection_id) crypto_secrets.secureZero(&record.carried_new_connection_id.stateless_reset_token);
 }
@@ -1095,30 +1114,40 @@ pub const Connection = struct {
         return self.adapter.peerTransportParameters();
     }
 
-    /// The bounds that decide how large an outbound datagram may be (#256-A).
-    /// Derived on demand rather than cached so a peer's transport parameters
-    /// take effect the moment they are authenticated, with no separate
-    /// invalidation step to get wrong.
+    /// The send-side bounds on an outbound datagram (#256-A). Derived on
+    /// demand rather than cached so a peer's transport parameters take effect
+    /// the moment they are authenticated, with no separate invalidation step
+    /// to get wrong.
+    ///
+    /// Note the asymmetry: `cfg.max_udp_payload_size` is *our* receive
+    /// capacity and never appears here, while the peer's advertisement of the
+    /// same parameter is *its* receive capacity and bounds everything we send.
     pub fn datagramLimits(self: *const Connection) quic_datagram.Limits {
         return .{
-            .local_max = self.cfg.max_udp_payload_size,
+            // #256-B replaces this operator assertion with measured per-path
+            // DPLPMTUD state; it defaults to the RFC 9000 §14 floor.
+            .current_path_max = self.cfg.max_send_udp_payload_size,
+            .send_ceiling = quic_datagram.max_size,
             .peer_max = if (self.adapter.peerTransportParameters()) |peer|
                 peer.max_udp_payload_size
             else
                 null,
-            // #256-B fills this in from per-path DPLPMTUD state. Until then
-            // the locally configured maximum is the operator's path assertion,
-            // and it defaults to the RFC 9000 §14 floor.
-            .validated_path_max = null,
         };
     }
 
     /// The one authoritative cap on an ordinary outbound UDP datagram: the
-    /// smallest of the locally configured maximum, the peer's advertised
-    /// `max_udp_payload_size` once authenticated, and the validated path size.
-    /// Never below `base_datagram_size`, so Initial padding always fits.
+    /// smallest of the current path size, this endpoint's send ceiling, and
+    /// the peer's advertised receive capacity once authenticated. Never below
+    /// `base_datagram_size`, so Initial padding always fits.
     pub fn effectiveMaxDatagramSize(self: *const Connection) usize {
         return self.datagramLimits().effective();
+    }
+
+    /// The largest datagram a PMTU probe may attempt (#256-B's upper bound).
+    /// Exposed now so the probe ceiling is part of the same authoritative
+    /// model rather than something the next slice re-derives.
+    pub fn probeMaxDatagramSize(self: *const Connection) usize {
+        return self.datagramLimits().probeCeiling();
     }
 
     pub fn closeInfo(self: *const Connection) ?CloseInfo {
@@ -1308,7 +1337,7 @@ pub const Connection = struct {
         }
 
         // Header protection removal needs a sample 4 bytes past pn_offset.
-        var work: [2048]u8 = undefined;
+        var work: [max_receive_datagram_size]u8 = undefined;
         if (bytes.len > work.len) {
             self.dropPacket(.malformed, bytes.len);
             self.emitZeroRttOutcome(level, .malformed, bytes.len);
@@ -1371,7 +1400,7 @@ pub const Connection = struct {
 
         const header = work[0 .. parsed.pn_offset + removed.packet_number_length];
         const ciphertext = work[parsed.pn_offset + removed.packet_number_length .. parsed.packet_len];
-        var plain: [2048]u8 = undefined;
+        var plain: [max_receive_datagram_size]u8 = undefined;
         const payload = keys.openPayloadWithProvider(self.adapter.provider, pn, header, ciphertext, &plain) catch {
             self.adapter.metrics.deprotection_failures += 1;
             self.dropPacket(.undecryptable, bytes.len);
@@ -2754,6 +2783,13 @@ pub const Connection = struct {
         if (self.state_ == .closed or self.state_ == .draining) return null;
         if (out.len < base_datagram_size) return null;
 
+        // RFC 9002 expresses every NewReno window in terms of the sender's
+        // *current* maximum datagram size, so recovery has to follow what the
+        // builder actually emits (#256-A). Refreshed here, before any gate
+        // reads it, rather than cached at init: the effective size changes the
+        // moment the peer's transport parameters authenticate.
+        self.recovery.congestion.setMaxDatagramSize(self.effectiveMaxDatagramSize());
+
         if (self.state_ == .closing) {
             if (!self.close_needs_send) return null;
             self.close_needs_send = false;
@@ -2868,9 +2904,10 @@ pub const Connection = struct {
 
     /// Assemble, seal, and record one control-only datagram for `path`: a
     /// queued PATH_RESPONSE and/or an outstanding PATH_CHALLENGE, padded per
-    /// RFC 9000 §8.2.1, gated strictly by that path's own anti-amplification
-    /// budget. Never carries ACK/STREAM/CRYPTO/flow-control/CID-management
-    /// content — that stays exclusively on the active path until promotion.
+    /// RFC 9000 §8.2.1, gated by that path's own anti-amplification budget and
+    /// by congestion control. Never carries ACK/STREAM/CRYPTO/flow-control/
+    /// CID-management content — that stays exclusively on the active path
+    /// until promotion.
     fn buildCandidatePacket(self: *Connection, path: quic_path.PathKey, out: []u8, now_us: u64) ?Transmit {
         if (out.len < base_datagram_size) return null;
         var keys = (self.adapter.protectionKeys(.application, .write) catch unreachable) orelse return null;
@@ -2883,6 +2920,19 @@ pub const Connection = struct {
         // ordinary traffic. They are padded to `min_initial_datagram`, which
         // the cap's floor guarantees room for.
         const budget = @min(out.len, self.effectiveMaxDatagramSize());
+
+        // A path-validation packet is ack-eliciting and padded to 1200, so it
+        // is in flight like any other — it is not an RFC 9002 PTO probe, and
+        // RFC 9000 §8.2 explicitly allows path validation to be delayed by
+        // congestion control. Gate before anything is dequeued: nothing below
+        // may remove a PATH_RESPONSE or clear `needs_send` for a packet that
+        // is not allowed out. The recovery tracker is preflighted for the same
+        // reason as on the ordinary path — an untracked in-flight packet would
+        // escape both loss detection and the window.
+        if (!self.recovery.canTrackPacket()) return null;
+        const cwnd_room = self.recovery.congestion.congestion_window -| self.recovery.congestion.bytes_in_flight;
+        const planned_total: usize = @min(min_initial_datagram, @min(budget, std.math.lossyCast(usize, remaining)));
+        if (planned_total > cwnd_room and self.recovery.congestion.bytes_in_flight != 0) return null;
 
         const space_idx = spaceIndex(.application);
         const pn = self.next_pn[space_idx];
@@ -2970,6 +3020,9 @@ pub const Connection = struct {
                 .ack_eliciting = true,
                 .in_flight = true,
             }) catch {
+                // Preflighted above; charge the window regardless so this
+                // cannot become a congestion-control bypass.
+                self.recovery.congestion.onPacketSent(total);
                 tracked = false;
             };
             self.last_ack_eliciting_sent_us[space_idx] = now_us;
@@ -3011,11 +3064,17 @@ pub const Connection = struct {
         const space_idx = spaceIndex(space);
         const probe = self.probes_pending[space_idx] > 0;
 
-        // Congestion gate: in-flight (ack-eliciting) bytes need window; pure
-        // ACK packets and PTO probes are exempt (RFC 9002 §7, §6.2.4).
+        // Congestion gate: in-flight bytes need window; pure ACK packets and
+        // PTO probes are exempt (RFC 9002 §7, §6.2.4).
         const cwnd_room = self.recovery.congestion.congestion_window -| self.recovery.congestion.bytes_in_flight;
-        const can_send_data = probe or cwnd_room >= recovery.max_datagram_size / 2 or
-            self.recovery.congestion.bytes_in_flight == 0;
+        // Recovery's tracker is bounded. An in-flight packet it cannot track
+        // would escape both loss detection and the congestion window, so
+        // preflight a slot here — before any frame is dequeued — and fall back
+        // to ACK-only output rather than sending something uncharged.
+        const can_track = self.recovery.canTrackPacket();
+        const can_send_data = can_track and (probe or
+            cwnd_room >= self.recovery.congestion.max_datagram_size / 2 or
+            self.recovery.congestion.bytes_in_flight == 0);
 
         // Anti-amplification gate applies to every byte a server sends before
         // the client's address is validated. Ordinary output always targets
@@ -3023,6 +3082,29 @@ pub const Connection = struct {
         // and gated separately by `buildCandidatePacket`).
         const amp_room = self.paths.activePath().anti_amplification.remaining();
         if (amp_room == 0) return null;
+
+        // RFC 9000 §14.1 expands an Initial-bearing datagram to 1200 whatever
+        // it carries, and recovery charges that padded size — so the padding
+        // has to be budgeted before anything is built, not discovered after
+        // the frames are already committed. The zero-in-flight escape keeps
+        // the very first flight sendable.
+        const initial_pad_target: usize = if (ctx.datagram_has_initial and ctx.is_last_level)
+            min_initial_datagram -| ctx.datagram_so_far
+        else
+            0;
+        if (!probe and initial_pad_target > cwnd_room and self.recovery.congestion.bytes_in_flight != 0) {
+            return null;
+        }
+
+        // Same rule for a PATH_RESPONSE riding on the active path: it forces
+        // the datagram to 1200 (§8.2.1-2). RFC 9000 §8.2 explicitly permits
+        // path validation to be delayed by congestion control, so when the
+        // padded size does not fit, the response stays queued rather than
+        // being sent uncharged.
+        const path_response_final: usize = min_initial_datagram -| ctx.datagram_so_far;
+        const allow_path_response = probe or
+            path_response_final <= cwnd_room or
+            self.recovery.congestion.bytes_in_flight == 0;
 
         var want_ack = self.ack_needed[space_idx];
         if (space == .application and want_ack) {
@@ -3038,7 +3120,7 @@ pub const Connection = struct {
             .application => !self.crypto_tx[2].pending.isEmpty(),
         };
         const has_app = space == .application and self.hasAppContent();
-        if (!want_ack and !has_crypto and !(has_app and can_send_data) and !probe) return null;
+        if (!want_ack and !has_crypto and !(has_app and can_send_data) and !(probe and can_track)) return null;
         if ((has_crypto or has_app) and !can_send_data and !want_ack and !probe) return null;
 
         // Header sizing.
@@ -3159,7 +3241,7 @@ pub const Connection = struct {
 
         // 3) Application-space control and stream frames
         if (space == .application and self.state_ == .established and (can_send_data or probe)) {
-            plain_len = self.buildAppFrames(&record, &plain, plain_len, data_budget);
+            plain_len = self.buildAppFrames(&record, &plain, plain_len, data_budget, allow_path_response);
         }
 
         // 4) Probe padding: a PTO probe with nothing else carries a PING.
@@ -3185,12 +3267,15 @@ pub const Connection = struct {
         // content; `buildCandidatePacket` pads candidate-path probes itself.
         // `plain_budget` already reflects the anti-amplification allowance,
         // which §8.2.1 lets cap the expansion.
-        if ((ctx.datagram_has_initial and ctx.is_last_level) or record.carried_path_response) {
-            const target = min_initial_datagram -| ctx.datagram_so_far;
+        if (initial_pad_target > 0 or record.carried_path_response) {
+            const target = @max(initial_pad_target, if (record.carried_path_response) path_response_final else 0);
             if (packet_overhead + plain_len < target and target <= plain_budget + packet_overhead) {
                 const padded = target - packet_overhead;
                 @memset(plain[plain_len..padded], 0);
                 plain_len = padded;
+                // RFC 9002 §2: a packet carrying PADDING is in flight even
+                // when nothing in it is ack-eliciting.
+                record.carried_padding = true;
             }
         }
 
@@ -3215,24 +3300,30 @@ pub const Connection = struct {
         const total = pn_offset + pn_len + sealed.len;
         self.next_pn[space_idx] = pn + 1;
 
-        // 7) Record for recovery. Non-ack-eliciting packets (pure ACKs) are
-        // never acknowledged by the peer, so tracking them would only fill
-        // the tracker; RFC 9002 excludes them from loss/congestion anyway.
-        if (record.ack_eliciting) {
+        // 7) Record for recovery. A packet is *in flight* when it is
+        // ack-eliciting or carries PADDING (RFC 9002 §2) — the two are not
+        // synonymous, and a padded non-ack-eliciting packet that skipped this
+        // would escape the congestion window entirely. A pure ACK really is
+        // exempt: the peer never acknowledges it, so tracking it would only
+        // consume tracker slots.
+        if (recordIsInFlight(record)) {
             var tracked = true;
             self.recovery.onPacketSent(.{
                 .space = space,
                 .packet_number = pn,
                 .time_sent_us = now_us,
                 .size = total,
-                .ack_eliciting = true,
+                .ack_eliciting = record.ack_eliciting,
                 .in_flight = true,
             }) catch {
-                // Tracker exhaustion: the packet is sealed and will be sent;
-                // treat it as untracked best-effort.
+                // `can_track` preflighted a slot before any frame was
+                // dequeued, so this is unreachable in practice. Charge the
+                // bytes anyway rather than letting an in-flight packet escape
+                // the congestion window.
+                self.recovery.congestion.onPacketSent(total);
                 tracked = false;
             };
-            self.last_ack_eliciting_sent_us[space_idx] = now_us;
+            if (record.ack_eliciting) self.last_ack_eliciting_sent_us[space_idx] = now_us;
             if (tracked) publishSentRecord(self, &record);
         }
         if (record.has_new_connection_id) {
@@ -3280,7 +3371,14 @@ pub const Connection = struct {
         return false;
     }
 
-    fn buildAppFrames(self: *Connection, record: *SentRecord, plain: []u8, start_len: usize, budget: usize) usize {
+    fn buildAppFrames(
+        self: *Connection,
+        record: *SentRecord,
+        plain: []u8,
+        start_len: usize,
+        budget: usize,
+        allow_path_response: bool,
+    ) usize {
         var plain_len = start_len;
 
         if (self.handshake_done_pending and self.role == .server) {
@@ -3353,7 +3451,7 @@ pub const Connection = struct {
         // ordinary content; one queued for a candidate path is sent in
         // isolation by `buildCandidatePacket` instead (candidate-path egress
         // must never carry ACK/STREAM/CRYPTO/flow-control content).
-        {
+        if (allow_path_response) {
             const active_key = self.paths.activePath().key;
             var i: usize = 0;
             while (i < self.pending_path_responses.items.len) {
@@ -7827,7 +7925,7 @@ fn openServerResponseStream(pair: *TestPair) !StreamId {
 
 test "driver: a raised local maximum is enforced by the datagrams actually emitted" {
     const allocator = testing.allocator;
-    const raised = config.Config{ .max_udp_payload_size = 1452 };
+    const raised = config.Config{ .max_send_udp_payload_size = 1452 };
     var pair = try TestPair.initWithConfigs(allocator, raised, raised);
     defer pair.deinit(allocator);
     try pair.pump();
@@ -7854,7 +7952,7 @@ test "driver: the peer's advertised maximum lowers the effective cap" {
     var pair = try TestPair.initWithConfigs(
         allocator,
         .{ .max_udp_payload_size = base_datagram_size },
-        .{ .max_udp_payload_size = max_datagram_size_ceiling },
+        .{ .max_send_udp_payload_size = max_datagram_size_ceiling },
     );
     defer pair.deinit(allocator);
     try pair.pump();
@@ -7876,7 +7974,7 @@ test "driver: the peer's advertised maximum lowers the effective cap" {
 
 test "driver: the cap stays at the floor until the peer's transport parameters arrive" {
     const allocator = testing.allocator;
-    const raised = config.Config{ .max_udp_payload_size = max_datagram_size_ceiling };
+    const raised = config.Config{ .max_send_udp_payload_size = max_datagram_size_ceiling };
     var pair = try TestPair.initWithConfigs(allocator, raised, raised);
     defer pair.deinit(allocator);
 
@@ -7899,7 +7997,7 @@ test "driver: the cap stays at the floor until the peer's transport parameters a
 
 test "driver: a raised local maximum does not widen the anti-amplification budget" {
     const allocator = testing.allocator;
-    const raised = config.Config{ .max_udp_payload_size = max_datagram_size_ceiling };
+    const raised = config.Config{ .max_send_udp_payload_size = max_datagram_size_ceiling };
     var pair = try TestPair.initWithConfigs(allocator, raised, raised);
     defer pair.deinit(allocator);
 
@@ -7920,7 +8018,7 @@ test "driver: a raised local maximum does not widen the anti-amplification budge
 
 test "driver: raising the cap leaves packet-number and congestion accounting intact" {
     const allocator = testing.allocator;
-    const raised = config.Config{ .max_udp_payload_size = 1452 };
+    const raised = config.Config{ .max_send_udp_payload_size = 1452 };
     var pair = try TestPair.initWithConfigs(allocator, raised, raised);
     defer pair.deinit(allocator);
     try pair.pump();
@@ -7944,7 +8042,7 @@ test "driver: raising the cap leaves packet-number and congestion accounting int
 
 test "driver: a raised datagram cap cannot widen the congestion overshoot" {
     const allocator = testing.allocator;
-    const raised = config.Config{ .max_udp_payload_size = max_datagram_size_ceiling };
+    const raised = config.Config{ .max_send_udp_payload_size = max_datagram_size_ceiling };
     var pair = try TestPair.initWithConfigs(allocator, raised, raised);
     defer pair.deinit(allocator);
     try pair.pump();
@@ -7977,7 +8075,7 @@ test "driver: a raised datagram cap cannot widen the congestion overshoot" {
 
 test "driver: a PTO probe keeps its congestion exemption under a raised cap" {
     const allocator = testing.allocator;
-    const raised = config.Config{ .max_udp_payload_size = max_datagram_size_ceiling };
+    const raised = config.Config{ .max_send_udp_payload_size = max_datagram_size_ceiling };
     var pair = try TestPair.initWithConfigs(allocator, raised, raised);
     defer pair.deinit(allocator);
     try pair.pump();
@@ -8004,4 +8102,218 @@ test "driver: a PTO probe keeps its congestion exemption under a raised cap" {
     try testing.expect(probe.bytes.len > 0);
     try testing.expect(probe.bytes.len <= max_datagram_size_ceiling);
     try testing.expect(congestion.bytes_in_flight > congestion.congestion_window);
+}
+
+test "driver: the advertised receive capacity is separate from the send size" {
+    const allocator = testing.allocator;
+    // A conservative sender still advertises the full capacity it can
+    // actually deprotect: receive capability is not path state.
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    try testing.expectEqual(
+        @as(u64, max_receive_datagram_size),
+        pair.server.local_params.max_udp_payload_size,
+    );
+    try testing.expectEqual(
+        @as(u64, max_receive_datagram_size),
+        pair.client.peerTransportParameters().?.max_udp_payload_size,
+    );
+    // ... while ordinary sends stay at the RFC 9000 §14 floor by default.
+    try testing.expectEqual(base_datagram_size, pair.server.effectiveMaxDatagramSize());
+    try testing.expectEqual(base_datagram_size, pair.client.effectiveMaxDatagramSize());
+}
+
+test "driver: the default probe ceiling leaves headroom above the send size" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+
+    // Before authentication nothing may exceed the floor, in either role.
+    try testing.expectEqual(base_datagram_size, pair.client.probeMaxDatagramSize());
+
+    try pair.pump();
+    // Afterwards #256-B has somewhere to probe *to* without the operator
+    // having to pre-configure a larger value.
+    try testing.expectEqual(max_datagram_size_ceiling, pair.server.probeMaxDatagramSize());
+    try testing.expect(pair.server.probeMaxDatagramSize() > pair.server.effectiveMaxDatagramSize());
+}
+
+test "driver: a padded non-ack-eliciting packet counts as in flight" {
+    // RFC 9002 §2 — the predicate the send path keys recovery accounting off.
+    try testing.expect(recordIsInFlight(.{
+        .space = .initial,
+        .packet_number = 0,
+        .ack_eliciting = false,
+        .carried_padding = true,
+    }));
+    try testing.expect(recordIsInFlight(.{
+        .space = .application,
+        .packet_number = 0,
+        .ack_eliciting = true,
+    }));
+    // A genuine pure ACK stays exempt.
+    try testing.expect(!recordIsInFlight(.{
+        .space = .application,
+        .packet_number = 0,
+        .ack_eliciting = false,
+    }));
+}
+
+/// Queue a PATH_RESPONSE for `conn`'s own active path, the way an inbound
+/// PATH_CHALLENGE on that path would.
+fn queueActivePathResponse(allocator: std.mem.Allocator, conn: *Connection) !void {
+    try conn.pending_path_responses.append(allocator, .{
+        .path = conn.paths.activePath().key,
+        .data = [_]u8{0xa7} ** quic_path.path_challenge_len,
+    });
+}
+
+test "driver: an active-path PATH_RESPONSE waits for window for its padded size" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.initWithConfigs(
+        allocator,
+        .{},
+        .{ .max_send_udp_payload_size = max_datagram_size_ceiling },
+    );
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    // Real bytes in flight first, so the window below is genuinely tight
+    // rather than zero (which every gate deliberately lets through).
+    const sid = try openServerResponseStream(pair);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x22} ** 2048, false);
+    var out: [max_datagram_size_ceiling]u8 = undefined;
+    while (pair.server.pollTransmitOnPath(&out, pair.now_us)) |_| {
+        pair.now_us += 500;
+    }
+    const congestion = &pair.server.recovery.congestion;
+    try testing.expect(congestion.bytes_in_flight > 0);
+
+    try queueActivePathResponse(allocator, pair.server);
+
+    // Room enough to clear the send gate's half-datagram threshold, but less
+    // than the 1200 bytes RFC 9000 §8.2.1-2 forces the carrying datagram to —
+    // and recovery charges that padded size, not the frame's size. §8.2 lets
+    // validation be delayed, so the response stays queued.
+    const room: usize = max_datagram_size_ceiling / 2 + 64;
+    try testing.expect(room < min_initial_datagram);
+    congestion.congestion_window = congestion.bytes_in_flight + room;
+    const window_before = congestion.congestion_window;
+
+    while (pair.server.pollTransmitOnPath(&out, pair.now_us)) |t| {
+        try testing.expect(t.bytes.len < min_initial_datagram);
+        pair.now_us += 500;
+    }
+    try testing.expectEqual(@as(usize, 1), pair.server.pending_path_responses.items.len);
+    try testing.expect(congestion.bytes_in_flight <= window_before);
+
+    // Given room for the padded datagram it goes out, still inside the window.
+    congestion.congestion_window = congestion.bytes_in_flight + 4 * min_initial_datagram;
+    const window = congestion.congestion_window;
+    const in_flight_before = congestion.bytes_in_flight;
+    const sent = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
+    try testing.expectEqual(min_initial_datagram, sent.bytes.len);
+    try testing.expectEqual(@as(usize, 0), pair.server.pending_path_responses.items.len);
+    try testing.expect(congestion.bytes_in_flight > in_flight_before);
+    try testing.expect(congestion.bytes_in_flight <= window);
+}
+
+test "driver: candidate-path validation traffic waits for congestion window" {
+    const allocator = testing.allocator;
+    var pair = try MigrationPair.init(allocator, .full);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    // Put real bytes in flight on the active path first, so the window can be
+    // genuinely spent rather than merely zero.
+    const server_sid = try pair.server.openStream(.bidi);
+    const response = [_]u8{0x31} ** (8 * 1024);
+    _ = try pair.server.writeStream(server_sid, &response, false);
+    var out: [max_datagram_size_ceiling]u8 = undefined;
+    while (pair.server.pollTransmitOnPath(&out, pair.now_us)) |_| {
+        pair.now_us += 500;
+    }
+    const congestion = &pair.server.recovery.congestion;
+    try testing.expect(congestion.bytes_in_flight > 0);
+
+    // A datagram from a rebound address opens a candidate path and credits it
+    // enough anti-amplification budget for a padded PATH_CHALLENGE.
+    const sid = try pair.client.openStream(.bidi);
+    const big_payload = [_]u8{0x42} ** 900;
+    _ = try pair.client.writeStream(sid, &big_payload, false);
+    var buf: [max_datagram_size_ceiling]u8 = undefined;
+    const from_client = pair.client.pollTransmitOnPath(&buf, pair.now_us) orelse return error.TestExpectedEqual;
+    try pair.server.ingestOnPath(from_client.bytes, rebind_candidate, TestPair.test_challenge_entropy, pair.now_us);
+
+    // With the window spent, path validation is delayed (RFC 9000 §8.2) rather
+    // than sent without being charged: nothing goes to the candidate path.
+    congestion.congestion_window = congestion.bytes_in_flight;
+    const in_flight_before = congestion.bytes_in_flight;
+    while (pair.server.pollTransmitOnPath(&out, pair.now_us)) |t| {
+        try testing.expect(!t.path.eql(rebind_candidate));
+        pair.now_us += 500;
+    }
+    try testing.expectEqual(in_flight_before, congestion.bytes_in_flight);
+
+    // Once there is window for the padded probe it transmits and is charged.
+    congestion.congestion_window = congestion.bytes_in_flight + 4 * min_initial_datagram;
+    const window = congestion.congestion_window;
+    const probe = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
+    try testing.expect(probe.path.eql(rebind_candidate));
+    try testing.expect(congestion.bytes_in_flight > in_flight_before);
+    try testing.expect(congestion.bytes_in_flight <= window);
+}
+
+test "driver: a saturated recovery tracker backpressures instead of sending untracked" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.initWithConfigs(
+        allocator,
+        .{},
+        .{ .max_send_udp_payload_size = 1452 },
+    );
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const sid = try openServerResponseStream(pair);
+    const payload = [_]u8{0x77} ** (64 * 1024);
+    _ = try pair.server.writeStream(sid, &payload, false);
+
+    // Plenty of window, but the bounded tracker is full: an in-flight packet
+    // it cannot track would escape both loss detection and the window.
+    const congestion = &pair.server.recovery.congestion;
+    congestion.congestion_window = 1 << 24;
+    var i: u64 = 0;
+    while (pair.server.recovery.canTrackPacket()) : (i += 1) {
+        try pair.server.recovery.tracker.onPacketSent(.{
+            .space = .initial,
+            .packet_number = 100_000 + i,
+            .time_sent_us = 1,
+            .size = 0,
+        });
+    }
+    try testing.expect(!pair.server.recovery.canTrackPacket());
+
+    const in_flight_before = congestion.bytes_in_flight;
+    const pn_before = pair.server.next_pn[Connection.spaceIndex(.application)];
+    var out: [max_datagram_size_ceiling]u8 = undefined;
+    while (pair.server.pollTransmitOnPath(&out, pair.now_us)) |t| {
+        // Only genuinely exempt content may still leave; nothing carrying the
+        // queued stream data does.
+        try testing.expect(t.bytes.len < base_datagram_size);
+        pair.now_us += 500;
+    }
+    try testing.expectEqual(in_flight_before, congestion.bytes_in_flight);
+    try testing.expect(pair.server.hasAppContent());
+
+    // Freeing a slot lets the next packet send, tracked and charged.
+    _ = pair.server.recovery.tracker.dropSpace(.initial);
+    try testing.expect(pair.server.recovery.canTrackPacket());
+    const tracked_before = pair.server.recovery.tracker.count;
+    const sent = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
+    try testing.expect(sent.bytes.len > base_datagram_size / 2);
+    try testing.expect(pair.server.recovery.tracker.count > tracked_before);
+    try testing.expect(congestion.bytes_in_flight >= in_flight_before + sent.bytes.len);
+    try testing.expect(pair.server.next_pn[Connection.spaceIndex(.application)] > pn_before);
 }

--- a/src/quic/datagram.zig
+++ b/src/quic/datagram.zig
@@ -1,0 +1,153 @@
+//! The one authoritative outbound UDP datagram size for pure Zig QUIC
+//! (#256-A).
+//!
+//! Datagram sizing used to be two independent knobs that could drift: the
+//! transport config's `max_udp_payload_size` and the HTTP/3 runtime's
+//! `max_datagram_size`, with the packet builder ignoring both in favour of a
+//! hardcoded constant. This module owns the single set of bounds and the one
+//! rule that combines them, so every surface derives its value from here.
+//!
+//! Nothing in this file does I/O or knows about paths, sockets, or packets;
+//! it is a pure function of the three inputs in `Limits`.
+
+const std = @import("std");
+
+/// RFC 9000 §14: every QUIC path must be able to carry a 1200-byte UDP
+/// payload, and §14.1 requires a datagram carrying an Initial packet to be
+/// padded to at least that size. So it is simultaneously the floor of any
+/// effective cap and the value the stack falls back to whenever nothing
+/// larger has been established. Also the operator-facing default.
+pub const base_size: usize = 1200;
+
+/// Hard ceiling on any datagram this stack will emit, whatever an operator or
+/// peer asks for. It bounds the per-packet plaintext scratch buffers in
+/// `connection.zig` and the transmit/receive buffers in the HTTP/3 runtime,
+/// so raising it means raising those too.
+pub const max_size: usize = 2048;
+
+/// The inputs to the effective outbound datagram cap. Every field is an upper
+/// bound in its own right; the cap is the smallest of them, clamped to
+/// `[base_size, max_size]`.
+pub const Limits = struct {
+    /// The locally configured maximum (`quic.config.Config.max_udp_payload_size`).
+    /// This is the operator's assertion about what the local host and path
+    /// can carry.
+    local_max: u64 = base_size,
+    /// The peer's advertised `max_udp_payload_size` transport parameter, once
+    /// transport parameters have been authenticated. `null` before then, and
+    /// treated as `base_size`: during the handshake we know least about both
+    /// the peer and the path, so the cap collapses to the size RFC 9000 §14
+    /// guarantees. A raised `local_max` therefore only takes effect once the
+    /// peer has actually committed to accepting larger datagrams.
+    peer_max: ?u64 = null,
+    /// The largest datagram size validated for the current path. `null` means
+    /// "not yet constrained by path measurement", in which case the locally
+    /// configured maximum stands in as the operator's path assertion.
+    ///
+    /// #256-B replaces that with per-path DPLPMTUD (RFC 8899) state and
+    /// black-hole fallback; until it lands, the shipped default for
+    /// `local_max` is `base_size`, so the stack does not assume any path
+    /// carries more than the RFC floor unless an operator says so.
+    validated_path_max: ?u64 = null,
+
+    /// The largest ordinary UDP datagram that may be emitted under these
+    /// limits. Never below `base_size` (Initial padding and the RFC floor
+    /// both need it) and never above `max_size`.
+    pub fn effective(self: Limits) usize {
+        var cap = self.endpointCeiling();
+        if (self.validated_path_max) |path_max| cap = @min(cap, clampToRange(path_max));
+        return cap;
+    }
+
+    /// The bound imposed by the two endpoints alone, ignoring what the path
+    /// has been shown to carry. A PMTU probe (#256-B) is allowed to exceed
+    /// `effective()` because exceeding the validated path size is the point,
+    /// but it must never exceed this: the peer will drop anything larger than
+    /// its advertised `max_udp_payload_size`, and the local ceiling bounds our
+    /// own buffers.
+    pub fn probeCeiling(self: Limits) usize {
+        return self.endpointCeiling();
+    }
+
+    fn endpointCeiling(self: Limits) usize {
+        return @min(clampToRange(self.local_max), clampToRange(self.peer_max orelse base_size));
+    }
+};
+
+/// Clamp one advertised or configured bound into the representable range.
+/// Values below `base_size` are raised rather than honoured: a peer
+/// advertising less than 1200 is already rejected as an invalid transport
+/// parameter, and we could not honour it anyway without violating the Initial
+/// padding rule.
+fn clampToRange(value: u64) usize {
+    if (value <= base_size) return base_size;
+    if (value >= max_size) return max_size;
+    return @intCast(value);
+}
+
+const testing = std.testing;
+
+test "datagram: defaults sit at the RFC 9000 floor" {
+    const limits = Limits{};
+    try testing.expectEqual(base_size, limits.effective());
+    try testing.expectEqual(base_size, limits.probeCeiling());
+}
+
+test "datagram: a larger local maximum raises the cap up to the ceiling" {
+    try testing.expectEqual(
+        @as(usize, 1452),
+        (Limits{ .local_max = 1452, .peer_max = 65_527 }).effective(),
+    );
+    try testing.expectEqual(
+        max_size,
+        (Limits{ .local_max = 65_527, .peer_max = 65_527 }).effective(),
+    );
+}
+
+test "datagram: the cap stays at the floor until the peer's parameters arrive" {
+    // Nothing an operator configures locally may raise the cap while the
+    // peer has not yet committed to accepting larger datagrams.
+    try testing.expectEqual(base_size, (Limits{ .local_max = 1500 }).effective());
+    try testing.expectEqual(base_size, (Limits{ .local_max = max_size }).probeCeiling());
+}
+
+test "datagram: the peer's advertised maximum lowers the cap" {
+    const limits = Limits{ .local_max = 1500, .peer_max = 1300 };
+    try testing.expectEqual(@as(usize, 1300), limits.effective());
+}
+
+test "datagram: a larger local maximum never overrides a smaller peer limit" {
+    const limits = Limits{ .local_max = max_size, .peer_max = 1200 };
+    try testing.expectEqual(base_size, limits.effective());
+}
+
+test "datagram: a larger peer maximum never raises the cap past the local one" {
+    const limits = Limits{ .local_max = 1300, .peer_max = 65_527 };
+    try testing.expectEqual(@as(usize, 1300), limits.effective());
+}
+
+test "datagram: the validated path size lowers the cap but never below the floor" {
+    try testing.expectEqual(
+        @as(usize, 1350),
+        (Limits{ .local_max = 1500, .peer_max = 1500, .validated_path_max = 1350 }).effective(),
+    );
+    try testing.expectEqual(
+        base_size,
+        (Limits{ .local_max = 1500, .peer_max = 1500, .validated_path_max = 900 }).effective(),
+    );
+}
+
+test "datagram: probes may exceed the validated path size but not the endpoint bounds" {
+    const limits = Limits{ .local_max = 1500, .peer_max = 1400, .validated_path_max = base_size };
+    try testing.expectEqual(base_size, limits.effective());
+    try testing.expectEqual(@as(usize, 1400), limits.probeCeiling());
+}
+
+test "datagram: out-of-range bounds are clamped rather than trusted" {
+    try testing.expectEqual(base_size, (Limits{ .local_max = 0, .peer_max = 65_527 }).effective());
+    try testing.expectEqual(base_size, (Limits{ .local_max = 1500, .peer_max = 0 }).effective());
+    try testing.expectEqual(
+        max_size,
+        (Limits{ .local_max = std.math.maxInt(u64), .peer_max = std.math.maxInt(u64) }).effective(),
+    );
+}

--- a/src/quic/datagram.zig
+++ b/src/quic/datagram.zig
@@ -25,52 +25,45 @@ pub const base_size: usize = 1200;
 /// so raising it means raising those too.
 pub const max_size: usize = 2048;
 
-/// The inputs to the effective outbound datagram cap. Every field is an upper
-/// bound in its own right; the cap is the smallest of them, clamped to
-/// `[base_size, max_size]`.
+/// The inputs to the outbound datagram limits.
+///
+/// These are *send*-side quantities. They are deliberately separate from the
+/// `max_udp_payload_size` transport parameter an endpoint advertises, which is
+/// what that endpoint is willing to *receive* (RFC 9000 §18.2) — an immutable
+/// statement of receive capacity, not mutable path state. Only the peer's
+/// advertisement appears here, as a ceiling on what we may send it.
 pub const Limits = struct {
-    /// The locally configured maximum (`quic.config.Config.max_udp_payload_size`).
-    /// This is the operator's assertion about what the local host and path
-    /// can carry.
-    local_max: u64 = base_size,
-    /// The peer's advertised `max_udp_payload_size` transport parameter, once
-    /// transport parameters have been authenticated. `null` before then, and
-    /// treated as `base_size`: during the handshake we know least about both
-    /// the peer and the path, so the cap collapses to the size RFC 9000 §14
-    /// guarantees. A raised `local_max` therefore only takes effect once the
-    /// peer has actually committed to accepting larger datagrams.
+    /// The sender's current maximum datagram size for the active path: what
+    /// this stack believes the path carries today. Starts at `base_size`, the
+    /// only size RFC 9000 §14 guarantees. An operator may assert a larger
+    /// value for a path whose MTU they control; #256-B replaces the assertion
+    /// with measured DPLPMTUD state and black-hole fallback.
+    current_path_max: u64 = base_size,
+    /// The largest datagram this endpoint will ever emit, independent of what
+    /// the path has been shown to carry. This is the ceiling a PMTU probe may
+    /// reach for, so it must have headroom above `base_size` or #256-B could
+    /// never discover anything.
+    send_ceiling: u64 = max_size,
+    /// The peer's advertised `max_udp_payload_size`: its receive capacity,
+    /// once transport parameters have been authenticated. `null` before then,
+    /// and treated as `base_size` — during the handshake we know least about
+    /// both the peer and the path, so everything collapses to the size RFC
+    /// 9000 §14 guarantees.
     peer_max: ?u64 = null,
-    /// The largest datagram size validated for the current path. `null` means
-    /// "not yet constrained by path measurement", in which case the locally
-    /// configured maximum stands in as the operator's path assertion.
-    ///
-    /// #256-B replaces that with per-path DPLPMTUD (RFC 8899) state and
-    /// black-hole fallback; until it lands, the shipped default for
-    /// `local_max` is `base_size`, so the stack does not assume any path
-    /// carries more than the RFC floor unless an operator says so.
-    validated_path_max: ?u64 = null,
 
-    /// The largest ordinary UDP datagram that may be emitted under these
-    /// limits. Never below `base_size` (Initial padding and the RFC floor
-    /// both need it) and never above `max_size`.
+    /// The largest ordinary UDP datagram that may be emitted. Never below
+    /// `base_size` (Initial padding and the RFC floor both need it) and never
+    /// above `max_size`.
     pub fn effective(self: Limits) usize {
-        var cap = self.endpointCeiling();
-        if (self.validated_path_max) |path_max| cap = @min(cap, clampToRange(path_max));
-        return cap;
+        return @min(clampToRange(self.current_path_max), self.probeCeiling());
     }
 
-    /// The bound imposed by the two endpoints alone, ignoring what the path
-    /// has been shown to carry. A PMTU probe (#256-B) is allowed to exceed
-    /// `effective()` because exceeding the validated path size is the point,
-    /// but it must never exceed this: the peer will drop anything larger than
-    /// its advertised `max_udp_payload_size`, and the local ceiling bounds our
-    /// own buffers.
+    /// The largest datagram a PMTU probe (#256-B) may attempt. A probe is
+    /// allowed to exceed `effective()` — exceeding the current path size is
+    /// the point — but never this: the peer drops anything above its
+    /// advertised receive capacity, and the local ceiling bounds our buffers.
     pub fn probeCeiling(self: Limits) usize {
-        return self.endpointCeiling();
-    }
-
-    fn endpointCeiling(self: Limits) usize {
-        return @min(clampToRange(self.local_max), clampToRange(self.peer_max orelse base_size));
+        return @min(clampToRange(self.send_ceiling), clampToRange(self.peer_max orelse base_size));
     }
 };
 
@@ -87,67 +80,75 @@ fn clampToRange(value: u64) usize {
 
 const testing = std.testing;
 
-test "datagram: defaults sit at the RFC 9000 floor" {
+test "datagram: defaults send at the RFC 9000 floor" {
     const limits = Limits{};
     try testing.expectEqual(base_size, limits.effective());
+    // Pre-authentication the probe ceiling collapses too: the peer has not
+    // yet said it can receive more.
     try testing.expectEqual(base_size, limits.probeCeiling());
 }
 
-test "datagram: a larger local maximum raises the cap up to the ceiling" {
+test "datagram: an authenticated peer leaves probe headroom above the floor" {
+    // The default send ceiling must let #256-B probe upward once the peer's
+    // receive capacity is known; ordinary sends stay at the current path size.
+    const limits = Limits{ .peer_max = max_size };
+    try testing.expectEqual(base_size, limits.effective());
+    try testing.expectEqual(max_size, limits.probeCeiling());
+    try testing.expect(limits.probeCeiling() > limits.effective());
+}
+
+test "datagram: the current path size raises ordinary sends up to the ceiling" {
     try testing.expectEqual(
         @as(usize, 1452),
-        (Limits{ .local_max = 1452, .peer_max = 65_527 }).effective(),
+        (Limits{ .current_path_max = 1452, .peer_max = 65_527 }).effective(),
     );
     try testing.expectEqual(
         max_size,
-        (Limits{ .local_max = 65_527, .peer_max = 65_527 }).effective(),
+        (Limits{ .current_path_max = 65_527, .peer_max = 65_527 }).effective(),
     );
 }
 
-test "datagram: the cap stays at the floor until the peer's parameters arrive" {
-    // Nothing an operator configures locally may raise the cap while the
-    // peer has not yet committed to accepting larger datagrams.
-    try testing.expectEqual(base_size, (Limits{ .local_max = 1500 }).effective());
-    try testing.expectEqual(base_size, (Limits{ .local_max = max_size }).probeCeiling());
+test "datagram: nothing raises the send size until the peer's parameters arrive" {
+    try testing.expectEqual(base_size, (Limits{ .current_path_max = 1500 }).effective());
+    try testing.expectEqual(base_size, (Limits{ .send_ceiling = max_size }).probeCeiling());
 }
 
-test "datagram: the peer's advertised maximum lowers the cap" {
-    const limits = Limits{ .local_max = 1500, .peer_max = 1300 };
+test "datagram: the peer's advertised receive capacity lowers the send size" {
+    const limits = Limits{ .current_path_max = 1500, .peer_max = 1300 };
     try testing.expectEqual(@as(usize, 1300), limits.effective());
+    try testing.expectEqual(@as(usize, 1300), limits.probeCeiling());
 }
 
-test "datagram: a larger local maximum never overrides a smaller peer limit" {
-    const limits = Limits{ .local_max = max_size, .peer_max = 1200 };
+test "datagram: a larger local path size never overrides a smaller peer limit" {
+    const limits = Limits{ .current_path_max = max_size, .peer_max = base_size };
     try testing.expectEqual(base_size, limits.effective());
 }
 
-test "datagram: a larger peer maximum never raises the cap past the local one" {
-    const limits = Limits{ .local_max = 1300, .peer_max = 65_527 };
+test "datagram: a larger peer capacity never raises past the local path size" {
+    const limits = Limits{ .current_path_max = 1300, .peer_max = 65_527 };
     try testing.expectEqual(@as(usize, 1300), limits.effective());
 }
 
-test "datagram: the validated path size lowers the cap but never below the floor" {
-    try testing.expectEqual(
-        @as(usize, 1350),
-        (Limits{ .local_max = 1500, .peer_max = 1500, .validated_path_max = 1350 }).effective(),
-    );
-    try testing.expectEqual(
-        base_size,
-        (Limits{ .local_max = 1500, .peer_max = 1500, .validated_path_max = 900 }).effective(),
-    );
+test "datagram: the send ceiling bounds both ordinary sends and probes" {
+    const limits = Limits{ .current_path_max = max_size, .send_ceiling = 1400, .peer_max = max_size };
+    try testing.expectEqual(@as(usize, 1400), limits.effective());
+    try testing.expectEqual(@as(usize, 1400), limits.probeCeiling());
 }
 
-test "datagram: probes may exceed the validated path size but not the endpoint bounds" {
-    const limits = Limits{ .local_max = 1500, .peer_max = 1400, .validated_path_max = base_size };
+test "datagram: probes may exceed the current path size but not the endpoint bounds" {
+    const limits = Limits{ .current_path_max = base_size, .send_ceiling = 1500, .peer_max = 1400 };
     try testing.expectEqual(base_size, limits.effective());
     try testing.expectEqual(@as(usize, 1400), limits.probeCeiling());
 }
 
 test "datagram: out-of-range bounds are clamped rather than trusted" {
-    try testing.expectEqual(base_size, (Limits{ .local_max = 0, .peer_max = 65_527 }).effective());
-    try testing.expectEqual(base_size, (Limits{ .local_max = 1500, .peer_max = 0 }).effective());
+    try testing.expectEqual(base_size, (Limits{ .current_path_max = 0, .peer_max = 65_527 }).effective());
+    try testing.expectEqual(base_size, (Limits{ .current_path_max = 1500, .peer_max = 0 }).effective());
     try testing.expectEqual(
         max_size,
-        (Limits{ .local_max = std.math.maxInt(u64), .peer_max = std.math.maxInt(u64) }).effective(),
+        (Limits{
+            .current_path_max = std.math.maxInt(u64),
+            .peer_max = std.math.maxInt(u64),
+        }).effective(),
     );
 }

--- a/src/quic/path.zig
+++ b/src/quic/path.zig
@@ -1458,7 +1458,7 @@ test "a real migration validates and requires congestion/RTT reset" {
     controller.congestion.onPacketSent(old_path_packet.size);
     controller.resetForPathMigration();
     try testing.expect(!controller.rtt.hasSample());
-    try testing.expectEqual(recovery.CongestionController.initialWindow(recovery.max_datagram_size), controller.congestion.congestion_window);
+    try testing.expectEqual(recovery.CongestionController.initialWindow(recovery.initial_max_datagram_size), controller.congestion.congestion_window);
     // Packets in flight on the old path stay in the single send ledger...
     try testing.expectEqual(@as(usize, 999), controller.congestion.bytes_in_flight);
     // ...and drain through the normal ack path without corrupting accounting.

--- a/src/quic/recovery.zig
+++ b/src/quic/recovery.zig
@@ -12,6 +12,13 @@ const std = @import("std");
 
 pub const max_ack_ranges = 32;
 pub const max_tracked_packets = 128;
+/// Tracker slots held back from ordinary STREAM/CRYPTO traffic for packets
+/// recovery cannot defer: PTO probes (RFC 9002 §6.2.4 requires at least one
+/// ack-eliciting probe) and packets that become in-flight only through
+/// mandatory PADDING. Ordinary traffic backpressures at
+/// `max_tracked_packets - reserved_tracked_packets` so the reserve is still
+/// there when recovery needs it (#256-A review).
+pub const reserved_tracked_packets = 8;
 /// The sender's maximum datagram size at connection start (RFC 9000 §14's
 /// floor). RFC 9002 defines the NewReno windows in terms of the sender's
 /// *current* maximum datagram size, so this is only the starting value:
@@ -460,12 +467,35 @@ pub const RecoveryController = struct {
         return self.ack_ranges[spaceIndex(space)].toAckFrame(ack_delay_us);
     }
 
-    /// Whether the bounded tracker can still take one more sent packet.
-    /// Callers must preflight this before dequeuing frames for an in-flight
-    /// packet: an untracked in-flight packet escapes both loss recovery and
-    /// the congestion window (#256-A review).
+    /// Whether the bounded tracker can take one more *ordinary* sent packet —
+    /// stopping short of the recovery reserve. Callers must preflight this
+    /// before dequeuing frames: an untracked in-flight packet escapes both
+    /// loss recovery and the congestion window, and because nothing can ever
+    /// remove its bytes again it permanently inflates `bytes_in_flight`
+    /// (#256-A review).
     pub fn canTrackPacket(self: *const RecoveryController) bool {
+        return self.tracker.count + reserved_tracked_packets < max_tracked_packets;
+    }
+
+    /// Whether the tracker can take one more packet drawn from the recovery
+    /// reserve. RFC 9002 §7.5 exempts a PTO probe from the congestion-window
+    /// admission gate but still counts it in flight, so a probe needs a slot
+    /// like anything else — when even the reserve is gone the probe waits
+    /// rather than being emitted untracked.
+    pub fn canTrackRecoveryPacket(self: *const RecoveryController) bool {
         return self.tracker.count < max_tracked_packets;
+    }
+
+    /// Record a sent packet whose tracker slot the caller already preflighted
+    /// with `canTrackPacket`/`canTrackRecoveryPacket`. Infallible by
+    /// construction: the send path has no safe way to handle a failure here
+    /// (the packet is already sealed and its frames already dequeued), so the
+    /// capacity check belongs before the frames are committed, and this
+    /// asserts that it happened.
+    pub fn onPacketSentAssumeCapacity(self: *RecoveryController, packet: SentPacket) void {
+        std.debug.assert(self.canTrackRecoveryPacket());
+        self.tracker.onPacketSent(packet) catch unreachable;
+        if (packet.in_flight) self.congestion.onPacketSent(packet.size);
     }
 
     pub fn onPacketSent(self: *RecoveryController, packet: SentPacket) error{TooManyTrackedPackets}!void {
@@ -854,11 +884,14 @@ test "recovery: a padded non-ack-eliciting packet is charged to the window" {
     try testing.expectEqual(@as(usize, 1200), controller.congestion.bytes_in_flight);
 }
 
-test "recovery: the bounded tracker reports when it can no longer take a packet" {
+test "recovery: ordinary traffic backpressures before the recovery reserve" {
     var controller = RecoveryController{};
+    const ordinary_capacity = max_tracked_packets - reserved_tracked_packets;
+
     var i: usize = 0;
-    while (i < max_tracked_packets) : (i += 1) {
+    while (i < ordinary_capacity) : (i += 1) {
         try testing.expect(controller.canTrackPacket());
+        try testing.expect(controller.canTrackRecoveryPacket());
         try controller.onPacketSent(.{
             .space = .application,
             .packet_number = i,
@@ -866,11 +899,34 @@ test "recovery: the bounded tracker reports when it can no longer take a packet"
             .size = 100,
         });
     }
+
+    // Ordinary traffic is done, but the reserve is intact for PTO probes and
+    // mandatory-padding packets.
     try testing.expect(!controller.canTrackPacket());
+    try testing.expect(controller.canTrackRecoveryPacket());
+
+    while (i < max_tracked_packets) : (i += 1) {
+        try testing.expect(controller.canTrackRecoveryPacket());
+        controller.onPacketSentAssumeCapacity(.{
+            .space = .application,
+            .packet_number = i,
+            .time_sent_us = i,
+            .size = 100,
+        });
+    }
+
+    // Fully saturated: recovery traffic must now wait rather than go
+    // untracked, which is what the send path's preflight enforces.
+    try testing.expect(!controller.canTrackRecoveryPacket());
     try testing.expectError(error.TooManyTrackedPackets, controller.onPacketSent(.{
         .space = .application,
         .packet_number = max_tracked_packets,
         .time_sent_us = 9_999,
         .size = 100,
     }));
+
+    // Freeing capacity restores both tiers in the right order.
+    _ = controller.tracker.dropSpace(.application);
+    try testing.expect(controller.canTrackRecoveryPacket());
+    try testing.expect(controller.canTrackPacket());
 }

--- a/src/quic/recovery.zig
+++ b/src/quic/recovery.zig
@@ -12,8 +12,12 @@ const std = @import("std");
 
 pub const max_ack_ranges = 32;
 pub const max_tracked_packets = 128;
-pub const max_datagram_size: usize = 1200;
-pub const min_congestion_window: usize = 2 * max_datagram_size;
+/// The sender's maximum datagram size at connection start (RFC 9000 §14's
+/// floor). RFC 9002 defines the NewReno windows in terms of the sender's
+/// *current* maximum datagram size, so this is only the starting value:
+/// `CongestionController.max_datagram_size` carries the live one and
+/// `setMaxDatagramSize` tracks it as the path's send size changes (#256-A).
+pub const initial_max_datagram_size: usize = 1200;
 pub const initial_rtt_us: u64 = 333_000;
 pub const timer_granularity_us: u64 = 1_000;
 pub const packet_threshold: u64 = 3;
@@ -350,13 +354,33 @@ pub const PacketTracker = struct {
 };
 
 pub const CongestionController = struct {
-    congestion_window: usize = initialWindow(max_datagram_size),
+    congestion_window: usize = initialWindow(initial_max_datagram_size),
     bytes_in_flight: usize = 0,
     ssthresh: usize = std.math.maxInt(usize),
     recovery_start_time_us: ?u64 = null,
+    /// The sender's current maximum datagram size (RFC 9002 §B.2). Every
+    /// NewReno window below is expressed in terms of it, so it must follow the
+    /// size the packet builder actually emits rather than a compile-time
+    /// constant (#256-A).
+    max_datagram_size: usize = initial_max_datagram_size,
 
     pub fn initialWindow(max_datagram: usize) usize {
         return @min(10 * max_datagram, @max(2 * max_datagram, 14_720));
+    }
+
+    pub fn minWindow(self: CongestionController) usize {
+        return 2 * self.max_datagram_size;
+    }
+
+    /// Adopt a new sender maximum datagram size. The congestion window is not
+    /// recomputed — it reflects measured capacity, not the packet size — but
+    /// it is lifted to the new minimum so a larger datagram can never be
+    /// blocked by a floor derived from a smaller one.
+    pub fn setMaxDatagramSize(self: *CongestionController, size: usize) void {
+        if (size == 0 or size == self.max_datagram_size) return;
+        self.max_datagram_size = size;
+        const floor = self.minWindow();
+        if (self.congestion_window < floor) self.congestion_window = floor;
     }
 
     pub fn onPacketSent(self: *CongestionController, bytes: usize) void {
@@ -371,7 +395,7 @@ pub const CongestionController = struct {
         if (self.congestion_window < self.ssthresh) {
             self.congestion_window += packet.size;
         } else {
-            self.congestion_window += @max(1, max_datagram_size * packet.size / self.congestion_window);
+            self.congestion_window += @max(1, self.max_datagram_size * packet.size / self.congestion_window);
         }
     }
 
@@ -382,13 +406,13 @@ pub const CongestionController = struct {
             if (largest_lost_time_sent_us <= start) return;
         }
         self.recovery_start_time_us = now_us;
-        self.congestion_window = @max(self.congestion_window / 2, min_congestion_window);
+        self.congestion_window = @max(self.congestion_window / 2, self.minWindow());
         self.ssthresh = self.congestion_window;
     }
 
     pub fn onPersistentCongestion(self: *CongestionController) void {
-        self.congestion_window = min_congestion_window;
-        self.ssthresh = min_congestion_window;
+        self.congestion_window = self.minWindow();
+        self.ssthresh = self.congestion_window;
     }
 
     pub fn pacingHint(self: CongestionController, now_us: u64, rtt: RttEstimator) PacingHint {
@@ -434,6 +458,14 @@ pub const RecoveryController = struct {
 
     pub fn ackFrameForSpace(self: *const RecoveryController, space: PacketNumberSpace, ack_delay_us: u64) ?AckFrameModel {
         return self.ack_ranges[spaceIndex(space)].toAckFrame(ack_delay_us);
+    }
+
+    /// Whether the bounded tracker can still take one more sent packet.
+    /// Callers must preflight this before dequeuing frames for an in-flight
+    /// packet: an untracked in-flight packet escapes both loss recovery and
+    /// the congestion window (#256-A review).
+    pub fn canTrackPacket(self: *const RecoveryController) bool {
+        return self.tracker.count < max_tracked_packets;
     }
 
     pub fn onPacketSent(self: *RecoveryController, packet: SentPacket) error{TooManyTrackedPackets}!void {
@@ -487,7 +519,14 @@ pub const RecoveryController = struct {
     /// per-path controllers, which is multipath-adjacent work outside #251.
     pub fn resetForPathMigration(self: *RecoveryController) void {
         self.rtt = RttEstimator.init(self.rtt.max_ack_delay_us);
-        self.congestion = .{ .bytes_in_flight = self.congestion.bytes_in_flight };
+        // A migration resets the measured window, not the sender's datagram
+        // size: the packet builder is still emitting that size, and #256-B
+        // revalidates the new path's PMTU separately.
+        self.congestion = .{
+            .bytes_in_flight = self.congestion.bytes_in_flight,
+            .max_datagram_size = self.congestion.max_datagram_size,
+            .congestion_window = CongestionController.initialWindow(self.congestion.max_datagram_size),
+        };
     }
 
     /// RFC 9002 §6.4: drop a packet-number space's tracked packets and ACK
@@ -639,12 +678,12 @@ test "NewReno baseline halves cwnd and persistent congestion uses minimum window
 
     cc.onPacketsLost(2_000, 1_200, 50_000);
     try testing.expectEqual(@as(usize, 1_600), cc.bytes_in_flight);
-    try testing.expect(cc.congestion_window >= min_congestion_window);
+    try testing.expect(cc.congestion_window >= cc.minWindow());
     try testing.expectEqual(cc.congestion_window, cc.ssthresh);
 
     cc.onPersistentCongestion();
-    try testing.expectEqual(@as(usize, min_congestion_window), cc.congestion_window);
-    try testing.expectEqual(@as(usize, min_congestion_window), cc.ssthresh);
+    try testing.expectEqual(cc.minWindow(), cc.congestion_window);
+    try testing.expectEqual(cc.minWindow(), cc.ssthresh);
 }
 
 test "NewReno recovery period prevents repeated cwnd cuts and old ACK growth" {
@@ -722,4 +761,116 @@ test "recovery controller wires ACK RTT loss congestion and events" {
 
 test {
     std.testing.refAllDecls(@This());
+}
+
+// ---------------------------------------------------------------------------
+// #256-A: the sender's current maximum datagram size drives NewReno.
+// ---------------------------------------------------------------------------
+
+test "congestion: the initial and minimum windows follow the sender's datagram size" {
+    // RFC 9002 §7.2/§7.3 express both in terms of the sender's current max
+    // datagram size, so a 1452- or 2048-byte sender gets proportionally
+    // larger windows than the 1200-byte floor.
+    // min(10*mds, max(2*mds, 14720)) per RFC 9002 §7.2.
+    try testing.expectEqual(@as(usize, 12_000), CongestionController.initialWindow(1200));
+    try testing.expectEqual(@as(usize, 14_520), CongestionController.initialWindow(1452));
+    try testing.expectEqual(@as(usize, 14_720), CongestionController.initialWindow(2048));
+
+    var cc = CongestionController{};
+    try testing.expectEqual(@as(usize, 2 * 1200), cc.minWindow());
+    cc.setMaxDatagramSize(1452);
+    try testing.expectEqual(@as(usize, 2 * 1452), cc.minWindow());
+    cc.setMaxDatagramSize(2048);
+    try testing.expectEqual(@as(usize, 2 * 2048), cc.minWindow());
+}
+
+test "congestion: adopting a larger datagram size lifts a window below the new floor" {
+    var cc = CongestionController{};
+    cc.congestion_window = 2 * initial_max_datagram_size;
+    cc.setMaxDatagramSize(2048);
+    // The window is measured capacity and is not rescaled, but it can never
+    // sit below a floor that would block a single datagram pair.
+    try testing.expectEqual(@as(usize, 2 * 2048), cc.congestion_window);
+}
+
+test "congestion: avoidance growth is proportional to the sender's datagram size" {
+    const acked = SentPacket{ .space = .application, .packet_number = 1, .time_sent_us = 0, .size = 1200 };
+
+    var small = CongestionController{ .congestion_window = 30_000, .ssthresh = 1_000, .bytes_in_flight = 1200 };
+    small.onPacketAcked(acked);
+    const small_growth = small.congestion_window - 30_000;
+
+    var large = CongestionController{ .congestion_window = 30_000, .ssthresh = 1_000, .bytes_in_flight = 1200 };
+    large.setMaxDatagramSize(2048);
+    large.onPacketAcked(acked);
+    const large_growth = large.congestion_window - 30_000;
+
+    try testing.expectEqual(@as(usize, 1200 * 1200 / 30_000), small_growth);
+    try testing.expectEqual(@as(usize, 2048 * 1200 / 30_000), large_growth);
+    try testing.expect(large_growth > small_growth);
+}
+
+test "congestion: loss and persistent congestion respect the larger floor" {
+    var cc = CongestionController{ .congestion_window = 40_000, .bytes_in_flight = 4_000 };
+    cc.setMaxDatagramSize(2048);
+    cc.onPacketsLost(10, 4_000, 100);
+    try testing.expect(cc.congestion_window >= cc.minWindow());
+
+    cc.onPersistentCongestion();
+    try testing.expectEqual(@as(usize, 2 * 2048), cc.congestion_window);
+    try testing.expectEqual(@as(usize, 2 * 2048), cc.ssthresh);
+}
+
+test "recovery: a path migration resets the window but keeps the sender's datagram size" {
+    var controller = RecoveryController{};
+    controller.congestion.setMaxDatagramSize(1452);
+    controller.congestion.congestion_window = 90_000;
+    controller.congestion.ssthresh = 40_000;
+    controller.congestion.bytes_in_flight = 3_000;
+
+    controller.resetForPathMigration();
+
+    // The measured window is discarded (RFC 9002 §7.8) but the size the packet
+    // builder is still emitting is not.
+    try testing.expectEqual(@as(usize, 1452), controller.congestion.max_datagram_size);
+    try testing.expectEqual(
+        CongestionController.initialWindow(1452),
+        controller.congestion.congestion_window,
+    );
+    try testing.expectEqual(@as(usize, std.math.maxInt(usize)), controller.congestion.ssthresh);
+    try testing.expectEqual(@as(usize, 3_000), controller.congestion.bytes_in_flight);
+}
+
+test "recovery: a padded non-ack-eliciting packet is charged to the window" {
+    var controller = RecoveryController{};
+    try controller.onPacketSent(.{
+        .space = .initial,
+        .packet_number = 0,
+        .time_sent_us = 0,
+        .size = 1200,
+        .ack_eliciting = false,
+        .in_flight = true,
+    });
+    try testing.expectEqual(@as(usize, 1200), controller.congestion.bytes_in_flight);
+}
+
+test "recovery: the bounded tracker reports when it can no longer take a packet" {
+    var controller = RecoveryController{};
+    var i: usize = 0;
+    while (i < max_tracked_packets) : (i += 1) {
+        try testing.expect(controller.canTrackPacket());
+        try controller.onPacketSent(.{
+            .space = .application,
+            .packet_number = i,
+            .time_sent_us = i,
+            .size = 100,
+        });
+    }
+    try testing.expect(!controller.canTrackPacket());
+    try testing.expectError(error.TooManyTrackedPackets, controller.onPacketSent(.{
+        .space = .application,
+        .packet_number = max_tracked_packets,
+        .time_sent_us = 9_999,
+        .size = 100,
+    }));
 }

--- a/src/quic/recovery.zig
+++ b/src/quic/recovery.zig
@@ -12,12 +12,10 @@ const std = @import("std");
 
 pub const max_ack_ranges = 32;
 pub const max_tracked_packets = 128;
-/// Tracker slots held back from ordinary STREAM/CRYPTO traffic for packets
-/// recovery cannot defer: PTO probes (RFC 9002 §6.2.4 requires at least one
-/// ack-eliciting probe) and packets that become in-flight only through
-/// mandatory PADDING. Ordinary traffic backpressures at
-/// `max_tracked_packets - reserved_tracked_packets` so the reserve is still
-/// there when recovery needs it (#256-A review).
+/// Fixed-array slots held back from ordinary STREAM/CRYPTO traffic so common
+/// PTO and mandatory-PADDING recovery stays allocation-free. This is a
+/// performance reserve, not a correctness bound: when the fixed tracker fills,
+/// required recovery packets spill into `PacketTracker.recovery_overflow`.
 pub const reserved_tracked_packets = 8;
 /// The sender's maximum datagram size at connection start (RFC 9000 §14's
 /// floor). RFC 9002 defines the NewReno windows in terms of the sender's
@@ -260,15 +258,57 @@ pub const LossResult = struct {
 };
 
 pub const PacketTracker = struct {
+    /// Fixed fast path. Ordinary traffic is bounded here and never consumes
+    /// allocator-backed overflow.
     packets: [max_tracked_packets]SentPacket = undefined,
     count: usize = 0,
+    /// Required recovery-only spill storage. PTO expiration is not evidence of
+    /// loss, so a full fixed tracker cannot be made available by pretending an
+    /// outstanding packet stopped being in flight. Instead, reserve overflow
+    /// before building the recovery packet and keep tracking both originals and
+    /// probes until normal ACK/loss/key-discard processing retires them.
+    recovery_overflow: std.ArrayList(SentPacket) = .empty,
     bytes_in_flight: usize = 0,
     largest_acked: [3]?u64 = .{ null, null, null },
 
+    pub fn deinit(self: *PacketTracker, allocator: std.mem.Allocator) void {
+        self.recovery_overflow.deinit(allocator);
+        self.recovery_overflow = .empty;
+    }
+
+    pub fn totalCount(self: *const PacketTracker) usize {
+        return self.count + self.recovery_overflow.items.len;
+    }
+
+    pub fn ensureRecoveryCapacity(self: *PacketTracker, allocator: std.mem.Allocator, additional: usize) !void {
+        const fixed_free = max_tracked_packets - self.count;
+        const overflow_needed = additional -| fixed_free;
+        if (overflow_needed > 0) {
+            try self.recovery_overflow.ensureUnusedCapacity(allocator, overflow_needed);
+        }
+    }
+
+    pub fn canTrackRecoveryPacket(self: *const PacketTracker) bool {
+        return self.count < max_tracked_packets or self.recovery_overflow.items.len < self.recovery_overflow.capacity;
+    }
+
+    /// Ordinary insert: fixed tracker only.
     pub fn onPacketSent(self: *PacketTracker, packet: SentPacket) error{TooManyTrackedPackets}!void {
         if (self.count == max_tracked_packets) return error.TooManyTrackedPackets;
         self.packets[self.count] = packet;
         self.count += 1;
+        if (packet.in_flight) self.bytes_in_flight += packet.size;
+    }
+
+    /// Required recovery insert after `ensureRecoveryCapacity` preflight.
+    pub fn onPacketSentAssumeRecoveryCapacity(self: *PacketTracker, packet: SentPacket) void {
+        if (self.count < max_tracked_packets) {
+            self.packets[self.count] = packet;
+            self.count += 1;
+        } else {
+            std.debug.assert(self.recovery_overflow.items.len < self.recovery_overflow.capacity);
+            self.recovery_overflow.appendAssumeCapacity(packet);
+        }
         if (packet.in_flight) self.bytes_in_flight += packet.size;
     }
 
@@ -285,76 +325,76 @@ pub const PacketTracker = struct {
                 .rtt_sample_us = if (packet.ack_eliciting) now_us - packet.time_sent_us else null,
             };
         }
+
+        var overflow_index: usize = 0;
+        while (overflow_index < self.recovery_overflow.items.len) : (overflow_index += 1) {
+            const packet = self.recovery_overflow.items[overflow_index];
+            if (packet.space != space or packet.packet_number != packet_number or packet.lost) continue;
+            if (packet.in_flight) self.bytes_in_flight -= packet.size;
+            self.noteLargestAcked(space, packet_number);
+            _ = self.recovery_overflow.orderedRemove(overflow_index);
+            return .{
+                .packet = packet,
+                .rtt_sample_us = if (packet.ack_eliciting) now_us - packet.time_sent_us else null,
+            };
+        }
         return null;
+    }
+
+    fn noteLost(result: *LossResult, packet: SentPacket, threshold_lost: bool, time_lost: bool) void {
+        if (threshold_lost) result.packet_threshold_losses += 1;
+        if (time_lost) result.time_threshold_losses += 1;
+        if (packet.in_flight) result.lost_bytes += packet.size;
+        if (result.largest_lost_time_sent_us == null or packet.time_sent_us > result.largest_lost_time_sent_us.?) {
+            result.largest_lost_time_sent_us = packet.time_sent_us;
+        }
     }
 
     pub fn detectLost(self: *PacketTracker, space: PacketNumberSpace, now_us: u64, rtt: RttEstimator) LossResult {
         const largest = self.largest_acked[spaceIndex(space)] orelse return .{};
         const time_threshold = rtt.lossDelay();
         var result = LossResult{};
+
         var index: usize = 0;
         while (index < self.count) {
-            var packet = self.packets[index];
+            const packet = self.packets[index];
             if (packet.space != space or packet.lost or packet.packet_number > largest) {
                 index += 1;
                 continue;
             }
-
             const threshold_lost = largest >= packet.packet_number + packet_threshold;
             const time_lost = now_us >= packet.time_sent_us and now_us - packet.time_sent_us >= time_threshold;
             if (!threshold_lost and !time_lost) {
                 index += 1;
                 continue;
             }
-
-            if (threshold_lost) result.packet_threshold_losses += 1;
-            if (time_lost) result.time_threshold_losses += 1;
-            if (packet.in_flight) {
-                result.lost_bytes += packet.size;
-                self.bytes_in_flight -= packet.size;
-            }
-            if (result.largest_lost_time_sent_us == null or packet.time_sent_us > result.largest_lost_time_sent_us.?) {
-                result.largest_lost_time_sent_us = packet.time_sent_us;
-            }
-            packet.lost = true;
-            self.packets[index] = packet;
+            noteLost(&result, packet, threshold_lost, time_lost);
+            if (packet.in_flight) self.bytes_in_flight -= packet.size;
             self.removeAt(index);
+        }
+
+        var overflow_index: usize = 0;
+        while (overflow_index < self.recovery_overflow.items.len) {
+            const packet = self.recovery_overflow.items[overflow_index];
+            if (packet.space != space or packet.lost or packet.packet_number > largest) {
+                overflow_index += 1;
+                continue;
+            }
+            const threshold_lost = largest >= packet.packet_number + packet_threshold;
+            const time_lost = now_us >= packet.time_sent_us and now_us - packet.time_sent_us >= time_threshold;
+            if (!threshold_lost and !time_lost) {
+                overflow_index += 1;
+                continue;
+            }
+            noteLost(&result, packet, threshold_lost, time_lost);
+            if (packet.in_flight) self.bytes_in_flight -= packet.size;
+            _ = self.recovery_overflow.orderedRemove(overflow_index);
         }
         return result;
     }
 
-    /// Retire the oldest tracked packet, preferring `space`, and return it.
-    /// Its bytes stop counting as in flight; the caller is responsible for
-    /// requeuing whatever it carried. Used only to free bookkeeping capacity
-    /// for traffic recovery cannot defer — see
-    /// `RecoveryController.retireOldestForRecovery`.
-    pub fn retireOldest(self: *PacketTracker, space: PacketNumberSpace) ?SentPacket {
-        var chosen: ?usize = null;
-        var index: usize = 0;
-        while (index < self.count) : (index += 1) {
-            const candidate = self.packets[index];
-            if (chosen) |best| {
-                const current = self.packets[best];
-                // Prefer `space`; within a space, the oldest packet number.
-                const better_space = candidate.space == space and current.space != space;
-                const same_tier = (candidate.space == space) == (current.space == space);
-                if (better_space or (same_tier and candidate.packet_number < current.packet_number)) {
-                    chosen = index;
-                }
-            } else {
-                chosen = index;
-            }
-        }
-        const idx = chosen orelse return null;
-        const packet = self.packets[idx];
-        if (packet.in_flight) self.bytes_in_flight -|= packet.size;
-        self.removeAt(idx);
-        return packet;
-    }
-
-    /// RFC 9002 §6.4: when a space's keys are discarded, its packets stop
-    /// counting toward bytes in flight and will never be acked or declared
-    /// lost. Returns the in-flight bytes removed.
+    /// RFC 9002 §6.4: discard both fixed and overflow entries for a packet
+    /// number space whose keys are gone.
     pub fn dropSpace(self: *PacketTracker, space: PacketNumberSpace) usize {
         var removed: usize = 0;
         var index: usize = 0;
@@ -370,7 +410,58 @@ pub const PacketTracker = struct {
             }
             self.removeAt(index);
         }
+
+        var overflow_index: usize = 0;
+        while (overflow_index < self.recovery_overflow.items.len) {
+            const packet = self.recovery_overflow.items[overflow_index];
+            if (packet.space != space) {
+                overflow_index += 1;
+                continue;
+            }
+            if (packet.in_flight) {
+                removed += packet.size;
+                self.bytes_in_flight -= packet.size;
+            }
+            _ = self.recovery_overflow.orderedRemove(overflow_index);
+        }
         return removed;
+    }
+
+    pub fn contains(self: *const PacketTracker, space: PacketNumberSpace, packet_number: u64) bool {
+        for (self.packets[0..self.count]) |packet| {
+            if (packet.space == space and packet.packet_number == packet_number) return true;
+        }
+        for (self.recovery_overflow.items) |packet| {
+            if (packet.space == space and packet.packet_number == packet_number) return true;
+        }
+        return false;
+    }
+
+    pub fn hasAckElicitingInFlight(self: *const PacketTracker, space: PacketNumberSpace) bool {
+        for (self.packets[0..self.count]) |packet| {
+            if (packet.space == space and packet.in_flight and packet.ack_eliciting) return true;
+        }
+        for (self.recovery_overflow.items) |packet| {
+            if (packet.space == space and packet.in_flight and packet.ack_eliciting) return true;
+        }
+        return false;
+    }
+
+    pub fn nextLossDeadline(self: *const PacketTracker, loss_delay: u64) ?u64 {
+        var deadline: ?u64 = null;
+        for (self.packets[0..self.count]) |packet| {
+            const largest = self.largest_acked[spaceIndex(packet.space)] orelse continue;
+            if (packet.lost or packet.packet_number > largest) continue;
+            const candidate = packet.time_sent_us + loss_delay;
+            deadline = if (deadline) |current| @min(current, candidate) else candidate;
+        }
+        for (self.recovery_overflow.items) |packet| {
+            const largest = self.largest_acked[spaceIndex(packet.space)] orelse continue;
+            if (packet.lost or packet.packet_number > largest) continue;
+            const candidate = packet.time_sent_us + loss_delay;
+            deadline = if (deadline) |current| @min(current, candidate) else candidate;
+        }
+        return deadline;
     }
 
     fn noteLargestAcked(self: *PacketTracker, space: PacketNumberSpace, packet_number: u64) void {
@@ -496,68 +587,27 @@ pub const RecoveryController = struct {
         return self.ack_ranges[spaceIndex(space)].toAckFrame(ack_delay_us);
     }
 
-    /// Whether the bounded tracker can take one more *ordinary* sent packet —
-    /// stopping short of the recovery reserve. Callers must preflight this
-    /// before dequeuing frames: an untracked in-flight packet escapes both
-    /// loss recovery and the congestion window, and because nothing can ever
-    /// remove its bytes again it permanently inflates `bytes_in_flight`
-    /// (#256-A review).
+    pub fn deinit(self: *RecoveryController, allocator: std.mem.Allocator) void {
+        self.tracker.deinit(allocator);
+    }
+
+    /// Ordinary traffic remains fixed/bounded and stops before the recovery
+    /// reserve. It never consumes allocator-backed recovery overflow.
     pub fn canTrackPacket(self: *const RecoveryController) bool {
-        return self.canTrackPacketWithPending(0);
+        return self.tracker.count + reserved_tracked_packets < max_tracked_packets;
     }
 
-    /// `canTrackPacket` as it will read once `pending` further packets from
-    /// the datagram currently being assembled have been tracked. Coalescing
-    /// has to plan against this, not against the current count: the earlier
-    /// packets in a datagram consume slots before the later ones are built.
-    pub fn canTrackPacketWithPending(self: *const RecoveryController, pending: usize) bool {
-        return self.tracker.count + pending + reserved_tracked_packets < max_tracked_packets;
+    pub fn ensureRecoveryPacketCapacity(self: *RecoveryController, allocator: std.mem.Allocator, additional: usize) !void {
+        try self.tracker.ensureRecoveryCapacity(allocator, additional);
     }
 
-    /// Whether the tracker can take one more packet drawn from the recovery
-    /// reserve. RFC 9002 §7.5 exempts a PTO probe from the congestion-window
-    /// admission gate but still counts it in flight, so a probe needs a slot
-    /// like anything else — when even the reserve is gone the probe waits
-    /// rather than being emitted untracked.
     pub fn canTrackRecoveryPacket(self: *const RecoveryController) bool {
-        return self.canTrackRecoveryPacketWithPending(0);
-    }
-
-    pub fn canTrackRecoveryPacketWithPending(self: *const RecoveryController, pending: usize) bool {
-        return self.tracker.count + pending < max_tracked_packets;
-    }
-
-    /// Record a sent packet whose tracker slot the caller already preflighted
-    /// with `canTrackPacket`/`canTrackRecoveryPacket`. Infallible by
-    /// construction: the send path has no safe way to handle a failure here
-    /// (the packet is already sealed and its frames already dequeued), so the
-    /// capacity check belongs before the frames are committed, and this
-    /// asserts that it happened.
-    /// Free one tracker slot so a PTO probe can be sent and tracked.
-    ///
-    /// RFC 9002 §6.2.4 requires an ack-eliciting probe on *every* PTO
-    /// expiration, and PTO expiration is not itself evidence of loss: during a
-    /// total-loss episode no ACK ever arrives, so neither ACK processing nor
-    /// threshold loss detection retires anything. A bounded tracker would then
-    /// run out — a fixed reserve only postpones that by however many probes it
-    /// holds — and probe transmission would stall until idle timeout. Retiring
-    /// the oldest outstanding packet keeps a slot available for every PTO for
-    /// the whole connection lifetime, whatever the negotiated idle timeout.
-    ///
-    /// The retired packet's bytes leave `bytes_in_flight` (leaving them would
-    /// reproduce the permanent-inflation bug this replaced), but no congestion
-    /// event is applied: running out of bookkeeping is not proof the packet was
-    /// lost. The caller must requeue whatever it carried, exactly as it would
-    /// for a detected loss, so no content is dropped.
-    pub fn retireOldestForRecovery(self: *RecoveryController, space: PacketNumberSpace) ?SentPacket {
-        const retired = self.tracker.retireOldest(space) orelse return null;
-        if (retired.in_flight) self.congestion.bytes_in_flight -|= retired.size;
-        return retired;
+        return self.tracker.canTrackRecoveryPacket();
     }
 
     pub fn onPacketSentAssumeCapacity(self: *RecoveryController, packet: SentPacket) void {
         std.debug.assert(self.canTrackRecoveryPacket());
-        self.tracker.onPacketSent(packet) catch unreachable;
+        self.tracker.onPacketSentAssumeRecoveryCapacity(packet);
         if (packet.in_flight) self.congestion.onPacketSent(packet.size);
     }
 
@@ -947,14 +997,14 @@ test "recovery: a padded non-ack-eliciting packet is charged to the window" {
     try testing.expectEqual(@as(usize, 1200), controller.congestion.bytes_in_flight);
 }
 
-test "recovery: ordinary traffic backpressures before the recovery reserve" {
+test "recovery: ordinary traffic stays bounded while required recovery spills past the fixed tracker" {
     var controller = RecoveryController{};
+    defer controller.deinit(testing.allocator);
     const ordinary_capacity = max_tracked_packets - reserved_tracked_packets;
 
     var i: usize = 0;
     while (i < ordinary_capacity) : (i += 1) {
         try testing.expect(controller.canTrackPacket());
-        try testing.expect(controller.canTrackRecoveryPacket());
         try controller.onPacketSent(.{
             .space = .application,
             .packet_number = i,
@@ -962,11 +1012,7 @@ test "recovery: ordinary traffic backpressures before the recovery reserve" {
             .size = 100,
         });
     }
-
-    // Ordinary traffic is done, but the reserve is intact for PTO probes and
-    // mandatory-padding packets.
     try testing.expect(!controller.canTrackPacket());
-    try testing.expect(controller.canTrackRecoveryPacket());
 
     while (i < max_tracked_packets) : (i += 1) {
         try testing.expect(controller.canTrackRecoveryPacket());
@@ -977,19 +1023,22 @@ test "recovery: ordinary traffic backpressures before the recovery reserve" {
             .size = 100,
         });
     }
-
-    // Fully saturated: recovery traffic must now wait rather than go
-    // untracked, which is what the send path's preflight enforces.
     try testing.expect(!controller.canTrackRecoveryPacket());
-    try testing.expectError(error.TooManyTrackedPackets, controller.onPacketSent(.{
+
+    try controller.ensureRecoveryPacketCapacity(testing.allocator, 1);
+    try testing.expect(controller.canTrackRecoveryPacket());
+    controller.onPacketSentAssumeCapacity(.{
         .space = .application,
         .packet_number = max_tracked_packets,
         .time_sent_us = 9_999,
-        .size = 100,
-    }));
+        .size = 123,
+    });
+    try testing.expectEqual(@as(usize, max_tracked_packets + 1), controller.tracker.totalCount());
+    try testing.expectEqual(@as(usize, 1), controller.tracker.recovery_overflow.items.len);
 
-    // Freeing capacity restores both tiers in the right order.
-    _ = controller.tracker.dropSpace(.application);
-    try testing.expect(controller.canTrackRecoveryPacket());
-    try testing.expect(controller.canTrackPacket());
+    const before = controller.congestion.bytes_in_flight;
+    controller.onAcked(.application, max_tracked_packets, 10_100, 0);
+    try testing.expectEqual(@as(usize, max_tracked_packets), controller.tracker.totalCount());
+    try testing.expectEqual(@as(usize, 0), controller.tracker.recovery_overflow.items.len);
+    try testing.expect(controller.congestion.bytes_in_flight < before);
 }

--- a/src/quic/recovery.zig
+++ b/src/quic/recovery.zig
@@ -323,6 +323,35 @@ pub const PacketTracker = struct {
         return result;
     }
 
+    /// Retire the oldest tracked packet, preferring `space`, and return it.
+    /// Its bytes stop counting as in flight; the caller is responsible for
+    /// requeuing whatever it carried. Used only to free bookkeeping capacity
+    /// for traffic recovery cannot defer — see
+    /// `RecoveryController.retireOldestForRecovery`.
+    pub fn retireOldest(self: *PacketTracker, space: PacketNumberSpace) ?SentPacket {
+        var chosen: ?usize = null;
+        var index: usize = 0;
+        while (index < self.count) : (index += 1) {
+            const candidate = self.packets[index];
+            if (chosen) |best| {
+                const current = self.packets[best];
+                // Prefer `space`; within a space, the oldest packet number.
+                const better_space = candidate.space == space and current.space != space;
+                const same_tier = (candidate.space == space) == (current.space == space);
+                if (better_space or (same_tier and candidate.packet_number < current.packet_number)) {
+                    chosen = index;
+                }
+            } else {
+                chosen = index;
+            }
+        }
+        const idx = chosen orelse return null;
+        const packet = self.packets[idx];
+        if (packet.in_flight) self.bytes_in_flight -|= packet.size;
+        self.removeAt(idx);
+        return packet;
+    }
+
     /// RFC 9002 §6.4: when a space's keys are discarded, its packets stop
     /// counting toward bytes in flight and will never be acked or declared
     /// lost. Returns the in-flight bytes removed.
@@ -474,7 +503,15 @@ pub const RecoveryController = struct {
     /// remove its bytes again it permanently inflates `bytes_in_flight`
     /// (#256-A review).
     pub fn canTrackPacket(self: *const RecoveryController) bool {
-        return self.tracker.count + reserved_tracked_packets < max_tracked_packets;
+        return self.canTrackPacketWithPending(0);
+    }
+
+    /// `canTrackPacket` as it will read once `pending` further packets from
+    /// the datagram currently being assembled have been tracked. Coalescing
+    /// has to plan against this, not against the current count: the earlier
+    /// packets in a datagram consume slots before the later ones are built.
+    pub fn canTrackPacketWithPending(self: *const RecoveryController, pending: usize) bool {
+        return self.tracker.count + pending + reserved_tracked_packets < max_tracked_packets;
     }
 
     /// Whether the tracker can take one more packet drawn from the recovery
@@ -483,7 +520,11 @@ pub const RecoveryController = struct {
     /// like anything else — when even the reserve is gone the probe waits
     /// rather than being emitted untracked.
     pub fn canTrackRecoveryPacket(self: *const RecoveryController) bool {
-        return self.tracker.count < max_tracked_packets;
+        return self.canTrackRecoveryPacketWithPending(0);
+    }
+
+    pub fn canTrackRecoveryPacketWithPending(self: *const RecoveryController, pending: usize) bool {
+        return self.tracker.count + pending < max_tracked_packets;
     }
 
     /// Record a sent packet whose tracker slot the caller already preflighted
@@ -492,6 +533,28 @@ pub const RecoveryController = struct {
     /// (the packet is already sealed and its frames already dequeued), so the
     /// capacity check belongs before the frames are committed, and this
     /// asserts that it happened.
+    /// Free one tracker slot so a PTO probe can be sent and tracked.
+    ///
+    /// RFC 9002 §6.2.4 requires an ack-eliciting probe on *every* PTO
+    /// expiration, and PTO expiration is not itself evidence of loss: during a
+    /// total-loss episode no ACK ever arrives, so neither ACK processing nor
+    /// threshold loss detection retires anything. A bounded tracker would then
+    /// run out — a fixed reserve only postpones that by however many probes it
+    /// holds — and probe transmission would stall until idle timeout. Retiring
+    /// the oldest outstanding packet keeps a slot available for every PTO for
+    /// the whole connection lifetime, whatever the negotiated idle timeout.
+    ///
+    /// The retired packet's bytes leave `bytes_in_flight` (leaving them would
+    /// reproduce the permanent-inflation bug this replaced), but no congestion
+    /// event is applied: running out of bookkeeping is not proof the packet was
+    /// lost. The caller must requeue whatever it carried, exactly as it would
+    /// for a detected loss, so no content is dropped.
+    pub fn retireOldestForRecovery(self: *RecoveryController, space: PacketNumberSpace) ?SentPacket {
+        const retired = self.tracker.retireOldest(space) orelse return null;
+        if (retired.in_flight) self.congestion.bytes_in_flight -|= retired.size;
+        return retired;
+    }
+
     pub fn onPacketSentAssumeCapacity(self: *RecoveryController, packet: SentPacket) void {
         std.debug.assert(self.canTrackRecoveryPacket());
         self.tracker.onPacketSent(packet) catch unreachable;

--- a/src/quic/root.zig
+++ b/src/quic/root.zig
@@ -2,6 +2,7 @@
 //! gateway types. HTTP/3 application mapping lives in `src/http3/`.
 
 pub const config = @import("config.zig");
+pub const datagram = @import("datagram.zig");
 pub const udp = @import("udp.zig");
 pub const varint = @import("quic_varint");
 pub const packet = @import("packet.zig");

--- a/tests/quic_h3_smoke.zig
+++ b/tests/quic_h3_smoke.zig
@@ -1078,7 +1078,7 @@ test "smoke harness resets recovery when validated migration changes host" {
     try smoke.completeHandshake();
 
     smoke.server.recovery.rtt.update(80_000, 0);
-    smoke.server.recovery.congestion.congestion_window = 3 * quic_recovery.max_datagram_size;
+    smoke.server.recovery.congestion.congestion_window = 3 * quic_recovery.initial_max_datagram_size;
     try testing.expect(smoke.server.recovery.rtt.hasSample());
 
     const migrated_client = quic_udp.Address.ip4(.{ 198, 51, 100, 7 }, 50_000);
@@ -1092,7 +1092,7 @@ test "smoke harness resets recovery when validated migration changes host" {
     try testing.expectEqual(@as(u64, 1), smoke.server.paths.metrics.migrations);
     try testing.expect(!smoke.server.recovery.rtt.hasSample());
     try testing.expectEqual(
-        quic_recovery.CongestionController.initialWindow(quic_recovery.max_datagram_size),
+        quic_recovery.CongestionController.initialWindow(quic_recovery.initial_max_datagram_size),
         smoke.server.recovery.congestion.congestion_window,
     );
 }


### PR DESCRIPTION
## Summary

Slice **256-A** only: make the outbound QUIC datagram size a real transport invariant and reconcile every send/receive/recovery surface that depends on it. Pacing (256-C), socket buffer tuning (256-D), ECN (256-E), and the benchmark matrix (256-G) are not in this PR. DPLPMTUD (256-B) is not implemented; this PR provides the sender/path-size seam it will own.

### Receive capacity is not send size

RFC 9000 §18.2 `max_udp_payload_size` is receive capacity, not path MTU. The two directions are now separate:

- **`Config.max_udp_payload_size`** is local receive capacity only. It defaults to `datagram.max_size`; validation refuses to advertise more than the receive/deprotection buffers can process.
- **`Config.max_send_udp_payload_size`** is the sender's assumed current path size, defaulting to the RFC 9000 §14 floor of 1200. `TARDIGRADE_HTTP3_MAX_DATAGRAM_SIZE` maps here.

### Effective datagram size

`src/quic/datagram.zig` owns the bounds:

```zig
current_path_max: u64 = base_size,
send_ceiling:     u64 = max_size,
peer_max:        ?u64 = null,
// ordinary: min(current_path_max, send_ceiling, peer_max)
// PMTU probe ceiling: min(send_ceiling, peer_max)
```

`Connection.effectiveMaxDatagramSize()` derives the ordinary cap on demand, so authenticated peer parameters take effect immediately. Before peer parameters authenticate, sends stay at 1200. The independent probe ceiling gives #256-B headroom without requiring the operator to preconfigure a larger current path size.

### Recovery and congestion control

Making sender MDS dynamic required the recovery path to follow it consistently:

- **NewReno uses the sender's current MDS** for minimum/initial-window behavior, additive increase, and migration reset state.
- **Ordinary in-flight packets are bounded by remaining cwnd including final packet overhead and mandatory padding.** Raising the datagram cap cannot widen congestion-window overshoot.
- **`ack_eliciting` and `in_flight` are separate.** A packet made in-flight by PADDING is tracked and charged even when it is not ack-eliciting.
- **Candidate-path PATH_CHALLENGE/PATH_RESPONSE traffic is congestion-gated before path-control state is dequeued.**
- **Ordinary recovery tracking remains bounded.** Ordinary STREAM/CRYPTO traffic stops before the fixed recovery reserve instead of failing open.
- **Required recovery traffic cannot deadlock on that fixed bound.** PTO probes and mandatory-padding recovery packets use the fixed reserve first, then allocator-backed *recovery-only* overflow. PTO expiration never fabricates loss or retires an outstanding original merely to reclaim a bookkeeping slot; originals remain tracked and count in `bytes_in_flight` until normal ACK, loss detection, or key discard retires them.
- Recovery overflow participates in ACK processing, loss detection, packet-space discard, in-flight/PTO queries, and loss-deadline calculation just like the fixed tier.
- The parallel semantic `sent_records` store grows only when recovery overflow needs it. Because records can contain copied stateless-reset tokens, growth uses an explicit **copy → secure-wipe old backing → free** sequence rather than `ArrayList`'s normal unwiped growth path.

### Initial padding / coalescing

RFC 9000 §14.1's 1200-byte obligation stays with the Initial packet itself. Merely having later Handshake/Application write keys does **not** transfer responsibility to a later packet, because that later packet may still be blocked by tracker, congestion, or anti-amplification gates. The Initial therefore makes the datagram legal before any optional later packet is considered; later packets can still coalesce when the effective datagram cap has remaining room.

### Docs

`docs/HTTP3_ROLLOUT.md` documents the receive-vs-send distinction, the conservative 1200 default, peer limiting, and the current `>1200` operator assertion. Without #256-B black-hole fallback, an incorrectly raised path assertion can remain stalled because Tardigrade's own recovery retries the same oversized path assumption.

## Test plan

- [x] `zig build test-quic` — QUIC/H3 suite green on the final source.
- [x] `zig build test` — full unit suite green on the final source.
- [x] `zig fmt` on the touched QUIC files.
- [x] Datagram units cover floor/ceiling clamping, peer lowering, send ceiling, probe headroom, and out-of-range clamping.
- [x] Connection sizing regressions assert actual emitted datagram sizes, conservative pre-auth behavior, receive/send separation, peer limits, and raised path sizes.
- [x] Congestion regressions cover near-full cwnd, spent cwnd, mandatory PATH_RESPONSE padding, candidate-path gating, PTO cwnd exemption, and exact packet/BIF accounting.
- [x] Recovery/NewReno units cover 1200/1452/2048 MDS, minimum window, CA growth, loss/persistent congestion, migration reset, and padded non-ack-eliciting packets.
- [x] Ordinary tracker saturation backpressures rather than sending retransmittable data untracked.
- [x] A real PTO at the ordinary threshold is emitted with a tracker/sent-record entry and its bytes drain on ACK.
- [x] **Sustained total loss crosses the old 128-packet fixed limit and multiple PTO rounds beyond the fixed reserve; every required probe remains tracked and charged using recovery overflow.**
- [x] **Exact last-ordinary-slot Initial+Handshake regression:** Initial consumes the last ordinary tracker slot, Handshake remains pending, and the returned Initial-bearing UDP datagram is still exactly 1200 bytes with correct congestion accounting.
- [x] Runtime/config regressions pin the operator knob to the send side and keep receive-capacity advertisement aligned with actual ingress buffers.

Refs #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)
