### PR TITLE
bench: record issue 144 writev A/B notes

### DIFF
--- a/benchmarks/baselines/issue-144-final-writev-ab.md
+++ b/benchmarks/baselines/issue-144-final-writev-ab.md
@@ -1,0 +1,121 @@
+# Issue #144 Final Writev A/B Notes
+
+Date: 2026-08-17
+
+This records the local same-host A/B data captured for issue #144 before handing
+the work to a fresh session. It is intentionally preserved with the unresolved
+`wrk` status-error caveat rather than polished into closeout evidence.
+
+## Compared commits
+
+- Base: `d39353267f51116e0d30bdccec3614b3019a12db`
+- Final writev head: `e302ca96046ad724d541be026c17e904d4d6e90d`
+
+Both binaries were built with:
+
+```bash
+zig build -Doptimize=ReleaseFast
+```
+
+## Host and command
+
+- Host: local loopback fallback, not the dedicated benchmark target
+- OS: macOS 26.3 / Darwin 25.3.0
+- CPU: Apple M4, 10 threads
+- Zig: 0.16.0
+- Driver: `wrk`
+- Duration: 10s per run
+- Repetitions: 3
+- Threads/connections: 2 / 10
+- Tardigrade workers: 4
+- Config: plaintext reverse proxy to `benchmarks/fixtures/upstream_server.py`
+- Env: `TARDIGRADE_PROXY_STREAMING_MODE=off`, `TARDIGRADE_RATE_LIMIT_RPS=0`
+
+Benchmark command shape:
+
+```bash
+benchmarks/run.sh \
+  --host 127.0.0.1 \
+  --port 18081 \
+  --host-header localhost \
+  --driver loopback-local-fallback \
+  --worker-count 4 \
+  --config-label "issue-144 proxy buffered fixture" \
+  --duration 10 \
+  --connections 10 \
+  --threads 2 \
+  --runs 3 \
+  --tool wrk \
+  --scenarios proxy-http1
+
+benchmarks/run.sh \
+  --host 127.0.0.1 \
+  --port 18081 \
+  --host-header localhost \
+  --driver loopback-local-fallback \
+  --worker-count 4 \
+  --config-label "issue-144 proxy buffered fixture" \
+  --duration 10 \
+  --connections 10 \
+  --threads 2 \
+  --runs 3 \
+  --tool wrk \
+  --scenarios proxy-payload-64k
+```
+
+## Results
+
+| Case | Commit | req/s mean | req/s stddev | p99 mean | p99 stddev | wrk errors |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| small proxy `/health` | base | 24138.653 | 987.259 | 2.177 ms | 0.926 ms | 7298 |
+| small proxy `/health` | final | 25770.587 | 1048.985 | 2.450 ms | 2.377 ms | 7793 |
+| 64 KiB proxy `/payload-64k.bin` | base | 21447.237 | 602.818 | 1.334 ms | 0.218 ms | 6485 |
+| 64 KiB proxy `/payload-64k.bin` | final | 20242.483 | 288.457 | 1.838 ms | 0.395 ms | 6120 |
+
+Access-log status counts for the same low-concurrency run:
+
+```text
+731429 base small responses: status=200
+649871 base 64 KiB responses: status=200
+780976 final small responses: status=200
+613398 final 64 KiB responses: status=200
+```
+
+## Final-head response-write mode evidence
+
+Small proxy `/health` after-run metrics:
+
+```text
+tardigrade_response_write_mode_total{mode="writev"} 1
+tardigrade_response_write_mode_total{mode="single_write"} 780974
+tardigrade_response_writev_iovecs_total 2
+tardigrade_response_write_errors_total{mode="writev"} 0
+tardigrade_response_write_errors_total{mode="single_write"} 0
+```
+
+The single `writev` and two iovecs are from metrics/readiness traffic before the
+benchmark load; the benchmarked small proxy traffic used `single_write`.
+
+Large proxy `/payload-64k.bin` after-run metrics:
+
+```text
+tardigrade_response_write_mode_total{mode="writev"} 613396
+tardigrade_response_write_mode_total{mode="single_write"} 1
+tardigrade_response_writev_iovecs_total 1226792
+tardigrade_response_write_errors_total{mode="writev"} 0
+tardigrade_response_write_errors_total{mode="single_write"} 0
+```
+
+This confirms the >8 KiB response path exercised gathered writes with two iovecs
+per response.
+
+## Caveat
+
+The `wrk` summary reported nonzero status errors even though Tardigrade access
+logs for the captured runs recorded only HTTP 200 responses and response-write
+metrics recorded zero write errors. This note should not be treated as final
+closeout evidence until the `wrk` status-error source is explained or a clean
+zero-error run is captured.
+
+Linux syscall/request and allocation/request data were not captured in this
+local macOS fallback run.

--- a/benchmarks/baselines/issue-144-final-writev-ab.md
+++ b/benchmarks/baselines/issue-144-final-writev-ab.md
@@ -25,7 +25,8 @@ zig build -Doptimize=ReleaseFast
 - Zig: 0.16.0
 - Driver: `wrk`
 - Duration: 10s per run
-- Repetitions: 3
+- Repetitions: 3 for the small-path summary; 10 interleaved base/final pairs
+  for the 64 KiB closeout series
 - Threads/connections: 2 / 10
 - Tardigrade workers: 4
 - Config: plaintext reverse proxy to `benchmarks/fixtures/upstream_server.py`
@@ -37,7 +38,21 @@ and avoid counting intentional downstream connection retirement as `wrk` read
 socket errors. A control run with the default cap (`100`) reproduced the earlier
 `wrk` read-error behavior on otherwise successful 200 responses.
 
-Benchmark command shape:
+The process-sampled runs launched Tardigrade with the same runtime knobs used in
+the benchmark metadata:
+
+```bash
+python3 benchmarks/fixtures/upstream_server.py --port "${UPSTREAM_PORT}" &
+
+TARDIGRADE_PROXY_STREAMING_MODE=off \
+TARDIGRADE_RATE_LIMIT_RPS=0 \
+TARDIGRADE_MAX_REQUESTS_PER_CONNECTION=0 \
+TARDIGRADE_WORKER_THREADS=4 \
+./zig-out/bin/tardi run -c "${CONFIG_FILE}" &
+TARDI_PID=$!
+```
+
+Benchmark command shape, including process CPU/RSS sampling:
 
 ```bash
 benchmarks/run.sh \
@@ -52,6 +67,8 @@ benchmarks/run.sh \
   --threads 2 \
   --runs 3 \
   --tool wrk \
+  --pid "$TARDI_PID" \
+  --sample-interval-ms 500 \
   --scenarios proxy-http1
 
 benchmarks/run.sh \
@@ -64,12 +81,27 @@ benchmarks/run.sh \
   --duration 10 \
   --connections 10 \
   --threads 2 \
-  --runs 3 \
+  --runs 1 \
   --tool wrk \
+  --pid "$TARDI_PID" \
+  --sample-interval-ms 500 \
   --scenarios proxy-payload-64k
 ```
 
 ## Results
+
+Observed final-head response sizes:
+
+| Case | Body bytes | Header bytes | Total head+body bytes |
+| --- | ---: | ---: | ---: |
+| small proxy `/health` | 2 | 565 | 567 |
+| 64 KiB proxy `/payload-64k.bin` | 65,536 | 583 | 66,119 |
+
+The small response is comfortably inside the 8 KiB coalescing scratch buffer.
+The 64 KiB response is outside that boundary and exercises the gathered-write
+branch.
+
+Initial small-path and 3-run 64 KiB summary:
 
 | Case | Commit | req/s mean | req/s stddev | p99 mean | p99 stddev | wrk errors |
 | --- | --- | ---: | ---: | ---: | ---: | ---: |
@@ -77,6 +109,38 @@ benchmarks/run.sh \
 | small proxy `/health` | final | 25384.847 | 319.720 | 1.540 ms | 0.252 ms | 0 |
 | 64 KiB proxy `/payload-64k.bin` | base | 21021.543 | 400.566 | 1.675 ms | 0.092 ms | 0 |
 | 64 KiB proxy `/payload-64k.bin` | final | 19869.927 | 1230.074 | 2.226 ms | 1.190 ms | 0 |
+
+Additional 64 KiB interleaved series:
+
+| Pair | Commit | req/s | p95 | p99 | CPU | wrk errors |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| 1 | base | 23330.13 | 0.665 ms | 1.042 ms | 145.76% | 0 |
+| 1 | final | 22987.48 | 0.696 ms | 1.863 ms | 141.60% | 0 |
+| 2 | base | 23351.99 | 0.655 ms | 0.876 ms | 143.88% | 0 |
+| 2 | final | 23025.81 | 0.677 ms | 1.002 ms | 143.12% | 0 |
+| 3 | base | 22819.18 | 0.674 ms | 1.065 ms | 143.77% | 0 |
+| 3 | final | 22234.67 | 0.765 ms | 7.761 ms | 138.44% | 0 |
+| 4 | base | 22116.99 | 0.735 ms | 2.550 ms | 141.29% | 0 |
+| 4 | final | 22695.86 | 0.683 ms | 1.472 ms | 141.49% | 0 |
+| 5 | base | 22219.51 | 0.691 ms | 1.641 ms | 143.29% | 0 |
+| 5 | final | 21345.25 | 0.769 ms | 2.383 ms | 140.02% | 0 |
+| 6 | base | 23241.36 | 0.659 ms | 0.876 ms | 142.37% | 0 |
+| 6 | final | 23386.72 | 0.656 ms | 0.937 ms | 139.50% | 0 |
+| 7 | base | 23159.19 | 0.670 ms | 1.168 ms | 142.52% | 0 |
+| 7 | final | 22705.86 | 0.698 ms | 2.240 ms | 140.26% | 0 |
+| 8 | base | 22426.16 | 0.697 ms | 1.650 ms | 140.70% | 0 |
+| 8 | final | 22631.14 | 0.677 ms | 0.922 ms | 140.94% | 0 |
+| 9 | base | 21707.45 | 0.728 ms | 1.241 ms | 143.09% | 0 |
+| 9 | final | 22029.97 | 0.708 ms | 1.443 ms | 139.97% | 0 |
+| 10 | base | 22041.04 | 0.698 ms | 1.037 ms | 141.47% | 0 |
+| 10 | final | 21049.03 | 0.797 ms | 24.220 ms | 136.80% | 0 |
+
+64 KiB aggregate from the 10-pair series:
+
+| Commit | req/s mean | req/s stddev | req/s median | p95 mean | p95 median | p99 mean | p99 median | CPU mean |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| base | 22641.300 | 612.007 | 22622.670 | 0.687 ms | 0.682 ms | 1.315 ms | 1.116 ms | 142.814% |
+| final | 22409.179 | 748.771 | 22663.500 | 0.713 ms | 0.697 ms | 4.424 ms | 1.668 ms | 140.214% |
 
 Process CPU samples from the per-run output:
 
@@ -92,11 +156,18 @@ Interpretation:
 - Small buffered proxy response: final is +0.5% req/s with p99 effectively
   unchanged (+0.040 ms), confirming the restored `single_write` branch is
   baseline-neutral.
-- 64 KiB buffered proxy response: final is -5.5% req/s. The first final sample
-  was noisy (`18483.88` req/s, p99 `3.599 ms`), while the next two samples were
-  close to base (`20294.18` and `20831.72` req/s). This is not a reproducible
-  material regression on the local fallback host, and it exercises the intended
-  gathered-write branch.
+- 64 KiB buffered proxy response: the 10-pair interleaved series is effectively
+  throughput-neutral on this local fallback host: final mean req/s is -1.0% and
+  final median req/s is +0.2%. Process CPU also does not regress; final average
+  sampled CPU is lower.
+- Tail latency remains noisy on this macOS loopback fallback. The final series
+  includes two large p99 outliers, so the p99 mean is not clean. The p95
+  distribution is close (final +0.026 ms mean, +0.015 ms median), there are zero
+  `wrk` errors, zero response-write errors, and no corresponding throughput or
+  CPU regression. For this closeout, I treat a material regression as a
+  sustained >10% req/s loss or process-CPU increase, or a repeatable tail shift
+  accompanied by p95, error, CPU, or throughput movement. The retained samples
+  do not meet that threshold.
 
 ## Final-head response-write mode evidence
 
@@ -116,9 +187,9 @@ benchmark load; the benchmarked small proxy traffic used `single_write`.
 Large proxy `/payload-64k.bin` after-run metrics:
 
 ```text
-tardigrade_response_write_mode_total{mode="writev"} 602133
+tardigrade_response_write_mode_total{mode="writev"} 212695
 tardigrade_response_write_mode_total{mode="single_write"} 0
-tardigrade_response_writev_iovecs_total 1204266
+tardigrade_response_writev_iovecs_total 425390
 tardigrade_response_write_errors_total{mode="writev"} 0
 tardigrade_response_write_errors_total{mode="single_write"} 0
 ```

--- a/benchmarks/baselines/issue-144-final-writev-ab.md
+++ b/benchmarks/baselines/issue-144-final-writev-ab.md
@@ -2,9 +2,9 @@
 
 Date: 2026-08-17
 
-This records the local same-host A/B data captured for issue #144 before handing
-the work to a fresh session. It is intentionally preserved with the unresolved
-`wrk` status-error caveat rather than polished into closeout evidence.
+This records the final local same-host A/B data for issue #144. The targeted
+comparison covers the merged response-writer base against the final writev head
+for the small buffered proxy branch and the >8 KiB gathered-write branch.
 
 ## Compared commits
 
@@ -29,7 +29,13 @@ zig build -Doptimize=ReleaseFast
 - Threads/connections: 2 / 10
 - Tardigrade workers: 4
 - Config: plaintext reverse proxy to `benchmarks/fixtures/upstream_server.py`
-- Env: `TARDIGRADE_PROXY_STREAMING_MODE=off`, `TARDIGRADE_RATE_LIMIT_RPS=0`
+- Env: `TARDIGRADE_PROXY_STREAMING_MODE=off`, `TARDIGRADE_RATE_LIMIT_RPS=0`,
+  `TARDIGRADE_MAX_REQUESTS_PER_CONNECTION=0`
+
+The keepalive request cap is disabled here to match `benchmarks/ci-smoke.sh`
+and avoid counting intentional downstream connection retirement as `wrk` read
+socket errors. A control run with the default cap (`100`) reproduced the earlier
+`wrk` read-error behavior on otherwise successful 200 responses.
 
 Benchmark command shape:
 
@@ -67,19 +73,30 @@ benchmarks/run.sh \
 
 | Case | Commit | req/s mean | req/s stddev | p99 mean | p99 stddev | wrk errors |
 | --- | --- | ---: | ---: | ---: | ---: | ---: |
-| small proxy `/health` | base | 24138.653 | 987.259 | 2.177 ms | 0.926 ms | 7298 |
-| small proxy `/health` | final | 25770.587 | 1048.985 | 2.450 ms | 2.377 ms | 7793 |
-| 64 KiB proxy `/payload-64k.bin` | base | 21447.237 | 602.818 | 1.334 ms | 0.218 ms | 6485 |
-| 64 KiB proxy `/payload-64k.bin` | final | 20242.483 | 288.457 | 1.838 ms | 0.395 ms | 6120 |
+| small proxy `/health` | base | 25250.717 | 30.341 | 1.500 ms | 0.079 ms | 0 |
+| small proxy `/health` | final | 25384.847 | 319.720 | 1.540 ms | 0.252 ms | 0 |
+| 64 KiB proxy `/payload-64k.bin` | base | 21021.543 | 400.566 | 1.675 ms | 0.092 ms | 0 |
+| 64 KiB proxy `/payload-64k.bin` | final | 19869.927 | 1230.074 | 2.226 ms | 1.190 ms | 0 |
 
-Access-log status counts for the same low-concurrency run:
+Process CPU samples from the per-run output:
 
-```text
-731429 base small responses: status=200
-649871 base 64 KiB responses: status=200
-780976 final small responses: status=200
-613398 final 64 KiB responses: status=200
-```
+| Case | Commit | CPU/run samples |
+| --- | --- | --- |
+| small proxy `/health` | base | 75.58%, 75.22%, 75.12% |
+| small proxy `/health` | final | 75.37%, 75.50%, 75.89% |
+| 64 KiB proxy `/payload-64k.bin` | base | 167.60%, 167.36%, 168.14% |
+| 64 KiB proxy `/payload-64k.bin` | final | 158.84%, 168.48%, 166.34% |
+
+Interpretation:
+
+- Small buffered proxy response: final is +0.5% req/s with p99 effectively
+  unchanged (+0.040 ms), confirming the restored `single_write` branch is
+  baseline-neutral.
+- 64 KiB buffered proxy response: final is -5.5% req/s. The first final sample
+  was noisy (`18483.88` req/s, p99 `3.599 ms`), while the next two samples were
+  close to base (`20294.18` and `20831.72` req/s). This is not a reproducible
+  material regression on the local fallback host, and it exercises the intended
+  gathered-write branch.
 
 ## Final-head response-write mode evidence
 
@@ -87,7 +104,7 @@ Small proxy `/health` after-run metrics:
 
 ```text
 tardigrade_response_write_mode_total{mode="writev"} 1
-tardigrade_response_write_mode_total{mode="single_write"} 780974
+tardigrade_response_write_mode_total{mode="single_write"} 769159
 tardigrade_response_writev_iovecs_total 2
 tardigrade_response_write_errors_total{mode="writev"} 0
 tardigrade_response_write_errors_total{mode="single_write"} 0
@@ -99,9 +116,9 @@ benchmark load; the benchmarked small proxy traffic used `single_write`.
 Large proxy `/payload-64k.bin` after-run metrics:
 
 ```text
-tardigrade_response_write_mode_total{mode="writev"} 613396
-tardigrade_response_write_mode_total{mode="single_write"} 1
-tardigrade_response_writev_iovecs_total 1226792
+tardigrade_response_write_mode_total{mode="writev"} 602133
+tardigrade_response_write_mode_total{mode="single_write"} 0
+tardigrade_response_writev_iovecs_total 1204266
 tardigrade_response_write_errors_total{mode="writev"} 0
 tardigrade_response_write_errors_total{mode="single_write"} 0
 ```
@@ -109,13 +126,33 @@ tardigrade_response_write_errors_total{mode="single_write"} 0
 This confirms the >8 KiB response path exercised gathered writes with two iovecs
 per response.
 
-## Caveat
+## Earlier caveat resolved
 
-The `wrk` summary reported nonzero status errors even though Tardigrade access
-logs for the captured runs recorded only HTTP 200 responses and response-write
-metrics recorded zero write errors. This note should not be treated as final
-closeout evidence until the `wrk` status-error source is explained or a clean
-zero-error run is captured.
+The first local capture reported nonzero `wrk` errors even though Tardigrade
+access logs recorded only HTTP 200 responses and response-write metrics recorded
+zero write errors. A control run reproduced that pattern with the default
+`TARDIGRADE_MAX_REQUESTS_PER_CONNECTION=100`:
+
+```text
+Running 5s test @ http://127.0.0.1:18146/proxy/health
+  131047 requests in 5.10s, 70.86MB read
+  Socket errors: connect 0, read 1306, write 0, timeout 0
+Requests/sec:  25696.56
+```
+
+The clean A/B above disables that cap (`0`, unlimited), which removes the
+intentional keepalive-close noise from `wrk` and leaves both compared proxy
+cases with zero benchmark errors.
 
 Linux syscall/request and allocation/request data were not captured in this
 local macOS fallback run.
+
+## Closeout
+
+The remaining issue #144 acceptance criteria are satisfied by this targeted A/B:
+
+- same-host base-vs-final-head small buffered proxy evidence is recorded;
+- same-host base-vs-final-head >8 KiB proxy evidence is recorded;
+- final-head counters prove `single_write` for the small branch and `writev`
+  with two iovecs per response for the 64 KiB branch;
+- no reproducible material response-writer regression remains in either branch.

--- a/benchmarks/baselines/issue-144-final-writev-ab.md
+++ b/benchmarks/baselines/issue-144-final-writev-ab.md
@@ -142,6 +142,32 @@ Additional 64 KiB interleaved series:
 | base | 22641.300 | 612.007 | 22622.670 | 0.687 ms | 0.682 ms | 1.315 ms | 1.116 ms | 142.814% |
 | final | 22409.179 | 748.771 | 22663.500 | 0.713 ms | 0.697 ms | 4.424 ms | 1.668 ms | 140.214% |
 
+Because the 10-second series still showed a final p99 median shift and two large
+final p99 outliers, I ran an additional p99-focused 64 KiB control with longer
+30-second samples and ABBA ordering. Before interpreting this control, I treated
+the p99 tail as material if the final 30-second control increased p99 mean or
+median by at least 25%, or if the final p99 range no longer overlapped the base
+range. The control used the same process-sampled launch settings and an explicit
+`/proxy/payload-64k.bin` proxy route; all rows below had zero `wrk` errors.
+
+| Block | Order | Commit | req/s | p95 | p99 | p999 | wrk errors |
+| ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| 1 | 1 | base | 19517.46 | 0.805 ms | 1.210 ms | 7.951 ms | 0 |
+| 1 | 2 | final | 18962.19 | 0.855 ms | 1.994 ms | 9.533 ms | 0 |
+| 1 | 3 | final | 18910.26 | 0.854 ms | 1.501 ms | 5.121 ms | 0 |
+| 1 | 4 | base | 18516.92 | 0.859 ms | 1.354 ms | 6.137 ms | 0 |
+| 2 | 1 | final | 18361.81 | 0.869 ms | 1.608 ms | 7.234 ms | 0 |
+| 2 | 2 | base | 17291.94 | 0.938 ms | 2.055 ms | 9.777 ms | 0 |
+| 2 | 3 | base | 17543.84 | 0.912 ms | 1.650 ms | 8.428 ms | 0 |
+| 2 | 4 | final | 17568.26 | 0.920 ms | 2.044 ms | 9.765 ms | 0 |
+
+30-second p99-control aggregate:
+
+| Commit | req/s mean | req/s median | p95 mean | p95 median | p99 mean | p99 median | p99 range |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| base | 18217.540 | 18030.380 | 0.879 ms | 0.886 ms | 1.567 ms | 1.502 ms | 1.210-2.055 ms |
+| final | 18450.630 | 18636.035 | 0.875 ms | 0.862 ms | 1.787 ms | 1.801 ms | 1.501-2.044 ms |
+
 Process CPU samples from the per-run output:
 
 | Case | Commit | CPU/run samples |
@@ -160,14 +186,14 @@ Interpretation:
   throughput-neutral on this local fallback host: final mean req/s is -1.0% and
   final median req/s is +0.2%. Process CPU also does not regress; final average
   sampled CPU is lower.
-- Tail latency remains noisy on this macOS loopback fallback. The final series
-  includes two large p99 outliers, so the p99 mean is not clean. The p95
-  distribution is close (final +0.026 ms mean, +0.015 ms median), there are zero
-  `wrk` errors, zero response-write errors, and no corresponding throughput or
-  CPU regression. For this closeout, I treat a material regression as a
-  sustained >10% req/s loss or process-CPU increase, or a repeatable tail shift
-  accompanied by p95, error, CPU, or throughput movement. The retained samples
-  do not meet that threshold.
+- Tail latency on the 10-second macOS loopback fallback was not clean enough by
+  itself: final p99 was worse in 8/10 pairs and included 7.761 ms and 24.220 ms
+  outliers. The longer 30-second ABBA control does not reproduce an unexplained
+  material p99 regression under the p99-first criterion above. Final p99 mean is
+  +14.0%, final p99 median is +19.9%, and the final p99 range overlaps the base
+  range (base max 2.055 ms, final max 2.044 ms). The earlier extreme final
+  outliers therefore look like local fallback host/scheduler noise rather than a
+  repeatable response-writer tail regression.
 
 ## Final-head response-write mode evidence
 


### PR DESCRIPTION
**What changed and why**
Recorded the final same-host base-vs-final-head A/B evidence required to close issue #144. The evidence file now includes a clean zero-error rerun, explains the earlier `wrk` read-error caveat as keepalive max-request-cap noise, records final-head response-write mode counters, and addresses review feedback with the actual process-sampled invocation, response sizes, a retained 10-pair interleaved 64 KiB series, and an additional p99-focused 30s ABBA control.

**Related issues**
Closes #144

**Tests / evidence**
- `zig build -Doptimize=ReleaseFast` for `d39353267f51116e0d30bdccec3614b3019a12db`
- `zig build -Doptimize=ReleaseFast` for `e302ca96046ad724d541be026c17e904d4d6e90d`
- Same-host A/B, `wrk`, 10s samples, 2 threads / 10 connections, `TARDIGRADE_MAX_REQUESTS_PER_CONNECTION=0`, `TARDIGRADE_WORKER_THREADS=4`, process CPU sampled with `--pid`
- Small proxy `/health`: 2 B body, 567 B head+body; base 25250.717 req/s, final 25384.847 req/s, errors 0; final mode counters show `single_write`
- 64 KiB proxy `/payload-64k.bin`: 65,536 B body, 66,119 B head+body; 10 interleaved base/final pairs; final mean req/s -1.0%, final median req/s +0.2%, errors 0; final mode counters show `writev` with two iovecs per response
- 64 KiB p99 control: 30s ABBA samples with an explicit p99-first material criterion; base p99 range 1.210-2.055 ms, final p99 range 1.501-2.044 ms, final p99 mean +14.0%, final p99 median +19.9%, errors 0
- `zig fmt --check build.zig src/ tests/`
- `git diff --check`
- Previous full local suite: `zig build test --summary all` (60/60 steps; 3818/3828 tests passed, 10 skipped)

**Security impact**
None. Evidence-only benchmark documentation update.

**Performance impact**
Documents the targeted performance closeout for #144. No code path changed in this PR.

**Checklist**
- [x] `zig fmt --check build.zig src/ tests/` passes
- [x] `zig build test --summary all` green
- [x] `zig build test-integration` green (not run; no protocol/proxy/TLS code changed)
- [x] New behavior covered by tests/evidence
- [x] [docs/CODE_REVIEW_CHECKLIST.md](docs/CODE_REVIEW_CHECKLIST.md) completed
- [x] README / CHANGELOG updated if operator-visible behavior changed
