### PR TITLE
ux: create operator quickstart and getting-started guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable user-facing changes to Tardigrade are documented here.
 ## [Unreleased]
 
 ### Added
+- **Operator quickstart and canonical `tardi`/`tardigrade.conf` first-run
+  contract (#157)** — `docs/QUICKSTART.md` is the canonical 5-minute
+  walkthrough: install/build, `tardi init <profile>`, `tardi check`,
+  `tardi run`, and a real request, for both the static-site and
+  reverse-proxy profiles, plus the explicit `-c <path>` form. `tardi check`
+  with no path now validates `./tardigrade.conf` directly instead of the
+  stale `./tardigrade.toml`, matching the nginx-style filename `tardi run`,
+  generated profiles, examples, and packaging already use (a
+  `TARDIGRADE_CONFIG_PATH` override still takes precedence for `run`, as
+  documented). Built-in `--help` now presents `tardi` as the canonical
+  command throughout, with `tardigrade` named only as a compatibility
+  alias. README gains a short Quickstart teaser and a prominent link
+  instead of a second onboarding surface.
+
 - **Profile-aware `tardi init <profile>` first-run config generator (#162)** —
   `tardi init static|proxy|tls|metrics|prod` writes a ready-to-check
   nginx-style `tardigrade.conf` starter to stdout only (no banner or status

--- a/README.md
+++ b/README.md
@@ -92,10 +92,9 @@ runtime dependency the DEB/RPM packages declare explicitly.
 Other install paths:
 
 - Download release archives directly from [GitHub Releases](https://github.com/Bare-Systems/Tardigrade/releases).
-- Native DEB/RPM packages (published on every release), systemd/launchd
-  service files, and a Homebrew formula — see
-  [packaging/README.md](packaging/README.md) for current status and
-  install/build instructions.
+- Native DEB/RPM packages (published on every release) and systemd/launchd
+  service files — see [packaging/README.md](packaging/README.md) for
+  current status and install/build instructions.
 - Build from source (see below).
 
 For running Tardigrade as a managed service — systemd unit, filesystem
@@ -137,10 +136,9 @@ Useful build options are documented in [CONTRIBUTING.md](CONTRIBUTING.md#build-o
 
 ## Quick start
 
-For the full walkthrough -- installing, generating a config, validating it,
-running it, and verifying a real request -- see the
-**[Quickstart guide](docs/QUICKSTART.md)**. The short version, once `tardi`
-is on your `PATH`:
+`tardi init <profile>` below requires [building from source](#build-from-source)
+until a release containing it is published; the latest published release
+predates it. Once `tardi` is on your `PATH`:
 
 ```bash
 mkdir -p public
@@ -151,75 +149,13 @@ tardi check
 tardi run
 ```
 
-Then open:
+Then open `http://localhost:8080/` and `http://localhost:8080/health`.
 
-- `http://localhost:8080/`
-- `http://localhost:8080/health`
-
-`init` writes configuration bytes only to stdout, so the redirect above
-produces a clean file with no extra output mixed in. Other common shapes:
-
-```bash
-tardi init proxy > tardigrade.conf     # reverse proxy to an upstream app
-tardi init tls > tardigrade.conf        # TLS termination + proxy
-tardi init metrics > tardigrade.conf    # proxy starter documenting /status/metrics
-tardi init prod > tardigrade.conf       # production-oriented TLS/proxy scaffold
-```
-
-Each profile also has a longer descriptive alias that resolves to the same
-template, e.g. `tardi init reverse-proxy` is identical to `tardi init proxy`.
-Run `tardi init --help` for the full profile/alias list. The `tls` and `prod`
-profiles reference certificate/key paths you must provision yourself — see
-[examples/tls-termination](examples/tls-termination/README.md) and
-[examples/production-baseline](examples/production-baseline/README.md) for
-how to generate a local test certificate. The `metrics` profile documents the
-existing `/status/metrics` endpoint; protect it in production with
-`TARDIGRADE_METRICS_REQUIRE_AUTH=true` or a network-boundary restriction.
-
-`tardi config init [<path>] [--force | --stdout] [--profile <profile>]` is
-the verbose, file-writing form of the same generator: it supports the same
-profiles via `--profile`, writes to a file (creating parent directories and
-refusing to overwrite an existing file unless `--force` is given), and keeps
-today's generic starter output when no `--profile` is given.
-
-Common CLI commands:
-
-```bash
-tardi check ./tardigrade.conf
-tardi config validate ./tardigrade.conf
-tardi validate -c ./tardigrade.conf
-tardi print-config -c ./tardigrade.conf
-tardi status -c ./tardigrade.conf
-tardi reload -c ./tardigrade.conf
-tardi stop -c ./tardigrade.conf
-tardi init <profile>
-tardi config init
-tardi explain <field>
-tardi config explain <field>
-```
-
-`check` performs a dry parse and semantic validation without starting listeners
-or connecting to upstreams. When no path is supplied, it validates
-`./tardigrade.conf` -- the same local file `run` selects with no explicit
-path.
-
-Not sure what a directive does or which values it accepts? `tardi explain
-<field>` looks it up from a built-in reference -- no config file required:
-
-```bash
-tardi explain listen
-tardi explain location.proxy_pass
-tardi explain upstream_protocol
-```
-
-`tardi config explain <field>` is a verbose alias for the same command.
-`explain` is a static documentation lookup: it describes the *supported*
-configuration contract (type, default, valid values, environment variable,
-example) and never loads a config file, inspects a running process, or
-prints current environment/secret values -- that's what `print-config`
-(effective configuration) is for.
-
-For copy/paste-runnable examples of common deployments (static file serving,
+See the **[Quickstart guide](docs/QUICKSTART.md)** for the full walkthrough,
+including installing `tardi`, a reverse-proxy happy path, and explicit
+config paths. For the full `tardi init`/`config`/`explain` command
+reference, see [docs/CONFIGURATION.md](docs/CONFIGURATION.md). For
+copy/paste-runnable examples of common deployments (static file serving,
 reverse proxy, TLS termination, rate limiting, and more), see the
 [examples/](examples/README.md) directory.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 </p>
 
 <p align="center">
+  <a href="docs/QUICKSTART.md"><strong>Quickstart</strong></a> |
   <a href="https://github.com/Bare-Systems/Tardigrade/releases">Releases</a> |
   <a href="docs/SUPPORT_MATRIX.md">Support Matrix</a> |
   <a href="docs/CONFIGURATION.md">Configuration</a> |
@@ -136,18 +137,18 @@ Useful build options are documented in [CONTRIBUTING.md](CONTRIBUTING.md#build-o
 
 ## Quick start
 
-Build Tardigrade, then generate a starter config for your deployment shape
-with `tardi init <profile>`:
+For the full walkthrough -- installing, generating a config, validating it,
+running it, and verifying a real request -- see the
+**[Quickstart guide](docs/QUICKSTART.md)**. The short version, once `tardi`
+is on your `PATH`:
 
 ```bash
-zig build
-
 mkdir -p public
 printf '%s\n' '<h1>Hello from Tardigrade</h1>' > public/index.html
 
-./zig-out/bin/tardi init static > tardigrade.conf
-./zig-out/bin/tardi check ./tardigrade.conf
-./zig-out/bin/tardi run -c ./tardigrade.conf
+tardi init static > tardigrade.conf
+tardi check
+tardi run
 ```
 
 Then open:
@@ -159,10 +160,10 @@ Then open:
 produces a clean file with no extra output mixed in. Other common shapes:
 
 ```bash
-./zig-out/bin/tardi init proxy > tardigrade.conf     # reverse proxy to an upstream app
-./zig-out/bin/tardi init tls > tardigrade.conf        # TLS termination + proxy
-./zig-out/bin/tardi init metrics > tardigrade.conf    # proxy starter documenting /status/metrics
-./zig-out/bin/tardi init prod > tardigrade.conf       # production-oriented TLS/proxy scaffold
+tardi init proxy > tardigrade.conf     # reverse proxy to an upstream app
+tardi init tls > tardigrade.conf        # TLS termination + proxy
+tardi init metrics > tardigrade.conf    # proxy starter documenting /status/metrics
+tardi init prod > tardigrade.conf       # production-oriented TLS/proxy scaffold
 ```
 
 Each profile also has a longer descriptive alias that resolves to the same
@@ -184,31 +185,31 @@ today's generic starter output when no `--profile` is given.
 Common CLI commands:
 
 ```bash
-./zig-out/bin/tardi check ./tardigrade.conf
-./zig-out/bin/tardi config validate ./tardigrade.conf
-./zig-out/bin/tardi validate -c ./tardigrade.conf
-./zig-out/bin/tardi print-config -c ./tardigrade.conf
-./zig-out/bin/tardi status -c ./tardigrade.conf
-./zig-out/bin/tardi reload -c ./tardigrade.conf
-./zig-out/bin/tardi stop -c ./tardigrade.conf
-./zig-out/bin/tardi init <profile>
-./zig-out/bin/tardi config init
-./zig-out/bin/tardi explain <field>
-./zig-out/bin/tardi config explain <field>
+tardi check ./tardigrade.conf
+tardi config validate ./tardigrade.conf
+tardi validate -c ./tardigrade.conf
+tardi print-config -c ./tardigrade.conf
+tardi status -c ./tardigrade.conf
+tardi reload -c ./tardigrade.conf
+tardi stop -c ./tardigrade.conf
+tardi init <profile>
+tardi config init
+tardi explain <field>
+tardi config explain <field>
 ```
 
 `check` performs a dry parse and semantic validation without starting listeners
 or connecting to upstreams. When no path is supplied, it validates
-`./tardigrade.toml`; pass the path explicitly when using the nginx-style
-`tardigrade.conf` examples.
+`./tardigrade.conf` -- the same local file `run` selects with no explicit
+path.
 
 Not sure what a directive does or which values it accepts? `tardi explain
 <field>` looks it up from a built-in reference -- no config file required:
 
 ```bash
-./zig-out/bin/tardi explain listen
-./zig-out/bin/tardi explain location.proxy_pass
-./zig-out/bin/tardi explain upstream_protocol
+tardi explain listen
+tardi explain location.proxy_pass
+tardi explain upstream_protocol
 ```
 
 `tardi config explain <field>` is a verbose alias for the same command.
@@ -245,6 +246,7 @@ operate without guessing which config file or pid file is active.
 
 | Topic | Location |
 | --- | --- |
+| Quickstart | [docs/QUICKSTART.md](docs/QUICKSTART.md) |
 | Core v1 support matrix | [docs/SUPPORT_MATRIX.md](docs/SUPPORT_MATRIX.md) |
 | Configuration reference | [docs/CONFIGURATION.md](docs/CONFIGURATION.md) |
 | HTTP/3 rollout and lifecycle | [docs/HTTP3_ROLLOUT.md](docs/HTTP3_ROLLOUT.md) |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -13,9 +13,10 @@ Runtime config-file selection, highest priority first:
 6. `$HOME/.config/tardigrade/tardigrade.conf`.
 
 `check [<config>]` and `config validate [<config>]` are validation commands.
-When no path is supplied, they validate `./tardigrade.conf` -- the same local
-file `run` selects first when no explicit path is given -- rather than the
-full runtime search path above.
+When no path is supplied, `check` validates `./tardigrade.conf` directly
+rather than using the full runtime search path above. `run` discovers that
+same local file when no higher-precedence `TARDIGRADE_CONFIG_PATH` override
+is set.
 
 Effective value precedence, highest priority first:
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -13,8 +13,9 @@ Runtime config-file selection, highest priority first:
 6. `$HOME/.config/tardigrade/tardigrade.conf`.
 
 `check [<config>]` and `config validate [<config>]` are validation commands.
-When no path is supplied, they validate `./tardigrade.toml` instead of using
-the runtime search path.
+When no path is supplied, they validate `./tardigrade.conf` -- the same local
+file `run` selects first when no explicit path is given -- rather than the
+full runtime search path above.
 
 Effective value precedence, highest priority first:
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -43,6 +43,69 @@ For copy/paste-runnable configs, see [examples/](../examples/README.md):
 [graceful reload](../examples/graceful-reload/README.md), and
 [production baseline](../examples/production-baseline/README.md).
 
+## Generating a Starter Config
+
+`tardi init <profile>` writes a ready-to-check config for a common
+deployment shape to stdout only, so `tardi init proxy > tardigrade.conf`
+produces a clean file with no extra output mixed in:
+
+```bash
+tardi init static > tardigrade.conf     # static files + SPA fallback + health
+tardi init proxy > tardigrade.conf      # reverse proxy to an upstream app
+tardi init tls > tardigrade.conf        # TLS termination + proxy
+tardi init metrics > tardigrade.conf    # proxy starter documenting /status/metrics
+tardi init prod > tardigrade.conf       # production-oriented TLS/proxy scaffold
+```
+
+Each profile also has a longer descriptive alias that resolves to the same
+template, e.g. `tardi init reverse-proxy` is identical to `tardi init proxy`.
+Run `tardi init --help` for the full profile/alias list. The `tls` and `prod`
+profiles reference certificate/key paths you must provision yourself — see
+[examples/tls-termination](../examples/tls-termination/README.md) and
+[examples/production-baseline](../examples/production-baseline/README.md)
+for how to generate a local test certificate. The `metrics` profile
+documents the existing `/status/metrics` endpoint; protect it in production
+with `TARDIGRADE_METRICS_REQUIRE_AUTH=true` or a network-boundary
+restriction.
+
+`tardi config init [<path>] [--force | --stdout] [--profile <profile>]` is
+the verbose, file-writing form of the same generator: it supports the same
+profiles via `--profile`, writes to a file (creating parent directories and
+refusing to overwrite an existing file unless `--force` is given), and keeps
+a generic starter output when no `--profile` is given.
+
+## CLI Command Reference
+
+```bash
+tardi check ./tardigrade.conf
+tardi config validate ./tardigrade.conf
+tardi validate -c ./tardigrade.conf
+tardi print-config -c ./tardigrade.conf
+tardi status -c ./tardigrade.conf
+tardi reload -c ./tardigrade.conf
+tardi stop -c ./tardigrade.conf
+tardi init <profile>
+tardi config init
+tardi explain <field>
+tardi config explain <field>
+```
+
+Not sure what a directive does or which values it accepts? `tardi explain
+<field>` looks it up from a built-in reference -- no config file required:
+
+```bash
+tardi explain listen
+tardi explain location.proxy_pass
+tardi explain upstream_protocol
+```
+
+`tardi config explain <field>` is a verbose alias for the same command.
+`explain` is a static documentation lookup: it describes the *supported*
+configuration contract (type, default, valid values, environment variable,
+example) and never loads a config file, inspects a running process, or
+prints current environment/secret values -- that's what `print-config`
+(effective configuration) is for.
+
 ## Config File Syntax
 
 Config files are nginx-inspired. Directives end in `;`; `server {}` and

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -142,5 +142,7 @@ form shown above, while `run` requires `-c`/`--config`.
   and graceful-shutdown contract.
 - [Core v1 support matrix](SUPPORT_MATRIX.md) -- what's stable versus
   experimental.
+- [Troubleshooting](TROUBLESHOOTING.md) -- symptom-to-diagnosis runbook for
+  when something doesn't work as expected.
 - [packaging/README.md](../packaging/README.md) -- install/build options
   and current platform coverage in detail.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -55,9 +55,11 @@ tardi run
 
 `tardi init static` writes a starter config to stdout only, so the
 redirect above produces a clean `tardigrade.conf` with no extra output mixed
-in. `tardi check` validates that same local file -- it defaults to
-`./tardigrade.conf`, the same file `tardi run` picks up with no explicit
-path. Validation performs a dry parse and never starts a listener.
+in. With no path given, `tardi check` validates `./tardigrade.conf` directly,
+and `tardi run` discovers that same local file too -- assuming, as in this
+walkthrough, that `TARDIGRADE_CONFIG_PATH` isn't set in your shell, since
+that env var takes precedence over the local file for `run` but not for
+`check`. Validation performs a dry parse and never starts a listener.
 
 `tardi run` starts listening on `http://localhost:8080`. From another
 terminal:

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,140 @@
+# Tardigrade Quickstart
+
+Run a local static site or reverse proxy with Tardigrade in a few minutes.
+
+Tardigrade is the project/package name. The installed command is `tardi`.
+Some installation formats may also provide `tardigrade` as a compatibility
+alias, but examples on this page use `tardi`.
+
+## Install
+
+The fastest way to install the latest release is the official install script:
+
+```bash
+curl -fsSL https://github.com/Bare-Systems/Tardigrade/releases/latest/download/install.sh | sh
+tardi version
+```
+
+This installs `tardi` (with a `tardigrade` compatibility alias) into
+`$HOME/.local/bin`. Make sure that directory is on your `PATH`. Published
+release binaries link OpenSSL at runtime, so OpenSSL 1.1/3.x must already be
+present on the host. See [packaging/README.md](../packaging/README.md) for
+other install paths (DEB/RPM packages, release archives) and current
+platform coverage.
+
+If you'd rather build from source:
+
+```bash
+git clone https://github.com/Bare-Systems/Tardigrade.git
+cd Tardigrade
+zig build -Doptimize=ReleaseFast
+export PATH="$PWD/zig-out/bin:$PATH"
+tardi version
+```
+
+Building from source requires [Zig](https://ziglang.org/) 0.16.0 and, on
+Linux, OpenSSL development libraries (`libssl-dev` on Debian/Ubuntu).
+
+## Static-site happy path
+
+From a clean directory:
+
+```bash
+mkdir -p public
+printf '%s\n' '<h1>Hello from Tardigrade</h1>' > public/index.html
+
+tardi init static > tardigrade.conf
+tardi check
+tardi run
+```
+
+`tardi init static` writes a starter config to stdout only, so the
+redirect above produces a clean `tardigrade.conf` with no extra output mixed
+in. `tardi check` validates that same local file -- it defaults to
+`./tardigrade.conf`, the same file `tardi run` picks up with no explicit
+path. Validation performs a dry parse and never starts a listener.
+
+`tardi run` starts listening on `http://localhost:8080`. From another
+terminal:
+
+```bash
+curl -fsS http://localhost:8080/
+curl -fsS http://localhost:8080/health
+```
+
+You should see:
+
+- the index request returns `<h1>Hello from Tardigrade</h1>`;
+- `/health` returns `ok`.
+
+Press `Ctrl-C` in the terminal running `tardi run` to stop it; it drains
+in-flight connections and exits cleanly.
+
+## Reverse-proxy happy path
+
+This walkthrough creates its own local upstream so it is fully runnable
+without any application of your own.
+
+Start a throwaway upstream in one terminal:
+
+```bash
+mkdir -p upstream
+printf '%s\n' 'hello from upstream' > upstream/index.html
+python3 -m http.server 3000 --bind 127.0.0.1 --directory upstream
+```
+
+In your Tardigrade working directory (a second terminal):
+
+```bash
+tardi init proxy > tardigrade.conf
+tardi check
+tardi run
+```
+
+The generated `proxy` profile points at `http://127.0.0.1:3000`, so no
+extra config is needed beyond what `check` already validated -- `check`
+validates the config's shape and does not require the upstream to be
+reachable. From a third terminal:
+
+```bash
+curl -fsS http://localhost:8080/
+curl -fsS http://localhost:8080/health
+```
+
+You should see:
+
+- the index request returns `hello from upstream`, proxied through
+  Tardigrade to the local Python server;
+- `/health` still returns `ok` directly from the edge, with no upstream
+  hop.
+
+`Ctrl-C` stops `tardi run` cleanly; stop the Python upstream with `Ctrl-C`
+in its own terminal.
+
+## Explicit config path
+
+The walkthroughs above rely on `tardi check` and `tardi run` finding
+`./tardigrade.conf` with no arguments. To point either command at a
+specific file instead:
+
+```bash
+tardi check ./my-site.conf
+tardi run -c ./my-site.conf
+```
+
+Both commands consume the same file you pass to `-c`/`--config`.
+
+## Next steps
+
+- [Configuration reference](CONFIGURATION.md) -- every directive, type,
+  default, and environment variable.
+- [Examples](../examples/README.md) -- curated, copy/paste-runnable configs
+  for TLS termination, virtual hosts, rate limiting, metrics, and more.
+- [Production deployment](DEPLOYMENT.md) -- running Tardigrade under
+  systemd or Docker.
+- [Reload, drain, and shutdown](RELOAD_SHUTDOWN.md) -- the full hot-reload
+  and graceful-shutdown contract.
+- [Core v1 support matrix](SUPPORT_MATRIX.md) -- what's stable versus
+  experimental.
+- [packaging/README.md](../packaging/README.md) -- install/build options
+  and current platform coverage in detail.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -8,21 +8,9 @@ alias, but examples on this page use `tardi`.
 
 ## Install
 
-The fastest way to install the latest release is the official install script:
-
-```bash
-curl -fsSL https://github.com/Bare-Systems/Tardigrade/releases/latest/download/install.sh | sh
-tardi version
-```
-
-This installs `tardi` (with a `tardigrade` compatibility alias) into
-`$HOME/.local/bin`. Make sure that directory is on your `PATH`. Published
-release binaries link OpenSSL at runtime, so OpenSSL 1.1/3.x must already be
-present on the host. See [packaging/README.md](../packaging/README.md) for
-other install paths (DEB/RPM packages, release archives) and current
-platform coverage.
-
-If you'd rather build from source:
+Build from source for this walkthrough. The latest published release
+(`v0.5.0`) predates `tardi init <profile>` and the `./tardigrade.conf`
+default this guide relies on, so it can't run the commands below yet:
 
 ```bash
 git clone https://github.com/Bare-Systems/Tardigrade.git
@@ -34,6 +22,23 @@ tardi version
 
 Building from source requires [Zig](https://ziglang.org/) 0.16.0 and, on
 Linux, OpenSSL development libraries (`libssl-dev` on Debian/Ubuntu).
+
+Once a release that includes `tardi init` is published, the official
+install script will also work for this guide:
+
+```bash
+curl -fsSL https://github.com/Bare-Systems/Tardigrade/releases/latest/download/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
+tardi version
+```
+
+This installs `tardi` (with a `tardigrade` compatibility alias) into
+`$HOME/.local/bin`; the `export` above puts that directory on `PATH` for
+the current shell. Published release binaries link OpenSSL at runtime, so
+OpenSSL 1.1/3.x must already be present on the host, and prebuilt archives
+currently cover Linux x86_64/aarch64 only. See
+[packaging/README.md](../packaging/README.md) for other install paths
+(DEB/RPM packages, release archives) and current platform coverage.
 
 ## Static-site happy path
 
@@ -122,7 +127,8 @@ tardi check ./my-site.conf
 tardi run -c ./my-site.conf
 ```
 
-Both commands consume the same file you pass to `-c`/`--config`.
+Both commands consume `./my-site.conf`: `check` accepts it as the positional
+form shown above, while `run` requires `-c`/`--config`.
 
 ## Next steps
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -16,10 +16,11 @@ All examples use the canonical packaged config path,
 (`tardigrade` also works as a compatibility alias installed by the release
 script — see [README.md#install](../README.md#install)). Substitute your own
 config path throughout; **always pass it explicitly** (`-c <path>` or a
-positional argument) rather than relying on defaults — `tardi check` and
-`tardi config validate` fall back to `./tardigrade.toml` when no path is
-given, which is almost never what you want against an nginx-style
-`tardigrade.conf` deployment.
+positional argument) for packaged deployments rather than relying on
+defaults. For local first-run use, `tardi check` with no path validates
+`./tardigrade.conf` directly; `tardi run` discovers that same local file
+only when no higher-precedence `TARDIGRADE_CONFIG_PATH` override is set --
+see [Configuration](CONFIGURATION.md) for the full runtime search order.
 
 ## Contents
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -417,21 +417,21 @@ fn parseExplainCommand(args: []const []const u8) !CliCommand {
 fn printUsage(writer: anytype) !void {
     try writer.writeAll(
         \\Usage:
-        \\  tardigrade check [<config>]
-        \\  tardigrade run [-c <path>] [--daemon]
-        \\  tardigrade validate [-c <path>]
-        \\  tardigrade status [-c <path>] [--pid-file <path> | --pid <pid>]
-        \\  tardigrade print-config [-c <path>]
-        \\  tardigrade routes [<config>] [-c <path>]
-        \\  tardigrade upstreams [<config>] [-c <path>]
-        \\  tardigrade reload [-c <path>] [--pid-file <path> | --pid <pid>]
-        \\  tardigrade stop [-c <path>] [--pid-file <path> | --pid <pid>]
-        \\  tardigrade version
-        \\  tardigrade init <profile>
+        \\  tardi check [<config>]
+        \\  tardi run [-c <path>] [--daemon]
+        \\  tardi validate [-c <path>]
+        \\  tardi status [-c <path>] [--pid-file <path> | --pid <pid>]
+        \\  tardi print-config [-c <path>]
+        \\  tardi routes [<config>] [-c <path>]
+        \\  tardi upstreams [<config>] [-c <path>]
+        \\  tardi reload [-c <path>] [--pid-file <path> | --pid <pid>]
+        \\  tardi stop [-c <path>] [--pid-file <path> | --pid <pid>]
+        \\  tardi version
+        \\  tardi init <profile>
         \\  tardi explain <field>
-        \\  tardigrade config init [<path>] [--force | --stdout] [--profile <profile>]
-        \\  tardigrade config print [-c <path>]
-        \\  tardigrade config validate [<config>]
+        \\  tardi config init [<path>] [--force | --stdout] [--profile <profile>]
+        \\  tardi config print [-c <path>]
+        \\  tardi config validate [<config>]
         \\  tardi config explain <field>
         \\
         \\Profiles (canonical name, descriptive alias -- aliases resolve to the
@@ -443,6 +443,9 @@ fn printUsage(writer: anytype) !void {
         \\  prod (production-baseline)   production-oriented TLS/proxy scaffold
         \\
         \\Notes:
+        \\  - `tardi` is the canonical command name. Some installation formats
+        \\    also provide `tardigrade` as a compatibility alias for the same
+        \\    binary.
         \\  - `init <profile>` writes the profile's config to stdout only, e.g.
         \\    `tardi init proxy > tardigrade.conf`; nothing else is printed to
         \\    stdout or stderr on success. `config init` is the verbose,
@@ -2000,4 +2003,30 @@ test "built-in usage documents the concise tardi explain form before the verbose
     // for these two commands, not the legacy `tardigrade` spelling.
     try std.testing.expect(std.mem.indexOf(u8, written, "tardigrade explain <field>") == null);
     try std.testing.expect(std.mem.indexOf(u8, written, "tardigrade config explain <field>") == null);
+}
+
+test "built-in usage presents tardi as canonical for every command" {
+    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer out.deinit();
+    try printUsage(&out.writer);
+    const written = out.writer.buffered();
+
+    // #157 requires the Usage block to be consistent with #163: `tardi` is
+    // canonical everywhere, not just for `explain`. `tardigrade` may still
+    // be named once as a compatibility alias, but never as a co-equal
+    // command prefix in the Usage rows themselves.
+    const usage_commands = [_][]const u8{
+        "check",        "run",          "validate",        "status",
+        "print-config", "routes",       "upstreams",       "reload",
+        "stop",         "version",      "init",            "explain",
+        "config init",  "config print", "config validate", "config explain",
+    };
+    for (usage_commands) |cmd| {
+        var buf: [64]u8 = undefined;
+        const needle = try std.fmt.bufPrint(&buf, "tardi {s}", .{cmd});
+        try std.testing.expect(std.mem.indexOf(u8, written, needle) != null);
+    }
+    try std.testing.expect(std.mem.indexOf(u8, written, "tardigrade check") == null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "tardigrade run") == null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "tardigrade version") == null);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -453,8 +453,9 @@ fn printUsage(writer: anytype) !void {
         \\    `--profile <profile>` and keeps today's generic starter output
         \\    when no `--profile` is given.
         \\  - `check [<config>]` validates a config file without starting the server.
-        \\    Accepts a positional config path or defaults to `./tardigrade.conf`,
-        \\    the same local file `run` selects with no explicit path.
+        \\    Accepts a positional config path or defaults to `./tardigrade.conf`
+        \\    directly. `run` discovers that same local file when no
+        \\    higher-precedence `TARDIGRADE_CONFIG_PATH` override is set.
         \\    `config validate [<config>]` is a verbose alias for the same command.
         \\  - Legacy `validate` and `--validate-config` remain supported.
         \\  - `status` reports process state when a pid target is available.

--- a/src/main.zig
+++ b/src/main.zig
@@ -10,7 +10,7 @@ const runtime_allocator = @import("runtime_allocator.zig");
 const tls_core = @import("tls_core");
 
 const ENV_CONFIG_PATH = "TARDIGRADE_CONFIG_PATH";
-const CHECK_DEFAULT_CONFIG_PATH = "./tardigrade.toml";
+const CHECK_DEFAULT_CONFIG_PATH = "./tardigrade.conf";
 const EXIT_INTERNAL_ERROR: u8 = 1;
 const EXIT_CONFIG_INVALID: u8 = 2;
 
@@ -450,7 +450,8 @@ fn printUsage(writer: anytype) !void {
         \\    `--profile <profile>` and keeps today's generic starter output
         \\    when no `--profile` is given.
         \\  - `check [<config>]` validates a config file without starting the server.
-        \\    Accepts a positional config path or defaults to `./tardigrade.toml`.
+        \\    Accepts a positional config path or defaults to `./tardigrade.conf`,
+        \\    the same local file `run` selects with no explicit path.
         \\    `config validate [<config>]` is a verbose alias for the same command.
         \\  - Legacy `validate` and `--validate-config` remain supported.
         \\  - `status` reports process state when a pid target is available.
@@ -1927,7 +1928,8 @@ test "parseCliCommand config validate with positional config path" {
     }
 }
 
-test "check command default path is tardigrade.toml" {
+test "check command default path is tardigrade.conf" {
+    try std.testing.expectEqualStrings("./tardigrade.conf", CHECK_DEFAULT_CONFIG_PATH);
     try std.testing.expectEqualStrings(CHECK_DEFAULT_CONFIG_PATH, validationTargetDescription(.{}, .check));
 }
 

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -17241,7 +17241,7 @@ test "init -h and --help print usage without generating a config" {
         defer allocator.free(res.stderr);
         try std.testing.expectEqual(std.process.Child.Term{ .exited = 0 }, res.term);
         try std.testing.expect(std.mem.indexOf(u8, res.stdout, "# Tardigrade profile:") == null);
-        try assertContains(res.stdout, "tardigrade init <profile>");
+        try assertContains(res.stdout, "tardi init <profile>");
     }
 }
 


### PR DESCRIPTION
**What changed and why**
Adds `docs/QUICKSTART.md`, the canonical 5-minute operator quickstart: install/build, generate a starter config with `tardi init <profile>`, validate it with `tardi check`, run it with `tardi run`, and verify a real request with `curl` — for both the static-site and reverse-proxy profiles, plus the explicit `-c <path>` form. Every command block was executed as written from a clean directory against a locally built release binary (and the published `install.sh` was run against the real `v0.5.0` GitHub release, which was found to predate `tardi init` — see below).

Fixes the one real first-run inconsistency called out in #157: `tardi check` with no path defaulted to the stale `./tardigrade.toml`, while `tardi run`'s no-argument runtime discovery, generated profiles, examples, and packaging all converge on nginx-style `./tardigrade.conf`. `check` now validates `./tardigrade.conf` directly when no path is given. `run`'s normal runtime discovery is unchanged — it still checks `TARDIGRADE_CONFIG_PATH` before the local file — and the docs/help text now say so precisely instead of implying `check` and `run` always agree.

README changes: a prominent Quickstart link in the top nav, a short teaser in the `## Quick start` section pointing at the full guide (rather than duplicating it), a `Quickstart` row in the Full documentation table. `printUsage()` now presents `tardi` as canonical for every command (was mostly `tardigrade`), with a compatibility-alias note. The install-first quickstart path was found to be broken against the actual `v0.5.0` release (predates `tardi init`), so `docs/QUICKSTART.md` now leads with the source-build path and gates the installer example on a future compatible release.

Homebrew is intentionally not advertised (not yet published per #463/#466). `docs/TROUBLESHOOTING.md` landed on `main` via #167/#626 after this branch was created; the branch has been synced with `main` and the Quickstart's Next Steps now link it. Added a CHANGELOG entry for this PR's operator-visible `tardi check` default-path change and the `tardi`-canonical first-run contract.

**Related issues**
Closes #157

**Tests**
- `zig fmt --check build.zig src/ tests/` — clean.
- `zig build test --summary all` — 3828/3829 passed (1 pre-existing skip), including tests asserting `CHECK_DEFAULT_CONFIG_PATH == "./tardigrade.conf"` and that built-in help presents `tardi` as canonical for every command.
- `zig build test-integration-init` — green (covers `tardi init -h`/`--help` output).
- Manually executed, from clean directories against a locally built `ReleaseFast` binary:
  - static profile: `tardi init static > tardigrade.conf`, `tardi check`, `tardi run`, `curl http://localhost:8080/` and `/health`, clean `Ctrl-C` (SIGINT) shutdown.
  - reverse-proxy profile: local `python3 -m http.server 3000` upstream, `tardi init proxy > tardigrade.conf`, `tardi check`, `tardi run`, `curl` proxied through to the upstream body, `/health` served directly, clean shutdown of both processes.
  - explicit path form: `tardi check ./my-site.conf` and `tardi run -c ./my-site.conf` against a renamed config file.
  - install script: downloaded and ran the real `install.sh` from the `v0.5.0` GitHub release into a scratch install dir; confirmed it lacks `tardi init <profile>`, which is why the guide no longer leads with it.
  - source build: fresh `git clone`, `zig build -Doptimize=ReleaseFast`, `export PATH=...`, `tardi version`.
- `zig build test-integration` fails in this sandbox both on this branch and on a pristine `origin/main` checkout (`error.InvalidHttpResponse` / `error.ConnectionResetByPeer` / `error.SocketUnconnected` from an upstream test handler) — confirmed pre-existing and environmental (sandbox networking), not caused by this change. CI's own Linux appliance-profile integration suite is green.

**Security impact**
None. Docs, a CLI default-path constant change, and a help-text change; no header parsing, routing, auth, TLS, path handling, or logging code touched.

**Performance impact**
None. No event loop, worker pool, or hot-path code touched.

**Checklist**
- [x] `zig fmt --check build.zig src/ tests/` passes
- [x] `zig build test --summary all` green
- [ ] `zig build test-integration` green (not required — no protocol/proxy/TLS code changed; pre-existing sandbox failure reproduced on `origin/main`, see Tests above; CI's own integration jobs are green)
- [x] New behavior covered by tests
- [x] [docs/CODE_REVIEW_CHECKLIST.md](docs/CODE_REVIEW_CHECKLIST.md) reviewed
- [x] README / CHANGELOG updated — README updated for the Quickstart link/teaser; CHANGELOG.md gets an `Unreleased` entry for the operator-visible `tardi check` default-path change and the `tardi`-canonical first-run contract, since this PR is not docs-only


---
_Generated by [Claude Code](https://claude.ai/code/session_01FwCjDuDNXg77dpUFHvGwXJ)_