### PR TITLE
quic: retain opt-in H3 interop observability artifacts

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -840,6 +840,7 @@ pub fn build(b: *std.Build) void {
     h3_interop_mod.addImport("http3", http3_mod);
     h3_interop_mod.addImport("stream_transport", stream_transport_mod);
     h3_interop_mod.addImport("tls_interop_matrix", tls_interop_matrix_mod);
+    h3_interop_mod.addImport("zig_compat", compat_mod);
     const h3_interop_tool = b.addExecutable(.{
         .name = "h3_interop_tool",
         .root_module = h3_interop_mod,

--- a/build.zig
+++ b/build.zig
@@ -848,6 +848,9 @@ pub fn build(b: *std.Build) void {
     const h3_interop_install = b.addInstallArtifact(h3_interop_tool, .{});
     const h3_interop_step = b.step("build-h3-interop", "Build the native HTTP/3 interop client/server tool");
     h3_interop_step.dependOn(&h3_interop_install.step);
+    const h3_interop_tests = b.addTest(.{ .root_module = h3_interop_mod });
+    const run_h3_interop_tests = b.addRunArtifact(h3_interop_tests);
+    test_step.dependOn(&run_h3_interop_tests.step);
 
     // Out-of-process record-transport TLS conformance driver (#338). Runs
     // the shared engine as client or server against external peers

--- a/docs/QUIC_QLOG.md
+++ b/docs/QUIC_QLOG.md
@@ -14,8 +14,9 @@ This document is the design of record. The scaffolding it describes lives in:
   gateway HTTP/3 listener.
 
 The event models, JSON-SEQ serializers, HTTP/3 qlog bridge, QUIC qlog bridge,
-shared TLS keylog emission seam, and gateway qlog/keylog file destinations are
-implemented. #247 artifact retention remains opt-in harness work.
+shared TLS keylog emission seam, gateway qlog/keylog file destinations, and
+#247 external H3 interop artifact retention are implemented. All artifact
+capture remains opt-in.
 
 ## Goals
 
@@ -222,6 +223,37 @@ Use `.sqlog` files with qvis. Use the `.keys` file with Wireshark only together
 with packet captures from traffic you own and are authorized to decrypt. Delete
 both artifacts after the debugging session unless your incident-retention
 policy explicitly says otherwise.
+
+### External H3 interop artifacts
+
+`scripts/interop/run-interop.sh` keeps ordinary matrix runs unchanged: no qlog
+or keylog artifacts are produced by default. For local failure debugging, enable
+artifacts explicitly:
+
+```sh
+INTEROP_QLOG=1 \
+INTEROP_ARTIFACT_DIR=/tmp/tardigrade-h3-artifacts \
+NGTCP2_EXAMPLES_DIR=/path/to/ngtcp2/build/examples \
+scripts/interop/run-interop.sh
+```
+
+`INTEROP_QLOG=1` passes `--qlog-dir` to each native `h3_interop_tool` direction
+and retains the resulting per-role `.sqlog` files under one directory per
+matrix case. `INTEROP_KEYLOG=1` additionally passes `--keylog-path`, writes a
+per-role `.keys` file beside the qlog files, and creates a
+`SENSITIVE-KEYLOG.txt` marker. Keylog capture is deliberately separate from
+qlog because the `.keys` file permits decrypting packet captures.
+
+If any matrix row fails and an artifact root is active, the script prints the
+artifact directory once at the end:
+
+```text
+interop failure artifacts: /tmp/tardigrade-h3-artifacts
+```
+
+Do not enable `INTEROP_KEYLOG` in ordinary public CI, and do not upload keylogs
+without an explicitly authorized secret-safe artifact policy. qlog traces can
+be useful opt-in failure evidence; keylogs require separate handling.
 
 ### Sink error handling
 

--- a/scripts/interop/README.md
+++ b/scripts/interop/README.md
@@ -118,6 +118,31 @@ The matrix logs stdout/stderr for each side under the printed `logs:` path.
 They contain request/response status and the explicit HRR assertion lines
 above, but no keylog output or secret material.
 
+## Optional qlog/keylog failure artifacts
+
+Default matrix runs produce only the normal text logs. Local debugging can
+opt in to qlog traces and, separately, TLS keylog files:
+
+```sh
+INTEROP_QLOG=1 \
+INTEROP_ARTIFACT_DIR=/tmp/tardigrade-h3-artifacts \
+NGTCP2_EXAMPLES_DIR=/tmp/tardigrade-h3-peer/client/build/examples \
+scripts/interop/run-interop.sh
+```
+
+`INTEROP_QLOG=1` passes `--qlog-dir` to each native `h3_interop_tool`
+invocation and retains per-case/per-role `.sqlog` files. `INTEROP_KEYLOG=1`
+also passes `--keylog-path`, writes per-role `.keys` files, and places a
+`SENSITIVE-KEYLOG.txt` marker beside them. Keylogs permit decrypting packet
+captures and must not be uploaded to public CI artifacts, logs, or issues.
+
+When any row fails and artifacts were enabled, the script prints the artifact
+root once after the summary so the directory can be collected:
+
+```text
+interop failure artifacts: /tmp/tardigrade-h3-artifacts
+```
+
 ## #522: production resumption/0-RTT interop
 
 The matrix above proves baseline wire interoperability against the direct

--- a/scripts/interop/run-interop.sh
+++ b/scripts/interop/run-interop.sh
@@ -32,8 +32,54 @@ mkdir -p "$certs" "$logs"
 pass=0
 fail=0
 skip=0
+artifact_dir=""
+qlog_enabled=0
+keylog_enabled=0
 
 say() { printf '%s\n' "$*"; }
+
+enabled() {
+  case "${1:-}" in
+    1|true|TRUE|yes|YES|on|ON) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if enabled "${INTEROP_QLOG:-}"; then
+  qlog_enabled=1
+fi
+if enabled "${INTEROP_KEYLOG:-}"; then
+  keylog_enabled=1
+fi
+if [ "$qlog_enabled" -eq 1 ] || [ "$keylog_enabled" -eq 1 ]; then
+  artifact_dir="${INTEROP_ARTIFACT_DIR:-$workdir/artifacts}"
+  mkdir -p "$artifact_dir"
+fi
+if [ "$keylog_enabled" -eq 1 ]; then
+  say "WARNING: INTEROP_KEYLOG is enabled; retained *.keys files permit decrypting captured traffic and must be treated as sensitive."
+fi
+
+native_artifact_args=() # case-id role
+prepare_native_artifacts() {
+  native_artifact_args=()
+  [ -n "$artifact_dir" ] || return 0
+  local case_id="$1"
+  local role="$2"
+  local case_dir="$artifact_dir/$case_id"
+  mkdir -p "$case_dir"
+  if [ "$qlog_enabled" -eq 1 ]; then
+    mkdir -p "$case_dir/qlog-$role"
+    native_artifact_args+=(--qlog-dir "$case_dir/qlog-$role")
+  fi
+  if [ "$keylog_enabled" -eq 1 ]; then
+    native_artifact_args+=(--keylog-path "$case_dir/$role.keys")
+    printf '%s\n' \
+      'SENSITIVE: *.keys files in this directory contain TLS traffic secrets.' \
+      'Do not upload them to public CI artifacts, logs, or issues.' \
+      >"$case_dir/SENSITIVE-KEYLOG.txt"
+    chmod 0600 "$case_dir/SENSITIVE-KEYLOG.txt" 2>/dev/null || true
+  fi
+}
 
 result() { # name status
   case "$2" in
@@ -68,8 +114,9 @@ if [ -n "${NGTCP2_EXAMPLES_DIR:-}" ] && [ -x "$NGTCP2_EXAMPLES_DIR/gtlsserver" ]
     -d "$workdir/docroot" --quiet >"$logs/1-gtlsserver.log" 2>&1 &
   peer=$!
   wait_udp_listen
+  prepare_native_artifacts "1-native-client-ngtcp2-server" "native-client"
   if "$tool" client --host 127.0.0.1 --port "$port" --authority tardigrade.test \
-    --path /interop.txt --insecure --timeout-ms 10000 >"$logs/1-native-client.log" 2>&1 &&
+    --path /interop.txt --insecure --timeout-ms 10000 "${native_artifact_args[@]}" >"$logs/1-native-client.log" 2>&1 &&
     grep -q "hello-from-ngtcp2" "$logs/1-native-client.log"; then
     result "native client -> ngtcp2 gtlsserver" PASS
   else
@@ -84,8 +131,9 @@ fi
 # --- 2. ngtcp2 gtlsclient -> native server --------------------------------
 next_port
 if [ -n "${NGTCP2_EXAMPLES_DIR:-}" ] && [ -x "$NGTCP2_EXAMPLES_DIR/gtlsclient" ]; then
+  prepare_native_artifacts "2-ngtcp2-client-native-server" "native-server"
   "$tool" server --port "$port" --cert "$certs/ed25519-cert.der" --key "$certs/ed25519-key.pkcs8.der" \
-    --timeout-ms 15000 >"$logs/2-native-server.log" 2>&1 &
+    --timeout-ms 15000 "${native_artifact_args[@]}" >"$logs/2-native-server.log" 2>&1 &
   peer=$!
   wait_udp_listen
   "$NGTCP2_EXAMPLES_DIR/gtlsclient" 127.0.0.1 "$port" "https://tardigrade.test/from-ngtcp2" \
@@ -112,9 +160,10 @@ if [ -n "${NGTCP2_EXAMPLES_DIR:-}" ] && [ -x "$NGTCP2_EXAMPLES_DIR/gtlsserver" ]
     -d "$workdir/hrr-docroot" --quiet >"$logs/333-1-gtlsserver-hrr.log" 2>&1 &
   peer=$!
   wait_udp_listen
+  prepare_native_artifacts "333-1-native-hrr-client-ngtcp2-server" "native-client"
   if "$tool" client --host 127.0.0.1 --port "$port" --authority tardigrade.test \
     --path /hrr.txt --insecure --empty-initial-key-share --expect-hrr --timeout-ms 10000 \
-    >"$logs/333-1-native-client-hrr.log" 2>&1 &&
+    "${native_artifact_args[@]}" >"$logs/333-1-native-client-hrr.log" 2>&1 &&
     grep -q "hello-from-ngtcp2-hrr" "$logs/333-1-native-client-hrr.log" &&
     grep -q "tls retry_state=hrr_received" "$logs/333-1-native-client-hrr.log"; then
     result "#333 native HRR client -> ngtcp2 gtlsserver" PASS
@@ -130,8 +179,9 @@ fi
 # --- 333-2. ngtcp2 HRR gtlsclient -> native server ------------------------
 next_port
 if [ -n "${NGTCP2_EXAMPLES_DIR:-}" ] && [ -x "$NGTCP2_EXAMPLES_DIR/gtlsclient" ]; then
+  prepare_native_artifacts "333-2-ngtcp2-hrr-client-native-server" "native-server"
   "$tool" server --port "$port" --cert "$certs/ed25519-cert.der" --key "$certs/ed25519-key.pkcs8.der" \
-    --expect-hrr --verbose --timeout-ms 15000 >"$logs/333-2-native-server-hrr.log" 2>&1 &
+    --expect-hrr --verbose --timeout-ms 15000 "${native_artifact_args[@]}" >"$logs/333-2-native-server-hrr.log" 2>&1 &
   peer=$!
   wait_udp_listen
   "$NGTCP2_EXAMPLES_DIR/gtlsclient" --groups=-GROUP-ALL:+GROUP-SECP256R1:+GROUP-X25519:%NO_SHUFFLE_EXTENSIONS \
@@ -160,8 +210,9 @@ if [ -n "${QUICHE_EXAMPLES_DIR:-}" ] && [ -x "$QUICHE_EXAMPLES_DIR/http3-server"
   (cd "$workdir/quiche-run" && exec "$QUICHE_EXAMPLES_DIR/http3-server") >"$logs/3-quiche-server.log" 2>&1 &
   peer=$!
   wait_udp_listen
+  prepare_native_artifacts "3-native-client-quiche-server" "native-client"
   if "$tool" client --host 127.0.0.1 --port 4433 --authority tardigrade.test \
-    --path /index.html --insecure --timeout-ms 10000 >"$logs/3-native-client.log" 2>&1 &&
+    --path /index.html --insecure --timeout-ms 10000 "${native_artifact_args[@]}" >"$logs/3-native-client.log" 2>&1 &&
     grep -q "^status: " "$logs/3-native-client.log"; then
     result "native client -> quiche http3-server" PASS
   else
@@ -176,8 +227,9 @@ fi
 # --- 4. quiche http3-client -> native server ------------------------------
 next_port
 if [ -n "${QUICHE_EXAMPLES_DIR:-}" ] && [ -x "$QUICHE_EXAMPLES_DIR/http3-client" ]; then
+  prepare_native_artifacts "4-quiche-client-native-server" "native-server"
   "$tool" server --port "$port" --cert "$certs/p256-cert.der" --key "$certs/p256-key.pkcs8.der" \
-    --timeout-ms 15000 >"$logs/4-native-server.log" 2>&1 &
+    --timeout-ms 15000 "${native_artifact_args[@]}" >"$logs/4-native-server.log" 2>&1 &
   peer=$!
   wait_udp_listen
   RUST_LOG=error "$QUICHE_EXAMPLES_DIR/http3-client" "https://127.0.0.1:$port/from-quiche" \
@@ -202,8 +254,9 @@ if [ -n "${AIOQUIC_PYTHON:-}" ]; then
     >"$logs/5-aioquic-server.log" 2>&1 &
   peer=$!
   wait_udp_listen
+  prepare_native_artifacts "5-native-client-aioquic-server" "native-client"
   if "$tool" client --host 127.0.0.1 --port "$port" --authority tardigrade.test \
-    --path /to-aioquic --insecure --timeout-ms 10000 >"$logs/5-native-client.log" 2>&1 &&
+    --path /to-aioquic --insecure --timeout-ms 10000 "${native_artifact_args[@]}" >"$logs/5-native-client.log" 2>&1 &&
     grep -q "hello from aioquic" "$logs/5-native-client.log"; then
     result "native client -> aioquic server (optional)" PASS
   else
@@ -218,8 +271,9 @@ fi
 # --- 6. aioquic client -> native server (optional) -------------------------
 next_port
 if [ -n "${AIOQUIC_PYTHON:-}" ]; then
+  prepare_native_artifacts "6-aioquic-client-native-server" "native-server"
   "$tool" server --port "$port" --cert "$certs/p256-cert.der" --key "$certs/p256-key.pkcs8.der" \
-    --timeout-ms 15000 >"$logs/6-native-server.log" 2>&1 &
+    --timeout-ms 15000 "${native_artifact_args[@]}" >"$logs/6-native-server.log" 2>&1 &
   peer=$!
   wait_udp_listen
   "$AIOQUIC_PYTHON" "$here/aioquic_client.py" 127.0.0.1 "$port" /from-aioquic \
@@ -239,4 +293,7 @@ fi
 
 say ""
 say "interop summary: $pass passed, $fail failed, $skip skipped (logs: $logs)"
+if [ "$fail" -ne 0 ] && [ -n "$artifact_dir" ]; then
+  say "interop failure artifacts: $artifact_dir"
+fi
 [ "$fail" -eq 0 ] || exit 1

--- a/tests/h3_interop_tool.zig
+++ b/tests/h3_interop_tool.zig
@@ -43,7 +43,7 @@ var verbose = false;
 
 const ArtifactSink = struct {
     qlog_file: ?compat.FileCompat = null,
-    keylog_file: ?compat.FileCompat = null,
+    keylog_fd: ?posix.fd_t = null,
     qlog_dropped_records: usize = 0,
     keylog_dropped_records: usize = 0,
     close_logged: bool = false,
@@ -64,6 +64,7 @@ const ArtifactSink = struct {
         if (qlog_dir.len > 0) {
             try compat.cwd().makePath(qlog_dir);
             const path = try std.fmt.allocPrint(allocator, "{s}/{s}-{s}.sqlog", .{ qlog_dir, @tagName(mode), group_id });
+            defer allocator.free(path);
             var file = try compat.cwd().createFile(path, .{ .read = false });
             errdefer file.close();
             var header_buf: [1024]u8 = undefined;
@@ -81,10 +82,7 @@ const ArtifactSink = struct {
         }
 
         if (keylog_path.len > 0) {
-            var file = try compat.cwd().createFile(keylog_path, .{ .read = false });
-            errdefer file.close();
-            if (std.c.fchmod(file.file.handle, 0o600) != 0) return error.PermissionDenied;
-            sink.keylog_file = file;
+            sink.keylog_fd = try openAppendOnly0600(keylog_path);
         }
 
         return sink;
@@ -92,7 +90,7 @@ const ArtifactSink = struct {
 
     fn deinit(self: *ArtifactSink) void {
         if (self.qlog_file) |*file| file.close();
-        if (self.keylog_file) |*file| file.close();
+        if (self.keylog_fd) |fd| _ = std.c.close(fd);
         self.* = undefined;
     }
 
@@ -107,7 +105,7 @@ const ArtifactSink = struct {
     }
 
     fn keylogContext(self: *ArtifactSink, role: quic.tls_core.state.Role) quic.tls_core.keylog.Context {
-        if (self.keylog_file == null) return .{};
+        if (self.keylog_fd == null) return .{};
         return .{
             .enabled = true,
             .role = role,
@@ -115,8 +113,24 @@ const ArtifactSink = struct {
         };
     }
 
-    fn diagnostics(self: *const ArtifactSink) bool {
-        return self.qlog_dropped_records != 0 or self.keylog_dropped_records != 0;
+    fn emitQuicQlog(self: *ArtifactSink, event: quic.qlog.Event) void {
+        if (self.qlog_file == null) return;
+        var bytes: [qlog_record_max]u8 = undefined;
+        const line = quic.qlog.writeJson(.{ .time_us = nowUs(), .event = event }, &bytes) catch {
+            self.qlog_dropped_records += 1;
+            return;
+        };
+        if (self.qlog_file) |*file| file.writeAll(line) catch {
+            self.qlog_dropped_records += 1;
+        };
+    }
+
+    fn reportDiagnostics(self: *const ArtifactSink) void {
+        if (self.qlog_dropped_records == 0 and self.keylog_dropped_records == 0) return;
+        std.debug.print("h3-interop: artifact diagnostics qlog_dropped_records={d} keylog_dropped_records={d}\n", .{
+            self.qlog_dropped_records,
+            self.keylog_dropped_records,
+        });
     }
 
     fn emitQuicEvent(ctx: ?*anyopaque, event: connection.Event) void {
@@ -130,14 +144,7 @@ const ArtifactSink = struct {
             },
             else => {},
         }
-        var bytes: [qlog_record_max]u8 = undefined;
-        const line = quic.qlog.writeJson(.{ .time_us = nowUs(), .event = qlog_event }, &bytes) catch {
-            self.qlog_dropped_records += 1;
-            return;
-        };
-        if (self.qlog_file) |*file| file.writeAll(line) catch {
-            self.qlog_dropped_records += 1;
-        };
+        self.emitQuicQlog(qlog_event);
     }
 
     fn emitH3Event(ctx: ?*anyopaque, event: http3.conn.Event) void {
@@ -160,9 +167,31 @@ const ArtifactSink = struct {
             self.keylog_dropped_records += 1;
             return;
         };
-        if (self.keylog_file) |*file| file.writeAll(line) catch {
+        if (self.keylog_fd) |fd| writeAllFd(fd, line) catch {
             self.keylog_dropped_records += 1;
         };
+    }
+
+    fn openAppendOnly0600(path: []const u8) !posix.fd_t {
+        const fd = try posix.openat(posix.AT.FDCWD, path, .{
+            .ACCMODE = .WRONLY,
+            .CREAT = true,
+            .APPEND = true,
+            .CLOEXEC = true,
+        }, 0o600);
+        errdefer _ = std.c.close(fd);
+        if (std.c.fchmod(fd, 0o600) != 0) return error.PermissionDenied;
+        return fd;
+    }
+
+    fn writeAllFd(fd: posix.fd_t, bytes: []const u8) !void {
+        var written: usize = 0;
+        while (written < bytes.len) {
+            const n = std.c.write(fd, bytes[written..].ptr, bytes.len - written);
+            if (n < 0) return error.WriteFailed;
+            if (n == 0) return error.WriteFailed;
+            written += @intCast(n);
+        }
     }
 };
 
@@ -746,7 +775,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
 
     const args = parseArgs(allocator, init.args) catch |err| {
         std.debug.print(
-                "h3-interop: bad arguments ({s})\n" ++
+            "h3-interop: bad arguments ({s})\n" ++
                 "usage: h3_interop_tool server --port N --cert cert.pem --key key.pem [--requests N] [--expect-hrr] [--qlog-dir DIR] [--keylog-path FILE]\n" ++
                 "       h3_interop_tool client --host IP --port N --authority NAME --path /p [--empty-initial-key-share] [--expect-hrr] [--insecure|--pin cert.der] [--qlog-dir DIR] [--keylog-path FILE]\n" ++
                 "\nnegotiation (#338, shared vocabulary with tls_interop_tool):\n" ++
@@ -774,9 +803,15 @@ fn runClient(allocator: std.mem.Allocator, args: Args) !void {
     var group_id_buf: [16]u8 = undefined;
     var artifacts = try ArtifactSink.init(allocator, args.qlog_dir, args.keylog_path, .client, cidHex(&odcid, &group_id_buf));
     defer artifacts.deinit();
+    defer artifacts.reportDiagnostics();
     if (args.keylog_path.len > 0) {
         std.debug.print("h3-interop: WARNING keylog enabled; {s} permits decrypting captured traffic\n", .{args.keylog_path});
     }
+    artifacts.emitQuicQlog(.{ .connection_started = .{
+        .odcid_len = @intCast(odcid.len),
+        .scid_len = @intCast(local_cid.len),
+        .dcid_len = @intCast(odcid.len),
+    } });
 
     const trust: tls_backend.Trust = if (args.pin.len > 0) blk: {
         const pinned = try readFileAlloc(allocator, args.pin, 64 * 1024);
@@ -784,6 +819,7 @@ fn runClient(allocator: std.mem.Allocator, args: Args) !void {
     } else .insecure_no_verification;
     if (args.pin.len == 0 and !args.insecure) {
         std.debug.print("h3-interop: client needs --pin cert.der or --insecure\n", .{});
+        artifacts.reportDiagnostics();
         std.process.exit(2);
     }
 
@@ -876,6 +912,7 @@ fn runClient(allocator: std.mem.Allocator, args: Args) !void {
             @tagName(client.state()),
             client.handshakeFailure(),
         });
+        artifacts.reportDiagnostics();
         std.process.exit(1);
     }
     const saw_hrr = backend.engine.core.retry_state == .hrr_received;
@@ -883,20 +920,18 @@ fn runClient(allocator: std.mem.Allocator, args: Args) !void {
     reportNegotiated(args, &backend, saw_hrr);
     if (args.expect_hrr and !saw_hrr) {
         std.debug.print("h3-interop: expected HelloRetryRequest but none was observed\n", .{});
+        artifacts.reportDiagnostics();
         std.process.exit(1);
     }
-    if (!matrixTupleHolds(args, &backend)) std.process.exit(1);
+    if (!matrixTupleHolds(args, &backend)) {
+        artifacts.reportDiagnostics();
+        std.process.exit(1);
+    }
     // Orderly close.
     client.close(0, "done", nowUs());
     var out: [2048]u8 = undefined;
     while (client.pollTransmitOnPath(&out, nowUs())) |t| {
         try socket.sendTo(sockaddrInFromAddress(t.path.remote), t.bytes);
-    }
-    if (artifacts.diagnostics()) {
-        std.debug.print("h3-interop: artifact diagnostics qlog_dropped_records={d} keylog_dropped_records={d}\n", .{
-            artifacts.qlog_dropped_records,
-            artifacts.keylog_dropped_records,
-        });
     }
     std.debug.print("h3-interop: client ok\n", .{});
 }
@@ -951,9 +986,15 @@ fn runServer(allocator: std.mem.Allocator, args: Args) !void {
         var group_id_buf: [16]u8 = undefined;
         var artifacts = try ArtifactSink.init(allocator, args.qlog_dir, args.keylog_path, .server, cidHex(parsed.dcid, &group_id_buf));
         defer artifacts.deinit();
+        defer artifacts.reportDiagnostics();
         if (args.keylog_path.len > 0) {
             std.debug.print("h3-interop: WARNING keylog enabled; {s} permits decrypting captured traffic\n", .{args.keylog_path});
         }
+        artifacts.emitQuicQlog(.{ .connection_started = .{
+            .odcid_len = @intCast(parsed.dcid.len),
+            .scid_len = @intCast(parsed.scid.len),
+            .dcid_len = @intCast(parsed.dcid.len),
+        } });
         const keylog_context = artifacts.keylogContext(.server);
         const server = try Connection.init(allocator, .{
             .role = .server,
@@ -1014,7 +1055,10 @@ fn runServer(allocator: std.mem.Allocator, args: Args) !void {
                 if (!h3_started) {
                     std.debug.print("h3-interop: established, alpn_h3={}\n", .{server.negotiatedH3()});
                     reportNegotiated(args, &backend, backend.engine.core.retry_state == .hrr_sent);
-                    if (!matrixTupleHolds(args, &backend)) std.process.exit(1);
+                    if (!matrixTupleHolds(args, &backend)) {
+                        artifacts.reportDiagnostics();
+                        std.process.exit(1);
+                    }
                     try h3.start(server);
                     h3_started = true;
                 }
@@ -1054,4 +1098,78 @@ fn runServer(allocator: std.mem.Allocator, args: Args) !void {
         std.process.exit(1);
     }
     std.debug.print("h3-interop: server ok, served={d}\n", .{served});
+}
+
+const testing = std.testing;
+
+test "artifact sink appends keylog lines across repeated connection sinks" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const allocator = testing.allocator;
+    const root = try compat.wrapDir(tmp.dir).realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+    const keylog_path = try std.fmt.allocPrint(allocator, "{s}/native-server.keys", .{root});
+    defer allocator.free(keylog_path);
+
+    const random_a = [_]u8{0x11} ** quic.tls_core.keylog.client_random_len;
+    const random_b = [_]u8{0x22} ** quic.tls_core.keylog.client_random_len;
+    const secret_a = [_]u8{0xaa} ** 32;
+    const secret_b = [_]u8{0xbb} ** 32;
+
+    var first = try ArtifactSink.init(allocator, "", keylog_path, .server, "first");
+    var first_context = first.keylogContext(.server);
+    try first_context.setClientRandom(&random_a);
+    first_context.emitSecret(.handshake, .write, &secret_a);
+    first.deinit();
+
+    var second = try ArtifactSink.init(allocator, "", keylog_path, .server, "second");
+    var second_context = second.keylogContext(.server);
+    try second_context.setClientRandom(&random_b);
+    second_context.emitSecret(.handshake, .write, &secret_b);
+    second.deinit();
+
+    const contents = try compat.cwd().readFileAlloc(allocator, keylog_path, 4096);
+    defer allocator.free(contents);
+    try testing.expectEqual(@as(usize, 2), std.mem.count(u8, contents, "SERVER_HANDSHAKE_TRAFFIC_SECRET"));
+    try testing.expect(std.mem.indexOf(u8, contents, "1111111111111111111111111111111111111111111111111111111111111111") != null);
+    try testing.expect(std.mem.indexOf(u8, contents, "2222222222222222222222222222222222222222222222222222222222222222") != null);
+    const stat = try compat.cwd().statFile(keylog_path);
+    try testing.expectEqual(@as(u32, 0o600), @intFromEnum(stat.permissions) & 0o777);
+}
+
+test "artifact sink writes qlog header connection start and representative events" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const allocator = testing.allocator;
+    const root = try compat.wrapDir(tmp.dir).realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+    const qlog_dir = try std.fmt.allocPrint(allocator, "{s}/qlog", .{root});
+    defer allocator.free(qlog_dir);
+
+    var sink = try ArtifactSink.init(allocator, qlog_dir, "", .server, "0011223344556677");
+    sink.emitQuicQlog(.{ .connection_started = .{
+        .odcid_len = 8,
+        .scid_len = 8,
+        .dcid_len = 8,
+    } });
+    sink.emitQuicQlog(.{ .packet_sent = .{
+        .packet_type = .initial,
+        .packet_number = 1,
+        .length = 1200,
+        .ack_eliciting = true,
+    } });
+    sink.h3Sink().emit(.{ .frame_created = .{
+        .stream_id = 0,
+        .frame = .{ .data = .{ .raw_length = 5 } },
+    } });
+    sink.deinit();
+
+    const qlog_path = try std.fmt.allocPrint(allocator, "{s}/server-0011223344556677.sqlog", .{qlog_dir});
+    defer allocator.free(qlog_path);
+    const contents = try compat.cwd().readFileAlloc(allocator, qlog_path, 4096);
+    defer allocator.free(contents);
+    try testing.expect(std.mem.indexOf(u8, contents, "\"file_schema\":\"urn:ietf:params:qlog:file:sequential\"") != null);
+    try testing.expect(std.mem.indexOf(u8, contents, "\"name\":\"quic:connection_started\"") != null);
+    try testing.expect(std.mem.indexOf(u8, contents, "\"name\":\"quic:packet_sent\"") != null);
+    try testing.expect(std.mem.indexOf(u8, contents, "\"name\":\"http3:frame_created\"") != null);
 }

--- a/tests/h3_interop_tool.zig
+++ b/tests/h3_interop_tool.zig
@@ -7,10 +7,12 @@
 //!
 //! Usage:
 //!   h3_interop_tool server --port N --cert cert.der --key key.pkcs8.der \
-//!       [--response-body STR] [--requests N] [--expect-hrr] [--verbose]
+//!       [--response-body STR] [--requests N] [--expect-hrr] [--verbose] \
+//!       [--qlog-dir DIR] [--keylog-path FILE]
 //!   h3_interop_tool client --host A.B.C.D --port N --authority NAME \
 //!       --path /p [--body STR] [--empty-initial-key-share] \
-//!       [--expect-hrr] [--insecure | --pin cert.der] [--verbose]
+//!       [--expect-hrr] [--insecure | --pin cert.der] [--verbose] \
+//!       [--qlog-dir DIR] [--keylog-path FILE]
 //!
 //! The client exits 0 once it has received a complete response (status and
 //! body are printed to stdout). The server exits 0 after serving --requests
@@ -22,6 +24,7 @@ const std = @import("std");
 const quic = @import("quic");
 const http3 = @import("http3");
 const matrix = @import("tls_interop_matrix");
+const compat = @import("zig_compat");
 
 const connection = quic.connection;
 const tls_backend = quic.tls_backend;
@@ -37,6 +40,131 @@ fn nowUs() u64 {
 }
 
 var verbose = false;
+
+const ArtifactSink = struct {
+    qlog_file: ?compat.FileCompat = null,
+    keylog_file: ?compat.FileCompat = null,
+    qlog_dropped_records: usize = 0,
+    keylog_dropped_records: usize = 0,
+    close_logged: bool = false,
+
+    const qlog_record_max = http3.qlog.max_serialized_record_len;
+    const keylog_record_max = 512;
+
+    fn init(
+        allocator: std.mem.Allocator,
+        qlog_dir: []const u8,
+        keylog_path: []const u8,
+        mode: Args.Mode,
+        group_id: []const u8,
+    ) !ArtifactSink {
+        var sink = ArtifactSink{};
+        errdefer sink.deinit();
+
+        if (qlog_dir.len > 0) {
+            try compat.cwd().makePath(qlog_dir);
+            const path = try std.fmt.allocPrint(allocator, "{s}/{s}-{s}.sqlog", .{ qlog_dir, @tagName(mode), group_id });
+            var file = try compat.cwd().createFile(path, .{ .read = false });
+            errdefer file.close();
+            var header_buf: [1024]u8 = undefined;
+            const header = try quic.qlog.writeTraceHeader(.{
+                .vantage_point = switch (mode) {
+                    .client => .client,
+                    .server => .server,
+                },
+                .group_id = group_id,
+                .title = "tardigrade-h3-interop",
+                .description = "Tardigrade HTTP/3 external interop debug trace",
+            }, &header_buf);
+            try file.writeAll(header);
+            sink.qlog_file = file;
+        }
+
+        if (keylog_path.len > 0) {
+            var file = try compat.cwd().createFile(keylog_path, .{ .read = false });
+            errdefer file.close();
+            if (std.c.fchmod(file.file.handle, 0o600) != 0) return error.PermissionDenied;
+            sink.keylog_file = file;
+        }
+
+        return sink;
+    }
+
+    fn deinit(self: *ArtifactSink) void {
+        if (self.qlog_file) |*file| file.close();
+        if (self.keylog_file) |*file| file.close();
+        self.* = undefined;
+    }
+
+    fn quicSink(self: *ArtifactSink) connection.EventSink {
+        if (self.qlog_file == null) return .{ .emitFn = logEvent };
+        return .{ .context = self, .emitFn = emitQuicEvent };
+    }
+
+    fn h3Sink(self: *ArtifactSink) http3.conn.EventSink {
+        if (self.qlog_file == null) return .{};
+        return .{ .context = self, .emitFn = emitH3Event };
+    }
+
+    fn keylogContext(self: *ArtifactSink, role: quic.tls_core.state.Role) quic.tls_core.keylog.Context {
+        if (self.keylog_file == null) return .{};
+        return .{
+            .enabled = true,
+            .role = role,
+            .sink = .{ .context = self, .emit_fn = emitKeylog },
+        };
+    }
+
+    fn diagnostics(self: *const ArtifactSink) bool {
+        return self.qlog_dropped_records != 0 or self.keylog_dropped_records != 0;
+    }
+
+    fn emitQuicEvent(ctx: ?*anyopaque, event: connection.Event) void {
+        logEvent(null, event);
+        const self: *ArtifactSink = @ptrCast(@alignCast(ctx.?));
+        const qlog_event = quicEventToQlog(event) orelse return;
+        switch (qlog_event) {
+            .connection_closed => {
+                if (self.close_logged) return;
+                self.close_logged = true;
+            },
+            else => {},
+        }
+        var bytes: [qlog_record_max]u8 = undefined;
+        const line = quic.qlog.writeJson(.{ .time_us = nowUs(), .event = qlog_event }, &bytes) catch {
+            self.qlog_dropped_records += 1;
+            return;
+        };
+        if (self.qlog_file) |*file| file.writeAll(line) catch {
+            self.qlog_dropped_records += 1;
+        };
+    }
+
+    fn emitH3Event(ctx: ?*anyopaque, event: http3.conn.Event) void {
+        const self: *ArtifactSink = @ptrCast(@alignCast(ctx.?));
+        const qlog_event = h3EventToQlog(event);
+        var bytes: [qlog_record_max]u8 = undefined;
+        const line = http3.qlog.writeJson(.{ .time_us = nowUs(), .event = qlog_event }, &bytes) catch {
+            self.qlog_dropped_records += 1;
+            return;
+        };
+        if (self.qlog_file) |*file| file.writeAll(line) catch {
+            self.qlog_dropped_records += 1;
+        };
+    }
+
+    fn emitKeylog(ctx: ?*anyopaque, entry: quic.tls_core.keylog.Entry) void {
+        const self: *ArtifactSink = @ptrCast(@alignCast(ctx.?));
+        var bytes: [keylog_record_max]u8 = undefined;
+        const line = quic.tls_core.keylog.writeLine(entry, &bytes) catch {
+            self.keylog_dropped_records += 1;
+            return;
+        };
+        if (self.keylog_file) |*file| file.writeAll(line) catch {
+            self.keylog_dropped_records += 1;
+        };
+    }
+};
 
 /// Plain sequential write(2) to fd 1. `Io.File.writer` uses positional
 /// writes, which scribble over interleaved stderr output when both streams
@@ -97,7 +225,9 @@ fn logEvent(_: ?*anyopaque, event: connection.Event) void {
 }
 
 const Args = struct {
-    mode: enum { client, server },
+    pub const Mode = enum { client, server };
+
+    mode: Mode,
     host: []const u8 = "127.0.0.1",
     port: u16 = 4433,
     authority: []const u8 = "tardigrade.test",
@@ -112,6 +242,8 @@ const Args = struct {
     timeout_ms: u64 = 15_000,
     empty_initial_key_share: bool = false,
     expect_hrr: bool = false,
+    qlog_dir: []const u8 = "",
+    keylog_path: []const u8 = "",
     /// #338: the shared conformance-matrix negotiation tuple. Left empty, the
     /// tool offers QUIC's ordinary default policy exactly as before.
     config: matrix.Config = .{},
@@ -218,6 +350,10 @@ fn parseArgs(allocator: std.mem.Allocator, init_args: std.process.Args) !Args {
             try args.config.addAlpn(try allocator.dupe(u8, it.next() orelse return error.MissingValue));
         } else if (std.mem.eql(u8, arg, "--expect-alpn")) {
             args.expect_alpn = try allocator.dupe(u8, it.next() orelse return error.MissingValue);
+        } else if (std.mem.eql(u8, arg, "--qlog-dir")) {
+            args.qlog_dir = try allocator.dupe(u8, it.next() orelse return error.MissingValue);
+        } else if (std.mem.eql(u8, arg, "--keylog-path")) {
+            args.keylog_path = try allocator.dupe(u8, it.next() orelse return error.MissingValue);
         } else {
             std.debug.print("h3-interop: unknown argument {s}\n", .{arg});
             return error.UnknownArgument;
@@ -338,6 +474,270 @@ fn randomEntropy() tls_backend.Entropy {
     return entropy;
 }
 
+fn cidHex(cid: []const u8, out: []u8) []const u8 {
+    const hex = "0123456789abcdef";
+    const len = @min(cid.len, out.len / 2);
+    for (cid[0..len], 0..) |byte, idx| {
+        out[idx * 2] = hex[byte >> 4];
+        out[idx * 2 + 1] = hex[byte & 0x0f];
+    }
+    return out[0 .. len * 2];
+}
+
+fn h3EventToQlog(event: http3.conn.Event) http3.qlog.Event {
+    return switch (event) {
+        .parameters_set => |parameters| .{ .parameters_set = .{
+            .initiator = switch (parameters.initiator) {
+                .local => .local,
+                .remote => .remote,
+            },
+            .max_field_section_size = parameters.settings.max_field_section_size,
+            .max_table_capacity = if (parameters.settings.qpack_max_table_capacity == 0) null else parameters.settings.qpack_max_table_capacity,
+            .blocked_streams_count = if (parameters.settings.qpack_blocked_streams == 0) null else parameters.settings.qpack_blocked_streams,
+            .extended_connect = if (parameters.settings.enable_connect_protocol) 1 else null,
+            .h3_datagram = if (parameters.settings.h3_datagram) 1 else null,
+        } },
+        .stream_type_set => |stream| .{ .stream_type_set = .{
+            .stream_id = stream.stream_id,
+            .stream_type = h3StreamTypeToQlog(stream.stream_type),
+        } },
+        .frame_created => |created| .{ .frame = .{
+            .direction = .created,
+            .stream_id = created.stream_id,
+            .frame = h3FrameToQlog(created.frame),
+        } },
+        .frame_parsed => |parsed| .{ .frame = .{
+            .direction = .parsed,
+            .stream_id = parsed.stream_id,
+            .frame = h3FrameToQlog(parsed.frame),
+        } },
+        .priority_updated => |updated| .{ .priority_updated = .{
+            .stream_id = updated.stream_id,
+            .new = .{ .urgency = updated.urgency, .incremental = updated.incremental },
+        } },
+    };
+}
+
+fn h3FrameToQlog(event_frame: http3.conn.EventFrame) http3.qlog.Frame {
+    return switch (event_frame) {
+        .data => |d| .{ .data = .{ .raw_length = d.raw_length } },
+        .headers => |h| .{ .headers = .{ .headers = h.fields, .raw_length = h.raw_length } },
+        .settings => |s| .{ .settings = .{ .settings = @ptrCast(s.entries), .raw_length = s.raw_length } },
+        .goaway => |g| .{ .goaway = .{ .id = g.id, .raw_length = g.raw_length } },
+        .priority_update => |update| .{ .priority_update = switch (update) {
+            .request => |r| .{ .request = .{ .stream_id = r.stream_id, .priority_field_value = r.field_value, .raw_length = r.raw_length } },
+            .push => |p| .{ .push = .{ .push_id = p.push_id, .priority_field_value = p.field_value, .raw_length = p.raw_length } },
+        } },
+        .push_promise => |p| .{ .push_promise = .{ .push_id = p.push_id, .headers = p.fields, .raw_length = p.raw_length } },
+        .cancel_push => |c| .{ .cancel_push = .{ .push_id = c.push_id, .raw_length = c.raw_length } },
+        .max_push_id => |m| .{ .max_push_id = .{ .push_id = m.push_id, .raw_length = m.raw_length } },
+        .unknown => |u| .{ .unknown = .{ .frame_type_bytes = u.frame_type_value, .raw_length = u.raw_length } },
+        .malformed => |m| .{ .malformed = .{
+            .frame_type = h3FrameTypeToQlog(m.frame_type),
+            .frame_type_bytes = m.frame_type_value,
+            .raw_length = m.raw_length,
+        } },
+    };
+}
+
+fn h3FrameTypeToQlog(typ: http3.frame.FrameType) http3.qlog.FrameType {
+    return switch (typ) {
+        .data => .data,
+        .headers => .headers,
+        .settings => .settings,
+        .goaway => .goaway,
+        .priority_update_request, .priority_update_push => .priority_update,
+        .push_promise => .push_promise,
+        .cancel_push => .cancel_push,
+        .max_push_id => .max_push_id,
+        .unknown => .unknown,
+    };
+}
+
+fn h3StreamTypeToQlog(typ: http3.conn.EventStreamType) http3.qlog.StreamType {
+    return switch (typ) {
+        .request => .request,
+        .control => .control,
+        .push => .push,
+        .qpack_encoder => .qpack_encode,
+        .qpack_decoder => .qpack_decode,
+        .unknown => .unknown,
+    };
+}
+
+fn quicEventToQlog(event: connection.Event) ?quic.qlog.Event {
+    return switch (event) {
+        .state => null,
+        .packet_received => |packet_event| .{ .packet_received = .{
+            .packet_type = packetTypeForKind(packet_event.packet_type),
+            .packet_number = packet_event.packet_number,
+            .length = packet_event.size,
+        } },
+        .packet_sent => |packet_event| .{ .packet_sent = .{
+            .packet_type = packetTypeForKind(packet_event.packet_type),
+            .packet_number = packet_event.packet_number,
+            .length = packet_event.size,
+            .ack_eliciting = packet_event.ack_eliciting,
+        } },
+        .packet_dropped => |drop| .{ .packet_dropped = .{
+            .trigger = dropReasonToQlog(drop.reason),
+            .length = drop.size,
+        } },
+        .keys_discarded => null,
+        .handshake_complete => .{ .handshake_progressed = .{ .stage = .application_keys_installed } },
+        .handshake_confirmed => .{ .handshake_progressed = .{ .stage = .confirmed } },
+        .pto_fired => |pto| .{ .recovery_metrics_updated = .{ .pto_count = @intCast(@min(pto.count, std.math.maxInt(u16))) } },
+        .packets_acked => |acked| .{ .packets_acked = .{
+            .packet_number_space = packetNumberSpaceToQlog(acked.space),
+            .packet_number = acked.packet_number,
+        } },
+        .packets_lost => |lost| .{ .packets_lost = .{
+            .packet_type = if (lost.packet_type) |kind| packetTypeForKind(kind) else null,
+            .lost_count = lost.lost_count,
+            .bytes = lost.bytes,
+        } },
+        .recovery_metrics_updated => |metrics| .{ .recovery_metrics_updated = .{
+            .latest_rtt_ms = usToMs(metrics.latest_rtt_us),
+            .smoothed_rtt_ms = usToMs(metrics.smoothed_rtt_us),
+            .rtt_variance_ms = usToMs(metrics.rttvar_us),
+            .pto_count = metrics.pto_count,
+            .congestion_window = metrics.congestion_window,
+            .bytes_in_flight = metrics.bytes_in_flight,
+        } },
+        .stream_reset => |reset| .{ .stream_reset = .{
+            .kind = if (reset.local) .reset_sent else .reset_received,
+            .stream_id = reset.id,
+            .error_code = reset.error_code,
+        } },
+        .stop_sending => |stop| .{ .stream_reset = .{
+            .kind = if (stop.local) .stop_sending_sent else .stop_sending_received,
+            .stream_id = stop.id,
+            .error_code = stop.error_code,
+        } },
+        .flow_control_state_changed => |blocked| switch (blocked.scope) {
+            .connection => .{ .data_blocked = .{ .connection = .{
+                .old = flowControlStateToQlog(blocked.old),
+                .new = flowControlStateToQlog(blocked.new),
+                .reason = .connection_flow_control,
+            } } },
+            .stream => .{ .data_blocked = .{ .stream = .{
+                .stream_id = blocked.stream_id orelse 0,
+                .old = flowControlStateToQlog(blocked.old),
+                .new = flowControlStateToQlog(blocked.new),
+                .reason = .stream_flow_control,
+            } } },
+        },
+        .flow_control_blocked_received => |blocked| .{ .flow_control_blocked_received = .{
+            .scope = switch (blocked.scope) {
+                .connection => .connection,
+                .stream => .stream,
+            },
+            .stream_id = blocked.stream_id,
+        } },
+        .local_close_started => |close| .{ .connection_closed = .{
+            .trigger = if (close.is_application) .application else .@"error",
+            .close_error = if (close.is_application) .{ .application_unknown = close.error_code } else .{ .connection_unknown = close.error_code },
+        } },
+        .close_sent => null,
+        .close_received => |close| .{ .connection_closed = .{
+            .trigger = if (close.is_application) .application else .@"error",
+            .close_error = if (close.is_application) .{ .application_unknown = close.error_code } else .{ .connection_unknown = close.error_code },
+        } },
+        .idle_timeout => .{ .connection_closed = .{ .trigger = .idle_timeout } },
+        .path_validation_started => .{ .path_validation = .{ .kind = .challenge_sent } },
+        .path_validation_succeeded => .{ .path_validation = .{ .kind = .validated } },
+        .path_validation_failed => .{ .path_validation = .{ .kind = .failed } },
+        .path_migration_blocked => null,
+        .path_promoted => |path| .{ .connection_migrated = .{ .new = switch (path.change) {
+            .nat_rebinding => .probing_successful,
+            .migration => .migration_complete,
+        } } },
+        .pmtu_updated, .zero_rtt_packet, .early_data_decision, .ecn_state_changed => null,
+        .stream_state_changed => |stream| .{ .stream_state_updated = .{
+            .stream_id = stream.id,
+            .stream_side = streamSideToQlog(stream.side),
+            .old = if (stream.old) |old| streamStateToQlog(old) else null,
+            .new = streamStateToQlog(stream.new),
+            .trigger = if (stream.trigger) |trigger| streamStateTriggerToQlog(trigger) else null,
+        } },
+        .congestion_state_changed => |congestion| .{ .congestion_state_updated = .{
+            .old = congestionStateToQlog(congestion.old),
+            .new = congestionStateToQlog(congestion.new),
+        } },
+        .persistent_congestion => .{ .persistent_congestion = .{} },
+    };
+}
+
+fn flowControlStateToQlog(state: connection.FlowControlState) quic.qlog.BlockedState {
+    return switch (state) {
+        .blocked => .blocked,
+        .unblocked => .unblocked,
+    };
+}
+
+fn streamSideToQlog(side: connection.StreamSide) quic.qlog.StreamSide {
+    return switch (side) {
+        .sending => .sending,
+        .receiving => .receiving,
+    };
+}
+
+fn streamStateToQlog(state: connection.StreamSideState) quic.qlog.StreamState {
+    return switch (state) {
+        .open => .open,
+        .closed => .closed,
+    };
+}
+
+fn streamStateTriggerToQlog(trigger: connection.StreamStateTrigger) quic.qlog.StreamStateTrigger {
+    return switch (trigger) {
+        .local => .local,
+        .remote => .remote,
+    };
+}
+
+fn packetNumberSpaceToQlog(space: quic.recovery.PacketNumberSpace) quic.qlog.PacketNumberSpace {
+    return switch (space) {
+        .initial => .initial,
+        .handshake => .handshake,
+        .application => .application_data,
+    };
+}
+
+fn congestionStateToQlog(state: connection.CongestionState) quic.qlog.CongestionState {
+    return switch (state) {
+        .slow_start => .slow_start,
+        .congestion_avoidance => .congestion_avoidance,
+        .recovery => .recovery,
+    };
+}
+
+fn packetTypeForKind(kind: quic.packet.PacketKind) quic.qlog.PacketType {
+    return switch (kind) {
+        .initial => .initial,
+        .zero_rtt => .zero_rtt,
+        .handshake => .handshake,
+        .one_rtt => .one_rtt,
+        .retry => .retry,
+        .version_negotiation => .version_negotiation,
+    };
+}
+
+fn dropReasonToQlog(reason: connection.DropReason) quic.qlog.DropTrigger {
+    return switch (reason) {
+        .unknown_cid => .connection_unknown,
+        .keys_unavailable => .key_unavailable,
+        .undecryptable => .decryption_failure,
+        .malformed => .invalid,
+        .unsupported_version => .unsupported,
+        .unexpected_type => .invalid,
+    };
+}
+
+fn usToMs(value: ?u64) ?u64 {
+    return if (value) |v| v / 1000 else null;
+}
+
 pub fn main(init: std.process.Init.Minimal) !void {
     // Short-lived tool: arena everything, reclaimed at exit.
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
@@ -346,9 +746,9 @@ pub fn main(init: std.process.Init.Minimal) !void {
 
     const args = parseArgs(allocator, init.args) catch |err| {
         std.debug.print(
-            "h3-interop: bad arguments ({s})\n" ++
-                "usage: h3_interop_tool server --port N --cert cert.pem --key key.pem [--requests N] [--expect-hrr]\n" ++
-                "       h3_interop_tool client --host IP --port N --authority NAME --path /p [--empty-initial-key-share] [--expect-hrr] [--insecure|--pin cert.der]\n" ++
+                "h3-interop: bad arguments ({s})\n" ++
+                "usage: h3_interop_tool server --port N --cert cert.pem --key key.pem [--requests N] [--expect-hrr] [--qlog-dir DIR] [--keylog-path FILE]\n" ++
+                "       h3_interop_tool client --host IP --port N --authority NAME --path /p [--empty-initial-key-share] [--expect-hrr] [--insecure|--pin cert.der] [--qlog-dir DIR] [--keylog-path FILE]\n" ++
                 "\nnegotiation (#338, shared vocabulary with tls_interop_tool):\n" ++
                 matrix.flag_usage,
             .{@errorName(err)},
@@ -371,6 +771,12 @@ fn runClient(allocator: std.mem.Allocator, args: Args) !void {
     randomBytes(&local_cid);
     var odcid: [8]u8 = undefined;
     randomBytes(&odcid);
+    var group_id_buf: [16]u8 = undefined;
+    var artifacts = try ArtifactSink.init(allocator, args.qlog_dir, args.keylog_path, .client, cidHex(&odcid, &group_id_buf));
+    defer artifacts.deinit();
+    if (args.keylog_path.len > 0) {
+        std.debug.print("h3-interop: WARNING keylog enabled; {s} permits decrypting captured traffic\n", .{args.keylog_path});
+    }
 
     const trust: tls_backend.Trust = if (args.pin.len > 0) blk: {
         const pinned = try readFileAlloc(allocator, args.pin, 64 * 1024);
@@ -396,6 +802,7 @@ fn runClient(allocator: std.mem.Allocator, args: Args) !void {
     var crypto_provider_state = production_crypto.Provider.init(crypto_provider_entropy.entropy());
     const crypto_provider = crypto_provider_state.cryptoProvider();
     var backend = tls_backend.Tls13Backend.initClientWithPolicyAndOptions(randomEntropy(), crypto_provider, trust, quicPolicy(&args), client_options);
+    const keylog_context = artifacts.keylogContext(.client);
     const client = try Connection.init(allocator, .{
         .role = .client,
         .local_cid = &local_cid,
@@ -404,7 +811,8 @@ fn runClient(allocator: std.mem.Allocator, args: Args) !void {
         .tls = backend.backend(),
         .crypto_provider = crypto_provider,
         .now_us = nowUs(),
-        .events = .{ .emitFn = logEvent },
+        .events = artifacts.quicSink(),
+        .tls_keylog_context = keylog_context,
         .allow_unverified_certificate = args.insecure,
         .initial_path = client_path,
     });
@@ -412,6 +820,7 @@ fn runClient(allocator: std.mem.Allocator, args: Args) !void {
 
     var h3 = H3.init(allocator, .client);
     defer h3.deinit();
+    if (artifacts.qlog_file != null) h3.setEventSink(artifacts.h3Sink());
 
     var request_id: ?u64 = null;
     const deadline = nowUs() + args.timeout_ms * 1_000;
@@ -483,6 +892,12 @@ fn runClient(allocator: std.mem.Allocator, args: Args) !void {
     while (client.pollTransmitOnPath(&out, nowUs())) |t| {
         try socket.sendTo(sockaddrInFromAddress(t.path.remote), t.bytes);
     }
+    if (artifacts.diagnostics()) {
+        std.debug.print("h3-interop: artifact diagnostics qlog_dropped_records={d} keylog_dropped_records={d}\n", .{
+            artifacts.qlog_dropped_records,
+            artifacts.keylog_dropped_records,
+        });
+    }
     std.debug.print("h3-interop: client ok\n", .{});
 }
 
@@ -533,6 +948,13 @@ fn runServer(allocator: std.mem.Allocator, args: Args) !void {
         var crypto_provider_state = production_crypto.Provider.init(crypto_provider_entropy.entropy());
         const crypto_provider = crypto_provider_state.cryptoProvider();
         var backend = tls_backend.Tls13Backend.initServerWithPolicy(randomEntropy(), crypto_provider, identity, quicPolicy(&args));
+        var group_id_buf: [16]u8 = undefined;
+        var artifacts = try ArtifactSink.init(allocator, args.qlog_dir, args.keylog_path, .server, cidHex(parsed.dcid, &group_id_buf));
+        defer artifacts.deinit();
+        if (args.keylog_path.len > 0) {
+            std.debug.print("h3-interop: WARNING keylog enabled; {s} permits decrypting captured traffic\n", .{args.keylog_path});
+        }
+        const keylog_context = artifacts.keylogContext(.server);
         const server = try Connection.init(allocator, .{
             .role = .server,
             .local_cid = parsed.dcid,
@@ -542,12 +964,14 @@ fn runServer(allocator: std.mem.Allocator, args: Args) !void {
             .tls = backend.backend(),
             .crypto_provider = crypto_provider,
             .now_us = nowUs(),
-            .events = .{ .emitFn = logEvent },
+            .events = artifacts.quicSink(),
+            .tls_keylog_context = keylog_context,
             .initial_path = server_path,
         });
         defer server.deinit();
         var h3 = H3.init(allocator, .server);
         defer h3.deinit();
+        if (artifacts.qlog_file != null) h3.setEventSink(artifacts.h3Sink());
         try server.ingestOnPath(first_datagram, server_path, test_challenge_entropy, nowUs());
 
         var h3_started = false;
@@ -620,6 +1044,9 @@ fn runServer(allocator: std.mem.Allocator, args: Args) !void {
     if (served < args.requests) {
         std.debug.print("h3-interop: server timed out with served={d}/{d}\n", .{ served, args.requests });
         std.process.exit(1);
+    }
+    if (args.qlog_dir.len > 0 or args.keylog_path.len > 0) {
+        std.debug.print("h3-interop: artifacts qlog_dir={s} keylog_path={s}\n", .{ args.qlog_dir, args.keylog_path });
     }
     std.debug.print("h3-interop: tls hello_retry_request={}\n", .{saw_hrr});
     if (args.expect_hrr and !saw_hrr) {


### PR DESCRIPTION
## Summary

- add h3_interop_tool --qlog-dir / --keylog-path flags for opt-in .sqlog and NSS keylog capture
- extend scripts/interop/run-interop.sh with INTEROP_QLOG, INTEROP_KEYLOG, and INTEROP_ARTIFACT_DIR wiring plus sensitive keylog markers
- document the local-debug artifact workflow and public-CI keylog restrictions

Refs #255

## Validation

- zig build build-h3-interop --summary all --error-style verbose
- bash -n scripts/interop/run-interop.sh
- INTEROP_WORKDIR=<tmp> scripts/interop/run-interop.sh (no peers: 8 skipped, no artifacts)
- h3_interop_tool client smoke with --qlog-dir/--keylog-path: .sqlog header written, .keys created 0600, warning emitted
- fake external-server failure smoke: script exited nonzero, printed artifact root once, retained per-case .sqlog/.keys and SENSITIVE-KEYLOG.txt
- zig build test --summary all --error-style verbose