### PR TITLE
perf(quic): finish ECN end to end (#256-E)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable user-facing changes to Tardigrade are documented here.
 ## [Unreleased]
 
 ### Added
+- **Explicit Congestion Notification for HTTP/3 (#256-E)** — the QUIC listener
+  now marks outbound datagrams ECT(0), counts the codepoints on received
+  packets, reports them to peers in ACK_ECN, and validates the counters peers
+  report back. A congested router can mark a packet instead of dropping it, so
+  congestion control reacts a round trip earlier and without a retransmission.
+
+  ECN is validated per network path and only after the handshake is confirmed;
+  a migration re-validates rather than inheriting an answer measured elsewhere.
+  Because the peer's counters are an input to congestion control and reachable
+  by anything on the path, they are checked against what was actually sent —
+  counters that regress, exceed what was marked, report a codepoint this
+  endpoint never sends, or fail to grow when marked packets are acknowledged
+  all turn marking off for that path. CE reports drive congestion response only
+  on a validated path, and the counters reported back come only from packets
+  that passed AEAD authentication, so an off-path spoofer cannot inflate them.
+  Every failure ends in ordinary non-ECN operation, never a connection error —
+  which is the common outcome on the open internet, where a great deal of
+  deployed gear clears or rewrites the field.
+
+  Platform support is gated on verified per-OS socket constants (Linux, Darwin,
+  FreeBSD); anywhere else the listener simply runs without ECN.
+  `TARDIGRADE_HTTP3_ECN` (default `true`) disables it outright, for hosts where
+  a middlebox drops marked traffic rather than clearing the marks — the one
+  failure mode per-path validation cannot see. The runtime status snapshot
+  publishes whether marking is actually running along with marked-sent,
+  validated-path, disabled-path, and CE counts. See `docs/HTTP3_ROLLOUT.md`.
 - **Tunable UDP socket buffers for the HTTP/3 listener (#256-D)** —
   `TARDIGRADE_HTTP3_UDP_RECV_BUFFER_BYTES` and
   `TARDIGRADE_HTTP3_UDP_SEND_BUFFER_BYTES` request `SO_RCVBUF`/`SO_SNDBUF` on

--- a/docs/CONCURRENCY.md
+++ b/docs/CONCURRENCY.md
@@ -168,6 +168,7 @@ they need public control.
 | Retry policy | address validation / tokens | `off` | `TARDIGRADE_HTTP3_RETRY_POLICY=off\|address_validation`; `address_validation` sends stateless QUIC Retry before allocating connection state |
 | Migration policy | `disable_active_migration` | NAT rebinding only | `TARDIGRADE_HTTP3_CONNECTION_MIGRATION=false` permits same-IP NAT rebinding but not active migration; `true` enables full migration |
 | UDP socket buffers | `SO_RCVBUF` / `SO_SNDBUF` | kernel default | `TARDIGRADE_HTTP3_UDP_RECV_BUFFER_BYTES` / `..._SEND_BUFFER_BYTES`; advisory, read back with `getsockopt` and published on the runtime snapshot |
+| ECN | ECT(0) marking + ACK_ECN | on where the kernel supports it | `TARDIGRADE_HTTP3_ECN=false` disables; validated per path and turned off for that path on inconsistent peer feedback |
 | qlog / keylog | debug artifact emission | off | local-debug toggle |
 | QPACK | SETTINGS | static-only, zero dynamic capacity | internal until dynamic QPACK lands |
 

--- a/docs/HTTP3_ROLLOUT.md
+++ b/docs/HTTP3_ROLLOUT.md
@@ -278,6 +278,14 @@ path it has been reached on:
   accounted for. Adopting the first report that happens to arrive would write
   off whatever was already in flight, and the next honest report covering
   those packets would look like an over-claim.
+
+  The counters that baseline is taken from advance only on reports that
+  *survived* validation. A rejected report is not a synchronisation point: a
+  count that regressed to 8 would otherwise become the baseline a later path is
+  measured from, and the real cumulative 10 arriving afterwards would credit
+  that path with growth it never earned. Counters that regress or over-claim
+  fail ECN closed for the connection; a stripped or rewritten codepoint
+  condemns only the route, and leaves the counters usable for the next path.
 - **A migration waits for the previous path's marks to drain** before the new
   one starts testing. Otherwise the old path's intact marks would validate a
   new path that is stripping every codepoint, and the old path's CE reports

--- a/docs/HTTP3_ROLLOUT.md
+++ b/docs/HTTP3_ROLLOUT.md
@@ -284,6 +284,12 @@ path it has been reached on:
   would halve the new path's window for congestion that is no longer on the
   route. Promotion additionally requires an acknowledgement of a packet the
   new path itself marked.
+
+  Only an *acknowledgement* drains that wait. A loss declaration does not:
+  QUIC loss is an inference, and the packet may well have arrived and been
+  counted while the ACK reporting it was itself lost. Since a packet that is
+  never acknowledged is never settled, the wait is bounded — and running out
+  turns ECN off for the connection rather than releasing on an assumption.
 - **An ACK that does not advance the largest acknowledged packet number is
   ignored entirely** (RFC 9000 §13.4.2.1). Cumulative counters arrive
   legitimately stale on a reordered ACK, and validating against them would
@@ -291,7 +297,17 @@ path it has been reached on:
 
 The testing window is armed by the first marked packet rather than by
 enabling, so an idle connection cannot time out a path that was never given a
-chance to carry one.
+chance to carry one. Only packets that are *in flight* are marked at all —
+never a pure ACK, which RFC 9000 §13.2 notes can go unacknowledged for a long
+time and so would arm that window on feedback that may never come.
+
+Two of these end in ECN being off for the whole connection rather than for one
+path: `evidence_lost` (the bounded per-connection ECN metadata overflowed, or a
+migration's wait ran out) and `platform_unsupported`. Both are conservative by
+design — the peer's counters drive congestion response, so when attribution
+stops being provable the answer is to stop using them, not to keep going on
+evidence that can no longer be checked. A long-lived connection over a lossy
+path can reach `evidence_lost`; that is a deliberate trade, not a defect.
 
 Validation is not a formality. The peer's counters are an *input to congestion
 control*, reachable by anything on the path and by the peer itself, so they are
@@ -305,6 +321,8 @@ checked against what this endpoint actually sent before they are believed:
 | More marked arrivals reported than were ever marked | `counts_exceed_sent` |
 | Marked packets acknowledged without matching counter growth | `insufficient_increase` |
 | No usable feedback within the testing window (3×PTO) | `testing_timeout` |
+| Metadata needed to attribute the counters was dropped | `evidence_lost` |
+| The socket turned out to be unable to set the codepoint | `platform_unsupported` |
 
 Any of these turns marking off for that path and the connection continues
 normally. **CE reports are acted on only on a validated path**, so an

--- a/docs/HTTP3_ROLLOUT.md
+++ b/docs/HTTP3_ROLLOUT.md
@@ -298,6 +298,15 @@ path it has been reached on:
   counted while the ACK reporting it was itself lost. Since a packet that is
   never acknowledged is never settled, the wait is bounded — and running out
   turns ECN off for the connection rather than releasing on an assumption.
+
+  Acknowledgement alone is not quite enough either. If the ACK that
+  acknowledged a mark carried no counts, or carried stale ones, the peer may
+  already have counted that mark where this endpoint cannot see it — so the
+  trusted baseline is behind by an unknown amount, and a new path started from
+  it would be handed the old path's growth as its own evidence. The wait
+  therefore also covers that obligation, discharged by the next current
+  ACK_ECN: generated after the acknowledgement, its counters necessarily
+  include whatever the acknowledged packet contributed.
 - **An ACK that does not advance the largest acknowledged packet number is
   ignored entirely** (RFC 9000 §13.4.2.1). Cumulative counters arrive
   legitimately stale on a reordered ACK, and validating against them would

--- a/docs/HTTP3_ROLLOUT.md
+++ b/docs/HTTP3_ROLLOUT.md
@@ -269,6 +269,30 @@ Whether ECN survives end to end is a property of the route, so a migration
 re-validates rather than inheriting an answer measured somewhere else. A path
 that failed validation stays unmarked for the life of that path incarnation.
 
+Three details make that per-path story hold, because the peer's counters are
+*not* per path — they are cumulative per packet number space and span every
+path it has been reached on:
+
+- **The baseline is snapshotted when a path starts marking**, before its first
+  marked packet goes out (RFC 9000 Appendix A.4), so every mark it places is
+  accounted for. Adopting the first report that happens to arrive would write
+  off whatever was already in flight, and the next honest report covering
+  those packets would look like an over-claim.
+- **A migration waits for the previous path's marks to drain** before the new
+  one starts testing. Otherwise the old path's intact marks would validate a
+  new path that is stripping every codepoint, and the old path's CE reports
+  would halve the new path's window for congestion that is no longer on the
+  route. Promotion additionally requires an acknowledgement of a packet the
+  new path itself marked.
+- **An ACK that does not advance the largest acknowledged packet number is
+  ignored entirely** (RFC 9000 §13.4.2.1). Cumulative counters arrive
+  legitimately stale on a reordered ACK, and validating against them would
+  read ordinary reordering as a peer walking its counters backwards.
+
+The testing window is armed by the first marked packet rather than by
+enabling, so an idle connection cannot time out a path that was never given a
+chance to carry one.
+
 Validation is not a formality. The peer's counters are an *input to congestion
 control*, reachable by anything on the path and by the peer itself, so they are
 checked against what this endpoint actually sent before they are believed:

--- a/docs/HTTP3_ROLLOUT.md
+++ b/docs/HTTP3_ROLLOUT.md
@@ -248,6 +248,92 @@ value and the host sysctls describe intent, not what the socket got.
 Both variables are restart-required: buffer sizes are socket state applied to
 the live descriptor at bind time, so changing one means a new socket.
 
+## Explicit Congestion Notification
+
+ECN (RFC 3168, RFC 9000 §13.4) lets a congested router *mark* a packet instead
+of dropping it. When it works, congestion control reacts a round trip earlier
+and without a retransmission; when it does not, nothing is lost. That asymmetry
+is why Tardigrade runs it by default and treats every failure as a fallback
+rather than an error.
+
+Tardigrade marks outbound datagrams **ECT(0)**, counts the codepoints on
+received packets, reports them to the peer in ACK_ECN, and validates the
+counters the peer sends back. ECT(1) is never sent: it belongs to L4S
+(RFC 9331), whose congestion response is not the RFC 9002 one implemented here.
+
+### Per path, and only after the handshake
+
+Marking starts once the handshake is **confirmed**, and each network path
+validates independently — the same scoping as DPLPMTUD, for the same reason.
+Whether ECN survives end to end is a property of the route, so a migration
+re-validates rather than inheriting an answer measured somewhere else. A path
+that failed validation stays unmarked for the life of that path incarnation.
+
+Validation is not a formality. The peer's counters are an *input to congestion
+control*, reachable by anything on the path and by the peer itself, so they are
+checked against what this endpoint actually sent before they are believed:
+
+| Check | Failure |
+| --- | --- |
+| Acknowledged marked packets, no ECN counts in the ACK | `missing_counts` — the marks were stripped, or the peer does not report |
+| A counter went backwards | `counts_regressed` |
+| ECT(1) reported | `unsent_codepoint` — something is rewriting the field |
+| More marked arrivals reported than were ever marked | `counts_exceed_sent` |
+| Marked packets acknowledged without matching counter growth | `insufficient_increase` |
+| No usable feedback within the testing window (3×PTO) | `testing_timeout` |
+
+Any of these turns marking off for that path and the connection continues
+normally. **CE reports are acted on only on a validated path**, so an
+unvalidated or forged report cannot shrink the congestion window on demand. The
+counters this endpoint reports back come only from packets that passed AEAD
+authentication, so an off-path spoofer cannot inflate what the peer is told.
+
+`ecn_paths_disabled` being non-zero on the open internet is expected and is not
+an error condition.
+
+### Platform support
+
+The transport decides *whether* to mark; the kernel is what actually sets and
+reads the IP header field, via `sendmsg`/`recvmsg` ancillary data. A socket-wide
+`IP_TOS` would not do — ECN is validated per path, and there would be no way to
+stop marking on the one path whose validation failed.
+
+| Platform | Receive | Send | Notes |
+| --- | --- | --- | --- |
+| Linux | `IP_RECVTOS` (13) / `IPV6_RECVTCLASS` (66) | `IP_TOS` (1) / `IPV6_TCLASS` (67) | Received IPv4 codepoints arrive under `IP_TOS`, not under the option that enabled them. |
+| macOS, iOS, tvOS, watchOS | `IP_RECVTOS` (27) / `IPV6_RECVTCLASS` (35) | `IP_TOS` (3) / `IPV6_TCLASS` (36) | Control messages align to 4 bytes (`__DARWIN_ALIGN32`), not the platform word. |
+| FreeBSD | `IP_RECVTOS` (68) / `IPV6_RECVTCLASS` (57) | `IP_TOS` (3) / `IPV6_TCLASS` (61) | Constants differ from Darwin's; not interchangeable. |
+| Other platforms | — | — | No verified API; the listener runs without ECN. |
+
+As with the no-fragmentation table, these are **not** shared across the BSDs and
+an unverified platform runs without ECN rather than guessing. The *receive* side
+gates everything: without received codepoints there is nothing to put in
+ACK_ECN, so the peer's own validation would fail and this endpoint would be
+marking into a feedback loop it cannot close. If the kernel later refuses the
+send-side control message, the listener logs it, stops asking, and each
+connection's validation discovers the marks are not arriving.
+
+There is nothing to tune on the host — no sysctl gates any of this. Whether ECN
+does anything useful depends on the routers between the endpoints, not on local
+configuration.
+
+### Operating
+
+`TARDIGRADE_HTTP3_ECN` (default `true`) turns marking off outright. The escape
+hatch exists for the one failure mode per-path validation cannot detect: a
+middlebox that *drops* ECT-marked traffic rather than clearing the marks, which
+looks like ordinary loss. Symptom: loss and PTO counts that fall when ECN is
+disabled on an otherwise unchanged path.
+
+The runtime status snapshot publishes `ecn_enabled` — whether marking is
+actually running, not merely requested — along with `ecn_marked_sent`,
+`ecn_paths_validated`, `ecn_paths_disabled`, and `ecn_ce_received`. Benchmark
+runs should record all five: a CE count is only meaningful next to the number
+of paths that validated.
+
+`TARDIGRADE_HTTP3_ECN` is restart-required, like every other listener-owned knob
+— the receive option is socket state applied at bind time.
+
 ## Reload
 
 Advertisement-only knobs can hot reload:
@@ -266,6 +352,7 @@ runtime does not atomically replace a live UDP socket and QUIC connection table:
 - `TARDIGRADE_HTTP3_MAX_DATAGRAM_SIZE`
 - `TARDIGRADE_HTTP3_UDP_RECV_BUFFER_BYTES`
 - `TARDIGRADE_HTTP3_UDP_SEND_BUFFER_BYTES`
+- `TARDIGRADE_HTTP3_ECN`
 
 A reload that changes one of those fields is rejected before publication. The
 old config, old runtime, and old effective advertisement remain active.

--- a/docs/HTTP3_ROLLOUT.md
+++ b/docs/HTTP3_ROLLOUT.md
@@ -308,9 +308,12 @@ path it has been reached on:
   ACK_ECN: generated after the acknowledgement, its counters necessarily
   include whatever the acknowledged packet contributed.
 - **An ACK that does not advance the largest acknowledged packet number is
-  ignored entirely** (RFC 9000 §13.4.2.1). Cumulative counters arrive
-  legitimately stale on a reordered ACK, and validating against them would
-  read ordinary reordering as a peer walking its counters backwards.
+  ignored for ECN counter validation** (RFC 9000 §13.4.2.1). Its cumulative
+  counters can legitimately be stale on a reordered ACK, so they cannot fail
+  the path. It can still newly acknowledge a previously missing packet,
+  though: that packet's local metadata is retired immediately, while any
+  marked contribution remains owed until a later advancing ACK_ECN
+  resynchronises the cumulative baseline.
 
 The testing window is armed by the first marked packet rather than by
 enabling, so an idle connection cannot time out a path that was never given a
@@ -341,11 +344,13 @@ checked against what this endpoint actually sent before they are believed:
 | Metadata needed to attribute the counters was dropped | `evidence_lost` |
 | The socket turned out to be unable to set the codepoint | `platform_unsupported` |
 
-Any of these turns marking off for that path and the connection continues
-normally. **CE reports are acted on only on a validated path**, so an
-unvalidated or forged report cannot shrink the congestion window on demand. The
-counters this endpoint reports back come only from packets that passed AEAD
-authentication, so an off-path spoofer cannot inflate what the peer is told.
+Path-local validation failures turn marking off for that path and the
+connection continues normally. `evidence_lost` and `platform_unsupported`
+instead turn ECN off for the whole connection, as described above. **CE
+reports are acted on only on a validated path**, so an unvalidated or forged
+report cannot shrink the congestion window on demand. The counters this
+endpoint reports back come only from packets that passed AEAD authentication,
+so an off-path spoofer cannot inflate what the peer is told.
 
 `ecn_paths_disabled` being non-zero on the open internet is expected and is not
 an error condition.
@@ -369,8 +374,10 @@ an unverified platform runs without ECN rather than guessing. The *receive* side
 gates everything: without received codepoints there is nothing to put in
 ACK_ECN, so the peer's own validation would fail and this endpoint would be
 marking into a feedback loop it cannot close. If the kernel later refuses the
-send-side control message, the listener logs it, stops asking, and each
-connection's validation discovers the marks are not arriving.
+send-side control message, the listener logs it, withdraws send-side ECN for
+future connections, and disables ECN on every live connection so transport
+state and published counters do not continue claiming marks the socket cannot
+place on the wire.
 
 There is nothing to tune on the host — no sysctl gates any of this. Whether ECN
 does anything useful depends on the routers between the endpoints, not on local

--- a/src/edge_config.zig
+++ b/src/edge_config.zig
@@ -281,6 +281,13 @@ pub const EdgeConfig = struct {
     /// (#256-D). `0` — the default — leaves the kernel's own sizing alone.
     http3_udp_recv_buffer_bytes: usize,
     http3_udp_send_buffer_bytes: usize,
+    /// Whether the QUIC listener runs ECN (#256-E). On by default and safe by
+    /// construction — the runtime only turns it on where the kernel can report
+    /// received codepoints, and the transport turns it off per path the moment
+    /// the peer's feedback stops adding up. The escape hatch exists for hosts
+    /// where a middlebox penalises marked traffic outright rather than merely
+    /// clearing the marks, which per-path validation cannot detect.
+    http3_ecn_enabled: bool,
     proxy_protocol_mode: ProxyProtocolMode,
     /// Gateway identity used in signed upstream trust headers.
     trust_gateway_id: []const u8,
@@ -955,6 +962,11 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
     // kernel refuses or trims is logged and published, never fatal.
     const http3_udp_recv_buffer_bytes = parseIntEnv(usize, allocator, "TARDIGRADE_HTTP3_UDP_RECV_BUFFER_BYTES", 0);
     const http3_udp_send_buffer_bytes = parseIntEnv(usize, allocator, "TARDIGRADE_HTTP3_UDP_SEND_BUFFER_BYTES", 0);
+    // #256-E: ECN defaults on. Unlike the buffer knobs it costs nothing to
+    // leave enabled — an unsupported platform never marks, and a path that
+    // cannot carry markings turns itself off — so this exists to disable it,
+    // not to enable it.
+    const http3_ecn_enabled = parseBoolEnv(allocator, "TARDIGRADE_HTTP3_ECN", true);
     const proxy_protocol_mode_str = envOrDefault(allocator, "TARDIGRADE_PROXY_PROTOCOL", "off") catch unreachable;
     defer allocator.free(proxy_protocol_mode_str);
     const proxy_protocol_mode = try parseProxyProtocolModeConfig(proxy_protocol_mode_str);
@@ -1645,6 +1657,7 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
         .http3_max_datagram_size = http3_max_datagram_size,
         .http3_udp_recv_buffer_bytes = http3_udp_recv_buffer_bytes,
         .http3_udp_send_buffer_bytes = http3_udp_send_buffer_bytes,
+        .http3_ecn_enabled = http3_ecn_enabled,
         .proxy_protocol_mode = proxy_protocol_mode,
         .trust_gateway_id = trust_gateway_id,
         .trust_shared_secret = trust_shared_secret,

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -516,6 +516,7 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
                 .recv_bytes = if (cfg.http3_udp_recv_buffer_bytes > 0) cfg.http3_udp_recv_buffer_bytes else null,
                 .send_bytes = if (cfg.http3_udp_send_buffer_bytes > 0) cfg.http3_udp_send_buffer_bytes else null,
             },
+            .ecn_enabled = cfg.http3_ecn_enabled,
             .request_handler = ghandlers.handleHttp3Request,
             .request_handler_ctx = &http3_dispatch_ctx,
             .early_data_compat_metrics_ctx = &state,
@@ -636,7 +637,7 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
         state.logger.info(null, "Proxy protocol enabled: {s} (plaintext and TLS listeners)", .{@tagName(cfg.proxy_protocol_mode)});
     }
     if (cfg.http3_enabled) {
-        state.logger.info(null, "HTTP/3 foundation enabled: quic_port={d} 0rtt={} migration={} retry_policy={s} max_datagram={d} udp_recv_buffer={d} udp_send_buffer={d}", .{
+        state.logger.info(null, "HTTP/3 foundation enabled: quic_port={d} 0rtt={} migration={} retry_policy={s} max_datagram={d} udp_recv_buffer={d} udp_send_buffer={d} ecn={}", .{
             cfg.quic_port,
             cfg.http3_enable_0rtt,
             cfg.http3_connection_migration,
@@ -644,6 +645,7 @@ pub fn run(cfg: *const edge_config.EdgeConfig) !void {
             cfg.http3_max_datagram_size,
             cfg.http3_udp_recv_buffer_bytes,
             cfg.http3_udp_send_buffer_bytes,
+            cfg.http3_ecn_enabled,
         });
     }
     if (cfg.trust_shared_secret.len > 0) {

--- a/src/gateway_shutdown.zig
+++ b/src/gateway_shutdown.zig
@@ -350,7 +350,11 @@ pub fn http3ListenerConfigChanged(
         // bind time. Changing them means a new socket, which is a listener
         // restart like every other knob here.
         current.http3_udp_recv_buffer_bytes != proposed.http3_udp_recv_buffer_bytes or
-        current.http3_udp_send_buffer_bytes != proposed.http3_udp_send_buffer_bytes;
+        current.http3_udp_send_buffer_bytes != proposed.http3_udp_send_buffer_bytes or
+        // #256-E: same reasoning — the ECN receive option is set on the live
+        // fd at bind time, and the transport's marking decision is fixed per
+        // connection at creation.
+        current.http3_ecn_enabled != proposed.http3_ecn_enabled;
 }
 
 pub fn listenerShardConfigChanged(
@@ -418,6 +422,12 @@ test "http3ListenerConfigChanged permits advertisement-only reloads" {
     proposed.http3_udp_recv_buffer_bytes = base.http3_udp_recv_buffer_bytes;
 
     proposed.http3_udp_send_buffer_bytes = base.http3_udp_send_buffer_bytes + 4096;
+    try std.testing.expect(http3ListenerConfigChanged(&base, &proposed));
+    proposed.http3_udp_send_buffer_bytes = base.http3_udp_send_buffer_bytes;
+
+    // #256-E: the ECN receive option is socket state too, and every live
+    // connection's marking decision was made when it was created.
+    proposed.http3_ecn_enabled = !base.http3_ecn_enabled;
     try std.testing.expect(http3ListenerConfigChanged(&base, &proposed));
 }
 

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -343,10 +343,6 @@ pub const Runtime = struct {
     /// message — the two are separate capabilities on some platforms, and one
     /// refusal is enough to know marking will never work here.
     ecn_send_enabled: bool = false,
-    /// Set when `noteEcnSendRejected` has withdrawn the capability and live
-    /// connections have not been told yet. Applied on the run loop's next
-    /// pass, which is the only place that holds the connection table.
-    ecn_disable_pending: bool = false,
 
     /// Erase `crypto_provider_state` to the boundary type for a `Connection`.
     /// Borrows `self`, so the returned value must not outlive this `Runtime`
@@ -548,7 +544,6 @@ pub const Runtime = struct {
             // 1) Timers and transmission for every connection.
             var wake_us: u64 = now + 100_000;
             {
-                var out: [quic.datagram.max_size]u8 = undefined;
                 var reap: [16]u64 = undefined;
                 var reap_count: usize = 0;
                 var it = connections.iterator();
@@ -559,21 +554,20 @@ pub const Runtime = struct {
                     self.maintainLocalCidRoutes(entry, kv.key_ptr.*, &routes);
                     self.foldPathMetrics(entry);
                     if (draining and !entry.drain_goaway_sent) self.sendDrainGoaway(entry);
-                    while (entry.conn.pollTransmitOnPath(&out, now)) |t| {
-                        self.sendDatagram(sockaddrInFromAddress(t.path.remote), t.bytes, t.ecn);
-                    }
+                    self.drainConnectionTransmits(entry, now);
                     if (drain_expired) {
                         entry.conn.close(0x0100, "h3 drain deadline", now);
                     } else {
                         self.pumpH3(entry, now);
                     }
-                    while (entry.conn.pollTransmitOnPath(&out, now)) |t| {
-                        self.sendDatagram(sockaddrInFromAddress(t.path.remote), t.bytes, t.ecn);
-                    }
-                    // #256-E: the socket has just proven it cannot mark, so
-                    // stop every live connection from claiming marks it never
-                    // sent. Distinct from a path failing ECN validation.
-                    if (self.ecn_disable_pending) entry.conn.disableEcnUnsupported();
+                    self.drainConnectionTransmits(entry, now);
+                    // #256-E: while the socket cannot mark, every live
+                    // connection is kept told — not once on the pass that
+                    // discovered it. A one-shot flag would miss every entry
+                    // this iterator had already walked past when the rejection
+                    // happened, and those connections would go on counting
+                    // marks for datagrams that left Not-ECT. Idempotent.
+                    if (!self.ecn_send_enabled) entry.conn.disableEcnUnsupported();
                     // Reap closed connections and half-open connections that
                     // blew the handshake deadline (spoofed/stalled Initials).
                     const stalled = !entry.conn.isEstablished() and now -| entry.accepted_at_us > handshake_timeout_us;
@@ -586,7 +580,6 @@ pub const Runtime = struct {
                     }
                     if (entry.conn.nextTimeoutUs()) |deadline| wake_us = @min(wake_us, deadline);
                 }
-                self.ecn_disable_pending = false;
                 for (reap[0..reap_count]) |handle| {
                     self.removeConnection(&connections, &routes, &per_ip, handle);
                 }
@@ -706,14 +699,9 @@ pub const Runtime = struct {
         }
         self.maybeIssueSessionTicket(entry);
 
-        var out: [quic.datagram.max_size]u8 = undefined;
-        while (entry.conn.pollTransmitOnPath(&out, now)) |t| {
-            self.sendDatagram(sockaddrInFromAddress(t.path.remote), t.bytes, t.ecn);
-        }
+        self.drainConnectionTransmits(entry, now);
         self.pumpH3(entry, now);
-        while (entry.conn.pollTransmitOnPath(&out, now)) |t| {
-            self.sendDatagram(sockaddrInFromAddress(t.path.remote), t.bytes, t.ecn);
-        }
+        self.drainConnectionTransmits(entry, now);
     }
 
     fn accept(
@@ -1196,6 +1184,31 @@ pub const Runtime = struct {
     /// Send one transport-produced datagram, carrying the ECN codepoint the
     /// transport asked for (#256-E). `mark` is `.not_ect` for every datagram
     /// on a path that is not marking, which is the plain-`sendto` path.
+    /// Drain one connection's pending datagrams.
+    ///
+    /// Checks the send-side ECN capability after every datagram rather than
+    /// once per pass: the refusal is discovered *inside* a send, and the rest
+    /// of this drain would otherwise keep building packets the transport counts
+    /// as marked while the socket emits them Not-ECT.
+    fn drainConnectionTransmits(self: *Runtime, entry: *ConnEntry, now: u64) void {
+        var out: [quic.datagram.max_size]u8 = undefined;
+        while (entry.conn.pollTransmitOnPath(&out, now)) |t| {
+            self.sendDatagram(sockaddrInFromAddress(t.path.remote), t.bytes, t.ecn);
+            if (!self.ecn_send_enabled) entry.conn.disableEcnUnsupported();
+        }
+    }
+
+    /// Tell every live connection that the socket cannot mark. Idempotent, and
+    /// safe to call on every pass.
+    fn applyEcnCapabilityLoss(
+        self: *Runtime,
+        connections: *std.AutoHashMap(u64, *ConnEntry),
+    ) void {
+        if (self.ecn_send_enabled) return;
+        var it = connections.iterator();
+        while (it.next()) |kv| kv.value_ptr.*.conn.disableEcnUnsupported();
+    }
+
     fn sendDatagram(self: *Runtime, peer: std.c.sockaddr.in, datagram: []const u8, mark: quic.udp.Ecn) void {
         const effective_mark = if (self.ecn_send_enabled) mark else .not_ect;
         const outcome = sendDatagramTo(self.socket_fd, &peer, datagram, effective_mark);
@@ -1223,7 +1236,6 @@ pub const Runtime = struct {
         if (!self.ecn_send_enabled) return;
         self.ecn_send_enabled = false;
         self.quic_config.ecn_enabled = false;
-        self.ecn_disable_pending = true;
         self.snapshot_mutex.lock();
         self.snapshot_state.ecn_enabled = false;
         self.snapshot_mutex.unlock();
@@ -5781,12 +5793,76 @@ test "http3 runtime: a socket that cannot mark withdraws ECN from the transport 
     try testing.expect(!runtime.quic_config.ecn_enabled);
     // ... the snapshot agrees ...
     try testing.expect(!runtime.snapshot().ecn_enabled);
-    // ... and live connections are queued to be told, which is a different
-    // thing from any one of their paths failing ECN validation.
-    try testing.expect(runtime.ecn_disable_pending);
+    // ... and the capability stays withdrawn, which is what
+    // `applyEcnCapabilityLoss` keys off on every subsequent pass.
+    try testing.expect(!runtime.ecn_send_enabled);
 
-    // Idempotent: a second refusal changes nothing and does not re-queue.
-    runtime.ecn_disable_pending = false;
+    // Idempotent.
     runtime.noteEcnSendRejected();
-    try testing.expect(!runtime.ecn_disable_pending);
+    try testing.expect(!runtime.ecn_send_enabled);
+    try testing.expect(!runtime.quic_config.ecn_enabled);
+}
+
+test "http3 runtime: every live connection is told the socket cannot mark (#256-E review)" {
+    // The rejection is discovered inside a send, part-way through the
+    // connection table. A one-shot "pending" flag would only reach entries the
+    // iterator had not yet walked past; the rest would keep counting marks for
+    // datagrams that left Not-ECT. So the capability loss is applied on every
+    // pass, for every connection, until the process restarts.
+    var fixed = tls_core.credentials.FixedCredentialProvider.init(
+        tls_core.credentials.testdata.identity(),
+        tls_core.credentials.testdata.ignoredEntropy(),
+    );
+    defer fixed.deinit();
+    var logger = logger_mod.Logger.init(.err, "http3-ecn-sweep-test");
+    var runtime = Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+        .credential_provider = fixed.provider(),
+    }) catch return error.SkipZigTest;
+    defer runtime.deinit();
+    if (!runtime.ecn_send_enabled) return error.SkipZigTest;
+
+    var connections = std.AutoHashMap(u64, *ConnEntry).init(testing.allocator);
+    defer deinitTestConnections(&connections, testing.allocator);
+    var routes = quic.cid.CidRoutingTable.init(testing.allocator);
+    defer routes.deinit();
+    var per_ip = std.AutoHashMap(u32, u32).init(testing.allocator);
+    defer per_ip.deinit();
+    var next_handle: u64 = 1;
+
+    // Two live connections, accepted before the capability is lost.
+    var handles: [2]u64 = undefined;
+    for (&handles, 0..) |*handle, index| {
+        const dcid = [_]u8{ 0xd0, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, @intCast(index) };
+        const scid = [_]u8{ 0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, @intCast(index) };
+        handle.* = runtime.accept(&connections, &routes, &per_ip, &next_handle, .{
+            .kind = .initial,
+            .version = quic.packet.quic_v1,
+            .dcid = &dcid,
+            .scid = &scid,
+            .token = "",
+        }, testPeerSockaddr(@intCast(45_000 + index)), 1_000_000) orelse
+            return error.SkipZigTest;
+    }
+    try testing.expectEqual(@as(usize, 2), connections.count());
+    for (handles) |handle| {
+        try testing.expect(connections.get(handle).?.conn.cfg.ecn_enabled);
+    }
+
+    runtime.noteEcnSendRejected();
+    runtime.applyEcnCapabilityLoss(&connections);
+
+    // Both — not just whichever one the rejection happened on.
+    for (handles) |handle| {
+        const conn = connections.get(handle).?.conn;
+        try testing.expect(!conn.cfg.ecn_enabled);
+        try testing.expectEqual(quic.udp.Ecn.not_ect, conn.ecnCodepoint());
+        const marked_before = conn.metrics.ecn_marked_sent;
+        var out: [quic.datagram.max_size]u8 = undefined;
+        while (conn.pollTransmitOnPath(&out, 1_000_000)) |t| {
+            try testing.expectEqual(quic.udp.Ecn.not_ect, t.ecn);
+        }
+        try testing.expectEqual(marked_before, conn.metrics.ecn_marked_sent);
+    }
 }

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -108,6 +108,14 @@ pub const Config = struct {
     /// measurements say otherwise. What the kernel actually granted is read
     /// back and published on `Snapshot.udp_buffers`.
     udp_buffer_tuning: quic.udp.BufferTuning = .{},
+    /// Whether to run ECN on this listener (#256-E, RFC 9000 §13.4). On by
+    /// default because it is safe by construction: the runtime turns it on
+    /// only after the kernel agrees to report received codepoints, and the
+    /// transport turns it off again per path the moment the peer's feedback
+    /// stops adding up — a path that cannot carry markings ends up in ordinary
+    /// non-ECN operation, never in an error. Set false to keep every datagram
+    /// unmarked regardless of platform support.
+    ecn_enabled: bool = true,
     request_handler: ?RequestHandler = null,
     request_handler_ctx: ?*anyopaque = null,
     early_data_compat_metrics_ctx: ?*anyopaque = null,
@@ -191,6 +199,19 @@ pub const Snapshot = struct {
     /// for the life of the socket, so unlike every counter above it is
     /// written once at init.
     udp_buffers: quic.udp.EffectiveBufferTuning = .{},
+    /// Whether this listener is running ECN at all (#256-E): the operator
+    /// asked for it *and* the kernel agreed to report received codepoints.
+    /// Fixed for the life of the socket unless a marked send is refused, which
+    /// clears it — so a benchmark run records the state that actually applied.
+    ecn_enabled: bool = false,
+    /// Folded from every connection's transport counters, so an operator can
+    /// tell "ECN is on and working" from "ECN is on and every path turned it
+    /// off". `ecn_paths_disabled` is expected to be non-zero on the open
+    /// internet and is not an error condition.
+    ecn_marked_sent: usize = 0,
+    ecn_paths_validated: usize = 0,
+    ecn_paths_disabled: usize = 0,
+    ecn_ce_received: usize = 0,
 
     pub fn handshakeState(self: Snapshot) []const u8 {
         if (!self.server_bootstrapped) return "bootstrap_incomplete";
@@ -234,6 +255,10 @@ const ConnEntry = struct {
     highest_admitted_request_stream_id: ?u64 = null,
     drain_goaway_boundary: ?u64 = null,
     last_path_metrics: quic.path.Metrics = .{},
+    /// The connection's transport counters as of the last fold, so the
+    /// listener snapshot accumulates deltas rather than re-adding totals
+    /// (#256-E). Same pattern as `last_path_metrics`.
+    last_transport_metrics: quic.connection.Metrics = .{},
     parked_h3_retries: std.ArrayList(ParkedH3Retry) = .empty,
 
     fn deinit(self: *ConnEntry, allocator: std.mem.Allocator) void {
@@ -312,6 +337,12 @@ pub const Runtime = struct {
     /// by real OS entropy.
     crypto_provider_entropy: tls_core.production_crypto.OsEntropy = .{},
     crypto_provider_state: tls_core.production_crypto.Provider = undefined,
+    /// Whether outbound datagrams may carry an ECN control message (#256-E).
+    /// Starts as whatever the receive-side configuration established, and is
+    /// cleared for good if the kernel ever refuses the send-side control
+    /// message — the two are separate capabilities on some platforms, and one
+    /// refusal is enough to know marking will never work here.
+    ecn_send_enabled: bool = false,
 
     /// Erase `crypto_provider_state` to the boundary type for a `Connection`.
     /// Borrows `self`, so the returned value must not outlive this `Runtime`
@@ -338,6 +369,16 @@ pub const Runtime = struct {
         const no_fragment = configureNoFragment(fd, sa_family);
         if (!no_fragment) {
             logger.warn(null, "http3: no-fragmentation socket policy unavailable; path MTU discovery held at {d} bytes", .{quic.datagram.base_size});
+        }
+        // ECN's precondition (#256-E). Marking is only worth doing if the peer
+        // can be observed marking back, so the *receive* side is what gates
+        // it: without received codepoints there is nothing to put in ACK_ECN,
+        // the peer's own validation fails, and this endpoint would be marking
+        // into a feedback loop it cannot close. Advisory to the listener —
+        // refusing it costs a congestion signal, not correctness.
+        const ecn_receive = cfg.ecn_enabled and configureEcnReceive(fd, sa_family);
+        if (cfg.ecn_enabled and !ecn_receive) {
+            logger.warn(null, "http3: ECN unavailable on this platform or socket; running without explicit congestion notification", .{});
         }
         // Advisory, and applied before `bind` so the socket is never briefly
         // reachable with a buffer the operator did not ask for (#256-D).
@@ -376,7 +417,8 @@ pub const Runtime = struct {
             .zero_rtt_enabled = zeroRttCarrierEnabled(cfg),
             .retry_policy = cfg.retry_policy,
             .secrets = .{},
-            .quic_config = quicConfigFrom(cfg, no_fragment),
+            .quic_config = quicConfigFrom(cfg, no_fragment, ecn_receive),
+            .ecn_send_enabled = ecn_receive,
             .h3_settings = cfg.h3_settings,
             .early_data_compat_metrics_ctx = cfg.early_data_compat_metrics_ctx,
             .early_data_compat_metrics_cb = cfg.early_data_compat_metrics_cb,
@@ -387,7 +429,11 @@ pub const Runtime = struct {
             .h3_qlog_sink = cfg.h3_qlog_sink,
             .h3_qlog_sink_factory_ctx = cfg.h3_qlog_sink_factory_ctx,
             .h3_qlog_sink_factory_cb = cfg.h3_qlog_sink_factory_cb,
-            .snapshot_state = .{ .quic_port = cfg.quic_port, .udp_buffers = udp_buffers },
+            .snapshot_state = .{
+                .quic_port = cfg.quic_port,
+                .udp_buffers = udp_buffers,
+                .ecn_enabled = ecn_receive,
+            },
             .stopping = std.atomic.Value(bool).init(false),
             .drain_requested = std.atomic.Value(bool).init(false),
             .drain_deadline_us = std.atomic.Value(u64).init(0),
@@ -510,7 +556,7 @@ pub const Runtime = struct {
                     self.foldPathMetrics(entry);
                     if (draining and !entry.drain_goaway_sent) self.sendDrainGoaway(entry);
                     while (entry.conn.pollTransmitOnPath(&out, now)) |t| {
-                        self.sendDatagram(sockaddrInFromAddress(t.path.remote), t.bytes);
+                        self.sendDatagram(sockaddrInFromAddress(t.path.remote), t.bytes, t.ecn);
                     }
                     if (drain_expired) {
                         entry.conn.close(0x0100, "h3 drain deadline", now);
@@ -518,7 +564,7 @@ pub const Runtime = struct {
                         self.pumpH3(entry, now);
                     }
                     while (entry.conn.pollTransmitOnPath(&out, now)) |t| {
-                        self.sendDatagram(sockaddrInFromAddress(t.path.remote), t.bytes);
+                        self.sendDatagram(sockaddrInFromAddress(t.path.remote), t.bytes, t.ecn);
                     }
                     // Reap closed connections and half-open connections that
                     // blew the handshake deadline (spoofed/stalled Initials).
@@ -550,7 +596,8 @@ pub const Runtime = struct {
             var from: std.c.sockaddr.storage = undefined;
             while (true) {
                 var from_len: std.c.socklen_t = @sizeOf(std.c.sockaddr.storage);
-                const n = std.c.recvfrom(self.socket_fd, &buf, buf.len, 0, @ptrCast(&from), &from_len);
+                const received = receiveDatagram(self.socket_fd, &buf, &from, &from_len);
+                const n = received.result;
                 if (n < 0) {
                     const e = posix.errno(n);
                     if (e == .AGAIN) break;
@@ -561,7 +608,7 @@ pub const Runtime = struct {
                 const datagram = buf[0..@intCast(n)];
                 if (from.family != posix.AF.INET) continue;
                 const peer: *const std.c.sockaddr.in = @ptrCast(&from);
-                self.ingest(&connections, &routes, &per_ip, &next_handle, datagram, peer.*, nowUs());
+                self.ingest(&connections, &routes, &per_ip, &next_handle, datagram, peer.*, received.ecn, nowUs());
             }
         }
     }
@@ -574,6 +621,7 @@ pub const Runtime = struct {
         next_handle: *u64,
         datagram: []const u8,
         peer: std.c.sockaddr.in,
+        ingress_ecn: quic.udp.Ecn,
         now: u64,
     ) void {
         self.noteDatagram(datagram.len);
@@ -622,7 +670,7 @@ pub const Runtime = struct {
         const ingress_path = quic.path.PathKey{ .local = self.local_address, .remote = ingress_remote };
         var challenge_entropy: [quic.path.path_challenge_len]u8 = undefined;
         compat.randomBytes(&challenge_entropy);
-        entry.conn.ingestOnPath(datagram, ingress_path, challenge_entropy, now) catch {
+        entry.conn.ingestOnPathWithEcn(datagram, ingress_path, ingress_ecn, challenge_entropy, now) catch {
             if (freshly_accepted) self.removeConnection(connections, routes, per_ip, found);
             return;
         };
@@ -651,11 +699,11 @@ pub const Runtime = struct {
 
         var out: [quic.datagram.max_size]u8 = undefined;
         while (entry.conn.pollTransmitOnPath(&out, now)) |t| {
-            self.sendDatagram(sockaddrInFromAddress(t.path.remote), t.bytes);
+            self.sendDatagram(sockaddrInFromAddress(t.path.remote), t.bytes, t.ecn);
         }
         self.pumpH3(entry, now);
         while (entry.conn.pollTransmitOnPath(&out, now)) |t| {
-            self.sendDatagram(sockaddrInFromAddress(t.path.remote), t.bytes);
+            self.sendDatagram(sockaddrInFromAddress(t.path.remote), t.bytes, t.ecn);
         }
     }
 
@@ -865,7 +913,9 @@ pub const Runtime = struct {
         const token = self.secrets.retry_tokens.issueRetry(parsed.dcid, retry_scid.slice(), parsed.version, remote, now, nonce, &token_buf) catch return;
         var retry_buf: [512]u8 = undefined;
         const retry = quic.packet.writeRetryV1(parsed.dcid, parsed.scid, retry_scid.slice(), token, &retry_buf) catch return;
-        self.sendDatagram(peer, retry);
+        // Unmarked: a Retry is sent before any connection state exists, so
+        // there is no path whose ECN validation could ever account for it.
+        self.sendDatagram(peer, retry, .not_ect);
         self.noteRetryPacketSent();
     }
 
@@ -1134,8 +1184,25 @@ pub const Runtime = struct {
         self.noteRequestCompleted();
     }
 
-    fn sendDatagram(self: *Runtime, peer: std.c.sockaddr.in, datagram: []const u8) void {
-        const sent = std.c.sendto(self.socket_fd, datagram.ptr, datagram.len, 0, @ptrCast(&peer), @sizeOf(std.c.sockaddr.in));
+    /// Send one transport-produced datagram, carrying the ECN codepoint the
+    /// transport asked for (#256-E). `mark` is `.not_ect` for every datagram
+    /// on a path that is not marking, which is the plain-`sendto` path.
+    fn sendDatagram(self: *Runtime, peer: std.c.sockaddr.in, datagram: []const u8, mark: quic.udp.Ecn) void {
+        const effective_mark = if (self.ecn_send_enabled) mark else .not_ect;
+        const outcome = sendDatagramTo(self.socket_fd, &peer, datagram, effective_mark);
+        if (outcome.ecn_rejected and self.ecn_send_enabled) {
+            // Reading the codepoint and setting it are separate kernel
+            // capabilities; this listener has just learned it only has the
+            // first. Stop asking rather than paying a failed `sendmsg` on
+            // every datagram, and let each connection's own ECN validation
+            // discover that its marks are not arriving.
+            self.ecn_send_enabled = false;
+            self.snapshot_mutex.lock();
+            self.snapshot_state.ecn_enabled = false;
+            self.snapshot_mutex.unlock();
+            self.logger.warn(null, "http3: kernel refused the ECN send option; continuing without explicit congestion notification", .{});
+        }
+        const sent = outcome.result;
         if (sent >= 0 and @as(usize, @intCast(sent)) == datagram.len) {
             self.notePacketOut(datagram.len);
         }
@@ -1528,6 +1595,17 @@ pub const Runtime = struct {
         self.snapshot_state.migrations_blocked += @intCast(current.migrations_blocked -| previous.migrations_blocked);
         self.snapshot_state.migrations_blocked_no_peer_cid += @intCast(current.migrations_blocked_no_peer_cid -| previous.migrations_blocked_no_peer_cid);
         self.snapshot_state.migration_events += @intCast(nat +| migrations);
+
+        // #256-E: ECN is transport state, but the interesting question is a
+        // listener-wide one — is marking working here at all — so the
+        // per-connection counters fold into the same snapshot.
+        const transport = entry.conn.metrics;
+        const last = entry.last_transport_metrics;
+        entry.last_transport_metrics = transport;
+        self.snapshot_state.ecn_marked_sent += @intCast(transport.ecn_marked_sent -| last.ecn_marked_sent);
+        self.snapshot_state.ecn_paths_validated += @intCast(transport.ecn_validated -| last.ecn_validated);
+        self.snapshot_state.ecn_paths_disabled += @intCast(transport.ecn_disabled -| last.ecn_disabled);
+        self.snapshot_state.ecn_ce_received += @intCast(transport.ecn_ce_received -| last.ecn_ce_received);
     }
 
     fn noteRetryPacketSent(self: *Runtime) void {
@@ -1602,10 +1680,14 @@ fn buildStreamRequest(allocator: std.mem.Allocator, exchange: stream_transport.E
 /// what the operator configured: a probe that the kernel may fragment cannot
 /// measure a path MTU, and raising the send size on that evidence would be
 /// worse than never discovering anything.
-fn quicConfigFrom(cfg: Config, no_fragment: bool) quic.config.Config {
+fn quicConfigFrom(cfg: Config, no_fragment: bool, ecn: bool) quic.config.Config {
     const configured = std.math.clamp(cfg.max_datagram_size, quic.datagram.base_size, quic.datagram.max_size);
     return .{
         .max_send_udp_payload_size = if (no_fragment) configured else quic.datagram.base_size,
+        // Only the socket owner can answer this, which is why the transport
+        // default is off: `quic/config.zig` has no way to know whether the
+        // codepoint can be set or read (#256-E).
+        .ecn_enabled = ecn,
         .zero_rtt_enabled = zeroRttCarrierEnabled(cfg),
         .retry_policy = cfg.retry_policy,
         .migration_policy = if (cfg.connection_migration) .full else .nat_rebinding_only,
@@ -1831,6 +1913,295 @@ fn configureNoFragment(fd: std.c.fd_t, sa_family: u32) bool {
     const value = options.value;
     posix.setsockopt(fd, @intCast(level), @intCast(option), std.mem.asBytes(&value)) catch return false;
     return true;
+}
+
+// ---------------------------------------------------------------------------
+// ECN socket support (#256-E).
+//
+// The transport decides *whether* to mark and what a peer's feedback means
+// (`quic/ecn.zig`); everything here is the platform half it cannot own —
+// asking the kernel to put ECT(0) in the IP header of one specific datagram,
+// and reading the field back off a received one. Both need ancillary control
+// messages, which is why they are `sendmsg`/`recvmsg` rather than socket-wide
+// options: ECN is validated per path, and a socket-wide `IP_TOS` would mark
+// every connection on the listener alike with no way to stop marking on the
+// one path whose validation failed.
+// ---------------------------------------------------------------------------
+
+/// The IP header option numbers this ECN implementation uses, per platform.
+///
+/// Named per OS rather than guessed, for the same reason `no_fragment_options`
+/// is: the numeric values differ between Linux, Darwin, and the BSDs, and a
+/// wrong constant that some kernel happens to accept would read as a working
+/// ECN path while marking nothing. An unverified platform gets `null` and the
+/// listener runs without ECN, which is a supported, tested state.
+const EcnSocketOptions = struct {
+    /// `setsockopt` that turns on delivery of the received codepoint.
+    recv_enable_v4: u32,
+    recv_enable_v6: u32,
+    /// The `cmsg_type` a received codepoint arrives under, which is not always
+    /// the same number as the option that enabled it.
+    recv_cmsg_v4: u32,
+    recv_cmsg_v6: u32,
+    /// The `cmsg_type` used to set the field on one outbound datagram.
+    send_cmsg_v4: u32,
+    send_cmsg_v6: u32,
+};
+
+const ecn_socket_options: ?EcnSocketOptions = switch (builtin.os.tag) {
+    // Linux: IP_TOS=1, IP_RECVTOS=13, IPV6_TCLASS=67, IPV6_RECVTCLASS=66
+    // (<linux/in.h>, <linux/in6.h>). Received IPv4 codepoints arrive under
+    // IP_TOS, *not* under the IP_RECVTOS that enabled them.
+    .linux => .{
+        .recv_enable_v4 = 13,
+        .recv_enable_v6 = 66,
+        .recv_cmsg_v4 = 1,
+        .recv_cmsg_v6 = 67,
+        .send_cmsg_v4 = 1,
+        .send_cmsg_v6 = 67,
+    },
+    // Darwin: IP_TOS=3, IP_RECVTOS=27 (<netinet/in.h>), IPV6_TCLASS=36,
+    // IPV6_RECVTCLASS=35 (<netinet6/in6.h>). Here the received IPv4 codepoint
+    // *does* arrive under IP_RECVTOS.
+    .macos, .ios, .tvos, .watchos => .{
+        .recv_enable_v4 = 27,
+        .recv_enable_v6 = 35,
+        .recv_cmsg_v4 = 27,
+        .recv_cmsg_v6 = 36,
+        .send_cmsg_v4 = 3,
+        .send_cmsg_v6 = 36,
+    },
+    // FreeBSD: IP_TOS=3, IP_RECVTOS=68, IPV6_TCLASS=61, IPV6_RECVTCLASS=57.
+    .freebsd => .{
+        .recv_enable_v4 = 68,
+        .recv_enable_v6 = 57,
+        .recv_cmsg_v4 = 68,
+        .recv_cmsg_v6 = 61,
+        .send_cmsg_v4 = 3,
+        .send_cmsg_v6 = 61,
+    },
+    else => null,
+};
+
+const ecn_supported = ecn_socket_options != null;
+
+/// RFC 3168 §5: the ECN field is the low two bits of the IPv4 TOS byte / IPv6
+/// traffic class. The other six are DSCP and are none of this stack's
+/// business — reading them would turn an operator's traffic-class marking into
+/// a spurious congestion signal.
+fn ecnFromTrafficClass(byte: u8) quic.udp.Ecn {
+    return switch (byte & 0x03) {
+        0b00 => .not_ect,
+        0b01 => .ect1,
+        0b10 => .ect0,
+        0b11 => .ce,
+        else => unreachable,
+    };
+}
+
+fn trafficClassFromEcn(mark: quic.udp.Ecn) ?c_int {
+    return switch (mark) {
+        .not_ect => 0b00,
+        .ect1 => 0b01,
+        .ect0 => 0b10,
+        .ce => 0b11,
+        // "The receive path could not tell" is not a codepoint to send.
+        .unavailable => null,
+    };
+}
+
+/// `CMSG_ALIGN`'s alignment, which is *not* the platform word everywhere.
+///
+/// Linux aligns to `sizeof(size_t)`; Darwin's `CMSG_DATA`/`CMSG_SPACE` use
+/// `__DARWIN_ALIGN32`, i.e. `sizeof(uint32_t)`, so on 64-bit Darwin the payload
+/// begins 12 bytes into a control message rather than 16. Assuming the word
+/// size on both is not a subtle bug: the ECN payload would be read four bytes
+/// past where the kernel wrote it, every received codepoint would come back
+/// `.unavailable`, and ECN would look like a network problem on every macOS
+/// host. The BSDs align to `register_t`, which is the word.
+const cmsg_alignment: usize = switch (builtin.os.tag) {
+    .macos, .ios, .tvos, .watchos => @alignOf(u32),
+    else => @alignOf(usize),
+};
+
+fn cmsgAlign(len: usize) usize {
+    return (len + cmsg_alignment - 1) & ~(cmsg_alignment - 1);
+}
+
+/// `CMSG_DATA`'s offset from the header: the header size, aligned up.
+const cmsg_data_offset: usize = cmsgAlign(@sizeOf(std.c.cmsghdr));
+
+fn cmsgSpace(payload_len: usize) usize {
+    return cmsg_data_offset + cmsgAlign(payload_len);
+}
+
+fn cmsgLen(payload_len: usize) usize {
+    return cmsg_data_offset + payload_len;
+}
+
+/// Room for one control message carrying a `c_int` — the only ancillary data
+/// this listener sends or expects. A kernel with more to say sets `MSG_CTRUNC`
+/// and the extra is simply not read.
+const ecn_control_len: usize = cmsgSpace(@sizeOf(c_int));
+
+/// Ask the kernel to report the received ECN codepoint on this socket
+/// (#256-E). Advisory: a refusal leaves a listener that serves QUIC normally
+/// and simply never reports a codepoint, which the transport reads as
+/// `.unavailable` rather than as an unmarked datagram.
+fn configureEcnReceive(fd: std.c.fd_t, sa_family: u32) bool {
+    const options = ecn_socket_options orelse return false;
+    const is_v6 = sa_family == posix.AF.INET6;
+    const option = if (is_v6) options.recv_enable_v6 else options.recv_enable_v4;
+    const value: c_int = 1;
+    posix.setsockopt(fd, if (is_v6) posix.IPPROTO.IPV6 else posix.IPPROTO.IP, @intCast(option), std.mem.asBytes(&value)) catch return false;
+    return true;
+}
+
+/// One received datagram: the `recvmsg` return value verbatim (negative on
+/// error, so the caller's errno handling is unchanged) and the ECN codepoint
+/// its IP header carried.
+const ReceivedDatagram = struct {
+    result: isize,
+    ecn: quic.udp.Ecn = .unavailable,
+};
+
+/// Receive one datagram with its ancillary metadata. `recvmsg` rather than
+/// `recvfrom` because the codepoint only arrives as a control message; the
+/// source address comes back identically either way.
+fn receiveDatagram(
+    fd: std.c.fd_t,
+    buf: []u8,
+    from: *std.c.sockaddr.storage,
+    from_len: *std.c.socklen_t,
+) ReceivedDatagram {
+    var control: [ecn_control_len]u8 align(@alignOf(usize)) = undefined;
+    var iov = [_]std.c.iovec{.{ .base = buf.ptr, .len = buf.len }};
+    var msg = std.mem.zeroes(std.c.msghdr);
+    msg.name = @ptrCast(from);
+    msg.namelen = from_len.*;
+    msg.iov = &iov;
+    msg.iovlen = 1;
+    msg.control = &control;
+    msg.controllen = @intCast(control.len);
+
+    const n = std.c.recvmsg(fd, &msg, 0);
+    if (n < 0) return .{ .result = n };
+    from_len.* = msg.namelen;
+    return .{
+        .result = n,
+        .ecn = ecnFromControl(&control, @intCast(msg.controllen), from.family),
+    };
+}
+
+/// Send one datagram, asking the kernel to put `mark` in its IP header when
+/// the transport called for one (#256-E). Returns the `sendmsg`/`sendto`
+/// result and whether the ECN control message was refused, which is the
+/// listener's cue to stop attempting it.
+const SentDatagram = struct {
+    result: isize,
+    /// True when this send carried an ECN control message and the kernel
+    /// rejected the call outright. Distinguished from an ordinary send failure
+    /// because it is a statement about the *capability*, not about this packet.
+    ecn_rejected: bool = false,
+};
+
+fn sendDatagramTo(
+    fd: std.c.fd_t,
+    peer: *const std.c.sockaddr.in,
+    datagram: []const u8,
+    mark: quic.udp.Ecn,
+) SentDatagram {
+    const options = ecn_socket_options;
+    const traffic_class: ?c_int = if (options == null) null else trafficClassFromEcn(mark);
+    // `.not_ect` is the default state of the field, so an unmarked datagram
+    // needs no control message at all — which keeps the common path a plain
+    // `sendto` and means a kernel that rejects the cmsg only ever affects
+    // listeners that are actually marking.
+    if (traffic_class == null or traffic_class.? == 0) {
+        return .{ .result = std.c.sendto(fd, datagram.ptr, datagram.len, 0, @ptrCast(peer), @sizeOf(std.c.sockaddr.in)) };
+    }
+
+    var control: [ecn_control_len]u8 align(@alignOf(usize)) = std.mem.zeroes([ecn_control_len]u8);
+    const header: *align(cmsg_alignment) std.c.cmsghdr = @ptrCast(@alignCast(&control[0]));
+    header.len = @intCast(cmsgLen(@sizeOf(c_int)));
+    header.level = if (peer.family == posix.AF.INET6) posix.IPPROTO.IPV6 else posix.IPPROTO.IP;
+    header.type = @intCast(if (peer.family == posix.AF.INET6) options.?.send_cmsg_v6 else options.?.send_cmsg_v4);
+    const value: c_int = traffic_class.?;
+    @memcpy(control[cmsg_data_offset..][0..@sizeOf(c_int)], std.mem.asBytes(&value));
+
+    var iov = [_]std.c.iovec_const{.{ .base = datagram.ptr, .len = datagram.len }};
+    var msg = std.mem.zeroes(std.c.msghdr_const);
+    msg.name = @ptrCast(peer);
+    msg.namelen = @sizeOf(std.c.sockaddr.in);
+    msg.iov = &iov;
+    msg.iovlen = 1;
+    msg.control = &control;
+    msg.controllen = @intCast(cmsgSpace(@sizeOf(c_int)));
+
+    const sent = std.c.sendmsg(fd, &msg, 0);
+    if (sent >= 0) return .{ .result = sent };
+    // A kernel that will not accept the control message rejects every marked
+    // send the same way, so retrying this one unmarked both delivers the
+    // datagram and tells the caller to stop asking. Losing the mark is safe in
+    // the direction that matters: the transport counted a marked packet the
+    // peer will report as unmarked, which its own validation reads as marks
+    // being stripped and answers by turning ECN off.
+    if (isEcnControlRejection(posix.errno(sent))) {
+        return .{
+            .result = std.c.sendto(fd, datagram.ptr, datagram.len, 0, @ptrCast(peer), @sizeOf(std.c.sockaddr.in)),
+            .ecn_rejected = true,
+        };
+    }
+    return .{ .result = sent };
+}
+
+/// Whether a `sendmsg` failure is the kernel refusing the ECN control message
+/// rather than an ordinary transient send failure. Deliberately narrow:
+/// treating a full send buffer or an unreachable host as "this platform cannot
+/// mark" would disable ECN for the life of the listener on the strength of one
+/// bad moment.
+fn isEcnControlRejection(err: posix.E) bool {
+    return switch (err) {
+        .INVAL, .NOPROTOOPT, .OPNOTSUPP, .PERM, .AFNOSUPPORT => true,
+        else => false,
+    };
+}
+
+/// The ECN codepoint carried by the control messages `recvmsg` returned, or
+/// `.unavailable` when the kernel reported none — a socket without the option,
+/// a platform without the constants, or a truncated control buffer.
+fn ecnFromControl(control: []const u8, controllen: usize, sa_family: u32) quic.udp.Ecn {
+    const options = ecn_socket_options orelse return .unavailable;
+    const is_v6 = sa_family == posix.AF.INET6;
+    const want_level: c_int = if (is_v6) posix.IPPROTO.IPV6 else posix.IPPROTO.IP;
+    const want_type: c_int = @intCast(if (is_v6) options.recv_cmsg_v6 else options.recv_cmsg_v4);
+
+    const limit = @min(controllen, control.len);
+    var offset: usize = 0;
+    while (offset + cmsg_data_offset <= limit) {
+        const header: *align(cmsg_alignment) const std.c.cmsghdr = @ptrCast(@alignCast(&control[offset]));
+        const len: usize = @intCast(header.len);
+        if (len < cmsg_data_offset or offset + len > limit) break;
+        if (header.level == want_level and header.type == want_type) {
+            const payload = control[offset + cmsg_data_offset .. offset + len];
+            // Kernels are inconsistent about the width: Linux delivers the
+            // IPv4 TOS as a single byte and the IPv6 traffic class as an int,
+            // and the BSDs differ again. Only the low byte of the value ever
+            // matters, and it is the first byte on every little-endian target
+            // this runs on — but read the width the kernel actually used
+            // rather than assuming one, so a big-endian port does not silently
+            // read the wrong end of an int.
+            if (payload.len == 0) return .unavailable;
+            if (payload.len >= @sizeOf(c_int)) {
+                var value: c_int = 0;
+                @memcpy(std.mem.asBytes(&value), payload[0..@sizeOf(c_int)]);
+                return ecnFromTrafficClass(@truncate(@as(u32, @bitCast(value))));
+            }
+            return ecnFromTrafficClass(payload[0]);
+        }
+        offset += cmsgAlign(len);
+    }
+    return .unavailable;
 }
 
 /// Read one socket buffer size back with `getsockopt`. Returns null when the
@@ -2344,16 +2715,16 @@ test "quicConfigFrom clamps datagram size into the work-buffer range" {
         .listen_host = "::",
         .quic_port = 443,
         .max_datagram_size = 512,
-    }, true).max_send_udp_payload_size);
+    }, true, false).max_send_udp_payload_size);
     // Above the 2048-byte work buffer snaps down.
     try testing.expectEqual(@as(u64, 2048), quicConfigFrom(.{
         .listen_host = "::",
         .quic_port = 443,
         .max_datagram_size = 9000,
-    }, true).max_send_udp_payload_size);
+    }, true, false).max_send_udp_payload_size);
     // An in-range value passes through, and default migration allows validated
     // same-IP NAT rebinding while still advertising disable_active_migration.
-    const mid = quicConfigFrom(.{ .listen_host = "::", .quic_port = 443, .max_datagram_size = 1350 }, true);
+    const mid = quicConfigFrom(.{ .listen_host = "::", .quic_port = 443, .max_datagram_size = 1350 }, true, false);
     try testing.expectEqual(@as(u64, 1350), mid.max_send_udp_payload_size);
     try testing.expectEqual(quic.config.MigrationPolicy.nat_rebinding_only, mid.migration_policy);
     try testing.expectEqual(quic.config.RetryPolicy.off, mid.retry_policy);
@@ -2361,12 +2732,12 @@ test "quicConfigFrom clamps datagram size into the work-buffer range" {
         .listen_host = "::",
         .quic_port = 443,
         .connection_migration = true,
-    }, true).migration_policy);
+    }, true, false).migration_policy);
     try testing.expectEqual(quic.config.RetryPolicy.address_validation, quicConfigFrom(.{
         .listen_host = "::",
         .quic_port = 443,
         .retry_policy = .address_validation,
-    }, true).retry_policy);
+    }, true, false).retry_policy);
 }
 
 test "quicConfigFrom: the runtime is the socket owner that opts discovery in" {
@@ -2381,7 +2752,7 @@ test "quicConfigFrom: the runtime is the socket owner that opts discovery in" {
         @as(u64, quic.datagram.base_size),
         (quic.config.Config{}).max_send_udp_payload_size,
     );
-    const mapped = quicConfigFrom(runtime_default, true);
+    const mapped = quicConfigFrom(runtime_default, true, false);
     try testing.expectEqual(
         @as(u64, quic.datagram.max_size),
         mapped.max_send_udp_payload_size,
@@ -2390,7 +2761,7 @@ test "quicConfigFrom: the runtime is the socket owner that opts discovery in" {
     // conservative default rather than the operator's ceiling.
     try testing.expectEqual(
         (quic.config.Config{}).max_send_udp_payload_size,
-        quicConfigFrom(runtime_default, false).max_send_udp_payload_size,
+        quicConfigFrom(runtime_default, false, false).max_send_udp_payload_size,
     );
     // The advertised receive capacity is a property of the transport's
     // buffers, not of this operator knob, so the knob must not move it.
@@ -2400,7 +2771,7 @@ test "quicConfigFrom: the runtime is the socket owner that opts discovery in" {
     );
     try testing.expectEqual(
         quic.datagram.max_size,
-        quicConfigFrom(.{ .listen_host = "::", .quic_port = 443, .max_datagram_size = 1350 }, true).max_udp_payload_size,
+        quicConfigFrom(.{ .listen_host = "::", .quic_port = 443, .max_datagram_size = 1350 }, true, false).max_udp_payload_size,
     );
 }
 
@@ -2641,28 +3012,28 @@ test "quicConfigFrom (#523): enable_0rtt alone never enables the 0-RTT carrier" 
     const gate = gate_adapter.gate();
 
     // No dependencies at all.
-    try testing.expect(!quicConfigFrom(.{ .listen_host = "::", .quic_port = 443, .enable_0rtt = true }, true).zero_rtt_enabled);
+    try testing.expect(!quicConfigFrom(.{ .listen_host = "::", .quic_port = 443, .enable_0rtt = true }, true, false).zero_rtt_enabled);
     // Only a resumption runtime.
     try testing.expect(!quicConfigFrom(.{
         .listen_host = "::",
         .quic_port = 443,
         .enable_0rtt = true,
         .resumption_runtime = &resumption,
-    }, true).zero_rtt_enabled);
+    }, true, false).zero_rtt_enabled);
     // Only a replay gate.
     try testing.expect(!quicConfigFrom(.{
         .listen_host = "::",
         .quic_port = 443,
         .enable_0rtt = true,
         .early_data_replay_gate = gate,
-    }, true).zero_rtt_enabled);
+    }, true, false).zero_rtt_enabled);
     // Both dependencies present but `enable_0rtt` false (the default): still disabled.
     try testing.expect(!quicConfigFrom(.{
         .listen_host = "::",
         .quic_port = 443,
         .resumption_runtime = &resumption,
         .early_data_replay_gate = gate,
-    }, true).zero_rtt_enabled);
+    }, true, false).zero_rtt_enabled);
     // Every dependency present: the carrier actually enables.
     try testing.expect(quicConfigFrom(.{
         .listen_host = "::",
@@ -2670,7 +3041,7 @@ test "quicConfigFrom (#523): enable_0rtt alone never enables the 0-RTT carrier" 
         .enable_0rtt = true,
         .resumption_runtime = &resumption,
         .early_data_replay_gate = gate,
-    }, true).zero_rtt_enabled);
+    }, true, false).zero_rtt_enabled);
 }
 
 fn expectInvalidH3SettingsAtRuntimeInit(settings: http3.frame.Settings) !void {
@@ -4970,17 +5341,17 @@ test "http3 runtime: DPLPMTUD stays at the floor without the no-fragmentation co
     const raised = Config{ .listen_host = "::", .quic_port = 443, .max_datagram_size = quic.datagram.max_size };
     try testing.expectEqual(
         @as(u64, quic.datagram.max_size),
-        quicConfigFrom(raised, true).max_send_udp_payload_size,
+        quicConfigFrom(raised, true, false).max_send_udp_payload_size,
     );
     try testing.expectEqual(
         @as(u64, quic.datagram.base_size),
-        quicConfigFrom(raised, false).max_send_udp_payload_size,
+        quicConfigFrom(raised, false, false).max_send_udp_payload_size,
     );
     // The advertised receive capacity is a property of this endpoint's
     // buffers and is unaffected either way.
     try testing.expectEqual(
-        quicConfigFrom(raised, true).max_udp_payload_size,
-        quicConfigFrom(raised, false).max_udp_payload_size,
+        quicConfigFrom(raised, true, false).max_udp_payload_size,
+        quicConfigFrom(raised, false, false).max_udp_payload_size,
     );
 }
 
@@ -5146,4 +5517,221 @@ test "http3 runtime: only verified platforms claim no-fragmentation support" {
         else => false,
     };
     try testing.expectEqual(expected, no_fragment_supported);
+}
+
+// ---------------------------------------------------------------------------
+// ECN socket support (#256-E).
+//
+// The state machine these feed is tested deterministically in `quic/ecn.zig`
+// and end to end in `quic/connection.zig`; what is left here is the part that
+// can only be checked against a real kernel, plus the pure conversions between
+// an IP traffic-class byte and the transport's codepoint model.
+// ---------------------------------------------------------------------------
+
+test "http3 runtime: only verified platforms claim ECN support" {
+    // Same rule as the no-fragmentation table: these option numbers differ
+    // per OS, and a wrong constant that a kernel happens to accept would read
+    // as a working ECN path while marking nothing. Unverified platforms run
+    // without ECN, which is a supported state.
+    const expected = switch (builtin.os.tag) {
+        .linux, .macos, .ios, .tvos, .watchos, .freebsd => true,
+        else => false,
+    };
+    try testing.expectEqual(expected, ecn_supported);
+}
+
+test "http3 runtime: the ECN field is the low two bits and nothing else" {
+    // RFC 3168 §5. The upper six bits are DSCP — an operator's traffic-class
+    // marking — and reading them as congestion would turn ordinary QoS
+    // configuration into a signal to halve the window.
+    try testing.expectEqual(quic.udp.Ecn.not_ect, ecnFromTrafficClass(0b0000_0000));
+    try testing.expectEqual(quic.udp.Ecn.ect1, ecnFromTrafficClass(0b0000_0001));
+    try testing.expectEqual(quic.udp.Ecn.ect0, ecnFromTrafficClass(0b0000_0010));
+    try testing.expectEqual(quic.udp.Ecn.ce, ecnFromTrafficClass(0b0000_0011));
+    // A DSCP-marked packet (CS5 = 0b101000_00) is still not-ECT.
+    try testing.expectEqual(quic.udp.Ecn.not_ect, ecnFromTrafficClass(0b1010_0000));
+    try testing.expectEqual(quic.udp.Ecn.ect0, ecnFromTrafficClass(0b1010_0010));
+
+    try testing.expectEqual(@as(?c_int, 0b10), trafficClassFromEcn(.ect0));
+    try testing.expectEqual(@as(?c_int, 0b11), trafficClassFromEcn(.ce));
+    try testing.expectEqual(@as(?c_int, 0), trafficClassFromEcn(.not_ect));
+    // "Could not observe one" is not a codepoint that can be sent.
+    try testing.expectEqual(@as(?c_int, null), trafficClassFromEcn(.unavailable));
+}
+
+test "http3 runtime: an absent or unrelated control message reads as unavailable" {
+    if (!ecn_supported) return error.SkipZigTest;
+    var control: [ecn_control_len]u8 align(@alignOf(usize)) = std.mem.zeroes([ecn_control_len]u8);
+
+    // No control data at all: the socket cannot report a codepoint, which is
+    // `.unavailable` and emphatically not `.not_ect` — reporting "unmarked"
+    // would make a peer's working marking look stripped.
+    try testing.expectEqual(quic.udp.Ecn.unavailable, ecnFromControl(&control, 0, posix.AF.INET));
+
+    // A well-formed control message for something else is skipped rather than
+    // misread as a traffic class.
+    const header: *align(cmsg_alignment) std.c.cmsghdr = @ptrCast(@alignCast(&control[0]));
+    header.len = @intCast(cmsgLen(@sizeOf(c_int)));
+    header.level = posix.SOL.SOCKET;
+    header.type = 0x7f;
+    try testing.expectEqual(
+        quic.udp.Ecn.unavailable,
+        ecnFromControl(&control, cmsgSpace(@sizeOf(c_int)), posix.AF.INET),
+    );
+
+    // A header claiming more data than the buffer holds is refused rather than
+    // read past — control data comes from the kernel, but the length arithmetic
+    // is this code's to get right.
+    header.level = posix.IPPROTO.IP;
+    header.type = @intCast(ecn_socket_options.?.recv_cmsg_v4);
+    header.len = @intCast(cmsgLen(@sizeOf(c_int)) + 4096);
+    try testing.expectEqual(
+        quic.udp.Ecn.unavailable,
+        ecnFromControl(&control, cmsgSpace(@sizeOf(c_int)), posix.AF.INET),
+    );
+}
+
+test "http3 runtime: a received traffic-class control message yields its codepoint" {
+    if (!ecn_supported) return error.SkipZigTest;
+    var control: [ecn_control_len]u8 align(@alignOf(usize)) = std.mem.zeroes([ecn_control_len]u8);
+    const header: *align(cmsg_alignment) std.c.cmsghdr = @ptrCast(@alignCast(&control[0]));
+    header.level = posix.IPPROTO.IP;
+    header.type = @intCast(ecn_socket_options.?.recv_cmsg_v4);
+
+    // Kernels disagree on the width they deliver this in — Linux hands back a
+    // single byte for IPv4, an int for IPv6, and the BSDs differ again — so
+    // both are read rather than one being assumed.
+    header.len = @intCast(cmsgLen(1));
+    control[cmsg_data_offset] = 0b11;
+    try testing.expectEqual(quic.udp.Ecn.ce, ecnFromControl(&control, cmsgSpace(1), posix.AF.INET));
+
+    header.len = @intCast(cmsgLen(@sizeOf(c_int)));
+    const value: c_int = 0b10;
+    @memcpy(control[cmsg_data_offset..][0..@sizeOf(c_int)], std.mem.asBytes(&value));
+    try testing.expectEqual(
+        quic.udp.Ecn.ect0,
+        ecnFromControl(&control, cmsgSpace(@sizeOf(c_int)), posix.AF.INET),
+    );
+}
+
+test "http3 runtime: a marked datagram survives a real loopback socket" {
+    // The one thing no state-machine test can establish: that this platform's
+    // option numbers, control-message layout, and alignment arithmetic are
+    // right, end to end, against the kernel that will actually carry the
+    // traffic. Everything above this line would pass with the constants wrong.
+    if (!ecn_supported) return error.SkipZigTest;
+
+    const receiver = openUdpSocket(posix.AF.INET);
+    if (receiver < 0) return error.SkipZigTest;
+    defer _ = std.c.close(receiver);
+    if (!configureEcnReceive(receiver, posix.AF.INET)) return error.SkipZigTest;
+
+    var bind_address = std.c.sockaddr.in{
+        .family = posix.AF.INET,
+        .port = 0,
+        .addr = std.mem.nativeToBig(u32, 0x7f00_0001),
+        .zero = [_]u8{0} ** 8,
+    };
+    if (std.c.bind(receiver, @ptrCast(&bind_address), @sizeOf(std.c.sockaddr.in)) != 0) return error.SkipZigTest;
+    var bound: std.c.sockaddr.in = undefined;
+    var bound_len: std.c.socklen_t = @sizeOf(std.c.sockaddr.in);
+    if (std.c.getsockname(receiver, @ptrCast(&bound), &bound_len) != 0) return error.SkipZigTest;
+
+    const sender = openUdpSocket(posix.AF.INET);
+    if (sender < 0) return error.SkipZigTest;
+    defer _ = std.c.close(sender);
+
+    const outcome = sendDatagramTo(sender, &bound, "ecn", .ect0);
+    // A kernel that refuses the control message is a real, supported outcome:
+    // the datagram still went out, unmarked, and the listener stops asking.
+    if (outcome.ecn_rejected) return error.SkipZigTest;
+    try testing.expectEqual(@as(isize, 3), outcome.result);
+
+    var buf: [64]u8 = undefined;
+    var from: std.c.sockaddr.storage = undefined;
+    var from_len: std.c.socklen_t = @sizeOf(std.c.sockaddr.storage);
+    var attempts: usize = 0;
+    const received = while (attempts < 200) : (attempts += 1) {
+        const attempt = receiveDatagram(receiver, &buf, &from, &from_len);
+        if (attempt.result >= 0) break attempt;
+        if (posix.errno(attempt.result) != .AGAIN) return error.SkipZigTest;
+        compat.sleepNs(1 * std.time.ns_per_ms);
+    } else return error.SkipZigTest;
+
+    try testing.expectEqualStrings("ecn", buf[0..@intCast(received.result)]);
+    try testing.expectEqual(quic.udp.Ecn.ect0, received.ecn);
+}
+
+test "http3 runtime: an unmarked datagram reports not-ECT, not unavailable" {
+    // The negative control for the test above: with the receive option on, a
+    // datagram that really was unmarked must come back as `.not_ect` so the
+    // peer's validation can distinguish "your marks were stripped" from "I
+    // cannot see marks at all".
+    if (!ecn_supported) return error.SkipZigTest;
+
+    const receiver = openUdpSocket(posix.AF.INET);
+    if (receiver < 0) return error.SkipZigTest;
+    defer _ = std.c.close(receiver);
+    if (!configureEcnReceive(receiver, posix.AF.INET)) return error.SkipZigTest;
+
+    var bind_address = std.c.sockaddr.in{
+        .family = posix.AF.INET,
+        .port = 0,
+        .addr = std.mem.nativeToBig(u32, 0x7f00_0001),
+        .zero = [_]u8{0} ** 8,
+    };
+    if (std.c.bind(receiver, @ptrCast(&bind_address), @sizeOf(std.c.sockaddr.in)) != 0) return error.SkipZigTest;
+    var bound: std.c.sockaddr.in = undefined;
+    var bound_len: std.c.socklen_t = @sizeOf(std.c.sockaddr.in);
+    if (std.c.getsockname(receiver, @ptrCast(&bound), &bound_len) != 0) return error.SkipZigTest;
+
+    const sender = openUdpSocket(posix.AF.INET);
+    if (sender < 0) return error.SkipZigTest;
+    defer _ = std.c.close(sender);
+    const outcome = sendDatagramTo(sender, &bound, "plain", .not_ect);
+    try testing.expectEqual(@as(isize, 5), outcome.result);
+    try testing.expect(!outcome.ecn_rejected);
+
+    var buf: [64]u8 = undefined;
+    var from: std.c.sockaddr.storage = undefined;
+    var from_len: std.c.socklen_t = @sizeOf(std.c.sockaddr.storage);
+    var attempts: usize = 0;
+    const received = while (attempts < 200) : (attempts += 1) {
+        const attempt = receiveDatagram(receiver, &buf, &from, &from_len);
+        if (attempt.result >= 0) break attempt;
+        if (posix.errno(attempt.result) != .AGAIN) return error.SkipZigTest;
+        compat.sleepNs(1 * std.time.ns_per_ms);
+    } else return error.SkipZigTest;
+    try testing.expectEqual(quic.udp.Ecn.not_ect, received.ecn);
+}
+
+test "http3 runtime: a listener publishes whether ECN is actually running" {
+    var logger = logger_mod.Logger.init(.err, "http3-ecn-test");
+    var runtime = Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+    }) catch return error.SkipZigTest;
+    defer runtime.deinit();
+
+    // On by default, but only *actually* on where the kernel agreed to report
+    // received codepoints — the snapshot reports what applied, not what was
+    // asked for, because that is what a benchmark run has to record.
+    try testing.expectEqual(ecn_supported, runtime.snapshot().ecn_enabled);
+    try testing.expectEqual(ecn_supported, runtime.quic_config.ecn_enabled);
+    try testing.expectEqual(ecn_supported, runtime.ecn_send_enabled);
+}
+
+test "http3 runtime: an operator can turn ECN off outright" {
+    var logger = logger_mod.Logger.init(.err, "http3-ecn-off-test");
+    var runtime = Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+        .ecn_enabled = false,
+    }) catch return error.SkipZigTest;
+    defer runtime.deinit();
+
+    try testing.expect(!runtime.snapshot().ecn_enabled);
+    try testing.expect(!runtime.quic_config.ecn_enabled);
+    try testing.expect(!runtime.ecn_send_enabled);
+    try testing.expectEqual(@as(usize, 0), runtime.snapshot().ecn_marked_sent);
 }

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -343,6 +343,10 @@ pub const Runtime = struct {
     /// message — the two are separate capabilities on some platforms, and one
     /// refusal is enough to know marking will never work here.
     ecn_send_enabled: bool = false,
+    /// Set when `noteEcnSendRejected` has withdrawn the capability and live
+    /// connections have not been told yet. Applied on the run loop's next
+    /// pass, which is the only place that holds the connection table.
+    ecn_disable_pending: bool = false,
 
     /// Erase `crypto_provider_state` to the boundary type for a `Connection`.
     /// Borrows `self`, so the returned value must not outlive this `Runtime`
@@ -566,6 +570,10 @@ pub const Runtime = struct {
                     while (entry.conn.pollTransmitOnPath(&out, now)) |t| {
                         self.sendDatagram(sockaddrInFromAddress(t.path.remote), t.bytes, t.ecn);
                     }
+                    // #256-E: the socket has just proven it cannot mark, so
+                    // stop every live connection from claiming marks it never
+                    // sent. Distinct from a path failing ECN validation.
+                    if (self.ecn_disable_pending) entry.conn.disableEcnUnsupported();
                     // Reap closed connections and half-open connections that
                     // blew the handshake deadline (spoofed/stalled Initials).
                     const stalled = !entry.conn.isEstablished() and now -| entry.accepted_at_us > handshake_timeout_us;
@@ -578,6 +586,7 @@ pub const Runtime = struct {
                     }
                     if (entry.conn.nextTimeoutUs()) |deadline| wake_us = @min(wake_us, deadline);
                 }
+                self.ecn_disable_pending = false;
                 for (reap[0..reap_count]) |handle| {
                     self.removeConnection(&connections, &routes, &per_ip, handle);
                 }
@@ -1190,22 +1199,35 @@ pub const Runtime = struct {
     fn sendDatagram(self: *Runtime, peer: std.c.sockaddr.in, datagram: []const u8, mark: quic.udp.Ecn) void {
         const effective_mark = if (self.ecn_send_enabled) mark else .not_ect;
         const outcome = sendDatagramTo(self.socket_fd, &peer, datagram, effective_mark);
-        if (outcome.ecn_rejected and self.ecn_send_enabled) {
-            // Reading the codepoint and setting it are separate kernel
-            // capabilities; this listener has just learned it only has the
-            // first. Stop asking rather than paying a failed `sendmsg` on
-            // every datagram, and let each connection's own ECN validation
-            // discover that its marks are not arriving.
-            self.ecn_send_enabled = false;
-            self.snapshot_mutex.lock();
-            self.snapshot_state.ecn_enabled = false;
-            self.snapshot_mutex.unlock();
-            self.logger.warn(null, "http3: kernel refused the ECN send option; continuing without explicit congestion notification", .{});
-        }
+        if (outcome.ecn_rejected) self.noteEcnSendRejected();
         const sent = outcome.result;
         if (sent >= 0 and @as(usize, @intCast(sent)) == datagram.len) {
             self.notePacketOut(datagram.len);
         }
+    }
+
+    /// The kernel refused the ECN control message, so this listener can read
+    /// the codepoint but not set it (#256-E review).
+    ///
+    /// Turning off the send shim alone is not enough: `quic_config` is copied
+    /// into every accepted `Connection`, so future connections would keep
+    /// entering ECN testing, counting marks, and waiting for ACK_ECN for
+    /// datagrams that actually left Not-ECT — with the snapshot simultaneously
+    /// reporting ECN off. So the capability is withdrawn at the transport
+    /// boundary too, and live connections are told explicitly (which is a
+    /// different thing from a path failing validation).
+    ///
+    /// Separated from `sendDatagram` so it is unit-testable without a kernel
+    /// that rejects the option.
+    fn noteEcnSendRejected(self: *Runtime) void {
+        if (!self.ecn_send_enabled) return;
+        self.ecn_send_enabled = false;
+        self.quic_config.ecn_enabled = false;
+        self.ecn_disable_pending = true;
+        self.snapshot_mutex.lock();
+        self.snapshot_state.ecn_enabled = false;
+        self.snapshot_mutex.unlock();
+        self.logger.warn(null, "http3: kernel refused the ECN send option; continuing without explicit congestion notification", .{});
     }
 
     fn h3DownstreamHandshakeComplete(ctx: *anyopaque) bool {
@@ -5734,4 +5756,37 @@ test "http3 runtime: an operator can turn ECN off outright" {
     try testing.expect(!runtime.quic_config.ecn_enabled);
     try testing.expect(!runtime.ecn_send_enabled);
     try testing.expectEqual(@as(usize, 0), runtime.snapshot().ecn_marked_sent);
+}
+
+test "http3 runtime: a socket that cannot mark withdraws ECN from the transport too" {
+    // #256-E review: turning off only the send shim would leave
+    // `quic_config.ecn_enabled` true, so every connection accepted afterwards
+    // would still enter ECN testing and count marks for datagrams that
+    // actually left Not-ECT — while the snapshot reported ECN off. Separated
+    // from `sendDatagram` so this is provable without a kernel that rejects
+    // the control message.
+    var logger = logger_mod.Logger.init(.err, "http3-ecn-reject-test");
+    var runtime = Runtime.init(testing.allocator, &logger, .{
+        .listen_host = "127.0.0.1",
+        .quic_port = 0,
+    }) catch return error.SkipZigTest;
+    defer runtime.deinit();
+    if (!runtime.ecn_send_enabled) return error.SkipZigTest;
+    try testing.expect(runtime.quic_config.ecn_enabled);
+
+    runtime.noteEcnSendRejected();
+
+    try testing.expect(!runtime.ecn_send_enabled);
+    // The capability is withdrawn where new connections read it ...
+    try testing.expect(!runtime.quic_config.ecn_enabled);
+    // ... the snapshot agrees ...
+    try testing.expect(!runtime.snapshot().ecn_enabled);
+    // ... and live connections are queued to be told, which is a different
+    // thing from any one of their paths failing ECN validation.
+    try testing.expect(runtime.ecn_disable_pending);
+
+    // Idempotent: a second refusal changes nothing and does not re-queue.
+    runtime.ecn_disable_pending = false;
+    runtime.noteEcnSendRejected();
+    try testing.expect(!runtime.ecn_disable_pending);
 }

--- a/src/quic/config.zig
+++ b/src/quic/config.zig
@@ -105,6 +105,22 @@ pub const Config = struct {
     initial_max_streams_uni: u64 = 16,
     retry_policy: RetryPolicy = .off,
     migration_policy: MigrationPolicy = .disabled,
+    /// Whether outbound packets may be marked ECT(0) and the peer's ACK_ECN
+    /// counters acted on (#256-E, RFC 9000 §13.4).
+    ///
+    /// Off by default for the same reason `max_send_udp_payload_size` starts
+    /// at the floor: this layer owns no socket. Marking a packet means asking
+    /// the kernel to set an IP header field on a specific datagram, and
+    /// reading the peer's marks back means ancillary receive metadata — both
+    /// are platform capabilities only the composition root that created the
+    /// socket can establish. Enabling it without them would mark nothing,
+    /// observe nothing, and then conclude from the resulting silence that the
+    /// *path* strips ECN.
+    ///
+    /// Enabling it is never a correctness risk in the other direction: every
+    /// validation failure ends in ordinary non-ECN operation rather than a
+    /// connection error.
+    ecn_enabled: bool = false,
     /// 0-RTT is off unless an operator explicitly opts in, given its replay
     /// exposure (RFC 9001 §9.2). The TLS adapter refuses 0-RTT keys while false.
     zero_rtt_enabled: bool = false,

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -917,20 +917,20 @@ const EcnSentMeta = struct {
     path_generation: u64,
     sent_time_us: u64,
     marked: bool,
-    /// Whether this packet can still move the peer's cumulative counters.
-    /// Cleared once recovery declares it lost: a packet the peer never
-    /// received never incremented anything. The entry itself stays, so a late
-    /// acknowledgement is still classified correctly — only the connection's
-    /// outstanding-mark accounting stops waiting on it.
-    can_affect_counts: bool = true,
 };
 
-/// How many application-space packets keep ECN metadata. Covers a full flight
-/// with headroom (recovery tracks at most `recovery.max_tracked_packets`), so
-/// eviction is the exception rather than the rule. A fixed array costs every
-/// connection ~4 KiB whether or not ECN is on, which is the price of not
-/// allocating on the send path.
-const ecn_history_capacity: usize = 128;
+/// How many application-space packets keep ECN metadata.
+///
+/// Entries retire fast — every advancing ACK_ECN clears everything at or below
+/// its largest acknowledged packet number — so this only has to cover packets
+/// sent since the last such ACK, which is a flight. Twice
+/// `recovery.max_tracked_packets` leaves room for the untracked packets
+/// recovery never sees. Overflowing it is not a silent condition: evicting an
+/// entry whose evidence is still owed fails ECN closed (`evidence_lost`),
+/// because memory pressure says nothing about whether that packet moved the
+/// peer's counters. A fixed array costs every connection ~8 KiB whether or not
+/// ECN is on, which is the price of not allocating on the send path.
+const ecn_history_capacity: usize = 2 * recovery.max_tracked_packets;
 
 /// Bounded ECN metadata for recently sent application-space packets.
 ///
@@ -1010,6 +1010,12 @@ const EcnAckTally = struct {
             if (entry.generation == generation) return entry.count;
         }
         return 0;
+    }
+
+    fn total(self: EcnAckTally) u64 {
+        var sum: u64 = 0;
+        for (self.entries[0..self.len]) |entry| sum +|= entry.count;
+        return sum;
     }
 };
 
@@ -1107,6 +1113,17 @@ pub const Connection = struct {
     /// see `syncPathEcn`.
     ecn_marking_generation: ?u64 = null,
     ecn_outstanding_marked: u32 = 0,
+    /// Marks retired by an ACK that did *not* advance the largest acknowledged
+    /// packet number, owed to the next one that does. Such an ACK really does
+    /// newly acknowledge those packets — it filled a gap — but its cumulative
+    /// counters are stale, so the growth they require has to be demanded of
+    /// the next report that is current (#256-E review).
+    ecn_carried_marked: u64 = 0,
+    /// When a migration's wait for the previous epoch stops being worth it.
+    /// The barrier cannot always drain — a marked packet that is never
+    /// acknowledged is never settled — so it is bounded, and running out fails
+    /// ECN closed rather than releasing on an assumption (#256-E review).
+    ecn_barrier_deadline_us: ?u64 = null,
     /// Whether an ACK must be assembled for the space, and when the obligation
     /// arose (for the encoded ack_delay and the delayed-ack timer).
     ack_needed: [3]bool = .{ false, false, false },
@@ -1449,7 +1466,6 @@ pub const Connection = struct {
     /// marked, which is only a clean comparison once one packet number space
     /// is doing all the work.
     fn syncPathEcn(self: *Connection, now_us: u64) void {
-        _ = now_us;
         if (!self.cfg.ecn_enabled) return;
         if (!self.handshake_confirmed or self.state_ != .established) return;
         const active = self.paths.activePathRef();
@@ -1465,8 +1481,24 @@ pub const Connection = struct {
         // and starts marking.
         if (self.ecn_marking_generation) |marking| {
             if (marking != active.generation) {
-                if (self.ecn_outstanding_marked > 0) return;
+                if (self.ecn_outstanding_marked > 0) {
+                    // Bounded, because the wait can be unbounded: a marked
+                    // packet that is never acknowledged is never settled, and
+                    // no amount of waiting makes it so. Running out fails ECN
+                    // closed for the connection rather than releasing on the
+                    // assumption that an unacknowledged packet was never
+                    // counted — which is precisely the assumption that lets an
+                    // old path's evidence validate a new one.
+                    const deadline = self.ecn_barrier_deadline_us orelse deadline: {
+                        const at = now_us +| quic_ecn.testing_pto_multiplier *| self.ptoDurationNow();
+                        self.ecn_barrier_deadline_us = at;
+                        break :deadline at;
+                    };
+                    if (now_us >= deadline) self.failEcnClosed(.evidence_lost);
+                    return;
+                }
                 self.ecn_marking_generation = null;
+                self.ecn_barrier_deadline_us = null;
             }
         }
 
@@ -1508,11 +1540,15 @@ pub const Connection = struct {
             .sent_time_us = now_us,
             .marked = marked,
         })) |evicted| {
-            // An evicted entry can no longer be classified, so it must stop
-            // holding the barrier open. Under-counting here only ever delays
-            // nothing and releases the barrier sooner, which is why eviction
-            // is bounded by a capacity comfortably above a full flight.
-            self.releaseEcnOutstanding(evicted);
+            // Evicting an entry whose evidence is still owed loses the ability
+            // to check something that matters: whether a mark this endpoint
+            // placed came back counted. Silently dropping it would let a
+            // stripped mark go unnoticed — 129 marked packets, the oldest
+            // evicted and stripped, and an ACK covering all of them validates
+            // on 128 — and would release the migration barrier on a packet
+            // whose contribution to the peer's counters is unknown. Memory
+            // pressure is not evidence, so this fails ECN closed instead.
+            if (evicted.marked) self.failEcnClosed(.evidence_lost);
         }
         if (!marked) return;
         self.paths.activeEcn().onMarkedSent(
@@ -1523,25 +1559,56 @@ pub const Connection = struct {
         self.metrics.ecn_marked_sent += 1;
     }
 
-    /// Stop waiting on one marked packet: it was acknowledged, declared lost,
-    /// or fell out of the history.
+    /// Stop waiting on one marked packet, because the peer acknowledged it and
+    /// its contribution to the counters is therefore settled.
+    ///
+    /// Acknowledgement is the *only* thing that qualifies. It is tempting to
+    /// also retire a packet the peer has evidently moved past — one below a
+    /// later ACK's largest acknowledged number — on the grounds that its
+    /// contribution must already be in those counts. That is exactly backwards:
+    /// a QUIC receiver reports every packet number it has received in its ACK
+    /// ranges, so a packet *missing* from them had not arrived when the ACK was
+    /// generated, and its contribution is still to come.
+    ///
+    /// Notably *not* a loss declaration. QUIC loss is an inference, not proof
+    /// of non-delivery: the packet may have arrived and incremented the peer's
+    /// counter while the ACK carrying that increment was itself lost, and this
+    /// implementation deliberately supports acknowledging a packet after
+    /// declaring it lost. RFC 9000 §13.4.2 treats an ECT-marked packet deemed
+    /// lost as validation *evidence*, not as proof it was never counted.
     fn releaseEcnOutstanding(self: *Connection, meta: EcnSentMeta) void {
-        if (!meta.marked or !meta.can_affect_counts) return;
+        if (!meta.marked) return;
         self.ecn_outstanding_marked -|= 1;
     }
 
-    /// Recovery declared an application-space packet lost. The peer never
-    /// received it, so it can no longer move the peer's counters and must stop
-    /// holding the epoch barrier open — but the history entry survives, so a
-    /// late acknowledgement (a spurious loss, a reordered ACK) is still
-    /// classified rather than silently unaccounted.
-    fn noteEcnPacketLost(self: *Connection, space: PacketNumberSpace, packet_number: u64) void {
-        if (space != .application or !self.cfg.ecn_enabled) return;
-        const index = self.ecn_history.find(packet_number) orelse return;
-        const entry = &self.ecn_history.entries[index];
-        if (!entry.can_affect_counts) return;
-        entry.can_affect_counts = false;
-        if (entry.marked) self.ecn_outstanding_marked -|= 1;
+    /// Give up on ECN for this connection because something needed to attribute
+    /// the peer's counters is gone. Marking stops on every path, and no new
+    /// epoch may start: the alternative is continuing to feed congestion
+    /// control from counters nothing can check.
+    fn failEcnClosed(self: *Connection, reason: quic_ecn.FailureReason) void {
+        if (!self.cfg.ecn_enabled) return;
+        self.cfg.ecn_enabled = false;
+        self.ecn_marking_generation = null;
+        self.ecn_outstanding_marked = 0;
+        self.ecn_carried_marked = 0;
+        self.ecn_barrier_deadline_us = null;
+        self.ecn_history.len = 0;
+        for (&self.paths.paths) |*slot| {
+            const path = &(slot.* orelse continue);
+            if (!path.ecn.marking()) continue;
+            path.ecn.disable(reason);
+            self.publishEcnState(path.key, .disabled, reason);
+        }
+    }
+
+    /// The socket layer has discovered it cannot put the codepoint on the wire
+    /// after all, so every packet this connection believes it marked actually
+    /// left Not-ECT (#256-E review). Distinct from a path failing validation:
+    /// nothing was learned about any path, and continuing to count marks the
+    /// socket did not send would make both the transport counters and the
+    /// listener snapshot claim something untrue.
+    pub fn disableEcnUnsupported(self: *Connection) void {
+        self.failEcnClosed(.platform_unsupported);
     }
 
     /// Publish an ECN state transition for `path`: the operator counter and
@@ -2355,23 +2422,13 @@ pub const Connection = struct {
         if (space != .application or !self.cfg.ecn_enabled) return;
         const space_idx = spaceIndex(space);
 
-        // RFC 9000 §13.4.2.1: an ACK that does not increase the largest
-        // acknowledged packet number must not fail ECN validation. The peer's
-        // counters are cumulative, so a delayed ACK carries the values as of
-        // *its* largest — older than what has already been processed — and
-        // judging those against the current state would read ordinary
-        // reordering as a peer walking its counters backwards. Nothing here
-        // runs for such an ACK: not the tally, not the counter update, not the
-        // history reaping, all of which would corrupt the ordering boundary.
-        const advances = self.largest_ecn_acked[space_idx] == null or
-            ack.largest_acknowledged > self.largest_ecn_acked[space_idx].?;
-        if (!advances) return;
-        self.largest_ecn_acked[space_idx] = ack.largest_acknowledged;
-
-        // Newly acknowledged packets, from the ECN history rather than from
-        // `sent_records`: a packet declared lost is gone from the latter and
-        // can still be acknowledged (a spurious loss, a reordered ACK), and
-        // RFC 9000 §13.4.2.1 is about what an ACK *newly acknowledges*.
+        // Retiring metadata and validating counters are two different things,
+        // and only the second is subject to the ordering rule. An ACK that
+        // does not advance the largest acknowledged packet number can still
+        // *newly acknowledge* a packet that was a gap in an earlier one, and
+        // that delivery is irrevocable — the peer is under no obligation to
+        // repeat the range. Leaving the entry charged would hold the migration
+        // barrier open until eviction, which now fails ECN closed.
         var tally = EcnAckTally{};
         var history_largest_sent_us: ?u64 = null;
         var index: usize = 0;
@@ -2388,6 +2445,24 @@ pub const Connection = struct {
             self.releaseEcnOutstanding(entry);
             self.ecn_history.removeAt(index);
         }
+
+        // RFC 9000 §13.4.2.1: an ACK that does not increase the largest
+        // acknowledged packet number must not fail ECN validation. The peer's
+        // counters are cumulative, so a delayed ACK carries the values as of
+        // *its* largest — older than what has already been processed — and
+        // judging those against the current state would read ordinary
+        // reordering as a peer walking its counters backwards.
+        //
+        // The marks it retired are not forgotten, though: their growth is owed
+        // by the next report that is current, so they are carried forward
+        // rather than dropped.
+        const advances = self.largest_ecn_acked[space_idx] == null or
+            ack.largest_acknowledged > self.largest_ecn_acked[space_idx].?;
+        if (!advances) {
+            self.ecn_carried_marked +|= tally.total();
+            return;
+        }
+        self.largest_ecn_acked[space_idx] = ack.largest_acknowledged;
 
         const feedback: ?quic_ecn.Feedback = if (ack.ecn) |counts|
             .{ .ect0 = counts.ect0, .ect1 = counts.ect1, .ce = counts.ce }
@@ -2412,9 +2487,11 @@ pub const Connection = struct {
         // sufficient, by ensuring no previous path's marks are still in flight
         // to contribute growth this path would otherwise be promoted on.
         const active = self.paths.activePathRef();
+        const carried = self.ecn_carried_marked;
+        self.ecn_carried_marked = 0;
         self.applyEcnFeedback(
             active,
-            tally.countFor(active.generation),
+            tally.countFor(active.generation) +| carried,
             feedback,
             history_largest_sent_us orelse record_largest_sent_us,
             now_us,
@@ -2508,11 +2585,10 @@ pub const Connection = struct {
                 continue;
             }
             count += 1;
-            // #256-E: a lost packet never reached the peer, so it can no
-            // longer move the peer's ECN counters and must stop holding the
-            // migration barrier open. Its history entry survives, so a late
-            // acknowledgement is still classified.
-            self.noteEcnPacketLost(space, record.packet_number);
+            // #256-E deliberately does nothing here. A loss declaration is an
+            // inference, not proof the peer never received the packet, so it
+            // neither retires the packet's ECN metadata nor releases the
+            // migration barrier. See `releaseEcnOutstanding`.
             if (record.carried_pmtu_probe != null) {
                 // Nothing to requeue: a probe carries no user data, and the
                 // search decides for itself whether to retry this size. The
@@ -3609,6 +3685,7 @@ pub const Connection = struct {
         var datagram_len: usize = 0;
         var has_initial = false;
         var sent_ack_eliciting = false;
+        var datagram_marked = false;
 
         const levels = [_]EncryptionLevel{ .initial, .handshake, .application };
         for (levels) |level| {
@@ -3621,6 +3698,7 @@ pub const Connection = struct {
             datagram_len += written.len;
             has_initial = has_initial or level == .initial;
             sent_ack_eliciting = sent_ack_eliciting or written.ack_eliciting;
+            datagram_marked = datagram_marked or written.ecn_marked;
             if (level == .handshake) {
                 if (!self.sent_handshake_packet) {
                     self.sent_handshake_packet = true;
@@ -3638,13 +3716,16 @@ pub const Connection = struct {
         self.paths.recordSentOnPath(active_key, datagram_len);
         self.metrics.datagrams_sent += 1;
         if (sent_ack_eliciting) self.armIdle(now_us);
-        // Every packet coalesced above shares this datagram's single IP
-        // header, so the codepoint is a property of the datagram — read once,
-        // here, from the same state each `buildPacket` stamped onto its record.
+        // Every packet coalesced above shares this datagram's single IP header,
+        // so the codepoint is a property of the datagram — and it must be
+        // exactly what the packets inside it were counted as. A datagram
+        // marked on the wire but not counted would make the peer's honest
+        // report look like an over-claim, which is why this follows what
+        // `buildPacket` actually did rather than re-reading the path state.
         return .{
             .bytes = out[0..datagram_len],
             .path = active_key,
-            .ecn = self.paths.activeEcn().sendCodepoint(),
+            .ecn = if (datagram_marked) quic_ecn.send_codepoint else .not_ect,
         };
     }
 
@@ -3928,7 +4009,14 @@ pub const Connection = struct {
             .size = total,
             .ack_eliciting = true,
         } });
-        return .{ .bytes = out[0..total], .path = active_key, .ecn = self.paths.activeEcn().sendCodepoint() };
+        // A probe is ack-eliciting and in flight, so it marks like ordinary
+        // traffic — but the codepoint still follows what was counted rather
+        // than the path state, so the two can never disagree.
+        return .{
+            .bytes = out[0..total],
+            .path = active_key,
+            .ecn = if (ecn_marked) quic_ecn.send_codepoint else .not_ect,
+        };
     }
 
     const BuildContext = struct {
@@ -3939,6 +4027,10 @@ pub const Connection = struct {
     const BuiltPacket = struct {
         len: usize,
         ack_eliciting: bool,
+        /// Whether this packet was marked ECT(0) (#256-E). The datagram's IP
+        /// header carries one codepoint for everything coalesced into it, so
+        /// the caller ORs this across the packets it builds.
+        ecn_marked: bool = false,
     };
 
     /// Assemble, seal, and record one packet at `level` into `out`. Returns
@@ -3952,6 +4044,10 @@ pub const Connection = struct {
         ctx: BuildContext,
     ) ?BuiltPacket {
         const space_idx = spaceIndex(space);
+        // Read once here rather than at the end: the path's state cannot
+        // change mid-build, and validation is a statement about how the packet
+        // actually left rather than about the state it finds later.
+        const ecn_marking = self.activeEcnMarking();
         // Ordinary traffic stays on the fixed tracker. Required PTO/padding
         // traffic pre-reserves recovery overflow before any frame is dequeued.
         const can_track_ordinary = self.recovery.canTrackPacket();
@@ -4054,7 +4150,6 @@ pub const Connection = struct {
             // content is built and recorded by `buildCandidatePacket`.
             .sent_path = self.paths.activePathRef(),
         };
-        const ecn_marked = self.activeEcnMarking();
         // `record` may pick up a dequeued NEW_CONNECTION_ID's reset token
         // below; `self.sent_records.append` (if reached) copies it into the
         // owned, tracked record, but this local stays around until every
@@ -4242,11 +4337,15 @@ pub const Connection = struct {
         if (record.has_new_connection_id) {
             if (self.local_cids) |*registry| registry.markAdvertised(record.carried_new_connection_id.sequence) catch {};
         }
-        // Recorded per *packet*, matching RFC 9000 §13.4.1's per-packet receive
-        // counters — and for pure ACKs too, which are not in flight and so
-        // were never published as a record. The peer counts them all the same,
-        // and a marked packet this endpoint failed to count would make the
-        // peer's honest report look like an over-claim.
+        // #256-E: only a packet that is in flight may be marked. A pure ACK is
+        // neither ack-eliciting nor tracked by recovery, and RFC 9000 §13.2
+        // notes it can go unacknowledged for a long time — so marking one
+        // would arm the testing window on a packet that may never produce
+        // feedback, and after a migration would hold the epoch barrier open
+        // with nothing able to resolve it. Recorded either way: dating a CE
+        // report needs the largest newly acknowledged packet's send time, and
+        // that packet need not have carried a mark.
+        const ecn_marked = ecn_marking and recordIsInFlight(record);
         if (space == .application) self.noteEcnPacketSent(pn, ecn_marked, now_us);
         self.metrics.packets_sent += 1;
         self.events.emit(.{ .packet_sent = .{
@@ -4255,7 +4354,7 @@ pub const Connection = struct {
             .size = total,
             .ack_eliciting = record.ack_eliciting,
         } });
-        return .{ .len = total, .ack_eliciting = record.ack_eliciting };
+        return .{ .len = total, .ack_eliciting = record.ack_eliciting, .ecn_marked = ecn_marked };
     }
 
     /// Whether a PATH_RESPONSE is queued for the active path specifically —
@@ -10425,13 +10524,13 @@ fn migrateServerPath(pair: *MigrationPair) !void {
     try testing.expect(pair.server.activePathKey().eql(rebind_candidate));
 }
 
-test "driver: a migration waits for the old path's marks before testing the new one" {
+test "driver: a loss declaration does not release the migration barrier (#256-E review)" {
     const allocator = testing.allocator;
     var pair = try MigrationPair.initWithEcn(allocator, .full, true);
     defer pair.deinit(allocator);
     try pair.pump();
 
-    // Put marked packets on the old path and leave them outstanding.
+    // Marked packets go out on the old path and are never acknowledged.
     const sid = try pair.server.openStream(.uni);
     _ = try pair.server.writeStream(sid, &[_]u8{0x66} ** 4096, false);
     _ = drainTransmits(pair.server, &pair.now_us);
@@ -10441,27 +10540,103 @@ test "driver: a migration waits for the old path's marks before testing the new 
 
     try migrateServerPath(pair);
 
-    // The epoch barrier. The peer's counters are cumulative per packet number
-    // space, so while the old path's marks can still arrive and move them, no
-    // growth is attributable to the new path — and starting to test here would
-    // let the old path's intact marks validate a route that is stripping every
-    // codepoint. So the new path stays unmarked until the old epoch drains.
+    // The epoch barrier: the peer's counters are cumulative per packet number
+    // space, so while the old path's marks can still be counted, no growth is
+    // attributable to the new path.
     var out: [2048]u8 = undefined;
     _ = pair.server.pollTransmitOnPath(&out, pair.now_us);
     try testing.expectEqual(quic_ecn.State.disabled, pair.server.pathEcn().state);
     try testing.expectEqual(quic_udp.Ecn.not_ect, pair.server.ecnCodepoint());
     try testing.expectEqual(@as(?u64, old_generation), pair.server.ecn_marking_generation);
 
-    // Once those packets are resolved — here by being declared lost, which is
-    // proof enough that they never reached the peer and so never moved a
-    // counter — the new path may start its own epoch.
+    // Declaring those packets lost must NOT release the barrier. QUIC loss is
+    // an inference, not proof of non-delivery: the packet may have arrived and
+    // incremented the peer's counter while the ACK carrying that increment was
+    // itself lost. Releasing here would let the new path start from a baseline
+    // missing that contribution, and then validate on it.
     _ = pair.server.recovery.tracker.dropSpace(.application);
     _ = pair.server.requeueUntrackedRecords(.application, pair.now_us);
+    try testing.expect(pair.server.ecn_outstanding_marked > 0);
+
+    _ = pair.server.pollTransmitOnPath(&out, pair.now_us);
+    try testing.expectEqual(quic_ecn.State.disabled, pair.server.pathEcn().state);
+    try testing.expectEqual(@as(?u64, old_generation), pair.server.ecn_marking_generation);
+}
+
+test "driver: an acknowledgement is what drains the migration barrier" {
+    const allocator = testing.allocator;
+    var pair = try MigrationPair.initWithEcn(allocator, .full, true);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const sid = try pair.server.openStream(.uni);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x69} ** 4096, false);
+    _ = drainTransmits(pair.server, &pair.now_us);
+    try testing.expect(pair.server.ecn_outstanding_marked > 0);
+
+    try migrateServerPath(pair);
+    var out: [2048]u8 = undefined;
+    _ = pair.server.pollTransmitOnPath(&out, pair.now_us);
+    try testing.expectEqual(quic_ecn.State.disabled, pair.server.pathEcn().state);
+
+    // Captured after the migration exchange, which advances the largest
+    // acknowledged number itself: an ACK built from earlier values would be
+    // non-advancing and correctly ignored for validation.
+    const space_idx = Connection.spaceIndex(.application);
+    const largest = pair.server.next_pn[space_idx] - 1;
+    const marked = markedAwaitingAck(pair.server, largest);
+    try testing.expect(marked > 0);
+    const counts_before = pair.server.ecn_last_counts;
+
+    // The old path's marks are acknowledged, with the counter growth to match.
+    // Now their contribution is settled and folded into `ecn_last_counts`, so
+    // the new path can take a baseline that already accounts for them.
+    var ranges = recovery.AckRangeSet{};
+    try ranges.insertRange(.{ .first = 0, .last = largest });
+    pair.server.processAck(.application, .{
+        .ranges = ranges,
+        .ack_delay_raw = 0,
+        .largest_acknowledged = largest,
+        .ecn = .{ .ect0 = counts_before.ect0 + marked, .ect1 = 0, .ce = counts_before.ce },
+    }, pair.now_us);
     try testing.expectEqual(@as(u32, 0), pair.server.ecn_outstanding_marked);
 
     _ = pair.server.pollTransmitOnPath(&out, pair.now_us);
     try testing.expectEqual(quic_ecn.State.testing, pair.server.pathEcn().state);
-    try testing.expect(pair.server.ecn_marking_generation.? != old_generation);
+    // And the new path starts from the counters that already include the old
+    // path's contribution, so none of it can be mistaken for its own evidence.
+    try testing.expectEqual(
+        counts_before.ect0 + marked,
+        pair.server.pathEcn().seen.ect0,
+    );
+}
+
+test "driver: a barrier that cannot drain fails ECN closed rather than releasing" {
+    const allocator = testing.allocator;
+    var pair = try MigrationPair.initWithEcn(allocator, .full, true);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const sid = try pair.server.openStream(.uni);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x6a} ** 4096, false);
+    _ = drainTransmits(pair.server, &pair.now_us);
+    try testing.expect(pair.server.ecn_outstanding_marked > 0);
+    try migrateServerPath(pair);
+
+    // The old marks are never acknowledged, so the barrier can never be shown
+    // to have drained. Waiting forever is not an option and releasing is not
+    // sound, so the bounded wait expires and ECN stops for the connection.
+    var out: [2048]u8 = undefined;
+    _ = pair.server.pollTransmitOnPath(&out, pair.now_us);
+    try testing.expect(pair.server.ecn_barrier_deadline_us != null);
+
+    pair.now_us = pair.server.ecn_barrier_deadline_us.?;
+    _ = pair.server.pollTransmitOnPath(&out, pair.now_us);
+    try testing.expect(!pair.server.cfg.ecn_enabled);
+    try testing.expectEqual(quic_ecn.State.disabled, pair.server.pathEcn().state);
+    try testing.expectEqual(quic_udp.Ecn.not_ect, pair.server.ecnCodepoint());
+    // Falling back is not failing: the connection carries on unchanged.
+    try testing.expectEqual(State.established, pair.server.state());
 }
 
 test "driver: old-path ECN growth cannot validate a new path that strips marks" {
@@ -10470,33 +10645,54 @@ test "driver: old-path ECN growth cannot validate a new path that strips marks" 
     defer pair.deinit(allocator);
     try pair.pump();
 
-    // Leave marked packets outstanding on the old path, then migrate. Every
-    // datagram the server sends from here on has its codepoint stripped.
+    // The reviewer's sequence: path O's marked packet is received by the peer
+    // and counted, path N then starts and strips its own marks, and O's growth
+    // arrives afterwards. N must not be validated by it.
     const sid = try pair.server.openStream(.uni);
     _ = try pair.server.writeStream(sid, &[_]u8{0x67} ** 4096, false);
     _ = drainTransmits(pair.server, &pair.now_us);
-    try migrateServerPath(pair);
-    pair.network_ecn = clearsEcn;
+    try testing.expect(pair.server.ecn_outstanding_marked > 0);
 
-    // The old path's marks now arrive and are reported honestly: real ECT(0)
-    // growth in the packet number space, caused entirely by path O. Without
-    // the barrier this growth would reach path N's controller, which — having
-    // sent marks of its own — would take it as proof that N carries ECN.
+    try migrateServerPath(pair);
     const space_idx = Connection.spaceIndex(.application);
-    const largest = pair.server.next_pn[space_idx] - 1;
-    const marked = markedAwaitingAck(pair.server, largest);
-    try testing.expect(marked > 0);
-    const validated_before = pair.server.metrics.ecn_validated;
-    var ranges = recovery.AckRangeSet{};
-    try ranges.insertRange(.{ .first = 0, .last = largest });
+    const old_largest = pair.server.next_pn[space_idx] - 1;
+    const old_marked = markedAwaitingAck(pair.server, old_largest);
+    try testing.expect(old_marked > 0);
+    const counts_before = pair.server.ecn_last_counts;
+
+    // O's marks are acknowledged and counted, draining the barrier: N's
+    // baseline therefore already contains every one of them.
+    var old_ranges = recovery.AckRangeSet{};
+    try old_ranges.insertRange(.{ .first = 0, .last = old_largest });
     pair.server.processAck(.application, .{
-        .ranges = ranges,
+        .ranges = old_ranges,
         .ack_delay_raw = 0,
-        .largest_acknowledged = largest,
-        .ecn = .{ .ect0 = marked, .ect1 = 0, .ce = 0 },
+        .largest_acknowledged = old_largest,
+        .ecn = .{ .ect0 = counts_before.ect0 + old_marked, .ect1 = 0, .ce = counts_before.ce },
     }, pair.now_us);
 
-    // N was never validated on O's evidence.
+    // N starts marking, and the network strips every one of its codepoints.
+    var out: [2048]u8 = undefined;
+    _ = pair.server.pollTransmitOnPath(&out, pair.now_us);
+    try testing.expectEqual(quic_ecn.State.testing, pair.server.pathEcn().state);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x68} ** 4096, false);
+    _ = drainTransmits(pair.server, &pair.now_us);
+    const new_largest = pair.server.next_pn[space_idx] - 1;
+    try testing.expect(markedAwaitingAck(pair.server, new_largest) > 0);
+
+    // N's marks come back acknowledged with no further growth at all — because
+    // they were stripped. The counters still show O's historical total, which
+    // is exactly the "old evidence" that must not validate N.
+    const validated_before = pair.server.metrics.ecn_validated;
+    var new_ranges = recovery.AckRangeSet{};
+    try new_ranges.insertRange(.{ .first = 0, .last = new_largest });
+    pair.server.processAck(.application, .{
+        .ranges = new_ranges,
+        .ack_delay_raw = 0,
+        .largest_acknowledged = new_largest,
+        .ecn = .{ .ect0 = counts_before.ect0 + old_marked, .ect1 = 0, .ce = counts_before.ce },
+    }, pair.now_us);
+
     try testing.expect(pair.server.pathEcn().state != .capable);
     try testing.expectEqual(validated_before, pair.server.metrics.ecn_validated);
     try testing.expectEqual(State.established, pair.server.state());
@@ -10509,27 +10705,30 @@ test "driver: an old-path CE report cannot congest the new path" {
     try pair.pump();
 
     const sid = try pair.server.openStream(.uni);
-    _ = try pair.server.writeStream(sid, &[_]u8{0x68} ** 4096, false);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x6b} ** 4096, false);
     _ = drainTransmits(pair.server, &pair.now_us);
-    try migrateServerPath(pair);
+    try testing.expect(pair.server.ecn_outstanding_marked > 0);
 
+    try migrateServerPath(pair);
     const space_idx = Connection.spaceIndex(.application);
     const largest = pair.server.next_pn[space_idx] - 1;
     const marked = markedAwaitingAck(pair.server, largest);
     try testing.expect(marked > 0);
+    const counts_before = pair.server.ecn_last_counts;
     pair.server.recovery.congestion.recovery_start_time_us = null;
 
     // Every one of the old path's marks met congestion. That is real
     // congestion — on the path this connection no longer uses. Halving the new
     // path's window on it would be responding to a bottleneck that is not on
-    // the route any more.
+    // the route any more, and while the barrier holds the new path is not even
+    // marking, so there is nothing of its own for the report to describe.
     var ranges = recovery.AckRangeSet{};
     try ranges.insertRange(.{ .first = 0, .last = largest });
     pair.server.processAck(.application, .{
         .ranges = ranges,
         .ack_delay_raw = 0,
         .largest_acknowledged = largest,
-        .ecn = .{ .ect0 = 0, .ect1 = 0, .ce = marked },
+        .ecn = .{ .ect0 = counts_before.ect0, .ect1 = 0, .ce = counts_before.ce + marked },
     }, pair.now_us);
 
     try testing.expectEqual(@as(u64, 0), pair.server.metrics.ecn_ce_received);
@@ -10537,6 +10736,122 @@ test "driver: an old-path CE report cannot congest the new path" {
         @as(?u64, null),
         pair.server.recovery.congestion.recovery_start_time_us,
     );
+}
+
+test "driver: evicting unresolved ECN evidence fails closed rather than forgetting it" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.initWithConfigs(allocator, ecn_enabled, ecn_enabled);
+    defer pair.deinit(allocator);
+    try pair.pump();
+    try settleEcn(pair);
+    try testing.expect(pair.server.cfg.ecn_enabled);
+
+    // Fill the history past capacity with marked packets that are never
+    // acknowledged. Discarding the oldest silently would lose the only record
+    // that a mark was owed — 129 marked packets with the evicted one stripped
+    // would then validate on 128 — and across a migration it would release the
+    // barrier on a packet whose contribution is unknown. Memory pressure is
+    // not evidence, so it fails ECN closed.
+    var packet_number = pair.server.next_pn[Connection.spaceIndex(.application)];
+    var pushed: usize = 0;
+    while (pushed < ecn_history_capacity + 1) : (pushed += 1) {
+        pair.server.noteEcnPacketSent(packet_number, true, pair.now_us);
+        packet_number += 1;
+    }
+
+    try testing.expect(!pair.server.cfg.ecn_enabled);
+    try testing.expectEqual(quic_ecn.State.disabled, pair.server.pathEcn().state);
+    try testing.expectEqual(
+        @as(?quic_ecn.FailureReason, .evidence_lost),
+        pair.server.pathEcn().failure,
+    );
+    try testing.expectEqual(quic_udp.Ecn.not_ect, pair.server.ecnCodepoint());
+    // And nothing re-enables it: the evidence is gone for good.
+    var out: [max_datagram_size_ceiling]u8 = undefined;
+    _ = pair.server.pollTransmitOnPath(&out, pair.now_us);
+    try testing.expectEqual(quic_ecn.State.disabled, pair.server.pathEcn().state);
+    try testing.expectEqual(State.established, pair.server.state());
+}
+
+test "driver: an ACK-only datagram is never marked (#256-E review)" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.initWithConfigs(allocator, ecn_enabled, ecn_enabled);
+    defer pair.deinit(allocator);
+    try pair.pump();
+    try settleEcn(pair);
+
+    // Make the server owe an ACK and nothing else, so its next datagram is a
+    // pure ACK: not ack-eliciting, not tracked by recovery, and — per RFC 9000
+    // §13.2 — able to go unacknowledged for a long time. Marking one would arm
+    // the testing window on a packet that may never produce feedback, and
+    // after a migration would hold the epoch barrier open with nothing able to
+    // resolve it.
+    const sid = try pair.client.openStream(.uni);
+    _ = try pair.client.writeStream(sid, "elicit an ack", false);
+    var buf: [max_datagram_size_ceiling]u8 = undefined;
+    const from_client = pair.client.pollTransmitOnPath(&buf, pair.now_us) orelse
+        return error.TestExpectedEqual;
+    const ingress = quic_path.PathKey{
+        .local = from_client.path.remote,
+        .remote = from_client.path.local,
+    };
+    try pair.server.ingestOnPathWithEcn(
+        from_client.bytes,
+        ingress,
+        from_client.ecn,
+        TestPair.test_challenge_entropy,
+        pair.now_us,
+    );
+
+    const marked_before = pair.server.metrics.ecn_marked_sent;
+    const outstanding_before = pair.server.ecn_outstanding_marked;
+    pair.now_us += local_max_ack_delay_us + 1;
+    var out: [max_datagram_size_ceiling]u8 = undefined;
+    const ack_only = pair.server.pollTransmitOnPath(&out, pair.now_us) orelse
+        return error.TestExpectedEqual;
+
+    // A pure ACK is short and carries nothing in flight.
+    try testing.expect(ack_only.bytes.len < base_datagram_size);
+    try testing.expectEqual(quic_udp.Ecn.not_ect, ack_only.ecn);
+    try testing.expectEqual(marked_before, pair.server.metrics.ecn_marked_sent);
+    try testing.expectEqual(outstanding_before, pair.server.ecn_outstanding_marked);
+    // The path is still marking — this is about which packets qualify, not
+    // about ECN being off.
+    try testing.expect(pair.server.pathEcn().marking());
+}
+
+test "driver: a socket that cannot mark disables ECN without blaming the path" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.initWithConfigs(allocator, ecn_enabled, ecn_enabled);
+    defer pair.deinit(allocator);
+    try pair.pump();
+    try settleEcn(pair);
+    try testing.expectEqual(quic_ecn.State.capable, pair.server.pathEcn().state);
+
+    // The listener has discovered the kernel will not set the codepoint, so
+    // every packet this connection believed it marked actually left Not-ECT.
+    // That is not the path's fault and must not be recorded as such, and the
+    // transport must stop counting marks the socket never sent.
+    pair.server.disableEcnUnsupported();
+
+    try testing.expect(!pair.server.cfg.ecn_enabled);
+    try testing.expectEqual(quic_ecn.State.disabled, pair.server.pathEcn().state);
+    try testing.expectEqual(
+        @as(?quic_ecn.FailureReason, .platform_unsupported),
+        pair.server.pathEcn().failure,
+    );
+    try testing.expectEqual(quic_udp.Ecn.not_ect, pair.server.ecnCodepoint());
+
+    const marked_before = pair.server.metrics.ecn_marked_sent;
+    const sid = try pair.server.openStream(.uni);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x71} ** 2048, false);
+    var out: [max_datagram_size_ceiling]u8 = undefined;
+    while (pair.server.pollTransmitOnPath(&out, pair.now_us)) |t| {
+        try testing.expectEqual(quic_udp.Ecn.not_ect, t.ecn);
+        pair.now_us += 500;
+    }
+    try testing.expectEqual(marked_before, pair.server.metrics.ecn_marked_sent);
+    try testing.expectEqual(State.established, pair.server.state());
 }
 
 test "driver: an idle connection does not burn its ECN testing window" {

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -2468,11 +2468,6 @@ pub const Connection = struct {
             .{ .ect0 = counts.ect0, .ect1 = counts.ect1, .ce = counts.ce }
         else
             null;
-        // What the peer has reported, kept at connection scope because that is
-        // the scope it has. This is the baseline a path takes when it starts
-        // marking, so it has to keep advancing even while no path is
-        // validating — during a migration's drain, most of all.
-        if (feedback) |counts| self.ecn_last_counts = counts;
 
         // Only the active path. Marking is only ever started on the active
         // path (`syncPathEcn`), so a path that is not active either never
@@ -2489,15 +2484,60 @@ pub const Connection = struct {
         const active = self.paths.activePathRef();
         const carried = self.ecn_carried_marked;
         self.ecn_carried_marked = 0;
-        self.applyEcnFeedback(
+        const rejected = self.applyEcnFeedback(
             active,
             tally.countFor(active.generation) +| carried,
             feedback,
             history_largest_sent_us orelse record_largest_sent_us,
             now_us,
         );
+        if (feedback) |counts| self.adoptEcnCounts(counts, rejected);
     }
 
+    /// Advance the connection's trusted view of the peer's counters — but only
+    /// once this report has survived validation (#256-E review).
+    ///
+    /// These counters are not scratch state: they are the baseline the *next*
+    /// path takes when it starts marking, which is to say the number that path
+    /// is then measured against. Committing a report that validation just
+    /// rejected would hand a future path a starting point the peer never
+    /// justified, and the arithmetic does the rest — a report that regressed to
+    /// 8 becomes the baseline, the real cumulative 10 arrives later, and a path
+    /// that preserved not one codepoint is credited with two marks of growth.
+    ///
+    /// So a report is adopted only if the path did not reject it *and* it is
+    /// monotonic against what is already trusted. The second check stands alone
+    /// when no path is validating — during a migration's drain, most of all,
+    /// which is exactly when the baseline matters most and when no controller
+    /// is watching. Anything else fails ECN closed: there is no way to
+    /// re-derive a trustworthy synchronisation point from a peer whose
+    /// cumulative counters have stopped making sense.
+    fn adoptEcnCounts(
+        self: *Connection,
+        counts: quic_ecn.Feedback,
+        rejected: ?quic_ecn.FailureReason,
+    ) void {
+        if (rejected) |reason| {
+            if (reason.impugnsCounters()) {
+                self.failEcnClosed(.evidence_lost);
+                return;
+            }
+            // A stripped or rewritten codepoint condemns the route, not the
+            // bookkeeping: the counters remain an honest record of what
+            // arrived, and the next path deserves an accurate baseline.
+        }
+        if (counts.ect0 < self.ecn_last_counts.ect0 or
+            counts.ect1 < self.ecn_last_counts.ect1 or
+            counts.ce < self.ecn_last_counts.ce)
+        {
+            self.failEcnClosed(.evidence_lost);
+            return;
+        }
+        self.ecn_last_counts = counts;
+    }
+
+    /// Returns the reason this path rejected the report, or null when it did
+    /// not — including when there was no path validating to reject it.
     fn applyEcnFeedback(
         self: *Connection,
         path: quic_path.PathRef,
@@ -2505,16 +2545,16 @@ pub const Connection = struct {
         feedback: ?quic_ecn.Feedback,
         largest_acked_sent_us: ?u64,
         now_us: u64,
-    ) void {
-        const controller = self.paths.ecnFor(path) orelse return;
-        if (controller.state == .disabled) return;
+    ) ?quic_ecn.FailureReason {
+        const controller = self.paths.ecnFor(path) orelse return null;
+        if (controller.state == .disabled) return null;
         const outcome = controller.onAck(newly_acked_marked, feedback);
         if (outcome.failed) |reason| {
             self.publishEcnState(path.key, .disabled, reason);
-            return;
+            return reason;
         }
         if (outcome.validated) self.publishEcnState(path.key, .capable, null);
-        if (outcome.ce_increase == 0) return;
+        if (outcome.ce_increase == 0) return null;
         self.metrics.ecn_ce_received +|= outcome.ce_increase;
         // RFC 9002 §7.1: a CE report on a *validated* path is congestion, and
         // it is congestion about packets that arrived — so the window halves
@@ -2524,6 +2564,7 @@ pub const Connection = struct {
         if (largest_acked_sent_us) |sent_us| {
             self.recovery.congestion.onCongestionEvent(sent_us, now_us);
         }
+        return null;
     }
 
     fn onRecordAcked(self: *Connection, record: *const SentRecord, now_us: u64) void {
@@ -10695,6 +10736,99 @@ test "driver: old-path ECN growth cannot validate a new path that strips marks" 
 
     try testing.expect(pair.server.pathEcn().state != .capable);
     try testing.expectEqual(validated_before, pair.server.metrics.ecn_validated);
+    try testing.expectEqual(State.established, pair.server.state());
+}
+
+test "driver: a rejected report never becomes a future path's baseline (#256-E review)" {
+    const allocator = testing.allocator;
+    var pair = try MigrationPair.initWithEcn(allocator, .full, true);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const sid = try pair.server.openStream(.uni);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x6c} ** 4096, false);
+    _ = drainTransmits(pair.server, &pair.now_us);
+    const space_idx = Connection.spaceIndex(.application);
+
+    // Establish a trusted cumulative count on the old path.
+    const first_largest = pair.server.next_pn[space_idx] - 1;
+    const first_marked = markedAwaitingAck(pair.server, first_largest);
+    try testing.expect(first_marked > 0);
+    const trusted_ect0 = pair.server.ecn_last_counts.ect0 + first_marked;
+    var first = recovery.AckRangeSet{};
+    try first.insertRange(.{ .first = 0, .last = first_largest });
+    pair.server.processAck(.application, .{
+        .ranges = first,
+        .ack_delay_raw = 0,
+        .largest_acknowledged = first_largest,
+        .ecn = .{ .ect0 = trusted_ect0, .ect1 = 0, .ce = 0 },
+    }, pair.now_us);
+    try testing.expectEqual(trusted_ect0, pair.server.ecn_last_counts.ect0);
+
+    // Now a report that goes backwards. The path rejects it as a regression —
+    // and the connection must not quietly keep it as the trusted baseline
+    // either, or a path that starts marking later is measured from a number
+    // the peer never justified and can be credited with growth it did not
+    // earn. Counters that regress are not describing this connection, so
+    // nothing derived from them is usable again.
+    _ = try pair.server.writeStream(sid, &[_]u8{0x6d} ** 2048, false);
+    _ = drainTransmits(pair.server, &pair.now_us);
+    const second_largest = pair.server.next_pn[space_idx] - 1;
+    var second = recovery.AckRangeSet{};
+    try second.insertRange(.{ .first = 0, .last = second_largest });
+    pair.server.processAck(.application, .{
+        .ranges = second,
+        .ack_delay_raw = 0,
+        .largest_acknowledged = second_largest,
+        .ecn = .{ .ect0 = trusted_ect0 - 2, .ect1 = 0, .ce = 0 },
+    }, pair.now_us);
+
+    try testing.expect(pair.server.ecn_last_counts.ect0 != trusted_ect0 - 2);
+    try testing.expect(!pair.server.cfg.ecn_enabled);
+
+    // A migration cannot resurrect ECN from that rejected state: no path
+    // starts marking, so the real cumulative count returning later has nothing
+    // to validate and nothing to congest.
+    try migrateServerPath(pair);
+    var out: [2048]u8 = undefined;
+    _ = pair.server.pollTransmitOnPath(&out, pair.now_us);
+    try testing.expectEqual(quic_ecn.State.disabled, pair.server.pathEcn().state);
+    try testing.expectEqual(quic_udp.Ecn.not_ect, pair.server.ecnCodepoint());
+
+    const validated_before = pair.server.metrics.ecn_validated;
+    const third_largest = pair.server.next_pn[space_idx] - 1;
+    var third = recovery.AckRangeSet{};
+    try third.insertRange(.{ .first = 0, .last = third_largest });
+    pair.server.processAck(.application, .{
+        .ranges = third,
+        .ack_delay_raw = 0,
+        .largest_acknowledged = third_largest,
+        .ecn = .{ .ect0 = trusted_ect0, .ect1 = 0, .ce = 0 },
+    }, pair.now_us);
+
+    try testing.expect(pair.server.pathEcn().state != .capable);
+    try testing.expectEqual(validated_before, pair.server.metrics.ecn_validated);
+    try testing.expectEqual(State.established, pair.server.state());
+}
+
+test "driver: a stripped path still leaves the counters usable for the next one" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.initWithConfigs(allocator, ecn_enabled, ecn_enabled);
+    defer pair.deinit(allocator);
+    pair.network_ecn = clearsEcn;
+    try pair.pump();
+    try settleEcn(pair);
+
+    // The path failed because the network cleared its codepoints. That
+    // condemns the route, not the peer's bookkeeping — so unlike a regression
+    // it must not poison the connection's trusted counters, and the next path
+    // is still entitled to an accurate baseline and its own chance.
+    try testing.expectEqual(quic_ecn.State.disabled, pair.server.pathEcn().state);
+    try testing.expectEqual(
+        @as(?quic_ecn.FailureReason, .missing_counts),
+        pair.server.pathEcn().failure,
+    );
+    try testing.expect(pair.server.cfg.ecn_enabled);
     try testing.expectEqual(State.established, pair.server.state());
 }
 

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -36,6 +36,7 @@ const quic_stream = @import("stream.zig");
 const quic_cid = @import("cid.zig");
 const quic_path = @import("path.zig");
 const quic_pmtu = @import("pmtu.zig");
+const quic_ecn = @import("ecn.zig");
 const quic_udp = @import("udp.zig");
 const test_quic_crypto = @import("test_quic_crypto");
 
@@ -155,6 +156,11 @@ pub const Event = union(enum) {
     /// `size` is the effective cap after the change, so it already reflects
     /// the peer's advertised capacity and this endpoint's own ceiling.
     pmtu_updated: PmtuUpdatedEvent,
+    /// #256-E: ECN marking started, was validated, or was turned off for a
+    /// path. Turning off is the common case in the field — a great deal of
+    /// deployed gear clears or rewrites the codepoint — and is never an
+    /// error, so `reason` is what makes it diagnosable rather than invisible.
+    ecn_state_changed: EcnStateChangedEvent,
     /// #523: a typed outcome for every `.zero_rtt` packet this connection
     /// processes, distinguishing "policy/keys unavailable" from a genuine
     /// AEAD authentication failure and from an authenticated duplicate —
@@ -210,6 +216,15 @@ pub const PmtuUpdatedEvent = struct {
     reason: quic_pmtu.SizeChange,
 };
 
+/// See `Event.ecn_state_changed`.
+pub const EcnStateChangedEvent = struct {
+    path: quic_path.PathKey,
+    state: quic_ecn.State,
+    /// Non-null only when `state` is `.disabled` and validation is what turned
+    /// it off; null when marking has simply started or been validated.
+    reason: ?quic_ecn.FailureReason = null,
+};
+
 pub const PathMigrationBlockedEvent = struct {
     path: quic_path.PathKey,
     change: quic_path.AddressChange,
@@ -224,6 +239,13 @@ pub const PathMigrationBlockedEvent = struct {
 pub const Transmit = struct {
     bytes: []const u8,
     path: quic_path.PathKey,
+    /// The IP ECN codepoint this datagram must go out with (#256-E). `.not_ect`
+    /// unless the path is marking, and never `.unavailable`: this is an
+    /// instruction to the send path, not a report about it. A caller whose
+    /// socket cannot set the field simply ignores it — the transport only ever
+    /// enables marking when told the platform supports it, so ignoring it
+    /// silently is a configuration mistake rather than a normal state.
+    ecn: quic_udp.Ecn = .not_ect,
 };
 
 pub const StreamSchedulingHint = struct {
@@ -264,6 +286,17 @@ pub const Metrics = struct {
     /// stopped traversing it.
     pmtu_probes_sent: u64 = 0,
     pmtu_black_holes: u64 = 0,
+    /// ECN (#256-E). `ecn_marked_sent` counts datagrams that went out carrying
+    /// ECT(0); `ecn_ce_received` counts CE reports that were *believed* — i.e.
+    /// arrived on a validated path and therefore reached congestion control —
+    /// so the two together say whether marking is doing anything. Validation
+    /// outcomes are counted separately from failures: a path that never
+    /// validates and a path that validated and later broke are different
+    /// operational stories.
+    ecn_marked_sent: u64 = 0,
+    ecn_validated: u64 = 0,
+    ecn_disabled: u64 = 0,
+    ecn_ce_received: u64 = 0,
 };
 
 pub const CloseInfo = struct {
@@ -772,6 +805,12 @@ const SentRecord = struct {
     /// and to keep the probe out of every path that reasons about *content*,
     /// like the PTO's search for something worth resending.
     carried_pmtu_probe: ?usize = null,
+    /// Whether the datagram this packet went out in carried ECT(0) (#256-E).
+    /// RFC 9000 §13.4.2.1 validation is a statement about *these* packets:
+    /// when the peer acknowledges them, its reported counters must have grown
+    /// to match. Recorded per packet rather than derived from the path's
+    /// current state, because that state can have been turned off in between.
+    ecn_marked: bool = false,
 
     const StreamRange = struct {
         id: StreamId,
@@ -864,6 +903,44 @@ fn wipePendingNewConnectionIdsOrderedRemoveResidue(frames: *std.ArrayList(quic_c
     crypto_secrets.secureZero(std.mem.asBytes(&frames.allocatedSlice()[frames.items.len]));
 }
 
+/// Newly acknowledged ECT-marked packets from one ACK, grouped by the path
+/// incarnation they were sent on (#256-E).
+///
+/// Bounded by `quic_path.max_paths` because that is how many path incarnations
+/// can still be reached by `PathManager.ecnFor`; feedback for an older one has
+/// nowhere to go and is dropped, which is the same rule the PMTU controller
+/// applies for the same reason. A fixed array rather than a map keeps this
+/// allocation-free on the ACK path.
+const EcnAckTally = struct {
+    const Entry = struct { path: quic_path.PathRef, count: u64 };
+
+    entries: [quic_path.max_paths]Entry = undefined,
+    len: usize = 0,
+
+    fn add(self: *EcnAckTally, path: quic_path.PathRef) void {
+        for (self.entries[0..self.len]) |*entry| {
+            if (entry.path.eql(path)) {
+                entry.count +|= 1;
+                return;
+            }
+        }
+        // Overflow is unreachable in practice — a record's path is always one
+        // of the tracked slots — and dropping is the safe direction anyway:
+        // under-counting acknowledged marks can only make validation more
+        // lenient, never make it fail on traffic that was fine.
+        if (self.len == self.entries.len) return;
+        self.entries[self.len] = .{ .path = path, .count = 1 };
+        self.len += 1;
+    }
+
+    fn countFor(self: EcnAckTally, path: quic_path.PathRef) u64 {
+        for (self.entries[0..self.len]) |entry| {
+            if (entry.path.eql(path)) return entry.count;
+        }
+        return 0;
+    }
+};
+
 /// A candidate path (RFC 9000 §9.3/§9.5) we are validating: the
 /// `PathManager`-issued PATH_CHALLENGE payload and whether the packet
 /// carrying it still needs to go out (initially, and again after loss —
@@ -927,6 +1004,16 @@ pub const Connection = struct {
     next_pn: [3]u64 = .{ 0, 0, 0 },
     largest_recv_pn: [3]?u64 = .{ null, null, null },
     largest_peer_acked: [3]?u64 = .{ null, null, null },
+    /// Received ECN codepoints per packet number space (#256-E, RFC 9000
+    /// §13.4.1). Per space rather than per path because that is the scope an
+    /// ACK frame reports in, and they are dropped with the space's keys.
+    recv_ecn: [3]quic_ecn.Counts = .{ .{}, .{}, .{} },
+    /// The ECN codepoint of the datagram currently being ingested, for the
+    /// packets inside it. Set by `ingestOnPathWithEcn` for the duration of one
+    /// datagram; `.unavailable` whenever the receive path could not report one,
+    /// which is not the same as an unmarked datagram and must not be counted
+    /// as one.
+    ingress_ecn: quic_udp.Ecn = .unavailable,
     /// Whether an ACK must be assembled for the space, and when the obligation
     /// arose (for the encoded ack_delay and the delayed-ack timer).
     ack_needed: [3]bool = .{ false, false, false },
@@ -1244,6 +1331,79 @@ pub const Connection = struct {
         }
     }
 
+    /// The active path's ECN state, for status/benchmark reporting (#256-E).
+    pub fn pathEcn(self: *const Connection) quic_ecn.Controller {
+        return self.paths.activePath().ecn;
+    }
+
+    /// This endpoint's received ECN counters for the application space — what
+    /// its ACK_ECN frames report. Exposed for benchmark and status output.
+    pub fn receivedEcnCounts(self: *const Connection) quic_ecn.Counts {
+        return self.recv_ecn[spaceIndex(.application)];
+    }
+
+    /// The codepoint the next datagram on the active path goes out with.
+    pub fn ecnCodepoint(self: *const Connection) quic_udp.Ecn {
+        return self.paths.activePath().ecn.sendCodepoint();
+    }
+
+    /// Start ECN marking on the active path once it can mean anything (#256-E).
+    ///
+    /// Gated on handshake confirmation for the same two reasons DPLPMTUD is:
+    /// before then the peer's ACK behaviour is still settling and the flights
+    /// have their own sizing and retransmission rules, and — specific to ECN —
+    /// validation compares reported counters against packets *this* endpoint
+    /// marked, which is only a clean comparison once one packet number space
+    /// is doing all the work.
+    fn syncPathEcn(self: *Connection, now_us: u64) void {
+        if (!self.cfg.ecn_enabled) return;
+        if (!self.handshake_confirmed or self.state_ != .established) return;
+        const controller = self.paths.activeEcn();
+        // `enable` is idempotent and refuses a path that already failed, but
+        // the event must fire exactly once per real transition.
+        if (controller.state != .disabled or controller.failure != null) return;
+        controller.enable(now_us, quic_ecn.testing_pto_multiplier *| self.ptoDurationNow());
+        self.events.emit(.{ .ecn_state_changed = .{
+            .path = self.paths.activePath().key,
+            .state = controller.state,
+        } });
+    }
+
+    /// Whether the packet about to be built goes out marked. Read once per
+    /// packet and stamped onto its record: the path's state can change before
+    /// the acknowledgement arrives, and validation is a statement about how
+    /// the packet actually left, not about the state it finds later.
+    fn activeEcnMarking(self: *Connection) bool {
+        return self.paths.activeEcn().marking();
+    }
+
+    /// One packet went out marked on the active path.
+    fn noteEcnMarkedSent(self: *Connection) void {
+        self.paths.activeEcn().onMarkedSent();
+        self.metrics.ecn_marked_sent += 1;
+    }
+
+    /// Publish an ECN state transition for `path`: the operator counter and
+    /// the event, in one place so no transition can become observable through
+    /// only one of them.
+    fn publishEcnState(
+        self: *Connection,
+        path: quic_path.PathKey,
+        next_state: quic_ecn.State,
+        reason: ?quic_ecn.FailureReason,
+    ) void {
+        switch (next_state) {
+            .capable => self.metrics.ecn_validated += 1,
+            .disabled => self.metrics.ecn_disabled += 1,
+            .testing => {},
+        }
+        self.events.emit(.{ .ecn_state_changed = .{
+            .path = path,
+            .state = next_state,
+            .reason = reason,
+        } });
+    }
+
     /// Feed one piece of black-hole evidence to the active path's controller
     /// and report the fallback if that tipped it. Both signals funnel through
     /// here so "the send size just dropped" is observed in exactly one place.
@@ -1397,6 +1557,13 @@ pub const Connection = struct {
     /// budget, or move the active path. `challenge_entropy` supplies fresh
     /// unpredictable PATH_CHALLENGE payload for use if this datagram starts a
     /// new candidate-path validation; unused otherwise.
+    /// Feed one received datagram whose IP ECN codepoint could not be observed.
+    ///
+    /// Not a deprecated form of `ingestOnPathWithEcn`: a receive path without
+    /// ancillary metadata genuinely has nothing to report, and `.unavailable`
+    /// says exactly that. It is distinct from `.not_ect` — an unmarked
+    /// datagram — because reporting "no marks arrived" when the truth is "this
+    /// socket cannot see marks" would make a peer's marking look broken.
     pub fn ingestOnPath(
         self: *Connection,
         datagram: []const u8,
@@ -1404,6 +1571,25 @@ pub const Connection = struct {
         challenge_entropy: [quic_path.path_challenge_len]u8,
         now_us: u64,
     ) IngestError!void {
+        return self.ingestOnPathWithEcn(datagram, ingress_path, .unavailable, challenge_entropy, now_us);
+    }
+
+    /// Feed one received datagram along with the IP ECN codepoint the socket
+    /// layer read off it (#256-E). The codepoint is counted per packet number
+    /// space, and only for packets that authenticate — see `quic_ecn.Counts`.
+    pub fn ingestOnPathWithEcn(
+        self: *Connection,
+        datagram: []const u8,
+        ingress_path: quic_path.PathKey,
+        ingress_ecn: quic_udp.Ecn,
+        challenge_entropy: [quic_path.path_challenge_len]u8,
+        now_us: u64,
+    ) IngestError!void {
+        // Scoped to this datagram: every packet coalesced inside it shares the
+        // one IP header that carried the codepoint, and nothing outside this
+        // call may read a stale value.
+        self.ingress_ecn = ingress_ecn;
+        defer self.ingress_ecn = .unavailable;
         if (self.state_ == .closed or self.state_ == .draining) return;
         self.metrics.datagrams_received += 1;
 
@@ -1590,6 +1776,12 @@ pub const Connection = struct {
         const already_received = self.recovery.wasReceived(space, pn);
         self.emitZeroRttOutcome(level, if (already_received) .duplicate else .accepted, bytes.len);
         if (!already_received) {
+            // RFC 9000 §13.4.1 counts *packets*, and only ones this endpoint
+            // processed: an unauthenticated or replayed packet must not move a
+            // counter the peer then treats as congestion feedback. Recorded
+            // beside the ACK-range insertion because the two travel together —
+            // the counts describe exactly the packets that ACK acknowledges.
+            self.recv_ecn[space_idx].record(self.ingress_ecn);
             self.recovery.onPacketReceived(space, pn) catch {
                 // Pathological ACK-range fragmentation; close rather than lose ACK state.
                 self.startClose(.{ .error_code = error_internal, .is_application = false, .local = true }, "ack range overflow", now_us);
@@ -1927,6 +2119,18 @@ pub const Connection = struct {
             self.largest_peer_acked[space_idx] = ack.largest_acknowledged;
         }
 
+        // #256-E: how many *newly* acknowledged packets went out ECT-marked,
+        // per path incarnation. Grouped by path rather than totalled because
+        // ECN validation is per path (RFC 9000 §13.4.2), and recovery
+        // deliberately keeps old-path packets in flight across a migration —
+        // so one ACK can acknowledge marked packets belonging to more than one
+        // controller, and crediting them all to whichever path is active now
+        // would validate a route on the strength of another one's marks.
+        var ecn_acks = EcnAckTally{};
+        // RFC 9002 §B.5 processes an ECN-CE report as a congestion event dated
+        // to the largest acked packet's send time.
+        var largest_acked_sent_us: ?u64 = null;
+
         // Ack every tracked packet covered by the ranges. The RTT sample only
         // comes from the largest acked packet (RFC 9002 §5.1).
         var index: usize = 0;
@@ -1938,8 +2142,10 @@ pub const Connection = struct {
             }
             if (self.recovery.tracker.onAcked(space, record.packet_number, now_us)) |acked| {
                 self.recovery.congestion.onPacketAcked(acked.packet);
+                if (record.ecn_marked) ecn_acks.add(record.sent_path);
                 if (record.packet_number == ack.largest_acknowledged) {
                     if (acked.rtt_sample_us) |sample| self.recovery.rtt.update(sample, ack_delay_us);
+                    largest_acked_sent_us = acked.packet.time_sent_us;
                 }
                 // Delivery of an ordinary datagram is DPLPMTUD's evidence that
                 // the path still carries the size it was sent at (#256-B) —
@@ -1966,7 +2172,77 @@ pub const Connection = struct {
         // A validated ACK ends the current PTO backoff episode.
         self.pto_count = 0;
 
+        self.processAckEcn(space, ack, ecn_acks, largest_acked_sent_us, now_us);
         self.detectAndRequeueLost(space, now_us);
+    }
+
+    /// Apply one ACK's ECN feedback (#256-E, RFC 9000 §13.4.2.1).
+    ///
+    /// Application space only. Marking never starts before the handshake is
+    /// confirmed, so an Initial/Handshake ACK can carry no feedback about
+    /// marked traffic — while its counters describe a *different* packet
+    /// number space, and adopting them as this path's baseline would compare
+    /// growth in one space against marks placed in another.
+    fn processAckEcn(
+        self: *Connection,
+        space: PacketNumberSpace,
+        ack: frame.Ack,
+        tally: EcnAckTally,
+        largest_acked_sent_us: ?u64,
+        now_us: u64,
+    ) void {
+        if (space != .application) return;
+        const feedback: ?quic_ecn.Feedback = if (ack.ecn) |counts|
+            .{ .ect0 = counts.ect0, .ect1 = counts.ect1, .ce = counts.ce }
+        else
+            null;
+
+        // Only the active path. Marking is only ever started on the active
+        // path (`syncPathEcn`), so a path that is not active is either one
+        // that never marked or one that was demoted and has stopped — and its
+        // validation state is inert either way. Feeding it these counters
+        // would be worse than pointless: they are *space*-scoped, so both
+        // controllers would compute their own deltas from the same reported CE
+        // marks and each report them as congestion, halving the window on one
+        // signal counted twice.
+        //
+        // The tally still separates by path so this uses the active path's own
+        // acknowledgements. That accounting is exact except across a
+        // migration, where marked packets sent by the previous path can be
+        // acknowledged after the new one adopted its baseline: the peer counts
+        // them, this path did not send them, and the surplus can read as an
+        // over-claim. That resolves to ECN off on the new path, which is the
+        // safe direction and is re-tested on the next path.
+        const active = self.paths.activePathRef();
+        self.applyEcnFeedback(active, tally.countFor(active), feedback, largest_acked_sent_us, now_us);
+    }
+
+    fn applyEcnFeedback(
+        self: *Connection,
+        path: quic_path.PathRef,
+        newly_acked_marked: u64,
+        feedback: ?quic_ecn.Feedback,
+        largest_acked_sent_us: ?u64,
+        now_us: u64,
+    ) void {
+        const controller = self.paths.ecnFor(path) orelse return;
+        if (controller.state == .disabled) return;
+        const outcome = controller.onAck(newly_acked_marked, feedback, now_us);
+        if (outcome.failed) |reason| {
+            self.publishEcnState(path.key, .disabled, reason);
+            return;
+        }
+        if (outcome.validated) self.publishEcnState(path.key, .capable, null);
+        if (outcome.ce_increase == 0) return;
+        self.metrics.ecn_ce_received +|= outcome.ce_increase;
+        // RFC 9002 §7.1: a CE report on a *validated* path is congestion, and
+        // it is congestion about packets that arrived — so the window halves
+        // without the in-flight ledger being touched a second time. The
+        // one-recovery-period rule inside `onCongestionEvent` is what keeps a
+        // CE report and a loss for the same round trip from halving twice.
+        if (largest_acked_sent_us) |sent_us| {
+            self.recovery.congestion.onCongestionEvent(sent_us, now_us);
+        }
     }
 
     fn onRecordAcked(self: *Connection, record: *const SentRecord, now_us: u64) void {
@@ -2622,6 +2898,10 @@ pub const Connection = struct {
         self.ack_needed[spaceIndex(space)] = false;
         self.last_ack_eliciting_sent_us[spaceIndex(space)] = null;
         self.probes_pending[spaceIndex(space)] = 0;
+        // RFC 9000 §13.4.1: ECN counts belong to the packet number space, so
+        // they go when it does. No ACK for this space can ever be sent again,
+        // and the counters would otherwise be reported by nothing.
+        self.recv_ecn[spaceIndex(space)].reset();
         self.events.emit(.{ .keys_discarded = space });
     }
 
@@ -2712,6 +2992,11 @@ pub const Connection = struct {
         // it when it fires, so this cannot return a deadline already in the
         // past and spin the caller.
         if (self.paths.activePath().plpmtu.deadlineUs()) |raise| deadline = minOpt(deadline, raise);
+        // #256-E: the ECN testing window. Without it a path whose marked
+        // packets vanish entirely — no ACK, no counters, nothing — would keep
+        // marking traffic into a route that drops it for as long as the
+        // connection lived. `Controller.onTimeout` disarms it when it fires.
+        if (self.paths.activePath().ecn.deadlineUs()) |testing_end| deadline = minOpt(deadline, testing_end);
         return deadline;
     }
 
@@ -2782,6 +3067,11 @@ pub const Connection = struct {
         // Let a black-hole fallback that has held long enough re-open the
         // search (#256-B, RFC 8899 PMTU_RAISE_TIMER).
         self.paths.activePlpmtu().onTimeout(now_us);
+        // Close the ECN testing window if the peer never confirmed a mark
+        // survived (#256-E). Falls back to ordinary non-ECN operation.
+        if (self.paths.activeEcn().onTimeout(now_us)) |reason| {
+            self.publishEcnState(self.paths.activePath().key, .disabled, reason);
+        }
         // Time-threshold loss detection.
         for ([_]PacketNumberSpace{ .initial, .handshake, .application }) |space| {
             self.detectAndRequeueLost(space, now_us);
@@ -3068,6 +3358,7 @@ pub const Connection = struct {
         // reads for the current path size, so recovery below sees the same
         // value the builder is about to use.
         self.syncPathPmtu(now_us);
+        self.syncPathEcn(now_us);
         self.recovery.congestion.setMaxDatagramSize(self.effectiveMaxDatagramSize());
 
         if (self.state_ == .closing) {
@@ -3138,7 +3429,14 @@ pub const Connection = struct {
         self.paths.recordSentOnPath(active_key, datagram_len);
         self.metrics.datagrams_sent += 1;
         if (sent_ack_eliciting) self.armIdle(now_us);
-        return .{ .bytes = out[0..datagram_len], .path = active_key };
+        // Every packet coalesced above shares this datagram's single IP
+        // header, so the codepoint is a property of the datagram — read once,
+        // here, from the same state each `buildPacket` stamped onto its record.
+        return .{
+            .bytes = out[0..datagram_len],
+            .path = active_key,
+            .ecn = self.paths.activeEcn().sendCodepoint(),
+        };
     }
 
     /// Whether `path` still corresponds to a live, outstanding validation
@@ -3309,6 +3607,10 @@ pub const Connection = struct {
             .size = total,
             .ack_eliciting = record.ack_eliciting,
         } });
+        // Unmarked (#256-E). ECN is validated per path (RFC 9000 §13.4.2) and
+        // a candidate path has no validation in progress — marking traffic on
+        // it would produce counter growth the active path's controller would
+        // then have to explain.
         return .{ .bytes = out[0..total], .path = path };
     }
 
@@ -3388,6 +3690,10 @@ pub const Connection = struct {
             .sent_path = self.paths.activePathRef(),
             .sent_size = total,
             .carried_pmtu_probe = probe_size,
+            // A probe is an ordinary datagram on this path in every respect
+            // but its size, so it is marked like the traffic it is measuring
+            // for — and its acknowledgement is usable ECN evidence.
+            .ecn_marked = self.activeEcnMarking(),
         };
         self.recovery.onPacketSentAssumeCapacity(.{
             .space = .application,
@@ -3402,6 +3708,7 @@ pub const Connection = struct {
         publishSentRecord(self, &record);
 
         self.paths.recordSentOnPath(active_key, total);
+        if (record.ecn_marked) self.noteEcnMarkedSent();
         self.metrics.packets_sent += 1;
         self.metrics.datagrams_sent += 1;
         self.metrics.pmtu_probes_sent += 1;
@@ -3412,7 +3719,7 @@ pub const Connection = struct {
             .size = total,
             .ack_eliciting = true,
         } });
-        return .{ .bytes = out[0..total], .path = active_key };
+        return .{ .bytes = out[0..total], .path = active_key, .ecn = self.paths.activeEcn().sendCodepoint() };
     }
 
     const BuildContext = struct {
@@ -3537,6 +3844,7 @@ pub const Connection = struct {
             // Ordinary content always targets the active path; candidate-path
             // content is built and recorded by `buildCandidatePacket`.
             .sent_path = self.paths.activePathRef(),
+            .ecn_marked = self.activeEcnMarking(),
         };
         // `record` may pick up a dequeued NEW_CONNECTION_ID's reset token
         // below; `self.sent_records.append` (if reached) copies it into the
@@ -3550,7 +3858,20 @@ pub const Connection = struct {
         if (want_ack) {
             const delay = now_us -| self.ack_armed_at_us[space_idx];
             if (self.recovery.ackFrameForSpace(space, delay)) |model| {
-                if (frame.encodeAck(model, local_ack_delay_exponent, plain[plain_len..plain_budget])) |n| {
+                // RFC 9000 §13.4.1: once any marked packet has been received in
+                // this space, every ACK for it reports the counts. Skipping
+                // them would read to the peer as its marks being stripped —
+                // which is exactly the conclusion `ecn.Controller` draws.
+                const counts = self.recv_ecn[space_idx];
+                const encoded = if (counts.any())
+                    frame.encodeAckEcn(model, .{
+                        .ect0 = counts.ect0,
+                        .ect1 = counts.ect1,
+                        .ce = counts.ce,
+                    }, local_ack_delay_exponent, plain[plain_len..plain_budget])
+                else
+                    frame.encodeAck(model, local_ack_delay_exponent, plain[plain_len..plain_budget]);
+                if (encoded) |n| {
                     plain_len += n;
                     record.carried_ack_largest = model.largest_acknowledged;
                     self.ack_needed[space_idx] = false;
@@ -3712,6 +4033,12 @@ pub const Connection = struct {
         if (record.has_new_connection_id) {
             if (self.local_cids) |*registry| registry.markAdvertised(record.carried_new_connection_id.sequence) catch {};
         }
+        // Counted per *packet*, matching RFC 9000 §13.4.1's per-packet receive
+        // counters — and counted for pure ACKs too, which are not in flight
+        // and so were never published as a record. The peer counts them all
+        // the same, and a marked packet this endpoint failed to count would
+        // make the peer's honest report look like an over-claim.
+        if (record.ecn_marked) self.noteEcnMarkedSent();
         self.metrics.packets_sent += 1;
         self.events.emit(.{ .packet_sent = .{
             .space = space,
@@ -4052,6 +4379,10 @@ pub const Connection = struct {
         self.paths.recordSentOnPath(active_key, total);
         self.metrics.datagrams_sent += 1;
         self.events.emit(.{ .close_sent = .{ .error_code = info.error_code } });
+        // Unmarked (#256-E). A close is never acknowledged, so marking it
+        // could only ever inflate the peer's counters past what this endpoint
+        // counted as sent — which reads as an over-claim and would disable ECN
+        // on the way out the door.
         return .{ .bytes = out[0..total], .path = active_key };
     }
 };
@@ -4383,6 +4714,8 @@ const TestPair = struct {
     client: *Connection = undefined,
     server: *Connection = undefined,
     now_us: u64 = 1_000_000,
+    /// See `deliveredEcn`.
+    network_ecn: ?*const fn (quic_udp.Ecn) quic_udp.Ecn = null,
 
     const client_cid = [_]u8{ 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8 };
     const odcid = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08 };
@@ -4648,6 +4981,20 @@ const TestPair = struct {
         allocator.destroy(self);
     }
 
+    /// #256-E: what the network between the two endpoints does to each
+    /// datagram's ECN codepoint. `null` — the default — delivers exactly what
+    /// was sent, i.e. a path that preserves markings. Tests point it at a
+    /// middlebox that clears them or a bottleneck that marks CE.
+    ///
+    /// Note the layering this models: the codepoint is set by the *sender's*
+    /// socket, rewritten in flight, and read by the *receiver's* socket. The
+    /// transport only ever sees the two ends of that, which is exactly why
+    /// validation exists.
+    fn deliveredEcn(self: *const TestPair, sent: quic_udp.Ecn) quic_udp.Ecn {
+        const rewrite = self.network_ecn orelse return sent;
+        return rewrite(sent);
+    }
+
     fn deliverOneClientDatagram(self: *TestPair) !void {
         var buf: [2048]u8 = undefined;
         const t = self.client.pollTransmitOnPath(&buf, self.now_us) orelse return error.TestUnexpectedResult;
@@ -4679,13 +5026,13 @@ const TestPair = struct {
             var buf: [2048]u8 = undefined;
             while (self.client.pollTransmitOnPath(&buf, self.now_us)) |t| {
                 const ingress = quic_path.PathKey{ .local = t.path.remote, .remote = t.path.local };
-                try self.server.ingestOnPath(t.bytes, ingress, test_challenge_entropy, self.now_us);
+                try self.server.ingestOnPathWithEcn(t.bytes, ingress, self.deliveredEcn(t.ecn), test_challenge_entropy, self.now_us);
                 progressed = true;
                 self.now_us += 500;
             }
             while (self.server.pollTransmitOnPath(&buf, self.now_us)) |t| {
                 const ingress = quic_path.PathKey{ .local = t.path.remote, .remote = t.path.local };
-                try self.client.ingestOnPath(t.bytes, ingress, test_challenge_entropy, self.now_us);
+                try self.client.ingestOnPathWithEcn(t.bytes, ingress, self.deliveredEcn(t.ecn), test_challenge_entropy, self.now_us);
                 progressed = true;
                 self.now_us += 500;
             }
@@ -9363,6 +9710,302 @@ test "driver: a bare embedder cannot discover above the floor" {
     const seen = drainTransmits(pair.server, &pair.now_us);
     try testing.expect(seen.count > 1);
     try testing.expect(seen.largest <= base_datagram_size);
+}
+
+// ---------------------------------------------------------------------------
+// ECN end to end (#256-E, RFC 9000 §13.4, RFC 9002 §7).
+// ---------------------------------------------------------------------------
+
+/// The configuration of an embedder whose socket can both set and read the IP
+/// ECN field. Off by default for the same reason discovery is: `quic/config`
+/// owns no socket and cannot know (see `Config.ecn_enabled`).
+const ecn_enabled = config.Config{ .ecn_enabled = true };
+
+/// A middlebox that clears every marking in flight — by far the most common
+/// way ECN fails in the field.
+fn clearsEcn(_: quic_udp.Ecn) quic_udp.Ecn {
+    return .not_ect;
+}
+
+/// A congested bottleneck that marks every ECT datagram CE.
+fn marksCe(sent: quic_udp.Ecn) quic_udp.Ecn {
+    return switch (sent) {
+        .ect0, .ect1, .ce => .ce,
+        .not_ect, .unavailable => sent,
+    };
+}
+
+/// A path that rewrites ECT(0) to ECT(1) — a codepoint this endpoint never
+/// sends, so any report of it is proof the field is being tampered with.
+fn rewritesToEct1(sent: quic_udp.Ecn) quic_udp.Ecn {
+    return switch (sent) {
+        .ect0 => .ect1,
+        else => sent,
+    };
+}
+
+/// Exchange enough application traffic for ECN validation to complete: the
+/// first ACK_ECN on a path only establishes the counter baseline, so growth
+/// has to be observed at least once after it.
+fn settleEcn(pair: *TestPair) !void {
+    const sid = try openServerResponseStream(pair);
+    var round: usize = 0;
+    while (round < 6) : (round += 1) {
+        _ = try pair.server.writeStream(sid, "chunk", false);
+        try pair.pump();
+        pair.now_us += 20_000;
+        pair.server.onTimeout(pair.now_us);
+        pair.client.onTimeout(pair.now_us);
+        try pair.pump();
+    }
+}
+
+test "driver: ECN marks outbound packets and is validated by the peer's counters" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.initWithConfigs(allocator, ecn_enabled, ecn_enabled);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    // Nothing is marked during the handshake: marking starts only once the
+    // handshake is confirmed and one packet number space is doing the work.
+    try testing.expectEqual(quic_ecn.State.testing, pair.server.pathEcn().state);
+    try testing.expectEqual(quic_udp.Ecn.ect0, pair.server.ecnCodepoint());
+
+    try settleEcn(pair);
+
+    // The peer received marked packets, counted them, and reported them back
+    // in ACK_ECN — which is what promoted the path.
+    try testing.expect(pair.client.receivedEcnCounts().ect0 > 0);
+    try testing.expectEqual(quic_ecn.State.capable, pair.server.pathEcn().state);
+    try testing.expect(pair.server.metrics.ecn_marked_sent > 0);
+    try testing.expectEqual(@as(u64, 1), pair.server.metrics.ecn_validated);
+    try testing.expectEqual(@as(u64, 0), pair.server.metrics.ecn_disabled);
+    // A path that preserves markings reports no congestion.
+    try testing.expectEqual(@as(u64, 0), pair.server.metrics.ecn_ce_received);
+}
+
+test "driver: ECN stays off for an embedder that did not opt in" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try pair.pump();
+    try settleEcn(pair);
+
+    // No marking, so nothing to count, so every ACK stays a plain ACK — which
+    // is exactly what a peer needs to see from an endpoint whose socket cannot
+    // set the field, rather than marks it can never explain.
+    try testing.expectEqual(quic_ecn.State.disabled, pair.server.pathEcn().state);
+    try testing.expectEqual(quic_udp.Ecn.not_ect, pair.server.ecnCodepoint());
+    try testing.expectEqual(@as(u64, 0), pair.server.metrics.ecn_marked_sent);
+    try testing.expect(!pair.client.receivedEcnCounts().any());
+    try testing.expect(!pair.server.receivedEcnCounts().any());
+}
+
+test "driver: a path that strips markings disables ECN and keeps serving" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.initWithConfigs(allocator, ecn_enabled, ecn_enabled);
+    defer pair.deinit(allocator);
+    pair.network_ecn = clearsEcn;
+    try pair.pump();
+    try settleEcn(pair);
+
+    // The peer saw nothing marked, so its ACKs carry no counts at all, so the
+    // marked packets they acknowledge are unaccounted for.
+    try testing.expect(!pair.client.receivedEcnCounts().any());
+    try testing.expectEqual(quic_ecn.State.disabled, pair.server.pathEcn().state);
+    try testing.expectEqual(
+        @as(?quic_ecn.FailureReason, .missing_counts),
+        pair.server.pathEcn().failure,
+    );
+    try testing.expectEqual(@as(u64, 1), pair.server.metrics.ecn_disabled);
+    try testing.expectEqual(quic_udp.Ecn.not_ect, pair.server.ecnCodepoint());
+
+    // Falling back is not failing: the connection is untouched and still
+    // carries data.
+    try testing.expectEqual(State.established, pair.server.state());
+    try testing.expectEqual(State.established, pair.client.state());
+    const sid = try openServerResponseStream(pair);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x21} ** 4096, false);
+    try pair.pump();
+    try testing.expectEqual(State.established, pair.server.state());
+}
+
+test "driver: a path that rewrites the codepoint disables ECN" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.initWithConfigs(allocator, ecn_enabled, ecn_enabled);
+    defer pair.deinit(allocator);
+    pair.network_ecn = rewritesToEct1;
+    try pair.pump();
+    try settleEcn(pair);
+
+    // The peer honestly reports ECT(1) arrivals. This endpoint never sends
+    // ECT(1), so the report is proof the field is being rewritten in flight
+    // and nothing derived from these counters can be trusted.
+    try testing.expect(pair.client.receivedEcnCounts().ect1 > 0);
+    try testing.expectEqual(quic_ecn.State.disabled, pair.server.pathEcn().state);
+    try testing.expectEqual(
+        @as(?quic_ecn.FailureReason, .unsent_codepoint),
+        pair.server.pathEcn().failure,
+    );
+    try testing.expectEqual(State.established, pair.server.state());
+}
+
+test "driver: CE reports on a validated path drive congestion response" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.initWithConfigs(allocator, ecn_enabled, ecn_enabled);
+    defer pair.deinit(allocator);
+    pair.network_ecn = marksCe;
+    try pair.pump();
+    try settleEcn(pair);
+
+    // Every marked datagram met the bottleneck, so the peer counted CE rather
+    // than ECT(0) — which still validates the path (a mark survived end to
+    // end) and additionally signals congestion.
+    try testing.expect(pair.client.receivedEcnCounts().ce > 0);
+    try testing.expectEqual(quic_ecn.State.capable, pair.server.pathEcn().state);
+    try testing.expect(pair.server.metrics.ecn_ce_received > 0);
+
+    // RFC 9002 §7.1: a CE report is a congestion event. The window has been
+    // reduced and recovery entered, without the congestion controller having
+    // reclaimed in-flight bytes twice over.
+    const congestion = pair.server.recovery.congestion;
+    try testing.expect(congestion.recovery_start_time_us != null);
+    try testing.expect(congestion.congestion_window < recovery.CongestionController.initialWindow(base_datagram_size));
+    try testing.expect(congestion.congestion_window >= congestion.minWindow());
+    try testing.expect(congestion.bytes_in_flight <= congestion.congestion_window +| base_datagram_size);
+}
+
+test "driver: a peer that over-claims marked arrivals disables ECN" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.initWithConfigs(allocator, ecn_enabled, ecn_enabled);
+    defer pair.deinit(allocator);
+    try pair.pump();
+    try settleEcn(pair);
+    try testing.expectEqual(quic_ecn.State.capable, pair.server.pathEcn().state);
+
+    // A forged or confused ACK_ECN claiming far more marked arrivals than this
+    // endpoint has ever marked. Parsed counters are not trusted congestion
+    // input: the arithmetic is checked against what was actually sent, and a
+    // report that cannot describe this connection turns ECN off rather than
+    // shrinking the window on demand.
+    const window_before = pair.server.recovery.congestion.congestion_window;
+    var ranges = recovery.AckRangeSet{};
+    try ranges.insert(pair.server.next_pn[Connection.spaceIndex(.application)] - 1);
+    pair.server.processAck(.application, .{
+        .ranges = ranges,
+        .ack_delay_raw = 0,
+        .largest_acknowledged = pair.server.next_pn[Connection.spaceIndex(.application)] - 1,
+        .ecn = .{ .ect0 = 1_000_000, .ect1 = 0, .ce = 1_000_000 },
+    }, pair.now_us);
+
+    try testing.expectEqual(quic_ecn.State.disabled, pair.server.pathEcn().state);
+    try testing.expectEqual(
+        @as(?quic_ecn.FailureReason, .counts_exceed_sent),
+        pair.server.pathEcn().failure,
+    );
+    try testing.expectEqual(@as(u64, 0), pair.server.metrics.ecn_ce_received);
+    try testing.expectEqual(window_before, pair.server.recovery.congestion.congestion_window);
+    try testing.expectEqual(State.established, pair.server.state());
+}
+
+test "driver: received ECN counters only count packets that authenticated" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.initWithConfigs(allocator, ecn_enabled, ecn_enabled);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const before = pair.server.receivedEcnCounts();
+    // A marked datagram that fails AEAD. RFC 9000 §13.4.1 counts processed
+    // packets, and counting this one would let an off-path spoofer inflate the
+    // counters this endpoint reports — which the peer feeds to congestion
+    // control.
+    var forged = [_]u8{0x41} ** 1200;
+    forged[0] = 0x40; // short header, spin bit clear
+    @memcpy(forged[1..][0..TestPair.odcid.len], &TestPair.odcid);
+    try pair.server.ingestOnPathWithEcn(
+        &forged,
+        TestPair.server_path,
+        .ce,
+        TestPair.test_challenge_entropy,
+        pair.now_us,
+    );
+    const after = pair.server.receivedEcnCounts();
+    try testing.expectEqual(before.ect0, after.ect0);
+    try testing.expectEqual(before.ce, after.ce);
+}
+
+test "driver: a receive path that cannot read the codepoint counts nothing" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.initWithConfigs(allocator, ecn_enabled, ecn_enabled);
+    defer pair.deinit(allocator);
+    try pair.pump();
+    const sid = try pair.client.openStream(.bidi);
+    _ = try pair.client.writeStream(sid, "request", false);
+
+    // `ingestOnPath` reports `.unavailable`, which is *not* `.not_ect`: it
+    // means this socket cannot see markings, not that none arrived. Counting
+    // it as unmarked would report zeros the peer reads as "my marks are being
+    // stripped" and would disable ECN on a path that is fine.
+    var buf: [2048]u8 = undefined;
+    const t = pair.client.pollTransmitOnPath(&buf, pair.now_us) orelse return error.TestExpectedEqual;
+    try testing.expectEqual(quic_udp.Ecn.ect0, t.ecn);
+    const received_before = pair.server.metrics.packets_received;
+    const ingress = quic_path.PathKey{ .local = t.path.remote, .remote = t.path.local };
+    try pair.server.ingestOnPath(t.bytes, ingress, TestPair.test_challenge_entropy, pair.now_us);
+
+    // The packet was processed in full — this is a report of "unknown", not a
+    // dropped datagram — and contributed to no counter.
+    try testing.expect(pair.server.metrics.packets_received > received_before);
+    try testing.expect(!pair.server.receivedEcnCounts().any());
+}
+
+test "driver: the ECN testing window closes when marked traffic vanishes" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.initWithConfigs(allocator, ecn_enabled, ecn_enabled);
+    defer pair.deinit(allocator);
+    try pair.pump();
+    try testing.expectEqual(quic_ecn.State.testing, pair.server.pathEcn().state);
+
+    // Nothing is delivered from here on: the peer never confirms a mark
+    // survived, and no ACK ever arrives to say otherwise. Without the timer a
+    // path that silently drops marked datagrams would be marked into forever.
+    const deadline = pair.server.pathEcn().deadlineUs() orelse return error.TestExpectedEqual;
+    try testing.expect(pair.server.nextTimeoutUs().? <= deadline);
+    pair.server.onTimeout(deadline);
+
+    try testing.expectEqual(quic_ecn.State.disabled, pair.server.pathEcn().state);
+    try testing.expectEqual(
+        @as(?quic_ecn.FailureReason, .testing_timeout),
+        pair.server.pathEcn().failure,
+    );
+    try testing.expectEqual(quic_udp.Ecn.not_ect, pair.server.ecnCodepoint());
+    try testing.expectEqual(State.established, pair.server.state());
+}
+
+test "driver: ECN feedback is not applied to handshake-space ACKs" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.initWithConfigs(allocator, ecn_enabled, ecn_enabled);
+    defer pair.deinit(allocator);
+    try pair.pump();
+    try settleEcn(pair);
+    try testing.expectEqual(quic_ecn.State.capable, pair.server.pathEcn().state);
+
+    // Counters belong to a packet number space. An Initial-space ACK's counts
+    // describe traffic that was never marked, so adopting them here would
+    // compare growth in one space against marks placed in another — and the
+    // mismatch would read as a validation failure.
+    const before = pair.server.pathEcn();
+    var ranges = recovery.AckRangeSet{};
+    try ranges.insert(0);
+    pair.server.processAck(.initial, .{
+        .ranges = ranges,
+        .ack_delay_raw = 0,
+        .largest_acknowledged = 0,
+        .ecn = .{ .ect0 = 9_999, .ect1 = 7, .ce = 9_999 },
+    }, pair.now_us);
+
+    try testing.expectEqual(quic_ecn.State.capable, pair.server.pathEcn().state);
+    try testing.expectEqual(before.ce_observed, pair.server.pathEcn().ce_observed);
 }
 
 test "driver: a padded non-ack-eliciting packet counts as in flight" {

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -1118,7 +1118,25 @@ pub const Connection = struct {
     /// newly acknowledge those packets — it filled a gap — but its cumulative
     /// counters are stale, so the growth they require has to be demanded of
     /// the next report that is current (#256-E review).
+    ///
+    /// Tagged with the epoch that placed them: a carried mark is evidence
+    /// about *that* path, and adding it to whatever path happens to be active
+    /// later would either validate the new one on the old one's growth or fail
+    /// a clean path for growth it never claimed.
     ecn_carried_marked: u64 = 0,
+    ecn_carried_generation: ?u64 = null,
+    /// Whether a marked packet has been acknowledged without a *current*
+    /// ACK_ECN having been adopted since (#256-E review).
+    ///
+    /// The peer counts on receipt, so an acknowledged mark may already sit in
+    /// its cumulative counters — but if the ACK that acknowledged it carried no
+    /// counts, or carried stale ones, this endpoint has not seen those counters
+    /// and its trusted baseline is behind reality by an unknown amount. Letting
+    /// a new path start from that baseline hands it the old path's growth as
+    /// its own evidence. Cleared by the next advancing ACK_ECN that is adopted:
+    /// having been generated after the acknowledgement, its counts necessarily
+    /// include whatever the acknowledged packet contributed.
+    ecn_sync_owed: bool = false,
     /// When a migration's wait for the previous epoch stops being worth it.
     /// The barrier cannot always drain — a marked packet that is never
     /// acknowledged is never settled — so it is bounded, and running out fails
@@ -1481,7 +1499,14 @@ pub const Connection = struct {
         // and starts marking.
         if (self.ecn_marking_generation) |marking| {
             if (marking != active.generation) {
-                if (self.ecn_outstanding_marked > 0) {
+                if (self.ecn_outstanding_marked > 0 or self.ecn_sync_owed) {
+                    // Two obligations, not one. A mark still outstanding may
+                    // yet be counted; a mark already acknowledged without a
+                    // current report may *already* have been counted, unseen.
+                    // Either way the trusted baseline is not known to be level
+                    // with the peer's, and a new path started from it would be
+                    // handed the old path's growth as its own evidence.
+                    //
                     // Bounded, because the wait can be unbounded: a marked
                     // packet that is never acknowledged is never settled, and
                     // no amount of waiting makes it so. Running out fails ECN
@@ -1499,6 +1524,11 @@ pub const Connection = struct {
                 }
                 self.ecn_marking_generation = null;
                 self.ecn_barrier_deadline_us = null;
+                // Carried marks belong to the epoch that placed them. The
+                // barrier has just certified that epoch as settled, so they
+                // have been accounted for and must not follow the new one.
+                self.ecn_carried_marked = 0;
+                self.ecn_carried_generation = null;
             }
         }
 
@@ -1591,6 +1621,8 @@ pub const Connection = struct {
         self.ecn_marking_generation = null;
         self.ecn_outstanding_marked = 0;
         self.ecn_carried_marked = 0;
+        self.ecn_carried_generation = null;
+        self.ecn_sync_owed = false;
         self.ecn_barrier_deadline_us = null;
         self.ecn_history.len = 0;
         for (&self.paths.paths) |*slot| {
@@ -2459,7 +2491,20 @@ pub const Connection = struct {
         const advances = self.largest_ecn_acked[space_idx] == null or
             ack.largest_acknowledged > self.largest_ecn_acked[space_idx].?;
         if (!advances) {
-            self.ecn_carried_marked +|= tally.total();
+            // The marks it retired stay tied to the epoch that placed them,
+            // and only that epoch's may be carried; anything else is another
+            // path's evidence and is handled by the barrier below.
+            if (self.ecn_marking_generation) |marking| {
+                const own = tally.countFor(marking);
+                if (own > 0) {
+                    self.ecn_carried_marked +|= own;
+                    self.ecn_carried_generation = marking;
+                }
+            }
+            // Retiring a mark is not the same as synchronising on it. These
+            // deliveries are real, but no current report has been adopted for
+            // them, so the trusted baseline is now behind by an unknown amount.
+            if (tally.total() > 0) self.ecn_sync_owed = true;
             return;
         }
         self.largest_ecn_acked[space_idx] = ack.largest_acknowledged;
@@ -2481,9 +2526,20 @@ pub const Connection = struct {
         // count honest; the epoch barrier in `syncPathEcn` is what makes it
         // sufficient, by ensuring no previous path's marks are still in flight
         // to contribute growth this path would otherwise be promoted on.
+        // An advancing ACK with no counts at all still acknowledges whatever it
+        // acknowledges. The path fails on that (`missing_counts`), but the
+        // connection also owes a synchronisation point: those marks may
+        // already be in the peer's counters, unseen from here.
+        if (feedback == null and tally.total() > 0) self.ecn_sync_owed = true;
+
         const active = self.paths.activePathRef();
-        const carried = self.ecn_carried_marked;
+        // Carried marks apply only to the epoch that placed them.
+        const carried = if (self.ecn_carried_generation == active.generation)
+            self.ecn_carried_marked
+        else
+            0;
         self.ecn_carried_marked = 0;
+        self.ecn_carried_generation = null;
         const rejected = self.applyEcnFeedback(
             active,
             tally.countFor(active.generation) +| carried,
@@ -2534,6 +2590,11 @@ pub const Connection = struct {
             return;
         }
         self.ecn_last_counts = counts;
+        // A current report has been adopted. It was generated after every
+        // acknowledgement processed so far, so its counters necessarily include
+        // whatever those acknowledged packets contributed: the trusted baseline
+        // is level with the peer's again.
+        self.ecn_sync_owed = false;
     }
 
     /// Returns the reason this path rejected the report, or null when it did
@@ -10695,6 +10756,11 @@ test "driver: old-path ECN growth cannot validate a new path that strips marks" 
     try testing.expect(pair.server.ecn_outstanding_marked > 0);
 
     try migrateServerPath(pair);
+    // The migration exchange acknowledges the highest packet number sent so
+    // far, so a report built on that would be non-advancing and — correctly —
+    // ignored for validation. One more datagram makes the report below current.
+    var out: [2048]u8 = undefined;
+    _ = pair.server.pollTransmitOnPath(&out, pair.now_us);
     const space_idx = Connection.spaceIndex(.application);
     const old_largest = pair.server.next_pn[space_idx] - 1;
     const old_marked = markedAwaitingAck(pair.server, old_largest);
@@ -10713,7 +10779,6 @@ test "driver: old-path ECN growth cannot validate a new path that strips marks" 
     }, pair.now_us);
 
     // N starts marking, and the network strips every one of its codepoints.
-    var out: [2048]u8 = undefined;
     _ = pair.server.pollTransmitOnPath(&out, pair.now_us);
     try testing.expectEqual(quic_ecn.State.testing, pair.server.pathEcn().state);
     _ = try pair.server.writeStream(sid, &[_]u8{0x68} ** 4096, false);
@@ -10736,6 +10801,164 @@ test "driver: old-path ECN growth cannot validate a new path that strips marks" 
 
     try testing.expect(pair.server.pathEcn().state != .capable);
     try testing.expectEqual(validated_before, pair.server.metrics.ecn_validated);
+    try testing.expectEqual(State.established, pair.server.state());
+}
+
+test "driver: a plain ACK of a marked packet blocks the next epoch until resynchronised" {
+    const allocator = testing.allocator;
+    var pair = try MigrationPair.initWithEcn(allocator, .full, true);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const sid = try pair.server.openStream(.uni);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x6e} ** 4096, false);
+    _ = drainTransmits(pair.server, &pair.now_us);
+    const space_idx = Connection.spaceIndex(.application);
+    const trusted = pair.server.ecn_last_counts;
+    const largest = pair.server.next_pn[space_idx] - 1;
+    try testing.expect(markedAwaitingAck(pair.server, largest) > 0);
+
+    // The old path's marks arrive and are counted by the peer — but the ACK
+    // carries no counts. The path rightly fails, and the connection is left
+    // with a trusted baseline that is behind the peer's by an unknown amount:
+    // those marks may already be in its cumulative counters, unseen from here.
+    var plain = recovery.AckRangeSet{};
+    try plain.insertRange(.{ .first = 0, .last = largest });
+    pair.server.processAck(.application, .{
+        .ranges = plain,
+        .ack_delay_raw = 0,
+        .largest_acknowledged = largest,
+        .ecn = null,
+    }, pair.now_us);
+    try testing.expectEqual(
+        @as(?quic_ecn.FailureReason, .missing_counts),
+        pair.server.pathEcn().failure,
+    );
+    try testing.expect(pair.server.ecn_sync_owed);
+
+    // Simulate the epoch change a migration produces, rather than driving the
+    // exchange: that exchange carries the peer's own ACK_ECN, which would
+    // legitimately resynchronise the baseline and hide the case under test. A
+    // new path incarnation gets a fresh controller by construction.
+    pair.server.paths.activeEcn().reset();
+    pair.server.ecn_marking_generation = pair.server.paths.activePathRef().generation +| 1;
+
+    // The new epoch must not start from that baseline. Doing so would hand the
+    // new path the old path's counter growth as its own evidence the moment it
+    // finally shows up.
+    var out: [2048]u8 = undefined;
+    _ = pair.server.pollTransmitOnPath(&out, pair.now_us);
+    try testing.expectEqual(quic_ecn.State.disabled, pair.server.pathEcn().state);
+    try testing.expectEqual(quic_udp.Ecn.not_ect, pair.server.ecnCodepoint());
+
+    // The old growth arrives on a current report. That is the synchronisation
+    // point: adopting it brings the baseline level with the peer, and only
+    // then may a new epoch begin — from counters that already contain it.
+    // A fresh packet first, so the report is current rather than a duplicate
+    // of the one that already set the ordering boundary.
+    _ = try pair.server.writeStream(sid, "resync", false);
+    _ = drainTransmits(pair.server, &pair.now_us);
+    const resync_largest = pair.server.next_pn[space_idx] - 1;
+    var resync = recovery.AckRangeSet{};
+    try resync.insertRange(.{ .first = 0, .last = resync_largest });
+    pair.server.processAck(.application, .{
+        .ranges = resync,
+        .ack_delay_raw = 0,
+        .largest_acknowledged = resync_largest,
+        .ecn = .{ .ect0 = trusted.ect0 + 1, .ect1 = 0, .ce = trusted.ce },
+    }, pair.now_us);
+    try testing.expect(!pair.server.ecn_sync_owed);
+    try testing.expectEqual(trusted.ect0 + 1, pair.server.ecn_last_counts.ect0);
+
+    _ = pair.server.pollTransmitOnPath(&out, pair.now_us);
+    try testing.expectEqual(quic_ecn.State.testing, pair.server.pathEcn().state);
+    // The new path starts from counters that already include the old mark, so
+    // that growth can never be re-spent as this path's evidence.
+    try testing.expectEqual(trusted.ect0 + 1, pair.server.pathEcn().seen.ect0);
+}
+
+test "driver: a gap filled by a stale ACK stays the old epoch's evidence" {
+    const allocator = testing.allocator;
+    var pair = try MigrationPair.initWithEcn(allocator, .full, true);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const sid = try pair.server.openStream(.uni);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x70} ** 4096, false);
+    _ = drainTransmits(pair.server, &pair.now_us);
+    const space_idx = Connection.spaceIndex(.application);
+    const largest = pair.server.next_pn[space_idx] - 1;
+    try testing.expect(largest >= 2);
+    const trusted = pair.server.ecn_last_counts;
+    const old_generation = pair.server.ecn_marking_generation orelse
+        return error.TestExpectedEqual;
+    // An advancing report that leaves a hole at `gap`.
+    const gap = largest - 1;
+    var with_gap = recovery.AckRangeSet{};
+    try with_gap.insertRange(.{ .first = 0, .last = gap - 1 });
+    try with_gap.insertRange(.{ .first = largest, .last = largest });
+    const acked_marks = blk: {
+        var n: u64 = 0;
+        for (pair.server.ecn_history.entries[0..pair.server.ecn_history.len]) |e| {
+            if (e.marked and with_gap.contains(e.packet_number)) n += 1;
+        }
+        break :blk n;
+    };
+    pair.server.processAck(.application, .{
+        .ranges = with_gap,
+        .ack_delay_raw = 0,
+        .largest_acknowledged = largest,
+        .ecn = .{ .ect0 = trusted.ect0 + acked_marks, .ect1 = 0, .ce = trusted.ce },
+    }, pair.now_us);
+
+    // A later *non-advancing* ACK fills the hole. The delivery is real, so the
+    // packet is retired — but its counter growth has not been reported by any
+    // current report, so it remains the old epoch's unsettled business.
+    var fills_gap = recovery.AckRangeSet{};
+    try fills_gap.insertRange(.{ .first = 0, .last = largest });
+    pair.server.processAck(.application, .{
+        .ranges = fills_gap,
+        .ack_delay_raw = 0,
+        .largest_acknowledged = largest,
+        .ecn = .{ .ect0 = trusted.ect0 + acked_marks, .ect1 = 0, .ce = trusted.ce },
+    }, pair.now_us);
+    try testing.expect(pair.server.ecn_sync_owed);
+    try testing.expectEqual(@as(?u64, old_generation), pair.server.ecn_carried_generation);
+
+    // A new epoch must neither start from the stale baseline nor inherit the
+    // carried mark as its own newly acknowledged evidence. The epoch change is
+    // simulated rather than driven, because a real migration exchange carries
+    // the peer's own ACK_ECN and would resynchronise before the case under
+    // test could arise.
+    // Bumping the active slot's generation is what a recycled or re-validated
+    // path slot does, and it gives the fresh controller a new incarnation
+    // without driving an exchange that would resynchronise first.
+    pair.server.paths.paths[pair.server.paths.active].?.generation = old_generation +| 1;
+    pair.server.paths.activeEcn().reset();
+    try testing.expect(pair.server.paths.activePathRef().generation != old_generation);
+    var out: [2048]u8 = undefined;
+    _ = pair.server.pollTransmitOnPath(&out, pair.now_us);
+    try testing.expectEqual(quic_ecn.State.disabled, pair.server.pathEcn().state);
+
+    // A current report resynchronises, and starting the new epoch discards the
+    // old one's carried evidence rather than crediting it to the new path.
+    _ = try pair.server.writeStream(sid, "resync", false);
+    _ = drainTransmits(pair.server, &pair.now_us);
+    const resync_largest = pair.server.next_pn[space_idx] - 1;
+    var resync = recovery.AckRangeSet{};
+    try resync.insertRange(.{ .first = 0, .last = resync_largest });
+    pair.server.processAck(.application, .{
+        .ranges = resync,
+        .ack_delay_raw = 0,
+        .largest_acknowledged = resync_largest,
+        .ecn = .{ .ect0 = trusted.ect0 + acked_marks + 1, .ect1 = 0, .ce = trusted.ce },
+    }, pair.now_us);
+    try testing.expect(!pair.server.ecn_sync_owed);
+
+    _ = pair.server.pollTransmitOnPath(&out, pair.now_us);
+    try testing.expectEqual(quic_ecn.State.testing, pair.server.pathEcn().state);
+    try testing.expectEqual(@as(u64, 0), pair.server.ecn_carried_marked);
+    try testing.expectEqual(@as(?u64, null), pair.server.ecn_carried_generation);
     try testing.expectEqual(State.established, pair.server.state());
 }
 

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -805,13 +805,6 @@ const SentRecord = struct {
     /// and to keep the probe out of every path that reasons about *content*,
     /// like the PTO's search for something worth resending.
     carried_pmtu_probe: ?usize = null,
-    /// Whether the datagram this packet went out in carried ECT(0) (#256-E).
-    /// RFC 9000 §13.4.2.1 validation is a statement about *these* packets:
-    /// when the peer acknowledges them, its reported counters must have grown
-    /// to match. Recorded per packet rather than derived from the path's
-    /// current state, because that state can have been turned off in between.
-    ecn_marked: bool = false,
-
     const StreamRange = struct {
         id: StreamId,
         range: Range,
@@ -903,6 +896,85 @@ fn wipePendingNewConnectionIdsOrderedRemoveResidue(frames: *std.ArrayList(quic_c
     crypto_secrets.secureZero(std.mem.asBytes(&frames.allocatedSlice()[frames.items.len]));
 }
 
+/// What one application-space packet needs to be remembered for, purely so a
+/// later ACK's ECN counters can be judged (#256-E review).
+///
+/// Deliberately independent of `SentRecord` and of the recovery tracker, both
+/// of which drop a packet the moment it is declared lost. RFC 9000 §13.4.2.1
+/// is about the packets an ACK *newly acknowledges*, and a packet declared
+/// lost can still be acknowledged afterwards — a spurious loss, or a
+/// reordered acknowledgement. Losing this metadata at loss-declaration time
+/// would mean a late plain ACK for a marked packet never triggers the required
+/// missing-counts failure, and a late CE report could not be dated to the
+/// packet that carried it.
+///
+/// Holds no retransmittable content: only enough to classify a late ACK.
+const EcnSentMeta = struct {
+    packet_number: u64,
+    /// The path incarnation that sent it, as a bare generation. Generations
+    /// are never reused, so this identifies the incarnation on its own and
+    /// costs 8 bytes instead of a whole `PathRef`.
+    path_generation: u64,
+    sent_time_us: u64,
+    marked: bool,
+    /// Whether this packet can still move the peer's cumulative counters.
+    /// Cleared once recovery declares it lost: a packet the peer never
+    /// received never incremented anything. The entry itself stays, so a late
+    /// acknowledgement is still classified correctly — only the connection's
+    /// outstanding-mark accounting stops waiting on it.
+    can_affect_counts: bool = true,
+};
+
+/// How many application-space packets keep ECN metadata. Covers a full flight
+/// with headroom (recovery tracks at most `recovery.max_tracked_packets`), so
+/// eviction is the exception rather than the rule. A fixed array costs every
+/// connection ~4 KiB whether or not ECN is on, which is the price of not
+/// allocating on the send path.
+const ecn_history_capacity: usize = 128;
+
+/// Bounded ECN metadata for recently sent application-space packets.
+///
+/// Insertion order is packet-number order, so the oldest entry is the one with
+/// the smallest packet number — which is what eviction needs and what lets the
+/// rest of this be a plain unordered array with `swapRemove` semantics.
+const EcnHistory = struct {
+    entries: [ecn_history_capacity]EcnSentMeta = undefined,
+    len: usize = 0,
+
+    /// Remember one packet, returning any entry evicted to make room.
+    fn record(self: *EcnHistory, meta: EcnSentMeta) ?EcnSentMeta {
+        var evicted: ?EcnSentMeta = null;
+        if (self.len == self.entries.len) {
+            const oldest = self.oldestIndex();
+            evicted = self.entries[oldest];
+            self.removeAt(oldest);
+        }
+        self.entries[self.len] = meta;
+        self.len += 1;
+        return evicted;
+    }
+
+    fn find(self: *const EcnHistory, packet_number: u64) ?usize {
+        for (self.entries[0..self.len], 0..) |entry, index| {
+            if (entry.packet_number == packet_number) return index;
+        }
+        return null;
+    }
+
+    fn removeAt(self: *EcnHistory, index: usize) void {
+        self.entries[index] = self.entries[self.len - 1];
+        self.len -= 1;
+    }
+
+    fn oldestIndex(self: *const EcnHistory) usize {
+        var oldest: usize = 0;
+        for (self.entries[1..self.len], 1..) |entry, index| {
+            if (entry.packet_number < self.entries[oldest].packet_number) oldest = index;
+        }
+        return oldest;
+    }
+};
+
 /// Newly acknowledged ECT-marked packets from one ACK, grouped by the path
 /// incarnation they were sent on (#256-E).
 ///
@@ -912,30 +984,30 @@ fn wipePendingNewConnectionIdsOrderedRemoveResidue(frames: *std.ArrayList(quic_c
 /// applies for the same reason. A fixed array rather than a map keeps this
 /// allocation-free on the ACK path.
 const EcnAckTally = struct {
-    const Entry = struct { path: quic_path.PathRef, count: u64 };
+    const Entry = struct { generation: u64, count: u64 };
 
     entries: [quic_path.max_paths]Entry = undefined,
     len: usize = 0,
 
-    fn add(self: *EcnAckTally, path: quic_path.PathRef) void {
+    fn add(self: *EcnAckTally, generation: u64) void {
         for (self.entries[0..self.len]) |*entry| {
-            if (entry.path.eql(path)) {
+            if (entry.generation == generation) {
                 entry.count +|= 1;
                 return;
             }
         }
-        // Overflow is unreachable in practice — a record's path is always one
+        // Overflow is unreachable in practice — a packet's path is always one
         // of the tracked slots — and dropping is the safe direction anyway:
         // under-counting acknowledged marks can only make validation more
         // lenient, never make it fail on traffic that was fine.
         if (self.len == self.entries.len) return;
-        self.entries[self.len] = .{ .path = path, .count = 1 };
+        self.entries[self.len] = .{ .generation = generation, .count = 1 };
         self.len += 1;
     }
 
-    fn countFor(self: EcnAckTally, path: quic_path.PathRef) u64 {
+    fn countFor(self: EcnAckTally, generation: u64) u64 {
         for (self.entries[0..self.len]) |entry| {
-            if (entry.path.eql(path)) return entry.count;
+            if (entry.generation == generation) return entry.count;
         }
         return 0;
     }
@@ -1014,6 +1086,27 @@ pub const Connection = struct {
     /// which is not the same as an unmarked datagram and must not be counted
     /// as one.
     ingress_ecn: quic_udp.Ecn = .unavailable,
+    /// The peer's application-space ECN counters as of the last ACK_ECN this
+    /// endpoint accepted (#256-E review). Connection-scoped, because that is
+    /// the scope the counters have: they are cumulative per packet number
+    /// space and span every path the peer has been reached on. A path
+    /// controller's baseline is snapshotted from here when it starts marking.
+    ecn_last_counts: quic_ecn.Feedback = .{ .ect0 = 0, .ect1 = 0, .ce = 0 },
+    /// The largest acknowledged packet number ECN feedback has been processed
+    /// for, per space. RFC 9000 §13.4.2.1: an ACK that does not advance it is
+    /// left entirely alone, because cumulative counters legitimately arrive
+    /// stale on a reordered ACK and validating against them would read
+    /// ordinary reordering as a hostile report.
+    largest_ecn_acked: [3]?u64 = .{ null, null, null },
+    /// ECN metadata for recently sent application-space packets, kept past
+    /// recovery's declaration of loss. See `EcnSentMeta`.
+    ecn_history: EcnHistory = .{},
+    /// The path incarnation currently marking, and how many of its marked
+    /// packets could still move the peer's counters. Together these are the
+    /// epoch barrier that stops one path's marks from validating another's;
+    /// see `syncPathEcn`.
+    ecn_marking_generation: ?u64 = null,
+    ecn_outstanding_marked: u32 = 0,
     /// Whether an ACK must be assembled for the space, and when the obligation
     /// arose (for the encoded ack_delay and the delayed-ack timer).
     ack_needed: [3]bool = .{ false, false, false },
@@ -1356,13 +1449,35 @@ pub const Connection = struct {
     /// marked, which is only a clean comparison once one packet number space
     /// is doing all the work.
     fn syncPathEcn(self: *Connection, now_us: u64) void {
+        _ = now_us;
         if (!self.cfg.ecn_enabled) return;
         if (!self.handshake_confirmed or self.state_ != .established) return;
+        const active = self.paths.activePathRef();
+
+        // The epoch barrier (#256-E review). The peer's counters are
+        // cumulative per packet number space, not per path, so while marks
+        // sent by a *previous* path can still arrive and move them, no growth
+        // is attributable to this path. Starting here anyway would let the old
+        // path's intact marks validate a new path that is stripping every
+        // codepoint — and let the old path's CE reports halve the new path's
+        // window. So a migration waits for the previous epoch's marks to be
+        // acknowledged or declared lost, and only then snapshots the counters
+        // and starts marking.
+        if (self.ecn_marking_generation) |marking| {
+            if (marking != active.generation) {
+                if (self.ecn_outstanding_marked > 0) return;
+                self.ecn_marking_generation = null;
+            }
+        }
+
         const controller = self.paths.activeEcn();
         // `enable` is idempotent and refuses a path that already failed, but
         // the event must fire exactly once per real transition.
         if (controller.state != .disabled or controller.failure != null) return;
-        controller.enable(now_us, quic_ecn.testing_pto_multiplier *| self.ptoDurationNow());
+        // The baseline is everything the peer has reported so far, taken
+        // before a single mark goes out on this path (RFC 9000 Appendix A.4).
+        controller.enable(self.ecn_last_counts);
+        self.ecn_marking_generation = active.generation;
         self.events.emit(.{ .ecn_state_changed = .{
             .path = self.paths.activePath().key,
             .state = controller.state,
@@ -1370,17 +1485,63 @@ pub const Connection = struct {
     }
 
     /// Whether the packet about to be built goes out marked. Read once per
-    /// packet and stamped onto its record: the path's state can change before
-    /// the acknowledgement arrives, and validation is a statement about how
-    /// the packet actually left, not about the state it finds later.
+    /// packet and stamped onto its ECN history entry: the path's state can
+    /// change before the acknowledgement arrives, and validation is a
+    /// statement about how the packet actually left, not about the state it
+    /// finds later.
     fn activeEcnMarking(self: *Connection) bool {
         return self.paths.activeEcn().marking();
     }
 
-    /// One packet went out marked on the active path.
-    fn noteEcnMarkedSent(self: *Connection) void {
-        self.paths.activeEcn().onMarkedSent();
+    /// Remember one application-space packet for ECN validation, and — when it
+    /// went out marked — count it against the epoch barrier.
+    ///
+    /// Every application-space packet is recorded while ECN is configured, not
+    /// only the marked ones: dating a CE report needs the send time of the
+    /// largest newly acknowledged packet (RFC 9002 §B.5), which is not
+    /// necessarily one that carried a mark.
+    fn noteEcnPacketSent(self: *Connection, packet_number: u64, marked: bool, now_us: u64) void {
+        if (!self.cfg.ecn_enabled) return;
+        if (self.ecn_history.record(.{
+            .packet_number = packet_number,
+            .path_generation = self.paths.activePathRef().generation,
+            .sent_time_us = now_us,
+            .marked = marked,
+        })) |evicted| {
+            // An evicted entry can no longer be classified, so it must stop
+            // holding the barrier open. Under-counting here only ever delays
+            // nothing and releases the barrier sooner, which is why eviction
+            // is bounded by a capacity comfortably above a full flight.
+            self.releaseEcnOutstanding(evicted);
+        }
+        if (!marked) return;
+        self.paths.activeEcn().onMarkedSent(
+            now_us,
+            quic_ecn.testing_pto_multiplier *| self.ptoDurationNow(),
+        );
+        self.ecn_outstanding_marked +|= 1;
         self.metrics.ecn_marked_sent += 1;
+    }
+
+    /// Stop waiting on one marked packet: it was acknowledged, declared lost,
+    /// or fell out of the history.
+    fn releaseEcnOutstanding(self: *Connection, meta: EcnSentMeta) void {
+        if (!meta.marked or !meta.can_affect_counts) return;
+        self.ecn_outstanding_marked -|= 1;
+    }
+
+    /// Recovery declared an application-space packet lost. The peer never
+    /// received it, so it can no longer move the peer's counters and must stop
+    /// holding the epoch barrier open — but the history entry survives, so a
+    /// late acknowledgement (a spurious loss, a reordered ACK) is still
+    /// classified rather than silently unaccounted.
+    fn noteEcnPacketLost(self: *Connection, space: PacketNumberSpace, packet_number: u64) void {
+        if (space != .application or !self.cfg.ecn_enabled) return;
+        const index = self.ecn_history.find(packet_number) orelse return;
+        const entry = &self.ecn_history.entries[index];
+        if (!entry.can_affect_counts) return;
+        entry.can_affect_counts = false;
+        if (entry.marked) self.ecn_outstanding_marked -|= 1;
     }
 
     /// Publish an ECN state transition for `path`: the operator counter and
@@ -2126,7 +2287,9 @@ pub const Connection = struct {
         // so one ACK can acknowledge marked packets belonging to more than one
         // controller, and crediting them all to whichever path is active now
         // would validate a route on the strength of another one's marks.
-        var ecn_acks = EcnAckTally{};
+        // Driven by `ecn_history` rather than by `sent_records`, because a
+        // packet declared lost is removed from the latter and can still be
+        // acknowledged afterwards (#256-E review).
         // RFC 9002 §B.5 processes an ECN-CE report as a congestion event dated
         // to the largest acked packet's send time.
         var largest_acked_sent_us: ?u64 = null;
@@ -2142,7 +2305,6 @@ pub const Connection = struct {
             }
             if (self.recovery.tracker.onAcked(space, record.packet_number, now_us)) |acked| {
                 self.recovery.congestion.onPacketAcked(acked.packet);
-                if (record.ecn_marked) ecn_acks.add(record.sent_path);
                 if (record.packet_number == ack.largest_acknowledged) {
                     if (acked.rtt_sample_us) |sample| self.recovery.rtt.update(sample, ack_delay_us);
                     largest_acked_sent_us = acked.packet.time_sent_us;
@@ -2172,7 +2334,7 @@ pub const Connection = struct {
         // A validated ACK ends the current PTO backoff episode.
         self.pto_count = 0;
 
-        self.processAckEcn(space, ack, ecn_acks, largest_acked_sent_us, now_us);
+        self.processAckEcn(space, ack, largest_acked_sent_us, now_us);
         self.detectAndRequeueLost(space, now_us);
     }
 
@@ -2187,34 +2349,76 @@ pub const Connection = struct {
         self: *Connection,
         space: PacketNumberSpace,
         ack: frame.Ack,
-        tally: EcnAckTally,
-        largest_acked_sent_us: ?u64,
+        record_largest_sent_us: ?u64,
         now_us: u64,
     ) void {
-        if (space != .application) return;
+        if (space != .application or !self.cfg.ecn_enabled) return;
+        const space_idx = spaceIndex(space);
+
+        // RFC 9000 §13.4.2.1: an ACK that does not increase the largest
+        // acknowledged packet number must not fail ECN validation. The peer's
+        // counters are cumulative, so a delayed ACK carries the values as of
+        // *its* largest — older than what has already been processed — and
+        // judging those against the current state would read ordinary
+        // reordering as a peer walking its counters backwards. Nothing here
+        // runs for such an ACK: not the tally, not the counter update, not the
+        // history reaping, all of which would corrupt the ordering boundary.
+        const advances = self.largest_ecn_acked[space_idx] == null or
+            ack.largest_acknowledged > self.largest_ecn_acked[space_idx].?;
+        if (!advances) return;
+        self.largest_ecn_acked[space_idx] = ack.largest_acknowledged;
+
+        // Newly acknowledged packets, from the ECN history rather than from
+        // `sent_records`: a packet declared lost is gone from the latter and
+        // can still be acknowledged (a spurious loss, a reordered ACK), and
+        // RFC 9000 §13.4.2.1 is about what an ACK *newly acknowledges*.
+        var tally = EcnAckTally{};
+        var history_largest_sent_us: ?u64 = null;
+        var index: usize = 0;
+        while (index < self.ecn_history.len) {
+            const entry = self.ecn_history.entries[index];
+            if (!ack.ranges.contains(entry.packet_number)) {
+                index += 1;
+                continue;
+            }
+            if (entry.marked) tally.add(entry.path_generation);
+            if (entry.packet_number == ack.largest_acknowledged) {
+                history_largest_sent_us = entry.sent_time_us;
+            }
+            self.releaseEcnOutstanding(entry);
+            self.ecn_history.removeAt(index);
+        }
+
         const feedback: ?quic_ecn.Feedback = if (ack.ecn) |counts|
             .{ .ect0 = counts.ect0, .ect1 = counts.ect1, .ce = counts.ce }
         else
             null;
+        // What the peer has reported, kept at connection scope because that is
+        // the scope it has. This is the baseline a path takes when it starts
+        // marking, so it has to keep advancing even while no path is
+        // validating — during a migration's drain, most of all.
+        if (feedback) |counts| self.ecn_last_counts = counts;
 
         // Only the active path. Marking is only ever started on the active
-        // path (`syncPathEcn`), so a path that is not active is either one
-        // that never marked or one that was demoted and has stopped — and its
-        // validation state is inert either way. Feeding it these counters
-        // would be worse than pointless: they are *space*-scoped, so both
-        // controllers would compute their own deltas from the same reported CE
-        // marks and each report them as congestion, halving the window on one
-        // signal counted twice.
+        // path (`syncPathEcn`), so a path that is not active either never
+        // marked or was demoted and has stopped — its validation state is
+        // inert either way. Feeding it these counters would be worse than
+        // pointless: they are *space*-scoped, so both controllers would derive
+        // their own deltas from the same reported CE marks and each report
+        // them as congestion, halving the window on one signal counted twice.
         //
-        // The tally still separates by path so this uses the active path's own
-        // acknowledgements. That accounting is exact except across a
-        // migration, where marked packets sent by the previous path can be
-        // acknowledged after the new one adopted its baseline: the peer counts
-        // them, this path did not send them, and the surplus can read as an
-        // over-claim. That resolves to ECN off on the new path, which is the
-        // safe direction and is re-tested on the next path.
+        // Crediting only this path's own acknowledged marks is what makes the
+        // count honest; the epoch barrier in `syncPathEcn` is what makes it
+        // sufficient, by ensuring no previous path's marks are still in flight
+        // to contribute growth this path would otherwise be promoted on.
         const active = self.paths.activePathRef();
-        self.applyEcnFeedback(active, tally.countFor(active), feedback, largest_acked_sent_us, now_us);
+        self.applyEcnFeedback(
+            active,
+            tally.countFor(active.generation),
+            feedback,
+            history_largest_sent_us orelse record_largest_sent_us,
+            now_us,
+        );
     }
 
     fn applyEcnFeedback(
@@ -2227,7 +2431,7 @@ pub const Connection = struct {
     ) void {
         const controller = self.paths.ecnFor(path) orelse return;
         if (controller.state == .disabled) return;
-        const outcome = controller.onAck(newly_acked_marked, feedback, now_us);
+        const outcome = controller.onAck(newly_acked_marked, feedback);
         if (outcome.failed) |reason| {
             self.publishEcnState(path.key, .disabled, reason);
             return;
@@ -2304,6 +2508,11 @@ pub const Connection = struct {
                 continue;
             }
             count += 1;
+            // #256-E: a lost packet never reached the peer, so it can no
+            // longer move the peer's ECN counters and must stop holding the
+            // migration barrier open. Its history entry survives, so a late
+            // acknowledgement is still classified.
+            self.noteEcnPacketLost(space, record.packet_number);
             if (record.carried_pmtu_probe != null) {
                 // Nothing to requeue: a probe carries no user data, and the
                 // search decides for itself whether to retry this size. The
@@ -3690,11 +3899,11 @@ pub const Connection = struct {
             .sent_path = self.paths.activePathRef(),
             .sent_size = total,
             .carried_pmtu_probe = probe_size,
-            // A probe is an ordinary datagram on this path in every respect
-            // but its size, so it is marked like the traffic it is measuring
-            // for — and its acknowledgement is usable ECN evidence.
-            .ecn_marked = self.activeEcnMarking(),
         };
+        // A probe is an ordinary datagram on this path in every respect but
+        // its size, so it is marked like the traffic it is measuring for —
+        // and its acknowledgement is usable ECN evidence.
+        const ecn_marked = self.activeEcnMarking();
         self.recovery.onPacketSentAssumeCapacity(.{
             .space = .application,
             .packet_number = pn,
@@ -3708,7 +3917,7 @@ pub const Connection = struct {
         publishSentRecord(self, &record);
 
         self.paths.recordSentOnPath(active_key, total);
-        if (record.ecn_marked) self.noteEcnMarkedSent();
+        self.noteEcnPacketSent(pn, ecn_marked, now_us);
         self.metrics.packets_sent += 1;
         self.metrics.datagrams_sent += 1;
         self.metrics.pmtu_probes_sent += 1;
@@ -3844,8 +4053,8 @@ pub const Connection = struct {
             // Ordinary content always targets the active path; candidate-path
             // content is built and recorded by `buildCandidatePacket`.
             .sent_path = self.paths.activePathRef(),
-            .ecn_marked = self.activeEcnMarking(),
         };
+        const ecn_marked = self.activeEcnMarking();
         // `record` may pick up a dequeued NEW_CONNECTION_ID's reset token
         // below; `self.sent_records.append` (if reached) copies it into the
         // owned, tracked record, but this local stays around until every
@@ -4033,12 +4242,12 @@ pub const Connection = struct {
         if (record.has_new_connection_id) {
             if (self.local_cids) |*registry| registry.markAdvertised(record.carried_new_connection_id.sequence) catch {};
         }
-        // Counted per *packet*, matching RFC 9000 §13.4.1's per-packet receive
-        // counters — and counted for pure ACKs too, which are not in flight
-        // and so were never published as a record. The peer counts them all
-        // the same, and a marked packet this endpoint failed to count would
-        // make the peer's honest report look like an over-claim.
-        if (record.ecn_marked) self.noteEcnMarkedSent();
+        // Recorded per *packet*, matching RFC 9000 §13.4.1's per-packet receive
+        // counters — and for pure ACKs too, which are not in flight and so
+        // were never published as a record. The peer counts them all the same,
+        // and a marked packet this endpoint failed to count would make the
+        // peer's honest report look like an over-claim.
+        if (space == .application) self.noteEcnPacketSent(pn, ecn_marked, now_us);
         self.metrics.packets_sent += 1;
         self.events.emit(.{ .packet_sent = .{
             .space = space,
@@ -7474,8 +7683,22 @@ const MigrationPair = struct {
     client: *Connection = undefined,
     server: *Connection = undefined,
     now_us: u64 = 1_000_000,
+    /// #256-E: what the network does to the *server's* outbound codepoints.
+    /// Only that direction is rewritten, so a scenario can strip marks on the
+    /// path under test while the peer keeps reporting honestly.
+    network_ecn: ?*const fn (quic_udp.Ecn) quic_udp.Ecn = null,
 
     fn init(allocator: std.mem.Allocator, policy: config.MigrationPolicy) !*MigrationPair {
+        return initWithEcn(allocator, policy, false);
+    }
+
+    /// #256-E: the same pair with ECN marking configured, for the migration
+    /// scenarios where ECN's per-path attribution is what is under test.
+    fn initWithEcn(
+        allocator: std.mem.Allocator,
+        policy: config.MigrationPolicy,
+        ecn: bool,
+    ) !*MigrationPair {
         const pair = try allocator.create(MigrationPair);
         const client_crypto_provider = pair.client_provider_storage.init(0x442_c);
         const server_crypto_provider = pair.server_provider_storage.init(0x442_5);
@@ -7499,7 +7722,11 @@ const MigrationPair = struct {
         errdefer allocator.destroy(pair);
         pair.client = try Connection.init(allocator, .{
             .role = .client,
-            .config = .{ .migration_policy = policy, .max_send_udp_payload_size = max_datagram_size_ceiling },
+            .config = .{
+                .migration_policy = policy,
+                .max_send_udp_payload_size = max_datagram_size_ceiling,
+                .ecn_enabled = ecn,
+            },
             .local_cid = &TestPair.client_cid,
             .original_destination_cid = &TestPair.odcid,
             .initial_secret_dcid = &TestPair.odcid,
@@ -7512,7 +7739,11 @@ const MigrationPair = struct {
         errdefer pair.client.deinit();
         pair.server = try Connection.init(allocator, .{
             .role = .server,
-            .config = .{ .migration_policy = policy, .max_send_udp_payload_size = max_datagram_size_ceiling },
+            .config = .{
+                .migration_policy = policy,
+                .max_send_udp_payload_size = max_datagram_size_ceiling,
+                .ecn_enabled = ecn,
+            },
             .local_cid = &TestPair.odcid,
             .original_destination_cid = &TestPair.odcid,
             .initial_secret_dcid = &TestPair.odcid,
@@ -7540,13 +7771,14 @@ const MigrationPair = struct {
             var buf: [2048]u8 = undefined;
             while (self.client.pollTransmitOnPath(&buf, self.now_us)) |t| {
                 const ingress = quic_path.PathKey{ .local = t.path.remote, .remote = t.path.local };
-                try self.server.ingestOnPath(t.bytes, ingress, TestPair.test_challenge_entropy, self.now_us);
+                try self.server.ingestOnPathWithEcn(t.bytes, ingress, t.ecn, TestPair.test_challenge_entropy, self.now_us);
                 progressed = true;
                 self.now_us += 500;
             }
             while (self.server.pollTransmitOnPath(&buf, self.now_us)) |t| {
                 const ingress = quic_path.PathKey{ .local = t.path.remote, .remote = t.path.local };
-                try self.client.ingestOnPath(t.bytes, ingress, TestPair.test_challenge_entropy, self.now_us);
+                const delivered = if (self.network_ecn) |rewrite| rewrite(t.ecn) else t.ecn;
+                try self.client.ingestOnPathWithEcn(t.bytes, ingress, delivered, TestPair.test_challenge_entropy, self.now_us);
                 progressed = true;
                 self.now_us += 500;
             }
@@ -9883,18 +10115,34 @@ test "driver: a peer that over-claims marked arrivals disables ECN" {
     try settleEcn(pair);
     try testing.expectEqual(quic_ecn.State.capable, pair.server.pathEcn().state);
 
+    // Put fresh, unacknowledged packets on the wire so the forged ACK below
+    // genuinely advances the largest acknowledged packet number — an ACK that
+    // does not is ignored outright (RFC 9000 §13.4.2.1) and would prove
+    // nothing about the arithmetic under test here.
+    const sid = try openServerResponseStream(pair);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x77} ** 2048, false);
+    _ = drainTransmits(pair.server, &pair.now_us);
+
     // A forged or confused ACK_ECN claiming far more marked arrivals than this
     // endpoint has ever marked. Parsed counters are not trusted congestion
     // input: the arithmetic is checked against what was actually sent, and a
     // report that cannot describe this connection turns ECN off rather than
     // shrinking the window on demand.
-    const window_before = pair.server.recovery.congestion.congestion_window;
+    // The forged ACK legitimately acknowledges real in-flight packets, which
+    // moves the window on its own. What must *not* happen is a congestion
+    // event: that is the payload of the attack, and `recovery_start_time_us`
+    // is what records one.
+    const recovery_before = pair.server.recovery.congestion.recovery_start_time_us;
+    const largest = pair.server.next_pn[Connection.spaceIndex(.application)] - 1;
     var ranges = recovery.AckRangeSet{};
-    try ranges.insert(pair.server.next_pn[Connection.spaceIndex(.application)] - 1);
+    // Acknowledge everything, so nothing is declared lost: a gap would enter
+    // recovery through ordinary loss detection and mask whether the CE claim
+    // did anything.
+    try ranges.insertRange(.{ .first = 0, .last = largest });
     pair.server.processAck(.application, .{
         .ranges = ranges,
         .ack_delay_raw = 0,
-        .largest_acknowledged = pair.server.next_pn[Connection.spaceIndex(.application)] - 1,
+        .largest_acknowledged = largest,
         .ecn = .{ .ect0 = 1_000_000, .ect1 = 0, .ce = 1_000_000 },
     }, pair.now_us);
 
@@ -9904,7 +10152,7 @@ test "driver: a peer that over-claims marked arrivals disables ECN" {
         pair.server.pathEcn().failure,
     );
     try testing.expectEqual(@as(u64, 0), pair.server.metrics.ecn_ce_received);
-    try testing.expectEqual(window_before, pair.server.recovery.congestion.congestion_window);
+    try testing.expectEqual(recovery_before, pair.server.recovery.congestion.recovery_start_time_us);
     try testing.expectEqual(State.established, pair.server.state());
 }
 
@@ -9980,6 +10228,353 @@ test "driver: the ECN testing window closes when marked traffic vanishes" {
     );
     try testing.expectEqual(quic_udp.Ecn.not_ect, pair.server.ecnCodepoint());
     try testing.expectEqual(State.established, pair.server.state());
+}
+
+/// How many ECT-marked packets at or below `largest` this connection still has
+/// ECN metadata for — i.e. what a synthetic ACK covering them newly
+/// acknowledges as marked. Tests that hand-build an ACK_ECN need this so the
+/// counter growth they report is the growth the peer would actually have
+/// reported; anything less is a legitimate `insufficient_increase` failure and
+/// would test the wrong thing.
+fn markedAwaitingAck(conn: *Connection, largest: u64) u64 {
+    var count: u64 = 0;
+    for (conn.ecn_history.entries[0..conn.ecn_history.len]) |entry| {
+        if (entry.marked and entry.packet_number <= largest) count += 1;
+    }
+    return count;
+}
+
+test "driver: a reordered ACK never fails ECN validation (#256-E review)" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.initWithConfigs(allocator, ecn_enabled, ecn_enabled);
+    defer pair.deinit(allocator);
+    try pair.pump();
+    try settleEcn(pair);
+    try testing.expectEqual(quic_ecn.State.capable, pair.server.pathEcn().state);
+
+    const sid = try openServerResponseStream(pair);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x33} ** 4096, false);
+    _ = drainTransmits(pair.server, &pair.now_us);
+
+    const space_idx = Connection.spaceIndex(.application);
+    const largest = pair.server.next_pn[space_idx] - 1;
+    const counts_before = pair.server.ecn_last_counts;
+    const marked = markedAwaitingAck(pair.server, largest);
+    try testing.expect(marked > 0);
+
+    // A well-formed ACK advancing the largest acknowledged packet number, with
+    // counter growth matching every mark it acknowledges.
+    var forward = recovery.AckRangeSet{};
+    try forward.insertRange(.{ .first = 0, .last = largest });
+    pair.server.processAck(.application, .{
+        .ranges = forward,
+        .ack_delay_raw = 0,
+        .largest_acknowledged = largest,
+        .ecn = .{
+            .ect0 = counts_before.ect0 + marked,
+            .ect1 = 0,
+            .ce = counts_before.ce,
+        },
+    }, pair.now_us);
+    try testing.expectEqual(quic_ecn.State.capable, pair.server.pathEcn().state);
+    try testing.expectEqual(@as(?u64, largest), pair.server.largest_ecn_acked[space_idx]);
+    const seen_after_forward = pair.server.pathEcn().seen;
+
+    // Now a delayed ACK from *before* it. RFC 9000 §13.4.2.1: an ACK that does
+    // not increase the largest acknowledged packet number must not fail ECN
+    // validation. Its counters are cumulative and therefore legitimately
+    // older, so treating the shortfall as a peer walking its counters
+    // backwards would disable ECN on ordinary network reordering.
+    var stale = recovery.AckRangeSet{};
+    try stale.insertRange(.{ .first = 0, .last = largest -| 1 });
+    pair.server.processAck(.application, .{
+        .ranges = stale,
+        .ack_delay_raw = 0,
+        .largest_acknowledged = largest -| 1,
+        .ecn = .{ .ect0 = counts_before.ect0, .ect1 = 0, .ce = counts_before.ce },
+    }, pair.now_us);
+
+    // Untouched in every respect: still validated, and the ordering boundary
+    // and reported counters did not move backwards either.
+    try testing.expectEqual(quic_ecn.State.capable, pair.server.pathEcn().state);
+    try testing.expectEqual(@as(?quic_ecn.FailureReason, null), pair.server.pathEcn().failure);
+    try testing.expectEqual(@as(?u64, largest), pair.server.largest_ecn_acked[space_idx]);
+    try testing.expectEqual(seen_after_forward.ect0, pair.server.pathEcn().seen.ect0);
+    try testing.expectEqual(State.established, pair.server.state());
+}
+
+test "driver: a marked packet declared lost can still be judged when acked late" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.initWithConfigs(allocator, ecn_enabled, ecn_enabled);
+    defer pair.deinit(allocator);
+    try pair.pump();
+    try settleEcn(pair);
+
+    const sid = try openServerResponseStream(pair);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x44} ** 4096, false);
+    _ = drainTransmits(pair.server, &pair.now_us);
+    const space_idx = Connection.spaceIndex(.application);
+    const largest = pair.server.next_pn[space_idx] - 1;
+
+    // Declare everything outstanding lost and let recovery drop its records.
+    // The ECN metadata must survive that: a packet declared lost can still be
+    // acknowledged afterwards — a spurious loss, a reordered ACK — and RFC
+    // 9000 §13.4.2.1 is about what an ACK *newly acknowledges*, not about what
+    // the loss-recovery tracker still happens to hold.
+    _ = pair.server.recovery.tracker.dropSpace(.application);
+    _ = pair.server.requeueUntrackedRecords(.application, pair.now_us);
+    try testing.expectEqual(@as(usize, 0), pair.server.sent_records.items.len);
+    try testing.expect(pair.server.ecn_history.len > 0);
+
+    // The late ACK acknowledges those marked packets and reports no counters
+    // at all. Without retained metadata this would look like an ACK for
+    // nothing marked and the required failure would be missed entirely.
+    var ranges = recovery.AckRangeSet{};
+    try ranges.insertRange(.{ .first = 0, .last = largest });
+    pair.server.processAck(.application, .{
+        .ranges = ranges,
+        .ack_delay_raw = 0,
+        .largest_acknowledged = largest,
+        .ecn = null,
+    }, pair.now_us);
+
+    try testing.expectEqual(quic_ecn.State.disabled, pair.server.pathEcn().state);
+    try testing.expectEqual(
+        @as(?quic_ecn.FailureReason, .missing_counts),
+        pair.server.pathEcn().failure,
+    );
+    try testing.expectEqual(State.established, pair.server.state());
+}
+
+test "driver: a CE report for a lost-then-late-acked packet still dates its congestion event" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.initWithConfigs(allocator, ecn_enabled, ecn_enabled);
+    defer pair.deinit(allocator);
+    try pair.pump();
+    try settleEcn(pair);
+    try testing.expectEqual(quic_ecn.State.capable, pair.server.pathEcn().state);
+
+    const sid = try openServerResponseStream(pair);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x55} ** 4096, false);
+    _ = drainTransmits(pair.server, &pair.now_us);
+    const space_idx = Connection.spaceIndex(.application);
+    const largest = pair.server.next_pn[space_idx] - 1;
+    const counts_before = pair.server.ecn_last_counts;
+
+    _ = pair.server.recovery.tracker.dropSpace(.application);
+    _ = pair.server.requeueUntrackedRecords(.application, pair.now_us);
+    pair.server.recovery.congestion.recovery_start_time_us = null;
+    const marked = markedAwaitingAck(pair.server, largest);
+    try testing.expect(marked > 0);
+
+    // The largest newly acknowledged packet's send time is what RFC 9002 §B.5
+    // dates the congestion event to. Its `SentRecord` is gone, so only the
+    // retained ECN metadata can supply it — and without a date the validated
+    // CE signal would be dropped on the floor.
+    //
+    // One of the acknowledged marks met congestion and arrived CE; the rest
+    // arrived ECT(0), so the counts account for every packet as they must.
+    var ranges = recovery.AckRangeSet{};
+    try ranges.insertRange(.{ .first = 0, .last = largest });
+    pair.server.processAck(.application, .{
+        .ranges = ranges,
+        .ack_delay_raw = 0,
+        .largest_acknowledged = largest,
+        .ecn = .{
+            .ect0 = counts_before.ect0 + marked - 1,
+            .ect1 = 0,
+            .ce = counts_before.ce + 1,
+        },
+    }, pair.now_us);
+
+    try testing.expectEqual(quic_ecn.State.capable, pair.server.pathEcn().state);
+    try testing.expect(pair.server.metrics.ecn_ce_received > 0);
+    try testing.expect(pair.server.recovery.congestion.recovery_start_time_us != null);
+}
+
+/// Drive `pair` through a NAT rebinding to `rebind_candidate`, leaving that
+/// path active on the server.
+fn migrateServerPath(pair: *MigrationPair) !void {
+    var buf: [2048]u8 = undefined;
+    const datagram = try clientDatagram(pair, &buf);
+    try pair.server.ingestOnPath(datagram, rebind_candidate, TestPair.test_challenge_entropy, pair.now_us);
+
+    var challenge_out: [2048]u8 = undefined;
+    const challenge = pair.server.pollTransmitOnPath(&challenge_out, pair.now_us) orelse
+        return error.TestExpectedEqual;
+    var challenge_bytes: [2048]u8 = undefined;
+    @memcpy(challenge_bytes[0..challenge.bytes.len], challenge.bytes);
+    try pair.client.ingestOnPath(
+        challenge_bytes[0..challenge.bytes.len],
+        TestPair.client_path,
+        TestPair.test_challenge_entropy,
+        pair.now_us,
+    );
+
+    var response_out: [2048]u8 = undefined;
+    const response = pair.client.pollTransmitOnPath(&response_out, pair.now_us) orelse
+        return error.TestExpectedEqual;
+    var response_bytes: [2048]u8 = undefined;
+    @memcpy(response_bytes[0..response.bytes.len], response.bytes);
+    try pair.server.ingestOnPath(
+        response_bytes[0..response.bytes.len],
+        rebind_candidate,
+        TestPair.test_challenge_entropy,
+        pair.now_us,
+    );
+    try testing.expect(pair.server.activePathKey().eql(rebind_candidate));
+}
+
+test "driver: a migration waits for the old path's marks before testing the new one" {
+    const allocator = testing.allocator;
+    var pair = try MigrationPair.initWithEcn(allocator, .full, true);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    // Put marked packets on the old path and leave them outstanding.
+    const sid = try pair.server.openStream(.uni);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x66} ** 4096, false);
+    _ = drainTransmits(pair.server, &pair.now_us);
+    try testing.expect(pair.server.ecn_outstanding_marked > 0);
+    const old_generation = pair.server.ecn_marking_generation orelse
+        return error.TestExpectedEqual;
+
+    try migrateServerPath(pair);
+
+    // The epoch barrier. The peer's counters are cumulative per packet number
+    // space, so while the old path's marks can still arrive and move them, no
+    // growth is attributable to the new path — and starting to test here would
+    // let the old path's intact marks validate a route that is stripping every
+    // codepoint. So the new path stays unmarked until the old epoch drains.
+    var out: [2048]u8 = undefined;
+    _ = pair.server.pollTransmitOnPath(&out, pair.now_us);
+    try testing.expectEqual(quic_ecn.State.disabled, pair.server.pathEcn().state);
+    try testing.expectEqual(quic_udp.Ecn.not_ect, pair.server.ecnCodepoint());
+    try testing.expectEqual(@as(?u64, old_generation), pair.server.ecn_marking_generation);
+
+    // Once those packets are resolved — here by being declared lost, which is
+    // proof enough that they never reached the peer and so never moved a
+    // counter — the new path may start its own epoch.
+    _ = pair.server.recovery.tracker.dropSpace(.application);
+    _ = pair.server.requeueUntrackedRecords(.application, pair.now_us);
+    try testing.expectEqual(@as(u32, 0), pair.server.ecn_outstanding_marked);
+
+    _ = pair.server.pollTransmitOnPath(&out, pair.now_us);
+    try testing.expectEqual(quic_ecn.State.testing, pair.server.pathEcn().state);
+    try testing.expect(pair.server.ecn_marking_generation.? != old_generation);
+}
+
+test "driver: old-path ECN growth cannot validate a new path that strips marks" {
+    const allocator = testing.allocator;
+    var pair = try MigrationPair.initWithEcn(allocator, .full, true);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    // Leave marked packets outstanding on the old path, then migrate. Every
+    // datagram the server sends from here on has its codepoint stripped.
+    const sid = try pair.server.openStream(.uni);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x67} ** 4096, false);
+    _ = drainTransmits(pair.server, &pair.now_us);
+    try migrateServerPath(pair);
+    pair.network_ecn = clearsEcn;
+
+    // The old path's marks now arrive and are reported honestly: real ECT(0)
+    // growth in the packet number space, caused entirely by path O. Without
+    // the barrier this growth would reach path N's controller, which — having
+    // sent marks of its own — would take it as proof that N carries ECN.
+    const space_idx = Connection.spaceIndex(.application);
+    const largest = pair.server.next_pn[space_idx] - 1;
+    const marked = markedAwaitingAck(pair.server, largest);
+    try testing.expect(marked > 0);
+    const validated_before = pair.server.metrics.ecn_validated;
+    var ranges = recovery.AckRangeSet{};
+    try ranges.insertRange(.{ .first = 0, .last = largest });
+    pair.server.processAck(.application, .{
+        .ranges = ranges,
+        .ack_delay_raw = 0,
+        .largest_acknowledged = largest,
+        .ecn = .{ .ect0 = marked, .ect1 = 0, .ce = 0 },
+    }, pair.now_us);
+
+    // N was never validated on O's evidence.
+    try testing.expect(pair.server.pathEcn().state != .capable);
+    try testing.expectEqual(validated_before, pair.server.metrics.ecn_validated);
+    try testing.expectEqual(State.established, pair.server.state());
+}
+
+test "driver: an old-path CE report cannot congest the new path" {
+    const allocator = testing.allocator;
+    var pair = try MigrationPair.initWithEcn(allocator, .full, true);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    const sid = try pair.server.openStream(.uni);
+    _ = try pair.server.writeStream(sid, &[_]u8{0x68} ** 4096, false);
+    _ = drainTransmits(pair.server, &pair.now_us);
+    try migrateServerPath(pair);
+
+    const space_idx = Connection.spaceIndex(.application);
+    const largest = pair.server.next_pn[space_idx] - 1;
+    const marked = markedAwaitingAck(pair.server, largest);
+    try testing.expect(marked > 0);
+    pair.server.recovery.congestion.recovery_start_time_us = null;
+
+    // Every one of the old path's marks met congestion. That is real
+    // congestion — on the path this connection no longer uses. Halving the new
+    // path's window on it would be responding to a bottleneck that is not on
+    // the route any more.
+    var ranges = recovery.AckRangeSet{};
+    try ranges.insertRange(.{ .first = 0, .last = largest });
+    pair.server.processAck(.application, .{
+        .ranges = ranges,
+        .ack_delay_raw = 0,
+        .largest_acknowledged = largest,
+        .ecn = .{ .ect0 = 0, .ect1 = 0, .ce = marked },
+    }, pair.now_us);
+
+    try testing.expectEqual(@as(u64, 0), pair.server.metrics.ecn_ce_received);
+    try testing.expectEqual(
+        @as(?u64, null),
+        pair.server.recovery.congestion.recovery_start_time_us,
+    );
+}
+
+test "driver: an idle connection does not burn its ECN testing window" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.initWithConfigs(allocator, ecn_enabled, ecn_enabled);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    // Start this path's ECN epoch over with nothing queued to send, which is
+    // the state a connection reaches whenever the handshake confirms on an
+    // otherwise idle connection.
+    pair.server.paths.activeEcn().reset();
+    pair.server.ecn_marking_generation = null;
+    var out: [max_datagram_size_ceiling]u8 = undefined;
+    try testing.expectEqual(@as(?Transmit, null), pair.server.pollTransmitOnPath(&out, pair.now_us));
+    try testing.expectEqual(quic_ecn.State.testing, pair.server.pathEcn().state);
+
+    // Marking is enabled and nothing has gone out under it, so there is no
+    // deadline to expire: the window is armed by the first marked packet, not
+    // by enabling. Timing out here would record a permanent `testing_timeout`
+    // against a path that was never given a chance to carry one.
+    try testing.expectEqual(@as(?u64, null), pair.server.pathEcn().deadlineUs());
+    // Well past 3×PTO (tens of milliseconds here) while staying inside the
+    // idle timeout, so the connection is genuinely quiet rather than gone.
+    pair.now_us += 5 * std.time.us_per_s;
+    pair.server.onTimeout(pair.now_us);
+    try testing.expectEqual(State.established, pair.server.state());
+    try testing.expectEqual(quic_ecn.State.testing, pair.server.pathEcn().state);
+    try testing.expectEqual(@as(?quic_ecn.FailureReason, null), pair.server.pathEcn().failure);
+
+    // The first marked packet is what starts the clock, dated from when it
+    // actually went out rather than from the long-past enable.
+    const sid = try pair.server.openStream(.uni);
+    _ = try pair.server.writeStream(sid, "now there is traffic", false);
+    const sent_at = pair.now_us;
+    _ = drainTransmits(pair.server, &pair.now_us);
+    const deadline = pair.server.pathEcn().deadlineUs() orelse return error.TestExpectedEqual;
+    try testing.expect(deadline >= sent_at);
 }
 
 test "driver: ECN feedback is not applied to handshake-space ACKs" {

--- a/src/quic/ecn.zig
+++ b/src/quic/ecn.zig
@@ -1,0 +1,554 @@
+//! Explicit Congestion Notification for pure Zig QUIC (#256-E, RFC 9000 §13.4,
+//! RFC 9002 §7).
+//!
+//! The wire pieces already existed before this module: `udp.Ecn` names the four
+//! IP codepoints and `frame.zig` parses and encodes ACK_ECN. What was missing
+//! is the part that decides anything — whether marking outbound packets is
+//! working on *this* path, and whether the counters a peer reports back may be
+//! believed.
+//!
+//! Both halves live here:
+//!
+//!  * `Counts` is the receive side: what arrived, per packet number space, so
+//!    an ACK_ECN can report it (RFC 9000 §13.4.1). Pure bookkeeping.
+//!  * `Controller` is the send side: it marks packets ECT(0), then checks the
+//!    peer's feedback against what was actually sent, and turns marking off for
+//!    the path the moment the feedback stops adding up.
+//!
+//! ECN is an optimisation that a surprising amount of deployed network gear
+//! quietly breaks — by clearing the codepoint, by rewriting it, or by dropping
+//! marked packets outright. So the design rule throughout is that **every
+//! failure ends in plain non-ECN operation**, never in a connection error. A
+//! false negative costs a congestion signal the stack would not have had
+//! anyway; trusting bad feedback would cost correctness, because a CE count is
+//! a congestion input and RFC 9000 §13.4.2 is explicit that it is attacker- and
+//! middlebox-reachable.
+//!
+//! One `Controller` belongs to one network path, for the same reason
+//! `pmtu.Controller` does: "does ECN survive here" is a property of the route,
+//! and a migration must re-establish it rather than inherit an answer measured
+//! somewhere else.
+//!
+//! Nothing here does I/O or touches sockets. The platform half — reading the IP
+//! header's ECN field off a received datagram and asking the kernel to set it
+//! on a sent one — belongs to whoever owns the socket, and it reports its
+//! capability in by simply never calling `enable`.
+
+const std = @import("std");
+const udp = @import("udp.zig");
+
+/// The codepoint this endpoint marks outbound packets with while ECN is in
+/// use. ECT(0) rather than ECT(1): ECT(1) belongs to L4S (RFC 9331), whose
+/// congestion response is not the RFC 9002 one implemented here, and RFC 9000
+/// §13.4.2.1 lets an endpoint treat *any* reported ECT(1) as proof that
+/// something on the path is rewriting codepoints.
+pub const send_codepoint: udp.Ecn = .ect0;
+
+/// How long the testing phase waits for the peer to confirm a marked packet
+/// arrived marked, expressed in PTOs (RFC 9000 §13.4.2 uses 3×PTO for the
+/// equivalent decision). The caller supplies the actual duration, since PTO
+/// lives in recovery; this is the multiplier it should apply.
+pub const testing_pto_multiplier: u64 = 3;
+
+pub const State = enum {
+    /// Marking is off: either nothing enabled it (the platform cannot set or
+    /// read the codepoint) or validation failed on this path.
+    disabled,
+    /// Packets are being marked ECT(0), and no peer feedback has yet proven
+    /// the marks survive the path. Congestion signals are *not* acted on in
+    /// this state — an unvalidated CE report is exactly the input RFC 9000
+    /// §13.4.2 warns is forgeable.
+    testing,
+    /// The peer has reported receiving marked packets consistent with what was
+    /// sent. CE reports are now believed and drive congestion response.
+    capable,
+};
+
+/// Why marking stopped on a path. Every one of these is an ordinary,
+/// non-fatal outcome — the path keeps carrying QUIC, without ECN.
+pub const FailureReason = enum {
+    /// The peer acknowledged packets that went out marked, in an ACK frame
+    /// carrying no ECN counts at all. Either the marks were stripped before
+    /// the peer saw them or the peer is not reporting; both mean the feedback
+    /// loop does not exist (RFC 9000 §13.4.2.1).
+    missing_counts,
+    /// A reported counter went backwards. Counters are monotonic by
+    /// construction, so this is a broken or hostile peer.
+    counts_regressed,
+    /// The peer reported ECT(1), which this endpoint never sends. Something on
+    /// the path is rewriting the codepoint.
+    unsent_codepoint,
+    /// The peer reported more marked arrivals than this endpoint has ever
+    /// marked. The counts are not describing our traffic.
+    counts_exceed_sent,
+    /// Packets known to have gone out marked were acknowledged, and the
+    /// ECT(0)+CE counts did not rise to match (RFC 9000 §13.4.2.1): the marks
+    /// are being cleared in flight.
+    insufficient_increase,
+    /// The testing window closed with no usable feedback at all.
+    testing_timeout,
+};
+
+/// Received ECN codepoints for one packet number space (RFC 9000 §13.4.1).
+///
+/// Per *space*, not per path, because that is the scope the peer's ACK frames
+/// are in: an ACK acknowledges packet numbers in one space and reports the
+/// counts for that space. Counting per path would produce numbers that no ACK
+/// frame could correctly carry.
+pub const Counts = struct {
+    ect0: u64 = 0,
+    ect1: u64 = 0,
+    ce: u64 = 0,
+
+    /// Count one *successfully authenticated* packet's codepoint. Called only
+    /// after AEAD open succeeds, so an off-path attacker cannot inflate the
+    /// counters this endpoint reports back — RFC 9000 §13.4.1 counts packets,
+    /// not datagrams, and an unauthenticated packet is not one.
+    pub fn record(self: *Counts, mark: udp.Ecn) void {
+        switch (mark) {
+            .ect0 => self.ect0 +|= 1,
+            .ect1 => self.ect1 +|= 1,
+            .ce => self.ce +|= 1,
+            // `.not_ect` is an unmarked packet and `.unavailable` means the
+            // receive path could not tell us — neither is a counter.
+            .not_ect, .unavailable => {},
+        }
+    }
+
+    /// Whether an ACK for this space must be an ACK_ECN. RFC 9000 §13.4.1
+    /// requires the counts once any marked packet has been received, and there
+    /// is nothing to say before that.
+    pub fn any(self: Counts) bool {
+        return self.ect0 != 0 or self.ect1 != 0 or self.ce != 0;
+    }
+
+    /// Discard the counters for a space whose keys were dropped.
+    pub fn reset(self: *Counts) void {
+        self.* = .{};
+    }
+};
+
+/// The ECN counters carried by one received ACK_ECN frame.
+pub const Feedback = struct {
+    ect0: u64,
+    ect1: u64,
+    ce: u64,
+};
+
+/// What one ACK meant for ECN on a path.
+pub const Outcome = struct {
+    /// Newly reported CE marks. Non-zero only in `.capable`: an unvalidated
+    /// report must never reach congestion control, or an attacker who can
+    /// forge feedback could shrink the window at will.
+    ce_increase: u64 = 0,
+    /// This ACK is what promoted the path from `.testing` to `.capable`.
+    validated: bool = false,
+    /// This ACK turned marking off, for this reason.
+    failed: ?FailureReason = null,
+};
+
+pub const Controller = struct {
+    state: State = .disabled,
+    /// Why marking is off, when it was ever on. Kept after failure so status
+    /// and benchmark output can say which way ECN broke rather than only that
+    /// it is not running.
+    failure: ?FailureReason = null,
+
+    /// Packets sent with `send_codepoint` on this path since marking began.
+    marked_sent: u64 = 0,
+    /// `marked_sent` as of the baseline ACK. Everything is judged in deltas
+    /// from there, so counters the peer accumulated for a *different* path — it
+    /// keeps them per packet number space, and a migration does not reset them
+    /// (RFC 9000 §13.4.2) — cannot be mistaken for feedback about this one.
+    marked_at_baseline: u64 = 0,
+    /// The largest counts the peer has reported, or null until the first
+    /// ACK_ECN establishes the baseline.
+    seen: ?Feedback = null,
+    /// Marked arrivals the peer has reported since the baseline, as ECT(0)+CE.
+    /// Compared against what was actually marked, so a peer cannot claim more
+    /// marked traffic than it was sent.
+    reported_since_baseline: u64 = 0,
+
+    /// When the testing phase gives up, or null when not testing.
+    testing_deadline_us: ?u64 = null,
+
+    /// Total CE marks believed (i.e. reported while `.capable`). The count a
+    /// benchmark or status page should show: unvalidated reports are excluded
+    /// because they never reached congestion control either.
+    ce_observed: u64 = 0,
+
+    /// The codepoint to put on the next outbound datagram for this path.
+    /// `.not_ect` — an explicit "no ECT" rather than `.unavailable` — is what
+    /// the send path asks the kernel for when marking is off, so a socket that
+    /// carries a stale marking cannot leak one.
+    pub fn sendCodepoint(self: Controller) udp.Ecn {
+        return switch (self.state) {
+            .disabled => .not_ect,
+            .testing, .capable => send_codepoint,
+        };
+    }
+
+    pub fn marking(self: Controller) bool {
+        return self.state != .disabled;
+    }
+
+    /// Start marking on this path and open the testing window. Idempotent, so
+    /// the send path can call it every poll; a path that already failed
+    /// validation stays failed until `reset` (a new path incarnation) rather
+    /// than re-enabling into the same broken route every poll.
+    pub fn enable(self: *Controller, now_us: u64, testing_window_us: u64) void {
+        if (self.state != .disabled or self.failure != null) return;
+        self.state = .testing;
+        self.testing_deadline_us = now_us +| testing_window_us;
+    }
+
+    /// Stop marking on this path. Used both by validation failures here and by
+    /// a caller that learns the platform cannot mark after all.
+    pub fn disable(self: *Controller, reason: FailureReason) void {
+        self.state = .disabled;
+        self.failure = reason;
+        self.testing_deadline_us = null;
+    }
+
+    /// One datagram went out carrying `send_codepoint` on this path.
+    pub fn onMarkedSent(self: *Controller) void {
+        self.marked_sent +|= 1;
+    }
+
+    /// Apply one ACK's worth of peer feedback.
+    ///
+    /// `newly_acked_marked` is how many packets *this ACK newly acknowledged*
+    /// that went out marked — the quantity RFC 9000 §13.4.2.1 requires the
+    /// reported counts to account for. `feedback` is null when the ACK frame
+    /// was a plain ACK rather than an ACK_ECN.
+    ///
+    /// Every rejection path here ends in `disable`, never in an error: the
+    /// worst case for a false positive is a path that runs without ECN, which
+    /// is where the vast majority of the internet already is.
+    pub fn onAck(
+        self: *Controller,
+        newly_acked_marked: u64,
+        feedback: ?Feedback,
+        now_us: u64,
+    ) Outcome {
+        _ = now_us;
+        if (self.state == .disabled) return .{};
+
+        const counts = feedback orelse {
+            // A plain ACK that acknowledges nothing we marked says nothing
+            // either way — ACKs for unmarked traffic are ordinary. One that
+            // acknowledges marked packets without counts is the feedback loop
+            // failing (RFC 9000 §13.4.2.1).
+            if (newly_acked_marked == 0) return .{};
+            return self.fail(.missing_counts);
+        };
+
+        const baseline = self.seen orelse {
+            // First report on this path: adopt it as the origin rather than
+            // validating against it. The peer's counters are per packet number
+            // space and span every path it has used, so their absolute values
+            // are not a statement about this path — only their growth is.
+            self.seen = counts;
+            self.marked_at_baseline = self.marked_sent;
+            return .{};
+        };
+
+        if (counts.ect0 < baseline.ect0 or counts.ect1 < baseline.ect1 or counts.ce < baseline.ce) {
+            return self.fail(.counts_regressed);
+        }
+        // Nothing this endpoint sends is ECT(1), so any ECT(1) growth means
+        // the codepoint is being rewritten somewhere on the path.
+        if (counts.ect1 > baseline.ect1) return self.fail(.unsent_codepoint);
+
+        const ect0_increase = counts.ect0 - baseline.ect0;
+        const ce_increase = counts.ce - baseline.ce;
+        const marked_increase = ect0_increase +| ce_increase;
+
+        // A peer cannot have received more marked packets than were marked.
+        // Checked cumulatively against the marks placed since the baseline, so
+        // it holds across reordered and delayed reports rather than only
+        // within one ACK.
+        const reported = self.reported_since_baseline +| marked_increase;
+        if (reported > self.marked_sent -| self.marked_at_baseline) {
+            return self.fail(.counts_exceed_sent);
+        }
+
+        // RFC 9000 §13.4.2.1: packets that went out marked and are now
+        // acknowledged must show up in the counts. CE counts too — a marked
+        // packet that met congestion arrives as CE, not ECT(0).
+        if (newly_acked_marked > 0 and marked_increase < newly_acked_marked) {
+            return self.fail(.insufficient_increase);
+        }
+
+        self.seen = counts;
+        self.reported_since_baseline = reported;
+
+        var outcome = Outcome{};
+        if (self.state == .testing and marked_increase > 0) {
+            self.state = .capable;
+            self.testing_deadline_us = null;
+            outcome.validated = true;
+        }
+        // Congestion response only once the path is validated (RFC 9002 §7.1
+        // is conditioned on exactly that). The promoting ACK counts: its marks
+        // are the evidence that validated the path, so they are as trustworthy
+        // as the next one's.
+        if (self.state == .capable and ce_increase > 0) {
+            self.ce_observed +|= ce_increase;
+            outcome.ce_increase = ce_increase;
+        }
+        return outcome;
+    }
+
+    /// The moment `onTimeout` has something to do, or null.
+    pub fn deadlineUs(self: Controller) ?u64 {
+        return self.testing_deadline_us;
+    }
+
+    /// Close the testing window if it has expired. Returns the failure when
+    /// this call is what ended marking.
+    pub fn onTimeout(self: *Controller, now_us: u64) ?FailureReason {
+        const deadline = self.testing_deadline_us orelse return null;
+        if (now_us < deadline) return null;
+        if (self.state != .testing) {
+            self.testing_deadline_us = null;
+            return null;
+        }
+        _ = self.fail(.testing_timeout);
+        return .testing_timeout;
+    }
+
+    /// Forget everything measured here, including a previous failure. The
+    /// caller uses this when the slot starts describing a genuinely different
+    /// path, which is the one situation where a path that could not carry ECN
+    /// deserves to be tried again.
+    pub fn reset(self: *Controller) void {
+        self.* = .{};
+    }
+
+    fn fail(self: *Controller, reason: FailureReason) Outcome {
+        self.disable(reason);
+        return .{ .failed = reason };
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Tests. Deterministic and platform-neutral by construction — nothing here
+// touches a socket, so the state machine is provable on every target even
+// where the OS half is unavailable.
+// ---------------------------------------------------------------------------
+
+const testing_alloc = std.testing;
+
+fn validatedController(now_us: u64) Controller {
+    var controller = Controller{};
+    controller.enable(now_us, 3 * 100_000);
+    // Baseline: the peer's counters already hold traffic from elsewhere.
+    controller.onMarkedSent();
+    _ = controller.onAck(0, .{ .ect0 = 40, .ect1 = 0, .ce = 7 }, now_us);
+    controller.onMarkedSent();
+    controller.onMarkedSent();
+    _ = controller.onAck(2, .{ .ect0 = 42, .ect1 = 0, .ce = 7 }, now_us);
+    return controller;
+}
+
+test "ecn: received codepoints accumulate per space and drive ACK_ECN" {
+    var counts = Counts{};
+    try testing_alloc.expect(!counts.any());
+    counts.record(.not_ect);
+    counts.record(.unavailable);
+    // Neither an unmarked packet nor a receive path that cannot report is a
+    // counter, so an ACK for this space is still a plain ACK.
+    try testing_alloc.expect(!counts.any());
+
+    counts.record(.ect0);
+    counts.record(.ect0);
+    counts.record(.ce);
+    counts.record(.ect1);
+    try testing_alloc.expect(counts.any());
+    try testing_alloc.expectEqual(@as(u64, 2), counts.ect0);
+    try testing_alloc.expectEqual(@as(u64, 1), counts.ect1);
+    try testing_alloc.expectEqual(@as(u64, 1), counts.ce);
+
+    counts.reset();
+    try testing_alloc.expect(!counts.any());
+}
+
+test "ecn: marking is off until enabled and never marks after failure" {
+    var controller = Controller{};
+    try testing_alloc.expectEqual(udp.Ecn.not_ect, controller.sendCodepoint());
+    try testing_alloc.expect(!controller.marking());
+
+    controller.enable(0, 300_000);
+    try testing_alloc.expectEqual(udp.Ecn.ect0, controller.sendCodepoint());
+    try testing_alloc.expectEqual(State.testing, controller.state);
+
+    controller.disable(.missing_counts);
+    try testing_alloc.expectEqual(udp.Ecn.not_ect, controller.sendCodepoint());
+    // Re-enabling into a path already known to break ECN would re-run the
+    // whole testing window on every poll and mark traffic that is being
+    // dropped or stripped. Only a new path incarnation gets another try.
+    controller.enable(0, 300_000);
+    try testing_alloc.expectEqual(State.disabled, controller.state);
+    controller.reset();
+    controller.enable(0, 300_000);
+    try testing_alloc.expectEqual(State.testing, controller.state);
+}
+
+test "ecn: the first report is a baseline, not evidence" {
+    var controller = Controller{};
+    controller.enable(0, 300_000);
+    controller.onMarkedSent();
+
+    // The peer's counters already carry traffic from another path — its
+    // counts are per packet number space and survive migration. Treating that
+    // history as feedback about this path would validate it on the strength of
+    // packets this path never carried.
+    const first = controller.onAck(1, .{ .ect0 = 900, .ect1 = 0, .ce = 3 }, 1_000);
+    try testing_alloc.expect(!first.validated);
+    try testing_alloc.expectEqual(State.testing, controller.state);
+    try testing_alloc.expectEqual(@as(u64, 1), controller.marked_at_baseline);
+
+    // Growth from that origin is what counts.
+    controller.onMarkedSent();
+    const second = controller.onAck(1, .{ .ect0 = 901, .ect1 = 0, .ce = 3 }, 2_000);
+    try testing_alloc.expect(second.validated);
+    try testing_alloc.expectEqual(State.capable, controller.state);
+}
+
+test "ecn: an ACK without counts for marked packets disables ECN" {
+    var controller = Controller{};
+    controller.enable(0, 300_000);
+    controller.onMarkedSent();
+
+    // An ACK that acknowledges nothing we marked is not evidence either way.
+    const unrelated = controller.onAck(0, null, 1_000);
+    try testing_alloc.expectEqual(@as(?FailureReason, null), unrelated.failed);
+    try testing_alloc.expectEqual(State.testing, controller.state);
+
+    const stripped = controller.onAck(1, null, 2_000);
+    try testing_alloc.expectEqual(@as(?FailureReason, .missing_counts), stripped.failed);
+    try testing_alloc.expectEqual(State.disabled, controller.state);
+    try testing_alloc.expectEqual(udp.Ecn.not_ect, controller.sendCodepoint());
+}
+
+test "ecn: CE reports reach congestion control only once validated" {
+    var controller = Controller{};
+    controller.enable(0, 300_000);
+    controller.onMarkedSent();
+    _ = controller.onAck(0, .{ .ect0 = 0, .ect1 = 0, .ce = 0 }, 1_000);
+
+    // Still `.testing`: a CE report here is unvalidated, and RFC 9000 §13.4.2
+    // is explicit that unvalidated feedback is forgeable. It promotes the path
+    // (a mark demonstrably survived) but must not double as a congestion
+    // signal on the strength of its own arrival.
+    controller.onMarkedSent();
+    const promoting = controller.onAck(1, .{ .ect0 = 0, .ect1 = 0, .ce = 1 }, 2_000);
+    try testing_alloc.expect(promoting.validated);
+    try testing_alloc.expectEqual(@as(u64, 1), promoting.ce_increase);
+    try testing_alloc.expectEqual(State.capable, controller.state);
+
+    controller.onMarkedSent();
+    const congested = controller.onAck(1, .{ .ect0 = 0, .ect1 = 0, .ce = 2 }, 3_000);
+    try testing_alloc.expectEqual(@as(u64, 1), congested.ce_increase);
+    try testing_alloc.expectEqual(@as(u64, 2), controller.ce_observed);
+}
+
+test "ecn: counts that go backwards disable ECN" {
+    var controller = validatedController(0);
+    controller.onMarkedSent();
+    const outcome = controller.onAck(1, .{ .ect0 = 41, .ect1 = 0, .ce = 7 }, 5_000);
+    try testing_alloc.expectEqual(@as(?FailureReason, .counts_regressed), outcome.failed);
+    try testing_alloc.expectEqual(@as(u64, 0), outcome.ce_increase);
+}
+
+test "ecn: a reported ECT(1) this endpoint never sends disables ECN" {
+    var controller = validatedController(0);
+    controller.onMarkedSent();
+    // Something on the path rewrote ECT(0) to ECT(1). The counts are no longer
+    // describing what was sent, so nothing derived from them can be believed.
+    const outcome = controller.onAck(1, .{ .ect0 = 43, .ect1 = 1, .ce = 7 }, 5_000);
+    try testing_alloc.expectEqual(@as(?FailureReason, .unsent_codepoint), outcome.failed);
+}
+
+test "ecn: a peer cannot report more marked arrivals than were marked" {
+    var controller = validatedController(0);
+    controller.onMarkedSent();
+    // Three packets have been marked since the baseline. A report of twelve
+    // marked arrivals is arithmetic that cannot describe this connection —
+    // the classic way a forged or confused ACK_ECN would try to manufacture
+    // congestion signals.
+    const outcome = controller.onAck(1, .{ .ect0 = 52, .ect1 = 0, .ce = 7 }, 5_000);
+    try testing_alloc.expectEqual(@as(?FailureReason, .counts_exceed_sent), outcome.failed);
+    try testing_alloc.expectEqual(@as(u64, 0), outcome.ce_increase);
+}
+
+test "ecn: marks cleared in flight disable ECN" {
+    var controller = Controller{};
+    controller.enable(0, 300_000);
+    controller.onMarkedSent();
+    _ = controller.onAck(0, .{ .ect0 = 0, .ect1 = 0, .ce = 0 }, 1_000);
+
+    // Four marked packets acknowledged, and the peer saw none of them marked:
+    // a middlebox is clearing the codepoint (RFC 9000 §13.4.2.1).
+    controller.onMarkedSent();
+    controller.onMarkedSent();
+    controller.onMarkedSent();
+    controller.onMarkedSent();
+    const outcome = controller.onAck(4, .{ .ect0 = 0, .ect1 = 0, .ce = 0 }, 2_000);
+    try testing_alloc.expectEqual(@as(?FailureReason, .insufficient_increase), outcome.failed);
+    try testing_alloc.expectEqual(State.disabled, controller.state);
+}
+
+test "ecn: a CE-marked delivery still accounts for its packet" {
+    var controller = Controller{};
+    controller.enable(0, 300_000);
+    controller.onMarkedSent();
+    _ = controller.onAck(0, .{ .ect0 = 0, .ect1 = 0, .ce = 0 }, 1_000);
+
+    // Two marked packets acknowledged; one arrived ECT(0), the other met
+    // congestion and arrived CE. The ECT(0) count alone is short of the two
+    // acknowledged, so validation must count CE as well or every congested
+    // path would look like a broken one.
+    controller.onMarkedSent();
+    controller.onMarkedSent();
+    const outcome = controller.onAck(2, .{ .ect0 = 1, .ect1 = 0, .ce = 1 }, 2_000);
+    try testing_alloc.expectEqual(@as(?FailureReason, null), outcome.failed);
+    try testing_alloc.expect(outcome.validated);
+    try testing_alloc.expectEqual(@as(u64, 1), outcome.ce_increase);
+}
+
+test "ecn: the testing window closes on silence" {
+    var controller = Controller{};
+    controller.enable(1_000, 300_000);
+    controller.onMarkedSent();
+    try testing_alloc.expectEqual(@as(?u64, 301_000), controller.deadlineUs());
+
+    try testing_alloc.expectEqual(@as(?FailureReason, null), controller.onTimeout(300_999));
+    try testing_alloc.expectEqual(State.testing, controller.state);
+
+    try testing_alloc.expectEqual(@as(?FailureReason, .testing_timeout), controller.onTimeout(301_000));
+    try testing_alloc.expectEqual(State.disabled, controller.state);
+    try testing_alloc.expectEqual(@as(?u64, null), controller.deadlineUs());
+    // Idempotent: a later timeout on a path that already gave up is silent.
+    try testing_alloc.expectEqual(@as(?FailureReason, null), controller.onTimeout(999_999));
+}
+
+test "ecn: validation clears the testing deadline" {
+    var controller = validatedController(0);
+    try testing_alloc.expectEqual(State.capable, controller.state);
+    try testing_alloc.expectEqual(@as(?u64, null), controller.deadlineUs());
+    // A validated path is never retired by the testing timer.
+    try testing_alloc.expectEqual(@as(?FailureReason, null), controller.onTimeout(std.math.maxInt(u64)));
+    try testing_alloc.expectEqual(State.capable, controller.state);
+}
+
+test "ecn: a disabled controller ignores feedback entirely" {
+    var controller = Controller{};
+    // Nothing enabled marking, so nothing was marked, so no report about this
+    // path can mean anything — including one claiming congestion.
+    const outcome = controller.onAck(5, .{ .ect0 = 5, .ect1 = 0, .ce = 5 }, 1_000);
+    try testing_alloc.expectEqual(@as(u64, 0), outcome.ce_increase);
+    try testing_alloc.expectEqual(@as(?FailureReason, null), outcome.failed);
+    try testing_alloc.expectEqual(State.disabled, controller.state);
+}

--- a/src/quic/ecn.zig
+++ b/src/quic/ecn.zig
@@ -87,6 +87,17 @@ pub const FailureReason = enum {
     insufficient_increase,
     /// The testing window closed with no usable feedback at all.
     testing_timeout,
+    /// The metadata needed to attribute the peer's counters was dropped before
+    /// it could be used, so nothing further about this path can be *proved*.
+    /// Marking stops rather than continuing on evidence that can no longer be
+    /// checked — the conservative direction, since the counters drive both
+    /// validation and congestion response.
+    evidence_lost,
+    /// The socket cannot put the codepoint on the wire after all, so every
+    /// "marked" packet actually left Not-ECT. Distinct from the network
+    /// failures above: nothing was learned about the path, and the peer's
+    /// silence about marks is this endpoint's own doing.
+    platform_unsupported,
 };
 
 /// Received ECN codepoints for one packet number space (RFC 9000 §13.4.1).
@@ -265,17 +276,22 @@ pub const Controller = struct {
             return self.fail(.missing_counts);
         };
 
-        // Nothing this endpoint ever sends is ECT(1), so a non-zero report is
-        // impossible for this connection whatever the baseline was. Checked as
-        // an absolute rather than as growth: a baseline adopted from a report
-        // that already contained ECT(1) would otherwise grandfather it in and
-        // let validation succeed on counters known to be rewritten.
-        if (counts.ect1 != 0) return self.fail(.unsent_codepoint);
-
+        // Judged against *this path's* baseline rather than against zero.
+        // The counters are cumulative per packet number space and survive a
+        // migration, so a path that rewrote ECT(0) to ECT(1) leaves a non-zero
+        // historical value that a later, clean path legitimately starts from —
+        // and rejecting it outright would deny that path the revalidation the
+        // per-path model exists to give it. An unchanged historical count is
+        // evidence about a route that is no longer in use; only *growth* says
+        // anything about this one, and this endpoint never sends ECT(1) at all.
         const baseline = self.seen;
-        if (counts.ect0 < baseline.ect0 or counts.ce < baseline.ce) {
+        if (counts.ect0 < baseline.ect0 or
+            counts.ect1 < baseline.ect1 or
+            counts.ce < baseline.ce)
+        {
             return self.fail(.counts_regressed);
         }
+        if (counts.ect1 > baseline.ect1) return self.fail(.unsent_codepoint);
 
         const ect0_increase = counts.ect0 - baseline.ect0;
         const ce_increase = counts.ce - baseline.ce;

--- a/src/quic/ecn.zig
+++ b/src/quic/ecn.zig
@@ -98,6 +98,29 @@ pub const FailureReason = enum {
     /// failures above: nothing was learned about the path, and the peer's
     /// silence about marks is this endpoint's own doing.
     platform_unsupported,
+
+    /// Whether this failure impugns the peer's *counters* or only this path.
+    ///
+    /// The distinction matters because the counters outlive the path: they are
+    /// cumulative per packet number space, and the next path to start marking
+    /// takes them as its baseline. A stripped or rewritten codepoint is a
+    /// statement about the route — the counters remain an honest record of what
+    /// arrived, and the next path deserves its own chance. Counters that go
+    /// backwards or claim more marked arrivals than were ever sent are not
+    /// describing this connection at all, and nothing derived from them can be
+    /// trusted again, including a future path's baseline.
+    pub fn impugnsCounters(self: FailureReason) bool {
+        return switch (self) {
+            .counts_regressed, .counts_exceed_sent => true,
+            .missing_counts,
+            .unsent_codepoint,
+            .insufficient_increase,
+            .testing_timeout,
+            .evidence_lost,
+            .platform_unsupported,
+            => false,
+        };
+    }
 };
 
 /// Received ECN codepoints for one packet number space (RFC 9000 §13.4.1).

--- a/src/quic/ecn.zig
+++ b/src/quic/ecn.zig
@@ -156,18 +156,21 @@ pub const Controller = struct {
 
     /// Packets sent with `send_codepoint` on this path since marking began.
     marked_sent: u64 = 0,
-    /// `marked_sent` as of the baseline ACK. Everything is judged in deltas
-    /// from there, so counters the peer accumulated for a *different* path — it
-    /// keeps them per packet number space, and a migration does not reset them
-    /// (RFC 9000 §13.4.2) — cannot be mistaken for feedback about this one.
-    marked_at_baseline: u64 = 0,
-    /// The largest counts the peer has reported, or null until the first
-    /// ACK_ECN establishes the baseline.
-    seen: ?Feedback = null,
+    /// The peer's counters as they stood when this path started marking, and
+    /// then the latest successfully validated report.
+    ///
+    /// The baseline is taken at `enable`, **before a single mark goes out**,
+    /// which is what RFC 9000 Appendix A.4 does when it snapshots the packet
+    /// number space's ECN counts as testing starts. Taking it from the first
+    /// ACK_ECN to arrive instead would silently write off every mark already
+    /// in flight: ten marked packets outstanding and a first report
+    /// acknowledging two would leave the other eight unaccounted, and the next
+    /// report that legitimately counted them would look like an over-claim.
+    seen: Feedback = .{ .ect0 = 0, .ect1 = 0, .ce = 0 },
     /// Marked arrivals the peer has reported since the baseline, as ECT(0)+CE.
     /// Compared against what was actually marked, so a peer cannot claim more
     /// marked traffic than it was sent.
-    reported_since_baseline: u64 = 0,
+    reported: u64 = 0,
 
     /// When the testing phase gives up, or null when not testing.
     testing_deadline_us: ?u64 = null,
@@ -192,14 +195,21 @@ pub const Controller = struct {
         return self.state != .disabled;
     }
 
-    /// Start marking on this path and open the testing window. Idempotent, so
-    /// the send path can call it every poll; a path that already failed
-    /// validation stays failed until `reset` (a new path incarnation) rather
-    /// than re-enabling into the same broken route every poll.
-    pub fn enable(self: *Controller, now_us: u64, testing_window_us: u64) void {
+    /// Start marking on this path, taking `baseline` as the peer's counters as
+    /// of right now (RFC 9000 Appendix A.4). Idempotent, so the send path can
+    /// call it every poll; a path that already failed validation stays failed
+    /// until `reset` (a new path incarnation) rather than re-enabling into the
+    /// same broken route every poll.
+    ///
+    /// The testing window is *not* armed here. It is armed by the first marked
+    /// packet actually leaving (`onMarkedSent`), because a connection that is
+    /// simply idle has not tested anything: arming at enable would let three
+    /// PTOs of silence record a permanent `testing_timeout` on a path that was
+    /// never given a chance.
+    pub fn enable(self: *Controller, baseline: Feedback) void {
         if (self.state != .disabled or self.failure != null) return;
         self.state = .testing;
-        self.testing_deadline_us = now_us +| testing_window_us;
+        self.seen = baseline;
     }
 
     /// Stop marking on this path. Used both by validation failures here and by
@@ -210,17 +220,31 @@ pub const Controller = struct {
         self.testing_deadline_us = null;
     }
 
-    /// One datagram went out carrying `send_codepoint` on this path.
-    pub fn onMarkedSent(self: *Controller) void {
+    /// One packet went out carrying `send_codepoint` on this path.
+    ///
+    /// The first one arms the testing window: that is the moment something is
+    /// actually under test, and dating the deadline from `enable` instead
+    /// would time out an idle connection that had not yet sent a thing.
+    pub fn onMarkedSent(self: *Controller, now_us: u64, testing_window_us: u64) void {
+        if (self.state == .testing and self.marked_sent == 0) {
+            self.testing_deadline_us = now_us +| testing_window_us;
+        }
         self.marked_sent +|= 1;
     }
 
     /// Apply one ACK's worth of peer feedback.
     ///
     /// `newly_acked_marked` is how many packets *this ACK newly acknowledged*
-    /// that went out marked — the quantity RFC 9000 §13.4.2.1 requires the
-    /// reported counts to account for. `feedback` is null when the ACK frame
-    /// was a plain ACK rather than an ACK_ECN.
+    /// that went out marked **on this path** — the quantity RFC 9000 §13.4.2.1
+    /// requires the reported counts to account for. `feedback` is null when the
+    /// ACK frame was a plain ACK rather than an ACK_ECN.
+    ///
+    /// The caller must only call this for an ACK that advanced the largest
+    /// acknowledged packet number in the space. RFC 9000 §13.4.2.1 requires
+    /// that an ACK which does not is left alone entirely: the peer's counters
+    /// are cumulative, so a delayed ACK legitimately carries *older* ones, and
+    /// judging those against what has since been reported would read ordinary
+    /// reordering as hostile feedback. `Connection.processAck` owns that gate.
     ///
     /// Every rejection path here ends in `disable`, never in an error: the
     /// worst case for a false positive is a path that runs without ECN, which
@@ -229,9 +253,7 @@ pub const Controller = struct {
         self: *Controller,
         newly_acked_marked: u64,
         feedback: ?Feedback,
-        now_us: u64,
     ) Outcome {
-        _ = now_us;
         if (self.state == .disabled) return .{};
 
         const counts = feedback orelse {
@@ -243,35 +265,28 @@ pub const Controller = struct {
             return self.fail(.missing_counts);
         };
 
-        const baseline = self.seen orelse {
-            // First report on this path: adopt it as the origin rather than
-            // validating against it. The peer's counters are per packet number
-            // space and span every path it has used, so their absolute values
-            // are not a statement about this path — only their growth is.
-            self.seen = counts;
-            self.marked_at_baseline = self.marked_sent;
-            return .{};
-        };
+        // Nothing this endpoint ever sends is ECT(1), so a non-zero report is
+        // impossible for this connection whatever the baseline was. Checked as
+        // an absolute rather than as growth: a baseline adopted from a report
+        // that already contained ECT(1) would otherwise grandfather it in and
+        // let validation succeed on counters known to be rewritten.
+        if (counts.ect1 != 0) return self.fail(.unsent_codepoint);
 
-        if (counts.ect0 < baseline.ect0 or counts.ect1 < baseline.ect1 or counts.ce < baseline.ce) {
+        const baseline = self.seen;
+        if (counts.ect0 < baseline.ect0 or counts.ce < baseline.ce) {
             return self.fail(.counts_regressed);
         }
-        // Nothing this endpoint sends is ECT(1), so any ECT(1) growth means
-        // the codepoint is being rewritten somewhere on the path.
-        if (counts.ect1 > baseline.ect1) return self.fail(.unsent_codepoint);
 
         const ect0_increase = counts.ect0 - baseline.ect0;
         const ce_increase = counts.ce - baseline.ce;
         const marked_increase = ect0_increase +| ce_increase;
 
         // A peer cannot have received more marked packets than were marked.
-        // Checked cumulatively against the marks placed since the baseline, so
-        // it holds across reordered and delayed reports rather than only
-        // within one ACK.
-        const reported = self.reported_since_baseline +| marked_increase;
-        if (reported > self.marked_sent -| self.marked_at_baseline) {
-            return self.fail(.counts_exceed_sent);
-        }
+        // Checked cumulatively against every mark this path has placed — the
+        // baseline was taken before the first of them — so it holds across
+        // reports that arrive in batches rather than only within one ACK.
+        const reported = self.reported +| marked_increase;
+        if (reported > self.marked_sent) return self.fail(.counts_exceed_sent);
 
         // RFC 9000 §13.4.2.1: packets that went out marked and are now
         // acknowledged must show up in the counts. CE counts too — a marked
@@ -281,10 +296,18 @@ pub const Controller = struct {
         }
 
         self.seen = counts;
-        self.reported_since_baseline = reported;
+        self.reported = reported;
 
         var outcome = Outcome{};
-        if (self.state == .testing and marked_increase > 0) {
+        // Promotion needs evidence attributable to *this* path: an ACK that
+        // newly acknowledged a packet this path marked, and counter growth to
+        // go with it. Growth alone is not enough — the peer's counters are
+        // per packet number space and span every path it has been reached on,
+        // so an ACK covering another path's marks would otherwise validate a
+        // route that is quietly stripping every codepoint. The connection's
+        // epoch barrier is what makes this sufficient rather than merely
+        // necessary; see `Connection.syncPathEcn`.
+        if (self.state == .testing and newly_acked_marked > 0 and marked_increase > 0) {
             self.state = .capable;
             self.testing_deadline_us = null;
             outcome.validated = true;
@@ -338,217 +361,280 @@ pub const Controller = struct {
 // where the OS half is unavailable.
 // ---------------------------------------------------------------------------
 
-const testing_alloc = std.testing;
+const testing = std.testing;
 
-fn validatedController(now_us: u64) Controller {
+const no_counts = Feedback{ .ect0 = 0, .ect1 = 0, .ce = 0 };
+
+/// A path whose markings demonstrably survive: enabled from a clean baseline,
+/// two marks sent, both acknowledged and both counted.
+fn validatedController() Controller {
     var controller = Controller{};
-    controller.enable(now_us, 3 * 100_000);
-    // Baseline: the peer's counters already hold traffic from elsewhere.
-    controller.onMarkedSent();
-    _ = controller.onAck(0, .{ .ect0 = 40, .ect1 = 0, .ce = 7 }, now_us);
-    controller.onMarkedSent();
-    controller.onMarkedSent();
-    _ = controller.onAck(2, .{ .ect0 = 42, .ect1 = 0, .ce = 7 }, now_us);
+    controller.enable(no_counts);
+    controller.onMarkedSent(0, 300_000);
+    controller.onMarkedSent(0, 300_000);
+    _ = controller.onAck(2, .{ .ect0 = 2, .ect1 = 0, .ce = 0 });
     return controller;
 }
 
 test "ecn: received codepoints accumulate per space and drive ACK_ECN" {
     var counts = Counts{};
-    try testing_alloc.expect(!counts.any());
+    try testing.expect(!counts.any());
     counts.record(.not_ect);
     counts.record(.unavailable);
     // Neither an unmarked packet nor a receive path that cannot report is a
     // counter, so an ACK for this space is still a plain ACK.
-    try testing_alloc.expect(!counts.any());
+    try testing.expect(!counts.any());
 
     counts.record(.ect0);
     counts.record(.ect0);
     counts.record(.ce);
     counts.record(.ect1);
-    try testing_alloc.expect(counts.any());
-    try testing_alloc.expectEqual(@as(u64, 2), counts.ect0);
-    try testing_alloc.expectEqual(@as(u64, 1), counts.ect1);
-    try testing_alloc.expectEqual(@as(u64, 1), counts.ce);
+    try testing.expect(counts.any());
+    try testing.expectEqual(@as(u64, 2), counts.ect0);
+    try testing.expectEqual(@as(u64, 1), counts.ect1);
+    try testing.expectEqual(@as(u64, 1), counts.ce);
 
     counts.reset();
-    try testing_alloc.expect(!counts.any());
+    try testing.expect(!counts.any());
 }
 
 test "ecn: marking is off until enabled and never marks after failure" {
     var controller = Controller{};
-    try testing_alloc.expectEqual(udp.Ecn.not_ect, controller.sendCodepoint());
-    try testing_alloc.expect(!controller.marking());
+    try testing.expectEqual(udp.Ecn.not_ect, controller.sendCodepoint());
+    try testing.expect(!controller.marking());
 
-    controller.enable(0, 300_000);
-    try testing_alloc.expectEqual(udp.Ecn.ect0, controller.sendCodepoint());
-    try testing_alloc.expectEqual(State.testing, controller.state);
+    controller.enable(no_counts);
+    try testing.expectEqual(udp.Ecn.ect0, controller.sendCodepoint());
+    try testing.expectEqual(State.testing, controller.state);
 
     controller.disable(.missing_counts);
-    try testing_alloc.expectEqual(udp.Ecn.not_ect, controller.sendCodepoint());
+    try testing.expectEqual(udp.Ecn.not_ect, controller.sendCodepoint());
     // Re-enabling into a path already known to break ECN would re-run the
     // whole testing window on every poll and mark traffic that is being
     // dropped or stripped. Only a new path incarnation gets another try.
-    controller.enable(0, 300_000);
-    try testing_alloc.expectEqual(State.disabled, controller.state);
+    controller.enable(no_counts);
+    try testing.expectEqual(State.disabled, controller.state);
     controller.reset();
-    controller.enable(0, 300_000);
-    try testing_alloc.expectEqual(State.testing, controller.state);
+    controller.enable(no_counts);
+    try testing.expectEqual(State.testing, controller.state);
 }
 
-test "ecn: the first report is a baseline, not evidence" {
+test "ecn: the baseline is taken before the first mark, not from the first report" {
+    // The peer's counters already carry traffic from another path — they are
+    // per packet number space and survive migration — so the baseline is that
+    // history, snapshotted as this path starts marking.
     var controller = Controller{};
-    controller.enable(0, 300_000);
-    controller.onMarkedSent();
+    controller.enable(.{ .ect0 = 900, .ect1 = 0, .ce = 3 });
+    try testing.expectEqual(@as(u64, 900), controller.seen.ect0);
 
-    // The peer's counters already carry traffic from another path — its
-    // counts are per packet number space and survive migration. Treating that
-    // history as feedback about this path would validate it on the strength of
-    // packets this path never carried.
-    const first = controller.onAck(1, .{ .ect0 = 900, .ect1 = 0, .ce = 3 }, 1_000);
-    try testing_alloc.expect(!first.validated);
-    try testing_alloc.expectEqual(State.testing, controller.state);
-    try testing_alloc.expectEqual(@as(u64, 1), controller.marked_at_baseline);
+    controller.onMarkedSent(0, 300_000);
+    const first = controller.onAck(1, .{ .ect0 = 901, .ect1 = 0, .ce = 3 });
+    // Growth from that origin validates immediately: there is no wasted round
+    // trip spent adopting a baseline that was already known.
+    try testing.expect(first.validated);
+    try testing.expectEqual(State.capable, controller.state);
+}
 
-    // Growth from that origin is what counts.
-    controller.onMarkedSent();
-    const second = controller.onAck(1, .{ .ect0 = 901, .ect1 = 0, .ce = 3 }, 2_000);
-    try testing_alloc.expect(second.validated);
-    try testing_alloc.expectEqual(State.capable, controller.state);
+test "ecn: marks outstanding before the first report are still accounted for" {
+    // The regression behind taking the baseline at `enable`. Ten marked
+    // packets go out; the first ACK_ECN acknowledges only two of them.
+    var controller = Controller{};
+    controller.enable(no_counts);
+    var sent: usize = 0;
+    while (sent < 10) : (sent += 1) controller.onMarkedSent(0, 300_000);
+
+    const first = controller.onAck(2, .{ .ect0 = 2, .ect1 = 0, .ce = 0 });
+    try testing.expect(first.validated);
+    try testing.expectEqual(@as(?FailureReason, null), first.failed);
+
+    // The remaining eight are acknowledged in later batches, with no further
+    // sends. A baseline adopted from that first report would have written the
+    // eight off as never sent, and this honest growth would read as an
+    // over-claim — disabling ECN on a path that is working perfectly.
+    const second = controller.onAck(3, .{ .ect0 = 5, .ect1 = 0, .ce = 0 });
+    try testing.expectEqual(@as(?FailureReason, null), second.failed);
+    const third = controller.onAck(5, .{ .ect0 = 10, .ect1 = 0, .ce = 0 });
+    try testing.expectEqual(@as(?FailureReason, null), third.failed);
+    try testing.expectEqual(State.capable, controller.state);
+    try testing.expectEqual(@as(u64, 10), controller.reported);
+}
+
+test "ecn: a first report containing ECT(1) is rejected, not adopted" {
+    // This endpoint never sends ECT(1) at all, so the check is on the absolute
+    // value rather than on growth. Adopting a non-zero ECT(1) as the baseline
+    // would grandfather in counters already known to be rewritten, and every
+    // later report could then validate the path as long as ECT(1) held still.
+    var controller = Controller{};
+    controller.enable(no_counts);
+    controller.onMarkedSent(0, 300_000);
+    const outcome = controller.onAck(1, .{ .ect0 = 1, .ect1 = 4, .ce = 0 });
+    try testing.expectEqual(@as(?FailureReason, .unsent_codepoint), outcome.failed);
+    try testing.expectEqual(State.disabled, controller.state);
 }
 
 test "ecn: an ACK without counts for marked packets disables ECN" {
     var controller = Controller{};
-    controller.enable(0, 300_000);
-    controller.onMarkedSent();
+    controller.enable(no_counts);
+    controller.onMarkedSent(0, 300_000);
 
     // An ACK that acknowledges nothing we marked is not evidence either way.
-    const unrelated = controller.onAck(0, null, 1_000);
-    try testing_alloc.expectEqual(@as(?FailureReason, null), unrelated.failed);
-    try testing_alloc.expectEqual(State.testing, controller.state);
+    const unrelated = controller.onAck(0, null);
+    try testing.expectEqual(@as(?FailureReason, null), unrelated.failed);
+    try testing.expectEqual(State.testing, controller.state);
 
-    const stripped = controller.onAck(1, null, 2_000);
-    try testing_alloc.expectEqual(@as(?FailureReason, .missing_counts), stripped.failed);
-    try testing_alloc.expectEqual(State.disabled, controller.state);
-    try testing_alloc.expectEqual(udp.Ecn.not_ect, controller.sendCodepoint());
+    const stripped = controller.onAck(1, null);
+    try testing.expectEqual(@as(?FailureReason, .missing_counts), stripped.failed);
+    try testing.expectEqual(State.disabled, controller.state);
+    try testing.expectEqual(udp.Ecn.not_ect, controller.sendCodepoint());
+}
+
+test "ecn: promotion requires an acknowledgement of this path's own mark" {
+    // Counter growth alone must not validate: the counters are per packet
+    // number space and span every path the peer has been reached on, so growth
+    // with nothing of this path's acknowledged is somebody else's evidence.
+    var controller = Controller{};
+    controller.enable(no_counts);
+    controller.onMarkedSent(0, 300_000);
+    controller.onMarkedSent(0, 300_000);
+
+    // Growth arrives, but this ACK acknowledged none of this path's marks.
+    // Whatever produced that growth, it was not evidence about this route.
+    const foreign = controller.onAck(0, .{ .ect0 = 1, .ect1 = 0, .ce = 0 });
+    try testing.expect(!foreign.validated);
+    try testing.expectEqual(State.testing, controller.state);
+    try testing.expectEqual(@as(u64, 0), foreign.ce_increase);
+
+    // Growth *and* one of this path's own marks acknowledged: evidence at
+    // last.
+    const own = controller.onAck(1, .{ .ect0 = 2, .ect1 = 0, .ce = 0 });
+    try testing.expect(own.validated);
+    try testing.expectEqual(State.capable, controller.state);
 }
 
 test "ecn: CE reports reach congestion control only once validated" {
     var controller = Controller{};
-    controller.enable(0, 300_000);
-    controller.onMarkedSent();
-    _ = controller.onAck(0, .{ .ect0 = 0, .ect1 = 0, .ce = 0 }, 1_000);
+    controller.enable(no_counts);
+    controller.onMarkedSent(0, 300_000);
 
-    // Still `.testing`: a CE report here is unvalidated, and RFC 9000 §13.4.2
-    // is explicit that unvalidated feedback is forgeable. It promotes the path
-    // (a mark demonstrably survived) but must not double as a congestion
-    // signal on the strength of its own arrival.
-    controller.onMarkedSent();
-    const promoting = controller.onAck(1, .{ .ect0 = 0, .ect1 = 0, .ce = 1 }, 2_000);
-    try testing_alloc.expect(promoting.validated);
-    try testing_alloc.expectEqual(@as(u64, 1), promoting.ce_increase);
-    try testing_alloc.expectEqual(State.capable, controller.state);
+    // The promoting ACK: a mark demonstrably survived, and it arrived CE.
+    const promoting = controller.onAck(1, .{ .ect0 = 0, .ect1 = 0, .ce = 1 });
+    try testing.expect(promoting.validated);
+    try testing.expectEqual(@as(u64, 1), promoting.ce_increase);
+    try testing.expectEqual(State.capable, controller.state);
 
-    controller.onMarkedSent();
-    const congested = controller.onAck(1, .{ .ect0 = 0, .ect1 = 0, .ce = 2 }, 3_000);
-    try testing_alloc.expectEqual(@as(u64, 1), congested.ce_increase);
-    try testing_alloc.expectEqual(@as(u64, 2), controller.ce_observed);
+    controller.onMarkedSent(0, 300_000);
+    const congested = controller.onAck(1, .{ .ect0 = 0, .ect1 = 0, .ce = 2 });
+    try testing.expectEqual(@as(u64, 1), congested.ce_increase);
+    try testing.expectEqual(@as(u64, 2), controller.ce_observed);
 }
 
 test "ecn: counts that go backwards disable ECN" {
-    var controller = validatedController(0);
-    controller.onMarkedSent();
-    const outcome = controller.onAck(1, .{ .ect0 = 41, .ect1 = 0, .ce = 7 }, 5_000);
-    try testing_alloc.expectEqual(@as(?FailureReason, .counts_regressed), outcome.failed);
-    try testing_alloc.expectEqual(@as(u64, 0), outcome.ce_increase);
+    var controller = validatedController();
+    controller.onMarkedSent(0, 300_000);
+    const outcome = controller.onAck(1, .{ .ect0 = 1, .ect1 = 0, .ce = 0 });
+    try testing.expectEqual(@as(?FailureReason, .counts_regressed), outcome.failed);
+    try testing.expectEqual(@as(u64, 0), outcome.ce_increase);
 }
 
 test "ecn: a reported ECT(1) this endpoint never sends disables ECN" {
-    var controller = validatedController(0);
-    controller.onMarkedSent();
+    var controller = validatedController();
+    controller.onMarkedSent(0, 300_000);
     // Something on the path rewrote ECT(0) to ECT(1). The counts are no longer
     // describing what was sent, so nothing derived from them can be believed.
-    const outcome = controller.onAck(1, .{ .ect0 = 43, .ect1 = 1, .ce = 7 }, 5_000);
-    try testing_alloc.expectEqual(@as(?FailureReason, .unsent_codepoint), outcome.failed);
+    const outcome = controller.onAck(1, .{ .ect0 = 3, .ect1 = 1, .ce = 0 });
+    try testing.expectEqual(@as(?FailureReason, .unsent_codepoint), outcome.failed);
 }
 
 test "ecn: a peer cannot report more marked arrivals than were marked" {
-    var controller = validatedController(0);
-    controller.onMarkedSent();
-    // Three packets have been marked since the baseline. A report of twelve
-    // marked arrivals is arithmetic that cannot describe this connection —
-    // the classic way a forged or confused ACK_ECN would try to manufacture
-    // congestion signals.
-    const outcome = controller.onAck(1, .{ .ect0 = 52, .ect1 = 0, .ce = 7 }, 5_000);
-    try testing_alloc.expectEqual(@as(?FailureReason, .counts_exceed_sent), outcome.failed);
-    try testing_alloc.expectEqual(@as(u64, 0), outcome.ce_increase);
+    var controller = validatedController();
+    controller.onMarkedSent(0, 300_000);
+    // Three marked packets in total, and a report of twelve marked arrivals:
+    // arithmetic that cannot describe this connection, and the classic way a
+    // forged or confused ACK_ECN would try to manufacture congestion signals.
+    const outcome = controller.onAck(1, .{ .ect0 = 12, .ect1 = 0, .ce = 0 });
+    try testing.expectEqual(@as(?FailureReason, .counts_exceed_sent), outcome.failed);
+    try testing.expectEqual(@as(u64, 0), outcome.ce_increase);
 }
 
 test "ecn: marks cleared in flight disable ECN" {
     var controller = Controller{};
-    controller.enable(0, 300_000);
-    controller.onMarkedSent();
-    _ = controller.onAck(0, .{ .ect0 = 0, .ect1 = 0, .ce = 0 }, 1_000);
+    controller.enable(no_counts);
 
     // Four marked packets acknowledged, and the peer saw none of them marked:
     // a middlebox is clearing the codepoint (RFC 9000 §13.4.2.1).
-    controller.onMarkedSent();
-    controller.onMarkedSent();
-    controller.onMarkedSent();
-    controller.onMarkedSent();
-    const outcome = controller.onAck(4, .{ .ect0 = 0, .ect1 = 0, .ce = 0 }, 2_000);
-    try testing_alloc.expectEqual(@as(?FailureReason, .insufficient_increase), outcome.failed);
-    try testing_alloc.expectEqual(State.disabled, controller.state);
+    var sent: usize = 0;
+    while (sent < 4) : (sent += 1) controller.onMarkedSent(0, 300_000);
+    const outcome = controller.onAck(4, no_counts);
+    try testing.expectEqual(@as(?FailureReason, .insufficient_increase), outcome.failed);
+    try testing.expectEqual(State.disabled, controller.state);
 }
 
 test "ecn: a CE-marked delivery still accounts for its packet" {
     var controller = Controller{};
-    controller.enable(0, 300_000);
-    controller.onMarkedSent();
-    _ = controller.onAck(0, .{ .ect0 = 0, .ect1 = 0, .ce = 0 }, 1_000);
+    controller.enable(no_counts);
+    controller.onMarkedSent(0, 300_000);
+    controller.onMarkedSent(0, 300_000);
 
     // Two marked packets acknowledged; one arrived ECT(0), the other met
     // congestion and arrived CE. The ECT(0) count alone is short of the two
     // acknowledged, so validation must count CE as well or every congested
     // path would look like a broken one.
-    controller.onMarkedSent();
-    controller.onMarkedSent();
-    const outcome = controller.onAck(2, .{ .ect0 = 1, .ect1 = 0, .ce = 1 }, 2_000);
-    try testing_alloc.expectEqual(@as(?FailureReason, null), outcome.failed);
-    try testing_alloc.expect(outcome.validated);
-    try testing_alloc.expectEqual(@as(u64, 1), outcome.ce_increase);
+    const outcome = controller.onAck(2, .{ .ect0 = 1, .ect1 = 0, .ce = 1 });
+    try testing.expectEqual(@as(?FailureReason, null), outcome.failed);
+    try testing.expect(outcome.validated);
+    try testing.expectEqual(@as(u64, 1), outcome.ce_increase);
+}
+
+test "ecn: the testing window is armed by the first mark, not by enabling" {
+    // A handshake-confirmed connection can sit idle. Arming at `enable` would
+    // let three PTOs of silence record a permanent `testing_timeout` on a path
+    // that was never given a chance to carry a single marked packet.
+    var controller = Controller{};
+    controller.enable(no_counts);
+    try testing.expectEqual(@as(?u64, null), controller.deadlineUs());
+    try testing.expectEqual(@as(?FailureReason, null), controller.onTimeout(10_000_000));
+    try testing.expectEqual(State.testing, controller.state);
+
+    // The first mark starts the clock, dated from when it actually went out.
+    controller.onMarkedSent(10_000_000, 300_000);
+    try testing.expectEqual(@as(?u64, 10_300_000), controller.deadlineUs());
+    // Later marks do not push the deadline out, or a busy path that strips
+    // every codepoint would never stop being tested.
+    controller.onMarkedSent(10_200_000, 300_000);
+    try testing.expectEqual(@as(?u64, 10_300_000), controller.deadlineUs());
 }
 
 test "ecn: the testing window closes on silence" {
     var controller = Controller{};
-    controller.enable(1_000, 300_000);
-    controller.onMarkedSent();
-    try testing_alloc.expectEqual(@as(?u64, 301_000), controller.deadlineUs());
+    controller.enable(no_counts);
+    controller.onMarkedSent(1_000, 300_000);
+    try testing.expectEqual(@as(?u64, 301_000), controller.deadlineUs());
 
-    try testing_alloc.expectEqual(@as(?FailureReason, null), controller.onTimeout(300_999));
-    try testing_alloc.expectEqual(State.testing, controller.state);
+    try testing.expectEqual(@as(?FailureReason, null), controller.onTimeout(300_999));
+    try testing.expectEqual(State.testing, controller.state);
 
-    try testing_alloc.expectEqual(@as(?FailureReason, .testing_timeout), controller.onTimeout(301_000));
-    try testing_alloc.expectEqual(State.disabled, controller.state);
-    try testing_alloc.expectEqual(@as(?u64, null), controller.deadlineUs());
+    try testing.expectEqual(@as(?FailureReason, .testing_timeout), controller.onTimeout(301_000));
+    try testing.expectEqual(State.disabled, controller.state);
+    try testing.expectEqual(@as(?u64, null), controller.deadlineUs());
     // Idempotent: a later timeout on a path that already gave up is silent.
-    try testing_alloc.expectEqual(@as(?FailureReason, null), controller.onTimeout(999_999));
+    try testing.expectEqual(@as(?FailureReason, null), controller.onTimeout(999_999));
 }
 
 test "ecn: validation clears the testing deadline" {
-    var controller = validatedController(0);
-    try testing_alloc.expectEqual(State.capable, controller.state);
-    try testing_alloc.expectEqual(@as(?u64, null), controller.deadlineUs());
+    var controller = validatedController();
+    try testing.expectEqual(State.capable, controller.state);
+    try testing.expectEqual(@as(?u64, null), controller.deadlineUs());
     // A validated path is never retired by the testing timer.
-    try testing_alloc.expectEqual(@as(?FailureReason, null), controller.onTimeout(std.math.maxInt(u64)));
-    try testing_alloc.expectEqual(State.capable, controller.state);
+    try testing.expectEqual(@as(?FailureReason, null), controller.onTimeout(std.math.maxInt(u64)));
+    try testing.expectEqual(State.capable, controller.state);
 }
 
 test "ecn: a disabled controller ignores feedback entirely" {
     var controller = Controller{};
     // Nothing enabled marking, so nothing was marked, so no report about this
     // path can mean anything — including one claiming congestion.
-    const outcome = controller.onAck(5, .{ .ect0 = 5, .ect1 = 0, .ce = 5 }, 1_000);
-    try testing_alloc.expectEqual(@as(u64, 0), outcome.ce_increase);
-    try testing_alloc.expectEqual(@as(?FailureReason, null), outcome.failed);
-    try testing_alloc.expectEqual(State.disabled, controller.state);
+    const outcome = controller.onAck(5, .{ .ect0 = 5, .ect1 = 0, .ce = 5 });
+    try testing.expectEqual(@as(u64, 0), outcome.ce_increase);
+    try testing.expectEqual(@as(?FailureReason, null), outcome.failed);
+    try testing.expectEqual(State.disabled, controller.state);
 }

--- a/src/quic/frame.zig
+++ b/src/quic/frame.zig
@@ -391,8 +391,31 @@ pub fn encodeStream(id: stream.StreamId, offset: u64, data: []const u8, fin: boo
 pub const max_stream_overhead = 1 + 8 + 8 + 8;
 
 pub fn encodeAck(model: recovery.AckFrameModel, ack_delay_exponent: u6, buf: []u8) EncodeError!usize {
+    return encodeAckFrame(model, null, ack_delay_exponent, buf);
+}
+
+/// RFC 9000 §19.3.2: the same ACK frame under type 0x03, with this endpoint's
+/// received ECN counters appended (#256-E). Required rather than optional once
+/// any marked packet has been received in the space — the peer's ECN validation
+/// is built on these counts, and an ACK that omits them after a marked arrival
+/// is exactly what tells the peer its marks are being stripped.
+pub fn encodeAckEcn(
+    model: recovery.AckFrameModel,
+    counts: Ecn,
+    ack_delay_exponent: u6,
+    buf: []u8,
+) EncodeError!usize {
+    return encodeAckFrame(model, counts, ack_delay_exponent, buf);
+}
+
+fn encodeAckFrame(
+    model: recovery.AckFrameModel,
+    counts: ?Ecn,
+    ack_delay_exponent: u6,
+    buf: []u8,
+) EncodeError!usize {
     var w = FrameWriter{ .buf = buf };
-    try w.int(frame_ack);
+    try w.int(if (counts == null) frame_ack else frame_ack_ecn);
     try w.int(model.largest_acknowledged);
     try w.int(model.ack_delay_us >> ack_delay_exponent);
     try w.int(model.range_count);
@@ -400,6 +423,11 @@ pub fn encodeAck(model: recovery.AckFrameModel, ack_delay_exponent: u6, buf: []u
     for (model.ranges[0..model.range_count]) |range| {
         try w.int(range.gap);
         try w.int(range.length);
+    }
+    if (counts) |ecn| {
+        try w.int(ecn.ect0);
+        try w.int(ecn.ect1);
+        try w.int(ecn.ce);
     }
     return w.pos;
 }
@@ -575,6 +603,33 @@ test "ACK frame with ECN counts parses" {
     try testing.expectEqual(@as(u64, 1), decoded.frame.ack.ecn.?.ect0);
     try testing.expectEqual(@as(u64, 3), decoded.frame.ack.ecn.?.ce);
     try testing.expectEqual(bytes.len, decoded.len);
+}
+
+test "ACK_ECN roundtrips the received counters alongside the ranges (#256-E)" {
+    var set = recovery.AckRangeSet{};
+    try set.insertRange(.{ .first = 1, .last = 2 });
+    try set.insertRange(.{ .first = 5, .last = 9 });
+    const model = set.toAckFrame(1_000).?;
+
+    var buf: [64]u8 = undefined;
+    const len = try encodeAckEcn(model, .{ .ect0 = 17, .ect1 = 0, .ce = 4 }, 3, &buf);
+    // The ECN counters ride on top of an otherwise identical frame, so the
+    // type byte is the only structural difference from a plain ACK.
+    try testing.expectEqual(@as(u8, frame_ack_ecn), buf[0]);
+    const decoded = try roundtripOne(buf[0..len]);
+    const ack = decoded.ack;
+    try testing.expectEqual(@as(u64, 9), ack.largest_acknowledged);
+    try testing.expect(ack.ranges.contains(1));
+    try testing.expect(ack.ranges.contains(9));
+    try testing.expectEqual(@as(u64, 17), ack.ecn.?.ect0);
+    try testing.expectEqual(@as(u64, 0), ack.ecn.?.ect1);
+    try testing.expectEqual(@as(u64, 4), ack.ecn.?.ce);
+
+    // And a plain ACK still reports no counters at all, rather than zeros —
+    // the peer's validation has to tell "nothing marked arrived" apart from
+    // "this endpoint is not reporting".
+    const plain_len = try encodeAck(model, 3, &buf);
+    try testing.expectEqual(@as(?Ecn, null), (try roundtripOne(buf[0..plain_len])).ack.ecn);
 }
 
 test "malformed ACK ranges fail deterministically" {

--- a/src/quic/path.zig
+++ b/src/quic/path.zig
@@ -1986,11 +1986,9 @@ test "ECN state is per path incarnation and is never inherited across migration 
     const handshake_ref = manager.activePathRef();
 
     // The handshake path validated ECN: markings survive it end to end.
-    manager.activeEcn().enable(0, 300_000);
-    manager.activeEcn().onMarkedSent();
-    _ = manager.activeEcn().onAck(0, .{ .ect0 = 0, .ect1 = 0, .ce = 0 }, 0);
-    manager.activeEcn().onMarkedSent();
-    _ = manager.activeEcn().onAck(1, .{ .ect0 = 1, .ect1 = 0, .ce = 0 }, 0);
+    manager.activeEcn().enable(.{ .ect0 = 0, .ect1 = 0, .ce = 0 });
+    manager.activeEcn().onMarkedSent(0, 300_000);
+    _ = manager.activeEcn().onAck(1, .{ .ect0 = 1, .ect1 = 0, .ce = 0 });
     try testing.expectEqual(ecn_mod.State.capable, manager.activePath().ecn.state);
 
     // Migrate to a different host. Whether ECN survives is a property of the

--- a/src/quic/path.zig
+++ b/src/quic/path.zig
@@ -19,6 +19,7 @@ const std = @import("std");
 const config = @import("config.zig");
 const packet = @import("packet.zig");
 const pmtu = @import("pmtu.zig");
+const ecn_mod = @import("ecn.zig");
 const udp = @import("udp.zig");
 const secrets = @import("crypto_secrets");
 
@@ -519,6 +520,13 @@ pub const Path = struct {
     /// slot therefore starts from the RFC 9000 §14 floor by construction —
     /// there is no inherit-the-old-value path to get wrong.
     plpmtu: pmtu.Controller = .{},
+    /// ECN state for *this* path (#256-E). Path-scoped for the same reason
+    /// `plpmtu` is: whether ECN codepoints survive end to end is a property of
+    /// the route, and a path that strips them says nothing about the next one.
+    /// RFC 9000 §13.4.2 requires exactly this — ECN is re-validated on a new
+    /// path — and a fresh or recycled slot gets a fresh controller by
+    /// construction, including one whose predecessor failed validation.
+    ecn: ecn_mod.Controller = .{},
 };
 
 /// The action the connection takes for a datagram from a given tuple.
@@ -616,6 +624,27 @@ pub const PathManager = struct {
     /// discovery model requires.
     pub fn activePlpmtu(self: *PathManager) *pmtu.Controller {
         return &self.paths[self.active].?.plpmtu;
+    }
+
+    /// The active path's ECN state (#256-E), for the send path that stamps a
+    /// codepoint onto the next datagram. Reached through the active slot for
+    /// the same reason as `activePlpmtu`: promoting a different path swaps in
+    /// that path's own validation state rather than carrying one over.
+    pub fn activeEcn(self: *PathManager) *ecn_mod.Controller {
+        return &self.paths[self.active].?.ecn;
+    }
+
+    /// The ECN state of a *specific* path incarnation, or null when that
+    /// incarnation is gone. This is the accessor ACK feedback must use, for
+    /// the reason spelled out on `plpmtuFor`: an acknowledgement can arrive
+    /// after a different path became active, and crediting its ECN counters to
+    /// whatever is active now would validate a route on the strength of marks
+    /// that traversed another one.
+    pub fn ecnFor(self: *PathManager, ref: PathRef) ?*ecn_mod.Controller {
+        const index = self.find(ref.key) orelse return null;
+        const path = &self.paths[index].?;
+        if (path.generation != ref.generation) return null;
+        return &path.ecn;
     }
 
     /// The active path's current incarnation, for stamping onto outbound
@@ -1950,4 +1979,40 @@ test "pendingPromotionCandidate finds a validated-but-unpromoted path and clears
 
     _ = manager.promoteValidated(candidate).?;
     try testing.expectEqual(@as(?PathKey, null), manager.pendingPromotionCandidate());
+}
+
+test "ECN state is per path incarnation and is never inherited across migration (#256-E)" {
+    var manager = PathManager.init(.full, testKey(50_000), true);
+    const handshake_ref = manager.activePathRef();
+
+    // The handshake path validated ECN: markings survive it end to end.
+    manager.activeEcn().enable(0, 300_000);
+    manager.activeEcn().onMarkedSent();
+    _ = manager.activeEcn().onAck(0, .{ .ect0 = 0, .ect1 = 0, .ce = 0 }, 0);
+    manager.activeEcn().onMarkedSent();
+    _ = manager.activeEcn().onAck(1, .{ .ect0 = 1, .ect1 = 0, .ce = 0 }, 0);
+    try testing.expectEqual(ecn_mod.State.capable, manager.activePath().ecn.state);
+
+    // Migrate to a different host. Whether ECN survives is a property of the
+    // route, so the new path starts from scratch — an inherited `.capable`
+    // would mark traffic into a path nothing has shown can carry a codepoint,
+    // and would accept its CE reports as congestion on that basis.
+    const candidate = testKeyOtherHost(50_000);
+    _ = manager.onDatagram(candidate, 100, test_challenge, 0);
+    _ = manager.validatePathResponse(candidate, test_challenge, 0);
+    _ = manager.promoteValidated(candidate);
+    try testing.expect(manager.activePath().key.eql(candidate));
+    try testing.expectEqual(ecn_mod.State.disabled, manager.activePath().ecn.state);
+    try testing.expectEqual(@as(?ecn_mod.FailureReason, null), manager.activePath().ecn.failure);
+    try testing.expectEqual(udp.Ecn.not_ect, manager.activePath().ecn.sendCodepoint());
+
+    // The old incarnation's state is still reachable by its own ref, so
+    // feedback for packets it sent resolves there rather than teaching the new
+    // path about a route it has never been on.
+    try testing.expectEqual(ecn_mod.State.capable, manager.ecnFor(handshake_ref).?.state);
+    // And a ref naming an incarnation that no longer exists resolves nowhere.
+    try testing.expectEqual(
+        @as(?*ecn_mod.Controller, null),
+        manager.ecnFor(.{ .key = candidate, .generation = 9_999 }),
+    );
 }

--- a/src/quic/recovery.zig
+++ b/src/quic/recovery.zig
@@ -556,8 +556,21 @@ pub const CongestionController = struct {
     pub fn onPacketsLost(self: *CongestionController, largest_lost_time_sent_us: u64, lost_bytes: usize, now_us: u64) void {
         if (lost_bytes == 0) return;
         self.bytes_in_flight -|= lost_bytes;
+        self.onCongestionEvent(largest_lost_time_sent_us, now_us);
+    }
+
+    /// RFC 9002 §7.1/§B.5: halve the window and enter recovery, without
+    /// touching the in-flight ledger.
+    ///
+    /// Split out for the ECN-CE case (#256-E), which is congestion evidence
+    /// about a packet that *arrived*: its bytes were already released when it
+    /// was acknowledged, and reclaiming them a second time here would
+    /// under-count what is on the wire. The one-recovery-period-per-event rule
+    /// is shared with loss, so a CE report and a loss for the same round trip
+    /// halve the window once between them rather than twice.
+    pub fn onCongestionEvent(self: *CongestionController, sent_time_us: u64, now_us: u64) void {
         if (self.recovery_start_time_us) |start| {
-            if (largest_lost_time_sent_us <= start) return;
+            if (sent_time_us <= start) return;
         }
         self.recovery_start_time_us = now_us;
         self.congestion_window = @max(self.congestion_window / 2, self.minWindow());

--- a/src/quic/root.zig
+++ b/src/quic/root.zig
@@ -15,6 +15,7 @@ pub const recovery = @import("recovery.zig");
 pub const cid = @import("cid.zig");
 pub const path = @import("path.zig");
 pub const pmtu = @import("pmtu.zig");
+pub const ecn = @import("ecn.zig");
 pub const stream = @import("stream.zig");
 pub const qlog = @import("qlog.zig");
 pub const keylog = @import("keylog.zig");

--- a/tests/h3_interop_tool.zig
+++ b/tests/h3_interop_tool.zig
@@ -72,6 +72,14 @@ fn logEvent(_: ?*anyopaque, event: connection.Event) void {
         .path_migration_blocked => |p| std.fmt.bufPrint(&buf, "path blocked change={s} reason={s} remote_port={d}", .{ @tagName(p.change), @tagName(p.reason), p.path.remote.port }),
         .path_promoted => |p| std.fmt.bufPrint(&buf, "path promoted change={s} remote_port={d}", .{ @tagName(p.change), p.path.remote.port }),
         .pmtu_updated => |p| std.fmt.bufPrint(&buf, "pmtu {s} size={d} remote_port={d}", .{ @tagName(p.reason), p.size, p.path.remote.port }),
+        // #256-E: the reason is what makes an interop transcript useful here.
+        // "ECN turned off" is the expected outcome against a lot of real
+        // networks, and which check rejected the peer's feedback is the
+        // difference between a stripped codepoint and a peer that miscounts.
+        .ecn_state_changed => |e| if (e.reason) |reason|
+            std.fmt.bufPrint(&buf, "ecn {s} reason={s} remote_port={d}", .{ @tagName(e.state), @tagName(reason), e.path.remote.port })
+        else
+            std.fmt.bufPrint(&buf, "ecn {s} remote_port={d}", .{ @tagName(e.state), e.path.remote.port }),
         .zero_rtt_packet => |z| std.fmt.bufPrint(&buf, "zero_rtt_packet outcome={s} size={d}", .{ @tagName(z.outcome), z.size }),
         .early_data_decision => |d| std.fmt.bufPrint(&buf, "early_data_decision {s}", .{@tagName(d)}),
     } catch return;


### PR DESCRIPTION
## Summary

The ECN wire pieces already existed on `main` — `udp.Ecn` named the four IP
codepoints and `frame.zig` parsed/encoded ACK_ECN — but nothing decided
anything with them. No packet was ever marked, no received codepoint was ever
counted, no ACK_ECN was ever generated, and a peer's reported counters went
nowhere. This is the missing half.

- **`src/quic/ecn.zig`** (new) — received counters per packet number space
  (RFC 9000 §13.4.1) and a per-path controller that marks ECT(0), then
  validates the peer's feedback. Pure state machine, no I/O.
- **`src/quic/connection.zig`** — ACK_ECN generation once any marked packet
  arrives in a space; per-packet `ecn_marked` on sent records; validation on
  ACK receipt; CE as an RFC 9002 §7.1 congestion event; a testing-window
  timer; `Transmit.ecn` for the socket layer. `ingestOnPathWithEcn` is the new
  entry point; `ingestOnPath` stays as the honest "this socket cannot see
  codepoints" form, which is `.unavailable` and deliberately *not* `.not_ect`.
- **`src/quic/path.zig`** — one ECN controller per path incarnation, alongside
  the PMTU controller and for the same reason.
- **`src/quic/recovery.zig`** — `onCongestionEvent` split out of
  `onPacketsLost`, since a CE report is congestion about a packet that
  *arrived* and must not reclaim in-flight bytes a second time.
- **`src/http/http3_runtime.zig`** — the real socket half: `IP_RECVTOS` /
  `IPV6_RECVTCLASS` at bind, `recvmsg`/`sendmsg` with ancillary data per
  datagram. Not a socket-wide `IP_TOS`, because ECN is validated per path and
  there would be no way to stop marking on the one path that failed.

### Trust

The peer's ACK_ECN counters are an input to congestion control, reachable by
anything on the path and by the peer itself, so they are never taken at face
value. Marking stops on that path when counters regress, when more marked
arrivals are reported than were ever marked, when ECT(1) appears (never sent
here), when acknowledged marked packets show no matching counter growth, or
when the testing window closes on silence. CE drives congestion response only
on a *validated* path, and the counters this endpoint reports back come only
from packets that passed AEAD — an off-path spoofer cannot inflate them.

Every failure ends in ordinary non-ECN operation, never a connection error.
`ecn_paths_disabled` being non-zero on the open internet is expected.

### Platform gating

Verified per-OS constants only (Linux, Darwin, FreeBSD); anywhere else the
listener runs without ECN rather than guessing — same rule as the
no-fragmentation table from #256-B.

One finding worth flagging: **Darwin aligns control messages to 4 bytes**
(`__DARWIN_ALIGN32`), not the platform word. Assuming otherwise reads the ECN
payload four bytes past where the kernel wrote it, so every received codepoint
comes back `.unavailable` and ECN looks like a network problem on every macOS
host. The state-machine tests all pass with that bug present, which is why
there is a loopback test pinning it against a real kernel.

### Operator surface

`TARDIGRADE_HTTP3_ECN` (default `true`) disables marking outright — the escape
hatch for the one failure mode per-path validation cannot see, a middlebox that
*drops* marked traffic rather than clearing the marks. Restart-required, and
enforced in `http3ListenerConfigChanged`. The runtime snapshot publishes
whether marking is actually running plus marked-sent, validated-path,
disabled-path, and CE counts.

## Test plan

- [x] `zig build test` — 3630 pass, 10 skipped (same 10 as `main`; nothing new
      skips), `zig fmt --check src/` clean
- [x] `ecn.zig`: baseline adoption, validation, regression, over-claim,
      unsent-codepoint, cleared-marks, CE-counts-toward-validation, testing
      timeout, disabled-controller inertness — deterministic, platform-neutral
- [x] `frame.zig`: ACK_ECN encode/decode roundtrip; a plain ACK still reports
      *no* counters rather than zeros
- [x] `connection.zig`: end-to-end validation over a modelled network that
      preserves / clears / rewrites / CE-marks codepoints; congestion response
      on CE; forged over-claim rejected with the window untouched; counters
      only from authenticated packets; `.unavailable` counts nothing; testing
      window closes on silence; handshake-space ACK counters ignored
- [x] `path.zig`: ECN state is per path incarnation and not inherited across
      migration; stale refs resolve nowhere
- [x] `http3_runtime.zig`: platform table, ECN-field extraction, malformed and
      unrelated control messages, and **a real loopback socket** — a marked
      datagram arrives ECT(0), an unmarked one arrives `.not_ect`. Both ran
      (did not skip) on macOS in this run.

Not in scope: batching/GSO/GRO design notes (#256-F) and the H3 benchmark
matrix (#256-G). The snapshot counters this adds are what #256-G will record.

Part of #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)