### PR TITLE
perf(quic): discover the path MTU instead of assuming one (#256-B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,14 @@ All notable user-facing changes to Tardigrade are documented here.
   than applied to the new one.
 
   Discovery above 1200 additionally requires the listener socket to establish a
-  no-IP-fragmentation contract (RFC 8899 §3: `IP_PMTUDISC_PROBE` on Linux,
-  `IP_DONTFRAG` on macOS/BSD). Without it an acknowledged large probe would be
-  measuring reassembly rather than the path, so on platforms where the kernel
-  refuses it the send size stays at 1200 regardless of configuration.
+  no-IP-fragmentation contract (RFC 8899 §3): `IP_PMTUDISC_PROBE` on Linux,
+  `IP_DONTFRAG` on Darwin and FreeBSD — whose IPv4 constants differ, so the
+  BSDs are handled per-OS rather than as a family. Without it an acknowledged
+  large probe would be measuring reassembly rather than the path, so where the
+  contract cannot be established the send size stays at 1200 regardless of
+  configuration. The QUIC transport's own default is 1200 for the same reason:
+  it owns no socket, so discovery is opt-in by whichever composition root
+  created one and can vouch for it.
 
   `TARDIGRADE_HTTP3_MAX_DATAGRAM_SIZE` changes meaning accordingly and now
   defaults to **2048**. It was an assertion — "this path carries this much" —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable user-facing changes to Tardigrade are documented here.
 ## [Unreleased]
 
 ### Added
+- **QUIC discovers the path MTU instead of assuming one (#256-B)** — Tardigrade
+  now runs DPLPMTUD (RFC 8899, RFC 9000 §14.3/§14.4) per network path. Every
+  path starts at the 1200-byte size RFC 9000 §14 guarantees and rises only as
+  far as a padded probe datagram is actually acknowledged; the first probe
+  reaches straight for the ceiling, so a path that carries it is discovered in
+  one round trip. Probe loss is not treated as congestion (§14.4), but probes
+  are still congestion controlled and anti-amplification limited, with none of
+  the RFC 9002 PTO exemptions. When a path stops carrying the discovered size —
+  oversized datagrams lost while smaller ones arrive, or consecutive PTOs with
+  nothing acknowledged — the send size falls back to 1200 rather than
+  retransmitting the same oversized datagram until the idle timeout, and the
+  RFC 8899 raise timer later re-searches below the size that failed. Discovery
+  is per path and never inherited: a migration or a re-validated tuple starts
+  over at 1200.
+
+  `TARDIGRADE_HTTP3_MAX_DATAGRAM_SIZE` changes meaning accordingly and now
+  defaults to **2048**. It was an assertion — "this path carries this much" —
+  and is now a *ceiling on what discovery may find*. Raising it can no longer
+  put a size on the wire that nothing has measured, so the wider default is not
+  a more aggressive one: the size actually emitted still starts at 1200.
+  Lowering it is now the only reason to set it. See `docs/HTTP3_ROLLOUT.md`.
+
 - **Native TLS negotiates `record_size_limit` and can pad records (#359)** —
   the record transport now offers and honors RFC 8449's `record_size_limit`
   extension in both roles. Each side advertises the largest inner plaintext it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,19 @@ All notable user-facing changes to Tardigrade are documented here.
   oversized datagrams lost while smaller ones arrive, or consecutive PTOs with
   nothing acknowledged — the send size falls back to 1200 rather than
   retransmitting the same oversized datagram until the idle timeout, and the
-  RFC 8899 raise timer later re-searches below the size that failed. Discovery
-  is per path and never inherited: a migration or a re-validated tuple starts
-  over at 1200.
+  RFC 8899 raise timer (10 minutes) later re-enters the search, discarding the
+  previous failure bound — it described a path condition that may no longer
+  hold — so a path that regains MTU is rediscovered rather than being stuck at
+  the size that once failed. Discovery is per path *incarnation* and never
+  inherited: a migration, or a tuple that has to be re-validated, starts over
+  at 1200, and feedback still owed by a previous incarnation is dropped rather
+  than applied to the new one.
+
+  Discovery above 1200 additionally requires the listener socket to establish a
+  no-IP-fragmentation contract (RFC 8899 §3: `IP_PMTUDISC_PROBE` on Linux,
+  `IP_DONTFRAG` on macOS/BSD). Without it an acknowledged large probe would be
+  measuring reassembly rather than the path, so on platforms where the kernel
+  refuses it the send size stays at 1200 regardless of configuration.
 
   `TARDIGRADE_HTTP3_MAX_DATAGRAM_SIZE` changes meaning accordingly and now
   defaults to **2048**. It was an assertion — "this path carries this much" —

--- a/docs/HTTP3_ROLLOUT.md
+++ b/docs/HTTP3_ROLLOUT.md
@@ -42,34 +42,75 @@ receive buffers the implementation allocates — **2048 bytes** — not somethin
 operator tunes, and it never changes for the life of a connection. The config
 layer refuses to advertise more than the transport can actually deprotect.
 
-**Send size** is what this process puts on the wire, and that is what
-`TARDIGRADE_HTTP3_MAX_DATAGRAM_SIZE` controls. It defaults to **1200** — the
-size RFC 9000 §14 requires every QUIC path to carry — and is clamped into
-`[1200, 2048]`. The transport resolves the size actually emitted as the smallest
-of:
+**Send size** is what this process puts on the wire. It is *measured*, not
+configured: every path starts at **1200** — the size RFC 9000 §14 requires every
+QUIC path to carry — and only rises as far as DPLPMTUD has proven the path
+carries (see below). The transport resolves the size actually emitted as the
+smallest of:
 
-1. the current path size (this knob, until DPLPMTUD replaces it);
-2. this endpoint's send ceiling (2048);
+1. the current path size, as discovered by DPLPMTUD;
+2. this endpoint's send ceiling — `TARDIGRADE_HTTP3_MAX_DATAGRAM_SIZE`, clamped
+   into `[1200, 2048]` and defaulting to 2048;
 3. the peer's advertised receive capacity, once its transport parameters are
    authenticated.
 
-Consequences worth knowing before tuning it:
+`TARDIGRADE_HTTP3_MAX_DATAGRAM_SIZE` is therefore a **ceiling on what discovery
+may find**, not a size taken on trust. Consequences worth knowing:
 
-- **The send size sits at 1200 for the whole handshake.** A raised value only
-  takes effect once the peer has authenticated and committed to accepting
-  larger datagrams. Datagrams carrying Initial packets are always padded to
-  1200 regardless.
-- **A peer always wins when it asks for less.** Raising this value can never
-  push a datagram past what the peer advertised.
-- **Raising it is an assertion about the path**, not a measurement. Tardigrade
-  does not yet run DPLPMTUD (RFC 8899), so a value above 1200 says "I know this
-  path carries this much". If it does not, those datagrams are dropped in the
-  network. Tardigrade's own loss recovery will notice and retransmit — but with
-  no PMTU black-hole fallback yet, the retransmissions are the same oversized
-  datagrams, so the connection can stall indefinitely rather than recovering at
-  a smaller size. Raise it only for paths whose MTU you control end to end (a
-  dedicated link, a loopback or same-rack benchmark host, a known-jumbo-frame
-  fabric). Leave it at the default on the open internet.
+- **The send size sits at 1200 for the whole handshake**, and stays there until
+  a probe of something larger is acknowledged. Datagrams carrying Initial
+  packets are always padded to 1200 regardless.
+- **A peer always wins when it asks for less.** Nothing here can push a
+  datagram past what the peer advertised.
+- **Lowering the ceiling is the only reason to touch it.** Raising it can never
+  make Tardigrade send a size the path has not been shown to carry, so the
+  default needs no defensive tuning. Lower it when you know a downstream link
+  is smaller than discovery would otherwise find, or to switch discovery off
+  entirely by pinning it to 1200.
+
+## Path MTU discovery
+
+Tardigrade runs DPLPMTUD (RFC 8899, RFC 9000 §14.3/§14.4) per network path,
+starting once the handshake is confirmed — the peer's receive capacity is
+authenticated by then, and a completed handshake is itself proof the path
+carries 1200 bytes, since every Initial-bearing datagram was padded to it.
+
+- **Probes are standalone datagrams** carrying only PING and PADDING, sized to
+  exactly the size being validated. Nothing rides on one, so a probe dropped by
+  a path too small for it costs no application progress.
+- **The first probe reaches straight for the ceiling** (RFC 8899's optimistic
+  search), so a path that really carries the configured maximum is discovered in
+  one round trip. After that the search bisects, converging to within 16 bytes.
+- **A probe's loss is not a congestion signal** (RFC 9000 §14.4) — being too big
+  is what a probe is for — but a probe is still congestion controlled and
+  anti-amplification limited like any other datagram, with none of the RFC 9002
+  PTO exemptions. It waits for window rather than overshooting.
+- **A size is only ruled out after three consecutive probe losses**, so ordinary
+  congestion cannot narrow the search.
+
+### Black holes
+
+A path that used to carry the discovered size can stop carrying it — a tunnel
+appears, a route changes, an operator lowers an MTU. Tardigrade watches for two
+signatures and pulls the send size back to 1200 when either fires three times:
+
+- oversized datagrams being lost while smaller ones are still delivered;
+- consecutive PTO expirations with nothing acknowledged in between, which is
+  what the same failure looks like when *every* datagram in flight is already
+  oversized and there is no smaller delivery to compare against.
+
+A false positive costs throughput until the RFC 8899 raise timer (10 minutes)
+re-opens a search below the size that failed. Not falling back costs the
+connection: Tardigrade's own retransmissions would keep re-sending the same
+oversized datagram until the idle timeout.
+
+Discovery is **per path, never inherited.** Migrating to a new path — or
+re-validating a tuple that has been away — restarts from 1200 rather than
+carrying over a size only the old path was shown to carry.
+
+Operator counters: `pmtu_probes_sent` and `pmtu_black_holes` on the connection's
+metrics, plus a `pmtu_updated` event carrying the path, the new effective size,
+and whether it rose or fell back.
 
 Nothing about this setting relaxes congestion control, flow control, or the
 server's anti-amplification budget:

--- a/docs/HTTP3_ROLLOUT.md
+++ b/docs/HTTP3_ROLLOUT.md
@@ -81,6 +81,12 @@ carries 1200 bytes, since every Initial-bearing datagram was padded to it.
 - **The first probe reaches straight for the ceiling** (RFC 8899's optimistic
   search), so a path that really carries the configured maximum is discovered in
   one round trip. After that the search bisects, converging to within 16 bytes.
+- **A converged search is re-run every 10 minutes** if it stopped because larger
+  sizes failed (RFC 8899's `PMTU_RAISE_TIMER`). A path can *gain* MTU on the
+  same address tuple — a tunnel goes away, a route changes — and the previous
+  failure bound describes a path condition that no longer exists, so it is
+  discarded and the sizes it ruled out become reachable again. A search that
+  converged at the ceiling has nothing above it to find and does not re-run.
 - **A probe's loss is not a congestion signal** (RFC 9000 §14.4) — being too big
   is what a probe is for — but a probe is still congestion controlled and
   anti-amplification limited like any other datagram, with none of the RFC 9002
@@ -94,15 +100,20 @@ A path that used to carry the discovered size can stop carrying it — a tunnel
 appears, a route changes, an operator lowers an MTU. Tardigrade watches for two
 signatures and pulls the send size back to 1200 when either fires three times:
 
-- oversized datagrams being lost while smaller ones are still delivered;
+- datagrams **at or above the current send size** being lost while **smaller**
+  ones are still delivered. Both halves are measured against the size actually
+  in question, not against the 1200-byte floor: with a discovered size of 1452,
+  a delivered 1300-byte datagram *corroborates* the black hole rather than
+  disproving it, while a delivered 1452-byte datagram clears the evidence
+  outright. A loss below the current size is not evidence at all — falling back
+  would not have saved it.
 - consecutive PTO expirations with nothing acknowledged in between, which is
   what the same failure looks like when *every* datagram in flight is already
   oversized and there is no smaller delivery to compare against.
 
-A false positive costs throughput until the RFC 8899 raise timer (10 minutes)
-re-opens a search below the size that failed. Not falling back costs the
-connection: Tardigrade's own retransmissions would keep re-sending the same
-oversized datagram until the idle timeout.
+A false positive costs throughput until the raise timer re-tests. Not falling
+back costs the connection: Tardigrade's own retransmissions would keep
+re-sending the same oversized datagram until the idle timeout.
 
 Discovery is **per path, never inherited.** Migrating to a new path — or
 re-validating a tuple that has been away — restarts from 1200 rather than

--- a/docs/HTTP3_ROLLOUT.md
+++ b/docs/HTTP3_ROLLOUT.md
@@ -67,6 +67,9 @@ may find**, not a size taken on trust. Consequences worth knowing:
   default needs no defensive tuning. Lower it when you know a downstream link
   is smaller than discovery would otherwise find, or to switch discovery off
   entirely by pinning it to 1200.
+- **It has no effect at all without the socket contract below.** On a platform
+  where no-IP-fragmentation cannot be established, the send size stays at 1200
+  however this is set.
 
 ## Path MTU discovery
 
@@ -115,20 +118,43 @@ A false positive costs throughput until the raise timer re-tests. Not falling
 back costs the connection: Tardigrade's own retransmissions would keep
 re-sending the same oversized datagram until the idle timeout.
 
-Discovery is **per path, never inherited.** Migrating to a new path — or
-re-validating a tuple that has been away — restarts from 1200 rather than
-carrying over a size only the old path was shown to carry.
+Discovery is **per path incarnation, never inherited.** Migrating to a new path
+restarts from 1200 rather than carrying over a size only the old path was shown
+to carry — and so does re-probing a tuple whose previous validation ended,
+whether it was promoted away or expired unanswered. Outcomes still owed by an
+earlier incarnation (a delayed acknowledgement, a late loss) are dropped rather
+than applied to the state that replaced it.
 
 ### Requirements and diagnostics
 
 Discovering anything above 1200 requires the listener socket to establish a
-**no-IP-fragmentation contract** — `IP_PMTUDISC_PROBE` on Linux (DF set, and the
-kernel's cached path MTU ignored, per RFC 8899 §4.5), `IP_DONTFRAG` on
-macOS/BSD. Without it a large probe may be fragmented, and its acknowledgement
-would prove the peer *reassembled* it rather than that the path carries it. On a
-platform or kernel that refuses the option the listener logs a warning and holds
+**no-IP-fragmentation contract**. Without it a large probe may be fragmented,
+and its acknowledgement would prove the peer *reassembled* it rather than that
+the path carries it. Supported platforms:
+
+| Platform | Mechanism | Notes |
+| --- | --- | --- |
+| Linux | `IP_PMTUDISC_PROBE` / `IPV6_PMTUDISC_PROBE` | Sets DF *and* ignores the kernel's cached path MTU, so DPLPMTUD is in control (RFC 8899 §4.5). |
+| macOS, iOS, tvOS, watchOS | `IP_DONTFRAG` (28) / `IPV6_DONTFRAG` (62) | DF only — no probe mode, so a kernel-cached PMTU can still bound a probe. Costs discovery reach, not soundness. |
+| FreeBSD | `IP_DONTFRAG` (67) / `IPV6_DONTFRAG` (62) | As above. Note the IPv4 constant differs from Darwin's. |
+| NetBSD, OpenBSD, DragonFly, others | — | No verified API; discovery stays at 1200. |
+
+These constants are deliberately **not** shared across the BSDs: Darwin's IPv4
+`IP_DONTFRAG` is 28 while FreeBSD's is 67, and OpenBSD uses option 28 for
+something else entirely. A wrong constant that a kernel happens to *accept*
+would report success without ever setting DF — the exact false positive this
+gate exists to prevent — so an unverified platform reports failure instead of
+guessing.
+
+Where the contract cannot be established the listener logs a warning and holds
 the send size at 1200 whatever `TARDIGRADE_HTTP3_MAX_DATAGRAM_SIZE` says — the
 conservative policy, not a silently unsound measurement.
+
+The QUIC transport's own `max_send_udp_payload_size` defaults to 1200 for the
+same reason: `src/quic/` owns no socket and cannot know whether a probe would be
+fragmented, so **discovery is opt-in by the composition root that created the
+socket**. An embedder using `quic.connection` directly gets the conservative
+policy until it establishes the contract itself and raises the ceiling.
 
 Diagnostics are currently **connection-level, not yet operator-facing**:
 `pmtu_probes_sent` and `pmtu_black_holes` on `quic.connection.Metrics`, plus a

--- a/docs/HTTP3_ROLLOUT.md
+++ b/docs/HTTP3_ROLLOUT.md
@@ -119,9 +119,22 @@ Discovery is **per path, never inherited.** Migrating to a new path — or
 re-validating a tuple that has been away — restarts from 1200 rather than
 carrying over a size only the old path was shown to carry.
 
-Operator counters: `pmtu_probes_sent` and `pmtu_black_holes` on the connection's
-metrics, plus a `pmtu_updated` event carrying the path, the new effective size,
-and whether it rose or fell back.
+### Requirements and diagnostics
+
+Discovering anything above 1200 requires the listener socket to establish a
+**no-IP-fragmentation contract** — `IP_PMTUDISC_PROBE` on Linux (DF set, and the
+kernel's cached path MTU ignored, per RFC 8899 §4.5), `IP_DONTFRAG` on
+macOS/BSD. Without it a large probe may be fragmented, and its acknowledgement
+would prove the peer *reassembled* it rather than that the path carries it. On a
+platform or kernel that refuses the option the listener logs a warning and holds
+the send size at 1200 whatever `TARDIGRADE_HTTP3_MAX_DATAGRAM_SIZE` says — the
+conservative policy, not a silently unsound measurement.
+
+Diagnostics are currently **connection-level, not yet operator-facing**:
+`pmtu_probes_sent` and `pmtu_black_holes` on `quic.connection.Metrics`, plus a
+`pmtu_updated` event carrying the path, the new effective size, and whether it
+rose or fell back. The HTTP/3 runtime's metrics/event bridge does not surface
+them yet; #255's observability work is where they become operator-visible.
 
 Nothing about this setting relaxes congestion control, flow control, or the
 server's anti-amplification budget:

--- a/src/edge_config.zig
+++ b/src/edge_config.zig
@@ -935,12 +935,15 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
     const http3_retry_policy_str = envOrDefault(allocator, "TARDIGRADE_HTTP3_RETRY_POLICY", "off") catch unreachable;
     defer allocator.free(http3_retry_policy_str);
     const http3_retry_policy = try parseHttp3RetryPolicyConfig(http3_retry_policy_str);
-    // #256-A: the **send** size, owned by `quic.datagram`. This is not the
-    // `max_udp_payload_size` this endpoint advertises — that is receive
-    // capacity, fixed by the transport's buffers. The transport clamps this
-    // into `[base_size, max_size]` and lowers it further whenever the peer
+    // #256-A/#256-B: the ceiling on the **send** size, owned by
+    // `quic.datagram`. This is not the `max_udp_payload_size` this endpoint
+    // advertises — that is receive capacity, fixed by the transport's buffers.
+    // Nor is it the size on the wire: DPLPMTUD starts every path at
+    // `base_size` and raises it only as far as a probe is acknowledged, so
+    // this bounds what discovery may find. The transport clamps it into
+    // `[base_size, max_size]` and lowers it further whenever the peer
     // advertises smaller receive capacity.
-    const http3_max_datagram_size = parseIntEnv(usize, allocator, "TARDIGRADE_HTTP3_MAX_DATAGRAM_SIZE", http.quic.datagram.base_size);
+    const http3_max_datagram_size = parseIntEnv(usize, allocator, "TARDIGRADE_HTTP3_MAX_DATAGRAM_SIZE", http.quic.datagram.max_size);
     const proxy_protocol_mode_str = envOrDefault(allocator, "TARDIGRADE_PROXY_PROTOCOL", "off") catch unreachable;
     defer allocator.free(proxy_protocol_mode_str);
     const proxy_protocol_mode = try parseProxyProtocolModeConfig(proxy_protocol_mode_str);

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -88,15 +88,18 @@ pub const Config = struct {
     h3_settings: http3.frame.Settings = .{},
     connection_migration: bool = false,
     retry_policy: quic.config.RetryPolicy = .off,
-    /// Operator-facing bound on the size of datagrams this listener **sends**,
-    /// clamped into `[quic.datagram.base_size, quic.datagram.max_size]`. It is
-    /// the assumed path MTU, not a receive limit: the `max_udp_payload_size`
-    /// this endpoint advertises is its own receive capacity and is fixed by
-    /// the transport's buffers, not by this knob (#256-A). The default is the
-    /// one authoritative value in `quic.datagram` rather than a second knob
-    /// that can drift from it; the transport lowers it further whenever the
-    /// peer advertises less receive capacity.
-    max_datagram_size: usize = quic.datagram.base_size,
+    /// Operator-facing ceiling on the size of datagrams this listener
+    /// **sends**, clamped into `[quic.datagram.base_size,
+    /// quic.datagram.max_size]`. It is not a receive limit: the
+    /// `max_udp_payload_size` this endpoint advertises is its own receive
+    /// capacity and is fixed by the transport's buffers, not by this knob
+    /// (#256-A). Nor is it the size on the wire — DPLPMTUD (#256-B) starts
+    /// every path at the RFC 9000 §14 floor and only raises it as far as a
+    /// probe is actually acknowledged, so this bounds what discovery may find.
+    /// The default is the one authoritative value in `quic.datagram` rather
+    /// than a second knob that can drift from it; the transport lowers it
+    /// further whenever the peer advertises less receive capacity.
+    max_datagram_size: usize = quic.datagram.max_size,
     request_handler: ?RequestHandler = null,
     request_handler_ctx: ?*anyopaque = null,
     early_data_compat_metrics_ctx: ?*anyopaque = null,
@@ -2142,7 +2145,7 @@ test "quicConfigFrom: the runtime default is the transport's own authoritative d
     // #256-A: the runtime must not carry a second datagram-size default that
     // can drift from the transport's. Both come from `quic.datagram`.
     const runtime_default = Config{ .listen_host = "::", .quic_port = 443 };
-    try testing.expectEqual(quic.datagram.base_size, runtime_default.max_datagram_size);
+    try testing.expectEqual(quic.datagram.max_size, runtime_default.max_datagram_size);
     const mapped = quicConfigFrom(runtime_default);
     try testing.expectEqual(
         (quic.config.Config{}).max_send_udp_payload_size,

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -1734,6 +1734,66 @@ fn cidSliceContains(cids: []const quic.cid.ConnectionId, needle: quic.cid.Connec
     return false;
 }
 
+/// The IPv4/IPv6 socket options that disable source fragmentation on this
+/// platform, or null where no such API has been verified.
+///
+/// These are *not* portable across the BSDs and must not be grouped: Apple's
+/// `<netinet/in.h>` defines IPv4 `IP_DONTFRAG` as 28, FreeBSD's defines it as
+/// 67, and OpenBSD uses option 28 for `IP_IPSEC_REMOTE_AUTH` entirely. Since
+/// this helper's return value is the gate that unlocks discovery above 1200, a
+/// wrong constant that some kernel happens to *accept* would report success
+/// without ever setting DF — the exact false-positive the gate exists to
+/// prevent. An unverified platform therefore returns null and stays on the
+/// conservative 1200-byte policy rather than guessing.
+const NoFragmentOptions = struct {
+    level_v4: u32,
+    option_v4: u32,
+    level_v6: u32,
+    option_v6: u32,
+    /// Linux's `IP_PMTUDISC_PROBE` is a mode value; the DF-only platforms set
+    /// a boolean instead.
+    value: c_int,
+};
+
+const no_fragment_options: ?NoFragmentOptions = switch (builtin.os.tag) {
+    // `IP_PMTUDISC_PROBE` sets DF *and* ignores the kernel's cached path MTU,
+    // which RFC 8899 §4.5 requires so DPLPMTUD is the thing in control.
+    .linux => .{
+        .level_v4 = posix.IPPROTO.IP,
+        .option_v4 = std.os.linux.IP.MTU_DISCOVER,
+        .level_v6 = posix.IPPROTO.IPV6,
+        .option_v6 = std.os.linux.IPV6.MTU_DISCOVER,
+        .value = std.os.linux.IP.PMTUDISC_PROBE,
+    },
+    // Darwin: IP_DONTFRAG (28) / IPV6_DONTFRAG (62) from <netinet/in.h> and
+    // <netinet6/in6.h>; not exposed by Zig's darwin bindings. DF only — there
+    // is no probe mode, so a kernel-cached PMTU can still bound a probe. That
+    // costs discovery reach, never soundness: a probe the kernel refuses to
+    // send simply fails, and a failed probe never validates a size.
+    .macos, .ios, .tvos, .watchos => .{
+        .level_v4 = posix.IPPROTO.IP,
+        .option_v4 = 28,
+        .level_v6 = posix.IPPROTO.IPV6,
+        .option_v6 = 62,
+        .value = 1,
+    },
+    // FreeBSD: IP_DONTFRAG is 67 there, *not* Darwin's 28.
+    .freebsd => .{
+        .level_v4 = posix.IPPROTO.IP,
+        .option_v4 = 67,
+        .level_v6 = posix.IPPROTO.IPV6,
+        .option_v6 = 62,
+        .value = 1,
+    },
+    // NetBSD/OpenBSD/DragonFly expose no IPv4 no-fragment option this code has
+    // verified, so they take the conservative path rather than a guess.
+    else => null,
+};
+
+/// Whether this platform has a verified no-source-fragmentation API at all.
+/// Discovery above the RFC 9000 §14 floor is gated on it.
+const no_fragment_supported = no_fragment_options != null;
+
 /// RFC 8899 §3 / RFC 9000 §14: a DPLPMTUD probe only measures a path MTU if
 /// the IP layer puts it on the wire as one *unfragmented* datagram. Where the
 /// kernel is free to source-fragment, an acknowledged 2048-byte probe proves
@@ -1742,42 +1802,18 @@ fn cidSliceContains(cids: []const quic.cid.ConnectionId, needle: quic.cid.Connec
 /// RFC 9000 §14 independently forbids fragmenting QUIC datagrams at all.
 ///
 /// So the no-fragmentation contract is a *precondition* for discovering
-/// anything above the RFC 9000 §14 floor, not a tuning detail. This returns
-/// whether the kernel accepted one; `Runtime.init` holds discovery at 1200 on
-/// platforms where it did not, which is the conservative policy #256's
-/// acceptance criteria allow as the alternative to DPLPMTUD.
-///
-/// Linux gets `IP_PMTUDISC_PROBE`, which sets DF *and* ignores the kernel's
-/// cached path MTU — RFC 8899 §4.5 requires DPLPMTUD to be in control rather
-/// than clamped by a lower layer's own discovery. macOS/BSD have no probe
-/// mode, so they get `IP_DONTFRAG`, which supplies the DF half; the kernel's
-/// cached PMTU can still bound a probe there, which costs discovery reach but
-/// never soundness — a probe the kernel refuses to send simply fails, and a
-/// failed probe is never evidence that a size works.
+/// anything above the floor, not a tuning detail. This returns whether the
+/// kernel accepted one; `Runtime.init` holds discovery at 1200 when it did
+/// not, which is the conservative policy #256's acceptance criteria allow as
+/// the alternative to DPLPMTUD.
 fn configureNoFragment(fd: std.c.fd_t, sa_family: u32) bool {
+    const options = no_fragment_options orelse return false;
     const is_v6 = sa_family == posix.AF.INET6;
-    switch (builtin.os.tag) {
-        .linux => {
-            const linux = std.os.linux;
-            const level: u32 = if (is_v6) posix.IPPROTO.IPV6 else posix.IPPROTO.IP;
-            const option: u32 = if (is_v6) linux.IPV6.MTU_DISCOVER else linux.IP.MTU_DISCOVER;
-            const mode: c_int = if (is_v6) linux.IPV6.PMTUDISC_PROBE else linux.IP.PMTUDISC_PROBE;
-            posix.setsockopt(fd, @intCast(level), @intCast(option), std.mem.asBytes(&mode)) catch return false;
-            return true;
-        },
-        .macos, .ios, .tvos, .watchos, .freebsd, .netbsd, .openbsd, .dragonfly => {
-            // Not exposed by Zig's darwin/BSD headers; the values are the
-            // stable ABI constants from <netinet/in.h> and <netinet6/in6.h>.
-            const ip_dontfrag: u32 = 28;
-            const ipv6_dontfrag: u32 = 62;
-            const level: u32 = if (is_v6) posix.IPPROTO.IPV6 else posix.IPPROTO.IP;
-            const option: u32 = if (is_v6) ipv6_dontfrag else ip_dontfrag;
-            const on: c_int = 1;
-            posix.setsockopt(fd, @intCast(level), @intCast(option), std.mem.asBytes(&on)) catch return false;
-            return true;
-        },
-        else => return false,
-    }
+    const level = if (is_v6) options.level_v6 else options.level_v4;
+    const option = if (is_v6) options.option_v6 else options.option_v4;
+    const value = options.value;
+    posix.setsockopt(fd, @intCast(level), @intCast(option), std.mem.asBytes(&value)) catch return false;
+    return true;
 }
 
 /// Create a non-blocking, close-on-exec UDP socket for `sa_family`. Returns a
@@ -2203,15 +2239,28 @@ test "quicConfigFrom clamps datagram size into the work-buffer range" {
     }, true).retry_policy);
 }
 
-test "quicConfigFrom: the runtime default is the transport's own authoritative default" {
-    // #256-A: the runtime must not carry a second datagram-size default that
-    // can drift from the transport's. Both come from `quic.datagram`.
+test "quicConfigFrom: the runtime is the socket owner that opts discovery in" {
+    // #256-A: neither layer carries a second datagram-size *value* that can
+    // drift — both come from `quic.datagram`. #256-B splits the two defaults
+    // on purpose, though: the transport cannot see a socket, so it stays at
+    // the floor, and this runtime raises the ceiling only because it just
+    // established the no-fragmentation contract on the socket it owns.
     const runtime_default = Config{ .listen_host = "::", .quic_port = 443 };
     try testing.expectEqual(quic.datagram.max_size, runtime_default.max_datagram_size);
+    try testing.expectEqual(
+        @as(u64, quic.datagram.base_size),
+        (quic.config.Config{}).max_send_udp_payload_size,
+    );
     const mapped = quicConfigFrom(runtime_default, true);
     try testing.expectEqual(
-        (quic.config.Config{}).max_send_udp_payload_size,
+        @as(u64, quic.datagram.max_size),
         mapped.max_send_udp_payload_size,
+    );
+    // ... and without that contract it falls back to the transport's own
+    // conservative default rather than the operator's ceiling.
+    try testing.expectEqual(
+        (quic.config.Config{}).max_send_udp_payload_size,
+        quicConfigFrom(runtime_default, false).max_send_udp_payload_size,
     );
     // The advertised receive capacity is a property of the transport's
     // buffers, not of this operator knob, so the knob must not move it.
@@ -4805,14 +4854,28 @@ test "http3 runtime: DPLPMTUD stays at the floor without the no-fragmentation co
     );
 }
 
-test "http3 runtime: the no-fragmentation socket option is actually accepted here" {
-    // Platform-gated: asserts the option is applied where the OS supports it,
-    // rather than trusting that `setsockopt` was called.
-    if (builtin.os.tag != .linux and builtin.os.tag != .macos) return error.SkipZigTest;
+test "http3 runtime: the no-fragmentation contract is established exactly where it is claimed" {
+    // Runs on every platform. Where the OS is one this code has verified, the
+    // option must actually be accepted by the kernel — not merely attempted.
+    // Where it is not, `configureNoFragment` must report failure so the
+    // ceiling collapses, rather than guessing a constant and reporting
+    // success without ever setting DF.
     for ([_]u32{ posix.AF.INET, posix.AF.INET6 }) |family| {
         const fd = openUdpSocket(family);
         if (fd < 0) continue;
         defer _ = std.c.close(fd);
-        try testing.expect(configureNoFragment(fd, family));
+        try testing.expectEqual(no_fragment_supported, configureNoFragment(fd, family));
     }
+}
+
+test "http3 runtime: only verified platforms claim no-fragmentation support" {
+    // The list here is the same one `docs/HTTP3_ROLLOUT.md` names. BSD is not
+    // one platform: Darwin's IP_DONTFRAG is 28 and FreeBSD's is 67, and
+    // OpenBSD uses 28 for something else entirely, so the families cannot be
+    // grouped and the unverified ones must stay conservative.
+    const expected = switch (builtin.os.tag) {
+        .linux, .macos, .ios, .tvos, .watchos, .freebsd => true,
+        else => false,
+    };
+    try testing.expectEqual(expected, no_fragment_supported);
 }

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -17,6 +17,7 @@
 //! backend. Without a provider the QUIC listener stays unbootstrapped with a
 //! logged warning while TCP continues to serve.
 
+const builtin = @import("builtin");
 const compat = @import("zig_compat");
 const std = @import("std");
 const early_data_policy = @import("early_data.zig");
@@ -318,6 +319,14 @@ pub const Runtime = struct {
         errdefer _ = std.c.close(fd);
 
         posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.REUSEADDR, std.mem.asBytes(&@as(c_int, 1))) catch {}; // REUSEADDR is advisory; bind proceeds regardless
+        // DPLPMTUD's precondition (#256-B). Advisory to the *listener* — a
+        // kernel that refuses it still serves QUIC — but binding on discovery:
+        // without it a probe can be fragmented and its acknowledgement would
+        // measure reassembly instead of the path.
+        const no_fragment = configureNoFragment(fd, sa_family);
+        if (!no_fragment) {
+            logger.warn(null, "http3: no-fragmentation socket policy unavailable; path MTU discovery held at {d} bytes", .{quic.datagram.base_size});
+        }
         const bind_rc = std.c.bind(fd, @ptrCast(&address.storage), @intCast(address.len));
         if (bind_rc != 0) {
             logger.warn(null, "http3: udp bind failed: {s}", .{@tagName(posix.errno(bind_rc))});
@@ -350,7 +359,7 @@ pub const Runtime = struct {
             .zero_rtt_enabled = zeroRttCarrierEnabled(cfg),
             .retry_policy = cfg.retry_policy,
             .secrets = .{},
-            .quic_config = quicConfigFrom(cfg),
+            .quic_config = quicConfigFrom(cfg, no_fragment),
             .h3_settings = cfg.h3_settings,
             .early_data_compat_metrics_ctx = cfg.early_data_compat_metrics_ctx,
             .early_data_compat_metrics_cb = cfg.early_data_compat_metrics_cb,
@@ -1570,9 +1579,16 @@ fn buildStreamRequest(allocator: std.mem.Allocator, exchange: stream_transport.E
 
 /// Map the operator-facing runtime config onto the native QUIC transport
 /// config.
-fn quicConfigFrom(cfg: Config) quic.config.Config {
+/// `no_fragment` is whether the listener's socket actually established the
+/// no-IP-fragmentation contract DPLPMTUD requires (RFC 8899 §3). Without it
+/// the discovery ceiling collapses to the RFC 9000 §14 floor regardless of
+/// what the operator configured: a probe that the kernel may fragment cannot
+/// measure a path MTU, and raising the send size on that evidence would be
+/// worse than never discovering anything.
+fn quicConfigFrom(cfg: Config, no_fragment: bool) quic.config.Config {
+    const configured = std.math.clamp(cfg.max_datagram_size, quic.datagram.base_size, quic.datagram.max_size);
     return .{
-        .max_send_udp_payload_size = std.math.clamp(cfg.max_datagram_size, quic.datagram.base_size, quic.datagram.max_size),
+        .max_send_udp_payload_size = if (no_fragment) configured else quic.datagram.base_size,
         .zero_rtt_enabled = zeroRttCarrierEnabled(cfg),
         .retry_policy = cfg.retry_policy,
         .migration_policy = if (cfg.connection_migration) .full else .nat_rebinding_only,
@@ -1716,6 +1732,52 @@ fn cidSliceContains(cids: []const quic.cid.ConnectionId, needle: quic.cid.Connec
         if (std.mem.eql(u8, cid.slice(), needle.slice())) return true;
     }
     return false;
+}
+
+/// RFC 8899 §3 / RFC 9000 §14: a DPLPMTUD probe only measures a path MTU if
+/// the IP layer puts it on the wire as one *unfragmented* datagram. Where the
+/// kernel is free to source-fragment, an acknowledged 2048-byte probe proves
+/// the peer reassembled two fragments — not that the path carries 2048 bytes —
+/// and discovery would happily raise the send size on that false evidence.
+/// RFC 9000 §14 independently forbids fragmenting QUIC datagrams at all.
+///
+/// So the no-fragmentation contract is a *precondition* for discovering
+/// anything above the RFC 9000 §14 floor, not a tuning detail. This returns
+/// whether the kernel accepted one; `Runtime.init` holds discovery at 1200 on
+/// platforms where it did not, which is the conservative policy #256's
+/// acceptance criteria allow as the alternative to DPLPMTUD.
+///
+/// Linux gets `IP_PMTUDISC_PROBE`, which sets DF *and* ignores the kernel's
+/// cached path MTU — RFC 8899 §4.5 requires DPLPMTUD to be in control rather
+/// than clamped by a lower layer's own discovery. macOS/BSD have no probe
+/// mode, so they get `IP_DONTFRAG`, which supplies the DF half; the kernel's
+/// cached PMTU can still bound a probe there, which costs discovery reach but
+/// never soundness — a probe the kernel refuses to send simply fails, and a
+/// failed probe is never evidence that a size works.
+fn configureNoFragment(fd: std.c.fd_t, sa_family: u32) bool {
+    const is_v6 = sa_family == posix.AF.INET6;
+    switch (builtin.os.tag) {
+        .linux => {
+            const linux = std.os.linux;
+            const level: u32 = if (is_v6) posix.IPPROTO.IPV6 else posix.IPPROTO.IP;
+            const option: u32 = if (is_v6) linux.IPV6.MTU_DISCOVER else linux.IP.MTU_DISCOVER;
+            const mode: c_int = if (is_v6) linux.IPV6.PMTUDISC_PROBE else linux.IP.PMTUDISC_PROBE;
+            posix.setsockopt(fd, @intCast(level), @intCast(option), std.mem.asBytes(&mode)) catch return false;
+            return true;
+        },
+        .macos, .ios, .tvos, .watchos, .freebsd, .netbsd, .openbsd, .dragonfly => {
+            // Not exposed by Zig's darwin/BSD headers; the values are the
+            // stable ABI constants from <netinet/in.h> and <netinet6/in6.h>.
+            const ip_dontfrag: u32 = 28;
+            const ipv6_dontfrag: u32 = 62;
+            const level: u32 = if (is_v6) posix.IPPROTO.IPV6 else posix.IPPROTO.IP;
+            const option: u32 = if (is_v6) ipv6_dontfrag else ip_dontfrag;
+            const on: c_int = 1;
+            posix.setsockopt(fd, @intCast(level), @intCast(option), std.mem.asBytes(&on)) catch return false;
+            return true;
+        },
+        else => return false,
+    }
 }
 
 /// Create a non-blocking, close-on-exec UDP socket for `sa_family`. Returns a
@@ -2116,16 +2178,16 @@ test "quicConfigFrom clamps datagram size into the work-buffer range" {
         .listen_host = "::",
         .quic_port = 443,
         .max_datagram_size = 512,
-    }).max_send_udp_payload_size);
+    }, true).max_send_udp_payload_size);
     // Above the 2048-byte work buffer snaps down.
     try testing.expectEqual(@as(u64, 2048), quicConfigFrom(.{
         .listen_host = "::",
         .quic_port = 443,
         .max_datagram_size = 9000,
-    }).max_send_udp_payload_size);
+    }, true).max_send_udp_payload_size);
     // An in-range value passes through, and default migration allows validated
     // same-IP NAT rebinding while still advertising disable_active_migration.
-    const mid = quicConfigFrom(.{ .listen_host = "::", .quic_port = 443, .max_datagram_size = 1350 });
+    const mid = quicConfigFrom(.{ .listen_host = "::", .quic_port = 443, .max_datagram_size = 1350 }, true);
     try testing.expectEqual(@as(u64, 1350), mid.max_send_udp_payload_size);
     try testing.expectEqual(quic.config.MigrationPolicy.nat_rebinding_only, mid.migration_policy);
     try testing.expectEqual(quic.config.RetryPolicy.off, mid.retry_policy);
@@ -2133,12 +2195,12 @@ test "quicConfigFrom clamps datagram size into the work-buffer range" {
         .listen_host = "::",
         .quic_port = 443,
         .connection_migration = true,
-    }).migration_policy);
+    }, true).migration_policy);
     try testing.expectEqual(quic.config.RetryPolicy.address_validation, quicConfigFrom(.{
         .listen_host = "::",
         .quic_port = 443,
         .retry_policy = .address_validation,
-    }).retry_policy);
+    }, true).retry_policy);
 }
 
 test "quicConfigFrom: the runtime default is the transport's own authoritative default" {
@@ -2146,7 +2208,7 @@ test "quicConfigFrom: the runtime default is the transport's own authoritative d
     // can drift from the transport's. Both come from `quic.datagram`.
     const runtime_default = Config{ .listen_host = "::", .quic_port = 443 };
     try testing.expectEqual(quic.datagram.max_size, runtime_default.max_datagram_size);
-    const mapped = quicConfigFrom(runtime_default);
+    const mapped = quicConfigFrom(runtime_default, true);
     try testing.expectEqual(
         (quic.config.Config{}).max_send_udp_payload_size,
         mapped.max_send_udp_payload_size,
@@ -2159,7 +2221,7 @@ test "quicConfigFrom: the runtime default is the transport's own authoritative d
     );
     try testing.expectEqual(
         quic.datagram.max_size,
-        quicConfigFrom(.{ .listen_host = "::", .quic_port = 443, .max_datagram_size = 1350 }).max_udp_payload_size,
+        quicConfigFrom(.{ .listen_host = "::", .quic_port = 443, .max_datagram_size = 1350 }, true).max_udp_payload_size,
     );
 }
 
@@ -2400,28 +2462,28 @@ test "quicConfigFrom (#523): enable_0rtt alone never enables the 0-RTT carrier" 
     const gate = gate_adapter.gate();
 
     // No dependencies at all.
-    try testing.expect(!quicConfigFrom(.{ .listen_host = "::", .quic_port = 443, .enable_0rtt = true }).zero_rtt_enabled);
+    try testing.expect(!quicConfigFrom(.{ .listen_host = "::", .quic_port = 443, .enable_0rtt = true }, true).zero_rtt_enabled);
     // Only a resumption runtime.
     try testing.expect(!quicConfigFrom(.{
         .listen_host = "::",
         .quic_port = 443,
         .enable_0rtt = true,
         .resumption_runtime = &resumption,
-    }).zero_rtt_enabled);
+    }, true).zero_rtt_enabled);
     // Only a replay gate.
     try testing.expect(!quicConfigFrom(.{
         .listen_host = "::",
         .quic_port = 443,
         .enable_0rtt = true,
         .early_data_replay_gate = gate,
-    }).zero_rtt_enabled);
+    }, true).zero_rtt_enabled);
     // Both dependencies present but `enable_0rtt` false (the default): still disabled.
     try testing.expect(!quicConfigFrom(.{
         .listen_host = "::",
         .quic_port = 443,
         .resumption_runtime = &resumption,
         .early_data_replay_gate = gate,
-    }).zero_rtt_enabled);
+    }, true).zero_rtt_enabled);
     // Every dependency present: the carrier actually enables.
     try testing.expect(quicConfigFrom(.{
         .listen_host = "::",
@@ -2429,7 +2491,7 @@ test "quicConfigFrom (#523): enable_0rtt alone never enables the 0-RTT carrier" 
         .enable_0rtt = true,
         .resumption_runtime = &resumption,
         .early_data_replay_gate = gate,
-    }).zero_rtt_enabled);
+    }, true).zero_rtt_enabled);
 }
 
 fn expectInvalidH3SettingsAtRuntimeInit(settings: http3.frame.Settings) !void {
@@ -4719,4 +4781,38 @@ test "sockaddr_in <-> quic.udp.Address conversion round-trips family, octets, an
 
 test {
     std.testing.refAllDecls(@This());
+}
+
+test "http3 runtime: DPLPMTUD stays at the floor without the no-fragmentation contract" {
+    // RFC 8899 §3: an acknowledged large probe only measures the path if the
+    // datagram was not fragmented. A listener that could not establish that
+    // contract must not discover above the RFC 9000 §14 floor, whatever the
+    // operator configured.
+    const raised = Config{ .listen_host = "::", .quic_port = 443, .max_datagram_size = quic.datagram.max_size };
+    try testing.expectEqual(
+        @as(u64, quic.datagram.max_size),
+        quicConfigFrom(raised, true).max_send_udp_payload_size,
+    );
+    try testing.expectEqual(
+        @as(u64, quic.datagram.base_size),
+        quicConfigFrom(raised, false).max_send_udp_payload_size,
+    );
+    // The advertised receive capacity is a property of this endpoint's
+    // buffers and is unaffected either way.
+    try testing.expectEqual(
+        quicConfigFrom(raised, true).max_udp_payload_size,
+        quicConfigFrom(raised, false).max_udp_payload_size,
+    );
+}
+
+test "http3 runtime: the no-fragmentation socket option is actually accepted here" {
+    // Platform-gated: asserts the option is applied where the OS supports it,
+    // rather than trusting that `setsockopt` was called.
+    if (builtin.os.tag != .linux and builtin.os.tag != .macos) return error.SkipZigTest;
+    for ([_]u32{ posix.AF.INET, posix.AF.INET6 }) |family| {
+        const fd = openUdpSocket(family);
+        if (fd < 0) continue;
+        defer _ = std.c.close(fd);
+        try testing.expect(configureNoFragment(fd, family));
+    }
 }

--- a/src/quic/config.zig
+++ b/src/quic/config.zig
@@ -81,13 +81,16 @@ pub const Config = struct {
     /// sized from. Send-side limits live in `max_send_udp_payload_size` and
     /// `quic.datagram.Limits`.
     max_udp_payload_size: u64 = quic_datagram.max_size,
-    /// The sender's maximum datagram size for a new path: what this endpoint
-    /// assumes the path carries before anything has measured it. Defaults to
-    /// the RFC 9000 §14 floor, the only size every path must support. Raising
-    /// it asserts a path MTU rather than measuring one; #256-B replaces the
-    /// assertion with DPLPMTUD. Always additionally bounded by the peer's
+    /// The largest UDP payload this endpoint will ever put on the wire — a
+    /// ceiling, not a size. DPLPMTUD (#256-B) searches inside
+    /// `[base_size, this]` and raises the size actually emitted only when a
+    /// probe of the larger size is acknowledged, so a fresh path still starts
+    /// at the RFC 9000 §14 floor no matter how high this is set. Lowering it
+    /// bounds what discovery may find, which is the only reason to touch it:
+    /// under #256-A raising it *asserted* a path MTU, and that is what
+    /// discovery replaces. Always additionally bounded by the peer's
     /// advertised receive capacity.
-    max_send_udp_payload_size: u64 = quic_datagram.base_size,
+    max_send_udp_payload_size: u64 = quic_datagram.max_size,
     initial_max_data: u64 = 8 * 1024 * 1024,
     initial_max_stream_data_bidi_local: u64 = 1024 * 1024,
     initial_max_stream_data_bidi_remote: u64 = 1024 * 1024,
@@ -216,7 +219,10 @@ test "default QUIC config maps to conservative transport parameters" {
     // The advertised parameter is receive capacity, so it matches the receive
     // buffers the implementation allocates; the send side stays conservative.
     try std.testing.expectEqual(@as(u64, quic_datagram.max_size), params.max_udp_payload_size);
-    try std.testing.expectEqual(@as(u64, quic_datagram.base_size), cfg.max_send_udp_payload_size);
+    // The send *ceiling* defaults wide open — DPLPMTUD keeps the size actually
+    // emitted at the RFC floor until a probe of something larger is
+    // acknowledged (#256-B), so a wide ceiling is not an aggressive default.
+    try std.testing.expectEqual(@as(u64, quic_datagram.max_size), cfg.max_send_udp_payload_size);
     try std.testing.expect(params.disable_active_migration);
     try std.testing.expect(!cfg.zero_rtt_enabled);
     try std.testing.expectEqual(QpackMode.static_only, cfg.qpack.mode);

--- a/src/quic/config.zig
+++ b/src/quic/config.zig
@@ -85,12 +85,18 @@ pub const Config = struct {
     /// ceiling, not a size. DPLPMTUD (#256-B) searches inside
     /// `[base_size, this]` and raises the size actually emitted only when a
     /// probe of the larger size is acknowledged, so a fresh path still starts
-    /// at the RFC 9000 §14 floor no matter how high this is set. Lowering it
-    /// bounds what discovery may find, which is the only reason to touch it:
-    /// under #256-A raising it *asserted* a path MTU, and that is what
-    /// discovery replaces. Always additionally bounded by the peer's
-    /// advertised receive capacity.
-    max_send_udp_payload_size: u64 = quic_datagram.max_size,
+    /// at the RFC 9000 §14 floor no matter how high this is set.
+    ///
+    /// It defaults to the floor, which means **discovery is off unless an
+    /// embedder opts in**. That is deliberate: a probe only measures a path
+    /// MTU if the socket it goes out on cannot source-fragment it (RFC 8899
+    /// §3), and this layer owns no socket and cannot know. Only the
+    /// composition root that created the socket can establish that contract,
+    /// so only it may raise this — see `http3_runtime.configureNoFragment`.
+    /// An embedder that raises it without one is asking discovery to trust an
+    /// acknowledgement that may only prove reassembly. Always additionally
+    /// bounded by the peer's advertised receive capacity.
+    max_send_udp_payload_size: u64 = quic_datagram.base_size,
     initial_max_data: u64 = 8 * 1024 * 1024,
     initial_max_stream_data_bidi_local: u64 = 1024 * 1024,
     initial_max_stream_data_bidi_remote: u64 = 1024 * 1024,
@@ -219,10 +225,9 @@ test "default QUIC config maps to conservative transport parameters" {
     // The advertised parameter is receive capacity, so it matches the receive
     // buffers the implementation allocates; the send side stays conservative.
     try std.testing.expectEqual(@as(u64, quic_datagram.max_size), params.max_udp_payload_size);
-    // The send *ceiling* defaults wide open — DPLPMTUD keeps the size actually
-    // emitted at the RFC floor until a probe of something larger is
-    // acknowledged (#256-B), so a wide ceiling is not an aggressive default.
-    try std.testing.expectEqual(@as(u64, quic_datagram.max_size), cfg.max_send_udp_payload_size);
+    // The send ceiling defaults to the floor: discovery is off until a socket
+    // owner that can guarantee no IP fragmentation opts in (#256-B).
+    try std.testing.expectEqual(@as(u64, quic_datagram.base_size), cfg.max_send_udp_payload_size);
     try std.testing.expect(params.disable_active_migration);
     try std.testing.expect(!cfg.zero_rtt_enabled);
     try std.testing.expectEqual(QpackMode.static_only, cfg.qpack.mode);

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -724,14 +724,16 @@ const SentRecord = struct {
     space: PacketNumberSpace,
     packet_number: u64,
     ack_eliciting: bool,
-    /// The path this packet actually went out on, and the size it went out at
-    /// (#256-B). DPLPMTUD feedback is a statement about *that* path, and a
-    /// migration does not retroactively move a packet: recovery keeps
-    /// old-path packets in flight across a promotion (RFC 9000 §9.4), so an
-    /// ACK or a loss can arrive long after a different path became active.
-    /// Every PMTU outcome is routed back through these two fields rather than
-    /// through whatever `activePath()` happens to be at the time.
-    sent_path: quic_path.PathKey,
+    /// The path *incarnation* this packet went out on, and the size it went
+    /// out at (#256-B). DPLPMTUD feedback is a statement about that specific
+    /// incarnation, and a migration does not retroactively move a packet:
+    /// recovery keeps old-path packets in flight across a promotion (RFC 9000
+    /// §9.4), so an ACK or a loss can arrive long after a different path
+    /// became active — or after this very tuple was re-validated and started
+    /// discovery over. Routing every outcome through the stamped `PathRef`
+    /// makes both cases resolve to the state that actually produced them, or
+    /// to nothing at all.
+    sent_path: quic_path.PathRef,
     sent_size: usize = 0,
     crypto: ?Range = null,
     stream_count: u8 = 0,
@@ -1168,16 +1170,14 @@ pub const Connection = struct {
     /// The same bounds resolved for a specific path's controller, so a report
     /// about a path that is no longer active (a PMTU change on a path whose
     /// delayed ACK just arrived) describes that path rather than this one.
-    fn datagramLimitsForPath(self: *const Connection, key: quic_path.PathKey) quic_datagram.Limits {
-        const active = self.paths.activePath();
-        const plpmtu = if (active.key.eql(key)) active.plpmtu else blk: {
-            for (self.paths.paths) |slot| {
-                const path = slot orelse continue;
-                if (path.key.eql(key)) break :blk path.plpmtu;
+    fn datagramLimitsForPath(self: *const Connection, ref: quic_path.PathRef) quic_datagram.Limits {
+        for (self.paths.paths) |slot| {
+            const path = slot orelse continue;
+            if (path.generation == ref.generation and path.key.eql(ref.key)) {
+                return self.datagramLimitsFor(path.plpmtu);
             }
-            break :blk active.plpmtu;
-        };
-        return self.datagramLimitsFor(plpmtu);
+        }
+        return self.datagramLimits();
     }
 
     fn datagramLimitsFor(self: *const Connection, plpmtu: quic_pmtu.Controller) quic_datagram.Limits {
@@ -1247,29 +1247,45 @@ pub const Connection = struct {
     /// Feed one piece of black-hole evidence to the active path's controller
     /// and report the fallback if that tipped it. Both signals funnel through
     /// here so "the send size just dropped" is observed in exactly one place.
-    fn notePmtuBlackHoleEvidence(
+    /// Feed one piece of DPLPMTUD evidence to `path`'s controller and publish
+    /// the fallback if that tipped it.
+    ///
+    /// Every mutation that can increment `black_holes` goes through
+    /// `publishPmtuFallbackIfChanged`, including the ordinary-ACK path: since
+    /// corroboration evaluates immediately, the first smaller delivery after
+    /// enough large losses *is* the transition, and it would otherwise fall
+    /// back silently — no metric, no event, and recovery still sized for a
+    /// datagram the path has stopped carrying (#256-B second review).
+    fn notePmtuEvidence(
         self: *Connection,
-        path: quic_path.PathKey,
-        kind: union(enum) { ordinary_loss: usize, stalled_pto },
+        path: quic_path.PathRef,
+        kind: union(enum) { ordinary_loss: usize, ordinary_ack: usize, stalled_pto },
         now_us: u64,
     ) void {
         const controller = self.paths.plpmtuFor(path) orelse return;
         const before = controller.black_holes;
         switch (kind) {
             .ordinary_loss => |size| controller.onOrdinaryLoss(size, now_us),
+            .ordinary_ack => |size| controller.onOrdinaryAck(size, now_us),
             .stalled_pto => controller.onProbeTimeout(now_us),
         }
+        self.publishPmtuFallbackIfChanged(path, before);
+    }
+
+    /// The one place a black-hole fallback becomes observable: the operator
+    /// counter, the event, and — when the fallback is on the path we are
+    /// actually sending on — recovery's current datagram size, which RFC 9002
+    /// §B.2 expresses every NewReno window in terms of and which therefore
+    /// cannot wait for the next poll.
+    fn publishPmtuFallbackIfChanged(self: *Connection, path: quic_path.PathRef, before: u32) void {
+        const controller = self.paths.plpmtuFor(path) orelse return;
         if (controller.black_holes == before) return;
         self.metrics.pmtu_black_holes += 1;
-        // Recovery's NewReno windows are expressed in the sender's current
-        // datagram size (RFC 9002 §B.2), so a fallback on the path we are
-        // actually sending on has to reach it now rather than at the next
-        // poll. A fallback on some other path changes nothing we emit today.
-        if (self.paths.activePath().key.eql(path)) {
+        if (self.paths.isActive(path)) {
             self.recovery.congestion.setMaxDatagramSize(self.effectiveMaxDatagramSize());
         }
         self.events.emit(.{ .pmtu_updated = .{
-            .path = path,
+            .path = path.key,
             .size = self.datagramLimitsForPath(path).effective(),
             .reason = .black_hole,
         } });
@@ -1932,9 +1948,7 @@ pub const Connection = struct {
                 // `onRecordAcked` resolves those against the outstanding probe
                 // instead.
                 if (!acked.packet.pmtu_probe) {
-                    if (self.paths.plpmtuFor(record.sent_path)) |controller| {
-                        controller.onOrdinaryAck(record.sent_size, now_us);
-                    }
+                    self.notePmtuEvidence(record.sent_path, .{ .ordinary_ack = record.sent_size }, now_us);
                 }
             }
             self.onRecordAcked(record, now_us);
@@ -1964,7 +1978,7 @@ pub const Connection = struct {
             const controller = self.paths.plpmtuFor(record.sent_path) orelse return;
             if (controller.onProbeAcked(record.packet_number, now_us)) {
                 self.events.emit(.{ .pmtu_updated = .{
-                    .path = record.sent_path,
+                    .path = record.sent_path.key,
                     .size = self.datagramLimitsForPath(record.sent_path).effective(),
                     .reason = .raised,
                 } });
@@ -2029,7 +2043,7 @@ pub const Connection = struct {
             // #256-B: a lost ordinary datagram is evidence about the path it
             // was sent on and the size it was sent at — the controller decides
             // whether that size is large enough to mean anything.
-            self.notePmtuBlackHoleEvidence(
+            self.notePmtuEvidence(
                 record.sent_path,
                 .{ .ordinary_loss = record.sent_size },
                 now_us,
@@ -2721,6 +2735,23 @@ pub const Connection = struct {
         return self.recovery.tracker.hasAckElicitingInFlight(space);
     }
 
+    /// Whether *this path incarnation* still has ack-eliciting packets the
+    /// peer has not acknowledged. `spaceHasAckElicitingInFlight` asks only
+    /// whether any packet in the space is outstanding, which after a migration
+    /// can be true entirely because of packets belonging to the path we left.
+    fn pathHasAckElicitingInFlight(
+        self: *const Connection,
+        space: PacketNumberSpace,
+        path: quic_path.PathRef,
+    ) bool {
+        for (self.sent_records.items) |record| {
+            if (record.space != space or !record.ack_eliciting) continue;
+            if (!record.sent_path.eql(path)) continue;
+            if (self.trackerContains(space, record.packet_number)) return true;
+        }
+        return false;
+    }
+
     /// Process timer expiry at `now_us`. Cheap when nothing expired.
     pub fn onTimeout(self: *Connection, now_us: u64) void {
         if (self.state_ == .closed) return;
@@ -2796,12 +2827,20 @@ pub const Connection = struct {
         // in two spaces is still one piece of evidence; discovery only runs
         // after confirmation anyway, when the earlier spaces are gone.
         //
-        // This one *is* an active-path statement, unlike the ACK/loss signals:
-        // it says what this endpoint is sending right now is not getting
-        // through, and what it is sending right now goes out on the active
-        // path at the active path's size.
+        // The QUIC PTO itself is connection-wide, which is *not* enough to
+        // charge as evidence against the active path: `resetForPathMigration`
+        // deliberately keeps old-path packets in recovery, so after A→B the
+        // timer can be driven entirely by outstanding A packets while every B
+        // packet has been acknowledged. Three of those would drag a healthy,
+        // freshly-discovered B back to the floor for something A did. Only
+        // count the expiry when the active path itself still has ack-eliciting
+        // packets outstanding — then the stall really is about what this
+        // endpoint is sending now, at the size it is sending it.
         if (space == .application) {
-            self.notePmtuBlackHoleEvidence(self.paths.activePath().key, .stalled_pto, now_us);
+            const active = self.paths.activePathRef();
+            if (self.pathHasAckElicitingInFlight(space, active)) {
+                self.notePmtuEvidence(active, .stalled_pto, now_us);
+            }
         }
         // Requeue the oldest unacked retransmittable content of the space so
         // the probe carries data rather than a bare PING when possible.
@@ -3178,7 +3217,7 @@ pub const Connection = struct {
         var plain: [max_datagram_size_ceiling]u8 = undefined;
         const plain_budget = @min(plain.len, max_packet - pn_offset - pn_len - aead_tag_len);
         var plain_len: usize = 0;
-        var record = SentRecord{ .space = .application, .packet_number = pn, .ack_eliciting = false, .sent_path = path };
+        var record = SentRecord{ .space = .application, .packet_number = pn, .ack_eliciting = false, .sent_path = self.paths.pathRefFor(path) orelse return null };
 
         var i: usize = 0;
         while (i < self.pending_path_responses.items.len) {
@@ -3344,7 +3383,7 @@ pub const Connection = struct {
             .space = .application,
             .packet_number = pn,
             .ack_eliciting = true,
-            .sent_path = active_key,
+            .sent_path = self.paths.activePathRef(),
             .sent_size = total,
             .carried_pmtu_probe = probe_size,
         };
@@ -3495,7 +3534,7 @@ pub const Connection = struct {
             .ack_eliciting = false,
             // Ordinary content always targets the active path; candidate-path
             // content is built and recorded by `buildCandidatePacket`.
-            .sent_path = self.paths.activePath().key,
+            .sent_path = self.paths.activePathRef(),
         };
         // `record` may pick up a dequeued NEW_CONNECTION_ID's reset token
         // below; `self.sent_records.append` (if reached) copies it into the
@@ -7933,8 +7972,8 @@ test "wipeSentRecordsSwapRemoveResidue zeroes the vacated slot regardless of its
     var records: std.ArrayList(SentRecord) = .empty;
     defer records.deinit(testing.allocator);
     try records.ensureTotalCapacityPrecise(testing.allocator, 4);
-    records.appendAssumeCapacity(.{ .space = .application, .packet_number = 1, .ack_eliciting = false, .sent_path = TestPair.client_path });
-    records.appendAssumeCapacity(.{ .space = .application, .packet_number = 2, .ack_eliciting = false, .sent_path = TestPair.client_path });
+    records.appendAssumeCapacity(.{ .space = .application, .packet_number = 1, .ack_eliciting = false, .sent_path = .{ .key = TestPair.client_path, .generation = 1 } });
+    records.appendAssumeCapacity(.{ .space = .application, .packet_number = 2, .ack_eliciting = false, .sent_path = .{ .key = TestPair.client_path, .generation = 1 } });
 
     _ = records.swapRemove(0);
     // Simulate whatever a safety-checked build's poison-fill (or a
@@ -8000,7 +8039,7 @@ test "connection: fixed sent-record and pending-CID capacities are preallocated"
             .space = .application,
             .packet_number = i,
             .ack_eliciting = false,
-            .sent_path = pair.server.paths.activePath().key,
+            .sent_path = pair.server.paths.activePathRef(),
         });
     }
     try testing.expectEqual(sent_records_backing, pair.server.sent_records.items.ptr);
@@ -8861,7 +8900,8 @@ test "driver: PMTU loss feedback after promotion lands on the path that sent it"
     try pair.pump();
 
     // The handshake path discovered a size above the floor.
-    const old_key = pair.server.activePathKey();
+    const old_ref = pair.server.paths.activePathRef();
+    const old_key = old_ref.key;
     const discovered = pair.server.effectiveMaxDatagramSize();
     try testing.expect(discovered > base_datagram_size);
 
@@ -8886,7 +8926,7 @@ test "driver: PMTU loss feedback after promotion lands on the path that sent it"
 
     // The new path starts clean.
     try testing.expectEqual(base_datagram_size, pair.server.effectiveMaxDatagramSize());
-    try testing.expectEqual(@as(u8, 0), pair.server.paths.plpmtuFor(rebind_candidate).?.oversized_losses);
+    try testing.expectEqual(@as(u8, 0), pair.server.paths.plpmtuFor(pair.server.paths.activePathRef()).?.oversized_losses);
 
     // An old-path packet, sent at the old path's larger size, is now declared
     // lost. `requeueUntrackedRecords` owns the attribution.
@@ -8895,17 +8935,17 @@ test "driver: PMTU loss feedback after promotion lands on the path that sent it"
         .space = .application,
         .packet_number = 9_999,
         .ack_eliciting = true,
-        .sent_path = old_key,
+        .sent_path = old_ref,
         .sent_size = discovered,
     };
     _ = pair.server.requeueUntrackedRecords(.application, pair.now_us);
 
     // It counted against the path that actually sent it ...
-    try testing.expectEqual(@as(u8, 1), pair.server.paths.plpmtuFor(old_key).?.oversized_losses);
+    try testing.expectEqual(@as(u8, 1), pair.server.paths.plpmtuFor(old_ref).?.oversized_losses);
     // ... and left the new path's controller alone. Attributing it here would
     // accumulate black-hole evidence against a size the new path has never
     // even sent, and three of those would drag it to the floor for nothing.
-    const fresh = pair.server.paths.plpmtuFor(rebind_candidate).?;
+    const fresh = pair.server.paths.plpmtuFor(pair.server.paths.activePathRef()).?;
     try testing.expectEqual(@as(u8, 0), fresh.oversized_losses);
     try testing.expectEqual(@as(u32, 0), fresh.black_holes);
     try testing.expectEqual(base_datagram_size, fresh.sendSize());
@@ -8918,9 +8958,9 @@ test "driver: a probe outcome after promotion resolves the probe's own path" {
     defer pair.deinit(allocator);
     try pair.pump();
 
-    const old_key = pair.server.activePathKey();
+    const old_ref = pair.server.paths.activePathRef();
     // An outstanding probe on the handshake path.
-    const old_controller = pair.server.paths.plpmtuFor(old_key).?;
+    const old_controller = pair.server.paths.plpmtuFor(old_ref).?;
     old_controller.reset();
     old_controller.enable(max_datagram_size_ceiling, pair.now_us);
     const probe_size = old_controller.nextProbeSize().?;
@@ -8947,13 +8987,13 @@ test "driver: a probe outcome after promotion resolves the probe's own path" {
         .space = .application,
         .packet_number = 4_242,
         .ack_eliciting = true,
-        .sent_path = old_key,
+        .sent_path = old_ref,
         .sent_size = probe_size,
         .carried_pmtu_probe = probe_size,
     }, pair.now_us);
 
-    try testing.expectEqual(probe_size, pair.server.paths.plpmtuFor(old_key).?.sendSize());
-    try testing.expectEqual(base_datagram_size, pair.server.paths.plpmtuFor(rebind_candidate).?.sendSize());
+    try testing.expectEqual(probe_size, pair.server.paths.plpmtuFor(old_ref).?.sendSize());
+    try testing.expectEqual(base_datagram_size, pair.server.paths.plpmtuFor(pair.server.paths.activePathRef()).?.sendSize());
     // The size on the wire follows the path we are actually sending on.
     try testing.expectEqual(base_datagram_size, pair.server.effectiveMaxDatagramSize());
 }
@@ -8969,14 +9009,14 @@ test "driver: PMTU feedback for a recycled path slot is dropped" {
         .local = TestPair.server_path.local,
         .remote = quic_udp.Address.ip4(.{ 198, 51, 100, 7 }, 4433),
     };
-    try testing.expectEqual(@as(?*quic_pmtu.Controller, null), pair.server.paths.plpmtuFor(stranger));
+    try testing.expectEqual(@as(?*quic_pmtu.Controller, null), pair.server.paths.plpmtuFor(.{ .key = stranger, .generation = 9_999 }));
 
     try ensureSentRecordCapacity(pair.server, pair.server.sent_records.items.len + 1);
     pair.server.sent_records.addOneAssumeCapacity().* = .{
         .space = .application,
         .packet_number = 8_888,
         .ack_eliciting = true,
-        .sent_path = stranger,
+        .sent_path = .{ .key = stranger, .generation = 9_999 },
         .sent_size = max_datagram_size_ceiling,
     };
     // Dropping the feedback is the point: applying it to some other path would
@@ -8986,27 +9026,249 @@ test "driver: PMTU feedback for a recycled path slot is dropped" {
     try testing.expectEqual(@as(u8, 0), pair.server.paths.activePlpmtu().oversized_losses);
 }
 
+test "driver: a re-validated tuple does not inherit its previous incarnation's feedback" {
+    const allocator = testing.allocator;
+    var pair = try MigrationPair.init(allocator, .full);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    // The handshake path A, with a discovered size and an outstanding record.
+    const old_ref = pair.server.paths.activePathRef();
+    const discovered = pair.server.effectiveMaxDatagramSize();
+    try testing.expect(discovered > base_datagram_size);
+
+    // Migrate A -> B.
+    var buf: [2048]u8 = undefined;
+    const datagram = try clientDatagram(pair, &buf);
+    try pair.server.ingestOnPath(datagram, rebind_candidate, TestPair.test_challenge_entropy, pair.now_us);
+    var challenge_out: [2048]u8 = undefined;
+    const challenge = pair.server.pollTransmitOnPath(&challenge_out, pair.now_us) orelse return error.TestExpectedEqual;
+    var challenge_bytes: [2048]u8 = undefined;
+    @memcpy(challenge_bytes[0..challenge.bytes.len], challenge.bytes);
+    try pair.client.ingestOnPath(challenge_bytes[0..challenge.bytes.len], TestPair.client_path, TestPair.test_challenge_entropy, pair.now_us);
+    var response_out: [2048]u8 = undefined;
+    const response = pair.client.pollTransmitOnPath(&response_out, pair.now_us) orelse return error.TestExpectedEqual;
+    var response_bytes: [2048]u8 = undefined;
+    @memcpy(response_bytes[0..response.bytes.len], response.bytes);
+    try pair.server.ingestOnPath(response_bytes[0..response.bytes.len], rebind_candidate, TestPair.test_challenge_entropy, pair.now_us);
+    try testing.expect(pair.server.activePathKey().eql(rebind_candidate));
+
+    // A reappears and must be re-validated, which restarts its discovery.
+    // `PathManager` hands the same tuple a new generation. A *fresh* datagram
+    // is required: an authenticated duplicate is deliberately inert and
+    // changes no path state.
+    var revisit_buf: [2048]u8 = undefined;
+    const revisit = try clientDatagram(pair, &revisit_buf);
+    try pair.server.ingestOnPath(revisit, old_ref.key, TestPair.test_challenge_entropy, pair.now_us);
+    const fresh_ref = pair.server.paths.pathRefFor(old_ref.key) orelse return error.TestExpectedEqual;
+    try testing.expect(fresh_ref.generation != old_ref.generation);
+    const fresh = pair.server.paths.plpmtuFor(fresh_ref) orelse return error.TestExpectedEqual;
+    try testing.expectEqual(base_datagram_size, fresh.sendSize());
+
+    // The *previous* incarnation's packet is now declared lost. Its tuple
+    // still matches, but the state that sent it is gone — resolving it against
+    // the fresh controller would teach a brand-new discovery about a path
+    // condition that no longer exists.
+    try testing.expectEqual(@as(?*quic_pmtu.Controller, null), pair.server.paths.plpmtuFor(old_ref));
+    try ensureSentRecordCapacity(pair.server, pair.server.sent_records.items.len + 1);
+    pair.server.sent_records.addOneAssumeCapacity().* = .{
+        .space = .application,
+        .packet_number = 7_777,
+        .ack_eliciting = true,
+        .sent_path = old_ref,
+        .sent_size = discovered,
+    };
+    _ = pair.server.requeueUntrackedRecords(.application, pair.now_us);
+
+    try testing.expectEqual(@as(u8, 0), fresh.oversized_losses);
+    try testing.expectEqual(@as(u32, 0), fresh.black_holes);
+    try testing.expectEqual(@as(?u64, null), fresh.outstanding_pn);
+    try testing.expectEqual(base_datagram_size, fresh.sendSize());
+    try testing.expectEqual(@as(u64, 0), pair.server.metrics.pmtu_black_holes);
+}
+
+/// Records every `pmtu_updated` event a connection emits.
+const PmtuEventRecorder = struct {
+    updates: [8]PmtuUpdatedEvent = undefined,
+    count: usize = 0,
+
+    fn sink(self: *PmtuEventRecorder) EventSink {
+        return .{ .context = self, .emitFn = emit };
+    }
+
+    fn emit(ctx: ?*anyopaque, event: Event) void {
+        const self: *PmtuEventRecorder = @ptrCast(@alignCast(ctx.?));
+        switch (event) {
+            .pmtu_updated => |update| {
+                if (self.count == self.updates.len) return;
+                self.updates[self.count] = update;
+                self.count += 1;
+            },
+            else => {},
+        }
+    }
+
+    fn blackHoles(self: *const PmtuEventRecorder) usize {
+        var seen: usize = 0;
+        for (self.updates[0..self.count]) |update| {
+            if (update.reason == .black_hole) seen += 1;
+        }
+        return seen;
+    }
+};
+
+test "driver: a fallback completed by a smaller ACK still publishes the transition" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try settleDiscovery(pair, max_datagram_size_ceiling);
+
+    const discovered = pair.server.effectiveMaxDatagramSize();
+    try testing.expect(discovered > base_datagram_size);
+
+    var recorder = PmtuEventRecorder{};
+    pair.server.events = recorder.sink();
+    const active = pair.server.paths.activePathRef();
+
+    // Full large-loss evidence, no corroborating delivery yet: nothing has
+    // fallen back, so nothing should have been published.
+    var i: u8 = 0;
+    while (i < quic_pmtu.black_hole_threshold) : (i += 1) {
+        pair.server.notePmtuEvidence(active, .{ .ordinary_loss = discovered }, pair.now_us);
+    }
+    try testing.expectEqual(@as(u64, 0), pair.server.metrics.pmtu_black_holes);
+    try testing.expectEqual(@as(usize, 0), recorder.blackHoles());
+
+    // The smaller delivery is the event that completes the signature. Because
+    // corroboration evaluates immediately, *this* call is the transition — and
+    // it must be as observable as one driven by loss or PTO.
+    pair.server.notePmtuEvidence(active, .{ .ordinary_ack = base_datagram_size }, pair.now_us);
+
+    try testing.expectEqual(base_datagram_size, pair.server.effectiveMaxDatagramSize());
+    try testing.expectEqual(@as(u64, 1), pair.server.metrics.pmtu_black_holes);
+    try testing.expectEqual(@as(usize, 1), recorder.blackHoles());
+    try testing.expectEqual(base_datagram_size, recorder.updates[recorder.count - 1].size);
+    // Recovery's windows are expressed in the sender's current datagram size,
+    // so the fallback reaches the controller now rather than at the next poll.
+    try testing.expectEqual(base_datagram_size, pair.server.recovery.congestion.max_datagram_size);
+}
+
+test "driver: a PTO driven by old-path packets is not charged to the new path" {
+    const allocator = testing.allocator;
+    var pair = try MigrationPair.init(allocator, .full);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const old_ref = pair.server.paths.activePathRef();
+    const discovered = pair.server.effectiveMaxDatagramSize();
+
+    // Leave an old-path packet outstanding: tracked, ack-eliciting, never
+    // acknowledged. `resetForPathMigration` keeps exactly this alive.
+    try pair.server.recovery.ensureRecoveryPacketCapacity(pair.server.allocator, 1);
+    pair.server.recovery.onPacketSentAssumeCapacity(.{
+        .space = .application,
+        .packet_number = 6_000,
+        .time_sent_us = pair.now_us,
+        .size = discovered,
+        .ack_eliciting = true,
+        .in_flight = true,
+    });
+    try ensureSentRecordCapacity(pair.server, pair.server.sent_records.items.len + 1);
+    pair.server.sent_records.addOneAssumeCapacity().* = .{
+        .space = .application,
+        .packet_number = 6_000,
+        .ack_eliciting = true,
+        .sent_path = old_ref,
+        .sent_size = discovered,
+    };
+
+    // Migrate A -> B.
+    var buf: [2048]u8 = undefined;
+    const datagram = try clientDatagram(pair, &buf);
+    try pair.server.ingestOnPath(datagram, rebind_candidate, TestPair.test_challenge_entropy, pair.now_us);
+    var challenge_out: [2048]u8 = undefined;
+    const challenge = pair.server.pollTransmitOnPath(&challenge_out, pair.now_us) orelse return error.TestExpectedEqual;
+    var challenge_bytes: [2048]u8 = undefined;
+    @memcpy(challenge_bytes[0..challenge.bytes.len], challenge.bytes);
+    try pair.client.ingestOnPath(challenge_bytes[0..challenge.bytes.len], TestPair.client_path, TestPair.test_challenge_entropy, pair.now_us);
+    var response_out: [2048]u8 = undefined;
+    const response = pair.client.pollTransmitOnPath(&response_out, pair.now_us) orelse return error.TestExpectedEqual;
+    var response_bytes: [2048]u8 = undefined;
+    @memcpy(response_bytes[0..response.bytes.len], response.bytes);
+    try pair.server.ingestOnPath(response_bytes[0..response.bytes.len], rebind_candidate, TestPair.test_challenge_entropy, pair.now_us);
+    try testing.expect(pair.server.activePathKey().eql(rebind_candidate));
+
+    const new_ref = pair.server.paths.activePathRef();
+    const new_controller = pair.server.paths.plpmtuFor(new_ref) orelse return error.TestExpectedEqual;
+    // Give the new path a discovered size, so a spurious stall would have
+    // something to pull it back *from*.
+    new_controller.reset();
+    new_controller.enable(max_datagram_size_ceiling, pair.now_us);
+    new_controller.onProbeSent(1452, 6_001);
+    try testing.expect(new_controller.onProbeAcked(6_001, pair.now_us));
+    try testing.expectEqual(@as(usize, 1452), new_controller.sendSize());
+
+    // The application PTO is connection-wide and keeps firing, driven entirely
+    // by the outstanding *old-path* packet. B has nothing outstanding of its
+    // own, so none of this is evidence about B.
+    try testing.expect(!pair.server.pathHasAckElicitingInFlight(.application, new_ref));
+    var round: usize = 0;
+    while (round < 4 * quic_pmtu.black_hole_threshold) : (round += 1) {
+        pair.server.firePto(.application, pair.now_us);
+    }
+
+    try testing.expectEqual(@as(u8, 0), new_controller.stalled_ptos);
+    try testing.expectEqual(@as(u32, 0), new_controller.black_holes);
+    try testing.expectEqual(@as(usize, 1452), new_controller.sendSize());
+    try testing.expectEqual(@as(u64, 0), pair.server.metrics.pmtu_black_holes);
+}
+
+test "driver: a PTO with the active path's own traffic outstanding is charged normally" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try settleDiscovery(pair, max_datagram_size_ceiling);
+    try testing.expect(pair.server.effectiveMaxDatagramSize() > base_datagram_size);
+
+    // Ordinary traffic on the active path, unacknowledged.
+    const sid = try openServerResponseStream(pair);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x77} ** (16 * 1024), false);
+    var out: [max_datagram_size_ceiling]u8 = undefined;
+    while (pair.server.pollTransmitOnPath(&out, pair.now_us)) |_| pair.now_us += 500;
+
+    const active = pair.server.paths.activePathRef();
+    try testing.expect(pair.server.pathHasAckElicitingInFlight(.application, active));
+
+    var round: usize = 0;
+    while (round < quic_pmtu.black_hole_threshold) : (round += 1) {
+        pair.server.firePto(.application, pair.now_us);
+    }
+    // The gate is about attribution, not about suppressing the signal.
+    try testing.expectEqual(@as(u64, 1), pair.server.metrics.pmtu_black_holes);
+    try testing.expectEqual(base_datagram_size, pair.server.effectiveMaxDatagramSize());
+}
+
 test "driver: a padded non-ack-eliciting packet counts as in flight" {
     // RFC 9002 §2 — the predicate the send path keys recovery accounting off.
     try testing.expect(recordIsInFlight(.{
         .space = .initial,
         .packet_number = 0,
         .ack_eliciting = false,
-        .sent_path = TestPair.client_path,
+        .sent_path = .{ .key = TestPair.client_path, .generation = 1 },
         .carried_padding = true,
     }));
     try testing.expect(recordIsInFlight(.{
         .space = .application,
         .packet_number = 0,
         .ack_eliciting = true,
-        .sent_path = TestPair.client_path,
+        .sent_path = .{ .key = TestPair.client_path, .generation = 1 },
     }));
     // A genuine pure ACK stays exempt.
     try testing.expect(!recordIsInFlight(.{
         .space = .application,
         .packet_number = 0,
         .ack_eliciting = false,
-        .sent_path = TestPair.client_path,
+        .sent_path = .{ .key = TestPair.client_path, .generation = 1 },
     }));
 }
 
@@ -9265,7 +9527,7 @@ fn fillOrdinaryTrackerWithRecords(conn: *Connection) !usize {
             .space = .initial,
             .packet_number = pn,
             .ack_eliciting = false,
-            .sent_path = conn.paths.activePath().key,
+            .sent_path = conn.paths.activePathRef(),
         };
     }
     return added;

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -35,6 +35,7 @@ const recovery = @import("recovery.zig");
 const quic_stream = @import("stream.zig");
 const quic_cid = @import("cid.zig");
 const quic_path = @import("path.zig");
+const quic_pmtu = @import("pmtu.zig");
 const quic_udp = @import("udp.zig");
 const test_quic_crypto = @import("test_quic_crypto");
 
@@ -149,6 +150,11 @@ pub const Event = union(enum) {
     /// A candidate path was promoted to active (RFC 9000 §9.3/§9.5): a NAT
     /// rebinding or a host migration, per `change`.
     path_promoted: PathTransitionEvent,
+    /// #256-B: DPLPMTUD changed the send size for a path — a probe validated
+    /// a larger one, or a black hole pulled it back to the RFC 9000 §14 floor.
+    /// `size` is the effective cap after the change, so it already reflects
+    /// the peer's advertised capacity and this endpoint's own ceiling.
+    pmtu_updated: PmtuUpdatedEvent,
     /// #523: a typed outcome for every `.zero_rtt` packet this connection
     /// processes, distinguishing "policy/keys unavailable" from a genuine
     /// AEAD authentication failure and from an authenticated duplicate —
@@ -195,6 +201,13 @@ pub const PathTransitionEvent = struct {
 pub const PathMigrationBlockedReason = enum {
     policy,
     no_peer_cid,
+};
+
+/// See `Event.pmtu_updated`.
+pub const PmtuUpdatedEvent = struct {
+    path: quic_path.PathKey,
+    size: usize,
+    reason: quic_pmtu.SizeChange,
 };
 
 pub const PathMigrationBlockedEvent = struct {
@@ -246,6 +259,11 @@ pub const Metrics = struct {
     packets_lost: u64 = 0,
     pto_count_total: u64 = 0,
     acks_sent: u64 = 0,
+    /// DPLPMTUD (#256-B): probes emitted, and how many times a path's send
+    /// size was pulled back to the RFC 9000 §14 floor because the size in use
+    /// stopped traversing it.
+    pmtu_probes_sent: u64 = 0,
+    pmtu_black_holes: u64 = 0,
 };
 
 pub const CloseInfo = struct {
@@ -737,6 +755,12 @@ const SentRecord = struct {
     /// to the congestion window.
     carried_padding: bool = false,
     carried_ack_largest: ?u64 = null,
+    /// Non-null when this record is a DPLPMTUD probe (#256-B), holding the
+    /// size it was validating. A probe carries no retransmittable content, so
+    /// this exists to route the ack/loss outcome to the path's controller —
+    /// and to keep the probe out of every path that reasons about *content*,
+    /// like the PTO's search for something worth resending.
+    carried_pmtu_probe: ?usize = null,
 
     const StreamRange = struct {
         id: StreamId,
@@ -1130,10 +1154,19 @@ pub const Connection = struct {
     /// same parameter is *its* receive capacity and bounds everything we send.
     pub fn datagramLimits(self: *const Connection) quic_datagram.Limits {
         return .{
-            // #256-B replaces this operator assertion with measured per-path
-            // DPLPMTUD state; it defaults to the RFC 9000 §14 floor.
-            .current_path_max = self.cfg.max_send_udp_payload_size,
-            .send_ceiling = quic_datagram.max_size,
+            // What DPLPMTUD has actually shown *this* path carries (#256-B),
+            // starting at the RFC 9000 §14 floor. Note "this path": promoting
+            // a different one swaps in that path's controller, so a migration
+            // cannot inherit a size only the old path was shown to carry.
+            .current_path_max = self.paths.activePath().plpmtu.sendSize(),
+            // `max_send_udp_payload_size` is a ceiling, not a starting point:
+            // it bounds what discovery may reach for rather than asserting a
+            // size outright, so raising it can only ever permit a size that
+            // was then measured (#256-B replacing #256-A's assertion).
+            .send_ceiling = @min(
+                @as(u64, quic_datagram.max_size),
+                self.cfg.max_send_udp_payload_size,
+            ),
             .peer_max = if (self.adapter.peerTransportParameters()) |peer|
                 peer.max_udp_payload_size
             else
@@ -1154,6 +1187,56 @@ pub const Connection = struct {
     /// model rather than something the next slice re-derives.
     pub fn probeMaxDatagramSize(self: *const Connection) usize {
         return self.datagramLimits().probeCeiling();
+    }
+
+    /// The active path's DPLPMTUD state, for status/benchmark reporting.
+    pub fn pathPlpmtu(self: *const Connection) quic_pmtu.Controller {
+        return self.paths.activePath().plpmtu;
+    }
+
+    /// Point the active path's DPLPMTUD controller at the current bounds, and
+    /// start discovery once the handshake is confirmed (#256-B).
+    ///
+    /// Deliberately not done at init: the probe ceiling collapses to the RFC
+    /// floor until the peer's `max_udp_payload_size` authenticates, so before
+    /// then there is nothing to reach for, and probing during the handshake
+    /// would compete with a flight that has its own sizing rules (RFC 9000
+    /// §14.1). Confirmation is also what proves the base size works — every
+    /// Initial-bearing datagram was padded to 1200 — which is the BASE-state
+    /// check RFC 8899 would otherwise owe before any search may start.
+    fn syncPathPmtu(self: *Connection) void {
+        // `probeCeiling()` already folds in both bounds a probe must respect:
+        // this endpoint's send ceiling (the operator's configured maximum) and
+        // the peer's advertised receive capacity.
+        const ceiling = self.probeMaxDatagramSize();
+        const controller = self.paths.activePlpmtu();
+        controller.configure(ceiling);
+        if (self.handshake_confirmed and self.state_ == .established) {
+            controller.enable(ceiling);
+        }
+    }
+
+    /// Feed one piece of black-hole evidence to the active path's controller
+    /// and report the fallback if that tipped it. Both signals funnel through
+    /// here so "the send size just dropped" is observed in exactly one place.
+    fn notePmtuBlackHoleEvidence(self: *Connection, kind: union(enum) { ordinary_loss: usize, stalled_pto }, now_us: u64) void {
+        const controller = self.paths.activePlpmtu();
+        const before = controller.black_holes;
+        switch (kind) {
+            .ordinary_loss => |size| controller.onOrdinaryLoss(size, now_us),
+            .stalled_pto => controller.onProbeTimeout(now_us),
+        }
+        if (controller.black_holes == before) return;
+        self.metrics.pmtu_black_holes += 1;
+        // Recovery's NewReno windows are expressed in the sender's current
+        // datagram size (RFC 9002 §B.2), so a fallback has to reach it now
+        // rather than at the next poll.
+        self.recovery.congestion.setMaxDatagramSize(self.effectiveMaxDatagramSize());
+        self.events.emit(.{ .pmtu_updated = .{
+            .path = self.paths.activePath().key,
+            .size = self.effectiveMaxDatagramSize(),
+            .reason = .black_hole,
+        } });
     }
 
     pub fn closeInfo(self: *const Connection) ?CloseInfo {
@@ -1791,6 +1874,13 @@ pub const Connection = struct {
                 if (record.packet_number == ack.largest_acknowledged) {
                     if (acked.rtt_sample_us) |sample| self.recovery.rtt.update(sample, ack_delay_us);
                 }
+                // Delivery of an ordinary datagram is DPLPMTUD's evidence that
+                // the path still carries the size it was sent at (#256-B).
+                // Probes are excluded: `onRecordAcked` resolves those against
+                // the outstanding probe instead.
+                if (!acked.packet.pmtu_probe) {
+                    self.paths.activePlpmtu().onOrdinaryAck(acked.packet.size);
+                }
             }
             self.onRecordAcked(record);
             // Delivery is confirmed: any reset token this record carried
@@ -1811,6 +1901,20 @@ pub const Connection = struct {
     }
 
     fn onRecordAcked(self: *Connection, record: *const SentRecord) void {
+        if (record.carried_pmtu_probe != null) {
+            // The probed size traversed the path, so it becomes the path's
+            // send size. Matching on the packet number means a stale ACK for
+            // an earlier probe cannot promote a size the current search has
+            // already ruled out.
+            if (self.paths.activePlpmtu().onProbeAcked(record.packet_number)) {
+                self.events.emit(.{ .pmtu_updated = .{
+                    .path = self.paths.activePath().key,
+                    .size = self.effectiveMaxDatagramSize(),
+                    .reason = .raised,
+                } });
+            }
+            return;
+        }
         if (record.carried_handshake_done) self.handshake_done_acked = true;
         if (record.crypto) |range| {
             if (record.space == .application) self.crypto_tx[2].markAcked(self.allocator, range);
@@ -1828,6 +1932,14 @@ pub const Connection = struct {
     fn detectAndRequeueLost(self: *Connection, space: PacketNumberSpace, now_us: u64) void {
         const loss = self.recovery.detectLost(space, now_us);
         if (loss.packet_threshold_losses + loss.time_threshold_losses == 0) return;
+        // #256-B: a lost *ordinary* datagram larger than the guaranteed floor
+        // is the one loss that a smaller send size could have prevented, so it
+        // is the only kind DPLPMTUD treats as evidence. Probe losses are
+        // excluded here and routed to the controller by `requeueUntrackedRecords`
+        // below — a probe is meant to be too big.
+        if (loss.largest_ordinary_lost_size > 0) {
+            self.notePmtuBlackHoleEvidence(.{ .ordinary_loss = loss.largest_ordinary_lost_size }, now_us);
+        }
         const lost_count = self.requeueUntrackedRecords(space);
         if (lost_count > 0) {
             self.metrics.packets_lost += lost_count;
@@ -1849,6 +1961,15 @@ pub const Connection = struct {
                 continue;
             }
             count += 1;
+            if (record.carried_pmtu_probe != null) {
+                // Nothing to requeue: a probe carries no user data, and the
+                // search decides for itself whether to retry this size.
+                self.paths.activePlpmtu().onProbeLost(record.packet_number);
+                wipeSentRecordToken(record);
+                _ = self.sent_records.swapRemove(index);
+                wipeSentRecordsSwapRemoveResidue(&self.sent_records);
+                continue;
+            }
             // Read the live element to requeue its content (a fresh copy of
             // any carried reset token lands in `pending_new_connection_ids`
             // via `requeueRecord`) before wiping this now-redundant copy and
@@ -2507,7 +2628,29 @@ pub const Connection = struct {
         // Fold in any outstanding path-validation deadline so `onTimeout`
         // expires it promptly rather than only on the next unrelated timer.
         if (self.paths.nextValidationDeadlineUs()) |validation| deadline = minOpt(deadline, validation);
+        // #256-B: the DPLPMTUD raise timer, armed only after a black-hole
+        // fallback. `Controller.onTimeout` disarms it when it fires, so this
+        // cannot return a deadline already in the past and spin the caller.
+        if (self.paths.activePath().plpmtu.deadlineUs()) |raise| deadline = minOpt(deadline, raise);
         return deadline;
+    }
+
+    /// The peer's largest acknowledged packet number in a space, as the
+    /// reference `packet.packetNumberLength` encodes against — or null when
+    /// there isn't a usable one.
+    ///
+    /// That function requires the reference to be *below* the packet number
+    /// being sent, and asserts it. `processAck` adopts `largest_acknowledged`
+    /// from the peer without checking it against anything this endpoint has
+    /// actually sent, so a peer acknowledging a packet number we never sent
+    /// (a protocol violation, RFC 9000 §13.1) leaves the two equal and trips
+    /// that assertion — a remote panic in a safety-checked build. Encoding
+    /// against no reference is always decodable, just wider, so declining the
+    /// reference is the safe answer rather than trusting or asserting on it.
+    fn packetNumberReference(self: *const Connection, space_idx: usize, pn: u64) ?u64 {
+        const acked = self.largest_peer_acked[space_idx] orelse return null;
+        if (acked >= pn) return null;
+        return acked;
     }
 
     fn spaceHasAckElicitingInFlight(self: *const Connection, space: PacketNumberSpace) bool {
@@ -2539,6 +2682,9 @@ pub const Connection = struct {
         for (self.paths.expireValidationsInto(now_us, &failed_validations)) |failed| {
             self.events.emit(.{ .path_validation_failed = .{ .path = failed.path, .change = failed.change } });
         }
+        // Let a black-hole fallback that has held long enough re-open the
+        // search (#256-B, RFC 8899 PMTU_RAISE_TIMER).
+        self.paths.activePlpmtu().onTimeout(now_us);
         // Time-threshold loss detection.
         for ([_]PacketNumberSpace{ .initial, .handshake, .application }) |space| {
             self.detectAndRequeueLost(space, now_us);
@@ -2554,7 +2700,7 @@ pub const Connection = struct {
             any_in_flight = true;
             if (space == .application and !self.handshake_confirmed) continue;
             if (now_us >= last + self.recovery.rtt.ptoDuration(space) * backoff) {
-                self.firePto(space);
+                self.firePto(space, now_us);
                 fired = true;
             }
         }
@@ -2562,9 +2708,9 @@ pub const Connection = struct {
             if (now_us >= self.last_activity_us + self.recovery.rtt.ptoDuration(.handshake) * backoff) {
                 // Anti-deadlock probe: resend the lowest-level flight we can.
                 if (self.adapter.hasProtectionKeys(.handshake, .write) catch unreachable) {
-                    self.firePto(.handshake);
+                    self.firePto(.handshake, now_us);
                 } else {
-                    self.firePto(.initial);
+                    self.firePto(.initial, now_us);
                 }
                 // Keep the anti-deadlock timer moving.
                 self.last_activity_us = now_us;
@@ -2572,17 +2718,29 @@ pub const Connection = struct {
         }
     }
 
-    fn firePto(self: *Connection, space: PacketNumberSpace) void {
+    fn firePto(self: *Connection, space: PacketNumberSpace, now_us: u64) void {
         self.pto_count += 1;
         self.metrics.pto_count_total += 1;
         const idx = spaceIndex(space);
         self.probes_pending[idx] = 2;
         self.events.emit(.{ .pto_fired = .{ .space = space, .count = self.pto_count } });
+        // #256-B: consecutive expirations while sending above the guaranteed
+        // floor, with nothing acknowledged in between, is the black-hole shape
+        // that loss-based detection cannot see — when every datagram in flight
+        // is oversized there is no smaller delivery to compare against. Only
+        // the application space counts, so one timer expiry that fires a PTO
+        // in two spaces is still one piece of evidence; discovery only runs
+        // after confirmation anyway, when the earlier spaces are gone.
+        if (space == .application) self.notePmtuBlackHoleEvidence(.stalled_pto, now_us);
         // Requeue the oldest unacked retransmittable content of the space so
         // the probe carries data rather than a bare PING when possible.
         var oldest: ?usize = null;
         for (self.sent_records.items, 0..) |record, i| {
             if (record.space != space or !record.ack_eliciting) continue;
+            // A DPLPMTUD probe holds no retransmittable content, so it is
+            // never the right thing to requeue — and requeuing one would put
+            // it through the loss path without it having been lost.
+            if (record.carried_pmtu_probe != null) continue;
             if (oldest == null or record.packet_number < self.sent_records.items[oldest.?].packet_number) {
                 oldest = i;
             }
@@ -2794,6 +2952,10 @@ pub const Connection = struct {
         // builder actually emits (#256-A). Refreshed here, before any gate
         // reads it, rather than cached at init: the effective size changes the
         // moment the peer's transport parameters authenticate.
+        // Refresh DPLPMTUD's bounds first: it is what `effectiveMaxDatagramSize`
+        // reads for the current path size, so recovery below sees the same
+        // value the builder is about to use.
+        self.syncPathPmtu();
         self.recovery.congestion.setMaxDatagramSize(self.effectiveMaxDatagramSize());
 
         if (self.state_ == .closing) {
@@ -2817,6 +2979,10 @@ pub const Connection = struct {
         }
 
         if (self.pollCandidateTransmit(out, now_us)) |t| return t;
+        // A DPLPMTUD probe is its own datagram (#256-B) and at most one is
+        // outstanding per path at a time, so trying it here starves nothing:
+        // ordinary content goes out on the very next poll.
+        if (self.buildPmtuProbe(out, now_us)) |t| return t;
 
         // Force the delayed app-space ACK when its timer expired.
         if (self.ack_needed[2] and now_us >= self.ack_armed_at_us[2] + local_max_ack_delay_us) {
@@ -2933,7 +3099,7 @@ pub const Connection = struct {
 
         const space_idx = spaceIndex(.application);
         const pn = self.next_pn[space_idx];
-        const pn_len: u3 = packet.packetNumberLength(pn, self.largest_peer_acked[space_idx]);
+        const pn_len: u3 = packet.packetNumberLength(pn, self.packetNumberReference(space_idx, pn));
         const pn_offset = packet.writeShortHeader(self.peer_cid.slice(), self.adapter.applicationWriteKeyPhase(), pn_len, out) catch return null;
 
         const max_packet: usize = @intCast(@min(@as(u64, budget), remaining));
@@ -3033,6 +3199,107 @@ pub const Connection = struct {
         return .{ .bytes = out[0..total], .path = path };
     }
 
+    /// Assemble one DPLPMTUD probe (#256-B, RFC 8899 §4.1): a standalone
+    /// datagram of *exactly* the probed size, carrying a PING and PADDING and
+    /// nothing else. Returns null when no probe is due or a send gate says no.
+    ///
+    /// Carrying no application data is the point. A probe is deliberately
+    /// larger than the path is known to carry, so it is expected to be
+    /// dropped; anything riding on it would have to be retransmitted, and
+    /// RFC 8899 §3 warns against coupling discovery to user data for exactly
+    /// that reason. PING makes it ack-eliciting, so QUIC's own loss detection
+    /// resolves it — the PROBE_TIMER RFC 8899 specifies for protocols without
+    /// acknowledgements is not needed here.
+    ///
+    /// Never coalesced: a probe's whole meaning is its size on the wire, so it
+    /// cannot share a datagram with content that would be lost along with it.
+    fn buildPmtuProbe(self: *Connection, out: []u8, now_us: u64) ?Transmit {
+        if (self.state_ != .established or !self.handshake_confirmed) return null;
+        const controller = self.paths.activePlpmtu();
+        const probe_size = controller.nextProbeSize() orelse return null;
+        if (probe_size > out.len) return null;
+
+        var keys = (self.adapter.protectionKeys(.application, .write) catch unreachable) orelse return null;
+        defer keys.deinit();
+
+        // Congestion control and anti-amplification are hard gates, not
+        // advisory (RFC 9000 §14.4 requires a probe to be congestion
+        // controlled). A probe is *not* an RFC 9002 PTO probe and gets none of
+        // its exemptions: the whole datagram must fit the remaining window, or
+        // it waits. Discovery is never urgent enough to overshoot.
+        if (!self.recovery.canTrackPacket()) return null;
+        ensureSentRecordCapacity(self, self.sent_records.items.len + 1) catch return null;
+        const cwnd_room = self.recovery.congestion.congestion_window -| self.recovery.congestion.bytes_in_flight;
+        if (probe_size > cwnd_room) return null;
+        const active_key = self.paths.activePath().key;
+        if (!self.paths.canSendOnPath(active_key, probe_size)) return null;
+
+        const space_idx = spaceIndex(.application);
+        const pn = self.next_pn[space_idx];
+        const pn_len: u3 = packet.packetNumberLength(pn, self.packetNumberReference(space_idx, pn));
+        const pn_offset = packet.writeShortHeader(self.peer_cid.slice(), self.adapter.applicationWriteKeyPhase(), pn_len, out) catch return null;
+
+        const packet_overhead = pn_offset + pn_len + aead_tag_len;
+        if (packet_overhead >= probe_size) return null;
+        var plain: [max_datagram_size_ceiling]u8 = undefined;
+        const plain_len = probe_size - packet_overhead;
+        if (plain_len > plain.len) return null;
+        // The probed size is at least `base_datagram_size`, so the plaintext
+        // is comfortably longer than header protection's sampling minimum.
+        const ping_len = frame.encodePing(plain[0..plain_len]) catch return null;
+        @memset(plain[ping_len..plain_len], 0);
+
+        const truncated = packet.truncatePacketNumber(pn, pn_len);
+        var pn_bytes: [4]u8 = undefined;
+        std.mem.writeInt(u32, &pn_bytes, truncated, .big);
+        @memcpy(out[pn_offset..][0..pn_len], pn_bytes[4 - @as(usize, pn_len) ..][0..pn_len]);
+
+        const header = out[0 .. pn_offset + pn_len];
+        const sealed = self.adapter.sealPacketPayload(.application, .write, pn, header, plain[0..plain_len], out[pn_offset + pn_len ..]) catch return null;
+
+        var sample: [sample_len]u8 = undefined;
+        @memcpy(&sample, out[pn_offset + 4 ..][0..sample_len]);
+        keys.applyHeaderProtectionWithProvider(self.adapter.provider, &out[0], out[pn_offset..][0..pn_len], sample) catch unreachable;
+
+        const total = pn_offset + pn_len + sealed.len;
+        // The padding was computed to land on exactly the probed size; a
+        // datagram of any other size would validate the wrong thing.
+        std.debug.assert(total == probe_size);
+        self.next_pn[space_idx] = pn + 1;
+
+        controller.onProbeSent(probe_size, pn);
+        var record = SentRecord{
+            .space = .application,
+            .packet_number = pn,
+            .ack_eliciting = true,
+            .carried_pmtu_probe = probe_size,
+        };
+        self.recovery.onPacketSentAssumeCapacity(.{
+            .space = .application,
+            .packet_number = pn,
+            .time_sent_us = now_us,
+            .size = total,
+            .ack_eliciting = true,
+            .in_flight = true,
+            .pmtu_probe = true,
+        });
+        self.last_ack_eliciting_sent_us[space_idx] = now_us;
+        publishSentRecord(self, &record);
+
+        self.paths.recordSentOnPath(active_key, total);
+        self.metrics.packets_sent += 1;
+        self.metrics.datagrams_sent += 1;
+        self.metrics.pmtu_probes_sent += 1;
+        self.armIdle(now_us);
+        self.events.emit(.{ .packet_sent = .{
+            .space = .application,
+            .packet_number = pn,
+            .size = total,
+            .ack_eliciting = true,
+        } });
+        return .{ .bytes = out[0..total], .path = active_key };
+    }
+
     const BuildContext = struct {
         datagram_has_initial: bool,
         datagram_so_far: usize,
@@ -3124,7 +3391,7 @@ pub const Connection = struct {
 
         // Header sizing.
         const pn = self.next_pn[space_idx];
-        const pn_len: u3 = packet.packetNumberLength(pn, self.largest_peer_acked[space_idx]);
+        const pn_len: u3 = packet.packetNumberLength(pn, self.packetNumberReference(space_idx, pn));
         var header_written: packet.WrittenLongHeader = undefined;
         var pn_offset: usize = 0;
         switch (level) {
@@ -3604,7 +3871,7 @@ pub const Connection = struct {
         const space = spaceForLevel(level);
         const space_idx = spaceIndex(space);
         const pn = self.next_pn[space_idx];
-        const pn_len: u3 = packet.packetNumberLength(pn, self.largest_peer_acked[space_idx]);
+        const pn_len: u3 = packet.packetNumberLength(pn, self.packetNumberReference(space_idx, pn));
 
         var pn_offset: usize = 0;
         var header_written: packet.WrittenLongHeader = undefined;
@@ -7489,8 +7756,8 @@ test "connection: RETIRE_CONNECTION_ID cancels a queued and an in-flight copy of
     // processing's own primitive) resurrects the retired sequence: both
     // consult the same `has_new_connection_id` flag on this record, and it
     // is now false.
-    pair.server.firePto(.application);
-    pair.server.firePto(.application);
+    pair.server.firePto(.application, pair.now_us);
+    pair.server.firePto(.application, pair.now_us);
     pair.server.requeueRecord(&pair.server.sent_records.items[sent_index]);
     try testing.expectEqual(@as(usize, 0), pair.server.pending_new_connection_ids.items.len);
     for (pair.server.pending_new_connection_ids.items) |queued| {
@@ -7911,6 +8178,55 @@ fn drainTransmits(conn: *Connection, now_us: *u64) EmittedDatagrams {
     return seen;
 }
 
+/// Run DPLPMTUD to a resolved state on both sides across a path that silently
+/// drops any datagram larger than `path_mtu` — the network behaviour #256-B
+/// exists to discover. Pass `max_datagram_size_ceiling` for a path that
+/// carries anything.
+///
+/// `pump` alone is not enough for this. A probe is a single ack-eliciting
+/// datagram, so when it is dropped nothing declares it lost until the PTO
+/// fires, and when it arrives its acknowledgement can sit behind the
+/// delayed-ACK timer with neither side having other traffic to piggyback on.
+/// Stepping time between quiet rounds drives both, making the outcome a
+/// function of the path rather than of how much unrelated traffic happened to
+/// be in flight.
+fn settleDiscovery(pair: *TestPair, path_mtu: usize) !void {
+    var rounds: usize = 0;
+    while (rounds < 128) : (rounds += 1) {
+        var progressed = false;
+        var buf: [max_datagram_size_ceiling]u8 = undefined;
+        while (pair.client.pollTransmitOnPath(&buf, pair.now_us)) |t| {
+            progressed = true;
+            pair.now_us += 500;
+            if (t.bytes.len > path_mtu) continue;
+            const ingress = quic_path.PathKey{ .local = t.path.remote, .remote = t.path.local };
+            try pair.server.ingestOnPath(t.bytes, ingress, TestPair.test_challenge_entropy, pair.now_us);
+        }
+        while (pair.server.pollTransmitOnPath(&buf, pair.now_us)) |t| {
+            progressed = true;
+            pair.now_us += 500;
+            if (t.bytes.len > path_mtu) continue;
+            const ingress = quic_path.PathKey{ .local = t.path.remote, .remote = t.path.local };
+            try pair.client.ingestOnPath(t.bytes, ingress, TestPair.test_challenge_entropy, pair.now_us);
+        }
+        if (progressed) continue;
+
+        const client = pair.client.pathPlpmtu();
+        const server = pair.server.pathPlpmtu();
+        if (client.state != .searching and server.state != .searching and
+            client.outstanding_pn == null and server.outstanding_pn == null)
+        {
+            return;
+        }
+        // Quiet: advance past the delayed-ACK and PTO timers so an
+        // outstanding probe is either acknowledged or declared lost.
+        pair.now_us += 100_000;
+        pair.client.onTimeout(pair.now_us);
+        pair.server.onTimeout(pair.now_us);
+    }
+    return error.DiscoveryStalled;
+}
+
 /// A client-opened bidi stream, established and known to both sides, ready
 /// for the server to write a response the size of which the test controls.
 fn openServerResponseStream(pair: *TestPair) !StreamId {
@@ -7983,13 +8299,16 @@ test "driver: the cap stays at the floor until the peer's transport parameters a
     const initial = pair.client.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
     try testing.expectEqual(min_initial_datagram, initial.bytes.len);
 
-    // Hand that same Initial on so the handshake still completes, then the
-    // authenticated peer parameters let the configured maximum take effect.
+    // Hand that same Initial on so the handshake still completes. The
+    // authenticated peer parameters then open the *ceiling* to the configured
+    // maximum — under #256-B that is permission for discovery to probe, not a
+    // size taken on trust, so nothing may exceed it either way.
     const ingress = quic_path.PathKey{ .local = initial.path.remote, .remote = initial.path.local };
     try pair.server.ingestOnPath(initial.bytes, ingress, TestPair.test_challenge_entropy, pair.now_us);
     pair.now_us += 500;
     try pair.pump();
-    try testing.expectEqual(max_datagram_size_ceiling, pair.client.effectiveMaxDatagramSize());
+    try testing.expectEqual(max_datagram_size_ceiling, pair.client.probeMaxDatagramSize());
+    try testing.expect(pair.client.effectiveMaxDatagramSize() <= max_datagram_size_ceiling);
 }
 
 test "driver: a raised local maximum does not widen the anti-amplification budget" {
@@ -8107,6 +8426,10 @@ test "driver: the advertised receive capacity is separate from the send size" {
     // actually deprotect: receive capability is not path state.
     var pair = try TestPair.init(allocator);
     defer pair.deinit(allocator);
+    // Ordinary sends start at the RFC 9000 §14 floor: receive capacity is not
+    // path state and never seeds the send size.
+    try testing.expectEqual(base_datagram_size, pair.server.effectiveMaxDatagramSize());
+    try testing.expectEqual(base_datagram_size, pair.client.effectiveMaxDatagramSize());
     try pair.pump();
 
     try testing.expectEqual(
@@ -8117,24 +8440,281 @@ test "driver: the advertised receive capacity is separate from the send size" {
         @as(u64, max_receive_datagram_size),
         pair.client.peerTransportParameters().?.max_udp_payload_size,
     );
-    // ... while ordinary sends stay at the RFC 9000 §14 floor by default.
-    try testing.expectEqual(base_datagram_size, pair.server.effectiveMaxDatagramSize());
-    try testing.expectEqual(base_datagram_size, pair.client.effectiveMaxDatagramSize());
+    // Whatever discovery does to the send size afterwards, the advertised
+    // receive capacity is fixed by this endpoint's buffers and does not move
+    // with it.
+    try testing.expectEqual(
+        @as(u64, max_receive_datagram_size),
+        pair.server.local_params.max_udp_payload_size,
+    );
 }
 
-test "driver: the default probe ceiling leaves headroom above the send size" {
+test "driver: the default deployment discovers a larger size rather than assuming one" {
     const allocator = testing.allocator;
     var pair = try TestPair.init(allocator);
     defer pair.deinit(allocator);
 
-    // Before authentication nothing may exceed the floor, in either role.
+    // Before authentication nothing may exceed the floor, in either role: the
+    // ceiling collapses until the peer says what it can receive.
     try testing.expectEqual(base_datagram_size, pair.client.probeMaxDatagramSize());
+    try testing.expectEqual(base_datagram_size, pair.client.effectiveMaxDatagramSize());
 
-    try pair.pump();
-    // Afterwards #256-B has somewhere to probe *to* without the operator
-    // having to pre-configure a larger value.
+    try settleDiscovery(pair, max_datagram_size_ceiling);
+    // Afterwards #256-B has somewhere to probe to without the operator
+    // pre-configuring anything ...
     try testing.expectEqual(max_datagram_size_ceiling, pair.server.probeMaxDatagramSize());
-    try testing.expect(pair.server.probeMaxDatagramSize() > pair.server.effectiveMaxDatagramSize());
+    // ... and on a path that carries it, the send size actually moved — the
+    // difference from #256-A being that a probe was acknowledged first.
+    try testing.expect(pair.server.effectiveMaxDatagramSize() > base_datagram_size);
+    try testing.expect(pair.server.metrics.pmtu_probes_sent > 0);
+    try testing.expectEqual(@as(u64, 0), pair.server.metrics.pmtu_black_holes);
+}
+
+// ---------------------------------------------------------------------------
+// #256-B: DPLPMTUD driven from the real send path.
+// ---------------------------------------------------------------------------
+
+test "driver: a path that only carries the floor is discovered as such" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+
+    // Every probe this endpoint sends is larger than the path carries, so
+    // every one is dropped — while ordinary 1200-byte traffic flows normally.
+    try settleDiscovery(pair, base_datagram_size);
+
+    const controller = pair.server.pathPlpmtu();
+    try testing.expectEqual(quic_pmtu.State.search_complete, controller.state);
+    // The send size never left the one size RFC 9000 §14 guarantees, so
+    // failing to discover anything costs correctness nothing.
+    try testing.expectEqual(base_datagram_size, pair.server.effectiveMaxDatagramSize());
+    try testing.expect(controller.probes_lost > 0);
+    try testing.expect(controller.smallest_failed <= pair.server.probeMaxDatagramSize());
+    // RFC 9000 §14.4: an oversized datagram dropped by a path too small for it
+    // is not congestion, so none of those losses cut the window.
+    try testing.expectEqual(@as(?u64, null), pair.server.recovery.congestion.recovery_start_time_us);
+    // Nor is it a black hole: the path never carried a larger size, so there
+    // is nothing to fall back *from*.
+    try testing.expectEqual(@as(u64, 0), pair.server.metrics.pmtu_black_holes);
+
+    // Ordinary traffic is unaffected by the failed search.
+    const sid = try openServerResponseStream(pair);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x11} ** (16 * 1024), false);
+    const seen = drainTransmits(pair.server, &pair.now_us);
+    try testing.expect(seen.count > 1);
+    try testing.expect(seen.largest <= base_datagram_size);
+}
+
+test "driver: a path larger than the floor is discovered, and only up to what it carries" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+
+    const path_mtu: usize = 1452;
+    try settleDiscovery(pair, path_mtu);
+
+    // The search converged inside the path's real capacity, within the
+    // deliberate `min_step` slack that stops it chasing the last few bytes.
+    const discovered = pair.server.effectiveMaxDatagramSize();
+    try testing.expect(discovered <= path_mtu);
+    try testing.expect(discovered > path_mtu - quic_pmtu.min_step);
+    try testing.expectEqual(quic_pmtu.State.search_complete, pair.server.pathPlpmtu().state);
+    try testing.expect(pair.server.metrics.pmtu_probes_sent > 1);
+    try testing.expectEqual(@as(u64, 0), pair.server.metrics.pmtu_black_holes);
+
+    // And the discovered size is what actually goes on the wire.
+    const sid = try openServerResponseStream(pair);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x22} ** (16 * 1024), false);
+    const seen = drainTransmits(pair.server, &pair.now_us);
+    try testing.expect(seen.count > 1);
+    try testing.expect(seen.largest > base_datagram_size);
+    try testing.expect(seen.largest <= discovered);
+}
+
+test "driver: a probe is its own datagram, exactly the size it validates" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    // Start a fresh search on the established connection so the very next
+    // datagram is the probe rather than whatever the handshake left queued.
+    const probes_before = pair.server.metrics.pmtu_probes_sent;
+    pair.server.paths.activePlpmtu().reset();
+    pair.server.syncPathPmtu();
+    const expected = pair.server.probeMaxDatagramSize();
+
+    var out: [max_datagram_size_ceiling]u8 = undefined;
+    const probe = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
+    // RFC 8899 §5.3 optimistic search reaches straight for the ceiling, and the
+    // datagram on the wire is exactly that size: one arriving at any other size
+    // would validate something else.
+    try testing.expectEqual(expected, probe.bytes.len);
+    try testing.expectEqual(expected, pair.server.pathPlpmtu().target_size);
+    try testing.expectEqual(probes_before + 1, pair.server.metrics.pmtu_probes_sent);
+    // It carries no user data, so losing it costs no application progress and
+    // the send size has not moved on the strength of merely sending it.
+    try testing.expectEqual(base_datagram_size, pair.server.effectiveMaxDatagramSize());
+}
+
+test "driver: a path that stops carrying the discovered size falls back to the floor" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try settleDiscovery(pair, max_datagram_size_ceiling);
+    const discovered = pair.server.effectiveMaxDatagramSize();
+    try testing.expect(discovered > base_datagram_size);
+
+    // The path stops passing the discovered size. Everything in flight is
+    // already oversized, so nothing comes back at all — consecutive PTOs with
+    // no progress, which is the black-hole signature loss-comparison cannot
+    // see.
+    const sid = try openServerResponseStream(pair);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x33} ** (32 * 1024), false);
+    var out: [max_datagram_size_ceiling]u8 = undefined;
+    while (pair.server.pollTransmitOnPath(&out, pair.now_us)) |_| pair.now_us += 500;
+
+    var rounds: usize = 0;
+    while (rounds < 16 and pair.server.metrics.pmtu_black_holes == 0) : (rounds += 1) {
+        pair.now_us += 1_000_000;
+        pair.server.onTimeout(pair.now_us);
+        while (pair.server.pollTransmitOnPath(&out, pair.now_us)) |_| pair.now_us += 500;
+    }
+
+    try testing.expectEqual(@as(u64, 1), pair.server.metrics.pmtu_black_holes);
+    // Back to the size RFC 9000 §14 guarantees every path carries, so the
+    // retransmissions that follow are no longer the same oversized datagram.
+    try testing.expectEqual(base_datagram_size, pair.server.effectiveMaxDatagramSize());
+    try testing.expectEqual(discovered, pair.server.pathPlpmtu().smallest_failed);
+    // The search does not immediately climb back into the size that broke: it
+    // waits out the RFC 8899 raise timer, which the connection's timer wheel
+    // now carries.
+    try testing.expectEqual(@as(?usize, null), pair.server.pathPlpmtu().nextProbeSize());
+    const raise = pair.server.pathPlpmtu().deadlineUs() orelse return error.TestExpectedEqual;
+    try testing.expect(pair.server.nextTimeoutUs().? <= raise);
+    // Recovery's NewReno windows follow the sender's current datagram size, so
+    // the fallback reached the controller rather than waiting for a poll.
+    try testing.expectEqual(base_datagram_size, pair.server.recovery.congestion.max_datagram_size);
+}
+
+test "driver: the peer's advertised capacity bounds what discovery may find" {
+    const allocator = testing.allocator;
+    // The client can only receive 1300 bytes, so no probe may reach for more,
+    // however high this endpoint's own ceiling is.
+    var pair = try TestPair.initWithConfigs(
+        allocator,
+        .{ .max_udp_payload_size = 1300 },
+        .{ .max_send_udp_payload_size = max_datagram_size_ceiling },
+    );
+    defer pair.deinit(allocator);
+    try settleDiscovery(pair, max_datagram_size_ceiling);
+
+    try testing.expectEqual(@as(usize, 1300), pair.server.probeMaxDatagramSize());
+    try testing.expectEqual(@as(usize, 1300), pair.server.effectiveMaxDatagramSize());
+    const sid = try openServerResponseStream(pair);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x44} ** (16 * 1024), false);
+    const seen = drainTransmits(pair.server, &pair.now_us);
+    try testing.expect(seen.count > 1);
+    try testing.expect(seen.largest <= 1300);
+}
+
+test "driver: a configured ceiling bounds discovery and is never exceeded" {
+    const allocator = testing.allocator;
+    const capped = config.Config{ .max_send_udp_payload_size = 1452 };
+    var pair = try TestPair.initWithConfigs(allocator, capped, capped);
+    defer pair.deinit(allocator);
+    try settleDiscovery(pair, max_datagram_size_ceiling);
+
+    // The operator's maximum stays a maximum: discovery lands exactly on it
+    // when the path carries it (the optimistic first probe), never above.
+    try testing.expectEqual(@as(usize, 1452), pair.server.effectiveMaxDatagramSize());
+
+    const sid = try openServerResponseStream(pair);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x55} ** (16 * 1024), false);
+    const seen = drainTransmits(pair.server, &pair.now_us);
+    try testing.expect(seen.count > 1);
+    try testing.expect(seen.largest > base_datagram_size);
+    try testing.expect(seen.largest <= 1452);
+}
+
+test "driver: a probe waits for congestion window rather than taking an exemption" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    // Put real bytes in flight first: the congestion window has a floor of two
+    // datagrams (RFC 9002 §7.2), so "not enough room for a probe" is only
+    // expressible with something already occupying the window.
+    const sid = try openServerResponseStream(pair);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x66} ** (16 * 1024), false);
+    var out: [max_datagram_size_ceiling]u8 = undefined;
+    var drained: usize = 0;
+    while (drained < 4) : (drained += 1) {
+        _ = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse break;
+        pair.now_us += 500;
+    }
+    const congestion = &pair.server.recovery.congestion;
+    try testing.expect(congestion.bytes_in_flight > 2 * base_datagram_size);
+
+    // A fresh search, then a window with room for ordinary traffic but not for
+    // a probe. A DPLPMTUD probe is not an RFC 9002 PTO probe and gets none of
+    // its exemptions: the whole datagram must fit (RFC 9000 §14.4 requires
+    // probes to be congestion controlled).
+    const probes_before = pair.server.metrics.pmtu_probes_sent;
+    pair.server.paths.activePlpmtu().reset();
+    pair.server.syncPathPmtu();
+    congestion.congestion_window = congestion.bytes_in_flight + base_datagram_size;
+    while (pair.server.pollTransmitOnPath(&out, pair.now_us)) |t| {
+        try testing.expect(t.bytes.len <= base_datagram_size);
+        pair.now_us += 500;
+    }
+    try testing.expectEqual(@as(?u64, null), pair.server.pathPlpmtu().outstanding_pn);
+    try testing.expectEqual(probes_before, pair.server.metrics.pmtu_probes_sent);
+
+    // With room, the same poll produces it.
+    congestion.congestion_window = congestion.bytes_in_flight + 4 * max_datagram_size_ceiling;
+    const probe = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse return error.TestExpectedEqual;
+    try testing.expectEqual(pair.server.probeMaxDatagramSize(), probe.bytes.len);
+    try testing.expectEqual(probes_before + 1, pair.server.metrics.pmtu_probes_sent);
+    try testing.expect(congestion.bytes_in_flight <= congestion.congestion_window);
+}
+
+test "driver: a migrated path revalidates its own MTU instead of inheriting one" {
+    const allocator = testing.allocator;
+    var pair = try MigrationPair.init(allocator, .full);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    // The handshake path discovered a size larger than the floor.
+    try testing.expect(pair.server.effectiveMaxDatagramSize() > base_datagram_size);
+
+    var buf: [2048]u8 = undefined;
+    const datagram = try clientDatagram(pair, &buf);
+    try pair.server.ingestOnPath(datagram, rebind_candidate, TestPair.test_challenge_entropy, pair.now_us);
+
+    var challenge_out: [2048]u8 = undefined;
+    const challenge = pair.server.pollTransmitOnPath(&challenge_out, pair.now_us) orelse return error.TestExpectedEqual;
+    try testing.expect(challenge.path.eql(rebind_candidate));
+    var challenge_bytes: [2048]u8 = undefined;
+    @memcpy(challenge_bytes[0..challenge.bytes.len], challenge.bytes);
+    try pair.client.ingestOnPath(challenge_bytes[0..challenge.bytes.len], TestPair.client_path, TestPair.test_challenge_entropy, pair.now_us);
+
+    var response_out: [2048]u8 = undefined;
+    const response = pair.client.pollTransmitOnPath(&response_out, pair.now_us) orelse return error.TestExpectedEqual;
+    var response_bytes: [2048]u8 = undefined;
+    @memcpy(response_bytes[0..response.bytes.len], response.bytes);
+    try pair.server.ingestOnPath(response_bytes[0..response.bytes.len], rebind_candidate, TestPair.test_challenge_entropy, pair.now_us);
+    try testing.expect(pair.server.activePathKey().eql(rebind_candidate));
+
+    // The new path starts from the only size RFC 9000 §14 guarantees. An
+    // inherited size here is exactly the black hole this slice exists to
+    // avoid: the new path may not carry it, and nothing has shown that it does.
+    try testing.expectEqual(base_datagram_size, pair.server.effectiveMaxDatagramSize());
+    try testing.expectEqual(
+        @as(usize, std.math.maxInt(usize)),
+        pair.server.pathPlpmtu().smallest_failed,
+    );
 }
 
 test "driver: a padded non-ack-eliciting packet counts as in flight" {

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -2706,9 +2706,11 @@ pub const Connection = struct {
         // Fold in any outstanding path-validation deadline so `onTimeout`
         // expires it promptly rather than only on the next unrelated timer.
         if (self.paths.nextValidationDeadlineUs()) |validation| deadline = minOpt(deadline, validation);
-        // #256-B: the DPLPMTUD raise timer, armed only after a black-hole
-        // fallback. `Controller.onTimeout` disarms it when it fires, so this
-        // cannot return a deadline already in the past and spin the caller.
+        // #256-B: the DPLPMTUD raise timer, armed whenever a search converged
+        // below the ceiling because larger sizes were ruled out — by probe
+        // failure or by a black-hole fallback. `Controller.onTimeout` disarms
+        // it when it fires, so this cannot return a deadline already in the
+        // past and spin the caller.
         if (self.paths.activePath().plpmtu.deadlineUs()) |raise| deadline = minOpt(deadline, raise);
         return deadline;
     }
@@ -7150,7 +7152,7 @@ const MigrationPair = struct {
         errdefer allocator.destroy(pair);
         pair.client = try Connection.init(allocator, .{
             .role = .client,
-            .config = .{ .migration_policy = policy },
+            .config = .{ .migration_policy = policy, .max_send_udp_payload_size = max_datagram_size_ceiling },
             .local_cid = &TestPair.client_cid,
             .original_destination_cid = &TestPair.odcid,
             .initial_secret_dcid = &TestPair.odcid,
@@ -7163,7 +7165,7 @@ const MigrationPair = struct {
         errdefer pair.client.deinit();
         pair.server = try Connection.init(allocator, .{
             .role = .server,
-            .config = .{ .migration_policy = policy },
+            .config = .{ .migration_policy = policy, .max_send_udp_payload_size = max_datagram_size_ceiling },
             .local_cid = &TestPair.odcid,
             .original_destination_cid = &TestPair.odcid,
             .initial_secret_dcid = &TestPair.odcid,
@@ -8302,6 +8304,19 @@ fn drainTransmits(conn: *Connection, now_us: *u64) EmittedDatagrams {
     return seen;
 }
 
+/// The configuration of an embedder that has established the
+/// no-IP-fragmentation contract on its socket and may therefore let discovery
+/// reach the ceiling (#256-B). The transport default is the RFC 9000 §14
+/// floor: `quic/config.zig` owns no socket and cannot know whether a probe
+/// would be fragmented, so raising this is the socket owner's call. Every
+/// discovery test opts in explicitly, exactly as `http3_runtime` does after
+/// `configureNoFragment` succeeds.
+const discovery_enabled = config.Config{ .max_send_udp_payload_size = max_datagram_size_ceiling };
+
+fn discoveryPair(allocator: std.mem.Allocator) !*TestPair {
+    return TestPair.initWithConfigs(allocator, discovery_enabled, discovery_enabled);
+}
+
 /// Run DPLPMTUD to a resolved state on both sides across a path that silently
 /// drops any datagram larger than `path_mtu` — the network behaviour #256-B
 /// exists to discover. Pass `max_datagram_size_ceiling` for a path that
@@ -8573,9 +8588,9 @@ test "driver: the advertised receive capacity is separate from the send size" {
     );
 }
 
-test "driver: the default deployment discovers a larger size rather than assuming one" {
+test "driver: an embedder that opts in discovers a larger size rather than assuming one" {
     const allocator = testing.allocator;
-    var pair = try TestPair.init(allocator);
+    var pair = try discoveryPair(allocator);
     defer pair.deinit(allocator);
 
     // Before authentication nothing may exceed the floor, in either role: the
@@ -8600,7 +8615,7 @@ test "driver: the default deployment discovers a larger size rather than assumin
 
 test "driver: a path that only carries the floor is discovered as such" {
     const allocator = testing.allocator;
-    var pair = try TestPair.init(allocator);
+    var pair = try discoveryPair(allocator);
     defer pair.deinit(allocator);
 
     // Every probe this endpoint sends is larger than the path carries, so
@@ -8631,7 +8646,7 @@ test "driver: a path that only carries the floor is discovered as such" {
 
 test "driver: a path larger than the floor is discovered, and only up to what it carries" {
     const allocator = testing.allocator;
-    var pair = try TestPair.init(allocator);
+    var pair = try discoveryPair(allocator);
     defer pair.deinit(allocator);
 
     const path_mtu: usize = 1452;
@@ -8657,7 +8672,7 @@ test "driver: a path larger than the floor is discovered, and only up to what it
 
 test "driver: a probe is its own datagram, exactly the size it validates" {
     const allocator = testing.allocator;
-    var pair = try TestPair.init(allocator);
+    var pair = try discoveryPair(allocator);
     defer pair.deinit(allocator);
     try pair.pump();
 
@@ -8683,7 +8698,7 @@ test "driver: a probe is its own datagram, exactly the size it validates" {
 
 test "driver: a path that stops carrying the discovered size falls back to the floor" {
     const allocator = testing.allocator;
-    var pair = try TestPair.init(allocator);
+    var pair = try discoveryPair(allocator);
     defer pair.deinit(allocator);
     try settleDiscovery(pair, max_datagram_size_ceiling);
     const discovered = pair.server.effectiveMaxDatagramSize();
@@ -8763,7 +8778,7 @@ test "driver: a configured ceiling bounds discovery and is never exceeded" {
 
 test "driver: a probe waits for congestion window rather than taking an exemption" {
     const allocator = testing.allocator;
-    var pair = try TestPair.init(allocator);
+    var pair = try discoveryPair(allocator);
     defer pair.deinit(allocator);
     try pair.pump();
 
@@ -9119,7 +9134,7 @@ const PmtuEventRecorder = struct {
 
 test "driver: a fallback completed by a smaller ACK still publishes the transition" {
     const allocator = testing.allocator;
-    var pair = try TestPair.init(allocator);
+    var pair = try discoveryPair(allocator);
     defer pair.deinit(allocator);
     try settleDiscovery(pair, max_datagram_size_ceiling);
 
@@ -9225,7 +9240,7 @@ test "driver: a PTO driven by old-path packets is not charged to the new path" {
 
 test "driver: a PTO with the active path's own traffic outstanding is charged normally" {
     const allocator = testing.allocator;
-    var pair = try TestPair.init(allocator);
+    var pair = try discoveryPair(allocator);
     defer pair.deinit(allocator);
     try settleDiscovery(pair, max_datagram_size_ceiling);
     try testing.expect(pair.server.effectiveMaxDatagramSize() > base_datagram_size);
@@ -9246,6 +9261,108 @@ test "driver: a PTO with the active path's own traffic outstanding is charged no
     // The gate is about attribution, not about suppressing the signal.
     try testing.expectEqual(@as(u64, 1), pair.server.metrics.pmtu_black_holes);
     try testing.expectEqual(base_datagram_size, pair.server.effectiveMaxDatagramSize());
+}
+
+test "driver: a retry after a failed validation is a new incarnation" {
+    const allocator = testing.allocator;
+    var pair = try MigrationPair.init(allocator, .full);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    // Candidate A starts validating, and its PATH_CHALLENGE goes out.
+    var buf: [2048]u8 = undefined;
+    const datagram = try clientDatagram(pair, &buf);
+    try pair.server.ingestOnPath(datagram, rebind_candidate, TestPair.test_challenge_entropy, pair.now_us);
+    const first_ref = pair.server.paths.pathRefFor(rebind_candidate) orelse return error.TestExpectedEqual;
+    var challenge_out: [2048]u8 = undefined;
+    _ = pair.server.pollTransmitOnPath(&challenge_out, pair.now_us) orelse return error.TestExpectedEqual;
+    try testing.expectEqual(quic_path.PathState.validating, pair.server.paths.stateOf(rebind_candidate).?);
+
+    // Nobody answers, so the attempt expires. Its challenge record is still
+    // alive in connection-wide recovery — expiry is a path-lifecycle event,
+    // not a recovery one.
+    pair.now_us += 4 * quic_path.default_validation_timeout_us;
+    pair.server.onTimeout(pair.now_us);
+    try testing.expectEqual(quic_path.PathState.failed, pair.server.paths.stateOf(rebind_candidate).?);
+
+    // The same tuple is probed again. A *failed* attempt ended just as
+    // definitively as a promoted one, so this is a new incarnation: the old
+    // attempt's outstanding challenge must not resolve against it.
+    var retry_buf: [2048]u8 = undefined;
+    const retry = try clientDatagram(pair, &retry_buf);
+    try pair.server.ingestOnPath(retry, rebind_candidate, TestPair.test_challenge_entropy, pair.now_us);
+    const second_ref = pair.server.paths.pathRefFor(rebind_candidate) orelse return error.TestExpectedEqual;
+    try testing.expect(second_ref.generation != first_ref.generation);
+    try testing.expectEqual(@as(?*quic_pmtu.Controller, null), pair.server.paths.plpmtuFor(first_ref));
+
+    // Promote it and give it a discovered size, so stale feedback would have
+    // something to corrupt.
+    var challenge2: [2048]u8 = undefined;
+    const challenge = pair.server.pollTransmitOnPath(&challenge2, pair.now_us) orelse return error.TestExpectedEqual;
+    var challenge_bytes: [2048]u8 = undefined;
+    @memcpy(challenge_bytes[0..challenge.bytes.len], challenge.bytes);
+    try pair.client.ingestOnPath(challenge_bytes[0..challenge.bytes.len], TestPair.client_path, TestPair.test_challenge_entropy, pair.now_us);
+    var response_out: [2048]u8 = undefined;
+    const response = pair.client.pollTransmitOnPath(&response_out, pair.now_us) orelse return error.TestExpectedEqual;
+    var response_bytes: [2048]u8 = undefined;
+    @memcpy(response_bytes[0..response.bytes.len], response.bytes);
+    try pair.server.ingestOnPath(response_bytes[0..response.bytes.len], rebind_candidate, TestPair.test_challenge_entropy, pair.now_us);
+    try testing.expect(pair.server.activePathKey().eql(rebind_candidate));
+
+    const fresh = pair.server.paths.plpmtuFor(second_ref) orelse return error.TestExpectedEqual;
+    fresh.reset();
+    fresh.enable(max_datagram_size_ceiling, pair.now_us);
+    fresh.onProbeSent(1452, 5_100);
+    try testing.expect(fresh.onProbeAcked(5_100, pair.now_us));
+    try testing.expectEqual(@as(usize, 1452), fresh.sendSize());
+
+    // Now resolve the *first* attempt's record, both ways.
+    try ensureSentRecordCapacity(pair.server, pair.server.sent_records.items.len + 1);
+    pair.server.sent_records.addOneAssumeCapacity().* = .{
+        .space = .application,
+        .packet_number = 5_101,
+        .ack_eliciting = true,
+        .sent_path = first_ref,
+        .sent_size = base_datagram_size,
+    };
+    _ = pair.server.requeueUntrackedRecords(.application, pair.now_us);
+    pair.server.notePmtuEvidence(first_ref, .{ .ordinary_ack = base_datagram_size }, pair.now_us);
+
+    try testing.expectEqual(@as(usize, 1452), fresh.sendSize());
+    try testing.expectEqual(@as(u8, 0), fresh.oversized_losses);
+    try testing.expectEqual(@as(u8, 0), fresh.stalled_ptos);
+    try testing.expectEqual(@as(?u64, null), fresh.outstanding_pn);
+    try testing.expectEqual(@as(u32, 0), fresh.black_holes);
+    try testing.expectEqual(@as(u64, 0), pair.server.metrics.pmtu_black_holes);
+}
+
+test "driver: a bare embedder cannot discover above the floor" {
+    const allocator = testing.allocator;
+    // The transport default owns no socket, so it cannot know whether a probe
+    // would be fragmented — and an acknowledged fragmented probe would measure
+    // reassembly, not the path (RFC 8899 §3). Discovery is therefore off until
+    // a socket owner opts in.
+    try testing.expectEqual(
+        @as(u64, base_datagram_size),
+        (config.Config{}).max_send_udp_payload_size,
+    );
+
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try settleDiscovery(pair, max_datagram_size_ceiling);
+
+    // Even on a path that would carry anything, and with the peer advertising
+    // full receive capacity, nothing is probed and nothing is raised.
+    try testing.expectEqual(base_datagram_size, pair.server.probeMaxDatagramSize());
+    try testing.expectEqual(base_datagram_size, pair.server.effectiveMaxDatagramSize());
+    try testing.expectEqual(@as(u64, 0), pair.server.metrics.pmtu_probes_sent);
+    try testing.expectEqual(@as(?usize, null), pair.server.pathPlpmtu().nextProbeSize());
+
+    const sid = try openServerResponseStream(pair);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x88} ** (16 * 1024), false);
+    const seen = drainTransmits(pair.server, &pair.now_us);
+    try testing.expect(seen.count > 1);
+    try testing.expect(seen.largest <= base_datagram_size);
 }
 
 test "driver: a padded non-ack-eliciting packet counts as in flight" {

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -724,6 +724,15 @@ const SentRecord = struct {
     space: PacketNumberSpace,
     packet_number: u64,
     ack_eliciting: bool,
+    /// The path this packet actually went out on, and the size it went out at
+    /// (#256-B). DPLPMTUD feedback is a statement about *that* path, and a
+    /// migration does not retroactively move a packet: recovery keeps
+    /// old-path packets in flight across a promotion (RFC 9000 §9.4), so an
+    /// ACK or a loss can arrive long after a different path became active.
+    /// Every PMTU outcome is routed back through these two fields rather than
+    /// through whatever `activePath()` happens to be at the time.
+    sent_path: quic_path.PathKey,
+    sent_size: usize = 0,
     crypto: ?Range = null,
     stream_count: u8 = 0,
     streams: [4]StreamRange = undefined,
@@ -1153,12 +1162,31 @@ pub const Connection = struct {
     /// capacity and never appears here, while the peer's advertisement of the
     /// same parameter is *its* receive capacity and bounds everything we send.
     pub fn datagramLimits(self: *const Connection) quic_datagram.Limits {
+        return self.datagramLimitsFor(self.paths.activePath().plpmtu);
+    }
+
+    /// The same bounds resolved for a specific path's controller, so a report
+    /// about a path that is no longer active (a PMTU change on a path whose
+    /// delayed ACK just arrived) describes that path rather than this one.
+    fn datagramLimitsForPath(self: *const Connection, key: quic_path.PathKey) quic_datagram.Limits {
+        const active = self.paths.activePath();
+        const plpmtu = if (active.key.eql(key)) active.plpmtu else blk: {
+            for (self.paths.paths) |slot| {
+                const path = slot orelse continue;
+                if (path.key.eql(key)) break :blk path.plpmtu;
+            }
+            break :blk active.plpmtu;
+        };
+        return self.datagramLimitsFor(plpmtu);
+    }
+
+    fn datagramLimitsFor(self: *const Connection, plpmtu: quic_pmtu.Controller) quic_datagram.Limits {
         return .{
-            // What DPLPMTUD has actually shown *this* path carries (#256-B),
-            // starting at the RFC 9000 §14 floor. Note "this path": promoting
-            // a different one swaps in that path's controller, so a migration
-            // cannot inherit a size only the old path was shown to carry.
-            .current_path_max = self.paths.activePath().plpmtu.sendSize(),
+            // What DPLPMTUD has actually shown this path carries (#256-B),
+            // starting at the RFC 9000 §14 floor. The controller is per path,
+            // so promoting a different one swaps in that path's own state and
+            // a migration cannot inherit a size only the old path carried.
+            .current_path_max = plpmtu.sendSize(),
             // `max_send_udp_payload_size` is a ceiling, not a starting point:
             // it bounds what discovery may reach for rather than asserting a
             // size outright, so raising it can only ever permit a size that
@@ -1204,23 +1232,28 @@ pub const Connection = struct {
     /// §14.1). Confirmation is also what proves the base size works — every
     /// Initial-bearing datagram was padded to 1200 — which is the BASE-state
     /// check RFC 8899 would otherwise owe before any search may start.
-    fn syncPathPmtu(self: *Connection) void {
+    fn syncPathPmtu(self: *Connection, now_us: u64) void {
         // `probeCeiling()` already folds in both bounds a probe must respect:
         // this endpoint's send ceiling (the operator's configured maximum) and
         // the peer's advertised receive capacity.
         const ceiling = self.probeMaxDatagramSize();
         const controller = self.paths.activePlpmtu();
-        controller.configure(ceiling);
+        controller.configure(ceiling, now_us);
         if (self.handshake_confirmed and self.state_ == .established) {
-            controller.enable(ceiling);
+            controller.enable(ceiling, now_us);
         }
     }
 
     /// Feed one piece of black-hole evidence to the active path's controller
     /// and report the fallback if that tipped it. Both signals funnel through
     /// here so "the send size just dropped" is observed in exactly one place.
-    fn notePmtuBlackHoleEvidence(self: *Connection, kind: union(enum) { ordinary_loss: usize, stalled_pto }, now_us: u64) void {
-        const controller = self.paths.activePlpmtu();
+    fn notePmtuBlackHoleEvidence(
+        self: *Connection,
+        path: quic_path.PathKey,
+        kind: union(enum) { ordinary_loss: usize, stalled_pto },
+        now_us: u64,
+    ) void {
+        const controller = self.paths.plpmtuFor(path) orelse return;
         const before = controller.black_holes;
         switch (kind) {
             .ordinary_loss => |size| controller.onOrdinaryLoss(size, now_us),
@@ -1229,12 +1262,15 @@ pub const Connection = struct {
         if (controller.black_holes == before) return;
         self.metrics.pmtu_black_holes += 1;
         // Recovery's NewReno windows are expressed in the sender's current
-        // datagram size (RFC 9002 §B.2), so a fallback has to reach it now
-        // rather than at the next poll.
-        self.recovery.congestion.setMaxDatagramSize(self.effectiveMaxDatagramSize());
+        // datagram size (RFC 9002 §B.2), so a fallback on the path we are
+        // actually sending on has to reach it now rather than at the next
+        // poll. A fallback on some other path changes nothing we emit today.
+        if (self.paths.activePath().key.eql(path)) {
+            self.recovery.congestion.setMaxDatagramSize(self.effectiveMaxDatagramSize());
+        }
         self.events.emit(.{ .pmtu_updated = .{
-            .path = self.paths.activePath().key,
-            .size = self.effectiveMaxDatagramSize(),
+            .path = path,
+            .size = self.datagramLimitsForPath(path).effective(),
             .reason = .black_hole,
         } });
     }
@@ -1856,6 +1892,21 @@ pub const Connection = struct {
             3;
         const ack_delay_us = ack.ackDelayUs(exponent);
         const space_idx = spaceIndex(space);
+        // RFC 9000 §13.1: an ACK covering a packet number this endpoint has
+        // never sent is a protocol violation. Reject it *before* it reaches
+        // `largest_peer_acked` — that value is the reference every subsequent
+        // packet number is encoded against, so accepting an attacker-chosen
+        // future number would keep encoding needlessly wide until `next_pn`
+        // caught up with it. `packetNumberReference` still refuses an unusable
+        // reference, but as a backstop rather than as the handling.
+        if (ack.largest_acknowledged >= self.next_pn[space_idx]) {
+            self.startClose(.{
+                .error_code = error_protocol_violation,
+                .is_application = false,
+                .local = true,
+            }, "ACK for unsent packet", now_us);
+            return;
+        }
         if (self.largest_peer_acked[space_idx] == null or ack.largest_acknowledged > self.largest_peer_acked[space_idx].?) {
             self.largest_peer_acked[space_idx] = ack.largest_acknowledged;
         }
@@ -1875,14 +1926,18 @@ pub const Connection = struct {
                     if (acked.rtt_sample_us) |sample| self.recovery.rtt.update(sample, ack_delay_us);
                 }
                 // Delivery of an ordinary datagram is DPLPMTUD's evidence that
-                // the path still carries the size it was sent at (#256-B).
-                // Probes are excluded: `onRecordAcked` resolves those against
-                // the outstanding probe instead.
+                // the path still carries the size it was sent at (#256-B) —
+                // evidence about `record.sent_path`, which after a migration
+                // is not necessarily the active one. Probes are excluded:
+                // `onRecordAcked` resolves those against the outstanding probe
+                // instead.
                 if (!acked.packet.pmtu_probe) {
-                    self.paths.activePlpmtu().onOrdinaryAck(acked.packet.size);
+                    if (self.paths.plpmtuFor(record.sent_path)) |controller| {
+                        controller.onOrdinaryAck(record.sent_size, now_us);
+                    }
                 }
             }
-            self.onRecordAcked(record);
+            self.onRecordAcked(record, now_us);
             // Delivery is confirmed: any reset token this record carried
             // has done its job (the registry keeps the durable copy for as
             // long as the CID stays active) and is now redundant. Wipe it
@@ -1900,16 +1955,17 @@ pub const Connection = struct {
         self.detectAndRequeueLost(space, now_us);
     }
 
-    fn onRecordAcked(self: *Connection, record: *const SentRecord) void {
+    fn onRecordAcked(self: *Connection, record: *const SentRecord, now_us: u64) void {
         if (record.carried_pmtu_probe != null) {
-            // The probed size traversed the path, so it becomes the path's
-            // send size. Matching on the packet number means a stale ACK for
-            // an earlier probe cannot promote a size the current search has
-            // already ruled out.
-            if (self.paths.activePlpmtu().onProbeAcked(record.packet_number)) {
+            // The probed size traversed the path the probe was sent on, so it
+            // becomes *that* path's send size. Matching on the packet number
+            // means a stale ACK for an earlier probe cannot promote a size the
+            // current search has already ruled out.
+            const controller = self.paths.plpmtuFor(record.sent_path) orelse return;
+            if (controller.onProbeAcked(record.packet_number, now_us)) {
                 self.events.emit(.{ .pmtu_updated = .{
-                    .path = self.paths.activePath().key,
-                    .size = self.effectiveMaxDatagramSize(),
+                    .path = record.sent_path,
+                    .size = self.datagramLimitsForPath(record.sent_path).effective(),
                     .reason = .raised,
                 } });
             }
@@ -1932,15 +1988,12 @@ pub const Connection = struct {
     fn detectAndRequeueLost(self: *Connection, space: PacketNumberSpace, now_us: u64) void {
         const loss = self.recovery.detectLost(space, now_us);
         if (loss.packet_threshold_losses + loss.time_threshold_losses == 0) return;
-        // #256-B: a lost *ordinary* datagram larger than the guaranteed floor
-        // is the one loss that a smaller send size could have prevented, so it
-        // is the only kind DPLPMTUD treats as evidence. Probe losses are
-        // excluded here and routed to the controller by `requeueUntrackedRecords`
-        // below — a probe is meant to be too big.
-        if (loss.largest_ordinary_lost_size > 0) {
-            self.notePmtuBlackHoleEvidence(.{ .ordinary_loss = loss.largest_ordinary_lost_size }, now_us);
-        }
-        const lost_count = self.requeueUntrackedRecords(space);
+        // #256-B evidence is fed per record inside `requeueUntrackedRecords`,
+        // where the path and size each lost packet actually went out on are
+        // still known. Deriving it from `loss` instead would collapse losses
+        // from several paths into one number and then attribute it to whichever
+        // path happens to be active.
+        const lost_count = self.requeueUntrackedRecords(space, now_us);
         if (lost_count > 0) {
             self.metrics.packets_lost += lost_count;
             self.events.emit(.{ .packets_lost = .{ .space = space, .bytes = loss.lost_bytes } });
@@ -1951,7 +2004,7 @@ pub const Connection = struct {
     /// holds. Shared by loss detection and by recovery-slot reclamation, which
     /// retires a tracked packet for exactly the same reason: its content must
     /// be resent, and its record must not outlive its tracker entry.
-    fn requeueUntrackedRecords(self: *Connection, space: PacketNumberSpace) u64 {
+    fn requeueUntrackedRecords(self: *Connection, space: PacketNumberSpace, now_us: u64) u64 {
         var index: usize = 0;
         var count: u64 = 0;
         while (index < self.sent_records.items.len) {
@@ -1963,13 +2016,24 @@ pub const Connection = struct {
             count += 1;
             if (record.carried_pmtu_probe != null) {
                 // Nothing to requeue: a probe carries no user data, and the
-                // search decides for itself whether to retry this size.
-                self.paths.activePlpmtu().onProbeLost(record.packet_number);
+                // search decides for itself whether to retry this size. The
+                // outcome belongs to the path the probe went out on.
+                if (self.paths.plpmtuFor(record.sent_path)) |controller| {
+                    controller.onProbeLost(record.packet_number, now_us);
+                }
                 wipeSentRecordToken(record);
                 _ = self.sent_records.swapRemove(index);
                 wipeSentRecordsSwapRemoveResidue(&self.sent_records);
                 continue;
             }
+            // #256-B: a lost ordinary datagram is evidence about the path it
+            // was sent on and the size it was sent at — the controller decides
+            // whether that size is large enough to mean anything.
+            self.notePmtuBlackHoleEvidence(
+                record.sent_path,
+                .{ .ordinary_loss = record.sent_size },
+                now_us,
+            );
             // Read the live element to requeue its content (a fresh copy of
             // any carried reset token lands in `pending_new_connection_ids`
             // via `requeueRecord`) before wiping this now-redundant copy and
@@ -2731,7 +2795,14 @@ pub const Connection = struct {
         // the application space counts, so one timer expiry that fires a PTO
         // in two spaces is still one piece of evidence; discovery only runs
         // after confirmation anyway, when the earlier spaces are gone.
-        if (space == .application) self.notePmtuBlackHoleEvidence(.stalled_pto, now_us);
+        //
+        // This one *is* an active-path statement, unlike the ACK/loss signals:
+        // it says what this endpoint is sending right now is not getting
+        // through, and what it is sending right now goes out on the active
+        // path at the active path's size.
+        if (space == .application) {
+            self.notePmtuBlackHoleEvidence(self.paths.activePath().key, .stalled_pto, now_us);
+        }
         // Requeue the oldest unacked retransmittable content of the space so
         // the probe carries data rather than a bare PING when possible.
         var oldest: ?usize = null;
@@ -2955,7 +3026,7 @@ pub const Connection = struct {
         // Refresh DPLPMTUD's bounds first: it is what `effectiveMaxDatagramSize`
         // reads for the current path size, so recovery below sees the same
         // value the builder is about to use.
-        self.syncPathPmtu();
+        self.syncPathPmtu(now_us);
         self.recovery.congestion.setMaxDatagramSize(self.effectiveMaxDatagramSize());
 
         if (self.state_ == .closing) {
@@ -3107,7 +3178,7 @@ pub const Connection = struct {
         var plain: [max_datagram_size_ceiling]u8 = undefined;
         const plain_budget = @min(plain.len, max_packet - pn_offset - pn_len - aead_tag_len);
         var plain_len: usize = 0;
-        var record = SentRecord{ .space = .application, .packet_number = pn, .ack_eliciting = false };
+        var record = SentRecord{ .space = .application, .packet_number = pn, .ack_eliciting = false, .sent_path = path };
 
         var i: usize = 0;
         while (i < self.pending_path_responses.items.len) {
@@ -3174,6 +3245,7 @@ pub const Connection = struct {
         self.next_pn[space_idx] = pn + 1;
 
         if (record.ack_eliciting) {
+            record.sent_size = total;
             // Slot preflighted at the top, before the PATH_RESPONSE was
             // dequeued or `needs_send` cleared.
             self.recovery.onPacketSentAssumeCapacity(.{
@@ -3272,6 +3344,8 @@ pub const Connection = struct {
             .space = .application,
             .packet_number = pn,
             .ack_eliciting = true,
+            .sent_path = active_key,
+            .sent_size = total,
             .carried_pmtu_probe = probe_size,
         };
         self.recovery.onPacketSentAssumeCapacity(.{
@@ -3419,6 +3493,9 @@ pub const Connection = struct {
             .space = space,
             .packet_number = pn,
             .ack_eliciting = false,
+            // Ordinary content always targets the active path; candidate-path
+            // content is built and recorded by `buildCandidatePacket`.
+            .sent_path = self.paths.activePath().key,
         };
         // `record` may pick up a dequeued NEW_CONNECTION_ID's reset token
         // below; `self.sent_records.append` (if reached) copies it into the
@@ -3573,6 +3650,7 @@ pub const Connection = struct {
         // exempt: the peer never acknowledges it, so tracking it would only
         // consume tracker slots.
         if (recordIsInFlight(record)) {
+            record.sent_size = total;
             // Every path that can reach here preflighted a tracker slot before
             // committing a frame — `can_track_ordinary` for ordinary content,
             // `can_track_recovery` for probes and mandatory padding — so this
@@ -6169,6 +6247,12 @@ test "#523: real TLS accept decision installs a usable QUIC 0-RTT read key end t
         const frame_len = try frame.encodeStream(4, 0, "real early data", true, &frame_buf);
         var wire: [256]u8 = undefined;
         const datagram = sealTestZeroRttPacket(suite, &TestPair.odcid, &TestPair.client_cid, real_secret, 0, frame_buf[0..frame_len], &wire);
+        // This packet is sealed outside the driver, so the client's own
+        // packet-number bookkeeping has to be told it went out. Without that,
+        // the server's ACK for it looks like an ACK for a packet the client
+        // never sent — a protocol violation (RFC 9000 §13.1) the client now
+        // rejects — and the handshake below would close instead of completing.
+        resumed.client.next_pn[Connection.spaceIndex(.application)] = 1;
         try resumed.server.ingestOnPath(datagram, TestPair.server_path, TestPair.test_challenge_entropy, resumed.now_us);
 
         try testing.expect(resumed.server.streamTransportEarly(4));
@@ -7849,8 +7933,8 @@ test "wipeSentRecordsSwapRemoveResidue zeroes the vacated slot regardless of its
     var records: std.ArrayList(SentRecord) = .empty;
     defer records.deinit(testing.allocator);
     try records.ensureTotalCapacityPrecise(testing.allocator, 4);
-    records.appendAssumeCapacity(.{ .space = .application, .packet_number = 1, .ack_eliciting = false });
-    records.appendAssumeCapacity(.{ .space = .application, .packet_number = 2, .ack_eliciting = false });
+    records.appendAssumeCapacity(.{ .space = .application, .packet_number = 1, .ack_eliciting = false, .sent_path = TestPair.client_path });
+    records.appendAssumeCapacity(.{ .space = .application, .packet_number = 2, .ack_eliciting = false, .sent_path = TestPair.client_path });
 
     _ = records.swapRemove(0);
     // Simulate whatever a safety-checked build's poison-fill (or a
@@ -7916,6 +8000,7 @@ test "connection: fixed sent-record and pending-CID capacities are preallocated"
             .space = .application,
             .packet_number = i,
             .ack_eliciting = false,
+            .sent_path = pair.server.paths.activePath().key,
         });
     }
     try testing.expectEqual(sent_records_backing, pair.server.sent_records.items.ptr);
@@ -8541,7 +8626,7 @@ test "driver: a probe is its own datagram, exactly the size it validates" {
     // datagram is the probe rather than whatever the handshake left queued.
     const probes_before = pair.server.metrics.pmtu_probes_sent;
     pair.server.paths.activePlpmtu().reset();
-    pair.server.syncPathPmtu();
+    pair.server.syncPathPmtu(pair.now_us);
     const expected = pair.server.probeMaxDatagramSize();
 
     var out: [max_datagram_size_ceiling]u8 = undefined;
@@ -8663,7 +8748,7 @@ test "driver: a probe waits for congestion window rather than taking an exemptio
     // probes to be congestion controlled).
     const probes_before = pair.server.metrics.pmtu_probes_sent;
     pair.server.paths.activePlpmtu().reset();
-    pair.server.syncPathPmtu();
+    pair.server.syncPathPmtu(pair.now_us);
     congestion.congestion_window = congestion.bytes_in_flight + base_datagram_size;
     while (pair.server.pollTransmitOnPath(&out, pair.now_us)) |t| {
         try testing.expect(t.bytes.len <= base_datagram_size);
@@ -8717,24 +8802,211 @@ test "driver: a migrated path revalidates its own MTU instead of inheriting one"
     );
 }
 
+test "driver: an ACK for a packet that was never sent is a protocol violation" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const space_idx = Connection.spaceIndex(.application);
+    const sent_reference = pair.server.largest_peer_acked[space_idx];
+    const unsent = pair.server.next_pn[space_idx] + 5;
+
+    var ranges = recovery.AckRangeSet{};
+    try ranges.insert(unsent);
+    pair.server.processAck(.application, .{
+        .ranges = ranges,
+        .ack_delay_raw = 0,
+        .largest_acknowledged = unsent,
+    }, pair.now_us);
+
+    // RFC 9000 §13.1. Detecting the violation exactly beats absorbing it: this
+    // must not merely avoid the `packetNumberLength` assertion.
+    try testing.expectEqual(State.closing, pair.server.state());
+    try testing.expectEqual(error_protocol_violation, pair.server.close_info.?.error_code);
+    try testing.expect(pair.server.close_info.?.local);
+    // The attacker-chosen number never reached the encoding reference, which
+    // would otherwise keep every subsequent packet number needlessly wide
+    // until `next_pn` caught up with it.
+    try testing.expectEqual(sent_reference, pair.server.largest_peer_acked[space_idx]);
+    if (pair.server.largest_peer_acked[space_idx]) |acked| {
+        try testing.expect(acked < pair.server.next_pn[space_idx]);
+    }
+}
+
+test "driver: an ACK for an unsent packet in a space that has sent nothing also closes" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+
+    // Nothing has been sent in the handshake space yet, so *any* ACK for it
+    // acknowledges something that does not exist.
+    try testing.expectEqual(@as(u64, 0), pair.server.next_pn[Connection.spaceIndex(.handshake)]);
+    var ranges = recovery.AckRangeSet{};
+    try ranges.insert(0);
+    pair.server.processAck(.handshake, .{
+        .ranges = ranges,
+        .ack_delay_raw = 0,
+        .largest_acknowledged = 0,
+    }, pair.now_us);
+
+    try testing.expectEqual(State.closing, pair.server.state());
+    try testing.expectEqual(error_protocol_violation, pair.server.close_info.?.error_code);
+}
+
+test "driver: PMTU loss feedback after promotion lands on the path that sent it" {
+    const allocator = testing.allocator;
+    var pair = try MigrationPair.init(allocator, .full);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    // The handshake path discovered a size above the floor.
+    const old_key = pair.server.activePathKey();
+    const discovered = pair.server.effectiveMaxDatagramSize();
+    try testing.expect(discovered > base_datagram_size);
+
+    // Migrate. Recovery deliberately keeps old-path packets in flight across
+    // this (RFC 9000 §9.4), which is exactly why their eventual ACK or loss
+    // can arrive once a different path is active.
+    var buf: [2048]u8 = undefined;
+    const datagram = try clientDatagram(pair, &buf);
+    try pair.server.ingestOnPath(datagram, rebind_candidate, TestPair.test_challenge_entropy, pair.now_us);
+    var challenge_out: [2048]u8 = undefined;
+    const challenge = pair.server.pollTransmitOnPath(&challenge_out, pair.now_us) orelse return error.TestExpectedEqual;
+    var challenge_bytes: [2048]u8 = undefined;
+    @memcpy(challenge_bytes[0..challenge.bytes.len], challenge.bytes);
+    try pair.client.ingestOnPath(challenge_bytes[0..challenge.bytes.len], TestPair.client_path, TestPair.test_challenge_entropy, pair.now_us);
+    var response_out: [2048]u8 = undefined;
+    const response = pair.client.pollTransmitOnPath(&response_out, pair.now_us) orelse return error.TestExpectedEqual;
+    var response_bytes: [2048]u8 = undefined;
+    @memcpy(response_bytes[0..response.bytes.len], response.bytes);
+    try pair.server.ingestOnPath(response_bytes[0..response.bytes.len], rebind_candidate, TestPair.test_challenge_entropy, pair.now_us);
+    try testing.expect(pair.server.activePathKey().eql(rebind_candidate));
+    try testing.expect(!old_key.eql(rebind_candidate));
+
+    // The new path starts clean.
+    try testing.expectEqual(base_datagram_size, pair.server.effectiveMaxDatagramSize());
+    try testing.expectEqual(@as(u8, 0), pair.server.paths.plpmtuFor(rebind_candidate).?.oversized_losses);
+
+    // An old-path packet, sent at the old path's larger size, is now declared
+    // lost. `requeueUntrackedRecords` owns the attribution.
+    try ensureSentRecordCapacity(pair.server, pair.server.sent_records.items.len + 1);
+    pair.server.sent_records.addOneAssumeCapacity().* = .{
+        .space = .application,
+        .packet_number = 9_999,
+        .ack_eliciting = true,
+        .sent_path = old_key,
+        .sent_size = discovered,
+    };
+    _ = pair.server.requeueUntrackedRecords(.application, pair.now_us);
+
+    // It counted against the path that actually sent it ...
+    try testing.expectEqual(@as(u8, 1), pair.server.paths.plpmtuFor(old_key).?.oversized_losses);
+    // ... and left the new path's controller alone. Attributing it here would
+    // accumulate black-hole evidence against a size the new path has never
+    // even sent, and three of those would drag it to the floor for nothing.
+    const fresh = pair.server.paths.plpmtuFor(rebind_candidate).?;
+    try testing.expectEqual(@as(u8, 0), fresh.oversized_losses);
+    try testing.expectEqual(@as(u32, 0), fresh.black_holes);
+    try testing.expectEqual(base_datagram_size, fresh.sendSize());
+    try testing.expectEqual(@as(u64, 0), pair.server.metrics.pmtu_black_holes);
+}
+
+test "driver: a probe outcome after promotion resolves the probe's own path" {
+    const allocator = testing.allocator;
+    var pair = try MigrationPair.init(allocator, .full);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const old_key = pair.server.activePathKey();
+    // An outstanding probe on the handshake path.
+    const old_controller = pair.server.paths.plpmtuFor(old_key).?;
+    old_controller.reset();
+    old_controller.enable(max_datagram_size_ceiling, pair.now_us);
+    const probe_size = old_controller.nextProbeSize().?;
+    old_controller.onProbeSent(probe_size, 4_242);
+
+    var buf: [2048]u8 = undefined;
+    const datagram = try clientDatagram(pair, &buf);
+    try pair.server.ingestOnPath(datagram, rebind_candidate, TestPair.test_challenge_entropy, pair.now_us);
+    var challenge_out: [2048]u8 = undefined;
+    const challenge = pair.server.pollTransmitOnPath(&challenge_out, pair.now_us) orelse return error.TestExpectedEqual;
+    var challenge_bytes: [2048]u8 = undefined;
+    @memcpy(challenge_bytes[0..challenge.bytes.len], challenge.bytes);
+    try pair.client.ingestOnPath(challenge_bytes[0..challenge.bytes.len], TestPair.client_path, TestPair.test_challenge_entropy, pair.now_us);
+    var response_out: [2048]u8 = undefined;
+    const response = pair.client.pollTransmitOnPath(&response_out, pair.now_us) orelse return error.TestExpectedEqual;
+    var response_bytes: [2048]u8 = undefined;
+    @memcpy(response_bytes[0..response.bytes.len], response.bytes);
+    try pair.server.ingestOnPath(response_bytes[0..response.bytes.len], rebind_candidate, TestPair.test_challenge_entropy, pair.now_us);
+    try testing.expect(pair.server.activePathKey().eql(rebind_candidate));
+
+    // The probe's ACK arrives after a different path became active. It must
+    // raise the old path's size, not the new path's.
+    pair.server.onRecordAcked(&.{
+        .space = .application,
+        .packet_number = 4_242,
+        .ack_eliciting = true,
+        .sent_path = old_key,
+        .sent_size = probe_size,
+        .carried_pmtu_probe = probe_size,
+    }, pair.now_us);
+
+    try testing.expectEqual(probe_size, pair.server.paths.plpmtuFor(old_key).?.sendSize());
+    try testing.expectEqual(base_datagram_size, pair.server.paths.plpmtuFor(rebind_candidate).?.sendSize());
+    // The size on the wire follows the path we are actually sending on.
+    try testing.expectEqual(base_datagram_size, pair.server.effectiveMaxDatagramSize());
+}
+
+test "driver: PMTU feedback for a recycled path slot is dropped" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    // A tuple this connection has never tracked has no controller to teach.
+    const stranger = quic_path.PathKey{
+        .local = TestPair.server_path.local,
+        .remote = quic_udp.Address.ip4(.{ 198, 51, 100, 7 }, 4433),
+    };
+    try testing.expectEqual(@as(?*quic_pmtu.Controller, null), pair.server.paths.plpmtuFor(stranger));
+
+    try ensureSentRecordCapacity(pair.server, pair.server.sent_records.items.len + 1);
+    pair.server.sent_records.addOneAssumeCapacity().* = .{
+        .space = .application,
+        .packet_number = 8_888,
+        .ack_eliciting = true,
+        .sent_path = stranger,
+        .sent_size = max_datagram_size_ceiling,
+    };
+    // Dropping the feedback is the point: applying it to some other path would
+    // be worse than losing it.
+    _ = pair.server.requeueUntrackedRecords(.application, pair.now_us);
+    try testing.expectEqual(@as(u64, 0), pair.server.metrics.pmtu_black_holes);
+    try testing.expectEqual(@as(u8, 0), pair.server.paths.activePlpmtu().oversized_losses);
+}
+
 test "driver: a padded non-ack-eliciting packet counts as in flight" {
     // RFC 9002 §2 — the predicate the send path keys recovery accounting off.
     try testing.expect(recordIsInFlight(.{
         .space = .initial,
         .packet_number = 0,
         .ack_eliciting = false,
+        .sent_path = TestPair.client_path,
         .carried_padding = true,
     }));
     try testing.expect(recordIsInFlight(.{
         .space = .application,
         .packet_number = 0,
         .ack_eliciting = true,
+        .sent_path = TestPair.client_path,
     }));
     // A genuine pure ACK stays exempt.
     try testing.expect(!recordIsInFlight(.{
         .space = .application,
         .packet_number = 0,
         .ack_eliciting = false,
+        .sent_path = TestPair.client_path,
     }));
 }
 
@@ -8993,6 +9265,7 @@ fn fillOrdinaryTrackerWithRecords(conn: *Connection) !usize {
             .space = .initial,
             .packet_number = pn,
             .ack_eliciting = false,
+            .sent_path = conn.paths.activePath().key,
         };
     }
     return added;

--- a/src/quic/datagram.zig
+++ b/src/quic/datagram.zig
@@ -16,7 +16,8 @@ const std = @import("std");
 /// payload, and §14.1 requires a datagram carrying an Initial packet to be
 /// padded to at least that size. So it is simultaneously the floor of any
 /// effective cap and the value the stack falls back to whenever nothing
-/// larger has been established. Also the operator-facing default.
+/// larger has been established — where every path starts, and where a
+/// black-hole fallback lands (#256-B).
 pub const base_size: usize = 1200;
 
 /// Hard ceiling on any datagram this stack will emit, whatever an operator or
@@ -33,16 +34,19 @@ pub const max_size: usize = 2048;
 /// statement of receive capacity, not mutable path state. Only the peer's
 /// advertisement appears here, as a ceiling on what we may send it.
 pub const Limits = struct {
-    /// The sender's current maximum datagram size for the active path: what
-    /// this stack believes the path carries today. Starts at `base_size`, the
-    /// only size RFC 9000 §14 guarantees. An operator may assert a larger
-    /// value for a path whose MTU they control; #256-B replaces the assertion
-    /// with measured DPLPMTUD state and black-hole fallback.
+    /// The sender's current maximum datagram size for the path in question:
+    /// what DPLPMTUD has *shown* the path carries (#256-B). Starts at
+    /// `base_size`, the only size RFC 9000 §14 guarantees, and rises only when
+    /// a probe of a larger size is acknowledged. Nothing an operator or peer
+    /// says raises it directly — that is the difference from #256-A, where
+    /// this was an assertion.
     current_path_max: u64 = base_size,
     /// The largest datagram this endpoint will ever emit, independent of what
-    /// the path has been shown to carry. This is the ceiling a PMTU probe may
-    /// reach for, so it must have headroom above `base_size` or #256-B could
-    /// never discover anything.
+    /// the path has been shown to carry: the operator's configured maximum,
+    /// held down to `base_size` on a listener that could not establish the
+    /// no-IP-fragmentation contract DPLPMTUD requires. This is the ceiling a
+    /// PMTU probe may reach for, so it must have headroom above `base_size`
+    /// or #256-B could never discover anything.
     send_ceiling: u64 = max_size,
     /// The peer's advertised `max_udp_payload_size`: its receive capacity,
     /// once transport parameters have been authenticated. `null` before then,

--- a/src/quic/path.zig
+++ b/src/quic/path.zig
@@ -18,6 +18,7 @@
 const std = @import("std");
 const config = @import("config.zig");
 const packet = @import("packet.zig");
+const pmtu = @import("pmtu.zig");
 const udp = @import("udp.zig");
 const secrets = @import("crypto_secrets");
 
@@ -486,6 +487,12 @@ pub const Path = struct {
     challenge: [path_challenge_len]u8 = undefined,
     challenge_deadline_us: u64 = 0,
     anti_amplification: AntiAmplification = .{},
+    /// DPLPMTUD state for *this* path (#256-B). Path-scoped rather than
+    /// connection-scoped because that is what the question means: a size
+    /// discovered on one path says nothing about another. A new or recycled
+    /// slot therefore starts from the RFC 9000 §14 floor by construction —
+    /// there is no inherit-the-old-value path to get wrong.
+    plpmtu: pmtu.Controller = .{},
 };
 
 /// The action the connection takes for a datagram from a given tuple.
@@ -569,6 +576,15 @@ pub const PathManager = struct {
 
     pub fn activePath(self: *const PathManager) *const Path {
         return &self.paths[self.active].?;
+    }
+
+    /// The active path's DPLPMTUD state, for a caller that drives probing and
+    /// consumes probe/loss feedback (#256-B). Mutable by design and reached
+    /// only through the active slot: promoting a different path swaps which
+    /// controller this returns, which is exactly the per-path reset the
+    /// discovery model requires.
+    pub fn activePlpmtu(self: *PathManager) *pmtu.Controller {
+        return &self.paths[self.active].?.plpmtu;
     }
 
     /// Lift the active path's anti-amplification limit once its address is
@@ -712,7 +728,15 @@ pub const PathManager = struct {
             // deliberately chose not to skip validation (RFC 9000 §9.3.1).
             // A path still mid-validation or awaiting promotion keeps its
             // ledger untouched — it either hasn't validated yet or just did.
-            if (path.state == .validated) path.anti_amplification = .{};
+            // Same reasoning for the path's measured MTU (#256-B): a tuple
+            // being re-validated after having been away is not demonstrably
+            // the same path it was, and an inherited size that no longer
+            // traverses it is a black hole waiting to happen. Discovery
+            // restarts from the guaranteed floor.
+            if (path.state == .validated) {
+                path.anti_amplification = .{};
+                path.plpmtu.reset();
+            }
             path.anti_amplification.recordReceived(authenticated_bytes);
             switch (path.state) {
                 .validating => return .probing,

--- a/src/quic/path.zig
+++ b/src/quic/path.zig
@@ -587,6 +587,21 @@ pub const PathManager = struct {
         return &self.paths[self.active].?.plpmtu;
     }
 
+    /// The DPLPMTUD state of a *specific* path, or null when that tuple is no
+    /// longer tracked. This is the accessor ACK/loss feedback must use, not
+    /// `activePlpmtu`: recovery deliberately keeps old-path packets in flight
+    /// across a migration (RFC 9000 §9.4, see
+    /// `recovery.resetForPathMigration`), so a delayed acknowledgement or a
+    /// loss can land well after a different path became active. Attributing
+    /// that outcome to whatever is active *now* would teach the new path a
+    /// size only the old one was ever shown to carry — exactly the inheritance
+    /// this per-path model exists to prevent. A null return means the slot was
+    /// recycled and the feedback has nowhere legitimate to go: drop it.
+    pub fn plpmtuFor(self: *PathManager, key: PathKey) ?*pmtu.Controller {
+        const index = self.find(key) orelse return null;
+        return &self.paths[index].?.plpmtu;
+    }
+
     /// Lift the active path's anti-amplification limit once its address is
     /// validated some other way (e.g. a non-Retry server's handshake
     /// completed). Prefer this over reaching into a connection-wide ledger.

--- a/src/quic/path.zig
+++ b/src/quic/path.zig
@@ -450,6 +450,26 @@ pub const PathKey = struct {
     }
 };
 
+/// A path *incarnation*: the address tuple plus the generation of the slot
+/// that represented it (#256-B review).
+///
+/// The tuple alone is not an identity for anything with per-path lifecycle
+/// state. A slot can be recycled, and `onDatagram` deliberately restarts a
+/// previously-validated tuple's discovery when it has to be re-validated — so
+/// the same `(local, remote)` can name a *fresh* PMTU controller while packets
+/// sent by its previous incarnation are still outstanding in recovery. Feeding
+/// those stale outcomes to the new controller would teach it about a path
+/// condition that no longer exists. Carrying the generation makes that
+/// detectable rather than silent.
+pub const PathRef = struct {
+    key: PathKey,
+    generation: u64,
+
+    pub fn eql(self: PathRef, other: PathRef) bool {
+        return self.generation == other.generation and self.key.eql(other.key);
+    }
+};
+
 pub const PathState = enum {
     /// Traffic seen, no validation started (policy denied or not yet probed).
     unvalidated,
@@ -487,6 +507,12 @@ pub const Path = struct {
     challenge: [path_challenge_len]u8 = undefined,
     challenge_deadline_us: u64 = 0,
     anti_amplification: AntiAmplification = .{},
+    /// Which incarnation of this slot the current lifecycle state belongs to.
+    /// Bumped whenever the slot starts representing a new path — a fresh or
+    /// recycled slot, or a validated tuple whose discovery is restarted — so
+    /// outcomes stamped with an older generation can be recognised as stale
+    /// and dropped rather than applied to state they did not produce.
+    generation: u64 = 0,
     /// DPLPMTUD state for *this* path (#256-B). Path-scoped rather than
     /// connection-scoped because that is what the question means: a size
     /// discovered on one path says nothing about another. A new or recycled
@@ -555,6 +581,9 @@ pub const PathManager = struct {
     paths: [max_paths]?Path = [_]?Path{null} ** max_paths,
     /// Index of the active (validated, in-use) path.
     active: usize = 0,
+    /// Monotonic source of path-incarnation generations. Never reused, so a
+    /// stamped `PathRef` can always be compared for staleness.
+    next_generation: u64 = 1,
     metrics: Metrics = .{},
 
     /// Start with the handshake path as the active routing path. Its
@@ -569,7 +598,9 @@ pub const PathManager = struct {
             .key = handshake_path,
             .state = .validated,
             .change = .migration,
+            .generation = 1,
         };
+        manager.next_generation = 2;
         if (initial_address_validated) manager.paths[0].?.anti_amplification.markValidated();
         return manager;
     }
@@ -587,6 +618,28 @@ pub const PathManager = struct {
         return &self.paths[self.active].?.plpmtu;
     }
 
+    /// The active path's current incarnation, for stamping onto outbound
+    /// records so their eventual outcome can be matched back to the state that
+    /// produced them.
+    pub fn activePathRef(self: *const PathManager) PathRef {
+        const path = self.activePath();
+        return .{ .key = path.key, .generation = path.generation };
+    }
+
+    /// The incarnation of a tracked tuple, or null when it is not tracked.
+    pub fn pathRefFor(self: *const PathManager, key: PathKey) ?PathRef {
+        const index = self.find(key) orelse return null;
+        const path = self.paths[index].?;
+        return .{ .key = path.key, .generation = path.generation };
+    }
+
+    /// Whether `ref` names the path that is active right now — both the tuple
+    /// and the incarnation, so a re-validated tuple does not answer for the
+    /// generation that preceded it.
+    pub fn isActive(self: *const PathManager, ref: PathRef) bool {
+        return self.activePathRef().eql(ref);
+    }
+
     /// The DPLPMTUD state of a *specific* path, or null when that tuple is no
     /// longer tracked. This is the accessor ACK/loss feedback must use, not
     /// `activePlpmtu`: recovery deliberately keeps old-path packets in flight
@@ -597,9 +650,14 @@ pub const PathManager = struct {
     /// size only the old one was ever shown to carry — exactly the inheritance
     /// this per-path model exists to prevent. A null return means the slot was
     /// recycled and the feedback has nowhere legitimate to go: drop it.
-    pub fn plpmtuFor(self: *PathManager, key: PathKey) ?*pmtu.Controller {
-        const index = self.find(key) orelse return null;
-        return &self.paths[index].?.plpmtu;
+    pub fn plpmtuFor(self: *PathManager, ref: PathRef) ?*pmtu.Controller {
+        const index = self.find(ref.key) orelse return null;
+        const path = &self.paths[index].?;
+        // Same tuple, different incarnation: the state that produced this
+        // outcome is gone, and the controller sitting here now describes a
+        // path that has not been shown to behave the same way.
+        if (path.generation != ref.generation) return null;
+        return &path.plpmtu;
     }
 
     /// Lift the active path's anti-amplification limit once its address is
@@ -728,7 +786,7 @@ pub const PathManager = struct {
                 return .{ .blocked = .{ .change = change, .first_observation = false } };
             } else {
                 const slot = self.claimSlot();
-                self.paths[slot] = .{ .key = key, .state = .unvalidated, .change = change };
+                self.paths[slot] = .{ .key = key, .state = .unvalidated, .change = change, .generation = self.claimGeneration() };
                 self.paths[slot].?.anti_amplification.recordReceived(authenticated_bytes);
                 return .{ .blocked = .{ .change = change, .first_observation = true } };
             }
@@ -751,6 +809,9 @@ pub const PathManager = struct {
             if (path.state == .validated) {
                 path.anti_amplification = .{};
                 path.plpmtu.reset();
+                // A new incarnation of the same tuple: outcomes still owed by
+                // the previous one must not land on this fresh state.
+                path.generation = self.claimGeneration();
             }
             path.anti_amplification.recordReceived(authenticated_bytes);
             switch (path.state) {
@@ -783,6 +844,7 @@ pub const PathManager = struct {
             .change = change,
             .challenge = challenge_entropy,
             .challenge_deadline_us = now_us + self.validation_timeout_us,
+            .generation = self.claimGeneration(),
         };
         self.paths[slot].?.anti_amplification.recordReceived(authenticated_bytes);
         self.metrics.path_challenges_sent += 1;
@@ -949,6 +1011,12 @@ pub const PathManager = struct {
 
     /// A free slot, or the oldest non-active failed/unvalidated slot when the
     /// table is full — probe storms recycle probes, never the active path.
+    fn claimGeneration(self: *PathManager) u64 {
+        const generation = self.next_generation;
+        self.next_generation +|= 1;
+        return generation;
+    }
+
     fn claimSlot(self: *PathManager) usize {
         for (self.paths, 0..) |slot, index| {
             if (slot == null) return index;

--- a/src/quic/path.zig
+++ b/src/quic/path.zig
@@ -801,17 +801,36 @@ pub const PathManager = struct {
             // deliberately chose not to skip validation (RFC 9000 §9.3.1).
             // A path still mid-validation or awaiting promotion keeps its
             // ledger untouched — it either hasn't validated yet or just did.
-            // Same reasoning for the path's measured MTU (#256-B): a tuple
-            // being re-validated after having been away is not demonstrably
-            // the same path it was, and an inherited size that no longer
-            // traverses it is a black hole waiting to happen. Discovery
-            // restarts from the guaranteed floor.
-            if (path.state == .validated) {
-                path.anti_amplification = .{};
+            // Whether this datagram *begins a new validation attempt*, as
+            // opposed to arriving during one that is already running or
+            // already finished. Every fresh attempt is a new incarnation of
+            // the tuple, whatever ended the previous one — a promotion
+            // elsewhere (`.validated`), an expiry (`.failed`), or a policy
+            // block that never probed (`.unvalidated`). Getting this wrong for
+            // `.failed` in particular leaves a hole: the expired attempt's
+            // PATH_CHALLENGE can still be sitting in connection-wide recovery,
+            // and its delayed ACK would resolve against the new attempt's
+            // state as if the two were the same path lifetime.
+            const fresh_attempt = switch (path.state) {
+                .validating, .validated_pending_promotion => false,
+                .failed, .unvalidated, .validated => true,
+            };
+            if (fresh_attempt) {
+                // Same reasoning as the ledger below, for the path's measured
+                // MTU (#256-B): a tuple being re-probed is not demonstrably
+                // the path it was, and an inherited size that no longer
+                // traverses it is a black hole waiting to happen. Discovery
+                // restarts from the guaranteed floor, and the new generation
+                // makes outcomes owed by the previous incarnation droppable.
                 path.plpmtu.reset();
-                // A new incarnation of the same tuple: outcomes still owed by
-                // the previous one must not land on this fresh state.
                 path.generation = self.claimGeneration();
+                // The anti-amplification reset stays specific to `.validated`:
+                // only a previously-*validated* path carries a lifted limit
+                // that must not survive into an attempt this code deliberately
+                // chose not to skip (RFC 9000 §9.3.1). A `.failed` or
+                // `.unvalidated` path's ledger is already the conservative one
+                // its own received bytes earned.
+                if (path.state == .validated) path.anti_amplification = .{};
             }
             path.anti_amplification.recordReceived(authenticated_bytes);
             switch (path.state) {

--- a/src/quic/pmtu.zig
+++ b/src/quic/pmtu.zig
@@ -1,0 +1,649 @@
+//! Datagram Packetization Layer PMTU Discovery for pure Zig QUIC (#256-B,
+//! RFC 8899, RFC 9000 §14.3/§14.4).
+//!
+//! #256-A made the outbound datagram size a single authoritative value but
+//! left `current_path_max` an *assertion*: an operator raising the knob told
+//! the stack a path carried more than the RFC 9000 §14 floor, with nothing
+//! measuring whether that was true. This module measures it, and — just as
+//! importantly — notices when a size that used to work stops working.
+//!
+//! One `Controller` belongs to one network path. That is not incidental: the
+//! whole point of the state here is "what does *this* path carry", so a
+//! migration to a materially different path must start from the guaranteed
+//! floor rather than inherit a value discovered somewhere else. `path.Path`
+//! owns a controller per slot, so a new or recycled path slot is a new
+//! controller by construction.
+//!
+//! Nothing here does I/O, builds packets, or knows about congestion control.
+//! It answers three questions for the send path — what size may I send, is a
+//! probe due, and how big — and consumes four facts back: a probe was sent,
+//! acknowledged, or lost, and ordinary traffic succeeded or failed.
+
+const std = @import("std");
+const datagram = @import("datagram.zig");
+
+/// The only datagram size RFC 9000 §14 guarantees every QUIC path carries, so
+/// simultaneously the search floor and the size a black-hole fallback lands on.
+pub const base_size: usize = datagram.base_size;
+
+/// RFC 8899 MAX_PROBES: how many times one probe size is retried before the
+/// size is treated as unreachable. A probe is a single datagram, so ordinary
+/// congestive loss can swallow one or two without meaning anything about MTU.
+pub const max_probes: u8 = 3;
+
+/// The search stops once the remaining window is narrower than this. Chasing
+/// the last few bytes of a path MTU costs probes and round trips for no
+/// meaningful throughput, and an unbounded binary search would never converge
+/// on an integer window.
+pub const min_step: usize = 16;
+
+/// RFC 8899 PMTU_RAISE_TIMER. Only armed after a black-hole fallback: an
+/// ordinary converged search has nothing left to discover, so re-running it
+/// would only produce a probe every ten minutes forever.
+pub const raise_interval_us: u64 = 600 * std.time.us_per_s;
+
+/// Consecutive pieces of black-hole evidence required before the send size is
+/// pulled back to `base_size`. Each piece is already filtered (see
+/// `onOrdinaryLoss` and `onProbeTimeout`); this is the count on top of that.
+pub const black_hole_threshold: u8 = 3;
+
+pub const State = enum {
+    /// Nothing measured and nothing probing. Every controller starts here and
+    /// stays until the connection enables it, which the QUIC mapping does once
+    /// the handshake is confirmed (RFC 9000 §14.4 — before that the peer's
+    /// receive capacity is unknown and the handshake needs its own sizing).
+    disabled,
+    /// A probe size is chosen or outstanding.
+    searching,
+    /// The window converged, or a black hole pulled the size back. `plpmtu`
+    /// is the answer for this path until the raise timer or a reset.
+    search_complete,
+};
+
+/// Why the send size changed, for the caller's diagnostics.
+pub const SizeChange = enum {
+    /// A probe of a larger size was acknowledged.
+    raised,
+    /// Evidence that the current size no longer traverses the path.
+    black_hole,
+};
+
+pub const Controller = struct {
+    state: State = .disabled,
+
+    /// The size ordinary datagrams may use on this path: `base_size` until a
+    /// probe of something larger has actually been acknowledged. Nothing but a
+    /// delivered probe raises it, which is the whole difference from #256-A —
+    /// the size on the wire is now measured rather than asserted.
+    plpmtu: usize = base_size,
+
+    /// Largest datagram this endpoint may emit on this path at all: the
+    /// operator's configured send ceiling met with the peer's advertised
+    /// receive capacity. A probe never exceeds it, so the search runs strictly
+    /// inside `[base_size, ceiling]` and a configured maximum stays a maximum.
+    ceiling: usize = base_size,
+    /// RFC 8899 §5.3 optimistic search: the first probe on a path goes
+    /// straight for the ceiling, so an operator who configured a size their
+    /// path really carries gets exactly that in one round trip instead of a
+    /// bisection that converges near it. Cleared once that probe is sent;
+    /// everything after it bisects.
+    optimistic: bool = true,
+    /// Smallest size known not to traverse this path. The search never
+    /// proposes it or anything larger. `maxInt` means nothing has failed yet.
+    smallest_failed: usize = std.math.maxInt(usize),
+
+    /// The size currently being probed for, zero when none is chosen.
+    target_size: usize = 0,
+    /// Packet number of the outstanding probe, null when none is in flight.
+    /// Probe identity is the packet number rather than the size, so a stale
+    /// ACK or loss for an earlier probe at the same size cannot resolve the
+    /// current one.
+    outstanding_pn: ?u64 = null,
+    /// Consecutive losses at `target_size`.
+    probe_count: u8 = 0,
+
+    /// When the search may restart after a black-hole fallback.
+    raise_at_us: ?u64 = null,
+
+    /// Black-hole evidence: ordinary datagrams larger than `base_size`
+    /// declared lost, and whether anything at all has been delivered since —
+    /// "the big ones vanish while the small ones arrive" is the signature that
+    /// separates an MTU black hole from plain congestion.
+    oversized_losses: u8 = 0,
+    smaller_delivered: bool = false,
+    /// Consecutive PTO expirations while sending above the floor with nothing
+    /// acknowledged in between. The other half of the signature, for the case
+    /// where *everything* in flight is oversized so no small delivery can be
+    /// observed.
+    stalled_ptos: u8 = 0,
+
+    probes_sent: u32 = 0,
+    probes_acked: u32 = 0,
+    probes_lost: u32 = 0,
+    black_holes: u32 = 0,
+
+    /// The size ordinary datagrams may use on this path.
+    pub fn sendSize(self: Controller) usize {
+        return self.plpmtu;
+    }
+
+    /// Adopt the largest datagram this endpoint may emit on this path
+    /// (`datagram.Limits.probeCeiling()`). Cheap and idempotent — the send
+    /// path calls it every poll, so a ceiling that only becomes real when the
+    /// peer's transport parameters authenticate takes effect immediately.
+    pub fn configure(self: *Controller, ceiling: usize) void {
+        const next_ceiling = clamp(ceiling);
+        if (next_ceiling == self.ceiling) return;
+        self.ceiling = next_ceiling;
+        // A ceiling below the current size binds immediately: the peer cannot
+        // receive more than it advertised, whatever this path carries.
+        if (self.plpmtu > next_ceiling) {
+            self.plpmtu = next_ceiling;
+            self.cancelProbe();
+        }
+        if (self.state != .disabled) self.reconsider();
+    }
+
+    /// Begin discovery on this path. The QUIC mapping calls this once the
+    /// handshake is confirmed: the peer's receive capacity is authenticated by
+    /// then, and completing the handshake is itself proof the path carries
+    /// `base_size` (every Initial-bearing datagram was padded to it), which is
+    /// exactly the RFC 8899 BASE-state confirmation this would otherwise owe.
+    pub fn enable(self: *Controller, ceiling: usize) void {
+        if (self.state != .disabled) return;
+        self.configure(ceiling);
+        self.state = .searching;
+        self.reconsider();
+    }
+
+    /// Discard everything measured here. The caller uses this when the slot
+    /// starts describing a materially different path; ordinarily a migration
+    /// simply lands on a different `Path` whose controller was never used.
+    pub fn reset(self: *Controller) void {
+        const kept_ceiling = self.ceiling;
+        self.* = .{ .ceiling = kept_ceiling };
+    }
+
+    /// The size of the probe datagram to send right now, or null when none is
+    /// due: not searching, one already outstanding, or the window converged.
+    /// Pure — the caller commits with `onProbeSent` only once the probe has
+    /// actually passed its congestion and anti-amplification gates and gone
+    /// out.
+    pub fn nextProbeSize(self: *const Controller) ?usize {
+        if (self.state != .searching) return null;
+        if (self.outstanding_pn != null) return null;
+        if (self.target_size != 0) return self.target_size;
+        return self.proposedSize();
+    }
+
+    /// A probe of `nextProbeSize()` bytes went out as `packet_number`.
+    pub fn onProbeSent(self: *Controller, size: usize, packet_number: u64) void {
+        if (self.state != .searching) return;
+        self.target_size = size;
+        self.outstanding_pn = packet_number;
+        self.optimistic = false;
+        self.probes_sent +|= 1;
+    }
+
+    /// The outstanding probe was acknowledged: the path carries `target_size`,
+    /// so it becomes the send size and the search window closes from below.
+    /// Returns true when the send size actually moved.
+    pub fn onProbeAcked(self: *Controller, packet_number: u64) bool {
+        const outstanding = self.outstanding_pn orelse return false;
+        if (outstanding != packet_number) return false;
+        // A ceiling that dropped while the probe was in flight still binds:
+        // the peer cannot receive more than it advertised, whatever arrived.
+        const validated = @min(self.target_size, self.ceiling);
+        self.outstanding_pn = null;
+        self.target_size = 0;
+        self.probe_count = 0;
+        self.probes_acked +|= 1;
+        const raised = validated > self.plpmtu;
+        if (raised) self.plpmtu = validated;
+        // A larger datagram just traversed the path, so whatever evidence had
+        // accumulated against the smaller current size is stale.
+        self.clearBlackHoleEvidence();
+        self.reconsider();
+        return raised;
+    }
+
+    /// The outstanding probe was declared lost. One loss is not evidence of an
+    /// MTU limit — a probe is a single ack-eliciting datagram and congestion
+    /// loses those routinely — so the same size is retried until `max_probes`
+    /// attempts have failed, and only then is it recorded as unreachable.
+    /// Deliberately does *not* feed black-hole detection: a probe is expected
+    /// to be too big, that is what it is for.
+    pub fn onProbeLost(self: *Controller, packet_number: u64) void {
+        const outstanding = self.outstanding_pn orelse return;
+        if (outstanding != packet_number) return;
+        self.outstanding_pn = null;
+        self.probes_lost +|= 1;
+        self.probe_count +|= 1;
+        if (self.probe_count < max_probes) return;
+        self.noteFailed(self.target_size);
+        self.target_size = 0;
+        self.probe_count = 0;
+        self.reconsider();
+    }
+
+    /// An ordinary (non-probe) datagram of `size` was acknowledged. A delivery
+    /// larger than the floor proves the path still carries the current size
+    /// and clears any accumulated black-hole evidence; a smaller one is the
+    /// "and the small ones arrive" half of the black-hole signature.
+    pub fn onOrdinaryAck(self: *Controller, size: usize) void {
+        self.stalled_ptos = 0;
+        if (size > base_size) {
+            self.clearBlackHoleEvidence();
+            return;
+        }
+        if (self.oversized_losses > 0) self.smaller_delivered = true;
+    }
+
+    /// An ordinary (non-probe) datagram of `size` was declared lost. Only a
+    /// loss above the guaranteed floor is evidence about MTU at all — losing a
+    /// 1200-byte datagram says nothing a fallback could fix.
+    pub fn onOrdinaryLoss(self: *Controller, size: usize, now_us: u64) void {
+        if (size <= base_size) return;
+        self.oversized_losses +|= 1;
+        self.evaluateBlackHole(now_us);
+    }
+
+    /// A PTO expired. Consecutive expirations while sending above the floor,
+    /// with nothing acknowledged in between, is the black-hole case where no
+    /// small delivery can ever be observed because every datagram in flight is
+    /// oversized. Ignored entirely at the floor: 1200 bytes is guaranteed, so
+    /// a stall there is congestion or an outage, and no fallback exists.
+    pub fn onProbeTimeout(self: *Controller, now_us: u64) void {
+        if (self.plpmtu <= base_size) return;
+        self.stalled_ptos +|= 1;
+        self.evaluateBlackHole(now_us);
+    }
+
+    /// The next moment `onTimeout` has something to do, or null.
+    pub fn deadlineUs(self: Controller) ?u64 {
+        return self.raise_at_us;
+    }
+
+    /// Re-open the search after a black-hole fallback has held for
+    /// `raise_interval_us`. The window stays bounded below the size that black
+    /// holed (`smallest_failed` survives), so this explores what the path
+    /// carries *now* without walking back into the size that broke it.
+    pub fn onTimeout(self: *Controller, now_us: u64) void {
+        const deadline = self.raise_at_us orelse return;
+        if (now_us < deadline) return;
+        self.raise_at_us = null;
+        if (self.state == .disabled) return;
+        self.state = .searching;
+        self.reconsider();
+    }
+
+    // -- internals -------------------------------------------------------
+
+    fn clearBlackHoleEvidence(self: *Controller) void {
+        self.oversized_losses = 0;
+        self.smaller_delivered = false;
+        self.stalled_ptos = 0;
+    }
+
+    fn evaluateBlackHole(self: *Controller, now_us: u64) void {
+        const by_loss = self.oversized_losses >= black_hole_threshold and self.smaller_delivered;
+        const by_stall = self.stalled_ptos >= black_hole_threshold;
+        if (!by_loss and !by_stall) return;
+        self.enterBlackHole(now_us);
+    }
+
+    /// Pull the send size back to the one size RFC 9000 §14 guarantees, and
+    /// remember that the size we were using does not traverse this path. A
+    /// false positive costs throughput until the raise timer; not falling back
+    /// costs the connection, because Tardigrade's own retransmissions would
+    /// keep re-sending the same oversized datagram until the idle timeout.
+    fn enterBlackHole(self: *Controller, now_us: u64) void {
+        const failed = self.plpmtu;
+        self.clearBlackHoleEvidence();
+        self.cancelProbe();
+        if (failed > base_size) self.noteFailed(failed);
+        self.plpmtu = base_size;
+        self.black_holes +|= 1;
+        self.state = .search_complete;
+        self.raise_at_us = now_us +| raise_interval_us;
+    }
+
+    fn cancelProbe(self: *Controller) void {
+        self.outstanding_pn = null;
+        self.target_size = 0;
+        self.probe_count = 0;
+    }
+
+    fn noteFailed(self: *Controller, size: usize) void {
+        if (size == 0) return;
+        self.smallest_failed = @min(self.smallest_failed, size);
+    }
+
+    /// The upper end of the search window: the endpoint/peer ceiling, held
+    /// below anything already known to fail.
+    fn searchHigh(self: Controller) usize {
+        const below_failure = self.smallest_failed -| 1;
+        return @max(self.plpmtu, @min(self.ceiling, below_failure));
+    }
+
+    /// The next size worth probing. The first probe on a path reaches straight
+    /// for the ceiling (RFC 8899 §5.3), so a correctly configured path lands on
+    /// exactly the configured size in one round trip; after that the window is
+    /// bisected, biased upward so a window of exactly `min_step` still proposes
+    /// the top of the range rather than stalling one byte below it.
+    fn proposedSize(self: Controller) ?usize {
+        const high = self.searchHigh();
+        const low = self.plpmtu;
+        if (high -| low < min_step) return null;
+        if (self.optimistic) return high;
+        return low + (high - low + 1) / 2;
+    }
+
+    /// Re-derive whether there is anything left to probe for. The one place
+    /// the searching/complete transition is decided, so every caller that
+    /// changes a bound, validates a size, or rules one out agrees.
+    fn reconsider(self: *Controller) void {
+        if (self.state == .disabled) return;
+        if (self.outstanding_pn != null) return;
+        if (self.proposedSize() != null) {
+            self.state = .searching;
+            return;
+        }
+        self.target_size = 0;
+        self.state = .search_complete;
+    }
+};
+
+/// Clamp a configured or advertised bound into the range this stack can
+/// represent. Mirrors `datagram.zig`: below the RFC floor is raised rather
+/// than honoured, since no QUIC endpoint may send less and Initial padding
+/// needs it regardless.
+fn clamp(value: usize) usize {
+    return std.math.clamp(value, base_size, datagram.max_size);
+}
+
+const testing = std.testing;
+
+fn enabled(ceiling: usize) Controller {
+    var controller = Controller{};
+    controller.enable(ceiling);
+    return controller;
+}
+
+test "pmtu: a fresh controller sits at the one size RFC 9000 guarantees" {
+    const controller = Controller{};
+    try testing.expectEqual(State.disabled, controller.state);
+    try testing.expectEqual(base_size, controller.sendSize());
+    try testing.expectEqual(@as(?usize, null), controller.nextProbeSize());
+}
+
+test "pmtu: nothing probes before the connection enables discovery" {
+    var controller = Controller{};
+    controller.configure(datagram.max_size);
+    try testing.expectEqual(@as(?usize, null), controller.nextProbeSize());
+    controller.onProbeTimeout(1_000);
+    try testing.expectEqual(@as(?u64, null), controller.deadlineUs());
+}
+
+test "pmtu: a ceiling at the floor leaves nothing to discover" {
+    // The default configuration, and also the state before the peer's
+    // transport parameters authenticate: `probeCeiling()` collapses to the
+    // floor, so there is nothing to reach for and no probe is ever emitted.
+    var controller = enabled(base_size);
+    try testing.expectEqual(State.search_complete, controller.state);
+    try testing.expectEqual(@as(?usize, null), controller.nextProbeSize());
+    try testing.expectEqual(base_size, controller.sendSize());
+
+    // Raising the ceiling opens the search.
+    controller.configure(datagram.max_size);
+    try testing.expectEqual(State.searching, controller.state);
+    try testing.expect(controller.nextProbeSize() != null);
+}
+
+test "pmtu: the first probe reaches straight for the configured ceiling" {
+    var controller = enabled(1452);
+    // RFC 8899 §5.3 optimistic search: an operator whose path really carries
+    // the configured size gets exactly it, not a bisection that lands near it.
+    try testing.expectEqual(@as(usize, 1452), controller.nextProbeSize().?);
+    // Idempotent while nothing has happened: the same probe is still due.
+    try testing.expectEqual(@as(usize, 1452), controller.nextProbeSize().?);
+
+    controller.onProbeSent(1452, 1);
+    try testing.expect(controller.onProbeAcked(1));
+    try testing.expectEqual(@as(usize, 1452), controller.sendSize());
+    // Nothing above the ceiling is ever probed, so the search is done.
+    try testing.expectEqual(State.search_complete, controller.state);
+    try testing.expectEqual(@as(?usize, null), controller.nextProbeSize());
+}
+
+test "pmtu: the send size does not move while a probe is outstanding" {
+    var controller = enabled(2048);
+    const first = controller.nextProbeSize().?;
+    controller.onProbeSent(first, 7);
+    try testing.expectEqual(base_size, controller.sendSize());
+    try testing.expectEqual(@as(?usize, null), controller.nextProbeSize());
+
+    try testing.expect(controller.onProbeAcked(7));
+    try testing.expectEqual(first, controller.sendSize());
+}
+
+test "pmtu: an acknowledgement for a different packet resolves nothing" {
+    var controller = enabled(2048);
+    const size = controller.nextProbeSize().?;
+    controller.onProbeSent(size, 7);
+    try testing.expect(!controller.onProbeAcked(8));
+    try testing.expectEqual(base_size, controller.sendSize());
+    controller.onProbeLost(8);
+    try testing.expectEqual(@as(u8, 0), controller.probe_count);
+    // The real probe is still outstanding and still resolvable.
+    try testing.expect(controller.onProbeAcked(7));
+}
+
+test "pmtu: a lost probe is retried before its size is ruled out" {
+    var controller = enabled(2048);
+    const size = controller.nextProbeSize().?;
+
+    var attempt: u8 = 0;
+    while (attempt < max_probes - 1) : (attempt += 1) {
+        controller.onProbeSent(size, attempt);
+        controller.onProbeLost(attempt);
+        // Same size, because one loss is congestion until proven otherwise.
+        try testing.expectEqual(size, controller.nextProbeSize().?);
+    }
+
+    controller.onProbeSent(size, max_probes);
+    controller.onProbeLost(max_probes);
+    try testing.expectEqual(size, controller.smallest_failed);
+    // The search continues below the size that failed, never at or above it.
+    const next = controller.nextProbeSize().?;
+    try testing.expect(next < size);
+    try testing.expect(next > base_size);
+    // A failed probe is not a black hole: the send size never moved.
+    try testing.expectEqual(@as(u32, 0), controller.black_holes);
+    try testing.expectEqual(base_size, controller.sendSize());
+}
+
+test "pmtu: the search converges and stops" {
+    var controller = enabled(2048);
+    var pn: u64 = 0;
+    // Everything at or below 1452 traverses; anything above is dropped.
+    while (controller.nextProbeSize()) |size| {
+        controller.onProbeSent(size, pn);
+        if (size <= 1452) {
+            _ = controller.onProbeAcked(pn);
+        } else {
+            controller.onProbeLost(pn);
+        }
+        pn += 1;
+        try testing.expect(pn < 64); // termination, not just convergence
+    }
+    try testing.expectEqual(State.search_complete, controller.state);
+    const found = controller.sendSize();
+    try testing.expect(found <= 1452);
+    try testing.expect(found > 1452 - min_step);
+    // Converged searches do not re-arm: there is nothing left to discover.
+    try testing.expectEqual(@as(?u64, null), controller.deadlineUs());
+}
+
+test "pmtu: a lowered ceiling binds the discovered size immediately" {
+    var controller = enabled(2048);
+    const size = controller.nextProbeSize().?;
+    controller.onProbeSent(size, 1);
+    try testing.expect(controller.onProbeAcked(1));
+    try testing.expectEqual(size, controller.sendSize());
+
+    // Not negotiable: the ceiling caps the discovered value rather than being
+    // averaged with it.
+    controller.configure(1300);
+    try testing.expectEqual(@as(usize, 1300), controller.sendSize());
+    try testing.expectEqual(@as(?usize, null), controller.nextProbeSize());
+}
+
+test "pmtu: ordinary congestion loss alone is not a black hole" {
+    var controller = enabled(2048);
+    controller.onProbeSent(1452, 1);
+    _ = controller.onProbeAcked(1);
+
+    var i: u8 = 0;
+    while (i < 3 * black_hole_threshold) : (i += 1) {
+        // Big datagrams are disappearing, but so is everything else: nothing
+        // is arriving to show the path still passes small packets.
+        controller.onOrdinaryLoss(1452, 1_000);
+    }
+    try testing.expectEqual(@as(u32, 0), controller.black_holes);
+    try testing.expectEqual(@as(usize, 1452), controller.sendSize());
+}
+
+test "pmtu: oversized loss while smaller traffic arrives falls back to the floor" {
+    var controller = enabled(2048);
+    controller.onProbeSent(1452, 1);
+    _ = controller.onProbeAcked(1);
+
+    var i: u8 = 0;
+    while (i < black_hole_threshold) : (i += 1) {
+        controller.onOrdinaryLoss(1452, 1_000);
+        controller.onOrdinaryAck(base_size);
+    }
+    try testing.expectEqual(@as(u32, 1), controller.black_holes);
+    try testing.expectEqual(base_size, controller.sendSize());
+    try testing.expectEqual(@as(usize, 1452), controller.smallest_failed);
+    try testing.expectEqual(@as(?u64, 1_000 + raise_interval_us), controller.deadlineUs());
+}
+
+test "pmtu: a delivery at the current size clears accumulated evidence" {
+    var controller = enabled(2048);
+    controller.onProbeSent(1452, 1);
+    _ = controller.onProbeAcked(1);
+
+    controller.onOrdinaryLoss(1452, 1_000);
+    controller.onOrdinaryAck(base_size);
+    controller.onOrdinaryLoss(1452, 1_000);
+    // A big datagram arrived: the path carries this size after all.
+    controller.onOrdinaryAck(1452);
+    controller.onOrdinaryLoss(1452, 1_000);
+    controller.onOrdinaryAck(base_size);
+    try testing.expectEqual(@as(u32, 0), controller.black_holes);
+    try testing.expectEqual(@as(usize, 1452), controller.sendSize());
+}
+
+test "pmtu: repeated PTO above the floor falls back when nothing arrives at all" {
+    // The case `onOrdinaryLoss` cannot see: every datagram in flight is
+    // oversized, so there is no small delivery to corroborate with.
+    var controller = enabled(2048);
+    controller.onProbeSent(1452, 1);
+    _ = controller.onProbeAcked(1);
+
+    var i: u8 = 0;
+    while (i < black_hole_threshold) : (i += 1) controller.onProbeTimeout(500);
+    try testing.expectEqual(base_size, controller.sendSize());
+    try testing.expectEqual(@as(u32, 1), controller.black_holes);
+}
+
+test "pmtu: PTO at the guaranteed floor never triggers a fallback" {
+    var controller = enabled(2048);
+    var i: u8 = 0;
+    while (i < 10 * black_hole_threshold) : (i += 1) controller.onProbeTimeout(500);
+    try testing.expectEqual(@as(u32, 0), controller.black_holes);
+    try testing.expectEqual(base_size, controller.sendSize());
+}
+
+test "pmtu: an acknowledgement interrupts a run of stalled PTOs" {
+    var controller = enabled(2048);
+    controller.onProbeSent(1452, 1);
+    _ = controller.onProbeAcked(1);
+
+    controller.onProbeTimeout(500);
+    controller.onProbeTimeout(500);
+    controller.onOrdinaryAck(base_size);
+    controller.onProbeTimeout(500);
+    controller.onProbeTimeout(500);
+    try testing.expectEqual(@as(u32, 0), controller.black_holes);
+}
+
+test "pmtu: the raise timer re-searches below the size that black holed" {
+    var controller = enabled(2048);
+    controller.onProbeSent(1452, 1);
+    _ = controller.onProbeAcked(1);
+    var i: u8 = 0;
+    while (i < black_hole_threshold) : (i += 1) controller.onProbeTimeout(500);
+    const deadline = controller.deadlineUs().?;
+
+    // Early wakeups change nothing, and the deadline stays armed.
+    controller.onTimeout(deadline - 1);
+    try testing.expectEqual(State.search_complete, controller.state);
+    try testing.expectEqual(@as(?u64, deadline), controller.deadlineUs());
+
+    controller.onTimeout(deadline);
+    try testing.expectEqual(State.searching, controller.state);
+    // Disarmed, so a caller folding this into a timer wheel cannot spin on it.
+    try testing.expectEqual(@as(?u64, null), controller.deadlineUs());
+    const size = controller.nextProbeSize().?;
+    try testing.expect(size > base_size);
+    try testing.expect(size < 1452);
+}
+
+test "pmtu: a fallback with no room left below it simply stays at the floor" {
+    // Nothing between 1200 and the failed size is worth probing, so the raise
+    // timer resolves to "still nothing to do" instead of proposing 1200 itself.
+    var controller = enabled(base_size + min_step);
+    controller.onProbeSent(controller.nextProbeSize().?, 1);
+    try testing.expect(controller.onProbeAcked(1));
+    var i: u8 = 0;
+    while (i < black_hole_threshold) : (i += 1) controller.onProbeTimeout(500);
+    try testing.expectEqual(base_size, controller.sendSize());
+
+    controller.onTimeout(controller.deadlineUs().?);
+    try testing.expectEqual(@as(?usize, null), controller.nextProbeSize());
+    try testing.expectEqual(State.search_complete, controller.state);
+}
+
+test "pmtu: a reset returns the path to the guaranteed floor" {
+    var controller = enabled(2048);
+    const size = controller.nextProbeSize().?;
+    controller.onProbeSent(size, 3);
+    try testing.expect(controller.onProbeAcked(3));
+    try testing.expect(controller.sendSize() > base_size);
+
+    controller.reset();
+    // A materially different path inherits no measurement, not even a
+    // favourable one — that is the whole reason this state is per path.
+    try testing.expectEqual(State.disabled, controller.state);
+    try testing.expectEqual(base_size, controller.sendSize());
+    try testing.expectEqual(@as(?usize, null), controller.nextProbeSize());
+    try testing.expectEqual(@as(usize, std.math.maxInt(usize)), controller.smallest_failed);
+}
+
+test "pmtu: bounds outside the representable range are clamped, not trusted" {
+    var controller = enabled(std.math.maxInt(usize));
+    try testing.expectEqual(base_size, controller.sendSize());
+    try testing.expectEqual(datagram.max_size, controller.ceiling);
+    try testing.expectEqual(datagram.max_size, controller.nextProbeSize().?);
+
+    controller.configure(0);
+    try testing.expectEqual(base_size, controller.ceiling);
+    try testing.expectEqual(@as(?usize, null), controller.nextProbeSize());
+}
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/quic/pmtu.zig
+++ b/src/quic/pmtu.zig
@@ -37,9 +37,11 @@ pub const max_probes: u8 = 3;
 /// on an integer window.
 pub const min_step: usize = 16;
 
-/// RFC 8899 PMTU_RAISE_TIMER. Only armed after a black-hole fallback: an
-/// ordinary converged search has nothing left to discover, so re-running it
-/// would only produce a probe every ten minutes forever.
+/// RFC 8899 PMTU_RAISE_TIMER: how long Search Complete holds before re-entering
+/// the Search Phase. Armed whenever a search stopped because larger sizes were
+/// ruled out — by probe failure or by a black hole — since a path can gain MTU
+/// on the same address tuple and nothing else would ever notice. Not armed when
+/// the search converged at the ceiling, where there is nothing above to find.
 pub const raise_interval_us: u64 = 600 * std.time.us_per_s;
 
 /// Consecutive pieces of black-hole evidence required before the send size is
@@ -102,13 +104,14 @@ pub const Controller = struct {
     /// Consecutive losses at `target_size`.
     probe_count: u8 = 0,
 
-    /// When the search may restart after a black-hole fallback.
+    /// When Search Complete re-enters the Search Phase (RFC 8899's
+    /// `PMTU_RAISE_TIMER`), or null when there is nothing above to rediscover.
     raise_at_us: ?u64 = null,
 
-    /// Black-hole evidence: ordinary datagrams larger than `base_size`
-    /// declared lost, and whether anything at all has been delivered since —
-    /// "the big ones vanish while the small ones arrive" is the signature that
-    /// separates an MTU black hole from plain congestion.
+    /// Black-hole evidence: ordinary datagrams at or above the current
+    /// `plpmtu` declared lost, and whether anything *smaller* has been
+    /// delivered since — "the big ones vanish while the small ones arrive" is
+    /// the signature that separates an MTU black hole from plain congestion.
     oversized_losses: u8 = 0,
     smaller_delivered: bool = false,
     /// Consecutive PTO expirations while sending above the floor with nothing
@@ -131,7 +134,7 @@ pub const Controller = struct {
     /// (`datagram.Limits.probeCeiling()`). Cheap and idempotent — the send
     /// path calls it every poll, so a ceiling that only becomes real when the
     /// peer's transport parameters authenticate takes effect immediately.
-    pub fn configure(self: *Controller, ceiling: usize) void {
+    pub fn configure(self: *Controller, ceiling: usize, now_us: u64) void {
         const next_ceiling = clamp(ceiling);
         if (next_ceiling == self.ceiling) return;
         self.ceiling = next_ceiling;
@@ -141,7 +144,7 @@ pub const Controller = struct {
             self.plpmtu = next_ceiling;
             self.cancelProbe();
         }
-        if (self.state != .disabled) self.reconsider();
+        if (self.state != .disabled) self.reconsider(now_us);
     }
 
     /// Begin discovery on this path. The QUIC mapping calls this once the
@@ -149,11 +152,11 @@ pub const Controller = struct {
     /// then, and completing the handshake is itself proof the path carries
     /// `base_size` (every Initial-bearing datagram was padded to it), which is
     /// exactly the RFC 8899 BASE-state confirmation this would otherwise owe.
-    pub fn enable(self: *Controller, ceiling: usize) void {
+    pub fn enable(self: *Controller, ceiling: usize, now_us: u64) void {
         if (self.state != .disabled) return;
-        self.configure(ceiling);
+        self.configure(ceiling, now_us);
         self.state = .searching;
-        self.reconsider();
+        self.reconsider(now_us);
     }
 
     /// Discard everything measured here. The caller uses this when the slot
@@ -188,22 +191,22 @@ pub const Controller = struct {
     /// The outstanding probe was acknowledged: the path carries `target_size`,
     /// so it becomes the send size and the search window closes from below.
     /// Returns true when the send size actually moved.
-    pub fn onProbeAcked(self: *Controller, packet_number: u64) bool {
+    pub fn onProbeAcked(self: *Controller, packet_number: u64, now_us: u64) bool {
         const outstanding = self.outstanding_pn orelse return false;
         if (outstanding != packet_number) return false;
         // A ceiling that dropped while the probe was in flight still binds:
         // the peer cannot receive more than it advertised, whatever arrived.
-        const validated = @min(self.target_size, self.ceiling);
+        const confirmed = @min(self.target_size, self.ceiling);
         self.outstanding_pn = null;
         self.target_size = 0;
         self.probe_count = 0;
         self.probes_acked +|= 1;
-        const raised = validated > self.plpmtu;
-        if (raised) self.plpmtu = validated;
+        const raised = confirmed > self.plpmtu;
+        if (raised) self.plpmtu = confirmed;
         // A larger datagram just traversed the path, so whatever evidence had
         // accumulated against the smaller current size is stale.
         self.clearBlackHoleEvidence();
-        self.reconsider();
+        self.reconsider(now_us);
         return raised;
     }
 
@@ -213,7 +216,7 @@ pub const Controller = struct {
     /// attempts have failed, and only then is it recorded as unreachable.
     /// Deliberately does *not* feed black-hole detection: a probe is expected
     /// to be too big, that is what it is for.
-    pub fn onProbeLost(self: *Controller, packet_number: u64) void {
+    pub fn onProbeLost(self: *Controller, packet_number: u64, now_us: u64) void {
         const outstanding = self.outstanding_pn orelse return;
         if (outstanding != packet_number) return;
         self.outstanding_pn = null;
@@ -223,27 +226,41 @@ pub const Controller = struct {
         self.noteFailed(self.target_size);
         self.target_size = 0;
         self.probe_count = 0;
-        self.reconsider();
+        self.reconsider(now_us);
     }
 
-    /// An ordinary (non-probe) datagram of `size` was acknowledged. A delivery
-    /// larger than the floor proves the path still carries the current size
-    /// and clears any accumulated black-hole evidence; a smaller one is the
-    /// "and the small ones arrive" half of the black-hole signature.
-    pub fn onOrdinaryAck(self: *Controller, size: usize) void {
+    /// An ordinary (non-probe) datagram of `size` was acknowledged.
+    ///
+    /// The comparison is against `plpmtu` — the size whose reachability is in
+    /// question — not the RFC floor. A delivery *at or above* it disproves a
+    /// black hole outright; one *below* it corroborates the larger losses,
+    /// because "the big ones vanish while the small ones arrive" is the whole
+    /// signature. Measuring against the floor instead would let a 1300-byte
+    /// delivery clear the evidence that 1452 has stopped working, which is
+    /// precisely the case the fallback exists for.
+    ///
+    /// Corroboration evaluates immediately: three losses followed by the first
+    /// smaller delivery is already the full signature, and waiting for an
+    /// unrelated fourth loss to notice would leave the connection sending into
+    /// a black hole for another round.
+    pub fn onOrdinaryAck(self: *Controller, size: usize, now_us: u64) void {
         self.stalled_ptos = 0;
-        if (size > base_size) {
+        if (size >= self.plpmtu) {
             self.clearBlackHoleEvidence();
             return;
         }
-        if (self.oversized_losses > 0) self.smaller_delivered = true;
+        if (self.oversized_losses == 0) return;
+        self.smaller_delivered = true;
+        self.evaluateBlackHole(now_us);
     }
 
     /// An ordinary (non-probe) datagram of `size` was declared lost. Only a
-    /// loss above the guaranteed floor is evidence about MTU at all — losing a
-    /// 1200-byte datagram says nothing a fallback could fix.
+    /// loss at or above the current send size is evidence about *this* size's
+    /// reachability: losing a smaller datagram says nothing a fallback to
+    /// `base_size` could fix, and neither does any loss while already sitting
+    /// at the floor.
     pub fn onOrdinaryLoss(self: *Controller, size: usize, now_us: u64) void {
-        if (size <= base_size) return;
+        if (self.plpmtu <= base_size or size < self.plpmtu) return;
         self.oversized_losses +|= 1;
         self.evaluateBlackHole(now_us);
     }
@@ -264,17 +281,27 @@ pub const Controller = struct {
         return self.raise_at_us;
     }
 
-    /// Re-open the search after a black-hole fallback has held for
-    /// `raise_interval_us`. The window stays bounded below the size that black
-    /// holed (`smallest_failed` survives), so this explores what the path
-    /// carries *now* without walking back into the size that broke it.
+    /// RFC 8899 §5.2: Search Complete re-enters the Search Phase when
+    /// `PMTU_RAISE_TIMER` expires. A path can gain MTU on the same address
+    /// tuple — a tunnel goes away, a route changes — and nothing else would
+    /// ever notice, since the size that failed is otherwise ruled out for the
+    /// life of the path.
+    ///
+    /// Everything learned about the *old* path condition is therefore stale by
+    /// definition and is discarded: `smallest_failed` is relaxed so the sizes
+    /// that previously failed can be reconsidered, and the search restarts
+    /// optimistically. This applies equally after a black-hole fallback — the
+    /// point of the timer is to re-test, and the fallback machinery is what
+    /// makes re-testing safe if the path is still broken.
     pub fn onTimeout(self: *Controller, now_us: u64) void {
         const deadline = self.raise_at_us orelse return;
         if (now_us < deadline) return;
         self.raise_at_us = null;
         if (self.state == .disabled) return;
+        self.smallest_failed = std.math.maxInt(usize);
+        self.optimistic = true;
         self.state = .searching;
-        self.reconsider();
+        self.reconsider(now_us);
     }
 
     // -- internals -------------------------------------------------------
@@ -304,8 +331,7 @@ pub const Controller = struct {
         if (failed > base_size) self.noteFailed(failed);
         self.plpmtu = base_size;
         self.black_holes +|= 1;
-        self.state = .search_complete;
-        self.raise_at_us = now_us +| raise_interval_us;
+        self.completeSearch(now_us);
     }
 
     fn cancelProbe(self: *Controller) void {
@@ -342,15 +368,29 @@ pub const Controller = struct {
     /// Re-derive whether there is anything left to probe for. The one place
     /// the searching/complete transition is decided, so every caller that
     /// changes a bound, validates a size, or rules one out agrees.
-    fn reconsider(self: *Controller) void {
+    fn reconsider(self: *Controller, now_us: u64) void {
         if (self.state == .disabled) return;
         if (self.outstanding_pn != null) return;
         if (self.proposedSize() != null) {
             self.state = .searching;
+            self.raise_at_us = null;
             return;
         }
+        self.completeSearch(now_us);
+    }
+
+    /// Settle into Search Complete, arming RFC 8899's `PMTU_RAISE_TIMER` only
+    /// when the search stopped *because larger sizes were ruled out*. A search
+    /// that converged at the ceiling has nothing above it to rediscover, so a
+    /// timer there would wake the connection every ten minutes to reach the
+    /// same conclusion.
+    fn completeSearch(self: *Controller, now_us: u64) void {
         self.target_size = 0;
         self.state = .search_complete;
+        self.raise_at_us = if (self.smallest_failed != std.math.maxInt(usize))
+            now_us +| raise_interval_us
+        else
+            null;
     }
 };
 
@@ -366,8 +406,36 @@ const testing = std.testing;
 
 fn enabled(ceiling: usize) Controller {
     var controller = Controller{};
-    controller.enable(ceiling);
+    controller.enable(ceiling, 0);
     return controller;
+}
+
+/// A controller whose search has already validated `ceiling` on a path that
+/// carries it — the ordinary way a connection arrives at a raised send size.
+fn validated(ceiling: usize) Controller {
+    var controller = enabled(ceiling);
+    const size = controller.nextProbeSize().?;
+    controller.onProbeSent(size, 1);
+    _ = controller.onProbeAcked(1, 0);
+    return controller;
+}
+
+/// Drive the search to completion against a simulated path that carries
+/// `path_mtu` and nothing larger. Packet numbers come from the controller's own
+/// monotonic probe count, so repeated runs never collide.
+fn converge(controller: *Controller, path_mtu: usize, now_us: u64) !void {
+    var guard: usize = 0;
+    while (controller.nextProbeSize()) |size| {
+        const pn: u64 = @as(u64, controller.probes_sent) + 1;
+        controller.onProbeSent(size, pn);
+        if (size <= path_mtu) {
+            _ = controller.onProbeAcked(pn, now_us);
+        } else {
+            controller.onProbeLost(pn, now_us);
+        }
+        guard += 1;
+        if (guard > 64) return error.SearchDidNotTerminate;
+    }
 }
 
 test "pmtu: a fresh controller sits at the one size RFC 9000 guarantees" {
@@ -379,23 +447,24 @@ test "pmtu: a fresh controller sits at the one size RFC 9000 guarantees" {
 
 test "pmtu: nothing probes before the connection enables discovery" {
     var controller = Controller{};
-    controller.configure(datagram.max_size);
+    controller.configure(datagram.max_size, 0);
     try testing.expectEqual(@as(?usize, null), controller.nextProbeSize());
     controller.onProbeTimeout(1_000);
     try testing.expectEqual(@as(?u64, null), controller.deadlineUs());
 }
 
 test "pmtu: a ceiling at the floor leaves nothing to discover" {
-    // The default configuration, and also the state before the peer's
-    // transport parameters authenticate: `probeCeiling()` collapses to the
-    // floor, so there is nothing to reach for and no probe is ever emitted.
+    // The state before the peer's transport parameters authenticate:
+    // `probeCeiling()` collapses to the floor, so there is nothing to reach
+    // for and no probe is ever emitted.
     var controller = enabled(base_size);
     try testing.expectEqual(State.search_complete, controller.state);
     try testing.expectEqual(@as(?usize, null), controller.nextProbeSize());
     try testing.expectEqual(base_size, controller.sendSize());
+    // Nothing was ruled out, so nothing is worth waking up to reconsider.
+    try testing.expectEqual(@as(?u64, null), controller.deadlineUs());
 
-    // Raising the ceiling opens the search.
-    controller.configure(datagram.max_size);
+    controller.configure(datagram.max_size, 0);
     try testing.expectEqual(State.searching, controller.state);
     try testing.expect(controller.nextProbeSize() != null);
 }
@@ -405,15 +474,17 @@ test "pmtu: the first probe reaches straight for the configured ceiling" {
     // RFC 8899 §5.3 optimistic search: an operator whose path really carries
     // the configured size gets exactly it, not a bisection that lands near it.
     try testing.expectEqual(@as(usize, 1452), controller.nextProbeSize().?);
-    // Idempotent while nothing has happened: the same probe is still due.
     try testing.expectEqual(@as(usize, 1452), controller.nextProbeSize().?);
 
     controller.onProbeSent(1452, 1);
-    try testing.expect(controller.onProbeAcked(1));
+    try testing.expect(controller.onProbeAcked(1, 0));
     try testing.expectEqual(@as(usize, 1452), controller.sendSize());
-    // Nothing above the ceiling is ever probed, so the search is done.
     try testing.expectEqual(State.search_complete, controller.state);
     try testing.expectEqual(@as(?usize, null), controller.nextProbeSize());
+    // Converged *at* the ceiling: nothing above it exists to rediscover, so no
+    // raise timer. Otherwise every such connection would wake every ten
+    // minutes to reach the same conclusion.
+    try testing.expectEqual(@as(?u64, null), controller.deadlineUs());
 }
 
 test "pmtu: the send size does not move while a probe is outstanding" {
@@ -423,7 +494,7 @@ test "pmtu: the send size does not move while a probe is outstanding" {
     try testing.expectEqual(base_size, controller.sendSize());
     try testing.expectEqual(@as(?usize, null), controller.nextProbeSize());
 
-    try testing.expect(controller.onProbeAcked(7));
+    try testing.expect(controller.onProbeAcked(7, 0));
     try testing.expectEqual(first, controller.sendSize());
 }
 
@@ -431,12 +502,11 @@ test "pmtu: an acknowledgement for a different packet resolves nothing" {
     var controller = enabled(2048);
     const size = controller.nextProbeSize().?;
     controller.onProbeSent(size, 7);
-    try testing.expect(!controller.onProbeAcked(8));
+    try testing.expect(!controller.onProbeAcked(8, 0));
     try testing.expectEqual(base_size, controller.sendSize());
-    controller.onProbeLost(8);
+    controller.onProbeLost(8, 0);
     try testing.expectEqual(@as(u8, 0), controller.probe_count);
-    // The real probe is still outstanding and still resolvable.
-    try testing.expect(controller.onProbeAcked(7));
+    try testing.expect(controller.onProbeAcked(7, 0));
 }
 
 test "pmtu: a lost probe is retried before its size is ruled out" {
@@ -446,15 +516,14 @@ test "pmtu: a lost probe is retried before its size is ruled out" {
     var attempt: u8 = 0;
     while (attempt < max_probes - 1) : (attempt += 1) {
         controller.onProbeSent(size, attempt);
-        controller.onProbeLost(attempt);
+        controller.onProbeLost(attempt, 0);
         // Same size, because one loss is congestion until proven otherwise.
         try testing.expectEqual(size, controller.nextProbeSize().?);
     }
 
     controller.onProbeSent(size, max_probes);
-    controller.onProbeLost(max_probes);
+    controller.onProbeLost(max_probes, 0);
     try testing.expectEqual(size, controller.smallest_failed);
-    // The search continues below the size that failed, never at or above it.
     const next = controller.nextProbeSize().?;
     try testing.expect(next < size);
     try testing.expect(next > base_size);
@@ -465,94 +534,100 @@ test "pmtu: a lost probe is retried before its size is ruled out" {
 
 test "pmtu: the search converges and stops" {
     var controller = enabled(2048);
-    var pn: u64 = 0;
-    // Everything at or below 1452 traverses; anything above is dropped.
-    while (controller.nextProbeSize()) |size| {
-        controller.onProbeSent(size, pn);
-        if (size <= 1452) {
-            _ = controller.onProbeAcked(pn);
-        } else {
-            controller.onProbeLost(pn);
-        }
-        pn += 1;
-        try testing.expect(pn < 64); // termination, not just convergence
-    }
+    try converge(&controller, 1452, 0);
+
     try testing.expectEqual(State.search_complete, controller.state);
     const found = controller.sendSize();
     try testing.expect(found <= 1452);
     try testing.expect(found > 1452 - min_step);
-    // Converged searches do not re-arm: there is nothing left to discover.
-    try testing.expectEqual(@as(?u64, null), controller.deadlineUs());
+    // It converged *below* the ceiling because larger sizes failed, so RFC
+    // 8899's raise timer is armed to reconsider them later.
+    try testing.expect(controller.deadlineUs() != null);
 }
 
 test "pmtu: a lowered ceiling binds the discovered size immediately" {
-    var controller = enabled(2048);
-    const size = controller.nextProbeSize().?;
-    controller.onProbeSent(size, 1);
-    try testing.expect(controller.onProbeAcked(1));
-    try testing.expectEqual(size, controller.sendSize());
+    var controller = validated(2048);
+    try testing.expectEqual(@as(usize, 2048), controller.sendSize());
 
-    // Not negotiable: the ceiling caps the discovered value rather than being
-    // averaged with it.
-    controller.configure(1300);
+    controller.configure(1300, 0);
     try testing.expectEqual(@as(usize, 1300), controller.sendSize());
     try testing.expectEqual(@as(?usize, null), controller.nextProbeSize());
 }
 
-test "pmtu: ordinary congestion loss alone is not a black hole" {
-    var controller = enabled(2048);
-    controller.onProbeSent(1452, 1);
-    _ = controller.onProbeAcked(1);
+// -- black-hole detection ---------------------------------------------------
 
+test "pmtu: ordinary congestion loss alone is not a black hole" {
+    var controller = validated(1452);
     var i: u8 = 0;
     while (i < 3 * black_hole_threshold) : (i += 1) {
         // Big datagrams are disappearing, but so is everything else: nothing
-        // is arriving to show the path still passes small packets.
+        // arrives to show the path still passes smaller packets.
         controller.onOrdinaryLoss(1452, 1_000);
     }
     try testing.expectEqual(@as(u32, 0), controller.black_holes);
     try testing.expectEqual(@as(usize, 1452), controller.sendSize());
 }
 
-test "pmtu: oversized loss while smaller traffic arrives falls back to the floor" {
-    var controller = enabled(2048);
-    controller.onProbeSent(1452, 1);
-    _ = controller.onProbeAcked(1);
-
+test "pmtu: delivery below the suspect size corroborates rather than clears" {
+    // The #256-B review case: PLPMTU 1452 stops traversing while 1300-byte
+    // datagrams still arrive. Comparing deliveries against the RFC floor would
+    // read 1300 as "the path still carries the current size" and clear the
+    // evidence — which is exactly the black hole the fallback exists for.
+    var controller = validated(1452);
     var i: u8 = 0;
     while (i < black_hole_threshold) : (i += 1) {
         controller.onOrdinaryLoss(1452, 1_000);
-        controller.onOrdinaryAck(base_size);
+        controller.onOrdinaryAck(1300, 1_000);
     }
     try testing.expectEqual(@as(u32, 1), controller.black_holes);
     try testing.expectEqual(base_size, controller.sendSize());
     try testing.expectEqual(@as(usize, 1452), controller.smallest_failed);
-    try testing.expectEqual(@as(?u64, 1_000 + raise_interval_us), controller.deadlineUs());
+}
+
+test "pmtu: corroboration falls back immediately, not on an unrelated later loss" {
+    var controller = validated(1452);
+    var i: u8 = 0;
+    while (i < black_hole_threshold) : (i += 1) controller.onOrdinaryLoss(1452, 1_000);
+    // Full loss evidence, no corroboration yet.
+    try testing.expectEqual(@as(u32, 0), controller.black_holes);
+
+    // The very first smaller delivery completes the signature. Waiting for a
+    // fourth loss to notice would send another round into the black hole.
+    controller.onOrdinaryAck(1300, 2_000);
+    try testing.expectEqual(@as(u32, 1), controller.black_holes);
+    try testing.expectEqual(base_size, controller.sendSize());
 }
 
 test "pmtu: a delivery at the current size clears accumulated evidence" {
-    var controller = enabled(2048);
-    controller.onProbeSent(1452, 1);
-    _ = controller.onProbeAcked(1);
+    var controller = validated(1452);
+    controller.onOrdinaryLoss(1452, 1_000);
+    controller.onOrdinaryAck(1300, 1_000);
+    controller.onOrdinaryLoss(1452, 1_000);
+    // A datagram at the suspect size arrived: the path carries it after all.
+    controller.onOrdinaryAck(1452, 1_000);
+    controller.onOrdinaryLoss(1452, 1_000);
+    controller.onOrdinaryAck(1300, 1_000);
+    try testing.expectEqual(@as(u32, 0), controller.black_holes);
+    try testing.expectEqual(@as(usize, 1452), controller.sendSize());
+}
 
-    controller.onOrdinaryLoss(1452, 1_000);
-    controller.onOrdinaryAck(base_size);
-    controller.onOrdinaryLoss(1452, 1_000);
-    // A big datagram arrived: the path carries this size after all.
-    controller.onOrdinaryAck(1452);
-    controller.onOrdinaryLoss(1452, 1_000);
-    controller.onOrdinaryAck(base_size);
+test "pmtu: losing a datagram smaller than the send size is not MTU evidence" {
+    // A 1201-byte datagram being lost says nothing about whether 1452 still
+    // traverses, and a fallback to 1200 would not have saved it.
+    var controller = validated(1452);
+    var i: u8 = 0;
+    while (i < 3 * black_hole_threshold) : (i += 1) {
+        controller.onOrdinaryLoss(base_size + 1, 1_000);
+        controller.onOrdinaryAck(1300, 1_000);
+    }
     try testing.expectEqual(@as(u32, 0), controller.black_holes);
     try testing.expectEqual(@as(usize, 1452), controller.sendSize());
 }
 
 test "pmtu: repeated PTO above the floor falls back when nothing arrives at all" {
     // The case `onOrdinaryLoss` cannot see: every datagram in flight is
-    // oversized, so there is no small delivery to corroborate with.
-    var controller = enabled(2048);
-    controller.onProbeSent(1452, 1);
-    _ = controller.onProbeAcked(1);
-
+    // oversized, so there is no smaller delivery to corroborate with.
+    var controller = validated(1452);
     var i: u8 = 0;
     while (i < black_hole_threshold) : (i += 1) controller.onProbeTimeout(500);
     try testing.expectEqual(base_size, controller.sendSize());
@@ -567,28 +642,30 @@ test "pmtu: PTO at the guaranteed floor never triggers a fallback" {
     try testing.expectEqual(base_size, controller.sendSize());
 }
 
-test "pmtu: an acknowledgement interrupts a run of stalled PTOs" {
-    var controller = enabled(2048);
-    controller.onProbeSent(1452, 1);
-    _ = controller.onProbeAcked(1);
-
+test "pmtu: a delivery at the send size interrupts a run of stalled PTOs" {
+    var controller = validated(1452);
     controller.onProbeTimeout(500);
     controller.onProbeTimeout(500);
-    controller.onOrdinaryAck(base_size);
+    controller.onOrdinaryAck(1452, 500);
     controller.onProbeTimeout(500);
     controller.onProbeTimeout(500);
     try testing.expectEqual(@as(u32, 0), controller.black_holes);
 }
 
-test "pmtu: the raise timer re-searches below the size that black holed" {
-    var controller = enabled(2048);
-    controller.onProbeSent(1452, 1);
-    _ = controller.onProbeAcked(1);
-    var i: u8 = 0;
-    while (i < black_hole_threshold) : (i += 1) controller.onProbeTimeout(500);
-    const deadline = controller.deadlineUs().?;
+// -- the raise timer --------------------------------------------------------
 
-    // Early wakeups change nothing, and the deadline stays armed.
+test "pmtu: a converged search rediscovers a path that later gains MTU" {
+    // RFC 8899 §5.2: Search Complete re-enters the Search Phase so a route or
+    // tunnel change that raises the PMTU on the same tuple is not invisible
+    // for the life of the path.
+    var controller = enabled(2048);
+    try converge(&controller, 1452, 0);
+    const first = controller.sendSize();
+    try testing.expect(first <= 1452);
+    try testing.expect(first > base_size);
+
+    const deadline = controller.deadlineUs() orelse return error.TestExpectedEqual;
+    // Early wakeups change nothing and leave the timer armed.
     controller.onTimeout(deadline - 1);
     try testing.expectEqual(State.search_complete, controller.state);
     try testing.expectEqual(@as(?u64, deadline), controller.deadlineUs());
@@ -597,31 +674,43 @@ test "pmtu: the raise timer re-searches below the size that black holed" {
     try testing.expectEqual(State.searching, controller.state);
     // Disarmed, so a caller folding this into a timer wheel cannot spin on it.
     try testing.expectEqual(@as(?u64, null), controller.deadlineUs());
-    const size = controller.nextProbeSize().?;
-    try testing.expect(size > base_size);
-    try testing.expect(size < 1452);
+    // The previous failure bound described the *old* path condition and is
+    // stale, so the sizes it ruled out are reachable again.
+    try testing.expectEqual(@as(usize, std.math.maxInt(usize)), controller.smallest_failed);
+
+    // The path now carries everything.
+    try converge(&controller, 2048, deadline);
+    try testing.expectEqual(@as(usize, 2048), controller.sendSize());
+    try testing.expect(controller.sendSize() > first);
+    // Converged at the ceiling this time, so it stops waking up.
+    try testing.expectEqual(@as(?u64, null), controller.deadlineUs());
 }
 
-test "pmtu: a fallback with no room left below it simply stays at the floor" {
-    // Nothing between 1200 and the failed size is worth probing, so the raise
-    // timer resolves to "still nothing to do" instead of proposing 1200 itself.
-    var controller = enabled(base_size + min_step);
-    controller.onProbeSent(controller.nextProbeSize().?, 1);
-    try testing.expect(controller.onProbeAcked(1));
+test "pmtu: a black-hole fallback re-tests the failed size after the raise timer" {
+    var controller = validated(1452);
     var i: u8 = 0;
     while (i < black_hole_threshold) : (i += 1) controller.onProbeTimeout(500);
     try testing.expectEqual(base_size, controller.sendSize());
 
-    controller.onTimeout(controller.deadlineUs().?);
-    try testing.expectEqual(@as(?usize, null), controller.nextProbeSize());
-    try testing.expectEqual(State.search_complete, controller.state);
+    const deadline = controller.deadlineUs() orelse return error.TestExpectedEqual;
+    controller.onTimeout(deadline);
+    try testing.expectEqual(State.searching, controller.state);
+    // Re-testing is the point of the timer, and the fallback machinery is what
+    // makes it safe: if the path is still broken the probe simply fails again.
+    try converge(&controller, 1452, deadline);
+    try testing.expectEqual(@as(usize, 1452), controller.sendSize());
+}
+
+test "pmtu: a search that converged at the ceiling does not wake up again" {
+    var controller = enabled(1452);
+    try converge(&controller, 2048, 0);
+    try testing.expectEqual(@as(usize, 1452), controller.sendSize());
+    try testing.expectEqual(@as(usize, std.math.maxInt(usize)), controller.smallest_failed);
+    try testing.expectEqual(@as(?u64, null), controller.deadlineUs());
 }
 
 test "pmtu: a reset returns the path to the guaranteed floor" {
-    var controller = enabled(2048);
-    const size = controller.nextProbeSize().?;
-    controller.onProbeSent(size, 3);
-    try testing.expect(controller.onProbeAcked(3));
+    var controller = validated(2048);
     try testing.expect(controller.sendSize() > base_size);
 
     controller.reset();
@@ -631,6 +720,7 @@ test "pmtu: a reset returns the path to the guaranteed floor" {
     try testing.expectEqual(base_size, controller.sendSize());
     try testing.expectEqual(@as(?usize, null), controller.nextProbeSize());
     try testing.expectEqual(@as(usize, std.math.maxInt(usize)), controller.smallest_failed);
+    try testing.expectEqual(@as(?u64, null), controller.deadlineUs());
 }
 
 test "pmtu: bounds outside the representable range are clamped, not trusted" {
@@ -639,7 +729,7 @@ test "pmtu: bounds outside the representable range are clamped, not trusted" {
     try testing.expectEqual(datagram.max_size, controller.ceiling);
     try testing.expectEqual(datagram.max_size, controller.nextProbeSize().?);
 
-    controller.configure(0);
+    controller.configure(0, 0);
     try testing.expectEqual(base_size, controller.ceiling);
     try testing.expectEqual(@as(?usize, null), controller.nextProbeSize());
 }

--- a/src/quic/recovery.zig
+++ b/src/quic/recovery.zig
@@ -243,6 +243,13 @@ pub const SentPacket = struct {
     ack_eliciting: bool = true,
     in_flight: bool = true,
     lost: bool = false,
+    /// A DPLPMTUD probe (#256-B). It is in flight and consumes congestion
+    /// window like anything else, but RFC 9000 §14.4 is explicit that losing
+    /// one is *not* a reliable congestion signal — an oversized datagram is
+    /// expected to be dropped by a path too small for it, which says nothing
+    /// about queue depth. Its bytes still leave the in-flight ledger; only the
+    /// window reduction is withheld.
+    pmtu_probe: bool = false,
 };
 
 pub const AckResult = struct {
@@ -253,8 +260,18 @@ pub const AckResult = struct {
 pub const LossResult = struct {
     packet_threshold_losses: usize = 0,
     time_threshold_losses: usize = 0,
+    /// Every in-flight byte declared lost, probes included. This is the
+    /// ledger figure — all of it must leave `bytes_in_flight`.
     lost_bytes: usize = 0,
     largest_lost_time_sent_us: ?u64 = null,
+    /// The subset of `lost_bytes` belonging to DPLPMTUD probes, which
+    /// RFC 9000 §14.4 excludes from the congestion reaction.
+    probe_lost_bytes: usize = 0,
+    /// The largest ordinary (non-probe) lost packet's size and send time: the
+    /// inputs to the congestion event and to black-hole detection, both of
+    /// which must ignore probes.
+    largest_ordinary_lost_size: usize = 0,
+    largest_ordinary_lost_time_sent_us: ?u64 = null,
 };
 
 pub const PacketTracker = struct {
@@ -347,6 +364,16 @@ pub const PacketTracker = struct {
         if (packet.in_flight) result.lost_bytes += packet.size;
         if (result.largest_lost_time_sent_us == null or packet.time_sent_us > result.largest_lost_time_sent_us.?) {
             result.largest_lost_time_sent_us = packet.time_sent_us;
+        }
+        if (packet.pmtu_probe) {
+            if (packet.in_flight) result.probe_lost_bytes += packet.size;
+            return;
+        }
+        result.largest_ordinary_lost_size = @max(result.largest_ordinary_lost_size, packet.size);
+        if (result.largest_ordinary_lost_time_sent_us == null or
+            packet.time_sent_us > result.largest_ordinary_lost_time_sent_us.?)
+        {
+            result.largest_ordinary_lost_time_sent_us = packet.time_sent_us;
         }
     }
 
@@ -537,6 +564,15 @@ pub const CongestionController = struct {
         self.ssthresh = self.congestion_window;
     }
 
+    /// Release lost DPLPMTUD probe bytes from the in-flight ledger without a
+    /// congestion event (RFC 9000 §14.4). The bytes were genuinely in flight
+    /// and must be reclaimed, but a probe deliberately sized larger than the
+    /// path is not evidence of congestion, and halving the window every time
+    /// discovery overshoots would make probing cost throughput.
+    pub fn onProbePacketsLost(self: *CongestionController, lost_bytes: usize) void {
+        self.bytes_in_flight -|= lost_bytes;
+    }
+
     pub fn onPersistentCongestion(self: *CongestionController) void {
         self.congestion_window = self.minWindow();
         self.ssthresh = self.congestion_window;
@@ -634,7 +670,14 @@ pub const RecoveryController = struct {
     pub fn detectLost(self: *RecoveryController, space: PacketNumberSpace, now_us: u64) LossResult {
         const result = self.tracker.detectLost(space, now_us, self.rtt);
         if (result.lost_bytes > 0) {
-            self.congestion.onPacketsLost(result.largest_lost_time_sent_us.?, result.lost_bytes, now_us);
+            // Probe bytes leave the ledger but drive no congestion event
+            // (RFC 9000 §14.4), and the event's timestamp comes from ordinary
+            // traffic so a probe cannot start a recovery period on its own.
+            if (result.probe_lost_bytes > 0) self.congestion.onProbePacketsLost(result.probe_lost_bytes);
+            const congestion_bytes = result.lost_bytes - result.probe_lost_bytes;
+            if (congestion_bytes > 0) {
+                self.congestion.onPacketsLost(result.largest_ordinary_lost_time_sent_us.?, congestion_bytes, now_us);
+            }
             self.events.emit(.{
                 .kind = .packet_lost,
                 .space = space,
@@ -995,6 +1038,80 @@ test "recovery: a padded non-ack-eliciting packet is charged to the window" {
         .in_flight = true,
     });
     try testing.expectEqual(@as(usize, 1200), controller.congestion.bytes_in_flight);
+}
+
+// ---------------------------------------------------------------------------
+// #256-B: a DPLPMTUD probe is in flight, but losing one is not congestion.
+// ---------------------------------------------------------------------------
+
+test "recovery: a lost PMTU probe returns its bytes without a congestion event" {
+    var controller = RecoveryController{};
+    const window_before = controller.congestion.congestion_window;
+
+    try controller.onPacketSent(.{
+        .space = .application,
+        .packet_number = 1,
+        .time_sent_us = 0,
+        .size = 1_624,
+        .pmtu_probe = true,
+    });
+    // A probe consumes window like anything else while it is outstanding.
+    try testing.expectEqual(@as(usize, 1_624), controller.congestion.bytes_in_flight);
+
+    // Later ordinary packets get through, which is what declares the probe
+    // lost by packet threshold — exactly the black-hole-free case where the
+    // path simply cannot carry the probed size.
+    var pn: u64 = 2;
+    while (pn <= 5) : (pn += 1) {
+        try controller.onPacketSent(.{ .space = .application, .packet_number = pn, .time_sent_us = pn, .size = 100 });
+    }
+    controller.onAcked(.application, 5, 1_000, 0);
+
+    const loss = controller.detectLost(.application, 1_000);
+    try testing.expectEqual(@as(usize, 1_624), loss.probe_lost_bytes);
+    try testing.expect(loss.lost_bytes > loss.probe_lost_bytes);
+    // The ordinary packets lost alongside it still count, and only their size
+    // reaches black-hole detection.
+    try testing.expectEqual(@as(usize, 100), loss.largest_ordinary_lost_size);
+    // The window was cut once, by the ordinary loss — never by the probe.
+    try testing.expect(controller.congestion.congestion_window < window_before);
+    try testing.expectEqual(controller.congestion.congestion_window, controller.congestion.ssthresh);
+    // Every lost byte, probe included, left both in-flight ledgers, leaving
+    // only the two packets that are neither acked nor yet declared lost.
+    try testing.expectEqual(@as(usize, 200), controller.tracker.bytes_in_flight);
+    try testing.expectEqual(@as(usize, 200), controller.congestion.bytes_in_flight);
+}
+
+test "recovery: a probe lost on its own leaves the congestion window untouched" {
+    var controller = RecoveryController{};
+    controller.congestion.congestion_window = 30_000;
+    controller.congestion.ssthresh = 30_000;
+
+    try controller.onPacketSent(.{
+        .space = .application,
+        .packet_number = 1,
+        .time_sent_us = 0,
+        .size = 1_624,
+        .pmtu_probe = true,
+    });
+    // Exactly `packet_threshold` newer packets, so the probe is the only thing
+    // far enough behind the acknowledged one to be declared lost.
+    try controller.onPacketSent(.{ .space = .application, .packet_number = 2, .time_sent_us = 10, .size = 200 });
+    try controller.onPacketSent(.{ .space = .application, .packet_number = 3, .time_sent_us = 20, .size = 200 });
+    try controller.onPacketSent(.{ .space = .application, .packet_number = 4, .time_sent_us = 30, .size = 200 });
+    controller.onAcked(.application, 4, 100, 0);
+    const window_before = controller.congestion.congestion_window;
+    const ssthresh_before = controller.congestion.ssthresh;
+
+    const loss = controller.detectLost(.application, 100);
+    try testing.expectEqual(@as(usize, 1_624), loss.lost_bytes);
+    try testing.expectEqual(loss.lost_bytes, loss.probe_lost_bytes);
+    try testing.expectEqual(@as(usize, 0), loss.largest_ordinary_lost_size);
+    try testing.expectEqual(@as(?u64, null), loss.largest_ordinary_lost_time_sent_us);
+    try testing.expectEqual(window_before, controller.congestion.congestion_window);
+    try testing.expectEqual(ssthresh_before, controller.congestion.ssthresh);
+    try testing.expectEqual(@as(?u64, null), controller.congestion.recovery_start_time_us);
+    try testing.expectEqual(@as(usize, 400), controller.congestion.bytes_in_flight);
 }
 
 test "recovery: ordinary traffic stays bounded while required recovery spills past the fixed tracker" {

--- a/src/quic/recovery.zig
+++ b/src/quic/recovery.zig
@@ -267,10 +267,11 @@ pub const LossResult = struct {
     /// The subset of `lost_bytes` belonging to DPLPMTUD probes, which
     /// RFC 9000 §14.4 excludes from the congestion reaction.
     probe_lost_bytes: usize = 0,
-    /// The largest ordinary (non-probe) lost packet's size and send time: the
-    /// inputs to the congestion event and to black-hole detection, both of
-    /// which must ignore probes.
-    largest_ordinary_lost_size: usize = 0,
+    /// Send time of the most recent ordinary (non-probe) lost packet: the
+    /// congestion event's timestamp, so a probe cannot start a recovery period
+    /// on its own. Deliberately *not* accompanied by an aggregate lost size —
+    /// DPLPMTUD evidence is per path, and a single number here would collapse
+    /// losses from several paths into one (#256-B review).
     largest_ordinary_lost_time_sent_us: ?u64 = null,
 };
 
@@ -369,7 +370,6 @@ pub const PacketTracker = struct {
             if (packet.in_flight) result.probe_lost_bytes += packet.size;
             return;
         }
-        result.largest_ordinary_lost_size = @max(result.largest_ordinary_lost_size, packet.size);
         if (result.largest_ordinary_lost_time_sent_us == null or
             packet.time_sent_us > result.largest_ordinary_lost_time_sent_us.?)
         {
@@ -1070,9 +1070,9 @@ test "recovery: a lost PMTU probe returns its bytes without a congestion event" 
     const loss = controller.detectLost(.application, 1_000);
     try testing.expectEqual(@as(usize, 1_624), loss.probe_lost_bytes);
     try testing.expect(loss.lost_bytes > loss.probe_lost_bytes);
-    // The ordinary packets lost alongside it still count, and only their size
-    // reaches black-hole detection.
-    try testing.expectEqual(@as(usize, 100), loss.largest_ordinary_lost_size);
+    // The ordinary loss supplies the congestion event's timestamp; the probe
+    // must not, or a probe could start a recovery period on its own.
+    try testing.expectEqual(@as(?u64, 2), loss.largest_ordinary_lost_time_sent_us);
     // The window was cut once, by the ordinary loss — never by the probe.
     try testing.expect(controller.congestion.congestion_window < window_before);
     try testing.expectEqual(controller.congestion.congestion_window, controller.congestion.ssthresh);
@@ -1106,7 +1106,6 @@ test "recovery: a probe lost on its own leaves the congestion window untouched" 
     const loss = controller.detectLost(.application, 100);
     try testing.expectEqual(@as(usize, 1_624), loss.lost_bytes);
     try testing.expectEqual(loss.lost_bytes, loss.probe_lost_bytes);
-    try testing.expectEqual(@as(usize, 0), loss.largest_ordinary_lost_size);
     try testing.expectEqual(@as(?u64, null), loss.largest_ordinary_lost_time_sent_us);
     try testing.expectEqual(window_before, controller.congestion.congestion_window);
     try testing.expectEqual(ssthresh_before, controller.congestion.ssthresh);

--- a/src/quic/root.zig
+++ b/src/quic/root.zig
@@ -14,6 +14,7 @@ pub const tls_backend = @import("tls_backend.zig");
 pub const recovery = @import("recovery.zig");
 pub const cid = @import("cid.zig");
 pub const path = @import("path.zig");
+pub const pmtu = @import("pmtu.zig");
 pub const stream = @import("stream.zig");
 pub const qlog = @import("qlog.zig");
 pub const keylog = @import("keylog.zig");

--- a/tests/h3_interop_tool.zig
+++ b/tests/h3_interop_tool.zig
@@ -71,6 +71,7 @@ fn logEvent(_: ?*anyopaque, event: connection.Event) void {
         .path_validation_failed => |p| std.fmt.bufPrint(&buf, "path validation failed change={s} remote_port={d}", .{ @tagName(p.change), p.path.remote.port }),
         .path_migration_blocked => |p| std.fmt.bufPrint(&buf, "path blocked change={s} reason={s} remote_port={d}", .{ @tagName(p.change), @tagName(p.reason), p.path.remote.port }),
         .path_promoted => |p| std.fmt.bufPrint(&buf, "path promoted change={s} remote_port={d}", .{ @tagName(p.change), p.path.remote.port }),
+        .pmtu_updated => |p| std.fmt.bufPrint(&buf, "pmtu {s} size={d} remote_port={d}", .{ @tagName(p.reason), p.size, p.path.remote.port }),
         .zero_rtt_packet => |z| std.fmt.bufPrint(&buf, "zero_rtt_packet outcome={s} size={d}", .{ @tagName(z.outcome), z.size }),
         .early_data_decision => |d| std.fmt.bufPrint(&buf, "early_data_decision {s}", .{@tagName(d)}),
     } catch return;


### PR DESCRIPTION
## Summary

Slice B of #256. #256-A made the outbound datagram size one authoritative value; this makes that value **measured** rather than asserted.

- **`src/quic/pmtu.zig`** — a DPLPMTUD state machine (RFC 8899, RFC 9000 §14.3/§14.4). It lives in `path.Path`, so discovery is per network path *by construction*: a migration, or a tuple that has to be re-validated, starts over at 1200 rather than inheriting a size only the old path was shown to carry.
- **Probes are standalone datagrams** of exactly the size being validated, carrying PING + PADDING and nothing else — a probe dropped by a path too small for it costs no application progress. The first probe reaches straight for the ceiling (RFC 8899 §5.3 optimistic search); after that the window bisects to within 16 bytes. A size is only ruled out after three consecutive losses, so ordinary congestion cannot narrow the search.
- **Probe loss is not congestion** (RFC 9000 §14.4) — its bytes still leave the in-flight ledger, but no window reduction and no recovery period. A probe is otherwise fully congestion controlled and anti-amplification limited, with **none** of the RFC 9002 PTO exemptions.
- **Black-hole fallback** returns the size to the RFC 9000 §14 floor after three pieces of evidence, measured against the size actually in question: datagrams at or above the current send size lost while *smaller* ones are delivered, or consecutive PTOs with nothing acknowledged when every in-flight datagram is already oversized. The RFC 8899 raise timer (10 min) later re-enters the search, **discarding the previous failure bound** — it described a path condition that may no longer hold — so a path that regains MTU is rediscovered instead of being stuck at the size that once failed.
- **Feedback is scoped to the path incarnation that produced it.** Recovery deliberately keeps old-path packets in flight across a migration, so `SentRecord` stamps a `PathRef{key, generation}` and every ACK/loss/probe outcome resolves through it. A tuple that is re-validated gets a new generation, so outcomes still owed by its previous incarnation are dropped rather than applied to a fresh controller.

### Socket precondition

Discovery above 1200 requires the listener to establish a **no-IP-fragmentation contract** (RFC 8899 §3, RFC 9000 §14). Without it an acknowledged large probe would prove the peer *reassembled* it, not that the path carries it. Support is per-OS, because these constants are **not** shared across the BSDs — Darwin's IPv4 `IP_DONTFRAG` is 28, FreeBSD's is 67, and OpenBSD uses 28 for something else entirely:

| Platform | Mechanism |
| --- | --- |
| Linux | `IP_PMTUDISC_PROBE` / `IPV6_PMTUDISC_PROBE` — DF plus RFC 8899 §4.5's requirement that DPLPMTUD not be clamped by the kernel's own cached PMTU |
| Darwin (macOS/iOS/tvOS/watchOS) | `IP_DONTFRAG` (28) / `IPV6_DONTFRAG` (62) — DF only |
| FreeBSD | `IP_DONTFRAG` (67) / `IPV6_DONTFRAG` (62) — DF only |
| NetBSD, OpenBSD, DragonFly, others | none verified → conservative 1200 |

A wrong constant that a kernel happens to *accept* would report success without ever setting DF, so unverified platforms report failure rather than guessing. Where the contract cannot be established the listener warns and holds the send size at 1200, which is #256's documented conservative-policy alternative.

The QUIC transport's own `max_send_udp_payload_size` defaults to 1200 for the same reason: `src/quic/` owns no socket and cannot know whether a probe would be fragmented, so **discovery is opt-in by the composition root that created the socket**. An embedder using `quic.connection` directly stays at the conservative policy.

### Operator-visible change

`TARDIGRADE_HTTP3_MAX_DATAGRAM_SIZE` changes meaning and **defaults to 2048** (was 1200). It was an assertion — "this path carries this much" — and is now a **ceiling on what discovery may find**. The wider default is not a more aggressive one: the size actually emitted still starts at 1200 on every path and rises only where a probe was acknowledged *and* the socket contract holds. Lowering it is now the only reason to set it. See `docs/HTTP3_ROLLOUT.md`.

### Drive-by fix

`processAck` adopted the peer's `largest_acknowledged` without checking it against anything this endpoint had sent, so a peer acknowledging an unsent packet number (RFC 9000 §13.1) tripped `packetNumberLength`'s assertion — a remote panic in a safety-checked build. It now closes with `PROTOCOL_VIOLATION` before mutating any ACK reference state; declining the encoding reference remains as a backstop.

## Test plan

- [x] `zig build test` — full suite green (Zig 0.16).
- [x] `zig build build-tls-interop build-h3-interop` — the interop tools are **not** built by `zig build test`, which is how an earlier CI break got through; now part of the pre-push routine along with `zig fmt --check`.
- [x] **`pmtu.zig`** — optimistic first probe, bisection, retry-before-ruling-out, convergence *and* termination, ceiling clamping mid-flight, per-path reset, both black-hole signatures measured against the current PLPMTU, immediate corroboration, "congestion loss alone is not a black hole", "a loss below the send size is not MTU evidence", "PTO at the floor never falls back", raise-timer rediscovery upward, and a converged-at-ceiling search that does not re-arm.
- [x] **`recovery.zig`** — probe loss returns bytes without a congestion event; a probe lost alongside ordinary traffic charges only the ordinary bytes and takes the congestion timestamp from them.
- [x] **`connection.zig` driver** — over a harness that drops datagrams above a simulated path MTU: a 1200-only path is discovered as such with no black hole and no window cut; a 1452 path converges inside its real capacity and the discovered size reaches the wire; the probe datagram is exactly the probed size; a black hole falls back and arms the raise timer; peer capacity and configured ceiling each bound discovery; a probe waits for congestion window rather than taking an exemption; a migrated path revalidates; old-path loss and probe ACK after promotion leave the new path untouched; a re-validated tuple does not inherit its previous incarnation's feedback; a fallback completed by a smaller ACK publishes metric, event, and recovery size; a PTO driven by old-path packets is not charged to the new path while one with the active path's own traffic still is; ACKing an unsent packet closes with `PROTOCOL_VIOLATION` without panicking.
- [x] **`http3_runtime.zig`** — the config ceiling collapses to 1200 without the socket contract, and the no-fragmentation option is asserted to be accepted on Linux and macOS.

Refs #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)
