### PR TITLE
perf(quic): wire real UDP socket buffer tuning (#256-D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable user-facing changes to Tardigrade are documented here.
 ## [Unreleased]
 
 ### Added
+- **Tunable UDP socket buffers for the HTTP/3 listener (#256-D)** —
+  `TARDIGRADE_HTTP3_UDP_RECV_BUFFER_BYTES` and
+  `TARDIGRADE_HTTP3_UDP_SEND_BUFFER_BYTES` request `SO_RCVBUF`/`SO_SNDBUF` on
+  the QUIC listener socket. Both default to `0`, leaving the kernel's own
+  sizing alone. A full receive buffer drops datagrams that QUIC then treats as
+  network loss — congestion control backs off for a reason nothing on the path
+  caused — so hosts that measure drops under bursts can now raise it without
+  patching.
+
+  The request is advisory in both directions: a kernel that refuses or trims it
+  still gets a listener that serves HTTP/3 correctly, since buffer sizing is a
+  performance setting and not worth failing startup over. It is not, however,
+  allowed to fail silently. The size is read back with `getsockopt` — Linux
+  caps requests at `net.core.rmem_max` while `setsockopt` still reports
+  success, and returns roughly double what was set — so the listener logs and
+  publishes what the kernel actually granted, distinguishing a grant from a
+  clamp, an outright refusal, and an accepted-but-unreadable result. Effective
+  values appear on the runtime status snapshot, and competitive benchmark runs
+  now record the host's UDP buffer ceilings alongside their results.
 - **QUIC discovers the path MTU instead of assuming one (#256-B)** — Tardigrade
   now runs DPLPMTUD (RFC 8899, RFC 9000 §14.3/§14.4) per network path. Every
   path starts at the 1200-byte size RFC 9000 §14 guarantees and rises only as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,13 @@ All notable user-facing changes to Tardigrade are documented here.
   performance setting and not worth failing startup over. It is not, however,
   allowed to fail silently. The size is read back with `getsockopt` — Linux
   caps requests at `net.core.rmem_max` while `setsockopt` still reports
-  success, and returns roughly double what was set — so the listener logs and
-  publishes what the kernel actually granted, distinguishing a grant from a
-  clamp, an outright refusal, and an accepted-but-unreadable result. Effective
+  success — so the listener logs and publishes what the kernel actually
+  granted, distinguishing a grant from a clamp, an outright refusal, and an
+  accepted-but-unreadable result. Linux stores and reports twice what was set
+  (the other half is bookkeeping, not payload capacity), so that judgement is
+  made on the reading restated in request units: a 256 KiB request capped at
+  208 KiB reads back as 416 KiB, which is larger than the request and still a
+  clamp. Effective
   values appear on the runtime status snapshot, and competitive benchmark runs
   now record the host's UDP buffer ceilings alongside their results.
 - **QUIC discovers the path MTU instead of assuming one (#256-B)** — Tardigrade

--- a/benchmarks/competitive/README.md
+++ b/benchmarks/competitive/README.md
@@ -142,3 +142,13 @@ The combined JSON shape is:
 Only compare rows from the same output directory. Cross-run comparisons are
 valid only when host load, tool versions, server versions, ulimits, loopback
 metadata, build flags, and run parameters match.
+
+`host.network.udp_buffers` records the host-wide ceilings on per-socket UDP
+buffers (`net.core.rmem_max`/`wmem_max` on Linux, `kern.ipc.maxsockbuf` on
+macOS and the BSDs) alongside whatever `TARDIGRADE_HTTP3_UDP_RECV_BUFFER_BYTES`
+/ `TARDIGRADE_HTTP3_UDP_SEND_BUFFER_BYTES` asked for. A QUIC run whose receive
+buffer filled shows up as loss in the results, so the limit that bounded it
+belongs next to the numbers it explains — and a request the kernel clamped
+makes two runs incomparable even with identical configuration. The size the
+listener actually got is read back with `getsockopt` and logged by the runtime
+at startup; only the process can see it. See `docs/HTTP3_ROLLOUT.md`.

--- a/benchmarks/competitive/run.sh
+++ b/benchmarks/competitive/run.sh
@@ -281,6 +281,61 @@ loopback_info() {
     fi
 }
 
+# Host-wide ceilings on per-socket UDP buffers (#256-D). A QUIC run whose
+# receive buffer filled looks like packet loss in the results, so the ceiling
+# that bounded it belongs in the metadata next to the numbers it explains.
+# These are the *host* limits; the size the listener actually got is read back
+# with getsockopt and logged by the runtime itself, since only the process can
+# see it.
+udp_sysctl() {
+    local key="$1"
+    if command -v sysctl >/dev/null 2>&1; then
+        sysctl -n "$key" 2>/dev/null || echo "unknown"
+    else
+        echo "unknown"
+    fi
+}
+
+udp_buffer_metadata_json() {
+    if [[ "$(uname -s 2>/dev/null || true)" == "Linux" ]]; then
+        jq -n \
+            --arg rmem_max "$(udp_sysctl net.core.rmem_max)" \
+            --arg wmem_max "$(udp_sysctl net.core.wmem_max)" \
+            --arg rmem_default "$(udp_sysctl net.core.rmem_default)" \
+            --arg wmem_default "$(udp_sysctl net.core.wmem_default)" \
+            --arg requested_recv "${TARDIGRADE_HTTP3_UDP_RECV_BUFFER_BYTES:-0}" \
+            --arg requested_send "${TARDIGRADE_HTTP3_UDP_SEND_BUFFER_BYTES:-0}" \
+            '{
+                host_ceiling: {
+                    "net.core.rmem_max": $rmem_max,
+                    "net.core.wmem_max": $wmem_max,
+                    "net.core.rmem_default": $rmem_default,
+                    "net.core.wmem_default": $wmem_default
+                },
+                tardigrade_requested: {
+                    recv_bytes: $requested_recv,
+                    send_bytes: $requested_send
+                }
+            }'
+    else
+        jq -n \
+            --arg maxsockbuf "$(udp_sysctl kern.ipc.maxsockbuf)" \
+            --arg recvspace "$(udp_sysctl net.inet.udp.recvspace)" \
+            --arg requested_recv "${TARDIGRADE_HTTP3_UDP_RECV_BUFFER_BYTES:-0}" \
+            --arg requested_send "${TARDIGRADE_HTTP3_UDP_SEND_BUFFER_BYTES:-0}" \
+            '{
+                host_ceiling: {
+                    "kern.ipc.maxsockbuf": $maxsockbuf,
+                    "net.inet.udp.recvspace": $recvspace
+                },
+                tardigrade_requested: {
+                    recv_bytes: $requested_recv,
+                    send_bytes: $requested_send
+                }
+            }'
+    fi
+}
+
 host_metadata_json() {
     jq -n \
         --arg load_tool "$TOOL" \
@@ -288,6 +343,7 @@ host_metadata_json() {
         --arg ulimit_n "$(ulimit -n 2>/dev/null || echo unknown)" \
         --arg ulimit_u "$(ulimit -u 2>/dev/null || echo unknown)" \
         --arg loopback "$(loopback_info)" \
+        --argjson udp_buffers "$(udp_buffer_metadata_json)" \
         --arg tardigrade_build_flags "$TARDIGRADE_BUILD_FLAGS" \
         --argjson tardigrade_binary_explicit "$($BINARY_EXPLICIT && echo true || echo false)" \
         '{
@@ -298,7 +354,8 @@ host_metadata_json() {
                 max_user_processes: $ulimit_u
             },
             network: {
-                loopback: $loopback
+                loopback: $loopback,
+                udp_buffers: $udp_buffers
             },
             tardigrade: {
                 build_flags: $tardigrade_build_flags,

--- a/docs/CONCURRENCY.md
+++ b/docs/CONCURRENCY.md
@@ -167,6 +167,7 @@ they need public control.
 | Max streams | `initial_max_streams_*` | 100 bidi, 16 uni | internal initially |
 | Retry policy | address validation / tokens | `off` | `TARDIGRADE_HTTP3_RETRY_POLICY=off\|address_validation`; `address_validation` sends stateless QUIC Retry before allocating connection state |
 | Migration policy | `disable_active_migration` | NAT rebinding only | `TARDIGRADE_HTTP3_CONNECTION_MIGRATION=false` permits same-IP NAT rebinding but not active migration; `true` enables full migration |
+| UDP socket buffers | `SO_RCVBUF` / `SO_SNDBUF` | kernel default | `TARDIGRADE_HTTP3_UDP_RECV_BUFFER_BYTES` / `..._SEND_BUFFER_BYTES`; advisory, read back with `getsockopt` and published on the runtime snapshot |
 | qlog / keylog | debug artifact emission | off | local-debug toggle |
 | QPACK | SETTINGS | static-only, zero dynamic capacity | internal until dynamic QPACK lands |
 

--- a/docs/HTTP3_ROLLOUT.md
+++ b/docs/HTTP3_ROLLOUT.md
@@ -208,7 +208,7 @@ so the size is **read back with `getsockopt`** and reported:
 | Log | Meaning |
 | --- | --- |
 | `udp receive buffer at kernel default effective_bytes=N` | Nothing requested. `N` is what the socket has. |
-| `udp receive buffer applied requested_bytes=N effective_bytes=M` | Granted. |
+| `udp receive buffer applied requested_bytes=N granted_bytes=N effective_bytes=M` | Granted. |
 | `udp receive buffer clamped by the kernel …` | The request was accepted and cut down by a host-wide ceiling. Only the host operator can raise it. |
 | `udp receive buffer … accepted but could not be read back` | The size is unknown; nothing was measured. |
 | `udp receive buffer request rejected by the kernel …` | The default buffer stands. |
@@ -220,10 +220,17 @@ numbers, and `setsockopt` reports success either way:
   `net.core.wmem_max`) — commonly 208 KiB on a stock kernel — so a listener
   asking for 16 MiB gets a fraction of it and no indication from the syscall.
   Raise the ceiling on the host (`sysctl -w net.core.rmem_max=8388608`,
-  persisted in `/etc/sysctl.d/`) before raising the request. Linux also reports
-  roughly **twice** what was set: the other half is per-datagram bookkeeping
-  overhead, not payload capacity, so a readback of 8 MiB for a 4 MiB request is
-  normal and is treated as a grant.
+  persisted in `/etc/sysctl.d/`) before raising the request.
+
+  Linux also stores and reports **twice** what was set: the other half is
+  per-datagram bookkeeping overhead, not payload capacity. Grant-versus-clamp
+  is therefore decided on the reading *restated in request units* — the half
+  that corresponds to what was asked for — and not on the raw number, which
+  would report a success whenever the kernel granted more than half the
+  request. A 256 KiB request on a host capped at 208 KiB reads back as
+  416 KiB: larger than the request, and still a clamp. Both figures are
+  logged, as `granted_bytes` and `effective_bytes`; the second is what the
+  kernel will tell anyone who inspects the socket directly.
 - **macOS and the BSDs** bound the total per-socket buffer with
   `kern.ipc.maxsockbuf` rather than per direction, and return the size set
   rather than a doubled one.

--- a/docs/HTTP3_ROLLOUT.md
+++ b/docs/HTTP3_ROLLOUT.md
@@ -182,6 +182,61 @@ RFC 9002's NewReno windows are defined in terms of the sender's current maximum
 datagram size, so the initial window, minimum window, and congestion-avoidance
 growth all scale with the value above rather than with a fixed 1200.
 
+## Socket buffers
+
+The UDP receive buffer is where datagrams wait between the kernel taking them
+off the wire and the listener thread reading them. When it fills, the kernel
+drops datagrams — silently, as far as QUIC is concerned. To the connection that
+looks exactly like network loss: congestion control backs off, packets are
+retransmitted, and throughput falls for a reason nothing on the path caused.
+A host whose default buffer is small relative to the bandwidth-delay product
+will do this under bursts even when the link is idle.
+
+`TARDIGRADE_HTTP3_UDP_RECV_BUFFER_BYTES` and
+`TARDIGRADE_HTTP3_UDP_SEND_BUFFER_BYTES` request `SO_RCVBUF` / `SO_SNDBUF` on
+the listener socket. Both default to `0`, meaning **leave the kernel's own
+sizing alone** — the right setting unless you have measured drops. Requests are
+clamped into `[2048, 1073741824]` before reaching the kernel, since the
+`setsockopt` ABI takes a signed 32-bit size and a typo must not wrap it.
+
+Everything here is advisory. A kernel that refuses the request, or grants less
+than was asked for, still gets a listener that serves HTTP/3 correctly — buffer
+sizing is a performance setting, and turning it into a startup failure would
+take a service down over a tuning knob. What it must not do is fail silently,
+so the size is **read back with `getsockopt`** and reported:
+
+| Log | Meaning |
+| --- | --- |
+| `udp receive buffer at kernel default effective_bytes=N` | Nothing requested. `N` is what the socket has. |
+| `udp receive buffer applied requested_bytes=N effective_bytes=M` | Granted. |
+| `udp receive buffer clamped by the kernel …` | The request was accepted and cut down by a host-wide ceiling. Only the host operator can raise it. |
+| `udp receive buffer … accepted but could not be read back` | The size is unknown; nothing was measured. |
+| `udp receive buffer request rejected by the kernel …` | The default buffer stands. |
+
+The readback matters because the request and the grant are routinely different
+numbers, and `setsockopt` reports success either way:
+
+- **Linux** caps `SO_RCVBUF` at `net.core.rmem_max` (and `SO_SNDBUF` at
+  `net.core.wmem_max`) — commonly 208 KiB on a stock kernel — so a listener
+  asking for 16 MiB gets a fraction of it and no indication from the syscall.
+  Raise the ceiling on the host (`sysctl -w net.core.rmem_max=8388608`,
+  persisted in `/etc/sysctl.d/`) before raising the request. Linux also reports
+  roughly **twice** what was set: the other half is per-datagram bookkeeping
+  overhead, not payload capacity, so a readback of 8 MiB for a 4 MiB request is
+  normal and is treated as a grant.
+- **macOS and the BSDs** bound the total per-socket buffer with
+  `kern.ipc.maxsockbuf` rather than per direction, and return the size set
+  rather than a doubled one.
+- **Other platforms** are not assumed to expose either knob; a refusal is
+  reported and the default stands.
+
+The effective values are published on the runtime's status snapshot
+(`udp_buffers`), which is what benchmark runs should record — the requested
+value and the host sysctls describe intent, not what the socket got.
+
+Both variables are restart-required: buffer sizes are socket state applied to
+the live descriptor at bind time, so changing one means a new socket.
+
 ## Reload
 
 Advertisement-only knobs can hot reload:
@@ -198,6 +253,8 @@ runtime does not atomically replace a live UDP socket and QUIC connection table:
 - `TARDIGRADE_HTTP3_RETRY_POLICY`
 - `TARDIGRADE_HTTP3_ENABLE_0RTT`
 - `TARDIGRADE_HTTP3_MAX_DATAGRAM_SIZE`
+- `TARDIGRADE_HTTP3_UDP_RECV_BUFFER_BYTES`
+- `TARDIGRADE_HTTP3_UDP_SEND_BUFFER_BYTES`
 
 A reload that changes one of those fields is rejected before publication. The
 old config, old runtime, and old effective advertisement remain active.

--- a/docs/HTTP3_ROLLOUT.md
+++ b/docs/HTTP3_ROLLOUT.md
@@ -196,8 +196,12 @@ will do this under bursts even when the link is idle.
 `TARDIGRADE_HTTP3_UDP_SEND_BUFFER_BYTES` request `SO_RCVBUF` / `SO_SNDBUF` on
 the listener socket. Both default to `0`, meaning **leave the kernel's own
 sizing alone** — the right setting unless you have measured drops. Requests are
-clamped into `[2048, 1073741824]` before reaching the kernel, since the
-`setsockopt` ABI takes a signed 32-bit size and a typo must not wrap it.
+clamped into `[2048, 1073741823]` before reaching the kernel: the `setsockopt`
+ABI takes a signed 32-bit size and a typo must not wrap it. The upper bound is
+`INT_MAX / 2` rather than a round 1 GiB because Linux stores twice what it is
+given and caps a request at that same figure first — asking for 1 GiB exactly
+would be reduced by a byte and then reported as clamped forever, blaming a
+sysctl that was never the cause.
 
 Everything here is advisory. A kernel that refuses the request, or grants less
 than was asked for, still gets a listener that serves HTTP/3 correctly — buffer

--- a/src/edge_config.zig
+++ b/src/edge_config.zig
@@ -277,6 +277,10 @@ pub const EdgeConfig = struct {
     http3_connection_migration: bool,
     http3_retry_policy: http.quic.config.RetryPolicy,
     http3_max_datagram_size: usize,
+    /// Optional `SO_RCVBUF`/`SO_SNDBUF` targets for the QUIC listener socket
+    /// (#256-D). `0` — the default — leaves the kernel's own sizing alone.
+    http3_udp_recv_buffer_bytes: usize,
+    http3_udp_send_buffer_bytes: usize,
     proxy_protocol_mode: ProxyProtocolMode,
     /// Gateway identity used in signed upstream trust headers.
     trust_gateway_id: []const u8,
@@ -944,6 +948,13 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
     // `[base_size, max_size]` and lowers it further whenever the peer
     // advertises smaller receive capacity.
     const http3_max_datagram_size = parseIntEnv(usize, allocator, "TARDIGRADE_HTTP3_MAX_DATAGRAM_SIZE", http.quic.datagram.max_size);
+    // #256-D: advisory socket buffer targets for the QUIC listener. `0` (the
+    // default) means "leave the kernel's sizing alone", which is what most
+    // deployments should do — these exist for hosts whose default receive
+    // buffer is small enough to drop datagrams in bursts. A request the
+    // kernel refuses or trims is logged and published, never fatal.
+    const http3_udp_recv_buffer_bytes = parseIntEnv(usize, allocator, "TARDIGRADE_HTTP3_UDP_RECV_BUFFER_BYTES", 0);
+    const http3_udp_send_buffer_bytes = parseIntEnv(usize, allocator, "TARDIGRADE_HTTP3_UDP_SEND_BUFFER_BYTES", 0);
     const proxy_protocol_mode_str = envOrDefault(allocator, "TARDIGRADE_PROXY_PROTOCOL", "off") catch unreachable;
     defer allocator.free(proxy_protocol_mode_str);
     const proxy_protocol_mode = try parseProxyProtocolModeConfig(proxy_protocol_mode_str);
@@ -1632,6 +1643,8 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
         .http3_connection_migration = http3_connection_migration,
         .http3_retry_policy = http3_retry_policy,
         .http3_max_datagram_size = http3_max_datagram_size,
+        .http3_udp_recv_buffer_bytes = http3_udp_recv_buffer_bytes,
+        .http3_udp_send_buffer_bytes = http3_udp_send_buffer_bytes,
         .proxy_protocol_mode = proxy_protocol_mode,
         .trust_gateway_id = trust_gateway_id,
         .trust_shared_secret = trust_shared_secret,

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -512,6 +512,10 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
             .connection_migration = cfg.http3_connection_migration,
             .retry_policy = cfg.http3_retry_policy,
             .max_datagram_size = cfg.http3_max_datagram_size,
+            .udp_buffer_tuning = .{
+                .recv_bytes = if (cfg.http3_udp_recv_buffer_bytes > 0) cfg.http3_udp_recv_buffer_bytes else null,
+                .send_bytes = if (cfg.http3_udp_send_buffer_bytes > 0) cfg.http3_udp_send_buffer_bytes else null,
+            },
             .request_handler = ghandlers.handleHttp3Request,
             .request_handler_ctx = &http3_dispatch_ctx,
             .early_data_compat_metrics_ctx = &state,
@@ -632,12 +636,14 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
         state.logger.info(null, "Proxy protocol enabled: {s} (plaintext and TLS listeners)", .{@tagName(cfg.proxy_protocol_mode)});
     }
     if (cfg.http3_enabled) {
-        state.logger.info(null, "HTTP/3 foundation enabled: quic_port={d} 0rtt={} migration={} retry_policy={s} max_datagram={d}", .{
+        state.logger.info(null, "HTTP/3 foundation enabled: quic_port={d} 0rtt={} migration={} retry_policy={s} max_datagram={d} udp_recv_buffer={d} udp_send_buffer={d}", .{
             cfg.quic_port,
             cfg.http3_enable_0rtt,
             cfg.http3_connection_migration,
             @tagName(cfg.http3_retry_policy),
             cfg.http3_max_datagram_size,
+            cfg.http3_udp_recv_buffer_bytes,
+            cfg.http3_udp_send_buffer_bytes,
         });
     }
     if (cfg.trust_shared_secret.len > 0) {

--- a/src/gateway_shutdown.zig
+++ b/src/gateway_shutdown.zig
@@ -345,7 +345,12 @@ pub fn http3ListenerConfigChanged(
         current.http3_enable_0rtt != proposed.http3_enable_0rtt or
         current.http3_connection_migration != proposed.http3_connection_migration or
         current.http3_retry_policy != proposed.http3_retry_policy or
-        current.http3_max_datagram_size != proposed.http3_max_datagram_size;
+        current.http3_max_datagram_size != proposed.http3_max_datagram_size or
+        // #256-D: buffer sizes are socket state, set once on the live fd at
+        // bind time. Changing them means a new socket, which is a listener
+        // restart like every other knob here.
+        current.http3_udp_recv_buffer_bytes != proposed.http3_udp_recv_buffer_bytes or
+        current.http3_udp_send_buffer_bytes != proposed.http3_udp_send_buffer_bytes;
 }
 
 pub fn listenerShardConfigChanged(
@@ -401,6 +406,18 @@ test "http3ListenerConfigChanged permits advertisement-only reloads" {
     proposed.quic_port = base.quic_port;
 
     proposed.http3_retry_policy = .address_validation;
+    try std.testing.expect(http3ListenerConfigChanged(&base, &proposed));
+    proposed.http3_retry_policy = base.http3_retry_policy;
+
+    // #256-D: socket buffer sizes are applied to the live descriptor at bind
+    // time. A reload cannot resize the socket the listener is already reading
+    // from, so changing either target has to go through a restart rather than
+    // being accepted and silently ignored.
+    proposed.http3_udp_recv_buffer_bytes = base.http3_udp_recv_buffer_bytes + 4096;
+    try std.testing.expect(http3ListenerConfigChanged(&base, &proposed));
+    proposed.http3_udp_recv_buffer_bytes = base.http3_udp_recv_buffer_bytes;
+
+    proposed.http3_udp_send_buffer_bytes = base.http3_udp_send_buffer_bytes + 4096;
     try std.testing.expect(http3ListenerConfigChanged(&base, &proposed));
 }
 

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -101,6 +101,13 @@ pub const Config = struct {
     /// than a second knob that can drift from it; the transport lowers it
     /// further whenever the peer advertises less receive capacity.
     max_datagram_size: usize = quic.datagram.max_size,
+    /// Optional `SO_RCVBUF`/`SO_SNDBUF` targets for the listener socket
+    /// (#256-D). Advisory in both directions: a kernel that refuses or trims
+    /// a request still gets a working listener, and the default (`null`,
+    /// leave the kernel's own sizing alone) is the right answer unless
+    /// measurements say otherwise. What the kernel actually granted is read
+    /// back and published on `Snapshot.udp_buffers`.
+    udp_buffer_tuning: quic.udp.BufferTuning = .{},
     request_handler: ?RequestHandler = null,
     request_handler_ctx: ?*anyopaque = null,
     early_data_compat_metrics_ctx: ?*anyopaque = null,
@@ -179,6 +186,11 @@ pub const Snapshot = struct {
     h3_goaway_sent: usize = 0,
     h3_drain_request_rejections: usize = 0,
     active_cid_routes: usize = 0,
+    /// What the kernel actually granted for this listener's socket buffers
+    /// (#256-D) — read back at bind time, never the requested value. Fixed
+    /// for the life of the socket, so unlike every counter above it is
+    /// written once at init.
+    udp_buffers: quic.udp.EffectiveBufferTuning = .{},
 
     pub fn handshakeState(self: Snapshot) []const u8 {
         if (!self.server_bootstrapped) return "bootstrap_incomplete";
@@ -327,6 +339,11 @@ pub const Runtime = struct {
         if (!no_fragment) {
             logger.warn(null, "http3: no-fragmentation socket policy unavailable; path MTU discovery held at {d} bytes", .{quic.datagram.base_size});
         }
+        // Advisory, and applied before `bind` so the socket is never briefly
+        // reachable with a buffer the operator did not ask for (#256-D).
+        const udp_buffers = tuneSocketBuffers(fd, cfg.udp_buffer_tuning);
+        logSocketBufferOutcome(logger, "receive", udp_buffers.recv);
+        logSocketBufferOutcome(logger, "send", udp_buffers.send);
         const bind_rc = std.c.bind(fd, @ptrCast(&address.storage), @intCast(address.len));
         if (bind_rc != 0) {
             logger.warn(null, "http3: udp bind failed: {s}", .{@tagName(posix.errno(bind_rc))});
@@ -370,7 +387,7 @@ pub const Runtime = struct {
             .h3_qlog_sink = cfg.h3_qlog_sink,
             .h3_qlog_sink_factory_ctx = cfg.h3_qlog_sink_factory_ctx,
             .h3_qlog_sink_factory_cb = cfg.h3_qlog_sink_factory_cb,
-            .snapshot_state = .{ .quic_port = cfg.quic_port },
+            .snapshot_state = .{ .quic_port = cfg.quic_port, .udp_buffers = udp_buffers },
             .stopping = std.atomic.Value(bool).init(false),
             .drain_requested = std.atomic.Value(bool).init(false),
             .drain_deadline_us = std.atomic.Value(u64).init(0),
@@ -1814,6 +1831,92 @@ fn configureNoFragment(fd: std.c.fd_t, sa_family: u32) bool {
     const value = options.value;
     posix.setsockopt(fd, @intCast(level), @intCast(option), std.mem.asBytes(&value)) catch return false;
     return true;
+}
+
+/// Read one socket buffer size back with `getsockopt`. Returns null when the
+/// readback fails, which is reported as such rather than being papered over
+/// with the requested value: the whole reason to read back is that the number
+/// the kernel chose and the number that was asked for routinely differ.
+fn socketBufferBytes(fd: std.c.fd_t, option: u32) ?usize {
+    var value: c_int = 0;
+    var len: posix.socklen_t = @sizeOf(c_int);
+    if (std.c.getsockopt(fd, posix.SOL.SOCKET, option, &value, &len) != 0) return null;
+    if (len != @sizeOf(c_int) or value < 0) return null;
+    return @intCast(value);
+}
+
+/// Apply one direction's requested socket buffer size and report what the
+/// kernel did with it (#256-D).
+///
+/// Advisory by construction. `SO_RCVBUF`/`SO_SNDBUF` are performance knobs:
+/// every failure mode here — refused, trimmed to a system ceiling, unreadable
+/// — still leaves a listener that serves QUIC correctly, so none of them
+/// returns an error. What they must not do is fail *silently*, which is why
+/// the value is always read back: Linux caps a request at `net.core.rmem_max`
+/// while returning success from `setsockopt`, so a listener asking for 16 MiB
+/// on a stock kernel gets ~208 KiB and no indication of it.
+fn tuneSocketBuffer(fd: std.c.fd_t, option: u32, requested: ?usize) quic.udp.BufferOutcome {
+    // Nothing requested still reads back: the kernel default is the number
+    // that explains a benchmark run or a report of unexplained loss, and it
+    // is only knowable from inside this process.
+    const want = requested orelse
+        return quic.udp.classifyBufferOutcome(null, false, socketBufferBytes(fd, option));
+    const clamped = quic.udp.clampBufferBytes(want);
+    const value: c_int = @intCast(clamped);
+    const accepted = if (posix.setsockopt(fd, posix.SOL.SOCKET, option, std.mem.asBytes(&value))) |_| true else |_| false;
+    return quic.udp.classifyBufferOutcome(clamped, accepted, socketBufferBytes(fd, option));
+}
+
+fn tuneSocketBuffers(fd: std.c.fd_t, tuning: quic.udp.BufferTuning) quic.udp.EffectiveBufferTuning {
+    return .{
+        .recv = tuneSocketBuffer(fd, posix.SO.RCVBUF, tuning.recv_bytes),
+        .send = tuneSocketBuffer(fd, posix.SO.SNDBUF, tuning.send_bytes),
+    };
+}
+
+/// The host-wide ceiling an operator has to raise before a larger per-socket
+/// request can be granted. Named per platform because these are not the same
+/// knob: Linux bounds each direction separately, the BSDs bound the total.
+const socket_buffer_ceiling_hint = switch (builtin.os.tag) {
+    .linux => "net.core.rmem_max/net.core.wmem_max",
+    .macos, .ios, .tvos, .watchos, .freebsd, .netbsd, .openbsd, .dragonfly => "kern.ipc.maxsockbuf",
+    else => "the host socket buffer ceiling",
+};
+
+/// Report one direction's tuning result. A granted request is `info`; every
+/// outcome where the operator did not get what they configured is `warn`,
+/// because the listener will otherwise run indefinitely with a buffer nobody
+/// chose and no way to tell from outside the process.
+fn logSocketBufferOutcome(
+    logger: *logger_mod.Logger,
+    direction: []const u8,
+    outcome: quic.udp.BufferOutcome,
+) void {
+    const effective = outcome.effective_bytes orelse 0;
+    switch (outcome.status) {
+        .default => if (outcome.effective_bytes != null) {
+            logger.info(null, "http3: udp {s} buffer at kernel default effective_bytes={d}", .{ direction, effective });
+        },
+        .applied => logger.info(null, "http3: udp {s} buffer applied requested_bytes={d} effective_bytes={d}", .{
+            direction,
+            outcome.requested_bytes orelse 0,
+            effective,
+        }),
+        .clamped => logger.warn(null, "http3: udp {s} buffer clamped by the kernel requested_bytes={d} effective_bytes={d}; raise {s} on the host or lower the configured request", .{
+            direction,
+            outcome.requested_bytes orelse 0,
+            effective,
+            socket_buffer_ceiling_hint,
+        }),
+        .unverified => logger.warn(null, "http3: udp {s} buffer requested_bytes={d} accepted but could not be read back; effective size unknown", .{
+            direction,
+            outcome.requested_bytes orelse 0,
+        }),
+        .unsupported => logger.warn(null, "http3: udp {s} buffer request rejected by the kernel requested_bytes={d}; kernel default in effect", .{
+            direction,
+            outcome.requested_bytes orelse 0,
+        }),
+    }
 }
 
 /// Create a non-blocking, close-on-exec UDP socket for `sa_family`. Returns a
@@ -4866,6 +4969,96 @@ test "http3 runtime: the no-fragmentation contract is established exactly where 
         defer _ = std.c.close(fd);
         try testing.expectEqual(no_fragment_supported, configureNoFragment(fd, family));
     }
+}
+
+test "http3 runtime: socket buffer sizes are read back from the kernel, not assumed" {
+    // #256-D: the request and the grant are different numbers on every
+    // platform — Linux returns roughly double, and caps at a sysctl the
+    // process cannot see — so what gets reported has to come from
+    // `getsockopt` on the real socket.
+    const fd = openUdpSocket(posix.AF.INET);
+    if (fd < 0) return error.SkipZigTest;
+    defer _ = std.c.close(fd);
+
+    // Nothing requested: still read back, because benchmark metadata and
+    // operator diagnostics want the number whether or not it was chosen here.
+    const untouched = tuneSocketBuffers(fd, .{});
+    try testing.expectEqual(quic.udp.BufferTuningStatus.default, untouched.recv.status);
+    try testing.expectEqual(quic.udp.BufferTuningStatus.default, untouched.send.status);
+    try testing.expectEqual(@as(?usize, null), untouched.recv.requested_bytes);
+    try testing.expect(untouched.recv.effective_bytes != null);
+    try testing.expect(untouched.send.effective_bytes != null);
+
+    // A request every kernel this runs on can satisfy from its default
+    // ceiling, so the outcome is a grant rather than a clamp.
+    const requested: usize = 256 * 1024;
+    const tuned = tuneSocketBuffers(fd, .{ .recv_bytes = requested, .send_bytes = requested });
+    try testing.expectEqual(quic.udp.BufferTuningStatus.applied, tuned.recv.status);
+    try testing.expectEqual(quic.udp.BufferTuningStatus.applied, tuned.send.status);
+    try testing.expectEqual(@as(?usize, requested), tuned.recv.requested_bytes);
+    try testing.expect(tuned.recv.effective_bytes.? >= requested);
+    try testing.expect(tuned.send.effective_bytes.? >= requested);
+}
+
+test "http3 runtime: an oversized buffer request never reaches the kernel as one" {
+    // `setsockopt(SO_RCVBUF)` takes a `c_int`. An operator typo must be
+    // clamped to something the ABI can express — handing it over unclamped
+    // would truncate to a negative size — and the clamped value is what gets
+    // reported, so the log never claims a request that was not made.
+    const fd = openUdpSocket(posix.AF.INET);
+    if (fd < 0) return error.SkipZigTest;
+    defer _ = std.c.close(fd);
+
+    const outcome = tuneSocketBuffer(fd, posix.SO.RCVBUF, std.math.maxInt(usize));
+    try testing.expectEqual(@as(?usize, quic.udp.max_buffer_bytes), outcome.requested_bytes);
+    // Whatever the kernel decided, this stays advisory: a refusal or a clamp
+    // is reported, never raised.
+    try testing.expect(outcome.status != .default);
+}
+
+test "http3 runtime: an unsatisfiable buffer request still yields a working listener" {
+    // Socket buffer sizing is a performance setting. A host whose ceiling is
+    // far below the request must still get a bound, bootstrapped listener —
+    // the outcome is published for diagnosis instead of failing startup.
+    var fixed = tls_core.credentials.FixedCredentialProvider.init(tls_core.credentials.testdata.identity(), tls_core.credentials.testdata.ignoredEntropy());
+    defer fixed.deinit();
+    var logger = logger_mod.Logger.init(.err, "http3-test");
+
+    var runtime = Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+        .credential_provider = fixed.provider(),
+        .udp_buffer_tuning = .{ .recv_bytes = quic.udp.max_buffer_bytes, .send_bytes = quic.udp.max_buffer_bytes },
+    }) catch return error.SkipZigTest;
+    defer runtime.deinit();
+
+    try testing.expect(runtime.snapshot().server_bootstrapped);
+    const buffers = runtime.snapshot().udp_buffers;
+    try testing.expectEqual(@as(?usize, quic.udp.max_buffer_bytes), buffers.recv.requested_bytes);
+    try testing.expectEqual(@as(?usize, quic.udp.max_buffer_bytes), buffers.send.requested_bytes);
+    // The listener publishes what it got, so a clamp is diagnosable from
+    // outside the process rather than showing up as unexplained loss.
+    try testing.expect(buffers.recv.status != .default);
+    if (buffers.recv.effective_bytes) |effective| try testing.expect(effective > 0);
+}
+
+test "http3 runtime: an untuned listener still reports its socket buffers" {
+    // The default path: nothing configured, kernel sizing left alone, and the
+    // effective values still published so benchmark runs and support tickets
+    // record what the socket actually had.
+    var logger = logger_mod.Logger.init(.err, "http3-test");
+    var runtime = Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+    }) catch return error.SkipZigTest;
+    defer runtime.deinit();
+
+    const buffers = runtime.snapshot().udp_buffers;
+    try testing.expectEqual(quic.udp.BufferTuningStatus.default, buffers.recv.status);
+    try testing.expectEqual(quic.udp.BufferTuningStatus.default, buffers.send.status);
+    try testing.expectEqual(@as(?usize, null), buffers.recv.requested_bytes);
+    try testing.expect(buffers.recv.effective_bytes != null);
+    try testing.expect(buffers.send.effective_bytes != null);
 }
 
 test "http3 runtime: only verified platforms claim no-fragmentation support" {

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -5035,24 +5035,34 @@ test "http3 runtime: socket buffer sizes are read back from the kernel, not assu
     try testing.expectEqual(grantedBufferBytes(tuned.recv.effective_bytes.?), tuned.recv.granted_bytes.?);
 }
 
-test "http3 runtime: a kernel ceiling below the request is reported as a clamp" {
-    // The failure this whole readback exists for: `setsockopt` succeeds, the
-    // kernel silently caps the size, and nothing outside the process can tell.
-    // Asking for the ABI maximum guarantees the cap on any host — no kernel
-    // grants a 1 GiB socket buffer by default — so this exercises the clamp
-    // path rather than describing it.
-    //
-    // On Linux the raw reading of that capped buffer is doubled and can exceed
-    // the request outright; the classification must still be `clamped`, which
-    // is what pins the false positive shut.
+test "http3 runtime: a real kernel's answer to the largest request is classified consistently" {
+    // The clamp *regression* is the deterministic classifier test in
+    // `quic.udp`; this checks the same policy against a real kernel, where the
+    // answer depends on the host. Asking for the maximum will be capped almost
+    // everywhere, but a deliberately tuned host can grant it — and a
+    // correctness test must not fail because someone raised their socket
+    // ceiling. So this asserts the invariants that must hold either way rather
+    // than demanding a particular verdict.
     const fd = openUdpSocket(posix.AF.INET);
     if (fd < 0) return error.SkipZigTest;
     defer _ = std.c.close(fd);
 
     const outcome = tuneSocketBuffer(fd, posix.SO.RCVBUF, quic.udp.max_buffer_bytes);
     if (outcome.status == .unsupported or outcome.status == .unverified) return error.SkipZigTest;
-    try testing.expectEqual(quic.udp.BufferTuningStatus.clamped, outcome.status);
-    try testing.expect(outcome.granted_bytes.? < quic.udp.max_buffer_bytes);
+    try testing.expectEqual(@as(?usize, quic.udp.max_buffer_bytes), outcome.requested_bytes);
+
+    // Whatever the kernel decided, the verdict follows from the
+    // request-comparable reading and nothing else. On Linux the raw reading of
+    // a capped buffer is doubled and can exceed the request outright, so a
+    // `clamped` verdict alongside an `effective_bytes` larger than the request
+    // is precisely the false positive this pins shut.
+    const granted = outcome.granted_bytes.?;
+    switch (outcome.status) {
+        .clamped => try testing.expect(granted < quic.udp.max_buffer_bytes),
+        .applied => try testing.expect(granted >= quic.udp.max_buffer_bytes),
+        else => return error.TestUnexpectedResult,
+    }
+    try testing.expectEqual(grantedBufferBytes(outcome.effective_bytes.?), granted);
 }
 
 test "http3 runtime: only Linux restates socket buffer readings" {
@@ -5080,10 +5090,11 @@ test "http3 runtime: an oversized buffer request never reaches the kernel as one
     try testing.expect(outcome.status != .default);
 }
 
-test "http3 runtime: an unsatisfiable buffer request still yields a working listener" {
-    // Socket buffer sizing is a performance setting. A host whose ceiling is
-    // far below the request must still get a bound, bootstrapped listener —
-    // the outcome is published for diagnosis instead of failing startup.
+test "http3 runtime: the largest possible buffer request still yields a working listener" {
+    // Socket buffer sizing is a performance setting. Whatever the host makes
+    // of a maximum-sized request — granting it, capping it, refusing it — the
+    // listener must still come up bound and bootstrapped, with the outcome
+    // published for diagnosis instead of failing startup.
     var fixed = tls_core.credentials.FixedCredentialProvider.init(tls_core.credentials.testdata.identity(), tls_core.credentials.testdata.ignoredEntropy());
     defer fixed.deinit();
     var logger = logger_mod.Logger.init(.err, "http3-test");

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -1845,6 +1845,23 @@ fn socketBufferBytes(fd: std.c.fd_t, option: u32) ?usize {
     return @intCast(value);
 }
 
+/// Restate a `getsockopt` reading in the units the request was made in, which
+/// is the only basis on which "did the kernel grant this?" can be answered.
+///
+/// Linux stores `SO_RCVBUF`/`SO_SNDBUF` as twice the requested size — the
+/// extra half is `sk_buff` bookkeeping, not payload capacity — and reports the
+/// doubled figure. Comparing that figure against the request would report a
+/// grant whenever the kernel gave *more than half* of what was asked for: a
+/// 256 KiB request on a host whose `net.core.rmem_max` is 208 KiB reads back
+/// as 416 KiB and would look like a success, which is precisely the silent
+/// clamp this readback exists to expose.
+///
+/// This lives here rather than in `src/quic/udp.zig` because it is a fact
+/// about the host's socket API, not about QUIC.
+fn grantedBufferBytes(reported: usize) usize {
+    return if (builtin.os.tag == .linux) reported / 2 else reported;
+}
+
 /// Apply one direction's requested socket buffer size and report what the
 /// kernel did with it (#256-D).
 ///
@@ -1860,11 +1877,15 @@ fn tuneSocketBuffer(fd: std.c.fd_t, option: u32, requested: ?usize) quic.udp.Buf
     // that explains a benchmark run or a report of unexplained loss, and it
     // is only knowable from inside this process.
     const want = requested orelse
-        return quic.udp.classifyBufferOutcome(null, false, socketBufferBytes(fd, option));
+        return quic.udp.classifyBufferOutcome(null, false, .{ .reported_bytes = socketBufferBytes(fd, option) });
     const clamped = quic.udp.clampBufferBytes(want);
     const value: c_int = @intCast(clamped);
     const accepted = if (posix.setsockopt(fd, posix.SOL.SOCKET, option, std.mem.asBytes(&value))) |_| true else |_| false;
-    return quic.udp.classifyBufferOutcome(clamped, accepted, socketBufferBytes(fd, option));
+    const reported = socketBufferBytes(fd, option);
+    return quic.udp.classifyBufferOutcome(clamped, accepted, .{
+        .reported_bytes = reported,
+        .granted_bytes = if (reported) |bytes| grantedBufferBytes(bytes) else null,
+    });
 }
 
 fn tuneSocketBuffers(fd: std.c.fd_t, tuning: quic.udp.BufferTuning) quic.udp.EffectiveBufferTuning {
@@ -1897,14 +1918,20 @@ fn logSocketBufferOutcome(
         .default => if (outcome.effective_bytes != null) {
             logger.info(null, "http3: udp {s} buffer at kernel default effective_bytes={d}", .{ direction, effective });
         },
-        .applied => logger.info(null, "http3: udp {s} buffer applied requested_bytes={d} effective_bytes={d}", .{
+        // `granted_bytes` is the request-comparable reading and `effective_bytes`
+        // the raw one the kernel will report to anyone who inspects the socket.
+        // Both are logged: on Linux they differ by design, and an operator
+        // checking the two against each other should find them consistent.
+        .applied => logger.info(null, "http3: udp {s} buffer applied requested_bytes={d} granted_bytes={d} effective_bytes={d}", .{
             direction,
             outcome.requested_bytes orelse 0,
+            outcome.granted_bytes orelse 0,
             effective,
         }),
-        .clamped => logger.warn(null, "http3: udp {s} buffer clamped by the kernel requested_bytes={d} effective_bytes={d}; raise {s} on the host or lower the configured request", .{
+        .clamped => logger.warn(null, "http3: udp {s} buffer clamped by the kernel requested_bytes={d} granted_bytes={d} effective_bytes={d}; raise {s} on the host or lower the configured request", .{
             direction,
             outcome.requested_bytes orelse 0,
+            outcome.granted_bytes orelse 0,
             effective,
             socket_buffer_ceiling_hint,
         }),
@@ -4989,15 +5016,52 @@ test "http3 runtime: socket buffer sizes are read back from the kernel, not assu
     try testing.expect(untouched.recv.effective_bytes != null);
     try testing.expect(untouched.send.effective_bytes != null);
 
-    // A request every kernel this runs on can satisfy from its default
-    // ceiling, so the outcome is a grant rather than a clamp.
-    const requested: usize = 256 * 1024;
-    const tuned = tuneSocketBuffers(fd, .{ .recv_bytes = requested, .send_bytes = requested });
+    // A satisfiable request, *derived from this host* rather than assumed: no
+    // fixed constant is below every kernel's ceiling, and a hardcoded one that
+    // happens to pass says nothing about the grant path. Half of what the
+    // socket already has is inside any ceiling that produced that default.
+    const recv_request = quic.udp.clampBufferBytes(grantedBufferBytes(untouched.recv.effective_bytes.?) / 2);
+    const send_request = quic.udp.clampBufferBytes(grantedBufferBytes(untouched.send.effective_bytes.?) / 2);
+    const tuned = tuneSocketBuffers(fd, .{ .recv_bytes = recv_request, .send_bytes = send_request });
     try testing.expectEqual(quic.udp.BufferTuningStatus.applied, tuned.recv.status);
     try testing.expectEqual(quic.udp.BufferTuningStatus.applied, tuned.send.status);
-    try testing.expectEqual(@as(?usize, requested), tuned.recv.requested_bytes);
-    try testing.expect(tuned.recv.effective_bytes.? >= requested);
-    try testing.expect(tuned.send.effective_bytes.? >= requested);
+    try testing.expectEqual(@as(?usize, recv_request), tuned.recv.requested_bytes);
+
+    // The grant is judged in request units. On Linux the raw reading is about
+    // twice that; asserting on the raw reading instead would pass for the
+    // wrong reason there.
+    try testing.expect(tuned.recv.granted_bytes.? >= recv_request);
+    try testing.expect(tuned.send.granted_bytes.? >= send_request);
+    try testing.expectEqual(grantedBufferBytes(tuned.recv.effective_bytes.?), tuned.recv.granted_bytes.?);
+}
+
+test "http3 runtime: a kernel ceiling below the request is reported as a clamp" {
+    // The failure this whole readback exists for: `setsockopt` succeeds, the
+    // kernel silently caps the size, and nothing outside the process can tell.
+    // Asking for the ABI maximum guarantees the cap on any host — no kernel
+    // grants a 1 GiB socket buffer by default — so this exercises the clamp
+    // path rather than describing it.
+    //
+    // On Linux the raw reading of that capped buffer is doubled and can exceed
+    // the request outright; the classification must still be `clamped`, which
+    // is what pins the false positive shut.
+    const fd = openUdpSocket(posix.AF.INET);
+    if (fd < 0) return error.SkipZigTest;
+    defer _ = std.c.close(fd);
+
+    const outcome = tuneSocketBuffer(fd, posix.SO.RCVBUF, quic.udp.max_buffer_bytes);
+    if (outcome.status == .unsupported or outcome.status == .unverified) return error.SkipZigTest;
+    try testing.expectEqual(quic.udp.BufferTuningStatus.clamped, outcome.status);
+    try testing.expect(outcome.granted_bytes.? < quic.udp.max_buffer_bytes);
+}
+
+test "http3 runtime: only Linux restates socket buffer readings" {
+    // The doubling is a Linux storage detail, not a portable one: Darwin and
+    // the BSDs report what was set. Halving elsewhere would invent a clamp
+    // that never happened and warn on every correctly applied request.
+    const reported: usize = 8 * 1024 * 1024;
+    const expected: usize = if (builtin.os.tag == .linux) reported / 2 else reported;
+    try testing.expectEqual(expected, grantedBufferBytes(reported));
 }
 
 test "http3 runtime: an oversized buffer request never reaches the kernel as one" {

--- a/src/quic/udp.zig
+++ b/src/quic/udp.zig
@@ -87,12 +87,19 @@ pub const BufferTuning = struct {
 
 /// Bounds on a socket buffer request. The upper bound is not a policy opinion
 /// about how much buffering is useful — kernels clamp long before this — it
-/// keeps the request inside the `c_int` every `setsockopt(SO_RCVBUF)` ABI
-/// takes, so an operator typo cannot wrap into a negative size. The lower
-/// bound is below every kernel minimum this code knows of, so it only catches
-/// values that could not have been meant.
+/// keeps the request inside what the platform can actually represent, so an
+/// operator typo cannot wrap into a negative size. The lower bound is below
+/// every kernel minimum this code knows of, so it only catches values that
+/// could not have been meant.
+///
+/// The upper bound is `INT_MAX / 2` rather than a round 1 GiB because the
+/// `setsockopt` ABI takes a signed 32-bit size *and* Linux stores twice what
+/// it is given: a request has to leave room for that doubling to stay
+/// representable. Asking for 1 GiB exactly would be silently reduced by one
+/// byte on Linux and then reported as a clamp forever — pointing the operator
+/// at a `net.core.rmem_max` that was never the cause.
 pub const min_buffer_bytes: usize = 2048;
-pub const max_buffer_bytes: usize = 1 << 30;
+pub const max_buffer_bytes: usize = @as(usize, std.math.maxInt(c_int)) / 2;
 
 pub fn clampBufferBytes(requested: usize) usize {
     return std.math.clamp(requested, min_buffer_bytes, max_buffer_bytes);
@@ -444,6 +451,34 @@ test "socket buffer requests stay inside the setsockopt ABI" {
     try std.testing.expect(max_buffer_bytes <= std.math.maxInt(c_int));
     try std.testing.expectEqual(min_buffer_bytes, clampBufferBytes(1));
     try std.testing.expectEqual(@as(usize, 4 * 1024 * 1024), clampBufferBytes(4 * 1024 * 1024));
+
+    // The bound has to survive *doubling*, not just the ABI: Linux stores
+    // twice what it is given and caps the request at `INT_MAX / 2` first, so a
+    // maximum that leaves no room for the doubling would be reduced by the
+    // kernel and could never be granted in full.
+    try std.testing.expect(max_buffer_bytes * 2 <= std.math.maxInt(c_int));
+}
+
+test "the maximum request is grantable, not permanently clamped by its own bound" {
+    // The exact upper boundary must be able to come back `applied` on a host
+    // whose ceiling permits it. A maximum the platform cannot represent would
+    // report a one-byte clamp forever and send the operator after a sysctl
+    // that was never the cause.
+    const at_maximum = classifyBufferOutcome(max_buffer_bytes, true, .{
+        // What Linux reports for a fully granted maximum: twice the request.
+        .reported_bytes = max_buffer_bytes * 2,
+        .granted_bytes = max_buffer_bytes,
+    });
+    try std.testing.expectEqual(BufferTuningStatus.applied, at_maximum.status);
+    try std.testing.expectEqual(@as(?usize, max_buffer_bytes), at_maximum.granted_bytes);
+
+    // And a host ceiling below it is still a clamp, so making the maximum
+    // reachable did not cost the diagnostic.
+    const capped_at_maximum = classifyBufferOutcome(max_buffer_bytes, true, .{
+        .reported_bytes = 425_984,
+        .granted_bytes = 212_992,
+    });
+    try std.testing.expectEqual(BufferTuningStatus.clamped, capped_at_maximum.status);
 }
 
 test "DCID routing key owns a bounded connection ID" {

--- a/src/quic/udp.zig
+++ b/src/quic/udp.zig
@@ -76,10 +76,95 @@ pub const SendDatagram = struct {
     send_at_us: ?u64 = null,
 };
 
+/// Requested socket buffer sizes. `null` leaves the kernel default alone —
+/// which is the right answer for most deployments, since the default is
+/// already sized for the host. See `EffectiveBufferTuning` for what a request
+/// is actually worth: this is advisory, and a kernel is free to grant less.
 pub const BufferTuning = struct {
     recv_bytes: ?usize = null,
     send_bytes: ?usize = null,
 };
+
+/// Bounds on a socket buffer request. The upper bound is not a policy opinion
+/// about how much buffering is useful — kernels clamp long before this — it
+/// keeps the request inside the `c_int` every `setsockopt(SO_RCVBUF)` ABI
+/// takes, so an operator typo cannot wrap into a negative size. The lower
+/// bound is below every kernel minimum this code knows of, so it only catches
+/// values that could not have been meant.
+pub const min_buffer_bytes: usize = 2048;
+pub const max_buffer_bytes: usize = 1 << 30;
+
+pub fn clampBufferBytes(requested: usize) usize {
+    return std.math.clamp(requested, min_buffer_bytes, max_buffer_bytes);
+}
+
+/// What became of one socket buffer request. Socket buffer sizing is a
+/// performance setting, not a correctness one: every outcome here is a
+/// working listener, and none of them is a reason to fail startup. The
+/// distinctions exist so an operator can tell "you got what you asked for"
+/// from "the kernel silently gave you an eighth of it", which otherwise look
+/// identical from outside the process.
+pub const BufferTuningStatus = enum {
+    /// Nothing was requested; the kernel default stands.
+    default,
+    /// The kernel granted at least the requested size.
+    applied,
+    /// The kernel accepted the request and granted less than was asked for —
+    /// a system-wide ceiling (`net.core.rmem_max` on Linux,
+    /// `kern.ipc.maxsockbuf` on Darwin/BSD) that only the host operator can
+    /// raise. Worth a warning: the process is running with a buffer it did
+    /// not choose.
+    clamped,
+    /// The kernel accepted the request but the size could not be read back,
+    /// so nothing here is a measurement. Reported separately rather than
+    /// being reported as `applied`, which would be a claim this code cannot
+    /// support.
+    unverified,
+    /// The kernel refused the request outright. The default buffer stands.
+    unsupported,
+};
+
+/// One direction's tuning result. `effective_bytes` is what `getsockopt` read
+/// back, never what was asked for: kernels adjust these requests and the
+/// adjustment is the interesting part. Linux in particular returns roughly
+/// *twice* what was set — it reserves the other half for its own per-datagram
+/// bookkeeping — so a readback larger than the request is normal there and is
+/// not evidence of extra payload capacity.
+pub const BufferOutcome = struct {
+    requested_bytes: ?usize = null,
+    /// `null` when the readback itself failed.
+    effective_bytes: ?usize = null,
+    status: BufferTuningStatus = .default,
+};
+
+pub const EffectiveBufferTuning = struct {
+    recv: BufferOutcome = .{},
+    send: BufferOutcome = .{},
+};
+
+/// Classify one direction's tuning attempt from what the socket layer
+/// observed: what was asked for, whether `setsockopt` accepted it, and what
+/// `getsockopt` read back afterwards (`null` if that failed).
+///
+/// Deliberately platform-neutral and syscall-free so the policy is testable
+/// without a socket — the caller owns the syscalls, this owns the meaning.
+pub fn classifyBufferOutcome(requested: ?usize, accepted: bool, effective: ?usize) BufferOutcome {
+    const want = requested orelse return .{ .effective_bytes = effective, .status = .default };
+    if (!accepted) return .{
+        .requested_bytes = want,
+        .effective_bytes = effective,
+        .status = .unsupported,
+    };
+    const got = effective orelse return .{
+        .requested_bytes = want,
+        .status = .unverified,
+    };
+    return .{
+        .requested_bytes = want,
+        .effective_bytes = got,
+        .status = if (got >= want) .applied else .clamped,
+    };
+}
 
 pub const ReceiveError = error{
     WouldBlock,
@@ -108,7 +193,7 @@ pub const Endpoint = struct {
     clock: Clock,
     recvFn: *const fn (*anyopaque, []u8, Clock) ReceiveError!ReceivedDatagram,
     sendFn: *const fn (*anyopaque, SendDatagram) SendError!void,
-    tuneBuffersFn: *const fn (*anyopaque, BufferTuning) void,
+    tuneBuffersFn: *const fn (*anyopaque, BufferTuning) EffectiveBufferTuning,
 
     pub fn receive(self: Endpoint, scratch: []u8) ReceiveError!ReceivedDatagram {
         return self.recvFn(self.ctx, scratch, self.clock);
@@ -120,8 +205,11 @@ pub const Endpoint = struct {
         try self.sendFn(self.ctx, datagram);
     }
 
-    pub fn tuneBuffers(self: Endpoint, tuning: BufferTuning) void {
-        self.tuneBuffersFn(self.ctx, tuning);
+    /// Advisory: a request the kernel refuses or trims still leaves a working
+    /// endpoint, so this reports what happened rather than failing. The
+    /// caller is expected to surface the result, not to act on it.
+    pub fn tuneBuffers(self: Endpoint, tuning: BufferTuning) EffectiveBufferTuning {
+        return self.tuneBuffersFn(self.ctx, tuning);
     }
 };
 
@@ -185,9 +273,13 @@ const FakeEndpoint = struct {
         self.last_sent_len = datagram.bytes.len;
     }
 
-    fn tune(ctx: *anyopaque, tuning: BufferTuning) void {
+    fn tune(ctx: *anyopaque, tuning: BufferTuning) EffectiveBufferTuning {
         const self: *FakeEndpoint = @ptrCast(@alignCast(ctx));
         self.last_tuning = tuning;
+        return .{
+            .recv = classifyBufferOutcome(tuning.recv_bytes, true, tuning.recv_bytes),
+            .send = classifyBufferOutcome(tuning.send_bytes, true, tuning.send_bytes),
+        };
     }
 
     fn endpoint(self: *FakeEndpoint) Endpoint {
@@ -230,9 +322,59 @@ test "UDP endpoint exposes send and buffer tuning hooks" {
         .remote = Address.ip4(.{ 127, 0, 0, 1 }, 4433),
         .send_at_us = 100,
     });
-    endpoint.tuneBuffers(.{ .recv_bytes = 4 * 1024 * 1024, .send_bytes = 1024 * 1024 });
+    const effective = endpoint.tuneBuffers(.{ .recv_bytes = 4 * 1024 * 1024, .send_bytes = 1024 * 1024 });
     try std.testing.expectEqual(@as(usize, 5), fake.last_sent_len);
     try std.testing.expectEqual(@as(?usize, 4 * 1024 * 1024), fake.last_tuning.recv_bytes);
+    try std.testing.expectEqual(BufferTuningStatus.applied, effective.recv.status);
+    try std.testing.expectEqual(@as(?usize, 1024 * 1024), effective.send.effective_bytes);
+}
+
+test "socket buffer tuning reports what the kernel did, not what was asked" {
+    // Nothing requested: the kernel default stands, and reading it back is
+    // still worth doing — benchmark metadata wants the number either way.
+    const untouched = classifyBufferOutcome(null, false, 212_992);
+    try std.testing.expectEqual(BufferTuningStatus.default, untouched.status);
+    try std.testing.expectEqual(@as(?usize, null), untouched.requested_bytes);
+    try std.testing.expectEqual(@as(?usize, 212_992), untouched.effective_bytes);
+
+    // Linux hands back about twice what was set — it reserves the rest for
+    // bookkeeping — so a larger readback is a grant, not an anomaly.
+    const doubled = classifyBufferOutcome(4 * 1024 * 1024, true, 8 * 1024 * 1024);
+    try std.testing.expectEqual(BufferTuningStatus.applied, doubled.status);
+
+    // Exactly what was asked for (Darwin, BSD) is equally a grant.
+    const exact = classifyBufferOutcome(4 * 1024 * 1024, true, 4 * 1024 * 1024);
+    try std.testing.expectEqual(BufferTuningStatus.applied, exact.status);
+
+    // The interesting case: `setsockopt` succeeded and the kernel still gave
+    // a fraction of the request, because a system-wide ceiling
+    // (`net.core.rmem_max`) outranks it. Silent without a readback.
+    const ceiling = classifyBufferOutcome(64 * 1024 * 1024, true, 425_984);
+    try std.testing.expectEqual(BufferTuningStatus.clamped, ceiling.status);
+    try std.testing.expectEqual(@as(?usize, 64 * 1024 * 1024), ceiling.requested_bytes);
+    try std.testing.expectEqual(@as(?usize, 425_984), ceiling.effective_bytes);
+
+    // Accepted but unreadable is not `applied`: nothing was measured, and
+    // claiming otherwise would invent a number the process never saw.
+    const unverified = classifyBufferOutcome(4 * 1024 * 1024, true, null);
+    try std.testing.expectEqual(BufferTuningStatus.unverified, unverified.status);
+    try std.testing.expectEqual(@as(?usize, null), unverified.effective_bytes);
+
+    // Refused outright: the default buffer is what the socket has, and it is
+    // reported rather than the request that failed.
+    const refused = classifyBufferOutcome(4 * 1024 * 1024, false, 212_992);
+    try std.testing.expectEqual(BufferTuningStatus.unsupported, refused.status);
+    try std.testing.expectEqual(@as(?usize, 212_992), refused.effective_bytes);
+}
+
+test "socket buffer requests stay inside the setsockopt ABI" {
+    // `setsockopt(SO_RCVBUF)` takes a `c_int`. A request that wraps it would
+    // be a negative size, so an operator typo is clamped to something the ABI
+    // can express rather than being handed to the kernel as-is.
+    try std.testing.expectEqual(max_buffer_bytes, clampBufferBytes(std.math.maxInt(usize)));
+    try std.testing.expect(max_buffer_bytes <= std.math.maxInt(c_int));
+    try std.testing.expectEqual(min_buffer_bytes, clampBufferBytes(1));
+    try std.testing.expectEqual(@as(usize, 4 * 1024 * 1024), clampBufferBytes(4 * 1024 * 1024));
 }
 
 test "DCID routing key owns a bounded connection ID" {

--- a/src/quic/udp.zig
+++ b/src/quic/udp.zig
@@ -124,16 +124,41 @@ pub const BufferTuningStatus = enum {
     unsupported,
 };
 
+/// One `getsockopt` readback, in both the units the kernel reports it in and
+/// the units the request was made in.
+///
+/// On most platforms these are the same number. Linux is the reason they are
+/// separate fields: it stores `SO_RCVBUF`/`SO_SNDBUF` as *twice* the requested
+/// size — the other half is per-datagram bookkeeping, not payload capacity —
+/// and reports the doubled figure. Comparing that figure to the request would
+/// call a grant of half what was asked for a success, which is exactly the
+/// case this whole readback exists to catch.
+///
+/// Translating between the two is a property of the OS, not of QUIC, so the
+/// caller that owns the socket owns the translation and this layer stays
+/// OS-neutral.
+pub const BufferReadback = struct {
+    /// Exactly what `getsockopt` returned. `null` when the readback failed.
+    /// This is the number to report: it is what the kernel will say if an
+    /// operator checks the socket themselves.
+    reported_bytes: ?usize = null,
+    /// The same measurement restated in the units the request was made in, so
+    /// it can be compared against it. `null` when nothing was requested or
+    /// the readback failed.
+    granted_bytes: ?usize = null,
+};
+
 /// One direction's tuning result. `effective_bytes` is what `getsockopt` read
 /// back, never what was asked for: kernels adjust these requests and the
-/// adjustment is the interesting part. Linux in particular returns roughly
-/// *twice* what was set — it reserves the other half for its own per-datagram
-/// bookkeeping — so a readback larger than the request is normal there and is
-/// not evidence of extra payload capacity.
+/// adjustment is the interesting part. `granted_bytes` is that same reading
+/// made comparable to `requested_bytes` (see `BufferReadback`), and is what
+/// the grant/clamp decision is made on.
 pub const BufferOutcome = struct {
     requested_bytes: ?usize = null,
     /// `null` when the readback itself failed.
     effective_bytes: ?usize = null,
+    /// `null` when nothing was requested, or when the readback failed.
+    granted_bytes: ?usize = null,
     status: BufferTuningStatus = .default,
 };
 
@@ -144,25 +169,31 @@ pub const EffectiveBufferTuning = struct {
 
 /// Classify one direction's tuning attempt from what the socket layer
 /// observed: what was asked for, whether `setsockopt` accepted it, and what
-/// `getsockopt` read back afterwards (`null` if that failed).
+/// `getsockopt` read back afterwards.
 ///
 /// Deliberately platform-neutral and syscall-free so the policy is testable
-/// without a socket — the caller owns the syscalls, this owns the meaning.
-pub fn classifyBufferOutcome(requested: ?usize, accepted: bool, effective: ?usize) BufferOutcome {
-    const want = requested orelse return .{ .effective_bytes = effective, .status = .default };
+/// without a socket — the caller owns the syscalls and the platform's readback
+/// semantics, this owns the meaning.
+pub fn classifyBufferOutcome(requested: ?usize, accepted: bool, readback: BufferReadback) BufferOutcome {
+    const want = requested orelse return .{
+        .effective_bytes = readback.reported_bytes,
+        .status = .default,
+    };
     if (!accepted) return .{
         .requested_bytes = want,
-        .effective_bytes = effective,
+        .effective_bytes = readback.reported_bytes,
         .status = .unsupported,
     };
-    const got = effective orelse return .{
+    const granted = readback.granted_bytes orelse return .{
         .requested_bytes = want,
+        .effective_bytes = readback.reported_bytes,
         .status = .unverified,
     };
     return .{
         .requested_bytes = want,
-        .effective_bytes = got,
-        .status = if (got >= want) .applied else .clamped,
+        .effective_bytes = readback.reported_bytes,
+        .granted_bytes = granted,
+        .status = if (granted >= want) .applied else .clamped,
     };
 }
 
@@ -277,8 +308,14 @@ const FakeEndpoint = struct {
         const self: *FakeEndpoint = @ptrCast(@alignCast(ctx));
         self.last_tuning = tuning;
         return .{
-            .recv = classifyBufferOutcome(tuning.recv_bytes, true, tuning.recv_bytes),
-            .send = classifyBufferOutcome(tuning.send_bytes, true, tuning.send_bytes),
+            .recv = classifyBufferOutcome(tuning.recv_bytes, true, .{
+                .reported_bytes = tuning.recv_bytes,
+                .granted_bytes = tuning.recv_bytes,
+            }),
+            .send = classifyBufferOutcome(tuning.send_bytes, true, .{
+                .reported_bytes = tuning.send_bytes,
+                .granted_bytes = tuning.send_bytes,
+            }),
         };
     }
 
@@ -332,39 +369,71 @@ test "UDP endpoint exposes send and buffer tuning hooks" {
 test "socket buffer tuning reports what the kernel did, not what was asked" {
     // Nothing requested: the kernel default stands, and reading it back is
     // still worth doing — benchmark metadata wants the number either way.
-    const untouched = classifyBufferOutcome(null, false, 212_992);
+    const untouched = classifyBufferOutcome(null, false, .{ .reported_bytes = 212_992 });
     try std.testing.expectEqual(BufferTuningStatus.default, untouched.status);
     try std.testing.expectEqual(@as(?usize, null), untouched.requested_bytes);
     try std.testing.expectEqual(@as(?usize, 212_992), untouched.effective_bytes);
 
-    // Linux hands back about twice what was set — it reserves the rest for
-    // bookkeeping — so a larger readback is a grant, not an anomaly.
-    const doubled = classifyBufferOutcome(4 * 1024 * 1024, true, 8 * 1024 * 1024);
-    try std.testing.expectEqual(BufferTuningStatus.applied, doubled.status);
-
-    // Exactly what was asked for (Darwin, BSD) is equally a grant.
-    const exact = classifyBufferOutcome(4 * 1024 * 1024, true, 4 * 1024 * 1024);
+    // Exactly what was asked for (Darwin, BSD) is a grant.
+    const exact = classifyBufferOutcome(4 * 1024 * 1024, true, .{
+        .reported_bytes = 4 * 1024 * 1024,
+        .granted_bytes = 4 * 1024 * 1024,
+    });
     try std.testing.expectEqual(BufferTuningStatus.applied, exact.status);
 
     // The interesting case: `setsockopt` succeeded and the kernel still gave
     // a fraction of the request, because a system-wide ceiling
     // (`net.core.rmem_max`) outranks it. Silent without a readback.
-    const ceiling = classifyBufferOutcome(64 * 1024 * 1024, true, 425_984);
+    const ceiling = classifyBufferOutcome(64 * 1024 * 1024, true, .{
+        .reported_bytes = 425_984,
+        .granted_bytes = 212_992,
+    });
     try std.testing.expectEqual(BufferTuningStatus.clamped, ceiling.status);
     try std.testing.expectEqual(@as(?usize, 64 * 1024 * 1024), ceiling.requested_bytes);
     try std.testing.expectEqual(@as(?usize, 425_984), ceiling.effective_bytes);
+    try std.testing.expectEqual(@as(?usize, 212_992), ceiling.granted_bytes);
 
     // Accepted but unreadable is not `applied`: nothing was measured, and
     // claiming otherwise would invent a number the process never saw.
-    const unverified = classifyBufferOutcome(4 * 1024 * 1024, true, null);
+    const unverified = classifyBufferOutcome(4 * 1024 * 1024, true, .{});
     try std.testing.expectEqual(BufferTuningStatus.unverified, unverified.status);
     try std.testing.expectEqual(@as(?usize, null), unverified.effective_bytes);
+    try std.testing.expectEqual(@as(?usize, null), unverified.granted_bytes);
 
     // Refused outright: the default buffer is what the socket has, and it is
     // reported rather than the request that failed.
-    const refused = classifyBufferOutcome(4 * 1024 * 1024, false, 212_992);
+    const refused = classifyBufferOutcome(4 * 1024 * 1024, false, .{ .reported_bytes = 212_992 });
     try std.testing.expectEqual(BufferTuningStatus.unsupported, refused.status);
     try std.testing.expectEqual(@as(?usize, 212_992), refused.effective_bytes);
+}
+
+test "a doubled Linux readback is judged in request units, not kernel units" {
+    // Linux stores twice what was set and reports the doubled figure. Judging
+    // a request against that figure would call any grant of more than half the
+    // request a success — including the ones this readback exists to catch —
+    // so the decision is made on the reading restated in request units, while
+    // the raw kernel number is still what gets reported.
+
+    // A true grant: 4 MiB set, 8 MiB reported, 4 MiB actually granted.
+    const granted = classifyBufferOutcome(4 * 1024 * 1024, true, .{
+        .reported_bytes = 8 * 1024 * 1024,
+        .granted_bytes = 4 * 1024 * 1024,
+    });
+    try std.testing.expectEqual(BufferTuningStatus.applied, granted.status);
+    try std.testing.expectEqual(@as(?usize, 8 * 1024 * 1024), granted.effective_bytes);
+    try std.testing.expectEqual(@as(?usize, 4 * 1024 * 1024), granted.granted_bytes);
+
+    // The false-positive window: a 300 KiB request on a host whose
+    // `net.core.rmem_max` is 208 KiB. The kernel caps at the ceiling and
+    // reports 416 KiB — larger than the request — while the operator got
+    // barely two thirds of what they asked for.
+    const capped = classifyBufferOutcome(307_200, true, .{
+        .reported_bytes = 425_984,
+        .granted_bytes = 212_992,
+    });
+    try std.testing.expectEqual(BufferTuningStatus.clamped, capped.status);
+    try std.testing.expect(capped.effective_bytes.? > capped.requested_bytes.?);
+    try std.testing.expect(capped.granted_bytes.? < capped.requested_bytes.?);
 }
 
 test "socket buffer requests stay inside the setsockopt ABI" {


### PR DESCRIPTION
## Summary

Slice D of #256 — the listener asks for the UDP socket buffers it wants, and reports what the kernel actually gave it.

A full UDP receive buffer drops datagrams the kernel has already taken off the wire. QUIC cannot distinguish that from network loss: congestion control backs off and packets are retransmitted for a reason nothing on the path caused. Until now the listener set `SO_REUSEADDR` and nothing else, so a host whose default buffer was small had no knob at all.

- **`TARDIGRADE_HTTP3_UDP_RECV_BUFFER_BYTES` / `TARDIGRADE_HTTP3_UDP_SEND_BUFFER_BYTES`** request `SO_RCVBUF`/`SO_SNDBUF` on the QUIC socket before `bind`. Both default to `0` — leave the kernel's own sizing alone — which stays the right answer unless drops have been measured. Requests are clamped into `[2048, 1 GiB]` so an operator typo cannot wrap the signed 32-bit `setsockopt` ABI into a negative size.
- **Advisory, never fatal.** A kernel that refuses or trims the request still yields a listener that serves HTTP/3 correctly; failing startup over a performance knob would be worse than running with the default.
- **But never silent.** Linux caps requests at `net.core.rmem_max` while `setsockopt` still returns success, so the size is **read back with `getsockopt`** and classified: `applied`, `clamped` (accepted, cut down by a host ceiling — warns, and names the sysctl to raise), `unsupported` (refused), `unverified` (accepted, unreadable — reported as such rather than claiming a number the process never saw), or `default`. Linux returning roughly double what was set is per-datagram bookkeeping overhead, not payload capacity, and counts as a grant.
- **Effective values are published** on `http3_runtime.Snapshot.udp_buffers` and logged at startup. The `EffectiveBufferTuning` classification lives in `src/quic/udp.zig` as a syscall-free, platform-neutral policy alongside the existing `BufferTuning` seam (which was test-only until now, and whose `tuneBuffers` hook now returns the outcome); `http3_runtime` owns the syscalls, next to `configureNoFragment`.
- **Benchmark metadata** records the host's UDP buffer ceilings (`net.core.rmem_max`/`wmem_max`, or `kern.ipc.maxsockbuf`) and the configured request, since a run whose buffer filled shows up as loss in the results and makes two otherwise-identical runs incomparable.
- Both variables are **restart-required** — buffer sizes are socket state applied to the live descriptor at bind time — and rejected by reload validation like every other listener-owned H3 knob.

Nothing here touches congestion control, flow control, path validation, or anti-amplification: it changes only how much the kernel will hold on this process's behalf.

## Test plan

- [x] `zig build test --summary all` — 3593 passed, 10 skipped (same 10 as on `main`).
- [x] `zig fmt --check build.zig src/ tests/`, `shellcheck benchmarks/competitive/run.sh`.
- [x] Deterministic classification tests in `src/quic/udp.zig`: Linux doubling counted as a grant, exact-match grant, kernel ceiling reported as `clamped` with both numbers, accepted-but-unreadable reported as `unverified` rather than `applied`, outright refusal reported with the default still read back, nothing-requested still read back, and the `c_int` ABI clamp.
- [x] Real-socket tests in `src/http/http3_runtime.zig`: untouched socket reports the kernel default; a satisfiable request is granted and read back; an oversized request is clamped to the ABI bound before reaching the kernel.
- [x] Runtime wiring tests: a listener asking for 1 GiB still binds and bootstraps, with the outcome published; an untuned listener still reports both effective sizes.
- [x] Reload test: changing either target requires a listener restart.
- [x] Live gateway run on macOS — `applied` (8 MiB requested, 8 MiB granted), `clamped` (1 GiB requested → 8388608, warning names `kern.ipc.maxsockbuf`), and the untuned default readback (Darwin's 9216-byte send buffer, which is exactly the kind of thing this makes visible).

Linux-specific behavior (the `rmem_max` clamp and the doubled readback) is covered by the deterministic classification tests rather than by a host that exhibits it; CI runs the socket tests on Linux.

Slice D of #256 — the umbrella issue stays open for the remaining slices (C pacing, E ECN, F GSO/GRO notes, G benchmarks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)