### PR TITLE
docs: document reload, drain, and shutdown behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ operate without guessing which config file or pid file is active.
 | Concurrency & hot-path audit | [docs/CONCURRENCY.md](docs/CONCURRENCY.md) |
 | Event-loop backend evaluation (epoll/kqueue vs libxev/std.Io/io_uring) | [docs/EVENT_LOOP_BACKENDS.md](docs/EVENT_LOOP_BACKENDS.md) |
 | Observability | [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) |
+| Reload, drain, and shutdown | [docs/RELOAD_SHUTDOWN.md](docs/RELOAD_SHUTDOWN.md) |
 | Proxy security | [docs/PROXY_SECURITY.md](docs/PROXY_SECURITY.md) |
 | Security test plan | [docs/SECURITY_TEST_PLAN.md](docs/SECURITY_TEST_PLAN.md) |
 | TLS interop & conformance matrix | [docs/TLS_INTEROP_MATRIX.md](docs/TLS_INTEROP_MATRIX.md) |

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -473,33 +473,33 @@ dropping connections:
 1. **Load** the new configuration from the environment / config file.
 2. **Validate** it. Invalid configuration is rejected here.
 3. **Install** the new config version through a lease-counted store
-   (`ReloadableConfigStore`): in-flight requests keep the config version they
-   started with, and the old version is retired only after its last lease is
-   released. New requests pick up the new version once installation completes.
+   (`ReloadableConfigStore`): in-flight requests keep their request-scoped config
+   lease, and the old version is retired only after its last lease is released.
+   New requests pick up the new version once installation completes.
 
 Guarantees:
 
-- **A failed reload never replaces the active config.** If load or validation
-  fails, the previous configuration stays active and continues serving traffic;
-  the failure is recorded and logged.
-- **In-flight requests are not disrupted** by a reload; they finish on the
-  config they began with.
+- **A failed reload before config publication keeps the previous published
+  config active** for request routing and config leases; the failure is recorded
+  and logged. Reload-owned runtime resources are not fully transactional.
+- **In-flight requests are not dropped** by a reload; they keep their
+  request-scoped config lease but can observe reloaded process-shared policy.
 - Reload status is queryable at `GET /tardigrade/reload/status`, which returns
   `{"ok": <bool|null>, "at_ms": <ts>, "error": <string|null>}`.
 
 ### Graceful shutdown and drain
 
-On a shutdown signal the accept loop stops taking new connections and the worker
-pool drains:
+On a shutdown signal the accept loop stops taking new TCP connections and the
+TCP worker pool drains:
 
-- **Active (already-dispatched) requests are allowed to finish** up to
-  `TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS`. During shutdown each request's deadline
-  is also capped to the remaining drain window so a single slow request cannot
-  block shutdown indefinitely.
-- **Queued (not-yet-started) connections** that remain when the drain deadline
-  elapses are **force-closed** (their sockets are closed; no partial HTTP
-  response is emitted). A drain timeout of `0` closes queued connections
-  immediately with no wait.
+- **Active (already-dispatched) TCP handlers are allowed to finish** naturally.
+  Requests whose handler starts after shutdown has been requested cap their
+  request deadline to the drain window when no stricter deadline exists.
+- **Queued, queue-owned, not-yet-started TCP accepted sockets** that remain when
+  the drain deadline elapses are **force-closed**. A drain timeout of `0`
+  abandons queued jobs immediately and closes queue-owned accepted sockets.
+- Native HTTP/3 uses the same timeout as a hard H3 drain deadline; H3 deadline
+  expiry is not folded into the TCP worker-pool drain timeout metric.
 - After the drain completes the worker threads are joined and the process exits.
 
 ### Reload / shutdown observability
@@ -510,8 +510,8 @@ Logs (runtime, via `src/http/logger.zig`):
 - `config reload failed during load` / `config reload rejected by validation` /
   `config reload allocation failed` / `config reload bookkeeping failed`
 - `Shutdown requested; draining active connection work (timeout=… active_connections=…)`
-- `drain timeout elapsed; force-closed N queued connection(s)`
-- `Graceful shutdown complete (forced_closes=… drain_timed_out=…)`
+- `drain timeout elapsed; force-closed N queued connection(s)` (TCP worker-pool timeout)
+- `Graceful shutdown complete (forced_closes=… drain_timed_out=…)` (TCP worker-pool outcome)
 
 Metrics (`/status/metrics`):
 
@@ -521,8 +521,8 @@ Metrics (`/status/metrics`):
 | `tardigrade_reload_success_total` | Reloads that loaded, validated, and installed. |
 | `tardigrade_reload_failure_total` | Reloads rejected; previous config kept. |
 | `tardigrade_drain_total` | Graceful-shutdown drains started. |
-| `tardigrade_drain_timeouts_total` | Drains that hit the drain timeout. |
-| `tardigrade_drain_forced_closes_total` | Queued connections force-closed on drain timeout. |
+| `tardigrade_drain_timeouts_total` | TCP worker-pool drains that reached a positive drain deadline before worker jobs finished; does not report native H3 deadline expiry. |
+| `tardigrade_drain_forced_closes_total` | Queue-owned unstarted TCP accepted sockets closed on worker drain expiry or an immediate zero-timeout shutdown. |
 
 A healthy reload increments `reload_attempts_total` and `reload_success_total`
 together; a rejected reload increments `reload_attempts_total` and

--- a/docs/RELOAD_SHUTDOWN.md
+++ b/docs/RELOAD_SHUTDOWN.md
@@ -146,7 +146,7 @@ Shutdown refuses new QUIC connections, sends H3 GOAWAY, and rejects new request
 streams past the drain boundary. Existing H3 work may complete before the
 deadline; remaining H3 connections are closed when the deadline expires.
 
-Expected shutdown logs include:
+Expected TCP worker-pool shutdown logs include:
 
 ```text
 Shutdown requested; draining active connection work (timeout=30000ms active_connections=...)
@@ -158,10 +158,10 @@ Related knobs:
 
 | Env var | Default | Effect |
 | --- | ---: | --- |
-| `TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS` | `30000` | TCP worker-pool drain window and native HTTP/3 drain deadline for graceful shutdown. |
-| `TARDIGRADE_WORKER_THREADS` | `0` | Worker thread count; `0` uses the runtime default. |
-| `TARDIGRADE_WORKER_QUEUE_SIZE` | `1024` | Worker queue capacity. |
-| `TARDIGRADE_WORKER_MAX_QUEUE_DEPTH` | `0` | Optional per-worker queue depth cap (`0` means unlimited beyond queue capacity behavior). |
+| `TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS` | `30000` | TCP worker-pool drain window and native HTTP/3 drain deadline for graceful shutdown. The final shutdown path uses the startup value; hot reload can publish a different request-scoped value, but the process drain/H3 deadline still requires restart to change coherently today. |
+| `TARDIGRADE_WORKER_THREADS` | `0` | Startup-owned worker thread count; `0` uses the runtime default. Restart required to change. |
+| `TARDIGRADE_WORKER_QUEUE_SIZE` | `1024` | Startup-owned worker queue capacity. Restart required to change. |
+| `TARDIGRADE_WORKER_MAX_QUEUE_DEPTH` | `0` | Startup-owned optional per-worker queue depth cap (`0` means unlimited beyond queue capacity behavior). Restart required to change. |
 
 Related references:
 
@@ -214,8 +214,8 @@ the configured metrics path, `/status/metrics` by default:
 | `tardigrade_reload_success_total` | Reloads successfully installed. |
 | `tardigrade_reload_failure_total` | Reloads rejected; previous config kept. |
 | `tardigrade_drain_total` | Graceful-shutdown drains started. |
-| `tardigrade_drain_timeouts_total` | Drains that reached the drain timeout. |
-| `tardigrade_drain_forced_closes_total` | Queued connections force-closed after drain timeout. |
+| `tardigrade_drain_timeouts_total` | TCP worker-pool drains that reached a positive drain deadline before worker jobs finished; does not report native H3 deadline expiry. |
+| `tardigrade_drain_forced_closes_total` | Queue-owned unstarted TCP accepted sockets closed on worker drain expiry or an immediate zero-timeout shutdown. |
 | `tardigrade_active_connections` | Currently accepted downstream connections. |
 | `tardigrade_worker_active_jobs` | Worker jobs currently running. |
 | `tardigrade_worker_queued_jobs` | Worker jobs waiting in queues. |

--- a/docs/RELOAD_SHUTDOWN.md
+++ b/docs/RELOAD_SHUTDOWN.md
@@ -61,9 +61,11 @@ keep a lease on the config version they started with and are allowed to finish o
 that version. Reload does not drain worker jobs, stop the listener, or close
 active client connections.
 
-If load, validation, allocation, bookkeeping, credential preparation, or another
-reload preflight fails, the active config is left in place. The failed config is
-not partially installed. Operators can inspect the last result through:
+If reload fails before config publication, the previously published config
+remains active for request routing and config leases. Reload-owned runtime
+resources are not fully transactional: a runtime update performed before a later
+failure may remain in effect even though the new config is not published.
+Operators can inspect the last result through:
 
 ```bash
 curl http://127.0.0.1:8080/tardigrade/reload/status
@@ -98,6 +100,9 @@ Tardigrade tracks accepted client connections separately from requests:
   request uses whichever config version they acquire at handler entry.
 - On graceful shutdown, new accepts stop and keep-alive is disabled for requests
   already being handled, so connections close instead of being re-parked.
+- Already-parked idle keep-alive connections are not worker jobs. They remain in
+  the parked registry during worker drain and are closed when the downstream
+  runtime is torn down; they do not extend the worker-pool drain deadline.
 
 The main related knobs are:
 
@@ -113,14 +118,16 @@ See [TIMEOUTS.md](TIMEOUTS.md) for request phase timeout semantics.
 ## Worker Jobs and Drain
 
 Graceful shutdown is the path that uses the drain timeout. Once shutdown is
-requested, the accept loop exits and the worker pool drains with
+requested, the accept loop exits and the TCP worker pool drains with
 `TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS` (default `30000` ms).
 
 Drain behavior:
 
 - Active, already-dispatched handlers are allowed to finish naturally.
-- During shutdown, request deadlines are capped to the drain window when a
-  request has no stricter deadline.
+- Requests whose handler/lifecycle starts after shutdown has been requested cap
+  their request deadline to the drain window when no stricter deadline exists.
+  Requests already executing when shutdown is requested keep their existing
+  lifecycle and phase deadlines.
 - Queued, not-yet-started connection jobs wait until the drain deadline.
 - If the drain deadline expires, remaining queued file descriptors owned by the
   worker queue are closed and counted as forced closes.
@@ -129,6 +136,11 @@ Drain behavior:
 The drain timeout is a soft process cap: active handlers are not killed inside
 the process. Their own phase deadlines, downstream disconnects, or the
 supervisor's external stop timeout bound the final exit.
+
+Native HTTP/3 uses the same shutdown timeout as a QUIC/H3 drain deadline.
+Shutdown refuses new QUIC connections, sends H3 GOAWAY, and rejects new request
+streams past the drain boundary. Existing H3 work may complete before the
+deadline; remaining H3 connections are closed when the deadline expires.
 
 Expected shutdown logs include:
 
@@ -155,12 +167,18 @@ downstream client connection lifecycle:
 - Hot reload keeps existing upstream idle and active pooled connections alive.
 - Requests already using an upstream connection finish under their current
   request/config lease.
-- New requests use the current config and may reuse an existing pooled
-  connection when it is still valid for the pool key.
+- New requests use the current request config, but they may still reuse an
+  existing pooled connection governed by the pool policy installed at startup.
 - Idle upstream connections are evicted by the maintenance tick when they exceed
   idle or lifetime limits.
 - Shutdown closes idle upstream pool connections during runtime teardown after
   worker drain.
+
+Hot reload does not reconfigure the process-owned upstream pool policy. Changes
+to pool enablement, capacity, idle timeout, lifetime, or active checkout limits
+require a restart today; existing pool instances and their startup policy remain
+in effect. Reloaded proxy-buffer limits are the exception and are applied through
+the pool's runtime setters.
 
 Related knobs:
 

--- a/docs/RELOAD_SHUTDOWN.md
+++ b/docs/RELOAD_SHUTDOWN.md
@@ -1,0 +1,196 @@
+# Reload, Drain, and Shutdown
+
+Tardigrade has three distinct lifecycle paths:
+
+- **Hot reload** (`tardi reload`, `SIGHUP`) validates and publishes a new runtime
+  configuration without stopping the process.
+- **Graceful shutdown** (`tardi stop`, `SIGTERM`, `SIGINT`, or `SIGUSR2` upgrade)
+  stops accepting new work and drains worker jobs before exit.
+- **Hard termination** (`SIGKILL`, process crash, or an external supervisor kill
+  after its own timeout) is outside Tardigrade's graceful path; the OS closes
+  sockets and in-flight requests can be interrupted.
+
+## Commands
+
+Use a PID file in production so control commands can find the running process:
+
+```bash
+TARDIGRADE_CONFIG_PATH=/etc/tardigrade/tardigrade.conf \
+TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid \
+./zig-out/bin/tardi run
+```
+
+Validate config edits before publishing them:
+
+```bash
+./zig-out/bin/tardi check /etc/tardigrade/tardigrade.conf
+./zig-out/bin/tardi reload --pid-file /run/tardigrade/tardigrade.pid
+./zig-out/bin/tardi status --pid-file /run/tardigrade/tardigrade.pid
+./zig-out/bin/tardi stop --pid-file /run/tardigrade/tardigrade.pid
+```
+
+`tardi reload` sends `SIGHUP`. `tardi stop` sends `SIGTERM`. Both commands also
+accept `--pid <pid>` when a PID file is not available.
+
+For systemd installs, validate first and then let the unit's `ExecReload` run:
+
+```bash
+sudo -u tardigrade tardi check /etc/tardigrade/tardigrade.conf
+sudo systemctl reload tardigrade
+sudo systemctl stop tardigrade
+```
+
+Set systemd `TimeoutStopSec` slightly above
+`TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS` so systemd does not escalate to a hard
+kill before Tardigrade's drain has finished.
+
+## Hot Reload
+
+On `SIGHUP`, the gateway handles reload on the maintenance tick:
+
+1. Load the new config from the configured source.
+2. Validate it.
+3. Prepare reload-owned runtime resources, such as reloadable TLS credentials.
+4. Reject the reload if it changes process-owned settings that require a
+   restart, such as listener shard topology, HTTP/3 listener-owned settings,
+   native early-data replay mode/capacity, or native ticket-key source mode.
+5. Publish the new config through the lease-counted config store.
+
+New requests acquire the newly published config after step 5. In-flight requests
+keep a lease on the config version they started with and are allowed to finish on
+that version. Reload does not drain worker jobs, stop the listener, or close
+active client connections.
+
+If load, validation, allocation, bookkeeping, credential preparation, or another
+reload preflight fails, the active config is left in place. The failed config is
+not partially installed. Operators can inspect the last result through:
+
+```bash
+curl http://127.0.0.1:8080/tardigrade/reload/status
+```
+
+The endpoint returns JSON in this shape:
+
+```json
+{"ok":false,"at_ms":1780000000000,"error":"validation rejected: InvalidConfigValue"}
+```
+
+Expected reload logs include:
+
+```text
+configuration hot-reload starting
+configuration hot-reload applied
+config reload failed during load: ...
+config reload rejected by validation: ...
+config reload rejected: ... restart the process ...
+```
+
+## Active Connections
+
+Tardigrade tracks accepted client connections separately from requests:
+
+- A keep-alive connection holds one connection slot while it is parked between
+  requests.
+- Parked keep-alive connections do not occupy a worker thread.
+- When a parked connection sends another request, it is resumed and submitted to
+  the worker pool.
+- On hot reload, parked and active client connections stay open. Their next
+  request uses whichever config version they acquire at handler entry.
+- On graceful shutdown, new accepts stop and keep-alive is disabled for requests
+  already being handled, so connections close instead of being re-parked.
+
+The main related knobs are:
+
+| Env var | Default | Effect |
+| --- | ---: | --- |
+| `TARDIGRADE_KEEP_ALIVE_TIMEOUT_MS` | `5000` | Idle parked downstream keep-alive timeout. |
+| `TARDIGRADE_MAX_REQUESTS_PER_CONNECTION` | `100` | Maximum requests served before closing a downstream connection. |
+| `TARDIGRADE_MAX_ACTIVE_CONNECTIONS` | `0` | Optional global accepted-connection cap (`0` means unlimited). |
+| `TARDIGRADE_MAX_IN_FLIGHT_REQUESTS` | `0` | Optional in-flight request cap (`0` means unlimited). |
+
+See [TIMEOUTS.md](TIMEOUTS.md) for request phase timeout semantics.
+
+## Worker Jobs and Drain
+
+Graceful shutdown is the path that uses the drain timeout. Once shutdown is
+requested, the accept loop exits and the worker pool drains with
+`TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS` (default `30000` ms).
+
+Drain behavior:
+
+- Active, already-dispatched handlers are allowed to finish naturally.
+- During shutdown, request deadlines are capped to the drain window when a
+  request has no stricter deadline.
+- Queued, not-yet-started connection jobs wait until the drain deadline.
+- If the drain deadline expires, remaining queued file descriptors owned by the
+  worker queue are closed and counted as forced closes.
+- A drain timeout of `0` closes queued work immediately.
+
+The drain timeout is a soft process cap: active handlers are not killed inside
+the process. Their own phase deadlines, downstream disconnects, or the
+supervisor's external stop timeout bound the final exit.
+
+Expected shutdown logs include:
+
+```text
+Shutdown requested; draining active connection work (timeout=30000ms active_connections=...)
+drain timeout elapsed; force-closed N queued connection(s)
+Graceful shutdown complete (forced_closes=N drain_timed_out=true)
+```
+
+Related knobs:
+
+| Env var | Default | Effect |
+| --- | ---: | --- |
+| `TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS` | `30000` | Worker-pool drain window for graceful shutdown. |
+| `TARDIGRADE_WORKER_THREADS` | `0` | Worker thread count; `0` uses the runtime default. |
+| `TARDIGRADE_WORKER_QUEUE_SIZE` | `1024` | Worker queue capacity. |
+| `TARDIGRADE_WORKER_MAX_QUEUE_DEPTH` | `0` | Optional per-worker queue depth cap (`0` means unlimited beyond queue capacity behavior). |
+
+## Upstream Keepalive Pools
+
+Upstream pools are origin-side keepalive caches. They are independent from the
+downstream client connection lifecycle:
+
+- Hot reload keeps existing upstream idle and active pooled connections alive.
+- Requests already using an upstream connection finish under their current
+  request/config lease.
+- New requests use the current config and may reuse an existing pooled
+  connection when it is still valid for the pool key.
+- Idle upstream connections are evicted by the maintenance tick when they exceed
+  idle or lifetime limits.
+- Shutdown closes idle upstream pool connections during runtime teardown after
+  worker drain.
+
+Related knobs:
+
+| Env var | Default | Effect |
+| --- | ---: | --- |
+| `TARDIGRADE_UPSTREAM_POOL_ENABLED` | `true` | Enables HTTP/1 upstream keepalive reuse. |
+| `TARDIGRADE_UPSTREAM_POOL_MAX_IDLE_PER_HOST` | `32` | Maximum idle upstream HTTP/1 connections per origin. |
+| `TARDIGRADE_UPSTREAM_POOL_IDLE_TIMEOUT_MS` | `90000` | Idle upstream pool eviction age. |
+| `TARDIGRADE_UPSTREAM_POOL_MAX_LIFETIME_MS` | `0` | Maximum pooled connection lifetime (`0` means unlimited). |
+| `TARDIGRADE_UPSTREAM_POOL_MAX_ACTIVE_PER_HOST` | `0` | Optional fail-fast active checkout cap per origin. |
+
+See [UPSTREAM_POOLING.md](UPSTREAM_POOLING.md) for the complete pool contract.
+
+## Observability
+
+Lifecycle logs are emitted through the runtime logger. Metrics are exposed at
+the configured metrics path, `/status/metrics` by default:
+
+| Metric | Meaning |
+| --- | --- |
+| `tardigrade_reload_attempts_total` | Reloads started. |
+| `tardigrade_reload_success_total` | Reloads successfully installed. |
+| `tardigrade_reload_failure_total` | Reloads rejected; previous config kept. |
+| `tardigrade_drain_total` | Graceful-shutdown drains started. |
+| `tardigrade_drain_timeouts_total` | Drains that reached the drain timeout. |
+| `tardigrade_drain_forced_closes_total` | Queued connections force-closed after drain timeout. |
+| `tardigrade_active_connections` | Currently accepted downstream connections. |
+| `tardigrade_worker_active_jobs` | Worker jobs currently running. |
+| `tardigrade_worker_queued_jobs` | Worker jobs waiting in queues. |
+
+See [OBSERVABILITY.md](OBSERVABILITY.md) for full metric and logging details,
+and [examples/graceful-reload](../examples/graceful-reload/README.md) for a
+copy/paste runnable local workflow.

--- a/docs/RELOAD_SHUTDOWN.md
+++ b/docs/RELOAD_SHUTDOWN.md
@@ -57,9 +57,10 @@ On `SIGHUP`, the gateway handles reload on the maintenance tick:
 5. Publish the new config through the lease-counted config store.
 
 New requests acquire the newly published config after step 5. In-flight requests
-keep a lease on the config version they started with and are allowed to finish on
-that version. Reload does not drain worker jobs, stop the listener, or close
-active client connections.
+retain their original config lease for request-scoped config reads. Reload also
+updates some process-shared runtime policy, so an in-flight request is not a
+fully isolated snapshot of the previous runtime configuration. Reload does not
+drain worker jobs, stop the listener, or close active client connections.
 
 If reload fails before config publication, the previously published config
 remains active for request routing and config leases. Reload-owned runtime
@@ -131,11 +132,14 @@ Drain behavior:
 - Queued, not-yet-started connection jobs wait until the drain deadline.
 - If the drain deadline expires, remaining queued file descriptors owned by the
   worker queue are closed and counted as forced closes.
-- A drain timeout of `0` closes queued work immediately.
+- A drain timeout of `0` skips the wait and abandons queued jobs immediately.
+  Queue-owned unstarted accepted sockets are closed, while non-owning
+  resume/poll work is discarded and cleaned up by its owning runtime state.
 
-The drain timeout is a soft process cap: active handlers are not killed inside
-the process. Their own phase deadlines, downstream disconnects, or the
-supervisor's external stop timeout bound the final exit.
+For TCP worker jobs, the drain timeout is a soft worker-drain cap: active
+handlers are not killed inside the process. Their own phase deadlines,
+downstream disconnects, or the supervisor's external stop timeout bound the
+final exit.
 
 Native HTTP/3 uses the same shutdown timeout as a QUIC/H3 drain deadline.
 Shutdown refuses new QUIC connections, sends H3 GOAWAY, and rejects new request
@@ -154,10 +158,17 @@ Related knobs:
 
 | Env var | Default | Effect |
 | --- | ---: | --- |
-| `TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS` | `30000` | Worker-pool drain window for graceful shutdown. |
+| `TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS` | `30000` | TCP worker-pool drain window and native HTTP/3 drain deadline for graceful shutdown. |
 | `TARDIGRADE_WORKER_THREADS` | `0` | Worker thread count; `0` uses the runtime default. |
 | `TARDIGRADE_WORKER_QUEUE_SIZE` | `1024` | Worker queue capacity. |
 | `TARDIGRADE_WORKER_MAX_QUEUE_DEPTH` | `0` | Optional per-worker queue depth cap (`0` means unlimited beyond queue capacity behavior). |
+
+Related references:
+
+- [TIMEOUTS.md lifecycle table](TIMEOUTS.md#lifecycle--operations) for timeout
+  semantics of `TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS`.
+- [examples/graceful-reload/tardigrade.env.example](../examples/graceful-reload/tardigrade.env.example)
+  for commented PID-file and drain-timeout configuration.
 
 ## Upstream Keepalive Pools
 

--- a/docs/TIMEOUTS.md
+++ b/docs/TIMEOUTS.md
@@ -60,7 +60,7 @@ Two principles, from the #196/#141 arc:
 
 | Class | Knob (`TARDIGRADE_…`) | Default | Enforcement | Semantics | Status |
 |---|---|---|---|---|---|
-| Shutdown drain | `SHUTDOWN_DRAIN_TIMEOUT_MS` | 30000 | TCP worker-pool drain deadline + native HTTP/3 drain deadline | TCP worker drain is a **soft cap**: queued work is drained/abandoned by the deadline, but active handlers finish naturally; native H3 uses the same value as a hard drain deadline and closes remaining H3 connections at expiry | 🟡 semantics documented here; a hard TCP process cap is a #169-adjacent decision |
+| Shutdown drain | `SHUTDOWN_DRAIN_TIMEOUT_MS` | 30000 | TCP worker-pool drain deadline + native HTTP/3 drain deadline | TCP worker drain is a **soft cap**: queued work is drained/abandoned by the deadline, but active handlers finish naturally; native H3 uses the same value as a hard drain deadline and closes remaining H3 connections at expiry. The final shutdown path uses the startup value today; restart required to change coherently. | 🟡 semantics documented here; a hard TCP process cap is a #169-adjacent decision |
 | Hot reload | — | — | config load/validation + lease-counted publication | no worker-pool drain; in-flight requests keep their request-scoped config lease, may observe reloaded process-shared policy, and failed reloads keep the previous config active for request routing | ✅ |
 | OCSP refresh | `TLS_OCSP_REFRESH_TIMEOUT_MS` | 10000 | bounded fetch | stale staple kept | ✅ |
 | TLS session cache lifetime | `TLS_SESSION_TIMEOUT_SECONDS` | 300 | OpenSSL session cache | session renegotiated | ✅ (cache lifetime, not an I/O deadline) |

--- a/docs/TIMEOUTS.md
+++ b/docs/TIMEOUTS.md
@@ -61,7 +61,7 @@ Two principles, from the #196/#141 arc:
 | Class | Knob (`TARDIGRADE_…`) | Default | Enforcement | Semantics | Status |
 |---|---|---|---|---|---|
 | Shutdown drain | `SHUTDOWN_DRAIN_TIMEOUT_MS` | 30000 | worker-pool drain deadline | **soft cap**: queued work is drained/abandoned by the deadline, but active handlers finish naturally (their own phase timeouts bound them) | 🟡 semantics documented here; a hard process cap is a #169-adjacent decision |
-| Reload drain | (same machinery) | — | as above | as above | 🟡 |
+| Hot reload | — | — | config load/validation + lease-counted publication | no worker-pool drain; in-flight requests keep their original config lease, and failed reloads keep the previous config active | ✅ |
 | OCSP refresh | `TLS_OCSP_REFRESH_TIMEOUT_MS` | 10000 | bounded fetch | stale staple kept | ✅ |
 | TLS session cache lifetime | `TLS_SESSION_TIMEOUT_SECONDS` | 300 | OpenSSL session cache | session renegotiated | ✅ (cache lifetime, not an I/O deadline) |
 

--- a/docs/TIMEOUTS.md
+++ b/docs/TIMEOUTS.md
@@ -60,8 +60,8 @@ Two principles, from the #196/#141 arc:
 
 | Class | Knob (`TARDIGRADE_…`) | Default | Enforcement | Semantics | Status |
 |---|---|---|---|---|---|
-| Shutdown drain | `SHUTDOWN_DRAIN_TIMEOUT_MS` | 30000 | worker-pool drain deadline | **soft cap**: queued work is drained/abandoned by the deadline, but active handlers finish naturally (their own phase timeouts bound them) | 🟡 semantics documented here; a hard process cap is a #169-adjacent decision |
-| Hot reload | — | — | config load/validation + lease-counted publication | no worker-pool drain; in-flight requests keep their original config lease, and failed reloads keep the previous config active | ✅ |
+| Shutdown drain | `SHUTDOWN_DRAIN_TIMEOUT_MS` | 30000 | TCP worker-pool drain deadline + native HTTP/3 drain deadline | TCP worker drain is a **soft cap**: queued work is drained/abandoned by the deadline, but active handlers finish naturally; native H3 uses the same value as a hard drain deadline and closes remaining H3 connections at expiry | 🟡 semantics documented here; a hard TCP process cap is a #169-adjacent decision |
+| Hot reload | — | — | config load/validation + lease-counted publication | no worker-pool drain; in-flight requests keep their request-scoped config lease, may observe reloaded process-shared policy, and failed reloads keep the previous config active for request routing | ✅ |
 | OCSP refresh | `TLS_OCSP_REFRESH_TIMEOUT_MS` | 10000 | bounded fetch | stale staple kept | ✅ |
 | TLS session cache lifetime | `TLS_SESSION_TIMEOUT_SECONDS` | 300 | OpenSSL session cache | session renegotiated | ✅ (cache lifetime, not an I/O deadline) |
 
@@ -86,4 +86,6 @@ Two principles, from the #196/#141 arc:
    by shrinking phase budgets, not inside every blocking syscall.
 2. **Downstream HTTP/2 and HTTP/3 per-stream phase deadlines** — need
    frame-level deadline tracking; out of scope until that work is scheduled.
-3. **Shutdown drain is a soft cap** by design; revisit with #169.
+3. **TCP shutdown drain is a soft cap** by design; revisit a hard TCP process
+   cap with #169. Native H3 already treats the same value as a connection drain
+   deadline.

--- a/examples/graceful-reload/README.md
+++ b/examples/graceful-reload/README.md
@@ -4,7 +4,7 @@ Hot-reloads configuration without dropping in-flight requests and drains connect
 
 ## What it demonstrates
 
-- Hot reload via `tardi reload` (SIGHUP): new requests use the updated config immediately; existing in-flight requests finish on the old config.
+- Hot reload via `tardi reload` (SIGHUP): new requests use the updated config immediately; existing in-flight requests keep their request-scoped config lease but can observe reloaded process-shared policy.
 - Graceful shutdown via `tardi stop`: stops accepting new connections and waits up to `TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS` for worker jobs to drain.
 - PID file for signal-based process management with init systems.
 
@@ -35,8 +35,8 @@ curl http://localhost:8080/health
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `TARDIGRADE_PID_FILE` | `""` | Path to the PID file. Required for `tardi reload` and `tardi stop`. |
-| `TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS` | `30000` | Max time in ms to wait for worker jobs to drain on shutdown. |
+| `TARDIGRADE_PID_FILE` | `""` | Path to the PID file. Required for `tardi reload` and `tardi stop` unless `--pid` is supplied. |
+| `TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS` | `30000` | TCP worker-pool drain window and native HTTP/3 drain deadline on shutdown. |
 
 See `tardigrade.env.example` for the full list with comments.
 
@@ -44,7 +44,7 @@ See `tardigrade.env.example` for the full list with comments.
 
 | Action | Command | Behavior |
 |--------|---------|---------|
-| Hot reload | `tardi reload --pid-file <path>` | Applies config changes; in-flight requests finish on the old config. Zero downtime. |
+| Hot reload | `tardi reload --pid-file <path>` | Applies config changes without dropping active client connections; in-flight requests keep their request-scoped config lease but can observe reloaded process-shared policy. |
 | Graceful stop | `tardi stop --pid-file <path>` | Sends SIGTERM; the running process stops accepting new connections, drains worker jobs until the deadline, then force-closes queued unstarted accepted sockets while active handlers finish naturally. |
 | Status check | `tardi status --pid-file <path>` | Prints running/stopped state, PID or PID-file information, and the effective config summary. |
 

--- a/examples/graceful-reload/README.md
+++ b/examples/graceful-reload/README.md
@@ -27,7 +27,7 @@ curl http://localhost:8080/health
 # Edit this config file, then hot-reload — no downtime
 ./zig-out/bin/tardi reload --pid-file /tmp/tardigrade.pid
 
-# Graceful stop — waits for worker jobs to drain
+# Graceful stop — sends SIGTERM; the running process drains before exit
 ./zig-out/bin/tardi stop --pid-file /tmp/tardigrade.pid
 ```
 
@@ -45,7 +45,7 @@ See `tardigrade.env.example` for the full list with comments.
 | Action | Command | Behavior |
 |--------|---------|---------|
 | Hot reload | `tardi reload --pid-file <path>` | Applies config changes; in-flight requests finish on the old config. Zero downtime. |
-| Graceful stop | `tardi stop --pid-file <path>` | Stops accepting new connections; drains in-flight requests up to the drain timeout. |
+| Graceful stop | `tardi stop --pid-file <path>` | Sends SIGTERM; the running process stops accepting new connections, drains worker jobs until the deadline, then force-closes queued unstarted accepted sockets while active handlers finish naturally. |
 | Status check | `tardi status --pid-file <path>` | Prints running/stopped state, PID or PID-file information, and the effective config summary. |
 
 For the full lifecycle contract, including failed reloads, upstream pools,
@@ -54,7 +54,10 @@ queued worker jobs, and hard termination, see
 
 ## systemd integration
 
-The included drain timeout works with `TimeoutStopSec=` in a systemd unit file. Set both to the same value so systemd does not kill Tardigrade before the drain completes:
+The included drain timeout works with `TimeoutStopSec=` in a systemd unit file.
+Set `TimeoutStopSec` slightly above `TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS` so
+Tardigrade can complete its drain and teardown before systemd escalates to a
+hard kill:
 
 ```ini
 [Service]

--- a/examples/graceful-reload/README.md
+++ b/examples/graceful-reload/README.md
@@ -5,7 +5,7 @@ Hot-reloads configuration without dropping in-flight requests and drains connect
 ## What it demonstrates
 
 - Hot reload via `tardi reload` (SIGHUP): new requests use the updated config immediately; existing in-flight requests keep their request-scoped config lease but can observe reloaded process-shared policy.
-- Graceful shutdown via `tardi stop`: stops accepting new connections and waits up to `TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS` for worker jobs to drain.
+- Graceful shutdown via `tardi stop`: sends SIGTERM; the running process stops accepting new connections and drains before exit.
 - PID file for signal-based process management with init systems.
 
 ## Quick start

--- a/examples/graceful-reload/README.md
+++ b/examples/graceful-reload/README.md
@@ -5,7 +5,7 @@ Hot-reloads configuration without dropping in-flight requests and drains connect
 ## What it demonstrates
 
 - Hot reload via `tardi reload` (SIGHUP): new requests use the updated config immediately; existing in-flight requests finish on the old config.
-- Graceful shutdown via `tardi stop`: waits up to `TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS` for in-flight requests to complete before closing connections.
+- Graceful shutdown via `tardi stop`: stops accepting new connections and waits up to `TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS` for worker jobs to drain.
 - PID file for signal-based process management with init systems.
 
 ## Quick start
@@ -27,7 +27,7 @@ curl http://localhost:8080/health
 # Edit this config file, then hot-reload — no downtime
 ./zig-out/bin/tardi reload --pid-file /tmp/tardigrade.pid
 
-# Graceful stop — waits for in-flight requests to finish
+# Graceful stop — waits for worker jobs to drain
 ./zig-out/bin/tardi stop --pid-file /tmp/tardigrade.pid
 ```
 
@@ -36,7 +36,7 @@ curl http://localhost:8080/health
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `TARDIGRADE_PID_FILE` | `""` | Path to the PID file. Required for `tardi reload` and `tardi stop`. |
-| `TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS` | `30000` | Max time in ms to wait for in-flight requests to finish on shutdown. |
+| `TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS` | `30000` | Max time in ms to wait for worker jobs to drain on shutdown. |
 
 See `tardigrade.env.example` for the full list with comments.
 
@@ -47,6 +47,10 @@ See `tardigrade.env.example` for the full list with comments.
 | Hot reload | `tardi reload --pid-file <path>` | Applies config changes; in-flight requests finish on the old config. Zero downtime. |
 | Graceful stop | `tardi stop --pid-file <path>` | Stops accepting new connections; drains in-flight requests up to the drain timeout. |
 | Status check | `tardi status --pid-file <path>` | Prints running/stopped state, PID or PID-file information, and the effective config summary. |
+
+For the full lifecycle contract, including failed reloads, upstream pools,
+queued worker jobs, and hard termination, see
+[docs/RELOAD_SHUTDOWN.md](../../docs/RELOAD_SHUTDOWN.md).
 
 ## systemd integration
 

--- a/examples/graceful-reload/tardigrade.conf
+++ b/examples/graceful-reload/tardigrade.conf
@@ -6,8 +6,7 @@
 # What this config does:
 #   - Listens on port 8080 (no TLS).
 #   - Writes a PID file so the reload/stop commands can signal the process.
-#   - Waits up to 30 seconds for in-flight requests to complete before
-#     closing connections on shutdown or reload (drain timeout).
+#   - Waits up to 30 seconds for worker jobs to drain on shutdown.
 #
 # Reload workflow:
 #   1. Edit this config file.

--- a/examples/graceful-reload/tardigrade.conf
+++ b/examples/graceful-reload/tardigrade.conf
@@ -6,17 +6,18 @@
 # What this config does:
 #   - Listens on port 8080 (no TLS).
 #   - Writes a PID file so the reload/stop commands can signal the process.
-#   - Waits up to 30 seconds for worker jobs to drain on shutdown.
+#   - Configures the shutdown drain timeout for TCP worker jobs and native H3.
 #
 # Reload workflow:
 #   1. Edit this config file.
 #   2. Run: ./zig-out/bin/tardi reload --pid-file /tmp/tardigrade.pid
 #      (sends SIGHUP to the running process).
-#   3. New requests use the new config; existing requests finish on the old config.
+#   3. New requests use the new config; existing requests keep their
+#      request-scoped config lease but can observe reloaded shared policy.
 #
 # Drain workflow (graceful stop):
 #   ./zig-out/bin/tardi stop --pid-file /tmp/tardigrade.pid
-#   # waits up to TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS
+#   # sends SIGTERM; the running process drains before exit
 #
 # Minimal local setup:
 #   TARDIGRADE_CONFIG_PATH=examples/graceful-reload/tardigrade.conf \

--- a/examples/graceful-reload/tardigrade.env.example
+++ b/examples/graceful-reload/tardigrade.env.example
@@ -17,6 +17,7 @@ TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid
 
 # ── Graceful shutdown ─────────────────────────────────────────────────────────
 
-# Maximum time in milliseconds to wait for in-flight requests to complete
-# before forcefully closing connections. Default: 30000 (30 s).
+# Worker-pool drain window on graceful shutdown. On expiry, queued unstarted
+# accepted sockets are closed; already-active handlers finish naturally.
+# Default: 30000 (30 s).
 TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS=30000

--- a/examples/graceful-reload/tardigrade.env.example
+++ b/examples/graceful-reload/tardigrade.env.example
@@ -12,12 +12,14 @@ TARDIGRADE_UPSTREAM_BASE_URL=http://127.0.0.1:8081
 # ── Process management ────────────────────────────────────────────────────────
 
 # PID file written at startup and removed at exit.
-# Required for `tardi reload` and `tardi stop` to find the running process.
+# Required for `tardi reload` and `tardi stop` unless `--pid` is supplied.
 TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid
 
 # ── Graceful shutdown ─────────────────────────────────────────────────────────
 
-# Worker-pool drain window on graceful shutdown. On expiry, queued unstarted
-# accepted sockets are closed; already-active handlers finish naturally.
+# TCP worker-pool drain window and native HTTP/3 drain deadline on graceful
+# shutdown. For TCP, queued unstarted accepted sockets are closed on expiry,
+# while already-active handlers finish naturally. For native H3, remaining
+# H3 connections are closed when the deadline expires.
 # Default: 30000 (30 s).
 TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS=30000

--- a/examples/graceful-reload/tardigrade.env.example
+++ b/examples/graceful-reload/tardigrade.env.example
@@ -21,5 +21,6 @@ TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid
 # shutdown. For TCP, queued unstarted accepted sockets are closed on expiry,
 # while already-active handlers finish naturally. For native H3, remaining
 # H3 connections are closed when the deadline expires.
+# Startup-owned for the final shutdown drain path; restart to change coherently.
 # Default: 30000 (30 s).
 TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS=30000

--- a/examples/production-baseline/README.md
+++ b/examples/production-baseline/README.md
@@ -56,7 +56,7 @@ curl -k https://localhost:8443/status/metrics  # → Prometheus text
 - [ ] Set `TARDIGRADE_RATE_LIMIT_RPS` and `TARDIGRADE_RATE_LIMIT_BURST` to match your traffic profile.
 - [ ] Restrict `/status/metrics` with a firewall rule or `TARDIGRADE_METRICS_REQUIRE_AUTH=true`.
 - [ ] Set `TARDIGRADE_PID_FILE` to a path your init system can write to (e.g. `/run/tardigrade/tardigrade.pid`).
-- [ ] Match `TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS` to `TimeoutStopSec` in your systemd unit.
+- [ ] Set `TimeoutStopSec` slightly above `TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS` in your systemd unit.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- add a dedicated reload, drain, and shutdown lifecycle doc
- document reload failure behavior, in-flight request handling, worker drain semantics, upstream pools, commands, logs, and metrics
- link the new doc from the README and graceful reload example, and correct the timeout matrix reload wording

## Validation
- test -f doc/link targets
- git diff --check

Closes #165