### PR TITLE
perf(quic): pace packets on an RFC 9002 schedule (#256-C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,20 +19,28 @@ All notable user-facing changes to Tardigrade are documented here.
   datagrams, which also caps what a connection returning from idle may send at
   once. BBR and other rate estimators remain out of scope.
 
-  Only application data waits on the bucket. Acknowledgements, PTO probes, and
-  Initial/Handshake flights are charged to it but never delayed by it: an ACK
-  is not congestion-controlled traffic, a probe is how a stalled connection
-  recovers, and the handshake is already bounded by the initial window and by
-  anti-amplification. Congestion control and anti-amplification stay the hard
-  gates — pacing only ever delays a datagram, never authorises one.
+  Only application data waits on the bucket. PTO probes, Initial/Handshake
+  flights, DPLPMTUD probes, and path-validation probes are charged to it but
+  never delayed by it — a probe is how a stalled connection recovers, and the
+  handshake is already bounded by the initial window and by anti-amplification.
+  Pure ACKs are exempt outright, neither delayed nor charged, since an ACK-only
+  packet is not congestion-controlled traffic and metering it would only add
+  latency to the peer's loss recovery. Congestion control and anti-amplification
+  stay the hard gates — pacing only ever delays a datagram, never authorises one.
 
   Packet construction never sleeps: `pollTransmitOnPath` declines to build
   paced data while the bucket is short, and the listener folds the connection's
-  next release time into the same poll timeout it already computes from timers,
-  so a paced connection neither spins nor sleeps past its own deadline. There
-  is no operator knob — a pacing rate adjustable independently of the window
-  would be a way to defeat congestion control rather than to tune it. See
-  `docs/HTTP3_ROLLOUT.md`.
+  next release time into the same sleep it already computes from timers, so a
+  paced connection neither spins nor sleeps past its own deadline. Because
+  pacing intervals are routinely sub-millisecond — a 480 kB window over a 10 ms
+  RTT is one datagram every ~20 µs — the QUIC listener now waits with `ppoll`
+  on Linux and a `kqueue` timeout on the BSDs, falling back to millisecond
+  `poll` elsewhere; without that, rounding each release up to 1 ms would have
+  capped the listener at one burst per millisecond regardless of window and RTT.
+
+  There is no operator knob — a pacing rate adjustable independently of the
+  window would be a way to defeat congestion control rather than to tune it.
+  See `docs/HTTP3_ROLLOUT.md`.
 - **Explicit Congestion Notification for HTTP/3 (#256-E)** — the QUIC listener
   now marks outbound datagrams ECT(0), counts the codepoints on received
   packets, reports them to peers in ACK_ECN, and validates the counters peers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable user-facing changes to Tardigrade are documented here.
 ## [Unreleased]
 
 ### Added
+- **RFC 9002 packet pacing for HTTP/3 (#256-C)** — QUIC now spreads outbound
+  application data across the round trip instead of writing until the
+  congestion window is full. A window bounds how much data may be outstanding,
+  not how fast it may leave, so a sender with plenty of nominal capacity could
+  still hand its whole window to the first router in the path as one burst and
+  take queue-overflow loss for it.
+
+  The schedule is the leaky bucket RFC 9002 §7.7 describes: credit accrues at
+  `N × congestion_window / smoothed_rtt`, with `N` of 2 in slow start and 1.25
+  in congestion avoidance. Two things follow — datagrams leave one interval
+  apart once the bucket is empty, and a burst is capped at ten maximum-size
+  datagrams, which also caps what a connection returning from idle may send at
+  once. BBR and other rate estimators remain out of scope.
+
+  Only application data waits on the bucket. Acknowledgements, PTO probes, and
+  Initial/Handshake flights are charged to it but never delayed by it: an ACK
+  is not congestion-controlled traffic, a probe is how a stalled connection
+  recovers, and the handshake is already bounded by the initial window and by
+  anti-amplification. Congestion control and anti-amplification stay the hard
+  gates — pacing only ever delays a datagram, never authorises one.
+
+  Packet construction never sleeps: `pollTransmitOnPath` declines to build
+  paced data while the bucket is short, and the listener folds the connection's
+  next release time into the same poll timeout it already computes from timers,
+  so a paced connection neither spins nor sleeps past its own deadline. There
+  is no operator knob — a pacing rate adjustable independently of the window
+  would be a way to defeat congestion control rather than to tune it. See
+  `docs/HTTP3_ROLLOUT.md`.
 - **Explicit Congestion Notification for HTTP/3 (#256-E)** — the QUIC listener
   now marks outbound datagrams ECT(0), counts the codepoints on received
   packets, reports them to peers in ACK_ECN, and validates the counters peers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,21 +12,27 @@ All notable user-facing changes to Tardigrade are documented here.
   still hand its whole window to the first router in the path as one burst and
   take queue-overflow loss for it.
 
-  The schedule is the leaky bucket RFC 9002 §7.7 describes: credit accrues at
-  `N × congestion_window / smoothed_rtt`, with `N` of 2 in slow start and 1.25
-  in congestion avoidance. Two things follow — datagrams leave one interval
-  apart once the bucket is empty, and a burst is capped at ten maximum-size
-  datagrams, which also caps what a connection returning from idle may send at
-  once. BBR and other rate estimators remain out of scope.
+  The schedule is a leaky bucket filling at RFC 9002 §7.7's rate
+  `N × congestion_window / smoothed_rtt`. Tardigrade uses `N` of 2 in slow
+  start and 1.25 in congestion avoidance — a local policy carried over from the
+  earlier QUIC recovery drafts, not an RFC requirement; RFC 9002 fixes the rate
+  form and asks only that `N` be a small value above 1. Two things follow:
+  datagrams leave one interval apart once the bucket is empty, and a burst is
+  capped at a NewReno initial window for the current datagram size, which also
+  caps what a connection returning from idle may send at once. BBR and other
+  rate estimators remain out of scope.
 
   Only application data waits on the bucket. PTO probes, Initial/Handshake
   flights, DPLPMTUD probes, and path-validation probes are charged to it but
   never delayed by it — a probe is how a stalled connection recovers, and the
   handshake is already bounded by the initial window and by anti-amplification.
-  Pure ACKs are exempt outright, neither delayed nor charged, since an ACK-only
-  packet is not congestion-controlled traffic and metering it would only add
-  latency to the peer's loss recovery. Congestion control and anti-amplification
-  stay the hard gates — pacing only ever delays a datagram, never authorises one.
+  Being exempt does not make them free: when one leaves an empty bucket the
+  balance goes negative, and refill repays that debt before releasing ordinary
+  traffic again. Pure ACKs are exempt outright, neither delayed nor charged,
+  since an ACK-only packet is not congestion-controlled traffic and metering it
+  would only add latency to the peer's loss recovery. Congestion control and
+  anti-amplification stay the hard gates — pacing only ever delays a datagram,
+  never authorises one.
 
   Packet construction never sleeps: `pollTransmitOnPath` declines to build
   paced data while the bucket is short, and the listener folds the connection's

--- a/docs/CONCURRENCY.md
+++ b/docs/CONCURRENCY.md
@@ -128,7 +128,8 @@ The target module seams are:
 
 | Seam | Responsibility |
 |---|---|
-| `src/quic/udp.zig` | HTTP-independent UDP endpoint: send/receive datagrams, local/remote address metadata, ECN, socket buffer tuning, deterministic clock hook, and future batching/GSO/pacing extension points |
+| `src/quic/udp.zig` | HTTP-independent UDP endpoint: send/receive datagrams, local/remote address metadata, ECN, socket buffer tuning, deterministic clock hook, and future batching/GSO extension points |
+| `src/quic/recovery.zig` | Loss detection, RTT, NewReno congestion control, and the RFC 9002 §7.7 pacer whose release times gate `pollTransmitOnPath` and feed the listener's sleep deadline |
 | `src/quic/config.zig` | Internal config defaults, validation, and QUIC transport-parameter mapping |
 | `src/quic/packet.*` / `connection.*` / `stream.*` | QUIC packet codec, connection state, packet number spaces, DCID routing, timers, loss recovery, stream flow control, close/drain |
 | `src/quic/tls_adapter.*` | QUIC TLS 1.3 handshake bytes, transport parameters, traffic secrets, AEAD/header protection, ALPN, certificate state, and key updates |

--- a/docs/HTTP3_ROLLOUT.md
+++ b/docs/HTTP3_ROLLOUT.md
@@ -400,6 +400,67 @@ of paths that validated.
 `TARDIGRADE_HTTP3_ECN` is restart-required, like every other listener-owned knob
 — the receive option is socket state applied at bind time.
 
+## Packet pacing
+
+A congestion window is a bound on how much data may be *outstanding*, not on
+how fast it may leave. A sender that holds a 64 kB window and simply writes
+until the window is full hands that whole window to the first router in the
+path as one burst — which is how a connection with plenty of nominal capacity
+still sees queue-overflow loss. RFC 9002 §7.7 requires a sender to either pace
+or bound such bursts. Tardigrade does both.
+
+Pacing is a **leaky bucket**, not a bandwidth model: credit accrues at
+`N × congestion_window / smoothed_rtt` and is spent by packets as they leave.
+`N` is 2 while the connection is in slow start and 1.25 in congestion
+avoidance, exactly as RFC 9002 §7.7 describes. BBR and any other rate estimator
+are out of scope.
+
+Two properties follow, and they are what the setting is for:
+
+- **Spacing.** Once the bucket is empty, datagrams leave one interval apart —
+  a full window's worth of data reaches the path spread over a round trip
+  rather than as a single flight.
+- **A burst ceiling.** The bucket holds at most ten maximum-size datagrams.
+  That bounds the opening flight, and it bounds the *restart* flight: a
+  connection that has been idle for a second has notionally earned megabytes
+  of credit, and gets ten packets.
+
+### What is paced, and what is not
+
+Only application-space data waits on the bucket. Three kinds of traffic are
+charged to it — the bytes are genuinely on the wire — but never delayed by it:
+
+- **Acknowledgements.** A pure ACK is not congestion-controlled traffic at all.
+  Metering it would add latency to the *peer's* loss recovery for no capacity
+  reason.
+- **PTO probes.** RFC 9002 §7 already exempts probes from the congestion
+  window; making loss recovery wait on a token is how a stalled connection
+  stays stalled.
+- **Initial and Handshake flights.** These are already bounded by the initial
+  window and, for a server, by anti-amplification. Pacing them at a rate
+  derived from an RTT nobody has measured yet would slow every connection
+  setup to buy nothing.
+
+Congestion control and anti-amplification remain the hard gates. Pacing can
+only ever *delay* a datagram — it never authorises one the window or the
+amplification budget would refuse, and a connection blocked by either of those
+reports no pacing deadline at all.
+
+### How it reaches the wire
+
+Pacing is a schedule, not a sleep. `Connection.pollTransmitOnPath` never
+blocks: while the bucket is short it simply declines to build paced data, and
+`Connection.nextSendTimeUs` reports the instant the schedule next releases
+something. The listener folds that deadline into the same `poll` timeout it
+already computes from timers, so a paced connection neither spins nor sleeps
+past its own release. Packet construction and scheduling stay separable — the
+same seam a batching or GSO send path would need later.
+
+There is no operator knob. Pacing follows congestion control, and a rate an
+operator could raise independently of the window would be a way to defeat
+congestion control rather than to tune it. A path whose measured capacity
+grows paces faster on its own.
+
 ## Reload
 
 Advertisement-only knobs can hot reload:

--- a/docs/HTTP3_ROLLOUT.md
+++ b/docs/HTTP3_ROLLOUT.md
@@ -427,19 +427,43 @@ Two properties follow, and they are what the setting is for:
 
 ### What is paced, and what is not
 
-Only application-space data waits on the bucket. Three kinds of traffic are
-charged to it — the bytes are genuinely on the wire — but never delayed by it:
+Only application-space data waits on the bucket: stream data, application
+control frames, post-handshake CRYPTO (session tickets), and a PATH_RESPONSE
+riding on the active path. RFC 9000 §8.2 explicitly permits path validation to
+be delayed by congestion control, which is why the last of those is in the
+list rather than exempt.
 
-- **Acknowledgements.** A pure ACK is not congestion-controlled traffic at all.
-  Metering it would add latency to the *peer's* loss recovery for no capacity
-  reason.
-- **PTO probes.** RFC 9002 §7 already exempts probes from the congestion
-  window; making loss recovery wait on a token is how a stalled connection
-  stays stalled.
-- **Initial and Handshake flights.** These are already bounded by the initial
-  window and, for a server, by anti-amplification. Pacing them at a rate
-  derived from an RTT nobody has measured yet would slow every connection
-  setup to buy nothing.
+Everything else is exempt from *waiting*, but the two categories differ in
+whether the bytes are **charged** to the bucket:
+
+| Traffic | Delayed by pacing? | Charged to the bucket? |
+|---|---|---|
+| Application data, app control frames, post-handshake CRYPTO, active-path PATH_RESPONSE | yes | yes |
+| PTO probes | no | yes |
+| Initial and Handshake flights | no | yes |
+| DPLPMTUD probes | no | yes |
+| Candidate-path PATH_CHALLENGE / PATH_RESPONSE | no | yes |
+| Pure ACK packets | no | **no** |
+
+The reasoning behind each exemption:
+
+- **Acknowledgements** are not congestion-controlled traffic at all — an
+  ACK-only packet is not in flight, so it is neither delayed by the bucket nor
+  charged to it. Metering acknowledgements would add latency to the *peer's*
+  loss recovery for no capacity reason.
+- **PTO probes** are already exempt from the congestion window by RFC 9002 §7;
+  making loss recovery wait on a token is how a stalled connection stays
+  stalled.
+- **Initial and Handshake flights** are already bounded by the initial window
+  and, for a server, by anti-amplification. Pacing them at a rate derived from
+  an RTT nobody has measured yet would slow every connection setup to buy
+  nothing.
+- **DPLPMTUD and path-validation probes** each build their own datagram, and at
+  most one is outstanding per path at a time, so they cannot burst.
+
+Everything in the "charged but not delayed" rows still puts bytes on the wire,
+and the bucket accounts for them. A pacer that ignored a handshake flight would
+let application data follow it at a rate the path was never shown to support.
 
 Congestion control and anti-amplification remain the hard gates. Pacing can
 only ever *delay* a datagram — it never authorises one the window or the
@@ -451,10 +475,36 @@ reports no pacing deadline at all.
 Pacing is a schedule, not a sleep. `Connection.pollTransmitOnPath` never
 blocks: while the bucket is short it simply declines to build paced data, and
 `Connection.nextSendTimeUs` reports the instant the schedule next releases
-something. The listener folds that deadline into the same `poll` timeout it
-already computes from timers, so a paced connection neither spins nor sleeps
-past its own release. Packet construction and scheduling stay separable — the
-same seam a batching or GSO send path would need later.
+something. The listener folds that deadline into the same sleep it already
+computes from timers, so a paced connection neither spins nor sleeps past its
+own release. Packet construction and scheduling stay separable — the same seam
+a batching or GSO send path would need later.
+
+### Timer resolution
+
+Pacing intervals are routinely **sub-millisecond**. A 480 kB window over a
+10 ms RTT is one datagram every ~20 µs, which is an ordinary datacentre or
+loopback figure and exactly the case #256 exists for.
+
+That rules out `poll(2)` as the listener's only wait: its timeout is an integer
+number of milliseconds, so every one of those releases would round up to 1 ms.
+Against a ten-datagram burst ceiling that would cap the listener near 12 MB/s
+no matter how much window and RTT allowed — a 50× loss on the path above. The
+listener therefore waits with a nanosecond-resolution primitive where the
+platform has one:
+
+| Platform | Wait primitive |
+|---|---|
+| Linux | `ppoll` |
+| macOS, FreeBSD, NetBSD, OpenBSD, DragonFly | `kqueue` timeout |
+| Anything else | `poll`, rounded up to the next millisecond |
+
+The fallback is safe, not broken: a platform that lands there sends at a
+coarser cadence, never an incorrect one — the pacer still decides *whether* a
+datagram may leave. The same reasoning is why the pacing release is not floored
+at the recovery timer granularity (1 ms): that constant is loss-detection
+resolution, and imposing it on the pacer would reintroduce the cap the
+fine-grained wait exists to remove.
 
 There is no operator knob. Pacing follows congestion control, and a rate an
 operator could raise independently of the window would be a way to defeat

--- a/docs/HTTP3_ROLLOUT.md
+++ b/docs/HTTP3_ROLLOUT.md
@@ -410,20 +410,32 @@ still sees queue-overflow loss. RFC 9002 §7.7 requires a sender to either pace
 or bound such bursts. Tardigrade does both.
 
 Pacing is a **leaky bucket**, not a bandwidth model: credit accrues at
-`N × congestion_window / smoothed_rtt` and is spent by packets as they leave.
-`N` is 2 while the connection is in slow start and 1.25 in congestion
-avoidance, exactly as RFC 9002 §7.7 describes. BBR and any other rate estimator
-are out of scope.
+RFC 9002 §7.7's rate `N × congestion_window / smoothed_rtt` and is spent by
+packets as they leave. BBR and any other rate estimator are out of scope.
+
+Tardigrade uses `N = 2` in slow start and `N = 1.25` in congestion avoidance.
+That split is a **local policy, not an RFC requirement**: RFC 9002 fixes the
+shape of the rate and asks only that `N` be a small value above 1, offering
+1.25 as an example. The explicit per-phase split comes from the earlier QUIC
+recovery drafts, and is kept for the reason those drafts gave — slow start
+doubles the window every round trip, so pacing it at 1.25× would hold the
+sender below growth the window is already granting.
 
 Two properties follow, and they are what the setting is for:
 
 - **Spacing.** Once the bucket is empty, datagrams leave one interval apart —
   a full window's worth of data reaches the path spread over a round trip
   rather than as a single flight.
-- **A burst ceiling.** The bucket holds at most ten maximum-size datagrams.
-  That bounds the opening flight, and it bounds the *restart* flight: a
-  connection that has been idle for a second has notionally earned megabytes
-  of credit, and gets ten packets.
+- **A burst ceiling.** The bucket holds at most a NewReno **initial window**
+  for the current datagram size. That bounds the opening flight, and it bounds
+  the *restart* flight: a connection idle for a second has notionally earned
+  megabytes of credit, and gets one initial window.
+
+  The ceiling is the smaller of ten datagrams and `initialWindow(datagram
+  size)`, which matters once DPLPMTUD raises the path size past 1472 bytes.
+  RFC 9002 §7.2 caps the initial window at 14720 bytes, so at a 2048-byte
+  datagram the bucket holds 14720 bytes (seven packets), not ten packets'
+  20480 bytes.
 
 ### What is paced, and what is not
 
@@ -464,6 +476,15 @@ The reasoning behind each exemption:
 Everything in the "charged but not delayed" rows still puts bytes on the wire,
 and the bucket accounts for them. A pacer that ignored a handshake flight would
 let application data follow it at a rate the path was never shown to support.
+
+**Exempt means "may send now", not "outside the schedule."** Those packets
+routinely leave when the bucket cannot cover them, so the balance is signed and
+goes negative — the overdraft is carried as debt, and refill pays it off before
+producing credit again. Discarding it instead would let an exempt packet
+consume path capacity for free: one interval later, ordinary application data
+would be released as though the probe had never been sent. A connection that
+emits a PTO probe on an empty bucket therefore waits two intervals for its next
+application datagram, not one.
 
 Congestion control and anti-amplification remain the hard gates. Pacing can
 only ever *delay* a datagram — it never authorises one the window or the

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -159,6 +159,112 @@ const max_connections: usize = 1024;
 const max_connections_per_source: u32 = 32;
 const handshake_timeout_us: u64 = 10 * std.time.us_per_s;
 const cid_generation_retries: usize = 16;
+/// The listener never sleeps longer than this in one pass, so a connection
+/// whose state changed without arming a deadline is still revisited promptly.
+const max_loop_wait_us: u64 = 100 * std.time.us_per_ms;
+
+/// Wait for the QUIC socket to become readable, or for a deadline — with
+/// finer resolution than `poll(2)` can express (#256-C).
+///
+/// `poll` takes an integer number of milliseconds. That was fine when every
+/// deadline this loop computed came from a timer measured in milliseconds, and
+/// it stopped being fine when pacing started producing them: on a fast path
+/// the interval between two datagrams is tens of microseconds, and rounding
+/// each release up to 1 ms caps the listener at one burst per millisecond no
+/// matter what the congestion window and RTT actually permit. So the wait uses
+/// whatever nanosecond-resolution primitive the platform has.
+///
+/// `poll` remains the fallback, and it is a safe one rather than a broken one:
+/// a platform that lands there sleeps at millisecond granularity exactly as
+/// this loop always did. It sends at a coarser cadence, not an incorrect one —
+/// the pacer is still what decides *whether* a datagram may leave.
+const SocketWaiter = struct {
+    fd: posix.fd_t,
+    /// BSD `kqueue` descriptor, or `-1` on platforms that do not use one —
+    /// including a BSD where `kqueue` failed, which simply falls back.
+    kq: i32 = -1,
+
+    const uses_kqueue = switch (builtin.os.tag) {
+        .macos, .ios, .tvos, .watchos, .visionos, .freebsd, .netbsd, .openbsd, .dragonfly => true,
+        else => false,
+    };
+
+    /// A valid pointer for the list `kevent` is told to read zero entries
+    /// from. The kernel never dereferences it, but handing a syscall an
+    /// `undefined` pointer is undefined behaviour on this side of the call
+    /// regardless of what the other side does with it.
+    const no_events: [0]std.c.Kevent = .{};
+
+    /// Every reference to `std.c.Kevent`/`EVFILT`/`EV` sits inside a branch on
+    /// this comptime-known flag, so it is never *analysed* off the BSDs — on
+    /// Linux `std.c.Kevent` resolves to `void` and naming its fields would not
+    /// merely be dead code, it would fail to compile.
+    fn init(fd: posix.fd_t) SocketWaiter {
+        var self = SocketWaiter{ .fd = fd };
+        if (uses_kqueue) {
+            if (fd < 0) return self;
+            const kq = std.c.kqueue();
+            if (kq < 0) return self;
+            // Registered once, level-triggered: every later `kevent` call is a
+            // pure wait with no changelist, which is what keeps the hot path
+            // to a single syscall.
+            const change = [_]std.c.Kevent{.{
+                .ident = @intCast(fd),
+                .filter = std.c.EVFILT.READ,
+                .flags = std.c.EV.ADD,
+                .fflags = 0,
+                .data = 0,
+                .udata = 0,
+            }};
+            if (std.c.kevent(kq, &change, 1, @constCast(&no_events), 0, null) < 0) {
+                _ = std.c.close(kq);
+                return self;
+            }
+            self.kq = kq;
+        }
+        return self;
+    }
+
+    fn deinit(self: *SocketWaiter) void {
+        if (self.kq >= 0) _ = std.c.close(self.kq);
+        self.kq = -1;
+    }
+
+    /// Sleep until the socket is readable or `timeout_us` elapses. Errors are
+    /// swallowed deliberately: every one of them means "stopped waiting early",
+    /// and the loop's next pass re-derives what to do from connection state
+    /// rather than from what this call returned.
+    fn wait(self: *SocketWaiter, timeout_us: u64) void {
+        const ts = std.posix.timespec{
+            .sec = @intCast(timeout_us / std.time.us_per_s),
+            .nsec = @intCast((timeout_us % std.time.us_per_s) * std.time.ns_per_us),
+        };
+        if (uses_kqueue) {
+            if (self.kq >= 0) {
+                var event: [1]std.c.Kevent = undefined;
+                _ = std.c.kevent(self.kq, &no_events, 0, &event, 1, &ts);
+                return;
+            }
+        }
+        var fds = [_]posix.pollfd{
+            .{ .fd = self.fd, .events = posix.POLL.IN, .revents = 0 },
+        };
+        if (builtin.os.tag == .linux) {
+            _ = posix.ppoll(&fds, &ts, null) catch {};
+            return;
+        }
+        _ = posix.poll(&fds, pollTimeoutMs(timeout_us)) catch {};
+    }
+
+    /// `poll`'s millisecond timeout for a microsecond deadline. Rounds *up* so
+    /// the loop never wakes before the deadline it computed and re-runs a pass
+    /// that can do nothing; a sub-millisecond deadline therefore becomes 1 ms,
+    /// which is the resolution limit this fallback exists to acknowledge.
+    fn pollTimeoutMs(timeout_us: u64) i32 {
+        const ms = (timeout_us + std.time.us_per_ms - 1) / std.time.us_per_ms;
+        return @intCast(@min(@max(ms, 1), max_loop_wait_us / std.time.us_per_ms));
+    }
+};
 
 const ParkedH3Retry = struct {
     stream_id: u64,
@@ -547,7 +653,9 @@ pub const Runtime = struct {
         // Half-open admission accounting, keyed on the source IPv4 address.
         var per_ip = std.AutoHashMap(u32, u32).init(allocator);
         var next_handle: u64 = 1;
+        var waiter = SocketWaiter.init(self.socket_fd);
         defer {
+            waiter.deinit();
             var it = connections.valueIterator();
             while (it.next()) |entry| {
                 entry.*.deinit(allocator);
@@ -610,11 +718,7 @@ pub const Runtime = struct {
             if (draining and connections.count() == 0) break;
 
             // 2) Sleep until the earliest deadline or socket readability.
-            const timeout_ms: i32 = @intCast(@min((wake_us -| nowUs()) / 1_000 + 1, 100));
-            var fds = [_]posix.pollfd{
-                .{ .fd = self.socket_fd, .events = posix.POLL.IN, .revents = 0 },
-            };
-            _ = posix.poll(&fds, timeout_ms) catch {};
+            waiter.wait(@min(wake_us -| nowUs(), max_loop_wait_us));
 
             // 3) Ingest every waiting datagram.
             var buf: [quic.datagram.max_size]u8 = undefined;
@@ -3212,20 +3316,20 @@ test "http3 runtime: CID route collision rolls back without stealing an existing
 
 /// Queue a response far larger than one burst on the harness's server
 /// connection and pin the window and RTT, so what holds the send path back is
-/// the pacer rather than a sub-millisecond handshake RTT (see the matching
-/// fixture in `quic/connection.zig`). Returns with the opening burst already
-/// spent at `harness.now_us`.
-fn spendPacingBurst(harness: *RuntimeCidHarness) !void {
+/// the pacer rather than the sub-millisecond RTT the in-process handshake
+/// leaves behind (see the matching fixture in `quic/connection.zig`). Returns
+/// with the opening burst already spent at `harness.now_us`.
+fn spendPacingBurst(harness: *RuntimeCidHarness, cwnd: usize, srtt_us: u64) !void {
     const sid = try harness.client.openStream(.bidi);
     _ = try harness.client.writeStream(sid, "request", false);
     try harness.pump();
     _ = try harness.entry.conn.writeStream(sid, &[_]u8{0xab} ** (64 * 1024), false);
 
     harness.entry.conn.recovery.rtt = quic.recovery.RttEstimator.init(25_000);
-    harness.entry.conn.recovery.rtt.update(100_000, 0);
+    harness.entry.conn.recovery.rtt.update(srtt_us, 0);
     const congestion = &harness.entry.conn.recovery.congestion;
-    congestion.congestion_window = 64 * 1024;
-    congestion.ssthresh = 64 * 1024;
+    congestion.congestion_window = cwnd;
+    congestion.ssthresh = cwnd;
     congestion.bytes_in_flight = 0;
     congestion.pacer = .{};
 
@@ -3247,7 +3351,7 @@ test "http3 runtime: the loop's sleep deadline follows the pacing release" {
     const quiet = Runtime.connectionWakeUs(harness.entry, harness.now_us, floor);
     try testing.expectEqual(@as(?u64, null), harness.entry.conn.nextSendTimeUs(harness.now_us));
 
-    try spendPacingBurst(harness);
+    try spendPacingBurst(harness, 64 * 1024, 100_000);
     const now = harness.now_us;
 
     // Held back by the pacer and by nothing else, and the release beats every
@@ -3269,7 +3373,7 @@ test "http3 runtime: a connection with nothing paced contributes no wakeup of it
     var harness = try RuntimeCidHarness.init(testing.allocator, fixed.provider());
     defer harness.deinit(testing.allocator);
 
-    try spendPacingBurst(harness);
+    try spendPacingBurst(harness, 64 * 1024, 100_000);
     const now = harness.now_us;
 
     // Congestion control is the harder gate, and when it is what a connection
@@ -6280,4 +6384,66 @@ test "http3 runtime: every live connection is told the socket cannot mark (#256-
         }
         try testing.expectEqual(marked_before, conn.metrics.ecn_marked_sent);
     }
+}
+
+test "http3 runtime: a low-RTT connection hands the loop a sub-millisecond deadline" {
+    var fixed = tls_core.credentials.FixedCredentialProvider.init(tls_core.credentials.testdata.identity(), tls_core.credentials.testdata.ignoredEntropy());
+    defer fixed.deinit();
+    var harness = try RuntimeCidHarness.init(testing.allocator, fixed.provider());
+    defer harness.deinit(testing.allocator);
+
+    // 1.25 × 480 kB over a 10 ms RTT — a datacentre or loopback path, and the
+    // case #256 exists for. One datagram every ~20 µs.
+    try spendPacingBurst(harness, 480 * 1024, 10_000);
+    const now = harness.now_us;
+
+    const release = harness.entry.conn.nextSendTimeUs(now) orelse return error.TestExpectedEqual;
+    try testing.expect(release > now);
+    try testing.expect(release - now < std.time.us_per_ms);
+    try testing.expectEqual(release, Runtime.connectionWakeUs(harness.entry, now, now + max_loop_wait_us));
+
+    // The deadline reaches the wait primitive in microseconds. Rounding it to
+    // an integer-millisecond `poll` timeout — what this loop did before
+    // #256-C — would sleep ~50 pacing intervals past it, and with a bounded
+    // burst that caps the listener at one burst per millisecond however much
+    // window and RTT allow.
+    try testing.expect(SocketWaiter.pollTimeoutMs(release - now) == 1);
+    try testing.expect(release - now < SocketWaiter.pollTimeoutMs(release - now) * std.time.us_per_ms);
+}
+
+test "http3 runtime: the socket waiter rounds its fallback up and clamps to the loop ceiling" {
+    // Never round *down*: a wait that returns before its deadline costs the
+    // loop a whole pass that can produce nothing.
+    try testing.expectEqual(@as(i32, 1), SocketWaiter.pollTimeoutMs(1));
+    try testing.expectEqual(@as(i32, 1), SocketWaiter.pollTimeoutMs(999));
+    try testing.expectEqual(@as(i32, 1), SocketWaiter.pollTimeoutMs(1_000));
+    try testing.expectEqual(@as(i32, 2), SocketWaiter.pollTimeoutMs(1_001));
+
+    // A zero deadline still blocks for a tick rather than spinning the loop.
+    try testing.expectEqual(@as(i32, 1), SocketWaiter.pollTimeoutMs(0));
+
+    // And never past the loop's own ceiling.
+    try testing.expectEqual(@as(i32, 100), SocketWaiter.pollTimeoutMs(max_loop_wait_us));
+    try testing.expectEqual(@as(i32, 100), SocketWaiter.pollTimeoutMs(10 * max_loop_wait_us));
+}
+
+test "http3 runtime: the socket waiter takes a sub-millisecond path where the platform has one" {
+    const fd = std.c.socket(posix.AF.INET, posix.SOCK.DGRAM, posix.IPPROTO.UDP);
+    if (fd < 0) return error.SkipZigTest;
+    defer _ = std.c.close(fd);
+
+    var waiter = SocketWaiter.init(fd);
+    defer waiter.deinit();
+
+    // Linux waits with `ppoll` and needs no descriptor; the BSDs need a
+    // `kqueue` and this asserts one was actually obtained, so a silent
+    // fallback to millisecond `poll` on a platform that has better cannot pass
+    // unnoticed.
+    if (SocketWaiter.uses_kqueue) try testing.expect(waiter.kq >= 0);
+
+    // A sub-millisecond wait on a socket with nothing to read must return, not
+    // hang or fail. Deliberately no assertion on elapsed time: this is a real
+    // syscall against a shared scheduler, and the deadline is a floor on how
+    // long it sleeps, never a ceiling.
+    waiter.wait(200);
 }

--- a/src/http/http3_runtime.zig
+++ b/src/http/http3_runtime.zig
@@ -601,7 +601,7 @@ pub const Runtime = struct {
                         }
                         continue;
                     }
-                    if (entry.conn.nextTimeoutUs()) |deadline| wake_us = @min(wake_us, deadline);
+                    wake_us = connectionWakeUs(entry, now, wake_us);
                 }
                 for (reap[0..reap_count]) |handle| {
                     self.removeConnection(&connections, &routes, &per_ip, handle);
@@ -1213,6 +1213,28 @@ pub const Runtime = struct {
         self.noteRequestCompleted();
     }
 
+    /// Fold one connection's deadlines into the loop's sleep deadline.
+    ///
+    /// Two independent sources, and the pacing one is the reason this exists
+    /// (#256-C). A connection the pacer is holding data back for has no timer
+    /// to fire — `drainConnectionTransmits` has already stopped producing
+    /// datagrams for it, and none of `nextTimeoutUs`'s deadlines knows the
+    /// send path is waiting — so without `nextSendTimeUs` here the data would
+    /// sit until the next unrelated wakeup or the 100 ms loop floor.
+    ///
+    /// The converse matters as much: `nextSendTimeUs` is null unless something
+    /// is genuinely paced out and is always strictly in the future, so this
+    /// neither wakes an idle listener nor lets a busy one spin on a deadline
+    /// that has already passed.
+    ///
+    /// Split out of `serve` so the selection is testable without a socket.
+    fn connectionWakeUs(entry: *ConnEntry, now: u64, current: u64) u64 {
+        var wake = current;
+        if (entry.conn.nextTimeoutUs()) |deadline| wake = @min(wake, deadline);
+        if (entry.conn.nextSendTimeUs(now)) |release| wake = @min(wake, release);
+        return wake;
+    }
+
     /// Send one transport-produced datagram, carrying the ECN codepoint the
     /// transport asked for (#256-E). `mark` is `.not_ect` for every datagram
     /// on a path that is not marking, which is the plain-`sendto` path.
@@ -1222,6 +1244,11 @@ pub const Runtime = struct {
     /// once per pass: the refusal is discovered *inside* a send, and the rest
     /// of this drain would otherwise keep building packets the transport counts
     /// as marked while the socket emits them Not-ECT.
+    ///
+    /// Stops when the transport declines — including when the pacer is what
+    /// declines (#256-C). The bounded burst is what keeps this drain from
+    /// flushing a whole congestion window in one pass, and the deadline
+    /// `connectionWakeUs` folds in is what brings the loop back for the rest.
     fn drainConnectionTransmits(self: *Runtime, entry: *ConnEntry, now: u64) void {
         var out: [quic.datagram.max_size]u8 = undefined;
         while (entry.conn.pollTransmitOnPath(&out, now)) |t| {
@@ -3181,6 +3208,80 @@ test "http3 runtime: CID route collision rolls back without stealing an existing
     try testing.expectEqual(before_owned, harness.entry.owned_cid_count);
     try testing.expectEqual(before_pending, harness.entry.conn.pending_new_connection_ids.items.len);
     try testing.expectEqual(@as(?u64, collision_owner), routes.lookup(candidate.slice()));
+}
+
+/// Queue a response far larger than one burst on the harness's server
+/// connection and pin the window and RTT, so what holds the send path back is
+/// the pacer rather than a sub-millisecond handshake RTT (see the matching
+/// fixture in `quic/connection.zig`). Returns with the opening burst already
+/// spent at `harness.now_us`.
+fn spendPacingBurst(harness: *RuntimeCidHarness) !void {
+    const sid = try harness.client.openStream(.bidi);
+    _ = try harness.client.writeStream(sid, "request", false);
+    try harness.pump();
+    _ = try harness.entry.conn.writeStream(sid, &[_]u8{0xab} ** (64 * 1024), false);
+
+    harness.entry.conn.recovery.rtt = quic.recovery.RttEstimator.init(25_000);
+    harness.entry.conn.recovery.rtt.update(100_000, 0);
+    const congestion = &harness.entry.conn.recovery.congestion;
+    congestion.congestion_window = 64 * 1024;
+    congestion.ssthresh = 64 * 1024;
+    congestion.bytes_in_flight = 0;
+    congestion.pacer = .{};
+
+    var out: [quic.datagram.max_size]u8 = undefined;
+    var emitted: usize = 0;
+    while (harness.entry.conn.pollTransmitOnPath(&out, harness.now_us)) |_| emitted += 1;
+    try testing.expect(emitted > 0);
+    try testing.expect(emitted <= quic.recovery.default_pacer_burst_packets);
+}
+
+test "http3 runtime: the loop's sleep deadline follows the pacing release" {
+    var fixed = tls_core.credentials.FixedCredentialProvider.init(tls_core.credentials.testdata.identity(), tls_core.credentials.testdata.ignoredEntropy());
+    defer fixed.deinit();
+    var harness = try RuntimeCidHarness.init(testing.allocator, fixed.provider());
+    defer harness.deinit(testing.allocator);
+
+    // The loop's own idle ceiling, which every other deadline competes with.
+    const floor = harness.now_us + 100_000;
+    const quiet = Runtime.connectionWakeUs(harness.entry, harness.now_us, floor);
+    try testing.expectEqual(@as(?u64, null), harness.entry.conn.nextSendTimeUs(harness.now_us));
+
+    try spendPacingBurst(harness);
+    const now = harness.now_us;
+
+    // Held back by the pacer and by nothing else, and the release beats every
+    // timer deadline — so a loop that folded in only `nextTimeoutUs` would
+    // sleep straight past the moment this data became eligible.
+    const release = harness.entry.conn.nextSendTimeUs(now) orelse return error.TestExpectedEqual;
+    try testing.expect(release > now);
+    try testing.expect(release < quiet);
+    try testing.expectEqual(release, Runtime.connectionWakeUs(harness.entry, now, floor));
+
+    // And sleeping until it is productive: the send path yields again there.
+    var out: [quic.datagram.max_size]u8 = undefined;
+    try testing.expect(harness.entry.conn.pollTransmitOnPath(&out, release) != null);
+}
+
+test "http3 runtime: a connection with nothing paced contributes no wakeup of its own" {
+    var fixed = tls_core.credentials.FixedCredentialProvider.init(tls_core.credentials.testdata.identity(), tls_core.credentials.testdata.ignoredEntropy());
+    defer fixed.deinit();
+    var harness = try RuntimeCidHarness.init(testing.allocator, fixed.provider());
+    defer harness.deinit(testing.allocator);
+
+    try spendPacingBurst(harness);
+    const now = harness.now_us;
+
+    // Congestion control is the harder gate, and when it is what a connection
+    // is waiting on there is no pacing wakeup to schedule: the loss and PTO
+    // timers already in `nextTimeoutUs` are what should bring the loop back.
+    const congestion = &harness.entry.conn.recovery.congestion;
+    congestion.bytes_in_flight = congestion.congestion_window;
+    try testing.expectEqual(@as(?u64, null), harness.entry.conn.nextSendTimeUs(now));
+
+    const floor = now + 100_000;
+    const timers = harness.entry.conn.nextTimeoutUs() orelse floor;
+    try testing.expectEqual(@min(floor, timers), Runtime.connectionWakeUs(harness.entry, now, floor));
 }
 
 test "http3 runtime: retired CIDs stop routing, replenish, and teardown removes every route" {

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -3645,11 +3645,18 @@ pub const Connection = struct {
     ///
     /// Null unless there is genuinely paced content held back, so it cannot
     /// keep an otherwise-idle listener awake. When it is non-null the value is
-    /// strictly in the future (`pacingReleaseUs` floors the wait at one timer
-    /// granularity), so a loop that sleeps until it always advances.
+    /// strictly in the future, so a loop that sleeps until it always advances.
     pub fn nextSendTimeUs(self: *Connection, now_us: u64) ?u64 {
         if (self.state_ != .established) return null;
-        if (!self.hasAppContent()) return null;
+        // Must name every source `buildPacket` subjects to the pacing gate,
+        // not just streams and control frames. Application-space CRYPTO is the
+        // one that is easy to miss: `emitNewSessionTicket` queues post-
+        // handshake bytes into `crypto_tx[2]`, which the builder paces like any
+        // other application-space content. A predicate that only asked
+        // `hasAppContent` would report no deadline for a connection whose only
+        // held-back content was a session ticket — the ticket would be refused
+        // at `now` and then wait for an unrelated wakeup.
+        if (!self.hasAppContent() and self.crypto_tx[2].pending.isEmpty()) return null;
         const size = self.recovery.congestion.max_datagram_size;
         // Congestion control is the harder gate and it is not a pacing
         // deadline: when the window is what is holding the sender back, the
@@ -4457,8 +4464,6 @@ pub const Connection = struct {
         // window term below and the anti-amplification check after it remain
         // the gates that refuse outright. What waits on a token is
         // application-space data, and only that:
-        //   * a pure ACK is not congestion controlled at all, so metering it
-        //     would add latency to acknowledgements for no capacity reason;
         //   * a PTO probe is recovery traffic RFC 9002 §7 already exempts from
         //     the window, and making loss recovery wait on a token is how a
         //     stalled connection stays stalled;
@@ -4466,8 +4471,16 @@ pub const Connection = struct {
         //     for a server, by anti-amplification — pacing the handshake at a
         //     rate derived from an RTT nobody has measured yet would slow every
         //     connection setup to buy nothing.
-        // The bytes all three put on the wire are still charged to the bucket
-        // (`RecoveryController.chargeSend`); they simply never wait on it.
+        // Both still put bytes on the wire and are charged for them
+        // (`RecoveryController.chargeSend`); they just never wait.
+        //
+        // A pure ACK is exempt without needing to be named here: it is not in
+        // flight, so it is neither delayed by the bucket nor charged to it —
+        // metering acknowledgements would add latency to the *peer's* loss
+        // recovery for no capacity reason. It reaches the wire through the
+        // `want_ack` terms below, which `can_send_data` does not gate.
+        // `buildPmtuProbe` and `buildCandidatePacket` are likewise unpaced;
+        // both build their own datagram without coming through here.
         const pacing_blocked = space == .application and !probe and
             !self.recovery.pacingAllows(self.recovery.congestion.max_datagram_size, now_us);
 
@@ -12919,4 +12932,54 @@ test "driver: an acknowledgement is not delayed by a spent pacing bucket" {
     pair.server.ack_eliciting_since_ack[Connection.spaceIndex(.application)] = ack_eliciting_threshold;
     const ack = pair.server.pollTransmitOnPath(&out, now) orelse return error.TestExpectedEqual;
     try testing.expect(ack.bytes.len > 0);
+}
+
+test "driver: a paced session ticket is refused now and reported as a deadline" {
+    const allocator = testing.allocator;
+    var pair = try TestPair.init(allocator);
+    defer pair.deinit(allocator);
+    try pair.pump();
+
+    // Post-handshake CRYPTO is application-space content, so `buildPacket`
+    // paces it like any other. Nothing else is queued here — no streams, no
+    // control frames — so a wake predicate that only asked `hasAppContent`
+    // would report no deadline and leave the ticket waiting for an unrelated
+    // wakeup.
+    pair.server.recovery.rtt = recovery.RttEstimator.init(25_000);
+    pair.server.recovery.rtt.update(100_000, 0);
+    const congestion = &pair.server.recovery.congestion;
+    congestion.congestion_window = 64 * 1024;
+    congestion.ssthresh = 64 * 1024;
+    congestion.bytes_in_flight = 0;
+    // A bucket spent down to nothing, without anything having been sent that
+    // could queue other content alongside the ticket.
+    congestion.pacer = .{ .tokens = 0, .updated_at_us = pair.now_us };
+
+    var server_state = try pair.server.emitNewSessionTicket(.{
+        .ticket_lifetime = 60,
+        .ticket_age_add = 1,
+        .ticket_nonce = "\x01",
+        .opaque_ticket = "paced-ticket",
+        .issued_at_unix_ms = 10,
+    }, tls_core.session.Limits.default);
+    defer server_state.deinit();
+
+    const now = pair.now_us;
+    try testing.expect(!pair.server.crypto_tx[Connection.spaceIndex(.application)].pending.isEmpty());
+    try testing.expect(!pair.server.hasAppContent());
+
+    // Refused at `now` — and the connection says when to come back rather than
+    // going silent.
+    try testing.expectEqual(@as(usize, 0), drainAtInstant(pair.server, now));
+    const release = pair.server.nextSendTimeUs(now) orelse return error.TestExpectedEqual;
+    try testing.expect(release > now);
+    try testing.expectEqual(@as(usize, 0), drainAtInstant(pair.server, release - 1));
+
+    // At the release the ticket goes out, as application-space CRYPTO.
+    var out: [max_datagram_size_ceiling]u8 = undefined;
+    const sent = pair.server.pollTransmitOnPath(&out, release) orelse return error.TestExpectedEqual;
+    try testing.expect(sent.bytes.len > 0);
+    const record = pair.server.sent_records.items[pair.server.sent_records.items.len - 1];
+    try testing.expectEqual(PacketNumberSpace.application, record.space);
+    try testing.expect(record.crypto != null);
 }

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -12828,7 +12828,7 @@ test "driver: pacing spaces datagrams evenly once the opening burst is spent" {
     // bucket — the interval the schedule is aiming at.
     const mds = pair.server.effectiveMaxDatagramSize();
     var empty = pair.server.recovery.congestion;
-    empty.pacer = .{ .tokens = 0, .updated_at_us = 0 };
+    empty.pacer = .{ .balance = 0, .updated_at_us = 0 };
     const interval = empty.pacingReleaseUs(mds, 0, pair.server.recovery.rtt);
 
     // Past the opening burst, each wakeup waits about one datagram-interval
@@ -12953,7 +12953,7 @@ test "driver: a paced session ticket is refused now and reported as a deadline" 
     congestion.bytes_in_flight = 0;
     // A bucket spent down to nothing, without anything having been sent that
     // could queue other content alongside the ticket.
-    congestion.pacer = .{ .tokens = 0, .updated_at_us = pair.now_us };
+    congestion.pacer = .{ .balance = 0, .updated_at_us = pair.now_us };
 
     var server_state = try pair.server.emitNewSessionTicket(.{
         .ticket_lifetime = 60,

--- a/src/quic/connection.zig
+++ b/src/quic/connection.zig
@@ -3631,6 +3631,37 @@ pub const Connection = struct {
         return deadline;
     }
 
+    /// #256-C: the instant this connection's *pacing* schedule next releases a
+    /// datagram, or null when nothing is waiting on it.
+    ///
+    /// This is the scheduling half of `pollTransmitOnPath`. That function
+    /// declines to build application data while the token bucket is short
+    /// rather than sleeping inside packet construction, so an event loop that
+    /// watched only `nextTimeoutUs` would have nothing telling it when the
+    /// data became eligible — it would either sleep past the release or come
+    /// back immediately and be refused again. Deliberately separate from
+    /// `nextTimeoutUs`: this deadline arms no timer and needs no `onTimeout`
+    /// work, it only says when to try transmitting again.
+    ///
+    /// Null unless there is genuinely paced content held back, so it cannot
+    /// keep an otherwise-idle listener awake. When it is non-null the value is
+    /// strictly in the future (`pacingReleaseUs` floors the wait at one timer
+    /// granularity), so a loop that sleeps until it always advances.
+    pub fn nextSendTimeUs(self: *Connection, now_us: u64) ?u64 {
+        if (self.state_ != .established) return null;
+        if (!self.hasAppContent()) return null;
+        const size = self.recovery.congestion.max_datagram_size;
+        // Congestion control is the harder gate and it is not a pacing
+        // deadline: when the window is what is holding the sender back, the
+        // PTO and loss timers `nextTimeoutUs` already reports are what should
+        // wake the loop. Mirrors `buildPacket`'s window check so this never
+        // promises a wakeup that would produce nothing.
+        const cwnd_room = self.recovery.congestion.congestion_window -| self.recovery.congestion.bytes_in_flight;
+        if (cwnd_room < size / 2 and self.recovery.congestion.bytes_in_flight != 0) return null;
+        if (self.recovery.pacingAllows(size, now_us)) return null;
+        return self.recovery.pacingReleaseUs(size, now_us);
+    }
+
     /// The peer's largest acknowledged packet number in a space, as the
     /// reference `packet.packetNumberLength` encodes against — or null when
     /// there isn't a usable one.
@@ -4421,11 +4452,30 @@ pub const Connection = struct {
         // Congestion gate: in-flight bytes need window; pure ACK packets and
         // PTO probes are exempt (RFC 9002 §7, §6.2.4).
         const cwnd_room = self.recovery.congestion.congestion_window -| self.recovery.congestion.bytes_in_flight;
+
+        // #256-C: the RFC 9002 §7.7 pacing gate. It only ever *delays* — the
+        // window term below and the anti-amplification check after it remain
+        // the gates that refuse outright. What waits on a token is
+        // application-space data, and only that:
+        //   * a pure ACK is not congestion controlled at all, so metering it
+        //     would add latency to acknowledgements for no capacity reason;
+        //   * a PTO probe is recovery traffic RFC 9002 §7 already exempts from
+        //     the window, and making loss recovery wait on a token is how a
+        //     stalled connection stays stalled;
+        //   * Initial/Handshake flights are bounded by the initial window and,
+        //     for a server, by anti-amplification — pacing the handshake at a
+        //     rate derived from an RTT nobody has measured yet would slow every
+        //     connection setup to buy nothing.
+        // The bytes all three put on the wire are still charged to the bucket
+        // (`RecoveryController.chargeSend`); they simply never wait on it.
+        const pacing_blocked = space == .application and !probe and
+            !self.recovery.pacingAllows(self.recovery.congestion.max_datagram_size, now_us);
+
         // Recovery's tracker is bounded. An in-flight packet it cannot track
         // would escape both loss detection and the congestion window, so
         // preflight a slot here — before any frame is dequeued — and fall back
         // to ACK-only output rather than sending something uncharged.
-        const can_send_data = can_track_ordinary and (probe or
+        const can_send_data = can_track_ordinary and !pacing_blocked and (probe or
             cwnd_room >= self.recovery.congestion.max_datagram_size / 2 or
             self.recovery.congestion.bytes_in_flight == 0);
 
@@ -12658,4 +12708,215 @@ test "driver: a fully saturated tracker never seals a padded in-flight packet" {
     _ = pair.server.recovery.tracker.dropSpace(.initial);
     try pair.pump();
     try testing.expect(pair.server.isEstablished());
+}
+
+// -- #256-C: pacing ----------------------------------------------------------
+
+/// A connection parked where pacing, and only pacing, is what bounds egress:
+/// established, a large stream queued, and a fresh token bucket. Every other
+/// gate — the window, flow control, the recovery tracker, anti-amplification —
+/// is deliberately left with slack, so a test that observes backpressure here
+/// is observing the pacer.
+///
+/// The window and RTT are pinned rather than inherited from the handshake,
+/// which leaves a sub-millisecond RTT that would put the pacing rate in the
+/// hundreds of MB/s — a rate at which the schedule correctly stops mattering
+/// and there would be nothing to observe. A 64 kB window over a 100 ms RTT
+/// paces one 1200-byte datagram every 1.5 ms, and holds ~53 datagrams, so the
+/// ten-datagram burst ceiling is the binding constraint and not the window.
+fn pacedServerPair(allocator: std.mem.Allocator) !*TestPair {
+    const pair = try TestPair.init(allocator);
+    errdefer pair.deinit(allocator);
+    try pair.pump();
+
+    const sid = try openServerResponseStream(pair);
+    _ = try pair.server.writeStream(sid, &[_]u8{0xab} ** (64 * 1024), false);
+
+    pair.server.recovery.rtt = recovery.RttEstimator.init(25_000);
+    pair.server.recovery.rtt.update(100_000, 0);
+    const congestion = &pair.server.recovery.congestion;
+    congestion.congestion_window = 64 * 1024;
+    congestion.ssthresh = 64 * 1024;
+    congestion.bytes_in_flight = 0;
+    congestion.pacer = .{};
+    return pair;
+}
+
+/// Drain every datagram the connection will produce at one frozen instant.
+/// Distinct from `drainTransmits`, which advances the clock between datagrams
+/// and so lets the bucket refill mid-drain — exactly what a burst-bound test
+/// must not do.
+fn drainAtInstant(conn: *Connection, now_us: u64) usize {
+    var out: [max_datagram_size_ceiling]u8 = undefined;
+    var count: usize = 0;
+    while (conn.pollTransmitOnPath(&out, now_us)) |_| count += 1;
+    return count;
+}
+
+test "driver: pacing bounds one instant's egress and declines rather than sleeping" {
+    const allocator = testing.allocator;
+    var pair = try pacedServerPair(allocator);
+    defer pair.deinit(allocator);
+
+    const now = pair.now_us;
+    const congestion = &pair.server.recovery.congestion;
+    const mds = pair.server.effectiveMaxDatagramSize();
+
+    // The event loop asks for datagrams until it is told no. With the clock
+    // frozen, what stops it is the burst ceiling — not a sleep inside packet
+    // construction, and not the 512 kB window, which is wide enough for far
+    // more than this.
+    const burst = drainAtInstant(pair.server, now);
+    try testing.expect(burst > 0);
+    try testing.expect(burst <= recovery.default_pacer_burst_packets);
+    try testing.expect(congestion.bytes_in_flight < congestion.congestion_window);
+    try testing.expect(!pair.server.recovery.pacingAllows(mds, now));
+
+    // Asking again at the same instant produces nothing at all: the listener
+    // stops, it does not spin.
+    try testing.expectEqual(@as(usize, 0), drainAtInstant(pair.server, now));
+}
+
+test "driver: a paced connection reports the wakeup deadline its send path is waiting on" {
+    const allocator = testing.allocator;
+    var pair = try pacedServerPair(allocator);
+    defer pair.deinit(allocator);
+
+    const now = pair.now_us;
+    _ = drainAtInstant(pair.server, now);
+
+    // Nothing in `nextTimeoutUs` knows about the pacer, so without this the
+    // event loop would have no deadline for the data it is holding back.
+    const release = pair.server.nextSendTimeUs(now) orelse return error.TestExpectedEqual;
+    try testing.expect(release > now);
+
+    // Strictly in the future, so sleeping until it always advances — and
+    // nothing more comes out before it does.
+    try testing.expectEqual(@as(usize, 0), drainAtInstant(pair.server, release - 1));
+
+    // At the deadline the send path produces again, and having produced, it is
+    // once more waiting on a later deadline.
+    const in_flight_before = pair.server.recovery.congestion.bytes_in_flight;
+    try testing.expect(drainAtInstant(pair.server, release) > 0);
+    try testing.expect(pair.server.recovery.congestion.bytes_in_flight > in_flight_before);
+    const next = pair.server.nextSendTimeUs(release) orelse return error.TestExpectedEqual;
+    try testing.expect(next > release);
+}
+
+test "driver: pacing spaces datagrams evenly once the opening burst is spent" {
+    const allocator = testing.allocator;
+    var pair = try pacedServerPair(allocator);
+    defer pair.deinit(allocator);
+
+    var now = pair.now_us;
+    _ = drainAtInstant(pair.server, now);
+
+    // What one maximum-size datagram costs at this pacing rate, from an empty
+    // bucket — the interval the schedule is aiming at.
+    const mds = pair.server.effectiveMaxDatagramSize();
+    var empty = pair.server.recovery.congestion;
+    empty.pacer = .{ .tokens = 0, .updated_at_us = 0 };
+    const interval = empty.pacingReleaseUs(mds, 0, pair.server.recovery.rtt);
+
+    // Past the opening burst, each wakeup waits about one datagram-interval
+    // and releases a datagram or two — never the ceiling again. That is the
+    // whole point of the bucket: a window's worth of data reaches the path
+    // spread across a round trip instead of as one flight.
+    //
+    // Not exactly `interval` each time, because a datagram that comes out
+    // slightly under the maximum size leaves that much credit behind and
+    // shortens the next wait. Bounded above by construction (the deficit can
+    // never exceed a full datagram) and, for a stream this large, never far
+    // below it.
+    var step: usize = 0;
+    while (step < 5) : (step += 1) {
+        const release = pair.server.nextSendTimeUs(now) orelse return error.TestExpectedEqual;
+        const gap = release - now;
+        try testing.expect(gap > 0);
+        try testing.expect(gap <= interval);
+        try testing.expect(gap >= interval / 2);
+
+        const emitted = drainAtInstant(pair.server, release);
+        try testing.expect(emitted > 0);
+        try testing.expect(emitted < recovery.default_pacer_burst_packets);
+        now = release;
+    }
+}
+
+test "driver: an idle paced connection restarts with a burst rather than a backlog" {
+    const allocator = testing.allocator;
+    var pair = try pacedServerPair(allocator);
+    defer pair.deinit(allocator);
+
+    const now = pair.now_us;
+    const burst = drainAtInstant(pair.server, now);
+    try testing.expect(burst > 0);
+
+    // A second's silence is worth many times the burst in accrued credit. The
+    // restart is bounded by the same ceiling as the opening flight, so a
+    // connection coming back from idle cannot hand the path a datagram storm.
+    const after_idle = now + 1_000_000;
+    const restart = drainAtInstant(pair.server, after_idle);
+    try testing.expect(restart > 0);
+    try testing.expect(restart <= recovery.default_pacer_burst_packets);
+    try testing.expectEqual(@as(usize, 0), drainAtInstant(pair.server, after_idle));
+}
+
+test "driver: congestion control outranks pacing, and reports no pacing deadline" {
+    const allocator = testing.allocator;
+    var pair = try pacedServerPair(allocator);
+    defer pair.deinit(allocator);
+
+    const now = pair.now_us;
+    const congestion = &pair.server.recovery.congestion;
+
+    // A full bucket over a closed window puts nothing new on the wire. Pacing
+    // releases traffic; it never authorises it past the window. Measured on
+    // the in-flight ledger rather than on the datagram count, because a pure
+    // ACK is entitled to leave here and is not charged to the window.
+    congestion.bytes_in_flight = congestion.congestion_window;
+    const closed = congestion.bytes_in_flight;
+    try testing.expect(pair.server.recovery.pacingAllows(pair.server.effectiveMaxDatagramSize(), now));
+    _ = drainAtInstant(pair.server, now);
+    try testing.expectEqual(closed, congestion.bytes_in_flight);
+
+    // And no pacing deadline is reported for it: the pacer is not what this
+    // connection is waiting on, so the loss and PTO timers `nextTimeoutUs`
+    // already publishes are what should wake the loop.
+    try testing.expectEqual(@as(?u64, null), pair.server.nextSendTimeUs(now));
+
+    // Reopening the window releases the data without any wait — the credit
+    // was there the whole time.
+    congestion.bytes_in_flight = 0;
+    try testing.expect(drainAtInstant(pair.server, now) > 0);
+}
+
+test "driver: an acknowledgement is not delayed by a spent pacing bucket" {
+    const allocator = testing.allocator;
+    var pair = try pacedServerPair(allocator);
+    defer pair.deinit(allocator);
+
+    const now = pair.now_us;
+    _ = drainAtInstant(pair.server, now);
+    try testing.expect(!pair.server.recovery.pacingAllows(pair.server.effectiveMaxDatagramSize(), now));
+
+    // The client sends something ack-eliciting into a server whose bucket is
+    // empty. An ACK is not congestion-controlled traffic, so metering it would
+    // add pure latency to the peer's recovery for no capacity reason.
+    const sid = try pair.client.openStream(.uni);
+    _ = try pair.client.writeStream(sid, "ping", false);
+    var out: [max_datagram_size_ceiling]u8 = undefined;
+    var delivered: usize = 0;
+    while (pair.client.pollTransmitOnPath(&out, now)) |t| {
+        const ingress = quic_path.PathKey{ .local = t.path.remote, .remote = t.path.local };
+        try pair.server.ingestOnPath(t.bytes, ingress, TestPair.test_challenge_entropy, now);
+        delivered += 1;
+    }
+    try testing.expect(delivered > 0);
+
+    // Forced past the delayed-ACK timer so this is about pacing and not about
+    // the ACK still legitimately waiting.
+    pair.server.ack_eliciting_since_ack[Connection.spaceIndex(.application)] = ack_eliciting_threshold;
+    const ack = pair.server.pollTransmitOnPath(&out, now) orelse return error.TestExpectedEqual;
+    try testing.expect(ack.bytes.len > 0);
 }

--- a/src/quic/recovery.zig
+++ b/src/quic/recovery.zig
@@ -34,12 +34,26 @@ pub const default_max_ack_delay_us: u64 = 25_000;
 /// bursts; this bounds them at the initial window, so a connection whose
 /// congestion window has grown to many times that still cannot hand the
 /// network a window-sized burst in a single event-loop pass.
+///
+/// A packet count is only half the ceiling — `Pacer.burstBytes` also applies
+/// `initialWindow`, which is what keeps the "initial window" claim true once
+/// DPLPMTUD raises the datagram size past 1472.
 pub const default_pacer_burst_packets: usize = 10;
 
 const time_threshold_numerator: u64 = 9;
 const time_threshold_denominator: u64 = 8;
-/// RFC 9002 §7.7's pacing gain `N`: 2 while in slow start, 1.25 in congestion
-/// avoidance.
+/// The pacing gain `N` in RFC 9002 §7.7's rate `N * cwnd / smoothed_rtt`:
+/// 2 while in slow start, 1.25 in congestion avoidance.
+///
+/// This phase split is Tardigrade's policy, not an RFC requirement. The final
+/// RFC 9002 fixes the *shape* of the rate and asks only that `N` be a small
+/// value above 1, offering 1.25 as an example; the explicit slow-start/
+/// congestion-avoidance split comes from the earlier QUIC recovery drafts and
+/// is what several deployed stacks still do. It is kept here for the reason
+/// those drafts gave: slow start doubles the window every round trip, so
+/// pacing it at 1.25x would hold the sender below the growth the window is
+/// already granting, while congestion avoidance wants the smaller gain to
+/// keep a full window from leaving as one burst.
 const pacing_gain_slow_start_numerator: u64 = 2;
 const pacing_gain_slow_start_denominator: u64 = 1;
 const pacing_gain_avoidance_numerator: u64 = 5;
@@ -897,11 +911,9 @@ pub const CongestionController = struct {
         self.ssthresh = self.congestion_window;
     }
 
-    /// RFC 9002 §7.7's pacing gain `N`, as an exact fraction so the schedule
-    /// stays integer arithmetic. Slow start doubles the window every round
-    /// trip, so pacing it at 1.25× would hold the sender below the growth the
-    /// window is already granting; congestion avoidance wants the smaller
-    /// gain, which is what keeps a full window from leaving as one burst.
+    /// The pacing gain `N`, as an exact fraction so the schedule stays integer
+    /// arithmetic. See `pacing_gain_slow_start_numerator` for why the split by
+    /// phase is a local policy rather than something RFC 9002 prescribes.
     fn pacingGain(self: CongestionController) PacingGain {
         if (self.congestion_window < self.ssthresh) {
             return .{ .numerator = pacing_gain_slow_start_numerator, .denominator = pacing_gain_slow_start_denominator };
@@ -916,7 +928,11 @@ pub const CongestionController = struct {
         return @max(self.congestion_window, self.minWindow());
     }
 
-    /// Bytes the pacing bucket holds at `now_us` (#256-C).
+    /// The pacing bucket's balance at `now_us`, in bytes (#256-C).
+    ///
+    /// Signed, and the sign carries meaning: a negative balance is *debt* left
+    /// by a packet that bypassed the pacing gate. Exempt means "may send
+    /// now", not "free from the schedule" — see `onPacingSent`.
     ///
     /// Pure by design: asking "may I send?" must not itself move the
     /// schedule, so the bucket is only ever advanced by `onPacingSent`, and
@@ -924,8 +940,8 @@ pub const CongestionController = struct {
     /// computed from the last charge rather than accumulated tick by tick,
     /// which is what makes the schedule independent of how often the event
     /// loop happens to wake.
-    pub fn pacingTokens(self: CongestionController, now_us: u64, rtt: RttEstimator) usize {
-        const burst = self.pacer.burstBytes(self.max_datagram_size);
+    pub fn pacingBalance(self: CongestionController, now_us: u64, rtt: RttEstimator) i64 {
+        const burst: i64 = @intCast(self.pacer.burstBytes(self.max_datagram_size));
         // A pacer that has never sent starts full: the first flight of a
         // connection (and the first after an idle period, once
         // `onPacingSent`'s stamp has aged past a full burst's worth of
@@ -937,13 +953,18 @@ pub const CongestionController = struct {
         const gain = self.pacingGain();
         const gained = (@as(u128, elapsed) * gain.numerator * self.pacingWindow()) /
             (@as(u128, gain.denominator) * srtt);
-        return @intCast(@min(@as(u128, self.pacer.tokens) + gained, @as(u128, burst)));
+        // Clamp the *gain* before adding it: a long idle period accrues more
+        // credit than an i64 can hold, and the ceiling below discards all of
+        // it anyway. Saturating addition then keeps a large gain from wrapping
+        // a large debt.
+        const earned: i64 = @intCast(@min(gained, @as(u128, std.math.maxInt(i64) / 2)));
+        return @min(self.pacer.balance +| earned, burst);
     }
 
     /// Whether a `bytes`-sized congestion-controlled datagram is eligible to
     /// leave at `now_us` under the pacing schedule.
     pub fn pacingAllows(self: CongestionController, bytes: usize, now_us: u64, rtt: RttEstimator) bool {
-        return self.pacingTokens(now_us, rtt) >= bytes;
+        return self.pacingBalance(now_us, rtt) >= @as(i64, @intCast(bytes));
     }
 
     /// The earliest time `bytes` becomes eligible — `now_us` when it already
@@ -959,12 +980,15 @@ pub const CongestionController = struct {
     /// path would round every release up and, against a bounded burst, cap the
     /// sender at `burst / 1 ms` no matter how much window and RTT allowed.
     pub fn pacingReleaseUs(self: CongestionController, bytes: usize, now_us: u64, rtt: RttEstimator) u64 {
-        const tokens = self.pacingTokens(now_us, rtt);
-        if (tokens >= bytes) return now_us;
-        const deficit = bytes - tokens;
+        const balance = self.pacingBalance(now_us, rtt);
+        const want: i64 = @intCast(bytes);
+        if (balance >= want) return now_us;
+        // Widened before subtracting: `balance` may be a debt, in which case
+        // the wait covers repaying it *and* earning this packet's own credit.
+        const deficit: u128 = @intCast(@as(i128, want) - @as(i128, balance));
         const srtt = @max(rtt.smoothed_rtt_us orelse initial_rtt_us, 1);
         const gain = self.pacingGain();
-        const numerator = @as(u128, deficit) * gain.denominator * srtt;
+        const numerator = deficit * gain.denominator * srtt;
         const denominator = @as(u128, gain.numerator) * self.pacingWindow();
         const delay: u64 = @intCast(@min((numerator + denominator - 1) / denominator, @as(u128, std.math.maxInt(u32))));
         return now_us + @max(delay, 1);
@@ -974,8 +998,19 @@ pub const CongestionController = struct {
     /// congestion-controlled packet that actually left, and only for those:
     /// a pure ACK is not in flight and is not metered here, which is what
     /// keeps acknowledgement latency independent of the send schedule.
+    ///
+    /// The charge can drive the balance negative, and deliberately so. Packets
+    /// that bypass the pacing gate — PTO probes, Initial/Handshake flights,
+    /// DPLPMTUD probes, candidate-path validation — still arrive here, and
+    /// they routinely leave when the bucket cannot cover them. Clamping the
+    /// balance at zero would discard that overdraft: the exempt packet would
+    /// consume path capacity for free, and one interval later ordinary
+    /// application data would be released as though it had never been sent.
+    /// Carrying the debt makes that next packet wait for the rate its
+    /// predecessor actually used. Exempt means "may send now", not "outside
+    /// the schedule".
     pub fn onPacingSent(self: *CongestionController, bytes: usize, now_us: u64, rtt: RttEstimator) void {
-        self.pacer.tokens = self.pacingTokens(now_us, rtt) -| bytes;
+        self.pacer.balance = self.pacingBalance(now_us, rtt) -| @as(i64, @intCast(bytes));
         // Never move the stamp backwards: a coalesced datagram's packets are
         // charged one after another with the same timestamp, and a caller
         // replaying an older `now_us` must not hand the bucket a second refill
@@ -985,17 +1020,17 @@ pub const CongestionController = struct {
 
     pub fn pacingHint(self: CongestionController, now_us: u64, rtt: RttEstimator) PacingHint {
         const allowance = self.congestion_window -| self.bytes_in_flight;
-        const tokens = self.pacingTokens(now_us, rtt);
+        const balance = self.pacingBalance(now_us, rtt);
         if (allowance == 0) {
             return .{
                 .bytes_available = 0,
-                .pacing_tokens = tokens,
+                .pacing_balance = balance,
                 .next_send_time_us = now_us + rtt.ptoDuration(.application),
             };
         }
         return .{
             .bytes_available = allowance,
-            .pacing_tokens = tokens,
+            .pacing_balance = balance,
             .next_send_time_us = self.pacingReleaseUs(@min(self.max_datagram_size, allowance), now_us, rtt),
         };
     }
@@ -1003,19 +1038,21 @@ pub const CongestionController = struct {
 
 const PacingGain = struct { numerator: u64, denominator: u64 };
 
-/// RFC 9002 §7.7 leaky-bucket pacer (#256-C). Credit accrues at the pacing
-/// rate `N * congestion_window / smoothed_rtt` and is spent by packets that
-/// leave; the bucket's ceiling is what bounds a burst, so a sender whose
-/// window has grown large still cannot empty it onto the wire in one pass.
+/// Leaky-bucket pacer (#256-C). Credit accrues at the RFC 9002 §7.7 rate
+/// `N * congestion_window / smoothed_rtt` and is spent by packets that leave;
+/// the bucket's ceiling is what bounds a burst, so a sender whose window has
+/// grown large still cannot empty it onto the wire in one pass.
 ///
 /// Deliberately a token bucket rather than a rate estimator: BBR and any
 /// other bandwidth model are out of scope here (#240 non-goals). This one only
 /// ever *delays* traffic — congestion control and anti-amplification stay the
 /// gates that can refuse it outright.
 pub const Pacer = struct {
-    /// Credit remaining as of `updated_at_us`, in bytes.
-    tokens: usize = 0,
-    /// When `tokens` was last charged. Null until the first paced packet: an
+    /// Balance as of `updated_at_us`, in bytes. Signed: see
+    /// `CongestionController.onPacingSent` for why an overdraft has to be
+    /// carried rather than clamped away.
+    balance: i64 = 0,
+    /// When `balance` was last charged. Null until the first paced packet: an
     /// unused pacer is treated as full, not empty.
     updated_at_us: ?u64 = null,
     /// The burst ceiling, in maximum-size datagrams. Expressed in packets
@@ -1024,16 +1061,30 @@ pub const Pacer = struct {
     /// being frozen at whatever it was when the connection started.
     burst_packets: usize = default_pacer_burst_packets,
 
+    /// The ceiling in bytes, which is the NewReno *initial window* for the
+    /// current datagram size — not simply `burst_packets * size`.
+    ///
+    /// The two part company above a 1472-byte datagram, because
+    /// `initialWindow` carries RFC 9002 §7.2's absolute 14720-byte cap and a
+    /// packet count does not. Once DPLPMTUD raises the path size to, say,
+    /// 2048, ten packets would be 20480 bytes — half again the window a fresh
+    /// connection is trusted with, handed to the path in one pass after every
+    /// idle period. Taking the smaller of the two keeps the stated contract
+    /// true at every datagram size this transport supports.
     pub fn burstBytes(self: Pacer, max_datagram_size: usize) usize {
-        return self.burst_packets * max_datagram_size;
+        return @min(
+            self.burst_packets * max_datagram_size,
+            CongestionController.initialWindow(max_datagram_size),
+        );
     }
 };
 
 pub const PacingHint = struct {
     /// Bytes the congestion window still permits in flight.
     bytes_available: usize,
-    /// Bytes the pacing bucket has credited at the queried instant.
-    pacing_tokens: usize,
+    /// The pacing bucket's balance at the queried instant. Negative when a
+    /// packet exempt from the pacing gate overdrew it.
+    pacing_balance: i64,
     /// The earliest instant a maximum-size datagram may leave: the queried
     /// time when the sender is eligible now, the pacing release time when the
     /// bucket is short, and a PTO out when the window itself is full.
@@ -1046,7 +1097,7 @@ pub const PacingHint = struct {
     /// Whether a `bytes`-sized congestion-controlled datagram may leave right
     /// now: it needs both window and pacing credit.
     pub fn canSendNow(self: PacingHint, bytes: usize) bool {
-        return self.bytes_available >= bytes and self.pacing_tokens >= bytes;
+        return self.bytes_available >= bytes and self.pacing_balance >= @as(i64, @intCast(bytes));
     }
 };
 
@@ -1807,7 +1858,7 @@ test "pacing: a bounded burst leaves back to back, then the bucket is empty" {
     const cc = &fixture.cc;
     const now: u64 = 1_000_000;
 
-    try testing.expectEqual(@as(usize, 12_000), cc.pacingTokens(now, fixture.rtt));
+    try testing.expectEqual(@as(i64, 12_000), cc.pacingBalance(now, fixture.rtt));
 
     // The whole burst leaves at one instant of the fake clock: nothing here
     // advances time, so the only thing that can stop the tenth datagram is the
@@ -1818,7 +1869,7 @@ test "pacing: a bounded burst leaves back to back, then the bucket is empty" {
         if (sent > default_pacer_burst_packets) break;
     }
     try testing.expectEqual(default_pacer_burst_packets, sent);
-    try testing.expectEqual(@as(usize, 0), cc.pacingTokens(now, fixture.rtt));
+    try testing.expectEqual(@as(i64, 0), cc.pacingBalance(now, fixture.rtt));
     try testing.expect(!cc.pacingAllows(1_200, now, fixture.rtt));
 }
 
@@ -1847,9 +1898,69 @@ test "pacing: the release schedule spaces datagrams at the RFC 9002 rate" {
         cc.onPacingSent(1_200, now, fixture.rtt);
         // One datagram's worth of credit was earned and one was spent, so the
         // sender never banks a second burst while it is transmitting.
-        try testing.expect(cc.pacingTokens(now, fixture.rtt) < 1_200);
+        try testing.expect(cc.pacingBalance(now, fixture.rtt) < 1_200);
         previous = now;
     }
+}
+
+test "pacing: an exempt packet carries its debt instead of sending for free" {
+    var fixture = pacingFixture();
+    const cc = &fixture.cc;
+    const now: u64 = 1_000_000;
+    while (cc.pacingAllows(1_200, now, fixture.rtt)) cc.onPacingSent(1_200, now, fixture.rtt);
+    try testing.expectEqual(@as(i64, 0), cc.pacingBalance(now, fixture.rtt));
+
+    // A PTO probe, handshake flight, DPLPMTUD probe or path-validation packet
+    // bypasses the pacing gate — but it still puts 1200 bytes on the wire, and
+    // `chargeSend` still bills it. With the bucket already empty the balance
+    // has to go *negative*: clamping it at zero would hand the path a free
+    // datagram's worth of rate.
+    cc.onPacingSent(1_200, now, fixture.rtt);
+    try testing.expectEqual(@as(i64, -1_200), cc.pacingBalance(now, fixture.rtt));
+
+    // One ordinary interval later the debt is exactly repaid and nothing more,
+    // so application data is *still* blocked — where a discarded overdraft
+    // would have released it as though the exempt packet never existed.
+    const one_interval = now + 8_000;
+    try testing.expectEqual(@as(i64, 0), cc.pacingBalance(one_interval, fixture.rtt));
+    try testing.expect(!cc.pacingAllows(1_200, one_interval, fixture.rtt));
+
+    // It becomes eligible only after the debt *plus* its own credit has
+    // accrued — two intervals, which is what the release time reports.
+    try testing.expectEqual(now + 16_000, cc.pacingReleaseUs(1_200, now, fixture.rtt));
+    try testing.expect(cc.pacingAllows(1_200, now + 16_000, fixture.rtt));
+}
+
+test "pacing: the burst ceiling stays the initial window at every datagram size" {
+    var rtt = RttEstimator.init(25_000);
+    rtt.update(100_000, 0);
+    const pacer = Pacer{};
+
+    // At and below 1472 bytes the packet count is the binding term, and ten
+    // packets is exactly the initial window.
+    try testing.expectEqual(@as(usize, 12_000), pacer.burstBytes(1_200));
+    try testing.expectEqual(CongestionController.initialWindow(1_200), pacer.burstBytes(1_200));
+    try testing.expectEqual(CongestionController.initialWindow(1_452), pacer.burstBytes(1_452));
+
+    // Above it RFC 9002 §7.2's absolute 14720-byte cap takes over, and a plain
+    // packet count would not know about it: ten 2048-byte datagrams are 20480
+    // bytes, half again the window a fresh connection is trusted with.
+    try testing.expect(10 * 2_048 > CongestionController.initialWindow(2_048));
+    try testing.expectEqual(@as(usize, 14_720), pacer.burstBytes(2_048));
+
+    // And the ceiling is what an idle restart actually gets, not just a
+    // number: after DPLPMTUD raises the size, the restart burst is the initial
+    // window rather than ten packets.
+    var cc = CongestionController{ .congestion_window = 512 * 1024, .ssthresh = 512 * 1024 };
+    cc.setMaxDatagramSize(2_048);
+    const now: u64 = 1_000_000;
+    var sent: usize = 0;
+    while (cc.pacingAllows(2_048, now, rtt)) : (sent += 1) {
+        cc.onPacingSent(2_048, now, rtt);
+        if (sent > default_pacer_burst_packets) break;
+    }
+    try testing.expectEqual(@as(usize, 7), sent);
+    try testing.expect(sent * 2_048 <= CongestionController.initialWindow(2_048));
 }
 
 test "pacing: a fast path keeps its sub-millisecond interval" {
@@ -1895,7 +2006,7 @@ test "pacing: an idle sender restarts with one burst, not with everything it mis
     // quiet would come back entitled to dump its whole idle period onto the
     // path in one pass.
     const after_idle = now + 10_000_000;
-    try testing.expectEqual(@as(usize, 12_000), cc.pacingTokens(after_idle, fixture.rtt));
+    try testing.expectEqual(@as(i64, 12_000), cc.pacingBalance(after_idle, fixture.rtt));
 
     var sent: usize = 0;
     while (cc.pacingAllows(1_200, after_idle, fixture.rtt)) : (sent += 1) {
@@ -1914,7 +2025,7 @@ test "pacing: the congestion window stays the harder gate" {
     // traffic, never authorise it.
     cc.bytes_in_flight = cc.congestion_window;
     const blocked = cc.pacingHint(now, fixture.rtt);
-    try testing.expectEqual(@as(usize, 12_000), blocked.pacing_tokens);
+    try testing.expectEqual(@as(i64, 12_000), blocked.pacing_balance);
     try testing.expect(cc.pacingAllows(1_200, now, fixture.rtt));
     try testing.expect(!blocked.canSend());
     try testing.expect(!blocked.canSendNow(1_200));
@@ -1960,7 +2071,7 @@ test "pacing: only in-flight packets are metered, and a shrinking window slows t
 
     // A pure ACK is not congestion controlled, so it spends no credit —
     // acknowledgement latency must not depend on the send schedule.
-    const before = controller.congestion.pacingTokens(now, controller.rtt);
+    const before = controller.congestion.pacingBalance(now, controller.rtt);
     try controller.onPacketSent(.{
         .space = .application,
         .packet_number = 0,
@@ -1969,7 +2080,7 @@ test "pacing: only in-flight packets are metered, and a shrinking window slows t
         .ack_eliciting = false,
         .in_flight = false,
     });
-    try testing.expectEqual(before, controller.congestion.pacingTokens(now, controller.rtt));
+    try testing.expectEqual(before, controller.congestion.pacingBalance(now, controller.rtt));
 
     // An in-flight packet is.
     try controller.onPacketSent(.{
@@ -1978,7 +2089,7 @@ test "pacing: only in-flight packets are metered, and a shrinking window slows t
         .time_sent_us = now,
         .size = 1_200,
     });
-    try testing.expectEqual(before - 1_200, controller.congestion.pacingTokens(now, controller.rtt));
+    try testing.expectEqual(before - 1_200, controller.congestion.pacingBalance(now, controller.rtt));
 
     // Halving the window halves the pacing rate: the schedule is derived from
     // congestion control rather than running alongside it.

--- a/src/quic/recovery.zig
+++ b/src/quic/recovery.zig
@@ -29,8 +29,21 @@ pub const timer_granularity_us: u64 = 1_000;
 pub const packet_threshold: u64 = 3;
 pub const default_max_ack_delay_us: u64 = 25_000;
 
+/// How many maximum-size datagrams the pacer will let leave back to back
+/// (#256-C). RFC 9002 §7.7 requires a sender to either pace or bound its
+/// bursts; this bounds them at the initial window, so a connection whose
+/// congestion window has grown to many times that still cannot hand the
+/// network a window-sized burst in a single event-loop pass.
+pub const default_pacer_burst_packets: usize = 10;
+
 const time_threshold_numerator: u64 = 9;
 const time_threshold_denominator: u64 = 8;
+/// RFC 9002 §7.7's pacing gain `N`: 2 while in slow start, 1.25 in congestion
+/// avoidance.
+const pacing_gain_slow_start_numerator: u64 = 2;
+const pacing_gain_slow_start_denominator: u64 = 1;
+const pacing_gain_avoidance_numerator: u64 = 5;
+const pacing_gain_avoidance_denominator: u64 = 4;
 
 pub const PacketNumberSpace = enum {
     initial,
@@ -804,6 +817,11 @@ pub const CongestionController = struct {
     /// size the packet builder actually emits rather than a compile-time
     /// constant (#256-A).
     max_datagram_size: usize = initial_max_datagram_size,
+    /// RFC 9002 §7.7 pacing state (#256-C). Lives here because the pacing
+    /// rate is a function of this controller's window: a reset that discards
+    /// the window (path migration) must discard the schedule derived from it
+    /// in the same step.
+    pacer: Pacer = .{},
 
     pub fn initialWindow(max_datagram: usize) usize {
         return @min(10 * max_datagram, @max(2 * max_datagram, 14_720));
@@ -879,19 +897,149 @@ pub const CongestionController = struct {
         self.ssthresh = self.congestion_window;
     }
 
+    /// RFC 9002 §7.7's pacing gain `N`, as an exact fraction so the schedule
+    /// stays integer arithmetic. Slow start doubles the window every round
+    /// trip, so pacing it at 1.25× would hold the sender below the growth the
+    /// window is already granting; congestion avoidance wants the smaller
+    /// gain, which is what keeps a full window from leaving as one burst.
+    fn pacingGain(self: CongestionController) PacingGain {
+        if (self.congestion_window < self.ssthresh) {
+            return .{ .numerator = pacing_gain_slow_start_numerator, .denominator = pacing_gain_slow_start_denominator };
+        }
+        return .{ .numerator = pacing_gain_avoidance_numerator, .denominator = pacing_gain_avoidance_denominator };
+    }
+
+    /// The window the pacing rate is derived from. Floored at the minimum
+    /// window so a controller driven to its floor still paces at a rate that
+    /// makes forward progress rather than dividing by a collapsed number.
+    fn pacingWindow(self: CongestionController) u64 {
+        return @max(self.congestion_window, self.minWindow());
+    }
+
+    /// Bytes the pacing bucket holds at `now_us` (#256-C).
+    ///
+    /// Pure by design: asking "may I send?" must not itself move the
+    /// schedule, so the bucket is only ever advanced by `onPacingSent`, and
+    /// two queries at the same instant give the same answer. The refill is
+    /// computed from the last charge rather than accumulated tick by tick,
+    /// which is what makes the schedule independent of how often the event
+    /// loop happens to wake.
+    pub fn pacingTokens(self: CongestionController, now_us: u64, rtt: RttEstimator) usize {
+        const burst = self.pacer.burstBytes(self.max_datagram_size);
+        // A pacer that has never sent starts full: the first flight of a
+        // connection (and the first after an idle period, once
+        // `onPacingSent`'s stamp has aged past a full burst's worth of
+        // refill) is allowed the whole burst rather than being metered out
+        // from an empty bucket.
+        const since = self.pacer.updated_at_us orelse return burst;
+        const elapsed = now_us -| since;
+        const srtt = @max(rtt.smoothed_rtt_us orelse initial_rtt_us, 1);
+        const gain = self.pacingGain();
+        const gained = (@as(u128, elapsed) * gain.numerator * self.pacingWindow()) /
+            (@as(u128, gain.denominator) * srtt);
+        return @intCast(@min(@as(u128, self.pacer.tokens) + gained, @as(u128, burst)));
+    }
+
+    /// Whether a `bytes`-sized congestion-controlled datagram is eligible to
+    /// leave at `now_us` under the pacing schedule.
+    pub fn pacingAllows(self: CongestionController, bytes: usize, now_us: u64, rtt: RttEstimator) bool {
+        return self.pacingTokens(now_us, rtt) >= bytes;
+    }
+
+    /// The earliest time `bytes` becomes eligible — `now_us` when it already
+    /// is. When it is not, the result is strictly greater than `now_us` (at
+    /// least one timer granularity out), so an event loop that sleeps until
+    /// this deadline always makes progress instead of spinning on a deadline
+    /// that has already passed.
+    pub fn pacingReleaseUs(self: CongestionController, bytes: usize, now_us: u64, rtt: RttEstimator) u64 {
+        const tokens = self.pacingTokens(now_us, rtt);
+        if (tokens >= bytes) return now_us;
+        const deficit = bytes - tokens;
+        const srtt = @max(rtt.smoothed_rtt_us orelse initial_rtt_us, 1);
+        const gain = self.pacingGain();
+        const numerator = @as(u128, deficit) * gain.denominator * srtt;
+        const denominator = @as(u128, gain.numerator) * self.pacingWindow();
+        const delay: u64 = @intCast(@min((numerator + denominator - 1) / denominator, @as(u128, std.math.maxInt(u32))));
+        return now_us + @max(delay, timer_granularity_us);
+    }
+
+    /// Charge `bytes` to the pacing bucket at `now_us`. Called for every
+    /// congestion-controlled packet that actually left, and only for those:
+    /// a pure ACK is not in flight and is not metered here, which is what
+    /// keeps acknowledgement latency independent of the send schedule.
+    pub fn onPacingSent(self: *CongestionController, bytes: usize, now_us: u64, rtt: RttEstimator) void {
+        self.pacer.tokens = self.pacingTokens(now_us, rtt) -| bytes;
+        // Never move the stamp backwards: a coalesced datagram's packets are
+        // charged one after another with the same timestamp, and a caller
+        // replaying an older `now_us` must not hand the bucket a second refill
+        // for time it has already been credited.
+        self.pacer.updated_at_us = @max(now_us, self.pacer.updated_at_us orelse now_us);
+    }
+
     pub fn pacingHint(self: CongestionController, now_us: u64, rtt: RttEstimator) PacingHint {
         const allowance = self.congestion_window -| self.bytes_in_flight;
-        if (allowance > 0) return .{ .bytes_available = allowance, .next_send_time_us = now_us };
-        return .{ .bytes_available = 0, .next_send_time_us = now_us + rtt.ptoDuration(.application) };
+        const tokens = self.pacingTokens(now_us, rtt);
+        if (allowance == 0) {
+            return .{
+                .bytes_available = 0,
+                .pacing_tokens = tokens,
+                .next_send_time_us = now_us + rtt.ptoDuration(.application),
+            };
+        }
+        return .{
+            .bytes_available = allowance,
+            .pacing_tokens = tokens,
+            .next_send_time_us = self.pacingReleaseUs(@min(self.max_datagram_size, allowance), now_us, rtt),
+        };
+    }
+};
+
+const PacingGain = struct { numerator: u64, denominator: u64 };
+
+/// RFC 9002 §7.7 leaky-bucket pacer (#256-C). Credit accrues at the pacing
+/// rate `N * congestion_window / smoothed_rtt` and is spent by packets that
+/// leave; the bucket's ceiling is what bounds a burst, so a sender whose
+/// window has grown large still cannot empty it onto the wire in one pass.
+///
+/// Deliberately a token bucket rather than a rate estimator: BBR and any
+/// other bandwidth model are out of scope here (#240 non-goals). This one only
+/// ever *delays* traffic — congestion control and anti-amplification stay the
+/// gates that can refuse it outright.
+pub const Pacer = struct {
+    /// Credit remaining as of `updated_at_us`, in bytes.
+    tokens: usize = 0,
+    /// When `tokens` was last charged. Null until the first paced packet: an
+    /// unused pacer is treated as full, not empty.
+    updated_at_us: ?u64 = null,
+    /// The burst ceiling, in maximum-size datagrams. Expressed in packets
+    /// because that is the unit the bound is meaningful in — the byte ceiling
+    /// follows the sender's current datagram size (#256-A/B) rather than
+    /// being frozen at whatever it was when the connection started.
+    burst_packets: usize = default_pacer_burst_packets,
+
+    pub fn burstBytes(self: Pacer, max_datagram_size: usize) usize {
+        return self.burst_packets * max_datagram_size;
     }
 };
 
 pub const PacingHint = struct {
+    /// Bytes the congestion window still permits in flight.
     bytes_available: usize,
+    /// Bytes the pacing bucket has credited at the queried instant.
+    pacing_tokens: usize,
+    /// The earliest instant a maximum-size datagram may leave: the queried
+    /// time when the sender is eligible now, the pacing release time when the
+    /// bucket is short, and a PTO out when the window itself is full.
     next_send_time_us: u64,
 
     pub fn canSend(self: PacingHint) bool {
         return self.bytes_available > 0;
+    }
+
+    /// Whether a `bytes`-sized congestion-controlled datagram may leave right
+    /// now: it needs both window and pacing credit.
+    pub fn canSendNow(self: PacingHint, bytes: usize) bool {
+        return self.bytes_available >= bytes and self.pacing_tokens >= bytes;
     }
 };
 
@@ -947,14 +1095,37 @@ pub const RecoveryController = struct {
         var tracked = packet;
         tracked.rtt_sample_available_at_send = self.rtt.smoothed_rtt_us != null;
         self.tracker.onPacketSentAssumeRecoveryCapacity(tracked);
-        if (tracked.in_flight) self.congestion.onPacketSent(tracked.size);
+        if (tracked.in_flight) self.chargeSend(tracked);
     }
 
     pub fn onPacketSent(self: *RecoveryController, packet: SentPacket) error{TooManyTrackedPackets}!void {
         var tracked = packet;
         tracked.rtt_sample_available_at_send = self.rtt.smoothed_rtt_us != null;
         try self.tracker.onPacketSent(tracked);
-        if (tracked.in_flight) self.congestion.onPacketSent(tracked.size);
+        if (tracked.in_flight) self.chargeSend(tracked);
+    }
+
+    /// Bill one in-flight packet to the congestion window and, in the same
+    /// step, to the pacing bucket (#256-C). Handshake and PTO traffic is
+    /// charged like everything else even though neither *waits* on the pacer:
+    /// those bytes are genuinely on the wire, and a bucket that ignored them
+    /// would let application data follow a handshake flight at a rate the
+    /// path was never shown to support.
+    fn chargeSend(self: *RecoveryController, packet: SentPacket) void {
+        self.congestion.onPacketSent(packet.size);
+        self.congestion.onPacingSent(packet.size, packet.time_sent_us, self.rtt);
+    }
+
+    /// Whether a `bytes`-sized congestion-controlled datagram may leave at
+    /// `now_us` under the pacing schedule (#256-C).
+    pub fn pacingAllows(self: *const RecoveryController, bytes: usize, now_us: u64) bool {
+        return self.congestion.pacingAllows(bytes, now_us, self.rtt);
+    }
+
+    /// The earliest instant a `bytes`-sized congestion-controlled datagram
+    /// becomes eligible; `now_us` when it already is.
+    pub fn pacingReleaseUs(self: *const RecoveryController, bytes: usize, now_us: u64) u64 {
+        return self.congestion.pacingReleaseUs(bytes, now_us, self.rtt);
     }
 
     pub fn onAcked(self: *RecoveryController, space: PacketNumberSpace, packet_number: u64, now_us: u64, ack_delay_us: u64) error{OutOfMemory}!void {
@@ -1021,7 +1192,10 @@ pub const RecoveryController = struct {
         self.rtt = RttEstimator.init(self.rtt.max_ack_delay_us);
         // A migration resets the measured window, not the sender's datagram
         // size: the packet builder is still emitting that size, and #256-B
-        // revalidates the new path's PMTU separately.
+        // revalidates the new path's PMTU separately. The pacer goes back to
+        // its default with it (#256-C) — its rate is derived from the window
+        // that was just discarded, and credit earned against the old path's
+        // capacity says nothing about the new one.
         self.congestion = .{
             .bytes_in_flight = self.congestion.bytes_in_flight,
             .max_datagram_size = self.congestion.max_datagram_size,
@@ -1602,6 +1776,192 @@ test "NewReno recovery period prevents repeated cwnd cuts and old ACK growth" {
     try testing.expect(cc.congestion_window > after_first_loss);
     try testing.expect(cc.recovery_start_time_us == null);
     try testing.expectEqual(@as(usize, 1_200), cc.bytes_in_flight);
+}
+
+/// A controller parked in congestion avoidance with a 12 kB window and a
+/// 100 ms smoothed RTT, so every pacing number below is exact:
+/// `1.25 * 12_000 B / 0.1 s` is 150 kB/s, one 1200-byte datagram every 8 ms,
+/// and the burst ceiling is `10 * 1200 = 12_000` bytes — ten datagrams.
+fn pacingFixture() struct { cc: CongestionController, rtt: RttEstimator } {
+    var rtt = RttEstimator.init(25_000);
+    rtt.update(100_000, 0);
+    return .{
+        .cc = .{ .congestion_window = 12_000, .ssthresh = 12_000 },
+        .rtt = rtt,
+    };
+}
+
+test "pacing: a bounded burst leaves back to back, then the bucket is empty" {
+    var fixture = pacingFixture();
+    const cc = &fixture.cc;
+    const now: u64 = 1_000_000;
+
+    try testing.expectEqual(@as(usize, 12_000), cc.pacingTokens(now, fixture.rtt));
+
+    // The whole burst leaves at one instant of the fake clock: nothing here
+    // advances time, so the only thing that can stop the tenth datagram is the
+    // bucket's ceiling.
+    var sent: usize = 0;
+    while (cc.pacingAllows(1_200, now, fixture.rtt)) : (sent += 1) {
+        cc.onPacingSent(1_200, now, fixture.rtt);
+        if (sent > default_pacer_burst_packets) break;
+    }
+    try testing.expectEqual(default_pacer_burst_packets, sent);
+    try testing.expectEqual(@as(usize, 0), cc.pacingTokens(now, fixture.rtt));
+    try testing.expect(!cc.pacingAllows(1_200, now, fixture.rtt));
+}
+
+test "pacing: the release schedule spaces datagrams at the RFC 9002 rate" {
+    var fixture = pacingFixture();
+    const cc = &fixture.cc;
+    var now: u64 = 1_000_000;
+
+    while (cc.pacingAllows(1_200, now, fixture.rtt)) cc.onPacingSent(1_200, now, fixture.rtt);
+
+    // 1200 bytes at 150 kB/s is 8 ms, and the deadline is exact rather than
+    // approximate: a datagram is refused at 7999 µs and released at 8000.
+    const release = cc.pacingReleaseUs(1_200, now, fixture.rtt);
+    try testing.expectEqual(now + 8_000, release);
+    try testing.expect(!cc.pacingAllows(1_200, release - 1, fixture.rtt));
+    try testing.expect(cc.pacingAllows(1_200, release, fixture.rtt));
+
+    // And the spacing is a steady interval, not a one-off: each send moves the
+    // next release exactly one interval on.
+    var previous = now;
+    var step: usize = 0;
+    while (step < 4) : (step += 1) {
+        now = cc.pacingReleaseUs(1_200, now, fixture.rtt);
+        try testing.expectEqual(previous + 8_000, now);
+        try testing.expect(cc.pacingAllows(1_200, now, fixture.rtt));
+        cc.onPacingSent(1_200, now, fixture.rtt);
+        // One datagram's worth of credit was earned and one was spent, so the
+        // sender never banks a second burst while it is transmitting.
+        try testing.expect(cc.pacingTokens(now, fixture.rtt) < 1_200);
+        previous = now;
+    }
+}
+
+test "pacing: an idle sender restarts with one burst, not with everything it missed" {
+    var fixture = pacingFixture();
+    const cc = &fixture.cc;
+    const now: u64 = 1_000_000;
+
+    while (cc.pacingAllows(1_200, now, fixture.rtt)) cc.onPacingSent(1_200, now, fixture.rtt);
+
+    // Ten seconds idle is 1.5 MB of credit at this rate. The bucket keeps a
+    // burst and discards the rest: without the ceiling, a connection that went
+    // quiet would come back entitled to dump its whole idle period onto the
+    // path in one pass.
+    const after_idle = now + 10_000_000;
+    try testing.expectEqual(@as(usize, 12_000), cc.pacingTokens(after_idle, fixture.rtt));
+
+    var sent: usize = 0;
+    while (cc.pacingAllows(1_200, after_idle, fixture.rtt)) : (sent += 1) {
+        cc.onPacingSent(1_200, after_idle, fixture.rtt);
+        if (sent > default_pacer_burst_packets) break;
+    }
+    try testing.expectEqual(default_pacer_burst_packets, sent);
+}
+
+test "pacing: the congestion window stays the harder gate" {
+    var fixture = pacingFixture();
+    const cc = &fixture.cc;
+    const now: u64 = 1_000_000;
+
+    // A full bucket over a full window sends nothing: pacing may delay
+    // traffic, never authorise it.
+    cc.bytes_in_flight = cc.congestion_window;
+    const blocked = cc.pacingHint(now, fixture.rtt);
+    try testing.expectEqual(@as(usize, 12_000), blocked.pacing_tokens);
+    try testing.expect(cc.pacingAllows(1_200, now, fixture.rtt));
+    try testing.expect(!blocked.canSend());
+    try testing.expect(!blocked.canSendNow(1_200));
+    try testing.expectEqual(now + fixture.rtt.ptoDuration(.application), blocked.next_send_time_us);
+
+    // Window room alone is not enough either — an empty bucket over an open
+    // window reports the pacing release, not `now`.
+    cc.bytes_in_flight = 0;
+    while (cc.pacingAllows(1_200, now, fixture.rtt)) cc.onPacingSent(1_200, now, fixture.rtt);
+    const paced = cc.pacingHint(now, fixture.rtt);
+    try testing.expect(paced.canSend());
+    try testing.expect(!paced.canSendNow(1_200));
+    try testing.expectEqual(now + 8_000, paced.next_send_time_us);
+
+    // Both open: send now.
+    const ready = cc.pacingHint(now + 8_000, fixture.rtt);
+    try testing.expect(ready.canSendNow(1_200));
+    try testing.expectEqual(now + 8_000, ready.next_send_time_us);
+}
+
+test "pacing: slow start paces at 2x and congestion avoidance at 1.25x" {
+    var fixture = pacingFixture();
+    const cc = &fixture.cc;
+    const now: u64 = 1_000_000;
+    while (cc.pacingAllows(1_200, now, fixture.rtt)) cc.onPacingSent(1_200, now, fixture.rtt);
+
+    // Congestion avoidance (cwnd == ssthresh): N = 1.25, 8 ms apart.
+    try testing.expectEqual(now + 8_000, cc.pacingReleaseUs(1_200, now, fixture.rtt));
+
+    // Slow start doubles the window every round trip, so pacing it at the
+    // avoidance gain would hold the sender below the growth the window is
+    // already granting: N = 2, 5 ms apart.
+    cc.ssthresh = std.math.maxInt(usize);
+    try testing.expectEqual(now + 5_000, cc.pacingReleaseUs(1_200, now, fixture.rtt));
+}
+
+test "pacing: only in-flight packets are metered, and a shrinking window slows the rate" {
+    var controller = RecoveryController{};
+    controller.rtt.update(100_000, 0);
+    controller.congestion.congestion_window = 12_000;
+    controller.congestion.ssthresh = 12_000;
+    const now: u64 = 1_000_000;
+
+    // A pure ACK is not congestion controlled, so it spends no credit —
+    // acknowledgement latency must not depend on the send schedule.
+    const before = controller.congestion.pacingTokens(now, controller.rtt);
+    try controller.onPacketSent(.{
+        .space = .application,
+        .packet_number = 0,
+        .time_sent_us = now,
+        .size = 1_200,
+        .ack_eliciting = false,
+        .in_flight = false,
+    });
+    try testing.expectEqual(before, controller.congestion.pacingTokens(now, controller.rtt));
+
+    // An in-flight packet is.
+    try controller.onPacketSent(.{
+        .space = .application,
+        .packet_number = 1,
+        .time_sent_us = now,
+        .size = 1_200,
+    });
+    try testing.expectEqual(before - 1_200, controller.congestion.pacingTokens(now, controller.rtt));
+
+    // Halving the window halves the pacing rate: the schedule is derived from
+    // congestion control rather than running alongside it.
+    const wide = controller.pacingReleaseUs(12_000, now);
+    controller.congestion.congestion_window = 6_000;
+    controller.congestion.ssthresh = 6_000;
+    const narrow = controller.pacingReleaseUs(12_000, now);
+    try testing.expectEqual(2 * (wide - now), narrow - now);
+}
+
+test "pacing: a path migration discards the schedule with the window it came from" {
+    var controller = RecoveryController{};
+    controller.rtt.update(100_000, 0);
+    const now: u64 = 1_000_000;
+    while (controller.pacingAllows(1_200, now)) {
+        controller.congestion.onPacingSent(1_200, now, controller.rtt);
+    }
+    try testing.expect(!controller.pacingAllows(1_200, now));
+
+    controller.resetForPathMigration();
+    try testing.expect(controller.pacingAllows(1_200, now));
+    try testing.expectEqual(
+        @as(?u64, null),
+        controller.congestion.pacer.updated_at_us,
+    );
 }
 
 test "pacing hint exposes send allowance and blocked wake time" {

--- a/src/quic/recovery.zig
+++ b/src/quic/recovery.zig
@@ -947,10 +947,17 @@ pub const CongestionController = struct {
     }
 
     /// The earliest time `bytes` becomes eligible — `now_us` when it already
-    /// is. When it is not, the result is strictly greater than `now_us` (at
-    /// least one timer granularity out), so an event loop that sleeps until
-    /// this deadline always makes progress instead of spinning on a deadline
-    /// that has already passed.
+    /// is. When it is not, the result is strictly greater than `now_us`, so an
+    /// event loop that sleeps until this deadline always makes progress
+    /// instead of spinning on a deadline that has already passed.
+    ///
+    /// Anti-spin needs exactly one microsecond of headroom and gets it for
+    /// free: the ceil-division below cannot return 0 while the deficit is
+    /// non-zero. Deliberately *not* floored at `timer_granularity_us` — that
+    /// constant is loss-detection timer resolution, and a fast path's pacing
+    /// interval is legitimately far below it. A 1 ms floor on a 40 Mbit-plus
+    /// path would round every release up and, against a bounded burst, cap the
+    /// sender at `burst / 1 ms` no matter how much window and RTT allowed.
     pub fn pacingReleaseUs(self: CongestionController, bytes: usize, now_us: u64, rtt: RttEstimator) u64 {
         const tokens = self.pacingTokens(now_us, rtt);
         if (tokens >= bytes) return now_us;
@@ -960,7 +967,7 @@ pub const CongestionController = struct {
         const numerator = @as(u128, deficit) * gain.denominator * srtt;
         const denominator = @as(u128, gain.numerator) * self.pacingWindow();
         const delay: u64 = @intCast(@min((numerator + denominator - 1) / denominator, @as(u128, std.math.maxInt(u32))));
-        return now_us + @max(delay, timer_granularity_us);
+        return now_us + @max(delay, 1);
     }
 
     /// Charge `bytes` to the pacing bucket at `now_us`. Called for every
@@ -1106,11 +1113,15 @@ pub const RecoveryController = struct {
     }
 
     /// Bill one in-flight packet to the congestion window and, in the same
-    /// step, to the pacing bucket (#256-C). Handshake and PTO traffic is
-    /// charged like everything else even though neither *waits* on the pacer:
-    /// those bytes are genuinely on the wire, and a bucket that ignored them
-    /// would let application data follow a handshake flight at a rate the
-    /// path was never shown to support.
+    /// step, to the pacing bucket (#256-C). Handshake, PTO, DPLPMTUD-probe and
+    /// path-validation traffic is charged like everything else even though
+    /// none of it *waits* on the pacer: those bytes are genuinely on the wire,
+    /// and a bucket that ignored them would let application data follow a
+    /// handshake flight at a rate the path was never shown to support.
+    ///
+    /// The `in_flight` test at both call sites is also what exempts a pure ACK
+    /// from the bucket entirely — not delayed by it and not charged to it,
+    /// since an ACK-only packet is not congestion-controlled traffic.
     fn chargeSend(self: *RecoveryController, packet: SentPacket) void {
         self.congestion.onPacketSent(packet.size);
         self.congestion.onPacingSent(packet.size, packet.time_sent_us, self.rtt);
@@ -1839,6 +1850,37 @@ test "pacing: the release schedule spaces datagrams at the RFC 9002 rate" {
         try testing.expect(cc.pacingTokens(now, fixture.rtt) < 1_200);
         previous = now;
     }
+}
+
+test "pacing: a fast path keeps its sub-millisecond interval" {
+    // 1.25 × 480 kB over a 10 ms RTT is 60 MB/s — one 1200-byte datagram every
+    // 20 µs. Ordinary for a datacentre or loopback path, and two orders of
+    // magnitude below `timer_granularity_us`.
+    var cc = CongestionController{ .congestion_window = 480_000, .ssthresh = 480_000 };
+    var rtt = RttEstimator.init(25_000);
+    rtt.update(10_000, 0);
+    var now: u64 = 1_000_000;
+    while (cc.pacingAllows(1_200, now, rtt)) cc.onPacingSent(1_200, now, rtt);
+
+    // `timer_granularity_us` is loss-detection resolution and has no business
+    // here: flooring the release at 1 ms would underpace this path 50×.
+    const release = cc.pacingReleaseUs(1_200, now, rtt);
+    try testing.expectEqual(now + 20, release);
+    try testing.expect(release - now < timer_granularity_us);
+
+    // The consequence a floor would have, stated as throughput: one
+    // millisecond of this schedule releases five bursts' worth. Floored at
+    // 1 ms it could never exceed one, whatever the window and RTT said.
+    const deadline = now + 1_000;
+    var released: usize = 0;
+    while (true) {
+        now = cc.pacingReleaseUs(1_200, now, rtt);
+        if (now > deadline) break;
+        cc.onPacingSent(1_200, now, rtt);
+        released += 1;
+    }
+    try testing.expectEqual(@as(usize, 50), released);
+    try testing.expect(released > default_pacer_burst_packets);
 }
 
 test "pacing: an idle sender restarts with one burst, not with everything it missed" {

--- a/src/quic/udp.zig
+++ b/src/quic/udp.zig
@@ -72,7 +72,17 @@ pub const SendDatagram = struct {
     local: ?Address = null,
     remote: Address,
     ecn: Ecn = .unavailable,
-    /// Future pacing hook. `null` means send as soon as the endpoint can.
+    /// Earliest instant this datagram may leave; `null` means send as soon as
+    /// the endpoint can.
+    ///
+    /// Not a second pacing API (#256-C). The transport's schedule lives in
+    /// `recovery.Pacer`, and `Connection.pollTransmitOnPath` already declines
+    /// to build a paced datagram before it is eligible — so every datagram
+    /// that reaches an endpoint is one the pacer has released, and this field
+    /// is null on the production path. It stays for endpoints that queue
+    /// ahead of the wire (batching, a test harness driving a fake clock),
+    /// which need somewhere to carry the release time that
+    /// `Connection.nextSendTimeUs` reports.
     send_at_us: ?u64 = null,
 };
 


### PR DESCRIPTION
## Summary

A congestion window bounds how much data may be *outstanding*, not how fast it may leave. Until now the send path wrote until the window was full, so a connection with plenty of nominal capacity still handed its whole window to the first router in the path as one burst — which is how queue-overflow loss shows up on a link that had the capacity.

- **`recovery.Pacer`** — an RFC 9002 §7.7 leaky bucket replacing the coarse `pacingHint()`. Credit accrues at `N × congestion_window / smoothed_rtt`, with `N` of 2 in slow start and 1.25 in congestion avoidance. The ceiling is ten maximum-size datagrams, which bounds the opening flight *and* the flight a connection returning from idle may send. BBR and other rate estimators stay out of scope.
- **Generation and scheduling stay separable.** Nothing sleeps inside packet construction. `pollTransmitOnPath` declines to build paced data while the bucket is short; `Connection.nextSendTimeUs` reports when the schedule next releases something.
- **`http3_runtime` folds that release into its existing `wake_us`**, via a new `connectionWakeUs` seam split out of `serve` so the selection is testable without a socket. A paced connection neither spins nor sleeps past its own deadline, and one `drainConnectionTransmits` pass can no longer flush a cwnd-sized burst.
- **Responsiveness preserved.** ACKs, PTO probes, and Initial/Handshake flights are charged to the bucket but never delayed by it — an ACK is not congestion-controlled traffic, a probe is how a stalled connection recovers, and the handshake is already bounded by the initial window and anti-amplification.
- **Congestion control and anti-amplification stay the hard gates.** Pacing only ever delays; a connection blocked by the window reports no pacing deadline at all, so the loss/PTO timers keep owning that wakeup.
- **One pacing API.** `udp.SendDatagram.send_at_us` is documented as the same contract rather than a parallel one — it is null on the production path because the transport releases datagrams before they reach an endpoint.
- Docs: a `Packet pacing` section in `docs/HTTP3_ROLLOUT.md`, plus CHANGELOG and `docs/CONCURRENCY.md` seam updates.

## Test plan

All new tests drive a fake clock — no wall-clock sleeps.

- [x] `recovery.zig`: burst bound (exactly ten datagrams leave at one frozen instant, then the bucket is empty); spacing (release is exact at 8000 µs, refused at 7999, and steady across successive sends); idle restart (ten seconds of accrued credit collapses to one burst, not a backlog); cwnd as the harder gate (full bucket over a full window sends nothing); slow-start vs congestion-avoidance gain; only in-flight packets metered; a shrinking window halves the rate; migration discards the schedule with the window.
- [x] `connection.zig`: a frozen-clock drain is bounded by the burst and then returns nothing (no spin); `nextSendTimeUs` is strictly future, produces nothing at `release - 1`, and produces at `release`; steady spacing past the opening burst; idle restart bounded; a closed window adds no in-flight bytes and reports no pacing deadline; an ACK is not delayed by a spent bucket.
- [x] `http3_runtime.zig`: the loop's sleep deadline equals the pacing release when that beats every timer, and a cwnd-blocked connection contributes no wakeup of its own.
- [x] `zig build test` — full suite green, `zig fmt --check src/` clean.

One pre-existing note: `gateway_proxy.zig`'s Unix-socket test aborts under a socket-blocking sandbox (`setsockopt(SO_RCVTIMEO)` → `EINVAL`). Unrelated to this change and passes when the sandbox is off; it only became visible here because touching `http3_runtime.zig` invalidated that step's build cache.

Refs #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)