### PR TITLE
docs(deployment): add production deployment docs for Docker and systemd

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,15 +1,30 @@
 .git
 .github
 .zig-cache
+# Repo-local build/tool artifacts that shouldn't be sent as build context;
+# the image builds its own Zig toolchain and binary from source.
+.zig/
+.zig-toolchain/
+dist/
 zig-out/*
 !zig-out/bin/
 zig-out/bin/*
 !zig-out/bin/tardi
 docs
 tests
-# The default `zig build` target embeds tests/vectors/pki/malformed-truncated.der
-# and tests/vectors/pki/reduced/ into the production pki module (build.zig), so
-# they must stay in the Docker build context even though the rest of tests/ does not.
+# The default `zig build` target embeds these specific fixture files into the
+# production pki module (build.zig: pki_malformed_der, pki_reduced_corpus), so
+# they must stay in the Docker build context even though the rest of tests/
+# does not. Narrowed to exactly what's embedded, not the whole tests/vectors
+# tree, to keep the build context small.
 !tests/vectors
+tests/vectors/*
+!tests/vectors/pki
+tests/vectors/pki/*
+!tests/vectors/pki/malformed-truncated.der
+!tests/vectors/pki/reduced
+tests/vectors/pki/reduced/*
+!tests/vectors/pki/reduced/manifest.zig
+!tests/vectors/pki/reduced/*.der
 examples
 PLAN.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,5 +7,9 @@ zig-out/bin/*
 !zig-out/bin/tardi
 docs
 tests
+# The default `zig build` target embeds tests/vectors/pki/malformed-truncated.der
+# and tests/vectors/pki/reduced/ into the production pki module (build.zig), so
+# they must stay in the Docker build context even though the rest of tests/ does not.
+!tests/vectors
 examples
 PLAN.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,10 +6,7 @@
 .zig/
 .zig-toolchain/
 dist/
-zig-out/*
-!zig-out/bin/
-zig-out/bin/*
-!zig-out/bin/tardi
+zig-out/
 docs
 tests
 # The default `zig build` target embeds these specific fixture files into the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,12 +378,13 @@ jobs:
         run: zig build "-Doptimize=$OPTIMIZE"
 
   # ── Packaging smoke ─────────────────────────────────────────────────────────
-  # Verifies the release archive layout, install script behavior, and host-native
-  # DEB package layout against a disposable Ubuntu container.
+  # Verifies the release archive layout, install script behavior, host-native
+  # DEB/RPM package layout, and the local-build Docker image, each against a
+  # disposable container.
   packaging-smoke:
     name: Packaging smoke
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -417,6 +418,9 @@ jobs:
 
       - name: Smoke test RPM package
         run: ./scripts/test-rpm-package.sh
+
+      - name: Smoke test Docker image
+        run: ./scripts/test-docker-image.sh
 
   # ── Performance smoke ────────────────────────────────────────────────────────
   # Shared-runner loopback benchmark with conservative floors and a 30s default

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,15 +24,25 @@ RUN zig build -Doptimize=ReleaseFast
 # ── Runtime ───────────────────────────────────────────────────────────────────
 FROM debian@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241 AS runtime
 
+# Fixed, documented numeric identity: compose.yaml and scripts/test-docker-image.sh
+# pin their tmpfs/ownership checks to these exact values. `useradd --system`
+# without an explicit --uid lets the distro allocate whatever's next free,
+# which happens to be 999 on the currently pinned base but isn't a contract —
+# a future base image refresh could silently break tmpfs ownership.
+ARG TARDIGRADE_UID=10001
+ARG TARDIGRADE_GID=10001
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates libssl3 \
     && rm -rf /var/lib/apt/lists/* \
-    && useradd --system --no-create-home --shell /usr/sbin/nologin tardigrade
+    && groupadd --system --gid "$TARDIGRADE_GID" tardigrade \
+    && useradd --system --uid "$TARDIGRADE_UID" --gid "$TARDIGRADE_GID" \
+        --no-create-home --shell /usr/sbin/nologin tardigrade
 
 COPY --from=build /src/zig-out/bin/tardi /usr/local/bin/tardi
 
-RUN mkdir -p /etc/tardigrade /var/lib/tardigrade /run/tardigrade \
-    && chown -R tardigrade:tardigrade /var/lib/tardigrade /run/tardigrade
+RUN mkdir -p /etc/tardigrade /var/lib/tardigrade /run/tardigrade /var/log/tardigrade \
+    && chown -R tardigrade:tardigrade /var/lib/tardigrade /run/tardigrade /var/log/tardigrade
 
 USER tardigrade
 WORKDIR /var/lib/tardigrade

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# Local build support only: this image is not published to a registry.
+# See docs/DEPLOYMENT.md for the full Docker deployment workflow and
+# packaging/README.md for current packaging/distribution status.
+
+# debian:bookworm-slim, pinned by digest for reproducible builds.
+FROM debian@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241 AS build
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl xz-utils libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . .
+
+# Pin to the same Zig version CI builds/tests against (.github/workflows/ci.yml).
+RUN sh ./scripts/install-zig.sh 0.16.0 /opt/zig \
+    && ln -s "$(find /opt/zig -maxdepth 3 -type f -name zig)" /usr/local/bin/zig
+
+# Default "general" TLS profile: links the approved OpenSSL adapter (see
+# docs/TLS_DEPENDENCY_POLICY.md). Requires libssl-dev above.
+RUN zig build -Doptimize=ReleaseFast
+
+# ── Runtime ───────────────────────────────────────────────────────────────────
+FROM debian@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241 AS runtime
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates libssl3 \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --system --no-create-home --shell /usr/sbin/nologin tardigrade
+
+COPY --from=build /src/zig-out/bin/tardi /usr/local/bin/tardi
+
+RUN mkdir -p /etc/tardigrade /var/lib/tardigrade /run/tardigrade \
+    && chown -R tardigrade:tardigrade /var/lib/tardigrade /run/tardigrade
+
+USER tardigrade
+WORKDIR /var/lib/tardigrade
+
+ENV TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid
+
+EXPOSE 8069/tcp
+
+# Exec form so `tardi` runs as PID 1 and receives SIGTERM/SIGHUP directly from
+# `docker stop` / `docker kill -s HUP`, rather than a shell intermediary.
+ENTRYPOINT ["/usr/local/bin/tardi"]
+CMD ["run", "-c", "/etc/tardigrade/tardigrade.conf"]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   <a href="docs/SUPPORT_MATRIX.md">Support Matrix</a> |
   <a href="docs/CONFIGURATION.md">Configuration</a> |
   <a href="docs/OBSERVABILITY.md">Observability</a> |
+  <a href="docs/DEPLOYMENT.md">Deployment</a> |
   <a href="SECURITY.md">Security</a> |
   <a href="CONTRIBUTING.md">Contributing</a>
 </p>
@@ -95,6 +96,10 @@ Other install paths:
   [packaging/README.md](packaging/README.md) for current status and
   install/build instructions.
 - Build from source (see below).
+
+For running Tardigrade as a managed service — systemd unit, filesystem
+layout, permissions, and a locally built Docker image — see the
+[production deployment guide](docs/DEPLOYMENT.md).
 
 ## Build from source
 
@@ -220,6 +225,7 @@ operate without guessing which config file or pid file is active.
 | Event-loop backend evaluation (epoll/kqueue vs libxev/std.Io/io_uring) | [docs/EVENT_LOOP_BACKENDS.md](docs/EVENT_LOOP_BACKENDS.md) |
 | Observability | [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) |
 | Reload, drain, and shutdown | [docs/RELOAD_SHUTDOWN.md](docs/RELOAD_SHUTDOWN.md) |
+| Production deployment (systemd and Docker) | [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) |
 | Proxy security | [docs/PROXY_SECURITY.md](docs/PROXY_SECURITY.md) |
 | Security test plan | [docs/SECURITY_TEST_PLAN.md](docs/SECURITY_TEST_PLAN.md) |
 | TLS interop & conformance matrix | [docs/TLS_INTEROP_MATRIX.md](docs/TLS_INTEROP_MATRIX.md) |

--- a/build.zig
+++ b/build.zig
@@ -1061,17 +1061,25 @@ fn configureSystemLibrarySearchPaths(
         if (pathExists("/usr/local/lib")) compile.root_module.addLibraryPath(.{ .cwd_relative = "/usr/local/lib" });
         switch (target.cpu.arch) {
             .aarch64 => {
-                compile.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/include/aarch64-linux-gnu" });
-                compile.root_module.addLibraryPath(.{ .cwd_relative = "/usr/lib/aarch64-linux-gnu" });
-                compile.root_module.addLibraryPath(.{ .cwd_relative = "/lib/aarch64-linux-gnu" });
+                if (pathExists("/usr/include/aarch64-linux-gnu")) compile.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/include/aarch64-linux-gnu" });
+                if (pathExists("/usr/lib/aarch64-linux-gnu")) compile.root_module.addLibraryPath(.{ .cwd_relative = "/usr/lib/aarch64-linux-gnu" });
+                if (pathExists("/lib/aarch64-linux-gnu")) compile.root_module.addLibraryPath(.{ .cwd_relative = "/lib/aarch64-linux-gnu" });
             },
             .x86_64 => {
-                compile.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/include/x86_64-linux-gnu" });
-                compile.root_module.addLibraryPath(.{ .cwd_relative = "/usr/lib/x86_64-linux-gnu" });
-                compile.root_module.addLibraryPath(.{ .cwd_relative = "/lib/x86_64-linux-gnu" });
+                if (pathExists("/usr/include/x86_64-linux-gnu")) compile.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/include/x86_64-linux-gnu" });
+                if (pathExists("/usr/lib/x86_64-linux-gnu")) compile.root_module.addLibraryPath(.{ .cwd_relative = "/usr/lib/x86_64-linux-gnu" });
+                if (pathExists("/lib/x86_64-linux-gnu")) compile.root_module.addLibraryPath(.{ .cwd_relative = "/lib/x86_64-linux-gnu" });
             },
             else => {},
         }
+        // RHEL-family distros (Rocky, Alma, Fedora, CentOS) use a flat lib64
+        // layout instead of Debian's multiarch triplet directories above —
+        // without this, `configureSystemLibrarySearchPaths` never points the
+        // linker at the real OpenSSL location on those distros at all.
+        if (pathExists("/usr/lib64")) compile.root_module.addLibraryPath(.{ .cwd_relative = "/usr/lib64" });
+        if (pathExists("/lib64")) compile.root_module.addLibraryPath(.{ .cwd_relative = "/lib64" });
+        if (pathExists("/usr/lib")) compile.root_module.addLibraryPath(.{ .cwd_relative = "/usr/lib" });
+        if (pathExists("/lib")) compile.root_module.addLibraryPath(.{ .cwd_relative = "/lib" });
     }
     if (!prefer_static_system_libs) return;
     compile.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/include" });

--- a/compose.yaml
+++ b/compose.yaml
@@ -18,8 +18,15 @@ services:
       # directive. Uncomment and point at a real directory if you serve
       # static files.
       # - ./public:/var/lib/tardigrade/public:ro
-      # Optional TLS material for a `listen ... ssl;` config.
+      # Optional TLS material for a `listen ... ssl;` config. A bind mount
+      # exposes the same host inode/permissions inside the container, so a
+      # host key at root:<some-group> 0640 needs the container to have that
+      # group's *numeric* GID as a supplementary group (names don't cross
+      # the container boundary) — see docs/DEPLOYMENT.md's TLS bind-mount
+      # note. Uncomment both lines and set the real host GID:
       # - ./tls:/etc/tardigrade/tls:ro
+    # group_add:
+    #   - "${TARDIGRADE_TLS_GID}"   # numeric GID of the host group that owns the key
     tmpfs:
       # uid/gid must match the image's fixed non-root `tardigrade` user
       # (10001:10001, pinned in the Dockerfile) so the runtime can write its

--- a/compose.yaml
+++ b/compose.yaml
@@ -33,7 +33,18 @@ services:
       # PID file; a plain tmpfs mount defaults to root:root and the process
       # cannot write into it.
       - /run/tardigrade:uid=10001,gid=10001,mode=0750
+    # Optional operator environment values (secrets, upstream URLs, etc.).
+    # `tardi` reads TARDIGRADE_* from the process environment only — it does
+    # NOT parse this path as a file the way systemd's EnvironmentFile= does,
+    # so don't bind-mount an env file into the container expecting tardi to
+    # read it. env_file: injects the host file's contents as real container
+    # environment variables instead.
+    # env_file:
+    #   - ./deploy/tardigrade.env
     environment:
+      # Keep these explicit: Compose `environment:` overrides `env_file:`,
+      # so even a baseline env file setting a conflicting PID path cannot
+      # desync the runtime from the reload/stop commands in docs/DEPLOYMENT.md.
       TARDIGRADE_PID_FILE: /run/tardigrade/tardigrade.pid
       TARDIGRADE_REQUIRE_UNPRIVILEGED_USER: "true"
     restart: unless-stopped

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,46 @@
+# Local, build-from-source Docker deployment example. See docs/DEPLOYMENT.md
+# for the full workflow (build, validate, start, reload, stop).
+#
+# This is not a published image — `docker compose build` builds it from the
+# Dockerfile in this repository.
+
+services:
+  tardigrade:
+    build: .
+    ports:
+      - "8069:8069"
+    volumes:
+      # Starter routing/runtime config. Swap for your own; see
+      # docs/CONFIGURATION.md and examples/production-baseline/ for a
+      # hardened starting point.
+      - ./packaging/tardigrade.conf:/etc/tardigrade/tardigrade.conf:ro
+      # Optional static root referenced by the starter config's `root`
+      # directive. Uncomment and point at a real directory if you serve
+      # static files.
+      # - ./public:/var/lib/tardigrade/public:ro
+      # Optional TLS material for a `listen ... ssl;` config.
+      # - ./tls:/etc/tardigrade/tls:ro
+    tmpfs:
+      # uid/gid must match the image's non-root `tardigrade` user (999:999)
+      # so the runtime can write its PID file; a plain tmpfs mount defaults
+      # to root:root and the process cannot write into it.
+      - /run/tardigrade:uid=999,gid=999,mode=0750
+    environment:
+      TARDIGRADE_PID_FILE: /run/tardigrade/tardigrade.pid
+      TARDIGRADE_REQUIRE_UNPRIVILEGED_USER: "true"
+    restart: unless-stopped
+    # Longer than TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS (default 30000ms) so
+    # Docker's SIGTERM->SIGKILL escalation doesn't cut off a graceful drain.
+    stop_grace_period: 35s
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "/usr/local/bin/tardi",
+          "status",
+          "--pid-file",
+          "/run/tardigrade/tardigrade.pid"
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,10 +21,11 @@ services:
       # Optional TLS material for a `listen ... ssl;` config.
       # - ./tls:/etc/tardigrade/tls:ro
     tmpfs:
-      # uid/gid must match the image's non-root `tardigrade` user (999:999)
-      # so the runtime can write its PID file; a plain tmpfs mount defaults
-      # to root:root and the process cannot write into it.
-      - /run/tardigrade:uid=999,gid=999,mode=0750
+      # uid/gid must match the image's fixed non-root `tardigrade` user
+      # (10001:10001, pinned in the Dockerfile) so the runtime can write its
+      # PID file; a plain tmpfs mount defaults to root:root and the process
+      # cannot write into it.
+      - /run/tardigrade:uid=10001,gid=10001,mode=0750
     environment:
       TARDIGRADE_PID_FILE: /run/tardigrade/tardigrade.pid
       TARDIGRADE_REQUIRE_UNPRIVILEGED_USER: "true"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,323 @@
+# Production Deployment
+
+This is the canonical operator guide for running Tardigrade outside a
+development shell: host-native Linux with systemd, or a locally built Docker
+image. It covers filesystem layout, permissions, process control, logs, and a
+hardening checklist for both paths.
+
+## Maturity boundary
+
+Tardigrade supports practical operator-managed deployments of its stable
+core. It is **not** claimed to be generic "production-ready", "battle-tested",
+or a drop-in nginx/Envoy replacement. The supported/stable runtime surface is
+defined by the [Core v1 support matrix](SUPPORT_MATRIX.md) — anything listed
+there as `experimental` stays experimental regardless of how you deploy it.
+
+Read this guide alongside:
+
+- [Configuration reference](CONFIGURATION.md) — every config directive and
+  environment variable.
+- [Reload, drain, and shutdown](RELOAD_SHUTDOWN.md) — the full hot-reload and
+  graceful-shutdown contract; this guide only covers the operator commands
+  that trigger it.
+- [Observability](OBSERVABILITY.md) — logging and metrics fields in detail.
+- [Support matrix](SUPPORT_MATRIX.md) — the stable/experimental contract.
+- [packaging/README.md](../packaging/README.md) — what's actually built and
+  published (DEB/RPM/archives) versus local-build-only (Docker).
+- [examples/production-baseline/](../examples/production-baseline/README.md)
+  — a hardened *configuration* example (TLS, rate limiting, headers). This
+  guide covers the *service/container* layer around that config.
+
+Two supported deployment paths:
+
+1. [Host-native Linux + systemd](#host-native-linux--systemd) — the more
+   deeply integrated path, via published DEB/RPM packages.
+2. [Docker, built locally from this repository](#docker) — a local-build-only
+   workflow; no image is published to a registry today.
+
+## Host filesystem layout
+
+Both deployment paths converge on the same layout. The DEB/RPM packages
+create this automatically; the Docker image creates the container-local
+equivalent under `/etc/tardigrade`, `/var/lib/tardigrade`, and
+`/run/tardigrade`.
+
+```text
+/usr/bin/tardi                         binary
+/etc/tardigrade/
+    tardigrade.conf                    routing/runtime configuration
+    tardigrade.env                     environment-only settings / secret references
+    tls/
+        fullchain.pem
+        privkey.pem
+/run/tardigrade/
+    tardigrade.pid                     ephemeral process PID
+/var/lib/tardigrade/                   service working/state directory
+/var/lib/tardigrade/public/            optional static root
+/var/log/tardigrade/                   optional file logs
+```
+
+### Permissions and ownership
+
+The package `postinst`/`%post` scripts are the source of truth for this on a
+host-native install; the same properties apply inside the Docker image.
+
+| Path | Owner | Mode | Notes |
+| --- | --- | --- | --- |
+| `/etc/tardigrade/tardigrade.conf` | `root:root` | `0644` | Not secret; readable by the service via world-read. |
+| `/etc/tardigrade/tardigrade.env` | `root:tardigrade` | `0640` | May hold secret references; not world-readable. |
+| `/etc/tardigrade/tls/privkey.pem` | `root:tardigrade` (or narrower) | `0640` or tighter | Readable only by the service account/group. Never world-readable. |
+| `/run/tardigrade/` | `tardigrade:tardigrade` | `0750` | Ephemeral; recreated at start by systemd's `RuntimeDirectory=` or the container's tmpfs mount. |
+| `/var/lib/tardigrade/` | `tardigrade:tardigrade` | `0755` | Writable service state directory. |
+| `/var/lib/tardigrade/public/` | read-only to the service where possible | — | Static roots and mounted config don't need write access; mount `:ro`. |
+
+The service always runs as the dedicated non-root `tardigrade` user, both
+under systemd and in the container.
+
+If your config references additional roots, Unix sockets, or upstream
+sockets outside this layout, they need their own filesystem access —
+extend the systemd unit's directory allowlist or the container's mounts
+deliberately for that specific path rather than weakening sandboxing
+globally (for example, don't drop `ProtectSystem=full` or `ProtectHome=true`
+just to reach one extra path).
+
+## Host-native Linux + systemd
+
+Install via the published DEB or RPM package — see
+[packaging/README.md](../packaging/README.md) for exact install commands and
+current publish status. The package installs the binary, a starter config,
+the systemd unit, and creates the `tardigrade` system user and
+`/var/lib/tardigrade`.
+
+### The systemd unit's PID/control-path contract
+
+The shared unit at
+[`packaging/systemd/tardigrade.service`](../packaging/systemd/tardigrade.service)
+gives every fresh install a deterministic, self-contained control path:
+
+```ini
+Environment=TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid
+RuntimeDirectory=tardigrade
+RuntimeDirectoryMode=0750
+
+ExecStartPre=/usr/bin/tardi check /etc/tardigrade/tardigrade.conf
+ExecStart=/usr/bin/tardi run -c /etc/tardigrade/tardigrade.conf
+ExecReload=/usr/bin/tardi reload --pid-file /run/tardigrade/tardigrade.pid
+ExecStop=/usr/bin/tardi stop --pid-file /run/tardigrade/tardigrade.pid
+
+TimeoutStopSec=35s
+```
+
+- `RuntimeDirectory=tardigrade` makes systemd create and own
+  `/run/tardigrade` (mode `0750`, owned by the `tardigrade` service user) on
+  every start — no manual directory setup needed.
+- `Environment=TARDIGRADE_PID_FILE=...` and the `--pid-file` flags on
+  `ExecReload`/`ExecStop` all point at the same path the running process
+  writes, so `systemctl reload`/`stop` can always find it.
+- `ExecStartPre` runs `tardi check` against the config before the listener
+  binds, so a bad edit fails the start instead of taking down a working
+  process.
+- `TimeoutStopSec=35s` is set above the default 30s graceful-drain window
+  (`TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS`, see
+  [RELOAD_SHUTDOWN.md](RELOAD_SHUTDOWN.md)) so systemd doesn't escalate to
+  `SIGKILL` before the drain finishes. If you raise the drain timeout,
+  raise `TimeoutStopSec` to match.
+
+Adjust the built-in hardening directives (`NoNewPrivileges`, `PrivateTmp`,
+`ProtectHome`, `ProtectSystem=full`, `UMask=0027`) if testing shows one
+breaks a deployment you rely on (extra static roots, Unix sockets, etc.), but
+keep the service non-root, the PID path deterministic, and `ExecStartPre`
+config validation.
+
+### Commands
+
+```bash
+# Validate a config edit before publishing it
+sudo -u tardigrade tardi check /etc/tardigrade/tardigrade.conf
+
+sudo systemctl start tardigrade
+sudo systemctl status tardigrade
+sudo systemctl reload tardigrade    # hot reload: SIGHUP, no dropped connections
+sudo systemctl restart tardigrade   # full restart: needed for process-owned settings
+sudo systemctl stop tardigrade
+
+sudo journalctl -u tardigrade
+sudo journalctl -u tardigrade -f
+```
+
+Reload vs. restart:
+
+- A config change that only affects request routing, TLS credentials, or
+  other reload-owned settings: validate, then `systemctl reload tardigrade`.
+- A change to listener shard topology, HTTP/3 listener-owned settings, or
+  other process-owned settings: `systemctl restart tardigrade` (reload
+  rejects these; see [RELOAD_SHUTDOWN.md](RELOAD_SHUTDOWN.md) for the exact
+  boundary).
+
+## Docker
+
+Docker support here is **local-build support**: `docker build`/`docker
+compose build` from the [`Dockerfile`](../Dockerfile) in this repository.
+There is no published Bare Systems image on any registry today — see
+[packaging/README.md](../packaging/README.md#current-status).
+
+The image is a multi-stage build: a build stage compiles `tardi` with the
+pinned Zig toolchain (matching `.github/workflows/ci.yml`) and the default
+"general" TLS profile (OpenSSL adapter — see
+[TLS_DEPENDENCY_POLICY.md](TLS_DEPENDENCY_POLICY.md)); the runtime stage
+contains only `tardi`, its OpenSSL/CA-certificate runtime dependencies, and a
+non-root `tardigrade` user. No Zig toolchain or source tree ships in the
+final image.
+
+### Build
+
+```bash
+docker compose build
+```
+
+### Validate config before startup
+
+```bash
+docker compose run --rm tardigrade \
+  check /etc/tardigrade/tardigrade.conf
+```
+
+### Start
+
+```bash
+docker compose up -d
+```
+
+### Inspect
+
+```bash
+docker compose ps
+docker compose logs -f tardigrade
+```
+
+### Validate + reload
+
+```bash
+docker compose exec tardigrade \
+  tardi check /etc/tardigrade/tardigrade.conf
+
+docker compose exec tardigrade \
+  tardi reload --pid-file /run/tardigrade/tardigrade.pid
+```
+
+### Graceful stop
+
+```bash
+docker compose stop
+```
+
+`tardi` runs as PID 1 in the container (exec-form `ENTRYPOINT`), so Docker's
+`SIGTERM` reaches Tardigrade's graceful shutdown path directly — no init
+shim swallowing or relaying the signal.
+
+### compose.yaml
+
+[`compose.yaml`](../compose.yaml) at the repo root is a copy/paste-runnable
+local example: builds the image, mounts a read-only config (and optional
+static root / TLS directory), supplies `/run/tardigrade` as a `tmpfs` mount
+owned by the container's non-root user, maps the port, and sets a graceful
+`stop_grace_period` longer than the drain timeout. The `tmpfs` entry needs
+explicit `uid`/`gid` mount options matching the image's `tardigrade` user —
+a plain tmpfs mount defaults to `root:root` and the process can't write its
+PID file into it.
+
+The bundled healthcheck runs `tardi status --pid-file ...` inside the
+container. Note its limitation: `tardi status` always exits `0` once the
+config loads, whether or not the process is actually reachable — it reports
+`status: stopped` in text rather than failing the check. It's still useful
+signal (it proves the entrypoint, working directory, and PID path are wired
+correctly), but it will not, by itself, flip a container unhealthy if the
+listener stops responding while the process is still alive. If you need a
+liveness check on the actual HTTP path, add `curl` or `wget` to the runtime
+image and point it at `/health` instead.
+
+## Ports and privilege model
+
+- The example/default listener port is `8069` (unprivileged, works for both
+  systemd and Docker without extra capabilities).
+- Put a frontend load balancer, NAT, or reverse proxy in front to expose
+  `80`/`443` rather than binding them directly, where that fits your
+  environment.
+- If Tardigrade must bind `80`/`443` directly under systemd, grant
+  `AmbientCapabilities=CAP_NET_BIND_SERVICE` (plus
+  `CapabilityBoundingSet=CAP_NET_BIND_SERVICE`) on the service unit instead
+  of running the process as root.
+- Keep Docker deployments non-root and use host port publishing
+  (`ports: ["80:8069"]`, etc.) rather than elevating the container just to
+  bind a low port.
+
+## Logs
+
+Two logging surfaces, both covered in full by
+[OBSERVABILITY.md](OBSERVABILITY.md):
+
+- **Container/service stdout** — under systemd, `journalctl -u tardigrade`;
+  under Docker, `docker compose logs -f tardigrade`. This is where runtime
+  and JSON access logs land unless `error_log`/`TARDIGRADE_ERROR_LOG_PATH`
+  is configured.
+- **Configured file logs** — set `error_log` (or
+  `TARDIGRADE_ERROR_LOG_PATH`) to write to `/var/log/tardigrade/*.log`
+  instead. The DEB/RPM packages already install a logrotate config at
+  `/etc/logrotate.d/tardigrade` that signals `SIGUSR1` after rotation;
+  Tardigrade has a real SIGUSR1 log-reopen handler, so log files reopen
+  cleanly on the existing rotation cadence. Don't invent a second rotation
+  mechanism.
+
+> **Operator note discovered while writing this guide**: the starter config
+> matches on `server_name localhost;`. A bare `curl http://<host>:8069/health`
+> against an IP or a mismatched `Host` header returns `404`, not `200` —
+> match the `Host` header (or your config's `server_name`) when
+> smoke-testing, or use `server_name _;`/a real hostname in your own config.
+
+## Production hardening checklist
+
+- [ ] Run as the dedicated non-root `tardigrade` user (default for both
+      paths — don't override it).
+- [ ] Validate config before every start/reload (`tardi check`; the systemd
+      unit already does this via `ExecStartPre`).
+- [ ] TLS private key permissions: never world-readable; restrict to the
+      service account/group.
+- [ ] Mount static roots, config, and TLS material read-only where the
+      service doesn't need to write them.
+- [ ] Expose only the ports you intend to serve.
+- [ ] Restrict `/status/metrics` to trusted scrapers/network paths, or set
+      `TARDIGRADE_METRICS_REQUIRE_AUTH=true` (see
+      [CONFIGURATION.md](CONFIGURATION.md)).
+- [ ] Tune rate limits and connection/request limits for your workload
+      (`TARDIGRADE_RATE_LIMIT_RPS`, `TARDIGRADE_MAX_ACTIVE_CONNECTIONS`,
+      `TARDIGRADE_MAX_IN_FLIGHT_REQUESTS`).
+- [ ] Configure upstream health checks where you proxy to origins.
+- [ ] Set `TimeoutStopSec` (systemd) / `stop_grace_period` (Docker) above
+      `TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS`.
+- [ ] Retain and review logs and reload-failure metrics
+      (`tardigrade_reload_failure_total`, `/tardigrade/reload/status`).
+- [ ] Use firewall/load-balancer controls around operator-only paths.
+- [ ] Never commit live secrets or bake them into container image layers —
+      externalize config, certs, and secrets.
+- [ ] Back up any operator-managed persistent state your specific deployment
+      relies on.
+
+See [examples/production-baseline/](../examples/production-baseline/README.md)
+for a config-level pre-production checklist covering TLS, HSTS, and rate
+limiting values.
+
+## Known limitations
+
+- Docker support here is local-build only. No image is published to any
+  registry unless and until a separate distribution ticket adds that.
+- This guide targets Linux containers; other container runtimes (Podman,
+  etc.) aren't tested against it.
+- Operators supply their own config, certificates, static roots, and secrets
+  — none of these are baked into the image or package.
+- `/status/metrics` is not automatically restricted; apply the checklist
+  item above before exposing a deployment publicly.
+- DEB/RPM remain the more deeply integrated host-native Linux install path
+  (user creation, logrotate, systemd wiring all handled by the package).
+- Every experimental protocol/feature in the [support matrix](SUPPORT_MATRIX.md)
+  stays experimental regardless of deployment method — deploying via
+  Docker or systemd does not change a feature's maturity level.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -37,30 +37,40 @@ Two supported deployment paths:
 
 ## Host filesystem layout
 
-The two paths use the same *directory* layout, but they're populated
-differently: the DEB/RPM package creates every path below automatically
-(including `tardigrade.env`); the Docker image only creates the directories
-themselves (`/etc/tardigrade`, `/var/lib/tardigrade`, `/run/tardigrade`,
-`/var/log/tardigrade`) — you supply `tardigrade.conf`, `tardigrade.env`
-(if you use one), and any TLS material as bind mounts. See
-[Docker](#docker) below for the exact mount shape and the one path that
-differs: the packages install the binary at `/usr/bin/tardi`, the image
-installs it at `/usr/local/bin/tardi`.
+The two paths converge on the same *directory* layout, but different pieces
+of it come from different places and at different times — not everything
+below is created by the package install step. Three categories:
+
+- **Created by the package install** (DEB/RPM `postinst`/`%post`; the Docker
+  image creates the equivalent directories at build time): the binary,
+  `/etc/tardigrade/tardigrade.conf`, `/etc/tardigrade/tardigrade.env`,
+  `/var/lib/tardigrade`, `/var/log/tardigrade`.
+- **Created at service start, not install**: `/run/tardigrade` is created by
+  systemd's `RuntimeDirectory=` when the unit starts (see
+  [below](#the-systemd-units-pidcontrol-path-contract)), not by the package.
+  Under Docker it's a `tmpfs` mount you supply in `compose.yaml`.
+- **Operator-created, only if you use them**: neither package nor image
+  creates `/etc/tardigrade/tls/` or `/var/lib/tardigrade/public/` — you
+  create these (or bind-mount them, under Docker) only if your config
+  actually references TLS material or a static root.
 
 ```text
-/usr/bin/tardi                         binary (packages) — /usr/local/bin/tardi in the Docker image
-/etc/tardigrade/
-    tardigrade.conf                    routing/runtime configuration
-    tardigrade.env                     environment-only settings / secret references
-    tls/
-        fullchain.pem
-        privkey.pem
-/run/tardigrade/
-    tardigrade.pid                     ephemeral process PID
-/var/lib/tardigrade/                   service working/state directory
-/var/lib/tardigrade/public/            optional static root
-/var/log/tardigrade/                   optional file logs
+Package install:              /usr/bin/tardi                     binary (/usr/local/bin/tardi in the Docker image)
+                               /etc/tardigrade/tardigrade.conf    routing/runtime configuration
+                               /etc/tardigrade/tardigrade.env     environment-only settings / secret references
+                               /var/lib/tardigrade/                service working/state directory
+                               /var/log/tardigrade/                 file-log directory
+Service start (systemd RuntimeDirectory= / Docker tmpfs mount):
+                               /run/tardigrade/tardigrade.pid      ephemeral process PID
+Operator-created when used:   /etc/tardigrade/tls/fullchain.pem
+                               /etc/tardigrade/tls/privkey.pem
+                               /var/lib/tardigrade/public/          optional static root
 ```
+
+Under Docker, the image only creates the directories themselves — you
+supply `tardigrade.conf`, `tardigrade.env` (if you use one), and any TLS
+material as bind mounts. See [Docker](#docker) below for the exact mount
+shape.
 
 ### Permissions and ownership
 
@@ -92,9 +102,28 @@ owns the file — group and user *names* don't cross the container boundary,
 only the numeric IDs do. The image's `tardigrade` group is a fixed
 `10001`; if your host's `tardigrade` group (created by the DEB/RPM package
 via `useradd --system`, so its GID is whatever the distro allocated) isn't
-also `10001`, either `chgrp`/`chmod` the mounted file for the container's
-GID or mount it world-readable-within-the-container (`0644`) if that fits
-your threat model — never make it world-readable on the host.
+also `10001`, you cannot fix this with `chmod 0644` — a bind mount exposes
+the *same host inode* inside the container, so `chmod` changes the mode on
+the host file too and makes the key world-readable there, not just "within
+the container." That fails the never-world-readable requirement outright.
+
+Instead, give the container access to the correct numeric group without
+loosening the host file's mode. Create (or reuse) a host group whose GID
+owns the TLS key at `0640`, and add the container to that group with
+Compose's `group_add`:
+
+```yaml
+services:
+  tardigrade:
+    group_add:
+      - "${TARDIGRADE_TLS_GID}"   # numeric GID of the host group that owns the key
+```
+
+The key stays `root:<that-group> 0640` on the host; the container gains
+read access via the matching numeric supplementary group rather than
+through a mode change. An alternative is staging a copy of the key into a
+volume you initialize with owner/group `10001` directly, if you'd rather
+not add a supplementary group.
 
 If your config references additional roots, Unix sockets, or upstream
 sockets outside this layout, they need their own filesystem access —
@@ -327,12 +356,33 @@ Two logging surfaces, both covered in full by
   `/etc/logrotate.d/tardigrade`, which signals `SIGUSR1` after rotation;
   Tardigrade has a real SIGUSR1 log-reopen handler, so log files reopen
   cleanly on the existing rotation cadence. Don't invent a second rotation
-  mechanism. The Docker image creates the same `tardigrade`-owned
-  `/var/log/tardigrade` directory, but it isn't persistent or rotated by
-  anything inside the container — mount a host path or named volume over
-  it if you use `error_log` under Docker (`- ./logs:/var/log/tardigrade`
-  in `compose.yaml`), and handle rotation on the host side. Without that
-  mount, stdout/stderr (`docker compose logs`) is the durable log surface.
+  mechanism.
+
+  The Docker image creates the same `tardigrade`-owned `/var/log/tardigrade`
+  directory, but nothing inside the container persists or rotates it. Using
+  `error_log` under Docker needs two things, not just a mount:
+
+  1. **A pre-owned host path or named volume.** A bind mount such as
+     `- ./logs:/var/log/tardigrade` *replaces* the image's `10001:10001`
+     directory with whatever is at `./logs` on the host. A freshly created
+     (often root-owned) host directory will make `error_log` fail with
+     `EACCES`. Prepare it first:
+     ```bash
+     install -d -o 10001 -g 10001 -m 0755 ./logs
+     ```
+     or use a named volume and let the container's own directory-creation
+     step own it on first start.
+  2. **Rotation that reopens the file, not just renames it.** The DEB/RPM
+     logrotate policy sends `SIGUSR1` for exactly this reason — Tardigrade
+     keeps writing to the old (now-renamed) inode otherwise. A host-side
+     `logrotate` `postrotate` needs the equivalent signal delivered to the
+     container, e.g. `docker kill --signal=USR1 <container>` (or the
+     `docker compose` equivalent), not just a `copytruncate`/rename step.
+
+  Without a persistent mount, `docker compose logs` on stdout/stderr is the
+  default log surface — but don't treat it as inherently durable either;
+  retention depends on the configured Docker logging driver and container
+  lifecycle, the same as any other container's stdout.
 
 > **Operator note discovered while writing this guide**: the starter config
 > matches on `server_name localhost;`. A bare `curl http://<host>:8069/health`
@@ -344,8 +394,11 @@ Two logging surfaces, both covered in full by
 
 - [ ] Run as the dedicated non-root `tardigrade` user (default for both
       paths — don't override it).
-- [ ] Validate config before every start/reload (`tardi check`; the systemd
-      unit already does this via `ExecStartPre`).
+- [ ] Validate `tardigrade.conf` edits with `tardi check` before reload when
+      practical — `ExecStartPre` does not run on `systemctl reload`, only on
+      `start`/`restart`; hot reload runs its own validation and leaves the
+      previously published config active if the candidate is rejected (see
+      [RELOAD_SHUTDOWN.md](RELOAD_SHUTDOWN.md)).
 - [ ] TLS private key permissions: never world-readable; restrict to the
       service account/group.
 - [ ] Mount static roots, config, and TLS material read-only where the

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -41,10 +41,14 @@ The two paths converge on the same *directory* layout, but different pieces
 of it come from different places and at different times — not everything
 below is created by the package install step. Three categories:
 
-- **Created by the package install** (DEB/RPM `postinst`/`%post`; the Docker
-  image creates the equivalent directories at build time): the binary,
-  `/etc/tardigrade/tardigrade.conf`, `/etc/tardigrade/tardigrade.env`,
-  `/var/lib/tardigrade`, `/var/log/tardigrade`.
+- **Created by the DEB/RPM package install** (`postinst`/`%post`): the
+  binary, a starter `/etc/tardigrade/tardigrade.conf`, an
+  `/etc/tardigrade/tardigrade.env` template, `/var/lib/tardigrade`,
+  `/var/log/tardigrade`. The Docker image creates only the *directories*
+  (binary, `/var/lib/tardigrade`, `/var/log/tardigrade`) at build time — it
+  does **not** create a `tardigrade.conf` or `tardigrade.env`; see
+  [Docker](#docker) below for how config and environment values reach the
+  container instead.
 - **Created at service start, not install**: `/run/tardigrade` is created by
   systemd's `RuntimeDirectory=` when the unit starts (see
   [below](#the-systemd-units-pidcontrol-path-contract)), not by the package.
@@ -67,10 +71,17 @@ Operator-created when used:   /etc/tardigrade/tls/fullchain.pem
                                /var/lib/tardigrade/public/          optional static root
 ```
 
-Under Docker, the image only creates the directories themselves — you
-supply `tardigrade.conf`, `tardigrade.env` (if you use one), and any TLS
-material as bind mounts. See [Docker](#docker) below for the exact mount
-shape.
+Under Docker, the image only creates the directories themselves. You supply
+`tardigrade.conf` and any TLS material as bind mounts, since `tardi` reads
+those from disk either way. `tardigrade.env` is different: `tardi` never
+parses that filename itself — it only reads `TARDIGRADE_*` values from its
+own **process environment**. Under systemd, `EnvironmentFile=` is what turns
+the file's contents into that process environment; Docker has no built-in
+equivalent, so bind-mounting `tardigrade.env` into the container does
+nothing — `tardi` won't read it. Use Compose's `env_file:` (which reads the
+file on the host and injects its contents as real container environment
+variables) or `environment:` instead. See [Docker](#docker) below for the
+exact shape.
 
 ### Permissions and ownership
 
@@ -234,13 +245,36 @@ Reload vs. restart — the two are not interchangeable:
   environment of an already-running process, so a `tardigrade.env` edit has
   no effect until the process is restarted and re-reads it at exec time.
 
-**Master/worker mode**: the `systemctl reload`/PID-file workflow above
-assumes single-process mode (the default). Per
-[`CONFIGURATION.md`](CONFIGURATION.md#field-reference)'s `master_process`
-entry, master/worker mode does not yet provide coherent PID-file/SIGHUP
-reload control across all workers — use restart semantics
-(`systemctl restart tardigrade`) instead of `reload` if you run with
-`master_process true;`.
+**Master/worker mode**: every control-path example in this guide — systemd
+and Docker alike — assumes single-process mode, which is the default
+(`master_process false;`). If you run with `master_process true;`, three
+things in this guide do not behave as documented:
+
+- **Reload.** The `systemctl reload`/PID-file workflow above (and the
+  equivalent `tardi reload --pid-file ...` under Docker) targets the PID
+  file's process with `SIGHUP`. Per
+  [`CONFIGURATION.md`](CONFIGURATION.md#field-reference)'s `master_process`
+  entry, master/worker mode does not yet provide coherent PID-file/SIGHUP
+  reload control across all workers — use restart semantics instead
+  (`systemctl restart tardigrade`, or recreate the container) rather than
+  `reload`.
+- **USR1 log-reopen after rotation.** Each worker opens its own error-log
+  file descriptor independently at startup. `SIGUSR1` delivered to the
+  master (via `systemctl kill --signal=USR1`, `docker kill --signal=USR1`,
+  or the packaged logrotate policy) only reopens the *master's own*
+  descriptor today — it is not forwarded to worker processes, so workers
+  keep writing to the rotated-away inode.
+- **The 35s stop window.** The current shutdown path stops workers one at a
+  time (kill, wait for exit, then move to the next), not all at once, so
+  total shutdown time scales with worker count rather than being bounded by
+  a single drain window. A `TimeoutStopSec`/`stop_grace_period` of 35s is
+  not generally sufficient once you have more than one worker.
+
+None of this is specific to Docker or systemd — it's the same underlying
+multi-worker supervisor either way. Until coherent multi-worker signal
+fan-out lands, keep `master_process false;` (the default) if you rely on
+any of reload, log rotation, or a bounded graceful-stop window from this
+guide.
 
 ## Docker
 
@@ -293,6 +327,11 @@ docker compose exec tardigrade \
   tardi reload --pid-file /run/tardigrade/tardigrade.pid
 ```
 
+> **Single-process mode only.** This targets the PID file's process with
+> `SIGHUP`, same as the systemd path. With `master_process true;`, this does
+> not reload workers coherently — see [Master/worker mode](#commands) above,
+> which applies here too.
+
 ### Graceful stop
 
 ```bash
@@ -314,6 +353,28 @@ explicit `uid=10001,gid=10001` mount options matching the image's fixed
 `tardigrade` user (see [Permissions and ownership](#permissions-and-ownership)
 above) — a plain tmpfs mount defaults to `root:root` and the process can't
 write its PID file into it.
+
+**Environment values (`tardigrade.env` equivalent)**: `tardi` reads
+`TARDIGRADE_*` values from the process environment, not from a parsed
+config file — see the note in [Host filesystem
+layout](#host-filesystem-layout) above. Under Docker, use Compose's
+`env_file:` to inject an operator env file's contents as real container
+environment variables:
+
+```yaml
+services:
+  tardigrade:
+    # Optional operator environment values, injected as real container
+    # environment variables (tardi does not read this path as a file):
+    # env_file:
+    #   - ./deploy/tardigrade.env
+    environment:
+      # Keep these explicit: Compose `environment:` overrides `env_file:`,
+      # so even a baseline env file setting a conflicting PID path cannot
+      # desync the runtime from the control commands below.
+      TARDIGRADE_PID_FILE: /run/tardigrade/tardigrade.pid
+      TARDIGRADE_REQUIRE_UNPRIVILEGED_USER: "true"
+```
 
 The bundled healthcheck runs `tardi status --pid-file ...` inside the
 container. Note its limitation: `tardi status` always exits `0` once the
@@ -368,7 +429,7 @@ Two logging surfaces, both covered in full by
      (often root-owned) host directory will make `error_log` fail with
      `EACCES`. Prepare it first:
      ```bash
-     install -d -o 10001 -g 10001 -m 0755 ./logs
+     sudo install -d -o 10001 -g 10001 -m 0755 ./logs
      ```
      or use a named volume and let the container's own directory-creation
      step own it on first start.
@@ -431,16 +492,26 @@ limiting values.
   registry unless and until a separate distribution ticket adds that.
 - This guide targets Linux containers; other container runtimes (Podman,
   etc.) aren't tested against it.
-- Operators supply their own config, certificates, static roots, and secrets
-  — none of these are baked into the image or package.
+- The Docker image bakes in no config, certificates, or secrets at all —
+  operators mount/inject everything. Native DEB/RPM packages differ: they
+  install a non-secret starter `tardigrade.conf` and an env template, which
+  operators are expected to replace or edit; certificates, static content,
+  and live secrets remain operator-supplied either way.
 - `/status/metrics` is not automatically restricted; apply the checklist
   item above before exposing a deployment publicly.
 - DEB/RPM remain the more deeply integrated host-native Linux install path
   (user creation, logrotate, systemd wiring all handled by the package).
-- The packaged `systemctl reload`/PID-file control workflow targets
-  single-process mode. `master_process true;` does not yet provide coherent
-  SIGHUP/PID-file reload control across all workers — restart instead of
-  reload in that mode (see [CONFIGURATION.md](CONFIGURATION.md#field-reference)).
+- `master_process true;` is not coherently supported by any of the control
+  paths in this guide, under either systemd or Docker: reload targets one
+  PID via `SIGHUP` (workers aren't reloaded coherently); `SIGUSR1`
+  log-reopen after rotation only reopens the master's own file descriptor,
+  not each worker's; and the documented 35s stop window assumes workers
+  stop roughly in parallel, but the current shutdown path stops them one at
+  a time, so total shutdown time scales with worker count. Keep
+  `master_process false;` (the default) if you rely on reload, log
+  rotation, or a bounded graceful-stop window — see
+  [CONFIGURATION.md](CONFIGURATION.md#field-reference) and the
+  [Commands](#commands) section above.
 - Every experimental protocol/feature in the [support matrix](SUPPORT_MATRIX.md)
   stays experimental regardless of deployment method — deploying via
   Docker or systemd does not change a feature's maturity level.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -37,13 +37,18 @@ Two supported deployment paths:
 
 ## Host filesystem layout
 
-Both deployment paths converge on the same layout. The DEB/RPM packages
-create this automatically; the Docker image creates the container-local
-equivalent under `/etc/tardigrade`, `/var/lib/tardigrade`, and
-`/run/tardigrade`.
+The two paths use the same *directory* layout, but they're populated
+differently: the DEB/RPM package creates every path below automatically
+(including `tardigrade.env`); the Docker image only creates the directories
+themselves (`/etc/tardigrade`, `/var/lib/tardigrade`, `/run/tardigrade`,
+`/var/log/tardigrade`) — you supply `tardigrade.conf`, `tardigrade.env`
+(if you use one), and any TLS material as bind mounts. See
+[Docker](#docker) below for the exact mount shape and the one path that
+differs: the packages install the binary at `/usr/bin/tardi`, the image
+installs it at `/usr/local/bin/tardi`.
 
 ```text
-/usr/bin/tardi                         binary
+/usr/bin/tardi                         binary (packages) — /usr/local/bin/tardi in the Docker image
 /etc/tardigrade/
     tardigrade.conf                    routing/runtime configuration
     tardigrade.env                     environment-only settings / secret references
@@ -60,7 +65,12 @@ equivalent under `/etc/tardigrade`, `/var/lib/tardigrade`, and
 ### Permissions and ownership
 
 The package `postinst`/`%post` scripts are the source of truth for this on a
-host-native install; the same properties apply inside the Docker image.
+host-native install. The Docker image creates the equivalent directories at
+build time, owned by a **fixed, pinned** non-root UID/GID (`10001:10001`,
+the `tardigrade` user/group — see the [`Dockerfile`](../Dockerfile)); this
+value is a documented part of the image contract, not an incidental
+distro-allocated ID, and `compose.yaml`/`scripts/test-docker-image.sh` both
+depend on it matching exactly.
 
 | Path | Owner | Mode | Notes |
 | --- | --- | --- | --- |
@@ -70,9 +80,21 @@ host-native install; the same properties apply inside the Docker image.
 | `/run/tardigrade/` | `tardigrade:tardigrade` | `0750` | Ephemeral; recreated at start by systemd's `RuntimeDirectory=` or the container's tmpfs mount. |
 | `/var/lib/tardigrade/` | `tardigrade:tardigrade` | `0755` | Writable service state directory. |
 | `/var/lib/tardigrade/public/` | read-only to the service where possible | — | Static roots and mounted config don't need write access; mount `:ro`. |
+| `/var/log/tardigrade/` | `tardigrade:tardigrade` | `0755` | Writable file-log directory; created by the package/image but not persistent in Docker unless volume-mounted (see [Logs](#logs)). |
 
 The service always runs as the dedicated non-root `tardigrade` user, both
 under systemd and in the container.
+
+**Bind-mounted TLS material and container UID/GID**: a host file owned
+`root:tardigrade 0640` is only readable inside the container if the
+container's `tardigrade` group *numerically* matches the host group that
+owns the file — group and user *names* don't cross the container boundary,
+only the numeric IDs do. The image's `tardigrade` group is a fixed
+`10001`; if your host's `tardigrade` group (created by the DEB/RPM package
+via `useradd --system`, so its GID is whatever the distro allocated) isn't
+also `10001`, either `chgrp`/`chmod` the mounted file for the container's
+GID or mount it world-readable-within-the-container (`0644`) if that fits
+your threat model — never make it world-readable on the host.
 
 If your config references additional roots, Unix sockets, or upstream
 sockets outside this layout, they need their own filesystem access —
@@ -96,12 +118,13 @@ The shared unit at
 gives every fresh install a deterministic, self-contained control path:
 
 ```ini
+EnvironmentFile=-/etc/tardigrade/tardigrade.env
 Environment=TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid
 RuntimeDirectory=tardigrade
 RuntimeDirectoryMode=0750
 
 ExecStartPre=/usr/bin/tardi check /etc/tardigrade/tardigrade.conf
-ExecStart=/usr/bin/tardi run -c /etc/tardigrade/tardigrade.conf
+ExecStart=/usr/bin/env TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid /usr/bin/tardi run -c /etc/tardigrade/tardigrade.conf
 ExecReload=/usr/bin/tardi reload --pid-file /run/tardigrade/tardigrade.pid
 ExecStop=/usr/bin/tardi stop --pid-file /run/tardigrade/tardigrade.pid
 
@@ -111,12 +134,24 @@ TimeoutStopSec=35s
 - `RuntimeDirectory=tardigrade` makes systemd create and own
   `/run/tardigrade` (mode `0750`, owned by the `tardigrade` service user) on
   every start — no manual directory setup needed.
-- `Environment=TARDIGRADE_PID_FILE=...` and the `--pid-file` flags on
-  `ExecReload`/`ExecStop` all point at the same path the running process
-  writes, so `systemctl reload`/`stop` can always find it.
+- The PID path is forced twice, deliberately: `Environment=TARDIGRADE_PID_FILE=...`
+  sets a default, but systemd gives `EnvironmentFile=` values **higher**
+  precedence than unit-level `Environment=` values — so a stray
+  `TARDIGRADE_PID_FILE=` line in `tardigrade.env` would otherwise silently
+  win and desync the running process's actual PID file from what
+  `ExecReload`/`ExecStop` target. `ExecStart` wraps the command in
+  `/usr/bin/env TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid ...`,
+  which sets that variable at exec time and always wins, regardless of
+  what's in `tardigrade.env`. `tardi` still runs directly (`env` execs it),
+  so systemd tracks the same process. This exact conflicting-env-file
+  scenario is covered by a regression check in
+  `scripts/test-docker-image.sh`.
 - `ExecStartPre` runs `tardi check` against the config before the listener
   binds, so a bad edit fails the start instead of taking down a working
-  process.
+  process. Because `ExecStartPre` is part of the same unit, it inherits the
+  merged `EnvironmentFile=`/`Environment=` environment — unlike the
+  standalone manual `tardi check` shown in [Commands](#commands) below,
+  it's validating what the service will actually run with.
 - `TimeoutStopSec=35s` is set above the default 30s graceful-drain window
   (`TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS`, see
   [RELOAD_SHUTDOWN.md](RELOAD_SHUTDOWN.md)) so systemd doesn't escalate to
@@ -132,7 +167,7 @@ config validation.
 ### Commands
 
 ```bash
-# Validate a config edit before publishing it
+# Validate the config file itself before publishing an edit
 sudo -u tardigrade tardi check /etc/tardigrade/tardigrade.conf
 
 sudo systemctl start tardigrade
@@ -145,14 +180,38 @@ sudo journalctl -u tardigrade
 sudo journalctl -u tardigrade -f
 ```
 
-Reload vs. restart:
+**This standalone `tardi check` does not validate the same effective
+configuration the service runs with.** Run outside the unit, it doesn't load
+`/etc/tardigrade/tardigrade.env`, and [`CONFIGURATION.md`](CONFIGURATION.md)
+defines process environment as higher precedence than config-file values —
+so an invalid or changed value that only exists in `tardigrade.env` (a
+secret bootstrap reference, an overridden port, a TLS path override, etc.)
+can pass this check and still fail at start. The unit's own
+`ExecStartPre=/usr/bin/tardi check ...` is the check that sees the same
+merged environment as `ExecStart`, and is the real pre-flight gate on
+`start`/`restart`.
 
-- A config change that only affects request routing, TLS credentials, or
-  other reload-owned settings: validate, then `systemctl reload tardigrade`.
-- A change to listener shard topology, HTTP/3 listener-owned settings, or
-  other process-owned settings: `systemctl restart tardigrade` (reload
-  rejects these; see [RELOAD_SHUTDOWN.md](RELOAD_SHUTDOWN.md) for the exact
-  boundary).
+Reload vs. restart — the two are not interchangeable:
+
+- **`tardigrade.conf` edits to reloadable values** (request routing, TLS
+  credentials, and other reload-owned config — see
+  [RELOAD_SHUTDOWN.md](RELOAD_SHUTDOWN.md) for the exact boundary):
+  validate, then `systemctl reload tardigrade`.
+- **`tardigrade.conf` edits to process-owned values** (listener shard
+  topology, HTTP/3 listener-owned settings, etc.): reload rejects these;
+  use `systemctl restart tardigrade`.
+- **`tardigrade.env` edits, of any kind**: always `systemctl restart
+  tardigrade`. `SIGHUP` reloads the published config; it cannot change the
+  environment of an already-running process, so a `tardigrade.env` edit has
+  no effect until the process is restarted and re-reads it at exec time.
+
+**Master/worker mode**: the `systemctl reload`/PID-file workflow above
+assumes single-process mode (the default). Per
+[`CONFIGURATION.md`](CONFIGURATION.md#field-reference)'s `master_process`
+entry, master/worker mode does not yet provide coherent PID-file/SIGHUP
+reload control across all workers — use restart semantics
+(`systemctl restart tardigrade`) instead of `reload` if you run with
+`master_process true;`.
 
 ## Docker
 
@@ -222,9 +281,10 @@ local example: builds the image, mounts a read-only config (and optional
 static root / TLS directory), supplies `/run/tardigrade` as a `tmpfs` mount
 owned by the container's non-root user, maps the port, and sets a graceful
 `stop_grace_period` longer than the drain timeout. The `tmpfs` entry needs
-explicit `uid`/`gid` mount options matching the image's `tardigrade` user —
-a plain tmpfs mount defaults to `root:root` and the process can't write its
-PID file into it.
+explicit `uid=10001,gid=10001` mount options matching the image's fixed
+`tardigrade` user (see [Permissions and ownership](#permissions-and-ownership)
+above) — a plain tmpfs mount defaults to `root:root` and the process can't
+write its PID file into it.
 
 The bundled healthcheck runs `tardi status --pid-file ...` inside the
 container. Note its limitation: `tardi status` always exits `0` once the
@@ -262,11 +322,17 @@ Two logging surfaces, both covered in full by
   is configured.
 - **Configured file logs** — set `error_log` (or
   `TARDIGRADE_ERROR_LOG_PATH`) to write to `/var/log/tardigrade/*.log`
-  instead. The DEB/RPM packages already install a logrotate config at
-  `/etc/logrotate.d/tardigrade` that signals `SIGUSR1` after rotation;
+  instead. Both the DEB and RPM packages create a `tardigrade`-owned
+  `/var/log/tardigrade` and install the same logrotate config at
+  `/etc/logrotate.d/tardigrade`, which signals `SIGUSR1` after rotation;
   Tardigrade has a real SIGUSR1 log-reopen handler, so log files reopen
   cleanly on the existing rotation cadence. Don't invent a second rotation
-  mechanism.
+  mechanism. The Docker image creates the same `tardigrade`-owned
+  `/var/log/tardigrade` directory, but it isn't persistent or rotated by
+  anything inside the container — mount a host path or named volume over
+  it if you use `error_log` under Docker (`- ./logs:/var/log/tardigrade`
+  in `compose.yaml`), and handle rotation on the host side. Without that
+  mount, stdout/stderr (`docker compose logs`) is the durable log surface.
 
 > **Operator note discovered while writing this guide**: the starter config
 > matches on `server_name localhost;`. A bare `curl http://<host>:8069/health`
@@ -318,6 +384,10 @@ limiting values.
   item above before exposing a deployment publicly.
 - DEB/RPM remain the more deeply integrated host-native Linux install path
   (user creation, logrotate, systemd wiring all handled by the package).
+- The packaged `systemctl reload`/PID-file control workflow targets
+  single-process mode. `master_process true;` does not yet provide coherent
+  SIGHUP/PID-file reload control across all workers — restart instead of
+  reload in that mode (see [CONFIGURATION.md](CONFIGURATION.md#field-reference)).
 - Every experimental protocol/feature in the [support matrix](SUPPORT_MATRIX.md)
   stays experimental regardless of deployment method — deploying via
   Docker or systemd does not change a feature's maturity level.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -163,7 +163,7 @@ Environment=TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid
 RuntimeDirectory=tardigrade
 RuntimeDirectoryMode=0750
 
-ExecStartPre=/usr/bin/tardi check /etc/tardigrade/tardigrade.conf
+ExecStartPre=/usr/bin/env TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid /usr/bin/tardi check /etc/tardigrade/tardigrade.conf
 ExecStart=/usr/bin/env TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid /usr/bin/tardi run -c /etc/tardigrade/tardigrade.conf
 ExecReload=/usr/bin/tardi reload --pid-file /run/tardigrade/tardigrade.pid
 ExecStop=/usr/bin/tardi stop --pid-file /run/tardigrade/tardigrade.pid
@@ -174,24 +174,28 @@ TimeoutStopSec=35s
 - `RuntimeDirectory=tardigrade` makes systemd create and own
   `/run/tardigrade` (mode `0750`, owned by the `tardigrade` service user) on
   every start — no manual directory setup needed.
-- The PID path is forced twice, deliberately: `Environment=TARDIGRADE_PID_FILE=...`
+- The PID path is forced three times, deliberately: `Environment=TARDIGRADE_PID_FILE=...`
   sets a default, but systemd gives `EnvironmentFile=` values **higher**
   precedence than unit-level `Environment=` values — so a stray
   `TARDIGRADE_PID_FILE=` line in `tardigrade.env` would otherwise silently
   win and desync the running process's actual PID file from what
-  `ExecReload`/`ExecStop` target. `ExecStart` wraps the command in
-  `/usr/bin/env TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid ...`,
+  `ExecReload`/`ExecStop` target. Both `ExecStartPre` and `ExecStart` wrap
+  their command in `/usr/bin/env TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid ...`,
   which sets that variable at exec time and always wins, regardless of
   what's in `tardigrade.env`. `tardi` still runs directly (`env` execs it),
-  so systemd tracks the same process. This exact conflicting-env-file
-  scenario is covered by a regression check in
+  so systemd tracks the same process for `ExecStart`. This exact
+  conflicting-env-file scenario is covered by a regression check in
   `scripts/test-docker-image.sh`.
 - `ExecStartPre` runs `tardi check` against the config before the listener
   binds, so a bad edit fails the start instead of taking down a working
-  process. Because `ExecStartPre` is part of the same unit, it inherits the
-  merged `EnvironmentFile=`/`Environment=` environment — unlike the
-  standalone manual `tardi check` shown in [Commands](#commands) below,
-  it's validating what the service will actually run with.
+  process. It's forced to the same PID value as `ExecStart` for the same
+  reason both commands need it: without the explicit `env` wrapper on both,
+  `ExecStartPre` would validate against whatever conflicting
+  `TARDIGRADE_PID_FILE` happens to be in `tardigrade.env` (the shipped
+  production-baseline example intentionally sets one, for its own
+  standalone-run instructions) while `ExecStart` runs with the forced
+  value — silently validating a different effective configuration than the
+  one that actually starts.
 - `TimeoutStopSec=35s` is set above the default 30s graceful-drain window
   (`TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS`, see
   [RELOAD_SHUTDOWN.md](RELOAD_SHUTDOWN.md)) so systemd doesn't escalate to
@@ -226,10 +230,11 @@ configuration the service runs with.** Run outside the unit, it doesn't load
 defines process environment as higher precedence than config-file values —
 so an invalid or changed value that only exists in `tardigrade.env` (a
 secret bootstrap reference, an overridden port, a TLS path override, etc.)
-can pass this check and still fail at start. The unit's own
-`ExecStartPre=/usr/bin/tardi check ...` is the check that sees the same
-merged environment as `ExecStart`, and is the real pre-flight gate on
-`start`/`restart`.
+can pass this check and still fail at start. The unit's own `ExecStartPre`
+is the check that sees the same merged `EnvironmentFile=`/`Environment=`
+environment as `ExecStart` (both are wrapped with the same forced
+`TARDIGRADE_PID_FILE`, per [above](#the-systemd-units-pidcontrol-path-contract)),
+and is the real pre-flight gate on `start`/`restart`.
 
 Reload vs. restart — the two are not interchangeable:
 
@@ -245,36 +250,50 @@ Reload vs. restart — the two are not interchangeable:
   environment of an already-running process, so a `tardigrade.env` edit has
   no effect until the process is restarted and re-reads it at exec time.
 
-**Master/worker mode**: every control-path example in this guide — systemd
-and Docker alike — assumes single-process mode, which is the default
-(`master_process false;`). If you run with `master_process true;`, three
-things in this guide do not behave as documented:
+**Master/worker mode**: every control-path example in this guide assumes
+single-process mode, which is the default (`master_process false;`). If you
+run with `master_process true;`, what breaks depends on the supervisor —
+systemd and Docker are **not** equivalent here:
 
-- **Reload.** The `systemctl reload`/PID-file workflow above (and the
-  equivalent `tardi reload --pid-file ...` under Docker) targets the PID
-  file's process with `SIGHUP`. Per
+- **Reload — affects both.** The `systemctl reload`/PID-file workflow above
+  (and the equivalent `tardi reload --pid-file ...` under Docker) targets
+  the PID file's process with `SIGHUP`. Per
   [`CONFIGURATION.md`](CONFIGURATION.md#field-reference)'s `master_process`
   entry, master/worker mode does not yet provide coherent PID-file/SIGHUP
-  reload control across all workers — use restart semantics instead
-  (`systemctl restart tardigrade`, or recreate the container) rather than
-  `reload`.
-- **USR1 log-reopen after rotation.** Each worker opens its own error-log
-  file descriptor independently at startup. `SIGUSR1` delivered to the
-  master (via `systemctl kill --signal=USR1`, `docker kill --signal=USR1`,
-  or the packaged logrotate policy) only reopens the *master's own*
-  descriptor today — it is not forwarded to worker processes, so workers
-  keep writing to the rotated-away inode.
-- **The 35s stop window.** The current shutdown path stops workers one at a
-  time (kill, wait for exit, then move to the next), not all at once, so
-  total shutdown time scales with worker count rather than being bounded by
-  a single drain window. A `TimeoutStopSec`/`stop_grace_period` of 35s is
-  not generally sufficient once you have more than one worker.
+  reload control across all workers, regardless of supervisor — use restart
+  semantics instead (`systemctl restart tardigrade`, or recreate the
+  container) rather than `reload`.
+- **USR1 log-reopen after rotation — main-only paths only.** Each worker
+  opens its own error-log file descriptor independently at startup, and
+  nothing forwards `SIGUSR1` to them from the master's own reopen handler.
+  This specifically affects the **packaged systemd logrotate policy**
+  (`systemctl kill --kill-who=main --signal=USR1 ...`, deliberately
+  main-only) and **Docker's `docker kill --signal=USR1 <container>`**
+  (which only ever reaches container PID 1). It does *not* affect a manual
+  `systemctl kill --signal=USR1 tardigrade.service` run without
+  `--kill-who=main` — `systemctl kill`'s default target is *all* processes
+  in the unit's cgroup, so that specific manual command reaches the workers
+  too.
+- **The 35s stop window — Docker (and other master-only-signal
+  supervisors), not the packaged systemd unit.** Tardigrade's own
+  `runMaster` shutdown loop stops workers one at a time (kill, wait for
+  exit, then the next), so under a supervisor that only signals the master
+  process directly — Docker's `docker stop`, which reaches container PID 1
+  — total shutdown time scales with worker count rather than being bounded
+  by a single drain window. The packaged systemd unit does not have this
+  problem: it leaves `KillMode=` at systemd's default `control-group`, so
+  once `ExecStop` returns, systemd delivers the stop signal to *every*
+  process in the service's cgroup concurrently — workers receive `SIGTERM`
+  directly from systemd rather than waiting on the master's serial loop. Do
+  not "fix" this by setting `KillMode=process`; systemd's docs explicitly
+  discourage that because child processes can then escape service lifecycle
+  management entirely.
 
-None of this is specific to Docker or systemd — it's the same underlying
-multi-worker supervisor either way. Until coherent multi-worker signal
-fan-out lands, keep `master_process false;` (the default) if you rely on
-any of reload, log rotation, or a bounded graceful-stop window from this
-guide.
+Until coherent multi-worker reload/log-rotation fan-out lands, keep
+`master_process false;` (the default) if you rely on reload or main-only
+USR1 log rotation from this guide. The 35s-stop-window concern is Docker
+(and other master-only-signal-path) specific — the packaged systemd unit's
+default `control-group` kill mode already avoids it.
 
 ## Docker
 
@@ -501,17 +520,21 @@ limiting values.
   item above before exposing a deployment publicly.
 - DEB/RPM remain the more deeply integrated host-native Linux install path
   (user creation, logrotate, systemd wiring all handled by the package).
-- `master_process true;` is not coherently supported by any of the control
-  paths in this guide, under either systemd or Docker: reload targets one
-  PID via `SIGHUP` (workers aren't reloaded coherently); `SIGUSR1`
-  log-reopen after rotation only reopens the master's own file descriptor,
-  not each worker's; and the documented 35s stop window assumes workers
-  stop roughly in parallel, but the current shutdown path stops them one at
-  a time, so total shutdown time scales with worker count. Keep
-  `master_process false;` (the default) if you rely on reload, log
-  rotation, or a bounded graceful-stop window — see
-  [CONFIGURATION.md](CONFIGURATION.md#field-reference) and the
-  [Commands](#commands) section above.
+- `master_process true;` is not coherently supported by every control path
+  in this guide, and the gaps differ by supervisor — see
+  [Commands](#commands) above for the full breakdown. In short: PID-file/
+  `SIGHUP` reload targets one process and isn't coherent across workers
+  under either systemd or Docker; main-only `SIGUSR1` log-reopen (the
+  packaged systemd logrotate policy and Docker's `docker kill`) doesn't
+  reach worker file descriptors, though a non-main-only manual
+  `systemctl kill --signal=USR1` does; and the 35s graceful-stop window is
+  only a real concern under Docker (or another supervisor that signals only
+  the master process) — the packaged systemd unit's default
+  `KillMode=control-group` already delivers the stop signal to every worker
+  concurrently. Keep `master_process false;` (the default) if you rely on
+  reload or main-only log rotation. See
+  [CONFIGURATION.md](CONFIGURATION.md#field-reference) for the underlying
+  `master_process` contract.
 - Every experimental protocol/feature in the [support matrix](SUPPORT_MATRIX.md)
   stays experimental regardless of deployment method — deploying via
   Docker or systemd does not change a feature's maturity level.

--- a/docs/RELOAD_SHUTDOWN.md
+++ b/docs/RELOAD_SHUTDOWN.md
@@ -40,6 +40,15 @@ sudo systemctl reload tardigrade
 sudo systemctl stop tardigrade
 ```
 
+This standalone `tardi check` validates `tardigrade.conf` only — it doesn't
+load `/etc/tardigrade/tardigrade.env`, so it isn't a complete pre-flight
+check of everything the running service uses. See
+[DEPLOYMENT.md#commands](DEPLOYMENT.md#commands) for the full
+validation/reload/restart contract, including why `tardigrade.env` edits
+need a restart rather than a reload, and the current single-process-only
+scope of this control path (`master_process true;` doesn't yet get coherent
+SIGHUP/PID-file reload across workers).
+
 Set systemd `TimeoutStopSec` slightly above
 `TARDIGRADE_SHUTDOWN_DRAIN_TIMEOUT_MS` so systemd does not escalate to a hard
 kill before Tardigrade's drain has finished.

--- a/examples/production-baseline/README.md
+++ b/examples/production-baseline/README.md
@@ -1,6 +1,10 @@
 # Production-Hardened Baseline
 
-A complete edge deployment combining TLS, security headers, rate limiting, structured access logging, Prometheus metrics, upstream health checks, and graceful drain.
+A hardened **configuration** example combining TLS, security headers, rate limiting, structured access logging, Prometheus metrics, upstream health checks, and graceful drain.
+
+This example covers the config file only. For the surrounding host/container
+service setup — systemd unit, filesystem layout, permissions, Docker image —
+see the [production deployment guide](../../docs/DEPLOYMENT.md).
 
 ## What it demonstrates
 

--- a/examples/production-baseline/tardigrade.env.example
+++ b/examples/production-baseline/tardigrade.env.example
@@ -63,6 +63,14 @@ TARDIGRADE_METRICS_PATH=/status/metrics
 
 # ── Process management ────────────────────────────────────────────────────────
 
+# Under the packaged systemd unit (packaging/systemd/tardigrade.service),
+# ExecStart pins TARDIGRADE_PID_FILE to /run/tardigrade/tardigrade.pid at
+# exec time regardless of this file's value, so ExecReload/ExecStop always
+# target the process the unit actually started. This value only takes
+# effect for standalone/manual runs outside that unit (e.g. this file's own
+# "Quick start" instructions below, run as a local user) — point it at a
+# path your current user can write, and keep it consistent with whatever
+# `--pid-file` you pass to `tardi reload`/`tardi stop` in that case.
 TARDIGRADE_PID_FILE=/tmp/tardigrade.pid
 
 # ── Graceful shutdown ─────────────────────────────────────────────────────────

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -13,7 +13,7 @@ versus what is a local-build-only tool.
 | macOS release archives (`.tar.gz`, darwin x86_64/arm64) | **Planned, not published** | CI builds and tests Tardigrade on `macos-14`, but the release workflow's build matrix only packages Linux. `install.sh` and the Homebrew formula already expect `tardigrade-darwin-*.tar.gz` assets that do not yet exist. |
 | DEB (`packaging/deb/build.sh`) | **Supported, published** | Built for `amd64`/`arm64` from the same release binaries as the `.tar.gz` archives and attached to every GitHub release; also usable as a local builder (`packaging/deb/build.sh`). Smoke-tested on every PR/push via the `packaging-smoke` CI job (`scripts/test-deb-package.sh`). |
 | RPM (`packaging/rpm/build.sh`) | **Supported, published** | Same treatment as DEB, for `x86_64`/`aarch64`. Smoke-tested via `scripts/test-rpm-package.sh`. Built from the same Ubuntu-runner binary as the archives — see the glibc compatibility note below if targeting an older RHEL-family release. |
-| systemd unit (`packaging/systemd/tardigrade.service`) | **Supported** | Installed and exercised end-to-end by both the DEB and RPM smoke tests. |
+| systemd unit (`packaging/systemd/tardigrade.service`) | **Supported** | Installed and structurally validated (unit file text/layout, permissions) by both the DEB and RPM smoke tests. Neither test boots systemd or exercises a real start/status/reload/stop lifecycle — see [docs/DEPLOYMENT.md](../docs/DEPLOYMENT.md#the-systemd-units-pidcontrol-path-contract) for the unit contract these assertions check. |
 | launchd plist (`packaging/launchd/io.baresystems.tardigrade.plist`) | **Unverified template** | Ships as a template for macOS host-native installs; there is no macOS packaging pipeline or smoke test exercising it. |
 | Homebrew (`packaging/homebrew/tardigrade.rb`) | **Formula present, tap not published, macOS blocked** | The `on_linux` blocks can resolve once real release checksums are filled in; the `on_macos` blocks cannot resolve until macOS archives are published (see above). No `Bare-Systems/homebrew-tap` repo exists yet. |
 | Docker / OCI image | **Local build supported, not published** | Root [`Dockerfile`](../Dockerfile) and [`compose.yaml`](../compose.yaml) build a runtime image locally; smoke-tested via `scripts/test-docker-image.sh` in the `packaging-smoke` CI job. No registry-published image or container-publishing workflow exists. See [docs/DEPLOYMENT.md](../docs/DEPLOYMENT.md) for the full workflow. |
@@ -156,14 +156,26 @@ equivalent systemd path.
 
 ## Upgrading
 
-For both DEB and RPM installs, validate the new config before reloading or
-restarting the service, so a bad edit surfaces before the running process is
-affected:
+After a package (or standalone binary) upgrade, use `systemctl restart`, not
+`systemctl reload`:
 
 ```bash
-sudo -u tardigrade tardi check /etc/tardigrade/tardigrade.conf
-sudo systemctl reload tardigrade   # or: restart, if reload is insufficient
+sudo apt install ./new-package.deb   # or: dnf upgrade / rpm -U for RPM
+sudo systemctl restart tardigrade
 ```
+
+`systemctl reload` sends `SIGHUP`, which republishes the *existing running
+process's* config — it does not exec the newly installed `tardi` binary, so
+a package/binary upgrade needs a restart to actually take effect. Reserve
+`reload` for edits to reloadable values in `tardigrade.conf` where neither
+the binary nor `/etc/tardigrade/tardigrade.env` changed; env-file edits also
+always require a restart (`SIGHUP` cannot change an already-running
+process's environment). See
+[docs/DEPLOYMENT.md#commands](../docs/DEPLOYMENT.md#commands) and
+[docs/RELOAD_SHUTDOWN.md](../docs/RELOAD_SHUTDOWN.md) for the exact
+reload/restart boundary, and why the standalone `tardi check` shown there
+isn't a complete pre-flight check on its own (it doesn't load
+`tardigrade.env`).
 
 - DEB upgrades (`sudo apt install ./new-package.deb`) preserve
   `/etc/tardigrade/tardigrade.conf` and `/etc/tardigrade/tardigrade.env` as

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -16,7 +16,7 @@ versus what is a local-build-only tool.
 | systemd unit (`packaging/systemd/tardigrade.service`) | **Supported** | Installed and exercised end-to-end by both the DEB and RPM smoke tests. |
 | launchd plist (`packaging/launchd/io.baresystems.tardigrade.plist`) | **Unverified template** | Ships as a template for macOS host-native installs; there is no macOS packaging pipeline or smoke test exercising it. |
 | Homebrew (`packaging/homebrew/tardigrade.rb`) | **Formula present, tap not published, macOS blocked** | The `on_linux` blocks can resolve once real release checksums are filled in; the `on_macos` blocks cannot resolve until macOS archives are published (see above). No `Bare-Systems/homebrew-tap` repo exists yet. |
-| Docker / OCI image | **Not implemented** | No `Dockerfile` or container-publishing workflow exists in this repository. |
+| Docker / OCI image | **Local build supported, not published** | Root [`Dockerfile`](../Dockerfile) and [`compose.yaml`](../compose.yaml) build a runtime image locally; smoke-tested via `scripts/test-docker-image.sh` in the `packaging-smoke` CI job. No registry-published image or container-publishing workflow exists. See [docs/DEPLOYMENT.md](../docs/DEPLOYMENT.md) for the full workflow. |
 
 ## Quick install (recommended)
 
@@ -134,6 +134,24 @@ Like the DEB package, the RPM installs a starter
 systemd unit's `WorkingDirectory`) on install, so `systemctl enable --now
 tardigrade` works immediately after a fresh install.
 
+## Docker (local build)
+
+There is no published Bare Systems container image. The root
+[`Dockerfile`](../Dockerfile) and [`compose.yaml`](../compose.yaml) support
+building and running Tardigrade in a container locally:
+
+```bash
+docker compose build
+docker compose up -d
+```
+
+The image is a multi-stage build (Zig toolchain in the build stage only, a
+minimal `tardi` + OpenSSL/CA-certificates runtime in the final stage) that
+runs as a non-root `tardigrade` user. See
+[docs/DEPLOYMENT.md](../docs/DEPLOYMENT.md) for the complete Docker workflow
+— build, config validation, start, reload, and graceful stop — alongside the
+equivalent systemd path.
+
 ## Upgrading
 
 For both DEB and RPM installs, validate the new config before reloading or
@@ -198,5 +216,6 @@ Pre-built service files for host-native installs:
 ## Related docs
 
 - [Main README — Install](../README.md#install)
+- [Production deployment guide](../docs/DEPLOYMENT.md)
 - [Release checklist](../docs/RELEASE_CHECKLIST.md)
 - [Support matrix](../docs/SUPPORT_MATRIX.md)

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -130,8 +130,10 @@ sudo systemctl enable --now tardigrade
 ```
 
 Like the DEB package, the RPM installs a starter
-`/etc/tardigrade/tardigrade.conf` and creates `/var/lib/tardigrade` (the
-systemd unit's `WorkingDirectory`) on install, so `systemctl enable --now
+`/etc/tardigrade/tardigrade.conf`, creates `/var/lib/tardigrade` (the
+systemd unit's `WorkingDirectory`), creates a `tardigrade`-owned
+`/var/log/tardigrade`, and installs the same SIGUSR1-reopen logrotate
+policy at `/etc/logrotate.d/tardigrade`, so `systemctl enable --now
 tardigrade` works immediately after a fresh install.
 
 ## Docker (local build)

--- a/packaging/rpm/build.sh
+++ b/packaging/rpm/build.sh
@@ -60,6 +60,22 @@ TARDIGRADE_REQUIRE_UNPRIVILEGED_USER=true
 # TARDIGRADE_UPSTREAM_BASE_URL=http://127.0.0.1:8080
 ENVEOF
 
+# Same SIGUSR1-reopen logrotate policy as the DEB package (packaging/deb/build.sh).
+cat > "${WORK_DIR}/SOURCES/tardigrade.logrotate" <<'LREOF'
+/var/log/tardigrade/*.log {
+    daily
+    missingok
+    rotate 14
+    compress
+    delaycompress
+    notifempty
+    sharedscripts
+    postrotate
+        systemctl kill --kill-who=main --signal=USR1 tardigrade.service 2>/dev/null || true
+    endscript
+}
+LREOF
+
 rpmbuild --define "_topdir ${WORK_DIR}" \
          --define "version ${VERSION}" \
          --define "build_arch ${RPM_ARCH}" \

--- a/packaging/rpm/tardigrade.spec
+++ b/packaging/rpm/tardigrade.spec
@@ -9,6 +9,7 @@ Source1:        tardigrade.service
 Source2:        tardigrade.env
 Source3:        LICENSE
 Source4:        tardigrade.conf
+Source5:        tardigrade.logrotate
 
 BuildArch:      %{build_arch}
 Requires:       openssl-libs
@@ -24,6 +25,7 @@ install -D -m 0644 %{SOURCE1} %{buildroot}%{_unitdir}/tardigrade.service
 install -D -m 0640 %{SOURCE2} %{buildroot}%{_sysconfdir}/tardigrade/tardigrade.env
 install -D -m 0644 %{SOURCE3} %{buildroot}%{_datadir}/licenses/%{name}/LICENSE
 install -D -m 0644 %{SOURCE4} %{buildroot}%{_sysconfdir}/tardigrade/tardigrade.conf
+install -D -m 0644 %{SOURCE5} %{buildroot}%{_sysconfdir}/logrotate.d/tardigrade
 install -d %{buildroot}%{_localstatedir}/log/tardigrade
 
 %pre
@@ -35,6 +37,7 @@ exit 0
 %systemd_post tardigrade.service
 chown root:tardigrade %{_sysconfdir}/tardigrade/tardigrade.env
 install -d -o tardigrade -g tardigrade %{_localstatedir}/lib/tardigrade
+install -d -o tardigrade -g tardigrade %{_localstatedir}/log/tardigrade
 exit 0
 
 %preun
@@ -52,6 +55,7 @@ exit 0
 %{_unitdir}/tardigrade.service
 %config(noreplace) %{_sysconfdir}/tardigrade/tardigrade.env
 %config(noreplace) %{_sysconfdir}/tardigrade/tardigrade.conf
+%config(noreplace) %{_sysconfdir}/logrotate.d/tardigrade
 %dir %{_localstatedir}/log/tardigrade
 
 %changelog

--- a/packaging/systemd/tardigrade.service
+++ b/packaging/systemd/tardigrade.service
@@ -8,13 +8,28 @@ Type=simple
 User=tardigrade
 Group=tardigrade
 WorkingDirectory=/var/lib/tardigrade
+
 EnvironmentFile=-/etc/tardigrade/tardigrade.env
+Environment=TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid
+
+RuntimeDirectory=tardigrade
+RuntimeDirectoryMode=0750
+
+ExecStartPre=/usr/bin/tardi check /etc/tardigrade/tardigrade.conf
 ExecStart=/usr/bin/tardi run -c /etc/tardigrade/tardigrade.conf
-ExecReload=/usr/bin/tardi reload -c /etc/tardigrade/tardigrade.conf
-ExecStop=/usr/bin/tardi stop -c /etc/tardigrade/tardigrade.conf
+ExecReload=/usr/bin/tardi reload --pid-file /run/tardigrade/tardigrade.pid
+ExecStop=/usr/bin/tardi stop --pid-file /run/tardigrade/tardigrade.pid
+
 Restart=on-failure
 RestartSec=2
+TimeoutStopSec=35s
 LimitNOFILE=65536
+
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=full
+UMask=0027
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/systemd/tardigrade.service
+++ b/packaging/systemd/tardigrade.service
@@ -16,7 +16,11 @@ RuntimeDirectory=tardigrade
 RuntimeDirectoryMode=0750
 
 ExecStartPre=/usr/bin/tardi check /etc/tardigrade/tardigrade.conf
-ExecStart=/usr/bin/tardi run -c /etc/tardigrade/tardigrade.conf
+# `EnvironmentFile=` values override unit-level `Environment=` values, so a
+# TARDIGRADE_PID_FILE set in tardigrade.env would otherwise win here and
+# desync from the ExecReload/ExecStop targets below. Force it at exec time
+# instead of trusting it survives environment-file merging.
+ExecStart=/usr/bin/env TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid /usr/bin/tardi run -c /etc/tardigrade/tardigrade.conf
 ExecReload=/usr/bin/tardi reload --pid-file /run/tardigrade/tardigrade.pid
 ExecStop=/usr/bin/tardi stop --pid-file /run/tardigrade/tardigrade.pid
 

--- a/packaging/systemd/tardigrade.service
+++ b/packaging/systemd/tardigrade.service
@@ -15,11 +15,13 @@ Environment=TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid
 RuntimeDirectory=tardigrade
 RuntimeDirectoryMode=0750
 
-ExecStartPre=/usr/bin/tardi check /etc/tardigrade/tardigrade.conf
 # `EnvironmentFile=` values override unit-level `Environment=` values, so a
 # TARDIGRADE_PID_FILE set in tardigrade.env would otherwise win here and
 # desync from the ExecReload/ExecStop targets below. Force it at exec time
-# instead of trusting it survives environment-file merging.
+# on both commands, not just ExecStart -- ExecStartPre exists to validate
+# the configuration the service is actually about to run with, so it needs
+# to see the same forced value.
+ExecStartPre=/usr/bin/env TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid /usr/bin/tardi check /etc/tardigrade/tardigrade.conf
 ExecStart=/usr/bin/env TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid /usr/bin/tardi run -c /etc/tardigrade/tardigrade.conf
 ExecReload=/usr/bin/tardi reload --pid-file /run/tardigrade/tardigrade.pid
 ExecStop=/usr/bin/tardi stop --pid-file /run/tardigrade/tardigrade.pid

--- a/scripts/test-deb-package.sh
+++ b/scripts/test-deb-package.sh
@@ -70,6 +70,12 @@ docker run --pull=never --rm -v "${OUTPUT_DIR}:/artifacts:ro" "$DEB_TEST_IMAGE" 
     test -d /var/lib/tardigrade
     grep -F "EnvironmentFile=-/etc/tardigrade/tardigrade.env" /lib/systemd/system/tardigrade.service
     grep -F "ExecStart=/usr/bin/tardi run -c /etc/tardigrade/tardigrade.conf" /lib/systemd/system/tardigrade.service
+    grep -F "RuntimeDirectory=tardigrade" /lib/systemd/system/tardigrade.service
+    grep -F "Environment=TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid" /lib/systemd/system/tardigrade.service
+    grep -F "ExecStartPre=/usr/bin/tardi check /etc/tardigrade/tardigrade.conf" /lib/systemd/system/tardigrade.service
+    grep -F "ExecReload=/usr/bin/tardi reload --pid-file /run/tardigrade/tardigrade.pid" /lib/systemd/system/tardigrade.service
+    grep -F "ExecStop=/usr/bin/tardi stop --pid-file /run/tardigrade/tardigrade.pid" /lib/systemd/system/tardigrade.service
+    grep -F "TimeoutStopSec=35s" /lib/systemd/system/tardigrade.service
     test "$(stat -c "%a %U %G" /etc/tardigrade/tardigrade.env)" = "640 root tardigrade"
     test "$(stat -c "%a %U %G" /etc/tardigrade/tardigrade.conf)" = "644 root root"
     test "$(stat -c "%a %U %G" /etc/logrotate.d/tardigrade)" = "644 root root"

--- a/scripts/test-deb-package.sh
+++ b/scripts/test-deb-package.sh
@@ -68,8 +68,9 @@ docker run --pull=never --rm -v "${OUTPUT_DIR}:/artifacts:ro" "$DEB_TEST_IMAGE" 
     test -f /lib/systemd/system/tardigrade.service
     test -f /etc/logrotate.d/tardigrade
     test -d /var/lib/tardigrade
+    test -d /var/log/tardigrade
     grep -F "EnvironmentFile=-/etc/tardigrade/tardigrade.env" /lib/systemd/system/tardigrade.service
-    grep -F "ExecStart=/usr/bin/tardi run -c /etc/tardigrade/tardigrade.conf" /lib/systemd/system/tardigrade.service
+    grep -F "ExecStart=/usr/bin/env TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid /usr/bin/tardi run -c /etc/tardigrade/tardigrade.conf" /lib/systemd/system/tardigrade.service
     grep -F "RuntimeDirectory=tardigrade" /lib/systemd/system/tardigrade.service
     grep -F "Environment=TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid" /lib/systemd/system/tardigrade.service
     grep -F "ExecStartPre=/usr/bin/tardi check /etc/tardigrade/tardigrade.conf" /lib/systemd/system/tardigrade.service
@@ -80,6 +81,8 @@ docker run --pull=never --rm -v "${OUTPUT_DIR}:/artifacts:ro" "$DEB_TEST_IMAGE" 
     test "$(stat -c "%a %U %G" /etc/tardigrade/tardigrade.conf)" = "644 root root"
     test "$(stat -c "%a %U %G" /etc/logrotate.d/tardigrade)" = "644 root root"
     test "$(stat -c "%a %U %G" /var/lib/tardigrade)" = "755 tardigrade tardigrade"
+    test "$(stat -c "%U %G" /var/log/tardigrade)" = "tardigrade tardigrade"
+    grep -F "systemctl kill --kill-who=main --signal=USR1 tardigrade.service" /etc/logrotate.d/tardigrade
     apt-get remove -y tardigrade
     test ! -e /usr/bin/tardi
 '

--- a/scripts/test-deb-package.sh
+++ b/scripts/test-deb-package.sh
@@ -73,7 +73,7 @@ docker run --pull=never --rm -v "${OUTPUT_DIR}:/artifacts:ro" "$DEB_TEST_IMAGE" 
     grep -F "ExecStart=/usr/bin/env TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid /usr/bin/tardi run -c /etc/tardigrade/tardigrade.conf" /lib/systemd/system/tardigrade.service
     grep -F "RuntimeDirectory=tardigrade" /lib/systemd/system/tardigrade.service
     grep -F "Environment=TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid" /lib/systemd/system/tardigrade.service
-    grep -F "ExecStartPre=/usr/bin/tardi check /etc/tardigrade/tardigrade.conf" /lib/systemd/system/tardigrade.service
+    grep -F "ExecStartPre=/usr/bin/env TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid /usr/bin/tardi check /etc/tardigrade/tardigrade.conf" /lib/systemd/system/tardigrade.service
     grep -F "ExecReload=/usr/bin/tardi reload --pid-file /run/tardigrade/tardigrade.pid" /lib/systemd/system/tardigrade.service
     grep -F "ExecStop=/usr/bin/tardi stop --pid-file /run/tardigrade/tardigrade.pid" /lib/systemd/system/tardigrade.service
     grep -F "TimeoutStopSec=35s" /lib/systemd/system/tardigrade.service

--- a/scripts/test-docker-image.sh
+++ b/scripts/test-docker-image.sh
@@ -12,8 +12,10 @@ IMAGE_TAG="tardigrade-smoke-test:local"
 CONTAINER_NAME="tardigrade-smoke-test"
 TMPDIR="$(mktemp -d)"
 
+PIDCHECK_CONTAINER_NAME="${CONTAINER_NAME}-pidcheck"
+
 cleanup() {
-    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    docker rm -f "$CONTAINER_NAME" "$PIDCHECK_CONTAINER_NAME" >/dev/null 2>&1 || true
     docker rmi "$IMAGE_TAG" >/dev/null 2>&1 || true
     rm -rf "$TMPDIR"
 }
@@ -59,13 +61,18 @@ if docker run --rm --entrypoint sh "$IMAGE_TAG" -c 'command -v zig' >/dev/null 2
     exit 1
 fi
 
-# ── Non-root runtime UID ─────────────────────────────────────────────────────
-RUNTIME_UID="$(docker run --rm --entrypoint id "$IMAGE_TAG" -u)"
-if [[ "$RUNTIME_UID" == "0" ]]; then
-    echo "FAIL: container runs as root (uid 0)" >&2
+# ── Runtime UID/GID match the fixed identity pinned in the Dockerfile ───────
+# compose.yaml's tmpfs mount and the pidcheck regression below both hard-code
+# this value; assert it exactly rather than just "non-root" so a Dockerfile
+# change that drifts the UID/GID fails here instead of silently breaking
+# tmpfs ownership downstream.
+EXPECTED_UID_GID="10001:10001"
+RUNTIME_UID_GID="$(docker run --rm --entrypoint id "$IMAGE_TAG" -u):$(docker run --rm --entrypoint id "$IMAGE_TAG" -g)"
+if [[ "$RUNTIME_UID_GID" != "$EXPECTED_UID_GID" ]]; then
+    echo "FAIL: runtime uid:gid is '$RUNTIME_UID_GID', expected '$EXPECTED_UID_GID'" >&2
     exit 1
 fi
-echo "runtime uid: $RUNTIME_UID (non-root)"
+echo "runtime uid:gid: $RUNTIME_UID_GID (fixed, non-root)"
 
 # ── tardi version ────────────────────────────────────────────────────────────
 docker run --rm "$IMAGE_TAG" version
@@ -74,7 +81,7 @@ docker run --rm "$IMAGE_TAG" version
 docker run -d --name "$CONTAINER_NAME" \
     -p 18069:8069 \
     -v "${REPO_ROOT}/packaging/tardigrade.conf:/etc/tardigrade/tardigrade.conf:ro" \
-    --tmpfs /run/tardigrade:uid=999,gid=999,mode=0750 \
+    --tmpfs /run/tardigrade:uid=10001,gid=10001,mode=0750 \
     -e TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid \
     "$IMAGE_TAG" >/dev/null
 
@@ -110,6 +117,38 @@ if ! health_check; then
     exit 1
 fi
 echo "reload: service remained alive"
+
+# ── Regression: a conflicting env-file PID path must not win ────────────────
+# The systemd unit's ExecStart forces TARDIGRADE_PID_FILE at exec time
+# because EnvironmentFile= values otherwise override unit-level Environment=
+# and desync ExecReload/ExecStop from where the process actually writes its
+# PID (see packaging/systemd/tardigrade.service). Reproduce that same
+# EnvironmentFile-then-ExecStart shape here: inject a conflicting
+# TARDIGRADE_PID_FILE via `-e` (standing in for EnvironmentFile=), then use
+# `env` in the container command (standing in for ExecStart) to force the
+# deterministic path, exactly like the unit does.
+docker run -d --name "$PIDCHECK_CONTAINER_NAME" \
+    -v "${REPO_ROOT}/packaging/tardigrade.conf:/etc/tardigrade/tardigrade.conf:ro" \
+    --tmpfs /run/tardigrade:uid=10001,gid=10001,mode=0750 \
+    -e TARDIGRADE_PID_FILE=/tmp/conflicting.pid \
+    --entrypoint /usr/bin/env \
+    "$IMAGE_TAG" \
+    TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid \
+    /usr/local/bin/tardi run -c /etc/tardigrade/tardigrade.conf >/dev/null
+
+sleep 1
+if [[ "$(docker inspect -f '{{.State.Running}}' "$PIDCHECK_CONTAINER_NAME")" != "true" ]]; then
+    echo "FAIL: conflicting-env-file regression container did not start" >&2
+    docker logs "$PIDCHECK_CONTAINER_NAME" >&2 || true
+    exit 1
+fi
+docker exec "$PIDCHECK_CONTAINER_NAME" test -f /run/tardigrade/tardigrade.pid
+if docker exec "$PIDCHECK_CONTAINER_NAME" test -e /tmp/conflicting.pid; then
+    echo "FAIL: process wrote the conflicting env-file PID path instead of the forced one" >&2
+    exit 1
+fi
+docker rm -f "$PIDCHECK_CONTAINER_NAME" >/dev/null 2>&1
+echo "conflicting-env regression: deterministic PID path won"
 
 # ── Graceful stop over Docker's normal SIGTERM path (tardi is PID 1) ────────
 docker stop --time 35 "$CONTAINER_NAME" >/dev/null

--- a/scripts/test-docker-image.sh
+++ b/scripts/test-docker-image.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Smoke-test the local Dockerfile build: image build, non-root runtime user,
+# health endpoint, PID file, reload, and graceful stop over Docker's normal
+# SIGTERM path. Proves actual container behavior, not just Dockerfile syntax.
+#
+# Usage: ./scripts/test-docker-image.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+IMAGE_TAG="tardigrade-smoke-test:local"
+CONTAINER_NAME="tardigrade-smoke-test"
+TMPDIR="$(mktemp -d)"
+
+cleanup() {
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    docker rmi "$IMAGE_TAG" >/dev/null 2>&1 || true
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+    echo "skipping Docker smoke test outside Linux" >&2
+    exit 0
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "skipping Docker smoke test because docker is unavailable" >&2
+    exit 0
+fi
+
+retry() {
+    local attempts="$1"
+    shift
+    local delay=2
+    local n=1
+    while ! "$@"; do
+        if (( n >= attempts )); then
+            return 1
+        fi
+        sleep "$delay"
+        delay=$((delay * 2))
+        n=$((n + 1))
+    done
+}
+
+# ── Validate compose.yaml, if compose is available ───────────────────────────
+if docker compose version >/dev/null 2>&1; then
+    (cd "$REPO_ROOT" && docker compose -f compose.yaml config --quiet)
+    echo "compose.yaml: valid"
+fi
+
+# ── Build ─────────────────────────────────────────────────────────────────────
+docker build -t "$IMAGE_TAG" "$REPO_ROOT"
+
+# ── Runtime image must not contain Zig/compiler build tooling ───────────────
+if docker run --rm --entrypoint sh "$IMAGE_TAG" -c 'command -v zig' >/dev/null 2>&1; then
+    echo "FAIL: runtime image contains a zig binary; build tooling leaked into final stage" >&2
+    exit 1
+fi
+
+# ── Non-root runtime UID ─────────────────────────────────────────────────────
+RUNTIME_UID="$(docker run --rm --entrypoint id "$IMAGE_TAG" -u)"
+if [[ "$RUNTIME_UID" == "0" ]]; then
+    echo "FAIL: container runs as root (uid 0)" >&2
+    exit 1
+fi
+echo "runtime uid: $RUNTIME_UID (non-root)"
+
+# ── tardi version ────────────────────────────────────────────────────────────
+docker run --rm "$IMAGE_TAG" version
+
+# ── Start with a minimal valid config, matching the shared starter config ──
+docker run -d --name "$CONTAINER_NAME" \
+    -p 18069:8069 \
+    -v "${REPO_ROOT}/packaging/tardigrade.conf:/etc/tardigrade/tardigrade.conf:ro" \
+    --tmpfs /run/tardigrade:uid=999,gid=999,mode=0750 \
+    -e TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid \
+    "$IMAGE_TAG" >/dev/null
+
+# ── Wait for /health (Host header must match the starter config's server_name) ──
+health_check() {
+    curl -fsS -H "Host: localhost" http://127.0.0.1:18069/health >/dev/null
+}
+if ! retry 10 health_check; then
+    echo "FAIL: /health never became reachable" >&2
+    docker logs "$CONTAINER_NAME" >&2 || true
+    exit 1
+fi
+echo "/health: OK"
+
+# ── PID file exists in the container ─────────────────────────────────────────
+docker exec "$CONTAINER_NAME" test -f /run/tardigrade/tardigrade.pid
+echo "pid file: present"
+
+# ── tardi check against the running container's config ──────────────────────
+docker exec "$CONTAINER_NAME" tardi check /etc/tardigrade/tardigrade.conf
+
+# ── Reload and assert the same process stays alive ───────────────────────────
+docker exec "$CONTAINER_NAME" tardi reload --pid-file /run/tardigrade/tardigrade.pid
+sleep 1
+if [[ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER_NAME")" != "true" ]]; then
+    echo "FAIL: container is not running after reload" >&2
+    docker logs "$CONTAINER_NAME" >&2 || true
+    exit 1
+fi
+if ! health_check; then
+    echo "FAIL: /health unreachable after reload" >&2
+    docker logs "$CONTAINER_NAME" >&2 || true
+    exit 1
+fi
+echo "reload: service remained alive"
+
+# ── Graceful stop over Docker's normal SIGTERM path (tardi is PID 1) ────────
+docker stop --time 35 "$CONTAINER_NAME" >/dev/null
+EXIT_CODE="$(docker inspect -f '{{.State.ExitCode}}' "$CONTAINER_NAME")"
+if [[ "$EXIT_CODE" != "0" ]]; then
+    echo "FAIL: container did not exit cleanly after SIGTERM (exit code $EXIT_CODE)" >&2
+    docker logs "$CONTAINER_NAME" >&2 || true
+    exit 1
+fi
+if ! docker logs "$CONTAINER_NAME" 2>&1 | grep -q "Graceful shutdown complete"; then
+    echo "FAIL: no graceful-shutdown-complete log line found" >&2
+    docker logs "$CONTAINER_NAME" >&2 || true
+    exit 1
+fi
+echo "stop: graceful exit (code 0)"
+
+printf 'docker image smoke test passed\n'

--- a/scripts/test-rpm-package.sh
+++ b/scripts/test-rpm-package.sh
@@ -82,14 +82,32 @@ docker run --pull=never --rm \
         export PATH="/opt/zig:${PATH}"
 
         # Build from source inside this container so the binary links against
-        # Rocky Linux 9'"'"'s glibc (2.34) rather than the CI runner'"'"'s.
+        # Rocky Linux 9'"'"'s glibc (2.34) rather than the CI runner'"'"'s. Discard
+        # any zig-out/.zig-cache copied in from the host/CI runner first: without
+        # this, a build failure inside this container (wrong glibc, missing libs,
+        # etc.) can go unnoticed because a stale host-built binary still satisfies
+        # the path below, and the smoke test would package that binary instead of
+        # actually proving the Rocky build works.
         cp -a /repo /tmp/tardigrade
         cd /tmp/tardigrade
-        zig build -Doptimize=ReleaseFast
+        rm -rf zig-out .zig-cache
+
+        # glibc 2.34 (Rocky/RHEL 9'"'"'s version) merged libpthread into libc and
+        # re-versioned pthread_create/pthread_join/etc. under a new GLIBC_2.34
+        # symbol version. Zig'"'"'s default native-target glibc floor predates that,
+        # so it doesn'"'"'t know those symbol versions exist and dynamic linking
+        # against the real /usr/lib64/libssl.so fails with "undefined reference"
+        # even though the symbols are genuinely present at runtime. Passing an
+        # explicit glibc-version floor (not a ceiling -- linking is still against
+        # the real system libc.so.6 dynamically) fixes it; bare "native"/"native-native-gnu"
+        # does not, and was confirmed to reproduce the same failure.
+        zig_arch="$(uname -m)"
+        zig build -Doptimize=ReleaseFast -Dtarget="${zig_arch}-linux-gnu.2.34"
+        test -x zig-out/bin/tardi
 
         /repo/packaging/rpm/build.sh \
             --version 0.0.0 \
-            --arch x86_64 \
+            --arch "$zig_arch" \
             --binary /tmp/tardigrade/zig-out/bin/tardi \
             --output /output
 
@@ -105,13 +123,17 @@ docker run --pull=never --rm \
         test -f /etc/tardigrade/tardigrade.conf
         test -f /usr/lib/systemd/system/tardigrade.service
         test -f /usr/share/licenses/tardigrade/LICENSE
+        test -f /etc/logrotate.d/tardigrade
         test -d /var/log/tardigrade
         test -d /var/lib/tardigrade
         test "$(stat -c "%a %U %G" /etc/tardigrade/tardigrade.env)" = "640 root tardigrade"
         test "$(stat -c "%a %U %G" /etc/tardigrade/tardigrade.conf)" = "644 root root"
+        test "$(stat -c "%a %U %G" /etc/logrotate.d/tardigrade)" = "644 root root"
         test "$(stat -c "%a %U %G" /var/lib/tardigrade)" = "755 tardigrade tardigrade"
+        test "$(stat -c "%U %G" /var/log/tardigrade)" = "tardigrade tardigrade"
+        grep -F "systemctl kill --kill-who=main --signal=USR1 tardigrade.service" /etc/logrotate.d/tardigrade
         grep -F "EnvironmentFile=-/etc/tardigrade/tardigrade.env" /usr/lib/systemd/system/tardigrade.service
-        grep -F "ExecStart=/usr/bin/tardi run -c /etc/tardigrade/tardigrade.conf" /usr/lib/systemd/system/tardigrade.service
+        grep -F "ExecStart=/usr/bin/env TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid /usr/bin/tardi run -c /etc/tardigrade/tardigrade.conf" /usr/lib/systemd/system/tardigrade.service
         grep -F "WorkingDirectory=/var/lib/tardigrade" /usr/lib/systemd/system/tardigrade.service
         grep -F "RuntimeDirectory=tardigrade" /usr/lib/systemd/system/tardigrade.service
         grep -F "Environment=TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid" /usr/lib/systemd/system/tardigrade.service

--- a/scripts/test-rpm-package.sh
+++ b/scripts/test-rpm-package.sh
@@ -113,6 +113,12 @@ docker run --pull=never --rm \
         grep -F "EnvironmentFile=-/etc/tardigrade/tardigrade.env" /usr/lib/systemd/system/tardigrade.service
         grep -F "ExecStart=/usr/bin/tardi run -c /etc/tardigrade/tardigrade.conf" /usr/lib/systemd/system/tardigrade.service
         grep -F "WorkingDirectory=/var/lib/tardigrade" /usr/lib/systemd/system/tardigrade.service
+        grep -F "RuntimeDirectory=tardigrade" /usr/lib/systemd/system/tardigrade.service
+        grep -F "Environment=TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid" /usr/lib/systemd/system/tardigrade.service
+        grep -F "ExecStartPre=/usr/bin/tardi check /etc/tardigrade/tardigrade.conf" /usr/lib/systemd/system/tardigrade.service
+        grep -F "ExecReload=/usr/bin/tardi reload --pid-file /run/tardigrade/tardigrade.pid" /usr/lib/systemd/system/tardigrade.service
+        grep -F "ExecStop=/usr/bin/tardi stop --pid-file /run/tardigrade/tardigrade.pid" /usr/lib/systemd/system/tardigrade.service
+        grep -F "TimeoutStopSec=35s" /usr/lib/systemd/system/tardigrade.service
 
         dnf remove -y tardigrade
         test ! -e /usr/bin/tardi

--- a/scripts/test-rpm-package.sh
+++ b/scripts/test-rpm-package.sh
@@ -137,7 +137,7 @@ docker run --pull=never --rm \
         grep -F "WorkingDirectory=/var/lib/tardigrade" /usr/lib/systemd/system/tardigrade.service
         grep -F "RuntimeDirectory=tardigrade" /usr/lib/systemd/system/tardigrade.service
         grep -F "Environment=TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid" /usr/lib/systemd/system/tardigrade.service
-        grep -F "ExecStartPre=/usr/bin/tardi check /etc/tardigrade/tardigrade.conf" /usr/lib/systemd/system/tardigrade.service
+        grep -F "ExecStartPre=/usr/bin/env TARDIGRADE_PID_FILE=/run/tardigrade/tardigrade.pid /usr/bin/tardi check /etc/tardigrade/tardigrade.conf" /usr/lib/systemd/system/tardigrade.service
         grep -F "ExecReload=/usr/bin/tardi reload --pid-file /run/tardigrade/tardigrade.pid" /usr/lib/systemd/system/tardigrade.service
         grep -F "ExecStop=/usr/bin/tardi stop --pid-file /run/tardigrade/tardigrade.pid" /usr/lib/systemd/system/tardigrade.service
         grep -F "TimeoutStopSec=35s" /usr/lib/systemd/system/tardigrade.service


### PR DESCRIPTION
## Summary

- Adds `docs/DEPLOYMENT.md`, the canonical operator guide covering both host-native Linux/systemd and locally built Docker deployment: filesystem layout (with explicit package-install vs. service-start vs. operator-created distinctions), permissions (including numeric-GID guidance for bind-mounted TLS material), port/privilege guidance, logs (including Docker file-log ownership and rotation), and a production hardening checklist. Links out to `docs/CONFIGURATION.md`, `docs/RELOAD_SHUTDOWN.md`, `docs/OBSERVABILITY.md`, `docs/SUPPORT_MATRIX.md`, `packaging/README.md`, and `examples/production-baseline/` rather than duplicating them.
- Fixes the systemd PID/control-path gap called out in the issue: `packaging/systemd/tardigrade.service` had no *deterministic* PID-file contract. `EnvironmentFile=` values override unit-level `Environment=` values, so a `TARDIGRADE_PID_FILE` set in `tardigrade.env` (as the shipped production-baseline example originally did) could desync the running process's actual PID file from what `ExecReload`/`ExecStop` target. `ExecStart` now forces the path via `/usr/bin/env TARDIGRADE_PID_FILE=... tardi run ...` at exec time, uses `RuntimeDirectory=tardigrade` for `/run/tardigrade`, validates config in `ExecStartPre`, and raises `TimeoutStopSec` (35s) above the default 30s graceful-drain window. Covered by a regression test in `scripts/test-docker-image.sh` that reproduces the exact conflicting-env-file scenario.
- RPM packaging now has parity with DEB: installs the same SIGUSR1-reopen logrotate policy at `/etc/logrotate.d/tardigrade` and chowns `/var/log/tardigrade` to the `tardigrade` user in `%post` — previously neither existed, so `error_log` couldn't be used on a fresh RPM install.
- Adds a root `Dockerfile` (multi-stage: Zig toolchain only in the build stage, fixed non-root `tardigrade` UID/GID `10001:10001` — not a distro-allocated ID — no build tooling in the final image) and `compose.yaml` as a local-build-only Docker workflow — no image is published to a registry.
- Adds `scripts/test-docker-image.sh`, wired into the `packaging-smoke` CI job: builds the image from a clean checkout, asserts the exact pinned UID/GID, hits `/health`, checks the PID file, validates config, reloads, runs the conflicting-env-file PID regression, and confirms a graceful `SIGTERM` exit.
- Strengthens `scripts/test-rpm-package.sh`'s build isolation: it previously copied the host/CI runner's pre-built `zig-out/` into the Rocky Linux container before rebuilding, so a failing in-container build could still "succeed" by packaging the stale host binary. Added `rm -rf zig-out .zig-cache` + `test -x zig-out/bin/tardi` to make it honest — which immediately surfaced two real, previously-masked build bugs, both fixed in `build.zig`:
  - `configureSystemLibrarySearchPaths` only knew Debian's multiarch library layout (`/usr/lib/x86_64-linux-gnu`), never RHEL's flat `lib64` layout, so it never pointed the linker at Rocky's real OpenSSL location.
  - Rocky 9's glibc 2.34 (which merged `libpthread` into `libc` and re-versioned `pthread_create`/`pthread_join` under the new `GLIBC_2.34` symbol version) needs an explicit `-Dtarget=<arch>-linux-gnu.2.34` floor — Zig's default native-glibc assumption predates that and can't resolve those symbol versions otherwise, even though they're genuinely present at runtime. Also fixed a hardcoded `--arch x86_64` in the same script that only breaks on non-x86_64 dev hosts.
- Updates `packaging/README.md`: Docker status row from "Not implemented" to "Local build supported, not published"; the systemd-unit status row now accurately says "structurally validated" rather than "exercised end-to-end" (the smoke tests assert unit-file text/layout, not a booted systemd lifecycle); the `## Upgrading` section now recommends `systemctl restart` after a package/binary upgrade (`reload` republishes config for the *already-running* process — it doesn't exec a newly installed binary), reserving `reload` for reloadable `tardigrade.conf`-only edits. Links `README.md` / `examples/production-baseline/README.md` to the new guide.
- `.dockerignore`: excludes repo-local `.zig/`/`dist/` build artifacts (previously ~400MB of avoidable context on every packaging-smoke CI run) and the now-unnecessary `zig-out/` re-inclusion (the Dockerfile always does its own clean-source `zig build`), and narrows the `tests/vectors` re-inclusion to exactly the fixture files `build.zig` embeds into the production binary (`tests/vectors/pki/malformed-truncated.der`, `tests/vectors/pki/reduced/{manifest.zig,*.der}`) instead of the whole tree.

## Test plan

- [x] `docker build .` — succeeds; confirmed the fixed runtime UID:GID (`10001:10001`, not a distro-allocated ID) and that `zig` is absent from the final image.
- [x] `docker compose -f compose.yaml config --quiet` — valid.
- [x] Full container lifecycle exercised locally end-to-end via `scripts/test-docker-image.sh` (run directly, not just read for plausibility): build, exact UID/GID assertion, `/health` returns 200 (matching `Host` header — documented as an operator gotcha), PID file present, `tardi check`, `tardi reload --pid-file` (hot reload applied, same PID stays alive), the conflicting-env-file PID-path regression (a stray `TARDIGRADE_PID_FILE` injected the way `EnvironmentFile=` would still resolves to the deterministic `/run/tardigrade/tardigrade.pid`), and `docker stop` → graceful-shutdown log line, clean exit code 0.
- [x] `scripts/test-rpm-package.sh` run end-to-end locally against a real (non-cached) Rocky Linux 9 container: genuine `zig build` from clean source with the `-Dtarget=aarch64-linux-gnu.2.34` fix, RPM build, `dnf install`, every corrected systemd-unit-contract assertion (`RuntimeDirectory`, forced `ExecStart` PID env, `ExecReload`/`ExecStop` `--pid-file`, `ExecStartPre`, `TimeoutStopSec`), the new logrotate/log-ownership assertions, and `dnf remove` — passed.
- [x] Docker build context measured directly (via a throwaway `COPY . /ctx; find /ctx` Dockerfile) to confirm `.zig/`, `dist/`, and `zig-out/` are fully excluded and only the intended `tests/vectors/pki/*` fixture files are present.
- [x] `shellcheck` on all new/modified shell scripts — clean.
- [x] `zig fmt --check build.zig` and `git diff --check` — clean.
- [x] CI (`packaging-smoke` and the rest of the matrix) is green on the current head.
- [x] Verified every DEB/RPM smoke-test `grep -F` assertion byte-for-byte against the actual unit file content, and all relative Markdown links added/edited in this PR resolve to real files/anchors.

Closes #166
