### PR TITLE
Wire circuit breaker into proxy request paths

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -399,9 +399,12 @@ Notes on the two pool-style resources called out in the issue:
   least-connections balancer sheds a saturated backend to the least-loaded
   healthy one and returns no candidate when every backend is unhealthy (the
   request is shed deterministically rather than queued without bound); the
-  circuit breaker fast-fails once a backend trips its failure threshold and
-  recovers through a single half-open probe. Both paths have fault-injection
-  coverage in `src/gateway_state.zig`.
+  process-wide circuit breaker fast-fails proxied requests with HTTP `503` and
+  JSON `"code":"upstream_circuit_open"` once upstream failures trip its
+  configured threshold, then recovers through a half-open probe after
+  `TARDIGRADE_CB_TIMEOUT_MS`. The state machine has focused coverage in
+  `src/gateway_state.zig`, and live proxy gating is covered in
+  `src/gateway_proxy_runtime.zig`.
 - **Log / metrics sink slow or unavailable** — access logging is best-effort and
   never blocks the request that emitted it. In buffered mode the buffer flushes
   at its configured threshold and is cleared regardless of the write outcome, so
@@ -445,7 +448,7 @@ regression test in `src/gateway_accept.zig`.
 | `413` / `431` / `414` in access logs | Oversized body, headers, or URI | Confirm the configured request limits match legitimate client traffic before raising them |
 | Tail latency spikes under many idle keepalive clients | Parked-connection backlog or too-long idle timeout | Watch parked `timeouts_total`; tune the idle-park timeout and `max_requests_per_connection` |
 | Gaps in access logs, throughput otherwise normal | Log sink (stderr pipe / syslog) slow or unavailable | Logging is best-effort: dropped lines are counted internally and the request path is never blocked; check the downstream log collector / pipe rather than the gateway |
-| All requests to one backend failing fast with no upstream contact | Circuit breaker open for that backend | Expected protection after repeated upstream failures; confirm the upstream is healthy — the breaker recovers via a half-open probe once `upstream_fail_timeout` elapses |
+| Proxied requests fail fast with `503` / `upstream_circuit_open` and no upstream contact | Circuit breaker open | Expected protection after repeated upstream failures; confirm the upstream is healthy — the breaker recovers via a half-open probe once `TARDIGRADE_CB_TIMEOUT_MS` elapses |
 
 Tuning principle: raise a limit only after confirming the gateway has headroom
 (CPU, memory, fds) to honor it. The limits exist so that exhaustion produces a

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -403,8 +403,10 @@ Notes on the two pool-style resources called out in the issue:
   JSON `"code":"upstream_circuit_open"` once upstream failures trip its
   configured threshold, then recovers through a half-open probe after
   `TARDIGRADE_CB_TIMEOUT_MS`. The state machine has focused coverage in
-  `src/gateway_state.zig`, and live proxy gating is covered in
-  `src/gateway_proxy_runtime.zig`.
+  `src/gateway_state.zig` and `src/gateway_proxy_runtime.zig`; live
+  open → half-open → closed behavior is covered by
+  `proxy.circuit_breaker_opens_fast_fails_and_recovers` in
+  `tests/integration.zig`.
 - **Log / metrics sink slow or unavailable** — access logging is best-effort and
   never blocks the request that emitted it. In buffered mode the buffer flushes
   at its configured threshold and is cleared regardless of the write outcome, so

--- a/docs/TIMEOUTS.md
+++ b/docs/TIMEOUTS.md
@@ -73,7 +73,8 @@ Two principles, from the #196/#141 arc:
   `upstream_timeout`** (`error.Timeout`/`error.WouldBlock`), and non-timeout
   upstream failures map to **502 `upstream_error`**. Saturation (`#239`
   active cap) is deliberately distinct: **503 `upstream_saturated`**, no
-  health impact.
+  health impact. An open circuit breaker is also distinct: **503
+  `upstream_circuit_open`**, no upstream contact.
 - Upstream timeouts count toward passive health / the circuit breaker;
   downstream write timeouts do not (client's fault, not the origin's).
 - Config validation warns on inconsistent relationships

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -705,7 +705,7 @@ itself is unhealthy.
 
 `503` here is a local capacity/availability signal, not a gateway or
 timeout failure — don't fold it into the 502/504 explanations above. There
-are four independent local-capacity families that all return `503`, and
+are five independent local-capacity/availability families that all return `503`, and
 they need different metrics/response bodies to tell apart:
 
 1. **Accept-time connection/worker-queue saturation** — the global or
@@ -722,7 +722,7 @@ they need different metrics/response bodies to tell apart:
    `Retry-After`, and does **not** move `connection_rejections_total`/
    `queue_rejections_total` — only `tardigrade_error_overload_total` moves.
    Flat connection/queue rejection counters alone don't identify this
-   family, though — families 3 and 4 below also leave those two flat;
+   family, though — families 3, 4, and 5 below also leave those two flat;
    `code:"overloaded"` plus `tardigrade_error_overload_total` rising is
    what actually identifies family 2 specifically.
 3. **Per-origin upstream connection-pool cap** —
@@ -736,11 +736,16 @@ they need different metrics/response bodies to tell apart:
    before any response byte is committed (`error.ProxyBufferCapacityUnavailable`).
    JSON `"code":"proxy_buffer_saturated"`, no `Retry-After`, connection
    closed.
+5. **Process-wide upstream circuit breaker open** —
+   `TARDIGRADE_CB_THRESHOLD` is enabled and recent confirmed upstream
+   failures opened the breaker. Requests fail before contacting the upstream
+   with JSON `"code":"upstream_circuit_open"`, no `Retry-After`, and recover
+   through a single half-open probe after `TARDIGRADE_CB_TIMEOUT_MS`.
 
 The response body's `code` field (`overloaded`/`upstream_saturated`/
-`proxy_buffer_saturated`) plus the family-specific counters below are what
-actually distinguish families 2–4 from each other — not the presence or
-absence of `Retry-After`.
+`proxy_buffer_saturated`/`upstream_circuit_open`) plus the family-specific
+counters below are what actually distinguish families 2–5 from each other —
+not the presence or absence of `Retry-After`.
 
 Marking backends unhealthy (passive failure tracking or active probing —
 see [§8](#8-health-checks-mark-an-upstream-down)) changes backend
@@ -753,17 +758,13 @@ necessarily a `503` — check the access log's `upstream_status`/
 `error_category` for the specific request rather than assuming `503` from
 health state alone.
 
-> `GatewayState`'s circuit-breaker fields
-> (`circuitTryAcquire`/`circuitRecordFailure`/`circuitRecordSuccess`) exist
-> and are unit-tested in isolation, but as of this writing they are not
-> called from the live proxy request path (`gateway_proxy.zig`,
-> `gateway_proxy_runtime.zig`, `gateway_control_plane_proxy.zig`,
-> `gateway_handlers.zig`) — only referenced in comments. Despite
-> `OBSERVABILITY.md`'s troubleshooting table describing a circuit-breaker-
-> open symptom, this guide does not document it as a live `503` cause.
-> Tracked by [#627](https://github.com/Bare-Systems/Tardigrade/issues/627);
-> treat any breaker-shaped symptom you observe as one of the causes above
-> instead until that issue resolves the discrepancy one way or the other.
+For `"code":"upstream_circuit_open"`, check whether the upstream has just
+returned repeated 5xx responses, timed out, reset streams, or failed
+protocol/connection handling. Local proxy capacity refusals, client upload
+errors, and downstream write failures do not trip the breaker. If the origin
+has recovered, wait at least `TARDIGRADE_CB_TIMEOUT_MS` for the half-open
+probe window; one probe is allowed through, and additional concurrent requests
+continue to fail fast until that probe succeeds.
 
 #### Concrete fixes
 

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -3319,16 +3319,16 @@ fn h2UnsupportedProxyOrchestration(cfg: *const edge_config.EdgeConfig, matched: 
         cfg.proxy_streaming_mode.responseStreamingEnabled(),
     )) return true;
 
-    // `upstream_max_fails`/`upstream_fail_timeout_ms` drive passive
-    // upstream health accounting that `handleLocationProxyPass` records
-    // around the low-level executor this path calls directly; skipping it
-    // means a configured circuit breaker silently never opens (or closes)
+    // `upstream_max_fails`/`upstream_fail_timeout_ms` and the process-wide
+    // circuit breaker depend on health/accounting that `handleLocationProxyPass`
+    // records around the low-level executor this path calls directly; skipping
+    // it means configured upstream protection silently never opens (or closes)
     // for traffic negotiated over H2. Deliberately NOT included:
     // `upstream_pool_enabled` -- it defaults to true, and connection
     // pooling itself is already correctly threaded through via
     // `state.upstream_pool`/`state.h2_pool` below, so treating it as
     // unsupported would fail closed on every H2 proxy_pass by default.
-    if (cfg.upstream_max_fails > 0) return true;
+    if (cfg.upstream_max_fails > 0 or cfg.cb_threshold > 0) return true;
 
     const pool = gs.upstreamPoolForScope(cfg, .global);
     return cfg.upstream_retry_attempts > 1 or

--- a/src/gateway_control_plane_proxy.zig
+++ b/src/gateway_control_plane_proxy.zig
@@ -8,6 +8,7 @@
 //! work can replace the current bounded-buffer compatibility executor.
 
 const compat = @import("zig_compat");
+const builtin = @import("builtin");
 const std = @import("std");
 const http = @import("http.zig");
 const edge_config = @import("edge_config.zig");
@@ -48,6 +49,7 @@ pub fn controlPlaneBufferedResponseLimit(cfg: *const edge_config.EdgeConfig) usi
 
 fn controlPlaneAttemptErrorCountsAsUpstreamFailure(err: anyerror) bool {
     return switch (err) {
+        error.ControlPlaneResponseMaterializationFailed,
         error.OutOfMemory,
         error.UpstreamUntrusted,
         error.UpstreamAtCapacity,
@@ -73,6 +75,21 @@ fn recordControlPlaneProxyFailure(
         state.circuitRecordFailurePermit(permit);
     } else {
         state.recordProxyUpstreamFailure(cfg, upstream_base_url, permit);
+    }
+}
+
+fn recordControlPlaneProxyStatus(
+    state: *GatewayState,
+    cfg: *const edge_config.EdgeConfig,
+    upstream_base_url: []const u8,
+    absolute_target: bool,
+    permit: http.circuit_breaker.Permit,
+    status: u16,
+) void {
+    if (status >= 500) {
+        recordControlPlaneProxyFailure(state, cfg, upstream_base_url, absolute_target, permit);
+    } else {
+        recordControlPlaneProxySuccess(state, cfg, upstream_base_url, absolute_target, permit);
     }
 }
 
@@ -154,6 +171,7 @@ pub const ControlPlaneProxyResult = struct {
     set_cookie: ?[]u8,
     cacheable: bool,
     upstream_addr: []const u8,
+    accounted: bool = false,
 };
 
 pub const ControlPlaneProxyExecution = union(enum) {
@@ -387,7 +405,7 @@ pub fn executeBoundedControlPlaneJsonProxy(
                 absolute_proxy_target,
                 circuit_permit,
             ) catch |err| {
-                if (err == error.DownstreamWriteFailed) return err;
+                if (err == error.DownstreamWriteFailed or err == error.ControlPlaneResponseMaterializationFailed) return err;
                 if (controlPlaneAttemptErrorCountsAsUpstreamFailure(err)) {
                     recordControlPlaneProxyFailure(state, cfg, upstream_base_url, absolute_proxy_target, circuit_permit);
                 } else {
@@ -413,8 +431,10 @@ pub fn executeBoundedControlPlaneJsonProxy(
                 return exec;
             },
             .buffered => |res| {
+                if (!res.accounted) {
+                    recordControlPlaneProxyStatus(state, cfg, upstream_base_url, absolute_proxy_target, circuit_permit, res.status);
+                }
                 if (res.status >= 500) {
-                    recordControlPlaneProxyFailure(state, cfg, upstream_base_url, absolute_proxy_target, circuit_permit);
                     if (attempt + 1 < max_attempts) {
                         allocator.free(res.body);
                         allocator.free(res.content_type);
@@ -423,8 +443,6 @@ pub fn executeBoundedControlPlaneJsonProxy(
                         if (res.set_cookie) |cookie| allocator.free(cookie);
                         continue;
                     }
-                } else {
-                    recordControlPlaneProxySuccess(state, cfg, upstream_base_url, absolute_proxy_target, circuit_permit);
                 }
                 return exec;
             },
@@ -581,19 +599,16 @@ fn executeBoundedControlPlaneJsonProxyAttempt(
         const upstream_reason = buffered_resp.reason;
         const upstream_content_type = buffered_resp.headerValue("Content-Type") orelse JSON_CONTENT_TYPE;
         const upstream_content_disposition = buffered_resp.headerValue("Content-Disposition");
+        recordControlPlaneProxyStatus(state, cfg, upstream_base_url, absolute_proxy_target, circuit_permit, status_code);
+        try maybeFailControlPlaneMaterializationAfterStatus();
         const upstream_location = if (buffered_resp.headerValue("Location")) |location|
-            try allocator.dupe(u8, location)
+            allocator.dupe(u8, location) catch return error.ControlPlaneResponseMaterializationFailed
         else
             null;
         errdefer if (upstream_location) |location| allocator.free(location);
         const cacheable = !bufferedUpstreamResponseHasNoStore(&buffered_resp);
         const stream_status = enable_streaming_success and (status_code == 200 or cfg.proxy_stream_all_statuses);
         if (stream_status) {
-            if (status_code >= 500) {
-                recordControlPlaneProxyFailure(state, cfg, upstream_base_url, absolute_proxy_target, circuit_permit);
-            } else {
-                recordControlPlaneProxySuccess(state, cfg, upstream_base_url, absolute_proxy_target, circuit_permit);
-            }
             writeStreamedUpstreamResponse(
                 downstream_writer,
                 status_code,
@@ -613,15 +628,15 @@ fn executeBoundedControlPlaneJsonProxyAttempt(
         }
 
         if (status_code != 200) {
-            const buffered_content_type = try allocator.dupe(u8, upstream_content_type);
+            const buffered_content_type = allocator.dupe(u8, upstream_content_type) catch return error.ControlPlaneResponseMaterializationFailed;
             errdefer allocator.free(buffered_content_type);
             const buffered_content_disposition = if (upstream_content_disposition) |cd|
-                try allocator.dupe(u8, cd)
+                allocator.dupe(u8, cd) catch return error.ControlPlaneResponseMaterializationFailed
             else
                 null;
             errdefer if (buffered_content_disposition) |cd| allocator.free(cd);
             const buffered_set_cookie = if (sticky_set_cookie) |cookie|
-                try allocator.dupe(u8, cookie)
+                allocator.dupe(u8, cookie) catch return error.ControlPlaneResponseMaterializationFailed
             else
                 null;
             errdefer if (buffered_set_cookie) |cookie| allocator.free(cookie);
@@ -649,21 +664,22 @@ fn executeBoundedControlPlaneJsonProxyAttempt(
                     .set_cookie = buffered_set_cookie,
                     .cacheable = false,
                     .upstream_addr = upstream_host,
+                    .accounted = true,
                 },
             };
         }
 
-        const body = try allocator.dupe(u8, buffered_resp.body);
+        const body = allocator.dupe(u8, buffered_resp.body) catch return error.ControlPlaneResponseMaterializationFailed;
         errdefer allocator.free(body);
-        const buffered_content_type = try allocator.dupe(u8, upstream_content_type);
+        const buffered_content_type = allocator.dupe(u8, upstream_content_type) catch return error.ControlPlaneResponseMaterializationFailed;
         errdefer allocator.free(buffered_content_type);
         const buffered_content_disposition = if (upstream_content_disposition) |cd|
-            try allocator.dupe(u8, cd)
+            allocator.dupe(u8, cd) catch return error.ControlPlaneResponseMaterializationFailed
         else
             null;
         errdefer if (buffered_content_disposition) |cd| allocator.free(cd);
         const buffered_set_cookie = if (sticky_set_cookie) |cookie|
-            try allocator.dupe(u8, cookie)
+            allocator.dupe(u8, cookie) catch return error.ControlPlaneResponseMaterializationFailed
         else
             null;
         errdefer if (buffered_set_cookie) |cookie| allocator.free(cookie);
@@ -690,9 +706,16 @@ fn executeBoundedControlPlaneJsonProxyAttempt(
                 .set_cookie = buffered_set_cookie,
                 .cacheable = cacheable,
                 .upstream_addr = upstream_host,
+                .accounted = true,
             },
         };
     }
+}
+
+var test_fail_control_plane_materialization_after_status: bool = false;
+
+fn maybeFailControlPlaneMaterializationAfterStatus() !void {
+    if (builtin.is_test and test_fail_control_plane_materialization_after_status) return error.ControlPlaneResponseMaterializationFailed;
 }
 
 test "control-plane buffered response limit is explicit and bounded" {
@@ -942,6 +965,103 @@ test "control-plane downstream streaming write failure records known 500 and nev
         FailingControlPlaneDownstreamWriter{},
         &state,
         true,
+        null,
+    ));
+
+    try std.testing.expectEqual(@as(usize, 1), origin.requestCount());
+    try std.testing.expectEqual(@as(usize, 0), state.upstreamUnhealthyCount());
+    try std.testing.expectEqualStrings("open", state.circuitStateName());
+    try std.testing.expect(state.circuitTryAcquirePermit() != null);
+}
+
+test "control-plane post-status materialization failure records known 200 and never retries" {
+    const allocator = std.testing.allocator;
+    var origin = try ControlPlaneTestOrigin.start(allocator, &.{ 200, 200 });
+    defer origin.stop();
+    try origin.run();
+
+    var state: GatewayState = undefined;
+    initControlPlaneProxyTestState(&state, allocator);
+    defer deinitControlPlaneProxyTestState(&state);
+    var cfg = initControlPlaneProxyTestConfig("http://configured.example");
+    cfg.upstream_retry_idempotent_only = false;
+    cfg.upstream_retry_attempts = 3;
+    const target = try std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}/api", .{origin.port()});
+    defer allocator.free(target);
+    state.circuit_breaker = http.circuit_breaker.CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0, .half_open_successes = 1 });
+    state.circuitRecordFailurePermit(state.circuitTryAcquirePermit().?);
+
+    test_fail_control_plane_materialization_after_status = true;
+    defer test_fail_control_plane_materialization_after_status = false;
+    var body_buf: [1024]u8 = undefined;
+    var body_writer = compat.fixedBufferStream(&body_buf);
+    try std.testing.expectError(error.ControlPlaneResponseMaterializationFailed, executeBoundedControlPlaneJsonProxy(
+        allocator,
+        &cfg,
+        .global,
+        target,
+        null,
+        "{}",
+        "test-correlation",
+        "127.0.0.1",
+        null,
+        null,
+        null,
+        null,
+        null,
+        "localhost",
+        null,
+        body_writer.writer(),
+        &state,
+        false,
+        null,
+    ));
+
+    try std.testing.expectEqual(@as(usize, 1), origin.requestCount());
+    try std.testing.expectEqual(@as(usize, 0), state.upstreamUnhealthyCount());
+    try std.testing.expectEqualStrings("closed", state.circuitStateName());
+}
+
+test "control-plane post-status materialization failure records known 500 and never retries" {
+    const allocator = std.testing.allocator;
+    var origin = try ControlPlaneTestOrigin.start(allocator, &.{ 500, 500 });
+    defer origin.stop();
+    try origin.run();
+
+    var state: GatewayState = undefined;
+    initControlPlaneProxyTestState(&state, allocator);
+    defer deinitControlPlaneProxyTestState(&state);
+    var cfg = initControlPlaneProxyTestConfig("http://configured.example");
+    cfg.upstream_retry_idempotent_only = false;
+    cfg.upstream_retry_attempts = 3;
+    const target = try std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}/api", .{origin.port()});
+    defer allocator.free(target);
+    state.circuit_breaker = http.circuit_breaker.CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0, .half_open_successes = 1 });
+    state.circuitRecordFailurePermit(state.circuitTryAcquirePermit().?);
+
+    test_fail_control_plane_materialization_after_status = true;
+    defer test_fail_control_plane_materialization_after_status = false;
+    var body_buf: [1024]u8 = undefined;
+    var body_writer = compat.fixedBufferStream(&body_buf);
+    try std.testing.expectError(error.ControlPlaneResponseMaterializationFailed, executeBoundedControlPlaneJsonProxy(
+        allocator,
+        &cfg,
+        .global,
+        target,
+        null,
+        "{}",
+        "test-correlation",
+        "127.0.0.1",
+        null,
+        null,
+        null,
+        null,
+        null,
+        "localhost",
+        null,
+        body_writer.writer(),
+        &state,
+        false,
         null,
     ));
 

--- a/src/gateway_control_plane_proxy.zig
+++ b/src/gateway_control_plane_proxy.zig
@@ -326,7 +326,7 @@ pub fn executeBoundedControlPlaneJsonProxy(
         else
             null;
         defer if (sticky_set_cookie) |cookie| allocator.free(cookie);
-        if (!state.circuitTryAcquire()) return error.CircuitOpen;
+        const circuit_permit = state.circuitTryAcquirePermit() orelse return error.CircuitOpen;
         state.recordUpstreamAttemptStart(upstream_base_url);
         const exec = blk: {
             defer state.recordUpstreamAttemptEnd(upstream_base_url);
@@ -354,9 +354,9 @@ pub fn executeBoundedControlPlaneJsonProxy(
                 sticky_set_cookie,
             ) catch |err| {
                 if (controlPlaneAttemptErrorCountsAsUpstreamFailure(err)) {
-                    state.recordProxyUpstreamFailure(cfg, upstream_base_url);
+                    state.recordProxyUpstreamFailure(cfg, upstream_base_url, circuit_permit);
                 } else {
-                    state.circuitReleaseProbe();
+                    state.circuitReleasePermit(circuit_permit);
                 }
                 last_err = err;
                 if (attempt + 1 < max_attempts) {
@@ -369,15 +369,15 @@ pub fn executeBoundedControlPlaneJsonProxy(
         switch (exec) {
             .streamed_status => |streamed| {
                 if (streamed.status >= 500) {
-                    state.recordProxyUpstreamFailure(cfg, upstream_base_url);
+                    state.recordProxyUpstreamFailure(cfg, upstream_base_url, circuit_permit);
                 } else {
-                    state.recordProxyUpstreamSuccess(cfg, upstream_base_url);
+                    state.recordProxyUpstreamSuccess(cfg, upstream_base_url, circuit_permit);
                 }
                 return exec;
             },
             .buffered => |res| {
                 if (res.status >= 500) {
-                    state.recordProxyUpstreamFailure(cfg, upstream_base_url);
+                    state.recordProxyUpstreamFailure(cfg, upstream_base_url, circuit_permit);
                     if (attempt + 1 < max_attempts) {
                         allocator.free(res.body);
                         allocator.free(res.content_type);
@@ -387,7 +387,7 @@ pub fn executeBoundedControlPlaneJsonProxy(
                         continue;
                     }
                 } else {
-                    state.recordProxyUpstreamSuccess(cfg, upstream_base_url);
+                    state.recordProxyUpstreamSuccess(cfg, upstream_base_url, circuit_permit);
                 }
                 return exec;
             },

--- a/src/gateway_control_plane_proxy.zig
+++ b/src/gateway_control_plane_proxy.zig
@@ -160,6 +160,7 @@ pub const ControlPlaneProxyExecution = union(enum) {
     streamed_status: struct {
         status: u16,
         upstream_addr: []const u8,
+        accounted: bool = false,
     },
     buffered: ControlPlaneProxyResult,
 };
@@ -383,7 +384,10 @@ pub fn executeBoundedControlPlaneJsonProxy(
                 state,
                 enable_streaming_success,
                 sticky_set_cookie,
+                absolute_proxy_target,
+                circuit_permit,
             ) catch |err| {
+                if (err == error.DownstreamWriteFailed) return err;
                 if (controlPlaneAttemptErrorCountsAsUpstreamFailure(err)) {
                     recordControlPlaneProxyFailure(state, cfg, upstream_base_url, absolute_proxy_target, circuit_permit);
                 } else {
@@ -399,10 +403,12 @@ pub fn executeBoundedControlPlaneJsonProxy(
         };
         switch (exec) {
             .streamed_status => |streamed| {
-                if (streamed.status >= 500) {
-                    recordControlPlaneProxyFailure(state, cfg, upstream_base_url, absolute_proxy_target, circuit_permit);
-                } else {
-                    recordControlPlaneProxySuccess(state, cfg, upstream_base_url, absolute_proxy_target, circuit_permit);
+                if (!streamed.accounted) {
+                    if (streamed.status >= 500) {
+                        recordControlPlaneProxyFailure(state, cfg, upstream_base_url, absolute_proxy_target, circuit_permit);
+                    } else {
+                        recordControlPlaneProxySuccess(state, cfg, upstream_base_url, absolute_proxy_target, circuit_permit);
+                    }
                 }
                 return exec;
             },
@@ -450,6 +456,8 @@ fn executeBoundedControlPlaneJsonProxyAttempt(
     state: *GatewayState,
     enable_streaming_success: bool,
     sticky_set_cookie: ?[]const u8,
+    absolute_proxy_target: bool,
+    circuit_permit: http.circuit_breaker.Permit,
 ) !ControlPlaneProxyExecution {
     const proxy_json_extra_header_slack = 12;
     const proxy_json_owned_header_value_slack = 3;
@@ -581,6 +589,11 @@ fn executeBoundedControlPlaneJsonProxyAttempt(
         const cacheable = !bufferedUpstreamResponseHasNoStore(&buffered_resp);
         const stream_status = enable_streaming_success and (status_code == 200 or cfg.proxy_stream_all_statuses);
         if (stream_status) {
+            if (status_code >= 500) {
+                recordControlPlaneProxyFailure(state, cfg, upstream_base_url, absolute_proxy_target, circuit_permit);
+            } else {
+                recordControlPlaneProxySuccess(state, cfg, upstream_base_url, absolute_proxy_target, circuit_permit);
+            }
             writeStreamedUpstreamResponse(
                 downstream_writer,
                 status_code,
@@ -596,7 +609,7 @@ fn executeBoundedControlPlaneJsonProxyAttempt(
                 writeChunk(downstream_writer, buffered_resp.body) catch return error.DownstreamWriteFailed;
             }
             downstream_writer.writeAll("0\r\n\r\n") catch return error.DownstreamWriteFailed;
-            return .{ .streamed_status = .{ .status = status_code, .upstream_addr = upstream_host } };
+            return .{ .streamed_status = .{ .status = status_code, .upstream_addr = upstream_host, .accounted = true } };
         }
 
         if (status_code != 200) {
@@ -848,7 +861,7 @@ fn deinitControlPlaneProxyTestState(state: *GatewayState) void {
     state.h2_pool.deinit();
 }
 
-test "control-plane downstream streaming write failure stays neutral for health and circuit" {
+test "control-plane downstream streaming write failure records known 200 and never retries" {
     const allocator = std.testing.allocator;
     var origin = try ControlPlaneTestOrigin.start(allocator, &.{200});
     defer origin.stop();
@@ -858,8 +871,12 @@ test "control-plane downstream streaming write failure stays neutral for health 
     initControlPlaneProxyTestState(&state, allocator);
     defer deinitControlPlaneProxyTestState(&state);
     var cfg = initControlPlaneProxyTestConfig("http://configured.example");
+    cfg.upstream_retry_idempotent_only = false;
+    cfg.upstream_retry_attempts = 3;
     const target = try std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}/api", .{origin.port()});
     defer allocator.free(target);
+    state.circuit_breaker = http.circuit_breaker.CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0, .half_open_successes = 1 });
+    state.circuitRecordFailurePermit(state.circuitTryAcquirePermit().?);
 
     try std.testing.expectError(error.DownstreamWriteFailed, executeBoundedControlPlaneJsonProxy(
         allocator,
@@ -885,8 +902,53 @@ test "control-plane downstream streaming write failure stays neutral for health 
 
     try std.testing.expectEqual(@as(usize, 1), origin.requestCount());
     try std.testing.expectEqual(@as(usize, 0), state.upstreamUnhealthyCount());
-    try std.testing.expect(state.circuitTryAcquirePermit() != null);
     try std.testing.expectEqualStrings("closed", state.circuitStateName());
+}
+
+test "control-plane downstream streaming write failure records known 500 and never retries" {
+    const allocator = std.testing.allocator;
+    var origin = try ControlPlaneTestOrigin.start(allocator, &.{500});
+    defer origin.stop();
+    try origin.run();
+
+    var state: GatewayState = undefined;
+    initControlPlaneProxyTestState(&state, allocator);
+    defer deinitControlPlaneProxyTestState(&state);
+    var cfg = initControlPlaneProxyTestConfig("http://configured.example");
+    cfg.proxy_stream_all_statuses = true;
+    cfg.upstream_retry_idempotent_only = false;
+    cfg.upstream_retry_attempts = 3;
+    const target = try std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}/api", .{origin.port()});
+    defer allocator.free(target);
+    state.circuit_breaker = http.circuit_breaker.CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0, .half_open_successes = 1 });
+    state.circuitRecordFailurePermit(state.circuitTryAcquirePermit().?);
+
+    try std.testing.expectError(error.DownstreamWriteFailed, executeBoundedControlPlaneJsonProxy(
+        allocator,
+        &cfg,
+        .global,
+        target,
+        null,
+        "{}",
+        "test-correlation",
+        "127.0.0.1",
+        null,
+        null,
+        null,
+        null,
+        null,
+        "localhost",
+        null,
+        FailingControlPlaneDownstreamWriter{},
+        &state,
+        true,
+        null,
+    ));
+
+    try std.testing.expectEqual(@as(usize, 1), origin.requestCount());
+    try std.testing.expectEqual(@as(usize, 0), state.upstreamUnhealthyCount());
+    try std.testing.expectEqualStrings("open", state.circuitStateName());
+    try std.testing.expect(state.circuitTryAcquirePermit() != null);
 }
 
 test "control-plane absolute target outcomes do not mutate configured passive health" {

--- a/src/gateway_control_plane_proxy.zig
+++ b/src/gateway_control_plane_proxy.zig
@@ -45,6 +45,21 @@ pub fn controlPlaneBufferedResponseLimit(cfg: *const edge_config.EdgeConfig) usi
         DEFAULT_CONTROL_PLANE_BUFFERED_RESPONSE_LIMIT;
 }
 
+fn controlPlaneAttemptErrorCountsAsUpstreamFailure(err: anyerror) bool {
+    return switch (err) {
+        error.OutOfMemory,
+        error.UpstreamUntrusted,
+        error.UpstreamAtCapacity,
+        error.CircuitOpen,
+        error.InvalidUri,
+        error.InvalidFormat,
+        error.UnsupportedUriScheme,
+        error.MissingUriHost,
+        => false,
+        else => true,
+    };
+}
+
 pub fn buildProxyCacheKey(
     allocator: std.mem.Allocator,
     key_template: []const u8,
@@ -338,7 +353,11 @@ pub fn executeBoundedControlPlaneJsonProxy(
                 enable_streaming_success,
                 sticky_set_cookie,
             ) catch |err| {
-                state.recordUpstreamFailure(cfg, upstream_base_url);
+                if (controlPlaneAttemptErrorCountsAsUpstreamFailure(err)) {
+                    state.recordProxyUpstreamFailure(cfg, upstream_base_url);
+                } else {
+                    state.circuitReleaseProbe();
+                }
                 last_err = err;
                 if (attempt + 1 < max_attempts) {
                     state.logger.warn(correlation_id, "upstream attempt {d}/{d} failed: {}", .{ attempt + 1, max_attempts, err });
@@ -350,15 +369,15 @@ pub fn executeBoundedControlPlaneJsonProxy(
         switch (exec) {
             .streamed_status => |streamed| {
                 if (streamed.status >= 500) {
-                    state.recordUpstreamFailure(cfg, upstream_base_url);
+                    state.recordProxyUpstreamFailure(cfg, upstream_base_url);
                 } else {
-                    state.recordUpstreamSuccess(cfg, upstream_base_url);
+                    state.recordProxyUpstreamSuccess(cfg, upstream_base_url);
                 }
                 return exec;
             },
             .buffered => |res| {
                 if (res.status >= 500) {
-                    state.recordUpstreamFailure(cfg, upstream_base_url);
+                    state.recordProxyUpstreamFailure(cfg, upstream_base_url);
                     if (attempt + 1 < max_attempts) {
                         allocator.free(res.body);
                         allocator.free(res.content_type);
@@ -368,7 +387,7 @@ pub fn executeBoundedControlPlaneJsonProxy(
                         continue;
                     }
                 } else {
-                    state.recordUpstreamSuccess(cfg, upstream_base_url);
+                    state.recordProxyUpstreamSuccess(cfg, upstream_base_url);
                 }
                 return exec;
             },

--- a/src/gateway_control_plane_proxy.zig
+++ b/src/gateway_control_plane_proxy.zig
@@ -19,6 +19,7 @@ const StickyUpstreamSelection = gs.StickyUpstreamSelection;
 const upstreamPoolForScope = gs.upstreamPoolForScope;
 const upstreamScopeName = gs.upstreamScopeName;
 const buildStickySetCookieHeader = gs.buildStickySetCookieHeader;
+const isAbsoluteHttpUrl = gs.isAbsoluteHttpUrl;
 const gp = @import("gateway_proxy.zig");
 const resolveProxyTarget = gp.resolveProxyTarget;
 const buildForwardedFor = gp.buildForwardedFor;
@@ -51,6 +52,7 @@ fn controlPlaneAttemptErrorCountsAsUpstreamFailure(err: anyerror) bool {
         error.UpstreamUntrusted,
         error.UpstreamAtCapacity,
         error.CircuitOpen,
+        error.DownstreamWriteFailed,
         error.InvalidUri,
         error.InvalidFormat,
         error.UnsupportedUriScheme,
@@ -58,6 +60,34 @@ fn controlPlaneAttemptErrorCountsAsUpstreamFailure(err: anyerror) bool {
         => false,
         else => true,
     };
+}
+
+fn recordControlPlaneProxyFailure(
+    state: *GatewayState,
+    cfg: *const edge_config.EdgeConfig,
+    upstream_base_url: []const u8,
+    absolute_target: bool,
+    permit: http.circuit_breaker.Permit,
+) void {
+    if (absolute_target) {
+        state.circuitRecordFailurePermit(permit);
+    } else {
+        state.recordProxyUpstreamFailure(cfg, upstream_base_url, permit);
+    }
+}
+
+fn recordControlPlaneProxySuccess(
+    state: *GatewayState,
+    cfg: *const edge_config.EdgeConfig,
+    upstream_base_url: []const u8,
+    absolute_target: bool,
+    permit: http.circuit_breaker.Permit,
+) void {
+    if (absolute_target) {
+        state.circuitRecordSuccessPermit(permit);
+    } else {
+        state.recordProxyUpstreamSuccess(cfg, upstream_base_url, permit);
+    }
 }
 
 pub fn buildProxyCacheKey(
@@ -301,6 +331,7 @@ pub fn executeBoundedControlPlaneJsonProxy(
     const max_attempts: usize = if (cfg.upstream_retry_idempotent_only) 1 else configured_attempts;
     const start_ms = http.event_loop.monotonicMs();
     const upstream_hash_key = if (payload.len > 0) payload else (suffix_path orelse proxy_pass_target);
+    const absolute_proxy_target = isAbsoluteHttpUrl(std.mem.trim(u8, proxy_pass_target, " \t\r\n"));
 
     var attempt: usize = 0;
     var last_err: ?anyerror = null;
@@ -354,7 +385,7 @@ pub fn executeBoundedControlPlaneJsonProxy(
                 sticky_set_cookie,
             ) catch |err| {
                 if (controlPlaneAttemptErrorCountsAsUpstreamFailure(err)) {
-                    state.recordProxyUpstreamFailure(cfg, upstream_base_url, circuit_permit);
+                    recordControlPlaneProxyFailure(state, cfg, upstream_base_url, absolute_proxy_target, circuit_permit);
                 } else {
                     state.circuitReleasePermit(circuit_permit);
                 }
@@ -369,15 +400,15 @@ pub fn executeBoundedControlPlaneJsonProxy(
         switch (exec) {
             .streamed_status => |streamed| {
                 if (streamed.status >= 500) {
-                    state.recordProxyUpstreamFailure(cfg, upstream_base_url, circuit_permit);
+                    recordControlPlaneProxyFailure(state, cfg, upstream_base_url, absolute_proxy_target, circuit_permit);
                 } else {
-                    state.recordProxyUpstreamSuccess(cfg, upstream_base_url, circuit_permit);
+                    recordControlPlaneProxySuccess(state, cfg, upstream_base_url, absolute_proxy_target, circuit_permit);
                 }
                 return exec;
             },
             .buffered => |res| {
                 if (res.status >= 500) {
-                    state.recordProxyUpstreamFailure(cfg, upstream_base_url, circuit_permit);
+                    recordControlPlaneProxyFailure(state, cfg, upstream_base_url, absolute_proxy_target, circuit_permit);
                     if (attempt + 1 < max_attempts) {
                         allocator.free(res.body);
                         allocator.free(res.content_type);
@@ -387,7 +418,7 @@ pub fn executeBoundedControlPlaneJsonProxy(
                         continue;
                     }
                 } else {
-                    state.recordProxyUpstreamSuccess(cfg, upstream_base_url, circuit_permit);
+                    recordControlPlaneProxySuccess(state, cfg, upstream_base_url, absolute_proxy_target, circuit_permit);
                 }
                 return exec;
             },
@@ -550,7 +581,7 @@ fn executeBoundedControlPlaneJsonProxyAttempt(
         const cacheable = !bufferedUpstreamResponseHasNoStore(&buffered_resp);
         const stream_status = enable_streaming_success and (status_code == 200 or cfg.proxy_stream_all_statuses);
         if (stream_status) {
-            try writeStreamedUpstreamResponse(
+            writeStreamedUpstreamResponse(
                 downstream_writer,
                 status_code,
                 upstream_reason,
@@ -560,11 +591,11 @@ fn executeBoundedControlPlaneJsonProxyAttempt(
                 &state.security_headers,
                 state.http3_alt_svc,
                 sticky_set_cookie,
-            );
+            ) catch return error.DownstreamWriteFailed;
             if (buffered_resp.body.len > 0) {
-                try writeChunk(downstream_writer, buffered_resp.body);
+                writeChunk(downstream_writer, buffered_resp.body) catch return error.DownstreamWriteFailed;
             }
-            try downstream_writer.writeAll("0\r\n\r\n");
+            downstream_writer.writeAll("0\r\n\r\n") catch return error.DownstreamWriteFailed;
             return .{ .streamed_status = .{ .status = status_code, .upstream_addr = upstream_host } };
         }
 
@@ -661,6 +692,293 @@ test "control-plane buffered response limit is explicit and bounded" {
 
     cfg.max_connection_memory_bytes = 512 * 1024;
     try std.testing.expectEqual(@as(usize, 512 * 1024), controlPlaneBufferedResponseLimit(&cfg));
+}
+
+const ControlPlaneTestOrigin = struct {
+    listen_fd: std.posix.fd_t,
+    listen_port: u16,
+    statuses: []const u16,
+    request_count: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+    thread: ?std.Thread = null,
+
+    fn start(allocator: std.mem.Allocator, statuses: []const u16) !ControlPlaneTestOrigin {
+        _ = allocator;
+        const listen_fd = std.c.socket(std.posix.AF.INET, std.posix.SOCK.STREAM, std.posix.IPPROTO.TCP);
+        try std.testing.expect(listen_fd >= 0);
+        _ = std.c.setsockopt(listen_fd, std.posix.SOL.SOCKET, std.posix.SO.REUSEADDR, std.mem.asBytes(&@as(c_int, 1)), @sizeOf(c_int));
+        var sin = std.c.sockaddr.in{
+            .family = std.posix.AF.INET,
+            .port = std.mem.nativeToBig(u16, 0),
+            .addr = std.mem.nativeToBig(u32, 0x7f000001),
+            .zero = [_]u8{0} ** 8,
+        };
+        try std.testing.expect(std.c.bind(listen_fd, @ptrCast(&sin), @sizeOf(std.c.sockaddr.in)) == 0);
+        try std.testing.expect(std.c.listen(listen_fd, 8) == 0);
+        var bound: std.c.sockaddr.in = undefined;
+        var bound_len: std.c.socklen_t = @sizeOf(std.c.sockaddr.in);
+        try std.testing.expect(std.c.getsockname(listen_fd, @ptrCast(&bound), &bound_len) == 0);
+        return .{
+            .listen_fd = listen_fd,
+            .listen_port = std.mem.bigToNative(u16, bound.port),
+            .statuses = statuses,
+        };
+    }
+
+    fn run(self: *ControlPlaneTestOrigin) !void {
+        self.thread = try std.Thread.spawn(.{}, ControlPlaneTestOrigin.serve, .{self});
+    }
+
+    fn stop(self: *ControlPlaneTestOrigin) void {
+        _ = std.c.close(self.listen_fd);
+        if (self.thread) |thread| thread.join();
+        self.thread = null;
+    }
+
+    fn port(self: *const ControlPlaneTestOrigin) u16 {
+        return self.listen_port;
+    }
+
+    fn requestCount(self: *const ControlPlaneTestOrigin) usize {
+        return self.request_count.load(.monotonic);
+    }
+
+    fn serve(self: *ControlPlaneTestOrigin) void {
+        while (self.request_count.load(.monotonic) < self.statuses.len) {
+            const fd = std.c.accept(self.listen_fd, null, null);
+            if (fd < 0) return;
+            defer _ = std.c.close(fd);
+            var req_buf: [2048]u8 = undefined;
+            _ = std.c.read(fd, &req_buf, req_buf.len);
+            const idx = self.request_count.fetchAdd(1, .monotonic);
+            const status = self.statuses[@min(idx, self.statuses.len - 1)];
+            const body = if (status == 200) "ok" else "fail";
+            var response_buf: [256]u8 = undefined;
+            const response = std.fmt.bufPrint(&response_buf, "HTTP/1.1 {d} test\r\nContent-Type: application/json\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n{s}", .{
+                status,
+                body.len,
+                body,
+            }) catch return;
+            _ = std.c.write(fd, response.ptr, response.len);
+        }
+    }
+};
+
+const FailingControlPlaneDownstreamWriter = struct {
+    pub fn writeAll(_: FailingControlPlaneDownstreamWriter, _: []const u8) !void {
+        return error.TestDownstreamWriteFailed;
+    }
+
+    pub fn print(self: FailingControlPlaneDownstreamWriter, comptime _: []const u8, _: anytype) !void {
+        return self.writeAll("");
+    }
+};
+
+fn initControlPlaneProxyTestConfig(upstream_base_url: []const u8) edge_config.EdgeConfig {
+    var cfg: edge_config.EdgeConfig = undefined;
+    cfg.upstream_base_url = upstream_base_url;
+    cfg.upstream_base_urls = &.{};
+    cfg.upstream_base_url_weights = &.{};
+    cfg.upstream_backup_base_urls = &.{};
+    cfg.upstream_chat_base_urls = &.{};
+    cfg.upstream_chat_base_url_weights = &.{};
+    cfg.upstream_chat_backup_base_urls = &.{};
+    cfg.upstream_commands_base_urls = &.{};
+    cfg.upstream_commands_base_url_weights = &.{};
+    cfg.upstream_commands_backup_base_urls = &.{};
+    cfg.upstream_retry_attempts = 1;
+    cfg.upstream_retry_idempotent_only = true;
+    cfg.upstream_timeout_ms = 1000;
+    cfg.upstream_connect_timeout_ms = 1000;
+    cfg.upstream_response_timeout_ms = 1000;
+    cfg.upstream_timeout_budget_ms = 0;
+    cfg.upstream_gunzip_enabled = false;
+    cfg.upstream_pool_enabled = false;
+    cfg.upstream_pool_max_active_per_host = 0;
+    cfg.upstream_pool_max_idle_per_host = 0;
+    cfg.upstream_pool_idle_timeout_ms = 0;
+    cfg.upstream_pool_max_lifetime_ms = 0;
+    cfg.upstream_tls_verify = false;
+    cfg.upstream_tls_ca_bundle = "";
+    cfg.upstream_tls_server_name = "";
+    cfg.upstream_tls_client_cert = "";
+    cfg.upstream_tls_client_key = "";
+    cfg.trust_require_upstream_identity = false;
+    cfg.trust_shared_secret = "";
+    cfg.trust_gateway_id = "";
+    cfg.trusted_upstream_identities = &.{};
+    cfg.max_connection_memory_bytes = 0;
+    cfg.upstream_max_fails = 1;
+    cfg.upstream_fail_timeout_ms = 60_000;
+    cfg.upstream_active_health_interval_ms = 0;
+    cfg.upstream_slow_start_ms = 0;
+    cfg.proxy_stream_all_statuses = false;
+    cfg.tls_cert_path = "";
+    cfg.tls_key_path = "";
+    return cfg;
+}
+
+fn initControlPlaneProxyTestState(state: *GatewayState, allocator: std.mem.Allocator) void {
+    state.allocator = allocator;
+    state.upstream_mutex = .{};
+    state.circuit_mutex = .{};
+    state.metrics_mutex = .{};
+    state.transcript_mutex = .{};
+    state.metrics = http.metrics.Metrics.init();
+    state.logger = http.logger.Logger.init(.err, "test");
+    state.security_headers = .{};
+    state.http3_alt_svc = null;
+    state.transcript_store_path = "";
+    state.upstream_rr_index = 0;
+    state.upstream_backup_rr_index = 0;
+    state.circuit_breaker = http.circuit_breaker.CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 30_000 });
+    state.upstream_health = std.StringHashMap(gs.UpstreamHealth).init(allocator);
+    state.upstream_active_requests = std.StringHashMap(usize).init(allocator);
+    state.upstream_pool = http.upstream_pool.UpstreamPool.init(allocator, .{});
+    state.h2_pool = http.upstream_h2.H2ConnPool.init(allocator, .{});
+}
+
+fn deinitControlPlaneProxyTestState(state: *GatewayState) void {
+    var h_it = state.upstream_health.iterator();
+    while (h_it.next()) |entry| state.allocator.free(entry.key_ptr.*);
+    state.upstream_health.deinit();
+    var a_it = state.upstream_active_requests.iterator();
+    while (a_it.next()) |entry| state.allocator.free(entry.key_ptr.*);
+    state.upstream_active_requests.deinit();
+    state.upstream_pool.deinit();
+    state.h2_pool.deinit();
+}
+
+test "control-plane downstream streaming write failure stays neutral for health and circuit" {
+    const allocator = std.testing.allocator;
+    var origin = try ControlPlaneTestOrigin.start(allocator, &.{200});
+    defer origin.stop();
+    try origin.run();
+
+    var state: GatewayState = undefined;
+    initControlPlaneProxyTestState(&state, allocator);
+    defer deinitControlPlaneProxyTestState(&state);
+    var cfg = initControlPlaneProxyTestConfig("http://configured.example");
+    const target = try std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}/api", .{origin.port()});
+    defer allocator.free(target);
+
+    try std.testing.expectError(error.DownstreamWriteFailed, executeBoundedControlPlaneJsonProxy(
+        allocator,
+        &cfg,
+        .global,
+        target,
+        null,
+        "{}",
+        "test-correlation",
+        "127.0.0.1",
+        null,
+        null,
+        null,
+        null,
+        null,
+        "localhost",
+        null,
+        FailingControlPlaneDownstreamWriter{},
+        &state,
+        true,
+        null,
+    ));
+
+    try std.testing.expectEqual(@as(usize, 1), origin.requestCount());
+    try std.testing.expectEqual(@as(usize, 0), state.upstreamUnhealthyCount());
+    try std.testing.expect(state.circuitTryAcquirePermit() != null);
+    try std.testing.expectEqualStrings("closed", state.circuitStateName());
+}
+
+test "control-plane absolute target outcomes do not mutate configured passive health" {
+    const allocator = std.testing.allocator;
+    var origin = try ControlPlaneTestOrigin.start(allocator, &.{ 500, 200 });
+    defer origin.stop();
+    try origin.run();
+
+    var state: GatewayState = undefined;
+    initControlPlaneProxyTestState(&state, allocator);
+    defer deinitControlPlaneProxyTestState(&state);
+    var cfg = initControlPlaneProxyTestConfig("http://configured.example");
+    const target = try std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}/api", .{origin.port()});
+    defer allocator.free(target);
+
+    var body_buf_1: [1024]u8 = undefined;
+    var body_writer_1 = compat.fixedBufferStream(&body_buf_1);
+    var exec_1 = try executeBoundedControlPlaneJsonProxy(
+        allocator,
+        &cfg,
+        .global,
+        target,
+        null,
+        "{}",
+        "test-correlation",
+        "127.0.0.1",
+        null,
+        null,
+        null,
+        null,
+        null,
+        "localhost",
+        null,
+        body_writer_1.writer(),
+        &state,
+        false,
+        null,
+    );
+    defer switch (exec_1) {
+        .buffered => |*res| {
+            allocator.free(res.body);
+            allocator.free(res.content_type);
+            if (res.content_disposition) |cd| allocator.free(cd);
+            if (res.location) |location| allocator.free(location);
+            if (res.set_cookie) |cookie| allocator.free(cookie);
+        },
+        .streamed_status => {},
+    };
+
+    try std.testing.expectEqual(@as(usize, 0), state.upstreamUnhealthyCount());
+    try std.testing.expect(state.circuitTryAcquirePermit() == null);
+
+    state.circuit_breaker = http.circuit_breaker.CircuitBreaker.init(.{});
+    state.recordUpstreamFailure(&cfg, cfg.upstream_base_url);
+    try std.testing.expectEqual(@as(usize, 1), state.upstreamUnhealthyCount());
+
+    var body_buf_2: [1024]u8 = undefined;
+    var body_writer_2 = compat.fixedBufferStream(&body_buf_2);
+    var exec_2 = try executeBoundedControlPlaneJsonProxy(
+        allocator,
+        &cfg,
+        .global,
+        target,
+        null,
+        "{}",
+        "test-correlation",
+        "127.0.0.1",
+        null,
+        null,
+        null,
+        null,
+        null,
+        "localhost",
+        null,
+        body_writer_2.writer(),
+        &state,
+        false,
+        null,
+    );
+    defer switch (exec_2) {
+        .buffered => |*res| {
+            allocator.free(res.body);
+            allocator.free(res.content_type);
+            if (res.content_disposition) |cd| allocator.free(cd);
+            if (res.location) |location| allocator.free(location);
+            if (res.set_cookie) |cookie| allocator.free(cookie);
+        },
+        .streamed_status => {},
+    };
+
+    try std.testing.expectEqual(@as(usize, 1), state.upstreamUnhealthyCount());
+    try std.testing.expectEqual(@as(usize, 2), origin.requestCount());
 }
 
 test "buildProxyCacheKey supports template tokens" {

--- a/src/gateway_control_plane_proxy.zig
+++ b/src/gateway_control_plane_proxy.zig
@@ -976,7 +976,7 @@ test "control-plane downstream streaming write failure records known 500 and nev
 
 test "control-plane post-status materialization failure records known 200 and never retries" {
     const allocator = std.testing.allocator;
-    var origin = try ControlPlaneTestOrigin.start(allocator, &.{ 200, 200 });
+    var origin = try ControlPlaneTestOrigin.start(allocator, &.{200});
     defer origin.stop();
     try origin.run();
 
@@ -1024,7 +1024,7 @@ test "control-plane post-status materialization failure records known 200 and ne
 
 test "control-plane post-status materialization failure records known 500 and never retries" {
     const allocator = std.testing.allocator;
-    var origin = try ControlPlaneTestOrigin.start(allocator, &.{ 500, 500 });
+    var origin = try ControlPlaneTestOrigin.start(allocator, &.{500});
     defer origin.stop();
     try origin.run();
 

--- a/src/gateway_control_plane_proxy.zig
+++ b/src/gateway_control_plane_proxy.zig
@@ -311,6 +311,7 @@ pub fn executeBoundedControlPlaneJsonProxy(
         else
             null;
         defer if (sticky_set_cookie) |cookie| allocator.free(cookie);
+        if (!state.circuitTryAcquire()) return error.CircuitOpen;
         state.recordUpstreamAttemptStart(upstream_base_url);
         const exec = blk: {
             defer state.recordUpstreamAttemptEnd(upstream_base_url);

--- a/src/gateway_handlers.zig
+++ b/src/gateway_handlers.zig
@@ -1885,6 +1885,7 @@ const Http3BufferedProxyAttemptExecutor = struct {
         forward_early_data: bool,
     ) !gproxy_runtime.DataPlaneProxyResponse {
         _ = attempt;
+        if (!self.state.circuitTryAcquire()) return error.CircuitOpen;
         const per_attempt_timeout_ms = try self.perAttemptTimeoutMs();
         self.state.recordUpstreamAttemptStart(self.selection_base_url);
         self.last_attempt_start_ms = http.event_loop.monotonicMs();
@@ -2102,6 +2103,7 @@ const Http3Early425ProxyContinuation = struct {
         if (self.test_execute_fn) |test_execute| {
             return test_execute(self.test_execute_ctx, self, per_attempt_timeout_ms, forward_early_data);
         }
+        if (!self.state.circuitTryAcquire()) return error.CircuitOpen;
         self.state.recordUpstreamAttemptStart(self.selection_base_url);
         self.last_attempt_start_ms = http.event_loop.monotonicMs();
         const resp = executeBufferedDataPlaneProxyRequest(
@@ -2165,6 +2167,10 @@ const Http3Early425ProxyContinuation = struct {
                     try rejectHttp3ProxyErrorWithState(allocator, response, self.state, .service_unavailable, "upstream_saturated", "Upstream connection limit reached", self.correlation_id);
                     return;
                 }
+                if (err == error.CircuitOpen) {
+                    try rejectHttp3ProxyErrorWithState(allocator, response, self.state, .service_unavailable, "upstream_circuit_open", "Upstream circuit breaker open", self.correlation_id);
+                    return;
+                }
                 self.state.recordUpstreamFailure(&self.cfg_snapshot, self.selection_base_url);
                 if (err == error.OutOfMemory) return error.OutOfMemory;
                 const err_status: http.Status = switch (err) {
@@ -2187,6 +2193,11 @@ const Http3Early425ProxyContinuation = struct {
                 self.state.metricsRecordEarlyDataRetry(.success);
             }
             try applyHttp3ProxyResponse(allocator, response, self.state, &upstream_response, self.correlation_id);
+            if (upstream_response.statusCode() >= 500) {
+                self.state.recordUpstreamFailure(&self.cfg_snapshot, self.selection_base_url);
+            } else if (upstream_response.statusCode() != @intFromEnum(http.Status.too_early)) {
+                self.state.recordUpstreamSuccess(&self.cfg_snapshot, self.selection_base_url);
+            }
             return;
         }
     }
@@ -2246,6 +2257,10 @@ fn handleHttp3LocationProxyPass(
             try rejectHttp3ProxyError(allocator, response, ctx, .service_unavailable, "upstream_saturated", "Upstream connection limit reached", correlation_id);
             return;
         },
+        .circuit_open => {
+            try rejectHttp3ProxyError(allocator, response, ctx, .service_unavailable, "upstream_circuit_open", "Upstream circuit breaker open", correlation_id);
+            return;
+        },
         .request_cancelled, .retry_budget_exhausted => {
             try rejectHttp3ProxyError(allocator, response, ctx, .gateway_timeout, "upstream_timeout", "Upstream request timed out", correlation_id);
             return;
@@ -2264,6 +2279,11 @@ fn handleHttp3LocationProxyPass(
     };
     defer upstream_response.deinit(allocator);
     defer ctx.state.metricsReleaseProxyBufferedBytes(upstream_response.bodyLen());
+    if (upstream_response.statusCode() >= 500) {
+        ctx.state.recordUpstreamFailure(ctx.cfg, ctx.cfg.upstream_base_url);
+    } else if (upstream_response.statusCode() != @intFromEnum(http.Status.too_early)) {
+        ctx.state.recordUpstreamSuccess(ctx.cfg, ctx.cfg.upstream_base_url);
+    }
     try applyHttp3ProxyResponse(allocator, response, ctx.state, &upstream_response, correlation_id);
 }
 

--- a/src/gateway_handlers.zig
+++ b/src/gateway_handlers.zig
@@ -544,6 +544,8 @@ fn minimalHttp3ProxyConfig(blocks: []http.location_router.LocationBlock) edge_co
 
 fn initHttp3ProxyTestState(state: *GatewayState, allocator: std.mem.Allocator, add_headers: []const edge_config.EdgeConfig.HeaderPair) void {
     initHandlerTestState(state, allocator, add_headers);
+    state.circuit_mutex = .{};
+    state.circuit_breaker = http.circuit_breaker.CircuitBreaker.init(.{});
     state.upstream_mutex = .{};
     state.upstream_health = std.StringHashMap(gs.UpstreamHealth).init(allocator);
     state.upstream_active_requests = std.StringHashMap(usize).init(allocator);
@@ -1841,21 +1843,22 @@ fn recordHttp3ProxyOutcome(
     selection_base_url: []const u8,
     absolute_target: bool,
     status_code: u16,
+    permit: http.circuit_breaker.Permit,
 ) void {
     if (status_code >= 500) {
         if (absolute_target) {
-            state.circuitRecordFailure();
+            state.circuitRecordFailurePermit(permit);
         } else {
-            state.recordProxyUpstreamFailure(cfg, selection_base_url);
+            state.recordProxyUpstreamFailure(cfg, selection_base_url, permit);
         }
     } else if (status_code != @intFromEnum(http.Status.too_early)) {
         if (absolute_target) {
-            state.circuitRecordSuccess();
+            state.circuitRecordSuccessPermit(permit);
         } else {
-            state.recordProxyUpstreamSuccess(cfg, selection_base_url);
+            state.recordProxyUpstreamSuccess(cfg, selection_base_url, permit);
         }
     } else {
-        state.circuitReleaseProbe();
+        state.circuitReleasePermit(permit);
     }
 }
 
@@ -1878,6 +1881,7 @@ const Http3BufferedProxyAttemptExecutor = struct {
     absolute_target: bool,
     budget_start_ms: u64,
     last_attempt_start_ms: u64 = 0,
+    circuit_permit: ?http.circuit_breaker.Permit = null,
 
     pub fn recordEarlyUpstream425Action(
         self: *Http3BufferedProxyAttemptExecutor,
@@ -1910,7 +1914,9 @@ const Http3BufferedProxyAttemptExecutor = struct {
         forward_early_data: bool,
     ) !gproxy_runtime.DataPlaneProxyResponse {
         _ = attempt;
-        if (!self.state.circuitTryAcquire()) return error.CircuitOpen;
+        if (self.circuit_permit == null) {
+            self.circuit_permit = self.state.circuitTryAcquirePermit() orelse return error.CircuitOpen;
+        }
         const per_attempt_timeout_ms = try self.perAttemptTimeoutMs();
         self.state.recordUpstreamAttemptStart(self.selection_base_url);
         self.last_attempt_start_ms = http.event_loop.monotonicMs();
@@ -1960,7 +1966,29 @@ const Http3BufferedProxyAttemptExecutor = struct {
     }
 
     pub fn releaseCircuitProbe(self: *Http3BufferedProxyAttemptExecutor) void {
-        self.state.circuitReleaseProbe();
+        const permit = self.circuit_permit orelse return;
+        self.state.circuitReleasePermit(permit);
+        self.circuit_permit = null;
+    }
+
+    fn recordCircuitFailure(self: *Http3BufferedProxyAttemptExecutor) void {
+        const permit = self.circuit_permit orelse return;
+        if (self.absolute_target) {
+            self.state.circuitRecordFailurePermit(permit);
+        } else {
+            self.state.recordProxyUpstreamFailure(self.cfg, self.selection_base_url, permit);
+        }
+        self.circuit_permit = null;
+    }
+
+    fn recordCircuitSuccess(self: *Http3BufferedProxyAttemptExecutor) void {
+        const permit = self.circuit_permit orelse return;
+        if (self.absolute_target) {
+            self.state.circuitRecordSuccessPermit(permit);
+        } else {
+            self.state.recordProxyUpstreamSuccess(self.cfg, self.selection_base_url, permit);
+        }
+        self.circuit_permit = null;
     }
 
     pub fn onTerminalAttemptError(
@@ -1968,13 +1996,9 @@ const Http3BufferedProxyAttemptExecutor = struct {
         err: anyerror,
     ) !void {
         if (gproxy_runtime.proxyAttemptErrorCountsAsUpstreamFailure(err)) {
-            if (self.absolute_target) {
-                self.state.circuitRecordFailure();
-            } else {
-                self.state.recordProxyUpstreamFailure(self.cfg, self.selection_base_url);
-            }
+            self.recordCircuitFailure();
         } else {
-            self.state.circuitReleaseProbe();
+            self.releaseCircuitProbe();
         }
     }
 
@@ -2028,11 +2052,7 @@ const Http3BufferedProxyAttemptExecutor = struct {
         max_attempts: usize,
         result: *gproxy_runtime.DataPlaneProxyResponse,
     ) !void {
-        if (self.absolute_target) {
-            self.state.circuitRecordFailure();
-        } else {
-            self.state.recordProxyUpstreamFailure(self.cfg, self.selection_base_url);
-        }
+        self.recordCircuitFailure();
         self.state.logger.warn(self.correlation_id, "h3 proxy attempt {d}/{d} got {d}, retrying", .{ configured_attempt_index + 1, max_attempts, result.statusCode() });
         self.state.metricsReleaseProxyBufferedBytes(result.bodyLen());
         result.deinit(self.allocator);
@@ -2056,6 +2076,7 @@ const Http3Early425ProxyContinuation = struct {
     absolute_target: bool,
     budget_start_ms: u64,
     last_attempt_start_ms: u64 = 0,
+    circuit_permit: ?http.circuit_breaker.Permit = null,
     transport_early: bool,
     test_execute_ctx: ?*anyopaque = null,
     test_execute_fn: ?*const fn (?*anyopaque, *Http3Early425ProxyContinuation, u32, bool) anyerror!gproxy_runtime.DataPlaneProxyResponse = null,
@@ -2107,6 +2128,7 @@ const Http3Early425ProxyContinuation = struct {
             .selection_base_url = executor.selection_base_url,
             .absolute_target = executor.absolute_target,
             .budget_start_ms = executor.budget_start_ms,
+            .circuit_permit = executor.circuit_permit,
             .transport_early = executor.request.transport_early,
         };
         return plan;
@@ -2143,10 +2165,12 @@ const Http3Early425ProxyContinuation = struct {
     }
 
     fn execute(self: *Http3Early425ProxyContinuation, per_attempt_timeout_ms: u32, forward_early_data: bool) !gproxy_runtime.DataPlaneProxyResponse {
+        if (self.circuit_permit == null) {
+            self.circuit_permit = self.state.circuitTryAcquirePermit() orelse return error.CircuitOpen;
+        }
         if (self.test_execute_fn) |test_execute| {
             return test_execute(self.test_execute_ctx, self, per_attempt_timeout_ms, forward_early_data);
         }
-        if (!self.state.circuitTryAcquire()) return error.CircuitOpen;
         self.state.recordUpstreamAttemptStart(self.selection_base_url);
         self.last_attempt_start_ms = http.event_loop.monotonicMs();
         const resp = executeBufferedDataPlaneProxyRequest(
@@ -2203,19 +2227,27 @@ const Http3Early425ProxyContinuation = struct {
                 }
                 self.state.metricsRecordEarlyDataRetry(.failure);
                 if (err == error.ProxyBudgetExhausted or err == error.RequestCancelled) {
-                    if (err == error.ProxyBudgetExhausted) self.state.circuitReleaseProbe();
+                    const permit = self.circuit_permit;
+                    if (err == error.ProxyBudgetExhausted) {
+                        if (permit) |p| self.state.circuitReleasePermit(p);
+                        self.circuit_permit = null;
+                    }
                     if (err == error.RequestCancelled) {
-                        if (self.absolute_target) {
-                            self.state.circuitRecordFailure();
-                        } else {
-                            self.state.recordProxyUpstreamFailure(&self.cfg_snapshot, self.selection_base_url);
+                        if (permit) |p| {
+                            if (self.absolute_target) {
+                                self.state.circuitRecordFailurePermit(p);
+                            } else {
+                                self.state.recordProxyUpstreamFailure(&self.cfg_snapshot, self.selection_base_url, p);
+                            }
+                            self.circuit_permit = null;
                         }
                     }
                     try rejectHttp3ProxyErrorWithState(allocator, response, self.state, .gateway_timeout, "upstream_timeout", "Upstream request timed out", self.correlation_id);
                     return;
                 }
                 if (err == error.UpstreamAtCapacity) {
-                    self.state.circuitReleaseProbe();
+                    if (self.circuit_permit) |p| self.state.circuitReleasePermit(p);
+                    self.circuit_permit = null;
                     try rejectHttp3ProxyErrorWithState(allocator, response, self.state, .service_unavailable, "upstream_saturated", "Upstream connection limit reached", self.correlation_id);
                     return;
                 }
@@ -2224,17 +2256,23 @@ const Http3Early425ProxyContinuation = struct {
                     return;
                 }
                 if (err == error.OutOfMemory) {
-                    self.state.circuitReleaseProbe();
+                    if (self.circuit_permit) |p| self.state.circuitReleasePermit(p);
+                    self.circuit_permit = null;
                     return error.OutOfMemory;
                 }
+                const permit = self.circuit_permit;
                 if (gproxy_runtime.proxyAttemptErrorCountsAsUpstreamFailure(err)) {
-                    if (self.absolute_target) {
-                        self.state.circuitRecordFailure();
-                    } else {
-                        self.state.recordProxyUpstreamFailure(&self.cfg_snapshot, self.selection_base_url);
+                    if (permit) |p| {
+                        if (self.absolute_target) {
+                            self.state.circuitRecordFailurePermit(p);
+                        } else {
+                            self.state.recordProxyUpstreamFailure(&self.cfg_snapshot, self.selection_base_url, p);
+                        }
+                        self.circuit_permit = null;
                     }
                 } else {
-                    self.state.circuitReleaseProbe();
+                    if (permit) |p| self.state.circuitReleasePermit(p);
+                    self.circuit_permit = null;
                 }
                 const err_status: http.Status = switch (err) {
                     error.Timeout, error.TimedOut, error.WouldBlock => .gateway_timeout,
@@ -2255,7 +2293,10 @@ const Http3Early425ProxyContinuation = struct {
             } else {
                 self.state.metricsRecordEarlyDataRetry(.success);
             }
-            recordHttp3ProxyOutcome(self.state, &self.cfg_snapshot, self.selection_base_url, self.absolute_target, upstream_response.statusCode());
+            if (self.circuit_permit) |permit| {
+                recordHttp3ProxyOutcome(self.state, &self.cfg_snapshot, self.selection_base_url, self.absolute_target, upstream_response.statusCode(), permit);
+                self.circuit_permit = null;
+            }
             try applyHttp3ProxyResponse(allocator, response, self.state, &upstream_response, self.correlation_id);
             return;
         }
@@ -2340,7 +2381,10 @@ fn handleHttp3LocationProxyPass(
     };
     defer upstream_response.deinit(allocator);
     defer ctx.state.metricsReleaseProxyBufferedBytes(upstream_response.bodyLen());
-    recordHttp3ProxyOutcome(ctx.state, ctx.cfg, ctx.cfg.upstream_base_url, absolute_target, upstream_response.statusCode());
+    if (attempt_executor.circuit_permit) |permit| {
+        recordHttp3ProxyOutcome(ctx.state, ctx.cfg, ctx.cfg.upstream_base_url, absolute_target, upstream_response.statusCode(), permit);
+        attempt_executor.circuit_permit = null;
+    }
     try applyHttp3ProxyResponse(allocator, response, ctx.state, &upstream_response, correlation_id);
 }
 
@@ -2622,7 +2666,7 @@ test "recordHttp3ProxyOutcome keeps absolute target failures out of passive heal
     cfg.upstream_max_fails = 1;
     cfg.upstream_fail_timeout_ms = 60_000;
 
-    recordHttp3ProxyOutcome(&state, &cfg, cfg.upstream_base_url, true, 500);
+    recordHttp3ProxyOutcome(&state, &cfg, cfg.upstream_base_url, true, 500, .ordinary);
 
     try std.testing.expectEqual(@as(usize, 0), state.upstreamUnhealthyCount());
     try std.testing.expect(!state.circuitTryAcquire());
@@ -3251,7 +3295,7 @@ test "h3 proxy parked early 425 forwards second 425 without third delivery" {
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_retry_total{result=\"too_early\"} 1") != null);
 }
 
-test "h3 proxy parked early 425 treats stale ordinary retry as transparent" {
+test "h3 proxy parked early 425 carries half-open permit across stale retry" {
     const allocator = std.testing.allocator;
     var origin = try H3ProxyOrigin.start(allocator, &.{425});
     defer origin.stop();
@@ -3276,6 +3320,8 @@ test "h3 proxy parked early 425 treats stale ordinary retry as transparent" {
     var state: GatewayState = undefined;
     initHttp3ProxyTestState(&state, allocator, &.{});
     defer deinitHttp3ProxyTestState(&state);
+    state.circuit_breaker = http.circuit_breaker.CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0, .half_open_successes = 1 });
+    state.circuitRecordFailurePermit(.ordinary);
     var dispatch_ctx = Http3DispatchContext{
         .config_store = &config_store,
         .cfg = &cfg,
@@ -3302,6 +3348,8 @@ test "h3 proxy parked early 425 treats stale ordinary retry as transparent" {
     try std.testing.expectError(error.Http3RequestParked, handleHttp3Request(allocator, &request, &first_response, &dispatch_ctx));
     try std.testing.expectEqual(@as(usize, 1), origin.requestCount());
     try std.testing.expect(origin.requestContains(0, "\r\nEarly-Data: 1\r\n"));
+    try std.testing.expectEqualStrings("half-open", state.circuitStateName());
+    try std.testing.expect(!state.circuitTryAcquire());
 
     var continuation = capture.take();
     defer continuation.deinit(allocator);
@@ -3331,6 +3379,7 @@ test "h3 proxy parked early 425 treats stale ordinary retry as transparent" {
     try std.testing.expect(execute_script.timeouts_ms.items[1] <= execute_script.timeouts_ms.items[0]);
     try std.testing.expectEqual(original_budget_start_ms, plan.budget_start_ms);
     try std.testing.expectEqual(@as(usize, 0), state.upstream_health.count());
+    try std.testing.expectEqualStrings("closed", state.circuitStateName());
 
     const prom = try state.metrics.toPrometheus(allocator);
     defer allocator.free(prom);
@@ -3362,6 +3411,7 @@ test "h3 proxy parked early 425 records failure after stale recovery exhausts" {
     var state: GatewayState = undefined;
     initHttp3ProxyTestState(&state, allocator, &.{});
     defer deinitHttp3ProxyTestState(&state);
+    state.circuit_breaker = http.circuit_breaker.CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 30_000 });
     var dispatch_ctx = Http3DispatchContext{
         .config_store = &config_store,
         .cfg = &cfg,
@@ -3411,7 +3461,8 @@ test "h3 proxy parked early 425 records failure after stale recovery exhausts" {
     try std.testing.expectEqual(@as(u16, 502), @intFromEnum(resumed_response.status));
     try std.testing.expectEqual(@as(usize, 3), execute_script.calls);
     try std.testing.expectEqualSlices(bool, &.{ false, false, false }, execute_script.forward_early_data.items);
-    try std.testing.expectEqual(@as(usize, 1), state.upstream_health.count());
+    try std.testing.expectEqual(@as(usize, 0), state.upstream_health.count());
+    try std.testing.expect(!state.circuitTryAcquire());
 
     const prom = try state.metrics.toPrometheus(allocator);
     defer allocator.free(prom);

--- a/src/gateway_handlers.zig
+++ b/src/gateway_handlers.zig
@@ -2027,6 +2027,7 @@ const Http3BufferedProxyAttemptExecutor = struct {
         self.state.logger.debug(self.correlation_id, "h3 parking early-data upstream 425 retry until downstream handshake completion", .{});
         var plan = try Http3Early425ProxyContinuation.init(self.allocator, self);
         errdefer {
+            plan.circuit_permit = null;
             plan.deinit(self.allocator);
             self.allocator.destroy(plan);
         }
@@ -2035,6 +2036,7 @@ const Http3BufferedProxyAttemptExecutor = struct {
             .resume_fn = Http3Early425ProxyContinuation.run,
             .deinit_fn = Http3Early425ProxyContinuation.destroy,
         });
+        self.circuit_permit = null;
         self.state.metricsReleaseProxyBufferedBytes(result.bodyLen());
         result.deinit(self.allocator);
     }
@@ -2135,6 +2137,10 @@ const Http3Early425ProxyContinuation = struct {
     }
 
     fn deinit(self: *Http3Early425ProxyContinuation, allocator: std.mem.Allocator) void {
+        if (self.circuit_permit) |permit| {
+            self.state.circuitReleasePermit(permit);
+            self.circuit_permit = null;
+        }
         self.config_lease.release();
         allocator.free(self.upstream_url);
         allocator.free(self.method);
@@ -2212,6 +2218,10 @@ const Http3Early425ProxyContinuation = struct {
             const per_attempt_timeout_ms = self.perAttemptTimeoutMs() catch |err| {
                 self.state.metricsRecordEarlyDataRetry(.failure);
                 if (err == error.OutOfMemory) return error.OutOfMemory;
+                if (self.circuit_permit) |permit| {
+                    self.state.circuitReleasePermit(permit);
+                    self.circuit_permit = null;
+                }
                 try rejectHttp3ProxyErrorWithState(allocator, response, self.state, .gateway_timeout, "upstream_timeout", "Upstream request timed out", self.correlation_id);
                 return;
             };
@@ -2669,7 +2679,7 @@ test "recordHttp3ProxyOutcome keeps absolute target failures out of passive heal
     recordHttp3ProxyOutcome(&state, &cfg, cfg.upstream_base_url, true, 500, .ordinary);
 
     try std.testing.expectEqual(@as(usize, 0), state.upstreamUnhealthyCount());
-    try std.testing.expect(!state.circuitTryAcquire());
+    try std.testing.expect(state.circuitTryAcquirePermit() == null);
     try std.testing.expectEqualStrings("open", state.circuitStateName());
 }
 
@@ -3349,7 +3359,7 @@ test "h3 proxy parked early 425 carries half-open permit across stale retry" {
     try std.testing.expectEqual(@as(usize, 1), origin.requestCount());
     try std.testing.expect(origin.requestContains(0, "\r\nEarly-Data: 1\r\n"));
     try std.testing.expectEqualStrings("half-open", state.circuitStateName());
-    try std.testing.expect(!state.circuitTryAcquire());
+    try std.testing.expect(state.circuitTryAcquirePermit() == null);
 
     var continuation = capture.take();
     defer continuation.deinit(allocator);
@@ -3462,12 +3472,71 @@ test "h3 proxy parked early 425 records failure after stale recovery exhausts" {
     try std.testing.expectEqual(@as(usize, 3), execute_script.calls);
     try std.testing.expectEqualSlices(bool, &.{ false, false, false }, execute_script.forward_early_data.items);
     try std.testing.expectEqual(@as(usize, 0), state.upstream_health.count());
-    try std.testing.expect(!state.circuitTryAcquire());
+    try std.testing.expect(state.circuitTryAcquirePermit() == null);
 
     const prom = try state.metrics.toPrometheus(allocator);
     defer allocator.free(prom);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_upstream_425_total{action=\"retried\"} 1") != null);
     try std.testing.expect(std.mem.find(u8, prom, "tardigrade_http_early_data_retry_total{result=\"failure\"} 1") != null);
+}
+
+test "h3 proxy parked half-open 425 releases permit when destroyed before resume" {
+    const allocator = std.testing.allocator;
+    var origin = try H3ProxyOrigin.start(allocator, &.{425});
+    defer origin.stop();
+    try origin.run();
+
+    const target = try std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}", .{origin.port()});
+    defer allocator.free(target);
+    var blocks = [_]http.location_router.LocationBlock{.{
+        .match_type = .prefix,
+        .pattern = "/proxy/",
+        .priority = 0,
+        .action = .{ .proxy_pass = target },
+        .early_data = .replay_safe,
+        .proxy_early_data = .rfc8470,
+    }};
+    var cfg = minimalHttp3ProxyConfig(blocks[0..]);
+    var config_store = try ReloadableConfigStore.initBorrowed(allocator, &cfg);
+    defer config_store.deinit();
+    var state: GatewayState = undefined;
+    initHttp3ProxyTestState(&state, allocator, &.{});
+    defer deinitHttp3ProxyTestState(&state);
+    state.circuit_breaker = http.circuit_breaker.CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0, .half_open_successes = 1 });
+    state.circuitRecordFailurePermit(.ordinary);
+    var dispatch_ctx = Http3DispatchContext{
+        .config_store = &config_store,
+        .cfg = &cfg,
+        .state = &state,
+    };
+    var barrier = TestHttp3RequestHandshake{ .complete = false };
+    var capture = H3ParkCapture{};
+    var request = http.http3_session.StreamRequest{
+        .allocator = allocator,
+        .stream_id = 17,
+        .method = try allocator.dupe(u8, "GET"),
+        .path = try allocator.dupe(u8, "/proxy/item"),
+        .authority = null,
+        .headers = http.Headers.init(allocator),
+        .body = try allocator.alloc(u8, 0),
+        .transport_early = true,
+        .downstream_handshake = barrier.barrier(),
+        .park_early_425_retry = .{ .ctx = &capture, .park_fn = H3ParkCapture.park },
+    };
+    defer request.deinit();
+    var first_response = http.Response.init(allocator);
+    defer first_response.deinit();
+
+    try std.testing.expectError(error.Http3RequestParked, handleHttp3Request(allocator, &request, &first_response, &dispatch_ctx));
+    try std.testing.expectEqualStrings("half-open", state.circuitStateName());
+    try std.testing.expect(state.circuitTryAcquirePermit() == null);
+
+    var continuation = capture.take();
+    continuation.deinit(allocator);
+
+    const next_probe = state.circuitTryAcquirePermit() orelse return error.TestExpectedHalfOpenPermit;
+    defer state.circuitReleasePermit(next_probe);
+    try std.testing.expectEqualStrings("half-open", state.circuitStateName());
 }
 
 test "h3 proxy parked early 425 fails without origin retry after budget expires" {
@@ -3493,6 +3562,8 @@ test "h3 proxy parked early 425 fails without origin retry after budget expires"
     var state: GatewayState = undefined;
     initHttp3ProxyTestState(&state, allocator, &.{});
     defer deinitHttp3ProxyTestState(&state);
+    state.circuit_breaker = http.circuit_breaker.CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0, .half_open_successes = 1 });
+    state.circuitRecordFailurePermit(.ordinary);
     var dispatch_ctx = Http3DispatchContext{
         .config_store = &config_store,
         .cfg = &cfg,
@@ -3518,6 +3589,8 @@ test "h3 proxy parked early 425 fails without origin retry after budget expires"
 
     try std.testing.expectError(error.Http3RequestParked, handleHttp3Request(allocator, &request, &first_response, &dispatch_ctx));
     try std.testing.expectEqual(@as(usize, 1), origin.requestCount());
+    try std.testing.expectEqualStrings("half-open", state.circuitStateName());
+    try std.testing.expect(state.circuitTryAcquirePermit() == null);
     compat.sleepNs(3 * std.time.ns_per_ms);
 
     var continuation = capture.take();
@@ -3528,6 +3601,8 @@ test "h3 proxy parked early 425 fails without origin retry after budget expires"
 
     try std.testing.expectEqual(@as(usize, 1), origin.requestCount());
     try std.testing.expectEqual(@as(u16, 504), @intFromEnum(resumed_response.status));
+    const next_probe = state.circuitTryAcquirePermit() orelse return error.TestExpectedHalfOpenPermit;
+    defer state.circuitReleasePermit(next_probe);
 
     const prom = try state.metrics.toPrometheus(allocator);
     defer allocator.free(prom);

--- a/src/gateway_handlers.zig
+++ b/src/gateway_handlers.zig
@@ -2676,7 +2676,7 @@ test "recordHttp3ProxyOutcome keeps absolute target failures out of passive heal
     cfg.upstream_max_fails = 1;
     cfg.upstream_fail_timeout_ms = 60_000;
 
-    recordHttp3ProxyOutcome(&state, &cfg, cfg.upstream_base_url, true, 500, .ordinary);
+    recordHttp3ProxyOutcome(&state, &cfg, cfg.upstream_base_url, true, 500, state.circuitTryAcquirePermit().?);
 
     try std.testing.expectEqual(@as(usize, 0), state.upstreamUnhealthyCount());
     try std.testing.expect(state.circuitTryAcquirePermit() == null);
@@ -3331,7 +3331,7 @@ test "h3 proxy parked early 425 carries half-open permit across stale retry" {
     initHttp3ProxyTestState(&state, allocator, &.{});
     defer deinitHttp3ProxyTestState(&state);
     state.circuit_breaker = http.circuit_breaker.CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0, .half_open_successes = 1 });
-    state.circuitRecordFailurePermit(.ordinary);
+    state.circuitRecordFailurePermit(state.circuitTryAcquirePermit().?);
     var dispatch_ctx = Http3DispatchContext{
         .config_store = &config_store,
         .cfg = &cfg,
@@ -3503,7 +3503,7 @@ test "h3 proxy parked half-open 425 releases permit when destroyed before resume
     initHttp3ProxyTestState(&state, allocator, &.{});
     defer deinitHttp3ProxyTestState(&state);
     state.circuit_breaker = http.circuit_breaker.CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0, .half_open_successes = 1 });
-    state.circuitRecordFailurePermit(.ordinary);
+    state.circuitRecordFailurePermit(state.circuitTryAcquirePermit().?);
     var dispatch_ctx = Http3DispatchContext{
         .config_store = &config_store,
         .cfg = &cfg,
@@ -3563,7 +3563,7 @@ test "h3 proxy parked early 425 fails without origin retry after budget expires"
     initHttp3ProxyTestState(&state, allocator, &.{});
     defer deinitHttp3ProxyTestState(&state);
     state.circuit_breaker = http.circuit_breaker.CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0, .half_open_successes = 1 });
-    state.circuitRecordFailurePermit(.ordinary);
+    state.circuitRecordFailurePermit(state.circuitTryAcquirePermit().?);
     var dispatch_ctx = Http3DispatchContext{
         .config_store = &config_store,
         .cfg = &cfg,

--- a/src/gateway_handlers.zig
+++ b/src/gateway_handlers.zig
@@ -1835,6 +1835,30 @@ fn applyHttp3ProxyResponse(
     state.metricsRecord(upstream_response.statusCode());
 }
 
+fn recordHttp3ProxyOutcome(
+    state: *GatewayState,
+    cfg: *const edge_config.EdgeConfig,
+    selection_base_url: []const u8,
+    absolute_target: bool,
+    status_code: u16,
+) void {
+    if (status_code >= 500) {
+        if (absolute_target) {
+            state.circuitRecordFailure();
+        } else {
+            state.recordProxyUpstreamFailure(cfg, selection_base_url);
+        }
+    } else if (status_code != @intFromEnum(http.Status.too_early)) {
+        if (absolute_target) {
+            state.circuitRecordSuccess();
+        } else {
+            state.recordProxyUpstreamSuccess(cfg, selection_base_url);
+        }
+    } else {
+        state.circuitReleaseProbe();
+    }
+}
+
 const Http3BufferedProxyAttemptExecutor = struct {
     allocator: std.mem.Allocator,
     cfg: *const edge_config.EdgeConfig,
@@ -1851,6 +1875,7 @@ const Http3BufferedProxyAttemptExecutor = struct {
     forwarded_proto: []const u8,
     incoming_host: ?[]const u8,
     selection_base_url: []const u8,
+    absolute_target: bool,
     budget_start_ms: u64,
     last_attempt_start_ms: u64 = 0,
 
@@ -1934,11 +1959,23 @@ const Http3BufferedProxyAttemptExecutor = struct {
         self.state.logger.warn(self.correlation_id, "h3 proxy retrying on fresh connection after stale upstream keep-alive ({d}/{d})", .{ stale_conn_retries, max_stale_conn_retries });
     }
 
+    pub fn releaseCircuitProbe(self: *Http3BufferedProxyAttemptExecutor) void {
+        self.state.circuitReleaseProbe();
+    }
+
     pub fn onTerminalAttemptError(
         self: *Http3BufferedProxyAttemptExecutor,
-        _: anyerror,
+        err: anyerror,
     ) !void {
-        self.state.recordUpstreamFailure(self.cfg, self.selection_base_url);
+        if (gproxy_runtime.proxyAttemptErrorCountsAsUpstreamFailure(err)) {
+            if (self.absolute_target) {
+                self.state.circuitRecordFailure();
+            } else {
+                self.state.recordProxyUpstreamFailure(self.cfg, self.selection_base_url);
+            }
+        } else {
+            self.state.circuitReleaseProbe();
+        }
     }
 
     pub fn onConfiguredErrorRetry(
@@ -1991,7 +2028,11 @@ const Http3BufferedProxyAttemptExecutor = struct {
         max_attempts: usize,
         result: *gproxy_runtime.DataPlaneProxyResponse,
     ) !void {
-        self.state.recordUpstreamFailure(self.cfg, self.selection_base_url);
+        if (self.absolute_target) {
+            self.state.circuitRecordFailure();
+        } else {
+            self.state.recordProxyUpstreamFailure(self.cfg, self.selection_base_url);
+        }
         self.state.logger.warn(self.correlation_id, "h3 proxy attempt {d}/{d} got {d}, retrying", .{ configured_attempt_index + 1, max_attempts, result.statusCode() });
         self.state.metricsReleaseProxyBufferedBytes(result.bodyLen());
         result.deinit(self.allocator);
@@ -2012,6 +2053,7 @@ const Http3Early425ProxyContinuation = struct {
     forwarded_proto: []u8,
     incoming_host: ?[]u8,
     selection_base_url: []const u8,
+    absolute_target: bool,
     budget_start_ms: u64,
     last_attempt_start_ms: u64 = 0,
     transport_early: bool,
@@ -2063,6 +2105,7 @@ const Http3Early425ProxyContinuation = struct {
             .forwarded_proto = forwarded_proto,
             .incoming_host = incoming_host,
             .selection_base_url = executor.selection_base_url,
+            .absolute_target = executor.absolute_target,
             .budget_start_ms = executor.budget_start_ms,
             .transport_early = executor.request.transport_early,
         };
@@ -2160,10 +2203,19 @@ const Http3Early425ProxyContinuation = struct {
                 }
                 self.state.metricsRecordEarlyDataRetry(.failure);
                 if (err == error.ProxyBudgetExhausted or err == error.RequestCancelled) {
+                    if (err == error.ProxyBudgetExhausted) self.state.circuitReleaseProbe();
+                    if (err == error.RequestCancelled) {
+                        if (self.absolute_target) {
+                            self.state.circuitRecordFailure();
+                        } else {
+                            self.state.recordProxyUpstreamFailure(&self.cfg_snapshot, self.selection_base_url);
+                        }
+                    }
                     try rejectHttp3ProxyErrorWithState(allocator, response, self.state, .gateway_timeout, "upstream_timeout", "Upstream request timed out", self.correlation_id);
                     return;
                 }
                 if (err == error.UpstreamAtCapacity) {
+                    self.state.circuitReleaseProbe();
                     try rejectHttp3ProxyErrorWithState(allocator, response, self.state, .service_unavailable, "upstream_saturated", "Upstream connection limit reached", self.correlation_id);
                     return;
                 }
@@ -2171,8 +2223,19 @@ const Http3Early425ProxyContinuation = struct {
                     try rejectHttp3ProxyErrorWithState(allocator, response, self.state, .service_unavailable, "upstream_circuit_open", "Upstream circuit breaker open", self.correlation_id);
                     return;
                 }
-                self.state.recordUpstreamFailure(&self.cfg_snapshot, self.selection_base_url);
-                if (err == error.OutOfMemory) return error.OutOfMemory;
+                if (err == error.OutOfMemory) {
+                    self.state.circuitReleaseProbe();
+                    return error.OutOfMemory;
+                }
+                if (gproxy_runtime.proxyAttemptErrorCountsAsUpstreamFailure(err)) {
+                    if (self.absolute_target) {
+                        self.state.circuitRecordFailure();
+                    } else {
+                        self.state.recordProxyUpstreamFailure(&self.cfg_snapshot, self.selection_base_url);
+                    }
+                } else {
+                    self.state.circuitReleaseProbe();
+                }
                 const err_status: http.Status = switch (err) {
                     error.Timeout, error.TimedOut, error.WouldBlock => .gateway_timeout,
                     else => .bad_gateway,
@@ -2192,12 +2255,8 @@ const Http3Early425ProxyContinuation = struct {
             } else {
                 self.state.metricsRecordEarlyDataRetry(.success);
             }
+            recordHttp3ProxyOutcome(self.state, &self.cfg_snapshot, self.selection_base_url, self.absolute_target, upstream_response.statusCode());
             try applyHttp3ProxyResponse(allocator, response, self.state, &upstream_response, self.correlation_id);
-            if (upstream_response.statusCode() >= 500) {
-                self.state.recordUpstreamFailure(&self.cfg_snapshot, self.selection_base_url);
-            } else if (upstream_response.statusCode() != @intFromEnum(http.Status.too_early)) {
-                self.state.recordUpstreamSuccess(&self.cfg_snapshot, self.selection_base_url);
-            }
             return;
         }
     }
@@ -2220,6 +2279,7 @@ fn handleHttp3LocationProxyPass(
     defer allocator.free(resolved.url);
     var upstream_url = try appendProxyQueryString(allocator, resolved.url, request_query);
     defer upstream_url.deinit(allocator);
+    const absolute_target = gs.isAbsoluteHttpUrl(std.mem.trim(u8, target, " \t\r\n"));
 
     const max_attempts = gproxy_runtime.proxyRetryAttemptLimit(ctx.cfg.upstream_retry_attempts, ctx.cfg.upstream_retry_idempotent_only, request.method);
     var attempt_executor = Http3BufferedProxyAttemptExecutor{
@@ -2238,6 +2298,7 @@ fn handleHttp3LocationProxyPass(
         .forwarded_proto = if (edge_config.hasTlsFiles(ctx.cfg)) "https" else "http",
         .incoming_host = request.headers.get(":authority") orelse request.headers.get("host"),
         .selection_base_url = ctx.cfg.upstream_base_url,
+        .absolute_target = absolute_target,
         .budget_start_ms = http.event_loop.monotonicMs(),
     };
 
@@ -2279,11 +2340,7 @@ fn handleHttp3LocationProxyPass(
     };
     defer upstream_response.deinit(allocator);
     defer ctx.state.metricsReleaseProxyBufferedBytes(upstream_response.bodyLen());
-    if (upstream_response.statusCode() >= 500) {
-        ctx.state.recordUpstreamFailure(ctx.cfg, ctx.cfg.upstream_base_url);
-    } else if (upstream_response.statusCode() != @intFromEnum(http.Status.too_early)) {
-        ctx.state.recordUpstreamSuccess(ctx.cfg, ctx.cfg.upstream_base_url);
-    }
+    recordHttp3ProxyOutcome(ctx.state, ctx.cfg, ctx.cfg.upstream_base_url, absolute_target, upstream_response.statusCode());
     try applyHttp3ProxyResponse(allocator, response, ctx.state, &upstream_response, correlation_id);
 }
 
@@ -2550,6 +2607,26 @@ test "routeHttp3Location rejects auth-required locations before action execution
     try std.testing.expectEqual(@as(u64, 1), state.metrics.total_requests);
     try std.testing.expectEqual(@as(u64, 1), state.metrics.status_4xx);
     try std.testing.expectEqual(@as(u64, 1), state.metrics.err_unauthorized);
+}
+
+test "recordHttp3ProxyOutcome keeps absolute target failures out of passive health" {
+    const allocator = std.testing.allocator;
+    var state: GatewayState = undefined;
+    initHttp3ProxyTestState(&state, allocator, &.{});
+    defer deinitHttp3ProxyTestState(&state);
+    state.circuit_mutex = .{};
+    state.circuit_breaker = http.circuit_breaker.CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 30_000 });
+
+    var cfg = minimalHttp3ProxyConfig(&.{});
+    cfg.upstream_base_url = "http://configured.example";
+    cfg.upstream_max_fails = 1;
+    cfg.upstream_fail_timeout_ms = 60_000;
+
+    recordHttp3ProxyOutcome(&state, &cfg, cfg.upstream_base_url, true, 500);
+
+    try std.testing.expectEqual(@as(usize, 0), state.upstreamUnhealthyCount());
+    try std.testing.expect(!state.circuitTryAcquire());
+    try std.testing.expectEqualStrings("open", state.circuitStateName());
 }
 
 test "routeHttp3Location rejects prior-hop Early-Data on ordinary 1-RTT before auth side effects" {

--- a/src/gateway_proxy.zig
+++ b/src/gateway_proxy.zig
@@ -310,6 +310,7 @@ pub const StreamingProxyResult = struct {
     response_body_bytes: usize,
     upstream_ttfb_ms: u64,
     upstream_aborted: bool = false,
+    downstream_aborted_after_status: bool = false,
     /// The relay was truncated because *local* proxy buffer capacity ran out,
     /// not because the origin failed. The response head was already committed
     /// so the status cannot change, but the origin must not be blamed for it —
@@ -317,6 +318,16 @@ pub const StreamingProxyResult = struct {
     /// trip a healthy origin's circuit breaker.
     local_capacity_aborted: bool = false,
 };
+
+fn streamingResultAfterDownstreamAbort(status_code: u16, reason: []const u8, body_bytes: usize, ttfb_ms: u64) StreamingProxyResult {
+    return .{
+        .status_code = status_code,
+        .reason = reason,
+        .response_body_bytes = body_bytes,
+        .upstream_ttfb_ms = ttfb_ms,
+        .downstream_aborted_after_status = true,
+    };
+}
 
 pub fn uriComponentBytes(component: std.Uri.Component) []const u8 {
     return switch (component) {
@@ -1272,7 +1283,7 @@ fn streamViaH2Pool(
                 ) catch {
                     conn.finishStreaming(stream); // resets the unfinished stream
                     h2_pool.release(conn);
-                    return error.ClientAborted;
+                    return streamingResultAfterDownstreamAbort(status, reason, 0, ttfb_ms);
                 };
 
                 var body_bytes: usize = 0;
@@ -1305,7 +1316,7 @@ fn streamViaH2Pool(
                         gpres.writeChunk(downstream_writer, response_buf.?[0..n]) catch {
                             conn.finishStreaming(stream);
                             h2_pool.release(conn);
-                            return error.ClientAborted;
+                            return streamingResultAfterDownstreamAbort(status, reason, body_bytes, ttfb_ms);
                         };
                         conn.acknowledgeStreamingBody(stream, n);
                         body_bytes += n;
@@ -1314,7 +1325,7 @@ fn streamViaH2Pool(
                         gpres.writeChunk(downstream_writer, "") catch {
                             conn.finishStreaming(stream);
                             h2_pool.release(conn);
-                            return error.ClientAborted;
+                            return streamingResultAfterDownstreamAbort(status, reason, body_bytes, ttfb_ms);
                         };
                     }
                 }
@@ -2406,18 +2417,32 @@ fn streamProxyOverTransport(
         security,
         alt_svc,
         sticky_set_cookie,
-    ) catch return error.ClientAborted;
+    ) catch return .{
+        .result = streamingResultAfterDownstreamAbort(head.status_code, reason, 0, ttfb_ms),
+        .reusable = false,
+    };
     wrote_downstream.* = true;
 
     var body_bytes: usize = 0;
     var aborted = false;
     var reusable = head.http_1_1 and !head.connection_close;
     if (body_allowed) {
-        const outcome = try relayUpstreamBody(&rb, transport, fd, read_deadline_ms, head.framing, downstream_writer, cancel_token);
+        const outcome = relayUpstreamBody(&rb, transport, fd, read_deadline_ms, head.framing, downstream_writer, cancel_token) catch |err| {
+            if (err == error.ClientAborted) {
+                return .{
+                    .result = streamingResultAfterDownstreamAbort(head.status_code, reason, body_bytes, ttfb_ms),
+                    .reusable = false,
+                };
+            }
+            return err;
+        };
         body_bytes = outcome.body_bytes;
         aborted = outcome.aborted;
         reusable = reusable and outcome.reusable;
-        if (!aborted) gpres.writeChunk(downstream_writer, "") catch return error.ClientAborted;
+        if (!aborted) gpres.writeChunk(downstream_writer, "") catch return .{
+            .result = streamingResultAfterDownstreamAbort(head.status_code, reason, body_bytes, ttfb_ms),
+            .reusable = false,
+        };
     }
     if (aborted) reusable = false;
 
@@ -2741,6 +2766,11 @@ pub fn mapControlPlaneProxyExecutionError(err: anyerror) ProxyExecMappedError {
             .status = .service_unavailable,
             .code = "upstream_circuit_open",
             .message = "Upstream circuit breaker open",
+        },
+        error.ControlPlaneResponseMaterializationFailed => .{
+            .status = .bad_gateway,
+            .code = "upstream_response_error",
+            .message = "Upstream response could not be delivered",
         },
         else => .{
             .status = .gateway_timeout,
@@ -4521,6 +4551,7 @@ const Http1ResponseRelay = struct {
     err: ?anyerror = null,
     status: u16 = 0,
     upstream_aborted: bool = false,
+    downstream_aborted_after_status: bool = false,
 
     fn init(
         relay_bytes: usize,
@@ -4587,6 +4618,7 @@ const Http1ResponseRelay = struct {
         };
         self.status = res.result.status_code;
         self.upstream_aborted = res.result.upstream_aborted;
+        self.downstream_aborted_after_status = res.result.downstream_aborted_after_status;
     }
 
     fn runCapturing(self: *Http1ResponseRelay) void {
@@ -4715,7 +4747,30 @@ test "http1 response relay releases its origin reservation when the client abort
     // write failing means it is live at the moment the client vanishes.
     relay.run(FailingDownstreamWriter{});
 
-    try std.testing.expectEqual(@as(?anyerror, error.ClientAborted), relay.err);
+    try std.testing.expect(relay.err == null);
+    try std.testing.expectEqual(@as(u16, 200), relay.status);
+    try std.testing.expect(relay.downstream_aborted_after_status);
+    try relay.expectNothingHeld();
+}
+
+test "http1 response relay returns known 500 when downstream aborts after status" {
+    var origin = proxy_buffer_account.Aggregate.init(.origin, 64 * 1024);
+    var global = proxy_buffer_account.Aggregate.init(.global, 0);
+    const relay_bytes: usize = 16 * 1024;
+
+    var relay = try Http1ResponseRelay.init(
+        relay_bytes,
+        uploadTestLimits(1024 * 1024),
+        .{ .origin = &origin, .global = &global },
+    );
+    defer relay.deinit();
+
+    relay.originSend("HTTP/1.1 500 Oops\r\nContent-Length: 4\r\n\r\nfail");
+    relay.run(FailingDownstreamWriter{});
+
+    try std.testing.expect(relay.err == null);
+    try std.testing.expectEqual(@as(u16, 500), relay.status);
+    try std.testing.expect(relay.downstream_aborted_after_status);
     try relay.expectNothingHeld();
 }
 

--- a/src/gateway_proxy.zig
+++ b/src/gateway_proxy.zig
@@ -2737,6 +2737,11 @@ pub fn mapControlPlaneProxyExecutionError(err: anyerror) ProxyExecMappedError {
             .code = "upstream_saturated",
             .message = "Upstream connection limit reached",
         },
+        error.CircuitOpen => .{
+            .status = .service_unavailable,
+            .code = "upstream_circuit_open",
+            .message = "Upstream circuit breaker open",
+        },
         else => .{
             .status = .gateway_timeout,
             .code = "upstream_timeout",

--- a/src/gateway_proxy.zig
+++ b/src/gateway_proxy.zig
@@ -2756,6 +2756,12 @@ test "mapUpstreamError returns stable codes" {
     try std.testing.expectEqualStrings("tool_unavailable", mapped.code);
 }
 
+test "mapControlPlaneProxyExecutionError maps open circuit distinctly" {
+    const mapped = mapControlPlaneProxyExecutionError(error.CircuitOpen);
+    try std.testing.expectEqual(http.Status.service_unavailable, mapped.status);
+    try std.testing.expectEqualStrings("upstream_circuit_open", mapped.code);
+}
+
 // --- Malformed upstream response handling tests ---
 
 test "parseBufferedUpstreamResponse handles response with no body" {

--- a/src/gateway_proxy_runtime.zig
+++ b/src/gateway_proxy_runtime.zig
@@ -513,6 +513,7 @@ pub fn handleLocationProxyPass(
         cfg.upstream_base_url
     else
         selection.base_url;
+    const absolute_proxy_target = isAbsoluteHttpUrl(std.mem.trim(u8, target, " \t\r\n"));
 
     const resolved = try resolveProxyTarget(temp_allocator, selected_base_url, target, suffix_path);
     const body = request.body orelse "";
@@ -536,11 +537,11 @@ pub fn handleLocationProxyPass(
         .early_data_retry_semantics
     else switch (streamingEligibilityForDataPlaneProxyRequest(cfg, matched_block, max_attempts)) {
         .stream => {
-            if (!state.circuitTryAcquire()) {
+            const circuit_permit = state.circuitTryAcquirePermit() orelse {
                 try sendApiError(allocator, writer, .service_unavailable, "upstream_circuit_open", "Upstream circuit breaker open", correlation_id, false, state);
                 ctx.setUpstreamResult(resolved.upstream_host, @intFromEnum(http.Status.service_unavailable), 0);
                 return @intFromEnum(http.Status.service_unavailable);
-            }
+            };
             state.recordUpstreamAttemptStart(selection.base_url);
             const proxy_buffer_observer = state.proxyBufferObserver();
             const streamed = executeStreamingHttpProxyRequest(
@@ -573,7 +574,7 @@ pub fn handleLocationProxyPass(
             ) catch |err| {
                 state.recordUpstreamAttemptEnd(selection.base_url);
                 if (err == error.ClientAborted) {
-                    state.circuitReleaseProbe();
+                    state.circuitReleasePermit(circuit_permit);
                     state.metricsRecordProxyClientAbort();
                     return err;
                 }
@@ -582,7 +583,7 @@ pub fn handleLocationProxyPass(
                     // byte was committed (#140). Like the active-connection cap
                     // above this is local saturation, not an origin fault, so
                     // it must not touch upstream health / circuit-breaker state.
-                    state.circuitReleaseProbe();
+                    state.circuitReleasePermit(circuit_permit);
                     try sendApiError(allocator, writer, .service_unavailable, "proxy_buffer_saturated", "Proxy buffer capacity exhausted", correlation_id, false, state);
                     ctx.setUpstreamResult(resolved.upstream_host, @intFromEnum(http.Status.service_unavailable), 0);
                     return @intFromEnum(http.Status.service_unavailable);
@@ -591,7 +592,7 @@ pub fn handleLocationProxyPass(
                     // Fail-fast at the per-origin active cap (#239): a local
                     // saturation rejection, not an origin failure — do not count
                     // it against upstream health / circuit-breaker state.
-                    state.circuitReleaseProbe();
+                    state.circuitReleasePermit(circuit_permit);
                     try sendApiError(allocator, writer, .service_unavailable, "upstream_saturated", "Upstream connection limit reached", correlation_id, false, state);
                     ctx.setUpstreamResult(resolved.upstream_host, @intFromEnum(http.Status.service_unavailable), 0);
                     return @intFromEnum(http.Status.service_unavailable);
@@ -602,7 +603,7 @@ pub fn handleLocationProxyPass(
                 // is the client's 413 and not a 503 — and, being a client fault
                 // raised before commitment, it is not charged to the origin.
                 if (err == error.RequestBufferLimitExceeded) {
-                    state.circuitReleaseProbe();
+                    state.circuitReleasePermit(circuit_permit);
                     try sendApiError(allocator, writer, .payload_too_large, "payload_too_large", "Request body too large", correlation_id, false, state);
                     ctx.setUpstreamResult(resolved.upstream_host, @intFromEnum(http.Status.payload_too_large), 0);
                     return @intFromEnum(http.Status.payload_too_large);
@@ -612,7 +613,7 @@ pub fn handleLocationProxyPass(
                 // faults raised before any response byte is committed, so the
                 // origin is not blamed for them.
                 if (err == error.InvalidChunkedUpload or err == error.ChunkedUploadTooLarge) {
-                    state.circuitReleaseProbe();
+                    state.circuitReleasePermit(circuit_permit);
                     const upload_status: http.Status = if (err == error.ChunkedUploadTooLarge) .payload_too_large else .bad_request;
                     const upload_code = if (err == error.ChunkedUploadTooLarge) "payload_too_large" else "invalid_request";
                     const upload_msg = if (err == error.ChunkedUploadTooLarge) "Request body too large" else "Malformed chunked request body";
@@ -621,17 +622,25 @@ pub fn handleLocationProxyPass(
                     return @intFromEnum(upload_status);
                 }
                 if (err == error.RequestCancelled) {
-                    state.recordProxyUpstreamFailure(cfg, selection.base_url);
+                    if (absolute_proxy_target) {
+                        state.circuitRecordFailurePermit(circuit_permit);
+                    } else {
+                        state.recordProxyUpstreamFailure(cfg, selection.base_url, circuit_permit);
+                    }
                     if (ctx.lifecycle) |lc| lc.logTimeout("upstream_connect");
                     try sendApiError(allocator, writer, .gateway_timeout, "upstream_timeout", "Upstream request timed out", correlation_id, false, state);
                     ctx.setUpstreamResult(resolved.upstream_host, @intFromEnum(http.Status.gateway_timeout), 0);
                     return @intFromEnum(http.Status.gateway_timeout);
                 }
                 if (err == error.OutOfMemory) {
-                    state.circuitReleaseProbe();
+                    state.circuitReleasePermit(circuit_permit);
                     return error.OutOfMemory;
                 }
-                state.recordProxyUpstreamFailure(cfg, selection.base_url);
+                if (absolute_proxy_target) {
+                    state.circuitRecordFailurePermit(circuit_permit);
+                } else {
+                    state.recordProxyUpstreamFailure(cfg, selection.base_url, circuit_permit);
+                }
                 const err_status: http.Status = switch (err) {
                     error.Timeout, error.WouldBlock => .gateway_timeout,
                     else => .bad_gateway,
@@ -662,26 +671,25 @@ pub fn handleLocationProxyPass(
                 "",
                 transcript_redactions,
             );
-            const absolute_proxy_target = isAbsoluteHttpUrl(std.mem.trim(u8, target, " \t\r\n"));
             if (absolute_proxy_target) {
                 if (streamed.status_code >= 500 or streamed.upstream_aborted) {
-                    state.circuitRecordFailure();
+                    state.circuitRecordFailurePermit(circuit_permit);
                 } else if (!streamed.local_capacity_aborted) {
-                    state.circuitRecordSuccess();
+                    state.circuitRecordSuccessPermit(circuit_permit);
                 } else {
-                    state.circuitReleaseProbe();
+                    state.circuitReleasePermit(circuit_permit);
                 }
             } else {
                 // A relay truncated by local buffer capacity is not evidence
                 // about the origin, so it is neither a failure nor a success
                 // for health purposes (#140).
                 if (streamed.local_capacity_aborted) {
-                    state.circuitReleaseProbe();
+                    state.circuitReleasePermit(circuit_permit);
                     state.logger.warn(correlation_id, "streaming relay truncated: local proxy buffer capacity exhausted", .{});
                 } else if (streamed.status_code >= 500 or streamed.upstream_aborted) {
-                    state.recordProxyUpstreamFailure(cfg, selection.base_url);
+                    state.recordProxyUpstreamFailure(cfg, selection.base_url, circuit_permit);
                 } else {
-                    state.recordProxyUpstreamSuccess(cfg, selection.base_url);
+                    state.recordProxyUpstreamSuccess(cfg, selection.base_url, circuit_permit);
                 }
             }
             // `tardigrade_proxy_upstream_aborts_total` means "aborted by the
@@ -735,6 +743,7 @@ pub fn handleLocationProxyPass(
         .auth_device_id = auth_device_id,
         .auth_scopes = auth_scopes,
         .selection_base_url = selection.base_url,
+        .absolute_target = absolute_proxy_target,
         .budget_start_ms = budget_start_ms,
     };
     var upstream_response: DataPlaneProxyResponse = switch (try runBufferedProxyAttempts(
@@ -807,21 +816,21 @@ pub fn handleLocationProxyPass(
         upstream_response.transcriptBody(),
         transcript_redactions,
     );
-    if (isAbsoluteHttpUrl(std.mem.trim(u8, target, " \t\r\n"))) {
+    if (absolute_proxy_target) {
         if (upstream_response.statusCode() >= 500) {
-            state.circuitRecordFailure();
+            attempt_executor.recordCircuitFailure();
         } else if (upstream_response.statusCode() != @intFromEnum(http.Status.too_early)) {
-            state.circuitRecordSuccess();
+            attempt_executor.recordCircuitSuccess();
         } else {
-            state.circuitReleaseProbe();
+            attempt_executor.releaseCircuitProbe();
         }
     } else {
         if (upstream_response.statusCode() >= 500) {
-            state.recordProxyUpstreamFailure(cfg, selection.base_url);
+            attempt_executor.recordCircuitFailure();
         } else if (upstream_response.statusCode() != @intFromEnum(http.Status.too_early)) {
-            state.recordProxyUpstreamSuccess(cfg, selection.base_url);
+            attempt_executor.recordCircuitSuccess();
         } else {
-            state.circuitReleaseProbe();
+            attempt_executor.releaseCircuitProbe();
         }
     }
     ctx.setUpstreamResult(resolved.upstream_host, upstream_response.statusCode(), upstream_response.bodyLen());
@@ -1077,8 +1086,10 @@ const ProductionBufferedProxyAttemptExecutor = struct {
     auth_device_id: ?[]const u8,
     auth_scopes: ?[]const u8,
     selection_base_url: []const u8,
+    absolute_target: bool,
     budget_start_ms: u64,
     last_attempt_start_ms: u64 = 0,
+    circuit_permit: ?http.circuit_breaker.Permit = null,
 
     fn recordEarlyUpstream425Action(
         self: *ProductionBufferedProxyAttemptExecutor,
@@ -1119,7 +1130,9 @@ const ProductionBufferedProxyAttemptExecutor = struct {
         forward_early_data: bool,
     ) !DataPlaneProxyResponse {
         _ = attempt;
-        if (!self.state.circuitTryAcquire()) return error.CircuitOpen;
+        if (self.circuit_permit == null) {
+            self.circuit_permit = self.state.circuitTryAcquirePermit() orelse return error.CircuitOpen;
+        }
         const per_attempt_timeout_ms = try self.perAttemptTimeoutMs();
         self.state.recordUpstreamAttemptStart(self.selection_base_url);
         self.last_attempt_start_ms = http.event_loop.monotonicMs();
@@ -1169,7 +1182,29 @@ const ProductionBufferedProxyAttemptExecutor = struct {
     }
 
     fn releaseCircuitProbe(self: *ProductionBufferedProxyAttemptExecutor) void {
-        self.state.circuitReleaseProbe();
+        const permit = self.circuit_permit orelse return;
+        self.state.circuitReleasePermit(permit);
+        self.circuit_permit = null;
+    }
+
+    fn recordCircuitFailure(self: *ProductionBufferedProxyAttemptExecutor) void {
+        const permit = self.circuit_permit orelse return;
+        if (self.absolute_target) {
+            self.state.circuitRecordFailurePermit(permit);
+        } else {
+            self.state.recordProxyUpstreamFailure(self.cfg, self.selection_base_url, permit);
+        }
+        self.circuit_permit = null;
+    }
+
+    fn recordCircuitSuccess(self: *ProductionBufferedProxyAttemptExecutor) void {
+        const permit = self.circuit_permit orelse return;
+        if (self.absolute_target) {
+            self.state.circuitRecordSuccessPermit(permit);
+        } else {
+            self.state.recordProxyUpstreamSuccess(self.cfg, self.selection_base_url, permit);
+        }
+        self.circuit_permit = null;
     }
 
     fn onTerminalAttemptError(
@@ -1177,9 +1212,9 @@ const ProductionBufferedProxyAttemptExecutor = struct {
         err: anyerror,
     ) !void {
         if (proxyAttemptErrorCountsAsUpstreamFailure(err)) {
-            self.state.recordProxyUpstreamFailure(self.cfg, self.selection_base_url);
+            self.recordCircuitFailure();
         } else {
-            self.state.circuitReleaseProbe();
+            self.releaseCircuitProbe();
         }
     }
 
@@ -1214,12 +1249,61 @@ const ProductionBufferedProxyAttemptExecutor = struct {
         max_attempts: usize,
         result: *DataPlaneProxyResponse,
     ) !void {
-        self.state.recordProxyUpstreamFailure(self.cfg, self.selection_base_url);
+        self.recordCircuitFailure();
         self.state.logger.warn(self.correlation_id, "proxy attempt {d}/{d} got {d}, retrying", .{ configured_attempt_index + 1, max_attempts, result.statusCode() });
         self.state.metricsReleaseProxyBufferedBytes(result.bodyLen());
         result.deinit(self.allocator);
     }
 };
+
+test "ProductionBufferedProxyAttemptExecutor keeps absolute target failures out of passive health" {
+    const allocator = std.testing.allocator;
+    var state: GatewayState = undefined;
+    state.allocator = allocator;
+    state.upstream_mutex = .{};
+    state.circuit_mutex = .{};
+    state.metrics_mutex = .{};
+    state.metrics = http.metrics.Metrics.init();
+    state.circuit_breaker = http.circuit_breaker.CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 30_000 });
+    state.upstream_health = std.StringHashMap(gs.UpstreamHealth).init(allocator);
+    defer {
+        var it = state.upstream_health.iterator();
+        while (it.next()) |entry| allocator.free(entry.key_ptr.*);
+        state.upstream_health.deinit();
+    }
+
+    const permit = state.circuitTryAcquirePermit() orelse return error.TestExpectedOrdinaryPermit;
+    var cfg: edge_config.EdgeConfig = undefined;
+    cfg.upstream_max_fails = 1;
+    cfg.upstream_fail_timeout_ms = 60_000;
+
+    var attempt_executor = ProductionBufferedProxyAttemptExecutor{
+        .allocator = allocator,
+        .cfg = &cfg,
+        .state = &state,
+        .ctx = undefined,
+        .request = undefined,
+        .body = "",
+        .upstream_url = "http://absolute.example/resource",
+        .unix_socket_path = null,
+        .correlation_id = "test",
+        .client_ip = "127.0.0.1",
+        .forwarded_proto = "http",
+        .auth_identity = null,
+        .auth_user_id = null,
+        .auth_device_id = null,
+        .auth_scopes = null,
+        .selection_base_url = "http://configured.example",
+        .absolute_target = true,
+        .budget_start_ms = 0,
+        .circuit_permit = permit,
+    };
+
+    attempt_executor.recordCircuitFailure();
+
+    try std.testing.expectEqual(@as(usize, 0), state.upstreamUnhealthyCount());
+    try std.testing.expect(!state.circuitTryAcquire());
+}
 
 const Early425RetryHarnessResult = struct {
     downstream_status: u16,

--- a/src/gateway_proxy_runtime.zig
+++ b/src/gateway_proxy_runtime.zig
@@ -36,6 +36,22 @@ const writeBufferedUpstreamResponseWithMetrics = gp.writeBufferedUpstreamRespons
 
 pub const StreamingRequestBody = gp.StreamingRequestBody;
 
+pub fn proxyAttemptErrorCountsAsUpstreamFailure(err: anyerror) bool {
+    return switch (err) {
+        error.OutOfMemory,
+        error.ClientAborted,
+        error.ProxyBufferCapacityUnavailable,
+        error.RequestBufferLimitExceeded,
+        error.InvalidChunkedUpload,
+        error.ChunkedUploadTooLarge,
+        error.UpstreamAtCapacity,
+        error.ProxyBudgetExhausted,
+        error.CircuitOpen,
+        => false,
+        else => true,
+    };
+}
+
 /// Why a request took the bounded buffered path instead of streaming (#139).
 /// Every reason is recorded as a metric label and a debug log line so operators
 /// can tell whether a given large transfer actually streamed.
@@ -557,6 +573,7 @@ pub fn handleLocationProxyPass(
             ) catch |err| {
                 state.recordUpstreamAttemptEnd(selection.base_url);
                 if (err == error.ClientAborted) {
+                    state.circuitReleaseProbe();
                     state.metricsRecordProxyClientAbort();
                     return err;
                 }
@@ -565,6 +582,7 @@ pub fn handleLocationProxyPass(
                     // byte was committed (#140). Like the active-connection cap
                     // above this is local saturation, not an origin fault, so
                     // it must not touch upstream health / circuit-breaker state.
+                    state.circuitReleaseProbe();
                     try sendApiError(allocator, writer, .service_unavailable, "proxy_buffer_saturated", "Proxy buffer capacity exhausted", correlation_id, false, state);
                     ctx.setUpstreamResult(resolved.upstream_host, @intFromEnum(http.Status.service_unavailable), 0);
                     return @intFromEnum(http.Status.service_unavailable);
@@ -573,6 +591,7 @@ pub fn handleLocationProxyPass(
                     // Fail-fast at the per-origin active cap (#239): a local
                     // saturation rejection, not an origin failure — do not count
                     // it against upstream health / circuit-breaker state.
+                    state.circuitReleaseProbe();
                     try sendApiError(allocator, writer, .service_unavailable, "upstream_saturated", "Upstream connection limit reached", correlation_id, false, state);
                     ctx.setUpstreamResult(resolved.upstream_host, @intFromEnum(http.Status.service_unavailable), 0);
                     return @intFromEnum(http.Status.service_unavailable);
@@ -583,6 +602,7 @@ pub fn handleLocationProxyPass(
                 // is the client's 413 and not a 503 — and, being a client fault
                 // raised before commitment, it is not charged to the origin.
                 if (err == error.RequestBufferLimitExceeded) {
+                    state.circuitReleaseProbe();
                     try sendApiError(allocator, writer, .payload_too_large, "payload_too_large", "Request body too large", correlation_id, false, state);
                     ctx.setUpstreamResult(resolved.upstream_host, @intFromEnum(http.Status.payload_too_large), 0);
                     return @intFromEnum(http.Status.payload_too_large);
@@ -592,6 +612,7 @@ pub fn handleLocationProxyPass(
                 // faults raised before any response byte is committed, so the
                 // origin is not blamed for them.
                 if (err == error.InvalidChunkedUpload or err == error.ChunkedUploadTooLarge) {
+                    state.circuitReleaseProbe();
                     const upload_status: http.Status = if (err == error.ChunkedUploadTooLarge) .payload_too_large else .bad_request;
                     const upload_code = if (err == error.ChunkedUploadTooLarge) "payload_too_large" else "invalid_request";
                     const upload_msg = if (err == error.ChunkedUploadTooLarge) "Request body too large" else "Malformed chunked request body";
@@ -599,14 +620,18 @@ pub fn handleLocationProxyPass(
                     ctx.setUpstreamResult(resolved.upstream_host, @intFromEnum(upload_status), 0);
                     return @intFromEnum(upload_status);
                 }
-                state.recordUpstreamFailure(cfg, selection.base_url);
                 if (err == error.RequestCancelled) {
+                    state.recordProxyUpstreamFailure(cfg, selection.base_url);
                     if (ctx.lifecycle) |lc| lc.logTimeout("upstream_connect");
                     try sendApiError(allocator, writer, .gateway_timeout, "upstream_timeout", "Upstream request timed out", correlation_id, false, state);
                     ctx.setUpstreamResult(resolved.upstream_host, @intFromEnum(http.Status.gateway_timeout), 0);
                     return @intFromEnum(http.Status.gateway_timeout);
                 }
-                if (err == error.OutOfMemory) return error.OutOfMemory;
+                if (err == error.OutOfMemory) {
+                    state.circuitReleaseProbe();
+                    return error.OutOfMemory;
+                }
+                state.recordProxyUpstreamFailure(cfg, selection.base_url);
                 const err_status: http.Status = switch (err) {
                     error.Timeout, error.WouldBlock => .gateway_timeout,
                     else => .bad_gateway,
@@ -643,17 +668,20 @@ pub fn handleLocationProxyPass(
                     state.circuitRecordFailure();
                 } else if (!streamed.local_capacity_aborted) {
                     state.circuitRecordSuccess();
+                } else {
+                    state.circuitReleaseProbe();
                 }
             } else {
                 // A relay truncated by local buffer capacity is not evidence
                 // about the origin, so it is neither a failure nor a success
                 // for health purposes (#140).
                 if (streamed.local_capacity_aborted) {
+                    state.circuitReleaseProbe();
                     state.logger.warn(correlation_id, "streaming relay truncated: local proxy buffer capacity exhausted", .{});
                 } else if (streamed.status_code >= 500 or streamed.upstream_aborted) {
-                    state.recordUpstreamFailure(cfg, selection.base_url);
+                    state.recordProxyUpstreamFailure(cfg, selection.base_url);
                 } else {
-                    state.recordUpstreamSuccess(cfg, selection.base_url);
+                    state.recordProxyUpstreamSuccess(cfg, selection.base_url);
                 }
             }
             // `tardigrade_proxy_upstream_aborts_total` means "aborted by the
@@ -784,12 +812,16 @@ pub fn handleLocationProxyPass(
             state.circuitRecordFailure();
         } else if (upstream_response.statusCode() != @intFromEnum(http.Status.too_early)) {
             state.circuitRecordSuccess();
+        } else {
+            state.circuitReleaseProbe();
         }
     } else {
         if (upstream_response.statusCode() >= 500) {
-            state.recordUpstreamFailure(cfg, selection.base_url);
+            state.recordProxyUpstreamFailure(cfg, selection.base_url);
         } else if (upstream_response.statusCode() != @intFromEnum(http.Status.too_early)) {
-            state.recordUpstreamSuccess(cfg, selection.base_url);
+            state.recordProxyUpstreamSuccess(cfg, selection.base_url);
+        } else {
+            state.circuitReleaseProbe();
         }
     }
     ctx.setUpstreamResult(resolved.upstream_host, upstream_response.statusCode(), upstream_response.bodyLen());
@@ -937,10 +969,16 @@ pub fn runBufferedProxyAttempts(
                 try attempt_executor.onStaleConnectionRetry(stale_conn_retries, max_stale_conn_retries);
                 continue;
             }
-            if (err == error.CircuitOpen) return .circuit_open;
             retry_state.recordEarly425RetryResultOnce(attempt_executor, .failure);
-            if (err == error.ProxyBudgetExhausted) return .retry_budget_exhausted;
-            if (err == error.UpstreamAtCapacity) return .upstream_at_capacity;
+            if (err == error.CircuitOpen) return .circuit_open;
+            if (err == error.ProxyBudgetExhausted) {
+                maybeReleaseCircuitProbe(attempt_executor);
+                return .retry_budget_exhausted;
+            }
+            if (err == error.UpstreamAtCapacity) {
+                maybeReleaseCircuitProbe(attempt_executor);
+                return .upstream_at_capacity;
+            }
             try attempt_executor.onTerminalAttemptError(err);
             if (err == error.RequestCancelled) return .request_cancelled;
             if (retry_state.hasConfiguredRetryRemaining(attempt, max_attempts, stale_conn_retries)) {
@@ -1014,6 +1052,12 @@ fn maybeParkEarly425Retry(attempt_executor: anytype, result: *DataPlaneProxyResp
         return true;
     }
     return false;
+}
+
+fn maybeReleaseCircuitProbe(attempt_executor: anytype) void {
+    if (comptime @hasDecl(@TypeOf(attempt_executor.*), "releaseCircuitProbe")) {
+        attempt_executor.releaseCircuitProbe();
+    }
 }
 
 const ProductionBufferedProxyAttemptExecutor = struct {
@@ -1124,11 +1168,19 @@ const ProductionBufferedProxyAttemptExecutor = struct {
         self.state.logger.warn(self.correlation_id, "proxy retrying on fresh connection after stale upstream keep-alive ({d}/{d})", .{ stale_conn_retries, max_stale_conn_retries });
     }
 
+    fn releaseCircuitProbe(self: *ProductionBufferedProxyAttemptExecutor) void {
+        self.state.circuitReleaseProbe();
+    }
+
     fn onTerminalAttemptError(
         self: *ProductionBufferedProxyAttemptExecutor,
-        _: anyerror,
+        err: anyerror,
     ) !void {
-        self.state.recordUpstreamFailure(self.cfg, self.selection_base_url);
+        if (proxyAttemptErrorCountsAsUpstreamFailure(err)) {
+            self.state.recordProxyUpstreamFailure(self.cfg, self.selection_base_url);
+        } else {
+            self.state.circuitReleaseProbe();
+        }
     }
 
     fn onConfiguredErrorRetry(
@@ -1162,7 +1214,7 @@ const ProductionBufferedProxyAttemptExecutor = struct {
         max_attempts: usize,
         result: *DataPlaneProxyResponse,
     ) !void {
-        self.state.recordUpstreamFailure(self.cfg, self.selection_base_url);
+        self.state.recordProxyUpstreamFailure(self.cfg, self.selection_base_url);
         self.state.logger.warn(self.correlation_id, "proxy attempt {d}/{d} got {d}, retrying", .{ configured_attempt_index + 1, max_attempts, result.statusCode() });
         self.state.metricsReleaseProxyBufferedBytes(result.bodyLen());
         result.deinit(self.allocator);
@@ -1816,6 +1868,39 @@ test "early upstream 425 ordinary retry transport failure records failure once" 
         .terminal_error => |err| try std.testing.expectEqual(error.TestRetryTransportFailed, err),
         else => return error.TestUnexpectedTerminalProxyResult,
     }
+    try std.testing.expectEqual(@as(usize, 1), executor.deliveries);
+    try std.testing.expectEqual(@as(usize, 1), executor.execute_failures);
+    try std.testing.expectEqual(@as(usize, 1), executor.early_425_retried);
+    try std.testing.expectEqual(@as(usize, 1), executor.early_retry_failure);
+    try std.testing.expectEqual(@as(usize, 0), executor.early_retry_success);
+    try std.testing.expectEqualSlices(usize, &.{ 1, 0 }, header_counts.items);
+}
+
+test "early upstream 425 retry blocked by circuit records failure once" {
+    const allocator = std.testing.allocator;
+    const block = edge_config.EdgeConfig.LocationBlock{
+        .match_type = .prefix,
+        .pattern = "/",
+        .priority = 0,
+        .action = .{ .proxy_pass = "http://127.0.0.1:9001" },
+        .early_data = .replay_safe,
+        .proxy_early_data = .rfc8470,
+    };
+    var barrier = TestEarly425Barrier{};
+    var ctx = http.request_context.EarlyDataContext{ .transport_early = true, .downstream_handshake = barrier.barrier() };
+    var header_counts = std.array_list.Managed(usize).init(allocator);
+    defer header_counts.deinit();
+    var executor = ScriptedBufferedAttemptExecutor{
+        .allocator = allocator,
+        .upstream_statuses = &.{425},
+        .early_data_header_counts = &header_counts,
+        .fail_attempt_index = 1,
+        .fail_attempt_err = error.CircuitOpen,
+    };
+
+    const result = try runBufferedProxyAttempts(&ctx, true, "GET", &block, 1, 0, true, &executor);
+
+    try std.testing.expectEqual(std.meta.Tag(BufferedProxyAttemptsResult).circuit_open, std.meta.activeTag(result));
     try std.testing.expectEqual(@as(usize, 1), executor.deliveries);
     try std.testing.expectEqual(@as(usize, 1), executor.execute_failures);
     try std.testing.expectEqual(@as(usize, 1), executor.early_425_retried);

--- a/src/gateway_proxy_runtime.zig
+++ b/src/gateway_proxy_runtime.zig
@@ -520,6 +520,11 @@ pub fn handleLocationProxyPass(
         .early_data_retry_semantics
     else switch (streamingEligibilityForDataPlaneProxyRequest(cfg, matched_block, max_attempts)) {
         .stream => {
+            if (!state.circuitTryAcquire()) {
+                try sendApiError(allocator, writer, .service_unavailable, "upstream_circuit_open", "Upstream circuit breaker open", correlation_id, false, state);
+                ctx.setUpstreamResult(resolved.upstream_host, @intFromEnum(http.Status.service_unavailable), 0);
+                return @intFromEnum(http.Status.service_unavailable);
+            }
             state.recordUpstreamAttemptStart(selection.base_url);
             const proxy_buffer_observer = state.proxyBufferObserver();
             const streamed = executeStreamingHttpProxyRequest(
@@ -632,7 +637,14 @@ pub fn handleLocationProxyPass(
                 "",
                 transcript_redactions,
             );
-            if (!isAbsoluteHttpUrl(std.mem.trim(u8, target, " \t\r\n"))) {
+            const absolute_proxy_target = isAbsoluteHttpUrl(std.mem.trim(u8, target, " \t\r\n"));
+            if (absolute_proxy_target) {
+                if (streamed.status_code >= 500 or streamed.upstream_aborted) {
+                    state.circuitRecordFailure();
+                } else if (!streamed.local_capacity_aborted) {
+                    state.circuitRecordSuccess();
+                }
+            } else {
                 // A relay truncated by local buffer capacity is not evidence
                 // about the origin, so it is neither a failure nor a success
                 // for health purposes (#140).
@@ -718,6 +730,11 @@ pub fn handleLocationProxyPass(
             ctx.setUpstreamResult(resolved.upstream_host, @intFromEnum(http.Status.service_unavailable), 0);
             return @intFromEnum(http.Status.service_unavailable);
         },
+        .circuit_open => {
+            try sendApiError(allocator, writer, .service_unavailable, "upstream_circuit_open", "Upstream circuit breaker open", correlation_id, keep_alive, state);
+            ctx.setUpstreamResult(resolved.upstream_host, @intFromEnum(http.Status.service_unavailable), 0);
+            return @intFromEnum(http.Status.service_unavailable);
+        },
         .request_cancelled => {
             if (ctx.lifecycle) |lc| lc.logTimeout("upstream_connect");
             try sendApiError(allocator, writer, .gateway_timeout, "upstream_timeout", "Upstream request timed out", correlation_id, keep_alive, state);
@@ -762,7 +779,13 @@ pub fn handleLocationProxyPass(
         upstream_response.transcriptBody(),
         transcript_redactions,
     );
-    if (!isAbsoluteHttpUrl(std.mem.trim(u8, target, " \t\r\n"))) {
+    if (isAbsoluteHttpUrl(std.mem.trim(u8, target, " \t\r\n"))) {
+        if (upstream_response.statusCode() >= 500) {
+            state.circuitRecordFailure();
+        } else if (upstream_response.statusCode() != @intFromEnum(http.Status.too_early)) {
+            state.circuitRecordSuccess();
+        }
+    } else {
         if (upstream_response.statusCode() >= 500) {
             state.recordUpstreamFailure(cfg, selection.base_url);
         } else if (upstream_response.statusCode() != @intFromEnum(http.Status.too_early)) {
@@ -881,6 +904,7 @@ pub const BufferedProxyAttemptsResult = union(enum) {
     response: DataPlaneProxyResponse,
     early_425_retry_parked,
     upstream_at_capacity,
+    circuit_open,
     request_cancelled,
     retry_budget_exhausted,
     terminal_error: anyerror,
@@ -913,6 +937,7 @@ pub fn runBufferedProxyAttempts(
                 try attempt_executor.onStaleConnectionRetry(stale_conn_retries, max_stale_conn_retries);
                 continue;
             }
+            if (err == error.CircuitOpen) return .circuit_open;
             retry_state.recordEarly425RetryResultOnce(attempt_executor, .failure);
             if (err == error.ProxyBudgetExhausted) return .retry_budget_exhausted;
             if (err == error.UpstreamAtCapacity) return .upstream_at_capacity;
@@ -1050,6 +1075,7 @@ const ProductionBufferedProxyAttemptExecutor = struct {
         forward_early_data: bool,
     ) !DataPlaneProxyResponse {
         _ = attempt;
+        if (!self.state.circuitTryAcquire()) return error.CircuitOpen;
         const per_attempt_timeout_ms = try self.perAttemptTimeoutMs();
         self.state.recordUpstreamAttemptStart(self.selection_base_url);
         self.last_attempt_start_ms = http.event_loop.monotonicMs();
@@ -1536,6 +1562,7 @@ fn runEarly425RetryHarness(
         },
         .early_425_retry_parked,
         .upstream_at_capacity,
+        .circuit_open,
         .request_cancelled,
         .retry_budget_exhausted,
         .terminal_error,
@@ -2164,6 +2191,26 @@ test "buffered proxy attempts stop on local retry budget exhaustion before upstr
     const result = try runBufferedProxyAttempts(&ctx, false, "GET", &block, 3, 0, true, &executor);
 
     try std.testing.expectEqual(std.meta.Tag(BufferedProxyAttemptsResult).retry_budget_exhausted, std.meta.activeTag(result));
+    try std.testing.expectEqual(@as(usize, 1), executor.execute_calls);
+    try std.testing.expectEqual(@as(usize, 0), executor.terminal_attempt_errors);
+    try std.testing.expectEqual(@as(usize, 0), executor.configured_error_retries);
+}
+
+test "buffered proxy attempts fail fast when circuit breaker is open" {
+    const block = edge_config.EdgeConfig.LocationBlock{
+        .match_type = .prefix,
+        .pattern = "/",
+        .priority = 0,
+        .action = .{ .proxy_pass = "http://127.0.0.1:9001" },
+        .early_data = .replay_safe,
+        .proxy_early_data = .rfc8470,
+    };
+    var ctx = http.request_context.EarlyDataContext{};
+    var executor = ErrorBufferedAttemptExecutor{ .err = error.CircuitOpen };
+
+    const result = try runBufferedProxyAttempts(&ctx, false, "GET", &block, 3, 0, true, &executor);
+
+    try std.testing.expectEqual(std.meta.Tag(BufferedProxyAttemptsResult).circuit_open, std.meta.activeTag(result));
     try std.testing.expectEqual(@as(usize, 1), executor.execute_calls);
     try std.testing.expectEqual(@as(usize, 0), executor.terminal_attempt_errors);
     try std.testing.expectEqual(@as(usize, 0), executor.configured_error_retries);

--- a/src/gateway_proxy_runtime.zig
+++ b/src/gateway_proxy_runtime.zig
@@ -84,6 +84,12 @@ fn recordStreamingProxyOutcome(
     }
 }
 
+fn propagateStreamingDownstreamAbortAfterStatus(state: *GatewayState, streamed: *const gp.StreamingProxyResult) !void {
+    if (!streamed.downstream_aborted_after_status) return;
+    state.metricsRecordProxyClientAbort();
+    return error.ClientAborted;
+}
+
 /// Why a request took the bounded buffered path instead of streaming (#139).
 /// Every reason is recorded as a metric label and a debug log line so operators
 /// can tell whether a given large transfer actually streamed.
@@ -714,6 +720,7 @@ pub fn handleLocationProxyPass(
                 streamed.local_capacity_aborted,
                 correlation_id,
             );
+            try propagateStreamingDownstreamAbortAfterStatus(state, &streamed);
             // `tardigrade_proxy_upstream_aborts_total` means "aborted by the
             // origin". A truncation this proxy caused by running out of buffer
             // capacity is not that, and counting it there would misattribute
@@ -1364,6 +1371,54 @@ test "streaming absolute target local capacity abort releases circuit permit fir
     try std.testing.expectEqual(@as(usize, 0), state.upstreamUnhealthyCount());
     try std.testing.expectEqualStrings("closed", state.circuitStateName());
     try std.testing.expect(state.circuitTryAcquirePermit() != null);
+}
+
+test "streaming downstream abort after known 500 records outcome then propagates client abort" {
+    const allocator = std.testing.allocator;
+    var state: GatewayState = undefined;
+    state.allocator = allocator;
+    state.upstream_mutex = .{};
+    state.circuit_mutex = .{};
+    state.metrics_mutex = .{};
+    state.metrics = http.metrics.Metrics.init();
+    state.logger = http.logger.Logger.init(.err, "test");
+    state.circuit_breaker = http.circuit_breaker.CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0, .half_open_successes = 1 });
+    state.upstream_health = std.StringHashMap(gs.UpstreamHealth).init(allocator);
+    defer {
+        var it = state.upstream_health.iterator();
+        while (it.next()) |entry| allocator.free(entry.key_ptr.*);
+        state.upstream_health.deinit();
+    }
+
+    var cfg: edge_config.EdgeConfig = undefined;
+    cfg.upstream_max_fails = 1;
+    cfg.upstream_fail_timeout_ms = 60_000;
+    state.circuitRecordFailurePermit(state.circuitTryAcquirePermit().?);
+    const permit = state.circuitTryAcquirePermit() orelse return error.TestExpectedHalfOpenPermit;
+
+    const streamed = gp.StreamingProxyResult{
+        .status_code = 500,
+        .reason = "Internal Server Error",
+        .response_body_bytes = 0,
+        .upstream_ttfb_ms = 7,
+        .downstream_aborted_after_status = true,
+    };
+    recordStreamingProxyOutcome(
+        &state,
+        &cfg,
+        "http://configured.example",
+        true,
+        permit,
+        streamed.status_code,
+        streamed.upstream_aborted,
+        streamed.local_capacity_aborted,
+        "test-correlation",
+    );
+    try std.testing.expectError(error.ClientAborted, propagateStreamingDownstreamAbortAfterStatus(&state, &streamed));
+
+    try std.testing.expectEqualStrings("open", state.circuitStateName());
+    try std.testing.expect(state.circuitTryAcquirePermit() != null);
+    try std.testing.expectEqual(@as(u64, 1), state.metrics.proxy_client_aborts);
 }
 
 const Early425RetryHarnessResult = struct {

--- a/src/gateway_proxy_runtime.zig
+++ b/src/gateway_proxy_runtime.zig
@@ -1302,7 +1302,7 @@ test "ProductionBufferedProxyAttemptExecutor keeps absolute target failures out 
     attempt_executor.recordCircuitFailure();
 
     try std.testing.expectEqual(@as(usize, 0), state.upstreamUnhealthyCount());
-    try std.testing.expect(!state.circuitTryAcquire());
+    try std.testing.expect(state.circuitTryAcquirePermit() == null);
 }
 
 const Early425RetryHarnessResult = struct {

--- a/src/gateway_proxy_runtime.zig
+++ b/src/gateway_proxy_runtime.zig
@@ -52,6 +52,38 @@ pub fn proxyAttemptErrorCountsAsUpstreamFailure(err: anyerror) bool {
     };
 }
 
+fn recordStreamingProxyOutcome(
+    state: *GatewayState,
+    cfg: *const edge_config.EdgeConfig,
+    selection_base_url: []const u8,
+    absolute_target: bool,
+    circuit_permit: http.circuit_breaker.Permit,
+    status_code: u16,
+    upstream_aborted: bool,
+    local_capacity_aborted: bool,
+    correlation_id: []const u8,
+) void {
+    // Local capacity exhaustion can set `upstream_aborted` too because the
+    // relay stops reading the origin after committing a response. Classify that
+    // as local first so memory pressure cannot trip a healthy origin's circuit.
+    if (local_capacity_aborted) {
+        state.circuitReleasePermit(circuit_permit);
+        state.logger.warn(correlation_id, "streaming relay truncated: local proxy buffer capacity exhausted", .{});
+    } else if (status_code >= 500 or upstream_aborted) {
+        if (absolute_target) {
+            state.circuitRecordFailurePermit(circuit_permit);
+        } else {
+            state.recordProxyUpstreamFailure(cfg, selection_base_url, circuit_permit);
+        }
+    } else {
+        if (absolute_target) {
+            state.circuitRecordSuccessPermit(circuit_permit);
+        } else {
+            state.recordProxyUpstreamSuccess(cfg, selection_base_url, circuit_permit);
+        }
+    }
+}
+
 /// Why a request took the bounded buffered path instead of streaming (#139).
 /// Every reason is recorded as a metric label and a debug log line so operators
 /// can tell whether a given large transfer actually streamed.
@@ -671,27 +703,17 @@ pub fn handleLocationProxyPass(
                 "",
                 transcript_redactions,
             );
-            if (absolute_proxy_target) {
-                if (streamed.status_code >= 500 or streamed.upstream_aborted) {
-                    state.circuitRecordFailurePermit(circuit_permit);
-                } else if (!streamed.local_capacity_aborted) {
-                    state.circuitRecordSuccessPermit(circuit_permit);
-                } else {
-                    state.circuitReleasePermit(circuit_permit);
-                }
-            } else {
-                // A relay truncated by local buffer capacity is not evidence
-                // about the origin, so it is neither a failure nor a success
-                // for health purposes (#140).
-                if (streamed.local_capacity_aborted) {
-                    state.circuitReleasePermit(circuit_permit);
-                    state.logger.warn(correlation_id, "streaming relay truncated: local proxy buffer capacity exhausted", .{});
-                } else if (streamed.status_code >= 500 or streamed.upstream_aborted) {
-                    state.recordProxyUpstreamFailure(cfg, selection.base_url, circuit_permit);
-                } else {
-                    state.recordProxyUpstreamSuccess(cfg, selection.base_url, circuit_permit);
-                }
-            }
+            recordStreamingProxyOutcome(
+                state,
+                cfg,
+                selection.base_url,
+                absolute_proxy_target,
+                circuit_permit,
+                streamed.status_code,
+                streamed.upstream_aborted,
+                streamed.local_capacity_aborted,
+                correlation_id,
+            );
             // `tardigrade_proxy_upstream_aborts_total` means "aborted by the
             // origin". A truncation this proxy caused by running out of buffer
             // capacity is not that, and counting it there would misattribute
@@ -1303,6 +1325,45 @@ test "ProductionBufferedProxyAttemptExecutor keeps absolute target failures out 
 
     try std.testing.expectEqual(@as(usize, 0), state.upstreamUnhealthyCount());
     try std.testing.expect(state.circuitTryAcquirePermit() == null);
+}
+
+test "streaming absolute target local capacity abort releases circuit permit first" {
+    const allocator = std.testing.allocator;
+    var state: GatewayState = undefined;
+    state.allocator = allocator;
+    state.upstream_mutex = .{};
+    state.circuit_mutex = .{};
+    state.metrics_mutex = .{};
+    state.metrics = http.metrics.Metrics.init();
+    state.logger = http.logger.Logger.init(.err, "test");
+    state.circuit_breaker = http.circuit_breaker.CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 30_000 });
+    state.upstream_health = std.StringHashMap(gs.UpstreamHealth).init(allocator);
+    defer {
+        var it = state.upstream_health.iterator();
+        while (it.next()) |entry| allocator.free(entry.key_ptr.*);
+        state.upstream_health.deinit();
+    }
+
+    const permit = state.circuitTryAcquirePermit() orelse return error.TestExpectedOrdinaryPermit;
+    var cfg: edge_config.EdgeConfig = undefined;
+    cfg.upstream_max_fails = 1;
+    cfg.upstream_fail_timeout_ms = 60_000;
+
+    recordStreamingProxyOutcome(
+        &state,
+        &cfg,
+        "http://configured.example",
+        true,
+        permit,
+        200,
+        true,
+        true,
+        "test-correlation",
+    );
+
+    try std.testing.expectEqual(@as(usize, 0), state.upstreamUnhealthyCount());
+    try std.testing.expectEqualStrings("closed", state.circuitStateName());
+    try std.testing.expect(state.circuitTryAcquirePermit() != null);
 }
 
 const Early425RetryHarnessResult = struct {

--- a/src/gateway_shutdown.zig
+++ b/src/gateway_shutdown.zig
@@ -148,6 +148,27 @@ pub fn hotReloadConfig(
         }
     }
     {
+        // The circuit breaker is process-owned state constructed once at
+        // startup. Reloading its policy in place would require generation-safe
+        // permit migration, so reject those changes and keep config/state
+        // coherent until a restart installs the new policy.
+        var current_lease = worker_ctx.config_store.acquire();
+        const circuit_breaker_config_changed = circuitBreakerConfigChanged(current_lease.cfg, cfg_ptr);
+        current_lease.release();
+        if (circuit_breaker_config_changed) {
+            worker_ctx.config_store.destroyVersion(prepared_version);
+            const msg = std.fmt.bufPrint(&state.last_reload_error, "circuit breaker configuration changed; restart required", .{}) catch "circuit breaker configuration changed";
+            state.reload_mutex.lock();
+            state.last_reload_ok = false;
+            state.last_reload_at_ms = now_ms;
+            state.last_reload_error_len = msg.len;
+            state.reload_mutex.unlock();
+            state.metricsRecordReloadFailure();
+            state.logger.warn(null, "config reload rejected: TARDIGRADE_CB_THRESHOLD/_TIMEOUT_MS changed; restart the process to change circuit breaker policy", .{});
+            return;
+        }
+    }
+    {
         var current_lease = worker_ctx.config_store.acquire();
         const source_changed = (current_lease.cfg.tls_native_ticket_keys_path.len == 0) != (cfg_ptr.tls_native_ticket_keys_path.len == 0);
         current_lease.release();
@@ -366,6 +387,14 @@ pub fn listenerShardConfigChanged(
     return current.listener_shards != proposed.listener_shards;
 }
 
+pub fn circuitBreakerConfigChanged(
+    current: *const edge_config.EdgeConfig,
+    proposed: *const edge_config.EdgeConfig,
+) bool {
+    return current.cb_threshold != proposed.cb_threshold or
+        current.cb_timeout_ms != proposed.cb_timeout_ms;
+}
+
 test "earlyDataReplayConfigChanged detects mode and capacity changes independently" {
     const allocator = std.testing.allocator;
     var base = try edge_config.loadFromEnv(allocator);
@@ -392,6 +421,36 @@ test "earlyDataReplayConfigChanged detects mode and capacity changes independent
     try std.testing.expect(earlyDataReplayConfigChanged(&base, &proposed));
     proposed.tls_native_early_data_replay_max_entries = base.tls_native_early_data_replay_max_entries;
     try std.testing.expect(!earlyDataReplayConfigChanged(&base, &proposed));
+}
+
+test "circuitBreakerConfigChanged treats threshold and timeout as restart-only" {
+    const allocator = std.testing.allocator;
+    var base = try edge_config.loadFromEnv(allocator);
+    defer base.deinit(allocator);
+    var proposed = try edge_config.loadFromEnv(allocator);
+    defer proposed.deinit(allocator);
+
+    try std.testing.expect(!circuitBreakerConfigChanged(&base, &proposed));
+
+    proposed.cb_threshold = base.cb_threshold + 1;
+    try std.testing.expect(circuitBreakerConfigChanged(&base, &proposed));
+    proposed.cb_threshold = base.cb_threshold;
+    try std.testing.expect(!circuitBreakerConfigChanged(&base, &proposed));
+
+    base.cb_threshold = 1;
+    proposed.cb_threshold = 0;
+    try std.testing.expect(circuitBreakerConfigChanged(&base, &proposed));
+    proposed.cb_threshold = base.cb_threshold;
+    try std.testing.expect(!circuitBreakerConfigChanged(&base, &proposed));
+
+    base.cb_threshold = 0;
+    proposed.cb_threshold = 1;
+    try std.testing.expect(circuitBreakerConfigChanged(&base, &proposed));
+    proposed.cb_threshold = base.cb_threshold;
+    try std.testing.expect(!circuitBreakerConfigChanged(&base, &proposed));
+
+    proposed.cb_timeout_ms = base.cb_timeout_ms + 1;
+    try std.testing.expect(circuitBreakerConfigChanged(&base, &proposed));
 }
 
 test "http3ListenerConfigChanged permits advertisement-only reloads" {

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -3781,10 +3781,9 @@ test "gateway circuit breaker opens under upstream failure pressure" {
     defer deinitUpstreamTestState(&gs);
     gs.circuit_breaker = http.circuit_breaker.CircuitBreaker.init(.{ .threshold = 3, .timeout_ms = 30_000 });
 
-    try std.testing.expect(gs.circuitTryAcquirePermit() != null);
-    gs.circuitRecordFailurePermit(.ordinary);
-    gs.circuitRecordFailurePermit(.ordinary);
-    gs.circuitRecordFailurePermit(.ordinary);
+    gs.circuitRecordFailurePermit(gs.circuitTryAcquirePermit().?);
+    gs.circuitRecordFailurePermit(gs.circuitTryAcquirePermit().?);
+    gs.circuitRecordFailurePermit(gs.circuitTryAcquirePermit().?);
     // Open: requests fast-fail deterministically instead of piling onto a sick
     // upstream (the recovery timeout has not elapsed).
     try std.testing.expect(gs.circuitTryAcquirePermit() == null);
@@ -3797,7 +3796,7 @@ test "gateway circuit breaker recovers through a half-open probe" {
     defer deinitUpstreamTestState(&gs);
     gs.circuit_breaker = http.circuit_breaker.CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0, .half_open_successes = 1 });
 
-    gs.circuitRecordFailurePermit(.ordinary);
+    gs.circuitRecordFailurePermit(gs.circuitTryAcquirePermit().?);
     // timeout_ms = 0 → the next acquire admits one probe in half-open state.
     const permit = gs.circuitTryAcquirePermit() orelse return error.TestExpectedHalfOpenPermit;
     try std.testing.expectEqualStrings("half-open", gs.circuitStateName());
@@ -3819,9 +3818,9 @@ test "gateway proxy outcome accounting drives live circuit breaker" {
     try std.testing.expect(gs.circuitTryAcquirePermit() != null);
     try std.testing.expectEqualStrings("closed", gs.circuitStateName());
 
-    gs.recordProxyUpstreamFailure(&cfg, "http://origin.example", .ordinary);
+    gs.recordProxyUpstreamFailure(&cfg, "http://origin.example", gs.circuitTryAcquirePermit().?);
     try std.testing.expect(gs.circuitTryAcquirePermit() != null);
-    gs.recordProxyUpstreamFailure(&cfg, "http://origin.example", .ordinary);
+    gs.recordProxyUpstreamFailure(&cfg, "http://origin.example", gs.circuitTryAcquirePermit().?);
 
     try std.testing.expect(gs.circuitTryAcquirePermit() == null);
     try std.testing.expectEqualStrings("open", gs.circuitStateName());

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -2394,6 +2394,7 @@ pub const GatewayState = struct {
     }
 
     pub fn recordUpstreamFailure(self: *GatewayState, cfg: *const edge_config.EdgeConfig, upstream_base_url: []const u8) void {
+        self.circuitRecordFailure();
         if (cfg.upstream_max_fails == 0) return;
 
         self.upstream_mutex.lock();
@@ -2425,6 +2426,7 @@ pub const GatewayState = struct {
     }
 
     pub fn recordUpstreamSuccess(self: *GatewayState, cfg: *const edge_config.EdgeConfig, upstream_base_url: []const u8) void {
+        self.circuitRecordSuccess();
         if (cfg.upstream_max_fails == 0) return;
 
         self.upstream_mutex.lock();
@@ -3787,6 +3789,23 @@ test "gateway circuit breaker recovers through a half-open probe" {
     try std.testing.expectEqualStrings("half-open", gs.circuitStateName());
     gs.circuitRecordSuccess();
     try std.testing.expectEqualStrings("closed", gs.circuitStateName());
+}
+
+test "gateway upstream outcome accounting drives live circuit breaker" {
+    var gs: GatewayState = undefined;
+    initUpstreamTestState(&gs, std.testing.allocator);
+    defer deinitUpstreamTestState(&gs);
+    gs.circuit_breaker = http.circuit_breaker.CircuitBreaker.init(.{ .threshold = 2, .timeout_ms = 30_000 });
+
+    var cfg: edge_config.EdgeConfig = undefined;
+    cfg.upstream_max_fails = 0;
+
+    gs.recordUpstreamFailure(&cfg, "http://origin.example");
+    try std.testing.expect(gs.circuitTryAcquire());
+    gs.recordUpstreamFailure(&cfg, "http://origin.example");
+
+    try std.testing.expect(!gs.circuitTryAcquire());
+    try std.testing.expectEqualStrings("open", gs.circuitStateName());
 }
 
 fn initMetricsJsonTestState(gs: *GatewayState, allocator: std.mem.Allocator) void {

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -1399,6 +1399,12 @@ pub const GatewayState = struct {
         self.circuit_breaker.recordSuccess();
     }
 
+    pub fn circuitReleaseProbe(self: *GatewayState) void {
+        self.circuit_mutex.lock();
+        defer self.circuit_mutex.unlock();
+        self.circuit_breaker.releaseProbe();
+    }
+
     pub fn circuitStateName(self: *GatewayState) []const u8 {
         self.circuit_mutex.lock();
         defer self.circuit_mutex.unlock();
@@ -2394,7 +2400,6 @@ pub const GatewayState = struct {
     }
 
     pub fn recordUpstreamFailure(self: *GatewayState, cfg: *const edge_config.EdgeConfig, upstream_base_url: []const u8) void {
-        self.circuitRecordFailure();
         if (cfg.upstream_max_fails == 0) return;
 
         self.upstream_mutex.lock();
@@ -2426,7 +2431,6 @@ pub const GatewayState = struct {
     }
 
     pub fn recordUpstreamSuccess(self: *GatewayState, cfg: *const edge_config.EdgeConfig, upstream_base_url: []const u8) void {
-        self.circuitRecordSuccess();
         if (cfg.upstream_max_fails == 0) return;
 
         self.upstream_mutex.lock();
@@ -2437,6 +2441,16 @@ pub const GatewayState = struct {
             health.slow_start_until_ms = 0;
         }
         self.updateUpstreamHealthMetricLocked();
+    }
+
+    pub fn recordProxyUpstreamFailure(self: *GatewayState, cfg: *const edge_config.EdgeConfig, upstream_base_url: []const u8) void {
+        self.recordUpstreamFailure(cfg, upstream_base_url);
+        self.circuitRecordFailure();
+    }
+
+    pub fn recordProxyUpstreamSuccess(self: *GatewayState, cfg: *const edge_config.EdgeConfig, upstream_base_url: []const u8) void {
+        self.recordUpstreamSuccess(cfg, upstream_base_url);
+        self.circuitRecordSuccess();
     }
 
     pub fn recordActiveProbeResult(self: *GatewayState, cfg: *const edge_config.EdgeConfig, upstream_base_url: []const u8, healthy: bool) void {
@@ -3791,7 +3805,7 @@ test "gateway circuit breaker recovers through a half-open probe" {
     try std.testing.expectEqualStrings("closed", gs.circuitStateName());
 }
 
-test "gateway upstream outcome accounting drives live circuit breaker" {
+test "gateway proxy outcome accounting drives live circuit breaker" {
     var gs: GatewayState = undefined;
     initUpstreamTestState(&gs, std.testing.allocator);
     defer deinitUpstreamTestState(&gs);
@@ -3801,8 +3815,13 @@ test "gateway upstream outcome accounting drives live circuit breaker" {
     cfg.upstream_max_fails = 0;
 
     gs.recordUpstreamFailure(&cfg, "http://origin.example");
-    try std.testing.expect(gs.circuitTryAcquire());
     gs.recordUpstreamFailure(&cfg, "http://origin.example");
+    try std.testing.expect(gs.circuitTryAcquire());
+    try std.testing.expectEqualStrings("closed", gs.circuitStateName());
+
+    gs.recordProxyUpstreamFailure(&cfg, "http://origin.example");
+    try std.testing.expect(gs.circuitTryAcquire());
+    gs.recordProxyUpstreamFailure(&cfg, "http://origin.example");
 
     try std.testing.expect(!gs.circuitTryAcquire());
     try std.testing.expectEqualStrings("open", gs.circuitStateName());

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -1382,27 +1382,43 @@ pub const GatewayState = struct {
     }
 
     pub fn circuitTryAcquire(self: *GatewayState) bool {
+        return self.circuitTryAcquirePermit() != null;
+    }
+
+    pub fn circuitTryAcquirePermit(self: *GatewayState) ?http.circuit_breaker.Permit {
         self.circuit_mutex.lock();
         defer self.circuit_mutex.unlock();
-        return self.circuit_breaker.tryAcquire();
+        return self.circuit_breaker.tryAcquirePermit();
     }
 
     pub fn circuitRecordFailure(self: *GatewayState) void {
+        self.circuitRecordFailurePermit(.ordinary);
+    }
+
+    pub fn circuitRecordFailurePermit(self: *GatewayState, permit: http.circuit_breaker.Permit) void {
         self.circuit_mutex.lock();
         defer self.circuit_mutex.unlock();
-        self.circuit_breaker.recordFailure();
+        self.circuit_breaker.recordFailurePermit(permit);
     }
 
     pub fn circuitRecordSuccess(self: *GatewayState) void {
+        self.circuitRecordSuccessPermit(.ordinary);
+    }
+
+    pub fn circuitRecordSuccessPermit(self: *GatewayState, permit: http.circuit_breaker.Permit) void {
         self.circuit_mutex.lock();
         defer self.circuit_mutex.unlock();
-        self.circuit_breaker.recordSuccess();
+        self.circuit_breaker.recordSuccessPermit(permit);
     }
 
     pub fn circuitReleaseProbe(self: *GatewayState) void {
+        self.circuitReleasePermit(.ordinary);
+    }
+
+    pub fn circuitReleasePermit(self: *GatewayState, permit: http.circuit_breaker.Permit) void {
         self.circuit_mutex.lock();
         defer self.circuit_mutex.unlock();
-        self.circuit_breaker.releaseProbe();
+        self.circuit_breaker.releasePermit(permit);
     }
 
     pub fn circuitStateName(self: *GatewayState) []const u8 {
@@ -2443,14 +2459,14 @@ pub const GatewayState = struct {
         self.updateUpstreamHealthMetricLocked();
     }
 
-    pub fn recordProxyUpstreamFailure(self: *GatewayState, cfg: *const edge_config.EdgeConfig, upstream_base_url: []const u8) void {
+    pub fn recordProxyUpstreamFailure(self: *GatewayState, cfg: *const edge_config.EdgeConfig, upstream_base_url: []const u8, permit: http.circuit_breaker.Permit) void {
         self.recordUpstreamFailure(cfg, upstream_base_url);
-        self.circuitRecordFailure();
+        self.circuitRecordFailurePermit(permit);
     }
 
-    pub fn recordProxyUpstreamSuccess(self: *GatewayState, cfg: *const edge_config.EdgeConfig, upstream_base_url: []const u8) void {
+    pub fn recordProxyUpstreamSuccess(self: *GatewayState, cfg: *const edge_config.EdgeConfig, upstream_base_url: []const u8, permit: http.circuit_breaker.Permit) void {
         self.recordUpstreamSuccess(cfg, upstream_base_url);
-        self.circuitRecordSuccess();
+        self.circuitRecordSuccessPermit(permit);
     }
 
     pub fn recordActiveProbeResult(self: *GatewayState, cfg: *const edge_config.EdgeConfig, upstream_base_url: []const u8, healthy: bool) void {
@@ -3799,9 +3815,9 @@ test "gateway circuit breaker recovers through a half-open probe" {
 
     gs.circuitRecordFailure();
     // timeout_ms = 0 → the next acquire admits one probe in half-open state.
-    try std.testing.expect(gs.circuitTryAcquire());
+    const permit = gs.circuitTryAcquirePermit() orelse return error.TestExpectedHalfOpenPermit;
     try std.testing.expectEqualStrings("half-open", gs.circuitStateName());
-    gs.circuitRecordSuccess();
+    gs.circuitRecordSuccessPermit(permit);
     try std.testing.expectEqualStrings("closed", gs.circuitStateName());
 }
 
@@ -3819,9 +3835,9 @@ test "gateway proxy outcome accounting drives live circuit breaker" {
     try std.testing.expect(gs.circuitTryAcquire());
     try std.testing.expectEqualStrings("closed", gs.circuitStateName());
 
-    gs.recordProxyUpstreamFailure(&cfg, "http://origin.example");
+    gs.recordProxyUpstreamFailure(&cfg, "http://origin.example", .ordinary);
     try std.testing.expect(gs.circuitTryAcquire());
-    gs.recordProxyUpstreamFailure(&cfg, "http://origin.example");
+    gs.recordProxyUpstreamFailure(&cfg, "http://origin.example", .ordinary);
 
     try std.testing.expect(!gs.circuitTryAcquire());
     try std.testing.expectEqualStrings("open", gs.circuitStateName());

--- a/src/gateway_state.zig
+++ b/src/gateway_state.zig
@@ -1381,18 +1381,10 @@ pub const GatewayState = struct {
         };
     }
 
-    pub fn circuitTryAcquire(self: *GatewayState) bool {
-        return self.circuitTryAcquirePermit() != null;
-    }
-
     pub fn circuitTryAcquirePermit(self: *GatewayState) ?http.circuit_breaker.Permit {
         self.circuit_mutex.lock();
         defer self.circuit_mutex.unlock();
         return self.circuit_breaker.tryAcquirePermit();
-    }
-
-    pub fn circuitRecordFailure(self: *GatewayState) void {
-        self.circuitRecordFailurePermit(.ordinary);
     }
 
     pub fn circuitRecordFailurePermit(self: *GatewayState, permit: http.circuit_breaker.Permit) void {
@@ -1401,18 +1393,10 @@ pub const GatewayState = struct {
         self.circuit_breaker.recordFailurePermit(permit);
     }
 
-    pub fn circuitRecordSuccess(self: *GatewayState) void {
-        self.circuitRecordSuccessPermit(.ordinary);
-    }
-
     pub fn circuitRecordSuccessPermit(self: *GatewayState, permit: http.circuit_breaker.Permit) void {
         self.circuit_mutex.lock();
         defer self.circuit_mutex.unlock();
         self.circuit_breaker.recordSuccessPermit(permit);
-    }
-
-    pub fn circuitReleaseProbe(self: *GatewayState) void {
-        self.circuitReleasePermit(.ordinary);
     }
 
     pub fn circuitReleasePermit(self: *GatewayState, permit: http.circuit_breaker.Permit) void {
@@ -3797,13 +3781,13 @@ test "gateway circuit breaker opens under upstream failure pressure" {
     defer deinitUpstreamTestState(&gs);
     gs.circuit_breaker = http.circuit_breaker.CircuitBreaker.init(.{ .threshold = 3, .timeout_ms = 30_000 });
 
-    try std.testing.expect(gs.circuitTryAcquire());
-    gs.circuitRecordFailure();
-    gs.circuitRecordFailure();
-    gs.circuitRecordFailure();
+    try std.testing.expect(gs.circuitTryAcquirePermit() != null);
+    gs.circuitRecordFailurePermit(.ordinary);
+    gs.circuitRecordFailurePermit(.ordinary);
+    gs.circuitRecordFailurePermit(.ordinary);
     // Open: requests fast-fail deterministically instead of piling onto a sick
     // upstream (the recovery timeout has not elapsed).
-    try std.testing.expect(!gs.circuitTryAcquire());
+    try std.testing.expect(gs.circuitTryAcquirePermit() == null);
     try std.testing.expectEqualStrings("open", gs.circuitStateName());
 }
 
@@ -3813,7 +3797,7 @@ test "gateway circuit breaker recovers through a half-open probe" {
     defer deinitUpstreamTestState(&gs);
     gs.circuit_breaker = http.circuit_breaker.CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0, .half_open_successes = 1 });
 
-    gs.circuitRecordFailure();
+    gs.circuitRecordFailurePermit(.ordinary);
     // timeout_ms = 0 → the next acquire admits one probe in half-open state.
     const permit = gs.circuitTryAcquirePermit() orelse return error.TestExpectedHalfOpenPermit;
     try std.testing.expectEqualStrings("half-open", gs.circuitStateName());
@@ -3832,14 +3816,14 @@ test "gateway proxy outcome accounting drives live circuit breaker" {
 
     gs.recordUpstreamFailure(&cfg, "http://origin.example");
     gs.recordUpstreamFailure(&cfg, "http://origin.example");
-    try std.testing.expect(gs.circuitTryAcquire());
+    try std.testing.expect(gs.circuitTryAcquirePermit() != null);
     try std.testing.expectEqualStrings("closed", gs.circuitStateName());
 
     gs.recordProxyUpstreamFailure(&cfg, "http://origin.example", .ordinary);
-    try std.testing.expect(gs.circuitTryAcquire());
+    try std.testing.expect(gs.circuitTryAcquirePermit() != null);
     gs.recordProxyUpstreamFailure(&cfg, "http://origin.example", .ordinary);
 
-    try std.testing.expect(!gs.circuitTryAcquire());
+    try std.testing.expect(gs.circuitTryAcquirePermit() == null);
     try std.testing.expectEqualStrings("open", gs.circuitStateName());
 }
 

--- a/src/http/circuit_breaker.zig
+++ b/src/http/circuit_breaker.zig
@@ -9,7 +9,7 @@ const compat = @import("zig_compat");
 pub const State = enum { closed, open, half_open };
 
 pub const Permit = union(enum) {
-    ordinary,
+    closed: u64,
     half_open: u64,
 };
 
@@ -32,6 +32,7 @@ pub const CircuitBreaker = struct {
     failure_count: u32,
     success_count: u32,
     half_open_probe_in_flight: bool,
+    closed_generation: u64,
     half_open_generation: u64,
     /// Nanosecond timestamp of the last recorded failure.
     last_failure_ns: i128,
@@ -44,6 +45,7 @@ pub const CircuitBreaker = struct {
             .failure_count = 0,
             .success_count = 0,
             .half_open_probe_in_flight = false,
+            .closed_generation = 1,
             .half_open_generation = 0,
             .last_failure_ns = 0,
             .config = config,
@@ -55,10 +57,10 @@ pub const CircuitBreaker = struct {
     /// Side effects: if the circuit is open and the recovery timeout has
     /// elapsed, transitions to half-open and allows one probe through.
     pub fn tryAcquirePermit(self: *CircuitBreaker) ?Permit {
-        if (self.config.threshold == 0) return .ordinary; // disabled
+        if (self.config.threshold == 0) return .{ .closed = self.closed_generation }; // disabled
 
         return switch (self.state) {
-            .closed => .ordinary,
+            .closed => .{ .closed = self.closed_generation },
             .open => blk: {
                 const now = compat.nanoTimestamp();
                 const elapsed_ns = now - self.last_failure_ns;
@@ -87,7 +89,7 @@ pub const CircuitBreaker = struct {
     pub fn releasePermit(self: *CircuitBreaker, permit: Permit) void {
         if (self.config.threshold == 0) return;
         switch (permit) {
-            .ordinary => {},
+            .closed => {},
             .half_open => |generation| {
                 if (self.state == .half_open and self.half_open_generation == generation) {
                     self.half_open_probe_in_flight = false;
@@ -101,8 +103,8 @@ pub const CircuitBreaker = struct {
         if (self.config.threshold == 0) return;
 
         switch (permit) {
-            .ordinary => {
-                if (self.state == .closed) self.failure_count = 0;
+            .closed => |generation| {
+                if (self.state == .closed and self.closed_generation == generation) self.failure_count = 0;
             },
             .half_open => |generation| {
                 if (self.state != .half_open or self.half_open_generation != generation) return;
@@ -114,6 +116,8 @@ pub const CircuitBreaker = struct {
                     self.failure_count = 0;
                     self.success_count = 0;
                     self.half_open_probe_in_flight = false;
+                    self.closed_generation +%= 1;
+                    if (self.closed_generation == 0) self.closed_generation = 1;
                 }
             },
         }
@@ -124,13 +128,15 @@ pub const CircuitBreaker = struct {
         if (self.config.threshold == 0) return;
 
         switch (permit) {
-            .ordinary => {
-                if (self.state == .closed) {
+            .closed => |generation| {
+                if (self.state == .closed and self.closed_generation == generation) {
                     self.last_failure_ns = compat.nanoTimestamp();
                     self.failure_count += 1;
                     if (self.failure_count >= self.config.threshold) {
                         self.state = .open;
                         self.half_open_probe_in_flight = false;
+                        self.closed_generation +%= 1;
+                        if (self.closed_generation == 0) self.closed_generation = 1;
                     }
                 }
             },
@@ -164,39 +170,39 @@ test "circuit breaker starts closed" {
 test "circuit breaker opens after threshold failures" {
     var cb = CircuitBreaker.init(.{ .threshold = 3 });
 
-    cb.recordFailurePermit(.ordinary);
+    cb.recordFailurePermit(cb.tryAcquirePermit().?);
     try std.testing.expectEqual(State.closed, cb.state);
     try std.testing.expect(cb.tryAcquirePermit() != null);
 
-    cb.recordFailurePermit(.ordinary);
+    cb.recordFailurePermit(cb.tryAcquirePermit().?);
     try std.testing.expectEqual(State.closed, cb.state);
 
-    cb.recordFailurePermit(.ordinary);
+    cb.recordFailurePermit(cb.tryAcquirePermit().?);
     try std.testing.expectEqual(State.open, cb.state);
     try std.testing.expect(cb.tryAcquirePermit() == null);
 }
 
 test "circuit breaker success resets failure count" {
     var cb = CircuitBreaker.init(.{ .threshold = 3 });
-    cb.recordFailurePermit(.ordinary);
-    cb.recordFailurePermit(.ordinary);
-    cb.recordSuccessPermit(.ordinary);
+    cb.recordFailurePermit(cb.tryAcquirePermit().?);
+    cb.recordFailurePermit(cb.tryAcquirePermit().?);
+    cb.recordSuccessPermit(cb.tryAcquirePermit().?);
     try std.testing.expectEqual(@as(u32, 0), cb.failure_count);
     try std.testing.expectEqual(State.closed, cb.state);
 }
 
 test "circuit breaker disabled when threshold is 0" {
     var cb = CircuitBreaker.init(.{ .threshold = 0 });
-    cb.recordFailurePermit(.ordinary);
-    cb.recordFailurePermit(.ordinary);
-    cb.recordFailurePermit(.ordinary);
+    cb.recordFailurePermit(cb.tryAcquirePermit().?);
+    cb.recordFailurePermit(cb.tryAcquirePermit().?);
+    cb.recordFailurePermit(cb.tryAcquirePermit().?);
     try std.testing.expectEqual(State.closed, cb.state);
     try std.testing.expect(cb.tryAcquirePermit() != null);
 }
 
 test "circuit breaker half-open closes on success" {
     var cb = CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0, .half_open_successes = 1 });
-    cb.recordFailurePermit(.ordinary);
+    cb.recordFailurePermit(cb.tryAcquirePermit().?);
     try std.testing.expectEqual(State.open, cb.state);
 
     // With timeout_ms = 0, tryAcquire should move to half-open immediately
@@ -209,7 +215,7 @@ test "circuit breaker half-open closes on success" {
 
 test "circuit breaker permits only one half-open probe at a time" {
     var cb = CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0, .half_open_successes = 1 });
-    cb.recordFailurePermit(.ordinary);
+    cb.recordFailurePermit(cb.tryAcquirePermit().?);
 
     const permit = cb.tryAcquirePermit() orelse return error.TestExpectedHalfOpenPermit;
     try std.testing.expectEqual(State.half_open, cb.state);
@@ -225,7 +231,7 @@ test "circuit breaker permits only one half-open probe at a time" {
 
 test "circuit breaker half-open re-opens on failure" {
     var cb = CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0 });
-    cb.recordFailurePermit(.ordinary);
+    cb.recordFailurePermit(cb.tryAcquirePermit().?);
     const permit = cb.tryAcquirePermit() orelse return error.TestExpectedHalfOpenPermit; // transition to half-open
     try std.testing.expectEqual(State.half_open, cb.state);
 
@@ -236,7 +242,7 @@ test "circuit breaker half-open re-opens on failure" {
 test "ordinary permit cannot complete or release a later half-open probe" {
     var cb = CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0, .half_open_successes = 1 });
     const old_request = cb.tryAcquirePermit() orelse return error.TestExpectedOrdinaryPermit;
-    cb.recordFailurePermit(.ordinary);
+    cb.recordFailurePermit(cb.tryAcquirePermit().?);
     const probe = cb.tryAcquirePermit() orelse return error.TestExpectedHalfOpenPermit;
     try std.testing.expectEqual(State.half_open, cb.state);
 
@@ -255,9 +261,37 @@ test "ordinary permit cannot complete or release a later half-open probe" {
     try std.testing.expectEqual(State.closed, cb.state);
 }
 
+test "stale closed permit cannot re-open recovered breaker" {
+    var cb = CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0, .half_open_successes = 1 });
+    const stale = cb.tryAcquirePermit() orelse return error.TestExpectedClosedPermit;
+    cb.recordFailurePermit(cb.tryAcquirePermit().?);
+    const probe = cb.tryAcquirePermit() orelse return error.TestExpectedHalfOpenPermit;
+    cb.recordSuccessPermit(probe);
+    try std.testing.expectEqual(State.closed, cb.state);
+
+    cb.recordFailurePermit(stale);
+    try std.testing.expectEqual(State.closed, cb.state);
+}
+
+test "stale closed success cannot clear newer closed failures after recovery" {
+    var cb = CircuitBreaker.init(.{ .threshold = 2, .timeout_ms = 0, .half_open_successes = 1 });
+    const stale = cb.tryAcquirePermit() orelse return error.TestExpectedClosedPermit;
+    cb.recordFailurePermit(cb.tryAcquirePermit().?);
+    cb.recordFailurePermit(cb.tryAcquirePermit().?);
+    const probe = cb.tryAcquirePermit() orelse return error.TestExpectedHalfOpenPermit;
+    cb.recordSuccessPermit(probe);
+    try std.testing.expectEqual(State.closed, cb.state);
+
+    cb.recordFailurePermit(cb.tryAcquirePermit().?);
+    try std.testing.expectEqual(@as(u32, 1), cb.failure_count);
+    cb.recordSuccessPermit(stale);
+    try std.testing.expectEqual(@as(u32, 1), cb.failure_count);
+    try std.testing.expectEqual(State.closed, cb.state);
+}
+
 test "half-open permit survives neutral retry without reacquiring" {
     var cb = CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0, .half_open_successes = 1 });
-    cb.recordFailurePermit(.ordinary);
+    cb.recordFailurePermit(cb.tryAcquirePermit().?);
     const probe = cb.tryAcquirePermit() orelse return error.TestExpectedHalfOpenPermit;
     try std.testing.expect(cb.tryAcquirePermit() == null);
 
@@ -268,6 +302,6 @@ test "half-open permit survives neutral retry without reacquiring" {
 test "stateName returns correct labels" {
     var cb = CircuitBreaker.init(.{ .threshold = 1 });
     try std.testing.expectEqualStrings("closed", cb.stateName());
-    cb.recordFailurePermit(.ordinary);
+    cb.recordFailurePermit(cb.tryAcquirePermit().?);
     try std.testing.expectEqualStrings("open", cb.stateName());
 }

--- a/src/http/circuit_breaker.zig
+++ b/src/http/circuit_breaker.zig
@@ -82,10 +82,6 @@ pub const CircuitBreaker = struct {
         };
     }
 
-    pub fn tryAcquire(self: *CircuitBreaker) bool {
-        return self.tryAcquirePermit() != null;
-    }
-
     /// Release an admitted half-open probe when the request did not reach the
     /// upstream and therefore has no success/failure outcome to record.
     pub fn releasePermit(self: *CircuitBreaker, permit: Permit) void {
@@ -98,10 +94,6 @@ pub const CircuitBreaker = struct {
                 }
             },
         }
-    }
-
-    pub fn releaseProbe(self: *CircuitBreaker) void {
-        self.releasePermit(.{ .half_open = self.half_open_generation });
     }
 
     /// Record a successful upstream call.
@@ -125,10 +117,6 @@ pub const CircuitBreaker = struct {
                 }
             },
         }
-    }
-
-    pub fn recordSuccess(self: *CircuitBreaker) void {
-        self.recordSuccessPermit(.ordinary);
     }
 
     /// Record a failed upstream call (connection error or 5xx).
@@ -155,10 +143,6 @@ pub const CircuitBreaker = struct {
         }
     }
 
-    pub fn recordFailure(self: *CircuitBreaker) void {
-        self.recordFailurePermit(.ordinary);
-    }
-
     /// Human-readable state label for logging.
     pub fn stateName(self: *const CircuitBreaker) []const u8 {
         return switch (self.state) {
@@ -174,40 +158,40 @@ pub const CircuitBreaker = struct {
 test "circuit breaker starts closed" {
     var cb = CircuitBreaker.init(.{});
     try std.testing.expectEqual(State.closed, cb.state);
-    try std.testing.expect(cb.tryAcquire());
+    try std.testing.expect(cb.tryAcquirePermit() != null);
 }
 
 test "circuit breaker opens after threshold failures" {
     var cb = CircuitBreaker.init(.{ .threshold = 3 });
 
-    cb.recordFailure();
+    cb.recordFailurePermit(.ordinary);
     try std.testing.expectEqual(State.closed, cb.state);
-    try std.testing.expect(cb.tryAcquire());
+    try std.testing.expect(cb.tryAcquirePermit() != null);
 
-    cb.recordFailure();
+    cb.recordFailurePermit(.ordinary);
     try std.testing.expectEqual(State.closed, cb.state);
 
-    cb.recordFailure();
+    cb.recordFailurePermit(.ordinary);
     try std.testing.expectEqual(State.open, cb.state);
-    try std.testing.expect(!cb.tryAcquire());
+    try std.testing.expect(cb.tryAcquirePermit() == null);
 }
 
 test "circuit breaker success resets failure count" {
     var cb = CircuitBreaker.init(.{ .threshold = 3 });
-    cb.recordFailure();
-    cb.recordFailure();
-    cb.recordSuccess();
+    cb.recordFailurePermit(.ordinary);
+    cb.recordFailurePermit(.ordinary);
+    cb.recordSuccessPermit(.ordinary);
     try std.testing.expectEqual(@as(u32, 0), cb.failure_count);
     try std.testing.expectEqual(State.closed, cb.state);
 }
 
 test "circuit breaker disabled when threshold is 0" {
     var cb = CircuitBreaker.init(.{ .threshold = 0 });
-    cb.recordFailure();
-    cb.recordFailure();
-    cb.recordFailure();
+    cb.recordFailurePermit(.ordinary);
+    cb.recordFailurePermit(.ordinary);
+    cb.recordFailurePermit(.ordinary);
     try std.testing.expectEqual(State.closed, cb.state);
-    try std.testing.expect(cb.tryAcquire());
+    try std.testing.expect(cb.tryAcquirePermit() != null);
 }
 
 test "circuit breaker half-open closes on success" {
@@ -229,11 +213,11 @@ test "circuit breaker permits only one half-open probe at a time" {
 
     const permit = cb.tryAcquirePermit() orelse return error.TestExpectedHalfOpenPermit;
     try std.testing.expectEqual(State.half_open, cb.state);
-    try std.testing.expect(!cb.tryAcquire());
+    try std.testing.expect(cb.tryAcquirePermit() == null);
 
     cb.releasePermit(permit);
     const next_permit = cb.tryAcquirePermit() orelse return error.TestExpectedHalfOpenPermit;
-    try std.testing.expect(!cb.tryAcquire());
+    try std.testing.expect(cb.tryAcquirePermit() == null);
 
     cb.recordSuccessPermit(next_permit);
     try std.testing.expectEqual(State.closed, cb.state);
@@ -258,14 +242,14 @@ test "ordinary permit cannot complete or release a later half-open probe" {
 
     cb.recordSuccessPermit(old_request);
     try std.testing.expectEqual(State.half_open, cb.state);
-    try std.testing.expect(!cb.tryAcquire());
+    try std.testing.expect(cb.tryAcquirePermit() == null);
 
     cb.recordFailurePermit(old_request);
     try std.testing.expectEqual(State.half_open, cb.state);
-    try std.testing.expect(!cb.tryAcquire());
+    try std.testing.expect(cb.tryAcquirePermit() == null);
 
     cb.releasePermit(old_request);
-    try std.testing.expect(!cb.tryAcquire());
+    try std.testing.expect(cb.tryAcquirePermit() == null);
 
     cb.recordSuccessPermit(probe);
     try std.testing.expectEqual(State.closed, cb.state);
@@ -275,7 +259,7 @@ test "half-open permit survives neutral retry without reacquiring" {
     var cb = CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0, .half_open_successes = 1 });
     cb.recordFailurePermit(.ordinary);
     const probe = cb.tryAcquirePermit() orelse return error.TestExpectedHalfOpenPermit;
-    try std.testing.expect(!cb.tryAcquire());
+    try std.testing.expect(cb.tryAcquirePermit() == null);
 
     cb.recordSuccessPermit(probe);
     try std.testing.expectEqual(State.closed, cb.state);
@@ -284,6 +268,6 @@ test "half-open permit survives neutral retry without reacquiring" {
 test "stateName returns correct labels" {
     var cb = CircuitBreaker.init(.{ .threshold = 1 });
     try std.testing.expectEqualStrings("closed", cb.stateName());
-    cb.recordFailure();
+    cb.recordFailurePermit(.ordinary);
     try std.testing.expectEqualStrings("open", cb.stateName());
 }

--- a/src/http/circuit_breaker.zig
+++ b/src/http/circuit_breaker.zig
@@ -26,6 +26,7 @@ pub const CircuitBreaker = struct {
     state: State,
     failure_count: u32,
     success_count: u32,
+    half_open_probe_in_flight: bool,
     /// Nanosecond timestamp of the last recorded failure.
     last_failure_ns: i128,
     config: Config,
@@ -36,6 +37,7 @@ pub const CircuitBreaker = struct {
             .state = .closed,
             .failure_count = 0,
             .success_count = 0,
+            .half_open_probe_in_flight = false,
             .last_failure_ns = 0,
             .config = config,
         };
@@ -58,12 +60,24 @@ pub const CircuitBreaker = struct {
                 if (elapsed_ms >= self.config.timeout_ms) {
                     self.state = .half_open;
                     self.success_count = 0;
+                    self.half_open_probe_in_flight = true;
                     break :blk true;
                 }
                 break :blk false;
             },
-            .half_open => self.success_count < self.config.half_open_successes,
+            .half_open => blk: {
+                if (self.half_open_probe_in_flight) break :blk false;
+                self.half_open_probe_in_flight = true;
+                break :blk true;
+            },
         };
+    }
+
+    /// Release an admitted half-open probe when the request did not reach the
+    /// upstream and therefore has no success/failure outcome to record.
+    pub fn releaseProbe(self: *CircuitBreaker) void {
+        if (self.config.threshold == 0) return;
+        if (self.state == .half_open) self.half_open_probe_in_flight = false;
     }
 
     /// Record a successful upstream call.
@@ -73,11 +87,13 @@ pub const CircuitBreaker = struct {
         switch (self.state) {
             .closed => self.failure_count = 0,
             .half_open => {
+                self.half_open_probe_in_flight = false;
                 self.success_count += 1;
                 if (self.success_count >= self.config.half_open_successes) {
                     self.state = .closed;
                     self.failure_count = 0;
                     self.success_count = 0;
+                    self.half_open_probe_in_flight = false;
                 }
             },
             .open => {},
@@ -94,9 +110,13 @@ pub const CircuitBreaker = struct {
                 self.failure_count += 1;
                 if (self.failure_count >= self.config.threshold) {
                     self.state = .open;
+                    self.half_open_probe_in_flight = false;
                 }
             },
-            .half_open => self.state = .open,
+            .half_open => {
+                self.state = .open;
+                self.half_open_probe_in_flight = false;
+            },
             .open => {},
         }
     }
@@ -161,6 +181,22 @@ test "circuit breaker half-open closes on success" {
     const available = cb.tryAcquire();
     try std.testing.expectEqual(State.half_open, cb.state);
     try std.testing.expect(available);
+
+    cb.recordSuccess();
+    try std.testing.expectEqual(State.closed, cb.state);
+}
+
+test "circuit breaker permits only one half-open probe at a time" {
+    var cb = CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0, .half_open_successes = 1 });
+    cb.recordFailure();
+
+    try std.testing.expect(cb.tryAcquire());
+    try std.testing.expectEqual(State.half_open, cb.state);
+    try std.testing.expect(!cb.tryAcquire());
+
+    cb.releaseProbe();
+    try std.testing.expect(cb.tryAcquire());
+    try std.testing.expect(!cb.tryAcquire());
 
     cb.recordSuccess();
     try std.testing.expectEqual(State.closed, cb.state);

--- a/src/http/circuit_breaker.zig
+++ b/src/http/circuit_breaker.zig
@@ -8,6 +8,11 @@ const compat = @import("zig_compat");
 /// Half-Open → testing recovery; one probe request allowed; success closes, failure re-opens.
 pub const State = enum { closed, open, half_open };
 
+pub const Permit = union(enum) {
+    ordinary,
+    half_open: u64,
+};
+
 /// Circuit breaker configuration.
 pub const Config = struct {
     /// Number of consecutive failures before opening the circuit (0 = disabled).
@@ -27,6 +32,7 @@ pub const CircuitBreaker = struct {
     failure_count: u32,
     success_count: u32,
     half_open_probe_in_flight: bool,
+    half_open_generation: u64,
     /// Nanosecond timestamp of the last recorded failure.
     last_failure_ns: i128,
     config: Config,
@@ -38,6 +44,7 @@ pub const CircuitBreaker = struct {
             .failure_count = 0,
             .success_count = 0,
             .half_open_probe_in_flight = false,
+            .half_open_generation = 0,
             .last_failure_ns = 0,
             .config = config,
         };
@@ -47,46 +54,67 @@ pub const CircuitBreaker = struct {
     ///
     /// Side effects: if the circuit is open and the recovery timeout has
     /// elapsed, transitions to half-open and allows one probe through.
-    pub fn tryAcquire(self: *CircuitBreaker) bool {
-        if (self.config.threshold == 0) return true; // disabled
+    pub fn tryAcquirePermit(self: *CircuitBreaker) ?Permit {
+        if (self.config.threshold == 0) return .ordinary; // disabled
 
         return switch (self.state) {
-            .closed => true,
+            .closed => .ordinary,
             .open => blk: {
                 const now = compat.nanoTimestamp();
                 const elapsed_ns = now - self.last_failure_ns;
-                if (elapsed_ns < 0) break :blk false;
+                if (elapsed_ns < 0) break :blk null;
                 const elapsed_ms: u64 = @intCast(@divFloor(elapsed_ns, std.time.ns_per_ms));
                 if (elapsed_ms >= self.config.timeout_ms) {
                     self.state = .half_open;
                     self.success_count = 0;
                     self.half_open_probe_in_flight = true;
-                    break :blk true;
+                    self.half_open_generation +%= 1;
+                    if (self.half_open_generation == 0) self.half_open_generation = 1;
+                    break :blk Permit{ .half_open = self.half_open_generation };
                 }
-                break :blk false;
+                break :blk null;
             },
             .half_open => blk: {
-                if (self.half_open_probe_in_flight) break :blk false;
+                if (self.half_open_probe_in_flight) break :blk null;
                 self.half_open_probe_in_flight = true;
-                break :blk true;
+                break :blk Permit{ .half_open = self.half_open_generation };
             },
         };
     }
 
+    pub fn tryAcquire(self: *CircuitBreaker) bool {
+        return self.tryAcquirePermit() != null;
+    }
+
     /// Release an admitted half-open probe when the request did not reach the
     /// upstream and therefore has no success/failure outcome to record.
-    pub fn releaseProbe(self: *CircuitBreaker) void {
+    pub fn releasePermit(self: *CircuitBreaker, permit: Permit) void {
         if (self.config.threshold == 0) return;
-        if (self.state == .half_open) self.half_open_probe_in_flight = false;
+        switch (permit) {
+            .ordinary => {},
+            .half_open => |generation| {
+                if (self.state == .half_open and self.half_open_generation == generation) {
+                    self.half_open_probe_in_flight = false;
+                }
+            },
+        }
+    }
+
+    pub fn releaseProbe(self: *CircuitBreaker) void {
+        self.releasePermit(.{ .half_open = self.half_open_generation });
     }
 
     /// Record a successful upstream call.
-    pub fn recordSuccess(self: *CircuitBreaker) void {
+    pub fn recordSuccessPermit(self: *CircuitBreaker, permit: Permit) void {
         if (self.config.threshold == 0) return;
 
-        switch (self.state) {
-            .closed => self.failure_count = 0,
-            .half_open => {
+        switch (permit) {
+            .ordinary => {
+                if (self.state == .closed) self.failure_count = 0;
+            },
+            .half_open => |generation| {
+                if (self.state != .half_open or self.half_open_generation != generation) return;
+                if (!self.half_open_probe_in_flight) return;
                 self.half_open_probe_in_flight = false;
                 self.success_count += 1;
                 if (self.success_count >= self.config.half_open_successes) {
@@ -96,29 +124,39 @@ pub const CircuitBreaker = struct {
                     self.half_open_probe_in_flight = false;
                 }
             },
-            .open => {},
         }
     }
 
+    pub fn recordSuccess(self: *CircuitBreaker) void {
+        self.recordSuccessPermit(.ordinary);
+    }
+
     /// Record a failed upstream call (connection error or 5xx).
-    pub fn recordFailure(self: *CircuitBreaker) void {
+    pub fn recordFailurePermit(self: *CircuitBreaker, permit: Permit) void {
         if (self.config.threshold == 0) return;
 
-        self.last_failure_ns = compat.nanoTimestamp();
-        switch (self.state) {
-            .closed => {
-                self.failure_count += 1;
-                if (self.failure_count >= self.config.threshold) {
-                    self.state = .open;
-                    self.half_open_probe_in_flight = false;
+        switch (permit) {
+            .ordinary => {
+                if (self.state == .closed) {
+                    self.last_failure_ns = compat.nanoTimestamp();
+                    self.failure_count += 1;
+                    if (self.failure_count >= self.config.threshold) {
+                        self.state = .open;
+                        self.half_open_probe_in_flight = false;
+                    }
                 }
             },
-            .half_open => {
+            .half_open => |generation| {
+                if (self.state != .half_open or self.half_open_generation != generation) return;
+                self.last_failure_ns = compat.nanoTimestamp();
                 self.state = .open;
                 self.half_open_probe_in_flight = false;
             },
-            .open => {},
         }
+    }
+
+    pub fn recordFailure(self: *CircuitBreaker) void {
+        self.recordFailurePermit(.ordinary);
     }
 
     /// Human-readable state label for logging.
@@ -174,42 +212,73 @@ test "circuit breaker disabled when threshold is 0" {
 
 test "circuit breaker half-open closes on success" {
     var cb = CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0, .half_open_successes = 1 });
-    cb.recordFailure();
+    cb.recordFailurePermit(.ordinary);
     try std.testing.expectEqual(State.open, cb.state);
 
     // With timeout_ms = 0, tryAcquire should move to half-open immediately
-    const available = cb.tryAcquire();
+    const permit = cb.tryAcquirePermit() orelse return error.TestExpectedHalfOpenPermit;
     try std.testing.expectEqual(State.half_open, cb.state);
-    try std.testing.expect(available);
 
-    cb.recordSuccess();
+    cb.recordSuccessPermit(permit);
     try std.testing.expectEqual(State.closed, cb.state);
 }
 
 test "circuit breaker permits only one half-open probe at a time" {
     var cb = CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0, .half_open_successes = 1 });
-    cb.recordFailure();
+    cb.recordFailurePermit(.ordinary);
 
-    try std.testing.expect(cb.tryAcquire());
+    const permit = cb.tryAcquirePermit() orelse return error.TestExpectedHalfOpenPermit;
     try std.testing.expectEqual(State.half_open, cb.state);
     try std.testing.expect(!cb.tryAcquire());
 
-    cb.releaseProbe();
-    try std.testing.expect(cb.tryAcquire());
+    cb.releasePermit(permit);
+    const next_permit = cb.tryAcquirePermit() orelse return error.TestExpectedHalfOpenPermit;
     try std.testing.expect(!cb.tryAcquire());
 
-    cb.recordSuccess();
+    cb.recordSuccessPermit(next_permit);
     try std.testing.expectEqual(State.closed, cb.state);
 }
 
 test "circuit breaker half-open re-opens on failure" {
     var cb = CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0 });
-    cb.recordFailure();
-    _ = cb.tryAcquire(); // transition to half-open
+    cb.recordFailurePermit(.ordinary);
+    const permit = cb.tryAcquirePermit() orelse return error.TestExpectedHalfOpenPermit; // transition to half-open
     try std.testing.expectEqual(State.half_open, cb.state);
 
-    cb.recordFailure();
+    cb.recordFailurePermit(permit);
     try std.testing.expectEqual(State.open, cb.state);
+}
+
+test "ordinary permit cannot complete or release a later half-open probe" {
+    var cb = CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0, .half_open_successes = 1 });
+    const old_request = cb.tryAcquirePermit() orelse return error.TestExpectedOrdinaryPermit;
+    cb.recordFailurePermit(.ordinary);
+    const probe = cb.tryAcquirePermit() orelse return error.TestExpectedHalfOpenPermit;
+    try std.testing.expectEqual(State.half_open, cb.state);
+
+    cb.recordSuccessPermit(old_request);
+    try std.testing.expectEqual(State.half_open, cb.state);
+    try std.testing.expect(!cb.tryAcquire());
+
+    cb.recordFailurePermit(old_request);
+    try std.testing.expectEqual(State.half_open, cb.state);
+    try std.testing.expect(!cb.tryAcquire());
+
+    cb.releasePermit(old_request);
+    try std.testing.expect(!cb.tryAcquire());
+
+    cb.recordSuccessPermit(probe);
+    try std.testing.expectEqual(State.closed, cb.state);
+}
+
+test "half-open permit survives neutral retry without reacquiring" {
+    var cb = CircuitBreaker.init(.{ .threshold = 1, .timeout_ms = 0, .half_open_successes = 1 });
+    cb.recordFailurePermit(.ordinary);
+    const probe = cb.tryAcquirePermit() orelse return error.TestExpectedHalfOpenPermit;
+    try std.testing.expect(!cb.tryAcquire());
+
+    cb.recordSuccessPermit(probe);
+    try std.testing.expectEqual(State.closed, cb.state);
 }
 
 test "stateName returns correct labels" {

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -4506,7 +4506,7 @@ test "proxy.circuit_breaker_opens_fast_fails_and_recovers" {
     var upstream = try UpstreamServer.start(allocator, &.{
         .{ .status_code = 500, .body = "fail-1", .connection_header = "close" },
         .{ .status_code = 500, .body = "fail-2", .connection_header = "close" },
-        .{ .status_code = 200, .body = "recovered", .connection_header = "close" },
+        .{ .status_code = 200, .body = "recovered", .delay_ms = 3_000, .connection_header = "close" },
     });
     defer upstream.stop();
     try upstream.run();
@@ -4526,6 +4526,7 @@ test "proxy.circuit_breaker_opens_fast_fails_and_recovers" {
         .config_text = config_text,
         .ready_path = "/healthz",
         .extra_env = &.{
+            .{ .name = "TARDIGRADE_WORKER_THREADS", .value = "2" },
             .{ .name = "TARDIGRADE_CB_THRESHOLD", .value = "2" },
             .{ .name = "TARDIGRADE_CB_TIMEOUT_MS", .value = "250" },
         },
@@ -4549,12 +4550,45 @@ test "proxy.circuit_breaker_opens_fast_fails_and_recovers" {
     compat.sleepNs(50 * std.time.ns_per_ms);
     try std.testing.expectEqual(@as(u32, 2), upstream.requestCount());
 
+    const ProbeResult = struct {
+        status: u16 = 0,
+        body_matched: bool = false,
+        done: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+        err: ?anyerror = null,
+
+        fn run(self: *@This(), port: u16) void {
+            defer self.done.store(true, .release);
+            var response = sendRequestWithTimeout(std.heap.page_allocator, port, .{ .method = "GET", .path = "/cb", .body = null, .headers = &.{} }, 8_000) catch |err| {
+                self.err = err;
+                return;
+            };
+            defer response.deinit();
+            self.status = response.status_code;
+            self.body_matched = std.mem.find(u8, response.body, "recovered") != null or std.mem.find(u8, response.body, "\"code\":\"upstream_circuit_open\"") != null;
+        }
+    };
+
     compat.sleepNs(300 * std.time.ns_per_ms);
-    var recovered = try sendRequest(allocator, tardigrade.port, .{ .method = "GET", .path = "/cb", .body = null, .headers = &.{} });
-    defer recovered.deinit();
-    try std.testing.expectEqual(@as(u16, 200), recovered.status_code);
-    try assertContains(recovered.body, "recovered");
+    var probe_a = ProbeResult{};
+    const thread_a = try std.Thread.spawn(.{}, ProbeResult.run, .{ &probe_a, tardigrade.port });
     try waitForUpstreamCount(&upstream, 3, 2_000);
+    try std.testing.expect(!probe_a.done.load(.acquire));
+
+    var probe_b = try sendRequest(allocator, tardigrade.port, .{ .method = "GET", .path = "/cb", .body = null, .headers = &.{} });
+    defer probe_b.deinit();
+    thread_a.join();
+
+    if (probe_a.err) |err| return err;
+    try std.testing.expect(probe_a.body_matched);
+    const ok_a: u8 = if (probe_a.status == 200) 1 else 0;
+    const ok_b: u8 = if (probe_b.status_code == 200) 1 else 0;
+    const open_a: u8 = if (probe_a.status == 503) 1 else 0;
+    const open_b: u8 = if (probe_b.status_code == 503) 1 else 0;
+    const ok_count: u8 = ok_a + ok_b;
+    const open_count: u8 = open_a + open_b;
+    try std.testing.expectEqual(@as(u8, 1), ok_count);
+    try std.testing.expectEqual(@as(u8, 1), open_count);
+    try std.testing.expectEqual(@as(u32, 3), upstream.requestCount());
 }
 
 test "interop.openssl.h2.proxy_request_translation_is_secret_safe" {
@@ -6093,13 +6127,11 @@ test "interop.h2.proxy_passive_health_tracking_fails_closed" {
             .{ .name = "TARDIGRADE_TLS_KEY_PATH", .value = tls_paths.key_path },
             .{ .name = "TARDIGRADE_TLS_SERVER_NAME", .value = "tardigrade.test" },
             .{ .name = "TARDIGRADE_HTTP2_ENABLED", .value = "true" },
-            // Passive health and the process-wide circuit breaker are opt-in;
-            // once configured, H1's handleLocationProxyPass wrapper records
-            // failure/success and gates every proxied request. The direct H2
-            // executor has no equivalent, so it must fail closed rather than
-            // silently never participating.
+            // Passive health is opt-in; once configured, H1's
+            // handleLocationProxyPass wrapper records failure/success around
+            // every proxied request. The direct H2 executor has no equivalent,
+            // so it must fail closed rather than silently never participating.
             .{ .name = "TARDIGRADE_UPSTREAM_MAX_FAILS", .value = "3" },
-            .{ .name = "TARDIGRADE_CB_THRESHOLD", .value = "3" },
         },
     });
     defer tardigrade.stop();
@@ -6108,6 +6140,57 @@ test "interop.h2.proxy_passive_health_tracking_fails_closed" {
     const headers = [_]hpack.HeaderField{
         .{ .name = ":method", .value = "GET" },
         .{ .name = ":path", .value = "/h2-passive-health" },
+        .{ .name = ":scheme", .value = "https" },
+        .{ .name = ":authority", .value = "tardigrade.test" },
+    };
+    const body = try pureZigH2GetBody(allocator, tardigrade.port, headers[0..]);
+    defer allocator.free(body);
+    try assertContains(body, "\"code\":\"h2_proxy_policy_unsupported\"");
+    compat.sleepNs(200 * std.time.ns_per_ms);
+    try std.testing.expectEqual(@as(u32, 0), upstream.requestCount());
+}
+
+test "interop.h2.proxy_circuit_breaker_fails_closed" {
+    try requireNativeTlsProfile();
+    const allocator = std.testing.allocator;
+
+    var tls_paths = try nativeTlsFixturePaths(allocator);
+    defer tls_paths.deinit();
+
+    var upstream = try UpstreamServer.start(allocator, &.{.{ .body = "must-not-run" }});
+    defer upstream.stop();
+    try upstream.run();
+
+    const config_text = try std.fmt.allocPrint(allocator,
+        \\location = /healthz {{
+        \\    return 200 alive;
+        \\}}
+        \\
+        \\location = /h2-circuit-breaker {{
+        \\    proxy_pass http://{s}:{d}/h2-circuit-breaker;
+        \\}}
+    , .{ test_host, upstream.port() });
+    defer allocator.free(config_text);
+
+    var tardigrade = try TardigradeProcess.start(allocator, .{
+        .config_text = config_text,
+        .ready_https_insecure = true,
+        .ready_path = "/healthz",
+        .extra_env = &.{
+            .{ .name = "TARDIGRADE_TLS_CERT_PATH", .value = tls_paths.cert_path },
+            .{ .name = "TARDIGRADE_TLS_KEY_PATH", .value = tls_paths.key_path },
+            .{ .name = "TARDIGRADE_TLS_SERVER_NAME", .value = "tardigrade.test" },
+            .{ .name = "TARDIGRADE_HTTP2_ENABLED", .value = "true" },
+            .{ .name = "TARDIGRADE_UPSTREAM_MAX_FAILS", .value = "0" },
+            .{ .name = "TARDIGRADE_CB_THRESHOLD", .value = "3" },
+        },
+    });
+    defer tardigrade.stop();
+    try upstream.resetCapture();
+
+    const headers = [_]hpack.HeaderField{
+        .{ .name = ":method", .value = "GET" },
+        .{ .name = ":path", .value = "/h2-circuit-breaker" },
         .{ .name = ":scheme", .value = "https" },
         .{ .name = ":authority", .value = "tardigrade.test" },
     };

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -4507,6 +4507,7 @@ test "proxy.circuit_breaker_opens_fast_fails_and_recovers" {
         .{ .status_code = 500, .body = "fail-1", .connection_header = "close" },
         .{ .status_code = 500, .body = "fail-2", .connection_header = "close" },
         .{ .status_code = 200, .body = "recovered", .delay_ms = 3_000, .connection_header = "close" },
+        .{ .status_code = 200, .body = "closed-again", .connection_header = "close" },
     });
     defer upstream.stop();
     try upstream.run();
@@ -4589,6 +4590,12 @@ test "proxy.circuit_breaker_opens_fast_fails_and_recovers" {
     try std.testing.expectEqual(@as(u8, 1), ok_count);
     try std.testing.expectEqual(@as(u8, 1), open_count);
     try std.testing.expectEqual(@as(u32, 3), upstream.requestCount());
+
+    var after_probe = try sendRequest(allocator, tardigrade.port, .{ .method = "GET", .path = "/cb", .body = null, .headers = &.{} });
+    defer after_probe.deinit();
+    try std.testing.expectEqual(@as(u16, 200), after_probe.status_code);
+    try assertContains(after_probe.body, "closed-again");
+    try std.testing.expectEqual(@as(u32, 4), upstream.requestCount());
 }
 
 test "interop.openssl.h2.proxy_request_translation_is_secret_safe" {

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -4500,6 +4500,63 @@ test "interop.openssl.h2.tls_resume" {
     try std.testing.expect(accepted_after >= accepted_before + 1);
 }
 
+test "proxy.circuit_breaker_opens_fast_fails_and_recovers" {
+    const allocator = std.testing.allocator;
+
+    var upstream = try UpstreamServer.start(allocator, &.{
+        .{ .status_code = 500, .body = "fail-1", .connection_header = "close" },
+        .{ .status_code = 500, .body = "fail-2", .connection_header = "close" },
+        .{ .status_code = 200, .body = "recovered", .connection_header = "close" },
+    });
+    defer upstream.stop();
+    try upstream.run();
+
+    const config_text = try std.fmt.allocPrint(allocator,
+        \\location = /healthz {{
+        \\    return 200 alive;
+        \\}}
+        \\
+        \\location = /cb {{
+        \\    proxy_pass http://{s}:{d}/cb;
+        \\}}
+    , .{ test_host, upstream.port() });
+    defer allocator.free(config_text);
+
+    var tardigrade = try TardigradeProcess.start(allocator, .{
+        .config_text = config_text,
+        .ready_path = "/healthz",
+        .extra_env = &.{
+            .{ .name = "TARDIGRADE_CB_THRESHOLD", .value = "2" },
+            .{ .name = "TARDIGRADE_CB_TIMEOUT_MS", .value = "250" },
+        },
+    });
+    defer tardigrade.stop();
+    try upstream.resetCapture();
+
+    var first = try sendRequest(allocator, tardigrade.port, .{ .method = "GET", .path = "/cb", .body = null, .headers = &.{} });
+    defer first.deinit();
+    try std.testing.expectEqual(@as(u16, 500), first.status_code);
+
+    var second = try sendRequest(allocator, tardigrade.port, .{ .method = "GET", .path = "/cb", .body = null, .headers = &.{} });
+    defer second.deinit();
+    try std.testing.expectEqual(@as(u16, 500), second.status_code);
+    try waitForUpstreamCount(&upstream, 2, 2_000);
+
+    var open = try sendRequest(allocator, tardigrade.port, .{ .method = "GET", .path = "/cb", .body = null, .headers = &.{} });
+    defer open.deinit();
+    try std.testing.expectEqual(@as(u16, 503), open.status_code);
+    try assertContains(open.body, "\"code\":\"upstream_circuit_open\"");
+    compat.sleepNs(50 * std.time.ns_per_ms);
+    try std.testing.expectEqual(@as(u32, 2), upstream.requestCount());
+
+    compat.sleepNs(300 * std.time.ns_per_ms);
+    var recovered = try sendRequest(allocator, tardigrade.port, .{ .method = "GET", .path = "/cb", .body = null, .headers = &.{} });
+    defer recovered.deinit();
+    try std.testing.expectEqual(@as(u16, 200), recovered.status_code);
+    try assertContains(recovered.body, "recovered");
+    try waitForUpstreamCount(&upstream, 3, 2_000);
+}
+
 test "interop.openssl.h2.proxy_request_translation_is_secret_safe" {
     try requireNativeTlsProfile();
     const allocator = std.testing.allocator;
@@ -6036,12 +6093,13 @@ test "interop.h2.proxy_passive_health_tracking_fails_closed" {
             .{ .name = "TARDIGRADE_TLS_KEY_PATH", .value = tls_paths.key_path },
             .{ .name = "TARDIGRADE_TLS_SERVER_NAME", .value = "tardigrade.test" },
             .{ .name = "TARDIGRADE_HTTP2_ENABLED", .value = "true" },
-            // Passive health circuit breaking is opt-in (default 0/off);
+            // Passive health and the process-wide circuit breaker are opt-in;
             // once configured, H1's handleLocationProxyPass wrapper records
-            // failure/success against it around every proxied request. The
-            // direct H2 executor has no equivalent, so it must fail closed
-            // rather than silently never participating.
+            // failure/success and gates every proxied request. The direct H2
+            // executor has no equivalent, so it must fail closed rather than
+            // silently never participating.
             .{ .name = "TARDIGRADE_UPSTREAM_MAX_FAILS", .value = "3" },
+            .{ .name = "TARDIGRADE_CB_THRESHOLD", .value = "3" },
         },
     });
     defer tardigrade.stop();


### PR DESCRIPTION
## Summary
- gate live data-plane, control-plane, and HTTP/3 proxy attempts on the configured circuit breaker
- feed breaker success/failure from live upstream outcomes, including absolute proxy_pass targets
- document the open-breaker response as 503 upstream_circuit_open and add live integration coverage for open -> half-open -> closed recovery

Fixes #627

## Validation
- zig build --summary all --error-style verbose
- zig build test-integration --summary all --error-style verbose --test-timeout 120s

Note: broad `zig build test --summary all --error-style verbose --test-timeout 120s` was interrupted after it remained silent beyond the configured timeout; no Zig test process was left running.